### PR TITLE
Issue #13999: Resolve Pitest suppression for `ancestor.getType() == TokenTypes.LITERAL_TRY` of JavadocMethod

### DIFF
--- a/config/pitest-suppressions/pitest-javadoc-suppressions.xml
+++ b/config/pitest-suppressions/pitest-javadoc-suppressions.xml
@@ -111,15 +111,6 @@
   <mutation unstable="false">
     <sourceFile>JavadocMethodCheck.java</sourceFile>
     <mutatedClass>com.puppycrawl.tools.checkstyle.checks.javadoc.JavadocMethodCheck</mutatedClass>
-    <mutatedMethod>isInIgnoreBlock</mutatedMethod>
-    <mutator>org.pitest.mutationtest.engine.gregor.mutators.RemoveConditionalMutator_EQUAL_IF</mutator>
-    <description>removed conditional - replaced equality check with true</description>
-    <lineContent>if (ancestor.getType() == TokenTypes.LITERAL_TRY</lineContent>
-  </mutation>
-
-  <mutation unstable="false">
-    <sourceFile>JavadocMethodCheck.java</sourceFile>
-    <mutatedClass>com.puppycrawl.tools.checkstyle.checks.javadoc.JavadocMethodCheck</mutatedClass>
     <mutatedMethod>processThrows</mutatedMethod>
     <mutator>org.pitest.mutationtest.engine.gregor.mutators.NonVoidMethodCallMutator</mutator>
     <description>removed call to com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocMethodCheck$Token::getText</description>

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocMethodCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocMethodCheck.java
@@ -688,12 +688,11 @@ public class JavadocMethodCheck extends AbstractCheck {
     private static boolean isInIgnoreBlock(DetailAST methodBodyAst, DetailAST throwAst) {
         DetailAST ancestor = throwAst;
         while (ancestor != methodBodyAst) {
-            if (ancestor.getType() == TokenTypes.LITERAL_TRY
-                    && ancestor.findFirstToken(TokenTypes.LITERAL_CATCH) != null
-                    || ancestor.getType() == TokenTypes.LAMBDA
-                    || ancestor.getType() == TokenTypes.OBJBLOCK) {
-                // throw is inside a try block, and there is a catch block,
-                // or throw is inside a lambda expression/anonymous class/local class
+            if (ancestor.getType() == TokenTypes.LAMBDA
+                    || ancestor.getType() == TokenTypes.OBJBLOCK
+                    || ancestor.findFirstToken(TokenTypes.LITERAL_CATCH) != null) {
+                // throw is inside a lambda expression/anonymous class/local class,
+                // or throw is inside a try block, and there is a catch block
                 break;
             }
             if (ancestor.getType() == TokenTypes.LITERAL_CATCH


### PR DESCRIPTION
Part of #13999 

([Check Documentation](https://checkstyle.org/checks/javadoc/javadocmethod.html))

**Mutation:**
https://github.com/checkstyle/checkstyle/blob/943576fc0da0f0e00b15b7d77f15b16dc8823416/config/pitest-suppressions/pitest-javadoc-suppressions.xml#L111-L118
<hr>

### Definitions:
1. **and-expression**:-
```java
ancestor.getType() == TokenTypes.LITERAL_TRY
&& ancestor.findFirstToken(TokenTypes.LITERAL_CATCH) != null	
```
2. **first-operand**: `ancestor.getType() == TokenTypes.LITERAL_TRY`
3. **second-operand**: `ancestor.findFirstToken(TokenTypes.LITERAL_CATCH) != null`
4. **mutant**: replacing **first-operand** with `true`.
<hr>

### Why mutant survives:
- **mutant** does not alters the result of **and-expression** because `LITERAL_CATCH` cannot exist without being the child of `LITERAL_TRY`. 
- This makes evaluating **first-operand** not a necessity because **second-operand** being evaluated as `true` implicitly means that the type of `ancestor` is `LITERAL_TRY`.
<hr>

### Why mutant cannot be killed:
- For this, there needs to be an input where `LITERAL_CATCH` exist without a preceding `LITERAL_TRY` block
- This results in compilation error and hence is not possible.
<hr>

### Why not remove second-operand:
- The **and-expression** is meant to evaluate if the `throw` is inside a `try` block which has a corresponding `catch` block.
- Unlike `catch` block, which cannot exist without a `try` block, `try` block _can_ exist without a `catch` block.
<hr>

### ⚠️ Performance Impact: 
- Benefit due to short circuiting in **and-expression** should be weighed in before merging this PR.
- If `ancestor` is not `LITERAL_TRY`, `findFirstToken()` is not only useless for the reason that it won't find a `LITERAL_CATCH` ;
- But along with that, it may impact performance if `ancestor` has a significant number of children.
- This is avoided by short circuiting in **and-expression** but results in the surviving **mutant**.
<hr>

### Change: 
Updated the code as Pitest mutated, except it is now the last operand of the or-statement to help mitigate the performance impact by a bit.
(Although this shifting of operands may produce negligible performance gains, still better than none)
<hr>

### Usage:
Definition and the only usage for the method with **mutant** is in `JavadocMethodCheck`. (1 usage)
`JavadocMethodCheck` does not affect any other class.
**Call Stack:**
```
isInIgnoreBlock:691, JavadocMethodCheck (com.puppycrawl.tools.checkstyle.checks.javadoc)
  getThrowed:640, JavadocMethodCheck (com.puppycrawl.tools.checkstyle.checks.javadoc)
    checkComment:442, JavadocMethodCheck (com.puppycrawl.tools.checkstyle.checks.javadoc)
      processAST:392, JavadocMethodCheck (com.puppycrawl.tools.checkstyle.checks.javadoc)
        visitToken:374, JavadocMethodCheck (com.puppycrawl.tools.checkstyle.checks.javadoc)
          notifyVisit:335, TreeWalker (com.puppycrawl.tools.checkstyle)
            processIter:408, TreeWalker (com.puppycrawl.tools.checkstyle)
              ...
```
<hr>

### Regression:
**Result:** No differences found. ([Report](https://checkstyle-diff-reports.s3.us-east-2.amazonaws.com/2c6df13_2024140229/reports/diff/index.html))

Diff Regression config: https://gist.githubusercontent.com/sktpy/44a31ea4e946a0755fa3e331fd65de98/raw/233b4d68f7cd46f957ee37e94813922d5fd1733c/check.xml

Diff Regression projects: https://gist.githubusercontent.com/sktpy/49239940660ceaef88d224d6abc8878e/raw/058cbb1b662c9276e934fdffbb99cec760332398/projects-to-test-on.properties