### PR TITLE
Issue #3502: update VariableDeclarationUsageDistance to do violation to move variables closer to block

### DIFF
--- a/config/pitest-suppressions/pitest-coding-1-suppressions.xml
+++ b/config/pitest-suppressions/pitest-coding-1-suppressions.xml
@@ -1,0 +1,47 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<suppressedMutations>
+  <mutation unstable="false">
+    <sourceFile>VariableDeclarationUsageDistanceCheck.java</sourceFile>
+    <mutatedClass>com.puppycrawl.tools.checkstyle.checks.coding.VariableDeclarationUsageDistanceCheck</mutatedClass>
+    <mutatedMethod>getDistToVariableUsageInChildNode</mutatedMethod>
+    <mutator>org.pitest.mutationtest.engine.gregor.mutators.experimental.NakedReceiverMutator</mutator>
+    <description>replaced call to com/puppycrawl/tools/checkstyle/api/DetailAST::getFirstChild with receiver</description>
+    <lineContent>examineNode = examineNode.getFirstChild().getNextSibling();</lineContent>
+  </mutation>
+
+  <mutation unstable="false">
+    <sourceFile>VariableDeclarationUsageDistanceCheck.java</sourceFile>
+    <mutatedClass>com.puppycrawl.tools.checkstyle.checks.coding.VariableDeclarationUsageDistanceCheck</mutatedClass>
+    <mutatedMethod>getDistToVariableUsageInChildNode</mutatedMethod>
+    <mutator>org.pitest.mutationtest.engine.gregor.mutators.experimental.NakedReceiverMutator</mutator>
+    <description>replaced call to com/puppycrawl/tools/checkstyle/api/DetailAST::getNextSibling with receiver</description>
+    <lineContent>examineNode = examineNode.getFirstChild().getNextSibling();</lineContent>
+  </mutation>
+
+  <mutation unstable="false">
+    <sourceFile>VariableDeclarationUsageDistanceCheck.java</sourceFile>
+    <mutatedClass>com.puppycrawl.tools.checkstyle.checks.coding.VariableDeclarationUsageDistanceCheck</mutatedClass>
+    <mutatedMethod>getDistToVariableUsageInChildNode</mutatedMethod>
+    <mutator>org.pitest.mutationtest.engine.gregor.mutators.NonVoidMethodCallMutator</mutator>
+    <description>removed call to com/puppycrawl/tools/checkstyle/api/DetailAST::getType</description>
+    <lineContent>if (examineNode.getType() == TokenTypes.LABELED_STAT) {</lineContent>
+  </mutation>
+
+  <mutation unstable="false">
+    <sourceFile>VariableDeclarationUsageDistanceCheck.java</sourceFile>
+    <mutatedClass>com.puppycrawl.tools.checkstyle.checks.coding.VariableDeclarationUsageDistanceCheck</mutatedClass>
+    <mutatedMethod>getDistToVariableUsageInChildNode</mutatedMethod>
+    <mutator>org.pitest.mutationtest.engine.gregor.mutators.RemoveConditionalMutator_EQUAL_ELSE</mutator>
+    <description>removed conditional - replaced equality check with false</description>
+    <lineContent>if (examineNode.getType() == TokenTypes.LABELED_STAT) {</lineContent>
+  </mutation>
+
+  <mutation unstable="false">
+    <sourceFile>VariableDeclarationUsageDistanceCheck.java</sourceFile>
+    <mutatedClass>com.puppycrawl.tools.checkstyle.checks.coding.VariableDeclarationUsageDistanceCheck</mutatedClass>
+    <mutatedMethod>getDistToVariableUsageInChildNode</mutatedMethod>
+    <mutator>org.pitest.mutationtest.engine.gregor.mutators.experimental.RemoveSwitchMutator_4</mutator>
+    <description>RemoveSwitch 4 (case value 89)</description>
+    <lineContent>switch (examineNode.getType()) {</lineContent>
+  </mutation>
+</suppressedMutations>

--- a/src/it/java/com/google/checkstyle/test/chapter4formatting/rule4822variabledistance/VariableDeclarationUsageDistanceTest.java
+++ b/src/it/java/com/google/checkstyle/test/chapter4formatting/rule4822variabledistance/VariableDeclarationUsageDistanceTest.java
@@ -43,6 +43,7 @@ public class VariableDeclarationUsageDistanceTest extends AbstractGoogleModuleTe
             "219:9: " + getCheckMessage(clazz, msgExt, "t", 5, 3),
             "483:9: " + getCheckMessage(clazz, msgExt, "myOption", 7, 3),
             "495:9: " + getCheckMessage(clazz, msgExt, "myOption", 6, 3),
+            "508:9: " + getCheckMessage(clazz, msgExt, "count", 4, 3),
         };
 
         final Configuration checkConfig =

--- a/src/it/resources/com/google/checkstyle/test/chapter4formatting/rule4822variabledistance/InputVariableDeclarationUsageDistanceCheck.java
+++ b/src/it/resources/com/google/checkstyle/test/chapter4formatting/rule4822variabledistance/InputVariableDeclarationUsageDistanceCheck.java
@@ -505,7 +505,7 @@ public class InputVariableDeclarationUsageDistanceCheck {
     public int testIssue32_11(String toDir)
             throws Exception
     {
-        int count = 0;
+        int count = 0;  // warn
         String[] files = {};
 
         System.identityHashCode("Data archival started");

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/VariableDeclarationUsageDistanceCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/VariableDeclarationUsageDistanceCheck.java
@@ -306,7 +306,7 @@ public class VariableDeclarationUsageDistanceCheck extends AbstractCheck {
         while (!firstUsageFound && currentAst != null) {
             if (currentAst.getFirstChild() != null) {
                 if (isChild(currentAst, variableIdentAst)) {
-                    dist = getDistToVariableUsageInChildNode(currentAst, variableIdentAst, dist);
+                    dist = getDistToVariableUsageInChildNode(currentAst, dist);
                     variableUsageAst = currentAst;
                     firstUsageFound = true;
                 }
@@ -324,11 +324,10 @@ public class VariableDeclarationUsageDistanceCheck extends AbstractCheck {
      * Returns the distance to variable usage for in the child node.
      *
      * @param childNode child node.
-     * @param varIdent variable variable identifier.
      * @param currentDistToVarUsage current distance to the variable usage.
      * @return the distance to variable usage for in the child node.
      */
-    private static int getDistToVariableUsageInChildNode(DetailAST childNode, DetailAST varIdent,
+    private static int getDistToVariableUsageInChildNode(DetailAST childNode,
                                                          int currentDistToVarUsage) {
         DetailAST examineNode = childNode;
         if (examineNode.getType() == TokenTypes.LABELED_STAT) {
@@ -336,6 +335,7 @@ public class VariableDeclarationUsageDistanceCheck extends AbstractCheck {
         }
 
         int resultDist = currentDistToVarUsage;
+
         switch (examineNode.getType()) {
             case TokenTypes.SLIST:
                 resultDist = 0;
@@ -345,17 +345,12 @@ public class VariableDeclarationUsageDistanceCheck extends AbstractCheck {
             case TokenTypes.LITERAL_DO:
             case TokenTypes.LITERAL_IF:
             case TokenTypes.LITERAL_SWITCH:
-                if (isVariableInOperatorExpr(examineNode, varIdent)) {
-                    resultDist++;
-                }
-                else {
-                    // variable usage is in inner scope
-                    // reset counters, because we can't determine distance
-                    resultDist = 0;
-                }
+                // variable usage is in inner scope, treated as 1 block
+                // or in operator expression, then distance + 1
+                resultDist++;
                 break;
             default:
-                if (examineNode.findFirstToken(TokenTypes.SLIST) == null) {
+                if (childNode.findFirstToken(TokenTypes.SLIST) == null) {
                     resultDist++;
                 }
                 else {
@@ -706,22 +701,6 @@ public class VariableDeclarationUsageDistanceCheck extends AbstractCheck {
                 break;
             }
             ast = ast.getNextSibling();
-        }
-
-        // Variable may be met in ELSE declaration
-        // So, check variable usage in these declarations.
-        if (!isVarInOperatorDeclaration) {
-            final DetailAST elseBlock = operator.getLastChild();
-
-            if (elseBlock.getType() == TokenTypes.LITERAL_ELSE) {
-                // Get IF followed by ELSE
-                final DetailAST firstNodeInsideElseBlock = elseBlock.getFirstChild();
-
-                if (firstNodeInsideElseBlock.getType() == TokenTypes.LITERAL_IF) {
-                    isVarInOperatorDeclaration =
-                        isVariableInOperatorExpr(firstNodeInsideElseBlock, variable);
-                }
-            }
         }
 
         return isVarInOperatorDeclaration;

--- a/src/test/java/com/puppycrawl/tools/checkstyle/bdd/InlineConfigParser.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/bdd/InlineConfigParser.java
@@ -301,7 +301,6 @@ public final class InlineConfigParser {
 
     private static String getFullyQualifiedClassName(String filePath, String moduleName)
             throws CheckstyleException {
-        String fullyQualifiedClassName;
         // This is a hack until https://github.com/checkstyle/checkstyle/issues/13845
         final Map<String, String> moduleMappings = new HashMap<>();
         moduleMappings.put("ParameterNumber",
@@ -320,6 +319,7 @@ public final class InlineConfigParser {
                 "com.puppycrawl.tools.checkstyle.checks.javadoc.SummaryJavadocCheck");
         moduleMappings.put("LineLength",
                 "com.puppycrawl.tools.checkstyle.checks.sizes.LineLengthCheck");
+        String fullyQualifiedClassName;
         if (moduleMappings.containsKey(moduleName)) {
             fullyQualifiedClassName = moduleMappings.get(moduleName);
         }

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/coding/VariableDeclarationUsageDistanceCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/coding/VariableDeclarationUsageDistanceCheckTest.java
@@ -168,6 +168,8 @@ public class VariableDeclarationUsageDistanceCheckTest extends
             "231:9: " + getCheckMessage(MSG_KEY, "t", 5, 1),
             "234:9: " + getCheckMessage(MSG_KEY, "c", 3, 1),
             "235:9: " + getCheckMessage(MSG_KEY, "d2", 3, 1),
+            "272:9: " + getCheckMessage(MSG_KEY, "sel", 2, 1),
+            "273:9: " + getCheckMessage(MSG_KEY, "model", 2, 1),
             "312:9: " + getCheckMessage(MSG_KEY, "wh", 2, 1),
             "355:9: " + getCheckMessage(MSG_KEY, "green", 2, 1),
             "356:9: " + getCheckMessage(MSG_KEY, "blue", 3, 1),
@@ -178,10 +180,20 @@ public class VariableDeclarationUsageDistanceCheckTest extends
             "483:9: " + getCheckMessage(MSG_KEY, "l2", 2, 1),
             "491:9: " + getCheckMessage(MSG_KEY, "myOption", 7, 1),
             "503:9: " + getCheckMessage(MSG_KEY, "myOption", 6, 1),
+            "516:9: " + getCheckMessage(MSG_KEY, "count", 4, 1),
             "517:9: " + getCheckMessage(MSG_KEY, "files", 2, 1),
             "552:13: " + getCheckMessage(MSG_KEY, "id", 2, 1),
             "554:13: " + getCheckMessage(MSG_KEY, "parentId", 4, 1),
+            "855:9: " + getCheckMessage(MSG_KEY, "a", 5, 1),
+            "867:9: " + getCheckMessage(MSG_KEY, "a", 5, 1),
+            "879:9: " + getCheckMessage(MSG_KEY, "a", 5, 1),
+            "891:9: " + getCheckMessage(MSG_KEY, "a", 5, 1),
+            "903:9: " + getCheckMessage(MSG_KEY, "a", 5, 1),
+            "913:9: " + getCheckMessage(MSG_KEY, "a", 5, 1),
+            "924:9: " + getCheckMessage(MSG_KEY, "a", 2, 1),
+            "945:9: " + getCheckMessage(MSG_KEY, "a", 5, 1),
             "990:9: " + getCheckMessage(MSG_KEY, "a", 2, 1),
+            "1001:9: " + getCheckMessage(MSG_KEY, "a", 4, 1),
             "1036:9: " + getCheckMessage(MSG_KEY, "c", 4, 1),
             "1066:9: " + getCheckMessage(MSG_KEY, "a", 4, 1),
         };
@@ -253,11 +265,19 @@ public class VariableDeclarationUsageDistanceCheckTest extends
             "231:9: " + getCheckMessage(MSG_KEY_EXT, "t", 5, 3),
             "491:9: " + getCheckMessage(MSG_KEY_EXT, "myOption", 7, 3),
             "503:9: " + getCheckMessage(MSG_KEY_EXT, "myOption", 6, 3),
+            "516:9: " + getCheckMessage(MSG_KEY_EXT, "count", 4, 3),
             "554:13: " + getCheckMessage(MSG_KEY_EXT, "parentId", 4, 3),
+            "855:9: " + getCheckMessage(MSG_KEY_EXT, "a", 5, 3),
+            "867:9: " + getCheckMessage(MSG_KEY_EXT, "a", 5, 3),
+            "879:9: " + getCheckMessage(MSG_KEY_EXT, "a", 5, 3),
+            "891:9: " + getCheckMessage(MSG_KEY_EXT, "a", 5, 3),
+            "903:9: " + getCheckMessage(MSG_KEY_EXT, "a", 5, 3),
+            "913:9: " + getCheckMessage(MSG_KEY_EXT, "a", 5, 3),
+            "945:9: " + getCheckMessage(MSG_KEY_EXT, "a", 5, 3),
             "1036:9: " + getCheckMessage(MSG_KEY_EXT, "c", 4, 3),
+            "1001:9: " + getCheckMessage(MSG_KEY_EXT, "a", 4, 3),
             "1066:9: " + getCheckMessage(MSG_KEY_EXT, "a", 4, 3),
         };
-
         verifyWithInlineConfigParser(
                 getPath("InputVariableDeclarationUsageDistanceDefault.java"), expected);
     }
@@ -283,8 +303,9 @@ public class VariableDeclarationUsageDistanceCheckTest extends
 
     @Test
     public void testLabels() throws Exception {
-        final String[] expected = CommonUtil.EMPTY_STRING_ARRAY;
-
+        final String[] expected = {
+            "15:9: " + getCheckMessage(MSG_KEY_EXT, "eol", 5, 3),
+        };
         verifyWithInlineConfigParser(
                 getPath("InputVariableDeclarationUsageDistanceLabels.java"), expected);
     }
@@ -376,5 +397,15 @@ public class VariableDeclarationUsageDistanceCheckTest extends
 
         verifyWithInlineConfigParser(
                 getPath("InputVariableDeclarationUsageDistance1.java"), expected);
+    }
+
+    @Test
+    public void testVariableDeclarationUsageDistanceCloseToBlock() throws Exception {
+        final String[] expected = {
+            "15:9: " + getCheckMessage(MSG_KEY, "a", 13, 1),
+            "16:9: " + getCheckMessage(MSG_KEY, "b", 13, 1),
+        };
+        verifyWithInlineConfigParser(
+                getPath("InputVariableDeclarationUsageDistanceCloseToBlock.java"), expected);
     }
 }

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/variabledeclarationusagedistance/InputVariableDeclarationUsageDistanceCloseToBlock.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/variabledeclarationusagedistance/InputVariableDeclarationUsageDistanceCloseToBlock.java
@@ -1,0 +1,59 @@
+/*
+VariableDeclarationUsageDistance
+allowedDistance = 1
+ignoreVariablePattern = (default)
+validateBetweenScopes = false
+ignoreFinal = false
+
+
+*/
+
+package com.puppycrawl.tools.checkstyle.checks.coding.variabledeclarationusagedistance;
+
+public class InputVariableDeclarationUsageDistanceCloseToBlock {
+    void method() {
+        int a = 3; // violation 'Distance between .* declaration and its first usage is 13.'
+        int b = 2; // violation 'Distance between .* declaration and its first usage is 13.'
+
+        run();
+        run();
+        run();
+        run();
+        run();
+        run();
+        run();
+        run();
+        run();
+        run();
+        run();
+        run();
+
+        for (int i = 0; i < 10; i++) {
+            a = a + b;
+        }
+    }
+
+     void method2() {
+        run();
+        run();
+        run();
+        run();
+        run();
+        run();
+        run();
+        run();
+        run();
+        run();
+        run();
+        run();
+
+        int a = 3;
+        int b = 2;
+
+        for (int i = 0; i < 10; i++) {
+            a = a + b;  // distance = 1
+        }
+    }
+
+    public void run() {};
+}

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/variabledeclarationusagedistance/InputVariableDeclarationUsageDistanceDefault.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/variabledeclarationusagedistance/InputVariableDeclarationUsageDistanceDefault.java
@@ -513,7 +513,7 @@ public class InputVariableDeclarationUsageDistanceDefault {
     public int testIssue32_11(String toDir)
             throws Exception
     {
-        int count = 0;
+        int count = 0;  // violation 'Distance .* is 4.'
         String[] files = {};
 
         System.identityHashCode("Data archival started");
@@ -852,7 +852,7 @@ public class InputVariableDeclarationUsageDistanceDefault {
 
 class New6 {
     void a() {
-        int a = 1;
+        int a = 1; // violation 'Distance .* is 5.'
         System.lineSeparator();
         System.lineSeparator();
         System.lineSeparator();
@@ -864,7 +864,7 @@ class New6 {
     }
 
     void b() {
-        int a = 1;
+        int a = 1; // violation 'Distance .* is 5.'
         System.lineSeparator();
         System.lineSeparator();
         System.lineSeparator();
@@ -876,7 +876,7 @@ class New6 {
     }
 
     void c() {
-        int a = 1;
+        int a = 1; // violation 'Distance .* is 5.'
         System.lineSeparator();
         System.lineSeparator();
         System.lineSeparator();
@@ -888,7 +888,7 @@ class New6 {
     }
 
     void d() {
-        int a = 1;
+        int a = 1; // violation 'Distance .* is 5.'
         System.lineSeparator();
         System.lineSeparator();
         System.lineSeparator();
@@ -900,7 +900,7 @@ class New6 {
     }
 
     void f() {
-        int a = 1;
+        int a = 1; // violation 'Distance .* is 5.'
         System.lineSeparator();
         System.lineSeparator();
         System.lineSeparator();
@@ -910,7 +910,7 @@ class New6 {
     }
 
     void h() {
-        int a = 1;
+        int a = 1; // violation 'Distance .* is 5.'
         System.lineSeparator();
         System.lineSeparator();
         System.lineSeparator();
@@ -942,7 +942,7 @@ class New6 {
     }
 
     void k() {
-        int a = 1;
+        int a = 1; // violation 'Distance .* is 5.'
         System.lineSeparator();
         System.lineSeparator();
         System.lineSeparator();
@@ -998,7 +998,7 @@ class New6 {
     }
 
     void test() {
-        int a = 0;
+        int a = 0; // violation 'Distance .* is 4.'
 
         System.lineSeparator();
         System.lineSeparator();

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/variabledeclarationusagedistance/InputVariableDeclarationUsageDistanceLabels.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/variabledeclarationusagedistance/InputVariableDeclarationUsageDistanceLabels.java
@@ -12,7 +12,7 @@ package com.puppycrawl.tools.checkstyle.checks.coding.variabledeclarationusagedi
 
 public class InputVariableDeclarationUsageDistanceLabels {
     public void method() {
-        boolean eol = false;
+        boolean eol = false; // violation 'Distance .* is 5.'
 
         nothing();
         nothing();

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/variabledeclarationusagedistance/InputVariableDeclarationUsageDistanceScopes.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/variabledeclarationusagedistance/InputVariableDeclarationUsageDistanceScopes.java
@@ -269,8 +269,8 @@ public class InputVariableDeclarationUsageDistanceScopes {
     }
 
     public int[] getSelectedIndices() {
-        int[] sel = new int[5];
-        String model = "";
+        int[] sel = new int[5]; // violation 'Distance .* is 2.'
+        String model = ""; // violation 'Distance between .* declaration and its first usage is 2.'
         int a = 0;
         a++;
         for (int index = 0; index < 5; ++index) {
@@ -513,7 +513,7 @@ public class InputVariableDeclarationUsageDistanceScopes {
     public int testIssue32_11(String toDir)
             throws Exception
     {
-        int count = 0;
+        int count = 0; // violation 'Distance .* is 4.'
         String[] files = {}; // violation 'Distance .* is 2.'
 
         System.identityHashCode("Data archival started");
@@ -852,7 +852,7 @@ public class InputVariableDeclarationUsageDistanceScopes {
 
 class New4 {
     void a() {
-        int a = 1;
+        int a = 1; // violation 'Distance .* is 5.'
         System.lineSeparator();
         System.lineSeparator();
         System.lineSeparator();
@@ -864,7 +864,7 @@ class New4 {
     }
 
     void b() {
-        int a = 1;
+        int a = 1; // violation 'Distance .* is 5.'
         System.lineSeparator();
         System.lineSeparator();
         System.lineSeparator();
@@ -876,7 +876,7 @@ class New4 {
     }
 
     void c() {
-        int a = 1;
+        int a = 1; // violation 'Distance .* is 5.'
         System.lineSeparator();
         System.lineSeparator();
         System.lineSeparator();
@@ -888,7 +888,7 @@ class New4 {
     }
 
     void d() {
-        int a = 1;
+        int a = 1; // violation 'Distance .* is 5.'
         System.lineSeparator();
         System.lineSeparator();
         System.lineSeparator();
@@ -900,7 +900,7 @@ class New4 {
     }
 
     void f() {
-        int a = 1;
+        int a = 1; // violation 'Distance .* is 5.'
         System.lineSeparator();
         System.lineSeparator();
         System.lineSeparator();
@@ -910,7 +910,7 @@ class New4 {
     }
 
     void h() {
-        int a = 1;
+        int a = 1; // violation 'Distance .* is 5.'
         System.lineSeparator();
         System.lineSeparator();
         System.lineSeparator();
@@ -921,7 +921,7 @@ class New4 {
     }
 
     void i() {
-        int a = 1;
+        int a = 1; // violation 'Distance .* is 2.'
         switch (Math.max(1, 2)) {
         case 1:
             System.lineSeparator();
@@ -942,7 +942,7 @@ class New4 {
     }
 
     void k() {
-        int a = 1;
+        int a = 1; // violation 'Distance .* is 5.'
         System.lineSeparator();
         System.lineSeparator();
         System.lineSeparator();
@@ -998,7 +998,7 @@ class New4 {
     }
 
     void test() {
-        int a = 0;
+        int a = 0; // violation 'Distance between .* declaration and its first usage is 4.'
 
         System.lineSeparator();
         System.lineSeparator();


### PR DESCRIPTION
Resolves #3502:
- updated VariableDeclarationUsageDistance to do violation to move variables closer to the block
- updated corresponding tests to match the new functionality of the check

## Regression
I will generate 2 reports difference is expected for report-2

Diff Regression config: https://gist.githubusercontent.com/mahfouz72/ce878f7db10dd474a7f6aa53ada50c7c/raw/68d7ec7bcef08b49d6deaa712d2e18cf8c328dcd/check1.xml
Report label: report-2


I generated two report
- [report-1](https://checkstyle-diff-reports.s3.us-east-2.amazonaws.com/17c1f8f_2024173315/reports/diff/index.html) (no diff) with this [config](https://gist.githubusercontent.com/mahfouz72/afd57aa6e51ca161b7927acd959e5211/raw/e82a7576e6372a18bb4794217b6713b475f0e4f9/check.xml) to check that the check behavior didn't change when `validateBetweenScopes` is on 

- [report-2](https://checkstyle-diff-reports.s3.us-east-2.amazonaws.com/17c1f8f_2024192425/reports/diff/index.html) (expected diff) with this [config](https://gist.githubusercontent.com/mahfouz72/ce878f7db10dd474a7f6aa53ada50c7c/raw/68d7ec7bcef08b49d6deaa712d2e18cf8c328dcd/check1.xml) to check that we raise a violation to move variable near to the block when `validateBetweenScopes` is off as stated in the issue