### PR TITLE
Issue #11214: Specify violation messages for EmptyForInitializerPadCheck Input Files

### DIFF
--- a/src/test/java/com/puppycrawl/tools/checkstyle/bdd/InlineConfigParser.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/bdd/InlineConfigParser.java
@@ -139,8 +139,7 @@ public final class InlineConfigParser {
      * one violation message key.
      * Until <a href="https://github.com/checkstyle/checkstyle/issues/11214">#11214</a>
      */
-    private static final Set<String> SUPPRESSED_CHECKS = new HashSet<>(Arrays.asList(
-            "com.puppycrawl.tools.checkstyle.checks.whitespace.EmptyForInitializerPadCheck",
+    private static final Set<String> SUPPRESSED_CHECKS = new HashSet<>(List.of(
             "com.puppycrawl.tools.checkstyle.checks.javadoc.JavadocStyleCheck"));
 
     /**

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/whitespace/emptyforinitializerpad/InputEmptyForInitializerPad2.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/whitespace/emptyforinitializerpad/InputEmptyForInitializerPad2.java
@@ -7,5 +7,5 @@ option = invalid_option
 
 package com.puppycrawl.tools.checkstyle.checks.whitespace.emptyforinitializerpad;
 
-class InputEmptyForInitializerPad2 // violation
+class InputEmptyForInitializerPad2
 { }


### PR DESCRIPTION
Issue #11214 
