### PR TITLE
Issue #13672: Kill mutation for DetailAstImpl-3

### DIFF
--- a/config/pitest-suppressions/pitest-common-2-suppressions.xml
+++ b/config/pitest-suppressions/pitest-common-2-suppressions.xml
@@ -27,23 +27,23 @@
 
 
 
-  <mutation unstable="false">
-    <sourceFile>DetailAstImpl.java</sourceFile>
-    <mutatedClass>com.puppycrawl.tools.checkstyle.DetailAstImpl</mutatedClass>
-    <mutatedMethod>addNextSibling</mutatedMethod>
-    <mutator>org.pitest.mutationtest.engine.gregor.mutators.experimental.MemberVariableMutator</mutator>
-    <description>Removed assignment to member variable previousSibling</description>
-    <lineContent>astImpl.previousSibling = this;</lineContent>
-  </mutation>
 
-  <mutation unstable="false">
-    <sourceFile>DetailAstImpl.java</sourceFile>
-    <mutatedClass>com.puppycrawl.tools.checkstyle.DetailAstImpl</mutatedClass>
-    <mutatedMethod>addNextSibling</mutatedMethod>
-    <mutator>org.pitest.mutationtest.engine.gregor.mutators.experimental.MemberVariableMutator</mutator>
-    <description>Removed assignment to member variable previousSibling</description>
-    <lineContent>sibling.previousSibling = astImpl;</lineContent>
-  </mutation>
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
 
 
 

--- a/src/main/java/com/puppycrawl/tools/checkstyle/DetailAstImpl.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/DetailAstImpl.java
@@ -144,13 +144,8 @@ public final class DetailAstImpl implements DetailAST {
             // parent is set in setNextSibling
             final DetailAstImpl sibling = nextSibling;
             final DetailAstImpl astImpl = (DetailAstImpl) ast;
+            astImpl.setNextSibling(sibling);
 
-            if (sibling != null) {
-                astImpl.setNextSibling(sibling);
-                sibling.previousSibling = astImpl;
-            }
-
-            astImpl.previousSibling = this;
             setNextSibling(astImpl);
         }
     }

--- a/src/test/java/com/puppycrawl/tools/checkstyle/DetailAstImplTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/DetailAstImplTest.java
@@ -477,20 +477,91 @@ public class DetailAstImplTest extends AbstractModuleTestSupport {
         final DetailAstImpl parent = new DetailAstImpl();
         final DetailAstImpl child = new DetailAstImpl();
         final DetailAstImpl sibling = new DetailAstImpl();
-        final DetailAST newSibling = new DetailAstImpl();
+        final DetailAstImpl newSibling = new DetailAstImpl();
+        final DetailAST newNextSibling = new DetailAstImpl();
+
         parent.setFirstChild(child);
         child.setNextSibling(sibling);
         child.addNextSibling(newSibling);
+        newSibling.addNextSibling(newNextSibling);
 
+        assertWithMessage("Invalid previous sibling")
+            .that(newNextSibling.getPreviousSibling())
+            .isEqualTo(newSibling);
+        assertWithMessage("Invalid next sibling")
+            .that(newNextSibling.getNextSibling())
+            .isEqualTo(sibling);
+        assertWithMessage("Invalid next sibling")
+            .that(sibling.getNextSibling())
+            .isNull();
+        assertWithMessage("Invalid node")
+            .that(sibling.getPreviousSibling().getPreviousSibling())
+            .isEqualTo(newSibling);
+        assertWithMessage("Invalid node")
+            .that(newNextSibling.getPreviousSibling().getPreviousSibling())
+            .isEqualTo(child);
         assertWithMessage("Invalid parent")
             .that(newSibling.getParent())
             .isEqualTo(parent);
         assertWithMessage("Invalid next sibling")
             .that(newSibling.getNextSibling())
-            .isEqualTo(sibling);
+            .isEqualTo(newNextSibling);
         assertWithMessage("Invalid child")
             .that(child.getNextSibling())
             .isEqualTo(newSibling);
+    }
+
+    @Test
+    public void testAddNextSibling2() {
+        final DetailAstImpl parent = new DetailAstImpl();
+        final DetailAstImpl child = new DetailAstImpl();
+        parent.setFirstChild(child);
+        final DetailAstImpl siblingOfChild = new DetailAstImpl();
+        child.addNextSibling(siblingOfChild);
+
+        assertWithMessage("Previous Sibling should be child")
+            .that(siblingOfChild.getPreviousSibling())
+            .isEqualTo(child);
+
+        final DetailAST nullChild = null;
+        siblingOfChild.addNextSibling(nullChild);
+        assertWithMessage("Expected to be null")
+            .that(siblingOfChild.getNextSibling())
+            .isNull();
+        assertWithMessage("Child count should be 2")
+            .that(parent.getChildCount())
+            .isEqualTo(2);
+    }
+
+    @Test
+    public void testAddNextSibling3() {
+        final DetailAstImpl parent = new DetailAstImpl();
+        final DetailAstImpl child = new DetailAstImpl();
+        final DetailAstImpl sibling = new DetailAstImpl();
+
+        parent.setFirstChild(child);
+        child.setNextSibling(sibling);
+        child.addNextSibling(null);
+
+        assertWithMessage("Invalid next sibling")
+                .that(child.getNextSibling())
+                .isEqualTo(sibling);
+    }
+
+    @Test
+    public void testAddNextSibling4() {
+        final DetailAstImpl parent = new DetailAstImpl();
+        parent.setText("Parent");
+        final DetailAstImpl child = new DetailAstImpl();
+        child.setText("Child");
+        final DetailAstImpl sibling = new DetailAstImpl();
+        sibling.setText("Sibling");
+        parent.setFirstChild(child);
+        child.addNextSibling(sibling);
+
+        assertWithMessage("Invalid next sibling")
+                .that(child.getNextSibling())
+                .isEqualTo(sibling);
     }
 
     @Test


