### PR TITLE
Issue #14620:  `LITERAL_CASE` token support in RightCurlyCheck

### DIFF
--- a/config/checker-framework-suppressions/checker-nullness-optional-interning-suppressions.xml
+++ b/config/checker-framework-suppressions/checker-nullness-optional-interning-suppressions.xml
@@ -1577,8 +1577,30 @@
   <checkerFrameworkError unstable="false">
     <fileName>src/main/java/com/puppycrawl/tools/checkstyle/checks/blocks/RightCurlyCheck.java</fileName>
     <specifier>argument</specifier>
+    <message>incompatible argument for parameter lcurly of Details constructor.</message>
+    <lineContent>return new Details(lcurly.orElse(null), rcurly, nextToken.orElse(null), true);</lineContent>
+    <details>
+      found   : @Initialized @Nullable DetailAST
+      required: @Initialized @NonNull DetailAST
+    </details>
+  </checkerFrameworkError>
+
+  <checkerFrameworkError unstable="false">
+    <fileName>src/main/java/com/puppycrawl/tools/checkstyle/checks/blocks/RightCurlyCheck.java</fileName>
+    <specifier>argument</specifier>
     <message>incompatible argument for parameter nextToken of Details constructor.</message>
     <lineContent>return new Details(lcurly, rcurly, nextToken, true);</lineContent>
+    <details>
+      found   : @Initialized @Nullable DetailAST
+      required: @Initialized @NonNull DetailAST
+    </details>
+  </checkerFrameworkError>
+
+  <checkerFrameworkError unstable="false">
+    <fileName>src/main/java/com/puppycrawl/tools/checkstyle/checks/blocks/RightCurlyCheck.java</fileName>
+    <specifier>argument</specifier>
+    <message>incompatible argument for parameter nextToken of Details constructor.</message>
+    <lineContent>return new Details(lcurly.orElse(null), rcurly, nextToken.orElse(null), true);</lineContent>
     <details>
       found   : @Initialized @Nullable DetailAST
       required: @Initialized @NonNull DetailAST
@@ -1623,6 +1645,17 @@
     <specifier>argument</specifier>
     <message>incompatible argument for parameter rcurly of Details constructor.</message>
     <lineContent>return new Details(lcurly, rcurly, nextToken, true);</lineContent>
+    <details>
+      found   : @Initialized @Nullable DetailAST
+      required: @Initialized @NonNull DetailAST
+    </details>
+  </checkerFrameworkError>
+
+  <checkerFrameworkError unstable="false">
+    <fileName>src/main/java/com/puppycrawl/tools/checkstyle/checks/blocks/RightCurlyCheck.java</fileName>
+    <specifier>argument</specifier>
+    <message>incompatible argument for parameter rcurly of Details constructor.</message>
+    <lineContent>return new Details(lcurly.orElse(null), rcurly, nextToken.orElse(null), true);</lineContent>
     <details>
       found   : @Initialized @Nullable DetailAST
       required: @Initialized @NonNull DetailAST

--- a/config/checkstyle-checks.xml
+++ b/config/checkstyle-checks.xml
@@ -330,6 +330,7 @@
       <property name="tokens" value="ENUM_DEF"/>
       <property name="tokens" value="RECORD_DEF"/>
       <property name="tokens" value="COMPACT_CTOR_DEF"/>
+      <property name="tokens" value="LITERAL_CASE"/>
       <property name="option" value="alone"/>
     </module>
     <module name="RightCurly">

--- a/src/it/java/com/google/checkstyle/test/chapter4formatting/rule412nonemptyblocks/RightCurlyTest.java
+++ b/src/it/java/com/google/checkstyle/test/chapter4formatting/rule412nonemptyblocks/RightCurlyTest.java
@@ -130,4 +130,19 @@ public class RightCurlyTest extends AbstractGoogleModuleTestSupport {
         final Integer[] warnList = getLinesWithWarn(filePath);
         verify(checkConfig, filePath, expected, warnList);
     }
+
+    @Test
+    public void testRightCurlySwitchCases() throws Exception {
+        final String[] expected = {
+            "25:13: " + getCheckMessage(RightCurlyCheck.class, MSG_KEY_LINE_ALONE, "}", 13),
+            "34:28: " + getCheckMessage(RightCurlyCheck.class, MSG_KEY_LINE_ALONE, "}", 28),
+            "57:33: " + getCheckMessage(RightCurlyCheck.class, MSG_KEY_LINE_ALONE, "}", 33),
+        };
+
+        final Configuration checkConfig = createTreeWalkerConfig(getModuleConfigsByIds(MODULES));
+        final String filePath = getPath("InputRightCurlySwitchCasesBlocks.java");
+
+        final Integer[] warnList = getLinesWithWarn(filePath);
+        verify(checkConfig, filePath, expected, warnList);
+    }
 }

--- a/src/it/resources/com/google/checkstyle/test/chapter4formatting/rule412nonemptyblocks/InputRightCurlySwitchCasesBlocks.java
+++ b/src/it/resources/com/google/checkstyle/test/chapter4formatting/rule412nonemptyblocks/InputRightCurlySwitchCasesBlocks.java
@@ -1,0 +1,60 @@
+package com.google.checkstyle.test.chapter4formatting.rule412nonemptyblocks;
+
+public class InputRightCurlySwitchCasesBlocks {
+
+     public static void test0() {
+        int mode = 0;
+        switch (mode) {
+            case 1: {
+                int x = 1;
+                break;
+            }
+            case 2: {
+                int x = 0;
+                break;
+            }
+        }
+    }
+
+    public static void test() {
+        int mode = 0;
+        switch (mode) {
+            case 1:{
+                int x = 1;
+                break;
+            } default :          // warn
+                int x = 0;
+        }
+    }
+
+    public static void test1() {
+        int k = 0;
+        switch (k) {
+            case 1:{
+                 int x = 1;}   // warn
+            case 2:
+                 int x = 2;
+                 break;
+        }
+    }
+
+     public static void test2() {
+        int mode = 0;
+        switch (mode) {
+            case 1: int x = 1;
+            case 2: {
+                break;
+            }
+        }
+    }
+
+     public static void test3() {
+        int k = 0;
+        switch (k) {
+            case 1:{
+                 int x = 1;
+            }
+            case 2: { int x = 2;}    // warn
+        }
+    }
+}

