### PR TITLE
Issue #13501: Kill mutation for NonEmptyAtclauseDescriptionCheck

### DIFF
--- a/config/pitest-suppressions/pitest-javadoc-suppressions.xml
+++ b/config/pitest-suppressions/pitest-javadoc-suppressions.xml
@@ -693,14 +693,14 @@
     <lineContent>return (excludeScope == null</lineContent>
   </mutation>
 
-  <mutation unstable="false">
-    <sourceFile>NonEmptyAtclauseDescriptionCheck.java</sourceFile>
-    <mutatedClass>com.puppycrawl.tools.checkstyle.checks.javadoc.NonEmptyAtclauseDescriptionCheck</mutatedClass>
-    <mutatedMethod>visitJavadocToken</mutatedMethod>
-    <mutator>org.pitest.mutationtest.engine.gregor.mutators.NonVoidMethodCallMutator</mutator>
-    <description>removed call to com/puppycrawl/tools/checkstyle/api/DetailNode::getText</description>
-    <lineContent>log(ast.getLineNumber(), MSG_KEY, ast.getText());</lineContent>
-  </mutation>
+
+
+
+
+
+
+
+
 
   <mutation unstable="false">
     <sourceFile>RequireEmptyLineBeforeBlockTagGroupCheck.java</sourceFile>

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/NonEmptyAtclauseDescriptionCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/NonEmptyAtclauseDescriptionCheck.java
@@ -155,7 +155,7 @@ public class NonEmptyAtclauseDescriptionCheck extends AbstractJavadocCheck {
     @Override
     public void visitJavadocToken(DetailNode ast) {
         if (isEmptyTag(ast.getParent())) {
-            log(ast.getLineNumber(), MSG_KEY, ast.getText());
+            log(ast.getLineNumber(), MSG_KEY);
         }
     }
 


### PR DESCRIPTION
Issue #13501: Kill mutation for NonEmptyAtclauseDescriptionCheck

-----

# Check :- 
https://checkstyle.org/checks/javadoc/nonemptyatclausedescription.html#NonEmptyAtclauseDescription

-----

# Mutation 
https://github.com/checkstyle/checkstyle/blob/d2c985ecdb5deb34ce5e535034060826d2f9bff4/config/pitest-suppressions/pitest-javadoc-suppressions.xml#L696-L704

-----

# Explaination

Their is only one message key https://github.com/checkstyle/checkstyle/blob/d2c985ecdb5deb34ce5e535034060826d2f9bff4/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/NonEmptyAtclauseDescriptionCheck.java#L142

https://github.com/checkstyle/checkstyle/blob/d2c985ecdb5deb34ce5e535034060826d2f9bff4/src/main/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/messages.properties#L33
not require ast.getText
