### PR TITLE
Issue #14625: fixed inspections violations MismatchedJavadocCode

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/ant/CheckstyleAntTask.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/ant/CheckstyleAntTask.java
@@ -445,12 +445,10 @@ public class CheckstyleAntTask extends Task {
     }
 
     /**
-     * Return the list of listeners set in this task.
+     * Return the array of listeners set in this task.
      *
-     * @return the list of listeners.
+     * @return the array of listeners.
      * @throws BuildException if the listeners could not be created.
-     * @noinspection MismatchedJavadocCode
-     * @noinspectionreason MismatchedJavadocCode - until issue #14625
      */
     private AuditListener[] getListeners() {
         final int formatterCount = Math.max(1, formatters.size());

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/EqualsAvoidNullCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/EqualsAvoidNullCheck.java
@@ -634,9 +634,7 @@ public class EqualsAvoidNullCheck extends AbstractCheck {
          * Determines whether this FieldFrame contains the field.
          *
          * @param name name of the field to check.
-         * @return true if this FieldFrame contains instance field.
-         * @noinspection MismatchedJavadocCode
-         * @noinspectionreason MismatchedJavadocCode - until issue #14625
+         * @return DetailAST if this FieldFrame contains instance field.
          */
         public DetailAST findField(String name) {
             return fieldNameToAst.get(name);

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/UnusedLocalVariableCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/UnusedLocalVariableCheck.java
@@ -521,9 +521,7 @@ public class UnusedLocalVariableCheck extends AbstractCheck {
      * Checks if there is a type declaration with same name as the super class.
      *
      * @param superClassName name of the super class
-     * @return true if there is another type declaration with same name.
-     * @noinspection MismatchedJavadocCode
-     * @noinspectionreason MismatchedJavadocCode - until issue #14625
+     * @return list if there is another type declaration with same name.
      */
     private List<TypeDeclDesc> typeDeclWithSameName(String superClassName) {
         return typeDeclAstToTypeDeclDesc.values().stream()


### PR DESCRIPTION
Part of #14625 

Deals with **MismatchedJavadocCode** inspection.

```
<problems is_local_tool="true">
<problem>
<file>file://$PROJECT_DIR$/src/main/java/com/puppycrawl/tools/checkstyle/ant/CheckstyleAntTask.java</file>
<line>450</line>
<module>project</module>
<package>com.puppycrawl.tools.checkstyle.ant</package>
<entry_point TYPE="method" FQNAME="com.puppycrawl.tools.checkstyle.ant.CheckstyleAntTask com.puppycrawl.tools.checkstyle.api.AuditListener[] getListeners()"/>
<problem_class id="MismatchedJavadocCode" severity="WARNING" attribute_key="WARNING_ATTRIBUTES">Mismatch between Javadoc and code</problem_class>
<description>Method is specified to return list but the return type is array</description>
<highlighted_element>list</highlighted_element>
<language>JAVA</language>
<offset>19</offset>
<length>4</length>
</problem>

<problem>
<file>file://$PROJECT_DIR$/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/EqualsAvoidNullCheck.java</file>
<line>637</line>
<module>project</module>
<package>com.puppycrawl.tools.checkstyle.checks.coding</package>
<entry_point TYPE="method" FQNAME="com.puppycrawl.tools.checkstyle.checks.coding.EqualsAvoidNullCheck.FieldFrame com.puppycrawl.tools.checkstyle.api.DetailAST findField(java.lang.String name)"/>
<problem_class id="MismatchedJavadocCode" severity="WARNING" attribute_key="WARNING_ATTRIBUTES">Mismatch between Javadoc and code</problem_class>
<description>Method is specified to return 'true' but its return type is not boolean</description>
<highlighted_element>true</highlighted_element>
<language>JAVA</language>
<offset>19</offset>
<length>4</length>
</problem>

<problem>
<file>file://$PROJECT_DIR$/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/UnusedLocalVariableCheck.java</file>
<line>520</line>
<module>project</module>
<package>com.puppycrawl.tools.checkstyle.checks.coding</package>
<entry_point TYPE="method" FQNAME="com.puppycrawl.tools.checkstyle.checks.coding.UnusedLocalVariableCheck java.util.List<com.puppycrawl.tools.checkstyle.checks.coding.UnusedLocalVariableCheck.TypeDeclDesc> typeDeclWithSameName(java.lang.String superClassName)"/>
<problem_class id="MismatchedJavadocCode" severity="WARNING" attribute_key="WARNING_ATTRIBUTES">Mismatch between Javadoc and code</problem_class>
<description>Method is specified to return 'true' but its return type is not boolean</description>
<highlighted_element>true</highlighted_element>
<language>JAVA</language>
<offset>15</offset>
<length>4</length>
</problem>
</problems>
```