### PR TITLE
Issue #13999: Kill mutation in AbstractJavadocCheck

### DIFF
--- a/config/pitest-suppressions/pitest-javadoc-suppressions.xml
+++ b/config/pitest-suppressions/pitest-javadoc-suppressions.xml
@@ -31,15 +31,6 @@
     <sourceFile>AbstractJavadocCheck.java</sourceFile>
     <mutatedClass>com.puppycrawl.tools.checkstyle.checks.javadoc.AbstractJavadocCheck</mutatedClass>
     <mutatedMethod>walk</mutatedMethod>
-    <mutator>org.pitest.mutationtest.engine.gregor.mutators.RemoveConditionalMutator_EQUAL_IF</mutator>
-    <description>removed conditional - replaced equality check with true</description>
-    <lineContent>if (toVisit == null) {</lineContent>
-  </mutation>
-
-  <mutation unstable="false">
-    <sourceFile>AbstractJavadocCheck.java</sourceFile>
-    <mutatedClass>com.puppycrawl.tools.checkstyle.checks.javadoc.AbstractJavadocCheck</mutatedClass>
-    <mutatedMethod>walk</mutatedMethod>
     <mutator>org.pitest.mutationtest.engine.gregor.mutators.NonVoidMethodCallMutator</mutator>
     <description>removed call to com/puppycrawl/tools/checkstyle/checks/javadoc/AbstractJavadocCheck::shouldBeProcessed</description>
     <lineContent>waitsForProcessing = shouldBeProcessed(curNode);</lineContent>

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/AbstractJavadocCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/AbstractJavadocCheck.java
@@ -382,11 +382,9 @@ public abstract class AbstractJavadocCheck extends AbstractCheck {
                 }
 
                 toVisit = JavadocUtil.getNextSibling(curNode);
-                if (toVisit == null) {
-                    curNode = curNode.getParent();
-                    if (curNode != null) {
-                        waitsForProcessing = shouldBeProcessed(curNode);
-                    }
+                curNode = curNode.getParent();
+                if (curNode != null) {
+                    waitsForProcessing = shouldBeProcessed(curNode);
                 }
             }
             curNode = toVisit;


### PR DESCRIPTION
issue #13999:
## Mutation
https://github.com/checkstyle/checkstyle/blob/d43ccb86e7b3dd82aee759851b184aa4f899317a/config/pitest-suppressions/pitest-javadoc-suppressions.xml#L30-L37

## Modules
All checks that are a subclass of  `AbstractJavadocCheck`

## Explanation
this condition reported by Pitest is ok to remove and won't affect the function behavior. we traverse the tree to look for interested nodes for the checks we get the child of the node first if the child is null we enter this loop to search for the sibling instead of the child and then update the curr node  with the sibling
```
 while (curNode != null && toVisit == null) {
                if (waitsForProcessing) {
                    leaveJavadocToken(curNode);
                }
                toVisit = JavadocUtil.getNextSibling(curNode);
                curNode = curNode.getParent();
                if (curNode != null) {
                  waitsForProcessing = shouldBeProcessed(curNode);
                }
            }
```
before mutation, if we are inside this loop and the sibling is also null. then we get the parent to recurse back to it and continue the loop to traverse the parent siblings
now, after the mutation, we simply  execute this statment `curNode = curNode.getParent();` every time rather than being executed only when the siblings null . but it won't affect anything as we have two conditions
1. `toVisit != null` so we have a sibling to visit so the loop will break and we continue with this sibling as the current node 
( we don't need the parent that returned from here `curNode.getParent()` )
2. `toVisit == null` we will procced the loop with the parent of the node and continue to get its siblings

So, the mutation results in executing this statement `curNode = curNode.getParent(); `  even if we don't need it but the behaviour won't change

**Conclusion:** Just cleaning of unnecessary conditions and this function can be cleaned further but there is an open PR for the remaining mutations in it

## Regression
Diff Regression config: https://gist.githubusercontent.com/mahfouz72/128b74034c745e0122b4427b82cdd500/raw/2d85cdeb459476c0cdb2137b6454ca8ab58183a4/javadocchecks.xml