### PR TITLE
Issue #13999: Resolved pitest suppression shouldCheck of JavadocMethodCheck

### DIFF
--- a/config/pitest-suppressions/pitest-javadoc-suppressions.xml
+++ b/config/pitest-suppressions/pitest-javadoc-suppressions.xml
@@ -119,15 +119,6 @@
 
   <mutation unstable="false">
     <sourceFile>JavadocMethodCheck.java</sourceFile>
-    <mutatedClass>com.puppycrawl.tools.checkstyle.checks.javadoc.JavadocMethodCheck</mutatedClass>
-    <mutatedMethod>shouldCheck</mutatedMethod>
-    <mutator>org.pitest.mutationtest.engine.gregor.mutators.RemoveConditionalMutator_EQUAL_IF</mutator>
-    <description>removed conditional - replaced equality check with true</description>
-    <lineContent>return surroundingAccessModifier != null</lineContent>
-  </mutation>
-
-  <mutation unstable="false">
-    <sourceFile>JavadocMethodCheck.java</sourceFile>
     <mutatedClass>com.puppycrawl.tools.checkstyle.checks.javadoc.JavadocMethodCheck$Token</mutatedClass>
     <mutatedMethod>&lt;init&gt;</mutatedMethod>
     <mutator>org.pitest.mutationtest.engine.gregor.mutators.NonVoidMethodCallMutator</mutator>

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocMethodCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocMethodCheck.java
@@ -405,8 +405,7 @@ public class JavadocMethodCheck extends AbstractCheck {
                 .getSurroundingAccessModifier(ast);
         final AccessModifierOption accessModifier = CheckUtil
                 .getAccessModifierFromModifiersToken(ast);
-        return surroundingAccessModifier != null
-                && Arrays.stream(accessModifiers)
+        return Arrays.stream(accessModifiers)
                         .anyMatch(modifier -> modifier == surroundingAccessModifier)
                 && Arrays.stream(accessModifiers).anyMatch(modifier -> modifier == accessModifier);
     }


### PR DESCRIPTION
Part of #13999 

Resolved pitest suppression for one method in JavadocMethodCheck.
Report generated manually : 
```
commit message: "Issue #13999: Resolved pitest suppression shouldCheck"<br />
Patch branch last commit timestamp: "Mon Feb 26 09:42:30 2024 +0530"<br />
<br />Tested projects: 1<br />&#177; differences found: 0<br />
Time of report generation: Mon Feb 26 10:58:33 IST 2024
```

Regression
Diff Regression config: https://gist.githubusercontent.com/Zopsss/e5c173e3f7d020c335e73260cabc8c25/raw/c15d7975221b4eca529841f31631860b1e10ef50/JavadocMethod.xml

Diff Regression projects: https://gist.githubusercontent.com/Zopsss/22adadb570e4deb95296917244c580b3/raw/29ea756eada8915637b76678db4f46048c198808/projects-to-test-on-for-github-action.properties

Report label: JavadocMethod-shouldCheck
