### PR TITLE
Issue #11340: Add ignoreAnnotatedBy property to ParameterNumberCheck

### DIFF
--- a/src/it/java/org/checkstyle/suppressionxpathfilter/XpathRegressionParameterNumberTest.java
+++ b/src/it/java/org/checkstyle/suppressionxpathfilter/XpathRegressionParameterNumberTest.java
@@ -103,4 +103,30 @@ public class XpathRegressionParameterNumberTest extends AbstractXpathTestSupport
         runVerifications(moduleConfig, fileToProcess, expectedViolations, expectedXpathQueries);
     }
 
+    @Test
+    public void testIgnoreAnnotatedBy() throws Exception {
+        final String filePath =
+                getPath("SuppressionXpathRegressionParameterNumberIgnoreAnnotatedBy.java");
+        final File fileToProcess = new File(filePath);
+
+        final DefaultConfiguration moduleConfig = createModuleConfig(ParameterNumberCheck.class);
+        moduleConfig.addProperty("ignoreAnnotatedBy", "MyAnno");
+        moduleConfig.addProperty("max", "2");
+
+        final String[] expectedViolations = {
+            "15:34: " + getCheckMessage(ParameterNumberCheck.class, MSG_KEY, 2, 3),
+        };
+
+        final List<String> expectedXpathQueries = Collections.singletonList(
+                "/COMPILATION_UNIT/CLASS_DEF"
+                + "[./IDENT[@text='SuppressionXpathRegressionParameterNumberIgnoreAnnotatedBy']]"
+                + "/OBJBLOCK/CLASS_DEF[./IDENT[@text='InnerClass']]"
+                + "/OBJBLOCK/STATIC_INIT/SLIST/EXPR/LITERAL_NEW[./IDENT[@text='Object']]"
+                + "/OBJBLOCK/METHOD_DEF[./IDENT[@text='method']]"
+                + "/SLIST/LITERAL_IF/SLIST/EXPR/LITERAL_NEW[./IDENT[@text='Object']]"
+                + "/OBJBLOCK/METHOD_DEF/IDENT[@text='checkedMethod']"
+        );
+
+        runVerifications(moduleConfig, fileToProcess, expectedViolations, expectedXpathQueries);
+    }
 }

--- a/src/it/resources/org/checkstyle/suppressionxpathfilter/parameternumber/SuppressionXpathRegressionParameterNumberIgnoreAnnotatedBy.java
+++ b/src/it/resources/org/checkstyle/suppressionxpathfilter/parameternumber/SuppressionXpathRegressionParameterNumberIgnoreAnnotatedBy.java
@@ -1,0 +1,26 @@
+package org.checkstyle.suppressionxpathfilter.parameternumber;
+
+public class SuppressionXpathRegressionParameterNumberIgnoreAnnotatedBy {
+    static class InnerClass {
+        static {
+            new Object() {
+                void method() {
+                    if (true) {
+                        new Object() {
+                            @MyAnno
+                            void ignoredMethod(int a, @MyAnno int b, int c) {
+
+                            }
+
+                            void checkedMethod(int a, @MyAnno int b, int c) { // warn
+
+                            }
+                        };
+                    }
+                }
+            };
+        }
+    }
+
+    @interface MyAnno {}
+}

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/sizes/ParameterNumberCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/sizes/ParameterNumberCheck.java
@@ -19,6 +19,9 @@
 
 package com.puppycrawl.tools.checkstyle.checks.sizes;
 
+import java.util.Collections;
+import java.util.Set;
+
 import com.puppycrawl.tools.checkstyle.StatelessCheck;
 import com.puppycrawl.tools.checkstyle.api.AbstractCheck;
 import com.puppycrawl.tools.checkstyle.api.DetailAST;
@@ -31,6 +34,12 @@ import com.puppycrawl.tools.checkstyle.utils.CommonUtil;
  * Checks the number of parameters of a method or constructor.
  * </p>
  * <ul>
+ * <li>
+ * Property {@code ignoreAnnotatedBy} - Ignore methods and constructors
+ * annotated with the specified annotation(s).
+ * Type is {@code java.lang.String[]}.
+ * Default value is {@code ""}.
+ * </li>
  * <li>
  * Property {@code ignoreOverriddenMethods} - Ignore number of parameters for
  * methods with {@code @Override} annotation.
