### PR TITLE
Pull #13505: Restore usage of TreeSet

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/site/ViolationMessagesMacro.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/site/ViolationMessagesMacro.java
@@ -19,8 +19,7 @@
 
 package com.puppycrawl.tools.checkstyle.site;
 
-import java.util.Collections;
-import java.util.List;
+import java.util.Set;
 
 import org.apache.maven.doxia.macro.AbstractMacro;
 import org.apache.maven.doxia.macro.Macro;
@@ -44,7 +43,7 @@ public class ViolationMessagesMacro extends AbstractMacro {
         final String checkName = (String) request.getParameter("checkName");
         final Object instance = SiteUtil.getModuleInstance(checkName);
         final Class<?> clss = instance.getClass();
-        final List<String> messageKeys = SiteUtil.getCheckMessageKeys(clss, instance);
+        final Set<String> messageKeys = SiteUtil.getMessageKeys(clss);
         createListOfMessages((XdocSink) sink, clss, messageKeys);
     }
 
@@ -56,7 +55,7 @@ public class ViolationMessagesMacro extends AbstractMacro {
      * @param messageKeys the List of message keys to iterate through.
      */
     private static void createListOfMessages(
-            XdocSink sink, Class<?> clss, List<String> messageKeys) {
+            XdocSink sink, Class<?> clss, Set<String> messageKeys) {
         final String indentLevel8 = SiteUtil.getNewlineAndIndentSpaces(8);
 
         // This is a hack to prevent a newline from being inserted by the default sink.
@@ -66,7 +65,6 @@ public class ViolationMessagesMacro extends AbstractMacro {
         sink.list();
         sink.setInsertNewline(true);
 
-        Collections.sort(messageKeys);
         for (String messageKey : messageKeys) {
             createListItem(sink, clss, messageKey);
         }


### PR DESCRIPTION
As suggested in https://github.com/checkstyle/checkstyle/pull/13423#discussion_r1281289602

>  please restore copy pasta and add a comment about why we use treeset

In https://github.com/checkstyle/checkstyle/pull/13423#discussion_r1275385868 there is a thread about a chunk of code that is a direct copy of those two:

https://github.com/checkstyle/checkstyle/blob/ec5cd7e2ffd7c5c3a1b2cd4e28e4d3c37bb723fc/src/test/java/com/puppycrawl/tools/checkstyle/internal/utils/CheckUtil.java#L211-L213
https://github.com/checkstyle/checkstyle/blob/0c2ab5338db569b4699d5d20121d1bd508394eb9/src/test/java/com/puppycrawl/tools/checkstyle/internal/XdocsPagesTest.java#L1381-L1389

There was some uncertainty as to why `TreeSet` is used, but @rnveach explained that in https://github.com/checkstyle/checkstyle/pull/13423#discussion_r1281288043

> You can't use a collection that is based on hashcode. It is JVM specific and different runs can generate different hashes and orders. We can't use insertion order here because reflection is not guaranteed an order and we want to ensure our documentation is consistent in order. It will be bad if one run says A,B,C and then another run says C,A,B. This is why we originally used TreeSet, to say order is alphabetic.
I recommend keeping this a copy/paste and just create new issues to fix anything.

This PR restores the check message keys extraction process to use TreeSet.