### PR TITLE
Issue #6207: Add XPath IT Regression test for IllegalInstantiationCheck

### DIFF
--- a/src/it/java/org/checkstyle/suppressionxpathfilter/XpathRegressionIllegalInstantiationTest.java
+++ b/src/it/java/org/checkstyle/suppressionxpathfilter/XpathRegressionIllegalInstantiationTest.java
@@ -1,0 +1,128 @@
+///////////////////////////////////////////////////////////////////////////////////////////////
+// checkstyle: Checks Java source code and other text files for adherence to a set of rules.
+// Copyright (C) 2001-2024 the original author or authors.
+//
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the GNU Lesser General Public
+// License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+//
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+// Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public
+// License along with this library; if not, write to the Free Software
+// Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+///////////////////////////////////////////////////////////////////////////////////////////////
+
+package org.checkstyle.suppressionxpathfilter;
+
+import static com.puppycrawl.tools.checkstyle.checks.coding.IllegalInstantiationCheck.MSG_KEY;
+
+import java.io.File;
+import java.util.Arrays;
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+
+import com.puppycrawl.tools.checkstyle.DefaultConfiguration;
+import com.puppycrawl.tools.checkstyle.checks.coding.IllegalInstantiationCheck;
+
+public class XpathRegressionIllegalInstantiationTest extends AbstractXpathTestSupport {
+    @Override
+    protected String getCheckName() {
+        return IllegalInstantiationCheck.class.getSimpleName();
+    }
+
+    @Test
+    public void testSimple() throws Exception {
+        final String fileName = "SuppressionXpathRegressionIllegalInstantiationSimple.java";
+        final File fileToProcess = new File(getNonCompilablePath(fileName));
+
+        final DefaultConfiguration moduleConfig =
+                createModuleConfig(IllegalInstantiationCheck.class);
+        moduleConfig.addProperty("classes", "java.lang.Boolean");
+
+        final String[] expectedViolation = {
+            "8:21: " + getCheckMessage(IllegalInstantiationCheck.class, MSG_KEY,
+                    "java.lang.Boolean"),
+        };
+
+        final List<String> expectedXpathQueries = Arrays.asList(
+                "/COMPILATION_UNIT/CLASS_DEF[./IDENT"
+                + "[@text='SuppressionXpathRegressionIllegalInstantiationSimple']]"
+                + "/OBJBLOCK/METHOD_DEF[./IDENT[@text='test']]/SLIST/"
+                + "VARIABLE_DEF[./IDENT[@text='x']]/ASSIGN/EXPR",
+                "/COMPILATION_UNIT/CLASS_DEF"
+                + "[./IDENT[@text='SuppressionXpathRegressionIllegalInstantiationSimple']]"
+                + "/OBJBLOCK/METHOD_DEF[./IDENT[@text='test']]/SLIST/VARIABLE_DEF"
+                + "[./IDENT[@text='x']]/ASSIGN/EXPR/LITERAL_NEW[./IDENT[@text='Boolean']]"
+        );
+
+        runVerifications(moduleConfig, fileToProcess, expectedViolation,
+                expectedXpathQueries);
+    }
+
+    @Test
+    public void testAnonymous() throws Exception {
+        final String fileName = "SuppressionXpathRegressionIllegalInstantiationAnonymous.java";
+        final File fileToProcess = new File(getNonCompilablePath(fileName));
+
+        final DefaultConfiguration moduleConfig =
+                createModuleConfig(IllegalInstantiationCheck.class);
+        moduleConfig.addProperty("classes", "java.lang.Integer");
+
+        final String[] expectedViolation = {
+            "10:25: " + getCheckMessage(IllegalInstantiationCheck.class, MSG_KEY,
+                    "java.lang.Integer"),
+        };
+
+        final List<String> expectedXpathQueries = Arrays.asList(
+                "/COMPILATION_UNIT/CLASS_DEF[./IDENT"
+                + "[@text='SuppressionXpathRegressionIllegalInstantiationAnonymous']]"
+                + "/OBJBLOCK/CLASS_DEF[./IDENT[@text='Inner']]/OBJBLOCK/METHOD_DEF"
+                + "[./IDENT[@text='test']]/SLIST/VARIABLE_DEF[./IDENT[@text='e']]/ASSIGN/EXPR",
+                "/COMPILATION_UNIT/CLASS_DEF[./IDENT"
+                + "[@text='SuppressionXpathRegressionIllegalInstantiationAnonymous']]"
+                + "/OBJBLOCK/CLASS_DEF[./IDENT[@text='Inner']]/OBJBLOCK/METHOD_DEF"
+                + "[./IDENT[@text='test']]/SLIST/VARIABLE_DEF[./IDENT[@text='e']]"
+                + "/ASSIGN/EXPR/LITERAL_NEW[./IDENT[@text='Integer']]"
+        );
+
+        runVerifications(moduleConfig, fileToProcess, expectedViolation,
+                expectedXpathQueries);
+    }
+
+    @Test
+    public void testInterface() throws Exception {
+        final String fileName = "SuppressionXpathRegressionIllegalInstantiationInterface.java";
+        final File fileToProcess = new File(getNonCompilablePath(fileName));
+
+        final DefaultConfiguration moduleConfig =
+                createModuleConfig(IllegalInstantiationCheck.class);
+        moduleConfig.addProperty("classes", "java.lang.String");
+
+        final String[] expectedViolation = {
+            "10:24: " + getCheckMessage(IllegalInstantiationCheck.class, MSG_KEY,
+                    "java.lang.String"),
+        };
+
+        final List<String> expectedXpathQueries = Arrays.asList(
+                "/COMPILATION_UNIT/CLASS_DEF[./IDENT"
+                + "[@text='SuppressionXpathRegressionIllegalInstantiationInterface']]"
+                + "/OBJBLOCK/INTERFACE_DEF[./IDENT[@text='Inner']]/"
+                + "OBJBLOCK/METHOD_DEF[./IDENT[@text='test']]/SLIST/"
+                + "VARIABLE_DEF[./IDENT[@text='s']]/ASSIGN/EXPR",
+                "/COMPILATION_UNIT/CLASS_DEF[./IDENT"
+                + "[@text='SuppressionXpathRegressionIllegalInstantiationInterface']]"
+                + "/OBJBLOCK/INTERFACE_DEF[./IDENT[@text='Inner']]"
+                + "/OBJBLOCK/METHOD_DEF[./IDENT[@text='test']]/SLIST/VARIABLE_DEF"
+                + "[./IDENT[@text='s']]/ASSIGN/EXPR/LITERAL_NEW[./IDENT[@text='String']]"
+        );
+
+        runVerifications(moduleConfig, fileToProcess, expectedViolation,
+                expectedXpathQueries);
+    }
+}