--- a/src/main/resources/com/puppycrawl/tools/checkstyle/meta/checks/blocks/RightCurlyCheck.xml
+++ b/src/main/resources/com/puppycrawl/tools/checkstyle/meta/checks/blocks/RightCurlyCheck.xml
@@ -6,8 +6,8 @@
              parent="com.puppycrawl.tools.checkstyle.TreeWalker">
          <description>&lt;p&gt;
  Checks the placement of right curly braces (&lt;code&gt;'}'&lt;/code&gt;) for code blocks. This check
- supports if-else, try-catch-finally blocks, switch statements, while-loops, for-loops,
- method definitions, class definitions, constructor definitions,
+ supports if-else, try-catch-finally blocks, switch statements, switch cases, while-loops,
+  for-loops, method definitions, class definitions, constructor definitions,
  instance, static initialization blocks, annotation definitions and enum definitions.
  For right curly brace of expression blocks of arrays, lambdas and class instances
  please follow issue

--- a/src/main/resources/google_checks.xml
+++ b/src/main/resources/google_checks.xml
@@ -96,7 +96,7 @@
       <property name="tokens"
                value="CLASS_DEF, METHOD_DEF, CTOR_DEF, LITERAL_FOR, LITERAL_WHILE, STATIC_INIT,
                     INSTANCE_INIT, ANNOTATION_DEF, ENUM_DEF, INTERFACE_DEF, RECORD_DEF,
-                    COMPACT_CTOR_DEF, LITERAL_SWITCH"/>
+                    COMPACT_CTOR_DEF, LITERAL_SWITCH, LITERAL_CASE"/>
     </module>
     <module name="SuppressionXpathSingleFilter">
       <!-- suppresion is required till https://github.com/checkstyle/checkstyle/issues/7541 -->

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/blocks/RightCurlyCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/blocks/RightCurlyCheckTest.java
@@ -827,4 +827,158 @@ public class RightCurlyCheckTest extends AbstractModuleTestSupport {
         verifyWithInlineConfigParser(
                 getNonCompilablePath("InputRightCurlyTestSwitchExpression7.java"), expected);
     }
+
+    @Test
+    public void testCaseBlocksInSwitchStatementAlone() throws Exception {
+        final String[] expected = {
+            "33:13: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}", 13),
+            "44:13: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}", 13),
+            "73:13: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}", 13),
+            "78:44: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}", 44),
+            "90:39: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}", 39),
+            "97:42: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}", 42),
+            "107:35: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}", 35),
+        };
+        verifyWithInlineConfigParser(
+                getPath("InputRightCurlyCaseBlocksInSwitchStatementAlone.java"), expected);
+    }
+
+    @Test
+    public void testCaseBlocksInSwitchStatementAlone2() throws Exception {
+        final String[] expected = {
+            "17:15: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}", 15),
+            "26:13: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}", 13),
+            "38:13: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}", 13),
+            "41:13: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}", 13),
+            "49:24: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}", 24),
+            "49:45: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}", 45),
+            "57:13: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}", 13),
+            "68:13: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}", 13),
+            "68:26: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}", 26),
+            "75:34: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}", 34),
+            "75:47: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}", 47),
+            "82:23: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}", 23),
+            "102:13: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}", 13),
+        };
+        verifyWithInlineConfigParser(
+                getPath("InputRightCurlyCaseBlocksInSwitchStatementAlone2.java"), expected);
+    }
+
+    @Test
+    public void testCaseBlocksInSwitchStatementAloneOrSingleLine() throws Exception {
+        final String[] expected = {
+            "33:13: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}", 13),
+            "44:13: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}", 13),
+            "73:13: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}", 13),
+            "78:51: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}", 51),
+        };
+        verifyWithInlineConfigParser(
+                getPath("InputRightCurlyCaseBlocksInSwitchStatementAloneOrSingleline.java"),
+                expected);
+    }
+
+    @Test
+    public void testCaseBlocksInSwitchStatementAloneOrSingle2() throws Exception {
+        final String[] expected = {
+            "18:15: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}", 15),
+            "27:13: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}", 13),
+            "39:13: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}", 13),
+            "42:15: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}", 15),
+            "50:23: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}", 23),
+            "71:13: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}", 13),
+            "80:23: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}", 23),
+            "100:13: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}", 13),
+        };
+        verifyWithInlineConfigParser(
+                getPath("InputRightCurlyCaseBlocksInSwitchStatementAloneOrSingleline2.java"),
+                expected);
+    }
+
+    @Test
+    public void testCaseBlocksInSwitchStatementSame() throws Exception {
+        final String[] expected = {
+            "33:16: " + getCheckMessage(MSG_KEY_LINE_BREAK_BEFORE, "}", 16),
+            "44:13: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}", 13),
+            "73:13: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}", 13),
+            "78:51: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}", 51),
+            "106:23: " + getCheckMessage(MSG_KEY_LINE_BREAK_BEFORE, "}", 23),
+        };
+        verifyWithInlineConfigParser(
+                getPath("InputRightCurlyCaseBlocksInSwitchStatementSame.java"), expected);
+    }
+
+    @Test
+    public void testCaseBlocksInSwitchStatementSame2() throws Exception {
+        final String[] expected = {
+            "18:13: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}", 13),
+            "27:13: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}", 13),
+            "39:13: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}", 13),
+            "42:13: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}", 13),
+            "50:13: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}", 13),
+            "70:13: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}", 13),
+            "77:34: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}", 34),
+            "77:47: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}", 47),
+            "85:23: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}", 23),
+            "103:13: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}", 13),
+        };
+        verifyWithInlineConfigParser(
+                getPath("InputRightCurlyCaseBlocksInSwitchStatementSame2.java"), expected);
+    }
+
+    @Test
+    public void testCaseBlocksWithSwitchRuleAlone() throws Exception {
+        final String[] expected = {
+            "32:13: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}", 13),
+            "44:13: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}", 13),
+            "45:27: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}", 27),
+            "56:13: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}", 13),
+            "69:13: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}", 13),
+            "74:46: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}", 46),
+            "83:13: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}", 13),
+            "83:36: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}", 36),
+            "93:31: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}", 31),
+            "94:31: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}", 31),
+        };
+        verifyWithInlineConfigParser(
+                getNonCompilablePath("InputRightCurlyCaseBlocksWithSwitchRuleAlone.java"),
+                expected);
+    }
+
+    @Test
+    public void testCaseBlocksWithSwitchRuleAloneOrSingleLine() throws Exception {
+
+        final String[] expected = {
+            "27:19: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}", 19),
+            "41:13: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}", 13),
+            "53:23: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}", 23),
+            "54:27: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}", 27),
+            "64:13: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}", 13),
+            "77:13: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}", 13),
+            "82:46: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}", 46),
+            "91:13: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}", 13),
+            "102:31: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}", 31),
+        };
+        final String fileName = "InputRightCurlyCaseBlocksWithSwitchRuleAloneOrSingleline.java";
+        verifyWithInlineConfigParser(getNonCompilablePath(fileName), expected);
+    }
+
+    @Test
+    public void testCaseBlocksWithSwitchExpressionAlone() throws Exception {
+        final String[] expected = {
+            "63:31: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}", 31),
+            "86:42: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}", 42),
+        };
+        final String fileName = "InputRightCurlyCaseBlocksWithSwitchExpressionAlone.java";
+        verifyWithInlineConfigParser(getNonCompilablePath(fileName), expected);
+    }
+
+    @Test
+    public void testCaseBlocksWithSwitchExpressionAloneOrSingleLine() throws Exception {
+        final String[] expected = {
+            "63:31: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}", 31),
+        };
+        final String fileName =
+                "InputRightCurlyCaseBlocksWithSwitchExpressionAloneOrSingleline.java";
+        verifyWithInlineConfigParser(getNonCompilablePath(fileName), expected);
+    }
 }

