### PR TITLE
Issue #11163: Enforced filesize HtmlNoTagsViolation

### DIFF
--- a/config/checkstyle-input-suppressions.xml
+++ b/config/checkstyle-input-suppressions.xml
@@ -1711,10 +1711,6 @@
   <suppress id="UnnecessaryOkComment"
             files="checks[\\/]javadoc[\\/]abstractjavadoc[\\/]InputAbstractJavadocNonTightHtmlTags2.java"/>
   <suppress id="UnnecessaryOkComment"
-            files="checks[\\/]javadoc[\\/]abstractjavadoc[\\/]InputAbstractJavadocNonTightHtmlTagsNoViolation.java"/>
-  <suppress id="UnnecessaryOkComment"
-            files="checks[\\/]javadoc[\\/]abstractjavadoc[\\/]InputAbstractJavadocNonTightHtmlTagsNoViolation.java"/>
-  <suppress id="UnnecessaryOkComment"
             files="checks[\\/]javadoc[\\/]abstractjavadoc[\\/]InputAbstractJavadocPosition.java"/>
   <suppress id="UnnecessaryOkComment"
             files="checks[\\/]javadoc[\\/]abstractjavadoc[\\/]InputAbstractJavadocPositionOnlyComments.java"/>

--- a/config/checkstyle-resources-suppressions.xml
+++ b/config/checkstyle-resources-suppressions.xml
@@ -199,8 +199,6 @@
   <suppress checks="FileLength"
     files="[\\/]test[\\/]resources[\\/]com[\\/]puppycrawl[\\/]tools[\\/]checkstyle[\\/]checks[\\/]javadoc[\\/]abstractjavadoc[\\/]InputAbstractJavadocPositionWithSinglelineComments\.java"/>
   <suppress checks="FileLength"
-    files="[\\/]test[\\/]resources[\\/]com[\\/]puppycrawl[\\/]tools[\\/]checkstyle[\\/]checks[\\/]javadoc[\\/]abstractjavadoc[\\/]InputAbstractJavadocNonTightHtmlTagsNoViolation\.java"/>
-  <suppress checks="FileLength"
     files="[\\/]test[\\/]resources[\\/]com[\\/]puppycrawl[\\/]tools[\\/]checkstyle[\\/]checks[\\/]javadoc[\\/]abstractjavadoc[\\/]InputAbstractJavadocCorrectParagraph\.java"/>
   <suppress checks="FileLength"
     files="[\\/]test[\\/]resources[\\/]com[\\/]puppycrawl[\\/]tools[\\/]checkstyle[\\/]checks[\\/]javadoc[\\/]abstractjavadoc[\\/]InputAbstractJavadocNonTightHtmlTagsVisitCount\.java"/>

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/javadoc/AbstractJavadocCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/javadoc/AbstractJavadocCheckTest.java
@@ -398,10 +398,17 @@ public class AbstractJavadocCheckTest extends AbstractModuleTestSupport {
     }
 
     @Test
