### PR TITLE
Issue #13693: migrate few metric modules to property macro

### DIFF
--- a/config/checkstyle-non-main-files-suppressions.xml
+++ b/config/checkstyle-non-main-files-suppressions.xml
@@ -278,10 +278,6 @@
   <suppress id="propertiesMacroMustExist"
          files="src[\\/]xdocs[\\/]checks[\\/]javadoc[\\/]writetag.xml.template"/>
   <suppress id="propertiesMacroMustExist"
-         files="src[\\/]xdocs[\\/]checks[\\/]metrics[\\/]classdataabstractioncoupling.xml.template"/>
-  <suppress id="propertiesMacroMustExist"
-         files="src[\\/]xdocs[\\/]checks[\\/]metrics[\\/]classfanoutcomplexity.xml.template"/>
-  <suppress id="propertiesMacroMustExist"
          files="src[\\/]xdocs[\\/]checks[\\/]metrics[\\/]javancss.xml.template"/>
   <suppress id="propertiesMacroMustExist"
          files="src[\\/]xdocs[\\/]checks[\\/]metrics[\\/]npathcomplexity.xml.template"/>

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/metrics/AbstractClassCouplingCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/metrics/AbstractClassCouplingCheck.java
@@ -101,8 +101,7 @@ public abstract class AbstractClassCouplingCheck extends AbstractCheck {
     private Set<String> excludedClasses = DEFAULT_EXCLUDED_CLASSES;
 
     /**
-     * Specify user-configured packages to ignore. All excluded packages
-     * should end with a period, so it also appends a dot to a package name.
+     * Specify user-configured packages to ignore.
      */
     private Set<String> excludedPackages = DEFAULT_EXCLUDED_PACKAGES;
 
@@ -164,8 +163,7 @@ public abstract class AbstractClassCouplingCheck extends AbstractCheck {
     }
 
     /**
-     * Setter to specify user-configured packages to ignore. All excluded packages
-     * should end with a period, so it also appends a dot to a package name.
+     * Setter to specify user-configured packages to ignore.
      *
      * @param excludedPackages packages to ignore.
      * @throws IllegalArgumentException if there are invalid identifiers among the packages.

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/metrics/ClassFanOutComplexityCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/metrics/ClassFanOutComplexityCheck.java
@@ -67,7 +67,6 @@ import com.puppycrawl.tools.checkstyle.api.TokenTypes;
  * </li>
  * <li>
  * Property {@code excludedPackages} - Specify user-configured packages to ignore.
- * All excluded packages should end with a period, so it also appends a dot to a package name.
  * Type is {@code java.lang.String[]}.
  * Default value is {@code ""}.
  * </li>

--- a/src/main/java/com/puppycrawl/tools/checkstyle/site/SiteUtil.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/site/SiteUtil.java
@@ -193,6 +193,21 @@ public final class SiteUtil {
     private static final String VERSION_3_0 = "3.0";
 
     /**
+     * Frequent version.
+     */
+    private static final String VERSION_7_7 = "7.7";
+
+    /**
+     * Frequent version.
+     */
+    private static final String VERSION_5_7 = "5.7";
+
+    /**
+     * Frequent version.
+     */
+    private static final String VERSION_3_4 = "3.4";
+
+    /**
      * Map of properties whose since version is different from module version but
      * are not specified in code because they are inherited from their super class(es).
      * Until <a href="https://github.com/checkstyle/checkstyle/issues/14052">#14052</a>.
@@ -208,6 +223,14 @@ public final class SiteUtil {
         Map.entry("RegexpHeaderCheck.fileExtensions", VERSION_6_9),
         Map.entry("RegexpHeaderCheck.headerFile", VERSION_3_2),
         Map.entry(REGEXP_HEADER_CHECK_HEADER, VERSION_5_0),
+        Map.entry("ClassDataAbstractionCouplingCheck.excludeClassesRegexps", VERSION_7_7),
+        Map.entry("ClassDataAbstractionCouplingCheck.excludedClasses", VERSION_5_7),
+        Map.entry("ClassDataAbstractionCouplingCheck.excludedPackages", VERSION_7_7),
+        Map.entry("ClassDataAbstractionCouplingCheck.max", VERSION_3_4),
+        Map.entry("ClassFanOutComplexityCheck.excludeClassesRegexps", VERSION_7_7),
+        Map.entry("ClassFanOutComplexityCheck.excludedClasses", VERSION_5_7),
+        Map.entry("ClassFanOutComplexityCheck.excludedPackages", VERSION_7_7),
+        Map.entry("ClassFanOutComplexityCheck.max", VERSION_3_4),
         Map.entry("NonEmptyAtclauseDescriptionCheck.javadocTokens", "7.3"),
         Map.entry("FileTabCharacterCheck.fileExtensions", VERSION_5_0),
         Map.entry("JavadocPackageCheck.fileExtensions", VERSION_5_0),
@@ -240,6 +263,8 @@ public final class SiteUtil {
                 "api", "AbstractFileSetCheck.java").toString()),
         new File(Paths.get(MAIN_FOLDER_PATH,
                 CHECKS, "header", "AbstractHeaderCheck.java").toString()),
+        new File(Paths.get(MAIN_FOLDER_PATH,
+                CHECKS, "metrics", "AbstractClassCouplingCheck.java").toString()),
         new File(Paths.get(MAIN_FOLDER_PATH,
                 CHECKS, "whitespace", "AbstractParenPadCheck.java").toString())
     );

--- a/src/main/resources/com/puppycrawl/tools/checkstyle/meta/checks/metrics/ClassFanOutComplexityCheck.xml
+++ b/src/main/resources/com/puppycrawl/tools/checkstyle/meta/checks/metrics/ClassFanOutComplexityCheck.xml
@@ -40,8 +40,7 @@
                <description>Specify user-configured class names to ignore.</description>
             </property>
             <property default-value="" name="excludedPackages" type="java.lang.String[]">
-               <description>Specify user-configured packages to ignore.
- All excluded packages should end with a period, so it also appends a dot to a package name.</description>
+               <description>Specify user-configured packages to ignore.</description>
             </property>
             <property default-value="20" name="max" type="int">
                <description>Specify the maximum threshold allowed.</description>

--- a/src/xdocs/checks/metrics/classdataabstractioncoupling.xml
+++ b/src/xdocs/checks/metrics/classdataabstractioncoupling.xml
@@ -90,18 +90,7 @@
               <td>excludedClasses</td>
               <td>Specify user-configured class names to ignore.</td>
               <td><a href="../../property_types.html#String.5B.5D">String[]</a></td>
-              <td><code>
-                ArrayIndexOutOfBoundsException, ArrayList, Boolean, Byte,
-                Character, Class, Collection, Deprecated, Deque, Double, DoubleStream, EnumSet,
-                Exception, Float, FunctionalInterface, HashMap, HashSet, IllegalArgumentException,
-                IllegalStateException, IndexOutOfBoundsException, IntStream, Integer,
-                LinkedHashMap, LinkedHashSet, LinkedList, List, Long, LongStream, Map,
-                NullPointerException, Object, Optional, OptionalDouble, OptionalInt, OptionalLong,
-                Override, Queue, RuntimeException, SafeVarargs, SecurityException, Set, Short,
-                SortedMap, SortedSet, Stream, String, StringBuffer, StringBuilder,
-                SuppressWarnings, Throwable, TreeMap, TreeSet, UnsupportedOperationException, Void,
-                boolean, byte, char, double, float, int, long, short, var, void</code>
-              </td>
+              <td><code>ArrayIndexOutOfBoundsException, ArrayList, Boolean, Byte, Character, Class, Collection, Deprecated, Deque, Double, DoubleStream, EnumSet, Exception, Float, FunctionalInterface, HashMap, HashSet, IllegalArgumentException, IllegalStateException, IndexOutOfBoundsException, IntStream, Integer, LinkedHashMap, LinkedHashSet, LinkedList, List, Long, LongStream, Map, NullPointerException, Object, Optional, OptionalDouble, OptionalInt, OptionalLong, Override, Queue, RuntimeException, SafeVarargs, SecurityException, Set, Short, SortedMap, SortedSet, Stream, String, StringBuffer, StringBuilder, SuppressWarnings, Throwable, TreeMap, TreeSet, UnsupportedOperationException, Void, boolean, byte, char, double, float, int, long, short, var, void</code></td>
               <td>5.7</td>
             </tr>
             <tr>

--- a/src/xdocs/checks/metrics/classdataabstractioncoupling.xml.template
+++ b/src/xdocs/checks/metrics/classdataabstractioncoupling.xml.template
@@ -71,54 +71,10 @@
 
       <subsection name="Properties" id="Properties">
         <div class="wrapper">
-          <table>
-            <tr>
-              <th>name</th>
-              <th>description</th>
-              <th>type</th>
-              <th>default value</th>
-              <th>since</th>
-            </tr>
-            <tr>
-              <td>excludeClassesRegexps</td>
-              <td>Specify user-configured regular expressions to ignore classes.</td>
-              <td><a href="../../property_types.html#Pattern.5B.5D">Pattern[]</a></td>
-              <td><code>^$</code></td>
-              <td>7.7</td>
-            </tr>
-            <tr>
-              <td>excludedClasses</td>
-              <td>Specify user-configured class names to ignore.</td>
-              <td><a href="../../property_types.html#String.5B.5D">String[]</a></td>
-              <td><code>
-                ArrayIndexOutOfBoundsException, ArrayList, Boolean, Byte,
-                Character, Class, Collection, Deprecated, Deque, Double, DoubleStream, EnumSet,
-                Exception, Float, FunctionalInterface, HashMap, HashSet, IllegalArgumentException,
-                IllegalStateException, IndexOutOfBoundsException, IntStream, Integer,
-                LinkedHashMap, LinkedHashSet, LinkedList, List, Long, LongStream, Map,
-                NullPointerException, Object, Optional, OptionalDouble, OptionalInt, OptionalLong,
-                Override, Queue, RuntimeException, SafeVarargs, SecurityException, Set, Short,
-                SortedMap, SortedSet, Stream, String, StringBuffer, StringBuilder,
-                SuppressWarnings, Throwable, TreeMap, TreeSet, UnsupportedOperationException, Void,
-                boolean, byte, char, double, float, int, long, short, var, void</code>
-              </td>
-              <td>5.7</td>
-            </tr>
-            <tr>
-              <td>excludedPackages</td>
-              <td>Specify user-configured packages to ignore.</td>
-              <td><a href="../../property_types.html#String.5B.5D">String[]</a></td>
-              <td><code>{}</code></td>
-              <td>7.7</td>
-            </tr>
-            <tr>
-              <td>max</td>
-              <td>Specify the maximum threshold allowed.</td>
-              <td><a href="../../property_types.html#int">int</a></td>
-              <td><code>7</code></td>
-              <td>3.4</td>
-            </tr>
-          </table>
+          <macro name="properties">
+            <param name="modulePath"
+                   value="src/main/java/com/puppycrawl/tools/checkstyle/checks/metrics/ClassDataAbstractionCouplingCheck.java"/>
+          </macro>
         </div>
       </subsection>
 

--- a/src/xdocs/checks/metrics/classfanoutcomplexity.xml
+++ b/src/xdocs/checks/metrics/classfanoutcomplexity.xml
@@ -56,26 +56,12 @@
               <td>excludedClasses</td>
               <td>Specify user-configured class names to ignore.</td>
               <td><a href="../../property_types.html#String.5B.5D">String[]</a></td>
-              <td><code>
-                ArrayIndexOutOfBoundsException, ArrayList, Boolean, Byte,
-                Character, Class, Collection, Deprecated, Deque, Double, DoubleStream, EnumSet,
-                Exception, Float, FunctionalInterface, HashMap, HashSet, IllegalArgumentException,
-                IllegalStateException, IndexOutOfBoundsException, IntStream, Integer,
-                LinkedHashMap, LinkedHashSet, LinkedList, List, Long, LongStream, Map,
-                NullPointerException, Object, Optional, OptionalDouble, OptionalInt, OptionalLong,
-                Override, Queue, RuntimeException, SafeVarargs, SecurityException, Set, Short,
-                SortedMap, SortedSet, Stream, String, StringBuffer, StringBuilder,
-                SuppressWarnings, Throwable, TreeMap, TreeSet, UnsupportedOperationException, Void,
-                boolean, byte, char, double, float, int, long, short, var, void</code>
-              </td>
+              <td><code>ArrayIndexOutOfBoundsException, ArrayList, Boolean, Byte, Character, Class, Collection, Deprecated, Deque, Double, DoubleStream, EnumSet, Exception, Float, FunctionalInterface, HashMap, HashSet, IllegalArgumentException, IllegalStateException, IndexOutOfBoundsException, IntStream, Integer, LinkedHashMap, LinkedHashSet, LinkedList, List, Long, LongStream, Map, NullPointerException, Object, Optional, OptionalDouble, OptionalInt, OptionalLong, Override, Queue, RuntimeException, SafeVarargs, SecurityException, Set, Short, SortedMap, SortedSet, Stream, String, StringBuffer, StringBuilder, SuppressWarnings, Throwable, TreeMap, TreeSet, UnsupportedOperationException, Void, boolean, byte, char, double, float, int, long, short, var, void</code></td>
               <td>5.7</td>
             </tr>
             <tr>
               <td>excludedPackages</td>
-              <td>
-                Specify user-configured packages to ignore. All excluded packages
-                should end with a period, so it also appends a dot to a package name.
-              </td>
+              <td>Specify user-configured packages to ignore.</td>
               <td><a href="../../property_types.html#String.5B.5D">String[]</a></td>
               <td><code>{}</code></td>
               <td>7.7</td>

--- a/src/xdocs/checks/metrics/classfanoutcomplexity.xml.template
+++ b/src/xdocs/checks/metrics/classfanoutcomplexity.xml.template
@@ -37,57 +37,10 @@
 
       <subsection name="Properties" id="Properties">
         <div class="wrapper">
-          <table>
-            <tr>
-              <th>name</th>
-              <th>description</th>
-              <th>type</th>
-              <th>default value</th>
-              <th>since</th>
-            </tr>
-            <tr>
-              <td>excludeClassesRegexps</td>
-              <td>Specify user-configured regular expressions to ignore classes.</td>
-              <td><a href="../../property_types.html#Pattern.5B.5D">Pattern[]</a></td>
-              <td><code>^$</code></td>
-              <td>7.7</td>
-            </tr>
-            <tr>
-              <td>excludedClasses</td>
-              <td>Specify user-configured class names to ignore.</td>
-              <td><a href="../../property_types.html#String.5B.5D">String[]</a></td>
-              <td><code>
-                ArrayIndexOutOfBoundsException, ArrayList, Boolean, Byte,
-                Character, Class, Collection, Deprecated, Deque, Double, DoubleStream, EnumSet,
-                Exception, Float, FunctionalInterface, HashMap, HashSet, IllegalArgumentException,
-                IllegalStateException, IndexOutOfBoundsException, IntStream, Integer,
-                LinkedHashMap, LinkedHashSet, LinkedList, List, Long, LongStream, Map,
-                NullPointerException, Object, Optional, OptionalDouble, OptionalInt, OptionalLong,
-                Override, Queue, RuntimeException, SafeVarargs, SecurityException, Set, Short,
-                SortedMap, SortedSet, Stream, String, StringBuffer, StringBuilder,
-                SuppressWarnings, Throwable, TreeMap, TreeSet, UnsupportedOperationException, Void,
-                boolean, byte, char, double, float, int, long, short, var, void</code>
-              </td>
-              <td>5.7</td>
-            </tr>
-            <tr>
-              <td>excludedPackages</td>
-              <td>
-                Specify user-configured packages to ignore. All excluded packages
-                should end with a period, so it also appends a dot to a package name.
-              </td>
-              <td><a href="../../property_types.html#String.5B.5D">String[]</a></td>
-              <td><code>{}</code></td>
-              <td>7.7</td>
-            </tr>
-            <tr>
-              <td>max</td>
-              <td>Specify the maximum threshold allowed.</td>
-              <td><a href="../../property_types.html#int">int</a></td>
-              <td><code>20</code></td>
-              <td>3.4</td>
-            </tr>
-          </table>
+          <macro name="properties">
+            <param name="modulePath"
+                   value="src/main/java/com/puppycrawl/tools/checkstyle/checks/metrics/ClassFanOutComplexityCheck.java"/>
+          </macro>
         </div>
       </subsection>
 


### PR DESCRIPTION
Issue #13693

setMax: https://github.com/checkstyle/checkstyle/commit/c044038c3b932586c0d384b614254cc2d1838838#diff-d554a793e3a3cbe81e95a9dd9b699444150c22c39a4c35ee7696fbdd04805d14R109 ( Jan 2, 2004)
https://sourceforge.net/projects/checkstyle/files/OldFiles/
![image](https://github.com/checkstyle/checkstyle/assets/812984/f6ced923-027e-48d4-917d-afc168b88015)


setExcludedClass: (Dec 2, 2013) , it is 5.7
https://github.com/checkstyle/checkstyle/commit/cd7d040b4d2c4a80e87ef9b5be9bbd964f19e97d#diff-d554a793e3a3cbe81e95a9dd9b699444150c22c39a4c35ee7696fbdd04805d14R109
dates are weird a bit for few releases of 5.X:
![image](https://github.com/checkstyle/checkstyle/assets/812984/ed2e1814-9a73-4870-91e7-3307c0e0464f)


setExcludeClassesRegexps:
https://github.com/checkstyle/checkstyle/commit/7b95603c0e5036f397365a05b68483d0da690c63#diff-ae3adc6efccc0a0cca1c89bf35cb69fd68ae8d0ce40c52176814218bd4e144a7R133
tags are weird ..... it isnot 4.4
https://github.com/checkstyle/checkstyle/issues/3234, it is 7.7


setExcludedPackages:
https://github.com/checkstyle/checkstyle/commit/57785f3aa7d71b67a3c8adc8b60a008f921c33c8#diff-ae3adc6efccc0a0cca1c89bf35cb69fd68ae8d0ce40c52176814218bd4e144a7R152
tags are weird
it is 7.7 by issue - https://github.com/checkstyle/checkstyle/issues/3309
