### PR TITLE
Issue #13969: Update JavaDocStyleChecks and it's input files

### DIFF
--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocStyleCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocStyleCheckTest.java
@@ -73,20 +73,18 @@ public class JavadocStyleCheckTest
         final String[] expected = {
             "23: " + getCheckMessage(MSG_NO_PERIOD),
             "48: " + getCheckMessage(MSG_NO_PERIOD),
-            "56:11: " + getCheckMessage(MSG_UNCLOSED_HTML,
-                    "<b>This guy is missing end of bold tag // violation"),
-            "59:7: " + getCheckMessage(MSG_EXTRA_HTML, "</td>Extra tag"
-                    + " shouldn't be here // violation"),
-            "60:49: " + getCheckMessage(MSG_EXTRA_HTML, "</style> // violation"),
-            "61:19: " + getCheckMessage(MSG_UNCLOSED_HTML, "<code>dummy. // violation"),
-            "65: " + getCheckMessage(MSG_NO_PERIOD),
-            "66:23: " + getCheckMessage(MSG_UNCLOSED_HTML, "<b>should fail // violation"),
-            "70: " + getCheckMessage(MSG_NO_PERIOD),
-            "71:31: " + getCheckMessage(MSG_UNCLOSED_HTML, "<b>should fail // violation"),
-            "75: " + getCheckMessage(MSG_NO_PERIOD),
-            "76:31: " + getCheckMessage(MSG_EXTRA_HTML, "</code> // violation"),
-            "77: " + getCheckMessage(MSG_INCOMPLETE_TAG, "    * should fail <"),
-            "92:39: " + getCheckMessage(MSG_EXTRA_HTML, "</img> // violation"),
+            "56:11: " + getCheckMessage(MSG_UNCLOSED_HTML, "<b>"),
+            "59:7: " + getCheckMessage(MSG_EXTRA_HTML, "</td>"),
+            "60:49: " + getCheckMessage(MSG_EXTRA_HTML, "</style>"),
+            "61:19: " + getCheckMessage(MSG_UNCLOSED_HTML, "<code>dummy"),
+            "68: " + getCheckMessage(MSG_NO_PERIOD),
+            "69:23: " + getCheckMessage(MSG_UNCLOSED_HTML, "<b>"),
+            "73: " + getCheckMessage(MSG_NO_PERIOD),
+            "74:31: " + getCheckMessage(MSG_UNCLOSED_HTML, "<b>"),
+            "79: " + getCheckMessage(MSG_NO_PERIOD),
+            "80:31: " + getCheckMessage(MSG_EXTRA_HTML, "</code>"),
+            "81: " + getCheckMessage(MSG_INCOMPLETE_TAG, "    * should fail <"),
+            "94:39: " + getCheckMessage(MSG_EXTRA_HTML, "</img>"),
         };
 
         verifyWithInlineConfigParser(
@@ -97,7 +95,7 @@ public class JavadocStyleCheckTest
     public void testJavadocStyleDefaultSettingsTwo()
             throws Exception {
         final String[] expected = {
-            "61:8: " + getCheckMessage(MSG_UNCLOSED_HTML, "<blockquote> // violation"),
+            "61:8: " + getCheckMessage(MSG_UNCLOSED_HTML, "<blockquote>"),
             "66: " + getCheckMessage(MSG_NO_PERIOD),
             "98: " + getCheckMessage(MSG_NO_PERIOD),
         };
@@ -110,7 +108,7 @@ public class JavadocStyleCheckTest
     public void testJavadocStyleDefaultSettingsThree()
             throws Exception {
         final String[] expected = {
-            "103:21: " + getCheckMessage(MSG_EXTRA_HTML, "</string> // violation"),
+            "103:21: " + getCheckMessage(MSG_EXTRA_HTML, "</string>"),
         };
 
         verifyWithInlineConfigParser(
@@ -121,10 +119,10 @@ public class JavadocStyleCheckTest
     public void testJavadocStyleDefaultSettingsFour()
             throws Exception {
         final String[] expected = {
-            "29:33: " + getCheckMessage(MSG_UNCLOSED_HTML, "<code> // violation"),
+            "29:33: " + getCheckMessage(MSG_UNCLOSED_HTML, "<code>"),
             "40: " + getCheckMessage(MSG_NO_PERIOD),
             "46:11: " + getCheckMessage(MSG_UNCLOSED_HTML,
-                                         "<b>Note:<b> it's unterminated tag.</p> // violation"),
+                    "<b>Note:<b> it's unterminated tag.</p>"),
             "50: " + getCheckMessage(MSG_NO_PERIOD),
             "54: " + getCheckMessage(MSG_NO_PERIOD),
             "61: " + getCheckMessage(MSG_NO_PERIOD),
@@ -237,17 +235,15 @@ public class JavadocStyleCheckTest
     @Test
     public void testHtml1() throws Exception {
         final String[] expected = {
-            "55:11: " + getCheckMessage(MSG_UNCLOSED_HTML,
-                "<b>This guy is missing end of bold tag // violation"),
-            "58:7: " + getCheckMessage(MSG_EXTRA_HTML, "</td>Extra tag "
-                + "shouldn't be here // violation"),
-            "59:49: " + getCheckMessage(MSG_EXTRA_HTML, "</style> // violation"),
-            "60:19: " + getCheckMessage(MSG_UNCLOSED_HTML, "<code>dummy. // violation"),
-            "65:23: " + getCheckMessage(MSG_UNCLOSED_HTML, "<b>should fail // violation"),
-            "70:31: " + getCheckMessage(MSG_UNCLOSED_HTML, "<b>should fail // violation"),
-            "75:31: " + getCheckMessage(MSG_EXTRA_HTML, "</code> // violation"),
-            "76: " + getCheckMessage(MSG_INCOMPLETE_TAG, "    * should fail <"),
-            "91:39: " + getCheckMessage(MSG_EXTRA_HTML, "</img> // violation"),
+            "56:11: " + getCheckMessage(MSG_UNCLOSED_HTML, "<b>"),
+            "59:7: " + getCheckMessage(MSG_EXTRA_HTML, "</td>"),
+            "60:49: " + getCheckMessage(MSG_EXTRA_HTML, "</style>"),
+            "61:19: " + getCheckMessage(MSG_UNCLOSED_HTML, "<code>dummy"),
+            "69:23: " + getCheckMessage(MSG_UNCLOSED_HTML, "<b>"),
+            "74:31: " + getCheckMessage(MSG_UNCLOSED_HTML, "<b>"),
+            "80:31: " + getCheckMessage(MSG_EXTRA_HTML, "</code>"),
+            "81: " + getCheckMessage(MSG_INCOMPLETE_TAG, "    * should fail <"),
+            "96:39: " + getCheckMessage(MSG_EXTRA_HTML, "</img>"),
         };
 
         verifyWithInlineConfigParser(
@@ -257,7 +253,7 @@ public class JavadocStyleCheckTest
     @Test
     public void testHtml2() throws Exception {
         final String[] expected = {
-            "67:8: " + getCheckMessage(MSG_UNCLOSED_HTML, "<blockquote> // violation"),
+            "67:8: " + getCheckMessage(MSG_UNCLOSED_HTML, "<blockquote>"),
         };
 
         verifyWithInlineConfigParser(
@@ -267,7 +263,7 @@ public class JavadocStyleCheckTest
     @Test
     public void testHtml3() throws Exception {
         final String[] expected = {
-            "102:21: " + getCheckMessage(MSG_EXTRA_HTML, "</string> // violation"),
+            "102:21: " + getCheckMessage(MSG_EXTRA_HTML, "</string>"),
         };
 
         verifyWithInlineConfigParser(
@@ -277,9 +273,8 @@ public class JavadocStyleCheckTest
     @Test
     public void testHtml4() throws Exception {
         final String[] expected = {
-            "28:33: " + getCheckMessage(MSG_UNCLOSED_HTML, "<code> // violation"),
-            "45:11: " + getCheckMessage(MSG_UNCLOSED_HTML,
-                    "<b>Note:<b> it's unterminated tag.</p> // violation"),
+            "28:33: " + getCheckMessage(MSG_UNCLOSED_HTML, "<code>"),
+            "45:11: " + getCheckMessage(MSG_UNCLOSED_HTML, "<b>"),
         };
 
         verifyWithInlineConfigParser(
@@ -314,10 +309,11 @@ public class JavadocStyleCheckTest
     public void testScopePublic1()
             throws Exception {
         final String[] expected = {
-            "75: " + getCheckMessage(MSG_NO_PERIOD),
-            "76:31: " + getCheckMessage(MSG_EXTRA_HTML, "</code> // violation"),
-            "77: " + getCheckMessage(MSG_INCOMPLETE_TAG, "    * should fail <"),
+            "76: " + getCheckMessage(MSG_NO_PERIOD),
+            "77:31: " + getCheckMessage(MSG_EXTRA_HTML, "</code>"),
+            "78: " + getCheckMessage(MSG_INCOMPLETE_TAG, "    * should fail <"),
         };
+
         verifyWithInlineConfigParser(
                 getPath("InputJavadocStyleScopePublic1.java"), expected);
     }
@@ -330,6 +326,7 @@ public class JavadocStyleCheckTest
             "101: " + getCheckMessage(MSG_EMPTY),
             "106: " + getCheckMessage(MSG_NO_PERIOD),
         };
+
         verifyWithInlineConfigParser(
                 getPath("InputJavadocStyleScopePublic2.java"), expected);
     }
@@ -338,8 +335,9 @@ public class JavadocStyleCheckTest
     public void testScopePublic3()
             throws Exception {
         final String[] expected = {
-            "103:21: " + getCheckMessage(MSG_EXTRA_HTML, "</string> // violation"),
+            "103:21: " + getCheckMessage(MSG_EXTRA_HTML, "</string>"),
         };
+
         verifyWithInlineConfigParser(
                 getPath("InputJavadocStyleScopePublic3.java"), expected);
     }
@@ -352,6 +350,7 @@ public class JavadocStyleCheckTest
             "54: " + getCheckMessage(MSG_NO_PERIOD),
             "86: " + getCheckMessage(MSG_NO_PERIOD),
         };
+
         verifyWithInlineConfigParser(
                 getPath("InputJavadocStyleScopePublic4.java"), expected);
     }
@@ -361,11 +360,12 @@ public class JavadocStyleCheckTest
             throws Exception {
         final String[] expected = {
             "65: " + getCheckMessage(MSG_NO_PERIOD),
-            "66:23: " + getCheckMessage(MSG_UNCLOSED_HTML, "<b>should fail // violation"),
-            "75: " + getCheckMessage(MSG_NO_PERIOD),
-            "76:31: " + getCheckMessage(MSG_EXTRA_HTML, "</code> // violation"),
-            "77: " + getCheckMessage(MSG_INCOMPLETE_TAG, "    * should fail <"),
+            "66:23: " + getCheckMessage(MSG_UNCLOSED_HTML, "<b>"),
+            "76: " + getCheckMessage(MSG_NO_PERIOD),
+            "77:31: " + getCheckMessage(MSG_EXTRA_HTML, "</code>"),
+            "78: " + getCheckMessage(MSG_INCOMPLETE_TAG, "    * should fail <"),
         };
+
         verifyWithInlineConfigParser(
                 getPath("InputJavadocStyleScopeProtected1.java"), expected);
     }
@@ -379,6 +379,7 @@ public class JavadocStyleCheckTest
             "94: " + getCheckMessage(MSG_EMPTY),
             "99: " + getCheckMessage(MSG_NO_PERIOD),
         };
+
         verifyWithInlineConfigParser(
                 getPath("InputJavadocStyleScopeProtected2.java"), expected);
     }
@@ -387,8 +388,9 @@ public class JavadocStyleCheckTest
     public void testScopeProtected3()
             throws Exception {
         final String[] expected = {
-            "103:21: " + getCheckMessage(MSG_EXTRA_HTML, "</string> // violation"),
+            "103:21: " + getCheckMessage(MSG_EXTRA_HTML, "</string>"),
         };
+
         verifyWithInlineConfigParser(
                 getPath("InputJavadocStyleScopeProtected3.java"), expected);
     }
@@ -401,6 +403,7 @@ public class JavadocStyleCheckTest
             "54: " + getCheckMessage(MSG_NO_PERIOD),
             "86: " + getCheckMessage(MSG_NO_PERIOD),
         };
+
         verifyWithInlineConfigParser(
                 getPath("InputJavadocStyleScopeProtected4.java"), expected);
     }
@@ -410,13 +413,14 @@ public class JavadocStyleCheckTest
             throws Exception {
         final String[] expected = {
             "65: " + getCheckMessage(MSG_NO_PERIOD),
-            "66:24: " + getCheckMessage(MSG_UNCLOSED_HTML, "<b>should fail // violation"),
+            "66:24: " + getCheckMessage(MSG_UNCLOSED_HTML, "<b>"),
             "70: " + getCheckMessage(MSG_NO_PERIOD),
-            "71:32: " + getCheckMessage(MSG_UNCLOSED_HTML, "<b>should fail // violation"),
-            "75: " + getCheckMessage(MSG_NO_PERIOD),
-            "76:32: " + getCheckMessage(MSG_EXTRA_HTML, "</code> // violation"),
-            "77: " + getCheckMessage(MSG_INCOMPLETE_TAG, "     * should fail <"),
+            "71:32: " + getCheckMessage(MSG_UNCLOSED_HTML, "<b>"),
+            "76: " + getCheckMessage(MSG_NO_PERIOD),
+            "77:32: " + getCheckMessage(MSG_EXTRA_HTML, "</code>"),
+            "78: " + getCheckMessage(MSG_INCOMPLETE_TAG, "     * should fail <"),
         };
+
         verifyWithInlineConfigParser(
                 getPath("InputJavadocStyleScopePackage1.java"), expected);
     }
@@ -431,6 +435,7 @@ public class JavadocStyleCheckTest
             "94: " + getCheckMessage(MSG_EMPTY),
             "99: " + getCheckMessage(MSG_NO_PERIOD),
         };
+
         verifyWithInlineConfigParser(
                 getPath("InputJavadocStyleScopePackage2.java"), expected);
     }
@@ -439,8 +444,9 @@ public class JavadocStyleCheckTest
     public void testScopePackage3()
             throws Exception {
         final String[] expected = {
-            "103:21: " + getCheckMessage(MSG_EXTRA_HTML, "</string> // violation"),
+            "103:21: " + getCheckMessage(MSG_EXTRA_HTML, "</string>"),
         };
+
         verifyWithInlineConfigParser(
                 getPath("InputJavadocStyleScopePackage3.java"), expected);
     }
@@ -455,6 +461,7 @@ public class JavadocStyleCheckTest
             "73: " + getCheckMessage(MSG_NO_PERIOD),
             "86: " + getCheckMessage(MSG_NO_PERIOD),
         };
+
         verifyWithInlineConfigParser(
                 getPath("InputJavadocStyleScopePackage4.java"), expected);
     }
@@ -503,16 +510,15 @@ public class JavadocStyleCheckTest
         final String[] expected = {
             "23: " + getCheckMessage(MSG_NO_PERIOD),
             "48: " + getCheckMessage(MSG_NO_PERIOD),
-            "56:11: " + getCheckMessage(MSG_UNCLOSED_HTML,
-                    "<b>This guy is missing end of bold tag // violation"),
-            "59:7: " + getCheckMessage(MSG_EXTRA_HTML, "</td>Extra tag "
-                    + "shouldn't be here // violation"),
-            "60:49: " + getCheckMessage(MSG_EXTRA_HTML, "</style> // violation"),
-            "61:19: " + getCheckMessage(MSG_UNCLOSED_HTML, "<code>dummy. // violation"),
-            "70: " + getCheckMessage(MSG_NO_PERIOD),
-            "71:31: " + getCheckMessage(MSG_UNCLOSED_HTML, "<b>should fail // violation"),
-            "92:39: " + getCheckMessage(MSG_EXTRA_HTML, "</img> // violation"),
+            "56:11: " + getCheckMessage(MSG_UNCLOSED_HTML, "<b>"),
+            "59:7: " + getCheckMessage(MSG_EXTRA_HTML, "</td>"),
+            "60:49: " + getCheckMessage(MSG_EXTRA_HTML, "</style>"),
+            "61:19: " + getCheckMessage(MSG_UNCLOSED_HTML, "<code>dummy"),
+            "72: " + getCheckMessage(MSG_NO_PERIOD),
+            "73:31: " + getCheckMessage(MSG_UNCLOSED_HTML, "<b>"),
+            "94:39: " + getCheckMessage(MSG_EXTRA_HTML, "</img>"),
         };
+
         verifyWithInlineConfigParser(
                 getPath("InputJavadocStyleExcludeScope1.java"), expected);
     }
