### PR TITLE
Issue #3110: BugFix in Checker.java removed hardcoded exception messages of finishLocalSetup method

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/Checker.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/Checker.java
@@ -88,6 +88,11 @@ public class Checker extends AbstractAutomaticBean implements MessageDispatcher,
     /** The audit event filters. */
     private final FilterSet filters = new FilterSet();
 
+    /** Message used by finishLocalSetup method. */
+    private final LocalizedMessage finishLocalSetupMsg = new LocalizedMessage(
+            Definitions.CHECKSTYLE_BUNDLE, getClass(),
+                    "Checker.finishLocalSetup");
+
     /** The basedir to strip off in file names. */
     private String basedir;
 
@@ -440,9 +445,8 @@ public class Checker extends AbstractAutomaticBean implements MessageDispatcher,
 
         if (moduleFactory == null) {
             if (moduleClassLoader == null) {
-                throw new CheckstyleException(
-                        "if no custom moduleFactory is set, "
-                                + "moduleClassLoader must be specified");
+                final String finishLocalSetupMessage = finishLocalSetupMsg.getMessage();
+                throw new CheckstyleException(finishLocalSetupMessage);
             }
 
             final Set<String> packageNames = PackageNamesLoader

--- a/src/main/resources/com/puppycrawl/tools/checkstyle/messages.properties
+++ b/src/main/resources/com/puppycrawl/tools/checkstyle/messages.properties
@@ -1,12 +1,10 @@
+Checker.finishLocalSetup=if no custom moduleFactory is set, moduleClassLoader must be specified
 DefaultLogger.addException=Error auditing {0}
 DefaultLogger.auditFinished=Audit done.
 DefaultLogger.auditStarted=Starting audit...
 general.exception=Got an exception - {0}
 general.fileNotFound=File not found!
 Main.createListener=Invalid output format. Found ''{0}'' but expected ''{1}'' or ''{2}''.
-#
-# for Main.java
-#
 Main.errorCounter=Checkstyle ends with {0} errors.
 Main.loadProperties=Unable to load properties from file ''{0}''.
 PackageObjectFactory.ambiguousModuleNameExceptionMessage=In config there is ''{0}'', \

--- a/src/main/resources/com/puppycrawl/tools/checkstyle/messages_de.properties
+++ b/src/main/resources/com/puppycrawl/tools/checkstyle/messages_de.properties
@@ -1,12 +1,11 @@
+Checker.finishLocalSetup=wenn kein Brauch moduleFactory eingestellt ist, moduleClassLoader \
+  muss angegeben werden
 DefaultLogger.addException=Fehler beim Prüfen von {0}
 DefaultLogger.auditFinished=Prüfung beendet.
 DefaultLogger.auditStarted=Beginne Prüfung...
 general.exception=Ein Fehler ist aufgetreten - {0}
 general.fileNotFound=Datei nicht gefunden!
 Main.createListener=Ungültiges Ausgabeformat. Gefunden ''{0}'', aber ''{1}'' oder ''{2}'' erwartet.
-#
-# for Main.java
-#
 Main.errorCounter=Checkstyle endet mit {0} Fehlern.
 Main.loadProperties=Die Eigenschaften von Datei ''{0}'' können nicht geladen werden.
 PackageObjectFactory.ambiguousModuleNameExceptionMessage=In der Konfiguration gibt es ''{0}'', \

--- a/src/main/resources/com/puppycrawl/tools/checkstyle/messages_es.properties
+++ b/src/main/resources/com/puppycrawl/tools/checkstyle/messages_es.properties
@@ -1,12 +1,11 @@
+Checker.finishLocalSetup=si no hay costumbre moduleFactory Está establecido, \
+  moduleClassLoader debe ser especificado
 DefaultLogger.addException=Error auditando {0}
 DefaultLogger.auditFinished=Auditoría concluida.
 DefaultLogger.auditStarted=Comenzando auditoría...
 general.exception=Ocurrió una excepción - {0}
 general.fileNotFound=¡Fichero no encontrado!
 Main.createListener=Formato de salida no válido. Encontrado ''{0}'' pero esperado ''{1}'' o ''{2}''.
-#
-# for Main.java
-#
 Main.errorCounter=Checkstyle termina con {0} errores.
 Main.loadProperties=No se pueden cargar las propiedades del archivo ''{0}''.
 PackageObjectFactory.ambiguousModuleNameExceptionMessage=En configuración hay ''{0}'', \

--- a/src/main/resources/com/puppycrawl/tools/checkstyle/messages_fi.properties
+++ b/src/main/resources/com/puppycrawl/tools/checkstyle/messages_fi.properties
@@ -1,12 +1,11 @@
+Checker.finishLocalSetup=jos ei ole tapaa moduleFactory on asetettu, moduleClassLoader \
+  on täsmennettävä
 DefaultLogger.addException=Virhe {0}:n tarkistuksessa
 DefaultLogger.auditFinished=Tarkistus valmis.
 DefaultLogger.auditStarted=Aloitetaan tarkistus...
 general.exception=Poikkeus - {0}
 general.fileNotFound=Tiedostoa ei löydy!
 Main.createListener=Virheellinen tulostusmuoto. Löytyi ''{0}'' mutta odotti ''{1}'' tai ''{2}''.
-#
-# for Main.java
-#
 Main.errorCounter=Checkstyle päättyy {0} virheellä.
 Main.loadProperties=Ominaisuuksia ei voi ladata tiedostosta ''{0}''.
 PackageObjectFactory.ambiguousModuleNameExceptionMessage=Konfigissa on ''{0}'', \

--- a/src/main/resources/com/puppycrawl/tools/checkstyle/messages_fr.properties
+++ b/src/main/resources/com/puppycrawl/tools/checkstyle/messages_fr.properties
@@ -1,12 +1,11 @@
+Checker.finishLocalSetup=si pas de coutume moduleFactory est réglé, \
+  moduleClassLoader il faut préciser
 DefaultLogger.addException=Une erreur est survenue {0}
 DefaultLogger.auditFinished=Vérification terminée.
 DefaultLogger.auditStarted=Début de la vérification...
 general.exception=Exception levée : {0}
 general.fileNotFound=Fichier non trouvé !
 Main.createListener=Format de sortie invalide. Trouvé ''{0}'' mais attendu ''{1}'' ou ''{2}''.
-#
-# for Main.java
-#
 Main.errorCounter=Checkstyle se termine par {0} erreurs.
 Main.loadProperties=Impossible de charger des propriétés à partir du fichier ''{0}''.
 PackageObjectFactory.ambiguousModuleNameExceptionMessage=Dans la configuration il y a ''{0}'', \

--- a/src/main/resources/com/puppycrawl/tools/checkstyle/messages_ja.properties
+++ b/src/main/resources/com/puppycrawl/tools/checkstyle/messages_ja.properties
@@ -1,12 +1,11 @@
+Checker.finishLocalSetup=習慣がなければ moduleFactory 設定されています, \
+  moduleClassLoader 指定する必要があります
 DefaultLogger.addException={0} を監査中のエラー
 DefaultLogger.auditFinished=監査が完了しました。
 DefaultLogger.auditStarted=監査を開始しています...
 general.exception=例外が発生しました - {0}
 general.fileNotFound=ファイルが見つかりません！
 Main.createListener=無効な出力形式です。''{0}'' 名が見つかりましたが、''{1}'' 名か ''{2}'' 名です。
-#
-# for Main.java
-#
 Main.errorCounter=Checkstyleは {0} 個のエラーで終了します。
 Main.loadProperties=ファイル ''{0}'' からプロパティを読み込めません。
 PackageObjectFactory.ambiguousModuleNameExceptionMessage=設定には ''{0}''がありますが、\

--- a/src/main/resources/com/puppycrawl/tools/checkstyle/messages_pt.properties
+++ b/src/main/resources/com/puppycrawl/tools/checkstyle/messages_pt.properties
@@ -1,12 +1,11 @@
+Checker.finishLocalSetup=se não houver costume moduleFactory está definido, \
+  moduleClassLoader deve ser especificado
 DefaultLogger.addException=Erro ao auditar {0}
 DefaultLogger.auditFinished=Auditoria completa.
 DefaultLogger.auditStarted=Iniciando a auditoria...
 general.exception=Foi capturada uma exceção - {0}
 general.fileNotFound=Arquivo não encontrado!
 Main.createListener=O formato de saída é inválido. Foi encontrado ''{0}'', mas esperava ''{1}'' ou ''{2}''.
-#
-# for Main.java
-#
 Main.errorCounter=O Checkstyle terminou com {0} erros.
 Main.loadProperties=Não foi possível carregar propriedades do arquivo ''{0}''.
 PackageObjectFactory.ambiguousModuleNameExceptionMessage=Na configuração há ''{0}'', \

--- a/src/main/resources/com/puppycrawl/tools/checkstyle/messages_ru.properties
+++ b/src/main/resources/com/puppycrawl/tools/checkstyle/messages_ru.properties
@@ -1,12 +1,11 @@
+Checker.finishLocalSetup=если нет обычая moduleFactory установлен, \
+  moduleClassLoader должно быть указано
 DefaultLogger.addException=Ошибка проверки {0}
 DefaultLogger.auditFinished=Проверка завершена.
 DefaultLogger.auditStarted=Начинаем проверку...
 general.exception=Поймано исключение {0}
 general.fileNotFound=Файл не найден!
 Main.createListener=Недопустимый формат вывода. Найдено ''{0}'', но ожидалось ''{1}'' или ''{2}''.
-#
-# for Main.java
-#
 Main.errorCounter=Checkstyle заканчивается с количеством ошибок {0}.
 Main.loadProperties=Не удалось загрузить свойства из файла ''{0}''.
 PackageObjectFactory.ambiguousModuleNameExceptionMessage=В конфигурации есть ''{0}'', \

--- a/src/main/resources/com/puppycrawl/tools/checkstyle/messages_tr.properties
+++ b/src/main/resources/com/puppycrawl/tools/checkstyle/messages_tr.properties
@@ -1,12 +1,10 @@
+Checker.finishLocalSetup=özel değilse moduleFactory ayarlandı, moduleClassLoader belirtilmeli
 DefaultLogger.addException={0} denetlenirken hata oluştu
 DefaultLogger.auditFinished=Denetleme tamamlandı.
 DefaultLogger.auditStarted=Denetleme başlıyor...
 general.exception=Bir istisna yakalandı - {0}
 general.fileNotFound=Dosya bulunamadı!
 Main.createListener=Geçersiz çıktı biçimi. ''{0}'' ancak beklenen ''{1}'' veya ''{2}'' bulundu.
-#
-# for Main.java
-#
 Main.errorCounter=Checkstyle {0} hatayla bitiyor.
 Main.loadProperties=''{0}'' dosyasından özellik yüklenemiyor.
 PackageObjectFactory.ambiguousModuleNameExceptionMessage=Yapılandırmada ''{0}'' var, \

--- a/src/main/resources/com/puppycrawl/tools/checkstyle/messages_zh.properties
+++ b/src/main/resources/com/puppycrawl/tools/checkstyle/messages_zh.properties
@@ -1,12 +1,10 @@
+Checker.finishLocalSetup=如果没有定制 moduleFactory 已设置, moduleClassLoader 必须指定
 DefaultLogger.addException=检查错误： {0}
 DefaultLogger.auditFinished=检查完成。
 DefaultLogger.auditStarted=开始检查……
 general.exception=异常 - {0}
 general.fileNotFound=找不到文件！
 Main.createListener=非法的输出格式。预期为 ''{1}'' 或 ''{2}''，但实际为 ''{0}''。
-#
-# for Main.java
-#
 Main.errorCounter=Checkstyle以 {0} 个错误结束。
 Main.loadProperties=无法从文件 ''{0}'' 中加载属性。
 PackageObjectFactory.ambiguousModuleNameExceptionMessage=配置文件中出现 ''{0}''，\


### PR DESCRIPTION
Part of #3110 

All hardcoded messages in finishLocalSetup  method of Checker.java have been removed and replaced with keys pointing to respective messages.properties files to support non-locale translations.

I have used Google translate to extract translations of the messages.
PS : Simplified Chinese has been used for messages_zh.properties