### PR TITLE
infra: disable sonar until we migrate to jdk17

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -75,7 +75,6 @@ jobs:
             export PR_HEAD_SHA=$CIRCLE_SHA1
             export PR_NUMBER=$CIRCLE_PR_NUMBER
             << parameters.command >>
-
   sonarqube:
     docker:
       - image: checkstyle/jdk-11-groovy-git-mvn:11.0.20.1__2.4.21__2.42.0__3.9.5
@@ -106,11 +105,12 @@ jobs:
           command: yamllint -f parsable -c config/yamllint.yaml .
 
 workflows:
-  sonarqube:
-    jobs:
-      - sonarqube:
-          context:
-            - sonarqube
+  #  until https://github.com/checkstyle/checkstyle/issues/13209
+  #  sonarqube:
+  #    jobs:
+  #      - sonarqube:
+  #          context:
+  #            - sonarqube
 
   test:
     jobs:


### PR DESCRIPTION
until https://github.com/checkstyle/checkstyle/issues/13209

to fix `The version of Java (11.0.20.1) used to run this analysis is deprecated, and SonarCloud no longer supports it. Please upgrade to Java 17 or later.
As a temporary measure, you can set the property 'sonar.scanner.force-deprecated-java-version' to 'true' to continue using Java 11.0.20.1
This workaround will only be effective until January 28, 2024. After this date, all scans using the deprecated Java 11 will fail.`
from https://app.circleci.com/pipelines/github/checkstyle/checkstyle/22927/workflows/a8517d08-b7c7-44f4-8b07-1ec4b10ffab6/jobs/476750