### PR TITLE
Issue #14019: Resolve pitest utils suppressions for ScopeUtil#getScopeFromMods

### DIFF
--- a/config/checker-framework-suppressions/checker-nullness-optional-interning-suppressions.xml
+++ b/config/checker-framework-suppressions/checker-nullness-optional-interning-suppressions.xml
@@ -6333,7 +6333,7 @@
     <fileName>src/main/java/com/puppycrawl/tools/checkstyle/utils/ScopeUtil.java</fileName>
     <specifier>introduce.eliminate</specifier>
     <message>It is bad style to create an Optional just to chain methods to get a value.</message>
-    <lineContent>.orElseGet(() -&gt; getDefaultScope(aMods.getParent()));</lineContent>
+    <lineContent>.orElseGet(() -&gt; getDefaultScope(aMods));</lineContent>
   </checkerFrameworkError>
 
   <checkerFrameworkError unstable="false">

--- a/config/pitest-suppressions/pitest-utils-suppressions.xml
+++ b/config/pitest-suppressions/pitest-utils-suppressions.xml
@@ -26,13 +26,4 @@
     <description>removed conditional - replaced equality check with true</description>
     <lineContent>token != null &amp;&amp; !returnValue;</lineContent>
   </mutation>
-
-  <mutation unstable="false">
-    <sourceFile>ScopeUtil.java</sourceFile>
-    <mutatedClass>com.puppycrawl.tools.checkstyle.utils.ScopeUtil</mutatedClass>
-    <mutatedMethod>lambda$getScopeFromMods$1</mutatedMethod>
-    <mutator>org.pitest.mutationtest.engine.gregor.mutators.experimental.NakedReceiverMutator</mutator>
-    <description>replaced call to com/puppycrawl/tools/checkstyle/api/DetailAST::getParent with receiver</description>
-    <lineContent>.orElseGet(() -&gt; getDefaultScope(aMods.getParent()));</lineContent>
-  </mutation>
 </suppressedMutations>

--- a/src/main/java/com/puppycrawl/tools/checkstyle/utils/ScopeUtil.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/utils/ScopeUtil.java
@@ -85,7 +85,7 @@ public final class ScopeUtil {
      */
     public static Scope getScopeFromMods(DetailAST aMods) {
         return Optional.ofNullable(getDeclaredScopeFromMods(aMods))
-                .orElseGet(() -> getDefaultScope(aMods.getParent()));
+                .orElseGet(() -> getDefaultScope(aMods));
     }
 
     /**


### PR DESCRIPTION
Issue #14019 

### Explanation


Mutation - 

https://github.com/checkstyle/checkstyle/blob/11e2b4baee11523db5c15602380775e95fb437ba/config/pitest-suppressions/pitest-utils-suppressions.xml#L39-L46

### Dependency Tree

```
Method
    getScopeFromMods(DetailAST)
Usages or usages of base method in Project Files
  Unclassified
    checkstyle
      com.puppycrawl.tools.checkstyle.checks.coding
        DeclarationOrderCheck
          processModifiersSubState(DetailAST, ScopeState, boolean)
          final Scope access = ScopeUtil.getScopeFromMods(modifiersAst);
```


### Modules 

1. `DeclarationOrderCheck`


Diff Regression config: https://gist.githubusercontent.com/suniti0804/35fc6bb1108b1e7ddb7c5f13471510b8/raw/fffe9dbf99d906a8e1855e38dcbf64c57fca430d/pull-14061-regerssion-config

Diff Regression projects: https://gist.githubusercontent.com/suniti0804/1d7bd7fbc50bf6c93896fbe2bbbf2c4a/raw/f71611ef97d0737b6d8bb1c1253cab18b9342429/projects-to-test-on-for-github-action.properties

Report label: Issue#14061-Report

### Analysis for ScopeUtil#getScopeFromMods Method Modification

The original code was: `.orElseGet(() -> getDefaultScope(aMods.getParent()));`
The mutated code is: `.orElseGet(() -> getDefaultScope(aMods));`

In the original code, `getDefaultScope()` was being called with the parent of `aMods` as the argument. In the mutated code, `getDefaultScope()` is being called with `aMods` itself.

**Justification for the Change:**

1. All unit tests are passing after the change, which means that the modification has not broken any existing functionality.

2. The `getDefaultScope()` method determines the default scope based on the type of the AST node. It does not require a parent node specifically, and there are no operations in the method that would fail if a non-parent node were passed. Therefore, it is safe to pass `aMods` instead of `aMods.getParent()`.

3. The `getDefaultScope()` method checks if the `DetailAST` object is in an enum block, an interface or annotation block, or none of these. It does not rely on the hierarchical relationship of the nodes. Therefore, replacing `aMods.getParent()` with `aMods` does not alter the logic or the context of the application.

4. There doesn't seem to be any side-effects of this change as the `getDefaultScope()` method only checks for the type of the node and doesn't depend on the node's parent-child relationship.

The mutation doesn't seem to break the functionality because `getDefaultScope()` doesn't require a parent node as an argument. It only needs a node of an appropriate type, which `aMods` is. 