### PR TITLE
Issue #14653: support XML configs without detalization

### DIFF
--- a/src/test/java/com/puppycrawl/tools/checkstyle/AbstractModuleTestSupport.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/AbstractModuleTestSupport.java
@@ -221,6 +221,25 @@ public abstract class AbstractModuleTestSupport extends AbstractPathTestSupport 
     }
 
     /**
+     * Performs verification of the file with given file path using configurations parsed from
+     * xml header of the file and the array expected messages. Also performs verification of
+     * the config specified in input file.
+     *
+     * @param filePath file path to verify
+     * @param expected an array of expected messages
+     * @throws Exception if exception occurs
+     */
+    protected final void verifyWithInlineXmlConfig(String filePath, String... expected)
+            throws Exception {
+        final TestInputConfiguration testInputConfiguration =
+                InlineConfigParser.parseWithXmlHeader(filePath);
+        final Configuration xmlConfig =
+                testInputConfiguration.getXmlConfiguration();
+        verifyViolations(xmlConfig, filePath, testInputConfiguration.getViolations());
+        verify(xmlConfig, filePath, expected);
+    }
+
+    /**
      * Performs verification of the file with the given file path using specified configuration
      * and the array expected messages. Also performs verification of the config specified in
      * input file.

--- a/src/test/java/com/puppycrawl/tools/checkstyle/CheckerTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/CheckerTest.java
@@ -443,7 +443,7 @@ public class CheckerTest extends AbstractModuleTestSupport {
     public void testSetSeverity() throws Exception {
         final String[] expected = CommonUtil.EMPTY_STRING_ARRAY;
 
-        verifyWithInlineConfigParser(getPath("InputCheckerTestSeverity.java"), expected);
+        verifyWithInlineXmlConfig(getPath("InputCheckerTestSeverity.java"), expected);
     }
 
     @Test

--- a/src/test/java/com/puppycrawl/tools/checkstyle/bdd/InlineConfigParser.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/bdd/InlineConfigParser.java
@@ -224,6 +224,56 @@ public final class InlineConfigParser {
         return parse(inputFilePath, true);
     }
 
+    /**
+     * Parse the input file with configuration in xml header.
+     *
+     * @param inputFilePath the input file path.
+     * @throws Exception if unable to parse the xml header
+     */
+    public static TestInputConfiguration parseWithXmlHeader(String inputFilePath)
+            throws Exception {
+
+        final Path filePath = Paths.get(inputFilePath);
+        final List<String> lines = readFile(filePath);
+        if (!checkIsXmlConfig(lines)) {
+            throw new CheckstyleException("Config cannot be parsed as xml.");
+        }
+
+        final List<String> inlineConfig = getInlineConfig(lines);
+        final String stringXmlConfig = LATEST_DTD + String.join("", inlineConfig);
+        final InputSource inputSource = new InputSource(new StringReader(stringXmlConfig));
+        final Configuration xmlConfig = ConfigurationLoader.loadConfiguration(
+                inputSource, new PropertiesExpander(System.getProperties()),
+                ConfigurationLoader.IgnoredModulesOptions.EXECUTE
+        );
+        final String configName = xmlConfig.getName();
+        if (!"Checker".equals(configName)) {
+            throw new CheckstyleException(
+                    "First module should be Checker, but was " + configName);
+        }
+
+        final TestInputConfiguration.Builder testInputConfigBuilder =
+                new TestInputConfiguration.Builder();
+        testInputConfigBuilder.setXmlConfiguration(xmlConfig);
+        try {
+            setViolations(testInputConfigBuilder, lines, false);
+        }
+        catch (CheckstyleException ex) {
+            throw new CheckstyleException(ex.getMessage() + " in " + inputFilePath, ex);
+        }
+        return testInputConfigBuilder.buildWithXmlConfiguration();
+    }
+
+    /**
+     * Check whether a file provides xml configuration.
+     *
+     * @param lines lines of the file
+     * @return true if a file provides xml configuration, otherwise false.
+     */
+    private static boolean checkIsXmlConfig(List<String> lines) {
+        return "/*xml".equals(lines.get(0));
+    }
+
     private static void setModules(TestInputConfiguration.Builder testInputConfigBuilder,
                                    String inputFilePath, List<String> lines)
             throws Exception {
@@ -233,9 +283,8 @@ public final class InlineConfigParser {
         }
 
         final List<String> inlineConfig = getInlineConfig(lines);
-        final boolean isXmlConfig = "/*xml".equals(lines.get(0));
 
-        if (isXmlConfig) {
+        if (checkIsXmlConfig(lines)) {
             final String stringXmlConfig = LATEST_DTD + String.join("", inlineConfig);
             final InputSource inputSource = new InputSource(new StringReader(stringXmlConfig));
             final Configuration xmlConfig = ConfigurationLoader.loadConfiguration(
@@ -247,7 +296,7 @@ public final class InlineConfigParser {
                 throw new CheckstyleException(
                         "First module should be Checker, but was " + configName);
             }
-            handleXmlConfig(testInputConfigBuilder, inputFilePath, xmlConfig);
+            handleXmlConfig(testInputConfigBuilder, inputFilePath, xmlConfig.getChildren());
         }
         else {
             handleKeyValueConfig(testInputConfigBuilder, inputFilePath, inlineConfig);
@@ -273,14 +322,10 @@ public final class InlineConfigParser {
             }
             else {
                 final ModuleInputConfiguration.Builder moduleInputConfigBuilder =
-                    new ModuleInputConfiguration.Builder();
+                        new ModuleInputConfiguration.Builder();
                 setModuleName(moduleInputConfigBuilder, inputFilePath, moduleName);
                 setProperties(inputFilePath, module, moduleInputConfigBuilder);
                 testInputConfigBuilder.addChildModule(moduleInputConfigBuilder.build());
-
-                if ("Checker".equals(moduleName)) {
-                    handleXmlConfig(testInputConfigBuilder, inputFilePath, module.getChildren());
-                }
             }
         }
     }
@@ -323,8 +368,6 @@ public final class InlineConfigParser {
                 "com.puppycrawl.tools.checkstyle.checks.javadoc.SummaryJavadocCheck");
         moduleMappings.put("LineLength",
                 "com.puppycrawl.tools.checkstyle.checks.sizes.LineLengthCheck");
-        moduleMappings.put("Checker",
-                "com.puppycrawl.tools.checkstyle.CheckerCheck");
 
         String fullyQualifiedClassName;
         if (moduleMappings.containsKey(moduleName)) {

--- a/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/checks/naming/AbbreviationAsWordInNameExamplesTest.java
+++ b/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/checks/naming/AbbreviationAsWordInNameExamplesTest.java
@@ -42,7 +42,7 @@ public class AbbreviationAsWordInNameExamplesTest extends AbstractExamplesModule
             "31:15: " + getCheckMessage(MSG_KEY, "incrementGLOBAL", DEFAULT_EXPECTED_CAPITAL_COUNT),
         };
 
-        verifyWithInlineConfigParser(getPath("Example1.java"), expected);
+        verifyWithInlineXmlConfig(getPath("Example1.java"), expected);
     }
 
     @Test
@@ -55,7 +55,7 @@ public class AbbreviationAsWordInNameExamplesTest extends AbstractExamplesModule
             "35:15: " + getCheckMessage(MSG_KEY, "incrementGLOBAL", DEFAULT_EXPECTED_CAPITAL_COUNT),
         };
 
