### PR TITLE
Issue #13501: Kill mutation for RequireEmptyLineBeforeBlockTagGroupCheck

### DIFF
--- a/config/pitest-suppressions/pitest-javadoc-suppressions.xml
+++ b/config/pitest-suppressions/pitest-javadoc-suppressions.xml
@@ -702,14 +702,14 @@
     <lineContent>log(ast.getLineNumber(), MSG_KEY, ast.getText());</lineContent>
   </mutation>
 
-  <mutation unstable="false">
-    <sourceFile>RequireEmptyLineBeforeBlockTagGroupCheck.java</sourceFile>
-    <mutatedClass>com.puppycrawl.tools.checkstyle.checks.javadoc.RequireEmptyLineBeforeBlockTagGroupCheck</mutatedClass>
-    <mutatedMethod>hasInsufficientConsecutiveNewlines</mutatedMethod>
-    <mutator>org.pitest.mutationtest.engine.gregor.mutators.RemoveConditionalMutator_ORDER_IF</mutator>
-    <description>removed conditional - replaced comparison check with true</description>
-    <lineContent>while (count &lt;= 1</lineContent>
-  </mutation>
+
+
+
+
+
+
+
+
 
 
 

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/RequireEmptyLineBeforeBlockTagGroupCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/RequireEmptyLineBeforeBlockTagGroupCheck.java
@@ -242,11 +242,10 @@ public class RequireEmptyLineBeforeBlockTagGroupCheck extends AbstractJavadocChe
     private static boolean hasInsufficientConsecutiveNewlines(DetailNode tagNode) {
         int count = 0;
         DetailNode currentNode = JavadocUtil.getPreviousSibling(tagNode);
-        while (count <= 1
-                && currentNode != null
+        while (currentNode != null
                 && (currentNode.getType() == JavadocTokenTypes.NEWLINE
-                    || currentNode.getType() == JavadocTokenTypes.WS
-                    || currentNode.getType() == JavadocTokenTypes.LEADING_ASTERISK)) {
+                || currentNode.getType() == JavadocTokenTypes.WS
+                || currentNode.getType() == JavadocTokenTypes.LEADING_ASTERISK)) {
             if (currentNode.getType() == JavadocTokenTypes.NEWLINE) {
                 count++;
             }


### PR DESCRIPTION
Issue #13501: Kill mutation for RequireEmptyLineBeforeBlockTagGroup

-----

# Check :- 
https://checkstyle.org/checks/javadoc/requireemptylinebeforeblocktaggroup.html#RequireEmptyLineBeforeBlockTagGroup

-----

# Mutation 
https://github.com/checkstyle/checkstyle/blob/d2c985ecdb5deb34ce5e535034060826d2f9bff4/config/pitest-suppressions/pitest-javadoc-suppressions.xml#L705-L712

-----

# Explaination

The removed condition is only for break (Bad side affect)


-----

# Regression :- 


-----

Diff Regression config: https://gist.githubusercontent.com/Kevin222004/9ee46058f8167a1f6118a5fa7f3baf1f/raw/ad9ecf2e08cafdecfc1d16ada9430e4fbd8f77a6/RequireEmptyLineBeforeBlockTagGroup.xml
Diff Regression projects: https://gist.githubusercontent.com/Kevin222004/9600f179b602d4c971bdb0a050099005/raw/360a95ed7bb60d7a0956e531199d484c4d6f6617/test-projects.properties
Report label: Regression-2
