### PR TITLE
Issue#13999: Resolve pitest suppression for throwAst.getParent() of JavadocMethod

### DIFF
--- a/config/pitest-suppressions/pitest-javadoc-suppressions.xml
+++ b/config/pitest-suppressions/pitest-javadoc-suppressions.xml
@@ -112,15 +112,6 @@
     <sourceFile>JavadocMethodCheck.java</sourceFile>
     <mutatedClass>com.puppycrawl.tools.checkstyle.checks.javadoc.JavadocMethodCheck</mutatedClass>
     <mutatedMethod>isInIgnoreBlock</mutatedMethod>
-    <mutator>org.pitest.mutationtest.engine.gregor.mutators.experimental.NakedReceiverMutator</mutator>
-    <description>replaced call to com/puppycrawl/tools/checkstyle/api/DetailAST::getParent with receiver</description>
-    <lineContent>DetailAST ancestor = throwAst.getParent();</lineContent>
-  </mutation>
-
-  <mutation unstable="false">
-    <sourceFile>JavadocMethodCheck.java</sourceFile>
-    <mutatedClass>com.puppycrawl.tools.checkstyle.checks.javadoc.JavadocMethodCheck</mutatedClass>
-    <mutatedMethod>isInIgnoreBlock</mutatedMethod>
     <mutator>org.pitest.mutationtest.engine.gregor.mutators.RemoveConditionalMutator_EQUAL_IF</mutator>
     <description>removed conditional - replaced equality check with true</description>
     <lineContent>if (ancestor.getType() == TokenTypes.LITERAL_TRY</lineContent>

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocMethodCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocMethodCheck.java
@@ -686,7 +686,7 @@ public class JavadocMethodCheck extends AbstractCheck {
      * @return true if throwAst is inside a block that should be ignored
      */
     private static boolean isInIgnoreBlock(DetailAST methodBodyAst, DetailAST throwAst) {
-        DetailAST ancestor = throwAst.getParent();
+        DetailAST ancestor = throwAst;
         while (ancestor != methodBodyAst) {
             if (ancestor.getType() == TokenTypes.LITERAL_TRY
                     && ancestor.findFirstToken(TokenTypes.LITERAL_CATCH) != null


### PR DESCRIPTION
issue: #13999 

#### Mutation

https://github.com/checkstyle/checkstyle/blob/6d83d86d162c25071a280d5b19c1dbc9daa40cb1/config/pitest-suppressions/pitest-javadoc-suppressions.xml#L111-L119

#### Explanation
The `isInIgnoreBlock()` modified in this PR is used to check whether there is `throw` keyword is used in a block that should be ignored. Blocks that should be ignored are try block with catch, local classes, anonymous class & lambda expressions.  

The `DetailAST throwAst` parameter used in this method is a DetailAst node representing the `throw` keyword used in the current block. Pitest was complaining about the `getParent()` method used on this parameter ( throwAst.getParent() ). The getParent() is used to get the parent token of the current token which in our case is `throw` keyword. 

We're using the parent token to find that if the `throw` used in this block is a block which should be ignored or not. We're calling the `getParent()` method before starting the loop and storing it in a `ancestor` variable. We're running a while loop in this method which checks that the block should be ignored or not by continuously calling the `getParent()` on `ancestor` and checking it against the some certain `TokenTypes` which represents the block that should be ignored. So removing the `getParent()` method call at starting does not affects the result of `isInIgnoreBlock()` method, it was there just for little optimization.

#### Dependency Tree

```
JavadocMethodCheck.getThrowed(DetailAST)  (com.puppycrawl.tools.checkstyle.checks.javadoc)
    JavadocMethodCheck.checkComment(DetailAST, TextBlock)  (com.puppycrawl.tools.checkstyle.checks.javadoc)
        JavadocMethodCheck.processAST(DetailAST)  (com.puppycrawl.tools.checkstyle.checks.javadoc)
            JavadocMethodCheck.visitToken(DetailAST)  (com.puppycrawl.tools.checkstyle.checks.javadoc)
                TestUtil.isStatefulFieldClearedDuringBeginTree(AbstractCheck, DetailAST, String, Predicate<Object>)  (com.puppycrawl.tools.checkstyle.internal.utils)
                TreeWalker.notifyVisit(DetailAST, AstState)  (com.puppycrawl.tools.checkstyle)
```


#### Regression

Diff Regression config: https://gist.githubusercontent.com/Zopsss/e5c173e3f7d020c335e73260cabc8c25/raw/c15d7975221b4eca529841f31631860b1e10ef50/JavadocMethod.xml

Diff Regression projects: https://gist.githubusercontent.com/Zopsss/22adadb570e4deb95296917244c580b3/raw/29ea756eada8915637b76678db4f46048c198808/projects-to-test-on-for-github-action.properties

Report label: JavadocMethod-1