### PR TITLE
Issue #14137: Enable `CollectorMutability` check

### DIFF
--- a/config/checker-framework-suppressions/checker-lock-tainting-suppressions.xml
+++ b/config/checker-framework-suppressions/checker-lock-tainting-suppressions.xml
@@ -100,7 +100,7 @@
     <fileName>src/main/java/com/puppycrawl/tools/checkstyle/PropertiesExpander.java</fileName>
     <specifier>methodref.receiver.bound</specifier>
     <message>Incompatible receiver type</message>
-    <lineContent>.collect(Collectors.toMap(Function.identity(), properties::getProperty));</lineContent>
+    <lineContent>.collect(ImmutableMap.toImmutableMap(Function.identity(), properties::getProperty));</lineContent>
     <details>
       found   : @GuardedBy Properties
       required: @GuardSatisfied Properties

--- a/config/checker-framework-suppressions/checker-nullness-optional-interning-suppressions.xml
+++ b/config/checker-framework-suppressions/checker-nullness-optional-interning-suppressions.xml
@@ -775,7 +775,7 @@
     <fileName>src/main/java/com/puppycrawl/tools/checkstyle/PropertiesExpander.java</fileName>
     <specifier>methodref.return</specifier>
     <message>Incompatible return type</message>
-    <lineContent>.collect(Collectors.toMap(Function.identity(), properties::getProperty));</lineContent>
+    <lineContent>.collect(ImmutableMap.toImmutableMap(Function.identity(), properties::getProperty));</lineContent>
     <details>
       found   : @Initialized @Nullable String
       required: @Initialized @NonNull String

--- a/config/pitest-suppressions/pitest-filters-suppressions.xml
+++ b/config/pitest-suppressions/pitest-filters-suppressions.xml
@@ -213,6 +213,6 @@
     <mutatedMethod>isXpathQueryMatching</mutatedMethod>
     <mutator>org.pitest.mutationtest.engine.gregor.mutators.experimental.NakedReceiverMutator</mutator>
     <description>replaced call to java/util/stream/Stream::map with receiver</description>
-    <lineContent>.stream().map(AbstractNode.class::cast).collect(Collectors.toList());</lineContent>
+    <lineContent>.stream().map(AbstractNode.class::cast).collect(ImmutableList.toImmutableList());</lineContent>
   </mutation>
 </suppressedMutations>

--- a/pom.xml
+++ b/pom.xml
@@ -238,6 +238,8 @@
     <error-prone-support.version>0.14.0</error-prone-support.version>
     <doxia.version>1.12.0</doxia.version>
     <error-prone.configuration-args>
+      <!-- Prefer usage of immutable collectors. -->
+      -Xep:CollectorMutability:ERROR
       <!-- Reason at https://github.com/checkstyle/checkstyle/issues/8252. -->
       -Xep:JUnitClassModifiers:OFF
       <!-- Reason at https://github.com/checkstyle/checkstyle/issues/8252. -->

--- a/src/main/java/com/puppycrawl/tools/checkstyle/Checker.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/Checker.java
@@ -32,12 +32,13 @@ import java.util.Locale;
 import java.util.Set;
 import java.util.SortedSet;
 import java.util.TreeSet;
-import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
 import com.puppycrawl.tools.checkstyle.api.AuditEvent;
 import com.puppycrawl.tools.checkstyle.api.AuditListener;
 import com.puppycrawl.tools.checkstyle.api.BeforeExecutionFileFilter;
@@ -222,7 +223,7 @@ public class Checker extends AbstractAutomaticBean implements MessageDispatcher,
 
         final List<File> targetFiles = files.stream()
                 .filter(file -> CommonUtil.matchesFileExtension(file, fileExtensions))
-                .collect(Collectors.toList());
+                .collect(ImmutableList.toImmutableList());
         processFiles(targetFiles);
 
         // Finish up
@@ -251,7 +252,7 @@ public class Checker extends AbstractAutomaticBean implements MessageDispatcher,
                 return ((ExternalResourceHolder) resource)
                         .getExternalResourceLocations().stream();
             })
-            .collect(Collectors.toSet());
+            .collect(ImmutableSet.toImmutableSet());
     }
 
     /** Notify all listeners about the audit start. */

--- a/src/main/java/com/puppycrawl/tools/checkstyle/JavaAstVisitor.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/JavaAstVisitor.java
@@ -35,6 +35,7 @@ import org.antlr.v4.runtime.Token;
 import org.antlr.v4.runtime.tree.ParseTree;
 import org.antlr.v4.runtime.tree.TerminalNode;
 
+import com.google.common.collect.ImmutableList;
 import com.puppycrawl.tools.checkstyle.api.TokenTypes;
 import com.puppycrawl.tools.checkstyle.grammar.java.JavaLanguageLexer;
 import com.puppycrawl.tools.checkstyle.grammar.java.JavaLanguageParser;
@@ -419,7 +420,7 @@ public final class JavaAstVisitor extends JavaLanguageParserBaseVisitor<DetailAs
         // Process all children except C style array declarators
         processChildren(methodDef, ctx.children.stream()
                 .filter(child -> !(child instanceof JavaLanguageParser.ArrayDeclaratorContext))
-                .collect(Collectors.toList()));
+                .collect(ImmutableList.toImmutableList()));
 
         // We add C style array declarator brackets to TYPE ast
         final DetailAstImpl typeAst = (DetailAstImpl) methodDef.findFirstToken(TokenTypes.TYPE);
@@ -483,7 +484,7 @@ public final class JavaAstVisitor extends JavaLanguageParserBaseVisitor<DetailAs
         final List<ParseTree> children = ctx.children
                 .stream()
                 .filter(child -> !(child instanceof JavaLanguageParser.ArrayDeclaratorContext))
-                .collect(Collectors.toList());
+                .collect(ImmutableList.toImmutableList());
         processChildren(methodDef, children);
 
         // We add C style array declarator brackets to TYPE ast
@@ -834,7 +835,7 @@ public final class JavaAstVisitor extends JavaLanguageParserBaseVisitor<DetailAs
         // Process all children except C style array declarators
         processChildren(annotationFieldDef, ctx.children.stream()
                 .filter(child -> !(child instanceof JavaLanguageParser.ArrayDeclaratorContext))
-                .collect(Collectors.toList()));
+                .collect(ImmutableList.toImmutableList()));
 
         // We add C style array declarator brackets to TYPE ast
         final DetailAstImpl typeAst =
@@ -881,7 +882,7 @@ public final class JavaAstVisitor extends JavaLanguageParserBaseVisitor<DetailAs
         // filter 'LITERAL_SUPER'
         processChildren(primaryCtorCall, ctx.children.stream()
                    .filter(child -> !child.equals(ctx.LITERAL_SUPER()))
-                   .collect(Collectors.toList()));
+                   .collect(ImmutableList.toImmutableList()));
         return primaryCtorCall;
     }
 
@@ -1119,7 +1120,7 @@ public final class JavaAstVisitor extends JavaLanguageParserBaseVisitor<DetailAs
         // filter mods
         processChildren(catchParameterDef, ctx.children.stream()
                 .filter(child -> !(child instanceof JavaLanguageParser.VariableModifierContext))
-                .collect(Collectors.toList()));
+                .collect(ImmutableList.toImmutableList()));
         return catchParameterDef;
     }
 
@@ -1552,7 +1553,7 @@ public final class JavaAstVisitor extends JavaLanguageParserBaseVisitor<DetailAs
                 (Token) ctx.DOUBLE_COLON().getPayload());
         final List<ParseTree> children = ctx.children.stream()
                 .filter(child -> !child.equals(ctx.DOUBLE_COLON()))
-                .collect(Collectors.toList());
+                .collect(ImmutableList.toImmutableList());
         processChildren(doubleColon, children);
         return doubleColon;
     }
@@ -1562,7 +1563,7 @@ public final class JavaAstVisitor extends JavaLanguageParserBaseVisitor<DetailAs
         final DetailAstImpl root = create(ctx.QUESTION());
         processChildren(root, ctx.children.stream()
                 .filter(child -> !child.equals(ctx.QUESTION()))
-                .collect(Collectors.toList()));
+                .collect(ImmutableList.toImmutableList()));
         return root;
     }
 

