### PR TITLE
Issue #14907: Add support to check grouping of constructors in google style guide implementation

### DIFF
--- a/src/it/java/com/google/checkstyle/test/chapter3filestructure/rule3421overloadsplit/ConstructorsDeclarationGroupingTest.java
+++ b/src/it/java/com/google/checkstyle/test/chapter3filestructure/rule3421overloadsplit/ConstructorsDeclarationGroupingTest.java
@@ -1,0 +1,82 @@
+///////////////////////////////////////////////////////////////////////////////////////////////
+// checkstyle: Checks Java source code and other text files for adherence to a set of rules.
+// Copyright (C) 2001-2024 the original author or authors.
+//
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the GNU Lesser General Public
+// License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+//
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+// Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public
+// License along with this library; if not, write to the Free Software
+// Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+///////////////////////////////////////////////////////////////////////////////////////////////
+
+package com.google.checkstyle.test.chapter3filestructure.rule3421overloadsplit;
+
+import org.junit.jupiter.api.Test;
+
+import com.google.checkstyle.test.base.AbstractGoogleModuleTestSupport;
+import com.puppycrawl.tools.checkstyle.api.Configuration;
+import com.puppycrawl.tools.checkstyle.checks.coding.ConstructorsDeclarationGroupingCheck;
+
+public class ConstructorsDeclarationGroupingTest extends AbstractGoogleModuleTestSupport {
+
+    @Override
+    protected String getPackageLocation() {
+        return "com/google/checkstyle/test/chapter3filestructure/rule3421overloadsplit";
+    }
+
+    @Test
+    public void testOverloadConstructors() throws Exception {
+        final Class<ConstructorsDeclarationGroupingCheck> clazz =
+                ConstructorsDeclarationGroupingCheck.class;
+        final String messageKey = "constructors.declaration.grouping";
+
+        final String[] expected = {
+            "17:5: " + getCheckMessage(clazz, messageKey, 13),
+            "21:5: " + getCheckMessage(clazz, messageKey, 13),
+            "37:9: " + getCheckMessage(clazz, messageKey, 31),
+            "46:13: " + getCheckMessage(clazz, messageKey, 40),
+            "49:9: " + getCheckMessage(clazz, messageKey, 31),
+            "52:5: " + getCheckMessage(clazz, messageKey, 13),
+            "54:5: " + getCheckMessage(clazz, messageKey, 13),
+            "72:7: " + getCheckMessage(clazz, messageKey, 68),
+            "76:7: " + getCheckMessage(clazz, messageKey, 68),
+            "78:7: " + getCheckMessage(clazz, messageKey, 68),
+            "81:5: " + getCheckMessage(clazz, messageKey, 13),
+        };
+
+        final Configuration checkConfig = getModuleConfig("ConstructorsDeclarationGrouping");
+        final String filePath = getPath("InputConstructorsDeclarationGrouping.java");
+
+        final Integer[] warnList = getLinesWithWarn(filePath);
+        verify(checkConfig, filePath, expected, warnList);
+    }
+
+    @Test
+    public void testOverloadConstructorsRecords() throws Exception {
+        final Class<ConstructorsDeclarationGroupingCheck> clazz =
+                ConstructorsDeclarationGroupingCheck.class;
+        final String messageKey = "constructors.declaration.grouping";
+
+        final String[] expected = {
+            "14:9: " + getCheckMessage(clazz, messageKey, 6),
+            "16:9: " + getCheckMessage(clazz, messageKey, 6),
+            "20:9: " + getCheckMessage(clazz, messageKey, 6),
+            "36:9: " + getCheckMessage(clazz, messageKey, 30),
+        };
+
+        final Configuration checkConfig = getModuleConfig("ConstructorsDeclarationGrouping");
+        final String filePath =
+                getNonCompilablePath("InputConstructorsDeclarationGroupingRecords.java");
+
+        final Integer[] warnList = getLinesWithWarn(filePath);
+        verify(checkConfig, filePath, expected, warnList);
+    }
+}

--- a/src/it/java/com/google/checkstyle/test/chapter3filestructure/rule3421overloadsplit/OverloadMethodsDeclarationOrderTest.java
+++ b/src/it/java/com/google/checkstyle/test/chapter3filestructure/rule3421overloadsplit/OverloadMethodsDeclarationOrderTest.java
@@ -59,8 +59,8 @@ public class OverloadMethodsDeclarationOrderTest extends AbstractGoogleModuleTes
         final String[] expected = CommonUtil.EMPTY_STRING_ARRAY;
 
         final Configuration checkConfig = getModuleConfig("OverloadMethodsDeclarationOrder");
