### PR TITLE
Issue #14137: Disable Error Prone Support checks

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -237,6 +237,20 @@
     <error-prone.version>2.24.0</error-prone.version>
     <error-prone-support.version>0.14.0</error-prone-support.version>
     <doxia.version>1.12.0</doxia.version>
+    <error-prone.configuration-args>
+      <!-- Reason at https://github.com/checkstyle/checkstyle/issues/8252. -->
+      -Xep:JUnitClassModifiers:OFF
+      <!-- Reason at https://github.com/checkstyle/checkstyle/issues/8252. -->
+      -Xep:JUnitMethodDeclaration:OFF
+      <!-- We prefer different style of writing tests. -->
+      -Xep:JUnitValueSource:OFF
+      <!-- Until https://github.com/checkstyle/checkstyle/issues/14194. -->
+      -Xep:LexicographicalAnnotationListing:OFF
+      <!-- This check is not finalized. -->
+      -Xep:MethodReferenceUsage:OFF
+      <!-- We prefer to qualify all static method calls with class name. -->
+      -Xep:StaticImport:OFF
+    </error-prone.configuration-args>
   </properties>
 
   <dependencies>
@@ -2380,7 +2394,7 @@
                     <arg>-Xpkginfo:always</arg>
                     <arg>-XDcompilePolicy=simple</arg>
                     <arg>
-                      -Xplugin:ErrorProne
+                      -Xplugin:ErrorProne ${error-prone.configuration-args}
                     </arg>
                   </compilerArgs>
                   <annotationProcessorPaths>
@@ -2438,7 +2452,8 @@
                     <arg>-XDcompilePolicy=simple</arg>
                     <arg>
                       -Xplugin:ErrorProne \
-                      -XepExcludedPaths:.*[\\/]resources[\\/].*
+                      -XepExcludedPaths:.*[\\/]resources[\\/].* \
+                      ${error-prone.configuration-args}
                     </arg>
                   </compilerArgs>
                   <annotationProcessorPaths>
@@ -2451,7 +2466,7 @@
                       <groupId>tech.picnic.error-prone-support</groupId>
                       <artifactId>error-prone-contrib</artifactId>
                       <version>${error-prone-support.version}</version>
-                    </path>b
+                    </path>
                   </annotationProcessorPaths>
                 </configuration>
               </execution>


### PR DESCRIPTION
Related issue https://github.com/checkstyle/checkstyle/issues/14137.

This PR disables a few checks from Error Prone Support. Additionally, the goal of this PR is to agree on how we are going to configure the rest of the checks in the `pom.xml`. If we, at some point, decide to either disable or enable more checks from Error Prone itself that have severity `WARN` or `INFO` we can do that in the same configuration section (see [docs](https://errorprone.info/bugpatterns)).

At Picnic we have the convention to add a comment for every rule explaining why we disable it. If we would like the same here, I need your help to write the correct reasoning :). We can also decide to leave it like this. For now, I disabled two extra rules that are that will cause more noise than improvements.

[In the previous PR](https://github.com/checkstyle/checkstyle/pull/14136#issuecomment-1853104700) @rnveach mentioned:

> Log file jumped from 100 kb to 2.5 megs in this PR.  

With disabling these checks we are down to normal numbers again.

More PRs to follow :rocket:!
