### PR TITLE
Issue #14502: Handling of whitespace between generic and record header (GenericWhitespaceCheck)

### DIFF
--- a/src/main/resources/com/puppycrawl/tools/checkstyle/meta/checks/whitespace/GenericWhitespaceCheck.xml
+++ b/src/main/resources/com/puppycrawl/tools/checkstyle/meta/checks/whitespace/GenericWhitespaceCheck.xml
@@ -26,7 +26,8 @@
  &lt;ul&gt;
  &lt;li&gt; should not be preceded with whitespace in all cases.&lt;/li&gt;
  &lt;li&gt; should be followed with whitespace in almost all cases,
-   except diamond operators and when preceding method name or constructor.&lt;/li&gt;&lt;/ul&gt;</description>
+   except diamond operators and when preceding a method name, constructor, or record header.&lt;/li&gt;
+ &lt;/ul&gt;</description>
          <message-keys>
             <message-key key="ws.followed"/>
             <message-key key="ws.illegalFollow"/>

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/whitespace/GenericWhitespaceCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/whitespace/GenericWhitespaceCheckTest.java
@@ -228,7 +228,45 @@ public class GenericWhitespaceCheckTest
 
     @Test
     public void testBeforeRecordHeader() throws Exception {
-        final String[] expected = CommonUtil.EMPTY_STRING_ARRAY;
+        final String[] expected = {
+            "17:20: " + getCheckMessage(MSG_WS_FOLLOWED, '>'),
+            "18:20: " + getCheckMessage(MSG_WS_FOLLOWED, '<'),
+            "18:20: " + getCheckMessage(MSG_WS_PRECEDED, '<'),
+            "18:24: " + getCheckMessage(MSG_WS_FOLLOWED, '>'),
+            "18:24: " + getCheckMessage(MSG_WS_PRECEDED, '>'),
+            "30:27: " + getCheckMessage(MSG_WS_FOLLOWED, '>'),
+            "30:38: " + getCheckMessage(MSG_WS_PRECEDED, '<'),
+            "30:80: " + getCheckMessage(MSG_WS_ILLEGAL_FOLLOW, '>'),
+            "36:38: " + getCheckMessage(MSG_WS_FOLLOWED, '>'),
+            "43:44: " + getCheckMessage(MSG_WS_PRECEDED, '<'),
+            "43:69: " + getCheckMessage(MSG_WS_FOLLOWED, '>'),
+            "49:21: " + getCheckMessage(MSG_WS_PRECEDED, '<'),
+            "49:64: " + getCheckMessage(MSG_WS_PRECEDED, '>'),
+            "49:66: " + getCheckMessage(MSG_WS_FOLLOWED, '>'),
+            "56:63: " + getCheckMessage(MSG_WS_PRECEDED, '<'),
+            "56:80: " + getCheckMessage(MSG_WS_FOLLOWED, '>'),
+            "62:36: " + getCheckMessage(MSG_WS_PRECEDED, '<'),
+            "62:61: " + getCheckMessage(MSG_WS_FOLLOWED, '>'),
+            "67:49: " + getCheckMessage(MSG_WS_FOLLOWED, '>'),
+            "73:26: " + getCheckMessage(MSG_WS_PRECEDED, '<'),
+            "73:51: " + getCheckMessage(MSG_WS_FOLLOWED, '>'),
+            "73:64: " + getCheckMessage(MSG_WS_FOLLOWED, '<'),
+            "80:26: " + getCheckMessage(MSG_WS_PRECEDED, '<'),
+            "80:34: " + getCheckMessage(MSG_WS_FOLLOWED, '<'),
+            "80:55: " + getCheckMessage(MSG_WS_ILLEGAL_FOLLOW, '>'),
+            "91:25: " + getCheckMessage(MSG_WS_FOLLOWED, '>'),
+            "91:44: " + getCheckMessage(MSG_WS_PRECEDED, '<'),
+            "91:47: " + getCheckMessage(MSG_WS_PRECEDED, '>'),
+            "91:61: " + getCheckMessage(MSG_WS_PRECEDED, '<'),
+            "91:71: " + getCheckMessage(MSG_WS_FOLLOWED, '>'),
+            "91:73: " + getCheckMessage(MSG_WS_PRECEDED, '>'),
+            "101:25: " + getCheckMessage(MSG_WS_PRECEDED, '<'),
+            "101:58: " + getCheckMessage(MSG_WS_FOLLOWED, '>'),
+            "108:25: " + getCheckMessage(MSG_WS_PRECEDED, '<'),
+            "108:32: " + getCheckMessage(MSG_WS_FOLLOWED, '>'),
+            "108:46: " + getCheckMessage(MSG_WS_FOLLOWED, '<'),
+            "108:63: " + getCheckMessage(MSG_WS_FOLLOWED, '>'),
+        };
         verifyWithInlineConfigParser(
                 getNonCompilablePath("InputGenericWhitespaceBeforeRecordHeader.java"),
                 expected);

--- a/src/test/resources-noncompilable/com/puppycrawl/tools/checkstyle/checks/whitespace/genericwhitespace/InputGenericWhitespaceBeforeRecordHeader.java
+++ b/src/test/resources-noncompilable/com/puppycrawl/tools/checkstyle/checks/whitespace/genericwhitespace/InputGenericWhitespaceBeforeRecordHeader.java
@@ -4,9 +4,116 @@ GenericWhitespace
 
 */
 
-//non-compiled with javac: Compilable with Java16
+//non-compiled with javac: Compilable with Java21
 package com.puppycrawl.tools.checkstyle.checks.whitespace.genericwhitespace;
 
+import java.lang.annotation.Target;
+import java.util.HashMap;
+
+import static java.lang.annotation.ElementType.TYPE_USE;
+
 public class InputGenericWhitespaceBeforeRecordHeader {
-    record Session<T>() {}
+    record License<T>() {}
+    record Person<T> () {} // violation, ''>' is followed by whitespace.'
+    record Session < T > (T a) {}
+    // 4 violations above:
+    //                    ''<' is followed by whitespace.'
+    //                    ''<' is preceded with whitespace.'
+    //                    ''>' is followed by whitespace.'
+    //                    ''>' is preceded with whitespace.'
+
+    class InnerClass {
+        static <T> void innerMethod(T a) {}
+        static <T> void innerMethod(T a, boolean isSession) {}
+        record Participant<T>() {
+            //            +          +                                         +
+            record Stats<T> (HashMap <String, Session<HashMap<String, Integer>>>stats) {
+                // 3 violations above:
+                //                    ''>' is followed by whitespace.'
+                //                    ''<' is preceded with whitespace.'
+                //                    ''>' is followed by an illegal character.'
+
+                record Achievements<T> () {} // violation, ''>' is followed by whitespace.'
+            }
+        }
+    }
+
+    int method(Session<HashMap<String, Integer>> ssn) {
+        //                                 +                        +
+        InnerClass.innerMethod(new Session <HashMap<Integer, String>> (new HashMap()));
+        // 2 violations above:
+        //                    ''<' is preceded with whitespace.'
+        //                    ''>' is followed by whitespace.'
+
+        //          +                                          + +
+        new License <@A Session<HashMap<@A Session, @A Session >>> ();
+        // 3 violations above:
+        //                    ''<' is preceded with whitespace.'
+        //                    ''>' is preceded with whitespace.'
+        //                    ''>' is followed by whitespace.'
+
+        //                                                    +                +
+        new InnerClass.Participant.Stats.Achievements<Session <License<String>>> ();
+        // 2 violations above:
+        //                   ''<' is preceded with whitespace.'
+        //                   ''>' is followed by whitespace.'
+
+        //                         +                        +
+        if (ssn instanceof Session <HashMap<String, Integer>> (var sess)) {
+            // 2 violations above:
+            //                    ''<' is preceded with whitespace.'
+            //                    ''>' is followed by whitespace.'
+
+            InnerClass.innerMethod(new Session<?> []{}, true);
+            // violation above, ''>' is followed by whitespace.'
+        }
+
+        return switch (ssn) {
+            //           +                        +            +
+            case Session <HashMap<String, Integer>> (@A HashMap< @A String, Integer> hm) -> 1;
+            //  3 violations above:
+            //                     ''<' is preceded with whitespace.'
+            //                     ''>' is followed by whitespace.'
+            //                     ''<' is followed by whitespace.'
+
+            //           +       +                    +
+            case Session <HashMap< @A String, Integer>>sess -> 1;
+            // 3 violations above:
+            //                    ''<' is preceded with whitespace.'
+            //                    ''<' is followed by whitespace.'
+            //                    ''>' is followed by an illegal character.'
+        };
+    }
+
+    static {
+        new Object() {
+            //          +                  +  +             +         + +
+            record Sys<T> (Session<Session <T >> p, Session <Session<T> > q) {}
+            // 6 violations above:
+            //                    ''>' is followed by whitespace.'
+            //                    ''<' is preceded with whitespace.'
+            //                    ''>' is preceded with whitespace.'
+            //                    ''<' is preceded with whitespace.'
+            //                    ''>' is followed by whitespace.'
+            //                    ''>' is preceded with whitespace.'
+
+            //          +                                +
+            record Game <T extends Number & Comparable<T>> (T guess) {}
+            // 2 violations above:
+            //                    ''<' is preceded with whitespace.'
+            //                    ''>' is followed by whitespace.'
+
+            void method() {
+                //      +      +             +                +
+                new Sys <String> (new Session< Session<String>> (new Session<>("a")), null);
+                // 4 violations above:
+                //                    ''<' is preceded with whitespace.'
+                //                    ''>' is followed by whitespace.'
+                //                    ''<' is followed by whitespace.'
+                //                    ''>' is followed by whitespace.'
+            }
+        };
+    }
+
+    @Target({TYPE_USE}) @interface A {}
 }

--- a/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/whitespace/genericwhitespace/Example1.txt
+++ b/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/whitespace/genericwhitespace/Example1.txt
@@ -23,4 +23,6 @@ List<T> list = ImmutableList.Builder<T>::new;
 sort(list, Comparable::<String>compareTo);
 // Constructor call
 MyClass obj = new <String>MyClass();
+// Record header
+record License<T>() {}
 // xdoc section -- end

--- a/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/whitespace/genericwhitespace/Example2.txt
+++ b/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/whitespace/genericwhitespace/Example2.txt
@@ -14,4 +14,6 @@ public<T> void foo() {} // violation, "<" not preceded with whitespace
 List a = new ArrayList<> (); // violation, ">" followed by whitespace
 Map<Integer, String>m; // violation, ">" not followed by whitespace
 Pair<Integer, Integer > p; // violation, ">" preceded with whitespace
+
+record License<T> () {} // violation, ">" followed by whitespace
 // xdoc section -- end

--- a/src/xdocs/checks/whitespace/genericwhitespace.xml
+++ b/src/xdocs/checks/whitespace/genericwhitespace.xml
@@ -30,7 +30,7 @@
         <ul>
           <li> should not be preceded with whitespace in all cases.</li>
           <li> should be followed with whitespace in almost all cases, except diamond operators
-               and when preceding method name or constructor.</li>
+            and when preceding a method name, constructor, or record header.</li>
         </ul>
       </subsection>
 
@@ -65,6 +65,8 @@ List&lt;T&gt; list = ImmutableList.Builder&lt;T&gt;::new;
 sort(list, Comparable::&lt;String&gt;compareTo);
 // Constructor call
 MyClass obj = new &lt;String&gt;MyClass();
+// Record header
+record License&lt;T&gt;() {}
         </source>
         <p id="Example2-code">
           Examples with incorrect spacing:
@@ -77,6 +79,8 @@ public&lt;T&gt; void foo() {} // violation, &quot;&lt;&quot; not preceded with w
 List a = new ArrayList&lt;&gt; (); // violation, &quot;&gt;&quot; followed by whitespace
 Map&lt;Integer, String&gt;m; // violation, &quot;&gt;&quot; not followed by whitespace
 Pair&lt;Integer, Integer &gt; p; // violation, &quot;&gt;&quot; preceded with whitespace
+
+record License&lt;T&gt; () {} // violation, &quot;&gt;&quot; followed by whitespace
         </source>
       </subsection>
 

--- a/src/xdocs/checks/whitespace/genericwhitespace.xml.template
+++ b/src/xdocs/checks/whitespace/genericwhitespace.xml.template
@@ -30,7 +30,7 @@
         <ul>
           <li> should not be preceded with whitespace in all cases.</li>
           <li> should be followed with whitespace in almost all cases, except diamond operators
-               and when preceding method name or constructor.</li>
+            and when preceding a method name, constructor, or record header.</li>
         </ul>
       </subsection>
 


### PR DESCRIPTION
Resolves #14502 

Reasoning for the changes are mentioned in the comments.

Old Doc([site](https://checkstyle.org/checks/whitespace/genericwhitespace.html)), New Doc([site](https://checkstyle-diff-reports.s3.us-east-2.amazonaws.com/05dd30d_2024155912/checks/whitespace/genericwhitespace.html#Description))
<hr>

#### Regression: ([Report](https://checkstyle-diff-reports.s3.us-east-2.amazonaws.com/e3fa404_2024081446/reports/diff/index.html))

Differences found (expected)
- **Added Violations (4)**: Example (rest occurrences are similar) ([link](https://checkstyle-diff-reports.s3.us-east-2.amazonaws.com/e3fa404_2024081446/reports/diff/checkstyle/xref/home/runner/work/checkstyle/checkstyle/.ci-temp/contribution/checkstyle-tester/repositories/checkstyle/src/it/resources-noncompilable/org/checkstyle/suppressionxpathfilter/recordtypeparametername/SuppressionXpathRegressionRecordTypeParameterName1.java.html#L7))
This is intended behaviour of the fix, whitespace between generic and record header is counted as violation.

Diff Regression config: https://gist.githubusercontent.com/sktpy/44a31ea4e946a0755fa3e331fd65de98/raw/bc9e57764a6ef5b9f4aa27bcb6f55115460423bb/check.xml