### PR TITLE
Issue #13501: Kill mutation for JavadocStyleCheck4

### DIFF
--- a/config/pitest-suppressions/pitest-javadoc-suppressions.xml
+++ b/config/pitest-suppressions/pitest-javadoc-suppressions.xml
@@ -378,14 +378,14 @@
     <lineContent>return builder.toString().trim();</lineContent>
   </mutation>
 
-  <mutation unstable="false">
-    <sourceFile>JavadocStyleCheck.java</sourceFile>
-    <mutatedClass>com.puppycrawl.tools.checkstyle.checks.javadoc.JavadocStyleCheck</mutatedClass>
-    <mutatedMethod>isExtraHtml</mutatedMethod>
-    <mutator>org.pitest.mutationtest.engine.gregor.mutators.RemoveConditionalMutator_EQUAL_IF</mutator>
-    <description>removed conditional - replaced equality check with true</description>
-    <lineContent>if (token.equalsIgnoreCase(tag.getId())) {</lineContent>
-  </mutation>
+
+
+
+
+
+
+
+
 
 
 

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocStyleCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocStyleCheckTest.java
@@ -764,7 +764,9 @@ public class JavadocStyleCheckTest
 
     @Test
     public void testJavadocTag3() throws Exception {
-        final String[] expected = CommonUtil.EMPTY_STRING_ARRAY;
+        final String[] expected = {
+            "18:4: " + getCheckMessage(MSG_EXTRA_HTML, "</body>"),
+        };
         verifyWithInlineConfigParser(
                 getPath("InputJavadocStyleCheck2.java"),
                 expected);

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadocstyle/InputJavadocStyleCheck2.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadocstyle/InputJavadocStyleCheck2.java
@@ -10,3 +10,15 @@ package /** package */ com.puppycrawl.tools
 public class InputJavadocStyleCheck2 {
 
 }
+
+/**
+ * <body>
+ * <p> This class is only meant for testing. </p>
+ * <p> In html, closing all tags is not necessary.
+ * </body>
+ *
+ * @see "https://www.w3.org/TR/html51/syntax.html#optional-start-and-end-tags"
+ */
+// violation 4 lines above 'Extra HTML tag found: </body>'
+class check {
+}


### PR DESCRIPTION
Issue #13501: Kill mutation for JavadocStyleCheck4

----

# Check
https://checkstyle.org/checks/javadoc/javadocstyle.html#JavadocStyle

-------

# Mutation 
https://github.com/checkstyle/checkstyle/blob/d2c985ecdb5deb34ce5e535034060826d2f9bff4/config/pitest-suppressions/pitest-javadoc-suppressions.xml#L381-L388

-----

# Explaination

Test added

-----

# Regression :- 


-----

Diff Regression config: https://gist.githubusercontent.com/Kevin222004/0b07ecc7d3ca0ca403454d504707156d/raw/8c76ea8db01b4bcb565d1af9301130f7c67c3c1d/JavadocStyleCheck.xml
Diff Regression projects: https://gist.githubusercontent.com/Kevin222004/21e3934e85f802e2fbd48af06d122364/raw/604256badd733d8568064f371d55657c04b00dfd/test-projects-2.properties
Report label: Regression-1

