### PR TITLE
Issue #13501: Kill mutation for JavaParser

### DIFF
--- a/config/pitest-suppressions/pitest-common-2-suppressions.xml
+++ b/config/pitest-suppressions/pitest-common-2-suppressions.xml
@@ -90,14 +90,14 @@
     <lineContent>return text + &quot;[&quot; + getLineNo() + &quot;x&quot; + getColumnNo() + &quot;]&quot;;</lineContent>
   </mutation>
 
-  <mutation unstable="false">
-    <sourceFile>JavaParser.java</sourceFile>
-    <mutatedClass>com.puppycrawl.tools.checkstyle.JavaParser</mutatedClass>
-    <mutatedMethod>appendHiddenCommentNodes</mutatedMethod>
-    <mutator>org.pitest.mutationtest.engine.gregor.mutators.returns.NullReturnValsMutator</mutator>
-    <description>replaced return value with null for com/puppycrawl/tools/checkstyle/JavaParser::appendHiddenCommentNodes</description>
-    <lineContent>return root;</lineContent>
-  </mutation>
+
+
+
+
+
+
+
+
 
   <mutation unstable="false">
     <sourceFile>JavaParser.java</sourceFile>

--- a/src/test/java/com/puppycrawl/tools/checkstyle/JavaParserTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/JavaParserTest.java
@@ -20,6 +20,7 @@
 package com.puppycrawl.tools.checkstyle;
 
 import static com.google.common.truth.Truth.assertWithMessage;
+import static com.puppycrawl.tools.checkstyle.checks.javadoc.JavadocContentLocationCheck.MSG_JAVADOC_CONTENT_SECOND_LINE;
 
 import java.io.File;
 import java.util.ArrayList;
@@ -32,6 +33,7 @@ import org.junit.jupiter.api.Test;
 import com.puppycrawl.tools.checkstyle.api.CheckstyleException;
 import com.puppycrawl.tools.checkstyle.api.DetailAST;
 import com.puppycrawl.tools.checkstyle.api.TokenTypes;
+import com.puppycrawl.tools.checkstyle.checks.javadoc.JavadocContentLocationCheck;
 import com.puppycrawl.tools.checkstyle.internal.utils.TestUtil;
 
 public class JavaParserTest extends AbstractModuleTestSupport {
@@ -272,6 +274,17 @@ public class JavaParserTest extends AbstractModuleTestSupport {
         assertWithMessage("File parsing should complete successfully.")
                 .that(JavaParser.parseFile(file, JavaParser.Options.WITH_COMMENTS))
                 .isNotNull();
+    }
+
+    @Test
+    public void testReturnValueOfAppendHiddenCommentNodes()
+            throws Exception {
+        final String[] expected = {
+            "9:1: " + getCheckMessage(JavadocContentLocationCheck.class,
+                    MSG_JAVADOC_CONTENT_SECOND_LINE),
+        };
+        verifyWithInlineConfigParser(
+                getPath("InputJavaParserHiddenComments4.java"), expected);
     }
 
     private static final class CountComments {

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/javaparser/InputJavaParserHiddenComments4.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/javaparser/InputJavaParserHiddenComments4.java
@@ -1,0 +1,14 @@
+/*
+com.puppycrawl.tools.checkstyle.checks.javadoc.JavadocContentLocationCheck
+
+
+*/
+
+package com.puppycrawl.tools.checkstyle.javaparser;
+// violation below 'Javadoc content should start from the next line after /*'
+/**Summary.
+ *
+ *
+ */
+public interface InputJavaParserHiddenComments4 {
+}


### PR DESCRIPTION
Issue #13501: Kill mutation for JavaParser

https://github.com/checkstyle/checkstyle/blob/master/src/main/java/com/puppycrawl/tools/checkstyle/JavaParser.java

-------

# Mutations 
https://github.com/checkstyle/checkstyle/blob/88486f7ca9795f613d28fa6c2a53beccef521dfc/config/pitest-suppressions/pitest-common-2-suppressions.xml#L93-L100

------------

# Explaination

Test added

