### PR TITLE
Issue #13501: Kill mutation for JavadocTypeCheck3

### DIFF
--- a/config/pitest-suppressions/pitest-javadoc-suppressions.xml
+++ b/config/pitest-suppressions/pitest-javadoc-suppressions.xml
@@ -576,14 +576,14 @@
     <lineContent>return astType == TokenTypes.VARIABLE_DEF</lineContent>
   </mutation>
 
-  <mutation unstable="false">
-    <sourceFile>JavadocTypeCheck.java</sourceFile>
-    <mutatedClass>com.puppycrawl.tools.checkstyle.checks.javadoc.JavadocTypeCheck</mutatedClass>
-    <mutatedMethod>checkTypeParamTag</mutatedMethod>
-    <mutator>org.pitest.mutationtest.engine.gregor.mutators.experimental.NakedReceiverMutator</mutator>
-    <description>replaced call to java/util/stream/Stream::filter with receiver</description>
-    <lineContent>.filter(JavadocTag::isParamTag)</lineContent>
-  </mutation>
+
+
+
+
+
+
+
+
 
 
 

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocTypeCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocTypeCheckTest.java
@@ -416,7 +416,9 @@ public class JavadocTypeCheckTest extends AbstractModuleTestSupport {
 
     @Test
     public void testJavadocType() throws Exception {
-        final String[] expected = CommonUtil.EMPTY_STRING_ARRAY;
+        final String[] expected = {
+            "28:5: " + getCheckMessage(MSG_MISSING_TAG, "@param <T>"),
+        };
         verifyWithInlineConfigParser(
                 getPath("InputJavadocType3.java"), expected);
     }

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadoctype/InputJavadocType3.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadoctype/InputJavadocType3.java
@@ -20,4 +20,12 @@ public class InputJavadocType3 {
      * @param <P> some parameter
      */
     public interface InvalidParameterInJavadoc<T> {}
+
+    /**
+    *
+    * @link <T>
+    */
+    protected class InnerPublic2<T> // violation 'missing @param <T> tag.'
+    {
+    }
 }


### PR DESCRIPTION
Issue #13501: Kill mutation for JavadocTypeCheck3

----

# Check
https://checkstyle.org/checks/javadoc/javadoctype.html#JavadocType

-------

# Mutation 
https://github.com/checkstyle/checkstyle/blob/d2c985ecdb5deb34ce5e535034060826d2f9bff4/config/pitest-suppressions/pitest-javadoc-suppressions.xml#L579-L586


We filter only params at https://github.com/checkstyle/checkstyle/blob/0fa8d8b3e951ddee26785a2af50c7ff7c159f7c3/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocTypeCheck.java#L619 so it is double check, not required.
-----

# Regression :- 

Report-1 :- https://checkstyle-diff-reports.s3.us-east-2.amazonaws.com/6d4c16b_2023215123/reports/diff/index.html

Report-2 :- https://checkstyle-diff-reports.s3.us-east-2.amazonaws.com/6d4c16b_2023234000/reports/diff/index.html

-----

Diff Regression config: https://gist.githubusercontent.com/Kevin222004/e591a1cf82070108242c5569a7236a01/raw/9b17bf12fa20506af727bb7cae5c18b5b6dfe4ec/JavadocTypeCheck.xml
Diff Regression projects: https://gist.githubusercontent.com/Kevin222004/9600f179b602d4c971bdb0a050099005/raw/360a95ed7bb60d7a0956e531199d484c4d6f6617/test-projects.properties
Report label: Regression-2
