### PR TITLE
Issue #3110: BugFix in MetadataGeneratorLoggerTest removed hardcoded messages

### DIFF
--- a/src/main/resources/com/puppycrawl/tools/checkstyle/messages.properties
+++ b/src/main/resources/com/puppycrawl/tools/checkstyle/messages.properties
@@ -9,6 +9,10 @@ Main.createListener=Invalid output format. Found ''{0}'' but expected ''{1}'' or
 #
 Main.errorCounter=Checkstyle ends with {0} errors.
 Main.loadProperties=Unable to load properties from file ''{0}''.
+MetadataGeneratorLogger.emptyOutputStream=Output stream should be empty
+MetadataGeneratorLogger.unexpectedClose=Unexpected close count
+MetadataGeneratorLogger.unexpectedFlush=Unexpected flush count
+MetadataGeneratorLogger.violationRequiresException=Violation should contain exception message
 PackageObjectFactory.ambiguousModuleNameExceptionMessage=In config there is ''{0}'', \
   but in classpath there are {1}, please resolve ambiguity by specifying fully qualified \
   name in config.

--- a/src/main/resources/com/puppycrawl/tools/checkstyle/messages_de.properties
+++ b/src/main/resources/com/puppycrawl/tools/checkstyle/messages_de.properties
@@ -9,6 +9,10 @@ Main.createListener=Ungültiges Ausgabeformat. Gefunden ''{0}'', aber ''{1}'' od
 #
 Main.errorCounter=Checkstyle endet mit {0} Fehlern.
 Main.loadProperties=Die Eigenschaften von Datei ''{0}'' können nicht geladen werden.
+MetadataGeneratorLogger.emptyOutputStream=Der Ausgabestream sollte leer sein
+MetadataGeneratorLogger.unexpectedClose=Unerwartete Abschlusszählung
+MetadataGeneratorLogger.unexpectedFlush=Unerwartete Flush-Anzahl
+MetadataGeneratorLogger.violationRequiresException=Der Verstoß sollte eine Ausnahmemeldung enthalten
 PackageObjectFactory.ambiguousModuleNameExceptionMessage=In der Konfiguration gibt es ''{0}'', \
   aber im Klassenpfad gibt es {1}. Bitte lösen Sie Mehrdeutigkeiten durch die Angabe voll \
   qualifizierter Namen in der Konfiguration.

--- a/src/main/resources/com/puppycrawl/tools/checkstyle/messages_es.properties
+++ b/src/main/resources/com/puppycrawl/tools/checkstyle/messages_es.properties
@@ -9,6 +9,10 @@ Main.createListener=Formato de salida no válido. Encontrado ''{0}'' pero espera
 #
 Main.errorCounter=Checkstyle termina con {0} errores.
 Main.loadProperties=No se pueden cargar las propiedades del archivo ''{0}''.
+MetadataGeneratorLogger.emptyOutputStream=El flujo de salida debe estar vacío
+MetadataGeneratorLogger.unexpectedClose=Recuento cercano inesperado
+MetadataGeneratorLogger.unexpectedFlush=Recuento de color inesperado
+MetadataGeneratorLogger.violationRequiresException=La infracción debe contener un mensaje de excepción
 PackageObjectFactory.ambiguousModuleNameExceptionMessage=En configuración hay ''{0}'', \
   pero en classpath hay {1}, por favor, resolver la ambigüedad mediante la especificación \
   de nombre completo en config.

