### PR TITLE
Issue #13213: Removed '//ok' from Input files along with its suppressions

### DIFF
--- a/config/checkstyle-input-suppressions.xml
+++ b/config/checkstyle-input-suppressions.xml
@@ -92,8 +92,6 @@
   <suppress id="UnnecessaryOkComment"
             files="checks[\\/]coding[\\/]onestatementperline[\\/]InputOneStatementPerLineTryWithResourcesIgnore.java"/>
   <suppress id="UnnecessaryOkComment"
-            files="checks[\\/]coding[\\/]packagedeclaration[\\/]InputPackageDeclarationPlain.java"/>
-  <suppress id="UnnecessaryOkComment"
             files="checks[\\/]coding[\\/]packagedeclaration[\\/]InputPackageDeclarationWithCommentOnly.java"/>
   <suppress id="UnnecessaryOkComment"
             files="checks[\\/]coding[\\/]requirethis[\\/]InputRequireThis15Extensions.java"/>
@@ -105,16 +103,6 @@
             files="checks[\\/]coding[\\/]requirethis[\\/]InputRequireThisBraceAlone.java"/>
   <suppress id="UnnecessaryOkComment"
             files="checks[\\/]coding[\\/]requirethis[\\/]InputRequireThisCaseGroup.java"/>
-  <suppress id="UnnecessaryOkComment"
-            files="checks[\\/]coding[\\/]requirethis[\\/]InputRequireThisEnumConstant.java"/>
-  <suppress id="UnnecessaryOkComment"
-            files="checks[\\/]coding[\\/]requirethis[\\/]InputRequireThisExtendedMethod.java"/>
-  <suppress id="UnnecessaryOkComment"
-            files="checks[\\/]coding[\\/]requirethis[\\/]InputRequireThisFinalInstanceVariable.java"/>
-  <suppress id="UnnecessaryOkComment"
-            files="checks[\\/]coding[\\/]requirethis[\\/]InputRequireThisLocalClassesInsideLambdas.java"/>
-  <suppress id="UnnecessaryOkComment"
-            files="checks[\\/]coding[\\/]requirethis[\\/]InputRequireThisMethodReferences.java"/>
   <suppress id="UnnecessaryOkComment"
             files="checks[\\/]coding[\\/]requirethis[\\/]InputRequireThisReceiver.java"/>
   <suppress id="UnnecessaryOkComment"

--- a/config/checkstyle-input-suppressions.xml
+++ b/config/checkstyle-input-suppressions.xml
@@ -90,8 +90,6 @@
   <suppress id="UnnecessaryOkComment"
             files="checks[\\/]coding[\\/]onestatementperline[\\/]InputOneStatementPerLineTryWithResourcesIgnore.java"/>
   <suppress id="UnnecessaryOkComment"
-            files="checks[\\/]coding[\\/]onestatementperline[\\/]InputOneStatementPerLineTryWithResourcesIgnore.java"/>
-  <suppress id="UnnecessaryOkComment"
             files="checks[\\/]coding[\\/]packagedeclaration[\\/]InputPackageDeclarationWithCommentOnly.java"/>
   <suppress id="UnnecessaryOkComment"
             files="checks[\\/]coding[\\/]requirethis[\\/]InputRequireThis15Extensions.java"/>
@@ -269,8 +267,6 @@
             files="checks[\\/]javadoc[\\/]abstractjavadoc[\\/]InputAbstractJavadocCustomTag.java"/>
   <suppress id="UnnecessaryOkComment"
             files="checks[\\/]javadoc[\\/]abstractjavadoc[\\/]InputAbstractJavadocCustomTag.java"/>
