### PR TITLE
Issue #13553: False positive in FallThroughCheck on last case

### DIFF
--- a/config/checker-framework-suppressions/checker-lock-tainting-suppressions.xml
+++ b/config/checker-framework-suppressions/checker-lock-tainting-suppressions.xml
@@ -453,6 +453,36 @@
   </checkerFrameworkError>
 
   <checkerFrameworkError unstable="false">
+    <fileName>src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/FallThroughCheck.java</fileName>
+    <specifier>methodref.param</specifier>
+    <message>Incompatible parameter type for obj</message>
+    <lineContent>.filter(Objects::nonNull)</lineContent>
+    <details>
+      found   : @GuardSatisfied Object
+      required: @GuardedBy DetailAST
+      Consequence: method in @GuardedBy Objects
+      @GuardedBy boolean nonNull(@GuardSatisfied Object p0)
+      is not a valid method reference for method in @GuardedBy Predicate&lt;@GuardedBy DetailAST&gt;
+      @GuardedBy boolean test(@GuardedBy Predicate&lt;@GuardedBy DetailAST&gt; this, @GuardedBy DetailAST p0)
+    </details>
+  </checkerFrameworkError>
+
+  <checkerFrameworkError unstable="false">
+    <fileName>src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/FallThroughCheck.java</fileName>
+    <specifier>methodref.param</specifier>
+    <message>Incompatible parameter type for obj</message>
+    <lineContent>Objects::nonNull,</lineContent>
+    <details>
+      found   : @GuardSatisfied Object
+      required: @GuardedBy DetailAST
+      Consequence: method in @GuardedBy Objects
+      @GuardedBy boolean nonNull(@GuardSatisfied Object p0)
+      is not a valid method reference for method in @GuardedBy Predicate&lt;@GuardedBy DetailAST&gt;
+      @GuardedBy boolean test(@GuardedBy Predicate&lt;@GuardedBy DetailAST&gt; this, @GuardedBy DetailAST p0)
+    </details>
+  </checkerFrameworkError>
+
+  <checkerFrameworkError unstable="false">
     <fileName>src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/ModifiedControlVariableCheck.java</fileName>
     <specifier>methodref.param</specifier>
     <message>Incompatible parameter type for arg0</message>

--- a/config/checker-framework-suppressions/checker-nullness-optional-interning-suppressions.xml
+++ b/config/checker-framework-suppressions/checker-nullness-optional-interning-suppressions.xml
@@ -1767,13 +1767,6 @@
   </checkerFrameworkError>
 
   <checkerFrameworkError unstable="false">
-    <fileName>src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/FallThroughCheck.java</fileName>
-    <specifier>introduce.eliminate</specifier>
-    <message>It is bad style to create an Optional just to chain methods to get a non-optional value.</message>
-    <lineContent>.orElse(Boolean.FALSE);</lineContent>
-  </checkerFrameworkError>
-
-  <checkerFrameworkError unstable="false">
     <fileName>src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/FinalLocalVariableCheck.java</fileName>
     <specifier>dereference.of.nullable</specifier>
     <message>dereference of possibly-null reference candidate</message>

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/FallThroughCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/FallThroughCheck.java
@@ -20,9 +20,11 @@
 package com.puppycrawl.tools.checkstyle.checks.coding;
 
 import java.util.HashSet;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
 import java.util.regex.Pattern;
+import java.util.stream.Stream;
 
 import com.puppycrawl.tools.checkstyle.StatelessCheck;
 import com.puppycrawl.tools.checkstyle.api.AbstractCheck;
@@ -42,9 +44,9 @@ import com.puppycrawl.tools.checkstyle.utils.TokenUtil;
  * "fallthru", "fall thru", "fall-thru",
  * "fallthrough", "fall through", "fall-through"
  * "fallsthrough", "falls through", "falls-through" (case-sensitive).
