### PR TITLE
Issue #13672: Kill mutation related to Charset in FileText

### DIFF
--- a/config/pitest-suppressions/pitest-api-suppressions.xml
+++ b/config/pitest-suppressions/pitest-api-suppressions.xml
@@ -10,42 +10,6 @@
   </mutation>
 
   <mutation unstable="false">
-    <sourceFile>FileText.java</sourceFile>
-    <mutatedClass>com.puppycrawl.tools.checkstyle.api.FileText</mutatedClass>
-    <mutatedMethod>&lt;init&gt;</mutatedMethod>
-    <mutator>org.pitest.mutationtest.engine.gregor.mutators.NonVoidMethodCallMutator</mutator>
-    <description>removed call to java/nio/charset/CharsetDecoder::onMalformedInput</description>
-    <lineContent>decoder.onMalformedInput(CodingErrorAction.REPLACE);</lineContent>
-  </mutation>
-
-  <mutation unstable="false">
-    <sourceFile>FileText.java</sourceFile>
-    <mutatedClass>com.puppycrawl.tools.checkstyle.api.FileText</mutatedClass>
-    <mutatedMethod>&lt;init&gt;</mutatedMethod>
-    <mutator>org.pitest.mutationtest.engine.gregor.mutators.experimental.NakedReceiverMutator</mutator>
-    <description>replaced call to java/nio/charset/CharsetDecoder::onMalformedInput with receiver</description>
-    <lineContent>decoder.onMalformedInput(CodingErrorAction.REPLACE);</lineContent>
-  </mutation>
-
-  <mutation unstable="false">
-    <sourceFile>FileText.java</sourceFile>
-    <mutatedClass>com.puppycrawl.tools.checkstyle.api.FileText</mutatedClass>
-    <mutatedMethod>&lt;init&gt;</mutatedMethod>
-    <mutator>org.pitest.mutationtest.engine.gregor.mutators.NonVoidMethodCallMutator</mutator>
-    <description>removed call to java/nio/charset/CharsetDecoder::onUnmappableCharacter</description>
-    <lineContent>decoder.onUnmappableCharacter(CodingErrorAction.REPLACE);</lineContent>
-  </mutation>
-
-  <mutation unstable="false">
-    <sourceFile>FileText.java</sourceFile>
-    <mutatedClass>com.puppycrawl.tools.checkstyle.api.FileText</mutatedClass>
-    <mutatedMethod>&lt;init&gt;</mutatedMethod>
-    <mutator>org.pitest.mutationtest.engine.gregor.mutators.experimental.NakedReceiverMutator</mutator>
-    <description>replaced call to java/nio/charset/CharsetDecoder::onUnmappableCharacter with receiver</description>
-    <lineContent>decoder.onUnmappableCharacter(CodingErrorAction.REPLACE);</lineContent>
-  </mutation>
-
-  <mutation unstable="false">
     <sourceFile>Violation.java</sourceFile>
     <mutatedClass>com.puppycrawl.tools.checkstyle.api.Violation</mutatedClass>
     <mutatedMethod>&lt;init&gt;</mutatedMethod>

--- a/pom.xml
+++ b/pom.xml
@@ -4672,6 +4672,8 @@
                 <param>com.puppycrawl.tools.checkstyle.checks.coding.UnusedLocalVariableCheckTest</param>
                 <!-- 1% mutation in CheckUtil -->
                 <param>com.puppycrawl.tools.checkstyle.checks.OuterTypeFilenameCheckTest</param>
+                <param>com.puppycrawl.tools.checkstyle.checks.sizes.LineLengthCheckTest</param>
+                <param>com.puppycrawl.tools.checkstyle.checks.javadoc.NonEmptyAtclauseDescriptionCheckTest</param>
                 <param>org.checkstyle.suppressionxpathfilter.XpathRegressionUnusedLocalVariableTest</param>
                 <param>com.puppycrawl.tools.checkstyle.checks.javadoc.SummaryJavadocCheckTest</param>
                 <param>org.checkstyle.suppressionxpathfilter.XpathRegressionJavadocMethodTest</param>

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/javadoc/NonEmptyAtclauseDescriptionCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/javadoc/NonEmptyAtclauseDescriptionCheckTest.java
@@ -22,10 +22,16 @@ package com.puppycrawl.tools.checkstyle.checks.javadoc;
 import static com.google.common.truth.Truth.assertWithMessage;
 import static com.puppycrawl.tools.checkstyle.checks.javadoc.NonEmptyAtclauseDescriptionCheck.MSG_KEY;
 
+import java.nio.charset.CodingErrorAction;
+
 import org.junit.jupiter.api.Test;
 
 import com.puppycrawl.tools.checkstyle.AbstractModuleTestSupport;
+import com.puppycrawl.tools.checkstyle.DefaultConfiguration;
+import com.puppycrawl.tools.checkstyle.TreeWalker;
 import com.puppycrawl.tools.checkstyle.api.TokenTypes;