--- a/src/test/resources-noncompilable/com/puppycrawl/tools/checkstyle/checks/blocks/rightcurly/InputRightCurlyCaseBlocksWithSwitchExpressionAlone.java
+++ b/src/test/resources-noncompilable/com/puppycrawl/tools/checkstyle/checks/blocks/rightcurly/InputRightCurlyCaseBlocksWithSwitchExpressionAlone.java
@@ -1,0 +1,92 @@
+/*
+RightCurly
+option = ALONE
+tokens = LITERAL_CASE, LITERAL_IF
+
+*/
+
+//non-compiled with javac: Compilable with Java14
+package com.puppycrawl.tools.checkstyle.checks.blocks.rightcurly;
+
+public class InputRightCurlyCaseBlocksWithSwitchExpressionAlone {
+
+    int foo(int yield) {
+        return switch (yield) {
+            case 1 -> 2;
+            case 2 -> 3;
+            case 3 -> 4;
+            default -> 5;
+        };
+    }
+
+    void test() {
+        int x = 1;
+        String s = switch (x) {
+            case 1 -> {
+
+                yield "and that's it";
+            }  case 2 -> "x is 2";
+            default -> "x is neither 1 nor 2";
+        };
+    }
+
+    void test2() {
+        int x = 1;
+        String s = switch (x) {
+            case 1 -> {
+
+                yield "and that's it";
+            }  case 2 -> { yield "x is 2";}
+            default -> "x is neither 1 nor 2";
+        };
+    }
+
+    void test3() {
+        int x = 1;
+         String s = switch (x) {
+            case 1 -> {
+
+                String s1 = "and that's it";
+                yield s1;
+            } case 2 -> { yield "x is 2";}
+            default -> "x is neither 1 nor 2";
+        };
+    }
+
+    void test4() throws Exception {
+           int a = 0;
+           int b = switch (a) {
+                case 0 -> {
+                    int x = 5;
+                    int y = 6;
+                    if (a == 2) {
+                        y = 7;}   // violation '}' at column 31 should be alone on a line'
+                    throw new Exception();
+                }  default -> 2;
+            };
+    }
+
+    void test5() throws Exception {
+        int a = 0;
+        int b = switch (a) {
+            case 0 -> {throw new Exception();}
+            default -> 2;
+        };
+    }
+
+    void test6() throws Exception {
+         int y = 0;
+         int x = 0;
+         final boolean a = switch (y) {
+             case 1 -> {x = 1; yield true;}
+             case 2 -> {
+                 x = 1;
+                 yield true;} case 3 -> {
+                 x = 1;
+                 if (x == 1) {yield true;} // violation '}' at column 42 should be alone on a line'
+                 yield false;}
+             default -> throw new RuntimeException();
+         };
+    }
+
+}

--- a/src/test/resources-noncompilable/com/puppycrawl/tools/checkstyle/checks/blocks/rightcurly/InputRightCurlyCaseBlocksWithSwitchExpressionAloneOrSingleline.java
+++ b/src/test/resources-noncompilable/com/puppycrawl/tools/checkstyle/checks/blocks/rightcurly/InputRightCurlyCaseBlocksWithSwitchExpressionAloneOrSingleline.java
@@ -1,0 +1,93 @@
+/*
+RightCurly
+option = ALONE_OR_SINGLELINE
+tokens = LITERAL_CASE, LITERAL_IF
+
+*/
+
+//non-compiled with javac: Compilable with Java14
+package com.puppycrawl.tools.checkstyle.checks.blocks.rightcurly;
+
+public class InputRightCurlyCaseBlocksWithSwitchExpressionAloneOrSingleline {
+
+    int foo(int yield) {
+        return switch (yield) {
+            case 1 -> 2;
+            case 2 -> 3;
+            case 3 -> 4;
+            default -> 5;
+        };
+    }
+
+    void test() {
+        int x = 1;
+        String s = switch (x) {
+            case 1 -> {
+
+                yield "and that's it";
+            }  case 2 -> "x is 2";
+            default -> "x is neither 1 nor 2";
+        };
+    }
+
+    void test2() {
+        int x = 1;
+        String s = switch (x) {
+            case 1 -> {
+
+                yield "and that's it";
+            }  case 2 -> { yield "x is 2";}
+            default -> "x is neither 1 nor 2";
+        };
+    }
+
+    void test3() {
+        int x = 1;
+         String s = switch (x) {
+            case 1 -> {
+
+                String s1 = "and that's it";
+                yield s1;
+            } case 2 -> { yield "x is 2";}
+            default -> "x is neither 1 nor 2";
+        };
+    }
+
+    void test4() throws Exception {
+           int a = 0;
+           int b = switch (a) {
+                case 0 -> {
+                    int x = 5;
+                    int y = 6;
+                    if (a == 2) {
+                        y = 7;}   // violation '}' at column 31 should be alone on a line'
+                    throw new Exception();
+                }  default -> 2;
+            };
+    }
+
+    void test5() throws Exception {
+        int a = 0;
+        int b = switch (a) {
+            case 0 -> {throw new Exception();}
+            default -> 2;
+        };
+    }
+
+    void test6() {
+         int y = 0;
+         int x = 0;
+         final boolean a = switch (y) {
+             case 1 -> {x = 1; yield true;
+             }case 2 -> {
+                 x = 1;
+                 yield true;} case 3 -> {
+                 x = 1;
+                 if (x == 1) {yield true;} // ok single line
+                 yield false;
+             }
+             default -> throw new RuntimeException();
+         };
+    }
+
+}

