### PR TITLE
Issue #13213: Remove ok comments from descendanttoken package

### DIFF
--- a/config/checkstyle-input-suppressions.xml
+++ b/config/checkstyle-input-suppressions.xml
@@ -1848,16 +1848,6 @@
   <suppress id="UnnecessaryOkComment"
             files="checks[\\/]coding[\\/]variabledeclarationusagedistance[\\/]InputVariableDeclarationUsageDistanceLabels.java"/>
   <suppress id="UnnecessaryOkComment"
-            files="checks[\\/]descendanttoken[\\/]InputDescendantTokenIllegalTokens.java"/>
-  <suppress id="UnnecessaryOkComment"
-            files="checks[\\/]descendanttoken[\\/]InputDescendantTokenIllegalTokens5.java"/>
-  <suppress id="UnnecessaryOkComment"
-            files="checks[\\/]descendanttoken[\\/]InputDescendantTokenIllegalTokens6.java"/>
-  <suppress id="UnnecessaryOkComment"
-            files="checks[\\/]descendanttoken[\\/]InputDescendantTokenReturnFromFinally2.java"/>
-  <suppress id="UnnecessaryOkComment"
-            files="checks[\\/]descendanttoken[\\/]InputDescendantTokenTestLimitedToken.java"/>
-  <suppress id="UnnecessaryOkComment"
             files="checks[\\/]design[\\/]designforextension[\\/]InputDesignForExtensionMultipleAnnotations.java"/>
   <suppress id="UnnecessaryOkComment"
             files="checks[\\/]design[\\/]finalclass[\\/]InputFinalClass.java"/>

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/descendanttoken/InputDescendantTokenIllegalTokens.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/descendanttoken/InputDescendantTokenIllegalTokens.java
@@ -15,7 +15,7 @@ tokens = (default)empty
 
 package com.puppycrawl.tools.checkstyle.checks.descendanttoken;
 
-public class InputDescendantTokenIllegalTokens // ok
+public class InputDescendantTokenIllegalTokens
 {
     public void methodWithPreviouslyIllegalTokens()
     {

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/descendanttoken/InputDescendantTokenIllegalTokens5.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/descendanttoken/InputDescendantTokenIllegalTokens5.java
@@ -15,7 +15,7 @@ tokens = LITERAL_SWITCH
 
 package com.puppycrawl.tools.checkstyle.checks.descendanttoken;
 
-public class InputDescendantTokenIllegalTokens5 // ok
+public class InputDescendantTokenIllegalTokens5
 {
     public void methodWithPreviouslyIllegalTokens()
     {

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/descendanttoken/InputDescendantTokenIllegalTokens6.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/descendanttoken/InputDescendantTokenIllegalTokens6.java
@@ -15,7 +15,7 @@ tokens = LITERAL_SWITCH
 
 package com.puppycrawl.tools.checkstyle.checks.descendanttoken;
 
-public class InputDescendantTokenIllegalTokens6 // ok
+public class InputDescendantTokenIllegalTokens6
 {
     public void methodWithPreviouslyIllegalTokens()
     {

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/descendanttoken/InputDescendantTokenReturnFromFinally2.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/descendanttoken/InputDescendantTokenReturnFromFinally2.java
@@ -15,7 +15,7 @@ tokens = NOT_EQUAL, EQUAL
 
 package com.puppycrawl.tools.checkstyle.checks.descendanttoken;
 
-public class InputDescendantTokenReturnFromFinally2 { // ok
+public class InputDescendantTokenReturnFromFinally2 {
     public void foo() {
         try {
             System.currentTimeMillis();

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/descendanttoken/InputDescendantTokenTestLimitedToken.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/descendanttoken/InputDescendantTokenTestLimitedToken.java
@@ -8,7 +8,6 @@ minimumNumber = 1
 
 package com.puppycrawl.tools.checkstyle.checks.descendanttoken;
 
-// ok
 public class InputDescendantTokenTestLimitedToken {
 }
 


### PR DESCRIPTION
part of #13213 


Link to check documentation :  [clickHere](https://checkstyle.sourceforge.io/checks/misc/descendanttoken.html#DescendantToken)

Proof that all suppressions has removed : 
```
rajro@DESKTOP-HSV42DL MINGW64 ~/checkstyle (master)
$ grep descendanttoken config/checkstyle-input-suppressions.xml
            files="checks[\\/]descendanttoken[\\/]InputDescendantTokenIllegalTokens.java"/>
            files="checks[\\/]descendanttoken[\\/]InputDescendantTokenIllegalTokens5.java"/>
            files="checks[\\/]descendanttoken[\\/]InputDescendantTokenIllegalTokens6.java"/>
            files="checks[\\/]descendanttoken[\\/]InputDescendantTokenReturnFromFinally2.java"/>
            files="checks[\\/]descendanttoken[\\/]InputDescendantTokenTestLimitedToken.java"/>

rajro@DESKTOP-HSV42DL MINGW64 ~/checkstyle (master)
$ git checkout issue-13213-descendanttoken
Switched to branch 'issue-13213-descendanttoken'

rajro@DESKTOP-HSV42DL MINGW64 ~/checkstyle (issue-13213-descendanttoken)
$ grep descendanttoken config/checkstyle-input-suppressions.xml

rajro@DESKTOP-HSV42DL MINGW64 ~/checkstyle (issue-13213-descendanttoken)
$ echo $?
1
```