### PR DESCRIPTION
Issue #13672: Kill mutation for DetailAstImpl-3

https://github.com/checkstyle/checkstyle/blob/master/src/main/java/com/puppycrawl/tools/checkstyle/DetailAstImpl.java

-------

# Mutations 
https://github.com/checkstyle/checkstyle/blob/88486f7ca9795f613d28fa6c2a53beccef521dfc/config/pitest-suppressions/pitest-common-2-suppressions.xml#L30-L46

------------

# Explaination

To add Next sibiling. The code is 
https://github.com/checkstyle/checkstyle/blob/0dba32b6c8c29977d74af675078501fa8052c10f/src/main/java/com/puppycrawl/tools/checkstyle/DetailAstImpl.java#L140-L156

Line 150 and 153 is mutated 

This explaination is almost similar to https://github.com/checkstyle/checkstyle/pull/13390#issue-1800473514

lets suppose `if (sibling != null) {` if this statment execute then 
`astImpl.setNextSibling(sibling);` while calling setNextSibling the previous sibling will be set at https://github.com/checkstyle/checkstyle/blob/0dba32b6c8c29977d74af675078501fa8052c10f/src/main/java/com/puppycrawl/tools/checkstyle/DetailAstImpl.java#L473-L475 



For 100% surity we can remove 
https://github.com/checkstyle/checkstyle/blob/0dba32b6c8c29977d74af675078501fa8052c10f/src/main/java/com/puppycrawl/tools/checkstyle/DetailAstImpl.java#L466-L476

if last statment from this code in which previous sibiling are set
https://github.com/checkstyle/checkstyle/blob/0dba32b6c8c29977d74af675078501fa8052c10f/src/main/java/com/puppycrawl/tools/checkstyle/DetailAstImpl.java#L473-L475

 testing puropse that this happening or not we can remove 
 and know if you run my updated test case it will still run know run this test by removing the mutated code it will fail.

--------------

# Regression 

No Diff

https://kevin222004.github.io/reports/com3/2023-09-06-T-16-25-20/part3-report/index.html

https://kevin222004.github.io/reports/com3/2023-09-06-T-16-25-20/sevntu-check-regression_part_1-report/index.html

https://kevin222004.github.io/reports/com3/2023-09-06-T-16-25-20/checks-nonjavadoc-error-report/index.html

https://kevin222004.github.io/reports/com3/2023-09-06-T-16-25-20/sevntu-check-regression_part_2-report/index.html

https://kevin222004.github.io/reports/com3/2023-09-06-T-16-25-20/test-report/index.html

https://kevin222004.github.io/reports/com3/2023-09-06-T-16-25-20/checks-only-javadoc-error-report/index.html

https://kevin222004.github.io/reports/com3/2023-09-06-T-16-25-20/part1-report/index.html

https://kevin222004.github.io/reports/com3/2023-09-06-T-16-25-20/part5-report/index.html

https://kevin222004.github.io/reports/com3/2023-09-06-T-16-25-20/part6-report/index.html

https://kevin222004.github.io/reports/com3/2023-09-06-T-16-25-20/part4-report/index.html

https://kevin222004.github.io/reports/com3/2023-09-06-T-16-25-20/antlr-report/index.html

https://kevin222004.github.io/reports/com3/2023-09-06-T-16-25-20/part2-report/index.html

https://kevin222004.github.io/reports/com3/2023-09-06-T-16-30-48/part3-report/index.html

https://kevin222004.github.io/reports/com3/2023-09-06-T-16-30-48/sevntu-check-regression_part_1-report/index.html

https://kevin222004.github.io/reports/com3/2023-09-06-T-16-30-48/checks-nonjavadoc-error-report/index.html

https://kevin222004.github.io/reports/com3/2023-09-06-T-16-30-48/sevntu-check-regression_part_2-report/index.html

https://kevin222004.github.io/reports/com3/2023-09-06-T-16-30-48/test-report/index.html

https://kevin222004.github.io/reports/com3/2023-09-06-T-16-30-48/checks-only-javadoc-error-report/index.html

https://kevin222004.github.io/reports/com3/2023-09-06-T-16-30-48/part1-report/index.html

https://kevin222004.github.io/reports/com3/2023-09-06-T-16-30-48/part5-report/index.html

https://kevin222004.github.io/reports/com3/2023-09-06-T-16-30-48/part6-report/index.html

https://kevin222004.github.io/reports/com3/2023-09-06-T-16-30-48/part4-report/index.html

https://kevin222004.github.io/reports/com3/2023-09-06-T-16-30-48/antlr-report/index.html

https://kevin222004.github.io/reports/com3/2023-09-06-T-16-30-48/part2-report/index.html

