### PR TITLE
Issue #12653: Add regexp config to violate since version number

### DIFF
--- a/config/checkstyle-checks.xml
+++ b/config/checkstyle-checks.xml
@@ -189,6 +189,13 @@
     <property name="message"
               value="Package comment marker should not be used if other visibility is defined"/>
   </module>
+  <module name="RegexpSingleline">
+    <property name="id" value="sinceVersionNumber"/>
+    <property name="format" value="\*\s+@since\s+([1-9][0-9])(\.[0-9]+)?$"/>
+    <property name="fileExtensions" value="java"/>
+    <property name="message"
+              value="@since tag must follow the X.Y.Z version format after version 10.5.0."/>
+  </module>
   <module name="RegexpOnFilename">
     <property name="id" value="regexpOnFilenameWithSpace"/>
   </module>


### PR DESCRIPTION
closes #12653: 
The regex is ugly but I think this is the best possible solution. Suppression by file and lines is not flexible if the line number is changed and will be huge. `WriteTagCheck` isn't applicable here because it always will requires the tag to be present


---
test commit : e8344a207bf8c50eeabd9225f78f404df55ebaa3

https://app.circleci.com/pipelines/github/checkstyle/checkstyle/25884/workflows/ef4b7987-40cf-4d8a-a696-89bce3b46140/jobs/605288

```
[ERROR] [checkstyle] [ERROR] /home/circleci/project/src/main/java/com/puppycrawl/tools/checkstyle/api/TokenTypes.java:6690: @since tag must follow the X.Y.Z version format after version 10.5.0. [sinceVersionNumber]
[ERROR] [checkstyle] [ERROR] /home/circleci/project/src/main/java/com/puppycrawl/tools/checkstyle/api/TokenTypes.java:6741: @since tag must follow the X.Y.Z version format after version 10.5.0. [sinceVersionNumber]
[ERROR] [checkstyle] [ERROR] /home/circleci/project/src/main/java/com/puppycrawl/tools/checkstyle/api/TokenTypes.java:6781: @since tag must follow the X.Y.Z version format after version 10.5.0. [sinceVersionNumber]
[ERROR] [checkstyle] [ERROR] /home/circleci/project/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/ConstructorsDeclarationGroupingCheck.java:58: @since tag must follow the X.Y.Z version format after version 10.5.0. [sinceVersionNumber]
```
