### PR TITLE
Issue #13345: Enabled NoCodeInFileCheckExamplesTest

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/NoCodeInFileCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/NoCodeInFileCheck.java
@@ -26,7 +26,9 @@ import com.puppycrawl.tools.checkstyle.utils.CommonUtil;
 
 /**
  * <p>
- * Checks whether file contains code. Files which are considered to have no code:
+ * Checks whether file contains code.
+ * Java compiler is not raising errors on files with no code or all commented out.
+ * Files which are considered to have no code:
  * </p>
  * <ul>
  * <li>

--- a/src/main/resources/com/puppycrawl/tools/checkstyle/meta/checks/NoCodeInFileCheck.xml
+++ b/src/main/resources/com/puppycrawl/tools/checkstyle/meta/checks/NoCodeInFileCheck.xml
@@ -5,7 +5,9 @@
              name="NoCodeInFile"
              parent="com.puppycrawl.tools.checkstyle.TreeWalker">
          <description>&lt;p&gt;
- Checks whether file contains code. Files which are considered to have no code:
+ Checks whether file contains code.
+ Java compiler is not raising errors on files with no code or all commented out.
+ Files which are considered to have no code:
  &lt;/p&gt;
  &lt;ul&gt;
  &lt;li&gt;

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/meta/javadocmetadatascraper/ExpectedJavadocMetadataScraperNoCodeInFileCheck.txt
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/meta/javadocmetadatascraper/ExpectedJavadocMetadataScraperNoCodeInFileCheck.txt
@@ -5,7 +5,9 @@ FullQualifiedName: com.puppycrawl.tools.checkstyle.meta.javadocmetadatascraper.I
 ocMetadataScraperNoCodeInFileCheck
 Parent: com.puppycrawl.tools.checkstyle.TreeWalker
 Description: <p>
- Checks whether file contains code. Files which are considered to have no code:
+ Checks whether file contains code.
+ Java compiler is not raising errors on files with no code or all commented out.
+ Files which are considered to have no code:
  </p>
  <ul>
  <li>

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/meta/javadocmetadatascraper/InputJavadocMetadataScraperNoCodeInFileCheck.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/meta/javadocmetadatascraper/InputJavadocMetadataScraperNoCodeInFileCheck.java
@@ -14,7 +14,9 @@ import com.puppycrawl.tools.checkstyle.api.AbstractCheck;
 
 /**
  * <p>
- * Checks whether file contains code. Files which are considered to have no code:
+ * Checks whether file contains code.
+ * Java compiler is not raising errors on files with no code or all commented out.
+ * Files which are considered to have no code:
  * </p>
  * <ul>
  * <li>

--- a/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/checks/NoCodeInFileCheckExamplesTest.java
+++ b/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/checks/NoCodeInFileCheckExamplesTest.java
@@ -19,12 +19,12 @@
 
 package com.puppycrawl.tools.checkstyle.checks;
 
-import org.junit.jupiter.api.Disabled;
+import static com.puppycrawl.tools.checkstyle.checks.NoCodeInFileCheck.MSG_KEY_NO_CODE;
+
 import org.junit.jupiter.api.Test;
 
 import com.puppycrawl.tools.checkstyle.AbstractExamplesModuleTestSupport;
 
-@Disabled("until https://github.com/checkstyle/checkstyle/issues/13345")
 public class NoCodeInFileCheckExamplesTest extends AbstractExamplesModuleTestSupport {
     @Override
     protected String getPackageLocation() {
@@ -34,18 +34,18 @@ public class NoCodeInFileCheckExamplesTest extends AbstractExamplesModuleTestSup
     @Test
     public void testExample1() throws Exception {
         final String[] expected = {
-
+            "1: " + getCheckMessage(MSG_KEY_NO_CODE),
         };
 
-        verifyWithInlineConfigParser(getPath("Example1.txt"), expected);
+        verifyWithInlineConfigParser(getPath("Example1.java"), expected);
     }
 
     @Test
     public void testExample2() throws Exception {
         final String[] expected = {
-
+            "1: " + getCheckMessage(MSG_KEY_NO_CODE),
         };
 
-        verifyWithInlineConfigParser(getPath("Example2.txt"), expected);
+        verifyWithInlineConfigParser(getPath("Example2.java"), expected);
     }
 }

--- a/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/nocodeinfile/Example1.java
+++ b/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/nocodeinfile/Example1.java
@@ -6,6 +6,11 @@
 </module>
 */
 
