### PR TITLE
Issue #13213: Remove //ok comments for suppress id=defaultcomeslast

### DIFF
--- a/config/checkstyle-input-suppressions.xml
+++ b/config/checkstyle-input-suppressions.xml
@@ -114,10 +114,6 @@
 
   <!-- until https://github.com/checkstyle/checkstyle/issues/13213 -->
   <suppress id="UnnecessaryOkComment"
-            files="checks[\\/]coding[\\/]defaultcomeslast[\\/]InputDefaultComesLastSwitchExpressionsSkipIfLast.java"/>
-  <suppress id="UnnecessaryOkComment"
-            files="checks[\\/]coding[\\/]defaultcomeslast[\\/]InputDefaultComesLastSwitchExpressionsSkipIfLast.java"/>
-  <suppress id="UnnecessaryOkComment"
             files="checks[\\/]coding[\\/]equalsavoidnull[\\/]InputEqualsAvoidNullEnhancedInstanceof.java"/>
   <suppress id="UnnecessaryOkComment"
             files="checks[\\/]coding[\\/]equalsavoidnull[\\/]InputEqualsAvoidNullRecordsAndCompactCtors.java"/>
@@ -975,12 +971,6 @@
             files="checks[\\/]coding[\\/]declarationorder[\\/]InputDeclarationOrder2.java"/>
   <suppress id="UnnecessaryOkComment"
             files="checks[\\/]coding[\\/]declarationorder[\\/]InputDeclarationOrder2.java"/>
-  <suppress id="UnnecessaryOkComment"
-            files="checks[\\/]coding[\\/]defaultcomeslast[\\/]InputDefaultComesLastDefaultMethodsInInterface.java"/>
-  <suppress id="UnnecessaryOkComment"
-            files="checks[\\/]coding[\\/]defaultcomeslast[\\/]InputDefaultComesLastDefaultMethodsInInterface.java"/>
-  <suppress id="UnnecessaryOkComment"
-            files="checks[\\/]coding[\\/]defaultcomeslast[\\/]InputDefaultComesLastDefaultMethodsInInterface2.java"/>
   <suppress id="UnnecessaryOkComment"
             files="checks[\\/]coding[\\/]equalsavoidnull[\\/]InputEqualsAvoidNull.java"/>
   <suppress id="UnnecessaryOkComment"

--- a/src/test/resources-noncompilable/com/puppycrawl/tools/checkstyle/checks/coding/defaultcomeslast/InputDefaultComesLastSwitchExpressionsSkipIfLast.java
+++ b/src/test/resources-noncompilable/com/puppycrawl/tools/checkstyle/checks/coding/defaultcomeslast/InputDefaultComesLastSwitchExpressionsSkipIfLast.java
@@ -13,7 +13,7 @@ public class InputDefaultComesLastSwitchExpressionsSkipIfLast {
         int x = 7;
         switch (i) {
             case 1:
-            default: // ok
+            default:
                 x = 9;
                 break;
             case 2:
@@ -54,7 +54,7 @@ public class InputDefaultComesLastSwitchExpressionsSkipIfLast {
         return switch (i) {
             case 1 -> 8;
             case 2 -> 7;
-            default -> 9; // ok
+            default -> 9; //
         };
     }
 }

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/defaultcomeslast/InputDefaultComesLastDefaultMethodsInInterface.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/defaultcomeslast/InputDefaultComesLastDefaultMethodsInInterface.java
@@ -13,11 +13,11 @@ public interface InputDefaultComesLastDefaultMethodsInInterface {
 
     String toJson(String document);
 
-    default String toJson(Object one) { // ok
+    default String toJson(Object one) {
       return toJson(one, one, one);
     }
 
-    default String toJson(Object one, Object two) { // ok
+    default String toJson(Object one, Object two) {
       return toJson(one, one, two);
     }
   }

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/defaultcomeslast/InputDefaultComesLastDefaultMethodsInInterface2.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/defaultcomeslast/InputDefaultComesLastDefaultMethodsInInterface2.java
@@ -8,7 +8,7 @@ skipIfLastAndSharedWithCase = true
 package com.puppycrawl.tools.checkstyle.checks.coding.defaultcomeslast;
 
 public interface InputDefaultComesLastDefaultMethodsInInterface2 {
-    default int apply() { // ok
+    default int apply() {
         return 1;
     }
 }


### PR DESCRIPTION
Issue #13213 

Proof that all suppressions for this check are removed:

```
suniti@CJHFFWQW9J checkstyle % grep methodparampad config/checkstyle-input-suppressions.xml   
suniti@CJHFFWQW9J checkstyle % files="checks[\\/]coding[\\/]defaultcomeslast[\\/]InputDefaultComesLastSwitchExpressionsSkipIfLast.java"
suniti@CJHFFWQW9J checkstyle % files="checks[\\/]coding[\\/]defaultcomeslast[\\/]InputDefaultComesLastSwitchExpressionsSkipIfLast.java"
suniti@CJHFFWQW9J checkstyle % git checkout remove-ok-defaultcomeslast                                                                 
Switched to branch 'remove-ok-defaultcomeslast'
Your branch is up to date with 'origin/remove-ok-defaultcomeslast'.
suniti@CJHFFWQW9J checkstyle % grep methodparampad config/checkstyle-input-suppressions.xml
suniti@CJHFFWQW9J checkstyle % echo $?
1

```