### PR TITLE
Issue #13809: Kill mutation in Filters

### DIFF
--- a/config/checker-framework-suppressions/checker-lock-tainting-suppressions.xml
+++ b/config/checker-framework-suppressions/checker-lock-tainting-suppressions.xml
@@ -841,6 +841,69 @@
 
   <checkerFrameworkError unstable="false">
     <fileName>src/main/java/com/puppycrawl/tools/checkstyle/filters/SuppressFilterElement.java</fileName>
+    <specifier>method.guarantee.violated</specifier>
+    <message>@Pure method equals calls method getPatternSafely with a weaker @ReleasesNoLocks side effect guarantee</message>
+    <lineContent>&amp;&amp; Objects.equals(getPatternSafely(checkRegexp),</lineContent>
+  </checkerFrameworkError>
+
+  <checkerFrameworkError unstable="false">
+    <fileName>src/main/java/com/puppycrawl/tools/checkstyle/filters/SuppressFilterElement.java</fileName>
+    <specifier>method.guarantee.violated</specifier>
+    <message>@Pure method equals calls method getPatternSafely with a weaker @ReleasesNoLocks side effect guarantee</message>
+    <lineContent>&amp;&amp; Objects.equals(getPatternSafely(messageRegexp),</lineContent>
+  </checkerFrameworkError>
+
+  <checkerFrameworkError unstable="false">
+    <fileName>src/main/java/com/puppycrawl/tools/checkstyle/filters/SuppressFilterElement.java</fileName>
+    <specifier>method.guarantee.violated</specifier>
+    <message>@Pure method equals calls method getPatternSafely with a weaker @ReleasesNoLocks side effect guarantee</message>
+    <lineContent>getPatternSafely(suppressElement.checkRegexp))</lineContent>
+  </checkerFrameworkError>
+
+  <checkerFrameworkError unstable="false">
+    <fileName>src/main/java/com/puppycrawl/tools/checkstyle/filters/SuppressFilterElement.java</fileName>
+    <specifier>method.guarantee.violated</specifier>
+    <message>@Pure method equals calls method getPatternSafely with a weaker @ReleasesNoLocks side effect guarantee</message>
+    <lineContent>getPatternSafely(suppressElement.fileRegexp))</lineContent>
+  </checkerFrameworkError>
+
+  <checkerFrameworkError unstable="false">
+    <fileName>src/main/java/com/puppycrawl/tools/checkstyle/filters/SuppressFilterElement.java</fileName>
+    <specifier>method.guarantee.violated</specifier>
+    <message>@Pure method equals calls method getPatternSafely with a weaker @ReleasesNoLocks side effect guarantee</message>
+    <lineContent>getPatternSafely(suppressElement.messageRegexp))</lineContent>
+  </checkerFrameworkError>
+
+  <checkerFrameworkError unstable="false">
+    <fileName>src/main/java/com/puppycrawl/tools/checkstyle/filters/SuppressFilterElement.java</fileName>
+    <specifier>method.guarantee.violated</specifier>
+    <message>@Pure method equals calls method getPatternSafely with a weaker @ReleasesNoLocks side effect guarantee</message>
+    <lineContent>return Objects.equals(getPatternSafely(fileRegexp),</lineContent>
+  </checkerFrameworkError>
+
+  <checkerFrameworkError unstable="false">
+    <fileName>src/main/java/com/puppycrawl/tools/checkstyle/filters/SuppressFilterElement.java</fileName>
+    <specifier>method.guarantee.violated</specifier>
+    <message>@Pure method hashCode calls method getPatternSafely with a weaker @ReleasesNoLocks side effect guarantee</message>
+    <lineContent>getPatternSafely(messageRegexp), moduleId, linesCsv, columnsCsv);</lineContent>
+  </checkerFrameworkError>
+
+  <checkerFrameworkError unstable="false">
+    <fileName>src/main/java/com/puppycrawl/tools/checkstyle/filters/SuppressFilterElement.java</fileName>
+    <specifier>method.guarantee.violated</specifier>
+    <message>@Pure method hashCode calls method getPatternSafely with a weaker @ReleasesNoLocks side effect guarantee</message>
+    <lineContent>return Objects.hash(getPatternSafely(fileRegexp), getPatternSafely(checkRegexp),</lineContent>
+  </checkerFrameworkError>
+
+  <checkerFrameworkError unstable="false">
+    <fileName>src/main/java/com/puppycrawl/tools/checkstyle/filters/SuppressFilterElement.java</fileName>
+    <specifier>method.guarantee.violated</specifier>
+    <message>@Pure method hashCode calls method getPatternSafely with a weaker @ReleasesNoLocks side effect guarantee</message>
+    <lineContent>return Objects.hash(getPatternSafely(fileRegexp), getPatternSafely(checkRegexp),</lineContent>
+  </checkerFrameworkError>
+
+  <checkerFrameworkError unstable="false">
+    <fileName>src/main/java/com/puppycrawl/tools/checkstyle/filters/SuppressFilterElement.java</fileName>
     <specifier>override.param</specifier>
     <message>Incompatible parameter type for other.</message>
     <lineContent>public boolean equals(Object other) {</lineContent>
@@ -1107,6 +1170,69 @@
       cannot override method in @GuardedBy Object
       @GuardedBy int hashCode(@GuardSatisfied Object this)
     </details>
+  </checkerFrameworkError>
+
+  <checkerFrameworkError unstable="false">
+    <fileName>src/main/java/com/puppycrawl/tools/checkstyle/filters/XpathFilterElement.java</fileName>
+    <specifier>method.guarantee.violated</specifier>
+    <message>@Pure method equals calls method getPatternSafely with a weaker @ReleasesNoLocks side effect guarantee</message>
+    <lineContent>&amp;&amp; Objects.equals(getPatternSafely(checkRegexp),</lineContent>
+  </checkerFrameworkError>
+
+  <checkerFrameworkError unstable="false">
+    <fileName>src/main/java/com/puppycrawl/tools/checkstyle/filters/XpathFilterElement.java</fileName>
+    <specifier>method.guarantee.violated</specifier>
+    <message>@Pure method equals calls method getPatternSafely with a weaker @ReleasesNoLocks side effect guarantee</message>
+    <lineContent>&amp;&amp; Objects.equals(getPatternSafely(messageRegexp),</lineContent>
+  </checkerFrameworkError>
+
+  <checkerFrameworkError unstable="false">
+    <fileName>src/main/java/com/puppycrawl/tools/checkstyle/filters/XpathFilterElement.java</fileName>
+    <specifier>method.guarantee.violated</specifier>
+    <message>@Pure method equals calls method getPatternSafely with a weaker @ReleasesNoLocks side effect guarantee</message>
+    <lineContent>getPatternSafely(xpathFilter.checkRegexp))</lineContent>
+  </checkerFrameworkError>
+
+  <checkerFrameworkError unstable="false">
+    <fileName>src/main/java/com/puppycrawl/tools/checkstyle/filters/XpathFilterElement.java</fileName>
+    <specifier>method.guarantee.violated</specifier>
+    <message>@Pure method equals calls method getPatternSafely with a weaker @ReleasesNoLocks side effect guarantee</message>
+    <lineContent>getPatternSafely(xpathFilter.fileRegexp))</lineContent>
+  </checkerFrameworkError>
+
+  <checkerFrameworkError unstable="false">
+    <fileName>src/main/java/com/puppycrawl/tools/checkstyle/filters/XpathFilterElement.java</fileName>
+    <specifier>method.guarantee.violated</specifier>
+    <message>@Pure method equals calls method getPatternSafely with a weaker @ReleasesNoLocks side effect guarantee</message>
+    <lineContent>getPatternSafely(xpathFilter.messageRegexp))</lineContent>
+  </checkerFrameworkError>
+
+  <checkerFrameworkError unstable="false">
+    <fileName>src/main/java/com/puppycrawl/tools/checkstyle/filters/XpathFilterElement.java</fileName>
+    <specifier>method.guarantee.violated</specifier>
+    <message>@Pure method equals calls method getPatternSafely with a weaker @ReleasesNoLocks side effect guarantee</message>
+    <lineContent>return Objects.equals(getPatternSafely(fileRegexp),</lineContent>
+  </checkerFrameworkError>
+
+  <checkerFrameworkError unstable="false">
+    <fileName>src/main/java/com/puppycrawl/tools/checkstyle/filters/XpathFilterElement.java</fileName>
+    <specifier>method.guarantee.violated</specifier>
+    <message>@Pure method hashCode calls method getPatternSafely with a weaker @ReleasesNoLocks side effect guarantee</message>
+    <lineContent>getPatternSafely(messageRegexp), moduleId, xpathQuery);</lineContent>
+  </checkerFrameworkError>
+
+  <checkerFrameworkError unstable="false">
+    <fileName>src/main/java/com/puppycrawl/tools/checkstyle/filters/XpathFilterElement.java</fileName>
+    <specifier>method.guarantee.violated</specifier>
+    <message>@Pure method hashCode calls method getPatternSafely with a weaker @ReleasesNoLocks side effect guarantee</message>
+    <lineContent>return Objects.hash(getPatternSafely(fileRegexp), getPatternSafely(checkRegexp),</lineContent>
+  </checkerFrameworkError>
+
+  <checkerFrameworkError unstable="false">
+    <fileName>src/main/java/com/puppycrawl/tools/checkstyle/filters/XpathFilterElement.java</fileName>
+    <specifier>method.guarantee.violated</specifier>
+    <message>@Pure method hashCode calls method getPatternSafely with a weaker @ReleasesNoLocks side effect guarantee</message>
+    <lineContent>return Objects.hash(getPatternSafely(fileRegexp), getPatternSafely(checkRegexp),</lineContent>
   </checkerFrameworkError>
 
   <checkerFrameworkError unstable="false">

--- a/config/checker-framework-suppressions/checker-nullness-optional-interning-suppressions.xml
+++ b/config/checker-framework-suppressions/checker-nullness-optional-interning-suppressions.xml
@@ -4690,28 +4690,6 @@
     <fileName>src/main/java/com/puppycrawl/tools/checkstyle/filters/SuppressFilterElement.java</fileName>
     <specifier>assignment</specifier>
     <message>incompatible types in assignment.</message>
-    <lineContent>checkRegexp = null;</lineContent>
-    <details>
-      found   : null (NullType)
-      required: @Initialized @NonNull Pattern
-    </details>
-  </checkerFrameworkError>
-
-  <checkerFrameworkError unstable="false">
-    <fileName>src/main/java/com/puppycrawl/tools/checkstyle/filters/SuppressFilterElement.java</fileName>
-    <specifier>assignment</specifier>
-    <message>incompatible types in assignment.</message>
-    <lineContent>fileRegexp = null;</lineContent>
-    <details>
-      found   : null (NullType)
-      required: @Initialized @NonNull Pattern
-    </details>
-  </checkerFrameworkError>
-
-  <checkerFrameworkError unstable="false">
-    <fileName>src/main/java/com/puppycrawl/tools/checkstyle/filters/SuppressFilterElement.java</fileName>
-    <specifier>assignment</specifier>
-    <message>incompatible types in assignment.</message>
     <lineContent>fileRegexp = null;</lineContent>
     <details>
       found   : null (NullType)
@@ -4727,28 +4705,6 @@
     <details>
       found   : null (NullType)
       required: @Initialized @NonNull Pattern
-    </details>
-  </checkerFrameworkError>
-
-  <checkerFrameworkError unstable="false">
-    <fileName>src/main/java/com/puppycrawl/tools/checkstyle/filters/SuppressFilterElement.java</fileName>
-    <specifier>assignment</specifier>
-    <message>incompatible types in assignment.</message>
-    <lineContent>messageRegexp = null;</lineContent>
-    <details>
-      found   : null (NullType)
-      required: @Initialized @NonNull Pattern
-    </details>
-  </checkerFrameworkError>
-
-  <checkerFrameworkError unstable="false">
-    <fileName>src/main/java/com/puppycrawl/tools/checkstyle/filters/SuppressFilterElement.java</fileName>
-    <specifier>assignment</specifier>
-    <message>incompatible types in assignment.</message>
-    <lineContent>checkPattern = null;</lineContent>
-    <details>
-      found   : null (NullType)
-      required: @Initialized @NonNull String
     </details>
   </checkerFrameworkError>
 
@@ -4757,17 +4713,6 @@
     <specifier>assignment</specifier>
     <message>incompatible types in assignment.</message>
     <lineContent>columnsCsv = null;</lineContent>
-    <details>
-      found   : null (NullType)
-      required: @Initialized @NonNull String
-    </details>
-  </checkerFrameworkError>
-
-  <checkerFrameworkError unstable="false">
-    <fileName>src/main/java/com/puppycrawl/tools/checkstyle/filters/SuppressFilterElement.java</fileName>
-    <specifier>assignment</specifier>
-    <message>incompatible types in assignment.</message>
-    <lineContent>filePattern = null;</lineContent>
     <details>
       found   : null (NullType)
       required: @Initialized @NonNull String
@@ -4787,17 +4732,6 @@
 
   <checkerFrameworkError unstable="false">
     <fileName>src/main/java/com/puppycrawl/tools/checkstyle/filters/SuppressFilterElement.java</fileName>
-    <specifier>assignment</specifier>
-    <message>incompatible types in assignment.</message>
-    <lineContent>messagePattern = null;</lineContent>
-    <details>
-      found   : null (NullType)
-      required: @Initialized @NonNull String
-    </details>
-  </checkerFrameworkError>
-
-  <checkerFrameworkError unstable="false">
-    <fileName>src/main/java/com/puppycrawl/tools/checkstyle/filters/SuppressFilterElement.java</fileName>
     <specifier>override.param</specifier>
     <message>Incompatible parameter type for other.</message>
     <lineContent>public boolean equals(Object other) {</lineContent>
@@ -4808,6 +4742,17 @@
       @Initialized @NonNull boolean equals(@Initialized @NonNull SuppressFilterElement this, @Initialized @NonNull Object p0)
       cannot override method in @Initialized @NonNull Object
       @Initialized @NonNull boolean equals(@Initialized @NonNull Object this, @Initialized @Nullable Object p0)
+    </details>
+  </checkerFrameworkError>
+
+  <checkerFrameworkError unstable="false">
+    <fileName>src/main/java/com/puppycrawl/tools/checkstyle/filters/SuppressFilterElement.java</fileName>
+    <specifier>return</specifier>
+    <message>incompatible types in return.</message>
+    <lineContent>return result;</lineContent>
+    <details>
+      type of expression: @Initialized @Nullable String
+      method return type: @Initialized @NonNull String
     </details>
   </checkerFrameworkError>
 
@@ -5357,72 +5302,6 @@
     <fileName>src/main/java/com/puppycrawl/tools/checkstyle/filters/XpathFilterElement.java</fileName>
     <specifier>assignment</specifier>
     <message>incompatible types in assignment.</message>
-    <lineContent>checkRegexp = null;</lineContent>
-    <details>
-      found   : null (NullType)
-      required: @Initialized @NonNull Pattern
-    </details>
-  </checkerFrameworkError>
-
-  <checkerFrameworkError unstable="false">
-    <fileName>src/main/java/com/puppycrawl/tools/checkstyle/filters/XpathFilterElement.java</fileName>
-    <specifier>assignment</specifier>
-    <message>incompatible types in assignment.</message>
-    <lineContent>fileRegexp = null;</lineContent>
-    <details>
-      found   : null (NullType)
-      required: @Initialized @NonNull Pattern
-    </details>
-  </checkerFrameworkError>
-
-  <checkerFrameworkError unstable="false">
-    <fileName>src/main/java/com/puppycrawl/tools/checkstyle/filters/XpathFilterElement.java</fileName>
-    <specifier>assignment</specifier>
-    <message>incompatible types in assignment.</message>
-    <lineContent>messageRegexp = null;</lineContent>
-    <details>
-      found   : null (NullType)
-      required: @Initialized @NonNull Pattern
-    </details>
-  </checkerFrameworkError>
-
-  <checkerFrameworkError unstable="false">
-    <fileName>src/main/java/com/puppycrawl/tools/checkstyle/filters/XpathFilterElement.java</fileName>
-    <specifier>assignment</specifier>
-    <message>incompatible types in assignment.</message>
-    <lineContent>checkPattern = null;</lineContent>
-    <details>
-      found   : null (NullType)
-      required: @Initialized @NonNull String
-    </details>
-  </checkerFrameworkError>
-
-  <checkerFrameworkError unstable="false">
-    <fileName>src/main/java/com/puppycrawl/tools/checkstyle/filters/XpathFilterElement.java</fileName>
-    <specifier>assignment</specifier>
-    <message>incompatible types in assignment.</message>
-    <lineContent>filePattern = null;</lineContent>
-    <details>
-      found   : null (NullType)
-      required: @Initialized @NonNull String
-    </details>
-  </checkerFrameworkError>
-
-  <checkerFrameworkError unstable="false">
-    <fileName>src/main/java/com/puppycrawl/tools/checkstyle/filters/XpathFilterElement.java</fileName>
-    <specifier>assignment</specifier>
-    <message>incompatible types in assignment.</message>
-    <lineContent>messagePattern = null;</lineContent>
-    <details>
-      found   : null (NullType)
-      required: @Initialized @NonNull String
-    </details>
-  </checkerFrameworkError>
-
-  <checkerFrameworkError unstable="false">
-    <fileName>src/main/java/com/puppycrawl/tools/checkstyle/filters/XpathFilterElement.java</fileName>
-    <specifier>assignment</specifier>
-    <message>incompatible types in assignment.</message>
     <lineContent>xpathExpression = null;</lineContent>
     <details>
       found   : null (NullType)
@@ -5442,6 +5321,17 @@
       @Initialized @NonNull boolean equals(@Initialized @NonNull XpathFilterElement this, @Initialized @NonNull Object p0)
       cannot override method in @Initialized @NonNull Object
       @Initialized @NonNull boolean equals(@Initialized @NonNull Object this, @Initialized @Nullable Object p0)
+    </details>
+  </checkerFrameworkError>
+
+  <checkerFrameworkError unstable="false">
+    <fileName>src/main/java/com/puppycrawl/tools/checkstyle/filters/XpathFilterElement.java</fileName>
+    <specifier>return</specifier>
+    <message>incompatible types in return.</message>
+    <lineContent>return result;</lineContent>
+    <details>
+      type of expression: @Initialized @Nullable String
+      method return type: @Initialized @NonNull String
     </details>
   </checkerFrameworkError>
 

--- a/config/pitest-suppressions/pitest-filters-suppressions.xml
+++ b/config/pitest-suppressions/pitest-filters-suppressions.xml
@@ -4,33 +4,6 @@
     <sourceFile>SuppressFilterElement.java</sourceFile>
     <mutatedClass>com.puppycrawl.tools.checkstyle.filters.SuppressFilterElement</mutatedClass>
     <mutatedMethod>&lt;init&gt;</mutatedMethod>
-    <mutator>org.pitest.mutationtest.engine.gregor.mutators.NonVoidMethodCallMutator</mutator>
-    <description>removed call to java/util/regex/Pattern::pattern</description>
-    <lineContent>checkPattern = checks.pattern();</lineContent>
-  </mutation>
-
-  <mutation unstable="false">
-    <sourceFile>SuppressFilterElement.java</sourceFile>
-    <mutatedClass>com.puppycrawl.tools.checkstyle.filters.SuppressFilterElement</mutatedClass>
-    <mutatedMethod>&lt;init&gt;</mutatedMethod>
-    <mutator>org.pitest.mutationtest.engine.gregor.mutators.experimental.MemberVariableMutator</mutator>
-    <description>Removed assignment to member variable checkPattern</description>
-    <lineContent>checkPattern = checks.pattern();</lineContent>
-  </mutation>
-
-  <mutation unstable="false">
-    <sourceFile>SuppressFilterElement.java</sourceFile>
-    <mutatedClass>com.puppycrawl.tools.checkstyle.filters.SuppressFilterElement</mutatedClass>
-    <mutatedMethod>&lt;init&gt;</mutatedMethod>
-    <mutator>org.pitest.mutationtest.engine.gregor.mutators.experimental.MemberVariableMutator</mutator>
-    <description>Removed assignment to member variable checkPattern</description>
-    <lineContent>checkPattern = null;</lineContent>
-  </mutation>
-
-  <mutation unstable="false">
-    <sourceFile>SuppressFilterElement.java</sourceFile>
-    <mutatedClass>com.puppycrawl.tools.checkstyle.filters.SuppressFilterElement</mutatedClass>
-    <mutatedMethod>&lt;init&gt;</mutatedMethod>
     <mutator>org.pitest.mutationtest.engine.gregor.mutators.experimental.MemberVariableMutator</mutator>
     <description>Removed assignment to member variable checkRegexp</description>
     <lineContent>checkRegexp = null;</lineContent>
@@ -67,42 +40,6 @@
     <sourceFile>SuppressFilterElement.java</sourceFile>
     <mutatedClass>com.puppycrawl.tools.checkstyle.filters.SuppressFilterElement</mutatedClass>
     <mutatedMethod>&lt;init&gt;</mutatedMethod>
-    <mutator>org.pitest.mutationtest.engine.gregor.mutators.NonVoidMethodCallMutator</mutator>
-    <description>removed call to java/util/regex/Pattern::pattern</description>
-    <lineContent>filePattern = files.pattern();</lineContent>
-  </mutation>
-
-  <mutation unstable="false">
-    <sourceFile>SuppressFilterElement.java</sourceFile>
-    <mutatedClass>com.puppycrawl.tools.checkstyle.filters.SuppressFilterElement</mutatedClass>
-    <mutatedMethod>&lt;init&gt;</mutatedMethod>
-    <mutator>org.pitest.mutationtest.engine.gregor.mutators.experimental.MemberVariableMutator</mutator>
-    <description>Removed assignment to member variable filePattern</description>
-    <lineContent>filePattern = files.pattern();</lineContent>
-  </mutation>
-
-  <mutation unstable="false">
-    <sourceFile>SuppressFilterElement.java</sourceFile>
-    <mutatedClass>com.puppycrawl.tools.checkstyle.filters.SuppressFilterElement</mutatedClass>
-    <mutatedMethod>&lt;init&gt;</mutatedMethod>
-    <mutator>org.pitest.mutationtest.engine.gregor.mutators.experimental.MemberVariableMutator</mutator>
-    <description>Removed assignment to member variable filePattern</description>
-    <lineContent>filePattern = files;</lineContent>
-  </mutation>
-
-  <mutation unstable="false">
-    <sourceFile>SuppressFilterElement.java</sourceFile>
-    <mutatedClass>com.puppycrawl.tools.checkstyle.filters.SuppressFilterElement</mutatedClass>
-    <mutatedMethod>&lt;init&gt;</mutatedMethod>
-    <mutator>org.pitest.mutationtest.engine.gregor.mutators.experimental.MemberVariableMutator</mutator>
-    <description>Removed assignment to member variable filePattern</description>
-    <lineContent>filePattern = null;</lineContent>
-  </mutation>
-
-  <mutation unstable="false">
-    <sourceFile>SuppressFilterElement.java</sourceFile>
-    <mutatedClass>com.puppycrawl.tools.checkstyle.filters.SuppressFilterElement</mutatedClass>
-    <mutatedMethod>&lt;init&gt;</mutatedMethod>
     <mutator>org.pitest.mutationtest.engine.gregor.mutators.experimental.MemberVariableMutator</mutator>
     <description>Removed assignment to member variable fileRegexp</description>
     <lineContent>fileRegexp = null;</lineContent>
@@ -133,42 +70,6 @@
     <mutator>org.pitest.mutationtest.engine.gregor.mutators.experimental.MemberVariableMutator</mutator>
     <description>Removed assignment to member variable linesCsv</description>
     <lineContent>linesCsv = null;</lineContent>
-  </mutation>
-
-  <mutation unstable="false">
-    <sourceFile>SuppressFilterElement.java</sourceFile>
-    <mutatedClass>com.puppycrawl.tools.checkstyle.filters.SuppressFilterElement</mutatedClass>
-    <mutatedMethod>&lt;init&gt;</mutatedMethod>
-    <mutator>org.pitest.mutationtest.engine.gregor.mutators.NonVoidMethodCallMutator</mutator>
-    <description>removed call to java/util/regex/Pattern::pattern</description>
-    <lineContent>messagePattern = message.pattern();</lineContent>
-  </mutation>
-
-  <mutation unstable="false">
-    <sourceFile>SuppressFilterElement.java</sourceFile>
-    <mutatedClass>com.puppycrawl.tools.checkstyle.filters.SuppressFilterElement</mutatedClass>
-    <mutatedMethod>&lt;init&gt;</mutatedMethod>
-    <mutator>org.pitest.mutationtest.engine.gregor.mutators.experimental.MemberVariableMutator</mutator>
-    <description>Removed assignment to member variable messagePattern</description>
-    <lineContent>messagePattern = message.pattern();</lineContent>
-  </mutation>
-
-  <mutation unstable="false">
-    <sourceFile>SuppressFilterElement.java</sourceFile>
-    <mutatedClass>com.puppycrawl.tools.checkstyle.filters.SuppressFilterElement</mutatedClass>
-    <mutatedMethod>&lt;init&gt;</mutatedMethod>
-    <mutator>org.pitest.mutationtest.engine.gregor.mutators.experimental.MemberVariableMutator</mutator>
-    <description>Removed assignment to member variable messagePattern</description>
-    <lineContent>messagePattern = message;</lineContent>
-  </mutation>
-
-  <mutation unstable="false">
-    <sourceFile>SuppressFilterElement.java</sourceFile>
-    <mutatedClass>com.puppycrawl.tools.checkstyle.filters.SuppressFilterElement</mutatedClass>
-    <mutatedMethod>&lt;init&gt;</mutatedMethod>
-    <mutator>org.pitest.mutationtest.engine.gregor.mutators.experimental.MemberVariableMutator</mutator>
-    <description>Removed assignment to member variable messagePattern</description>
-    <lineContent>messagePattern = null;</lineContent>
   </mutation>
 
   <mutation unstable="false">
@@ -313,114 +214,6 @@
     <mutator>org.pitest.mutationtest.engine.gregor.mutators.experimental.ArgumentPropagationMutator</mutator>
     <description>replaced call to java/util/Optional::orElse with argument</description>
     <lineContent>Optional.ofNullable(checks).map(CommonUtil::createPattern).orElse(null),</lineContent>
-  </mutation>
-
-  <mutation unstable="false">
-    <sourceFile>XpathFilterElement.java</sourceFile>
-    <mutatedClass>com.puppycrawl.tools.checkstyle.filters.XpathFilterElement</mutatedClass>
-    <mutatedMethod>&lt;init&gt;</mutatedMethod>
-    <mutator>org.pitest.mutationtest.engine.gregor.mutators.NonVoidMethodCallMutator</mutator>
-    <description>removed call to java/util/regex/Pattern::pattern</description>
-    <lineContent>checkPattern = checks.pattern();</lineContent>
-  </mutation>
-
-  <mutation unstable="false">
-    <sourceFile>XpathFilterElement.java</sourceFile>
-    <mutatedClass>com.puppycrawl.tools.checkstyle.filters.XpathFilterElement</mutatedClass>
-    <mutatedMethod>&lt;init&gt;</mutatedMethod>
-    <mutator>org.pitest.mutationtest.engine.gregor.mutators.experimental.MemberVariableMutator</mutator>
-    <description>Removed assignment to member variable checkPattern</description>
-    <lineContent>checkPattern = checks.pattern();</lineContent>
-  </mutation>
-
-  <mutation unstable="false">
-    <sourceFile>XpathFilterElement.java</sourceFile>
-    <mutatedClass>com.puppycrawl.tools.checkstyle.filters.XpathFilterElement</mutatedClass>
-    <mutatedMethod>&lt;init&gt;</mutatedMethod>
-    <mutator>org.pitest.mutationtest.engine.gregor.mutators.experimental.MemberVariableMutator</mutator>
-    <description>Removed assignment to member variable checkPattern</description>
-    <lineContent>checkPattern = null;</lineContent>
-  </mutation>
-
-  <mutation unstable="false">
-    <sourceFile>XpathFilterElement.java</sourceFile>
-    <mutatedClass>com.puppycrawl.tools.checkstyle.filters.XpathFilterElement</mutatedClass>
-    <mutatedMethod>&lt;init&gt;</mutatedMethod>
-    <mutator>org.pitest.mutationtest.engine.gregor.mutators.experimental.MemberVariableMutator</mutator>
-    <description>Removed assignment to member variable checkRegexp</description>
-    <lineContent>checkRegexp = null;</lineContent>
-  </mutation>
-
-  <mutation unstable="false">
-    <sourceFile>XpathFilterElement.java</sourceFile>
-    <mutatedClass>com.puppycrawl.tools.checkstyle.filters.XpathFilterElement</mutatedClass>
-    <mutatedMethod>&lt;init&gt;</mutatedMethod>
-    <mutator>org.pitest.mutationtest.engine.gregor.mutators.NonVoidMethodCallMutator</mutator>
-    <description>removed call to java/util/regex/Pattern::pattern</description>
-    <lineContent>filePattern = files.pattern();</lineContent>
-  </mutation>
-
-  <mutation unstable="false">
-    <sourceFile>XpathFilterElement.java</sourceFile>
-    <mutatedClass>com.puppycrawl.tools.checkstyle.filters.XpathFilterElement</mutatedClass>
-    <mutatedMethod>&lt;init&gt;</mutatedMethod>
-    <mutator>org.pitest.mutationtest.engine.gregor.mutators.experimental.MemberVariableMutator</mutator>
-    <description>Removed assignment to member variable filePattern</description>
-    <lineContent>filePattern = files.pattern();</lineContent>
-  </mutation>
-
-  <mutation unstable="false">
-    <sourceFile>XpathFilterElement.java</sourceFile>
-    <mutatedClass>com.puppycrawl.tools.checkstyle.filters.XpathFilterElement</mutatedClass>
-    <mutatedMethod>&lt;init&gt;</mutatedMethod>
-    <mutator>org.pitest.mutationtest.engine.gregor.mutators.experimental.MemberVariableMutator</mutator>
-    <description>Removed assignment to member variable filePattern</description>
-    <lineContent>filePattern = null;</lineContent>
-  </mutation>
-
-  <mutation unstable="false">
-    <sourceFile>XpathFilterElement.java</sourceFile>
-    <mutatedClass>com.puppycrawl.tools.checkstyle.filters.XpathFilterElement</mutatedClass>
-    <mutatedMethod>&lt;init&gt;</mutatedMethod>
-    <mutator>org.pitest.mutationtest.engine.gregor.mutators.experimental.MemberVariableMutator</mutator>
-    <description>Removed assignment to member variable fileRegexp</description>
-    <lineContent>fileRegexp = null;</lineContent>
-  </mutation>
-
-  <mutation unstable="false">
-    <sourceFile>XpathFilterElement.java</sourceFile>
-    <mutatedClass>com.puppycrawl.tools.checkstyle.filters.XpathFilterElement</mutatedClass>
-    <mutatedMethod>&lt;init&gt;</mutatedMethod>
-    <mutator>org.pitest.mutationtest.engine.gregor.mutators.NonVoidMethodCallMutator</mutator>
-    <description>removed call to java/util/regex/Pattern::pattern</description>
-    <lineContent>messagePattern = message.pattern();</lineContent>
-  </mutation>
-
-  <mutation unstable="false">
-    <sourceFile>XpathFilterElement.java</sourceFile>
-    <mutatedClass>com.puppycrawl.tools.checkstyle.filters.XpathFilterElement</mutatedClass>
-    <mutatedMethod>&lt;init&gt;</mutatedMethod>
-    <mutator>org.pitest.mutationtest.engine.gregor.mutators.experimental.MemberVariableMutator</mutator>
-    <description>Removed assignment to member variable messagePattern</description>
-    <lineContent>messagePattern = message.pattern();</lineContent>
-  </mutation>
-
-  <mutation unstable="false">
-    <sourceFile>XpathFilterElement.java</sourceFile>
-    <mutatedClass>com.puppycrawl.tools.checkstyle.filters.XpathFilterElement</mutatedClass>
-    <mutatedMethod>&lt;init&gt;</mutatedMethod>
-    <mutator>org.pitest.mutationtest.engine.gregor.mutators.experimental.MemberVariableMutator</mutator>
-    <description>Removed assignment to member variable messagePattern</description>
-    <lineContent>messagePattern = null;</lineContent>
-  </mutation>
-
-  <mutation unstable="false">
-    <sourceFile>XpathFilterElement.java</sourceFile>
-    <mutatedClass>com.puppycrawl.tools.checkstyle.filters.XpathFilterElement</mutatedClass>
-    <mutatedMethod>&lt;init&gt;</mutatedMethod>
-    <mutator>org.pitest.mutationtest.engine.gregor.mutators.experimental.MemberVariableMutator</mutator>
-    <description>Removed assignment to member variable messageRegexp</description>
-    <lineContent>messageRegexp = null;</lineContent>
   </mutation>
 
   <mutation unstable="false">

--- a/src/main/java/com/puppycrawl/tools/checkstyle/filters/SuppressFilterElement.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/filters/SuppressFilterElement.java
@@ -43,20 +43,11 @@ public class SuppressFilterElement
     /** The regexp to match file names against. */
     private final Pattern fileRegexp;
 
-    /** The pattern for file names. */
-    private final String filePattern;
-
     /** The regexp to match check names against. */
     private final Pattern checkRegexp;
 
-    /** The pattern for check class names. */
-    private final String checkPattern;
-
     /** The regexp to match message names against. */
     private final Pattern messageRegexp;
-
-    /** The pattern for message names. */
-    private final String messagePattern;
 
     /** Module id filter. */
     private final String moduleId;
@@ -86,21 +77,18 @@ public class SuppressFilterElement
      */
     public SuppressFilterElement(String files, String checks,
                            String message, String modId, String lines, String columns) {
-        filePattern = files;
         if (files == null) {
             fileRegexp = null;
         }
         else {
             fileRegexp = Pattern.compile(files);
         }
-        checkPattern = checks;
         if (checks == null) {
             checkRegexp = null;
         }
         else {
             checkRegexp = Pattern.compile(checks);
         }
-        messagePattern = message;
         if (message == null) {
             messageRegexp = null;
         }
@@ -136,30 +124,9 @@ public class SuppressFilterElement
      */
     public SuppressFilterElement(Pattern files, Pattern checks, Pattern message, String moduleId,
             String lines, String columns) {
-        if (files == null) {
-            filePattern = null;
-            fileRegexp = null;
-        }
-        else {
-            filePattern = files.pattern();
-            fileRegexp = files;
-        }
-        if (checks == null) {
-            checkPattern = null;
-            checkRegexp = null;
-        }
-        else {
-            checkPattern = checks.pattern();
-            checkRegexp = checks;
-        }
-        if (message == null) {
-            messagePattern = null;
-            messageRegexp = null;
-        }
-        else {
-            messagePattern = message.pattern();
-            messageRegexp = message;
-        }
+        fileRegexp = files;
+        checkRegexp = checks;
+        messageRegexp = message;
         this.moduleId = moduleId;
         if (lines == null) {
             linesCsv = null;
@@ -224,8 +191,8 @@ public class SuppressFilterElement
 
     @Override
     public int hashCode() {
-        return Objects.hash(filePattern, checkPattern, messagePattern, moduleId, linesCsv,
-                columnsCsv);
+        return Objects.hash(getPatternSafely(fileRegexp), getPatternSafely(checkRegexp),
+                getPatternSafely(messageRegexp), moduleId, linesCsv, columnsCsv);
     }
 
     @Override
@@ -237,12 +204,29 @@ public class SuppressFilterElement
             return false;
         }
         final SuppressFilterElement suppressElement = (SuppressFilterElement) other;
-        return Objects.equals(filePattern, suppressElement.filePattern)
-                && Objects.equals(checkPattern, suppressElement.checkPattern)
-                && Objects.equals(messagePattern, suppressElement.messagePattern)
+        return Objects.equals(getPatternSafely(fileRegexp),
+                    getPatternSafely(suppressElement.fileRegexp))
+                && Objects.equals(getPatternSafely(checkRegexp),
+                    getPatternSafely(suppressElement.checkRegexp))
+                && Objects.equals(getPatternSafely(messageRegexp),
+                    getPatternSafely(suppressElement.messageRegexp))
                 && Objects.equals(moduleId, suppressElement.moduleId)
                 && Objects.equals(linesCsv, suppressElement.linesCsv)
                 && Objects.equals(columnsCsv, suppressElement.columnsCsv);
     }
 
+    /**
+     * Util method to get pattern String value from Pattern object safely, return null if
+     * pattern object is null.
+     *
+     * @param pattern pattern object
+     * @return value of pattern or null
+     */
+    private static String getPatternSafely(Pattern pattern) {
+        String result = null;
+        if (pattern != null) {
+            result = pattern.pattern();
+        }
+        return result;
+    }
 }

--- a/src/main/java/com/puppycrawl/tools/checkstyle/filters/XpathFilterElement.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/filters/XpathFilterElement.java
@@ -47,20 +47,11 @@ public class XpathFilterElement implements TreeWalkerFilter {
     /** The regexp to match file names against. */
     private final Pattern fileRegexp;
 
-    /** The pattern for file names. */
-    private final String filePattern;
-
     /** The regexp to match check names against. */
     private final Pattern checkRegexp;
 
-    /** The pattern for check class names. */
-    private final String checkPattern;
-
     /** The regexp to match message names against. */
     private final Pattern messageRegexp;
-
-    /** The pattern for message names. */
-    private final String messagePattern;
 
     /** Module id filter. */
     private final String moduleId;
@@ -105,30 +96,9 @@ public class XpathFilterElement implements TreeWalkerFilter {
      */
     public XpathFilterElement(Pattern files, Pattern checks, Pattern message,
                            String moduleId, String query) {
-        if (files == null) {
-            filePattern = null;
-            fileRegexp = null;
-        }
-        else {
-            filePattern = files.pattern();
-            fileRegexp = files;
-        }
-        if (checks == null) {
-            checkPattern = null;
-            checkRegexp = null;
-        }
-        else {
-            checkPattern = checks.pattern();
-            checkRegexp = checks;
-        }
-        if (message == null) {
-            messagePattern = null;
-            messageRegexp = null;
-        }
-        else {
-            messagePattern = message.pattern();
-            messageRegexp = message;
-        }
+        fileRegexp = files;
+        checkRegexp = checks;
+        messageRegexp = message;
         this.moduleId = moduleId;
         xpathQuery = query;
         if (xpathQuery == null) {
@@ -240,8 +210,8 @@ public class XpathFilterElement implements TreeWalkerFilter {
 
     @Override
     public int hashCode() {
-        return Objects.hash(filePattern, checkPattern, messagePattern,
-            moduleId, xpathQuery);
+        return Objects.hash(getPatternSafely(fileRegexp), getPatternSafely(checkRegexp),
+                getPatternSafely(messageRegexp), moduleId, xpathQuery);
     }
 
     @Override
@@ -253,11 +223,28 @@ public class XpathFilterElement implements TreeWalkerFilter {
             return false;
         }
         final XpathFilterElement xpathFilter = (XpathFilterElement) other;
-        return Objects.equals(filePattern, xpathFilter.filePattern)
-                && Objects.equals(checkPattern, xpathFilter.checkPattern)
-                && Objects.equals(messagePattern, xpathFilter.messagePattern)
+        return Objects.equals(getPatternSafely(fileRegexp),
+                    getPatternSafely(xpathFilter.fileRegexp))
+                && Objects.equals(getPatternSafely(checkRegexp),
+                    getPatternSafely(xpathFilter.checkRegexp))
+                && Objects.equals(getPatternSafely(messageRegexp),
+                    getPatternSafely(xpathFilter.messageRegexp))
                 && Objects.equals(moduleId, xpathFilter.moduleId)
                 && Objects.equals(xpathQuery, xpathFilter.xpathQuery);
     }
 
+    /**
+     * Util method to get pattern String value from Pattern object safely, return null if
+     * pattern object is null.
+     *
+     * @param pattern pattern object
+     * @return value of pattern or null
+     */
+    private static String getPatternSafely(Pattern pattern) {
+        String result = null;
+        if (pattern != null) {
+            result = pattern.pattern();
+        }
+        return result;
+    }
 }

--- a/src/test/java/com/puppycrawl/tools/checkstyle/filters/SuppressFilterElementTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/filters/SuppressFilterElementTest.java
@@ -286,8 +286,7 @@ public class SuppressFilterElementTest {
     public void testEqualsAndHashCode() {
         final EqualsVerifierReport ev = EqualsVerifier.forClass(SuppressFilterElement.class)
                 .usingGetClass()
-                .withIgnoredFields("fileRegexp", "checkRegexp", "messageRegexp", "columnFilter",
-                        "lineFilter")
+                .withIgnoredFields("columnFilter", "lineFilter")
                 .suppress(Warning.NONFINAL_FIELDS)
                 .report();
         assertWithMessage("Error: " + ev.getMessage())

--- a/src/test/java/com/puppycrawl/tools/checkstyle/filters/XpathFilterElementTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/filters/XpathFilterElementTest.java
@@ -351,8 +351,7 @@ public class XpathFilterElementTest extends AbstractModuleTestSupport {
                 xpathEvaluator.createExpression("//METHOD_DEF"),
                 xpathEvaluator.createExpression("//VARIABLE_DEF"))
                 .usingGetClass()
-                .withIgnoredFields("fileRegexp", "checkRegexp", "messageRegexp",
-                    "xpathExpression", "isEmptyConfig")
+                .withIgnoredFields("xpathExpression", "isEmptyConfig")
                 .report();
         assertWithMessage("Error: " + ev.getMessage())
                 .that(ev.isSuccessful())


### PR DESCRIPTION
Issue #13809: Kill mutation in Filters

this is typical extra data storage that pitest catch as not critical for execution.
I think it is fine to remove it here as cost of taking String value of regexp from Pattern object is cheap, as it is stored as is (String) in Patter class (it is single getter to get String on Pattern class).

https://github.com/openjdk/jdk/blob/ecd25e7d6f9d69f9dbdbff0a4a9b9d6b19288593/src/java.base/share/classes/java/util/regex/Pattern.java#L1138-L1144