### PR TITLE
Issue #14216: CustomImportOrder property 'customImportOrderRules' should be String[]

### DIFF
--- a/config/checkstyle-input-suppressions.xml
+++ b/config/checkstyle-input-suppressions.xml
@@ -47,6 +47,8 @@
   <suppress id="noCheckstyleInInputs"
             files="[\\/]checks[\\/]imports[\\/]customimportorder[\\/]InputCustomImportOrderSingleLine.java"/>
   <suppress id="noCheckstyleInInputs"
+            files="[\\/]checks[\\/]imports[\\/]customimportorder[\\/]InputCustomImportOrderSingleLineList.java"/>
+  <suppress id="noCheckstyleInInputs"
             files="[\\/]checks[\\/]imports[\\/]customimportorder[\\/]InputCustomImportOrderSpanMultipleLines.java"/>
   <suppress id="noCheckstyleInInputs"
             files="[\\/]checks[\\/]imports[\\/]customimportorder[\\/]InputCustomImportOrder_OverlappingPatterns.java"/>

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/imports/CustomImportOrderCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/imports/CustomImportOrderCheck.java
@@ -20,6 +20,7 @@
 package com.puppycrawl.tools.checkstyle.checks.imports;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 import java.util.StringTokenizer;
 import java.util.regex.Matcher;
@@ -82,7 +83,11 @@ import com.puppycrawl.tools.checkstyle.utils.CommonUtil;
  * </li>
  * </ol>
  * <p>
- * Use the separator '###' between rules.
+ * Rules are configured as a comma-separated ordered list.
+ * </p>
+ * <p>
+ * Note: '###' group separator is deprecated (in favor of a comma-separated list),
+ * but is currently supported for backward compatibility.
  * </p>
  * <p>
  * To set RegExps for THIRD_PARTY_PACKAGE and STANDARD_JAVA_PACKAGE groups use
@@ -135,9 +140,8 @@ import com.puppycrawl.tools.checkstyle.utils.CommonUtil;
  * </p>
  * <ul>
  * <li>
- * Property {@code customImportOrderRules} - Specify format of order declaration
- * customizing by user.
- * Type is {@code java.lang.String}.
+ * Property {@code customImportOrderRules} - Specify ordered list of import groups.
+ * Type is {@code java.lang.String[]}.
  * Default value is {@code ""}.
  * </li>
  * <li>