--- a/src/test/resources-noncompilable/com/puppycrawl/tools/checkstyle/checks/blocks/rightcurly/InputRightCurlyCaseBlocksWithSwitchRuleAlone.java
+++ b/src/test/resources-noncompilable/com/puppycrawl/tools/checkstyle/checks/blocks/rightcurly/InputRightCurlyCaseBlocksWithSwitchRuleAlone.java
@@ -1,0 +1,96 @@
+/*
+RightCurly
+option = ALONE
+tokens = LITERAL_CASE
+
+*/
+
+//non-compiled with javac: Compilable with Java14
+package com.puppycrawl.tools.checkstyle.checks.blocks.rightcurly;
+
+public class InputRightCurlyCaseBlocksWithSwitchRuleAlone {
+
+    public static void test0() {
+        int mode = 0;
+        switch (mode) {
+            case 1 -> {
+                int x = 1;
+            }
+            case 2 -> {
+                int x = 0;
+            }
+            case 3 -> System.out.println("x is 3");
+        }
+    }
+
+    public static void test() {
+        int mode = 0;
+        switch (mode) {
+            case 1 -> {
+                int x = 1;
+
+            } default -> {          // violation '}' at column 13 should be alone on a line'
+                int x = 0;
+            }
+        }
+    }
+
+    public static void test1() {
+        int k = 0;
+        switch (k) {
+            case 1 -> {
+                 int x = 1;
+
+            } case 2 -> {       // violation '}' at column 13 should be alone on a line'
+                int x = 2;}     // violation '}' at column 27 should be alone on a line'
+
+        }
+    }
+
+    public static void test2() {
+         int k = 0;
+         switch (k) {
+            case 1 -> {
+                 int x = 1;
+
+            }case 2 -> throw new RuntimeException();
+            // violation above '}' at column 13 should be alone on a line'
+         }
+    }
+
+    public static void test3() {
+         int k = 0;
+         switch (k) {
+            case 1 -> {
+                 int x = 1;
+            }
+            case 2 -> {
+                    int x = 2;
+            } }      // violation '}' at column 13 should be alone on a line'
+    }
+
+    public static void test4() {
+        int mode = 0;
+        switch (mode) { case 0 -> {int x = 1;} }
+        // violation above '}' at column 46 should be alone on a line'
+    }
+
+    public static void test5() {
+        int mode = 0;
+        switch (mode) {
+            case 0 -> {
+                int x = 1;
+            } case 1 -> {int x = 2;}  // 2 violations
+        }
+    }
+
+    public static void test8() {
+        int mode = 0;
+        int x = 0;
+        switch (mode) {
+            case 0 -> throw new RuntimeException();
+            case 1 -> x = 1;
+            case 2 -> {x = 1; }      // violation '}' at column 31 should be alone on a line'
+            case 3 -> {x = 5; } }   // violation '}' at column 31 should be alone on a line'
+    }
+}

