### PR TITLE
Issue #14465: Refactor to exclude createTempFile methods

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1864,17 +1864,6 @@
 
                 <!-- all bellow until https://github.com/checkstyle/checkstyle/issues/11446 -->
                 <exclude>**/CheckerTest.class</exclude>
-
-                <!-- all bellow until https://github.com/checkstyle/checkstyle/issues/14465 -->
-                <!-- Excludes for createTempFile forbidden method -->
-                <exclude>**/SuppressionFilterTest.class</exclude>
-                <exclude>**/XpathUtilTest.class</exclude>
-                <exclude>**/TreeWalkerTest.class</exclude>
-                <exclude>**/PropertyCacheFileTest.class</exclude>
-                <exclude>**/FilterUtilTest.class</exclude>
-                <exclude>**/AbstractXpathTestSupport.class</exclude>
-                <exclude>**/AbstractJavadocCheckTest.class</exclude>
-                <exclude>**/ImportControlCheckTest.class</exclude>
               </excludes>
             </configuration>
           </execution>

--- a/src/it/java/org/checkstyle/suppressionxpathfilter/AbstractXpathTestSupport.java
+++ b/src/it/java/org/checkstyle/suppressionxpathfilter/AbstractXpathTestSupport.java
@@ -25,9 +25,9 @@ import java.io.File;
 import java.io.Writer;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
-import java.nio.file.Path;
 import java.util.List;
 import java.util.Locale;
+import java.util.UUID;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -56,7 +56,7 @@ public abstract class AbstractXpathTestSupport extends AbstractCheckstyleModuleT
      * The temporary folder to hold intermediate files.
      */
     @TempDir
