### PR TITLE
Issue #11163: Enforced filesize HtmlTagsNoViolation

### DIFF
--- a/config/checkstyle-input-suppressions.xml
+++ b/config/checkstyle-input-suppressions.xml
@@ -1663,10 +1663,6 @@
   <suppress id="UnnecessaryOkComment"
             files="checks[\\/]javadoc[\\/]abstractjavadoc[\\/]InputAbstractJavadocNonTightHtmlTags2.java"/>
   <suppress id="UnnecessaryOkComment"
-            files="checks[\\/]javadoc[\\/]abstractjavadoc[\\/]InputAbstractJavadocNonTightHtmlTagsNoViolation.java"/>
-  <suppress id="UnnecessaryOkComment"
-            files="checks[\\/]javadoc[\\/]abstractjavadoc[\\/]InputAbstractJavadocNonTightHtmlTagsNoViolation.java"/>
-  <suppress id="UnnecessaryOkComment"
             files="checks[\\/]javadoc[\\/]abstractjavadoc[\\/]InputAbstractJavadocPosition.java"/>
   <suppress id="UnnecessaryOkComment"
             files="checks[\\/]javadoc[\\/]abstractjavadoc[\\/]InputAbstractJavadocPositionOnlyComments.java"/>

--- a/config/checkstyle-input-suppressions.xml
+++ b/config/checkstyle-input-suppressions.xml
@@ -1663,8 +1663,6 @@
   <suppress id="UnnecessaryOkComment"
             files="checks[\\/]javadoc[\\/]abstractjavadoc[\\/]InputAbstractJavadocNonTightHtmlTags2.java"/>
   <suppress id="UnnecessaryOkComment"
-            files="checks[\\/]javadoc[\\/]abstractjavadoc[\\/]InputAbstractJavadocPosition.java"/>
-  <suppress id="UnnecessaryOkComment"
             files="checks[\\/]javadoc[\\/]abstractjavadoc[\\/]InputAbstractJavadocPositionOnlyComments.java"/>
   <suppress id="UnnecessaryOkComment"
             files="checks[\\/]javadoc[\\/]abstractjavadoc[\\/]InputAbstractJavadocTokensPass.java"/>

--- a/config/checkstyle-resources-suppressions.xml
+++ b/config/checkstyle-resources-suppressions.xml
@@ -195,8 +195,6 @@
 
   <!-- Until https://github.com/checkstyle/checkstyle/issues/11163 -->
   <suppress checks="FileLength"
-    files="[\\/]test[\\/]resources[\\/]com[\\/]puppycrawl[\\/]tools[\\/]checkstyle[\\/]checks[\\/]javadoc[\\/]abstractjavadoc[\\/]InputAbstractJavadocPosition\.java"/>
-  <suppress checks="FileLength"
     files="[\\/]test[\\/]resources[\\/]com[\\/]puppycrawl[\\/]tools[\\/]checkstyle[\\/]checks[\\/]javadoc[\\/]abstractjavadoc[\\/]InputAbstractJavadocCorrectParagraph\.java"/>
   <suppress checks="FileLength"
     files="[\\/]test[\\/]resources[\\/]com[\\/]puppycrawl[\\/]tools[\\/]checkstyle[\\/]checks[\\/]javadoc[\\/]abstractjavadoc[\\/]InputAbstractJavadocNonTightHtmlTagsVisitCount\.java"/>

--- a/config/checkstyle-resources-suppressions.xml
+++ b/config/checkstyle-resources-suppressions.xml
@@ -197,8 +197,6 @@
   <suppress checks="FileLength"
     files="[\\/]test[\\/]resources[\\/]com[\\/]puppycrawl[\\/]tools[\\/]checkstyle[\\/]checks[\\/]javadoc[\\/]abstractjavadoc[\\/]InputAbstractJavadocPosition\.java"/>
   <suppress checks="FileLength"
