### PR TITLE
minor: Rename static variable in UnusedLocalVar check to make more sense

### DIFF
--- a/config/jsoref-spellchecker/whitelist.words
+++ b/config/jsoref-spellchecker/whitelist.words
@@ -1340,6 +1340,7 @@ ttf
 tvf
 tw
 typecastparenpad
+TYPEDECL
 typename
 typevariablenames
 uber

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/UnusedLocalVariableCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/UnusedLocalVariableCheck.java
@@ -120,7 +120,7 @@ public class UnusedLocalVariableCheck extends AbstractCheck {
     /**
      * An array of blocks in which local anon inner classes can exist.
      */
-    private static final int[] CONTAINERS_FOR_ANON_INNERS = {
+    private static final int[] TYPEDECL_BODY_DECLARATION_TOKENS = {
         TokenTypes.METHOD_DEF,
         TokenTypes.CTOR_DEF,
         TokenTypes.STATIC_INIT,
@@ -155,7 +155,7 @@ public class UnusedLocalVariableCheck extends AbstractCheck {
     private final Map<DetailAST, TypeDeclDesc> anonInnerAstToTypeDeclDesc = new HashMap<>();
 
     /**
-     * Set of tokens of type {@link UnusedLocalVariableCheck#CONTAINERS_FOR_ANON_INNERS}
+     * Set of tokens of type {@link UnusedLocalVariableCheck#TYPEDECL_BODY_DECLARATION_TOKENS}
      * and {@link TokenTypes#LAMBDA} in some cases.
      */
     private final Set<DetailAST> anonInnerClassHolders = new HashSet<>();
@@ -397,7 +397,7 @@ public class UnusedLocalVariableCheck extends AbstractCheck {
     private static DetailAST getBlockContainingLocalAnonInnerClass(DetailAST literalNewAst) {
         DetailAST currentAst = literalNewAst;
         DetailAST result = null;
-        while (!TokenUtil.isOfType(currentAst, CONTAINERS_FOR_ANON_INNERS)) {
+        while (!TokenUtil.isOfType(currentAst, TYPEDECL_BODY_DECLARATION_TOKENS)) {
             if (currentAst.getType() == TokenTypes.LAMBDA
                     && currentAst.getParent()
                     .getParent().getParent().getType() == TokenTypes.OBJBLOCK) {


### PR DESCRIPTION
 > Please rename this collection to something like `CLASS_BODY_DECLARATION_TOKENS`  or even `ANONYMOUS_INNER_CLASS_SCOPES` in a separate commit first, `container` is nonsense in this context. Then update the method naming, etc. appropriately.

_Originally posted by @nrmancuso in https://github.com/checkstyle/checkstyle/pull/13543#discussion_r1289084593_
            