### PR TITLE
Issue #13501: Kill mutation for JavadocParagraph4

### DIFF
--- a/config/pitest-suppressions/pitest-javadoc-suppressions.xml
+++ b/config/pitest-suppressions/pitest-javadoc-suppressions.xml
@@ -333,14 +333,14 @@
     <lineContent>if (previousSibling.getType() == JavadocTokenTypes.TEXT</lineContent>
   </mutation>
 
-  <mutation unstable="false">
-    <sourceFile>JavadocParagraphCheck.java</sourceFile>
-    <mutatedClass>com.puppycrawl.tools.checkstyle.checks.javadoc.JavadocParagraphCheck</mutatedClass>
-    <mutatedMethod>isFirstParagraph</mutatedMethod>
-    <mutator>org.pitest.mutationtest.engine.gregor.mutators.RemoveConditionalMutator_EQUAL_ELSE</mutator>
-    <description>removed conditional - replaced equality check with false</description>
-    <lineContent>&amp;&amp; previousNode.getType() != JavadocTokenTypes.NEWLINE</lineContent>
-  </mutation>
+
+
+
+
+
+
+
+
 
   <mutation unstable="false">
     <sourceFile>JavadocParagraphCheck.java</sourceFile>

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocParagraphCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocParagraphCheck.java
@@ -286,7 +286,7 @@ public class JavadocParagraphCheck extends AbstractJavadocCheck {
             if (previousNode.getType() == JavadocTokenTypes.TEXT
                     && !CommonUtil.isBlank(previousNode.getText())
                 || previousNode.getType() != JavadocTokenTypes.LEADING_ASTERISK
-                    && previousNode.getType() != JavadocTokenTypes.NEWLINE
+                    && false
                     && previousNode.getType() != JavadocTokenTypes.TEXT) {
                 result = false;
                 break;


### PR DESCRIPTION
Issue #13501: Kill mutation for JavadocParagraph4

----

# Check
https://checkstyle.org/checks/javadoc/javadocparagraph.html#JavadocParagraph

-------

# Mutation 
https://github.com/checkstyle/checkstyle/blob/d2c985ecdb5deb34ce5e535034060826d2f9bff4/config/pitest-suppressions/pitest-javadoc-suppressions.xml#L372-L379

-----

# Explaination

-----

# Regression :- 


-----

Diff Regression config: https://gist.githubusercontent.com/Kevin222004/131e059942a4ef61d37aef621fe27777/raw/eb52f0fe0b9810e3fe6192ece69350da2ca40115/JavadocParagraph.xml
Diff Regression projects: https://gist.githubusercontent.com/Kevin222004/434a299f5e5f7cd6a47551db18dd3a52/raw/fdd656db76aa93589ef74d015440deb6deca1993/update.properties
Report label: Regression-1

