### PR TITLE
Issue #13213: Remove '//ok' comments from Input files (MethodParamPad…

### DIFF
--- a/config/checkstyle-input-suppressions.xml
+++ b/config/checkstyle-input-suppressions.xml
@@ -6318,12 +6318,6 @@
   <suppress id="UnnecessaryOkComment"
             files="checks[\\/]whitespace[\\/]emptylineseparator[\\/]packageinfo[\\/]test2[\\/]package-info.java"/>
   <suppress id="UnnecessaryOkComment"
-            files="checks[\\/]whitespace[\\/]methodparampad[\\/]InputMethodParamPad4.java"/>
-  <suppress id="UnnecessaryOkComment"
-            files="checks[\\/]whitespace[\\/]methodparampad[\\/]InputMethodParamPadSetOptionTrim.java"/>
-  <suppress id="UnnecessaryOkComment"
-            files="checks[\\/]whitespace[\\/]methodparampad[\\/]InputMethodParamPadWhitespaceAround.java"/>
-  <suppress id="UnnecessaryOkComment"
             files="checks[\\/]whitespace[\\/]nolinewrap[\\/]InputNoLineWrapGood.java"/>
   <suppress id="UnnecessaryOkComment"
             files="checks[\\/]whitespace[\\/]nolinewrap[\\/]InputNoLineWrapGood.java"/>

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/whitespace/methodparampad/InputMethodParamPad4.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/whitespace/methodparampad/InputMethodParamPad4.java
@@ -11,7 +11,7 @@ tokens = (default)CTOR_DEF, LITERAL_NEW, METHOD_CALL, METHOD_DEF, SUPER_CTOR_CAL
 package com.puppycrawl.tools.checkstyle.checks.whitespace.methodparampad;
 import java.util.Vector;
 /** Test input for MethodDefPadCheck */
-public class InputMethodParamPad4 // ok
+public class InputMethodParamPad4
 {
     public InputMethodParamPad4()
     {

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/whitespace/methodparampad/InputMethodParamPadSetOptionTrim.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/whitespace/methodparampad/InputMethodParamPadSetOptionTrim.java
@@ -19,7 +19,7 @@ public class InputMethodParamPadSetOptionTrim {
         }
     }
 
-    public int method2 () { // ok
+    public int method2 () {
         return 1;
     }
 

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/whitespace/methodparampad/InputMethodParamPadWhitespaceAround.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/whitespace/methodparampad/InputMethodParamPadWhitespaceAround.java
@@ -11,16 +11,22 @@ tokens = (default)CTOR_DEF, LITERAL_NEW, METHOD_CALL, METHOD_DEF, SUPER_CTOR_CAL
 package com.puppycrawl.tools.checkstyle.checks.whitespace.methodparampad;
 
 @SuppressWarnings({"this", "that"})
-public class InputMethodParamPadWhitespaceAround // ok
+public class InputMethodParamPadWhitespaceAround
 {
     protected InputMethodParamPadWhitespaceAround ( int i )
     {
-        this (); //whitespace
+        this (); // ok, whitespace between 'this' and ()
         toString ();
     }
     protected InputMethodParamPadWhitespaceAround ()
     {
         super ();
+    }
+
+    protected InputMethodParamPadWhitespaceAround ( String s)
+    {
+        // ok, until https://github.com/checkstyle/checkstyle/issues/13675
+        this();
     }
 
     public void enhancedFor ()
@@ -33,9 +39,11 @@ public class InputMethodParamPadWhitespaceAround // ok
 }
 
 @interface CronExpression {
+    // annotation type elements are not checked
     Class<?>[] groups() default {};
 }
 
 @interface CronExpression1 {
-    Class<?>[] groups() default { }; // extra space
+    // annotation type elements are not checked
+    Class<?>[] groups() default { };
 }


### PR DESCRIPTION
Part of #13213 

Link to check documentation: https://checkstyle.org/checks/whitespace/methodparampad.html#MethodParamPad

Proof that all suppressions for this check are removed:
```bash
➜  checkstyle git:(master) grep methodparampad config/checkstyle-input-suppressions.xml 
            files="checks[\\/]whitespace[\\/]methodparampad[\\/]InputMethodParamPad4.java"/>
            files="checks[\\/]whitespace[\\/]methodparampad[\\/]InputMethodParamPadSetOptionTrim.java"/>
            files="checks[\\/]whitespace[\\/]methodparampad[\\/]InputMethodParamPadWhitespaceAround.java"/>

➜  checkstyle git:(master) git checkout issue-13213-methodparampad 
Switched to branch 'issue-13213-methodparampad'
Your branch is up to date with 'origin/issue-13213-methodparampad'.

➜  checkstyle git:(issue-13213-methodparampad) grep methodparampad config/checkstyle-input-suppressions.xml

➜  checkstyle git:(issue-13213-methodparampad) echo $?
1
```