### PR TITLE
dependency: bump pmd.version to 7.1.0 and maven-pmd-plugin to 3.22.0

### DIFF
--- a/config/pmd-main.xml
+++ b/config/pmd-main.xml
@@ -18,29 +18,28 @@
              we value full coverage more than final modifier.
            Picocli fields will have their value injected and should not be marked final. -->
       <property name="violationSuppressXPath"
-               value="//ClassOrInterfaceDeclaration[@SimpleName='FileText']
+               value="//ClassDeclaration[@SimpleName='FileText']
                         //FieldDeclaration//VariableDeclarator[@Name='fullText']
-                    | //ClassOrInterfaceDeclaration[@SimpleName='CliOptions']"/>
+                    | //ClassDeclaration[@SimpleName='CliOptions']"/>
     </properties>
   </rule>
   <rule ref="category/java/errorprone.xml/CloseResource">
     <properties>
       <property name="allowedResourceTypes"
-               value="java.io.ByteArrayOutputStream|java.io.ByteArrayInputStream"/>
-      <property name="allowedResourceTypes"
-               value="java.io.StringWriter|java.io.CharArrayWriter|java.io.StringReader"/>
+               value="java.io.ByteArrayOutputStream,java.io.ByteArrayInputStream,
+                      java.io.StringWriter,java.io.CharArrayWriter,java.io.StringReader"/>
       <!-- we do close streams in special methods -->
       <property name="violationSuppressXPath"
-               value="//ClassOrInterfaceDeclaration[@SimpleName='DefaultLogger']
-                    | //ClassOrInterfaceDeclaration[@SimpleName='Main']
+               value="//ClassDeclaration[@SimpleName='DefaultLogger']
+                    | //ClassDeclaration[@SimpleName='Main']
                         //MethodDeclaration[@Name='createListener']
-                    | //ClassOrInterfaceDeclaration[@SimpleName='PropertyCacheFile']
+                    | //ClassDeclaration[@SimpleName='PropertyCacheFile']
                         //MethodDeclaration[@Name='persist' or @Name='serialize']
-                    | //ClassOrInterfaceDeclaration[@SimpleName='XmlLoader']
+                    | //ClassDeclaration[@SimpleName='XmlLoader']
                         //MethodDeclaration[@Name='resolveEntity']
-                    | //ClassOrInterfaceDeclaration[@SimpleName='CheckstyleAntTask']
+                    | //ClassDeclaration[@SimpleName='CheckstyleAntTask']
                         //MethodDeclaration[@Name='getListeners' or @Name='createDefaultLogger']
-                    | //ClassOrInterfaceDeclaration[@SimpleName='AbstractNode']
+                    | //ClassDeclaration[@SimpleName='AbstractNode']
                         //MethodDeclaration[@Name='iterateAxis']"/>
     </properties>
   </rule>
@@ -48,20 +47,20 @@
     <properties>
       <!-- until https://github.com/checkstyle/checkstyle/issues/12873 -->
       <property name="violationSuppressXPath"
-         value="//ClassOrInterfaceDeclaration[@SimpleName='AutomaticBean']"/>
+         value="//ClassDeclaration[@SimpleName='AutomaticBean']"/>
     </properties>
   </rule>
   <rule ref="category/java/design.xml/AvoidCatchingGenericException">
     <properties>
       <!-- we allow catching Exception in certain cases to provide more details in wrapper -->
       <property name="violationSuppressXPath"
-         value="//ClassOrInterfaceDeclaration[@SimpleName='PropertiesMacro']
+         value="//ClassDeclaration[@SimpleName='PropertiesMacro']
                         //MethodDeclaration[@Name='writeTablePropertiesRows']
-                    | //ClassOrInterfaceDeclaration[@SimpleName='Checker']
+                    | //ClassDeclaration[@SimpleName='Checker']
                         //MethodDeclaration[@Name='processFiles']
-                    | //ClassOrInterfaceDeclaration[@SimpleName='Checker']
+                    | //ClassDeclaration[@SimpleName='Checker']
                         //MethodDeclaration[@Name='processFile']
-                    | //ClassOrInterfaceDeclaration[@SimpleName='TranslationCheck']
+                    | //ClassDeclaration[@SimpleName='TranslationCheck']
                         //MethodDeclaration[@Name='getTranslationKeys']"/>
     </properties>
   </rule>

--- a/config/pmd-test.xml
+++ b/config/pmd-test.xml
@@ -95,10 +95,20 @@
            assertion calls are not required as they are called by the library.
            In MainTest PMD does not find asserts in lambdas called in the method
              invokeAndWait. -->
+      <!-- For AllCheckTest.testAllModulesAreReferencedInConfigFile,
+           testAllCheckTokensAreReferencedInCheckstyleConfigFile,
+           testAllCheckTokensAreReferencedInGoogleConfigFile,
+           testAllCheckstyleModulesHaveXdocDocumentation
+           until https://github.com/checkstyle/checkstyle/issues/14870 -->
       <property name="violationSuppressXPath"
                value="//ClassDeclaration[@SimpleName='AllChecksTest'
                      or @SimpleName='AstRegressionTest'
                      or @SimpleName='ImportControlCheckTest']//PrimaryPrefix/Name[@Name='verify']
+                   | //ClassDeclaration[@SimpleName='AllChecksTest']
+                       //MethodDeclaration[@Name='testAllModulesAreReferencedInConfigFile'
+                        or @Name='testAllCheckTokensAreReferencedInCheckstyleConfigFile'
+                        or @Name='testAllCheckTokensAreReferencedInGoogleConfigFile'
+                        or @Name='testAllCheckstyleModulesHaveXdocDocumentation']
                    | //ClassDeclaration[@SimpleName='MainTest']
                        //PrimaryPrefix//Name[starts-with(@SimpleName, 'assert')]
                    | //ClassDeclaration[@SimpleName='XdocsPagesTest']
@@ -137,6 +147,8 @@
           as they check each token and each rule explicitly.
          JavadocTokenTypes.testTokenValues contains several asserts as it checks each
           token explicitly. -->
