### PR TITLE
Issue #13693: migrate header modules to use property macro

### DIFF
--- a/config/checkstyle-non-main-files-suppressions.xml
+++ b/config/checkstyle-non-main-files-suppressions.xml
@@ -252,10 +252,6 @@
          files="src[\\/]xdocs[\\/]checks[\\/]coding[\\/]unusedlocalvariable.xml.template"/>
   <!-- Properties macro suppressions until https://github.com/checkstyle/checkstyle/issues/13693 -->
   <suppress id="propertiesMacroMustExist"
-         files="src[\\/]xdocs[\\/]checks[\\/]header[\\/]header.xml.template"/>
-  <suppress id="propertiesMacroMustExist"
-         files="src[\\/]xdocs[\\/]checks[\\/]header[\\/]regexpheader.xml.template"/>
-  <suppress id="propertiesMacroMustExist"
          files="src[\\/]xdocs[\\/]checks[\\/]imports[\\/]customimportorder.xml.template"/>
   <suppress id="propertiesMacroMustExist"
          files="src[\\/]xdocs[\\/]checks[\\/]javadoc[\\/]atclauseorder.xml.template"/>

--- a/config/suppressions.xml
+++ b/config/suppressions.xml
@@ -60,6 +60,8 @@
   <suppress checks="MethodCount" files="[\\/]RequireThisCheck.java$"/>
   <!-- Apart from complex logic, there is a nested class which contains many methods.  -->
   <suppress checks="MethodCount" files="[\\/]UnusedLocalVariableCheck.java"/>
+  <!-- Utility class is combination of a lot of different methods .  -->
+  <suppress checks="MethodCount" files="[\\/]SiteUtil.java"/>
   <!-- parse method needs catching Exceptions to print context of execution -->
   <suppress checks="IllegalCatch" files="[\\/]src[\\/]test[\\/].*[\\/]InlineConfigParser\.java"/>
   <!-- exception maybe thrown while executing the static block -->

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/header/AbstractHeaderCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/header/AbstractHeaderCheck.java
@@ -77,7 +77,7 @@ public abstract class AbstractHeaderCheck extends AbstractFileSetCheck
     }
 
     /**
-     * Setter to specify the charset to use when reading the headerFile.
+     * Setter to specify the character encoding to use when reading the headerFile.
      *
      * @param charset the charset name to use for loading the header from a file
      */