- * The comment containing these words must be all on one line,
- * and must be on the last non-empty line before the {@code case} triggering
- * the warning or on the same line before the {@code case}(ugly, but possible).
+ * The comment containing these words must be on the last non-empty line
+ * before the {@code case} triggering the warning or on the same line before
+ * the {@code case}(ugly, but possible).
  * </p>
  * <p>
  * Note: The check assumes that there is no unreachable code in the {@code case}.
@@ -454,11 +456,19 @@ public class FallThroughCheck extends AbstractCheck {
      * @return true if relief comment found
      */
     private boolean hasReliefComment(DetailAST ast) {
-        return Optional.ofNullable(getNextNonCommentAst(ast))
-                .map(DetailAST::getPreviousSibling)
-                .map(previous -> previous.getFirstChild().getText())
-                .map(text -> reliefPattern.matcher(text).find())
-                .orElse(Boolean.FALSE);
+        final DetailAST nonCommentAst = getNextNonCommentAst(ast);
+        boolean result = false;
+        if (nonCommentAst != null) {
+            final int prevLineNumber = nonCommentAst.getPreviousSibling().getLineNo();
+            result = Stream.iterate(nonCommentAst.getPreviousSibling(),
+                            Objects::nonNull,
+                            DetailAST::getPreviousSibling)
+                    .takeWhile(sibling -> sibling.getLineNo() == prevLineNumber)
+                    .map(DetailAST::getFirstChild)
+                    .filter(Objects::nonNull)
+                    .anyMatch(firstChild -> reliefPattern.matcher(firstChild.getText()).find());
+        }
+        return result;
     }
 
 }

--- a/src/main/resources/com/puppycrawl/tools/checkstyle/meta/checks/coding/FallThroughCheck.xml
+++ b/src/main/resources/com/puppycrawl/tools/checkstyle/meta/checks/coding/FallThroughCheck.xml
@@ -15,9 +15,9 @@
  "fallthru", "fall thru", "fall-thru",
  "fallthrough", "fall through", "fall-through"
  "fallsthrough", "falls through", "falls-through" (case-sensitive).
