### PR TITLE
Issue #14436: Enforcing Naming Convention on InputAbstractJavadocCorrectParagraphOne.java

### DIFF
--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/javadoc/AbstractJavadocCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/javadoc/AbstractJavadocCheckTest.java
@@ -121,14 +121,14 @@ public class AbstractJavadocCheckTest extends AbstractModuleTestSupport {
     @Test
     public void testWithMultipleChecksOne() throws Exception {
         verifyWithInlineConfigParser(
-                getPath("InputAbstractJavadocCorrectParagraphOne.java"),
+                getPath("InputAbstractJavadocCheckParagraphOnInnerClass.java"),
                 CommonUtil.EMPTY_STRING_ARRAY);
     }
 
     @Test
     public void testWithMultipleChecksTwo() throws Exception {
         verifyWithInlineConfigParser(
-                getPath("InputAbstractJavadocCorrectParagraphTwo.java"),
+                getPath("InputAbstractJavadocCheckParagraphOnPlainComment.java"),
                 CommonUtil.EMPTY_STRING_ARRAY);
     }
 

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/abstractjavadoc/InputAbstractJavadocCheckParagraphOnInnerClass.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/abstractjavadoc/InputAbstractJavadocCheckParagraphOnInnerClass.java
@@ -20,7 +20,7 @@ package com.puppycrawl.tools.checkstyle.checks.javadoc.abstractjavadoc;
  * <p>Some Javadoc.
  *
  */
-class InputAbstractJavadocCorrectParagraphOne {
+class InputAbstractJavadocCheckParagraphOnInnerClass {
 
     /**
      * Some Javadoc.
@@ -67,7 +67,7 @@ class InputAbstractJavadocCorrectParagraphOne {
      * <p>Some Javadoc.
      *
      */
-     class InnerInputCorrectJavaDocParagraphCheck {
+    class InnerInputAbstractJavadocCheckParagraphOnInnerClass {
 
         /**
          * Some Javadoc.
@@ -91,7 +91,8 @@ class InputAbstractJavadocCorrectParagraphOne {
         boolean emulated() {return false;}
     }
 
-    InnerInputCorrectJavaDocParagraphCheck anon = new InnerInputCorrectJavaDocParagraphCheck() {
+    InnerInputAbstractJavadocCheckParagraphOnInnerClass anon =
+            new InnerInputAbstractJavadocCheckParagraphOnInnerClass() {
 
         /**
          * Some Javadoc.

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/abstractjavadoc/InputAbstractJavadocCheckParagraphOnPlainComment.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/abstractjavadoc/InputAbstractJavadocCheckParagraphOnPlainComment.java
@@ -6,14 +6,11 @@ target = (default)CLASS_DEF, INTERFACE_DEF, ENUM_DEF, METHOD_DEF, \
 tagOrder = (default)@author, @deprecated, @exception, @param, @return, \
            @see, @serial, @serialData, @serialField, @since, @throws, @version
 
-
 com.puppycrawl.tools.checkstyle.checks.javadoc.JavadocParagraphCheck
 violateExecutionOnNonTightHtml = (default)false
 allowNewlineParagraph = (default)true
 
-
 */
-
 
 package com.puppycrawl.tools.checkstyle.checks.javadoc.abstractjavadoc;
 
@@ -23,7 +20,7 @@ package com.puppycrawl.tools.checkstyle.checks.javadoc.abstractjavadoc;
  * <p>Some Javadoc.
  *
  */
-class InputAbstractJavadocCorrectParagraphTwo {}
+class InputAbstractJavadocCheckParagraphOnPlainComment {}
 
 /*
  *  This comment has paragraph without '<p>' tag.


### PR DESCRIPTION
Issue #14436: Enforcing Naming Convention on InputAbstractJavadocCorrectParagraphOne.java