### PR TITLE
Issue #13213: Removed '//ok' noncompilable/coding

### DIFF
--- a/config/checkstyle-input-suppressions.xml
+++ b/config/checkstyle-input-suppressions.xml
@@ -69,34 +69,6 @@
 
   <!-- until https://github.com/checkstyle/checkstyle/issues/13213 -->
   <suppress id="UnnecessaryOkComment"
-            files="checks[\\/]coding[\\/]finallocalvariable[\\/]InputFinalLocalVariableCheckRecords.java"/>
-  <suppress id="UnnecessaryOkComment"
-            files="checks[\\/]coding[\\/]hiddenfield[\\/]InputHiddenFieldClassNestedInRecord.java"/>
-  <suppress id="UnnecessaryOkComment"
-            files="checks[\\/]coding[\\/]illegalinstantiation[\\/]InputIllegalInstantiationLang2.java"/>
-  <suppress id="UnnecessaryOkComment"
-            files="checks[\\/]coding[\\/]nofinalizer[\\/]InputNoFinalizerFallThrough.java"/>
-  <suppress id="UnnecessaryOkComment"
-            files="checks[\\/]coding[\\/]nofinalizer[\\/]InputNoFinalizerFallThrough.java"/>
-  <suppress id="UnnecessaryOkComment"
-            files="checks[\\/]coding[\\/]onestatementperline[\\/]InputOneStatementPerLine.java"/>
-  <suppress id="UnnecessaryOkComment"
-            files="checks[\\/]coding[\\/]stringliteralequality[\\/]InputStringLiteralEqualityCheckTextBlocks.java"/>
-  <suppress id="UnnecessaryOkComment"
-            files="checks[\\/]coding[\\/]stringliteralequality[\\/]InputStringLiteralEqualityCheckTextBlocks.java"/>
-  <suppress id="UnnecessaryOkComment"
-            files="checks[\\/]coding[\\/]unnecessaryparentheses[\\/]InputUnnecessaryParenthesesCheckPatterns.java"/>
-  <suppress id="UnnecessaryOkComment"
-            files="checks[\\/]coding[\\/]unnecessaryparentheses[\\/]InputUnnecessaryParenthesesCheckPatterns.java"/>
-  <suppress id="UnnecessaryOkComment"
-            files="checks[\\/]coding[\\/]unnecessarysemicolonafteroutertypedeclaration[\\/]InputUnnecessarySemicolonAfterOuterTypeDeclarationRecords.java"/>
-  <suppress id="UnnecessaryOkComment"
-            files="checks[\\/]coding[\\/]unusedlocalvariable[\\/]InputUnusedLocalVariableRecords.java"/>
-  <suppress id="UnnecessaryOkComment"
-            files="checks[\\/]coding[\\/]unusedlocalvariable[\\/]InputUnusedLocalVariableWithoutPackageStatement.java"/>
-  <suppress id="UnnecessaryOkComment"
-            files="checks[\\/]coding[\\/]unusedlocalvariable[\\/]InputUnusedLocalVariableWithoutPackageStatement.java"/>
-  <suppress id="UnnecessaryOkComment"
             files="checks[\\/]design[\\/]designforextension[\\/]InputDesignForExtensionRecords.java"/>
   <suppress id="UnnecessaryOkComment"
             files="checks[\\/]design[\\/]onetoplevelclass[\\/]InputOneTopLevelClassEmpty.java"/>

