### PR TITLE
Issue #14137: Enable `Slf4jLogStatement` check

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -254,6 +254,7 @@
       -Xep:NestedOptionals:ERROR
       -Xep:PrimitiveComparison:ERROR
       -Xep:RedundantStringConversion:ERROR
+      -Xep:Slf4jLogStatement:ERROR
       -Xep:StringJoin:ERROR
       -Xep:TimeZoneUsage:ERROR
       <!-- Reason at https://github.com/checkstyle/checkstyle/issues/8252. -->


### PR DESCRIPTION
Issue #14137.

This PR enables the https://error-prone.picnic.tech/bugpatterns/Slf4jLogStatement/ check.