### PR TITLE
Issue #14715: Enforce new naming convention on methodtypeparametername in IT area

### DIFF
--- a/src/it/java/org/checkstyle/suppressionxpathfilter/XpathRegressionMethodTypeParameterNameTest.java
+++ b/src/it/java/org/checkstyle/suppressionxpathfilter/XpathRegressionMethodTypeParameterNameTest.java
@@ -42,7 +42,7 @@ public class XpathRegressionMethodTypeParameterNameTest extends AbstractXpathTes
     @Test
     public void test1() throws Exception {
         final File fileToProcess =
-                new File(getPath("SuppressionXpathRegressionMethodTypeParameterName1.java"));
+                new File(getPath("InputXpathMethodTypeParameterNameDefault.java"));
 
         final DefaultConfiguration moduleConfig =
                 createModuleConfig(MethodTypeParameterNameCheck.class);
@@ -54,11 +54,11 @@ public class XpathRegressionMethodTypeParameterNameTest extends AbstractXpathTes
 
         final List<String> expectedXpathQueries = Arrays.asList(
                 "/COMPILATION_UNIT/CLASS_DEF[./"
-                  + "IDENT[@text='SuppressionXpathRegressionMethodTypeParameterName1']]"
+                  + "IDENT[@text='InputXpathMethodTypeParameterNameDefault']]"
                   + "/OBJBLOCK/METHOD_DEF[./IDENT[@text='foo']]/TYPE_PARAMETERS"
                   + "/TYPE_PARAMETER[./IDENT[@text='TT']]", "/COMPILATION_UNIT"
                   + "/CLASS_DEF[./IDENT["
-                  + "@text='SuppressionXpathRegressionMethodTypeParameterName1']]"
+                  + "@text='InputXpathMethodTypeParameterNameDefault']]"
                   + "/OBJBLOCK/METHOD_DEF[./IDENT[@text='foo']]"
                   + "/TYPE_PARAMETERS/TYPE_PARAMETER/IDENT[@text='TT']"
         );
@@ -69,7 +69,7 @@ public class XpathRegressionMethodTypeParameterNameTest extends AbstractXpathTes
     @Test
     public void test2() throws Exception {
         final File fileToProcess =
-                new File(getPath("SuppressionXpathRegressionMethodTypeParameterName2.java"));
+                new File(getPath("InputXpathMethodTypeParameterNameInner.java"));
 
         final DefaultConfiguration moduleConfig =
                 createModuleConfig(MethodTypeParameterNameCheck.class);
@@ -82,12 +82,12 @@ public class XpathRegressionMethodTypeParameterNameTest extends AbstractXpathTes
 
         final List<String> expectedXpathQueries = Arrays.asList(
                 "/COMPILATION_UNIT/CLASS_DEF[./IDENT["
-                  + "@text='SuppressionXpathRegressionMethodTypeParameterName2']]"
+                  + "@text='InputXpathMethodTypeParameterNameInner']]"
                   + "/OBJBLOCK/CLASS_DEF[./IDENT[@text='Junk']]/OBJBLOCK"
                   + "/METHOD_DEF[./IDENT[@text='foo']]/TYPE_PARAMETERS"
                   + "/TYPE_PARAMETER[./IDENT[@text='fo_']]", "/COMPILATION_UNIT"
                   + "/CLASS_DEF[./IDENT[@text="
-                  + "'SuppressionXpathRegressionMethodTypeParameterName2']]"
+                  + "'InputXpathMethodTypeParameterNameInner']]"
                   + "/OBJBLOCK/CLASS_DEF[./IDENT[@text='Junk']]/OBJBLOCK"
                   + "/METHOD_DEF[./IDENT[@text='foo']]/TYPE_PARAMETERS"
                   + "/TYPE_PARAMETER/IDENT[@text='fo_']"
@@ -99,7 +99,7 @@ public class XpathRegressionMethodTypeParameterNameTest extends AbstractXpathTes
     @Test
     public void test3() throws Exception {
         final File fileToProcess =
-                new File(getPath("SuppressionXpathRegressionMethodTypeParameterName3.java"));
+                new File(getPath("InputXpathMethodTypeParameterNameLowercase.java"));
 
         final DefaultConfiguration moduleConfig =
                 createModuleConfig(MethodTypeParameterNameCheck.class);
@@ -112,11 +112,11 @@ public class XpathRegressionMethodTypeParameterNameTest extends AbstractXpathTes
 
         final List<String> expectedXpathQueries = Arrays.asList(
                 "/COMPILATION_UNIT/CLASS_DEF[./IDENT"
-                  + "[@text='SuppressionXpathRegressionMethodTypeParameterName3']]"
+                  + "[@text='InputXpathMethodTypeParameterNameLowercase']]"
                   + "/OBJBLOCK/METHOD_DEF[./IDENT[@text='myMethod']]/TYPE_PARAMETERS"
                   + "/TYPE_PARAMETER[./IDENT[@text='a_a']]", "/COMPILATION_UNIT"
                   + "/CLASS_DEF[./IDENT[@text="
-                  + "'SuppressionXpathRegressionMethodTypeParameterName3']]"
+                  + "'InputXpathMethodTypeParameterNameLowercase']]"
                   + "/OBJBLOCK/METHOD_DEF[./IDENT[@text='myMethod']]"
                   + "/TYPE_PARAMETERS/TYPE_PARAMETER/IDENT[@text='a_a']"
         );

--- a/src/it/resources/org/checkstyle/suppressionxpathfilter/methodtypeparametername/InputXpathMethodTypeParameterNameDefault.java
+++ b/src/it/resources/org/checkstyle/suppressionxpathfilter/methodtypeparametername/InputXpathMethodTypeParameterNameDefault.java
@@ -1,5 +1,5 @@
 package org.checkstyle.suppressionxpathfilter.methodtypeparametername;
 
-public class SuppressionXpathRegressionMethodTypeParameterName1{
+public class InputXpathMethodTypeParameterNameDefault {
   public <TT> void foo() { } // warn
 }

--- a/src/it/resources/org/checkstyle/suppressionxpathfilter/methodtypeparametername/InputXpathMethodTypeParameterNameInner.java
+++ b/src/it/resources/org/checkstyle/suppressionxpathfilter/methodtypeparametername/InputXpathMethodTypeParameterNameInner.java
@@ -1,6 +1,6 @@
 package org.checkstyle.suppressionxpathfilter.methodtypeparametername;
 
-public class SuppressionXpathRegressionMethodTypeParameterName2 <T>{
+public class InputXpathMethodTypeParameterNameInner<T>{
 
     static class Junk <T> {
         <fo_ extends T> void foo() { // warn

--- a/src/it/resources/org/checkstyle/suppressionxpathfilter/methodtypeparametername/InputXpathMethodTypeParameterNameLowercase.java
+++ b/src/it/resources/org/checkstyle/suppressionxpathfilter/methodtypeparametername/InputXpathMethodTypeParameterNameLowercase.java
@@ -2,7 +2,7 @@ package org.checkstyle.suppressionxpathfilter.methodtypeparametername;
 
 import java.util.List;
 
-public class SuppressionXpathRegressionMethodTypeParameterName3<T> {
+public class InputXpathMethodTypeParameterNameLowercase<T> {
 
     <a_a> a_a myMethod(List<? super T> list) {return null;} // warn
 

--- a/src/test/java/com/puppycrawl/tools/checkstyle/internal/XpathRegressionTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/internal/XpathRegressionTest.java
@@ -189,7 +189,6 @@ public class XpathRegressionTest extends AbstractModuleTestSupport {
             "MethodLength",
             "MethodName",
             "MethodParamPad",
-            "MethodTypeParameterName",
             "MissingCtor",
             "MissingJavadocMethod",
             "MissingJavadocPackage",


### PR DESCRIPTION
Part of #14715 
rename xpath it regression input files in MethodTypeParameterName module
