### PR TITLE
Issue #13999: Resolve pitest suppression for JavadocParagraphCheck

### DIFF
--- a/config/pitest-suppressions/pitest-javadoc-suppressions.xml
+++ b/config/pitest-suppressions/pitest-javadoc-suppressions.xml
@@ -199,15 +199,6 @@
   </mutation>
 
   <mutation unstable="false">
-    <sourceFile>JavadocParagraphCheck.java</sourceFile>
-    <mutatedClass>com.puppycrawl.tools.checkstyle.checks.javadoc.JavadocParagraphCheck</mutatedClass>
-    <mutatedMethod>getNearestEmptyLine</mutatedMethod>
-    <mutator>org.pitest.mutationtest.engine.gregor.mutators.experimental.ArgumentPropagationMutator</mutator>
-    <description>replaced call to com/puppycrawl/tools/checkstyle/utils/JavadocUtil::getPreviousSibling with argument</description>
-    <lineContent>DetailNode newLine = JavadocUtil.getPreviousSibling(node);</lineContent>
-  </mutation>
-
-  <mutation unstable="false">
     <sourceFile>JavadocStyleCheck.java</sourceFile>
     <mutatedClass>com.puppycrawl.tools.checkstyle.checks.javadoc.JavadocStyleCheck</mutatedClass>
     <mutatedMethod>findTextStart</mutatedMethod>

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocParagraphCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocParagraphCheck.java
@@ -252,7 +252,7 @@ public class JavadocParagraphCheck extends AbstractJavadocCheck {
      * @return Some nearest empty line in javadoc.
      */
     private static DetailNode getNearestEmptyLine(DetailNode node) {
-        DetailNode newLine = JavadocUtil.getPreviousSibling(node);
+        DetailNode newLine = node;
         while (newLine != null) {
             final DetailNode previousSibling = JavadocUtil.getPreviousSibling(newLine);
             if (newLine.getType() == JavadocTokenTypes.NEWLINE && isEmptyLine(newLine)) {


### PR DESCRIPTION
Issue #13999 

### Explanation

The mutation involves replacing the `JavadocUtil.getPreviousSibling(node)` method call with the `node` itself. The mutated line of code is as follows:

`DetailNode newLine = node;`

In the mutated code, instead of getting the previous sibling of the node, we directly assign the node to the `newLine`.
The overall purpose of the `getNearestEmptyLine` method is to find and return the nearest empty line in Javadoc. The mutation changes the starting point of the search from the previous sibling to the current node itself. The change in the code does not alter the logic or the context of the application. The `getNearestEmptyLine` method does not rely on the hierarchical relationship between the nodes. Therefore, starting the search from the current node instead of its previous sibling does not have any negative impact.


### Dependency Tree

```
JavadocParagraphCheck.visitJavadocToken(DetailNode)  (com.puppycrawl.tools.checkstyle.checks.javadoc)
    AbstractJavadocCheck.walk(DetailNode)  (com.puppycrawl.tools.checkstyle.checks.javadoc)
        AbstractJavadocCheck.processTree(DetailNode)  (com.puppycrawl.tools.checkstyle.checks.javadoc)
            AbstractJavadocCheck.visitToken(DetailAST)  (com.puppycrawl.tools.checkstyle.checks.javadoc)
                TestUtil.isStatefulFieldClearedDuringBeginTree(AbstractCheck, DetailAST, String, Predicate<Object>)  (com.puppycrawl.tools.checkstyle.internal.utils)
                TreeWalker.notifyVisit(DetailAST, AstState)  (com.puppycrawl.tools.checkstyle)
               

```

### Modules 

1. JavadocParagraphCheck
2. AbstractJavadocCheck
3. AbstractCheck


Diff Regression config: https://gist.githubusercontent.com/suniti0804/6766ce69085472472e70919b819fd834/raw/886ef73fd101561a30969878ce520da27bd40768/pull-14098-regression-config

Diff Regression projects: https://gist.githubusercontent.com/suniti0804/1d7bd7fbc50bf6c93896fbe2bbbf2c4a/raw/f71611ef97d0737b6d8bb1c1253cab18b9342429/projects-to-test-on-for-github-action.properties

Report label: Issue#14098-Report

