### PR TITLE
Issue #13421: Add since in javadoc of each property setter for header checks

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/header/HeaderCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/header/HeaderCheck.java
@@ -179,6 +179,7 @@ public class HeaderCheck extends AbstractHeaderCheck {
      * Setter to specify the line numbers to ignore.
      *
      * @param lines line numbers to ignore in header.
+     * @since 3.2
      */
     public void setIgnoreLines(int... lines) {
         ignoreLines = TokenUtil.asBitSet(lines);

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/header/RegexpHeaderCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/header/RegexpHeaderCheck.java
@@ -242,6 +242,7 @@ public class RegexpHeaderCheck extends AbstractHeaderCheck {
      * Setter to specify the line numbers to repeat (zero or more times).
      *
      * @param list line numbers to repeat in header.
+     * @since 3.4
      */
     public void setMultiLines(int... list) {
         multiLines = TokenUtil.asBitSet(list);
@@ -363,6 +364,7 @@ public class RegexpHeaderCheck extends AbstractHeaderCheck {
      * Regular expressions must not span multiple lines.
      *
      * @param header the header value to validate and set (in that order)
+     * @since 5.0
      */
     @Override
     public void setHeader(String header) {


### PR DESCRIPTION
Part of #13421 

---
Adds `@since` to each property setter.

Taken from https://checkstyle.sourceforge.io/checks/header/index.html