### PR TITLE
minor: avoid flaky test in nondex execution

### DIFF
--- a/.ci/validation.sh
+++ b/.ci/validation.sh
@@ -88,9 +88,14 @@ eclipse-static-analysis)
   ;;
 
 nondex)
-  # Below we exclude test that fails due to picocli library usage
-  mvn -e --no-transfer-progress --fail-never clean nondex:nondex -DargLine='-Xms1024m -Xmx2048m' \
-    -Dtest=!JavadocPropertiesGeneratorTest#testNonExistentArgument
+  # Exclude test that fails due to picocli library usage
+  SKIPPED_TESTS='!JavadocPropertiesGeneratorTest#testNonExistentArgument,'
+  # Exclude test that fails due to stackoverflow error
+  SKIPPED_TESTS+='!SingleSpaceSeparatorCheckTest#testNoStackoverflowError'
+  mvn -e --no-transfer-progress \
+    --fail-never clean nondex:nondex -DargLine='-Xms1024m -Xmx2048m' \
+    -Dtest="$SKIPPED_TESTS"
+
   mkdir -p .ci-temp
   grep -RlE 'td class=.x' .nondex/ | cat > .ci-temp/output.txt
   RESULT=$(cat .ci-temp/output.txt | wc -c)


### PR DESCRIPTION
Noticed at https://checkstyle.semaphoreci.com/jobs/b360caba-c32a-48f7-8405-eab7c233924c and elsewhere, nondex has become unstable for this test.


