### PR TITLE
Issue #13213: Removed '//ok' from InputOneTopLevelClass and InputOneTopLevelClassAnnotation

### DIFF
--- a/config/checkstyle-input-suppressions.xml
+++ b/config/checkstyle-input-suppressions.xml
@@ -1407,10 +1407,6 @@
   <suppress id="UnnecessaryOkComment"
             files="checks[\\/]design[\\/]mutableexception[\\/]InputMutableExceptionClassExtendsGenericClass.java"/>
   <suppress id="UnnecessaryOkComment"
-            files="checks[\\/]design[\\/]onetoplevelclass[\\/]InputOneTopLevelClass.java"/>
-  <suppress id="UnnecessaryOkComment"
-            files="checks[\\/]design[\\/]onetoplevelclass[\\/]InputOneTopLevelClassAnnotation.java"/>
-  <suppress id="UnnecessaryOkComment"
             files="checks[\\/]design[\\/]onetoplevelclass[\\/]InputOneTopLevelClassEnum.java"/>
   <suppress id="UnnecessaryOkComment"
             files="checks[\\/]design[\\/]onetoplevelclass[\\/]InputOneTopLevelClassInterface.java"/>

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/design/onetoplevelclass/InputOneTopLevelClass.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/design/onetoplevelclass/InputOneTopLevelClass.java
@@ -6,7 +6,7 @@ OneTopLevelClass
 
 package com.puppycrawl.tools.checkstyle.checks.design.onetoplevelclass;
 
-public class InputOneTopLevelClass // ok
+public class InputOneTopLevelClass
 {
     static final int FOO2 = 3;
 

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/design/onetoplevelclass/InputOneTopLevelClassAnnotation.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/design/onetoplevelclass/InputOneTopLevelClassAnnotation.java
@@ -6,6 +6,6 @@ OneTopLevelClass
 
 package com.puppycrawl.tools.checkstyle.checks.design.onetoplevelclass;
 
-@interface InputOneTopLevelClassAnnotation { // ok
+@interface InputOneTopLevelClassAnnotation {
    String author();
 }


### PR DESCRIPTION
Issue #13213: Removed '//ok' from InputOneTopLevelClass and InputOneTopLevelClassAnnotation