### PR TITLE
Pull #13499: Exclude xdocs from line length validation and validate templates instead

### DIFF
--- a/config/checkstyle-checks.xml
+++ b/config/checkstyle-checks.xml
@@ -155,7 +155,7 @@
     <property name="id" value="lineLengthXml"/>
     <property name="format"
               value="^(?!(\s*,?\s*&lt;a href=&quot;[^&quot;]+&quot;&gt;|.*http)).{101,}$"/>
-    <property name="fileExtensions" value="xml, vm"/>
+    <property name="fileExtensions" value="xml, vm, template"/>
     <property name="message" value="Line should not be longer than 100 symbols"/>
   </module>
   <!--

--- a/config/checkstyle-non-main-files-suppressions.xml
+++ b/config/checkstyle-non-main-files-suppressions.xml
@@ -111,6 +111,12 @@
   <!-- We will preserve formatting of archived release notes -->
   <suppress id="lineLength" files="[\\/]releasenotes_old_8\-0_8\-34\.xml"/>
 
+  <!-- All xdoc checks/filters files are generated from templates and have escaped characters that
+       make the lines long. We still validate index.xml and template files.
+       until https://github.com/checkstyle/checkstyle/issues/13426 -->
+  <suppress id="lineLength"
+            files="[\\/]src[\\/]xdocs[\\/](checks|(file)?filters)[\\/](?!.*index\.xml)(?!.*\.xml\.template).+\.xml"/>
+
   <!-- apply check numberOfTestCasesInXpath only for files in suppressionxpathfilter directory -->
   <suppress id="numberOfTestCasesInXpath"
          files="src[\\/]it[\\/]java[\\/]com[\\/].*" />

--- a/config/suppressions.xml
+++ b/config/suppressions.xml
@@ -182,4 +182,10 @@
   <!-- the filter is not part of the documentation -->
   <suppress id="settersHaveSinceTag"
             files="[\\/]src[\\/]main[\\/]java[\\/]com[\\/]puppycrawl[\\/]tools[\\/]checkstyle[\\/]XpathFileGeneratorAstFilter.java"/>
+
+  <!-- All xdoc checks/filters files are generated from templates and have escaped characters that
+       make the lines long. We still validate index.xml and template files.
+       until https://github.com/checkstyle/checkstyle/issues/13426 -->
+  <suppress id="lineLengthXml"
+            files="[\\/]src[\\/]xdocs[\\/](checks|(file)?filters)[\\/](?!.*index\.xml)(?!.*\.xml\.template).+\.xml"/>
 </suppressions>


### PR DESCRIPTION
Required for https://github.com/checkstyle/checkstyle/issues/13498

---
Excludes regular `.xml` Xdoc files from line-length validation and adds templates `.xml.template` to line-length validation. The problem is that the parser escapes lots of characters(`"`, for example) and some lines inside code blocks become longer than 100 chars after generation.

---
Proof of suppression work: https://regexr.com/7hvad
![Screenshot from 2023-08-01 21-29-37](https://github.com/checkstyle/checkstyle/assets/23459549/29344749-d3cd-497b-8861-76ba59a97414)