@@ -521,9 +527,10 @@ public class JavadocStyleCheckTest
     public void testExcludeScope2()
             throws Exception {
         final String[] expected = {
-            "68:8: " + getCheckMessage(MSG_UNCLOSED_HTML, "<blockquote> // violation"),
+            "68:8: " + getCheckMessage(MSG_UNCLOSED_HTML, "<blockquote>"),
             "73: " + getCheckMessage(MSG_NO_PERIOD),
         };
+
         verifyWithInlineConfigParser(
                 getPath("InputJavadocStyleExcludeScope2.java"), expected);
     }
@@ -541,13 +548,14 @@ public class JavadocStyleCheckTest
     public void testExcludeScope4()
             throws Exception {
         final String[] expected = {
-            "29:33: " + getCheckMessage(MSG_UNCLOSED_HTML, "<code> // violation"),
+            "29:33: " + getCheckMessage(MSG_UNCLOSED_HTML, "<code>"),
             "40: " + getCheckMessage(MSG_NO_PERIOD),
             "46:11: " + getCheckMessage(MSG_UNCLOSED_HTML,
-                    "<b>Note:<b> it's unterminated tag.</p> // violation"),
+                    "<b>Note:<b> it's unterminated tag.</p>"),
             "61: " + getCheckMessage(MSG_NO_PERIOD),
             "73: " + getCheckMessage(MSG_NO_PERIOD),
         };
