### PR TITLE
Issue #14092: fix UnusedLocalVariableCheck to support local classes

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/UnusedLocalVariableCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/UnusedLocalVariableCheck.java
@@ -263,7 +263,10 @@ public class UnusedLocalVariableCheck extends AbstractCheck {
     private static void visitDotToken(DetailAST dotAst, Deque<VariableDesc> variablesStack) {
         if (dotAst.getParent().getType() != TokenTypes.LITERAL_NEW
                 && shouldCheckIdentTokenNestedUnderDot(dotAst)) {
-            checkIdentifierAst(dotAst.findFirstToken(TokenTypes.IDENT), variablesStack);
+            final DetailAST identifier = dotAst.findFirstToken(TokenTypes.IDENT);
+            if (identifier != null) {
+                checkIdentifierAst(identifier, variablesStack);
+            }
         }
     }
 
@@ -420,14 +423,15 @@ public class UnusedLocalVariableCheck extends AbstractCheck {
     private static void addLocalVariables(DetailAST varDefAst, Deque<VariableDesc> variablesStack) {
         final DetailAST parentAst = varDefAst.getParent();
         final DetailAST grandParent = parentAst.getParent();
-        final boolean isInstanceVarInAnonymousInnerClass =
-                grandParent.getType() == TokenTypes.LITERAL_NEW;
-        if (isInstanceVarInAnonymousInnerClass
+        final boolean isInstanceVarInInnerClass =
+                grandParent.getType() == TokenTypes.LITERAL_NEW
+                || grandParent.getType() == TokenTypes.CLASS_DEF;
+        if (isInstanceVarInInnerClass
                 || parentAst.getType() != TokenTypes.OBJBLOCK) {
             final DetailAST ident = varDefAst.findFirstToken(TokenTypes.IDENT);
             final VariableDesc desc = new VariableDesc(ident.getText(),
                     varDefAst.findFirstToken(TokenTypes.TYPE), findScopeOfVariable(varDefAst));
-            if (isInstanceVarInAnonymousInnerClass) {
+            if (isInstanceVarInInnerClass) {
                 desc.registerAsInstOrClassVar();
             }
             variablesStack.push(desc);

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/coding/UnusedLocalVariableCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/coding/UnusedLocalVariableCheckTest.java
@@ -150,6 +150,16 @@ public class UnusedLocalVariableCheckTest extends AbstractModuleTestSupport {
     }
 
     @Test
+    public void testUnusedLocalVar3() throws Exception {
+        final String[] expected = {
+            "21:13: " + getCheckMessage(MSG_UNUSED_LOCAL_VARIABLE, "a"),
+        };
+        verifyWithInlineConfigParser(
+                getPath("InputUnusedLocalVariable3.java"),
+                expected);
+    }
+
+    @Test
     public void testUnusedLocalVarInAnonInnerClasses() throws Exception {
         final String[] expected = {
             "14:9: " + getCheckMessage(MSG_UNUSED_LOCAL_VARIABLE, "a"),
@@ -238,6 +248,59 @@ public class UnusedLocalVariableCheckTest extends AbstractModuleTestSupport {
 
         verifyWithInlineConfigParser(
                 getPath("InputUnusedLocalVariableNestedClasses3.java"),
+                expected);
+    }
+
+    @Test
+    public void testUnusedLocalVarNestedClasses4() throws Exception {
+        final String[] expected = {
+            "12:5: " + getCheckMessage(MSG_UNUSED_LOCAL_VARIABLE, "a"),
+            "13:5: " + getCheckMessage(MSG_UNUSED_LOCAL_VARIABLE, "ab"),
+        };
+
+        verifyWithInlineConfigParser(
+                getPath("InputUnusedLocalVariableNestedClasses4.java"),
+                expected);
+    }
+
+    @Test
+    public void testUnusedLocalVarNestedClasses5() throws Exception {
+        final String[] expected = {
+            "12:5: " + getCheckMessage(MSG_UNUSED_LOCAL_VARIABLE, "a"),
+            "13:5: " + getCheckMessage(MSG_UNUSED_LOCAL_VARIABLE, "ab"),
+            "19:11: " + getCheckMessage(MSG_UNUSED_LOCAL_VARIABLE, "abc"),
+        };
+
+        verifyWithInlineConfigParser(
+                getPath("InputUnusedLocalVariableNestedClasses5.java"),
+                expected);
+    }
+
+    @Test
+    public void testUnusedLocalVarNestedClasses6() throws Exception {
+        final String[] expected = {
+            "12:5: " + getCheckMessage(MSG_UNUSED_LOCAL_VARIABLE, "a"),
+            "13:5: " + getCheckMessage(MSG_UNUSED_LOCAL_VARIABLE, "ab"),
+        };
+
+        verifyWithInlineConfigParser(
+                getPath("InputUnusedLocalVariableNestedClasses6.java"),
+                expected);
+    }
+
+    @Test
+    public void testUnusedLocalVarNestedClasses7() throws Exception {
+        final String[] expected = {
+            "10:5: " + getCheckMessage(MSG_UNUSED_LOCAL_VARIABLE, "a"),
+            "11:5: " + getCheckMessage(MSG_UNUSED_LOCAL_VARIABLE, "ab"),
+            "16:9: " + getCheckMessage(MSG_UNUSED_LOCAL_VARIABLE, "ab"),
+            "23:9: " + getCheckMessage(MSG_UNUSED_LOCAL_VARIABLE, "a"),
+            "24:9: " + getCheckMessage(MSG_UNUSED_LOCAL_VARIABLE, "ab"),
+            "28:13: " + getCheckMessage(MSG_UNUSED_LOCAL_VARIABLE, "a"),
+        };
+
+        verifyWithInlineConfigParser(
+                getPath("InputUnusedLocalVariableNestedClasses7.java"),
                 expected);
     }
 

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/unusedlocalvariable/InputUnusedLocalVariable3.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/unusedlocalvariable/InputUnusedLocalVariable3.java
@@ -1,0 +1,25 @@
+/*
+UnusedLocalVariable
+
+
+*/
+
+package com.puppycrawl.tools.checkstyle.checks.coding.unusedlocalvariable;
+
+public class InputUnusedLocalVariable3 {
+    class Parent {
+        protected int a = 0;
+        public Parent(Child d) {
+            a = 1;
+        }
+    }
+
+    class Child extends InputUnusedLocalVariable3.Parent {
+        protected int b = 0;
+        public Child(Child d) {
+            InputUnusedLocalVariable3.this.super(d);
+            int a = 0; // violation, unused variable 'a'
+            System.out.println(super.a);
+        }
+    }
+}

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/unusedlocalvariable/InputUnusedLocalVariableNestedClasses4.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/unusedlocalvariable/InputUnusedLocalVariableNestedClasses4.java
@@ -1,0 +1,23 @@
+/*
+UnusedLocalVariable
+
+
+*/
+package com.puppycrawl.tools.checkstyle.checks.coding.unusedlocalvariable;
+
+public class InputUnusedLocalVariableNestedClasses4 {
+  int a = 12;
+
+  void foo() {
+    int a = 12; // violation, unused variable 'a'
+    int ab = 12; // violation, unused variable 'ab'
+
+    class asd {
+      Test a = new Test() {
+        void asd() {
+          System.out.println(a);
+        }
+      };
+    }
+  }
+}

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/unusedlocalvariable/InputUnusedLocalVariableNestedClasses5.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/unusedlocalvariable/InputUnusedLocalVariableNestedClasses5.java
@@ -1,0 +1,32 @@
+/*
+UnusedLocalVariable
+
+
+*/
+package com.puppycrawl.tools.checkstyle.checks.coding.unusedlocalvariable;
+
+public class InputUnusedLocalVariableNestedClasses5 {
+  int a = 12;
+
+  void foo() {
+    int a = 12; // violation, unused variable 'a'
+    int ab = 12; // violation, unused variable 'ab'
+
+    class abc {
+      Test a = new Test() {
+        void abc() {
+          System.out.println(a);
+          int abc = 10; // violation, unused variable 'abc'
+
+          class def {
+            Test abc = new Test() {
+              void def() {
+                System.out.println(abc);
+              }
+            };
+          }
+        }
+      };
+    }
+  }
+}

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/unusedlocalvariable/InputUnusedLocalVariableNestedClasses6.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/unusedlocalvariable/InputUnusedLocalVariableNestedClasses6.java
@@ -1,0 +1,32 @@
+/*
+UnusedLocalVariable
+
+
+*/
+package com.puppycrawl.tools.checkstyle.checks.coding.unusedlocalvariable;
+
+public class InputUnusedLocalVariableNestedClasses6 {
+  int a = 12;
+
+  void foo() {
+    int a = 12; // violation, unused variable 'a'
+    int ab = 12; // violation, unused variable 'ab'
+
+    class abc {
+      Test a = new Test() {
+        void abc() {
+          System.out.println(a);
+          int abc = 10;
+
+          class def {
+            Test ab = new Test() {
+              void def() {
+                System.out.println(abc);
+              }
+            };
+          }
+        }
+      };
+    }
+  }
+}

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/unusedlocalvariable/InputUnusedLocalVariableNestedClasses7.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/unusedlocalvariable/InputUnusedLocalVariableNestedClasses7.java
@@ -1,0 +1,36 @@
+/*
+UnusedLocalVariable
+
+
+*/
+package com.puppycrawl.tools.checkstyle.checks.coding.unusedlocalvariable;
+
+public class InputUnusedLocalVariableNestedClasses7 {
+  void foo() {
+    int a = 12; // violation, unused variable 'a'
+    int ab = 12; // violation, unused variable 'ab'
+
+    class Ghi {
+      void foo() {
+        int a = 12;
+        int ab = 12; // violation, unused variable 'ab'
+        System.out.println(a);
+      }
+    }
+
+    class Def {
+      void foo() {
+        int a = 12; // violation, unused variable 'a'
+        int ab = 12; // violation, unused variable 'ab'
+
+        class InnerDef {
+          void foo() {
+            int a = 12; // violation, unused variable 'a'
+            int ab = 12;
+            System.out.println(ab);
+          }
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
Fix for Issue #14092

```Java
public class Test {
    int a = 12;

    void foo() {
        int a = 12; // this is unused, no violation
        int ab = 12; // this is unused, violation thrown

        class asd {
            Test a = new Test() {
                void asd() {
                    System.out.println(a);
                }
            };
        }
    }
}
```

Update:
modify `addLocalVariables()` to also push a variable that has a grandparent of type `TokenTypes.CLASS_DEF` into the variable stack.

Cause of the problem: 
For `Test a = new Test()`, `a` is not pushed into the stack, because `isInstanceVarInAnonymousInnerClass` condition is not met. However, `a` in this case should meet this condition and be pushed to the stack. Because of that, when the visitor goes through `System.out.println(a);`, it marks the wrong variable `a` as used.

Diff Regression config: https://gist.githubusercontent.com/Lmh-java/61f6994f932b68314de6e3eaebadc9a1/raw/856ec72f11921568b5ea6966f9680930e75f53a4/config.xml