+// violation 8 lines above
+
 // xdoc section -- start
-// single-line comment // violation
+// the violation is on first line of file
+// public class Example1 {
+// single-line comment is not code
+// }
 // xdoc section -- end

--- a/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/nocodeinfile/Example2.java
+++ b/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/nocodeinfile/Example2.java
@@ -6,8 +6,13 @@
 </module>
 */
 
+// violation 8 lines above
+
 // xdoc section -- start
-/* // violation
- block comment
+// the violation is on first line of file
+/*
+ public class Example2 {
+ block comment is not code
+ }
 */
 // xdoc section -- end

--- a/src/xdocs/checks/misc/nocodeinfile.xml
+++ b/src/xdocs/checks/misc/nocodeinfile.xml
@@ -12,6 +12,7 @@
       <subsection name="Description" id="Description">
         <p>
           Checks whether file contains code.
+          Java compiler is not raising errors on files with no code or all commented out.
           Files which are considered to have no code:
         </p>
         <ul>
@@ -38,19 +39,20 @@
   &lt;/module&gt;
 &lt;/module&gt;
         </source>
-        <p>
-          Example:
-        </p>
-        <p id="Example1-code">
-          Content of the files:
-        </p>
+        <p id="Example1-code">Example:</p>
         <source>
-// single-line comment // violation
+// the violation is on first line of file
+// public class Example1 {
+// single-line comment is not code
+// }
         </source>
         <p id="Example2-code">Example:</p>
         <source>
-/* // violation
- block comment
+// the violation is on first line of file
+/*
+ public class Example2 {
+ block comment is not code
+ }
 */
         </source>
       </subsection>

--- a/src/xdocs/checks/misc/nocodeinfile.xml.template
+++ b/src/xdocs/checks/misc/nocodeinfile.xml.template
@@ -12,6 +12,7 @@
       <subsection name="Description" id="Description">
         <p>
           Checks whether file contains code.
+          Java compiler is not raising errors on files with no code or all commented out.
           Files which are considered to have no code:
         </p>
         <ul>
@@ -33,24 +34,19 @@
         </p>
         <macro name="example">
           <param name="path"
-                 value="resources/com/puppycrawl/tools/checkstyle/checks/nocodeinfile/Example1.txt"/>
+                 value="resources/com/puppycrawl/tools/checkstyle/checks/nocodeinfile/Example1.java"/>
           <param name="type" value="config"/>
         </macro>
-        <p>
-          Example:
-        </p>
-        <p id="Example1-code">
-          Content of the files:
-        </p>
+        <p id="Example1-code">Example:</p>
         <macro name="example">
           <param name="path"
-                 value="resources/com/puppycrawl/tools/checkstyle/checks/nocodeinfile/Example1.txt"/>
+                 value="resources/com/puppycrawl/tools/checkstyle/checks/nocodeinfile/Example1.java"/>
           <param name="type" value="code"/>
         </macro>
         <p id="Example2-code">Example:</p>
         <macro name="example">
           <param name="path"
-                 value="resources/com/puppycrawl/tools/checkstyle/checks/nocodeinfile/Example2.txt"/>
+                 value="resources/com/puppycrawl/tools/checkstyle/checks/nocodeinfile/Example2.java"/>
           <param name="type" value="code"/>
         </macro>
       </subsection>


### PR DESCRIPTION
Part of #13345 

Enabled NoCodeInFileCheckExamplesTest

Based on findings in this PR #14395  and Response to  https://github.com/checkstyle/checkstyle/pull/14395#discussion_r1483020974 ,
Updated the `NoCodeInFileCheck` description in all related files.

**_Previously :_** 

`Checks whether file contains code. Files which are considered to have no code:`

**_After update :_** 
```
 * Checks whether file contains code.
 * Java compiler is not raising errors on files with no code or all commented out.
 * Files which are considered to have no code:
```