### PR TITLE
Issue #14908: Renamed section 4.1.1 and created test cases for lambdas

### DIFF
--- a/config/checkstyle-resources-suppressions.xml
+++ b/config/checkstyle-resources-suppressions.xml
@@ -809,7 +809,7 @@
   <suppress checks="FileLength"
     files="[\\/]it[\\/]resources[\\/]com[\\/]google[\\/]checkstyle[\\/]test[\\/]chapter7javadoc[\\/]rule713atclauses[\\/]InputJavaDocTagContinuationIndentation\.java"/>
   <suppress checks="FileLength"
-    files="[\\/]it[\\/]resources[\\/]com[\\/]google[\\/]checkstyle[\\/]test[\\/]chapter4formatting[\\/]rule411bracesareused[\\/]InputNeedBraces\.java"/>
+    files="[\\/]it[\\/]resources[\\/]com[\\/]google[\\/]checkstyle[\\/]test[\\/]chapter4formatting[\\/]rule411optionalbracesusage[\\/]InputNeedBraces\.java"/>
   <suppress checks="FileLength"
     files="[\\/]it[\\/]resources[\\/]com[\\/]google[\\/]checkstyle[\\/]test[\\/]chapter4formatting[\\/]rule4861blockcommentstyle[\\/]InputCommentsIndentationCommentIsAtTheEndOfBlock\.java"/>
   <suppress checks="FileLength"

--- a/config/jsoref-spellchecker/whitelist.words
+++ b/config/jsoref-spellchecker/whitelist.words
@@ -129,7 +129,6 @@ BNOT
 booleanexpressioncomplexity
 bothfiles
 Bpmn
-bracesareused
 breadcrumbs
 BSR
 Bsubscribe
@@ -976,6 +975,7 @@ openstreetmap
 operatorwrap
 optgroup
 optimisation
+optionalbracesusage
 OQ
 orderedproperties
 orderingandspacing

--- a/src/it/java/com/google/checkstyle/test/chapter4formatting/rule411optionalbracesusage/NeedBracesTest.java
+++ b/src/it/java/com/google/checkstyle/test/chapter4formatting/rule411optionalbracesusage/NeedBracesTest.java
@@ -17,7 +17,7 @@
 // Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 ///////////////////////////////////////////////////////////////////////////////////////////////
 
-package com.google.checkstyle.test.chapter4formatting.rule411bracesareused;
+package com.google.checkstyle.test.chapter4formatting.rule411optionalbracesusage;
 
 import org.junit.jupiter.api.Test;
 
