### PR TITLE
Issue #13213: Remove '//ok' comments from Input files (InputGenericWhitespace)

### DIFF
--- a/config/checkstyle-input-suppressions.xml
+++ b/config/checkstyle-input-suppressions.xml
@@ -7842,16 +7842,6 @@
   <suppress id="UnnecessaryOkComment"
             files="checks[\\/]whitespace[\\/]emptylineseparator[\\/]packageinfo[\\/]test2[\\/]package-info.java"/>
   <suppress id="UnnecessaryOkComment"
-            files="checks[\\/]whitespace[\\/]genericwhitespace[\\/]InputGenericWhitespaceEndsTheLine.java"/>
-  <suppress id="UnnecessaryOkComment"
-            files="checks[\\/]whitespace[\\/]genericwhitespace[\\/]InputGenericWhitespaceInnerClass.java"/>
-  <suppress id="UnnecessaryOkComment"
-            files="checks[\\/]whitespace[\\/]genericwhitespace[\\/]InputGenericWhitespaceList.java"/>
-  <suppress id="UnnecessaryOkComment"
-            files="checks[\\/]whitespace[\\/]genericwhitespace[\\/]InputGenericWhitespaceMethodRef1.java"/>
-  <suppress id="UnnecessaryOkComment"
-            files="checks[\\/]whitespace[\\/]genericwhitespace[\\/]InputGenericWhitespaceWithEmoji.java"/>
-  <suppress id="UnnecessaryOkComment"
             files="checks[\\/]whitespace[\\/]methodparampad[\\/]InputMethodParamPad4.java"/>
   <suppress id="UnnecessaryOkComment"
             files="checks[\\/]whitespace[\\/]methodparampad[\\/]InputMethodParamPadSetOptionTrim.java"/>

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/whitespace/genericwhitespace/InputGenericWhitespaceEndsTheLine.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/whitespace/genericwhitespace/InputGenericWhitespaceEndsTheLine.java
@@ -6,7 +6,7 @@ GenericWhitespace
 
 package com.puppycrawl.tools.checkstyle.checks.whitespace.genericwhitespace;
 
-public class InputGenericWhitespaceEndsTheLine { // ok
+public class InputGenericWhitespaceEndsTheLine {
     public boolean returnsGenericObjectAtEndOfLine(Object otherObject) {
         return otherObject instanceof Enum<?>;
     }

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/whitespace/genericwhitespace/InputGenericWhitespaceInnerClass.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/whitespace/genericwhitespace/InputGenericWhitespaceInnerClass.java
@@ -4,7 +4,7 @@ GenericWhitespace
 
 */
 
-package com.puppycrawl.tools.checkstyle.checks.whitespace.genericwhitespace; // ok
+package com.puppycrawl.tools.checkstyle.checks.whitespace.genericwhitespace;
 
 import java.util.List;
 

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/whitespace/genericwhitespace/InputGenericWhitespaceList.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/whitespace/genericwhitespace/InputGenericWhitespaceList.java
@@ -8,7 +8,7 @@ package com.puppycrawl.tools.checkstyle.checks.whitespace.genericwhitespace;
 
 import java.util.List;
 
-public class InputGenericWhitespaceList // ok
+public class InputGenericWhitespaceList
 {
     public List<List<String>[]> listOfListOFArrays;
 }

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/whitespace/genericwhitespace/InputGenericWhitespaceMethodRef1.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/whitespace/genericwhitespace/InputGenericWhitespaceMethodRef1.java
@@ -8,7 +8,7 @@ package com.puppycrawl.tools.checkstyle.checks.whitespace.genericwhitespace;
 import java.util.function.Supplier;
 public class InputGenericWhitespaceMethodRef1
 {
-  public static class SomeClass { // ok
+  public static class SomeClass {
     public static class Nested<V> {
       private Nested() {
       }

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/whitespace/genericwhitespace/InputGenericWhitespaceWithEmoji.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/whitespace/genericwhitespace/InputGenericWhitespaceWithEmoji.java
@@ -12,7 +12,7 @@ import java.util.function.Supplier;
 
 public class InputGenericWhitespaceWithEmoji {
 
-    /* 👇🏻dsad */public static class SomeClass { /* 😂 */ // ok
+    /* 👇🏻dsad */public static class SomeClass { /* 😂 */
 
         public static class Nested<V> {
 


### PR DESCRIPTION
Part of https://github.com/checkstyle/checkstyle/issues/13213

Link to check documentation: https://checkstyle.org/checks/whitespace/genericwhitespace.html

```
➜  checkstyle git:(master) grep genericwhitespace config/checkstyle-input-suppressions.xml
            files="checks[\\/]whitespace[\\/]genericwhitespace[\\/]InputGenericWhitespaceEndsTheLine.java"/>
            files="checks[\\/]whitespace[\\/]genericwhitespace[\\/]InputGenericWhitespaceInnerClass.java"/>
            files="checks[\\/]whitespace[\\/]genericwhitespace[\\/]InputGenericWhitespaceList.java"/>
            files="checks[\\/]whitespace[\\/]genericwhitespace[\\/]InputGenericWhitespaceMethodRef1.java"/>
            files="checks[\\/]whitespace[\\/]genericwhitespace[\\/]InputGenericWhitespaceWithEmoji.java"/>
➜  checkstyle git:(master) echo $?                                                             
0

➜  checkstyle git:(remove-ok-InputGenericWhitespaceList) grep genericwhitespace config/checkstyle-input-suppressions.xml
➜  checkstyle git:(remove-ok-InputGenericWhitespaceList) echo $?      
1
```