-    files="[\\/]test[\\/]resources[\\/]com[\\/]puppycrawl[\\/]tools[\\/]checkstyle[\\/]checks[\\/]javadoc[\\/]abstractjavadoc[\\/]InputAbstractJavadocNonTightHtmlTagsNoViolation\.java"/>
-  <suppress checks="FileLength"
     files="[\\/]test[\\/]resources[\\/]com[\\/]puppycrawl[\\/]tools[\\/]checkstyle[\\/]checks[\\/]javadoc[\\/]abstractjavadoc[\\/]InputAbstractJavadocCorrectParagraph\.java"/>
   <suppress checks="FileLength"
     files="[\\/]test[\\/]resources[\\/]com[\\/]puppycrawl[\\/]tools[\\/]checkstyle[\\/]checks[\\/]javadoc[\\/]abstractjavadoc[\\/]InputAbstractJavadocNonTightHtmlTagsVisitCount\.java"/>

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/javadoc/AbstractJavadocCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/javadoc/AbstractJavadocCheckTest.java
@@ -424,10 +424,17 @@ public class AbstractJavadocCheckTest extends AbstractModuleTestSupport {
     }
 
     @Test
-    public void testNonTightHtmlTagIntolerantCheckReportingNoViolation() throws Exception {
+    public void testNonTightHtmlTagIntolerantCheckReportingNoViolationOne() throws Exception {
         final String[] expected = CommonUtil.EMPTY_STRING_ARRAY;
         verifyWithInlineConfigParser(
-                getPath("InputAbstractJavadocNonTightHtmlTagsNoViolation.java"), expected);
+                getPath("InputAbstractJavadocNonTightHtmlTagsNoViolationOne.java"), expected);
+    }
+
+    @Test
+    public void testNonTightHtmlTagIntolerantCheckReportingNoViolationTwo() throws Exception {
+        final String[] expected = CommonUtil.EMPTY_STRING_ARRAY;
+        verifyWithInlineConfigParser(
+                getPath("InputAbstractJavadocNonTightHtmlTagsNoViolationTwo.java"), expected);
     }
 
     @Test

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/abstractjavadoc/InputAbstractJavadocNonTightHtmlTagsNoViolationOne.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/abstractjavadoc/InputAbstractJavadocNonTightHtmlTagsNoViolationOne.java
@@ -1,0 +1,73 @@
+/*
+com.puppycrawl.tools.checkstyle.checks.javadoc.AbstractJavadocCheckTest$NonTightHtmlTagCheck
+
+*/
+
+package com.puppycrawl.tools.checkstyle.checks.javadoc.abstractjavadoc;
+
+/**
+ * <body>
+ * <p> This class is only meant for testing. </p>
+ * <p> In html, closing all tags is not necessary.
+ * <li> neither is opening every tag <p> </li>
+ * </body>
+ *
+ * @see "https://www.w3.org/TR/html51/syntax.html#optional-start-and-end-tags"
+ */
+public class InputAbstractJavadocNonTightHtmlTagsNoViolationOne {
+    /** <p> <p> paraception </p> </p> */
+    private int field1;
+
+    /**<li> paraTags should be opened</p> list isn't nested in parse tree </li>*/
+    private int field2;
+
+    /**
+     * <p> this paragraph is closed and would be nested in javadoc tree </p>
+     * <li> this list has an <p> unclosed para, but still the list would get nested </li>
+     */
+    private int field3;
+
+    /**
+     * <li> Complete <p> nesting </p> </li>
+     * <tr> Zero </p> nesting despite `tr` is closed </tr>
+     */
+
+    int getField1() {return field1;}
+
+    /***/
+    int getField2() {return field2;} //method with empty javadoc
+
+    /**
+     * <tr> <li> list is going to be nested in the parse tree </li> </tr>
+     *
+     * @param field1 {@code <p> paraTag will not be recognized} in javadoc tree </p>
+     */
+    void setField1(int field1) {this.field1 = field1;}
+
+    /**
+     * <p>This is a setter method.
+     * And paraTag shall be nested in parse tree </p>
+     * @param field2 <p> setter
+     */
+    void setField2(int field2) {this.field2 = field2;}
+
+    /**
+     * <p> paragraph with a <br>singletonElement. <hr> And it contains another one. </p>
+     * <li> List with singletonElement
+     * <param name=mov value="~/imitation game.mp4"> <param name=allowfullscreen value=true> </li>
+     * @return <tr> tr with <base href="www.something.com"> singletonElement </tr>
+     *     <tr> nonTight </th>
+     */
+    private int getField3() {return field3;}
+
+    /**
+     * @param field3 <td> td with singletonElement <br/> </td>
+     */
+    private void setField3(int field3) { this.field3 = field3;}
+
+    /**
+     * <html> <bR> <Br> <BR> <Br/> <BR/> <bR/> </html>
+     * <option> <INPut/> </option>
+     * @return <tbody> <input/> <br> </tbody>
+     */
+}

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/abstractjavadoc/InputAbstractJavadocNonTightHtmlTagsNoViolationTwo.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/abstractjavadoc/InputAbstractJavadocNonTightHtmlTagsNoViolationTwo.java
@@ -14,23 +14,8 @@ package com.puppycrawl.tools.checkstyle.checks.javadoc.abstractjavadoc;
  *
  * @see "https://www.w3.org/TR/html51/syntax.html#optional-start-and-end-tags"
  */