@@ -29,7 +29,7 @@ public class NeedBracesTest extends AbstractGoogleModuleTestSupport {
 
     @Override
     protected String getPackageLocation() {
-        return "com/google/checkstyle/test/chapter4formatting/rule411bracesareused";
+        return "com/google/checkstyle/test/chapter4formatting/rule411optionalbracesusage";
     }
 
     @Test
@@ -55,27 +55,27 @@ public class NeedBracesTest extends AbstractGoogleModuleTestSupport {
             "97:9: " + getCheckMessage(clazz, messageKey, "else"),
             "99:9: " + getCheckMessage(clazz, messageKey, "if"),
             "100:13: " + getCheckMessage(clazz, messageKey, "if"),
-            "126:9: " + getCheckMessage(clazz, messageKey, "while"),
-            "129:9: " + getCheckMessage(clazz, messageKey, "do"),
-            "135:9: " + getCheckMessage(clazz, messageKey, "if"),
-            "138:9: " + getCheckMessage(clazz, messageKey, "if"),
-            "139:9: " + getCheckMessage(clazz, messageKey, "else"),
-            "144:9: " + getCheckMessage(clazz, messageKey, "for"),
-            "147:9: " + getCheckMessage(clazz, messageKey, "for"),
-            "157:13: " + getCheckMessage(clazz, messageKey, "while"),
-            "160:13: " + getCheckMessage(clazz, messageKey, "do"),
-            "166:13: " + getCheckMessage(clazz, messageKey, "if"),
-            "169:13: " + getCheckMessage(clazz, messageKey, "if"),
-            "170:13: " + getCheckMessage(clazz, messageKey, "else"),
-            "175:13: " + getCheckMessage(clazz, messageKey, "for"),
-            "178:13: " + getCheckMessage(clazz, messageKey, "for"),
-            "189:13: " + getCheckMessage(clazz, messageKey, "while"),
-            "192:13: " + getCheckMessage(clazz, messageKey, "do"),
-            "198:13: " + getCheckMessage(clazz, messageKey, "if"),
-            "201:13: " + getCheckMessage(clazz, messageKey, "if"),
-            "202:13: " + getCheckMessage(clazz, messageKey, "else"),
-            "207:13: " + getCheckMessage(clazz, messageKey, "for"),
-            "210:13: " + getCheckMessage(clazz, messageKey, "for"),
+            "133:9: " + getCheckMessage(clazz, messageKey, "while"),
+            "136:9: " + getCheckMessage(clazz, messageKey, "do"),
+            "142:9: " + getCheckMessage(clazz, messageKey, "if"),
+            "145:9: " + getCheckMessage(clazz, messageKey, "if"),
+            "146:9: " + getCheckMessage(clazz, messageKey, "else"),
+            "151:9: " + getCheckMessage(clazz, messageKey, "for"),
+            "154:9: " + getCheckMessage(clazz, messageKey, "for"),
+            "164:13: " + getCheckMessage(clazz, messageKey, "while"),
+            "167:13: " + getCheckMessage(clazz, messageKey, "do"),
+            "173:13: " + getCheckMessage(clazz, messageKey, "if"),
+            "176:13: " + getCheckMessage(clazz, messageKey, "if"),
+            "177:13: " + getCheckMessage(clazz, messageKey, "else"),
+            "182:13: " + getCheckMessage(clazz, messageKey, "for"),
+            "185:13: " + getCheckMessage(clazz, messageKey, "for"),
+            "196:13: " + getCheckMessage(clazz, messageKey, "while"),
+            "199:13: " + getCheckMessage(clazz, messageKey, "do"),
+            "205:13: " + getCheckMessage(clazz, messageKey, "if"),
+            "208:13: " + getCheckMessage(clazz, messageKey, "if"),
+            "209:13: " + getCheckMessage(clazz, messageKey, "else"),
+            "214:13: " + getCheckMessage(clazz, messageKey, "for"),
+            "217:13: " + getCheckMessage(clazz, messageKey, "for"),
         };
 
         final Configuration checkConfig = getModuleConfig("NeedBraces");

--- a/src/it/resources/com/google/checkstyle/test/chapter4formatting/rule411optionalbracesusage/InputNeedBraces.java
+++ b/src/it/resources/com/google/checkstyle/test/chapter4formatting/rule411optionalbracesusage/InputNeedBraces.java
@@ -1,4 +1,4 @@
-package com.google.checkstyle.test.chapter4formatting.rule411bracesareused;
+package com.google.checkstyle.test.chapter4formatting.rule411optionalbracesusage;
 
 import java.io.*;
 import javax.script.*;
@@ -116,6 +116,13 @@ class InputNeedBraces
 
     /** Empty method block. **/
     public void emptyImplementation() {}
+
+    /** Testing Lambdas. **/
+    static Runnable r2 = ()-> String.CASE_INSENSITIVE_ORDER.equals("Hello world one!");
+    static Runnable r3 = ()->
+            String.CASE_INSENSITIVE_ORDER.equals("Hello world one!");
+    static Runnable r4 = ()-> { String.CASE_INSENSITIVE_ORDER.equals("Hello world one!"); };
+    static Runnable r5 = ()-> {};
 }
 
 class EmptyBlocks {

--- a/src/xdocs/google_style.xml
+++ b/src/xdocs/google_style.xml
@@ -620,8 +620,8 @@
                   </a>
                 </td>
                 <td>
-                  <a href="styleguides/google-java-style-20180523/javaguide.html#s4.1.1-braces-always-used">
-                    4.1.1 Braces are used where optional</a>
+                  <a href="styleguides/google-java-style-20220203/javaguide.html#s4.1.1-braces-always-used">
+                    4.1.1 Use of optional braces</a>
                 </td>
                 <td>
                   <span class="wrapper inline">
@@ -633,7 +633,7 @@
                   <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources%20path%3A**%2Fgoogle_checks.xml+repo%3Acheckstyle%2Fcheckstyle+NeedBraces">
                     config</a>
                   <br />
-                  <a href="https://github.com/checkstyle/checkstyle/blob/master/src/it/java/com/google/checkstyle/test/chapter4formatting/rule411bracesareused/NeedBracesTest.java">
+                  <a href="https://github.com/checkstyle/checkstyle/blob/master/src/it/java/com/google/checkstyle/test/chapter4formatting/rule411optionalbracesusage/NeedBracesTest.java">
                     test</a>
                 </td>
               </tr>


### PR DESCRIPTION
Issue #14908 

Renamed section `4.1.1` from ` Braces are used where optional` to `Use of optional braces` and referenced it to the new cached page.

Created test cases for lambdas to ensure that if we ever update config of this rule, we will be ignoring `lambdas` as per the newly paragraph added here:

https://github.com/checkstyle/checkstyle/pull/14901/files#diff-3f79fa1ed75e6db042f0bb87505b89c47280f86dc510d90ed8d039c77869ce33R264