### PR TITLE
Issue #14533: Documentation fix Updated False description and Docs for AtclauseOrderCheck

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/AtclauseOrderCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/AtclauseOrderCheck.java
@@ -48,7 +48,7 @@ import com.puppycrawl.tools.checkstyle.utils.TokenUtil;
  * Property {@code tagOrder} - Specify the order by tags.
  * Type is {@code java.lang.String[]}.
  * Default value is
- * {@code @author, @deprecated, @exception, @param, @return, @see, @serial, @serialData, @serialField, @since, @throws, @version}.
+ * {@code @author, @version, @param, @return, @throws, @exception, @see, @since, @serial, @serialField, @serialData, @deprecated}.
  * </li>
  * <li>
  * Property {@code target} - Specify block tags targeted.

--- a/src/main/resources/com/puppycrawl/tools/checkstyle/meta/checks/javadoc/AtclauseOrderCheck.xml
+++ b/src/main/resources/com/puppycrawl/tools/checkstyle/meta/checks/javadoc/AtclauseOrderCheck.xml
@@ -13,7 +13,7 @@
  Note: Google used the term "at-clauses" for block tags in their guide till 2017-02-28.
  &lt;/p&gt;</description>
          <properties>
-            <property default-value="@author, @deprecated, @exception, @param, @return, @see, @serial, @serialData, @serialField, @since, @throws, @version"
+            <property default-value="@author, @version, @param, @return, @throws, @exception, @see, @since, @serial, @serialField, @serialData, @deprecated"
                       name="tagOrder"
                       type="java.lang.String[]">
                <description>Specify the order by tags.</description>

--- a/src/test/resources-noncompilable/com/puppycrawl/tools/checkstyle/checks/javadoc/atclauseorder/InputAtclauseOrderLotsOfRecords1.java
+++ b/src/test/resources-noncompilable/com/puppycrawl/tools/checkstyle/checks/javadoc/atclauseorder/InputAtclauseOrderLotsOfRecords1.java
@@ -3,8 +3,8 @@ AtclauseOrder
 violateExecutionOnNonTightHtml = (default)false
 target = (default)CLASS_DEF, INTERFACE_DEF, ENUM_DEF, METHOD_DEF, \
          CTOR_DEF, VARIABLE_DEF, RECORD_DEF, COMPACT_CTOR_DEF
-tagOrder = @author, @version, @param, @return, @throws, @exception, @see, @since, @serial, \
-           @serialField, @serialData, @deprecated
+tagOrder = (default)@author, @version, @param, @return, @throws, @exception, \
+            @see, @since, @serial, @serialField, @serialData, @deprecated
 
 
 */

--- a/src/test/resources-noncompilable/com/puppycrawl/tools/checkstyle/checks/javadoc/atclauseorder/InputAtclauseOrderLotsOfRecords2.java
+++ b/src/test/resources-noncompilable/com/puppycrawl/tools/checkstyle/checks/javadoc/atclauseorder/InputAtclauseOrderLotsOfRecords2.java
@@ -3,8 +3,8 @@ AtclauseOrder
 violateExecutionOnNonTightHtml = (default)false
 target = (default)CLASS_DEF, INTERFACE_DEF, ENUM_DEF, METHOD_DEF, \
          CTOR_DEF, VARIABLE_DEF, RECORD_DEF, COMPACT_CTOR_DEF
-tagOrder = @author, @version, @param, @return, @throws, @exception, @see, @since, @serial, \
-           @serialField, @serialData, @deprecated
+tagOrder = (default)@author, @version, @param, @return, @throws, @exception, \
+            @see, @since, @serial, @serialField, @serialData, @deprecated
 
 
 */

--- a/src/test/resources-noncompilable/com/puppycrawl/tools/checkstyle/checks/javadoc/atclauseorder/InputAtclauseOrderLotsOfRecords3.java
+++ b/src/test/resources-noncompilable/com/puppycrawl/tools/checkstyle/checks/javadoc/atclauseorder/InputAtclauseOrderLotsOfRecords3.java
@@ -3,8 +3,8 @@ AtclauseOrder
 violateExecutionOnNonTightHtml = (default)false
 target = (default)CLASS_DEF, INTERFACE_DEF, ENUM_DEF, METHOD_DEF, \
          CTOR_DEF, VARIABLE_DEF, RECORD_DEF, COMPACT_CTOR_DEF
-tagOrder = @author, @version, @param, @return, @throws, @exception, @see, @since, @serial, \
-           @serialField, @serialData, @deprecated
+tagOrder = (default)@author, @version, @param, @return, @throws, @exception, \
+            @see, @since, @serial, @serialField, @serialData, @deprecated
 
 
 */

