### PR TITLE
Pull #13397: update link check to only check internal links in PRs

### DIFF
--- a/.ci/run-link-check-plugin.sh
+++ b/.ci/run-link-check-plugin.sh
@@ -11,9 +11,19 @@ mvn -e --no-transfer-progress clean site -Dcheckstyle.ant.skip=true -DskipTests 
    -Dpmd.skip=true -Dspotbugs.skip=true -Djacoco.skip=true -Dcheckstyle.skip=true
 mkdir -p .ci-temp
 
+OPTION=$1
+
 echo "------------ grep of linkcheck.html--BEGIN"
-grep -E "doesn't exist|externalLink" target/site/linkcheck.html | grep -v 'Read timed out' \
-  | sed 's/<\/table><\/td><\/tr>//g' | sort > .ci-temp/linkcheck-errors-sorted.txt
+LINKCHECK_ERRORS=$(grep -E "doesn't exist|externalLink" target/site/linkcheck.html \
+  | grep -v 'Read timed out' | sed 's/<\/table><\/td><\/tr>//g' || true)
+
+if [[ $OPTION == "--skip-external" ]]; then
+  echo "Checking internal (checkstyle website) links only."
+  echo "$LINKCHECK_ERRORS" | grep -v 'externalLink' | sort > .ci-temp/linkcheck-errors-sorted.txt
+else
+  echo "Checking internal (checkstyle website) and external links."
+  echo "$LINKCHECK_ERRORS" | sort > .ci-temp/linkcheck-errors-sorted.txt
+fi
 
 sort config/linkcheck-suppressions.txt | sed 's/<\/table><\/td><\/tr>//g' \
   > .ci-temp/linkcheck-suppressions-sorted.txt

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -221,7 +221,7 @@ workflows:
       - validate-with-maven-script:
           name: "linkcheck-plugin"
           image-name: "cimg/openjdk:11.0.19"
-          command: "./.ci/run-link-check-plugin.sh"
+          command: "./.ci/run-link-check-plugin.sh --skip-external"
 
   idea:
     jobs:


### PR DESCRIPTION
We should only check for internal links in PRs.

Linkcheck run should pass in this PR even though we have a bad external link (stickler-ci) in master: https://circleci.com/gh/checkstyle/checkstyle/335960

Link to failure in master: https://github.com/checkstyle/checkstyle/actions/runs/5546064017/jobs/10125837894


----------------
Proof that `--check-external` works: https://app.circleci.com/pipelines/github/checkstyle/checkstyle/19614/workflows/2475ba7b-ee8e-4d65-96b3-fbc06dd143ab/jobs/336405

Proof that default works (internal only): https://circleci.com/gh/checkstyle/checkstyle/336829