+      <!-- For ClassImportRuleTest and all the below suppressions
+          until https://github.com/checkstyle/checkstyle/issues/14870 -->
       <property name="violationSuppressXPath"
                value="//ClassDeclaration[@SimpleName='JavadocTokenTypesTest']
                         //MethodDeclaration[@Name='testTokenValues']
@@ -145,7 +157,15 @@
                     | //ClassDeclaration[@SimpleName='GeneratedJavadocTokenTypesTest']
                         //MethodDeclaration[@Name='testTokenNumbers']
                     | //ClassDeclaration[@SimpleName='ParseTreeTablePresentationTest']
-                        //MethodDeclaration[@Name='testGetValueAtDetailNode']"/>
+                        //MethodDeclaration[@Name='testGetValueAtDetailNode']
+                    | //ClassDeclaration[@SimpleName='ClassImportRuleTest']
+                    | //ClassDeclaration[@SimpleName='PkgImportRuleTest']
+                    | //ClassDeclaration[@SimpleName='PkgImportControlTest']
+                       //MethodDeclaration[ends-with(@Name, 'CheckAccess')]
+                    | //ClassDeclaration[@SimpleName='JavadocTagInfoTest']
+                       //MethodDeclaration[@Name='testCoverage']
+                    | //ClassDeclaration[@SimpleName='AstRegressionTest']
+                       //MethodDeclaration[@Name='testCustomAstTree']"/>
     </properties>
   </rule>
 
@@ -198,9 +218,16 @@
   <rule ref="category/java/multithreading.xml/DoNotUseThreads">
     <properties>
       <!-- We use thread to limit the stack size for a test method. -->
+      <!-- For SuppressionFilterTest.isConnectionAvailableAndStable and
+           SuppressionsLoaderTest.loadFilterSet
+           https://github.com/checkstyle/checkstyle/issues/14870 -->
       <property name="violationSuppressXPath"
                value="//ClassDeclaration[@SimpleName='TestUtil']
-                        //MethodDeclaration[@Name='getResultWithLimitedResources']"/>
+                        //MethodDeclaration[@Name='getResultWithLimitedResources']
+               | //ClassDeclaration[@SimpleName='SuppressionFilterTest']
+                        //MethodDeclaration[@Name='isConnectionAvailableAndStable']
+               | //ClassDeclaration[@SimpleName='SuppressionsLoaderTest']
+                    //MethodDeclaration[@Name='loadFilterSet']"/>
     </properties>
   </rule>
 </ruleset>

--- a/config/pmd-test.xml
+++ b/config/pmd-test.xml
@@ -40,9 +40,6 @@
     <exclude name="AvoidUsingHardCodedIP"/>
     <!-- UTests are required to be public by design -->
     <exclude name="ExcessivePublicCount"/>
-    <!-- we have too much UTs for each main class, it is better to keep all tests in one
-      file to ease navigation and search for test -->
-    <exclude name="ExcessiveClassLength"/>
     <!-- we want to avoid wide throws signature, it is just test -->
     <exclude name="AvoidCatchingGenericException"/>
     <!-- we do not want to invest extra time to make logic ideal
@@ -71,13 +68,13 @@
              token explicitly.
            IndentationCheckTest has a lot of cases. -->
       <property name="violationSuppressXPath"
-              value="//ClassOrInterfaceDeclaration[@SimpleName='JavadocTokenTypesTest']
+              value="//ClassDeclaration[@SimpleName='JavadocTokenTypesTest']
                        //MethodDeclaration[@Name='testTokenValues']
-                   | //ClassOrInterfaceDeclaration[@SimpleName='GeneratedJavaTokenTypesTest']
+                   | //ClassDeclaration[@SimpleName='GeneratedJavaTokenTypesTest']
                        //MethodDeclaration[@Name='testTokenNumbering']
-                   | //ClassOrInterfaceDeclaration[@SimpleName='GeneratedJavadocTokenTypesTest']
+                   | //ClassDeclaration[@SimpleName='GeneratedJavadocTokenTypesTest']
                        //MethodDeclaration[@Name='testTokenNumbers']
-                   | //ClassOrInterfaceDeclaration[@SimpleName='IndentationCheckTest']"/>
+                   | //ClassDeclaration[@SimpleName='IndentationCheckTest']"/>
     </properties>
   </rule>
 
@@ -99,28 +96,28 @@
            In MainTest PMD does not find asserts in lambdas called in the method
              invokeAndWait. -->
       <property name="violationSuppressXPath"
-               value="//ClassOrInterfaceDeclaration[@SimpleName='AllChecksTest'
+               value="//ClassDeclaration[@SimpleName='AllChecksTest'
                      or @SimpleName='AstRegressionTest'
-                     or @SimpleName='ImportControlCheckTest']//PrimaryPrefix/Name[@Image='verify']
-                   | //ClassOrInterfaceDeclaration[@SimpleName='MainTest']
+                     or @SimpleName='ImportControlCheckTest']//PrimaryPrefix/Name[@Name='verify']
+                   | //ClassDeclaration[@SimpleName='MainTest']
                        //PrimaryPrefix//Name[starts-with(@SimpleName, 'assert')]
-                   | //ClassOrInterfaceDeclaration[@SimpleName='XdocsPagesTest']
+                   | //ClassDeclaration[@SimpleName='XdocsPagesTest']
                        //MethodDeclaration[@Name='testAllChecksPresentOnAvailableChecksPage']
-                   | //ClassOrInterfaceDeclaration[@SimpleName='XdocsJavaDocsTest']
+                   | //ClassDeclaration[@SimpleName='XdocsJavaDocsTest']
                        //MethodDeclaration[@Name='testAllCheckSectionJavaDocs']
-                   | //ClassOrInterfaceDeclaration[starts-with(@SimpleName,'XpathRegression')]
+                   | //ClassDeclaration[starts-with(@SimpleName,'XpathRegression')]
                        //MethodDeclaration
-                   | //ClassOrInterfaceDeclaration[@SimpleName='ImmutabilityTest']
+                   | //ClassDeclaration[@SimpleName='ImmutabilityTest']
                        //MethodDeclaration
-                   | //ClassOrInterfaceDeclaration[@SimpleName='ArchUnitTest']
+                   | //ClassDeclaration[@SimpleName='ArchUnitTest']
                        //MethodDeclaration
