### PR TITLE
Issue #13501: Kill mutation for JavadocTypeCheck4

### DIFF
--- a/config/pitest-suppressions/pitest-javadoc-suppressions.xml
+++ b/config/pitest-suppressions/pitest-javadoc-suppressions.xml
@@ -585,14 +585,14 @@
     <lineContent>.filter(JavadocTag::isParamTag)</lineContent>
   </mutation>
 
-  <mutation unstable="false">
-    <sourceFile>JavadocTypeCheck.java</sourceFile>
-    <mutatedClass>com.puppycrawl.tools.checkstyle.checks.javadoc.JavadocTypeCheck</mutatedClass>
-    <mutatedMethod>setAllowedAnnotations</mutatedMethod>
-    <mutator>org.pitest.mutationtest.engine.gregor.mutators.experimental.MemberVariableMutator</mutator>
-    <description>Removed assignment to member variable allowedAnnotations</description>
-    <lineContent>allowedAnnotations = Set.of(userAnnotations);</lineContent>
-  </mutation>
+
+
+
+
+
+
+
+
 
   <mutation unstable="false">
     <sourceFile>JavadocTypeCheck.java</sourceFile>

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocTypeCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocTypeCheckTest.java
@@ -327,7 +327,9 @@ public class JavadocTypeCheckTest extends AbstractModuleTestSupport {
     @Test
     public void testAllowedAnnotationsNotAllowed() throws Exception {
 
-        final String[] expected = CommonUtil.EMPTY_STRING_ARRAY;
+        final String[] expected = {
+            "38:1: " + getCheckMessage(MSG_MISSING_TAG, "@param <T>"),
+        };
         verifyWithInlineConfigParser(
                 getPath("InputJavadocTypeAllowedAnnotations_3.java"),
             expected);

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadoctype/InputJavadocTypeAllowedAnnotations_3.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadoctype/InputJavadocTypeAllowedAnnotations_3.java
@@ -33,3 +33,10 @@ class InputJavadocTypeAllowedAnnotationByDefault_3 {
  * Annotation for unit tests.
  */
 @interface ThisIsOk_3 {}
+
+/** */
+@Generated // violation 'Type Javadoc comment is missing @param <T> tag'
+class Application<T> {}
+
+@interface Generated {
+}


### PR DESCRIPTION
Issue #13501: Kill mutation for JavadocTypeCheck2

----

# Check
https://checkstyle.org/checks/javadoc/javadoctype.html#JavadocType

-------

# Mutation 
https://github.com/checkstyle/checkstyle/blob/d2c985ecdb5deb34ce5e535034060826d2f9bff4/config/pitest-suppressions/pitest-javadoc-suppressions.xml#L588-L595

-----

# Explaination

Test added
