### PR TITLE
Issue #14137: Enable `AsertJIsNull` check

### DIFF
--- a/config/jsoref-spellchecker/whitelist.words
+++ b/config/jsoref-spellchecker/whitelist.words
@@ -685,6 +685,7 @@ jhu
 jide
 jidesoft
 jira
+JIs
 jitpack
 jkl
 JLabel

--- a/pom.xml
+++ b/pom.xml
@@ -239,6 +239,7 @@
     <doxia.version>1.12.0</doxia.version>
     <error-prone.configuration-args>
       -Xep:AmbiguousJsonCreator:ERROR
+      -Xep:AssertJIsNull:ERROR
       <!-- Reason at https://github.com/checkstyle/checkstyle/issues/8252. -->
       -Xep:JUnitClassModifiers:OFF
       <!-- Reason at https://github.com/checkstyle/checkstyle/issues/8252. -->


### PR DESCRIPTION
Issue #14137.

This PR enables the `AssertJIsNull` check, see https://error-prone.picnic.tech/bugpatterns/AssertJIsNull/. 