### PR TITLE
Issue #13666: Assert that properties are ordered alphabetically in xdoc

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/annotation/AnnotationUseStyleCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/annotation/AnnotationUseStyleCheck.java
@@ -98,16 +98,16 @@ import com.puppycrawl.tools.checkstyle.api.TokenTypes;
  * </p>
  * <ul>
  * <li>
- * Property {@code elementStyle} - Define the annotation element styles.
- * Type is {@code
- * com.puppycrawl.tools.checkstyle.checks.annotation.AnnotationUseStyleCheck$ElementStyleOption}.
- * Default value is {@code compact_no_array}.
- * </li>
- * <li>
  * Property {@code closingParens} - Define the policy for ending parenthesis.
  * Type is {@code
  * com.puppycrawl.tools.checkstyle.checks.annotation.AnnotationUseStyleCheck$ClosingParensOption}.
  * Default value is {@code never}.
+ * </li>
+ * <li>
+ * Property {@code elementStyle} - Define the annotation element styles.
+ * Type is {@code
+ * com.puppycrawl.tools.checkstyle.checks.annotation.AnnotationUseStyleCheck$ElementStyleOption}.
+ * Default value is {@code compact_no_array}.
  * </li>
  * <li>
  * Property {@code trailingArrayComma} - Define the policy for trailing comma in arrays.

--- a/src/main/resources/com/puppycrawl/tools/checkstyle/meta/checks/annotation/AnnotationUseStyleCheck.xml
+++ b/src/main/resources/com/puppycrawl/tools/checkstyle/meta/checks/annotation/AnnotationUseStyleCheck.xml
@@ -74,15 +74,15 @@
  Java Language specification, &amp;#167;9.7&lt;/a&gt;.
  &lt;/p&gt;</description>
          <properties>
-            <property default-value="compact_no_array"
-                      name="elementStyle"
-                      type="com.puppycrawl.tools.checkstyle.checks.annotation.AnnotationUseStyleCheck$ElementStyleOption">
-               <description>Define the annotation element styles.</description>
-            </property>
             <property default-value="never"
                       name="closingParens"
                       type="com.puppycrawl.tools.checkstyle.checks.annotation.AnnotationUseStyleCheck$ClosingParensOption">
                <description>Define the policy for ending parenthesis.</description>
+            </property>
+            <property default-value="compact_no_array"
+                      name="elementStyle"
+                      type="com.puppycrawl.tools.checkstyle.checks.annotation.AnnotationUseStyleCheck$ElementStyleOption">
+               <description>Define the annotation element styles.</description>
             </property>
             <property default-value="never"
                       name="trailingArrayComma"