-  <suppress id="UnnecessaryOkComment"
-            files="checks[\\/]javadoc[\\/]abstractjavadoc[\\/]InputAbstractJavadocJavadocTagsWithoutArgs.java"/>
   <suppress id="UnnecessaryOkComment"
             files="checks[\\/]javadoc[\\/]abstractjavadoc[\\/]InputAbstractJavadocJavadocTagsWithoutArgs.java"/>
   <suppress id="UnnecessaryOkComment"

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/onestatementperline/InputOneStatementPerLineTryWithResourcesIgnore.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/onestatementperline/InputOneStatementPerLineTryWithResourcesIgnore.java
@@ -17,13 +17,13 @@ public class InputOneStatementPerLineTryWithResourcesIgnore {
     void method() throws IOException {
         OutputStream s1 = new PipedOutputStream();
         OutputStream s2 = new PipedOutputStream();
-        try (s1; s2; OutputStream s3 = new PipedOutputStream();) { // ok
+        try (s1; s2; OutputStream s3 = new PipedOutputStream();) {
         }
-        try (s1; OutputStream s4 = new PipedOutputStream(); s2;) { // ok
+        try (s1; OutputStream s4 = new PipedOutputStream(); s2;) {
         }
-        try (s1; s2; OutputStream s5 = new PipedOutputStream()) { // ok
+        try (s1; s2; OutputStream s5 = new PipedOutputStream()) {
         }
-        try (s1; OutputStream s6 = new PipedOutputStream(); s2) { // ok
+        try (s1; OutputStream s6 = new PipedOutputStream(); s2) {
         }
         try (
 OutputStream s7 = new PipedOutputStream();OutputStream s8 = new PipedOutputStream();
@@ -40,7 +40,7 @@ OutputStream s9=new PipedOutputStream();s2;OutputStream s10 = new PipedOutputStr
              ;s2;) {
         }
         try (OutputStream
-             s12 = new PipedOutputStream();s1;OutputStream s3 // ok
+             s12 = new PipedOutputStream();s1;OutputStream s3
                 = new PipedOutputStream()) {}
         try (s1; s2; OutputStream stream3 =
              new PipedOutputStream()) {}

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/packagedeclaration/InputPackageDeclarationPlain.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/packagedeclaration/InputPackageDeclarationPlain.java
@@ -5,7 +5,7 @@ matchDirectoryStructure = (default)true
 
 */
 
-package com.puppycrawl.tools.checkstyle.checks.coding.packagedeclaration; // ok
+package com.puppycrawl.tools.checkstyle.checks.coding.packagedeclaration;
 
 class InputPackageDeclarationPlain {
     public String value;

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/requirethis/InputRequireThisEnumConstant.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/requirethis/InputRequireThisEnumConstant.java
@@ -7,7 +7,7 @@ validateOnlyOverlapping = false
 
 */
 
-package com.puppycrawl.tools.checkstyle.checks.coding.requirethis; // ok
+package com.puppycrawl.tools.checkstyle.checks.coding.requirethis;
 
 public class InputRequireThisEnumConstant {
     private final String TEST = "";

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/requirethis/InputRequireThisExtendedMethod.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/requirethis/InputRequireThisExtendedMethod.java
@@ -11,7 +11,7 @@ package com.puppycrawl.tools.checkstyle.checks.coding.requirethis;
 
 import java.util.logging.Logger;
 
-public class InputRequireThisExtendedMethod // ok
+public class InputRequireThisExtendedMethod
 {
     public class Check {
         private Logger log1 = Logger.getLogger(getClass().getName());

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/requirethis/InputRequireThisFinalInstanceVariable.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/requirethis/InputRequireThisFinalInstanceVariable.java
@@ -24,6 +24,6 @@ public class InputRequireThisFinalInstanceVariable {
     }
 
     public void foo(int x) {
-        x = x; // ok
+        x = x;
     }
 }

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/requirethis/InputRequireThisLocalClassesInsideLambdas.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/requirethis/InputRequireThisLocalClassesInsideLambdas.java
@@ -23,7 +23,7 @@ public interface InputRequireThisLocalClassesInsideLambdas {
                 int index;
 
                 public InnerSubscriber(int index) {
-                    this.index = index; // ok
+                    this.index = index;
                 }
             }
         });

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/requirethis/InputRequireThisMethodReferences.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/requirethis/InputRequireThisMethodReferences.java
@@ -15,7 +15,7 @@ import java.util.Set;
 import java.util.TreeSet;
 import java.util.stream.Collectors;
 
-public class InputRequireThisMethodReferences { // ok
+public class InputRequireThisMethodReferences {
     private Set<String> tags = Collections.unmodifiableSortedSet(
         Arrays.stream(new String[] {"br", "li", "dt", "dd", "hr", "img", "p", "td", "tr", "th",})
             .collect(Collectors.toCollection(TreeSet::new)));

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/abstractjavadoc/InputAbstractJavadocJavadocTagsWithoutArgs.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/abstractjavadoc/InputAbstractJavadocJavadocTagsWithoutArgs.java
@@ -7,23 +7,23 @@ package com.puppycrawl.tools.checkstyle.checks.javadoc.abstractjavadoc;
 
 import java.io.Serializable;
 
-/**@author*/ // ok
+/**@author*/
 public class InputAbstractJavadocJavadocTagsWithoutArgs implements Serializable{
 
-    /**@serial*/ // ok
+    /**@serial*/
     private static final long serialVersionUID = 7556448691029650757L;
 
     /**@see*/ // violation 'Javadoc comment at column 4 has parse error.'
     // Details: no viable alternative at input '<EOF>' while parsing JAVADOC_TAG
     private static int field2;
 
-    /**@since*/ // ok
+    /**@since*/
     private static String field3;
 
-    /**@version*/ // ok
+    /**@version*/
     private static Object field4;
 
-    /**serialField*/ // ok
+    /**serialField*/
     private static Object field5;
 
     /**@exception*/ // violation 'Javadoc comment at column 10 has parse error.'
@@ -38,7 +38,7 @@ public class InputAbstractJavadocJavadocTagsWithoutArgs implements Serializable{
 
     }
 
-    /**@return*/ // ok
+    /**@return*/
     public static int method3() {
         return -1;
     }
@@ -49,17 +49,17 @@ public class InputAbstractJavadocJavadocTagsWithoutArgs implements Serializable{
 
     }
 
-    /**@customTag*/ // ok
+    /**@customTag*/
     public static void method5(int a) {
 
     }
 
-    /**@deprecated*/ // ok
+    /**@deprecated*/
     public static void method6(int a) {
 
     }
 
-    /**@serialData*/ // ok
+    /**@serialData*/
     private void readObject(java.io.ObjectInputStream inputStream) {
 
     }


### PR DESCRIPTION
Remove '//ok' comments from Input files (InputPackageDeclarationPlain.java, InputRequireThisEnumConstant.java, InputRequireThisExtendedMethod.java, InputRequireThisFinalInstanceVariable.java, InputRequireThisLocalClassesInsideLambdas.java, InputRequireThisMethodReferences.java)


