### PR TITLE
Issue #13421: Add since in javadoc of each property setter for design checks

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/design/DesignForExtensionCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/design/DesignForExtensionCheck.java
@@ -395,6 +395,7 @@ public class DesignForExtensionCheck extends AbstractCheck {
      * Setter to specify annotations which allow the check to skip the method from validation.
      *
      * @param ignoredAnnotations method annotations.
+     * @since 7.2
      */
     public void setIgnoredAnnotations(String... ignoredAnnotations) {
         this.ignoredAnnotations = Arrays.stream(ignoredAnnotations).collect(Collectors.toSet());
@@ -405,6 +406,7 @@ public class DesignForExtensionCheck extends AbstractCheck {
      * method as designed for extension. Supports multi-line regex.
      *
      * @param requiredJavadocPhrase method annotations.
+     * @since 8.40
      */
     public void setRequiredJavadocPhrase(Pattern requiredJavadocPhrase) {
         this.requiredJavadocPhrase = requiredJavadocPhrase;

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/design/InterfaceIsTypeCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/design/InterfaceIsTypeCheck.java
@@ -150,6 +150,7 @@ public final class InterfaceIsTypeCheck
      * Setter to control whether marker interfaces like Serializable are allowed.
      *
      * @param flag whether to allow marker interfaces or not
+     * @since 3.1
      */
     public void setAllowMarkerInterfaces(boolean flag) {
         allowMarkerInterfaces = flag;

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/design/MutableExceptionCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/design/MutableExceptionCheck.java
@@ -230,6 +230,7 @@ public final class MutableExceptionCheck extends AbstractCheck {
      * Setter to specify pattern for extended class names.
      *
      * @param extendedClassNameFormat a {@code String} value
+     * @since 6.2
      */
     public void setExtendedClassNameFormat(Pattern extendedClassNameFormat) {
         this.extendedClassNameFormat = extendedClassNameFormat;
@@ -239,6 +240,7 @@ public final class MutableExceptionCheck extends AbstractCheck {
      * Setter to specify pattern for exception class names.
      *
      * @param pattern the new pattern
+     * @since 3.2
      */
     public void setFormat(Pattern pattern) {
         format = pattern;

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/design/ThrowsCountCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/design/ThrowsCountCheck.java
@@ -232,6 +232,7 @@ public final class ThrowsCountCheck extends AbstractCheck {
      * Setter to allow private methods to be ignored.
      *
      * @param ignorePrivateMethods whether private methods must be ignored.
+     * @since 6.7
      */
     public void setIgnorePrivateMethods(boolean ignorePrivateMethods) {
         this.ignorePrivateMethods = ignorePrivateMethods;
@@ -241,6 +242,7 @@ public final class ThrowsCountCheck extends AbstractCheck {
      * Setter to specify maximum allowed number of throws statements.
      *
      * @param max maximum allowed throws statements.
+     * @since 3.2
      */
     public void setMax(int max) {
         this.max = max;

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/design/VisibilityModifierCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/design/VisibilityModifierCheck.java
@@ -830,6 +830,7 @@ public class VisibilityModifierCheck
      * in consideration.
      *
      * @param annotationNames array of ignore annotations canonical names.
+     * @since 6.5
      */
     public void setIgnoreAnnotationCanonicalNames(String... annotationNames) {
         ignoreAnnotationCanonicalNames = Set.of(annotationNames);
@@ -839,6 +840,7 @@ public class VisibilityModifierCheck
      * Setter to control whether protected members are allowed.
      *
      * @param protectedAllowed whether protected members are allowed
+     * @since 3.0
      */
     public void setProtectedAllowed(boolean protectedAllowed) {
         this.protectedAllowed = protectedAllowed;
@@ -848,6 +850,7 @@ public class VisibilityModifierCheck
      * Setter to control whether package visible members are allowed.
      *
      * @param packageAllowed whether package visible members are allowed
+     * @since 3.0
      */
     public void setPackageAllowed(boolean packageAllowed) {
         this.packageAllowed = packageAllowed;
@@ -858,6 +861,7 @@ public class VisibilityModifierCheck
      *
      * @param pattern
      *        pattern for public members to ignore.
+     * @since 3.0
      */
     public void setPublicMemberPattern(Pattern pattern) {
         publicMemberPattern = pattern;
@@ -867,6 +871,7 @@ public class VisibilityModifierCheck
      * Setter to allow immutable fields to be declared as public if defined in final class.
      *
      * @param allow user's value.
+     * @since 6.4
      */
     public void setAllowPublicImmutableFields(boolean allow) {
         allowPublicImmutableFields = allow;
@@ -876,6 +881,7 @@ public class VisibilityModifierCheck
      * Setter to allow final fields to be declared as public.
      *
      * @param allow user's value.
+     * @since 7.0
      */
     public void setAllowPublicFinalFields(boolean allow) {
         allowPublicFinalFields = allow;
@@ -885,6 +891,7 @@ public class VisibilityModifierCheck
      * Setter to specify immutable classes canonical names.
      *
      * @param classNames array of immutable types canonical names.
+     * @since 6.4.1
      */
     public void setImmutableClassCanonicalNames(String... classNames) {
         immutableClassCanonicalNames = Set.of(classNames);


### PR DESCRIPTION
Part of #13421 

---
Adds `@since` to each property setter.

Taken from https://checkstyle.sourceforge.io/checks/design/index.html