### PR TITLE
Issue #14137: Enable `AutowiredConstructor` check

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -240,6 +240,7 @@
     <error-prone.configuration-args>
       -Xep:AmbiguousJsonCreator:ERROR
       -Xep:AssertJIsNull:ERROR
+      -Xep:AutowiredConstructor:ERROR
       <!-- Reason at https://github.com/checkstyle/checkstyle/issues/8252. -->
       -Xep:JUnitClassModifiers:OFF
       <!-- Reason at https://github.com/checkstyle/checkstyle/issues/8252. -->


### PR DESCRIPTION
Issue #14137.

This PR enables the following check: https://error-prone.picnic.tech/bugpatterns/AutowiredConstructor/.