### PR TITLE
Issue #13213: Remove '//ok' comments from Input files (avoidinlineconditionals)

### DIFF
--- a/config/checkstyle-input-suppressions.xml
+++ b/config/checkstyle-input-suppressions.xml
@@ -68,10 +68,7 @@
           files="[\\/]packageobjectfactory[\\/]zoo[\\/]FooCheck.java"/>
 
   <!-- until https://github.com/checkstyle/checkstyle/issues/13213 -->
-  <suppress id="UnnecessaryOkComment"
-            files="checks[\\/]coding[\\/]avoidinlineconditionals[\\/]InputAvoidInlineConditionals.java"/>
-  <suppress id="UnnecessaryOkComment"
-            files="checks[\\/]coding[\\/]avoidinlineconditionals[\\/]InputAvoidInlineConditionals.java"/>
+
   <suppress id="UnnecessaryOkComment"
             files="checks[\\/]coding[\\/]illegalthrows[\\/]InputIllegalThrowsIgnoreMethodNames.java"/>
   <suppress id="UnnecessaryOkComment"

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/avoidinlineconditionals/InputAvoidInlineConditionals.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/avoidinlineconditionals/InputAvoidInlineConditionals.java
@@ -38,10 +38,10 @@ class InputAvoidInlineConditionals
     /** assert statement test */
     public void assertTest()
     {
-        // OK
+
         assert true;
 
-        // OK
+
         assert true : "Whups";
 
         // evil colons, should be OK


### PR DESCRIPTION
Issue #13213 

Removed // ok comments from InputAvoidInlineConditionals.java and its suppressions