### PR TITLE
Issue #11214: Remove SummaryJavaDocCheck from Suppression List

### DIFF
--- a/src/test/java/com/puppycrawl/tools/checkstyle/bdd/InlineConfigParser.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/bdd/InlineConfigParser.java
@@ -142,8 +142,7 @@ public final class InlineConfigParser {
     private static final Set<String> SUPPRESSED_CHECKS = new HashSet<>(Arrays.asList(
             "com.puppycrawl.tools.checkstyle.checks.regexp.RegexpCheck",
             "com.puppycrawl.tools.checkstyle.checks.whitespace.EmptyForInitializerPadCheck",
-            "com.puppycrawl.tools.checkstyle.checks.javadoc.JavadocStyleCheck",
-            "com.puppycrawl.tools.checkstyle.checks.javadoc.SummaryJavadocCheck"));
+            "com.puppycrawl.tools.checkstyle.checks.javadoc.JavadocStyleCheck"));
 
     /**
      *  Inlined configs can not be used in non-java checks, as Inlined config is java style


### PR DESCRIPTION
Issue #11214 

This PR removes the `SummaryJavaDocCheck` from the suppression list in `InlineConfigParser.java` class as all the checks using this have the violation message specified.


