### PR TITLE
minor: remove stickler-ci from active tools

### DIFF
--- a/src/xdocs/index.xml.vm
+++ b/src/xdocs/index.xml.vm
@@ -407,23 +407,6 @@
             </tr>
             <tr>
               <td>
-                <a href="https://stickler-ci.com/">Stickler CI</a>
-              </td>
-              <td>Mark Story</td>
-              <td>
-                <a href="https://stickler-ci.com/docs#java">
-                  Built in
-                </a>
-              </td>
-              <td>
-                Provides analysis per pull request as GitHub
-                <a href="https://docs.github.com/en/rest/checks">
-                  Check Run</a>
-                annotations. Supports CheckStyle config files.
-              </td>
-            </tr>
-            <tr>
-              <td>
                 <a href="https://github.com/nikitasavinov/checkstyle-action#checkstyle-github-action">
                 Checkstyle GitHub Actions</a>
               </td>


### PR DESCRIPTION
From https://github.com/checkstyle/checkstyle/actions/runs/5560007224/jobs/10156644820#step:4:2338:

```
------------ grep of linkcheck.html--BEGIN
0a1,2
> <td><i><a class="externalLink" href="https://stickler-ci.com/">https://stickler-ci.com/</a>: org.apache.commons.httpclient.ConnectTimeoutException : The host did not accept the connection within timeout of 6000 ms</i></td></tr>
> <td><i><a class="externalLink" href="https://stickler-ci.com/docs#java">https://stickler-ci.com/docs#java</a>: org.apache.commons.httpclient.ConnectTimeoutException : The host did not accept the connection within timeout of 6000 ms</i></td></tr>
------------ grep of linkcheck.html--END

```

Looks like stickler ci is not active anymore, I am removing it from "Active Tools" section. See https://stickler-ci.com/shutting-down for details.

search for `stickler`:
```
➜  checkstyle git:(master) ✗ ag -Q "stickler"
src/main/java/com/puppycrawl/tools/checkstyle/XmlLoader.java
43: * scrupulous, set, severe, square, stern, stickler, straight, strait-laced,

src/xdocs/index.xml.vm
410:                <a href="https://stickler-ci.com/">Stickler CI</a>
414:                <a href="https://stickler-ci.com/docs#java">

src/xdocs/releasenotes.xml
5809:            doc: Add stickler-ci to the active tool list.
➜  checkstyle git:(remove-stickler) ✗ ag -Q "stickler"
src/main/java/com/puppycrawl/tools/checkstyle/XmlLoader.java
43: * scrupulous, set, severe, square, stern, stickler, straight, strait-laced,

src/xdocs/releasenotes.xml
5809:            doc: Add stickler-ci to the active tool list.
➜  checkstyle git:(remove-stickler) ✗ 
```