### PR TITLE
Issue #14137: Enable `TimeZoneUsage` check

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -249,6 +249,7 @@
       -Xep:IsInstanceLambdaUsage:ERROR
       -Xep:MockitoMockClassReference:ERROR
       -Xep:NestedOptionals:ERROR
+      -Xep:TimeZoneUsage:ERROR
       <!-- Reason at https://github.com/checkstyle/checkstyle/issues/8252. -->
       -Xep:JUnitClassModifiers:OFF
       <!-- Reason at https://github.com/checkstyle/checkstyle/issues/8252. -->


### PR DESCRIPTION
Issue https://github.com/checkstyle/checkstyle/issues/14137.

This PR enables the [error-prone.picnic.tech/bugpatterns/TimeZoneUsage](https://error-prone.picnic.tech/bugpatterns/TimeZoneUsage/) check.