### PR TITLE
Issue #14396: Improved checker-framework-groovy to detect Out of Memory Exception and fail

### DIFF
--- a/.ci/checker-framework.groovy
+++ b/.ci/checker-framework.groovy
@@ -112,6 +112,7 @@ private static int checkCheckerFrameworkReport(final String profile) {
  */
 private static List<List<String>> getCheckerFrameworkErrors(final String profile) {
     final List<String> checkerFrameworkLines = new ArrayList<>()
+    final List<List<String>> checkerFrameworkErrors = new ArrayList<>()
     final String command = "mvn -e --no-transfer-progress clean compile" +
         " -P${profile},no-validations"
     final ProcessBuilder processBuilder = new ProcessBuilder(getOsSpecificCmd(command).split(' '))
@@ -120,11 +121,20 @@ private static List<List<String>> getCheckerFrameworkErrors(final String profile
 
     BufferedReader reader = null
     try {
+        Pattern detectOomException = Pattern.
+            compile(".*OutOfMemoryError.*max memory = \\d\n\
+                        +.*total memory = \\d+.*free memory = \\d+.*",
+                Pattern.CASE_INSENSITIVE);
         reader = new BufferedReader(new InputStreamReader(process.inputStream))
         String lineFromReader = reader.readLine()
         while (lineFromReader != null) {
             println(lineFromReader)
             checkerFrameworkLines.add(lineFromReader)
+            if (detectOomException.matcher(lineFromReader).matches()) {
+                List<String> oomError = new ArrayList<>();
+                oomError.add("ERROR: " + lineFromReader);
+                checkerFrameworkErrors.add(oomError);
+            }
             lineFromReader = reader.readLine()
         }
         process.waitFor()
@@ -132,7 +142,6 @@ private static List<List<String>> getCheckerFrameworkErrors(final String profile
         reader.close()
     }
 
-    final List<List<String>> checkerFrameworkErrors = new ArrayList<>()
     for (int index = 0; index < checkerFrameworkLines.size(); index++) {
         final String line = checkerFrameworkLines.get(index)
         if (line.startsWith('[WARNING]')) {

--- a/config/jsoref-spellchecker/whitelist.words
+++ b/config/jsoref-spellchecker/whitelist.words
@@ -961,6 +961,7 @@ onetoplevelclass
 onevariableperline
 oo
 OOL
+oom
 oopsla
 OOQ
 opencollective


### PR DESCRIPTION
Closes #14396 

@romani , @nrmancuso 
I have been working on this ever since we merged the workaround for the issue by bumping maxmem to 8192m.

We have found that the checker throws an error and dies. The exception was never reported : 

```
Warning:  Garbage collection consumed 86% of CPU during the past 60 seconds.
Error:  An exception has occurred in the compiler (11.0.21). Please file a bug against the Java compiler via the Java bug reporting page (https://bugreport.java.com/) after checking the Bug Database (https://bugs.java.com/) for duplicates. Include your program and the following diagnostic in your report. Thank you.
com.sun.tools.javac.util.ClientCodeException: java.lang.OutOfMemoryError: Java heap space
	at jdk.compiler/com.sun.tools.javac.api.ClientCodeWrapper$WrappedTaskListener.finished(ClientCodeWrapper.java:832)
	at jdk.compiler/com.sun.tools.javac.api.MultiTaskListener.finished(MultiTaskListener.java:132)
	at jdk.compiler/com.sun.tools.javac.main.JavaCompiler.flow(JavaCompiler.java:1414)
	at jdk.compiler/com.sun.tools.javac.main.JavaCompiler.flow(JavaCompiler.java:1371)
	at jdk.compiler/com.sun.tools.javac.main.JavaCompiler.compile(JavaCompiler.java:973)
	at jdk.compiler/com.sun.tools.javac.main.Main.compile(Main.java:311)
	at jdk.compiler/com.sun.tools.javac.main.Main.compile(Main.java:170)
	at jdk.compiler/com.sun.tools.javac.Main.compile(Main.java:57)
	at jdk.compiler/com.sun.tools.javac.Main.main(Main.java:43)
Caused by: java.lang.OutOfMemoryError: Java heap space
	at org.checkerframework.framework.source.SourceChecker.wrapThrowableAsBugInCF(SourceChecker.java:2671)
	at org.checkerframework.framework.source.SourceChecker.typeProcess(SourceChecker.java:1059)
	at org.checkerframework.common.basetype.BaseTypeChecker.typeProcess(BaseTypeChecker.java:558)
	at org.checkerframework.javacutil.AbstractTypeProcessor$AttributionTaskListener.finished(AbstractTypeProcessor.java:188)
	at jdk.compiler/com.sun.tools.javac.api.ClientCodeWrapper$WrappedTaskListener.finished(ClientCodeWrapper.java:828)
	... 8 more
```

Adding a check to groovy script : 
Groovy script scans entire maven run, so we should be able to just be able to add a check for the exception. https://github.com/checkstyle/checkstyle/blob/master/.ci/checker-framework.groovy