### PR TITLE
Issue #11163: Enforced filesize MethodLengthSimple

### DIFF
--- a/config/checkstyle-resources-suppressions.xml
+++ b/config/checkstyle-resources-suppressions.xml
@@ -363,8 +363,6 @@
   <suppress checks="FileLength"
     files="[\\/]test[\\/]resources[\\/]com[\\/]puppycrawl[\\/]tools[\\/]checkstyle[\\/]checks[\\/]annotation[\\/]annotationlocation[\\/]InputAnnotationLocationIncorrect\.java"/>
   <suppress checks="FileLength"
-    files="[\\/]test[\\/]resources[\\/]com[\\/]puppycrawl[\\/]tools[\\/]checkstyle[\\/]checks[\\/]sizes[\\/]methodlength[\\/]InputMethodLengthSimple\.java"/>
-  <suppress checks="FileLength"
     files="[\\/]test[\\/]resources[\\/]com[\\/]puppycrawl[\\/]tools[\\/]checkstyle[\\/]checks[\\/]sizes[\\/]methodlength[\\/]InputMethodLengthCountEmptyIsFalse\.java"/>
   <suppress checks="FileLength"
     files="[\\/]test[\\/]resources[\\/]com[\\/]puppycrawl[\\/]tools[\\/]checkstyle[\\/]checks[\\/]sizes[\\/]methodlength[\\/]InputMethodLengthModifier\.java"/>

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/sizes/MethodLengthCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/sizes/MethodLengthCheckTest.java
@@ -61,12 +61,19 @@ public class MethodLengthCheckTest extends AbstractModuleTestSupport {
     }
 
     @Test
-    public void testIt() throws Exception {
+    public void testItOne() throws Exception {
+        final String[] expected = CommonUtil.EMPTY_STRING_ARRAY;
+        verifyWithInlineConfigParser(
+                getPath("InputMethodLengthSimpleOne.java"), expected);
+    }
+
+    @Test
+    public void testItTwo() throws Exception {
         final String[] expected = {
-            "76:5: " + getCheckMessage(MSG_KEY, 20, 19, "longMethod"),
+            "16:5: " + getCheckMessage(MSG_KEY, 20, 19, "longMethod"),
         };
         verifyWithInlineConfigParser(
-                getPath("InputMethodLengthSimple.java"), expected);
+                getPath("InputMethodLengthSimpleTwo.java"), expected);
     }
 
     @Test

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/sizes/methodlength/InputMethodLengthSimpleOne.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/sizes/methodlength/InputMethodLengthSimpleOne.java
@@ -4,13 +4,12 @@ max = 19
 countEmpty = (default)true
 tokens = (default)METHOD_DEF , CTOR_DEF , COMPACT_CTOR_DEF
 
-
 */
 
 package com.puppycrawl.tools.checkstyle.checks.sizes.methodlength;
 import java.io.*;
 
-final class InputMethodLengthSimple
+final class InputMethodLengthSimpleOne
 {
     // Long line ----------------------------------------------------------------
     // Contains a tab ->        <-
@@ -54,9 +53,7 @@ final class InputMethodLengthSimple
     /** should be private **/
     public int mTest2;
 
-    //
     // Parameter name format tests
-    //
 
     /**
      * @return hack
@@ -72,31 +69,8 @@ final class InputMethodLengthSimple
         return 0;
     }
 
-    /** method that is 20 lines long **/
-    private void longMethod() // violation
-    {
-        // a line
-        // a line
-        // a line
-        // a line
-        // a line
-        // a line
-        // a line
-        // a line
-        // a line
-        // a line
-        // a line
-        // a line
-        // a line
-        // a line
-        // a line
-        // a line
-        // a line
-        // a line
-    }
-
-    /** constructor that is 10 lines long **/
-    private InputMethodLengthSimple()
+/** constructor that is 10 lines long **/
+    private InputMethodLengthSimpleOne()
     {
         // a line
         // a line
@@ -129,69 +103,6 @@ final class InputMethodLengthSimple
             String InnerBlockVariable = "";
         }
     }
