### PR TITLE
Issue #13501: Kill mutation for MissingJavadocMethodCheck

### DIFF
--- a/config/pitest-suppressions/pitest-javadoc-suppressions.xml
+++ b/config/pitest-suppressions/pitest-javadoc-suppressions.xml
@@ -648,14 +648,14 @@
     <lineContent>if (ScopeUtil.isOuterMostType(ast)) {</lineContent>
   </mutation>
 
-  <mutation unstable="false">
-    <sourceFile>MissingJavadocMethodCheck.java</sourceFile>
-    <mutatedClass>com.puppycrawl.tools.checkstyle.checks.javadoc.MissingJavadocMethodCheck</mutatedClass>
-    <mutatedMethod>&lt;init&gt;</mutatedMethod>
-    <mutator>org.pitest.mutationtest.engine.gregor.mutators.experimental.MemberVariableMutator</mutator>
-    <description>Removed assignment to member variable minLineCount</description>
-    <lineContent>private int minLineCount = DEFAULT_MIN_LINE_COUNT;</lineContent>
-  </mutation>
+
+
+
+
+
+
+
+
 
   <mutation unstable="false">
     <sourceFile>MissingJavadocMethodCheck.java</sourceFile>

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/javadoc/MissingJavadocMethodCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/javadoc/MissingJavadocMethodCheckTest.java
@@ -445,4 +445,14 @@ public class MissingJavadocMethodCheckTest extends AbstractModuleTestSupport {
                 getNonCompilablePath("InputMissingJavadocMethodRecordsAndCtorsMinLineCount.java"),
             expected);
     }
+
+    @Test
+    public void testMinLineCount() throws Exception {
+        final String[] expected = {
+            "14:5: " + getCheckMessage(MSG_JAVADOC_MISSING),
+        };
+        verifyWithInlineConfigParser(
+                getNonCompilablePath("InputMissingJavadocMethod1.java"),
+                expected);
+    }
 }

--- a/src/test/resources-noncompilable/com/puppycrawl/tools/checkstyle/checks/javadoc/missingjavadocmethod/InputMissingJavadocMethod1.java
+++ b/src/test/resources-noncompilable/com/puppycrawl/tools/checkstyle/checks/javadoc/missingjavadocmethod/InputMissingJavadocMethod1.java
@@ -1,0 +1,16 @@
+/*
+MissingJavadocMethod
+scope = private
+
+
+*/
+
+//non-compiled with javac: Compilable with Java15
+package com.puppycrawl.tools.checkstyle.checks.javadoc.missingjavadocmethod;
+
+public class InputMissingJavadocMethod1 {
+
+    // violation below 'Missing a Javadoc comment'
+    void text2Lines() {String a = """
+        """;}
+}


### PR DESCRIPTION
Issue #13501: Kill mutation for MissingJavadocMethodCheck

----------

# Check :- 
https://checkstyle.org/checks/javadoc/missingjavadocmethod.html#MissingJavadocMethod

-----

# Mutation 
https://github.com/checkstyle/checkstyle/blob/d2c985ecdb5deb34ce5e535034060826d2f9bff4/config/pitest-suppressions/pitest-javadoc-suppressions.xml#L651-L658

-----

# Explaination

Test added