-                   | //ClassOrInterfaceDeclaration[@SimpleName='ArchUnitSuperClassTest']
+                   | //ClassDeclaration[@SimpleName='ArchUnitSuperClassTest']
                        //MethodDeclaration
-                   | //ClassOrInterfaceDeclaration[@SimpleName='ArchUnitCyclesCheckTest']
+                   | //ClassDeclaration[@SimpleName='ArchUnitCyclesCheckTest']
                        //MethodDeclaration
-                   | //ClassOrInterfaceDeclaration[@SimpleName='SuppressionFilterTest']
+                   | //ClassDeclaration[@SimpleName='SuppressionFilterTest']
                        //MethodDeclaration[starts-with(@Name, 'testUseCache')]
-                   | //ClassOrInterfaceDeclaration[@SimpleName='MainTest']
+                   | //ClassDeclaration[@SimpleName='MainTest']
                        //MethodDeclaration[starts-with(@Name, 'testMain')]"/>
     </properties>
   </rule>
@@ -129,7 +126,7 @@
     <properties>
       <!-- A false positive. -->
       <property name="violationSuppressXPath"
-               value="//ClassOrInterfaceDeclaration[@SimpleName='CommitValidationTest']"/>
+               value="//ClassDeclaration[@SimpleName='CommitValidationTest']"/>
     </properties>
   </rule>
   <rule ref="category/java/bestpractices.xml/JUnitTestContainsTooManyAsserts">
@@ -141,13 +138,13 @@
          JavadocTokenTypes.testTokenValues contains several asserts as it checks each
           token explicitly. -->
       <property name="violationSuppressXPath"
-               value="//ClassOrInterfaceDeclaration[@SimpleName='JavadocTokenTypesTest']
+               value="//ClassDeclaration[@SimpleName='JavadocTokenTypesTest']
                         //MethodDeclaration[@Name='testTokenValues']
-                    | //ClassOrInterfaceDeclaration[@SimpleName='GeneratedJavaTokenTypesTest']
+                    | //ClassDeclaration[@SimpleName='GeneratedJavaTokenTypesTest']
                         //MethodDeclaration[@Name='testTokenNumbering']
-                    | //ClassOrInterfaceDeclaration[@SimpleName='GeneratedJavadocTokenTypesTest']
+                    | //ClassDeclaration[@SimpleName='GeneratedJavadocTokenTypesTest']
                         //MethodDeclaration[@Name='testTokenNumbers']
-                    | //ClassOrInterfaceDeclaration[@SimpleName='ParseTreeTablePresentationTest']
+                    | //ClassDeclaration[@SimpleName='ParseTreeTablePresentationTest']
                         //MethodDeclaration[@Name='testGetValueAtDetailNode']"/>
     </properties>
   </rule>
@@ -157,7 +154,7 @@
       <!-- A false positive: commit validation is a sequence of checks, if we shuffle them
           it would be broken. -->
       <property name="violationSuppressXPath"
-               value="//ClassOrInterfaceDeclaration[@SimpleName='CommitValidationTest']
+               value="//ClassDeclaration[@SimpleName='CommitValidationTest']
                         //MethodDeclaration[@Name='validateCommitMessage']"/>
     </properties>
   </rule>
@@ -169,9 +166,9 @@
          easy to maintain. The rule should also only check public methods but has a bug.
          Suppress the false-positives. -->
       <property name="violationSuppressXPath"
-               value="//ClassOrInterfaceDeclaration[@SimpleName='SuppressionXpathSingleFilterTest']
+               value="//ClassDeclaration[@SimpleName='SuppressionXpathSingleFilterTest']
                         //MethodDeclaration[@Name='createSuppressionXpathSingleFilter']
-                    | //ClassOrInterfaceDeclaration[ @SimpleName='XdocsPagesTest']
+                    | //ClassDeclarationClassDeclaration[@SimpleName='XdocsPagesTest']
                         //MethodDeclaration[@Name='validateRuleNameOrder']"/>
     </properties>
   </rule>
@@ -179,17 +176,17 @@
     <properties>
       <!-- we do close streams in special methods -->
       <property name="violationSuppressXPath"
-               value="//ClassOrInterfaceDeclaration[@SimpleName='XdocsPagesTest']
+               value="//ClassDeclaration[@SimpleName='XdocsPagesTest']
                         //MethodDeclaration[@Name='getModulePropertyExpectedValue']
-                 | //ClassOrInterfaceDeclaration[@SimpleName='DefaultLoggerPowerTest']
+                 | //ClassDeclaration[@SimpleName='DefaultLoggerPowerTest']
                      //MethodDeclaration[@Name='testNewCtor']
-                 | //ClassOrInterfaceDeclaration[@SimpleName='ImportControlLoaderPowerTest']
+                 | //ClassDeclaration[@SimpleName='ImportControlLoaderPowerTest']
                      //MethodDeclaration[@Name='testInputStreamThatFailsOnClose']
-                 | //ClassOrInterfaceDeclaration[@SimpleName='ImportControlLoaderPowerTest']
+                 | //ClassDeclaration[@SimpleName='ImportControlLoaderPowerTest']
                      //MethodDeclaration[@Name='testInputStreamFailsOnRead']
-                 | //ClassOrInterfaceDeclaration[@SimpleName='XpathFileGeneratorAuditListenerTest']
+                 | //ClassDeclaration[@SimpleName='XpathFileGeneratorAuditListenerTest']
                      //MethodDeclaration[@Name='verifyOutput']
-                 | //ClassOrInterfaceDeclaration[@SimpleName='CommonUtilTest']
+                 | //ClassDeclaration[@SimpleName='CommonUtilTest']
                      //MethodDeclaration[@Name='testClose']"/>
     </properties>
   </rule>
@@ -202,7 +199,7 @@
     <properties>
       <!-- We use thread to limit the stack size for a test method. -->
       <property name="violationSuppressXPath"
-               value="//ClassOrInterfaceDeclaration[@SimpleName='TestUtil']
+               value="//ClassDeclaration[@SimpleName='TestUtil']
                         //MethodDeclaration[@Name='getResultWithLimitedResources']"/>
     </properties>
   </rule>