--- a/src/test/resources-noncompilable/com/puppycrawl/tools/checkstyle/checks/javadoc/atclauseorder/InputAtclauseOrderLotsOfRecords4.java
+++ b/src/test/resources-noncompilable/com/puppycrawl/tools/checkstyle/checks/javadoc/atclauseorder/InputAtclauseOrderLotsOfRecords4.java
@@ -3,8 +3,8 @@ AtclauseOrder
 violateExecutionOnNonTightHtml = (default)false
 target = (default)CLASS_DEF, INTERFACE_DEF, ENUM_DEF, METHOD_DEF, \
          CTOR_DEF, VARIABLE_DEF, RECORD_DEF, COMPACT_CTOR_DEF
-tagOrder = @author, @version, @param, @return, @throws, @exception, @see, @since, @serial, \
-           @serialField, @serialData, @deprecated
+tagOrder = (default)@author, @version, @param, @return, @throws, @exception, \
+            @see, @since, @serial, @serialField, @serialData, @deprecated
 
 
 */

--- a/src/test/resources-noncompilable/com/puppycrawl/tools/checkstyle/checks/javadoc/atclauseorder/InputAtclauseOrderRecords.java
+++ b/src/test/resources-noncompilable/com/puppycrawl/tools/checkstyle/checks/javadoc/atclauseorder/InputAtclauseOrderRecords.java
@@ -3,8 +3,8 @@ AtclauseOrder
 violateExecutionOnNonTightHtml = (default)false
 target = (default)CLASS_DEF, INTERFACE_DEF, ENUM_DEF, METHOD_DEF, \
          CTOR_DEF, VARIABLE_DEF, RECORD_DEF, COMPACT_CTOR_DEF
-tagOrder = @author, @version, @param, @return, @throws, @exception, @see, @since, @serial, \
-           @serialField, @serialData, @deprecated
+tagOrder = (default)@author, @version, @param, @return, @throws, @exception, \
+            @see, @since, @serial, @serialField, @serialData, @deprecated
 
 
 */

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/atclauseorder/InputAtclauseOrderCorrect1.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/atclauseorder/InputAtclauseOrderCorrect1.java
@@ -3,8 +3,8 @@ AtclauseOrder
 violateExecutionOnNonTightHtml = (default)false
 target = (default)CLASS_DEF, INTERFACE_DEF, ENUM_DEF, METHOD_DEF, \
          CTOR_DEF, VARIABLE_DEF, RECORD_DEF, COMPACT_CTOR_DEF
-tagOrder = (default)@author, @deprecated, @exception, @param, @return, \
-           @see, @serial, @serialData, @serialField, @since, @throws, @version
+tagOrder = (default)@author, @version, @param, @return, @throws, @exception, \
+            @see, @since, @serial, @serialField, @serialData, @deprecated
 
 
 */

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/atclauseorder/InputAtclauseOrderCorrect2.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/atclauseorder/InputAtclauseOrderCorrect2.java
@@ -3,8 +3,8 @@ AtclauseOrder
 violateExecutionOnNonTightHtml = (default)false
 target = (default)CLASS_DEF, INTERFACE_DEF, ENUM_DEF, METHOD_DEF, \
          CTOR_DEF, VARIABLE_DEF, RECORD_DEF, COMPACT_CTOR_DEF
-tagOrder = (default)@author, @deprecated, @exception, @param, @return, \
-           @see, @serial, @serialData, @serialField, @since, @throws, @version
+tagOrder = (default)@author, @version, @param, @return, @throws, @exception, \
+            @see, @since, @serial, @serialField, @serialData, @deprecated
 
 
 */

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/atclauseorder/InputAtclauseOrderCorrect3.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/atclauseorder/InputAtclauseOrderCorrect3.java
@@ -3,8 +3,8 @@ AtclauseOrder
 violateExecutionOnNonTightHtml = (default)false
 target = (default)CLASS_DEF, INTERFACE_DEF, ENUM_DEF, METHOD_DEF, \
          CTOR_DEF, VARIABLE_DEF, RECORD_DEF, COMPACT_CTOR_DEF
-tagOrder = (default)@author, @deprecated, @exception, @param, @return, \
-           @see, @serial, @serialData, @serialField, @since, @throws, @version
+tagOrder = (default)@author, @version, @param, @return, @throws, @exception, \
+            @see, @since, @serial, @serialField, @serialData, @deprecated
 
 
 */

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/atclauseorder/InputAtclauseOrderCorrect4.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/atclauseorder/InputAtclauseOrderCorrect4.java
@@ -3,8 +3,8 @@ AtclauseOrder
 violateExecutionOnNonTightHtml = (default)false
 target = (default)CLASS_DEF, INTERFACE_DEF, ENUM_DEF, METHOD_DEF, \
          CTOR_DEF, VARIABLE_DEF, RECORD_DEF, COMPACT_CTOR_DEF
