### PR TITLE
Issue #3110: Bugfix in Checker.java removed English hardcoded msgs & Added new method to extract non-locale translations

### DIFF
--- a/config/checker-framework-suppressions/checker-nullness-optional-interning-suppressions.xml
+++ b/config/checker-framework-suppressions/checker-nullness-optional-interning-suppressions.xml
@@ -24,6 +24,17 @@
   <checkerFrameworkError unstable="false">
     <fileName>src/main/java/com/puppycrawl/tools/checkstyle/Checker.java</fileName>
     <specifier>argument</specifier>
+    <message>incompatible argument for parameter args of Checker.getLocalizedMessage.</message>
+    <lineContent>getLocalizedMessage(&quot;Checker.setupChildModule&quot;, name, ex.getMessage()), ex);</lineContent>
+    <details>
+      found   : @Initialized @Nullable String
+      required: @Initialized @NonNull Object
+    </details>
+  </checkerFrameworkError>
+
+  <checkerFrameworkError unstable="false">
+    <fileName>src/main/java/com/puppycrawl/tools/checkstyle/Checker.java</fileName>
+    <specifier>argument</specifier>
     <message>incompatible argument for parameter args of Violation constructor.</message>
     <lineContent>new String[] {ioe.getMessage()}, null, getClass(), null));</lineContent>
     <details>

--- a/src/main/java/com/puppycrawl/tools/checkstyle/Checker.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/Checker.java
@@ -88,11 +88,6 @@ public class Checker extends AbstractAutomaticBean implements MessageDispatcher,
     /** The audit event filters. */
     private final FilterSet filters = new FilterSet();
 
-    /** Message used by finishLocalSetup method. */
-    private final LocalizedMessage finishLocalSetupMsg = new LocalizedMessage(
-            Definitions.CHECKSTYLE_BUNDLE, getClass(),
-                    "Checker.finishLocalSetup");
-
     /** The basedir to strip off in file names. */
     private String basedir;
 
@@ -313,8 +308,8 @@ public class Checker extends AbstractAutomaticBean implements MessageDispatcher,
                 }
 
                 // We need to catch all exceptions to put a reason failure (file name) in exception
-                throw new CheckstyleException("Exception was thrown while processing "
-                        + filePath, ex);
+                throw new CheckstyleException(
+                        getLocalizedMessage("Checker.processFilesException", filePath), ex);
             }
             catch (Error error) {
                 if (fileName != null && cacheFile != null) {
@@ -445,8 +440,7 @@ public class Checker extends AbstractAutomaticBean implements MessageDispatcher,
 
         if (moduleFactory == null) {
             if (moduleClassLoader == null) {
-                final String finishLocalSetupMessage = finishLocalSetupMsg.getMessage();
-                throw new CheckstyleException(finishLocalSetupMessage);
+                throw new CheckstyleException(getLocalizedMessage("Checker.finishLocalSetup"));
             }
 
             final Set<String> packageNames = PackageNamesLoader
@@ -486,8 +480,8 @@ public class Checker extends AbstractAutomaticBean implements MessageDispatcher,
             }
         }
         catch (final CheckstyleException ex) {
-            throw new CheckstyleException("cannot initialize module " + name
-                    + " - " + ex.getMessage(), ex);
+            throw new CheckstyleException(
+                    getLocalizedMessage("Checker.setupChildModule", name, ex.getMessage()), ex);
         }
         if (child instanceof FileSetCheck) {
             final FileSetCheck fsc = (FileSetCheck) child;
@@ -507,8 +501,8 @@ public class Checker extends AbstractAutomaticBean implements MessageDispatcher,
             addListener(listener);
         }
         else {
-            throw new CheckstyleException(name
-                    + " is not allowed as a child in Checker");
+            throw new CheckstyleException(
+                    getLocalizedMessage("Checker.setupChildNotAllowed", name));
         }
     }
 
@@ -620,8 +614,8 @@ public class Checker extends AbstractAutomaticBean implements MessageDispatcher,
     public void setCharset(String charset)
             throws UnsupportedEncodingException {
         if (!Charset.isSupported(charset)) {
-            final String message = "unsupported charset: '" + charset + "'";
-            throw new UnsupportedEncodingException(message);
+            throw new UnsupportedEncodingException(
+                    getLocalizedMessage("Checker.setCharset", charset));
         }
         this.charset = charset;
     }
@@ -651,6 +645,21 @@ public class Checker extends AbstractAutomaticBean implements MessageDispatcher,
         if (cacheFile != null) {
             cacheFile.reset();
         }
