### PR TITLE
Issue #12586: Refactor test method to execute Check only once for AbsractJavadocCheckTest

### DIFF
--- a/src/test/java/com/puppycrawl/tools/checkstyle/AbstractModuleTestSupport.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/AbstractModuleTestSupport.java
@@ -299,6 +299,24 @@ public abstract class AbstractModuleTestSupport extends AbstractPathTestSupport 
     }
 
     /**
+     * Performs verification of the file with the given file path using specified configuration
+     * and the array of expected messages. Unlike verifyWithInlineConfigParser, this method
+     * does not perform an additional verification step, thereby executing the Check only once.
+     *
+     * @param filePath file path to verify.
+     * @param expected an array of expected messages.
+     * @throws Exception if exception occurs during verification process.
+     */
+    protected final void verifyOnceWithInlineConfigParser(String filePath, String... expected)
+            throws Exception {
+        final TestInputConfiguration testInputConfiguration =
+                InlineConfigParser.parse(filePath);
+        final DefaultConfiguration parsedConfig =
+                testInputConfiguration.createConfiguration();
+        verifyViolations(parsedConfig, filePath, testInputConfiguration.getViolations());
+    }
+
+    /**
      * Performs verification of the file with the given file name. Uses specified configuration.
      * Expected messages are represented by the array of strings.
      * This implementation uses overloaded

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/javadoc/AbstractJavadocCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/javadoc/AbstractJavadocCheckTest.java
@@ -185,25 +185,21 @@ public class AbstractJavadocCheckTest extends AbstractModuleTestSupport {
     public void testPosition() throws Exception {
         JavadocCatchCheck.clearCounter();
         final String[] expected = CommonUtil.EMPTY_STRING_ARRAY;
-        verifyWithInlineConfigParser(getPath("InputAbstractJavadocPosition.java"), expected);
+        verifyOnceWithInlineConfigParser(getPath("InputAbstractJavadocPosition.java"), expected);
         assertWithMessage("Invalid number of javadocs")
             .that(JavadocCatchCheck.javadocsNumber)
-            // until https://github.com/checkstyle/checkstyle/issues/12586
-            // actual javadoc count is 65, but verifyWithInlineConfigParser verify file twice
-            .isEqualTo(130);
+            .isEqualTo(65);
     }
 
     @Test
     public void testPositionWithSinglelineComments() throws Exception {
         JavadocCatchCheck.clearCounter();
         final String[] expected = CommonUtil.EMPTY_STRING_ARRAY;
-        verifyWithInlineConfigParser(
+        verifyOnceWithInlineConfigParser(
                 getPath("InputAbstractJavadocPositionWithSinglelineComments.java"), expected);
         assertWithMessage("Invalid number of javadocs")
             .that(JavadocCatchCheck.javadocsNumber)
-            // until https://github.com/checkstyle/checkstyle/issues/12586
-            // actual javadoc count is 65, but verifyWithInlineConfigParser verify file twice
-            .isEqualTo(130);
+            .isEqualTo(65);
     }
 
     @Test


### PR DESCRIPTION
Issue #12586 

This commit resolves an issue where the Check was being executed twice in the 2 test methods of class `AbstractJavadocCheckTest`.  This was due to the `verifyWithInlineConfigParser` method running the Check twice. 

This change ensures that the test methods now expects the correct number of Javadocs, fixing the error in the test.

_Alternatively we can - 
Overload the 'verifyWithInlineConfigParser' method and add only one argument - (String filePath). Please let me know which way will suit us more._