+
         verifyWithInlineConfigParser(
                 getPath("InputJavadocStyleExcludeScope4.java"), expected);
     }
@@ -631,6 +639,7 @@ public class JavadocStyleCheckTest
         final String[] expected = {
             "73: " + getCheckMessage(MSG_NO_PERIOD),
         };
+
         verifyWithInlineConfigParser(
                 getPath("InputJavadocStyleRestrictedTokenSet1.java"), expected);
     }
@@ -660,6 +669,7 @@ public class JavadocStyleCheckTest
             "59: " + getCheckMessage(MSG_NO_PERIOD),
             "91: " + getCheckMessage(MSG_NO_PERIOD),
         };
+
         verifyWithInlineConfigParser(
                 getPath("InputJavadocStyleRestrictedTokenSet4.java"), expected);
     }
@@ -669,17 +679,15 @@ public class JavadocStyleCheckTest
         final String[] expected = {
             "23: " + getCheckMessage(MSG_NO_PERIOD),
             "43: " + getCheckMessage(MSG_NO_PERIOD),
-            "52:16: " + getCheckMessage(MSG_UNCLOSED_HTML,
-                    "<b>This guy is missing end of bold tag // violation"),
-            "55:12: " + getCheckMessage(MSG_EXTRA_HTML, "</td>Extra tag "
-                    + "shouldn't be here // violation"),
-            "56:54: " + getCheckMessage(MSG_EXTRA_HTML, "</style> // violation"),
-            "58:24: " + getCheckMessage(MSG_UNCLOSED_HTML, "<code>dummy. // violation"),
-            "70: " + getCheckMessage(MSG_NO_PERIOD),
-            "71:36: " + getCheckMessage(MSG_EXTRA_HTML, "</code> // violation"),
-            "72: " + getCheckMessage(MSG_INCOMPLETE_TAG, "         * should fail <"),
-            "87:37: " + getCheckMessage(MSG_UNCLOSED_HTML, "<code> // violation"),
-            "102: " + getCheckMessage(MSG_NO_PERIOD),
+            "53:16: " + getCheckMessage(MSG_UNCLOSED_HTML, "<b>"),
+            "56:12: " + getCheckMessage(MSG_EXTRA_HTML, "</td>"),
+            "57:54: " + getCheckMessage(MSG_EXTRA_HTML, "</style>"),
+            "59:24: " + getCheckMessage(MSG_UNCLOSED_HTML, "<code>dummy"),
+            "74: " + getCheckMessage(MSG_NO_PERIOD),
+            "75:36: " + getCheckMessage(MSG_EXTRA_HTML, "</code>"),
+            "76: " + getCheckMessage(MSG_INCOMPLETE_TAG, "         * should fail <"),
+            "92:37: " + getCheckMessage(MSG_UNCLOSED_HTML, "<code>"),
+            "108: " + getCheckMessage(MSG_NO_PERIOD),
         };
 
         verifyWithInlineConfigParser(
@@ -745,6 +753,7 @@ public class JavadocStyleCheckTest
             "11: " + getCheckMessage(MSG_NO_PERIOD),
             "15: " + getCheckMessage(MSG_NO_PERIOD),
         };
