### PR TITLE
Issue #13501: Kill mutation for JavadocParagraph1

### DIFF
--- a/config/pitest-suppressions/pitest-javadoc-suppressions.xml
+++ b/config/pitest-suppressions/pitest-javadoc-suppressions.xml
@@ -315,14 +315,14 @@
     <lineContent>DetailNode newLine = JavadocUtil.getPreviousSibling(node);</lineContent>
   </mutation>
 
-  <mutation unstable="false">
-    <sourceFile>JavadocParagraphCheck.java</sourceFile>
-    <mutatedClass>com.puppycrawl.tools.checkstyle.checks.javadoc.JavadocParagraphCheck</mutatedClass>
-    <mutatedMethod>getNearestNode</mutatedMethod>
-    <mutator>org.pitest.mutationtest.engine.gregor.mutators.experimental.ArgumentPropagationMutator</mutator>
-    <description>replaced call to com/puppycrawl/tools/checkstyle/utils/JavadocUtil::getNextSibling with argument</description>
-    <lineContent>DetailNode tag = JavadocUtil.getNextSibling(node);</lineContent>
-  </mutation>
+
+
+
+
+
+
+
+
 
 
 

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocParagraphCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocParagraphCheck.java
@@ -190,12 +190,12 @@ public class JavadocParagraphCheck extends AbstractJavadocCheck {
      * @return nearest node.
      */
     private static DetailNode getNearestNode(DetailNode node) {
-        DetailNode tag = JavadocUtil.getNextSibling(node);
-        while (tag.getType() == JavadocTokenTypes.LEADING_ASTERISK
-                || tag.getType() == JavadocTokenTypes.NEWLINE) {
-            tag = JavadocUtil.getNextSibling(tag);
+        DetailNode currentNode = node;
+        while (currentNode.getType() == JavadocTokenTypes.LEADING_ASTERISK
+                || currentNode.getType() == JavadocTokenTypes.NEWLINE) {
+            currentNode = JavadocUtil.getNextSibling(currentNode);
         }
-        return tag;
+        return currentNode;
     }
 
     /**


### PR DESCRIPTION
Issue #13501: Kill mutation for JavadocParagraph

----

# Check
https://checkstyle.org/checks/javadoc/javadocparagraph.html#JavadocParagraph

-------

# Mutation 
https://github.com/checkstyle/checkstyle/blob/d2c985ecdb5deb34ce5e535034060826d2f9bff4/config/pitest-suppressions/pitest-javadoc-suppressions.xml#L372-L379

-----

# Explaination

Regression will find nothing. 
loops run 1 time more. our node always be newline. so always while will execute and value will update which is done at `        DetailNode tag = JavadocUtil.getNextSibling(node);
`

-----

# Regression :- 


-----

Diff Regression config: https://gist.githubusercontent.com/Kevin222004/131e059942a4ef61d37aef621fe27777/raw/eb52f0fe0b9810e3fe6192ece69350da2ca40115/JavadocParagraph.xml
Diff Regression projects: https://gist.githubusercontent.com/Kevin222004/9600f179b602d4c971bdb0a050099005/raw/360a95ed7bb60d7a0956e531199d484c4d6f6617/test-projects.properties
Report label: Regression-2

