### PR TITLE
Issue #13693: migrate LineLength to property xdco macro; improving ex…

### DIFF
--- a/config/pmd-main.xml
+++ b/config/pmd-main.xml
@@ -51,4 +51,18 @@
          value="//ClassOrInterfaceDeclaration[@SimpleName='AutomaticBean']"/>
     </properties>
   </rule>
+  <rule ref="category/java/design.xml/AvoidCatchingGenericException">
+    <properties>
+      <!-- we allow catching Exception in certain cases to provide more details in wrapper -->
+      <property name="violationSuppressXPath"
+         value="//ClassOrInterfaceDeclaration[@SimpleName='PropertiesMacro']
+                        //MethodDeclaration[@Name='writeTablePropertiesRows']
+                    | //ClassOrInterfaceDeclaration[@SimpleName='Checker']
+                        //MethodDeclaration[@Name='processFiles']
+                    | //ClassOrInterfaceDeclaration[@SimpleName='Checker']
+                        //MethodDeclaration[@Name='processFile']
+                    | //ClassOrInterfaceDeclaration[@SimpleName='TranslationCheck']
+                        //MethodDeclaration[@Name='getTranslationKeys']"/>
+    </properties>
+  </rule>
 </ruleset>

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/sizes/LineLengthCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/sizes/LineLengthCheck.java
@@ -60,7 +60,7 @@ import com.puppycrawl.tools.checkstyle.utils.CommonUtil;
  * </ul>
  * <ul>
  * <li>
- * Property {@code fileExtensions} - Specify file extensions that are accepted.
+ * Property {@code fileExtensions} - Specify the file type extension of files to process.
  * Type is {@code java.lang.String[]}.
  * Default value is {@code ""}.
  * </li>

--- a/src/main/java/com/puppycrawl/tools/checkstyle/site/PropertiesMacro.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/site/PropertiesMacro.java
@@ -208,9 +208,18 @@ public class PropertiesMacro extends AbstractMacro {
         final List<String> orderedProperties = orderProperties(properties);
 
         for (String property : orderedProperties) {
-            final DetailNode propertyJavadoc = propertiesJavadocs.get(property);
-            final DetailNode currentModuleJavadoc = propertiesJavadocs.get(currentModuleName);
-            writePropertyRow(sink, property, propertyJavadoc, instance, currentModuleJavadoc);
+            try {
+                final DetailNode propertyJavadoc = propertiesJavadocs.get(property);
+                final DetailNode currentModuleJavadoc = propertiesJavadocs.get(currentModuleName);
+                writePropertyRow(sink, property, propertyJavadoc, instance, currentModuleJavadoc);
+            }
+            // -@cs[IllegalCatch] we need to get details in wrapping exception
+            catch (Exception exc) {
+                final String message = String.format(Locale.ROOT,
+                        "Exception while handling moduleName: %s propertyName: %s",
+                        currentModuleName, property);
+                throw new MacroExecutionException(message, exc);
+            }
         }
     }
 

--- a/src/main/java/com/puppycrawl/tools/checkstyle/site/SiteUtil.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/site/SiteUtil.java
@@ -158,14 +158,20 @@ public final class SiteUtil {
     );
 
     /**
+     * Frequent version.
+     */
+    private static final String V824 = "8.24";
+
+    /**
      * Map of properties whose since version is different from module version but
      * are not specified in code because they are inherited from their super class(es).
      */
     private static final Map<String, String> SINCE_VERSION_FOR_INHERITED_PROPERTY = Map.ofEntries(
-        Map.entry("MissingDeprecatedCheck.violateExecutionOnNonTightHtml", "8.24"),
+        Map.entry("MissingDeprecatedCheck.violateExecutionOnNonTightHtml", V824),
         Map.entry("NonEmptyAtclauseDescriptionCheck.violateExecutionOnNonTightHtml", "8.3"),
         Map.entry("NonEmptyAtclauseDescriptionCheck.javadocTokens", "7.3"),
         Map.entry("FileTabCharacterCheck.fileExtensions", "5.0"),
+        Map.entry("LineLengthCheck.fileExtensions", V824),
         Map.entry("ParenPadCheck.option", "3.0"),
         Map.entry("TypecastParenPadCheck.option", "3.2")
     );

