### PR TITLE
Issue #13999: Resolve pitest suppression for getTagId() method of TagParser

### DIFF
--- a/config/pitest-suppressions/pitest-javadoc-suppressions.xml
+++ b/config/pitest-suppressions/pitest-javadoc-suppressions.xml
@@ -292,33 +292,6 @@
     <sourceFile>TagParser.java</sourceFile>
     <mutatedClass>com.puppycrawl.tools.checkstyle.checks.javadoc.TagParser</mutatedClass>
     <mutatedMethod>getTagId</mutatedMethod>
-    <mutator>org.pitest.mutationtest.engine.gregor.mutators.NonVoidMethodCallMutator</mutator>
-    <description>removed call to java/lang/Character::isJavaIdentifierStart</description>
-    <lineContent>&amp;&amp; (Character.isJavaIdentifierStart(text.charAt(position))</lineContent>
-  </mutation>
-
-  <mutation unstable="false">
-    <sourceFile>TagParser.java</sourceFile>
-    <mutatedClass>com.puppycrawl.tools.checkstyle.checks.javadoc.TagParser</mutatedClass>
-    <mutatedMethod>getTagId</mutatedMethod>
-    <mutator>org.pitest.mutationtest.engine.gregor.mutators.NonVoidMethodCallMutator</mutator>
-    <description>removed call to java/lang/String::charAt</description>
-    <lineContent>&amp;&amp; (Character.isJavaIdentifierStart(text.charAt(position))</lineContent>
-  </mutation>
-
-  <mutation unstable="false">
-    <sourceFile>TagParser.java</sourceFile>
-    <mutatedClass>com.puppycrawl.tools.checkstyle.checks.javadoc.TagParser</mutatedClass>
-    <mutatedMethod>getTagId</mutatedMethod>
-    <mutator>org.pitest.mutationtest.engine.gregor.mutators.RemoveConditionalMutator_EQUAL_IF</mutator>
-    <description>removed conditional - replaced equality check with true</description>
-    <lineContent>&amp;&amp; (Character.isJavaIdentifierStart(text.charAt(position))</lineContent>
-  </mutation>
-
-  <mutation unstable="false">
-    <sourceFile>TagParser.java</sourceFile>
-    <mutatedClass>com.puppycrawl.tools.checkstyle.checks.javadoc.TagParser</mutatedClass>
-    <mutatedMethod>getTagId</mutatedMethod>
     <mutator>org.pitest.mutationtest.engine.gregor.mutators.experimental.NakedReceiverMutator</mutator>
     <description>replaced call to java/lang/String::trim with receiver</description>
     <lineContent>text = text.substring(column).trim();</lineContent>

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/TagParser.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/TagParser.java
@@ -183,8 +183,7 @@ class TagParser {
             // Character.isJavaIdentifier... may not be a valid HTML
             // identifier but is valid for generics
             while (position < text.length()
-                    && (Character.isJavaIdentifierStart(text.charAt(position))
-                        || Character.isJavaIdentifierPart(text.charAt(position)))) {
+                    && Character.isJavaIdentifierPart(text.charAt(position))) {
                 position++;
             }
 


### PR DESCRIPTION
Issue #13999 

### Dependency Tree

```
TagParser.parseTags(String[], int)  (com.puppycrawl.tools.checkstyle.checks.javadoc)
    TagParser.TagParser(String[], int)  (com.puppycrawl.tools.checkstyle.checks.javadoc)
        JavadocStyleCheck.checkHtmlTags(DetailAST, TextBlock)  (com.puppycrawl.tools.checkstyle.checks.javadoc)
            JavadocStyleCheck.checkComment(DetailAST, TextBlock)  (com.puppycrawl.tools.checkstyle.checks.javadoc)
                JavadocStyleCheck.visitToken(DetailAST)  (com.puppycrawl.tools.checkstyle.checks.javadoc)
                    TreeWalker.notifyVisit(DetailAST, AstState)  (com.puppycrawl.tools.checkstyle)
                    TestUtil.isStatefulFieldClearedDuringBeginTree(AbstractCheck, DetailAST, String, Predicate<Object>)  (com.puppycrawl.tools.checkstyle.internal.utils)
```


### Module
1. JavadocStyleCheck


Diff Regression config: https://gist.githubusercontent.com/suniti0804/466108cc17f588f2311aa2d4f40b60bb/raw/f1a067202e11a4639696c0779f36574e4a81000d/pull-14033-regerssion-config

Diff Regression projects: https://gist.githubusercontent.com/suniti0804/1d7bd7fbc50bf6c93896fbe2bbbf2c4a/raw/f71611ef97d0737b6d8bb1c1253cab18b9342429/projects-to-test-on-for-github-action.properties

Report label: Issue#14189-Report