```
java.util.concurrent.ExecutionException: java.lang.Error: Error was thrown while processing /home/semaphore/checkstyle/src/test/resources/com/puppycrawl/tools/checkstyle/checks/whitespace/singlespaceseparator/InputSingleSpaceSeparatorNoStackoverflowError.java13:23
	at java.base/java.util.concurrent.FutureTask.report(FutureTask.java:122)13:23
	at java.base/java.util.concurrent.FutureTask.get(FutureTask.java:205)13:23
	at com.puppycrawl.tools.checkstyle.internal.utils.TestUtil.getResultWithLimitedResources(TestUtil.java:258)13:23
	at com.puppycrawl.tools.checkstyle.AbstractModuleTestSupport.verifyWithLimitedResources(AbstractModuleTestSupport.java:390)13:23
	at com.puppycrawl.tools.checkstyle.checks.whitespace.SingleSpaceSeparatorCheckTest.testNoStackoverflowError(SingleSpaceSeparatorCheckTest.java:46)13:23
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)13:23
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)13:23
	at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)13:23
	at java.base/java.lang.reflect.Method.invoke(Method.java:566)13:23
	at org.junit.platform.commons.util.ReflectionUtils.invokeMethod(ReflectionUtils.java:727)13:23
	at org.junit.jupiter.engine.execution.MethodInvocation.proceed(MethodInvocation.java:60)13:23
	at org.junit.jupiter.engine.execution.InvocationInterceptorChain$ValidatingInvocation.proceed(InvocationInterceptorChain.java:131)13:23
	at org.junit.jupiter.engine.extension.TimeoutExtension.intercept(TimeoutExtension.java:156)13:23
	at org.junit.jupiter.engine.extension.TimeoutExtension.interceptTestableMethod(TimeoutExtension.java:147)13:23
	at org.junit.jupiter.engine.extension.TimeoutExtension.interceptTestMethod(TimeoutExtension.java:86)13:23
	at org.junit.jupiter.engine.execution.InterceptingExecutableInvoker$ReflectiveInterceptorCall.lambda$ofVoidMethod$0(InterceptingExecutableInvoker.java:103)13:23
	at org.junit.jupiter.engine.execution.InterceptingExecutableInvoker.lambda$invoke$0(InterceptingExecutableInvoker.java:93)13:23
	at org.junit.jupiter.engine.execution.InvocationInterceptorChain$InterceptedInvocation.proceed(InvocationInterceptorChain.java:106)13:23
	at org.junit.jupiter.engine.execution.InvocationInterceptorChain.proceed(InvocationInterceptorChain.java:64)13:23
	at org.junit.jupiter.engine.execution.InvocationInterceptorChain.chainAndInvoke(InvocationInterceptorChain.java:45)13:23
	at org.junit.jupiter.engine.execution.InvocationInterceptorChain.invoke(InvocationInterceptorChain.java:37)13:23
	at org.junit.jupiter.engine.execution.InterceptingExecutableInvoker.invoke(InterceptingExecutableInvoker.java:92)13:23
	at org.junit.jupiter.engine.execution.InterceptingExecutableInvoker.invoke(InterceptingExecutableInvoker.java:86)13:23
	at org.junit.jupiter.engine.descriptor.TestMethodTestDescriptor.lambda$invokeTestMethod$7(TestMethodTestDescriptor.java:217)13:23
	at org.junit.platform.engine.support.hierarchical.ThrowableCollector.execute(ThrowableCollector.java:73)13:23
	at org.junit.jupiter.engine.descriptor.TestMethodTestDescriptor.invokeTestMethod(TestMethodTestDescriptor.java:213)13:23
	at org.junit.jupiter.engine.descriptor.TestMethodTestDescriptor.execute(TestMethodTestDescriptor.java:138)13:23
	at org.junit.jupiter.engine.descriptor.TestMethodTestDescriptor.execute(TestMethodTestDescriptor.java:68)13:23
	at org.junit.platform.engine.support.hierarchical.NodeTestTask.lambda$executeRecursively$6(NodeTestTask.java:151)13:23
	at org.junit.platform.engine.support.hierarchical.ThrowableCollector.execute(ThrowableCollector.java:73)13:23
	at org.junit.platform.engine.support.hierarchical.NodeTestTask.lambda$executeRecursively$8(NodeTestTask.java:141)13:23
	at org.junit.platform.engine.support.hierarchical.Node.around(Node.java:137)13:23
	at org.junit.platform.engine.support.hierarchical.NodeTestTask.lambda$executeRecursively$9(NodeTestTask.java:139)13:23
	at org.junit.platform.engine.support.hierarchical.ThrowableCollector.execute(ThrowableCollector.java:73)13:23
	at org.junit.platform.engine.support.hierarchical.NodeTestTask.executeRecursively(NodeTestTask.java:138)13:23
	at org.junit.platform.engine.support.hierarchical.NodeTestTask.execute(NodeTestTask.java:95)13:23
	at java.base/java.util.ArrayList.forEach(ArrayList.java:1541)13:23
	at org.junit.platform.engine.support.hierarchical.SameThreadHierarchicalTestExecutorService.invokeAll(SameThreadHierarchicalTestExecutorService.java:41)13:23
	at org.junit.platform.engine.support.hierarchical.NodeTestTask.lambda$executeRecursively$6(NodeTestTask.java:155)13:23
	at org.junit.platform.engine.support.hierarchical.ThrowableCollector.execute(ThrowableCollector.java:73)13:23
	at org.junit.platform.engine.support.hierarchical.NodeTestTask.lambda$executeRecursively$8(NodeTestTask.java:141)13:23
	at org.junit.platform.engine.support.hierarchical.Node.around(Node.java:137)13:23
	at org.junit.platform.engine.support.hierarchical.NodeTestTask.lambda$executeRecursively$9(NodeTestTask.java:139)13:23
	at org.junit.platform.engine.support.hierarchical.ThrowableCollector.execute(ThrowableCollector.java:73)13:23
	at org.junit.platform.engine.support.hierarchical.NodeTestTask.executeRecursively(NodeTestTask.java:138)13:23
	at org.junit.platform.engine.support.hierarchical.NodeTestTask.execute(NodeTestTask.java:95)13:23
	at java.base/java.util.ArrayList.forEach(ArrayList.java:1541)13:23
	at org.junit.platform.engine.support.hierarchical.SameThreadHierarchicalTestExecutorService.invokeAll(SameThreadHierarchicalTestExecutorService.java:41)13:23
	at org.junit.platform.engine.support.hierarchical.NodeTestTask.lambda$executeRecursively$6(NodeTestTask.java:155)13:23
	at org.junit.platform.engine.support.hierarchical.ThrowableCollector.execute(ThrowableCollector.java:73)13:23
	at org.junit.platform.engine.support.hierarchical.NodeTestTask.lambda$executeRecursively$8(NodeTestTask.java:141)13:23
	at org.junit.platform.engine.support.hierarchical.Node.around(Node.java:137)13:23
	at org.junit.platform.engine.support.hierarchical.NodeTestTask.lambda$executeRecursively$9(NodeTestTask.java:139)13:23
	at org.junit.platform.engine.support.hierarchical.ThrowableCollector.execute(ThrowableCollector.java:73)13:23
	at org.junit.platform.engine.support.hierarchical.NodeTestTask.executeRecursively(NodeTestTask.java:138)13:23
	at org.junit.platform.engine.support.hierarchical.NodeTestTask.execute(NodeTestTask.java:95)13:23
	at org.junit.platform.engine.support.hierarchical.SameThreadHierarchicalTestExecutorService.submit(SameThreadHierarchicalTestExecutorService.java:35)13:23
	at org.junit.platform.engine.support.hierarchical.HierarchicalTestExecutor.execute(HierarchicalTestExecutor.java:57)13:23
	at org.junit.platform.engine.support.hierarchical.HierarchicalTestEngine.execute(HierarchicalTestEngine.java:54)13:23
	at org.junit.platform.launcher.core.EngineExecutionOrchestrator.execute(EngineExecutionOrchestrator.java:147)13:23
	at org.junit.platform.launcher.core.EngineExecutionOrchestrator.execute(EngineExecutionOrchestrator.java:127)13:23
	at org.junit.platform.launcher.core.EngineExecutionOrchestrator.execute(EngineExecutionOrchestrator.java:90)13:23
	at org.junit.platform.launcher.core.EngineExecutionOrchestrator.lambda$execute$0(EngineExecutionOrchestrator.java:55)13:23
	at org.junit.platform.launcher.core.EngineExecutionOrchestrator.withInterceptedStreams(EngineExecutionOrchestrator.java:102)13:23
	at org.junit.platform.launcher.core.EngineExecutionOrchestrator.execute(EngineExecutionOrchestrator.java:54)13:23
	at org.junit.platform.launcher.core.DefaultLauncher.execute(DefaultLauncher.java:114)13:23
	at org.junit.platform.launcher.core.DefaultLauncher.execute(DefaultLauncher.java:86)13:23
	at org.junit.platform.launcher.core.DefaultLauncherSession$DelegatingLauncher.execute(DefaultLauncherSession.java:86)13:23
	at org.apache.maven.surefire.junitplatform.LazyLauncher.execute(LazyLauncher.java:56)13:23
	at org.apache.maven.surefire.junitplatform.JUnitPlatformProvider.execute(JUnitPlatformProvider.java:184)13:23
	at org.apache.maven.surefire.junitplatform.JUnitPlatformProvider.invokeAllTests(JUnitPlatformProvider.java:148)13:23
	at org.apache.maven.surefire.junitplatform.JUnitPlatformProvider.invoke(JUnitPlatformProvider.java:122)13:23
	at org.apache.maven.surefire.booter.ForkedBooter.runSuitesInProcess(ForkedBooter.java:385)13:23
	at org.apache.maven.surefire.booter.ForkedBooter.execute(ForkedBooter.java:162)13:23
	at org.apache.maven.surefire.booter.ForkedBooter.run(ForkedBooter.java:507)13:23
	at org.apache.maven.surefire.booter.ForkedBooter.main(ForkedBooter.java:495)13:23
Caused by: java.lang.Error: Error was thrown while processing /home/semaphore/checkstyle/src/test/resources/com/puppycrawl/tools/checkstyle/checks/whitespace/singlespaceseparator/InputSingleSpaceSeparatorNoStackoverflowError.java13:23
	at com.puppycrawl.tools.checkstyle.Checker.processFiles(Checker.java:314)13:23
	at com.puppycrawl.tools.checkstyle.Checker.process(Checker.java:223)13:23
	at com.puppycrawl.tools.checkstyle.AbstractModuleTestSupport.getActualViolationsForFile(AbstractModuleTestSupport.java:460)13:23
	at com.puppycrawl.tools.checkstyle.AbstractModuleTestSupport.verifyViolations(AbstractModuleTestSupport.java:427)13:23
	at com.puppycrawl.tools.checkstyle.AbstractModuleTestSupport.verifyWithInlineConfigParser(AbstractModuleTestSupport.java:237)13:23
	at com.puppycrawl.tools.checkstyle.AbstractModuleTestSupport.lambda$verifyWithLimitedResources$2(AbstractModuleTestSupport.java:391)13:23
	at java.base/java.util.concurrent.FutureTask.run(FutureTask.java:264)13:23
	at java.base/java.lang.Thread.run(Thread.java:829)13:23
Caused by: java.lang.StackOverflowError13:23
	at org.antlr.v4.runtime.atn.ParserATNSimulator.closureCheckingStopState(ParserATNSimulator.java:1516)13:23
	at org.antlr.v4.runtime.atn.ParserATNSimulator.closure_(ParserATNSimulator.java:1589)13:23
	at org.antlr.v4.runtime.atn.ParserATNSimulator.closureCheckingStopState(ParserATNSimulator.java:1516)13:23
	at org.antlr.v4.runtime.atn.ParserATNSimulator.closure_(ParserATNSimulator.java:1589)13:23
	at org.antlr.v4.runtime.atn.ParserATNSimulator.closureCheckingStopState(ParserATNSimulator.java:1516)13:23
	at org.antlr.v4.runtime.atn.ParserATNSimulator.closure_(ParserATNSimulator.java:1589)13:23
	at org.antlr.v4.runtime.atn.ParserATNSimulator.closureCheckingStopState(ParserATNSimulator.java:1516)13:23
	at org.antlr.v4.runtime.atn.ParserATNSimulator.closure_(ParserATNSimulator.java:1589)13:23
	at org.antlr.v4.runtime.atn.ParserATNSimulator.closureCheckingStopState(ParserATNSimulator.java:1516)13:23
	at org.antlr.v4.runtime.atn.ParserATNSimulator.closure_(ParserATNSimulator.java:1589)13:23
	at org.antlr.v4.runtime.atn.ParserATNSimulator.closureCheckingStopState(ParserATNSimulator.java:1516)13:23
	at org.antlr.v4.runtime.atn.ParserATNSimulator.closureCheckingStopState(ParserATNSimulator.java:1499)13:23
	at org.antlr.v4.runtime.atn.ParserATNSimulator.closure_(ParserATNSimulator.java:1589)13:23
	at org.antlr.v4.runtime.atn.ParserATNSimulator.closureCheckingStopState(ParserATNSimulator.java:1516)13:23
	at org.antlr.v4.runtime.atn.ParserATNSimulator.closure_(ParserATNSimulator.java:1589)13:23
	at org.antlr.v4.runtime.atn.ParserATNSimulator.closureCheckingStopState(ParserATNSimulator.java:1516)13:23
	at org.antlr.v4.runtime.atn.ParserATNSimulator.closure_(ParserATNSimulator.java:1589)13:23
	at org.antlr.v4.runtime.atn.ParserATNSimulator.closureCheckingStopState(ParserATNSimulator.java:1516)13:23
	at org.antlr.v4.runtime.atn.ParserATNSimulator.closure_(ParserATNSimulator.java:1589)13:23
	at org.antlr.v4.runtime.atn.ParserATNSimulator.closureCheckingStopState(ParserATNSimulator.java:1516)13:23
 13:23
	at org.antlr.v4.runtime.atn.ParserATNSimulator.closureCheckingStopState(ParserATNSimulator.java:1516)13:23
	at org.antlr.v4.runtime.atn.ParserATNSimulator.closure_(ParserATNSimulator.java:1589)13:23
	at org.antlr.v4.runtime.atn.ParserATNSimulator.closureCheckingStopState(ParserATNSimulator.java:1516)13:23
	at org.antlr.v4.runtime.atn.ParserATNSimulator.closure_(ParserATNSimulator.java:1589)13:23
	at org.antlr.v4.runtime.atn.ParserATNSimulator.closureCheckingStopState(ParserATNSimulator.java:1516)13:23
	at org.antlr.v4.runtime.atn.ParserATNSimulator.closure_(ParserATNSimulator.java:1589)13:23
	at org.antlr.v4.runtime.atn.ParserATNSimulator.closureCheckingStopState(ParserATNSimulator.java:1516)13:23
	at org.antlr.v4.runtime.atn.ParserATNSimulator.closure_(ParserATNSimulator.java:1589)13:23
	at org.antlr.v4.runtime.atn.ParserATNSimulator.closureCheckingStopState(ParserATNSimulator.java:1516)13:23
	at org.antlr.v4.runtime.atn.ParserATNSimulator.closure_(ParserATNSimulator.java:1589)13:23
	at org.antlr.v4.runtime.atn.ParserATNSimulator.closureCheckingStopState(ParserATNSimulator.java:1516)13:23
	at org.antlr.v4.runtime.atn.ParserATNSimulator.closure_(ParserATNSimulator.java:1589)13:23
	at org.antlr.v4.runtime.atn.ParserATNSimulator.closureCheckingStopState(ParserATNSimulator.java:1516)13:23
	at org.antlr.v4.runtime.atn.ParserATNSimulator.closure_(ParserATNSimulator.java:1589)13:23
	at org.antlr.v4.runtime.atn.ParserATNSimulator.closureCheckingStopState(ParserATNSimulator.java:1516)13:23
	at org.antlr.v4.runtime.atn.ParserATNSimulator.closure_(ParserATNSimulator.java:1589)13:23
	at org.antlr.v4.runtime.atn.ParserATNSimulator.closureCheckingStopState(ParserATNSimulator.java:1516)13:23
	at org.antlr.v4.runtime.atn.ParserATNSimulator.closure_(ParserATNSimulator.java:1589)13:23
	at org.antlr.v4.runtime.atn.ParserATNSimulator.closureCheckingStopState(ParserATNSimulator.java:1516)13:23
	at org.antlr.v4.runtime.atn.ParserATNSimulator.closure_(ParserATNSimulator.java:1589)13:23
	at org.antlr.v4.runtime.atn.ParserATNSimulator.closureCheckingStopState(ParserATNSimulator.java:1516)13:23
	at org.antlr.v4.runtime.atn.ParserATNSimulator.closure_(ParserATNSimulator.java:1589)13:23
	at org.antlr.v4.runtime.atn.ParserATNSimulator.closureCheckingStopState(ParserATNSimulator.java:1516)13:23
	at org.antlr.v4.runtime.atn.ParserATNSimulator.closure_(ParserATNSimulator.java:1589)13:23
	at org.antlr.v4.runtime.atn.ParserATNSimulator.closureCheckingStopState(ParserATNSimulator.java:1516)13:23
	at org.antlr.v4.runtime.atn.ParserATNSimulator.closure_(ParserATNSimulator.java:1589)13:23
 13:23
	at org.antlr.v4.runtime.atn.ParserATNSimulator.closure_(ParserATNSimulator.java:1589)13:23
	at org.antlr.v4.runtime.atn.ParserATNSimulator.closureCheckingStopState(ParserATNSimulator.java:1516)13:23
	at org.antlr.v4.runtime.atn.ParserATNSimulator.closure_(ParserATNSimulator.java:1589)13:23
	at org.antlr.v4.runtime.atn.ParserATNSimulator.closureCheckingStopState(ParserATNSimulator.java:1516)13:23
	at org.antlr.v4.runtime.atn.ParserATNSimulator.closure_(ParserATNSimulator.java:1589)13:23
	at org.antlr.v4.runtime.atn.ParserATNSimulator.closureCheckingStopState(ParserATNSimulator.java:1516)13:23
	at org.antlr.v4.runtime.atn.ParserATNSimulator.closure_(ParserATNSimulator.java:1589)13:23
	at org.antlr.v4.runtime.atn.ParserATNSimulator.closureCheckingStopState(ParserATNSimulator.java:1516)13:23
	at org.antlr.v4.runtime.atn.ParserATNSimulator.closure_(ParserATNSimulator.java:1589)13:23
	at org.antlr.v4.runtime.atn.ParserATNSimulator.closureCheckingStopState(ParserATNSimulator.java:1516)13:23
	at org.antlr.v4.runtime.atn.ParserATNSimulator.closure_(ParserATNSimulator.java:1589)13:23
	at org.antlr.v4.runtime.atn.ParserATNSimulator.closureCheckingStopState(ParserATNSimulator.java:1516)13:23
	at org.antlr.v4.runtime.atn.ParserATNSimulator.closure_(ParserATNSimulator.java:1589)13:23
	at org.antlr.v4.runtime.atn.ParserATNSimulator.closureCheckingStopState(ParserATNSimulator.java:1516)13:23
	at org.antlr.v4.runtime.atn.ParserATNSimulator.closure_(ParserATNSimulator.java:1589)13:23
	at org.antlr.v4.runtime.atn.ParserATNSimulator.closureCheckingStopState(ParserATNSimulator.java:1516)13:23
	at org.antlr.v4.runtime.atn.ParserATNSimulator.closure_(ParserATNSimulator.java:1589)13:23
	at org.antlr.v4.runtime.atn.ParserATNSimulator.closureCheckingStopState(ParserATNSimulator.java:1516)13:23
	at org.antlr.v4.runtime.atn.ParserATNSimulator.closure_(ParserATNSimulator.java:1589)13:23
	at org.antlr.v4.runtime.atn.ParserATNSimulator.closureCheckingStopState(ParserATNSimulator.java:1516)13:23
	at org.antlr.v4.runtime.atn.ParserATNSimulator.closure_(ParserATNSimulator.java:1589)13:23
	at org.antlr.v4.runtime.atn.ParserATNSimulator.closureCheckingStopState(ParserATNSimulator.java:1516)13:23
 13:23
	at org.antlr.v4.runtime.atn.ParserATNSimulator.closureCheckingStopState(ParserATNSimulator.java:1516)13:23
	at org.antlr.v4.runtime.atn.ParserATNSimulator.closure_(ParserATNSimulator.java:1589)13:23
	at org.antlr.v4.runtime.atn.ParserATNSimulator.closureCheckingStopState(ParserATNSimulator.java:1516)13:23
	at org.antlr.v4.runtime.atn.ParserATNSimulator.closure_(ParserATNSimulator.java:1589)13:23
	at org.antlr.v4.runtime.atn.ParserATNSimulator.closureCheckingStopState(ParserATNSimulator.java:1516)13:23
	at org.antlr.v4.runtime.atn.ParserATNSimulator.closure_(ParserATNSimulator.java:1589)13:23
	at org.antlr.v4.runtime.atn.ParserATNSimulator.closureCheckingStopState(ParserATNSimulator.java:1516)13:23
	at org.antlr.v4.runtime.atn.ParserATNSimulator.closure_(ParserATNSimulator.java:1589)13:23
	at 

```