### PR TITLE
Issue #13735: Fixed typos

### DIFF
--- a/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/invalidjavadocposition/Example1.txt
+++ b/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/invalidjavadocposition/Example1.txt
@@ -9,7 +9,7 @@
 // xdoc section -- start
 @SuppressWarnings("serial")
 /**
- * This comment looks like javadoc but it at an invalid location.
+ * This comment looks like Javadoc but it is at an invalid location.
  * Therefore, the text will not get into TestClass.html and the check will produce a violation.
  */
 public class TestClass {

--- a/src/xdocs/checks/javadoc/invalidjavadocposition.xml
+++ b/src/xdocs/checks/javadoc/invalidjavadocposition.xml
@@ -39,7 +39,7 @@
         <source>
 @SuppressWarnings(&quot;serial&quot;)
 /**
- * This comment looks like javadoc but it at an invalid location.
+ * This comment looks like Javadoc but it is at an invalid location.
  * Therefore, the text will not get into TestClass.html and the check will produce a violation.
  */
 public class TestClass {


### PR DESCRIPTION
Issue #13735:  Fixed typos in files `invalidjavadocposition.xml` and `Example1.txt`