### PR TITLE
Issue #13213: Remove "// ok"  from javadocmissingwhitespaceafterasterisk

### DIFF
--- a/config/checkstyle-input-suppressions.xml
+++ b/config/checkstyle-input-suppressions.xml
@@ -722,14 +722,6 @@
   <suppress id="UnnecessaryOkComment"
             files="checks[\\/]javadoc[\\/]javadocmissingleadingasterisk[\\/]InputJavadocMissingLeadingAsteriskCorrect.java"/>
   <suppress id="UnnecessaryOkComment"
-            files="checks[\\/]javadoc[\\/]javadocmissingwhitespaceafterasterisk[\\/]InputJavadocMissingWhitespaceAfterAsteriskValid.java"/>
-  <suppress id="UnnecessaryOkComment"
-            files="checks[\\/]javadoc[\\/]javadocmissingwhitespaceafterasterisk[\\/]InputJavadocMissingWhitespaceAfterAsteriskValid.java"/>
-  <suppress id="UnnecessaryOkComment"
-            files="checks[\\/]javadoc[\\/]javadocmissingwhitespaceafterasterisk[\\/]InputJavadocMissingWhitespaceAfterAsteriskValidWithTab.java"/>
-  <suppress id="UnnecessaryOkComment"
-            files="checks[\\/]javadoc[\\/]javadocmissingwhitespaceafterasterisk[\\/]InputJavadocMissingWhitespaceAfterAsteriskValidWithTab.java"/>
-  <suppress id="UnnecessaryOkComment"
             files="checks[\\/]javadoc[\\/]javadoctagcontinuationindentation[\\/]InputJavadocTagContinuationIndentation.java"/>
   <suppress id="UnnecessaryOkComment"
             files="checks[\\/]javadoc[\\/]javadoctagcontinuationindentation[\\/]InputJavadocTagContinuationIndentationBlockTag.java"/>

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadocmissingwhitespaceafterasterisk/InputJavadocMissingWhitespaceAfterAsteriskValid.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadocmissingwhitespaceafterasterisk/InputJavadocMissingWhitespaceAfterAsteriskValid.java
@@ -8,9 +8,9 @@ violateExecutionOnNonTightHtml = (default)false
 package com.puppycrawl.tools.checkstyle.checks.javadoc.javadocmissingwhitespaceafterasterisk;
 
 /***
- * Some Javadoc. // ok
+ * Some Javadoc.
  *
- * <p>Some Javadoc. // ok
+ * <p>Some Javadoc.
  ***/
 class InputJavadocMissingWhitespaceAfterAsteriskValid
 {

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadocmissingwhitespaceafterasterisk/InputJavadocMissingWhitespaceAfterAsteriskValidWithTab.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadocmissingwhitespaceafterasterisk/InputJavadocMissingWhitespaceAfterAsteriskValidWithTab.java
@@ -8,9 +8,9 @@ violateExecutionOnNonTightHtml = (default)false
 package com.puppycrawl.tools.checkstyle.checks.javadoc.javadocmissingwhitespaceafterasterisk;
 
 /***
- *	Some Javadoc with tab. // ok
+ *	Some Javadoc with tab.
  *
- *	<p>Some Javadoc with tab. // ok
+ *	<p>Some Javadoc with tab.
  ***/
 class InputJavadocMissingWhitespaceAfterAsteriskValidWithTab
 {


### PR DESCRIPTION
Part of Issue: https://github.com/checkstyle/checkstyle/issues/13213

Remove "// ok" comments from 4 classes under javadocmissingwhitespaceafterasterisk.
Remove corresponding suppress statements in config/checkstyle-input-suppressions.xml
