### PR TITLE
Issue #13501: Kill mutation for JavadocStyleCheck2

### DIFF
--- a/config/pitest-suppressions/pitest-javadoc-suppressions.xml
+++ b/config/pitest-suppressions/pitest-javadoc-suppressions.xml
@@ -369,14 +369,14 @@
     <lineContent>index += 2;</lineContent>
   </mutation>
 
-  <mutation unstable="false">
-    <sourceFile>JavadocStyleCheck.java</sourceFile>
-    <mutatedClass>com.puppycrawl.tools.checkstyle.checks.javadoc.JavadocStyleCheck</mutatedClass>
-    <mutatedMethod>getCommentText</mutatedMethod>
-    <mutator>org.pitest.mutationtest.engine.gregor.mutators.experimental.NakedReceiverMutator</mutator>
-    <description>replaced call to java/lang/String::trim with receiver</description>
-    <lineContent>return builder.toString().trim();</lineContent>
-  </mutation>
+
+
+
+
+
+
+
+
 
 
 

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocStyleCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocStyleCheckTest.java
@@ -781,4 +781,14 @@ public class JavadocStyleCheckTest
                 getPath("InputJavadocStyleCheck3.java"),
                 expected);
     }
+
+    @Test
+    public void testJavadocStyleCheck4() throws Exception {
+        final String[] expected = {
+            "12: " + getCheckMessage(MSG_NO_PERIOD),
+        };
+        verifyWithInlineConfigParser(
+                getPath("InputJavadocStyleCheck5.java"),
+                expected);
+    }
 }

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadocstyle/InputJavadocStyleCheck5.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadocstyle/InputJavadocStyleCheck5.java
@@ -1,0 +1,14 @@
+/*
+JavadocStyle
+endOfSentenceFormat = \n
+
+
+*/
+
+package com.puppycrawl.tools.checkstyle.checks.javadoc.javadocstyle;
+
+public class InputJavadocStyleCheck5 {
+
+    /**             Set of all class field names.        */
+    public String field; // violation above 'First sentence should end with a period'
+}


### PR DESCRIPTION
Issue #13501: Kill mutation for JavadocStyleCheck2

----

# Check
https://checkstyle.org/checks/javadoc/javadocstyle.html#JavadocStyle

-------

# Mutation 
https://github.com/checkstyle/checkstyle/blob/d2c985ecdb5deb34ce5e535034060826d2f9bff4/config/pitest-suppressions/pitest-javadoc-suppressions.xml#L372-L379

-----

# Explaination

Trim is not required becuase we are trimming at https://github.com/checkstyle/checkstyle/blob/17ace5521807a9696bd03b96ddd5e998745737b5/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocStyleCheck.java#L509

-----

# Regression :- 

Report-1 :- https://checkstyle-diff-reports.s3.us-east-2.amazonaws.com/d3e54b4_2023204347/reports/diff/index.html

-----

Diff Regression config: https://gist.githubusercontent.com/Kevin222004/0b07ecc7d3ca0ca403454d504707156d/raw/8c76ea8db01b4bcb565d1af9301130f7c67c3c1d/JavadocStyleCheck.xml
Diff Regression projects: https://gist.githubusercontent.com/Kevin222004/9600f179b602d4c971bdb0a050099005/raw/360a95ed7bb60d7a0956e531199d484c4d6f6617/test-projects.properties
Report label: Regression-2