### PR TITLE
Issue #13809: kill mutation for AuditEventDefaultFormatter

### DIFF
--- a/config/checker-framework-suppressions/checker-index-suppressions.xml
+++ b/config/checker-framework-suppressions/checker-index-suppressions.xml
@@ -12,17 +12,6 @@
   </checkerFrameworkError>
 
   <checkerFrameworkError unstable="false">
-    <fileName>src/main/java/com/puppycrawl/tools/checkstyle/AuditEventDefaultFormatter.java</fileName>
-    <specifier>argument</specifier>
-    <message>incompatible argument for parameter capacity of StringBuilder.</message>
-    <lineContent>final StringBuilder sb = new StringBuilder(bufLen);</lineContent>
-    <details>
-      found   : int
-      required: @NonNegative int
-    </details>
-  </checkerFrameworkError>
-
-  <checkerFrameworkError unstable="false">
     <fileName>src/main/java/com/puppycrawl/tools/checkstyle/DetailAstImpl.java</fileName>
     <specifier>argument</specifier>
     <message>incompatible argument for parameter bitIndex of get.</message>

--- a/config/pitest-suppressions/pitest-common-suppressions.xml
+++ b/config/pitest-suppressions/pitest-common-suppressions.xml
@@ -1,33 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <suppressedMutations>
   <mutation unstable="false">
-    <sourceFile>AuditEventDefaultFormatter.java</sourceFile>
-    <mutatedClass>com.puppycrawl.tools.checkstyle.AuditEventDefaultFormatter</mutatedClass>
-    <mutatedMethod>format</mutatedMethod>
-    <mutator>org.pitest.mutationtest.engine.gregor.mutators.NonVoidMethodCallMutator</mutator>
-    <description>removed call to com/puppycrawl/tools/checkstyle/AuditEventDefaultFormatter::calculateBufferLength</description>
-    <lineContent>final int bufLen = calculateBufferLength(event, severityLevelName.length());</lineContent>
-  </mutation>
-
-  <mutation unstable="false">
-    <sourceFile>AuditEventDefaultFormatter.java</sourceFile>
-    <mutatedClass>com.puppycrawl.tools.checkstyle.AuditEventDefaultFormatter</mutatedClass>
-    <mutatedMethod>format</mutatedMethod>
-    <mutator>org.pitest.mutationtest.engine.gregor.mutators.NonVoidMethodCallMutator</mutator>
-    <description>removed call to java/lang/String::length</description>
-    <lineContent>final int bufLen = calculateBufferLength(event, severityLevelName.length());</lineContent>
-  </mutation>
-
-  <mutation unstable="false">
-    <sourceFile>AuditEventDefaultFormatter.java</sourceFile>
-    <mutatedClass>com.puppycrawl.tools.checkstyle.AuditEventDefaultFormatter</mutatedClass>
-    <mutatedMethod>format</mutatedMethod>
-    <mutator>org.pitest.mutationtest.engine.gregor.mutators.experimental.ArgumentPropagationMutator</mutator>
-    <description>replaced call to com/puppycrawl/tools/checkstyle/AuditEventDefaultFormatter::calculateBufferLength with argument</description>
-    <lineContent>final int bufLen = calculateBufferLength(event, severityLevelName.length());</lineContent>
-  </mutation>
-
-  <mutation unstable="false">
     <sourceFile>Checker.java</sourceFile>
     <mutatedClass>com.puppycrawl.tools.checkstyle.Checker</mutatedClass>
     <mutatedMethod>&lt;init&gt;</mutatedMethod>

--- a/pom.xml
+++ b/pom.xml
@@ -4372,6 +4372,8 @@
               <excludedMethods>
                 <!-- caching of search results, big performance optimization -->
                 <param>lazyLoad</param>
+                <!-- performance optimization -->
+                <param>initStringBuilderWithOptimalBuffer</param>
               </excludedMethods>
               <coverageThreshold>100</coverageThreshold>
               <mutationThreshold>96</mutationThreshold>

--- a/src/main/java/com/puppycrawl/tools/checkstyle/AuditEventDefaultFormatter.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/AuditEventDefaultFormatter.java
@@ -55,9 +55,7 @@ public class AuditEventDefaultFormatter implements AuditEventFormatter {
             severityLevelName = severityLevel.getName().toUpperCase(Locale.US);
         }
 
-        // Avoid StringBuffer.expandCapacity
-        final int bufLen = calculateBufferLength(event, severityLevelName.length());
-        final StringBuilder sb = new StringBuilder(bufLen);
+        final StringBuilder sb = initStringBuilderWithOptimalBuffer(event, severityLevelName);
 
         sb.append('[').append(severityLevelName).append("] ")
             .append(fileName).append(':').append(event.getLine());
@@ -78,18 +76,21 @@ public class AuditEventDefaultFormatter implements AuditEventFormatter {
     }
 
     /**
-     * Returns the length of the buffer for StringBuilder.
+     * Returns the StringBuilder that should avoid StringBuffer.expandCapacity.
      * bufferLength = fileNameLength + messageLength + lengthOfAllSeparators +
      * + severityNameLength + checkNameLength.
+     * Method is excluded from pitest validation.
      *
      * @param event audit event.
-     * @param severityLevelNameLength length of severity level name.
-     * @return the length of the buffer for StringBuilder.
+     * @param severityLevelName severity level name.
+     * @return optimal StringBuilder.
      */
-    private static int calculateBufferLength(AuditEvent event, int severityLevelNameLength) {
-        return LENGTH_OF_ALL_SEPARATORS + event.getFileName().length()
-            + event.getMessage().length() + severityLevelNameLength
+    private static StringBuilder initStringBuilderWithOptimalBuffer(AuditEvent event,
+            String severityLevelName) {
+        final int bufLen = LENGTH_OF_ALL_SEPARATORS + event.getFileName().length()
+            + event.getMessage().length() + severityLevelName.length()
             + getCheckShortName(event).length();
+        return new StringBuilder(bufLen);
     }
 
     /**

--- a/src/test/java/com/puppycrawl/tools/checkstyle/AuditEventDefaultFormatterTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/AuditEventDefaultFormatterTest.java
@@ -80,12 +80,12 @@ public class AuditEventDefaultFormatterTest {
                 "messages.properties", "key", null, SeverityLevel.ERROR, null,
                 getClass(), null);
         final AuditEvent auditEvent = new AuditEvent(new Object(), "fileName", violation);
-        final int result = TestUtil.invokeStaticMethod(AuditEventDefaultFormatter.class,
-                "calculateBufferLength", auditEvent, SeverityLevel.ERROR.ordinal());
+        final StringBuilder result = TestUtil.invokeStaticMethod(AuditEventDefaultFormatter.class,
+                "initStringBuilderWithOptimalBuffer", auditEvent, SeverityLevel.ERROR.toString());
 
         assertWithMessage("Buffer length is not expected")
-                .that(result)
-                .isEqualTo(54);
+                .that(result.capacity())
+                .isEqualTo(56);
     }
 
     private static final class TestModuleCheck {


### PR DESCRIPTION
Issue #13809: kill mutation for AuditEventDefaultFormatter

# Explaintation

I didn't find any test case for this and the reason may be in StringBuilder even after we assign the capacity if the character or string goes beyond the limit of assigned capacity. it will automatically expands the necessary memory to accommodate character to string builder.