### PR TITLE
Issue #13693: migrate to module macros few naming modules

### DIFF
--- a/config/checkstyle-non-main-files-suppressions.xml
+++ b/config/checkstyle-non-main-files-suppressions.xml
@@ -352,10 +352,6 @@
   <suppress id="propertiesMacroMustExist"
          files="src[\\/]xdocs[\\/]checks[\\/]naming[\\/]recordtypeparametername.xml.template"/>
   <suppress id="propertiesMacroMustExist"
-         files="src[\\/]xdocs[\\/]checks[\\/]naming[\\/]staticvariablename.xml.template"/>
-  <suppress id="propertiesMacroMustExist"
-         files="src[\\/]xdocs[\\/]checks[\\/]naming[\\/]typename.xml.template"/>
-  <suppress id="propertiesMacroMustExist"
          files="src[\\/]xdocs[\\/]checks[\\/]regexp[\\/]regexp.xml.template"/>
   <suppress id="propertiesMacroMustExist"
          files="src[\\/]xdocs[\\/]checks[\\/]regexp[\\/]regexpmultiline.xml.template"/>

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/naming/StaticVariableNameCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/naming/StaticVariableNameCheck.java
@@ -29,27 +29,29 @@ import com.puppycrawl.tools.checkstyle.utils.ScopeUtil;
  * </p>
  * <ul>
  * <li>
- * Property {@code applyToPackage} - Controls whether to apply the check to package-private member.
+ * Property {@code applyToPackage} - Control whether we should apply the check to package-private
+ *   members.
  * Type is {@code boolean}.
  * Default value is {@code true}.
  * </li>
  * <li>
- * Property {@code applyToPrivate} - Controls whether to apply the check to private member.
+ * Property {@code applyToPrivate} - Control whether we should apply the check to private members.
  * Type is {@code boolean}.
  * Default value is {@code true}.
  * </li>
  * <li>
- * Property {@code applyToProtected} - Controls whether to apply the check to protected member.
+ * Property {@code applyToProtected} - Control whether we should apply the check to protected
+ *   members.
  * Type is {@code boolean}.
  * Default value is {@code true}.
  * </li>
  * <li>
- * Property {@code applyToPublic} - Controls whether to apply the check to public member.
+ * Property {@code applyToPublic} - Control whether we should apply the check to public members.
  * Type is {@code boolean}.
  * Default value is {@code true}.
  * </li>
  * <li>
- * Property {@code format} - Specifies valid identifiers.
+ * Property {@code format} - Set the format for the specified regular expression.
  * Type is {@code java.util.regex.Pattern}.
  * Default value is {@code "^[a-z][a-zA-Z0-9]*$"}.
  * </li>

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/naming/TypeNameCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/naming/TypeNameCheck.java
@@ -28,27 +28,29 @@ import com.puppycrawl.tools.checkstyle.utils.CommonUtil;
  * </p>
  * <ul>
  * <li>
- * Property {@code applyToPackage} - Controls whether to apply the check to package-private member.
+ * Property {@code applyToPackage} - Control whether we should apply the check to package-private
+ *   members.
  * Type is {@code boolean}.
  * Default value is {@code true}.
  * </li>
  * <li>
- * Property {@code applyToPrivate} - Controls whether to apply the check to private member.
+ * Property {@code applyToPrivate} - Control whether we should apply the check to private members.
  * Type is {@code boolean}.
  * Default value is {@code true}.
  * </li>
  * <li>
- * Property {@code applyToProtected} - Controls whether to apply the check to protected member.
+ * Property {@code applyToProtected} - Control whether we should apply the check to protected
+ *   members.
  * Type is {@code boolean}.
  * Default value is {@code true}.
  * </li>
  * <li>
- * Property {@code applyToPublic} - Controls whether to apply the check to public member.
+ * Property {@code applyToPublic} - Control whether we should apply the check to public members.
  * Type is {@code boolean}.
  * Default value is {@code true}.
  * </li>
  * <li>
- * Property {@code format} - Specifies valid identifiers.
+ * Property {@code format} - Set the format for the specified regular expression.
  * Type is {@code java.util.regex.Pattern}.
  * Default value is {@code "^[A-Z][a-zA-Z0-9]*$"}.
  * </li>

--- a/src/main/java/com/puppycrawl/tools/checkstyle/site/SiteUtil.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/site/SiteUtil.java
@@ -51,6 +51,8 @@ import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 import java.util.stream.Stream;
 
