### PR TITLE
Issue #13213: Remove '//ok' comments from lambdabodylength

### DIFF
--- a/config/checkstyle-input-suppressions.xml
+++ b/config/checkstyle-input-suppressions.xml
@@ -1370,8 +1370,6 @@
   <suppress id="UnnecessaryOkComment"
             files="checks[\\/]sizes[\\/]executablestatementcount[\\/]InputExecutableStatementCountMaxZero.java"/>
   <suppress id="UnnecessaryOkComment"
-            files="checks[\\/]sizes[\\/]lambdabodylength[\\/]InputLambdaBodyLengthMax.java"/>
-  <suppress id="UnnecessaryOkComment"
             files="checks[\\/]sizes[\\/]outertypenumber[\\/]InputOuterTypeNumberEmptyInner.java"/>
   <suppress id="UnnecessaryOkComment"
             files="checks[\\/]sizes[\\/]outertypenumber[\\/]InputOuterTypeNumberSimple1.java"/>

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/sizes/lambdabodylength/InputLambdaBodyLengthMax.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/sizes/lambdabodylength/InputLambdaBodyLengthMax.java
@@ -39,7 +39,7 @@ public class InputLambdaBodyLengthMax {
                 + "3"
                 + "4"
             ;
-        Supplier<String> s2 = () -> // ok
+        Supplier<String> s2 = () ->
             "1"
                 + "2"
                 + "3"


### PR DESCRIPTION
Issue #13213

Removed "//ok" comments from "InputLambdaBodyLengthMax.java" file 
and also removed respective suppressions