### PR TITLE
Issue #13501: Kill mutation for CommonUtil-2

### DIFF
--- a/config/pitest-suppressions/pitest-utils-suppressions.xml
+++ b/config/pitest-suppressions/pitest-utils-suppressions.xml
@@ -234,23 +234,23 @@
     <lineContent>if (index == -1) {</lineContent>
   </mutation>
 
-  <mutation unstable="false">
-    <sourceFile>CommonUtil.java</sourceFile>
-    <mutatedClass>com.puppycrawl.tools.checkstyle.utils.CommonUtil</mutatedClass>
-    <mutatedMethod>isName</mutatedMethod>
-    <mutator>org.pitest.mutationtest.engine.gregor.mutators.NonVoidMethodCallMutator</mutator>
-    <description>removed call to java/lang/String::isEmpty</description>
-    <lineContent>boolean isName = !str.isEmpty();</lineContent>
-  </mutation>
 
-  <mutation unstable="false">
-    <sourceFile>CommonUtil.java</sourceFile>
-    <mutatedClass>com.puppycrawl.tools.checkstyle.utils.CommonUtil</mutatedClass>
-    <mutatedMethod>isName</mutatedMethod>
-    <mutator>org.pitest.mutationtest.engine.gregor.mutators.RemoveConditionalMutator_EQUAL_IF</mutator>
-    <description>removed conditional - replaced equality check with true</description>
-    <lineContent>boolean isName = !str.isEmpty();</lineContent>
-  </mutation>
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
 
   <mutation unstable="false">
     <sourceFile>CommonUtil.java</sourceFile>

--- a/src/main/java/com/puppycrawl/tools/checkstyle/utils/CommonUtil.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/utils/CommonUtil.java
@@ -579,11 +579,14 @@ public final class CommonUtil {
      * @return true when the given string contains valid name.
      */
     public static boolean isName(String str) {
-        boolean isName = !str.isEmpty();
+        boolean isName = false;
 
         final String[] identifiers = str.split("\\.", -1);
-        for (int i = 0; isName && i < identifiers.length; i++) {
-            isName = isIdentifier(identifiers[i]);
+        for (String identifier : identifiers) {
+            isName = isIdentifier(identifier);
+            if (!isName) {
+                break;
+            }
         }
 
         return isName;


### PR DESCRIPTION
Issue #13501: Kill mutation for CommonUtil-2

------

# Mutation 
https://github.com/checkstyle/checkstyle/blob/bb64c20cbcf6e543b297b6e809f379bd8746b5e7/config/pitest-suppressions/pitest-utils-suppressions.xml#L246-L262

------

# Explaination
This method is used in https://github.com/checkstyle/checkstyle/blob/f9df51921515e7ee48f2a0fc3bd35a4c36ad2ed0/src/main/java/com/puppycrawl/tools/checkstyle/checks/metrics/AbstractClassCouplingCheck.java#L173-L175
This method is used to set the property excludedPackages lets suppose if it is set empty then in filter commonUtil.isName never be call so the string never be empty it always true

---------

Diff Regression config: https://gist.githubusercontent.com/Kevin222004/ccd588c72cd541ff98736f08dc687e43/raw/28c14aa0fdf848a5191761ffe4cbbea8c860a0a9/gist.xml
Diff Regression projects: https://gist.githubusercontent.com/Kevin222004/9600f179b602d4c971bdb0a050099005/raw/360a95ed7bb60d7a0956e531199d484c4d6f6617/test-projects.properties
Report label: New-Regression-2