### PR TITLE
Issue #13999: Resolve pitest suppression for validateDefaultJavadocTokens method of AbstractJavadocCheck

### DIFF
--- a/config/checker-framework-suppressions/checker-lock-tainting-suppressions.xml
+++ b/config/checker-framework-suppressions/checker-lock-tainting-suppressions.xml
@@ -542,6 +542,21 @@
   </checkerFrameworkError>
 
   <checkerFrameworkError unstable="false">
+    <fileName>src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/AbstractJavadocCheck.java</fileName>
+    <specifier>methodref.param</specifier>
+    <message>Incompatible parameter type for obj</message>
+    <lineContent>.map(String::valueOf)</lineContent>
+    <details>
+      found   : @GuardSatisfied Object
+      required: @GuardedBy Integer
+      Consequence: method in @GuardedBy String
+      @NewObject String valueOf(@GuardSatisfied Object p0)
+      is not a valid method reference for method in @GuardedBy Function&lt;@GuardedBy Integer, @GuardedBy String&gt;
+      @GuardedBy String apply(@GuardedBy Function&lt;@GuardedBy Integer, @GuardedBy String&gt; this, @GuardedBy Integer p0)
+    </details>
+  </checkerFrameworkError>
+
+  <checkerFrameworkError unstable="false">
     <fileName>src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/HtmlTag.java</fileName>
     <specifier>override.receiver</specifier>
     <message>Incompatible receiver type</message>

--- a/config/pitest-suppressions/pitest-javadoc-suppressions.xml
+++ b/config/pitest-suppressions/pitest-javadoc-suppressions.xml
@@ -3,15 +3,6 @@
   <mutation unstable="false">
     <sourceFile>AbstractJavadocCheck.java</sourceFile>
     <mutatedClass>com.puppycrawl.tools.checkstyle.checks.javadoc.AbstractJavadocCheck</mutatedClass>
-    <mutatedMethod>validateDefaultJavadocTokens</mutatedMethod>
-    <mutator>org.pitest.mutationtest.engine.gregor.mutators.RemoveConditionalMutator_EQUAL_IF</mutator>
-    <description>removed conditional - replaced equality check with true</description>
-    <lineContent>if (getRequiredJavadocTokens().length != 0) {</lineContent>
-  </mutation>
-
-  <mutation unstable="false">
-    <sourceFile>AbstractJavadocCheck.java</sourceFile>
-    <mutatedClass>com.puppycrawl.tools.checkstyle.checks.javadoc.AbstractJavadocCheck</mutatedClass>
     <mutatedMethod>visitToken</mutatedMethod>
     <mutator>org.pitest.mutationtest.engine.gregor.mutators.NonVoidMethodCallMutator</mutator>
     <description>removed call to com/puppycrawl/tools/checkstyle/api/DetailAST::getColumnNo</description>

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/AbstractJavadocCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/AbstractJavadocCheck.java
@@ -22,6 +22,7 @@ package com.puppycrawl.tools.checkstyle.checks.javadoc;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Set;
@@ -217,19 +218,25 @@ public abstract class AbstractJavadocCheck extends AbstractCheck {
      * @throws IllegalStateException when validation of default javadoc tokens fails
      */
     private void validateDefaultJavadocTokens() {
-        if (getRequiredJavadocTokens().length != 0) {
-            final int[] defaultJavadocTokens = getDefaultJavadocTokens();
-            Arrays.sort(defaultJavadocTokens);
-            for (final int javadocToken : getRequiredJavadocTokens()) {
-                if (Arrays.binarySearch(defaultJavadocTokens, javadocToken) < 0) {
-                    final String message = String.format(Locale.ROOT,
-                            "Javadoc Token \"%s\" from required javadoc "
-                                + "tokens was not found in default "
-                                + "javadoc tokens list in check %s",
-                            javadocToken, getClass().getName());
-                    throw new IllegalStateException(message);
-                }
-            }
+        final Set<Integer> defaultTokens = Arrays.stream(getDefaultJavadocTokens())
+                .boxed()
+                .collect(Collectors.toUnmodifiableSet());
+
+        final List<Integer> missingRequiredTokenNames = Arrays.stream(getRequiredJavadocTokens())
+                .boxed()
+                .filter(token -> !defaultTokens.contains(token))
+                .collect(Collectors.toUnmodifiableList());
+
+        if (!missingRequiredTokenNames.isEmpty()) {
+            final String message = String.format(Locale.ROOT,
+                        "Javadoc Token \"%s\" from required javadoc "
+                            + "tokens was not found in default "
+                            + "javadoc tokens list in check %s",
+                        missingRequiredTokenNames.stream()
+                        .map(String::valueOf)
+                        .collect(Collectors.joining(", ")),
+                        getClass().getName());
+            throw new IllegalStateException(message);
         }
     }
 

--- a/src/test/java/com/puppycrawl/tools/checkstyle/meta/MetadataGeneratorUtilTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/meta/MetadataGeneratorUtilTest.java
@@ -80,7 +80,7 @@ public final class MetadataGeneratorUtilTest extends AbstractModuleTestSupport {
         final String[] expectedErrorMessages = {
             "31: " + getCheckMessage(MSG_DESC_MISSING, "AbstractSuperCheck"),
             "44: " + getCheckMessage(MSG_DESC_MISSING, "AbstractHeaderCheck"),
-            "42: " + getCheckMessage(MSG_DESC_MISSING, "AbstractJavadocCheck"),
+            "43: " + getCheckMessage(MSG_DESC_MISSING, "AbstractJavadocCheck"),
             "45: " + getCheckMessage(MSG_DESC_MISSING, "AbstractClassCouplingCheck"),
             "26: " + getCheckMessage(MSG_DESC_MISSING, "AbstractAccessControlNameCheck"),
             "30: " + getCheckMessage(MSG_DESC_MISSING, "AbstractNameCheck"),


### PR DESCRIPTION
part of #13999 

Explanation - All the Overridden implementation of the method `getRequiredJavadocTokens()` are of length more than 0.


Diff Regression config: https://gist.githubusercontent.com/TanayMorakhia/431cb93bf15c238967db9914a3d164ec/raw/575ff26646e5f029e9f9053a8878f27859bb186b/AbstractJavaDocCheck.xml

Diff Regression projects: https://gist.githubusercontent.com/TanayMorakhia/f3a248e4d705e5b3e0defe44c8bc8452/raw/6a2871822b807d93bcb58a449f79d94a55702f35/project.properties