### PR TITLE
Issue #6207: Add XPath IT Regression for VisibilityModifier

### DIFF
--- a/src/it/java/org/checkstyle/suppressionxpathfilter/XpathRegressionVisibilityModifierTest.java
+++ b/src/it/java/org/checkstyle/suppressionxpathfilter/XpathRegressionVisibilityModifierTest.java
@@ -1,0 +1,130 @@
+///////////////////////////////////////////////////////////////////////////////////////////////
+// checkstyle: Checks Java source code and other text files for adherence to a set of rules.
+// Copyright (C) 2001-2024 the original author or authors.
+//
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the GNU Lesser General Public
+// License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+//
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+// Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public
+// License along with this library; if not, write to the Free Software
+// Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+///////////////////////////////////////////////////////////////////////////////////////////////
+
+package org.checkstyle.suppressionxpathfilter;
+
+import static com.puppycrawl.tools.checkstyle.checks.design.VisibilityModifierCheck.MSG_KEY;
+
+import java.io.File;
+import java.util.Collections;
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+
+import com.puppycrawl.tools.checkstyle.DefaultConfiguration;
+import com.puppycrawl.tools.checkstyle.checks.design.VisibilityModifierCheck;
+
+public class XpathRegressionVisibilityModifierTest extends AbstractXpathTestSupport {
+
+    private final String checkName = VisibilityModifierCheck.class.getSimpleName();
+
+    @Override
+    protected String getCheckName() {
+        return checkName;
+    }
+
+    @Test
+    public void testDefaultModifier() throws Exception {
+        final File fileToProcess =
+                new File(getPath("SuppressionXpathRegressionVisibilityModifierDefault.java"));
+
+        final DefaultConfiguration moduleConfig =
+                createModuleConfig(VisibilityModifierCheck.class);
+
+        final String[] expectedViolation = {
+            "6:9: " + getCheckMessage(VisibilityModifierCheck.class, MSG_KEY, "field"),
+        };
+
+        final List<String> expectedXpathQueries = Collections.singletonList(
+                "/COMPILATION_UNIT/CLASS_DEF[./IDENT["
+                        + "@text='SuppressionXpathRegressionVisibilityModifierDefault']]"
+                        + "/OBJBLOCK/VARIABLE_DEF/IDENT[@text='field']"
+        );
+
+        runVerifications(moduleConfig, fileToProcess, expectedViolation, expectedXpathQueries);
+    }
+
+    @Test
+    public void testAnnotation() throws Exception {
+        final File fileToProcess =
+                new File(getPath("SuppressionXpathRegressionVisibilityModifierAnnotation.java"));
+
+        final DefaultConfiguration moduleConfig =
+                createModuleConfig(VisibilityModifierCheck.class);
+        moduleConfig.addProperty("ignoreAnnotationCanonicalNames", "Deprecated");
+
+        final String[] expectedViolation = {
+            "5:12: " + getCheckMessage(VisibilityModifierCheck.class, MSG_KEY,
+                    "annotatedString"),
+        };
+
+        final List<String> expectedXpathQueries = Collections.singletonList(
+                "/COMPILATION_UNIT/CLASS_DEF[./IDENT["
+                        + "@text='SuppressionXpathRegressionVisibilityModifierAnnotation']]"
+                        + "/OBJBLOCK/VARIABLE_DEF/IDENT[@text='annotatedString']"
+        );
+
+        runVerifications(moduleConfig, fileToProcess, expectedViolation, expectedXpathQueries);
+    }
+
+    @Test
+    public void testAnonymousClass() throws Exception {
+        final File fileToProcess =
+                new File(getPath("SuppressionXpathRegressionVisibilityModifierAnonymous.java"));
+
+        final DefaultConfiguration moduleConfig =
+                createModuleConfig(VisibilityModifierCheck.class);
+
+        final String[] expectedViolation = {
+            "6:23: " + getCheckMessage(VisibilityModifierCheck.class, MSG_KEY, "field1"),
+        };
+
+        final List<String> expectedXpathQueries = Collections.singletonList(
+                "/COMPILATION_UNIT/CLASS_DEF[./IDENT["
+                        + "@text='SuppressionXpathRegressionVisibilityModifierAnonymous']]"
+                        + "/OBJBLOCK/VARIABLE_DEF[./IDENT[@text='runnable']]"
+                        + "/ASSIGN/EXPR/LITERAL_NEW[./IDENT[@text='Runnable']]"
+                        + "/OBJBLOCK/VARIABLE_DEF/IDENT[@text='field1']"
+        );
+
+        runVerifications(moduleConfig, fileToProcess, expectedViolation, expectedXpathQueries);
+    }
+
+    @Test
+    public void testInnerClass() throws Exception {
+        final File fileToProcess =
+                new File(getPath("SuppressionXpathRegressionVisibilityModifierInner.java"));
+
+        final DefaultConfiguration moduleConfig =
+                createModuleConfig(VisibilityModifierCheck.class);
+
+        final String[] expectedViolation = {
+            "7:20: " + getCheckMessage(VisibilityModifierCheck.class, MSG_KEY, "field2"),
+        };
+
+        final List<String> expectedXpathQueries = Collections.singletonList(
+                "/COMPILATION_UNIT/CLASS_DEF[./IDENT["
+                        + "@text='SuppressionXpathRegressionVisibilityModifierInner']]"
+                        + "/OBJBLOCK/CLASS_DEF[./IDENT[@text='InnerClass']]/OBJBLOCK/"
+                        + "VARIABLE_DEF/IDENT[@text='field2']"
+        );
+
+        runVerifications(moduleConfig, fileToProcess, expectedViolation, expectedXpathQueries);
+    }
+}

