### PR TITLE
Issue #13498: Create templates from coding-2 checks xdocs

### DIFF
--- a/src/xdocs/checks/coding/innerassignment.xml
+++ b/src/xdocs/checks/coding/innerassignment.xml
@@ -51,7 +51,7 @@ while ((line = bufferedReader.readLine()) != null); // OK
           To configure the check:
         </p>
         <source>
-&lt;module name="InnerAssignment"/&gt;
+&lt;module name=&quot;InnerAssignment&quot;/&gt;
         </source>
         <p>Example:</p>
         <source>
@@ -71,7 +71,7 @@ class MyClass {
 
     String nameOne;
     List&lt;String&gt; myList = new ArrayList&lt;String&gt;();
-    myList.add(nameOne = "tom"); // violation
+    myList.add(nameOne = &quot;tom&quot;); // violation
 
     for (int k = 0; k &lt; 10; k = k + 2) { // OK
       // some code
@@ -84,7 +84,7 @@ class MyClass {
 
     while (someVal = false) {} // violation
 
-    InputStream is = new FileInputStream("textFile.txt");
+    InputStream is = new FileInputStream(&quot;textFile.txt&quot;);
     while ((b = is.read()) != -1) { // OK, this is a common idiom
       // some code
     }

--- a/src/xdocs/checks/coding/innerassignment.xml.template
+++ b/src/xdocs/checks/coding/innerassignment.xml.template
@@ -1,0 +1,141 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<document xmlns="http://maven.apache.org/XDOC/2.0"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/XDOC/2.0 https://maven.apache.org/xsd/xdoc-2.0.xsd">
+  <head>
+    <title>InnerAssignment</title>
+  </head>
+  <body>
+    <section name="InnerAssignment">
+      <p>Since Checkstyle 3.0</p>
+      <subsection name="Description" id="Description">
+        <p>
+          Checks for assignments in subexpressions, such as in
+          <code>String s = Integer.toString(i = 2);</code>.
+        </p>
+
+        <p>
+          Rationale: Except for the loop idioms,
+          all assignments should occur in their own top-level statement
+          to increase readability. With inner assignments like the one given above, it is difficult
+          to see all places where a variable is set.
+        </p>
+
+        <p>
+          Note: Check allows usage of the popular assignments in loops:
+        </p>
+        <source>
+String line;
+while ((line = bufferedReader.readLine()) != null) { // OK
+  // process the line
+}
+
+for (;(line = bufferedReader.readLine()) != null;) { // OK
+  // process the line
+}
+
+do {
+  // process the line
+}
+while ((line = bufferedReader.readLine()) != null); // OK
+        </source>
+        <p>
+          Assignment inside a condition is not a problem here, as the assignment is surrounded by
+          an extra pair of parentheses. The comparison is <code>!= null</code> and there is no
+          chance that intention was to write <code>line == reader.readLine()</code>.
+        </p>
+      </subsection>
+
+      <subsection name="Examples" id="Examples">
+        <p>
+          To configure the check:
+        </p>
+        <source>
+&lt;module name="InnerAssignment"/&gt;
+        </source>
+        <p>Example:</p>
+        <source>
+class MyClass {
+
+  void foo() {
+    int a, b;
+    a = b = 5; // violation, assignment to each variable should be in a separate statement
+    a = b += 5; // violation
+
+    a = 5; // OK
+    b = 5; // OK
+    a = 5; b = 5; // OK
+
+    double myDouble;
+    double[] doubleArray = new double[] {myDouble = 4.5, 15.5}; // violation
+
+    String nameOne;
+    List&lt;String&gt; myList = new ArrayList&lt;String&gt;();
+    myList.add(nameOne = "tom"); // violation
+
+    for (int k = 0; k &lt; 10; k = k + 2) { // OK
+      // some code
+    }
+
+    boolean someVal;
+    if (someVal = true) { // violation
+      // some code
+    }
+
+    while (someVal = false) {} // violation
+
+    InputStream is = new FileInputStream("textFile.txt");
+    while ((b = is.read()) != -1) { // OK, this is a common idiom
+      // some code
+    }
+  }
+
+  boolean testMethod() {
+    boolean val;
+    return val = true; // violation
+  }
+}
+        </source>
+      </subsection>
+
+      <subsection name="Example of Usage" id="Example_of_Usage">
+        <ul>
+          <li>
+            <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources%20path%3A**%2Fsun_checks.xml+repo%3Acheckstyle%2Fcheckstyle+InnerAssignment">
+            Sun Style</a>
+          </li>
+          <li>
+            <a href="https://github.com/search?q=path%3Aconfig%20path%3A**%2Fcheckstyle-checks.xml+repo%3Acheckstyle%2Fcheckstyle+InnerAssignment">
+            Checkstyle Style</a>
+          </li>
+        </ul>
+      </subsection>
+
+      <subsection name="Violation Messages" id="Violation_Messages">
+        <ul>
+          <li>
+            <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources%2Fcom%2Fpuppycrawl%2Ftools%2Fcheckstyle%2Fchecks%2Fcoding%20path%3A**%2Fmessages*.properties+repo%3Acheckstyle%2Fcheckstyle+%22assignment.inner.avoid%22">
+            assignment.inner.avoid</a>
+          </li>
+        </ul>
+        <p>
+          All messages can be customized if the default message doesn't suit you.
+          Please <a href="../../config.html#Custom_messages">see the documentation</a>
+          to learn how to.
+        </p>
+      </subsection>
+
+      <subsection name="Package" id="Package">
+        <p>
+          com.puppycrawl.tools.checkstyle.checks.coding
+        </p>
+      </subsection>
+
+      <subsection name="Parent Module" id="Parent_Module">
+        <p>
+          <a href="../../config.html#TreeWalker">TreeWalker</a>
+        </p>
+      </subsection>
+    </section>
+  </body>
+</document>

--- a/src/xdocs/checks/coding/magicnumber.xml
+++ b/src/xdocs/checks/coding/magicnumber.xml
@@ -12,7 +12,7 @@
         <p>
           Checks that there are no
           <a href="https://en.wikipedia.org/wiki/Magic_number_%28programming%29">
-          "magic numbers"</a> where a magic
+          &quot;magic numbers&quot;</a> where a magic
           number is a numeric literal that is not defined as a constant.
           By default, -1, 0, 1, and 2 are not considered to be magic numbers.
         </p>
@@ -148,7 +148,7 @@ static final Integer ANSWER_TO_THE_ULTIMATE_QUESTION_OF_LIFE = new Integer(42);
           To configure the check with default configuration:
         </p>
         <source>
-&lt;module name="MagicNumber"/&gt;
+&lt;module name=&quot;MagicNumber&quot;/&gt;
         </source>
         <p>
           results is following violations:
@@ -177,11 +177,11 @@ class MyClass {
           that are not 0, 0.5, or 1:
         </p>
         <source>
-&lt;module name="MagicNumber"&gt;
-  &lt;property name="tokens" value="NUM_DOUBLE, NUM_FLOAT"/&gt;
-  &lt;property name="ignoreNumbers" value="0, 0.5, 1"/&gt;
-  &lt;property name="ignoreFieldDeclaration" value="true"/&gt;
-  &lt;property name="ignoreAnnotation" value="true"/&gt;
+&lt;module name=&quot;MagicNumber&quot;&gt;
+  &lt;property name=&quot;tokens&quot; value=&quot;NUM_DOUBLE, NUM_FLOAT&quot;/&gt;
+  &lt;property name=&quot;ignoreNumbers&quot; value=&quot;0, 0.5, 1&quot;/&gt;
+  &lt;property name=&quot;ignoreFieldDeclaration&quot; value=&quot;true&quot;/&gt;
+  &lt;property name=&quot;ignoreAnnotation&quot; value=&quot;true&quot;/&gt;
 &lt;/module&gt;
         </source>
         <p>
@@ -202,8 +202,8 @@ class MyClass {
           To configure the check so that it ignores magic numbers in field declarations:
         </p>
         <source>
-&lt;module name="MagicNumber"&gt;
-    &lt;property name="ignoreFieldDeclaration" value="false"/&gt;
+&lt;module name=&quot;MagicNumber&quot;&gt;
+    &lt;property name=&quot;ignoreFieldDeclaration&quot; value=&quot;false&quot;/&gt;
 &lt;/module&gt;
         </source>
         <p>
@@ -223,8 +223,8 @@ public record MyRecord() {
         To configure the check to check annotation element defaults:
         </p>
         <source>
-&lt;module name="MagicNumber"&gt;
-  &lt;property name="ignoreAnnotationElementDefaults" value="false"/&gt;
+&lt;module name=&quot;MagicNumber&quot;&gt;
+  &lt;property name=&quot;ignoreAnnotationElementDefaults&quot; value=&quot;false&quot;/&gt;
 &lt;/module&gt;
         </source>
         <p>
@@ -240,9 +240,9 @@ public record MyRecord() {
         Config example of constantWaiverParentToken option:
         </p>
         <source>
-&lt;module name="MagicNumber"&gt;
-  &lt;property name="constantWaiverParentToken" value="ASSIGN,ARRAY_INIT,EXPR,
-  UNARY_PLUS, UNARY_MINUS, TYPECAST, ELIST, DIV, PLUS "/&gt;
+&lt;module name=&quot;MagicNumber&quot;&gt;
+  &lt;property name=&quot;constantWaiverParentToken&quot; value=&quot;ASSIGN,ARRAY_INIT,EXPR,
+  UNARY_PLUS, UNARY_MINUS, TYPECAST, ELIST, DIV, PLUS &quot;/&gt;
 &lt;/module&gt;
         </source>
         <p>result is following violation:</p>
@@ -268,8 +268,8 @@ class TestMethodCall {
         Config example of ignoreHashCodeMethod option:
         </p>
         <source>
-&lt;module name="MagicNumber"&gt;
-    &lt;property name="ignoreHashCodeMethod" value="true"/&gt;
+&lt;module name=&quot;MagicNumber&quot;&gt;
+    &lt;property name=&quot;ignoreHashCodeMethod&quot; value=&quot;true&quot;/&gt;
 &lt;/module&gt;
         </source>
         <p>result is no violation:</p>

--- a/src/xdocs/checks/coding/magicnumber.xml.template
+++ b/src/xdocs/checks/coding/magicnumber.xml.template
@@ -1,0 +1,326 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<document xmlns="http://maven.apache.org/XDOC/2.0"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/XDOC/2.0 https://maven.apache.org/xsd/xdoc-2.0.xsd">
+  <head>
+    <title>MagicNumber</title>
+  </head>
+  <body>
+    <section name="MagicNumber">
+      <p>Since Checkstyle 3.1</p>
+      <subsection name="Description" id="Description">
+        <p>
+          Checks that there are no
+          <a href="https://en.wikipedia.org/wiki/Magic_number_%28programming%29">
+          "magic numbers"</a> where a magic
+          number is a numeric literal that is not defined as a constant.
+          By default, -1, 0, 1, and 2 are not considered to be magic numbers.
+        </p>
+        <p>
+          Constant definition is any variable/field that has 'final' modifier.
+          It is fine to have one constant defining multiple numeric literals within one expression:
+        </p>
+        <source>
+static final int SECONDS_PER_DAY = 24 * 60 * 60;
+static final double SPECIAL_RATIO = 4.0 / 3.0;
+static final double SPECIAL_SUM = 1 + Math.E;
+static final double SPECIAL_DIFFERENCE = 4 - Math.PI;
+static final Border STANDARD_BORDER = BorderFactory.createEmptyBorder(3, 3, 3, 3);
+static final Integer ANSWER_TO_THE_ULTIMATE_QUESTION_OF_LIFE = new Integer(42);
+        </source>
+      </subsection>
+
+      <subsection name="Properties" id="Properties">
+        <div class="wrapper">
+          <table>
+            <tr>
+              <th>name</th>
+              <th>description</th>
+              <th>type</th>
+              <th>default value</th>
+              <th>since</th>
+            </tr>
+            <tr>
+              <td>ignoreNumbers</td>
+              <td>Specify non-magic numbers.</td>
+              <td><a href="../../property_types.html#double.5B.5D">double[]</a></td>
+              <td><code>-1, 0, 1, 2</code></td>
+              <td>3.1</td>
+            </tr>
+            <tr>
+              <td>ignoreHashCodeMethod</td>
+              <td>Ignore magic numbers in hashCode methods.</td>
+              <td><a href="../../property_types.html#boolean">boolean</a></td>
+              <td><code>false</code></td>
+              <td>5.3</td>
+            </tr>
+            <tr>
+              <td>ignoreAnnotation</td>
+              <td>Ignore magic numbers in annotation declarations.</td>
+              <td><a href="../../property_types.html#boolean">boolean</a></td>
+              <td><code>false</code></td>
+              <td>5.4</td>
+            </tr>
+            <tr>
+              <td>ignoreFieldDeclaration</td>
+              <td>Ignore magic numbers in field declarations.</td>
+              <td><a href="../../property_types.html#boolean">boolean</a></td>
+              <td><code>false</code></td>
+              <td>6.6</td>
+            </tr>
+            <tr>
+              <td>ignoreAnnotationElementDefaults</td>
+              <td>Ignore magic numbers in annotation elements defaults.</td>
+              <td><a href="../../property_types.html#boolean">boolean</a></td>
+              <td><code>true</code></td>
+              <td>8.23</td>
+            </tr>
+            <tr>
+              <td>constantWaiverParentToken</td>
+              <td>Specify tokens that are allowed in the AST path from the number literal to the
+                  enclosing constant definition.</td>
+              <td>subset of tokens
+                <a href="../../apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html">TokenTypes</a>
+              </td>
+              <td>
+                <a href="../../apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#ARRAY_INIT">
+                ARRAY_INIT</a>
+                , <a href="../../apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#ASSIGN">
+                ASSIGN</a>
+                , <a href="../../apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#DIV">
+                DIV</a>
+                , <a href="../../apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#ELIST">
+                ELIST</a>
+                , <a href="../../apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#EXPR">
+                EXPR</a>
+                , <a href="../../apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#LITERAL_NEW">
+                LITERAL_NEW</a>
+                , <a href="../../apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#METHOD_CALL">
+                METHOD_CALL</a>
+                , <a href="../../apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#MINUS">
+                MINUS</a>
+                , <a href="../../apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#PLUS">
+                PLUS</a>
+                , <a href="../../apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#STAR">
+                STAR</a>
+                , <a href="../../apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#TYPECAST">
+                TYPECAST</a>
+                , <a href="../../apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#UNARY_MINUS">
+                UNARY_MINUS</a>
+                , <a href="../../apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#UNARY_PLUS">
+                UNARY_PLUS</a>
+              </td>
+              <td>6.11</td>
+            </tr>
+            <tr>
+              <td>tokens</td>
+              <td>tokens to check</td>
+              <td>subset of tokens
+                <a href="../../apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#NUM_DOUBLE">
+                NUM_DOUBLE</a>
+                , <a href="../../apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#NUM_FLOAT">
+                NUM_FLOAT</a>
+                , <a href="../../apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#NUM_INT">
+                NUM_INT</a>
+                , <a href="../../apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#NUM_LONG">
+                NUM_LONG</a>
+                .
+              </td>
+              <td>
+                <a href="../../apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#NUM_DOUBLE">
+                NUM_DOUBLE</a>
+                , <a href="../../apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#NUM_FLOAT">
+                NUM_FLOAT</a>
+                , <a href="../../apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#NUM_INT">
+                NUM_INT</a>
+                , <a href="../../apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#NUM_LONG">
+                NUM_LONG</a>
+                .
+              </td>
+              <td>3.1</td>
+            </tr>
+          </table>
+        </div>
+      </subsection>
+
+      <subsection name="Examples" id="Examples">
+        <p>
+          To configure the check with default configuration:
+        </p>
+        <source>
+&lt;module name="MagicNumber"/&gt;
+        </source>
+        <p>
+          results is following violations:
+        </p>
+        <source>
+@MyAnnotation(6) // violation
+class MyClass {
+  private field = 7; // violation
+
+  void foo() {
+    int i = i + 1; // no violation
+    int j = j + 8; // violation
+  }
+
+  public int hashCode() {
+    return 10;    // violation
+  }
+}
+@interface anno {
+  int value() default 10; // no violation
+}
+        </source>
+
+        <p>
+          To configure the check so that it checks floating-point numbers
+          that are not 0, 0.5, or 1:
+        </p>
+        <source>
+&lt;module name="MagicNumber"&gt;
+  &lt;property name="tokens" value="NUM_DOUBLE, NUM_FLOAT"/&gt;
+  &lt;property name="ignoreNumbers" value="0, 0.5, 1"/&gt;
+  &lt;property name="ignoreFieldDeclaration" value="true"/&gt;
+  &lt;property name="ignoreAnnotation" value="true"/&gt;
+&lt;/module&gt;
+        </source>
+        <p>
+          results is following violations:
+        </p>
+        <source>
+@MyAnnotation(6) // no violation
+class MyClass {
+  private field = 7; // no violation
+
+  void foo() {
+    int i = i + 1; // no violation
+    int j = j + 8; // violation
+  }
+}
+        </source>
+        <p>
+          To configure the check so that it ignores magic numbers in field declarations:
+        </p>
+        <source>
+&lt;module name="MagicNumber"&gt;
+    &lt;property name="ignoreFieldDeclaration" value="false"/&gt;
+&lt;/module&gt;
+        </source>
+        <p>
+          results in the following violations:
+        </p>
+        <source>
+public record MyRecord() {
+    private static int myInt = 7; // ok, field declaration
+
+    void foo() {
+        int i = myInt + 1; // no violation, 1 is defined as non-magic
+        int j = myInt + 8; // violation
+    }
+}
+        </source>
+        <p>
+        To configure the check to check annotation element defaults:
+        </p>
+        <source>
+&lt;module name="MagicNumber"&gt;
+  &lt;property name="ignoreAnnotationElementDefaults" value="false"/&gt;
+&lt;/module&gt;
+        </source>
+        <p>
+        results in following violations:
+        </p>
+        <source>
+@interface anno {
+  int value() default 10; // violation
+  int[] value2() default {10}; // violation
+}
+        </source>
+        <p>
+        Config example of constantWaiverParentToken option:
+        </p>
+        <source>
+&lt;module name="MagicNumber"&gt;
+  &lt;property name="constantWaiverParentToken" value="ASSIGN,ARRAY_INIT,EXPR,
+  UNARY_PLUS, UNARY_MINUS, TYPECAST, ELIST, DIV, PLUS "/&gt;
+&lt;/module&gt;
+        </source>
+        <p>result is following violation:</p>
+        <source>
+class TestMethodCall {
+  public void method2() {
+    final TestMethodCall dummyObject = new TestMethodCall(62);    //violation
+    final int a = 3;        // ok as waiver is ASSIGN
+    final int [] b = {4, 5} // ok as waiver is ARRAY_INIT
+    final int c = -3;       // ok as waiver is UNARY_MINUS
+    final int d = +4;       // ok as waiver is UNARY_PLUS
+    final int e = method(1, 2) // ELIST is there but violation due to METHOD_CALL
+    final int x = 3 * 4;    // violation
+    final int y = 3 / 4;    // ok as waiver is DIV
+    final int z = 3 + 4;    // ok as waiver is PLUS
+    final int w = 3 - 4;    // violation
+    final int x = (int)(3.4);    //ok as waiver is TYPECAST
+  }
+}
+        </source>
+
+        <p>
+        Config example of ignoreHashCodeMethod option:
+        </p>
+        <source>
+&lt;module name="MagicNumber"&gt;
+    &lt;property name="ignoreHashCodeMethod" value="true"/&gt;
+&lt;/module&gt;
+        </source>
+        <p>result is no violation:</p>
+        <source>
+class TestHashCode {
+  public int hashCode() {
+    return 10;              // OK
+  }
+}
+        </source>
+
+      </subsection>
+
+      <subsection name="Example of Usage" id="Example_of_Usage">
+        <ul>
+          <li>
+            <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources%20path%3A**%2Fsun_checks.xml+repo%3Acheckstyle%2Fcheckstyle+MagicNumber">
+            Sun Style</a>
+          </li>
+          <li>
+            <a href="https://github.com/search?q=path%3Aconfig%20path%3A**%2Fcheckstyle-checks.xml+repo%3Acheckstyle%2Fcheckstyle+MagicNumber">
+            Checkstyle Style</a>
+          </li>
+        </ul>
+      </subsection>
+
+      <subsection name="Violation Messages" id="Violation_Messages">
+        <ul>
+          <li>
+            <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources%2Fcom%2Fpuppycrawl%2Ftools%2Fcheckstyle%2Fchecks%2Fcoding%20path%3A**%2Fmessages*.properties+repo%3Acheckstyle%2Fcheckstyle+%22magic.number%22">
+            magic.number</a>
+          </li>
+        </ul>
+        <p>
+          All messages can be customized if the default message doesn't suit you.
+          Please <a href="../../config.html#Custom_messages">see the documentation</a>
+          to learn how to.
+        </p>
+      </subsection>
+
+      <subsection name="Package" id="Package">
+        <p>
+          com.puppycrawl.tools.checkstyle.checks.coding
+        </p>
+      </subsection>
+
+      <subsection name="Parent Module" id="Parent_Module">
+        <p>
+          <a href="../../config.html#TreeWalker">TreeWalker</a>
+        </p>
+      </subsection>
+    </section>
+  </body>
+</document>

--- a/src/xdocs/checks/coding/matchxpath.xml
+++ b/src/xdocs/checks/coding/matchxpath.xml
@@ -47,7 +47,7 @@
               <td>query</td>
               <td>Specify Xpath query.</td>
               <td><a href="../../property_types.html#String">String</a></td>
-              <td><code>""</code></td>
+              <td><code>&quot;&quot;</code></td>
               <td>8.39</td>
             </tr>
           </table>
@@ -88,7 +88,7 @@ CLASS_DEF -&gt; CLASS_DEF [1:0]
 |       |--LITERAL_RETURN -&gt; return [3:8]
 |       |   |--EXPR -&gt; EXPR [3:25]
 |       |   |   `--PLUS -&gt; + [3:25]
-|       |   |       |--STRING_LITERAL -&gt; "Hello, " [3:15]
+|       |   |       |--STRING_LITERAL -&gt; &quot;Hello, &quot; [3:15]
 |       |   |       `--IDENT -&gt; name [3:27]
 |       |   `--SEMI -&gt; ; [3:31]
 |       `--RCURLY -&gt; } [4:4]
@@ -97,7 +97,7 @@ CLASS_DEF -&gt; CLASS_DEF [1:0]
         <p><b>-b</b> option shows AST nodes that match given Xpath query. This command can be
           used to validate accuracy of Xpath query against given file.</p>
         <source>
-$ java -jar checkstyle-X.XX-all.jar Main.java -b "//METHOD_DEF[./IDENT[@text='sayHello']]"
+$ java -jar checkstyle-X.XX-all.jar Main.java -b &quot;//METHOD_DEF[./IDENT[@text='sayHello']]&quot;
 CLASS_DEF -&gt; CLASS_DEF [1:0]
 `--OBJBLOCK -&gt; OBJBLOCK [1:18]
 |--METHOD_DEF -&gt; METHOD_DEF [2:4]
@@ -105,11 +105,11 @@ CLASS_DEF -&gt; CLASS_DEF [1:0]
         <p>The following example demonstrates validation of methods order, so that public methods
           should come before the private ones:</p>
         <source>
-&lt;module name="MatchXpath"&gt;
-  &lt;property name="query" value="//METHOD_DEF[.//LITERAL_PRIVATE and
-          following-sibling::METHOD_DEF[.//LITERAL_PUBLIC]]"/&gt;
-  &lt;message key="matchxpath.match"
-          value="Private methods must appear after public methods"/&gt;
+&lt;module name=&quot;MatchXpath&quot;&gt;
+  &lt;property name=&quot;query&quot; value=&quot;//METHOD_DEF[.//LITERAL_PRIVATE and
+          following-sibling::METHOD_DEF[.//LITERAL_PUBLIC]]&quot;/&gt;
+  &lt;message key=&quot;matchxpath.match&quot;
+          value=&quot;Private methods must appear after public methods&quot;/&gt;
 &lt;/module&gt;
         </source>
         <p>Example:</p>
@@ -125,12 +125,12 @@ public class Test {
         </source>
         <p>To violate if there are any parametrized constructors</p>
         <source>
-&lt;module name="MatchXpath"&gt;
-  &lt;property name="query" value="//CTOR_DEF[count(./PARAMETERS/*)
-          &gt; 0]"/&gt;
-  &lt;message key="matchxpath.match"
-          value="Parameterized constructors are not allowed, there should be only default
-          ctor"/&gt;
+&lt;module name=&quot;MatchXpath&quot;&gt;
+  &lt;property name=&quot;query&quot; value=&quot;//CTOR_DEF[count(./PARAMETERS/*)
+          &gt; 0]&quot;/&gt;
+  &lt;message key=&quot;matchxpath.match&quot;
+          value=&quot;Parameterized constructors are not allowed, there should be only default
+          ctor&quot;/&gt;
 &lt;/module&gt;
         </source>
         <p>Example:</p>
@@ -143,11 +143,11 @@ public class Test {
         </source>
         <p>To violate if method name is 'test' or 'foo'</p>
         <source>
-&lt;module name="MatchXpath"&gt;
-  &lt;property name="query" value="//METHOD_DEF[./IDENT[@text='test'
-          or @text='foo']]"/&gt;
-  &lt;message key="matchxpath.match"
-          value="Method name should not be 'test' or 'foo'"/&gt;
+&lt;module name=&quot;MatchXpath&quot;&gt;
+  &lt;property name=&quot;query&quot; value=&quot;//METHOD_DEF[./IDENT[@text='test'
+          or @text='foo']]&quot;/&gt;
+  &lt;message key=&quot;matchxpath.match&quot;
+          value=&quot;Method name should not be 'test' or 'foo'&quot;/&gt;
 &lt;/module&gt;
         </source>
         <p>Example:</p>
@@ -161,12 +161,12 @@ public class Test {
         </source>
         <p>To violate if new instance creation was done without <b>var</b> type</p>
         <source>
-&lt;module name="MatchXpath"&gt;
-  &lt;property name="query" value="//VARIABLE_DEF[./ASSIGN/EXPR/LITERAL_NEW
-          and not(./TYPE/IDENT[@text='var'])]"/&gt;
-  &lt;message key="matchxpath.match"
-          value="New instances should be created via 'var' keyword to avoid duplication of
-          type reference in statement"/&gt;
+&lt;module name=&quot;MatchXpath&quot;&gt;
+  &lt;property name=&quot;query&quot; value=&quot;//VARIABLE_DEF[./ASSIGN/EXPR/LITERAL_NEW
+          and not(./TYPE/IDENT[@text='var'])]&quot;/&gt;
+  &lt;message key=&quot;matchxpath.match&quot;
+          value=&quot;New instances should be created via 'var' keyword to avoid duplication of
+          type reference in statement&quot;/&gt;
 &lt;/module&gt;
         </source>
         <p>Example:</p>

--- a/src/xdocs/checks/coding/matchxpath.xml.template
+++ b/src/xdocs/checks/coding/matchxpath.xml.template
@@ -1,0 +1,219 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<document xmlns="http://maven.apache.org/XDOC/2.0"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/XDOC/2.0 https://maven.apache.org/xsd/xdoc-2.0.xsd">
+  <head>
+    <title>MatchXpath</title>
+  </head>
+  <body>
+    <section name="MatchXpath">
+      <p>Since Checkstyle 8.39</p>
+      <subsection name="Description" id="Description">
+        <p>
+          Evaluates Xpath query and report violation on all matching AST nodes. This check allows
+          user to implement custom checks using Xpath. If Xpath query is not specified explicitly,
+          then the check does nothing.
+        </p>
+        <p>
+          It is recommended to define custom message for violation to explain what is not allowed
+          and what to use instead, default message might be too abstract. To customize a message
+          you need to add <code>message</code> element with <b>matchxpath.match</b> as
+          <code>key</code> attribute and desired message as <code>value</code> attribute.
+        </p>
+        <p>
+          Please read more about Xpath syntax at
+          <a href="https://www.saxonica.com/html/documentation10/expressions/">Xpath Syntax</a>.
+          Information regarding Xpath functions can be found at
+          <a href="https://www.saxonica.com/html/documentation10/functions/fn/">XSLT/XPath
+            Reference</a>. Note, that <b>@text</b> attribute can be used only with token types that
+          are listed in
+          <a href="https://github.com/checkstyle/checkstyle/search?q=%22TOKEN_TYPES_WITH_TEXT_ATTRIBUTE+%3D+Arrays.asList%22">
+            XpathUtil</a>.
+        </p>
+
+      </subsection>
+
+      <subsection name="Properties" id="Properties">
+        <div class="wrapper">
+          <table>
+            <tr>
+              <th>name</th>
+              <th>description</th>
+              <th>type</th>
+              <th>default value</th>
+              <th>since</th>
+            </tr>
+            <tr>
+              <td>query</td>
+              <td>Specify Xpath query.</td>
+              <td><a href="../../property_types.html#String">String</a></td>
+              <td><code>""</code></td>
+              <td>8.39</td>
+            </tr>
+          </table>
+        </div>
+      </subsection>
+
+      <subsection name="Examples" id="Examples">
+        <p>
+          Checkstyle provides <a href="https://checkstyle.org/cmdline.html">command line tool</a>
+          and <a href="https://checkstyle.org/writingchecks.html#The_Checkstyle_SDK_Gui">GUI
+          application</a> with options to show AST and to ease usage of Xpath queries.
+        </p>
+        <p><b>-T</b> option prints AST tree of the checked file.</p>
+        <source>
+$ java -jar checkstyle-X.XX-all.jar -T Main.java
+CLASS_DEF -&gt; CLASS_DEF [1:0]
+|--MODIFIERS -&gt; MODIFIERS [1:0]
+|   `--LITERAL_PUBLIC -&gt; public [1:0]
+|--LITERAL_CLASS -&gt; class [1:7]
+|--IDENT -&gt; Main [1:13]
+`--OBJBLOCK -&gt; OBJBLOCK [1:18]
+|--LCURLY -&gt; { [1:18]
+|--METHOD_DEF -&gt; METHOD_DEF [2:4]
+|   |--MODIFIERS -&gt; MODIFIERS [2:4]
+|   |   `--LITERAL_PUBLIC -&gt; public [2:4]
+|   |--TYPE -&gt; TYPE [2:11]
+|   |   `--IDENT -&gt; String [2:11]
+|   |--IDENT -&gt; sayHello [2:18]
+|   |--LPAREN -&gt; ( [2:26]
+|   |--PARAMETERS -&gt; PARAMETERS [2:27]
+|   |   `--PARAMETER_DEF -&gt; PARAMETER_DEF [2:27]
+|   |       |--MODIFIERS -&gt; MODIFIERS [2:27]
+|   |       |--TYPE -&gt; TYPE [2:27]
+|   |       |   `--IDENT -&gt; String [2:27]
+|   |       `--IDENT -&gt; name [2:34]
+|   |--RPAREN -&gt; ) [2:38]
+|   `--SLIST -&gt; { [2:40]
+|       |--LITERAL_RETURN -&gt; return [3:8]
+|       |   |--EXPR -&gt; EXPR [3:25]
+|       |   |   `--PLUS -&gt; + [3:25]
+|       |   |       |--STRING_LITERAL -&gt; "Hello, " [3:15]
+|       |   |       `--IDENT -&gt; name [3:27]
+|       |   `--SEMI -&gt; ; [3:31]
+|       `--RCURLY -&gt; } [4:4]
+`--RCURLY -&gt; } [5:0]
+        </source>
+        <p><b>-b</b> option shows AST nodes that match given Xpath query. This command can be
+          used to validate accuracy of Xpath query against given file.</p>
+        <source>
+$ java -jar checkstyle-X.XX-all.jar Main.java -b "//METHOD_DEF[./IDENT[@text='sayHello']]"
+CLASS_DEF -&gt; CLASS_DEF [1:0]
+`--OBJBLOCK -&gt; OBJBLOCK [1:18]
+|--METHOD_DEF -&gt; METHOD_DEF [2:4]
+        </source>
+        <p>The following example demonstrates validation of methods order, so that public methods
+          should come before the private ones:</p>
+        <source>
+&lt;module name="MatchXpath"&gt;
+  &lt;property name="query" value="//METHOD_DEF[.//LITERAL_PRIVATE and
+          following-sibling::METHOD_DEF[.//LITERAL_PUBLIC]]"/&gt;
+  &lt;message key="matchxpath.match"
+          value="Private methods must appear after public methods"/&gt;
+&lt;/module&gt;
+        </source>
+        <p>Example:</p>
+        <source>
+public class Test {
+  public void method1() { }
+  private void method2() { } // violation
+  public void method3() { }
+  private void method4() { } // violation
+  public void method5() { }
+  private void method6() { } // ok
+}
+        </source>
+        <p>To violate if there are any parametrized constructors</p>
+        <source>
+&lt;module name="MatchXpath"&gt;
+  &lt;property name="query" value="//CTOR_DEF[count(./PARAMETERS/*)
+          &gt; 0]"/&gt;
+  &lt;message key="matchxpath.match"
+          value="Parameterized constructors are not allowed, there should be only default
+          ctor"/&gt;
+&lt;/module&gt;
+        </source>
+        <p>Example:</p>
+        <source>
+public class Test {
+  public Test(Object c) { } // violation
+  public Test(int a, HashMap&lt;String, Integer&gt; b) { } // violation
+  public Test() { } // ok
+}
+        </source>
+        <p>To violate if method name is 'test' or 'foo'</p>
+        <source>
+&lt;module name="MatchXpath"&gt;
+  &lt;property name="query" value="//METHOD_DEF[./IDENT[@text='test'
+          or @text='foo']]"/&gt;
+  &lt;message key="matchxpath.match"
+          value="Method name should not be 'test' or 'foo'"/&gt;
+&lt;/module&gt;
+        </source>
+        <p>Example:</p>
+        <source>
+public class Test {
+  public void test() {} // violation
+  public void getName() {} // ok
+  public void foo() {} // violation
+  public void sayHello() {} // ok
+}
+        </source>
+        <p>To violate if new instance creation was done without <b>var</b> type</p>
+        <source>
+&lt;module name="MatchXpath"&gt;
+  &lt;property name="query" value="//VARIABLE_DEF[./ASSIGN/EXPR/LITERAL_NEW
+          and not(./TYPE/IDENT[@text='var'])]"/&gt;
+  &lt;message key="matchxpath.match"
+          value="New instances should be created via 'var' keyword to avoid duplication of
+          type reference in statement"/&gt;
+&lt;/module&gt;
+        </source>
+        <p>Example:</p>
+        <source>
+public class Test {
+  public void foo() {
+    SomeObject a = new SomeObject(); // violation
+    var b = new SomeObject(); // OK
+  }
+}
+        </source>
+      </subsection>
+
+      <subsection name="Example of Usage" id="Example_of_Usage">
+        <ul>
+          <li>
+            <a href="https://github.com/search?q=path%3Aconfig%20path%3A**%2Fcheckstyle-checks.xml+repo%3Acheckstyle%2Fcheckstyle+MatchXpath">
+              Checkstyle Style</a>
+          </li>
+        </ul>
+      </subsection>
+
+      <subsection name="Violation Messages" id="Violation_Messages">
+        <ul>
+          <li>
+            <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources%2Fcom%2Fpuppycrawl%2Ftools%2Fcheckstyle%2Fchecks%2Fcoding%20path%3A**%2Fmessages*.properties+repo%3Acheckstyle%2Fcheckstyle+%22matchxpath.match%22">
+              matchxpath.match</a>
+          </li>
+        </ul>
+        <p>
+          All messages can be customized if the default message doesn't suit you.
+          Please <a href="../../config.html#Custom_messages">see the documentation</a>
+          to learn how to.
+        </p>
+      </subsection>
+
+      <subsection name="Package" id="Package">
+        <p>
+          com.puppycrawl.tools.checkstyle.checks.coding
+        </p>
+      </subsection>
+
+      <subsection name="Parent Module" id="Parent_Module">
+        <p>
+          <a href="../../config.html#TreeWalker">TreeWalker</a>
+        </p>
+      </subsection>
+    </section>
+  </body>
+</document>

--- a/src/xdocs/checks/coding/missingctor.xml
+++ b/src/xdocs/checks/coding/missingctor.xml
@@ -20,7 +20,7 @@
           To configure the check:
         </p>
         <source>
-&lt;module name="MissingCtor"/&gt;
+&lt;module name=&quot;MissingCtor&quot;/&gt;
         </source>
         <p>Example:</p>
         <source>
@@ -33,7 +33,7 @@ class ExampleOk { // OK
 class ExampleDefaultCtor { // OK
   private String s;
   ExampleDefaultCtor() {
-    s = "foobar";
+    s = &quot;foobar&quot;;
   }
 }
 class InvalidExample { // violation, class must have a constructor.

--- a/src/xdocs/checks/coding/missingctor.xml.template
+++ b/src/xdocs/checks/coding/missingctor.xml.template
@@ -1,0 +1,84 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<document xmlns="http://maven.apache.org/XDOC/2.0"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/XDOC/2.0 https://maven.apache.org/xsd/xdoc-2.0.xsd">
+  <head>
+    <title>MissingCtor</title>
+  </head>
+  <body>
+    <section name="MissingCtor">
+      <p>Since Checkstyle 3.4</p>
+      <subsection name="Description" id="Description">
+        <p>
+          Checks that classes (except abstract ones) define a constructor and don't
+          rely on the default one.
+        </p>
+      </subsection>
+
+      <subsection name="Examples" id="Examples">
+        <p>
+          To configure the check:
+        </p>
+        <source>
+&lt;module name="MissingCtor"/&gt;
+        </source>
+        <p>Example:</p>
+        <source>
+class ExampleOk { // OK
+  private int a;
+  ExampleOk(int a) {
+    this.a = a;
+  }
+}
+class ExampleDefaultCtor { // OK
+  private String s;
+  ExampleDefaultCtor() {
+    s = "foobar";
+  }
+}
+class InvalidExample { // violation, class must have a constructor.
+  public void test() {}
+}
+abstract class AbstractExample { // OK
+  public abstract void test() {}
+}
+        </source>
+      </subsection>
+
+      <subsection name="Example of Usage" id="Example_of_Usage">
+        <ul>
+          <li>
+            <a href="https://github.com/search?q=path%3Aconfig%20path%3A**%2Fcheckstyle-checks.xml+repo%3Acheckstyle%2Fcheckstyle+MissingCtor">
+            Checkstyle Style</a>
+          </li>
+        </ul>
+      </subsection>
+
+      <subsection name="Violation Messages" id="Violation_Messages">
+        <ul>
+          <li>
+            <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources%2Fcom%2Fpuppycrawl%2Ftools%2Fcheckstyle%2Fchecks%2Fcoding%20path%3A**%2Fmessages*.properties+repo%3Acheckstyle%2Fcheckstyle+%22missing.ctor%22">
+            missing.ctor</a>
+          </li>
+        </ul>
+        <p>
+          All messages can be customized if the default message doesn't suit you.
+          Please <a href="../../config.html#Custom_messages">see the documentation</a>
+          to learn how to.
+        </p>
+      </subsection>
+
+      <subsection name="Package" id="Package">
+        <p>
+          com.puppycrawl.tools.checkstyle.checks.coding
+        </p>
+      </subsection>
+
+      <subsection name="Parent Module" id="Parent_Module">
+        <p>
+          <a href="../../config.html#TreeWalker">TreeWalker</a>
+        </p>
+      </subsection>
+    </section>
+  </body>
+</document>

--- a/src/xdocs/checks/coding/missingswitchdefault.xml
+++ b/src/xdocs/checks/coding/missingswitchdefault.xml
@@ -45,7 +45,7 @@
           To configure the check:
         </p>
         <source>
-&lt;module name="MissingSwitchDefault"/&gt;
+&lt;module name=&quot;MissingSwitchDefault&quot;/&gt;
         </source>
         <p>
           Example of violation:
@@ -75,7 +75,7 @@ switch (o) {
         System.out.println(s);
         break;
     case Integer i: // type pattern
-        System.out.println("Integer");
+        System.out.println(&quot;Integer&quot;);
         break;
     default:    // will not compile without default label, thanks to type pattern label usage
         break;
@@ -100,9 +100,9 @@ record C(int i) implements S {}  // Implicitly final
  */
 static void showSealedCompleteness(S s) {
     switch (s) {
-        case A a: System.out.println("A"); break;
-        case B b: System.out.println("B"); break;
-        case C c: System.out.println("C"); break;
+        case A a: System.out.println(&quot;A&quot;); break;
+        case B b: System.out.println(&quot;B&quot;); break;
+        case C c: System.out.println(&quot;C&quot;); break;
     }
 }
 
@@ -116,7 +116,7 @@ static void showSealedCompleteness(S s) {
 static void showTotality(String s) {
     switch (s) {
         case Object o: // total type pattern
-            System.out.println("o!");
+            System.out.println(&quot;o!&quot;);
     }
 }
 
@@ -124,13 +124,13 @@ enum Color { RED, GREEN, BLUE }
 
 static int showSwitchExpressionExhaustiveness(Color color) {
     switch (color) {
-        case RED: System.out.println("RED"); break;
-        case BLUE: System.out.println("BLUE"); break;
-        case GREEN: System.out.println("GREEN"); break;
+        case RED: System.out.println(&quot;RED&quot;); break;
+        case BLUE: System.out.println(&quot;BLUE&quot;); break;
+        case GREEN: System.out.println(&quot;GREEN&quot;); break;
         // Check will require default label below, compiler
         // does not enforce a switch statement with constants
         // to be complete.
-        default: System.out.println("Something else");
+        default: System.out.println(&quot;Something else&quot;);
     }
 
     // Check will not require default label in switch

--- a/src/xdocs/checks/coding/missingswitchdefault.xml.template
+++ b/src/xdocs/checks/coding/missingswitchdefault.xml.template
@@ -1,0 +1,196 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<document xmlns="http://maven.apache.org/XDOC/2.0"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/XDOC/2.0 https://maven.apache.org/xsd/xdoc-2.0.xsd">
+  <head>
+    <title>MissingSwitchDefault</title>
+  </head>
+  <body>
+    <section name="MissingSwitchDefault">
+      <p>Since Checkstyle 3.1</p>
+      <subsection name="Description" id="Description">
+        <p>
+          Checks that switch statement has a <code>default</code> clause.
+        </p>
+
+        <p>
+          Rationale: It's usually a good idea to introduce a default case in
+          every switch statement. Even if the developer is sure that all
+          currently possible cases are covered, this should be expressed in
+          the default branch, e.g. by using an assertion. This way the code is
+          protected against later changes, e.g. introduction of new types in an
+          enumeration type.
+        </p>
+        <p>
+          This check does not validate any switch expressions. Rationale:
+          The compiler requires switch expressions to be exhaustive. This means
+          that all possible inputs must be covered.
+        </p>
+        <p>
+          This check does not validate switch statements that use pattern or null
+          labels. Rationale: Switch statements that use pattern or null labels are
+          checked by the compiler for exhaustiveness. This means that all possible
+          inputs must be covered.
+        </p>
+        <p>
+          See the
+          <a href="https://docs.oracle.com/javase/specs/jls/se17/html/jls-15.html#jls-15.28">
+          Java Language Specification</a> for more information about switch statements
+          and expressions.
+        </p>
+      </subsection>
+
+      <subsection name="Examples" id="Examples">
+        <p>
+          To configure the check:
+        </p>
+        <source>
+&lt;module name="MissingSwitchDefault"/&gt;
+        </source>
+        <p>
+          Example of violation:
+        </p>
+        <source>
+switch (i) {    // violation
+  case 1:
+    break;
+  case 2:
+    break;
+}
+        </source>
+        <p>
+          Example of correct code:
+        </p>
+        <source>
+switch (i) {
+  case 1:
+    break;
+  case 2:
+    break;
+  default: // OK
+    break;
+}
+switch (o) {
+    case String s: // type pattern
+        System.out.println(s);
+        break;
+    case Integer i: // type pattern
+        System.out.println("Integer");
+        break;
+    default:    // will not compile without default label, thanks to type pattern label usage
+        break;
+}
+        </source>
+        <p>
+          Example of correct code which does not require default labels:
+        </p>
+        <source>
+sealed interface S permits A, B, C {}
+final class A implements S {}
+final class B implements S {}
+record C(int i) implements S {}  // Implicitly final
+
+/**
+ * The completeness of a switch statement can be
+ * determined by the contents of the permits clause
+ * of interface S. No default label or default case
+ * label is allowed by the compiler in this situation, so
+ * this check does not enforce a default label in such
+ * statements.
+ */
+static void showSealedCompleteness(S s) {
+    switch (s) {
+        case A a: System.out.println("A"); break;
+        case B b: System.out.println("B"); break;
+        case C c: System.out.println("C"); break;
+    }
+}
+
+/**
+ * A total type pattern matches all possible inputs,
+ * including null. A default label or
+ * default case is not allowed by the compiler in this
+ * situation. Accordingly, check does not enforce a
+ * default label in this case.
+ */
+static void showTotality(String s) {
+    switch (s) {
+        case Object o: // total type pattern
+            System.out.println("o!");
+    }
+}
+
+enum Color { RED, GREEN, BLUE }
+
+static int showSwitchExpressionExhaustiveness(Color color) {
+    switch (color) {
+        case RED: System.out.println("RED"); break;
+        case BLUE: System.out.println("BLUE"); break;
+        case GREEN: System.out.println("GREEN"); break;
+        // Check will require default label below, compiler
+        // does not enforce a switch statement with constants
+        // to be complete.
+        default: System.out.println("Something else");
+    }
+
+    // Check will not require default label in switch
+    // expression below, because code will not compile
+    // if all possible values are not handled. If the
+    // 'Color' enum is extended, code will fail to compile.
+    return switch (color) {
+        case RED:
+            yield 1;
+        case GREEN:
+            yield 2;
+        case BLUE:
+            yield 3;
+    };
+}
+        </source>
+      </subsection>
+
+      <subsection name="Example of Usage" id="Example_of_Usage">
+        <ul>
+          <li>
+            <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources%20path%3A**%2Fgoogle_checks.xml+repo%3Acheckstyle%2Fcheckstyle+MissingSwitchDefault">
+            Google Style</a>
+          </li>
+          <li>
+            <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources%20path%3A**%2Fsun_checks.xml+repo%3Acheckstyle%2Fcheckstyle+MissingSwitchDefault">
+            Sun Style</a>
+          </li>
+          <li>
+            <a href="https://github.com/search?q=path%3Aconfig%20path%3A**%2Fcheckstyle-checks.xml+repo%3Acheckstyle%2Fcheckstyle+MissingSwitchDefault">
+            Checkstyle Style</a>
+          </li>
+        </ul>
+      </subsection>
+
+      <subsection name="Violation Messages" id="Violation_Messages">
+        <ul>
+          <li>
+            <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources%2Fcom%2Fpuppycrawl%2Ftools%2Fcheckstyle%2Fchecks%2Fcoding%20path%3A**%2Fmessages*.properties+repo%3Acheckstyle%2Fcheckstyle+%22missing.switch.default%22">
+            missing.switch.default</a>
+          </li>
+        </ul>
+        <p>
+          All messages can be customized if the default message doesn't suit you.
+          Please <a href="../../config.html#Custom_messages">see the documentation</a>
+          to learn how to.
+        </p>
+      </subsection>
+
+      <subsection name="Package" id="Package">
+        <p>
+          com.puppycrawl.tools.checkstyle.checks.coding
+        </p>
+      </subsection>
+
+      <subsection name="Parent Module" id="Parent_Module">
+        <p>
+          <a href="../../config.html#TreeWalker">TreeWalker</a>
+        </p>
+      </subsection>
+    </section>
+  </body>
+</document>

--- a/src/xdocs/checks/coding/modifiedcontrolvariable.xml
+++ b/src/xdocs/checks/coding/modifiedcontrolvariable.xml
@@ -78,7 +78,7 @@ for (int a[]={0};a[0] &lt; 10;a[0]++) {
           To configure the check:
         </p>
         <source>
-&lt;module name="ModifiedControlVariable"/&gt;
+&lt;module name=&quot;ModifiedControlVariable&quot;/&gt;
         </source>
         <p>
           Example:
@@ -87,7 +87,7 @@ for (int a[]={0};a[0] &lt; 10;a[0]++) {
 for(int i=0;i &lt; 8;i++) {
   i++; // violation, control variable modified
 }
-String args1[]={"Coding", "block"};
+String args1[]={&quot;Coding&quot;, &quot;block&quot;};
 for (String arg: args1) {
   arg = arg.trim(); // violation, control variable modified
 }
@@ -105,8 +105,8 @@ for (String arg: args1) {
           An example of how to configure the check so that it skips enhanced For Loop Variable is:
         </p>
         <source>
-&lt;module name="ModifiedControlVariable"&gt;
-  &lt;property name="skipEnhancedForLoopVariable" value="true"/&gt;
+&lt;module name=&quot;ModifiedControlVariable&quot;&gt;
+  &lt;property name=&quot;skipEnhancedForLoopVariable&quot; value=&quot;true&quot;/&gt;
 &lt;/module&gt;
         </source>
         <p>Example:</p>
@@ -114,7 +114,7 @@ for (String arg: args1) {
 for(int i=0;i &lt; 8;i++) {
   i++; // violation, control variable modified
 }
-String args1[]={"Coding", "block"};
+String args1[]={&quot;Coding&quot;, &quot;block&quot;};
 for (String arg: args1) {
   arg = arg.trim(); // ok
 }

--- a/src/xdocs/checks/coding/modifiedcontrolvariable.xml.template
+++ b/src/xdocs/checks/coding/modifiedcontrolvariable.xml.template
@@ -1,0 +1,160 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<document xmlns="http://maven.apache.org/XDOC/2.0"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/XDOC/2.0 https://maven.apache.org/xsd/xdoc-2.0.xsd">
+  <head>
+    <title>ModifiedControlVariable</title>
+  </head>
+  <body>
+    <section name="ModifiedControlVariable">
+      <p>Since Checkstyle 3.5</p>
+      <subsection name="Description" id="Description">
+        <p>
+            Checks that for loop control variables are not modified inside
+            the for block. An example is:
+        </p>
+        <source>
+for (int i = 0; i &lt; 1; i++) {
+  i++; // violation
+}
+        </source>
+        <p>
+          Rationale: If the control variable is modified inside the loop
+          body, the program flow becomes more difficult to follow. See
+          <a href="https://docs.oracle.com/javase/specs/jls/se11/html/jls-14.html#jls-14.14">
+          FOR statement</a> specification for more details.
+        </p>
+        <p>
+          Such loop would be suppressed:
+        </p>
+        <source>
+for (int i = 0; i &lt; 10;) {
+  i++;
+}
+        </source>
+        <p>
+          NOTE:The check works with only primitive type variables.
+          The check will not work for arrays used as control variable.An example is
+        </p>
+        <source>
+for (int a[]={0};a[0] &lt; 10;a[0]++) {
+ a[0]++;   // it will skip this violation
+}
+        </source>
+      </subsection>
+
+      <subsection name="Properties" id="Properties">
+        <div class="wrapper">
+          <table>
+            <tr class="header">
+              <th>name</th>
+              <th>description</th>
+              <th>type</th>
+              <th>default value</th>
+              <th>since</th>
+            </tr>
+
+            <tr>
+              <td>skipEnhancedForLoopVariable</td>
+              <td>
+                Control whether to check
+                <a href="https://docs.oracle.com/javase/specs/jls/se11/html/jls-14.html#jls-14.14.2">
+                  enhanced for-loop</a> variable.
+              </td>
+              <td>
+                <a href="../../property_types.html#boolean">boolean</a>
+              </td>
+              <td>
+                <code>false</code>
+              </td>
+              <td>6.8</td>
+            </tr>
+          </table>
+        </div>
+      </subsection>
+
+      <subsection name="Examples" id="Examples">
+        <p>
+          To configure the check:
+        </p>
+        <source>
+&lt;module name="ModifiedControlVariable"/&gt;
+        </source>
+        <p>
+          Example:
+        </p>
+        <source>
+for(int i=0;i &lt; 8;i++) {
+  i++; // violation, control variable modified
+}
+String args1[]={"Coding", "block"};
+for (String arg: args1) {
+  arg = arg.trim(); // violation, control variable modified
+}
+        </source>
+        <p>
+          By default, This Check validates
+          <a href="https://docs.oracle.com/javase/specs/jls/se11/html/jls-14.html#jls-14.14.2">
+          Enhanced For-Loop</a>.
+        </p>
+        <p>
+          Option 'skipEnhancedForLoopVariable' could be used to skip check of variable
+          from Enhanced For Loop.
+        </p>
+        <p>
+          An example of how to configure the check so that it skips enhanced For Loop Variable is:
+        </p>
+        <source>
+&lt;module name="ModifiedControlVariable"&gt;
+  &lt;property name="skipEnhancedForLoopVariable" value="true"/&gt;
+&lt;/module&gt;
+        </source>
+        <p>Example:</p>
+        <source>
+for(int i=0;i &lt; 8;i++) {
+  i++; // violation, control variable modified
+}
+String args1[]={"Coding", "block"};
+for (String arg: args1) {
+  arg = arg.trim(); // ok
+}
+        </source>
+      </subsection>
+
+      <subsection name="Example of Usage" id="Example_of_Usage">
+        <ul>
+          <li>
+            <a href="https://github.com/search?q=path%3Aconfig%20path%3A**%2Fcheckstyle-checks.xml+repo%3Acheckstyle%2Fcheckstyle+ModifiedControlVariable">
+            Checkstyle Style</a>
+          </li>
+        </ul>
+      </subsection>
+
+      <subsection name="Violation Messages" id="Violation_Messages">
+        <ul>
+          <li>
+            <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources%2Fcom%2Fpuppycrawl%2Ftools%2Fcheckstyle%2Fchecks%2Fcoding%20path%3A**%2Fmessages*.properties+repo%3Acheckstyle%2Fcheckstyle+%22modified.control.variable%22">
+            modified.control.variable</a>
+          </li>
+        </ul>
+        <p>
+          All messages can be customized if the default message doesn't suit you.
+          Please <a href="../../config.html#Custom_messages">see the documentation</a>
+          to learn how to.
+        </p>
+      </subsection>
+
+      <subsection name="Package" id="Package">
+        <p>
+          com.puppycrawl.tools.checkstyle.checks.coding
+        </p>
+      </subsection>
+
+      <subsection name="Parent Module" id="Parent_Module">
+        <p>
+          <a href="../../config.html#TreeWalker">TreeWalker</a>
+        </p>
+      </subsection>
+    </section>
+  </body>
+</document>

--- a/src/xdocs/checks/coding/multiplestringliterals.xml
+++ b/src/xdocs/checks/coding/multiplestringliterals.xml
@@ -46,7 +46,7 @@
                 Specify RegExp for ignored strings (with quotation marks).
               </td>
               <td><a href="../../property_types.html#Pattern">Pattern</a></td>
-              <td><code>"^""$"</code></td>
+              <td><code>&quot;^&quot;&quot;$&quot;</code></td>
               <td>4.0</td>
             </tr>
             <tr>
@@ -74,19 +74,19 @@
           To configure the check:
         </p>
         <source>
-&lt;module name="MultipleStringLiterals"/&gt;
+&lt;module name=&quot;MultipleStringLiterals&quot;/&gt;
         </source>
         <p>Example:</p>
         <source>
 public class MyClass {
-  String a = "StringContents";
-  String a1 = "unchecked";
-  @SuppressWarnings("unchecked") // OK, duplicate strings are ignored in annotations
+  String a = &quot;StringContents&quot;;
+  String a1 = &quot;unchecked&quot;;
+  @SuppressWarnings(&quot;unchecked&quot;) // OK, duplicate strings are ignored in annotations
   public void myTest() {
-    String a2 = "StringContents"; // violation, "StringContents" occurs twice
-    String a3 = "DoubleString" + "DoubleString"; // violation, "DoubleString" occurs twice
-    String a4 = "SingleString"; // OK
-    String a5 = ", " + ", " + ", "; // violation, ", " occurs three times
+    String a2 = &quot;StringContents&quot;; // violation, &quot;StringContents&quot; occurs twice
+    String a3 = &quot;DoubleString&quot; + &quot;DoubleString&quot;; // violation, &quot;DoubleString&quot; occurs twice
+    String a4 = &quot;SingleString&quot;; // OK
+    String a5 = &quot;, &quot; + &quot;, &quot; + &quot;, &quot;; // violation, &quot;, &quot; occurs three times
   }
 }
         </source>
@@ -95,68 +95,68 @@ public class MyClass {
           string:
         </p>
         <source>
-&lt;module name="MultipleStringLiterals"&gt;
-  &lt;property name="allowedDuplicates" value="2"/&gt;
+&lt;module name=&quot;MultipleStringLiterals&quot;&gt;
+  &lt;property name=&quot;allowedDuplicates&quot; value=&quot;2&quot;/&gt;
 &lt;/module&gt;
         </source>
         <p>Example:</p>
         <source>
 public class MyClass {
-  String a = "StringContents";
-  String a1 = "unchecked";
-  @SuppressWarnings("unchecked") // OK, duplicate strings are ignored in annotations
+  String a = &quot;StringContents&quot;;
+  String a1 = &quot;unchecked&quot;;
+  @SuppressWarnings(&quot;unchecked&quot;) // OK, duplicate strings are ignored in annotations
   public void myTest() {
-    String a2 = "StringContents"; // OK, two occurrences are allowed
-    String a3 = "DoubleString" + "DoubleString"; // OK, two occurrences are allowed
-    String a4 = "SingleString"; // OK
-    String a5 = ", " + ", " + ", "; // violation, three occurrences are NOT allowed
+    String a2 = &quot;StringContents&quot;; // OK, two occurrences are allowed
+    String a3 = &quot;DoubleString&quot; + &quot;DoubleString&quot;; // OK, two occurrences are allowed
+    String a4 = &quot;SingleString&quot;; // OK
+    String a5 = &quot;, &quot; + &quot;, &quot; + &quot;, &quot;; // violation, three occurrences are NOT allowed
   }
 }
         </source>
         <p>
-          To configure the check so that it ignores ", " and empty strings:
+          To configure the check so that it ignores &quot;, &quot; and empty strings:
         </p>
         <source>
-&lt;module name="MultipleStringLiterals"&gt;
-  &lt;property name="ignoreStringsRegexp"
-    value='^(("")|(", "))$'/&gt;
+&lt;module name=&quot;MultipleStringLiterals&quot;&gt;
+  &lt;property name=&quot;ignoreStringsRegexp&quot;
+    value='^((&quot;&quot;)|(&quot;, &quot;))$'/&gt;
 &lt;/module&gt;
         </source>
         <p>Example:</p>
         <source>
 public class MyClass {
-  String a = "StringContents";
-  String a1 = "unchecked";
-  @SuppressWarnings("unchecked") // OK, duplicate strings are ignored in annotations
+  String a = &quot;StringContents&quot;;
+  String a1 = &quot;unchecked&quot;;
+  @SuppressWarnings(&quot;unchecked&quot;) // OK, duplicate strings are ignored in annotations
   public void myTest() {
-    String a2 = "StringContents"; // violation, "StringContents" occurs twice
-    String a3 = "DoubleString" + "DoubleString"; // violation, "DoubleString" occurs twice
-    String a4 = "SingleString"; // OK
-    String a5 = ", " + ", " + ", "; // OK, multiple occurrences of ", " are allowed
+    String a2 = &quot;StringContents&quot;; // violation, &quot;StringContents&quot; occurs twice
+    String a3 = &quot;DoubleString&quot; + &quot;DoubleString&quot;; // violation, &quot;DoubleString&quot; occurs twice
+    String a4 = &quot;SingleString&quot;; // OK
+    String a5 = &quot;, &quot; + &quot;, &quot; + &quot;, &quot;; // OK, multiple occurrences of &quot;, &quot; are allowed
   }
 }
         </source>
         <p>
           To configure the check so that it flags duplicate strings in all
           syntactical contexts, even in annotations like
-          <code>@SuppressWarnings("unchecked")</code>:
+          <code>@SuppressWarnings(&quot;unchecked&quot;)</code>:
         </p>
         <source>
-&lt;module name="MultipleStringLiterals"&gt;
-  &lt;property name="ignoreOccurrenceContext" value=""/&gt;
+&lt;module name=&quot;MultipleStringLiterals&quot;&gt;
+  &lt;property name=&quot;ignoreOccurrenceContext&quot; value=&quot;&quot;/&gt;
 &lt;/module&gt;
         </source>
         <p>Example:</p>
         <source>
 public class MyClass {
-  String a = "StringContents";
-  String a1 = "unchecked";
-  @SuppressWarnings("unchecked") // violation, "unchecked" occurs twice
+  String a = &quot;StringContents&quot;;
+  String a1 = &quot;unchecked&quot;;
+  @SuppressWarnings(&quot;unchecked&quot;) // violation, &quot;unchecked&quot; occurs twice
   public void myTest() {
-    String a2 = "StringContents"; // violation, "StringContents" occurs twice
-    String a3 = "DoubleString" + "DoubleString"; // violation, "DoubleString" occurs twice
-    String a4 = "SingleString"; // OK
-    String a5 = ", " + ", " + ", "; // violation, ", " occurs three times
+    String a2 = &quot;StringContents&quot;; // violation, &quot;StringContents&quot; occurs twice
+    String a3 = &quot;DoubleString&quot; + &quot;DoubleString&quot;; // violation, &quot;DoubleString&quot; occurs twice
+    String a4 = &quot;SingleString&quot;; // OK
+    String a5 = &quot;, &quot; + &quot;, &quot; + &quot;, &quot;; // violation, &quot;, &quot; occurs three times
   }
 }
         </source>

--- a/src/xdocs/checks/coding/multiplestringliterals.xml.template
+++ b/src/xdocs/checks/coding/multiplestringliterals.xml.template
@@ -1,0 +1,201 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<document xmlns="http://maven.apache.org/XDOC/2.0"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/XDOC/2.0 https://maven.apache.org/xsd/xdoc-2.0.xsd">
+  <head>
+    <title>MultipleStringLiterals</title>
+  </head>
+  <body>
+    <section name="MultipleStringLiterals">
+      <p>Since Checkstyle 3.5</p>
+      <subsection name="Description" id="Description">
+        <p>
+          Checks for multiple occurrences of the same string literal within a
+          single file.
+        </p>
+
+        <p>
+          Rationale: Code duplication makes maintenance more difficult, so it
+          can be better to replace the multiple occurrences with a constant.
+        </p>
+      </subsection>
+
+      <subsection name="Properties" id="Properties">
+        <div class="wrapper">
+          <table>
+            <tr>
+              <th>name</th>
+              <th>description</th>
+              <th>type</th>
+              <th>default value</th>
+              <th>since</th>
+            </tr>
+            <tr>
+              <td>allowedDuplicates</td>
+              <td>
+                Specify the maximum number of occurrences to allow without generating a
+                warning.
+              </td>
+              <td><a href="../../property_types.html#int">int</a></td>
+              <td><code>1</code></td>
+              <td>3.5</td>
+            </tr>
+            <tr>
+              <td>ignoreStringsRegexp</td>
+              <td>
+                Specify RegExp for ignored strings (with quotation marks).
+              </td>
+              <td><a href="../../property_types.html#Pattern">Pattern</a></td>
+              <td><code>"^""$"</code></td>
+              <td>4.0</td>
+            </tr>
+            <tr>
+              <td>ignoreOccurrenceContext</td>
+              <td>
+                Specify token type names where duplicate strings are ignored even if they don't
+                match ignoredStringsRegexp. This allows you to exclude syntactical contexts like
+                annotations or static initializers from the check.
+              </td>
+              <td>
+                subset of tokens
+                <a href="../../apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html">TokenTypes</a>
+              </td>
+              <td>
+                <code>ANNOTATION</code>
+              </td>
+              <td>4.4</td>
+            </tr>
+          </table>
+        </div>
+      </subsection>
+
+      <subsection name="Examples" id="Examples">
+        <p>
+          To configure the check:
+        </p>
+        <source>
+&lt;module name="MultipleStringLiterals"/&gt;
+        </source>
+        <p>Example:</p>
+        <source>
+public class MyClass {
+  String a = "StringContents";
+  String a1 = "unchecked";
+  @SuppressWarnings("unchecked") // OK, duplicate strings are ignored in annotations
+  public void myTest() {
+    String a2 = "StringContents"; // violation, "StringContents" occurs twice
+    String a3 = "DoubleString" + "DoubleString"; // violation, "DoubleString" occurs twice
+    String a4 = "SingleString"; // OK
+    String a5 = ", " + ", " + ", "; // violation, ", " occurs three times
+  }
+}
+        </source>
+        <p>
+          To configure the check so that it allows two occurrences of each
+          string:
+        </p>
+        <source>
+&lt;module name="MultipleStringLiterals"&gt;
+  &lt;property name="allowedDuplicates" value="2"/&gt;
+&lt;/module&gt;
+        </source>
+        <p>Example:</p>
+        <source>
+public class MyClass {
+  String a = "StringContents";
+  String a1 = "unchecked";
+  @SuppressWarnings("unchecked") // OK, duplicate strings are ignored in annotations
+  public void myTest() {
+    String a2 = "StringContents"; // OK, two occurrences are allowed
+    String a3 = "DoubleString" + "DoubleString"; // OK, two occurrences are allowed
+    String a4 = "SingleString"; // OK
+    String a5 = ", " + ", " + ", "; // violation, three occurrences are NOT allowed
+  }
+}
+        </source>
+        <p>
+          To configure the check so that it ignores ", " and empty strings:
+        </p>
+        <source>
+&lt;module name="MultipleStringLiterals"&gt;
+  &lt;property name="ignoreStringsRegexp"
+    value='^(("")|(", "))$'/&gt;
+&lt;/module&gt;
+        </source>
+        <p>Example:</p>
+        <source>
+public class MyClass {
+  String a = "StringContents";
+  String a1 = "unchecked";
+  @SuppressWarnings("unchecked") // OK, duplicate strings are ignored in annotations
+  public void myTest() {
+    String a2 = "StringContents"; // violation, "StringContents" occurs twice
+    String a3 = "DoubleString" + "DoubleString"; // violation, "DoubleString" occurs twice
+    String a4 = "SingleString"; // OK
+    String a5 = ", " + ", " + ", "; // OK, multiple occurrences of ", " are allowed
+  }
+}
+        </source>
+        <p>
+          To configure the check so that it flags duplicate strings in all
+          syntactical contexts, even in annotations like
+          <code>@SuppressWarnings("unchecked")</code>:
+        </p>
+        <source>
+&lt;module name="MultipleStringLiterals"&gt;
+  &lt;property name="ignoreOccurrenceContext" value=""/&gt;
+&lt;/module&gt;
+        </source>
+        <p>Example:</p>
+        <source>
+public class MyClass {
+  String a = "StringContents";
+  String a1 = "unchecked";
+  @SuppressWarnings("unchecked") // violation, "unchecked" occurs twice
+  public void myTest() {
+    String a2 = "StringContents"; // violation, "StringContents" occurs twice
+    String a3 = "DoubleString" + "DoubleString"; // violation, "DoubleString" occurs twice
+    String a4 = "SingleString"; // OK
+    String a5 = ", " + ", " + ", "; // violation, ", " occurs three times
+  }
+}
+        </source>
+      </subsection>
+
+      <subsection name="Example of Usage" id="Example_of_Usage">
+        <ul>
+          <li>
+            <a href="https://github.com/search?q=path%3Aconfig%20path%3A**%2Fcheckstyle-checks.xml+repo%3Acheckstyle%2Fcheckstyle+MultipleStringLiterals">
+            Checkstyle Style</a>
+          </li>
+        </ul>
+      </subsection>
+
+      <subsection name="Violation Messages" id="Violation_Messages">
+        <ul>
+          <li>
+            <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources%2Fcom%2Fpuppycrawl%2Ftools%2Fcheckstyle%2Fchecks%2Fcoding%20path%3A**%2Fmessages*.properties+repo%3Acheckstyle%2Fcheckstyle+%22multiple.string.literal%22">
+            multiple.string.literal</a>
+          </li>
+        </ul>
+        <p>
+          All messages can be customized if the default message doesn't suit you.
+          Please <a href="../../config.html#Custom_messages">see the documentation</a>
+          to learn how to.
+        </p>
+      </subsection>
+
+      <subsection name="Package" id="Package">
+        <p>
+          com.puppycrawl.tools.checkstyle.checks.coding
+        </p>
+      </subsection>
+
+      <subsection name="Parent Module" id="Parent_Module">
+        <p>
+          <a href="../../config.html#TreeWalker">TreeWalker</a>
+        </p>
+      </subsection>
+    </section>
+  </body>
+</document>

--- a/src/xdocs/checks/coding/multiplevariabledeclarations.xml
+++ b/src/xdocs/checks/coding/multiplevariabledeclarations.xml
@@ -27,7 +27,7 @@
           To configure the check:
         </p>
         <source>
-&lt;module name="MultipleVariableDeclarations"/&gt;
+&lt;module name=&quot;MultipleVariableDeclarations&quot;/&gt;
         </source>
         <p>
           Example:

--- a/src/xdocs/checks/coding/multiplevariabledeclarations.xml.template
+++ b/src/xdocs/checks/coding/multiplevariabledeclarations.xml.template
@@ -1,0 +1,103 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<document xmlns="http://maven.apache.org/XDOC/2.0"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/XDOC/2.0 https://maven.apache.org/xsd/xdoc-2.0.xsd">
+  <head>
+    <title>MultipleVariableDeclarations</title>
+  </head>
+  <body>
+    <section name="MultipleVariableDeclarations">
+      <p>Since Checkstyle 3.4</p>
+      <subsection name="Description" id="Description">
+        <p>
+          Checks that each variable declaration is in its own statement and on
+          its own line.
+        </p>
+
+        <p>
+          Rationale:
+          <a href="../../styleguides/sun-code-conventions-19990420/CodeConventions.doc5.html#a2992">
+          the Java code conventions chapter 6.1</a> recommends that
+          declarations should be one per line/statement.
+        </p>
+      </subsection>
+
+      <subsection name="Examples" id="Examples">
+        <p>
+          To configure the check:
+        </p>
+        <source>
+&lt;module name="MultipleVariableDeclarations"/&gt;
+        </source>
+        <p>
+          Example:
+        </p>
+        <source>
+public class Test {
+  public void myTest() {
+    int mid;
+    int high;
+    // ...
+
+    int lower, higher; // violation
+    // ...
+
+    int value,
+        index; // violation
+    // ...
+
+    int place = mid, number = high;  // violation
+  }
+}
+        </source>
+      </subsection>
+
+      <subsection name="Example of Usage" id="Example_of_Usage">
+        <ul>
+          <li>
+            <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources%20path%3A**%2Fgoogle_checks.xml+repo%3Acheckstyle%2Fcheckstyle+MultipleVariableDeclarations">
+            Google Style</a>
+          </li>
+          <li>
+            <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources%20path%3A**%2Fsun_checks.xml+repo%3Acheckstyle%2Fcheckstyle+MultipleVariableDeclarations">
+            Sun Style</a>
+          </li>
+          <li>
+            <a href="https://github.com/search?q=path%3Aconfig%20path%3A**%2Fcheckstyle-checks.xml+repo%3Acheckstyle%2Fcheckstyle+MultipleVariableDeclarations">
+            Checkstyle Style</a>
+          </li>
+        </ul>
+      </subsection>
+
+      <subsection name="Violation Messages" id="Violation_Messages">
+        <ul>
+          <li>
+            <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources%2Fcom%2Fpuppycrawl%2Ftools%2Fcheckstyle%2Fchecks%2Fcoding%20path%3A**%2Fmessages*.properties+repo%3Acheckstyle%2Fcheckstyle+%22multiple.variable.declarations%22">
+            multiple.variable.declarations</a>
+          </li>
+          <li>
+            <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources%2Fcom%2Fpuppycrawl%2Ftools%2Fcheckstyle%2Fchecks%2Fcoding%20path%3A**%2Fmessages*.properties+repo%3Acheckstyle%2Fcheckstyle+%22multiple.variable.declarations.comma%22">
+            multiple.variable.declarations.comma</a>
+          </li>
+        </ul>
+        <p>
+          All messages can be customized if the default message doesn't suit you.
+          Please <a href="../../config.html#Custom_messages">see the documentation</a>
+          to learn how to.
+        </p>
+      </subsection>
+
+      <subsection name="Package" id="Package">
+        <p>
+          com.puppycrawl.tools.checkstyle.checks.coding
+        </p>
+      </subsection>
+
+      <subsection name="Parent Module" id="Parent_Module">
+        <p>
+          <a href="../../config.html#TreeWalker">TreeWalker</a>
+        </p>
+      </subsection>
+    </section>
+  </body>
+</document>

--- a/src/xdocs/checks/coding/nestedfordepth.xml
+++ b/src/xdocs/checks/coding/nestedfordepth.xml
@@ -38,7 +38,7 @@
           To configure the check:
         </p>
         <source>
-&lt;module name="NestedForDepth"/&gt;
+&lt;module name=&quot;NestedForDepth&quot;/&gt;
         </source>
         <p>Example:</p>
         <source>
@@ -58,8 +58,8 @@ for(int i=0; i&lt;10; i++) {
           To configure the check to allow nesting depth 2:
         </p>
         <source>
-&lt;module name="NestedForDepth"&gt;
-  &lt;property name="max" value="2"/&gt;
+&lt;module name=&quot;NestedForDepth&quot;&gt;
+  &lt;property name=&quot;max&quot; value=&quot;2&quot;/&gt;
 &lt;/module&gt;
         </source>
         <p>Example:</p>

--- a/src/xdocs/checks/coding/nestedfordepth.xml.template
+++ b/src/xdocs/checks/coding/nestedfordepth.xml.template
@@ -1,0 +1,121 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<document xmlns="http://maven.apache.org/XDOC/2.0"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/XDOC/2.0 https://maven.apache.org/xsd/xdoc-2.0.xsd">
+  <head>
+    <title>NestedForDepth</title>
+  </head>
+  <body>
+    <section name="NestedForDepth">
+      <p>Since Checkstyle 5.3</p>
+      <subsection name="Description" id="Description">
+        <p>Restricts nested <code>for</code> blocks to a specified depth.</p>
+      </subsection>
+
+      <subsection name="Properties" id="Properties">
+        <div class="wrapper">
+          <table>
+            <tr>
+              <th>name</th>
+              <th>description</th>
+              <th>type</th>
+              <th>default value</th>
+              <th>since</th>
+            </tr>
+            <tr>
+              <td>max</td>
+              <td>Specify maximum allowed nesting depth.</td>
+              <td><a href="../../property_types.html#int">int</a></td>
+              <td><code>1</code></td>
+              <td>5.3</td>
+            </tr>
+          </table>
+        </div>
+      </subsection>
+
+      <subsection name="Examples" id="Examples">
+        <p>
+          To configure the check:
+        </p>
+        <source>
+&lt;module name="NestedForDepth"/&gt;
+        </source>
+        <p>Example:</p>
+        <source>
+for(int i=0; i&lt;10; i++) {
+    for(int j=0; j&lt;i; j++) {
+        for(int k=0; k&lt;j; k++) { // violation, max allowed nested loop number is 1
+        }
+    }
+}
+
+for(int i=0; i&lt;10; i++) {
+    for(int j=0; j&lt;i; j++) { // ok
+    }
+}
+        </source>
+        <p>
+          To configure the check to allow nesting depth 2:
+        </p>
+        <source>
+&lt;module name="NestedForDepth"&gt;
+  &lt;property name="max" value="2"/&gt;
+&lt;/module&gt;
+        </source>
+        <p>Example:</p>
+        <source>
+for(int i=0; i&lt;10; i++) {
+    for(int j=0; j&lt;i; j++) {
+        for(int k=0; k&lt;j; k++) {
+            for(int l=0; l&lt;k; l++) { // violation, max allowed nested loop number is 2
+            }
+        }
+    }
+}
+
+for(int i=0; i&lt;10; i++) {
+    for(int j=0; j&lt;i; j++) {
+        for(int k=0; k&lt;j; k++) { // ok
+        }
+    }
+}
+        </source>
+      </subsection>
+
+      <subsection name="Example of Usage" id="Example_of_Usage">
+        <ul>
+          <li>
+            <a href="https://github.com/search?q=path%3Aconfig%20path%3A**%2Fcheckstyle-checks.xml+repo%3Acheckstyle%2Fcheckstyle+NestedForDepth">
+            Checkstyle Style</a>
+          </li>
+        </ul>
+      </subsection>
+
+      <subsection name="Violation Messages" id="Violation_Messages">
+        <ul>
+          <li>
+            <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources%2Fcom%2Fpuppycrawl%2Ftools%2Fcheckstyle%2Fchecks%2Fcoding%20path%3A**%2Fmessages*.properties+repo%3Acheckstyle%2Fcheckstyle+%22nested.for.depth%22">
+            nested.for.depth</a>
+          </li>
+        </ul>
+        <p>
+          All messages can be customized if the default message doesn't suit you.
+          Please <a href="../../config.html#Custom_messages">see the documentation</a>
+          to learn how to.
+        </p>
+      </subsection>
+
+      <subsection name="Package" id="Package">
+        <p>
+          com.puppycrawl.tools.checkstyle.checks.coding
+        </p>
+      </subsection>
+
+      <subsection name="Parent Module" id="Parent_Module">
+        <p>
+          <a href="../../config.html#TreeWalker">TreeWalker</a>
+        </p>
+      </subsection>
+    </section>
+  </body>
+</document>

--- a/src/xdocs/checks/coding/nestedifdepth.xml
+++ b/src/xdocs/checks/coding/nestedifdepth.xml
@@ -38,7 +38,7 @@
           To configure the check:
         </p>
         <source>
-&lt;module name="NestedIfDepth"/&gt;
+&lt;module name=&quot;NestedIfDepth&quot;/&gt;
         </source>
         <p>Valid code example:</p>
         <source>
@@ -60,8 +60,8 @@ if (true) {
           To configure the check to allow nesting depth 3:
         </p>
         <source>
-&lt;module name="NestedIfDepth"&gt;
-  &lt;property name="max" value="3"/&gt;
+&lt;module name=&quot;NestedIfDepth&quot;&gt;
+  &lt;property name=&quot;max&quot; value=&quot;3&quot;/&gt;
 &lt;/module&gt;
         </source>
         <p>Valid code example:</p>

--- a/src/xdocs/checks/coding/nestedifdepth.xml.template
+++ b/src/xdocs/checks/coding/nestedifdepth.xml.template
@@ -1,0 +1,131 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<document xmlns="http://maven.apache.org/XDOC/2.0"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/XDOC/2.0 https://maven.apache.org/xsd/xdoc-2.0.xsd">
+  <head>
+    <title>NestedIfDepth</title>
+  </head>
+  <body>
+    <section name="NestedIfDepth">
+      <p>Since Checkstyle 3.2</p>
+      <subsection name="Description" id="Description">
+        <p>Restricts nested if-else blocks to a specified depth.</p>
+      </subsection>
+
+      <subsection name="Properties" id="Properties">
+        <div class="wrapper">
+          <table>
+            <tr>
+              <th>name</th>
+              <th>description</th>
+              <th>type</th>
+              <th>default value</th>
+              <th>since</th>
+            </tr>
+            <tr>
+              <td>max</td>
+              <td>Specify maximum allowed nesting depth.</td>
+              <td><a href="../../property_types.html#int">int</a></td>
+              <td><code>1</code></td>
+              <td>3.2</td>
+            </tr>
+          </table>
+        </div>
+      </subsection>
+
+      <subsection name="Examples" id="Examples">
+        <p>
+          To configure the check:
+        </p>
+        <source>
+&lt;module name="NestedIfDepth"/&gt;
+        </source>
+        <p>Valid code example:</p>
+        <source>
+if (true) {
+    if (true) {} // OK
+    else {}
+}
+        </source>
+        <p>Invalid code example:</p>
+        <source>
+if (true) {
+    if (true) {
+        if (true) { // violation, nested if-else depth is 2 (max allowed is 1)
+        }
+    }
+}
+        </source>
+        <p>
+          To configure the check to allow nesting depth 3:
+        </p>
+        <source>
+&lt;module name="NestedIfDepth"&gt;
+  &lt;property name="max" value="3"/&gt;
+&lt;/module&gt;
+        </source>
+        <p>Valid code example:</p>
+        <source>
+if (true) {
+   if (true) {
+      if (true) {
+         if (true) {} // OK
+         else {}
+      }
+   }
+}
+        </source>
+        <p>Invalid code example:</p>
+        <source>
+if (true) {
+   if (true) {
+      if (true) {
+         if (true) {
+            if (true) { // violation, nested if-else depth is 4 (max allowed is 3)
+               if (true) {} // violation, nested if-else depth is 5 (max allowed is 3)
+               else {}
+            }
+         }
+      }
+   }
+}
+        </source>
+      </subsection>
+
+      <subsection name="Example of Usage" id="Example_of_Usage">
+        <ul>
+          <li>
+            <a href="https://github.com/search?q=path%3Aconfig%20path%3A**%2Fcheckstyle-checks.xml+repo%3Acheckstyle%2Fcheckstyle+NestedIfDepth">
+            Checkstyle Style</a>
+          </li>
+        </ul>
+      </subsection>
+
+      <subsection name="Violation Messages" id="Violation_Messages">
+        <ul>
+          <li>
+            <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources%2Fcom%2Fpuppycrawl%2Ftools%2Fcheckstyle%2Fchecks%2Fcoding%20path%3A**%2Fmessages*.properties+repo%3Acheckstyle%2Fcheckstyle+%22nested.if.depth%22">
+            nested.if.depth</a>
+          </li>
+        </ul>
+        <p>
+          All messages can be customized if the default message doesn't suit you.
+          Please <a href="../../config.html#Custom_messages">see the documentation</a>
+          to learn how to.
+        </p>
+      </subsection>
+
+      <subsection name="Package" id="Package">
+        <p>
+          com.puppycrawl.tools.checkstyle.checks.coding
+        </p>
+      </subsection>
+
+      <subsection name="Parent Module" id="Parent_Module">
+        <p>
+          <a href="../../config.html#TreeWalker">TreeWalker</a>
+        </p>
+      </subsection>
+    </section>
+  </body>
+</document>

--- a/src/xdocs/checks/coding/nestedtrydepth.xml
+++ b/src/xdocs/checks/coding/nestedtrydepth.xml
@@ -38,7 +38,7 @@
           To configure the check:
         </p>
         <source>
-&lt;module name="NestedTryDepth"/&gt;
+&lt;module name=&quot;NestedTryDepth&quot;/&gt;
         </source>
         <p>
             case 1: Example of code with violation:
@@ -87,8 +87,8 @@ try {
           To configure the check to allow nesting depth 3:
         </p>
         <source>
-&lt;module name="NestedTryDepth"&gt;
-  &lt;property name="max" value="3"/&gt;
+&lt;module name=&quot;NestedTryDepth&quot;&gt;
+  &lt;property name=&quot;max&quot; value=&quot;3&quot;/&gt;
 &lt;/module&gt;
         </source>
         <p>

--- a/src/xdocs/checks/coding/nestedtrydepth.xml.template
+++ b/src/xdocs/checks/coding/nestedtrydepth.xml.template
@@ -1,0 +1,169 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<document xmlns="http://maven.apache.org/XDOC/2.0"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/XDOC/2.0 https://maven.apache.org/xsd/xdoc-2.0.xsd">
+  <head>
+    <title>NestedTryDepth</title>
+  </head>
+  <body>
+    <section name="NestedTryDepth">
+      <p>Since Checkstyle 3.2</p>
+      <subsection name="Description" id="Description">
+        <p>Restricts nested try-catch-finally blocks to a specified depth.</p>
+      </subsection>
+
+      <subsection name="Properties" id="Properties">
+        <div class="wrapper">
+          <table>
+            <tr>
+              <th>name</th>
+              <th>description</th>
+              <th>type</th>
+              <th>default value</th>
+              <th>since</th>
+            </tr>
+            <tr>
+              <td>max</td>
+              <td>Specify maximum allowed nesting depth.</td>
+              <td><a href="../../property_types.html#int">int</a></td>
+              <td><code>1</code></td>
+              <td>3.2</td>
+            </tr>
+          </table>
+        </div>
+      </subsection>
+
+      <subsection name="Examples" id="Examples">
+        <p>
+          To configure the check:
+        </p>
+        <source>
+&lt;module name="NestedTryDepth"/&gt;
+        </source>
+        <p>
+            case 1: Example of code with violation:
+        </p>
+        <source>
+try {
+    try {
+        try { // violation, current depth is 2, default max allowed depth is 1
+        } catch (Exception e) {
+        }
+    } catch (Exception e) {
+    }
+} catch (Exception e) {
+}
+        </source>
+        <p>
+          case 1: Example of compliant code:
+        </p>
+        <source>
+try {
+    try { // OK, current depth is 1, default max allowed depth is also 1
+    } catch (Exception e) {
+    }
+} catch (Exception e) {
+}
+        </source>
+        <p>case 2: Example of code for handling unique and general exceptions</p>
+        <source>
+try {
+    try { // OK, current depth is 1, default max allowed depth is also 1
+            // any more nesting could cause code violation!
+            throw ArithmeticException();
+    } catch (ArithmeticException e) { // catches arithmetic exceptions
+    } catch (NumberFormatException e) { // catches number-format exceptions
+    } catch (Exception e) { // catches general exceptions other than stated above
+    }
+} catch (
+  ArithmeticException
+  | NumberFormatException
+  | ArrayIndexOutOfBoundsException e) { // catches any of the 3 exception
+} catch (Exception e) { // catches general exception
+} finally { // do something when try-catch block finished execution
+}
+        </source>
+        <p>
+          To configure the check to allow nesting depth 3:
+        </p>
+        <source>
+&lt;module name="NestedTryDepth"&gt;
+  &lt;property name="max" value="3"/&gt;
+&lt;/module&gt;
+        </source>
+        <p>
+            Example of code with violation:
+        </p>
+        <source>
+try {
+    try {
+        try {
+            try {
+                try { // violation, current depth is 4, max allowed depth is 3
+                } catch (Exception e) {
+                }
+            } catch (Exception e) {
+            }
+        } catch (Exception e) {
+        }
+    } catch (Exception e) {
+    }
+} catch (Exception e) {
+}
+        </source>
+        <p>
+            Example of compliant code:
+        </p>
+        <source>
+try {
+    try {
+        try {
+            try { // OK, current depth is 3, max allowed depth is also 3
+            } catch (Exception e) {
+            }
+        } catch (Exception e) {
+        }
+    } catch (Exception e) {
+    }
+} catch (Exception e) {
+}
+        </source>
+      </subsection>
+
+      <subsection name="Example of Usage" id="Example_of_Usage">
+        <ul>
+          <li>
+            <a href="https://github.com/search?q=path%3Aconfig%20path%3A**%2Fcheckstyle-checks.xml+repo%3Acheckstyle%2Fcheckstyle+NestedTryDepth">
+            Checkstyle Style</a>
+          </li>
+        </ul>
+      </subsection>
+
+      <subsection name="Violation Messages" id="Violation_Messages">
+        <ul>
+          <li>
+            <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources%2Fcom%2Fpuppycrawl%2Ftools%2Fcheckstyle%2Fchecks%2Fcoding%20path%3A**%2Fmessages*.properties+repo%3Acheckstyle%2Fcheckstyle+%22nested.try.depth%22">
+            nested.try.depth</a>
+          </li>
+        </ul>
+        <p>
+          All messages can be customized if the default message doesn't suit you.
+          Please <a href="../../config.html#Custom_messages">see the documentation</a>
+          to learn how to.
+        </p>
+      </subsection>
+
+      <subsection name="Package" id="Package">
+        <p>
+          com.puppycrawl.tools.checkstyle.checks.coding
+        </p>
+      </subsection>
+
+      <subsection name="Parent Module" id="Parent_Module">
+        <p>
+          <a href="../../config.html#TreeWalker">TreeWalker</a>
+        </p>
+      </subsection>
+    </section>
+  </body>
+</document>

--- a/src/xdocs/checks/coding/noarraytrailingcomma.xml
+++ b/src/xdocs/checks/coding/noarraytrailingcomma.xml
@@ -26,8 +26,8 @@ int[] foo = new int[] {
         </p>
         <source>
 String[] foo = new String[] {
-  "FOO",
-  "BAR", //violation
+  &quot;FOO&quot;,
+  &quot;BAR&quot;, //violation
 }
         </source>
       </subsection>
@@ -36,22 +36,22 @@ String[] foo = new String[] {
           To configure the check:
         </p>
         <source>
-&lt;module name="NoArrayTrailingComma"/&gt;
+&lt;module name=&quot;NoArrayTrailingComma&quot;/&gt;
         </source>
         <p>
           Which results in the following violations:
         </p>
         <source>
 String[] foo1 = {
-  "FOO", // OK
-  "BAR", // violation
+  &quot;FOO&quot;, // OK
+  &quot;BAR&quot;, // violation
 };
-String[] foo2 = { "FOO", "BAR", }; // violation
+String[] foo2 = { &quot;FOO&quot;, &quot;BAR&quot;, }; // violation
 String[] foo3 = {
-  "FOO", // OK
-  "BAR" // OK
+  &quot;FOO&quot;, // OK
+  &quot;BAR&quot; // OK
 };
-String[] foo4 = { "FOO", "BAR" }; // OK
+String[] foo4 = { &quot;FOO&quot;, &quot;BAR&quot; }; // OK
         </source>
       </subsection>
       <subsection name="Example of Usage" id="Example_of_Usage">

--- a/src/xdocs/checks/coding/noarraytrailingcomma.xml.template
+++ b/src/xdocs/checks/coding/noarraytrailingcomma.xml.template
@@ -1,0 +1,93 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<document xmlns="http://maven.apache.org/XDOC/2.0"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/XDOC/2.0 https://maven.apache.org/xsd/xdoc-2.0.xsd">
+  <head>
+    <title>NoArrayTrailingComma</title>
+  </head>
+  <body>
+    <section name="NoArrayTrailingComma">
+      <p>Since Checkstyle 8.28</p>
+      <subsection name="Description" id="Description">
+        <p>
+          Checks that array initialization do not contain a trailing comma.
+          Rationale: JLS allows trailing commas in arrays and enumerations, but does not allow
+          them in other locations. To unify the coding style, the use of trailing commas should
+          be prohibited.
+        </p>
+        <source>
+int[] foo = new int[] {
+  1,
+  2
+};
+        </source>
+        <p>
+          The check demands that there should not be any comma after the last element of an array.
+        </p>
+        <source>
+String[] foo = new String[] {
+  "FOO",
+  "BAR", //violation
+}
+        </source>
+      </subsection>
+      <subsection name="Examples" id="Examples">
+        <p>
+          To configure the check:
+        </p>
+        <source>
+&lt;module name="NoArrayTrailingComma"/&gt;
+        </source>
+        <p>
+          Which results in the following violations:
+        </p>
+        <source>
+String[] foo1 = {
+  "FOO", // OK
+  "BAR", // violation
+};
+String[] foo2 = { "FOO", "BAR", }; // violation
+String[] foo3 = {
+  "FOO", // OK
+  "BAR" // OK
+};
+String[] foo4 = { "FOO", "BAR" }; // OK
+        </source>
+      </subsection>
+      <subsection name="Example of Usage" id="Example_of_Usage">
+        <ul>
+          <li>
+            <a href="https://github.com/search?q=path%3Aconfig%20path%3A**%2Fcheckstyle-checks.xml+repo%3Acheckstyle%2Fcheckstyle+NoArrayTrailingComma">
+            Checkstyle Style</a>
+          </li>
+        </ul>
+      </subsection>
+
+      <subsection name="Violation Messages" id="Violation_Messages">
+        <ul>
+          <li>
+            <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources%2Fcom%2Fpuppycrawl%2Ftools%2Fcheckstyle%2Fchecks%2Fcoding%20path%3A**%2Fmessages*.properties+repo%3Acheckstyle%2Fcheckstyle+%22no.array.trailing.comma%22">
+            no.array.trailing.comma</a>
+          </li>
+        </ul>
+        <p>
+          All messages can be customized if the default message doesn't suit you.
+          Please <a href="../../config.html#Custom_messages">see the documentation</a>
+          to learn how to.
+        </p>
+      </subsection>
+
+      <subsection name="Package" id="Package">
+        <p>
+          com.puppycrawl.tools.checkstyle.checks.coding
+        </p>
+      </subsection>
+
+      <subsection name="Parent Module" id="Parent_Module">
+        <p>
+          <a href="../../config.html#TreeWalker">TreeWalker</a>
+        </p>
+      </subsection>
+    </section>
+  </body>
+</document>

--- a/src/xdocs/checks/coding/noclone.xml
+++ b/src/xdocs/checks/coding/noclone.xml
@@ -116,7 +116,7 @@ System.out.println(s2 instanceof Square); //true
           To configure the check:
         </p>
         <source>
-&lt;module name="NoClone"/&gt;
+&lt;module name=&quot;NoClone&quot;/&gt;
         </source>
         <p>Example: </p>
         <source>

--- a/src/xdocs/checks/coding/noclone.xml.template
+++ b/src/xdocs/checks/coding/noclone.xml.template
@@ -1,0 +1,173 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<document xmlns="http://maven.apache.org/XDOC/2.0"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/XDOC/2.0 https://maven.apache.org/xsd/xdoc-2.0.xsd">
+  <head>
+    <title>NoClone</title>
+  </head>
+  <body>
+    <section name="NoClone">
+      <p>Since Checkstyle 5.0</p>
+      <subsection name="Description" id="Description">
+        <p>
+          Checks that the clone method is not overridden from the
+          Object class.
+        </p>
+        <p>
+          This check is almost exactly the same as the <code>NoFinalizerCheck</code>.
+        </p>
+        <p>
+          See <a href="https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/lang/Object.html#clone()">
+          Object.clone()</a>
+        </p>
+        <p>
+          Rationale: The clone method relies on strange, hard to follow rules that
+          are difficult to get right and do not work in all situations.
+          In some cases, either a copy constructor
+          or a static factory method can be used instead of the clone method
+          to return copies of an object.
+          For more information on rules for the clone method and its issues, see Effective Java:
+          Programming Language Guide First Edition by Joshua Bloch
+          pages 45-52.
+        </p>
+        <p>
+          Below are some rules/reasons why the clone method should be avoided.
+        </p>
+        <ul>
+          <li>
+            Classes supporting the clone method should implement the Cloneable interface
+            but the Cloneable interface does not include the clone method.
+            As a result, it doesn't enforce the method override.
+          </li>
+          <li>
+            The Cloneable interface forces the Object's clone method to work correctly.
+            Without implementing it, the Object's clone method will throw a
+            CloneNotSupportedException.
+          </li>
+          <li>
+            Non-final classes must return the object returned from a call to super.clone().
+          </li>
+          <li>
+            Final classes can use a constructor to create a clone which is different
+            from non-final classes.
+          </li>
+          <li>
+            If a super class implements the clone method incorrectly all subclasses calling
+            super.clone() are doomed to failure.
+          </li>
+          <li>
+            If a class has references to mutable objects then those object references must be
+            replaced with copies in the clone method after calling super.clone().
+          </li>
+          <li>
+            The clone method does not work correctly with final mutable object references because
+            final references cannot be reassigned.
+          </li>
+          <li>
+            If a super class overrides the clone method then all subclasses must provide a correct
+            clone implementation.
+          </li>
+        </ul>
+        <p>
+          Two alternatives to the clone method, in some cases, is a copy constructor or a static
+          factory method to return copies of an object. Both of these approaches are simpler and
+          do not conflict with final fields. They do not force the calling client to handle a
+          CloneNotSupportedException.  They also are typed therefore no casting is necessary.
+          Finally, they are more flexible since they can take interface types rather than concrete
+          classes.
+        </p>
+        <p>
+          Sometimes a copy constructor or static factory is not an acceptable alternative to the
+          clone method.  The example below highlights the limitation of a copy constructor
+          (or static factory). Assume Square is a subclass for Shape.
+        </p>
+        <source>
+Shape s1 = new Square();
+System.out.println(s1 instanceof Square); //true
+        </source>
+        <p>
+          ...assume at this point the code knows nothing of s1 being a Square that's the beauty
+          of polymorphism but the code wants to copy the Square which is declared as a Shape,
+          its super type...
+        </p>
+        <source>
+Shape s2 = new Shape(s1); //using the copy constructor
+System.out.println(s2 instanceof Square); //false
+        </source>
+        <p>
+          The working solution (without knowing about all subclasses and doing many casts) is to do
+          the following (assuming correct clone implementation).
+        </p>
+        <source>
+Shape s2 = s1.clone();
+System.out.println(s2 instanceof Square); //true
+        </source>
+        <p>
+          Just keep in mind if this type of polymorphic cloning is required then a properly
+          implemented clone method may be the best choice.
+        </p>
+        <p>
+          Much of this information was taken from Effective Java: Programming Language Guide First
+          Edition by Joshua Bloch pages 45-52.  Give Bloch credit for writing an excellent book.
+        </p>
+      </subsection>
+      <subsection name="Examples" id="Examples">
+        <p>
+          To configure the check:
+        </p>
+        <source>
+&lt;module name="NoClone"/&gt;
+        </source>
+        <p>Example: </p>
+        <source>
+public class Foo {
+
+ public Object clone() {return null;} // violation, overrides the clone method
+
+ public Foo clone() {return null;} // violation, overrides the clone method
+
+ public static Object clone(Object o) {return null;} // OK
+
+ public static Foo clone(Foo o) {return null;} // OK
+
+}
+        </source>
+      </subsection>
+
+      <subsection name="Example of Usage" id="Example_of_Usage">
+        <ul>
+          <li>
+            <a href="https://github.com/search?q=path%3Aconfig%20path%3A**%2Fcheckstyle-checks.xml+repo%3Acheckstyle%2Fcheckstyle+NoClone">
+            Checkstyle Style</a>
+          </li>
+        </ul>
+      </subsection>
+
+      <subsection name="Violation Messages" id="Violation_Messages">
+        <ul>
+          <li>
+            <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources%2Fcom%2Fpuppycrawl%2Ftools%2Fcheckstyle%2Fchecks%2Fcoding%20path%3A**%2Fmessages*.properties+repo%3Acheckstyle%2Fcheckstyle+%22avoid.clone.method%22">
+            avoid.clone.method</a>
+          </li>
+        </ul>
+        <p>
+          All messages can be customized if the default message doesn't suit you.
+          Please <a href="../../config.html#Custom_messages">see the documentation</a>
+          to learn how to.
+        </p>
+      </subsection>
+
+      <subsection name="Package" id="Package">
+        <p>
+          com.puppycrawl.tools.checkstyle.checks.coding
+        </p>
+      </subsection>
+
+      <subsection name="Parent Module" id="Parent_Module">
+        <p>
+          <a href="../../config.html#TreeWalker">TreeWalker</a>
+        </p>
+      </subsection>
+    </section>
+  </body>
+</document>

--- a/src/xdocs/checks/coding/noenumtrailingcomma.xml
+++ b/src/xdocs/checks/coding/noenumtrailingcomma.xml
@@ -38,7 +38,7 @@ enum Foo1 {
           To configure the check:
         </p>
         <source>
-&lt;module name="NoEnumTrailingComma"/&gt;
+&lt;module name=&quot;NoEnumTrailingComma&quot;/&gt;
         </source>
         <p>
           Which results in the following violations:

--- a/src/xdocs/checks/coding/noenumtrailingcomma.xml.template
+++ b/src/xdocs/checks/coding/noenumtrailingcomma.xml.template
@@ -1,0 +1,116 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<document xmlns="http://maven.apache.org/XDOC/2.0"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/XDOC/2.0 https://maven.apache.org/xsd/xdoc-2.0.xsd">
+  <head>
+    <title>NoEnumTrailingComma</title>
+  </head>
+  <body>
+    <section name="NoEnumTrailingComma">
+      <p>Since Checkstyle 8.29</p>
+      <subsection name="Description" id="Description">
+        <p>
+          Checks that enum definition does not contain a trailing comma.
+          Rationale: JLS allows trailing commas in arrays and enumerations, but does not allow
+          them in other locations. To unify the coding style, the use of trailing commas should
+          be prohibited.
+        </p>
+        <source>
+enum Foo1 {
+  FOO,
+  BAR;
+}
+        </source>
+        <p>
+          The check demands that there should not be any comma after last constant in
+          enum definition.
+        </p>
+        <source>
+enum Foo1 {
+  FOO,
+  BAR, //violation
+}
+        </source>
+      </subsection>
+
+      <subsection name="Examples" id="Examples">
+        <p>
+          To configure the check:
+        </p>
+        <source>
+&lt;module name="NoEnumTrailingComma"/&gt;
+        </source>
+        <p>
+          Which results in the following violations:
+        </p>
+        <source>
+enum Foo1 {
+  FOO,
+  BAR; //OK
+}
+enum Foo2 {
+  FOO,
+  BAR //OK
+}
+enum Foo3 {
+  FOO,
+  BAR, //violation
+}
+enum Foo4 {
+  FOO,
+  BAR, // violation
+  ;
+}
+enum Foo5 {
+  FOO,
+  BAR,; // violation
+}
+enum Foo6 { FOO, BAR,; } // violation
+enum Foo7 { FOO, BAR, } // violation
+enum Foo8 {
+  FOO,
+  BAR // OK
+  ;
+}
+enum Foo9 { FOO, BAR; } // OK
+enum Foo10 { FOO, BAR } // OK
+        </source>
+      </subsection>
+
+      <subsection name="Example of Usage" id="Example_of_Usage">
+        <ul>
+          <li>
+            <a href="https://github.com/search?q=path%3Aconfig%20path%3A**%2Fcheckstyle-checks.xml+repo%3Acheckstyle%2Fcheckstyle+NoEnumTrailingComma">
+            Checkstyle Style</a>
+          </li>
+        </ul>
+      </subsection>
+
+      <subsection name="Violation Messages" id="Violation_Messages">
+        <ul>
+          <li>
+            <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources%2Fcom%2Fpuppycrawl%2Ftools%2Fcheckstyle%2Fchecks%2Fcoding%20path%3A**%2Fmessages*.properties+repo%3Acheckstyle%2Fcheckstyle+%22no.enum.trailing.comma%22">
+            no.enum.trailing.comma</a>
+          </li>
+        </ul>
+        <p>
+          All messages can be customized if the default message doesn't suit you.
+          Please <a href="../../config.html#Custom_messages">see the documentation</a>
+          to learn how to.
+        </p>
+      </subsection>
+
+      <subsection name="Package" id="Package">
+        <p>
+          com.puppycrawl.tools.checkstyle.checks.coding
+        </p>
+      </subsection>
+
+      <subsection name="Parent Module" id="Parent_Module">
+        <p>
+          <a href="../../config.html#TreeWalker">TreeWalker</a>
+        </p>
+      </subsection>
+    </section>
+  </body>
+</document>

--- a/src/xdocs/checks/coding/nofinalizer.xml
+++ b/src/xdocs/checks/coding/nofinalizer.xml
@@ -18,7 +18,7 @@
             Rationale: Finalizers are unpredictable, often dangerous, and generally unnecessary.
             Their use can cause erratic behavior, poor performance, and portability problems.
             For more information for the finalize method and its issues, see Effective Java:
-            Programming Language Guide Third Edition by Joshua Bloch, §8.
+            Programming Language Guide Third Edition by Joshua Bloch, &#xa7;8.
         </p>
       </subsection>
 
@@ -27,7 +27,7 @@
           To configure the check:
         </p>
         <source>
-&lt;module name="NoFinalizer"/&gt;
+&lt;module name=&quot;NoFinalizer&quot;/&gt;
         </source>
         <p>Example:</p>
         <source>
@@ -35,7 +35,7 @@ public class Test {
 
     protected void finalize() throws Throwable { // violation
         try {
-           System.out.println("overriding finalize()");
+           System.out.println(&quot;overriding finalize()&quot;);
         } catch (Throwable t) {
            throw t;
         } finally {

--- a/src/xdocs/checks/coding/nofinalizer.xml.template
+++ b/src/xdocs/checks/coding/nofinalizer.xml.template
@@ -1,0 +1,89 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<document xmlns="http://maven.apache.org/XDOC/2.0"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/XDOC/2.0 https://maven.apache.org/xsd/xdoc-2.0.xsd">
+  <head>
+    <title>NoFinalizer</title>
+  </head>
+  <body>
+    <section name="NoFinalizer">
+      <p>Since Checkstyle 5.0</p>
+      <subsection name="Description" id="Description">
+        <p>Checks that there is no method <code>finalize</code> with zero parameters.</p>
+        <p>
+          See <a href="https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/lang/Object.html#finalize()">
+          Object.finalize()</a>
+        </p>
+        <p>
+            Rationale: Finalizers are unpredictable, often dangerous, and generally unnecessary.
+            Their use can cause erratic behavior, poor performance, and portability problems.
+            For more information for the finalize method and its issues, see Effective Java:
+            Programming Language Guide Third Edition by Joshua Bloch, §8.
+        </p>
+      </subsection>
+
+      <subsection name="Examples" id="Examples">
+        <p>
+          To configure the check:
+        </p>
+        <source>
+&lt;module name="NoFinalizer"/&gt;
+        </source>
+        <p>Example:</p>
+        <source>
+public class Test {
+
+    protected void finalize() throws Throwable { // violation
+        try {
+           System.out.println("overriding finalize()");
+        } catch (Throwable t) {
+           throw t;
+        } finally {
+           super.finalize();
+        }
+    }
+}
+        </source>
+      </subsection>
+
+      <subsection name="Example of Usage" id="Example_of_Usage">
+        <ul>
+          <li>
+            <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources%20path%3A**%2Fgoogle_checks.xml+repo%3Acheckstyle%2Fcheckstyle+NoFinalizer">
+            Google Style</a>
+          </li>
+          <li>
+            <a href="https://github.com/search?q=path%3Aconfig%20path%3A**%2Fcheckstyle-checks.xml+repo%3Acheckstyle%2Fcheckstyle+NoFinalizer">
+            Checkstyle Style</a>
+          </li>
+        </ul>
+      </subsection>
+
+      <subsection name="Violation Messages" id="Violation_Messages">
+        <ul>
+          <li>
+            <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources%2Fcom%2Fpuppycrawl%2Ftools%2Fcheckstyle%2Fchecks%2Fcoding%20path%3A**%2Fmessages*.properties+repo%3Acheckstyle%2Fcheckstyle+%22avoid.finalizer.method%22">
+            avoid.finalizer.method</a>
+          </li>
+        </ul>
+        <p>
+          All messages can be customized if the default message doesn't suit you.
+          Please <a href="../../config.html#Custom_messages">see the documentation</a>
+          to learn how to.
+        </p>
+      </subsection>
+
+      <subsection name="Package" id="Package">
+        <p>
+          com.puppycrawl.tools.checkstyle.checks.coding
+        </p>
+      </subsection>
+
+      <subsection name="Parent Module" id="Parent_Module">
+        <p>
+          <a href="../../config.html#TreeWalker">TreeWalker</a>
+        </p>
+      </subsection>
+    </section>
+  </body>
+</document>

--- a/src/xdocs/checks/coding/onestatementperline.xml
+++ b/src/xdocs/checks/coding/onestatementperline.xml
@@ -55,7 +55,7 @@
           To configure the check:
         </p>
         <source>
-&lt;module name="OneStatementPerLine"/&gt;
+&lt;module name=&quot;OneStatementPerLine&quot;/&gt;
         </source>
         <p>
           The following examples will be flagged as a violation:
@@ -81,14 +81,14 @@ r = 5; int t; //violation here
           in a try statement as statements to require them on their own line:
         </p>
         <source>
-&lt;module name="OneStatementPerLine"&gt;
-  &lt;property name="treatTryResourcesAsStatement" value="true"/&gt;
+&lt;module name=&quot;OneStatementPerLine&quot;&gt;
+  &lt;property name=&quot;treatTryResourcesAsStatement&quot; value=&quot;true&quot;/&gt;
 &lt;/module&gt;
         </source>
         <p>
           Note: resource declarations can contain variable definitions
           and variable references (from java9).
-          When property "treatTryResourcesAsStatement" is enabled,
+          When property &quot;treatTryResourcesAsStatement&quot; is enabled,
           this check is only applied to variable definitions.
           If there are one or more variable references
           and one variable definition on the same line in resources declaration,

--- a/src/xdocs/checks/coding/onestatementperline.xml.template
+++ b/src/xdocs/checks/coding/onestatementperline.xml.template
@@ -1,0 +1,150 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<document xmlns="http://maven.apache.org/XDOC/2.0"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/XDOC/2.0 https://maven.apache.org/xsd/xdoc-2.0.xsd">
+  <head>
+    <title>OneStatementPerLine</title>
+  </head>
+  <body>
+    <section name="OneStatementPerLine">
+      <p>Since Checkstyle 5.3</p>
+      <subsection name="Description" id="Description">
+        <p>
+          Checks that there is only one statement per line.
+        </p>
+        <p>
+          Rationale: It's very difficult to read multiple statements on one line.
+        </p>
+        <p>
+          In the Java programming language, statements are the fundamental unit of
+          execution. All statements except blocks are terminated by a semicolon.
+          Blocks are denoted by open and close curly braces.
+        </p>
+        <p>
+          OneStatementPerLineCheck checks the following types of statements:
+          variable declaration statements, empty statements, import statements,
+          assignment statements, expression statements, increment statements,
+          object creation statements, 'for loop' statements, 'break' statements,
+          'continue' statements, 'return' statements, resources statements (optional).
+        </p>
+      </subsection>
+
+      <subsection name="Properties" id="Properties">
+        <div class="wrapper">
+          <table>
+            <tr>
+              <th>name</th>
+              <th>description</th>
+              <th>type</th>
+              <th>default value</th>
+              <th>since</th>
+            </tr>
+            <tr>
+              <td>treatTryResourcesAsStatement</td>
+              <td>Enable resources processing.</td>
+              <td><a href="../../property_types.html#boolean">boolean</a></td>
+              <td><code>false</code></td>
+              <td>8.23</td>
+            </tr>
+          </table>
+        </div>
+      </subsection>
+
+      <subsection name="Examples" id="Examples">
+        <p>
+          To configure the check:
+        </p>
+        <source>
+&lt;module name="OneStatementPerLine"/&gt;
+        </source>
+        <p>
+          The following examples will be flagged as a violation:
+        </p>
+        <source>
+//Each line causes violation:
+int var1; int var2;
+var1 = 1; var2 = 2;
+int var1 = 1; int var2 = 2;
+var1++; var2++;
+Object obj1 = new Object(); Object obj2 = new Object();
+import java.io.EOFException; import java.io.BufferedReader;
+;; //two empty statements on the same line.
+
+//Multi-line statements:
+int var1 = 1
+; var2 = 2; //violation here
+int o = 1, p = 2,
+r = 5; int t; //violation here
+        </source>
+        <p>
+          An example of how to configure the check to treat resources
+          in a try statement as statements to require them on their own line:
+        </p>
+        <source>
+&lt;module name="OneStatementPerLine"&gt;
+  &lt;property name="treatTryResourcesAsStatement" value="true"/&gt;
+&lt;/module&gt;
+        </source>
+        <p>
+          Note: resource declarations can contain variable definitions
+          and variable references (from java9).
+          When property "treatTryResourcesAsStatement" is enabled,
+          this check is only applied to variable definitions.
+          If there are one or more variable references
+          and one variable definition on the same line in resources declaration,
+          there is no violation.
+          The following examples will illustrate difference:
+        </p>
+        <source>
+OutputStream s1 = new PipedOutputStream();
+OutputStream s2 = new PipedOutputStream();
+// only one statement(variable definition) with two variable references
+try (s1; s2; OutputStream s3 = new PipedOutputStream();) // OK
+{}
+// two statements with variable definitions
+try (Reader r = new PipedReader(); s2; Reader s3 = new PipedReader() // violation
+) {}
+        </source>
+      </subsection>
+
+      <subsection name="Example of Usage" id="Example_of_Usage">
+        <ul>
+          <li>
+            <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources%20path%3A**%2Fgoogle_checks.xml+repo%3Acheckstyle%2Fcheckstyle+OneStatementPerLine">
+            Google Style</a>
+          </li>
+          <li>
+            <a href="https://github.com/search?q=path%3Aconfig%20path%3A**%2Fcheckstyle-checks.xml+repo%3Acheckstyle%2Fcheckstyle+OneStatementPerLine">
+            Checkstyle Style</a>
+          </li>
+        </ul>
+      </subsection>
+
+      <subsection name="Violation Messages" id="Violation_Messages">
+        <ul>
+          <li>
+            <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources%2Fcom%2Fpuppycrawl%2Ftools%2Fcheckstyle%2Fchecks%2Fcoding%20path%3A**%2Fmessages*.properties+repo%3Acheckstyle%2Fcheckstyle+%22multiple.statements.line%22">
+            multiple.statements.line</a>
+          </li>
+        </ul>
+        <p>
+          All messages can be customized if the default message doesn't suit you.
+          Please <a href="../../config.html#Custom_messages">see the documentation</a>
+          to learn how to.
+        </p>
+      </subsection>
+
+      <subsection name="Package" id="Package">
+        <p>
+          com.puppycrawl.tools.checkstyle.checks.coding
+        </p>
+      </subsection>
+
+      <subsection name="Parent Module" id="Parent_Module">
+        <p>
+          <a href="../../config.html#TreeWalker">TreeWalker</a>
+        </p>
+      </subsection>
+    </section>
+  </body>
+</document>

--- a/src/xdocs/checks/coding/overloadmethodsdeclarationorder.xml
+++ b/src/xdocs/checks/coding/overloadmethodsdeclarationorder.xml
@@ -19,7 +19,7 @@
       <subsection name="Examples" id="Examples">
         <p>To configure the check:</p>
         <source>
-&lt;module name="OverloadMethodsDeclarationOrder"/&gt;
+&lt;module name=&quot;OverloadMethodsDeclarationOrder&quot;/&gt;
         </source>
         <p>Example of correct grouping of overloaded methods:</p>
         <source>

--- a/src/xdocs/checks/coding/overloadmethodsdeclarationorder.xml.template
+++ b/src/xdocs/checks/coding/overloadmethodsdeclarationorder.xml.template
@@ -1,0 +1,82 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<document xmlns="http://maven.apache.org/XDOC/2.0"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/XDOC/2.0 https://maven.apache.org/xsd/xdoc-2.0.xsd">
+  <head>
+    <title>OverloadMethodsDeclarationOrder</title>
+  </head>
+  <body>
+    <section name="OverloadMethodsDeclarationOrder">
+      <p>Since Checkstyle 5.8</p>
+      <subsection name="Description" id="Description">
+        <p>
+          Checks that overloaded methods are grouped together. Overloaded methods have the same
+          name but different signatures where the signature can differ by the number of input
+          parameters or type of input parameters or both.
+        </p>
+      </subsection>
+
+      <subsection name="Examples" id="Examples">
+        <p>To configure the check:</p>
+        <source>
+&lt;module name="OverloadMethodsDeclarationOrder"/&gt;
+        </source>
+        <p>Example of correct grouping of overloaded methods:</p>
+        <source>
+public void foo(int i) {}
+public void foo(String s) {}
+public void foo(String s, int i) {}
+public void foo(int i, String s) {}
+public void notFoo() {}
+        </source>
+        <p>Example of incorrect grouping of overloaded methods:</p>
+        <source>
+public void foo(int i) {} // OK
+public void foo(String s) {} // OK
+public void notFoo() {} // violation. Have to be after foo(String s, int i)
+public void foo(int i, String s) {}
+public void foo(String s, int i) {}
+        </source>
+      </subsection>
+
+      <subsection name="Example of Usage" id="Example_of_Usage">
+        <ul>
+          <li>
+            <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources%20path%3A**%2Fgoogle_checks.xml+repo%3Acheckstyle%2Fcheckstyle+OverloadMethodsDeclarationOrder">
+            Google Style</a>
+          </li>
+          <li>
+            <a href="https://github.com/search?q=path%3Aconfig%20path%3A**%2Fcheckstyle-checks.xml+repo%3Acheckstyle%2Fcheckstyle+OverloadMethodsDeclarationOrder">
+            Checkstyle Style</a>
+          </li>
+        </ul>
+      </subsection>
+
+      <subsection name="Violation Messages" id="Violation_Messages">
+        <ul>
+          <li>
+            <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources%2Fcom%2Fpuppycrawl%2Ftools%2Fcheckstyle%2Fchecks%2Fcoding%20path%3A**%2Fmessages*.properties+repo%3Acheckstyle%2Fcheckstyle+%22overload.methods.declaration%22">
+            overload.methods.declaration</a>
+          </li>
+        </ul>
+        <p>
+          All messages can be customized if the default message doesn't suit you.
+          Please <a href="../../config.html#Custom_messages">see the documentation</a>
+          to learn how to.
+        </p>
+      </subsection>
+
+      <subsection name="Package" id="Package">
+        <p>
+          com.puppycrawl.tools.checkstyle.checks.coding
+        </p>
+      </subsection>
+
+      <subsection name="Parent Module" id="Parent_Module">
+        <p>
+          <a href="../../config.html#TreeWalker">TreeWalker</a>
+        </p>
+      </subsection>
+    </section>
+  </body>
+</document>

--- a/src/xdocs/checks/coding/packagedeclaration.xml
+++ b/src/xdocs/checks/coding/packagedeclaration.xml
@@ -51,7 +51,7 @@
           To configure the check:
         </p>
         <source>
-&lt;module name="PackageDeclaration"/&gt;
+&lt;module name=&quot;PackageDeclaration&quot;/&gt;
         </source>
         <p>
           Let us consider the class AnnotationLocationCheck which is in the directory
@@ -69,8 +69,8 @@ public class AnnotationLocationCheck extends AbstractCheck {
           /com/puppycrawl/tools/checkstyle/checks/annotations/ along with the following setup,
         </p>
         <source>
-&lt;module name="PackageDeclaration"&gt;
-&lt;property name="matchDirectoryStructure" value="false"/&gt;
+&lt;module name=&quot;PackageDeclaration&quot;&gt;
+&lt;property name=&quot;matchDirectoryStructure&quot; value=&quot;false&quot;/&gt;
 &lt;/module&gt;
         </source>
         <source>

--- a/src/xdocs/checks/coding/packagedeclaration.xml.template
+++ b/src/xdocs/checks/coding/packagedeclaration.xml.template
@@ -1,0 +1,125 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<document xmlns="http://maven.apache.org/XDOC/2.0"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/XDOC/2.0 https://maven.apache.org/xsd/xdoc-2.0.xsd">
+  <head>
+    <title>PackageDeclaration</title>
+  </head>
+  <body>
+    <section name="PackageDeclaration">
+      <p>Since Checkstyle 3.2</p>
+      <subsection name="Description" id="Description">
+        <p>
+          Ensures that a class has a package declaration, and (optionally) whether
+          the package name matches the directory name for the source file.
+        </p>
+        <p>
+          Rationale: Classes that live in the null package cannot be
+          imported. Many novice developers are not aware of this.
+        </p>
+        <p>
+          Packages provide logical namespace to classes and should be stored in
+          the form of directory levels to provide physical grouping to your classes.
+          These directories are added to the classpath so that your classes
+          are visible to JVM when it runs the code.
+        </p>
+      </subsection>
+
+      <subsection name="Properties" id="Properties">
+        <div class="wrapper">
+          <table>
+            <tr>
+              <th>name</th>
+              <th>description</th>
+              <th>type</th>
+              <th>default value</th>
+              <th>since</th>
+            </tr>
+            <tr>
+              <td>matchDirectoryStructure</td>
+              <td>Control whether to check for directory and package name match.</td>
+              <td><a href="../../property_types.html#boolean">boolean</a></td>
+              <td><code>true</code></td>
+              <td>7.6.1</td>
+            </tr>
+          </table>
+        </div>
+      </subsection>
+
+      <subsection name="Examples" id="Examples">
+        <p>
+          To configure the check:
+        </p>
+        <source>
+&lt;module name="PackageDeclaration"/&gt;
+        </source>
+        <p>
+          Let us consider the class AnnotationLocationCheck which is in the directory
+          /com/puppycrawl/tools/checkstyle/checks/annotations/
+        </p>
+        <source>
+package com.puppycrawl.tools.checkstyle.checks; //Violation
+public class AnnotationLocationCheck extends AbstractCheck {
+  //...
+}
+        </source>
+        <p>
+          Example of how the check works when matchDirectoryStructure option is set to false.
+          Let us again consider the AnnotationLocationCheck class located at directory
+          /com/puppycrawl/tools/checkstyle/checks/annotations/ along with the following setup,
+        </p>
+        <source>
+&lt;module name="PackageDeclaration"&gt;
+&lt;property name="matchDirectoryStructure" value="false"/&gt;
+&lt;/module&gt;
+        </source>
+        <source>
+package com.puppycrawl.tools.checkstyle.checks;  //No Violation
+
+public class AnnotationLocationCheck extends AbstractCheck {
+  //...
+}
+        </source>
+      </subsection>
+
+      <subsection name="Example of Usage" id="Example_of_Usage">
+        <ul>
+          <li>
+            <a href="https://github.com/search?q=path%3Aconfig%20path%3A**%2Fcheckstyle-checks.xml+repo%3Acheckstyle%2Fcheckstyle+PackageDeclaration">
+            Checkstyle Style</a>
+          </li>
+        </ul>
+      </subsection>
+
+      <subsection name="Violation Messages" id="Violation_Messages">
+        <ul>
+          <li>
+            <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources%2Fcom%2Fpuppycrawl%2Ftools%2Fcheckstyle%2Fchecks%2Fcoding%20path%3A**%2Fmessages*.properties+repo%3Acheckstyle%2Fcheckstyle+%22mismatch.package.directory%22">
+            mismatch.package.directory</a>
+          </li>
+          <li>
+            <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources%2Fcom%2Fpuppycrawl%2Ftools%2Fcheckstyle%2Fchecks%2Fcoding%20path%3A**%2Fmessages*.properties+repo%3Acheckstyle%2Fcheckstyle+%22missing.package.declaration%22">
+            missing.package.declaration</a>
+          </li>
+        </ul>
+        <p>
+          All messages can be customized if the default message doesn't suit you.
+          Please <a href="../../config.html#Custom_messages">see the documentation</a>
+          to learn how to.
+        </p>
+      </subsection>
+
+      <subsection name="Package" id="Package">
+        <p>
+          com.puppycrawl.tools.checkstyle.checks.coding
+        </p>
+      </subsection>
+
+      <subsection name="Parent Module" id="Parent_Module">
+        <p>
+          <a href="../../config.html#TreeWalker">TreeWalker</a>
+        </p>
+      </subsection>
+    </section>
+  </body>
+</document>

--- a/src/xdocs/checks/coding/parameterassignment.xml
+++ b/src/xdocs/checks/coding/parameterassignment.xml
@@ -23,7 +23,7 @@
           To configure the check:
         </p>
         <source>
-&lt;module name="ParameterAssignment"/&gt;
+&lt;module name=&quot;ParameterAssignment&quot;/&gt;
         </source>
         <p>
           Example:
@@ -32,7 +32,7 @@
 class MyClass {
   int methodOne(int parameter) {
     if (parameter &lt;= 0 ) {
-      throw new IllegalArgumentException("A positive value is expected");
+      throw new IllegalArgumentException(&quot;A positive value is expected&quot;);
     }
     parameter -= 2;  // violation
     return parameter;
@@ -40,7 +40,7 @@ class MyClass {
 
   int methodTwo(int parameter) {
     if (parameter &lt;= 0 ) {
-      throw new IllegalArgumentException("A positive value is expected");
+      throw new IllegalArgumentException(&quot;A positive value is expected&quot;);
     }
     int local = parameter;
     local -= 2;  // OK

--- a/src/xdocs/checks/coding/parameterassignment.xml.template
+++ b/src/xdocs/checks/coding/parameterassignment.xml.template
@@ -1,0 +1,100 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<document xmlns="http://maven.apache.org/XDOC/2.0"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/XDOC/2.0 https://maven.apache.org/xsd/xdoc-2.0.xsd">
+  <head>
+    <title>ParameterAssignment</title>
+  </head>
+  <body>
+    <section name="ParameterAssignment">
+      <p>Since Checkstyle 3.2</p>
+      <subsection name="Description" id="Description">
+        <p> Disallows assignment of parameters.</p>
+        <p>
+          Rationale: Parameter assignment is often considered poor programming
+          practice. Forcing developers to declare parameters as final is often
+          onerous. Having a check ensure that parameters are never assigned
+          would give the best of both worlds.
+        </p>
+      </subsection>
+
+      <subsection name="Examples" id="Examples">
+        <p>
+          To configure the check:
+        </p>
+        <source>
+&lt;module name="ParameterAssignment"/&gt;
+        </source>
+        <p>
+          Example:
+        </p>
+        <source>
+class MyClass {
+  int methodOne(int parameter) {
+    if (parameter &lt;= 0 ) {
+      throw new IllegalArgumentException("A positive value is expected");
+    }
+    parameter -= 2;  // violation
+    return parameter;
+  }
+
+  int methodTwo(int parameter) {
+    if (parameter &lt;= 0 ) {
+      throw new IllegalArgumentException("A positive value is expected");
+    }
+    int local = parameter;
+    local -= 2;  // OK
+    return local;
+  }
+
+  IntPredicate obj = a -&gt; ++a == 12; // violation
+  IntBinaryOperator obj2 = (int a, int b) -&gt; {
+      a++;     // violation
+      b += 12; // violation
+      return a + b;
+  };
+  IntPredicate obj3 = a -&gt; {
+      int b = a; // ok
+      return ++b == 12;
+  };
+}
+        </source>
+      </subsection>
+
+      <subsection name="Example of Usage" id="Example_of_Usage">
+        <ul>
+          <li>
+            <a href="https://github.com/search?q=path%3Aconfig%20path%3A**%2Fcheckstyle-checks.xml+repo%3Acheckstyle%2Fcheckstyle+ParameterAssignment">
+            Checkstyle Style</a>
+          </li>
+        </ul>
+      </subsection>
+
+      <subsection name="Violation Messages" id="Violation_Messages">
+        <ul>
+          <li>
+            <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources%2Fcom%2Fpuppycrawl%2Ftools%2Fcheckstyle%2Fchecks%2Fcoding%20path%3A**%2Fmessages*.properties+repo%3Acheckstyle%2Fcheckstyle+%22parameter.assignment%22">
+            parameter.assignment</a>
+          </li>
+        </ul>
+        <p>
+          All messages can be customized if the default message doesn't suit you.
+          Please <a href="../../config.html#Custom_messages">see the documentation</a>
+          to learn how to.
+        </p>
+      </subsection>
+
+      <subsection name="Package" id="Package">
+        <p>
+          com.puppycrawl.tools.checkstyle.checks.coding
+        </p>
+      </subsection>
+
+      <subsection name="Parent Module" id="Parent_Module">
+        <p>
+          <a href="../../config.html#TreeWalker">TreeWalker</a>
+        </p>
+      </subsection>
+    </section>
+  </body>
+</document>

--- a/src/xdocs/checks/coding/requirethis.xml
+++ b/src/xdocs/checks/coding/requirethis.xml
@@ -11,9 +11,9 @@
       <subsection name="Description" id="Description">
         <p>
           Checks that references to instance variables and methods of the present
-          object are explicitly of the form "this.varName" or
-          "this.methodName(args)" and that those references don't
-          rely on the default behavior when "this." is absent.
+          object are explicitly of the form &quot;this.varName&quot; or
+          &quot;this.methodName(args)&quot; and that those references don't
+          rely on the default behavior when &quot;this.&quot; is absent.
         </p>
 
         <p>
@@ -27,7 +27,7 @@
         <ol>
           <li>
             The same notation/habit for C++ and Java (C++ have global methods, so having
-            "this." do make sense in it to distinguish call of method of class
+            &quot;this.&quot; do make sense in it to distinguish call of method of class
             instead of global).
           </li>
           <li>
@@ -86,7 +86,7 @@
           To configure the default check:
         </p>
         <source>
-&lt;module name="RequireThis"/&gt;
+&lt;module name=&quot;RequireThis&quot;/&gt;
         </source>
         <p>Example:</p>
         <source>
@@ -104,7 +104,7 @@ public class Test {
 
   public void foo(int c) {
     // overlapping by method argument
-    c = c;            // violation, reference to instance variable "c" requires "this"
+    c = c;            // violation, reference to instance variable &quot;c&quot; requires &quot;this&quot;
   }
 }
         </source>
@@ -112,8 +112,8 @@ public class Test {
           To configure the check for fields only:
         </p>
         <source>
-&lt;module name="RequireThis"&gt;
-  &lt;property name="checkMethods" value="false"/&gt;
+&lt;module name=&quot;RequireThis&quot;&gt;
+  &lt;property name=&quot;checkMethods&quot; value=&quot;false&quot;/&gt;
 &lt;/module&gt;
         </source>
         <p>Example:</p>
@@ -132,7 +132,7 @@ public class Test {
 
   public void foo(int c) {
     // overlapping by method argument
-    c = c;            // violation, reference to instance variable "c" requires "this"
+    c = c;            // violation, reference to instance variable &quot;c&quot; requires &quot;this&quot;
   }
 }
         </source>
@@ -140,8 +140,8 @@ public class Test {
             To configure the check for methods only:
         </p>
         <source>
-&lt;module name="RequireThis"&gt;
-  &lt;property name="checkFields" value="false"/&gt;
+&lt;module name=&quot;RequireThis&quot;&gt;
+  &lt;property name=&quot;checkFields&quot; value=&quot;false&quot;/&gt;
 &lt;/module&gt;
         </source>
         <p>Example:</p>
@@ -172,8 +172,8 @@ public class Test {
             To configure the check to validate for non-overlapping fields and methods:
         </p>
         <source>
-&lt;module name="RequireThis"&gt;
-  &lt;property name="validateOnlyOverlapping" value="false"/&gt;
+&lt;module name=&quot;RequireThis&quot;&gt;
+  &lt;property name=&quot;validateOnlyOverlapping&quot; value=&quot;false&quot;/&gt;
 &lt;/module&gt;
         </source>
         <p>Example:</p>
@@ -186,13 +186,13 @@ public class Test {
   public Test(int a) {
     // overlapping by constructor argument
     this.a = a;       // OK, no validation for fields
-    b = 0;            // violation, reference to instance variable "b" requires "this"
-    foo(5);           // violation, method call "foo(5)" requires "this"
+    b = 0;            // violation, reference to instance variable &quot;b&quot; requires &quot;this&quot;
+    foo(5);           // violation, method call &quot;foo(5)&quot; requires &quot;this&quot;
   }
 
   public void foo(int c) {
     // overlapping by method argument
-    c = c;            // violation, reference to instance variable "c" requires "this"
+    c = c;            // violation, reference to instance variable &quot;c&quot; requires &quot;this&quot;
   }
 }
         </source>
@@ -227,7 +227,7 @@ public class D {
   private String prefix;
 
   public String modifyPrefix(String prefix) {
-    prefix = "^" + prefix + "$";  // no violation, because method parameter is returned
+    prefix = &quot;^&quot; + prefix + &quot;$&quot;;  // no violation, because method parameter is returned
     return prefix;
   }
 }

--- a/src/xdocs/checks/coding/requirethis.xml.template
+++ b/src/xdocs/checks/coding/requirethis.xml.template
@@ -1,0 +1,277 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<document xmlns="http://maven.apache.org/XDOC/2.0"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/XDOC/2.0 https://maven.apache.org/xsd/xdoc-2.0.xsd">
+  <head>
+    <title>RequireThis</title>
+  </head>
+  <body>
+    <section name="RequireThis">
+      <p>Since Checkstyle 3.4</p>
+      <subsection name="Description" id="Description">
+        <p>
+          Checks that references to instance variables and methods of the present
+          object are explicitly of the form "this.varName" or
+          "this.methodName(args)" and that those references don't
+          rely on the default behavior when "this." is absent.
+        </p>
+
+        <p>
+           Warning: the Check is very controversial if 'validateOnlyOverlapping' option is set to
+           'false' and not that actual nowadays.
+        </p>
+
+        <p>
+          Rationale:
+        </p>
+        <ol>
+          <li>
+            The same notation/habit for C++ and Java (C++ have global methods, so having
+            "this." do make sense in it to distinguish call of method of class
+            instead of global).
+          </li>
+          <li>
+            Non-IDE development (ease of refactoring, some clearness to distinguish
+            static and non-static methods).
+          </li>
+        </ol>
+      </subsection>
+      <subsection name="Notes" id="Notes">
+        <p>
+          Limitations: Nothing is currently done about static variables
+          or catch-blocks.  Static methods invoked on a class name seem to be OK;
+          both the class name and the method name have a DOT parent.
+          Non-static methods invoked on either this or a variable name seem to be
+          OK, likewise.
+        </p>
+      </subsection>
+
+      <subsection name="Properties" id="Properties">
+        <div class="wrapper">
+          <table>
+            <tr>
+              <th>name</th>
+              <th>description</th>
+              <th>type</th>
+              <th>default value</th>
+              <th>since</th>
+            </tr>
+            <tr>
+              <td>checkFields</td>
+              <td>Control whether to check references to fields.</td>
+              <td><a href="../../property_types.html#boolean">boolean</a></td>
+              <td><code>true</code></td>
+              <td>3.4</td>
+            </tr>
+            <tr>
+              <td>checkMethods</td>
+              <td>Control whether to check references to methods.</td>
+              <td><a href="../../property_types.html#boolean">boolean</a></td>
+              <td><code>true</code></td>
+              <td>3.4</td>
+            </tr>
+            <tr>
+              <td>validateOnlyOverlapping</td>
+              <td>Control whether to check only overlapping by variables or arguments.</td>
+              <td><a href="../../property_types.html#boolean">boolean</a></td>
+              <td><code>true</code></td>
+              <td>6.17</td>
+            </tr>
+          </table>
+        </div>
+      </subsection>
+
+      <subsection name="Examples" id="Examples">
+        <p>
+          To configure the default check:
+        </p>
+        <source>
+&lt;module name="RequireThis"/&gt;
+        </source>
+        <p>Example:</p>
+        <source>
+public class Test {
+  private int a;
+  private int b;
+  private int c;
+
+  public Test(int a) {
+    // overlapping by constructor argument
+    this.a = a;       // OK, this keyword used
+    b = 0;            // OK, no overlap
+    foo(5);           // OK
+  }
+
+  public void foo(int c) {
+    // overlapping by method argument
+    c = c;            // violation, reference to instance variable "c" requires "this"
+  }
+}
+        </source>
+        <p>
+          To configure the check for fields only:
+        </p>
+        <source>
+&lt;module name="RequireThis"&gt;
+  &lt;property name="checkMethods" value="false"/&gt;
+&lt;/module&gt;
+        </source>
+        <p>Example:</p>
+        <source>
+public class Test {
+  private int a;
+  private int b;
+  private int c;
+
+  public Test(int a) {
+    // overlapping by constructor argument
+    this.a = a;       // OK, this keyword used
+    b = 0;            // OK, no overlap
+    foo(5);           // OK, no validation for methods
+  }
+
+  public void foo(int c) {
+    // overlapping by method argument
+    c = c;            // violation, reference to instance variable "c" requires "this"
+  }
+}
+        </source>
+        <p>
+            To configure the check for methods only:
+        </p>
+        <source>
+&lt;module name="RequireThis"&gt;
+  &lt;property name="checkFields" value="false"/&gt;
+&lt;/module&gt;
+        </source>
+        <p>Example:</p>
+        <source>
+public class Test {
+  private int a;
+  private int b;
+  private int c;
+
+  public Test(int a) {
+    // overlapping by constructor argument
+    this.a = a;       // OK, no validation for fields
+    b = 0;            // OK, no validation for fields
+    foo(5);           // OK, no overlap
+  }
+
+  public void foo(int c) {
+    // overlapping by method argument
+    c = c;            // OK, no validation for fields
+  }
+}
+        </source>
+        <p>
+          Note that method call foo(5) does not raise a violation
+          because methods cannot be overlapped in java.
+        </p>
+        <p>
+            To configure the check to validate for non-overlapping fields and methods:
+        </p>
+        <source>
+&lt;module name="RequireThis"&gt;
+  &lt;property name="validateOnlyOverlapping" value="false"/&gt;
+&lt;/module&gt;
+        </source>
+        <p>Example:</p>
+        <source>
+public class Test {
+  private int a;
+  private int b;
+  private int c;
+
+  public Test(int a) {
+    // overlapping by constructor argument
+    this.a = a;       // OK, no validation for fields
+    b = 0;            // violation, reference to instance variable "b" requires "this"
+    foo(5);           // violation, method call "foo(5)" requires "this"
+  }
+
+  public void foo(int c) {
+    // overlapping by method argument
+    c = c;            // violation, reference to instance variable "c" requires "this"
+  }
+}
+        </source>
+        <p>
+          Please, be aware of the following logic, which is implemented in the check:
+        </p>
+        <p>
+          1) If you arrange 'this' in your code on your own, the check will not raise violation for
+          variables which use 'this' to reference a class field, for example:
+        </p>
+        <source>
+public class C {
+  private int scale;
+  private int x;
+
+  public void foo(int scale) {
+    scale = this.scale;      // no violation
+
+    if (scale &gt; 0) {
+      scale = -scale;        // no violation
+    }
+    x *= scale;
+  }
+}
+        </source>
+        <p>
+          2) If method parameter is returned from the method, the check will not raise violation for
+             returned variable/parameter, for example:
+        </p>
+        <source>
+public class D {
+  private String prefix;
+
+  public String modifyPrefix(String prefix) {
+    prefix = "^" + prefix + "$";  // no violation, because method parameter is returned
+    return prefix;
+  }
+}
+        </source>
+      </subsection>
+
+      <subsection name="Example of Usage" id="Example_of_Usage">
+        <ul>
+          <li>
+            <a href="https://github.com/search?q=path%3Aconfig%20path%3A**%2Fcheckstyle-checks.xml+repo%3Acheckstyle%2Fcheckstyle+RequireThis">
+            Checkstyle Style</a>
+          </li>
+        </ul>
+      </subsection>
+
+      <subsection name="Violation Messages" id="Violation_Messages">
+        <ul>
+          <li>
+            <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources%2Fcom%2Fpuppycrawl%2Ftools%2Fcheckstyle%2Fchecks%2Fcoding%20path%3A**%2Fmessages*.properties+repo%3Acheckstyle%2Fcheckstyle+%22require.this.method%22">
+            require.this.method</a>
+          </li>
+          <li>
+            <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources%2Fcom%2Fpuppycrawl%2Ftools%2Fcheckstyle%2Fchecks%2Fcoding%20path%3A**%2Fmessages*.properties+repo%3Acheckstyle%2Fcheckstyle+%22require.this.variable%22">
+            require.this.variable</a>
+          </li>
+        </ul>
+        <p>
+          All messages can be customized if the default message doesn't suit you.
+          Please <a href="../../config.html#Custom_messages">see the documentation</a>
+          to learn how to.
+        </p>
+      </subsection>
+
+      <subsection name="Package" id="Package">
+        <p>
+          com.puppycrawl.tools.checkstyle.checks.coding
+        </p>
+      </subsection>
+
+      <subsection name="Parent Module" id="Parent_Module">
+        <p>
+          <a href="../../config.html#TreeWalker">TreeWalker</a>
+        </p>
+      </subsection>
+    </section>
+  </body>
+</document>

--- a/src/xdocs/checks/coding/returncount.xml
+++ b/src/xdocs/checks/coding/returncount.xml
@@ -24,7 +24,7 @@
           that have no return type (IE 'return;').
           It will only count visible return statements. Return statements not normally written, but
           implied, at the end of the method/constructor definition will not be taken into account.
-          To disallow "return;" in void return type methods, use a value of 0.
+          To disallow &quot;return;&quot; in void return type methods, use a value of 0.
         </p>
 
         <p>
@@ -64,7 +64,7 @@
               <td>format</td>
               <td>Specify method names to ignore.</td>
               <td><a href="../../property_types.html#Pattern">Pattern</a></td>
-              <td><code>"^equals$"</code></td>
+              <td><code>&quot;^equals$&quot;</code></td>
               <td>3.4</td>
             </tr>
             <tr>
@@ -102,8 +102,8 @@
           method):
         </p>
         <source>
-&lt;module name="ReturnCount"&gt;
-  &lt;property name="max" value="3"/&gt;
+&lt;module name=&quot;ReturnCount&quot;&gt;
+  &lt;property name=&quot;max&quot; value=&quot;3&quot;/&gt;
 &lt;/module&gt;
         </source>
         <p>
@@ -136,8 +136,8 @@ public class MyClass {
           return statements per void method:
         </p>
         <source>
-&lt;module name="ReturnCount"&gt;
-  &lt;property name="maxForVoid" value="0"/&gt;
+&lt;module name=&quot;ReturnCount&quot;&gt;
+  &lt;property name=&quot;maxForVoid&quot; value=&quot;0&quot;/&gt;
 &lt;/module&gt;
         </source>
         <p>
@@ -160,9 +160,9 @@ public class MyClass {
           method) and more than 1 return statements per void method:
         </p>
         <source>
-&lt;module name="ReturnCount"&gt;
-  &lt;property name="max" value="2"/&gt;
-  &lt;property name="maxForVoid" value="1"/&gt;
+&lt;module name=&quot;ReturnCount&quot;&gt;
+  &lt;property name=&quot;max&quot; value=&quot;2&quot;/&gt;
+  &lt;property name=&quot;maxForVoid&quot; value=&quot;1&quot;/&gt;
 &lt;/module&gt;
         </source>
         <p>
@@ -204,9 +204,9 @@ public class MyClass {
           return statements per method for all methods:
         </p>
         <source>
-&lt;module name="ReturnCount"&gt;
-  &lt;property name="max" value="3"/&gt;
-  &lt;property name="format" value="^$"/&gt;
+&lt;module name=&quot;ReturnCount&quot;&gt;
+  &lt;property name=&quot;max&quot; value=&quot;3&quot;/&gt;
+  &lt;property name=&quot;format&quot; value=&quot;^$&quot;/&gt;
 &lt;/module&gt;
         </source>
         <p>
@@ -240,17 +240,17 @@ public class MyClass {
           expressions and more than two return statements in methods:
         </p>
         <source>
-&lt;module name="ReturnCount"&gt;
-  &lt;property name="maxForVoid" value="0"/&gt;
-  &lt;property name="tokens" value="CTOR_DEF"/&gt;
+&lt;module name=&quot;ReturnCount&quot;&gt;
+  &lt;property name=&quot;maxForVoid&quot; value=&quot;0&quot;/&gt;
+  &lt;property name=&quot;tokens&quot; value=&quot;CTOR_DEF&quot;/&gt;
 &lt;/module&gt;
-&lt;module name="ReturnCount"&gt;
-  &lt;property name="max" value="1"/&gt;
-  &lt;property name="tokens" value="LAMBDA"/&gt;
+&lt;module name=&quot;ReturnCount&quot;&gt;
+  &lt;property name=&quot;max&quot; value=&quot;1&quot;/&gt;
+  &lt;property name=&quot;tokens&quot; value=&quot;LAMBDA&quot;/&gt;
 &lt;/module&gt;
-&lt;module name="ReturnCount"&gt;
-  &lt;property name="max" value="2"/&gt;
-  &lt;property name="tokens" value="METHOD_DEF"/&gt;
+&lt;module name=&quot;ReturnCount&quot;&gt;
+  &lt;property name=&quot;max&quot; value=&quot;2&quot;/&gt;
+  &lt;property name=&quot;tokens&quot; value=&quot;METHOD_DEF&quot;/&gt;
 &lt;/module&gt;
         </source>
         <p>

--- a/src/xdocs/checks/coding/returncount.xml.template
+++ b/src/xdocs/checks/coding/returncount.xml.template
@@ -1,0 +1,338 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<document xmlns="http://maven.apache.org/XDOC/2.0"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/XDOC/2.0 https://maven.apache.org/xsd/xdoc-2.0.xsd">
+  <head>
+    <title>ReturnCount</title>
+  </head>
+  <body>
+    <section name="ReturnCount">
+      <p>Since Checkstyle 3.2</p>
+      <subsection name="Description" id="Description">
+        <p>
+          Restricts the number of return statements in methods, constructors and lambda expressions.
+          Ignores specified methods (<code>equals</code> by default).
+        </p>
+
+        <p>
+          <b>max</b> property will only check returns in methods and lambdas that return a specific
+          value (Ex: 'return 1;').
+        </p>
+
+        <p>
+          <b>maxForVoid</b> property will only check returns in methods, constructors, and lambdas
+          that have no return type (IE 'return;').
+          It will only count visible return statements. Return statements not normally written, but
+          implied, at the end of the method/constructor definition will not be taken into account.
+          To disallow "return;" in void return type methods, use a value of 0.
+        </p>
+
+        <p>
+          Rationale: Too many return points can mean that code is
+          attempting to do too much or may be difficult to understand.
+        </p>
+      </subsection>
+
+      <subsection name="Properties" id="Properties">
+        <div class="wrapper">
+          <table>
+            <tr>
+              <th>name</th>
+              <th>description</th>
+              <th>type</th>
+              <th>default value</th>
+              <th>since</th>
+            </tr>
+            <tr>
+              <td>max</td>
+              <td>
+                Specify maximum allowed number of return statements in non-void methods/lambdas.
+              </td>
+              <td><a href="../../property_types.html#int">int</a></td>
+              <td><code>2</code></td>
+              <td>3.2</td>
+            </tr>
+            <tr>
+              <td>maxForVoid</td>
+              <td>Specify maximum allowed number of return statements in void
+                  methods/constructors/lambdas.</td>
+              <td><a href="../../property_types.html#int">int</a></td>
+              <td><code>1</code></td>
+              <td>6.19</td>
+            </tr>
+            <tr>
+              <td>format</td>
+              <td>Specify method names to ignore.</td>
+              <td><a href="../../property_types.html#Pattern">Pattern</a></td>
+              <td><code>"^equals$"</code></td>
+              <td>3.4</td>
+            </tr>
+            <tr>
+              <td>tokens</td>
+              <td>tokens to check</td>
+              <td>
+                subset of tokens
+                <a href="../../apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#CTOR_DEF">
+                  CTOR_DEF</a>
+                , <a href="../../apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#METHOD_DEF">
+                  METHOD_DEF</a>
+                , <a href="../../apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#LAMBDA">
+                  LAMBDA</a>
+                  .
+              </td>
+              <td>
+                <a href="../../apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#CTOR_DEF">
+                  CTOR_DEF</a>
+                , <a href="../../apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#METHOD_DEF">
+                  METHOD_DEF</a>
+                , <a href="../../apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#LAMBDA">
+                  LAMBDA</a>
+                  .
+              </td>
+              <td>3.2</td>
+            </tr>
+          </table>
+        </div>
+      </subsection>
+
+      <subsection name="Examples" id="Examples">
+        <p>
+          To configure the check so that it doesn't allow more than three
+          return statements per method (ignoring the <code>equals()</code>
+          method):
+        </p>
+        <source>
+&lt;module name="ReturnCount"&gt;
+  &lt;property name="max" value="3"/&gt;
+&lt;/module&gt;
+        </source>
+        <p>
+            Example:
+        </p>
+        <source>
+public class MyClass {
+  public int sign(int x) {
+    if (x &lt; 0)
+      return -1;
+    if (x == 0)
+      return 1;
+    return 0;
+  } // OK
+
+  public int badSign(int x) {
+    if (x &lt; -2)
+      return -2;
+    if (x == 0)
+      return 0;
+    if (x &gt; 2)
+      return 2;
+    return 1;
+  } // violation, more than three return statements
+}
+        </source>
+
+        <p>
+          To configure the check so that it doesn't allow any
+          return statements per void method:
+        </p>
+        <source>
+&lt;module name="ReturnCount"&gt;
+  &lt;property name="maxForVoid" value="0"/&gt;
+&lt;/module&gt;
+        </source>
+        <p>
+            Example:
+        </p>
+        <source>
+public class MyClass {
+  public void firstMethod(int x) {
+  } // OK
+
+  public void badMethod(int x) {
+    return;
+  } // violation, return statements per void method
+}
+        </source>
+
+        <p>
+          To configure the check so that it doesn't allow more than 2
+          return statements per method (ignoring the <code>equals()</code>
+          method) and more than 1 return statements per void method:
+        </p>
+        <source>
+&lt;module name="ReturnCount"&gt;
+  &lt;property name="max" value="2"/&gt;
+  &lt;property name="maxForVoid" value="1"/&gt;
+&lt;/module&gt;
+        </source>
+        <p>
+            Example:
+        </p>
+        <source>
+public class MyClass {
+  public void firstMethod() {
+  } // OK
+
+  public void secondMethod() {
+    return;
+  } // OK
+
+  public void badMethod(int x) {
+    if (x == 0)
+      return;
+    return;
+  } // violation, more than one return statements
+
+  public int sign(int x) {
+    if (x &lt; 0)
+      return -1;
+    return 0;
+  } // OK
+
+  public int badSign(int x) {
+    if (x &lt; 0)
+      return -1;
+    if (x == 0)
+      return 1;
+    return 0;
+  } // violation, more than two return statements in methods
+}
+        </source>
+
+        <p>
+          To configure the check so that it doesn't allow more than three
+          return statements per method for all methods:
+        </p>
+        <source>
+&lt;module name="ReturnCount"&gt;
+  &lt;property name="max" value="3"/&gt;
+  &lt;property name="format" value="^$"/&gt;
+&lt;/module&gt;
+        </source>
+        <p>
+            Example:
+        </p>
+        <source>
+public class MyClass {
+  public int sign(int x) {
+    if (x &lt; 0)
+      return -1;
+    if (x == 0)
+      return 1;
+    return 0;
+  } // OK
+
+  public int badSign(int x) {
+    if (x &lt; -2)
+      return -2;
+    if (x == 0)
+      return 0;
+    if (x &gt; 2)
+      return 2;
+    return 1;
+  } // violation, more than three return statements per method
+}
+        </source>
+
+        <p>
+          To configure the check so that it doesn't allow any return statements
+          in constructors, more than one return statement in all lambda
+          expressions and more than two return statements in methods:
+        </p>
+        <source>
+&lt;module name="ReturnCount"&gt;
+  &lt;property name="maxForVoid" value="0"/&gt;
+  &lt;property name="tokens" value="CTOR_DEF"/&gt;
+&lt;/module&gt;
+&lt;module name="ReturnCount"&gt;
+  &lt;property name="max" value="1"/&gt;
+  &lt;property name="tokens" value="LAMBDA"/&gt;
+&lt;/module&gt;
+&lt;module name="ReturnCount"&gt;
+  &lt;property name="max" value="2"/&gt;
+  &lt;property name="tokens" value="METHOD_DEF"/&gt;
+&lt;/module&gt;
+        </source>
+        <p>
+            Example:
+        </p>
+        <source>
+import java.util.function.Predicate;
+
+public class Test {
+  public Test() {
+  } // OK
+
+  public Test(int i) {
+    return; // violation, max allowed for constructors is 0
+  }
+
+  final Predicate&lt;Integer&gt; p = i -&gt; {
+    if (i &gt; 5) {
+      return true;
+    }
+    return false;
+  }; // violation, max allowed for lambdas is 1
+
+  final Predicate&lt;Integer&gt; q = i -&gt; {
+    return i &gt; 5;
+  }; // OK
+
+  public int sign(int x) {
+    if (x &gt; 0)
+      return -1;
+    return 0;
+  } // OK
+
+  public int badSign(int x) {
+    if (x &lt; 0)
+      return -1;
+    if (x == 0)
+      return 1;
+    return 0;
+  } // violation, more than two return statements in methods
+}
+        </source>
+      </subsection>
+
+      <subsection name="Example of Usage" id="Example_of_Usage">
+        <ul>
+          <li>
+            <a href="https://github.com/search?q=path%3Aconfig%20path%3A**%2Fcheckstyle-checks.xml+repo%3Acheckstyle%2Fcheckstyle+ReturnCount">
+            Checkstyle Style</a>
+          </li>
+        </ul>
+      </subsection>
+
+      <subsection name="Violation Messages" id="Violation_Messages">
+        <ul>
+          <li>
+            <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources%2Fcom%2Fpuppycrawl%2Ftools%2Fcheckstyle%2Fchecks%2Fcoding%20path%3A**%2Fmessages*.properties+repo%3Acheckstyle%2Fcheckstyle+%22return.count%22">
+            return.count</a>
+          </li>
+          <li>
+            <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources%2Fcom%2Fpuppycrawl%2Ftools%2Fcheckstyle%2Fchecks%2Fcoding%20path%3A**%2Fmessages*.properties+repo%3Acheckstyle%2Fcheckstyle+%22return.countVoid%22">
+            return.countVoid</a>
+          </li>
+        </ul>
+        <p>
+          All messages can be customized if the default message doesn't suit you.
+          Please <a href="../../config.html#Custom_messages">see the documentation</a>
+          to learn how to.
+        </p>
+      </subsection>
+
+      <subsection name="Package" id="Package">
+        <p>
+          com.puppycrawl.tools.checkstyle.checks.coding
+        </p>
+      </subsection>
+
+      <subsection name="Parent Module" id="Parent_Module">
+        <p>
+          <a href="../../config.html#TreeWalker">TreeWalker</a>
+        </p>
+      </subsection>
+    </section>
+  </body>
+</document>

--- a/src/xdocs/checks/coding/simplifybooleanexpression.xml
+++ b/src/xdocs/checks/coding/simplifybooleanexpression.xml
@@ -27,7 +27,7 @@
           To configure the check:
         </p>
         <source>
-&lt;module name="SimplifyBooleanExpression"/&gt;
+&lt;module name=&quot;SimplifyBooleanExpression&quot;/&gt;
         </source>
         <p>Example:</p>
         <source>

--- a/src/xdocs/checks/coding/simplifybooleanexpression.xml.template
+++ b/src/xdocs/checks/coding/simplifybooleanexpression.xml.template
@@ -1,0 +1,101 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<document xmlns="http://maven.apache.org/XDOC/2.0"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/XDOC/2.0 https://maven.apache.org/xsd/xdoc-2.0.xsd">
+  <head>
+    <title>SimplifyBooleanExpression</title>
+  </head>
+  <body>
+    <section name="SimplifyBooleanExpression">
+      <p>Since Checkstyle 3.0</p>
+      <subsection name="Description" id="Description">
+        <p>
+          Checks for over-complicated boolean expressions. Currently, it finds
+          code like <code> if (b == true)</code>, <code>b || true</code>, <code>!false</code>,
+          <code>boolean a = q &gt; 12 ? true : false</code>,
+          etc.
+        </p>
+
+        <p>
+          Rationale: Complex boolean logic makes code hard to understand and
+          maintain.
+        </p>
+      </subsection>
+
+      <subsection name="Examples" id="Examples">
+        <p>
+          To configure the check:
+        </p>
+        <source>
+&lt;module name="SimplifyBooleanExpression"/&gt;
+        </source>
+        <p>Example:</p>
+        <source>
+public class Test {
+
+  public void bar() {
+
+    boolean a, b;
+    Foo c, d, e;
+
+    if (!false) {};       // violation, can be simplified to true
+
+    if (a == true) {};    // violation, can be simplified to a
+    if (a == b) {};       // OK
+    if (a == false) {};   // violation, can be simplified to !a
+    if (!(a != true)) {}; // violation, can be simplified to a
+
+    e = (a || b) ? c : d;     // OK
+    e = (a || false) ? c : d; // violation, can be simplified to a
+    e = (a &amp;&amp; b) ? c : d;     // OK
+
+    int s = 12;
+    boolean m = s &gt; 1 ? true : false; // violation, can be simplified to s &gt; 1
+    boolean f = c == null ? false : c.someMethod(); // OK
+  }
+
+}
+        </source>
+      </subsection>
+
+      <subsection name="Example of Usage" id="Example_of_Usage">
+        <ul>
+          <li>
+            <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources%20path%3A**%2Fsun_checks.xml+repo%3Acheckstyle%2Fcheckstyle+SimplifyBooleanExpression">
+            Sun Style</a>
+          </li>
+          <li>
+            <a href="https://github.com/search?q=path%3Aconfig%20path%3A**%2Fcheckstyle-checks.xml+repo%3Acheckstyle%2Fcheckstyle+SimplifyBooleanExpression">
+            Checkstyle Style</a>
+          </li>
+        </ul>
+      </subsection>
+
+      <subsection name="Violation Messages" id="Violation_Messages">
+        <ul>
+          <li>
+            <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources%2Fcom%2Fpuppycrawl%2Ftools%2Fcheckstyle%2Fchecks%2Fcoding%20path%3A**%2Fmessages*.properties+repo%3Acheckstyle%2Fcheckstyle+%22simplify.expression%22">
+            simplify.expression</a>
+          </li>
+        </ul>
+        <p>
+          All messages can be customized if the default message doesn't suit you.
+          Please <a href="../../config.html#Custom_messages">see the documentation</a>
+          to learn how to.
+        </p>
+      </subsection>
+
+      <subsection name="Package" id="Package">
+        <p>
+          com.puppycrawl.tools.checkstyle.checks.coding
+        </p>
+      </subsection>
+
+      <subsection name="Parent Module" id="Parent_Module">
+        <p>
+          <a href="../../config.html#TreeWalker">TreeWalker</a>
+        </p>
+      </subsection>
+    </section>
+  </body>
+</document>

--- a/src/xdocs/checks/coding/simplifybooleanreturn.xml
+++ b/src/xdocs/checks/coding/simplifybooleanreturn.xml
@@ -38,7 +38,7 @@ return !valid();
           To configure the check:
         </p>
         <source>
-&lt;module name="SimplifyBooleanReturn"/&gt;
+&lt;module name=&quot;SimplifyBooleanReturn&quot;/&gt;
         </source>
         <p>Example:</p>
         <source>
@@ -64,11 +64,11 @@ public class Test {
 
  // violations, can be simplified
  public boolean check3() {
-  if (cond == true) { // can be simplified to "if (cond)"
+  if (cond == true) { // can be simplified to &quot;if (cond)&quot;
     return false;
   }
   else {
-    return true; // can be simplified to "return !cond"
+    return true; // can be simplified to &quot;return !cond&quot;
   }
  }
 

--- a/src/xdocs/checks/coding/simplifybooleanreturn.xml.template
+++ b/src/xdocs/checks/coding/simplifybooleanreturn.xml.template
@@ -1,0 +1,134 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<document xmlns="http://maven.apache.org/XDOC/2.0"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/XDOC/2.0 https://maven.apache.org/xsd/xdoc-2.0.xsd">
+  <head>
+    <title>SimplifyBooleanReturn</title>
+  </head>
+  <body>
+    <section name="SimplifyBooleanReturn">
+      <p>Since Checkstyle 3.0</p>
+      <subsection name="Description" id="Description">
+        <p>
+          Checks for over-complicated boolean return statements. For example
+          the following code
+        </p>
+        <source>
+if (valid())
+  return false;
+else
+  return true;
+        </source>
+
+        <p>
+          could be written as
+        </p>
+        <source>
+return !valid();
+        </source>
+
+        <p>
+          The idea for this Check has been shamelessly stolen from the
+          equivalent <a href="https://pmd.github.io/">PMD</a> rule.
+        </p>
+      </subsection>
+
+      <subsection name="Examples" id="Examples">
+        <p>
+          To configure the check:
+        </p>
+        <source>
+&lt;module name="SimplifyBooleanReturn"/&gt;
+        </source>
+        <p>Example:</p>
+        <source>
+public class Test {
+
+ private boolean cond;
+ private Foo a;
+ private Foo b;
+
+ public boolean check1() {
+  if (cond) { // violation, can be simplified
+    return true;
+  }
+  else {
+    return false;
+  }
+ }
+
+ // Ok, simplified version of check1()
+ public boolean check2() {
+  return cond;
+ }
+
+ // violations, can be simplified
+ public boolean check3() {
+  if (cond == true) { // can be simplified to "if (cond)"
+    return false;
+  }
+  else {
+    return true; // can be simplified to "return !cond"
+  }
+ }
+
+ // Ok, can be simplified but doesn't return a Boolean
+ public Foo choose1() {
+  if (cond) {
+    return a;
+  }
+  else {
+    return b;
+  }
+ }
+
+ // Ok, simplified version of choose1()
+ public Foo choose2() {
+  return cond ? a: b;
+ }
+
+}
+        </source>
+      </subsection>
+
+      <subsection name="Example of Usage" id="Example_of_Usage">
+        <ul>
+          <li>
+            <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources%20path%3A**%2Fsun_checks.xml+repo%3Acheckstyle%2Fcheckstyle+SimplifyBooleanReturn">
+            Sun Style</a>
+          </li>
+          <li>
+            <a href="https://github.com/search?q=path%3Aconfig%20path%3A**%2Fcheckstyle-checks.xml+repo%3Acheckstyle%2Fcheckstyle+SimplifyBooleanReturn">
+            Checkstyle Style</a>
+          </li>
+        </ul>
+      </subsection>
+
+      <subsection name="Violation Messages" id="Violation_Messages">
+        <ul>
+          <li>
+            <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources%2Fcom%2Fpuppycrawl%2Ftools%2Fcheckstyle%2Fchecks%2Fcoding%20path%3A**%2Fmessages*.properties+repo%3Acheckstyle%2Fcheckstyle+%22simplify.boolReturn%22">
+            simplify.boolReturn</a>
+          </li>
+        </ul>
+        <p>
+          All messages can be customized if the default message doesn't suit you.
+          Please <a href="../../config.html#Custom_messages">see the documentation</a>
+          to learn how to.
+        </p>
+      </subsection>
+
+      <subsection name="Package" id="Package">
+        <p>
+          com.puppycrawl.tools.checkstyle.checks.coding
+        </p>
+      </subsection>
+
+      <subsection name="Parent Module" id="Parent_Module">
+        <p>
+          <a href="../../config.html#TreeWalker">TreeWalker</a>
+        </p>
+      </subsection>
+    </section>
+  </body>
+</document>

--- a/src/xdocs/checks/coding/stringliteralequality.xml
+++ b/src/xdocs/checks/coding/stringliteralequality.xml
@@ -24,12 +24,12 @@
           Rationale: Novice Java programmers often use code like:
         </p>
         <source>
-if (x == "something")
+if (x == &quot;something&quot;)
         </source>
 
         <p>when they mean</p>
         <source>
-if ("something".equals(x))
+if (&quot;something&quot;.equals(x))
         </source>
       </subsection>
 
@@ -38,23 +38,23 @@ if ("something".equals(x))
           To configure the check:
         </p>
         <source>
-&lt;module name="StringLiteralEquality"/&gt;
+&lt;module name=&quot;StringLiteralEquality&quot;/&gt;
         </source>
         <p>
           Examples of violations:
         </p>
         <source>
-String status = "pending";
+String status = &quot;pending&quot;;
 
-if (status == "done") {} // violation
+if (status == &quot;done&quot;) {} // violation
 
-while (status != "done") {} // violation
+while (status != &quot;done&quot;) {} // violation
 
-boolean flag = (status == "done"); // violation
+boolean flag = (status == &quot;done&quot;); // violation
 
-boolean flag = (status.equals("done")); // OK
+boolean flag = (status.equals(&quot;done&quot;)); // OK
 
-String name = "X";
+String name = &quot;X&quot;;
 
 if (name == getName()) {}
 // OK, limitation that check cannot tell runtime type returned from method call

--- a/src/xdocs/checks/coding/stringliteralequality.xml.template
+++ b/src/xdocs/checks/coding/stringliteralequality.xml.template
@@ -1,0 +1,100 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<document xmlns="http://maven.apache.org/XDOC/2.0"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/XDOC/2.0 https://maven.apache.org/xsd/xdoc-2.0.xsd">
+  <head>
+    <title>StringLiteralEquality</title>
+  </head>
+  <body>
+    <section name="StringLiteralEquality">
+      <p>Since Checkstyle 3.2</p>
+      <subsection name="Description" id="Description">
+        <p>
+          Checks that string literals are not used with <code>==</code> or
+          <code>!=</code>.
+          Since <code>==</code> will compare the object references,
+          not the actual value of the strings,
+          <code>String.equals()</code> should be used.
+          More information can be found
+          <a href="https://stackoverflow.com/questions/513832/how-do-i-compare-strings-in-java/">
+          in this article</a>.
+        </p>
+
+        <p>
+          Rationale: Novice Java programmers often use code like:
+        </p>
+        <source>
+if (x == "something")
+        </source>
+
+        <p>when they mean</p>
+        <source>
+if ("something".equals(x))
+        </source>
+      </subsection>
+
+      <subsection name="Examples" id="Examples">
+        <p>
+          To configure the check:
+        </p>
+        <source>
+&lt;module name="StringLiteralEquality"/&gt;
+        </source>
+        <p>
+          Examples of violations:
+        </p>
+        <source>
+String status = "pending";
+
+if (status == "done") {} // violation
+
+while (status != "done") {} // violation
+
+boolean flag = (status == "done"); // violation
+
+boolean flag = (status.equals("done")); // OK
+
+String name = "X";
+
+if (name == getName()) {}
+// OK, limitation that check cannot tell runtime type returned from method call
+        </source>
+      </subsection>
+
+      <subsection name="Example of Usage" id="Example_of_Usage">
+        <ul>
+          <li>
+            <a href="https://github.com/search?q=path%3Aconfig%20path%3A**%2Fcheckstyle-checks.xml+repo%3Acheckstyle%2Fcheckstyle+StringLiteralEquality">
+            Checkstyle Style</a>
+          </li>
+        </ul>
+      </subsection>
+
+      <subsection name="Violation Messages" id="Violation_Messages">
+        <ul>
+          <li>
+            <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources%2Fcom%2Fpuppycrawl%2Ftools%2Fcheckstyle%2Fchecks%2Fcoding%20path%3A**%2Fmessages*.properties+repo%3Acheckstyle%2Fcheckstyle+%22string.literal.equality%22">
+            string.literal.equality</a>
+          </li>
+        </ul>
+        <p>
+          All messages can be customized if the default message doesn't suit you.
+          Please <a href="../../config.html#Custom_messages">see the documentation</a>
+          to learn how to.
+        </p>
+      </subsection>
+
+      <subsection name="Package" id="Package">
+        <p>
+          com.puppycrawl.tools.checkstyle.checks.coding
+        </p>
+      </subsection>
+
+      <subsection name="Parent Module" id="Parent_Module">
+        <p>
+          <a href="../../config.html#TreeWalker">TreeWalker</a>
+        </p>
+      </subsection>
+    </section>
+  </body>
+</document>

--- a/src/xdocs/checks/coding/superclone.xml
+++ b/src/xdocs/checks/coding/superclone.xml
@@ -26,7 +26,7 @@
           To configure the check:
         </p>
         <source>
-&lt;module name="SuperClone"/&gt;
+&lt;module name=&quot;SuperClone&quot;/&gt;
         </source>
         <p>Example:</p>
         <source>

--- a/src/xdocs/checks/coding/superclone.xml.template
+++ b/src/xdocs/checks/coding/superclone.xml.template
@@ -1,0 +1,95 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<document xmlns="http://maven.apache.org/XDOC/2.0"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/XDOC/2.0 https://maven.apache.org/xsd/xdoc-2.0.xsd">
+  <head>
+    <title>SuperClone</title>
+  </head>
+  <body>
+    <section name="SuperClone">
+      <p>Since Checkstyle 3.2</p>
+      <subsection name="Description" id="Description">
+        <p>
+          Checks that an overriding <code>clone()</code> method invokes
+          <code>super.clone()</code>. Does not check native methods, as
+          they have no possible java defined implementation.
+        </p>
+
+        <p>
+          Reference: <a href="https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/lang/Object.html#clone%28%29">
+          Object.clone()</a>.
+        </p>
+      </subsection>
+
+      <subsection name="Examples" id="Examples">
+        <p>
+          To configure the check:
+        </p>
+        <source>
+&lt;module name="SuperClone"/&gt;
+        </source>
+        <p>Example:</p>
+        <source>
+class A {
+
+ public Object clone() { // OK
+  return super.clone();
+ }
+}
+
+class B {
+private int b;
+
+ public B clone() { // violation, does not call super.clone()
+  B other = new B();
+  other.b = this.b;
+  return other;
+ }
+}
+
+class C {
+
+ public C clone() { // OK
+  return (C) super.clone();
+ }
+}
+        </source>
+      </subsection>
+
+      <subsection name="Example of Usage" id="Example_of_Usage">
+        <ul>
+          <li>
+            <a href="https://github.com/search?q=path%3Aconfig%20path%3A**%2Fcheckstyle-checks.xml+repo%3Acheckstyle%2Fcheckstyle+SuperClone">
+            Checkstyle Style</a>
+          </li>
+        </ul>
+      </subsection>
+
+      <subsection name="Violation Messages" id="Violation_Messages">
+        <ul>
+          <li>
+            <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources%2Fcom%2Fpuppycrawl%2Ftools%2Fcheckstyle%2Fchecks%2Fcoding%20path%3A**%2Fmessages*.properties+repo%3Acheckstyle%2Fcheckstyle+%22missing.super.call%22">
+            missing.super.call</a>
+          </li>
+        </ul>
+        <p>
+          All messages can be customized if the default message doesn't suit you.
+          Please <a href="../../config.html#Custom_messages">see the documentation</a>
+          to learn how to.
+        </p>
+      </subsection>
+
+      <subsection name="Package" id="Package">
+        <p>
+          com.puppycrawl.tools.checkstyle.checks.coding
+        </p>
+      </subsection>
+
+      <subsection name="Parent Module" id="Parent_Module">
+        <p>
+          <a href="../../config.html#TreeWalker">TreeWalker</a>
+        </p>
+      </subsection>
+    </section>
+  </body>
+</document>

--- a/src/xdocs/checks/coding/superfinalize.xml
+++ b/src/xdocs/checks/coding/superfinalize.xml
@@ -29,19 +29,19 @@
           To configure the check:
         </p>
         <source>
-&lt;module name="SuperFinalize"/&gt;
+&lt;module name=&quot;SuperFinalize&quot;/&gt;
         </source>
         <p>Example:</p>
         <source>
 public class A {
       protected void finalize() throws Throwable {
-            System.out.println("In finalize block");
+            System.out.println(&quot;In finalize block&quot;);
             super.finalize(); // OK, calls super.finalize()
       }
 }
 public class B {
       protected void finalize() throws Throwable { // violation
-            System.out.println("In finalize block");
+            System.out.println(&quot;In finalize block&quot;);
       }
 }
         </source>

--- a/src/xdocs/checks/coding/superfinalize.xml.template
+++ b/src/xdocs/checks/coding/superfinalize.xml.template
@@ -1,0 +1,87 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<document xmlns="http://maven.apache.org/XDOC/2.0"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/XDOC/2.0 https://maven.apache.org/xsd/xdoc-2.0.xsd">
+  <head>
+    <title>SuperFinalize</title>
+  </head>
+  <body>
+    <section name="SuperFinalize">
+      <p>Since Checkstyle 3.2</p>
+      <subsection name="Description" id="Description">
+        <p>
+          Checks that an overriding <code>finalize()</code> method invokes
+          <code>super.finalize()</code>. Does not check native methods, as
+          they have no possible java defined implementation.
+        </p>
+
+        <p>
+          References:
+          <a href="https://www.oracle.com/technical-resources/articles/javase/finalization.html">
+          How to Handle Java Finalization's Memory-Retention Issues</a>;
+          <a href="https://javarevisited.blogspot.com/2012/03/finalize-method-in-java-tutorial.html">
+          10 points on finalize method in Java</a>.
+        </p>
+      </subsection>
+
+      <subsection name="Examples" id="Examples">
+        <p>
+          To configure the check:
+        </p>
+        <source>
+&lt;module name="SuperFinalize"/&gt;
+        </source>
+        <p>Example:</p>
+        <source>
+public class A {
+      protected void finalize() throws Throwable {
+            System.out.println("In finalize block");
+            super.finalize(); // OK, calls super.finalize()
+      }
+}
+public class B {
+      protected void finalize() throws Throwable { // violation
+            System.out.println("In finalize block");
+      }
+}
+        </source>
+
+      </subsection>
+
+      <subsection name="Example of Usage" id="Example_of_Usage">
+        <ul>
+          <li>
+            <a href="https://github.com/search?q=path%3Aconfig%20path%3A**%2Fcheckstyle-checks.xml+repo%3Acheckstyle%2Fcheckstyle+SuperFinalize">
+            Checkstyle Style</a>
+          </li>
+        </ul>
+      </subsection>
+
+      <subsection name="Violation Messages" id="Violation_Messages">
+        <ul>
+          <li>
+            <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources%2Fcom%2Fpuppycrawl%2Ftools%2Fcheckstyle%2Fchecks%2Fcoding%20path%3A**%2Fmessages*.properties+repo%3Acheckstyle%2Fcheckstyle+%22missing.super.call%22">
+            missing.super.call</a>
+          </li>
+        </ul>
+        <p>
+          All messages can be customized if the default message doesn't suit you.
+          Please <a href="../../config.html#Custom_messages">see the documentation</a>
+          to learn how to.
+        </p>
+      </subsection>
+
+      <subsection name="Package" id="Package">
+        <p>
+          com.puppycrawl.tools.checkstyle.checks.coding
+        </p>
+      </subsection>
+
+      <subsection name="Parent Module" id="Parent_Module">
+        <p>
+          <a href="../../config.html#TreeWalker">TreeWalker</a>
+        </p>
+      </subsection>
+    </section>
+  </body>
+</document>

--- a/src/xdocs/checks/coding/unnecessaryparentheses.xml
+++ b/src/xdocs/checks/coding/unnecessaryparentheses.xml
@@ -28,7 +28,7 @@ boolean b = (~a) &gt; -27            // parens around ~a
 
       <subsection name="Notes" id="Notes">
         <p>
-          The check is not "type aware", that is to say, it can't tell if parentheses
+          The check is not &quot;type aware&quot;, that is to say, it can't tell if parentheses
           are unnecessary based on the types in an expression. The check is partially aware about
           operator precedence but unaware about operator associativity.
           It won't catch cases such as:
@@ -48,7 +48,7 @@ if (p == (q &lt;= r)) {}
           of type <code>int</code> and <em>p</em> is of type <code>boolean</code>
           and removing parentheses will give a compile-time error. Even if <em>q</em>
           and <em>r</em> were <code>boolean</code> still there will be no violation
-          raised as check is not "type aware".
+          raised as check is not &quot;type aware&quot;.
         </p>
         <p>
           The partial support for operator precedence includes cases of the following type:
@@ -62,7 +62,7 @@ if (a &amp;&amp; (b || c)) { // ok
 }
 if ((a == b) &amp;&amp; c) { // violation, unnecessary paren
 }
-String e = "e";
+String e = &quot;e&quot;;
 if ((e instanceof String) &amp;&amp; a || b) { // violation, unnecessary paren
 }
 int f = 0;
@@ -276,7 +276,7 @@ if ((++f) &gt; g &amp;&amp; a) { // violation, unnecessary paren
           To configure the check:
         </p>
         <source>
-&lt;module name="UnnecessaryParentheses"/&gt;
+&lt;module name=&quot;UnnecessaryParentheses&quot;/&gt;
         </source>
         <p>
           Which results in the following violations:
@@ -292,9 +292,9 @@ for(int i=(0); i&lt;10; i++){          // violation
   sumOfSquares += (square(x * x));  // violation
 }
 double num = (10.0); //violation
-List&lt;String&gt; list = Arrays.asList("a1", "b1", "c1");
+List&lt;String&gt; list = Arrays.asList(&quot;a1&quot;, &quot;b1&quot;, &quot;c1&quot;);
 myList.stream()
-  .filter((s) -&gt; s.startsWith("c")) // violation
+  .filter((s) -&gt; s.startsWith(&quot;c&quot;)) // violation
   .forEach(System.out::println);
 int a = 10, b = 12, c = 15;
 boolean x = true, y = false, z= true;
@@ -320,8 +320,8 @@ if (x==(y == z)) { // ok
           <code> '^' </code>:
         </p>
         <source>
-&lt;module name="UnnecessaryParentheses"&gt;
-  &lt;property name="tokens" value="BOR, BAND, BXOR" /&gt;
+&lt;module name=&quot;UnnecessaryParentheses&quot;&gt;
+  &lt;property name=&quot;tokens&quot; value=&quot;BOR, BAND, BXOR&quot; /&gt;
 &lt;/module&gt;
         </source>
         <source>

--- a/src/xdocs/checks/coding/unnecessaryparentheses.xml.template
+++ b/src/xdocs/checks/coding/unnecessaryparentheses.xml.template
@@ -1,0 +1,415 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<document xmlns="http://maven.apache.org/XDOC/2.0"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/XDOC/2.0 https://maven.apache.org/xsd/xdoc-2.0.xsd">
+  <head>
+    <title>UnnecessaryParentheses</title>
+  </head>
+  <body>
+    <section name="UnnecessaryParentheses">
+      <p>Since Checkstyle 3.4</p>
+      <subsection name="Description" id="Description">
+        <p>
+          Checks if unnecessary parentheses are used in a statement or expression.
+          The check will flag the following with warnings:
+        </p>
+        <source>
+return (x);          // parens around identifier
+return (x + 1);      // parens around return value
+int x = (y / 2 + 1); // parens around assignment rhs
+for (int i = (0); i &lt; 10; i++) {  // parens around literal
+t -= (z + 1);                     // parens around assignment rhs
+boolean a = (x &gt; 7 &amp;&amp; y &gt; 5)      // parens around expression
+            || z &lt; 9;
+boolean b = (~a) &gt; -27            // parens around ~a
+            &amp;&amp; (a-- &lt; 30);        // parens around expression
+        </source>
+      </subsection>
+
+      <subsection name="Notes" id="Notes">
+        <p>
+          The check is not "type aware", that is to say, it can't tell if parentheses
+          are unnecessary based on the types in an expression. The check is partially aware about
+          operator precedence but unaware about operator associativity.
+          It won't catch cases such as:
+        </p>
+        <source>
+int x = (a + b) + c; // 1st Case
+boolean p = true; // 2nd Case
+int q = 4;
+int r = 3;
+if (p == (q &lt;= r)) {}
+        </source>
+        <p>
+          In the first case, given that <em>a</em>, <em>b</em>, and <em>c</em> are all
+          <code>int</code> variables, the parentheses around <code>a + b</code>
+          are not needed.
+          In the second case, parentheses are required as <em>q</em>, <em>r</em> are
+          of type <code>int</code> and <em>p</em> is of type <code>boolean</code>
+          and removing parentheses will give a compile-time error. Even if <em>q</em>
+          and <em>r</em> were <code>boolean</code> still there will be no violation
+          raised as check is not "type aware".
+        </p>
+        <p>
+          The partial support for operator precedence includes cases of the following type:
+        </p>
+        <source>
+boolean a = true, b = true;
+boolean c = false, d = false;
+if ((a &amp;&amp; b) || c) { // violation, unnecessary paren
+}
+if (a &amp;&amp; (b || c)) { // ok
+}
+if ((a == b) &amp;&amp; c) { // violation, unnecessary paren
+}
+String e = "e";
+if ((e instanceof String) &amp;&amp; a || b) { // violation, unnecessary paren
+}
+int f = 0;
+int g = 0;
+if (!(f &gt;= g) // ok
+        &amp;&amp; (g &gt; f)) { // violation, unnecessary paren
+}
+if ((++f) &gt; g &amp;&amp; a) { // violation, unnecessary paren
+}
+        </source>
+      </subsection>
+
+      <subsection name="Properties" id="Properties">
+        <div class="wrapper">
+          <table>
+            <tr>
+              <th>name</th>
+              <th>description</th>
+              <th>type</th>
+              <th>default value</th>
+              <th>since</th>
+            </tr>
+            <tr>
+              <td>tokens</td>
+              <td>tokens to check</td>
+              <td>
+                subset of tokens
+                <a href="../../apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#EXPR">
+                  EXPR</a>
+                , <a href="../../apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#IDENT">
+                  IDENT</a>
+                , <a href="../../apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#NUM_DOUBLE">
+                  NUM_DOUBLE</a>
+                , <a href="../../apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#NUM_FLOAT">
+                  NUM_FLOAT</a>
+                , <a href="../../apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#NUM_INT">
+                  NUM_INT</a>
+                , <a href="../../apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#NUM_LONG">
+                  NUM_LONG</a>
+                , <a href="../../apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#STRING_LITERAL">
+                  STRING_LITERAL</a>
+                , <a href="../../apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#LITERAL_NULL">
+                  LITERAL_NULL</a>
+                , <a href="../../apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#LITERAL_FALSE">
+                  LITERAL_FALSE</a>
+                , <a href="../../apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#LITERAL_TRUE">
+                  LITERAL_TRUE</a>
+                , <a href="../../apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#ASSIGN">
+                  ASSIGN</a>
+                , <a href="../../apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#BAND_ASSIGN">
+                  BAND_ASSIGN</a>
+                , <a href="../../apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#BOR_ASSIGN">
+                  BOR_ASSIGN</a>
+                , <a href="../../apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#BSR_ASSIGN">
+                  BSR_ASSIGN</a>
+                , <a href="../../apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#BXOR_ASSIGN">
+                  BXOR_ASSIGN</a>
+                , <a href="../../apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#DIV_ASSIGN">
+                  DIV_ASSIGN</a>
+                , <a href="../../apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#MINUS_ASSIGN">
+                  MINUS_ASSIGN</a>
+                , <a href="../../apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#MOD_ASSIGN">
+                  MOD_ASSIGN</a>
+                , <a href="../../apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#PLUS_ASSIGN">
+                  PLUS_ASSIGN</a>
+                , <a href="../../apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#SL_ASSIGN">
+                  SL_ASSIGN</a>
+                , <a href="../../apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#SR_ASSIGN">
+                  SR_ASSIGN</a>
+                , <a href="../../apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#STAR_ASSIGN">
+                  STAR_ASSIGN</a>
+                , <a href="../../apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#LAMBDA">
+                  LAMBDA</a>
+                ,<a href="../../apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#TEXT_BLOCK_LITERAL_BEGIN">
+                TEXT_BLOCK_LITERAL_BEGIN</a>
+                ,<a href="../../apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#LAND">
+                LAND</a>
+                ,<a href="../../apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#LOR">
+                LOR</a>
+                ,<a href="../../apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#LITERAL_INSTANCEOF">
+                LITERAL_INSTANCEOF</a>
+                ,<a href="../../apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#GT">
+                GT</a>
+                ,<a href="../../apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#LT">
+                LT</a>
+                ,<a href="../../apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#GE">
+                GE</a>
+                ,<a href="../../apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#LE">
+                LE</a>
+                ,<a href="../../apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#EQUAL">
+                EQUAL</a>
+                ,<a href="../../apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#NOT_EQUAL">
+                NOT_EQUAL</a>
+                ,<a href="../../apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#UNARY_MINUS">
+                UNARY_MINUS</a>
+                ,<a href="../../apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#UNARY_PLUS">
+                UNARY_PLUS</a>
+                ,<a href="../../apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#INC">
+                INC</a>
+                ,<a href="../../apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#DEC">
+                DEC</a>
+                ,<a href="../../apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#LNOT">
+                LNOT</a>
+                ,<a href="../../apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#BNOT">
+                BNOT</a>
+                ,<a href="../../apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#POST_INC">
+                POST_INC</a>
+                ,<a href="../../apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#POST_DEC">
+                POST_DEC</a>
+                ,<a href="../../apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#BXOR">
+                BXOR</a>
+                ,<a href="../../apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#BOR">
+                BOR</a>
+                ,<a href="../../apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#BAND">
+                BAND</a>
+                  .
+              </td>
+              <td>
+                <a href="../../apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#EXPR">
+                  EXPR</a>
+                , <a href="../../apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#IDENT">
+                  IDENT</a>
+                , <a href="../../apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#NUM_DOUBLE">
+                  NUM_DOUBLE</a>
+                , <a href="../../apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#NUM_FLOAT">
+                  NUM_FLOAT</a>
+                , <a href="../../apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#NUM_INT">
+                  NUM_INT</a>
+                , <a href="../../apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#NUM_LONG">
+                  NUM_LONG</a>
+                , <a href="../../apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#STRING_LITERAL">
+                  STRING_LITERAL</a>
+                , <a href="../../apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#LITERAL_NULL">
+                  LITERAL_NULL</a>
+                , <a href="../../apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#LITERAL_FALSE">
+                  LITERAL_FALSE</a>
+                , <a href="../../apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#LITERAL_TRUE">
+                  LITERAL_TRUE</a>
+                , <a href="../../apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#ASSIGN">
+                  ASSIGN</a>
+                , <a href="../../apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#BAND_ASSIGN">
+                  BAND_ASSIGN</a>
+                , <a href="../../apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#BOR_ASSIGN">
+                  BOR_ASSIGN</a>
+                , <a href="../../apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#BSR_ASSIGN">
+                  BSR_ASSIGN</a>
+                , <a href="../../apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#BXOR_ASSIGN">
+                  BXOR_ASSIGN</a>
+                , <a href="../../apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#DIV_ASSIGN">
+                  DIV_ASSIGN</a>
+                , <a href="../../apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#MINUS_ASSIGN">
+                  MINUS_ASSIGN</a>
+                , <a href="../../apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#MOD_ASSIGN">
+                  MOD_ASSIGN</a>
+                , <a href="../../apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#PLUS_ASSIGN">
+                  PLUS_ASSIGN</a>
+                , <a href="../../apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#SL_ASSIGN">
+                  SL_ASSIGN</a>
+                , <a href="../../apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#SR_ASSIGN">
+                  SR_ASSIGN</a>
+                , <a href="../../apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#STAR_ASSIGN">
+                  STAR_ASSIGN</a>
+                , <a href="../../apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#LAMBDA">
+                  LAMBDA</a>
+                ,<a href="../../apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#TEXT_BLOCK_LITERAL_BEGIN">
+                  TEXT_BLOCK_LITERAL_BEGIN</a>
+                ,<a href="../../apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#LAND">
+                  LAND</a>
+                ,<a href="../../apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#LOR">
+                  LOR</a>
+                ,<a href="../../apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#LITERAL_INSTANCEOF">
+                  LITERAL_INSTANCEOF</a>
+                ,<a href="../../apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#GT">
+                  GT</a>
+                ,<a href="../../apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#LT">
+                  LT</a>
+                ,<a href="../../apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#GE">
+                  GE</a>
+                ,<a href="../../apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#LE">
+                  LE</a>
+                ,<a href="../../apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#EQUAL">
+                  EQUAL</a>
+                ,<a href="../../apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#NOT_EQUAL">
+                  NOT_EQUAL</a>
+                ,<a href="../../apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#UNARY_MINUS">
+                  UNARY_MINUS</a>
+                ,<a href="../../apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#UNARY_PLUS">
+                  UNARY_PLUS</a>
+                ,<a href="../../apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#INC">
+                  INC</a>
+                ,<a href="../../apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#DEC">
+                  DEC</a>
+                ,<a href="../../apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#LNOT">
+                  LNOT</a>
+                ,<a href="../../apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#BNOT">
+                  BNOT</a>
+                ,<a href="../../apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#POST_INC">
+                  POST_INC</a>
+                ,<a href="../../apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#POST_DEC">
+                  POST_DEC</a>
+                  .
+              </td>
+              <td>3.4</td>
+            </tr>
+          </table>
+        </div>
+      </subsection>
+
+      <subsection name="Examples" id="Examples">
+        <p>
+          To configure the check:
+        </p>
+        <source>
+&lt;module name="UnnecessaryParentheses"/&gt;
+        </source>
+        <p>
+          Which results in the following violations:
+        </p>
+        <source>
+public int square(int a, int b){
+  int square = (a * b); // violation
+  return (square);      // violation
+}
+int sumOfSquares = 0;
+for(int i=(0); i&lt;10; i++){          // violation
+  int x = (i + 1);                  // violation
+  sumOfSquares += (square(x * x));  // violation
+}
+double num = (10.0); //violation
+List&lt;String&gt; list = Arrays.asList("a1", "b1", "c1");
+myList.stream()
+  .filter((s) -&gt; s.startsWith("c")) // violation
+  .forEach(System.out::println);
+int a = 10, b = 12, c = 15;
+boolean x = true, y = false, z= true;
+if ((a &gt;= 0 &amp;&amp; b &lt;= 9)            // violation, unnecessary parenthesis
+         || (c &gt;= 5 &amp;&amp; b &lt;= 5)    // violation, unnecessary parenthesis
+         || (c &gt;= 3 &amp;&amp; a &lt;= 7)) { // violation, unnecessary parenthesis
+    return;
+}
+if ((-a) != -27 // violation, unnecessary parenthesis
+         &amp;&amp; b &gt; 5) {
+    return;
+}
+if (x==(a &lt;= 15)) { // ok
+    return;
+}
+if (x==(y == z)) { // ok
+    return;
+}
+        </source>
+        <p>
+          To configure the check to detect unnecessary parentheses around bitwise inclusive OR
+          <code> '|' </code>, bitwise AND <code> '&amp;' </code>, bitwise exclusive OR
+          <code> '^' </code>:
+        </p>
+        <source>
+&lt;module name="UnnecessaryParentheses"&gt;
+  &lt;property name="tokens" value="BOR, BAND, BXOR" /&gt;
+&lt;/module&gt;
+        </source>
+        <source>
+class Test {
+
+    void method() {
+        int x = 9, y = 8;
+        if(x&gt;= 0 ^ (x&lt;=8 &amp; y&lt;=11) // violation, unnecessary parenthesis
+            ^ y&gt;=8) {
+            return;
+        }
+         if(x&gt;= 0 ^ x&lt;=8 &amp; y&lt;=11 ^ y&gt;=8) { // ok
+            return;
+        }
+        if(x&gt;= 0 || (x&lt;=8 &amp; y&lt;=11) // violation, unnecessary parenthesis
+            &amp;&amp; y&gt;=8) {
+            return;
+        }
+        if(x&gt;= 0 || x&lt;=8 &amp; y&lt;=11 &amp;&amp; y&gt;=8) { // ok
+            return;
+        }
+        if(x&gt;= 0 &amp; (x&lt;=8 ^ y&lt;=11) &amp; y&gt;=8) { // ok
+            return;
+        }
+    }
+
+}
+        </source>
+      </subsection>
+
+      <subsection name="Example of Usage" id="Example_of_Usage">
+        <ul>
+          <li>
+            <a href="https://github.com/search?q=path%3Aconfig%20path%3A**%2Fcheckstyle-checks.xml+repo%3Acheckstyle%2Fcheckstyle+UnnecessaryParentheses">
+            Checkstyle Style</a>
+          </li>
+        </ul>
+      </subsection>
+
+      <subsection name="Violation Messages" id="Violation_Messages">
+        <ul>
+          <li>
+            <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources%2Fcom%2Fpuppycrawl%2Ftools%2Fcheckstyle%2Fchecks%2Fcoding%20path%3A**%2Fmessages*.properties+repo%3Acheckstyle%2Fcheckstyle+%22unnecessary.paren.assign%22">
+            unnecessary.paren.assign</a>
+          </li>
+          <li>
+            <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources%2Fcom%2Fpuppycrawl%2Ftools%2Fcheckstyle%2Fchecks%2Fcoding%20path%3A**%2Fmessages*.properties+repo%3Acheckstyle%2Fcheckstyle+%22unnecessary.paren.expr%22">
+            unnecessary.paren.expr</a>
+          </li>
+          <li>
+            <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources%2Fcom%2Fpuppycrawl%2Ftools%2Fcheckstyle%2Fchecks%2Fcoding%20path%3A**%2Fmessages*.properties+repo%3Acheckstyle%2Fcheckstyle+%22unnecessary.paren.ident%22">
+            unnecessary.paren.ident</a>
+          </li>
+          <li>
+            <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources%2Fcom%2Fpuppycrawl%2Ftools%2Fcheckstyle%2Fchecks%2Fcoding%20path%3A**%2Fmessages*.properties+repo%3Acheckstyle%2Fcheckstyle+%22unnecessary.paren.lambda%22">
+            unnecessary.paren.lambda</a>
+          </li>
+          <li>
+            <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources%2Fcom%2Fpuppycrawl%2Ftools%2Fcheckstyle%2Fchecks%2Fcoding%20path%3A**%2Fmessages*.properties+repo%3Acheckstyle%2Fcheckstyle+%22unnecessary.paren.literal%22">
+            unnecessary.paren.literal</a>
+          </li>
+          <li>
+            <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources%2Fcom%2Fpuppycrawl%2Ftools%2Fcheckstyle%2Fchecks%2Fcoding%20path%3A**%2Fmessages*.properties+repo%3Acheckstyle%2Fcheckstyle+%22unnecessary.paren.return%22">
+            unnecessary.paren.return</a>
+          </li>
+          <li>
+            <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources%2Fcom%2Fpuppycrawl%2Ftools%2Fcheckstyle%2Fchecks%2Fcoding%20path%3A**%2Fmessages*.properties+repo%3Acheckstyle%2Fcheckstyle+%22unnecessary.paren.string%22">
+            unnecessary.paren.string</a>
+          </li>
+        </ul>
+        <p>
+          All messages can be customized if the default message doesn't suit you.
+          Please <a href="../../config.html#Custom_messages">see the documentation</a>
+          to learn how to.
+        </p>
+      </subsection>
+
+      <subsection name="Package" id="Package">
+        <p>
+          com.puppycrawl.tools.checkstyle.checks.coding
+        </p>
+      </subsection>
+
+      <subsection name="Parent Module" id="Parent_Module">
+        <p>
+          <a href="../../config.html#TreeWalker">TreeWalker</a>
+        </p>
+      </subsection>
+    </section>
+  </body>
+</document>

--- a/src/xdocs/checks/coding/unnecessarysemicolonafteroutertypedeclaration.xml
+++ b/src/xdocs/checks/coding/unnecessarysemicolonafteroutertypedeclaration.xml
@@ -71,7 +71,7 @@
           To configure the check:
         </p>
         <source>
-&lt;module name="UnnecessarySemicolonAfterOuterTypeDeclaration"/&gt;
+&lt;module name=&quot;UnnecessarySemicolonAfterOuterTypeDeclaration&quot;/&gt;
         </source>
         <p>
           Example:
@@ -102,8 +102,8 @@ enum C {
            definitions:
         </p>
         <source>
-&lt;module name="UnnecessarySemicolonAfterOuterTypeDeclaration"&gt;
-  &lt;property name="tokens" value="CLASS_DEF"/&gt;
+&lt;module name=&quot;UnnecessarySemicolonAfterOuterTypeDeclaration&quot;&gt;
+  &lt;property name=&quot;tokens&quot; value=&quot;CLASS_DEF&quot;/&gt;
 &lt;/module&gt;
         </source>
         <p>

--- a/src/xdocs/checks/coding/unnecessarysemicolonafteroutertypedeclaration.xml.template
+++ b/src/xdocs/checks/coding/unnecessarysemicolonafteroutertypedeclaration.xml.template
@@ -1,0 +1,170 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<document xmlns="http://maven.apache.org/XDOC/2.0"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/XDOC/2.0 https://maven.apache.org/xsd/xdoc-2.0.xsd">
+  <head>
+    <title>UnnecessarySemicolonAfterOuterTypeDeclaration</title>
+  </head>
+  <body>
+    <section name="UnnecessarySemicolonAfterOuterTypeDeclaration">
+      <p>Since Checkstyle 8.31</p>
+      <subsection name="Description" id="Description">
+        <p>
+          Checks if unnecessary semicolon is used after type declaration.
+        </p>
+      </subsection>
+      <subsection name="Notes" id="Notes">
+        <p>
+          This check is not applicable to nested type declarations,
+          <a href="https://checkstyle.org/checks/coding/unnecessarysemicolonaftertypememberdeclaration.html">
+          UnnecessarySemicolonAfterTypeMemberDeclaration</a> is responsible for it.
+        </p>
+      </subsection>
+      <subsection name="Properties" id="Properties">
+        <div class="wrapper">
+          <table>
+            <tr>
+              <th>name</th>
+              <th>description</th>
+              <th>type</th>
+              <th>default value</th>
+              <th>since</th>
+            </tr>
+            <tr>
+              <td>tokens</td>
+              <td>tokens to check</td>
+              <td>
+                subset of tokens
+                <a href="https://checkstyle.org/apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#CLASS_DEF">
+                 CLASS_DEF</a>
+                , <a href="https://checkstyle.org/apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#INTERFACE_DEF">
+                INTERFACE_DEF</a>
+                , <a href="https://checkstyle.org/apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#ENUM_DEF">
+                ENUM_DEF</a>
+                , <a href="https://checkstyle.org/apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#ANNOTATION_DEF">
+                ANNOTATION_DEF</a>
+                , <a href="https://checkstyle.org/apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#RECORD_DEF">
+                RECORD_DEF</a>
+                  .
+              </td>
+              <td>
+                <a href="https://checkstyle.org/apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#CLASS_DEF">
+                    CLASS_DEF</a>
+                , <a href="https://checkstyle.org/apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#INTERFACE_DEF">
+                    INTERFACE_DEF</a>
+                , <a href="https://checkstyle.org/apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#ENUM_DEF">
+                    ENUM_DEF</a>
+                , <a href="https://checkstyle.org/apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#ANNOTATION_DEF">
+                    ANNOTATION_DEF</a>
+                , <a href="https://checkstyle.org/apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#RECORD_DEF">
+                    RECORD_DEF</a>
+                  .
+              </td>
+              <td>8.31</td>
+            </tr>
+          </table>
+        </div>
+      </subsection>
+
+      <subsection name="Examples" id="Examples">
+        <p>
+          To configure the check:
+        </p>
+        <source>
+&lt;module name="UnnecessarySemicolonAfterOuterTypeDeclaration"/&gt;
+        </source>
+        <p>
+          Example:
+        </p>
+        <source>
+class A {
+
+   class Nested {
+
+   }; // OK, nested type declarations are ignored
+
+}; // violation
+
+interface B {
+
+}; // violation
+
+enum C {
+
+}; // violation
+
+{@literal @}interface D {
+
+}; // violation
+        </source>
+        <p>
+           To configure the check to detect unnecessary semicolon only after top level class
+           definitions:
+        </p>
+        <source>
+&lt;module name="UnnecessarySemicolonAfterOuterTypeDeclaration"&gt;
+  &lt;property name="tokens" value="CLASS_DEF"/&gt;
+&lt;/module&gt;
+        </source>
+        <p>
+          Example:
+        </p>
+        <source>
+class A {
+
+}; // violation
+
+interface B {
+
+}; // OK
+
+enum C {
+
+}; // OK
+
+{@literal @}interface D {
+
+}; // OK
+        </source>
+      </subsection>
+
+      <subsection name="Example of Usage"
+        id="Example_of_Usage">
+        <ul>
+          <li>
+            <a href="https://github.com/search?q=path%3Aconfig%20path%3A**%2Fcheckstyle-checks.xml+repo%3Acheckstyle%2Fcheckstyle+UnnecessarySemicolonAfterOuterTypeDeclaration">
+              Checkstyle Style</a>
+          </li>
+        </ul>
+      </subsection>
+
+      <subsection name="Violation Messages"
+        id="Violation_Messages">
+        <ul>
+          <li>
+            <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources%2Fcom%2Fpuppycrawl%2Ftools%2Fcheckstyle%2Fchecks%2Fcoding%20path%3A**%2Fmessages*.properties+repo%3Acheckstyle%2Fcheckstyle+%22unnecessary.semicolon%22">
+                unnecessary.semicolon</a>
+          </li>
+        </ul>
+        <p>
+          All messages can be customized if the default message doesn't suit you.
+          Please <a href="../../config.html#Custom_messages">see the documentation</a>
+          to learn how to.
+        </p>
+      </subsection>
+
+      <subsection name="Package" id="Package">
+        <p>
+          com.puppycrawl.tools.checkstyle.checks.coding
+        </p>
+      </subsection>
+
+      <subsection name="Parent Module"
+        id="Parent_Module">
+        <p>
+          <a href="../../config.html#TreeWalker">TreeWalker</a>
+        </p>
+      </subsection>
+    </section>
+  </body>
+</document>

--- a/src/xdocs/checks/coding/unnecessarysemicolonaftertypememberdeclaration.xml
+++ b/src/xdocs/checks/coding/unnecessarysemicolonaftertypememberdeclaration.xml
@@ -105,7 +105,7 @@
           To configure the check:
         </p>
         <source>
-&lt;module name="UnnecessarySemicolonAfterTypeMemberDeclaration"/&gt;
+&lt;module name=&quot;UnnecessarySemicolonAfterTypeMemberDeclaration&quot;/&gt;
         </source>
         <p>
           Results in following:

--- a/src/xdocs/checks/coding/unnecessarysemicolonaftertypememberdeclaration.xml.template
+++ b/src/xdocs/checks/coding/unnecessarysemicolonaftertypememberdeclaration.xml.template
@@ -1,0 +1,177 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<document xmlns="http://maven.apache.org/XDOC/2.0"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/XDOC/2.0 https://maven.apache.org/xsd/xdoc-2.0.xsd">
+  <head>
+    <title>UnnecessarySemicolonAfterTypeMemberDeclaration</title>
+  </head>
+  <body>
+    <section name="UnnecessarySemicolonAfterTypeMemberDeclaration">
+      <p>Since Checkstyle 8.24</p>
+      <subsection name="Description"
+        id="Description">
+        <p>
+          Checks if unnecessary semicolon is used after type member declaration.
+        </p>
+      </subsection>
+      <subsection name="Notes" id="Notes">
+        <p>
+          This check is not applicable to empty statements (unnecessary semicolons inside
+          methods or init blocks),
+          <a href="https://checkstyle.org/checks/coding/emptystatement.html">EmptyStatement</a>
+          is responsible for it.
+        </p>
+      </subsection>
+      <subsection name="Properties" id="Properties">
+        <div class="wrapper">
+          <table>
+            <tr>
+              <th>name</th>
+              <th>description</th>
+              <th>type</th>
+              <th>default value</th>
+              <th>since</th>
+            </tr>
+            <tr>
+              <td>tokens</td>
+              <td>tokens to check</td>
+              <td>
+                subset of tokens
+                <a href="https://checkstyle.org/apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#CLASS_DEF">
+                 CLASS_DEF</a>
+                , <a href="https://checkstyle.org/apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#INTERFACE_DEF">
+                INTERFACE_DEF</a>
+                , <a href="https://checkstyle.org/apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#ENUM_DEF">
+                ENUM_DEF</a>
+                , <a href="https://checkstyle.org/apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#ANNOTATION_DEF">
+                ANNOTATION_DEF</a>
+                , <a href="https://checkstyle.org/apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#VARIABLE_DEF">
+                VARIABLE_DEF</a>
+                , <a href="https://checkstyle.org/apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#ANNOTATION_FIELD_DEF">
+                ANNOTATION_FIELD_DEF</a>
+                , <a href="https://checkstyle.org/apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#STATIC_INIT">
+                STATIC_INIT</a>
+                , <a href="https://checkstyle.org/apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#INSTANCE_INIT">
+                INSTANCE_INIT</a>
+                , <a href="https://checkstyle.org/apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#CTOR_DEF">
+                CTOR_DEF</a>
+                , <a href="https://checkstyle.org/apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#METHOD_DEF">
+                METHOD_DEF</a>
+                , <a href="https://checkstyle.org/apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#ENUM_CONSTANT_DEF">
+                ENUM_CONSTANT_DEF</a>
+                , <a href="https://checkstyle.org/apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#COMPACT_CTOR_DEF">
+                COMPACT_CTOR_DEF</a>
+                , <a href="https://checkstyle.org/apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#RECORD_DEF">
+                RECORD_DEF</a>
+                  .
+              </td>
+              <td>
+                <a href="https://checkstyle.org/apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#CLASS_DEF">
+                    CLASS_DEF</a>
+                , <a href="https://checkstyle.org/apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#INTERFACE_DEF">
+                    INTERFACE_DEF</a>
+                , <a href="https://checkstyle.org/apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#ENUM_DEF">
+                    ENUM_DEF</a>
+                , <a href="https://checkstyle.org/apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#ANNOTATION_DEF">
+                    ANNOTATION_DEF</a>
+                , <a href="https://checkstyle.org/apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#VARIABLE_DEF">
+                    VARIABLE_DEF</a>
+                , <a href="https://checkstyle.org/apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#ANNOTATION_FIELD_DEF">
+                    ANNOTATION_FIELD_DEF</a>
+                , <a href="https://checkstyle.org/apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#STATIC_INIT">
+                    STATIC_INIT</a>
+                , <a href="https://checkstyle.org/apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#INSTANCE_INIT">
+                    INSTANCE_INIT</a>
+                , <a href="https://checkstyle.org/apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#CTOR_DEF">
+                    CTOR_DEF</a>
+                , <a href="https://checkstyle.org/apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#METHOD_DEF">
+                    METHOD_DEF</a>
+                , <a href="https://checkstyle.org/apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#ENUM_CONSTANT_DEF">
+                    ENUM_CONSTANT_DEF</a>
+                , <a href="https://checkstyle.org/apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#COMPACT_CTOR_DEF">
+                    COMPACT_CTOR_DEF</a>
+                , <a href="https://checkstyle.org/apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#RECORD_DEF">
+                    RECORD_DEF</a>
+                  .
+              </td>
+              <td>8.24</td>
+            </tr>
+          </table>
+        </div>
+      </subsection>
+
+      <subsection name="Examples" id="Examples">
+        <p>
+          To configure the check:
+        </p>
+        <source>
+&lt;module name="UnnecessarySemicolonAfterTypeMemberDeclaration"/&gt;
+        </source>
+        <p>
+          Results in following:
+        </p>
+        <source>
+class A {
+    ; // violation, standalone semicolon
+    {}; // violation, extra semicolon after init block
+    static {}; // violation, extra semicolon after static init block
+    A(){}; // violation, extra semicolon after constructor definition
+    void method() {}; // violation, extra semicolon after method definition
+    int field = 10;; // violation, extra semicolon after field declaration
+
+    {
+        ; // no violation, it is empty statement inside init block
+    }
+
+    static {
+        ; // no violation, it is empty statement inside static init block
+    }
+
+    void anotherMethod() {
+        ; // no violation, it is empty statement
+        if(true); // no violation, it is empty statement
+    }
+}
+        </source>
+      </subsection>
+
+      <subsection name="Example of Usage"
+        id="Example_of_Usage">
+        <ul>
+          <li>
+            <a href="https://github.com/search?q=path%3Aconfig%20path%3A**%2Fcheckstyle-checks.xml+repo%3Acheckstyle%2Fcheckstyle+UnnecessarySemicolonAfterTypeMemberDeclaration">
+              Checkstyle Style</a>
+          </li>
+        </ul>
+      </subsection>
+
+      <subsection name="Violation Messages"
+        id="Violation_Messages">
+        <ul>
+          <li>
+            <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources%2Fcom%2Fpuppycrawl%2Ftools%2Fcheckstyle%2Fchecks%2Fcoding%20path%3A**%2Fmessages*.properties+repo%3Acheckstyle%2Fcheckstyle+%22unnecessary.semicolon%22">
+                unnecessary.semicolon</a>
+          </li>
+        </ul>
+        <p>
+          All messages can be customized if the default message doesn't suit you.
+          Please <a href="../../config.html#Custom_messages">see the documentation</a>
+          to learn how to.
+        </p>
+      </subsection>
+
+      <subsection name="Package" id="Package">
+        <p>
+          com.puppycrawl.tools.checkstyle.checks.coding
+        </p>
+      </subsection>
+
+      <subsection name="Parent Module"
+        id="Parent_Module">
+        <p>
+          <a href="../../config.html#TreeWalker">TreeWalker</a>
+        </p>
+      </subsection>
+    </section>
+  </body>
+</document>

--- a/src/xdocs/checks/coding/unnecessarysemicoloninenumeration.xml
+++ b/src/xdocs/checks/coding/unnecessarysemicoloninenumeration.xml
@@ -20,7 +20,7 @@
           To configure the check:
         </p>
         <source>
-&lt;module name="UnnecessarySemicolonInEnumeration"/&gt;
+&lt;module name=&quot;UnnecessarySemicolonInEnumeration&quot;/&gt;
         </source>
         <p>
           Example of violations
@@ -51,7 +51,7 @@ enum Five {
 enum Normal {
     A,
     B,
-    ; // required ";", no violation
+    ; // required &quot;;&quot;, no violation
     Normal(){}
 }
 enum NoSemicolon {

--- a/src/xdocs/checks/coding/unnecessarysemicoloninenumeration.xml.template
+++ b/src/xdocs/checks/coding/unnecessarysemicoloninenumeration.xml.template
@@ -1,0 +1,100 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<document xmlns="http://maven.apache.org/XDOC/2.0"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/XDOC/2.0 https://maven.apache.org/xsd/xdoc-2.0.xsd">
+  <head>
+    <title>UnnecessarySemicolonInEnumeration</title>
+  </head>
+  <body>
+    <section name="UnnecessarySemicolonInEnumeration">
+      <p>Since Checkstyle 8.22</p>
+      <subsection name="Description" id="Description">
+        <p>
+            Checks if unnecessary semicolon is in enum definitions.
+            Semicolon is not needed if enum body contains only enum constants.
+        </p>
+      </subsection>
+
+      <subsection name="Examples" id="Examples">
+        <p>
+          To configure the check:
+        </p>
+        <source>
+&lt;module name="UnnecessarySemicolonInEnumeration"/&gt;
+        </source>
+        <p>
+          Example of violations
+        </p>
+        <source>
+enum One {
+    A,B; // violation
+}
+enum Two {
+    A,B,; // violation
+}
+enum Three {
+    A,B(); // violation
+}
+enum Four {
+    A,B{}; // violation
+}
+enum Five {
+    A,
+    B
+    ; // violation
+}
+        </source>
+        <p>
+          Example of good cases
+        </p>
+        <source>
+enum Normal {
+    A,
+    B,
+    ; // required ";", no violation
+    Normal(){}
+}
+enum NoSemicolon {
+    A, B // only enum constants, no semicolon required
+}
+        </source>
+      </subsection>
+
+      <subsection name="Example of Usage" id="Example_of_Usage">
+        <ul>
+          <li>
+            <a href="https://github.com/search?q=path%3Aconfig%20path%3A**%2Fcheckstyle-checks.xml+repo%3Acheckstyle%2Fcheckstyle+UnnecessarySemicolonInEnumeration">
+            Checkstyle Style</a>
+          </li>
+        </ul>
+      </subsection>
+
+      <subsection name="Violation Messages"
+        id="Violation_Messages">
+        <ul>
+          <li>
+            <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources%2Fcom%2Fpuppycrawl%2Ftools%2Fcheckstyle%2Fchecks%2Fcoding%20path%3A**%2Fmessages*.properties+repo%3Acheckstyle%2Fcheckstyle+%22unnecessary.semicolon%22">
+            unnecessary.semicolon</a>
+          </li>
+        </ul>
+        <p>
+          All messages can be customized if the default message doesn't suit you.
+          Please <a href="../../config.html#Custom_messages">see the documentation</a>
+          to learn how to.
+        </p>
+      </subsection>
+
+      <subsection name="Package" id="Package">
+        <p>
+          com.puppycrawl.tools.checkstyle.checks.coding
+        </p>
+      </subsection>
+
+      <subsection name="Parent Module" id="Parent_Module">
+        <p>
+          <a href="../../config.html#TreeWalker">TreeWalker</a>
+        </p>
+      </subsection>
+    </section>
+  </body>
+</document>

--- a/src/xdocs/checks/coding/unnecessarysemicolonintrywithresources.xml
+++ b/src/xdocs/checks/coding/unnecessarysemicolonintrywithresources.xml
@@ -41,7 +41,7 @@
           To configure the check:
         </p>
         <source>
-&lt;module name="UnnecessarySemicolonInTryWithResources"/&gt;
+&lt;module name=&quot;UnnecessarySemicolonInTryWithResources&quot;/&gt;
         </source>
         <p>
           Example of violations
@@ -64,8 +64,8 @@ class A {
           if closing paren is not on same line
         </p>
         <source>
-&lt;module name="UnnecessarySemicolonInTryWithResources"&gt;
-  &lt;property name="allowWhenNoBraceAfterSemicolon" value="false"/&gt;
+&lt;module name=&quot;UnnecessarySemicolonInTryWithResources&quot;&gt;
+  &lt;property name=&quot;allowWhenNoBraceAfterSemicolon&quot; value=&quot;false&quot;/&gt;
 &lt;/module&gt;
         </source>
         <p>

--- a/src/xdocs/checks/coding/unnecessarysemicolonintrywithresources.xml.template
+++ b/src/xdocs/checks/coding/unnecessarysemicolonintrywithresources.xml.template
@@ -1,0 +1,124 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<document xmlns="http://maven.apache.org/XDOC/2.0"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/XDOC/2.0 https://maven.apache.org/xsd/xdoc-2.0.xsd">
+  <head>
+    <title>UnnecessarySemicolonInTryWithResources</title>
+  </head>
+  <body>
+    <section name="UnnecessarySemicolonInTryWithResources">
+      <p>Since Checkstyle 8.22</p>
+      <subsection name="Description" id="Description">
+        <p>
+          Checks if unnecessary semicolon is used in last resource declaration.
+        </p>
+      </subsection>
+
+      <subsection name="Properties" id="Properties">
+        <div class="wrapper">
+          <table>
+            <tr>
+              <th>name</th>
+              <th>description</th>
+              <th>type</th>
+              <th>default value</th>
+              <th>since</th>
+            </tr>
+
+            <tr>
+              <td>allowWhenNoBraceAfterSemicolon</td>
+              <td>Allow unnecessary semicolon if closing paren is not on the same line.</td>
+              <td><a href="../../property_types.html#boolean">boolean</a></td>
+              <td><code>true</code></td>
+              <td>8.22</td>
+            </tr>
+          </table>
+        </div>
+      </subsection>
+
+      <subsection name="Examples" id="Examples">
+        <p>
+          To configure the check:
+        </p>
+        <source>
+&lt;module name="UnnecessarySemicolonInTryWithResources"/&gt;
+        </source>
+        <p>
+          Example of violations
+        </p>
+        <source>
+class A {
+    void method() throws IOException {
+        try(Reader r1 = new PipedReader();){} // violation
+        try(Reader r4 = new PipedReader();Reader r5 = new PipedReader()
+        ;){} // violation
+        try(Reader r6 = new PipedReader();
+            Reader r7
+                   = new PipedReader();
+        ){}
+    }
+}
+        </source>
+        <p>
+          To configure the check to detect unnecessary semicolon
+          if closing paren is not on same line
+        </p>
+        <source>
+&lt;module name="UnnecessarySemicolonInTryWithResources"&gt;
+  &lt;property name="allowWhenNoBraceAfterSemicolon" value="false"/&gt;
+&lt;/module&gt;
+        </source>
+        <p>
+          Example of exclusion
+        </p>
+        <source>
+class A {
+    void method() throws IOException {
+        try(Reader r1 = new PipedReader();){} // violation
+        try(Reader r6 = new PipedReader();
+            Reader r7 = new PipedReader(); // violation
+        ){}
+    }
+}
+        </source>
+      </subsection>
+
+      <subsection name="Example of Usage"
+        id="Example_of_Usage">
+        <ul>
+          <li>
+            <a href="https://github.com/search?q=path%3Aconfig%20path%3A**%2Fcheckstyle-checks.xml+repo%3Acheckstyle%2Fcheckstyle+UnnecessarySemicolonInTryWithResources">
+            Checkstyle Style</a>
+          </li>
+        </ul>
+      </subsection>
+
+      <subsection name="Violation Messages"
+        id="Violation_Messages">
+        <ul>
+          <li>
+            <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources%2Fcom%2Fpuppycrawl%2Ftools%2Fcheckstyle%2Fchecks%2Fcoding%20path%3A**%2Fmessages*.properties+repo%3Acheckstyle%2Fcheckstyle+%22unnecessary.semicolon%22">
+            unnecessary.semicolon</a>
+          </li>
+        </ul>
+        <p>
+          All messages can be customized if the default message doesn't suit you.
+          Please <a href="../../config.html#Custom_messages">see the documentation</a>
+          to learn how to.
+        </p>
+      </subsection>
+
+      <subsection name="Package" id="Package">
+        <p>
+          com.puppycrawl.tools.checkstyle.checks.coding
+        </p>
+      </subsection>
+
+      <subsection name="Parent Module" id="Parent_Module">
+        <p>
+          <a href="../../config.html#TreeWalker">TreeWalker</a>
+        </p>
+      </subsection>
+    </section>
+  </body>
+</document>

--- a/src/xdocs/checks/coding/unusedlocalvariable.xml
+++ b/src/xdocs/checks/coding/unusedlocalvariable.xml
@@ -22,7 +22,7 @@
           To configure the check:
         </p>
         <source>
-&lt;module name="UnusedLocalVariable"/&gt;
+&lt;module name=&quot;UnusedLocalVariable&quot;/&gt;
         </source>
         <p>
           Example:
@@ -60,7 +60,7 @@ class Test {
         }
         try (BufferedReader reader1 // ok as 'reader1' is a resource and resources are closed
                                     // at the end of the statement
-            = new BufferedReader(new FileReader("abc.txt"))) {
+            = new BufferedReader(new FileReader(&quot;abc.txt&quot;))) {
         }
         try {
         } catch (Exception e) {     // ok as e is an exception parameter
@@ -79,7 +79,7 @@ class Test {
         Predicate&lt;String&gt; obj = (String str) -&gt; { // ok as 'str' is a lambda parameter
             return true;
         };
-        obj.test("test");
+        obj.test(&quot;test&quot;);
     }
 }
         </source>

--- a/src/xdocs/checks/coding/unusedlocalvariable.xml.template
+++ b/src/xdocs/checks/coding/unusedlocalvariable.xml.template
@@ -1,0 +1,125 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<document xmlns="http://maven.apache.org/XDOC/2.0"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/XDOC/2.0 https://maven.apache.org/xsd/xdoc-2.0.xsd">
+  <head>
+    <title>UnusedLocalVariable</title>
+  </head>
+  <body>
+    <section name="UnusedLocalVariable">
+      <p>Since Checkstyle 9.3</p>
+      <subsection name="Description" id="Description">
+        <p>
+          Checks that a local variable is declared and/or assigned, but not used.
+          Doesn't support <a href="https://docs.oracle.com/javase/specs/jls/se17/html/jls-14.html#jls-14.30">pattern variables yet</a>.
+          Doesn't check <a href="https://docs.oracle.com/javase/specs/jls/se17/html/jls-4.html#jls-4.12.3">array components</a> as array
+          components are classified as different kind of variables by <a href="https://docs.oracle.com/javase/specs/jls/se17/html/index.html">JLS</a>.
+        </p>
+      </subsection>
+
+      <subsection name="Examples" id="Examples">
+        <p>
+          To configure the check:
+        </p>
+        <source>
+&lt;module name="UnusedLocalVariable"/&gt;
+        </source>
+        <p>
+          Example:
+        </p>
+        <source>
+class Test {
+
+    int a;
+
+    {
+        int k = 12; // violation, assigned and updated but never used
+        k++;
+    }
+
+    Test(int a) {   // ok as 'a' is a constructor parameter not a local variable
+        this.a = 12;
+    }
+
+    void method(int b) {
+        int a = 10;             // violation
+        int[] arr = {1, 2, 3};  // violation
+        int[] anotherArr = {1}; // ok
+        anotherArr[0] = 4;
+    }
+
+    String convertValue(String newValue) {
+        String s = newValue.toLowerCase(); // violation
+        return newValue.toLowerCase();
+    }
+
+    void read() throws IOException {
+        BufferedReader reader = new BufferedReader(new InputStreamReader(System.in));
+        String s; // violation
+        while ((s = reader.readLine()) != null) {
+        }
+        try (BufferedReader reader1 // ok as 'reader1' is a resource and resources are closed
+                                    // at the end of the statement
+            = new BufferedReader(new FileReader("abc.txt"))) {
+        }
+        try {
+        } catch (Exception e) {     // ok as e is an exception parameter
+        }
+    }
+
+    void loops() {
+        int j = 12;
+        for (int i = 0; j &lt; 11; i++) { // violation, unused local variable 'i'.
+        }
+        for (int p = 0; j &lt; 11; p++)   // ok
+            p /= 2;
+    }
+
+    void lambdas() {
+        Predicate&lt;String&gt; obj = (String str) -&gt; { // ok as 'str' is a lambda parameter
+            return true;
+        };
+        obj.test("test");
+    }
+}
+        </source>
+      </subsection>
+
+      <subsection name="Example of Usage" id="Example_of_Usage">
+        <ul>
+          <li>
+            <a href="https://github.com/search?q=path%3Aconfig%20path%3A**%2Fcheckstyle-checks.xml+repo%3Acheckstyle%2Fcheckstyle+UnusedLocalVariable">
+                Checkstyle Style</a>
+          </li>
+        </ul>
+      </subsection>
+
+      <subsection name="Violation Messages" id="Violation_Messages">
+        <ul>
+          <li>
+            <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources%2Fcom%2Fpuppycrawl%2Ftools%2Fcheckstyle%2Fchecks%2Fcoding%20path%3A**%2Fmessages*.properties+repo%3Acheckstyle%2Fcheckstyle+%22unused.local.var%22">
+                unused.local.var
+            </a>
+          </li>
+        </ul>
+        <p>
+          All messages can be customized if the default message doesn't suit you.
+          Please <a href="../../config.html#Custom_messages">see the documentation</a>
+          to learn how to.
+        </p>
+      </subsection>
+
+      <subsection name="Package" id="Package">
+        <p>
+          com.puppycrawl.tools.checkstyle.checks.coding
+        </p>
+      </subsection>
+
+      <subsection name="Parent Module" id="Parent_Module">
+        <p>
+          <a href="../../config.html#TreeWalker">TreeWalker</a>
+        </p>
+      </subsection>
+    </section>
+  </body>
+</document>

--- a/src/xdocs/checks/coding/variabledeclarationusagedistance.xml
+++ b/src/xdocs/checks/coding/variabledeclarationusagedistance.xml
@@ -42,7 +42,7 @@
                 Define RegExp to ignore distance calculation for variables listed in this pattern.
               </td>
               <td><a href="../../property_types.html#Pattern">Pattern</a></td>
-              <td><code>""</code></td>
+              <td><code>&quot;&quot;</code></td>
               <td>5.8</td>
             </tr>
 
@@ -71,7 +71,7 @@
             To configure the check with default config:
         </p>
         <source>
-&lt;module name="VariableDeclarationUsageDistance"/&gt;
+&lt;module name=&quot;VariableDeclarationUsageDistance&quot;/&gt;
         </source>
         <p>Example:</p>
         <source>
@@ -80,9 +80,9 @@ public class Test {
   public void foo1() {
     int num;        // violation, distance = 4
     final double PI;   // OK, final variables not checked
-    System.out.println("Statement 1");
-    System.out.println("Statement 2");
-    System.out.println("Statement 3");
+    System.out.println(&quot;Statement 1&quot;);
+    System.out.println(&quot;Statement 2&quot;);
+    System.out.println(&quot;Statement 3&quot;);
     num = 1;
     PI = 3.14;
   }
@@ -93,7 +93,7 @@ public class Test {
     int count = 0;  // OK, used in different scope
 
     {
-      System.out.println("Inside inner scope");
+      System.out.println(&quot;Inside inner scope&quot;);
       a = 1;
       b = 2;
       count++;
@@ -119,7 +119,7 @@ cal.set(Calendar.HOUR_OF_DAY, hh);
 cal.set(Calendar.MINUTE, minutes);
         </source>
         <p>
-          The distance for the variable "minutes" is 1 even
+          The distance for the variable &quot;minutes&quot; is 1 even
           though this variable is used in the fifth method's call.
         </p>
         <p>
@@ -136,15 +136,15 @@ cal.set(Calendar.HOUR_OF_DAY, hh);
 cal.set(Calendar.MINUTE, minutes);
         </source>
         <p>
-          The distance for the variable "minutes" is 6 because there is one more expression
+          The distance for the variable &quot;minutes&quot; is 6 because there is one more expression
           (except the initialization block) between the declaration of this variable and its usage.
         </p>
         <p>
             To configure the check to set allowed distance:
         </p>
         <source>
-&lt;module name="VariableDeclarationUsageDistance"&gt;
-  &lt;property name="allowedDistance" value="4"/&gt;
+&lt;module name=&quot;VariableDeclarationUsageDistance&quot;&gt;
+  &lt;property name=&quot;allowedDistance&quot; value=&quot;4&quot;/&gt;
 &lt;/module&gt;
         </source>
         <p>Example:</p>
@@ -154,9 +154,9 @@ public class Test {
   public void foo1() {
     int num;        // OK, distance = 4
     final double PI;   // OK, final variables not checked
-    System.out.println("Statement 1");
-    System.out.println("Statement 2");
-    System.out.println("Statement 3");
+    System.out.println(&quot;Statement 1&quot;);
+    System.out.println(&quot;Statement 2&quot;);
+    System.out.println(&quot;Statement 3&quot;);
     num = 1;
     PI = 3.14;
   }
@@ -167,7 +167,7 @@ public class Test {
     int count = 0;  // OK, used in different scope
 
     {
-      System.out.println("Inside inner scope");
+      System.out.println(&quot;Inside inner scope&quot;);
       a = 1;
       b = 2;
       count++;
@@ -179,12 +179,12 @@ public class Test {
             To configure the check to ignore certain variables:
         </p>
         <source>
-&lt;module name="VariableDeclarationUsageDistance"&gt;
-  &lt;property name="ignoreVariablePattern" value="^num$"/&gt;
+&lt;module name=&quot;VariableDeclarationUsageDistance&quot;&gt;
+  &lt;property name=&quot;ignoreVariablePattern&quot; value=&quot;^num$&quot;/&gt;
 &lt;/module&gt;
         </source>
         <p>
-            This configuration ignores variables named "num".
+            This configuration ignores variables named &quot;num&quot;.
         </p>
         <p>Example:</p>
         <source>
@@ -193,9 +193,9 @@ public class Test {
   public void foo1() {
     int num;        // OK, variable ignored
     final double PI;   // OK, final variables not checked
-    System.out.println("Statement 1");
-    System.out.println("Statement 2");
-    System.out.println("Statement 3");
+    System.out.println(&quot;Statement 1&quot;);
+    System.out.println(&quot;Statement 2&quot;);
+    System.out.println(&quot;Statement 3&quot;);
     num = 1;
     PI = 3.14;
   }
@@ -206,7 +206,7 @@ public class Test {
     int count = 0;  // OK, used in different scope
 
     {
-      System.out.println("Inside inner scope");
+      System.out.println(&quot;Inside inner scope&quot;);
       a = 1;
       b = 2;
       count++;
@@ -218,8 +218,8 @@ public class Test {
             To configure the check to force validation between scopes:
         </p>
         <source>
-&lt;module name="VariableDeclarationUsageDistance"&gt;
-  &lt;property name="validateBetweenScopes" value="true"/&gt;
+&lt;module name=&quot;VariableDeclarationUsageDistance&quot;&gt;
+  &lt;property name=&quot;validateBetweenScopes&quot; value=&quot;true&quot;/&gt;
 &lt;/module&gt;
         </source>
         <p>Example:</p>
@@ -229,9 +229,9 @@ public class Test {
   public void foo1() {
     int num;        // violation, distance = 4
     final double PI;   // OK, final variables not checked
-    System.out.println("Statement 1");
-    System.out.println("Statement 2");
-    System.out.println("Statement 3");
+    System.out.println(&quot;Statement 1&quot;);
+    System.out.println(&quot;Statement 2&quot;);
+    System.out.println(&quot;Statement 3&quot;);
     num = 1;
     PI = 3.14;
   }
@@ -242,7 +242,7 @@ public class Test {
     int count = 0;  // violation, distance = 4
 
     {
-      System.out.println("Inside inner scope");
+      System.out.println(&quot;Inside inner scope&quot;);
       a = 1;
       b = 2;
       count++;
@@ -254,8 +254,8 @@ public class Test {
             To configure the check to check final variables:
         </p>
         <source>
-&lt;module name="VariableDeclarationUsageDistance"&gt;
-  &lt;property name="ignoreFinal" value="false"/&gt;
+&lt;module name=&quot;VariableDeclarationUsageDistance&quot;&gt;
+  &lt;property name=&quot;ignoreFinal&quot; value=&quot;false&quot;/&gt;
 &lt;/module&gt;
         </source>
         <p>Example:</p>
@@ -265,9 +265,9 @@ public class Test {
   public void foo1() {
     int num;        // violation, distance = 4
     final double PI;   // violation, distance = 5
-    System.out.println("Statement 1");
-    System.out.println("Statement 2");
-    System.out.println("Statement 3");
+    System.out.println(&quot;Statement 1&quot;);
+    System.out.println(&quot;Statement 2&quot;);
+    System.out.println(&quot;Statement 3&quot;);
     num = 1;
     PI = 3.14;
   }
@@ -278,7 +278,7 @@ public class Test {
     int count = 0;  // OK, used in different scope
 
     {
-      System.out.println("Inside inner scope");
+      System.out.println(&quot;Inside inner scope&quot;);
       a = 1;
       b = 2;
       count++;

--- a/src/xdocs/checks/coding/variabledeclarationusagedistance.xml.template
+++ b/src/xdocs/checks/coding/variabledeclarationusagedistance.xml.template
@@ -1,0 +1,336 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<document xmlns="http://maven.apache.org/XDOC/2.0"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/XDOC/2.0 https://maven.apache.org/xsd/xdoc-2.0.xsd">
+  <head>
+    <title>VariableDeclarationUsageDistance</title>
+  </head>
+  <body>
+    <section name="VariableDeclarationUsageDistance">
+      <p>Since Checkstyle 5.8</p>
+      <subsection name="Description" id="Description">
+        <p>
+          Checks the distance between declaration of variable and its first usage.
+          Note : Variable declaration/initialization statements are not counted
+          while calculating length.
+        </p>
+      </subsection>
+
+      <subsection name="Properties" id="Properties">
+        <div class="wrapper">
+          <table>
+            <tr>
+              <th>name</th>
+              <th>description</th>
+              <th>type</th>
+              <th>default value</th>
+              <th>since</th>
+            </tr>
+
+            <tr>
+              <td>allowedDistance</td>
+              <td>Specify distance between declaration of variable and its first usage.
+                  Values should be greater than 0.</td>
+              <td><a href="../../property_types.html#int">int</a></td>
+              <td><code>3</code></td>
+              <td>5.8</td>
+            </tr>
+
+            <tr>
+              <td>ignoreVariablePattern</td>
+              <td>
+                Define RegExp to ignore distance calculation for variables listed in this pattern.
+              </td>
+              <td><a href="../../property_types.html#Pattern">Pattern</a></td>
+              <td><code>""</code></td>
+              <td>5.8</td>
+            </tr>
+
+            <tr>
+              <td>validateBetweenScopes</td>
+              <td>Allow to calculate the distance between declaration of variable and its
+                  first usage in the different scopes.</td>
+              <td><a href="../../property_types.html#boolean">boolean</a></td>
+              <td><code>false</code></td>
+              <td>5.8</td>
+            </tr>
+
+            <tr>
+              <td>ignoreFinal</td>
+              <td>Allow to ignore variables with a 'final' modifier.</td>
+              <td><a href="../../property_types.html#boolean">boolean</a></td>
+              <td><code>true</code></td>
+              <td>5.8</td>
+            </tr>
+          </table>
+        </div>
+      </subsection>
+
+      <subsection name="Examples" id="Examples">
+        <p>
+            To configure the check with default config:
+        </p>
+        <source>
+&lt;module name="VariableDeclarationUsageDistance"/&gt;
+        </source>
+        <p>Example:</p>
+        <source>
+public class Test {
+
+  public void foo1() {
+    int num;        // violation, distance = 4
+    final double PI;   // OK, final variables not checked
+    System.out.println("Statement 1");
+    System.out.println("Statement 2");
+    System.out.println("Statement 3");
+    num = 1;
+    PI = 3.14;
+  }
+
+  public void foo2() {
+    int a;          // OK, used in different scope
+    int b;          // OK, used in different scope
+    int count = 0;  // OK, used in different scope
+
+    {
+      System.out.println("Inside inner scope");
+      a = 1;
+      b = 2;
+      count++;
+    }
+  }
+}
+        </source>
+        <p>
+          Check can detect a block of initialization methods. If a variable is used in
+          such a block and there are no other statements after variable declaration,
+          then distance = 1.
+        </p>
+        <p>
+          Case #1:
+        </p>
+        <source>
+int minutes = 5;
+Calendar cal = Calendar.getInstance();
+cal.setTimeInMillis(timeNow);
+cal.set(Calendar.SECOND, 0);
+cal.set(Calendar.MILLISECOND, 0);
+cal.set(Calendar.HOUR_OF_DAY, hh);
+cal.set(Calendar.MINUTE, minutes);
+        </source>
+        <p>
+          The distance for the variable "minutes" is 1 even
+          though this variable is used in the fifth method's call.
+        </p>
+        <p>
+          Case #2:
+        </p>
+        <source>
+int minutes = 5;
+Calendar cal = Calendar.getInstance();
+cal.setTimeInMillis(timeNow);
+cal.set(Calendar.SECOND, 0);
+cal.set(Calendar.MILLISECOND, 0);
+System.out.println(cal);
+cal.set(Calendar.HOUR_OF_DAY, hh);
+cal.set(Calendar.MINUTE, minutes);
+        </source>
+        <p>
+          The distance for the variable "minutes" is 6 because there is one more expression
+          (except the initialization block) between the declaration of this variable and its usage.
+        </p>
+        <p>
+            To configure the check to set allowed distance:
+        </p>
+        <source>
+&lt;module name="VariableDeclarationUsageDistance"&gt;
+  &lt;property name="allowedDistance" value="4"/&gt;
+&lt;/module&gt;
+        </source>
+        <p>Example:</p>
+        <source>
+public class Test {
+
+  public void foo1() {
+    int num;        // OK, distance = 4
+    final double PI;   // OK, final variables not checked
+    System.out.println("Statement 1");
+    System.out.println("Statement 2");
+    System.out.println("Statement 3");
+    num = 1;
+    PI = 3.14;
+  }
+
+  public void foo2() {
+    int a;          // OK, used in different scope
+    int b;          // OK, used in different scope
+    int count = 0;  // OK, used in different scope
+
+    {
+      System.out.println("Inside inner scope");
+      a = 1;
+      b = 2;
+      count++;
+    }
+  }
+}
+        </source>
+        <p>
+            To configure the check to ignore certain variables:
+        </p>
+        <source>
+&lt;module name="VariableDeclarationUsageDistance"&gt;
+  &lt;property name="ignoreVariablePattern" value="^num$"/&gt;
+&lt;/module&gt;
+        </source>
+        <p>
+            This configuration ignores variables named "num".
+        </p>
+        <p>Example:</p>
+        <source>
+public class Test {
+
+  public void foo1() {
+    int num;        // OK, variable ignored
+    final double PI;   // OK, final variables not checked
+    System.out.println("Statement 1");
+    System.out.println("Statement 2");
+    System.out.println("Statement 3");
+    num = 1;
+    PI = 3.14;
+  }
+
+  public void foo2() {
+    int a;          // OK, used in different scope
+    int b;          // OK, used in different scope
+    int count = 0;  // OK, used in different scope
+
+    {
+      System.out.println("Inside inner scope");
+      a = 1;
+      b = 2;
+      count++;
+    }
+  }
+}
+        </source>
+        <p>
+            To configure the check to force validation between scopes:
+        </p>
+        <source>
+&lt;module name="VariableDeclarationUsageDistance"&gt;
+  &lt;property name="validateBetweenScopes" value="true"/&gt;
+&lt;/module&gt;
+        </source>
+        <p>Example:</p>
+        <source>
+public class Test {
+
+  public void foo1() {
+    int num;        // violation, distance = 4
+    final double PI;   // OK, final variables not checked
+    System.out.println("Statement 1");
+    System.out.println("Statement 2");
+    System.out.println("Statement 3");
+    num = 1;
+    PI = 3.14;
+  }
+
+  public void foo2() {
+    int a;          // OK, distance = 2
+    int b;          // OK, distance = 3
+    int count = 0;  // violation, distance = 4
+
+    {
+      System.out.println("Inside inner scope");
+      a = 1;
+      b = 2;
+      count++;
+    }
+  }
+}
+        </source>
+        <p>
+            To configure the check to check final variables:
+        </p>
+        <source>
+&lt;module name="VariableDeclarationUsageDistance"&gt;
+  &lt;property name="ignoreFinal" value="false"/&gt;
+&lt;/module&gt;
+        </source>
+        <p>Example:</p>
+        <source>
+public class Test {
+
+  public void foo1() {
+    int num;        // violation, distance = 4
+    final double PI;   // violation, distance = 5
+    System.out.println("Statement 1");
+    System.out.println("Statement 2");
+    System.out.println("Statement 3");
+    num = 1;
+    PI = 3.14;
+  }
+
+  public void foo2() {
+    int a;          // OK, used in different scope
+    int b;          // OK, used in different scope
+    int count = 0;  // OK, used in different scope
+
+    {
+      System.out.println("Inside inner scope");
+      a = 1;
+      b = 2;
+      count++;
+    }
+  }
+}
+        </source>
+      </subsection>
+
+      <subsection name="Example of Usage" id="Example_of_Usage">
+        <ul>
+          <li>
+            <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources%20path%3A**%2Fgoogle_checks.xml+repo%3Acheckstyle%2Fcheckstyle+VariableDeclarationUsageDistance">
+            Google Style</a>
+          </li>
+          <li>
+            <a href="https://github.com/search?q=path%3Aconfig%20path%3A**%2Fcheckstyle-checks.xml+repo%3Acheckstyle%2Fcheckstyle+VariableDeclarationUsageDistance">
+            Checkstyle Style</a>
+          </li>
+        </ul>
+      </subsection>
+
+      <subsection name="Violation Messages"
+        id="Violation_Messages">
+        <ul>
+          <li>
+            <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources%2Fcom%2Fpuppycrawl%2Ftools%2Fcheckstyle%2Fchecks%2Fcoding%20path%3A**%2Fmessages*.properties+repo%3Acheckstyle%2Fcheckstyle+%22variable.declaration.usage.distance%22">
+            variable.declaration.usage.distance</a>
+          </li>
+          <li>
+            <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources%2Fcom%2Fpuppycrawl%2Ftools%2Fcheckstyle%2Fchecks%2Fcoding%20path%3A**%2Fmessages*.properties+repo%3Acheckstyle%2Fcheckstyle+%22variable.declaration.usage.distance.extend%22">
+            variable.declaration.usage.distance.extend</a>
+          </li>
+        </ul>
+        <p>
+          All messages can be customized if the default message doesn't suit you.
+          Please <a href="../../config.html#Custom_messages">see the documentation</a>
+          to learn how to.
+        </p>
+      </subsection>
+
+      <subsection name="Package" id="Package">
+        <p>
+          com.puppycrawl.tools.checkstyle.checks.coding
+        </p>
+      </subsection>
+
+      <subsection name="Parent Module" id="Parent_Module">
+        <p>
+          <a href="../../config.html#TreeWalker">TreeWalker</a>
+        </p>
+      </subsection>
+    </section>
+  </body>
+</document>


### PR DESCRIPTION
Part of #13498

---
This is the second half of the coding checks. The category is very big so I split it in 2

Copied the `coding` checks xdocs and named them as `xx.xml.template`.

Note: The generation escapes certain characters - quotes, <, >