### PR TITLE
Issue #13213: Removed //ok from methodcount

### DIFF
--- a/config/checkstyle-input-suppressions.xml
+++ b/config/checkstyle-input-suppressions.xml
@@ -3199,12 +3199,6 @@
   <suppress id="UnnecessaryOkComment"
             files="checks[\\/]sizes[\\/]lambdabodylength[\\/]InputLambdaBodyLengthMax.java"/>
   <suppress id="UnnecessaryOkComment"
-            files="checks[\\/]sizes[\\/]methodcount[\\/]InputMethodCount.java"/>
-  <suppress id="UnnecessaryOkComment"
-            files="checks[\\/]sizes[\\/]methodcount[\\/]InputMethodCount4.java"/>
-  <suppress id="UnnecessaryOkComment"
-            files="checks[\\/]sizes[\\/]methodcount[\\/]InputMethodCount6.java"/>
-  <suppress id="UnnecessaryOkComment"
             files="checks[\\/]sizes[\\/]methodlength[\\/]InputMethodLengthCountEmptyIsFalse.java"/>
   <suppress id="UnnecessaryOkComment"
             files="checks[\\/]sizes[\\/]methodlength[\\/]InputMethodLengthCountEmptySmallSize.java"/>

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/sizes/methodcount/InputMethodCount.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/sizes/methodcount/InputMethodCount.java
@@ -12,7 +12,7 @@ tokens = (default)CLASS_DEF, ENUM_CONSTANT_DEF, ENUM_DEF, INTERFACE_DEF, ANNOTAT
 
 package com.puppycrawl.tools.checkstyle.checks.sizes.methodcount;
 
-public class InputMethodCount { // ok
+public class InputMethodCount {
 
   /**
    * Dummy inner class to check that the inner-classes methods are not counted

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/sizes/methodcount/InputMethodCount4.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/sizes/methodcount/InputMethodCount4.java
@@ -12,7 +12,7 @@ tokens = (default)CLASS_DEF, ENUM_CONSTANT_DEF, ENUM_DEF, INTERFACE_DEF, ANNOTAT
 
 package com.puppycrawl.tools.checkstyle.checks.sizes.methodcount;
 
-@interface InputMethodCount4 { // ok
+@interface InputMethodCount4 {
   Object object = new Object(){
     @Override
     public String toString() {

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/sizes/methodcount/InputMethodCount6.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/sizes/methodcount/InputMethodCount6.java
@@ -12,7 +12,7 @@ tokens = ENUM_DEF
 
 package com.puppycrawl.tools.checkstyle.checks.sizes.methodcount;
 
-public class InputMethodCount6 { // ok
+public class InputMethodCount6 {
     void method1() {
     }
 }


### PR DESCRIPTION
Part of #13213
Removed `//ok` comments from **InputMethodCount.java**, **InputMethodCount4.java** and **InputMethodCount6.java**