### PR TITLE
Issue #11446: Update AllBlockCommentsTest to use execute

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1828,7 +1828,6 @@
                 <exclude>**/DetailAstImplTest.class</exclude>
                 <exclude>**/TreeWalkerTest.class</exclude>
                 <exclude>**/CheckerTest.class</exclude>
-                <exclude>**/AllBlockCommentsTest.class</exclude>
               </excludes>
             </configuration>
           </execution>

--- a/src/test/java/com/puppycrawl/tools/checkstyle/grammar/comments/AllBlockCommentsTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/grammar/comments/AllBlockCommentsTest.java
@@ -34,7 +34,6 @@ import com.puppycrawl.tools.checkstyle.api.AbstractCheck;
 import com.puppycrawl.tools.checkstyle.api.DetailAST;
 import com.puppycrawl.tools.checkstyle.api.TokenTypes;
 import com.puppycrawl.tools.checkstyle.internal.utils.CheckUtil;
-import com.puppycrawl.tools.checkstyle.utils.CommonUtil;
 
 public class AllBlockCommentsTest extends AbstractModuleTestSupport {
 
@@ -53,8 +52,7 @@ public class AllBlockCommentsTest extends AbstractModuleTestSupport {
                 createModuleConfig(BlockCommentListenerCheck.class);
         final String path = getPath("InputFullOfBlockComments.java");
         lineSeparator = CheckUtil.getLineSeparatorForFile(path, StandardCharsets.UTF_8);
-        final String[] expected = CommonUtil.EMPTY_STRING_ARRAY;
-        verify(checkConfig, path, expected);
+        execute(checkConfig, path);
         assertWithMessage("All comments should be empty")
             .that(ALL_COMMENTS)
             .isEmpty();


### PR DESCRIPTION
Issue #11446 

Here we have used `execute` taking reference from https://github.com/checkstyle/checkstyle/blob/54616f662130aa0ca5afe45f72d36cdefb78a781/src/test/java/com/puppycrawl/tools/checkstyle/grammar/comments/AllSinglelineCommentsTest.java