### PR TITLE
Issue #13501: Kill mutation for JavaParser2

### DIFF
--- a/config/pitest-suppressions/pitest-common-2-suppressions.xml
+++ b/config/pitest-suppressions/pitest-common-2-suppressions.xml
@@ -99,14 +99,14 @@
 
 
 
-  <mutation unstable="false">
-    <sourceFile>JavaParser.java</sourceFile>
-    <mutatedClass>com.puppycrawl.tools.checkstyle.JavaParser</mutatedClass>
-    <mutatedMethod>parseFile</mutatedMethod>
-    <mutator>org.pitest.mutationtest.engine.gregor.mutators.experimental.NakedReceiverMutator</mutator>
-    <description>replaced call to java/io/File::getAbsoluteFile with receiver</description>
-    <lineContent>final FileText text = new FileText(file.getAbsoluteFile(),</lineContent>
-  </mutation>
+
+
+
+
+
+
+
+
 
   <mutation unstable="false">
     <sourceFile>JavadocPropertiesGenerator.java</sourceFile>

--- a/src/main/java/com/puppycrawl/tools/checkstyle/JavaParser.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/JavaParser.java
@@ -137,7 +137,7 @@ public final class JavaParser {
      */
     public static DetailAST parseFile(File file, Options options)
             throws IOException, CheckstyleException {
-        final FileText text = new FileText(file.getAbsoluteFile(),
+        final FileText text = new FileText(file,
             StandardCharsets.UTF_8.name());
         return parseFileText(text, options);
     }


### PR DESCRIPTION
Issue #13501: Kill mutation for JavaParser2

https://github.com/Kevin222004/checkstyle/blob/master/src/main/java/com/puppycrawl/tools/checkstyle/JavaParser.java

-------

# Mutations 
https://github.com/checkstyle/checkstyle/blob/7007bef1f43a621757ae0b885818cf8baa0e6ef1/config/pitest-suppressions/pitest-common-2-suppressions.xml#L102-L109

------------

# Explaination

https://github.com/Kevin222004/checkstyle/blob/7007bef1f43a621757ae0b885818cf8baa0e6ef1/src/main/java/com/puppycrawl/tools/checkstyle/JavaParser.java#L140

The code is mutated as to remove `file.getAbsoluteFile()` --> `file` getAbsoluteFile this method will give the absolute path of file.

As per my research, the file from the parameter is already an absolute file path. I also don't think that test case is even possible because if we provide only filename then it will become exception. 

--------------

# Regression 

