### PR TITLE
Issue #13321: Kill mutation for SuppressWarningsHolder

### DIFF
--- a/config/pitest-suppressions/pitest-misc-suppressions.xml
+++ b/config/pitest-suppressions/pitest-misc-suppressions.xml
@@ -81,14 +81,6 @@
 
 
 
-  <mutation unstable="false">
-    <sourceFile>SuppressWarningsHolder.java</sourceFile>
-    <mutatedClass>com.puppycrawl.tools.checkstyle.checks.SuppressWarningsHolder</mutatedClass>
-    <mutatedMethod>addSuppressions</mutatedMethod>
-    <mutator>org.pitest.mutationtest.engine.gregor.mutators.NonVoidMethodCallMutator</mutator>
-    <description>removed call to com/puppycrawl/tools/checkstyle/api/DetailAST::getColumnNo</description>
-    <lineContent>final int firstColumn = targetAST.getColumnNo();</lineContent>
-  </mutation>
 
 
 

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/SuppressWarningsHolderTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/SuppressWarningsHolderTest.java
@@ -530,4 +530,17 @@ public class SuppressWarningsHolderTest extends AbstractModuleTestSupport {
                 getNonCompilablePath("InputSuppressWarningsHolder2.java"),
                 expected);
     }
+
+    @Test
+    public void test3() throws Exception {
+        final String pattern = "^[a-z][a-zA-Z0-9]*$";
+
+        final String[] expected = {
+            "18:16: " + getCheckMessage(MemberNameCheck.class,
+                    AbstractNameCheck.MSG_INVALID_PATTERN, "K", pattern),
+        };
+        verifyWithInlineConfigParser(
+                getPath("InputSuppressWarningsHolder8.java"),
+                expected);
+    }
 }

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/suppresswarningsholder/InputSuppressWarningsHolder8.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/suppresswarningsholder/InputSuppressWarningsHolder8.java
@@ -1,0 +1,20 @@
+/*
+com.puppycrawl.tools.checkstyle.checks.SuppressWarningsHolder
+aliasList = (default)
+
+com.puppycrawl.tools.checkstyle.filters.SuppressWarningsFilter
+
+com.puppycrawl.tools.checkstyle.checks.naming.MemberNameCheck
+format = ^[a-z][a-zA-Z0-9]*$
+
+
+*/
+
+package com.puppycrawl.tools.checkstyle.checks.suppresswarningsholder;
+
+public class InputSuppressWarningsHolder8 {
+
+   // violation below 'Name 'K' must match pattern'
+   private int K;   @SuppressWarnings("membername")
+   private int J; // violation suppressed
+}


### PR DESCRIPTION
Issue #13321: Kill mutation for SuppressWarningsHolder

-----

# Check :- 
https://checkstyle.org/checks/annotation/suppresswarningsholder.html#SuppressWarningsHolder

-----

# Mutation 
https://github.com/checkstyle/checkstyle/blob/834e5ed9177b81c6ef73e8bba967f131db2d2c74/config/pitest-suppressions/pitest-misc-suppressions.xml#L84-L91

-----

# Explaination
Test added
