### PR TITLE
Issue #14946: False negative in IllegalTypeCheck on record pattern

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/IllegalTypeCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/IllegalTypeCheck.java
@@ -143,7 +143,9 @@ import com.puppycrawl.tools.checkstyle.utils.TokenUtil;
  * <a href="https://checkstyle.org/apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#RECORD_DEF">
  * RECORD_DEF</a>,
  * <a href="https://checkstyle.org/apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#RECORD_COMPONENT_DEF">
- * RECORD_COMPONENT_DEF</a>.
+ * RECORD_COMPONENT_DEF</a>,
+ * <a href="https://checkstyle.org/apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#RECORD_PATTERN_DEF">
+ * RECORD_PATTERN_DEF</a>.
  * </li>
  * </ul>
  * <p>
@@ -264,6 +266,7 @@ public final class IllegalTypeCheck extends AbstractCheck {
             TokenTypes.PATTERN_VARIABLE_DEF,
             TokenTypes.RECORD_DEF,
             TokenTypes.RECORD_COMPONENT_DEF,
+            TokenTypes.RECORD_PATTERN_DEF,
         };
     }
 
@@ -299,6 +302,7 @@ public final class IllegalTypeCheck extends AbstractCheck {
                 visitVariableDef(ast);
                 break;
             case TokenTypes.RECORD_COMPONENT_DEF:
+            case TokenTypes.RECORD_PATTERN_DEF:
                 checkClassName(ast);
                 break;
             case TokenTypes.PARAMETER_DEF:

--- a/src/main/resources/com/puppycrawl/tools/checkstyle/meta/checks/coding/IllegalTypeCheck.xml
+++ b/src/main/resources/com/puppycrawl/tools/checkstyle/meta/checks/coding/IllegalTypeCheck.xml
@@ -83,7 +83,7 @@
                       type="boolean">
                <description>Control whether to validate abstract class names.</description>
             </property>
-            <property default-value="ANNOTATION_FIELD_DEF,CLASS_DEF,INTERFACE_DEF,METHOD_CALL,METHOD_DEF,METHOD_REF,PARAMETER_DEF,VARIABLE_DEF,PATTERN_VARIABLE_DEF,RECORD_DEF,RECORD_COMPONENT_DEF"
+            <property default-value="ANNOTATION_FIELD_DEF,CLASS_DEF,INTERFACE_DEF,METHOD_CALL,METHOD_DEF,METHOD_REF,PARAMETER_DEF,VARIABLE_DEF,PATTERN_VARIABLE_DEF,RECORD_DEF,RECORD_COMPONENT_DEF,RECORD_PATTERN_DEF"
                       name="tokens"
                       type="java.lang.String[]"
                       validation-type="tokenSet">

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/coding/IllegalTypeCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/coding/IllegalTypeCheckTest.java
@@ -456,4 +456,34 @@ public class IllegalTypeCheckTest extends AbstractModuleTestSupport {
                 getPath("InputIllegalTypeAbstractClassNameFormat.java"),
                 expected);
     }
+
+    @Test
+    public void testIllegalTypeWithRecordPattern() throws Exception {
+        final String[] expected = {
+            "28:25: " + getCheckMessage(MSG_KEY, "Point"),
+            "29:22: " + getCheckMessage(MSG_KEY, "ColoredPoint"),
+            "29:46: " + getCheckMessage(MSG_KEY, "ColoredPoint"),
+            "39:28: " + getCheckMessage(MSG_KEY, "Rectangle"),
+            "40:28: " + getCheckMessage(MSG_KEY, "Rectangle"),
+            "40:38: " + getCheckMessage(MSG_KEY, "ColoredPoint"),
+            "40:54: " + getCheckMessage(MSG_KEY, "ColoredPoint"),
+            "45:28: " + getCheckMessage(MSG_KEY, "Rectangle"),
+            "45:38: " + getCheckMessage(MSG_KEY, "ColoredPoint"),
+            "45:51: " + getCheckMessage(MSG_KEY, "Point"),
+            "50:28: " + getCheckMessage(MSG_KEY, "Point"),
+            "58:9: " + getCheckMessage(MSG_KEY, "LinkedHashMap"),
+            "61:9: " + getCheckMessage(MSG_KEY, "Box"),
+            "61:13: " + getCheckMessage(MSG_KEY, "LinkedHashMap"),
+            "66:28: " + getCheckMessage(MSG_KEY, "Box"),
+            "66:32: " + getCheckMessage(MSG_KEY, "LinkedHashMap"),
+            "76:18: " + getCheckMessage(MSG_KEY, "Point"),
+            "77:18: " + getCheckMessage(MSG_KEY, "Rectangle"),
+            "77:28: " + getCheckMessage(MSG_KEY, "ColoredPoint"),
+            "77:41: " + getCheckMessage(MSG_KEY, "Point"),
+            "83:18: " + getCheckMessage(MSG_KEY, "ColoredPoint"),
+        };
+        verifyWithInlineConfigParser(
+                getNonCompilablePath("InputIllegalTypeWithRecordPattern.java"),
+                expected);
+    }
 }

