### PR TITLE
Issue #2827: JavadocMethod doesn't report anonymous class methods

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/utils/CheckUtil.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/utils/CheckUtil.java
@@ -379,9 +379,6 @@ public final class CheckUtil {
                 || type == TokenTypes.ENUM_DEF) {
                 returnValue = getAccessModifierFromModifiersToken(token);
             }
-            else if (type == TokenTypes.LITERAL_NEW) {
-                break;
-            }
         }
 
         return returnValue;

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocMethodCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocMethodCheckTest.java
@@ -179,6 +179,13 @@ public class JavadocMethodCheckTest extends AbstractModuleTestSupport {
             "87:41: " + getCheckMessage(MSG_EXPECTED_TAG, "@param", "aA"),
             "92:37: " + getCheckMessage(MSG_EXPECTED_TAG, "@param", "aA"),
             "102:32: " + getCheckMessage(MSG_EXPECTED_TAG, "@param", "aA"),
+            "136: " + getCheckMessage(MSG_RETURN_EXPECTED),
+            "136:49: " + getCheckMessage(MSG_EXPECTED_TAG, "@param", "a"),
+            "136:59: " + getCheckMessage(MSG_EXPECTED_TAG, "@param", "b"),
+            "154: " + getCheckMessage(MSG_RETURN_EXPECTED),
+            "154:43: " + getCheckMessage(MSG_EXPECTED_TAG, "@param", "a"),
+            "154:53: " + getCheckMessage(MSG_EXPECTED_TAG, "@param", "b"),
+
         };
         verifyWithInlineConfigParser(
                 getPath("InputJavadocMethodPublicOnly.java"), expected);
@@ -521,5 +528,14 @@ public class JavadocMethodCheckTest extends AbstractModuleTestSupport {
         final String[] expected = CommonUtil.EMPTY_STRING_ARRAY;
         verifyWithInlineConfigParser(
                 getPath("InputJavadocMethod3.java"), expected);
+    }
+
+    @Test
+    public void test4() throws Exception {
+        final String[] expected = {
+            "21:24: " + getCheckMessage(MSG_EXPECTED_TAG, "@param", "a"),
+        };
+        verifyWithInlineConfigParser(
+                getPath("InputJavadocMethodAnonymousMethod.java"), expected);
     }
 }

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadocmethod/InputJavadocMethodAnonymousMethod.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadocmethod/InputJavadocMethodAnonymousMethod.java
@@ -1,0 +1,23 @@
+/*
+JavadocMethod
+allowedAnnotations = (default)Override
+validateThrows = (default)false
+accessModifiers = (default)public, protected, package, private
+allowMissingParamTags = (default)false
+allowMissingReturnTag = (default)false
+tokens = (default)METHOD_DEF, CTOR_DEF, ANNOTATION_FIELD_DEF, COMPACT_CTOR_DEF
+
+
+*/
+package com.puppycrawl.tools.checkstyle.checks.javadoc.javadocmethod;
+
+public class InputJavadocMethodAnonymousMethod {
+
+    Thread ob = new Thread(){
+
+     /**
+     *
+     */
+        void print(int a){} //violation 'Expected @param tag for 'a''
+    };
+}

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadocmethod/InputJavadocMethodPublicOnly.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadocmethod/InputJavadocMethodPublicOnly.java
@@ -130,10 +130,13 @@ public class InputJavadocMethodPublicOnly // ignore - need javadoc
                 privateMethod(null, null);
             }
 
-            /**
-             * Javadoc
-             */
+           /**
+           * Javadoc
+           */
             private String privateMethod(String a, String b) {
+                // violation above '@return tag should be present and have description.'
+                // violation 2 lines above 'Expected @param tag for 'a'.'
+                // violation 3 lines above 'Expected @param tag for 'b'.'
                 return null;
             }
         };
@@ -149,6 +152,9 @@ public class InputJavadocMethodPublicOnly // ignore - need javadoc
          * Javadoc
          */
         public String publicMethod(String a, String b) {
+            // violation above '@return tag should be present and have description.'
+            // violation 2 lines above 'Expected @param tag for 'a'.'
+            // violation 3 lines above 'Expected @param tag for 'b'.'
             return null;
         }
     };


### PR DESCRIPTION
Related: https://github.com/checkstyle/checkstyle/issues/2827
Diff Regression config: https://gist.githubusercontent.com/AayushSaini101/218a9a57a04728fb154b406078059651/raw/9122a6c84272be78546541c4adf7ee3135d99b99/gistfile1.txt
Diff Regression Project:  https://gist.githubusercontent.com/AayushSaini101/0747edfd032791a6db97ab895e5c930c/raw/2b6a38b42b347c8827b7423cdd6086e40d95a236/gistfile1.txt