### PR TITLE
Issue #14019: Resolve pitest suppressions for ScopeUtil 2

### DIFF
--- a/config/pitest-suppressions/pitest-utils-suppressions.xml
+++ b/config/pitest-suppressions/pitest-utils-suppressions.xml
@@ -12,15 +12,6 @@
   <mutation unstable="false">
     <sourceFile>ScopeUtil.java</sourceFile>
     <mutatedClass>com.puppycrawl.tools.checkstyle.utils.ScopeUtil</mutatedClass>
-    <mutatedMethod>getDeclaredScopeFromMods</mutatedMethod>
-    <mutator>org.pitest.mutationtest.engine.gregor.mutators.RemoveConditionalMutator_EQUAL_IF</mutator>
-    <description>removed conditional - replaced equality check with true</description>
-    <lineContent>for (DetailAST token = aMods.getFirstChild(); token != null &amp;&amp; result == null;</lineContent>
-  </mutation>
-
-  <mutation unstable="false">
-    <sourceFile>ScopeUtil.java</sourceFile>
-    <mutatedClass>com.puppycrawl.tools.checkstyle.utils.ScopeUtil</mutatedClass>
     <mutatedMethod>getSurroundingScope</mutatedMethod>
     <mutator>org.pitest.mutationtest.engine.gregor.mutators.experimental.NakedReceiverMutator</mutator>
     <description>replaced call to com/puppycrawl/tools/checkstyle/api/DetailAST::getParent with receiver</description>

--- a/src/main/java/com/puppycrawl/tools/checkstyle/utils/ScopeUtil.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/utils/ScopeUtil.java
@@ -44,8 +44,8 @@ public final class ScopeUtil {
      */
     public static Scope getDeclaredScopeFromMods(DetailAST aMods) {
         Scope result = null;
-        for (DetailAST token = aMods.getFirstChild(); token != null && result == null;
-                token = token.getNextSibling()) {
+        for (DetailAST token = aMods.getFirstChild(); token != null;
+             token = token.getNextSibling()) {
             switch (token.getType()) {
                 case TokenTypes.LITERAL_PUBLIC:
                     result = Scope.PUBLIC;


### PR DESCRIPTION
Issue #14019 

### Explanation

In this PR, I've made a change to the `getDeclaredScopeFromMods` method in the `ScopeUtil` class. I removed the `result == null` condition from the for loop. This change was based on a mutation test, which suggested that we could remove this condition without affecting the functionality of the code.

After making this change, I ran our suite of unit and integration tests. I'm happy to report that all tests passed successfully, indicating that this change did not introduce any regressions or break any existing functionality.

Based on my analysis, the impact of this change appears to be minimal. The `result == null` condition was not contributing to the functionality of the method, and its removal has not negatively affected any other parts of our code.

In conclusion, it seems safe to remove this condition based on the successful passing of all tests and the lack of any adverse effects on the rest of the code.

https://github.com/checkstyle/checkstyle/blob/3a23ae03d5f7cd3e59693017b5c971bb3d886770/config/pitest-suppressions/pitest-utils-suppressions.xml#L12-L19


### Dependency Tree 

```
ScopeUtil.getScopeFromMods(DetailAST)  (com.puppycrawl.tools.checkstyle.utils)
    DeclarationOrderCheck.processModifiersSubState(DetailAST, ScopeState, boolean)  (com.puppycrawl.tools.checkstyle.checks.coding)
        DeclarationOrderCheck.processModifiers(DetailAST)  (com.puppycrawl.tools.checkstyle.checks.coding)
            DeclarationOrderCheck.visitToken(DetailAST)  (com.puppycrawl.tools.checkstyle.checks.coding)

ScopeUtil.getScope(DetailAST)  (com.puppycrawl.tools.checkstyle.utils)
    ScopeUtil.getSurroundingScope(DetailAST)  (com.puppycrawl.tools.checkstyle.utils)
        JavadocVariableCheck.shouldCheck(DetailAST)  (com.puppycrawl.tools.checkstyle.checks.javadoc)
            JavadocVariableCheck.visitToken(DetailAST)  (com.puppycrawl.tools.checkstyle.checks.javadoc)
        MissingJavadocMethodCheck.shouldCheck(DetailAST, Scope)  (com.puppycrawl.tools.checkstyle.checks.javadoc)
            MissingJavadocMethodCheck.visitToken(DetailAST)  (com.puppycrawl.tools.checkstyle.checks.javadoc)
        MissingJavadocTypeCheck.shouldCheck(DetailAST)  (com.puppycrawl.tools.checkstyle.checks.javadoc)
            MissingJavadocTypeCheck.visitToken(DetailAST)  (com.puppycrawl.tools.checkstyle.checks.javadoc)
        DesignForExtensionCheck.canBeOverridden(DetailAST)  (com.puppycrawl.tools.checkstyle.checks.design)
            DesignForExtensionCheck.visitToken(DetailAST)  (com.puppycrawl.tools.checkstyle.checks.design)
```

### Modules 

1. `DeclarationOrderCheck`
2. `JavadocVariableCheck`
3. `MissingJavadocMethodCheck`
4. `MissingJavadocTypeCheck`
5. `DesignForExtensionCheck`


Diff Regression config: https://gist.githubusercontent.com/suniti0804/585da89f8b5c29b3e841c61fcdfc9985/raw/ca3a0fa8aab621b053880cc5ea38109b081accec/pull-14030-regerssion-config

Diff Regression projects: https://gist.githubusercontent.com/suniti0804/1d7bd7fbc50bf6c93896fbe2bbbf2c4a/raw/f71611ef97d0737b6d8bb1c1253cab18b9342429/projects-to-test-on-for-github-action.properties

Report label: Issue#14030-Report