### PR TITLE
Issue #13501: Kill mutation for JavadocStyleCheck7

### DIFF
--- a/config/pitest-suppressions/pitest-javadoc-suppressions.xml
+++ b/config/pitest-suppressions/pitest-javadoc-suppressions.xml
@@ -414,23 +414,23 @@
     <lineContent>&amp;&amp; builder.charAt(index - 1) == &apos;*&apos;) {</lineContent>
   </mutation>
 
-  <mutation unstable="false">
-    <sourceFile>JavadocStyleCheck.java</sourceFile>
-    <mutatedClass>com.puppycrawl.tools.checkstyle.checks.javadoc.JavadocStyleCheck</mutatedClass>
-    <mutatedMethod>trimTail</mutatedMethod>
-    <mutator>org.pitest.mutationtest.engine.gregor.mutators.NonVoidMethodCallMutator</mutator>
-    <description>removed call to java/lang/StringBuilder::deleteCharAt</description>
-    <lineContent>builder.deleteCharAt(index - 1);</lineContent>
-  </mutation>
 
-  <mutation unstable="false">
-    <sourceFile>JavadocStyleCheck.java</sourceFile>
-    <mutatedClass>com.puppycrawl.tools.checkstyle.checks.javadoc.JavadocStyleCheck</mutatedClass>
-    <mutatedMethod>trimTail</mutatedMethod>
-    <mutator>org.pitest.mutationtest.engine.gregor.mutators.experimental.NakedReceiverMutator</mutator>
-    <description>replaced call to java/lang/StringBuilder::deleteCharAt with receiver</description>
-    <lineContent>builder.deleteCharAt(index - 1);</lineContent>
-  </mutation>
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
 
   <mutation unstable="false">
     <sourceFile>JavadocStyleCheck.java</sourceFile>

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocStyleCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocStyleCheckTest.java
@@ -765,7 +765,7 @@ public class JavadocStyleCheckTest
     @Test
     public void testJavadocTag3() throws Exception {
         final String[] expected = {
-            "18:4: " + getCheckMessage(MSG_EXTRA_HTML, "</body>"),
+            "21:4: " + getCheckMessage(MSG_EXTRA_HTML, "</body>"),
         };
         verifyWithInlineConfigParser(
                 getPath("InputJavadocStyleCheck2.java"),

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadocstyle/InputJavadocStyleCheck2.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadocstyle/InputJavadocStyleCheck2.java
@@ -9,6 +9,9 @@ package /** package */ com.puppycrawl.tools
 
 public class InputJavadocStyleCheck2 {
 
+    /** Empty constructor block. **/
+    public InputJavadocStyleCheck2() {
+    }
 }
 
 /**


### PR DESCRIPTION
Issue #13501: Kill mutation for JavadocStyleCheck7

----

# Check
https://checkstyle.org/checks/javadoc/javadocstyle.html#JavadocStyle

-------

# Mutation 
https://github.com/checkstyle/checkstyle/blob/d2c985ecdb5deb34ce5e535034060826d2f9bff4/config/pitest-suppressions/pitest-javadoc-suppressions.xml#L420-L451

-----

# Explaination

Test added

-----

# Regression :- 


-----

Diff Regression config: https://gist.githubusercontent.com/Kevin222004/0b07ecc7d3ca0ca403454d504707156d/raw/8c76ea8db01b4bcb565d1af9301130f7c67c3c1d/JavadocStyleCheck.xml
Diff Regression projects: https://gist.githubusercontent.com/Kevin222004/21e3934e85f802e2fbd48af06d122364/raw/604256badd733d8568064f371d55657c04b00dfd/test-projects-2.properties
Report label: Regression-1