-        final String filePath = getPath(
-                "InputOverloadMethodsDeclarationOrderPrivateAndStaticMethods.java");
+        final String filePath =
+                getPath("InputOverloadMethodsDeclarationOrderPrivateAndStaticMethods.java");
 
         verify(checkConfig, filePath, expected);
     }

--- a/src/it/resources-noncompilable/com/google/checkstyle/test/chapter3filestructure/rule3421overloadsplit/InputConstructorsDeclarationGroupingRecords.java
+++ b/src/it/resources-noncompilable/com/google/checkstyle/test/chapter3filestructure/rule3421overloadsplit/InputConstructorsDeclarationGroupingRecords.java
@@ -1,0 +1,70 @@
+//non-compiled with javac: Compilable with Java17
+package com.puppycrawl.tools.checkstyle.checks.coding.constructorsdeclarationgrouping;
+
+public class InputConstructorsDeclarationGroupingRecords {
+    public record MyRecord1(int x, int y) {
+        public MyRecord1(int a) {
+            this(a,a);
+        }
+
+        void foo() {}
+
+        void foo2() {}
+
+        public MyRecord1 {} // warn
+
+        public MyRecord1(int a, int b, int c, int d) { // warn
+            this(a+b, c+d);
+        }
+
+        public MyRecord1(int x, int y, int z) { // warn
+            this(x+y, z);
+        }
+    }
+
+    class MyClass {
+        int x = 20;
+
+        MyClass() {}
+
+        MyClass(String s) {}
+
+        String[] str;
+
+        String[] str2;
+
+        MyClass(int a) {} // warn
+    }
+
+    public record MyRecord2(double d) {
+        public MyRecord2(double a, double b, double c) {
+            this(a+b+c);
+        }
+
+        public MyRecord2 {}
+
+        public MyRecord2(double a, double b) {
+            this(a+b);
+        }
+    }
+
+    public record MyRecord3(float f) {
+        public MyRecord3(float a, float b, float c) {
+            this(a+b+c);
+        }
+    }
+
+    public record MyRecord4(String str) {
+        public MyRecord4 {}
+    }
+
+    public record MyRecord5(long l) {
+        void test() {}
+
+        void test2() {}
+
+        void test3() {}
+    }
+
+    public record MyRecord6(String str, int x) {}
+}

--- a/src/it/resources/com/google/checkstyle/test/chapter3filestructure/rule3421overloadsplit/InputConstructorsDeclarationGrouping.java
+++ b/src/it/resources/com/google/checkstyle/test/chapter3filestructure/rule3421overloadsplit/InputConstructorsDeclarationGrouping.java
@@ -1,0 +1,113 @@
+package com.google.checkstyle.test.chapter3filestructure.rule3421overloadsplit;
+
+public class InputConstructorsDeclarationGrouping {
+
+    int a;
+
+    int b;
+
+    void foo() {}
+
+    InputConstructorsDeclarationGrouping() {}
+
+    InputConstructorsDeclarationGrouping(String a) {}
+
+    void foo2() {}
+
+    InputConstructorsDeclarationGrouping(int a) {} // warn
+
+    int abc;
+
+    InputConstructorsDeclarationGrouping(double x) {} // warn
+
+    private enum InnerEnum1 {
+
+        one;
+
+        int x;
+
+        InnerEnum1() {}
+
+        InnerEnum1(String f) {}
+
+        String str;
+
+        String str2;
+
+        InnerEnum1(int x) {} // warn
+
+        private abstract class Inner {
+            Inner() {}
+
+            int x;
+
+            String neko;
+
+            Inner(String g) {} // warn
+        }
+
+        InnerEnum1(double d) {} // warn
+    }
+
+    InputConstructorsDeclarationGrouping(float x) {} // warn
+
+    InputConstructorsDeclarationGrouping(long l) {} // warn
+
+    private class Inner {
+        Inner() {}
+
+        Inner(String str) {}
+
+        // Comments are allowed between constructors.
+        Inner(int x) {}
+    }
+
+    private class Inner2 {
+      Inner2() {}
+
+      Inner2(String str) {}
+
+      int x;
+
+      Inner2(int x) {} // warn
+
+      String xx;
+
+      Inner2(double d) {} // warn
+
+      Inner2(float f) {} // warn
+    }
+
+    InputConstructorsDeclarationGrouping(long l, double d) {} // warn
+
+    InputConstructorsDeclarationGrouping annoynmous = new InputConstructorsDeclarationGrouping() {
+        int x;
+        void test() {}
+        void test2() {}
+    };
+
+    private enum InnerEnum2 {
+        ONE,TWO,THREE;
+        void test() {}
+        void test2() {}
+        void test3() {}
+    }
+
+    private enum InnerEnum3 {
+        InnerEnum3() {}
+    }
+
+    private enum InnerEnum4 {}
+
+    private class Inner3 {
+        void test() {}
+        void test2() {}
+        void test3() {}
+    }
+
+    private class Inner4 {
+        Inner4() {}
+    }
+
+    private class Inner5 {}
+}