--- a/config/pmd.xml
+++ b/config/pmd.xml
@@ -14,6 +14,28 @@
     <!-- too much false-positives from 6.18.0 -->
     <exclude name="UnusedPrivateMethod"/>
   </rule>
+  <rule ref="category/java/bestpractices.xml/UnusedLocalVariable">
+    <properties>
+      <!-- until https://github.com/checkstyle/checkstyle/issues/14870 -->
+      <property name="violationSuppressXPath"
+                value="//ClassDeclaration[@SimpleName='FilterUtil']
+                        //MethodDeclaration[@Name='isFileExists']
+                | //ClassDeclaration[@SimpleName='TreeWalkerTest']
+                        //MethodDeclaration[@Name='testNoAuditEventsWithoutFilters']
+                | //ClassDeclaration[@SimpleName='OrderedPropertiesCheckTest']
+                        //MethodDeclaration[@Name='getFileNotFoundDetail']
+                | //ClassDeclaration[@SimpleName='UniquePropertiesCheckTest']
+                        //MethodDeclaration[@Name='getFileNotFoundDetail']
+                | //ClassDeclaration[@SimpleName='HeaderCheckTest']
+                        //MethodDeclaration[@Name='testIoExceptionWhenLoadingHeader']
+                | //ClassDeclaration[@SimpleName='CustomImportOrderCheckTest']
+                        //MethodDeclaration[@Name='testGetFullImportIdent']
+               | //ClassDeclaration[@SimpleName='MainFrameTest']
+                        //MethodDeclaration[@Name='testOpenFileButton']
+               | //ClassDeclaration[@SimpleName='ConfigurationLoaderTest']
+                        //MethodDeclaration[@Name='testConfigWithIgnoreExceptionalAttributes']"/>
+    </properties>
+  </rule>
   <rule ref="category/java/bestpractices.xml/AvoidPrintStackTrace">
     <properties>
       <!-- It is ok to use print stack trace in CLI class. -->
@@ -39,6 +61,42 @@
                        or @SimpleName='JavadocPropertiesGenerator']"/>
     </properties>
   </rule>
+  <rule ref="category/java/bestpractices.xml/LiteralsFirstInComparisons">
+    <properties>
+      <!-- until https://github.com/checkstyle/checkstyle/issues/14870 -->
+      <property name="violationSuppressXPath" value="//ClassDeclaration[
+        @SimpleName='XdocsUrlTest']//MethodDeclaration[@Name='characters' or @Name='endElement']"/>
+    </properties>
+  </rule>
+  <rule ref="category/java/bestpractices.xml/LooseCoupling">
+    <properties>
+      <!-- until https://github.com/checkstyle/checkstyle/issues/14870 -->
+      <property name="violationSuppressXPath"
+                value="//ClassDeclaration[@SimpleName='CodeSelectorPresentationTest']
+                     //FieldDeclaration//VariableDeclarator[@Name='linesToPosition']
+                | //ClassDeclaration[@SimpleName='FileText']
+                     //ConstructorDeclaration
+                | //ClassDeclaration[@SimpleName='ArchUnitSuperClassTest']
+                  //MethodDeclaration[@Name=
+                  'testChecksShouldHaveAllowedAbstractClassAsSuperclass']
+                | //ClassDeclaration[@SimpleName='ArchUnitTest']
+                  //MethodDeclaration[@Name='nonProtectedCheckMethodsTest'
+                      or @Name='testClassesInApiDoNotDependOnClassesInUtil']
+               | //ClassDeclaration[@SimpleName='ImmutabilityTest']
+                    //FieldDeclaration//VariableDeclarator[@Name='CHECKSTYLE_CHECKS']
+               | //ClassDeclaration[@SimpleName='ImmutabilityTest']
+                    //MethodDeclaration[@Name='testUtilClassesImmutability']"/>
+    </properties>
+  </rule>
+  <rule ref="category/java/bestpractices.xml/UnnecessaryVarargsArrayCreation">
+    <properties>
+      <!-- until https://github.com/checkstyle/checkstyle/issues/14870 -->
+      <property name="violationSuppressXPath"
+                value="//ClassDeclaration[@SimpleName='CustomImportOrderCheckTest']
+                    //MethodDeclaration[@Name='testGetFullImportIdent']"/>
+    </properties>
+  </rule>
+
 
   <rule ref="category/java/documentation.xml">
     <!-- We use class comments as source for xdoc files,
@@ -153,6 +211,22 @@
       <property name="checkTopLevelTypes" value="false" />
     </properties>
   </rule>
+  <rule ref="category/java/codestyle.xml/UnnecessaryBoxing">
+    <properties>
+      <!-- until https://github.com/checkstyle/checkstyle/issues/14870 -->
+      <property name="violationSuppressXPath"
+                value="//ClassDeclaration[@SimpleName='IntMatchFilterElement']
+                        //MethodDeclaration[@Name='hashCode']"/>
+    </properties>
+  </rule>
+  <rule ref="category/java/codestyle.xml/CommentDefaultAccessModifier">
+    <!-- until https://github.com/checkstyle/checkstyle/issues/14870 -->
+    <properties>
+      <property name="violationSuppressXPath"
+                value="//ClassDeclaration[@SimpleName='Main']
+                        //EnumDeclaration[@SimpleName='OutputFormat']"/>
+    </properties>
+  </rule>
 
   <rule ref="category/java/errorprone.xml">
     <!-- That rule is not practical, no options to allow some magic numbers,
@@ -192,8 +266,20 @@
     <properties>
       <!-- There is no alternative to using System.exit in the CLI class
            to report the return code. -->
+      <!-- For MainTest.assertMainReturnCode
+            until https://github.com/checkstyle/checkstyle/issues/14870 -->
       <property name="violationSuppressXPath"
