### PR TITLE
Issue #13610: Use parent module macro in regexp templates

### DIFF
--- a/src/xdocs/checks/regexp/regexp.xml.template
+++ b/src/xdocs/checks/regexp/regexp.xml.template
@@ -351,9 +351,9 @@
       </subsection>
 
       <subsection name="Parent Module" id="Parent_Module">
-        <p>
-          <a href="../../config.html#TreeWalker">TreeWalker</a>
-        </p>
+        <macro name="parent-module">
+          <param name="moduleName" value="Regexp"/>
+        </macro>
       </subsection>
     </section>
   </body>

--- a/src/xdocs/checks/regexp/regexpmultiline.xml.template
+++ b/src/xdocs/checks/regexp/regexpmultiline.xml.template
@@ -239,9 +239,9 @@
       </subsection>
 
       <subsection name="Parent Module" id="Parent_Module">
-        <p>
-          <a href="../../config.html#Checker">Checker</a>
-        </p>
+        <macro name="parent-module">
+          <param name="moduleName" value="RegexpMultiline"/>
+        </macro>
       </subsection>
     </section>
   </body>

--- a/src/xdocs/checks/regexp/regexponfilename.xml.template
+++ b/src/xdocs/checks/regexp/regexponfilename.xml.template
@@ -242,9 +242,9 @@
       </subsection>
 
       <subsection name="Parent Module" id="Parent_Module">
-        <p>
-          <a href="../../config.html#Checker">Checker</a>
-        </p>
+        <macro name="parent-module">
+          <param name="moduleName" value="RegexpOnFilename"/>
+        </macro>
       </subsection>
     </section>
   </body>

--- a/src/xdocs/checks/regexp/regexpsingleline.xml.template
+++ b/src/xdocs/checks/regexp/regexpsingleline.xml.template
@@ -194,9 +194,9 @@
       </subsection>
 
       <subsection name="Parent Module" id="Parent_Module">
-        <p>
-          <a href="../../config.html#Checker">Checker</a>
-        </p>
+        <macro name="parent-module">
+          <param name="moduleName" value="RegexpSingleline"/>
+        </macro>
       </subsection>
     </section>
   </body>

--- a/src/xdocs/checks/regexp/regexpsinglelinejava.xml.template
+++ b/src/xdocs/checks/regexp/regexpsinglelinejava.xml.template
@@ -210,9 +210,9 @@
       </subsection>
 
       <subsection name="Parent Module" id="Parent_Module">
-        <p>
-          <a href="../../config.html#TreeWalker">TreeWalker</a>
-        </p>
+        <macro name="parent-module">
+          <param name="moduleName" value="RegexpSinglelineJava"/>
+        </macro>
       </subsection>
     </section>
   </body>


### PR DESCRIPTION
Part of #13610

We see no diff in generated files because formatting matches exactly