### PR TITLE
infra: use valid SPDX license identifier

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -24,8 +24,8 @@
   <inceptionYear>2001</inceptionYear>
   <licenses>
     <license>
-      <name>LGPL-2.1+</name>
-      <url>http://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt</url>
+      <name>LGPL-2.1-or-later</name>
+      <url>https://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt</url>
     </license>
   </licenses>
 


### PR DESCRIPTION
The previous identifier has been replaced by a more readable one at some point in the past.
* https://spdx.org/licenses/
* https://github.com/spdx/license-list-XML/blob/main/src/LGPL-2.1%2B.xml