### PR TITLE
Issue #13809: kill mutation for JavadocPropertiesGenerator

### DIFF
--- a/config/pitest-suppressions/pitest-common-2-suppressions.xml
+++ b/config/pitest-suppressions/pitest-common-2-suppressions.xml
@@ -13,15 +13,6 @@
   <mutation unstable="false">
     <sourceFile>JavadocPropertiesGenerator.java</sourceFile>
     <mutatedClass>com.puppycrawl.tools.checkstyle.JavadocPropertiesGenerator</mutatedClass>
-    <mutatedMethod>getFirstJavadocSentence</mutatedMethod>
-    <mutator>org.pitest.mutationtest.engine.gregor.mutators.NonVoidMethodCallMutator</mutator>
-    <description>removed call to com/puppycrawl/tools/checkstyle/api/DetailAST::getNextSibling</description>
-    <lineContent>child = child.getNextSibling()) {</lineContent>
-  </mutation>
-
-  <mutation unstable="false">
-    <sourceFile>JavadocPropertiesGenerator.java</sourceFile>
-    <mutatedClass>com.puppycrawl.tools.checkstyle.JavadocPropertiesGenerator</mutatedClass>
     <mutatedMethod>main</mutatedMethod>
     <mutator>org.pitest.mutationtest.engine.gregor.mutators.experimental.NakedReceiverMutator</mutator>
     <description>replaced call to picocli/CommandLine::setUsageHelpWidth with receiver</description>

--- a/src/test/java/com/puppycrawl/tools/checkstyle/JavadocPropertiesGeneratorTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/JavadocPropertiesGeneratorTest.java
@@ -355,4 +355,23 @@ public class JavadocPropertiesGeneratorTest extends AbstractPathTestSupport {
         }
     }
 
+    @Test
+    public void testGetFirstJavadocSentence(@SysErr Capturable systemErr,
+                                            @SysOut Capturable systemOut) throws Exception {
+        final String expectedContent = "EOF1=First Javadoc Sentence.";
+
+        JavadocPropertiesGenerator.main(
+                getPath("InputJavadocPropertiesGeneratorGetFirstJavadocSentence.java"),
+            "--destfile", DESTFILE_ABSOLUTE_PATH);
+        assertWithMessage("Unexpected error log")
+            .that(systemErr.getCapturedData())
+            .isEqualTo("");
+        assertWithMessage("Unexpected output log")
+            .that(systemOut.getCapturedData())
+            .isEqualTo("");
+        final String fileContent = FileUtils.readFileToString(DESTFILE, StandardCharsets.UTF_8);
+        assertWithMessage("File content is not expected")
+            .that(fileContent.trim())
+            .isEqualTo(expectedContent.trim());
+    }
 }

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/javadocpropertiesgenerator/InputJavadocPropertiesGeneratorGetFirstJavadocSentence.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/javadocpropertiesgenerator/InputJavadocPropertiesGeneratorGetFirstJavadocSentence.java
@@ -1,0 +1,13 @@
+package com.puppycrawl.tools.checkstyle.javadocpropertiesgenerator;
+
+public class InputJavadocPropertiesGeneratorGetFirstJavadocSentence {
+
+    // Test getFirstJavadocSentence with SingleLineComment above javadoc.
+    // This test case will be helpful to test the loop.
+    // We can ensure that we print the correct javadoc no matter how many
+    // tokens are as a first child of MODIFIERS.
+    /**
+     * First Javadoc Sentence.
+     */
+    public static final int EOF1 = 1;
+}


### PR DESCRIPTION
Issue #13809: kill mutation for JavadocPropertiesGenerator

# Mutation

https://github.com/checkstyle/checkstyle/blob/a7fa83a3de92486dd7033b45bc5364ca3eae9725/config/pitest-suppressions/pitest-common-2-suppressions.xml#L111-L118

# Explaintaion
Test