### PR TITLE
Issue #13213: Removed //ok leftout checks

### DIFF
--- a/config/checkstyle-input-suppressions.xml
+++ b/config/checkstyle-input-suppressions.xml
@@ -123,8 +123,6 @@
   <suppress id="UnnecessaryOkComment"
             files="checks[\\/]naming[\\/]typename[\\/]InputTypeNameRecords.java"/>
   <suppress id="UnnecessaryOkComment"
-            files="checks[\\/]outertypefilename[\\/]package-info.java"/>
-  <suppress id="UnnecessaryOkComment"
             files="checks[\\/]sizes[\\/]lambdabodylength[\\/]InputLambdaBodyLengthSwitchExps.java"/>
   <suppress id="UnnecessaryOkComment"
             files="checks[\\/]sizes[\\/]linelength[\\/]InputLineLengthIgnoringImportStatements.java"/>
@@ -237,8 +235,6 @@
   <suppress id="UnnecessaryOkComment"
             files="checks[\\/]sizes[\\/]recordcomponentnumber[\\/]InputRecordComponentNumberTopLevel2.java"/>
   <suppress id="UnnecessaryOkComment"
-            files="checks[\\/]uncommentedmain[\\/]InputUncommentedMainRecords.java"/>
-  <suppress id="UnnecessaryOkComment"
             files="checks[\\/]whitespace[\\/]emptylineseparator[\\/]InputEmptyLineSeparatorRecordsAndCompactCtors.java"/>
   <suppress id="UnnecessaryOkComment"
             files="checks[\\/]whitespace[\\/]emptylineseparator[\\/]InputEmptyLineSeparatorRecordsAndCompactCtors.java"/>
@@ -348,8 +344,6 @@
             files="checks[\\/]whitespace[\\/]whitespacearound[\\/]InputWhitespaceAroundRecordsAllowEmptyTypes.java"/>
   <suppress id="UnnecessaryOkComment"
             files="checks[\\/]whitespace[\\/]whitespacearound[\\/]InputWhitespaceAroundRecordsAllowEmptyTypes.java"/>
-  <suppress id="UnnecessaryOkComment"
-            files="checks[\\/]annotation[\\/]packageannotation[\\/]InputPackageAnnotation.java"/>
   <suppress id="UnnecessaryOkComment"
             files="checks[\\/]avoidescapedunicodecharacters[\\/]InputAvoidEscapedUnicodeCharactersAllEscapedUnicodeCharacters.java"/>
   <suppress id="UnnecessaryOkComment"
@@ -1293,19 +1287,11 @@
   <suppress id="UnnecessaryOkComment"
             files="checks[\\/]design[\\/]visibilitymodifier[\\/]inputs[\\/]InetSocketAddress.java"/>
   <suppress id="UnnecessaryOkComment"
-            files="checks[\\/]finalparameters[\\/]InputFinalParametersReceiver.java"/>
-  <suppress id="UnnecessaryOkComment"
-            files="checks[\\/]indentation[\\/]commentsindentation[\\/]InputCommentsIndentationCommentIsAtTheEndOfBlock.java"/>
-  <suppress id="UnnecessaryOkComment"
-            files="checks[\\/]indentation[\\/]commentsindentation[\\/]InputCommentsIndentationCommentIsAtTheEndOfBlock.java"/>
-  <suppress id="UnnecessaryOkComment"
             files="checks[\\/]indentation[\\/]commentsindentation[\\/]InputCommentsIndentationCommentsAfterMethodCall.java"/>
   <suppress id="UnnecessaryOkComment"
             files="checks[\\/]indentation[\\/]commentsindentation[\\/]InputCommentsIndentationCommentsAfterMethodCall.java"/>
   <suppress id="UnnecessaryOkComment"
             files="checks[\\/]indentation[\\/]commentsindentation[\\/]InputCommentsIndentationCommentsAfterMethodCall.java"/>
-  <suppress id="UnnecessaryOkComment"
-            files="checks[\\/]indentation[\\/]commentsindentation[\\/]InputCommentsIndentationNoNpe.java"/>
   <suppress id="UnnecessaryOkComment"
             files="checks[\\/]indentation[\\/]commentsindentation[\\/]InputCommentsIndentationWithInMethodCallWithSameIndent.java"/>
   <suppress id="UnnecessaryOkComment"

--- a/src/test/resources-noncompilable/com/puppycrawl/tools/checkstyle/checks/outertypefilename/package-info.java
+++ b/src/test/resources-noncompilable/com/puppycrawl/tools/checkstyle/checks/outertypefilename/package-info.java
@@ -5,5 +5,5 @@ OuterTypeFilename
 */
 
 @Deprecated
-package com.puppycrawl.tools.checkstyle.checks.outertypefilename; // ok
+package com.puppycrawl.tools.checkstyle.checks.outertypefilename;
 

--- a/src/test/resources-noncompilable/com/puppycrawl/tools/checkstyle/checks/uncommentedmain/InputUncommentedMainRecords.java
+++ b/src/test/resources-noncompilable/com/puppycrawl/tools/checkstyle/checks/uncommentedmain/InputUncommentedMainRecords.java
@@ -13,7 +13,7 @@ public record InputUncommentedMainRecords(Integer x) {
         System.out.println("no comments here!");
     }
 
-    // public static void main(String... args) { } // ok
+    // public static void main(String... args) { }
 
     // unlike inner classes, inner records CAN have static methods
     record InnerRecord(String... args) {

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/annotation/packageannotation/InputPackageAnnotation.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/annotation/packageannotation/InputPackageAnnotation.java
@@ -7,6 +7,6 @@ PackageAnnotation
 package com.puppycrawl.tools.checkstyle.checks.annotation.packageannotation;
 
 @Deprecated
-public class InputPackageAnnotation { // ok
+public class InputPackageAnnotation {
 
 }

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/finalparameters/InputFinalParametersReceiver.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/finalparameters/InputFinalParametersReceiver.java
@@ -8,7 +8,7 @@ tokens = (default)METHOD_DEF, CTOR_DEF
 
 package com.puppycrawl.tools.checkstyle.checks.finalparameters;
 
-public class InputFinalParametersReceiver { // ok
+public class InputFinalParametersReceiver {
     public void foo4(InputFinalParametersReceiver this) {}
 
     private class Inner {

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/indentation/commentsindentation/InputCommentsIndentationNoNpe.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/indentation/commentsindentation/InputCommentsIndentationNoNpe.java
@@ -17,7 +17,7 @@ import java.lang.reflect.Method;
  * Provides convenience methods such as {@link #isPublic} and {@link #isPackagePrivate}.
  *
  */
-class InputCommentsIndentationNoNpe { // ok
+class InputCommentsIndentationNoNpe {
 
 }
 /* The Check should not throw NPE here! */


### PR DESCRIPTION
Part of #13213 
Removed '//ok' comments from leftout files of /noncompilable.

Also, noticed that there were few unnecessary suppress tags in checkstyle-input-suppressions.xml
The reason was due to the files changed in the recent PR [#14308](https://github.com/checkstyle/checkstyle/pull/14308).
I noticed that the comments were removed as part of enforcing file size but the respective suppress tags have not been removed.
The PR however was merged and thus the unnecessary suppress tags, which I have removed now.