### PR TITLE
Issue #14376: Removed Parent POM & Updated maven-release-plugin Config to fix Broken mvn-Enforcer Config

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -3,13 +3,6 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
 
-  <!-- This parent is requirements for deploy of artifacts to maven central -->
-  <parent>
-    <groupId>org.sonatype.oss</groupId>
-    <artifactId>oss-parent</artifactId>
-    <version>9</version>
-  </parent>
-
   <groupId>com.puppycrawl.tools</groupId>
   <artifactId>checkstyle</artifactId>
   <version>10.14.0-SNAPSHOT</version>
@@ -485,9 +478,11 @@
         </plugin>
         <plugin>
           <artifactId>maven-release-plugin</artifactId>
-          <!-- version is same as in supper-pom as it is better to use same version
-               as in sonatype-nexus-staging -->
           <version>2.1</version>
+          <configuration>
+            <mavenExecutorId>forked-path</mavenExecutorId>
+            <useReleaseProfile>false</useReleaseProfile>
+          </configuration>
         </plugin>
         <!-- from super-pom END -->
         <plugin>


### PR DESCRIPTION
Closes  #14376 

@romani  , @nrmancuso 

In order to remove the parent pom usage, we needed to apply the parent pom's plugin config. See https://github.com/sonatype/oss-parents/blob/master/codehaus-parent/pom.xml for this configuration.

Without updating this configuration, we get the following error:
 
```
[ERROR] Project does not define required minimum version of Maven.
[ERROR] Update the pom.xml to contain maven-enforcer-plugin to
[ERROR] force the Maven version which is needed to build this project.
```

We also had failures in the [release-dry-run workflow](https://app.circleci.com/pipelines/github/checkstyle/checkstyle/23415/workflows/1abd9b3b-bf74-424b-afd6-cf50631e7dd2/jobs/497715?invite=true#step-103-22861_57):

```
launch (Launcher.java:226)
    at org.codehaus.plexus.classworlds.launcher.Launcher.mainWithExitCode (Launcher.java:407)
    at org.codehaus.plexus.classworlds.launcher.Launcher.main (Launcher.java:348)
Caused by: org.apache.maven.plugin.PluginContainerException: An API incompatibility was encountered while executing org.apache.maven.plugins:maven-release-plugin:2.2.1:prepare: java.lang.NoSuchMethodError: 'org.apache.maven.settings.RuntimeInfo org.apache.maven.settings.Settings.getRuntimeInfo()'
```


org.sonatype.oss oss-parent 9 : 
```
  <!-- This parent is requirements for deploy of artifacts to maven central -->
  <parent>
    <groupId>org.sonatype.oss</groupId>
    <artifactId>oss-parent</artifactId>
    <version>9</version>
  </parent>
```
