### PR TITLE
Issue #13693: use property macros in few coding modules

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/ExplicitInitializationCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/ExplicitInitializationCheck.java
@@ -43,7 +43,7 @@ import com.puppycrawl.tools.checkstyle.utils.ScopeUtil;
  * </p>
  * <ul>
  * <li>
- * Property {@code onlyObjectReferences} - control whether only explicit
+ * Property {@code onlyObjectReferences} - Control whether only explicit
  * initializations made to null for objects should be checked.
  * Type is {@code boolean}.
  * Default value is {@code false}.

--- a/src/main/resources/com/puppycrawl/tools/checkstyle/meta/checks/coding/ExplicitInitializationCheck.xml
+++ b/src/main/resources/com/puppycrawl/tools/checkstyle/meta/checks/coding/ExplicitInitializationCheck.xml
@@ -20,7 +20,7 @@
  &lt;/p&gt;</description>
          <properties>
             <property default-value="false" name="onlyObjectReferences" type="boolean">
-               <description>control whether only explicit
+               <description>Control whether only explicit
  initializations made to null for objects should be checked.</description>
             </property>
          </properties>

--- a/src/xdocs/checks/coding/equalsavoidnull.xml
+++ b/src/xdocs/checks/coding/equalsavoidnull.xml
@@ -38,9 +38,7 @@
             </tr>
             <tr>
               <td>ignoreEqualsIgnoreCase</td>
-              <td>
-                Control whether to ignore <code>String.equalsIgnoreCase(String)</code> invocations.
-              </td>
+              <td>Control whether to ignore <code>String.equalsIgnoreCase(String)</code> invocations.</td>
               <td><a href="../../property_types.html#boolean">boolean</a></td>
               <td><code>false</code></td>
               <td>5.4</td>

--- a/src/xdocs/checks/coding/equalsavoidnull.xml.template
+++ b/src/xdocs/checks/coding/equalsavoidnull.xml.template
@@ -28,24 +28,10 @@
 
       <subsection name="Properties" id="Properties">
         <div class="wrapper">
-          <table>
-            <tr>
-              <th>name</th>
-              <th>description</th>
-              <th>type</th>
-              <th>default value</th>
-              <th>since</th>
-            </tr>
-            <tr>
-              <td>ignoreEqualsIgnoreCase</td>
-              <td>
-                Control whether to ignore <code>String.equalsIgnoreCase(String)</code> invocations.
-              </td>
-              <td><a href="../../property_types.html#boolean">boolean</a></td>
-              <td><code>false</code></td>
-              <td>5.4</td>
-            </tr>
-          </table>
+          <macro name="properties">
+            <param name="modulePath"
+              value="src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/EqualsAvoidNullCheck.java"/>
+          </macro>
         </div>
       </subsection>
 

--- a/src/xdocs/checks/coding/explicitinitialization.xml
+++ b/src/xdocs/checks/coding/explicitinitialization.xml
@@ -36,8 +36,7 @@
             </tr>
             <tr>
               <td>onlyObjectReferences</td>
-              <td>control whether only explicit initializations made to
-                  null for objects should be checked.</td>
+              <td>Control whether only explicit initializations made to null for objects should be checked.</td>
               <td><a href="../../property_types.html#boolean">boolean</a></td>
               <td><code>false</code></td>
               <td>7.8</td>

--- a/src/xdocs/checks/coding/explicitinitialization.xml.template
+++ b/src/xdocs/checks/coding/explicitinitialization.xml.template
@@ -26,23 +26,10 @@
 
       <subsection name="Properties" id="Properties">
         <div class="wrapper">
-          <table>
-            <tr>
-              <th>name</th>
-              <th>description</th>
-              <th>type</th>
-              <th>default value</th>
-              <th>since</th>
-            </tr>
-            <tr>
-              <td>onlyObjectReferences</td>
-              <td>control whether only explicit initializations made to
-                  null for objects should be checked.</td>
-              <td><a href="../../property_types.html#boolean">boolean</a></td>
-              <td><code>false</code></td>
-              <td>7.8</td>
-            </tr>
-          </table>
+          <macro name="properties">
+            <param name="modulePath"
+              value="src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/ExplicitInitializationCheck.java"/>
+          </macro>
         </div>
       </subsection>
 

--- a/src/xdocs/checks/coding/fallthrough.xml
+++ b/src/xdocs/checks/coding/fallthrough.xml
@@ -46,19 +46,14 @@
             </tr>
             <tr>
               <td>checkLastCaseGroup</td>
-              <td>
-                Control whether the last case group must be checked.
-              </td>
+              <td>Control whether the last case group must be checked.</td>
               <td><a href="../../property_types.html#boolean">boolean</a></td>
               <td><code>false</code></td>
               <td>4.0</td>
             </tr>
             <tr>
               <td>reliefPattern</td>
-              <td>
-                Define the RegExp to match the relief comment that suppresses
-                the warning about a fall through.
-              </td>
+              <td>Define the RegExp to match the relief comment that suppresses the warning about a fall through.</td>
               <td><a href="../../property_types.html#Pattern">Pattern</a></td>
               <td><code>&quot;falls?[ -]?thr(u|ough)&quot;</code></td>
               <td>4.0</td>

--- a/src/xdocs/checks/coding/fallthrough.xml.template
+++ b/src/xdocs/checks/coding/fallthrough.xml.template
@@ -36,34 +36,10 @@
 
       <subsection name="Properties" id="Properties">
         <div class="wrapper">
-          <table>
-            <tr>
-              <th>name</th>
-              <th>description</th>
-              <th>type</th>
-              <th>default value</th>
-              <th>since</th>
-            </tr>
-            <tr>
-              <td>checkLastCaseGroup</td>
-              <td>
-                Control whether the last case group must be checked.
-              </td>
-              <td><a href="../../property_types.html#boolean">boolean</a></td>
-              <td><code>false</code></td>
-              <td>4.0</td>
-            </tr>
-            <tr>
-              <td>reliefPattern</td>
-              <td>
-                Define the RegExp to match the relief comment that suppresses
-                the warning about a fall through.
-              </td>
-              <td><a href="../../property_types.html#Pattern">Pattern</a></td>
-              <td><code>"falls?[ -]?thr(u|ough)"</code></td>
-              <td>4.0</td>
-            </tr>
-          </table>
+          <macro name="properties">
+            <param name="modulePath"
+              value="src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/FallThroughCheck.java"/>
+          </macro>
         </div>
       </subsection>
 


### PR DESCRIPTION
Issue #13693


FinalLocalVariable i not possible to migrate until we fix ordering in junit:
```
ailures: 
[ERROR]   XdocsPagesTest.testAllCheckSections:650->validateCheckSection:733->validatePropertySection:875
->validatePropertySectionPropertiesOrder:922 finallocalvariable.xml 
section 'FinalLocalVariable' should have properties in the requested order
contents match, but order was wrong
expected: [validateEnhancedForLoopVariable, tokens]
but was : [tokens, validateEnhancedForLoopVariable]
[INFO] 

``` 