### PR TITLE
Issue #13205: Add links to examples' paragraphs

### DIFF
--- a/src/site/resources/css/site.css
+++ b/src/site/resources/css/site.css
@@ -42,7 +42,7 @@ h4 {
   float: right;
 }
 
-h2:hover .anchor, h3:hover .anchor {
+h2:hover .anchor, h3:hover .anchor, p[id^="Example"]:hover .anchor {
   visibility: visible;
 }
 

--- a/src/site/resources/js/anchors.js
+++ b/src/site/resources/js/anchors.js
@@ -56,6 +56,25 @@
             anchor.appendChild(a);
             anchorItem.appendChild(anchor);
         });
+
+        const exampleDivs = document.querySelectorAll('p[id^="Example"]');
+        [].forEach.call(exampleDivs, function (exampleDiv) {
+            const name = exampleDiv.id;
+            const link = "" + url + "#" + name + "";
+
+            const a = document.createElement("a");
+            a.setAttribute("href", link);
+
+            const image = document.createElement("img");
+            image.setAttribute("src", `${relativePath}/images/anchor.png`);
+
+            const anchor = document.createElement("div");
+            anchor.className = "anchor";
+
+            a.appendChild(image);
+            anchor.appendChild(a);
+            exampleDiv.appendChild(anchor);
+        });
     });
 }());
 


### PR DESCRIPTION
Resolves #13205

---

Adds anchors to paragraphs that have an ID starting with `Example`. For now, this applies to `WhitespaceAfter`'s paragraphs because only they have such IDs. But as we transfer more xdocs to templates, others will get IDs too.