### PR TITLE
Issue #13501: Kill mutation for MissingJavadocMethodCheck2

### DIFF
--- a/config/pitest-suppressions/pitest-javadoc-suppressions.xml
+++ b/config/pitest-suppressions/pitest-javadoc-suppressions.xml
@@ -657,41 +657,41 @@
 
 
 
-  <mutation unstable="false">
-    <sourceFile>MissingJavadocMethodCheck.java</sourceFile>
-    <mutatedClass>com.puppycrawl.tools.checkstyle.checks.javadoc.MissingJavadocMethodCheck</mutatedClass>
-    <mutatedMethod>isContentsAllowMissingJavadoc</mutatedMethod>
-    <mutator>org.pitest.mutationtest.engine.gregor.mutators.RemoveConditionalMutator_EQUAL_ELSE</mutator>
-    <description>removed conditional - replaced equality check with false</description>
-    <lineContent>return (ast.getType() == TokenTypes.METHOD_DEF</lineContent>
-  </mutation>
 
-  <mutation unstable="false">
-    <sourceFile>MissingJavadocMethodCheck.java</sourceFile>
-    <mutatedClass>com.puppycrawl.tools.checkstyle.checks.javadoc.MissingJavadocMethodCheck</mutatedClass>
-    <mutatedMethod>isContentsAllowMissingJavadoc</mutatedMethod>
-    <mutator>org.pitest.mutationtest.engine.gregor.mutators.RemoveConditionalMutator_EQUAL_IF</mutator>
-    <description>removed conditional - replaced equality check with true</description>
-    <lineContent>|| ast.getType() == TokenTypes.COMPACT_CTOR_DEF)</lineContent>
-  </mutation>
 
-  <mutation unstable="false">
-    <sourceFile>MissingJavadocMethodCheck.java</sourceFile>
-    <mutatedClass>com.puppycrawl.tools.checkstyle.checks.javadoc.MissingJavadocMethodCheck</mutatedClass>
-    <mutatedMethod>isContentsAllowMissingJavadoc</mutatedMethod>
-    <mutator>org.pitest.mutationtest.engine.gregor.mutators.RemoveConditionalMutator_EQUAL_ELSE</mutator>
-    <description>removed conditional - replaced equality check with false</description>
-    <lineContent>|| ast.getType() == TokenTypes.CTOR_DEF</lineContent>
-  </mutation>
 
