### PR TITLE
Issue #13421: Add since in javadoc of each property setter for sizes checks

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/sizes/AnonInnerLengthCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/sizes/AnonInnerLengthCheck.java
@@ -118,6 +118,7 @@ public class AnonInnerLengthCheck extends AbstractCheck {
      * Setter to specify the maximum number of lines allowed.
      *
      * @param length the maximum length of an anonymous inner class.
+     * @since 3.2
      */
     public void setMax(int length) {
         max = length;

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/sizes/ExecutableStatementCountCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/sizes/ExecutableStatementCountCheck.java
@@ -148,6 +148,7 @@ public final class ExecutableStatementCountCheck
      * Setter to specify the maximum threshold allowed.
      *
      * @param max the maximum threshold.
+     * @since 3.2
      */
     public void setMax(int max) {
         this.max = max;

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/sizes/FileLengthCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/sizes/FileLengthCheck.java
@@ -100,6 +100,7 @@ public class FileLengthCheck extends AbstractFileSetCheck {
      * Setter to specify the maximum number of lines allowed.
      *
      * @param length the maximum length of a Java source file
+     * @since 3.2
      */
     public void setMax(int length) {
         max = length;

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/sizes/LambdaBodyLengthCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/sizes/LambdaBodyLengthCheck.java
@@ -157,6 +157,7 @@ public class LambdaBodyLengthCheck extends AbstractCheck {
      * Setter to specify the maximum number of lines allowed.
      *
      * @param length the maximum length of lambda body.
+     * @since 8.37
      */
     public void setMax(int length) {
         max = length;

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/sizes/LineLengthCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/sizes/LineLengthCheck.java
@@ -181,6 +181,7 @@ public class LineLengthCheck extends AbstractFileSetCheck {
      * Setter to specify the maximum line length allowed.
      *
      * @param length the maximum length of a line
+     * @since 3.0
      */
     public void setMax(int length) {
         max = length;
@@ -190,6 +191,7 @@ public class LineLengthCheck extends AbstractFileSetCheck {
      * Setter to specify pattern for lines to ignore.
      *
      * @param pattern a pattern.
+     * @since 3.0
      */
     public final void setIgnorePattern(Pattern pattern) {
         ignorePattern = pattern;

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/sizes/MethodCountCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/sizes/MethodCountCheck.java
@@ -330,6 +330,7 @@ public final class MethodCountCheck extends AbstractCheck {
      * Setter to specify the maximum number of {@code private} methods allowed.
      *
      * @param value the maximum allowed.
+     * @since 5.3
      */
     public void setMaxPrivate(int value) {
         maxPrivate = value;
@@ -339,6 +340,7 @@ public final class MethodCountCheck extends AbstractCheck {
      * Setter to specify the maximum number of {@code package} methods allowed.
      *
      * @param value the maximum allowed.
+     * @since 5.3
      */
     public void setMaxPackage(int value) {
         maxPackage = value;
@@ -348,6 +350,7 @@ public final class MethodCountCheck extends AbstractCheck {
      * Setter to specify the maximum number of {@code protected} methods allowed.
      *
      * @param value the maximum allowed.
+     * @since 5.3
      */
     public void setMaxProtected(int value) {
         maxProtected = value;
@@ -357,6 +360,7 @@ public final class MethodCountCheck extends AbstractCheck {
      * Setter to specify the maximum number of {@code public} methods allowed.
      *
      * @param value the maximum allowed.
+     * @since 5.3
      */
     public void setMaxPublic(int value) {
         maxPublic = value;
@@ -366,6 +370,7 @@ public final class MethodCountCheck extends AbstractCheck {
      * Setter to specify the maximum number of methods allowed at all scope levels.
      *
      * @param value the maximum allowed.
+     * @since 5.3
      */
     public void setMaxTotal(int value) {
         maxTotal = value;

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/sizes/MethodLengthCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/sizes/MethodLengthCheck.java
@@ -295,6 +295,7 @@ public class MethodLengthCheck extends AbstractCheck {
      * Setter to specify the maximum number of lines allowed.
      *
      * @param length the maximum length of a method.
+     * @since 3.0
      */
     public void setMax(int length) {
         max = length;
@@ -304,6 +305,7 @@ public class MethodLengthCheck extends AbstractCheck {
      * Setter to control whether to count empty lines and comments.
      *
      * @param countEmpty whether to count empty and comments.
+     * @since 3.2
      */
     public void setCountEmpty(boolean countEmpty) {
         this.countEmpty = countEmpty;

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/sizes/OuterTypeNumberCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/sizes/OuterTypeNumberCheck.java
@@ -133,6 +133,7 @@ public class OuterTypeNumberCheck extends AbstractCheck {
      * Setter to specify the maximum number of outer types allowed.
      *
      * @param max the new number.
+     * @since 5.0
      */
     public void setMax(int max) {
         this.max = max;

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/sizes/ParameterNumberCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/sizes/ParameterNumberCheck.java
@@ -128,6 +128,7 @@ public class ParameterNumberCheck
      * Setter to specify the maximum number of parameters allowed.
      *
      * @param max the max allowed parameters
+     * @since 3.0
      */
     public void setMax(int max) {
         this.max = max;
@@ -137,6 +138,7 @@ public class ParameterNumberCheck
      * Setter to ignore number of parameters for methods with {@code @Override} annotation.
      *
      * @param ignoreOverriddenMethods set ignore overridden methods
+     * @since 6.2
      */
     public void setIgnoreOverriddenMethods(boolean ignoreOverriddenMethods) {
         this.ignoreOverriddenMethods = ignoreOverriddenMethods;

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/sizes/RecordComponentNumberCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/sizes/RecordComponentNumberCheck.java
@@ -163,6 +163,7 @@ public class RecordComponentNumberCheck extends AbstractCheck {
      * of a record definition.
      *
      * @param value the maximum allowed.
+     * @since 8.36
      */
     public void setMax(int value) {
         max = value;
@@ -173,6 +174,7 @@ public class RecordComponentNumberCheck extends AbstractCheck {
      * components should be checked.
      *
      * @param accessModifiers access modifiers of record definitions which should be checked.
+     * @since 8.36
      */
     public void setAccessModifiers(AccessModifierOption... accessModifiers) {
         this.accessModifiers =


### PR DESCRIPTION
Part of #13421 

---
Adds `@since` to each property setter.

Taken from https://checkstyle.sourceforge.io/checks/sizes/index.html