### PR TITLE
Issue #12586: Optimize testing methods to run check one time over a file

### DIFF
--- a/src/test/java/com/puppycrawl/tools/checkstyle/TreeWalkerTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/TreeWalkerTest.java
@@ -98,7 +98,7 @@ public class TreeWalkerTest extends AbstractModuleTestSupport {
             "10:27: " + getCheckMessage(ConstantNameCheck.class,
                         MSG_INVALID_PATTERN, "k", "^[A-Z][A-Z0-9]*(_[A-Z0-9]+)*$"),
         };
-        verifyWithInlineConfigParser(path, expected);
+        verifyWithInlineConfigParserTwice(path, expected);
     }
 
     /**
@@ -133,7 +133,7 @@ public class TreeWalkerTest extends AbstractModuleTestSupport {
                  Mockito.mockConstruction(TreeWalkerAuditEvent.class, (mock, context) -> {
                      throw new CheckstyleException("No audit events expected");
                  })) {
-            verifyWithInlineConfigParser(getPath("InputTreeWalker.java"), expected);
+            verifyWithInlineConfigParserTwice(getPath("InputTreeWalker.java"), expected);
         }
     }
 
@@ -158,7 +158,7 @@ public class TreeWalkerTest extends AbstractModuleTestSupport {
             // This will re-enable walk(..., AstState.WITH_COMMENTS)
             parser.when(() -> JavaParser.appendHiddenCommentNodes(mockAst)).thenReturn(realAst);
 
-            verifyWithInlineConfigParser(path, expected);
+            verifyWithInlineConfigParserTwice(path, expected);
         }
     }
 
@@ -178,7 +178,7 @@ public class TreeWalkerTest extends AbstractModuleTestSupport {
             parser.when(() -> JavaParser.appendHiddenCommentNodes(any(DetailAST.class)))
                     .thenThrow(IllegalStateException.class);
 
-            verifyWithInlineConfigParser(getPath("InputTreeWalker.java"), expected);
+            verifyWithInlineConfigParserTwice(getPath("InputTreeWalker.java"), expected);
         }
     }
 
@@ -189,7 +189,7 @@ public class TreeWalkerTest extends AbstractModuleTestSupport {
         final File tempFile = new File(temporaryFolder, "file.pdf");
         Files.copy(originalFile.toPath(), tempFile.toPath(), StandardCopyOption.REPLACE_EXISTING);
         final String[] expected = CommonUtil.EMPTY_STRING_ARRAY;
-        verifyWithInlineConfigParser(tempFile.getPath(), expected);
+        verifyWithInlineConfigParserTwice(tempFile.getPath(), expected);
     }
 
     @Test
@@ -354,7 +354,7 @@ public class TreeWalkerTest extends AbstractModuleTestSupport {
     public void testWithCacheWithNoViolation() throws Exception {
         final String path = getPath("InputTreeWalkerWithCacheWithNoViolation.java");
         final String[] expected = CommonUtil.EMPTY_STRING_ARRAY;
-        verifyWithInlineConfigParser(path, expected);
+        verifyWithInlineConfigParserTwice(path, expected);
     }
 
     @Test
@@ -416,7 +416,7 @@ public class TreeWalkerTest extends AbstractModuleTestSupport {
             writer.write(configComment);
         }
         final String[] expected = CommonUtil.EMPTY_STRING_ARRAY;
-        verifyWithInlineConfigParser(file.getPath(), expected);
+        verifyWithInlineConfigParserTwice(file.getPath(), expected);
     }
 
     @Test
@@ -496,7 +496,7 @@ public class TreeWalkerTest extends AbstractModuleTestSupport {
                     "^[a-z][a-zA-Z0-9]*$"),
         };
 
-        verifyWithInlineConfigParser(
+        verifyWithInlineConfigParserTwice(
                 getPath("InputTreeWalkerSuppressionCommentFilter.java"),
                 expected);
     }
@@ -509,7 +509,7 @@ public class TreeWalkerTest extends AbstractModuleTestSupport {
             "13:9: " + getCheckMessage(WhitespaceAroundCheck.class, "ws.notFollowed", "if"),
         };
 
-        verifyWithInlineConfigParser(
+        verifyWithInlineConfigParserTwice(
                 getPath("InputTreeWalkerMultiCheckOrder.java"),
                 expected);
     }
@@ -524,7 +524,7 @@ public class TreeWalkerTest extends AbstractModuleTestSupport {
                     "name.invalidPattern", "b", "^[a-z][a-z0-9][a-zA-Z0-9]*$"),
         };
 
-        verifyWithInlineConfigParser(
+        verifyWithInlineConfigParserTwice(
                 getPath("InputTreeWalkerMultiCheckOrder2.java"),
                 expected);
     }
@@ -614,7 +614,7 @@ public class TreeWalkerTest extends AbstractModuleTestSupport {
                 + "/InputTreeWalkerSuppressionXpathFilterAbsolute.java";
 
         final String[] expected = CommonUtil.EMPTY_STRING_ARRAY;
-        verifyWithInlineConfigParser(filePath, expected);
+        verifyWithInlineConfigParserTwice(filePath, expected);
     }
 
     @Test

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/javadoc/AbstractJavadocCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/javadoc/AbstractJavadocCheckTest.java
@@ -196,9 +196,7 @@ public class AbstractJavadocCheckTest extends AbstractModuleTestSupport {
         verifyWithInlineConfigParser(getPath("InputAbstractJavadocPositionOne.java"), expected);
         assertWithMessage("Invalid number of javadocs")
             .that(JavadocCatchCheck.javadocsNumber)
-            // until https://github.com/checkstyle/checkstyle/issues/12586
-            // actual javadoc count is 21, but verifyWithInlineConfigParser verify file twice
-            .isEqualTo(42);
+            .isEqualTo(21);
     }
 
     @Test
@@ -208,9 +206,7 @@ public class AbstractJavadocCheckTest extends AbstractModuleTestSupport {
         verifyWithInlineConfigParser(getPath("InputAbstractJavadocPositionTwo.java"), expected);
         assertWithMessage("Invalid number of javadocs")
             .that(JavadocCatchCheck.javadocsNumber)
-            // until https://github.com/checkstyle/checkstyle/issues/12586
-            // actual javadoc count is 29, but verifyWithInlineConfigParser verify file twice
-            .isEqualTo(58);
+            .isEqualTo(29);
     }
 
     @Test
@@ -220,9 +216,7 @@ public class AbstractJavadocCheckTest extends AbstractModuleTestSupport {
         verifyWithInlineConfigParser(getPath("InputAbstractJavadocPositionThree.java"), expected);
         assertWithMessage("Invalid number of javadocs")
             .that(JavadocCatchCheck.javadocsNumber)
-            // until https://github.com/checkstyle/checkstyle/issues/12586
-            // actual javadoc count is 15, but verifyWithInlineConfigParser verify file twice
-            .isEqualTo(30);
+            .isEqualTo(15);
     }
 
     @Test
@@ -233,9 +227,7 @@ public class AbstractJavadocCheckTest extends AbstractModuleTestSupport {
                 getPath("InputAbstractJavadocPositionWithSinglelineCommentsOne.java"), expected);
         assertWithMessage("Invalid number of javadocs")
             .that(JavadocCatchCheck.javadocsNumber)
-            // until https://github.com/checkstyle/checkstyle/issues/12586
-            // actual javadoc count is 21, but verifyWithInlineConfigParser verify file twice
-            .isEqualTo(42);
+            .isEqualTo(21);
     }
 
     @Test
@@ -246,9 +238,7 @@ public class AbstractJavadocCheckTest extends AbstractModuleTestSupport {
                 getPath("InputAbstractJavadocPositionWithSinglelineCommentsTwo.java"), expected);
         assertWithMessage("Invalid number of javadocs")
             .that(JavadocCatchCheck.javadocsNumber)
-            // until https://github.com/checkstyle/checkstyle/issues/12586
-            // actual javadoc count is 29, but verifyWithInlineConfigParser verify file twice
-            .isEqualTo(58);
+            .isEqualTo(29);
     }
 
     @Test
@@ -259,9 +249,7 @@ public class AbstractJavadocCheckTest extends AbstractModuleTestSupport {
                 getPath("InputAbstractJavadocPositionWithSinglelineCommentsThree.java"), expected);
         assertWithMessage("Invalid number of javadocs")
             .that(JavadocCatchCheck.javadocsNumber)
-            // until https://github.com/checkstyle/checkstyle/issues/12586
-            // actual javadoc count is 15, but verifyWithInlineConfigParser verify file twice
-            .isEqualTo(30);
+            .isEqualTo(15);
     }
 
     @Test

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/javadoc/WriteTagCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/javadoc/WriteTagCheckTest.java
@@ -60,7 +60,7 @@ public class WriteTagCheckTest extends AbstractModuleTestSupport {
         final String[] expected = {
             "15: " + getCheckMessage(MSG_WRITE_TAG, "@author", "Daniel Grenner"),
         };
-        verifyWithInlineConfigParser(getPath("InputWriteTag.java"), expected);
+        verifyWithInlineConfigParserTwice(getPath("InputWriteTag.java"), expected);
     }
 
     @Test
@@ -68,7 +68,8 @@ public class WriteTagCheckTest extends AbstractModuleTestSupport {
         final String[] expected = {
             "15: " + getCheckMessage(MSG_WRITE_TAG, "@author", "Daniel Grenner"),
         };
-        verifyWithInlineConfigParser(getPath("InputWriteTagMissingFormat.java"), expected);
+        verifyWithInlineConfigParserTwice(
+                getPath("InputWriteTagMissingFormat.java"), expected);
     }
 
     @Test
@@ -77,7 +78,8 @@ public class WriteTagCheckTest extends AbstractModuleTestSupport {
             "16: " + getCheckMessage(MSG_WRITE_TAG, "@incomplete",
                 "This class needs more code..."),
         };
-        verifyWithInlineConfigParser(getPath("InputWriteTagIncomplete.java"), expected);
+        verifyWithInlineConfigParserTwice(
+                getPath("InputWriteTagIncomplete.java"), expected);
     }
 
     @Test
@@ -86,7 +88,8 @@ public class WriteTagCheckTest extends AbstractModuleTestSupport {
             "18: " + getCheckMessage(MSG_WRITE_TAG, "@doubletag", "first text"),
             "19: " + getCheckMessage(MSG_WRITE_TAG, "@doubletag", "second text"),
         };
-        verifyWithInlineConfigParser(getPath("InputWriteTagDoubleTag.java"), expected);
+        verifyWithInlineConfigParserTwice(
+                getPath("InputWriteTagDoubleTag.java"), expected);
     }
 
     @Test
@@ -94,7 +97,8 @@ public class WriteTagCheckTest extends AbstractModuleTestSupport {
         final String[] expected = {
             "19: " + getCheckMessage(MSG_WRITE_TAG, "@emptytag", ""),
         };
-        verifyWithInlineConfigParser(getPath("InputWriteTagEmptyTag.java"), expected);
+        verifyWithInlineConfigParserTwice(
+                getPath("InputWriteTagEmptyTag.java"), expected);
     }
 
     @Test
@@ -102,7 +106,8 @@ public class WriteTagCheckTest extends AbstractModuleTestSupport {
         final String[] expected = {
             "20: " + getCheckMessage(MSG_MISSING_TAG, "@missingtag"),
         };
-        verifyWithInlineConfigParser(getPath("InputWriteTagMissingTag.java"), expected);
+        verifyWithInlineConfigParserTwice(
+                getPath("InputWriteTagMissingTag.java"), expected);
     }
 
     @Test
@@ -112,7 +117,8 @@ public class WriteTagCheckTest extends AbstractModuleTestSupport {
                     "Add a constructor comment"),
             "36: " + getCheckMessage(MSG_WRITE_TAG, "@todo", "Add a comment"),
         };
-        verifyWithInlineConfigParser(getPath("InputWriteTagMethod.java"), expected);
+        verifyWithInlineConfigParserTwice(
+                getPath("InputWriteTagMethod.java"), expected);
     }
 
     @Test
@@ -120,19 +126,21 @@ public class WriteTagCheckTest extends AbstractModuleTestSupport {
         final String[] expected = {
             "16: " + getCheckMessage(MSG_WRITE_TAG, "@author", "Daniel Grenner"),
         };
-        verifyWithInlineConfigParser(getPath("InputWriteTagSeverity.java"), expected);
+        verifyWithInlineConfigParserTwice(
+                getPath("InputWriteTagSeverity.java"), expected);
     }
 
     @Test
     public void testIgnoreMissing() throws Exception {
         final String[] expected = CommonUtil.EMPTY_STRING_ARRAY;
-        verifyWithInlineConfigParser(getPath("InputWriteTagIgnore.java"), expected);
+        verifyWithInlineConfigParserTwice(getPath("InputWriteTagIgnore.java"), expected);
     }
 
     @Test
     public void testRegularEx() throws Exception {
         final String[] expected = CommonUtil.EMPTY_STRING_ARRAY;
-        verifyWithInlineConfigParser(getPath("InputWriteTagRegularExpression.java"), expected);
+        verifyWithInlineConfigParserTwice(
+                getPath("InputWriteTagRegularExpression.java"), expected);
     }
 
     @Test
@@ -140,7 +148,8 @@ public class WriteTagCheckTest extends AbstractModuleTestSupport {
         final String[] expected = {
             "15: " + getCheckMessage(MSG_TAG_FORMAT, "@author", "ABC"),
         };
-        verifyWithInlineConfigParser(getPath("InputWriteTagExpressionError.java"), expected);
+        verifyWithInlineConfigParserTwice(
+                getPath("InputWriteTagExpressionError.java"), expected);
     }
 
     @Test
@@ -155,7 +164,8 @@ public class WriteTagCheckTest extends AbstractModuleTestSupport {
             "33: " + getCheckMessage(MSG_WRITE_TAG, "@incomplete",
                     "This annotation field needs more code..."),
         };
-        verifyWithInlineConfigParser(getPath("InputWriteTagEnumsAndAnnotations.java"), expected);
+        verifyWithInlineConfigParserTwice(
+                getPath("InputWriteTagEnumsAndAnnotations.java"), expected);
     }
 
     @Test
@@ -163,7 +173,7 @@ public class WriteTagCheckTest extends AbstractModuleTestSupport {
         final String[] expected = {
             "13: " + getCheckMessage(MSG_MISSING_TAG, "null"),
         };
-        verifyWithInlineConfigParser(getPath("InputWriteTagNoJavadoc.java"), expected);
+        verifyWithInlineConfigParserTwice(getPath("InputWriteTagNoJavadoc.java"), expected);
     }
 
     @Test
@@ -184,7 +194,7 @@ public class WriteTagCheckTest extends AbstractModuleTestSupport {
             "62: " + getCheckMessage(MSG_WRITE_TAG, "@incomplete",
                     "Failed to recognize 'record' introduced in Java 14."),
         };
-        verifyWithInlineConfigParser(
+        verifyWithInlineConfigParserTwice(
             getNonCompilablePath("InputWriteTagRecordsAndCompactCtors.java"), expected);
     }
 


### PR DESCRIPTION
First step for #12586:   

this is not the final fix I just want to make sure that I am on the right direction also I faced some errors want to discuss them. IMO once this optimization is completed and reaches its final form, it will provide significant benefits. specifically aims to improve the process of ` mvn test` and `mvn clean verify.`

