### PR TITLE
Issue #14137: Introduce Error Prone Support

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -233,8 +233,9 @@
     <junit.version>5.10.1</junit.version>
     <forbiddenapis.version>3.6</forbiddenapis.version>
     <json-schema-validator.version>1.2.0</json-schema-validator.version>
-    <error-prone.version>2.23.0</error-prone.version>
     <checkerframework.version>3.42.0</checkerframework.version>
+    <error-prone.version>2.23.0</error-prone.version>
+    <error-prone-support.version>0.14.0</error-prone-support.version>
     <doxia.version>1.12.0</doxia.version>
   </properties>
 
@@ -2385,6 +2386,11 @@
                       <artifactId>error_prone_core</artifactId>
                       <version>${error-prone.version}</version>
                     </path>
+                    <path>
+                      <groupId>tech.picnic.error-prone-support</groupId>
+                      <artifactId>error-prone-contrib</artifactId>
+                      <version>${error-prone-support.version}</version>
+                    </path>
                   </annotationProcessorPaths>
                 </configuration>
               </execution>
@@ -2438,6 +2444,11 @@
                       <artifactId>error_prone_core</artifactId>
                       <version>${error-prone.version}</version>
                     </path>
+                    <path>
+                      <groupId>tech.picnic.error-prone-support</groupId>
+                      <artifactId>error-prone-contrib</artifactId>
+                      <version>${error-prone-support.version}</version>
+                    </path>b
                   </annotationProcessorPaths>
                 </configuration>
               </execution>


### PR DESCRIPTION
This PR is based on a suggestion by @romani in: https://github.com/checkstyle/checkstyle/issues/14129. The idea is to add Error Prone Support to Checkstyle in this PR and after that discuss which checks we want to enable.

I added Error Prone Support as part of the already existing Maven profile that runs Error Prone. The reason for this is that Error Prone Support is an extension and "just adds some checks". Configuration wise, this is the simplest. The only difference the user could notice is that the documentation URL from the Error Prone Support checks are slightly different. See an example below.

Error from an Error Prone check from Google:
> Error:  /home/runner/work/checkstyle/checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocNodeImpl.java:[183,51] [ArrayHashCode] hashcode method on array does not hash array contents
    (see https://errorprone.info/bugpattern/ArrayHashCode)

Error from an Error Prone check from Error Prone Support:
> Error:  /home/runner/work/checkstyle/checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/checks/TranslationCheck.java:[257,88] [CollectorMutability] Avoid `Collectors.to{List,Map,Set}` in favor of collectors that emphasize (im)mutability
    (see https://error-prone.picnic.tech/bugpatterns/CollectorMutability)

Checkstyle is configured to only consider checks that have `SeverityLevel.ERROR`, see [here](https://github.com/checkstyle/checkstyle/blob/master/.ci/error-prone-check.groovy#L89). In Error Prone Support there are 3 checks with error severity. So adding the tool itself requires changes only in the `pom.xml`.
Now we can simply increase the severity of Error Prone Support checks as follows:
```
-Xplugin:ErrorProne -Xep:CollectorMutability:ERROR
```

In the follow up issue (https://github.com/checkstyle/checkstyle/issues/14137) we can discuss which checks we want to enable. I'm definitely open to creating PRs for that!