--- a/src/test/resources-noncompilable/com/puppycrawl/tools/checkstyle/checks/blocks/rightcurly/InputRightCurlyCaseBlocksWithSwitchRuleAloneOrSingleline.java
+++ b/src/test/resources-noncompilable/com/puppycrawl/tools/checkstyle/checks/blocks/rightcurly/InputRightCurlyCaseBlocksWithSwitchRuleAloneOrSingleline.java
@@ -1,0 +1,104 @@
+/*
+RightCurly
+option = ALONE_OR_SINGLELINE
+tokens = LITERAL_CASE
+
+*/
+
+//non-compiled with javac: Compilable with Java14
+package com.puppycrawl.tools.checkstyle.checks.blocks.rightcurly;
+
+public class InputRightCurlyCaseBlocksWithSwitchRuleAloneOrSingleline {
+
+    public void testt0() {
+        int mode = 0;
+        switch (mode) {
+            case 1 -> {int x = 1;}   // ok, single line
+            case 2 -> {int x = 0;}
+            case 3 -> System.out.println("x is 3");
+        }
+    }
+
+    public static void test0() {
+        int mode = 0;
+        switch (mode) {
+            case 1 -> {
+                int
+            x = 1;} // violation '}' at column 19 should be alone on a line'
+            case 2 -> {
+                int x = 0;
+            }
+            case 3 -> System.out.println("x is 3");
+        }
+    }
+
+    public static void test() {
+        int mode = 0;
+        switch (mode) {
+            case 1 -> {
+                int x = 1;
+
+            } default -> {          // violation '}' at column 13 should be alone on a line'
+                int x = 0;
+            }
+        }
+    }
+
+    public static void test1() {
+        int k = 0;
+        switch (k) {
+            case 1 -> {
+
+
+           int x = 1; } case 2 -> {       // violation '}' at column 23 should be alone on a line'
+                int x = 2;}     // violation '}' at column 27 should be alone on a line'
+
+        }
+    }
+
+    public static void test2() {
+         int k = 0;
+         switch (k) {
+            case 1 -> {int x = 1;
+
+            }case 2 -> throw new RuntimeException();
+            // violation above '}' at column 13 should be alone on a line'
+         }
+    }
+
+    public static void test3() {
+         int k = 0;
+         switch (k) {
+            case 1 -> {
+                 int x = 1;
+            }
+            case 2 -> {
+                    int x = 2;
+            } }      // violation '}' at column 13 should be alone on a line'
+    }
+
+    public static void test4() {
+        int mode = 0;
+        switch (mode) { case 0 -> {int x = 1;} default -> {int x = 0;} }
+        // violation above '}' at column 46 should be alone on a line'
+    }
+
+    public static void test5() {
+        int mode = 0;
+        switch (mode) {
+            case 0 -> {
+                int x = 1;
+            } case 1 -> {int x = 2;}  // violation '}' at column 13 should be alone on a line'
+        }
+    }
+
+    public static void test8() {
+        int mode = 0;
+        int x = 0;
+        switch (mode) {
+            case 0 -> throw new RuntimeException();
+            case 1 -> x = 1;
+            case 2 -> {x = 1; }      // ok, single line
+            case 3 -> {x = 5; } }   // violation '}' at column 31 should be alone on a line'
+    }
+}

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/blocks/rightcurly/InputRightCurlyCaseBlocksInSwitchStatementAlone.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/blocks/rightcurly/InputRightCurlyCaseBlocksInSwitchStatementAlone.java
@@ -1,0 +1,111 @@
+/*
+RightCurly
+option = ALONE
+tokens = LITERAL_CASE
+
+*/
+package com.puppycrawl.tools.checkstyle.checks.blocks.rightcurly;
+
+public class InputRightCurlyCaseBlocksInSwitchStatementAlone {
+    public static void test0() {
+        int mode = 0;
+        switch (mode) {
+            case 1: {
+                int x = 1;
+                break;
+            }
+            case 2:
+            default:  {
+                int x = 0;
+            }break;
+            case 3: {
+                int x = 3;
+            }
+        }
+    }
+
+    public static void test() {
+        int mode = 0;
+        switch (mode) {
+            case 1:{
+                int x = 1;
+                break;
+            } default :          // violation '}' at column 13 should be alone on a line'
+                int x = 0;
+        }
+    }
+
+    public static void test1() {
+        int k = 0;
+        switch (k) {
+            case 1:{
+                 int x = 1;
+                 break;
+            } case 2:        // violation '}' at column 13 should be alone on a line'
+                 int x = 2;
+                 break;
+        }
+    }
+
+    public static void test2() {
+         int k = 0;
+         switch (k) {
+            case 1:{
+                 int x = 1;
+                 break;
+            }
+            case 2:
+                 int x = 2;
+                 break;
+         }
+    }
+
+    public static void test3() {
+         int k = 0;
+         switch (k) {
+            case 1:{
+                 int x = 1;
+                 break;
+            }
+            case 2:{
+                    int x = 2;
+                    break;
+            } }      // violation '}' at column 13 should be alone on a line'
+    }
+
+    public static void test4() {
+        int mode = 0;
+        switch (mode) { case 0: {int x = 1;} break; default : int x = 5; }
+        // violation above '}' at column 44 should be alone on a line'
+    }
+
+    public static void test5() {
+        int mode = 0;
+        switch (mode) { case 0: }
+    }
+
+    public static void test6() {
+        int mode = 0;
+        switch (mode) {
+            case 0: {int x = 1; break;}  // violation '}' at column 39 should be alone on a line'
+            default : break;
+        }
+    }
+
+    public static void test7() {
+        int mode = 0;
+        switch (mode) {case 0:{int x = 1;} // violation '}' at column 42 should be alone on a line'
+            break; default : break; }
+    }
+
+    public static void test8() {
+        int mode = 0;
+        int x = 0;
+        switch (mode) {
+            case 0:
+            case 1: x = 1; break;
+            case 2: {x = 1; break;} // violation '}' at column 35 should be alone on a line'
+            default : x = 5;
+        }
+    }
+}

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/blocks/rightcurly/InputRightCurlyCaseBlocksInSwitchStatementAlone2.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/blocks/rightcurly/InputRightCurlyCaseBlocksInSwitchStatementAlone2.java
@@ -1,0 +1,120 @@
+/*
+RightCurly
+option = ALONE
+tokens = LITERAL_CASE
+
+*/
+package com.puppycrawl.tools.checkstyle.checks.blocks.rightcurly;
+
+public class InputRightCurlyCaseBlocksInSwitchStatementAlone2 {
+     public static void test9() {
+        int mode = 0;
+        switch (mode) {
+            case 0: int x = 1;
+            case 1: x = 1; break;
+            case 2: {
+                x =
+            1;} default : x = 5;         // violation '}' at column 15 should be alone on a line'
+        }
+    }
+
+    public static void test10() {
+        int mode = 0;
+        switch (mode) {
+            case 0: {
+
+            } case 1: int x = 1; break;    // violation '}' at column 13 should be alone on a line'
+            case 2: {
+
+            }
+            default : x = 5;
+        }
+    }
+     public static void test11() {
+        int mode = 0;
+        switch (mode) {
+            case 0: {
+
+            } case 1: int x = 1; break;   // violation '}' at column 13 should be alone on a line'
+            case 2: {
+
+            } default : x = 5;            // violation '}' at column 13 should be alone on a line'
+        }
+    }
+    public static void test12() {
+        int mode = 0;
+        switch (mode) {
+            case 0: {
+
+            int x = 1; } case 1: {int x = 1;} break;  // 2 violations
+        }
+    }
+    public static void test13() {
+        int mode = 0;
+        switch (mode) {
+            case 0: { int x = 1;
+
+            } case 1: { // violation '}' at column 13 should be alone on a line'
+
+            }
+            default : break;
+        }
+    }
+    public static void test14() {
+        int mode = 0;
+        switch (mode) {
+            case 0: {
+
+            } case 1: {  }         // 2 violations
+            default : {break;}
+        }
+    }
+
+    public static void test15() {
+        int mode = 0;
+        switch (mode) {case 0: { } case 1: {  } } // 2 violations
+    }
+
+    public static void test16() {
+        int mode = 0;
+        switch (mode) {
+            case 0: int x = 1; { } break;  // ok, the braces is not a first child of case
+            case 1: { } int y = 1; break;
+            // violation above '}' at column 23 should be alone on a line'
+            case 2: int t = 1; { };
+        }
+    }
+
+    public static void test17() {
+        int mode = 0;
+        switch (mode) {
+            case 0:
+            int x = 1;
+            {  }  // ok, the braces is not a first child of case
+            case 1:
+            mode++;
+            {
+
+            } int y; // ok, the braces is not a first child of case
+            case 3:
+            {
+
+            } int z = 1;  // violation '}' at column 13 should be alone on a line'
+        }
+    }
+
+    public static void test18() {
+        int mode = 0;
+        switch (mode) {
+            case 0: {
+            }
+            int x;
+            case 1:
+            int z;
+            {
+
+            }break; default: break; // ok, the braces is not a first child of case
+        }
+    }
+}
+

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/blocks/rightcurly/InputRightCurlyCaseBlocksInSwitchStatementAloneOrSingleline.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/blocks/rightcurly/InputRightCurlyCaseBlocksInSwitchStatementAloneOrSingleline.java
@@ -1,0 +1,111 @@
+/*
+RightCurly
+option = ALONE_OR_SINGLELINE
+tokens = LITERAL_CASE
+
+*/
+package com.puppycrawl.tools.checkstyle.checks.blocks.rightcurly;
+
+public class InputRightCurlyCaseBlocksInSwitchStatementAloneOrSingleline {
+    public static void test0() {
+        int mode = 0;
+        switch (mode) {
+            case 1: {
+                int x = 1;
+                break;
+            }
+            case 2: {
+                int x = 0;
+                break;
+            }
+            case 3: {
+                break;
+            }
+        }
+    }
+
+    public static void test() {
+        int mode = 0;
+        switch (mode) {
+            case 1:{
+                int x = 1;
+                break;
+            } default :          // violation '}' at column 13 should be alone on a line'
+                int x = 0;
+        }
+    }
+
+    public static void test1() {
+        int k = 0;
+        switch (k) {
+            case 1:{
+                 int x = 1;
+                 break;
+            } case 2:        // violation '}' at column 13 should be alone on a line'
+                 int x = 2;
+                 break;
+        }
+    }
+
+    public static void test2() {
+         int k = 0;
+         switch (k) {
+            case 1:{
+                 int x = 1;
+                 break;
+            }
+            case 2:
+                 int x = 2;
+                 break;
+         }
+    }
+
+    public static void test3() {
+         int k = 0;
+         switch (k) {
+            case 1:{
+                 int x = 1;
+                 break;
+            }
+            case 2:{
+                    int x = 2;
+                    break;
+            } }      // violation '}' at column 13 should be alone on a line'
+    }
+
+    public static void test4() {
+        int mode = 0;
+        switch (mode) { case 0: {int x = 1; break;} default : int x = 5; }
+        // violation above '}' at column 51 should be alone on a line'
+    }
+
+    public static void test5() {
+        int mode = 0;
+        switch (mode) { case 0: int x = 1; }
+    }
+
+    public static void test6() {
+        int mode = 0;
+        switch (mode) {
+            case 0: {int x = 1; break;}  // ok , single line
+            default : break;
+        }
+    }
+
+    public static void test7() {
+        int mode = 0;
+        switch (mode) { case 0: {int x = 1;}     // ok, single line
+            break; default : break; }
+    }
+
+    public static void test8() {
+        int mode = 0;
+        switch (mode) {
+            case 0: int x = 1;
+            case 1: x = 1; break;
+            case 2: {x = 1; break;} // ok, single line
+            default : x = 5;
+        }
+    }
+
+}

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/blocks/rightcurly/InputRightCurlyCaseBlocksInSwitchStatementAloneOrSingleline2.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/blocks/rightcurly/InputRightCurlyCaseBlocksInSwitchStatementAloneOrSingleline2.java
@@ -1,0 +1,117 @@
+/*
+RightCurly
+option = ALONE_OR_SINGLELINE
+tokens = LITERAL_CASE
+
+*/
+package com.puppycrawl.tools.checkstyle.checks.blocks.rightcurly;
+
+public class InputRightCurlyCaseBlocksInSwitchStatementAloneOrSingleline2 {
+
+    public static void test9() {
+        int mode = 0;
+        switch (mode) {
+            case 0: int x = 1;
+            case 1: x = 1; break;
+            case 2: {
+                x =
+            1;} default : x = 5;         // violation '}' at column 15 should be alone on a line'
+        }
+    }
+
+    public static void test10() {
+        int mode = 0;
+        switch (mode) {
+            case 0: {
+
+            } case 1: int x = 1; break;    // violation '}' at column 13 should be alone on a line'
+            case 2: {
+
+            }
+            default : x = 5;
+        }
+    }
+     public static void test11() {
+        int mode = 0;
+        switch (mode) {
+            case 0: {
+
+            } case 1: int x = 1; break;   // violation '}' at column 13 should be alone on a line'
+            case 2: {
+                int
+            y;} default : x = 5;         // violation '}' at column 15 should be alone on a line'
+        }
+    }
+    public static void test12() {
+        int mode = 0;
+        switch (mode) {
+            case 0: {
+
+            int x = 1;} case 1: {int x = 1; break;}
+            // violation above '}' at column 23 should be alone on a line'
+        }
+    }
+    public static void test13() {
+        int mode = 0;
+        switch (mode) {
+            case 0: {
+
+            }
+            case 1: {
+
+            }
+            default : break;
+        }
+    }
+     public static void test14() {
+        int mode = 0;
+        switch (mode) {
+            case 0: { int x = 1;
+
+            } case 1: {  }         // violation '}' at column 13 should be alone on a line'
+            default : {break;}
+        }
+    }
+
+     public static void test15() {
+        int mode = 0;
+        switch (mode) {
+            case 0: int x = 1; { } break;
+            case 1: { } int y = 1; break; // violation '}' at column 23 should be alone on a line'
+
+            case 2: int t = 1; { };
+        }
+    }
+
+    public static void test17() {
+        int mode = 0;
+        switch (mode) {
+            case 0:
+            int x = 1;
+            {  }
+            case 1:
+            mode++;
+            {
+
+            } int y; // ok, the braces is not a first child of case
+            case 3:
+            {
+
+            } int z = 1;  // violation '}' at column 13 should be alone on a line'
+        }
+    }
+
+    public static void test18() {
+        int mode = 0;
+        switch (mode) {
+            case 0: {
+
+            }
+            case 1:
+            int z;
+            {
+
+            } break; default: break; // ok, the braces is not a first child of case
+        }
+    }
+}

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/blocks/rightcurly/InputRightCurlyCaseBlocksInSwitchStatementSame.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/blocks/rightcurly/InputRightCurlyCaseBlocksInSwitchStatementSame.java
@@ -1,0 +1,114 @@
+/*
+RightCurly
+option = SAME
+tokens = LITERAL_CASE
+
+*/
+package com.puppycrawl.tools.checkstyle.checks.blocks.rightcurly;
+
+public class InputRightCurlyCaseBlocksInSwitchStatementSame {
+    public static void test0() {
+        int mode = 0;
+        switch (mode) {
+            case 1: {
+                int x = 1;
+                break;
+            }
+            case 2: {
+                int x = 0;
+                break;
+            }
+            default: {
+                break;
+            }
+        }
+    }
+
+    public static void test() {
+        int mode = 0;
+        switch (mode) {
+            case 1:{
+                int x
+
+            =1;} default :          // violation '}' at column 16 should have line break before'
+                int x = 0;
+        }
+    }
+
+    public static void test1() {
+        int k = 0;
+        switch (k) {
+            case 1:{
+                 int x = 1;
+                 break;
+            } case 2:        // violation '}' at column 13 should be alone on a line'
+                 int x = 2;
+                 break;
+        }
+    }
+
+    public static void test2() {
+         int k = 0;
+         switch (k) {
+            case 1:{
+                 int x = 1;
+                 break;
+            }
+            case 2:
+                 int x = 2;
+                 break;
+         }
+    }
+
+    public static void test3() {
+         int k = 0;
+         switch (k) {
+            case 1:{
+                 int x = 1;
+                 break;
+            }
+            case 2:{
+                    int x = 2;
+                    break;
+            } }      // violation '}' at column 13 should be alone on a line'
+    }
+
+    public static void test4() {
+        int mode = 0;
+        switch (mode) { case 0: {int x = 1; break;} default : int x = 5; }
+        // violation above '}' at column 51 should be alone on a line'
+    }
+
+    public static void test5() {
+        int mode = 0;
+        switch (mode) { case 0: int x = 1;}
+    }
+
+    public static void test6() {
+        int mode = 0;
+        switch (mode) {
+            case 0: {int x = 1; break;}  // ok , single line
+            default : break;
+        }
+    }
+
+    public static void test7() {
+        int mode = 0;
+        switch (mode) { case 0: {int x = 1;}     // ok, single line
+            break; default : break; }
+    }
+
+    public static void test8() {
+        int mode = 0;
+        int x = 0;
+        switch (mode) {
+            case 0:{
+            int y = 1;} // violation '}' at column 23 should have line break before'
+            case 1: {x = 1;
+            }
+            case 2: {x = 1; break;} // ok, single line
+            default : x = 5;
+        }
+    }
+
+}

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/blocks/rightcurly/InputRightCurlyCaseBlocksInSwitchStatementSame2.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/blocks/rightcurly/InputRightCurlyCaseBlocksInSwitchStatementSame2.java
@@ -1,0 +1,119 @@
+/*
+RightCurly
+option = SAME
+tokens = LITERAL_CASE
+
+*/
+package com.puppycrawl.tools.checkstyle.checks.blocks.rightcurly;
+
+public class InputRightCurlyCaseBlocksInSwitchStatementSame2 {
+
+     public static void test9() {
+        int mode = 0;
+        switch (mode) {
+            case 0: int x = 1;
+            case 1: x = 1; break;
+            case 2: {
+                x = 1; break;
+            } default : x = 5;         // violation '}' at column 13 should be alone on a line'
+        }
+    }
+
+    public static void test10() {
+        int mode = 0;
+        switch (mode) {
+            case 0: {
+
+            } case 1: int x = 1; break;    // violation '}' at column 13 should be alone on a line'
+            case 2: {
+
+            }
+            default : x = 5;
+        }
+    }
+     public static void test11() {
+        int mode = 0;
+        switch (mode) {
+            case 0: {
+
+            } case 1: int x = 1; break;   // violation '}' at column 13 should be alone on a line'
+            case 2: {
+
+            } default : x = 5;            // violation '}' at column 13 should be alone on a line'
+        }
+    }
+    public static void test12() {
+        int mode = 0;
+        switch (mode) {
+            case 0: {
+
+            } case 1: {int x = 1; break;} // violation '}' at column 13 should be alone on a line'
+        }
+    }
+    public static void test13() {
+        int mode = 0;
+        switch (mode) {
+            case 0: {
+
+            }
+            case 1: {
+
+            }
+            default : break;
+        }
+    }
+     public static void test14() {
+        int mode = 0;
+        switch (mode) {
+            case 0: {
+
+            } case 1: {  }         // violation '}' at column 13 should be alone on a line'
+            default : {break;}
+        }
+    }
+
+    public static void test15() {
+        int mode = 0;
+        switch (mode) {case 0: { } case 1: {  } } // 2 violations
+
+    }
+
+    public static void test16() {
+        int mode = 0;
+        switch (mode) {
+            case 0: int x = 1; { } break;
+            case 1: { } int y = 1; break; // violation '}' at column 23 should be alone on a line'
+
+            case 2: int t = 1; { };
+        }
+    }
+    public static void test17() {
+        int mode = 0;
+        switch (mode) {
+            case 0:
+            int x = 1;
+            {  }
+            case 1:
+            mode++;
+            {
+            } int y; // ok, the braces is not a first child of case
+            case 3:
+            {
+
+            } int z = 1; // violation '}' at column 13 should be alone on a line'
+        }
+    }
+    public static void test18() {
+        int mode = 0;
+        switch (mode) {
+            case 0: {
+            }
+            int x;
+            case 1:
+            int z;
+            {
+
+            } break; default: break; // ok, the braces is not a first child of case
+        }
+    }
+}

