### PR TITLE
Issue  #13999: Cover pitest survival for init() method of AbstractJavaDocCheck

### DIFF
--- a/config/pitest-suppressions/pitest-javadoc-suppressions.xml
+++ b/config/pitest-suppressions/pitest-javadoc-suppressions.xml
@@ -3,15 +3,6 @@
   <mutation unstable="false">
     <sourceFile>AbstractJavadocCheck.java</sourceFile>
     <mutatedClass>com.puppycrawl.tools.checkstyle.checks.javadoc.AbstractJavadocCheck</mutatedClass>
-    <mutatedMethod>init</mutatedMethod>
-    <mutator>org.pitest.mutationtest.engine.gregor.mutators.NonVoidMethodCallMutator</mutator>
-    <description>removed call to java/lang/Class::getName</description>
-    <lineContent>JavadocUtil.getTokenName(javadocTokenId), getClass().getName());</lineContent>
-  </mutation>
-
-  <mutation unstable="false">
-    <sourceFile>AbstractJavadocCheck.java</sourceFile>
-    <mutatedClass>com.puppycrawl.tools.checkstyle.checks.javadoc.AbstractJavadocCheck</mutatedClass>
     <mutatedMethod>validateDefaultJavadocTokens</mutatedMethod>
     <mutator>org.pitest.mutationtest.engine.gregor.mutators.RemoveConditionalMutator_EQUAL_IF</mutator>
     <description>removed conditional - replaced equality check with true</description>

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/javadoc/AbstractJavadocCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/javadoc/AbstractJavadocCheckTest.java
@@ -290,7 +290,8 @@ public class AbstractJavadocCheckTest extends AbstractModuleTestSupport {
         catch (IllegalStateException ex) {
             final String expected = "Javadoc Token "
                     + "\"RETURN_LITERAL\" was not found in "
-                    + "Acceptable javadoc tokens list in check";
+                    + "Acceptable javadoc tokens list in check "
+                    + TokenIsNotInAcceptablesJavadocCheck.class.getName();
             assertWithMessage("Invalid exception, should start with: " + expected)
                     .that(ex.getMessage())
                     .startsWith(expected);


### PR DESCRIPTION
Issue #13999 

Changes in the `AbstractJavadocCheck` class for the mutated method are covered by the existing test cases.