+import javax.annotation.Nullable;
+
 import org.apache.commons.beanutils.PropertyUtils;
 import org.apache.maven.doxia.macro.MacroExecutionException;
 
@@ -217,7 +219,17 @@ public final class SiteUtil {
         Map.entry("JavadocMissingLeadingAsteriskCheck.violateExecutionOnNonTightHtml", "8.38"),
         Map.entry("ParenPadCheck.option", VERSION_3_0),
         Map.entry("TypecastParenPadCheck.option", VERSION_3_2),
-        Map.entry("FileLengthCheck.fileExtensions", VERSION_5_0)
+        Map.entry("FileLengthCheck.fileExtensions", VERSION_5_0),
+        Map.entry("StaticVariableNameCheck.applyToPackage", VERSION_5_0),
+        Map.entry("StaticVariableNameCheck.applyToPrivate", VERSION_5_0),
+        Map.entry("StaticVariableNameCheck.applyToProtected", VERSION_5_0),
+        Map.entry("StaticVariableNameCheck.applyToPublic", VERSION_5_0),
+        Map.entry("StaticVariableNameCheck.format", VERSION_3_0),
+        Map.entry("TypeNameCheck.applyToPackage", VERSION_5_0),
+        Map.entry("TypeNameCheck.applyToPrivate", VERSION_5_0),
+        Map.entry("TypeNameCheck.applyToProtected", VERSION_5_0),
+        Map.entry("TypeNameCheck.applyToPublic", VERSION_5_0),
+        Map.entry("TypeNameCheck.format", VERSION_3_0)
     );
 
     /** Map of all superclasses properties and their javadocs. */
@@ -763,7 +775,8 @@ public final class SiteUtil {
 
         if (sinceVersion == null) {
             final String message = String.format(Locale.ROOT,
-                    "Failed to find since version for %s", propertyName);
+                    "Failed to find '@since' version for '%s' property"
+                            + " in '%s' and all parent classes.", propertyName, moduleName);
             throw new MacroExecutionException(message);
         }
 
