### PR TITLE
config: Suppress mutation in PkgImportControl.java init method

### DIFF
--- a/config/pitest-suppressions/pitest-imports-suppressions.xml
+++ b/config/pitest-suppressions/pitest-imports-suppressions.xml
@@ -17,13 +17,4 @@
     <description>Removed assignment to member variable patternForPartialMatch</description>
     <lineContent>patternForPartialMatch = null;</lineContent>
   </mutation>
-
-  <mutation unstable="false">
-    <sourceFile>PkgImportControl.java</sourceFile>
-    <mutatedClass>com.puppycrawl.tools.checkstyle.checks.imports.PkgImportControl</mutatedClass>
-    <mutatedMethod>&lt;init&gt;</mutatedMethod>
-    <mutator>org.pitest.mutationtest.engine.gregor.mutators.experimental.MemberVariableMutator</mutator>
-    <description>Removed assignment to member variable regex</description>
-    <lineContent>this.regex = false;</lineContent>
-  </mutation>
 </suppressedMutations>


### PR DESCRIPTION
This edit was passing in my locals and resulting in build success, so raised this PR to remove this mutation. But one check is failing here, so I am closing this PR.