- The comment containing these words must be all on one line,
- and must be on the last non-empty line before the {@code case} triggering
- the warning or on the same line before the {@code case}(ugly, but possible).
+ The comment containing these words must be on the last non-empty line
+ before the {@code case} triggering the warning or on the same line before
+ the {@code case}(ugly, but possible).
  &lt;/p&gt;
  &lt;p&gt;
  Note: The check assumes that there is no unreachable code in the {@code case}.

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/coding/FallThroughCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/coding/FallThroughCheckTest.java
@@ -252,7 +252,6 @@ public class FallThroughCheckTest extends AbstractModuleTestSupport {
         final String[] expected = {
             "48:11: " + getCheckMessage(MSG_FALL_THROUGH_LAST),
             "83:11: " + getCheckMessage(MSG_FALL_THROUGH_LAST),
-            "112:11: " + getCheckMessage(MSG_FALL_THROUGH_LAST),
         };
         verifyWithInlineConfigParser(
                 getPath("InputFallThrough4.java"),
@@ -331,11 +330,7 @@ public class FallThroughCheckTest extends AbstractModuleTestSupport {
     public void testLastLine() throws Exception {
         final String[] expected = {
             "21:13: " + getCheckMessage(MSG_FALL_THROUGH),
-            // until https://github.com/checkstyle/checkstyle/issues/13553
-            "33:13: " + getCheckMessage(MSG_FALL_THROUGH),
             "99:39: " + getCheckMessage(MSG_FALL_THROUGH_LAST),
-            // until https://github.com/checkstyle/checkstyle/issues/13553
-            "107:11: " + getCheckMessage(MSG_FALL_THROUGH_LAST),
         };
         verifyWithInlineConfigParser(
                 getPath("InputFallThroughLastLineCommentCheck.java"),
@@ -355,12 +350,7 @@ public class FallThroughCheckTest extends AbstractModuleTestSupport {
 
     @Test
     public void testReliefCommentBetweenMultipleComment() throws Exception {
-        final String[] expected = {
-            // until https://github.com/checkstyle/checkstyle/issues/13553
-            "25:17: " + getCheckMessage(MSG_FALL_THROUGH),
-            // until https://github.com/checkstyle/checkstyle/issues/13553
-            "34:13: " + getCheckMessage(MSG_FALL_THROUGH_LAST),
-        };
+        final String[] expected = {};
         verifyWithInlineConfigParser(
                 getPath("InputFallThrough8.java"),
                 expected);
@@ -383,12 +373,45 @@ public class FallThroughCheckTest extends AbstractModuleTestSupport {
 
     @Test
     public void testSwitchLabeledRules() throws Exception {
-        final String[] expected = {
-
-        };
+        final String[] expected = {};
 
         verifyWithInlineConfigParser(
                 getNonCompilablePath("InputFallThroughSwitchRules.java"),
+                expected);
+    }
+
+    @Test
+    public void testInlineSingleCase() throws Exception {
+        final String[] expected = {
+            "12:17: " + getCheckMessage(MSG_FALL_THROUGH_LAST),
+        };
+
+        verifyWithInlineConfigParser(
+                getPath("InputFallThroughInlineSingleCase.java"),
+                expected);
+    }
+
+    @Test
+    public void testInlineMultipleComment() throws Exception {
+        final String[] expected = {};
+
+        verifyWithInlineConfigParser(
+                getPath("InputFallThroughMultipleReliefPatterns.java"),
+                expected);
+    }
+
+    @Test
+    public void testFallThroughWithoutReliefPattern() throws Exception {
+        final String[] expected = {
+            "21:9: " + getCheckMessage(MSG_FALL_THROUGH),
+            "45:9: " + getCheckMessage(MSG_FALL_THROUGH),
+            "54:9: " + getCheckMessage(MSG_FALL_THROUGH),
+            "60:9: " + getCheckMessage(MSG_FALL_THROUGH),
+            "77:9: " + getCheckMessage(MSG_FALL_THROUGH),
+            "94:9: " + getCheckMessage(MSG_FALL_THROUGH),
+        };
+        verifyWithInlineConfigParser(
+                getPath("InputFallThroughWithoutReliefPattern.java"),
                 expected);
     }
 }

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/fallthrough/InputFallThrough4.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/fallthrough/InputFallThrough4.java
@@ -109,7 +109,7 @@ public class InputFallThrough4 {
    void method5(int i, int j, boolean cond) {
       while (true) {
           switch (i){
-          case 5: // violation 'Fall\ through from the last branch of the switch statement'
+          case 5:
               i++;
               /* block */ /* fallthru */ // comment
           }

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/fallthrough/InputFallThrough8.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/fallthrough/InputFallThrough8.java
@@ -22,7 +22,7 @@ public class InputFallThrough8 {
                 case 2:
                     i++;
                     /* comment */ /* fall thru */ /* comment */
-                case 3: // violation 'Fall\ through from previous branch of the switch statement'
+                case 3:
                     i--;
                     break;
             }
@@ -31,7 +31,7 @@ public class InputFallThrough8 {
 
     void testLastCase(int i) {
         switch (i) {
-            case 0: // violation 'Fall\ through from the last branch of the switch statement'
+            case 0:
                 i++;
                 /* comment */ /* fall thru */ /* comment */
         }

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/fallthrough/InputFallThroughInlineSingleCase.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/fallthrough/InputFallThroughInlineSingleCase.java
@@ -1,0 +1,15 @@
+/*
+FallThrough
+checkLastCaseGroup = true
+reliefPattern = (default)falls?[ -]?thr(u|ough)
+
+
+*/
+package com.puppycrawl.tools.checkstyle.checks.coding.fallthrough;
+
+public class InputFallThroughInlineSingleCase{
+  void method(int a) {
+    switch (a) {case 1:;}
+    // violation above 'Fall\ through from the last branch of the switch statement.'
+  }
+}

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/fallthrough/InputFallThroughLastLineCommentCheck.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/fallthrough/InputFallThroughLastLineCommentCheck.java
@@ -30,7 +30,7 @@ public class InputFallThroughLastLineCommentCheck {
             case 1:
                 i++;
                 /* block */ /* fallthru */ // comment
-            case 2: // violation 'Fall\ through from previous branch of the switch statement'
+            case 2:
                 // this is comment
                 i++;
                 // fall through
@@ -104,7 +104,7 @@ public class InputFallThroughLastLineCommentCheck {
    void method7(int i, int j, boolean cond) {
       while (true) {
           switch (i){
-          case 5: // violation 'Fall\ through from the last branch of the switch statement'
+          case 5:
               i++;
               /* block */ i++; /* fallthru */ // comment
           }

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/fallthrough/InputFallThroughMultipleReliefPatterns.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/fallthrough/InputFallThroughMultipleReliefPatterns.java
@@ -1,0 +1,26 @@
+/*
+FallThrough
+checkLastCaseGroup = true
+reliefPattern = (default)falls?[ -]?thr(u|ough)
+
+
+*/
+package com.puppycrawl.tools.checkstyle.checks.coding.fallthrough;
+
+public class InputFallThroughMultipleReliefPatterns {
+
+  void method(int i) {
+    while (true) {
+      switch (i) {
+        case 5: {
+          i++;
+        }
+        /* block */ /* fallthru */ // comment
+        case 6:
+          i++;
+          /* block */ /* fallthru */ // comment
+
+      }
+    }
+  }
+}

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/fallthrough/InputFallThroughWithoutReliefPattern.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/fallthrough/InputFallThroughWithoutReliefPattern.java
@@ -1,0 +1,117 @@
+/*
+FallThrough
+checkLastCaseGroup = (default)false
+reliefPattern = Continue with next case
+
+
+*/
+
+package com.puppycrawl.tools.checkstyle.checks.coding.fallthrough;
+
+public class InputFallThroughWithoutReliefPattern {
+  void method(int i, boolean cond) {
+    while (true) {
+      switch (i) {
+        case 0:
+        case 1:
+          i++;
+          break;
+        case 2:
+          i++;
+        case 3: // violation 'Fall\ through from previous branch of the switch statement.'
+          i++;
+          break;
+        case 4:
+          return;
+        case 5:
+          throw new RuntimeException("");
+        case 6:
+          continue;
+        case 7: {
+          break;
+        }
+        case 8: {
+          return;
+        }
+        case 9: {
+          throw new RuntimeException("");
+        }
+        case 10: {
+          continue;
+        }
+        case 11: {
+          i++;
+        }
+        case 12: // violation 'Fall\ through from previous branch of the switch statement.'
+          if (false)
+            break;
+          else
+            break;
+        case 13:
+          if (true) {
+            return;
+          }
+        case 14: // violation 'Fall\ through from previous branch of the switch statement.'
+          if (true) {
+            return;
+          } else {
+            //do nothing
+          }
+        case 15: // violation 'Fall\ through from previous branch of the switch statement.'
+          do {
+            System.identityHashCode("something");
+            return;
+          } while (true);
+        case 16:
+          for (int j1 = 0; j1 < 10; j1++) {
+            String.valueOf("something");
+            return;
+          }
+        case 17:
+          while (true)
+            throw new RuntimeException("");
+        case 18:
+          while (cond) {
+            break;
+          }
+        case 19: // violation 'Fall\ through from previous branch of the switch statement.'
+          try {
+            i++;
+            break;
+          } catch (RuntimeException e) {
+            break;
+          } catch (Error e) {
+            return;
+          }
+        case 20:
+          try {
+            i++;
+            break;
+          } catch (RuntimeException e) {
+          } catch (Error e) {
+            return;
+          }
+        case 21: // violation 'Fall\ through from previous branch of the switch statement.'
+          try {
+            i++;
+          } catch (RuntimeException e) {
+            i--;
+          } finally {
+            break;
+          }
+        case 22:
+          try {
+            i++;
+            break;
+          } catch (RuntimeException e) {
+            i--;
+            break;
+          } finally {
+            i++;
+          }
+        default:
+          i++;
+      }
+    }
+  }
+}

--- a/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/checks/coding/FallThroughCheckExamplesTest.java
+++ b/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/checks/coding/FallThroughCheckExamplesTest.java
@@ -36,8 +36,7 @@ public class FallThroughCheckExamplesTest extends AbstractExamplesModuleTestSupp
     @Test
     public void testExample1() throws Exception {
         final String[] expected = {
-            "21:9: " + getCheckMessage(MSG_FALL_THROUGH),
-            "32:9: " + getCheckMessage(MSG_FALL_THROUGH),
+            "33:9: " + getCheckMessage(MSG_FALL_THROUGH),
         };
 
         verifyWithInlineConfigParser(getPath("Example1.java"), expected);

--- a/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/coding/fallthrough/Example1.java
+++ b/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/coding/fallthrough/Example1.java
@@ -18,7 +18,8 @@ class Example1 {
       switch (i) {
         case 1:
           i++;
-        case 2: // violation 'Fall\ through from previous branch of the switch'
+          /* block */ /* fallthru */ // comment
+        case 2: // ok, ReliefPattern is present in above line.
           i++;
           break;
         case 3:

--- a/src/xdocs/checks/coding/fallthrough.xml
+++ b/src/xdocs/checks/coding/fallthrough.xml
@@ -22,8 +22,7 @@
           &quot;fallthru&quot;, &quot;fall thru&quot;, &quot;fall-thru&quot;,
           &quot;fallthrough&quot;, &quot;fall through&quot;, &quot;fall-through&quot;
           &quot;fallsthrough&quot;, &quot;falls through&quot;, &quot;falls-through&quot; (case-sensitive).
-          The comment containing these words must be all on one line,
-          and must be on the last non-empty line before the
+          The comment containing these words must be on the last non-empty line before the
           <code>case</code> triggering the warning or on
           the same line before the <code>case</code>
           (ugly, but possible).
@@ -84,7 +83,8 @@ class Example1 {
       switch (i) {
         case 1:
           i++;
-        case 2: // violation 'Fall\ through from previous branch of the switch'
+          /* block */ /* fallthru */ // comment
+        case 2: // ok, ReliefPattern is present in above line.
           i++;
           break;
         case 3:

--- a/src/xdocs/checks/coding/fallthrough.xml.template
+++ b/src/xdocs/checks/coding/fallthrough.xml.template
@@ -22,8 +22,7 @@
           "fallthru", "fall thru", "fall-thru",
           "fallthrough", "fall through", "fall-through"
           "fallsthrough", "falls through", "falls-through" (case-sensitive).
-          The comment containing these words must be all on one line,
-          and must be on the last non-empty line before the
+          The comment containing these words must be on the last non-empty line before the
           <code>case</code> triggering the warning or on
           the same line before the <code>case</code>
           (ugly, but possible).


### PR DESCRIPTION
Fix for Issue #13553, Continue of #14016

## Config
```xml
<module name="FallThrough">
    <property name="checkLastCaseGroup" value="true"/>
</module>
```

## Regression Report
https://checkstyle-diff-reports.s3.us-east-2.amazonaws.com/8a0a354_2024060435/reports/diff/checkstyle/index.html
5 violations are removed in Checkstyle code base. Differences in this report are intended. 

For example:
https://github.com/checkstyle/checkstyle/blob/4fe811819594747bcce6f62c216ea133c3cd2954/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/fallthrough/InputFallThrough4.java#L109

```java
void method5(int i, int j, boolean cond) {
      while (true) {
          switch (i){
          case 5: // violation 'Fall\ through from the last branch of the switch statement'
              i++;
              /* block */ /* fallthru */ // comment
          }
      }
   }
```
This is no longer a violation in this case. Same for the other 4 cases.

Diff Regression config: https://gist.githubusercontent.com/Lmh-java/55bdd9e289522aff23374ad7b5571c2c/raw/4e52c69d3888eff5f976f0ae87c058e98c0dd72d/input-fall-thru-config.xml