### PR TITLE
Issue #8122: BugFix Google Style enforced space around single line comments

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/whitespace/WhitespaceAroundCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/whitespace/WhitespaceAroundCheck.java
@@ -198,6 +198,8 @@ import com.puppycrawl.tools.checkstyle.utils.CommonUtil;
  * QUESTION</a>,
  * <a href="https://checkstyle.org/apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#RCURLY">
  * RCURLY</a>,
+ * <a href="https://checkstyle.org/apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#SINGLE_LINE_COMMENT">
+ * SINGLE_LINE_COMMENT</a>,
  * <a href="https://checkstyle.org/apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#SL">
  * SL</a>,
  * <a href="https://checkstyle.org/apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#SLIST">
@@ -314,6 +316,7 @@ public class WhitespaceAroundCheck extends AbstractCheck {
             TokenTypes.PLUS_ASSIGN,
             TokenTypes.QUESTION,
             TokenTypes.RCURLY,
+            TokenTypes.SINGLE_LINE_COMMENT,
             TokenTypes.SL,
             TokenTypes.SLIST,
             TokenTypes.SL_ASSIGN,
@@ -372,6 +375,7 @@ public class WhitespaceAroundCheck extends AbstractCheck {
             TokenTypes.PLUS_ASSIGN,
             TokenTypes.QUESTION,
             TokenTypes.RCURLY,
+            TokenTypes.SINGLE_LINE_COMMENT,
             TokenTypes.SL,
             TokenTypes.SLIST,
             TokenTypes.SL_ASSIGN,
@@ -391,6 +395,11 @@ public class WhitespaceAroundCheck extends AbstractCheck {
     @Override
     public int[] getRequiredTokens() {
         return CommonUtil.EMPTY_INT_ARRAY;
+    }
+
+    @Override
+    public boolean isCommentNodesRequired() {
+        return true;
     }
 
     /**

--- a/src/main/resources/google_checks.xml
+++ b/src/main/resources/google_checks.xml
@@ -124,8 +124,9 @@
                     LCURLY, LE, LITERAL_CATCH, LITERAL_DO, LITERAL_ELSE, LITERAL_FINALLY,
                     LITERAL_FOR, LITERAL_IF, LITERAL_RETURN, LITERAL_SWITCH, LITERAL_SYNCHRONIZED,
                     LITERAL_TRY, LITERAL_WHILE, LOR, LT, MINUS, MINUS_ASSIGN, MOD, MOD_ASSIGN,
-                    NOT_EQUAL, PLUS, PLUS_ASSIGN, QUESTION, RCURLY, SL, SLIST, SL_ASSIGN, SR,
-                    SR_ASSIGN, STAR, STAR_ASSIGN, LITERAL_ASSERT, TYPE_EXTENSION_AND"/>
+                    NOT_EQUAL, PLUS, PLUS_ASSIGN, QUESTION, RCURLY, SINGLE_LINE_COMMENT, SL,
+                    SLIST, SL_ASSIGN, SR, SR_ASSIGN, STAR,
+                    STAR_ASSIGN, LITERAL_ASSERT, TYPE_EXTENSION_AND"/>
       <message key="ws.notFollowed"
               value="WhitespaceAround: ''{0}'' is not followed by whitespace. Empty blocks
                may only be represented as '{}' when not part of a multi-block statement (4.1.3)"/>

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/whitespace/WhitespaceAroundCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/whitespace/WhitespaceAroundCheckTest.java
@@ -85,6 +85,7 @@ public class WhitespaceAroundCheckTest
             "169:9: " + getCheckMessage(MSG_WS_NOT_FOLLOWED, "assert"),
             "172:20: " + getCheckMessage(MSG_WS_NOT_PRECEDED, ":"),
             "172:20: " + getCheckMessage(MSG_WS_NOT_FOLLOWED, ":"),
+            "252:11: " + getCheckMessage(MSG_WS_NOT_FOLLOWED, "//"),
             "278:13: " + getCheckMessage(MSG_WS_NOT_FOLLOWED, "}"),
             "307:24: " + getCheckMessage(MSG_WS_NOT_FOLLOWED, "+"),
             "307:24: " + getCheckMessage(MSG_WS_NOT_PRECEDED, "+"),
@@ -105,6 +106,7 @@ public class WhitespaceAroundCheckTest
             "171:26: " + getCheckMessage(MSG_WS_NOT_FOLLOWED, "="),
             "172:26: " + getCheckMessage(MSG_WS_NOT_FOLLOWED, "="),
             "173:26: " + getCheckMessage(MSG_WS_NOT_FOLLOWED, "="),
+            "221:11: " + getCheckMessage(MSG_WS_NOT_FOLLOWED, "//"),
         };
         verifyWithInlineConfigParser(
                 getPath("InputWhitespaceAroundSimple.java"), expected);
@@ -128,6 +130,8 @@ public class WhitespaceAroundCheckTest
             "70:9: " + getCheckMessage(MSG_WS_NOT_FOLLOWED, "for"),
             // + ":74:23: ';' is not followed by whitespace.",
             // + ":74:29: ';' is not followed by whitespace.",
+            "118:11: " + getCheckMessage(MSG_WS_NOT_FOLLOWED, "//"),
+            "121:11: " + getCheckMessage(MSG_WS_NOT_FOLLOWED, "//"),
             "127:42: " + getCheckMessage(MSG_WS_NOT_FOLLOWED, "{"),
             "127:43: " + getCheckMessage(MSG_WS_NOT_PRECEDED, "}"),
             "130:39: " + getCheckMessage(MSG_WS_NOT_FOLLOWED, "{"),
@@ -147,6 +151,8 @@ public class WhitespaceAroundCheckTest
         final String[] expected = {
             "53:9: " + getCheckMessage(MSG_WS_NOT_FOLLOWED, "while"),
             "70:9: " + getCheckMessage(MSG_WS_NOT_FOLLOWED, "for"),
+            "118:11: " + getCheckMessage(MSG_WS_NOT_FOLLOWED, "//"),
+            "121:11: " + getCheckMessage(MSG_WS_NOT_FOLLOWED, "//"),
             "134:9: " + getCheckMessage(MSG_WS_NOT_FOLLOWED, "if"),
             "134:17: " + getCheckMessage(MSG_WS_NOT_FOLLOWED, "{"),
             "134:17: " + getCheckMessage(MSG_WS_NOT_PRECEDED, "{"),
@@ -179,6 +185,7 @@ public class WhitespaceAroundCheckTest
         final String[] expected = {
             "27:16: " + getCheckMessage(MSG_WS_NOT_PRECEDED, "&"),
             "27:16: " + getCheckMessage(MSG_WS_NOT_FOLLOWED, "&"),
+            "31:11: " + getCheckMessage(MSG_WS_NOT_FOLLOWED, "//"),
         };
         verifyWithInlineConfigParser(
                 getPath("InputWhitespaceAroundGenerics.java"), expected);
@@ -186,7 +193,9 @@ public class WhitespaceAroundCheckTest
 
     @Test
     public void test1322879And1649038() throws Exception {
-        final String[] expected = CommonUtil.EMPTY_STRING_ARRAY;
+        final String[] expected = {
+            "28:11: " + getCheckMessage(MSG_WS_NOT_FOLLOWED, "//"),
+        };
         verifyWithInlineConfigParser(
                 getPath("InputWhitespaceAround1.java"),
                expected);
@@ -210,6 +219,7 @@ public class WhitespaceAroundCheckTest
     @Test
     public void testIgnoreEnhancedForColon() throws Exception {
         final String[] expected = {
+            "28:11: " + getCheckMessage(MSG_WS_NOT_FOLLOWED, "//"),
             "39:20: " + getCheckMessage(MSG_WS_NOT_PRECEDED, ":"),
         };
         verifyWithInlineConfigParser(
@@ -271,7 +281,9 @@ public class WhitespaceAroundCheckTest
 
     @Test
     public void allowEmptyMethods() throws Exception {
-        final String[] expected = CommonUtil.EMPTY_STRING_ARRAY;
+        final String[] expected = {
+            "28:11: " + getCheckMessage(MSG_WS_NOT_FOLLOWED, "//"),
+        };
         verifyWithInlineConfigParser(
                 getPath("InputWhitespaceAround3.java"), expected);
     }
@@ -324,6 +336,7 @@ public class WhitespaceAroundCheckTest
             TokenTypes.PLUS_ASSIGN,
             TokenTypes.QUESTION,
             TokenTypes.RCURLY,
+            TokenTypes.SINGLE_LINE_COMMENT,
             TokenTypes.SL,
             TokenTypes.SLIST,
             TokenTypes.SL_ASSIGN,

--- a/src/xdocs/checks/whitespace/whitespacearound.xml
+++ b/src/xdocs/checks/whitespace/whitespacearound.xml
@@ -209,6 +209,8 @@ try {
                     QUESTION</a>
                 , <a href="../../apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#RCURLY">
                     RCURLY</a>
+                , <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#SINGLE_LINE_COMMENT">
+                    SINGLE_LINE_COMMENT</a>
                 , <a href="../../apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#SL">
                     SL</a>
                 , <a href="../../apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#SLIST">
@@ -322,6 +324,8 @@ try {
                     QUESTION</a>
                 , <a href="../../apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#RCURLY">
                     RCURLY</a>
+                , <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#SINGLE_LINE_COMMENT">
+                    SINGLE_LINE_COMMENT</a>
                 , <a href="../../apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#SL">
                     SL</a>
                 , <a href="../../apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#SLIST">


### PR DESCRIPTION
May resolve part of #8122 

Code below taken as input
```
Class Test
{
    protected Test ( int i )
    {
        this (); //whitespace
        toString ();
    }
}
```
Gave : 
```
C:\Users\ManishK\Workspace>java -jar checkstyle-8.31-all.jar -c config.xml Test.java
Starting audit...
Audit done.
```
Added new token to WhitespaceAroundCheck
After changes, I am able to produce expected results from inputs of compilable path.

However, there seems to be an error --> `NullPointerException` with the non-compilable files
@romani , I couldn't find the root cause yet. Any suggestions would be helpful !!

```
[ERROR] Errors:
[ERROR]   WhitespaceAroundCheckTest.testWhitespaceAroundAllowEmptyCompactCtors:509->AbstractModuleTestSupport.verifyWithInlineConfigParser:238->AbstractModuleTestSupport.verifyViolations:475->AbstractModuleTestSupport.getActualViolationsForFile:508 » Checkstyle Exception was thrown while processing E:\MANISH\Workspace\checkstyle\src\test\resources-noncompilable\com\puppycrawl\tools\checkstyle\checks\whitespace\whitespacearound\InputWhitespaceAroundAllowEmptyCompactCtors.java
[ERROR]   WhitespaceAroundCheckTest.testWhitespaceAroundRecords:479->AbstractModuleTestSupport.verifyWithInlineConfigParser:238->AbstractModuleTestSupport.verifyViolations:475->AbstractModuleTestSupport.getActualViolationsForFile:508 » Checkstyle Exception was thrown while processing E:\MANISH\Workspace\checkstyle\src\test\resources-noncompilable\com\puppycrawl\tools\checkstyle\checks\whitespace\whitespacearound\InputWhitespaceAroundRecords.java
[ERROR]   WhitespaceAroundCheckTest.testWhitespaceAroundRecordsAllowEmptyTypes:518->AbstractModuleTestSupport.verifyWithInlineConfigParser:238->AbstractModuleTestSupport.verifyViolations:475->AbstractModuleTestSupport.getActualViolationsForFile:508 » Checkstyle Exception was thrown while processing E:\MANISH\Workspace\checkstyle\src\test\resources-noncompilable\com\puppycrawl\tools\checkstyle\checks\whitespace\whitespacearound\InputWhitespaceAroundRecordsAllowEmptyTypes.java
```

```
Caused by: java.lang.NullPointerException: Cannot invoke "com.puppycrawl.tools.checkstyle.api.DetailAST.getType()" because the return value of "com.puppycrawl.tools.checkstyle.api.DetailAST.getParent()" is null
        at com.puppycrawl.tools.checkstyle.checks.whitespace.WhitespaceAroundCheck.isPartOfDoubleBraceInitializerForNextToken(WhitespaceAroundCheck.java:798)
        at com.puppycrawl.tools.checkstyle.checks.whitespace.WhitespaceAroundCheck.shouldCheckSeparationFromNextToken(WhitespaceAroundCheck.java:564)
        at com.puppycrawl.tools.checkstyle.checks.whitespace.WhitespaceAroundCheck.visitToken(WhitespaceAroundCheck.java:492)
        at com.puppycrawl.tools.checkstyle.TreeWalker.notifyVisit(TreeWalker.java:335)
        at com.puppycrawl.tools.checkstyle.TreeWalker.processIter(TreeWalker.java:408)
        at com.puppycrawl.tools.checkstyle.TreeWalker.walk(TreeWalker.java:273)
        at com.puppycrawl.tools.checkstyle.TreeWalker.processFiltered(TreeWalker.java:158)
        at com.puppycrawl.tools.checkstyle.api.AbstractFileSetCheck.process(AbstractFileSetCheck.java:101)
        at com.puppycrawl.tools.checkstyle.Checker.processFile(Checker.java:340)
        at com.puppycrawl.tools.checkstyle.Checker.processFiles(Checker.java:299)
        ... 76 more
```
