### PR TITLE
Issue #13321: Kill mutation for CheckUtil

### DIFF
--- a/config/pitest-suppressions/pitest-utils-suppressions.xml
+++ b/config/pitest-suppressions/pitest-utils-suppressions.xml
@@ -72,14 +72,14 @@
     <lineContent>for (DetailAST token = node.getParent();</lineContent>
   </mutation>
 
-  <mutation unstable="false">
-    <sourceFile>CheckUtil.java</sourceFile>
-    <mutatedClass>com.puppycrawl.tools.checkstyle.utils.CheckUtil</mutatedClass>
-    <mutatedMethod>isElseWithCurlyBraces</mutatedMethod>
-    <mutator>org.pitest.mutationtest.engine.gregor.mutators.RemoveConditionalMutator_EQUAL_IF</mutator>
-    <description>removed conditional - replaced equality check with true</description>
-    <lineContent>return ast.getType() == TokenTypes.SLIST</lineContent>
-  </mutation>
+
+
+
+
+
+
+
+
 
   <mutation unstable="false">
     <sourceFile>CheckUtil.java</sourceFile>

--- a/src/main/java/com/puppycrawl/tools/checkstyle/utils/CheckUtil.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/utils/CheckUtil.java
@@ -143,8 +143,7 @@ public final class CheckUtil {
      * @return whether the toke does represent an SLIST as part of an ELSE
      */
     private static boolean isElseWithCurlyBraces(DetailAST ast) {
-        return ast.getType() == TokenTypes.SLIST
-            && ast.getChildCount() == 2
+        return ast.getChildCount() == 2
             && isElse(ast.getParent());
     }
 


### PR DESCRIPTION
Issue #13321: Kill mutation for CheckUtil

-----

# Mutation 
https://github.com/checkstyle/checkstyle/blob/f4a33f90bf8eda8ef2cdf7f66fd60878d2aa1736/config/pitest-suppressions/pitest-utils-suppressions.xml#L75-L82

-----

# Explaination

Usage of method in check :- https://checkstyle.org/checks/coding/nestedifdepth.html#NestedIfDepth

https://github.com/checkstyle/checkstyle/blob/f4a33f90bf8eda8ef2cdf7f66fd60878d2aa1736/src/main/java/com/puppycrawl/tools/checkstyle/utils/CheckUtil.java#L145-L149
This method is used by https://github.com/checkstyle/checkstyle/blob/f4a33f90bf8eda8ef2cdf7f66fd60878d2aa1736/src/main/java/com/puppycrawl/tools/checkstyle/utils/CheckUtil.java#L121-L126
this method is used by NestedIfDepthCheck and the parameter ast is always LiteralIf and in the mutated method the parameter passed is always parent of literalIF 
https://github.com/checkstyle/checkstyle/blob/f4a33f90bf8eda8ef2cdf7f66fd60878d2aa1736/src/main/java/com/puppycrawl/tools/checkstyle/utils/CheckUtil.java#L146
so here the ast is always the parent of LITERAL_IF token abd it will always be `TokenTypes.SLIST` whether it is used in method, constructor or in Switch cases

-----

# Regression :- 

-----

Diff Regression config: https://gist.githubusercontent.com/Kevin222004/b79c1d6f36c0d6db4516ff0aa57b8aee/raw/6e708ea645d0a75bfde0bd2baaff2adbf01730e0/NestedIf.xml
Diff Regression projects: https://gist.githubusercontent.com/Kevin222004/21e3934e85f802e2fbd48af06d122364/raw/604256badd733d8568064f371d55657c04b00dfd/test-projects-2.properties
Report label: Regression-1
