### PR TITLE
Issue #13999: Kill mutation in TagParser

### DIFF
--- a/config/checker-framework-suppressions/checker-index-suppressions.xml
+++ b/config/checker-framework-suppressions/checker-index-suppressions.xml
@@ -1842,7 +1842,7 @@
     <fileName>src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/TagParser.java</fileName>
     <specifier>argument</specifier>
     <message>incompatible argument for parameter beginIndex of String.substring.</message>
-    <lineContent>text = text.substring(column).trim();</lineContent>
+    <lineContent>text = text.substring(column);</lineContent>
     <details>
       found   : int
       required: @NonNegative int

--- a/config/pitest-suppressions/pitest-javadoc-suppressions.xml
+++ b/config/pitest-suppressions/pitest-javadoc-suppressions.xml
@@ -255,15 +255,6 @@
   <mutation unstable="false">
     <sourceFile>TagParser.java</sourceFile>
     <mutatedClass>com.puppycrawl.tools.checkstyle.checks.javadoc.TagParser</mutatedClass>
-    <mutatedMethod>getTagId</mutatedMethod>
-    <mutator>org.pitest.mutationtest.engine.gregor.mutators.experimental.NakedReceiverMutator</mutator>
-    <description>replaced call to java/lang/String::trim with receiver</description>
-    <lineContent>text = text.substring(column).trim();</lineContent>
-  </mutation>
-
-  <mutation unstable="false">
-    <sourceFile>TagParser.java</sourceFile>
-    <mutatedClass>com.puppycrawl.tools.checkstyle.checks.javadoc.TagParser</mutatedClass>
     <mutatedMethod>skipHtmlComment</mutatedMethod>
     <mutator>org.pitest.mutationtest.engine.gregor.mutators.experimental.ArgumentPropagationMutator</mutator>
     <description>replaced call to com/puppycrawl/tools/checkstyle/checks/javadoc/TagParser::findChar with argument</description>

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/TagParser.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/TagParser.java
@@ -176,8 +176,7 @@ class TagParser {
             if (text.charAt(column) == '/') {
                 column++;
             }
-
-            text = text.substring(column).trim();
+            text = text.substring(column);
             int position = 0;
 
             // Character.isJavaIdentifier... may not be a valid HTML


### PR DESCRIPTION
issue #13999:

## Mutation
https://github.com/checkstyle/checkstyle/blob/8e76057c776b00ba718a3df6669e4e05f15f1399/config/pitest-suppressions/pitest-javadoc-suppressions.xml#L255-L262

## Modules 

`javadocStyleCheck`

## Explanation
`.trim()` is redundant here the spaces at the end of the tag `<b      >` got trimmed already by the loop below. the spaces is not considered as  `JavaIdentifierPart` so the loops breaks when encounter a space
```
while (position < text.length()
                    && Character.isJavaIdentifierPart(text.charAt(position))) {
                position++;
            }

```
and if there is a space at the start of the tag `<        b>` it is not considered as valid HTML tag and didn't even get passed to the TagParser 

## Regression 

Diff Regression config: https://gist.githubusercontent.com/mahfouz72/83da30fe55de9d9465940675441ec003/raw/c939775415328f2bf39289ab7f6fc97717c1b79c/gistfile1.txt

Diff Regression projects: https://gist.githubusercontent.com/mahfouz72/649bd1dced8e2cde1d5b5aa148ab93a1/raw/db4ff628cf5ecdf578729cd4811f880de1fca868/projects-to-test-on.properties

