### PR TITLE
Issue #13999: Resolve pitest suppression for skipHtmlComment() method of TagParser

### DIFF
--- a/config/pitest-suppressions/pitest-javadoc-suppressions.xml
+++ b/config/pitest-suppressions/pitest-javadoc-suppressions.xml
@@ -234,12 +234,4 @@
     <lineContent>return astType == TokenTypes.VARIABLE_DEF</lineContent>
   </mutation>
 
-  <mutation unstable="false">
-    <sourceFile>TagParser.java</sourceFile>
-    <mutatedClass>com.puppycrawl.tools.checkstyle.checks.javadoc.TagParser</mutatedClass>
-    <mutatedMethod>skipHtmlComment</mutatedMethod>
-    <mutator>org.pitest.mutationtest.engine.gregor.mutators.experimental.ArgumentPropagationMutator</mutator>
-    <description>replaced call to com/puppycrawl/tools/checkstyle/checks/javadoc/TagParser::findChar with argument</description>
-    <lineContent>toPoint = findChar(text, &apos;&gt;&apos;, getNextPoint(text, toPoint));</lineContent>
-  </mutation>
 </suppressedMutations>

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/TagParser.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/TagParser.java
@@ -214,7 +214,7 @@ class TagParser {
         Point toPoint = fromPoint;
         while (toPoint.getLineNo() < text.length && !text[toPoint.getLineNo()]
                 .substring(0, toPoint.getColumnNo() + 1).endsWith("-->")) {
-            toPoint = findChar(text, '>', getNextPoint(text, toPoint));
+            toPoint = getNextPoint(text, toPoint);
         }
         return toPoint;
     }


### PR DESCRIPTION
Issue #13999 

### Dependency Tree 

```
TagParser.TagParser(String[], int)  (com.puppycrawl.tools.checkstyle.checks.javadoc)
    JavadocStyleCheck.checkHtmlTags(DetailAST, TextBlock)  (com.puppycrawl.tools.checkstyle.checks.javadoc)
        JavadocStyleCheck.checkComment(DetailAST, TextBlock)  (com.puppycrawl.tools.checkstyle.checks.javadoc)
            JavadocStyleCheck.visitToken(DetailAST)  (com.puppycrawl.tools.checkstyle.checks.javadoc)
                TreeWalker.notifyVisit(DetailAST, AstState)  (com.puppycrawl.tools.checkstyle)
                 TestUtil.isStatefulFieldClearedDuringBeginTree(AbstractCheck, DetailAST, String, Predicate<Object>)  (com.puppycrawl.tools.checkstyle.internal.utils)
```

### Module

1. JavadocStyleCheck

Diff Regression config: https://gist.githubusercontent.com/suniti0804/466108cc17f588f2311aa2d4f40b60bb/raw/f1a067202e11a4639696c0779f36574e4a81000d/pull-14033-regerssion-config

Diff Regression projects: https://gist.githubusercontent.com/suniti0804/1d7bd7fbc50bf6c93896fbe2bbbf2c4a/raw/f71611ef97d0737b6d8bb1c1253cab18b9342429/projects-to-test-on-for-github-action.properties

Report label: Issue#14181-Report
                       