### PR TITLE
Issue #13213: Remove "// ok" from onestatementperline

### DIFF
--- a/config/checkstyle-input-suppressions.xml
+++ b/config/checkstyle-input-suppressions.xml
@@ -70,28 +70,6 @@
   <!-- until https://github.com/checkstyle/checkstyle/issues/13213 -->
 
   <suppress id="UnnecessaryOkComment"
-            files="checks[\\/]coding[\\/]onestatementperline[\\/]InputOneStatementPerLineBeginTreeLastVariableResourcesStatementEnd1.java"/>
-  <suppress id="UnnecessaryOkComment"
-            files="checks[\\/]coding[\\/]onestatementperline[\\/]InputOneStatementPerLineBeginTreeLastVariableResourcesStatementEnd2.java"/>
-  <suppress id="UnnecessaryOkComment"
-            files="checks[\\/]coding[\\/]onestatementperline[\\/]InputOneStatementPerLineBeginTreeTest.java"/>
-  <suppress id="UnnecessaryOkComment"
-            files="checks[\\/]coding[\\/]onestatementperline[\\/]InputOneStatementPerLineBeginTreeTest.java"/>
-  <suppress id="UnnecessaryOkComment"
-            files="checks[\\/]coding[\\/]onestatementperline[\\/]InputOneStatementPerLineTest.java"/>
-  <suppress id="UnnecessaryOkComment"
-            files="checks[\\/]coding[\\/]onestatementperline[\\/]InputOneStatementPerLineTryWithResources.java"/>
-  <suppress id="UnnecessaryOkComment"
-            files="checks[\\/]coding[\\/]onestatementperline[\\/]InputOneStatementPerLineTryWithResourcesIgnore.java"/>
-  <suppress id="UnnecessaryOkComment"
-            files="checks[\\/]coding[\\/]onestatementperline[\\/]InputOneStatementPerLineTryWithResourcesIgnore.java"/>
-  <suppress id="UnnecessaryOkComment"
-            files="checks[\\/]coding[\\/]onestatementperline[\\/]InputOneStatementPerLineTryWithResourcesIgnore.java"/>
-  <suppress id="UnnecessaryOkComment"
-            files="checks[\\/]coding[\\/]onestatementperline[\\/]InputOneStatementPerLineTryWithResourcesIgnore.java"/>
-  <suppress id="UnnecessaryOkComment"
-            files="checks[\\/]coding[\\/]onestatementperline[\\/]InputOneStatementPerLineTryWithResourcesIgnore.java"/>
-  <suppress id="UnnecessaryOkComment"
             files="checks[\\/]coding[\\/]packagedeclaration[\\/]InputPackageDeclarationPlain.java"/>
   <suppress id="UnnecessaryOkComment"
             files="checks[\\/]coding[\\/]packagedeclaration[\\/]InputPackageDeclarationWithCommentOnly.java"/>

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/onestatementperline/InputOneStatementPerLineBeginTreeLastVariableResourcesStatementEnd1.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/onestatementperline/InputOneStatementPerLineBeginTreeLastVariableResourcesStatementEnd1.java
@@ -9,7 +9,7 @@ package com.puppycrawl.tools.checkstyle.checks.coding.onestatementperline;
 
 import java.io.*;
 
