### PR TITLE
minor: suppress IDEA violation

### DIFF
--- a/config/intellij-idea-inspections.xml
+++ b/config/intellij-idea-inspections.xml
@@ -2594,6 +2594,8 @@
     <scope name="Tests" level="ERROR" enabled="false">
       <option name="ignoreInstanceofOnLibraryClasses" value="false"/>
     </scope>
+    <!-- until https://github.com/checkstyle/checkstyle/issues/13500 -->
+    <scope class="SiteUtil" level="ERROR" enabled="false"/>
     <option name="ignoreInstanceofOnLibraryClasses" value="true"/>
   </inspection_tool>
   <inspection_tool class="InstanceofIncompatibleInterface" enabled="true" level="WARNING"

--- a/src/main/java/com/puppycrawl/tools/checkstyle/site/SiteUtil.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/site/SiteUtil.java
@@ -56,7 +56,6 @@ public final class SiteUtil {
      * @noinspection InstanceofChain
      * @noinspectionreason InstanceofChain - We will deal with this at
      *                     <a href="https://github.com/checkstyle/checkstyle/issues/13500">13500</a>
-     *
      */
     public static List<String> getCheckMessageKeys(Class<?> module, Object checkInstance)
             throws MacroExecutionException {


### PR DESCRIPTION
There is an IDEA violation in master that was supposedly suppressed
https://app.circleci.com/pipelines/github/checkstyle/checkstyle/19995/workflows/ff4641c7-f764-47f3-ad3e-9ab0f5602489/jobs/351880/artifacts
```xml
<problems is_local_tool="true">
<problem>
<file>
file://$PROJECT_DIR$/src/main/java/com/puppycrawl/tools/checkstyle/site/SiteUtil.java
</file>
<line>103</line>
<module>project</module>
<package>com.puppycrawl.tools.checkstyle.site</package>
<entry_point TYPE="method" FQNAME="com.puppycrawl.tools.checkstyle.site.SiteUtil java.util.List<java.lang.String> getCheckMessageKeys(java.lang.Class<?> module, java.lang.Object checkInstance)"/>
<problem_class id="InstanceofChain" severity="ERROR" attribute_key="ERRORS_ATTRIBUTES">Chain of 'instanceof' checks</problem_class>
<description>
Chain of class equality checks indicates abstraction failure #loc
</description>
<highlighted_element>if</highlighted_element>
<language>JAVA</language>
<offset>12</offset>
<length>2</length>
</problem>
</problems>
```

For some reason, the `@noinspection` doesn't suppress the violation so I added a suppression for the whole file.