-                value="//ClassDeclaration[@SimpleName='ExitHelper']"/>
+                value="//ClassDeclaration[@SimpleName='ExitHelper']
+                 | //ClassDeclaration[@SimpleName='MainTest']
+                    //MethodDeclaration[@Name='assertMainReturnCode'] "/>
+    </properties>
+  </rule>
+  <rule ref="category/java/errorprone.xml/ConstructorCallsOverridableMethod">
+    <properties>
+      <!-- until https://github.com/checkstyle/checkstyle/issues/14870 -->
+      <property name="violationSuppressXPath"
+                value="//ClassDeclaration[@SimpleName='MainFrame']
+                        //ConstructorDeclaration"/>
     </properties>
   </rule>
 
@@ -252,9 +338,13 @@
     <properties>
       <!-- I do not see any problem, looks like a false positive.
            SiteUtil is a utility class providing different functionality. -->
+      <!-- For all Except SiteUtil and HandlerFactory
+          until https://github.com/checkstyle/checkstyle/issues/14870 -->
       <property name="violationSuppressXPath"
                 value="//ClassDeclaration[@SimpleName='HandlerFactory'
-                or @SimpleName='SiteUtil']"/>
+                or @SimpleName='SiteUtil' or @SimpleName='Checker' or @SimpleName='JavaAstVisitor'
+                or @SimpleName='Main' or @SimpleName='TreeWalker' or @SimpleName='CheckstyleAntTask'
+                or @SimpleName='TranslationCheck' or @SimpleName='JavadocMethodCheck']"/>
     </properties>
   </rule>
   <rule ref="category/java/design.xml/NcssCount">
@@ -372,6 +462,13 @@
                     //MethodDeclaration[@Name='getDescriptionFromJavadoc']"/>
     </properties>
   </rule>
+  <rule ref="category/java/design.xml/ClassWithOnlyPrivateConstructorsShouldBeFinal">
+    <properties>
+       <!-- until https://github.com/checkstyle/checkstyle/issues/14870 -->
+      <property name="violationSuppressXPath"
+                value="//ClassDeclaration[@SimpleName='AbstractInvalidClass']"/>
+    </properties>
+  </rule>
 
   <rule ref="category/java/multithreading.xml">
     <!-- Checkstyle is not thread safe till https://github.com/checkstyle/checkstyle/projects/5. -->
@@ -393,6 +490,30 @@
     <exclude name="AvoidInstantiatingObjectsInLoops"/>
     <!-- Not configurable, decreases readability. -->
     <exclude name="UseStringBufferForStringAppends"/>
+  </rule>
+
+  <rule ref="category/java/performance.xml/ConsecutiveAppendsShouldReuse">
+    <properties>
+      <!-- until https://github.com/checkstyle/checkstyle/issues/14870 -->
+      <property name="violationSuppressXPath"
+                value="//ClassDeclaration[@SimpleName='XMLLogger']
+                        //MethodDeclaration[@Name='encode']
+                | //ClassDeclaration[@SimpleName='InlineTagUtil']
+                      //MethodDeclaration[@Name='convertLinesToString']
+                | //ClassDeclaration[@SimpleName='XdocsPagesTest']
+                      //MethodDeclaration[@Name='validateViolationSection']
+                | //ClassDeclaration[@SimpleName='XdocsJavaDocsTest']
+                     //MethodDeclaration[@Name='createPropertiesText'
+                        or @Name='appendNodeText' or @Name='getAttributeText']"/>
+    </properties>
+  </rule>
+  <rule ref="category/java/performance.xml/UseArraysAsList">
+    <properties>
+      <!-- until https://github.com/checkstyle/checkstyle/issues/14870 -->
+      <property name="violationSuppressXPath"
+                value="//ClassDeclaration[@SimpleName='DescriptionExtractor']
+                        //MethodDeclaration[@Name='getDescriptionNodes']"/>
+    </properties>
   </rule>
 
   <rule ref="category/java/design.xml/ExcessivePublicCount">

--- a/config/pmd.xml
+++ b/config/pmd.xml
@@ -17,7 +17,7 @@
   <rule ref="category/java/bestpractices.xml/AvoidPrintStackTrace">
     <properties>
       <!-- It is ok to use print stack trace in CLI class. -->
-      <property name="violationSuppressXPath" value="//ClassOrInterfaceDeclaration[
+      <property name="violationSuppressXPath" value="//ClassDeclaration[
         @SimpleName='Main']"/>
     </properties>
   </rule>
@@ -26,7 +26,7 @@
       <!-- The PMD check accepts only a string constant as the assertion message.
            This check uses a method call. -->
       <property name="violationSuppressXPath"
-                value="//ClassOrInterfaceDeclaration[@SimpleName='JavadocCatchCheck']
+                value="//ClassDeclaration[@SimpleName='JavadocCatchCheck']
                            //MethodDeclaration[@Name='visitJavadocToken']"/>
     </properties>
   </rule>
@@ -34,7 +34,7 @@
     <properties>
       <!-- it is ok to use println in CLI class. -->
       <property name="violationSuppressXPath"
-                value="//ClassOrInterfaceDeclaration
+                value="//ClassDeclaration
                        [@SimpleName='Main' or @SimpleName='Main$CliOptions'
                        or @SimpleName='JavadocPropertiesGenerator']"/>
     </properties>
@@ -49,18 +49,13 @@
     <properties>
       <!-- RequireThisCheck$AbstractFrame is a private class, no comment is required. -->
       <property name="violationSuppressXPath"
-                value="//ClassOrInterfaceDeclaration[@SimpleName='RequireThisCheck']"/>
+                value="//ClassDeclaration[@SimpleName='RequireThisCheck']"/>
     </properties>
   </rule>
 
   <rule ref="category/java/codestyle.xml">
     <!-- Opposite to UnnecessaryConstructor. -->
     <exclude name="AtLeastOneConstructor"/>
-    <!-- Turning a local variable to the field may create design problems and extend the scope of
-           the variable. -->
-    <exclude name="AvoidFinalLocalVariable"/>
-    <!-- Conflicts with names that does not mean in/out. -->
-    <exclude name="AvoidPrefixingMethodParameters"/>
     <!-- Calling super() is completely pointless, no matter if class inherits anything or not;
          it is meaningful only if you do not call implicit constructor of the base class. -->
     <exclude name="CallSuperInConstructor"/>
@@ -90,7 +85,7 @@
            JavadocTokenTypes and TokenTypes aren't utility classes. They are
              token definition classes. Also, they are part of the API. -->
       <property name="violationSuppressXPath"