-public class InputAbstractJavadocNonTightHtmlTagsNoViolation {
-    /** <p> <p> paraception </p> </p> */ // ok
-    private int field1;
-
-    /**<li> paraTags should be opened</p> list isn't nested in parse tree </li>*/ // ok
-    private int field2;
-
-    /**
-     * <p> this paragraph is closed and would be nested in javadoc tree </p>
-     * <li> this list has an <p> unclosed para, but still the list would get nested </li>
-     */
-    private int field3;
-
-    /**
-     * <li> Complete <p> nesting </p> </li>
-     * <tr> Zero </p> nesting despite `tr` is closed </tr>
-     */
+public class InputAbstractJavadocNonTightHtmlTagsNoViolationTwo {
+    /** <p> <p> paraception </p> </p> */
     private int field4;
 
     /**
@@ -58,44 +43,7 @@ public class InputAbstractJavadocNonTightHtmlTagsNoViolation {
      *
      * @return <li> <li> outer list isn't nested in parse tree </li> </li>
      */
-    int getField1() {return field1;}
 
-    /***/
-    int getField2() {return field2;} //method with empty javadoc
-
-    /**
-     * <tr> <li> list is going to be nested in the parse tree </li> </tr>
-     *
-     * @param field1 {@code <p> paraTag will not be recognized} in javadoc tree </p>
-     */
-    void setField1(int field1) {this.field1 = field1;}
-
-    /**
-     * <p>This is a setter method.
-     * And paraTag shall be nested in parse tree </p>
-     * @param field2 <p> setter
-     */
-    void setField2(int field2) {this.field2 = field2;}
-
-    /**
-     * <p> paragraph with a <br>singletonElement. <hr> And it contains another one. </p>
-     * <li> List with singletonElement
-     * <param name=mov value="~/imitation game.mp4"> <param name=allowfullscreen value=true> </li>
-     * @return <tr> tr with <base href="www.something.com"> singletonElement </tr>
-     *     <tr> nonTight </th>
-     */
-    private int getField3() {return field3;}
-
-    /**
-     * @param field3 <td> td with singletonElement <br/> </td>
-     */
-    private void setField3(int field3) { this.field3 = field3;}
-
-    /**
-     * <html> <bR> <Br> <BR> <Br/> <BR/> <bR/> </html>
-     * <option> <INPut/> </option>
-     * @return <tbody> <input/> <br> </tbody>
-     */
     private int getField4() {return field4;}
 
     /**


### PR DESCRIPTION
Part of #11163 
Enforced file size for InputAbstractJavadocHtmlTagsNoViolation
The decided file size limit was 120 lines and I have implemented the same.

Part of #13213 
While modifying InputAbstractJavadocHtmlTagsNoViolation.java , unnecessary '//ok' comments were found which have been removed as part of the same commit.