### PR TITLE
Issue #14516: Updated LITERAL_NEW outdated examples and AST of TokenTypes.java to new format of AST print

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/api/TokenTypes.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/api/TokenTypes.java
@@ -4283,119 +4283,115 @@ public final class TokenTypes {
      * <p>For example:</p>
      *
      * <pre>
-     * new ArrayList(50)
+     * List&lt;String&gt; l = new ArrayList&lt;String&gt;();
      * </pre>
      *
      * <p>parses as:</p>
      * <pre>
-     * LITERAL_NEW -&gt; new
-     *  |--IDENT -&gt; ArrayList
-     *  |--TYPE_ARGUMENTS -&gt; TYPE_ARGUMENTS
-     *  |   |--GENERIC_START -&gt; &lt;
-     *  |   `--GENERIC_END -&gt; &gt;
-     *  |--LPAREN -&gt; (
-     *  |--ELIST -&gt; ELIST
+     * VARIABLE_DEF -&gt; VARIABLE_DEF
+     *  |--MODIFIERS -&gt; MODIFIERS
+     *  |--TYPE -&gt; TYPE
+     *  |   |--IDENT -&gt; List
+     *  |   `--TYPE_ARGUMENTS -&gt; TYPE_ARGUMENTS
+     *  |       |--GENERIC_START -&gt; &lt;
+     *  |       |--TYPE_ARGUMENT -&gt; TYPE_ARGUMENT
+     *  |       |   `--IDENT -&gt; String
+     *  |       `--GENERIC_END -&gt; &gt;
+     *  |--IDENT -&gt; l
+     *  |--ASSIGN -&gt; =
      *  |   `--EXPR -&gt; EXPR
-     *  |       `--NUM_INT -&gt; 50
-     *  `--RPAREN -&gt; )
+     *  |       `--LITERAL_NEW -&gt; new
+     *  |           |--IDENT -&gt; ArrayList
+     *  |           |--TYPE_ARGUMENTS -&gt; TYPE_ARGUMENTS
+     *  |           |   |--GENERIC_START -&gt; &lt;
+     *  |           |   |--TYPE_ARGUMENT -&gt; TYPE_ARGUMENT
+     *  |           |   |   `--IDENT -&gt; String
+     *  |           |   `--GENERIC_END -&gt; &gt;
+     *  |           |--LPAREN -&gt; (
+     *  |           |--ELIST -&gt; ELIST
+     *  |           `--RPAREN -&gt; )
+     *  `--SEMI -&gt; ;
      * </pre>
      *
      * <p>For example:</p>
      * <pre>
-     * new float[]
-     *   {
-     *     3.0f,
-     *     4.0f
-     *   };
+     * String[] strings = new String[3];
      * </pre>
      *
      * <p>parses as:</p>
      * <pre>
-     * +--LITERAL_NEW (new)
-     *     |
-     *     +--LITERAL_FLOAT (float)
-     *     +--ARRAY_DECLARATOR ([)
-     *     +--ARRAY_INIT ({)
-     *         |
-     *         +--EXPR
-     *             |
-     *             +--NUM_FLOAT (3.0f)
-     *         +--COMMA (,)
-     *         +--EXPR
-     *             |
-     *             +--NUM_FLOAT (4.0f)
-     *         +--RCURLY (})
+     * VARIABLE_DEF -&gt; VARIABLE_DEF
+     *  |--MODIFIERS -&gt; MODIFIERS
+     *  |--TYPE -&gt; TYPE
+     *  |   |--IDENT -&gt; String
+     *  |   `--ARRAY_DECLARATOR -&gt; [
+     *  |       `--RBRACK -&gt; ]
+     *  |--IDENT -&gt; strings
+     *  |--ASSIGN -&gt; =
+     *  |   `--EXPR -&gt; EXPR
+     *  |       `--LITERAL_NEW -&gt; new
+     *  |           |--IDENT -&gt; String
+     *  |           `--ARRAY_DECLARATOR -&gt; [
+     *  |               |--EXPR -&gt; EXPR
+     *  |               |   `--NUM_INT -&gt; 3
+     *  |               `--RBRACK -&gt; ]
+     *  `--SEMI -&gt; ;
      * </pre>
      *
      * <p>For example:</p>
      * <pre>
-     * new FilenameFilter()
-     * {
-     *   public boolean accept(File dir, String name)
-     *   {
-     *     return name.endsWith(".java");
-     *   }
-     * }
+     * Supplier&lt;Integer&gt; s = new Supplier&lt;&gt;() {
+     *     &#064;Override
+     *     public Integer get() {
+     *         return 42;
+     *     }
+     * };
      * </pre>
      *
      * <p>parses as:</p>
      * <pre>
-     * +--LITERAL_NEW (new)
-     *     |
-     *     +--IDENT (FilenameFilter)
-     *     +--LPAREN (()
-     *     +--ELIST
-     *     +--RPAREN ())
-     *     +--OBJBLOCK
-     *         |
-     *         +--LCURLY ({)
-     *         +--METHOD_DEF
-     *             |
-     *             +--MODIFIERS
-     *                 |
-     *                 +--LITERAL_PUBLIC (public)
-     *             +--TYPE
-     *                 |
-     *                 +--LITERAL_BOOLEAN (boolean)
-     *             +--IDENT (accept)
-     *             +--PARAMETERS
-     *                 |
-     *                 +--PARAMETER_DEF
-     *                     |
-     *                     +--MODIFIERS
-     *                     +--TYPE
-     *                         |
-     *                         +--IDENT (File)
-     *                     +--IDENT (dir)
-     *                 +--COMMA (,)
-     *                 +--PARAMETER_DEF
-     *                     |
-     *                     +--MODIFIERS
-     *                     +--TYPE
-     *                         |
-     *                         +--IDENT (String)
-     *                     +--IDENT (name)
-     *             +--SLIST ({)
-     *                 |
-     *                 +--LITERAL_RETURN (return)
-     *                     |
-     *                     +--EXPR
-     *                         |
-     *                         +--METHOD_CALL (()
-     *                             |
-     *                             +--DOT (.)
-     *                                 |
-     *                                 +--IDENT (name)
-     *                                 +--IDENT (endsWith)
-     *                             +--ELIST
-     *                                 |
-     *                                 +--EXPR
-     *                                     |
-     *                                     +--STRING_LITERAL (".java")
-     *                             +--RPAREN ())
-     *                     +--SEMI (;)
-     *                 +--RCURLY (})
-     *         +--RCURLY (})
+     * VARIABLE_DEF -&gt; VARIABLE_DEF
+     *  |--MODIFIERS -&gt; MODIFIERS
+     *  |--TYPE -&gt; TYPE
+     *  |   |--IDENT -&gt; Supplier
+     *  |   `--TYPE_ARGUMENTS -&gt; TYPE_ARGUMENTS
+     *  |       |--GENERIC_START -&gt; &lt;
+     *  |       |--TYPE_ARGUMENT -&gt; TYPE_ARGUMENT
+     *  |       |   `--IDENT -&gt; Integer
+     *  |       `--GENERIC_END -&gt; &gt;
+     *  |--IDENT -&gt; s
+     *  |--ASSIGN -&gt; =
+     *  |   `--EXPR -&gt; EXPR
+     *  |       `--LITERAL_NEW -&gt; new
+     *  |           |--IDENT -&gt; Supplier
+     *  |           |--TYPE_ARGUMENTS -&gt; TYPE_ARGUMENTS
+     *  |           |   |--GENERIC_START -&gt; &lt;
+     *  |           |   `--GENERIC_END -&gt; &gt;
+     *  |           |--LPAREN -&gt; (
+     *  |           |--ELIST -&gt; ELIST
+     *  |           |--RPAREN -&gt; )
+     *  |           `--OBJBLOCK -&gt; OBJBLOCK
+     *  |               |--LCURLY -&gt; {
+     *  |               |--METHOD_DEF -&gt; METHOD_DEF
+     *  |               |   |--MODIFIERS -&gt; MODIFIERS
+     *  |               |   |   |--ANNOTATION -&gt; ANNOTATION
+     *  |               |   |   |   |--AT -&gt; @
+     *  |               |   |   |   `--IDENT -&gt; Override
+     *  |               |   |   `--LITERAL_PUBLIC -&gt; public
+     *  |               |   |--TYPE -&gt; TYPE
+     *  |               |   |   `--IDENT -&gt; Integer
+     *  |               |   |--IDENT -&gt; get
+     *  |               |   |--LPAREN -&gt; (
+     *  |               |   |--PARAMETERS -&gt; PARAMETERS
+     *  |               |   |--RPAREN -&gt; )
+     *  |               |   `--SLIST -&gt; {
+     *  |               |       |--LITERAL_RETURN -&gt; return
+     *  |               |       |   |--EXPR -&gt; EXPR
+     *  |               |       |   |   `--NUM_INT -&gt; 42
+     *  |               |       |   `--SEMI -&gt; ;
+     *  |               |       `--RCURLY -&gt; }
+     *  |               `--RCURLY -&gt; }
+     *  `--SEMI -&gt; ;
      * </pre>
      *
      * @see #IDENT

--- a/src/xdocs/writingchecks.xml
+++ b/src/xdocs/writingchecks.xml
@@ -384,7 +384,7 @@ public class MethodLimitCheck extends AbstractCheck
 
       <p>
         There are four methods in Check class to control the processed
-        <a href="apidocs/index.html">TokenTypes</a> -
+        <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html">TokenTypes</a> -
         one setter
         <a href="apidocs/com/puppycrawl/tools/checkstyle/api/AbstractCheck.html#setTokens-java.lang.String...-">
         setTokens()</a>, which is used to define a custom set (which is different


### PR DESCRIPTION
Aims to close #14516

EDIT : Changed link to TokenTypes of our docs to be more specific
https://checkstyle.sourceforge.io/apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html

Updated Inputs based on suggestions from review :

```
E:\MANISH\Workspace>cat Test.java
import java.util.ArrayList;
import java.util.List;

public class Test {
    List<String> l = new ArrayList<String>();
}

```
```
E:\MANISH\Workspace>cat Test.java
public class Test {
    String[] strings = new String[3];
}

```
```
E:\MANISH\Workspace>cat Test.java
public abstract class Supplier<Integer> {
    public abstract Integer get();
}
public class Test {
    Supplier<Integer> s = new Supplier<>() {
        @Override
        public Integer get() {
            return 42;
        }
    };
}

```
// Outdated Inputs used previously : 

```
public class Test {
  float[] test = new float[]
    {
      3.0f,
      4.0f
    };
}
```
```
E:\MANISH\Workspace>cat Test.java
import java.io.File;

public class FilenameFilter {}
public class Test {
    FilenameFilter test = new FilenameFilter()
    {
      public boolean accept(File dir, String name)
      {
        return name.endsWith(".java");
      }
    };
}
```