### PR TITLE
Issue #13745: MissingDeprecated shows unclear message on not closed html tag

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/annotation/MissingDeprecatedCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/annotation/MissingDeprecatedCheck.java
@@ -97,6 +97,9 @@ import com.puppycrawl.tools.checkstyle.utils.TokenUtil;
  * {@code javadoc.parse.rule.error}
  * </li>
  * <li>
+ * {@code javadoc.unclosedHtml}
+ * </li>
+ * <li>
  * {@code javadoc.wrong.singleton.html.tag}
  * </li>
  * </ul>
@@ -112,6 +115,9 @@ public final class MissingDeprecatedCheck extends AbstractJavadocCheck {
      */
     public static final String MSG_KEY_ANNOTATION_MISSING_DEPRECATED =
             "annotation.missing.deprecated";
+
+    /** Message property key for the Unclosed HTML message. */
+    public static final String MSG_KEY_UNCLOSED_HTML_TAG = "javadoc.unclosedHtml";
 
     /**
      * A key is pointing to the warning message text in "messages.properties"

--- a/src/main/resources/com/puppycrawl/tools/checkstyle/checks/annotation/messages.properties
+++ b/src/main/resources/com/puppycrawl/tools/checkstyle/checks/annotation/messages.properties
@@ -12,7 +12,7 @@ annotation.trailing.comma.present=Annotation array values cannot contain trailin
 javadoc.duplicateTag=Duplicate {0} tag.
 javadoc.missed.html.close=Javadoc comment at column {0} has parse error. Missed HTML close tag ''{1}''. Sometimes it means that close tag missed for one of previous tags.
 javadoc.parse.rule.error=Javadoc comment at column {0} has parse error. Details: {1} while parsing {2}
+javadoc.unclosedHtml=Unclosed HTML tag found: {0}.
 javadoc.wrong.singleton.html.tag=Javadoc comment at column {0} has parse error. It is forbidden to close singleton HTML tags. Tag: {1}.
 suppressed.warning.not.allowed=The warning ''{0}'' cannot be suppressed at this location.
 tag.not.valid.on=The Javadoc {0} tag is not valid at this location.
-

--- a/src/main/resources/com/puppycrawl/tools/checkstyle/checks/annotation/messages_de.properties
+++ b/src/main/resources/com/puppycrawl/tools/checkstyle/checks/annotation/messages_de.properties
@@ -12,6 +12,7 @@ annotation.trailing.comma.present=Annotation-Array-Werte dürfen nicht mit einem
 javadoc.duplicateTag=Das Javadoc-Tag {0} ist doppelt.
 javadoc.missed.html.close=Der Javadoc-Kommentar an Position {0} führt zu einem Parserfehler. Fehlendes schließendes HTML-Tag ''{1}''. Manchmal bedeutet dies, dass das schließende Tag eines vorherigen Tags fehlt.
 javadoc.parse.rule.error=Der Javadoc-Kommentar an Position {0} führt zu einem Parserfehler. Details: {1} beim Parsen von {2}
+javadoc.unclosedHtml=Nicht geschlossenes HTML-Tag gefunden: {0}
 javadoc.wrong.singleton.html.tag=Der Javadoc-Kommentar an Position {0} führt zu einem Parserfehler. Singleton-HTML-Tags dürfen nicht geschlossen werden. Tag: {1}
 suppressed.warning.not.allowed=Die Warnung ''{0}'' darf an dieser Stelle nicht unterdrückt werden.
 tag.not.valid.on=Das Javadoc-Tag {0} ist an dieser Stelle nicht zulässig.

--- a/src/main/resources/com/puppycrawl/tools/checkstyle/checks/annotation/messages_es.properties
+++ b/src/main/resources/com/puppycrawl/tools/checkstyle/checks/annotation/messages_es.properties
@@ -12,6 +12,7 @@ annotation.trailing.comma.present=Valores de la matriz de anotación no pueden c
 javadoc.duplicateTag=La etiqueta Javadoc ''{0}'' no debería ser duplicada.
 javadoc.missed.html.close=Javadoc comentario en la columna {0} tiene parse error. Perdidas HTML cerca etiqueta ''{1}''. A veces esto significa que cerca de la etiqueta se perdió por una de las etiquetas anteriores.
 javadoc.parse.rule.error=Javadoc comentario en la columna {0} tiene parse error. Detalles: {1} al analizar {2}
+javadoc.unclosedHtml=Se encontró una etiqueta HTML sin cerrar: {0}
 javadoc.wrong.singleton.html.tag=El comentario Javadoc en la columna {0} tiene un error sintáctico. Es prohibido cerrar etiquetas HTML autocerrantes. Tag: {1}
 suppressed.warning.not.allowed=La advertencia ''{0}'' no se puede suprimir en este lugar.
 tag.not.valid.on=El Javadoc {0} etiqueta no es válido en este lugar.

--- a/src/main/resources/com/puppycrawl/tools/checkstyle/checks/annotation/messages_fi.properties
+++ b/src/main/resources/com/puppycrawl/tools/checkstyle/checks/annotation/messages_fi.properties
@@ -12,6 +12,7 @@ annotation.trailing.comma.present=Annotation array arvot voi sisältää perää
 javadoc.duplicateTag=Monista {0} tunniste.
 javadoc.missed.html.close=Javadoc kommentti sarakkeessa {0} on Jäsennysvirhe. Missed HTML lähellä tag ''{1}''. Joskus se tarkoittaa, että lähellä tag jäi yhden edellisen tunnisteita.
 javadoc.parse.rule.error=Javadoc kommentti sarakkeessa {0} on Jäsennysvirhe. Tiedot: {1} jäsennettäessä {2}
+javadoc.unclosedHtml=Unclosed HTML-koodi löytyy: {0}
 javadoc.wrong.singleton.html.tag=Javadoc kommentti sarakkeessa {0} on Jäsennysvirhe. On kiellettyä sulkea yksittäiseksi HTML tageja. Tag: {1} .
 suppressed.warning.not.allowed=Varoitus ''{0}'' ei voi estää tässä paikassa.
 tag.not.valid.on=Javadoc {0} tunniste ei kelpaa tässä paikassa.

--- a/src/main/resources/com/puppycrawl/tools/checkstyle/checks/annotation/messages_fr.properties
+++ b/src/main/resources/com/puppycrawl/tools/checkstyle/checks/annotation/messages_fr.properties
@@ -12,6 +12,7 @@ annotation.trailing.comma.present=Les valeurs de tableau d''annotation ne peuven
 javadoc.duplicateTag=La balise Javadoc ''{0}'' ne devrait pas être dupliquée.
 javadoc.missed.html.close=Le commentaire Javadoc à la colonne {0} ne peut être analysé. La balise HTML fermante ''{1}'' n''a pas été trouvée. Parfois, cela signifie qu''une des balises fermantes précédentes est manquante.
 javadoc.parse.rule.error=Le commentaire Javadoc à la colonne {0} ne peut être analysé. Détails : {1} lors de l''analyse {2}
+javadoc.unclosedHtml=Balise HTML trouvée dans la Javadoc : {0}
 javadoc.wrong.singleton.html.tag=Le commentaire Javadoc à la colonne {0} ne peut être analysé. Il est interdit de fermer les balises HTML singleton. Balise : {1}
 suppressed.warning.not.allowed=L''avertissement ''{0}'' ne peut pas être supprimé à cet endroit.
 tag.not.valid.on=La balise Javadoc {0} n''est pas valide à cet endroit.

--- a/src/main/resources/com/puppycrawl/tools/checkstyle/checks/annotation/messages_ja.properties
+++ b/src/main/resources/com/puppycrawl/tools/checkstyle/checks/annotation/messages_ja.properties
@@ -12,6 +12,7 @@ annotation.trailing.comma.present=アノテーションの配列値には末尾�
 javadoc.duplicateTag={0}タグが重複しています。
 javadoc.missed.html.close={0} 桁目の Javadoc コメントでパースエラーが発生しました。HTML タグ ''{1}'' が閉じていません。どこかもっと前のタグが閉じていない可能性もあります。
 javadoc.parse.rule.error={0} 桁目の Javadoc コメントでパースエラーが発生しました。詳細: {1}、{2} の解析中に発生。
+javadoc.unclosedHtml=閉じていない HTML タグが見つかりました: {0}
 javadoc.wrong.singleton.html.tag={0} 桁目の Javadoc コメントでパースエラーが発生しました。空要素の閉じタグは禁止されています。タグ: {1}。
 suppressed.warning.not.allowed=この場所で、警告 ''{0}'' を抑制することはできません。
 tag.not.valid.on=この場所で、Javadoc の{0}タグは有効ではありません。

--- a/src/main/resources/com/puppycrawl/tools/checkstyle/checks/annotation/messages_pt.properties
+++ b/src/main/resources/com/puppycrawl/tools/checkstyle/checks/annotation/messages_pt.properties
@@ -12,6 +12,7 @@ annotation.trailing.comma.present=A lista de valores de um array de anotações 
 javadoc.duplicateTag=A tag {0} não deveria ser duplicada.
 javadoc.missed.html.close=O comentário de Javadoc na coluna {0} tem erro sintático. Faltou uma etiqueta de fechamento HTML ''{1}''. Às vezes, isso significa que uma etiqueta de fechamento foi esquecida em uma das etiquetas HTML anteriores.
 javadoc.parse.rule.error=O comentário Javadoc na coluna {0} tem um erro sintático. Detalhes: {1} ao analisar {2}
+javadoc.unclosedHtml=Encontrada uma etiqueta HTML não fechada: {0}
 javadoc.wrong.singleton.html.tag=O comentário Javadoc na coluna {0} tem um erro sintático. É proibido fechar etiquetas HTML auto-fechantes. Tag: {1}.
 suppressed.warning.not.allowed=A advertência ''{0}'' não pode ser suprimida neste local.
 tag.not.valid.on=A tag Javadoc {0} não pode ser usada neste local.

--- a/src/main/resources/com/puppycrawl/tools/checkstyle/checks/annotation/messages_ru.properties
+++ b/src/main/resources/com/puppycrawl/tools/checkstyle/checks/annotation/messages_ru.properties
@@ -12,6 +12,7 @@ annotation.trailing.comma.present=В массиве значений у анно
 javadoc.duplicateTag=Повторяющийся тег {0}.
 javadoc.missed.html.close=Ошибка синтаксического анализа Javadoc в символе {0}. Тег HTML ''{1}'' не закрыт. Также возможно, что какой-то более ранний тег не закрыт.
 javadoc.parse.rule.error=Ошибка синтаксического анализа Javadoc в символе {0}. Подробнее: {1} во время разбора {2}
+javadoc.unclosedHtml=Обнаружен незакрытый HTML тег: {0}
 javadoc.wrong.singleton.html.tag=Ошибка синтаксического анализа Javadoc в символе {0}. HTML теги: {1} не нужно закрывать.
 suppressed.warning.not.allowed=Предупреждение ''{0}'' недопустимо подавлять в этом месте.
 tag.not.valid.on=В этом месте тег Javadoc {0} нельзя использовать.

--- a/src/main/resources/com/puppycrawl/tools/checkstyle/checks/annotation/messages_tr.properties
+++ b/src/main/resources/com/puppycrawl/tools/checkstyle/checks/annotation/messages_tr.properties
@@ -12,6 +12,7 @@ annotation.trailing.comma.present=Anotasyonun dizi değerlerini takip eden bir v
 javadoc.duplicateTag=Tekrarlanmış {0} etiketi.
 javadoc.missed.html.close=Sütununda Javadoc comment {0} hatası ayrıştırmak vardır. Cevapsız HTML yakın etiketi ''{1}'' Bazen yakın etiketi önceki etiketler biri için kaçırmış demektir.
 javadoc.parse.rule.error=Sütununda Javadoc comment {0} hatası ayrıştırmak vardır. Detaylar: {1} ayrıştırılırken {2}
+javadoc.unclosedHtml=Kapatılmamış bir HTML etiketi bulundu: {0}
 javadoc.wrong.singleton.html.tag=Sütununda Javadoc comment {0} hatası ayrıştırmak vardır. Bu singleton HTML etiketleri kapatmak için yasaktır. Etiket: {1}
 suppressed.warning.not.allowed=''{0}'' uyarısı bu konumda bastırılamaz.
 tag.not.valid.on={0} Javadoc etiketi bu konumda geçersiz.

--- a/src/main/resources/com/puppycrawl/tools/checkstyle/checks/annotation/messages_zh.properties
+++ b/src/main/resources/com/puppycrawl/tools/checkstyle/checks/annotation/messages_zh.properties
@@ -12,6 +12,7 @@ annotation.trailing.comma.present=注解数组最后元素尾部不应附加逗�
 javadoc.duplicateTag=重复的 Javadoc 注释： {0} 。
 javadoc.missed.html.close=Javadoc 第 {0} 个字符解析错误。缺少 HTML 闭合标签： ''{1}''。 有时这代表前一标签未闭合。
 javadoc.parse.rule.error=Javadoc 第 {0} 个字符解析错误。解析 {2} ，详情： {1}
+javadoc.unclosedHtml=未关闭的 HTML 标签： {0} 。
 javadoc.wrong.singleton.html.tag=Javadoc 第 {0} 个字符解析错误。HTML 标签： {1} 不需要闭合。
 suppressed.warning.not.allowed=不能忽略  ''{0}''  警告。
 tag.not.valid.on=此处不应有Javadoc注释： {0} 。

--- a/src/main/resources/com/puppycrawl/tools/checkstyle/meta/checks/annotation/MissingDeprecatedCheck.xml
+++ b/src/main/resources/com/puppycrawl/tools/checkstyle/meta/checks/annotation/MissingDeprecatedCheck.xml
@@ -54,6 +54,7 @@
             <message-key key="javadoc.duplicateTag"/>
             <message-key key="javadoc.missed.html.close"/>
             <message-key key="javadoc.parse.rule.error"/>
+            <message-key key="javadoc.unclosedHtml"/>
             <message-key key="javadoc.wrong.singleton.html.tag"/>
          </message-keys>
       </check>

--- a/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/checks/annotation/MissingDeprecatedCheckExamplesTest.java
+++ b/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/checks/annotation/MissingDeprecatedCheckExamplesTest.java
@@ -19,8 +19,8 @@
 
 package com.puppycrawl.tools.checkstyle.checks.annotation;
 
-import static com.puppycrawl.tools.checkstyle.JavadocDetailNodeParser.MSG_UNCLOSED_HTML_TAG;
 import static com.puppycrawl.tools.checkstyle.checks.annotation.MissingDeprecatedCheck.MSG_KEY_ANNOTATION_MISSING_DEPRECATED;
+import static com.puppycrawl.tools.checkstyle.checks.annotation.MissingDeprecatedCheck.MSG_KEY_UNCLOSED_HTML_TAG;
 
 import org.junit.jupiter.api.Test;
 
@@ -45,7 +45,7 @@ public class MissingDeprecatedCheckExamplesTest extends AbstractExamplesModuleTe
     public void testExample2() throws Exception {
         final String[] expected = {
             "20: " + getCheckMessage(MSG_KEY_ANNOTATION_MISSING_DEPRECATED),
-            "32: " + MSG_UNCLOSED_HTML_TAG,
+            "32: " + getCheckMessage(MSG_KEY_UNCLOSED_HTML_TAG, "p"),
         };
 
         verifyWithInlineConfigParser(getPath("Example2.java"), expected);

--- a/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/annotation/missingdeprecated/Example2.java
+++ b/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/annotation/missingdeprecated/Example2.java
@@ -29,7 +29,7 @@ class Example2 {
 
   /**
    * @deprecated
-   * <p>  // violation, 'javadoc.unclosedHtml'
+   * <p> // violation, 'Unclosed HTML tag found: p'
   */
   @Deprecated
   public static final int CONST = 12;

--- a/src/xdocs/checks/annotation/missingdeprecated.xml
+++ b/src/xdocs/checks/annotation/missingdeprecated.xml
@@ -138,7 +138,7 @@ class Example2 {
 
   /**
    * @deprecated
-   * &lt;p&gt;  // violation, 'javadoc.unclosedHtml'
+   * &lt;p&gt; // violation, 'Unclosed HTML tag found: p'
   */
   @Deprecated
   public static final int CONST = 12;
@@ -175,6 +175,11 @@ class Example2 {
           <li>
             <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources%2Fcom%2Fpuppycrawl%2Ftools%2Fcheckstyle%2Fchecks%2Fannotation%20path%3A**%2Fmessages*.properties+repo%3Acheckstyle%2Fcheckstyle+%22javadoc.parse.rule.error%22">
               javadoc.parse.rule.error
+            </a>
+          </li>
+          <li>
+            <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources%2Fcom%2Fpuppycrawl%2Ftools%2Fcheckstyle%2Fchecks%2Fannotation%20path%3A**%2Fmessages*.properties+repo%3Acheckstyle%2Fcheckstyle+%22javadoc.unclosedHtml%22">
+              javadoc.unclosedHtml
             </a>
           </li>
           <li>


### PR DESCRIPTION
Resolve #13745