### PR TITLE
Issue #13213: Remove '//ok' comments from annotationonsameline

### DIFF
--- a/config/checkstyle-input-suppressions.xml
+++ b/config/checkstyle-input-suppressions.xml
@@ -140,10 +140,6 @@
 
   <!-- until https://github.com/checkstyle/checkstyle/issues/13213 -->
   <suppress id="UnnecessaryOkComment"
-            files="checks[\\/]annotation[\\/]annotationonsameline[\\/]InputAnnotationOnSameLineRecordsAndCompactCtors.java"/>
-  <suppress id="UnnecessaryOkComment"
-            files="checks[\\/]annotation[\\/]annotationonsameline[\\/]InputAnnotationOnSameLineRecordsAndCompactCtors.java"/>
-  <suppress id="UnnecessaryOkComment"
             files="checks[\\/]avoidescapedunicodecharacters[\\/]InputAvoidEscapedUnicodeCharactersEscapedS.java"/>
   <suppress id="UnnecessaryOkComment"
             files="checks[\\/]avoidescapedunicodecharacters[\\/]InputAvoidEscapedUnicodeCharactersEscapedS.java"/>
@@ -1359,18 +1355,6 @@
             files="checks[\\/]whitespace[\\/]whitespacearound[\\/]InputWhitespaceAroundRecordsAllowEmptyTypes.java"/>
   <suppress id="UnnecessaryOkComment"
             files="checks[\\/]whitespace[\\/]whitespacearound[\\/]InputWhitespaceAroundRecordsAllowEmptyTypes.java"/>
-  <suppress id="UnnecessaryOkComment"
-            files="checks[\\/]annotation[\\/]annotationonsameline[\\/]InputAnnotationOnSameLineCheck.java"/>
-  <suppress id="UnnecessaryOkComment"
-            files="checks[\\/]annotation[\\/]annotationonsameline[\\/]InputAnnotationOnSameLineCheck.java"/>
-  <suppress id="UnnecessaryOkComment"
-            files="checks[\\/]annotation[\\/]annotationonsameline[\\/]InputAnnotationOnSameLineCheck2.java"/>
-  <suppress id="UnnecessaryOkComment"
-            files="checks[\\/]annotation[\\/]annotationonsameline[\\/]InputAnnotationOnSameLineCheck2.java"/>
-  <suppress id="UnnecessaryOkComment"
-            files="checks[\\/]annotation[\\/]annotationonsameline[\\/]InputAnnotationOnSameLineCheck3.java"/>
-  <suppress id="UnnecessaryOkComment"
-            files="checks[\\/]annotation[\\/]annotationonsameline[\\/]InputAnnotationOnSameLineCheck3.java"/>
   <suppress id="UnnecessaryOkComment"
             files="checks[\\/]annotation[\\/]missingdeprecated[\\/]InputMissingDeprecatedGood.java"/>
   <suppress id="UnnecessaryOkComment"

