### PR TITLE
Issue #14485: should use release 11 for compilation

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -222,6 +222,7 @@
     <maven.versions.plugin.version>2.16.2</maven.versions.plugin.version>
     <maven.compiler.plugin.version>3.12.1</maven.compiler.plugin.version>
     <java.version>11</java.version>
+    <maven.compiler.release>${java.version}</maven.compiler.release>
     <pitest.plugin.version>1.15.8</pitest.plugin.version>
     <pitest.plugin.timeout.factor>10</pitest.plugin.timeout.factor>
     <pitest.plugin.output.formats>HTML,XML</pitest.plugin.output.formats>
@@ -795,8 +796,6 @@
         <artifactId>maven-compiler-plugin</artifactId>
         <version>${maven.compiler.plugin.version}</version>
         <configuration>
-          <source>${java.version}</source>
-          <target>${java.version}</target>
           <compilerArgs>
             <arg>-Xpkginfo:always</arg>
           </compilerArgs>
@@ -2415,8 +2414,6 @@
                 </goals>
                 <configuration>
                   <failOnError>false</failOnError>
-                  <source>${java.version}</source>
-                  <target>${java.version}</target>
                   <compilerArgs>
                     <arg>-Xpkginfo:always</arg>
                     <arg>-XDcompilePolicy=simple</arg>
@@ -2472,8 +2469,6 @@
                 </goals>
                 <configuration>
                   <failOnError>false</failOnError>
-                  <source>${java.version}</source>
-                  <target>${java.version}</target>
                   <compilerArgs>
                     <arg>-Xpkginfo:always</arg>
                     <arg>-XDcompilePolicy=simple</arg>


### PR DESCRIPTION
Issue #14485

Configure maven compiler level in a single place by using the default user property. Remove all duplicate properties. Use release instead of source and target, since that includes the API compatibility check.