### PR TITLE
minor: fix inspections violation

### DIFF
--- a/config/intellij-idea-inspections.xml
+++ b/config/intellij-idea-inspections.xml
@@ -4106,6 +4106,9 @@
                    enabled_by_default="false"/>
   <inspection_tool class="SpringBootApplicationYaml" enabled="false" level="ERROR"
                    enabled_by_default="false"/>
+  <!-- until #14448 -->
+  <inspection_tool class="YAMLSchemaValidation" enabled="false" level="ERROR"
+                   enabled_by_default="false"/>
   <inspection_tool class="SpringBootBootstrapConfigurationInspection" enabled="false"
                    level="WEAK WARNING" enabled_by_default="false"/>
   <inspection_tool class="SpringCacheAnnotationsOnInterfaceInspection" enabled="false"

--- a/src/it/java/org/checkstyle/suppressionxpathfilter/XpathRegressionExecutableStatementCountTest.java
+++ b/src/it/java/org/checkstyle/suppressionxpathfilter/XpathRegressionExecutableStatementCountTest.java
@@ -122,10 +122,10 @@ public class XpathRegressionExecutableStatementCountTest extends AbstractXpathTe
             "7:22: " + getCheckMessage(ExecutableStatementCountCheck.class, MSG_KEY, 2, 1),
         };
 
-        final List<String> expectedXpathQueries = Arrays.asList(
-            "/COMPILATION_UNIT/CLASS_DEF[./IDENT"
-            + "[@text='SuppressionXpathRegressionExecutableStatementCountLambdas']]"
-            + "/OBJBLOCK/VARIABLE_DEF[./IDENT[@text='c']]/ASSIGN/LAMBDA"
+        final List<String> expectedXpathQueries = List.of(
+                "/COMPILATION_UNIT/CLASS_DEF[./IDENT"
+                        + "[@text='SuppressionXpathRegressionExecutableStatementCountLambdas']]"
+                        + "/OBJBLOCK/VARIABLE_DEF[./IDENT[@text='c']]/ASSIGN/LAMBDA"
         );
 
         runVerifications(moduleConfig, fileToProcess, expectedViolations, expectedXpathQueries);


### PR DESCRIPTION
We leaked an inspections failure from being too comfortable with failing inspections. This PR fixes inspection's complaint and disables the inspection that keeps failing.

Leaked in PR: https://github.com/checkstyle/checkstyle/pull/14578
Link to build: https://app.circleci.com/pipelines/github/checkstyle/checkstyle/24261/workflows/30c63bd9-0623-4723-814f-1afb0c072212/jobs/534230/artifacts

```
<problems is_local_tool="true">
<problem>
<file>file://$PROJECT_DIR$/src/it/java/org/checkstyle/suppressionxpathfilter/XpathRegressionExecutableStatementCountTest.java</file>
<line>125</line>
<module>project</module>
<package>org.checkstyle.suppressionxpathfilter</package>
<entry_point TYPE="method" FQNAME="org.checkstyle.suppressionxpathfilter.XpathRegressionExecutableStatementCountTest void testLambdas()"/>
<problem_class id="ArraysAsListWithZeroOrOneArgument" severity="ERROR" attribute_key="ERRORS_ATTRIBUTES">Call to 'Arrays.asList()' with too few arguments</problem_class>
<description>Call to <code>asList()</code> with only one argument #loc</description>
<highlighted_element>asList</highlighted_element>
<language>JAVA</language>
<offset>57</offset>
<length>6</length>
</problem>
</problems>


```