### PR TITLE
Issue#13999: Resolve pitest suppression for getParamater() of Javadoc…

### DIFF
--- a/config/pitest-suppressions/pitest-javadoc-suppressions.xml
+++ b/config/pitest-suppressions/pitest-javadoc-suppressions.xml
@@ -75,15 +75,6 @@
   <mutation unstable="false">
     <sourceFile>JavadocMethodCheck.java</sourceFile>
     <mutatedClass>com.puppycrawl.tools.checkstyle.checks.javadoc.JavadocMethodCheck</mutatedClass>
-    <mutatedMethod>getParameters</mutatedMethod>
-    <mutator>org.pitest.mutationtest.engine.gregor.mutators.RemoveConditionalMutator_EQUAL_IF</mutator>
-    <description>removed conditional - replaced equality check with true</description>
-    <lineContent>if (child.getType() == TokenTypes.PARAMETER_DEF) {</lineContent>
-  </mutation>
-
-  <mutation unstable="false">
-    <sourceFile>JavadocMethodCheck.java</sourceFile>
-    <mutatedClass>com.puppycrawl.tools.checkstyle.checks.javadoc.JavadocMethodCheck</mutatedClass>
     <mutatedMethod>getThrowed</mutatedMethod>
     <mutator>org.pitest.mutationtest.engine.gregor.mutators.experimental.NakedReceiverMutator</mutator>
     <description>replaced call to com/puppycrawl/tools/checkstyle/api/DetailAST::findFirstToken with receiver</description>

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocMethodCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocMethodCheck.java
@@ -590,11 +590,9 @@ public class JavadocMethodCheck extends AbstractCheck {
 
         DetailAST child = params.getFirstChild();
         while (child != null) {
-            if (child.getType() == TokenTypes.PARAMETER_DEF) {
-                final DetailAST ident = child.findFirstToken(TokenTypes.IDENT);
-                if (ident != null) {
-                    returnValue.add(ident);
-                }
+            final DetailAST ident = child.findFirstToken(TokenTypes.IDENT);
+            if (ident != null) {
+                returnValue.add(ident);
             }
             child = child.getNextSibling();
         }


### PR DESCRIPTION
Issue: #13999 : 
Resolve pitest suppression for getParamater() of JavadocMethod
Thanks @Zopsss for the config and proj files.
Regression
Diff Regression config: https://gist.githubusercontent.com/Zopsss/e5c173e3f7d020c335e73260cabc8c25/raw/c15d7975221b4eca529841f31631860b1e10ef50/JavadocMethod.xml

Diff Regression projects: https://gist.githubusercontent.com/Zopsss/22adadb570e4deb95296917244c580b3/raw/29ea756eada8915637b76678db4f46048c198808/projects-to-test-on-for-github-action.properties

Report label: JavadocMethod-1