### PR TITLE
Issue #13389: Extend `getXdocsFilePaths` to gather `.xml.vm` files

### DIFF
--- a/src/test/java/com/puppycrawl/tools/checkstyle/internal/XdocsPagesTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/internal/XdocsPagesTest.java
@@ -433,7 +433,9 @@ public class XdocsPagesTest {
 
                 // can't test ant structure, or old and outdated checks
                 assertWithMessage("Xml is invalid, old or has outdated structure")
-                        .that(fileName.startsWith("anttask") || fileName.startsWith("releasenotes")
+                        .that(fileName.startsWith("anttask")
+                                || fileName.startsWith("releasenotes")
+                                || fileName.startsWith("writingjavadocchecks")
                                 || isValidCheckstyleXml(fileName, code, unserializedSource))
                         .isTrue();
             }

--- a/src/test/java/com/puppycrawl/tools/checkstyle/internal/utils/XdocUtil.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/internal/utils/XdocUtil.java
@@ -60,7 +60,11 @@ public final class XdocUtil {
     public static Set<Path> getXdocsFilePaths() throws IOException {
         final Path directory = Paths.get(DIRECTORY_PATH);
         try (Stream<Path> stream = Files.find(directory, Integer.MAX_VALUE,
-                (path, attr) -> attr.isRegularFile() && path.toString().endsWith(".xml"))) {
+                (path, attr) -> {
+                    return attr.isRegularFile()
+                            && (path.toString().endsWith(".xml")
+                            || path.toString().endsWith(".xml.vm"));
+                })) {
             return stream.collect(Collectors.toSet());
         }
     }

--- a/src/xdocs/index.xml.vm
+++ b/src/xdocs/index.xml.vm
@@ -551,7 +551,7 @@
         </div>
       </subsection>
 
-      <subsection name="Inactive / Old Tools" id="Related_Tools_Inactive_Old_Tools">
+      <subsection name="Inactive or Old Tools" id="Related_Tools_Inactive_or_Old_Tools">
         <div class="wrapper">
           <table>
             <tr>

--- a/src/xdocs/writingjavadocchecks.xml.vm
+++ b/src/xdocs/writingjavadocchecks.xml.vm
@@ -529,39 +529,41 @@ JAVADOC -> JAVADOC [0:0]
 
       <p>More examples:</p>
 
-      <table style="table-layout: fixed;">
-        <tr>
-          <td>
-            1) Unclosed paragraph HTML tag. As you see in the tree, content of the paragraph tag is
-            not nested to this tag.
-            That is because HTML tags are not closed by pair tag &lt;/p&gt;, and Checkstyle requires
-            <a href="#Tight-HTML_rules">Tight-HTML</a> code to predictably parse Javadoc comments.
-          </td>
-          <td>
-            2) Here is correct version with open and closed HTML tags.
-          </td>
-        </tr>
+      <div class="wrapper">
+        <table style="table-layout: fixed;">
+          <tr>
+            <td>
+              1) Unclosed paragraph HTML tag. As you see in the tree, content of the paragraph tag
+              is not nested to this tag.
+              That is because HTML tags are not closed by pair tag &lt;/p&gt;, and Checkstyle
+              requires <a href="#Tight-HTML_rules">Tight-HTML</a> code to predictably parse
+              Javadoc comments.
+            </td>
+            <td>
+              2) Here is correct version with open and closed HTML tags.
+            </td>
+          </tr>
 
-        <tr>
-          <td>
-            <source><![CDATA[
+          <tr>
+            <td>
+              <source><![CDATA[
 <p> First
 <p> Second
 ]]>
-            </source>
-          </td>
-          <td>
-            <source><![CDATA[
+              </source>
+            </td>
+            <td>
+              <source><![CDATA[
 <p> First </p>
 <p> Second </p>
 ]]>
-            </source>
-          </td>
-        </tr>
+              </source>
+            </td>
+          </tr>
 
-        <tr>
-          <td>
-            <source><![CDATA[
+          <tr>
+            <td>
+              <source><![CDATA[
 JAVADOC -> JAVADOC [0:0]
 |--HTML_ELEMENT -> HTML_ELEMENT [0:0]
 |   `--P_TAG_START -> P_TAG_START [0:0]
@@ -578,10 +580,10 @@ JAVADOC -> JAVADOC [0:0]
 |--TEXT ->  Second [1:3]
 `--EOF -> <EOF> [1:10]
 ]]>
-            </source>
-          </td>
-          <td>
-            <source><![CDATA[
+              </source>
+            </td>
+            <td>
+              <source><![CDATA[
 JAVADOC -> JAVADOC [0:0]
 |--HTML_ELEMENT -> HTML_ELEMENT [0:0]
 |   `--PARAGRAPH -> PARAGRAPH [0:0]
@@ -610,10 +612,11 @@ JAVADOC -> JAVADOC [0:0]
 |           `--END -> > [1:14]
 `--EOF -> <EOF> [1:15]
 ]]>
-            </source>
-          </td>
-        </tr>
-      </table>
+              </source>
+            </td>
+          </tr>
+        </table>
+      </div>
 
       <p>
         Checks can also be configured to log violation on encountering non-tight HTML tags.


### PR DESCRIPTION
Resolves #13389 