### PR TITLE
Issue #13809: Kill mutation in Checker

### DIFF
--- a/config/checker-framework-suppressions/checker-nullness-optional-interning-suppressions.xml
+++ b/config/checker-framework-suppressions/checker-nullness-optional-interning-suppressions.xml
@@ -89,19 +89,8 @@
 
   <checkerFrameworkError unstable="false">
     <fileName>src/main/java/com/puppycrawl/tools/checkstyle/Checker.java</fileName>
-    <specifier>assignment</specifier>
-    <message>incompatible types in assignment.</message>
-    <lineContent>fileExtensions = null;</lineContent>
-    <details>
-      found   : null (NullType)
-      required: @Initialized @NonNull String @Initialized @NonNull []
-    </details>
-  </checkerFrameworkError>
-
-  <checkerFrameworkError unstable="false">
-    <fileName>src/main/java/com/puppycrawl/tools/checkstyle/Checker.java</fileName>
     <specifier>initialization.fields.uninitialized</specifier>
-    <message>the constructor does not initialize fields: basedir, moduleFactory, moduleClassLoader, childContext, cacheFile</message>
+    <message>the constructor does not initialize fields: basedir, moduleFactory, moduleClassLoader, childContext, fileExtensions, cacheFile</message>
     <lineContent>public Checker() {</lineContent>
   </checkerFrameworkError>
 

--- a/config/pitest-suppressions/pitest-common-suppressions.xml
+++ b/config/pitest-suppressions/pitest-common-suppressions.xml
@@ -3,15 +3,6 @@
   <mutation unstable="false">
     <sourceFile>Checker.java</sourceFile>
     <mutatedClass>com.puppycrawl.tools.checkstyle.Checker</mutatedClass>
-    <mutatedMethod>&lt;init&gt;</mutatedMethod>
-    <mutator>org.pitest.mutationtest.engine.gregor.mutators.experimental.MemberVariableMutator</mutator>
-    <description>Removed assignment to member variable fileExtensions</description>
-    <lineContent>private String[] fileExtensions = CommonUtil.EMPTY_STRING_ARRAY;</lineContent>
-  </mutation>
-
-  <mutation unstable="false">
-    <sourceFile>Checker.java</sourceFile>
-    <mutatedClass>com.puppycrawl.tools.checkstyle.Checker</mutatedClass>
     <mutatedMethod>acceptFileStarted</mutatedMethod>
     <mutator>org.pitest.mutationtest.engine.gregor.mutators.experimental.ArgumentPropagationMutator</mutator>
     <description>replaced call to com/puppycrawl/tools/checkstyle/utils/CommonUtil::relativizeAndNormalizePath with argument</description>
@@ -43,15 +34,6 @@
     <mutator>org.pitest.mutationtest.engine.gregor.mutators.NonVoidMethodCallMutator</mutator>
     <description>removed call to java/io/File::getPath</description>
     <lineContent>throw new Error(&quot;Error was thrown while processing &quot; + file.getPath(), error);</lineContent>
-  </mutation>
-
-  <mutation unstable="false">
-    <sourceFile>Checker.java</sourceFile>
-    <mutatedClass>com.puppycrawl.tools.checkstyle.Checker</mutatedClass>
-    <mutatedMethod>setFileExtensions</mutatedMethod>
-    <mutator>org.pitest.mutationtest.engine.gregor.mutators.experimental.MemberVariableMutator</mutator>
-    <description>Removed assignment to member variable fileExtensions</description>
-    <lineContent>fileExtensions = null;</lineContent>
   </mutation>
 
   <mutation unstable="false">

--- a/src/main/java/com/puppycrawl/tools/checkstyle/Checker.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/Checker.java
@@ -108,7 +108,7 @@ public class Checker extends AbstractAutomaticBean implements MessageDispatcher,
     private Context childContext;
 
     /** The file extensions that are accepted. */
-    private String[] fileExtensions = CommonUtil.EMPTY_STRING_ARRAY;
+    private String[] fileExtensions;
 
     /**
      * The severity level of any violations found by submodules.
@@ -547,10 +547,7 @@ public class Checker extends AbstractAutomaticBean implements MessageDispatcher,
      *     initial '.' character of an extension is automatically added.
      */
     public final void setFileExtensions(String... extensions) {
-        if (extensions == null) {
-            fileExtensions = null;
-        }
-        else {
+        if (extensions != null) {
             fileExtensions = new String[extensions.length];
             for (int i = 0; i < extensions.length; i++) {
                 final String extension = extensions[i];


### PR DESCRIPTION
Issue #13809: Kill mutation in Checker

class :- https://github.com/checkstyle/checkstyle/blob/master/src/main/java/com/puppycrawl/tools/checkstyle/Checker.java

------------

# Mutation
https://github.com/checkstyle/checkstyle/blob/8dffc49e46490cbd472548cfd6cccccd5ecedc4f/config/pitest-suppressions/pitest-common-suppressions.xml#L3-L10
and 
https://github.com/checkstyle/checkstyle/blob/8dffc49e46490cbd472548cfd6cccccd5ecedc4f/config/pitest-suppressions/pitest-common-suppressions.xml#L48-L55

---------

# Explaination:- 

we initialize fileExtensions to null if extensions are null at 
https://github.com/checkstyle/checkstyle/blob/8dffc49e46490cbd472548cfd6cccccd5ecedc4f/src/main/java/com/puppycrawl/tools/checkstyle/Checker.java#L549-L552
so if we remove it and remove the empty initialization at 
https://github.com/checkstyle/checkstyle/blob/8dffc49e46490cbd472548cfd6cccccd5ecedc4f/src/main/java/com/puppycrawl/tools/checkstyle/Checker.java#L111 
as this is not final it will be considered as null. so no issue will be there.