-    public Path temporaryFolder;
+    public File temporaryFolder;
 
     /**
      * Returns name of the check.
@@ -120,9 +120,10 @@ public abstract class AbstractXpathTestSupport extends AbstractCheckstyleModuleT
     private String createSuppressionsXpathConfigFile(String checkName,
                                                      List<String> xpathQueries)
             throws Exception {
-        final Path suppressionsXpathConfigPath =
-                Files.createTempFile(temporaryFolder, "", "");
-        try (Writer bw = Files.newBufferedWriter(suppressionsXpathConfigPath,
+        final String uniqueFileName =
+                "suppressions_xpath_config_" + UUID.randomUUID() + ".xml";
+        final File suppressionsXpathConfigPath = new File(temporaryFolder, uniqueFileName);
+        try (Writer bw = Files.newBufferedWriter(suppressionsXpathConfigPath.toPath(),
                 StandardCharsets.UTF_8)) {
             bw.write("<?xml version=\"1.0\"?>\n");
             bw.write("<!DOCTYPE suppressions PUBLIC\n");

--- a/src/test/java/com/puppycrawl/tools/checkstyle/PropertyCacheFileTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/PropertyCacheFileTest.java
@@ -40,6 +40,7 @@ import java.util.HashSet;
 import java.util.Locale;
 import java.util.Properties;
 import java.util.Set;
+import java.util.UUID;
 
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.DisabledOnOs;
@@ -90,10 +91,11 @@ public class PropertyCacheFileTest extends AbstractPathTestSupport {
     }
 
     @Test
-    public void testInCache() throws IOException {
+    public void testInCache() {
         final Configuration config = new DefaultConfiguration("myName");
-        final String filePath = File.createTempFile("junit", null, temporaryFolder).getPath();
-        final PropertyCacheFile cache = new PropertyCacheFile(config, filePath);
+        final String uniqueFileName = "junit_" + UUID.randomUUID() + ".java";
+        final File filePath = new File(temporaryFolder, uniqueFileName);
+        final PropertyCacheFile cache = new PropertyCacheFile(config, filePath.toString());
         cache.put("myFile", 1);
         assertWithMessage("Should return true when file is in cache")
                 .that(cache.isInCache("myFile", 1))
@@ -149,8 +151,9 @@ public class PropertyCacheFileTest extends AbstractPathTestSupport {
     @Test
     public void testConfigHashOnReset() throws IOException {
         final Configuration config = new DefaultConfiguration("myName");
-        final String filePath = File.createTempFile("junit", null, temporaryFolder).getPath();
-        final PropertyCacheFile cache = new PropertyCacheFile(config, filePath);
+        final String uniqueFileName = "junit_" + UUID.randomUUID() + ".java";
+        final File filePath = new File(temporaryFolder, uniqueFileName);
+        final PropertyCacheFile cache = new PropertyCacheFile(config, filePath.toString());
 
         cache.load();
 
@@ -169,8 +172,9 @@ public class PropertyCacheFileTest extends AbstractPathTestSupport {
     @Test
     public void testConfigHashRemainsOnResetExternalResources() throws IOException {
         final Configuration config = new DefaultConfiguration("myName");
-        final String filePath = File.createTempFile("junit", null, temporaryFolder).getPath();
-        final PropertyCacheFile cache = new PropertyCacheFile(config, filePath);
+        final String uniqueFileName = "file_" + UUID.randomUUID() + ".java";
+        final File filePath = new File(temporaryFolder, uniqueFileName);
+        final PropertyCacheFile cache = new PropertyCacheFile(config, filePath.toString());
 
         // create cache with one file
         cache.load();
@@ -197,17 +201,20 @@ public class PropertyCacheFileTest extends AbstractPathTestSupport {
     @Test
     public void testCacheRemainsWhenExternalResourceTheSame() throws IOException {
         final Configuration config = new DefaultConfiguration("myName");
-        final String externalResourcePath =
-                File.createTempFile("junit", null, temporaryFolder).getPath();
-        final String filePath = File.createTempFile("junit", null, temporaryFolder).getPath();
-        final PropertyCacheFile cache = new PropertyCacheFile(config, filePath);
+        final String externalFile = "junit_" + UUID.randomUUID() + ".java";
+        final File externalResourcePath = new File(temporaryFolder, externalFile);
+        externalResourcePath.createNewFile();
+        final String uniqueFileName = "junit_" + UUID.randomUUID() + ".java";
+        final File filePath = new File(temporaryFolder, uniqueFileName);
+        filePath.createNewFile();
+        final PropertyCacheFile cache = new PropertyCacheFile(config, filePath.toString());
 
         // pre-populate with cache with resources
 
         cache.load();
 
         final Set<String> resources = new HashSet<>();
-        resources.add(externalResourcePath);
+        resources.add(externalResourcePath.toString());
         cache.putExternalResources(resources);
 
         cache.persist();
@@ -226,8 +233,9 @@ public class PropertyCacheFileTest extends AbstractPathTestSupport {
     @Test
     public void testExternalResourceIsSavedInCache() throws Exception {
         final Configuration config = new DefaultConfiguration("myName");
-        final String filePath = File.createTempFile("junit", null, temporaryFolder).getPath();
-        final PropertyCacheFile cache = new PropertyCacheFile(config, filePath);
+        final String uniqueFileName = "junit_" + UUID.randomUUID() + ".java";
+        final File filePath = new File(temporaryFolder, uniqueFileName);
+        final PropertyCacheFile cache = new PropertyCacheFile(config, filePath.toString());
 
         cache.load();
 
@@ -327,10 +335,12 @@ public class PropertyCacheFileTest extends AbstractPathTestSupport {
     @Test
     @DisabledOnOs(OS.WINDOWS)
     public void testSymbolicLinkToNonDirectory() throws IOException {
-        final Path tempFile = Files.createTempFile("tempFile", null);
+        final String uniqueFileName = "tempFile_" + UUID.randomUUID() + ".java";
+        final File tempFile = new File(temporaryFolder, uniqueFileName);
+        tempFile.createNewFile();
         final Path symbolicLinkDirectory = temporaryFolder.toPath();
         final Path symbolicLink = symbolicLinkDirectory.resolve("symbolicLink");
-        Files.createSymbolicLink(symbolicLink, tempFile);
+        Files.createSymbolicLink(symbolicLink, tempFile.toPath());
 
         final Configuration config = new DefaultConfiguration("myName");
         final String cacheFilePath = symbolicLink.resolve("cache.temp").toString();
@@ -375,8 +385,8 @@ public class PropertyCacheFileTest extends AbstractPathTestSupport {
     public void testChangeInConfig() throws Exception {
         final DefaultConfiguration config = new DefaultConfiguration("myConfig");
         config.addProperty("attr", "value");
-
-        final File cacheFile = File.createTempFile("junit", null, temporaryFolder);
+        final String uniqueFileName = "junit_" + UUID.randomUUID() + ".java";
+        final File cacheFile = new File(temporaryFolder, uniqueFileName);
         final PropertyCacheFile cache = new PropertyCacheFile(config, cacheFile.getPath());
         cache.load();
 
@@ -424,8 +434,9 @@ public class PropertyCacheFileTest extends AbstractPathTestSupport {
     @Test
     public void testNonExistentResource() throws IOException {
         final Configuration config = new DefaultConfiguration("myName");
-        final String filePath = File.createTempFile("junit", null, temporaryFolder).getPath();
-        final PropertyCacheFile cache = new PropertyCacheFile(config, filePath);
+        final String uniqueFileName = "junit_" + UUID.randomUUID() + ".java";
+        final File filePath = new File(temporaryFolder, uniqueFileName);
+        final PropertyCacheFile cache = new PropertyCacheFile(config, filePath.toString());
 
         // create cache with one file
         cache.load();
@@ -453,10 +464,11 @@ public class PropertyCacheFileTest extends AbstractPathTestSupport {
     }
 
     @Test
-    public void testExceptionNoSuchAlgorithmException() throws Exception {
+    public void testExceptionNoSuchAlgorithmException() {
         final Configuration config = new DefaultConfiguration("myName");
-        final String filePath = File.createTempFile("junit", null, temporaryFolder).getPath();
-        final PropertyCacheFile cache = new PropertyCacheFile(config, filePath);
+        final String uniqueFileName = "junit_" + UUID.randomUUID() + ".java";
+        final File filePath = new File(temporaryFolder, uniqueFileName);
+        final PropertyCacheFile cache = new PropertyCacheFile(config, filePath.toString());
         cache.put("myFile", 1);
 
         try (MockedStatic<MessageDigest> messageDigest = mockStatic(MessageDigest.class)) {
@@ -491,7 +503,8 @@ public class PropertyCacheFileTest extends AbstractPathTestSupport {
     @ParameterizedTest
     @ValueSource(strings = {"Same;Same", "First;Second"})
     public void testPutNonExistentExternalResource(String rawMessages) throws Exception {
-        final File cacheFile = File.createTempFile("junit", null, temporaryFolder);
+        final String uniqueFileName = "junit_" + UUID.randomUUID() + ".java";
+        final File cacheFile = new File(temporaryFolder, uniqueFileName);
         final String[] messages = rawMessages.split(";");
         // We mock getUriByFilename method of CommonUtil to guarantee that it will
         // throw CheckstyleException with the specific content.

--- a/src/test/java/com/puppycrawl/tools/checkstyle/TreeWalkerTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/TreeWalkerTest.java
@@ -38,6 +38,7 @@ import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
+import java.util.UUID;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -220,7 +221,9 @@ public class TreeWalkerTest extends AbstractModuleTestSupport {
     @Test
     public void testOnEmptyFile() throws Exception {
         final DefaultConfiguration checkConfig = createModuleConfig(HiddenFieldCheck.class);
-        final File emptyFile = File.createTempFile("file", ".java", temporaryFolder);
+        final String uniqueFileName = "file_" + UUID.randomUUID() + ".java";
+        final File emptyFile = new File(temporaryFolder, uniqueFileName);
+        emptyFile.createNewFile();
         execute(checkConfig, emptyFile.getPath());
         final long fileSize = Files.size(emptyFile.toPath());
         assertWithMessage("File should be empty")
@@ -233,8 +236,9 @@ public class TreeWalkerTest extends AbstractModuleTestSupport {
         final DefaultConfiguration checkConfig = createModuleConfig(JavadocPackageCheck.class);
 
         try {
-            execute(createTreeWalkerConfig(checkConfig),
-                    File.createTempFile("junit", null, temporaryFolder).getPath());
+            final String uniqueFileName = "junit_" + UUID.randomUUID() + ".java";
+            final File filePath = new File(temporaryFolder, uniqueFileName);
+            execute(createTreeWalkerConfig(checkConfig), filePath.toString());
             assertWithMessage("CheckstyleException is expected").fail();
         }
         catch (CheckstyleException exception) {
@@ -285,11 +289,11 @@ public class TreeWalkerTest extends AbstractModuleTestSupport {
     @Test
     public void testForInvalidCheckImplementation() throws Exception {
         final DefaultConfiguration checkConfig = createModuleConfig(BadJavaDocCheck.class);
-        final String pathToEmptyFile =
-                File.createTempFile("file", ".java", temporaryFolder).getPath();
+        final String uniqueFileName = "file_" + UUID.randomUUID() + ".java";
+        final File pathToEmptyFile = new File(temporaryFolder, uniqueFileName);
 
         try {
-            execute(checkConfig, pathToEmptyFile);
+            execute(checkConfig, pathToEmptyFile.toString());
             assertWithMessage("Exception is expected").fail();
         }
         catch (CheckstyleException ex) {
@@ -545,7 +549,8 @@ public class TreeWalkerTest extends AbstractModuleTestSupport {
     public void testCheckInitIsCalledInTreeWalker() throws Exception {
         final DefaultConfiguration checkConfig =
                 createModuleConfig(VerifyInitCheck.class);
-        final File file = File.createTempFile("file", ".pdf", temporaryFolder);
+        final String uniqueFileName = "file_" + UUID.randomUUID() + ".pdf";
+        final File file = new File(temporaryFolder, uniqueFileName);
         execute(checkConfig, file.getPath());
         assertWithMessage("Init was not called")
                 .that(VerifyInitCheck.isInitWasCalled())
@@ -557,7 +562,8 @@ public class TreeWalkerTest extends AbstractModuleTestSupport {
         VerifyDestroyCheck.resetDestroyWasCalled();
         final DefaultConfiguration checkConfig =
                 createModuleConfig(VerifyDestroyCheck.class);
-        final File file = File.createTempFile("file", ".pdf", temporaryFolder);
+        final String uniqueFileName = "file_" + UUID.randomUUID() + ".pdf";
+        final File file = new File(temporaryFolder, uniqueFileName);
         execute(checkConfig, file.getPath());
         assertWithMessage("Destroy was not called")
                 .that(VerifyDestroyCheck.isDestroyWasCalled())
@@ -569,7 +575,8 @@ public class TreeWalkerTest extends AbstractModuleTestSupport {
         VerifyDestroyCheck.resetDestroyWasCalled();
         final DefaultConfiguration checkConfig =
                 createModuleConfig(VerifyDestroyCommentCheck.class);
-        final File file = File.createTempFile("file", ".pdf", temporaryFolder);
+        final String uniqueFileName = "file_" + UUID.randomUUID() + ".pdf";
+        final File file = new File(temporaryFolder, uniqueFileName);
         execute(checkConfig, file.getPath());
         assertWithMessage("Destroy was not called")
                 .that(VerifyDestroyCheck.isDestroyWasCalled())
@@ -584,14 +591,16 @@ public class TreeWalkerTest extends AbstractModuleTestSupport {
         treeWalkerConfig.addChild(filterConfig);
 
         final DefaultConfiguration checkerConfig = createRootConfig(treeWalkerConfig);
-        final File cacheFile = File.createTempFile("junit", null, temporaryFolder);
+        final String uniqueFileName1 = "junit_" + UUID.randomUUID() + ".java";
+        final File cacheFile = new File(temporaryFolder, uniqueFileName1);
         checkerConfig.addProperty("cacheFile", cacheFile.getPath());
 
-        final String filePath = File.createTempFile("file", ".java", temporaryFolder).getPath();
+        final String uniqueFileName2 = "file_" + UUID.randomUUID() + ".java";
+        final File filePath = new File(temporaryFolder, uniqueFileName2);
 
-        execute(checkerConfig, filePath);
+        execute(checkerConfig, filePath.toString());
         // One more time to use cache.
-        execute(checkerConfig, filePath);
+        execute(checkerConfig, filePath.toString());
 
         assertWithMessage("External resource is not present in cache")
                 .that(Files.readString(cacheFile.toPath()))
@@ -618,11 +627,13 @@ public class TreeWalkerTest extends AbstractModuleTestSupport {
         treeWalkerConfig.addChild(filterConfig);
 
         final DefaultConfiguration checkerConfig = createRootConfig(treeWalkerConfig);
-        final File cacheFile = File.createTempFile("junit", null, temporaryFolder);
+        final String uniqueFileName1 = "junit_" + UUID.randomUUID() + ".java";
+        final File cacheFile = new File(temporaryFolder, uniqueFileName1);
         checkerConfig.addProperty("cacheFile", cacheFile.getPath());
-        final String filePath = File.createTempFile("file", ".java", temporaryFolder).getPath();
+        final String uniqueFileName2 = "junit_" + UUID.randomUUID() + ".java";
+        final File filePath = new File(temporaryFolder, uniqueFileName2);
 
-        execute(checkerConfig, filePath);
+        execute(checkerConfig, filePath.toString());
 
         final long cacheSize = Files.size(cacheFile.toPath());
         assertWithMessage("cacheFile should not be empty")

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/imports/ImportControlCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/imports/ImportControlCheckTest.java
@@ -30,6 +30,7 @@ import java.io.File;
 import java.nio.file.Files;
 import java.util.Arrays;
 import java.util.List;
+import java.util.UUID;
 
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
@@ -341,14 +342,16 @@ public class ImportControlCheckTest extends AbstractModuleTestSupport {
         treeWalkerConfig.addChild(checkConfig);
 
         final DefaultConfiguration checkerConfig = createRootConfig(treeWalkerConfig);
-        final File cacheFile = File.createTempFile("junit", null, temporaryFolder);
+        final String uniqueFileName1 = "junit_" + UUID.randomUUID() + ".java";
+        final File cacheFile = new File(temporaryFolder, uniqueFileName1);
         checkerConfig.addProperty("cacheFile", cacheFile.getPath());
 
-        final String filePath = File.createTempFile("empty", ".java", temporaryFolder).getPath();
+        final String uniqueFileName2 = "empty_" + UUID.randomUUID() + ".java";
+        final File filePath = new File(temporaryFolder, uniqueFileName2);
 
-        execute(checkerConfig, filePath);
+        execute(checkerConfig, filePath.toString());
         // One more time to use cache.
-        execute(checkerConfig, filePath);
+        execute(checkerConfig, filePath.toString());
 
         final String contents = Files.readString(cacheFile.toPath());
         assertWithMessage("External resource is not present in cache")

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/javadoc/AbstractJavadocCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/javadoc/AbstractJavadocCheckTest.java
@@ -29,6 +29,7 @@ import static com.puppycrawl.tools.checkstyle.checks.javadoc.SummaryJavadocCheck
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 
 import java.io.File;
+import java.util.UUID;
 
 import org.itsallcode.io.Capturable;
 import org.itsallcode.junit.sysextensions.SystemErrGuard;
@@ -361,11 +362,11 @@ public class AbstractJavadocCheckTest extends AbstractModuleTestSupport {
     public void testRequiredTokenIsNotInDefaultTokens() throws Exception {
         final DefaultConfiguration checkConfig =
             createModuleConfig(RequiredTokenIsNotInDefaultsJavadocCheck.class);
-        final String pathToEmptyFile =
-                File.createTempFile("empty", ".java", temporaryFolder).getPath();
+        final String uniqueFileName = "empty_" + UUID.randomUUID() + ".java";
+        final File pathToEmptyFile = new File(temporaryFolder, uniqueFileName);
 
         try {
-            execute(checkConfig, pathToEmptyFile);
+            execute(checkConfig, pathToEmptyFile.toString());
             assertWithMessage("CheckstyleException is expected").fail();
         }
         catch (IllegalStateException ex) {

--- a/src/test/java/com/puppycrawl/tools/checkstyle/filters/SuppressionFilterTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/filters/SuppressionFilterTest.java
@@ -28,6 +28,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.net.HttpURLConnection;
 import java.net.URL;
+import java.util.UUID;
 
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
@@ -168,14 +169,15 @@ public class SuppressionFilterTest extends AbstractModuleTestSupport {
         filterConfig.addProperty("file", getPath("InputSuppressionFilterNone.xml"));
 
         final DefaultConfiguration checkerConfig = createRootConfig(filterConfig);
-        final File cacheFile = File.createTempFile("junit", null, temporaryFolder);
+        final String uniqueFileName = "junit_" + UUID.randomUUID() + ".java";
+        final File cacheFile = new File(temporaryFolder, uniqueFileName);
         checkerConfig.addProperty("cacheFile", cacheFile.getPath());
 
-        final String filePath = File.createTempFile("file", ".java", temporaryFolder).getPath();
+        final File filePath = new File(temporaryFolder, uniqueFileName);
 
-        execute(checkerConfig, filePath);
+        execute(checkerConfig, filePath.toString());
         // One more time to use cache.
-        execute(checkerConfig, filePath);
+        execute(checkerConfig, filePath.toString());
     }
 
     @Test
@@ -200,13 +202,14 @@ public class SuppressionFilterTest extends AbstractModuleTestSupport {
         firstFilterConfig.addProperty("file", urlForTest);
 
         final DefaultConfiguration firstCheckerConfig = createRootConfig(firstFilterConfig);
-        final File cacheFile = File.createTempFile("junit", null, temporaryFolder);
+        final String uniqueFileName1 = "junit_" + UUID.randomUUID() + ".java";
+        final File cacheFile = new File(temporaryFolder, uniqueFileName1);
         firstCheckerConfig.addProperty("cacheFile", cacheFile.getPath());
 
-        final String pathToEmptyFile =
-                File.createTempFile("file", ".java", temporaryFolder).getPath();
+        final String uniqueFileName2 = "file_" + UUID.randomUUID() + ".java";
+        final File pathToEmptyFile = new File(temporaryFolder, uniqueFileName2);
 
-        execute(firstCheckerConfig, pathToEmptyFile);
+        execute(firstCheckerConfig, pathToEmptyFile.toString());
 
         // One more time to use cache.
         final DefaultConfiguration secondFilterConfig =
@@ -217,7 +220,7 @@ public class SuppressionFilterTest extends AbstractModuleTestSupport {
         final DefaultConfiguration secondCheckerConfig = createRootConfig(secondFilterConfig);
         secondCheckerConfig.addProperty("cacheFile", cacheFile.getPath());
 
-        execute(secondCheckerConfig, pathToEmptyFile);
+        execute(secondCheckerConfig, pathToEmptyFile.toString());
     }
 
     private static boolean isConnectionAvailableAndStable(String url) throws Exception {

--- a/src/test/java/com/puppycrawl/tools/checkstyle/utils/FilterUtilTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/utils/FilterUtilTest.java
@@ -23,6 +23,7 @@ import static com.google.common.truth.Truth.assertWithMessage;
 import static com.puppycrawl.tools.checkstyle.internal.utils.TestUtil.isUtilsClassHasPrivateConstructor;
 
 import java.io.File;
+import java.util.UUID;
 
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
@@ -41,7 +42,9 @@ public class FilterUtilTest {
 
     @Test
     public void testExistingFile() throws Exception {
-        final File file = File.createTempFile("junit", null, temporaryFolder);
+        final String uniqueFileName = "junit_" + UUID.randomUUID() + ".java";
+        final File file = new File(temporaryFolder, uniqueFileName);
+        file.createNewFile();
         assertWithMessage("Suppression file exists")
                 .that(FilterUtil.isFileExists(file.getPath()))
                 .isTrue();

--- a/src/test/java/com/puppycrawl/tools/checkstyle/utils/XpathUtilTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/utils/XpathUtilTest.java
@@ -29,6 +29,7 @@ import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.util.List;
+import java.util.UUID;
 
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
@@ -100,7 +101,8 @@ public class XpathUtilTest {
     @Test
     public void testPrintXpathNotComment() throws Exception {
         final String fileContent = "class Test { public void method() {int a = 5;}}";
-        final File file = File.createTempFile("junit", null, tempFolder);
+        final String uniqueFileName = "junit_" + UUID.randomUUID() + ".java";
+        final File file = new File(tempFolder, uniqueFileName);
         Files.write(file.toPath(), fileContent.getBytes(StandardCharsets.UTF_8));
         final String expected = addEndOfLine(
             "COMPILATION_UNIT -> COMPILATION_UNIT [1:0]",
@@ -120,7 +122,8 @@ public class XpathUtilTest {
     @Test
     public void testPrintXpathComment() throws Exception {
         final String fileContent = "class Test { /* comment */ }";
