### PR TITLE
infra: do not allow in-progress site action to be cancelled by skipped run

### DIFF
--- a/.github/workflows/site.yml
+++ b/.github/workflows/site.yml
@@ -27,7 +27,7 @@ permissions:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.issue.number || github.ref }}
-  cancel-in-progress: true
+  cancel-in-progress: false
 
 jobs:
   parse_pr_info:


### PR DESCRIPTION
Noticed at https://github.com/checkstyle/checkstyle/pull/13861#issuecomment-1755265092, skipped runs count towards concurrency. Updating the `cancel-in-progress` configuration to be `false` will protect in-progress actions from being cancelled.