+import com.puppycrawl.tools.checkstyle.utils.CommonUtil;
+import de.thetaphi.forbiddenapis.SuppressForbidden;
 
 public class NonEmptyAtclauseDescriptionCheckTest
         extends AbstractModuleTestSupport {
@@ -94,5 +100,31 @@ public class NonEmptyAtclauseDescriptionCheckTest
             "77: " + getCheckMessage(MSG_KEY),
         };
         verifyWithInlineConfigParser(getPath("InputNonEmptyAtclauseDescriptionTwo.java"), expected);
+    }
+
+    /**
+     * This tests that the check does not fail when the input file contains unmappable characters.
+     * The test file contains the character ü which is not mappable to US-ASCII. It makes sure that
+     * unmappable characters are replaced with the default replacement character using
+     * {@link CodingErrorAction#REPLACE}.
+     *
+     * @throws Exception exception
+     */
+    @SuppressForbidden
+    @Test
+    public void testDecoderOnMalformedInput() throws Exception {
+        final String[] expected = CommonUtil.EMPTY_STRING_ARRAY;
+        final DefaultConfiguration checkConfig =
+                createModuleConfig(NonEmptyAtclauseDescriptionCheck.class);
+
+        final DefaultConfiguration treeWalkerConfig = createModuleConfig(TreeWalker.class);
+        treeWalkerConfig.addChild(checkConfig);
+
+        final DefaultConfiguration checkerConfig = createRootConfig(treeWalkerConfig);
+        checkerConfig.addChild(treeWalkerConfig);
+        checkerConfig.addProperty("charset", "US-ASCII");
+
+        verify(checkerConfig,
+                getPath("InputNonEmptyAtclauseDescriptionDifferentCharset.java"), expected);
     }
 }

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/sizes/LineLengthCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/sizes/LineLengthCheckTest.java
@@ -21,9 +21,13 @@ package com.puppycrawl.tools.checkstyle.checks.sizes;
 
 import static com.puppycrawl.tools.checkstyle.checks.sizes.LineLengthCheck.MSG_KEY;
 
+import java.nio.charset.CodingErrorAction;
+
 import org.junit.jupiter.api.Test;
 
 import com.puppycrawl.tools.checkstyle.AbstractModuleTestSupport;
+import com.puppycrawl.tools.checkstyle.DefaultConfiguration;
+import de.thetaphi.forbiddenapis.SuppressForbidden;
 
 public class LineLengthCheckTest extends AbstractModuleTestSupport {
 
@@ -118,4 +122,27 @@ public class LineLengthCheckTest extends AbstractModuleTestSupport {
             getNonCompilablePath("InputLineLengthIgnoringImportStatements.java"), expected);
     }
 
+    /**
+     * This tests that the check does not fail when the file contains unmappable characters.
+     * Unmappable characters should be replaced with the default replacement character
+     * {@link CodingErrorAction#REPLACE}. For example, the 0x80 (hex.) character is unmappable
+     * in the IBM1098 charset.
+     *
+     * @throws Exception exception
+     */
+    @SuppressForbidden
+    @Test
+    public void testUnmappableCharacters() throws Exception {
+        final String[] expected = {
+            "4: " + getCheckMessage(MSG_KEY, 75, 238),
+        };
+
+        final DefaultConfiguration checkConfig = createModuleConfig(LineLengthCheck.class);
+        checkConfig.addProperty("max", "75");
+
+        final DefaultConfiguration checkerConfig = createRootConfig(checkConfig);
+        checkerConfig.addProperty("charset", "IBM1098");
+
+        verify(checkerConfig, getPath("InputLineLengthUnmappableCharacters.java"), expected);
+    }
 }

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/nonemptyatclausedescription/InputNonEmptyAtclauseDescriptionDifferentCharset.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/nonemptyatclausedescription/InputNonEmptyAtclauseDescriptionDifferentCharset.java
@@ -1,0 +1,10 @@
+package com.puppycrawl.tools.checkstyle.checks.javadoc.nonemptyatclausedescription;
+
+public class InputNonEmptyAtclauseDescriptionDifferentCharset {
+
+    /**
+     * @author ü
+     */
+    private void foo() {
+    }
+}

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/sizes/linelength/InputLineLengthUnmappableCharacters.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/sizes/linelength/InputLineLengthUnmappableCharacters.java
@@ -1,0 +1,5 @@
+package com.puppycrawl.tools.checkstyle.checks.sizes.linelength;
+
+public class InputLineLengthUnmappableCharacters {
+    String a = "ᾀᾀᾀᾀᾀᾀᾀᾀᾀᾀᾀᾀᾀᾀᾀᾀᾀᾀᾀᾀᾀᾀᾀᾀᾀᾀᾀᾀᾀᾀᾀᾀᾀᾀᾀᾀᾀᾀᾀᾀᾀᾀᾀᾀᾀᾀᾀᾀᾀᾀᾀᾀᾀᾀᾀᾀᾀᾀᾀᾀᾀᾀᾀᾀᾀᾀᾀᾀᾀ"; // violation
+}


### PR DESCRIPTION
Issue #13672: Kill mutation related to Charset in FileText

originally discussed at https://github.com/checkstyle/checkstyle/pull/13181#discussion_r1308725119

---

# Mutation Covered
https://github.com/checkstyle/checkstyle/blob/958051594a64ea5a228359919ed7426e69a242d7/config/pitest-suppressions/pitest-api-suppressions.xml#L12-L28