@@ -257,11 +261,8 @@ public class CustomImportOrderCheck extends AbstractCheck {
     /** Pattern used to separate groups of imports. */
     private static final Pattern GROUP_SEPARATOR_PATTERN = Pattern.compile("\\s*###\\s*");
 
-    /** Specify format of order declaration customizing by user. */
-    private static final String DEFAULT_CUSTOM_IMPORT_ORDER_RULES = "";
-
-    /** Processed list of import order rules. */
-    private final List<String> customOrderRules = new ArrayList<>();
+    /** Specify ordered list of import groups. */
+    private final List<String> customImportOrderRules = new ArrayList<>();
 
     /** Contains objects with import attributes. */
     private final List<ImportDetails> importToGroupList = new ArrayList<>();
@@ -347,19 +348,19 @@ public class CustomImportOrderCheck extends AbstractCheck {
     }
 
     /**
-     * Setter to specify format of order declaration customizing by user.
+     * Setter to specify ordered list of import groups.
      *
-     * @param inputCustomImportOrder
+     * @param rules
      *        user value.
      * @since 5.8
      */
-    public final void setCustomImportOrderRules(final String inputCustomImportOrder) {
-        if (!DEFAULT_CUSTOM_IMPORT_ORDER_RULES.equals(inputCustomImportOrder)) {
-            for (String currentState : GROUP_SEPARATOR_PATTERN.split(inputCustomImportOrder)) {
-                addRulesToList(currentState);
-            }
-            customOrderRules.add(NON_GROUP_RULE_GROUP);
-        }
+    public final void setCustomImportOrderRules(String... rules) {
+        Arrays.stream(rules)
+                .map(GROUP_SEPARATOR_PATTERN::split)
+                .flatMap(Arrays::stream)
+                .forEach(this::addRulesToList);
+
+        customImportOrderRules.add(NON_GROUP_RULE_GROUP);
     }
 
     @Override
@@ -410,7 +411,7 @@ public class CustomImportOrderCheck extends AbstractCheck {
     /** Examine the order of all the imports and log any violations. */
     private void finishImportList() {
         String currentGroup = getFirstGroup();
-        int currentGroupNumber = customOrderRules.lastIndexOf(currentGroup);
+        int currentGroupNumber = customImportOrderRules.lastIndexOf(currentGroup);
         ImportDetails previousImportObjectFromCurrentGroup = null;
         String previousImportFromCurrentGroup = null;
 
@@ -432,13 +433,13 @@ public class CustomImportOrderCheck extends AbstractCheck {
             }
             else {
                 // not the last group, last one is always NON_GROUP
-                if (customOrderRules.size() > currentGroupNumber + 1) {
+                if (customImportOrderRules.size() > currentGroupNumber + 1) {
                     final String nextGroup = getNextImportGroup(currentGroupNumber + 1);
                     if (importGroup.equals(nextGroup)) {
                         validateMissedEmptyLine(previousImportObjectFromCurrentGroup,
                                 importObject, fullImportIdent);
                         currentGroup = nextGroup;
-                        currentGroupNumber = customOrderRules.lastIndexOf(nextGroup);
+                        currentGroupNumber = customImportOrderRules.lastIndexOf(nextGroup);
                         previousImportFromCurrentGroup = fullImportIdent;
                     }
                     else {
@@ -584,13 +585,13 @@ public class CustomImportOrderCheck extends AbstractCheck {
     private String getNextImportGroup(int currentGroupNumber) {
         int nextGroupNumber = currentGroupNumber;
 
-        while (customOrderRules.size() > nextGroupNumber + 1) {
-            if (hasAnyImportInCurrentGroup(customOrderRules.get(nextGroupNumber))) {
+        while (customImportOrderRules.size() > nextGroupNumber + 1) {
+            if (hasAnyImportInCurrentGroup(customImportOrderRules.get(nextGroupNumber))) {
                 break;
             }
             nextGroupNumber++;
         }
-        return customOrderRules.get(nextGroupNumber);
+        return customImportOrderRules.get(nextGroupNumber);
     }
 
     /**
@@ -623,11 +624,11 @@ public class CustomImportOrderCheck extends AbstractCheck {
      */
     private String getImportGroup(boolean isStatic, String importPath) {
         RuleMatchForImport bestMatch = new RuleMatchForImport(NON_GROUP_RULE_GROUP, 0, 0);
-        if (isStatic && customOrderRules.contains(STATIC_RULE_GROUP)) {
+        if (isStatic && customImportOrderRules.contains(STATIC_RULE_GROUP)) {
             bestMatch.group = STATIC_RULE_GROUP;
             bestMatch.matchLength = importPath.length();
         }
-        else if (customOrderRules.contains(SAME_PACKAGE_RULE_GROUP)) {
+        else if (customImportOrderRules.contains(SAME_PACKAGE_RULE_GROUP)) {
             final String importPathTrimmedToSamePackageDepth =
                     getFirstDomainsFromIdent(samePackageMatchingDepth, importPath);
             if (samePackageDomainsRegExp.equals(importPathTrimmedToSamePackageDepth)) {
@@ -635,7 +636,7 @@ public class CustomImportOrderCheck extends AbstractCheck {
                 bestMatch.matchLength = importPath.length();
             }
         }
-        for (String group : customOrderRules) {
+        for (String group : customImportOrderRules) {
             if (STANDARD_JAVA_PACKAGE_RULE_GROUP.equals(group)) {
                 bestMatch = findBetterPatternMatch(importPath,
                         STANDARD_JAVA_PACKAGE_RULE_GROUP, standardPackageRegExp, bestMatch);
@@ -647,7 +648,7 @@ public class CustomImportOrderCheck extends AbstractCheck {
         }
 
         if (NON_GROUP_RULE_GROUP.equals(bestMatch.group)
-                && customOrderRules.contains(THIRD_PARTY_PACKAGE_RULE_GROUP)
+                && customImportOrderRules.contains(THIRD_PARTY_PACKAGE_RULE_GROUP)
                 && thirdPartyPackageRegExp.matcher(importPath).find()) {
             bestMatch.group = THIRD_PARTY_PACKAGE_RULE_GROUP;
         }
@@ -766,7 +767,7 @@ public class CustomImportOrderCheck extends AbstractCheck {
                 || THIRD_PARTY_PACKAGE_RULE_GROUP.equals(ruleStr)
                 || STANDARD_JAVA_PACKAGE_RULE_GROUP.equals(ruleStr)
                 || SPECIAL_IMPORTS_RULE_GROUP.equals(ruleStr)) {
-            customOrderRules.add(ruleStr);
+            customImportOrderRules.add(ruleStr);
         }
         else if (ruleStr.startsWith(SAME_PACKAGE_RULE_GROUP)) {
             final String rule = ruleStr.substring(ruleStr.indexOf('(') + 1,
@@ -776,7 +777,7 @@ public class CustomImportOrderCheck extends AbstractCheck {
                 throw new IllegalArgumentException(
                         "SAME_PACKAGE rule parameter should be positive integer: " + ruleStr);
             }
-            customOrderRules.add(SAME_PACKAGE_RULE_GROUP);
+            customImportOrderRules.add(SAME_PACKAGE_RULE_GROUP);
         }
         else {
             throw new IllegalStateException("Unexpected rule: " + ruleStr);

--- a/src/main/resources/com/puppycrawl/tools/checkstyle/meta/checks/imports/CustomImportOrderCheck.xml
+++ b/src/main/resources/com/puppycrawl/tools/checkstyle/meta/checks/imports/CustomImportOrderCheck.xml
@@ -53,7 +53,11 @@
  &lt;/li&gt;
  &lt;/ol&gt;
  &lt;p&gt;
- Use the separator '###' between rules.
+ Rules are configured as a comma-separated ordered list.
+ &lt;/p&gt;
+ &lt;p&gt;
+ Note: '###' group separator is deprecated (in favor of a comma-separated list),
+ but is currently supported for backward compatibility.
  &lt;/p&gt;
  &lt;p&gt;
  To set RegExps for THIRD_PARTY_PACKAGE and STANDARD_JAVA_PACKAGE groups use
@@ -107,9 +111,8 @@
          <properties>
             <property default-value=""
                       name="customImportOrderRules"
-                      type="java.lang.String">
-               <description>Specify format of order declaration
- customizing by user.</description>
+                      type="java.lang.String[]">
+               <description>Specify ordered list of import groups.</description>
             </property>
             <property default-value="true"
                       name="separateLineBetweenGroups"

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/imports/CustomImportOrderCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/imports/CustomImportOrderCheckTest.java
@@ -116,6 +116,52 @@ public class CustomImportOrderCheckTest extends AbstractModuleTestSupport {
                 getPath("InputCustomImportOrderDefault3.java"), expected);
     }
 
+    @Test
+    public void testStaticStandardThirdListCustomRules() throws Exception {
+        final String[] expected = {
+            "16:1: " + getCheckMessage(MSG_LEX, "java.awt.Button.ABORT",
+                    "java.io.File.createTempFile"),
+            "17:1: " + getCheckMessage(MSG_LEX, "java.awt.print.Paper.*",
+                    "java.io.File.createTempFile"),
+            "22:1: " + getCheckMessage(MSG_LEX, "java.awt.Dialog", "java.awt.Frame"),
+            "27:1: " + getCheckMessage(MSG_LEX, "java.io.File", "javax.swing.JTable"),
+            "28:1: " + getCheckMessage(MSG_LEX, "java.io.IOException", "javax.swing.JTable"),
+            "29:1: " + getCheckMessage(MSG_LEX, "java.io.InputStream", "javax.swing.JTable"),
+            "30:1: " + getCheckMessage(MSG_LEX, "java.io.Reader", "javax.swing.JTable"),
+            "34:1: " + getCheckMessage(MSG_SEPARATED_IN_GROUP, "com.google.common.collect.*"),
+            "34:1: " + getCheckMessage(MSG_LEX, "com.google.common.collect.*",
+                    "com.google.errorprone.annotations.*"),
+        };
+
+        verifyWithInlineConfigParser(
+                getPath("InputCustomImportOrderListRules.java"), expected);
+    }
+
+    @Test
+    public void testStaticStandardThirdListCustomRulesWhitespace() throws Exception {
+        final String[] expected = CommonUtil.EMPTY_STRING_ARRAY;
+
+        verifyWithInlineConfigParser(
+                getPath("InputCustomImportOrderListRulesWhitespace.java"), expected);
+    }
+
+    @Test
+    public void testInputCustomImportOrderSingleLineList() throws Exception {
+        final String[] expected = {
+            "14:112: " + getCheckMessage(MSG_LINE_SEPARATOR,
+                "java.util.Map"),
+            "15:1: " + getCheckMessage(MSG_LINE_SEPARATOR,
+                "com.google.common.annotations.Beta"),
+            "22:1: " + getCheckMessage(MSG_LINE_SEPARATOR,
+                "com.puppycrawl.tools.checkstyle.*"),
+            "26:1: " + getCheckMessage(MSG_LINE_SEPARATOR,
+                "picocli.*"),
+        };
+        verifyWithInlineConfigParser(
+                getPath("InputCustomImportOrderSingleLineList.java"),
+            expected);
+    }
+
     /**
      * Checks different combinations for same_package group.
      */

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/imports/customimportorder/InputCustomImportOrderListRules.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/imports/customimportorder/InputCustomImportOrderListRules.java
@@ -1,0 +1,38 @@
+/*
+CustomImportOrder
+customImportOrderRules = STATIC, STANDARD_JAVA_PACKAGE, THIRD_PARTY_PACKAGE
+standardPackageRegExp = (default)^(java|javax)\.
+thirdPartyPackageRegExp = com.|org.
+specialImportsRegExp = (default)^$
+separateLineBetweenGroups = (default)true
+sortImportsInGroupAlphabetically = true
+
+
+*/
+
+package com.puppycrawl.tools.checkstyle.checks.imports.customimportorder;
+
+import static java.io.File.createTempFile;
+import static java.awt.Button.ABORT; // violation 'Wrong lexicographical order for\s.*. Should be before .*'
+import static java.awt.print.Paper.*; // violation 'Wrong lexicographical order for\s.*. Should be before .*'
+import static javax.swing.WindowConstants.*;
+
+import java.awt.Button;
+import java.awt.Frame;
+import java.awt.Dialog; // violation 'Wrong lexicographical order for.*. Should be before .*'
+import java.awt.color.ColorSpace;
+import java.awt.event.ActionEvent;
+import javax.swing.JComponent;
+import javax.swing.JTable;
+import java.io.File; // violation 'Wrong lexicographical order for.*. Should be before .*'
+import java.io.IOException; // violation 'Wrong lexicographical order for.*. Should be before .*'
+import java.io.InputStream; // violation 'Wrong lexicographical order for.*. Should be before .*'
+import java.io.Reader; // violation 'Wrong lexicographical order for.*. Should be before .*'
+
+import com.google.errorprone.annotations.*;
+
+import com.google.common.collect.*; // 2 violations
+import org.junit.*;
+
+public class InputCustomImportOrderListRules {
+}

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/imports/customimportorder/InputCustomImportOrderListRulesWhitespace.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/imports/customimportorder/InputCustomImportOrderListRulesWhitespace.java
@@ -1,0 +1,16 @@
+/*
+CustomImportOrder
+customImportOrderRules =
+standardPackageRegExp = (default)^(java|javax)\.
+thirdPartyPackageRegExp = com.|org.
+specialImportsRegExp = (default)^$
+separateLineBetweenGroups = (default)true
+sortImportsInGroupAlphabetically = true
+
+
+*/
+
+package com.puppycrawl.tools.checkstyle.checks.imports.customimportorder;
+
+public class InputCustomImportOrderListRulesWhitespace {
+}

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/imports/customimportorder/InputCustomImportOrderSingleLineList.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/imports/customimportorder/InputCustomImportOrderSingleLineList.java
@@ -1,0 +1,28 @@
+/*
+CustomImportOrder
+customImportOrderRules = STATIC, STANDARD_JAVA_PACKAGE, THIRD_PARTY_PACKAGE,\
+                         SPECIAL_IMPORTS, SAME_PACKAGE(3)
+standardPackageRegExp = (default)^(java|javax)\\.
+thirdPartyPackageRegExp = ^com\\.google\\..+
+specialImportsRegExp = ^org\\..+
+separateLineBetweenGroups = (default)true
+sortImportsInGroupAlphabetically = (default)false
+
+
+*/
+
+package com.puppycrawl.tools.checkstyle.checks.imports.customimportorder; import static java.awt.Button.ABORT; import java.util.Map; import java.util.Map.Entry; // violation '.*Map' should be separated from previous import group by one line'
+import com.google.common.annotations.Beta; import com.google.common.collect.HashMultimap; // violation '.*Beta' should be separated from previous import group by one line'
+
+import org.junit.rules.*;
+import org.junit.runner.*;
+import org.junit.validator.*;
+
+
+import com.puppycrawl.tools.checkstyle.*; // violation '.* should be separated from previous import group by one line'
+
+
+
+import picocli.*; // violation '.* should be separated from previous import group by one line'
+
+class InputCustomImportOrderSingleLineList {}

--- a/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/imports/customimportorder/Example10.txt
+++ b/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/imports/customimportorder/Example10.txt
@@ -3,7 +3,7 @@
   <module name="TreeWalker">
     <module name="CustomImportOrder">
       <property name="customImportOrderRules"
-        value="THIRD_PARTY_PACKAGE###SPECIAL_IMPORTS###STANDARD_JAVA_PACKAGE###STATIC"/>
+        value="THIRD_PARTY_PACKAGE, SPECIAL_IMPORTS, STANDARD_JAVA_PACKAGE, STATIC"/>
       <property name="specialImportsRegExp" value="^javax\."/>
       <property name="standardPackageRegExp" value="^java\."/>
       <property name="sortImportsInGroupAlphabetically" value="true"/>

--- a/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/imports/customimportorder/Example12.txt
+++ b/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/imports/customimportorder/Example12.txt
@@ -3,7 +3,7 @@
   <module name="TreeWalker">
     <module name="CustomImportOrder">
       <property name="customImportOrderRules"
-        value="STATIC###SAME_PACKAGE(3)###THIRD_PARTY_PACKAGE###STANDARD_JAVA_PACKAGE"/>
+        value="STATIC, SAME_PACKAGE(3), THIRD_PARTY_PACKAGE, STANDARD_JAVA_PACKAGE"/>
       <property name="thirdPartyPackageRegExp" value="^(com|org)\."/>
       <property name="standardPackageRegExp" value="^(java|javax)\."/>
     </module>

--- a/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/imports/customimportorder/Example15.txt
+++ b/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/imports/customimportorder/Example15.txt
@@ -3,7 +3,7 @@
   <module name="TreeWalker">
     <module name="CustomImportOrder">
       <property name="customImportOrderRules"
-        value="SAME_PACKAGE(3)###THIRD_PARTY_PACKAGE###STATIC###SPECIAL_IMPORTS"/>
+        value="SAME_PACKAGE(3), THIRD_PARTY_PACKAGE, STATIC, SPECIAL_IMPORTS"/>
       <property name="specialImportsRegExp" value="^android\."/>
     </module>
   </module>

--- a/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/imports/customimportorder/Example2.txt
+++ b/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/imports/customimportorder/Example2.txt
@@ -3,7 +3,7 @@
   <module name="TreeWalker">
     <module name="CustomImportOrder">
       <property name="customImportOrderRules"
-        value="STATIC###STANDARD_JAVA_PACKAGE###THIRD_PARTY_PACKAGE"/>
+        value="STATIC, STANDARD_JAVA_PACKAGE, THIRD_PARTY_PACKAGE"/>
     </module>
   </module>
 </module>

--- a/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/imports/customimportorder/Example3.txt
+++ b/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/imports/customimportorder/Example3.txt
@@ -3,7 +3,7 @@
   <module name="TreeWalker">
     <module name="CustomImportOrder">
       <property name="customImportOrderRules"
-        value="STATIC###STANDARD_JAVA_PACKAGE###THIRD_PARTY_PACKAGE"/>
+        value="STATIC, STANDARD_JAVA_PACKAGE, THIRD_PARTY_PACKAGE"/>
       <property name="standardPackageRegExp" value="^java\."/>
     </module>
   </module>

--- a/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/imports/customimportorder/Example4.txt
+++ b/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/imports/customimportorder/Example4.txt
@@ -3,7 +3,7 @@
   <module name="TreeWalker">
     <module name="CustomImportOrder">
       <property name="customImportOrderRules"
-        value="STATIC###STANDARD_JAVA_PACKAGE###SPECIAL_IMPORTS###THIRD_PARTY_PACKAGE"/>
+        value="STATIC, STANDARD_JAVA_PACKAGE, SPECIAL_IMPORTS, THIRD_PARTY_PACKAGE"/>
       <property name="thirdPartyPackageRegExp" value="^com\."/>
     </module>
   </module>

--- a/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/imports/customimportorder/Example5.txt
+++ b/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/imports/customimportorder/Example5.txt
@@ -3,7 +3,7 @@
   <module name="TreeWalker">
     <module name="CustomImportOrder">
       <property name="customImportOrderRules"
-        value="STATIC###SPECIAL_IMPORTS###STANDARD_JAVA_PACKAGE"/>
+        value="STATIC, SPECIAL_IMPORTS, STANDARD_JAVA_PACKAGE"/>
       <property name="specialImportsRegExp" value="^org\."/>
     </module>
   </module>

--- a/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/imports/customimportorder/Example6.txt
+++ b/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/imports/customimportorder/Example6.txt
@@ -3,7 +3,7 @@
   <module name="TreeWalker">
     <module name="CustomImportOrder">
       <property name="customImportOrderRules"
-        value="STATIC###STANDARD_JAVA_PACKAGE###SPECIAL_IMPORTS###THIRD_PARTY_PACKAGE"/>
+        value="STATIC, STANDARD_JAVA_PACKAGE, SPECIAL_IMPORTS, THIRD_PARTY_PACKAGE"/>
       <property name="specialImportsRegExp" value="^org\."/>
       <property name="thirdPartyPackageRegExp" value="^com\."/>
       <property name="separateLineBetweenGroups" value="true"/>

--- a/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/imports/customimportorder/Example7.txt
+++ b/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/imports/customimportorder/Example7.txt
@@ -3,7 +3,7 @@
   <module name="TreeWalker">
     <module name="CustomImportOrder">
       <property name="customImportOrderRules"
-        value="STATIC###STANDARD_JAVA_PACKAGE###SPECIAL_IMPORTS###THIRD_PARTY_PACKAGE"/>
+        value="STATIC, STANDARD_JAVA_PACKAGE, SPECIAL_IMPORTS, THIRD_PARTY_PACKAGE"/>
       <property name="specialImportsRegExp" value="^org\."/>
       <property name="thirdPartyPackageRegExp" value="^com\."/>
       <property name="separateLineBetweenGroups" value="false"/>

--- a/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/imports/customimportorder/Example8.txt
+++ b/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/imports/customimportorder/Example8.txt
@@ -3,7 +3,7 @@
   <module name="TreeWalker">
     <module name="CustomImportOrder">
       <property name="customImportOrderRules"
-        value="STATIC###STANDARD_JAVA_PACKAGE###SPECIAL_IMPORTS"/>
+        value="STATIC, STANDARD_JAVA_PACKAGE, SPECIAL_IMPORTS"/>
       <property name="specialImportsRegExp" value="^org\."/>
       <property name="sortImportsInGroupAlphabetically" value="true"/>
       <property name="separateLineBetweenGroups" value="true"/>

--- a/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/imports/customimportorder/Example9.txt
+++ b/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/imports/customimportorder/Example9.txt
@@ -3,7 +3,7 @@
   <module name="TreeWalker">
     <module name="CustomImportOrder">
       <property name="customImportOrderRules"
-        value="STATIC###STANDARD_JAVA_PACKAGE###SPECIAL_IMPORTS###THIRD_PARTY_PACKAGE"/>
+        value="STATIC, STANDARD_JAVA_PACKAGE, SPECIAL_IMPORTS, THIRD_PARTY_PACKAGE"/>
       <property name="specialImportsRegExp" value="^org\."/>
       <property name="thirdPartyPackageRegExp" value="^com\."/>
       <property name="sortImportsInGroupAlphabetically" value="true"/>

--- a/src/xdocs/checks/imports/customimportorder.xml
+++ b/src/xdocs/checks/imports/customimportorder.xml
@@ -66,7 +66,11 @@ import java.util.regex.Matcher; //#8
 
       <subsection name="Notes" id="Notes">
         <p>
-          Use the separator '###' between rules.
+          Rules are configured as a comma-separated ordered list.
+        </p>
+        <p>
+          Note: '###' group separator is deprecated (in favor of a comma-separated list),
+          but is currently supported for backward compatibility.
         </p>
         <p>
           To set RegExps for THIRD_PARTY_PACKAGE and STANDARD_JAVA_PACKAGE groups use
@@ -124,9 +128,9 @@ import com.puppycrawl.tools.checkstyle.checks.imports.AvoidStarImportCheck;
             </tr>
             <tr>
               <td>customImportOrderRules</td>
-              <td>Specify format of order declaration customizing by user.</td>
-              <td><a href="../../property_types.html#String">String</a></td>
-              <td><code>&quot;&quot;</code></td>
+              <td>Specify ordered list of import groups.</td>
+              <td><a href="../../property_types.html#String[]">String[]</a></td>
+              <td><code>{}</code></td>
               <td>5.8</td>
             </tr>
             <tr>
@@ -203,7 +207,7 @@ import com.puppycrawl.tools.checkstyle.checks.imports.ImportOrderCheck; // OK
   &lt;module name=&quot;TreeWalker&quot;&gt;
     &lt;module name=&quot;CustomImportOrder&quot;&gt;
       &lt;property name=&quot;customImportOrderRules&quot;
-        value=&quot;STATIC###STANDARD_JAVA_PACKAGE###THIRD_PARTY_PACKAGE&quot;/&gt;
+        value=&quot;STATIC, STANDARD_JAVA_PACKAGE, THIRD_PARTY_PACKAGE&quot;/&gt;
     &lt;/module&gt;
   &lt;/module&gt;
 &lt;/module&gt;
@@ -232,7 +236,7 @@ import com.puppycrawl.tools.checkstyle.checks.imports.ImportOrderCheck; // OK
   &lt;module name=&quot;TreeWalker&quot;&gt;
     &lt;module name=&quot;CustomImportOrder&quot;&gt;
       &lt;property name=&quot;customImportOrderRules&quot;
-        value=&quot;STATIC###STANDARD_JAVA_PACKAGE###THIRD_PARTY_PACKAGE&quot;/&gt;
+        value=&quot;STATIC, STANDARD_JAVA_PACKAGE, THIRD_PARTY_PACKAGE&quot;/&gt;
       &lt;property name=&quot;standardPackageRegExp&quot; value=&quot;^java\.&quot;/&gt;
     &lt;/module&gt;
   &lt;/module&gt;
@@ -263,7 +267,7 @@ import com.puppycrawl.tools.checkstyle.checks.imports.ImportOrderCheck; // OK
   &lt;module name=&quot;TreeWalker&quot;&gt;
     &lt;module name=&quot;CustomImportOrder&quot;&gt;
       &lt;property name=&quot;customImportOrderRules&quot;
-        value=&quot;STATIC###STANDARD_JAVA_PACKAGE###SPECIAL_IMPORTS###THIRD_PARTY_PACKAGE&quot;/&gt;
+        value=&quot;STATIC, STANDARD_JAVA_PACKAGE, SPECIAL_IMPORTS, THIRD_PARTY_PACKAGE&quot;/&gt;
       &lt;property name=&quot;thirdPartyPackageRegExp&quot; value=&quot;^com\.&quot;/&gt;
     &lt;/module&gt;
   &lt;/module&gt;
@@ -293,7 +297,7 @@ import com.puppycrawl.tools.checkstyle.checks.imports.ImportOrderCheck; // OK
   &lt;module name=&quot;TreeWalker&quot;&gt;
     &lt;module name=&quot;CustomImportOrder&quot;&gt;
       &lt;property name=&quot;customImportOrderRules&quot;
-        value=&quot;STATIC###SPECIAL_IMPORTS###STANDARD_JAVA_PACKAGE&quot;/&gt;
+        value=&quot;STATIC, SPECIAL_IMPORTS, STANDARD_JAVA_PACKAGE&quot;/&gt;
       &lt;property name=&quot;specialImportsRegExp&quot; value=&quot;^org\.&quot;/&gt;
     &lt;/module&gt;
   &lt;/module&gt;
@@ -323,7 +327,7 @@ import org.apache.commons.io.FileUtils; // violation
   &lt;module name=&quot;TreeWalker&quot;&gt;
     &lt;module name=&quot;CustomImportOrder&quot;&gt;
       &lt;property name=&quot;customImportOrderRules&quot;
-        value=&quot;STATIC###STANDARD_JAVA_PACKAGE###SPECIAL_IMPORTS###THIRD_PARTY_PACKAGE&quot;/&gt;
+        value=&quot;STATIC, STANDARD_JAVA_PACKAGE, SPECIAL_IMPORTS, THIRD_PARTY_PACKAGE&quot;/&gt;
       &lt;property name=&quot;specialImportsRegExp&quot; value=&quot;^org\.&quot;/&gt;
       &lt;property name=&quot;thirdPartyPackageRegExp&quot; value=&quot;^com\.&quot;/&gt;
       &lt;property name=&quot;separateLineBetweenGroups&quot; value=&quot;true&quot;/&gt;
@@ -354,7 +358,7 @@ import com.puppycrawl.tools.checkstyle.checks.imports.ImportOrderCheck; // OK
   &lt;module name=&quot;TreeWalker&quot;&gt;
     &lt;module name=&quot;CustomImportOrder&quot;&gt;
       &lt;property name=&quot;customImportOrderRules&quot;
-        value=&quot;STATIC###STANDARD_JAVA_PACKAGE###SPECIAL_IMPORTS###THIRD_PARTY_PACKAGE&quot;/&gt;
+        value=&quot;STATIC, STANDARD_JAVA_PACKAGE, SPECIAL_IMPORTS, THIRD_PARTY_PACKAGE&quot;/&gt;
       &lt;property name=&quot;specialImportsRegExp&quot; value=&quot;^org\.&quot;/&gt;
       &lt;property name=&quot;thirdPartyPackageRegExp&quot; value=&quot;^com\.&quot;/&gt;
       &lt;property name=&quot;separateLineBetweenGroups&quot; value=&quot;false&quot;/&gt;
@@ -399,7 +403,7 @@ import com.puppycrawl.tools.checkstyle.checks.imports.ImportOrderCheck; // OK
   &lt;module name=&quot;TreeWalker&quot;&gt;
     &lt;module name=&quot;CustomImportOrder&quot;&gt;
       &lt;property name=&quot;customImportOrderRules&quot;
-        value=&quot;STATIC###STANDARD_JAVA_PACKAGE###SPECIAL_IMPORTS&quot;/&gt;
+        value=&quot;STATIC, STANDARD_JAVA_PACKAGE, SPECIAL_IMPORTS&quot;/&gt;
       &lt;property name=&quot;specialImportsRegExp&quot; value=&quot;^org\.&quot;/&gt;
       &lt;property name=&quot;sortImportsInGroupAlphabetically&quot; value=&quot;true&quot;/&gt;
       &lt;property name=&quot;separateLineBetweenGroups&quot; value=&quot;true&quot;/&gt;
@@ -438,7 +442,7 @@ import com.puppycrawl.tools.checkstyle.checks.imports.ImportOrderCheck; // OK
   &lt;module name=&quot;TreeWalker&quot;&gt;
     &lt;module name=&quot;CustomImportOrder&quot;&gt;
       &lt;property name=&quot;customImportOrderRules&quot;
-        value=&quot;STATIC###STANDARD_JAVA_PACKAGE###SPECIAL_IMPORTS###THIRD_PARTY_PACKAGE&quot;/&gt;
+        value=&quot;STATIC, STANDARD_JAVA_PACKAGE, SPECIAL_IMPORTS, THIRD_PARTY_PACKAGE&quot;/&gt;
       &lt;property name=&quot;specialImportsRegExp&quot; value=&quot;^org\.&quot;/&gt;
       &lt;property name=&quot;thirdPartyPackageRegExp&quot; value=&quot;^com\.&quot;/&gt;
       &lt;property name=&quot;sortImportsInGroupAlphabetically&quot; value=&quot;true&quot;/&gt;
@@ -485,7 +489,7 @@ import org.apache.commons.io.FileUtils;
   &lt;module name=&quot;TreeWalker&quot;&gt;
     &lt;module name=&quot;CustomImportOrder&quot;&gt;
       &lt;property name=&quot;customImportOrderRules&quot;
-        value=&quot;THIRD_PARTY_PACKAGE###SPECIAL_IMPORTS###STANDARD_JAVA_PACKAGE###STATIC&quot;/&gt;
+        value=&quot;THIRD_PARTY_PACKAGE, SPECIAL_IMPORTS, STANDARD_JAVA_PACKAGE, STATIC&quot;/&gt;
       &lt;property name=&quot;specialImportsRegExp&quot; value=&quot;^javax\.&quot;/&gt;
       &lt;property name=&quot;standardPackageRegExp&quot; value=&quot;^java\.&quot;/&gt;
       &lt;property name=&quot;sortImportsInGroupAlphabetically&quot; value=&quot;true&quot;/&gt;
@@ -553,7 +557,7 @@ import org.apache.commons.io.FileUtils; // should not be separated by line
   &lt;module name=&quot;TreeWalker&quot;&gt;
     &lt;module name=&quot;CustomImportOrder&quot;&gt;
       &lt;property name=&quot;customImportOrderRules&quot;
-        value=&quot;STATIC###SAME_PACKAGE(3)###THIRD_PARTY_PACKAGE###STANDARD_JAVA_PACKAGE&quot;/&gt;
+        value=&quot;STATIC, SAME_PACKAGE(3), THIRD_PARTY_PACKAGE, STANDARD_JAVA_PACKAGE&quot;/&gt;
       &lt;property name=&quot;thirdPartyPackageRegExp&quot; value=&quot;^(com|org)\.&quot;/&gt;
       &lt;property name=&quot;standardPackageRegExp&quot; value=&quot;^(java|javax)\.&quot;/&gt;
     &lt;/module&gt;
@@ -652,7 +656,7 @@ import android.*;
   &lt;module name=&quot;TreeWalker&quot;&gt;
     &lt;module name=&quot;CustomImportOrder&quot;&gt;
       &lt;property name=&quot;customImportOrderRules&quot;
-        value=&quot;SAME_PACKAGE(3)###THIRD_PARTY_PACKAGE###STATIC###SPECIAL_IMPORTS&quot;/&gt;
+        value=&quot;SAME_PACKAGE(3), THIRD_PARTY_PACKAGE, STATIC, SPECIAL_IMPORTS&quot;/&gt;
       &lt;property name=&quot;specialImportsRegExp&quot; value=&quot;^android\.&quot;/&gt;
     &lt;/module&gt;
   &lt;/module&gt;

--- a/src/xdocs/checks/imports/customimportorder.xml.template
+++ b/src/xdocs/checks/imports/customimportorder.xml.template
@@ -66,7 +66,11 @@ import java.util.regex.Matcher; //#8
 
       <subsection name="Notes" id="Notes">
         <p>
-          Use the separator '###' between rules.
+          Rules are configured as a comma-separated ordered list.
+        </p>
+        <p>
+          Note: '###' group separator is deprecated (in favor of a comma-separated list),
+          but is currently supported for backward compatibility.
         </p>
         <p>
           To set RegExps for THIRD_PARTY_PACKAGE and STANDARD_JAVA_PACKAGE groups use
@@ -124,9 +128,9 @@ import com.puppycrawl.tools.checkstyle.checks.imports.AvoidStarImportCheck;
             </tr>
             <tr>
               <td>customImportOrderRules</td>
-              <td>Specify format of order declaration customizing by user.</td>
-              <td><a href="../../property_types.html#String">String</a></td>
-              <td><code>""</code></td>
+              <td>Specify ordered list of import groups.</td>
+              <td><a href="../../property_types.html#String[]">String[]</a></td>
+              <td><code>{}</code></td>
               <td>5.8</td>
             </tr>
             <tr>


### PR DESCRIPTION
Resolves #14216, if we decide to approve.

We can add a note about still supporting `###` delimited string if we want to, I don't think it's necessary. I have left UT configs alone to show that we don't have a regression.