### PR TITLE
Issue #11166: remove getFileContents from EmptyLineSeparator

### DIFF
--- a/config/suppressions.xml
+++ b/config/suppressions.xml
@@ -62,6 +62,8 @@
   <suppress checks="MethodCount" files="[\\/]UnusedLocalVariableCheck.java"/>
   <!-- Utility class is combination of a lot of different methods .  -->
   <suppress checks="MethodCount" files="[\\/]SiteUtil.java"/>
+  <!-- a lot of small methods for a better readability.  -->
+  <suppress checks="MethodCount" files="[\\/]EmptyLineSeparatorCheck.java"/>
   <!-- parse method needs catching Exceptions to print context of execution -->
   <suppress checks="IllegalCatch" files="[\\/]src[\\/]test[\\/].*[\\/]InlineConfigParser\.java"/>
   <!-- exception maybe thrown while executing the static block -->

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/whitespace/emptylineseparator/InputEmptyLineSeparator.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/whitespace/emptylineseparator/InputEmptyLineSeparator.java
@@ -43,7 +43,7 @@ class InputEmptyLineSeparator // violation ''CLASS_DEF' should be separated from
     // one blank line - ok
     {
         //empty instance initializer
-    }
+    }    /* . */
     // no blank line - fail
     /**
      *


### PR DESCRIPTION
Issue #11166 : 
refactor  EmptyLineSeparatorCheck to use AST-based logic not `getFileContents()`

Diff Regression config: https://gist.githubusercontent.com/mahfouz72/afd57aa6e51ca161b7927acd959e5211/raw/9384f843297bb2e10c074bcb33ddc46902d6bd52/check.xml

**WIP**. just wants to get an initial review from CIs and maintainers