### PR TITLE
Issue #13770: Override write func to enforce unix-style newline

### DIFF
--- a/config/checker-framework-suppressions/checker-lock-tainting-suppressions.xml
+++ b/config/checker-framework-suppressions/checker-lock-tainting-suppressions.xml
@@ -1185,6 +1185,21 @@
   </checkerFrameworkError>
 
   <checkerFrameworkError unstable="false">
+    <fileName>src/main/java/com/puppycrawl/tools/checkstyle/site/XdocsTemplateSink.java</fileName>
+    <specifier>override.receiver</specifier>
+    <message>Incompatible receiver type</message>
+    <lineContent>public void write(String line, int offset, int length) {</lineContent>
+    <details>
+      found   : @GuardedBy CustomPrintWriter
+      required: @GuardSatisfied PrintWriter
+      Consequence: method in @GuardedBy CustomPrintWriter
+      void write(@GuardedBy CustomPrintWriter this, @GuardedBy String p0, @GuardedBy int p1, @GuardedBy int p2)
+      cannot override method in @GuardedBy PrintWriter
+      void write(@GuardSatisfied PrintWriter this, @GuardedBy String p0, @GuardedBy int p1, @GuardedBy int p2)
+    </details>
+  </checkerFrameworkError>
+
+  <checkerFrameworkError unstable="false">
     <fileName>src/main/java/com/puppycrawl/tools/checkstyle/utils/TokenUtil.java</fileName>
     <specifier>methodref.receiver</specifier>
     <message>Incompatible receiver type</message>

--- a/src/main/java/com/puppycrawl/tools/checkstyle/site/XdocsTemplateSink.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/site/XdocsTemplateSink.java
@@ -21,6 +21,7 @@ package com.puppycrawl.tools.checkstyle.site;
 
 import java.io.PrintWriter;
 import java.io.Writer;
+import java.util.regex.Pattern;
 
 import javax.swing.text.MutableAttributeSet;
 
@@ -112,6 +113,12 @@ public class XdocsTemplateSink extends XdocSink {
      */
     private static final class CustomPrintWriter extends PrintWriter {
 
+        /** A Regex pattern to represent all kinds of newline character. */
+        private static final Pattern LINE_BREAK_ESCAPE = Pattern.compile("\\R");
+
+        /** Unix-Style newline character. */
+        private static final String NEWLINE = "\n";
+
         /**
          * Creates a new instance of this custom writer.
          *
@@ -122,11 +129,25 @@ public class XdocsTemplateSink extends XdocSink {
         }
 
         /**
-         * Enforces Unix-Style Newline character.
+         * Enforces Unix-style newline character.
          */
         @Override
         public void println() {
-            write("\n");
+            write(NEWLINE, 0, NEWLINE.length());
+        }
+
+        /**
+         * Unifies all newline characters to Unix-Style Newline character.
+         *
+         * @param line   text that is to be written in the output file.
+         * @param offset starting offset value for writing data.
+         * @param length total length of string to be written.
+         */
+        @Override
+        public void write(String line, int offset, int length) {
+            final String lineBreakReplacedLine =
+                LINE_BREAK_ESCAPE.matcher(line).replaceAll(NEWLINE);
+            super.write(lineBreakReplacedLine, 0, lineBreakReplacedLine.length());
         }
     }
 }


### PR DESCRIPTION
For Issue #13770: PR #13774 has a bug, to resolve that we are overriding the `write` func of PrinterWriter as well to make it concrete.

Proof of Validity - https://ci.appveyor.com/project/Checkstyle/checkstyle/builds/48355264