### PR TITLE
Issue #14625: fix inspection violation OptionalGetWithoutIsPresent JavaParserTest testSingleLineComment

### DIFF
--- a/src/test/java/com/puppycrawl/tools/checkstyle/JavaParserTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/JavaParserTest.java
@@ -105,12 +105,6 @@ public class JavaParserTest extends AbstractModuleTestSupport {
             .isEqualTo(1);
     }
 
-    /**
-     * Temporary java doc.
-     *
-     * @noinspection OptionalGetWithoutIsPresent
-     * @noinspectionreason OptionalGetWithoutIsPresent - until issue #14625
-     */
     @Test
     public void testAppendHiddenSingleLineCommentNodes() throws Exception {
         final DetailAST root =
@@ -120,10 +114,10 @@ public class JavaParserTest extends AbstractModuleTestSupport {
         final Optional<DetailAST> singleLineComment = TestUtil.findTokenInAstByPredicate(root,
             ast -> ast.getType() == TokenTypes.SINGLE_LINE_COMMENT);
         assertWithMessage("Single line comment should be present")
-                .that(singleLineComment.isPresent())
-                .isTrue();
+            .that(singleLineComment.isPresent())
+            .isTrue();
 
-        final DetailAST comment = singleLineComment.get();
+        final DetailAST comment = singleLineComment.orElseThrow();
 
         assertWithMessage("Unexpected line number")
             .that(comment.getLineNo())


### PR DESCRIPTION
Part of #14625 

Deals with one problem of **OptionalGetWithoutIsPresent** inspection.

```
<problem>
<file>file://$PROJECT_DIR$/src/test/java/com/puppycrawl/tools/checkstyle/JavaParserTest.java</file>
<line>114</line>
<module>project</module>
<package>com.puppycrawl.tools.checkstyle</package>
<entry_point TYPE="method" FQNAME="com.puppycrawl.tools.checkstyle.JavaParserTest void testAppendHiddenSingleLineCommentNodes()"/>
<problem_class id="OptionalGetWithoutIsPresent" severity="WARNING" attribute_key="WARNING_ATTRIBUTES">Optional.get() is called without isPresent() check</problem_class>
<description><code>Optional.get()</code> without 'isPresent()' check</description>
<highlighted_element>get</highlighted_element>
<language>JAVA</language>
<offset>52</offset>
<length>3</length>
</problem>
```

https://docs.oracle.com/javase/8/docs/api/java/util/Optional.html
https://docs.oracle.com/javase/8/docs/api/java/util/Optional.html#isPresent--
https://docs.oracle.com/javase/8/docs/api/java/util/Optional.html#get--

https://docs.oracle.com/javase/8/docs/api/java/util/Optional.html#orElseThrow-java.util.function.Supplier-