### PR TITLE
Issue #13213: Remove '//ok' comments from missingdeprecated

### DIFF
--- a/config/checkstyle-input-suppressions.xml
+++ b/config/checkstyle-input-suppressions.xml
@@ -928,10 +928,6 @@
   <suppress id="UnnecessaryOkComment"
             files="checks[\\/]whitespace[\\/]whitespacearound[\\/]InputWhitespaceAroundRecordsAllowEmptyTypes.java"/>
   <suppress id="UnnecessaryOkComment"
-            files="checks[\\/]annotation[\\/]missingdeprecated[\\/]InputMissingDeprecatedGood.java"/>
-  <suppress id="UnnecessaryOkComment"
-            files="checks[\\/]annotation[\\/]missingdeprecated[\\/]InputMissingDeprecatedSingleComment.java"/>
-  <suppress id="UnnecessaryOkComment"
             files="checks[\\/]annotation[\\/]packageannotation[\\/]InputPackageAnnotation.java"/>
   <suppress id="UnnecessaryOkComment"
             files="checks[\\/]annotation[\\/]suppresswarnings[\\/]InputSuppressWarningsConstants.java"/>

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/annotation/missingdeprecated/InputMissingDeprecatedGood.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/annotation/missingdeprecated/InputMissingDeprecatedGood.java
@@ -12,7 +12,7 @@ package com.puppycrawl.tools.checkstyle.checks.annotation.missingdeprecated;
  * bleh
  */
 @Deprecated
-public class InputMissingDeprecatedGood // ok
+public class InputMissingDeprecatedGood
 {
     /**
      * @deprecated           bleh

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/annotation/missingdeprecated/InputMissingDeprecatedSingleComment.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/annotation/missingdeprecated/InputMissingDeprecatedSingleComment.java
@@ -16,5 +16,5 @@ package com.puppycrawl.tools.checkstyle.checks.annotation.missingdeprecated;
  * @deprecated do not use
  */
 @Deprecated
-class InputMissingDeprecatedSingleComment { // ok
+class InputMissingDeprecatedSingleComment {
 }


### PR DESCRIPTION
part of #13213 

Link to check documentation : [ClickHere](https://checkstyle.sourceforge.io/checks/annotation/missingdeprecated.html#MissingDeprecated)

```
rajro@DESKTOP-HSV42DL MINGW64 ~/checkstyle (master)
$ grep missingdeprecated config/checkstyle-input-suppressions.xml
            files="checks[\\/]annotation[\\/]missingdeprecated[\\/]InputMissingDeprecatedGood.java"/>
            files="checks[\\/]annotation[\\/]missingdeprecated[\\/]InputMissingDeprecatedSingleComment.java"/>

rajro@DESKTOP-HSV42DL MINGW64 ~/checkstyle (master)
$ git checkout issue-13213-missingdeprecated
Switched to branch 'issue-13213-missingdeprecated'

rajro@DESKTOP-HSV42DL MINGW64 ~/checkstyle (issue-13213-missingdeprecated)
$ grep missingdeprecated config/checkstyle-input-suppressions.xml

rajro@DESKTOP-HSV42DL MINGW64 ~/checkstyle (issue-13213-missingdeprecated)
$ echo $?
1

```

