### PR TITLE
Issue #12020: False positive in RightCurly with 'alone_or_singleline'

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/blocks/RightCurlyCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/blocks/RightCurlyCheck.java
@@ -328,9 +328,16 @@ public class RightCurlyCheck extends AbstractCheck {
             nextToken = Details.getNextToken(nextToken);
         }
 
-        if (nextToken != null && nextToken.getType() == TokenTypes.DO_WHILE) {
-            final DetailAST doWhileSemi = nextToken.getParent();
-            nextToken = Details.getNextToken(doWhileSemi);
+        // sibling tokens should be allowed on a single line
+        final int[] tokensWithBlockSibling = {
+            TokenTypes.DO_WHILE,
+            TokenTypes.LITERAL_FINALLY,
+            TokenTypes.LITERAL_CATCH,
+        };
+
+        if (TokenUtil.isOfType(nextToken, tokensWithBlockSibling)) {
+            final DetailAST parent = nextToken.getParent();
+            nextToken = Details.getNextToken(parent);
         }
 
         return TokenUtil.areOnSameLine(details.lcurly, details.rcurly)

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/blocks/RightCurlyCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/blocks/RightCurlyCheckTest.java
@@ -307,6 +307,13 @@ public class RightCurlyCheckTest extends AbstractModuleTestSupport {
     }
 
     @Test
+    public void testAloneOrSingleLineTryCatchBlock() throws Exception {
+        final String[] expected = CommonUtil.EMPTY_STRING_ARRAY;
+        verifyWithInlineConfigParser(
+                getPath("InputRightCurlyTestAloneOrSinglelineTryCatchBlock.java"), expected);
+    }
+
+    @Test
     public void testCatchWithoutFinally() throws Exception {
         final String[] expected = {
             "19:9: " + getCheckMessage(MSG_KEY_LINE_SAME, "}", 9),
@@ -387,9 +394,8 @@ public class RightCurlyCheckTest extends AbstractModuleTestSupport {
     public void testTryWithResourceAloneSingle() throws Exception {
         final String[] expected = {
             "27:9: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}", 9),
-            "36:64: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}", 64),
-            "44:15: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}", 15),
-            "46:13: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}", 13),
+            "43:15: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}", 15),
+            "45:13: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}", 13),
         };
         verifyWithInlineConfigParser(
                 getPath("InputRightCurlyTryWithResourceAloneSingle.java"), expected);

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/blocks/rightcurly/InputRightCurlyTestAloneOrSinglelineTryCatchBlock.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/blocks/rightcurly/InputRightCurlyTestAloneOrSinglelineTryCatchBlock.java
@@ -1,0 +1,30 @@
+/*
+RightCurly
+option = ALONE_OR_SINGLELINE
+tokens = LITERAL_TRY, LITERAL_CATCH, LITERAL_FINALLY
+
+
+*/
+
+package com.puppycrawl.tools.checkstyle.checks.blocks.rightcurly;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+
+public class InputRightCurlyTestAloneOrSinglelineTryCatchBlock {
+
+     private void foo() {
+
+            try {
+                int i = 5; int b = 10;
+            }
+            catch (Exception e) { }
+     }
+     private void testSingleLineTryBlock() {
+         try { } catch (Exception e) { }
+         try {int x = 5;} catch (RuntimeException e) { } catch (Exception e) { }
+         try { } catch (RuntimeException e) { } catch (Exception e) { } finally { foo();}
+         try (BufferedReader br1 = new BufferedReader(null)) {} catch (IOException e) { ; }
+    }
+
+}

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/blocks/rightcurly/InputRightCurlyTryWithResourceAloneSingle.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/blocks/rightcurly/InputRightCurlyTryWithResourceAloneSingle.java
@@ -32,7 +32,6 @@ class InputRightCurlyTryWithResourceAloneSingle {
                 BufferedReader br2 = new BufferedReader(br1)) { ; }
         catch (IOException e) { ; }
         try (BufferedReader br1 = new BufferedReader(null);
-                // violation below ''}' at column 64 should be alone on a line'
                 BufferedReader br2 = new BufferedReader(br1)) {} catch (IOException e) { ; }
         try (BufferedReader br1 = new BufferedReader(null);
                 BufferedReader br2 = new BufferedReader(br1)) {


### PR DESCRIPTION
Resolves #12020:  
tryBlock at single line was raising a violation in `ALONE_OR_SINGLELINE`  option

Diff Regression config: https://gist.githubusercontent.com/mahfouz72/b3282ceb40c5ca4a56ede9f6c5194a3f/raw/bb787f9f9d73023e38b43faae582a6e4f9d6d20d/rightcurly.xml

[report](https://checkstyle-diff-reports.s3.us-east-2.amazonaws.com/9179d1b_2024114344/reports/diff/index.html) expected difference. violation has been removed for all single line try-catch blocks when `ALONE_OR_SINGLELINE`  option
