### PR TITLE
Issue #13501: Kill mutation for DetailAstImpl-4

### DIFF
--- a/config/pitest-suppressions/pitest-common-2-suppressions.xml
+++ b/config/pitest-suppressions/pitest-common-2-suppressions.xml
@@ -9,23 +9,23 @@
 
 
 
-  <mutation unstable="false">
-    <sourceFile>DetailAstImpl.java</sourceFile>
-    <mutatedClass>com.puppycrawl.tools.checkstyle.DetailAstImpl</mutatedClass>
-    <mutatedMethod>addChild</mutatedMethod>
-    <mutator>org.pitest.mutationtest.engine.gregor.mutators.NonVoidMethodCallMutator</mutator>
-    <description>removed call to com/puppycrawl/tools/checkstyle/DetailAstImpl::getLastChild</description>
-    <lineContent>astImpl.previousSibling = (DetailAstImpl) getLastChild();</lineContent>
-  </mutation>
 
-  <mutation unstable="false">
-    <sourceFile>DetailAstImpl.java</sourceFile>
-    <mutatedClass>com.puppycrawl.tools.checkstyle.DetailAstImpl</mutatedClass>
-    <mutatedMethod>addChild</mutatedMethod>
-    <mutator>org.pitest.mutationtest.engine.gregor.mutators.experimental.MemberVariableMutator</mutator>
-    <description>Removed assignment to member variable previousSibling</description>
-    <lineContent>astImpl.previousSibling = (DetailAstImpl) getLastChild();</lineContent>
-  </mutation>
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
 
   <mutation unstable="false">
     <sourceFile>DetailAstImpl.java</sourceFile>

--- a/src/main/java/com/puppycrawl/tools/checkstyle/DetailAstImpl.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/DetailAstImpl.java
@@ -166,7 +166,6 @@ public final class DetailAstImpl implements DetailAST {
         if (child != null) {
             final DetailAstImpl astImpl = (DetailAstImpl) child;
             astImpl.setParent(this);
-            astImpl.previousSibling = (DetailAstImpl) getLastChild();
         }
         DetailAST temp = firstChild;
         if (temp == null) {

--- a/src/test/java/com/puppycrawl/tools/checkstyle/DetailAstImplTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/DetailAstImplTest.java
@@ -674,6 +674,27 @@ public class DetailAstImplTest extends AbstractModuleTestSupport {
                 .isEqualTo(0);
     }
 
+    @Test
+    public void testAddChild() {
+        final DetailAstImpl grandParent = new DetailAstImpl();
+        grandParent.setText("grandparent");
+        final DetailAstImpl parent = new DetailAstImpl();
+        parent.setText("parent");
+        grandParent.setFirstChild(parent);
+
+        final DetailAstImpl child = new DetailAstImpl();
+        child.setText("child");
+        parent.setFirstChild(child);
+
+        final DetailAstImpl secondChild = new DetailAstImpl();
+        secondChild.setText("SecondChild");
+        parent.addChild(secondChild);
+
+        assertWithMessage("Invalid previous sibling")
+                .that(secondChild.getPreviousSibling())
+                .isEqualTo(child);
+    }
+
     private static List<File> getAllFiles(File dir) {
         final List<File> result = new ArrayList<>();
 


### PR DESCRIPTION
Issue #13501: Kill mutation for DetailAstImpl-4


https://github.com/checkstyle/checkstyle/blob/master/src/main/java/com/puppycrawl/tools/checkstyle/DetailAstImpl.java

-------

# Mutations 
https://github.com/checkstyle/checkstyle/blob/88486f7ca9795f613d28fa6c2a53beccef521dfc/config/pitest-suppressions/pitest-common-2-suppressions.xml#L12-L28

------------

# Explaination

https://github.com/checkstyle/checkstyle/blob/0dba32b6c8c29977d74af675078501fa8052c10f/src/main/java/com/puppycrawl/tools/checkstyle/DetailAstImpl.java#L169 
This line is mutated. 

The similar reason https://github.com/checkstyle/checkstyle/pull/13391 and https://github.com/checkstyle/checkstyle/pull/13390#issue-1800473514

https://github.com/checkstyle/checkstyle/blob/0dba32b6c8c29977d74af675078501fa8052c10f/src/main/java/com/puppycrawl/tools/checkstyle/DetailAstImpl.java#L180

here the next sibiling will be set

--------------

# Regression 

No DIff

Report-1 :- https://kevin222004.github.io/reports/DetailAstImpl/2023-08-27-T-17-02-02/part3-report/index.html

Report-2 :- https://kevin222004.github.io/reports/DetailAstImpl/2023-08-27-T-17-02-02/sevntu-check-regression_part_1-report/index.html

Report-3 :- https://kevin222004.github.io/reports/DetailAstImpl/2023-08-27-T-17-02-02/checks-nonjavadoc-error-report/index.html

Report-4 :- https://kevin222004.github.io/reports/DetailAstImpl/2023-08-27-T-17-02-02/sevntu-check-regression_part_2-report/index.html

Report-5 :- https://kevin222004.github.io/reports/DetailAstImpl/2023-08-27-T-17-02-02/checks-only-javadoc-error-report/index.html

Report-6 :- https://kevin222004.github.io/reports/DetailAstImpl/2023-08-27-T-17-02-02/part1-report/index.html

Report-7 :- https://kevin222004.github.io/reports/DetailAstImpl/2023-08-27-T-17-02-02/part5-report/index.html

Report-8 :- https://kevin222004.github.io/reports/DetailAstImpl/2023-08-27-T-17-02-02/part6-report/index.html

Report-9 :- https://kevin222004.github.io/reports/DetailAstImpl/2023-08-27-T-17-02-02/part4-report/index.html

Report-10 :- https://kevin222004.github.io/reports/DetailAstImpl/2023-08-27-T-17-02-02/antlr-report/index.html

Report-11 :- https://kevin222004.github.io/reports/DetailAstImpl/2023-08-27-T-17-02-02/part2-report/index.html

Report-12 :- https://kevin222004.github.io/reports/DetailAstImpl/2023-08-27-T-21-10-43/part3-report/index.html

Report-13 :- https://kevin222004.github.io/reports/DetailAstImpl/2023-08-27-T-21-10-43/sevntu-check-regression_part_1-report/index.html

Report-14 :-  https://kevin222004.github.io/reports/DetailAstImpl/2023-08-27-T-21-10-43/checks-nonjavadoc-error-report/index.html

Report-15 :-  https://kevin222004.github.io/reports/DetailAstImpl/2023-08-27-T-21-10-43/sevntu-check-regression_part_2-report/index.html

Report-16 :- https://kevin222004.github.io/reports/DetailAstImpl/2023-08-27-T-21-10-43/checks-only-javadoc-error-report/index.html

Report-17 :- https://kevin222004.github.io/reports/DetailAstImpl/2023-08-27-T-21-10-43/part1-report/index.html

Report-18 :-  https://kevin222004.github.io/reports/DetailAstImpl/2023-08-27-T-21-10-43/part5-report/index.html

Report-19 :- https://kevin222004.github.io/reports/DetailAstImpl/2023-08-27-T-21-10-43/part6-report/index.html

Report-20 :- https://kevin222004.github.io/reports/DetailAstImpl/2023-08-27-T-21-10-43/part4-report/index.html

Report-21 :-  https://kevin222004.github.io/reports/DetailAstImpl/2023-08-27-T-21-10-43/antlr-report/index.html

Report-22 :-  https://kevin222004.github.io/reports/DetailAstImpl/2023-08-27-T-21-10-43/part2-report/index.html