+
         verifyWithInlineConfigParser(
                 getPath("InputJavadocStyleDefault4.java"),
                 expected);
@@ -757,6 +766,7 @@ public class JavadocStyleCheckTest
             "18:16: " + getCheckMessage(MSG_UNCLOSED_HTML,
                     "<AREA ALT=\"alt\" Coordination=\"100,0,200,50\" HREF=\"/href/\"> <"),
         };
+
         verifyWithInlineConfigParser(
                 getPath("InputJavadocStyleCheck1.java"),
                 expected);
@@ -767,6 +777,7 @@ public class JavadocStyleCheckTest
         final String[] expected = {
             "21:4: " + getCheckMessage(MSG_EXTRA_HTML, "</body>"),
         };
+
         verifyWithInlineConfigParser(
                 getPath("InputJavadocStyleCheck2.java"),
                 expected);
@@ -777,6 +788,7 @@ public class JavadocStyleCheckTest
         final String[] expected = {
             "11: " + getCheckMessage(MSG_NO_PERIOD),
         };
+
         verifyWithInlineConfigParser(
                 getPath("InputJavadocStyleCheck3.java"),
                 expected);
@@ -787,6 +799,7 @@ public class JavadocStyleCheckTest
         final String[] expected = {
             "12: " + getCheckMessage(MSG_NO_PERIOD),
         };
