### PR TITLE
infra: trim spaces in links, to avoid validation error

### DIFF
--- a/.ci/diff-report.sh
+++ b/.ci/diff-report.sh
@@ -95,6 +95,11 @@ parse-pr-description-text)
   NEW_MODULE_CONFIG_LINK=$(echo "$NEW_MODULE_CONFIG_PARAMETER" | sed -E 's/New module config: //')
   PATCH_CONFIG_LINK=$(echo "$PATCH_CONFIG_PARAMETER" | sed -E 's/Diff Regression patch config: //')
   REPORT_LABEL=$(echo "$REPORT_LABEL_PARAMETER" | sed -E 's/Report label: //')
+  # trim
+  PROJECTS_LINK=$(echo "$PROJECTS_LINK" | tr -d '[:space:]')
+  CONFIG_LINK=$(echo "$CONFIG_LINK" | tr -d '[:space:]')
+  NEW_MODULE_CONFIG_LINK=$(echo "$NEW_MODULE_CONFIG_LINK" | tr -d '[:space:]')
+  PATCH_CONFIG_LINK=$(echo "$PATCH_CONFIG_LINK" | tr -d '[:space:]')
 
   echo "URLs extracted from parameters:"
   echo "PROJECTS_LINK: '$PROJECTS_LINK'"


### PR DESCRIPTION
run into this multiple time:
https://github.com/checkstyle/checkstyle/actions/runs/7072702035/job/19251823922#step:6:23

```
Validating PROJECTS_LINK...
URL 'https://gist.githubusercontent.com/romani/db8ebee721f2a387e1d4b81a55f2d5f1/raw/8e4a96fdad2654d55808851ae59553b58f5e782f/pull-9758-only-guava.properties ' does not match regexp '^(https?|ftp|file)://[-A-Za-z0-9\+&@#/%?=~_|!:,.;]*[-A-Za-z0-9\+&@#/%=~_|]\.[-A-Za-z0-9\+&@#/%?=~_|!:,.;]*[-A-Za-z0-9\+&@#/%=~_|]$'.
Error: Process completed with exit code 1.
```