### PR TITLE
Issue #13421: Add since in javadoc of each property setter for filters

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/filters/SeverityMatchFilter.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/filters/SeverityMatchFilter.java
@@ -85,6 +85,7 @@ public class SeverityMatchFilter
      *
      * @param severity  The new severity level
      * @see SeverityLevel
+     * @since 3.2
      */
     public final void setSeverity(SeverityLevel severity) {
         this.severity = severity;
@@ -98,6 +99,7 @@ public class SeverityMatchFilter
      *
      * @param acceptOnMatch if true, accept on matches; if
      *     false, reject on matches.
+     * @since 3.2
      */
     public final void setAcceptOnMatch(boolean acceptOnMatch) {
         this.acceptOnMatch = acceptOnMatch;

--- a/src/main/java/com/puppycrawl/tools/checkstyle/filters/SuppressWithNearbyCommentFilter.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/filters/SuppressWithNearbyCommentFilter.java
@@ -319,6 +319,7 @@ public class SuppressWithNearbyCommentFilter
      * Setter to specify comment pattern to trigger filter to begin suppression.
      *
      * @param pattern a pattern.
+     * @since 5.0
      */
     public final void setCommentFormat(Pattern pattern) {
         commentFormat = pattern;
@@ -348,6 +349,7 @@ public class SuppressWithNearbyCommentFilter
      * Setter to specify check pattern to suppress.
      *
      * @param format a {@code String} value
+     * @since 5.0
      */
     public final void setCheckFormat(String format) {
         checkFormat = format;
@@ -357,6 +359,7 @@ public class SuppressWithNearbyCommentFilter
      * Setter to define message pattern to suppress.
      *
      * @param format a {@code String} value
+     * @since 5.0
      */
     public void setMessageFormat(String format) {
         messageFormat = format;
@@ -366,6 +369,7 @@ public class SuppressWithNearbyCommentFilter
      * Setter to specify check ID pattern to suppress.
      *
      * @param format a {@code String} value
+     * @since 8.24
      */
     public void setIdFormat(String format) {
         idFormat = format;
@@ -376,6 +380,7 @@ public class SuppressWithNearbyCommentFilter
      * of lines preceding/at/following the suppression comment.
      *
      * @param format a {@code String} value
+     * @since 5.0
      */
     public final void setInfluenceFormat(String format) {
         influenceFormat = format;
@@ -385,6 +390,7 @@ public class SuppressWithNearbyCommentFilter
      * Setter to control whether to check C++ style comments ({@code //}).
      *
      * @param checkCpp {@code true} if C++ comments are checked.
+     * @since 5.0
      */
     // -@cs[AbbreviationAsWordInName] We can not change it as,
     // check's property is a part of API (used in configurations).
@@ -396,6 +402,7 @@ public class SuppressWithNearbyCommentFilter
      * Setter to control whether to check C style comments ({@code &#47;* ... *&#47;}).
      *
      * @param checkC {@code true} if C comments are checked.
+     * @since 5.0
      */
     public void setCheckC(boolean checkC) {
         this.checkC = checkC;

--- a/src/main/java/com/puppycrawl/tools/checkstyle/filters/SuppressWithNearbyTextFilter.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/filters/SuppressWithNearbyTextFilter.java
@@ -339,6 +339,7 @@ public class SuppressWithNearbyTextFilter extends AbstractAutomaticBean implemen
      * Setter to specify nearby text pattern to trigger filter to begin suppression.
      *
      * @param pattern a {@code Pattern} value.
+     * @since 10.10.0
      */
     public final void setNearbyTextPattern(Pattern pattern) {
         nearbyTextPattern = pattern;
@@ -350,6 +351,7 @@ public class SuppressWithNearbyTextFilter extends AbstractAutomaticBean implemen
      * format of {@code $x} and be picked from line that matches {@code nearbyTextPattern}.
      *
      * @param pattern a {@code String} value.
+     * @since 10.10.0
      */
     public final void setCheckPattern(String pattern) {
         checkPattern = pattern;
@@ -359,6 +361,7 @@ public class SuppressWithNearbyTextFilter extends AbstractAutomaticBean implemen
      * Setter to specify check violation message pattern to suppress.
      *
      * @param pattern a {@code String} value.
+     * @since 10.10.0
      */
     public void setMessagePattern(String pattern) {
         messagePattern = pattern;
@@ -368,6 +371,7 @@ public class SuppressWithNearbyTextFilter extends AbstractAutomaticBean implemen
      * Setter to specify check ID pattern to suppress.
      *
      * @param pattern a {@code String} value.
+     * @since 10.10.0
      */
     public void setIdPattern(String pattern) {
         idPattern = pattern;
@@ -380,6 +384,7 @@ public class SuppressWithNearbyTextFilter extends AbstractAutomaticBean implemen
      * format of {@code $x} and be picked from line that matches {@code nearbyTextPattern}.
      *
      * @param format a {@code String} value.
+     * @since 10.10.0
      */
     public final void setLineRange(String format) {
         lineRange = format;

--- a/src/main/java/com/puppycrawl/tools/checkstyle/filters/SuppressWithPlainTextCommentFilter.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/filters/SuppressWithPlainTextCommentFilter.java
@@ -349,6 +349,7 @@ public class SuppressWithPlainTextCommentFilter extends AbstractAutomaticBean im
      * Setter to specify comment pattern to trigger filter to begin suppression.
      *
      * @param pattern off comment format pattern.
+     * @since 8.6
      */
     public final void setOffCommentFormat(Pattern pattern) {
         offCommentFormat = pattern;
@@ -358,6 +359,7 @@ public class SuppressWithPlainTextCommentFilter extends AbstractAutomaticBean im
      * Setter to specify comment pattern to trigger filter to end suppression.
      *
      * @param pattern  on comment format pattern.
+     * @since 8.6
      */
     public final void setOnCommentFormat(Pattern pattern) {
         onCommentFormat = pattern;
@@ -367,6 +369,7 @@ public class SuppressWithPlainTextCommentFilter extends AbstractAutomaticBean im
      * Setter to specify check pattern to suppress.
      *
      * @param format pattern for check format.
+     * @since 8.6
      */
     public final void setCheckFormat(String format) {
         checkFormat = format;
@@ -376,6 +379,7 @@ public class SuppressWithPlainTextCommentFilter extends AbstractAutomaticBean im
      * Setter to specify message pattern to suppress.
      *
      * @param format pattern for message format.
+     * @since 8.6
      */
     public final void setMessageFormat(String format) {
         messageFormat = format;
@@ -385,6 +389,7 @@ public class SuppressWithPlainTextCommentFilter extends AbstractAutomaticBean im
      * Setter to specify check ID pattern to suppress.
      *
      * @param format pattern for check ID format
+     * @since 8.24
      */
     public final void setIdFormat(String format) {
         idFormat = format;

--- a/src/main/java/com/puppycrawl/tools/checkstyle/filters/SuppressionCommentFilter.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/filters/SuppressionCommentFilter.java
@@ -558,6 +558,7 @@ public class SuppressionCommentFilter
      * Setter to specify comment pattern to trigger filter to begin suppression.
      *
      * @param pattern a pattern.
+     * @since 3.5
      */
     public final void setOffCommentFormat(Pattern pattern) {
         offCommentFormat = pattern;
@@ -567,6 +568,7 @@ public class SuppressionCommentFilter
      * Setter to specify comment pattern to trigger filter to end suppression.
      *
      * @param pattern a pattern.
+     * @since 3.5
      */
     public final void setOnCommentFormat(Pattern pattern) {
         onCommentFormat = pattern;
@@ -596,6 +598,7 @@ public class SuppressionCommentFilter
      * Setter to specify check pattern to suppress.
      *
      * @param format a {@code String} value
+     * @since 3.5
      */
     public final void setCheckFormat(String format) {
         checkFormat = format;
@@ -605,6 +608,7 @@ public class SuppressionCommentFilter
      * Setter to specify message pattern to suppress.
      *
      * @param format a {@code String} value
+     * @since 3.5
      */
     public void setMessageFormat(String format) {
         messageFormat = format;
@@ -614,6 +618,7 @@ public class SuppressionCommentFilter
      * Setter to specify check ID pattern to suppress.
      *
      * @param format a {@code String} value
+     * @since 8.24
      */
     public void setIdFormat(String format) {
         idFormat = format;
@@ -623,6 +628,7 @@ public class SuppressionCommentFilter
      * Setter to control whether to check C++ style comments ({@code //}).
      *
      * @param checkCpp {@code true} if C++ comments are checked.
+     * @since 3.5
      */
     // -@cs[AbbreviationAsWordInName] We can not change it as,
     // check's property is a part of API (used in configurations).
@@ -634,6 +640,7 @@ public class SuppressionCommentFilter
      * Setter to control whether to check C style comments ({@code &#47;* ... *&#47;}).
      *
      * @param checkC {@code true} if C comments are checked.
+     * @since 3.5
      */
     public void setCheckC(boolean checkC) {
         this.checkC = checkC;

--- a/src/main/java/com/puppycrawl/tools/checkstyle/filters/SuppressionFilter.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/filters/SuppressionFilter.java
@@ -239,6 +239,7 @@ public class SuppressionFilter
      * Setter to specify the location of the <em>suppressions XML document</em> file.
      *
      * @param fileName name of the suppressions file.
+     * @since 3.2
      */
     public void setFile(String fileName) {
         file = fileName;
@@ -251,6 +252,7 @@ public class SuppressionFilter
      * and file is not found, the filter accept all audit events.
      *
      * @param optional tells if config file existence is optional.
+     * @since 6.15
      */
     public void setOptional(boolean optional) {
         this.optional = optional;

--- a/src/main/java/com/puppycrawl/tools/checkstyle/filters/SuppressionSingleFilter.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/filters/SuppressionSingleFilter.java
@@ -235,6 +235,7 @@ public class SuppressionSingleFilter extends AbstractAutomaticBean implements Fi
      * event.
      *
      * @param files regular expression for filtered file names
+     * @since 8.23
      */
     public void setFiles(Pattern files) {
         this.files = files;
@@ -245,6 +246,7 @@ public class SuppressionSingleFilter extends AbstractAutomaticBean implements Fi
      * audit event.
      *
      * @param checks the name of the check
+     * @since 8.23
      */
     public void setChecks(String checks) {
         this.checks = Pattern.compile(checks);
@@ -255,6 +257,7 @@ public class SuppressionSingleFilter extends AbstractAutomaticBean implements Fi
      * an audit event.
      *
      * @param message the message of the check
+     * @since 8.23
      */
     public void setMessage(Pattern message) {
         this.message = message;
@@ -265,6 +268,7 @@ public class SuppressionSingleFilter extends AbstractAutomaticBean implements Fi
      * event.
      *
      * @param id the ID of the check
+     * @since 8.23
      */
     public void setId(String id) {
         this.id = id;
@@ -275,6 +279,7 @@ public class SuppressionSingleFilter extends AbstractAutomaticBean implements Fi
      * range of integers denoted by integer-integer.
      *
      * @param lines the lines of the check
+     * @since 8.23
      */
     public void setLines(String lines) {
         this.lines = lines;
@@ -285,6 +290,7 @@ public class SuppressionSingleFilter extends AbstractAutomaticBean implements Fi
      * range of integers denoted by integer-integer.
      *
      * @param columns the columns of the check
+     * @since 8.23
      */
     public void setColumns(String columns) {
         this.columns = columns;

--- a/src/main/java/com/puppycrawl/tools/checkstyle/filters/SuppressionXpathFilter.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/filters/SuppressionXpathFilter.java
@@ -525,6 +525,7 @@ public class SuppressionXpathFilter extends AbstractAutomaticBean implements
      * Setter to specify the location of the <em>suppressions XML document</em> file.
      *
      * @param fileName name of the suppressions file.
+     * @since 8.6
      */
     public void setFile(String fileName) {
         file = fileName;
@@ -537,6 +538,7 @@ public class SuppressionXpathFilter extends AbstractAutomaticBean implements
      * the filter accepts all audit events.
      *
      * @param optional tells if config file existence is optional.
+     * @since 8.6
      */
     public void setOptional(boolean optional) {
         this.optional = optional;

--- a/src/main/java/com/puppycrawl/tools/checkstyle/filters/SuppressionXpathSingleFilter.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/filters/SuppressionXpathSingleFilter.java
@@ -443,6 +443,7 @@ public class SuppressionXpathSingleFilter extends AbstractAutomaticBean implemen
      * associated with an audit event.
      *
      * @param files the name of the file
+     * @since 8.18
      */
     public void setFiles(String files) {
         if (files == null) {
@@ -458,6 +459,7 @@ public class SuppressionXpathSingleFilter extends AbstractAutomaticBean implemen
      * associated with an audit event.
      *
      * @param checks the name of the check
+     * @since 8.18
      */
     public void setChecks(String checks) {
         if (checks == null) {
@@ -473,6 +475,7 @@ public class SuppressionXpathSingleFilter extends AbstractAutomaticBean implemen
      * the check associated with an audit event.
      *
      * @param message the message of the check
+     * @since 8.18
      */
     public void setMessage(String message) {
         if (message == null) {
@@ -488,6 +491,7 @@ public class SuppressionXpathSingleFilter extends AbstractAutomaticBean implemen
      * with an audit event.
      *
      * @param id the ID of the check
+     * @since 8.18
      */
     public void setId(String id) {
         this.id = id;
@@ -497,6 +501,7 @@ public class SuppressionXpathSingleFilter extends AbstractAutomaticBean implemen
      * Setter to define a string xpath query.
      *
      * @param query the xpath query
+     * @since 8.18
      */
     public void setQuery(String query) {
         this.query = query;


### PR DESCRIPTION
Part of #13421 

---
Adds `@since` to each property setter.

Taken from https://checkstyle.sourceforge.io/filters/index.html