### PR TITLE
Issue #13775: 'javadoc.unclosedHtml' message not present in documentation of most Javadoc Checks

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/annotation/MissingDeprecatedCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/annotation/MissingDeprecatedCheck.java
@@ -97,6 +97,9 @@ import com.puppycrawl.tools.checkstyle.utils.TokenUtil;
  * {@code javadoc.parse.rule.error}
  * </li>
  * <li>
+ * {@code javadoc.unclosedHtml}
+ * </li>
+ * <li>
  * {@code javadoc.wrong.singleton.html.tag}
  * </li>
  * </ul>

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/AbstractJavadocCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/AbstractJavadocCheck.java
@@ -72,6 +72,12 @@ public abstract class AbstractJavadocCheck extends AbstractCheck {
             JavadocDetailNodeParser.MSG_JAVADOC_PARSE_RULE_ERROR;
 
     /**
+     * Message key of error message.
+     */
+    public static final String MSG_KEY_UNCLOSED_HTML_TAG =
+            JavadocDetailNodeParser.MSG_UNCLOSED_HTML_TAG;
+
+    /**
      * Key is "line:column". Value is {@link DetailNode} tree. Map is stored in {@link ThreadLocal}
      * to guarantee basic thread safety and avoid shared, mutable state when not necessary.
      */
@@ -319,7 +325,7 @@ public abstract class AbstractJavadocCheck extends AbstractCheck {
 
                 if (violateExecutionOnNonTightHtml && result.isNonTight()) {
                     log(result.getFirstNonTightHtmlTag().getLine(),
-                            JavadocDetailNodeParser.MSG_UNCLOSED_HTML_TAG,
+                            MSG_KEY_UNCLOSED_HTML_TAG,
                             result.getFirstNonTightHtmlTag().getText());
                 }
             }

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/AtclauseOrderCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/AtclauseOrderCheck.java
@@ -97,6 +97,9 @@ import com.puppycrawl.tools.checkstyle.utils.TokenUtil;
  * {@code javadoc.parse.rule.error}
  * </li>
  * <li>
+ * {@code javadoc.unclosedHtml}
+ * </li>
+ * <li>
  * {@code javadoc.wrong.singleton.html.tag}
  * </li>
  * </ul>

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocBlockTagLocationCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocBlockTagLocationCheck.java
@@ -88,6 +88,9 @@ import com.puppycrawl.tools.checkstyle.api.JavadocTokenTypes;
  * {@code javadoc.parse.rule.error}
  * </li>
  * <li>
+ * {@code javadoc.unclosedHtml}
+ * </li>
+ * <li>
  * {@code javadoc.wrong.singleton.html.tag}
  * </li>
  * </ul>

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocMissingLeadingAsteriskCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocMissingLeadingAsteriskCheck.java
@@ -62,6 +62,9 @@ import com.puppycrawl.tools.checkstyle.utils.TokenUtil;
  * {@code javadoc.parse.rule.error}
  * </li>
  * <li>
+ * {@code javadoc.unclosedHtml}
+ * </li>
+ * <li>
  * {@code javadoc.wrong.singleton.html.tag}
  * </li>
  * </ul>

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocMissingWhitespaceAfterAsteriskCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocMissingWhitespaceAfterAsteriskCheck.java
@@ -57,6 +57,9 @@ import com.puppycrawl.tools.checkstyle.utils.JavadocUtil;
  * {@code javadoc.parse.rule.error}
  * </li>
  * <li>
+ * {@code javadoc.unclosedHtml}
+ * </li>
+ * <li>
  * {@code javadoc.wrong.singleton.html.tag}
  * </li>
  * </ul>

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocParagraphCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocParagraphCheck.java
@@ -79,6 +79,9 @@ import com.puppycrawl.tools.checkstyle.utils.JavadocUtil;
  * {@code javadoc.parse.rule.error}
  * </li>
  * <li>
+ * {@code javadoc.unclosedHtml}
+ * </li>
+ * <li>
  * {@code javadoc.wrong.singleton.html.tag}
  * </li>
  * </ul>

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocTagContinuationIndentationCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocTagContinuationIndentationCheck.java
@@ -64,6 +64,9 @@ import com.puppycrawl.tools.checkstyle.utils.JavadocUtil;
  * {@code javadoc.parse.rule.error}
  * </li>
  * <li>
+ * {@code javadoc.unclosedHtml}
+ * </li>
+ * <li>
  * {@code javadoc.wrong.singleton.html.tag}
  * </li>
  * <li>

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/NonEmptyAtclauseDescriptionCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/NonEmptyAtclauseDescriptionCheck.java
@@ -68,6 +68,9 @@ import com.puppycrawl.tools.checkstyle.utils.JavadocUtil;
  * {@code javadoc.parse.rule.error}
  * </li>
  * <li>
+ * {@code javadoc.unclosedHtml}
+ * </li>
+ * <li>
  * {@code javadoc.wrong.singleton.html.tag}
  * </li>
  * <li>

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/RequireEmptyLineBeforeBlockTagGroupCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/RequireEmptyLineBeforeBlockTagGroupCheck.java
@@ -59,6 +59,9 @@ import com.puppycrawl.tools.checkstyle.utils.JavadocUtil;
  * {@code javadoc.tag.line.before}
  * </li>
  * <li>
+ * {@code javadoc.unclosedHtml}
+ * </li>
+ * <li>
  * {@code javadoc.wrong.singleton.html.tag}
  * </li>
  * </ul>

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/SingleLineJavadocCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/SingleLineJavadocCheck.java
@@ -70,6 +70,9 @@ import com.puppycrawl.tools.checkstyle.utils.TokenUtil;
  * {@code javadoc.parse.rule.error}
  * </li>
  * <li>
+ * {@code javadoc.unclosedHtml}
+ * </li>
+ * <li>
  * {@code javadoc.wrong.singleton.html.tag}
  * </li>
  * <li>

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/SummaryJavadocCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/SummaryJavadocCheck.java
@@ -74,6 +74,9 @@ import com.puppycrawl.tools.checkstyle.utils.TokenUtil;
  * {@code javadoc.parse.rule.error}
  * </li>
  * <li>
+ * {@code javadoc.unclosedHtml}
+ * </li>
+ * <li>
  * {@code javadoc.wrong.singleton.html.tag}
  * </li>
  * <li>

--- a/src/main/resources/com/puppycrawl/tools/checkstyle/meta/checks/annotation/MissingDeprecatedCheck.xml
+++ b/src/main/resources/com/puppycrawl/tools/checkstyle/meta/checks/annotation/MissingDeprecatedCheck.xml
@@ -54,6 +54,7 @@
             <message-key key="javadoc.duplicateTag"/>
             <message-key key="javadoc.missed.html.close"/>
             <message-key key="javadoc.parse.rule.error"/>
+            <message-key key="javadoc.unclosedHtml"/>
             <message-key key="javadoc.wrong.singleton.html.tag"/>
          </message-keys>
       </check>

--- a/src/main/resources/com/puppycrawl/tools/checkstyle/meta/checks/javadoc/AtclauseOrderCheck.xml
+++ b/src/main/resources/com/puppycrawl/tools/checkstyle/meta/checks/javadoc/AtclauseOrderCheck.xml
@@ -36,6 +36,7 @@
             <message-key key="at.clause.order"/>
             <message-key key="javadoc.missed.html.close"/>
             <message-key key="javadoc.parse.rule.error"/>
+            <message-key key="javadoc.unclosedHtml"/>
             <message-key key="javadoc.wrong.singleton.html.tag"/>
          </message-keys>
       </check>

--- a/src/main/resources/com/puppycrawl/tools/checkstyle/meta/checks/javadoc/JavadocBlockTagLocationCheck.xml
+++ b/src/main/resources/com/puppycrawl/tools/checkstyle/meta/checks/javadoc/JavadocBlockTagLocationCheck.xml
@@ -48,6 +48,7 @@
             <message-key key="javadoc.blockTagLocation"/>
             <message-key key="javadoc.missed.html.close"/>
             <message-key key="javadoc.parse.rule.error"/>
+            <message-key key="javadoc.unclosedHtml"/>
             <message-key key="javadoc.wrong.singleton.html.tag"/>
          </message-keys>
       </check>

--- a/src/main/resources/com/puppycrawl/tools/checkstyle/meta/checks/javadoc/JavadocMissingLeadingAsteriskCheck.xml
+++ b/src/main/resources/com/puppycrawl/tools/checkstyle/meta/checks/javadoc/JavadocMissingLeadingAsteriskCheck.xml
@@ -26,6 +26,7 @@
             <message-key key="javadoc.missed.html.close"/>
             <message-key key="javadoc.missing.asterisk"/>
             <message-key key="javadoc.parse.rule.error"/>
+            <message-key key="javadoc.unclosedHtml"/>
             <message-key key="javadoc.wrong.singleton.html.tag"/>
          </message-keys>
       </check>

--- a/src/main/resources/com/puppycrawl/tools/checkstyle/meta/checks/javadoc/JavadocMissingWhitespaceAfterAsteriskCheck.xml
+++ b/src/main/resources/com/puppycrawl/tools/checkstyle/meta/checks/javadoc/JavadocMissingWhitespaceAfterAsteriskCheck.xml
@@ -23,6 +23,7 @@
             <message-key key="javadoc.missed.html.close"/>
             <message-key key="javadoc.missing.whitespace"/>
             <message-key key="javadoc.parse.rule.error"/>
+            <message-key key="javadoc.unclosedHtml"/>
             <message-key key="javadoc.wrong.singleton.html.tag"/>
          </message-keys>
       </check>

--- a/src/main/resources/com/puppycrawl/tools/checkstyle/meta/checks/javadoc/JavadocParagraphCheck.xml
+++ b/src/main/resources/com/puppycrawl/tools/checkstyle/meta/checks/javadoc/JavadocParagraphCheck.xml
@@ -36,6 +36,7 @@
             <message-key key="javadoc.paragraph.redundant.paragraph"/>
             <message-key key="javadoc.paragraph.tag.after"/>
             <message-key key="javadoc.parse.rule.error"/>
+            <message-key key="javadoc.unclosedHtml"/>
             <message-key key="javadoc.wrong.singleton.html.tag"/>
          </message-keys>
       </check>

--- a/src/main/resources/com/puppycrawl/tools/checkstyle/meta/checks/javadoc/JavadocTagContinuationIndentationCheck.xml
+++ b/src/main/resources/com/puppycrawl/tools/checkstyle/meta/checks/javadoc/JavadocTagContinuationIndentationCheck.xml
@@ -26,6 +26,7 @@
          <message-keys>
             <message-key key="javadoc.missed.html.close"/>
             <message-key key="javadoc.parse.rule.error"/>
+            <message-key key="javadoc.unclosedHtml"/>
             <message-key key="javadoc.wrong.singleton.html.tag"/>
             <message-key key="tag.continuation.indent"/>
          </message-keys>

--- a/src/main/resources/com/puppycrawl/tools/checkstyle/meta/checks/javadoc/NonEmptyAtclauseDescriptionCheck.xml
+++ b/src/main/resources/com/puppycrawl/tools/checkstyle/meta/checks/javadoc/NonEmptyAtclauseDescriptionCheck.xml
@@ -25,6 +25,7 @@
          <message-keys>
             <message-key key="javadoc.missed.html.close"/>
             <message-key key="javadoc.parse.rule.error"/>
+            <message-key key="javadoc.unclosedHtml"/>
             <message-key key="javadoc.wrong.singleton.html.tag"/>
             <message-key key="non.empty.atclause"/>
          </message-keys>

--- a/src/main/resources/com/puppycrawl/tools/checkstyle/meta/checks/javadoc/RequireEmptyLineBeforeBlockTagGroupCheck.xml
+++ b/src/main/resources/com/puppycrawl/tools/checkstyle/meta/checks/javadoc/RequireEmptyLineBeforeBlockTagGroupCheck.xml
@@ -21,6 +21,7 @@
             <message-key key="javadoc.missed.html.close"/>
             <message-key key="javadoc.parse.rule.error"/>
             <message-key key="javadoc.tag.line.before"/>
+            <message-key key="javadoc.unclosedHtml"/>
             <message-key key="javadoc.wrong.singleton.html.tag"/>
          </message-keys>
       </check>

--- a/src/main/resources/com/puppycrawl/tools/checkstyle/meta/checks/javadoc/SingleLineJavadocCheck.xml
+++ b/src/main/resources/com/puppycrawl/tools/checkstyle/meta/checks/javadoc/SingleLineJavadocCheck.xml
@@ -30,6 +30,7 @@
          <message-keys>
             <message-key key="javadoc.missed.html.close"/>
             <message-key key="javadoc.parse.rule.error"/>
+            <message-key key="javadoc.unclosedHtml"/>
             <message-key key="javadoc.wrong.singleton.html.tag"/>
             <message-key key="singleline.javadoc"/>
          </message-keys>

--- a/src/main/resources/com/puppycrawl/tools/checkstyle/meta/checks/javadoc/SummaryJavadocCheck.xml
+++ b/src/main/resources/com/puppycrawl/tools/checkstyle/meta/checks/javadoc/SummaryJavadocCheck.xml
@@ -33,6 +33,7 @@
          <message-keys>
             <message-key key="javadoc.missed.html.close"/>
             <message-key key="javadoc.parse.rule.error"/>
+            <message-key key="javadoc.unclosedHtml"/>
             <message-key key="javadoc.wrong.singleton.html.tag"/>
             <message-key key="summary.first.sentence"/>
             <message-key key="summary.javaDoc"/>

--- a/src/test/java/com/puppycrawl/tools/checkstyle/internal/AllChecksTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/internal/AllChecksTest.java
@@ -562,9 +562,7 @@ public class AllChecksTest extends AbstractModuleTestSupport {
 
             for (Object key : pr.keySet()) {
                 // hidden exception messages
-                // unclosedHtml until https://github.com/checkstyle/checkstyle/issues/13775
-                if ("translation.wrongLanguageCode".equals(key)
-                        || "javadoc.unclosedHtml".equals(key)) {
+                if ("translation.wrongLanguageCode".equals(key)) {
                     continue;
                 }
 

--- a/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/checks/annotation/MissingDeprecatedCheckExamplesTest.java
+++ b/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/checks/annotation/MissingDeprecatedCheckExamplesTest.java
@@ -19,8 +19,8 @@
 
 package com.puppycrawl.tools.checkstyle.checks.annotation;
 
-import static com.puppycrawl.tools.checkstyle.JavadocDetailNodeParser.MSG_UNCLOSED_HTML_TAG;
 import static com.puppycrawl.tools.checkstyle.checks.annotation.MissingDeprecatedCheck.MSG_KEY_ANNOTATION_MISSING_DEPRECATED;
+import static com.puppycrawl.tools.checkstyle.checks.javadoc.AbstractJavadocCheck.MSG_KEY_UNCLOSED_HTML_TAG;
 
 import org.junit.jupiter.api.Test;
 
@@ -45,7 +45,7 @@ public class MissingDeprecatedCheckExamplesTest extends AbstractExamplesModuleTe
     public void testExample2() throws Exception {
         final String[] expected = {
             "20: " + getCheckMessage(MSG_KEY_ANNOTATION_MISSING_DEPRECATED),
-            "32: " + getCheckMessage(MSG_UNCLOSED_HTML_TAG, "p"),
+            "32: " + getCheckMessage(MSG_KEY_UNCLOSED_HTML_TAG, "p"),
         };
 
         verifyWithInlineConfigParser(getPath("Example2.java"), expected);

--- a/src/xdocs/checks/annotation/missingdeprecated.xml
+++ b/src/xdocs/checks/annotation/missingdeprecated.xml
@@ -178,6 +178,11 @@ class Example2 {
             </a>
           </li>
           <li>
+            <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources%2Fcom%2Fpuppycrawl%2Ftools%2Fcheckstyle%2Fchecks%2Fannotation%20path%3A**%2Fmessages*.properties+repo%3Acheckstyle%2Fcheckstyle+%22javadoc.unclosedHtml%22">
+              javadoc.unclosedHtml
+            </a>
+          </li>
+          <li>
             <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources%2Fcom%2Fpuppycrawl%2Ftools%2Fcheckstyle%2Fchecks%2Fannotation%20path%3A**%2Fmessages*.properties+repo%3Acheckstyle%2Fcheckstyle+%22javadoc.wrong.singleton.html.tag%22">
               javadoc.wrong.singleton.html.tag
             </a>

--- a/src/xdocs/checks/javadoc/atclauseorder.xml
+++ b/src/xdocs/checks/javadoc/atclauseorder.xml
@@ -165,6 +165,11 @@ class Invalid implements Serializable
             </a>
           </li>
           <li>
+            <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources%2Fcom%2Fpuppycrawl%2Ftools%2Fcheckstyle%2Fchecks%2Fjavadoc%20path%3A**%2Fmessages*.properties+repo%3Acheckstyle%2Fcheckstyle+%22javadoc.unclosedHtml%22">
+              javadoc.unclosedHtml
+            </a>
+          </li>
+          <li>
             <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources%2Fcom%2Fpuppycrawl%2Ftools%2Fcheckstyle%2Fchecks%2Fjavadoc%20path%3A**%2Fmessages*.properties+repo%3Acheckstyle%2Fcheckstyle+%22javadoc.wrong.singleton.html.tag%22">
               javadoc.wrong.singleton.html.tag
             </a>

--- a/src/xdocs/checks/javadoc/javadocblocktaglocation.xml
+++ b/src/xdocs/checks/javadoc/javadocblocktaglocation.xml
@@ -149,6 +149,11 @@
             </a>
           </li>
           <li>
+            <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources%2Fcom%2Fpuppycrawl%2Ftools%2Fcheckstyle%2Fchecks%2Fjavadoc%20path%3A**%2Fmessages*.properties+repo%3Acheckstyle%2Fcheckstyle+%22javadoc.unclosedHtml%22">
+              javadoc.unclosedHtml
+            </a>
+          </li>
+          <li>
             <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources%2Fcom%2Fpuppycrawl%2Ftools%2Fcheckstyle%2Fchecks%2Fjavadoc%20path%3A**%2Fmessages*.properties+repo%3Acheckstyle%2Fcheckstyle+%22javadoc.wrong.singleton.html.tag%22">
               javadoc.wrong.singleton.html.tag
             </a>

--- a/src/xdocs/checks/javadoc/javadocmissingleadingasterisk.xml
+++ b/src/xdocs/checks/javadoc/javadocmissingleadingasterisk.xml
@@ -128,6 +128,11 @@ class Code {}
             </a>
           </li>
           <li>
+            <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources%2Fcom%2Fpuppycrawl%2Ftools%2Fcheckstyle%2Fchecks%2Fjavadoc%20path%3A**%2Fmessages*.properties+repo%3Acheckstyle%2Fcheckstyle+%22javadoc.unclosedHtml%22">
+              javadoc.unclosedHtml
+            </a>
+          </li>
+          <li>
             <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources%2Fcom%2Fpuppycrawl%2Ftools%2Fcheckstyle%2Fchecks%2Fjavadoc%20path%3A**%2Fmessages*.properties+repo%3Acheckstyle%2Fcheckstyle+%22javadoc.wrong.singleton.html.tag%22">
               javadoc.wrong.singleton.html.tag
             </a>

--- a/src/xdocs/checks/javadoc/javadocmissingwhitespaceafterasterisk.xml
+++ b/src/xdocs/checks/javadoc/javadocmissingwhitespaceafterasterisk.xml
@@ -106,6 +106,11 @@ class TestClass {
             </a>
           </li>
           <li>
+            <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources%2Fcom%2Fpuppycrawl%2Ftools%2Fcheckstyle%2Fchecks%2Fjavadoc%20path%3A**%2Fmessages*.properties+repo%3Acheckstyle%2Fcheckstyle+%22javadoc.unclosedHtml%22">
+              javadoc.unclosedHtml
+            </a>
+          </li>
+          <li>
             <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources%2Fcom%2Fpuppycrawl%2Ftools%2Fcheckstyle%2Fchecks%2Fjavadoc%20path%3A**%2Fmessages*.properties+repo%3Acheckstyle%2Fcheckstyle+%22javadoc.wrong.singleton.html.tag%22">
               javadoc.wrong.singleton.html.tag
             </a>

--- a/src/xdocs/checks/javadoc/javadocparagraph.xml
+++ b/src/xdocs/checks/javadoc/javadocparagraph.xml
@@ -170,6 +170,11 @@ public class TestClass {
             </a>
           </li>
           <li>
+            <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources%2Fcom%2Fpuppycrawl%2Ftools%2Fcheckstyle%2Fchecks%2Fjavadoc%20path%3A**%2Fmessages*.properties+repo%3Acheckstyle%2Fcheckstyle+%22javadoc.unclosedHtml%22">
+              javadoc.unclosedHtml
+            </a>
+          </li>
+          <li>
             <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources%2Fcom%2Fpuppycrawl%2Ftools%2Fcheckstyle%2Fchecks%2Fjavadoc%20path%3A**%2Fmessages*.properties+repo%3Acheckstyle%2Fcheckstyle+%22javadoc.wrong.singleton.html.tag%22">
               javadoc.wrong.singleton.html.tag
             </a>

--- a/src/xdocs/checks/javadoc/javadoctagcontinuationindentation.xml
+++ b/src/xdocs/checks/javadoc/javadoctagcontinuationindentation.xml
@@ -152,6 +152,11 @@ public class Test {
             </a>
           </li>
           <li>
+            <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources%2Fcom%2Fpuppycrawl%2Ftools%2Fcheckstyle%2Fchecks%2Fjavadoc%20path%3A**%2Fmessages*.properties+repo%3Acheckstyle%2Fcheckstyle+%22javadoc.unclosedHtml%22">
+              javadoc.unclosedHtml
+            </a>
+          </li>
+          <li>
             <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources%2Fcom%2Fpuppycrawl%2Ftools%2Fcheckstyle%2Fchecks%2Fjavadoc%20path%3A**%2Fmessages*.properties+repo%3Acheckstyle%2Fcheckstyle+%22javadoc.wrong.singleton.html.tag%22">
               javadoc.wrong.singleton.html.tag
             </a>

--- a/src/xdocs/checks/javadoc/nonemptyatclausedescription.xml
+++ b/src/xdocs/checks/javadoc/nonemptyatclausedescription.xml
@@ -165,6 +165,11 @@ class Test
             </a>
           </li>
           <li>
+            <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources%2Fcom%2Fpuppycrawl%2Ftools%2Fcheckstyle%2Fchecks%2Fjavadoc%20path%3A**%2Fmessages*.properties+repo%3Acheckstyle%2Fcheckstyle+%22javadoc.unclosedHtml%22">
+              javadoc.unclosedHtml
+            </a>
+          </li>
+          <li>
             <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources%2Fcom%2Fpuppycrawl%2Ftools%2Fcheckstyle%2Fchecks%2Fjavadoc%20path%3A**%2Fmessages*.properties+repo%3Acheckstyle%2Fcheckstyle+%22javadoc.wrong.singleton.html.tag%22">
               javadoc.wrong.singleton.html.tag
             </a>

--- a/src/xdocs/checks/javadoc/requireemptylinebeforeblocktaggroup.xml
+++ b/src/xdocs/checks/javadoc/requireemptylinebeforeblocktaggroup.xml
@@ -110,6 +110,11 @@ public boolean testMethod(int firstParam) {
             </a>
           </li>
           <li>
+            <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources%2Fcom%2Fpuppycrawl%2Ftools%2Fcheckstyle%2Fchecks%2Fjavadoc%20path%3A**%2Fmessages*.properties+repo%3Acheckstyle%2Fcheckstyle+%22javadoc.unclosedHtml%22">
+              javadoc.unclosedHtml
+            </a>
+          </li>
+          <li>
             <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources%2Fcom%2Fpuppycrawl%2Ftools%2Fcheckstyle%2Fchecks%2Fjavadoc%20path%3A**%2Fmessages*.properties+repo%3Acheckstyle%2Fcheckstyle+%22javadoc.wrong.singleton.html.tag%22">
               javadoc.wrong.singleton.html.tag
             </a>

--- a/src/xdocs/checks/javadoc/singlelinejavadoc.xml
+++ b/src/xdocs/checks/javadoc/singlelinejavadoc.xml
@@ -278,6 +278,11 @@ public int foobar() {
             </a>
           </li>
           <li>
+            <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources%2Fcom%2Fpuppycrawl%2Ftools%2Fcheckstyle%2Fchecks%2Fjavadoc%20path%3A**%2Fmessages*.properties+repo%3Acheckstyle%2Fcheckstyle+%22javadoc.unclosedHtml%22">
+              javadoc.unclosedHtml
+            </a>
+          </li>
+          <li>
             <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources%2Fcom%2Fpuppycrawl%2Ftools%2Fcheckstyle%2Fchecks%2Fjavadoc%20path%3A**%2Fmessages*.properties+repo%3Acheckstyle%2Fcheckstyle+%22javadoc.wrong.singleton.html.tag%22">
               javadoc.wrong.singleton.html.tag
             </a>

--- a/src/xdocs/checks/javadoc/summaryjavadoc.xml
+++ b/src/xdocs/checks/javadoc/summaryjavadoc.xml
@@ -222,6 +222,11 @@ public class Test {
             </a>
           </li>
           <li>
+            <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources%2Fcom%2Fpuppycrawl%2Ftools%2Fcheckstyle%2Fchecks%2Fjavadoc%20path%3A**%2Fmessages*.properties+repo%3Acheckstyle%2Fcheckstyle+%22javadoc.unclosedHtml%22">
+              javadoc.unclosedHtml
+            </a>
+          </li>
+          <li>
             <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources%2Fcom%2Fpuppycrawl%2Ftools%2Fcheckstyle%2Fchecks%2Fjavadoc%20path%3A**%2Fmessages*.properties+repo%3Acheckstyle%2Fcheckstyle+%22javadoc.wrong.singleton.html.tag%22">
               javadoc.wrong.singleton.html.tag
             </a>


### PR DESCRIPTION
Resolve #13775