### PR TITLE
infra: test new cimg

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -78,11 +78,10 @@ jobs:
 
   sonarqube:
     docker:
-      - image: checkstyle/jdk-11-groovy-git-mvn:11.0.13__3.0.9__2.25.1__3.6.3
+      - image: nrmancuso/custom-cimg:latest
 
     steps:
       - checkout
-      - run: apt-get install -y jq
       - run:
           name: Run sonarqube
           command: |
@@ -118,7 +117,7 @@ workflows:
       # no-exception-test script
       - validate-with-maven-script:
           name: "no-exception-lucene-and-others-javadoc"
-          image-name: &custom_img "checkstyle/jdk-11-groovy-git-mvn:11.0.13__3.0.9__2.25.1__3.6.3"
+          image-name: &custom_img "nrmancuso/custom-cimg:latest"
           command: "./.ci/no-exception-test.sh no-exception-lucene-and-others-javadoc"
       - validate-with-maven-script:
           name: "no-exception-cassandra-storm-tapestry-javadoc"


### PR DESCRIPTION
Testing

```dockerfile
FROM cimg/base:2023.10

# ca-certificates-java must be installed AND configured before java + groovy installation
RUN sudo apt update && \
  sudo apt install ca-certificates-java && \
  sudo apt install openjdk-11-jdk groovy jq -y

ENV JAVA_HOME=/usr/lib/jvm/java-11-openjdk-amd64 \
    GROOVY_HOME=/usr/share/groovy \
    PATH=$GROOVY_HOME/bin:$PATH

ENV MAVEN_VERSION=3.9.5 \
    PATH=/opt/apache-maven/bin:$PATH

RUN MAVEN_3_URL=https://www.apache.org/dist/maven/maven-3 && \
    MAVEN_VERSION_URL=$MAVEN_VERSION/binaries/apache-maven-${MAVEN_VERSION}-bin.tar.gz && \
    export URL=${MAVEN_3_URL}/${MAVEN_VERSION_URL} && \
    curl -sSL --fail --retry 3 $URL -o apache-maven.tar.gz && \
    sudo tar -xzf apache-maven.tar.gz -C /opt/ && \
    rm apache-maven.tar.gz && \
    sudo ln -s /opt/apache-maven-* /opt/apache-maven && \
    mvn --version


```

https://hub.docker.com/repository/docker/nrmancuso/custom-cimg/general