### PR TITLE
Issue #14137: Enable `CanonicalAnnotationSyntax` check

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -241,6 +241,7 @@
       -Xep:AmbiguousJsonCreator:ERROR
       -Xep:AssertJIsNull:ERROR
       -Xep:AutowiredConstructor:ERROR
+      -Xep:CanonicalAnnotationSyntax:ERROR
       <!-- Reason at https://github.com/checkstyle/checkstyle/issues/8252. -->
       -Xep:JUnitClassModifiers:OFF
       <!-- Reason at https://github.com/checkstyle/checkstyle/issues/8252. -->


### PR DESCRIPTION
Issue #14137.

This PR enables the https://error-prone.picnic.tech/bugpatterns/CanonicalAnnotationSyntax/ check.