### PR TITLE
Issue #13421: Add since in javadoc of each property setter for imports checks

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/imports/AvoidStarImportCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/imports/AvoidStarImportCheck.java
@@ -238,6 +238,7 @@ public class AvoidStarImportCheck
      *
      * @param excludesParam package names/fully-qualifies class names
      *     where star imports are ok
+     * @since 3.2
      */
     public void setExcludes(String... excludesParam) {
         for (final String exclude : excludesParam) {
@@ -255,6 +256,7 @@ public class AvoidStarImportCheck
      * {@code import java.util.*;}.
      *
      * @param allow true to allow false to disallow
+     * @since 5.3
      */
     public void setAllowClassImports(boolean allow) {
         allowClassImports = allow;
@@ -265,6 +267,7 @@ public class AvoidStarImportCheck
      * {@code import static org.junit.Assert.*;}.
      *
      * @param allow true to allow false to disallow
+     * @since 5.3
      */
     public void setAllowStaticMemberImports(boolean allow) {
         allowStaticMemberImports = allow;

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/imports/AvoidStaticImportCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/imports/AvoidStaticImportCheck.java
@@ -140,6 +140,7 @@ public class AvoidStaticImportCheck
      *
      * @param excludes fully-qualified class names/specific
      *     static members where static imports are ok
+     * @since 5.0
      */
     public void setExcludes(String... excludes) {
         this.excludes = excludes.clone();

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/imports/CustomImportOrderCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/imports/CustomImportOrderCheck.java
@@ -754,6 +754,7 @@ public class CustomImportOrderCheck extends AbstractCheck {
      *
      * @param regexp
      *        user value.
+     * @since 5.8
      */
     public final void setStandardPackageRegExp(Pattern regexp) {
         standardPackageRegExp = regexp;
@@ -764,6 +765,7 @@ public class CustomImportOrderCheck extends AbstractCheck {
      *
      * @param regexp
      *        user value.
+     * @since 5.8
      */
     public final void setThirdPartyPackageRegExp(Pattern regexp) {
         thirdPartyPackageRegExp = regexp;
@@ -774,6 +776,7 @@ public class CustomImportOrderCheck extends AbstractCheck {
      *
      * @param regexp
      *        user value.
+     * @since 5.8
      */
     public final void setSpecialImportsRegExp(Pattern regexp) {
         specialImportsRegExp = regexp;
@@ -784,6 +787,7 @@ public class CustomImportOrderCheck extends AbstractCheck {
      *
      * @param value
      *        user value.
+     * @since 5.8
      */
     public final void setSeparateLineBetweenGroups(boolean value) {
         separateLineBetweenGroups = value;
@@ -795,6 +799,7 @@ public class CustomImportOrderCheck extends AbstractCheck {
      *
      * @param value
      *        user value.
+     * @since 5.8
      */
     public final void setSortImportsInGroupAlphabetically(boolean value) {
         sortImportsInGroupAlphabetically = value;
@@ -805,6 +810,7 @@ public class CustomImportOrderCheck extends AbstractCheck {
      *
      * @param inputCustomImportOrder
      *        user value.
+     * @since 5.8
      */
     public final void setCustomImportOrderRules(final String inputCustomImportOrder) {
         if (!DEFAULT_CUSTOM_IMPORT_ORDER_RULES.equals(inputCustomImportOrder)) {

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/imports/IllegalImportCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/imports/IllegalImportCheck.java
@@ -329,6 +329,7 @@ public class IllegalImportCheck
      * @param from illegal packages
      * @noinspection WeakerAccess
      * @noinspectionreason WeakerAccess - we avoid 'protected' when possible
+     * @since 3.0
      */
     public final void setIllegalPkgs(String... from) {
         illegalPkgs = from.clone();
@@ -345,6 +346,7 @@ public class IllegalImportCheck
      * Note, all properties for match will be used.
      *
      * @param from illegal classes
+     * @since 7.8
      */
     public void setIllegalClasses(String... from) {
         illegalClasses = from.clone();
@@ -358,6 +360,7 @@ public class IllegalImportCheck
      * should be interpreted as regular expressions.
      *
      * @param regexp a {@code Boolean} value
+     * @since 7.8
      */
     public void setRegexp(boolean regexp) {
         this.regexp = regexp;

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/imports/ImportControlCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/imports/ImportControlCheck.java
@@ -599,6 +599,7 @@ public class ImportControlCheck extends AbstractCheck implements ExternalResourc
      *
      * @param uri the uri of the file to load.
      * @throws IllegalArgumentException on error loading the file.
+     * @since 4.0
      */
     public void setFile(URI uri) {
         // Handle empty param
@@ -619,6 +620,7 @@ public class ImportControlCheck extends AbstractCheck implements ExternalResourc
      * against the full absolute file path.
      *
      * @param pattern the file path regex this check should apply to.
+     * @since 7.5
      */
     public void setPath(Pattern pattern) {
         path = pattern;

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/imports/ImportOrderCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/imports/ImportOrderCheck.java
@@ -665,6 +665,7 @@ public class ImportOrderCheck
      *
      * @param optionStr string to decode option from
      * @throws IllegalArgumentException if unable to decode
+     * @since 5.0
      */
     public void setOption(String optionStr) {
         option = ImportOrderOption.valueOf(optionStr.trim().toUpperCase(Locale.ENGLISH));
@@ -678,6 +679,7 @@ public class ImportOrderCheck
      * means one group for all type imports.
      *
      * @param packageGroups a comma-separated list of package names/prefixes.
+     * @since 3.2
      */
     public void setGroups(String... packageGroups) {
         groups = compilePatterns(packageGroups);
@@ -692,6 +694,7 @@ public class ImportOrderCheck
      * the property {@code option} is set to {@code top} or {@code bottom}.
      *
      * @param packageGroups a comma-separated list of package names/prefixes.
+     * @since 8.12
      */
     public void setStaticGroups(String... packageGroups) {
         staticGroups = compilePatterns(packageGroups);
@@ -704,6 +707,7 @@ public class ImportOrderCheck
      * @param ordered
      *            whether lexicographic ordering of imports within a group
      *            required or not.
+     * @since 3.2
      */
     public void setOrdered(boolean ordered) {
         this.ordered = ordered;
@@ -716,6 +720,7 @@ public class ImportOrderCheck
      *
      * @param separated
      *            whether groups should be separated by one blank line or comment.
+     * @since 3.2
      */
     public void setSeparated(boolean separated) {
         this.separated = separated;
@@ -730,6 +735,7 @@ public class ImportOrderCheck
      *
      * @param separatedStaticGroups
      *            whether groups should be separated by one blank line or comment.
+     * @since 8.12
      */
     public void setSeparatedStaticGroups(boolean separatedStaticGroups) {
         this.separatedStaticGroups = separatedStaticGroups;
@@ -743,6 +749,7 @@ public class ImportOrderCheck
      *
      * @param caseSensitive
      *            whether string comparison should be case-sensitive.
+     * @since 3.3
      */
     public void setCaseSensitive(boolean caseSensitive) {
         this.caseSensitive = caseSensitive;
@@ -753,6 +760,7 @@ public class ImportOrderCheck
      * <b>bottom</b> are sorted within the group.
      *
      * @param sortAlphabetically true or false.
+     * @since 6.5
      */
     public void setSortStaticImportsAlphabetically(boolean sortAlphabetically) {
         sortStaticImportsAlphabetically = sortAlphabetically;
@@ -763,6 +771,7 @@ public class ImportOrderCheck
      * imports or not.
      *
      * @param useContainerOrdering whether to use container ordering for static imports or not.
+     * @since 7.1
      */
     public void setUseContainerOrderingForStatic(boolean useContainerOrdering) {
         useContainerOrderingForStatic = useContainerOrdering;

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/imports/UnusedImportsCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/imports/UnusedImportsCheck.java
@@ -210,6 +210,7 @@ public class UnusedImportsCheck extends AbstractCheck {
      * Setter to control whether to process Javadoc comments.
      *
      * @param value Flag for processing Javadoc comments.
+     * @since 5.4
      */
     public void setProcessJavadoc(boolean value) {
         processJavadoc = value;


### PR DESCRIPTION
Part of #13421 

---
Adds `@since` to each property setter.

Taken from https://checkstyle.sourceforge.io/checks/imports/index.html