--- a/src/main/resources/google_checks.xml
+++ b/src/main/resources/google_checks.xml
@@ -268,6 +268,7 @@
     </module>
     <module name="NoWhitespaceBeforeCaseDefaultColon"/>
     <module name="OverloadMethodsDeclarationOrder"/>
+    <module name="ConstructorsDeclarationGrouping"/>
     <module name="VariableDeclarationUsageDistance"/>
     <module name="CustomImportOrder">
       <property name="sortImportsInGroupAlphabetically" value="true"/>

--- a/src/xdocs/checks/coding/constructorsdeclarationgrouping.xml
+++ b/src/xdocs/checks/coding/constructorsdeclarationgrouping.xml
@@ -109,6 +109,10 @@ public class Example2 {
             <a href="https://github.com/search?q=path%3Aconfig%20path%3A**%2Fcheckstyle-checks.xml+repo%3Acheckstyle%2Fcheckstyle+ConstructorsDeclarationGrouping">
             Checkstyle Style</a>
           </li>
+          <li>
+            <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources%20path%3A**%2Fgoogle_checks.xml+repo%3Acheckstyle%2Fcheckstyle+ConstructorsDeclarationGrouping">
+            Google Style</a>
+          </li>
         </ul>
       </subsection>
 

--- a/src/xdocs/checks/coding/constructorsdeclarationgrouping.xml.template
+++ b/src/xdocs/checks/coding/constructorsdeclarationgrouping.xml.template
@@ -52,6 +52,10 @@
             <a href="https://github.com/search?q=path%3Aconfig%20path%3A**%2Fcheckstyle-checks.xml+repo%3Acheckstyle%2Fcheckstyle+ConstructorsDeclarationGrouping">
             Checkstyle Style</a>
           </li>
+          <li>
+            <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources%20path%3A**%2Fgoogle_checks.xml+repo%3Acheckstyle%2Fcheckstyle+ConstructorsDeclarationGrouping">
+            Google Style</a>
+          </li>
         </ul>
       </subsection>
 

--- a/src/xdocs/google_style.xml
+++ b/src/xdocs/google_style.xml
@@ -561,7 +561,7 @@
                   </a>
                 </td>
                 <td>
-                  <a href="styleguides/google-java-style-20180523/javaguide.html#s3.4.2.1-overloads-never-split">
+                  <a href="styleguides/google-java-style-20220203/javaguide.html#s3.4.2.1-overloads-never-split">
                     3.4.2.1 Overloads: never split</a>
                 </td>
                 <td>
@@ -570,6 +570,13 @@
                   </span>
                   <a href="checks/coding/overloadmethodsdeclarationorder.html#OverloadMethodsDeclarationOrder">
                     OverloadMethodsDeclarationOrder</a>
+                  <br />
+                  <br />
+                  <span class="wrapper inline">
+                    <img src="images/ok_green.png" alt="" />
+                  </span>
+                  <a href="checks/coding/constructorsdeclarationgrouping.html#ConstructorsDeclarationGrouping">
+                    ConstructorsDeclarationGrouping</a>
                 </td>
                 <td>
                   <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources%20path%3A**%2Fgoogle_checks.xml+repo%3Acheckstyle%2Fcheckstyle+OverloadMethodsDeclarationOrder">
@@ -577,6 +584,13 @@
                   <br />
                   <a href="https://github.com/checkstyle/checkstyle/blob/master/src/it/java/com/google/checkstyle/test/chapter3filestructure/rule3421overloadsplit/OverloadMethodsDeclarationOrderTest.java">
                     test</a>
+                  <br />
+                  <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources%20path%3A**%2Fgoogle_checks.xml+repo%3Acheckstyle%2Fcheckstyle+ConstructorsDeclarationGrouping">
+                    config</a>
+                  <br />
+                  <a href="https://github.com/checkstyle/checkstyle/blob/master/src/it/java/com/google/checkstyle/test/chapter3filestructure/rule3421overloadsplit/ConstructorsDeclarationGroupingTest.java">
+                    test</a>
+                  <br />
                 </td>
               </tr>
               <tr>


### PR DESCRIPTION
Issue #14907 

This PR contains following:
- Added [ConstructorsDeclarationGrouping](https://checkstyle.org/checks/coding/constructorsdeclarationgrouping.html#ConstructorsDeclarationGrouping) module in google_checks.xml.
- Created test cases for it.
- Updated the coverage page, added new config & test links and updated the style guide reference to the new cached page.