### PR TITLE
Issue #11163: Enforced file size on NonTightHtmlTags

### DIFF
--- a/config/checkstyle-resources-suppressions.xml
+++ b/config/checkstyle-resources-suppressions.xml
@@ -203,8 +203,6 @@
   <suppress checks="FileLength"
     files="[\\/]test[\\/]resources[\\/]com[\\/]puppycrawl[\\/]tools[\\/]checkstyle[\\/]checks[\\/]javadoc[\\/]abstractjavadoc[\\/]InputAbstractJavadocNonTightHtmlTagsVisitCount\.java"/>
   <suppress checks="FileLength"
-    files="[\\/]test[\\/]resources[\\/]com[\\/]puppycrawl[\\/]tools[\\/]checkstyle[\\/]checks[\\/]javadoc[\\/]abstractjavadoc[\\/]InputAbstractJavadocNonTightHtmlTags\.java"/>
-  <suppress checks="FileLength"
     files="[\\/]test[\\/]resources[\\/]com[\\/]puppycrawl[\\/]tools[\\/]checkstyle[\\/]checks[\\/]javadoc[\\/]abstractjavadoc[\\/]InputAbstractJavadocLeaveToken\.java"/>
   <suppress checks="FileLength"
     files="[\\/]test[\\/]resources[\\/]com[\\/]puppycrawl[\\/]tools[\\/]checkstyle[\\/]checks[\\/]javadoc[\\/]missingjavadoctype[\\/]InputMissingJavadocTypeNoJavadoc3\.java"/>

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/javadoc/AbstractJavadocCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/javadoc/AbstractJavadocCheckTest.java
@@ -406,21 +406,31 @@ public class AbstractJavadocCheckTest extends AbstractModuleTestSupport {
     }
 
     @Test
-    public void testNonTightHtmlTagIntolerantCheck() throws Exception {
+    public void testNonTightHtmlTagIntolerantCheckOne() throws Exception {
         final String[] expected = {
             "12: " + getCheckMessage(MSG_UNCLOSED_HTML_TAG, "p"),
             "19: " + getCheckMessage(MSG_UNCLOSED_HTML_TAG, "p"),
             "22: " + getCheckMessage(MSG_UNCLOSED_HTML_TAG, "li"),
             "28: " + getCheckMessage(MSG_UNCLOSED_HTML_TAG, "p"),
             "35: " + getCheckMessage(MSG_UNCLOSED_HTML_TAG, "tr"),
-            "43: " + getCheckMessage(MSG_UNCLOSED_HTML_TAG, "li"),
-            "64: " + getCheckMessage(MSG_UNCLOSED_HTML_TAG, "li"),
-            "82: " + getCheckMessage(MSG_UNCLOSED_HTML_TAG, "p"),
-            "92: " + getCheckMessage(MSG_UNCLOSED_HTML_TAG, "tr"),
-            "137: " + getCheckMessage(MSG_UNCLOSED_HTML_TAG, "p"),
+            "54: " + getCheckMessage(MSG_UNCLOSED_HTML_TAG, "p"),
+            "64: " + getCheckMessage(MSG_UNCLOSED_HTML_TAG, "tr"),
         };
         verifyWithInlineConfigParser(
-                getPath("InputAbstractJavadocNonTightHtmlTags.java"), expected);
+                getPath("InputAbstractJavadocNonTightHtmlTagsOne.java"), expected);
+    }
+
+    @Test
+    public void testNonTightHtmlTagIntolerantCheckTwo() throws Exception {
+        final String[] expected = {
+            "12: " + getCheckMessage(MSG_UNCLOSED_HTML_TAG, "p"),
+            "19: " + getCheckMessage(MSG_UNCLOSED_HTML_TAG, "p"),
+            "25: " + getCheckMessage(MSG_UNCLOSED_HTML_TAG, "li"),
+            "46: " + getCheckMessage(MSG_UNCLOSED_HTML_TAG, "li"),
+            "80: " + getCheckMessage(MSG_UNCLOSED_HTML_TAG, "p"),
+        };
+        verifyWithInlineConfigParser(
+                getPath("InputAbstractJavadocNonTightHtmlTagsTwo.java"), expected);
     }
 
     @Test

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/abstractjavadoc/InputAbstractJavadocNonTightHtmlTagsOne.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/abstractjavadoc/InputAbstractJavadocNonTightHtmlTagsOne.java
@@ -1,0 +1,79 @@
+/*
+com.puppycrawl.tools.checkstyle.checks.javadoc.AbstractJavadocCheckTest$NonTightHtmlTagCheck
+violateExecutionOnNonTightHtml = true
+
+*/
+
+package com.puppycrawl.tools.checkstyle.checks.javadoc.abstractjavadoc;
+
+/**
+ * <body>
+ * <p> This class is only meant for testing. </p>
+ * <p> In html, closing all tags is not necessary.
+ * </body>
+ *
+ * @see "https://www.w3.org/TR/html51/syntax.html#optional-start-and-end-tags"
+ */
+// violation 5 lines above 'Unclosed HTML tag found: p'
+public class InputAbstractJavadocNonTightHtmlTagsOne {
+    /** <p> <p> paraception </p> </p> */ // violation 'Unclosed HTML tag found: p'
+    private int field1;
+
+    /**<li> paraTags should be opened</p> list isn't nested in parse tree </li>*/
+    // violation above 'Unclosed HTML tag found: li'
+    private int field2;
+
+    /**
+     * <p> this paragraph is closed and would be nested in javadoc tree </p>
+     * <li> list has an <p> unclosed para, but still the list would get nested </li>
+     */
+    // violation 2 lines above 'Unclosed HTML tag found: p'
+    private int field3;
+
+    /**
+     * <li> Complete <p> nesting </p> </li>
+     * <tr> Zero </p> nesting despite `tr` is closed </tr>
+     */
+    // violation 2 lines above 'Unclosed HTML tag found: tr'
+
+    int getField1() {return field1;}
+
+    /***/
+    int getField2() {return field2;} //method with empty javadoc
+
+    /**
+     * <tr> <li> list is going to be nested in the parse tree </li> </tr>
+     *
+     * @param field1 {@code <p> paraTag will not be recognized} in javadoc tree </p>
+     */
+    void setField1(int field1) {this.field1 = field1;}
+
+    /**
+     * <p>This is a setter method.
+     * And paraTag shall be nested in parse tree </p>
+     * @param field2 <p> setter
+     */
+    // violation 2 lines above 'Unclosed HTML tag found: p'
+    void setField2(int field2) {this.field2 = field2;}
+
+    /**
+     * <p> paragraph with a <br>singletonElement. <hr> And it contains another one. </p>
+     * <li> List with singletonElement
+     * <param name=mov value="~/imitation game.mp4"> <param name=allowfullscreen value=true> </li>
+     * @return <tr> tr with <base href="www.something.com"> singletonElement </tr>
+     *     <tr> nonTight </th>
+     */
+    // violation 2 lines above 'Unclosed HTML tag found: tr'
+    private int getField3() {return field3;}
+
+    /**
+     * @param field3 <td> td with singletonElement <br/> </td>
+     */
+    private void setField3(int field3) { this.field3 = field3;}
+
+    /**
+     * <html> <bR> <Br> <BR> <Br/> <BR/> <bR/> </html>
+     * <option> <INPut/> </option>
+     * @return <tbody> <input/> <br> </tbody>
+     */
+}

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/abstractjavadoc/InputAbstractJavadocNonTightHtmlTagsTwo.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/abstractjavadoc/InputAbstractJavadocNonTightHtmlTagsTwo.java
@@ -15,26 +15,8 @@ package com.puppycrawl.tools.checkstyle.checks.javadoc.abstractjavadoc;
  * @see "https://www.w3.org/TR/html51/syntax.html#optional-start-and-end-tags"
  */
 // violation 5 lines above 'Unclosed HTML tag found: p'
