### PR TITLE
 Fix "Parameter endIndex should be final" 

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/JavadocPropertiesGenerator.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/JavadocPropertiesGenerator.java
@@ -228,7 +228,7 @@ public final class JavadocPropertiesGenerator {
      *      malformed (does not end with any of the end-of-sentence markers)
      * @throws CheckstyleException if an unsupported inline tag found
      */
-    private static String getFirstJavadocSentence(DetailNode tree) throws CheckstyleException {
+    private static String getFirstJavadocSentence(final DetailNode tree) throws CheckstyleException {
         String firstSentence = null;
         final StringBuilder builder = new StringBuilder(128);
         for (DetailNode node : tree.getChildren()) {
@@ -260,7 +260,7 @@ public final class JavadocPropertiesGenerator {
      * @param inlineTag to format
      * @throws CheckstyleException if the inline javadoc tag is not a literal nor a code tag
      */
-    private static void formatInlineCodeTag(StringBuilder builder, DetailNode inlineTag)
+    private static void formatInlineCodeTag(final StringBuilder builder, final DetailNode inlineTag)
             throws CheckstyleException {
         boolean wrapWithCodeTag = false;
         for (DetailNode node : inlineTag.getChildren()) {
@@ -296,7 +296,7 @@ public final class JavadocPropertiesGenerator {
      * @param builder to append
      * @param node to format
      */
-    private static void formatHtmlElement(StringBuilder builder, DetailNode node) {
+    private static void formatHtmlElement(final StringBuilder builder, final DetailNode node) {
         switch (node.getType()) {
             case JavadocTokenTypes.START:
             case JavadocTokenTypes.HTML_TAG_NAME:

--- a/src/main/java/com/puppycrawl/tools/checkstyle/Main.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/Main.java
@@ -108,7 +108,7 @@ public final class Main {
      *      show all details in case of failure
      * @noinspectionreason CallToSystemExit - driver class must call exit
      **/
-    public static void main(String... args) throws IOException {
+    public static void main(final String... args) throws IOException {
 
         final CliOptions cliOptions = new CliOptions();
         final CommandLine commandLine = new CommandLine(cliOptions);
@@ -178,7 +178,7 @@ public final class Main {
      * @noinspectionreason UseOfSystemOutOrSystemErr - driver class for Checkstyle requires
      *      usage of System.out and System.err
      */
-    private static int execute(ParseResult parseResult, CliOptions options)
+    private static int execute(final ParseResult parseResult, final CliOptions options)
             throws IOException, CheckstyleException {
 
         final int exitStatus;
@@ -203,7 +203,7 @@ public final class Main {
      * @param options the user-specified options
      * @return list of files to process
      */
-    private static List<File> getFilesToProcess(CliOptions options) {
+    private static List<File> getFilesToProcess(final CliOptions options) {
         final List<Pattern> patternsToExclude = options.getExclusions();
 
         final List<File> result = new LinkedList<>();
@@ -223,7 +223,7 @@ public final class Main {
      *        files.
      * @return found files
      */
-    private static List<File> listFiles(File node, List<Pattern> patternsToExclude) {
+    private static List<File> listFiles(final File node, final List<Pattern> patternsToExclude) {
         // could be replaced with org.apache.commons.io.FileUtils.list() method
         // if only we add commons-io library
         final List<File> result = new LinkedList<>();
@@ -254,7 +254,7 @@ public final class Main {
      *        or being added as files.
      * @return True if the directory/file matches one of the patterns.
      */
-    private static boolean isPathExcluded(String path, Iterable<Pattern> patternsToExclude) {
+    private static boolean isPathExcluded(final String path, final Iterable<Pattern> patternsToExclude) {
         boolean result = false;
 
         for (Pattern pattern : patternsToExclude) {
@@ -279,7 +279,7 @@ public final class Main {
      * @noinspectionreason UseOfSystemOutOrSystemErr - driver class for Checkstyle requires
      *      usage of System.out and System.err
      */
-    private static int runCli(CliOptions options, List<File> filesToProcess)
+    private static int runCli(final CliOptions options, final List<File> filesToProcess)
             throws IOException, CheckstyleException {
         int result = 0;
         final boolean hasSuppressionLineColumnNumber = options.suppressionLineColumnNumber != null;
@@ -352,7 +352,7 @@ public final class Main {
      * @throws CheckstyleException
      *         when properties file could not be loaded
      */
-    private static int runCheckstyle(CliOptions options, List<File> filesToProcess)
+    private static int runCheckstyle(final CliOptions options, final List<File> filesToProcess)
             throws CheckstyleException, IOException {
         // setup the properties
         final Properties props;
@@ -457,7 +457,7 @@ public final class Main {
      * @return The new instance of the root module.
      * @throws CheckstyleException if no module can be instantiated from name
      */
-    private static RootModule getRootModule(String name, ClassLoader moduleClassLoader)
+    private static RootModule getRootModule(final String name, final ClassLoader moduleClassLoader)
             throws CheckstyleException {
         final ModuleFactory factory = new PackageObjectFactory(
                 Checker.class.getPackage().getName(), moduleClassLoader);
@@ -471,7 +471,7 @@ public final class Main {
      * @param config The configuration object.
      * @return The {@code TreeWalker} module configuration.
      */
-    private static Configuration getTreeWalkerConfig(Configuration config) {
+    private static Configuration getTreeWalkerConfig(final Configuration config) {
         Configuration result = null;
 
         final Configuration[] children = config.getChildren();
@@ -494,7 +494,7 @@ public final class Main {
      * @return a fresh new {@code AuditListener}
      * @exception IOException when provided output location is not found
      */
-    private static AuditListener createListener(OutputFormat format, Path outputLocation)
+    private static AuditListener createListener(final OutputFormat format, final Path outputLocation)
             throws IOException {
         final OutputStream out = getOutputStream(outputLocation);
         final OutputStreamOptions closeOutputStreamOption =
@@ -513,7 +513,7 @@ public final class Main {
      *      usage of System.out and System.err
      */
     @SuppressWarnings("resource")
-    private static OutputStream getOutputStream(Path outputPath) throws IOException {
+    private static OutputStream getOutputStream(final Path outputPath) throws IOException {
         final OutputStream result;
         if (outputPath == null) {
             result = System.out;
@@ -564,8 +564,8 @@ public final class Main {
          * @throws IOException if there is any IO exception during logger initialization
          */
         public AuditListener createListener(
-            OutputStream out,
-            OutputStreamOptions options) throws IOException {
+            final OutputStream out,
+            final OutputStreamOptions options) throws IOException {
             final AuditListener result;
             if (this == XML) {
                 result = new XMLLogger(out, options);
@@ -602,7 +602,7 @@ public final class Main {
          * @return true if the logger name is in the package of this class or a subpackage
          */
         @Override
-        public boolean isLoggable(LogRecord logRecord) {
+        public boolean isLoggable(final LogRecord logRecord) {
             return logRecord.getLoggerName().startsWith(packageName);
         }
     }
@@ -817,7 +817,7 @@ public final class Main {
          * @return list of violations
          */
         // -@cs[CyclomaticComplexity] Breaking apart will damage encapsulation
-        private List<String> validateCli(ParseResult parseResult, List<File> filesToProcess) {
+        private List<String> validateCli(final ParseResult parseResult, final List<File> filesToProcess) {
             final List<String> result = new ArrayList<>();
             final boolean hasConfigurationFile = configurationFile != null;
             final boolean hasSuppressionLineColumnNumber = suppressionLineColumnNumber != null;

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/naming/AbbreviationAsWordInNameCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/naming/AbbreviationAsWordInNameCheck.java
@@ -185,7 +185,7 @@ public class AbbreviationAsWordInNameCheck extends AbstractCheck {
      *        Defines if ignore variables with 'final' modifier or not.
      * @since 5.8
      */
-    public void setIgnoreFinal(boolean ignoreFinal) {
+    public void setIgnoreFinal(final boolean ignoreFinal) {
         this.ignoreFinal = ignoreFinal;
     }
 
@@ -207,7 +207,7 @@ public class AbbreviationAsWordInNameCheck extends AbstractCheck {
      *        Defines if ignore variables with both 'static' and 'final' modifiers or not.
      * @since 8.32
      */
-    public void setIgnoreStaticFinal(boolean ignoreStaticFinal) {
+    public void setIgnoreStaticFinal(final boolean ignoreStaticFinal) {
         this.ignoreStaticFinal = ignoreStaticFinal;
     }
 
@@ -243,7 +243,7 @@ public class AbbreviationAsWordInNameCheck extends AbstractCheck {
      *        skipped from checking.
      * @since 5.8
      */
-    public void setAllowedAbbreviations(String... allowedAbbreviations) {
+    public void setAllowedAbbreviations(final String... allowedAbbreviations) {
         if (allowedAbbreviations != null) {
             this.allowedAbbreviations =
                 Arrays.stream(allowedAbbreviations).collect(Collectors.toUnmodifiableSet());
@@ -291,7 +291,7 @@ public class AbbreviationAsWordInNameCheck extends AbstractCheck {
     }
 
     @Override
-    public void visitToken(DetailAST ast) {
+    public void visitToken(final DetailAST ast) {
         if (!isIgnoreSituation(ast)) {
             final DetailAST nameAst = ast.findFirstToken(TokenTypes.IDENT);
             final String typeName = nameAst.getText();
@@ -310,7 +310,7 @@ public class AbbreviationAsWordInNameCheck extends AbstractCheck {
      * @return true if it is an ignore situation found for given input DetailAST
      *         node.
      */
-    private boolean isIgnoreSituation(DetailAST ast) {
+    private boolean isIgnoreSituation(final DetailAST ast) {
         final DetailAST modifiers = ast.getFirstChild();
 
         final boolean result;
@@ -338,7 +338,7 @@ public class AbbreviationAsWordInNameCheck extends AbstractCheck {
      * @param modifiers modifiers of the variable to be checked
      * @return true if there is a modifier to be ignored
      */
-    private boolean hasIgnoredModifiers(DetailAST modifiers) {
+    private boolean hasIgnoredModifiers(final DetailAST modifiers) {
         final boolean isStatic = modifiers.findFirstToken(TokenTypes.LITERAL_STATIC) != null;
         final boolean isFinal = modifiers.findFirstToken(TokenTypes.FINAL) != null;
         final boolean result;
@@ -358,7 +358,7 @@ public class AbbreviationAsWordInNameCheck extends AbstractCheck {
      * @return true if variable definition(variableDefAst) is in interface
      *     or @interface definition.
      */
-    private static boolean isInterfaceDeclaration(DetailAST variableDefAst) {
+    private static boolean isInterfaceDeclaration(final DetailAST variableDefAst) {
         boolean result = false;
         final DetailAST astBlock = variableDefAst.getParent();
         final DetailAST astParent2 = astBlock.getParent();
@@ -378,7 +378,7 @@ public class AbbreviationAsWordInNameCheck extends AbstractCheck {
      *        (MODIFIERS type).
      * @return true if method has "@Override" annotation.
      */
-    private static boolean hasOverrideAnnotation(DetailAST methodModifiersAST) {
+    private static boolean hasOverrideAnnotation(final DetailAST methodModifiersAST) {
         boolean result = false;
         for (DetailAST child : getChildren(methodModifiersAST)) {
             final DetailAST annotationIdent = child.findFirstToken(TokenTypes.IDENT);
@@ -399,7 +399,7 @@ public class AbbreviationAsWordInNameCheck extends AbstractCheck {
      * @return the disallowed abbreviation contained in given String as a
      *         separate String.
      */
-    private String getDisallowedAbbreviation(String str) {
+    private String getDisallowedAbbreviation(final String str) {
         int beginIndex = 0;
         boolean abbrStarted = false;
         String result = null;
@@ -452,8 +452,8 @@ public class AbbreviationAsWordInNameCheck extends AbstractCheck {
      * @return the abbreviation if it is bigger than required and not in the
      *         ignore list, otherwise {@code null}
      */
-    private String getAbbreviationIfIllegal(String str, int beginIndex, int endIndex,
-                                            int allowedLength) {
+    private String getAbbreviationIfIllegal(final String str, final int beginIndex, final int endIndex,
+                                            final int allowedLength) {
         String result = null;
         final int abbrLength = endIndex - beginIndex;
         if (abbrLength > allowedLength) {
@@ -483,7 +483,7 @@ public class AbbreviationAsWordInNameCheck extends AbstractCheck {
      * @param endIndex end index
      * @return the specified abbreviation
      */
-    private static String getAbbreviation(String str, int beginIndex, int endIndex) {
+    private static String getAbbreviation(final String str, final int beginIndex, final int endIndex) {
         final String result;
         if (endIndex == str.length() - 1) {
             result = str.substring(beginIndex);


### PR DESCRIPTION
 **utilizing final parameters in method signatures improves code clarity, prevents unintended side effects, enhances thread safety, potentially optimizes code execution, and reinforces good coding practices.**