### PR TITLE
Issue #14631: Updated exception_literal to new AST format

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/api/JavadocTokenTypes.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/api/JavadocTokenTypes.java
@@ -287,13 +287,13 @@ public final class JavadocTokenTypes {
      * <pre>{@code @exception SQLException if query is not correct}</pre>
      * <b>Tree:</b>
      * <pre>{@code
-     *   |--JAVADOC_TAG[3x0] : [@exception SQLException if query is not correct]
-     *       |--EXCEPTION_LITERAL[3x0] : [@exception]
-     *       |--WS[3x10] : [ ]
-     *       |--CLASS_NAME[3x11] : [SQLException]
-     *       |--WS[3x23] : [ ]
-     *       |--DESCRIPTION[3x24] : [if query is not correct]
-     *           |--TEXT[3x24] : [if query is not correct]
+     *   JAVADOC_TAG -> JAVADOC_TAG
+     *    |--EXCEPTION_LITERAL -> @exception
+     *    |--WS ->
+     *    |--CLASS_NAME -> SQLException
+     *    |--WS ->
+     *    `--DESCRIPTION -> DESCRIPTION
+     *        `--TEXT -> if query is not correct
      * }</pre>
      *
      * @see


### PR DESCRIPTION
Issue: #14631 

```
SteLeo@DESKTOP-11C7U5R MINGW64 ~/exception_literal test
$ cat Test.java
* @exception SQLException if query is not correct
SteLeo@DESKTOP-11C7U5R MINGW64 ~/exception_literal test
$ java -jar checkstyle-10.16.0-all.jar -j Test.java | sed "s/\[[0-9]\+:[0-9]\+\]//g"
JAVADOC -> JAVADOC
|--LEADING_ASTERISK -> *
|--WS ->
|--JAVADOC_TAG -> JAVADOC_TAG
|   |--EXCEPTION_LITERAL -> @exception
|   |--WS ->
|   |--CLASS_NAME -> SQLException
|   |--WS ->
|   `--DESCRIPTION -> DESCRIPTION
|       `--TEXT -> if query is not correct
`--EOF -> <EOF>

SteLeo@DESKTOP-11C7U5R MINGW64 ~/exception_literal test
$
```
