### PR TITLE
doc: fix line length violation in releasenotes.xml

### DIFF
--- a/src/xdocs/releasenotes.xml
+++ b/src/xdocs/releasenotes.xml
@@ -33,7 +33,8 @@
         <ul>
           <li>
             Remove &#39;//ok&#39; comments from Input files .
-            Author: Aye Nyein San, biplavoraon, mahfouz72, Abhishek Maity, SteLeo1602, akanksha, MANISH-K-07, Tahanima Chowdhury, CubeTures
+            Author: Aye Nyein San, biplavoraon, mahfouz72, Abhishek Maity, SteLeo1602,
+            akanksha, MANISH-K-07, Tahanima Chowdhury, CubeTures
             <a href="https://github.com/checkstyle/checkstyle/issues/13213">#13213</a>
           </li>
           <li>


### PR DESCRIPTION
the latest releasenotes has line length violation
```
[INFO] [checkstyle] Running Checkstyle  on 2122 files
[ERROR] [checkstyle] [ERROR] /home/circleci/project/src/xdocs/releasenotes.xml:36: Line should not be longer than 100 symbols [lineLengthXml]
[INFO]      [echo] Checkstyle finished (checkstyle-checks.xml) : 28/02/2024 04:26:27 PM
[INFO]      [echo] Checkstyle started (checkstyle-non-main-files-checks.xml): 28/02/2024 04:25:09 PM
[INFO] [checkstyle] Running Checkstyle  on 4368 files
[ERROR] [checkstyle] [ERROR] /home/circleci/project/src/xdocs/releasenotes.xml:36: Line should not be longer than 100 symbols [lineLength]
```