### PR TITLE
minor: Fix wording of Javadoc comment for malformed input

### DIFF
--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/javadoc/NonEmptyAtclauseDescriptionCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/javadoc/NonEmptyAtclauseDescriptionCheckTest.java
@@ -103,10 +103,10 @@ public class NonEmptyAtclauseDescriptionCheckTest
     }
 
     /**
-     * This tests that the check does not fail when the input file contains unmappable characters.
-     * The test file contains the character ü which is not mappable to US-ASCII. It makes sure that
-     * unmappable characters are replaced with the default replacement character using
-     * {@link CodingErrorAction#REPLACE}.
+     * This tests that the check does not fail when the input file contains malformed characters
+     * for a particular charset. The test file contains the character {@code ü} which is not
+     * mappable to US-ASCII. It makes sure that malformed characters than cannot be mapped are
+     * replaced with the default replacement character using {@link CodingErrorAction#REPLACE}.
      *
      * @throws Exception exception
      */


### PR DESCRIPTION
The basic difference is that the comment did not include the term `malformed` input characters. This test particularly tests for malformed input sequences for a particular charset.