### PR TITLE
Issue #13494: Redirects checks 404 error page from index.html to https://checkstyle.org/checks.html

### DIFF
--- a/src/xdocs/checks/index.html
+++ b/src/xdocs/checks/index.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
+  <meta charset="UTF-8" />
+  <title>Redirecting...</title>
+  <meta http-equiv="refresh" content="0; URL=https://checkstyle.org/checks" />
+</head>
+
+<body></body>
+
+</html>


### PR DESCRIPTION
Part of #13494 

I have added an `index.html` file that is theoretically supposed to redirect to a custom set url.
The redirecting url has been set to https://checkstyle.org/checks.html from root.

The file added is very basic boiler plate with just a title and redirection link. If this works, we can add viewport, canonical link (for SEO), and anything else if required.