### PR TITLE
Issue #13421: Add since in javadoc of each property setter for block checks

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/blocks/AvoidNestedBlocksCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/blocks/AvoidNestedBlocksCheck.java
@@ -197,6 +197,7 @@ public class AvoidNestedBlocksCheck extends AbstractCheck {
      *
      * @param allowInSwitchCase whether nested blocks are allowed
      *                 if they are the only child of a switch case.
+     * @since 3.2
      */
     public void setAllowInSwitchCase(boolean allowInSwitchCase) {
         this.allowInSwitchCase = allowInSwitchCase;

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/blocks/EmptyBlockCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/blocks/EmptyBlockCheck.java
@@ -196,6 +196,7 @@ public class EmptyBlockCheck
      *
      * @param optionStr string to decode option from
      * @throws IllegalArgumentException if unable to decode
+     * @since 3.0
      */
     public void setOption(String optionStr) {
         option = BlockOption.valueOf(optionStr.trim().toUpperCase(Locale.ENGLISH));

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/blocks/EmptyCatchBlockCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/blocks/EmptyCatchBlockCheck.java
@@ -257,6 +257,7 @@ public class EmptyCatchBlockCheck extends AbstractCheck {
      *
      * @param exceptionVariablePattern
      *        pattern of exception's variable name.
+     * @since 6.4
      */
     public void setExceptionVariableName(Pattern exceptionVariablePattern) {
         exceptionVariableName = exceptionVariablePattern;
@@ -269,6 +270,7 @@ public class EmptyCatchBlockCheck extends AbstractCheck {
      *
      * @param commentPattern
      *        pattern of comment.
+     * @since 6.4
      */
     public void setCommentFormat(Pattern commentPattern) {
         commentFormat = commentPattern;

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/blocks/LeftCurlyCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/blocks/LeftCurlyCheck.java
@@ -260,6 +260,7 @@ public class LeftCurlyCheck
      *
      * @param optionStr string to decode option from
      * @throws IllegalArgumentException if unable to decode
+     * @since 3.0
      */
     public void setOption(String optionStr) {
         option = LeftCurlyOption.valueOf(optionStr.trim().toUpperCase(Locale.ENGLISH));
@@ -269,6 +270,7 @@ public class LeftCurlyCheck
      * Setter to allow to ignore enums when left curly brace policy is EOL.
      *
      * @param ignoreEnums check's option for ignoring enums.
+     * @since 6.9
      */
     public void setIgnoreEnums(boolean ignoreEnums) {
         this.ignoreEnums = ignoreEnums;

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/blocks/NeedBracesCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/blocks/NeedBracesCheck.java
@@ -284,6 +284,7 @@ public class NeedBracesCheck extends AbstractCheck {
      * Setter to allow single-line statements without braces.
      *
      * @param allowSingleLineStatement Check's option for skipping single-line statements
+     * @since 6.5
      */
     public void setAllowSingleLineStatement(boolean allowSingleLineStatement) {
         this.allowSingleLineStatement = allowSingleLineStatement;
@@ -293,6 +294,7 @@ public class NeedBracesCheck extends AbstractCheck {
      * Setter to allow loops with empty bodies.
      *
      * @param allowEmptyLoopBody Check's option for allowing loops with empty body.
+     * @since 6.12.1
      */
     public void setAllowEmptyLoopBody(boolean allowEmptyLoopBody) {
         this.allowEmptyLoopBody = allowEmptyLoopBody;

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/blocks/RightCurlyCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/blocks/RightCurlyCheck.java
@@ -333,6 +333,7 @@ public class RightCurlyCheck extends AbstractCheck {
      *
      * @param optionStr string to decode option from
      * @throws IllegalArgumentException if unable to decode
+     * @since 3.0
      */
     public void setOption(String optionStr) {
         option = RightCurlyOption.valueOf(optionStr.trim().toUpperCase(Locale.ENGLISH));


### PR DESCRIPTION
Part of #13421 

---
Adds `@since` to each property setter.

Taken from https://checkstyle.sourceforge.io/checks/blocks/index.html