### PR TITLE
Issue #14137: Enable `RedundantStringConversion` check

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -252,6 +252,7 @@
       -Xep:MockitoStubbing:ERROR
       -Xep:NestedOptionals:ERROR
       -Xep:PrimitiveComparison:ERROR
+      -Xep:RedundantStringConversion:ERROR
       -Xep:TimeZoneUsage:ERROR
       <!-- Reason at https://github.com/checkstyle/checkstyle/issues/8252. -->
       -Xep:JUnitClassModifiers:OFF

--- a/src/test/java/com/puppycrawl/tools/checkstyle/internal/ImmutabilityTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/internal/ImmutabilityTest.java
@@ -378,7 +378,7 @@ public class ImmutabilityTest {
                 final String message = String
                     .format(Locale.ROOT, "Field <%s> should %s in %s",
                             item.getFullName(), getDescription(),
-                            item.getSourceCodeLocation().toString());
+                            item.getSourceCodeLocation());
                 events.add(SimpleConditionEvent.violated(item, message));
             }
         }


### PR DESCRIPTION
Issue #14137.

This PR enables the https://error-prone.picnic.tech/bugpatterns/RedundantStringConversion/ check.
