### PR TITLE
doc: add direct link to check

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/SimplifyBooleanReturnCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/SimplifyBooleanReturnCheck.java
@@ -44,7 +44,8 @@ import com.puppycrawl.tools.checkstyle.utils.TokenUtil;
  * </pre>
  * <p>
  * The idea for this Check has been shamelessly stolen from the equivalent
- * <a href="https://pmd.github.io/">PMD</a> rule.
+ * <a href="https://pmd.github.io/pmd/pmd_rules_java_design.html#simplifybooleanreturns">
+ *     PMD</a> rule.
  * </p>
  * <p>
  * Parent is {@code com.puppycrawl.tools.checkstyle.TreeWalker}

--- a/src/main/resources/com/puppycrawl/tools/checkstyle/meta/checks/coding/SimplifyBooleanReturnCheck.xml
+++ b/src/main/resources/com/puppycrawl/tools/checkstyle/meta/checks/coding/SimplifyBooleanReturnCheck.xml
@@ -22,7 +22,8 @@
  &lt;/pre&gt;
  &lt;p&gt;
  The idea for this Check has been shamelessly stolen from the equivalent
- &lt;a href="https://pmd.github.io/"&gt;&lt;/a&gt; rule.
+ &lt;a href="https://pmd.github.io/pmd/pmd_rules_java_design.html#simplifybooleanreturns"&gt;
+     PMD&lt;/a&gt; rule.
  &lt;/p&gt;</description>
          <message-keys>
             <message-key key="simplify.boolReturn"/>

--- a/src/xdocs/checks/coding/simplifybooleanreturn.xml
+++ b/src/xdocs/checks/coding/simplifybooleanreturn.xml
@@ -29,7 +29,8 @@ return !valid();
 
         <p>
           The idea for this Check has been shamelessly stolen from the
-          equivalent <a href="https://pmd.github.io/">PMD</a> rule.
+          equivalent <a href="https://pmd.github.io/pmd/pmd_rules_java_design.html#simplifybooleanreturns">
+          PMD</a> rule.
         </p>
       </subsection>
 

--- a/src/xdocs/checks/coding/simplifybooleanreturn.xml.template
+++ b/src/xdocs/checks/coding/simplifybooleanreturn.xml.template
@@ -29,7 +29,8 @@ return !valid();
 
         <p>
           The idea for this Check has been shamelessly stolen from the
-          equivalent <a href="https://pmd.github.io/">PMD</a> rule.
+          equivalent <a href="https://pmd.github.io/pmd/pmd_rules_java_design.html#simplifybooleanreturns">
+          PMD</a> rule.
         </p>
       </subsection>
 


### PR DESCRIPTION
Noticed at https://checkstyle.org/checks/coding/simplifybooleanreturn.html#SimplifyBooleanReturn, I expected a direct link to this PMD rule.