### PR TITLE
Issue #14137: Enable `EmptyMethod` check

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -244,6 +244,7 @@
       -Xep:CanonicalAnnotationSyntax:ERROR
       -Xep:DirectReturn:ERROR
       -Xep:CollectorMutability:ERROR
+      -Xep:EmptyMethod:ERROR
       <!-- Reason at https://github.com/checkstyle/checkstyle/issues/8252. -->
       -Xep:JUnitClassModifiers:OFF
       <!-- Reason at https://github.com/checkstyle/checkstyle/issues/8252. -->


### PR DESCRIPTION
Issue #14137.

This PR enables the https://error-prone.picnic.tech/bugpatterns/EmptyMethod/ check.