### PR TITLE
Issue #14487: add support to ignore JSNI methods for LineLength check in google config

### DIFF
--- a/config/jsoref-spellchecker/whitelist.words
+++ b/config/jsoref-spellchecker/whitelist.words
@@ -495,7 +495,6 @@ GMetrics
 gnupg
 google
 googleapis
-googleblog
 googlecloudplatform
 googleecommon
 googlegroups
@@ -1417,7 +1416,6 @@ webjar
 Weblogic
 Webp
 website
-webtoolkit
 Wellformedness
 wget
 wherejavadocrequired

--- a/src/it/java/com/google/checkstyle/test/chapter4formatting/rule44columnlimit/LineLengthTest.java
+++ b/src/it/java/com/google/checkstyle/test/chapter4formatting/rule44columnlimit/LineLengthTest.java
@@ -22,6 +22,7 @@ package com.google.checkstyle.test.chapter4formatting.rule44columnlimit;
 import org.junit.jupiter.api.Test;
 
 import com.google.checkstyle.test.base.AbstractGoogleModuleTestSupport;
+import com.puppycrawl.tools.checkstyle.DefaultConfiguration;
 import com.puppycrawl.tools.checkstyle.api.Configuration;
 import com.puppycrawl.tools.checkstyle.checks.sizes.LineLengthCheck;
 
@@ -44,6 +45,24 @@ public class LineLengthTest extends AbstractGoogleModuleTestSupport {
 
         final Integer[] warnList = getLinesWithWarn(filePath);
         verify(checkConfig, filePath, expected, warnList);
+    }
+
+    @Test
+    public void testLineLengthJsniMethods() throws Exception {
+        final String[] expected = {
+            "14: " + getCheckMessage(LineLengthCheck.class, "maxLineLen", 100, 165),
+        };
+
+        final Configuration lineLengthConfig = getModuleConfig("LineLength");
+        final DefaultConfiguration rootConfig = createRootConfig(lineLengthConfig);
+
+        final Configuration filterConfig = getModuleConfig("SuppressWithPlainTextCommentFilter");
+        rootConfig.addChild(filterConfig);
+
+        final String filePath = getPath("InputLineLengthJsniMethods.java");
+
+        final Integer[] warnList = getLinesWithWarn(filePath);
+        verify(rootConfig, filePath, expected, warnList);
     }
 
 }

--- a/src/it/resources/com/google/checkstyle/test/chapter4formatting/rule44columnlimit/InputLineLengthJsniMethods.java
+++ b/src/it/resources/com/google/checkstyle/test/chapter4formatting/rule44columnlimit/InputLineLengthJsniMethods.java
@@ -1,0 +1,16 @@
+package com.google.checkstyle.test.chapter4formatting.rule44columnlimit;
+
+public class InputLineLengthJsniMethods {
+
+  // JSNI method
+  public static native void alertMessage(String msg) /*-{
+    $wnd.alert(msg);
+    console.log('my very long message ....................................................................................................................');
+  }-*/;
+
+  // just a comment, no JSNI delimiters
+  public static native void alertMessage2(String msg) /*
+    $wnd.alert(msg);
+    console.log('my very long message ....................................................................................................................'); // warn
+  */;
+}

--- a/src/main/resources/google_checks.xml
+++ b/src/main/resources/google_checks.xml
@@ -48,6 +48,14 @@
     <property name="ignorePattern" value="^package.*|^import.*|a href|href|http://|https://|ftp://"/>
   </module>
 
+  <!-- To ignore JSNI Methods for LineLength check -->
+  <!-- See https://google.github.io/styleguide/javaguide.html#s4.4-column-limit  -->
+  <module name="SuppressWithPlainTextCommentFilter">
+    <property name="offCommentFormat" value="\/\*-\{"/>
+    <property name="onCommentFormat" value="\}-\*\/"/>
+    <property name="checkFormat" value="LineLength"/>
+  </module>
+
   <module name="TreeWalker">
     <module name="OuterTypeFilename"/>
     <module name="IllegalTokenText">

