### PR TITLE
Issue #13809: kill mutation for AbstarctRootNode

### DIFF
--- a/config/pitest-suppressions/pitest-xpath-suppressions.xml
+++ b/config/pitest-suppressions/pitest-xpath-suppressions.xml
@@ -1,15 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <suppressedMutations>
   <mutation unstable="false">
-    <sourceFile>AbstractRootNode.java</sourceFile>
-    <mutatedClass>com.puppycrawl.tools.checkstyle.xpath.AbstractRootNode</mutatedClass>
-    <mutatedMethod>iterateAxis</mutatedMethod>
-    <mutator>org.pitest.mutationtest.engine.gregor.mutators.experimental.RemoveSwitchMutator_2</mutator>
-    <description>RemoveSwitch 2 (case value 2)</description>
-    <lineContent>switch (axisNumber) {</lineContent>
-  </mutation>
-
-  <mutation unstable="false">
     <sourceFile>FollowingIterator.java</sourceFile>
     <mutatedClass>com.puppycrawl.tools.checkstyle.xpath.iterators.FollowingIterator</mutatedClass>
     <mutatedMethod>next</mutatedMethod>

--- a/src/main/java/com/puppycrawl/tools/checkstyle/xpath/AbstractRootNode.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/xpath/AbstractRootNode.java
@@ -126,7 +126,6 @@ public abstract class AbstractRootNode extends AbstractNode {
         final AxisIterator result;
         switch (axisNumber) {
             case AxisInfo.ANCESTOR:
-            case AxisInfo.ATTRIBUTE:
             case AxisInfo.PARENT:
             case AxisInfo.FOLLOWING:
             case AxisInfo.FOLLOWING_SIBLING:


### PR DESCRIPTION
Issue #13809: kill mutation for AbstarctRootNode

## Mutation
https://github.com/checkstyle/checkstyle/blob/d316b893da935d33736e90321b909f9b72d835d8/config/pitest-suppressions/pitest-xpath-suppressions.xml#L3-L10


Attributes are not allowed by design:
https://github.com/checkstyle/checkstyle/blob/a7fa83a3de92486dd7033b45bc5364ca3eae9725/src/main/java/com/puppycrawl/tools/checkstyle/xpath/AbstractRootNode.java#L73-L75