### PR TITLE
infra: make --list for validation.sh

### DIFF
--- a/.ci/validation.sh
+++ b/.ci/validation.sh
@@ -18,6 +18,10 @@ addCheckstyleBundleToAntResolvers() {
     ivysettings.xml
 }
 
+function list_tasks() {
+  cat "${0}" | sed -E -n 's/^([a-zA-Z0-9\-]*)\)$/\1/p' | sort
+}
+
 case $1 in
 
 all-sevntu-checks)
@@ -1216,7 +1220,8 @@ check-wildcards-on-pitest-target-classes)
 
 *)
   echo "Unexpected argument: $1"
-  sleep 5s
+  echo "Supported tasks:"
+  list_tasks "${0}"
   false
   ;;
 


### PR DESCRIPTION
do it like just
```
✔ ~/java/github/romani/checkstyle
 $ ./.ci/validation.sh --list
Supported tasks:
all-sevntu-checks
assembly-run-all-jar
check-missing-pitests
check-since-version
checkstyle-and-sevntu
check-wildcards-on-pitest-target-classes
ci-temp-check
eclipse-static-analysis
git-check-pull-number
git-diff
git-no-merge-commits
jacoco
javac11
javac14
javac15
javac16
javac17
javac19
javac20
javac21
--list
markdownlint
no-error-checkstyles-sevntu
no-error-contribution
no-error-equalsverifier
no-error-hibernate-search
no-error-htmlunit
no-error-methods-distance
no-error-orekit
no-error-pgjdbc
no-error-pmd
no-error-sevntu-checks
no-error-spotbugs
no-error-spring-cloud-gcp
no-error-spring-integration
no-error-strata
no-error-test-sbe
no-error-xwiki
no-exception-alot-of-projects
no-exception-checkstyle-sevntu
no-exception-checkstyle-sevntu-javadoc
no-exception-guava
no-exception-hbase
no-exception-hibernate-orm
no-exception-Pmd-elasticsearch-lombok-ast
no-exception-spoon
no-exception-spotbugs
no-exception-spring-framework
no-exception-struts
nondex
no-violation-test-configurate
no-violation-test-josm
no-warning-imports-guava
no-warning-imports-java-design-patterns
package-site
pr-age
release-dry-run
site
sonarqube
spotbugs-and-pmd
test
test-al
test-de
test-es
test-fi
test-fr
test-ja
test-pt
test-ru
test-tr
test-zh
verify-no-exception-configs
verify-regexp-id
versions

```