### PR TITLE
Issue #12671: kill pitest mutations in FinalLocalVariableCheck

### DIFF
--- a/config/checker-framework-suppressions/checker-nullness-optional-interning-suppressions.xml
+++ b/config/checker-framework-suppressions/checker-nullness-optional-interning-suppressions.xml
@@ -1747,28 +1747,6 @@
 
   <checkerFrameworkError unstable="false">
     <fileName>src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/FinalLocalVariableCheck.java</fileName>
-    <specifier>argument</specifier>
-    <message>incompatible argument for parameter prevScopeUninitializedVariableData of updateAllUninitializedVariables.</message>
-    <lineContent>updateAllUninitializedVariables(prevScopeUninitializedVariableData);</lineContent>
-    <details>
-      found   : @Initialized @Nullable Deque&lt;@Initialized @NonNull DetailAST&gt;
-      required: @Initialized @NonNull Deque&lt;@Initialized @NonNull DetailAST&gt;
-    </details>
-  </checkerFrameworkError>
-
-  <checkerFrameworkError unstable="false">
-    <fileName>src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/FinalLocalVariableCheck.java</fileName>
-    <specifier>argument</specifier>
-    <message>incompatible argument for parameter prevScopeUninitializedVariableData of updateAllUninitializedVariables.</message>
-    <lineContent>updateAllUninitializedVariables(prevScopeUninitializedVariableData);</lineContent>
-    <details>
-      found   : @Initialized @Nullable Deque&lt;@Initialized @NonNull DetailAST&gt;
-      required: @Initialized @NonNull Deque&lt;@Initialized @NonNull DetailAST&gt;
-    </details>
-  </checkerFrameworkError>
-
-  <checkerFrameworkError unstable="false">
-    <fileName>src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/FinalLocalVariableCheck.java</fileName>
     <specifier>dereference.of.nullable</specifier>
     <message>dereference of possibly-null reference candidate</message>
     <lineContent>shouldRemove = candidate.alreadyAssigned;</lineContent>

--- a/config/pitest-suppressions/pitest-coding-2-suppressions.xml
+++ b/config/pitest-suppressions/pitest-coding-2-suppressions.xml
@@ -1,35 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <suppressedMutations>
   <mutation unstable="false">
-    <sourceFile>FinalLocalVariableCheck.java</sourceFile>
-    <mutatedClass>com.puppycrawl.tools.checkstyle.checks.coding.FinalLocalVariableCheck</mutatedClass>
-    <mutatedMethod>leaveToken</mutatedMethod>
-    <mutator>org.pitest.mutationtest.engine.gregor.mutators.NonVoidMethodCallMutator</mutator>
-    <description>removed call to java/util/Deque::pop</description>
-    <lineContent>prevScopeUninitializedVariables.pop();</lineContent>
-  </mutation>
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-  <mutation unstable="false">
     <sourceFile>UnusedLocalVariableCheck.java</sourceFile>
     <mutatedClass>com.puppycrawl.tools.checkstyle.checks.coding.UnusedLocalVariableCheck$TypeDeclDesc</mutatedClass>
     <mutatedMethod>getUpdatedCopyOfVarStack</mutatedMethod>


### PR DESCRIPTION
Issue #12671

Diff Regression config: https://gist.githubusercontent.com/Kevin222004/6e271c2ae713051c0a30111211de5627/raw/9f34341ce6c7feabbda4bc3d59fa62df427d775d/FinalLocal.xml
Diff Regression projects: https://gist.githubusercontent.com/Kevin222004/9600f179b602d4c971bdb0a050099005/raw/360a95ed7bb60d7a0956e531199d484c4d6f6617/test-projects.properties
Report label: Regression-Oct-03

Attempt to improve [this PR](https://github.com/checkstyle/checkstyle/pull/13184) and kill mutation without affecting performance issues mentioned in the comments.

We don't need a separate stack for `prevScopeUninitializedVariables`. We can track those variables within `ScopeData` and rely on the current check's logic to `pop` from `scopeStack`.