### PR TITLE
Issue #13501: Kill mutation for DetailAstImpl-5

### DIFF
--- a/config/pitest-suppressions/pitest-common-2-suppressions.xml
+++ b/config/pitest-suppressions/pitest-common-2-suppressions.xml
@@ -1,13 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <suppressedMutations>
-  <mutation unstable="false">
-    <sourceFile>DetailAstImpl.java</sourceFile>
-    <mutatedClass>com.puppycrawl.tools.checkstyle.DetailAstImpl</mutatedClass>
-    <mutatedMethod>&lt;init&gt;</mutatedMethod>
-    <mutator>org.pitest.mutationtest.engine.gregor.mutators.experimental.MemberVariableMutator</mutator>
-    <description>Removed assignment to member variable childCount</description>
-    <lineContent>private int childCount = NOT_INITIALIZED;</lineContent>
-  </mutation>
+
+
+
+
+
+
+
+
 
   <mutation unstable="false">
     <sourceFile>DetailAstImpl.java</sourceFile>

--- a/src/main/java/com/puppycrawl/tools/checkstyle/DetailAstImpl.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/DetailAstImpl.java
@@ -47,7 +47,7 @@ public final class DetailAstImpl implements DetailAST {
     private int columnNo = NOT_INITIALIZED;
 
     /** Number of children. */
-    private int childCount = NOT_INITIALIZED;
+    private int childCount;
     /** The parent token. */
     private DetailAstImpl parent;
     /** Previous sibling. */


### PR DESCRIPTION
Issue #13501: Kill mutation for DetailAstImpl-5

https://github.com/checkstyle/checkstyle/blob/master/src/main/java/com/puppycrawl/tools/checkstyle/DetailAstImpl.java

-------

# Mutations 
https://github.com/checkstyle/checkstyle/blob/88486f7ca9795f613d28fa6c2a53beccef521dfc/config/pitest-suppressions/pitest-common-2-suppressions.xml#L3-L10

------------

# Explaination

https://github.com/checkstyle/checkstyle/blob/0dba32b6c8c29977d74af675078501fa8052c10f/src/main/java/com/puppycrawl/tools/checkstyle/DetailAstImpl.java#L50

This line is mutated. 

The reason of removal is whenever any node is created and set it as parent, child, nextSibling, previousSibling. every time the method is called https://github.com/checkstyle/checkstyle/blob/0dba32b6c8c29977d74af675078501fa8052c10f/src/main/java/com/puppycrawl/tools/checkstyle/DetailAstImpl.java#L443-L447
where childCount is assigned to `NOT_INITIALIZED`.  

--------------

# Regression 

Report-1 :- https://kevin222004.github.io/reports/DetailAstImpl2/2023-08-27-T-21-38-05/part3-report/index.html

Report-2 :- https://kevin222004.github.io/reports/DetailAstImpl2/2023-08-27-T-21-38-05/sevntu-check-regression_part_1-report/index.html

Report-3 :- https://kevin222004.github.io/reports/DetailAstImpl2/2023-08-27-T-21-38-05/checks-nonjavadoc-error-report/index.html

Report-4 :- https://kevin222004.github.io/reports/DetailAstImpl2/2023-08-27-T-21-38-05/sevntu-check-regression_part_2-report/index.html

Report-5 :- https://kevin222004.github.io/reports/DetailAstImpl2/2023-08-27-T-21-38-05/checks-only-javadoc-error-report/index.html

Report-6 :- https://kevin222004.github.io/reports/DetailAstImpl2/2023-08-27-T-21-38-05/part1-report/index.html

Report-7 :- https://kevin222004.github.io/reports/DetailAstImpl2/2023-08-27-T-21-38-05/part5-report/index.html

Report-8 :- https://kevin222004.github.io/reports/DetailAstImpl2/2023-08-27-T-21-38-05/part6-report/index.html

Report-9 :- https://kevin222004.github.io/reports/DetailAstImpl2/2023-08-27-T-21-38-05/part4-report/index.html

Report-10 :- https://kevin222004.github.io/reports/DetailAstImpl2/2023-08-27-T-21-38-05/antlr-report/index.html

Report-11 :- https://kevin222004.github.io/reports/DetailAstImpl2/2023-08-27-T-21-38-05/part2-report/index.html

Report-12 :- https://kevin222004.github.io/reports/DetailAstImpl2/2023-08-27-T-21-51-36/part3-report/index.html

Report-13 :- https://kevin222004.github.io/reports/DetailAstImpl2/2023-08-27-T-21-51-36/sevntu-check-regression_part_1-report/index.html

Report-14 :- https://kevin222004.github.io/reports/DetailAstImpl2/2023-08-27-T-21-51-36/checks-nonjavadoc-error-report/index.html

Report-15 :- https://kevin222004.github.io/reports/DetailAstImpl2/2023-08-27-T-21-51-36/sevntu-check-regression_part_2-report/index.html

Report-16 :- https://kevin222004.github.io/reports/DetailAstImpl2/2023-08-27-T-21-51-36/checks-only-javadoc-error-report/index.html

Report-17 :- https://kevin222004.github.io/reports/DetailAstImpl2/2023-08-27-T-21-51-36/part1-report/index.html

Report-18 :- https://kevin222004.github.io/reports/DetailAstImpl2/2023-08-27-T-21-51-36/part5-report/index.html

Report-19 :- https://kevin222004.github.io/reports/DetailAstImpl2/2023-08-27-T-21-51-36/part6-report/index.html

Report-20 :- https://kevin222004.github.io/reports/DetailAstImpl2/2023-08-27-T-21-51-36/part4-report/index.html

Report-21 :- https://kevin222004.github.io/reports/DetailAstImpl2/2023-08-27-T-21-51-36/antlr-report/index.html

Report-22 :- https://kevin222004.github.io/reports/DetailAstImpl2/2023-08-27-T-21-51-36/part2-report/index.html