### PR TITLE
Issue #13421: Add since in javadoc of each property setter for modifier checks

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/modifier/ClassMemberImpliedModifierCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/modifier/ClassMemberImpliedModifierCheck.java
@@ -163,6 +163,7 @@ public class ClassMemberImpliedModifierCheck
      *
      * @param violateImplied
      *        True to perform the check, false to turn the check off.
+     * @since 8.16
      */
     public void setViolateImpliedStaticOnNestedEnum(boolean violateImplied) {
         violateImpliedStaticOnNestedEnum = violateImplied;
@@ -174,6 +175,7 @@ public class ClassMemberImpliedModifierCheck
      *
      * @param violateImplied
      *        True to perform the check, false to turn the check off.
+     * @since 8.16
      */
     public void setViolateImpliedStaticOnNestedInterface(boolean violateImplied) {
         violateImpliedStaticOnNestedInterface = violateImplied;
@@ -185,6 +187,7 @@ public class ClassMemberImpliedModifierCheck
      *
      * @param violateImplied
      *        True to perform the check, false to turn the check off.
+     * @since 8.36
      */
     public void setViolateImpliedStaticOnNestedRecord(boolean violateImplied) {
         violateImpliedStaticOnNestedRecord = violateImplied;

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/modifier/InterfaceMemberImpliedModifierCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/modifier/InterfaceMemberImpliedModifierCheck.java
@@ -279,6 +279,7 @@ public class InterfaceMemberImpliedModifierCheck
      *
      * @param violateImpliedPublicField
      *        True to perform the check, false to turn the check off.
+     * @since 8.12
      */
     public void setViolateImpliedPublicField(boolean violateImpliedPublicField) {
         this.violateImpliedPublicField = violateImpliedPublicField;
@@ -290,6 +291,7 @@ public class InterfaceMemberImpliedModifierCheck
      *
      * @param violateImpliedStaticField
      *        True to perform the check, false to turn the check off.
+     * @since 8.12
      */
     public void setViolateImpliedStaticField(boolean violateImpliedStaticField) {
         this.violateImpliedStaticField = violateImpliedStaticField;
@@ -301,6 +303,7 @@ public class InterfaceMemberImpliedModifierCheck
      *
      * @param violateImpliedFinalField
      *        True to perform the check, false to turn the check off.
+     * @since 8.12
      */
     public void setViolateImpliedFinalField(boolean violateImpliedFinalField) {
         this.violateImpliedFinalField = violateImpliedFinalField;
@@ -312,6 +315,7 @@ public class InterfaceMemberImpliedModifierCheck
      *
      * @param violateImpliedPublicMethod
      *        True to perform the check, false to turn the check off.
+     * @since 8.12
      */
     public void setViolateImpliedPublicMethod(boolean violateImpliedPublicMethod) {
         this.violateImpliedPublicMethod = violateImpliedPublicMethod;
@@ -323,6 +327,7 @@ public class InterfaceMemberImpliedModifierCheck
      *
      * @param violateImpliedAbstractMethod
      *        True to perform the check, false to turn the check off.
+     * @since 8.12
      */
     public void setViolateImpliedAbstractMethod(boolean violateImpliedAbstractMethod) {
         this.violateImpliedAbstractMethod = violateImpliedAbstractMethod;
@@ -334,6 +339,7 @@ public class InterfaceMemberImpliedModifierCheck
      *
      * @param violateImpliedPublicNested
      *        True to perform the check, false to turn the check off.
+     * @since 8.12
      */
     public void setViolateImpliedPublicNested(boolean violateImpliedPublicNested) {
         this.violateImpliedPublicNested = violateImpliedPublicNested;
@@ -345,6 +351,7 @@ public class InterfaceMemberImpliedModifierCheck
      *
      * @param violateImpliedStaticNested
      *        True to perform the check, false to turn the check off.
+     * @since 8.12
      */
     public void setViolateImpliedStaticNested(boolean violateImpliedStaticNested) {
         this.violateImpliedStaticNested = violateImpliedStaticNested;


### PR DESCRIPTION
Part of #13421 

---
Adds `@since` to each property setter.

Taken from https://checkstyle.sourceforge.io/checks/modifier/index.html