### PR TITLE
Issue #14909: Renamed section 4.8.4.3 of google style guide implementation

### DIFF
--- a/config/jsoref-spellchecker/whitelist.words
+++ b/config/jsoref-spellchecker/whitelist.words
@@ -284,8 +284,8 @@ Ddry
 declarationorder
 Deconstruction
 defau
-defaultcasepresent
 defaultcomeslast
+defaultlabelpresence
 delims
 DENORMALIZER
 Depedency

--- a/src/it/java/com/google/checkstyle/test/chapter4formatting/rule4843defaultlabelpresence/MissingSwitchDefaultTest.java
+++ b/src/it/java/com/google/checkstyle/test/chapter4formatting/rule4843defaultlabelpresence/MissingSwitchDefaultTest.java
@@ -17,7 +17,7 @@
 // Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 ///////////////////////////////////////////////////////////////////////////////////////////////
 
-package com.google.checkstyle.test.chapter4formatting.rule4843defaultcasepresent;
+package com.google.checkstyle.test.chapter4formatting.rule4843defaultlabelpresence;
 
 import org.junit.jupiter.api.Test;
 
@@ -29,7 +29,7 @@ public class MissingSwitchDefaultTest extends AbstractGoogleModuleTestSupport {
 
     @Override
     protected String getPackageLocation() {
-        return "com/google/checkstyle/test/chapter4formatting/rule4843defaultcasepresent";
+        return "com/google/checkstyle/test/chapter4formatting/rule4843defaultlabelpresence";
     }
 
     @Test

--- a/src/it/resources/com/google/checkstyle/test/chapter4formatting/rule4843defaultlabelpresence/InputMissingSwitchDefault.java
+++ b/src/it/resources/com/google/checkstyle/test/chapter4formatting/rule4843defaultlabelpresence/InputMissingSwitchDefault.java
@@ -1,4 +1,4 @@
-package com.google.checkstyle.test.chapter4formatting.rule4843defaultcasepresent;
+package com.google.checkstyle.test.chapter4formatting.rule4843defaultlabelpresence;
 
 public class InputMissingSwitchDefault {
     public void foo() {

--- a/src/xdocs/google_style.xml
+++ b/src/xdocs/google_style.xml
@@ -1316,8 +1316,8 @@
                   </a>
                 </td>
                 <td>
-                  <a href="styleguides/google-java-style-20180523/javaguide.html#s4.8.4.3-switch-default">
-                    4.8.4.3 The default case is present</a>
+                  <a href="styleguides/google-java-style-20220203/javaguide.html#s4.8.4.3-switch-default">
+                    4.8.4.3 Presence of the default label</a>
                 </td>
                 <td>
                   <span class="wrapper inline">
@@ -1336,7 +1336,7 @@
                   <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources%20path%3A**%2Fgoogle_checks.xml+repo%3Acheckstyle%2Fcheckstyle+MissingSwitchDefault">
                     config</a>
                   <br />
-                  <a href="https://github.com/checkstyle/checkstyle/blob/master/src/it/java/com/google/checkstyle/test/chapter4formatting/rule4843defaultcasepresent/MissingSwitchDefaultTest.java">
+                  <a href="https://github.com/checkstyle/checkstyle/blob/master/src/it/java/com/google/checkstyle/test/chapter4formatting/rule4843defaultlabelpresence/MissingSwitchDefaultTest.java">
                     test</a>
                 </td>
               </tr>


### PR DESCRIPTION
Issue #14909 

Renamed section `4.8.4.3` of google style guide implementation from `The default case is present` to `Presence of the default label` and referenced to the new cached page.

Renamed test folder from `rule4843defaultcasepresent` to `rule4843defaultlabelpresence` also.