### PR TITLE
supplemental: refactor misaligned leading asterisks in javadoc comments

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/api/TokenTypes.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/api/TokenTypes.java
@@ -37,7 +37,7 @@ public final class TokenTypes {
      * This is the root node for the source file.  It's children
      * are an optional package definition, zero or more import statements,
      * and zero or more type declarations.
-      * <p>For example:</p>
+     * <p>For example:</p>
      * <pre>
      * import java.util.List;
      *

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/DescendantTokenCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/DescendantTokenCheck.java
@@ -345,11 +345,11 @@ public class DescendantTokenCheck extends AbstractCheck {
     }
 
     /**
-      * Setter to specify a maximum count for descendants.
-      *
-      * @param maximumNumber the maximum count for descendants.
-      * @since 3.2
-      */
+     * Setter to specify a maximum count for descendants.
+     *
+     * @param maximumNumber the maximum count for descendants.
+     * @since 3.2
+     */
     public void setMaximumNumber(int maximumNumber) {
         this.maximumNumber = maximumNumber;
     }

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/blocks/LeftCurlyCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/blocks/LeftCurlyCheck.java
@@ -151,7 +151,7 @@ public class LeftCurlyCheck
 
     /**
      * Specify the policy on placement of a left curly brace (<code>'{'</code>).
-     * */
+     */
     private LeftCurlyOption option = LeftCurlyOption.EOL;
 
     /**

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/design/HideUtilityClassConstructorCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/design/HideUtilityClassConstructorCheck.java
@@ -162,7 +162,7 @@ public class HideUtilityClassConstructorCheck extends AbstractCheck {
          * C-tor.
          *
          * @param ast class ast
-         * */
+         */
         private Details(DetailAST ast) {
             this.ast = ast;
         }

--- a/src/main/java/com/puppycrawl/tools/checkstyle/site/PropertiesMacro.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/site/PropertiesMacro.java
@@ -105,7 +105,7 @@ public class PropertiesMacro extends AbstractMacro {
     /**
      * This property is used to change the existing properties for javadoc.
      * Tokens always present at the end of all properties.
-    */
+     */
     private static final String TOKENS_PROPERTY = SiteUtil.TOKENS;
 
     /** The name of the current module being processed. */

--- a/src/main/java/com/puppycrawl/tools/checkstyle/utils/XpathUtil.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/utils/XpathUtil.java
@@ -101,7 +101,7 @@ public final class XpathUtil {
      * </pre>
      * Only these tokens support text attribute because they make our xpath queries more accurate.
      * These token types are listed below.
-     * */
+     */
     private static final BitSet TOKEN_TYPES_WITH_TEXT_ATTRIBUTE = TokenUtil.asBitSet(
             TokenTypes.IDENT, TokenTypes.STRING_LITERAL, TokenTypes.CHAR_LITERAL,
             TokenTypes.NUM_LONG, TokenTypes.NUM_INT, TokenTypes.NUM_DOUBLE, TokenTypes.NUM_FLOAT,

--- a/src/test/java/com/puppycrawl/tools/checkstyle/PackageObjectFactoryTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/PackageObjectFactoryTest.java
@@ -494,11 +494,11 @@ public class PackageObjectFactoryTest {
     }
 
     /**
-    * This test case is designed to verify the behavior of the PackageObjectFactory's
-    * createModule method when it is provided with a fully qualified class name
-    * (containing a package separator).
-    * It ensures that ModuleReflectionUtil.getCheckstyleModules is not executed in this case.
-    */
+     * This test case is designed to verify the behavior of the PackageObjectFactory's
+     * createModule method when it is provided with a fully qualified class name
+     * (containing a package separator).
+     * It ensures that ModuleReflectionUtil.getCheckstyleModules is not executed in this case.
+     */
     @Test
     public void testCreateObjectWithNameContainingPackageSeparatorWithoutSearch() throws Exception {
         final ClassLoader classLoader = ClassLoader.getSystemClassLoader();

--- a/src/test/java/com/puppycrawl/tools/checkstyle/utils/ModuleReflectionUtilTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/utils/ModuleReflectionUtilTest.java
@@ -80,10 +80,10 @@ public class ModuleReflectionUtilTest {
     }
 
     /**
-    * This test case is designed to verify the behavior of getCheckstyleModules method.
-    * It is provided with a package name that does not contain any checkstyle modules.
-    * It ensures that ModuleReflectionUtil.getCheckstyleModules is returning an empty set.
-    */
+     * This test case is designed to verify the behavior of getCheckstyleModules method.
+     * It is provided with a package name that does not contain any checkstyle modules.
+     * It ensures that ModuleReflectionUtil.getCheckstyleModules is returning an empty set.
+     */
     @Test
     public void testGetCheckStyleModules() throws IOException {
         final ClassLoader classLoader = ClassLoader.getSystemClassLoader();


### PR DESCRIPTION
Supplemental for #6723 

Refactored misaligned leading asterisks in javadoc comments.