### PR TITLE
Issue #13213: Remove //ok comments for supress id: covariantequals

### DIFF
--- a/config/checkstyle-input-suppressions.xml
+++ b/config/checkstyle-input-suppressions.xml
@@ -114,8 +114,6 @@
 
   <!-- until https://github.com/checkstyle/checkstyle/issues/13213 -->
   <suppress id="UnnecessaryOkComment"
-            files="checks[\\/]coding[\\/]covariantequals[\\/]InputCovariantEqualsRecords.java"/>
-  <suppress id="UnnecessaryOkComment"
             files="checks[\\/]coding[\\/]defaultcomeslast[\\/]InputDefaultComesLastSwitchExpressionsSkipIfLast.java"/>
   <suppress id="UnnecessaryOkComment"
             files="checks[\\/]coding[\\/]defaultcomeslast[\\/]InputDefaultComesLastSwitchExpressionsSkipIfLast.java"/>

--- a/src/test/resources-noncompilable/com/puppycrawl/tools/checkstyle/checks/coding/covariantequals/InputCovariantEqualsRecords.java
+++ b/src/test/resources-noncompilable/com/puppycrawl/tools/checkstyle/checks/coding/covariantequals/InputCovariantEqualsRecords.java
@@ -16,7 +16,7 @@ public class InputCovariantEqualsRecords {
     }
 
     public record MyRecord2() {
-        public boolean equals(String str) { // ok
+        public boolean equals(String str) {
             return str.equals(this);
         }
         public boolean equals(Object obj) {


### PR DESCRIPTION
Issue #13213 

Proof that all suppressions for this check are removed:

```
suniti@CJHFFWQW9J checkstyle % grep methodparampad config/checkstyle-input-suppressions.xml                        
suniti@CJHFFWQW9J checkstyle % files="checks[\\/]coding[\\/]covariantequals[\\/]InputCovariantEqualsRecords.java"  
suniti@CJHFFWQW9J checkstyle % git checkout remove-ok-covariantequals                                              
Switched to branch 'remove-ok-covariantequals'
Your branch is up to date with 'origin/remove-ok-covariantequals'.
suniti@CJHFFWQW9J checkstyle % grep methodparampad config/checkstyle-input-suppressions.xml
suniti@CJHFFWQW9J checkstyle % echo $?
1

```
