### PR TITLE
Issue #13309: False positive error from JavadocType with record

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocTypeCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocTypeCheck.java
@@ -190,7 +190,7 @@ public class JavadocTypeCheck
 
     /** Pattern to match type name within angle brackets in javadoc param tag. */
     private static final Pattern TYPE_NAME_IN_JAVADOC_TAG =
-            Pattern.compile("\\s*<([^>]+)>.*");
+            Pattern.compile("^<([^>]+)");
 
     /** Pattern to split type name field in javadoc param tag. */
     private static final Pattern TYPE_NAME_IN_JAVADOC_TAG_SPLITTER =

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocTypeCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocTypeCheckTest.java
@@ -358,6 +358,35 @@ public class JavadocTypeCheckTest extends AbstractModuleTestSupport {
     }
 
     @Test
+    public void testJavadocTypeParamDescriptionWithAngularTags() throws Exception {
+        final String[] expected = {
+            "44:4: " + getCheckMessage(MSG_UNUSED_TAG, "@param", "<P>"),
+            "46:1: " + getCheckMessage(MSG_MISSING_TAG, "@param <U>"),
+            "50:4: " + getCheckMessage(MSG_UNUSED_TAG, "@param", "region"),
+        };
+
+        verifyWithInlineConfigParser(
+                getPath("InputJavadocTypeParamDescriptionWithAngularTags.java"), expected);
+    }
+
+    @Test
+    public void testJavadocTypeRecordParamDescriptionWithAngularTags() throws Exception {
+        final String[] expected = {
+            "51:4: " + getCheckMessage(MSG_UNUSED_TAG, "@param", "<P>"),
+            "53:1: " + getCheckMessage(MSG_MISSING_TAG, "@param <U>"),
+            "57:4: " + getCheckMessage(MSG_UNUSED_TAG, "@param", "region"),
+            "60:1: " + getCheckMessage(MSG_MISSING_TAG, "@param a"),
+            "73:4: " + getCheckMessage(MSG_UNUSED_TAG, "@param", "e"),
+            "76:1: " + getCheckMessage(MSG_MISSING_TAG, "@param c"),
+        };
+
+        verifyWithInlineConfigParser(
+                getNonCompilablePath(
+                        "InputJavadocTypeRecordParamDescriptionWithAngularTags.java"),
+                expected);
+    }
+
+    @Test
     public void testJavadocTypeRecordComponents2() throws Exception {
 
         final String[] expected = {

--- a/src/test/resources-noncompilable/com/puppycrawl/tools/checkstyle/checks/javadoc/javadoctype/InputJavadocTypeRecordParamDescriptionWithAngularTags.java
+++ b/src/test/resources-noncompilable/com/puppycrawl/tools/checkstyle/checks/javadoc/javadoctype/InputJavadocTypeRecordParamDescriptionWithAngularTags.java
@@ -1,0 +1,99 @@
+/*
+JavadocType
+
+
+*/
+
+//non-compiled with javac: Compilable with Java16
+package com.puppycrawl.tools.checkstyle.checks.javadoc.javadoctype;
+
+/**
+ *
+ * @param <T> stuff <stuff>
+ * @param value
+ */
+public record InputJavadocTypeRecordParamDescriptionWithAngularTags<T>(String value) {
+
+}
+
+/**
+ *
+ * @param    <T>    🐦‍🔥stuff<stuff>stu🐦‍🔥ff</stuff>stuff🐦‍🔥
+ * @param     a     <stuff>
+ */
+record Record1<T>(int a) {}
+
+/**
+ *
+ * @param <T> &lt;stuff&gt;
+ * @param a stUff&lt;stuff&gt;sutff&lt;🐦‍🔥&gt;🐦‍🔥
+ * @param b <>>>>><<<<
+ */
+record Record2<T>(int a, int b) {
+    /**
+     *
+     * @param <T>
+     * @param a <//< <stuff></> stuff >>  <stuff>st<u>ff</stuff> >><
+     * @param b stuff <><><<stuff></></></> stuff
+     * @param c /-+`[]:^^<stuff **%%$>##(sutff)stuff()</stuff> @@
+     */
+    record Record3<T>(int a, int b, int c) {}
+
+    /**
+     *
+     * @param <V> [(<>{@code stuff<stuff>&lt;stuff&gt;}</>)]{@code {&lt;stuff&gt;}}
+     */
+    record Record4<V>() {}
+}
+
+/**
+ * @param <T>
+ * @param    <P>     stuff <><><<stuff></></></> stuff // violation,'Unused @param tag for '<P>'.'
+ */
+record Record5<T, U>() {} // violation, 'Type Javadoc comment is missing @param <U> tag.'
+
+/**
+ *
+ * @param region [(<>{@code stuff<stuff🐦‍🔥>🐦‍🔥&lt;stuff&gt;}</>)]{@code {&lt;stuff&gt;}}
+ * // violation above, 'Unused @param tag for 'region'.'
+ */
+record Record6(int a) {} // violation, 'Type Javadoc comment is missing @param a tag.'
+
+/**
+ *
+ * @param <T>
+ * @param a 🐦‍🔥<><🐦‍🔥><<stuff></></></> stuff🐦‍🔥
+ * @param b
+ */
+record Record7<T>(int a, int b) {}
+
+/**
+ * @param a <<></>></><<></>></>
+ * @param b stuff<stuff>:<>:<>:<🐦‍🔥<<🐦‍🔥>>🐦‍🔥>
+ * @param e [(<>{@code stuff<stuff🐦[(‍{🔥}])>🐦‍🔥&lt;stuff&gt;}</>)]{@code {&lt;stuff&gt;}}
+ * // violation above, 'Unused @param tag for 'e'.'
+ */
+record Record8(int a, int b, int c) { // violation, 'Type Javadoc comment is missing @param c tag.'
+}
+
+/**
+ *
+ * @param a [(<>{@code stuff<stuff🐦‍🔥>🐦‍🔥&lt;stuff&gt;}</>)]
+ */
+record Record9(int a) {}
+
+/**
+ *
+ * @param a <><><><><><><><>
+ * @param b >><>>><><><<<><<
+ * @param c {@code <{[(<stu<f>f>)]}>}
+ */
+record Record10(int a, int b, int c) {}
+
+/**
+ * One Transaction.
+ *
+ * @param transactionId  unique ID of the transaction in format: {@code <first Code>:<second Code>}
+ */
+record MyTransaction(String transactionId) {
+}

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadoctype/InputJavadocTypeParamDescriptionWithAngularTags.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadoctype/InputJavadocTypeParamDescriptionWithAngularTags.java
@@ -1,0 +1,53 @@
+/*
+JavadocType
+
+
+*/
+
+package com.puppycrawl.tools.checkstyle.checks.javadoc.javadoctype;
+
+/**
+ *
+ * @param <T> <stuff>
+ */
+public class InputJavadocTypeParamDescriptionWithAngularTags<T> {}
+
+/**
+ *
+ * @param <T> 🐦‍🔥stuff<stuff>stu🐦‍🔥ff</stuff>stuff🐦‍🔥
+ */
+interface Ronin<T> {}
+
+/**
+ *
+ * @param <T> &lt;stuff&gt;
+ * @param <U> stUff&lt;stuff&gt;sutff&lt;🐦‍🔥&gt;🐦‍🔥
+ */
+class Shogun<T, U> {
+    /**
+     *
+     * @param <T> <//< <stuff></> stuff >>  <stuff>st<u>ff</stuff> >><
+     * @param    <U>     stuff <><><<stuff></></></> stuff
+     * @param <V> /-+`[]:^^<stuff **%%$>##(sutff){stuff}{}()stuff</stuff> @@
+     */
+    interface Mandate<T, U, V> {}
+
+    /**
+     *
+     * @param <V> [(<>{@code stuff<stuff>&lt;stuff&gt;}</>)]{@code {&lt;stuff&gt;}}
+     */
+    class Minowara<V> extends Shogun<T, U> implements Mandate<T, U, V> {}
+}
+
+/**
+ * @param    <T>
+ * @param <P> stuff <><><<stuff></></></> stuff // violation, 'Unused @param tag for '<P>'.'
+ */
+interface Regent<T, U> {} // violation, 'Type Javadoc comment is missing @param <U> tag.'
+
+/**
+ *
+ * @param region [(<>{@code stuff<stuff🐦‍🔥@@@>🐦‍🔥&lt;{stuff}&gt;}</>@)]{@code {&lt;stuff&gt;}}
+ * // violation above, 'Unused @param tag for 'region'.'
+ */
+class Fief {}


### PR DESCRIPTION
Resolves https://github.com/checkstyle/checkstyle/issues/13309

<hr>

**Regression:** ([Report](https://checkstyle-diff-reports.s3.us-east-2.amazonaws.com/0fbf9da_2024125210/reports/diff/index.html)) No Differences Found
Expected to have some differences(specifically removed violations) as we have fixed a false positive,
but we do not see any due the very specific scope of this false positive. ([Reference](https://github.com/checkstyle/checkstyle/issues/13309#issuecomment-1971651949))

The fix is working as intended and can be verified using the added test inputs, which previously would have produced a false violation.

Diff Regression config: https://gist.githubusercontent.com/sktpy/44a31ea4e946a0755fa3e331fd65de98/raw/df79e294a1b3f1fc37a6fdc971273c2dd746cea2/check.xml