### PR TITLE
minor: print mvn version; MAVEN_OPTS --show-version is not working

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -160,6 +160,7 @@ steps:
 
   - bash: |
       set -e
+      mvn --version
       echo "ON_CRON_ONLY:"$ON_CRON_ONLY
       echo "BUILD_REASON:"$BUILD_REASON
       echo "cmd: "$(cmd)


### PR DESCRIPTION
trying to understand https://github.com/checkstyle/checkstyle/pull/13887
and what will be required for https://github.com/checkstyle/checkstyle/pull/14012

fact that maven opts are not printing mvn version, but print jdk version:
https://dev.azure.com/romanivanovjr/romanivanovjr/_build/results?buildId=17918&view=logs&j=c902ebb4-c9f8-5f09-4e17-ff78fbbc842e&t=9ca98c81-ff64-58f0-9d03-a23ac1c4a111&l=14
```
========================== Starting Command Output ===========================
/usr/bin/bash /home/vsts/work/_temp/bb44b446-8cfc-40a0-a0a6-02d141cff2bd.sh
ON_CRON_ONLY:$(onCronOnly)
BUILD_REASON:PullRequest
cmd: ./.ci/validation.sh test
openjdk 11.0.21 2023-10-17
OpenJDK Runtime Environment Temurin-11.0.21+9 (build 11.0.21+9)
OpenJDK 64-Bit Server VM Temurin-11.0.21+9 (build 11.0.21+9, mixed mode)

```