### PR TITLE
Issue #13321: Kill mutation for DetailAstImpl-2

### DIFF
--- a/config/pitest-suppressions/pitest-common-2-suppressions.xml
+++ b/config/pitest-suppressions/pitest-common-2-suppressions.xml
@@ -45,23 +45,23 @@
     <lineContent>sibling.previousSibling = astImpl;</lineContent>
   </mutation>
 
-  <mutation unstable="false">
-    <sourceFile>DetailAstImpl.java</sourceFile>
-    <mutatedClass>com.puppycrawl.tools.checkstyle.DetailAstImpl</mutatedClass>
-    <mutatedMethod>addPreviousSibling</mutatedMethod>
-    <mutator>org.pitest.mutationtest.engine.gregor.mutators.experimental.MemberVariableMutator</mutator>
-    <description>Removed assignment to member variable previousSibling</description>
-    <lineContent>astImpl.previousSibling = previousSiblingNode;</lineContent>
-  </mutation>
 
-  <mutation unstable="false">
-    <sourceFile>DetailAstImpl.java</sourceFile>
-    <mutatedClass>com.puppycrawl.tools.checkstyle.DetailAstImpl</mutatedClass>
-    <mutatedMethod>addPreviousSibling</mutatedMethod>
-    <mutator>org.pitest.mutationtest.engine.gregor.mutators.experimental.MemberVariableMutator</mutator>
-    <description>Removed assignment to member variable previousSibling</description>
-    <lineContent>previousSibling = astImpl;</lineContent>
-  </mutation>
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
 
   <mutation unstable="false">
     <sourceFile>DetailAstImpl.java</sourceFile>

--- a/src/main/java/com/puppycrawl/tools/checkstyle/DetailAstImpl.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/DetailAstImpl.java
@@ -122,7 +122,6 @@ public final class DetailAstImpl implements DetailAST {
             final DetailAstImpl astImpl = (DetailAstImpl) ast;
 
             if (previousSiblingNode != null) {
-                astImpl.previousSibling = previousSiblingNode;
                 previousSiblingNode.setNextSibling(astImpl);
             }
             else if (parent != null) {
@@ -130,7 +129,6 @@ public final class DetailAstImpl implements DetailAST {
             }
 
             astImpl.setNextSibling(this);
-            previousSibling = astImpl;
         }
     }
 

--- a/src/test/java/com/puppycrawl/tools/checkstyle/DetailAstImplTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/DetailAstImplTest.java
@@ -285,6 +285,24 @@ public class DetailAstImplTest extends AbstractModuleTestSupport {
         assertWithMessage("unexpected result")
             .that(parent.getFirstChild())
             .isEqualTo(previousSibling);
+
+        final DetailAstImpl secondNewPreviousSibling = new DetailAstImpl();
+        instance.addPreviousSibling(secondNewPreviousSibling);
+        assertWithMessage("unexpected result")
+                .that(secondNewPreviousSibling.getPreviousSibling())
+                .isEqualTo(newPreviousSibling);
+        assertWithMessage("unexpected result")
+                .that(secondNewPreviousSibling.getNextSibling())
+                .isEqualTo(instance);
+        assertWithMessage("unexpected result")
+                .that(newPreviousSibling.getNextSibling())
+                .isEqualTo(secondNewPreviousSibling);
+        assertWithMessage("unexpected result")
+                .that(secondNewPreviousSibling.getPreviousSibling().getPreviousSibling())
+                .isEqualTo(previousSibling);
+        assertWithMessage("unexpected result")
+                .that(instance.getPreviousSibling().getPreviousSibling().getPreviousSibling())
+                .isEqualTo(previousSibling);
     }
 
     @Test


### PR DESCRIPTION
Issue #13321: Kill mutation for DetailAstImpl-2

https://github.com/checkstyle/checkstyle/blob/master/src/main/java/com/puppycrawl/tools/checkstyle/DetailAstImpl.java

-------

# Mutations 
https://github.com/checkstyle/checkstyle/blob/88486f7ca9795f613d28fa6c2a53beccef521dfc/config/pitest-suppressions/pitest-common-2-suppressions.xml#L48-L64

--------

# Explaintion 
here the code in method to addPreviousSibiling is 
https://github.com/checkstyle/checkstyle/blob/88486f7ca9795f613d28fa6c2a53beccef521dfc/src/main/java/com/puppycrawl/tools/checkstyle/DetailAstImpl.java#L116-L135
in which line no 121 and 133 is mutated and the reasonto removal is same for both

