### PR TITLE
Issue #13610: Use parent module macro in javadoc templates

### DIFF
--- a/src/xdocs/checks/javadoc/atclauseorder.xml.template
+++ b/src/xdocs/checks/javadoc/atclauseorder.xml.template
@@ -147,9 +147,9 @@
       </subsection>
 
       <subsection name="Parent Module" id="Parent_Module">
-        <p>
-          <a href="../../config.html#TreeWalker">TreeWalker</a>
-        </p>
+        <macro name="parent-module">
+          <param name="moduleName" value="AtclauseOrder"/>
+        </macro>
       </subsection>
     </section>
   </body>

--- a/src/xdocs/checks/javadoc/invalidjavadocposition.xml.template
+++ b/src/xdocs/checks/javadoc/invalidjavadocposition.xml.template
@@ -79,9 +79,9 @@
       </subsection>
 
       <subsection name="Parent Module" id="Parent_Module">
-        <p>
-          <a href="../../config.html#TreeWalker">TreeWalker</a>
-        </p>
+        <macro name="parent-module">
+          <param name="moduleName" value="InvalidJavadocPosition"/>
+        </macro>
       </subsection>
     </section>
   </body>

--- a/src/xdocs/checks/javadoc/javadocblocktaglocation.xml.template
+++ b/src/xdocs/checks/javadoc/javadocblocktaglocation.xml.template
@@ -150,9 +150,9 @@
       </subsection>
 
       <subsection name="Parent Module" id="Parent_Module">
-        <p>
-          <a href="../../config.html#TreeWalker">TreeWalker</a>
-        </p>
+        <macro name="parent-module">
+          <param name="moduleName" value="JavadocBlockTagLocation"/>
+        </macro>
       </subsection>
     </section>
   </body>

--- a/src/xdocs/checks/javadoc/javadoccontentlocation.xml.template
+++ b/src/xdocs/checks/javadoc/javadoccontentlocation.xml.template
@@ -167,9 +167,9 @@ public void method();
       </subsection>
 
       <subsection name="Parent Module" id="Parent_Module">
-        <p>
-          <a href="../../config.html#TreeWalker">TreeWalker</a>
-        </p>
+        <macro name="parent-module">
+          <param name="moduleName" value="JavadocContentLocation"/>
+        </macro>
       </subsection>
     </section>
   </body>

