### PR TITLE
Issue #13321: Kill mutation for CheckUtil-2

### DIFF
--- a/config/checker-framework-suppressions/checker-index-suppressions.xml
+++ b/config/checker-framework-suppressions/checker-index-suppressions.xml
@@ -115,17 +115,6 @@
     <fileName>src/main/java/com/puppycrawl/tools/checkstyle/XMLLogger.java</fileName>
     <specifier>argument</specifier>
     <message>incompatible argument for parameter beginIndex of substring.</message>
-    <lineContent>final String name = ent.substring(1, ent.length() - 1);</lineContent>
-    <details>
-      found   : @UpperBoundLiteral(1) int
-      required: @LTEqLengthOf(&quot;ent&quot;) int
-    </details>
-  </checkerFrameworkError>
-
-  <checkerFrameworkError unstable="false">
-    <fileName>src/main/java/com/puppycrawl/tools/checkstyle/XMLLogger.java</fileName>
-    <specifier>argument</specifier>
-    <message>incompatible argument for parameter beginIndex of substring.</message>
     <lineContent>ent.substring(prefixLength, ent.length() - 1), radix);</lineContent>
     <details>
       found   : int
@@ -136,30 +125,8 @@
   <checkerFrameworkError unstable="false">
     <fileName>src/main/java/com/puppycrawl/tools/checkstyle/XMLLogger.java</fileName>
     <specifier>argument</specifier>
-    <message>incompatible argument for parameter endIndex of substring.</message>
-    <lineContent>ent.substring(prefixLength, ent.length() - 1), radix);</lineContent>
-    <details>
-      found   : @GTENegativeOne int
-      required: @NonNegative int
-    </details>
-  </checkerFrameworkError>
-
-  <checkerFrameworkError unstable="false">
-    <fileName>src/main/java/com/puppycrawl/tools/checkstyle/XMLLogger.java</fileName>
-    <specifier>argument</specifier>
-    <message>incompatible argument for parameter endIndex of substring.</message>
-    <lineContent>final String name = ent.substring(1, ent.length() - 1);</lineContent>
-    <details>
-      found   : @GTENegativeOne int
-      required: @NonNegative int
-    </details>
-  </checkerFrameworkError>
-
-  <checkerFrameworkError unstable="false">
-    <fileName>src/main/java/com/puppycrawl/tools/checkstyle/XMLLogger.java</fileName>
-    <specifier>argument</specifier>
     <message>incompatible argument for parameter index of charAt.</message>
