### PR TITLE
Issue #6207: Added Xpath IT Regression test for ParameterAssignmentCheck

### DIFF
--- a/src/it/java/org/checkstyle/suppressionxpathfilter/XpathRegressionParameterAssignmentTest.java
+++ b/src/it/java/org/checkstyle/suppressionxpathfilter/XpathRegressionParameterAssignmentTest.java
@@ -1,0 +1,124 @@
+///////////////////////////////////////////////////////////////////////////////////////////////
+// checkstyle: Checks Java source code and other text files for adherence to a set of rules.
+// Copyright (C) 2001-2024 the original author or authors.
+//
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the GNU Lesser General Public
+// License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+//
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+// Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public
+// License along with this library; if not, write to the Free Software
+// Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+///////////////////////////////////////////////////////////////////////////////////////////////
+
+package org.checkstyle.suppressionxpathfilter;
+
+import static com.puppycrawl.tools.checkstyle.checks.coding.ParameterAssignmentCheck.MSG_KEY;
+
+import java.io.File;
+import java.util.Arrays;
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+
+import com.puppycrawl.tools.checkstyle.DefaultConfiguration;
+import com.puppycrawl.tools.checkstyle.checks.coding.ParameterAssignmentCheck;
+
+public class XpathRegressionParameterAssignmentTest extends AbstractXpathTestSupport {
+
+    @Override
+    protected String getCheckName() {
+        return ParameterAssignmentCheck.class.getSimpleName();
+    }
+
+    @Test
+    public void testMethods() throws Exception {
+        final String filePath =
+                getPath("SuppressionXpathRegressionParameterAssignmentMethods.java");
+        final File fileToProcess = new File(filePath);
+
+        final DefaultConfiguration moduleConfig =
+                createModuleConfig(ParameterAssignmentCheck.class);
+
+        final String[] expectedViolations = {
+            "9:15: " + getCheckMessage(ParameterAssignmentCheck.class, MSG_KEY, "field"),
+        };
+
+        final List<String> expectedXpathQueries = Arrays.asList(
+            "/COMPILATION_UNIT/CLASS_DEF[./IDENT["
+            + "@text='SuppressionXpathRegressionParameterAssignmentMethods']]"
+            + "/OBJBLOCK/METHOD_DEF[./IDENT[@text='Test1']]/SLIST/EXPR"
+            + "[./PLUS_ASSIGN/IDENT[@text='field']]",
+            "/COMPILATION_UNIT/CLASS_DEF[./IDENT["
+            + "@text='SuppressionXpathRegressionParameterAssignmentMethods']]"
+            + "/OBJBLOCK/METHOD_DEF[./IDENT[@text='Test1']]"
+            + "/SLIST/EXPR/PLUS_ASSIGN[./IDENT[@text='field']]"
+        );
+
+        runVerifications(moduleConfig, fileToProcess, expectedViolations, expectedXpathQueries);
+
+    }
+
+    @Test
+    public void testLambdas() throws Exception {
+        final String filePath =
+                getPath("SuppressionXpathRegressionParameterAssignmentLambdas.java");
+        final File fileToProcess = new File(filePath);
+
+        final DefaultConfiguration moduleConfig =
+                createModuleConfig(ParameterAssignmentCheck.class);
+
+        final String[] expectedViolations = {
+            "9:32: " + getCheckMessage(ParameterAssignmentCheck.class, MSG_KEY, "q"),
+        };
+
+        final List<String> expectedXpathQueries = Arrays.asList(
+            "/COMPILATION_UNIT/CLASS_DEF[./IDENT["
+            + "@text='SuppressionXpathRegressionParameterAssignmentLambdas']]"
+            + "/OBJBLOCK/VARIABLE_DEF[./IDENT[@text='obj1']]"
+            + "/ASSIGN/LAMBDA[./IDENT[@text='q']]/EXPR",
+            "/COMPILATION_UNIT/CLASS_DEF[./IDENT["
+            + "@text='SuppressionXpathRegressionParameterAssignmentLambdas']]"
+            + "/OBJBLOCK/VARIABLE_DEF[./IDENT[@text='obj1']]/ASSIGN/LAMBDA[./IDENT["
+            + "@text='q']]/EXPR/POST_INC[./IDENT[@text='q']]"
+        );
+
+        runVerifications(moduleConfig, fileToProcess, expectedViolations, expectedXpathQueries);
+    }
+
+    @Test
+    public void testCtor() throws Exception {
+        final String filePath =
+                getPath("SuppressionXpathRegressionParameterAssignmentCtor.java");
+        final File fileToProcess = new File(filePath);
+
+        final DefaultConfiguration moduleConfig =
+                createModuleConfig(ParameterAssignmentCheck.class);
+
+        final String[] expectedViolations = {
+            "9:15: " + getCheckMessage(ParameterAssignmentCheck.class, MSG_KEY, "field"),
+        };
+
+        final List<String> expectedXpathQueries = Arrays.asList(
+            "/COMPILATION_UNIT/CLASS_DEF[./IDENT["
+            + "@text='SuppressionXpathRegressionParameterAssignmentCtor']]"
+            + "/OBJBLOCK/CTOR_DEF[./IDENT["
+            + "@text='SuppressionXpathRegressionParameterAssignmentCtor']]"
+            + "/SLIST/EXPR[./PLUS_ASSIGN/IDENT[@text='field']]",
+            "/COMPILATION_UNIT/CLASS_DEF[./IDENT["
+            + "@text='SuppressionXpathRegressionParameterAssignmentCtor']]"
+            + "/OBJBLOCK/CTOR_DEF[./IDENT["
+            + "@text='SuppressionXpathRegressionParameterAssignmentCtor']]"
+            + "/SLIST/EXPR/PLUS_ASSIGN[./IDENT[@text='field']]"
+        );
+
+        runVerifications(moduleConfig, fileToProcess, expectedViolations, expectedXpathQueries);
+    }
+
+}

