### PR TITLE
Issue #14910: Add new section 4.8.5.2 in google style guide implementation

### DIFF
--- a/config/jsoref-spellchecker/whitelist.words
+++ b/config/jsoref-spellchecker/whitelist.words
@@ -197,6 +197,7 @@ cimg
 Cinit
 circleci
 cirrusci
+classannotations
 classdataabstractioncoupling
 classfanoutcomplexity
 classloader

--- a/config/sevntu-suppressions.xml
+++ b/config/sevntu-suppressions.xml
@@ -39,6 +39,7 @@
 
   <!-- Suppressed alternative method of pulling partial configuration from file -->
   <suppress checks="CheckstyleTestMakeup" files="[\\/]RightCurlyTest\.java"/>
+  <suppress checks="CheckstyleTestMakeup" files="[\\/]ClassAnnotationsTest\.java"/>
 
   <!-- No need for constructor with cause -->
   <suppress checks="CauseParameterInException" files=".*MetadataGenerationException\.java"/>

--- a/src/it/java/com/google/checkstyle/test/chapter4formatting/rule4852classannotations/ClassAnnotationsTest.java
+++ b/src/it/java/com/google/checkstyle/test/chapter4formatting/rule4852classannotations/ClassAnnotationsTest.java
@@ -1,0 +1,68 @@
+///////////////////////////////////////////////////////////////////////////////////////////////
+// checkstyle: Checks Java source code and other text files for adherence to a set of rules.
+// Copyright (C) 2001-2024 the original author or authors.
+//
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the GNU Lesser General Public
+// License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+//
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+// Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public
+// License along with this library; if not, write to the Free Software
+// Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+///////////////////////////////////////////////////////////////////////////////////////////////
+
+package com.google.checkstyle.test.chapter4formatting.rule4852classannotations;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+
+import com.google.checkstyle.test.base.AbstractGoogleModuleTestSupport;
+import com.puppycrawl.tools.checkstyle.api.Configuration;
+import com.puppycrawl.tools.checkstyle.checks.annotation.AnnotationLocationCheck;
+import com.puppycrawl.tools.checkstyle.checks.javadoc.InvalidJavadocPositionCheck;
+
+public class ClassAnnotationsTest extends AbstractGoogleModuleTestSupport {
+
+    @Override
+    protected String getPackageLocation() {
+        return "com/google/checkstyle/test/chapter4formatting/rule4852classannotations";
+    }
+
+    @Test
+    public void testAnnotation() throws Exception {
+        final Class<AnnotationLocationCheck> clazz1 = AnnotationLocationCheck.class;
+        final Class<InvalidJavadocPositionCheck> clazz2 = InvalidJavadocPositionCheck.class;
+
+        final Configuration annotationConfig = getModuleConfig("AnnotationLocation",
+                "AnnotationLocationMostCases");
+        final Configuration invalidJavadocPositionConfig =
+                getModuleConfig("InvalidJavadocPosition");
+        final List<Configuration> childrenConfigs = new ArrayList<>();
+        childrenConfigs.add(annotationConfig);
+        childrenConfigs.add(invalidJavadocPositionConfig);
+        final Configuration treeWalkerConfig = createTreeWalkerConfig(childrenConfigs);
+
+        final String annotationAloneMsg = "annotation.location.alone";
+        final String invalidJavadocPositionMsg = "invalid.position";
+
+        final String[] expected = {
+            "17:5: " + getCheckMessage(clazz2, invalidJavadocPositionMsg),
+            "25:22: " + getCheckMessage(clazz1, annotationAloneMsg, "SomeAnnotation2"),
+            "28:22: " + getCheckMessage(clazz1, annotationAloneMsg, "SomeAnnotation2"),
+            "29:5: " + getCheckMessage(clazz2, invalidJavadocPositionMsg),
+        };
+
+        final String filePath = getPath("InputClassAnnotations.java");
+
+        final Integer[] warnList = getLinesWithWarn(filePath);
+        verify(treeWalkerConfig, filePath, expected, warnList);
+    }
+}

