### PR TITLE
usageof propery macros for MultipleStringLiterals generate bad link to property type

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/MultipleStringLiteralsCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/MultipleStringLiteralsCheck.java
@@ -51,17 +51,17 @@ import com.puppycrawl.tools.checkstyle.utils.TokenUtil;
  * Default value is {@code 1}.
  * </li>
  * <li>
- * Property {@code ignoreStringsRegexp} - Specify RegExp for ignored strings (with quotation marks).
- * Type is {@code java.util.regex.Pattern}.
- * Default value is {@code "^""$"}.
- * </li>
- * <li>
  * Property {@code ignoreOccurrenceContext} - Specify token type names where duplicate
  * strings are ignored even if they don't match ignoredStringsRegexp. This allows you to
  * exclude syntactical contexts like annotations or static initializers from the check.
  * Type is {@code java.lang.String[]}.
  * Validation type is {@code tokenTypesSet}.
  * Default value is {@code ANNOTATION}.
+ * </li>
+ * <li>
+ * Property {@code ignoreStringsRegexp} - Specify RegExp for ignored strings (with quotation marks).
+ * Type is {@code java.util.regex.Pattern}.
+ * Default value is {@code "^""$"}.
  * </li>
  * </ul>
  * <p>

--- a/src/main/resources/com/puppycrawl/tools/checkstyle/meta/checks/coding/MultipleStringLiteralsCheck.xml
+++ b/src/main/resources/com/puppycrawl/tools/checkstyle/meta/checks/coding/MultipleStringLiteralsCheck.xml
@@ -16,11 +16,6 @@
                <description>Specify the maximum number of occurrences
  to allow without generating a warning.</description>
             </property>
-            <property default-value="^$"
-                      name="ignoreStringsRegexp"
-                      type="java.util.regex.Pattern">
-               <description>Specify RegExp for ignored strings (with quotation marks).</description>
-            </property>
             <property default-value="ANNOTATION"
                       name="ignoreOccurrenceContext"
                       type="java.lang.String[]"
@@ -28,6 +23,11 @@
                <description>Specify token type names where duplicate
  strings are ignored even if they don't match ignoredStringsRegexp. This allows you to
  exclude syntactical contexts like annotations or static initializers from the check.</description>
+            </property>
+            <property default-value="^$"
+                      name="ignoreStringsRegexp"
+                      type="java.util.regex.Pattern">
+               <description>Specify RegExp for ignored strings (with quotation marks).</description>
             </property>
          </properties>
          <message-keys>

--- a/src/xdocs/checks/coding/multiplestringliterals.xml
+++ b/src/xdocs/checks/coding/multiplestringliterals.xml
@@ -32,38 +32,24 @@
             </tr>
             <tr>
               <td>allowedDuplicates</td>
-              <td>
-                Specify the maximum number of occurrences to allow without generating a
-                warning.
-              </td>
+              <td>Specify the maximum number of occurrences to allow without generating a warning.</td>
               <td><a href="../../property_types.html#int">int</a></td>
               <td><code>1</code></td>
               <td>3.5</td>
             </tr>
             <tr>
+              <td>ignoreOccurrenceContext</td>
+              <td>Specify token type names where duplicate strings are ignored even if they don't match ignoredStringsRegexp. This allows you to exclude syntactical contexts like annotations or static initializers from the check.</td>
+              <td><a href="../../property_types.html#subset of tokens TokenTypes">subset of tokens TokenTypes</a></td>
+              <td><code>ANNOTATION</code></td>
+              <td>4.4</td>
+            </tr>
+            <tr>
               <td>ignoreStringsRegexp</td>
-              <td>
-                Specify RegExp for ignored strings (with quotation marks).
-              </td>
+              <td>Specify RegExp for ignored strings (with quotation marks).</td>
               <td><a href="../../property_types.html#Pattern">Pattern</a></td>
               <td><code>&quot;^&quot;&quot;$&quot;</code></td>
               <td>4.0</td>
-            </tr>
-            <tr>
-              <td>ignoreOccurrenceContext</td>
-              <td>
-                Specify token type names where duplicate strings are ignored even if they don't
-                match ignoredStringsRegexp. This allows you to exclude syntactical contexts like
-                annotations or static initializers from the check.
-              </td>
-              <td>
-                subset of tokens
-                <a href="../../apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html">TokenTypes</a>
-              </td>
-              <td>
-                <code>ANNOTATION</code>
-              </td>
-              <td>4.4</td>
             </tr>
           </table>
         </div>

--- a/src/xdocs/checks/coding/multiplestringliterals.xml.template
+++ b/src/xdocs/checks/coding/multiplestringliterals.xml.template
@@ -22,50 +22,10 @@
 
       <subsection name="Properties" id="Properties">
         <div class="wrapper">
-          <table>
-            <tr>
-              <th>name</th>
-              <th>description</th>
-              <th>type</th>
-              <th>default value</th>
-              <th>since</th>
-            </tr>
-            <tr>
-              <td>allowedDuplicates</td>
-              <td>
-                Specify the maximum number of occurrences to allow without generating a
-                warning.
-              </td>
-              <td><a href="../../property_types.html#int">int</a></td>
-              <td><code>1</code></td>
-              <td>3.5</td>
-            </tr>
-            <tr>
-              <td>ignoreStringsRegexp</td>
-              <td>
-                Specify RegExp for ignored strings (with quotation marks).
-              </td>
-              <td><a href="../../property_types.html#Pattern">Pattern</a></td>
-              <td><code>"^""$"</code></td>
-              <td>4.0</td>
-            </tr>
-            <tr>
-              <td>ignoreOccurrenceContext</td>
-              <td>
-                Specify token type names where duplicate strings are ignored even if they don't
-                match ignoredStringsRegexp. This allows you to exclude syntactical contexts like
-                annotations or static initializers from the check.
-              </td>
-              <td>
-                subset of tokens
-                <a href="../../apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html">TokenTypes</a>
-              </td>
-              <td>
-                <code>ANNOTATION</code>
-              </td>
-              <td>4.4</td>
-            </tr>
-          </table>
+          <macro name="properties">
+            <param name="modulePath"
+              value="src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/MultipleStringLiteralsCheck.java"/>
+          </macro>
         </div>
       </subsection>
 


### PR DESCRIPTION
Issue #13693

problem detected at https://github.com/checkstyle/checkstyle/pull/13717#issuecomment-1710874863

we need to fix link.
This PR is just to show a problem and to share a code to reuse for functional fix.