### PR TITLE
Issue #13421: Add since in javadoc of each property setter for coding checks

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/ArrayTrailingCommaCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/ArrayTrailingCommaCheck.java
@@ -212,6 +212,7 @@ public class ArrayTrailingCommaCheck extends AbstractCheck {
      * Setter to control whether to always check for a trailing comma, even when an array is inline.
      *
      * @param alwaysDemandTrailingComma whether to always check for a trailing comma.
+     * @since 8.33
      */
     public void setAlwaysDemandTrailingComma(boolean alwaysDemandTrailingComma) {
         this.alwaysDemandTrailingComma = alwaysDemandTrailingComma;

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/DeclarationOrderCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/DeclarationOrderCheck.java
@@ -456,6 +456,7 @@ public class DeclarationOrderCheck extends AbstractCheck {
      * Setter to control whether to ignore constructors.
      *
      * @param ignoreConstructors whether to ignore constructors.
+     * @since 5.2
      */
     public void setIgnoreConstructors(boolean ignoreConstructors) {
         this.ignoreConstructors = ignoreConstructors;
@@ -465,6 +466,7 @@ public class DeclarationOrderCheck extends AbstractCheck {
      * Setter to control whether to ignore modifiers (fields, ...).
      *
      * @param ignoreModifiers whether to ignore modifiers.
+     * @since 5.2
      */
     public void setIgnoreModifiers(boolean ignoreModifiers) {
         this.ignoreModifiers = ignoreModifiers;

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/DefaultComesLastCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/DefaultComesLastCheck.java
@@ -173,6 +173,7 @@ public class DefaultComesLastCheck extends AbstractCheck {
      * {@code case} if they are not last.
      *
      * @param newValue whether to ignore checking.
+     * @since 7.7
      */
     public void setSkipIfLastAndSharedWithCase(boolean newValue) {
         skipIfLastAndSharedWithCase = newValue;

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/EqualsAvoidNullCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/EqualsAvoidNullCheck.java
@@ -173,6 +173,7 @@ public class EqualsAvoidNullCheck extends AbstractCheck {
      *
      * @param newValue whether to ignore checking
      *     {@code String.equalsIgnoreCase(String)}.
+     * @since 5.4
      */
     public void setIgnoreEqualsIgnoreCase(boolean newValue) {
         ignoreEqualsIgnoreCase = newValue;

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/ExplicitInitializationCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/ExplicitInitializationCheck.java
@@ -164,6 +164,7 @@ public class ExplicitInitializationCheck extends AbstractCheck {
      *
      * @param onlyObjectReferences whether only explicit initialization made to null
      *                             should be checked
+     * @since 7.8
      */
     public void setOnlyObjectReferences(boolean onlyObjectReferences) {
         this.onlyObjectReferences = onlyObjectReferences;

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/FallThroughCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/FallThroughCheck.java
@@ -243,6 +243,7 @@ public class FallThroughCheck extends AbstractCheck {
      *
      * @param pattern
      *            The regular expression pattern.
+     * @since 4.0
      */
     public void setReliefPattern(Pattern pattern) {
         reliefPattern = pattern;
@@ -252,6 +253,7 @@ public class FallThroughCheck extends AbstractCheck {
      * Setter to control whether the last case group must be checked.
      *
      * @param value new value of the property.
+     * @since 4.0
      */
     public void setCheckLastCaseGroup(boolean value) {
         checkLastCaseGroup = value;

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/FinalLocalVariableCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/FinalLocalVariableCheck.java
@@ -203,6 +203,7 @@ public class FinalLocalVariableCheck extends AbstractCheck {
      * enhanced for-loop</a> variable.
      *
      * @param validateEnhancedForLoopVariable whether to check for-loop variable
+     * @since 6.5
      */
     public final void setValidateEnhancedForLoopVariable(boolean validateEnhancedForLoopVariable) {
         this.validateEnhancedForLoopVariable = validateEnhancedForLoopVariable;

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/HiddenFieldCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/HiddenFieldCheck.java
@@ -726,6 +726,7 @@ public class HiddenFieldCheck
      * Setter to define the RegExp for names of variables and parameters to ignore.
      *
      * @param pattern a pattern.
+     * @since 3.2
      */
     public void setIgnoreFormat(Pattern pattern) {
         ignoreFormat = pattern;
@@ -736,6 +737,7 @@ public class HiddenFieldCheck
      *
      * @param ignoreSetter decide whether to ignore the parameter of
      *     a property setter method.
+     * @since 3.2
      */
     public void setIgnoreSetter(boolean ignoreSetter) {
         this.ignoreSetter = ignoreSetter;
@@ -750,6 +752,7 @@ public class HiddenFieldCheck
      *        in order to be recognized as setter method (otherwise
      *        already recognized as a setter) must return void.  Later is
      *        the default behavior.
+     * @since 6.3
      */
     public void setSetterCanReturnItsClass(
         boolean aSetterCanReturnItsClass) {
@@ -761,6 +764,7 @@ public class HiddenFieldCheck
      *
      * @param ignoreConstructorParameter decide whether to ignore
      *     constructor parameters.
+     * @since 3.2
      */
     public void setIgnoreConstructorParameter(
         boolean ignoreConstructorParameter) {
@@ -772,6 +776,7 @@ public class HiddenFieldCheck
      *
      * @param ignoreAbstractMethods decide whether to ignore
      *     parameters of abstract methods.
+     * @since 4.0
      */
     public void setIgnoreAbstractMethods(
         boolean ignoreAbstractMethods) {

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/IllegalCatchCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/IllegalCatchCheck.java
@@ -163,6 +163,7 @@ public final class IllegalCatchCheck extends AbstractCheck {
      *
      * @param classNames
      *            array of illegal exception classes
+     * @since 3.2
      */
     public void setIllegalClassNames(final String... classNames) {
         illegalClassNames.clear();

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/IllegalInstantiationCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/IllegalInstantiationCheck.java
@@ -415,6 +415,7 @@ public class IllegalInstantiationCheck
      * Setter to specify fully qualified class names that should not be instantiated.
      *
      * @param names class names
+     * @since 3.0
      */
     public void setClasses(String... names) {
         classes = Arrays.stream(names).collect(Collectors.toSet());

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/IllegalThrowsCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/IllegalThrowsCheck.java
@@ -180,6 +180,7 @@ public final class IllegalThrowsCheck extends AbstractCheck {
      *
      * @param classNames
      *            array of illegal exception classes
+     * @since 4.0
      */
     public void setIllegalClassNames(final String... classNames) {
         illegalClassNames.clear();
@@ -245,6 +246,7 @@ public final class IllegalThrowsCheck extends AbstractCheck {
      * Setter to specify names of methods to ignore.
      *
      * @param methodNames array of ignored method names
+     * @since 5.4
      */
     public void setIgnoredMethodNames(String... methodNames) {
         ignoredMethodNames.clear();
@@ -256,6 +258,7 @@ public final class IllegalThrowsCheck extends AbstractCheck {
      * (marked with {@code Override} or {@code java.lang.Override} annotation).
      *
      * @param ignoreOverriddenMethods Check's property.
+     * @since 6.4
      */
     public void setIgnoreOverriddenMethods(boolean ignoreOverriddenMethods) {
         this.ignoreOverriddenMethods = ignoreOverriddenMethods;

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/IllegalTokenTextCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/IllegalTokenTextCheck.java
@@ -219,6 +219,7 @@ public class IllegalTokenTextCheck
      *
      * @param message custom message which should be used
      *                 to report about violations.
+     * @since 3.2
      */
     public void setMessage(String message) {
         this.message = Objects.requireNonNullElse(message, "");
@@ -228,6 +229,7 @@ public class IllegalTokenTextCheck
      * Setter to define the RegExp for illegal pattern.
      *
      * @param format a {@code String} value
+     * @since 3.2
      */
     public void setFormat(String format) {
         formatString = format;
@@ -238,6 +240,7 @@ public class IllegalTokenTextCheck
      * Setter to control whether to ignore case when matching.
      *
      * @param caseInsensitive true if the match is case-insensitive.
+     * @since 3.2
      */
     public void setIgnoreCase(boolean caseInsensitive) {
         ignoreCase = caseInsensitive;

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/IllegalTypeCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/IllegalTypeCheck.java
@@ -404,6 +404,7 @@ public final class IllegalTypeCheck extends AbstractCheck {
      * Setter to specify RegExp for illegal abstract class names.
      *
      * @param pattern a pattern.
+     * @since 3.2
      */
     public void setIllegalAbstractClassNameFormat(Pattern pattern) {
         illegalAbstractClassNameFormat = pattern;
@@ -413,6 +414,7 @@ public final class IllegalTypeCheck extends AbstractCheck {
      * Setter to control whether to validate abstract class names.
      *
      * @param validateAbstractClassNames whether abstract class names must be ignored.
+     * @since 6.10
      */
     public void setValidateAbstractClassNames(boolean validateAbstractClassNames) {
         this.validateAbstractClassNames = validateAbstractClassNames;
@@ -818,6 +820,7 @@ public final class IllegalTypeCheck extends AbstractCheck {
      * @param classNames array of illegal variable types
      * @noinspection WeakerAccess
      * @noinspectionreason WeakerAccess - we avoid 'protected' when possible
+     * @since 3.2
      */
     public void setIllegalClassNames(String... classNames) {
         illegalClassNames.clear();
@@ -830,6 +833,7 @@ public final class IllegalTypeCheck extends AbstractCheck {
      * @param methodNames array of ignored method names
      * @noinspection WeakerAccess
      * @noinspectionreason WeakerAccess - we avoid 'protected' when possible
+     * @since 3.2
      */
     public void setIgnoredMethodNames(String... methodNames) {
         ignoredMethodNames.clear();
@@ -842,6 +846,7 @@ public final class IllegalTypeCheck extends AbstractCheck {
      * @param classNames array of legal abstract class names
      * @noinspection WeakerAccess
      * @noinspectionreason WeakerAccess - we avoid 'protected' when possible
+     * @since 4.2
      */
     public void setLegalAbstractClassNames(String... classNames) {
         Collections.addAll(legalAbstractClassNames, classNames);
@@ -853,6 +858,7 @@ public final class IllegalTypeCheck extends AbstractCheck {
      * This property does not affect method calls nor method references nor record components.
      *
      * @param modifiers String contains modifiers.
+     * @since 6.3
      */
     public void setMemberModifiers(String modifiers) {
         memberModifiers = TokenUtil.asBitSet(modifiers.split(","));

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/MagicNumberCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/MagicNumberCheck.java
@@ -547,6 +547,7 @@ public class MagicNumberCheck extends AbstractCheck {
      * number literal to the enclosing constant definition.
      *
      * @param tokens The string representation of the tokens interested in
+     * @since 6.11
      */
     public void setConstantWaiverParentToken(String... tokens) {
         constantWaiverParentToken = TokenUtil.asBitSet(tokens);
@@ -556,6 +557,7 @@ public class MagicNumberCheck extends AbstractCheck {
      * Setter to specify non-magic numbers.
      *
      * @param list numbers to ignore.
+     * @since 3.1
      */
     public void setIgnoreNumbers(double... list) {
         ignoreNumbers = new double[list.length];
@@ -568,6 +570,7 @@ public class MagicNumberCheck extends AbstractCheck {
      *
      * @param ignoreHashCodeMethod decide whether to ignore
      *     hash code methods
+     * @since 5.3
      */
     public void setIgnoreHashCodeMethod(boolean ignoreHashCodeMethod) {
         this.ignoreHashCodeMethod = ignoreHashCodeMethod;
@@ -577,6 +580,7 @@ public class MagicNumberCheck extends AbstractCheck {
      * Setter to ignore magic numbers in annotation declarations.
      *
      * @param ignoreAnnotation decide whether to ignore annotations
+     * @since 5.4
      */
     public void setIgnoreAnnotation(boolean ignoreAnnotation) {
         this.ignoreAnnotation = ignoreAnnotation;
@@ -587,6 +591,7 @@ public class MagicNumberCheck extends AbstractCheck {
      *
      * @param ignoreFieldDeclaration decide whether to ignore magic numbers
      *     in field declaration
+     * @since 6.6
      */
     public void setIgnoreFieldDeclaration(boolean ignoreFieldDeclaration) {
         this.ignoreFieldDeclaration = ignoreFieldDeclaration;
@@ -596,6 +601,7 @@ public class MagicNumberCheck extends AbstractCheck {
      * Setter to ignore magic numbers in annotation elements defaults.
      *
      * @param ignoreAnnotationElementDefaults decide whether to ignore annotation elements defaults
+     * @since 8.23
      */
     public void setIgnoreAnnotationElementDefaults(boolean ignoreAnnotationElementDefaults) {
         this.ignoreAnnotationElementDefaults = ignoreAnnotationElementDefaults;

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/MatchXpathCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/MatchXpathCheck.java
@@ -233,6 +233,7 @@ public class MatchXpathCheck extends AbstractCheck {
      *
      * @param query Xpath query.
      * @throws IllegalStateException if creation of xpath expression fails
+     * @since 8.39
      */
     public void setQuery(String query) {
         this.query = query;

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/ModifiedControlVariableCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/ModifiedControlVariableCheck.java
@@ -174,6 +174,7 @@ public final class ModifiedControlVariableCheck extends AbstractCheck {
      * enhanced for-loop</a> variable.
      *
      * @param skipEnhancedForLoopVariable whether to skip enhanced for-loop variable
+     * @since 6.8
      */
     public void setSkipEnhancedForLoopVariable(boolean skipEnhancedForLoopVariable) {
         this.skipEnhancedForLoopVariable = skipEnhancedForLoopVariable;

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/MultipleStringLiteralsCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/MultipleStringLiteralsCheck.java
@@ -228,6 +228,7 @@ public class MultipleStringLiteralsCheck extends AbstractCheck {
      * Setter to specify the maximum number of occurrences to allow without generating a warning.
      *
      * @param allowedDuplicates The maximum number of duplicates.
+     * @since 3.5
      */
     public void setAllowedDuplicates(int allowedDuplicates) {
         this.allowedDuplicates = allowedDuplicates;
@@ -240,6 +241,7 @@ public class MultipleStringLiteralsCheck extends AbstractCheck {
      *        regular expression pattern for ignored strings
      * @noinspection WeakerAccess
      * @noinspectionreason WeakerAccess - we avoid 'protected' when possible
+     * @since 4.0
      */
     public final void setIgnoreStringsRegexp(Pattern ignoreStringsRegexp) {
         if (ignoreStringsRegexp == null || ignoreStringsRegexp.pattern().isEmpty()) {
@@ -256,6 +258,7 @@ public class MultipleStringLiteralsCheck extends AbstractCheck {
      * syntactical contexts like annotations or static initializers from the check.
      *
      * @param strRep the string representation of the tokens interested in
+     * @since 4.4
      */
     public final void setIgnoreOccurrenceContext(String... strRep) {
         ignoreOccurrenceContext.clear();

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/NestedForDepthCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/NestedForDepthCheck.java
@@ -113,6 +113,7 @@ public final class NestedForDepthCheck extends AbstractCheck {
      * Setter to specify maximum allowed nesting depth.
      *
      * @param max maximum allowed nesting depth.
+     * @since 5.3
      */
     public void setMax(int max) {
         this.max = max;

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/NestedIfDepthCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/NestedIfDepthCheck.java
@@ -124,6 +124,7 @@ public final class NestedIfDepthCheck extends AbstractCheck {
      * Setter to specify maximum allowed nesting depth.
      *
      * @param max maximum allowed nesting depth.
+     * @since 3.2
      */
     public void setMax(int max) {
         this.max = max;

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/NestedTryDepthCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/NestedTryDepthCheck.java
@@ -161,6 +161,7 @@ public final class NestedTryDepthCheck extends AbstractCheck {
      * Setter to specify maximum allowed nesting depth.
      *
      * @param max maximum allowed nesting depth.
+     * @since 3.2
      */
     public void setMax(int max) {
         this.max = max;

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/OneStatementPerLineCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/OneStatementPerLineCheck.java
@@ -174,6 +174,7 @@ public final class OneStatementPerLineCheck extends AbstractCheck {
      * Setter to enable resources processing.
      *
      * @param treatTryResourcesAsStatement user's value of treatTryResourcesAsStatement.
+     * @since 8.23
      */
     public void setTreatTryResourcesAsStatement(boolean treatTryResourcesAsStatement) {
         this.treatTryResourcesAsStatement = treatTryResourcesAsStatement;

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/PackageDeclarationCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/PackageDeclarationCheck.java
@@ -125,6 +125,7 @@ public final class PackageDeclarationCheck extends AbstractCheck {
      * Setter to control whether to check for directory and package name match.
      *
      * @param matchDirectoryStructure the new value.
+     * @since 7.6.1
      */
     public void setMatchDirectoryStructure(boolean matchDirectoryStructure) {
         this.matchDirectoryStructure = matchDirectoryStructure;

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/RequireThisCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/RequireThisCheck.java
@@ -321,6 +321,7 @@ public class RequireThisCheck extends AbstractCheck {
      * Setter to control whether to check references to fields.
      *
      * @param checkFields should we check fields usage or not
+     * @since 3.4
      */
     public void setCheckFields(boolean checkFields) {
         this.checkFields = checkFields;
@@ -330,6 +331,7 @@ public class RequireThisCheck extends AbstractCheck {
      * Setter to control whether to check references to methods.
      *
      * @param checkMethods should we check methods usage or not
+     * @since 3.4
      */
     public void setCheckMethods(boolean checkMethods) {
         this.checkMethods = checkMethods;
@@ -339,6 +341,7 @@ public class RequireThisCheck extends AbstractCheck {
      * Setter to control whether to check only overlapping by variables or arguments.
      *
      * @param validateOnlyOverlapping should we check only overlapping by variables or arguments
+     * @since 6.17
      */
     public void setValidateOnlyOverlapping(boolean validateOnlyOverlapping) {
         this.validateOnlyOverlapping = validateOnlyOverlapping;

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/ReturnCountCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/ReturnCountCheck.java
@@ -342,6 +342,7 @@ public final class ReturnCountCheck extends AbstractCheck {
      * Setter to specify method names to ignore.
      *
      * @param pattern a pattern.
+     * @since 3.4
      */
     public void setFormat(Pattern pattern) {
         format = pattern;
@@ -352,6 +353,7 @@ public final class ReturnCountCheck extends AbstractCheck {
      * in non-void methods/lambdas.
      *
      * @param max maximum allowed number of return statements.
+     * @since 3.2
      */
     public void setMax(int max) {
         this.max = max;
@@ -362,6 +364,7 @@ public final class ReturnCountCheck extends AbstractCheck {
      * in void methods/constructors/lambdas.
      *
      * @param maxForVoid maximum allowed number of return statements for void methods.
+     * @since 6.19
      */
     public void setMaxForVoid(int maxForVoid) {
         this.maxForVoid = maxForVoid;

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/UnnecessarySemicolonInTryWithResourcesCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/UnnecessarySemicolonInTryWithResourcesCheck.java
@@ -128,6 +128,7 @@ public final class UnnecessarySemicolonInTryWithResourcesCheck extends AbstractC
      * Setter to allow unnecessary semicolon if closing paren is not on the same line.
      *
      * @param allowWhenNoBraceAfterSemicolon a value to set.
+     * @since 8.22
      */
     public void setAllowWhenNoBraceAfterSemicolon(boolean allowWhenNoBraceAfterSemicolon) {
         this.allowWhenNoBraceAfterSemicolon = allowWhenNoBraceAfterSemicolon;

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/VariableDeclarationUsageDistanceCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/VariableDeclarationUsageDistanceCheck.java
@@ -342,6 +342,7 @@ public class VariableDeclarationUsageDistanceCheck extends AbstractCheck {
      * @param allowedDistance
      *        Allowed distance between declaration of variable and its first
      *        usage.
+     * @since 5.8
      */
     public void setAllowedDistance(int allowedDistance) {
         this.allowedDistance = allowedDistance;
@@ -351,6 +352,7 @@ public class VariableDeclarationUsageDistanceCheck extends AbstractCheck {
      * Setter to define RegExp to ignore distance calculation for variables listed in this pattern.
      *
      * @param pattern a pattern.
+     * @since 5.8
      */
     public void setIgnoreVariablePattern(Pattern pattern) {
         ignoreVariablePattern = pattern;
@@ -363,6 +365,7 @@ public class VariableDeclarationUsageDistanceCheck extends AbstractCheck {
      * @param validateBetweenScopes
      *        Defines if allow to calculate distance between declaration of
      *        variable and its first usage in different scopes or not.
+     * @since 5.8
      */
     public void setValidateBetweenScopes(boolean validateBetweenScopes) {
         this.validateBetweenScopes = validateBetweenScopes;
@@ -373,6 +376,7 @@ public class VariableDeclarationUsageDistanceCheck extends AbstractCheck {
      *
      * @param ignoreFinal
      *        Defines if ignore variables with 'final' modifier or not.
+     * @since 5.8
      */
     public void setIgnoreFinal(boolean ignoreFinal) {
         this.ignoreFinal = ignoreFinal;


### PR DESCRIPTION
Part of #13421 

---
Adds `@since` to each property setter.

Taken from https://checkstyle.sourceforge.io/checks/coding/index.html