### PR TITLE
Issue #13213: Remove '//ok' comments from methodlength

### DIFF
--- a/config/checkstyle-input-suppressions.xml
+++ b/config/checkstyle-input-suppressions.xml
@@ -1380,14 +1380,6 @@
   <suppress id="UnnecessaryOkComment"
             files="checks[\\/]sizes[\\/]lambdabodylength[\\/]InputLambdaBodyLengthMax.java"/>
   <suppress id="UnnecessaryOkComment"
-            files="checks[\\/]sizes[\\/]methodlength[\\/]InputMethodLengthCountEmptyIsFalse.java"/>
-  <suppress id="UnnecessaryOkComment"
-            files="checks[\\/]sizes[\\/]methodlength[\\/]InputMethodLengthCountEmptySmallSize.java"/>
-  <suppress id="UnnecessaryOkComment"
-            files="checks[\\/]sizes[\\/]methodlength[\\/]InputMethodLengthCountEmptySmallSize.java"/>
-  <suppress id="UnnecessaryOkComment"
-            files="checks[\\/]sizes[\\/]methodlength[\\/]InputMethodLengthCountEmptySmallSize.java"/>
-  <suppress id="UnnecessaryOkComment"
             files="checks[\\/]sizes[\\/]outertypenumber[\\/]InputOuterTypeNumberEmptyInner.java"/>
   <suppress id="UnnecessaryOkComment"
             files="checks[\\/]sizes[\\/]outertypenumber[\\/]InputOuterTypeNumberSimple1.java"/>

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/sizes/methodlength/InputMethodLengthCountEmptyIsFalse.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/sizes/methodlength/InputMethodLengthCountEmptyIsFalse.java
@@ -10,7 +10,7 @@ tokens = (default)METHOD_DEF , CTOR_DEF , COMPACT_CTOR_DEF
 package com.puppycrawl.tools.checkstyle.checks.sizes.methodlength;
 import java.io.*;
 
-final class InputMethodLengthCountEmptyIsFalse // ok
+final class InputMethodLengthCountEmptyIsFalse
 {
     // Long line ----------------------------------------------------------------
     // Contains a tab ->        <-

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/sizes/methodlength/InputMethodLengthCountEmptySmallSize.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/sizes/methodlength/InputMethodLengthCountEmptySmallSize.java
@@ -25,18 +25,18 @@ class AA {
         oneLine();
     }
 
-    void twoLines() { // ok
+    void twoLines() {
 
     }
 
-    void twoLines2() { // ok
+    void twoLines2() {
         oneLine();}
 
-    void twoLinesAndComment() { // ok
+    void twoLinesAndComment() {
         // some comment
     }
 
-    void oneLine() { oneLine();/* ok */ }
+    void oneLine() { oneLine();}
 
     void threeLines() { // violation 'Method threeLines length is 3 lines (max allowed is 2).'
         oneLine();


### PR DESCRIPTION
Issue #13213

Removed "//ok" comments from 
"InputMethodLengthCountEmptyIsFalse.java" and "InputMethodLengthCountEmptySmallSize.java" files

and also removed respective suppressions