### PR TITLE
Issue #13501: Kill mutation for CheckUtil8

### DIFF
--- a/config/pitest-suppressions/pitest-utils-suppressions.xml
+++ b/config/pitest-suppressions/pitest-utils-suppressions.xml
@@ -99,23 +99,23 @@
 
 
 
-  <mutation unstable="false">
-    <sourceFile>CheckUtil.java</sourceFile>
-    <mutatedClass>com.puppycrawl.tools.checkstyle.utils.CheckUtil</mutatedClass>
-    <mutatedMethod>isGetterMethod</mutatedMethod>
-    <mutator>org.pitest.mutationtest.engine.gregor.mutators.RemoveConditionalMutator_EQUAL_IF</mutator>
-    <description>removed conditional - replaced equality check with true</description>
-    <lineContent>if (matchesGetterFormat &amp;&amp; noParams) {</lineContent>
-  </mutation>
 
-  <mutation unstable="false">
-    <sourceFile>CheckUtil.java</sourceFile>
-    <mutatedClass>com.puppycrawl.tools.checkstyle.utils.CheckUtil</mutatedClass>
-    <mutatedMethod>isGetterMethod</mutatedMethod>
-    <mutator>org.pitest.mutationtest.engine.gregor.mutators.RemoveConditionalMutator_EQUAL_IF</mutator>
-    <description>removed conditional - replaced equality check with true</description>
-    <lineContent>if (slist != null &amp;&amp; slist.getChildCount() == GETTER_BODY_SIZE) {</lineContent>
-  </mutation>
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
 
   <mutation unstable="false">
     <sourceFile>CheckUtil.java</sourceFile>

--- a/src/main/java/com/puppycrawl/tools/checkstyle/utils/CheckUtil.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/utils/CheckUtil.java
@@ -60,9 +60,6 @@ public final class CheckUtil {
     /** Maximum nodes allowed in a body of setter. */
     private static final int SETTER_BODY_SIZE = 3;
 
-    /** Maximum nodes allowed in a body of getter. */
-    private static final int GETTER_BODY_SIZE = 2;
-
     /** Pattern matching underscore characters ('_'). */
     private static final Pattern UNDERSCORE_PATTERN = Pattern.compile("_");
 
@@ -351,7 +348,7 @@ public final class CheckUtil {
                 // RCURLY
                 final DetailAST slist = ast.findFirstToken(TokenTypes.SLIST);
 
-                if (slist != null && slist.getChildCount() == GETTER_BODY_SIZE) {
+                if (slist != null) {
                     final DetailAST expr = slist.getFirstChild();
                     getterMethod = expr.getType() == TokenTypes.LITERAL_RETURN;
                 }

--- a/src/test/java/com/puppycrawl/tools/checkstyle/utils/CheckUtilTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/utils/CheckUtilTest.java
@@ -445,6 +445,10 @@ public class CheckUtilTest extends AbstractModuleTestSupport {
         final String[] expected = {
             "20:5: " + getCheckMessage(MissingJavadocMethodCheck.class,
                     MSG_JAVADOC_MISSING),
+            "24:5: " + getCheckMessage(MissingJavadocMethodCheck.class,
+                    MSG_JAVADOC_MISSING),
+            "29:5: " + getCheckMessage(MissingJavadocMethodCheck.class,
+                    MSG_JAVADOC_MISSING),
         };
         verifyWithInlineConfigParser(
                 getPath("InputCheckUtil9.java"), expected);

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/utils/checkutil/InputCheckUtil9.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/utils/checkutil/InputCheckUtil9.java
@@ -21,4 +21,13 @@ public class InputCheckUtil9 {
         mNumber = number; // violation above 'Missing a Javadoc comment'
     }
 
+    public int Cost1() // violation 'Missing a Javadoc comment'
+    {
+        return 666;
+    }
+
+    public int getCost1(int forMe) // violation 'Missing a Javadoc comment'
+    {
+        return 666;
+    }
 }


### PR DESCRIPTION
Issue #13501: Kill mutation for CheckUtil8

-----

# Mutation 

https://github.com/checkstyle/checkstyle/blob/79e760900c400c0ebac121a67517235529012eb3/config/pitest-suppressions/pitest-utils-suppressions.xml#L102-L118

-----

# Explaination

**Usage**
MissingJavadocMethodCheck :- https://checkstyle.org/checks/javadoc/missingjavadocmethod.html#MissingJavadocMethod

https://github.com/checkstyle/checkstyle/blob/79e760900c400c0ebac121a67517235529012eb3/src/main/java/com/puppycrawl/tools/checkstyle/utils/CheckUtil.java#L354-L357
the condition `slist.getChildCount() == GETTER_BODY_SIZE` replace this with true as a suggestion of pit.

know the `getterMethod = expr.getType() == TokenTypes.LITERAL_RETURN;` this is only possible when the child count is 2.
becuase expr here is
 `final DetailAST expr = slist.getFirstChild();` 
example for method
```
    public int getCost1(int forMe) {
        return 666;
    }
``` 
The ast looks like 
```
        |--METHOD_DEF -> METHOD_DEF [2:4]
        |   |--MODIFIERS -> MODIFIERS [2:4]
        |   |   `--LITERAL_PUBLIC -> public [2:4]
        |   |--TYPE -> TYPE [2:11]
        |   |   `--LITERAL_INT -> int [2:11]
        |   |--IDENT -> getCost1 [2:15]
        |   |--LPAREN -> ( [2:23]
        |   |--PARAMETERS -> PARAMETERS [2:24]
        |   |   `--PARAMETER_DEF -> PARAMETER_DEF [2:24]
        |   |       |--MODIFIERS -> MODIFIERS [2:24]
        |   |       |--TYPE -> TYPE [2:24]
        |   |       |   `--LITERAL_INT -> int [2:24]
        |   |       `--IDENT -> forMe [2:28]
        |   |--RPAREN -> ) [2:33]
        |   `--SLIST -> { [2:35]
        |       |--LITERAL_RETURN -> return [3:8]
        |       |   |--EXPR -> EXPR [3:15]
        |       |   |   `--NUM_INT -> 666 [3:15]
        |       |   `--SEMI -> ; [3:18]
        |       `--RCURLY -> } [4:4]
```

we can't write any code after the break becuase it becomes unreachable. and their is no possibilities that if code is written before break and then the first child become `LITERAL_RETURN`

-----

# Regression :- 

report 1 :- https://checkstyle-diff-reports.s3.us-east-2.amazonaws.com/d48268d_2023061252/reports/diff/index.html

report 2 :- https://checkstyle-diff-reports.s3.us-east-2.amazonaws.com/41c3609_2023071837/reports/diff/index.html

-----

Diff Regression config: https://gist.githubusercontent.com/Kevin222004/e68ff3727846e014d16ab79850e397c9/raw/ed2a46a684de49b6e500e30c1e1a5f867c6c6695/MissingJavadocMethodCheck.xml
Diff Regression projects: https://gist.githubusercontent.com/Kevin222004/9600f179b602d4c971bdb0a050099005/raw/360a95ed7bb60d7a0956e531199d484c4d6f6617/test-projects.properties
Report label: Regression-2