### PR TITLE
Issue #14376: Added JAR generation config in maven-source to replace OSS parent pom

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -3,13 +3,6 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
 
-  <!-- This parent is requirements for deploy of artifacts to maven central -->
-  <parent>
-    <groupId>org.sonatype.oss</groupId>
-    <artifactId>oss-parent</artifactId>
-    <version>9</version>
-  </parent>
-
   <groupId>com.puppycrawl.tools</groupId>
   <artifactId>checkstyle</artifactId>
   <version>10.14.1-SNAPSHOT</version>
@@ -487,9 +480,11 @@
         </plugin>
         <plugin>
           <artifactId>maven-release-plugin</artifactId>
-          <!-- version is same as in supper-pom as it is better to use same version
-               as in sonatype-nexus-staging -->
           <version>2.1</version>
+          <configuration>
+            <mavenExecutorId>forked-path</mavenExecutorId>
+            <useReleaseProfile>false</useReleaseProfile>
+          </configuration>
         </plugin>
         <!-- from super-pom END -->
         <plugin>
@@ -550,6 +545,14 @@
               </tag>
             </tags>
           </configuration>
+          <executions>
+            <execution>
+              <id>attach-javadocs</id>
+              <goals>
+                <goal>jar</goal>
+              </goals>
+            </execution>
+          </executions>
         </plugin>
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
@@ -697,8 +700,7 @@
             <execution>
               <id>attach-sources</id>
               <goals>
-                <goal>test-jar</goal>
-                <goal>jar</goal>
+                <goal>jar-no-fork</goal>
               </goals>
             </execution>
           </executions>
@@ -1610,6 +1612,15 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-source-plugin</artifactId>
+        <version>3.3.0</version>
+        <executions>
+          <execution>
+            <id>attach-sources</id>
+            <goals>
+              <goal>jar-no-fork</goal>
+            </goals>
+          </execution>
+        </executions>
       </plugin>
 
       <plugin>
@@ -1910,7 +1921,9 @@
       </plugin>
 
       <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
+        <version>3.6.3</version>
         <reportSets>
           <reportSet>
             <id>default</id>
@@ -2504,6 +2517,15 @@
                 <arg>loopback</arg>
               </gpgArguments>
             </configuration>
+            <executions>
+              <execution>
+                <id>sign-artifacts</id>
+                <phase>verify</phase>
+                <goals>
+                  <goal>sign</goal>
+                </goals>
+              </execution>
+            </executions>
           </plugin>
         </plugins>
       </build>


### PR DESCRIPTION
Aims to close #14376 

@romani , @nrmancuso , This PR is a Follow-up of #14397 in response to https://github.com/checkstyle/checkstyle/issues/14376#issuecomment-1969038627

In order to remove the parent pom usage, we needed to apply the parent pom's plugin config. See https://github.com/sonatype/oss-parents/blob/master/codehaus-parent/pom.xml for this configuration.

We also had problems with release :
https://github.com/checkstyle/checkstyle/actions/runs/8066068513/job/22033791002#step:6:399
```
Error: ROR]   Rule "javadoc-staging" failures
Error: ROR]     * Missing: no javadoc jar found in folder '/com/puppycrawl/tools/checkstyle/10.14.0'
```
After digging in, I found that we had a dummy maven-source-plugin for build helpin our pom which was fine until we used oss parent. I believe this is the root cause for previous failures.
```
      <!-- Generate test sources as well as main sources. -->
      <plugin>
        <groupId>org.apache.maven.plugins</groupId>
        <artifactId>maven-source-plugin</artifactId>
      </plugin>
```
For JAR generation, I have introduced related configs to the plugins to execute.

https://maven.apache.org/plugins/maven-source-plugin/
Specified goals : `jar` and `test-jar` , `jar-no-fork`