--- a/src/test/java/com/puppycrawl/tools/checkstyle/internal/XdocsPagesTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/internal/XdocsPagesTest.java
@@ -226,6 +226,78 @@ public class XdocsPagesTest {
     private static final Set<String> GOOGLE_MODULES = Collections.unmodifiableSet(
         CheckUtil.getConfigGoogleStyleModules());
 
+    // until https://github.com/checkstyle/checkstyle/issues/13666
+    private static final Set<String> MODULES_WITH_UNORDERED_PROPERTIES = Set.of(
+        "Checker",
+        "MissingJavadocMethod",
+        "VariableDeclarationUsageDistance",
+        "LocalVariableName",
+        "JavadocTagContinuationIndentation",
+        "ClassFanOutComplexity",
+        "Translation",
+        "MethodCount",
+        "SummaryJavadoc",
+        "ClassDataAbstractionCoupling",
+        "JavadocMethod",
+        "VisibilityModifier",
+        "MethodLength",
+        "Regexp",
+        "Indentation",
+        "MethodName",
+        "AtclauseOrder",
+        "SuppressWithNearbyTextFilter",
+        "SuppressWithPlainTextCommentFilter",
+        "MemberName",
+        "AvoidStarImport",
+        "ReturnCount",
+        "StaticVariableName",
+        "AvoidEscapedUnicodeCharacters",
+        "ParameterNumber",
+        "RecordComponentNumber",
+        "RegexpSingleline",
+        "RegexpOnFilename",
+        "JavaNCSS",
+        "EmptyCatchBlock",
+        "ParameterName",
+        "IllegalThrows",
+        "HiddenField",
+        "SuppressionXpathSingleFilter",
+        "WhitespaceAround",
+        "RegexpSinglelineJava",
+        "ImportOrder",
+        "IllegalType",
+        "ConstantName",
+        "MutableException",
+        "JavadocType",
+        "CustomImportOrder",
+        "AnnotationLocation",
+        "Header",
+        "DescendantToken",
+        "RegexpMultiline",
+        "JavadocVariable",
+        "SuppressionSingleFilter",
+        "InterfaceMemberImpliedModifier",
+        "IllegalImport",
+        "NewlineAtEndOfFile",
+        "SingleLineJavadoc",
+        "MissingJavadocType",
+        "FileLength",
+        "RegexpHeader",
+        "ThrowsCount",
+        "SuppressionCommentFilter",
+        "TypeName",
+        "MagicNumber",
+        "NeedBraces",
+        "SeverityMatchFilter",
+        "SuppressWithNearbyCommentFilter",
+        "MultipleStringLiterals",
+        "LeftCurly",
+        "AbbreviationAsWordInName",
+        "EmptyLineSeparator",
+        "JavadocStyle",
+        "JavadocParagraph"
+    );
+
     /**
      * Generate xdoc content from templates before validation.
      * This method will be removed once
@@ -797,6 +869,10 @@ public class XdocsPagesTest {
                 .that(table.getNodeName())
                 .isEqualTo("table");
 
+            if (!MODULES_WITH_UNORDERED_PROPERTIES.contains(sectionName)) {
+                validatePropertySectionPropertiesOrder(fileName, sectionName, table, properties);
+            }
+
             validatePropertySectionProperties(fileName, sectionName, table, instance,
                     properties);
         }
@@ -805,6 +881,43 @@ public class XdocsPagesTest {
                 fileName + " section '" + sectionName + "' should show properties: " + properties)
             .that(properties)
             .isEmpty();
+    }
+
+    private static void validatePropertySectionPropertiesOrder(String fileName, String sectionName,
+                                                               Node table, Set<String> properties) {
+        final Set<Node> rows = XmlUtil.getChildrenElements(table);
+        final List<String> orderedPropertyNames = new ArrayList<>(properties);
+        final List<String> tablePropertyNames = new ArrayList<>();
+
+        // javadocTokens and tokens should be last
+        if (orderedPropertyNames.contains("javadocTokens")) {
+            orderedPropertyNames.remove("javadocTokens");
+            orderedPropertyNames.add("javadocTokens");
+        }
+        if (orderedPropertyNames.contains("tokens")) {
+            orderedPropertyNames.remove("tokens");
+            orderedPropertyNames.add("tokens");
+        }
+
+        rows
+            .stream()
+            // First row is header row
+            .skip(1)
+            .forEach(row -> {
+                final List<Node> columns = new ArrayList<>(XmlUtil.getChildrenElements(row));
+                assertWithMessage(fileName + " section '" + sectionName
+                        + "' should have the requested columns")
+                    .that(columns)
+                    .hasSize(5);
+
+                final String propertyName = columns.get(0).getTextContent();
+                tablePropertyNames.add(propertyName);
+            });
+
+        assertWithMessage(fileName + " section '" + sectionName
+                + "' should have properties in the requested order")
+            .that(tablePropertyNames)
+            .isEqualTo(orderedPropertyNames);
     }
 
     private static void fixCapturedProperties(String sectionName, Object instance, Class<?> clss,

--- a/src/xdocs/checks/annotation/annotationusestyle.xml
+++ b/src/xdocs/checks/annotation/annotationusestyle.xml
@@ -86,19 +86,6 @@
               <th>since</th>
             </tr>
             <tr>
-              <td>elementStyle</td>
-              <td>
-                Define the annotation element styles.
-              </td>
-              <td>
-                <a href="../../property_types.html#ElementStyleOption">ElementStyleOption</a>
-              </td>
-              <td>
-                <code>compact_no_array</code>
-              </td>
-              <td>5.0</td>
-            </tr>
-            <tr>
               <td>closingParens</td>
               <td>
                 Define the policy for ending parenthesis.
@@ -108,6 +95,19 @@
               </td>
               <td>
                 <code>never</code>
+              </td>
+              <td>5.0</td>
+            </tr>
+            <tr>
+              <td>elementStyle</td>
+              <td>
+                Define the annotation element styles.
+              </td>
+              <td>
+                <a href="../../property_types.html#ElementStyleOption">ElementStyleOption</a>
+              </td>
+              <td>
+                <code>compact_no_array</code>
               </td>
               <td>5.0</td>
             </tr>

--- a/src/xdocs/checks/annotation/annotationusestyle.xml.template
+++ b/src/xdocs/checks/annotation/annotationusestyle.xml.template
@@ -86,19 +86,6 @@
               <th>since</th>
             </tr>
             <tr>
-              <td>elementStyle</td>
-              <td>
-                Define the annotation element styles.
-              </td>
-              <td>
-                <a href="../../property_types.html#ElementStyleOption">ElementStyleOption</a>
-              </td>
-              <td>
-                <code>compact_no_array</code>
-              </td>
-              <td>5.0</td>
-            </tr>
-            <tr>
               <td>closingParens</td>
               <td>
                 Define the policy for ending parenthesis.
@@ -108,6 +95,19 @@
               </td>
               <td>
                 <code>never</code>
+              </td>
+              <td>5.0</td>
+            </tr>
+            <tr>
+              <td>elementStyle</td>
+              <td>
+                Define the annotation element styles.
+              </td>
+              <td>
+                <a href="../../property_types.html#ElementStyleOption">ElementStyleOption</a>
+              </td>
+              <td>
+                <code>compact_no_array</code>
               </td>
               <td>5.0</td>
             </tr>


### PR DESCRIPTION
Resolves #13666 

- Adds extra check in `XdocsPagesTest` to assert that the properties are ordered alphabetically with `javadocTokens` and `tokens` being last
- Adds a suppression list of all modules whose properties are not ordered
- Orders the properties of `AnnotationUseStyle`