### PR TITLE
Issue #13501: Kill mutation for CodePointUtil

### DIFF
--- a/config/checker-framework-suppressions/checker-index-suppressions.xml
+++ b/config/checker-framework-suppressions/checker-index-suppressions.xml
@@ -2764,17 +2764,6 @@
   </checkerFrameworkError>
 
   <checkerFrameworkError unstable="false">
-    <fileName>src/main/java/com/puppycrawl/tools/checkstyle/utils/CodePointUtil.java</fileName>
-    <specifier>argument</specifier>
-    <message>incompatible argument for parameter from of copyOfRange.</message>
-    <lineContent>return Arrays.copyOfRange(codePoints, startIndex, codePoints.length);</lineContent>
-    <details>
-      found   : int
-      required: @LTEqLengthOf(&quot;codePoints&quot;) int
-    </details>
-  </checkerFrameworkError>
-
-  <checkerFrameworkError unstable="false">
     <fileName>src/main/java/com/puppycrawl/tools/checkstyle/utils/CommonUtil.java</fileName>
     <specifier>argument</specifier>
     <message>incompatible argument for parameter beginIndex of substring.</message>

--- a/config/pitest-suppressions/pitest-utils-suppressions.xml
+++ b/config/pitest-suppressions/pitest-utils-suppressions.xml
@@ -171,59 +171,59 @@
 
 
 
