### PR TITLE
supplemental: Issue#14273 Add JUnit test coverage for overloaded private and static methods for OverloadMethodsDeclarationOrder

### DIFF
--- a/src/it/java/com/google/checkstyle/test/chapter3filestructure/rule3421overloadsplit/OverloadMethodsDeclarationOrderTest.java
+++ b/src/it/java/com/google/checkstyle/test/chapter3filestructure/rule3421overloadsplit/OverloadMethodsDeclarationOrderTest.java
@@ -24,6 +24,7 @@ import org.junit.jupiter.api.Test;
 import com.google.checkstyle.test.base.AbstractGoogleModuleTestSupport;
 import com.puppycrawl.tools.checkstyle.api.Configuration;
 import com.puppycrawl.tools.checkstyle.checks.coding.OverloadMethodsDeclarationOrderCheck;
+import com.puppycrawl.tools.checkstyle.utils.CommonUtil;
 
 public class OverloadMethodsDeclarationOrderTest extends AbstractGoogleModuleTestSupport {
 
@@ -50,6 +51,18 @@ public class OverloadMethodsDeclarationOrderTest extends AbstractGoogleModuleTes
 
         final Integer[] warnList = getLinesWithWarn(filePath);
         verify(checkConfig, filePath, expected, warnList);
+    }
+
+    @Test
+    public void testOverloadMethodsDeclarationOrderPrivateAndStaticMethods() throws Exception {
+
+        final String[] expected = CommonUtil.EMPTY_STRING_ARRAY;
+
+        final Configuration checkConfig = getModuleConfig("OverloadMethodsDeclarationOrder");
+        final String filePath = getPath(
+                "InputOverloadMethodsDeclarationOrderPrivateAndStaticMethods.java");
+
+        verify(checkConfig, filePath, expected);
     }
 
 }

--- a/src/it/resources/com/google/checkstyle/test/chapter3filestructure/rule3421overloadsplit/InputOverloadMethodsDeclarationOrderPrivateAndStaticMethods.java
+++ b/src/it/resources/com/google/checkstyle/test/chapter3filestructure/rule3421overloadsplit/InputOverloadMethodsDeclarationOrderPrivateAndStaticMethods.java
@@ -1,0 +1,18 @@
+package com.google.checkstyle.test.chapter3filestructure.rule3421overloadsplit;
+
+public class InputOverloadMethodsDeclarationOrderPrivateAndStaticMethods {
+    public void testing() {
+    }
+
+    private void testing(int a) {
+    }
+
+    public void testing(int a, int b) {
+    }
+
+    public static void testing(String a) {
+    }
+
+    public void testing(String a, String b) {
+    }
+}

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/coding/OverloadMethodsDeclarationOrderCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/coding/OverloadMethodsDeclarationOrderCheckTest.java
@@ -25,6 +25,7 @@ import static com.puppycrawl.tools.checkstyle.checks.coding.OverloadMethodsDecla
 import org.junit.jupiter.api.Test;
 
 import com.puppycrawl.tools.checkstyle.AbstractModuleTestSupport;
+import com.puppycrawl.tools.checkstyle.utils.CommonUtil;
 
 public class OverloadMethodsDeclarationOrderCheckTest
     extends AbstractModuleTestSupport {
@@ -58,6 +59,17 @@ public class OverloadMethodsDeclarationOrderCheckTest
         verifyWithInlineConfigParser(
                 getNonCompilablePath("InputOverloadMethodsDeclarationOrderRecords.java"),
             expected);
+    }
+
+    @Test
+    public void testOverloadMethodsDeclarationOrderPrivateAndStaticMethods() throws Exception {
+
+        final String[] expected = CommonUtil.EMPTY_STRING_ARRAY;
+
+        verifyWithInlineConfigParser(
+                getPath(
+                        "InputOverloadMethodsDeclarationOrderPrivateAndStaticMethods.java"
+                ), expected);
     }
 
     @Test

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/overloadmethodsdeclarationorder/InputOverloadMethodsDeclarationOrderPrivateAndStaticMethods.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/overloadmethodsdeclarationorder/InputOverloadMethodsDeclarationOrderPrivateAndStaticMethods.java
@@ -1,0 +1,24 @@
+/*
+OverloadMethodsDeclarationOrder
+
+
+*/
+
+package com.puppycrawl.tools.checkstyle.checks.coding.overloadmethodsdeclarationorder;
+
+public class InputOverloadMethodsDeclarationOrderPrivateAndStaticMethods {
+    public void testing() {
+    }
+
+    private void testing(int a) {
+    }
+
+    public void testing(int a, int b) {
+    }
+
+    public static void testing(String a) {
+    }
+
+    public void testing(String a, String b) {
+    }
+}


### PR DESCRIPTION
Issue: #14273 

> Thanks a lot for testing modifiers, please send PR to contribute Junit test coverage to make sure it will always be like this:).

Added JUnit Test coverage for private and static methods as a part of `OverloadMethodsDeclarationOrder` check.

Created a new input file called `InputOverloadMethodsDeclarationOrderPrivateAndStaticMethods.java` and wrote the test method for it.