+    }
+
+    /**
+     * Extracts localized messages from properties files.
+     *
+     * @param messageKey the key pointing to localized message in respective properties file.
+     * @param args the arguments of message in respective properties file.
+     * @return a string containing extracted localized message
+     */
+    private String getLocalizedMessage(String messageKey, Object... args) {
+        final LocalizedMessage localizedMessage = new LocalizedMessage(
+            Definitions.CHECKSTYLE_BUNDLE, getClass(),
+                    messageKey, args);
+
+        return localizedMessage.getMessage();
     }
 
 }

--- a/src/main/resources/com/puppycrawl/tools/checkstyle/messages.properties
+++ b/src/main/resources/com/puppycrawl/tools/checkstyle/messages.properties
@@ -1,4 +1,8 @@
 Checker.finishLocalSetup=if no custom moduleFactory is set, moduleClassLoader must be specified
+Checker.processFilesException=Exception was thrown while processing {0}
+Checker.setCharset=unsupported charset: ''{0}''
+Checker.setupChildModule=cannot initialize module {0} - {1}
+Checker.setupChildNotAllowed={0} is not allowed as a child in Checker
 DefaultLogger.addException=Error auditing {0}
 DefaultLogger.auditFinished=Audit done.
 DefaultLogger.auditStarted=Starting audit...

--- a/src/main/resources/com/puppycrawl/tools/checkstyle/messages_de.properties
+++ b/src/main/resources/com/puppycrawl/tools/checkstyle/messages_de.properties
@@ -1,5 +1,9 @@
 Checker.finishLocalSetup=wenn kein Brauch moduleFactory eingestellt ist, moduleClassLoader \
   muss angegeben werden
+Checker.processFilesException=Während der Verarbeitung wurde eine Ausnahme ausgelöst {0}
+Checker.setCharset=Nicht unterstützter Zeichensatz: ''{0}''
+Checker.setupChildModule=Modul kann nicht initialisiert werden {0} - {1}
+Checker.setupChildNotAllowed={0} ist als Kind nicht erlaubt Checker
 DefaultLogger.addException=Fehler beim Prüfen von {0}
 DefaultLogger.auditFinished=Prüfung beendet.
 DefaultLogger.auditStarted=Beginne Prüfung...

--- a/src/main/resources/com/puppycrawl/tools/checkstyle/messages_es.properties
+++ b/src/main/resources/com/puppycrawl/tools/checkstyle/messages_es.properties
@@ -1,5 +1,9 @@
 Checker.finishLocalSetup=si no hay costumbre moduleFactory Está establecido, \
   moduleClassLoader debe ser especificado
+Checker.processFilesException=Se lanzó una excepción durante el procesamiento {0}
+Checker.setCharset=juego de caracteres no soportado: ''{0}''
+Checker.setupChildModule=no se puede inicializar el módulo {0} - {1}
+Checker.setupChildNotAllowed={0} No está permitido como niña en Checker
 DefaultLogger.addException=Error auditando {0}
 DefaultLogger.auditFinished=Auditoría concluida.
 DefaultLogger.auditStarted=Comenzando auditoría...

--- a/src/main/resources/com/puppycrawl/tools/checkstyle/messages_fi.properties
+++ b/src/main/resources/com/puppycrawl/tools/checkstyle/messages_fi.properties
@@ -1,5 +1,9 @@
 Checker.finishLocalSetup=jos ei ole tapaa moduleFactory on asetettu, moduleClassLoader \
   on täsmennettävä
+Checker.processFilesException=Poikkeus tehtiin käsittelyn aikana {0}
+Checker.setCharset=ei-tuettu merkkisarja: ''{0}''
+Checker.setupChildModule=moduulia ei voi alustaa {0} - {1}
+Checker.setupChildNotAllowed={0} ei saa lapsena sisään Checker
 DefaultLogger.addException=Virhe {0}:n tarkistuksessa
 DefaultLogger.auditFinished=Tarkistus valmis.
 DefaultLogger.auditStarted=Aloitetaan tarkistus...

--- a/src/main/resources/com/puppycrawl/tools/checkstyle/messages_fr.properties
+++ b/src/main/resources/com/puppycrawl/tools/checkstyle/messages_fr.properties
@@ -1,5 +1,9 @@
 Checker.finishLocalSetup=si pas de coutume moduleFactory est réglé, \
   moduleClassLoader il faut préciser
+Checker.processFilesException=Une exception a été levée lors du traitement {0}
+Checker.setCharset=jeu de caractères non pris en charge: ''{0}''
+Checker.setupChildModule=impossible d initialiser le module {0} - {1}
+Checker.setupChildNotAllowed={0} n'est pas autorisé en tant qu'enfant à Checker
 DefaultLogger.addException=Une erreur est survenue {0}
 DefaultLogger.auditFinished=Vérification terminée.
 DefaultLogger.auditStarted=Début de la vérification...

