### PR TITLE
Issue #13501: Kill mutation for CommonUtil

### DIFF
--- a/config/pitest-suppressions/pitest-utils-suppressions.xml
+++ b/config/pitest-suppressions/pitest-utils-suppressions.xml
@@ -225,14 +225,14 @@
     <lineContent>return stripLeading(strippedCodePoints);</lineContent>
   </mutation>
 
-  <mutation unstable="false">
-    <sourceFile>CommonUtil.java</sourceFile>
-    <mutatedClass>com.puppycrawl.tools.checkstyle.utils.CommonUtil</mutatedClass>
-    <mutatedMethod>baseClassName</mutatedMethod>
-    <mutator>org.pitest.mutationtest.engine.gregor.mutators.RemoveConditionalMutator_EQUAL_ELSE</mutator>
-    <description>removed conditional - replaced equality check with false</description>
-    <lineContent>if (index == -1) {</lineContent>
-  </mutation>
+
+
+
+
+
+
+
+
 
 
 

--- a/src/main/java/com/puppycrawl/tools/checkstyle/utils/CommonUtil.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/utils/CommonUtil.java
@@ -241,15 +241,8 @@ public final class CommonUtil {
      * @return the base class name from a fully qualified name
      */
     public static String baseClassName(String type) {
-        final String className;
         final int index = type.lastIndexOf('.');
-        if (index == -1) {
-            className = type;
-        }
-        else {
-            className = type.substring(index + 1);
-        }
-        return className;
+        return type.substring(index + 1);
     }
 
     /**


### PR DESCRIPTION
Issue #13501: Kill mutation for CommonUtil

-------

# Mutation 
https://github.com/Kevin222004/checkstyle/blob/0dba32b6c8c29977d74af675078501fa8052c10f/config/pitest-suppressions/pitest-utils-suppressions.xml#L228-L235

-----

# Explaination

Regression will find nothing.
Reason 
```
    public static String baseClassName(String type) {
        final String className;
        final int index = type.lastIndexOf('.');
        if (index == -1) {
            className = type;
        }
        else {
            className = type.substring(index + 1);
        }
        return className;
    }
```
lets suppose if type means the name of class is only `SomeClassName` here index will become -1. know 
if we remove the if condition then in else className is equal to `type.substring(index+1)` it means starting point of substring is 0 and index also start from 0. and in if condition className = type. so both are doing same thing   

-----

# Regression :- 


-----

Diff Regression config: https://gist.githubusercontent.com/Kevin222004/2c4249a9fdf3ce52a06a16608bd6e6b7/raw/1a8f90bb4e6da6fbe3602f35b368d91ae97f3521/common.xml
Diff Regression projects: https://gist.githubusercontent.com/Kevin222004/21e3934e85f802e2fbd48af06d122364/raw/604256badd733d8568064f371d55657c04b00dfd/test-projects-2.properties
Report label: Regression-2