--- a/src/main/java/com/puppycrawl/tools/checkstyle/PackageObjectFactory.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/PackageObjectFactory.java
@@ -32,6 +32,7 @@ import java.util.function.Supplier;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
+import com.google.common.collect.ImmutableList;
 import com.puppycrawl.tools.checkstyle.api.CheckstyleException;
 import com.puppycrawl.tools.checkstyle.utils.ModuleReflectionUtil;
 
@@ -389,7 +390,7 @@ public class PackageObjectFactory implements ModuleFactory {
         final List<String> possibleNames = packages.stream()
             .map(packageName -> packageName + PACKAGE_SEPARATOR + name)
             .flatMap(className -> Stream.of(className, className + CHECK_SUFFIX))
-            .collect(Collectors.toList());
+            .collect(ImmutableList.toImmutableList());
         Object instance = null;
         for (String possibleName : possibleNames) {
             instance = createObject(possibleName);

--- a/src/main/java/com/puppycrawl/tools/checkstyle/PropertiesExpander.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/PropertiesExpander.java
@@ -22,7 +22,8 @@ package com.puppycrawl.tools.checkstyle;
 import java.util.Map;
 import java.util.Properties;
 import java.util.function.Function;
-import java.util.stream.Collectors;
+
+import com.google.common.collect.ImmutableMap;
 
 /**
  * Resolves external properties from an
@@ -48,7 +49,7 @@ public final class PropertiesExpander
         }
         values = properties.stringPropertyNames()
                 .stream()
-                .collect(Collectors.toMap(Function.identity(), properties::getProperty));
+                .collect(ImmutableMap.toImmutableMap(Function.identity(), properties::getProperty));
     }
 
     @Override

--- a/src/main/java/com/puppycrawl/tools/checkstyle/TreeWalker.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/TreeWalker.java
@@ -30,9 +30,9 @@ import java.util.Map;
 import java.util.Set;
 import java.util.SortedSet;
 import java.util.TreeSet;
-import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
+import com.google.common.collect.ImmutableSet;
 import com.puppycrawl.tools.checkstyle.api.AbstractCheck;
 import com.puppycrawl.tools.checkstyle.api.AbstractFileSetCheck;
 import com.puppycrawl.tools.checkstyle.api.CheckstyleException;
@@ -392,7 +392,7 @@ public final class TreeWalker extends AbstractFileSetCheck implements ExternalRe
                 return ((ExternalResourceHolder) resource)
                         .getExternalResourceLocations().stream();
             })
-            .collect(Collectors.toSet());
+            .collect(ImmutableSet.toImmutableSet());
     }
 
     /**

--- a/src/main/java/com/puppycrawl/tools/checkstyle/ant/CheckstyleAntTask.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/ant/CheckstyleAntTask.java
@@ -31,7 +31,6 @@ import java.util.Locale;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Properties;
-import java.util.stream.Collectors;
 
 import org.apache.tools.ant.BuildException;
 import org.apache.tools.ant.DirectoryScanner;
@@ -42,6 +41,7 @@ import org.apache.tools.ant.types.EnumeratedAttribute;
 import org.apache.tools.ant.types.FileSet;
 import org.apache.tools.ant.types.Path;
 
+import com.google.common.collect.ImmutableList;
 import com.puppycrawl.tools.checkstyle.AbstractAutomaticBean.OutputStreamOptions;
 import com.puppycrawl.tools.checkstyle.Checker;
 import com.puppycrawl.tools.checkstyle.ConfigurationLoader;
@@ -587,7 +587,7 @@ public class CheckstyleAntTask extends Task {
         return Arrays.stream(fileNames)
             .map(name -> scanner.getBasedir() + File.separator + name)
             .map(File::new)
-            .collect(Collectors.toList());
+            .collect(ImmutableList.toImmutableList());
     }
 
     /**

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/TranslationCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/TranslationCheck.java
@@ -37,11 +37,11 @@ import java.util.TreeSet;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
-import java.util.stream.Collectors;
 
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 
+import com.google.common.collect.ImmutableSet;
 import com.puppycrawl.tools.checkstyle.Definitions;
 import com.puppycrawl.tools.checkstyle.GlobalStatefulCheck;
 import com.puppycrawl.tools.checkstyle.LocalizedMessage;
@@ -254,7 +254,7 @@ public class TranslationCheck extends AbstractFileSetCheck {
      * @since 6.11
      */
     public void setRequiredTranslations(String... translationCodes) {
-        requiredTranslations = Arrays.stream(translationCodes).collect(Collectors.toSet());
+        requiredTranslations = Arrays.stream(translationCodes).collect(ImmutableSet.toImmutableSet());
         validateUserSpecifiedLanguageCodes(requiredTranslations);
     }
 
@@ -520,7 +520,7 @@ public class TranslationCheck extends AbstractFileSetCheck {
         for (Entry<File, Set<String>> fileKey : fileKeys.entrySet()) {
             final Set<String> currentFileKeys = fileKey.getValue();
             final Set<String> missingKeys = keysThatMustExist.stream()
-                .filter(key -> !currentFileKeys.contains(key)).collect(Collectors.toSet());
+                .filter(key -> !currentFileKeys.contains(key)).collect(ImmutableSet.toImmutableSet());
             if (!missingKeys.isEmpty()) {
                 final MessageDispatcher dispatcher = getMessageDispatcher();
                 final String path = fileKey.getKey().getAbsolutePath();

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/IllegalInstantiationCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/IllegalInstantiationCheck.java
@@ -22,8 +22,8 @@ package com.puppycrawl.tools.checkstyle.checks.coding;
 import java.util.Arrays;
 import java.util.HashSet;
 import java.util.Set;
-import java.util.stream.Collectors;
 
+import com.google.common.collect.ImmutableSet;
 import com.puppycrawl.tools.checkstyle.FileStatefulCheck;
 import com.puppycrawl.tools.checkstyle.api.AbstractCheck;
 import com.puppycrawl.tools.checkstyle.api.DetailAST;
@@ -346,7 +346,7 @@ public class IllegalInstantiationCheck
      * @since 3.0
      */
     public void setClasses(String... names) {
-        classes = Arrays.stream(names).collect(Collectors.toSet());
+        classes = Arrays.stream(names).collect(ImmutableSet.toImmutableSet());
     }
 
 }

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/MatchXpathCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/MatchXpathCheck.java
@@ -20,8 +20,8 @@
 package com.puppycrawl.tools.checkstyle.checks.coding;
 
 import java.util.List;
-import java.util.stream.Collectors;
 
+import com.google.common.collect.ImmutableList;
 import com.puppycrawl.tools.checkstyle.StatelessCheck;
 import com.puppycrawl.tools.checkstyle.api.AbstractCheck;
 import com.puppycrawl.tools.checkstyle.api.DetailAST;
@@ -156,7 +156,7 @@ public class MatchXpathCheck extends AbstractCheck {
             final List<Item> matchingItems = xpathExpression.evaluate(xpathDynamicContext);
             return matchingItems.stream()
                     .map(item -> (DetailAST) ((AbstractNode) item).getUnderlyingNode())
-                    .collect(Collectors.toList());
+                    .collect(ImmutableList.toImmutableList());
         }
         catch (XPathException ex) {
             throw new IllegalStateException("Evaluation of Xpath query failed: " + query, ex);

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/ModifiedControlVariableCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/ModifiedControlVariableCheck.java
@@ -26,8 +26,8 @@ import java.util.HashSet;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Set;
-import java.util.stream.Collectors;
 
+import com.google.common.collect.ImmutableSet;
 import com.puppycrawl.tools.checkstyle.FileStatefulCheck;
 import com.puppycrawl.tools.checkstyle.api.AbstractCheck;
 import com.puppycrawl.tools.checkstyle.api.DetailAST;
@@ -312,7 +312,7 @@ public final class ModifiedControlVariableCheck extends AbstractCheck {
         final Set<String> initializedVariables = getForInitVariables(ast);
         final Set<String> iteratingVariables = getForIteratorVariables(ast);
         return initializedVariables.stream().filter(iteratingVariables::contains)
-            .collect(Collectors.toSet());
+            .collect(ImmutableSet.toImmutableSet());
     }
 
     /**

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/UnusedLocalVariableCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/UnusedLocalVariableCheck.java
@@ -29,8 +29,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
-import java.util.stream.Collectors;
 
+import com.google.common.collect.ImmutableList;
 import com.puppycrawl.tools.checkstyle.FileStatefulCheck;
 import com.puppycrawl.tools.checkstyle.api.AbstractCheck;
 import com.puppycrawl.tools.checkstyle.api.DetailAST;
@@ -524,7 +524,7 @@ public class UnusedLocalVariableCheck extends AbstractCheck {
                 .filter(typeDeclDesc -> {
                     return hasSameNameAsSuperClass(superClassName, typeDeclDesc);
                 })
-                .collect(Collectors.toList());
+                .collect(ImmutableList.toImmutableList());
     }
 
     /**

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/design/DesignForExtensionCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/design/DesignForExtensionCheck.java
@@ -26,8 +26,8 @@ import java.util.Set;
 import java.util.function.Predicate;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
-import java.util.stream.Collectors;
 
+import com.google.common.collect.ImmutableSet;
 import com.puppycrawl.tools.checkstyle.StatelessCheck;
 import com.puppycrawl.tools.checkstyle.api.AbstractCheck;
 import com.puppycrawl.tools.checkstyle.api.DetailAST;
@@ -196,7 +196,7 @@ public class DesignForExtensionCheck extends AbstractCheck {
      * Specify annotations which allow the check to skip the method from validation.
      */
     private Set<String> ignoredAnnotations = Arrays.stream(new String[] {"Test", "Before", "After",
-        "BeforeClass", "AfterClass", }).collect(Collectors.toSet());
+        "BeforeClass", "AfterClass", }).collect(ImmutableSet.toImmutableSet());
 
     /**
      * Specify the comment text pattern which qualifies a method as designed for extension.
@@ -211,7 +211,7 @@ public class DesignForExtensionCheck extends AbstractCheck {
      * @since 7.2
      */
     public void setIgnoredAnnotations(String... ignoredAnnotations) {
-        this.ignoredAnnotations = Arrays.stream(ignoredAnnotations).collect(Collectors.toSet());
+        this.ignoredAnnotations = Arrays.stream(ignoredAnnotations).collect(ImmutableSet.toImmutableSet());
     }
 
     /**

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/AbstractJavadocCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/AbstractJavadocCheck.java
@@ -25,8 +25,8 @@ import java.util.HashSet;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Set;
-import java.util.stream.Collectors;
 
+import com.google.common.collect.ImmutableList;
 import com.puppycrawl.tools.checkstyle.JavadocDetailNodeParser;
 import com.puppycrawl.tools.checkstyle.JavadocDetailNodeParser.ParseErrorMessage;
 import com.puppycrawl.tools.checkstyle.JavadocDetailNodeParser.ParseStatus;
@@ -194,7 +194,7 @@ public abstract class AbstractJavadocCheck extends AbstractCheck {
         validateDefaultJavadocTokens();
         if (javadocTokens.isEmpty()) {
             javadocTokens.addAll(
-                    Arrays.stream(getDefaultJavadocTokens()).boxed().collect(Collectors.toList()));
+                    Arrays.stream(getDefaultJavadocTokens()).boxed().collect(ImmutableList.toImmutableList()));
         }
         else {
             final int[] acceptableJavadocTokens = getAcceptableJavadocTokens();

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocBlockTagLocationCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocBlockTagLocationCheck.java
@@ -23,8 +23,8 @@ import java.util.Arrays;
 import java.util.Set;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
-import java.util.stream.Collectors;
 
+import com.google.common.collect.ImmutableSet;
 import com.puppycrawl.tools.checkstyle.StatelessCheck;
 import com.puppycrawl.tools.checkstyle.api.DetailNode;
 import com.puppycrawl.tools.checkstyle.api.JavadocTokenTypes;
@@ -152,7 +152,7 @@ public class JavadocBlockTagLocationCheck extends AbstractJavadocCheck {
      * @since 8.24
      */
     public final void setTags(String... values) {
-        tags = Arrays.stream(values).collect(Collectors.toSet());
+        tags = Arrays.stream(values).collect(ImmutableSet.toImmutableSet());
     }
 
     /**

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/metrics/AbstractClassCouplingCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/metrics/AbstractClassCouplingCheck.java
@@ -32,8 +32,8 @@ import java.util.Set;
 import java.util.TreeSet;
 import java.util.function.Predicate;
 import java.util.regex.Pattern;
-import java.util.stream.Collectors;
 
+import com.google.common.collect.ImmutableList;
 import com.puppycrawl.tools.checkstyle.FileStatefulCheck;
 import com.puppycrawl.tools.checkstyle.api.AbstractCheck;
 import com.puppycrawl.tools.checkstyle.api.DetailAST;
@@ -171,7 +171,7 @@ public abstract class AbstractClassCouplingCheck extends AbstractCheck {
     public final void setExcludedPackages(String... excludedPackages) {
         final List<String> invalidIdentifiers = Arrays.stream(excludedPackages)
             .filter(Predicate.not(CommonUtil::isName))
-            .collect(Collectors.toList());
+            .collect(ImmutableList.toImmutableList());
         if (!invalidIdentifiers.isEmpty()) {
             throw new IllegalArgumentException(
                 "the following values are not valid identifiers: " + invalidIdentifiers);

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/naming/AbbreviationAsWordInNameCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/naming/AbbreviationAsWordInNameCheck.java
@@ -24,8 +24,8 @@ import java.util.HashSet;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Set;
-import java.util.stream.Collectors;
 
+import com.google.common.collect.ImmutableSet;
 import com.puppycrawl.tools.checkstyle.StatelessCheck;
 import com.puppycrawl.tools.checkstyle.api.AbstractCheck;
 import com.puppycrawl.tools.checkstyle.api.DetailAST;
@@ -246,7 +246,7 @@ public class AbbreviationAsWordInNameCheck extends AbstractCheck {
     public void setAllowedAbbreviations(String... allowedAbbreviations) {
         if (allowedAbbreviations != null) {
             this.allowedAbbreviations =
-                Arrays.stream(allowedAbbreviations).collect(Collectors.toSet());
+                Arrays.stream(allowedAbbreviations).collect(ImmutableSet.toImmutableSet());
         }
     }
 

--- a/src/main/java/com/puppycrawl/tools/checkstyle/filters/XpathFilterElement.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/filters/XpathFilterElement.java
@@ -23,8 +23,8 @@ import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.regex.Pattern;
-import java.util.stream.Collectors;
 
+import com.google.common.collect.ImmutableList;
 import com.puppycrawl.tools.checkstyle.TreeWalkerAuditEvent;
 import com.puppycrawl.tools.checkstyle.TreeWalkerFilter;
 import com.puppycrawl.tools.checkstyle.utils.CommonUtil;
@@ -167,7 +167,7 @@ public class XpathFilterElement implements TreeWalkerFilter {
         else {
             isMatching = false;
             final List<AbstractNode> nodes = getItems(event)
-                    .stream().map(AbstractNode.class::cast).collect(Collectors.toList());
+                    .stream().map(AbstractNode.class::cast).collect(ImmutableList.toImmutableList());
             for (AbstractNode abstractNode : nodes) {
                 isMatching = abstractNode.getTokenType() == event.getTokenType()
                         && abstractNode.getLineNumber() == event.getLine()

--- a/src/main/java/com/puppycrawl/tools/checkstyle/meta/MetadataGeneratorUtil.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/meta/MetadataGeneratorUtil.java
@@ -28,9 +28,9 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
+import com.google.common.collect.ImmutableList;
 import com.puppycrawl.tools.checkstyle.AbstractAutomaticBean.OutputStreamOptions;
 import com.puppycrawl.tools.checkstyle.Checker;
 import com.puppycrawl.tools.checkstyle.DefaultConfiguration;
@@ -99,7 +99,7 @@ public final class MetadataGeneratorUtil {
                                     || fileName.endsWith("Check.java")
                                     || fileName.endsWith("Filter.java");
                         })
-                        .collect(Collectors.toList()));
+                        .collect(ImmutableList.toImmutableList()));
             }
         }
 

--- a/src/main/java/com/puppycrawl/tools/checkstyle/site/PropertiesMacro.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/site/PropertiesMacro.java
@@ -29,7 +29,6 @@ import java.util.Locale;
 import java.util.Map;
 import java.util.Set;
 import java.util.regex.Pattern;
-import java.util.stream.Collectors;
 
 import org.apache.maven.doxia.macro.AbstractMacro;
 import org.apache.maven.doxia.macro.Macro;
@@ -39,6 +38,8 @@ import org.apache.maven.doxia.module.xdoc.XdocSink;
 import org.apache.maven.doxia.sink.Sink;
 import org.codehaus.plexus.component.annotations.Component;
 
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
 import com.puppycrawl.tools.checkstyle.PropertyType;
 import com.puppycrawl.tools.checkstyle.api.AbstractCheck;
 import com.puppycrawl.tools.checkstyle.api.DetailNode;
@@ -66,7 +67,7 @@ public class PropertiesMacro extends AbstractMacro {
                 "IllegalType - memberModifiers",
                 "MagicNumber - constantWaiverParentToken",
                 "MultipleStringLiterals - ignoreOccurrenceContext",
-            }).collect(Collectors.toSet()));
+            }).collect(ImmutableSet.toImmutableSet()));
 
     /** The precompiled pattern for a comma followed by a space. */
     private static final Pattern COMMA_SPACE_PATTERN = Pattern.compile(", ");
@@ -337,7 +338,7 @@ public class PropertiesMacro extends AbstractMacro {
                                 check.getRequiredTokens())
                         .stream()
                         .map(TokenUtil::getTokenName)
-                        .collect(Collectors.toList());
+                        .collect(ImmutableList.toImmutableList());
                 sink.text("subset of tokens");
 
                 writeTokensList(sink, configurableTokens, SiteUtil.PATH_TO_TOKEN_TYPES, true);
@@ -350,7 +351,7 @@ public class PropertiesMacro extends AbstractMacro {
                             check.getRequiredJavadocTokens())
                     .stream()
                     .map(JavadocUtil::getTokenName)
-                    .collect(Collectors.toList());
+                    .collect(ImmutableList.toImmutableList());
             sink.text("subset of javadoc tokens");
             writeTokensList(sink, configurableTokens, SiteUtil.PATH_TO_JAVADOC_TOKEN_TYPES, true);
         }
@@ -492,7 +493,7 @@ public class PropertiesMacro extends AbstractMacro {
                                 check.getRequiredTokens())
                         .stream()
                         .map(TokenUtil::getTokenName)
-                        .collect(Collectors.toList());
+                        .collect(ImmutableList.toImmutableList());
                 writeTokensList(sink, configurableTokens, SiteUtil.PATH_TO_TOKEN_TYPES, true);
             }
         }