--- a/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/checks/blocks/RightCurlyCheckExamplesTest.java
+++ b/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/checks/blocks/RightCurlyCheckExamplesTest.java
@@ -56,7 +56,8 @@ public class RightCurlyCheckExamplesTest extends AbstractExamplesModuleTestSuppo
     @Test
     public void testExample3() throws Exception {
         final String[] expected = {
-            "35:16: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}", "16"),
+            "24:22: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}", "22"),
+            "38:16: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}", "16"),
         };
 
         verifyWithInlineConfigParser(getPath("Example3.java"), expected);
@@ -74,7 +75,7 @@ public class RightCurlyCheckExamplesTest extends AbstractExamplesModuleTestSuppo
     @Test
     public void testExample5() throws Exception {
         final String[] expected = {
-            "41:16: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}", "16"),
+            "44:16: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}", "16"),
         };
 
         verifyWithInlineConfigParser(getPath("Example5.java"), expected);

--- a/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/blocks/rightcurly/Example3.java
+++ b/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/blocks/rightcurly/Example3.java
@@ -3,7 +3,7 @@
   <module name="TreeWalker">
     <module name="RightCurly">
       <property name="option" value="alone"/>
-      <property name="tokens" value="LITERAL_SWITCH"/>
+      <property name="tokens" value="LITERAL_SWITCH, LITERAL_CASE"/>
     </module>
   </module>
 </module>
