### PR TITLE
Issue #14448: Migrated IDEA to highest true scopes release v2022.3.3

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,7 +4,7 @@ jobs:
 
   run-inspections:
     docker:
-      - image: checkstyle/idea-docker:jdk11-idea2022.2.2
+      - image: checkstyle/idea-docker:jdk11-idea2022.3.3
 
     steps:
       - checkout

--- a/src/main/java/com/puppycrawl/tools/checkstyle/ant/CheckstyleAntTask.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/ant/CheckstyleAntTask.java
@@ -449,6 +449,8 @@ public class CheckstyleAntTask extends Task {
      *
      * @return the list of listeners.
      * @throws BuildException if the listeners could not be created.
+     * @noinspection MismatchedJavadocCode
+     * @noinspectionreason MismatchedJavadocCode - until issue #14625
      */
     private AuditListener[] getListeners() {
         final int formatterCount = Math.max(1, formatters.size());

--- a/src/main/java/com/puppycrawl/tools/checkstyle/api/FullIdent.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/api/FullIdent.java
@@ -74,6 +74,8 @@ public final class FullIdent {
      *
      * @param full the FullIdent to add to
      * @param ast the node to recurse from
+     * @noinspection TailRecursion
+     * @noinspectionreason TailRecursion - until issue #14625
      */
     private static void extractFullIdent(FullIdent full, DetailAST ast) {
         if (ast != null) {

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/annotation/SuppressWarningsCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/annotation/SuppressWarningsCheck.java
@@ -309,6 +309,8 @@ public class SuppressWarningsCheck extends AbstractCheck {
      *
      * @param cond a Conditional type
      *     {@link TokenTypes#QUESTION QUESTION}
+     * @noinspection TailRecursion
+     * @noinspectionreason TailRecursion - until issue #14625
      */
     private void walkConditional(final DetailAST cond) {
         if (cond.getType() == TokenTypes.QUESTION) {

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/EqualsAvoidNullCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/EqualsAvoidNullCheck.java
@@ -635,6 +635,8 @@ public class EqualsAvoidNullCheck extends AbstractCheck {
          *
          * @param name name of the field to check.
          * @return true if this FieldFrame contains instance field.
+         * @noinspection MismatchedJavadocCode
+         * @noinspectionreason MismatchedJavadocCode - until issue #14625
          */
         public DetailAST findField(String name) {
             return fieldNameToAst.get(name);

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/HiddenFieldCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/HiddenFieldCheck.java
@@ -649,6 +649,8 @@ public class HiddenFieldCheck
          *
          * @param field the field to check
          * @return true if this FieldFrame contains instance field
+         * @noinspection TailRecursion
+         * @noinspectionreason TailRecursion - until issue #14625
          */
         public boolean containsInstanceField(String field) {
             return instanceFields.contains(field)
@@ -661,6 +663,8 @@ public class HiddenFieldCheck
          *
          * @param field the field to check
          * @return true if this FieldFrame contains static field
+         * @noinspection TailRecursion
+         * @noinspectionreason TailRecursion - until issue #14625
          */
         public boolean containsStaticField(String field) {
             return staticFields.contains(field)

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/UnusedLocalVariableCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/UnusedLocalVariableCheck.java
@@ -522,6 +522,8 @@ public class UnusedLocalVariableCheck extends AbstractCheck {
      *
      * @param superClassName name of the super class
      * @return true if there is another type declaration with same name.
+     * @noinspection MismatchedJavadocCode
+     * @noinspectionreason MismatchedJavadocCode - until issue #14625
      */
     private List<TypeDeclDesc> typeDeclWithSameName(String superClassName) {
         return typeDeclAstToTypeDeclDesc.values().stream()

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/regexp/RegexpCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/regexp/RegexpCheck.java
@@ -302,7 +302,12 @@ public class RegexpCheck extends AbstractCheck {
         findMatch();
     }
 
-    /** Recursive method that finds the matches. */
+    /**
+     * Recursive method that finds the matches.
+     *
+     * @noinspection TailRecursion
+     * @noinspectionreason TailRecursion - until issue #14625
+     */
     // suppress deprecation until https://github.com/checkstyle/checkstyle/issues/11166
     @SuppressWarnings("deprecation")
     private void findMatch() {

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/regexp/SinglelineDetector.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/regexp/SinglelineDetector.java
@@ -97,6 +97,8 @@ class SinglelineDetector {
      * @param line the line to check
      * @param matcher the matcher to use
      * @param startPosition the position to start searching from.
+     * @noinspection TailRecursion
+     * @noinspectionreason TailRecursion - until issue #14625
      */
     private void checkLine(int lineNo, String line, Matcher matcher,
             int startPosition) {

--- a/src/test/java/com/puppycrawl/tools/checkstyle/JavaParserTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/JavaParserTest.java
@@ -57,6 +57,12 @@ public class JavaParserTest extends AbstractModuleTestSupport {
             .isNull();
     }
 
+    /**
+     * Temporary java doc.
+     *
+     * @noinspection OptionalGetWithoutIsPresent
+     * @noinspectionreason OptionalGetWithoutIsPresent - until issue #14625
+     */
     @Test
     public void testAppendHiddenBlockCommentNodes() throws Exception {
         final DetailAST root =
@@ -99,6 +105,12 @@ public class JavaParserTest extends AbstractModuleTestSupport {
             .isEqualTo(1);
     }
 
+    /**
+     * Temporary java doc.
+     *
+     * @noinspection OptionalGetWithoutIsPresent
+     * @noinspectionreason OptionalGetWithoutIsPresent - until issue #14625
+     */
     @Test
     public void testAppendHiddenSingleLineCommentNodes() throws Exception {
         final DetailAST root =
@@ -139,6 +151,12 @@ public class JavaParserTest extends AbstractModuleTestSupport {
                 .startsWith(" inline comment");
     }
 
+    /**
+     * Temporary java doc.
+     *
+     * @noinspection OptionalGetWithoutIsPresent
+     * @noinspectionreason OptionalGetWithoutIsPresent - until issue #14625
+     */
     @Test
     public void testAppendHiddenSingleLineCommentNodes2() throws Exception {
         final DetailAST root =
@@ -230,6 +248,12 @@ public class JavaParserTest extends AbstractModuleTestSupport {
             .isEqualTo(Arrays.asList("5,4", "8,0"));
     }
 
+    /**
+     * Temporary java doc.
+     *
+     * @noinspection OptionalGetWithoutIsPresent
+     * @noinspectionreason OptionalGetWithoutIsPresent - until issue #14625
+     */
     @Test
     public void testJava14TextBlocks() throws Exception {
         final DetailAST root =

--- a/src/test/java/com/puppycrawl/tools/checkstyle/ant/CheckstyleAntTaskTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/ant/CheckstyleAntTaskTest.java
@@ -858,6 +858,12 @@ public class CheckstyleAntTaskTest extends AbstractPathTestSupport {
         assertLoggedTime(loggedMessages, testingTime, "To process the files");
     }
 
+    /**
+     * Temporary java doc.
+     *
+     * @noinspection OptionalGetWithoutIsPresent
+     * @noinspectionreason OptionalGetWithoutIsPresent - until issue #14625
+     */
     private static void assertLoggedTime(List<MessageLevelPair> loggedMessages,
                                          long testingTime, String expectedMsg) {
 

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/SuppressWarningsHolderTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/SuppressWarningsHolderTest.java
@@ -406,6 +406,12 @@ public class SuppressWarningsHolderTest extends AbstractModuleTestSupport {
         verifyWithInlineConfigParser(getPath("InputSuppressWarningsHolder7.java"), expected);
     }
 
+    /**
+     * Temporary java doc.
+     *
+     * @noinspection OptionalGetWithoutIsPresent
+     * @noinspectionreason OptionalGetWithoutIsPresent - until issue #14625
+     */
     @Test
     @SuppressWarnings("unchecked")
     public void testClearState() throws Exception {

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/coding/HiddenFieldCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/coding/HiddenFieldCheckTest.java
@@ -500,6 +500,8 @@ public class HiddenFieldCheckTest
      * state of the field will be cleared.
      *
      * @throws Exception when code tested throws exception
+     * @noinspection OptionalGetWithoutIsPresent
+     * @noinspectionreason OptionalGetWithoutIsPresent - until issue #14625
      */
     @Test
     public void testClearState() throws Exception {

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/coding/IllegalInstantiationCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/coding/IllegalInstantiationCheckTest.java
@@ -166,6 +166,8 @@ public class IllegalInstantiationCheckTest
      * state of the field will be cleared.
      *
      * @throws Exception when code tested throws exception
+     * @noinspection OptionalGetWithoutIsPresent
+     * @noinspectionreason OptionalGetWithoutIsPresent - until issue #14625
      */
     @Test
     @SuppressWarnings("unchecked")
@@ -193,6 +195,8 @@ public class IllegalInstantiationCheckTest
      * state of the field will be cleared.
      *
      * @throws Exception when code tested throws exception
+     * @noinspection OptionalGetWithoutIsPresent
+     * @noinspectionreason OptionalGetWithoutIsPresent - until issue #14625
      */
     @Test
     public void testClearStateImports() throws Exception {
@@ -219,6 +223,8 @@ public class IllegalInstantiationCheckTest
      * state of the field will be cleared.
      *
      * @throws Exception when code tested throws exception
+     * @noinspection OptionalGetWithoutIsPresent
+     * @noinspectionreason OptionalGetWithoutIsPresent - until issue #14625
      */
     @Test
     @SuppressWarnings("unchecked")

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/coding/ModifiedControlVariableCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/coding/ModifiedControlVariableCheckTest.java
@@ -178,6 +178,8 @@ public class ModifiedControlVariableCheckTest
      * state of the field will be cleared.
      *
      * @throws Exception when code tested throws exception
+     * @noinspection OptionalGetWithoutIsPresent
+     * @noinspectionreason OptionalGetWithoutIsPresent - until issue #14625
      */
     @Test
     @SuppressWarnings("unchecked")

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/coding/ParameterAssignmentCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/coding/ParameterAssignmentCheckTest.java
@@ -103,6 +103,8 @@ public class ParameterAssignmentCheckTest extends AbstractModuleTestSupport {
      * state of the field will be cleared.
      *
      * @throws Exception when code tested throws exception
+     * @noinspection OptionalGetWithoutIsPresent
+     * @noinspectionreason OptionalGetWithoutIsPresent - until issue #14625
      */
     @Test
     @SuppressWarnings("unchecked")

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/coding/RequireThisCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/coding/RequireThisCheckTest.java
@@ -562,6 +562,8 @@ public class RequireThisCheckTest extends AbstractModuleTestSupport {
      * state of the field will be cleared.
      *
      * @throws Exception when code tested throws exception
+     * @noinspection OptionalGetWithoutIsPresent
+     * @noinspectionreason OptionalGetWithoutIsPresent - until issue #14625
      */
     @Test
     public void testClearState() throws Exception {

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/coding/ReturnCountCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/coding/ReturnCountCheckTest.java
@@ -155,6 +155,8 @@ public class ReturnCountCheckTest extends AbstractModuleTestSupport {
      * state of the field will be cleared.
      *
      * @throws Exception when code tested throws exception
+     * @noinspection OptionalGetWithoutIsPresent
+     * @noinspectionreason OptionalGetWithoutIsPresent - until issue #14625
      */
     @Test
     @SuppressWarnings("unchecked")

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/coding/SuperCloneCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/coding/SuperCloneCheckTest.java
@@ -92,6 +92,8 @@ public class SuperCloneCheckTest
      * state of the field will be cleared.
      *
      * @throws Exception when code tested throws exception
+     * @noinspection OptionalGetWithoutIsPresent
+     * @noinspectionreason OptionalGetWithoutIsPresent - until issue #14625
      */
     @Test
     @SuppressWarnings("unchecked")

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/coding/UnusedLocalVariableCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/coding/UnusedLocalVariableCheckTest.java
@@ -360,6 +360,12 @@ public class UnusedLocalVariableCheckTest extends AbstractModuleTestSupport {
                 expected);
     }
 
+    /**
+     * Temporary java doc.
+     *
+     * @noinspection OptionalGetWithoutIsPresent
+     * @noinspectionreason OptionalGetWithoutIsPresent - until issue #14625
+     */
     @Test
     public void testClearStateVariables() throws Exception {
         final UnusedLocalVariableCheck check = new UnusedLocalVariableCheck();
@@ -382,6 +388,12 @@ public class UnusedLocalVariableCheckTest extends AbstractModuleTestSupport {
                 .isTrue();
     }
 
+    /**
+     * Temporary java doc.
+     *
+     * @noinspection OptionalGetWithoutIsPresent
+     * @noinspectionreason OptionalGetWithoutIsPresent - until issue #14625
+     */
     @Test
     public void testClearStateClasses() throws Exception {
         final UnusedLocalVariableCheck check = new UnusedLocalVariableCheck();
@@ -417,6 +429,12 @@ public class UnusedLocalVariableCheckTest extends AbstractModuleTestSupport {
                 .isTrue();
     }
 
+    /**
+     * Temporary java doc.
+     *
+     * @noinspection OptionalGetWithoutIsPresent
+     * @noinspectionreason OptionalGetWithoutIsPresent - until issue #14625
+     */
     @Test
     public void testClearStateAnonInnerClass() throws Exception {
         final UnusedLocalVariableCheck check = new UnusedLocalVariableCheck();
@@ -451,6 +469,12 @@ public class UnusedLocalVariableCheckTest extends AbstractModuleTestSupport {
                 .isTrue();
     }
 
+    /**
+     * Temporary java doc.
+     *
+     * @noinspection OptionalGetWithoutIsPresent
+     * @noinspectionreason OptionalGetWithoutIsPresent - until issue #14625
+     */
     @Test
     public void testClearStatePackageDef() throws Exception {
         final UnusedLocalVariableCheck check = new UnusedLocalVariableCheck();

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/design/FinalClassCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/design/FinalClassCheckTest.java
@@ -256,6 +256,8 @@ public class FinalClassCheckTest
      * state of the field will be cleared.
      *
      * @throws Exception when code tested throws exception
+     * @noinspection OptionalGetWithoutIsPresent
+     * @noinspectionreason OptionalGetWithoutIsPresent - until issue #14625
      */
     @Test
     public void testClearState() throws Exception {

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/imports/ImportOrderCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/imports/ImportOrderCheckTest.java
@@ -802,6 +802,8 @@ public class ImportOrderCheckTest extends AbstractModuleTestSupport {
      * leading to hard-to-detect and unstable violations that will affect our users.
      *
      * @throws Exception when code tested throws exception
+     * @noinspection OptionalGetWithoutIsPresent
+     * @noinspectionreason OptionalGetWithoutIsPresent - until issue #14625
      */
     @Test
     public void testClearState() throws Exception {

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/metrics/ClassFanOutComplexityCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/metrics/ClassFanOutComplexityCheckTest.java
@@ -298,6 +298,8 @@ public class ClassFanOutComplexityCheckTest extends AbstractModuleTestSupport {
      * state of the field will be cleared.
      *
      * @throws Exception when code tested throws exception
+     * @noinspection OptionalGetWithoutIsPresent
+     * @noinspectionreason OptionalGetWithoutIsPresent - until issue #14625
      */
     @Test
     @SuppressWarnings("unchecked")
@@ -325,6 +327,8 @@ public class ClassFanOutComplexityCheckTest extends AbstractModuleTestSupport {
      * state of the field will be cleared.
      *
      * @throws Exception when code tested throws exception
+     * @noinspection OptionalGetWithoutIsPresent
+     * @noinspectionreason OptionalGetWithoutIsPresent - until issue #14625
      */
     @Test
     public void testClearStateClassContexts() throws Exception {
@@ -351,6 +355,8 @@ public class ClassFanOutComplexityCheckTest extends AbstractModuleTestSupport {
      * state of the field will be cleared.
      *
      * @throws Exception when code tested throws exception
+     * @noinspection OptionalGetWithoutIsPresent
+     * @noinspectionreason OptionalGetWithoutIsPresent - until issue #14625
      */
     @Test
     public void testClearStatePackageName() throws Exception {

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/metrics/NPathComplexityCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/metrics/NPathComplexityCheckTest.java
@@ -161,6 +161,12 @@ public class NPathComplexityCheckTest extends AbstractModuleTestSupport {
                 .isTrue();
     }
 
+    /**
+     * Temporary java doc.
+     *
+     * @noinspection OptionalGetWithoutIsPresent
+     * @noinspectionreason OptionalGetWithoutIsPresent - until issue #14625
+     */
     @Test
     public void testStatefulFieldsClearedOnBeginTree3() throws Exception {
         final NPathComplexityCheck check = new NPathComplexityCheck();

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/sizes/OuterTypeNumberCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/sizes/OuterTypeNumberCheckTest.java
@@ -116,6 +116,8 @@ public class OuterTypeNumberCheckTest extends AbstractModuleTestSupport {
      * check as they are file specific values.
      *
      * @throws Exception if there is an error.
+     * @noinspection OptionalGetWithoutIsPresent
+     * @noinspectionreason OptionalGetWithoutIsPresent - until issue #14625
      */
     @Test
     public void testClearState() throws Exception {

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/whitespace/GenericWhitespaceCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/whitespace/GenericWhitespaceCheckTest.java
@@ -277,6 +277,8 @@ public class GenericWhitespaceCheckTest
      * start of processing the next file in the check.
      *
      * @throws Exception if there is an error.
+     * @noinspection OptionalGetWithoutIsPresent
+     * @noinspectionreason OptionalGetWithoutIsPresent - until issue #14625
      */
     @Test
     public void testClearState() throws Exception {

--- a/src/test/java/com/puppycrawl/tools/checkstyle/internal/XdocsJavaDocsTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/internal/XdocsJavaDocsTest.java
@@ -126,9 +126,10 @@ public class XdocsJavaDocsTest extends AbstractModuleTestSupport {
     /**
      * Validates check javadocs and xdocs for consistency.
      *
-     * @noinspection JUnitTestMethodWithNoAssertions
+     * @noinspection JUnitTestMethodWithNoAssertions, TestMethodWithoutAssertion
      * @noinspectionreason JUnitTestMethodWithNoAssertions - asserts in callstack,
      *      but not in this method
+     * @noinspectionreason TestMethodWithoutAssertion - until issue #14625
      */
     @Test
     public void testAllCheckSectionJavaDocs() throws Exception {

--- a/src/test/java/com/puppycrawl/tools/checkstyle/internal/XdocsPagesTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/internal/XdocsPagesTest.java
@@ -586,9 +586,10 @@ public class XdocsPagesTest {
     /**
      * Validates xml check documentation section.
      *
-     * @noinspection JUnitTestMethodWithNoAssertions
+     * @noinspection JUnitTestMethodWithNoAssertions, TestMethodWithoutAssertion
      * @noinspectionreason JUnitTestMethodWithNoAssertions -asserts in callstack,
      *      but not in this method
+     * @noinspectionreason TestMethodWithoutAssertion - until issue #14625
      */
     @Test
     public void testAllCheckSectionsEx() throws Exception {

--- a/src/test/java/com/puppycrawl/tools/checkstyle/utils/CheckUtilTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/utils/CheckUtilTest.java
@@ -420,6 +420,15 @@ public class CheckUtilTest extends AbstractModuleTestSupport {
         return getNode(JavaParser.parseFile(file, JavaParser.Options.WITH_COMMENTS), type);
     }
 
+    /**
+     * Temporary java doc.
+     *
+     * @param root of type DetailAST
+     * @param type of type int
+     * @return call to get() from node
+     * @noinspection OptionalGetWithoutIsPresent
+     * @noinspectionreason OptionalGetWithoutIsPresent - until issue #14625
+     */
     private static DetailAST getNode(DetailAST root, int type) {
         final Optional<DetailAST> node = findTokenInAstByPredicate(root,
             ast -> ast.getType() == type);

--- a/src/test/java/com/puppycrawl/tools/checkstyle/utils/ModuleReflectionUtilTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/utils/ModuleReflectionUtilTest.java
@@ -384,6 +384,13 @@ public class ModuleReflectionUtilTest {
             method(data);
         }
 
+        /**
+         * Temporary java doc.
+         *
+         * @param data of int type.
+         * @noinspection TailRecursion
+         * @noinspectionreason TailRecursion - until issue #14625
+         */
         public final void method(int data) {
             field++;
             if (data > 0) {


### PR DESCRIPTION
Aims to close https://github.com/checkstyle/checkstyle/issues/14448

Follow-up of  #14604 and https://github.com/checkstyle/contribution/pull/837

Based on observations from https://github.com/checkstyle/checkstyle/pull/14604#discussion_r1530584190 and further discussions.

The latest IDEA release that we have used for update (2023.3.4) had issues with scopes.
A bit of research on different versions landed me on `v2022.3.3` being stable and good with scopes.

Link to docker image (personal) for testing update : 
https://hub.docker.com/layers/manishkk07/manish-k-07-checkstyle/jdk11-idea2022.3.3/images/sha256-3a659714655f8e033e648d894ac20eb110a0aa557f0f19821366cb54e4089305?context=repo

To pull image : `docker pull manishkk07/manish-k-07-checkstyle:jdk11-idea2022.3.3`