@@ -87,6 +96,11 @@ public class ParameterNumberCheck
     private boolean ignoreOverriddenMethods;
 
     /**
+     * Ignore methods and constructors annotated with the specified annotation(s).
+     */
+    private Set<String> ignoreAnnotatedBy = Collections.emptySet();
+
+    /**
      * Setter to specify the maximum number of parameters allowed.
      *
      * @param max the max allowed parameters
@@ -104,6 +118,16 @@ public class ParameterNumberCheck
      */
     public void setIgnoreOverriddenMethods(boolean ignoreOverriddenMethods) {
         this.ignoreOverriddenMethods = ignoreOverriddenMethods;
+    }
+
+    /**
+     * Setter to ignore methods and constructors annotated with the specified annotation(s).
+     *
+     * @param annotationNames specified annotation(s)
+     * @since 10.15.0
+     */
+    public void setIgnoreAnnotatedBy(String... annotationNames) {
+        ignoreAnnotatedBy = Set.of(annotationNames);
     }
 
     @Override
@@ -132,16 +156,33 @@ public class ParameterNumberCheck
     }
 
     /**
-     * Determine whether to ignore number of parameters for the method.
+     * Determine whether to ignore number of parameters.
      *
      * @param ast the token to process
-     * @return true if this is overridden method and number of parameters should be ignored
-     *         false otherwise
+     * @return true if number of parameters should be ignored.
      */
     private boolean shouldIgnoreNumberOfParameters(DetailAST ast) {
-        // if you override a method, you have no power over the number of parameters
-        return ignoreOverriddenMethods
-                && AnnotationUtil.hasOverrideAnnotation(ast);
+        return isIgnoredOverriddenMethod(ast) || isAnnotatedByIgnoredAnnotations(ast);
+    }
+
+    /**
+     * Checks if method is overridden and should be ignored.
+     *
+     * @param ast method definition to check
+     * @return true if method is overridden and should be ignored.
+     */
+    private boolean isIgnoredOverriddenMethod(DetailAST ast) {
+        return ignoreOverriddenMethods && AnnotationUtil.hasOverrideAnnotation(ast);
+    }
+
+    /**
+     * Checks if method or constructor is annotated by ignored annotation(s).
+     *
+     * @param ast method or constructor definition to check
+     * @return true if annotated by ignored annotation(s).
+     */
+    private boolean isAnnotatedByIgnoredAnnotations(DetailAST ast) {
+        return AnnotationUtil.containsAnnotation(ast, ignoreAnnotatedBy);
     }
 
 }

--- a/src/main/resources/com/puppycrawl/tools/checkstyle/meta/checks/sizes/ParameterNumberCheck.xml
+++ b/src/main/resources/com/puppycrawl/tools/checkstyle/meta/checks/sizes/ParameterNumberCheck.xml
@@ -8,6 +8,10 @@
  Checks the number of parameters of a method or constructor.
  &lt;/p&gt;</description>
          <properties>
+            <property default-value="" name="ignoreAnnotatedBy" type="java.lang.String[]">
+               <description>Ignore methods and constructors
+ annotated with the specified annotation(s).</description>
+            </property>
             <property default-value="false" name="ignoreOverriddenMethods" type="boolean">
                <description>Ignore number of parameters for
  methods with {@code @Override} annotation.</description>

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/sizes/ParameterNumberCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/sizes/ParameterNumberCheckTest.java
@@ -123,4 +123,35 @@ public class ParameterNumberCheckTest
                 getPath("InputParameterNumber2.java"), expected);
     }
 
