### PR TITLE
Issue #13809: kill mutation for JavadocPropertiesGenerator-2

### DIFF
--- a/config/pitest-suppressions/pitest-common-2-suppressions.xml
+++ b/config/pitest-suppressions/pitest-common-2-suppressions.xml
@@ -9,13 +9,4 @@
     <description>removed call to com/puppycrawl/tools/checkstyle/grammar/java/JavaLanguageLexer::removeErrorListeners</description>
     <lineContent>lexer.removeErrorListeners();</lineContent>
   </mutation>
-
-  <mutation unstable="false">
-    <sourceFile>JavadocPropertiesGenerator.java</sourceFile>
-    <mutatedClass>com.puppycrawl.tools.checkstyle.JavadocPropertiesGenerator</mutatedClass>
-    <mutatedMethod>main</mutatedMethod>
-    <mutator>org.pitest.mutationtest.engine.gregor.mutators.experimental.NakedReceiverMutator</mutator>
-    <description>replaced call to picocli/CommandLine::setUsageHelpWidth with receiver</description>
-    <lineContent>final CommandLine cmd = new CommandLine(cliOptions).setUsageHelpWidth(USAGE_HELP_WIDTH);</lineContent>
-  </mutation>
 </suppressedMutations>

--- a/src/main/java/com/puppycrawl/tools/checkstyle/JavadocPropertiesGenerator.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/JavadocPropertiesGenerator.java
@@ -63,9 +63,6 @@ public final class JavadocPropertiesGenerator {
     private static final Pattern END_OF_SENTENCE_PATTERN = Pattern.compile(
         "(([^.?!]|[.?!](?!\\s|$))*+[.?!])(\\s|$)");
 
-    /** Max width of the usage help message for this command. */
-    private static final int USAGE_HELP_WIDTH = 100;
-
     /**
      * Don't create instance of this class, use the {@link #main(String[])} method instead.
      */
@@ -80,7 +77,7 @@ public final class JavadocPropertiesGenerator {
      **/
     public static void main(String... args) throws CheckstyleException {
         final CliOptions cliOptions = new CliOptions();
-        final CommandLine cmd = new CommandLine(cliOptions).setUsageHelpWidth(USAGE_HELP_WIDTH);
+        final CommandLine cmd = new CommandLine(cliOptions);
         try {
             final ParseResult parseResult = cmd.parseArgs(args);
             if (parseResult.isUsageHelpRequested()) {


### PR DESCRIPTION
Issue #13809: kill mutation for JavadocPropertiesGenerator-2

# Mutation

https://github.com/checkstyle/checkstyle/blob/649b669336ebdb914936b65e582eb00a5a9ed17f/config/pitest-suppressions/pitest-common-2-suppressions.xml#L13-L20

# Explaintaion

we don't need help when we run cmd from the config