-        verifyWithInlineConfigParser(getPath("Example2.java"), expected);
+        verifyWithInlineXmlConfig(getPath("Example2.java"), expected);
     }
 
     @Test
@@ -67,7 +67,7 @@ public class AbbreviationAsWordInNameExamplesTest extends AbstractExamplesModule
             "23:14: " + getCheckMessage(MSG_KEY, "fourthNUm", expectedCapitalCount),
         };
 
-        verifyWithInlineConfigParser(getPath("Example3.java"), expected);
+        verifyWithInlineXmlConfig(getPath("Example3.java"), expected);
     }
 
     @Test
@@ -80,7 +80,7 @@ public class AbbreviationAsWordInNameExamplesTest extends AbstractExamplesModule
             "26:10: " + getCheckMessage(MSG_KEY, "firstXML", expectedCapitalCount),
         };
 
-        verifyWithInlineConfigParser(getPath("Example4.java"), expected);
+        verifyWithInlineXmlConfig(getPath("Example4.java"), expected);
     }
 
     @Test
@@ -93,7 +93,7 @@ public class AbbreviationAsWordInNameExamplesTest extends AbstractExamplesModule
             "24:14: " + getCheckMessage(MSG_KEY, "nextID", expectedCapitalCount),
         };
 
-        verifyWithInlineConfigParser(getPath("Example5.java"), expected);
+        verifyWithInlineXmlConfig(getPath("Example5.java"), expected);
     }
 
     @Test
@@ -106,13 +106,13 @@ public class AbbreviationAsWordInNameExamplesTest extends AbstractExamplesModule
             "26:20: " + getCheckMessage(MSG_KEY, "MAX_ALLOWED", expectedCapitalCount),
         };
 
-        verifyWithInlineConfigParser(getPath("Example6.java"), expected);
+        verifyWithInlineXmlConfig(getPath("Example6.java"), expected);
     }
 
     @Test
     public void testExample7() throws Exception {
         final String[] expected = CommonUtil.EMPTY_STRING_ARRAY;
 
-        verifyWithInlineConfigParser(getPath("Example7.java"), expected);
+        verifyWithInlineXmlConfig(getPath("Example7.java"), expected);
     }
 }


### PR DESCRIPTION
Refactor for Issue #14653.

Updates:
1. Directly use configuration parsed from XML headers
2. Change `testInputConfiguration.createConfiguration()` to `testInputConfiguration.getConfiguration()`

Todo:
Delete `handleXmlConfig()` since it is not used anymore.

I have marked this PR as a draft. Please check it to see whether I am on the right track @romani