### PR TITLE
Issue #13999: PitestSuppression foundThrows.add

### DIFF
--- a/config/pitest-suppressions/pitest-javadoc-suppressions.xml
+++ b/config/pitest-suppressions/pitest-javadoc-suppressions.xml
@@ -102,24 +102,6 @@
   <mutation unstable="false">
     <sourceFile>JavadocMethodCheck.java</sourceFile>
     <mutatedClass>com.puppycrawl.tools.checkstyle.checks.javadoc.JavadocMethodCheck</mutatedClass>
-    <mutatedMethod>processThrows</mutatedMethod>
-    <mutator>org.pitest.mutationtest.engine.gregor.mutators.NonVoidMethodCallMutator</mutator>
-    <description>removed call to com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocMethodCheck$Token::getText</description>
-    <lineContent>foundThrows.add(documentedClassInfo.getName().getText());</lineContent>
-  </mutation>
-
-  <mutation unstable="false">
-    <sourceFile>JavadocMethodCheck.java</sourceFile>
-    <mutatedClass>com.puppycrawl.tools.checkstyle.checks.javadoc.JavadocMethodCheck</mutatedClass>
-    <mutatedMethod>processThrows</mutatedMethod>
-    <mutator>org.pitest.mutationtest.engine.gregor.mutators.NonVoidMethodCallMutator</mutator>
-    <description>removed call to java/util/Set::add</description>
-    <lineContent>foundThrows.add(documentedClassInfo.getName().getText());</lineContent>
-  </mutation>
-
-  <mutation unstable="false">
-    <sourceFile>JavadocMethodCheck.java</sourceFile>
-    <mutatedClass>com.puppycrawl.tools.checkstyle.checks.javadoc.JavadocMethodCheck</mutatedClass>
     <mutatedMethod>shouldCheck</mutatedMethod>
     <mutator>org.pitest.mutationtest.engine.gregor.mutators.RemoveConditionalMutator_EQUAL_IF</mutator>
     <description>removed conditional - replaced equality check with true</description>

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocMethodCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocMethodCheck.java
@@ -921,7 +921,7 @@ public class JavadocMethodCheck extends AbstractCheck {
             final Token token = new Token(tag.getFirstArg(), tag.getLineNo(), tag
                     .getColumnNo());
             final ClassInfo documentedClassInfo = new ClassInfo(token);
-            processThrows(throwsList, documentedClassInfo, foundThrows);
+            processThrows(throwsList, documentedClassInfo);
         }
         // Now dump out all throws without tags :- unless
         // the user has chosen to suppress these problems
@@ -941,10 +941,9 @@ public class JavadocMethodCheck extends AbstractCheck {
      *
      * @param throwsIterable collection of throws
      * @param documentedClassInfo documented exception class info
-     * @param foundThrows previously found throws
      */
     private static void processThrows(Iterable<ExceptionInfo> throwsIterable,
-                                      ClassInfo documentedClassInfo, Set<String> foundThrows) {
+                                      ClassInfo documentedClassInfo) {
         ExceptionInfo foundException = null;
 
         // First look for matches on the exception name
@@ -958,7 +957,6 @@ public class JavadocMethodCheck extends AbstractCheck {
 
         if (foundException != null) {
             foundException.setFound();
-            foundThrows.add(documentedClassInfo.getName().getText());
         }
     }
 


### PR DESCRIPTION
Issue: #13999 :
Resolve PitestSuppression: foundThrows.add. I am trying to resolve removed call to java/util/Set::add first
Thanks @Zopsss for the config and proj files.
Regression
Diff Regression config: https://gist.githubusercontent.com/Zopsss/e5c173e3f7d020c335e73260cabc8c25/raw/c15d7975221b4eca529841f31631860b1e10ef50/JavadocMethod.xml

Diff Regression projects: https://gist.githubusercontent.com/Zopsss/22adadb570e4deb95296917244c580b3/raw/29ea756eada8915637b76678db4f46048c198808/projects-to-test-on-for-github-action.properties

Report label: JavadocMethod-1