--- a/src/test/resources-noncompilable/com/puppycrawl/tools/checkstyle/checks/coding/illegaltype/InputIllegalTypeWithRecordPattern.java
+++ b/src/test/resources-noncompilable/com/puppycrawl/tools/checkstyle/checks/coding/illegaltype/InputIllegalTypeWithRecordPattern.java
@@ -1,0 +1,87 @@
+/*
+IllegalType
+validateAbstractClassNames = (default)false
+illegalClassNames = HashMap, HashSet, LinkedHashMap, LinkedHashSet, TreeMap, TreeSet, \
+                    java.util.HashMap, java.util.HashSet, java.util.LinkedHashMap, \
+                    java.util.LinkedHashSet, java.util.TreeMap, java.util.TreeSet, \
+                    Rectangle, ColoredPoint, Point, Box
+legalAbstractClassNames = (default)
+ignoredMethodNames = (default)getEnvironment, getInitialContext
+illegalAbstractClassNameFormat = (default)^(.*[.])?Abstract.*$
+memberModifiers = (default)
+tokens = (default)ANNOTATION_FIELD_DEF, CLASS_DEF, INTERFACE_DEF, METHOD_CALL, METHOD_DEF, \
+         METHOD_REF, PARAMETER_DEF, VARIABLE_DEF, PATTERN_VARIABLE_DEF, RECORD_DEF, \
+         RECORD_COMPONENT_DEF, RECORD_PATTERN_DEF
+
+
+*/
+
+//non-compiled with javac: Compilable with Java21
+package com.puppycrawl.tools.checkstyle.checks.coding.illegaltype;
+
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+
+public class InputIllegalTypeWithRecordPattern {
+
+    record ColoredPoint(Point p, String c) { } // violation, 'Usage of type 'Point' is not allowed.'
+    record Rectangle(ColoredPoint upperLeft, ColoredPoint lowerRight) { }
+    // 2 violations above:
+    //                    'Usage of type 'ColoredPoint' is not allowed.'
+    //                    'Usage of type 'ColoredPoint' is not allowed.'
+    record Point(int x, int y) { }
+    record Box<T>(T t) { }
+
+
+    public void testWithInstanceOf(Object obj) {
+        // violation below, 'Usage of type 'Rectangle' is not allowed.'
+        if (obj instanceof Rectangle r) { }
+        if (obj instanceof Rectangle(ColoredPoint x, ColoredPoint y)) { }
+        // 3 violations above:
+        //                  'Usage of type 'Rectangle' is not allowed.'
+        //                  'Usage of type 'ColoredPoint' is not allowed.'
+        //                  'Usage of type 'ColoredPoint' is not allowed.'
+        if (obj instanceof Rectangle(ColoredPoint(Point(int _,int _),_),_)) { }
+        // 3 violations above:
+        //                  'Usage of type 'Rectangle' is not allowed.'
+        //                  'Usage of type 'ColoredPoint' is not allowed.'
+        //                  'Usage of type 'Point' is not allowed.'
+        if (obj instanceof Point(_,_)) { }
+        // violation above, 'Usage of type 'Point' is not allowed.'
+
+    }
+
+    public void testWithInstanceOfWithGenerics() {
+
+        // violation below, 'Usage of type 'LinkedHashMap' is not allowed.'
+        LinkedHashMap<Integer, Integer> l2
+                = new LinkedHashMap<>();
+
+        Box<LinkedHashMap<Integer,Integer>> box = new Box<>(l2);
+        // 2 violations above:
+        //                  'Usage of type 'Box' is not allowed.'
+        //                  'Usage of type 'LinkedHashMap' is not allowed.'
+
+        if (box instanceof Box<LinkedHashMap<Integer,Integer>>(var linkedHashMap)) {}
+        // 2 violations above:
+        //                  'Usage of type 'Box' is not allowed.'
+        //                  'Usage of type 'LinkedHashMap' is not allowed.'
+
+    }
+
+    public void testWithSwitch(Object obj) {
+        switch (obj) {
+            // violation below,  'Usage of type 'Point' is not allowed.'
+            case Point(_,_) -> System.out.println("point");
+            case Rectangle(ColoredPoint(Point(_, _),_),_) -> System.out.println("rectangle");
+              // 3 violations above:
+              //                  'Usage of type 'Rectangle' is not allowed.'
+             //                  'Usage of type 'ColoredPoint' is not allowed.'
+            //                    'Usage of type 'Point' is not allowed.'
+            // violation below,  'Usage of type 'ColoredPoint' is not allowed.'
+            case ColoredPoint _ -> System.out.println("coloredPoint");
+            default -> throw new IllegalStateException("Unexpected value: " + obj);
+        }
+    }
+}

--- a/src/xdocs/checks/coding/illegaltype.xml
+++ b/src/xdocs/checks/coding/illegaltype.xml
@@ -101,6 +101,8 @@
                     RECORD_DEF</a>
                 , <a href="../../apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#RECORD_COMPONENT_DEF">
                     RECORD_COMPONENT_DEF</a>
+                , <a href="../../apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#RECORD_PATTERN_DEF">
+                    RECORD_PATTERN_DEF</a>
                   .
               </td>
               <td>
@@ -126,6 +128,8 @@
                     RECORD_DEF</a>
                 , <a href="../../apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#RECORD_COMPONENT_DEF">
                     RECORD_COMPONENT_DEF</a>
+                , <a href="../../apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#RECORD_PATTERN_DEF">
+                    RECORD_PATTERN_DEF</a>
                   .
               </td>
               <td>3.2</td>


### PR DESCRIPTION
closes #14946 :

added `RECORD_PATTERN_DEF` token to `IllegalTypeCheck`

Diff Regression config: https://gist.githubusercontent.com/mahfouz72/afd57aa6e51ca161b7927acd959e5211/raw/d09e02f562fa0cd9e71eebcc4f9ab6fd09a4fd36/check.xml

Diff Regression patch config: https://gist.githubusercontent.com/mahfouz72/33967bf86e4a29cafa429771b0e95808/raw/efa32547d82e4b966268643d284182774d68bfdd/check_patch.xml

Diff Regression projects: https://gist.githubusercontent.com/mahfouz72/a3d0af030c8f5efd0d8a39f2c14750bc/raw/8ca3493f88bc1003db86b40015a4c2101ab7bc94/projects-to-test-on.properties