### PR TITLE
Issue #13421: Add since in javadoc of each property setter for metrics checks

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/metrics/BooleanExpressionComplexityCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/metrics/BooleanExpressionComplexityCheck.java
@@ -225,6 +225,7 @@ public final class BooleanExpressionComplexityCheck extends AbstractCheck {
      * Setter to specify the maximum number of boolean operations allowed in one expression.
      *
      * @param max new maximum allowed complexity.
+     * @since 3.4
      */
     public void setMax(int max) {
         this.max = max;

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/metrics/CyclomaticComplexityCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/metrics/CyclomaticComplexityCheck.java
@@ -271,6 +271,7 @@ public class CyclomaticComplexityCheck
      *
      * @param switchBlockAsSingleDecisionPoint whether to treat the whole switch
      *                                          block as a single decision point.
+     * @since 6.11
      */
     public void setSwitchBlockAsSingleDecisionPoint(boolean switchBlockAsSingleDecisionPoint) {
         this.switchBlockAsSingleDecisionPoint = switchBlockAsSingleDecisionPoint;
@@ -280,6 +281,7 @@ public class CyclomaticComplexityCheck
      * Setter to specify the maximum threshold allowed.
      *
      * @param max the maximum threshold
+     * @since 3.2
      */
     public final void setMax(int max) {
         this.max = max;

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/metrics/JavaNCSSCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/metrics/JavaNCSSCheck.java
@@ -372,6 +372,7 @@ public class JavaNCSSCheck extends AbstractCheck {
      *
      * @param fileMaximum
      *            the maximum ncss
+     * @since 3.5
      */
     public void setFileMaximum(int fileMaximum) {
         this.fileMaximum = fileMaximum;
@@ -382,6 +383,7 @@ public class JavaNCSSCheck extends AbstractCheck {
      *
      * @param classMaximum
      *            the maximum ncss
+     * @since 3.5
      */
     public void setClassMaximum(int classMaximum) {
         this.classMaximum = classMaximum;
@@ -392,6 +394,7 @@ public class JavaNCSSCheck extends AbstractCheck {
      *
      * @param recordMaximum
      *            the maximum ncss
+     * @since 8.36
      */
     public void setRecordMaximum(int recordMaximum) {
         this.recordMaximum = recordMaximum;
@@ -402,6 +405,7 @@ public class JavaNCSSCheck extends AbstractCheck {
      *
      * @param methodMaximum
      *            the maximum ncss
+     * @since 3.5
      */
     public void setMethodMaximum(int methodMaximum) {
         this.methodMaximum = methodMaximum;

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/metrics/NPathComplexityCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/metrics/NPathComplexityCheck.java
@@ -278,6 +278,7 @@ public final class NPathComplexityCheck extends AbstractCheck {
      * Setter to specify the maximum threshold allowed.
      *
      * @param max the maximum threshold
+     * @since 3.4
      */
     public void setMax(int max) {
         this.max = max;


### PR DESCRIPTION
Part of #13421 

---
Adds `@since` to each property setter.

Taken from https://checkstyle.sourceforge.io/checks/metrics/index.html