### PR TITLE
Issue #13321: Kill mutation for TagParser

### DIFF
--- a/config/pitest-suppressions/pitest-javadoc-suppressions.xml
+++ b/config/pitest-suppressions/pitest-javadoc-suppressions.xml
@@ -1023,23 +1023,23 @@
     <lineContent>text = text.substring(column).trim();</lineContent>
   </mutation>
 
-  <mutation unstable="false">
-    <sourceFile>TagParser.java</sourceFile>
-    <mutatedClass>com.puppycrawl.tools.checkstyle.checks.javadoc.TagParser</mutatedClass>
-    <mutatedMethod>getTagId</mutatedMethod>
-    <mutator>org.pitest.mutationtest.engine.gregor.mutators.NonVoidMethodCallMutator</mutator>
-    <description>removed call to java/lang/Character::isJavaIdentifierPart</description>
-    <lineContent>|| Character.isJavaIdentifierPart(text.charAt(position)))) {</lineContent>
-  </mutation>
 
-  <mutation unstable="false">
-    <sourceFile>TagParser.java</sourceFile>
-    <mutatedClass>com.puppycrawl.tools.checkstyle.checks.javadoc.TagParser</mutatedClass>
-    <mutatedMethod>getTagId</mutatedMethod>
-    <mutator>org.pitest.mutationtest.engine.gregor.mutators.RemoveConditionalMutator_EQUAL_ELSE</mutator>
-    <description>removed conditional - replaced equality check with false</description>
-    <lineContent>|| Character.isJavaIdentifierPart(text.charAt(position)))) {</lineContent>
-  </mutation>
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
 
   <mutation unstable="false">
     <sourceFile>TagParser.java</sourceFile>

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocStyleCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocStyleCheckTest.java
@@ -738,4 +738,15 @@ public class JavadocStyleCheckTest
         verifyWithInlineConfigParser(
                 getPath("InputJavadocStyleCheckOptionLowercaseProperty.java"), expected);
     }
+
+    @Test
+    public void testJavadocTag() throws Exception {
+        final String[] expected = {
+            "11: " + getCheckMessage(MSG_NO_PERIOD),
+            "15: " + getCheckMessage(MSG_NO_PERIOD),
+        };
+        verifyWithInlineConfigParser(
+                getPath("InputJavadocStyleDefault4.java"),
+                expected);
+    }
 }

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadocstyle/InputJavadocStyleDefault4.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadocstyle/InputJavadocStyleDefault4.java
@@ -1,0 +1,17 @@
+/*
+JavadocStyle
+
+
+*/
+
+package com.puppycrawl.tools.checkstyle.checks.javadoc.javadocstyle;
+
+public class InputJavadocStyleDefault4 {
+
+    /** <h1> Some header </h1> {@inheritDoc} {@code bar1} text*/
+    void bar2() {} // violation above 'First sentence should end with a period'
+
+
+    /**          <h1> Some header </h1> {@inheritDoc} {@code bar1} text       */
+    void bar3() {} // violation above 'First sentence should end with a period'
+}


### PR DESCRIPTION
Issue #13321: Kill mutation for TagParser

--------

# Mutations 
https://github.com/checkstyle/checkstyle/blob/8b7dac5792b450386651647e2c8a5fa84e1d7f97/config/pitest-suppressions/pitest-javadoc-suppressions.xml#L1026-L1042

---------

# Explaination
Test added