-tagOrder = (default)@author, @deprecated, @exception, @param, @return, \
-           @see, @serial, @serialData, @serialField, @since, @throws, @version
+tagOrder = (default)@author, @version, @param, @return, @throws, @exception, \
+            @see, @since, @serial, @serialField, @serialData, @deprecated
 
 
 */

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/atclauseorder/InputAtclauseOrderIncorrect1.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/atclauseorder/InputAtclauseOrderIncorrect1.java
@@ -3,8 +3,8 @@ AtclauseOrder
 violateExecutionOnNonTightHtml = (default)false
 target = (default)CLASS_DEF, INTERFACE_DEF, ENUM_DEF, METHOD_DEF, \
          CTOR_DEF, VARIABLE_DEF, RECORD_DEF, COMPACT_CTOR_DEF
-tagOrder = (default)@author, @deprecated, @exception, @param, @return, \
-           @see, @serial, @serialData, @serialField, @since, @throws, @version
+tagOrder = (default)@author, @version, @param, @return, @throws, @exception, \
+            @see, @since, @serial, @serialField, @serialData, @deprecated
 
 
 */

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/atclauseorder/InputAtclauseOrderIncorrect2.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/atclauseorder/InputAtclauseOrderIncorrect2.java
@@ -3,8 +3,8 @@ AtclauseOrder
 violateExecutionOnNonTightHtml = (default)false
 target = (default)CLASS_DEF, INTERFACE_DEF, ENUM_DEF, METHOD_DEF, \
          CTOR_DEF, VARIABLE_DEF, RECORD_DEF, COMPACT_CTOR_DEF
-tagOrder = (default)@author, @deprecated, @exception, @param, @return, \
-           @see, @serial, @serialData, @serialField, @since, @throws, @version
+tagOrder = (default)@author, @version, @param, @return, @throws, @exception, \
+            @see, @since, @serial, @serialField, @serialData, @deprecated
 
 
 */

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/atclauseorder/InputAtclauseOrderIncorrect3.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/atclauseorder/InputAtclauseOrderIncorrect3.java
@@ -3,8 +3,8 @@ AtclauseOrder
 violateExecutionOnNonTightHtml = (default)false
 target = (default)CLASS_DEF, INTERFACE_DEF, ENUM_DEF, METHOD_DEF, \
          CTOR_DEF, VARIABLE_DEF, RECORD_DEF, COMPACT_CTOR_DEF
-tagOrder = (default)@author, @deprecated, @exception, @param, @return, \
-           @see, @serial, @serialData, @serialField, @since, @throws, @version
+tagOrder = (default)@author, @version, @param, @return, @throws, @exception, \
+            @see, @since, @serial, @serialField, @serialData, @deprecated
 
 
 */

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/atclauseorder/InputAtclauseOrderIncorrect4.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/atclauseorder/InputAtclauseOrderIncorrect4.java
@@ -3,8 +3,8 @@ AtclauseOrder
 violateExecutionOnNonTightHtml = (default)false
 target = (default)CLASS_DEF, INTERFACE_DEF, ENUM_DEF, METHOD_DEF, \
          CTOR_DEF, VARIABLE_DEF, RECORD_DEF, COMPACT_CTOR_DEF
-tagOrder = (default)@author, @deprecated, @exception, @param, @return, \
-           @see, @serial, @serialData, @serialField, @since, @throws, @version
+tagOrder = (default)@author, @version, @param, @return, @throws, @exception, \
+            @see, @since, @serial, @serialField, @serialData, @deprecated
 
 
 */

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/atclauseorder/InputAtclauseOrderMethodReturningArrayType.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/atclauseorder/InputAtclauseOrderMethodReturningArrayType.java
@@ -3,8 +3,8 @@ AtclauseOrder
 violateExecutionOnNonTightHtml = (default)false
 target = (default)CLASS_DEF, INTERFACE_DEF, ENUM_DEF, METHOD_DEF, \
          CTOR_DEF, VARIABLE_DEF, RECORD_DEF, COMPACT_CTOR_DEF
-tagOrder = (default)@author, @deprecated, @exception, @param, @return, \
-           @see, @serial, @serialData, @serialField, @since, @throws, @version
+tagOrder = (default)@author, @version, @param, @return, @throws, @exception, \
+            @see, @since, @serial, @serialField, @serialData, @deprecated
 
 
 */

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/atclauseorder/InputAtclauseOrderNewArrayDeclaratorStructure.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/atclauseorder/InputAtclauseOrderNewArrayDeclaratorStructure.java
@@ -3,8 +3,8 @@ AtclauseOrder
 violateExecutionOnNonTightHtml = (default)false
 target = (default)CLASS_DEF, INTERFACE_DEF, ENUM_DEF, METHOD_DEF, \
          CTOR_DEF, VARIABLE_DEF, RECORD_DEF, COMPACT_CTOR_DEF
