### PR TITLE
Issue #14436: Enforced naming convention for  `NestedForDepthCheckTest`

### DIFF
--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/coding/NestedForDepthCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/coding/NestedForDepthCheckTest.java
@@ -44,7 +44,7 @@ public class NestedForDepthCheckTest extends AbstractModuleTestSupport {
      *     interface-requirements for test-methods.
      */
     @Test
-    public void testNestedTooDeep() throws Exception {
+    public void testNestedForDepthCheckCustomMaxLevelTwo() throws Exception {
 
         final String[] expected = {
             "32:11: " + getCheckMessage(MSG_KEY, 3, 2),
@@ -53,7 +53,7 @@ public class NestedForDepthCheckTest extends AbstractModuleTestSupport {
         };
 
         verifyWithInlineConfigParser(
-                getPath("InputNestedForDepth.java"),
+                getPath("InputNestedForDepthCheckCustomMaxLevelTwo.java"),
                expected);
     }
 
@@ -68,12 +68,12 @@ public class NestedForDepthCheckTest extends AbstractModuleTestSupport {
      *     interface-requirements for test-methods.
      */
     @Test
-    public void testNestedOk() throws Exception {
+    public void testNestedForDepthCheckCustomMaxLevelFour() throws Exception {
 
         final String[] expected = CommonUtil.EMPTY_STRING_ARRAY;
 
         verifyWithInlineConfigParser(
-                getPath("InputNestedForDepth1.java"),
+                getPath("InputNestedForDepthCheckCustomMaxLevelFour.java"),
                expected);
     }
 
@@ -92,13 +92,13 @@ public class NestedForDepthCheckTest extends AbstractModuleTestSupport {
     }
 
     @Test
-    public void testNestedDefault() throws Exception {
+    public void testNestedForDepthCheckDefaultMaxLevel() throws Exception {
         final String[] expected = {
             "27:9: " + getCheckMessage(MSG_KEY, 2, 1),
         };
 
         verifyWithInlineConfigParser(
-                getPath("InputNestedForDepthDefault.java"),
+                getPath("InputNestedForDepthCheckDefaultMaxLevel.java"),
                expected);
     }
 }

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/nestedfordepth/InputNestedForDepthCheckCustomMaxLevelFour.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/nestedfordepth/InputNestedForDepthCheckCustomMaxLevelFour.java
@@ -13,7 +13,7 @@ package com.puppycrawl.tools.checkstyle.checks.coding.nestedfordepth;
  * @author Alexander Jesse
  * @see com.puppycrawl.tools.checkstyle.checks.coding.NestedForDepthCheck
  */
-public class InputNestedForDepth1 {
+public class InputNestedForDepthCheckCustomMaxLevelFour {
 
   /**
    * Dummy method containing 5 layers of for-statements.

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/nestedfordepth/InputNestedForDepthCheckCustomMaxLevelTwo.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/nestedfordepth/InputNestedForDepthCheckCustomMaxLevelTwo.java
@@ -13,7 +13,7 @@ package com.puppycrawl.tools.checkstyle.checks.coding.nestedfordepth;
  * @author Alexander Jesse
  * @see com.puppycrawl.tools.checkstyle.checks.coding.NestedForDepthCheck
  */
-public class InputNestedForDepth {
+public class InputNestedForDepthCheckCustomMaxLevelTwo {
 
   /**
    * Dummy method containing 5 layers of for-statements.

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/nestedfordepth/InputNestedForDepthCheckDefaultMaxLevel.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/nestedfordepth/InputNestedForDepthCheckDefaultMaxLevel.java
@@ -7,7 +7,7 @@ max = (default)1
 
 package com.puppycrawl.tools.checkstyle.checks.coding.nestedfordepth;
 
-public class InputNestedForDepthDefault {
+public class InputNestedForDepthCheckDefaultMaxLevel {
 
   public void method() {
     for (int i = 1; i < 5; i++) {


### PR DESCRIPTION
Part of #14436 