+
         verifyWithInlineConfigParser(
                 getPath("InputJavadocStyleCheck5.java"),
                 expected);

--- a/src/test/resources-noncompilable/com/puppycrawl/tools/checkstyle/checks/javadoc/javadocstyle/InputJavadocStyleRecordsAndCompactCtors.java
+++ b/src/test/resources-noncompilable/com/puppycrawl/tools/checkstyle/checks/javadoc/javadocstyle/InputJavadocStyleRecordsAndCompactCtors.java
@@ -46,17 +46,21 @@ public class InputJavadocStyleRecordsAndCompactCtors { // ok
         private void method4() {
         }
 
+        // violation 4 lines below
         /**
          * Test HTML in Javadoc comment
          * <dl>
-         * <dt><b>This guy is missing end of bold tag // violation
+         * <dt><b>
          * <dd>The dt and dd don't require end tags.
          * </dl>
-         * </td>Extra tag shouldn't be here // violation
-         * <style>this tag isn't supported in Javadoc</style> // violation
+         * </td>
+         * <style>this tag isn't supported in Javadoc</style>
          *
-         * @param arg1 <code>dummy. // violation
+         * @param arg1 <code>dummy
          */
+        // violation 5 lines above
+        // violation 5 lines above
+        // violation 4 lines above
         private void method5(int arg1) {
         }
     }
@@ -68,9 +72,10 @@ public class InputJavadocStyleRecordsAndCompactCtors { // ok
         static String props = "";
 
         /** // violation
-         * Public check should fail</code> // violation
+         * Public check should fail</code>
          * should fail <
-         */ // violation above
+         */ // violation 2 lines above
+        // violation 2 lines above
         public void method8() {
         }
     }
