### PR TITLE
minor: fix failing CI check_issues by referencing new issue link

### DIFF
--- a/config/intellij-idea-inspections.xml
+++ b/config/intellij-idea-inspections.xml
@@ -4106,7 +4106,7 @@
                    enabled_by_default="false"/>
   <inspection_tool class="SpringBootApplicationYaml" enabled="false" level="ERROR"
                    enabled_by_default="false"/>
-  <!-- until #14448 -->
+  <!-- until #14806 -->
   <inspection_tool class="YAMLSchemaValidation" enabled="false" level="ERROR"
                    enabled_by_default="false"/>
   <inspection_tool class="SpringBootBootstrapConfigurationInspection" enabled="false"


### PR DESCRIPTION
#14448 has been closed via #14696 

We had disabled `YAMLSchemaValidation` and was referenced to old issue.

https://github.com/checkstyle/checkstyle/blob/0707dd5ac38b2f0fd4af9941070ea2615c17f335/config/intellij-idea-inspections.xml#L4109-L4111

This PR updates linked issue to #14806 