### PR TITLE
Issue #14981: Add new property to skip FinalLocalVariable violations …

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/FinalLocalVariableCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/FinalLocalVariableCheck.java
@@ -53,6 +53,13 @@ import com.puppycrawl.tools.checkstyle.utils.TokenUtil;
  * Default value is {@code false}.
  * </li>
  * <li>
+ * Property {@code validateUnnamedVariables} - Control whether to check
+ * <a href="https://docs.oracle.com/javase/specs/jls/se21/preview/specs/unnamed-jls.html">
+ * unnamed variables</a>.
+ * Type is {@code boolean}.
+ * Default value is {@code false}.
+ * </li>
+ * <li>
  * Property {@code tokens} - tokens to check
  * Type is {@code java.lang.String[]}.
  * Validation type is {@code tokenSet}.
@@ -130,6 +137,13 @@ public class FinalLocalVariableCheck extends AbstractCheck {
     private boolean validateEnhancedForLoopVariable;
 
     /**
+     * Control whether to check
+     * <a href="https://docs.oracle.com/javase/specs/jls/se21/preview/specs/unnamed-jls.html">
+     * unnamed variables</a>.
+     */
+    private boolean validateUnnamedVariables;
+
+    /**
      * Setter to control whether to check
      * <a href="https://docs.oracle.com/javase/specs/jls/se11/html/jls-14.html#jls-14.14.2">
      * enhanced for-loop</a> variable.
@@ -139,6 +153,18 @@ public class FinalLocalVariableCheck extends AbstractCheck {
      */
     public final void setValidateEnhancedForLoopVariable(boolean validateEnhancedForLoopVariable) {
         this.validateEnhancedForLoopVariable = validateEnhancedForLoopVariable;
+    }
+
+    /**
+     * Setter to control whether to check
+     * <a href="https://docs.oracle.com/javase/specs/jls/se21/preview/specs/unnamed-jls.html">
+     * unnamed variables</a>.
+     *
+     * @param validateUnnamedVariables whether to check unnamed variables
+     * @since 10.18.0
+     */
+    public final void setValidateUnnamedVariables(boolean validateUnnamedVariables) {
+        this.validateUnnamedVariables = validateUnnamedVariables;
     }
 
     @Override
@@ -222,7 +248,8 @@ public class FinalLocalVariableCheck extends AbstractCheck {
                         && ast.findFirstToken(TokenTypes.MODIFIERS)
                             .findFirstToken(TokenTypes.FINAL) == null
                         && !isVariableInForInit(ast)
-                        && shouldCheckEnhancedForLoopVariable(ast)) {
+                        && shouldCheckEnhancedForLoopVariable(ast)
+                        && shouldCheckUnnamedVariable(ast)) {
                     insertVariable(ast);
                 }
                 break;
@@ -478,6 +505,17 @@ public class FinalLocalVariableCheck extends AbstractCheck {
     private boolean shouldCheckEnhancedForLoopVariable(DetailAST ast) {
         return validateEnhancedForLoopVariable
                 || ast.getParent().getType() != TokenTypes.FOR_EACH_CLAUSE;
+    }
+
+    /**
+     * Determines whether unnamed variable should be checked or not.
+     *
+     * @param ast The ast to compare.
+     * @return true if unnamed variable should be checked.
+     */
+    private boolean shouldCheckUnnamedVariable(DetailAST ast) {
+        return validateUnnamedVariables
+                 || !"_".equals(ast.findFirstToken(TokenTypes.IDENT).getText());
     }
 
     /**

--- a/src/main/resources/com/puppycrawl/tools/checkstyle/meta/checks/coding/FinalLocalVariableCheck.xml
+++ b/src/main/resources/com/puppycrawl/tools/checkstyle/meta/checks/coding/FinalLocalVariableCheck.xml
@@ -20,6 +20,13 @@
  &lt;a href="https://docs.oracle.com/javase/specs/jls/se11/html/jls-14.html#jls-14.14.2"&gt;
  enhanced for-loop&lt;/a&gt; variable.</description>
             </property>
+            <property default-value="false"
+                      name="validateUnnamedVariables"
+                      type="boolean">
+               <description>Control whether to check
+ &lt;a href="https://docs.oracle.com/javase/specs/jls/se21/preview/specs/unnamed-jls.html"&gt;
+ unnamed variables&lt;/a&gt;.</description>
+            </property>
             <property default-value="VARIABLE_DEF"
                       name="tokens"
                       type="java.lang.String[]"

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/coding/FinalLocalVariableCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/coding/FinalLocalVariableCheckTest.java
@@ -405,4 +405,34 @@ public class FinalLocalVariableCheckTest
             getPath("InputFinalLocalVariable3.java"),
             expected);
     }
+
+    @Test
+    public void testValidateUnnamedVariablesTrue() throws Exception {
+        final String[] expected = {
+            "21:22: " + getCheckMessage(MSG_KEY, "i"),
+            "22:17: " + getCheckMessage(MSG_KEY, "_"),
+            "23:17: " + getCheckMessage(MSG_KEY, "__"),
+            "26:13: " + getCheckMessage(MSG_KEY, "_"),
+            "27:13: " + getCheckMessage(MSG_KEY, "_result"),
+            "32:18: " + getCheckMessage(MSG_KEY, "_"),
+            "44:18: " + getCheckMessage(MSG_KEY, "_"),
+            "50:18: " + getCheckMessage(MSG_KEY, "__"),
+        };
+        verifyWithInlineConfigParser(
+                getNonCompilablePath("InputFinalLocalVariableValidateUnnamedVariablesTrue.java"),
+            expected);
+    }
+
+    @Test
+    public void testValidateUnnamedVariablesFalse() throws Exception {
+        final String[] expected = {
+            "21:22: " + getCheckMessage(MSG_KEY, "i"),
+            "23:17: " + getCheckMessage(MSG_KEY, "__"),
+            "27:13: " + getCheckMessage(MSG_KEY, "_result"),
+            "50:18: " + getCheckMessage(MSG_KEY, "__"),
+        };
+        verifyWithInlineConfigParser(
+                getNonCompilablePath("InputFinalLocalVariableValidateUnnamedVariablesFalse.java"),
+            expected);
+    }
 }

--- a/src/test/resources-noncompilable/com/puppycrawl/tools/checkstyle/checks/coding/finallocalvariable/InputFinalLocalVariableValidateUnnamedVariablesFalse.java
+++ b/src/test/resources-noncompilable/com/puppycrawl/tools/checkstyle/checks/coding/finallocalvariable/InputFinalLocalVariableValidateUnnamedVariablesFalse.java
@@ -1,0 +1,58 @@
+/*
+FinalLocalVariable
+validateUnnamedVariables = (default)false
+validateEnhancedForLoopVariable = true
+tokens = (default)VARIABLE_DEF
+
+*/
+
+//non-compiled with javac: Compilable with Java21
+package com.puppycrawl.tools.checkstyle.checks.coding.finallocalvariable;
+
+import java.util.PriorityQueue;
+import java.util.Queue;
+
+public class InputFinalLocalVariableValidateUnnamedVariablesFalse {
+
+    public void testUnnamedVariables() {
+        final Queue<Integer> q = new PriorityQueue<>();
+        q.add(1);
+        q.add(2);
+        for (Integer i : q) {  // violation,'Variable 'i' should be declared final'
+            var _ = q.poll();
+            var __ = q.poll(); // violation,'Variable '__' should be declared final'
+        }
+        final int _ = sideEffect();
+        int _ = sideEffect();
+        int _result = sideEffect(); // violation,'Variable '_result' should be declared final'
+    }
+
+    static
+    {
+        Runnable _ = new Runnable()
+        {
+            public void run()
+            {
+            }
+        };
+    }
+
+    public void testInEnhancedFor() {
+        final int[] squares = {0, 1, 4, 9, 16, 25};
+        for (final int i : squares) {
+        }
+        for (int _ : squares) {
+
+        }
+        for (final int _ : squares) {
+
+        }
+        for (int __ : squares) { // violation,'Variable '__' should be declared final'
+
+        }
+    }
+
+    public int sideEffect() {
+        return 0;
+    }
+}

--- a/src/test/resources-noncompilable/com/puppycrawl/tools/checkstyle/checks/coding/finallocalvariable/InputFinalLocalVariableValidateUnnamedVariablesTrue.java
+++ b/src/test/resources-noncompilable/com/puppycrawl/tools/checkstyle/checks/coding/finallocalvariable/InputFinalLocalVariableValidateUnnamedVariablesTrue.java
@@ -1,0 +1,58 @@
+/*
+FinalLocalVariable
+validateUnnamedVariables = true
+validateEnhancedForLoopVariable = true
+tokens = (default)VARIABLE_DEF
+
+*/
+
+//non-compiled with javac: Compilable with Java21
+package com.puppycrawl.tools.checkstyle.checks.coding.finallocalvariable;
+
+import java.util.PriorityQueue;
+import java.util.Queue;
+
+public class InputFinalLocalVariableValidateUnnamedVariablesTrue {
+
+    public void testUnnamedVariables() {
+        final Queue<Integer> q = new PriorityQueue<>();
+        q.add(1);
+        q.add(2);
+        for (Integer i : q) {  // violation,'Variable 'i' should be declared final'
+            var _ = q.poll(); // violation,'Variable '_' should be declared final'
+            var __ = q.poll(); // violation,'Variable '__' should be declared final'
+        }
+        final int _ = sideEffect();
+        int _ = sideEffect(); // violation,'Variable '_' should be declared final'
+        int _result = sideEffect(); // violation,'Variable '_result' should be declared final'
+    }
+
+    static
+    {
+        Runnable _ = new Runnable() // violation,'Variable '_' should be declared final'
+        {
+            public void run()
+            {
+            }
+        };
+    }
+
+    public void testInEnhancedFor() {
+        final int[] squares = {0, 1, 4, 9, 16, 25};
+        for (final int i : squares) {
+        }
+        for (int _ : squares) { // violation,'Variable '_' should be declared final'
+
+        }
+        for (final int _ : squares) {
+
+        }
+        for (int __ : squares) { // violation,'Variable '__' should be declared final'
+
+        }
+    }
+
+    public int sideEffect() {
+        return 0;
+    }
+}

--- a/src/xdocs/checks/coding/finallocalvariable.xml
+++ b/src/xdocs/checks/coding/finallocalvariable.xml
@@ -42,6 +42,14 @@
               <td>6.5</td>
             </tr>
             <tr>
+              <td>validateUnnamedVariables</td>
+              <td>Control whether to check <a href="https://docs.oracle.com/javase/specs/jls/se21/preview/specs/unnamed-jls.html">
+ unnamed variables</a>.</td>
+              <td><a href="../../property_types.html#boolean">boolean</a></td>
+              <td><code>false</code></td>
+              <td>10.18.0</td>
+            </tr>
+            <tr>
               <td>tokens</td>
               <td>tokens to check</td>
               <td>subset of tokens


### PR DESCRIPTION
closes #14981 

added a new property named `validateUnnamedVariables` to control whether to validate unnamed variables the default value  false

Diff Regression config: https://gist.githubusercontent.com/mahfouz72/afd57aa6e51ca161b7927acd959e5211/raw/2cceba105232745543e237d50c0c4a38883be735/check.xml

Diff Regression patch config: https://gist.githubusercontent.com/mahfouz72/33967bf86e4a29cafa429771b0e95808/raw/a13fee304bdf4e853b3de5dd71a3c4aece177445/check_patch.xml

Diff Regression projects: https://gist.githubusercontent.com/mahfouz72/a3d0af030c8f5efd0d8a39f2c14750bc/raw/a3424ad9b6f722e5de1a927e3d85e383101b2b93/projects-to-test-on.properties