--- a/src/xdocs/checks/javadoc/javadocmethod.xml.template
+++ b/src/xdocs/checks/javadoc/javadocmethod.xml.template
@@ -333,9 +333,9 @@ public int checkReturnTag(final int aTagIndex,
       </subsection>
 
       <subsection name="Parent Module" id="Parent_Module">
-        <p>
-          <a href="../../config.html#TreeWalker">TreeWalker</a>
-        </p>
+        <macro name="parent-module">
+          <param name="moduleName" value="JavadocMethod"/>
+        </macro>
       </subsection>
     </section>
   </body>

--- a/src/xdocs/checks/javadoc/javadocmissingleadingasterisk.xml.template
+++ b/src/xdocs/checks/javadoc/javadocmissingleadingasterisk.xml.template
@@ -107,9 +107,9 @@
       </subsection>
 
       <subsection name="Parent Module" id="Parent_Module">
-        <p>
-          <a href="../../config.html#TreeWalker">TreeWalker</a>
-        </p>
+        <macro name="parent-module">
+          <param name="moduleName" value="JavadocMissingLeadingAsterisk"/>
+        </macro>
       </subsection>
     </section>
   </body>

--- a/src/xdocs/checks/javadoc/javadocmissingwhitespaceafterasterisk.xml.template
+++ b/src/xdocs/checks/javadoc/javadocmissingwhitespaceafterasterisk.xml.template
@@ -105,9 +105,9 @@
       </subsection>
 
       <subsection name="Parent Module" id="Parent_Module">
-        <p>
-          <a href="../../config.html#TreeWalker">TreeWalker</a>
-        </p>
+        <macro name="parent-module">
+          <param name="moduleName" value="JavadocMissingWhitespaceAfterAsterisk"/>
+        </macro>
       </subsection>
     </section>
   </body>

--- a/src/xdocs/checks/javadoc/javadocpackage.xml.template
+++ b/src/xdocs/checks/javadoc/javadocpackage.xml.template
@@ -109,9 +109,9 @@
       </subsection>
 
       <subsection name="Parent Module" id="Parent_Module">
-        <p>
-          <a href="../../config.html#Checker">Checker</a>
-        </p>
+        <macro name="parent-module">
+          <param name="moduleName" value="JavadocPackage"/>
+        </macro>
       </subsection>
     </section>
   </body>

--- a/src/xdocs/checks/javadoc/javadocparagraph.xml.template
+++ b/src/xdocs/checks/javadoc/javadocparagraph.xml.template
@@ -154,9 +154,9 @@
       </subsection>
 
       <subsection name="Parent Module" id="Parent_Module">
-        <p>
-          <a href="../../config.html#TreeWalker">TreeWalker</a>
-        </p>
+        <macro name="parent-module">
+          <param name="moduleName" value="JavadocParagraph"/>
+        </macro>
       </subsection>
     </section>
   </body>

--- a/src/xdocs/checks/javadoc/javadocstyle.xml.template
+++ b/src/xdocs/checks/javadoc/javadocstyle.xml.template
@@ -332,9 +332,9 @@
       </subsection>
 
       <subsection name="Parent Module" id="Parent_Module">
-        <p>
-          <a href="../../config.html#TreeWalker">TreeWalker</a>
-        </p>
+        <macro name="parent-module">
+          <param name="moduleName" value="JavadocStyle"/>
+        </macro>
       </subsection>
     </section>
   </body>

--- a/src/xdocs/checks/javadoc/javadoctagcontinuationindentation.xml.template
+++ b/src/xdocs/checks/javadoc/javadoctagcontinuationindentation.xml.template
@@ -150,9 +150,9 @@
       </subsection>
 
       <subsection name="Parent Module" id="Parent_Module">
-        <p>
-          <a href="../../config.html#TreeWalker">TreeWalker</a>
-        </p>
+        <macro name="parent-module">
+          <param name="moduleName" value="JavadocTagContinuationIndentation"/>
+        </macro>
       </subsection>
     </section>
   </body>

--- a/src/xdocs/checks/javadoc/javadoctype.xml.template
+++ b/src/xdocs/checks/javadoc/javadoctype.xml.template
@@ -311,9 +311,9 @@
       </subsection>
 
       <subsection name="Parent Module" id="Parent_Module">
-        <p>
-          <a href="../../config.html#TreeWalker">TreeWalker</a>
-        </p>
+        <macro name="parent-module">
+          <param name="moduleName" value="JavadocType"/>
+        </macro>
       </subsection>
     </section>
   </body>

--- a/src/xdocs/checks/javadoc/javadocvariable.xml.template
+++ b/src/xdocs/checks/javadoc/javadocvariable.xml.template
@@ -182,9 +182,9 @@
       </subsection>
 
       <subsection name="Parent Module" id="Parent_Module">
-        <p>
-          <a href="../../config.html#TreeWalker">TreeWalker</a>
-        </p>
+        <macro name="parent-module">
+          <param name="moduleName" value="JavadocVariable"/>
+        </macro>
       </subsection>
     </section>
   </body>

--- a/src/xdocs/checks/javadoc/missingjavadocmethod.xml.template
+++ b/src/xdocs/checks/javadoc/missingjavadocmethod.xml.template
@@ -271,9 +271,9 @@ public boolean isSomething()
       </subsection>
 
       <subsection name="Parent Module" id="Parent_Module">
-        <p>
-          <a href="../../config.html#TreeWalker">TreeWalker</a>
-        </p>
+        <macro name="parent-module">
+          <param name="moduleName" value="MissingJavadocMethod"/>
+        </macro>
       </subsection>
     </section>
   </body>

--- a/src/xdocs/checks/javadoc/missingjavadocpackage.xml.template
+++ b/src/xdocs/checks/javadoc/missingjavadocpackage.xml.template
@@ -73,9 +73,9 @@
       </subsection>
 
       <subsection name="Parent Module" id="Parent_Module">
-        <p>
-          <a href="../../config.html#TreeWalker">TreeWalker</a>
-        </p>
+        <macro name="parent-module">
+          <param name="moduleName" value="MissingJavadocPackage"/>
+        </macro>
       </subsection>
     </section>
   </body>

--- a/src/xdocs/checks/javadoc/missingjavadoctype.xml.template
+++ b/src/xdocs/checks/javadoc/missingjavadoctype.xml.template
@@ -208,9 +208,9 @@
       </subsection>
 
       <subsection name="Parent Module" id="Parent_Module">
-        <p>
-          <a href="../../config.html#TreeWalker">TreeWalker</a>
-        </p>
+        <macro name="parent-module">
+          <param name="moduleName" value="MissingJavadocType"/>
+        </macro>
       </subsection>
     </section>
   </body>

--- a/src/xdocs/checks/javadoc/nonemptyatclausedescription.xml.template
+++ b/src/xdocs/checks/javadoc/nonemptyatclausedescription.xml.template
@@ -153,9 +153,9 @@
       </subsection>
 
       <subsection name="Parent Module" id="Parent_Module">
-        <p>
-          <a href="../../config.html#TreeWalker">TreeWalker</a>
-        </p>
+        <macro name="parent-module">
+          <param name="moduleName" value="NonEmptyAtclauseDescription"/>
+        </macro>
       </subsection>
     </section>
   </body>

--- a/src/xdocs/checks/javadoc/requireemptylinebeforeblocktaggroup.xml.template
+++ b/src/xdocs/checks/javadoc/requireemptylinebeforeblocktaggroup.xml.template
@@ -120,9 +120,9 @@ public boolean testMethod(int firstParam) {
       </subsection>
 
       <subsection name="Parent Module" id="Parent_Module">
-        <p>
-          <a href="../../config.html#TreeWalker">TreeWalker</a>
-        </p>
+        <macro name="parent-module">
+          <param name="moduleName" value="RequireEmptyLineBeforeBlockTagGroup"/>
+        </macro>
       </subsection>
     </section>
   </body>

--- a/src/xdocs/checks/javadoc/singlelinejavadoc.xml.template
+++ b/src/xdocs/checks/javadoc/singlelinejavadoc.xml.template
@@ -176,9 +176,9 @@
       </subsection>
 
       <subsection name="Parent Module" id="Parent_Module">
-        <p>
-          <a href="../../config.html#TreeWalker">TreeWalker</a>
-        </p>
+        <macro name="parent-module">
+          <param name="moduleName" value="SingleLineJavadoc"/>
+        </macro>
       </subsection>
     </section>
   </body>

--- a/src/xdocs/checks/javadoc/summaryjavadoc.xml.template
+++ b/src/xdocs/checks/javadoc/summaryjavadoc.xml.template
@@ -186,9 +186,9 @@
       </subsection>
 
       <subsection name="Parent Module" id="Parent_Module">
-        <p>
-          <a href="../../config.html#TreeWalker">TreeWalker</a>
-        </p>
+        <macro name="parent-module">
+          <param name="moduleName" value="SummaryJavadoc"/>
+        </macro>
       </subsection>
     </section>
   </body>

--- a/src/xdocs/checks/javadoc/writetag.xml.template
+++ b/src/xdocs/checks/javadoc/writetag.xml.template
@@ -202,9 +202,9 @@
       </subsection>
 
       <subsection name="Parent Module" id="Parent_Module">
-        <p>
-          <a href="../../config.html#TreeWalker">TreeWalker</a>
-        </p>
+        <macro name="parent-module">
+          <param name="moduleName" value="WriteTag"/>
+        </macro>
       </subsection>
     </section>
   </body>


### PR DESCRIPTION
Part of #13610

We see no diff in generated files because formatting matches exactly