### PR TITLE
Issue #13321: Kill mutation for BlockCommentPosition 2

### DIFF
--- a/config/pitest-suppressions/pitest-utils-suppressions.xml
+++ b/config/pitest-suppressions/pitest-utils-suppressions.xml
@@ -1,15 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <suppressedMutations>
   <mutation unstable="false">
-    <sourceFile>BlockCommentPosition.java</sourceFile>
-    <mutatedClass>com.puppycrawl.tools.checkstyle.utils.BlockCommentPosition</mutatedClass>
-    <mutatedMethod>isOnPlainClassMember</mutatedMethod>
-    <mutator>org.pitest.mutationtest.engine.gregor.mutators.RemoveConditionalMutator_EQUAL_IF</mutator>
-    <description>removed conditional - replaced equality check with true</description>
-    <lineContent>&amp;&amp; parent.getParent().getType() == memberType</lineContent>
-  </mutation>
-
-  <mutation unstable="false">
     <sourceFile>ModuleReflectionUtil.java</sourceFile>
     <mutatedClass>com.puppycrawl.tools.checkstyle.utils.ModuleReflectionUtil</mutatedClass>
     <mutatedMethod>getCheckstyleModules</mutatedMethod>

--- a/src/main/java/com/puppycrawl/tools/checkstyle/utils/BlockCommentPosition.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/utils/BlockCommentPosition.java
@@ -154,7 +154,7 @@ public final class BlockCommentPosition {
      * @return true if node is before method
      */
     public static boolean isOnMethod(DetailAST blockComment) {
-        return isOnPlainClassMember(blockComment, TokenTypes.METHOD_DEF)
+        return isOnPlainClassMember(blockComment)
                 || isOnTokenWithModifiers(blockComment, TokenTypes.METHOD_DEF)
                 || isOnTokenWithAnnotation(blockComment, TokenTypes.METHOD_DEF);
     }
@@ -166,7 +166,7 @@ public final class BlockCommentPosition {
      * @return true if node is before field
      */
     public static boolean isOnField(DetailAST blockComment) {
-        return isOnPlainClassMember(blockComment, TokenTypes.VARIABLE_DEF)
+        return isOnPlainClassMember(blockComment)
                 || isOnTokenWithModifiers(blockComment, TokenTypes.VARIABLE_DEF)
                     && blockComment.getParent().getParent().getParent()
                         .getType() == TokenTypes.OBJBLOCK
@@ -185,7 +185,7 @@ public final class BlockCommentPosition {
         return isOnPlainToken(blockComment, TokenTypes.CTOR_DEF, TokenTypes.IDENT)
                 || isOnTokenWithModifiers(blockComment, TokenTypes.CTOR_DEF)
                 || isOnTokenWithAnnotation(blockComment, TokenTypes.CTOR_DEF)
-                || isOnPlainClassMember(blockComment, TokenTypes.CTOR_DEF);
+                || isOnPlainClassMember(blockComment);
     }
 
     /**
@@ -230,7 +230,7 @@ public final class BlockCommentPosition {
      * @return true if node is before annotation field
      */
     public static boolean isOnAnnotationField(DetailAST blockComment) {
-        return isOnPlainClassMember(blockComment, TokenTypes.ANNOTATION_FIELD_DEF)
+        return isOnPlainClassMember(blockComment)
                 || isOnTokenWithModifiers(blockComment, TokenTypes.ANNOTATION_FIELD_DEF)
                 || isOnTokenWithAnnotation(blockComment, TokenTypes.ANNOTATION_FIELD_DEF);
     }
@@ -281,10 +281,9 @@ public final class BlockCommentPosition {
      * Checks that block comment is on specified class member without any modifiers.
      *
      * @param blockComment block comment start DetailAST
-     * @param memberType parent token type
      * @return true if block comment is on specified token without modifiers
      */
-    private static boolean isOnPlainClassMember(DetailAST blockComment, int memberType) {
+    private static boolean isOnPlainClassMember(DetailAST blockComment) {
         DetailAST parent = blockComment.getParent();
         // type could be in fully qualified form, so we go up to Type token
         while (parent.getType() == TokenTypes.DOT) {
@@ -292,7 +291,6 @@ public final class BlockCommentPosition {
         }
         return (parent.getType() == TokenTypes.TYPE
                     || parent.getType() == TokenTypes.TYPE_PARAMETERS)
-                && parent.getParent().getType() == memberType
                 // previous parent sibling is always TokenTypes.MODIFIERS
                 && !parent.getPreviousSibling().hasChildren()
                 && parent.getParent().getParent().getType() == TokenTypes.OBJBLOCK;

--- a/src/test/java/com/puppycrawl/tools/checkstyle/utils/BlockCommentPositionTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/utils/BlockCommentPositionTest.java
@@ -47,7 +47,7 @@ public class BlockCommentPositionTest extends AbstractModuleTestSupport {
     public void testJavaDocsRecognition() throws Exception {
         final List<BlockCommentPositionTestMetadata> metadataList = Arrays.asList(
                 new BlockCommentPositionTestMetadata("InputBlockCommentPositionOnClass.java",
-                        BlockCommentPosition::isOnClass, 3),
+                        BlockCommentPosition::isOnClass, 4),
                 new BlockCommentPositionTestMetadata("InputBlockCommentPositionOnMethod.java",
                         BlockCommentPosition::isOnMethod, 6),
                 new BlockCommentPositionTestMetadata("InputBlockCommentPositionOnField.java",

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/utils/blockcommentposition/InputBlockCommentPositionOnClass.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/utils/blockcommentposition/InputBlockCommentPositionOnClass.java
@@ -5,6 +5,13 @@ package com.puppycrawl.tools.checkstyle.utils.blockcommentposition;
  */
 public class InputBlockCommentPositionOnClass {
 
+    /**
+     * I'm a javadoc
+     */
+    public class InputBlockCommentPositionOnInnerClass {
+
+    }
+
 }
 
 /**


### PR DESCRIPTION
Issue #13321: Kill mutation for BlockCommentPosition 2

------

# Mutations 
https://github.com/checkstyle/checkstyle/blob/8804126fd3a4f58d5116712aaba939bcd2269b52/config/pitest-suppressions/pitest-utils-suppressions.xml#L21-L28

-----

# Explaination 


dependency tree on this method
```
BlockCommentPosition.isOnPlainClassMember
  +--isOnMethod
       +--ClassAndPropertiesSettersJavadocScraper
       +--BlockCommentPosition.isOnMember
            +--JavadocUtil.isCorrectJavadocPosition
                 +--InvalidJavadocPositionCheck
                 +--JavadocUtil.isJavadocComment
                      +--AstTreeStringPrinter
                      +--JavadocPropertiesGenerator
                      +--DesignForExtensionCheck
                      +--AbstractJavadocCheck
                           +-- all ast based javadoc checks
                      +--JavadocContentLocationCheck
                      +--MissingJavadocPackageCheck
  +--isOnField
     +-- isCorrectJavadocPosition ... same as above
  +--isOnConstructor
     +-- isCorrectJavadocPosition ... same as above
  +--isOnAnnotationField
     +-- isCorrectJavadocPosition ... same as above
```

so modules:
all ast based javadoc checks (MissingDeprecatedCheck, AtclauseOrderCheck, JavadocBlockTagLocationCheck, JavadocMissingLeadingAsteriskCheck, JavadocMissingWhitespaceAfterAsteriskCheck, JavadocParagraphCheck, JavadocTagContinuationIndentationCheck, NonEmptyAtclauseDescriptionCheck, RequireEmptyLineBeforeBlockTagGroupCheck, SingleLineJavadocCheck, SummaryJavadocCheck)
InvalidJavadocPositionCheck
DesignForExtensionCheck
MissingJavadocPackageCheck
JavadocContentLocationCheck

 we can reuse https://github.com/checkstyle/contribution/blob/master/checkstyle-tester/checks-only-javadoc-error.xml 

-------

# Regression 


-----



Diff Regression config: https://gist.githubusercontent.com/romani/c02d1cfd4005bdd25a4a1c9d0e5ec09c/raw/235d6dd039b9b3ee0c01afce35be1771af3ecb55/pull-13424-regression-config.xml
Diff Regression projects: https://gist.githubusercontent.com/Kevin222004/21e3934e85f802e2fbd48af06d122364/raw/604256badd733d8568064f371d55657c04b00dfd/test-projects-2.properties
Report label: Final-Report-2