--- a/src/test/resources-noncompilable/com/puppycrawl/tools/checkstyle/checks/annotation/annotationonsameline/InputAnnotationOnSameLineRecordsAndCompactCtors.java
+++ b/src/test/resources-noncompilable/com/puppycrawl/tools/checkstyle/checks/annotation/annotationonsameline/InputAnnotationOnSameLineRecordsAndCompactCtors.java
@@ -23,7 +23,7 @@ public class InputAnnotationOnSameLineRecordsAndCompactCtors {
             record MyRecord3() {
     }
 
-    @SuppressWarnings("deprecation") public record MyRecord4() { // ok
+    @SuppressWarnings("deprecation") public record MyRecord4() {
         @SuppressWarnings("deprecation") // violation
         public MyRecord4 {
         }
@@ -43,7 +43,7 @@ public class InputAnnotationOnSameLineRecordsAndCompactCtors {
      */
     @SuppressWarnings("deprecation") // violation
     public record MyRecord6() {
-        record MyInnerRecord() {@SuppressWarnings("Annotation")public MyInnerRecord {} // ok
+        record MyInnerRecord() {@SuppressWarnings("Annotation")public MyInnerRecord {}
         }
     }
 

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/annotation/annotationonsameline/InputAnnotationOnSameLineCheck.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/annotation/annotationonsameline/InputAnnotationOnSameLineCheck.java
@@ -10,7 +10,7 @@ package com.puppycrawl.tools.checkstyle.checks.annotation.annotationonsameline;
 
 public class InputAnnotationOnSameLineCheck {
 
-    @Annotation int x;      // ok
+    @Annotation int x;
 
     int y;
 
@@ -25,7 +25,7 @@ public class InputAnnotationOnSameLineCheck {
     public int field;
 
     public
-    @Annotation int field2; // ok
+    @Annotation int field2;
 }
 
 class SomeClass {

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/annotation/annotationonsameline/InputAnnotationOnSameLineCheck2.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/annotation/annotationonsameline/InputAnnotationOnSameLineCheck2.java
@@ -19,7 +19,7 @@ public class InputAnnotationOnSameLineCheck2 {
     @Ann        // violation
     private List<String> names = new ArrayList<>();
 
-    @Ann private List<String> names2 = new ArrayList<>();       // ok
+    @Ann private List<String> names2 = new ArrayList<>();
 
     @SuppressWarnings("deprecation")        // violation
     @Ann Integer x;
@@ -28,7 +28,7 @@ public class InputAnnotationOnSameLineCheck2 {
     @Ann                                    // violation
     Integer x2;
 
-    @SuppressWarnings("deprecation") @Ann @Ann2 @Ann3 @Ann4 Integer x3;     // ok
+    @SuppressWarnings("deprecation") @Ann @Ann2 @Ann3 @Ann4 Integer x3;
 
 }
 

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/annotation/annotationonsameline/InputAnnotationOnSameLineCheck3.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/annotation/annotationonsameline/InputAnnotationOnSameLineCheck3.java
@@ -11,7 +11,7 @@ package com.puppycrawl.tools.checkstyle.checks.annotation.annotationonsameline;
 
 public class InputAnnotationOnSameLineCheck3 {
 
-    @Annotation3 int x;     // ok
+    @Annotation3 int x;
 
     int y;
 
@@ -26,7 +26,7 @@ public class InputAnnotationOnSameLineCheck3 {
     public int field;
 
     public
-    @Annotation3 int field2; // ok
+    @Annotation3 int field2;
 }
 
 class SomeClass2 {


### PR DESCRIPTION
part of #13213 

Link to check the documentation : [ClickHere](https://checkstyle.sourceforge.io/checks/annotation/annotationonsameline.html#AnnotationOnSameLine)

Proof that all suppressions have removed : 

```
rajro@DESKTOP-HSV42DL MINGW64 ~/checkstyle (master)
$ grep annotationonsameline config/checkstyle-input-suppressions.xml
            files="checks[\\/]annotation[\\/]annotationonsameline[\\/]InputAnnotationOnSameLineRecordsAndCompactCtors.java"/>
            files="checks[\\/]annotation[\\/]annotationonsameline[\\/]InputAnnotationOnSameLineRecordsAndCompactCtors.java"/>
            files="checks[\\/]annotation[\\/]annotationonsameline[\\/]InputAnnotationOnSameLineCheck.java"/>
            files="checks[\\/]annotation[\\/]annotationonsameline[\\/]InputAnnotationOnSameLineCheck.java"/>
            files="checks[\\/]annotation[\\/]annotationonsameline[\\/]InputAnnotationOnSameLineCheck2.java"/>
            files="checks[\\/]annotation[\\/]annotationonsameline[\\/]InputAnnotationOnSameLineCheck2.java"/>
            files="checks[\\/]annotation[\\/]annotationonsameline[\\/]InputAnnotationOnSameLineCheck3.java"/>
            files="checks[\\/]annotation[\\/]annotationonsameline[\\/]InputAnnotationOnSameLineCheck3.java"/>

rajro@DESKTOP-HSV42DL MINGW64 ~/checkstyle (master)
$ git checkout issue-13213-annotationonsameline
\Switched to branch 'issue-13213-annotationonsameline'

rajro@DESKTOP-HSV42DL MINGW64 ~/checkstyle (issue-13213-annotationonsameline)
$ grep annotaitononsameline config/checkstyle-input-suppressions.xml

rajro@DESKTOP-HSV42DL MINGW64 ~/checkstyle (issue-13213-annotationonsameline)
$ echo $?
1

```