### PR TITLE
Issue #13610: Use parent module macro in headers templates

### DIFF
--- a/src/xdocs/checks/header/header.xml.template
+++ b/src/xdocs/checks/header/header.xml.template
@@ -181,9 +181,9 @@ line 5: ////////////////////////////////////////////////////////////////////
       </subsection>
 
       <subsection name="Parent Module" id="Parent_Module">
-        <p>
-          <a href="../../config.html#Checker">Checker</a>
-        </p>
+        <macro name="parent-module">
+          <param name="moduleName" value="Header"/>
+        </macro>
       </subsection>
     </section>
   </body>

--- a/src/xdocs/checks/header/regexpheader.xml.template
+++ b/src/xdocs/checks/header/regexpheader.xml.template
@@ -253,9 +253,9 @@ line 6: ^\W*$
       </subsection>
 
       <subsection name="Parent Module" id="Parent_Module">
-        <p>
-          <a href="../../config.html#Checker">Checker</a>
-        </p>
+        <macro name="parent-module">
+          <param name="moduleName" value="RegexpHeader"/>
+        </macro>
       </subsection>
     </section>
   </body>


### PR DESCRIPTION
Part of #13610

We see no diff in generated files because formatting matches exactly