### PR TITLE
Issue #13421: Add since in javadoc of each property setter for regexp checks

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/regexp/RegexpCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/regexp/RegexpCheck.java
@@ -545,6 +545,7 @@ public class RegexpCheck extends AbstractCheck {
      * if empty then the default (hard-coded) message is used.
      *
      * @param message custom message which should be used in report.
+     * @since 4.0
      */
     public void setMessage(String message) {
         this.message = message;
@@ -554,6 +555,7 @@ public class RegexpCheck extends AbstractCheck {
      * Setter to control whether to ignore matches found within comments.
      *
      * @param ignoreComments True if comments should be ignored.
+     * @since 4.0
      */
     public void setIgnoreComments(boolean ignoreComments) {
         this.ignoreComments = ignoreComments;
@@ -563,6 +565,7 @@ public class RegexpCheck extends AbstractCheck {
      * Setter to control whether the pattern is required or illegal.
      *
      * @param illegalPattern True if pattern is not allowed.
+     * @since 4.0
      */
     public void setIllegalPattern(boolean illegalPattern) {
         this.illegalPattern = illegalPattern;
@@ -572,6 +575,7 @@ public class RegexpCheck extends AbstractCheck {
      * Setter to specify the maximum number of violations before the check will abort.
      *
      * @param errorLimit the number of errors to report.
+     * @since 4.0
      */
     public void setErrorLimit(int errorLimit) {
         this.errorLimit = errorLimit;
@@ -585,6 +589,7 @@ public class RegexpCheck extends AbstractCheck {
      *
      * @param duplicateLimit negative values mean no duplicate checking,
      *     any positive value is used as the limit.
+     * @since 4.0
      */
     public void setDuplicateLimit(int duplicateLimit) {
         this.duplicateLimit = duplicateLimit;
@@ -595,6 +600,7 @@ public class RegexpCheck extends AbstractCheck {
      * Setter to specify the pattern to match against.
      *
      * @param pattern the new pattern
+     * @since 4.0
      */
     public final void setFormat(Pattern pattern) {
         format = CommonUtil.createPattern(pattern.pattern(), Pattern.MULTILINE);

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/regexp/RegexpMultilineCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/regexp/RegexpMultilineCheck.java
@@ -313,6 +313,7 @@ public class RegexpMultilineCheck extends AbstractFileSetCheck {
      * Setter to specify the format of the regular expression to match.
      *
      * @param format the format of the regular expression to match.
+     * @since 5.0
      */
     public void setFormat(String format) {
         this.format = format;
@@ -323,6 +324,7 @@ public class RegexpMultilineCheck extends AbstractFileSetCheck {
      * if empty then default (hard-coded) message is used.
      *
      * @param message the message to report for a match.
+     * @since 5.0
      */
     public void setMessage(String message) {
         this.message = message;
@@ -332,6 +334,7 @@ public class RegexpMultilineCheck extends AbstractFileSetCheck {
      * Setter to specify the minimum number of matches required in each file.
      *
      * @param minimum the minimum number of matches required in each file.
+     * @since 5.0
      */
     public void setMinimum(int minimum) {
         this.minimum = minimum;
@@ -341,6 +344,7 @@ public class RegexpMultilineCheck extends AbstractFileSetCheck {
      * Setter to specify the maximum number of matches required in each file.
      *
      * @param maximum the maximum number of matches required in each file.
+     * @since 5.0
      */
     public void setMaximum(int maximum) {
         this.maximum = maximum;
@@ -350,6 +354,7 @@ public class RegexpMultilineCheck extends AbstractFileSetCheck {
      * Setter to control whether to ignore case when searching.
      *
      * @param ignoreCase whether to ignore case when searching.
+     * @since 5.0
      */
     public void setIgnoreCase(boolean ignoreCase) {
         this.ignoreCase = ignoreCase;
@@ -359,6 +364,7 @@ public class RegexpMultilineCheck extends AbstractFileSetCheck {
      * Setter to control whether to match expressions across multiple lines.
      *
      * @param matchAcrossLines whether to match expressions across multiple lines.
+     * @since 8.25
      */
     public void setMatchAcrossLines(boolean matchAcrossLines) {
         this.matchAcrossLines = matchAcrossLines;

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/regexp/RegexpOnFilenameCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/regexp/RegexpOnFilenameCheck.java
@@ -289,6 +289,7 @@ public class RegexpOnFilenameCheck extends AbstractFileSetCheck {
      * Setter to specify the regular expression to match the folder path against.
      *
      * @param folderPattern format of folder.
+     * @since 6.15
      */
     public void setFolderPattern(Pattern folderPattern) {
         this.folderPattern = folderPattern;
@@ -298,6 +299,7 @@ public class RegexpOnFilenameCheck extends AbstractFileSetCheck {
      * Setter to specify the regular expression to match the file name against.
      *
      * @param fileNamePattern format of file.
+     * @since 6.15
      */
     public void setFileNamePattern(Pattern fileNamePattern) {
         this.fileNamePattern = fileNamePattern;
@@ -308,6 +310,7 @@ public class RegexpOnFilenameCheck extends AbstractFileSetCheck {
      * if the fileNamePattern is supplied, otherwise it is applied on the folderPattern.
      *
      * @param match check's option for matching file names.
+     * @since 6.15
      */
     public void setMatch(boolean match) {
         this.match = match;
@@ -317,6 +320,7 @@ public class RegexpOnFilenameCheck extends AbstractFileSetCheck {
      * Setter to control whether to ignore the file extension for the file name match.
      *
      * @param ignoreFileNameExtensions check's option for ignoring file extension.
+     * @since 6.15
      */
     public void setIgnoreFileNameExtensions(boolean ignoreFileNameExtensions) {
         this.ignoreFileNameExtensions = ignoreFileNameExtensions;

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/regexp/RegexpSinglelineCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/regexp/RegexpSinglelineCheck.java
@@ -236,6 +236,7 @@ public class RegexpSinglelineCheck extends AbstractFileSetCheck {
      * Setter to specify the format of the regular expression to match.
      *
      * @param format the format of the regular expression to match.
+     * @since 5.0
      */
     public void setFormat(String format) {
         this.format = format;
@@ -246,6 +247,7 @@ public class RegexpSinglelineCheck extends AbstractFileSetCheck {
      * if empty then default (hard-coded) message is used.
      *
      * @param message the message to report for a match.
+     * @since 5.0
      */
     public void setMessage(String message) {
         this.message = message;
@@ -255,6 +257,7 @@ public class RegexpSinglelineCheck extends AbstractFileSetCheck {
      * Setter to specify the minimum number of matches required in each file.
      *
      * @param minimum the minimum number of matches required in each file.
+     * @since 5.0
      */
     public void setMinimum(int minimum) {
         this.minimum = minimum;
@@ -264,6 +267,7 @@ public class RegexpSinglelineCheck extends AbstractFileSetCheck {
      * Setter to specify the maximum number of matches required in each file.
      *
      * @param maximum the maximum number of matches required in each file.
+     * @since 5.0
      */
     public void setMaximum(int maximum) {
         this.maximum = maximum;
@@ -273,6 +277,7 @@ public class RegexpSinglelineCheck extends AbstractFileSetCheck {
      * Setter to control whether to ignore case when searching.
      *
      * @param ignoreCase whether to ignore case when searching.
+     * @since 5.0
      */
     public void setIgnoreCase(boolean ignoreCase) {
         this.ignoreCase = ignoreCase;

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/regexp/RegexpSinglelineJavaCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/regexp/RegexpSinglelineJavaCheck.java
@@ -270,6 +270,7 @@ public class RegexpSinglelineJavaCheck extends AbstractCheck {
      * Setter to specify the format of the regular expression to match.
      *
      * @param format the format of the regular expression to match.
+     * @since 5.0
      */
     public void setFormat(String format) {
         this.format = format;
@@ -280,6 +281,7 @@ public class RegexpSinglelineJavaCheck extends AbstractCheck {
      * if empty then default (hard-coded) message is used.
      *
      * @param message the message to report for a match.
+     * @since 6.0
      */
     public void setMessage(String message) {
         this.message = message;
@@ -289,6 +291,7 @@ public class RegexpSinglelineJavaCheck extends AbstractCheck {
      * Setter to specify the minimum number of matches required in each file.
      *
      * @param minimum the minimum number of matches required in each file.
+     * @since 5.0
      */
     public void setMinimum(int minimum) {
         this.minimum = minimum;
@@ -298,6 +301,7 @@ public class RegexpSinglelineJavaCheck extends AbstractCheck {
      * Setter to specify the maximum number of matches required in each file.
      *
      * @param maximum the maximum number of matches required in each file.
+     * @since 5.0
      */
     public void setMaximum(int maximum) {
         this.maximum = maximum;
@@ -307,6 +311,7 @@ public class RegexpSinglelineJavaCheck extends AbstractCheck {
      * Setter to control whether to ignore case when searching.
      *
      * @param ignoreCase whether to ignore case when searching.
+     * @since 5.0
      */
     public void setIgnoreCase(boolean ignoreCase) {
         this.ignoreCase = ignoreCase;
@@ -316,6 +321,7 @@ public class RegexpSinglelineJavaCheck extends AbstractCheck {
      * Setter to control whether to ignore text in comments when searching.
      *
      * @param ignore whether to ignore text in comments when searching.
+     * @since 5.0
      */
     public void setIgnoreComments(boolean ignore) {
         ignoreComments = ignore;


### PR DESCRIPTION
Part of #13421 

---
Adds `@since` to each property setter.

Taken from https://checkstyle.sourceforge.io/checks/regexp/index.html