### PR TITLE
Issue #13213: remove "//ok" comments

### DIFF
--- a/config/checkstyle-input-suppressions.xml
+++ b/config/checkstyle-input-suppressions.xml
@@ -2457,6 +2457,4 @@
             files="checks[\\/]whitespace[\\/]emptylineseparator[\\/]InputEmptyLineSeparator.java"/>
   <suppress id="UnnecessaryOkComment"
             files="checks[\\/]whitespace[\\/]emptylineseparator[\\/]InputEmptyLineSeparator2.java"/>
-  <suppress id="UnnecessaryOkComment"
-            files="utils[\\/]checkutil[\\/]InputCheckUtil7.java"/>
 </suppressions>

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/utils/checkutil/InputCheckUtil7.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/utils/checkutil/InputCheckUtil7.java
@@ -14,8 +14,8 @@ package com.puppycrawl.tools.checkstyle.utils.checkutil;
 
 public class InputCheckUtil7 {
 
-    static public class TestException3 extends Exception { // ok
-        TestException3(String messg) { // ok
+    static public class TestException3 extends Exception { 
+        TestException3(String messg) { 
             super(messg);
         }
 


### PR DESCRIPTION
Removed "ok" comment from the InputCheckUtil7.java file, along with the unnecessary supressors. 

![MINGW64__c_Users_pakhi_AppData_Roaming_SPB_Data_my_patch 01-03-2024 02_24_59 AM](https://github.com/checkstyle/checkstyle/assets/101047461/ec0ac665-3776-4a86-84cc-640847758bea)
