### PR TITLE
Issue #13999: Resolve pitest suppression for visitToken() method of AbstractJavadocCheck

### DIFF
--- a/config/pitest-suppressions/pitest-javadoc-suppressions.xml
+++ b/config/pitest-suppressions/pitest-javadoc-suppressions.xml
@@ -12,15 +12,6 @@
   <mutation unstable="false">
     <sourceFile>AbstractJavadocCheck.java</sourceFile>
     <mutatedClass>com.puppycrawl.tools.checkstyle.checks.javadoc.AbstractJavadocCheck</mutatedClass>
-    <mutatedMethod>visitToken</mutatedMethod>
-    <mutator>org.pitest.mutationtest.engine.gregor.mutators.NonVoidMethodCallMutator</mutator>
-    <description>removed call to com/puppycrawl/tools/checkstyle/api/DetailAST::getColumnNo</description>
-    <lineContent>blockCommentNode.getColumnNo());</lineContent>
-  </mutation>
-
-  <mutation unstable="false">
-    <sourceFile>AbstractJavadocCheck.java</sourceFile>
-    <mutatedClass>com.puppycrawl.tools.checkstyle.checks.javadoc.AbstractJavadocCheck</mutatedClass>
     <mutatedMethod>walk</mutatedMethod>
     <mutator>org.pitest.mutationtest.engine.gregor.mutators.RemoveConditionalMutator_EQUAL_ELSE</mutator>
     <description>removed conditional - replaced equality check with false</description>

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/AbstractJavadocCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/AbstractJavadocCheck.java
@@ -312,8 +312,7 @@ public abstract class AbstractJavadocCheck extends AbstractCheck {
             // store as field, to share with child Checks
             context.get().blockCommentAst = blockCommentNode;
 
-            final LineColumn treeCacheKey = new LineColumn(blockCommentNode.getLineNo(),
-                    blockCommentNode.getColumnNo());
+            final LineColumn treeCacheKey = new LineColumn(blockCommentNode.getLineNo(), 0);
 
             final ParseStatus result = TREE_CACHE.get().computeIfAbsent(treeCacheKey, key -> {
                 return context.get().parser.parseJavadocAsDetailNode(blockCommentNode);


### PR DESCRIPTION
Issue #13999 

### Dependency

AbstractJavadocCheck  (com.puppycrawl.tools.checkstyle.checks.javadoc)
    TokenIsNotInAcceptablesCheck in AbstractJavadocCheckTest  (com.puppycrawl.tools.checkstyle.checks.javadoc)
    MissingDeprecatedCheck  (com.puppycrawl.tools.checkstyle.checks.annotation)
    AtclauseOrderCheck  (com.puppycrawl.tools.checkstyle.checks.javadoc)
    JavadocParagraphCheck  (com.puppycrawl.tools.checkstyle.checks.javadoc)
    JavadocMissingWhitespaceAfterAsteriskCheck  (com.puppycrawl.tools.checkstyle.checks.javadoc)
    SingleLineJavadocCheck  (com.puppycrawl.tools.checkstyle.checks.javadoc)
    RequiredTokenIsNotInDefaultsJavadocCheck in AbstractJavadocCheckTest  (com.puppycrawl.tools.checkstyle.checks.javadoc)
    ParseJavadocOnlyCheck in AbstractJavadocCheckTest  (com.puppycrawl.tools.checkstyle.checks.javadoc)
    JavadocMissingLeadingAsteriskCheck  (com.puppycrawl.tools.checkstyle.checks.javadoc)
    JavadocMetadataScraper  (com.puppycrawl.tools.checkstyle.meta)
    SummaryJavadocCheck  (com.puppycrawl.tools.checkstyle.checks.javadoc)
    JavadocTagContinuationIndentationCheck  (com.puppycrawl.tools.checkstyle.checks.javadoc)
    JavadocBlockTagLocationCheck  (com.puppycrawl.tools.checkstyle.checks.javadoc)
    JavadocVisitLeaveCheck in AbstractJavadocCheckTest  (com.puppycrawl.tools.checkstyle.checks.javadoc)
    NonTightHtmlTagCheck in AbstractJavadocCheckTest  (com.puppycrawl.tools.checkstyle.checks.javadoc)
    JavadocCatchCheck in AbstractJavadocCheckTest  (com.puppycrawl.tools.checkstyle.checks.javadoc)
    ClassAndPropertiesSettersJavadocScraper  (com.puppycrawl.tools.checkstyle.site)
    RequireEmptyLineBeforeBlockTagGroupCheck  (com.puppycrawl.tools.checkstyle.checks.javadoc)
    NonTightHtmlTagTolerantCheck in AbstractJavadocCheckTest  (com.puppycrawl.tools.checkstyle.checks.javadoc)
    NonEmptyAtclauseDescriptionCheck  (com.puppycrawl.tools.checkstyle.checks.javadoc)
    Anonymous in testTokens() in AbstractJavadocCheckTest  (com.puppycrawl.tools.checkstyle.checks.javadoc)
    Anonymous in testTokensFail() in AbstractJavadocCheckTest  (com.puppycrawl.tools.checkstyle.checks.javadoc)


### Modules

1. AbstractJavadocCheck
2. MissingDeprecatedCheck
3. AtclauseOrderCheck
4. JavadocParagraphCheck
5. JavadocMissingWhitespaceAfterAsteriskCheck
6. SingleLineJavadocCheck
7. JavadocMissingLeadingAsteriskCheck
8. SummaryJavadocCheck
9. JavadocTagContinuationIndentationCheck
10. JavadocBlockTagLocationCheck
11. RequireEmptyLineBeforeBlockTagGroupCheck
12. NonEmptyAtclauseDescriptionCheck


Diff Regression config: https://gist.githubusercontent.com/suniti0804/6e8c587c5228271ad8e7c7f0fdb30b82/raw/6022d258ac15af0d003a48085dcd4717c4ff9336/pull-14127-regerssion-config

Diff Regression projects: https://gist.githubusercontent.com/suniti0804/1d7bd7fbc50bf6c93896fbe2bbbf2c4a/raw/f71611ef97d0737b6d8bb1c1253cab18b9342429/projects-to-test-on-for-github-action.properties

Report label: Issue#14127-Report