### PR TITLE
Issue #13501: Kill mutation for DetailAstImpl-6

### DIFF
--- a/config/pitest-suppressions/pitest-common-2-suppressions.xml
+++ b/config/pitest-suppressions/pitest-common-2-suppressions.xml
@@ -72,23 +72,23 @@
     <lineContent>firstChild = null;</lineContent>
   </mutation>
 
-  <mutation unstable="false">
-    <sourceFile>DetailAstImpl.java</sourceFile>
-    <mutatedClass>com.puppycrawl.tools.checkstyle.DetailAstImpl</mutatedClass>
-    <mutatedMethod>toString</mutatedMethod>
-    <mutator>org.pitest.mutationtest.engine.gregor.mutators.NonVoidMethodCallMutator</mutator>
-    <description>removed call to com/puppycrawl/tools/checkstyle/DetailAstImpl::getColumnNo</description>
-    <lineContent>return text + &quot;[&quot; + getLineNo() + &quot;x&quot; + getColumnNo() + &quot;]&quot;;</lineContent>
-  </mutation>
 
-  <mutation unstable="false">
-    <sourceFile>DetailAstImpl.java</sourceFile>
-    <mutatedClass>com.puppycrawl.tools.checkstyle.DetailAstImpl</mutatedClass>
-    <mutatedMethod>toString</mutatedMethod>
-    <mutator>org.pitest.mutationtest.engine.gregor.mutators.NonVoidMethodCallMutator</mutator>
-    <description>removed call to com/puppycrawl/tools/checkstyle/DetailAstImpl::getLineNo</description>
-    <lineContent>return text + &quot;[&quot; + getLineNo() + &quot;x&quot; + getColumnNo() + &quot;]&quot;;</lineContent>
-  </mutation>
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
 
   <mutation unstable="false">
     <sourceFile>JavaParser.java</sourceFile>

--- a/src/test/java/com/puppycrawl/tools/checkstyle/DetailAstImplTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/DetailAstImplTest.java
@@ -652,11 +652,11 @@ public class DetailAstImplTest extends AbstractModuleTestSupport {
     public void testToString() {
         final DetailAstImpl ast = new DetailAstImpl();
         ast.setText("text");
-        ast.setColumnNo(0);
-        ast.setLineNo(0);
+        ast.setColumnNo(1);
+        ast.setLineNo(1);
         assertWithMessage("Invalid text")
             .that(ast.toString())
-            .isEqualTo("text[0x0]");
+            .isEqualTo("text[1x1]");
     }
 
     private static List<File> getAllFiles(File dir) {


### PR DESCRIPTION
Issue #13501: Kill mutation for DetailAstImpl-6

https://github.com/checkstyle/checkstyle/blob/master/src/main/java/com/puppycrawl/tools/checkstyle/DetailAstImpl.java

-------

# Mutations 
https://github.com/checkstyle/checkstyle/blob/88486f7ca9795f613d28fa6c2a53beccef521dfc/config/pitest-suppressions/pitest-common-2-suppressions.xml#L75-L91

------------

# Explaination

Test added

