### PR TITLE
Issue #14625: fix inspection violations OptionalGetWithoutIsPresent

### DIFF
--- a/src/test/java/com/puppycrawl/tools/checkstyle/JavaParserTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/JavaParserTest.java
@@ -57,12 +57,6 @@ public class JavaParserTest extends AbstractModuleTestSupport {
             .isNull();
     }
 
-    /**
-     * Temporary java doc.
-     *
-     * @noinspection OptionalGetWithoutIsPresent
-     * @noinspectionreason OptionalGetWithoutIsPresent - until issue #14625
-     */
     @Test
     public void testAppendHiddenBlockCommentNodes() throws Exception {
         final DetailAST root =
@@ -76,7 +70,7 @@ public class JavaParserTest extends AbstractModuleTestSupport {
                 .that(blockComment.isPresent())
                 .isTrue();
 
-        final DetailAST comment = blockComment.get();
+        final DetailAST comment = blockComment.orElseThrow();
 
         assertWithMessage("Unexpected line number")
             .that(comment.getLineNo())
@@ -145,12 +139,6 @@ public class JavaParserTest extends AbstractModuleTestSupport {
                 .startsWith(" inline comment");
     }
 
-    /**
-     * Temporary java doc.
-     *
-     * @noinspection OptionalGetWithoutIsPresent
-     * @noinspectionreason OptionalGetWithoutIsPresent - until issue #14625
-     */
     @Test
     public void testAppendHiddenSingleLineCommentNodes2() throws Exception {
         final DetailAST root =
@@ -163,7 +151,7 @@ public class JavaParserTest extends AbstractModuleTestSupport {
                 .that(singleLineComment.isPresent())
                 .isTrue();
 
-        final DetailAST comment = singleLineComment.get();
+        final DetailAST comment = singleLineComment.orElseThrow();
 
         assertWithMessage("Unexpected line number")
             .that(comment.getLineNo())
@@ -242,12 +230,6 @@ public class JavaParserTest extends AbstractModuleTestSupport {
             .isEqualTo(Arrays.asList("5,4", "8,0"));
     }
 
-    /**
-     * Temporary java doc.
-     *
-     * @noinspection OptionalGetWithoutIsPresent
-     * @noinspectionreason OptionalGetWithoutIsPresent - until issue #14625
-     */
     @Test
     public void testJava14TextBlocks() throws Exception {
         final DetailAST root =
@@ -262,7 +244,7 @@ public class JavaParserTest extends AbstractModuleTestSupport {
                 .that(textBlockContent.isPresent())
                 .isTrue();
 
-        final DetailAST content = textBlockContent.get();
+        final DetailAST content = textBlockContent.orElseThrow();
         final String expectedContents = "\n                 string";
 
         assertWithMessage("Unexpected line number")

--- a/src/test/java/com/puppycrawl/tools/checkstyle/ant/CheckstyleAntTaskTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/ant/CheckstyleAntTaskTest.java
@@ -858,12 +858,6 @@ public class CheckstyleAntTaskTest extends AbstractPathTestSupport {
         assertLoggedTime(loggedMessages, testingTime, "To process the files");
     }
 
-    /**
-     * Temporary java doc.
-     *
-     * @noinspection OptionalGetWithoutIsPresent
-     * @noinspectionreason OptionalGetWithoutIsPresent - until issue #14625
-     */
     private static void assertLoggedTime(List<MessageLevelPair> loggedMessages,
                                          long testingTime, String expectedMsg) {
 
@@ -875,7 +869,7 @@ public class CheckstyleAntTaskTest extends AbstractPathTestSupport {
             .that(optionalMessageLevelPair.isPresent())
             .isTrue();
 
-        final long actualTime = getNumberFromLine(optionalMessageLevelPair.get().getMsg());
+        final long actualTime = getNumberFromLine(optionalMessageLevelPair.orElseThrow().getMsg());
 
         assertWithMessage("Logged time in '" + expectedMsg + "' "
                               + "must be less than the testing time")

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/SuppressWarningsHolderTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/SuppressWarningsHolderTest.java
@@ -406,12 +406,6 @@ public class SuppressWarningsHolderTest extends AbstractModuleTestSupport {
         verifyWithInlineConfigParser(getPath("InputSuppressWarningsHolder7.java"), expected);
     }
 
-    /**
-     * Temporary java doc.
-     *
-     * @noinspection OptionalGetWithoutIsPresent
-     * @noinspectionreason OptionalGetWithoutIsPresent - until issue #14625
-     */
     @Test
     @SuppressWarnings("unchecked")
     public void testClearState() throws Exception {
@@ -427,8 +421,8 @@ public class SuppressWarningsHolderTest extends AbstractModuleTestSupport {
                 .that(annotationDef.isPresent())
                 .isTrue();
         assertWithMessage("State is not cleared on beginTree")
-                .that(TestUtil.isStatefulFieldClearedDuringBeginTree(check, annotationDef.get(),
-                        "ENTRIES",
+                .that(TestUtil.isStatefulFieldClearedDuringBeginTree(check,
+                        annotationDef.orElseThrow(), "ENTRIES",
                         entries -> ((ThreadLocal<List<Object>>) entries).get().isEmpty()))
                 .isTrue();
     }

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/coding/HiddenFieldCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/coding/HiddenFieldCheckTest.java
@@ -500,8 +500,6 @@ public class HiddenFieldCheckTest
      * state of the field will be cleared.
      *
      * @throws Exception when code tested throws exception
-     * @noinspection OptionalGetWithoutIsPresent
-     * @noinspectionreason OptionalGetWithoutIsPresent - until issue #14625
      */
     @Test
     public void testClearState() throws Exception {
@@ -516,8 +514,8 @@ public class HiddenFieldCheckTest
                 .isTrue();
         assertWithMessage("State is not cleared on beginTree")
                 .that(
-                    TestUtil.isStatefulFieldClearedDuringBeginTree(check, classDef.get(), "frame",
-                        new CheckIfStatefulFieldCleared()))
+                    TestUtil.isStatefulFieldClearedDuringBeginTree(check, classDef.orElseThrow(),
+                        "frame", new CheckIfStatefulFieldCleared()))
                 .isTrue();
     }
 

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/coding/IllegalInstantiationCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/coding/IllegalInstantiationCheckTest.java
@@ -166,8 +166,6 @@ public class IllegalInstantiationCheckTest
      * state of the field will be cleared.
      *
      * @throws Exception when code tested throws exception
-     * @noinspection OptionalGetWithoutIsPresent
-     * @noinspectionreason OptionalGetWithoutIsPresent - until issue #14625
      */
     @Test
     @SuppressWarnings("unchecked")
@@ -183,9 +181,8 @@ public class IllegalInstantiationCheckTest
                 .that(classDef.isPresent())
                 .isTrue();
         assertWithMessage("State is not cleared on beginTree")
-            .that(
-                TestUtil.isStatefulFieldClearedDuringBeginTree(check, classDef.get(), "classNames",
-                    classNames -> ((Collection<String>) classNames).isEmpty()))
+            .that(TestUtil.isStatefulFieldClearedDuringBeginTree(check, classDef.orElseThrow(),
+                    "classNames", classNames -> ((Collection<String>) classNames).isEmpty()))
             .isTrue();
     }
 
@@ -195,8 +192,6 @@ public class IllegalInstantiationCheckTest
      * state of the field will be cleared.
      *
      * @throws Exception when code tested throws exception
-     * @noinspection OptionalGetWithoutIsPresent
-     * @noinspectionreason OptionalGetWithoutIsPresent - until issue #14625
      */
     @Test
     public void testClearStateImports() throws Exception {
@@ -211,9 +206,8 @@ public class IllegalInstantiationCheckTest
                 .that(importDef.isPresent())
                 .isTrue();
         assertWithMessage("State is not cleared on beginTree")
-            .that(
-                TestUtil.isStatefulFieldClearedDuringBeginTree(check, importDef.get(), "imports",
-                    imports -> ((Collection<?>) imports).isEmpty()))
+            .that(TestUtil.isStatefulFieldClearedDuringBeginTree(check, importDef.orElseThrow(),
+                    "imports", imports -> ((Collection<?>) imports).isEmpty()))
             .isTrue();
     }
 
@@ -223,8 +217,6 @@ public class IllegalInstantiationCheckTest
      * state of the field will be cleared.
      *
      * @throws Exception when code tested throws exception
-     * @noinspection OptionalGetWithoutIsPresent
-     * @noinspectionreason OptionalGetWithoutIsPresent - until issue #14625
      */
     @Test
     @SuppressWarnings("unchecked")
@@ -240,8 +232,8 @@ public class IllegalInstantiationCheckTest
                 .that(literalNew.isPresent())
                 .isTrue();
         assertWithMessage("State is not cleared on beginTree")
-                .that(TestUtil.isStatefulFieldClearedDuringBeginTree(check, literalNew.get(),
-                        "instantiations",
+                .that(TestUtil.isStatefulFieldClearedDuringBeginTree(check,
+                        literalNew.orElseThrow(), "instantiations",
                         instantiations -> ((Collection<DetailAST>) instantiations).isEmpty()))
                 .isTrue();
     }

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/coding/ModifiedControlVariableCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/coding/ModifiedControlVariableCheckTest.java
@@ -178,8 +178,6 @@ public class ModifiedControlVariableCheckTest
      * state of the field will be cleared.
      *
      * @throws Exception when code tested throws exception
-     * @noinspection OptionalGetWithoutIsPresent
-     * @noinspectionreason OptionalGetWithoutIsPresent - until issue #14625
      */
     @Test
     @SuppressWarnings("unchecked")
@@ -195,8 +193,8 @@ public class ModifiedControlVariableCheckTest
                 .that(methodDef.isPresent())
                 .isTrue();
         assertWithMessage("State is not cleared on beginTree")
-                .that(TestUtil.isStatefulFieldClearedDuringBeginTree(check, methodDef.get(),
-                        "variableStack",
+                .that(TestUtil.isStatefulFieldClearedDuringBeginTree(check,
+                        methodDef.orElseThrow(), "variableStack",
                         variableStack -> ((Collection<Set<String>>) variableStack).isEmpty()))
                 .isTrue();
     }

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/coding/ParameterAssignmentCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/coding/ParameterAssignmentCheckTest.java
@@ -103,8 +103,6 @@ public class ParameterAssignmentCheckTest extends AbstractModuleTestSupport {
      * state of the field will be cleared.
      *
      * @throws Exception when code tested throws exception
-     * @noinspection OptionalGetWithoutIsPresent
-     * @noinspectionreason OptionalGetWithoutIsPresent - until issue #14625
      */
     @Test
     @SuppressWarnings("unchecked")
@@ -119,7 +117,7 @@ public class ParameterAssignmentCheckTest extends AbstractModuleTestSupport {
                 .that(methodDef.isPresent())
                 .isTrue();
         assertWithMessage("State is not cleared on beginTree")
-            .that(TestUtil.isStatefulFieldClearedDuringBeginTree(check, methodDef.get(),
+            .that(TestUtil.isStatefulFieldClearedDuringBeginTree(check, methodDef.orElseThrow(),
                 "parameterNamesStack",
                 parameterNamesStack -> ((Collection<Set<String>>) parameterNamesStack).isEmpty()))
             .isTrue();

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/coding/RequireThisCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/coding/RequireThisCheckTest.java
@@ -562,8 +562,6 @@ public class RequireThisCheckTest extends AbstractModuleTestSupport {
      * state of the field will be cleared.
      *
      * @throws Exception when code tested throws exception
-     * @noinspection OptionalGetWithoutIsPresent
-     * @noinspectionreason OptionalGetWithoutIsPresent - until issue #14625
      */
     @Test
     public void testClearState() throws Exception {
@@ -578,7 +576,7 @@ public class RequireThisCheckTest extends AbstractModuleTestSupport {
                 .that(classDef.isPresent())
                 .isTrue();
         assertWithMessage("State is not cleared on beginTree")
-                .that(TestUtil.isStatefulFieldClearedDuringBeginTree(check, classDef.get(),
+                .that(TestUtil.isStatefulFieldClearedDuringBeginTree(check, classDef.orElseThrow(),
                         "current", current -> ((Collection<?>) current).isEmpty()))
                 .isTrue();
     }

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/coding/ReturnCountCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/coding/ReturnCountCheckTest.java
@@ -155,8 +155,6 @@ public class ReturnCountCheckTest extends AbstractModuleTestSupport {
      * state of the field will be cleared.
      *
      * @throws Exception when code tested throws exception
-     * @noinspection OptionalGetWithoutIsPresent
-     * @noinspectionreason OptionalGetWithoutIsPresent - until issue #14625
      */
     @Test
     @SuppressWarnings("unchecked")
@@ -171,8 +169,8 @@ public class ReturnCountCheckTest extends AbstractModuleTestSupport {
                 .that(methodDef.isPresent())
                 .isTrue();
         assertWithMessage("State is not cleared on beginTree")
-                .that(TestUtil.isStatefulFieldClearedDuringBeginTree(check, methodDef.get(),
-                        "contextStack",
+                .that(TestUtil.isStatefulFieldClearedDuringBeginTree(check,
+                        methodDef.orElseThrow(), "contextStack",
                         contextStack -> ((Collection<Set<String>>) contextStack).isEmpty()))
                 .isTrue();
     }

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/coding/SuperCloneCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/coding/SuperCloneCheckTest.java
@@ -92,8 +92,6 @@ public class SuperCloneCheckTest
      * state of the field will be cleared.
      *
      * @throws Exception when code tested throws exception
-     * @noinspection OptionalGetWithoutIsPresent
-     * @noinspectionreason OptionalGetWithoutIsPresent - until issue #14625
      */
     @Test
     @SuppressWarnings("unchecked")
@@ -108,8 +106,8 @@ public class SuperCloneCheckTest
                 .that(methodDef.isPresent())
                 .isTrue();
         assertWithMessage("State is not cleared on beginTree")
-                .that(TestUtil.isStatefulFieldClearedDuringBeginTree(check, methodDef.get(),
-                        "methodStack",
+                .that(TestUtil.isStatefulFieldClearedDuringBeginTree(check,
+                        methodDef.orElseThrow(), "methodStack",
                         methodStack -> ((Collection<Set<String>>) methodStack).isEmpty()))
                 .isTrue();
     }

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/coding/UnusedLocalVariableCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/coding/UnusedLocalVariableCheckTest.java
@@ -360,12 +360,6 @@ public class UnusedLocalVariableCheckTest extends AbstractModuleTestSupport {
                 expected);
     }
 
-    /**
-     * Temporary java doc.
-     *
-     * @noinspection OptionalGetWithoutIsPresent
-     * @noinspectionreason OptionalGetWithoutIsPresent - until issue #14625
-     */
     @Test
     public void testClearStateVariables() throws Exception {
         final UnusedLocalVariableCheck check = new UnusedLocalVariableCheck();
@@ -377,7 +371,7 @@ public class UnusedLocalVariableCheckTest extends AbstractModuleTestSupport {
         assertWithMessage("Ast should contain METHOD_DEF")
                 .that(methodDef.isPresent())
                 .isTrue();
-        final DetailAST variableDef = methodDef.get().getLastChild()
+        final DetailAST variableDef = methodDef.orElseThrow().getLastChild()
                 .findFirstToken(TokenTypes.VARIABLE_DEF);
         assertWithMessage("State is not cleared on beginTree")
                 .that(TestUtil.isStatefulFieldClearedDuringBeginTree(check, variableDef,
@@ -388,12 +382,6 @@ public class UnusedLocalVariableCheckTest extends AbstractModuleTestSupport {
                 .isTrue();
     }
 
-    /**
-     * Temporary java doc.
-     *
-     * @noinspection OptionalGetWithoutIsPresent
-     * @noinspectionreason OptionalGetWithoutIsPresent - until issue #14625
-     */
     @Test
     public void testClearStateClasses() throws Exception {
         final UnusedLocalVariableCheck check = new UnusedLocalVariableCheck();
@@ -405,7 +393,7 @@ public class UnusedLocalVariableCheckTest extends AbstractModuleTestSupport {
         assertWithMessage("Ast should contain CLASS_DEF")
                 .that(classDef.isPresent())
                 .isTrue();
-        final DetailAST classDefToken = classDef.get();
+        final DetailAST classDefToken = classDef.orElseThrow();
         assertWithMessage("State is not cleared on beginTree")
                 .that(TestUtil.isStatefulFieldClearedDuringBeginTree(check, classDefToken,
                         "typeDeclarations",
@@ -429,12 +417,6 @@ public class UnusedLocalVariableCheckTest extends AbstractModuleTestSupport {
                 .isTrue();
     }
 
-    /**
-     * Temporary java doc.
-     *
-     * @noinspection OptionalGetWithoutIsPresent
-     * @noinspectionreason OptionalGetWithoutIsPresent - until issue #14625
-     */
     @Test
     public void testClearStateAnonInnerClass() throws Exception {
         final UnusedLocalVariableCheck check = new UnusedLocalVariableCheck();
@@ -451,7 +433,7 @@ public class UnusedLocalVariableCheckTest extends AbstractModuleTestSupport {
                 .isTrue();
         check.beginTree(root);
         check.visitToken(classDefAst);
-        check.visitToken(literalNew.get());
+        check.visitToken(literalNew.orElseThrow());
         check.beginTree(null);
         final Predicate<Object> isClear = anonInnerAstToTypeDesc -> {
             return ((Map<?, ?>) anonInnerAstToTypeDesc).isEmpty();
@@ -469,12 +451,6 @@ public class UnusedLocalVariableCheckTest extends AbstractModuleTestSupport {
                 .isTrue();
     }
 
-    /**
-     * Temporary java doc.
-     *
-     * @noinspection OptionalGetWithoutIsPresent
-     * @noinspectionreason OptionalGetWithoutIsPresent - until issue #14625
-     */
     @Test
     public void testClearStatePackageDef() throws Exception {
         final UnusedLocalVariableCheck check = new UnusedLocalVariableCheck();
@@ -486,7 +462,7 @@ public class UnusedLocalVariableCheckTest extends AbstractModuleTestSupport {
         assertWithMessage("Ast should contain PACKAGE_DEF")
                 .that(packageDef.isPresent())
                 .isTrue();
-        final DetailAST packageDefToken = packageDef.get();
+        final DetailAST packageDefToken = packageDef.orElseThrow();
         assertWithMessage("State is not cleared on beginTree")
                 .that(TestUtil.isStatefulFieldClearedDuringBeginTree(check, packageDefToken,
                         "packageName",

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/design/FinalClassCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/design/FinalClassCheckTest.java
@@ -256,8 +256,6 @@ public class FinalClassCheckTest
      * state of the field will be cleared.
      *
      * @throws Exception when code tested throws exception
-     * @noinspection OptionalGetWithoutIsPresent
-     * @noinspectionreason OptionalGetWithoutIsPresent - until issue #14625
      */
     @Test
     public void testClearState() throws Exception {
@@ -271,8 +269,9 @@ public class FinalClassCheckTest
                 .that(packageDef.isPresent())
                 .isTrue();
         assertWithMessage("State is not cleared on beginTree")
-                .that(TestUtil.isStatefulFieldClearedDuringBeginTree(check, packageDef.get(),
-                        "packageName", packageName -> ((String) packageName).isEmpty()))
+                .that(TestUtil.isStatefulFieldClearedDuringBeginTree(check,
+                        packageDef.orElseThrow(), "packageName",
+                        packageName -> ((String) packageName).isEmpty()))
                 .isTrue();
     }
 

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/imports/ImportOrderCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/imports/ImportOrderCheckTest.java
@@ -802,8 +802,6 @@ public class ImportOrderCheckTest extends AbstractModuleTestSupport {
      * leading to hard-to-detect and unstable violations that will affect our users.
      *
      * @throws Exception when code tested throws exception
-     * @noinspection OptionalGetWithoutIsPresent
-     * @noinspectionreason OptionalGetWithoutIsPresent - until issue #14625
      */
     @Test
     public void testClearState() throws Exception {
@@ -818,8 +816,9 @@ public class ImportOrderCheckTest extends AbstractModuleTestSupport {
                 .that(staticImport.isPresent())
                 .isTrue();
         assertWithMessage("State is not cleared on beginTree")
-                .that(TestUtil.isStatefulFieldClearedDuringBeginTree(check, staticImport.get(),
-                        "lastImportStatic", lastImportStatic -> !((boolean) lastImportStatic)))
+                .that(TestUtil.isStatefulFieldClearedDuringBeginTree(check,
+                        staticImport.orElseThrow(), "lastImportStatic",
+                        lastImportStatic -> !((boolean) lastImportStatic)))
                 .isTrue();
 
     }

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/metrics/ClassFanOutComplexityCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/metrics/ClassFanOutComplexityCheckTest.java
@@ -298,8 +298,6 @@ public class ClassFanOutComplexityCheckTest extends AbstractModuleTestSupport {
      * state of the field will be cleared.
      *
      * @throws Exception when code tested throws exception
-     * @noinspection OptionalGetWithoutIsPresent
-     * @noinspectionreason OptionalGetWithoutIsPresent - until issue #14625
      */
     @Test
     @SuppressWarnings("unchecked")
@@ -315,8 +313,8 @@ public class ClassFanOutComplexityCheckTest extends AbstractModuleTestSupport {
                 .that(importAst.isPresent())
                 .isTrue();
         assertWithMessage("State is not cleared on beginTree")
-                .that(TestUtil.isStatefulFieldClearedDuringBeginTree(check, importAst.get(),
-                    "importedClassPackages",
+                .that(TestUtil.isStatefulFieldClearedDuringBeginTree(check,
+                    importAst.orElseThrow(), "importedClassPackages",
                     importedClssPackage -> ((Map<String, String>) importedClssPackage).isEmpty()))
                 .isTrue();
     }
@@ -327,8 +325,6 @@ public class ClassFanOutComplexityCheckTest extends AbstractModuleTestSupport {
      * state of the field will be cleared.
      *
      * @throws Exception when code tested throws exception
-     * @noinspection OptionalGetWithoutIsPresent
-     * @noinspectionreason OptionalGetWithoutIsPresent - until issue #14625
      */
     @Test
     public void testClearStateClassContexts() throws Exception {
@@ -343,7 +339,7 @@ public class ClassFanOutComplexityCheckTest extends AbstractModuleTestSupport {
                 .that(classDef.isPresent())
                 .isTrue();
         assertWithMessage("State is not cleared on beginTree")
-                .that(TestUtil.isStatefulFieldClearedDuringBeginTree(check, classDef.get(),
+                .that(TestUtil.isStatefulFieldClearedDuringBeginTree(check, classDef.orElseThrow(),
                         "classesContexts",
                         classContexts -> ((Collection<?>) classContexts).size() == 1))
                 .isTrue();
@@ -355,8 +351,6 @@ public class ClassFanOutComplexityCheckTest extends AbstractModuleTestSupport {
      * state of the field will be cleared.
      *
      * @throws Exception when code tested throws exception
-     * @noinspection OptionalGetWithoutIsPresent
-     * @noinspectionreason OptionalGetWithoutIsPresent - until issue #14625
      */
     @Test
     public void testClearStatePackageName() throws Exception {
@@ -371,8 +365,8 @@ public class ClassFanOutComplexityCheckTest extends AbstractModuleTestSupport {
                 .that(packageDef.isPresent())
                 .isTrue();
         assertWithMessage("State is not cleared on beginTree")
-                .that(TestUtil.isStatefulFieldClearedDuringBeginTree(check, packageDef.get(),
-                        "packageName",
+                .that(TestUtil.isStatefulFieldClearedDuringBeginTree(check,
+                        packageDef.orElseThrow(), "packageName",
                         packageName -> ((String) packageName).isEmpty()))
                 .isTrue();
     }

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/metrics/NPathComplexityCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/metrics/NPathComplexityCheckTest.java
@@ -161,12 +161,6 @@ public class NPathComplexityCheckTest extends AbstractModuleTestSupport {
                 .isTrue();
     }
 
-    /**
-     * Temporary java doc.
-     *
-     * @noinspection OptionalGetWithoutIsPresent
-     * @noinspectionreason OptionalGetWithoutIsPresent - until issue #14625
-     */
     @Test
     public void testStatefulFieldsClearedOnBeginTree3() throws Exception {
         final NPathComplexityCheck check = new NPathComplexityCheck();
@@ -180,7 +174,7 @@ public class NPathComplexityCheckTest extends AbstractModuleTestSupport {
                 .isTrue();
 
         assertWithMessage("State is not cleared on beginTree")
-                .that(TestUtil.isStatefulFieldClearedDuringBeginTree(check, question.get(),
+                .that(TestUtil.isStatefulFieldClearedDuringBeginTree(check, question.orElseThrow(),
                         "processingTokenEnd", processingTokenEnd -> {
                             return TestUtil.<Integer>getInternalState(processingTokenEnd,
                                     "endLineNo") == 0

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/sizes/OuterTypeNumberCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/sizes/OuterTypeNumberCheckTest.java
@@ -116,8 +116,6 @@ public class OuterTypeNumberCheckTest extends AbstractModuleTestSupport {
      * check as they are file specific values.
      *
      * @throws Exception if there is an error.
-     * @noinspection OptionalGetWithoutIsPresent
-     * @noinspectionreason OptionalGetWithoutIsPresent - until issue #14625
      */
     @Test
     public void testClearState() throws Exception {
@@ -133,7 +131,7 @@ public class OuterTypeNumberCheckTest extends AbstractModuleTestSupport {
                 .isTrue();
         assertWithMessage("State is not cleared on beginTree")
                 .that(
-                    TestUtil.isStatefulFieldClearedDuringBeginTree(check, classDef.get(),
+                    TestUtil.isStatefulFieldClearedDuringBeginTree(check, classDef.orElseThrow(),
                             "currentDepth",
                             currentDepth -> ((Number) currentDepth).intValue() == 0))
                 .isTrue();

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/whitespace/GenericWhitespaceCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/whitespace/GenericWhitespaceCheckTest.java
@@ -277,8 +277,6 @@ public class GenericWhitespaceCheckTest
      * start of processing the next file in the check.
      *
      * @throws Exception if there is an error.
-     * @noinspection OptionalGetWithoutIsPresent
-     * @noinspectionreason OptionalGetWithoutIsPresent - until issue #14625
      */
     @Test
     public void testClearState() throws Exception {
@@ -297,8 +295,8 @@ public class GenericWhitespaceCheckTest
                 .isTrue();
         assertWithMessage("State is not cleared on beginTree")
                 .that(
-                    TestUtil.isStatefulFieldClearedDuringBeginTree(check, genericStart.get(),
-                            "depth",
+                    TestUtil.isStatefulFieldClearedDuringBeginTree(check,
+                            genericStart.orElseThrow(), "depth",
                             depth -> ((Number) depth).intValue() == 0))
                 .isTrue();
     }

--- a/src/test/java/com/puppycrawl/tools/checkstyle/utils/CheckUtilTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/utils/CheckUtilTest.java
@@ -426,8 +426,6 @@ public class CheckUtilTest extends AbstractModuleTestSupport {
      * @param root of type DetailAST
      * @param type of type int
      * @return call to get() from node
-     * @noinspection OptionalGetWithoutIsPresent
-     * @noinspectionreason OptionalGetWithoutIsPresent - until issue #14625
      */
     private static DetailAST getNode(DetailAST root, int type) {
         final Optional<DetailAST> node = findTokenInAstByPredicate(root,
@@ -437,6 +435,6 @@ public class CheckUtilTest extends AbstractModuleTestSupport {
             .that(node.isPresent())
             .isTrue();
 
-        return node.get();
+        return node.orElseThrow();
     }
 }


### PR DESCRIPTION
Part of #14625 

Fixes all inspection violations related to **OptionalGetWithoutIsPresent**.

https://output.circle-artifacts.com/output/job/e65c9574-61a6-4a48-8d9a-3b8206e5ad29/artifacts/0/home/circleci/project/target/inspection-results/OptionalGetWithoutIsPresent.xml

https://app.circleci.com/pipelines/github/checkstyle/checkstyle/1/workflows/0968f80e-db8e-401a-ad87-8c409072ba31/jobs/574793/artifacts