@@ -776,12 +789,14 @@ public final class SiteUtil {
      * @param javadoc the Javadoc to extract the since version from.
      * @return the since version of the setter.
      */
+    @Nullable
     private static String getSinceVersionFromJavadoc(DetailNode javadoc) {
         final DetailNode sinceJavadocTag = getSinceJavadocTag(javadoc);
-        final DetailNode description = JavadocUtil.findFirstToken(sinceJavadocTag,
-                JavadocTokenTypes.DESCRIPTION);
-        final DetailNode text = JavadocUtil.findFirstToken(description, JavadocTokenTypes.TEXT);
-        return text.getText();
+        return Optional.ofNullable(sinceJavadocTag)
+            .map(tag -> JavadocUtil.findFirstToken(tag, JavadocTokenTypes.DESCRIPTION))
+            .map(description -> JavadocUtil.findFirstToken(description, JavadocTokenTypes.TEXT))
+            .map(DetailNode::getText)
+            .orElse(null);
     }
 
     /**

--- a/src/main/resources/com/puppycrawl/tools/checkstyle/meta/checks/naming/StaticVariableNameCheck.xml
+++ b/src/main/resources/com/puppycrawl/tools/checkstyle/meta/checks/naming/StaticVariableNameCheck.xml
@@ -9,21 +9,23 @@
  &lt;/p&gt;</description>
          <properties>
             <property default-value="true" name="applyToPackage" type="boolean">
-               <description>Controls whether to apply the check to package-private member.</description>
+               <description>Control whether we should apply the check to package-private
+   members.</description>
             </property>
             <property default-value="true" name="applyToPrivate" type="boolean">
-               <description>Controls whether to apply the check to private member.</description>
+               <description>Control whether we should apply the check to private members.</description>
             </property>
             <property default-value="true" name="applyToProtected" type="boolean">
-               <description>Controls whether to apply the check to protected member.</description>
+               <description>Control whether we should apply the check to protected
+   members.</description>
             </property>
             <property default-value="true" name="applyToPublic" type="boolean">
-               <description>Controls whether to apply the check to public member.</description>
+               <description>Control whether we should apply the check to public members.</description>
             </property>
             <property default-value="^[a-z][a-zA-Z0-9]*$"
                       name="format"
                       type="java.util.regex.Pattern">
-               <description>Specifies valid identifiers.</description>
+               <description>Set the format for the specified regular expression.</description>
             </property>
          </properties>
          <message-keys>

--- a/src/main/resources/com/puppycrawl/tools/checkstyle/meta/checks/naming/TypeNameCheck.xml
+++ b/src/main/resources/com/puppycrawl/tools/checkstyle/meta/checks/naming/TypeNameCheck.xml
@@ -9,21 +9,23 @@
  &lt;/p&gt;</description>
          <properties>
             <property default-value="true" name="applyToPackage" type="boolean">
-               <description>Controls whether to apply the check to package-private member.</description>
+               <description>Control whether we should apply the check to package-private
+   members.</description>
             </property>
             <property default-value="true" name="applyToPrivate" type="boolean">
-               <description>Controls whether to apply the check to private member.</description>
+               <description>Control whether we should apply the check to private members.</description>
             </property>
             <property default-value="true" name="applyToProtected" type="boolean">
-               <description>Controls whether to apply the check to protected member.</description>
+               <description>Control whether we should apply the check to protected
+   members.</description>
             </property>
             <property default-value="true" name="applyToPublic" type="boolean">
-               <description>Controls whether to apply the check to public member.</description>
+               <description>Control whether we should apply the check to public members.</description>
             </property>
             <property default-value="^[A-Z][a-zA-Z0-9]*$"
                       name="format"
                       type="java.util.regex.Pattern">
-               <description>Specifies valid identifiers.</description>
+               <description>Set the format for the specified regular expression.</description>
             </property>
             <property default-value="CLASS_DEF,INTERFACE_DEF,ENUM_DEF,ANNOTATION_DEF,RECORD_DEF"
                       name="tokens"

--- a/src/xdocs/checks/naming/staticvariablename.xml
+++ b/src/xdocs/checks/naming/staticvariablename.xml
@@ -27,37 +27,35 @@
             </tr>
             <tr>
               <td>applyToPackage</td>
-              <td>
-                Controls whether to apply the check to package-private member.
-              </td>
+              <td>Control whether we should apply the check to package-private members.</td>
               <td><a href="../../property_types.html#boolean">boolean</a></td>
               <td><code>true</code></td>
               <td>5.0</td>
             </tr>
             <tr>
               <td>applyToPrivate</td>
-              <td>Controls whether to apply the check to private member.</td>
+              <td>Control whether we should apply the check to private members.</td>
               <td><a href="../../property_types.html#boolean">boolean</a></td>
               <td><code>true</code></td>
               <td>5.0</td>
             </tr>
             <tr>
               <td>applyToProtected</td>
-              <td>Controls whether to apply the check to protected member.</td>
+              <td>Control whether we should apply the check to protected members.</td>
               <td><a href="../../property_types.html#boolean">boolean</a></td>
               <td><code>true</code></td>
               <td>5.0</td>
             </tr>
             <tr>
               <td>applyToPublic</td>
-              <td>Controls whether to apply the check to public member.</td>
+              <td>Control whether we should apply the check to public members.</td>
               <td><a href="../../property_types.html#boolean">boolean</a></td>
               <td><code>true</code></td>
               <td>5.0</td>
             </tr>
             <tr>
               <td>format</td>
-              <td>Specifies valid identifiers.</td>
+              <td>Set the format for the specified regular expression.</td>
               <td><a href="../../property_types.html#Pattern">Pattern</a></td>
               <td><code>&quot;^[a-z][a-zA-Z0-9]*$&quot;</code></td>
               <td>3.0</td>

--- a/src/xdocs/checks/naming/staticvariablename.xml.template
+++ b/src/xdocs/checks/naming/staticvariablename.xml.template
@@ -17,52 +17,10 @@
 
       <subsection name="Properties" id="Properties">
         <div class="wrapper">
-          <table>
-            <tr>
-              <th>name</th>
-              <th>description</th>
-              <th>type</th>
-              <th>default value</th>
-              <th>since</th>
-            </tr>
-            <tr>
-              <td>applyToPackage</td>
-              <td>
-                Controls whether to apply the check to package-private member.
-              </td>
-              <td><a href="../../property_types.html#boolean">boolean</a></td>
-              <td><code>true</code></td>
-              <td>5.0</td>
-            </tr>
-            <tr>
-              <td>applyToPrivate</td>
-              <td>Controls whether to apply the check to private member.</td>
-              <td><a href="../../property_types.html#boolean">boolean</a></td>
-              <td><code>true</code></td>
-              <td>5.0</td>
-            </tr>
-            <tr>
-              <td>applyToProtected</td>
-              <td>Controls whether to apply the check to protected member.</td>
-              <td><a href="../../property_types.html#boolean">boolean</a></td>
-              <td><code>true</code></td>
-              <td>5.0</td>
-            </tr>
-            <tr>
-              <td>applyToPublic</td>
-              <td>Controls whether to apply the check to public member.</td>
-              <td><a href="../../property_types.html#boolean">boolean</a></td>
-              <td><code>true</code></td>
-              <td>5.0</td>
-            </tr>
-            <tr>
-              <td>format</td>
-              <td>Specifies valid identifiers.</td>
-              <td><a href="../../property_types.html#Pattern">Pattern</a></td>
-              <td><code>&quot;^[a-z][a-zA-Z0-9]*$&quot;</code></td>
-              <td>3.0</td>
-            </tr>
-          </table>
+          <macro name="properties">
+            <param name="modulePath"
+                   value="src/main/java/com/puppycrawl/tools/checkstyle/checks/naming/StaticVariableNameCheck.java"/>
+          </macro>
         </div>
       </subsection>
 

--- a/src/xdocs/checks/naming/typename.xml
+++ b/src/xdocs/checks/naming/typename.xml
@@ -26,37 +26,35 @@
             </tr>
             <tr>
               <td>applyToPackage</td>
-              <td>
-                Controls whether to apply the check to package-private member.
-              </td>
+              <td>Control whether we should apply the check to package-private members.</td>
               <td><a href="../../property_types.html#boolean">boolean</a></td>
               <td><code>true</code></td>
               <td>5.0</td>
             </tr>
             <tr>
               <td>applyToPrivate</td>
-              <td>Controls whether to apply the check to private member.</td>
+              <td>Control whether we should apply the check to private members.</td>
               <td><a href="../../property_types.html#boolean">boolean</a></td>
               <td><code>true</code></td>
               <td>5.0</td>
             </tr>
             <tr>
               <td>applyToProtected</td>
-              <td>Controls whether to apply the check to protected member.</td>
+              <td>Control whether we should apply the check to protected members.</td>
               <td><a href="../../property_types.html#boolean">boolean</a></td>
               <td><code>true</code></td>
               <td>5.0</td>
             </tr>
             <tr>
               <td>applyToPublic</td>
-              <td>Controls whether to apply the check to public member.</td>
+              <td>Control whether we should apply the check to public members.</td>
               <td><a href="../../property_types.html#boolean">boolean</a></td>
               <td><code>true</code></td>
               <td>5.0</td>
             </tr>
             <tr>
               <td>format</td>
-              <td>Specifies valid identifiers.</td>
+              <td>Set the format for the specified regular expression.</td>
               <td><a href="../../property_types.html#Pattern">Pattern</a></td>
               <td><code>&quot;^[A-Z][a-zA-Z0-9]*$&quot;</code></td>
               <td>3.0</td>
@@ -64,31 +62,30 @@
             <tr>
               <td>tokens</td>
               <td>tokens to check</td>
-              <td>
-                subset of tokens
+              <td>subset of tokens
                 <a href="../../apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#CLASS_DEF">
-                  CLASS_DEF</a>
+                    CLASS_DEF</a>
                 , <a href="../../apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#INTERFACE_DEF">
-                  INTERFACE_DEF</a>
+                    INTERFACE_DEF</a>
                 , <a href="../../apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#ENUM_DEF">
-                  ENUM_DEF</a>
+                    ENUM_DEF</a>
                 , <a href="../../apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#ANNOTATION_DEF">
-                  ANNOTATION_DEF</a>
-                ,<a href="../../apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#RECORD_DEF">
-                  RECORD_DEF</a>
+                    ANNOTATION_DEF</a>
+                , <a href="../../apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#RECORD_DEF">
+                    RECORD_DEF</a>
                   .
               </td>
               <td>
                 <a href="../../apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#CLASS_DEF">
-                  CLASS_DEF</a>
+                    CLASS_DEF</a>
                 , <a href="../../apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#INTERFACE_DEF">
-                  INTERFACE_DEF</a>
+                    INTERFACE_DEF</a>
                 , <a href="../../apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#ENUM_DEF">
-                  ENUM_DEF</a>
+                    ENUM_DEF</a>
                 , <a href="../../apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#ANNOTATION_DEF">
-                  ANNOTATION_DEF</a>
-                ,<a href="../../apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#RECORD_DEF">
-                  RECORD_DEF</a>
+                    ANNOTATION_DEF</a>
+                , <a href="../../apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#RECORD_DEF">
+                    RECORD_DEF</a>
                   .
               </td>
               <td>3.0</td>

--- a/src/xdocs/checks/naming/typename.xml.template
+++ b/src/xdocs/checks/naming/typename.xml.template
@@ -16,84 +16,10 @@
 
       <subsection name="Properties" id="Properties">
         <div class="wrapper">
-          <table>
-            <tr>
-              <th>name</th>
-              <th>description</th>
-              <th>type</th>
-              <th>default value</th>
-              <th>since</th>
-            </tr>
-            <tr>
-              <td>applyToPackage</td>
-              <td>
-                Controls whether to apply the check to package-private member.
-              </td>
-              <td><a href="../../property_types.html#boolean">boolean</a></td>
-              <td><code>true</code></td>
-              <td>5.0</td>
-            </tr>
-            <tr>
-              <td>applyToPrivate</td>
-              <td>Controls whether to apply the check to private member.</td>
-              <td><a href="../../property_types.html#boolean">boolean</a></td>
-              <td><code>true</code></td>
-              <td>5.0</td>
-            </tr>
-            <tr>
-              <td>applyToProtected</td>
-              <td>Controls whether to apply the check to protected member.</td>
-              <td><a href="../../property_types.html#boolean">boolean</a></td>
-              <td><code>true</code></td>
-              <td>5.0</td>
-            </tr>
-            <tr>
-              <td>applyToPublic</td>
-              <td>Controls whether to apply the check to public member.</td>
-              <td><a href="../../property_types.html#boolean">boolean</a></td>
-              <td><code>true</code></td>
-              <td>5.0</td>
-            </tr>
-            <tr>
-              <td>format</td>
-              <td>Specifies valid identifiers.</td>
-              <td><a href="../../property_types.html#Pattern">Pattern</a></td>
-              <td><code>"^[A-Z][a-zA-Z0-9]*$"</code></td>
-              <td>3.0</td>
-            </tr>
-            <tr>
-              <td>tokens</td>
-              <td>tokens to check</td>
-              <td>
-                subset of tokens
-                <a href="../../apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#CLASS_DEF">
-                  CLASS_DEF</a>
-                , <a href="../../apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#INTERFACE_DEF">
-                  INTERFACE_DEF</a>
-                , <a href="../../apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#ENUM_DEF">
-                  ENUM_DEF</a>
-                , <a href="../../apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#ANNOTATION_DEF">
-                  ANNOTATION_DEF</a>
-                ,<a href="../../apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#RECORD_DEF">
-                  RECORD_DEF</a>
-                  .
-              </td>
-              <td>
-                <a href="../../apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#CLASS_DEF">
-                  CLASS_DEF</a>
-                , <a href="../../apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#INTERFACE_DEF">
-                  INTERFACE_DEF</a>
-                , <a href="../../apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#ENUM_DEF">
-                  ENUM_DEF</a>
-                , <a href="../../apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#ANNOTATION_DEF">
-                  ANNOTATION_DEF</a>
-                ,<a href="../../apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#RECORD_DEF">
-                  RECORD_DEF</a>
-                  .
-              </td>
-              <td>3.0</td>
-            </tr>
-          </table>
+          <macro name="properties">
+            <param name="modulePath"
+                   value="src/main/java/com/puppycrawl/tools/checkstyle/checks/naming/TypeNameCheck.java"/>
+          </macro>
         </div>
       </subsection>
 


### PR DESCRIPTION
Issue #13693

exception will looks like:
```
Caused by: org.apache.maven.doxia.macro.MacroExecutionException: 
  Failed to find '@since' version for 'format' property in 'TypeNameCheck' and all parent classes of it
  at com.puppycrawl.tools.checkstyle.site.SiteUtil.getSinceVersion(SiteUtil.java:724)
  at com.puppycrawl.tools.checkstyle.site.PropertiesMacro.writePropertySinceVersionCell
      (PropertiesMacro.java:546)
  at com.puppycrawl.tools.checkstyle.site.PropertiesMacro.writePropertyRow(PropertiesMacro.java:268)
  at com.puppycrawl.tools.checkstyle.site.PropertiesMacro.writeTablePropertiesRows(PropertiesMacro.java:214)
  ... 73 more
  
```

Verifier.java from checkstyle 2.4:
[Verifier.java.txt](https://github.com/checkstyle/checkstyle/files/13464497/Verifier.java.txt)
[checkstyle-src-2.4.zip](https://github.com/checkstyle/checkstyle/files/13464499/checkstyle-src-2.4.zip)