+    @Test
+    public void testIgnoreAnnotatedBy() throws Exception {
+        final String[] expected = {
+            "23:10: " + getCheckMessage(MSG_KEY, 2, 3),
+            "30:10: " + getCheckMessage(MSG_KEY, 2, 4),
+            "35:14: " + getCheckMessage(MSG_KEY, 2, 3),
+            "43:9: " + getCheckMessage(MSG_KEY, 2, 4),
+            "58:30: " + getCheckMessage(MSG_KEY, 2, 3),
+            "62:29: " + getCheckMessage(MSG_KEY, 2, 3),
+            "77:34: " + getCheckMessage(MSG_KEY, 2, 4),
+            "97:10: " + getCheckMessage(MSG_KEY, 2, 3),
+            "106:14: " + getCheckMessage(MSG_KEY, 2, 3),
+        };
+        verifyWithInlineConfigParser(
+                getPath("InputParameterNumberIgnoreAnnotatedBy.java"), expected);
+    }
+
+    @Test
+    public void testIgnoreAnnotatedByFullyQualifiedClassName() throws Exception {
+        final String[] expected = {
+            "15:10: " + getCheckMessage(MSG_KEY, 2, 3),
+            "17:10: " + getCheckMessage(MSG_KEY, 2, 3),
+            "23:10: " + getCheckMessage(MSG_KEY, 2, 3),
+            "27:10: " + getCheckMessage(MSG_KEY, 2, 3),
+            "41:14: " + getCheckMessage(MSG_KEY, 2, 3),
+            "45:14: " + getCheckMessage(MSG_KEY, 2, 3),
+        };
+        verifyWithInlineConfigParser(
+                getPath("InputParameterNumberIgnoreAnnotatedByFullyQualifiedClassName.java"),
+                expected);
+    }
 }

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/sizes/parameternumber/InputParameterNumberIgnoreAnnotatedBy.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/sizes/parameternumber/InputParameterNumberIgnoreAnnotatedBy.java
@@ -1,0 +1,115 @@
+/*
+ParameterNumber
+max = 2
+ignoreAnnotatedBy = MyAnno, Session
+
+*/
+
+package com.puppycrawl.tools.checkstyle.checks.sizes.parameternumber;
+
+public class InputParameterNumberIgnoreAnnotatedBy {
+    @MyAnno
+    InputParameterNumberIgnoreAnnotatedBy(int a, int b, int c) {}
+
+    void method1(int a, int b) {}
+
+    @MyAnno
+    void method2(int a, int b, int c) {}
+
+    @Session(uid = "Y2K")
+    void method3(int a, int b, int c, int d) {}
+
+    @Wawa
+    void method5(int a, int b, int c) { // violation, 'More than 2 parameters (found 3).'
+    }
+
+    @Wawa
+    void method6(int a, int b) {}
+
+
+    void method7(int a, int b, int c, int d) { // violation, 'More than 2 parameters (found 4).'
+    }
+
+    class InnerClass extends InputParameterNumberIgnoreAnnotatedBy {
+        @Override
+        void method2(int a, int b, int c) { // violation, 'More than 2 parameters (found 3).'
+            int d = a + c;
+        }
+
+        InnerClass(int a, int b) {
+            super(1, 2, 3);
+        }
+
+        InnerClass(int a, int b, int c, int d) { // violation, 'More than 2 parameters (found 4).'
+            super(1, 2, 3);
+        }
+    }
+
+    static class Very {
+        static class Deep {
+            static class Rabbit {
+                enum Colors {
+                    GOLDEN(1, 2, 3) {
+                        void jump(int a, int b) {}
+                        @MyAnno
+                        void roll(int a, int b, int c) {}
+
+                        // violation below, 'More than 2 parameters (found 3).'
+                        void loaf(int a, int b, int c) {}
+                    };
+
+                    @Wawa
+                    private Colors(@MyAnno int a, int b, int c) {}
+                    // violation above, 'More than 2 parameters (found 3).'
+
+                    @Session(uid = ":D")
+                    private Colors(@Wawa int a, @Wawa int b, @Wawa int c, @Wawa int d) {}
+
+                    private Colors(int a) {}
+                }
+                static class Hole {
+                    static {
+                        new Object() {
+                            @MyAnno @Session(uid = "G0F")
+                            void method1(int a, int b, int c) {}
+
+                            // violation below, 'More than 2 parameters (found 4).'
+                            void method3(@MyAnno int a, @MyAnno int b, @MyAnno int c, int d) {}
+                        };
+                    }
+                }
+            }
+        }
+    }
+
+    @Wawa
+    @MyAnno
+    void method8(int a, int b, int c) {
+    }
+
+    @Session(uid = "H1") @Bit
+    @Wawa
+    void method9(int a, int b, int c) {
+    }
+
+    @Bit
+    @Wawa
+    void method10(int a, int b, int c) { // violation, 'More than 2 parameters (found 3).'
+    }
+
+    interface Reader {
+        void method1 (int a, int b);
+
+        @MyAnno
+        void method2 (int a, int b, int c);
+
+        void method3 (int a, int b, int c); // violation, 'More than 2 parameters (found 3).'
+    }
+
+    @interface Wawa {}
+    @interface Bit {}
+    @interface MyAnno {}
+    @interface Session {
+        String uid();
+    }
+}

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/sizes/parameternumber/InputParameterNumberIgnoreAnnotatedByFullyQualifiedClassName.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/sizes/parameternumber/InputParameterNumberIgnoreAnnotatedByFullyQualifiedClassName.java
@@ -1,0 +1,62 @@
+/*
+ParameterNumber
+max = 2
+ignoreAnnotatedBy = java.lang.Deprecated, InnerClass.InnerAnno, Session
+
+*/
+
+package com.puppycrawl.tools.checkstyle.checks.sizes.parameternumber;
+
+public class InputParameterNumberIgnoreAnnotatedByFullyQualifiedClassName {
+    @java.lang.Deprecated
+    void method3(int a, int b, int c) {}
+
+    @Deprecated
+    void method4(int a, int b, int c) {} // violation, 'More than 2 parameters (found 3).'
+
+    void method5(int a, int b, int c) {} // violation, 'More than 2 parameters (found 3).'
+
+    @Session
+    void method6(int a, int b, int c) {}
+
+    @InputParameterNumberIgnoreAnnotatedByFullyQualifiedClassName.Session
+    void method7(int a, int b, int c) {} // violation, 'More than 2 parameters (found 3).'
+
+    @com.puppycrawl.tools.checkstyle.checks.sizes.parameternumber
+            .InputParameterNumberIgnoreAnnotatedByFullyQualifiedClassName.Session
+    void method8(int a, int b, int c) {} // violation, 'More than 2 parameters (found 3).'
+
+    @com.puppycrawl.tools.checkstyle.checks.sizes.parameternumber
+            .InputParameterNumberIgnoreAnnotatedByFullyQualifiedClassName.Session
+    void method8(int a, int b) {}
+
+    private static class InnerClass {
+        private @interface InnerAnno {}
+
+        @InnerClass.InnerAnno
+        void method1(int a, int b, int c) {
+        }
+
+        @InnerAnno
+        void method2(int a, int b, int c) { // violation, 'More than 2 parameters (found 3).'
+        }
+
+        @Bit
+        void method3(int a, int b, int c) { // violation, 'More than 2 parameters (found 3).'
+        }
+
+        @InnerAnno
+        void method2(int a, int b) {
+        }
+
+        @Bit
+        void method3(int a, int b) {
+        }
+
+        void method4(int a, int b) {
+        }
+    }
+
+    @interface Session {}
+    @interface Bit{}
+}