-  <mutation unstable="false">
-    <sourceFile>MissingJavadocMethodCheck.java</sourceFile>
-    <mutatedClass>com.puppycrawl.tools.checkstyle.checks.javadoc.MissingJavadocMethodCheck</mutatedClass>
-    <mutatedMethod>shouldCheck</mutatedMethod>
-    <mutator>org.pitest.mutationtest.engine.gregor.mutators.RemoveConditionalMutator_EQUAL_IF</mutator>
-    <description>removed conditional - replaced equality check with true</description>
-    <lineContent>return (excludeScope == null</lineContent>
-  </mutation>
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
 
 
 

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/MissingJavadocMethodCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/MissingJavadocMethodCheck.java
@@ -303,9 +303,7 @@ public class MissingJavadocMethodCheck extends AbstractCheck {
      * @return True if this method or constructor doesn't need Javadoc.
      */
     private boolean isContentsAllowMissingJavadoc(DetailAST ast) {
-        return (ast.getType() == TokenTypes.METHOD_DEF
-                || ast.getType() == TokenTypes.CTOR_DEF
-                || ast.getType() == TokenTypes.COMPACT_CTOR_DEF)
+        return ast.getType() != TokenTypes.ANNOTATION_FIELD_DEF
                 && (getMethodsNumberOfLine(ast) <= minLineCount
                     || AnnotationUtil.containsAnnotation(ast, allowedAnnotations));
     }
@@ -341,11 +339,10 @@ public class MissingJavadocMethodCheck extends AbstractCheck {
     private boolean shouldCheck(final DetailAST ast, final Scope nodeScope) {
         final Scope surroundingScope = ScopeUtil.getSurroundingScope(ast);
 
-        return (excludeScope == null
-                || nodeScope != excludeScope
-                && surroundingScope != excludeScope)
-            && nodeScope.isIn(scope)
-            && surroundingScope.isIn(scope);
+        return nodeScope != excludeScope
+                && surroundingScope != excludeScope
+                && nodeScope.isIn(scope)
+                && surroundingScope.isIn(scope);
     }
 
 }

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/javadoc/MissingJavadocMethodCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/javadoc/MissingJavadocMethodCheckTest.java
@@ -455,4 +455,16 @@ public class MissingJavadocMethodCheckTest extends AbstractModuleTestSupport {
                 getNonCompilablePath("InputMissingJavadocMethod1.java"),
                 expected);
     }
+
+    @Test
+    public void testAnnotationField() throws Exception {
+        final String[] expected = {
+            "25:5: " + getCheckMessage(MSG_JAVADOC_MISSING),
+            "27:5: " + getCheckMessage(MSG_JAVADOC_MISSING),
+        };
+
+        verifyWithInlineConfigParser(
+                getPath("InputMissingJavadocMethodAnnotationField.java"),
+                expected);
+    }
 }

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/missingjavadocmethod/InputMissingJavadocMethodAnnotationField.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/missingjavadocmethod/InputMissingJavadocMethodAnnotationField.java
@@ -1,0 +1,29 @@
+/*
+MissingJavadocMethod
+minLineCount = 1
+allowedAnnotations = (default)Override
+scope = (default)public
+excludeScope = (default)null
+allowMissingPropertyJavadoc = (default)false
+ignoreMethodNamesRegex = (default)null
+tokens = (default)METHOD_DEF, CTOR_DEF, ANNOTATION_FIELD_DEF, COMPACT_CTOR_DEF
+
+
+*/
+
+package com.puppycrawl.tools.checkstyle.checks.javadoc.missingjavadocmethod;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.TYPE)
+public @interface InputMissingJavadocMethodAnnotationField {
+
+    int method(); // violation 'Missing a Javadoc comment'
+
+    String value() default "AMD"; // violation 'Missing a Javadoc comment'
+}
+


### PR DESCRIPTION
Issue #13501: Kill mutation for MissingJavadocMethodCheck2

----------

# Check :- 
https://checkstyle.org/checks/javadoc/missingjavadocmethod.html#MissingJavadocMethod

-----

# Mutation 
https://github.com/checkstyle/checkstyle/blob/d2c985ecdb5deb34ce5e535034060826d2f9bff4/config/pitest-suppressions/pitest-javadoc-suppressions.xml#L660-L694

-----

# Explaination

https://github.com/checkstyle/checkstyle/blob/d832cae442e754f6d76729ff4794cb6c6302a971/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/MissingJavadocMethodCheck.java#L432-L438
In this all the `ast.getType == .. ` are use less because they are the only tokens which is accepted so any token is going to be one of them because this method is called by https://github.com/checkstyle/checkstyle/blob/d832cae442e754f6d76729ff4794cb6c6302a971/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/MissingJavadocMethodCheck.java#L418-L423
in which the ast is not modified and this method is called by visitToken 
https://github.com/checkstyle/checkstyle/blob/d832cae442e754f6d76729ff4794cb6c6302a971/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/MissingJavadocMethodCheck.java#L380-L388
where ast is not changing.

**Second** 
 https://github.com/checkstyle/checkstyle/blob/d832cae442e754f6d76729ff4794cb6c6302a971/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/MissingJavadocMethodCheck.java#L468-L476
 `exclude == null` is also useless it is accepting both null and not null if it is not null then we have condition of that in logical Operators that's  `exclude == null` is useless
 
---------

# Regression 

Report-1 :- 

Report-2 :- 

------------

Diff Regression config: https://gist.githubusercontent.com/Kevin222004/e68ff3727846e014d16ab79850e397c9/raw/ed2a46a684de49b6e500e30c1e1a5f867c6c6695/MissingJavadocMethodCheck.xml
Diff Regression projects: https://gist.githubusercontent.com/Kevin222004/9600f179b602d4c971bdb0a050099005/raw/360a95ed7bb60d7a0956e531199d484c4d6f6617/test-projects.properties
Report label: Regression-1
