### PR TITLE
Pull #13392: Move section comments to include whole examples and shorten xml configs length

### DIFF
--- a/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/checks/naming/ConstantNameCheckExamplesTest.java
+++ b/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/checks/naming/ConstantNameCheckExamplesTest.java
@@ -57,10 +57,10 @@ public class ConstantNameCheckExamplesTest extends AbstractModuleTestSupport {
         final String pattern = "^log(ger)?$|^[A-Z][A-Z0-9]*(_[A-Z0-9]+)*$";
 
         final String[] expected = {
-            "19:20: " + getCheckMessage(MSG_INVALID_PATTERN, "third_Constant3", pattern),
-            "20:28: " + getCheckMessage(MSG_INVALID_PATTERN, "fourth_Const4", pattern),
-            "23:20: " + getCheckMessage(MSG_INVALID_PATTERN, "loggerMYSELF", pattern),
-            "25:30: " + getCheckMessage(MSG_INVALID_PATTERN, "myselfConstant", pattern),
+            "20:20: " + getCheckMessage(MSG_INVALID_PATTERN, "third_Constant3", pattern),
+            "21:28: " + getCheckMessage(MSG_INVALID_PATTERN, "fourth_Const4", pattern),
+            "24:20: " + getCheckMessage(MSG_INVALID_PATTERN, "loggerMYSELF", pattern),
+            "26:30: " + getCheckMessage(MSG_INVALID_PATTERN, "myselfConstant", pattern),
         };
 
         verifyWithInlineConfigParser(getPath("Example2.java"), expected);

--- a/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/checks/whitespace/EmptyLineSeparatorExamplesTest.java
+++ b/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/checks/whitespace/EmptyLineSeparatorExamplesTest.java
@@ -88,11 +88,11 @@ public class EmptyLineSeparatorExamplesTest extends AbstractModuleTestSupport {
     @Test
     public void testExample5() throws Exception {
         final String[] expected = {
-            "16:1: " + getCheckMessage(MSG_SHOULD_BE_SEPARATED, "package"),
-            "17:1: " + getCheckMessage(MSG_SHOULD_BE_SEPARATED, "import"),
-            "24:3: " + getCheckMessage(MSG_SHOULD_BE_SEPARATED, "VARIABLE_DEF"),
-            "31:3: " + getCheckMessage(MSG_SHOULD_BE_SEPARATED, "METHOD_DEF"),
-            "32:17: " + getCheckMessage(MSG_MULTIPLE_LINES_INSIDE),
+            "17:1: " + getCheckMessage(MSG_SHOULD_BE_SEPARATED, "package"),
+            "18:1: " + getCheckMessage(MSG_SHOULD_BE_SEPARATED, "import"),
+            "25:3: " + getCheckMessage(MSG_SHOULD_BE_SEPARATED, "VARIABLE_DEF"),
+            "32:3: " + getCheckMessage(MSG_SHOULD_BE_SEPARATED, "METHOD_DEF"),
+            "33:17: " + getCheckMessage(MSG_MULTIPLE_LINES_INSIDE),
         };
 
         verifyWithInlineConfigParser(getPath("Example5.java"), expected);

--- a/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/checks/whitespace/ParenPadExamplesTest.java
+++ b/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/checks/whitespace/ParenPadExamplesTest.java
@@ -53,9 +53,9 @@ public class ParenPadExamplesTest extends AbstractModuleTestSupport {
     @Test
     public void testExample2() throws Exception {
         final String[] expected = {
-            "28:27: " + getCheckMessage(MSG_WS_NOT_PRECEDED, ")"),
-            "38:12: " + getCheckMessage(MSG_WS_NOT_FOLLOWED, "("),
-            "44:34: " + getCheckMessage(MSG_WS_NOT_PRECEDED, ")"),
+            "29:27: " + getCheckMessage(MSG_WS_NOT_PRECEDED, ")"),
+            "39:12: " + getCheckMessage(MSG_WS_NOT_FOLLOWED, "("),
+            "45:34: " + getCheckMessage(MSG_WS_NOT_PRECEDED, ")"),
         };
 
         verifyWithInlineConfigParser(getPath("Example2.java"), expected);

--- a/src/xdocs-examples/resources-noncompilable/com/puppycrawl/tools/checkstyle/checks/whitespace/nowhitespacebeforecasedefaultcolon/Example1.java
+++ b/src/xdocs-examples/resources-noncompilable/com/puppycrawl/tools/checkstyle/checks/whitespace/nowhitespacebeforecasedefaultcolon/Example1.java
@@ -12,9 +12,9 @@ package com.puppycrawl.tools.checkstyle.checks.whitespace.nowhitespacebeforecase
 
 import java.time.DayOfWeek;
 
+// xdoc section -- start
 class Example1 {
   void example() {
-    // xdoc section -- start
     switch(1) {
       case 1 : // violation '':' is preceded with whitespace'
         break;
@@ -41,6 +41,6 @@ class Example1 {
       // violation below '':' is preceded with whitespace'
       case TUESDAY               : System.out.println("  7"); break;
     }
-    // xdoc section -- end
   }
 }
+// xdoc section -- end

--- a/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/naming/abbreviationaswordinname/Example1.java
+++ b/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/naming/abbreviationaswordinname/Example1.java
@@ -13,8 +13,8 @@ package com.puppycrawl.tools.checkstyle.checks.naming.abbreviationaswordinname;
 import java.util.HashSet;
 import java.util.Set;
 
+// xdoc section -- start
 class Example1 extends SuperClass {
-  // xdoc section -- start
   int CURRENT_COUNTER; // violation 'no more than '4' consecutive capital letters'
   static int GLOBAL_COUNTER;
   final Set<String> stringsFOUND = new HashSet<>();
@@ -31,5 +31,5 @@ class Example1 extends SuperClass {
   static void incrementGLOBAL() {
     GLOBAL_COUNTER++;
   }
-  // xdoc section -- end
 }
+// xdoc section -- end

--- a/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/naming/abbreviationaswordinname/Example2.java
+++ b/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/naming/abbreviationaswordinname/Example2.java
@@ -16,8 +16,8 @@ package com.puppycrawl.tools.checkstyle.checks.naming.abbreviationaswordinname;
 import java.util.HashSet;
 import java.util.Set;
 
+// xdoc section -- start
 class Example2 extends SuperClass {
-  // xdoc section -- start
   int CURRENT_COUNTER; // violation 'no more than '4' consecutive capital letters'
   // violation below 'no more than '4' consecutive capital letters'
   static int GLOBAL_COUNTER;
@@ -35,5 +35,5 @@ class Example2 extends SuperClass {
   static void incrementGLOBAL() {
     GLOBAL_COUNTER++;
   }
-  // xdoc section -- end
 }
+// xdoc section -- end

--- a/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/naming/abbreviationaswordinname/Example3.java
+++ b/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/naming/abbreviationaswordinname/Example3.java
@@ -15,8 +15,8 @@
 
 package com.puppycrawl.tools.checkstyle.checks.naming.abbreviationaswordinname;
 
+// xdoc section -- start
 class Example3 {
-  // xdoc section -- start
   int firstNum;
   int secondNUM; // violation 'no more than '1' consecutive capital letters'
   static int thirdNum;
@@ -28,5 +28,5 @@ class Example3 {
   void newOAuth2Client() {}
   void OAuth2() {}
   void OAUth2() {}
-  // xdoc section -- end
 }
+// xdoc section -- end

--- a/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/naming/abbreviationaswordinname/Example4.java
+++ b/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/naming/abbreviationaswordinname/Example4.java
@@ -15,8 +15,8 @@
 
 package com.puppycrawl.tools.checkstyle.checks.naming.abbreviationaswordinname;
 
+// xdoc section -- start
 class Example4 {
-  // xdoc section -- start
   int firstNum;
   int secondNUm;
   int secondMYNum; // violation 'no more than '2' consecutive capital letters'
@@ -26,5 +26,5 @@ class Example4 {
   String firstXML; // violation 'no more than '2' consecutive capital letters'
   final int TOTAL = 5;
   static final int LIMIT = 10;
-  // xdoc section -- end
 }
+// xdoc section -- end

--- a/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/naming/abbreviationaswordinname/Example5.java
+++ b/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/naming/abbreviationaswordinname/Example5.java
@@ -16,12 +16,12 @@
 
 package com.puppycrawl.tools.checkstyle.checks.naming.abbreviationaswordinname;
 
+// xdoc section -- start
 class Example5 {
-  // xdoc section -- start
   int counterXYZ = 1; // violation 'no more than '1' consecutive capital letters'
   // violation below 'no more than '1' consecutive capital letters'
   final int customerID = 2;
   static int nextID = 3; // violation 'no more than '1' consecutive capital letters'
   static final int MAX_ALLOWED = 4;
-  // xdoc section -- end
 }
+// xdoc section -- end

--- a/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/naming/abbreviationaswordinname/Example6.java
+++ b/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/naming/abbreviationaswordinname/Example6.java
@@ -16,13 +16,13 @@
 
 package com.puppycrawl.tools.checkstyle.checks.naming.abbreviationaswordinname;
 
+// xdoc section -- start
 class Example6 {
-  // xdoc section -- start
   int counterXYZ = 1; // violation 'no more than '1' consecutive capital letters'
   // violation below 'no more than '1' consecutive capital letters'
   final int customerID = 2;
   static int nextID = 3;
   // violation below 'no more than '1' consecutive capital letters'
   static final int MAX_ALLOWED = 4;
-  // xdoc section -- end
 }
+// xdoc section -- end

--- a/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/naming/abbreviationaswordinname/Example7.java
+++ b/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/naming/abbreviationaswordinname/Example7.java
@@ -13,11 +13,11 @@
 
 package com.puppycrawl.tools.checkstyle.checks.naming.abbreviationaswordinname;
 
+// xdoc section -- start
 class Example7 {
-  // xdoc section -- start
   int counterXYZ = 1;
   final int customerID = 2;
   static int nextID = 3;
   static final int MAX_ALLOWED = 4;
-  // xdoc section -- end
 }
+// xdoc section -- end

--- a/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/naming/abstractclassname/Example1.java
+++ b/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/naming/abstractclassname/Example1.java
@@ -10,8 +10,8 @@
 
 package com.puppycrawl.tools.checkstyle.checks.naming.abstractclassname;
 
+// xdoc section -- start
 class Example1 {
-  // xdoc section -- start
   abstract class AbstractFirst {}
   abstract class Second {} // violation 'must match pattern'
   class AbstractThird {} // violation 'must be declared as 'abstract''
@@ -19,5 +19,5 @@ class Example1 {
   abstract class GeneratorFifth {}
   // violation above 'must match pattern'
   class GeneratorSixth {}
-  // xdoc section -- end
 }
+// xdoc section -- end

--- a/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/naming/abstractclassname/Example2.java
+++ b/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/naming/abstractclassname/Example2.java
@@ -12,8 +12,8 @@
 
 package com.puppycrawl.tools.checkstyle.checks.naming.abstractclassname;
 
+// xdoc section -- start
 class Example2 {
-  // xdoc section -- start
   abstract class AbstractFirst {}
   abstract class Second {} // violation 'must match pattern'
   class AbstractThird {}
@@ -21,5 +21,5 @@ class Example2 {
   abstract class GeneratorFifth {}
   // violation above 'must match pattern'
   class GeneratorSixth {}
-  // xdoc section -- end
 }
+// xdoc section -- end

--- a/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/naming/abstractclassname/Example3.java
+++ b/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/naming/abstractclassname/Example3.java
@@ -12,13 +12,13 @@
 
 package com.puppycrawl.tools.checkstyle.checks.naming.abstractclassname;
 
+// xdoc section -- start
 class Example3 {
-  // xdoc section -- start
   abstract class AbstractFirst {}
   abstract class Second {}
   class AbstractThird {} // violation 'must be declared as 'abstract''
   class Fourth {}
   abstract class GeneratorFifth {}
   class GeneratorSixth {}
-  // xdoc section -- end
 }
+// xdoc section -- end

--- a/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/naming/abstractclassname/Example4.java
+++ b/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/naming/abstractclassname/Example4.java
@@ -12,8 +12,8 @@
 
 package com.puppycrawl.tools.checkstyle.checks.naming.abstractclassname;
 
+// xdoc section -- start
 class Example4 {
-  // xdoc section -- start
   // violation below 'must match pattern'
   abstract class AbstractFirst {}
   abstract class Second {} // violation 'must match pattern'
@@ -21,5 +21,5 @@ class Example4 {
   class Fourth {}
   abstract class GeneratorFifth {}
   class GeneratorSixth {} // violation 'must be declared as 'abstract''
-  // xdoc section -- end
 }
+// xdoc section -- end

--- a/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/naming/constantname/Example1.java
+++ b/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/naming/constantname/Example1.java
@@ -10,8 +10,8 @@
 
 package com.puppycrawl.tools.checkstyle.checks.naming.constantname;
 
+// xdoc section -- start
 class Example1 {
-  // xdoc section -- start
   public final static int FIRST_CONSTANT1 = 10;
   protected final static int SECOND_CONSTANT2 = 100;
   final static int third_Constant3 = 1000; // violation 'must match pattern'
@@ -21,5 +21,5 @@ class Example1 {
   final static int loggerMYSELF = 5; // violation 'must match pattern'
   final static int MYSELF = 100;
   protected final static int myselfConstant = 1; // violation 'must match pattern'
-  // xdoc section -- end
 }
+// xdoc section -- end

--- a/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/naming/constantname/Example2.java
+++ b/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/naming/constantname/Example2.java
@@ -2,7 +2,8 @@
 <module name="Checker">
   <module name="TreeWalker">
     <module name="ConstantName">
-      <property name="format" value="^log(ger)?$|^[A-Z][A-Z0-9]*(_[A-Z0-9]+)*$"/>
+      <property name="format"
+                value="^log(ger)?$|^[A-Z][A-Z0-9]*(_[A-Z0-9]+)*$"/>
     </module>
   </module>
 </module>
@@ -12,8 +13,8 @@
 
 package com.puppycrawl.tools.checkstyle.checks.naming.constantname;
 
+// xdoc section -- start
 class Example2 {
-  // xdoc section -- start
   public final static int FIRST_CONSTANT1 = 10;
   protected final static int SECOND_CONSTANT2 = 100;
   final static int third_Constant3 = 1000; // violation 'must match pattern'
@@ -23,5 +24,5 @@ class Example2 {
   final static int loggerMYSELF = 5; // violation 'must match pattern'
   final static int MYSELF = 100;
   protected final static int myselfConstant = 1; // violation 'must match pattern'
-  // xdoc section -- end
 }
+// xdoc section -- end

--- a/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/naming/constantname/Example3.java
+++ b/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/naming/constantname/Example3.java
@@ -13,8 +13,8 @@
 
 package com.puppycrawl.tools.checkstyle.checks.naming.constantname;
 
+// xdoc section -- start
 class Example3 {
-  // xdoc section -- start
   public final static int FIRST_CONSTANT1 = 10;
   protected final static int SECOND_CONSTANT2 = 100;
   final static int third_Constant3 = 1000; // violation 'must match pattern'
@@ -24,5 +24,5 @@ class Example3 {
   final static int loggerMYSELF = 5; // violation 'must match pattern'
   final static int MYSELF = 100;
   protected final static int myselfConstant = 1;
-  // xdoc section -- end
 }
+// xdoc section -- end

--- a/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/whitespace/emptyforinitializerpad/Example1.java
+++ b/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/whitespace/emptyforinitializerpad/Example1.java
@@ -10,16 +10,16 @@
 
 package com.puppycrawl.tools.checkstyle.checks.whitespace.emptyforinitializerpad;
 
+// xdoc section -- start
 class Example1 {
   int i = 0;
   void example() {
-    // xdoc section -- start
     for ( ; i < 1; i++ );  // violation '';' is preceded with whitespace'
     for (; i < 2; i++ );
     for (;i<2;i++);
     for ( ;i<2;i++);       // violation '';' is preceded with whitespace'
     for (
           ; i < 2; i++ );
-    // xdoc section -- end
   }
 }
+// xdoc section -- end

--- a/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/whitespace/emptyforinitializerpad/Example2.java
+++ b/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/whitespace/emptyforinitializerpad/Example2.java
@@ -12,16 +12,16 @@
 
 package com.puppycrawl.tools.checkstyle.checks.whitespace.emptyforinitializerpad;
 
+// xdoc section -- start
 class Example2 {
   int i = 0;
   void example() {
-    // xdoc section -- start
     for ( ; i < 2; i++ ) { };
     for (; i < 2; i++ ) { };    // violation '';' is not preceded with whitespace'
     for (;i<2;i++) { };         // violation '';' is not preceded with whitespace'
     for ( ;i<2;i++) { };
     for (
           ; i < 2; i++ );
-    // xdoc section -- end
   }
 }
+// xdoc section -- end

--- a/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/whitespace/emptyforiteratorpad/Example1.java
+++ b/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/whitespace/emptyforiteratorpad/Example1.java
@@ -14,10 +14,10 @@ import java.util.HashMap;
 import java.util.Iterator;
 import java.util.Map;
 
+// xdoc section -- start
 class Example1 {
   Map<String, String> map = new HashMap<>();
   void example() {
-    // xdoc section -- start
     for (Iterator it = map.entrySet().iterator();  it.hasNext(););
     for (Iterator it = map.entrySet().iterator();  it.hasNext(); );
     // violation above '';' is followed by whitespace'
@@ -25,6 +25,6 @@ class Example1 {
     for (Iterator foo = map.entrySet().iterator();
          foo.hasNext();
          );
-    // xdoc section -- end
   }
 }
+// xdoc section -- end

--- a/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/whitespace/emptyforiteratorpad/Example2.java
+++ b/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/whitespace/emptyforiteratorpad/Example2.java
@@ -16,10 +16,10 @@ import java.util.HashMap;
 import java.util.Iterator;
 import java.util.Map;
 
+// xdoc section -- start
 class Example2 {
   Map<String, String> map = new HashMap<>();
   void example() {
-    // xdoc section -- start
     for (Iterator it = map.entrySet().iterator();  it.hasNext(););
     // violation above '';' is not followed by whitespace.'
     for (Iterator it = map.entrySet().iterator();  it.hasNext(); );
@@ -27,6 +27,6 @@ class Example2 {
     for (Iterator foo = map.entrySet().iterator();
          foo.hasNext();
          );
-    // xdoc section -- end
   }
 }
+// xdoc section -- end

--- a/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/whitespace/emptylineseparator/Example5.java
+++ b/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/whitespace/emptylineseparator/Example5.java
@@ -2,7 +2,8 @@
 <module name="Checker">
   <module name="TreeWalker">
     <module name="EmptyLineSeparator">
-      <property name="allowMultipleEmptyLinesInsideClassMembers" value="false"/>
+      <property name="allowMultipleEmptyLinesInsideClassMembers"
+                value="false"/>
     </module>
   </module>
 </module>

--- a/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/whitespace/filetabcharacter/Example1.java
+++ b/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/whitespace/filetabcharacter/Example1.java
@@ -8,12 +8,12 @@
 
 package com.puppycrawl.tools.checkstyle.checks.whitespace.filetabcharacter;
 
+// xdoc section -- start
 class Example1 {
-  // xdoc section -- start
 	int a; // violation 'File contains tab characters'
 
 	public void foo (int arg) { // OK, only first occurrence in file reported
     a = arg; // OK, indented using spaces
   }
-  // xdoc section -- end
 }
+// xdoc section -- end

--- a/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/whitespace/filetabcharacter/Example2.java
+++ b/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/whitespace/filetabcharacter/Example2.java
@@ -10,12 +10,12 @@
 
 package com.puppycrawl.tools.checkstyle.checks.whitespace.filetabcharacter;
 
+// xdoc section -- start
 class Example2 {
-  // xdoc section -- start
 	int a; // violation 'contains a tab character'
 
 	public void foo (int arg) { // violation 'contains a tab character'
     a = arg; // OK, indented using spaces
   }
-  // xdoc section -- end
 }
+// xdoc section -- end

--- a/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/whitespace/filetabcharacter/Example3.java
+++ b/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/whitespace/filetabcharacter/Example3.java
@@ -10,12 +10,12 @@
 
 package com.puppycrawl.tools.checkstyle.checks.whitespace.filetabcharacter;
 
+// xdoc section -- start
 class Example3 {
-    // xdoc section -- start
 	int a; // violation 'File contains tab characters'
 
 	public void foo (int arg) { // OK, only first occurrence in file reported
     a = arg; // OK, indented using spaces
   }
-  // xdoc section -- end
 }
+// xdoc section -- end

--- a/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/whitespace/methodparampad/Example1.java
+++ b/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/whitespace/methodparampad/Example1.java
@@ -10,8 +10,8 @@
 
 package com.puppycrawl.tools.checkstyle.checks.whitespace.methodparampad;
 
+// xdoc section -- start
 class Example1 {
-  // xdoc section -- start
   public Example1() {
     super();
   }
@@ -24,5 +24,5 @@ class Example1 {
 
   public void methodWithVeryLongName
   () {} // violation ''(' should be on the previous line.'
-  // xdoc section -- end
 }
+// xdoc section -- end

--- a/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/whitespace/methodparampad/Example2.java
+++ b/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/whitespace/methodparampad/Example2.java
@@ -14,8 +14,8 @@
 
 package com.puppycrawl.tools.checkstyle.checks.whitespace.methodparampad;
 
+// xdoc section -- start
 class Example2 {
-  // xdoc section -- start
   public Example2() {
     super();
   }
@@ -28,5 +28,5 @@ class Example2 {
 
   public void methodWithVeryLongName
   () {} // OK, because allowLineBreaks is true
-  // xdoc section -- end
 }
+// xdoc section -- end

--- a/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/whitespace/nowhitespaceafter/Example1.java
+++ b/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/whitespace/nowhitespaceafter/Example1.java
@@ -10,8 +10,8 @@
 
 package com.puppycrawl.tools.checkstyle.checks.whitespace.nowhitespaceafter;
 
+// xdoc section -- start
 class Example1 {
-  // xdoc section -- start
   public void lineBreak(String x) {
     Integer.
         parseInt(x);
@@ -32,5 +32,5 @@ class Example1 {
     a = ~ a; // violation ''~' is followed by whitespace'
     a = ~a;
   }
-  // xdoc section -- end
 }
+// xdoc section -- end

--- a/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/whitespace/nowhitespaceafter/Example2.java
+++ b/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/whitespace/nowhitespaceafter/Example2.java
@@ -13,8 +13,8 @@
 
 package com.puppycrawl.tools.checkstyle.checks.whitespace.nowhitespaceafter;
 
+// xdoc section -- start
 class Example2 {
-  // xdoc section -- start
   public void lineBreak(String x) {
     Integer.
         parseInt(x); // violation above ''.' is followed by whitespace'
@@ -35,5 +35,5 @@ class Example2 {
     a = ~ a;
     a = ~a;
   }
-  // xdoc section -- end
 }
+// xdoc section -- end

--- a/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/whitespace/nowhitespacebefore/Example1.java
+++ b/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/whitespace/nowhitespacebefore/Example1.java
@@ -12,10 +12,10 @@ package com.puppycrawl.tools.checkstyle.checks.whitespace.nowhitespacebefore;
 
 import com.google.common.collect.Lists;
 
+// xdoc section -- start
 class Example1 {
   int foo = 5;
   void example() {
-    // xdoc section -- start
     foo ++; // violation 'is preceded with whitespace'
     foo++;
     for (int i = 0 ; i < 5; i++) {}  // violation '';' is preceded with whitespace'
@@ -36,6 +36,6 @@ class Example1 {
       label2:
       while (foo < 5) {}
     }
-    // xdoc section -- end
   }
 }
+// xdoc section -- end

--- a/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/whitespace/nowhitespacebefore/Example2.java
+++ b/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/whitespace/nowhitespacebefore/Example2.java
@@ -14,8 +14,8 @@ package com.puppycrawl.tools.checkstyle.checks.whitespace.nowhitespacebefore;
 
 import com.google.common.collect.Lists;
 
+// xdoc section -- start
 class Example2 {
-  // xdoc section -- start
   int[][] array = { { 1, 2 }
                   , { 3, 4 } };
   int[][] array2 = { { 1, 2 },
@@ -28,5 +28,5 @@ class Example2 {
          .listIterator()
          .forEachRemaining(System.out::print);
   };
-  // xdoc section -- end
 }
+// xdoc section -- end

--- a/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/whitespace/nowhitespacebefore/Example3.java
+++ b/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/whitespace/nowhitespacebefore/Example3.java
@@ -14,15 +14,15 @@ package com.puppycrawl.tools.checkstyle.checks.whitespace.nowhitespacebefore;
 
 import com.google.common.collect.Lists;
 
+// xdoc section -- start
 class Example3 {
   void example() {
-    // xdoc section -- start
     Lists.charactersOf("foo").listIterator()
          .forEachRemaining(System.out::print);
     // violation above ''.' is preceded with whitespace'
     Lists.charactersOf("foo").listIterator().forEachRemaining(System.out ::print);
     // violation above ''::' is preceded with whitespace'
     Lists.charactersOf("foo").listIterator().forEachRemaining(System.out::print);
-    // xdoc section -- end
   }
 }
+// xdoc section -- end

--- a/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/whitespace/nowhitespacebefore/Example4.java
+++ b/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/whitespace/nowhitespacebefore/Example4.java
@@ -15,9 +15,9 @@ package com.puppycrawl.tools.checkstyle.checks.whitespace.nowhitespacebefore;
 
 import com.google.common.collect.Lists;
 
+// xdoc section -- start
 class Example4 {
   void example() {
-    // xdoc section -- start
     Lists .charactersOf("foo") // violation ''.' is preceded with whitespace'
           .listIterator()
           .forEachRemaining(System.out ::print);
@@ -25,6 +25,6 @@ class Example4 {
     Lists.charactersOf("foo")
          .listIterator()
          .forEachRemaining(System.out::print);
-    // xdoc section -- end
   }
 }
+// xdoc section -- end

--- a/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/whitespace/operatorwrap/Example1.java
+++ b/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/whitespace/operatorwrap/Example1.java
@@ -10,9 +10,9 @@
 
 package com.puppycrawl.tools.checkstyle.checks.whitespace.operatorwrap;
 
+// xdoc section -- start
 class Example1 {
   void example() {
-    // xdoc section -- start
     String s = "Hello" + // violation ''\+' should be on a new line'
       "World";
 
@@ -29,6 +29,6 @@ class Example1 {
 
     int d = c
             + 10;
-    // xdoc section -- end
   }
 }
+// xdoc section -- end

--- a/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/whitespace/operatorwrap/Example2.java
+++ b/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/whitespace/operatorwrap/Example2.java
@@ -16,9 +16,9 @@
 
 package com.puppycrawl.tools.checkstyle.checks.whitespace.operatorwrap;
 
+// xdoc section -- start
 class Example2 {
   void example() {
-    // xdoc section -- start
     int b
             = 10; // violation ''=' should be on the previous line'
     int c =
@@ -45,6 +45,6 @@ class Example2 {
             &=1 ; // violation ''&=' should be on the previous line'
     c
             <<= 1; // violation ''<<=' should be on the previous line'
-    // xdoc section -- end
   }
 }
+// xdoc section -- end

--- a/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/whitespace/parenpad/Example2.java
+++ b/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/whitespace/parenpad/Example2.java
@@ -2,7 +2,8 @@
 <module name="Checker">
   <module name="TreeWalker">
     <module name="ParenPad">
-      <property name="tokens" value="LITERAL_FOR, LITERAL_CATCH, SUPER_CTOR_CALL"/>
+      <property name="tokens"
+                value="LITERAL_FOR, LITERAL_CATCH, SUPER_CTOR_CALL"/>
       <property name="option" value="space"/>
     </module>
   </module>

--- a/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/whitespace/singlespaceseparator/Example1.java
+++ b/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/whitespace/singlespaceseparator/Example1.java
@@ -10,8 +10,8 @@
 
 package com.puppycrawl.tools.checkstyle.checks.whitespace.singlespaceseparator;
 
+// xdoc section -- start
 class Example1 {
-  // xdoc section -- start
   int foo()   { // violation 'Use a single space'
     return  1; // violation 'Use a single space'
   }
@@ -19,5 +19,5 @@ class Example1 {
     return 3;
   }
   void  fun2() {} // violation 'Use a single space'
-  // xdoc section -- end
 }
+// xdoc section -- end

--- a/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/whitespace/singlespaceseparator/Example2.java
+++ b/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/whitespace/singlespaceseparator/Example2.java
@@ -12,8 +12,8 @@
 
 package com.puppycrawl.tools.checkstyle.checks.whitespace.singlespaceseparator;
 
+// xdoc section -- start
 class Example2 {
-  // xdoc section -- start
   // violation below 'Use a single space'
   void fun1() {}  // 2 whitespaces before the comment starts
   // violation below 'Use a single space'
@@ -32,5 +32,5 @@ class Example2 {
   /**
    * OK, 1 white space after the doc comment ends
    */ float f2;
-  // xdoc section -- end
 }
+// xdoc section -- end

--- a/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/whitespace/typecastparenpad/Example1.java
+++ b/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/whitespace/typecastparenpad/Example1.java
@@ -10,8 +10,8 @@
 
 package com.puppycrawl.tools.checkstyle.checks.whitespace.typecastparenpad;
 
+// xdoc section -- start
 class Example1 {
-  // xdoc section -- start
   float f1 = 3.14f;
 
   int n = ( int ) f1; // 2 violations
@@ -23,5 +23,5 @@ class Example1 {
   float f3 = (float) d;
 
   float f4 = ( float) d; // violation 'followed by whitespace'
-  // xdoc section -- end
 }
+// xdoc section -- end

--- a/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/whitespace/typecastparenpad/Example2.java
+++ b/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/whitespace/typecastparenpad/Example2.java
@@ -12,8 +12,8 @@
 
 package com.puppycrawl.tools.checkstyle.checks.whitespace.typecastparenpad;
 
+// xdoc section -- start
 class Example2 {
-  // xdoc section -- start
   double d1 = 3.14;
 
   int n = ( int ) d1;
@@ -25,5 +25,5 @@ class Example2 {
   int x = (int) d2; // 2 violations
 
   int y = ( int) d2; // violation 'not preceded with whitespace'
-  // xdoc section -- end
 }
+// xdoc section -- end


### PR DESCRIPTION
As requested in https://github.com/checkstyle/checkstyle/pull/13357#issuecomment-1633313837
> Please move all section comments moving to separate PR to merge instantly.

Reason at https://github.com/checkstyle/checkstyle/pull/13357#discussion_r1261601004

> I was getting checkstyle errors that <source> examples are indented. I am moving delimiters to include class definitions too. This is what was decided at some point after those examples were merged anyways.

And https://github.com/checkstyle/checkstyle/pull/13357#discussion_r1261593897
> Some XML configs become longer than 100 characters when <,> are substituted with &lt;,&gt;. I had to split those XML properties in multiple lines and that's why test lines change.
