### PR TITLE
Issue #14436: Enforced naming convention for annotaiononsameline

### DIFF
--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/annotation/AnnotationOnSameLineCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/annotation/AnnotationOnSameLineCheckTest.java
@@ -73,7 +73,7 @@ public class AnnotationOnSameLineCheckTest extends AbstractModuleTestSupport {
     }
 
     @Test
-    public void testCheck() throws Exception {
+    public void testAnnotationOnSameLineCheckPublicMethodAndVariable() throws Exception {
         final String[] expected = {
             "17:5: " + getCheckMessage(MSG_KEY_ANNOTATION_ON_SAME_LINE, "Annotation"),
             "18:5: " + getCheckMessage(MSG_KEY_ANNOTATION_ON_SAME_LINE, "Annotation"),
@@ -81,11 +81,11 @@ public class AnnotationOnSameLineCheckTest extends AbstractModuleTestSupport {
             "24:18: " + getCheckMessage(MSG_KEY_ANNOTATION_ON_SAME_LINE, "Annotation"),
         };
         verifyWithInlineConfigParser(
-                getPath("InputAnnotationOnSameLineCheck.java"), expected);
+                getPath("InputAnnotationOnSameLineCheckPublicMethodAndVariable.java"), expected);
     }
 
     @Test
-    public void testCheckAcceptableTokens() throws Exception {
+    public void testAnnotationOnSameLineCheckTokensOnMethodAndVar() throws Exception {
         final String[] expected = {
             "18:5: " + getCheckMessage(MSG_KEY_ANNOTATION_ON_SAME_LINE, "Annotation3"),
             "19:5: " + getCheckMessage(MSG_KEY_ANNOTATION_ON_SAME_LINE, "Annotation"),
@@ -93,11 +93,11 @@ public class AnnotationOnSameLineCheckTest extends AbstractModuleTestSupport {
             "25:18: " + getCheckMessage(MSG_KEY_ANNOTATION_ON_SAME_LINE, "Annotation3"),
         };
         verifyWithInlineConfigParser(
-                getPath("InputAnnotationOnSameLineCheck3.java"), expected);
+                getPath("InputAnnotationOnSameLineCheckTokensOnMethodAndVar.java"), expected);
     }
 
     @Test
-    public void testCheck2() throws Exception {
+    public void testAnnotationOnSameLineCheckPrivateAndDeprecatedVar() throws Exception {
         final String[] expected = {
             "19:5: " + getCheckMessage(MSG_KEY_ANNOTATION_ON_SAME_LINE, "Ann"),
             "24:5: " + getCheckMessage(MSG_KEY_ANNOTATION_ON_SAME_LINE, "SuppressWarnings"),
@@ -105,16 +105,16 @@ public class AnnotationOnSameLineCheckTest extends AbstractModuleTestSupport {
             "28:5: " + getCheckMessage(MSG_KEY_ANNOTATION_ON_SAME_LINE, "Ann"),
         };
         verifyWithInlineConfigParser(
-                getPath("InputAnnotationOnSameLineCheck2.java"), expected);
+                getPath("InputAnnotationOnSameLineCheckPrivateAndDeprecatedVar.java"), expected);
     }
 
     @Test
-    public void testCheckOnDifferentTokens() throws Exception {
+    public void testAnnotationOnSameLineCheckInterfaceAndEnum() throws Exception {
         final String[] expected = {
             "14:1: " + getCheckMessage(MSG_KEY_ANNOTATION_ON_SAME_LINE, "Ann"),
             "17:5: " + getCheckMessage(MSG_KEY_ANNOTATION_ON_SAME_LINE, "Ann"),
             "21:8: " + getCheckMessage(MSG_KEY_ANNOTATION_ON_SAME_LINE, "Ann"),
-            "22:72: " + getCheckMessage(MSG_KEY_ANNOTATION_ON_SAME_LINE, "Ann"),
+            "22:71: " + getCheckMessage(MSG_KEY_ANNOTATION_ON_SAME_LINE, "Ann"),
             "25:5: " + getCheckMessage(MSG_KEY_ANNOTATION_ON_SAME_LINE, "Ann"),
             "26:35: " + getCheckMessage(MSG_KEY_ANNOTATION_ON_SAME_LINE, "Ann"),
             "29:18: " + getCheckMessage(MSG_KEY_ANNOTATION_ON_SAME_LINE, "Ann"),
@@ -129,7 +129,7 @@ public class AnnotationOnSameLineCheckTest extends AbstractModuleTestSupport {
             "62:5: " + getCheckMessage(MSG_KEY_ANNOTATION_ON_SAME_LINE, "Ann"),
         };
         verifyWithInlineConfigParser(
-                getPath("InputAnnotationOnSameLineCheckOnDifferentTokens.java"), expected);
+                getPath("InputAnnotationOnSameLineCheckInterfaceAndEnum.java"), expected);
     }
 
     @Test

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/annotation/annotationonsameline/InputAnnotationOnSameLineCheckInterfaceAndEnum.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/annotation/annotationonsameline/InputAnnotationOnSameLineCheckInterfaceAndEnum.java
@@ -19,7 +19,7 @@ import java.util.List;
 }
 
 public @Ann     // violation
-@Ann2 class InputAnnotationOnSameLineCheckOnDifferentTokens implements @Ann     // violation
+@Ann2 class InputAnnotationOnSameLineCheckInterfaceAndEnum implements @Ann     // violation
         @Ann2 TestInterface {
 
     @Ann        // violation
@@ -35,7 +35,7 @@ public @Ann     // violation
     }
 
     @Ann        // violation
-    @Ann2 public InputAnnotationOnSameLineCheckOnDifferentTokens() {}
+    @Ann2 public InputAnnotationOnSameLineCheckInterfaceAndEnum() {}
 
     @Ann        // violation
     @Ann2 public void setX(@Ann             // violation

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/annotation/annotationonsameline/InputAnnotationOnSameLineCheckPrivateAndDeprecatedVar.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/annotation/annotationonsameline/InputAnnotationOnSameLineCheckPrivateAndDeprecatedVar.java
@@ -14,7 +14,7 @@ import java.lang.annotation.Target;
 import java.util.List;
 import java.util.ArrayList;
 
-public class InputAnnotationOnSameLineCheck2 {
+public class InputAnnotationOnSameLineCheckPrivateAndDeprecatedVar {
 
     @Ann        // violation
     private List<String> names = new ArrayList<>();

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/annotation/annotationonsameline/InputAnnotationOnSameLineCheckPublicMethodAndVariable.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/annotation/annotationonsameline/InputAnnotationOnSameLineCheckPublicMethodAndVariable.java
@@ -8,7 +8,7 @@ tokens = (default)CLASS_DEF, INTERFACE_DEF, ENUM_DEF, METHOD_DEF, CTOR_DEF, \
 
 package com.puppycrawl.tools.checkstyle.checks.annotation.annotationonsameline;
 
-public class InputAnnotationOnSameLineCheck {
+public class InputAnnotationOnSameLineCheckPublicMethodAndVariable {
 
     @Annotation int x;
 

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/annotation/annotationonsameline/InputAnnotationOnSameLineCheckTokensOnMethodAndVar.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/annotation/annotationonsameline/InputAnnotationOnSameLineCheckTokensOnMethodAndVar.java
@@ -9,7 +9,7 @@ tokens = CLASS_DEF, INTERFACE_DEF, ENUM_DEF, METHOD_DEF, CTOR_DEF, \
 
 package com.puppycrawl.tools.checkstyle.checks.annotation.annotationonsameline;
 
-public class InputAnnotationOnSameLineCheck3 {
+public class InputAnnotationOnSameLineCheckTokensOnMethodAndVar {
 
     @Annotation3 int x;
 


### PR DESCRIPTION
Part of #14436 

Renamed input files and test methods of annotationonsameline module to follow naming convention.

The following files test accordingly : 

-  InputAnnotationOnSameLineCheckTokensOnMethodAndVar - 
    tests for validity of multiple tokens on method and var declarations

- InputAnnotationOnSameLineCheckInterfaceAndEnum - 
    tests for validity of annotations on interface and enum declarations

- InputAnnotationOnSameLineCheckPrivateAndDeprecatedVar - 
    tests for validity of annotations on private var declarations and deprecations ( example : @SuppressWarnings )

- InputAnnotationOnSameLineCheckPublicMethodAndVariable - 
    tests for validity of annotations on public method and var declarations