### PR TITLE
Issue #13668: Order properties alphabetically in annotation checks

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/annotation/AnnotationLocationCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/annotation/AnnotationLocationCheck.java
@@ -65,16 +65,16 @@ import com.puppycrawl.tools.checkstyle.utils.TokenUtil;
  * Default value is {@code false}.
  * </li>
  * <li>
- * Property {@code allowSamelineSingleParameterlessAnnotation} - Allow single parameterless
- * annotation to be located on the same line as target element.
- * Type is {@code boolean}.
- * Default value is {@code true}.
- * </li>
- * <li>
  * Property {@code allowSamelineParameterizedAnnotation} - Allow one and only parameterized
  * annotation to be located on the same line as target element.
  * Type is {@code boolean}.
  * Default value is {@code false}.
+ * </li>
+ * <li>
+ * Property {@code allowSamelineSingleParameterlessAnnotation} - Allow single parameterless
+ * annotation to be located on the same line as target element.
+ * Type is {@code boolean}.
+ * Default value is {@code true}.
  * </li>
  * <li>
  * Property {@code tokens} - tokens to check

--- a/src/main/resources/com/puppycrawl/tools/checkstyle/meta/checks/annotation/AnnotationLocationCheck.xml
+++ b/src/main/resources/com/puppycrawl/tools/checkstyle/meta/checks/annotation/AnnotationLocationCheck.xml
@@ -41,16 +41,16 @@
                <description>Allow annotation(s) to be located on
  the same line as target element.</description>
             </property>
-            <property default-value="true"
-                      name="allowSamelineSingleParameterlessAnnotation"
-                      type="boolean">
-               <description>Allow single parameterless
- annotation to be located on the same line as target element.</description>
-            </property>
             <property default-value="false"
                       name="allowSamelineParameterizedAnnotation"
                       type="boolean">
                <description>Allow one and only parameterized
+ annotation to be located on the same line as target element.</description>
+            </property>
+            <property default-value="true"
+                      name="allowSamelineSingleParameterlessAnnotation"
+                      type="boolean">
+               <description>Allow single parameterless
  annotation to be located on the same line as target element.</description>
             </property>
             <property default-value="CLASS_DEF,INTERFACE_DEF,PACKAGE_DEF,ENUM_CONSTANT_DEF,ENUM_DEF,METHOD_DEF,CTOR_DEF,VARIABLE_DEF,RECORD_DEF,COMPACT_CTOR_DEF"

--- a/src/test/java/com/puppycrawl/tools/checkstyle/internal/XdocsPagesTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/internal/XdocsPagesTest.java
@@ -270,7 +270,6 @@ public class XdocsPagesTest {
         "MutableException",
         "JavadocType",
         "CustomImportOrder",
-        "AnnotationLocation",
         "Header",
         "DescendantToken",
         "RegexpMultiline",

--- a/src/xdocs/checks/annotation/annotationlocation.xml
+++ b/src/xdocs/checks/annotation/annotationlocation.xml
@@ -59,20 +59,20 @@ public String getNameIfPresent() { ... }
               <td>6.0</td>
             </tr>
             <tr>
-              <td>allowSamelineSingleParameterlessAnnotation</td>
-              <td>Allow single parameterless annotation to be located on the same line as
-                  target element.</td>
-              <td><a href="../../property_types.html#boolean">boolean</a></td>
-              <td><code>true</code></td>
-              <td>6.1</td>
-            </tr>
-            <tr>
               <td>allowSamelineParameterizedAnnotation</td>
               <td>Allow one and only parameterized annotation to be located on the same line as
                   target element.</td>
               <td><a href="../../property_types.html#boolean">boolean</a></td>
               <td><code>false</code></td>
               <td>6.4</td>
+            </tr>
+            <tr>
+              <td>allowSamelineSingleParameterlessAnnotation</td>
+              <td>Allow single parameterless annotation to be located on the same line as
+                  target element.</td>
+              <td><a href="../../property_types.html#boolean">boolean</a></td>
+              <td><code>true</code></td>
+              <td>6.1</td>
             </tr>
             <tr>
               <td>tokens</td>

--- a/src/xdocs/checks/annotation/annotationlocation.xml.template
+++ b/src/xdocs/checks/annotation/annotationlocation.xml.template
@@ -59,20 +59,20 @@ public String getNameIfPresent() { ... }
               <td>6.0</td>
             </tr>
             <tr>
-              <td>allowSamelineSingleParameterlessAnnotation</td>
-              <td>Allow single parameterless annotation to be located on the same line as
-                  target element.</td>
-              <td><a href="../../property_types.html#boolean">boolean</a></td>
-              <td><code>true</code></td>
-              <td>6.1</td>
-            </tr>
-            <tr>
               <td>allowSamelineParameterizedAnnotation</td>
               <td>Allow one and only parameterized annotation to be located on the same line as
                   target element.</td>
               <td><a href="../../property_types.html#boolean">boolean</a></td>
               <td><code>false</code></td>
               <td>6.4</td>
+            </tr>
+            <tr>
+              <td>allowSamelineSingleParameterlessAnnotation</td>
+              <td>Allow single parameterless annotation to be located on the same line as
+                  target element.</td>
+              <td><a href="../../property_types.html#boolean">boolean</a></td>
+              <td><code>true</code></td>
+              <td>6.1</td>
             </tr>
             <tr>
               <td>tokens</td>


### PR DESCRIPTION
Part of #13668

Orders properties in annotation checks alphabetically - `AnnotationLocationCheck`