### PR TITLE
Issue #14573: fix javadoc type check for empty tags

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocTypeCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocTypeCheck.java
@@ -379,10 +379,9 @@ public class JavadocTypeCheck
         final JavadocTags tags = JavadocUtil.getJavadocTags(textBlock,
             JavadocUtil.JavadocTagType.BLOCK);
         if (!allowUnknownTags) {
-            for (final InvalidJavadocTag tag : tags.getInvalidTags()) {
-                log(tag.getLine(), tag.getCol(), MSG_UNKNOWN_TAG,
-                    tag.getName());
-            }
+            tags.getInvalidTags().forEach(tag -> {
+                log(tag.getLine(), tag.getCol(), MSG_UNKNOWN_TAG, tag.getName());
+            });
         }
         return tags.getValidTags();
     }
@@ -481,11 +480,16 @@ public class JavadocTypeCheck
                         || recordComponentNames.contains(paramName);
 
                 if (!found) {
-                    final String actualParamName =
-                        TYPE_NAME_IN_JAVADOC_TAG_SPLITTER.split(tag.getFirstArg())[0];
-                    log(tag.getLineNo(), tag.getColumnNo(),
-                        MSG_UNUSED_TAG,
-                        JavadocTagInfo.PARAM.getText(), actualParamName);
+                    if (paramName.isEmpty()) {
+                        log(tag.getLineNo(), tag.getColumnNo(), MSG_UNUSED_TAG_GENERAL);
+                    }
+                    else {
+                        final String actualParamName =
+                            TYPE_NAME_IN_JAVADOC_TAG_SPLITTER.split(tag.getFirstArg())[0];
+                        log(tag.getLineNo(), tag.getColumnNo(),
+                            MSG_UNUSED_TAG,
+                            JavadocTagInfo.PARAM.getText(), actualParamName);
+                    }
                 }
             }
         }

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/utils/BlockTagUtil.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/utils/BlockTagUtil.java
@@ -34,11 +34,11 @@ public final class BlockTagUtil {
 
     /** Block tag pattern for a first line. */
     private static final Pattern BLOCK_TAG_PATTERN_FIRST_LINE = Pattern.compile(
-        "/\\*{2,}\\s*@(\\p{Alpha}+)\\s");
+        "/\\*{2,}\\s*@(\\p{Alpha}+)(\\s|$)");
 
     /** Block tag pattern. */
     private static final Pattern BLOCK_TAG_PATTERN = Pattern.compile(
-        "^\\s*\\**\\s*@(\\p{Alpha}+)\\s");
+        "^\\s*\\**\\s*@(\\p{Alpha}+)(\\s|$)");
 
     /** Closing tag. */
     private static final String JAVADOC_CLOSING_TAG = "*/";

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocTypeCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocTypeCheckTest.java
@@ -24,6 +24,7 @@ import static com.puppycrawl.tools.checkstyle.checks.javadoc.JavadocTypeCheck.MS
 import static com.puppycrawl.tools.checkstyle.checks.javadoc.JavadocTypeCheck.MSG_TAG_FORMAT;
 import static com.puppycrawl.tools.checkstyle.checks.javadoc.JavadocTypeCheck.MSG_UNKNOWN_TAG;
 import static com.puppycrawl.tools.checkstyle.checks.javadoc.JavadocTypeCheck.MSG_UNUSED_TAG;
+import static com.puppycrawl.tools.checkstyle.checks.javadoc.JavadocTypeCheck.MSG_UNUSED_TAG_GENERAL;
 
 import org.junit.jupiter.api.Test;
 
@@ -253,6 +254,7 @@ public class JavadocTypeCheckTest extends AbstractModuleTestSupport {
             "59:8: " + getCheckMessage(MSG_UNUSED_TAG, "@param", "<C>"),
             "62:5: " + getCheckMessage(MSG_MISSING_TAG, "@param <B>"),
             "75:5: " + getCheckMessage(MSG_UNUSED_TAG, "@param", "x"),
+            "79:5: " + getCheckMessage(MSG_UNUSED_TAG_GENERAL, "@param"),
         };
         verifyWithInlineConfigParser(
                 getPath("InputJavadocTypeTypeParamsTags_1.java"), expected);
