### PR TITLE
Issue #13501: Kill mutation for JavadocParagraph2

### DIFF
--- a/config/pitest-suppressions/pitest-javadoc-suppressions.xml
+++ b/config/pitest-suppressions/pitest-javadoc-suppressions.xml
@@ -324,41 +324,41 @@
     <lineContent>DetailNode tag = JavadocUtil.getNextSibling(node);</lineContent>
   </mutation>
 
-  <mutation unstable="false">
-    <sourceFile>JavadocParagraphCheck.java</sourceFile>
-    <mutatedClass>com.puppycrawl.tools.checkstyle.checks.javadoc.JavadocParagraphCheck</mutatedClass>
-    <mutatedMethod>isEmptyLine</mutatedMethod>
-    <mutator>org.pitest.mutationtest.engine.gregor.mutators.RemoveConditionalMutator_EQUAL_IF</mutator>
-    <description>removed conditional - replaced equality check with true</description>
-    <lineContent>if (previousSibling.getType() == JavadocTokenTypes.TEXT</lineContent>
-  </mutation>
 
-  <mutation unstable="false">
-    <sourceFile>JavadocParagraphCheck.java</sourceFile>
-    <mutatedClass>com.puppycrawl.tools.checkstyle.checks.javadoc.JavadocParagraphCheck</mutatedClass>
-    <mutatedMethod>isFirstParagraph</mutatedMethod>
-    <mutator>org.pitest.mutationtest.engine.gregor.mutators.RemoveConditionalMutator_EQUAL_ELSE</mutator>
-    <description>removed conditional - replaced equality check with false</description>
-    <lineContent>&amp;&amp; previousNode.getType() != JavadocTokenTypes.NEWLINE</lineContent>
-  </mutation>
 
-  <mutation unstable="false">
-    <sourceFile>JavadocParagraphCheck.java</sourceFile>
-    <mutatedClass>com.puppycrawl.tools.checkstyle.checks.javadoc.JavadocParagraphCheck</mutatedClass>
-    <mutatedMethod>isFirstParagraph</mutatedMethod>
-    <mutator>org.pitest.mutationtest.engine.gregor.mutators.RemoveConditionalMutator_EQUAL_ELSE</mutator>
-    <description>removed conditional - replaced equality check with false</description>
-    <lineContent>&amp;&amp; previousNode.getType() != JavadocTokenTypes.TEXT) {</lineContent>
-  </mutation>
 
-  <mutation unstable="false">
-    <sourceFile>JavadocParagraphCheck.java</sourceFile>
-    <mutatedClass>com.puppycrawl.tools.checkstyle.checks.javadoc.JavadocParagraphCheck</mutatedClass>
-    <mutatedMethod>isFirstParagraph</mutatedMethod>
-    <mutator>org.pitest.mutationtest.engine.gregor.mutators.RemoveConditionalMutator_EQUAL_ELSE</mutator>
-    <description>removed conditional - replaced equality check with false</description>
-    <lineContent>|| previousNode.getType() != JavadocTokenTypes.LEADING_ASTERISK</lineContent>
-  </mutation>
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
 
   <mutation unstable="false">
     <sourceFile>JavadocStyleCheck.java</sourceFile>

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocParagraphCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocParagraphCheckTest.java
@@ -126,4 +126,15 @@ public class JavadocParagraphCheckTest extends AbstractModuleTestSupport {
                 getPath("InputJavadocParagraphIncorrect2.java"), expected);
     }
 
+    @Test
+    public void testJavadocParagraph() throws Exception {
+        final String[] expected = {
+            "19: " + getCheckMessage(MSG_LINE_BEFORE),
+            "30: " + getCheckMessage(MSG_MISPLACED_TAG),
+            "30: " + getCheckMessage(MSG_LINE_BEFORE),
+        };
+
+        verifyWithInlineConfigParser(
+                getPath("InputJavadocParagraphCheck1.java"), expected);
+    }
 }

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadocparagraph/InputJavadocParagraphCheck1.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadocparagraph/InputJavadocParagraphCheck1.java
@@ -1,0 +1,33 @@
+/*
+JavadocParagraph
+
+*/
+
+package com.puppycrawl.tools.checkstyle.checks.javadoc.javadocparagraph;
+
+public class InputJavadocParagraphCheck1 {
+
+}
+
+
+/**
+ * Input based test.
+ *
+ * <p>Check.
+ *
+
+ * <p>CheckStyle.
+ *
+ * @author Kevin
+ */
+// violation 4 lines above '<p> tag should be preceded with an empty line'
+class Check {
+
+   /**
+    * <p>
+    * Checks whether file contains code. Files which are considered to have no code:
+    * </p>
+    * <p>
+    */ // 2 violations above
+    void inheritDocWithThrows() {}
+}


### PR DESCRIPTION
Issue #13501: Kill mutation for JavadocParagraph2

----

# Check
https://checkstyle.org/checks/javadoc/javadocparagraph.html#JavadocParagraph

-------

# Mutation 
https://github.com/checkstyle/checkstyle/blob/d2c985ecdb5deb34ce5e535034060826d2f9bff4/config/pitest-suppressions/pitest-javadoc-suppressions.xml#L327-L361

-----

# Explaination

Test added

-----

# Regression :- 


-----

Diff Regression config: https://gist.githubusercontent.com/Kevin222004/131e059942a4ef61d37aef621fe27777/raw/eb52f0fe0b9810e3fe6192ece69350da2ca40115/JavadocParagraph.xml
Diff Regression projects: https://gist.githubusercontent.com/Kevin222004/9600f179b602d4c971bdb0a050099005/raw/360a95ed7bb60d7a0956e531199d484c4d6f6617/test-projects.properties
Report label: Regression-2

