### PR TITLE
Issue #13213: Removed //ok from CorrectParagraph

### DIFF
--- a/config/checkstyle-input-suppressions.xml
+++ b/config/checkstyle-input-suppressions.xml
@@ -1455,8 +1455,6 @@
   <suppress id="UnnecessaryOkComment"
             files="checks[\\/]indentation[\\/]commentsindentation[\\/]InputCommentsIndentationWithInMethodCallWithSameIndent.java"/>
   <suppress id="UnnecessaryOkComment"
-            files="checks[\\/]javadoc[\\/]abstractjavadoc[\\/]InputAbstractJavadocCorrectParagraphTwo.java"/>
-  <suppress id="UnnecessaryOkComment"
             files="checks[\\/]javadoc[\\/]abstractjavadoc[\\/]InputAbstractJavadocCustomTag.java"/>
   <suppress id="UnnecessaryOkComment"
             files="checks[\\/]javadoc[\\/]abstractjavadoc[\\/]InputAbstractJavadocCustomTag.java"/>

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/abstractjavadoc/InputAbstractJavadocCorrectParagraphTwo.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/abstractjavadoc/InputAbstractJavadocCorrectParagraphTwo.java
@@ -26,7 +26,7 @@ package com.puppycrawl.tools.checkstyle.checks.javadoc.abstractjavadoc;
 class InputAbstractJavadocCorrectParagraphTwo {}
 
 /*
- *  This comment has paragraph without '<p>' tag. // ok
+ *  This comment has paragraph without '<p>' tag.
  *
  *  It's fine, because this is plain comment.
  */


### PR DESCRIPTION
Part of #13213 
Removed '//ok' comments from InputAbstractJavadocCorrectParagraphTwo.java file.