-                value="//ClassOrInterfaceDeclaration[@SimpleName='Definitions'
+                value="//ClassDeclaration[@SimpleName='Definitions'
                            or @SimpleName='LoadExternalDtdFeatureProvider'
                            or @SimpleName='JavadocTokenTypes'
                            or @SimpleName='TokenTypes'
@@ -101,17 +96,17 @@
     <properties>
       <!-- False positives on IF_ELSE-IF-ELSE-IF. -->
       <property name="violationSuppressXPath"
-                value="//ClassOrInterfaceDeclaration[@SimpleName='XMLLogger']
+                value="//ClassDeclaration[@SimpleName='XMLLogger']
                            //MethodDeclaration[@Name='isReference']
-      | //ClassOrInterfaceDeclaration[@SimpleName='DetailAstImpl']
+      | //ClassDeclaration[@SimpleName='DetailAstImpl']
               //MethodDeclaration[@Name='addPreviousSibling']
-      | //ClassOrInterfaceDeclaration[@SimpleName='AnnotationLocationCheck']
+      | //ClassDeclaration[@SimpleName='AnnotationLocationCheck']
               //MethodDeclaration[@Name='checkAnnotations']
-      | //ClassOrInterfaceDeclaration[@SimpleName='AbstractImportControl']
+      | //ClassDeclaration[@SimpleName='AbstractImportControl']
               //MethodDeclaration[@Name='checkAccess']
-      | //ClassOrInterfaceDeclaration[@SimpleName='HandlerFactory']
+      | //ClassDeclaration[@SimpleName='HandlerFactory']
               //MethodDeclaration[@Name='getHandler']
-      | //ClassOrInterfaceDeclaration[@SimpleName='JavaAstVisitor']
+      | //ClassDeclaration[@SimpleName='JavaAstVisitor']
               //MethodDeclaration[@Name='visitWildCardTypeArgument']"/>
     </properties>
   </rule>
@@ -122,11 +117,11 @@
        AbstractRootNode is what a root node is.
       -->
       <property name="violationSuppressXPath"
-                value="//ClassOrInterfaceDeclaration[@SimpleName='AbstractFileSetCheck'
+                value="//ClassDeclaration[@SimpleName='AbstractFileSetCheck'
         or @SimpleName='AbstractCheck' or @SimpleName='AbstractJavadocCheck'
         or @SimpleName='AbstractNode'
         or @SimpleName='AbstractViolationReporter']
-        | //ClassOrInterfaceDeclaration[@SimpleName='AbstractRootNode']
+        | //ClassDeclaration[@SimpleName='AbstractRootNode']
           //MethodDeclaration[@Name='getParent' or @Name='getDepth']"/>
     </properties>
   </rule>
@@ -148,7 +143,7 @@
       <!-- Main is a good name for the class containing the main method.
            Tag as inner class name is fine. -->
       <property name="violationSuppressXPath"
-                value="//ClassOrInterfaceDeclaration[@SimpleName='Main' or @SimpleName='Tag']"/>
+                value="//ClassDeclaration[@SimpleName='Main' or @SimpleName='Tag']"/>
     </properties>
   </rule>
   <rule ref="category/java/codestyle.xml/CommentDefaultAccessModifier">
@@ -166,8 +161,6 @@
     <!-- We need compare by ref as Tree structure is immutable, we can easily
          rely on refs. -->
     <exclude name="CompareObjectsWithEquals"/>
-    <!-- Too many false positives. -->
-    <exclude name="DataflowAnomalyAnalysis"/>
     <!-- This rule does not have any option, unreasonable to use. -->
     <exclude name="ImplicitSwitchFallThrough"/>
     <!-- We reuse Check instances between java files, we need to clear state of
@@ -187,7 +180,7 @@
       <property name="skipAnnotations" value="true"/>
       <!-- Keeping the duplicated strings maintains readability -->
       <property name="violationSuppressXPath"
-                value="//ClassOrInterfaceDeclaration[@SimpleName='SarifLogger']"/>
+                value="//ClassDeclaration[@SimpleName='SarifLogger']"/>
     </properties>
   </rule>
   <rule ref="category/java/errorprone.xml/EmptyCatchBlock">
@@ -200,7 +193,7 @@
       <!-- There is no alternative to using System.exit in the CLI class
            to report the return code. -->
       <property name="violationSuppressXPath"
-                value="//ClassOrInterfaceDeclaration[@SimpleName='ExitHelper']"/>
+                value="//ClassDeclaration[@SimpleName='ExitHelper']"/>
     </properties>
   </rule>
 
@@ -228,11 +221,11 @@
            a runtime exception.
            JavadocMethodCheck: Exception type is not predictable. -->
       <property name="violationSuppressXPath"
-                value="//ClassOrInterfaceDeclaration[@SimpleName='Checker']
+                value="//ClassDeclaration[@SimpleName='Checker']
                              //MethodDeclaration[@Name='processFiles']
-                      |//ClassOrInterfaceDeclaration[@SimpleName='TranslationCheck']
+                      | //ClassDeclaration[@SimpleName='TranslationCheck']
                              //MethodDeclaration[@Name='getTranslationKeys']
-                      |//ClassOrInterfaceDeclaration[@SimpleName='JavadocMethodCheck']
+                      | //ClassDeclaration[@SimpleName='JavadocMethodCheck']
                              //MethodDeclaration[@Name='resolveClass']"/>
     </properties>
   </rule>
@@ -242,7 +235,7 @@
        requires some extra IFs. -->
       <property name="problemDepth" value="4"/>
       <property name="violationSuppressXPath"
-                value="//ClassOrInterfaceDeclaration[@SimpleName='ClassResolver']
+                value="//ClassDeclaration[@SimpleName='ClassResolver']
                              //MethodDeclaration[@Name='resolve']"/>
     </properties>
   </rule>
@@ -251,7 +244,7 @@
       <!-- There is no other way to deliver the filename that was under processing.
            See https://github.com/checkstyle/checkstyle/issues/2285 -->
       <property name="violationSuppressXPath"