@@ -503,7 +504,7 @@ public class PropertiesMacro extends AbstractMacro {
                             check.getRequiredJavadocTokens())
                     .stream()
                     .map(JavadocUtil::getTokenName)
-                    .collect(Collectors.toList());
+                    .collect(ImmutableList.toImmutableList());
             writeTokensList(sink, configurableTokens, SiteUtil.PATH_TO_JAVADOC_TOKEN_TYPES, true);
         }
         else {

--- a/src/main/java/com/puppycrawl/tools/checkstyle/site/SiteUtil.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/site/SiteUtil.java
@@ -19,6 +19,8 @@
 
 package com.puppycrawl.tools.checkstyle.site;
 
+import static java.util.stream.Collectors.toCollection;
+
 import java.beans.PropertyDescriptor;
 import java.io.File;
 import java.io.IOException;
@@ -56,6 +58,8 @@ import javax.annotation.Nullable;
 import org.apache.commons.beanutils.PropertyUtils;
 import org.apache.maven.doxia.macro.MacroExecutionException;
 
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Lists;
 import com.puppycrawl.tools.checkstyle.Checker;
 import com.puppycrawl.tools.checkstyle.DefaultConfiguration;
@@ -466,7 +470,7 @@ public final class SiteUtil {
                     return attr.isRegularFile()
                             && path.toString().endsWith(".xml.template");
                 })) {
-            return stream.collect(Collectors.toSet());
+            return stream.collect(ImmutableSet.toImmutableSet());
         }
         catch (IOException ioException) {
             throw new MacroExecutionException("Failed to find xdocs templates", ioException);
@@ -527,7 +531,7 @@ public final class SiteUtil {
                     .filter(prop -> {
                         return !isGlobalProperty(clss, prop) && !isUndocumentedProperty(clss, prop);
                     })
-                    .collect(Collectors.toSet());
+                    .collect(toCollection(HashSet::new));
         properties.addAll(getNonExplicitProperties(instance, clss));
         return new TreeSet<>(properties);
     }
@@ -1175,11 +1179,11 @@ public final class SiteUtil {
     public static List<Integer> getDifference(int[] tokens, int... subtractions) {
         final Set<Integer> subtractionsSet = Arrays.stream(subtractions)
                 .boxed()
-                .collect(Collectors.toSet());
+                .collect(ImmutableSet.toImmutableSet());
         return Arrays.stream(tokens)
                 .boxed()
                 .filter(token -> !subtractionsSet.contains(token))
-                .collect(Collectors.toList());
+                .collect(ImmutableList.toImmutableList());
     }
 
     /**

--- a/src/main/java/com/puppycrawl/tools/checkstyle/utils/ModuleReflectionUtil.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/utils/ModuleReflectionUtil.java
@@ -24,8 +24,8 @@ import java.lang.reflect.Constructor;
 import java.lang.reflect.Modifier;
 import java.util.Collection;
 import java.util.Set;
-import java.util.stream.Collectors;
 
+import com.google.common.collect.ImmutableSet;
 import com.google.common.reflect.ClassPath;
 import com.puppycrawl.tools.checkstyle.AbstractAutomaticBean;
 import com.puppycrawl.tools.checkstyle.TreeWalkerFilter;
@@ -61,7 +61,7 @@ public final class ModuleReflectionUtil {
                 .flatMap(pkg -> classPath.getTopLevelClasses(pkg).stream())
                 .map(ClassPath.ClassInfo::load)
                 .filter(ModuleReflectionUtil::isCheckstyleModule)
-                .collect(Collectors.toSet());
+                .collect(ImmutableSet.toImmutableSet());
     }
 
     /**

--- a/src/main/java/com/puppycrawl/tools/checkstyle/utils/TokenUtil.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/utils/TokenUtil.java
@@ -32,6 +32,7 @@ import java.util.function.Predicate;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
+import com.google.common.collect.ImmutableMap;
 import com.puppycrawl.tools.checkstyle.api.DetailAST;
 import com.puppycrawl.tools.checkstyle.api.TokenTypes;
 
@@ -109,7 +110,7 @@ public final class TokenUtil {
      */
     public static Map<Integer, String> invertMap(Map<String, Integer> map) {
         return map.entrySet().stream()
-            .collect(Collectors.toMap(Map.Entry::getValue, Map.Entry::getKey));
+            .collect(ImmutableMap.toImmutableMap(Map.Entry::getValue, Map.Entry::getKey));
     }
 
     /**

--- a/src/main/java/com/puppycrawl/tools/checkstyle/xpath/XpathQueryGenerator.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/xpath/XpathQueryGenerator.java
@@ -21,8 +21,8 @@ package com.puppycrawl.tools.checkstyle.xpath;
 
 import java.util.ArrayList;
 import java.util.List;
-import java.util.stream.Collectors;
 
+import com.google.common.collect.ImmutableList;
 import com.puppycrawl.tools.checkstyle.TreeWalkerAuditEvent;
 import com.puppycrawl.tools.checkstyle.api.DetailAST;
 import com.puppycrawl.tools.checkstyle.api.FileText;
@@ -143,7 +143,7 @@ public class XpathQueryGenerator {
         return getMatchingAstElements()
             .stream()
             .map(XpathQueryGenerator::generateXpathQuery)
-            .collect(Collectors.toList());
+            .collect(ImmutableList.toImmutableList());
     }
 
     /**

--- a/src/test/java/com/puppycrawl/tools/checkstyle/AbstractModuleTestSupport.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/AbstractModuleTestSupport.java
@@ -39,6 +39,7 @@ import java.util.Map;
 import java.util.ResourceBundle;
 import java.util.stream.Collectors;
 
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Maps;
 import com.puppycrawl.tools.checkstyle.LocalizedMessage.Utf8Control;
@@ -440,7 +441,7 @@ public abstract class AbstractModuleTestSupport extends AbstractPathTestSupport 
         final Checker checker = createChecker(config);
         final List<File> files = Arrays.stream(filenames)
                 .map(File::new)
-                .collect(Collectors.toList());
+                .collect(ImmutableList.toImmutableList());
         checker.process(files);
         checker.destroy();
     }
@@ -461,10 +462,10 @@ public abstract class AbstractModuleTestSupport extends AbstractPathTestSupport 
         final List<Integer> actualViolationLines = actualViolations.stream()
                 .map(violation -> violation.substring(0, violation.indexOf(':')))
                 .map(Integer::valueOf)
-                .collect(Collectors.toList());
+                .collect(ImmutableList.toImmutableList());
         final List<Integer> expectedViolationLines = testInputViolations.stream()
                 .map(TestInputViolation::getLineNo)
-                .collect(Collectors.toList());
+                .collect(ImmutableList.toImmutableList());
         assertWithMessage("Violation lines for %s differ.", file)
                 .that(actualViolationLines)
                 .isEqualTo(expectedViolationLines);

--- a/src/test/java/com/puppycrawl/tools/checkstyle/CheckerTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/CheckerTest.java
@@ -51,11 +51,11 @@ import java.util.Properties;
 import java.util.Set;
 import java.util.SortedSet;
 import java.util.TreeSet;
-import java.util.stream.Collectors;
 
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 
+import com.google.common.collect.ImmutableList;
 import com.puppycrawl.tools.checkstyle.AbstractAutomaticBean.OutputStreamOptions;
 import com.puppycrawl.tools.checkstyle.api.AbstractCheck;
 import com.puppycrawl.tools.checkstyle.api.AbstractFileSetCheck;
@@ -1627,7 +1627,7 @@ public class CheckerTest extends AbstractModuleTestSupport {
                     .filter(line -> !getCheckMessage(AUDIT_FINISHED_MESSAGE).equals(line))
                     .limit(expected.length)
                     .sorted()
-                    .collect(Collectors.toList());
+                    .collect(ImmutableList.toImmutableList());
             Arrays.sort(expected);
 
             for (int i = 0; i < expected.length; i++) {

--- a/src/test/java/com/puppycrawl/tools/checkstyle/JavaAstVisitorTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/JavaAstVisitorTest.java
@@ -19,7 +19,6 @@
 
 package com.puppycrawl.tools.checkstyle;
 
-import static com.google.common.collect.ImmutableSet.toImmutableSet;
 import static com.google.common.truth.Truth.assertWithMessage;
 
 import java.io.File;
@@ -30,7 +29,6 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Set;
-import java.util.stream.Collectors;
 
 import org.antlr.v4.runtime.CharStream;
 import org.antlr.v4.runtime.CharStreams;
@@ -107,7 +105,7 @@ public class JavaAstVisitorTest extends AbstractModuleTestSupport {
                 .filter(method -> method.getName().contains("visit"))
                 .filter(method -> method.getModifiers() == Modifier.PUBLIC)
                 .map(Method::getName)
-                .collect(Collectors.toSet());
+                .collect(ImmutableSet.toImmutableSet());
 
         final ImmutableSet<String> filteredVisitMethodNames = Arrays.stream(visitMethods)
                 .filter(method -> method.getName().contains("visit"))
@@ -116,7 +114,7 @@ public class JavaAstVisitorTest extends AbstractModuleTestSupport {
                 .filter(method -> !"visit".equals(method.getName()))
                 .filter(method -> method.getModifiers() == Modifier.PUBLIC)
                 .map(Method::getName)
-                .collect(toImmutableSet());
+                .collect(ImmutableSet.toImmutableSet());
 
         final String message = "Visit methods in 'JavaLanguageParserBaseVisitor' generated from "
                 + "production rules and labeled alternatives in 'JavaLanguageParser.g4' should "

--- a/src/test/java/com/puppycrawl/tools/checkstyle/XdocsPropertyTypeTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/XdocsPropertyTypeTest.java
@@ -25,11 +25,11 @@ import java.io.IOException;
 import java.util.Arrays;
 import java.util.Objects;
 import java.util.Set;
-import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import org.junit.jupiter.api.Test;
 
+import com.google.common.collect.ImmutableSet;
 import com.puppycrawl.tools.checkstyle.checks.header.AbstractHeaderCheck;
 import com.puppycrawl.tools.checkstyle.internal.utils.CheckUtil;
 import com.puppycrawl.tools.checkstyle.utils.CommonUtil;
@@ -46,7 +46,7 @@ public class XdocsPropertyTypeTest {
             .map(field -> field.getAnnotation(XdocsPropertyType.class))
             .filter(Objects::nonNull)
             .map(XdocsPropertyType::value)
-            .collect(Collectors.toSet());
+            .collect(ImmutableSet.toImmutableSet());
 
         assertWithMessage("All property types should be used")
             .that(propertyTypes)

--- a/src/test/java/com/puppycrawl/tools/checkstyle/api/TokenTypesTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/api/TokenTypesTest.java
@@ -27,10 +27,10 @@ import java.util.Collections;
 import java.util.Locale;
 import java.util.ResourceBundle;
 import java.util.Set;
-import java.util.stream.Collectors;
 
 import org.junit.jupiter.api.Test;
 
+import com.google.common.collect.ImmutableSet;
 import com.puppycrawl.tools.checkstyle.utils.TokenUtil;
 
 public class TokenTypesTest {
@@ -43,7 +43,7 @@ public class TokenTypesTest {
         final Set<String> expected = Arrays.stream(TokenUtil.getAllTokenIds())
             .mapToObj(TokenUtil::getTokenName)
             .filter(name -> name.charAt(0) != '$')
-            .collect(Collectors.toSet());
+            .collect(ImmutableSet.toImmutableSet());
         final Set<String> actual = bundle.keySet();
         assertWithMessage("TokenTypes without description")
                 .that(actual)
@@ -56,7 +56,7 @@ public class TokenTypesTest {
             .mapToObj(TokenUtil::getTokenName)
             .filter(name -> name.charAt(0) != '$')
             .map(TokenUtil::getShortDescription)
-            .filter(desc -> desc.charAt(desc.length() - 1) != '.').collect(Collectors.toSet());
+            .filter(desc -> desc.charAt(desc.length() - 1) != '.').collect(ImmutableSet.toImmutableSet());
         assertWithMessage("Malformed TokenType descriptions")
                 .that(badDescriptions)
                 .isEqualTo(Collections.emptySet());

--- a/src/test/java/com/puppycrawl/tools/checkstyle/bdd/InlineConfigParser.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/bdd/InlineConfigParser.java
@@ -37,10 +37,10 @@ import java.util.Properties;
 import java.util.Set;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
-import java.util.stream.Collectors;
 
 import org.xml.sax.InputSource;
 
+import com.google.common.collect.ImmutableList;
 import com.puppycrawl.tools.checkstyle.ConfigurationLoader;
 import com.puppycrawl.tools.checkstyle.PropertiesExpander;
 import com.puppycrawl.tools.checkstyle.api.CheckstyleException;
@@ -258,7 +258,7 @@ public final class InlineConfigParser {
         return lines.stream()
                 .skip(1)
                 .takeWhile(line -> !line.startsWith("*/"))
-                .collect(Collectors.toList());
+                .collect(ImmutableList.toImmutableList());
     }
 
     private static void handleXmlConfig(TestInputConfiguration.Builder testInputConfigBuilder,

--- a/src/test/java/com/puppycrawl/tools/checkstyle/grammar/GeneratedJavaTokenTypesTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/grammar/GeneratedJavaTokenTypesTest.java
@@ -27,11 +27,11 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
-import java.util.stream.Collectors;
 
 import org.antlr.v4.runtime.VocabularyImpl;
 import org.junit.jupiter.api.Test;
 
+import com.google.common.collect.ImmutableList;
 import com.puppycrawl.tools.checkstyle.grammar.java.JavaLanguageLexer;
 
 /**
@@ -740,7 +740,7 @@ public class GeneratedJavaTokenTypesTest {
         final String[] nullableSymbolicNames = vocabulary.getSymbolicNames();
         final List<String> allTokenNames = Arrays.stream(nullableSymbolicNames)
                 .filter(Objects::nonNull)
-                .collect(Collectors.toList());
+                .collect(ImmutableList.toImmutableList());
 
         // Since the following tokens are not declared in the 'tokens' block,
         // they will always appear last in the list of symbolic names provided

--- a/src/test/java/com/puppycrawl/tools/checkstyle/internal/AllChecksTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/internal/AllChecksTest.java
@@ -35,11 +35,11 @@ import java.util.Map.Entry;
 import java.util.Properties;
 import java.util.Set;
 import java.util.TreeMap;
-import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import org.junit.jupiter.api.Test;
 
+import com.google.common.collect.ImmutableSet;
 import com.puppycrawl.tools.checkstyle.AbstractModuleTestSupport;
 import com.puppycrawl.tools.checkstyle.DefaultConfiguration;
 import com.puppycrawl.tools.checkstyle.Definitions;
@@ -85,14 +85,14 @@ public class AllChecksTest extends AbstractModuleTestSupport {
 
         CHECKSTYLE_TOKENS_IN_CONFIG_TO_IGNORE.put("NoWhitespaceBefore", Stream.of(
                 // we use GenericWhitespace for this behavior
-                "GENERIC_START", "GENERIC_END").collect(Collectors.toSet()));
+                "GENERIC_START", "GENERIC_END").collect(ImmutableSet.toImmutableSet()));
         CHECKSTYLE_TOKENS_IN_CONFIG_TO_IGNORE.put("AbbreviationAsWordInName", Stream.of(
                 // enum values should be uppercase, we use EnumValueNameCheck instead
-                "ENUM_CONSTANT_DEF").collect(Collectors.toSet()));
+                "ENUM_CONSTANT_DEF").collect(ImmutableSet.toImmutableSet()));
         CHECKSTYLE_TOKENS_IN_CONFIG_TO_IGNORE.put("FinalLocalVariable", Stream.of(
                 // we prefer all parameters be effectively final as to not damage readability
                 // we use ParameterAssignmentCheck to enforce this
-                "PARAMETER_DEF").collect(Collectors.toSet()));
+                "PARAMETER_DEF").collect(ImmutableSet.toImmutableSet()));
         // we have no need to block these specific tokens
         CHECKSTYLE_TOKENS_IN_CONFIG_TO_IGNORE.put("IllegalToken",
                 Stream.of("LITERAL_SUPER", "LITERAL_ASSERT", "ENUM_CONSTANT_DEF",
@@ -134,24 +134,24 @@ public class AllChecksTest extends AbstractModuleTestSupport {
                         "RECORD_COMPONENTS", "RECORD_COMPONENT_DEF", "COMPACT_CTOR_DEF",
                         "TEXT_BLOCK_LITERAL_BEGIN", "TEXT_BLOCK_CONTENT", "TEXT_BLOCK_LITERAL_END",
                         "LITERAL_YIELD", "SWITCH_RULE")
-                        .collect(Collectors.toSet()));
+                        .collect(ImmutableSet.toImmutableSet()));
         // we have no need to block specific token text
         CHECKSTYLE_TOKENS_IN_CONFIG_TO_IGNORE.put("IllegalTokenText",
                 Stream.of("NUM_DOUBLE", "NUM_FLOAT", "NUM_INT", "NUM_LONG", "IDENT",
                     "COMMENT_CONTENT", "STRING_LITERAL", "CHAR_LITERAL", "TEXT_BLOCK_CONTENT")
-                    .collect(Collectors.toSet()));
+                    .collect(ImmutableSet.toImmutableSet()));
         // we do not use this check as it is deprecated
         CHECKSTYLE_TOKENS_IN_CONFIG_TO_IGNORE.put("WriteTag",
                 Stream.of("ENUM_CONSTANT_DEF", "METHOD_DEF", "CTOR_DEF",
                     "ANNOTATION_FIELD_DEF", "RECORD_DEF", "COMPACT_CTOR_DEF")
-                    .collect(Collectors.toSet()));
+                    .collect(ImmutableSet.toImmutableSet()));
         // state of the configuration when test was made until reason found in
         // https://github.com/checkstyle/checkstyle/issues/3730
         CHECKSTYLE_TOKENS_IN_CONFIG_TO_IGNORE.put("AnnotationLocation",
                 Stream.of("CLASS_DEF", "CTOR_DEF", "ENUM_DEF", "INTERFACE_DEF",
                         "METHOD_DEF", "VARIABLE_DEF",
                         "RECORD_DEF", "COMPACT_CTOR_DEF")
-                        .collect(Collectors.toSet()));
+                        .collect(ImmutableSet.toImmutableSet()));
         CHECKSTYLE_TOKENS_IN_CONFIG_TO_IGNORE.put("NoLineWrap", Stream.of(
                 // method/constructor declaration could be long due to "parameters/exceptions", it
                 // is ok to be not strict there
@@ -159,43 +159,43 @@ public class AllChecksTest extends AbstractModuleTestSupport {
                 // type declaration could be long due to "extends/implements", it is ok to
                 // be not strict there
                 "CLASS_DEF", "ENUM_DEF", "INTERFACE_DEF", "RECORD_DEF")
-                .collect(Collectors.toSet()));
+                .collect(ImmutableSet.toImmutableSet()));
         CHECKSTYLE_TOKENS_IN_CONFIG_TO_IGNORE.put("NoWhitespaceAfter", Stream.of(
                 // whitespace after is preferred
-                "TYPECAST", "LITERAL_SYNCHRONIZED").collect(Collectors.toSet()));
+                "TYPECAST", "LITERAL_SYNCHRONIZED").collect(ImmutableSet.toImmutableSet()));
         CHECKSTYLE_TOKENS_IN_CONFIG_TO_IGNORE.put("SeparatorWrap", Stream.of(
                 // needs context to decide what type of parentheses should be separated or not
                 // which this check does not provide
-                "LPAREN", "RPAREN").collect(Collectors.toSet()));
+                "LPAREN", "RPAREN").collect(ImmutableSet.toImmutableSet()));
         CHECKSTYLE_TOKENS_IN_CONFIG_TO_IGNORE.put("NeedBraces", Stream.of(
                 // we prefer no braces here as it looks unusual even though they help avoid sharing
                 // scope of variables
-                "LITERAL_DEFAULT", "LITERAL_CASE").collect(Collectors.toSet()));
+                "LITERAL_DEFAULT", "LITERAL_CASE").collect(ImmutableSet.toImmutableSet()));
         CHECKSTYLE_TOKENS_IN_CONFIG_TO_IGNORE.put("FinalParameters", Stream.of(
                 // we prefer these to be effectively final as to not damage readability
-                "FOR_EACH_CLAUSE", "LITERAL_CATCH").collect(Collectors.toSet()));
+                "FOR_EACH_CLAUSE", "LITERAL_CATCH").collect(ImmutableSet.toImmutableSet()));
         CHECKSTYLE_TOKENS_IN_CONFIG_TO_IGNORE.put("WhitespaceAround", Stream.of(
                 // we prefer no spaces on one side or both for these tokens
                 "ARRAY_INIT",
                 "ELLIPSIS",
                 // these are covered by GenericWhitespaceCheck
-                "WILDCARD_TYPE", "GENERIC_END", "GENERIC_START").collect(Collectors.toSet()));
+                "WILDCARD_TYPE", "GENERIC_END", "GENERIC_START").collect(ImmutableSet.toImmutableSet()));
 
         // google
         GOOGLE_TOKENS_IN_CONFIG_TO_IGNORE.put("AnnotationLocation", Stream.of(
                 // state of the configuration when test was made until reason found in
                 // https://github.com/checkstyle/checkstyle/issues/3730
                 "ANNOTATION_DEF", "ANNOTATION_FIELD_DEF", "ENUM_CONSTANT_DEF", "PACKAGE_DEF")
-                .collect(Collectors.toSet()));
+                .collect(ImmutableSet.toImmutableSet()));
         GOOGLE_TOKENS_IN_CONFIG_TO_IGNORE.put("AbbreviationAsWordInName", Stream.of(
                 // enum values should be uppercase
-                "ENUM_CONSTANT_DEF").collect(Collectors.toSet()));
+                "ENUM_CONSTANT_DEF").collect(ImmutableSet.toImmutableSet()));
         GOOGLE_TOKENS_IN_CONFIG_TO_IGNORE.put("NoLineWrap", Stream.of(
                 // method declaration could be long due to "parameters/exceptions", it is ok to
                 // be not strict there
                 "METHOD_DEF", "CTOR_DEF", "CLASS_DEF", "ENUM_DEF", "INTERFACE_DEF", "RECORD_DEF",
                 "COMPACT_CTOR_DEF")
-                .collect(Collectors.toSet()));
+                .collect(ImmutableSet.toImmutableSet()));
         GOOGLE_TOKENS_IN_CONFIG_TO_IGNORE.put("SeparatorWrap", Stream.of(
                 // location could be any to allow writing expressions for indexes evaluation
                 // on new line, see https://github.com/checkstyle/checkstyle/issues/3752
@@ -208,10 +208,10 @@ public class AllChecksTest extends AbstractModuleTestSupport {
                 "SEMI",
                 // needs context to decide what type of parentheses should be separated or not
                 // which this check does not provide
-                "LPAREN", "RPAREN").collect(Collectors.toSet()));
+                "LPAREN", "RPAREN").collect(ImmutableSet.toImmutableSet()));
         GOOGLE_TOKENS_IN_CONFIG_TO_IGNORE.put("NeedBraces", Stream.of(
                 // google doesn't require or prevent braces on these
-                "LAMBDA", "LITERAL_DEFAULT", "LITERAL_CASE").collect(Collectors.toSet()));
+                "LAMBDA", "LITERAL_DEFAULT", "LITERAL_CASE").collect(ImmutableSet.toImmutableSet()));
         GOOGLE_TOKENS_IN_CONFIG_TO_IGNORE.put("EmptyBlock", Stream.of(
                 // google doesn't specifically mention empty braces at the start of a case/default
                 "LITERAL_DEFAULT", "LITERAL_CASE",
@@ -222,7 +222,7 @@ public class AllChecksTest extends AbstractModuleTestSupport {
                 // state of the configuration when test was made until
                 // https://github.com/checkstyle/checkstyle/issues/4121
                 "INSTANCE_INIT", "LITERAL_DO", "LITERAL_FOR", "LITERAL_SYNCHRONIZED",
-                "LITERAL_WHILE", "STATIC_INIT").collect(Collectors.toSet()));
+                "LITERAL_WHILE", "STATIC_INIT").collect(ImmutableSet.toImmutableSet()));
         GOOGLE_TOKENS_IN_CONFIG_TO_IGNORE.put("WhitespaceAround", Stream.of(
                 //  allowed via '4.8.3 Arrays'
                 "ARRAY_INIT",
@@ -230,12 +230,12 @@ public class AllChecksTest extends AbstractModuleTestSupport {
                 "ELLIPSIS",
                 // google prefers no spaces on one side or both for these tokens
                 "GENERIC_START", "GENERIC_END", "WILDCARD_TYPE")
-                .collect(Collectors.toSet()));
+                .collect(ImmutableSet.toImmutableSet()));
         GOOGLE_TOKENS_IN_CONFIG_TO_IGNORE.put("IllegalTokenText", Stream.of(
                 // all other java tokens and text are allowed
                 "NUM_DOUBLE", "NUM_FLOAT", "NUM_INT", "NUM_LONG", "IDENT",
                 "COMMENT_CONTENT", "STRING_LITERAL", "CHAR_LITERAL", "TEXT_BLOCK_CONTENT")
-                .collect(Collectors.toSet()));
+                .collect(ImmutableSet.toImmutableSet()));
         GOOGLE_TOKENS_IN_CONFIG_TO_IGNORE.put("OperatorWrap", Stream.of(
                 // specifically allowed via '4.5.1 Where to break' because the following are
                 // assignment operators and they are allowed to break before or after the symbol
@@ -244,19 +244,19 @@ public class AllChecksTest extends AbstractModuleTestSupport {
                 "MOD_ASSIGN",
                 // COLON token ignored in check config, explained in
                 // https://github.com/checkstyle/checkstyle/issues/4122
-                "COLON").collect(Collectors.toSet()));
+                "COLON").collect(ImmutableSet.toImmutableSet()));
         GOOGLE_TOKENS_IN_CONFIG_TO_IGNORE.put("NoWhitespaceBefore", Stream.of(
                 // google uses GenericWhitespace for this behavior
                 "GENERIC_START", "GENERIC_END",
                 // whitespace is necessary between a type annotation and ellipsis
                 // according '4.6.2 Horizontal whitespace point 9'
-                "ELLIPSIS").collect(Collectors.toSet()));
+                "ELLIPSIS").collect(ImmutableSet.toImmutableSet()));
         INTERNAL_MODULES = Definitions.INTERNAL_MODULES.stream()
                 .map(moduleName -> {
                     final String[] packageTokens = moduleName.split("\\.");
                     return packageTokens[packageTokens.length - 1];
                 })
-                .collect(Collectors.toSet());
+                .collect(ImmutableSet.toImmutableSet());
     }
 
     @Override

--- a/src/test/java/com/puppycrawl/tools/checkstyle/internal/CliOptionsXdocsSyncTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/internal/CliOptionsXdocsSyncTest.java
@@ -31,13 +31,13 @@ import java.util.Map;
 import java.util.Set;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
-import java.util.stream.Collectors;
 
 import org.junit.jupiter.api.Test;
 import org.w3c.dom.Document;
 import org.w3c.dom.Node;
 import org.w3c.dom.NodeList;
 
+import com.google.common.collect.ImmutableSet;
 import com.puppycrawl.tools.checkstyle.internal.utils.XmlUtil;
 import picocli.CommandLine;
 import picocli.CommandLine.Model.OptionSpec;
@@ -99,12 +99,12 @@ public class CliOptionsXdocsSyncTest {
         final Set<String> shortParamsMain = commandLine.getCommandSpec().options()
                         .stream()
                         .map(OptionSpec::shortestName)
-                        .collect(Collectors.toSet());
+                        .collect(ImmutableSet.toImmutableSet());
         final Set<String> longParamsMain = commandLine.getCommandSpec().options()
                         .stream()
                         .map(OptionSpec::longestName)
                         .filter(names -> names.length() != 2)
-                        .collect(Collectors.toSet());
+                        .collect(ImmutableSet.toImmutableSet());
 
         assertWithMessage("Short parameters in Main.java and cmdline"
                 + ".xml.vm should match")
@@ -140,7 +140,7 @@ public class CliOptionsXdocsSyncTest {
             result = XmlUtil.getChildrenElements(node)
                     .stream()
                     .map(Node::getTextContent)
-                    .collect(Collectors.toSet());
+                    .collect(ImmutableSet.toImmutableSet());
         }
         return result;
     }

--- a/src/test/java/com/puppycrawl/tools/checkstyle/internal/CommitValidationTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/internal/CommitValidationTest.java
@@ -29,7 +29,6 @@ import java.util.List;
 import java.util.Spliterator;
 import java.util.Spliterators;
 import java.util.regex.Pattern;
-import java.util.stream.Collectors;
 import java.util.stream.StreamSupport;
 
 import org.eclipse.jgit.api.Git;
@@ -41,6 +40,8 @@ import org.eclipse.jgit.revwalk.RevCommit;
 import org.eclipse.jgit.revwalk.RevWalk;
 import org.eclipse.jgit.storage.file.FileRepositoryBuilder;
 import org.junit.jupiter.api.Test;
+
+import com.google.common.collect.ImmutableList;
 
 /**
  * Validate commit message has proper structure.
@@ -319,7 +320,7 @@ public class CommitValidationTest {
         final Spliterator<RevCommit> spliterator =
             Spliterators.spliteratorUnknownSize(previousCommitsIterator, Spliterator.ORDERED);
         return StreamSupport.stream(spliterator, false).limit(PREVIOUS_COMMITS_TO_CHECK_COUNT)
-            .collect(Collectors.toList());
+            .collect(ImmutableList.toImmutableList());
     }
 
     private static List<RevCommit> getCommitsByLastCommitAuthor(

--- a/src/test/java/com/puppycrawl/tools/checkstyle/internal/ImmutabilityTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/internal/ImmutabilityTest.java
@@ -31,10 +31,10 @@ import java.util.Locale;
 import java.util.Map;
 import java.util.Set;
 import java.util.function.Function;
-import java.util.stream.Collectors;
 
 import org.junit.jupiter.api.Test;
 
+import com.google.common.collect.ImmutableMap;
 import com.puppycrawl.tools.checkstyle.FileStatefulCheck;
 import com.puppycrawl.tools.checkstyle.GlobalStatefulCheck;
 import com.puppycrawl.tools.checkstyle.StatelessCheck;
@@ -219,7 +219,7 @@ public class ImmutabilityTest {
      */
     private static final Map<String, ModuleDetails> MODULE_DETAILS_MAP =
         XmlMetaReader.readAllModulesIncludingThirdPartyIfAny().stream()
-            .collect(Collectors.toMap(ModuleDetails::getFullQualifiedName,
+            .collect(ImmutableMap.toImmutableMap(ModuleDetails::getFullQualifiedName,
                                       Function.identity()));
 
     /**

--- a/src/test/java/com/puppycrawl/tools/checkstyle/internal/XdocsPagesTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/internal/XdocsPagesTest.java
@@ -63,6 +63,7 @@ import org.w3c.dom.Node;
 import org.w3c.dom.NodeList;
 import org.xml.sax.InputSource;
 
+import com.google.common.collect.ImmutableSet;
 import com.puppycrawl.tools.checkstyle.Checker;
 import com.puppycrawl.tools.checkstyle.ConfigurationLoader;
 import com.puppycrawl.tools.checkstyle.ConfigurationLoader.IgnoredModulesOptions;
@@ -1409,7 +1410,7 @@ public class XdocsPagesTest {
             result = XmlUtil.getChildrenElements(node)
                     .stream()
                     .map(Node::getTextContent)
-                    .collect(Collectors.toSet());
+                    .collect(ImmutableSet.toImmutableSet());
         }
         return result;
     }

--- a/src/test/java/com/puppycrawl/tools/checkstyle/internal/XdocsUrlTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/internal/XdocsUrlTest.java
@@ -32,7 +32,6 @@ import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Set;
-import java.util.stream.Collectors;
 
 import javax.xml.parsers.SAXParser;
 import javax.xml.parsers.SAXParserFactory;
@@ -41,6 +40,7 @@ import org.junit.jupiter.api.Test;
 import org.xml.sax.Attributes;
 import org.xml.sax.helpers.DefaultHandler;
 
+import com.google.common.collect.ImmutableSet;
 import com.puppycrawl.tools.checkstyle.api.AbstractCheck;
 import com.puppycrawl.tools.checkstyle.api.AbstractFileSetCheck;
 import com.puppycrawl.tools.checkstyle.internal.utils.CheckUtil;
@@ -76,7 +76,7 @@ public class XdocsUrlTest {
                     return AbstractCheck.class.isAssignableFrom(clazz)
                             || AbstractFileSetCheck.class.isAssignableFrom(clazz);
                 })
-                .collect(Collectors.toSet());
+                .collect(ImmutableSet.toImmutableSet());
         for (Class<?> check : treeWalkerOrFileSetCheckSet) {
             final String checkName = check.getSimpleName();
             if (!TREE_WORKER.equals(checkName)) {

--- a/src/test/java/com/puppycrawl/tools/checkstyle/internal/XpathRegressionTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/internal/XpathRegressionTest.java
@@ -38,6 +38,8 @@ import java.util.stream.Collectors;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
 import com.puppycrawl.tools.checkstyle.AbstractModuleTestSupport;
 import com.puppycrawl.tools.checkstyle.Definitions;
 import com.puppycrawl.tools.checkstyle.checks.javadoc.AbstractJavadocCheck;
@@ -149,7 +151,7 @@ public class XpathRegressionTest extends AbstractModuleTestSupport {
     private static Map<String, String> getAllowedDirectoryAndChecks() {
         return SIMPLE_CHECK_NAMES
             .stream()
-            .collect(Collectors.toMap(id -> id.toLowerCase(Locale.ENGLISH), Function.identity()));
+            .collect(ImmutableMap.toImmutableMap(id -> id.toLowerCase(Locale.ENGLISH), Function.identity()));
     }
 
     private static Set<String> getInternalModules() {
@@ -158,7 +160,7 @@ public class XpathRegressionTest extends AbstractModuleTestSupport {
                 final String[] packageTokens = moduleName.split("\\.");
                 return packageTokens[packageTokens.length - 1];
             })
-            .collect(Collectors.toSet());
+            .collect(ImmutableSet.toImmutableSet());
     }
 
     @BeforeEach

--- a/src/test/java/com/puppycrawl/tools/checkstyle/internal/utils/CheckUtil.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/internal/utils/CheckUtil.java
@@ -39,6 +39,7 @@ import org.w3c.dom.Element;
 import org.w3c.dom.Node;
 import org.w3c.dom.NodeList;
 
+import com.google.common.collect.ImmutableSet;
 import com.google.common.reflect.ClassPath;
 import com.puppycrawl.tools.checkstyle.api.FileText;
 import com.puppycrawl.tools.checkstyle.checks.coding.AbstractSuperCheck;
@@ -151,7 +152,7 @@ public final class CheckUtil {
         final String packageName = "com.puppycrawl.tools.checkstyle";
         return getCheckstyleModulesRecursive(packageName, loader).stream()
                 .filter(ModuleReflectionUtil::isCheckstyleTreeWalkerCheck)
-                .collect(Collectors.toSet());
+                .collect(ImmutableSet.toImmutableSet());
     }
 
     /**
@@ -183,7 +184,7 @@ public final class CheckUtil {
                 .map(ClassPath.ClassInfo::load)
                 .filter(ModuleReflectionUtil::isCheckstyleModule)
                 .filter(CheckUtil::isFromAllowedPackages)
-                .collect(Collectors.toSet());
+                .collect(ImmutableSet.toImmutableSet());
     }
 
     /**

--- a/src/test/java/com/puppycrawl/tools/checkstyle/internal/utils/XdocUtil.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/internal/utils/XdocUtil.java
@@ -25,7 +25,6 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.HashSet;
 import java.util.Set;
-import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import javax.xml.parsers.DocumentBuilder;
@@ -37,6 +36,8 @@ import org.w3c.dom.Element;
 import org.w3c.dom.Node;
 import org.w3c.dom.NodeList;
 import org.xml.sax.SAXException;
+
+import com.google.common.collect.ImmutableSet;
 
 /**
  * XdocUtil.
@@ -65,7 +66,7 @@ public final class XdocUtil {
                             && (path.toString().endsWith(".xml")
                             || path.toString().endsWith(".xml.vm"));
                 })) {
-            return stream.collect(Collectors.toSet());
+            return stream.collect(ImmutableSet.toImmutableSet());
         }
     }
 
@@ -84,7 +85,7 @@ public final class XdocUtil {
                     return attr.isRegularFile()
                             && path.toString().endsWith(".xml.template");
                 })) {
-            return stream.collect(Collectors.toSet());
+            return stream.collect(ImmutableSet.toImmutableSet());
         }
     }
 


### PR DESCRIPTION
Issue https://github.com/checkstyle/checkstyle/issues/14137.

This PR enables the CollectorMutablility check, see [documentation](https://error-prone.picnic.tech/bugpatterns/CollectorMutability/).

Initially this was brought up in https://github.com/checkstyle/checkstyle/pull/12777#pullrequestreview-1325151741.