### PR TITLE
Issue #13501: Kill mutation for JavadocTagContinuationIndentationCheck2

### DIFF
--- a/config/pitest-suppressions/pitest-javadoc-suppressions.xml
+++ b/config/pitest-suppressions/pitest-javadoc-suppressions.xml
@@ -513,32 +513,32 @@
 
 
 
-  <mutation unstable="false">
-    <sourceFile>JavadocTagContinuationIndentationCheck.java</sourceFile>
-    <mutatedClass>com.puppycrawl.tools.checkstyle.checks.javadoc.JavadocTagContinuationIndentationCheck</mutatedClass>
-    <mutatedMethod>isInlineDescription</mutatedMethod>
-    <mutator>org.pitest.mutationtest.engine.gregor.mutators.experimental.NakedReceiverMutator</mutator>
-    <description>replaced call to com/puppycrawl/tools/checkstyle/api/DetailNode::getParent with receiver</description>
-    <lineContent>DetailNode inlineTag = description.getParent();</lineContent>
-  </mutation>
 
-  <mutation unstable="false">
-    <sourceFile>JavadocTagContinuationIndentationCheck.java</sourceFile>
-    <mutatedClass>com.puppycrawl.tools.checkstyle.checks.javadoc.JavadocTagContinuationIndentationCheck</mutatedClass>
-    <mutatedMethod>isInlineDescription</mutatedMethod>
-    <mutator>org.pitest.mutationtest.engine.gregor.mutators.NonVoidMethodCallMutator</mutator>
-    <description>removed call to com/puppycrawl/tools/checkstyle/api/DetailNode::getParent</description>
-    <lineContent>inlineTag = inlineTag.getParent();</lineContent>
-  </mutation>
 
-  <mutation unstable="false">
-    <sourceFile>JavadocTagContinuationIndentationCheck.java</sourceFile>
-    <mutatedClass>com.puppycrawl.tools.checkstyle.checks.javadoc.JavadocTagContinuationIndentationCheck</mutatedClass>
-    <mutatedMethod>isViolation</mutatedMethod>
-    <mutator>org.pitest.mutationtest.engine.gregor.mutators.RemoveConditionalMutator_EQUAL_IF</mutator>
-    <description>removed conditional - replaced equality check with true</description>
-    <lineContent>if (CommonUtil.isBlank(text)) {</lineContent>
-  </mutation>
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
 
   <mutation unstable="false">
     <sourceFile>JavadocTagInfo.java</sourceFile>

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocTagContinuationIndentationCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocTagContinuationIndentationCheck.java
@@ -246,13 +246,13 @@ public class JavadocTagContinuationIndentationCheck extends AbstractJavadocCheck
      */
     private static boolean isInlineDescription(DetailNode description) {
         boolean isInline = false;
-        DetailNode inlineTag = description.getParent();
-        while (inlineTag != null) {
-            if (inlineTag.getType() == JavadocTokenTypes.JAVADOC_INLINE_TAG) {
+        DetailNode currentNode = description;
+        while (currentNode != null) {
+            if (currentNode.getType() == JavadocTokenTypes.JAVADOC_INLINE_TAG) {
                 isInline = true;
                 break;
             }
-            inlineTag = inlineTag.getParent();
+            currentNode = currentNode.getParent();
         }
         return isInline;
     }

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocTagContinuationIndentationCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocTagContinuationIndentationCheckTest.java
@@ -145,4 +145,14 @@ public class JavadocTagContinuationIndentationCheckTest
                 getPath("InputJavadocTagContinuationIndentation1.java"),
                 expected);
     }
+
+    @Test
+    public void testJavadocTagContinuationIndentationCheck1() throws Exception {
+        final String[] expected = {
+            "16: " + getCheckMessage(MSG_KEY, 4),
+        };
+        verifyWithInlineConfigParser(
+                getPath("InputJavadocTagContinuationIndentationCheck1.java"),
+                expected);
+    }
 }

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadoctagcontinuationindentation/InputJavadocTagContinuationIndentationCheck1.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadoctagcontinuationindentation/InputJavadocTagContinuationIndentationCheck1.java
@@ -1,0 +1,19 @@
+/*
+JavadocTagContinuationIndentation
+violateExecutionOnNonTightHtml = (default)false
+offset = (default)4
+
+
+*/
+
+package com.puppycrawl.tools.checkstyle.checks.javadoc.javadoctagcontinuationindentation;
+
+public class InputJavadocTagContinuationIndentationCheck1 {
+
+    /****
+     * Some Javadoc.
+     *@see Something with violation
+     ****/
+    // violation above 'Line continuation .* expected level should be 4'
+    void foo1() {}
+}


### PR DESCRIPTION
Issue #13501: Kill mutation for JavadocTagContinuationIndentationCheck2

----

# Check
https://checkstyle.org/checks/javadoc/javadoctagcontinuationindentation.html#JavadocTagContinuationIndentation

-------

# Mutation 
https://github.com/checkstyle/checkstyle/blob/d2c985ecdb5deb34ce5e535034060826d2f9bff4/config/pitest-suppressions/pitest-javadoc-suppressions.xml#L516-L541

-----

# Explaination

loop run 1 time more

---------

# Regression

Report-1 :- https://checkstyle-diff-reports.s3.us-east-2.amazonaws.com/b09decb_2023223713/reports/diff/index.html

Report-2 :- https://checkstyle-diff-reports.s3.us-east-2.amazonaws.com/6e50bb5_2023174529/reports/diff/index.html

--------

Diff Regression config: https://gist.githubusercontent.com/Kevin222004/ec7b8b74e9e64a8a9f9c0014860b2016/raw/e392cb5c586eacde87601e6ef62098f95b8eba8f/JavadocTagContinuationIndentationCheck.xml
Diff Regression projects: https://gist.githubusercontent.com/Kevin222004/9600f179b602d4c971bdb0a050099005/raw/360a95ed7bb60d7a0956e531199d484c4d6f6617/test-projects.properties
Report label: Regression-2