-  <mutation unstable="false">
-    <sourceFile>CodePointUtil.java</sourceFile>
-    <mutatedClass>com.puppycrawl.tools.checkstyle.utils.CodePointUtil</mutatedClass>
-    <mutatedMethod>stripLeading</mutatedMethod>
-    <mutator>org.pitest.mutationtest.engine.gregor.mutators.NonVoidMethodCallMutator</mutator>
-    <description>removed call to com/puppycrawl/tools/checkstyle/utils/CommonUtil::isCodePointWhitespace</description>
-    <lineContent>&amp;&amp; CommonUtil.isCodePointWhitespace(codePoints, startIndex)) {</lineContent>
-  </mutation>
 
-  <mutation unstable="false">
-    <sourceFile>CodePointUtil.java</sourceFile>
-    <mutatedClass>com.puppycrawl.tools.checkstyle.utils.CodePointUtil</mutatedClass>
-    <mutatedMethod>stripLeading</mutatedMethod>
-    <mutator>org.pitest.mutationtest.engine.gregor.mutators.RemoveConditionalMutator_EQUAL_ELSE</mutator>
-    <description>removed conditional - replaced equality check with false</description>
-    <lineContent>&amp;&amp; CommonUtil.isCodePointWhitespace(codePoints, startIndex)) {</lineContent>
-  </mutation>
 
-  <mutation unstable="false">
-    <sourceFile>CodePointUtil.java</sourceFile>
-    <mutatedClass>com.puppycrawl.tools.checkstyle.utils.CodePointUtil</mutatedClass>
-    <mutatedMethod>stripLeading</mutatedMethod>
-    <mutator>org.pitest.mutationtest.engine.gregor.mutators.experimental.ArgumentPropagationMutator</mutator>
-    <description>replaced call to java/util/Arrays::copyOfRange with argument</description>
-    <lineContent>return Arrays.copyOfRange(codePoints, startIndex, codePoints.length);</lineContent>
-  </mutation>
 
-  <mutation unstable="false">
-    <sourceFile>CodePointUtil.java</sourceFile>
-    <mutatedClass>com.puppycrawl.tools.checkstyle.utils.CodePointUtil</mutatedClass>
-    <mutatedMethod>stripLeading</mutatedMethod>
-    <mutator>org.pitest.mutationtest.engine.gregor.mutators.RemoveConditionalMutator_ORDER_ELSE</mutator>
-    <description>removed conditional - replaced comparison check with false</description>
-    <lineContent>while (startIndex &lt; codePoints.length</lineContent>
-  </mutation>
 
-  <mutation unstable="false">
-    <sourceFile>CodePointUtil.java</sourceFile>
-    <mutatedClass>com.puppycrawl.tools.checkstyle.utils.CodePointUtil</mutatedClass>
-    <mutatedMethod>trim</mutatedMethod>
-    <mutator>org.pitest.mutationtest.engine.gregor.mutators.experimental.ArgumentPropagationMutator</mutator>
-    <description>replaced call to com/puppycrawl/tools/checkstyle/utils/CodePointUtil::stripTrailing with argument</description>
-    <lineContent>final int[] strippedCodePoints = stripTrailing(codePoints);</lineContent>
-  </mutation>
 
-  <mutation unstable="false">
-    <sourceFile>CodePointUtil.java</sourceFile>
-    <mutatedClass>com.puppycrawl.tools.checkstyle.utils.CodePointUtil</mutatedClass>
-    <mutatedMethod>trim</mutatedMethod>
-    <mutator>org.pitest.mutationtest.engine.gregor.mutators.experimental.ArgumentPropagationMutator</mutator>
-    <description>replaced call to com/puppycrawl/tools/checkstyle/utils/CodePointUtil::stripLeading with argument</description>
-    <lineContent>return stripLeading(strippedCodePoints);</lineContent>
-  </mutation>
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
 
   <mutation unstable="false">
     <sourceFile>CommonUtil.java</sourceFile>

--- a/pom.xml
+++ b/pom.xml
@@ -4842,10 +4842,6 @@
                 <param>
                   com.puppycrawl.tools.checkstyle.checks.whitespace.SingleSpaceSeparatorCheckTest
                 </param>
-                <!-- 35% coverage, 29% mutation in CodePointUtil -->
-                <param>
-                  com.puppycrawl.tools.checkstyle.checks.whitespace.SeparatorWrapCheckTest
-                </param>
                 <!-- 2% mutation in ScopeUtil -->
                 <param>
                   com.puppycrawl.tools.checkstyle.checks.javadoc.JavadocStyleCheckTest

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/whitespace/SeparatorWrapCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/whitespace/SeparatorWrapCheck.java
@@ -132,20 +132,20 @@ public class SeparatorWrapCheck
         final int colNo = ast.getColumnNo();
         final int lineNo = ast.getLineNo();
         final int[] currentLine = getLineCodePoints(lineNo - 1);
-        final int[] substringAfterToken = CodePointUtil.trim(
+        final boolean isLineEmptyAfterToken = CodePointUtil.isBlank(
                 Arrays.copyOfRange(currentLine, colNo + text.length(), currentLine.length)
         );
-        final int[] substringBeforeToken = CodePointUtil.trim(
+        final boolean isLineEmptyBeforeToken = CodePointUtil.isBlank(
                 Arrays.copyOfRange(currentLine, 0, colNo)
         );
 
-        if (option == WrapOption.EOL
-                && substringBeforeToken.length == 0) {
-            log(ast, MSG_LINE_PREVIOUS, text);
-        }
-        else if (option == WrapOption.NL
-                 && substringAfterToken.length == 0) {
+        if (option == WrapOption.NL
+                 && isLineEmptyAfterToken) {
             log(ast, MSG_LINE_NEW, text);
+        }
+        else if (option == WrapOption.EOL
+                && isLineEmptyBeforeToken) {
+            log(ast, MSG_LINE_PREVIOUS, text);
         }
     }
 

--- a/src/main/java/com/puppycrawl/tools/checkstyle/utils/CodePointUtil.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/utils/CodePointUtil.java
@@ -63,36 +63,10 @@ public final class CodePointUtil {
      */
     public static int[] stripTrailing(int... codePoints) {
         int lastIndex = codePoints.length;
-        while (lastIndex > 0 && CommonUtil.isCodePointWhitespace(codePoints, lastIndex - 1)) {
+        while (CommonUtil.isCodePointWhitespace(codePoints, lastIndex - 1)) {
             lastIndex--;
         }
         return Arrays.copyOfRange(codePoints, 0, lastIndex);
-    }
-
-    /**
-     * Removes leading whitespaces.
-     *
-     * @param codePoints array of unicode code points
-     * @return unicode code points array with leading whitespaces removed
-     */
-    public static int[] stripLeading(int... codePoints) {
-        int startIndex = 0;
-        while (startIndex < codePoints.length
-            && CommonUtil.isCodePointWhitespace(codePoints, startIndex)) {
-            startIndex++;
-        }
-        return Arrays.copyOfRange(codePoints, startIndex, codePoints.length);
-    }
-
-    /**
-     * Removes leading and trailing whitespaces.
-     *
-     * @param codePoints array of unicode code points
-     * @return unicode code points array with leading and trailing whitespaces removed
-     */
-    public static int[] trim(int... codePoints) {
-        final int[] strippedCodePoints = stripTrailing(codePoints);
-        return stripLeading(strippedCodePoints);
     }
 
     /**


### PR DESCRIPTION
Issue #13501: Kill mutation for CodePointUtil

Mutation introduction at https://github.com/checkstyle/checkstyle/commit/b8628532f12f46ab18e61372a997a4ca73e33d2a
@nrmancuso  is mandatory reviewer, as we allowed this code in PR year ago.

------

# Mutations
https://github.com/checkstyle/checkstyle/blob/bb64c20cbcf6e543b297b6e809f379bd8746b5e7/config/pitest-suppressions/pitest-utils-suppressions.xml#L174-L226

-----

# Explaintaion 

Both the method 
https://github.com/checkstyle/checkstyle/blob/79e760900c400c0ebac121a67517235529012eb3/src/main/java/com/puppycrawl/tools/checkstyle/utils/CodePointUtil.java#L64-L70
and
https://github.com/checkstyle/checkstyle/blob/79e760900c400c0ebac121a67517235529012eb3/src/main/java/com/puppycrawl/tools/checkstyle/utils/CodePointUtil.java#L78-L86
are same only logic has written differently.
in `stripTrailing` method loop start from lastIndex of array and finsih at index 0 and same but opposite in `stripLeading`
the condition of loop is `isCodePointWhitespace(codePoints, startIndex)` will fail in both the method if their is no whitespace


------

# Regression 

Report-1 :- https://checkstyle-diff-reports.s3.us-east-2.amazonaws.com/2237062_2023171438/reports/diff/index.html

Report-2 :- https://checkstyle-diff-reports.s3.us-east-2.amazonaws.com/2237062_2023180212/reports/diff/index.html

Report-3 :- https://checkstyle-diff-reports.s3.us-east-2.amazonaws.com/2237062_2023191958/reports/diff/index.html

Report-4 :- 

Report-5 :-

------

Diff Regression config: https://gist.githubusercontent.com/Kevin222004/66e91526d84b11d76ed35dc61f651108/raw/01d1012ebdb5cae259e1f1775c9b25d68c41c881/codeutil2.xml
Diff Regression projects: https://gist.githubusercontent.com/Kevin222004/2207ddd139a1721d00b0e6b312bc3f03/raw/a0b63175830fccda7c242058d8f513d61d4dce0d/util1.properties
Report label: Aug-28-2.2
