### PR TITLE
Pull #13656: Ensure only forward slashes are in relative link to parent module

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/site/ParentModuleMacro.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/site/ParentModuleMacro.java
@@ -97,6 +97,7 @@ public class ParentModuleMacro extends AbstractMacro {
                 .relativize(Paths.get("src", "xdocs", "config.xml"))
                 .toString()
                 .replace(".xml", ".html")
+                .replace('\\', '/')
                 + "#" + parentModule;
     }
 


### PR DESCRIPTION
Noticed in https://github.com/checkstyle/checkstyle/pull/13653

Enforces forward slashes in relative links to the parent module. Links to the parent module are generated by the `ParentModuleMacro` which constructs the link based on the location of the current Xdoc file and `src/xdocs/config.xml`. When that link is constructed, the system delimiter is used. On Ubuntu(`/`) that worked fine but on Windows the pathing delimiter is `\`.