--- a/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/sizes/parameternumber/Example4.txt
+++ b/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/sizes/parameternumber/Example4.txt
@@ -1,0 +1,31 @@
+/*xml
+<module name="Checker">
+  <module name="TreeWalker">
+    <module name="ParameterNumber">
+      <property name="ignoreAnnotatedBy" value="JsonCreator"/>
+    </module>
+  </module>
+</module>
+*/
+
+package com.puppycrawl.tools.checkstyle.checks.sizes.parameternumber;
+
+// xdoc section -- start
+class Example {
+    @JsonCreator
+    Example(int a, int b, int c, int d,
+            int e, int f, int g, int h) {}
+
+    // violation below, 'More than 7 parameters (found 8)'
+    Example(String a, String b, String c, String d,
+            String e, String f, String g, String h) {}
+
+    // annotation name must be an exact match
+    // violation below, 'More than 7 parameters (found 8)'
+    @com.puppycrawl.tools.checkstyle.checks.sizes.parameternumber.Example.JsonCreator
+    Example(float a, float b, float c, float d,
+            float e, float f, float g, float h) {}
+
+    @interface JsonCreator {}
+}
+// xdoc section -- end

--- a/src/xdocs/checks/sizes/parameternumber.xml
+++ b/src/xdocs/checks/sizes/parameternumber.xml
@@ -25,6 +25,13 @@
               <th>since</th>
             </tr>
             <tr>
+              <td>ignoreAnnotatedBy</td>
+              <td>Ignore methods and constructors annotated with the specified annotation(s).</td>
+              <td><a href="../../property_types.html#String.5B.5D">String[]</a></td>
+              <td><code>{}</code></td>
+              <td>10.15.0</td>
+            </tr>
+            <tr>
               <td>ignoreOverriddenMethods</td>
               <td>Ignore number of parameters for methods with <code>@Override</code> annotation.</td>
               <td><a href="../../property_types.html#boolean">boolean</a></td>
@@ -114,6 +121,43 @@ public void needsLotsOfParameters(int a,
     ...
 }
         </source>