--- a/src/test/resources-noncompilable/com/puppycrawl/tools/checkstyle/checks/coding/finallocalvariable/InputFinalLocalVariableCheckRecords.java
+++ b/src/test/resources-noncompilable/com/puppycrawl/tools/checkstyle/checks/coding/finallocalvariable/InputFinalLocalVariableCheckRecords.java
@@ -11,7 +11,7 @@ package com.puppycrawl.tools.checkstyle.checks.coding.finallocalvariable;
 
 public record InputFinalLocalVariableCheckRecords(boolean t, boolean f) {
     public InputFinalLocalVariableCheckRecords {
-        int a = 0; // ok
+        int a = 0;
         a = 1;
     }
 

--- a/src/test/resources-noncompilable/com/puppycrawl/tools/checkstyle/checks/coding/hiddenfield/InputHiddenFieldClassNestedInRecord.java
+++ b/src/test/resources-noncompilable/com/puppycrawl/tools/checkstyle/checks/coding/hiddenfield/InputHiddenFieldClassNestedInRecord.java
@@ -25,7 +25,7 @@ public class InputHiddenFieldClassNestedInRecord {
                 return foo.this;
             }
 
-            foo2 setB(int b) { // ok
+            foo2 setB(int b) {
                 this.b = b;
                 return this;
             }

--- a/src/test/resources-noncompilable/com/puppycrawl/tools/checkstyle/checks/coding/illegalinstantiation/InputIllegalInstantiationLang2.java
+++ b/src/test/resources-noncompilable/com/puppycrawl/tools/checkstyle/checks/coding/illegalinstantiation/InputIllegalInstantiationLang2.java
@@ -9,7 +9,7 @@ tokens = (default)CLASS_DEF
 //non-compiled with javac: compiling on jdk before 9
 package java.lang;
 
-class InputIllegalInstantiationLang2 { // ok
+class InputIllegalInstantiationLang2 {
     Boolean obj = new Boolean();
     Integer obj2 = new Integer();
 }

--- a/src/test/resources-noncompilable/com/puppycrawl/tools/checkstyle/checks/coding/nofinalizer/InputNoFinalizerFallThrough.java
+++ b/src/test/resources-noncompilable/com/puppycrawl/tools/checkstyle/checks/coding/nofinalizer/InputNoFinalizerFallThrough.java
@@ -8,7 +8,7 @@ NoFinalizer
 //Compilable by javac, but noncompilable by eclipse
 package com.puppycrawl.tools.checkstyle.checks.coding.nofinalizer;
 
-public class InputNoFinalizerFallThrough { // ok
+public class InputNoFinalizerFallThrough {
 
     void tryResource() throws Exception {
         switch (hashCode()) {
@@ -77,7 +77,7 @@ public class InputNoFinalizerFallThrough { // ok
         }
     }
 
-    private static class Resource implements AutoCloseable { // ok
+    private static class Resource implements AutoCloseable {
         @Override
         public void close() throws Exception {
         }

--- a/src/test/resources-noncompilable/com/puppycrawl/tools/checkstyle/checks/coding/onestatementperline/InputOneStatementPerLine.java
+++ b/src/test/resources-noncompilable/com/puppycrawl/tools/checkstyle/checks/coding/onestatementperline/InputOneStatementPerLine.java
@@ -70,7 +70,7 @@ public class InputOneStatementPerLine {
   InputOneStatementPerLine method(foo a) {
     foo obj = () -> {
       method(() ->
-             {method(null);}).method(null); // ok
+             {method(null);}).method(null);
     };
     return this;
   }

--- a/src/test/resources-noncompilable/com/puppycrawl/tools/checkstyle/checks/coding/stringliteralequality/InputStringLiteralEqualityCheckTextBlocks.java
+++ b/src/test/resources-noncompilable/com/puppycrawl/tools/checkstyle/checks/coding/stringliteralequality/InputStringLiteralEqualityCheckTextBlocks.java
@@ -13,7 +13,7 @@ public class InputStringLiteralEqualityCheckTextBlocks {
 
         boolean flag1 = (status1 == "done"); // violation
 
-        boolean flag2 = (status1.equals("done")); // ok
+        boolean flag2 = (status1.equals("done"));
 
 
         String status2 = """
@@ -29,7 +29,7 @@ public class InputStringLiteralEqualityCheckTextBlocks {
                 done"""); // violation above
 
         boolean flag4 = (status2.equals("""
-                done""")); // ok
+                done"""));
 
     }
 }

--- a/src/test/resources-noncompilable/com/puppycrawl/tools/checkstyle/checks/coding/unnecessaryparentheses/InputUnnecessaryParenthesesCheckPatterns.java
+++ b/src/test/resources-noncompilable/com/puppycrawl/tools/checkstyle/checks/coding/unnecessaryparentheses/InputUnnecessaryParenthesesCheckPatterns.java
@@ -18,7 +18,7 @@ public class InputUnnecessaryParenthesesCheckPatterns {
     void method() {
         Object o = "";
 
-        boolean result = (o instanceof String a) ? // ok
-                (o instanceof String x) : (!(o instanceof String y)); // ok
+        boolean result = (o instanceof String a) ?
+                (o instanceof String x) : (!(o instanceof String y));
     }
 }

--- a/src/test/resources-noncompilable/com/puppycrawl/tools/checkstyle/checks/coding/unnecessarysemicolonafteroutertypedeclaration/InputUnnecessarySemicolonAfterOuterTypeDeclarationRecords.java
+++ b/src/test/resources-noncompilable/com/puppycrawl/tools/checkstyle/checks/coding/unnecessarysemicolonafteroutertypedeclaration/InputUnnecessarySemicolonAfterOuterTypeDeclarationRecords.java
@@ -19,5 +19,5 @@ public record InputUnnecessarySemicolonAfterOuterTypeDeclarationRecords() {
 record OuterRecord() {
     record InnerRecord() {
 
-    }; // ok
+    };
 }; // violation

--- a/src/test/resources-noncompilable/com/puppycrawl/tools/checkstyle/checks/coding/unusedlocalvariable/InputUnusedLocalVariableRecords.java
+++ b/src/test/resources-noncompilable/com/puppycrawl/tools/checkstyle/checks/coding/unusedlocalvariable/InputUnusedLocalVariableRecords.java
@@ -11,7 +11,7 @@ import java.util.function.Predicate;
 //non-compiled with javac: Compilable with Java14
 public record InputUnusedLocalVariableRecords(int a, int b) {
     public InputUnusedLocalVariableRecords {
-        int ab = 12; // ok
+        int ab = 12;
         ab += a;
         int var1 = 1; // violation
         new nested() {

--- a/src/test/resources-noncompilable/com/puppycrawl/tools/checkstyle/checks/coding/unusedlocalvariable/InputUnusedLocalVariableWithoutPackageStatement.java
+++ b/src/test/resources-noncompilable/com/puppycrawl/tools/checkstyle/checks/coding/unusedlocalvariable/InputUnusedLocalVariableWithoutPackageStatement.java
@@ -20,7 +20,7 @@ public class InputUnusedLocalVariableWithoutPackageStatement {
     }
 
     void anotherMethod() {
-        int var1 = 12; // ok
+        int var1 = 12;
         int var2 = 13; // violation
         Foo obj = new Foo() {
             void method() {
@@ -43,7 +43,7 @@ class Foo {
 
         void method() {
             int var3 = 13; // violation
-            int var1 = 12; // ok
+            int var1 = 12;
             SharkFoo obj = new SharkFoo() {
                 void method() {
                     var3 += var1;


### PR DESCRIPTION
Part of #13213
Removed all the '//ok' comments from multiple checks belonging to the test/resources-noncompilable/coding module
like **_suggested_**.

Hope this is fine..
Also resolved the conflicts that occurred previously