-    <lineContent>if (ent.charAt(0) == &apos;&amp;&apos; &amp;&amp; CommonUtil.endsWithChar(ent, &apos;;&apos;)) {</lineContent>
+    <lineContent>if (ent.charAt(0) == &apos;&amp;&apos; &amp;&amp; ent.endsWith(&quot;;&quot;)) {</lineContent>
     <details>
       found   : @UpperBoundLiteral(0) int
       required: @LTLengthOf(&quot;ent&quot;) int
@@ -1095,28 +1062,6 @@
   <checkerFrameworkError unstable="false">
     <fileName>src/main/java/com/puppycrawl/tools/checkstyle/checks/imports/ImportOrderCheck.java</fileName>
     <specifier>argument</specifier>
-    <message>incompatible argument for parameter beginIndex of substring.</message>
-    <lineContent>pkg = pkg.substring(1, pkg.length() - 1);</lineContent>
-    <details>
-      found   : @UpperBoundLiteral(1) int
-      required: @LTEqLengthOf(&quot;pkg&quot;) int
-    </details>
-  </checkerFrameworkError>
-
-  <checkerFrameworkError unstable="false">
-    <fileName>src/main/java/com/puppycrawl/tools/checkstyle/checks/imports/ImportOrderCheck.java</fileName>
-    <specifier>argument</specifier>
-    <message>incompatible argument for parameter endIndex of substring.</message>
-    <lineContent>pkg = pkg.substring(1, pkg.length() - 1);</lineContent>
-    <details>
-      found   : @GTENegativeOne int
-      required: @NonNegative int
-    </details>
-  </checkerFrameworkError>
-
-  <checkerFrameworkError unstable="false">
-    <fileName>src/main/java/com/puppycrawl/tools/checkstyle/checks/imports/ImportOrderCheck.java</fileName>
-    <specifier>argument</specifier>
     <message>incompatible argument for parameter endIndex of substring.</message>
     <lineContent>return qualifiedImportName.substring(0, lastDotIndex);</lineContent>
     <details>
@@ -1420,28 +1365,6 @@
     <lineContent>return position != text.length() - 1 &amp;&amp; text.charAt(position + 1) == &apos;/&apos;;</lineContent>
     <details>
       found   : int
-      required: @NonNegative int
-    </details>
-  </checkerFrameworkError>
-
-  <checkerFrameworkError unstable="false">
-    <fileName>src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocMethodCheck.java</fileName>
-    <specifier>argument</specifier>
-    <message>incompatible argument for parameter beginIndex of substring.</message>
-    <lineContent>arg1.substring(1, arg1.length() - 1));</lineContent>
-    <details>
-      found   : @UpperBoundLiteral(1) int
-      required: @LTEqLengthOf(&quot;arg1&quot;) int
-    </details>
-  </checkerFrameworkError>
-
-  <checkerFrameworkError unstable="false">
-    <fileName>src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocMethodCheck.java</fileName>
-    <specifier>argument</specifier>
-    <message>incompatible argument for parameter endIndex of substring.</message>
-    <lineContent>arg1.substring(1, arg1.length() - 1));</lineContent>
-    <details>
-      found   : @GTENegativeOne int
       required: @NonNegative int
     </details>
   </checkerFrameworkError>
@@ -2712,17 +2635,6 @@
     <fileName>src/main/java/com/puppycrawl/tools/checkstyle/utils/CheckUtil.java</fileName>
     <specifier>argument</specifier>
     <message>incompatible argument for parameter beginIndex of substring.</message>
-    <lineContent>txt = txt.substring(1);</lineContent>
-    <details>
-      found   : @UpperBoundLiteral(1) int
-      required: @LTEqLengthOf(&quot;txt&quot;) int
-    </details>
-  </checkerFrameworkError>
-
-  <checkerFrameworkError unstable="false">
-    <fileName>src/main/java/com/puppycrawl/tools/checkstyle/utils/CheckUtil.java</fileName>
-    <specifier>argument</specifier>
-    <message>incompatible argument for parameter beginIndex of substring.</message>
     <lineContent>returnString = line.substring(indent, lastNonWhitespace);</lineContent>
     <details>
       found   : int
@@ -2745,21 +2657,21 @@
     <fileName>src/main/java/com/puppycrawl/tools/checkstyle/utils/CheckUtil.java</fileName>
     <specifier>argument</specifier>
     <message>incompatible argument for parameter endIndex of substring.</message>
-    <lineContent>txt = txt.substring(0, txt.length() - 1);</lineContent>
+    <lineContent>returnString = line.substring(indent, lastNonWhitespace);</lineContent>
     <details>
-      found   : @GTENegativeOne int
-      required: @NonNegative int
+      found   : int
+      required: @LTEqLengthOf(&quot;line&quot;) int
     </details>
   </checkerFrameworkError>
 
   <checkerFrameworkError unstable="false">
     <fileName>src/main/java/com/puppycrawl/tools/checkstyle/utils/CheckUtil.java</fileName>
     <specifier>argument</specifier>
-    <message>incompatible argument for parameter endIndex of substring.</message>
-    <lineContent>returnString = line.substring(indent, lastNonWhitespace);</lineContent>
+    <message>incompatible argument for parameter index of charAt.</message>
+    <lineContent>final boolean negative = txt.charAt(0) == &apos;-&apos;;</lineContent>
     <details>
