### PR TITLE
Issue #11446: update TreeWalkerTest to remove verify usage

### DIFF
--- a/src/test/java/com/puppycrawl/tools/checkstyle/TreeWalkerTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/TreeWalkerTest.java
@@ -27,9 +27,9 @@ import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
 
 import java.io.File;
-import java.io.Writer;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
+import java.nio.file.StandardCopyOption;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
@@ -183,15 +183,12 @@ public class TreeWalkerTest extends AbstractModuleTestSupport {
 
     @Test
     public void testImproperFileExtension() throws Exception {
-        final DefaultConfiguration checkConfig =
-                createModuleConfig(ConstantNameCheck.class);
-        final File file = new File(temporaryFolder, "file.pdf");
-        try (Writer writer = Files.newBufferedWriter(file.toPath(), StandardCharsets.UTF_8)) {
-            final String content = "public class Main { public static final int k = 5 + 4; }";
-            writer.write(content);
-        }
+        final String regularFilePath = getPath("InputTreeWalkerImproperFileExtension.java");
+        final File originalFile = new File(regularFilePath);
+        final File tempFile = new File(temporaryFolder, "file.pdf");
+        Files.copy(originalFile.toPath(), tempFile.toPath(), StandardCopyOption.REPLACE_EXISTING);
         final String[] expected = CommonUtil.EMPTY_STRING_ARRAY;
-        verify(checkConfig, file.getPath(), expected);
+        verifyWithInlineConfigParser(tempFile.getPath(), expected);
     }
 
     @Test
@@ -202,8 +199,7 @@ public class TreeWalkerTest extends AbstractModuleTestSupport {
         checkConfig.addProperty("tokens", "VARIABLE_DEF, ENUM_DEF, CLASS_DEF, METHOD_DEF,"
                 + "IMPORT");
         try {
-            final String[] expected = CommonUtil.EMPTY_STRING_ARRAY;
-            verify(checkConfig, getPath("InputTreeWalker.java"), expected);
+            execute(checkConfig, getPath("InputTreeWalker.java"));
             assertWithMessage("CheckstyleException is expected").fail();
         }
         catch (CheckstyleException ex) {
@@ -224,11 +220,12 @@ public class TreeWalkerTest extends AbstractModuleTestSupport {
     @Test
     public void testOnEmptyFile() throws Exception {
         final DefaultConfiguration checkConfig = createModuleConfig(HiddenFieldCheck.class);
-        final String pathToEmptyFile =
-                File.createTempFile("file", ".java", temporaryFolder).getPath();
-
-        final String[] expected = CommonUtil.EMPTY_STRING_ARRAY;
-        verify(checkConfig, pathToEmptyFile, expected);
+        final File emptyFile = File.createTempFile("file", ".java", temporaryFolder);
+        execute(checkConfig, emptyFile.getPath());
+        final long fileSize = Files.size(emptyFile.toPath());
+        assertWithMessage("File should be empty")
+                .that(fileSize)
+                .isEqualTo(0);
     }
 
     @Test
@@ -293,8 +290,7 @@ public class TreeWalkerTest extends AbstractModuleTestSupport {
                 File.createTempFile("file", ".java", temporaryFolder).getPath();
 
         try {
-            final String[] expected = CommonUtil.EMPTY_STRING_ARRAY;
-            verify(checkConfig, pathToEmptyFile, expected);
+            execute(checkConfig, pathToEmptyFile);
             assertWithMessage("Exception is expected").fail();
         }
         catch (CheckstyleException ex) {

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/treewalker/InputTreeWalkerImproperFileExtension.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/treewalker/InputTreeWalkerImproperFileExtension.java
@@ -1,0 +1,12 @@
+/*
+com.puppycrawl.tools.checkstyle.checks.naming.ConstantNameCheck
+
+*/
+
+package com.puppycrawl.tools.checkstyle.treewalker;
+
+public class InputTreeWalkerImproperFileExtension {
+
+    public static final int k = 5 + 4;
+
+}


### PR DESCRIPTION
issue #11446 :
partial migration for TreeWalkerTest to discard verify usage
but I received this pmd violation due to the absence of assertion in JUnit tests any ideas on how to fix this?
```
[INFO] PMD Failure: com.puppycrawl.tools.checkstyle.TreeWalkerTest:185 Rule:JUnitTestsShouldIncludeAssert Priority:3 JUnit tests should include assert() or fail().
[INFO] PMD Failure: com.puppycrawl.tools.checkstyle.TreeWalkerTest:220 Rule:JUnitTestsShouldIncludeAssert Priority:3 JUnit tests should include assert() or fail().
```
