### PR TITLE
Issue #14625: fix noinspectionreason for TestMethodWithoutAssertion

### DIFF
--- a/src/test/java/com/puppycrawl/tools/checkstyle/internal/XdocsJavaDocsTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/internal/XdocsJavaDocsTest.java
@@ -129,7 +129,8 @@ public class XdocsJavaDocsTest extends AbstractModuleTestSupport {
      * @noinspection JUnitTestMethodWithNoAssertions, TestMethodWithoutAssertion
      * @noinspectionreason JUnitTestMethodWithNoAssertions - asserts in callstack,
      *      but not in this method
-     * @noinspectionreason TestMethodWithoutAssertion - until issue #14625
+     * @noinspectionreason TestMethodWithoutAssertion - asserts in callstack,
+     *      but not in this method
      */
     @Test
     public void testAllCheckSectionJavaDocs() throws Exception {

--- a/src/test/java/com/puppycrawl/tools/checkstyle/internal/XdocsPagesTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/internal/XdocsPagesTest.java
@@ -587,9 +587,10 @@ public class XdocsPagesTest {
      * Validates xml check documentation section.
      *
      * @noinspection JUnitTestMethodWithNoAssertions, TestMethodWithoutAssertion
-     * @noinspectionreason JUnitTestMethodWithNoAssertions -asserts in callstack,
+     * @noinspectionreason JUnitTestMethodWithNoAssertions - asserts in callstack,
      *      but not in this method
-     * @noinspectionreason TestMethodWithoutAssertion - until issue #14625
+     * @noinspectionreason TestMethodWithoutAssertion - asserts in callstack,
+     *      but not in this method
      */
     @Test
     public void testAllCheckSectionsEx() throws Exception {


### PR DESCRIPTION
Part of #14625 

`TestMethodWithoutAssertion` inspection is a permanent suppression for `XdocsJavaDocsTest` & `XdocsPagesTest`.

Reason being same as for inspection `JUnitTestMethodWithNoAssertions`.

```
     * @noinspectionreason JUnitTestMethodWithNoAssertions - asserts in callstack,
     *      but not in this method
```

Ideally, in this case, both inspections function the same, I believe.

```
<problems is_local_tool="true">
<problem>
<file>file://$PROJECT_DIR$/src/test/java/com/puppycrawl/tools/checkstyle/internal/XdocsJavaDocsTest.java</file>
<line>134</line>
<module>project</module>
<package>com.puppycrawl.tools.checkstyle.internal</package>
<entry_point TYPE="method" FQNAME="com.puppycrawl.tools.checkstyle.internal.XdocsJavaDocsTest void testAllCheckSectionJavaDocs()"/>
<problem_class id="TestMethodWithoutAssertion" severity="ERROR" attribute_key="ERRORS_ATTRIBUTES">Test method without assertions</problem_class>
<description>Test method <code>testAllCheckSectionJavaDocs()</code> contains no assertions #loc</description>
<highlighted_element>testAllCheckSectionJavaDocs</highlighted_element>
<language>JAVA</language>
<offset>16</offset>
<length>27</length>
</problem>

<problem>
<file>file://$PROJECT_DIR$/src/test/java/com/puppycrawl/tools/checkstyle/internal/XdocsPagesTest.java</file>
<line>594</line>
<module>project</module>
<package>com.puppycrawl.tools.checkstyle.internal</package>
<entry_point TYPE="method" FQNAME="com.puppycrawl.tools.checkstyle.internal.XdocsPagesTest void testAllCheckSectionsEx()"/>
<problem_class id="TestMethodWithoutAssertion" severity="ERROR" attribute_key="ERRORS_ATTRIBUTES">Test method without assertions</problem_class>
<description>Test method <code>testAllCheckSectionsEx()</code> contains no assertions #loc</description>
<highlighted_element>testAllCheckSectionsEx</highlighted_element>
<language>JAVA</language>
<offset>16</offset>
<length>22</length>
</problem>
</problems>
```