### PR TITLE
Issue #13421: Add since in javadoc of each property setter for annotation checks

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/annotation/AnnotationLocationCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/annotation/AnnotationLocationCheck.java
@@ -260,6 +260,7 @@ public class AnnotationLocationCheck extends AbstractCheck {
      * target element.
      *
      * @param allow User's value of allowSamelineSingleParameterlessAnnotation.
+     * @since 6.1
      */
     public final void setAllowSamelineSingleParameterlessAnnotation(boolean allow) {
         allowSamelineSingleParameterlessAnnotation = allow;
@@ -270,6 +271,7 @@ public class AnnotationLocationCheck extends AbstractCheck {
      * target element.
      *
      * @param allow User's value of allowSamelineParameterizedAnnotation.
+     * @since 6.4
      */
     public final void setAllowSamelineParameterizedAnnotation(boolean allow) {
         allowSamelineParameterizedAnnotation = allow;
@@ -280,6 +282,7 @@ public class AnnotationLocationCheck extends AbstractCheck {
      * target element.
      *
      * @param allow User's value of allowSamelineMultipleAnnotations.
+     * @since 6.0
      */
     public final void setAllowSamelineMultipleAnnotations(boolean allow) {
         allowSamelineMultipleAnnotations = allow;

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/annotation/AnnotationUseStyleCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/annotation/AnnotationUseStyleCheck.java
@@ -414,6 +414,7 @@ public final class AnnotationUseStyleCheck extends AbstractCheck {
      * Setter to define the annotation element styles.
      *
      * @param style string representation
+     * @since 5.0
      */
     public void setElementStyle(final String style) {
         elementStyle = getOption(ElementStyleOption.class, style);
@@ -423,6 +424,7 @@ public final class AnnotationUseStyleCheck extends AbstractCheck {
      * Setter to define the policy for trailing comma in arrays.
      *
      * @param comma string representation
+     * @since 5.0
      */
     public void setTrailingArrayComma(final String comma) {
         trailingArrayComma = getOption(TrailingArrayCommaOption.class, comma);
@@ -432,6 +434,7 @@ public final class AnnotationUseStyleCheck extends AbstractCheck {
      * Setter to define the policy for ending parenthesis.
      *
      * @param parens string representation
+     * @since 5.0
      */
     public void setClosingParens(final String parens) {
         closingParens = getOption(ClosingParensOption.class, parens);

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/annotation/MissingOverrideCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/annotation/MissingOverrideCheck.java
@@ -197,6 +197,7 @@ public final class MissingOverrideCheck extends AbstractCheck {
      * Setter to enable java 5 compatibility mode.
      *
      * @param compatibility compatibility or not
+     * @since 5.0
      */
     public void setJavaFiveCompatibility(final boolean compatibility) {
         javaFiveCompatibility = compatibility;

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/annotation/SuppressWarningsCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/annotation/SuppressWarningsCheck.java
@@ -218,6 +218,7 @@ public class SuppressWarningsCheck extends AbstractCheck {
      * being suppressed matching this pattern will be flagged.
      *
      * @param pattern the new pattern
+     * @since 5.0
      */
     public final void setFormat(Pattern pattern) {
         format = pattern;


### PR DESCRIPTION
Part of #13421 

---
Adds `@since` to each property setter.

Taken from https://checkstyle.sourceforge.io/checks/annotation/index.html