### PR TITLE
Issue #13680: Simplify requirement for what we consider a setter method in ClassAndPropertiesSettersJavadocScraper

### DIFF
--- a/config/checker-framework-suppressions/checker-nullness-optional-interning-suppressions.xml
+++ b/config/checker-framework-suppressions/checker-nullness-optional-interning-suppressions.xml
@@ -6228,17 +6228,6 @@
 
   <checkerFrameworkError unstable="false">
     <fileName>src/main/java/com/puppycrawl/tools/checkstyle/site/SiteUtil.java</fileName>
-    <specifier>argument</specifier>
-    <message>incompatible argument for parameter value of putIfAbsent.</message>
-    <lineContent>javadocs.putIfAbsent(property, SUPER_CLASS_PROPERTIES_JAVADOCS.get(property));</lineContent>
-    <details>
-      found   : @Initialized @Nullable DetailNode
-      required: @Initialized @NonNull DetailNode
-    </details>
-  </checkerFrameworkError>
-
-  <checkerFrameworkError unstable="false">
-    <fileName>src/main/java/com/puppycrawl/tools/checkstyle/site/SiteUtil.java</fileName>
     <specifier>dereference.of.nullable</specifier>
     <message>dereference of possibly-null reference currentClass</message>
     <lineContent>result = currentClass.getDeclaredField(propertyName);</lineContent>

--- a/src/main/java/com/puppycrawl/tools/checkstyle/site/ClassAndPropertiesSettersJavadocScraper.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/site/ClassAndPropertiesSettersJavadocScraper.java
@@ -23,7 +23,6 @@ import java.beans.Introspector;
 import java.util.Collections;
 import java.util.LinkedHashMap;
 import java.util.Map;
-import java.util.Set;
 import java.util.regex.Pattern;
 
 import com.puppycrawl.tools.checkstyle.FileStatefulCheck;
@@ -47,12 +46,6 @@ public class ClassAndPropertiesSettersJavadocScraper extends AbstractJavadocChec
      */
     private static final Map<String, DetailNode> JAVADOC_FOR_MODULE_OR_PROPERTY =
             new LinkedHashMap<>();
-
-    /** List of setter methods that the scraper ignores but shouldn't. */
-    private static final Set<String> SUPERCLASS_SETTERS = Set.of(
-        "AbstractFileSetCheck.setFileExtensions",
-        "AbstractHeaderCheck.setHeader"
-    );
 
     /** Name of the module being scraped. */
     private static String moduleName = "";
@@ -88,13 +81,12 @@ public class ClassAndPropertiesSettersJavadocScraper extends AbstractJavadocChec
         final DetailAST blockCommentAst = getBlockCommentAst();
         if (BlockCommentPosition.isOnMethod(blockCommentAst)) {
             final DetailAST methodDef = getParentAst(blockCommentAst, TokenTypes.METHOD_DEF);
-            if (methodDef != null) {
+            if (methodDef != null
+                    && isSetterMethod(methodDef)
+                    && isMethodOfScrapedModule(methodDef)) {
                 final String methodName = methodDef.findFirstToken(TokenTypes.IDENT).getText();
-                if (isSetterMethod(methodDef) && isMethodOfScrapedModule(methodDef)
-                    || SUPERCLASS_SETTERS.contains(moduleName + "." + methodName)) {
-                    final String propertyName = getPropertyName(methodName);
-                    JAVADOC_FOR_MODULE_OR_PROPERTY.put(propertyName, ast);
-                }
+                final String propertyName = getPropertyName(methodName);
+                JAVADOC_FOR_MODULE_OR_PROPERTY.put(propertyName, ast);
             }
 
         }
@@ -169,34 +161,12 @@ public class ClassAndPropertiesSettersJavadocScraper extends AbstractJavadocChec
     private static boolean isSetterMethod(DetailAST ast) {
         boolean setterMethod = false;
 
-        // Check have a method with exactly 7 children which are all that
-        // is allowed in a proper setter method which does not throw any
-        // exceptions.
-        final int setterGetterMaxChildren = 7;
-        if (ast.getType() == TokenTypes.METHOD_DEF
-                && ast.getChildCount() == setterGetterMaxChildren) {
+        if (ast.getType() == TokenTypes.METHOD_DEF) {
             final DetailAST type = ast.findFirstToken(TokenTypes.TYPE);
             final String name = type.getNextSibling().getText();
             final Pattern setterPattern = Pattern.compile("^set[A-Z].*");
-            final boolean matchesSetterFormat = setterPattern.matcher(name).matches();
 
-            final DetailAST params = ast.findFirstToken(TokenTypes.PARAMETERS);
-            final boolean singleParam = params.getChildCount(TokenTypes.PARAMETER_DEF) == 1;
-
-            if (matchesSetterFormat && singleParam) {
-                // Now verify that the body consists of:
-                // SLIST -> EXPR -> ASSIGN
-                // SEMI
-                // RCURLY
-                final DetailAST slist = ast.findFirstToken(TokenTypes.SLIST);
-
-                // Maximum nodes allowed in a body of setter
-                final int setterBodySize = 3;
-                if (slist != null && slist.getChildCount() == setterBodySize) {
-                    final DetailAST expr = slist.getFirstChild();
-                    setterMethod = expr.getFirstChild().getType() == TokenTypes.ASSIGN;
-                }
-            }
+            setterMethod = setterPattern.matcher(name).matches();
         }
         return setterMethod;
     }

--- a/src/xdocs/checks/coding/matchxpath.xml.template
+++ b/src/xdocs/checks/coding/matchxpath.xml.template
@@ -37,22 +37,10 @@
 
       <subsection name="Properties" id="Properties">
         <div class="wrapper">
-          <table>
-            <tr>
-              <th>name</th>
-              <th>description</th>
-              <th>type</th>
-              <th>default value</th>
-              <th>since</th>
-            </tr>
-            <tr>
-              <td>query</td>
-              <td>Specify Xpath query.</td>
-              <td><a href="../../property_types.html#String">String</a></td>
-              <td><code>""</code></td>
-              <td>8.39</td>
-            </tr>
-          </table>
+          <macro name="properties">
+            <param name="modulePath"
+              value="src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/MatchXpathCheck.java"/>
+          </macro>
         </div>
       </subsection>
 


### PR DESCRIPTION
Resolves #13680 

---
- Simplifies `isSetterMethod()` to only check if the method name starts with `set`
- Ensures that we do not get `NullPointerException` if a Javadoc is missing but a better message