-        final File file = File.createTempFile("junit", null, tempFolder);
+        final String uniqueFileName = "junit_" + UUID.randomUUID() + ".java";
+        final File file = new File(tempFolder, uniqueFileName);
         Files.write(file.toPath(), fileContent.getBytes(StandardCharsets.UTF_8));
         final String expected = addEndOfLine(
             "COMPILATION_UNIT -> COMPILATION_UNIT [1:0]",
@@ -137,7 +140,8 @@ public class XpathUtilTest {
     @Test
     public void testPrintXpathTwo() throws Exception {
         final String fileContent = "class Test { public void method() {int a = 5; int b = 5;}}";
-        final File file = File.createTempFile("junit", null, tempFolder);
+        final String uniqueFileName = "junit_" + UUID.randomUUID() + ".java";
+        final File file = new File(tempFolder, uniqueFileName);
         Files.write(file.toPath(), fileContent.getBytes(StandardCharsets.UTF_8));
         final String expected = addEndOfLine(
             "COMPILATION_UNIT -> COMPILATION_UNIT [1:0]",
@@ -165,7 +169,8 @@ public class XpathUtilTest {
     @Test
     public void testInvalidXpath() throws IOException {
         final String fileContent = "class Test { public void method() {int a = 5; int b = 5;}}";
-        final File file = File.createTempFile("junit", null, tempFolder);
+        final String uniqueFileName = "junit_" + UUID.randomUUID() + ".java";
+        final File file = new File(tempFolder, uniqueFileName);
         Files.write(file.toPath(), fileContent.getBytes(StandardCharsets.UTF_8));
         final String invalidXpath = "\\//CLASS_DEF"
                 + "//METHOD_DEF//VARIABLE_DEF//IDENT";


### PR DESCRIPTION
Resolves: #14465

This PR aims to get rid of `Files.createTempFile` methods. 