-tagOrder = (default)@author, @deprecated, @exception, @param, @return, \
-           @see, @serial, @serialData, @serialField, @since, @throws, @version
+tagOrder = (default)@author, @version, @param, @return, @throws, @exception, \
+            @see, @since, @serial, @serialField, @serialData, @deprecated
 
 
 */

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/atclauseorder/InputAtclauseOrderWithAnnotationsOutsideJavadoc.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/atclauseorder/InputAtclauseOrderWithAnnotationsOutsideJavadoc.java
@@ -3,8 +3,8 @@ AtclauseOrder
 violateExecutionOnNonTightHtml = (default)false
 target = (default)CLASS_DEF, INTERFACE_DEF, ENUM_DEF, METHOD_DEF, \
          CTOR_DEF, VARIABLE_DEF, RECORD_DEF, COMPACT_CTOR_DEF
-tagOrder = (default)@author, @deprecated, @exception, @param, @return, \
-           @see, @serial, @serialData, @serialField, @since, @throws, @version
+tagOrder = (default)@author, @version, @param, @return, @throws, @exception, \
+            @see, @since, @serial, @serialField, @serialData, @deprecated
 
 
 */

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/atclauseorder/package-info.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/atclauseorder/package-info.java
@@ -3,8 +3,8 @@ AtclauseOrder
 violateExecutionOnNonTightHtml = (default)false
 target = (default)CLASS_DEF, INTERFACE_DEF, ENUM_DEF, METHOD_DEF, \
          CTOR_DEF, VARIABLE_DEF, RECORD_DEF, COMPACT_CTOR_DEF
-tagOrder = (default)@author, @deprecated, @exception, @param, @return, \
-           @see, @serial, @serialData, @serialField, @since, @throws, @version
+tagOrder = (default)@author, @version, @param, @return, @throws, @exception, \
+            @see, @since, @serial, @serialField, @serialData, @deprecated
 
 
 */

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/meta/javadocmetadatascraper/ExpectedJavadocMetadataScraperAtclauseOrderCheck.txt
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/meta/javadocmetadatascraper/ExpectedJavadocMetadataScraperAtclauseOrderCheck.txt
@@ -25,8 +25,8 @@ RD_DEF,COMPACT_CTOR_DEF
 Property ValidationType: tokenSet
 Property Description: Specify block tags targeted.
 Property Type: java.lang.String[]
-Property DefaultValue: @author, @deprecated, @exception, @param, @return, @see, @serial, @ser<split>
-ialData, @serialField, @since, @throws, @version
+Property DefaultValue: @author, @version, @param, @return, @throws, @exception, @see, @since,<split>
+ @serial, @serialField, @serialData, @deprecated
 Property ValidationType: null
 Property Description: Specify the order by tags.
 ViolationMessageKey: at.clause.order

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/meta/javadocmetadatascraper/InputJavadocMetadataScraperAtclauseOrderCheck.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/meta/javadocmetadatascraper/InputJavadocMetadataScraperAtclauseOrderCheck.java
@@ -63,7 +63,7 @@ import com.puppycrawl.tools.checkstyle.StatelessCheck;
  * Property {@code tagOrder} - Specify the order by tags.
  * Type is {@code java.lang.String[]}.
  * Default value is
- * {@code @author, @deprecated, @exception, @param, @return, @see, @serial, @serialData, @serialField, @since, @throws, @version}.
+ * {@code @author, @version, @param, @return, @throws, @exception, @see, @since, @serial, @serialField, @serialData, @deprecated}.
  * </li>
  * </ul>
  * <p>

--- a/src/xdocs/checks/javadoc/atclauseorder.xml
+++ b/src/xdocs/checks/javadoc/atclauseorder.xml
@@ -33,7 +33,7 @@
               <td>tagOrder</td>
               <td>Specify the order by tags.</td>
               <td><a href="../../property_types.html#String.5B.5D">String[]</a></td>
-              <td><code>@author, @deprecated, @exception, @param, @return, @see, @serial, @serialData, @serialField, @since, @throws, @version</code></td>
+              <td><code>@author, @version, @param, @return, @throws, @exception, @see, @since, @serial, @serialField, @serialData, @deprecated</code></td>
               <td>6.0</td>
             </tr>
             <tr>


### PR DESCRIPTION
Closes #14533 

The current check description shows default order of javadoc tags as follows.

```
 * Default value is
 * {@code @author, @deprecated, @exception, @param, @return, @see, @serial, @serialData, @serialField, @since, @throws, @version}.
```
The same was reflecting in our **_outdated documentation_** : https://checkstyle.org/checks/javadoc/atclauseorder.html#Properties

After Documentation update : 

```
 * Default value is
 * {@code @author, @version, @param, @return, @throws, @exception, @see, @since, @serial, @serialField, @serialData, @deprecated}.
```