--- a/src/main/resources/com/puppycrawl/tools/checkstyle/messages_fi.properties
+++ b/src/main/resources/com/puppycrawl/tools/checkstyle/messages_fi.properties
@@ -9,6 +9,10 @@ Main.createListener=Virheellinen tulostusmuoto. Löytyi ''{0}'' mutta odotti ''{
 #
 Main.errorCounter=Checkstyle päättyy {0} virheellä.
 Main.loadProperties=Ominaisuuksia ei voi ladata tiedostosta ''{0}''.
+MetadataGeneratorLogger.emptyOutputStream=Lähtövirran tulee olla tyhjä
+MetadataGeneratorLogger.unexpectedClose=Odottamaton lähiluku
+MetadataGeneratorLogger.unexpectedFlush=Odottamaton värimäärä
+MetadataGeneratorLogger.violationRequiresException=Rikkomuksen tulee sisältää poikkeusviesti
 PackageObjectFactory.ambiguousModuleNameExceptionMessage=Konfigissa on ''{0}'', \
   mutta luokkapolussa on {1}, ratkaise epäselvyys määrittämällä täydellinen nimi \
   konfiguroinnilla.

--- a/src/main/resources/com/puppycrawl/tools/checkstyle/messages_fr.properties
+++ b/src/main/resources/com/puppycrawl/tools/checkstyle/messages_fr.properties
@@ -9,6 +9,10 @@ Main.createListener=Format de sortie invalide. Trouvé ''{0}'' mais attendu ''{1
 #
 Main.errorCounter=Checkstyle se termine par {0} erreurs.
 Main.loadProperties=Impossible de charger des propriétés à partir du fichier ''{0}''.
+MetadataGeneratorLogger.emptyOutputStream=Le flux de sortie doit être vide
+MetadataGeneratorLogger.unexpectedClose=Nombre de clôtures inattendues
+MetadataGeneratorLogger.unexpectedFlush=Nombre de chasses inattendues
+MetadataGeneratorLogger.violationRequiresException=La violation doit contenir un message d'exception
 PackageObjectFactory.ambiguousModuleNameExceptionMessage=Dans la configuration il y a ''{0}'', \
   mais dans classpath il y a {1}, résolvez l''ambiguïté en spécifiant le nom complet dans config.
 PackageObjectFactory.unableToInstantiateExceptionMessage=Impossible d''instancier la classe \

--- a/src/main/resources/com/puppycrawl/tools/checkstyle/messages_ja.properties
+++ b/src/main/resources/com/puppycrawl/tools/checkstyle/messages_ja.properties
@@ -9,6 +9,10 @@ Main.createListener=無効な出力形式です。''{0}'' 名が見つかりま�
 #
 Main.errorCounter=Checkstyleは {0} 個のエラーで終了します。
 Main.loadProperties=ファイル ''{0}'' からプロパティを読み込めません。
+MetadataGeneratorLogger.emptyOutputStream=出力ストリームは空である必要があります
+MetadataGeneratorLogger.unexpectedClose=予期せぬクローズ数
+MetadataGeneratorLogger.unexpectedFlush=予期しないフラッシュ数
+MetadataGeneratorLogger.violationRequiresException=違反には例外メッセージを含める必要があります
 PackageObjectFactory.ambiguousModuleNameExceptionMessage=設定には ''{0}''がありますが、\
   クラスパスには{1}があります。設定に完全修飾名を指定してあいまいさを解決してください。
 PackageObjectFactory.unableToInstantiateExceptionMessage=''{0}'' クラスをインスタンス化\

--- a/src/main/resources/com/puppycrawl/tools/checkstyle/messages_pt.properties
+++ b/src/main/resources/com/puppycrawl/tools/checkstyle/messages_pt.properties
@@ -9,6 +9,10 @@ Main.createListener=O formato de saída é inválido. Foi encontrado ''{0}'', ma
 #
 Main.errorCounter=O Checkstyle terminou com {0} erros.
 Main.loadProperties=Não foi possível carregar propriedades do arquivo ''{0}''.
+MetadataGeneratorLogger.emptyOutputStream=O fluxo de saída deve estar vazio
+MetadataGeneratorLogger.unexpectedClose=Contagem de fechamentos inesperados
+MetadataGeneratorLogger.unexpectedFlush=Contagem de descarga inesperada
+MetadataGeneratorLogger.violationRequiresException=A violação deve conter mensagem de exceção
 PackageObjectFactory.ambiguousModuleNameExceptionMessage=Na configuração há ''{0}'', \
   mas no classpath há {1}. Por favor, resolva a ambiguidade especificando o nome totalmente \
   qualificado na configuração.

--- a/src/main/resources/com/puppycrawl/tools/checkstyle/messages_ru.properties
+++ b/src/main/resources/com/puppycrawl/tools/checkstyle/messages_ru.properties
@@ -9,6 +9,10 @@ Main.createListener=Недопустимый формат вывода. Найд
 #
 Main.errorCounter=Checkstyle заканчивается с количеством ошибок {0}.
 Main.loadProperties=Не удалось загрузить свойства из файла ''{0}''.
+MetadataGeneratorLogger.emptyOutputStream=Выходной поток должен быть пустым
+MetadataGeneratorLogger.unexpectedClose=Неожиданный близкий подсчет
+MetadataGeneratorLogger.unexpectedFlush=Неожиданное количество сбросов
+MetadataGeneratorLogger.violationRequiresException=Нарушение должно содержать сообщение об исключении
 PackageObjectFactory.ambiguousModuleNameExceptionMessage=В конфигурации есть ''{0}'', \
     но в classpath есть {1}, пожалуйста, устраните двусмысленность, указав полное соответствие \
     имени в конфигурации.

--- a/src/main/resources/com/puppycrawl/tools/checkstyle/messages_tr.properties
+++ b/src/main/resources/com/puppycrawl/tools/checkstyle/messages_tr.properties
@@ -9,6 +9,10 @@ Main.createListener=Geçersiz çıktı biçimi. ''{0}'' ancak beklenen ''{1}'' v
 #
 Main.errorCounter=Checkstyle {0} hatayla bitiyor.
 Main.loadProperties=''{0}'' dosyasından özellik yüklenemiyor.
+MetadataGeneratorLogger.emptyOutputStream=Çıkış akışı boş olmalıdır
+MetadataGeneratorLogger.unexpectedClose=Beklenmeyen kapanış sayısı
+MetadataGeneratorLogger.unexpectedFlush=Beklenmeyen yıkama sayısı
+MetadataGeneratorLogger.violationRequiresException=İhlal istisna mesajı içermelidir
 PackageObjectFactory.ambiguousModuleNameExceptionMessage=Yapılandırmada ''{0}'' var, \
   ancak sınıf yolunda {1} var, lütfen yapılandırmada tam adı belirterek belirsizliği gidermek.
 PackageObjectFactory.unableToInstantiateExceptionMessage=''{0}'' sınıfını açılamıyor, \

--- a/src/main/resources/com/puppycrawl/tools/checkstyle/messages_zh.properties
+++ b/src/main/resources/com/puppycrawl/tools/checkstyle/messages_zh.properties
@@ -9,6 +9,10 @@ Main.createListener=非法的输出格式。预期为 ''{1}'' 或 ''{2}''，但�
 #
 Main.errorCounter=Checkstyle以 {0} 个错误结束。
 Main.loadProperties=无法从文件 ''{0}'' 中加载属性。
+MetadataGeneratorLogger.emptyOutputStream=输出流应该为空
+MetadataGeneratorLogger.unexpectedClose=意外的接近计数
+MetadataGeneratorLogger.unexpectedFlush=意外的刷新计数
+MetadataGeneratorLogger.violationRequiresException=违规应包含异常消息
 PackageObjectFactory.ambiguousModuleNameExceptionMessage=配置文件中出现 ''{0}''，\
   但在 classpath 中存在 {1}，请在配置文件中使用 Module 的 fully qualified name 以避免混淆。
 PackageObjectFactory.unableToInstantiateExceptionMessage=无法初始化类： ''{0}'' \

--- a/src/test/java/com/puppycrawl/tools/checkstyle/MetadataGeneratorLoggerTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/MetadataGeneratorLoggerTest.java
@@ -35,6 +35,19 @@ import com.puppycrawl.tools.checkstyle.internal.utils.CloseAndFlushTestByteArray
 
 public class MetadataGeneratorLoggerTest {
 
+    private final LocalizedMessage emptyOutputStreamMessage = new LocalizedMessage(
+            Definitions.CHECKSTYLE_BUNDLE, getClass(),
+                    "MetadataGeneratorLogger.emptyOutputStream");
+    private final LocalizedMessage violationRequiresExceptionMessage = new LocalizedMessage(
+            Definitions.CHECKSTYLE_BUNDLE, getClass(),
+                    "MetadataGeneratorLogger.violationRequiresException");
+    private final LocalizedMessage unexpectedCloseMessage = new LocalizedMessage(
+            Definitions.CHECKSTYLE_BUNDLE, getClass(),
+                    "MetadataGeneratorLogger.unexpectedClose");
+    private final LocalizedMessage unexpectedFlushMessage = new LocalizedMessage(
+            Definitions.CHECKSTYLE_BUNDLE, getClass(),
+                    "MetadataGeneratorLogger.unexpectedFlush");
+
     @Test
     public void testIgnoreSeverityLevel() {
         final OutputStream outputStream = new ByteArrayOutputStream();
@@ -43,10 +56,11 @@ public class MetadataGeneratorLoggerTest {
         final AuditEvent event = new AuditEvent(this, "fileName",
                 new Violation(1, 2, "bundle", "key",
                         null, SeverityLevel.IGNORE, null, getClass(), "customViolation"));
+        final String emptyOutputStream = emptyOutputStreamMessage.getMessage();
         logger.finishLocalSetup();
         logger.addError(event);
         logger.auditFinished(event);
-        assertWithMessage("Output stream should be empty")
+        assertWithMessage(emptyOutputStream)
                 .that(outputStream.toString())
                 .isEmpty();
     }
@@ -57,9 +71,10 @@ public class MetadataGeneratorLoggerTest {
         final MetadataGeneratorLogger logger = new MetadataGeneratorLogger(outputStream,
                 OutputStreamOptions.CLOSE);
         final AuditEvent event = new AuditEvent(1);
+        final String violationRequiresException = violationRequiresExceptionMessage.getMessage();
         logger.addException(event, new IllegalStateException("Test Exception"));
         logger.auditFinished(event);
-        assertWithMessage("Violation should contain exception message")
+        assertWithMessage(violationRequiresException)
                 .that(outputStream.toString())
                 .contains("java.lang.IllegalStateException: Test Exception");
     }
@@ -71,7 +86,8 @@ public class MetadataGeneratorLoggerTest {
             final MetadataGeneratorLogger logger = new MetadataGeneratorLogger(outputStream,
                     OutputStreamOptions.CLOSE);
             logger.auditFinished(new AuditEvent(1));
-            assertWithMessage("Unexpected close count")
+            final String unexpectedClose = unexpectedCloseMessage.getMessage();
+            assertWithMessage(unexpectedClose)
                     .that(outputStream.getCloseCount())
                     .isEqualTo(1);
         }
@@ -85,7 +101,8 @@ public class MetadataGeneratorLoggerTest {
                     OutputStreamOptions.NONE);
             final AuditEvent event = new AuditEvent(1);
             logger.auditFinished(event);
-            assertWithMessage("Unexpected close count")
+            final String unexpectedClose = unexpectedCloseMessage.getMessage();
+            assertWithMessage(unexpectedClose)
                     .that(outputStream.getCloseCount())
                     .isEqualTo(0);
         }
@@ -100,11 +117,12 @@ public class MetadataGeneratorLoggerTest {
             final AuditEvent event = new AuditEvent(1);
             logger.auditStarted(event);
             logger.fileFinished(event);
-            assertWithMessage("Unexpected flush count")
+            final String unexpectedFlush = unexpectedFlushMessage.getMessage();
+            assertWithMessage(unexpectedFlush)
                     .that(outputStream.getFlushCount())
                     .isEqualTo(2);
             logger.auditFinished(event);
-            assertWithMessage("Unexpected flush count")
+            assertWithMessage(unexpectedFlush)
                     .that(outputStream.getFlushCount())
                     .isEqualTo(3);
         }


### PR DESCRIPTION
Part of #3110 

All hardcoded messages in MetadataGeneratorLoggerTest have been removed and replaced with keys pointing to respective messages.properties files to support non-locale translations.
I have used Google translate to extract translations of the messages.