### PR TITLE
infra: Update .cirrus.yml to skip execution on PR

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -1,3 +1,4 @@
+only_if: $CIRRUS_BRANCH == $CIRRUS_DEFAULT_BRANCH
 task:
   name: Windows build
   windows_container:


### PR DESCRIPTION
https://github.com/cirruslabs/cirrus-ci-docs/discussions/1269#discussioncomment-8841674


From CI:
>No tasks were found for the build. Either only_if expressions excluded all of the tasks and/or Starlark script did not generate any tasks.