### PR TITLE
Issue #13501: Kill mutation for JavadocTagContinuationIndentationCheck

### DIFF
--- a/config/pitest-suppressions/pitest-javadoc-suppressions.xml
+++ b/config/pitest-suppressions/pitest-javadoc-suppressions.xml
@@ -504,14 +504,14 @@
     <lineContent>while (builder.charAt(index - 1) == &apos;*&apos;) {</lineContent>
   </mutation>
 
-  <mutation unstable="false">
-    <sourceFile>JavadocTagContinuationIndentationCheck.java</sourceFile>
-    <mutatedClass>com.puppycrawl.tools.checkstyle.checks.javadoc.JavadocTagContinuationIndentationCheck</mutatedClass>
-    <mutatedMethod>getAllNewlineNodes</mutatedMethod>
-    <mutator>org.pitest.mutationtest.engine.gregor.mutators.experimental.ArgumentPropagationMutator</mutator>
-    <description>replaced call to com/puppycrawl/tools/checkstyle/utils/JavadocUtil::getNextSibling with argument</description>
-    <lineContent>while (JavadocUtil.getNextSibling(node) != null) {</lineContent>
-  </mutation>
+
+
+
+
+
+
+
+
 
   <mutation unstable="false">
     <sourceFile>JavadocTagContinuationIndentationCheck.java</sourceFile>

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocTagContinuationIndentationCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocTagContinuationIndentationCheckTest.java
@@ -136,4 +136,13 @@ public class JavadocTagContinuationIndentationCheckTest
                 expected);
     }
 
+    @Test
+    public void testContinuationIndentation() throws Exception {
+        final String[] expected = {
+            "23: " + getCheckMessage(MSG_KEY, 4),
+        };
+        verifyWithInlineConfigParser(
+                getPath("InputJavadocTagContinuationIndentation1.java"),
+                expected);
+    }
 }

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadoctagcontinuationindentation/InputJavadocTagContinuationIndentation1.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadoctagcontinuationindentation/InputJavadocTagContinuationIndentation1.java
@@ -1,0 +1,31 @@
+/*
+JavadocTagContinuationIndentation
+violateExecutionOnNonTightHtml = true
+offset = (default)4
+
+
+*/
+
+package com.puppycrawl.tools.checkstyle.checks.javadoc.javadoctagcontinuationindentation;
+
+import java.io.IOException;
+
+public class InputJavadocTagContinuationIndentation1 {
+
+    int key;
+    boolean usesShift;
+
+    /**
+     * Constructs a new MenuShortcut for the specified virtual keycode.
+     * @param key the raw keycode for this MenuShortcut, as would be returned.
+     *
+     * @param useShiftModifier indicates whether this MenuShortcut is invoked
+     * with the SHIFT key down.
+     * @see java.awt.event.KeyEvent
+     **/
+    // violation 3 lines above 'Line continuation have .* expected level should be 4'
+    public InputJavadocTagContinuationIndentation1(int key, boolean useShiftModifier) {
+        this.key = key;
+        this.usesShift = useShiftModifier;
+    }
+}


### PR DESCRIPTION
Issue #13501: Kill mutation for JavadocTagContinuationIndentationCheck

----

# Check
https://checkstyle.org/checks/javadoc/javadoctagcontinuationindentation.html#JavadocTagContinuationIndentation

-------

# Mutation 
https://github.com/checkstyle/checkstyle/blob/d2c985ecdb5deb34ce5e535034060826d2f9bff4/config/pitest-suppressions/pitest-javadoc-suppressions.xml#L507-L514

-----

# Explaination

Test added