### PR TITLE
Issue #13610: Use parent module macro in metrics templates

### DIFF
--- a/src/xdocs/checks/metrics/booleanexpressioncomplexity.xml.template
+++ b/src/xdocs/checks/metrics/booleanexpressioncomplexity.xml.template
@@ -167,9 +167,9 @@
       </subsection>
 
       <subsection name="Parent Module" id="Parent_Module">
-        <p>
-          <a href="../../config.html#TreeWalker">TreeWalker</a>
-        </p>
+        <macro name="parent-module">
+          <param name="moduleName" value="BooleanExpressionComplexity"/>
+        </macro>
       </subsection>
     </section>
   </body>

--- a/src/xdocs/checks/metrics/classdataabstractioncoupling.xml.template
+++ b/src/xdocs/checks/metrics/classdataabstractioncoupling.xml.template
@@ -360,9 +360,9 @@
       </subsection>
 
       <subsection name="Parent Module" id="Parent_Module">
-        <p>
-          <a href="../../config.html#TreeWalker">TreeWalker</a>
-        </p>
+        <macro name="parent-module">
+          <param name="moduleName" value="ClassDataAbstractionCoupling"/>
+        </macro>
       </subsection>
     </section>
   </body>

--- a/src/xdocs/checks/metrics/classfanoutcomplexity.xml.template
+++ b/src/xdocs/checks/metrics/classfanoutcomplexity.xml.template
@@ -329,9 +329,9 @@
       </subsection>
 
       <subsection name="Parent Module" id="Parent_Module">
-        <p>
-          <a href="../../config.html#TreeWalker">TreeWalker</a>
-        </p>
+        <macro name="parent-module">
+          <param name="moduleName" value="ClassFanOutComplexity"/>
+        </macro>
       </subsection>
     </section>
   </body>

--- a/src/xdocs/checks/metrics/cyclomaticcomplexity.xml.template
+++ b/src/xdocs/checks/metrics/cyclomaticcomplexity.xml.template
@@ -206,9 +206,9 @@
       </subsection>
 
       <subsection name="Parent Module" id="Parent_Module">
-        <p>
-          <a href="../../config.html#TreeWalker">TreeWalker</a>
-        </p>
+        <macro name="parent-module">
+          <param name="moduleName" value="CyclomaticComplexity"/>
+        </macro>
       </subsection>
     </section>
   </body>

--- a/src/xdocs/checks/metrics/javancss.xml.template
+++ b/src/xdocs/checks/metrics/javancss.xml.template
@@ -199,9 +199,9 @@
       </subsection>
 
       <subsection name="Parent Module" id="Parent_Module">
-        <p>
-          <a href="../../config.html#TreeWalker">TreeWalker</a>
-        </p>
+        <macro name="parent-module">
+          <param name="moduleName" value="JavaNCSS"/>
+        </macro>
       </subsection>
     </section>
   </body>

--- a/src/xdocs/checks/metrics/npathcomplexity.xml.template
+++ b/src/xdocs/checks/metrics/npathcomplexity.xml.template
@@ -189,9 +189,9 @@
       </subsection>
 
       <subsection name="Parent Module" id="Parent_Module">
-        <p>
-          <a href="../../config.html#TreeWalker">TreeWalker</a>
-        </p>
+        <macro name="parent-module">
+          <param name="moduleName" value="NPathComplexity"/>
+        </macro>
       </subsection>
     </section>
   </body>


### PR DESCRIPTION
Part of #13610

We see no diff in generated files because formatting matches exactly