### PR TITLE
Issue #14436: Enforced naming convention for illegalcatch

### DIFF
--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/coding/IllegalCatchCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/coding/IllegalCatchCheckTest.java
@@ -34,7 +34,7 @@ public class IllegalCatchCheckTest extends AbstractModuleTestSupport {
     }
 
     @Test
-    public void testDefault() throws Exception {
+    public void testIllegalCatchCheckDefaultTokens() throws Exception {
 
         final String[] expected = {
             "14:11: " + getCheckMessage(MSG_KEY, "RuntimeException"),
@@ -46,11 +46,11 @@ public class IllegalCatchCheckTest extends AbstractModuleTestSupport {
         };
 
         verifyWithInlineConfigParser(
-                getPath("InputIllegalCatch.java"), expected);
+                getPath("InputIllegalCatchCheckDefaultTokens.java"), expected);
     }
 
     @Test
-    public void testIllegalClassNames() throws Exception {
+    public void testIllegalCatchCheckSuperclassThrowable() throws Exception {
         final String[] expected = {
             "14:11: " + getCheckMessage(MSG_KEY, "Exception"),
             "15:11: " + getCheckMessage(MSG_KEY, "Throwable"),
@@ -59,11 +59,11 @@ public class IllegalCatchCheckTest extends AbstractModuleTestSupport {
         };
 
         verifyWithInlineConfigParser(
-                getPath("InputIllegalCatch3.java"), expected);
+                getPath("InputIllegalCatchCheckSuperclassThrowable.java"), expected);
     }
 
     @Test
-    public void testIllegalClassNamesBad() throws Exception {
+    public void testIllegalCatchCheckSuperclassException() throws Exception {
         // check that incorrect names don't break the Check
         final String[] expected = {
             "15:11: " + getCheckMessage(MSG_KEY, "Exception"),
@@ -71,11 +71,11 @@ public class IllegalCatchCheckTest extends AbstractModuleTestSupport {
         };
 
         verifyWithInlineConfigParser(
-                getPath("InputIllegalCatch4.java"), expected);
+                getPath("InputIllegalCatchCheckSuperclassException.java"), expected);
     }
 
     @Test
-    public void testMultipleTypes() throws Exception {
+    public void testIllegalCatchCheckMultipleExceptions() throws Exception {
         final String[] expected = {
             "15:11: " + getCheckMessage(MSG_KEY, "RuntimeException"),
             "15:11: " + getCheckMessage(MSG_KEY, "SQLException"),
@@ -91,7 +91,7 @@ public class IllegalCatchCheckTest extends AbstractModuleTestSupport {
         };
 
         verifyWithInlineConfigParser(
-                getPath("InputIllegalCatch2.java"), expected);
+                getPath("InputIllegalCatchCheckMultipleExceptions.java"), expected);
     }
 
     @Test

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/illegalcatch/InputIllegalCatchCheckDefaultTokens.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/illegalcatch/InputIllegalCatchCheckDefaultTokens.java
@@ -8,7 +8,7 @@ illegalClassNames = (default)Error, Exception, RuntimeException, Throwable, java
 
 package com.puppycrawl.tools.checkstyle.checks.coding.illegalcatch;
 
-public class InputIllegalCatch {
+public class InputIllegalCatchCheckDefaultTokens {
     public void foo() {
         try { //class names
         } catch (RuntimeException e) { // violation

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/illegalcatch/InputIllegalCatchCheckMultipleExceptions.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/illegalcatch/InputIllegalCatchCheckMultipleExceptions.java
@@ -8,7 +8,7 @@ illegalClassNames = java.lang.Error, java.lang.Exception, NullPointerException, 
 
 package com.puppycrawl.tools.checkstyle.checks.coding.illegalcatch;
 
-public class InputIllegalCatch2 {
+public class InputIllegalCatchCheckMultipleExceptions {
     public void foo() throws OneMoreException {
         try {
                 foo1();

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/illegalcatch/InputIllegalCatchCheckSuperclassException.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/illegalcatch/InputIllegalCatchCheckSuperclassException.java
@@ -8,7 +8,7 @@ illegalClassNames = java.lang.Error, java.lang.Exception, NullPointerException,\
 
 package com.puppycrawl.tools.checkstyle.checks.coding.illegalcatch;
 
-public class InputIllegalCatch4 {
+public class InputIllegalCatchCheckSuperclassException {
     public void foo() {
         try { //class names
         } catch (RuntimeException e) {

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/illegalcatch/InputIllegalCatchCheckSuperclassThrowable.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/illegalcatch/InputIllegalCatchCheckSuperclassThrowable.java
@@ -7,7 +7,7 @@ illegalClassNames = java.lang.Error, java.lang.Exception, java.lang.Throwable
 
 package com.puppycrawl.tools.checkstyle.checks.coding.illegalcatch;
 
-public class InputIllegalCatch3 {
+public class InputIllegalCatchCheckSuperclassThrowable {
     public void foo() {
         try { //class names
         } catch (RuntimeException e) {


### PR DESCRIPTION
Part of #14436 

Renamed input files and test methods of annotationonsameline module to follow naming convention.

The following files test accordingly : 

-  InputIllegalCatchCheckDefaultTokens- 
    tests for violations of default tokens in catch()

- InputIllegalCatchCheckMultipleExceptions- 
    tests for violations in catch() holding multiple exceptions

- InputIllegalCatchCheckSuperclassThrowable- 
    tests for violations related to usage of Superclass Throwable in catch()

- InputIllegalCatchCheckSuperclassException- 
    tests for violations related to usage of Superclass Exception in catch()