### PR TITLE
Issue#13345: Enable ilegalTokenTextExamplesTest

### DIFF
--- a/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/checks/coding/IllegalTokenTextCheckExamplesTest.java
+++ b/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/checks/coding/IllegalTokenTextCheckExamplesTest.java
@@ -19,12 +19,12 @@
 
 package com.puppycrawl.tools.checkstyle.checks.coding;
 
-import org.junit.jupiter.api.Disabled;
+import static com.puppycrawl.tools.checkstyle.checks.coding.IllegalTokenTextCheck.MSG_KEY;
+
 import org.junit.jupiter.api.Test;
 
 import com.puppycrawl.tools.checkstyle.AbstractExamplesModuleTestSupport;
 
-@Disabled("until https://github.com/checkstyle/checkstyle/issues/13345")
 public class IllegalTokenTextCheckExamplesTest extends AbstractExamplesModuleTestSupport {
     @Override
     protected String getPackageLocation() {
@@ -34,36 +34,38 @@ public class IllegalTokenTextCheckExamplesTest extends AbstractExamplesModuleTes
     @Test
     public void testExample1() throws Exception {
         final String[] expected = {
-
+            "17:20: " + getCheckMessage(MSG_KEY, "a href"),
         };
 
-        verifyWithInlineConfigParser(getPath("Example1.txt"), expected);
+        verifyWithInlineConfigParser(getPath("Example1.java"), expected);
     }
 
     @Test
     public void testExample2() throws Exception {
         final String[] expected = {
-
+            "18:20: " + getCheckMessage(MSG_KEY, "a href"),
+            "19:20: " + getCheckMessage(MSG_KEY, "a href"),
         };
 
-        verifyWithInlineConfigParser(getPath("Example2.txt"), expected);
+        verifyWithInlineConfigParser(getPath("Example2.java"), expected);
     }
 
     @Test
     public void testExample3() throws Exception {
         final String[] expected = {
-
+            "18:29: " + getCheckMessage(MSG_KEY, '"'),
         };
 
-        verifyWithInlineConfigParser(getPath("Example3.txt"), expected);
+        verifyWithInlineConfigParser(getNonCompilablePath("Example3.java"), expected);
     }
 
     @Test
     public void testExample4() throws Exception {
         final String[] expected = {
-
+            "21:17: " + getCheckMessage(MSG_KEY, "^0[^lx]"),
+            "23:18: " + getCheckMessage(MSG_KEY, "^0[^lx]"),
         };
 
-        verifyWithInlineConfigParser(getPath("Example4.txt"), expected);
+        verifyWithInlineConfigParser(getPath("Example4.java"), expected);
     }
 }

--- a/src/xdocs-examples/resources-noncompilable/com/puppycrawl/tools/checkstyle/checks/coding/illegaltokentext/Example3.java
+++ b/src/xdocs-examples/resources-noncompilable/com/puppycrawl/tools/checkstyle/checks/coding/illegaltokentext/Example3.java
@@ -8,10 +8,15 @@
   </module>
 </module>
 */
+//non-compiled with javac: Compilable with Java14
 
 // xdoc section -- start
-public void myTest() {
+package com.puppycrawl.tools.checkstyle.checks.coding.illegaltokentext;
+
+public class Example3 {
+  public void myTest() {
     final String quote = """
-               \""""; // violation
+            \""""; // violation above
+  }
 }
 // xdoc section -- end

--- a/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/coding/illegaltokentext/Example1.java
+++ b/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/coding/illegaltokentext/Example1.java
@@ -9,9 +9,13 @@
 </module>
 */
 
+package com.puppycrawl.tools.checkstyle.checks.coding.illegaltokentext;
+
 // xdoc section -- start
-public void myTest() {
-    String test = "a href"; // violation
+public class Example1 {
+  public void myTest() {
+    String test  = "a href"; // violation
     String test2 = "A href"; // OK, case is sensitive
+  }
 }
 // xdoc section -- end

--- a/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/coding/illegaltokentext/Example2.java
+++ b/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/coding/illegaltokentext/Example2.java
@@ -10,9 +10,13 @@
 </module>
 */
 
+package com.puppycrawl.tools.checkstyle.checks.coding.illegaltokentext;
+
 // xdoc section -- start
-public void myTest() {
-    String test = "a href"; // violation
-    String test2 = "A href"; // violation, case is ignored
+public class Example2 {
+  public void myTest() {
+    String test  = "a href"; // violation
+    String test2 = "A href"; // violation
+  }
 }
 // xdoc section -- end

--- a/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/coding/illegaltokentext/Example4.java
+++ b/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/coding/illegaltokentext/Example4.java
@@ -10,13 +10,17 @@
 </module>
 */
 
+package com.puppycrawl.tools.checkstyle.checks.coding.illegaltokentext;
+
 // xdoc section -- start
-public void myTest() {
+public class Example4 {
+  public void myTest() {
     int test1 = 0; // OK
     int test2 = 0x111; // OK
     int test3 = 0X111; // OK, case is ignored
     int test4 = 010; // violation
     long test5 = 0L; // OK
     long test6 = 010L; // violation
+  }
 }
 // xdoc section -- end

--- a/src/xdocs/checks/coding/illegaltokentext.xml
+++ b/src/xdocs/checks/coding/illegaltokentext.xml
@@ -94,9 +94,11 @@
         </source>
         <p id="Example1-code">Example:</p>
         <source>
-public void myTest() {
-    String test = &quot;a href&quot;; // violation
+public class Example1 {
+  public void myTest() {
+    String test  = &quot;a href&quot;; // violation
     String test2 = &quot;A href&quot;; // OK, case is sensitive
+  }
 }
         </source>
         <p id="Example2-config">
@@ -116,14 +118,16 @@ public void myTest() {
         </source>
         <p id="Example2-code">Example:</p>
         <source>
-public void myTest() {
-    String test = &quot;a href&quot;; // violation
-    String test2 = &quot;A href&quot;; // violation, case is ignored
+public class Example2 {
+  public void myTest() {
+    String test  = &quot;a href&quot;; // violation
+    String test2 = &quot;A href&quot;; // violation
+  }
 }
         </source>
         <p id="Example3-config">
           To configure the check to forbid string literal text blocks containing
-          <code>&quot;&quot;&quot;</code>:
+          <code>&quot;</code>:
         </p>
         <source>
 &lt;module name=&quot;Checker&quot;&gt;
@@ -137,9 +141,13 @@ public void myTest() {
         </source>
         <p id="Example3-code">Example:</p>
         <source>
-public void myTest() {
+package com.puppycrawl.tools.checkstyle.checks.coding.illegaltokentext;
+
+public class Example3 {
+  public void myTest() {
     final String quote = &quot;&quot;&quot;
-               \&quot;&quot;&quot;&quot;; // violation
+            \&quot;&quot;&quot;&quot;; // violation above
+  }
 }
         </source>
         <p id="Example4-config">
@@ -159,13 +167,15 @@ public void myTest() {
         </source>
         <p id="Example4-code">Example:</p>
         <source>
-public void myTest() {
+public class Example4 {
+  public void myTest() {
     int test1 = 0; // OK
     int test2 = 0x111; // OK
     int test3 = 0X111; // OK, case is ignored
     int test4 = 010; // violation
     long test5 = 0L; // OK
     long test6 = 010L; // violation
+  }
 }
         </source>
       </subsection>

--- a/src/xdocs/checks/coding/illegaltokentext.xml.template
+++ b/src/xdocs/checks/coding/illegaltokentext.xml.template
@@ -31,13 +31,13 @@
         </p>
         <macro name="example">
           <param name="path"
-                 value="resources/com/puppycrawl/tools/checkstyle/checks/coding/illegaltokentext/Example1.txt"/>
+                 value="resources/com/puppycrawl/tools/checkstyle/checks/coding/illegaltokentext/Example1.java"/>
           <param name="type" value="config"/>
         </macro>
         <p id="Example1-code">Example:</p>
         <macro name="example">
           <param name="path"
-                 value="resources/com/puppycrawl/tools/checkstyle/checks/coding/illegaltokentext/Example1.txt"/>
+                 value="resources/com/puppycrawl/tools/checkstyle/checks/coding/illegaltokentext/Example1.java"/>
           <param name="type" value="code"/>
         </macro>
         <p id="Example2-config">
@@ -46,28 +46,28 @@
         </p>
         <macro name="example">
           <param name="path"
-                 value="resources/com/puppycrawl/tools/checkstyle/checks/coding/illegaltokentext/Example2.txt"/>
+                 value="resources/com/puppycrawl/tools/checkstyle/checks/coding/illegaltokentext/Example2.java"/>
           <param name="type" value="config"/>
         </macro>
         <p id="Example2-code">Example:</p>
         <macro name="example">
           <param name="path"
-                 value="resources/com/puppycrawl/tools/checkstyle/checks/coding/illegaltokentext/Example2.txt"/>
+                 value="resources/com/puppycrawl/tools/checkstyle/checks/coding/illegaltokentext/Example2.java"/>
           <param name="type" value="code"/>
         </macro>
         <p id="Example3-config">
           To configure the check to forbid string literal text blocks containing
-          <code>"""</code>:
+          <code>"</code>:
         </p>
         <macro name="example">
           <param name="path"
-                 value="resources/com/puppycrawl/tools/checkstyle/checks/coding/illegaltokentext/Example3.txt"/>
+                 value="resources-noncompilable/com/puppycrawl/tools/checkstyle/checks/coding/illegaltokentext/Example3.java"/>
           <param name="type" value="config"/>
         </macro>
         <p id="Example3-code">Example:</p>
         <macro name="example">
           <param name="path"
-                 value="resources/com/puppycrawl/tools/checkstyle/checks/coding/illegaltokentext/Example3.txt"/>
+                 value="resources-noncompilable/com/puppycrawl/tools/checkstyle/checks/coding/illegaltokentext/Example3.java"/>
           <param name="type" value="code"/>
         </macro>
         <p id="Example4-config">
@@ -76,13 +76,13 @@
         </p>
         <macro name="example">
           <param name="path"
-                 value="resources/com/puppycrawl/tools/checkstyle/checks/coding/illegaltokentext/Example4.txt"/>
+                 value="resources/com/puppycrawl/tools/checkstyle/checks/coding/illegaltokentext/Example4.java"/>
           <param name="type" value="config"/>
         </macro>
         <p id="Example4-code">Example:</p>
         <macro name="example">
           <param name="path"
-                 value="resources/com/puppycrawl/tools/checkstyle/checks/coding/illegaltokentext/Example4.txt"/>
+                 value="resources/com/puppycrawl/tools/checkstyle/checks/coding/illegaltokentext/Example4.java"/>
           <param name="type" value="code"/>
         </macro>
       </subsection>


### PR DESCRIPTION
Issue: #13345 
Sorry for deleting the branch causing the last PR to close.
1. In example2, the program failed to detect violation message with explanation, problem may be in src/test/java/com/puppycrawl/tools/checkstyle/bdd/InlineConfigParser.java
2. In example3, text block will cause compile error in source10 environment, I turned it to another pattern and thus, test disabled 
