### PR TITLE
Issue #13213: Remove "// ok" from filelength 

### DIFF
--- a/config/checkstyle-input-suppressions.xml
+++ b/config/checkstyle-input-suppressions.xml
@@ -1370,14 +1370,6 @@
   <suppress id="UnnecessaryOkComment"
             files="checks[\\/]sizes[\\/]executablestatementcount[\\/]InputExecutableStatementCountMaxZero.java"/>
   <suppress id="UnnecessaryOkComment"
-            files="checks[\\/]sizes[\\/]filelength[\\/]InputFileLength2.java"/>
-  <suppress id="UnnecessaryOkComment"
-            files="checks[\\/]sizes[\\/]filelength[\\/]InputFileLength3.java"/>
-  <suppress id="UnnecessaryOkComment"
-            files="checks[\\/]sizes[\\/]filelength[\\/]InputFileLength4.java"/>
-  <suppress id="UnnecessaryOkComment"
-            files="checks[\\/]sizes[\\/]filelength[\\/]InputFileLengthDefault.java"/>
-  <suppress id="UnnecessaryOkComment"
             files="checks[\\/]sizes[\\/]lambdabodylength[\\/]InputLambdaBodyLengthMax.java"/>
   <suppress id="UnnecessaryOkComment"
             files="checks[\\/]sizes[\\/]methodlength[\\/]InputMethodLengthCountEmptyIsFalse.java"/>

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/sizes/filelength/InputFileLength2.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/sizes/filelength/InputFileLength2.java
@@ -16,7 +16,7 @@ package com.puppycrawl.tools.checkstyle.checks.sizes.filelength;
  * - Order of modifiers
  * @author Oliver Burn
  **/
-final class InputFileLength2 // ok
+final class InputFileLength2
 {
     // Long line ----------------------------------------------------------------
     // Contains a tab ->        <-

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/sizes/filelength/InputFileLength3.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/sizes/filelength/InputFileLength3.java
@@ -16,7 +16,7 @@ package com.puppycrawl.tools.checkstyle.checks.sizes.filelength;
  * - Order of modifiers
  * @author Oliver Burn
  **/
-final class InputFileLength3 // ok
+final class InputFileLength3
 {
     // Long line ----------------------------------------------------------------
     // Contains a tab ->        <-

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/sizes/filelength/InputFileLength4.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/sizes/filelength/InputFileLength4.java
@@ -16,7 +16,7 @@ package com.puppycrawl.tools.checkstyle.checks.sizes.filelength;
  * - Order of modifiers
  * @author Oliver Burn
  **/
-final class InputFileLength4 // ok
+final class InputFileLength4
 {
     // Long line ----------------------------------------------------------------
     // Contains a tab ->        <-

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/sizes/filelength/InputFileLengthDefault.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/sizes/filelength/InputFileLengthDefault.java
@@ -1,5 +1,7 @@
-/* // ok
+/*
 FileLength
+
+
 
 
 */


### PR DESCRIPTION
Part of Issue https://github.com/checkstyle/checkstyle/issues/13213

Updates
Removed filelength suppresion rules from checkstyle-input-suppressions.xml
Removed unnecessary // ok from all previously suppressed java files accordingly

