### PR TITLE
doc: Added reference to the Checkstyle extension for bld

### DIFF
--- a/config/jsoref-spellchecker/whitelist.words
+++ b/config/jsoref-spellchecker/whitelist.words
@@ -1298,6 +1298,7 @@ testmodules
 textlevel
 Tfo
 tfoot
+Thauvin
 thead
 thesummaryfragment
 thetaphi

--- a/src/xdocs/index.xml.vm
+++ b/src/xdocs/index.xml.vm
@@ -530,6 +530,14 @@
                   in your repository sources, and apply their related linters. Available as GitHub
                   Action, other CI tools and locally</td>
             </tr>
+            <tr>
+              <td>
+                <a href="https://rife2.com/bld">bld</a>
+              </td>
+              <td>Erik C. Thauvin</td>
+              <td><a href="https://github.com/rife2/bld-checkstyle">Checkstyle Extension</a> for bld</td>
+              <td>An extension for checking source code in a bld project</td>
+            </tr>
           </table>
         </div>
       </subsection>


### PR DESCRIPTION
Added reference to the [Checkstyle extension for bld](https://github.com/rife2/bld-checkstyle) in the ` Active Tools` table (#13995)


From https://rife2.com/bld:

>[bld](https://github.com/rife2/bld) is a new build system that allows you to write your build logic in pure Java.

