### PR TITLE
Issue #13893: Remove issue reference from checkstyle-non-main-files-suppressions.xml

### DIFF
--- a/config/checkstyle-non-main-files-suppressions.xml
+++ b/config/checkstyle-non-main-files-suppressions.xml
@@ -253,9 +253,6 @@
   <!-- until https://github.com/checkstyle/checkstyle/issues/13839 -->
   <suppress id="propertiesMacroMustExist"
          files="src[\\/]xdocs[\\/]checks[\\/]annotation[\\/]suppresswarningsholder.xml.template"/>
-  <!-- until https://github.com/checkstyle/checkstyle/issues/13893 -->
-  <suppress id="propertiesMacroMustExist"
-         files="src[\\/]xdocs[\\/]checks[\\/]coding[\\/]illegaltype.xml.template"/>
   <!-- until https://github.com/checkstyle/checkstyle/issues/13930 -->
   <suppress id="propertiesMacroMustExist"
          files="src[\\/]xdocs[\\/]checks[\\/]coding[\\/]magicnumber.xml.template"/>


### PR DESCRIPTION
Issue #13893 

This issue has been marked completed but is still having the reference in `checkstyle-non-main-files-suppressions.xml` file. This PR removes the reference so that in future PRs it doesn't gives error as - 

```
Following lines are referencing closed issues.
Such lines should be removed or the issue should be examined:

https://github.com/suniti0804/checkstyle/blob/xpathfinallocalvariable/config/checkstyle-non-main-files-suppressions.xml#L256