-    public void testNonTightHtmlTagIntolerantCheckReportingNoViolation() throws Exception {
+    public void testNonTightHtmlTagIntolerantCheckReportingNoViolationOne() throws Exception {
         final String[] expected = CommonUtil.EMPTY_STRING_ARRAY;
         verifyWithInlineConfigParser(
-                getPath("InputAbstractJavadocNonTightHtmlTagsNoViolation.java"), expected);
+                getPath("InputAbstractJavadocNonTightHtmlTagsNoViolationOne.java"), expected);
+    }
+
+    @Test
+    public void testNonTightHtmlTagIntolerantCheckReportingNoViolationTwo() throws Exception {
+        final String[] expected = CommonUtil.EMPTY_STRING_ARRAY;
+        verifyWithInlineConfigParser(
+                getPath("InputAbstractJavadocNonTightHtmlTagsNoViolationTwo.java"), expected);
     }
 
     @Test

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/abstractjavadoc/InputAbstractJavadocNonTightHtmlTagsNoViolationOne.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/abstractjavadoc/InputAbstractJavadocNonTightHtmlTagsNoViolationOne.java
@@ -1,0 +1,61 @@
+/*
+com.puppycrawl.tools.checkstyle.checks.javadoc.AbstractJavadocCheckTest$NonTightHtmlTagCheck
+
+*/
+
+package com.puppycrawl.tools.checkstyle.checks.javadoc.abstractjavadoc;
+
+/**
+ * <body>
+ * <p> This class is only meant for testing. </p>
+ * <p> In html, closing all tags is not necessary.
+ * <li> neither is opening every tag <p> </li>
+ * </body>
+ *
+ * @see "https://www.w3.org/TR/html51/syntax.html#optional-start-and-end-tags"
+ */
+public class InputAbstractJavadocNonTightHtmlTagsNoViolationOne {
+    /** <p> <p> paraception </p> </p> */
+    private int field1;
+
+    /**<li> paraTags should be opened</p> list isn't nested in parse tree </li>*/
+    private int field2;
+
+    /**
+     * <p> this paragraph is closed and would be nested in javadoc tree </p>
+     * <li> this list has an <p> unclosed para, but still the list would get nested </li>
+     */
+    private int field3;
+
+    /**
+     * <li> Complete <p> nesting </p> </li>
+     * <tr> Zero </p> nesting despite `tr` is closed </tr>
+     */
+    private int field4;
+
+    /**
+     * <p> <a href="www.something.com">something</a> paragraph with `htmlTag` </p>
+     * <p> <a href="www.something.com"/> Nested paragraph with `singletonTag` </p>
+     * <li> Outer tag <li> Inner tag nested </li> not nested </li>
+     */
+    private int field5;
+
+    /**
+     * <th> !isNonTight </th>
+     * <th> th with <base/> singletonElement </th>
+     * <body> body with <br/> singletonElement </body>
+     * <colgroup><col><col><col></colgroup>
+     * <dd> dd with <hr> singletonElement </dd>
+     * <dt> dt with <img src="~/singletonElement.jpg" alt="" width="100" height="150"/>
+     *     singletonElement </dt>
+     * <head> head with <img src="~/singletonElement.jpg" alt="" width="100" height="150">
+     * singletonElement </head>
+     */
+    private int field6;
+
+    /**
+     * <body> body <p> paragraph <li> list </li> </p> </body>
+     *
+     * @return <li> <li> outer list isn't nested in parse tree </li> </li>
+     */
+}

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/abstractjavadoc/InputAbstractJavadocNonTightHtmlTagsNoViolationTwo.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/abstractjavadoc/InputAbstractJavadocNonTightHtmlTagsNoViolationTwo.java
@@ -14,50 +14,7 @@ package com.puppycrawl.tools.checkstyle.checks.javadoc.abstractjavadoc;
  *
  * @see "https://www.w3.org/TR/html51/syntax.html#optional-start-and-end-tags"
  */
-public class InputAbstractJavadocNonTightHtmlTagsNoViolation {
-    /** <p> <p> paraception </p> </p> */ // ok
-    private int field1;
-
-    /**<li> paraTags should be opened</p> list isn't nested in parse tree </li>*/ // ok
-    private int field2;
-
-    /**
-     * <p> this paragraph is closed and would be nested in javadoc tree </p>
-     * <li> this list has an <p> unclosed para, but still the list would get nested </li>
-     */
-    private int field3;
-
-    /**
-     * <li> Complete <p> nesting </p> </li>
-     * <tr> Zero </p> nesting despite `tr` is closed </tr>
-     */
-    private int field4;
-
-    /**
-     * <p> <a href="www.something.com">something</a> paragraph with `htmlTag` </p>
-     * <p> <a href="www.something.com"/> Nested paragraph with `singletonTag` </p>
-     * <li> Outer tag <li> Inner tag nested </li> not nested </li>
-     */
-    private int field5;
-
-    /**
-     * <th> !isNonTight </th>
-     * <th> th with <base/> singletonElement </th>
-     * <body> body with <br/> singletonElement </body>
-     * <colgroup><col><col><col></colgroup>
-     * <dd> dd with <hr> singletonElement </dd>
-     * <dt> dt with <img src="~/singletonElement.jpg" alt="" width="100" height="150"/>
-     *     singletonElement </dt>
-     * <head> head with <img src="~/singletonElement.jpg" alt="" width="100" height="150">
-     * singletonElement </head>
-     */
-    private int field6;
-
-    /**
-     * <body> body <p> paragraph <li> list </li> </p> </body>
-     *
-     * @return <li> <li> outer list isn't nested in parse tree </li> </li>
-     */
+public class InputAbstractJavadocNonTightHtmlTagsNoViolationTwo {
     int getField1() {return field1;}
 
     /***/
@@ -132,3 +89,4 @@ public class InputAbstractJavadocNonTightHtmlTagsNoViolation {
      */
     private void setField6(int field6) {this.field6 = field6;}
 }
+


### PR DESCRIPTION
Part of #11163

Enforced file size on InputAbstractJavadocNonTightHtmlTagsNoViolation.
The decided file size limit was 120 and I have implemented the same.

Part of #13213 
While modifying InputAbstractJavadocNonTightHtmlTagsNoViolation.java , I noticed that there were unnecessary '//ok' comments which I removed as a part of the commit. Hope that it is fine.