here as per the condition `if (previousSibilingNode != null` it shows that we already have previousSibilingNode

lets suppose an example we have 2 node connected y and x in which y is the previous sibiling of node x. 
some thing like
 ```y - x```
and know we want to add the new previous sibiling of x which is w.
in that case the sceanrio looks like
``` y - w - x ```

know to make changes like this we need to perfom operation where 
according to the code we have in our codebase previousSibiling variable would be y in this case 
know
 https://github.com/checkstyle/checkstyle/blob/88486f7ca9795f613d28fa6c2a53beccef521dfc/src/main/java/com/puppycrawl/tools/checkstyle/DetailAstImpl.java#L121-L122

here as `previousSibilingNode` we are assinging `previousSibiling` it means know for my example 
`previousSibilingNode = y` and `astImpl = w`

so know to achieve `y - w - x`
1) we have to set w previous sibiling to y 
which is done by 
https://github.com/checkstyle/checkstyle/blob/88486f7ca9795f613d28fa6c2a53beccef521dfc/src/main/java/com/puppycrawl/tools/checkstyle/DetailAstImpl.java#L125

where astImpl means `w.previousSibiling = y` is set 
so the know the sceanrio looks like
`y <-- w`  
2) know we have to add y's next sibiling to w
which is done by 
https://github.com/checkstyle/checkstyle/blob/88486f7ca9795f613d28fa6c2a53beccef521dfc/src/main/java/com/puppycrawl/tools/checkstyle/DetailAstImpl.java#L126
this will set next sibiling of y as w 

know rest of the thing means we have set the condition right know as 
`y - w` but still we have to connect it with x which is done by https://github.com/checkstyle/checkstyle/blob/88486f7ca9795f613d28fa6c2a53beccef521dfc/src/main/java/com/puppycrawl/tools/checkstyle/DetailAstImpl.java#L132-L133 
with way i mention above.

so know in this both the case we see that we are setting nodes next sibiling using method `setNextSibiling`.
which code is 
https://github.com/checkstyle/checkstyle/blob/88486f7ca9795f613d28fa6c2a53beccef521dfc/src/main/java/com/puppycrawl/tools/checkstyle/DetailAstImpl.java#L468-L478
which is setting next sibiling for node 
so lets talk where we have to set y's next sibiling as w
https://github.com/checkstyle/checkstyle/blob/88486f7ca9795f613d28fa6c2a53beccef521dfc/src/main/java/com/puppycrawl/tools/checkstyle/DetailAstImpl.java#L126

here our previousSibilingNode is y and we have to set w as nextsibiling which is w
so 
here first directly https://github.com/checkstyle/checkstyle/blob/88486f7ca9795f613d28fa6c2a53beccef521dfc/src/main/java/com/puppycrawl/tools/checkstyle/DetailAstImpl.java#L471
after this line execute we got what we want 
`y - w` 
but this code contains 
https://github.com/checkstyle/checkstyle/blob/88486f7ca9795f613d28fa6c2a53beccef521dfc/src/main/java/com/puppycrawl/tools/checkstyle/DetailAstImpl.java#L475-L477
in which our nextSibiling never going to null so this statment is again assigning nextsibiling means in our case
the statment look like 
`w .previousSibiling = this`and it would be y

which we are setting in https://github.com/checkstyle/checkstyle/blob/88486f7ca9795f613d28fa6c2a53beccef521dfc/src/main/java/com/puppycrawl/tools/checkstyle/DetailAstImpl.java#L125 
and
https://github.com/checkstyle/checkstyle/blob/88486f7ca9795f613d28fa6c2a53beccef521dfc/src/main/java/com/puppycrawl/tools/checkstyle/DetailAstImpl.java#L133


we can verify this using for particular 	`addPreviousSibiling` method
**Note:-** 
This is just for testing it will affect the tree structure if we made change like this.

change https://github.com/checkstyle/checkstyle/blob/88486f7ca9795f613d28fa6c2a53beccef521dfc/src/main/java/com/puppycrawl/tools/checkstyle/DetailAstImpl.java#L126 as 
`previousSiblingNode.nextSibling = astImpl;` know if you remove the statment above statment then test will fail.

--------

# Regression  

 ***SUMMARY***
 
 NO DIFF FOUND
 
 -------
 
