### PR TITLE
minor: Simplify `PropertyCacheFileTest#testNonExistentResource`

### DIFF
--- a/config/error-prone-suppressions/test-compile-phase-suppressions.xml
+++ b/config/error-prone-suppressions/test-compile-phase-suppressions.xml
@@ -6,11 +6,4 @@
     <description>Return value of &apos;findFirst&apos; must be used</description>
     <lineContent>.findFirst();</lineContent>
   </error>
-
-  <error>
-    <sourceFile>PropertyCacheFileTest.java</sourceFile>
-    <bugPattern>CheckReturnValue</bugPattern>
-    <description>The result of `toByteArray(...)` must be used</description>
-    <lineContent>byteStream.when(() -&gt; ByteStreams.toByteArray(any(BufferedInputStream.class)))</lineContent>
-  </error>
 </suppressedErrors>

--- a/src/test/java/com/puppycrawl/tools/checkstyle/PropertyCacheFileTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/PropertyCacheFileTest.java
@@ -421,13 +421,6 @@ public class PropertyCacheFileTest extends AbstractPathTestSupport {
             .hasSize(1);
     }
 
-    /**
-     * Test functionality when toByteArray throws an exception.
-     *
-     * @noinspection ResultOfMethodCallIgnored
-     * @noinspectionreason ResultOfMethodCallIgnored - Setup for mockito to only
-     *                     mock toByteArray to throw exception.
-     */
     @Test
     public void testNonExistentResource() throws IOException {
         final Configuration config = new DefaultConfiguration("myName");
@@ -444,24 +437,19 @@ public class PropertyCacheFileTest extends AbstractPathTestSupport {
                 .that(hash)
                 .isNotNull();
 
-        try (MockedStatic<ByteStreams> byteStream = mockStatic(ByteStreams.class)) {
-            byteStream.when(() -> ByteStreams.toByteArray(any(BufferedInputStream.class)))
-                .thenThrow(IOException.class);
+        // apply new external resource to clear cache
+        final Set<String> resources = new HashSet<>();
+        final String resource = getPath("InputPropertyCacheFile.header");
+        resources.add(resource);
+        cache.putExternalResources(resources);
 
-            // apply new external resource to clear cache
-            final Set<String> resources = new HashSet<>();
-            final String resource = getPath("InputPropertyCacheFile.header");
-            resources.add(resource);
-            cache.putExternalResources(resources);
+        assertWithMessage("Should return false in file is not in cache")
+                .that(cache.isInCache(myFile, 1))
+                .isFalse();
 
-            assertWithMessage("Should return false in file is not in cache")
-                    .that(cache.isInCache(myFile, 1))
-                    .isFalse();
-
-            assertWithMessage("Should return false in file is not in cache")
-                    .that(cache.isInCache(resource, 1))
-                    .isFalse();
-        }
+        assertWithMessage("Should return false in file is not in cache")
+                .that(cache.isInCache(resource, 1))
+                .isFalse();
     }
 
     @Test


### PR DESCRIPTION
As of 0bb9038582406af853dd064d9c699ddc93c0994d the code under test no longer uses `ByteStreams.toByteArray`.