### PR TITLE
Issue #13809: Kill mutation in PackageObjectFactory

### DIFF
--- a/config/pitest-suppressions/pitest-common-suppressions.xml
+++ b/config/pitest-suppressions/pitest-common-suppressions.xml
@@ -48,24 +48,6 @@
   <mutation unstable="false">
     <sourceFile>PackageObjectFactory.java</sourceFile>
     <mutatedClass>com.puppycrawl.tools.checkstyle.PackageObjectFactory</mutatedClass>
-    <mutatedMethod>createModule</mutatedMethod>
-    <mutator>org.pitest.mutationtest.engine.gregor.mutators.NonVoidMethodCallMutator</mutator>
-    <description>removed call to java/lang/String::contains</description>
-    <lineContent>if (!name.contains(PACKAGE_SEPARATOR)) {</lineContent>
-  </mutation>
-
-  <mutation unstable="false">
-    <sourceFile>PackageObjectFactory.java</sourceFile>
-    <mutatedClass>com.puppycrawl.tools.checkstyle.PackageObjectFactory</mutatedClass>
-    <mutatedMethod>createModule</mutatedMethod>
-    <mutator>org.pitest.mutationtest.engine.gregor.mutators.RemoveConditionalMutator_EQUAL_IF</mutator>
-    <description>removed conditional - replaced equality check with true</description>
-    <lineContent>if (!name.contains(PACKAGE_SEPARATOR)) {</lineContent>
-  </mutation>
-
-  <mutation unstable="false">
-    <sourceFile>PackageObjectFactory.java</sourceFile>
-    <mutatedClass>com.puppycrawl.tools.checkstyle.PackageObjectFactory</mutatedClass>
     <mutatedMethod>createObjectFromFullModuleNames</mutatedMethod>
     <mutator>org.pitest.mutationtest.engine.gregor.mutators.experimental.NakedReceiverMutator</mutator>
     <description>replaced call to java/util/stream/Stream::sorted with receiver</description>

--- a/src/test/java/com/puppycrawl/tools/checkstyle/PackageObjectFactoryTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/PackageObjectFactoryTest.java
@@ -493,6 +493,35 @@ public class PackageObjectFactoryTest {
             .isInstanceOf(MockClass.class);
     }
 
+    /**
+    * This test case is designed to verify the behavior of the PackageObjectFactory's
+    * createModule method when it is provided with a fully qualified class name
+    * (containing a package separator).
+    * It ensures that ModuleReflectionUtil.getCheckstyleModules is not executed in this case.
+    */
+    @Test
+    public void testCreateObjectWithNameContainingPackageSeparatorWithoutSearch() throws Exception {
+        final ClassLoader classLoader = ClassLoader.getSystemClassLoader();
+        final Set<String> packages = Collections.singleton(BASE_PACKAGE);
+        final PackageObjectFactory objectFactory =
+            new PackageObjectFactory(packages, classLoader, TRY_IN_ALL_REGISTERED_PACKAGES);
+
+        try (MockedStatic<ModuleReflectionUtil> utilities =
+                     mockStatic(ModuleReflectionUtil.class)) {
+            utilities.when(() -> ModuleReflectionUtil.getCheckstyleModules(packages, classLoader))
+                    .thenThrow(new IllegalStateException("creation of objects by fully qualified"
+                            + " class names should not result in search of modules in classpath"));
+
+            final String fullyQualifiedName = MockClass.class.getName();
+            assertWithMessage("class name is not in expected format")
+                    .that(fullyQualifiedName).contains(".");
+            final Object object = objectFactory.createModule(fullyQualifiedName);
+            assertWithMessage("Object should be an instance of MockClass")
+                    .that(object)
+                    .isInstanceOf(MockClass.class);
+        }
+    }
+
     @Test
     public void testCreateModuleWithTryInAllRegisteredPackages() {
         final ClassLoader classLoader = ClassLoader.getSystemClassLoader();


### PR DESCRIPTION
Issue #13809: Kill mutation in PackageObjectFactory


# Explaination

if the string contains packageSeparator then the instance will be null. Probably no test case is possible.