--- a/src/test/java/com/puppycrawl/tools/checkstyle/internal/XdocsPagesTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/internal/XdocsPagesTest.java
@@ -1665,6 +1665,7 @@ public class XdocsPagesTest {
             styleChecks.remove("SuppressionCommentFilter");
             styleChecks.remove("SuppressWarningsFilter");
             styleChecks.remove("SuppressWarningsHolder");
+            styleChecks.remove("SuppressWithPlainTextCommentFilter");
 
             assertWithMessage(
                     fileName + " requires the following check(s) to appear: " + styleChecks)

--- a/src/xdocs/filters/suppresswithplaintextcommentfilter.xml
+++ b/src/xdocs/filters/suppresswithplaintextcommentfilter.xml
@@ -348,6 +348,10 @@ public class Example9 {
       <subsection name="Example of Usage" id="Example_of_Usage">
         <ul>
           <li>
+            <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources%20path%3A**%2Fgoogle_checks.xml+repo%3Acheckstyle%2Fcheckstyle+SuppressWithPlainTextCommentFilter">
+            Google Style</a>
+          </li>
+          <li>
             <a href="https://github.com/search?q=path%3Aconfig%20path%3A**%2Fcheckstyle-checks.xml+repo%3Acheckstyle%2Fcheckstyle+SuppressWithPlainTextCommentFilter">
             Checkstyle Style</a>
           </li>

--- a/src/xdocs/filters/suppresswithplaintextcommentfilter.xml.template
+++ b/src/xdocs/filters/suppresswithplaintextcommentfilter.xml.template
@@ -207,6 +207,10 @@
       <subsection name="Example of Usage" id="Example_of_Usage">
         <ul>
           <li>
+            <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources%20path%3A**%2Fgoogle_checks.xml+repo%3Acheckstyle%2Fcheckstyle+SuppressWithPlainTextCommentFilter">
+            Google Style</a>
+          </li>
+          <li>
             <a href="https://github.com/search?q=path%3Aconfig%20path%3A**%2Fcheckstyle-checks.xml+repo%3Acheckstyle%2Fcheckstyle+SuppressWithPlainTextCommentFilter">
             Checkstyle Style</a>
           </li>

--- a/src/xdocs/google_style.xml
+++ b/src/xdocs/google_style.xml
@@ -780,18 +780,10 @@
                 <td>
                   <span class="wrapper inline">
                     <img
-                        src="images/ok_blue.png"
+                        src="images/ok_green.png"
                         alt="" />
                   </span>
                   <a href="checks/sizes/linelength.html#LineLength">LineLength</a>
-                  <br />
-                  We can detect URL with protocol type as http://, https:// etc.
-                  <br />
-                  <a href="https://webtoolkit.googleblog.com/2008/07/getting-to-really-know-gwt-part-1-jsni.html">
-                    JSNI</a>
-                  could not be detected right now, but might be possible after
-                  comments and javadoc support appear in Checkstyle.
-                  <br />
                 </td>
                 <td>
                   <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources%20path%3A**%2Fgoogle_checks.xml+repo%3Acheckstyle%2Fcheckstyle+LineLength">
@@ -2362,7 +2354,7 @@
           <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources%20path%3A**%2Fgoogle_checks.xml+repo%3Acheckstyle%2Fcheckstyle+SuppressionCommentFilter">
                     SuppressionCommentFilter</a>,
           <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources%20path%3A**%2Fgoogle_checks.xml+repo%3Acheckstyle%2Fcheckstyle+SuppressWarningsFilter">
-                    SuppressWarningsFilter</a>,
+                    SuppressWarningsFilter</a>.
         </p>
       </subsection>
     </section>


### PR DESCRIPTION
Issue #14487

Ignore JSNI methods' length in google config based on [4.4 Column Limit: 100](https://google.github.io/styleguide/javaguide.html#s4.4-column-limit)
> ### Exceptions:
> 1. Lines where obeying the column limit is not possible (for example, a long URL in Javadoc, or a long JSNI method reference).