### PR TITLE
Issue #14123: Fix transitive dependency rejection after Guava upgrade to 32.1.3-jre

### DIFF
--- a/.ci/no-exception-test.sh
+++ b/.ci/no-exception-test.sh
@@ -258,6 +258,24 @@ no-exception-samples-gradle)
   removeFolderWithProtectedFiles checkstyle-samples
   ;;
 
+no-exception-slugify)
+  CS_POM_VERSION="$(getCheckstylePomVersion)"
+  echo 'CS_POM_VERSION='"${CS_POM_VERSION}"
+  mvn -e --no-transfer-progress -B install -Pno-validations
+  checkout_from https://github.com/slugify/slugify.git
+  cd .ci-temp/slugify
+
+  sed -i "/checkstyle {/,/}/ s/toolVersion = .*/toolVersion = '${CS_POM_VERSION}'/" \
+    build.gradle
+  sed -i '/repositories {/a\ \ \ \ mavenLocal()' build.gradle
+
+  echo "Checking edited build.gradle..."
+  grep build.gradle -e "checkstyle {" -A 3
+  ./gradlew build
+
+  cd ..
+  removeFolderWithProtectedFiles slugify
+  ;;
 
   *)
   echo "Unexpected argument: $1"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -226,6 +226,10 @@ workflows:
           name: "no-exception-samples-gradle"
           image-name: "cimg/openjdk:11.0.19"
           command: "./.ci/no-exception-test.sh no-exception-samples-gradle"
+      - validate-with-maven-script:
+          name: "no-exception-slugify"
+          image-name: "cimg/openjdk:11.0.19"
+          command: "./.ci/no-exception-test.sh no-exception-slugify"
 
   idea:
     jobs:

--- a/pom.xml
+++ b/pom.xml
@@ -434,6 +434,7 @@
       <groupId>org.apache.maven.doxia</groupId>
       <artifactId>doxia-core</artifactId>
       <version>${doxia.version}</version>
+      <scope>test</scope>
       <exclusions>
         <!-- Excluded due to security vulnerability in version 1.11
              https://github.com/checkstyle/checkstyle/pull/13357#issuecomment-1639480844 -->
@@ -451,6 +452,13 @@
       <groupId>org.apache.maven.doxia</groupId>
       <artifactId>doxia-module-xdoc</artifactId>
       <version>${doxia.version}</version>
+      <scope>test</scope>
+      <exclusions>
+        <exclusion>
+          <groupId>com.google.collections</groupId>
+          <artifactId>google-collections</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
   </dependencies>
 


### PR DESCRIPTION
Related to #14123

Reproduction of issue: https://app.circleci.com/pipelines/github/checkstyle/checkstyle/23869/workflows/92d24c51-2e5b-48b6-9aba-0ebd9141432b/jobs/517216

Not able to reproduce with the latest snapshot: https://app.circleci.com/pipelines/github/checkstyle/checkstyle/23868/workflows/1de3ed9f-abaa-4836-a720-403b7b397fa5/jobs/517169/steps (CI is green)
