### PR TITLE
Issue #13213: Remove '//ok' comments from arraytypestyle package

### DIFF
--- a/config/checkstyle-input-suppressions.xml
+++ b/config/checkstyle-input-suppressions.xml
@@ -1804,12 +1804,6 @@
   <suppress id="UnnecessaryOkComment"
             files="checks[\\/]annotation[\\/]suppresswarnings[\\/]InputSuppressWarningsValuePair.java"/>
   <suppress id="UnnecessaryOkComment"
-            files="checks[\\/]arraytypestyle[\\/]InputArrayTypeStyleNestedGenerics.java"/>
-  <suppress id="UnnecessaryOkComment"
-            files="checks[\\/]arraytypestyle[\\/]InputArrayTypeStyleNestedGenerics.java"/>
-  <suppress id="UnnecessaryOkComment"
-            files="checks[\\/]arraytypestyle[\\/]InputArrayTypeStyleNestedGenerics.java"/>
-  <suppress id="UnnecessaryOkComment"
             files="checks[\\/]avoidescapedunicodecharacters[\\/]InputAvoidEscapedUnicodeCharactersAllEscapedUnicodeCharacters.java"/>
   <suppress id="UnnecessaryOkComment"
             files="checks[\\/]avoidescapedunicodecharacters[\\/]InputAvoidEscapedUnicodeCharactersAllEscapedUnicodeCharacters.java"/>

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/arraytypestyle/InputArrayTypeStyleNestedGenerics.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/arraytypestyle/InputArrayTypeStyleNestedGenerics.java
@@ -8,9 +8,9 @@ javaStyle = (default)true
 package com.puppycrawl.tools.checkstyle.checks.arraytypestyle;
 
 public class InputArrayTypeStyleNestedGenerics {
-    protected Pair<Integer, Object>[] values1; // ok
-    protected Pair<Integer, Pair<String, Object>[]>[] values2; // ok
-    protected Pair<Integer, Pair<String, Pair<String, Object>>[]>[] values3a; // ok
+    protected Pair<Integer, Object>[] values1;
+    protected Pair<Integer, Pair<String, Object>[]>[] values2;
+    protected Pair<Integer, Pair<String, Pair<String, Object>>[]>[] values3a;
     protected Pair<
         Integer,
         Pair<


### PR DESCRIPTION
part of #13213 

Link to check documentation : [Click Here](https://checkstyle.sourceforge.io/checks/misc/arraytypestyle.html#ArrayTypeStyle)

proof that all supressions for this check are removed : 

```
rajro@DESKTOP-HSV42DL MINGW64 ~/checkstyle (master)
$ grep arraytypestyle config/checkstyle-input-suppressions.xml
            files="checks[\\/]arraytypestyle[\\/]InputArrayTypeStyleNestedGenerics.java"/>
            files="checks[\\/]arraytypestyle[\\/]InputArrayTypeStyleNestedGenerics.java"/>
            files="checks[\\/]arraytypestyle[\\/]InputArrayTypeStyleNestedGenerics.java"/>

rajro@DESKTOP-HSV42DL MINGW64 ~/checkstyle (master)
$ git checkout issue-13213-arraytypestyle
Switched to branch 'issue-13213-arraytypestyle'

rajro@DESKTOP-HSV42DL MINGW64 ~/checkstyle (issue-13213-arraytypestyle)
$ grep arraytypestyle config/checkstyle-input-suppressions.xml

rajro@DESKTOP-HSV42DL MINGW64 ~/checkstyle (issue-13213-arraytypestyle)
$ echo $?
1

```
