### PR TITLE
Issue #14938: Updated the google style coverage page regarding JSNI method

### DIFF
--- a/src/xdocs/google_style.xml
+++ b/src/xdocs/google_style.xml
@@ -809,8 +809,9 @@
                   <br />
                   <a href="https://webtoolkit.googleblog.com/2008/07/getting-to-really-know-gwt-part-1-jsni.html">
                     JSNI</a>
-                  could not be detected right now, but might be possible after
-                  comments and javadoc support appear in Checkstyle.
+                  is not supported, see reason at:
+                  <a href="https://github.com/checkstyle/checkstyle/issues/14938">
+                    #14938</a>.
                   <br />
                 </td>
                 <td>


### PR DESCRIPTION
Issue #14938 

Updated google style coverage page, removed the `JSNI could not be detected` message in section `4.4 Column Limit: 100` and added a new message indicating that it will be not supported by us with the issue link which contains all the discussion.