### PR TITLE
Issue #13610: Use parent module macro in sizes templates

### DIFF
--- a/src/xdocs/checks/sizes/anoninnerlength.xml.template
+++ b/src/xdocs/checks/sizes/anoninnerlength.xml.template
@@ -92,9 +92,9 @@
       </subsection>
 
       <subsection name="Parent Module" id="Parent_Module">
-        <p>
-          <a href="../../config.html#TreeWalker">TreeWalker</a>
-        </p>
+        <macro name="parent-module">
+          <param name="moduleName" value="AnonInnerLength"/>
+        </macro>
       </subsection>
     </section>
   </body>

--- a/src/xdocs/checks/sizes/executablestatementcount.xml.template
+++ b/src/xdocs/checks/sizes/executablestatementcount.xml.template
@@ -120,9 +120,9 @@
       </subsection>
 
       <subsection name="Parent Module" id="Parent_Module">
-        <p>
-          <a href="../../config.html#TreeWalker">TreeWalker</a>
-        </p>
+        <macro name="parent-module">
+          <param name="moduleName" value="ExecutableStatementCount"/>
+        </macro>
       </subsection>
     </section>
   </body>

--- a/src/xdocs/checks/sizes/filelength.xml.template
+++ b/src/xdocs/checks/sizes/filelength.xml.template
@@ -101,9 +101,9 @@
       </subsection>
 
       <subsection name="Parent Module" id="Parent_Module">
-        <p>
-          <a href="../../config.html#Checker">Checker</a>
-        </p>
+        <macro name="parent-module">
+          <param name="moduleName" value="FileLength"/>
+        </macro>
       </subsection>
     </section>
   </body>

--- a/src/xdocs/checks/sizes/lambdabodylength.xml.template
+++ b/src/xdocs/checks/sizes/lambdabodylength.xml.template
@@ -107,9 +107,9 @@
       </subsection>
 
       <subsection name="Parent Module" id="Parent_Module">
-        <p>
-          <a href="../../config.html#TreeWalker">TreeWalker</a>
-        </p>
+        <macro name="parent-module">
+          <param name="moduleName" value="LambdaBodyLength"/>
+        </macro>
       </subsection>
     </section>
   </body>

--- a/src/xdocs/checks/sizes/linelength.xml.template
+++ b/src/xdocs/checks/sizes/linelength.xml.template
@@ -187,9 +187,9 @@ import java.util.regex.Pattern; // The length of this comment will be taken into
       </subsection>
 
       <subsection name="Parent Module" id="Parent_Module">
-        <p>
-          <a href="../../config.html#Checker">Checker</a>
-        </p>
+        <macro name="parent-module">
+          <param name="moduleName" value="LineLength"/>
+        </macro>
       </subsection>
     </section>
   </body>

--- a/src/xdocs/checks/sizes/methodcount.xml.template
+++ b/src/xdocs/checks/sizes/methodcount.xml.template
@@ -218,9 +218,9 @@ public class ExampleClass {
       </subsection>
 
       <subsection name="Parent Module" id="Parent_Module">
-        <p>
-          <a href="../../config.html#TreeWalker">TreeWalker</a>
-        </p>
+        <macro name="parent-module">
+          <param name="moduleName" value="MethodCount"/>
+        </macro>
       </subsection>
     </section>
   </body>

--- a/src/xdocs/checks/sizes/methodlength.xml.template
+++ b/src/xdocs/checks/sizes/methodlength.xml.template
@@ -157,9 +157,9 @@
       </subsection>
 
       <subsection name="Parent Module" id="Parent_Module">
-        <p>
-          <a href="../../config.html#TreeWalker">TreeWalker</a>
-        </p>
+        <macro name="parent-module">
+          <param name="moduleName" value="MethodLength"/>
+        </macro>
       </subsection>
     </section>
   </body>

--- a/src/xdocs/checks/sizes/outertypenumber.xml.template
+++ b/src/xdocs/checks/sizes/outertypenumber.xml.template
@@ -92,9 +92,9 @@
       </subsection>
 
       <subsection name="Parent Module" id="Parent_Module">
-        <p>
-          <a href="../../config.html#TreeWalker">TreeWalker</a>
-        </p>
+        <macro name="parent-module">
+          <param name="moduleName" value="OuterTypeNumber"/>
+        </macro>
       </subsection>
     </section>
   </body>

--- a/src/xdocs/checks/sizes/parameternumber.xml.template
+++ b/src/xdocs/checks/sizes/parameternumber.xml.template
@@ -142,9 +142,9 @@
       </subsection>
 
       <subsection name="Parent Module" id="Parent_Module">
-        <p>
-          <a href="../../config.html#TreeWalker">TreeWalker</a>
-        </p>
+        <macro name="parent-module">
+          <param name="moduleName" value="ParameterNumber"/>
+        </macro>
       </subsection>
     </section>
   </body>

--- a/src/xdocs/checks/sizes/recordcomponentnumber.xml.template
+++ b/src/xdocs/checks/sizes/recordcomponentnumber.xml.template
@@ -139,9 +139,9 @@
       </subsection>
 
       <subsection name="Parent Module" id="Parent_Module">
-        <p>
-          <a href="../../config.html#TreeWalker">TreeWalker</a>
-        </p>
+        <macro name="parent-module">
+          <param name="moduleName" value="RecordComponentNumber"/>
+        </macro>
       </subsection>
     </section>
   </body>


### PR DESCRIPTION
Part of #13610

We see no diff in generated files because formatting matches exactly