### PR TITLE
Issue #14084: fix Checker violation with nullness

### DIFF
--- a/config/checker-framework-suppressions/checker-nullness-optional-interning-suppressions.xml
+++ b/config/checker-framework-suppressions/checker-nullness-optional-interning-suppressions.xml
@@ -6676,17 +6676,6 @@
   </checkerFrameworkError>
 
   <checkerFrameworkError unstable="false">
-    <fileName>src/main/java/com/puppycrawl/tools/checkstyle/xpath/XpathQueryGenerator.java</fileName>
-    <specifier>return</specifier>
-    <message>incompatible types in return.</message>
-    <lineContent>XpathUtil::supportsTextAttribute).orElse(null);</lineContent>
-    <details>
-      type of expression: @Initialized @Nullable DetailAST
-      method return type: @Initialized @NonNull DetailAST
-    </details>
-  </checkerFrameworkError>
-
-  <checkerFrameworkError unstable="false">
     <fileName>src/main/java/com/puppycrawl/tools/checkstyle/xpath/iterators/DescendantIterator.java</fileName>
     <specifier>assignment</specifier>
     <message>incompatible types in assignment.</message>

--- a/src/main/java/com/puppycrawl/tools/checkstyle/xpath/XpathQueryGenerator.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/xpath/XpathQueryGenerator.java
@@ -23,6 +23,8 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.Collectors;
 
+import javax.annotation.Nullable;
+
 import com.puppycrawl.tools.checkstyle.TreeWalkerAuditEvent;
 import com.puppycrawl.tools.checkstyle.api.DetailAST;
 import com.puppycrawl.tools.checkstyle.api.FileText;
@@ -152,6 +154,7 @@ public class XpathQueryGenerator {
      * @param root {@code DetailAST} root ast
      * @return child {@code DetailAst} element of the given root
      */
+    @Nullable
     private static DetailAST findChildWithTextAttribute(DetailAST root) {
         return TokenUtil.findFirstTokenByPredicate(root,
                 XpathUtil::supportsTextAttribute).orElse(null);
@@ -164,6 +167,7 @@ public class XpathQueryGenerator {
      * @param root {@code DetailAST} root ast
      * @return child {@code DetailAst} element of the given root
      */
+    @Nullable
     private static DetailAST findChildWithTextAttributeRecursively(DetailAST root) {
         DetailAST res = findChildWithTextAttribute(root);
         for (DetailAST ast = root.getFirstChild(); ast != null && res == null;


### PR DESCRIPTION
Part of issue #14084.

Remove violation suppression for `XpathQueryGenerator` by adding `@Nullable`