-public class InputAbstractJavadocNonTightHtmlTags {
+public class InputAbstractJavadocNonTightHtmlTagsTwo {
     /** <p> <p> paraception </p> </p> */ // violation 'Unclosed HTML tag found: p'
-    private int field1;
-
-    /**<li> paraTags should be opened</p> list isn't nested in parse tree </li>*/
-    // violation above 'Unclosed HTML tag found: li'
-    private int field2;
-
-    /**
-     * <p> this paragraph is closed and would be nested in javadoc tree </p>
-     * <li> list has an <p> unclosed para, but still the list would get nested </li>
-     */
-    // violation 2 lines above 'Unclosed HTML tag found: p'
-    private int field3;
-
-    /**
-     * <li> Complete <p> nesting </p> </li>
-     * <tr> Zero </p> nesting despite `tr` is closed </tr>
-     */
-    // violation 2 lines above 'Unclosed HTML tag found: tr'
     private int field4;
 
     /**
@@ -64,46 +46,7 @@ public class InputAbstractJavadocNonTightHtmlTags {
      * @return <li> <li> outer list isn't nested in parse tree </li> </li>
      */
     // violation 2 lines above 'Unclosed HTML tag found: li'
-    int getField1() {return field1;}
 
-    /***/
-    int getField2() {return field2;} //method with empty javadoc
-
-    /**
-     * <tr> <li> list is going to be nested in the parse tree </li> </tr>
-     *
-     * @param field1 {@code <p> paraTag will not be recognized} in javadoc tree </p>
-     */
-    void setField1(int field1) {this.field1 = field1;}
-
-    /**
-     * <p>This is a setter method.
-     * And paraTag shall be nested in parse tree </p>
-     * @param field2 <p> setter
-     */
-    // violation 2 lines above 'Unclosed HTML tag found: p'
-    void setField2(int field2) {this.field2 = field2;}
-
-    /**
-     * <p> paragraph with a <br>singletonElement. <hr> And it contains another one. </p>
-     * <li> List with singletonElement
-     * <param name=mov value="~/imitation game.mp4"> <param name=allowfullscreen value=true> </li>
-     * @return <tr> tr with <base href="www.something.com"> singletonElement </tr>
-     *     <tr> nonTight </th>
-     */
-    // violation 2 lines above 'Unclosed HTML tag found: tr'
-    private int getField3() {return field3;}
-
-    /**
-     * @param field3 <td> td with singletonElement <br/> </td>
-     */
-    private void setField3(int field3) { this.field3 = field3;}
-
-    /**
-     * <html> <bR> <Br> <BR> <Br/> <BR/> <bR/> </html>
-     * <option> <INPut/> </option>
-     * @return <tbody> <input/> <br> </tbody>
-     */
     private int getField4() {return field4;}
 
     /**


### PR DESCRIPTION
Part of #11163

Enforced file size for InputAbstractJavadocHtmlTags.java
The decided file size limit was 120 lines and I have implemented the same.