--- a/src/it/resources/com/google/checkstyle/test/chapter4formatting/rule4852classannotations/InputClassAnnotations.java
+++ b/src/it/resources/com/google/checkstyle/test/chapter4formatting/rule4852classannotations/InputClassAnnotations.java
@@ -1,0 +1,33 @@
+package com.google.checkstyle.test.chapter4formatting.rule4852classannotations;
+
+public class InputClassAnnotations {
+    public @interface SomeAnnotation1 { }
+
+    public @interface SomeAnnotation2 { }
+
+    /**
+     * Inner class 2.
+     */
+    @SomeAnnotation1
+    @SomeAnnotation2
+    class Inner1 {}
+
+    @SomeAnnotation1
+    @SomeAnnotation2
+    /** // warn
+     * Inner class 2.
+     */
+    class Inner2 {}
+
+    /**
+     * Inner class 3.
+     */
+    @SomeAnnotation1 @SomeAnnotation2 // warn
+    class Inner3 {}
+
+    @SomeAnnotation1 @SomeAnnotation2 // warn
+    /** // warn
+     * Inner class 4.
+     */
+    class Inner4 {}
+}

--- a/src/test/java/com/puppycrawl/tools/checkstyle/internal/XdocsPagesTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/internal/XdocsPagesTest.java
@@ -226,6 +226,62 @@ public class XdocsPagesTest {
     private static final Set<String> GOOGLE_MODULES = Collections.unmodifiableSet(
         CheckUtil.getConfigGoogleStyleModules());
 
+    // Contains all the sections which are not migrated to chapter wise testing
+    // in google style documentation.
+    // This list will be removed once all the sections are migrated.
+    // until https://github.com/checkstyle/checkstyle/issues/14937
+    private static final Set<String> PER_MODULE_TESTS_RULES_LIST = Set.of(
+            "2.1 File name",
+            "2.3.1 Whitespace characters",
+            "2.3.2 Special escape sequences",
+            "2.3.3 Non-ASCII characters",
+            "3 Source file structure",
+            "3.2 Package statement",
+            "3.3.1 No wildcard imports",
+            "3.3.2 No line-wrapping",
+            "3.3.3 Ordering and spacing",
+            "3.4.1 Exactly one top-level class declaration",
+            "3.4.2.1 Overloads: never split",
+            "4.1.1 Use of optional braces",
+            "4.1.2 Nonempty blocks: K & R style",
+            "4.1.3 Empty blocks: may be concise",
+            "4.2 Block indentation: +2 spaces",
+            "4.3 One statement per line",
+            "4.4 Column limit: 100",
+            "4.5.1 Where to break",
+            "4.5.2 Indent continuation lines at least +4 spaces",
+            "4.6.1 Vertical Whitespace",
+            "4.6.2 Horizontal whitespace",
+            "4.8.2.1 One variable per declaration",
+            "4.8.2.2 Declared when needed",
+            "4.8.3.2 No C-style array declarations",
+            "4.8.4.1 Indentation",
+            "4.8.4.2 Fall-through: commented",
+            "4.8.4.3 Presence of the default label",
+            "4.8.5 Annotations",
+            "4.8.6.1 Block comment style",
+            "4.8.7 Modifiers",
+            "4.8.8 Numeric Literals",
+            "5.2.1 Package names",
+            "5.2.2 Class names",
+            "5.2.3 Method names",
+            "5.2.5 Non-constant field names",
+            "5.2.6 Parameter names",
+            "5.2.7 Local variable names",
+            "5.2.8 Type variable names",
+            "5.3 Camel case: defined",
+            "6.2 Caught exceptions: not ignored",
+            "6.4 Finalizers: not used",
+            "7.1.1 General form",
+            "7.1.2 Paragraphs",
+            "7.1.3 Block tags",
+            "7.2 The summary fragment",
+            "7.3 Where Javadoc is used",
+            "7.3.1 Exception: self-explanatory methods",
+            "7.3.2 Exception: overrides",
+            "7.3.4 Non-required Javadoc"
+    );
+
     /**
      * Generate xdoc content from templates before validation.
      * This method will be removed once
@@ -1773,16 +1829,30 @@ public class XdocsPagesTest {
             Set<String> styleChecks, String styleName, String ruleName) {
         final Iterator<Node> itrChecks = checks.iterator();
         final Iterator<Node> itrConfigs = configs.iterator();
+        final boolean isRegularDocumentation = "sun".equals(styleName)
+               || "google".equals(styleName) && PER_MODULE_TESTS_RULES_LIST.contains(ruleName);
 
+        if (isRegularDocumentation) {
+            validateModuleWiseTesting(itrChecks, itrConfigs, styleChecks, styleName, ruleName);
+        }
+        else {
+            validateChapterWiseTesting(itrChecks, itrConfigs, styleChecks, styleName, ruleName);
+        }
+
+        assertWithMessage(styleName + "_style.xml rule '" + ruleName + "' has too many configs")
+                .that(itrConfigs.hasNext())
+                .isFalse();
+    }
+
+    private static void validateModuleWiseTesting(Iterator<Node> itrChecks,
+          Iterator<Node> itrConfigs, Set<String> styleChecks, String styleName, String ruleName) {
         while (itrChecks.hasNext()) {
             final Node module = itrChecks.next();
             final String moduleName = module.getTextContent().trim();
             final String href = module.getAttributes().getNamedItem("href").getTextContent();
-            // until https://github.com/checkstyle/checkstyle/issues/13132
-            final boolean moduleIsConfig = href.startsWith("config_");
             final boolean moduleIsCheck = href.startsWith("checks/");
 
-            if (!moduleIsConfig && !moduleIsCheck) {
+            if (!moduleIsCheck) {
                 continue;
             }
 
@@ -1842,10 +1912,91 @@ public class XdocsPagesTest {
                 }
             }
         }
+    }
 
-        assertWithMessage(styleName + "_style.xml rule '" + ruleName + "' has too many configs")
-                .that(itrConfigs.hasNext())
+    private static void validateChapterWiseTesting(Iterator<Node> itrChecks,
+          Iterator<Node> itrConfigs, Set<String> styleChecks, String styleName, String ruleName) {
+        boolean hasChecks = false;
+
+        while (itrChecks.hasNext()) {
+            final Node module = itrChecks.next();
+            final String moduleName = module.getTextContent().trim();
+            final String href = module.getAttributes().getNamedItem("href").getTextContent();
+            final boolean moduleIsCheck = href.startsWith("checks/");
+
+            if (!moduleIsCheck) {
+                continue;
+            }
+
+            hasChecks = true;
+
+            assertWithMessage(styleName + "_style.xml rule '" + ruleName + "' module '"
+                    + moduleName + "' shouldn't end with 'Check'")
+                    .that(moduleName.endsWith("Check"))
+                    .isFalse();
+
+            styleChecks.remove(moduleName);
+
+            Node config = null;
+
+            try {
+                config = itrConfigs.next();
+            }
+            catch (NoSuchElementException ignore) {
+                assertWithMessage(styleName + "_style.xml rule '" + ruleName + "' module '"
+                        + moduleName + "' is missing the config link: config").fail();
+            }
+
+            final String configUrl = config.getAttributes().getNamedItem("href")
+                    .getTextContent();
+
+            final String expectedUrl = "https://github.com/search?q="
+                    + "path%3Asrc%2Fmain%2Fresources%20path%3A**%2F" + styleName
+                    + "_checks.xml+repo%3Acheckstyle%2Fcheckstyle+" + moduleName;
+
+            assertWithMessage("google_style.xml rule '" + ruleName + "' module '"
+                    + moduleName + "' should have matching config url")
+                    .that(configUrl)
+                    .isEqualTo(expectedUrl);
+
+        }
+
+        if (itrConfigs.hasNext()) {
+            assertWithMessage(styleName + "_style.xml rule '" + ruleName + "' should have checks"
+                    + " if it has config/test links")
+                    .that(hasChecks)
+                    .isTrue();
+
+            final Node config = itrConfigs.next();
+            final String configUrl = config.getAttributes().getNamedItem("href")
+                    .getTextContent();
+            final String[] parts = ruleName.split(" ", 2);
+            final String extractedRuleName = parts[1].trim().replaceAll(" ", "");
+
+            assertWithMessage("google_style.xml rule '" + ruleName + "' rule '"
+                    + "' should have matching test url")
+                    .that(configUrl)
+                    .startsWith("https://github.com/checkstyle/checkstyle/"
+                            + "blob/master/src/it/java/com/google"
+                            + "/checkstyle/test/");
+
+            assertWithMessage("google_style.xml rule '" + ruleName
+                    + "' should have matching test url")
+                    .that(configUrl)
+                    .endsWith("/" + extractedRuleName + "Test.java");
+
+            assertWithMessage("google_style.xml rule '" + ruleName
+                    + "' should have a test that exists")
+                    .that(new File(configUrl.substring(53).replace('/',
+                            File.separatorChar)).exists())
+                    .isTrue();
+        }
+        else {
+            assertWithMessage(styleName + "_style.xml rule '" + ruleName + "' should have no"
+                 + " checks if it has no config/test links")
+                .that(hasChecks)
                 .isFalse();
+        }
     }
 
     @Test

--- a/src/xdocs/google_style.xml
+++ b/src/xdocs/google_style.xml
@@ -1365,8 +1365,23 @@
                   </a>
                 </td>
                 <td>
-                  <a href="styleguides/google-java-style-20180523/javaguide.html#s4.8.5-annotations">
+                  <a href="styleguides/google-java-style-20220203/javaguide.html#s4.8.5-annotations">
                     4.8.5 Annotations</a>
+                </td>
+                <td>↓</td>
+                <td/>
+              </tr>
+              <tr>
+                <td><a name="4.8.5.2"/>
+                  <a href="#4.8.5.2">
+                    <span class="wrapper inline">
+                      <img src="images/anchor.png" alt=""/>
+                    </span>
+                  </a>
+                </td>
+                <td>
+                  <a href="styleguides/google-java-style-20220203/javaguide.html#s4.8.5.2-class-annotation-style">
+                    4.8.5.2 Class Annotations</a>
                 </td>
                 <td>
                   <span class="wrapper inline">
@@ -1374,12 +1389,22 @@
                   </span>
                   <a href="checks/annotation/annotationlocation.html#AnnotationLocation">
                     AnnotationLocation</a>
+                  <br />
+                  <br />
+                  <span class="wrapper inline">
+                    <img src="images/ok_green.png" alt="" />
+                  </span>
+                  <a href="checks/javadoc/invalidjavadocposition.html#InvalidJavadocPosition">
+                    InvalidJavadocPosition</a>
                 </td>
                 <td>
                   <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources%20path%3A**%2Fgoogle_checks.xml+repo%3Acheckstyle%2Fcheckstyle+AnnotationLocation">
                     config</a>
                   <br />
-                  <a href="https://github.com/checkstyle/checkstyle/blob/master/src/it/java/com/google/checkstyle/test/chapter4formatting/rule485annotations/AnnotationLocationTest.java">
+                  <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources%20path%3A**%2Fgoogle_checks.xml+repo%3Acheckstyle%2Fcheckstyle+InvalidJavadocPosition">
+                    config</a>
+                  <br />
+                  <a href="https://github.com/checkstyle/checkstyle/blob/master/src/it/java/com/google/checkstyle/test/chapter4formatting/rule4852classannotations/ClassAnnotationsTest.java">
                     test</a>
                 </td>
               </tr>


### PR DESCRIPTION
Issue #14910 

~~Draft PR~~ because I had some doubts regarding failing xdoc tests.

I was adding a new section `4.8.5.2` to the google style guide implementation, to add support for this section, I required to combine 2 different modules ( AnnotationLocation & InvalidJavadocPosition ) in single test case. 

The test case is working fine but the problem is with Xdoc tests. I added 2 new configs and 1 test case in the coverage page, something like this:

![Screenshot 2024-06-02 012656](https://github.com/checkstyle/checkstyle/assets/86093112/c9037dce-b2b1-4f2c-a37e-1ba808a485a6)


Here, 2 `config` are for AnnotationLocation module and InvalidJavadocPosition module. The single `test` is the test file which uses these 2 configs internally to ensure we're following the rule.

But the `XdocPagesTest` is failing, it requires all the `config` to be paired with their individual `test` which is not the case here. In this case, it requires to have one `test` for AnnotationLocation and other `test` for InvalidJavadocPosition. 

And also it requires to have the test file linked in the `test` to be same name as its module name. In this case, for AnnotationLocation's `test`, it requires to be linked to a `AnnotationLocationTest` file and for InvalidJavadocPosition's `test`, it requires to be linked to a `InvalidJavadocPositionTest` file. In short, we cannot name the test file differently from its module name.


#### What we need for the new Xdoc model:

- Remove the pairing of `config` and `test` and allow us to have single `test` for multiple `config`. 
- The name of the test file used in the `test` does not have to be same as its module name.
