### PR TITLE
Issue #13501: Kill mutation for DetailAstImpl-7

### DIFF
--- a/config/pitest-suppressions/pitest-common-2-suppressions.xml
+++ b/config/pitest-suppressions/pitest-common-2-suppressions.xml
@@ -63,14 +63,14 @@
 
 
 
-  <mutation unstable="false">
-    <sourceFile>DetailAstImpl.java</sourceFile>
-    <mutatedClass>com.puppycrawl.tools.checkstyle.DetailAstImpl</mutatedClass>
-    <mutatedMethod>removeChildren</mutatedMethod>
-    <mutator>org.pitest.mutationtest.engine.gregor.mutators.experimental.MemberVariableMutator</mutator>
-    <description>Removed assignment to member variable firstChild</description>
-    <lineContent>firstChild = null;</lineContent>
-  </mutation>
+
+
+
+
+
+
+
+
 
   <mutation unstable="false">
     <sourceFile>DetailAstImpl.java</sourceFile>

--- a/src/test/java/com/puppycrawl/tools/checkstyle/DetailAstImplTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/DetailAstImplTest.java
@@ -659,6 +659,21 @@ public class DetailAstImplTest extends AbstractModuleTestSupport {
             .isEqualTo("text[0x0]");
     }
 
+    @Test
+    public void testRemoveChildren() {
+        final DetailAstImpl parent = new DetailAstImpl();
+        final DetailAstImpl child1 = new DetailAstImpl();
+        parent.setFirstChild(child1);
+        final DetailAstImpl child2 = new DetailAstImpl();
+        child1.setNextSibling(child2);
+
+        parent.removeChildren();
+
+        assertWithMessage("")
+                .that(parent.getChildCount())
+                .isEqualTo(0);
+    }
+
     private static List<File> getAllFiles(File dir) {
         final List<File> result = new ArrayList<>();
 


### PR DESCRIPTION
Issue #13501: Kill mutation for DetailAstImpl-7

https://github.com/checkstyle/checkstyle/blob/master/src/main/java/com/puppycrawl/tools/checkstyle/DetailAstImpl.java

-------

# Mutations 
https://github.com/checkstyle/checkstyle/blob/88486f7ca9795f613d28fa6c2a53beccef521dfc/config/pitest-suppressions/pitest-common-2-suppressions.xml#L66-L73

------------

# Explaination

Test added

