### PR TITLE
dependency: Updated Maven version in pom.xml

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -29,7 +29,7 @@ task:
     MAVEN_OPTS: "-Dhttp.keepAlive=false \
       -Dmaven.repo.local=%CIRRUS_WORKING_DIR%/.m2 \
       -Dmaven.wagon.http.retryHandler.count=3"
-    MAVEN_VERSION: "3.8.4"
+    MAVEN_VERSION: "3.8.6"
     PATH: "%PATH%;C:/Program Files/OpenJDK/%OPENJDK_PATH%/bin;\
       C:/ProgramData/chocolatey/lib/maven/apache-maven-%MAVEN_VERSION%/bin;\
       C:/ProgramData/chocolatey/bin"

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,6 +18,7 @@ before_install:
 
 install:
   - sudo apt install -y xmlstarlet
+  - "mvn -e --no-transfer-progress -N io.takari:maven:wrapper -Dmaven=3.8.6"
 
 jobs:
   fast_finish: true

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -18,6 +18,7 @@ install:
         )
         [System.IO.Compression.ZipFile]::ExtractToDirectory("C:\maven-bin.zip", "C:\maven")
       }
+
   - cmd: SET M2_HOME=C:\maven\apache-maven-3.8.8
   - cmd: SET PATH=%M2_HOME%\bin;%JAVA_HOME%\bin;%PATH%
   - cmd: git config core.autocrlf

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -133,10 +133,10 @@ steps:
   - bash: |
       apt-fast install -y xmlstarlet
     condition: |
-        and(
-             ne(variables['Agent.OS'], 'Darwin'),
-             eq(variables.NEED_XMLSTARLET, 'true')
-           )
+      and(
+           ne(variables['Agent.OS'], 'Darwin'),
+           eq(variables.NEED_XMLSTARLET, 'true')
+         )
 
   - bash: |
       gem install mdl
@@ -168,10 +168,10 @@ steps:
       ./.ci/validation.sh git-diff
       ./.ci/validation.sh ci-temp-check
     condition: |
-        or (
-            ne(variables.ON_CRON_ONLY, 'true'),
-            and(
-                 eq(variables.ON_CRON_ONLY, 'true'),
-                 eq(variables['Build.Reason'], 'Schedule')
-               )
-           )
+      or (
+          ne(variables.ON_CRON_ONLY, 'true'),
+          and(
+               eq(variables.ON_CRON_ONLY, 'true'),
+               eq(variables['Build.Reason'], 'Schedule')
+             )
+         )


### PR DESCRIPTION
Running maven with the current version 3.3.9 (as mentioned in pom.xml) results in the following error message - 

`[ERROR] Failed to execute goal org.codehaus.mojo:xml-maven-plugin:1.1.0:check-format (default) on project checkstyle: The plugin org.codehaus.mojo:xml-maven-plugin:1.1.0 requires Maven version 3.5.4 -> [Help 1]`

This PR updates the maven version from 3.3.9 to 3.5.4

