### PR TITLE
Issue #13610: Use parent module macro in modifiers templates

### DIFF
--- a/src/xdocs/checks/modifier/classmemberimpliedmodifier.xml.template
+++ b/src/xdocs/checks/modifier/classmemberimpliedmodifier.xml.template
@@ -131,9 +131,9 @@ public final class Person {
       </subsection>
 
       <subsection name="Parent Module" id="Parent_Module">
-        <p>
-          <a href="../../config.html#TreeWalker">TreeWalker</a>
-        </p>
+        <macro name="parent-module">
+          <param name="moduleName" value="ClassMemberImpliedModifier"/>
+        </macro>
       </subsection>
     </section>
   </body>

--- a/src/xdocs/checks/modifier/interfacememberimpliedmodifier.xml.template
+++ b/src/xdocs/checks/modifier/interfacememberimpliedmodifier.xml.template
@@ -229,9 +229,9 @@ public interface AddressFactory {
       </subsection>
 
       <subsection name="Parent Module" id="Parent_Module">
-        <p>
-          <a href="../../config.html#TreeWalker">TreeWalker</a>
-        </p>
+        <macro name="parent-module">
+          <param name="moduleName" value="InterfaceMemberImpliedModifier"/>
+        </macro>
       </subsection>
     </section>
   </body>

--- a/src/xdocs/checks/modifier/modifierorder.xml.template
+++ b/src/xdocs/checks/modifier/modifierorder.xml.template
@@ -124,9 +124,9 @@
       </subsection>
 
       <subsection name="Parent Module" id="Parent_Module">
-        <p>
-          <a href="../../config.html#TreeWalker">TreeWalker</a>
-        </p>
+        <macro name="parent-module">
+          <param name="moduleName" value="ModifierOrder"/>
+        </macro>
       </subsection>
     </section>
   </body>

--- a/src/xdocs/checks/modifier/redundantmodifier.xml.template
+++ b/src/xdocs/checks/modifier/redundantmodifier.xml.template
@@ -259,9 +259,9 @@ public class ClassExtending extends ClassExample {
       </subsection>
 
       <subsection name="Parent Module" id="Parent_Module">
-        <p>
-          <a href="../../config.html#TreeWalker">TreeWalker</a>
-        </p>
+        <macro name="parent-module">
+          <param name="moduleName" value="RedundantModifier"/>
+        </macro>
       </subsection>
     </section>
   </body>


### PR DESCRIPTION
Part of #13610

We see no diff in generated files because formatting matches exactly