@@ -274,6 +276,7 @@ public class JavadocTypeCheckTest extends AbstractModuleTestSupport {
         final String[] expected = {
             "20:4: " + getCheckMessage(MSG_UNUSED_TAG, "@param", "BAD"),
             "21:4: " + getCheckMessage(MSG_UNUSED_TAG, "@param", "<BAD>"),
+            "23:4: " + getCheckMessage(MSG_UNUSED_TAG_GENERAL, "@param"),
         };
         verifyWithInlineConfigParser(
                 getPath("InputJavadocTypeUnusedParamInJavadocForClass.java"),
@@ -284,6 +287,8 @@ public class JavadocTypeCheckTest extends AbstractModuleTestSupport {
     public void testBadTag() throws Exception {
         final String[] expected = {
             "19:4: " + getCheckMessage(MSG_UNKNOWN_TAG, "mytag"),
+            "21:4: " + getCheckMessage(MSG_UNKNOWN_TAG, "mytag"),
+            "28:5: " + getCheckMessage(MSG_UNKNOWN_TAG, "mytag"),
         };
         verifyWithInlineConfigParser(
                 getPath("InputJavadocTypeBadTag.java"),

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/javadoc/utils/BlockTagUtilTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/javadoc/utils/BlockTagUtilTest.java
@@ -43,13 +43,14 @@ public class BlockTagUtilTest {
             " * @bar def  ",
             "   @baz ghi  ",
             " * @qux jkl",
+            " * @mytag",
             " */",
         };
 
         final List<TagInfo> tags = BlockTagUtil.extractBlockTags(text);
         assertWithMessage("Invalid tags size")
             .that(tags)
-            .hasSize(4);
+            .hasSize(5);
 
         final TagInfo tag1 = tags.get(0);
         assertTagEquals(tag1, "foo", "abc", 1, 4);
@@ -62,6 +63,25 @@ public class BlockTagUtilTest {
 
         final TagInfo tag4 = tags.get(3);
         assertTagEquals(tag4, "qux", "jkl", 4, 3);
+
+        final TagInfo tag5 = tags.get(4);
+        assertTagEquals(tag5, "mytag", "", 5, 3);
+    }
+
+    @Test
+    public void testExtractBlockTagFirstLine() {
+        final String[] text = {
+            "/** @foo",
+            " */",
+        };
+
+        final List<TagInfo> tags = BlockTagUtil.extractBlockTags(text);
+        assertWithMessage("Invalid tags size")
+            .that(tags)
+            .hasSize(1);
+
+        final TagInfo tag1 = tags.get(0);
+        assertTagEquals(tag1, "foo", "", 1, 4);
     }
 
     @Test

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadoctype/InputJavadocTypeBadTag.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadoctype/InputJavadocTypeBadTag.java
@@ -17,7 +17,14 @@ package com.puppycrawl.tools.checkstyle.checks.javadoc.javadoctype;
 /**
  * The following is a bad tag.
  * @mytag Hello   // violation 'Unknown tag 'mytag'.'
+ * // violation below 'Unknown tag 'mytag''
+ * @mytag
  */
 public class InputJavadocTypeBadTag
 {
 }
+
+// violation below 'Unknown tag 'mytag''
+/** @mytag
+ */
+class InputJavadocTypeBadTagFirstLine {}

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadoctype/InputJavadocTypeTypeParamsTags_1.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadoctype/InputJavadocTypeTypeParamsTags_1.java
@@ -74,3 +74,8 @@ public class InputJavadocTypeTypeParamsTags_1<A,B1,C456 extends Comparable>
 
 /** @param x */  // violation 'Unused @param tag for 'x'.'
 class Test_1 {}
+
+// violation below 'Unused Javadoc tag'
+/** @param
+ * */
+class Test_2 {}

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadoctype/InputJavadocTypeUnusedParamInJavadocForClass.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadoctype/InputJavadocTypeUnusedParamInJavadocForClass.java
@@ -19,6 +19,7 @@ package com.puppycrawl.tools.checkstyle.checks.javadoc.javadoctype;
  *
  * @param BAD This is bad.   // violation 'Unused @param tag for 'BAD'.'
  * @param <BAD> This doesn't exist.   // violation 'Unused @param tag for '<BAD>'.'
+ * // violation below 'Unused Javadoc tag'
  * @param
  */
 public class InputJavadocTypeUnusedParamInJavadocForClass {


### PR DESCRIPTION
Closes #14573

Diff Regression config: https://gist.githubusercontent.com/strkkk/26466254f89c32d8f1a6bd53b6f5b251/raw/cf451b3aa6366addc027a08423786d455bc79aa7/config_single.xml
