### PR TITLE
Issue #13501: Kill mutation for JavadocStyleCheck6

### DIFF
--- a/config/pitest-suppressions/pitest-javadoc-suppressions.xml
+++ b/config/pitest-suppressions/pitest-javadoc-suppressions.xml
@@ -405,14 +405,14 @@
 
 
 
-  <mutation unstable="false">
-    <sourceFile>JavadocStyleCheck.java</sourceFile>
-    <mutatedClass>com.puppycrawl.tools.checkstyle.checks.javadoc.JavadocStyleCheck</mutatedClass>
-    <mutatedMethod>trimTail</mutatedMethod>
-    <mutator>org.pitest.mutationtest.engine.gregor.mutators.RemoveConditionalMutator_EQUAL_IF</mutator>
-    <description>removed conditional - replaced equality check with true</description>
-    <lineContent>&amp;&amp; builder.charAt(index - 1) == &apos;*&apos;) {</lineContent>
-  </mutation>
+
+
+
+
+
+
+
+
 
   <mutation unstable="false">
     <sourceFile>JavadocStyleCheck.java</sourceFile>

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocStyleCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocStyleCheckTest.java
@@ -771,4 +771,14 @@ public class JavadocStyleCheckTest
                 getPath("InputJavadocStyleCheck2.java"),
                 expected);
     }
+
+    @Test
+    public void testJavadocStyleCheck3() throws Exception {
+        final String[] expected = {
+            "11: " + getCheckMessage(MSG_NO_PERIOD),
+        };
+        verifyWithInlineConfigParser(
+                getPath("InputJavadocStyleCheck3.java"),
+                expected);
+    }
 }

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadocstyle/InputJavadocStyleCheck3.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadocstyle/InputJavadocStyleCheck3.java
@@ -1,0 +1,15 @@
+/*
+JavadocStyle
+
+
+*/
+
+package com.puppycrawl.tools.checkstyle.checks.javadoc.javadocstyle;
+
+public class InputJavadocStyleCheck3 {
+    // violation below 'First sentence should end with a period'
+    /**
+     * check：../
+     */
+    public static final String SPOT_SINGLE_SLASH = "../";
+}


### PR DESCRIPTION
Issue #13501: Kill mutation for JavadocStyleCheck6

----

# Check
https://checkstyle.org/checks/javadoc/javadocstyle.html#JavadocStyle

-------

# Mutation 
https://github.com/checkstyle/checkstyle/blob/d2c985ecdb5deb34ce5e535034060826d2f9bff4/config/pitest-suppressions/pitest-javadoc-suppressions.xml#L408-L415

-----

# Explaination

-----

# Regression :- 


-----

Diff Regression config: https://gist.githubusercontent.com/Kevin222004/0b07ecc7d3ca0ca403454d504707156d/raw/8c76ea8db01b4bcb565d1af9301130f7c67c3c1d/JavadocStyleCheck.xml
Diff Regression projects: https://gist.githubusercontent.com/Kevin222004/9600f179b602d4c971bdb0a050099005/raw/360a95ed7bb60d7a0956e531199d484c4d6f6617/test-projects.properties
Report label: Regression-2