--- a/src/it/resources/org/checkstyle/suppressionxpathfilter/parameterassignment/SuppressionXpathRegressionParameterAssignmentCtor.java
+++ b/src/it/resources/org/checkstyle/suppressionxpathfilter/parameterassignment/SuppressionXpathRegressionParameterAssignmentCtor.java
@@ -1,0 +1,16 @@
+package org.checkstyle.suppressionxpathfilter.parameterassignment;
+
+public class SuppressionXpathRegressionParameterAssignmentCtor {
+    int field;
+    SuppressionXpathRegressionParameterAssignmentCtor(int field) {
+        int i = field;
+        this.field = field;
+        i++;
+        field += 1; // warn
+        this.field++;
+    }
+    // without parameters
+    SuppressionXpathRegressionParameterAssignmentCtor() {
+        field = 0;
+    }
+}

--- a/src/it/resources/org/checkstyle/suppressionxpathfilter/parameterassignment/SuppressionXpathRegressionParameterAssignmentLambdas.java
+++ b/src/it/resources/org/checkstyle/suppressionxpathfilter/parameterassignment/SuppressionXpathRegressionParameterAssignmentLambdas.java
@@ -1,0 +1,18 @@
+package org.checkstyle.suppressionxpathfilter.parameterassignment;
+
+public class SuppressionXpathRegressionParameterAssignmentLambdas {
+
+    public interface SomeInterface {
+        void method(int a);
+    }
+
+    SomeInterface obj1 = q -> q++; // warn
+    void method() {
+        int q = 12;
+        SomeInterface obj = (d) -> {
+            SomeInterface b = (c) -> obj1.equals(this); // ok
+            int c = 12;
+            c++;
+        };
+    }
+}

--- a/src/it/resources/org/checkstyle/suppressionxpathfilter/parameterassignment/SuppressionXpathRegressionParameterAssignmentMethods.java
+++ b/src/it/resources/org/checkstyle/suppressionxpathfilter/parameterassignment/SuppressionXpathRegressionParameterAssignmentMethods.java
@@ -1,0 +1,16 @@
+package org.checkstyle.suppressionxpathfilter.parameterassignment;
+
+public class SuppressionXpathRegressionParameterAssignmentMethods {
+    int field;
+    void Test1(int field) {
+        int i = field;
+        this.field = field;
+        i++;
+        field += 1; // warn
+        this.field++;
+    }
+    // without parameters
+    void Test2() {
+        field = 0;
+    }
+}

--- a/src/test/java/com/puppycrawl/tools/checkstyle/internal/XpathRegressionTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/internal/XpathRegressionTest.java
@@ -102,7 +102,6 @@ public class XpathRegressionTest extends AbstractModuleTestSupport {
             "MethodTypeParameterName",
             "ModifiedControlVariable",
             "MutableException",
-            "ParameterAssignment",
             "RedundantModifier",
             "SeparatorWrap",
             "SuperFinalize",


### PR DESCRIPTION
Part of #6207 

Added new Xpath IT Regression test for ParameterAssignmentCheck
The check doesn't involve usage of config properties. So, created two files for different scenarios

`Update` : Created one more file to show violations in _**Ctor**_ parameter assignment.