### PR TITLE
Issue #14137: Enable `NestedOptionals` check

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -253,6 +253,7 @@
       -Xep:JUnitValueSource:OFF
       <!-- Until https://github.com/checkstyle/checkstyle/issues/14194. -->
       -Xep:LexicographicalAnnotationListing:OFF
+      -Xep:NestedOptionals:ERROR
       <!-- This check is not finalized. -->
       -Xep:MethodReferenceUsage:OFF
       <!-- We prefer to qualify all static method calls with class name. -->


### PR DESCRIPTION
Issue #14137.

This PR enables https://error-prone.picnic.tech/bugpatterns/NestedOptionals/ check.