--- a/src/it/resources/org/checkstyle/suppressionxpathfilter/visibilitymodifier/SuppressionXpathRegressionVisibilityModifierAnnotation.java
+++ b/src/it/resources/org/checkstyle/suppressionxpathfilter/visibilitymodifier/SuppressionXpathRegressionVisibilityModifierAnnotation.java
@@ -1,0 +1,9 @@
+package org.checkstyle.suppressionxpathfilter.visibilitymodifier;
+
+public class SuppressionXpathRegressionVisibilityModifierAnnotation {
+    @java.lang.Deprecated
+    String annotatedString; // warn
+
+    @Deprecated
+    String shortCustomAnnotated;
+}

--- a/src/it/resources/org/checkstyle/suppressionxpathfilter/visibilitymodifier/SuppressionXpathRegressionVisibilityModifierAnonymous.java
+++ b/src/it/resources/org/checkstyle/suppressionxpathfilter/visibilitymodifier/SuppressionXpathRegressionVisibilityModifierAnonymous.java
@@ -1,0 +1,13 @@
+package org.checkstyle.suppressionxpathfilter.visibilitymodifier;
+
+public class SuppressionXpathRegressionVisibilityModifierAnonymous {
+    private Runnable runnable = new Runnable() {
+
+        public String field1; // warn
+
+        @Override
+        public void run() {
+
+        }
+    };
+}

--- a/src/it/resources/org/checkstyle/suppressionxpathfilter/visibilitymodifier/SuppressionXpathRegressionVisibilityModifierDefault.java
+++ b/src/it/resources/org/checkstyle/suppressionxpathfilter/visibilitymodifier/SuppressionXpathRegressionVisibilityModifierDefault.java
@@ -1,0 +1,7 @@
+package org.checkstyle.suppressionxpathfilter.visibilitymodifier;
+
+public class SuppressionXpathRegressionVisibilityModifierDefault {
+    private int myPrivateField; // ok, private class member is allowed
+
+    int field; // warn
+}

--- a/src/it/resources/org/checkstyle/suppressionxpathfilter/visibilitymodifier/SuppressionXpathRegressionVisibilityModifierInner.java
+++ b/src/it/resources/org/checkstyle/suppressionxpathfilter/visibilitymodifier/SuppressionXpathRegressionVisibilityModifierInner.java
@@ -1,0 +1,9 @@
+package org.checkstyle.suppressionxpathfilter.visibilitymodifier;
+
+public class SuppressionXpathRegressionVisibilityModifierInner {
+    class InnerClass {
+        private int field1;
+
+        public int field2; // warn
+    }
+}

--- a/src/test/java/com/puppycrawl/tools/checkstyle/internal/XpathRegressionTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/internal/XpathRegressionTest.java
@@ -105,9 +105,7 @@ public class XpathRegressionTest extends AbstractModuleTestSupport {
             "RedundantModifier",
             "SeparatorWrap",
             "SuperFinalize",
-            "SuppressWarnings",
-            "VisibilityModifier"
-    );
+            "SuppressWarnings");
 
     // Modules that will never have xpath support ever because they not report violations
     private static final Set<String> NO_VIOLATION_MODULES = Set.of(


### PR DESCRIPTION
Part of Issue #6207. Add XPath Regression Test for VisibilityModifier

Documentation of VisibilityModifier: https://checkstyle.sourceforge.io/checks/design/visibilitymodifier.html

Hi, I am not sure whether these tests are sufficient enough to cover VisibilityModifier, could you please have a look.

Currently, there are tests for
1. field with default modifier
2. field with the annotation
3. field inside an anonymous class
4. field inside an inner class