### PR TITLE
Issue #13999: Resolve pitest to getTagt Id method of javadoc

### DIFF
--- a/config/pitest-suppressions/pitest-javadoc-suppressions.xml
+++ b/config/pitest-suppressions/pitest-javadoc-suppressions.xml
@@ -273,15 +273,6 @@
   <mutation unstable="false">
     <sourceFile>TagParser.java</sourceFile>
     <mutatedClass>com.puppycrawl.tools.checkstyle.checks.javadoc.TagParser</mutatedClass>
-    <mutatedMethod>getTagId</mutatedMethod>
-    <mutator>org.pitest.mutationtest.engine.gregor.mutators.experimental.NakedReceiverMutator</mutator>
-    <description>replaced call to java/lang/String::trim with receiver</description>
-    <lineContent>text = text.substring(column).trim();</lineContent>
-  </mutation>
-
-  <mutation unstable="false">
-    <sourceFile>TagParser.java</sourceFile>
-    <mutatedClass>com.puppycrawl.tools.checkstyle.checks.javadoc.TagParser</mutatedClass>
     <mutatedMethod>skipHtmlComment</mutatedMethod>
     <mutator>org.pitest.mutationtest.engine.gregor.mutators.experimental.ArgumentPropagationMutator</mutator>
     <description>replaced call to com/puppycrawl/tools/checkstyle/checks/javadoc/TagParser::findChar with argument</description>

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/TagParser.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/TagParser.java
@@ -177,7 +177,8 @@ class TagParser {
                 column++;
             }
 
-            text = text.substring(column).trim();
+            text = text.substring(column);
+            text = text.replaceAll("^\\s+|\\s+$", "");
             int position = 0;
 
             // Character.isJavaIdentifier... may not be a valid HTML


### PR DESCRIPTION
Related #13999 

Dependency tree :

```
TagParser.parseTags(String[], int)  (com.puppycrawl.tools.checkstyle.checks.javadoc)
    TagParser.TagParser(String[], int)  (com.puppycrawl.tools.checkstyle.checks.javadoc)
        JavadocStyleCheck.checkHtmlTags(DetailAST, TextBlock)  (com.puppycrawl.tools.checkstyle.checks.javadoc)
            JavadocStyleCheck.checkComment(DetailAST, TextBlock)  (com.puppycrawl.tools.checkstyle.checks.javadoc)
                JavadocStyleCheck.visitToken(DetailAST)  (com.puppycrawl.tools.checkstyle.checks.javadoc)
                    TreeWalker.notifyVisit(DetailAST, AstState)  (com.puppycrawl.tools.checkstyle)
                        TreeWalker.processIter(DetailAST, AstState)  (com.puppycrawl.tools.checkstyle)
```

Mutation : 

https://github.com/Rohanraj123/checkstyle/blob/e3e88333cf7ebff9673fb23f4099a58e3a0fe143/config/pitest-suppressions/pitest-javadoc-suppressions.xml#L264-L271

Explanation : 

`trim( )` method is just removing indent spaces. Doing the same thing by removing spaces using `ReplaceAll( )` method. 

