### PR TITLE
Issue #14084: fix Checker violation for nonnegative integer argument

### DIFF
--- a/config/checker-framework-suppressions/checker-index-suppressions.xml
+++ b/config/checker-framework-suppressions/checker-index-suppressions.xml
@@ -14,17 +14,6 @@
   <checkerFrameworkError unstable="false">
     <fileName>src/main/java/com/puppycrawl/tools/checkstyle/DetailAstImpl.java</fileName>
     <specifier>argument</specifier>
-    <message>incompatible argument for parameter bitIndex of BitSet.get.</message>
-    <lineContent>return getBranchTokenTypes().get(tokenType);</lineContent>
-    <details>
-      found   : int
-      required: @NonNegative int
-    </details>
-  </checkerFrameworkError>
-
-  <checkerFrameworkError unstable="false">
-    <fileName>src/main/java/com/puppycrawl/tools/checkstyle/DetailAstImpl.java</fileName>
-    <specifier>argument</specifier>
     <message>incompatible argument for parameter bitIndex of BitSet.set.</message>
     <lineContent>branchTokenTypes.set(type);</lineContent>
     <details>

--- a/src/main/java/com/puppycrawl/tools/checkstyle/DetailAstImpl.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/DetailAstImpl.java
@@ -384,7 +384,7 @@ public final class DetailAstImpl implements DetailAST {
 
     @Override
     public boolean branchContains(int tokenType) {
-        return getBranchTokenTypes().get(tokenType);
+        return tokenType >= 1 && getBranchTokenTypes().get(tokenType);
     }
 
     @Override

--- a/src/test/java/com/puppycrawl/tools/checkstyle/DetailAstImplTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/DetailAstImplTest.java
@@ -355,8 +355,9 @@ public class DetailAstImplTest extends AbstractModuleTestSupport {
 
     @Test
     public void testBranchContains() {
-        final DetailAstImpl root = createToken(null, TokenTypes.CLASS_DEF);
-        final DetailAstImpl modifiers = createToken(root, TokenTypes.MODIFIERS);
+        final DetailAstImpl root = createToken(null, TokenTypes.COMPILATION_UNIT);
+        final DetailAstImpl classDef = createToken(root, TokenTypes.CLASS_DEF);
+        final DetailAstImpl modifiers = createToken(classDef, TokenTypes.MODIFIERS);
         createToken(modifiers, TokenTypes.LITERAL_PUBLIC);
 
         assertWithMessage("invalid result")
@@ -364,6 +365,12 @@ public class DetailAstImplTest extends AbstractModuleTestSupport {
                 .isTrue();
         assertWithMessage("invalid result")
                 .that(root.branchContains(TokenTypes.OBJBLOCK))
+                .isFalse();
+        assertWithMessage("invalid result")
+                .that(root.branchContains(TokenTypes.COMPILATION_UNIT))
+                .isTrue();
+        assertWithMessage("negative tokenType")
+                .that(root.branchContains(-1))
                 .isFalse();
     }
 


### PR DESCRIPTION
Part of Issue #14084 
Solve suppression for `DetailAstImpl` by introducing `NonNegative` annotation.