### PR TITLE
Issue #13999: Resolve pitest suppression for index += 2; of JavadocStyleCheck

### DIFF
--- a/config/pitest-suppressions/pitest-javadoc-suppressions.xml
+++ b/config/pitest-suppressions/pitest-javadoc-suppressions.xml
@@ -201,15 +201,6 @@
   <mutation unstable="false">
     <sourceFile>JavadocStyleCheck.java</sourceFile>
     <mutatedClass>com.puppycrawl.tools.checkstyle.checks.javadoc.JavadocStyleCheck</mutatedClass>
-    <mutatedMethod>findTextStart</mutatedMethod>
-    <mutator>org.pitest.mutationtest.engine.gregor.mutators.experimental.RemoveIncrementsMutator</mutator>
-    <description>Removed increment 2</description>
-    <lineContent>index += 2;</lineContent>
-  </mutation>
-
-  <mutation unstable="false">
-    <sourceFile>JavadocStyleCheck.java</sourceFile>
-    <mutatedClass>com.puppycrawl.tools.checkstyle.checks.javadoc.JavadocStyleCheck</mutatedClass>
     <mutatedMethod>trimTail</mutatedMethod>
     <mutator>org.pitest.mutationtest.engine.gregor.mutators.NonVoidMethodCallMutator</mutator>
     <description>removed call to java/lang/StringBuilder::deleteCharAt</description>

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocStyleCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocStyleCheck.java
@@ -407,10 +407,8 @@ public class JavadocStyleCheck
         int index = 0;
         while (index < line.length()) {
             if (!Character.isWhitespace(line.charAt(index))) {
-                if (line.regionMatches(index, "/**", 0, "/**".length())) {
-                    index += 2;
-                }
-                else if (line.regionMatches(index, "*/", 0, 2)) {
+                if (line.regionMatches(index, "/**", 0, "/**".length())
+                    || line.regionMatches(index, "*/", 0, 2)) {
                     index++;
                 }
                 else if (line.charAt(index) != '*') {


### PR DESCRIPTION
Issue: #13999 

### Mutation
https://github.com/checkstyle/checkstyle/blob/5cd55fbd79d93f3a336c36319438450f51f133bd/config/pitest-suppressions/pitest-javadoc-suppressions.xml#L201-L208

### Explanation
`findTextStart(String line)` method is used to find the index of the first non-whitespace character ignoring the javadoc comment's start and end strings as well as `*`.

The mutated code was `index += 2;` which was incrementing the index by 2 whenever it encountered `/**`.  Now based on the changes I made, the index gets incremented by 1 only instead of 2 and the functionality of the method `findTextStart()` does not changes. The method checks that if the current character is a whitespace or `/**` or `*/` or `*`. When we encounters the `/**`, index gets incremented by 1 so the next character is `*` which gets ignored. 

So there is no side effects of removing the `index += 2;`  from `findTextStart()` method.

### Dependency Tree

```
JavadocStyleCheck.getCommentText(String...)  (com.puppycrawl.tools.checkstyle.checks.javadoc)
    JavadocStyleCheck.checkJavadocIsNotEmpty(TextBlock)  (com.puppycrawl.tools.checkstyle.checks.javadoc)
        JavadocStyleCheck.checkComment(DetailAST, TextBlock)  (com.puppycrawl.tools.checkstyle.checks.javadoc)
    JavadocStyleCheck.checkFirstSentenceEnding(DetailAST, TextBlock)  (com.puppycrawl.tools.checkstyle.checks.javadoc)
        JavadocStyleCheck.checkComment(DetailAST, TextBlock)  (com.puppycrawl.tools.checkstyle.checks.javadoc)
```

### Modules

1.  AbstractCheck

### Regression
Diff Regression config: https://gist.githubusercontent.com/Zopsss/f850f56e5a179ebfc20cb74a5fd15720/raw/6fb184165231d1b8eff8c749166ed4a827b4a61d/JavadocStyle.xml
Diff Regression projects: https://gist.githubusercontent.com/Zopsss/a0e23edd9aa5ad42936b5f2e5a31a471/raw/34015aaf8e10d22b26d3c8fa7c14bd4b48982c10/projects-to-test-on-for-github-action.properties
Report label: issue-13999-report
