### PR TITLE
Issue #13421: Add since in javadoc of each property setter for whitespace checks

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/whitespace/EmptyForInitializerPadCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/whitespace/EmptyForInitializerPadCheck.java
@@ -125,6 +125,7 @@ public class EmptyForInitializerPadCheck
      *
      * @param optionStr string to decode option from
      * @throws IllegalArgumentException if unable to decode
+     * @since 3.4
      */
     public void setOption(String optionStr) {
         option = PadOption.valueOf(optionStr.trim().toUpperCase(Locale.ENGLISH));

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/whitespace/EmptyForIteratorPadCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/whitespace/EmptyForIteratorPadCheck.java
@@ -128,6 +128,7 @@ public class EmptyForIteratorPadCheck
      *
      * @param optionStr string to decode option from
      * @throws IllegalArgumentException if unable to decode
+     * @since 3.0
      */
     public void setOption(String optionStr) {
         option = PadOption.valueOf(optionStr.trim().toUpperCase(Locale.ENGLISH));

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/whitespace/EmptyLineSeparatorCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/whitespace/EmptyLineSeparatorCheck.java
@@ -378,6 +378,7 @@ public class EmptyLineSeparatorCheck extends AbstractCheck {
      *
      * @param allow
      *        User's value.
+     * @since 5.8
      */
     public final void setAllowNoEmptyLineBetweenFields(boolean allow) {
         allowNoEmptyLineBetweenFields = allow;
@@ -387,6 +388,7 @@ public class EmptyLineSeparatorCheck extends AbstractCheck {
      * Setter to allow multiple empty lines between class members.
      *
      * @param allow User's value.
+     * @since 6.3
      */
     public void setAllowMultipleEmptyLines(boolean allow) {
         allowMultipleEmptyLines = allow;
@@ -396,6 +398,7 @@ public class EmptyLineSeparatorCheck extends AbstractCheck {
      * Setter to allow multiple empty lines inside class members.
      *
      * @param allow User's value.
+     * @since 6.18
      */
     public void setAllowMultipleEmptyLinesInsideClassMembers(boolean allow) {
         allowMultipleEmptyLinesInsideClassMembers = allow;

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/whitespace/FileTabCharacterCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/whitespace/FileTabCharacterCheck.java
@@ -194,6 +194,7 @@ public class FileTabCharacterCheck extends AbstractFileSetCheck {
      * instance.
      *
      * @param eachLine Whether report on each line containing a tab.
+     * @since 5.0
      */
     public void setEachLine(boolean eachLine) {
         this.eachLine = eachLine;

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/whitespace/MethodParamPadCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/whitespace/MethodParamPadCheck.java
@@ -236,6 +236,7 @@ public class MethodParamPadCheck
      *
      * @param allowLineBreaks whether whitespace should be
      *     flagged at line breaks.
+     * @since 3.4
      */
     public void setAllowLineBreaks(boolean allowLineBreaks) {
         this.allowLineBreaks = allowLineBreaks;
@@ -246,6 +247,7 @@ public class MethodParamPadCheck
      *
      * @param optionStr string to decode option from
      * @throws IllegalArgumentException if unable to decode
+     * @since 3.4
      */
     public void setOption(String optionStr) {
         option = PadOption.valueOf(optionStr.trim().toUpperCase(Locale.ENGLISH));

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/whitespace/NoWhitespaceAfterCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/whitespace/NoWhitespaceAfterCheck.java
@@ -235,6 +235,7 @@ public class NoWhitespaceAfterCheck extends AbstractCheck {
      *
      * @param allowLineBreaks whether whitespace should be
      *     flagged at linebreaks.
+     * @since 3.0
      */
     public void setAllowLineBreaks(boolean allowLineBreaks) {
         this.allowLineBreaks = allowLineBreaks;

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/whitespace/NoWhitespaceBeforeCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/whitespace/NoWhitespaceBeforeCheck.java
@@ -249,6 +249,7 @@ public class NoWhitespaceBeforeCheck
      *
      * @param allowLineBreaks whether whitespace should be
      *     flagged at line breaks.
+     * @since 3.0
      */
     public void setAllowLineBreaks(boolean allowLineBreaks) {
         this.allowLineBreaks = allowLineBreaks;

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/whitespace/OperatorWrapCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/whitespace/OperatorWrapCheck.java
@@ -221,6 +221,7 @@ public class OperatorWrapCheck
      *
      * @param optionStr string to decode option from
      * @throws IllegalArgumentException if unable to decode
+     * @since 3.0
      */
     public void setOption(String optionStr) {
         option = WrapOption.valueOf(optionStr.trim().toUpperCase(Locale.ENGLISH));

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/whitespace/SeparatorWrapCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/whitespace/SeparatorWrapCheck.java
@@ -183,6 +183,7 @@ public class SeparatorWrapCheck
      *
      * @param optionStr string to decode option from
      * @throws IllegalArgumentException if unable to decode
+     * @since 5.8
      */
     public void setOption(String optionStr) {
         option = WrapOption.valueOf(optionStr.trim().toUpperCase(Locale.ENGLISH));

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/whitespace/SingleSpaceSeparatorCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/whitespace/SingleSpaceSeparatorCheck.java
@@ -140,6 +140,7 @@ public class SingleSpaceSeparatorCheck extends AbstractCheck {
      * Setter to control whether to validate whitespaces surrounding comments.
      *
      * @param validateComments {@code true} to validate surrounding whitespaces at comments.
+     * @since 6.19
      */
     public void setValidateComments(boolean validateComments) {
         this.validateComments = validateComments;

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/whitespace/WhitespaceAroundCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/whitespace/WhitespaceAroundCheck.java
@@ -622,6 +622,7 @@ public class WhitespaceAroundCheck extends AbstractCheck {
      * Setter to allow empty method bodies.
      *
      * @param allow {@code true} to allow empty method bodies.
+     * @since 4.0
      */
     public void setAllowEmptyMethods(boolean allow) {
         allowEmptyMethods = allow;
@@ -631,6 +632,7 @@ public class WhitespaceAroundCheck extends AbstractCheck {
      * Setter to allow empty constructor bodies.
      *
      * @param allow {@code true} to allow empty constructor bodies.
+     * @since 4.0
      */
     public void setAllowEmptyConstructors(boolean allow) {
         allowEmptyConstructors = allow;
@@ -642,6 +644,7 @@ public class WhitespaceAroundCheck extends AbstractCheck {
      * enhanced for</a> loop.
      *
      * @param ignore {@code true} to ignore enhanced for colon.
+     * @since 5.5
      */
     public void setIgnoreEnhancedForColon(boolean ignore) {
         ignoreEnhancedForColon = ignore;
@@ -651,6 +654,7 @@ public class WhitespaceAroundCheck extends AbstractCheck {
      * Setter to allow empty class, interface and enum bodies.
      *
      * @param allow {@code true} to allow empty type bodies.
+     * @since 5.8
      */
     public void setAllowEmptyTypes(boolean allow) {
         allowEmptyTypes = allow;
@@ -660,6 +664,7 @@ public class WhitespaceAroundCheck extends AbstractCheck {
      * Setter to allow empty loop bodies.
      *
      * @param allow {@code true} to allow empty loops bodies.
+     * @since 5.8
      */
     public void setAllowEmptyLoops(boolean allow) {
         allowEmptyLoops = allow;
@@ -669,6 +674,7 @@ public class WhitespaceAroundCheck extends AbstractCheck {
      * Setter to allow empty lambda bodies.
      *
      * @param allow {@code true} to allow empty lambda expressions.
+     * @since 6.14
      */
     public void setAllowEmptyLambdas(boolean allow) {
         allowEmptyLambdas = allow;
@@ -678,6 +684,7 @@ public class WhitespaceAroundCheck extends AbstractCheck {
      * Setter to allow empty catch bodies.
      *
      * @param allow {@code true} to allow empty catch blocks.
+     * @since 7.6
      */
     public void setAllowEmptyCatches(boolean allow) {
         allowEmptyCatches = allow;


### PR DESCRIPTION
Part of #13421 

---
Adds `@since` to each property setter.

Taken from https://checkstyle.sourceforge.io/checks/whitespace/index.html