### PR TITLE
Issue #14123: Exclude google-collections from doxia-module-xdoc

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -454,6 +454,12 @@
       <groupId>org.apache.maven.doxia</groupId>
       <artifactId>doxia-module-xdoc</artifactId>
       <version>${doxia.version}</version>
+      <exclusions>
+        <exclusion>
+          <groupId>com.google.collections</groupId>
+          <artifactId>google-collections</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
   </dependencies>
 


### PR DESCRIPTION
Fixes Issues #14123 and #14211 by also excluding google-collections from doxia-module-xdoc.

A previous fix (#14140) removed google-collections from doxia-core, but doxia-module-xdoc also contains google-collections as a transitive dependency. 