### PR TITLE
Issue #14123: Remove transitive google-collections dependency

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -412,6 +412,10 @@
           <groupId>commons-codec</groupId>
           <artifactId>commons-codec</artifactId>
         </exclusion>
+        <exclusion>
+          <groupId>com.google.collections</groupId>
+          <artifactId>google-collections</artifactId>
+        </exclusion>
       </exclusions>
     </dependency>
     <dependency>


### PR DESCRIPTION
fixes Issue number: #14123 by excluding the dependency below doxia-core

before:
```
[INFO] --- dependency:3.6.1:tree (default-cli) @ checkstyle ---
[INFO] com.puppycrawl.tools:checkstyle:jar:10.12.7-SNAPSHOT
(...)
[INFO] +- org.apache.maven.doxia:doxia-core:jar:1.12.0:compile
[INFO] |  +- org.apache.maven.doxia:doxia-sink-api:jar:1.12.0:compile
[INFO] |  +- org.apache.maven.doxia:doxia-logging-api:jar:1.12.0:compile
[INFO] |  +- org.codehaus.plexus:plexus-utils:jar:3.3.0:compile
[INFO] |  +- org.codehaus.plexus:plexus-container-default:jar:2.1.0:compile
[INFO] |  |  +- org.codehaus.plexus:plexus-classworlds:jar:2.6.0:compile
[INFO] |  |  +- org.apache.xbean:xbean-reflect:jar:3.7:compile
[INFO] |  |  \- com.google.collections:google-collections:jar:1.0:compile
[INFO] |  +- org.codehaus.plexus:plexus-component-annotations:jar:2.1.0:compile
(...)
```

after:
```[INFO] --- dependency:3.6.1:tree (default-cli) @ checkstyle ---
[INFO] com.puppycrawl.tools:checkstyle:jar:10.12.7-SNAPSHOT
(...)
[INFO] +- org.apache.maven.doxia:doxia-core:jar:1.12.0:compile
[INFO] |  +- org.apache.maven.doxia:doxia-sink-api:jar:1.12.0:compile
[INFO] |  +- org.apache.maven.doxia:doxia-logging-api:jar:1.12.0:compile
[INFO] |  +- org.codehaus.plexus:plexus-utils:jar:3.3.0:compile
[INFO] |  +- org.codehaus.plexus:plexus-container-default:jar:2.1.0:compile
[INFO] |  |  +- org.codehaus.plexus:plexus-classworlds:jar:2.6.0:compile
[INFO] |  |  \- org.apache.xbean:xbean-reflect:jar:3.7:compile
[INFO] |  +- org.codehaus.plexus:plexus-component-annotations:jar:2.1.0:compile
(...)
```

an alternative could be to upgrade all the doxia dependencies to a more recent version