--- a/src/main/resources/com/puppycrawl/tools/checkstyle/messages_ja.properties
+++ b/src/main/resources/com/puppycrawl/tools/checkstyle/messages_ja.properties
@@ -1,5 +1,9 @@
 Checker.finishLocalSetup=習慣がなければ moduleFactory 設定されています, \
   moduleClassLoader 指定する必要があります
+Checker.processFilesException=処理中に例外がスローされました {0}
+Checker.setCharset=サポートされていない文字セット: ''{0}''
+Checker.setupChildModule=モジュールを初期化できません {0} - {1}
+Checker.setupChildNotAllowed={0} では子供として許可されていません Checker
 DefaultLogger.addException={0} を監査中のエラー
 DefaultLogger.auditFinished=監査が完了しました。
 DefaultLogger.auditStarted=監査を開始しています...

--- a/src/main/resources/com/puppycrawl/tools/checkstyle/messages_pt.properties
+++ b/src/main/resources/com/puppycrawl/tools/checkstyle/messages_pt.properties
@@ -1,5 +1,9 @@
 Checker.finishLocalSetup=se não houver costume moduleFactory está definido, \
   moduleClassLoader deve ser especificado
+Checker.processFilesException=Exceção foi lançada durante o processamento {0}
+Checker.setCharset=conjunto de caracteres não suportado: ''{0}''
+Checker.setupChildModule=não é possível inicializar o módulo {0} - {1}
+Checker.setupChildNotAllowed={0} não é permitido quando criança Checker
 DefaultLogger.addException=Erro ao auditar {0}
 DefaultLogger.auditFinished=Auditoria completa.
 DefaultLogger.auditStarted=Iniciando a auditoria...

--- a/src/main/resources/com/puppycrawl/tools/checkstyle/messages_ru.properties
+++ b/src/main/resources/com/puppycrawl/tools/checkstyle/messages_ru.properties
@@ -1,5 +1,9 @@
 Checker.finishLocalSetup=если нет обычая moduleFactory установлен, \
   moduleClassLoader должно быть указано
+Checker.processFilesException=Исключение возникло при обработке {0}
+Checker.setCharset=неподдерживаемая кодировка: ''{0}''
+Checker.setupChildModule=не могу инициализировать модуль {0} - {1}
+Checker.setupChildNotAllowed={0} не разрешен в качестве вложенного модуля в Checker
 DefaultLogger.addException=Ошибка проверки {0}
 DefaultLogger.auditFinished=Проверка завершена.
 DefaultLogger.auditStarted=Начинаем проверку...

--- a/src/main/resources/com/puppycrawl/tools/checkstyle/messages_tr.properties
+++ b/src/main/resources/com/puppycrawl/tools/checkstyle/messages_tr.properties
@@ -1,4 +1,8 @@
 Checker.finishLocalSetup=özel değilse moduleFactory ayarlandı, moduleClassLoader belirtilmeli
+Checker.processFilesException=İşlenirken istisna atıldı {0}
+Checker.setCharset=desteklenmeyen karakter kümesi: ''{0}''
+Checker.setupChildModule=modül başlatılamıyor {0} - {1}
+Checker.setupChildNotAllowed={0} çocukken girilmesine izin verilmiyor Checker
 DefaultLogger.addException={0} denetlenirken hata oluştu
 DefaultLogger.auditFinished=Denetleme tamamlandı.
 DefaultLogger.auditStarted=Denetleme başlıyor...

--- a/src/main/resources/com/puppycrawl/tools/checkstyle/messages_zh.properties
+++ b/src/main/resources/com/puppycrawl/tools/checkstyle/messages_zh.properties
@@ -1,4 +1,8 @@
 Checker.finishLocalSetup=如果没有定制 moduleFactory 已设置, moduleClassLoader 必须指定
+Checker.processFilesException=处理时抛出异常 {0}
+Checker.setCharset=不支持的字符集: ''{0}''
+Checker.setupChildModule=无法初始化模块 {0} - {1}
+Checker.setupChildNotAllowed={0} 不允许作为Checker的子模块
 DefaultLogger.addException=检查错误： {0}
 DefaultLogger.auditFinished=检查完成。
 DefaultLogger.auditStarted=开始检查……


### PR DESCRIPTION
Part of #3110 

The following methods required message keys : 

- processFiles (Exception msg)
- setupChild
- setCharset

Checker.java file now has only two more hardcoded strings left to completely be compatible with non-locale translations : 

1. destroy
2. processFiles (Error msg)

For maximum code optimization, I've designed a new method  `getLocalizedMessage` that takes in a String arg `messageKey` and returns another String `localizedMessage` that is extracted from _.properties_ files instead of returning _LocalizedMessage_ object, to make things even more simpler.

Thanks a lot @rdiachenko, for pointing this out coz, reused and optimized code is obviously the best !!
