### PR TITLE
Issue #13610: Use parent module macro in whitespace templates

### DIFF
--- a/src/xdocs/checks/whitespace/emptyforinitializerpad.xml.template
+++ b/src/xdocs/checks/whitespace/emptyforinitializerpad.xml.template
@@ -114,9 +114,9 @@ for (
       </subsection>
 
       <subsection name="Parent Module" id="Parent_Module">
-        <p>
-          <a href="../../config.html#TreeWalker">TreeWalker</a>
-        </p>
+        <macro name="parent-module">
+          <param name="moduleName" value="EmptyForInitializerPad"/>
+        </macro>
       </subsection>
     </section>
   </body>

--- a/src/xdocs/checks/whitespace/emptyforiteratorpad.xml.template
+++ b/src/xdocs/checks/whitespace/emptyforiteratorpad.xml.template
@@ -117,9 +117,9 @@ for (Iterator foo = very.long.line.iterator();
       </subsection>
 
       <subsection name="Parent Module" id="Parent_Module">
-        <p>
-          <a href="../../config.html#TreeWalker">TreeWalker</a>
-        </p>
+        <macro name="parent-module">
+          <param name="moduleName" value="EmptyForIteratorPad"/>
+        </macro>
       </subsection>
     </section>
   </body>

--- a/src/xdocs/checks/whitespace/emptylineseparator.xml.template
+++ b/src/xdocs/checks/whitespace/emptylineseparator.xml.template
@@ -275,9 +275,9 @@
       </subsection>
 
       <subsection name="Parent Module" id="Parent_Module">
-        <p>
-          <a href="../../config.html#TreeWalker">TreeWalker</a>
-        </p>
+        <macro name="parent-module">
+          <param name="moduleName" value="EmptyLineSeparator"/>
+        </macro>
       </subsection>
     </section>
   </body>

--- a/src/xdocs/checks/whitespace/filetabcharacter.xml.template
+++ b/src/xdocs/checks/whitespace/filetabcharacter.xml.template
@@ -158,9 +158,9 @@
       </subsection>
 
       <subsection name="Parent Module" id="Parent_Module">
-        <p>
-          <a href="../../config.html#Checker">Checker</a>
-        </p>
+        <macro name="parent-module">
+          <param name="moduleName" value="FileTabCharacter"/>
+        </macro>
       </subsection>
     </section>
   </body>

--- a/src/xdocs/checks/whitespace/genericwhitespace.xml.template
+++ b/src/xdocs/checks/whitespace/genericwhitespace.xml.template
@@ -111,9 +111,9 @@
       </subsection>
 
       <subsection name="Parent Module" id="Parent_Module">
-        <p>
-          <a href="../../config.html#TreeWalker">TreeWalker</a>
-        </p>
+        <macro name="parent-module">
+          <param name="moduleName" value="GenericWhitespace"/>
+        </macro>
       </subsection>
     </section>
   </body>

--- a/src/xdocs/checks/whitespace/methodparampad.xml.template
+++ b/src/xdocs/checks/whitespace/methodparampad.xml.template
@@ -176,9 +176,9 @@
       </subsection>
 
       <subsection name="Parent Module" id="Parent_Module">
-        <p>
-          <a href="../../config.html#TreeWalker">TreeWalker</a>
-        </p>
+        <macro name="parent-module">
+          <param name="moduleName" value="MethodParamPad"/>
+        </macro>
       </subsection>
     </section>
   </body>

--- a/src/xdocs/checks/whitespace/nolinewrap.xml.template
+++ b/src/xdocs/checks/whitespace/nolinewrap.xml.template
@@ -176,9 +176,9 @@ import static java.math.BigInteger.ZERO;
       </subsection>
 
       <subsection name="Parent Module" id="Parent_Module">
-        <p>
-          <a href="../../config.html#TreeWalker">TreeWalker</a>
-        </p>
+        <macro name="parent-module">
+          <param name="moduleName" value="NoLineWrap"/>
+        </macro>
       </subsection>
     </section>
   </body>

--- a/src/xdocs/checks/whitespace/nowhitespaceafter.xml.template
+++ b/src/xdocs/checks/whitespace/nowhitespaceafter.xml.template
@@ -200,9 +200,9 @@
       </subsection>
 
       <subsection name="Parent Module" id="Parent_Module">
-        <p>
-          <a href="../../config.html#TreeWalker">TreeWalker</a>
-        </p>
+        <macro name="parent-module">
+          <param name="moduleName" value="NoWhitespaceAfter"/>
+        </macro>
       </subsection>
     </section>
   </body>

--- a/src/xdocs/checks/whitespace/nowhitespacebefore.xml.template
+++ b/src/xdocs/checks/whitespace/nowhitespacebefore.xml.template
@@ -183,9 +183,9 @@
       </subsection>
 
       <subsection name="Parent Module" id="Parent_Module">
-        <p>
-          <a href="../../config.html#TreeWalker">TreeWalker</a>
-        </p>
+        <macro name="parent-module">
+          <param name="moduleName" value="NoWhitespaceBefore"/>
+        </macro>
       </subsection>
     </section>
   </body>

--- a/src/xdocs/checks/whitespace/nowhitespacebeforecasedefaultcolon.xml.template
+++ b/src/xdocs/checks/whitespace/nowhitespacebeforecasedefaultcolon.xml.template
@@ -66,9 +66,9 @@
       </subsection>
 
       <subsection name="Parent Module" id="Parent_Module">
-        <p>
-          <a href="../../config.html#TreeWalker">TreeWalker</a>
-        </p>
+        <macro name="parent-module">
+          <param name="moduleName" value="NoWhitespaceBeforeCaseDefaultColon"/>
+        </macro>
       </subsection>
     </section>
   </body>

--- a/src/xdocs/checks/whitespace/operatorwrap.xml.template
+++ b/src/xdocs/checks/whitespace/operatorwrap.xml.template
@@ -246,9 +246,9 @@
       </subsection>
 
       <subsection name="Parent Module" id="Parent_Module">
-        <p>
-          <a href="../../config.html#TreeWalker">TreeWalker</a>
-        </p>
+        <macro name="parent-module">
+          <param name="moduleName" value="OperatorWrap"/>
+        </macro>
       </subsection>
     </section>
   </body>

--- a/src/xdocs/checks/whitespace/parenpad.xml.template
+++ b/src/xdocs/checks/whitespace/parenpad.xml.template
@@ -245,9 +245,9 @@ try (Closeable resource = acquire(); ) // no check before right parenthesis
       </subsection>
 
       <subsection name="Parent Module" id="Parent_Module">
-        <p>
-          <a href="../../config.html#TreeWalker">TreeWalker</a>
-        </p>
+        <macro name="parent-module">
+          <param name="moduleName" value="ParenPad"/>
+        </macro>
       </subsection>
     </section>
   </body>

--- a/src/xdocs/checks/whitespace/separatorwrap.xml.template
+++ b/src/xdocs/checks/whitespace/separatorwrap.xml.template
@@ -166,9 +166,9 @@
       </subsection>
 
       <subsection name="Parent Module" id="Parent_Module">
-        <p>
-          <a href="../../config.html#TreeWalker">TreeWalker</a>
-        </p>
+        <macro name="parent-module">
+          <param name="moduleName" value="SeparatorWrap"/>
+        </macro>
       </subsection>
     </section>
   </body>

--- a/src/xdocs/checks/whitespace/singlespaceseparator.xml.template
+++ b/src/xdocs/checks/whitespace/singlespaceseparator.xml.template
@@ -123,9 +123,9 @@ public long toMicros(long d) { return d / (C1 / C0); }
       </subsection>
 
       <subsection name="Parent Module" id="Parent_Module">
-        <p>
-          <a href="../../config.html#TreeWalker">TreeWalker</a>
-        </p>
+        <macro name="parent-module">
+          <param name="moduleName" value="SingleSpaceSeparator"/>
+        </macro>
       </subsection>
     </section>
   </body>

--- a/src/xdocs/checks/whitespace/typecastparenpad.xml.template
+++ b/src/xdocs/checks/whitespace/typecastparenpad.xml.template
@@ -119,9 +119,9 @@
       </subsection>
 
       <subsection name="Parent Module" id="Parent_Module">
-        <p>
-          <a href="../../config.html#TreeWalker">TreeWalker</a>
-        </p>
+        <macro name="parent-module">
+          <param name="moduleName" value="TypecastParenPad"/>
+        </macro>
       </subsection>
     </section>
   </body>

--- a/src/xdocs/checks/whitespace/whitespacearound.xml.template
+++ b/src/xdocs/checks/whitespace/whitespacearound.xml.template
@@ -541,9 +541,9 @@ try {
       </subsection>
 
       <subsection name="Parent Module" id="Parent_Module">
-        <p>
-          <a href="../../config.html#TreeWalker">TreeWalker</a>
-        </p>
+        <macro name="parent-module">
+          <param name="moduleName" value="WhitespaceAround"/>
+        </macro>
       </subsection>
     </section>
   </body>


### PR DESCRIPTION
Part of #13610

We see no diff in generated files because formatting matches exactly