Links of Report
report-1 :- https://kevin222004.github.io/reports/com1/2023-07-28-T-20-52-30/sevntu-check-regression_part_1-report/index.html

report-2 :- https://kevin222004.github.io/reports/com1/2023-07-28-T-20-52-30/part4-report/index.html

report-3 :- https://kevin222004.github.io/reports/com1/2023-07-28-T-20-52-30/part2-report/index.html

report-4 :- https://kevin222004.github.io/reports/com1/2023-07-28-T-20-52-30/part3-report/index.html

report-5 :- https://kevin222004.github.io/reports/com1/2023-07-28-T-20-52-30/part5-report/index.html

report-6 :- https://kevin222004.github.io/reports/com1/2023-07-28-T-20-52-30/part6-report/index.html

report-7 :- https://kevin222004.github.io/reports/com1/2023-07-28-T-20-52-30/antlr-report/index.html

report-8 :- https://kevin222004.github.io/reports/com1/2023-07-28-T-20-52-30/part1-report/index.html

report-9 :- https://kevin222004.github.io/reports/com1/2023-07-28-T-20-52-30/sevntu-check-regression_part_2-report/index.html

report-10 :- https://kevin222004.github.io/reports/com1/2023-07-29-T-09-04-14/checks-only-javadoc-error-report/index.html

reprot-11 :- https://kevin222004.github.io/reports/com1/2023-07-29-T-09-04-14/antlr-report/index.html

report-12 :- https://kevin222004.github.io/reports/com1/2023-07-29-T-09-04-14/checks-nonjavadoc-error-report/index.html

report-13 :- https://kevin222004.github.io/reports/com1/2023-07-29-T-14-02-44/sevntu-check-regression_part_1-report/index.html

report-14 :- https://kevin222004.github.io/reports/com1/2023-07-29-T-14-02-44/part4-report/index.html

report-15 :- https://kevin222004.github.io/reports/com1/2023-07-29-T-14-02-44/part2-report/index.html

report-16 :- https://kevin222004.github.io/reports/com1/2023-07-29-T-14-02-44/part3-report/index.html

report-17 :- https://kevin222004.github.io/reports/com1/2023-07-29-T-14-02-44/part5-report/index.html

report-18 :- https://kevin222004.github.io/reports/com1/2023-07-29-T-14-02-44/checks-only-javadoc-error-report/index.html

report-19 :- https://kevin222004.github.io/reports/com1/2023-07-29-T-14-02-44/part6-report/index.html

report-20 :- https://kevin222004.github.io/reports/com1/2023-07-29-T-14-02-44/antlr-report/index.html

report-21 :- https://kevin222004.github.io/reports/com1/2023-07-29-T-14-02-44/checks-nonjavadoc-error-report/index.html

report-22 :- https://kevin222004.github.io/reports/com1/2023-07-29-T-14-02-44/part1-report/index.html

report-23 :- https://kevin222004.github.io/reports/com1/2023-07-29-T-14-02-44/sevntu-check-regression_part_2-report/index.html

report-24 :- https://kevin222004.github.io/reports/com1/2023-07-29-T-17-58-13/sevntu-check-regression_part_1-report/index.html

report-25 :- https://kevin222004.github.io/reports/com1/2023-07-29-T-17-58-13/part4-report/index.html

report-26 :- https://kevin222004.github.io/reports/com1/2023-07-29-T-17-58-13/part2-report/index.html

report-27 :- https://kevin222004.github.io/reports/com1/2023-07-29-T-17-58-13/part3-report/index.html

report-28 :- https://kevin222004.github.io/reports/com1/2023-07-29-T-17-58-13/part5-report/index.html

report-29 :- https://kevin222004.github.io/reports/com1/2023-07-29-T-17-58-13/checks-only-javadoc-error-report/index.html

report-30 :- https://kevin222004.github.io/reports/com1/2023-07-29-T-17-58-13/part6-report/index.html

report-31 :- https://kevin222004.github.io/reports/com1/2023-07-29-T-17-58-13/antlr-report/index.html

report-32 :- https://kevin222004.github.io/reports/com1/2023-07-29-T-17-58-13/checks-nonjavadoc-error-report/index.html

report-33 :- https://kevin222004.github.io/reports/com1/2023-07-29-T-17-58-13/part1-report/index.html

report-34 :- https://kevin222004.github.io/reports/com1/2023-07-29-T-17-58-13/sevntu-check-regression_part_2-report/index.html