### PR TITLE
Issue #14436: Enforce Naming Convention for MissingCtor

### DIFF
--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/coding/MissingCtorCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/coding/MissingCtorCheckTest.java
@@ -69,7 +69,7 @@ public class MissingCtorCheckTest extends AbstractModuleTestSupport {
         };
 
         verifyWithInlineConfigParser(
-                getPath("InputMissingCtor2.java"),
+                getPath("InputMissingCtorNestedClasses.java"),
                 expected);
     }
 

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/missingctor/InputMissingCtorNestedClasses.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/missingctor/InputMissingCtorNestedClasses.java
@@ -6,7 +6,7 @@ MissingCtor
 
 package com.puppycrawl.tools.checkstyle.checks.coding.missingctor;
 
-public class InputMissingCtor2 { // violation
+public class InputMissingCtorNestedClasses { // violation
     class Inner1 { // violation
         class Inner2 { // violation
 


### PR DESCRIPTION
Issue #14436 
InputMissingCtor2.java -> InputMissingCtorNestedClasses.java
Still need to change MissingCtorCheckTest.java.