-                value="//ClassOrInterfaceDeclaration[@SimpleName='Checker']
+                value="//ClassDeclaration[@SimpleName='Checker']
                              //MethodDeclaration[@Name='processFiles']"/>
     </properties>
   </rule>
@@ -260,7 +253,7 @@
       <!-- I do not see any problem, looks like a false positive.
            SiteUtil is a utility class providing different functionality. -->
       <property name="violationSuppressXPath"
-                value="//ClassOrInterfaceDeclaration[@SimpleName='HandlerFactory'
+                value="//ClassDeclaration[@SimpleName='HandlerFactory'
                 or @SimpleName='SiteUtil']"/>
     </properties>
   </rule>
@@ -280,34 +273,47 @@
            Splitting PropertiesMacro.getDefaultValue will damage readability
            Splitting SiteUtil.getDefaultValue would not make it more readable -->
       <property name="violationSuppressXPath"
-                value="//ClassOrInterfaceDeclaration[@SimpleName='Main'
+                value="//ClassDeclaration[@SimpleName='Main'
         or @SimpleName='PackageObjectFactory' or @SimpleName='RequireThisCheck'
         or @SimpleName='VariableDeclarationUsageDistanceCheck'
         or @SimpleName='HandlerFactory']
-      | //ClassOrInterfaceDeclaration[@SimpleName='XMLLogger']//MethodDeclaration[@Name='encode']
-      | //ClassOrInterfaceDeclaration[@SimpleName='SarifLogger']//MethodDeclaration[@Name='escape']
-      | //ClassOrInterfaceDeclaration[@SimpleName='LeftCurlyCheck'
+      | //ClassDeclaration[@SimpleName='XMLLogger']//MethodDeclaration[@Name='encode']
+      | //ClassDeclaration[@SimpleName='SarifLogger']//MethodDeclaration[@Name='escape']
+      | //ClassDeclaration[@SimpleName='LeftCurlyCheck'
         or @SimpleName='FinalLocalVariableCheck'
         or @SimpleName='NPathComplexityCheck']
              //MethodDeclaration[@Name='visitToken']
-      | //ClassOrInterfaceDeclaration[@SimpleName='FallThroughCheck']
+      | //ClassDeclaration[@SimpleName='FallThroughCheck']
              //MethodDeclaration[@Name='isTerminated']
-      | //ClassOrInterfaceDeclaration[@SimpleName='ModifiedControlVariableCheck'
+      | //ClassDeclaration[@SimpleName='ModifiedControlVariableCheck'
         or @SimpleName='NPathComplexityCheck']//MethodDeclaration[@Name='leaveToken']
-      | //ClassOrInterfaceDeclaration[@SimpleName='NoWhitespaceAfterCheck']
+      | //ClassDeclaration[@SimpleName='NoWhitespaceAfterCheck']
              //MethodDeclaration[@Name='getArrayDeclaratorPreviousElement']
-      | //ClassOrInterfaceDeclaration[@SimpleName='AbstractElementNode'
+      | //ClassDeclaration[@SimpleName='AbstractElementNode'
         or @SimpleName='AbstractRootNode']
              //MethodDeclaration[@Name='iterateAxis']
-      | //ClassOrInterfaceDeclaration[@SimpleName='SuppressFilterElement']
+      | //ClassDeclaration[@SimpleName='SuppressFilterElement']
              //ConstructorDeclaration
-      | //ClassOrInterfaceDeclaration[@SimpleName='PropertiesMacro']
+      | //ClassDeclaration[@SimpleName='PropertiesMacro']
              //MethodDeclaration[@Name='getDefaultValue']
-      | //ClassOrInterfaceDeclaration[@SimpleName='SiteUtil']
+      | //ClassDeclaration[@SimpleName='SiteUtil']
                //MethodDeclaration[@Name='getDefaultValue']
-      | //ClassOrInterfaceDeclaration[@SimpleName='DescriptionExtractor']
+      | //ClassDeclaration[@SimpleName='DescriptionExtractor']
                //MethodDeclaration[@Name='getDescriptionFromJavadoc']"/>
-      "/>
+    </properties>
+  </rule>
+  <rule ref="category/java/design.xml/NcssCount">
+    <properties>
+      <property name="classReportLevel" value="1000" />
+      <!-- *TokenTypes are special classes that are big due to a lot of description comments.
+           RequireThisCheck has to work with and identify many frames.
+           JavadocMethodCheck is in the process of being rewritten.
+           SiteUtil provides a lot of functionality to generate documentation. -->
+      <property name="violationSuppressXPath"
+                value="//ClassDeclaration[@SimpleName='JavadocTokenTypes'
+        or @SimpleName='TokenTypes' or @SimpleName='RequireThisCheck'
+        or @SimpleName='JavadocMethodCheck' or @SimpleName='JavaAstVisitor'
+        or @SimpleName='SiteUtil']"/>
     </properties>
   </rule>
   <rule ref="category/java/design.xml/TooManyFields">
@@ -315,9 +321,9 @@
       <!-- Unable to split fields out of the class. -->
       <!-- Main has an annotated field for each command line option. This is by design. -->
       <property name="violationSuppressXPath"
-                value="//ClassOrInterfaceDeclaration[@SimpleName='Checker']
-    | //ClassOrInterfaceDeclaration[@SimpleName='Main']
-    | //ClassOrInterfaceDeclaration[@SimpleName='ImportOrderCheck']"/>
+                value="//ClassDeclaration[@SimpleName='Checker']
+      | //ClassDeclaration[@SimpleName='Main']
+      |  //ClassDeclaration[@SimpleName='ImportOrderCheck']"/>
     </properties>
   </rule>
   <rule ref="category/java/design.xml/TooManyMethods">
@@ -326,27 +332,14 @@
       <property name="maxmethods" value="34"/>
       <!-- JavaAstVisitor is a visitor class with methods for the entire Java grammar. -->
       <property name="violationSuppressXPath"
