### PR TITLE
Issue #11446: update TreeWalkerTest to use inline config parser

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1862,7 +1862,6 @@
                 <exclude>**/RegexpHeaderCheckTest.class</exclude>
 
                 <!-- all bellow until https://github.com/checkstyle/checkstyle/issues/11446 -->
-                <exclude>**/TreeWalkerTest.class</exclude>
                 <exclude>**/CheckerTest.class</exclude>
               </excludes>
             </configuration>

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/treewalker/InputTreeWalkerSuppressionXpathFilterAbsolute.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/treewalker/InputTreeWalkerSuppressionXpathFilterAbsolute.java
@@ -1,3 +1,12 @@
+/*
+com.puppycrawl.tools.checkstyle.filters.SuppressionXpathFilter
+file = (file)InputTreeWalkerSuppressionXpathFilterAbsolute.xml
+
+com.puppycrawl.tools.checkstyle.checks.blocks.LeftCurlyCheck
+
+
+*/
+
 package com.puppycrawl.tools.checkstyle.treewalker;
 
 public class InputTreeWalkerSuppressionXpathFilterAbsolute {

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/treewalker/InputTreeWalkerWithCacheWithNoViolation.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/treewalker/InputTreeWalkerWithCacheWithNoViolation.java
@@ -1,0 +1,9 @@
+/*
+com.puppycrawl.tools.checkstyle.checks.coding.HiddenFieldCheck
+
+*/
+
+package com.puppycrawl.tools.checkstyle.treewalker;
+
+public class InputTreeWalkerWithCacheWithNoViolation {
+}


### PR DESCRIPTION
Issue #11446:
final migration of TreeWalketTest to discard verify usage and use inline configuration parser
