### PR TITLE
Issue: #14120 Automatic Module

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1557,6 +1557,9 @@
               <addDefaultImplementationEntries>true</addDefaultImplementationEntries>
               <addDefaultSpecificationEntries>true</addDefaultSpecificationEntries>
             </manifest>
+            <manifestEntries>
+              <Automatic-Module-Name>${project.groupId}.${project.artifactId}</Automatic-Module-Name>
+            </manifestEntries>
           </archive>
           <excludes>
             <exclude>**/Input*.*</exclude>


### PR DESCRIPTION
Part of #14120 
Added `Automatic-Module-Name` to `MANIFEST.MF`.

When using Checkstyle as a dependency (e.g. when implementing own checks), this will fix the warnings issued by the Java compiler and by Maven about an unstable automatic module name that is derived from the file name.

With this change, Checkstyle is still treated as an automatic module (as before) but with a stable name.