--- a/src/main/resources/com/puppycrawl/tools/checkstyle/meta/checks/sizes/LineLengthCheck.xml
+++ b/src/main/resources/com/puppycrawl/tools/checkstyle/meta/checks/sizes/LineLengthCheck.xml
@@ -36,7 +36,7 @@
  &lt;/ul&gt;</description>
          <properties>
             <property default-value="" name="fileExtensions" type="java.lang.String[]">
-               <description>Specify file extensions that are accepted.</description>
+               <description>Specify the file type extension of files to process.</description>
             </property>
             <property default-value="^(package|import) .*"
                       name="ignorePattern"

--- a/src/xdocs/checks/sizes/linelength.xml
+++ b/src/xdocs/checks/sizes/linelength.xml
@@ -33,7 +33,7 @@
             </tr>
             <tr>
               <td>fileExtensions</td>
-              <td>Specify file extensions that are accepted.</td>
+              <td>Specify the file type extension of files to process.</td>
               <td><a href="../../property_types.html#String.5B.5D">String[]</a></td>
               <td><code>all files</code></td>
               <td>8.24</td>

--- a/src/xdocs/checks/sizes/linelength.xml.template
+++ b/src/xdocs/checks/sizes/linelength.xml.template
@@ -23,36 +23,10 @@
 
       <subsection name="Properties" id="Properties">
         <div class="wrapper">
-          <table>
-            <tr>
-              <th>name</th>
-              <th>description</th>
-              <th>type</th>
-              <th>default value</th>
-              <th>since</th>
-            </tr>
-            <tr>
-              <td>fileExtensions</td>
-              <td>Specify file extensions that are accepted.</td>
-              <td><a href="../../property_types.html#String.5B.5D">String[]</a></td>
-              <td><code>all files</code></td>
-              <td>8.24</td>
-            </tr>
-            <tr>
-              <td>ignorePattern</td>
-              <td>Specify pattern for lines to ignore.</td>
-              <td><a href="../../property_types.html#Pattern">Pattern</a></td>
-              <td><code>"^(package|import) .*"</code></td>
-              <td>3.0</td>
-            </tr>
-            <tr>
-              <td>max</td>
-              <td>Specify the maximum line length allowed.</td>
-              <td><a href="../../property_types.html#int">int</a></td>
-              <td><code>80</code></td>
-              <td>3.0</td>
-            </tr>
-          </table>
+          <macro name="properties">
+            <param name="modulePath"
+                   value="src/main/java/com/puppycrawl/tools/checkstyle/checks/sizes/LineLengthCheck.java"/>
+          </macro>
         </div>
       </subsection>
 


### PR DESCRIPTION
Issue #13693

https://pmd.github.io/pmd/pmd_rules_java_design.html#avoidcatchinggenericexception