@@ -16,10 +16,13 @@ class Example3 {
 
   public void method0() {
     int mode = 0;
+    int x;
     switch (mode) {
       case 1:
-        int x = 1;
+        int y = 1;
         break;
+      case 2: {x = 1;}   // violation '}' at column 22 should be alone on a line'
+      case 3: int z = 0; {break;} // ok, the braces is not a first child of case
       default:
         x = 0;
     } // ok, RightCurly is alone
@@ -35,6 +38,5 @@ class Example3 {
         x = 0; }
     // violation above, 'should be alone on a line.'
   }
-
 }
 // xdoc section -- end

--- a/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/blocks/rightcurly/Example5.java
+++ b/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/blocks/rightcurly/Example5.java
@@ -3,7 +3,7 @@
   <module name="TreeWalker">
     <module name="RightCurly">
       <property name="option" value="alone_or_singleline"/>
-      <property name="tokens" value="LITERAL_SWITCH"/>
+      <property name="tokens" value="LITERAL_SWITCH, LITERAL_CASE"/>
     </module>
   </module>
 </module>
@@ -16,10 +16,13 @@ class Example5 {
 
   public void method0() {
     int mode = 0;
+    int x;
     switch (mode) {
       case 1:
-        int x = 1;
+        int y = 1;
         break;
+      case 2: {x = 1;}   // ok, RightCurly is in single line
+      case 3: int z = 0; {break;} // ok, the braces is not a first child of case
       default:
         x = 0;
     }

--- a/src/xdocs/checks/blocks/rightcurly.xml
+++ b/src/xdocs/checks/blocks/rightcurly.xml
@@ -11,7 +11,7 @@
       <subsection name="Description" id="Description">
         <p>
           Checks the placement of right curly braces (<code>'}'</code>) for code blocks.
-          This check supports if-else, try-catch-finally blocks, switch statements,
+          This check supports if-else, try-catch-finally blocks, switch statements, switch cases,
           while-loops, for-loops, method definitions, class definitions, constructor definitions,
           instance, static initialization blocks, annotation definitions and enum definitions.
           For right curly brace of expression blocks of arrays, lambdas and class instances
@@ -81,6 +81,8 @@
                     COMPACT_CTOR_DEF</a>
                 , <a href="../../apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#LITERAL_SWITCH">
                     LITERAL_SWITCH</a>
+                , <a href="../../apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#LITERAL_CASE">
+                    LITERAL_CASE</a>
                   .
               </td>
               <td>
@@ -220,14 +222,14 @@ public class Example2 {
           To configure the check with policy <code>alone</code> for
           <a href="https://docs.oracle.com/javase/tutorial/java/nutsandbolts/switch.html">
           Switch</a>
-          Statements:
+          Statements and Switch Cases:
         </p>
         <source>
 &lt;module name=&quot;Checker&quot;&gt;
   &lt;module name=&quot;TreeWalker&quot;&gt;
     &lt;module name=&quot;RightCurly&quot;&gt;
       &lt;property name=&quot;option&quot; value=&quot;alone&quot;/&gt;
-      &lt;property name=&quot;tokens&quot; value=&quot;LITERAL_SWITCH&quot;/&gt;
+      &lt;property name=&quot;tokens&quot; value=&quot;LITERAL_SWITCH, LITERAL_CASE&quot;/&gt;
     &lt;/module&gt;
   &lt;/module&gt;
 &lt;/module&gt;
@@ -238,10 +240,13 @@ class Example3 {
 
   public void method0() {
     int mode = 0;
+    int x;
     switch (mode) {
       case 1:
-        int x = 1;
+        int y = 1;
         break;
+      case 2: {x = 1;}   // violation '}' at column 22 should be alone on a line'
+      case 3: int z = 0; {break;} // ok, the braces is not a first child of case
       default:
         x = 0;
     } // ok, RightCurly is alone
@@ -257,7 +262,6 @@ class Example3 {
         x = 0; }
     // violation above, 'should be alone on a line.'
   }
-
 }
         </source>
         <p id="Example4-config">
@@ -315,14 +319,14 @@ public class Example4 {
           To configure the check with policy <code>alone_or_singleline</code> for
           <a href="https://docs.oracle.com/javase/tutorial/java/nutsandbolts/switch.html">
           Switch</a>
-          Statements:
+          Statements and Switch Cases:
         </p>
         <source>
 &lt;module name=&quot;Checker&quot;&gt;
   &lt;module name=&quot;TreeWalker&quot;&gt;
     &lt;module name=&quot;RightCurly&quot;&gt;
       &lt;property name=&quot;option&quot; value=&quot;alone_or_singleline&quot;/&gt;
-      &lt;property name=&quot;tokens&quot; value=&quot;LITERAL_SWITCH&quot;/&gt;
+      &lt;property name=&quot;tokens&quot; value=&quot;LITERAL_SWITCH, LITERAL_CASE&quot;/&gt;
     &lt;/module&gt;
   &lt;/module&gt;
 &lt;/module&gt;
@@ -333,10 +337,13 @@ class Example5 {
 
   public void method0() {
     int mode = 0;
+    int x;
     switch (mode) {
       case 1:
-        int x = 1;
+        int y = 1;
         break;
+      case 2: {x = 1;}   // ok, RightCurly is in single line
+      case 3: int z = 0; {break;} // ok, the braces is not a first child of case
       default:
         x = 0;
     }

--- a/src/xdocs/checks/blocks/rightcurly.xml.template
+++ b/src/xdocs/checks/blocks/rightcurly.xml.template
@@ -11,7 +11,7 @@
       <subsection name="Description" id="Description">
         <p>
           Checks the placement of right curly braces (<code>'}'</code>) for code blocks.
-          This check supports if-else, try-catch-finally blocks, switch statements,
+          This check supports if-else, try-catch-finally blocks, switch statements, switch cases,
           while-loops, for-loops, method definitions, class definitions, constructor definitions,
           instance, static initialization blocks, annotation definitions and enum definitions.
           For right curly brace of expression blocks of arrays, lambdas and class instances
@@ -65,7 +65,7 @@
           To configure the check with policy <code>alone</code> for
           <a href="https://docs.oracle.com/javase/tutorial/java/nutsandbolts/switch.html">
           Switch</a>
-          Statements:
+          Statements and Switch Cases:
         </p>
         <macro name="example">
             <param name="path"
@@ -100,7 +100,7 @@
           To configure the check with policy <code>alone_or_singleline</code> for
           <a href="https://docs.oracle.com/javase/tutorial/java/nutsandbolts/switch.html">
           Switch</a>
-          Statements:
+          Statements and Switch Cases:
         </p>
         <macro name="example">
             <param name="path"


### PR DESCRIPTION
Resolves #14620 :

Diff Regression config: https://gist.githubusercontent.com/mahfouz72/c82dbc1b4a05567e245729eccfc6cf62/raw/c4958b5ee00ded9c8f89d3af0a50fa871b352205/rcurlybase.xml

Diff Regression patch config: https://gist.githubusercontent.com/mahfouz72/fb26eda6b5a3264c0c42351e612cc4f6/raw/daf318509889f654cd61d58c9e039c9ba1505716/rcurlypatch.xml

### Site ([link](https://checkstyle-diff-reports.s3.us-east-2.amazonaws.com/8119c30_2024144719/checks/blocks/rightcurly.html#Description))
### Reports

- alone option ([link](https://checkstyle-diff-reports.s3.us-east-2.amazonaws.com/ddf54a1_2024014514/reports/diff/index.html))

- alone_or_singleline option ([link](https://checkstyle-diff-reports.s3.us-east-2.amazonaws.com/ddf54a1_2024024511/reports/diff/index.html  ))

- same option ([link](https://checkstyle-diff-reports.s3.us-east-2.amazonaws.com/ddf54a1_2024001633/reports/diff/index.html))