### PR TITLE
Issue #14137: Enable `MockitoStubbing` check

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -248,6 +248,7 @@
       -Xep:ExplicitEnumOrdering:ERROR
       -Xep:IsInstanceLambdaUsage:ERROR
       -Xep:MockitoMockClassReference:ERROR
+      -Xep:MockitoStubbing:ERROR
       -Xep:NestedOptionals:ERROR
       <!-- Reason at https://github.com/checkstyle/checkstyle/issues/8252. -->
       -Xep:JUnitClassModifiers:OFF


### PR DESCRIPTION
Issue #14137.

This PR enables the https://error-prone.picnic.tech/bugpatterns/MockitoStubbing/ check.