### PR TITLE
Issue #13421: Add since in javadoc of each property setter for filefilters

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/filefilters/BeforeExecutionExclusionFileFilter.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/filefilters/BeforeExecutionExclusionFileFilter.java
@@ -99,6 +99,7 @@ public final class BeforeExecutionExclusionFileFilter extends AbstractAutomaticB
      * Setter to define regular expression to match the file name against.
      *
      * @param fileNamePattern regular expression of the excluded file.
+     * @since 7.2
      */
     public void setFileNamePattern(Pattern fileNamePattern) {
         this.fileNamePattern = fileNamePattern;


### PR DESCRIPTION
Part of #13421 

---
Adds `@since` to each property setter.

Taken from https://checkstyle.sourceforge.io/filefilters/index.html