### PR TITLE
Issue #13345 Enable UnnecessarySemicolonAfterOuterTypeDeclarationChec…

### DIFF
--- a/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/checks/coding/UnnecessarySemicolonAfterOuterTypeDeclarationCheckExamplesTest.java
+++ b/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/checks/coding/UnnecessarySemicolonAfterOuterTypeDeclarationCheckExamplesTest.java
@@ -19,12 +19,12 @@
 
 package com.puppycrawl.tools.checkstyle.checks.coding;
 
-import org.junit.jupiter.api.Disabled;
+import static com.puppycrawl.tools.checkstyle.checks.coding.UnnecessarySemicolonAfterOuterTypeDeclarationCheck.MSG_SEMI;
+
 import org.junit.jupiter.api.Test;
 
 import com.puppycrawl.tools.checkstyle.AbstractExamplesModuleTestSupport;
 
-@Disabled("until https://github.com/checkstyle/checkstyle/issues/13345")
 public class UnnecessarySemicolonAfterOuterTypeDeclarationCheckExamplesTest
         extends AbstractExamplesModuleTestSupport {
     @Override
@@ -36,18 +36,20 @@ public class UnnecessarySemicolonAfterOuterTypeDeclarationCheckExamplesTest
     @Test
     public void testExample1() throws Exception {
         final String[] expected = {
-
+            "17:2: " + getCheckMessage(MSG_SEMI),
+            "21:2: " + getCheckMessage(MSG_SEMI),
+            "25:2: " + getCheckMessage(MSG_SEMI),
+            "29:2: " + getCheckMessage(MSG_SEMI),
         };
-
-        verifyWithInlineConfigParser(getPath("Example1.txt"), expected);
+        verifyWithInlineConfigParser(getPath("Example1.java"), expected);
     }
 
     @Test
     public void testExample2() throws Exception {
         final String[] expected = {
-
+            "19:2: " + getCheckMessage(MSG_SEMI),
         };
 
-        verifyWithInlineConfigParser(getPath("Example2.txt"), expected);
+        verifyWithInlineConfigParser(getPath("Example2.java"), expected);
     }
 }

--- a/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/coding/unnecessarysemicolonafteroutertypedeclaration/Example1.java
+++ b/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/coding/unnecessarysemicolonafteroutertypedeclaration/Example1.java
@@ -6,12 +6,13 @@
 </module>
 */
 
+package com.puppycrawl.tools.checkstyle.checks.coding.unnecessarysemicolonafteroutertypedeclaration;
+
 // xdoc section -- start
-class A {
+class Example1 {
+  class Nested {
 
-   class Nested {
-
-   }; // OK, nested type declarations are ignored
+  }; // OK, nested type declarations are ignored
 
 }; // violation
 
@@ -23,7 +24,7 @@ enum C {
 
 }; // violation
 
-{@literal @}interface D {
+@interface D {
 
 }; // violation
 // xdoc section -- end

--- a/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/coding/unnecessarysemicolonafteroutertypedeclaration/Example2.java
+++ b/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/coding/unnecessarysemicolonafteroutertypedeclaration/Example2.java
@@ -8,20 +8,26 @@
 </module>
 */
 
+package com.puppycrawl.tools.checkstyle.checks.coding.unnecessarysemicolonafteroutertypedeclaration;
+
 // xdoc section -- start
-class A {
+class Example2 {
+  class Nested {
+
+  }; // OK, nested type declarations are ignored
 
 }; // violation
 
-interface B {
+interface T {
 
-}; // OK
+};
 
-enum C {
+enum U {
 
-}; // OK
+};
 
-{@literal @}interface D {
+@interface V {
 
-}; // OK
+};
 // xdoc section -- end
+

--- a/src/xdocs/checks/coding/unnecessarysemicolonafteroutertypedeclaration.xml
+++ b/src/xdocs/checks/coding/unnecessarysemicolonafteroutertypedeclaration.xml
@@ -80,11 +80,10 @@
           Example:
         </p>
         <source>
-class A {
+class Example1 {
+  class Nested {
 
-   class Nested {
-
-   }; // OK, nested type declarations are ignored
+  }; // OK, nested type declarations are ignored
 
 }; // violation
 
@@ -96,7 +95,7 @@ enum C {
 
 }; // violation
 
-{@literal @}interface D {
+@interface D {
 
 }; // violation
         </source>
@@ -117,21 +116,24 @@ enum C {
           Example:
         </p>
         <source>
-class A {
+class Example2 {
+  class Nested {
+
+  }; // OK, nested type declarations are ignored
 
 }; // violation
 
-interface B {
+interface T {
 
-}; // OK
+};
 
-enum C {
+enum U {
 
-}; // OK
+};
 
-{@literal @}interface D {
+@interface V {
 
-}; // OK
+};
         </source>
       </subsection>
 

--- a/src/xdocs/checks/coding/unnecessarysemicolonafteroutertypedeclaration.xml.template
+++ b/src/xdocs/checks/coding/unnecessarysemicolonafteroutertypedeclaration.xml.template
@@ -35,7 +35,7 @@
         </p>
         <macro name="example">
           <param name="path"
-                 value="resources/com/puppycrawl/tools/checkstyle/checks/coding/unnecessarysemicolonafteroutertypedeclaration/Example1.txt"/>
+                 value="resources/com/puppycrawl/tools/checkstyle/checks/coding/unnecessarysemicolonafteroutertypedeclaration/Example1.java"/>
           <param name="type" value="config"/>
         </macro>
         <p id="Example1-code">
@@ -43,7 +43,7 @@
         </p>
         <macro name="example">
           <param name="path"
-                 value="resources/com/puppycrawl/tools/checkstyle/checks/coding/unnecessarysemicolonafteroutertypedeclaration/Example1.txt"/>
+                 value="resources/com/puppycrawl/tools/checkstyle/checks/coding/unnecessarysemicolonafteroutertypedeclaration/Example1.java"/>
           <param name="type" value="code"/>
         </macro>
         <p id="Example2-config">
@@ -52,7 +52,7 @@
         </p>
         <macro name="example">
           <param name="path"
-                 value="resources/com/puppycrawl/tools/checkstyle/checks/coding/unnecessarysemicolonafteroutertypedeclaration/Example2.txt"/>
+                 value="resources/com/puppycrawl/tools/checkstyle/checks/coding/unnecessarysemicolonafteroutertypedeclaration/Example2.java"/>
           <param name="type" value="config"/>
         </macro>
         <p id="Example2-code">
@@ -60,7 +60,7 @@
         </p>
         <macro name="example">
           <param name="path"
-                 value="resources/com/puppycrawl/tools/checkstyle/checks/coding/unnecessarysemicolonafteroutertypedeclaration/Example2.txt"/>
+                 value="resources/com/puppycrawl/tools/checkstyle/checks/coding/unnecessarysemicolonafteroutertypedeclaration/Example2.java"/>
           <param name="type" value="code"/>
         </macro>
       </subsection>


### PR DESCRIPTION
Issue: #13345 

Changes done as a part of PR
1. changed Example.txt files to Example.java files
2. Changed their references in` src/xdocs/checks/coding/unnecessarysemicolonafteroutertypedeclaration.xml.template`
3. updated `src/xdocs/checks/coding/unnecessarysemicolonafteroutertypedeclaration.xml`  with new changes
4. ` src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/checks/coding/UnnecessarySemicolonAfterOuterTypeDeclarationCheckExamplesTest.java ` - Removed disabled annotation, updated tests with new Example.java file