### PR TITLE
minor: removes extra method call from UnusedLocalVariableCheck

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/UnusedLocalVariableCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/UnusedLocalVariableCheck.java
@@ -232,8 +232,8 @@ public class UnusedLocalVariableCheck extends AbstractCheck {
         else if (isInsideLocalAnonInnerClass(ast)) {
             visitLocalAnonInnerClass(ast);
         }
-        else if (TokenUtil.isTypeDeclaration(type)) {
-            visitTypeDeclarationToken(ast);
+        else if (isNonLocalTypeDeclaration(ast)) {
+            visitNonLocalTypeDeclarationToken(ast);
         }
         else if (type == TokenTypes.PACKAGE_DEF) {
             packageName = CheckUtil.extractQualifiedName(ast.getFirstChild().getNextSibling());
@@ -304,18 +304,16 @@ public class UnusedLocalVariableCheck extends AbstractCheck {
     }
 
     /**
-     * Visit the type declaration token.
+     * Visit the non-local type declaration token.
      *
      * @param typeDeclAst type declaration ast
      */
-    private void visitTypeDeclarationToken(DetailAST typeDeclAst) {
-        if (isNonLocalTypeDeclaration(typeDeclAst)) {
-            final String qualifiedName = getQualifiedTypeDeclarationName(typeDeclAst);
-            final TypeDeclDesc currTypeDecl = new TypeDeclDesc(qualifiedName, depth, typeDeclAst);
-            depth++;
-            typeDeclarations.push(currTypeDecl);
-            typeDeclAstToTypeDeclDesc.put(typeDeclAst, currTypeDecl);
-        }
+    private void visitNonLocalTypeDeclarationToken(DetailAST typeDeclAst) {
+        final String qualifiedName = getQualifiedTypeDeclarationName(typeDeclAst);
+        final TypeDeclDesc currTypeDecl = new TypeDeclDesc(qualifiedName, depth, typeDeclAst);
+        depth++;
+        typeDeclarations.push(currTypeDecl);
+        typeDeclAstToTypeDeclDesc.put(typeDeclAst, currTypeDecl);
     }
 
     /**


### PR DESCRIPTION
This removes an if condition, and moves the if condition inside the method call to the outside. Nothing else was changed besides indentation.

The conditions we removed/moved before this change basically amounts to:
> TokenUtil.isTypeDeclaration && isNonLocalTypeDeclaration

[`isNonLocalTypeDeclaration`](https://github.com/checkstyle/checkstyle/blob/55f5c966bfa61b387110db6c4780f259a21676c8/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/UnusedLocalVariableCheck.java#L389) is basically:
> TokenUtil.isTypeDeclaration && !slist

So basically we are calling `TokenUtil.isTypeDeclaration` twice, and my changes remove the extra call.

Also, this code is in the `visitToken` and this change [aligns us with the `leaveToken` which has the same if condition check](https://github.com/checkstyle/checkstyle/blob/55f5c966bfa61b387110db6c4780f259a21676c8/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/UnusedLocalVariableCheck.java#L251).