### PR TITLE
Issue #13672: Kill mutation for FileImportControl

### DIFF
--- a/config/checker-framework-suppressions/checker-nullness-optional-interning-suppressions.xml
+++ b/config/checker-framework-suppressions/checker-nullness-optional-interning-suppressions.xml
@@ -2845,17 +2845,6 @@
 
   <checkerFrameworkError unstable="false">
     <fileName>src/main/java/com/puppycrawl/tools/checkstyle/checks/imports/FileImportControl.java</fileName>
-    <specifier>assignment</specifier>
-    <message>incompatible types in assignment.</message>
-    <lineContent>patternForExactMatch = null;</lineContent>
-    <details>
-      found   : null (NullType)
-      required: @Initialized @NonNull Pattern
-    </details>
-  </checkerFrameworkError>
-
-  <checkerFrameworkError unstable="false">
-    <fileName>src/main/java/com/puppycrawl/tools/checkstyle/checks/imports/FileImportControl.java</fileName>
     <specifier>return</specifier>
     <message>incompatible types in return.</message>
     <lineContent>return finestMatch;</lineContent>

--- a/config/pitest-suppressions/pitest-imports-suppressions.xml
+++ b/config/pitest-suppressions/pitest-imports-suppressions.xml
@@ -1,24 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <suppressedMutations>
   <mutation unstable="false">
-    <sourceFile>FileImportControl.java</sourceFile>
-    <mutatedClass>com.puppycrawl.tools.checkstyle.checks.imports.FileImportControl</mutatedClass>
-    <mutatedMethod>&lt;init&gt;</mutatedMethod>
-    <mutator>org.pitest.mutationtest.engine.gregor.mutators.experimental.MemberVariableMutator</mutator>
-    <description>Removed assignment to member variable patternForExactMatch</description>
-    <lineContent>patternForExactMatch = null;</lineContent>
-  </mutation>
-
-  <mutation unstable="false">
-    <sourceFile>FileImportControl.java</sourceFile>
-    <mutatedClass>com.puppycrawl.tools.checkstyle.checks.imports.FileImportControl</mutatedClass>
-    <mutatedMethod>&lt;init&gt;</mutatedMethod>
-    <mutator>org.pitest.mutationtest.engine.gregor.mutators.experimental.ArgumentPropagationMutator</mutator>
-    <description>replaced call to com/puppycrawl/tools/checkstyle/checks/imports/FileImportControl::encloseInGroup with argument</description>
-    <lineContent>this.name = encloseInGroup(name);</lineContent>
-  </mutation>
-
-  <mutation unstable="false">
     <sourceFile>PkgImportControl.java</sourceFile>
     <mutatedClass>com.puppycrawl.tools.checkstyle.checks.imports.PkgImportControl</mutatedClass>
     <mutatedMethod>&lt;init&gt;</mutatedMethod>

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/imports/FileImportControl.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/imports/FileImportControl.java
@@ -43,26 +43,9 @@ class FileImportControl extends AbstractImportControl {
      */
     /* package */ FileImportControl(PkgImportControl parent, String name, boolean regex) {
         super(parent, MismatchStrategy.DELEGATE_TO_PARENT);
-
         this.regex = regex;
-        if (regex) {
-            this.name = encloseInGroup(name);
-            patternForExactMatch = createPatternForExactMatch(this.name);
-        }
-        else {
-            this.name = name;
-            patternForExactMatch = null;
-        }
-    }
-
-    /**
-     * Enclose {@code expression} in a (non-capturing) group.
-     *
-     * @param expression the input regular expression
-     * @return a grouped pattern.
-     */
-    private static String encloseInGroup(String expression) {
-        return "(?:" + expression + ")";
+        this.name = name;
+        patternForExactMatch = createPatternForExactMatch(name);
     }
 
     /**

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/imports/ImportControlCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/imports/ImportControlCheckTest.java
@@ -452,6 +452,14 @@ public class ImportControlCheckTest extends AbstractModuleTestSupport {
     }
 
     @Test
+    public void testImportControlFileName2() throws Exception {
+        final String[] expected = CommonUtil.EMPTY_STRING_ARRAY;
+
+        verifyWithInlineConfigParser(
+                getPath("InputImportControlTestRegexpInFile2.java"), expected);
+    }
+
+    @Test
     public void testImportControlTestException() {
         final CheckstyleException ex = assertThrows(CheckstyleException.class, () -> {
             verifyWithInlineConfigParser(getPath("InputImportControlTestException.java"));

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/imports/importcontrol/InputImportControlTestRegexpInFile2.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/imports/importcontrol/InputImportControlTestRegexpInFile2.java
@@ -1,0 +1,12 @@
+/*
+ImportControl
+file = (file)(resource)InputImportControlTestRegexpInFile2.xml
+
+*/
+
+package com.puppycrawl.tools.checkstyle.checks.imports.importcontrol;
+
+import java.awt.Image;
+
+public class InputImportControlTestRegexpInFile2 {
+}

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/imports/importcontrol/InputImportControlTestRegexpInFile2.xml
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/imports/importcontrol/InputImportControlTestRegexpInFile2.xml
@@ -1,0 +1,11 @@
+<!DOCTYPE import-control PUBLIC
+    "-//Checkstyle//DTD ImportControl Configuration 1.4//EN"
+    "https://checkstyle.org/dtds/import_control_1_4.dtd">
+
+<import-control pkg="com.puppycrawl.tools.checkstyle.checks.imports">
+  <allow class="java.awt.Image"/>
+
+  <file name=".*" >
+    <disallow class="java.awt.Image"/>
+  </file>
+</import-control>


### PR DESCRIPTION
Issue #13672: Kill mutation for FileImportControl

# Mutation 
https://github.com/checkstyle/checkstyle/blob/ccc12eb6d7f6c8e0876077e7883cf8f59a541a37/config/pitest-suppressions/pitest-imports-suppressions.xml#L12-L19

# Explaination

This constructor
https://github.com/checkstyle/checkstyle/blob/ccc12eb6d7f6c8e0876077e7883cf8f59a541a37/src/main/java/com/puppycrawl/tools/checkstyle/checks/imports/FileImportControl.java#L44-L49
 is used called only at line 185
https://github.com/checkstyle/checkstyle/blob/ccc12eb6d7f6c8e0876077e7883cf8f59a541a37/src/main/java/com/puppycrawl/tools/checkstyle/checks/imports/ImportControlLoader.java#L181-L186

so this elseif statment will execute in case 
```
 <file name="InputImportControl.*" regex="true">
    <disallow class="java.awt.Image"/>
  </file>
```

where we have file know encloseInGroup is used to non-capture the group I have done some research at
https://stackoverflow.com/questions/3512471/what-is-a-non-capturing-group-in-regular-expressions
