### PR TITLE
Issue #13672: Kill mutation for Filter2

### DIFF
--- a/config/pitest-suppressions/pitest-filters-suppressions.xml
+++ b/config/pitest-suppressions/pitest-filters-suppressions.xml
@@ -315,14 +315,14 @@
 
 
 
-  <mutation unstable="false">
-    <sourceFile>SuppressionFilter.java</sourceFile>
-    <mutatedClass>com.puppycrawl.tools.checkstyle.filters.SuppressionFilter</mutatedClass>
-    <mutatedMethod>finishLocalSetup</mutatedMethod>
-    <mutator>org.pitest.mutationtest.engine.gregor.mutators.experimental.MemberVariableMutator</mutator>
-    <description>Removed assignment to member variable filters</description>
-    <lineContent>filters = new FilterSet();</lineContent>
-  </mutation>
+
+
+
+
+
+
+
+
 
 
 

--- a/src/main/java/com/puppycrawl/tools/checkstyle/filters/SuppressionFilter.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/filters/SuppressionFilter.java
@@ -179,9 +179,6 @@ public class SuppressionFilter
                 if (FilterUtil.isFileExists(file)) {
                     filters = SuppressionsLoader.loadSuppressions(file);
                 }
-                else {
-                    filters = new FilterSet();
-                }
             }
             else {
                 filters = SuppressionsLoader.loadSuppressions(file);


### PR DESCRIPTION
Issue #13672: Kill mutation for Filter2

----------

# Filter
https://checkstyle.sourceforge.io/filters/suppressionfilter.html#SuppressionFilter

----------

# Mutation 
https://github.com/checkstyle/checkstyle/blob/d73d90511ce01b9dcebd8486c332480a48369080/config/pitest-suppressions/pitest-filters-suppressions.xml#L318-L325

-----------

# Explaination 

https://github.com/checkstyle/checkstyle/blob/d73d90511ce01b9dcebd8486c332480a48369080/src/main/java/com/puppycrawl/tools/checkstyle/filters/SuppressionFilter.java#L182-L184 
The removal will not make affect becuase lets suppose the optional is true and the file does not exist then it is already initialized at https://github.com/checkstyle/checkstyle/blob/d73d90511ce01b9dcebd8486c332480a48369080/src/main/java/com/puppycrawl/tools/checkstyle/filters/SuppressionFilter.java#L145 so removal will not make affect 