-// ok
+
 public class InputOneStatementPerLineBeginTreeLastVariableResourcesStatementEnd1 {
     public void resourceListExists() throws IOException {
         try (FileInputStream f1 = new FileInputStream("1"); FileInputStream f2 =

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/onestatementperline/InputOneStatementPerLineBeginTreeLastVariableResourcesStatementEnd2.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/onestatementperline/InputOneStatementPerLineBeginTreeLastVariableResourcesStatementEnd2.java
@@ -9,7 +9,7 @@ package com.puppycrawl.tools.checkstyle.checks.coding.onestatementperline;
 
 import java.io.*;
 
-// ok
+
 public class InputOneStatementPerLineBeginTreeLastVariableResourcesStatementEnd2 {
     void m(OutputStream out) throws IOException {
         try (out; InputStream in = new FileInputStream("filename")) {

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/onestatementperline/InputOneStatementPerLineBeginTreeTest.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/onestatementperline/InputOneStatementPerLineBeginTreeTest.java
@@ -18,7 +18,7 @@ public class InputOneStatementPerLineBeginTreeTest {
     void testNestedInLambda() {
         Runnable r = () -> {
             try (OutputStream s1 = new PipedOutputStream();
-                 OutputStream s2 = new PipedOutputStream();) { // ok
+                 OutputStream s2 = new PipedOutputStream();) {
             }
             catch (IOException e) {
             }
@@ -26,7 +26,7 @@ public class InputOneStatementPerLineBeginTreeTest {
     }
 
     public void doLegalForLoop() {
-        for (int i = 0; i < 20; i++) { // ok
+        for (int i = 0; i < 20; i++) {
         }
      }
 

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/onestatementperline/InputOneStatementPerLineTest.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/onestatementperline/InputOneStatementPerLineTest.java
@@ -14,7 +14,7 @@ import java.io.PipedOutputStream;
 public class InputOneStatementPerLineTest {
     void testNestedInLambda() {
         Runnable r = () -> {
-            try (OutputStream s1 = new PipedOutputStream()) { // ok
+            try (OutputStream s1 = new PipedOutputStream()) {
             }
             catch (IOException e) {
             }

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/onestatementperline/InputOneStatementPerLineTryWithResources.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/onestatementperline/InputOneStatementPerLineTryWithResources.java
@@ -55,7 +55,7 @@ OutputStream s9=new PipedOutputStream();s2;OutputStream s10 = new PipedOutputStr
     void testNestedInLambda() {
         Runnable r = () -> {
             try (OutputStream s1 = new PipedOutputStream();
-                 OutputStream s2 = new PipedOutputStream();) { // ok
+                 OutputStream s2 = new PipedOutputStream();) {
             }
             catch (IOException e) {
             }

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/onestatementperline/InputOneStatementPerLineTryWithResourcesIgnore.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/onestatementperline/InputOneStatementPerLineTryWithResourcesIgnore.java
@@ -17,13 +17,13 @@ public class InputOneStatementPerLineTryWithResourcesIgnore {
     void method() throws IOException {
         OutputStream s1 = new PipedOutputStream();
         OutputStream s2 = new PipedOutputStream();
-        try (s1; s2; OutputStream s3 = new PipedOutputStream();) { // ok
+        try (s1; s2; OutputStream s3 = new PipedOutputStream();) {
         }
-        try (s1; OutputStream s4 = new PipedOutputStream(); s2;) { // ok
+        try (s1; OutputStream s4 = new PipedOutputStream(); s2;) {
         }
-        try (s1; s2; OutputStream s5 = new PipedOutputStream()) { // ok
+        try (s1; s2; OutputStream s5 = new PipedOutputStream()) {
         }
-        try (s1; OutputStream s6 = new PipedOutputStream(); s2) { // ok
+        try (s1; OutputStream s6 = new PipedOutputStream(); s2) {
         }
         try (
 OutputStream s7 = new PipedOutputStream();OutputStream s8 = new PipedOutputStream();
@@ -40,7 +40,7 @@ OutputStream s9=new PipedOutputStream();s2;OutputStream s10 = new PipedOutputStr
              ;s2;) {
         }
         try (OutputStream
-             s12 = new PipedOutputStream();s1;OutputStream s3 // ok
+             s12 = new PipedOutputStream();s1;OutputStream s3
                 = new PipedOutputStream()) {}
         try (s1; s2; OutputStream stream3 =
              new PipedOutputStream()) {}


### PR DESCRIPTION
Part of Issue: #13213

1. Remove "// ok" comments from 6 classes under onestatementperline.
2. Remove corresponding suppress statements in config/checkstyle-input-suppressions.xml