-      found   : int
-      required: @LTEqLengthOf(&quot;line&quot;) int
+      found   : @UpperBoundLiteral(0) int
+      required: @LTLengthOf(&quot;txt&quot;) int
     </details>
   </checkerFrameworkError>
 

--- a/config/intellij-idea-inspections.xml
+++ b/config/intellij-idea-inspections.xml
@@ -4051,8 +4051,9 @@
   <!-- the only violation found is false-positive at AvoidEscapedUnicodeCharactersCheck -->
   <inspection_tool class="SingleCharAlternation" enabled="false" level="WARNING"
                    enabled_by_default="false"/>
-  <inspection_tool class="SingleCharacterStartsWith" enabled="true" level="ERROR"
-                   enabled_by_default="true"/>
+  <!-- See reason at https://github.com/checkstyle/checkstyle/pull/13427 -->
+  <inspection_tool class="SingleCharacterStartsWith" enabled="false" level="ERROR"
+                   enabled_by_default="false"/>
   <!-- we like single import for single class -->
   <inspection_tool class="SingleClassImport" enabled="false" level="ERROR"
                    enabled_by_default="false"/>

--- a/config/jsoref-spellchecker/whitelist.words
+++ b/config/jsoref-spellchecker/whitelist.words
@@ -1186,7 +1186,6 @@ sickboy
 Simplifiable
 simplifybooleanexpression
 simplifybooleanreturn
-simplifystartswith
 singleline
 singlelined
 singlelinejavadoc

--- a/config/pitest-suppressions/pitest-javadoc-suppressions.xml
+++ b/config/pitest-suppressions/pitest-javadoc-suppressions.xml
@@ -96,7 +96,7 @@
     <mutatedMethod>checkParamTags</mutatedMethod>
     <mutator>org.pitest.mutationtest.engine.gregor.mutators.RemoveConditionalMutator_EQUAL_IF</mutator>
     <description>removed conditional - replaced equality check with true</description>