@@ -84,8 +89,9 @@ public class InputJavadocStyleRecordsAndCompactCtors { // ok
     public record MyFourthRecord(String myString) { // ok
         /**
          * This Javadoc contains unclosed tag.
-         * <code>unclosed 'code' tag<code> // violation
+         * <code>unclosed 'code' tag<code>
          */
+        // violation 2 lines above
         private static void unclosedTag() {
             System.out.println("stuff");
         }

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadocstyle/InputJavadocStyleDefaultSettingsFour.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadocstyle/InputJavadocStyleDefaultSettingsFour.java
@@ -26,8 +26,8 @@ public class InputJavadocStyleDefaultSettingsFour
 
     /**
      * This Javadoc contains unclosed tag.
-     * <code>unclosed 'code' tag<code> // violation
-     */
+     * <code>unclosed 'code' tag<code>
+     */ // violation above
     private void unclosedTag() {}
 
     void javadocLikeCommentInMethod() {
@@ -36,15 +36,15 @@ public class InputJavadocStyleDefaultSettingsFour
          */
         final int i = 0; // ok
     }
-    // violation below
-    /**
+
+    /** // violation
      * {@inheritDoc}
      */
     private void inheritDoc() {}
 
     /**
-     * <p><b>Note:<b> it's unterminated tag.</p> // violation
-     */
+     * <p><b>Note:<b> it's unterminated tag.</p>
+     */ // violation above
     private void unterminatedTag() {}
 
     /** // violation

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadocstyle/InputJavadocStyleDefaultSettingsOne.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadocstyle/InputJavadocStyleDefaultSettingsOne.java
@@ -50,30 +50,34 @@ public class InputJavadocStyleDefaultSettingsOne // ok
     */
    private void method4() {}
 
-   /**
+   /** // violation 3 lines below
     * Test HTML in Javadoc comment
     * <dl>
-    * <dt><b>This guy is missing end of bold tag // violation
+    * <dt><b>
     * <dd>The dt and dd don't require end tags.
     * </dl>
-    * </td>Extra tag shouldn't be here // violation
-    * <style>this tag isn't supported in Javadoc</style> // violation
-    * @param arg1 <code>dummy. // violation
-    */
+    * </td>
+    * <style>this tag isn't supported in Javadoc</style>
+    * @param arg1 <code>dummy
+    */ // violation 3 lines above
+   // violation 3 lines above
+   // violation 3 lines above
+
    private void method5(int arg1) {}
 
    /** // violation
-    * Protected check <b>should fail // violation
-    */
+    * Protected check <b>
+    */ // violation above
    protected void method6() {}
 
    /** // violation
-    * Package protected check <b>should fail // violation
-    */
+    * Package protected check <b>
+    */  // violation above
    void method7() {}
 
-   /** // violation
-    * Public check should fail</code> // violation
+   // violation below
+   /** // violation below
+    * Public check should fail</code>
     * should fail <
     */ // violation above
    public void method8() {}
@@ -81,16 +85,14 @@ public class InputJavadocStyleDefaultSettingsOne // ok
    /** {@inheritDoc} **/
    public void method9() {} // ok
 
-
     // Testcases to exercise the Tag parser (bug 843887)
-
     /**
      * Real men don't use XHTML.
      * <br />
      * <hr/>
      * < br/>
-     * <img src="schattenparker.jpg"/></img> // violation
-     */
+     * <img src="schattenparker.jpg"/></img>
+     */ // violation above
     private void method10() {}
 
     /**
@@ -109,7 +111,6 @@ public class InputJavadocStyleDefaultSettingsOne // ok
      * <!-- comments <div> should not be checked. -->
      */
     private void method11() {} // ok
-
     /**
      * Tags for two lines.
      * <a href="some_link"
@@ -117,4 +118,3 @@ public class InputJavadocStyleDefaultSettingsOne // ok
      */
     private void method12() {} // ok
 }
-

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadocstyle/InputJavadocStyleDefaultSettingsThree.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadocstyle/InputJavadocStyleDefaultSettingsThree.java
@@ -100,9 +100,9 @@ public class InputJavadocStyleDefaultSettingsThree
      * Checks HTML tags in javadoc.
      *
      * HTML no good tag
-     * <string>Tests</string> // violation
+     * <string>Tests</string>
      *
-     */
+     */ // violation 2 lines above
     public void method21() {}
 
     /**

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadocstyle/InputJavadocStyleDefaultSettingsTwo.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadocstyle/InputJavadocStyleDefaultSettingsTwo.java
@@ -58,8 +58,8 @@ public class InputJavadocStyleDefaultSettingsTwo
 
     /**
      * Some problematic javadoc. Sample usage:
-     * <blockquote> // violation
-     */
+     * <blockquote>
+     */ // violation above
 
     private void method14() {}
 

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadocstyle/InputJavadocStyleExcludeScope1.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadocstyle/InputJavadocStyleExcludeScope1.java
@@ -50,16 +50,18 @@ public class InputJavadocStyleExcludeScope1 // ok
     */
    private void method4() {}
 
-   /**
+   /** // violation 3 lines below
     * Test HTML in Javadoc comment
     * <dl>
-    * <dt><b>This guy is missing end of bold tag // violation
+    * <dt><b>
     * <dd>The dt and dd don't require end tags.
     * </dl>
-    * </td>Extra tag shouldn't be here // violation
-    * <style>this tag isn't supported in Javadoc</style> // violation
-    * @param arg1 <code>dummy. // violation
-    */
+    * </td>
+    * <style>this tag isn't supported in Javadoc</style>
+    * @param arg1 <code>dummy
+    */ // violation 3 lines above
+   // violation 3 lines above
+   // violation 3 lines above
    private void method5(int arg1) {}
 
    /**
@@ -68,8 +70,8 @@ public class InputJavadocStyleExcludeScope1 // ok
    protected void method6() {} // ok
 
    /** // violation
-    * Package protected check <b>should fail // violation
-    */
+    * Package protected check <b>
+    */ // violation above
    void method7() {}
 
    /**
@@ -89,8 +91,8 @@ public class InputJavadocStyleExcludeScope1 // ok
      * <br />
      * <hr/>
      * < br/>
-     * <img src="schattenparker.jpg"/></img> // violation
-     */
+     * <img src="schattenparker.jpg"/></img>
+     */ // violation above
     private void method10() {}
 
     /**

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadocstyle/InputJavadocStyleExcludeScope2.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadocstyle/InputJavadocStyleExcludeScope2.java
@@ -65,8 +65,8 @@ public class InputJavadocStyleExcludeScope2 // ok
 
     /**
      * Some problematic javadoc. Sample usage:
-     * <blockquote> // violation
-     */
+     * <blockquote>
+     */ // violation above
 
     private void method14() {}
 

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadocstyle/InputJavadocStyleExcludeScope4.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadocstyle/InputJavadocStyleExcludeScope4.java
@@ -26,8 +26,8 @@ public class InputJavadocStyleExcludeScope4 // ok
 
     /**
      * This Javadoc contains unclosed tag.
-     * <code>unclosed 'code' tag<code> // violation
-     */
+     * <code>unclosed 'code' tag<code>
+     */ // violation above
     private void unclosedTag() {}
 
     void javadocLikeCommentInMethod() { // ok
@@ -43,8 +43,8 @@ public class InputJavadocStyleExcludeScope4 // ok
     private void inheritDoc() {}
 
     /**
-     * <p><b>Note:<b> it's unterminated tag.</p> // violation
-     */
+     * <p><b>Note:<b> it's unterminated tag.</p>
+     */ // violation above
     private void unterminatedTag() {}
 
     /**

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadocstyle/InputJavadocStyleHtml1.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadocstyle/InputJavadocStyleHtml1.java
@@ -49,30 +49,35 @@ public class InputJavadocStyleHtml1 {
     */
    private void method4() {} // ok
 
+   // violation 4 lines below
    /**
     * Test HTML in Javadoc comment
     * <dl>
-    * <dt><b>This guy is missing end of bold tag // violation
+    * <dt><b>
     * <dd>The dt and dd don't require end tags.
     * </dl>
-    * </td>Extra tag shouldn't be here // violation
-    * <style>this tag isn't supported in Javadoc</style> // violation
-    * @param arg1 <code>dummy. // violation
+    * </td>
+    * <style>this tag isn't supported in Javadoc</style>
+    * @param arg1 <code>dummy
     */
+   // violation 4 lines above
+   // violation 4 lines above
+   // violation 4 lines above
    private void method5(int arg1) {}
 
    /**
-    * Protected check <b>should fail // violation
-    */
+    * Protected check <b>
+    */ // violation above
    protected void method6() {}
 
    /**
-    * Package protected check <b>should fail // violation
-    */
+    * Package protected check <b>
+    */ // violation above
    void method7() {}
 
+   // violation 2 lines below
    /**
-    * Public check should fail</code> // violation
+    * Public check should fail</code>
     * should fail <
     */ // violation above
    public void method8() {}
@@ -88,8 +93,8 @@ public class InputJavadocStyleHtml1 {
      * <br />
      * <hr/>
      * < br/>
-     * <img src="schattenparker.jpg"/></img> // violation
-     */
+     * <img src="schattenparker.jpg"/></img>
+     */ // violation above
     private void method10() {}
 
     /**

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadocstyle/InputJavadocStyleHtml2.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadocstyle/InputJavadocStyleHtml2.java
@@ -64,8 +64,8 @@ public class InputJavadocStyleHtml2 {
 
     /**
      * Some problematic javadoc. Sample usage:
-     * <blockquote> // violation
-     */
+     * <blockquote>
+     */ // violation above
 
     private void method14() {}
 

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadocstyle/InputJavadocStyleHtml3.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadocstyle/InputJavadocStyleHtml3.java
@@ -99,9 +99,9 @@ public class InputJavadocStyleHtml3 {
      * Checks HTML tags in javadoc.
      *
      * HTML no good tag
-     * <string>Tests</string> // violation
+     * <string>Tests</string>
      *
-     */
+     */ // violation 2 lines above
     public void method21() {}
 
     /**

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadocstyle/InputJavadocStyleHtml4.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadocstyle/InputJavadocStyleHtml4.java
@@ -25,8 +25,8 @@ public class InputJavadocStyleHtml4 {
 
     /**
      * This Javadoc contains unclosed tag.
-     * <code>unclosed 'code' tag<code> // violation
-     */
+     * <code>unclosed 'code' tag<code>
+     */ // violation above
     private void unclosedTag() {}
 
     void javadocLikeCommentInMethod() { // ok
@@ -41,8 +41,9 @@ public class InputJavadocStyleHtml4 {
      */
     private void inheritDoc() {} // ok
 
-    /**
-     * <p><b>Note:<b> it's unterminated tag.</p> // violation
+    /** // violation below
+     * <p><b>
+     * </p>
      */
     private void unterminatedTag() {}
 

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadocstyle/InputJavadocStyleScopePackage1.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadocstyle/InputJavadocStyleScopePackage1.java
@@ -63,17 +63,18 @@ public class InputJavadocStyleScopePackage1
     private void method5(int arg1) {} // ok
 
     /** // violation
-     * Protected check <b>should fail // violation
-     */
+     * Protected check <b>
+     */ // violation above
     protected void method6() {}
 
     /** // violation
-     * Package protected check <b>should fail // violation
-     */
+     * Package protected check <b>
+     */ // violation above
     void method7() {}
 
-    /** // violation
-     * Public check should fail</code> // violation
+    // violation below
+    /** // violation below
+     * Public check should fail</code>
      * should fail <
      */ // violation above
     public void method8() {}

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadocstyle/InputJavadocStyleScopePackage3.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadocstyle/InputJavadocStyleScopePackage3.java
@@ -100,9 +100,9 @@ public class InputJavadocStyleScopePackage3
      * Checks HTML tags in javadoc.
      *
      * HTML no good tag
-     * <string>Tests</string> // violation
+     * <string>Tests</string>
      *
-     */
+     */ // violation 2 lines above
     public void method21() {}
 
     /**

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadocstyle/InputJavadocStyleScopeProtected1.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadocstyle/InputJavadocStyleScopeProtected1.java
@@ -63,8 +63,8 @@ public class InputJavadocStyleScopeProtected1 // ok
    private void method5(int arg1) {} // ok
 
    /** // violation
-    * Protected check <b>should fail // violation
-    */
+    * Protected check <b>
+    */ // violation above
    protected void method6() {}
 
    /**
@@ -72,8 +72,9 @@ public class InputJavadocStyleScopeProtected1 // ok
     */
    void method7() {} // ok
 
-   /** // violation
-    * Public check should fail</code> // violation
+    // violation below
+   /** // violation below
+    * Public check should fail</code>
     * should fail <
     */ // violation above
    public void method8() {}

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadocstyle/InputJavadocStyleScopeProtected3.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadocstyle/InputJavadocStyleScopeProtected3.java
@@ -100,9 +100,9 @@ public class InputJavadocStyleScopeProtected3 // ok
      * Checks HTML tags in javadoc.
      *
      * HTML no good tag
-     * <string>Tests</string> // violation
+     * <string>Tests</string>
      *
-     */
+     */ // violation 2 lines above
     public void method21() {}
 
     /**

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadocstyle/InputJavadocStyleScopePublic1.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadocstyle/InputJavadocStyleScopePublic1.java
@@ -72,8 +72,9 @@ public class InputJavadocStyleScopePublic1 // ok
     */
    void method7() {} // ok
 
-   /** // violation
-    * Public check should fail</code> // violation
+   // violation below
+   /** // violation below
+    * Public check should fail</code>
     * should fail <
     */ // violation above
    public void method8() {}

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadocstyle/InputJavadocStyleScopePublic3.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadocstyle/InputJavadocStyleScopePublic3.java
@@ -100,9 +100,9 @@ public class InputJavadocStyleScopePublic3 // ok
      * Checks HTML tags in javadoc.
      *
      * HTML no good tag
-     * <string>Tests</string> // violation
+     * <string>Tests</string>
      *
-     */
+     */ // violation 2 lines above
     public void method21() {}
 
     /**


### PR DESCRIPTION
Issue #13969 

This PR aims to improve the clarity of our codebase's documentation by removing the term `// violation` from within Javadoc comments. Leveraging our support for annotations like `// violation X lines above/below`, these violation references will be relocated above the relevant Javadoc, enhancing readability.