### PR TITLE
Issue #13307: support for 'X violations above:'

### DIFF
--- a/src/test/java/com/puppycrawl/tools/checkstyle/bdd/InlineConfigParser.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/bdd/InlineConfigParser.java
@@ -53,7 +53,7 @@ public final class InlineConfigParser {
 
     /**
      * Pattern for lines under
-     * {@link InlineConfigParser#MULTIPLE_VIOLATIONS_SOME_LINES_ABOVE_PATTERN}.
+     * {@link InlineConfigParser#VIOLATIONS_SOME_LINES_ABOVE_PATTERN}.
      */
     private static final Pattern VIOLATION_MESSAGE_PATTERN = Pattern
             .compile(".*//\\s*(?:['\"](.*)['\"])?$");
@@ -159,7 +159,7 @@ public final class InlineConfigParser {
      * Messages are matched by {@link InlineConfigParser#VIOLATION_MESSAGE_PATTERN}
      * </p>
      */
-    private static final Pattern MULTIPLE_VIOLATIONS_SOME_LINES_ABOVE_PATTERN = Pattern
+    private static final Pattern VIOLATIONS_SOME_LINES_ABOVE_PATTERN = Pattern
             .compile(".*//\\s*(\\d+) violations (\\d+) lines above:$");
 
     /** The String "(null)". */
@@ -519,10 +519,10 @@ public final class InlineConfigParser {
                 VIOLATION_SOME_LINES_ABOVE_PATTERN.matcher(lines.get(lineNo));
         final Matcher violationSomeLinesBelowMatcher =
                 VIOLATION_SOME_LINES_BELOW_PATTERN.matcher(lines.get(lineNo));
-        final Matcher multipleViolationsAboveMatcherWithMessages =
+        final Matcher violationsAboveMatcherWithMessages =
                 VIOLATIONS_ABOVE_PATTERN_WITH_MESSAGES.matcher(lines.get(lineNo));
-        final Matcher multipleViolationsSomeLinesAboveMatcher =
-                MULTIPLE_VIOLATIONS_SOME_LINES_ABOVE_PATTERN.matcher(lines.get(lineNo));
+        final Matcher violationsSomeLinesAboveMatcher =
+                VIOLATIONS_SOME_LINES_ABOVE_PATTERN.matcher(lines.get(lineNo));
         if (violationMatcher.matches()) {
             final String violationMessage = violationMatcher.group(1);
             final int violationLineNum = lineNo + 1;
@@ -577,15 +577,15 @@ public final class InlineConfigParser {
                     violationLineNum);
             inputConfigBuilder.addViolation(violationLineNum, violationMessage);
         }
-        else if (multipleViolationsAboveMatcherWithMessages.matches()) {
+        else if (violationsAboveMatcherWithMessages.matches()) {
             inputConfigBuilder.addViolations(
-                getExpectedMultipleViolationsForSpecificLineAbove(
-                    lines, lineNo, lineNo, multipleViolationsAboveMatcherWithMessages));
+                getExpectedViolationsForSpecificLineAbove(
+                    lines, lineNo, lineNo, violationsAboveMatcherWithMessages));
         }
-        else if (multipleViolationsSomeLinesAboveMatcher.matches()) {
+        else if (violationsSomeLinesAboveMatcher.matches()) {
             inputConfigBuilder.addViolations(
-                getExpectedMultipleViolations(
-                    lines, lineNo, multipleViolationsSomeLinesAboveMatcher));
+                getExpectedViolations(
+                    lines, lineNo, violationsSomeLinesAboveMatcher));
         }
         else if (multipleViolationsMatcher.matches()) {
             Collections
@@ -615,7 +615,7 @@ public final class InlineConfigParser {
         }
     }
 
-    private static List<TestInputViolation> getExpectedMultipleViolationsForSpecificLineAbove(
+    private static List<TestInputViolation> getExpectedViolationsForSpecificLineAbove(
                                               List<String> lines, int lineNo, int violationLineNum,
                                               Matcher matcher) {
         final List<TestInputViolation> results = new ArrayList<>();
@@ -639,13 +639,13 @@ public final class InlineConfigParser {
         return results;
     }
 
-    private static List<TestInputViolation> getExpectedMultipleViolations(
+    private static List<TestInputViolation> getExpectedViolations(
                                               List<String> lines, int lineNo,
                                               Matcher matcher) {
         final int linesAbove =
             Integer.parseInt(matcher.group(2));
         final int violationLineNum = lineNo - linesAbove + 1;
-        return getExpectedMultipleViolationsForSpecificLineAbove(lines,
+        return getExpectedViolationsForSpecificLineAbove(lines,
             lineNo, violationLineNum, matcher);
     }
 

--- a/src/test/java/com/puppycrawl/tools/checkstyle/bdd/InlineConfigParser.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/bdd/InlineConfigParser.java
@@ -134,6 +134,21 @@ public final class InlineConfigParser {
 
     /**
      * <p>
+     * Multiple violations for above line. Messages are X lines below.
+     * {@code
+     *   // X violations above:
+     *   //                    'violation message1'
+     *   //                    'violation messageX'
+     * }
+     *
+     * Messages are matched by {@link InlineConfigParser#VIOLATION_MESSAGE_PATTERN}
+     * </p>
+     */
+    private static final Pattern VIOLATIONS_ABOVE_PATTERN_WITH_MESSAGES = Pattern
+            .compile(".*//\\s*(\\d+) violations above:$");
+
+    /**
+     * <p>
      * Multiple violations for line. Violations are Y lines above, messages are X lines below.
      * {@code
      *   // X violations Y lines above:
@@ -145,7 +160,7 @@ public final class InlineConfigParser {
      * </p>
      */
     private static final Pattern MULTIPLE_VIOLATIONS_SOME_LINES_ABOVE_PATTERN = Pattern
-            .compile(".*//\\s*(\\d+) violations (\\d+) lines above:\\s*(?:['\"](.*)['\"])?$");
+            .compile(".*//\\s*(\\d+) violations (\\d+) lines above:$");
 
     /** The String "(null)". */
     private static final String NULL_STRING = "(null)";
@@ -504,6 +519,8 @@ public final class InlineConfigParser {
                 VIOLATION_SOME_LINES_ABOVE_PATTERN.matcher(lines.get(lineNo));
         final Matcher violationSomeLinesBelowMatcher =
                 VIOLATION_SOME_LINES_BELOW_PATTERN.matcher(lines.get(lineNo));
+        final Matcher multipleViolationsAboveMatcherWithMessages =
+                VIOLATIONS_ABOVE_PATTERN_WITH_MESSAGES.matcher(lines.get(lineNo));
         final Matcher multipleViolationsSomeLinesAboveMatcher =
                 MULTIPLE_VIOLATIONS_SOME_LINES_ABOVE_PATTERN.matcher(lines.get(lineNo));
         if (violationMatcher.matches()) {
@@ -560,6 +577,11 @@ public final class InlineConfigParser {
                     violationLineNum);
             inputConfigBuilder.addViolation(violationLineNum, violationMessage);
         }
+        else if (multipleViolationsAboveMatcherWithMessages.matches()) {
+            inputConfigBuilder.addViolations(
+                getExpectedMultipleViolationsForSpecificLineAbove(
+                    lines, lineNo, lineNo, multipleViolationsAboveMatcherWithMessages));
+        }
         else if (multipleViolationsSomeLinesAboveMatcher.matches()) {
             inputConfigBuilder.addViolations(
                 getExpectedMultipleViolations(
@@ -593,13 +615,10 @@ public final class InlineConfigParser {
         }
     }
 
-    private static List<TestInputViolation> getExpectedMultipleViolations(
-                                              List<String> lines, int lineNo,
+    private static List<TestInputViolation> getExpectedMultipleViolationsForSpecificLineAbove(
+                                              List<String> lines, int lineNo, int violationLineNum,
                                               Matcher matcher) {
         final List<TestInputViolation> results = new ArrayList<>();
-        final int linesAbove =
-            Integer.parseInt(matcher.group(2));
-        final int violationLineNum = lineNo - linesAbove + 1;
 
         final int expectedMessageCount =
             Integer.parseInt(matcher.group(1));
@@ -618,6 +637,16 @@ public final class InlineConfigParser {
             throw new IllegalStateException(message);
         }
         return results;
+    }
+
+    private static List<TestInputViolation> getExpectedMultipleViolations(
+                                              List<String> lines, int lineNo,
+                                              Matcher matcher) {
+        final int linesAbove =
+            Integer.parseInt(matcher.group(2));
+        final int violationLineNum = lineNo - linesAbove + 1;
+        return getExpectedMultipleViolationsForSpecificLineAbove(lines,
+            lineNo, violationLineNum, matcher);
     }
 
     private static void setFilteredViolation(TestInputConfiguration.Builder inputConfigBuilder,

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/abstractjavadoc/InputAbstractJavadocNonTightHtmlTags2.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/abstractjavadoc/InputAbstractJavadocNonTightHtmlTags2.java
@@ -28,14 +28,14 @@ package com.puppycrawl.tools.checkstyle.checks.javadoc.abstractjavadoc;
 
 public class InputAbstractJavadocNonTightHtmlTags2 {
     /** <p> <p> paraception </p> </p> */
-    // 3 violations above
+    // 3 violations above:
     //                    'Unclosed HTML tag found: p'
     //                    'tag P_TAG_START'
     //                    'tag P_TAG_START'
     private int field1;
 
     /**<li> paraTags should be opened</p> list isn't nested in parse tree </li>*/
-    // 2 violations above
+    // 2 violations above:
     //                    'Unclosed HTML tag found: li'
     //                    'tag LI_TAG_START'
     private int field2;


### PR DESCRIPTION
Fixes #13307

VIOLATIONS_ABOVE_PATTERN_WITH_MESSAGES was MULTIPLE_VIOLATIONS_ABOVE_PATTERN_WITH_MESSAGES but PMD complained on length, it kind of right, so I removed MULTIPLE_.