-                value="//ClassOrInterfaceDeclaration[@SimpleName='JavaAstVisitor']"/>
-    </properties>
-  </rule>
-  <rule ref="category/java/design.xml/ExcessiveClassLength">
-    <properties>
-      <!-- *TokenTypes are special classes that are big due to a lot of description comments.
-           RequireThisCheck has to work with and identify many frames.
-           JavadocMethodCheck is in the process of being rewritten.
-           SiteUtil provides a lot of functionality to generate documentation. -->
-      <property name="violationSuppressXPath"
-                value="//ClassOrInterfaceDeclaration[@SimpleName='JavadocTokenTypes'
-        or @SimpleName='TokenTypes' or @SimpleName='RequireThisCheck'
-        or @SimpleName='JavadocMethodCheck' or @SimpleName='JavaAstVisitor'
-        or @SimpleName='SiteUtil']"/>
+                value="//ClassDeclaration[@SimpleName='JavaAstVisitor']"/>
     </properties>
   </rule>
   <rule ref="category/java/design.xml/ExcessiveParameterList">
     <properties>
       <!-- The class Violation has a constructor with many parameters by design. -->
       <property name="violationSuppressXPath"
-                value="//ClassOrInterfaceDeclaration[@SimpleName='Violation']"/>
+                value="//ClassDeclaration[@SimpleName='Violation']"/>
     </properties>
   </rule>
   <rule ref="category/java/design.xml/ExcessiveImports">
@@ -358,7 +351,7 @@
            SiteUtil uses a lot of imports to provide logic for generating documentation
             -->
       <property name="violationSuppressXPath"
-                value="//ClassOrInterfaceDeclaration[@SimpleName='Main'
+                value="//ClassDeclaration[@SimpleName='Main'
         or @SimpleName='Checker' or @SimpleName='CheckstyleAntTask'
         or @SimpleName='TranslationCheck'
         or @SimpleName='AbstractAutomaticBean'
@@ -371,11 +364,11 @@
       <!-- Till https://github.com/checkstyle/checkstyle/issues/10064
            Splitting SiteUtil's methods will damage readability -->
       <property name="violationSuppressXPath"
-                value="//ClassOrInterfaceDeclaration[@SimpleName='XdocsPagesTest']
+                value="//ClassDeclaration[@SimpleName='XdocsPagesTest']
                     //MethodDeclaration[@Name='getModulePropertyExpectedValue']
-                    |  //ClassOrInterfaceDeclaration[@SimpleName='SiteUtil']
+                    |  //ClassDeclaration[@SimpleName='SiteUtil']
                     //MethodDeclaration[@Name='getDefaultValue']
-                    |  //ClassOrInterfaceDeclaration[@SimpleName='DescriptionExtractor']
+                    |  //ClassDeclaration[@SimpleName='DescriptionExtractor']
                     //MethodDeclaration[@Name='getDescriptionFromJavadoc']"/>
     </properties>
   </rule>
@@ -390,7 +383,7 @@
       overloads a synchronized method, so it should have synchronized
       modifier. -->
       <property name="violationSuppressXPath"
-                value="//ClassOrInterfaceDeclaration[@SimpleName='UniqueProperties'
+                value="//ClassDeclaration[@SimpleName='UniqueProperties'
           or @SimpleName='SequencedProperties']//MethodDeclaration[@Name='keys' or @Name='put']"/>
     </properties>
   </rule>
@@ -405,14 +398,14 @@
   <rule ref="category/java/design.xml/ExcessivePublicCount">
     <properties>
       <property name="violationSuppressXPath"
-                value="//ClassOrInterfaceDeclaration[@SimpleName='JavaAstVisitor']"/>
+                value="//ClassDeclaration[@SimpleName='JavaAstVisitor']"/>
     </properties>
   </rule>
 
   <rule ref="category/java/design.xml/NPathComplexity">
     <properties>
       <property name="violationSuppressXPath"
-                value="//ClassOrInterfaceDeclaration[@SimpleName='DescriptionExtractor']
+                value="//ClassDeclaration[@SimpleName='DescriptionExtractor']
                       //MethodDeclaration[@Name='getDescriptionFromJavadoc']"/>
     </properties>
   </rule>

--- a/pom.xml
+++ b/pom.xml
@@ -209,8 +209,8 @@
     <antlr4.version>4.13.1</antlr4.version>
     <maven.site.plugin.version>3.12.1</maven.site.plugin.version>
     <maven.spotbugs.plugin.version>4.8.5.0</maven.spotbugs.plugin.version>
-    <maven.pmd.plugin.version>3.21.2</maven.pmd.plugin.version>
-    <pmd.version>6.55.0</pmd.version>
+    <maven.pmd.plugin.version>3.22.0</maven.pmd.plugin.version>
+    <pmd.version>7.1.0</pmd.version>
     <maven.jacoco.plugin.version>0.8.12</maven.jacoco.plugin.version>
     <mockito.version>5.2.0</mockito.version>
     <saxon.version>12.4</saxon.version>

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/imports/ImportOrderCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/imports/ImportOrderCheckTest.java
@@ -818,7 +818,7 @@ public class ImportOrderCheckTest extends AbstractModuleTestSupport {
         assertWithMessage("State is not cleared on beginTree")
                 .that(TestUtil.isStatefulFieldClearedDuringBeginTree(check,
                         staticImport.orElseThrow(), "lastImportStatic",
-                        lastImportStatic -> !((boolean) lastImportStatic)))
+                        lastImportStatic -> !(boolean) lastImportStatic))
                 .isTrue();
 
     }


### PR DESCRIPTION
```
[INFO] BUILD FAILURE
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  01:34 min
[INFO] Finished at: 2024-05-04T02:56:07+02:00
[INFO] ------------------------------------------------------------------------
[ERROR] Failed to execute goal org.apache.maven.plugins:maven-pmd-plugin:3.22.0:pmd (pmd) on project checkstyle: Execution pmd of goal org.apache.maven.plugins:maven-pmd-plugin:3.22.0:pmd failed: org.apache.maven.reporting.MavenReportException: The ruleset could not be loaded: Cannot load ruleset config/pmd.xml: An XML validation error occurred -> [Help 1]  
[ERROR]
```


I assumed that this is because we using [rules that were removed](https://docs.pmd-code.org/latest/pmd_release_notes_pmd7.html#removed-rules) in the latest pmd releases but even after the removal from pmd.xml, the issue is not fixed.
any ideas for why we got this XML validation error?