### PR TITLE
Issue #13213: Removed '//ok' from equalsavoidnull

### DIFF
--- a/config/checkstyle-input-suppressions.xml
+++ b/config/checkstyle-input-suppressions.xml
@@ -845,12 +845,6 @@
   <suppress id="UnnecessaryOkComment"
             files="checks[\\/]coding[\\/]declarationorder[\\/]InputDeclarationOrder2.java"/>
   <suppress id="UnnecessaryOkComment"
-            files="checks[\\/]coding[\\/]equalsavoidnull[\\/]InputEqualsAvoidNull.java"/>
-  <suppress id="UnnecessaryOkComment"
-            files="checks[\\/]coding[\\/]equalsavoidnull[\\/]InputEqualsAvoidNullIgnoreCase.java"/>
-  <suppress id="UnnecessaryOkComment"
-            files="checks[\\/]coding[\\/]equalsavoidnull[\\/]InputEqualsAvoidNullSuperClass.java"/>
-  <suppress id="UnnecessaryOkComment"
             files="checks[\\/]coding[\\/]equalshashcode[\\/]InputEqualsHashCode.java"/>
   <suppress id="UnnecessaryOkComment"
             files="checks[\\/]coding[\\/]equalshashcode[\\/]InputEqualsHashCode.java"/>

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/equalsavoidnull/InputEqualsAvoidNull.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/equalsavoidnull/InputEqualsAvoidNull.java
@@ -440,7 +440,7 @@ class TestThisWithNotStringInstance {
     MyString notString;
 
     void foo() {
-        this.notString.equals(""); // ok
+        this.notString.equals("");
     }
 
 }

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/equalsavoidnull/InputEqualsAvoidNullIgnoreCase.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/equalsavoidnull/InputEqualsAvoidNullIgnoreCase.java
@@ -439,7 +439,7 @@ class TestThisWithNotStringInstance1 {
     MyString1 notString;
 
     void foo() {
-        this.notString.equals(""); // ok
+        this.notString.equals("");
     }
 
 }

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/equalsavoidnull/InputEqualsAvoidNullSuperClass.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/equalsavoidnull/InputEqualsAvoidNullSuperClass.java
@@ -15,7 +15,7 @@ class DerivedClass extends InputEqualsAvoidNullSuperClass {
    protected String classField = "DEF";
 
     void m1() {
-        if (this.stringFromBaseClass.equals("JKHKJ")) { // ok
+        if (this.stringFromBaseClass.equals("JKHKJ")) {
         }
     }
 


### PR DESCRIPTION
Part of Issue #13213 
Removing '//ok' comments from input files equalsavoidnull module.

I have run the code on my local system using mvn verify
Status : Build successful.
Proof of work : 
![image](https://github.com/checkstyle/checkstyle/assets/148562451/43ea1d0f-6b35-41ad-a39e-6815b07acf2c)


