### PR TITLE
infra: disable tavis until issue with JAVA_PATH is resolved

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -36,27 +36,27 @@ jobs:
         - USE_MAVEN_REPO="true"
 
 before_script:
-  - |
-    if [[ $TRAVIS_CPU_ARCH == 'ppc64le' ]]; then
-        export JAVA_HOME=/usr/lib/jvm/adoptopenjdk-11-hotspot-ppc64el
-        export PATH=$JAVA_HOME/bin:$PATH
-    fi
-  - groovy --version
+  # - |
+  #  if [[ $TRAVIS_CPU_ARCH == 'ppc64le' ]]; then
+  #      export JAVA_HOME=/usr/lib/jvm/adoptopenjdk-11-hotspot-ppc64el
+  #      export PATH=$JAVA_HOME/bin:$PATH
+  #  fi
+  - java --version
 
 script:
   # manually set JAVA_HOME to overcome issue with travis ci noted at
   # https://github.com/checkstyle/checkstyle/pull/11699#issue-1261272652
   # - JAVA_HOME='/usr/lib/jvm/adoptopenjdk-11-hotspot-ppc64el'
-  - ./.ci/travis.sh init-m2-repo
-  - ./.ci/travis.sh run-command "$CMD"
+  # - ./.ci/travis.sh init-m2-repo
+  # - ./.ci/travis.sh run-command "$CMD"
   # - ./.ci/travis.sh remove-custom-mvn
   # - ./.ci/travis.sh remove-adoptium-jdk
-  - ./.ci/validation.sh git-diff
-  - ./.ci/validation.sh ci-temp-check
-  - ./.ci/travis.sh quarterly-cache-cleanup
+  # - ./.ci/validation.sh git-diff
+  # - ./.ci/validation.sh ci-temp-check
+  # - ./.ci/travis.sh quarterly-cache-cleanup
   - sleep 5s
 
 after_success:
-  - ./.ci/travis.sh run-command-after-success
-  - ./.ci/travis.sh deploy-snapshot
+  # - ./.ci/travis.sh run-command-after-success
+  # - ./.ci/travis.sh deploy-snapshot
   - sleep 5s


### PR DESCRIPTION
https://app.travis-ci.com/github/checkstyle/checkstyle/builds/264912656
```
$ ./.ci/travis.sh init-m2-repo
The JAVA_HOME environment variable is not defined correctly
This environment variable is needed to run this program
NB: JAVA_HOME should point to a JDK not a JRE
The command "./.ci/travis.sh init-m2-repo" exited with 1.
0.02s$ ./.ci/travis.sh run-command "$CMD"
eval of CMD is starting
CMD=mvn -e --no-transfer-progress clean integration-test failsafe:verify -DargLine='-Xms1024m -Xmx2048m'
The JAVA_HOME environment variable is not defined correctly
This environment variable is needed to run this
```

support was contacted, no reply.