### PR TITLE
Issue #13213: Removed //ok from modifierorder

### DIFF
--- a/config/checkstyle-input-suppressions.xml
+++ b/config/checkstyle-input-suppressions.xml
@@ -2941,8 +2941,6 @@
   <suppress id="UnnecessaryOkComment"
             files="checks[\\/]modifier[\\/]interfacememberimpliedmodifier[\\/]InputInterfaceMemberImpliedModifierPrivateMethods.java"/>
   <suppress id="UnnecessaryOkComment"
-            files="checks[\\/]modifier[\\/]modifierorder[\\/]InputModifierOrderDefaultMethods.java"/>
-  <suppress id="UnnecessaryOkComment"
             files="checks[\\/]modifier[\\/]redundantmodifier[\\/]InputRedundantModifierStaticMethodInInterface.java"/>
   <suppress id="UnnecessaryOkComment"
             files="checks[\\/]naming[\\/]abbreviationaswordinname[\\/]InputAbbreviationAsWordInNameAbstractMultisetSetCount.java"/>

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/modifier/modifierorder/InputModifierOrderDefaultMethods.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/modifier/modifierorder/InputModifierOrderDefaultMethods.java
@@ -7,7 +7,7 @@ ModifierOrder
 package com.puppycrawl.tools.checkstyle.checks.modifier.modifierorder;
 import java.util.Comparator;
 
-public interface InputModifierOrderDefaultMethods extends Comparator<Integer> { // ok
+public interface InputModifierOrderDefaultMethods extends Comparator<Integer> {
     @Override
     default int compare(Integer a, Integer b) {
      return 0;


### PR DESCRIPTION
Part of #13213
Removed `//ok` comments from **InputModifierOrderDefaultMethods.java**