### PR TITLE
Issue #14436: Rename ThrowsCount test input files and test methods to specify Test functionality

### DIFF
--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/design/ThrowsCountCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/design/ThrowsCountCheckTest.java
@@ -37,7 +37,7 @@ public class ThrowsCountCheckTest extends AbstractModuleTestSupport {
     }
 
     @Test
-    public void testDefault() throws Exception {
+    public void testThrowsCountDefault() throws Exception {
 
         final String[] expected = {
             "25:20: " + getCheckMessage(MSG_KEY, 5, 4),
@@ -47,18 +47,18 @@ public class ThrowsCountCheckTest extends AbstractModuleTestSupport {
         };
 
         verifyWithInlineConfigParser(
-                getPath("InputThrowsCount.java"), expected);
+                getPath("InputThrowsCountDefault.java"), expected);
     }
 
     @Test
-    public void testMax() throws Exception {
+    public void testThrowsCountCustomMaxCount() throws Exception {
 
         final String[] expected = {
             "35:20: " + getCheckMessage(MSG_KEY, 6, 5),
         };
 
         verifyWithInlineConfigParser(
-                getPath("InputThrowsCount2.java"), expected);
+                getPath("InputThrowsCountCustomMaxCount.java"), expected);
     }
 
     @Test
@@ -96,7 +96,7 @@ public class ThrowsCountCheckTest extends AbstractModuleTestSupport {
     }
 
     @Test
-    public void testNotIgnorePrivateMethod() throws Exception {
+    public void testThrowsCountNotIgnorePrivateMethods() throws Exception {
         final String[] expected = {
             "25:20: " + getCheckMessage(MSG_KEY, 5, 4),
             "30:20: " + getCheckMessage(MSG_KEY, 5, 4),
@@ -105,11 +105,11 @@ public class ThrowsCountCheckTest extends AbstractModuleTestSupport {
             "63:43: " + getCheckMessage(MSG_KEY, 5, 4),
         };
         verifyWithInlineConfigParser(
-                getPath("InputThrowsCount3.java"), expected);
+                getPath("InputThrowsCountNotIgnorePrivateMethods.java"), expected);
     }
 
     @Test
-    public void testMethodWithAnnotation() throws Exception {
+    public void testThrowsCountMethodWithAnnotation() throws Exception {
         final String[] expected = {
             "26:26: " + getCheckMessage(MSG_KEY, 5, 4),
         };
@@ -118,7 +118,7 @@ public class ThrowsCountCheckTest extends AbstractModuleTestSupport {
     }
 
     @Test
-    public void testOverriding() throws Exception {
+    public void testThrowsCountMaxAllowZero() throws Exception {
         final String[] expected = {
             "17:20: " + getCheckMessage(MSG_KEY, 1, 0),
             "21:20: " + getCheckMessage(MSG_KEY, 1, 0),
@@ -129,7 +129,7 @@ public class ThrowsCountCheckTest extends AbstractModuleTestSupport {
             "67:43: " + getCheckMessage(MSG_KEY, 5, 0),
         };
         verifyWithInlineConfigParser(
-                getPath("InputThrowsCount4.java"), expected);
+                getPath("InputThrowsCountMaxAllowZero.java"), expected);
     }
 
 }

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/design/throwscount/InputThrowsCountCustomMaxCount.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/design/throwscount/InputThrowsCountCustomMaxCount.java
@@ -13,7 +13,7 @@ import java.io.EOFException;
 import java.io.FileNotFoundException;
 import java.sql.SQLException;
 
-public class InputThrowsCount2 {
+public class InputThrowsCountCustomMaxCount {
     void method1() throws Exception
     {
     }
@@ -45,7 +45,7 @@ public class InputThrowsCount2 {
     }
 }
 
-class SubClass2 extends InputThrowsCount2 {
+class SubClass2 extends InputThrowsCountCustomMaxCount {
     @Override
     void method1() {
     }

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/design/throwscount/InputThrowsCountDefault.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/design/throwscount/InputThrowsCountDefault.java
@@ -1,7 +1,7 @@
 /*
 ThrowsCount
-max = 0
-ignorePrivateMethods = false
+max = (default)4
+ignorePrivateMethods = (default)true
 
 
 */
@@ -13,29 +13,26 @@ import java.io.EOFException;
 import java.io.FileNotFoundException;
 import java.sql.SQLException;
 
-public class InputThrowsCount4 {
-    void method1() throws Exception // violation 'Throws count is 1 (max allowed is 0)'
+public class InputThrowsCountDefault {
+    void method1() throws Exception
     {
     }
 
-    void method2() throws java.awt.AWTException // violation 'Throws count is 1 (max allowed is 0)'
+    void method2() throws java.awt.AWTException
     {
     }
 
-    void method3() throws Exception, AWTException, SQLException,
-            // violation above 'Throws count is 5 (max allowed is 0)'
+    void method3() throws Exception, AWTException, SQLException, // violation
             FileNotFoundException, EOFException
     {
     }
 
-    void method4() throws Exception, java.awt.AWTException, java.sql.SQLException,
-            // violation above 'Throws count is 5 (max allowed is 0)'
+    void method4() throws Exception, java.awt.AWTException, java.sql.SQLException, // violation
             java.io.FileNotFoundException, java.io.EOFException
     {
     }
 
-    void method5() throws Exception, AWTException, Throwable, SQLException,
-            // violation above 'Throws count is 6 (max allowed is 0)'
+    void method5() throws Exception, AWTException, Throwable, SQLException, // violation
             FileNotFoundException, EOFException
     {
     }
@@ -44,12 +41,11 @@ public class InputThrowsCount4 {
     }
 
     private void method7() throws Exception, AWTException, SQLException,
-            // violation above 'Throws count is 5 (max allowed is 0)'
             FileNotFoundException, EOFException {
     }
 }
 
-class SubClass4 extends InputThrowsCount {
+class SubClass extends InputThrowsCountDefault {
     @Override
     void method1() {
     }
@@ -64,8 +60,7 @@ class SubClass4 extends InputThrowsCount {
     }
 
     @SuppressWarnings("deprecation")
-    final void method2(Object ...objects) throws Exception,
-            // violation above 'Throws count is 5 (max allowed is 0)'
+    final void method2(Object ...objects) throws Exception, // violation
             AWTException, SQLException, FileNotFoundException, EOFException{
     }
 

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/design/throwscount/InputThrowsCountMaxAllowZero.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/design/throwscount/InputThrowsCountMaxAllowZero.java
@@ -1,7 +1,7 @@
 /*
 ThrowsCount
-max = (default)4
-ignorePrivateMethods = (default)true
+max = 0
+ignorePrivateMethods = false
 
 
 */
@@ -13,26 +13,29 @@ import java.io.EOFException;
 import java.io.FileNotFoundException;
 import java.sql.SQLException;
 
-public class InputThrowsCount {
-    void method1() throws Exception
+public class InputThrowsCountMaxAllowZero {
+    void method1() throws Exception // violation 'Throws count is 1 (max allowed is 0)'
     {
     }
 
-    void method2() throws java.awt.AWTException
+    void method2() throws java.awt.AWTException // violation 'Throws count is 1 (max allowed is 0)'
     {
     }
 
-    void method3() throws Exception, AWTException, SQLException, // violation
+    void method3() throws Exception, AWTException, SQLException,
+            // violation above 'Throws count is 5 (max allowed is 0)'
             FileNotFoundException, EOFException
     {
     }
 
-    void method4() throws Exception, java.awt.AWTException, java.sql.SQLException, // violation
+    void method4() throws Exception, java.awt.AWTException, java.sql.SQLException,
+            // violation above 'Throws count is 5 (max allowed is 0)'
             java.io.FileNotFoundException, java.io.EOFException
     {
     }
 
-    void method5() throws Exception, AWTException, Throwable, SQLException, // violation
+    void method5() throws Exception, AWTException, Throwable, SQLException,
+            // violation above 'Throws count is 6 (max allowed is 0)'
             FileNotFoundException, EOFException
     {
     }
@@ -41,11 +44,12 @@ public class InputThrowsCount {
     }
 
     private void method7() throws Exception, AWTException, SQLException,
+            // violation above 'Throws count is 5 (max allowed is 0)'
             FileNotFoundException, EOFException {
     }
 }
 
-class SubClass extends InputThrowsCount {
+class SubClass4 extends InputThrowsCountMaxAllowZero {
     @Override
     void method1() {
     }
@@ -60,7 +64,8 @@ class SubClass extends InputThrowsCount {
     }
 
     @SuppressWarnings("deprecation")
-    final void method2(Object ...objects) throws Exception, // violation
+    final void method2(Object ...objects) throws Exception,
+            // violation above 'Throws count is 5 (max allowed is 0)'
             AWTException, SQLException, FileNotFoundException, EOFException{
     }
 

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/design/throwscount/InputThrowsCountNotIgnorePrivateMethods.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/design/throwscount/InputThrowsCountNotIgnorePrivateMethods.java
@@ -13,7 +13,7 @@ import java.io.EOFException;
 import java.io.FileNotFoundException;
 import java.sql.SQLException;
 
-public class InputThrowsCount3 {
+public class InputThrowsCountNotIgnorePrivateMethods {
     void method1() throws Exception
     {
     }
@@ -45,7 +45,7 @@ public class InputThrowsCount3 {
     }
 }
 
-class SubClass3 extends InputThrowsCount3 {
+class SubClass3 extends InputThrowsCountNotIgnorePrivateMethods {
     @Override
     void method1() {
     }


### PR DESCRIPTION
Part of Issue #14436 

This PR is for testing resolved issues with failing CI of circleci workflow `no-error-xwiki`

We've had a failing CI of workflow related to `xwiki`
Investigation of the issue led me to the following error :

Before merge of  PR https://github.com/xwiki/xwiki-platform/pull/2934 : 

```
[INFO] Starting audit...
[ERROR] /home/circleci/project/.ci-temp/xwiki-platform/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-rest/src/main/java/org/xwiki/notifications/rest/NotificationsResource.java:131: Line is longer than 120 characters (found 123). [LineLength] Audit done.
[INFO] There is 1 error reported by Checkstyle 10.14.0-SNAPSHOT with checkstyle.xml ruleset. [ERROR] src/main/java/org/xwiki/notifications/rest/NotificationsResource.java:[131] (sizes) LineLength: Line is longer than 120 characters (found 123).

```

@romani ,
I have sent a PR to xwiki-platform that has been successfully merged, thereby fixing our failing CI.

After merge of PR https://github.com/xwiki/xwiki-platform/pull/2934 : 

`ci/circleci: no-error-xwiki — Your tests passed on CircleCI!`
https://circleci.com/gh/checkstyle/checkstyle/529861

_EDIT  -  This PR can be MERGED_