-    <lineContent>if (CommonUtil.startsWithChar(arg1, &apos;&lt;&apos;) &amp;&amp; CommonUtil.endsWithChar(arg1, &apos;&gt;&apos;)) {</lineContent>
+    <lineContent>if (arg1.startsWith(ELEMENT_START) &amp;&amp; arg1.endsWith(ELEMENT_END)) {</lineContent>
   </mutation>
 
   <mutation unstable="false">

--- a/config/pitest-suppressions/pitest-utils-suppressions.xml
+++ b/config/pitest-suppressions/pitest-utils-suppressions.xml
@@ -162,14 +162,14 @@
 
 
 
-  <mutation unstable="false">
-    <sourceFile>CheckUtil.java</sourceFile>
-    <mutatedClass>com.puppycrawl.tools.checkstyle.utils.CheckUtil</mutatedClass>
-    <mutatedMethod>parseDouble</mutatedMethod>
-    <mutator>org.pitest.mutationtest.engine.gregor.mutators.experimental.NakedReceiverMutator</mutator>
-    <description>replaced call to java/lang/String::substring with receiver</description>
-    <lineContent>txt = txt.substring(1);</lineContent>
-  </mutation>
+
+
+
+
+
+
+
+
 
   <mutation unstable="false">
     <sourceFile>CodePointUtil.java</sourceFile>
@@ -258,7 +258,7 @@
     <mutatedMethod>matchesFileExtension</mutatedMethod>
     <mutator>org.pitest.mutationtest.engine.gregor.mutators.RemoveConditionalMutator_EQUAL_IF</mutator>
     <description>removed conditional - replaced equality check with true</description>
-    <lineContent>if (startsWithChar(extension, &apos;.&apos;)) {</lineContent>
+    <lineContent>if (extension.startsWith(EXTENSION_SEPARATOR)) {</lineContent>
   </mutation>
 
   <mutation unstable="false">

--- a/src/main/java/com/puppycrawl/tools/checkstyle/Checker.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/Checker.java
@@ -65,6 +65,9 @@ public class Checker extends AbstractAutomaticBean implements MessageDispatcher,
     /** Message to use when an exception occurs and should be printed as a violation. */
     public static final String EXCEPTION_MSG = "general.exception";
 
+    /** The extension separator. */
+    private static final String EXTENSION_SEPARATOR = ".";
+
     /** Logger for Checker. */
     private final Log log;
 
@@ -551,11 +554,11 @@ public class Checker extends AbstractAutomaticBean implements MessageDispatcher,
             fileExtensions = new String[extensions.length];
             for (int i = 0; i < extensions.length; i++) {
                 final String extension = extensions[i];
-                if (CommonUtil.startsWithChar(extension, '.')) {
+                if (extension.startsWith(EXTENSION_SEPARATOR)) {
                     fileExtensions[i] = extension;
                 }
                 else {
-                    fileExtensions[i] = "." + extension;
+                    fileExtensions[i] = EXTENSION_SEPARATOR + extension;
                 }
             }
         }

--- a/src/main/java/com/puppycrawl/tools/checkstyle/PackageNamesLoader.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/PackageNamesLoader.java
@@ -40,7 +40,6 @@ import org.xml.sax.InputSource;
 import org.xml.sax.SAXException;
 
 import com.puppycrawl.tools.checkstyle.api.CheckstyleException;
-import com.puppycrawl.tools.checkstyle.utils.CommonUtil;
 
 /**
  * Loads a list of package names from a package name XML file.
@@ -110,7 +109,7 @@ public final class PackageNamesLoader
         while (iterator.hasNext()) {
             final String subPackage = iterator.next();
             buf.append(subPackage);
-            if (!CommonUtil.endsWithChar(subPackage, '.') && iterator.hasNext()) {
+            if (!subPackage.endsWith(".") && iterator.hasNext()) {
                 buf.append('.');
             }
         }

--- a/src/main/java/com/puppycrawl/tools/checkstyle/XMLLogger.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/XMLLogger.java
@@ -34,7 +34,6 @@ import com.puppycrawl.tools.checkstyle.api.AuditEvent;
 import com.puppycrawl.tools.checkstyle.api.AuditListener;
 import com.puppycrawl.tools.checkstyle.api.AutomaticBean;
 import com.puppycrawl.tools.checkstyle.api.SeverityLevel;
-import com.puppycrawl.tools.checkstyle.utils.CommonUtil;
 
 /**
  * Simple XML logger.
@@ -313,7 +312,7 @@ public class XMLLogger
     public static boolean isReference(String ent) {
         boolean reference = false;
 
-        if (ent.charAt(0) == '&' && CommonUtil.endsWithChar(ent, ';')) {
+        if (ent.charAt(0) == '&' && ent.endsWith(";")) {
             if (ent.charAt(1) == '#') {
                 // prefix is "&#"
                 int prefixLength = 2;

--- a/src/main/java/com/puppycrawl/tools/checkstyle/api/AbstractFileSetCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/api/AbstractFileSetCheck.java
@@ -38,6 +38,9 @@ public abstract class AbstractFileSetCheck
     extends AbstractViolationReporter
     implements FileSetCheck {
 
+    /** The extension separator. */
+    private static final String EXTENSION_SEPARATOR = ".";
+
     /**
      * The check context.
      *
@@ -174,11 +177,11 @@ public abstract class AbstractFileSetCheck
         fileExtensions = new String[extensions.length];
         for (int i = 0; i < extensions.length; i++) {
             final String extension = extensions[i];
-            if (CommonUtil.startsWithChar(extension, '.')) {
+            if (extension.startsWith(EXTENSION_SEPARATOR)) {
                 fileExtensions[i] = extension;
             }
             else {
-                fileExtensions[i] = "." + extension;
+                fileExtensions[i] = EXTENSION_SEPARATOR + extension;
             }
         }
     }

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/UpperEllCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/UpperEllCheck.java
@@ -23,7 +23,6 @@ import com.puppycrawl.tools.checkstyle.StatelessCheck;
 import com.puppycrawl.tools.checkstyle.api.AbstractCheck;
 import com.puppycrawl.tools.checkstyle.api.DetailAST;
 import com.puppycrawl.tools.checkstyle.api.TokenTypes;
-import com.puppycrawl.tools.checkstyle.utils.CommonUtil;
 
 /**
  * <p>
@@ -88,7 +87,7 @@ public class UpperEllCheck extends AbstractCheck {
 
     @Override
     public void visitToken(DetailAST ast) {
-        if (CommonUtil.endsWithChar(ast.getText(), 'l')) {
+        if (ast.getText().endsWith("l")) {
             log(ast, MSG_KEY);
         }
     }

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/imports/ImportOrderCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/imports/ImportOrderCheck.java
@@ -28,7 +28,6 @@ import com.puppycrawl.tools.checkstyle.api.AbstractCheck;
 import com.puppycrawl.tools.checkstyle.api.DetailAST;
 import com.puppycrawl.tools.checkstyle.api.FullIdent;
 import com.puppycrawl.tools.checkstyle.api.TokenTypes;
-import com.puppycrawl.tools.checkstyle.utils.CommonUtil;
 
 /**
  * <p>
@@ -573,6 +572,9 @@ public class ImportOrderCheck
 
     /** The special wildcard that catches all remaining groups. */
     private static final String WILDCARD_GROUP_NAME = "*";
+
+    /** The Forward slash. */
+    private static final String FORWARD_SLASH = "/";
 
     /** Empty array of pattern type needed to initialize check. */
     private static final Pattern[] EMPTY_PATTERN_ARRAY = new Pattern[0];
@@ -1144,7 +1146,6 @@ public class ImportOrderCheck
      */
     private static Pattern[] compilePatterns(String... packageGroups) {
         final Pattern[] patterns = new Pattern[packageGroups.length];
-
         for (int i = 0; i < packageGroups.length; i++) {
             String pkg = packageGroups[i];
             final Pattern grp;
@@ -1155,8 +1156,8 @@ public class ImportOrderCheck
                 // matches any package
                 grp = Pattern.compile("");
             }
-            else if (CommonUtil.startsWithChar(pkg, '/')) {
-                if (!CommonUtil.endsWithChar(pkg, '/')) {
+            else if (pkg.startsWith(FORWARD_SLASH)) {
+                if (!pkg.endsWith(FORWARD_SLASH)) {
                     throw new IllegalArgumentException("Invalid group: " + pkg);
                 }
                 pkg = pkg.substring(1, pkg.length() - 1);
@@ -1164,7 +1165,7 @@ public class ImportOrderCheck
             }
             else {
                 final StringBuilder pkgBuilder = new StringBuilder(pkg);
-                if (!CommonUtil.endsWithChar(pkg, '.')) {
+                if (!pkg.endsWith(".")) {
                     pkgBuilder.append('.');
                 }
                 grp = Pattern.compile("^" + Pattern.quote(pkgBuilder.toString()));

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocMethodCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocMethodCheck.java
@@ -554,6 +554,12 @@ public class JavadocMethodCheck extends AbstractCheck {
      */
     public static final String MSG_DUPLICATE_TAG = "javadoc.duplicateTag";
 
+    /** Html element start symbol. */
+    private static final String ELEMENT_START = "<";
+
+    /** Html element end symbol. */
+    private static final String ELEMENT_END = ">";
+
     /** Compiled regexp to match Javadoc tags that take an argument. */
     private static final Pattern MATCH_JAVADOC_ARG = CommonUtil.createPattern(
             "^\\s*(?>\\*|\\/\\*\\*)?\\s*@(throws|exception|param)\\s+(\\S+)\\s+\\S*");
@@ -1114,7 +1120,7 @@ public class JavadocMethodCheck extends AbstractCheck {
             final String arg1 = tag.getFirstArg();
             boolean found = removeMatchingParam(params, arg1);
 
-            if (CommonUtil.startsWithChar(arg1, '<') && CommonUtil.endsWithChar(arg1, '>')) {
+            if (arg1.startsWith(ELEMENT_START) && arg1.endsWith(ELEMENT_END)) {
                 found = searchMatchingTypeParameter(typeParams,
                         arg1.substring(1, arg1.length() - 1));
             }
@@ -1137,8 +1143,8 @@ public class JavadocMethodCheck extends AbstractCheck {
             for (DetailAST typeParam : typeParams) {
                 log(typeParam, MSG_EXPECTED_TAG,
                     JavadocTagInfo.PARAM.getText(),
-                    "<" + typeParam.findFirstToken(TokenTypes.IDENT).getText()
-                    + ">");
+                    ELEMENT_START + typeParam.findFirstToken(TokenTypes.IDENT).getText()
+                    + ELEMENT_END);
             }
         }
     }

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocParagraphCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocParagraphCheck.java
@@ -324,7 +324,7 @@ public class JavadocParagraphCheck extends AbstractJavadocCheck {
         final DetailNode nextSibling = JavadocUtil.getNextSibling(tag);
         return nextSibling.getType() == JavadocTokenTypes.NEWLINE
                 || nextSibling.getType() == JavadocTokenTypes.EOF
-                || CommonUtil.startsWithChar(nextSibling.getText(), ' ');
+                || nextSibling.getText().startsWith(" ");
     }
 
 }

--- a/src/main/java/com/puppycrawl/tools/checkstyle/utils/CheckUtil.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/utils/CheckUtil.java
@@ -140,9 +140,8 @@ public final class CheckUtil {
                     radix = BASE_2;
                     txt = txt.substring(2);
                 }
-                else if (CommonUtil.startsWithChar(txt, '0')) {
+                else if (txt.startsWith("0")) {
                     radix = BASE_8;
-                    txt = txt.substring(1);
                 }
                 result = parseNumber(txt, radix, type);
                 break;
@@ -167,32 +166,29 @@ public final class CheckUtil {
      */
     private static double parseNumber(final String text, final int radix, final int type) {
         String txt = text;
-        if (CommonUtil.endsWithChar(txt, 'L') || CommonUtil.endsWithChar(txt, 'l')) {
+        if (txt.endsWith("L") || txt.endsWith("l")) {
             txt = txt.substring(0, txt.length() - 1);
         }
         final double result;
-        if (txt.isEmpty()) {
-            result = 0.0;
-        }
-        else {
-            final boolean negative = txt.charAt(0) == '-';
-            if (type == TokenTypes.NUM_INT) {
-                if (negative) {
-                    result = Integer.parseInt(txt, radix);
-                }
-                else {
-                    result = Integer.parseUnsignedInt(txt, radix);
-                }
+
+        final boolean negative = txt.charAt(0) == '-';
+        if (type == TokenTypes.NUM_INT) {
+            if (negative) {
+                result = Integer.parseInt(txt, radix);
             }
             else {
-                if (negative) {
-                    result = Long.parseLong(txt, radix);
-                }
-                else {
-                    result = Long.parseUnsignedLong(txt, radix);
-                }
+                result = Integer.parseUnsignedInt(txt, radix);
             }
         }
+        else {
+            if (negative) {
+                result = Long.parseLong(txt, radix);
+            }
+            else {
+                result = Long.parseUnsignedLong(txt, radix);
+            }
+        }
+
         return result;
     }
 

--- a/src/main/java/com/puppycrawl/tools/checkstyle/utils/CommonUtil.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/utils/CommonUtil.java
@@ -67,6 +67,9 @@ public final class CommonUtil {
     /** Prefix for the exception when unable to find resource. */
     private static final String UNABLE_TO_FIND_EXCEPTION_PREFIX = "Unable to find: ";
 
+    /** The extension separator. */
+    private static final String EXTENSION_SEPARATOR = ".";
+
     /** Stop instances being created. **/
     private CommonUtil() {
     }
@@ -124,11 +127,11 @@ public final class CommonUtil {
             final String[] withDotExtensions = new String[fileExtensions.length];
             for (int i = 0; i < fileExtensions.length; i++) {
                 final String extension = fileExtensions[i];
-                if (startsWithChar(extension, '.')) {
+                if (extension.startsWith(EXTENSION_SEPARATOR)) {
                     withDotExtensions[i] = extension;
                 }
                 else {
-                    withDotExtensions[i] = "." + extension;
+                    withDotExtensions[i] = EXTENSION_SEPARATOR + extension;
                 }
             }
 
@@ -270,48 +273,6 @@ public final class CommonUtil {
             resultPath = pathBase.relativize(pathAbsolute).toString();
         }
         return resultPath;
-    }
-
-    /**
-     * Tests if this string starts with the specified prefix.
-     * <p>
-     * It is faster version of {@link String#startsWith(String)} optimized for
-     *  one-character prefixes at the expense of
-     * some readability. Suggested by
-     * <a href="https://docs.pmd-code.org/latest/pmd_rules_java_performance.html#simplifystartswith">
-     * SimplifyStartsWith</a> PMD rule:
-     * </p>
-     *
-     * @param value
-     *            the {@code String} to check
-     * @param prefix
-     *            the prefix to find
-     * @return {@code true} if the {@code char} is a prefix of the given {@code String};
-     *     {@code false} otherwise.
-     */
-    public static boolean startsWithChar(String value, char prefix) {
-        return !value.isEmpty() && value.charAt(0) == prefix;
-    }
-
-    /**
-     * Tests if this string ends with the specified suffix.
-     * <p>
-     * It is faster version of {@link String#endsWith(String)} optimized for
-     *  one-character suffixes at the expense of
-     * some readability. Suggested by
-     * <a href="https://docs.pmd-code.org/latest/pmd_rules_java_performance.html#simplifystartswith">
-     * SimplifyStartsWith</a> PMD rule:
-     * </p>
-     *
-     * @param value
-     *            the {@code String} to check
-     * @param suffix
-     *            the suffix to find
-     * @return {@code true} if the {@code char} is a suffix of the given {@code String};
-     *     {@code false} otherwise.
-     */
-    public static boolean endsWithChar(String value, char suffix) {
-        return !value.isEmpty() && value.charAt(value.length() - 1) == suffix;
     }
 
     /**


### PR DESCRIPTION
Issue #13321: Kill mutation for CheckUtil-2

-----

# Mutation 
https://github.com/checkstyle/checkstyle/blob/f4a33f90bf8eda8ef2cdf7f66fd60878d2aa1736/config/pitest-suppressions/pitest-utils-suppressions.xml#L165-L172

-----

# Explaination

0 will not make any issue while converting octal to decimal

-----

# Regression :- 

Report-1 :- https://checkstyle-diff-reports.s3.us-east-2.amazonaws.com/6e8fbb4_2023210658/reports/diff/index.html

Report-2 :- https://checkstyle-diff-reports.s3.us-east-2.amazonaws.com/7e63cf9_2023061818/reports/diff/index.html

-----

Diff Regression config: https://gist.githubusercontent.com/Kevin222004/22c763808f0888ecec916bbd916d9893/raw/1e441345ad27f5e0e07214cfd84b8c7c9d8f3d84/parseDouble.xml
Diff Regression projects: https://gist.githubusercontent.com/Kevin222004/9600f179b602d4c971bdb0a050099005/raw/360a95ed7bb60d7a0956e531199d484c4d6f6617/test-projects.properties
Report label: Regression-2