--- a/src/it/resources-noncompilable/org/checkstyle/suppressionxpathfilter/illegalinstantiation/SuppressionXpathRegressionIllegalInstantiationAnonymous.java
+++ b/src/it/resources-noncompilable/org/checkstyle/suppressionxpathfilter/illegalinstantiation/SuppressionXpathRegressionIllegalInstantiationAnonymous.java
@@ -1,0 +1,13 @@
+//non-compiled with javac: compiling on jdk before 9
+
+package org.checkstyle.suppressionxpathfilter.illegalinstantiation;
+
+public class SuppressionXpathRegressionIllegalInstantiationAnonymous {
+    int b = 5; // ok
+     class Inner{
+        public void test() {
+            Boolean x = new Boolean(true); // ok
+            Integer e = new Integer(b); // warn
+        }
+     }
+}

--- a/src/it/resources-noncompilable/org/checkstyle/suppressionxpathfilter/illegalinstantiation/SuppressionXpathRegressionIllegalInstantiationInterface.java
+++ b/src/it/resources-noncompilable/org/checkstyle/suppressionxpathfilter/illegalinstantiation/SuppressionXpathRegressionIllegalInstantiationInterface.java
@@ -1,0 +1,13 @@
+//non-compiled with javac: compiling on jdk before 9
+
+package org.checkstyle.suppressionxpathfilter.illegalinstantiation;
+
+public class SuppressionXpathRegressionIllegalInstantiationInterface {
+    interface Inner {
+        default void test() {
+            Boolean x = new Boolean(true); // ok
+            Integer e = new Integer(5); // ok
+            String s = new String(); // warn
+        }
+    }
+}

--- a/src/it/resources-noncompilable/org/checkstyle/suppressionxpathfilter/illegalinstantiation/SuppressionXpathRegressionIllegalInstantiationSimple.java
+++ b/src/it/resources-noncompilable/org/checkstyle/suppressionxpathfilter/illegalinstantiation/SuppressionXpathRegressionIllegalInstantiationSimple.java
@@ -1,0 +1,11 @@
+//non-compiled with javac: compiling on jdk before 9
+
+package org.checkstyle.suppressionxpathfilter.illegalinstantiation;
+
+public class SuppressionXpathRegressionIllegalInstantiationSimple {
+    int b = 5; // ok
+    public void test() {
+        Boolean x = new Boolean(true); // warn
+        Integer e = new Integer(b); // ok
+    }
+}

--- a/src/test/java/com/puppycrawl/tools/checkstyle/internal/XpathRegressionTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/internal/XpathRegressionTest.java
@@ -97,7 +97,6 @@ public class XpathRegressionTest extends AbstractModuleTestSupport {
             "DesignForExtension",
             "ExecutableStatementCount",
             "HideUtilityClassConstructor",
-            "IllegalInstantiation",
             "InterfaceTypeParameterName",
             "LocalFinalVariableName",
             "LocalVariableName",


### PR DESCRIPTION
part of #6207 [doc](https://checkstyle.org/checks/coding/illegalinstantiation.html#IllegalInstantiation)
add xPath regression test for   IllegalInstantiationCheck
1 test for normal case, 1 for anonymous class, 1 for interface
the input files aren't compiled by IntelliJ because there is a deprecation warning for the Boolean(boolean) and Integer constructors