### PR TITLE
infra: update appveyor.yml to use maven 3.8.8, 3.8.6 is not available…

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -11,21 +11,21 @@ branches:
 install:
   - ps: |
       Add-Type -AssemblyName System.IO.Compression.FileSystem
-      if (!(Test-Path -Path "C:\maven\apache-maven-3.8.6" )) {
+      if (!(Test-Path -Path "C:\maven\apache-maven-3.8.8" )) {
         (new-object System.Net.WebClient).DownloadFile(
-          'https://downloads.apache.org/maven/maven-3/3.8.6/binaries/apache-maven-3.8.6-bin.zip',
+          'https://downloads.apache.org/maven/maven-3/3.8.8/binaries/apache-maven-3.8.8-bin.zip',
           'C:\maven-bin.zip'
         )
         [System.IO.Compression.ZipFile]::ExtractToDirectory("C:\maven-bin.zip", "C:\maven")
       }
-  - cmd: SET M2_HOME=C:\maven\apache-maven-3.8.6
+  - cmd: SET M2_HOME=C:\maven\apache-maven-3.8.8
   - cmd: SET PATH=%M2_HOME%\bin;%JAVA_HOME%\bin;%PATH%
   - cmd: git config core.autocrlf
   - cmd: mvn --version
   - cmd: java -version
 
 cache:
-  - C:\maven\apache-maven-3.8.6
+  - C:\maven\apache-maven-3.8.8
   - C:\Users\appveyor\.m2
 
 matrix:
@@ -72,5 +72,5 @@ build_script:
       }
   - ps: ./.ci/validation.cmd git_diff
   - ps: echo "Size of caches (bytes):"
-  - ps: Get-ChildItem -Recurse 'C:\maven\apache-maven-3.8.6' | Measure-Object -Property Length -Sum
+  - ps: Get-ChildItem -Recurse 'C:\maven\apache-maven-3.8.8' | Measure-Object -Property Length -Sum
   - ps: Get-ChildItem -Recurse 'C:\Users\appveyor\.m2' | Measure-Object -Property Length -Sum


### PR DESCRIPTION
Detected at https://github.com/checkstyle/checkstyle/pull/14016#issuecomment-1826871665

https://ci.appveyor.com/project/Checkstyle/checkstyle/builds/48611585/job/8sp816adkneauq4n

```
(new-object System.Net.WebClient).DownloadFile(
    'https://downloads.apache.org/maven/maven-3/3.8.6/binaries/apache-maven-3.8.6-bin.zip',
    'C:\maven-bin.zip'
  )
  [System.IO.Compression.ZipFile]::ExtractToDirectory("C:\maven-bin.zip", "C:\maven")
}
Exception calling "DownloadFile" with "2" argument(s): "The remote server returned an error: (404) Not Found."
At line:3 char:3
+   (new-object System.Net.WebClient).DownloadFile(
+
```