### PR TITLE
minor: Add isUnamed method to TokenUtil

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/utils/TokenUtil.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/utils/TokenUtil.java
@@ -353,4 +353,19 @@ public final class TokenUtil {
                 .collect(BitSet::new, BitSet::set, BitSet::or);
     }
 
+    /**
+     * Checks if the given identifier AST node is an unnamed variable.
+     * An unnamed variable is a variable that is just an underscore {@code _}.
+     * A local variable, exception parameter, or lambda parameter that is declared using
+     * an underscore is called an unnamed local variable, unnamed exception parameter,
+     * or unnamed lambda parameter, respectively.
+     *
+     * @param identifierAst the AST node representing the identifier
+     * @return true if the identifier is an unnamed variable, false otherwise
+     */
+    public static boolean isUnnamed(DetailAST identifierAst) {
+        return isOfType(identifierAst, TokenTypes.IDENT)
+                    && "_".equals(identifierAst.getText());
+    }
+
 }

--- a/src/test/java/com/puppycrawl/tools/checkstyle/utils/TokenUtilTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/utils/TokenUtilTest.java
@@ -395,4 +395,34 @@ public class TokenUtilTest {
                 .isFalse();
     }
 
+    @Test
+    public void testIdentIsUnnamedTrue() {
+        final DetailAstImpl identifierAst = new DetailAstImpl();
+        identifierAst.setType(TokenTypes.IDENT);
+        identifierAst.setText("_");
+        final boolean result = TokenUtil.isUnnamed(identifierAst);
+
+        assertWithMessage("Result is not expected")
+                .that(result)
+                .isTrue();
+    }
+
+    @Test
+    public void testIdentIsUnnamedFalse() {
+        final DetailAstImpl identifierAst = new DetailAstImpl();
+        final DetailAstImpl stringLiteralAst = new DetailAstImpl();
+        stringLiteralAst.setType(TokenTypes.STRING_LITERAL);
+        identifierAst.setType(TokenTypes.IDENT);
+        identifierAst.setText("x");
+        stringLiteralAst.setText("_");
+        final boolean result = TokenUtil.isUnnamed(identifierAst);
+
+        assertWithMessage("Result is not expected")
+                .that(result)
+                .isFalse();
+        assertWithMessage("Result is not expected")
+                .that(TokenUtil.isUnnamed(stringLiteralAst))
+                .isFalse();
+    }
+
 }


### PR DESCRIPTION
since unnamed variables are just identifiers with `_` as their text. and we will need to check whether the given local variables, lambda parameters, etc... are unnamed in several checks. I thought it would be good if we separate this method outside the logic of the checks and to be in `TokenUtil`