### PR TITLE
Issue #14947: updated documentation and test case for section 7.1.1

### DIFF
--- a/src/it/java/com/google/checkstyle/test/chapter7javadoc/rule711generalform/SingleLineJavadocTest.java
+++ b/src/it/java/com/google/checkstyle/test/chapter7javadoc/rule711generalform/SingleLineJavadocTest.java
@@ -41,6 +41,7 @@ public class SingleLineJavadocTest extends AbstractGoogleModuleTestSupport {
             "29: " + msg,
             "35: " + msg,
             "41: " + msg,
+            "47: " + msg,
         };
 
         final Configuration checkConfig = getModuleConfig("SingleLineJavadoc");

--- a/src/it/resources/com/google/checkstyle/test/chapter7javadoc/rule711generalform/InputSingleLineJavadocCheck.java
+++ b/src/it/resources/com/google/checkstyle/test/chapter7javadoc/rule711generalform/InputSingleLineJavadocCheck.java
@@ -43,4 +43,12 @@ class InputSingleLineJavadocCheck{
 
     /** Single line Javadoc that references {@link String}. */
     void bar4() {}
+
+    /** @return in single line javadoc */ //warn
+    int bar5() { return 0; }
+
+    /**
+     * @return in multi line javadoc
+     */
+    int bar6() { return 0; }
 }

--- a/src/xdocs/google_style.xml
+++ b/src/xdocs/google_style.xml
@@ -2031,16 +2031,11 @@
                 <td>
                   <span class="wrapper inline">
                     <img
-                        src="images/ok_blue.png"
+                        src="images/ok_green.png"
                         alt="" />
                   </span>
                   <a href="checks/javadoc/singlelinejavadoc.html#SingleLineJavadoc">
                     SingleLineJavadoc</a>
-                  <br />
-                  Recent update for guide that clarify requirements will be
-                  addressed at
-                  <a href="https://github.com/checkstyle/checkstyle/issues/4052">
-                    #4052</a>
                   <br />
                   <br />
                   <span class="wrapper inline">


### PR DESCRIPTION
issue #14947 

updated google documentation for section 7.1.1, removed ok_blue.png and added ok_green.png and updated the test case for `@return` in single line javadoc comment