### PR TITLE
Issue #13213: Remove '//ok' comments from Input files (SuppressWarningsCheck)

### DIFF
--- a/config/checkstyle-input-suppressions.xml
+++ b/config/checkstyle-input-suppressions.xml
@@ -513,12 +513,6 @@
   <suppress id="UnnecessaryOkComment"
             files="checks[\\/]annotation[\\/]packageannotation[\\/]InputPackageAnnotation.java"/>
   <suppress id="UnnecessaryOkComment"
-            files="checks[\\/]annotation[\\/]suppresswarnings[\\/]InputSuppressWarningsConstants.java"/>
-  <suppress id="UnnecessaryOkComment"
-            files="checks[\\/]annotation[\\/]suppresswarnings[\\/]InputSuppressWarningsConstants.java"/>
-  <suppress id="UnnecessaryOkComment"
-            files="checks[\\/]annotation[\\/]suppresswarnings[\\/]InputSuppressWarningsValuePair.java"/>
-  <suppress id="UnnecessaryOkComment"
             files="checks[\\/]avoidescapedunicodecharacters[\\/]InputAvoidEscapedUnicodeCharactersAllEscapedUnicodeCharacters.java"/>
   <suppress id="UnnecessaryOkComment"
             files="checks[\\/]avoidescapedunicodecharacters[\\/]InputAvoidEscapedUnicodeCharactersAllEscapedUnicodeCharacters.java"/>

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/annotation/suppresswarnings/InputSuppressWarningsConstants.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/annotation/suppresswarnings/InputSuppressWarningsConstants.java
@@ -18,9 +18,9 @@ public class InputSuppressWarningsConstants
     public static final String UNCHECKED = "unchecked";
 
     public static void test() {
-        @SuppressWarnings(UNCHECKED) // ok
+        @SuppressWarnings(UNCHECKED)
         final List<String> dummyOne = (List<String>) new ArrayList();
-        @SuppressWarnings(InputSuppressWarningsConstants.UNCHECKED) // ok
+        @SuppressWarnings(InputSuppressWarningsConstants.UNCHECKED)
         final List<String> dummyTwo = (List<String>) new ArrayList();
     }
 }

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/annotation/suppresswarnings/InputSuppressWarningsValuePair.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/annotation/suppresswarnings/InputSuppressWarningsValuePair.java
@@ -18,7 +18,7 @@ public class InputSuppressWarningsValuePair
     public static final String UNCHECKED = "unchecked";
 
     public static void test() {
-        @SuppressWarnings(value = UNCHECKED) // ok
+        @SuppressWarnings(value = UNCHECKED)
         final List<String> dummyOne = (List<String>) new ArrayList();
     }
 }


### PR DESCRIPTION
Part of https://github.com/checkstyle/checkstyle/issues/13213

Link to check documentation:
https://checkstyle.org/checks/annotation/suppresswarnings#SuppressWarnings

Proof that all suppressions for this check are removed:
```
(master)$ grep suppresswarnings config/checkstyle-input-suppressions.xml
            files="checks[\\/]annotation[\\/]suppresswarnings[\\/]InputSuppressWarningsConstants.java"/>
            files="checks[\\/]annotation[\\/]suppresswarnings[\\/]InputSuppressWarningsConstants.java"/>
            files="checks[\\/]annotation[\\/]suppresswarnings[\\/]InputSuppressWarningsValuePair.java"/>

(issue-13213-suppresswarnings)$ grep suppresswarnings config/checkstyle-input-suppressions.xml
(issue-13213-suppresswarnings)$ echo $?
1
```

