### PR TITLE
Issue #13321: Kill mutation for DetectorOption

### DIFF
--- a/config/checker-framework-suppressions/checker-nullness-optional-interning-suppressions.xml
+++ b/config/checker-framework-suppressions/checker-nullness-optional-interning-suppressions.xml
@@ -4392,7 +4392,7 @@
   <checkerFrameworkError unstable="false">
     <fileName>src/main/java/com/puppycrawl/tools/checkstyle/checks/regexp/DetectorOptions.java</fileName>
     <specifier>initialization.fields.uninitialized</specifier>
-    <message>the constructor does not initialize fields: reporter, format, suppressor, pattern</message>
+    <message>the constructor does not initialize fields: reporter, format, message, suppressor, pattern</message>
     <lineContent>private DetectorOptions() {</lineContent>
   </checkerFrameworkError>
 

--- a/config/pitest-suppressions/pitest-regexp-suppressions.xml
+++ b/config/pitest-suppressions/pitest-regexp-suppressions.xml
@@ -1,13 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <suppressedMutations>
-  <mutation unstable="false">
-    <sourceFile>DetectorOptions.java</sourceFile>
-    <mutatedClass>com.puppycrawl.tools.checkstyle.checks.regexp.DetectorOptions</mutatedClass>
-    <mutatedMethod>&lt;init&gt;</mutatedMethod>
-    <mutator>org.pitest.mutationtest.engine.gregor.mutators.experimental.MemberVariableMutator</mutator>
-    <description>Removed assignment to member variable message</description>
-    <lineContent>private String message = &quot;&quot;;</lineContent>
-  </mutation>
 
   <mutation unstable="false">
     <sourceFile>MultilineDetector.java</sourceFile>

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/regexp/DetectorOptions.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/regexp/DetectorOptions.java
@@ -41,7 +41,7 @@ public final class DetectorOptions {
      */
     private String format;
     /** The message to report on detection. If blank, then use the format. */
-    private String message = "";
+    private String message;
     /** Minimum number of times regular expression should occur in a file. */
     private int minimum;
     /** Maximum number of times regular expression should occur in a file. */

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/regexp/RegexpSinglelineCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/regexp/RegexpSinglelineCheckTest.java
@@ -135,4 +135,14 @@ public class RegexpSinglelineCheckTest extends AbstractModuleTestSupport {
         verifyWithInlineConfigParser(
                 getPath("InputRegexpSinglelineSemantic9.java"), EMPTY);
     }
+
+    @Test
+    public void testMessage() throws Exception {
+
+        final String[] expected = {
+            "17: " + getCheckMessage(MSG_REGEXP_EXCEEDED, "SYSTEM\\.(OUT)|(ERR)\\.PRINT(LN)?\\("),
+        };
+        verifyWithInlineConfigParser(
+                getPath("InputRegexpSinglelineSemantic10.java"), expected);
+    }
 }

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/regexp/regexpsingleline/InputRegexpSinglelineSemantic10.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/regexp/regexpsingleline/InputRegexpSinglelineSemantic10.java
@@ -1,0 +1,19 @@
+/*
+RegexpSingleline
+format = SYSTEM\\.(OUT)|(ERR)\\.PRINT(LN)?\\(
+message =
+ignoreCase = true
+minimum = (default)0
+maximum = (default)0
+fileExtensions = (default)all files
+
+
+*/
+
+package com.puppycrawl.tools.checkstyle.checks.regexp.regexpsingleline;
+
+public class InputRegexpSinglelineSemantic10 {
+    public static void main(String[] args) {
+        System.out.println("str"); // violation ''
+    }
+}


### PR DESCRIPTION
Issue #13321: Kill mutation for DetectorOption

-----

# Mutation 
https://github.com/checkstyle/checkstyle/blob/2335abaea101774a23d0bdaf55f19e4f0cad0d37/config/pitest-suppressions/pitest-regexp-suppressions.xml#L3-L10

-----

# Explaination

It is some inner class, and all fields already not initialized, so with such update we do implementation consistent.


All the time whenever we use this message field in check we use the build method and the build method is 
https://github.com/checkstyle/checkstyle/blob/2335abaea101774a23d0bdaf55f19e4f0cad0d37/src/main/java/com/puppycrawl/tools/checkstyle/checks/regexp/DetectorOptions.java#L246-L250

message is set like `message = Optional.ofNullable(message).orElse("");` so if the message is null then it will be `""` empty string so removal will not make issue

-----

# Regression :- 


-----

Diff Regression config: https://gist.githubusercontent.com/Kevin222004/af6965cd82853221b89f6ba3b81b996a/raw/89f2f0efe08703af1c3c9b9f3b5d2330a064dea3/RegexpSingleline.xml
Diff Regression projects: https://gist.githubusercontent.com/Kevin222004/9600f179b602d4c971bdb0a050099005/raw/360a95ed7bb60d7a0956e531199d484c4d6f6617/test-projects.properties
Report label: Regression-2
