### PR TITLE
Issue #13213: Remove '//ok' comments from 'annotationlocation' package files

### DIFF
--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/annotation/annotationlocation/InputAnnotationLocationCorrect.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/annotation/annotationlocation/InputAnnotationLocationCorrect.java
@@ -14,78 +14,78 @@ package com.puppycrawl.tools.checkstyle.checks.annotation.annotationlocation;
 /* Config: default */
 
 
-@MyAnnotation6 // ok
-@MyAnnotation5 // ok
+@MyAnnotation6
+@MyAnnotation5
 class InputAnnotationLocationCorrect
 {
 
-    @MyAnnotation6 // ok
-    @MyAnnotation5 // ok
+    @MyAnnotation6
+    @MyAnnotation5
     public int a;
 
-    @MyAnnotation5 // ok
+    @MyAnnotation5
     public int b;
 
-    @MyAnnotation6 // ok
-    @MyAnnotation5 // ok
+    @MyAnnotation6
+    @MyAnnotation5
     public int c;
 
-    @MyAnnotation5 // ok
+    @MyAnnotation5
     public int d;
 
-    @MyAnnotation6 // ok
-    @MyAnnotation5 // ok
+    @MyAnnotation6
+    @MyAnnotation5
     public InputAnnotationLocationCorrect()
     {
         //comment
     }
-    @MyAnnotation5 // ok
-    @MyAnnotation6 // ok
+    @MyAnnotation5
+    @MyAnnotation6
     void foo1() {}
 
-    @MyAnnotation5 // ok
-    @MyAnnotation6 // ok
+    @MyAnnotation5
+    @MyAnnotation6
     void foo2() {}
 
-    @MyAnnotation5 // ok
-    @MyAnnotation6 // ok
-    @MyAnnotation3 // ok
-    @MyAnnotation4 // ok
+    @MyAnnotation5
+    @MyAnnotation6
+    @MyAnnotation3
+    @MyAnnotation4
     class InnerClass
     {
-        @MyAnnotation6 // ok
-        @MyAnnotation5 // ok
+        @MyAnnotation6
+        @MyAnnotation5
         public int a;
 
-        @MyAnnotation5 // ok
+        @MyAnnotation5
         public int b;
 
-        @MyAnnotation6 // ok
-        @MyAnnotation5 // ok
+        @MyAnnotation6
+        @MyAnnotation5
         public int c;
 
-        @MyAnnotation5 // ok
+        @MyAnnotation5
         public int d;
 
-        @MyAnnotation6 // ok
+        @MyAnnotation6
         public InnerClass()
         {
             // comment
         }
-        @MyAnnotation5 // ok
-        @MyAnnotation6 void foo1(int a) {} // ok
+        @MyAnnotation5
+        @MyAnnotation6 void foo1(int a) {}
 
-        @MyAnnotation5 // ok
-        @MyAnnotation6 // ok
+        @MyAnnotation5
+        @MyAnnotation6
         void foo2() {}
     }
 
-    @MyAnnotation5 // ok
-    @MyAnnotation6 // ok
+    @MyAnnotation5
+    @MyAnnotation6
     InnerClass anon = new InnerClass()
     {
-        @MyAnnotation6 // ok
-        @MyAnnotation5 // ok
+        @MyAnnotation6
+        @MyAnnotation5
         public int a;
 
         @MyAnnotation5 public int b;

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/annotation/annotationlocation/InputAnnotationLocationCustomAnnotationsDeclared.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/annotation/annotationlocation/InputAnnotationLocationCustomAnnotationsDeclared.java
@@ -14,13 +14,13 @@ package com.puppycrawl.tools.checkstyle.checks.annotation.annotationlocation;
 @MyAnnotation11 @MyAnnotation12 @MyAnnotation13 // 3 violations
 public class InputAnnotationLocationCustomAnnotationsDeclared {
 
-    @MyAnnotation13 // ok
+    @MyAnnotation13
     void method() {
 
     }
 
-    @MyAnnotation13 // ok
-    @MyAnnotation12 // ok
+    @MyAnnotation13
+    @MyAnnotation12
     void method2() {
 
     }

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/annotation/annotationlocation/InputAnnotationLocationDeprecatedAndCustom.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/annotation/annotationlocation/InputAnnotationLocationDeprecatedAndCustom.java
@@ -15,14 +15,14 @@ import java.lang.annotation.ElementType;
 import java.lang.annotation.Target;
 
 public class InputAnnotationLocationDeprecatedAndCustom {
-    @Deprecated // ok
+    @Deprecated
     public class Annotation
     {
         @Deprecated // <--method, separate line
-        public void test(@MyAnnotation String s) { // ok
+        public void test(@MyAnnotation String s) {
             @MyAnnotation // <--variable, separate line
             Integer i;
-            for (@MyAnnotation char c : s.toCharArray()) { // ok
+            for (@MyAnnotation char c : s.toCharArray()) {
             }
         }
     }

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/annotation/annotationlocation/InputAnnotationLocationEmpty.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/annotation/annotationlocation/InputAnnotationLocationEmpty.java
@@ -11,6 +11,6 @@ tokens = (default)CLASS_DEF, INTERFACE_DEF, PACKAGE_DEF, ENUM_CONSTANT_DEF, \
 
 package com.puppycrawl.tools.checkstyle.checks.annotation.annotationlocation;
 
-public class InputAnnotationLocationEmpty { // ok
+public class InputAnnotationLocationEmpty {
 
 }

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/annotation/annotationlocation/InputAnnotationLocationIncorrect.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/annotation/annotationlocation/InputAnnotationLocationIncorrect.java
@@ -22,26 +22,26 @@ class InputAnnotationLocationIncorrect
 
     @MyAnnotation1(value = "") public int b; // violation '.* should be alone on line.'
 
-    @MyAnn_21 // ok
+    @MyAnn_21
         @MyAnnotation1 // violation '.* incorrect .* level 8, .* should be 4.'
 (value = "")
     public int c;
 
-    @MyAnnotation1(value = "") // ok
+    @MyAnnotation1(value = "")
     public int d;
 
-    @MyAnn_21 // ok
+    @MyAnn_21
         @MyAnnotation1 // violation '.* incorrect .* level 8, .* should be 4.'
 (value = "")
     public InputAnnotationLocationIncorrect() {}
 
     @MyAnnotation1("foo") @MyAnn_21 void foo1() {} // 2 violations
 
-    @MyAnnotation1(value = "") // ok
+    @MyAnnotation1(value = "")
        @MyAnn_21 // violation '.* incorrect .* level 7, .* should be 4.'
     void foo2() {}
 
-    @MyAnnotation1(value = "") // ok
+    @MyAnnotation1(value = "")
         @MyAnn_21 // violation '.* incorrect .* level 8, .* should be 4.'
       @MyAnnotation3 // violation '.* incorrect .* level 6, .* should be 4.'
           @MyAnnotation4 // violation '.* incorrect .* level 10, .* should be 4.'
@@ -53,15 +53,15 @@ class InputAnnotationLocationIncorrect
 
         @MyAnnotation1(value = "") public int b; // violation '.* should be alone on line.'
 
-        @MyAnn_21 // ok
+        @MyAnn_21
             @MyAnnotation1 // violation '.* incorrect .* level 12, .* should be 8.'
 (value = "")
         public int c;
 
-        @MyAnnotation1(value = "") // ok
+        @MyAnnotation1(value = "")
         public int d;
 
-        @MyAnn_21 // ok
+        @MyAnn_21
         @MyAnnotation1(value = "") public InnerClass() // violation '.* should be alone on line.'
         {
             // comment
@@ -83,17 +83,17 @@ class InputAnnotationLocationIncorrect
 
         @MyAnnotation1(value = "") public int b; // violation '.* should be alone on line.'
 
-        @MyAnn_21 // ok
-        @MyAnnotation1(value = "") // ok
+        @MyAnn_21
+        @MyAnnotation1(value = "")
         public int c;
 
-        @MyAnnotation1(value = "") // ok
+        @MyAnnotation1(value = "")
         public int d;
 
-        @MyAnnotation1(value = "") // ok
+        @MyAnnotation1(value = "")
            @MyAnn_21 void foo1() {} // violation '.* incorrect .* level 11, .* should be 8.'
 
-        @MyAnnotation1(value = "") // ok
+        @MyAnnotation1(value = "")
           @MyAnn_21 // violation '.* incorrect .* level 10, .* should be 8.'
         void foo2() {}
         @MyAnnotation1(value = "") void foo42() {} // violation '.* should be alone on line.'
@@ -101,7 +101,7 @@ class InputAnnotationLocationIncorrect
 
 }
 
-   @MyAnnotation1 // ok
+   @MyAnnotation1
 (value = "")
 @MyAnn_21 // violation '.* incorrect .* level 0, .* should be 3.'
 class Foo {

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/annotation/annotationlocation/InputAnnotationLocationIncorrect2.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/annotation/annotationlocation/InputAnnotationLocationIncorrect2.java
@@ -11,104 +11,104 @@ tokens = (default)CLASS_DEF, INTERFACE_DEF, PACKAGE_DEF, ENUM_CONSTANT_DEF, \
 
 package com.puppycrawl.tools.checkstyle.checks.annotation.annotationlocation;
 
-@MyAnn_22 @com.puppycrawl.tools.checkstyle.checks.annotation.annotationlocation.MyAnn_2 // ok
+@MyAnn_22 @com.puppycrawl.tools.checkstyle.checks.annotation.annotationlocation.MyAnn_2
 (value = "")
 class InputAnnotationLocationIncorrect2
 {
 
-    @MyAnn_22 @MyAnnotation_12(value = "") // ok
+    @MyAnn_22 @MyAnnotation_12(value = "")
     public int a;
 
-    @MyAnnotation_12(value = "") public int b; // ok
+    @MyAnnotation_12(value = "") public int b;
 
-    @MyAnn_22 // ok
+    @MyAnn_22
         @MyAnnotation_12 // violation '.* incorrect .* level 8, .* should be 4.'
 (value = "")
     public int c;
 
-    @MyAnnotation_12(value = "") // ok
+    @MyAnnotation_12(value = "")
     public int d;
 
-    @MyAnn_22 // ok
+    @MyAnn_22
         @MyAnnotation_12 // violation '.* incorrect .* level 8, .* should be 4.'
 (value = "")
     public InputAnnotationLocationIncorrect2() {}
 
-    @MyAnnotation_12("foo") @MyAnn_22 void foo1() {} // ok
+    @MyAnnotation_12("foo") @MyAnn_22 void foo1() {}
 
-    @MyAnnotation_12(value = "") // ok
+    @MyAnnotation_12(value = "")
        @MyAnn_22 // violation '.*'MyAnn_22' have incorrect indentation level 7, .* should be 4.'
     void foo2() {}
 
-    @MyAnnotation_12(value = "") // ok
+    @MyAnnotation_12(value = "")
         @MyAnn_22 // violation '.* incorrect .* level 8, .* should be 4.'
       @MyAnnotation_32 // violation '.* incorrect .* level 6, .* should be 4.'
           @MyAnnotation_42 // violation '.* incorrect .* level 10, .* should be 4.'
     class InnerClass
     {
-        @MyAnn_22 @MyAnnotation_12 // ok
+        @MyAnn_22 @MyAnnotation_12
 (value = "")
         public int a;
 
-        @MyAnnotation_12(value = "") public int b; // ok
+        @MyAnnotation_12(value = "") public int b;
 
-        @MyAnn_22 // ok
+        @MyAnn_22
             @MyAnnotation_12 // violation '.* incorrect .* level 12, .* should be 8.'
 (value = "")
         public int c;
 
-        @MyAnnotation_12(value = "") // ok
+        @MyAnnotation_12(value = "")
         public int d;
 
-        @MyAnn_22 // ok
-        @MyAnnotation_12(value = "") public InnerClass() // ok
+        @MyAnn_22
+        @MyAnnotation_12(value = "") public InnerClass()
         {
             // comment
         }
-        @MyAnnotation_12(value = "") // ok
+        @MyAnnotation_12(value = "")
             @MyAnn_22 // violation '.* incorrect .* level 12, .* should be 8.'
         void foo1() {}
 
-        @MyAnnotation_12(value = "") // ok
+        @MyAnnotation_12(value = "")
             @MyAnn_22 // violation '.* incorrect .* level 12, .* should be 8.'
         void foo2() {}
     }
 
-    @MyAnnotation_12(value = "") // ok
+    @MyAnnotation_12(value = "")
        @MyAnn_22 // violation '.* incorrect .* level 7, .* should be 4.'
     InnerClass anon = new InnerClass()
     {
-        @MyAnn_22 @MyAnnotation_12(value = "") public int a; // ok
+        @MyAnn_22 @MyAnnotation_12(value = "") public int a;
 
-        @MyAnnotation_12(value = "") public int b; // ok
+        @MyAnnotation_12(value = "") public int b;
 
-        @MyAnn_22 // ok
-        @MyAnnotation_12(value = "") // ok
+        @MyAnn_22
+        @MyAnnotation_12(value = "")
         public int c;
 
-        @MyAnnotation_12(value = "") // ok
+        @MyAnnotation_12(value = "")
         public int d;
 
-        @MyAnnotation_12(value = "") // ok
+        @MyAnnotation_12(value = "")
            @MyAnn_22 void foo1() {} // violation '.* incorrect .* level 11, .* should be 8.'
 
-        @MyAnnotation_12(value = "") // ok
+        @MyAnnotation_12(value = "")
           @MyAnn_22 // violation '.* incorrect .* level 10, .* should be 8.'
         void foo2() {}
 
-        @MyAnnotation_12(value = "") void foo42() {} // ok
+        @MyAnnotation_12(value = "") void foo42() {}
     };
 
 }
 
-   @MyAnnotation_12 // ok
+   @MyAnnotation_12
 (value = "")
 @MyAnn_22 // violation '.*'MyAnn_22' have incorrect indentation level 0, .* should be 3.'
 class Foo2 {
-    public void method1(@MyAnnotation_32 @MyAnn_22 Object param1) { // ok
+    public void method1(@MyAnnotation_32 @MyAnn_22 Object param1) {
         try {
         }
-        catch (@MyAnnotation_32 @MyAnn_22 Exception e) { // ok
+        catch (@MyAnnotation_32 @MyAnn_22 Exception e) {
         }
         return;
     }

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/annotation/annotationlocation/InputAnnotationLocationIncorrect3.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/annotation/annotationlocation/InputAnnotationLocationIncorrect3.java
@@ -22,12 +22,12 @@ class InputAnnotationLocationIncorrect3
 
     @MyAnnotation_13(value = "") public int b; // violation '.* should be alone on line.'
 
-    @MyAnn_23 // ok
+    @MyAnn_23
         @MyAnnotation_13 // violation '.* incorrect .* level 8, .* should be 4.'
 (value = "")
     public int c;
 
-    @MyAnnotation_13(value = "") // ok
+    @MyAnnotation_13(value = "")
     public int d;
 
     @MyAnn_23
@@ -37,11 +37,11 @@ class InputAnnotationLocationIncorrect3
 
     @MyAnnotation_13("foo") @MyAnn_23 void foo1() {} // 2 violations
 
-    @MyAnnotation_13(value = "") // ok
+    @MyAnnotation_13(value = "")
        @MyAnn_23 // violation '.* incorrect .* level 7, .* should be 4.'
     void foo2() {}
 
-    @MyAnnotation_13(value = "") // ok
+    @MyAnnotation_13(value = "")
         @MyAnn_23 // violation '.* incorrect .* level 8, .* should be 4.'
       @MyAnnotation_33 // violation '.* incorrect .* level 6, .* should be 4.'
           @MyAnnotation_43 // violation '.* incorrect .* level 10, .* should be 4.'
@@ -53,12 +53,12 @@ class InputAnnotationLocationIncorrect3
 
         @MyAnnotation_13(value = "") public int b; // violation '.* should be alone on line.'
 
-        @MyAnn_23 // ok
+        @MyAnn_23
             @MyAnnotation_13 // violation '.* incorrect .* level 12, .* should be 8.'
 (value = "")
         public int c;
 
-        @MyAnnotation_13(value = "") // ok
+        @MyAnnotation_13(value = "")
         public int d;
 
         @MyAnn_23 // ok
@@ -66,16 +66,16 @@ class InputAnnotationLocationIncorrect3
         {
             // comment
         }
-        @MyAnnotation_13(value = "") // ok
+        @MyAnnotation_13(value = "")
             @MyAnn_23 // violation '.* incorrect .* level 12, .* should be 8.'
         void foo1() {}
 
-        @MyAnnotation_13(value = "") // ok
+        @MyAnnotation_13(value = "")
             @MyAnn_23 // violation '.*'MyAnn_23' have incorrect indentation level 12,.*should be 8.'
         void foo2() {}
     }
 
-    @MyAnnotation_13(value = "") // ok
+    @MyAnnotation_13(value = "")
        @MyAnn_23 // violation '.*'MyAnn_23' have incorrect indentation level 7,.*should be 4.'
     InnerClass3 anon = new InnerClass3()
     {
@@ -84,17 +84,17 @@ class InputAnnotationLocationIncorrect3
 
         @MyAnnotation_13(value = "") public int b; // violation '.* should be alone on line.'
 
-        @MyAnn_23 // ok
-        @MyAnnotation_13(value = "") // ok
+        @MyAnn_23
+        @MyAnnotation_13(value = "")
         public int c;
 
-        @MyAnnotation_13(value = "") // ok
+        @MyAnnotation_13(value = "")
         public int d;
 
-        @MyAnnotation_13(value = "") // ok
+        @MyAnnotation_13(value = "")
            @MyAnn_23 void foo1() {} // violation '.* incorrect .* level 11, .* should be 8.'
 
-        @MyAnnotation_13(value = "") // ok
+        @MyAnnotation_13(value = "")
           @MyAnn_23 // violation '.* incorrect .* level 10, .* should be 8.'
         void foo2() {}
 
@@ -103,7 +103,7 @@ class InputAnnotationLocationIncorrect3
 
 }
 
-   @MyAnnotation_13 // ok
+   @MyAnnotation_13
 (value = "")
 @MyAnn_23 // violation 'Annotation 'MyAnn_23' have incorrect indentation level 0, .* should be 3.'
 class Foo3 {

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/annotation/annotationlocation/InputAnnotationLocationMultiple.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/annotation/annotationlocation/InputAnnotationLocationMultiple.java
@@ -15,7 +15,7 @@ import java.lang.annotation.Repeatable;
 
 class InputAnnotationLocationMultiple {
 
-    @Annotation void singleParameterless() {} // ok
+    @Annotation void singleParameterless() {}
 
     @Annotation @Annotation void multipleParameterless() {}
 

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/annotation/annotationlocation/InputAnnotationLocationSingleParameterless.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/annotation/annotationlocation/InputAnnotationLocationSingleParameterless.java
@@ -31,10 +31,10 @@ class InputAnnotationLocationSingleParameterless {
     @Annotation("") @Annotation(value = "") void multipleParametrized() {} // 2 violations
 
     void parameterlessSamelineInForEach() {
-        for (@Annotation Object o : new Object[0]) break; //ok
-        for (@Annotation @Annotation Object o : new Object[0]) break; //ok
-        for (@Annotation Object o;;) break; // ok
-        for (@Annotation @Annotation Object o;;) break; //ok
+        for (@Annotation Object o : new Object[0]) break;
+        for (@Annotation @Annotation Object o : new Object[0]) break; //
+        for (@Annotation Object o;;) break;
+        for (@Annotation @Annotation Object o;;) break;
     }
 
     @Repeatable(Annotations.class)

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/annotation/annotationlocation/InputAnnotationLocationWithoutAnnotations.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/annotation/annotationlocation/InputAnnotationLocationWithoutAnnotations.java
@@ -12,7 +12,7 @@ tokens = CLASS_DEF, INTERFACE_DEF, ENUM_DEF, METHOD_DEF, CTOR_DEF, VARIABLE_DEF,
 package com.puppycrawl.tools.checkstyle.checks.annotation.annotationlocation;
 
 public class InputAnnotationLocationWithoutAnnotations {
-    public static void main(String[] args) { // ok
+    public static void main(String[] args) {
         final Foo foo = new Foo();
         foo.bar(new Bar<Foo>() {
             public void foo() {
@@ -25,7 +25,7 @@ public class InputAnnotationLocationWithoutAnnotations {
         }
     }
 
-    static abstract class Bar<T> { // ok
+    static abstract class Bar<T> {
         abstract void foo();
     }
 }

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/annotation/annotationlocation/inputs/PackageAnnotations.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/annotation/annotationlocation/inputs/PackageAnnotations.java
@@ -15,7 +15,7 @@ import java.lang.annotation.Target;
  */
 
 @Target(ElementType.PACKAGE)
-@interface PackageAnnotations { // ok
+@interface PackageAnnotations {
 
     PackageAnnotation[] value();
 


### PR DESCRIPTION
part of #13213 

Link to check package :  [clickhere](https://github.com/checkstyle/checkstyle/tree/master/src/test/resources/com/puppycrawl/tools/checkstyle/checks/annotation/annotationlocation)


