### PR TITLE
Issue #13321: Kill mutation for CheckUtil-7

### DIFF
--- a/config/pitest-suppressions/pitest-utils-suppressions.xml
+++ b/config/pitest-suppressions/pitest-utils-suppressions.xml
@@ -117,14 +117,14 @@
     <lineContent>if (slist != null &amp;&amp; slist.getChildCount() == GETTER_BODY_SIZE) {</lineContent>
   </mutation>
 
-  <mutation unstable="false">
-    <sourceFile>CheckUtil.java</sourceFile>
-    <mutatedClass>com.puppycrawl.tools.checkstyle.utils.CheckUtil</mutatedClass>
-    <mutatedMethod>isReceiverParameter</mutatedMethod>
-    <mutator>org.pitest.mutationtest.engine.gregor.mutators.RemoveConditionalMutator_EQUAL_IF</mutator>
-    <description>removed conditional - replaced equality check with true</description>
-    <lineContent>return parameterDefAst.getType() == TokenTypes.PARAMETER_DEF</lineContent>
-  </mutation>
+
+
+
+
+
+
+
+
 
 
 

--- a/pom.xml
+++ b/pom.xml
@@ -4906,6 +4906,9 @@
                 <param>
                   com.puppycrawl.tools.checkstyle.xpath.ElementNodeTest
                 </param>
+                <param>
+                  com.puppycrawl.tools.checkstyle.checks.FinalParametersCheckTest
+                </param>
               </targetTests>
               <excludedTestClasses>
                 <param>*.Input*</param>

--- a/src/main/java/com/puppycrawl/tools/checkstyle/api/TokenTypes.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/api/TokenTypes.java
@@ -712,7 +712,7 @@ public final class TokenTypes {
      * after the TYPE child).
      * <p>For example</p>
      * <pre>
-     *      void foo(int firstParameter, int... secondParameter) {}
+     *      void foo(SomeType SomeType.this, int firstParameter, int... secondParameter) {}
      * </pre>
      * <p>parses as:</p>
      * <pre>
@@ -726,6 +726,14 @@ public final class TokenTypes {
      *  |   |--PARAMETER_DEF -&gt; PARAMETER_DEF
      *  |   |   |--MODIFIERS -&gt; MODIFIERS
      *  |   |   |--TYPE -&gt; TYPE
+     *  |   |   |   `--IDENT -&gt; SomeType
+     *  |   |   `--DOT -&gt; .
+     *  |   |       |--IDENT -&gt; SomeType
+     *  |   |       `--LITERAL_THIS -&gt; this
+     *  |   |--COMMA -&gt; ,
+     *  |   |--PARAMETER_DEF -&gt; PARAMETER_DEF
+     *  |   |   |--MODIFIERS -&gt; MODIFIERS
+     *  |   |   |--TYPE -&gt; TYPE
      *  |   |   |   `--LITERAL_INT -&gt; int
      *  |   |   `--IDENT -&gt; firstParameter
      *  |   |--COMMA -&gt; ,
@@ -736,8 +744,9 @@ public final class TokenTypes {
      *  |       |--ELLIPSIS -&gt; ...
      *  |       `--IDENT -&gt; secondParameter
      *  |--RPAREN -&gt; )
-     *      `--SLIST -&gt; {
-     *          `--RCURLY -&gt; }
+     *  `--SLIST -&gt; {
+     *      `--RCURLY -&gt; }
+     *
      * </pre>
      *
      * @see #MODIFIERS

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/ParameterAssignmentCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/ParameterAssignmentCheck.java
@@ -256,8 +256,7 @@ public final class ParameterAssignmentCheck extends AbstractCheck {
             parametersAst.findFirstToken(TokenTypes.PARAMETER_DEF);
 
         while (parameterDefAST != null) {
-            if (parameterDefAST.getType() == TokenTypes.PARAMETER_DEF
-                    && !CheckUtil.isReceiverParameter(parameterDefAST)) {
+            if (!CheckUtil.isReceiverParameter(parameterDefAST)) {
                 final DetailAST param =
                     parameterDefAST.findFirstToken(TokenTypes.IDENT);
                 parameterNames.add(param.getText());

--- a/src/main/java/com/puppycrawl/tools/checkstyle/utils/CheckUtil.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/utils/CheckUtil.java
@@ -380,12 +380,21 @@ public final class CheckUtil {
     /**
      * Checks whether a parameter is a receiver.
      *
+     * <p>A receiver parameter is a special parameter that
+     * represents the object for which the method is invoked.
+     * It is denoted by the reserved keyword {@code this}
+     * in the method declaration. Check
+     * <a href="https://checkstyle.org/apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#PARAMETER_DEF">
+     * PARAMETER_DEF</a>
+     * </p>
+     *
      * @param parameterDefAst the parameter node.
      * @return true if the parameter is a receiver.
+     * @see <a href="https://docs.oracle.com/javase/specs/jls/se8/html/jls-8.html#jls-8.4.1">
+     *     ReceiverParameter</a>
      */
     public static boolean isReceiverParameter(DetailAST parameterDefAst) {
-        return parameterDefAst.getType() == TokenTypes.PARAMETER_DEF
-                && parameterDefAst.findFirstToken(TokenTypes.IDENT) == null;
+        return parameterDefAst.findFirstToken(TokenTypes.IDENT) == null;
     }
 
     /**

--- a/src/test/java/com/puppycrawl/tools/checkstyle/utils/CheckUtilTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/utils/CheckUtilTest.java
@@ -301,24 +301,6 @@ public class CheckUtilTest extends AbstractModuleTestSupport {
     }
 
     @Test
-    public void testIsReceiverParameter() throws Exception {
-        final DetailAST objBlock = getNodeFromFile(TokenTypes.OBJBLOCK);
-        final DetailAST methodWithReceiverParameter = objBlock.getLastChild().getPreviousSibling()
-                .getPreviousSibling();
-        final DetailAST receiverParameter =
-                getNode(methodWithReceiverParameter, TokenTypes.PARAMETER_DEF);
-        final DetailAST simpleParameter =
-                receiverParameter.getNextSibling().getNextSibling();
-
-        assertWithMessage("Invalid result: parameter provided is receiver parameter")
-                .that(CheckUtil.isReceiverParameter(receiverParameter))
-                .isTrue();
-        assertWithMessage("Invalid result: parameter provided is not receiver parameter")
-                .that(CheckUtil.isReceiverParameter(simpleParameter))
-                .isFalse();
-    }
-
-    @Test
     public void testParseDoubleFloatingPointValues() {
         assertWithMessage("Invalid parse result")
             .that(CheckUtil.parseDouble("-0.05f", TokenTypes.NUM_FLOAT))


### PR DESCRIPTION
Issue #13321: Kill mutation for CheckUtil-7

https://checkstyle.sourceforge.io/apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#PARAMETER_DEF

AST:
```
|--PARAMETERS -> PARAMETERS
  |   |--PARAMETER_DEF -> PARAMETER_DEF
  |   |   |--MODIFIERS -> MODIFIERS
  |   |   |--TYPE -> TYPE
  |   |   |   `--LITERAL_INT -> int
  |   |   `--IDENT -> firstParameter
```

-----

# Mutation 
  https://github.com/checkstyle/checkstyle/blob/f4a33f90bf8eda8ef2cdf7f66fd60878d2aa1736/config/pitest-suppressions/pitest-utils-suppressions.xml#L120-L127



-----

# Explaination

https://github.com/checkstyle/checkstyle/blob/a174e6e47fdc1e6e11f7c5a9688a481a5274df6c/src/main/java/com/puppycrawl/tools/checkstyle/utils/CheckUtil.java#L388-L391
when `this` is reciever parameter https://docs.oracle.com/javase/specs/jls/se8/html/jls-8.html#jls-8.4.1 
`public void foo4(InputAbbreviationAsWordInNameReceiver this) {}`

ast 
```
    |--METHOD_DEF -> METHOD_DEF [19:2]
    |   |--MODIFIERS -> MODIFIERS [19:2]
    |   |   `--LITERAL_PUBLIC -> public [19:2]
    |   |--TYPE -> TYPE [19:9]
    |   |   `--LITERAL_VOID -> void [19:9]
    |   |--IDENT -> foo4 [19:14]
    |   |--LPAREN -> ( [19:18]
    |   |--PARAMETERS -> PARAMETERS [19:19]
    |   |   `--PARAMETER_DEF -> PARAMETER_DEF [19:19]
    |   |       |--MODIFIERS -> MODIFIERS [19:19]
    |   |       |--TYPE -> TYPE [19:19]
    |   |       |   `--IDENT -> InputAbbreviationAsWordInNameReceiver [19:19]
    |   |       `--LITERAL_THIS -> this [19:57]
    |   |--RPAREN -> ) [19:61]
    |   `--SLIST -> { [19:63]
    |       `--RCURLY -> } [19:64]

```

ident will null only when the case is ast is receiver param

-----

# Regression :- 

Report-1 :- https://checkstyle-diff-reports.s3.us-east-2.amazonaws.com/6f76921_2023181801/reports/diff/index.html

Report-2 :-  https://checkstyle-diff-reports.s3.us-east-2.amazonaws.com/6f76921_2023233157/reports/diff/index.html

Report-3 :- https://checkstyle-diff-reports.s3.us-east-2.amazonaws.com/6f76921_2023210146/reports/diff/index.html

Report-4 :- https://checkstyle-diff-reports.s3.us-east-2.amazonaws.com/6f76921_2023222728/reports/diff/index.html


-----

Diff Regression config: https://gist.githubusercontent.com/Kevin222004/fa5563d3e1a37b3473cf29839166d996/raw/a95f67dafc408c49e69984caf70bf757fd707875/cu2.xml
Diff Regression projects: https://gist.githubusercontent.com/Kevin222004/9600f179b602d4c971bdb0a050099005/raw/360a95ed7bb60d7a0956e531199d484c4d6f6617/test-projects.properties
Report label: Regression-4