-
-    /** test method pattern */
-    void ALL_UPPERCASE_METHOD()
-    {
-    }
-
-    /** test illegal constant **/
-    private static final int BAD__NAME = 3;
-
-    // A very, very long line that is OK because it matches the regexp "^.*is OK.*regexp.*$"
-    // long line that has a tab ->        <- and would be OK if tab counted as 1 char
-    // tabs that count as one char because of their position ->        <-   ->        <-, OK
-
-    /** some lines to test the violation column after tabs */
-    void errorColumnAfterTabs()
-    {
-        // with tab-width 8 all statements below start at the same column,
-        // with different combinations of ' ' and '\t' before the statement
-                int tab0 =1;
-                int tab1 =1;
-                 int tab2 =1;
-                int tab3 =1;
-                    int tab4 =1;
-                  int tab5 =1;
-    }
-
-    // MEMME:
-    /* MEMME: a
-     * MEMME:
-     * OOOO
-     */
-    /* NOTHING */
-    /* YES */ /* MEMME: x */ /* YES!! */
-
-    /** test long comments **/
-    void veryLong()
-    {
-        /*
-          blah blah blah blah
-          blah blah blah blah
-          blah blah blah blah
-          blah blah blah blah
-          blah blah blah blah
-          blah blah blah blah
-          blah blah blah blah
-          blah blah blah blah
-          blah blah blah blah
-          blah blah blah blah
-          blah blah blah blah
-          blah blah blah blah
-          blah blah blah blah
-          blah blah blah blah
-          blah blah blah blah
-          enough talk */
-    }
-
-    /**
-     * @see to lazy to document all args. Testing excessive # args
-     **/
-    void toManyArgs(int aArg1, int aArg2, int aArg3, int aArg4, int aArg5,
-                    int aArg6, int aArg7, int aArg8, int aArg9)
-    {
-    }
 }
 
 /** Test class for variable naming in for each clause. */
@@ -203,20 +114,6 @@ class InputSimple2
         //"O" should be named "o"
         for (Object O : new java.util.ArrayList())
         {
-
         }
     }
-}
-
-/** Test enum for member naming check */
-enum MyEnum1
-{
-    /** ABC constant */
-    ABC,
-
-    /** XYZ constant */
-    XYZ;
-
-    /** Should be mSomeMember */
-    private int someMember;
 }

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/sizes/methodlength/InputMethodLengthSimpleTwo.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/sizes/methodlength/InputMethodLengthSimpleTwo.java
@@ -1,0 +1,113 @@
+/*
+MethodLength
+max = 19
+countEmpty = (default)true
+tokens = (default)METHOD_DEF , CTOR_DEF , COMPACT_CTOR_DEF
+
+
+*/
+
+package com.puppycrawl.tools.checkstyle.checks.sizes.methodlength;
+import java.io.*;
+
+final class InputMethodLengthSimpleTwo
+{
+    /** method that is 20 lines long **/
+    private void longMethod() // violation
+    {
+        // a line
+        // a line
+        // a line
+        // a line
+        // a line
+        // a line
+        // a line
+        // a line
+        // a line
+        // a line
+        // a line
+        // a line
+        // a line
+        // a line
+        // a line
+        // a line
+        // a line
+        // a line
+    }
+
+    /** test method pattern */
+    void ALL_UPPERCASE_METHOD()
+    {
+    }
+
+    /** test illegal constant **/
+    private static final int BAD__NAME = 3;
+
+    // A very, very long line that is OK because it matches the regexp "^.*is OK.*regexp.*$"
+    // long line that has a tab ->        <- and would be OK if tab counted as 1 char
+    // tabs that count as one char because of their position ->        <-   ->        <-, OK
+
+    /** some lines to test the violation column after tabs */
+    void errorColumnAfterTabs()
+    {
+        // with tab-width 8 all statements below start at the same column,
+        // with different combinations of ' ' and '\t' before the statement
+                int tab0 =1;
+                int tab1 =1;
+                 int tab2 =1;
+                int tab3 =1;
+                    int tab4 =1;
+                  int tab5 =1;
+    }
+
+    // MEMME:
+    /* MEMME: a
+     * MEMME:
+     * OOOO
+     */
+    /* NOTHING */
+    /* YES */ /* MEMME: x */ /* YES!! */
+
+    /** test long comments **/
+    void veryLong()
+    {
+        /*
+          blah blah blah blah
+          blah blah blah blah
+          blah blah blah blah
+          blah blah blah blah
+          blah blah blah blah
+          blah blah blah blah
+          blah blah blah blah
+          blah blah blah blah
+          blah blah blah blah
+          blah blah blah blah
+          blah blah blah blah
+          blah blah blah blah
+          blah blah blah blah
+          blah blah blah blah
+          blah blah blah blah
+          enough talk */
+    }
+
+    /**
+     * @see to lazy to document all args. Testing excessive # args
+     **/
+    void toManyArgs(int aArg1, int aArg2, int aArg3, int aArg4, int aArg5,
+                    int aArg6, int aArg7, int aArg8, int aArg9)
+    {
+    }
+}
+
+/** Test enum for member naming check */
+enum MyEnum1
+{
+    /** ABC constant */
+    ABC,
+
+    /** XYZ constant */
+    XYZ;
+
+    /** Should be mSomeMember */
+    private int someMember;
+}


### PR DESCRIPTION
Part of #11163 
Enforced file size on InputMethodLengthSimple file.

There was only one violation in the file before splitting, so I set the **_expected_** of first file to
expected = CommonUtil.EMPTY_STRING_ARRAY;
and mentioned the violation in second file.