### PR TITLE
Issue #13672: Kill mutation for JavadocMissingLeadingAsteriskCheck

### DIFF
--- a/config/pitest-suppressions/pitest-javadoc-suppressions.xml
+++ b/config/pitest-suppressions/pitest-javadoc-suppressions.xml
@@ -261,14 +261,14 @@
     <lineContent>lineNo = fullIdent.getLineNo();</lineContent>
   </mutation>
 
-  <mutation unstable="false">
-    <sourceFile>JavadocMissingLeadingAsteriskCheck.java</sourceFile>
-    <mutatedClass>com.puppycrawl.tools.checkstyle.checks.javadoc.JavadocMissingLeadingAsteriskCheck</mutatedClass>
-    <mutatedMethod>isLastLine</mutatedMethod>
-    <mutator>org.pitest.mutationtest.engine.gregor.mutators.RemoveConditionalMutator_EQUAL_IF</mutator>
-    <description>removed conditional - replaced equality check with true</description>
-    <lineContent>if (detailNode.getType() == JavadocTokenTypes.TEXT</lineContent>
-  </mutation>
+
+
+
+
+
+
+
+
 
   <mutation unstable="false">
     <sourceFile>JavadocNodeImpl.java</sourceFile>

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocMissingLeadingAsteriskCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocMissingLeadingAsteriskCheck.java
@@ -150,8 +150,7 @@ public class JavadocMissingLeadingAsteriskCheck extends AbstractJavadocCheck {
      */
     private static boolean isLastLine(DetailNode detailNode) {
         final DetailNode node;
-        if (detailNode.getType() == JavadocTokenTypes.TEXT
-                && CommonUtil.isBlank(detailNode.getText())) {
+        if (CommonUtil.isBlank(detailNode.getText())) {
             node = getNextNode(detailNode);
         }
         else {


### PR DESCRIPTION
Issue #13672: Kill mutation for JavadocMissingLeadingAsteriskCheck

---------

# Check :-  

https://checkstyle.org/checks/javadoc/javadocmissingleadingasterisk.html

----------

# Mutation 

https://github.com/checkstyle/checkstyle/blob/08814f209de43368cf9078a56e9175bf1f91f7a9/config/pitest-suppressions/pitest-javadoc-suppressions.xml#L264-L271

-----------

#  Exaplaination

I have tried various ways but whenever the asterisk is missing means the line is blank then that token is always a JavadocTokenTypes.TEXT

----------

# Regression:-   

Report-1 :- https://checkstyle-diff-reports.s3.us-east-2.amazonaws.com/aaa4542_2023215322/reports/diff/index.html

Report-2 :- https://checkstyle-diff-reports.s3.us-east-2.amazonaws.com/aaa4542_2023082849/reports/diff/index.html

------------

Diff Regression config: https://gist.githubusercontent.com/Kevin222004/a40a9f4ddbfed0d1fcb9ab6edf5ff597/raw/f8160ac02488ec6a3d342369b47aa51784e41ae8/JavadocMissingLeadingAsterisk.xml
Diff Regression projects: https://gist.githubusercontent.com/Kevin222004/21e3934e85f802e2fbd48af06d122364/raw/604256badd733d8568064f371d55657c04b00dfd/test-projects-2.properties
Report label: Regression-2