### PR TITLE
Issue #13307: support multiple different violations per line with mes…

### DIFF
--- a/config/suppressions.xml
+++ b/config/suppressions.xml
@@ -77,7 +77,7 @@
              files="(CheckerTest|AbstractModuleTestSupport|AbstractItModuleTestSupport|
                     |CheckstyleAntTaskTest|
                     |TranslationCheckTest|LocalizedMessageTest|AbstractFileSetCheckTest|
-                    |AbstractCheckTest)\.java"/>
+                    |AbstractCheckTest|InlineConfigParser)\.java"/>
   <suppress checks="ClassDataAbstractionCoupling"
              files="XpathFileGeneratorAuditListenerTest\.java"/>
   <suppress checks="ClassFanOutComplexity" files="[\\/]Main\.java"/>

--- a/src/test/java/com/puppycrawl/tools/checkstyle/bdd/InlineConfigParser.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/bdd/InlineConfigParser.java
@@ -26,6 +26,7 @@ import java.lang.reflect.Modifier;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
@@ -50,6 +51,12 @@ public final class InlineConfigParser {
     /** A pattern matching the symbol: "\" or "/". */
     private static final Pattern SLASH_PATTERN = Pattern.compile("[\\\\/]");
 
+    /**
+     * Pattern for lines under
+     * {@link InlineConfigParser#MULTIPLE_VIOLATIONS_SOME_LINES_ABOVE_PATTERN}.
+     */
+    private static final Pattern VIOLATION_MESSAGE_PATTERN = Pattern
+            .compile(".*//\\s*(?:['\"](.*)['\"])?$");
     /**
      * A pattern that matches the following comments formats.
      * <ol>
@@ -125,9 +132,20 @@ public final class InlineConfigParser {
     private static final Pattern VIOLATION_SOME_LINES_BELOW_PATTERN = Pattern
             .compile(".*//\\s*violation (\\d+) lines below\\s*(?:['\"](.*)['\"])?$");
 
-    /** A pattern to find the string: "// X violations Y lines above". */
+    /**
+     * <p>
+     * Multiple violations for line. Violations are Y lines above, messages are X lines below.
+     * {@code
+     *   // X violations Y lines above:
+     *   //                            'violation message1'
+     *   //                            'violation messageX'
+     * }
+     *
+     * Messages are matched by {@link InlineConfigParser#VIOLATION_MESSAGE_PATTERN}
+     * </p>
+     */
     private static final Pattern MULTIPLE_VIOLATIONS_SOME_LINES_ABOVE_PATTERN = Pattern
-            .compile(".*//\\s*(\\d+) violations (\\d+) lines above\\s*(?:['\"](.*)['\"])?$");
+            .compile(".*//\\s*(\\d+) violations (\\d+) lines above:\\s*(?:['\"](.*)['\"])?$");
 
     /** The String "(null)". */
     private static final String NULL_STRING = "(null)";
@@ -543,16 +561,9 @@ public final class InlineConfigParser {
             inputConfigBuilder.addViolation(violationLineNum, violationMessage);
         }
         else if (multipleViolationsSomeLinesAboveMatcher.matches()) {
-            final int linesAbove =
-                Integer.parseInt(multipleViolationsSomeLinesAboveMatcher.group(2));
-            final int violationLineNum = lineNo - linesAbove + 1;
-
-            Collections
-                    .nCopies(Integer.parseInt(multipleViolationsSomeLinesAboveMatcher.group(1)),
-                        violationLineNum)
-                    .forEach(actualLineNumber -> {
-                        inputConfigBuilder.addViolation(actualLineNumber, null);
-                    });
+            inputConfigBuilder.addViolations(
+                getExpectedMultipleViolations(
+                    lines, lineNo, multipleViolationsSomeLinesAboveMatcher));
         }
         else if (multipleViolationsMatcher.matches()) {
             Collections
@@ -580,6 +591,33 @@ public final class InlineConfigParser {
             setFilteredViolation(inputConfigBuilder, lineNo + 1,
                     lines.get(lineNo), specifyViolationMessage);
         }
+    }
+
+    private static List<TestInputViolation> getExpectedMultipleViolations(
+                                              List<String> lines, int lineNo,
+                                              Matcher matcher) {
+        final List<TestInputViolation> results = new ArrayList<>();
+        final int linesAbove =
+            Integer.parseInt(matcher.group(2));
+        final int violationLineNum = lineNo - linesAbove + 1;
+
+        final int expectedMessageCount =
+            Integer.parseInt(matcher.group(1));
+        for (int index = 1; index <= expectedMessageCount; index++) {
+            final String lineWithMessage = lines.get(lineNo + index);
+            final Matcher messageMatcher = VIOLATION_MESSAGE_PATTERN.matcher(lineWithMessage);
+            if (messageMatcher.matches()) {
+                final String violationMessage = messageMatcher.group(1);
+                results.add(new TestInputViolation(violationLineNum, violationMessage));
+            }
+        }
+        if (results.size() != expectedMessageCount) {
+            final String message = String.format(Locale.ROOT,
+                "Declared amount of violation messages at line %s is %s but found %s",
+                lineNo + 1, expectedMessageCount, results.size());
+            throw new IllegalStateException(message);
+        }
+        return results;
     }
 
     private static void setFilteredViolation(TestInputConfiguration.Builder inputConfigBuilder,

--- a/src/test/java/com/puppycrawl/tools/checkstyle/bdd/TestInputConfiguration.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/bdd/TestInputConfiguration.java
@@ -151,6 +151,10 @@ public final class TestInputConfiguration {
             violations.add(new TestInputViolation(violationLine, violationMessage));
         }
 
+        public void addViolations(List<TestInputViolation> inputViolations) {
+            violations.addAll(inputViolations);
+        }
+
         public void addFilteredViolation(int violationLine, String violationMessage) {
             filteredViolations.add(new TestInputViolation(violationLine, violationMessage));
         }

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/abstractjavadoc/InputAbstractJavadocNonTightHtmlTags2.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/abstractjavadoc/InputAbstractJavadocNonTightHtmlTags2.java
@@ -19,10 +19,10 @@ package com.puppycrawl.tools.checkstyle.checks.javadoc.abstractjavadoc;
  */
 // violation 9 lines above 'tag BODY_TAG_START'
 // violation 9 lines above 'tag P_TAG_START'
-// 2 violations 8 lines above
+// 2 violations 8 lines above:
 //                            'Unclosed HTML tag found: p'
 //                            'tag P_TAG_START'
-// 2 violations 10 lines above
+// 2 violations 10 lines above:
 //                            'tag LI_TAG_START'
 //                            'tag P_TAG_START'
 
@@ -45,7 +45,7 @@ public class InputAbstractJavadocNonTightHtmlTags2 {
      * <li> list has an <p> unclosed para, but still the list would get nested </li>
      */
     // violation 3 lines above 'P_TAG_START'
-    // 3 violations 3 lines above
+    // 3 violations 3 lines above:
     //                    'Unclosed HTML tag found: p'
     //                    'tag LI_TAG_START'
     //                    'tag P_TAG_START'
@@ -55,7 +55,7 @@ public class InputAbstractJavadocNonTightHtmlTags2 {
      * <li> Complete <p> nesting </p> </li>
      * <tr> Zero </p> nesting despite `tr` is closed </tr>
      */
-    // 2 violations 3 lines above
+    // 2 violations 3 lines above:
     //                            'tag LI_TAG_START'
     //                            'tag P_TAG_START'
     // violation 5 lines above 'Unclosed HTML tag found: tr'
@@ -68,7 +68,7 @@ public class InputAbstractJavadocNonTightHtmlTags2 {
      */
     // violation 4 lines above 'tag P_TAG_START'
     // violation 4 lines above 'tag P_TAG_START'
-    // 3 violations 4 lines above
+    // 3 violations 4 lines above:
     //                            'Unclosed HTML tag found: li'
     //                            'tag LI_TAG_START'
     //                            'tag LI_TAG_START'
@@ -79,11 +79,11 @@ public class InputAbstractJavadocNonTightHtmlTags2 {
      *
      * @return <li> <li> outer list isn't nested in parse tree </li> </li>
      */
-    // 3 violations 4 lines above
+    // 3 violations 4 lines above:
     //                            'tag BODY_TAG_START'
-    //                            'tag LI_TAG_START'
     //                            'tag P_TAG_START'
-    // 3 violations 6 lines above
+    //                            'tag LI_TAG_START'
+    // 3 violations 6 lines above:
     //                            'Unclosed HTML tag found: li'
     //                            'tag LI_TAG_START'
     //                            'tag LI_TAG_START'
@@ -98,7 +98,7 @@ public class InputAbstractJavadocNonTightHtmlTags2 {
      * @param field2 <p> setter
      */
     // violation 4 lines above 'tag P_TAG_START'
-    // 2 violations 3 lines above
+    // 2 violations 3 lines above:
     //                            'Unclosed HTML tag found: p'
     //                            'tag P_TAG_START'
     void setField2(int field2) {this.field2 = field2;}

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/abstractjavadoc/InputAbstractJavadocNonTightHtmlTags3.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/abstractjavadoc/InputAbstractJavadocNonTightHtmlTags3.java
@@ -37,7 +37,7 @@ public class InputAbstractJavadocNonTightHtmlTags3 {
      *      <tFoot>
      * @param field5 </p> value to which {@link #field5} is to be set to
      */
-    // 4 violations 4 lines above
+    // 4 violations 4 lines above:
     //                            'Unclosed HTML tag found: p'
     //                            'tag P_TAG_START'
     //                            'tag LI_TAG_START'


### PR DESCRIPTION
Fixes #13307

I think this simple format is enough.
wording can be changed, please suggest improvements.

I do not see same simple way to support "X violations Y lines below", I think we can skip it, as multiple violations is very exceptional case and we should continue to discourage contributors to use it.

NOT done validation of messages for:
```
public class InputAbstractJavadocNonTightHtmlTags2 {
    /** <p> <p> paraception </p> </p> */
    // 3 violations above
    //                    'Unclosed HTML tag found: p'
    //                    'tag P_TAG_START'
    //                    'tag P_TAG_START'
```
I think it is better to do this after this PR, to make sure prove of concept is megred and second PR will be easy to accept as it will just extension.