### PR TITLE
Issue #13213: Remove '//ok' comments from Input files (AvoidStaticImport)

### DIFF
--- a/config/checkstyle-input-suppressions.xml
+++ b/config/checkstyle-input-suppressions.xml
@@ -3542,8 +3542,6 @@
   <suppress id="UnnecessaryOkComment"
             files="checks[\\/]finalparameters[\\/]InputFinalParametersReceiver.java"/>
   <suppress id="UnnecessaryOkComment"
-            files="checks[\\/]imports[\\/]avoidstaticimport[\\/]InputAvoidStaticImportNestedClass.java"/>
-  <suppress id="UnnecessaryOkComment"
             files="checks[\\/]imports[\\/]importorder[\\/]InputImportOrderBeginTree.java"/>
   <suppress id="UnnecessaryOkComment"
             files="checks[\\/]imports[\\/]importorder[\\/]InputImportOrderBug.java"/>

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/imports/avoidstaticimport/InputAvoidStaticImportNestedClass.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/imports/avoidstaticimport/InputAvoidStaticImportNestedClass.java
@@ -6,7 +6,7 @@ No config
 
 package com.puppycrawl.tools.checkstyle.checks.imports.avoidstaticimport;
 
-public class InputAvoidStaticImportNestedClass{ // ok
+public class InputAvoidStaticImportNestedClass{
     public static Integer zero=0;
 
     public static class InnerClass {


### PR DESCRIPTION
part of https://github.com/checkstyle/checkstyle/issues/13213

link to check documentation: https://checkstyle.org/checks/imports/avoidstaticimport.html

```
% grep -A 1 'UnnecessaryOkComment' checkstyle-input-suppressions.xml | grep -B 1 'avoidstaticimport'
  <suppress id="UnnecessaryOkComment"
            files="checks[\\/]imports[\\/]avoidstaticimport[\\/]InputAvoidStaticImportNestedClass.java"/>

% grep -A 1 'UnnecessaryOkComment' checkstyle-input-suppressions.xml | grep -B 1 'avoidstaticimport'| sed '/^--$/d' | grep -c 'UnnecessaryOkComment'
1

% grep -A 1 'UnnecessaryOkComment' checkstyle-input-suppressions.xml | grep -B 1 'avoidstaticimport'
% grep -A 1 'UnnecessaryOkComment' checkstyle-input-suppressions.xml | grep -B 1 'avoidstaticimport'| sed '/^--$/d' | grep -c 'UnnecessaryOkComment'
0
```