@@ -86,7 +86,7 @@ public abstract class AbstractHeaderCheck extends AbstractFileSetCheck
     }
 
     /**
-     * Setter to specify the name of the file containing the required header..
+     * Setter to specify the name of the file containing the required header.
      *
      * @param uri the uri of the header to load.
      * @throws CheckstyleException if fileName is empty.
@@ -147,8 +147,9 @@ public abstract class AbstractHeaderCheck extends AbstractFileSetCheck
     }
 
     /**
-     * Set the header to check against. Individual lines in the header
-     * must be separated by '\n' characters.
+     * Specify the required header specified inline.
+     * Individual header lines must be separated by the string
+     * {@code "\n"}(even on platforms with a different line separator).
      *
      * @param header header content to check against.
      * @throws IllegalArgumentException if the header cannot be interpreted

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/header/HeaderCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/header/HeaderCheck.java
@@ -68,7 +68,7 @@ import com.puppycrawl.tools.checkstyle.utils.TokenUtil;
  * <li>
  * Property {@code header} - Specify the required header specified inline.
  * Individual header lines must be separated by the string {@code "\n"}
- * (even on platforms with a different line separator), see examples below.
+ * (even on platforms with a different line separator).
  * Type is {@code java.lang.String}.
  * Default value is {@code null}.
  * </li>

--- a/src/main/java/com/puppycrawl/tools/checkstyle/site/PropertiesMacro.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/site/PropertiesMacro.java
@@ -504,15 +504,7 @@ public class PropertiesMacro extends AbstractMacro {
             writeTokensList(sink, configurableTokens, SiteUtil.PATH_TO_JAVADOC_TOKEN_TYPES, true);
         }
         else {
-            final String defaultValue;
-
-            if (field != null) {
-                defaultValue = SiteUtil.getDefaultValue(
-                        propertyName, field, instance, currentModuleName);
-            }
-            else {
-                defaultValue = CURLY_BRACKET;
-            }
+            final String defaultValue = getDefaultValue(propertyName, field, instance);
             final String checkName = CHECK_PATTERN
                     .matcher(instance.getClass().getSimpleName()).replaceAll("");
 
@@ -532,6 +524,36 @@ public class PropertiesMacro extends AbstractMacro {
         }
 
         sink.tableCell_();
+    }
+
+    /**
+     * Get the default value of the property.
+     *
+     * @param propertyName the name of the property.
+     * @param field the field of the property.
+     * @param instance the instance of the module.
+     * @return the default value of the property.
+     * @throws MacroExecutionException if an error occurs during retrieval of the default value.
+     */
+    private static String getDefaultValue(String propertyName, Field field, Object instance)
+            throws MacroExecutionException {
+        final String result;
+
+        if (field != null) {
+            result = SiteUtil.getDefaultValue(
+                    propertyName, field, instance, currentModuleName);
+        }
+        else {
+            final Class<?> fieldClass = SiteUtil.getPropertyClass(propertyName, instance);
+
+            if (fieldClass.isArray()) {
+                result = CURLY_BRACKET;
+            }
+            else {
+                result = "null";
+            }
+        }
+        return result;
     }
 
     /**

--- a/src/main/java/com/puppycrawl/tools/checkstyle/site/SiteUtil.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/site/SiteUtil.java
@@ -140,6 +140,16 @@ public final class SiteUtil {
     private static final Set<String> FILESET_PROPERTIES =
             getProperties(AbstractFileSetCheck.class);
 
+    /**
+     * Check and property name.
+     */
+    private static final String HEADER_CHECK_HEADER = "HeaderCheck.header";
+
+    /**
+     * Check and property name.
+     */
+    private static final String REGEXP_HEADER_CHECK_HEADER = "RegexpHeaderCheck.header";
+
     /** Set of properties that are undocumented. Those are internal properties. */
     private static final Set<String> UNDOCUMENTED_PROPERTIES = Set.of(
         "SuppressWithNearbyCommentFilter.fileContents",
@@ -151,11 +161,26 @@ public final class SiteUtil {
         // static field (all upper case)
         "SuppressWarningsHolder.aliasList",
         // loads string into memory similar to file
-        "HeaderCheck.header",
-        "RegexpHeaderCheck.header",
+        HEADER_CHECK_HEADER,
+        REGEXP_HEADER_CHECK_HEADER,
         // until https://github.com/checkstyle/checkstyle/issues/13376
         "CustomImportOrderCheck.customImportOrderRules"
     );
+
+    /**
+     * Frequent version.
+     */
+    private static final String VERSION_6_9 = "6.9";
+
+    /**
+     * Frequent version.
+     */
+    private static final String VERSION_5_0 = "5.0";
+
+    /**
+     * Frequent version.
+     */
+    private static final String VERSION_3_2 = "3.2";
 
     /**
      * Frequent version.
@@ -169,11 +194,19 @@ public final class SiteUtil {
     private static final Map<String, String> SINCE_VERSION_FOR_INHERITED_PROPERTY = Map.ofEntries(
         Map.entry("MissingDeprecatedCheck.violateExecutionOnNonTightHtml", V824),
         Map.entry("NonEmptyAtclauseDescriptionCheck.violateExecutionOnNonTightHtml", "8.3"),
+        Map.entry("HeaderCheck.charset", VERSION_5_0),
+        Map.entry("HeaderCheck.fileExtensions", VERSION_6_9),
+        Map.entry("HeaderCheck.headerFile", VERSION_3_2),
+        Map.entry(HEADER_CHECK_HEADER, VERSION_5_0),
+        Map.entry("RegexpHeaderCheck.charset", VERSION_5_0),
+        Map.entry("RegexpHeaderCheck.fileExtensions", VERSION_6_9),
+        Map.entry("RegexpHeaderCheck.headerFile", VERSION_3_2),
+        Map.entry(REGEXP_HEADER_CHECK_HEADER, VERSION_5_0),
         Map.entry("NonEmptyAtclauseDescriptionCheck.javadocTokens", "7.3"),
-        Map.entry("FileTabCharacterCheck.fileExtensions", "5.0"),
+        Map.entry("FileTabCharacterCheck.fileExtensions", VERSION_5_0),
         Map.entry("LineLengthCheck.fileExtensions", V824),
         Map.entry("ParenPadCheck.option", "3.0"),
-        Map.entry("TypecastParenPadCheck.option", "3.2")
+        Map.entry("TypecastParenPadCheck.option", VERSION_3_2)
     );
 
     /** Map of all superclasses properties and their javadocs. */
@@ -803,7 +836,8 @@ public final class SiteUtil {
         final Class<?> fieldClass = getFieldClass(field, propertyName, moduleName, classInstance);
         String result = null;
         if (CHARSET.equals(propertyName)) {
-            result = "the charset property of the parent Checker module";
+            result = "the charset property of the parent"
+                    + " <a href=\"https://checkstyle.org/config.html#Checker\">Checker</a> module";
         }
         else if (classInstance instanceof PropertyCacheFile) {
             result = "null (no cache file)";
@@ -1021,14 +1055,7 @@ public final class SiteUtil {
                         "Could not find field " + propertyName + " in class " + moduleName);
             }
 
-            try {
-                final PropertyDescriptor descriptor = PropertyUtils.getPropertyDescriptor(instance,
-                    propertyName);
-                result = descriptor.getPropertyType();
-            }
-            catch (IllegalAccessException | InvocationTargetException | NoSuchMethodException exc) {
-                throw new MacroExecutionException(exc.getMessage(), exc);
-            }
+            result = getPropertyClass(propertyName, instance);
         }
         if (field != null && (result == List.class || result == Set.class)) {
             final ParameterizedType type = (ParameterizedType) field.getGenericType();
@@ -1053,6 +1080,29 @@ public final class SiteUtil {
             result = int[].class;
         }
 
+        return result;
+    }
+
+    /**
+     * Gets the class of the given java property.
+     *
+     * @param propertyName the name of the property.
+     * @param instance the instance of the module.
+     * @return the class of the java property.
+     * @throws MacroExecutionException if an error occurs during getting the class.
+     */
+    // -@cs[ForbidWildcardAsReturnType] Object is received as param, no prediction on type of field
+    public static Class<?> getPropertyClass(String propertyName, Object instance)
+            throws MacroExecutionException {
+        final Class<?> result;
+        try {
+            final PropertyDescriptor descriptor = PropertyUtils.getPropertyDescriptor(instance,
+                    propertyName);
+            result = descriptor.getPropertyType();
+        }
+        catch (IllegalAccessException | InvocationTargetException | NoSuchMethodException exc) {
+            throw new MacroExecutionException(exc.getMessage(), exc);
+        }
         return result;
     }
 

--- a/src/main/resources/com/puppycrawl/tools/checkstyle/meta/checks/header/HeaderCheck.xml
+++ b/src/main/resources/com/puppycrawl/tools/checkstyle/meta/checks/header/HeaderCheck.xml
@@ -40,7 +40,7 @@
             <property name="header" type="java.lang.String">
                <description>Specify the required header specified inline.
  Individual header lines must be separated by the string {@code "\n"}
- (even on platforms with a different line separator), see examples below.</description>
+ (even on platforms with a different line separator).</description>
             </property>
             <property name="headerFile" type="java.net.URI">
                <description>Specify the name of the file containing the required header.</description>

--- a/src/test/java/com/puppycrawl/tools/checkstyle/internal/XdocsPagesTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/internal/XdocsPagesTest.java
@@ -1164,7 +1164,8 @@ public class XdocsPagesTest {
                 result = "UTF-8";
             }
             else if ("charset".equals(propertyName)) {
-                result = "the charset property of the parent Checker module";
+                result = "the charset property of the parent"
+                    + " <a href=\"https://checkstyle.org/config.html#Checker\">Checker</a> module";
             }
             else if ("PropertyCacheFile".equals(fieldClass.getSimpleName())) {
                 result = "null (no cache file)";

--- a/src/xdocs/checks/header/header.xml
+++ b/src/xdocs/checks/header/header.xml
@@ -61,12 +61,7 @@ line 5: ////////////////////////////////////////////////////////////////////
               <td>charset</td>
               <td>Specify the character encoding to use when reading the headerFile.</td>
               <td><a href="../../property_types.html#String">String</a></td>
-              <td>
-                <code>
-                  the charset property of the parent<a href="../../config.html#Checker">
-                  Checker</a> module
-                </code>
-              </td>
+              <td><code>the charset property of the parent &lt;a href=&quot;https://checkstyle.org/config.html#Checker&quot;&gt;Checker&lt;/a&gt; module</code></td>
               <td>5.0</td>
             </tr>
             <tr>
@@ -78,11 +73,7 @@ line 5: ////////////////////////////////////////////////////////////////////
             </tr>
             <tr>
               <td>header</td>
-              <td>
-                Specify the required header specified inline. Individual header lines
-                must be separated by the string <code>&quot;\n&quot;</code> (even on platforms with
-                a different line separator), see examples below.
-              </td>
+              <td>Specify the required header specified inline. Individual header lines must be separated by the string <code>"\n"</code>(even on platforms with a different line separator).</td>
               <td><a href="../../property_types.html#String">String</a></td>
               <td><code>null</code></td>
               <td>5.0</td>

--- a/src/xdocs/checks/header/header.xml.template
+++ b/src/xdocs/checks/header/header.xml.template
@@ -49,59 +49,10 @@ line 5: ////////////////////////////////////////////////////////////////////
 
       <subsection name="Properties" id="Properties">
         <div class="wrapper">
-          <table>
-            <tr>
-              <th>name</th>
-              <th>description</th>
-              <th>type</th>
-              <th>default value</th>
-              <th>since</th>
-            </tr>
-            <tr>
-              <td>charset</td>
-              <td>Specify the character encoding to use when reading the headerFile.</td>
-              <td><a href="../../property_types.html#String">String</a></td>
-              <td>
-                <code>
-                  the charset property of the parent<a href="../../config.html#Checker">
-                  Checker</a> module
-                </code>
-              </td>
-              <td>5.0</td>
-            </tr>
-            <tr>
-              <td>fileExtensions</td>
-              <td>Specify the file type extension of files to process.</td>
-              <td><a href="../../property_types.html#String.5B.5D">String[]</a></td>
-              <td><code>all files</code></td>
-              <td>6.9</td>
-            </tr>
-            <tr>
-              <td>header</td>
-              <td>
-                Specify the required header specified inline. Individual header lines
-                must be separated by the string <code>"\n"</code> (even on platforms with
-                a different line separator), see examples below.
-              </td>
-              <td><a href="../../property_types.html#String">String</a></td>
-              <td><code>null</code></td>
-              <td>5.0</td>
-            </tr>
-            <tr>
-              <td>headerFile</td>
-              <td>Specify the name of the file containing the required header.</td>
-              <td><a href="../../property_types.html#URI">URI</a></td>
-              <td><code>null</code></td>
-              <td>3.2</td>
-            </tr>
-            <tr>
-              <td>ignoreLines</td>
-              <td>Specify the line numbers to ignore.</td>
-              <td><a href="../../property_types.html#int.5B.5D">int[]</a></td>
-              <td><code>{}</code></td>
-              <td>3.2</td>
-            </tr>
-          </table>
+          <macro name="properties">
+            <param name="modulePath"
+                   value="src/main/java/com/puppycrawl/tools/checkstyle/checks/header/HeaderCheck.java"/>
+          </macro>
         </div>
       </subsection>
 

--- a/src/xdocs/checks/header/regexpheader.xml
+++ b/src/xdocs/checks/header/regexpheader.xml
@@ -100,12 +100,7 @@ line 6: ^\W*$
               <td>charset</td>
               <td>Specify the character encoding to use when reading the headerFile.</td>
               <td><a href="../../property_types.html#String">String</a></td>
-              <td>
-                <code>
-                  the charset property of the parent<a href="../../config.html#Checker">
-                  Checker</a> module
-                </code>
-              </td>
+              <td><code>the charset property of the parent &lt;a href=&quot;https://checkstyle.org/config.html#Checker&quot;&gt;Checker&lt;/a&gt; module</code></td>
               <td>5.0</td>
             </tr>
             <tr>
@@ -117,13 +112,7 @@ line 6: ^\W*$
             </tr>
             <tr>
               <td>header</td>
-              <td>
-                Define the required header specified inline. Individual header lines
-                must be separated by the string <code>&quot;\n&quot;</code> (even on platforms with
-                a different line separator). For header lines containing
-                <code>&quot;\n\n&quot;</code> checkstyle will forcefully expect an empty line to
-                exist. See examples below. Regular expressions must not span multiple lines.
-              </td>
+              <td>Define the required header specified inline. Individual header lines must be separated by the string <code>"\n"</code> (even on platforms with a different line separator). For header lines containing <code>"\n\n"</code> checkstyle will forcefully expect an empty line to exist. See examples below. Regular expressions must not span multiple lines.</td>
               <td><a href="../../property_types.html#String">String</a></td>
               <td><code>null</code></td>
               <td>5.0</td>

--- a/src/xdocs/checks/header/regexpheader.xml.template
+++ b/src/xdocs/checks/header/regexpheader.xml.template
@@ -88,61 +88,10 @@ line 6: ^\W*$
 
       <subsection name="Properties" id="Properties">
         <div class="wrapper">
-          <table>
-            <tr>
-              <th>name</th>
-              <th>description</th>
-              <th>type</th>
-              <th>default value</th>
-              <th>since</th>
-            </tr>
-            <tr>
-              <td>charset</td>
-              <td>Specify the character encoding to use when reading the headerFile.</td>
-              <td><a href="../../property_types.html#String">String</a></td>
-              <td>
-                <code>
-                  the charset property of the parent<a href="../../config.html#Checker">
-                  Checker</a> module
-                </code>
-              </td>
-              <td>5.0</td>
-            </tr>
-            <tr>
-              <td>fileExtensions</td>
-              <td>Specify the file type extension of files to process.</td>
-              <td><a href="../../property_types.html#String.5B.5D">String[]</a></td>
-              <td><code>all files</code></td>
-              <td>6.9</td>
-            </tr>
-            <tr>
-              <td>header</td>
-              <td>
-                Define the required header specified inline. Individual header lines
-                must be separated by the string <code>"\n"</code> (even on platforms with
-                a different line separator). For header lines containing
-                <code>"\n\n"</code> checkstyle will forcefully expect an empty line to
-                exist. See examples below. Regular expressions must not span multiple lines.
-              </td>
-              <td><a href="../../property_types.html#String">String</a></td>
-              <td><code>null</code></td>
-              <td>5.0</td>
-            </tr>
-            <tr>
-              <td>headerFile</td>
-              <td>Specify the name of the file containing the required header.</td>
-              <td><a href="../../property_types.html#URI">URI</a></td>
-              <td><code>null</code></td>
-              <td>3.2</td>
-            </tr>
-            <tr>
-              <td>multiLines</td>
-              <td>Specify the line numbers to repeat (zero or more times).</td>
-              <td><a href="../../property_types.html#int.5B.5D">int[]</a></td>
-              <td><code>{}</code></td>
-              <td>3.4</td>
-            </tr>
-          </table>
+          <macro name="properties">
+            <param name="modulePath"
+                   value="src/main/java/com/puppycrawl/tools/checkstyle/checks/header/RegexpHeaderCheck.java"/>
+          </macro>
         </div>
       </subsection>
 


### PR DESCRIPTION
Issue #13693

all extra refactoring was enforced by our verify validation.

setCharset
https://github.com/checkstyle/checkstyle/commit/326e3ae67b8cc2a1dcbcf2356b30fd9a4afa964a#diff-fa56dd39f138d19b44a0aa110150c621c7ba641aead7a198d35db46fdbc767a2R71


setHeaderFile
https://github.com/checkstyle/checkstyle/commit/6f1f7bd3fdcca84404e97964b3e48de6db5024ec#diff-fa56dd39f138d19b44a0aa110150c621c7ba641aead7a198d35db46fdbc767a2R69

setHeader
https://github.com/checkstyle/checkstyle/commit/6f1f7bd3fdcca84404e97964b3e48de6db5024ec#diff-fa56dd39f138d19b44a0aa110150c621c7ba641aead7a198d35db46fdbc767a2R81