### PR TITLE
Issue #14137: Enable `ExplicitEnumOrdering` check

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -245,6 +245,7 @@
       -Xep:DirectReturn:ERROR
       -Xep:CollectorMutability:ERROR
       -Xep:EmptyMethod:ERROR
+      -Xep:ExplicitEnumOrdering:ERROR
       <!-- Reason at https://github.com/checkstyle/checkstyle/issues/8252. -->
       -Xep:JUnitClassModifiers:OFF
       <!-- Reason at https://github.com/checkstyle/checkstyle/issues/8252. -->


### PR DESCRIPTION
Issue #14137.

This PR enables the https://error-prone.picnic.tech/bugpatterns/ExplicitEnumOrdering/ check.
