### PR TITLE
Issue #13484: Fix package/resource location in example tests

### DIFF
--- a/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/AbstractExamplesModuleTestSupport.java
+++ b/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/AbstractExamplesModuleTestSupport.java
@@ -17,26 +17,13 @@
 // Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 ///////////////////////////////////////////////////////////////////////////////////////////////
 
-package com.puppycrawl.tools.checkstyle.checks.design;
+package com.puppycrawl.tools.checkstyle;
 
-import org.junit.jupiter.api.Disabled;
-import org.junit.jupiter.api.Test;
+public abstract class AbstractExamplesModuleTestSupport extends AbstractModuleTestSupport {
 
-import com.puppycrawl.tools.checkstyle.AbstractExamplesModuleTestSupport;
-
-@Disabled("until https://github.com/checkstyle/checkstyle/issues/13345")
-public class FinalClassCheckExamplesTest extends AbstractExamplesModuleTestSupport {
     @Override
-    protected String getPackageLocation() {
-        return "com/puppycrawl/tools/checkstyle/checks/design/finalclass";
+    protected String getResourceLocation() {
+        return "xdocs-examples";
     }
 
-    @Test
-    public void testExample1() throws Exception {
-        final String[] expected = {
-
-        };
-
-        verifyWithInlineConfigParser(getPath("Example1.txt"), expected);
-    }
 }

--- a/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/checks/annotation/AnnotationOnSameLineCheckExamplesTest.java
+++ b/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/checks/annotation/AnnotationOnSameLineCheckExamplesTest.java
@@ -22,17 +22,12 @@ package com.puppycrawl.tools.checkstyle.checks.annotation;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
-import com.puppycrawl.tools.checkstyle.AbstractModuleTestSupport;
+import com.puppycrawl.tools.checkstyle.AbstractExamplesModuleTestSupport;
 
 @Disabled("until https://github.com/checkstyle/checkstyle/issues/13345")
-public class AnnotationOnSameLineCheckExamplesTest extends AbstractModuleTestSupport {
+public class AnnotationOnSameLineCheckExamplesTest extends AbstractExamplesModuleTestSupport {
     @Override
     protected String getPackageLocation() {
-        return "xdocs-examples";
-    }
-
-    @Override
-    protected String getResourceLocation() {
         return "com/puppycrawl/tools/checkstyle/checks/annotation/annotationonsameline";
     }
 

--- a/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/checks/annotation/AnnotationUseStyleCheckExamplesTest.java
+++ b/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/checks/annotation/AnnotationUseStyleCheckExamplesTest.java
@@ -22,17 +22,12 @@ package com.puppycrawl.tools.checkstyle.checks.annotation;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
-import com.puppycrawl.tools.checkstyle.AbstractModuleTestSupport;
+import com.puppycrawl.tools.checkstyle.AbstractExamplesModuleTestSupport;
 
 @Disabled("until https://github.com/checkstyle/checkstyle/issues/13345")
-public class AnnotationUseStyleCheckExamplesTest extends AbstractModuleTestSupport {
+public class AnnotationUseStyleCheckExamplesTest extends AbstractExamplesModuleTestSupport {
     @Override
     protected String getPackageLocation() {
-        return "xdocs-examples";
-    }
-
-    @Override
-    protected String getResourceLocation() {
         return "com/puppycrawl/tools/checkstyle/checks/annotation/annotationusestyle";
     }
 

--- a/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/checks/annotation/MissingDeprecatedCheckExamplesTest.java
+++ b/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/checks/annotation/MissingDeprecatedCheckExamplesTest.java
@@ -22,17 +22,12 @@ package com.puppycrawl.tools.checkstyle.checks.annotation;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
-import com.puppycrawl.tools.checkstyle.AbstractModuleTestSupport;
+import com.puppycrawl.tools.checkstyle.AbstractExamplesModuleTestSupport;
 
 @Disabled("until https://github.com/checkstyle/checkstyle/issues/13345")
-public class MissingDeprecatedCheckExamplesTest extends AbstractModuleTestSupport {
+public class MissingDeprecatedCheckExamplesTest extends AbstractExamplesModuleTestSupport {
     @Override
     protected String getPackageLocation() {
-        return "xdocs-examples";
-    }
-
-    @Override
-    protected String getResourceLocation() {
         return "com/puppycrawl/tools/checkstyle/checks/annotation/missingdeprecated";
     }
 

--- a/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/checks/annotation/MissingOverrideCheckExamplesTest.java
+++ b/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/checks/annotation/MissingOverrideCheckExamplesTest.java
@@ -22,17 +22,12 @@ package com.puppycrawl.tools.checkstyle.checks.annotation;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
-import com.puppycrawl.tools.checkstyle.AbstractModuleTestSupport;
+import com.puppycrawl.tools.checkstyle.AbstractExamplesModuleTestSupport;
 
 @Disabled("until https://github.com/checkstyle/checkstyle/issues/13345")
-public class MissingOverrideCheckExamplesTest extends AbstractModuleTestSupport {
+public class MissingOverrideCheckExamplesTest extends AbstractExamplesModuleTestSupport {
     @Override
     protected String getPackageLocation() {
-        return "xdocs-examples";
-    }
-
-    @Override
-    protected String getResourceLocation() {
         return "com/puppycrawl/tools/checkstyle/checks/annotation/missingoverride";
     }
 

--- a/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/checks/annotation/SuppressWarningsCheckExamplesTest.java
+++ b/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/checks/annotation/SuppressWarningsCheckExamplesTest.java
@@ -22,17 +22,12 @@ package com.puppycrawl.tools.checkstyle.checks.annotation;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
-import com.puppycrawl.tools.checkstyle.AbstractModuleTestSupport;
+import com.puppycrawl.tools.checkstyle.AbstractExamplesModuleTestSupport;
 
 @Disabled("until https://github.com/checkstyle/checkstyle/issues/13345")
-public class SuppressWarningsCheckExamplesTest extends AbstractModuleTestSupport {
+public class SuppressWarningsCheckExamplesTest extends AbstractExamplesModuleTestSupport {
     @Override
     protected String getPackageLocation() {
-        return "xdocs-examples";
-    }
-
-    @Override
-    protected String getResourceLocation() {
         return "com/puppycrawl/tools/checkstyle/checks/annotation/suppresswarnings";
     }
 

--- a/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/checks/blocks/AvoidNestedBlocksCheckExamplesTest.java
+++ b/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/checks/blocks/AvoidNestedBlocksCheckExamplesTest.java
@@ -22,17 +22,12 @@ package com.puppycrawl.tools.checkstyle.checks.blocks;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
-import com.puppycrawl.tools.checkstyle.AbstractModuleTestSupport;
+import com.puppycrawl.tools.checkstyle.AbstractExamplesModuleTestSupport;
 
 @Disabled("until https://github.com/checkstyle/checkstyle/issues/13345")
-public class AvoidNestedBlocksCheckExamplesTest extends AbstractModuleTestSupport {
+public class AvoidNestedBlocksCheckExamplesTest extends AbstractExamplesModuleTestSupport {
     @Override
     protected String getPackageLocation() {
-        return "xdocs-examples";
-    }
-
-    @Override
-    protected String getResourceLocation() {
         return "com/puppycrawl/tools/checkstyle/checks/blocks/avoidnestedblocks";
     }
 

--- a/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/checks/blocks/EmptyBlockCheckExamplesTest.java
+++ b/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/checks/blocks/EmptyBlockCheckExamplesTest.java
@@ -22,17 +22,12 @@ package com.puppycrawl.tools.checkstyle.checks.blocks;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
-import com.puppycrawl.tools.checkstyle.AbstractModuleTestSupport;
+import com.puppycrawl.tools.checkstyle.AbstractExamplesModuleTestSupport;
 
 @Disabled("until https://github.com/checkstyle/checkstyle/issues/13345")
-public class EmptyBlockCheckExamplesTest extends AbstractModuleTestSupport {
+public class EmptyBlockCheckExamplesTest extends AbstractExamplesModuleTestSupport {
     @Override
     protected String getPackageLocation() {
-        return "xdocs-examples";
-    }
-
-    @Override
-    protected String getResourceLocation() {
         return "com/puppycrawl/tools/checkstyle/checks/blocks/emptyblock";
     }
 

--- a/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/checks/blocks/EmptyCatchBlockCheckExamplesTest.java
+++ b/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/checks/blocks/EmptyCatchBlockCheckExamplesTest.java
@@ -22,17 +22,12 @@ package com.puppycrawl.tools.checkstyle.checks.blocks;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
-import com.puppycrawl.tools.checkstyle.AbstractModuleTestSupport;
+import com.puppycrawl.tools.checkstyle.AbstractExamplesModuleTestSupport;
 
 @Disabled("until https://github.com/checkstyle/checkstyle/issues/13345")
-public class EmptyCatchBlockCheckExamplesTest extends AbstractModuleTestSupport {
+public class EmptyCatchBlockCheckExamplesTest extends AbstractExamplesModuleTestSupport {
     @Override
     protected String getPackageLocation() {
-        return "xdocs-examples";
-    }
-
-    @Override
-    protected String getResourceLocation() {
         return "com/puppycrawl/tools/checkstyle/checks/blocks/emptycatchblock";
     }
 

--- a/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/checks/blocks/LeftCurlyCheckExamplesTest.java
+++ b/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/checks/blocks/LeftCurlyCheckExamplesTest.java
@@ -22,17 +22,12 @@ package com.puppycrawl.tools.checkstyle.checks.blocks;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
-import com.puppycrawl.tools.checkstyle.AbstractModuleTestSupport;
+import com.puppycrawl.tools.checkstyle.AbstractExamplesModuleTestSupport;
 
 @Disabled("until https://github.com/checkstyle/checkstyle/issues/13345")
-public class LeftCurlyCheckExamplesTest extends AbstractModuleTestSupport {
+public class LeftCurlyCheckExamplesTest extends AbstractExamplesModuleTestSupport {
     @Override
     protected String getPackageLocation() {
-        return "xdocs-examples";
-    }
-
-    @Override
-    protected String getResourceLocation() {
         return "com/puppycrawl/tools/checkstyle/checks/blocks/leftcurly";
     }
 

--- a/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/checks/blocks/NeedBracesCheckExamplesTest.java
+++ b/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/checks/blocks/NeedBracesCheckExamplesTest.java
@@ -22,17 +22,12 @@ package com.puppycrawl.tools.checkstyle.checks.blocks;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
-import com.puppycrawl.tools.checkstyle.AbstractModuleTestSupport;
+import com.puppycrawl.tools.checkstyle.AbstractExamplesModuleTestSupport;
 
 @Disabled("until https://github.com/checkstyle/checkstyle/issues/13345")
-public class NeedBracesCheckExamplesTest extends AbstractModuleTestSupport {
+public class NeedBracesCheckExamplesTest extends AbstractExamplesModuleTestSupport {
     @Override
     protected String getPackageLocation() {
-        return "xdocs-examples";
-    }
-
-    @Override
-    protected String getResourceLocation() {
         return "com/puppycrawl/tools/checkstyle/checks/blocks/needbraces";
     }
 

--- a/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/checks/blocks/RightCurlyCheckExamplesTest.java
+++ b/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/checks/blocks/RightCurlyCheckExamplesTest.java
@@ -22,17 +22,12 @@ package com.puppycrawl.tools.checkstyle.checks.blocks;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
-import com.puppycrawl.tools.checkstyle.AbstractModuleTestSupport;
+import com.puppycrawl.tools.checkstyle.AbstractExamplesModuleTestSupport;
 
 @Disabled("until https://github.com/checkstyle/checkstyle/issues/13345")
-public class RightCurlyCheckExamplesTest extends AbstractModuleTestSupport {
+public class RightCurlyCheckExamplesTest extends AbstractExamplesModuleTestSupport {
     @Override
     protected String getPackageLocation() {
-        return "xdocs-examples";
-    }
-
-    @Override
-    protected String getResourceLocation() {
         return "com/puppycrawl/tools/checkstyle/checks/blocks/rightcurly";
     }
 

--- a/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/checks/design/DesignForExtensionCheckExamplesTest.java
+++ b/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/checks/design/DesignForExtensionCheckExamplesTest.java
@@ -22,17 +22,12 @@ package com.puppycrawl.tools.checkstyle.checks.design;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
-import com.puppycrawl.tools.checkstyle.AbstractModuleTestSupport;
+import com.puppycrawl.tools.checkstyle.AbstractExamplesModuleTestSupport;
 
 @Disabled("until https://github.com/checkstyle/checkstyle/issues/13345")
-public class DesignForExtensionCheckExamplesTest extends AbstractModuleTestSupport {
+public class DesignForExtensionCheckExamplesTest extends AbstractExamplesModuleTestSupport {
     @Override
     protected String getPackageLocation() {
-        return "xdocs-examples";
-    }
-
-    @Override
-    protected String getResourceLocation() {
         return "com/puppycrawl/tools/checkstyle/checks/design/designforextension";
     }
 

--- a/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/checks/design/HideUtilityClassConstructorCheckExamplesTest.java
+++ b/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/checks/design/HideUtilityClassConstructorCheckExamplesTest.java
@@ -22,17 +22,13 @@ package com.puppycrawl.tools.checkstyle.checks.design;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
-import com.puppycrawl.tools.checkstyle.AbstractModuleTestSupport;
+import com.puppycrawl.tools.checkstyle.AbstractExamplesModuleTestSupport;
 
 @Disabled("until https://github.com/checkstyle/checkstyle/issues/13345")
-public class HideUtilityClassConstructorCheckExamplesTest extends AbstractModuleTestSupport {
+public class HideUtilityClassConstructorCheckExamplesTest
+        extends AbstractExamplesModuleTestSupport {
     @Override
     protected String getPackageLocation() {
-        return "xdocs-examples";
-    }
-
-    @Override
-    protected String getResourceLocation() {
         return "com/puppycrawl/tools/checkstyle/checks/design/hideutilityclassconstructor";
     }
 


### PR DESCRIPTION
Resolves #13484 

---
Adds new class `AbstractExamplesModuleTestSupport` and fixes the 14 tests with switched `getResourceLocation` and `getPackageLocation`