### PR TITLE
Issue #13501: Kill mutation for JavadocStyleCheck5

### DIFF
--- a/config/pitest-suppressions/pitest-javadoc-suppressions.xml
+++ b/config/pitest-suppressions/pitest-javadoc-suppressions.xml
@@ -450,14 +450,14 @@
     <lineContent>builder.deleteCharAt(index);</lineContent>
   </mutation>
 
-  <mutation unstable="false">
-    <sourceFile>JavadocStyleCheck.java</sourceFile>
-    <mutatedClass>com.puppycrawl.tools.checkstyle.checks.javadoc.JavadocStyleCheck</mutatedClass>
-    <mutatedMethod>trimTail</mutatedMethod>
-    <mutator>org.pitest.mutationtest.engine.gregor.mutators.RemoveConditionalMutator_EQUAL_IF</mutator>
-    <description>removed conditional - replaced equality check with true</description>
-    <lineContent>else if (index &gt; 0 &amp;&amp; builder.charAt(index) == &apos;/&apos;</lineContent>
-  </mutation>
+
+
+
+
+
+
+
+
 
   <mutation unstable="false">
     <sourceFile>JavadocStyleCheck.java</sourceFile>

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadocstyle/InputJavadocStyleCheck2.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadocstyle/InputJavadocStyleCheck2.java
@@ -21,4 +21,11 @@ public class InputJavadocStyleCheck2 {
  */
 // violation 4 lines above 'Extra HTML tag found: </body>'
 class check {
+
+    /**
+     * Clear the cache and free all cached SSL_SESSION*.
+     */
+    synchronized void clear() {
+    }
+
 }


### PR DESCRIPTION
Issue #13501: Kill mutation for JavadocStyleCheck5

----

# Check
https://checkstyle.org/checks/javadoc/javadocstyle.html#JavadocStyle

-------

# Mutation 
https://github.com/checkstyle/checkstyle/blob/d2c985ecdb5deb34ce5e535034060826d2f9bff4/config/pitest-suppressions/pitest-javadoc-suppressions.xml#L372-L379

-----

# Explaination

Test added

-----

# Regression :- 


-----

Diff Regression config: https://gist.githubusercontent.com/Kevin222004/0b07ecc7d3ca0ca403454d504707156d/raw/8c76ea8db01b4bcb565d1af9301130f7c67c3c1d/JavadocStyleCheck.xml
Diff Regression projects: https://gist.githubusercontent.com/Kevin222004/21e3934e85f802e2fbd48af06d122364/raw/604256badd733d8568064f371d55657c04b00dfd/test-projects-2.properties
Report label: Regression-1