+        <p id="Example4-config">
+          To configure the check to ignore methods and constructors annotated with
+          <code>JsonCreator</code> annotation:
+        </p>
+        <source>
+&lt;module name=&quot;Checker&quot;&gt;
+  &lt;module name=&quot;TreeWalker&quot;&gt;
+    &lt;module name=&quot;ParameterNumber&quot;&gt;
+      &lt;property name=&quot;ignoreAnnotatedBy&quot; value=&quot;JsonCreator&quot;/&gt;
+    &lt;/module&gt;
+  &lt;/module&gt;
+&lt;/module&gt;
+        </source>
+        <p id="Example4-code">Example:</p>
+        <source>
+class Example {
+    @JsonCreator
+    Example(int a, int b, int c, int d,
+            int e, int f, int g, int h) {}
+
+    // violation below, 'More than 7 parameters (found 8)'
+    Example(String a, String b, String c, String d,
+            String e, String f, String g, String h) {}
+
+    // annotation name must be an exact match
+    // violation below, 'More than 7 parameters (found 8)'
+    @com.puppycrawl.tools.checkstyle.checks.sizes.parameternumber.Example.JsonCreator
+    Example(float a, float b, float c, float d,
+            float e, float f, float g, float h) {}
+
+    @interface JsonCreator {}
+}
+        </source>
+        <p>
+          Note: Annotation names specified in the <code>ignoreAnnotatedBy</code> property
+          must be an exact match for the annotation name on the method or constructor.
+        </p>
       </subsection>
 
       <subsection name="Example of Usage" id="Example_of_Usage">

--- a/src/xdocs/checks/sizes/parameternumber.xml.template
+++ b/src/xdocs/checks/sizes/parameternumber.xml.template
@@ -63,6 +63,25 @@
                  value="resources/com/puppycrawl/tools/checkstyle/checks/sizes/parameternumber/Example3.txt"/>
           <param name="type" value="code"/>
         </macro>
+        <p id="Example4-config">
+          To configure the check to ignore methods and constructors annotated with
+          <code>JsonCreator</code> annotation:
+        </p>
+        <macro name="example">
+          <param name="path"
+                 value="resources/com/puppycrawl/tools/checkstyle/checks/sizes/parameternumber/Example4.txt"/>
+          <param name="type" value="config"/>
+        </macro>
+        <p id="Example4-code">Example:</p>
+        <macro name="example">
+          <param name="path"
+                 value="resources/com/puppycrawl/tools/checkstyle/checks/sizes/parameternumber/Example4.txt"/>
+          <param name="type" value="code"/>
+        </macro>
+        <p>
+          Note: Annotation names specified in the <code>ignoreAnnotatedBy</code> property
+          must be an exact match for the annotation name on the method or constructor.
+        </p>
       </subsection>
 
       <subsection name="Example of Usage" id="Example_of_Usage">


### PR DESCRIPTION
Resolves #11340 

Old Doc([site](https://checkstyle.org/checks/sizes/parameternumber.html)), New Doc([site](https://checkstyle-diff-reports.s3.us-east-2.amazonaws.com/4cc9297_2024153913/checks/sizes/parameternumber.html#Properties))
<hr>

### Regression: ([Report](https://checkstyle-diff-reports.s3.us-east-2.amazonaws.com/a62d9ca_2024194155/reports/diff/index.html))

**Differences Found** (expected):
`Deprecated` is used as the value for the `ignoreAnnotatedBy`(selected for the purpose that it would produce some differences being a commonly used annotation)

**Removed violations** (**22**): Example ([link](https://checkstyle-diff-reports.s3.us-east-2.amazonaws.com/a62d9ca_2024194155/reports/diff/guava/xref/home/runner/work/checkstyle/checkstyle/.ci-temp/contribution/checkstyle-tester/repositories/guava/android/guava/src/com/google/common/collect/ImmutableSortedMapFauxverideShim.java.html#L107)), rest of the occurrences are similar.
```java
@Deprecated
public static <K, V> ImmutableSortedMap<K, V> of(K k1, V v1, K k2, V v2, K k3, V v3, K k4, V v4) {
```
  -   Method above contains 8 params, while maximum(by default) allowed are 7, 
  -   This is no longer a violation because it is annotated by `Deprecated` which is specified in `ignoreAnnotatedBy` property in the patch-config. 
  -   This is the intended behaviour.
<hr>

Diff Regression config: https://gist.githubusercontent.com/sktpy/0c6a38735b3206b86b593a490206e76d/raw/4c033289ef4802e25c473cec5ef58ff49ea8d788/base-config.xml
Diff Regression patch config: https://gist.githubusercontent.com/sktpy/43c4a398aadd414fbe69d75953704597/raw/7f468b2a7e04762d763d7148d81a640dad733091/patch-config.xml