exception was:
```
java.lang.NullPointerException
	at com.puppycrawl.tools.checkstyle.utils.JavadocUtil.getFirstChild(JavadocUtil.java:220)
	at com.puppycrawl.tools.checkstyle.utils.JavadocUtil.findFirstToken(JavadocUtil.java:200)
	at com.puppycrawl.tools.checkstyle.site.SiteUtil.getSinceVersionFromJavadoc(SiteUtil.java:731)
	at com.puppycrawl.tools.checkstyle.site.SiteUtil.getSinceVersion(SiteUtil.java:711)
	at com.puppycrawl.tools.checkstyle.site.PropertiesMacro.writePropertySinceVersionCell(PropertiesMacro.java:537)
	at com.puppycrawl.tools.checkstyle.site.PropertiesMacro.writePropertyRow(PropertiesMacro.java:259)
	at com.puppycrawl.tools.checkstyle.site.PropertiesMacro.writeTablePropertiesRows(PropertiesMacro.java:213)
	at com.puppycrawl.tools.checkstyle.site.PropertiesMacro.writePropertiesTable(PropertiesMacro.java:156)
	at com.puppycrawl.tools.checkstyle.site.PropertiesMacro.execute(PropertiesMacro.java:128)
	at org.apache.maven.doxia.parser.AbstractParser.executeMacro(AbstractParser.java:145)
	at com.puppycrawl.tools.checkstyle.site.XdocsTemplateParser.processMacroEnd(XdocsTemplateParser.java:187)
	at com.puppycrawl.tools.checkstyle.site.XdocsTemplateParser.handleEndTag(XdocsTemplateParser.java:116)
	at org.apache.maven.doxia.parser.AbstractXmlParser.parseXml(AbstractXmlParser.java:238)
	at org.apache.maven.doxia.parser.AbstractXmlParser.parse(AbstractXmlParser.java:156)
	at org.apache.maven.doxia.parser.XhtmlBaseParser.parse(XhtmlBaseParser.java:92)
	at org.apache.maven.doxia.module.xdoc.XdocParser.parse(XdocParser.java:113)
	at com.puppycrawl.tools.checkstyle.site.XdocsTemplateParser.parse(XdocsTemplateParser.java:76)
	at org.apache.maven.doxia.parser.AbstractParser.parse(AbstractParser.java:207)
	at com.puppycrawl.tools.checkstyle.internal.utils.XdocGenerator.generateXdocContent(XdocGenerator.java:68)
	at com.puppycrawl.tools.checkstyle.internal.XdocsPagesTest.generateXdocContent(XdocsPagesTest.java:238)
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.base/java.lang.reflect.Method.invoke(Method.java:566)
	at org.junit.platform.commons.util.ReflectionUtils.invokeMethod(ReflectionUtils.java:727)
	at org.junit.jupiter.engine.execution.MethodInvocation.proceed(MethodInvocation.java:60)
	at org.junit.jupiter.engine.execution.InvocationInterceptorChain$ValidatingInvocation.proceed(InvocationInterceptorChain.java:131)
	at org.junit.jupiter.engine.extension.TimeoutExtension.intercept(TimeoutExtension.java:156)
	at org.junit.jupiter.engine.extension.TimeoutExtension.interceptLifecycleMethod(TimeoutExtension.java:128)
	at org.junit.jupiter.engine.extension.TimeoutExtension.interceptBeforeAllMethod(TimeoutExtension.java:70)
	at org.junit.jupiter.engine.execution.InterceptingExecutableInvoker$ReflectiveInterceptorCall.lambda$ofVoidMethod$0(InterceptingExecutableInvoker.java:103)
	at org.junit.jupiter.engine.execution.InterceptingExecutableInvoker.lambda$invoke$0(InterceptingExecutableInvoker.java:93)
	at org.junit.jupiter.engine.execution.InvocationInterceptorChain$InterceptedInvocation.proceed(InvocationInterceptorChain.java:106)
	at org.junit.jupiter.engine.execution.InvocationInterceptorChain.proceed(InvocationInterceptorChain.java:64)
	at org.junit.jupiter.engine.execution.InvocationInterceptorChain.chainAndInvoke(InvocationInterceptorChain.java:45)
	at org.junit.jupiter.engine.execution.InvocationInterceptorChain.invoke(InvocationInterceptorChain.java:37)
	at org.junit.jupiter.engine.execution.InterceptingExecutableInvoker.invoke(InterceptingExecutableInvoker.java:92)
	at org.junit.jupiter.engine.execution.InterceptingExecutableInvoker.invoke(InterceptingExecutableInvoker.java:86)
	at org.junit.jupiter.engine.descriptor.ClassBasedTestDescriptor.lambda$invokeBeforeAllMethods$13(ClassBasedTestDescriptor.java:411)
	at org.junit.platform.engine.support.hierarchical.ThrowableCollector.execute(ThrowableCollector.java:73)
	at org.junit.jupiter.engine.descriptor.ClassBasedTestDescriptor.invokeBeforeAllMethods(ClassBasedTestDescriptor.java:409)
	at org.junit.jupiter.engine.descriptor.ClassBasedTestDescriptor.before(ClassBasedTestDescriptor.java:215)
	at org.junit.jupiter.engine.descriptor.ClassBasedTestDescriptor.before(ClassBasedTestDescriptor.java:84)
	at org.junit.platform.engine.support.hierarchical.NodeTestTask.lambda$executeRecursively$6(NodeTestTask.java:148)
	at org.junit.platform.engine.support.hierarchical.ThrowableCollector.execute(ThrowableCollector.java:73)
	at org.junit.platform.engine.support.hierarchical.NodeTestTask.lambda$executeRecursively$8(NodeTestTask.java:141)
	at org.junit.platform.engine.support.hierarchical.Node.around(Node.java:137)
	at org.junit.platform.engine.support.hierarchical.NodeTestTask.lambda$executeRecursively$9(NodeTestTask.java:139)
	at org.junit.platform.engine.support.hierarchical.ThrowableCollector.execute(ThrowableCollector.java:73)
	at org.junit.platform.engine.support.hierarchical.NodeTestTask.executeRecursively(NodeTestTask.java:138)
	at org.junit.platform.engine.support.hierarchical.NodeTestTask.execute(NodeTestTask.java:95)
	at java.base/java.util.ArrayList.forEach(ArrayList.java:1541)
	at org.junit.platform.engine.support.hierarchical.SameThreadHierarchicalTestExecutorService.invokeAll(SameThreadHierarchicalTestExecutorService.java:41)
	at org.junit.platform.engine.support.hierarchical.NodeTestTask.lambda$executeRecursively$6(NodeTestTask.java:155)
	at org.junit.platform.engine.support.hierarchical.ThrowableCollector.execute(ThrowableCollector.java:73)
	at org.junit.platform.engine.support.hierarchical.NodeTestTask.lambda$executeRecursively$8(NodeTestTask.java:141)
	at org.junit.platform.engine.support.hierarchical.Node.around(Node.java:137)
	at org.junit.platform.engine.support.hierarchical.NodeTestTask.lambda$executeRecursively$9(NodeTestTask.java:139)
	at org.junit.platform.engine.support.hierarchical.ThrowableCollector.execute(ThrowableCollector.java:73)
	at org.junit.platform.engine.support.hierarchical.NodeTestTask.executeRecursively(NodeTestTask.java:138)
	at org.junit.platform.engine.support.hierarchical.NodeTestTask.execute(NodeTestTask.java:95)
	at org.junit.platform.engine.support.hierarchical.SameThreadHierarchicalTestExecutorService.submit(SameThreadHierarchicalTestExecutorService.java:35)
	at org.junit.platform.engine.support.hierarchical.HierarchicalTestExecutor.execute(HierarchicalTestExecutor.java:57)
	at org.junit.platform.engine.support.hierarchical.HierarchicalTestEngine.execute(HierarchicalTestEngine.java:54)
	at org.junit.platform.launcher.core.EngineExecutionOrchestrator.execute(EngineExecutionOrchestrator.java:147)
	at org.junit.platform.launcher.core.EngineExecutionOrchestrator.execute(EngineExecutionOrchestrator.java:127)
	at org.junit.platform.launcher.core.EngineExecutionOrchestrator.execute(EngineExecutionOrchestrator.java:90)
	at org.junit.platform.launcher.core.EngineExecutionOrchestrator.lambda$execute$0(EngineExecutionOrchestrator.java:55)
	at org.junit.platform.launcher.core.EngineExecutionOrchestrator.withInterceptedStreams(EngineExecutionOrchestrator.java:102)
	at org.junit.platform.launcher.core.EngineExecutionOrchestrator.execute(EngineExecutionOrchestrator.java:54)
	at org.junit.platform.launcher.core.DefaultLauncher.execute(DefaultLauncher.java:114)
	at org.junit.platform.launcher.core.DefaultLauncher.execute(DefaultLauncher.java:86)
	at org.junit.platform.launcher.core.DefaultLauncherSession$DelegatingLauncher.execute(DefaultLauncherSession.java:86)
	at org.apache.maven.surefire.junitplatform.LazyLauncher.execute(LazyLauncher.java:56)
	at org.apache.maven.surefire.junitplatform.JUnitPlatformProvider.execute(JUnitPlatformProvider.java:184)
	at org.apache.maven.surefire.junitplatform.JUnitPlatformProvider.invokeAllTests(JUnitPlatformProvider.java:148)
	at org.apache.maven.surefire.junitplatform.JUnitPlatformProvider.invoke(JUnitPlatformProvider.java:122)
	at org.apache.maven.surefire.booter.ForkedBooter.runSuitesInProcess(ForkedBooter.java:385)
	at org.apache.maven.surefire.booter.ForkedBooter.execute(ForkedBooter.java:162)
	at org.apache.maven.surefire.booter.ForkedBooter.run(ForkedBooter.java:507)
	at org.apache.maven.surefire.booter.ForkedBooter.main(ForkedBooter.java:495)

```

becomes as shown at https://github.com/checkstyle/checkstyle/pull/14039