### PR TITLE
Issue #13501: Kill mutation for ScopeUtil-2

### DIFF
--- a/config/pitest-suppressions/pitest-utils-suppressions.xml
+++ b/config/pitest-suppressions/pitest-utils-suppressions.xml
@@ -297,14 +297,14 @@
     <lineContent>for (DetailAST token = aMods.getFirstChild(); token != null &amp;&amp; result == null;</lineContent>
   </mutation>
 
-  <mutation unstable="false">
-    <sourceFile>ScopeUtil.java</sourceFile>
-    <mutatedClass>com.puppycrawl.tools.checkstyle.utils.ScopeUtil</mutatedClass>
-    <mutatedMethod>getSurroundingScope</mutatedMethod>
-    <mutator>org.pitest.mutationtest.engine.gregor.mutators.experimental.NakedReceiverMutator</mutator>
-    <description>replaced call to com/puppycrawl/tools/checkstyle/api/DetailAST::getParent with receiver</description>
-    <lineContent>for (DetailAST token = node.getParent();</lineContent>
-  </mutation>
+
+
+
+
+
+
+
+
 
   <mutation unstable="false">
     <sourceFile>ScopeUtil.java</sourceFile>

--- a/src/main/java/com/puppycrawl/tools/checkstyle/utils/ScopeUtil.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/utils/ScopeUtil.java
@@ -131,7 +131,7 @@ public final class ScopeUtil {
      */
     public static Scope getSurroundingScope(DetailAST node) {
         Scope returnValue = null;
-        for (DetailAST token = node.getParent();
+        for (DetailAST token = node;
              token != null;
              token = token.getParent()) {
             final int type = token.getType();


### PR DESCRIPTION
Issue #13501: Kill mutation for ScopeUtil-2

------

# Mutation 
https://github.com/checkstyle/checkstyle/blob/bb64c20cbcf6e543b297b6e809f379bd8746b5e7/config/pitest-suppressions/pitest-utils-suppressions.xml#L318-L325

------

# Explaination

loop run 1 time more

-------

# Regression 

Report-1 :- https://checkstyle-diff-reports.s3.us-east-2.amazonaws.com/d904475_2023065751/reports/diff/index.html

Report-2 :- 

----------------

Diff Regression config: https://gist.githubusercontent.com/Kevin222004/b3211ffcecabf39f8245becc0c75cded/raw/fb0cfe706bdefa9a68688451cfe8145817dc4a01/su2.xml
Diff Regression projects: https://gist.githubusercontent.com/Kevin222004/89f2012d909bd657a467974a272f923c/raw/c23f3e4c51d579a4f6ef34a1e491c0f781e14732/project1.properties
Report label: Report-Aug-4-2

