### PR TITLE
minor: fixed inspections violation RegExpRedundantEscape

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocStyleCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocStyleCheck.java
@@ -222,7 +222,7 @@ public class JavadocStyleCheck
 
     /** Specify the format for inline return Javadoc. */
     private static final Pattern INLINE_RETURN_TAG_PATTERN =
-            Pattern.compile("\\{@return.*?\\}\\s*");
+            Pattern.compile("\\{@return.*?}\\s*");
 
     /** Specify the format for first word in javadoc. */
     private static final Pattern SENTENCE_SEPARATOR = Pattern.compile("\\.(?=\\s|$)");


### PR DESCRIPTION
We leaked an inspections validation failure from PR #13037 
https://output.circle-artifacts.com/output/job/c3a63de2-f8c9-427a-bb6b-1c5836ce1ef8/artifacts/0/home/circleci/project/target/inspection-results/RegExpRedundantEscape.xml

```
<problem>
<file>file://$PROJECT_DIR$/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocStyleCheck.java</file>
<line>225</line>
<module>project</module>
<package>com.puppycrawl.tools.checkstyle.checks.javadoc</package>
<entry_point TYPE="field" FQNAME="com.puppycrawl.tools.checkstyle.checks.javadoc.JavadocStyleCheck INLINE_RETURN_TAG_PATTERN"/>
<problem_class id="RegExpRedundantEscape" severity="WARNING" attribute_key="WARNING_ATTRIBUTES">Redundant character escape</problem_class>
<description>Redundant character escape <code>\\}</code> in RegExp</description>
<highlighted_element>\\}</highlighted_element>
<language>RegExp</language>
<offset>42</offset>
<length>3</length>
</problem>
```

https://github.com/checkstyle/checkstyle/blob/646f49995cad29f62d489e14ba910788fc953aa6/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocStyleCheck.java#L223-L225

Here, the escape char `\\` before right curly is basically reduntant and hence can be removed.