### PR TITLE
infra: update azure to macOS-12 to avoid deprecation warning

### DIFF
--- a/.ci/validation.sh
+++ b/.ci/validation.sh
@@ -1145,7 +1145,6 @@ ci-temp-check)
         fail=1
     fi
     ls -A .ci-temp
-    sleep 5s
     exit $fail
   ;;
 

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -92,12 +92,12 @@ strategy:
 
     # MacOS JDK11 verify
     'MacOS JDK11 verify':
-      image: 'macOS-11'
+      image: 'macOS-12'
       cmd: "JAVA_HOME=$JAVA_HOME_11_X64 mvn -e --no-transfer-progress verify"
 
     # MacOS JDK17 verify
     'MacOS JDK17 verify':
-      image: 'macOS-11'
+      image: 'macOS-12'
       cmd: "JAVA_HOME=$JAVA_HOME_17_X64 mvn -e --no-transfer-progress verify"
 
     # moved back to Travis till we find a way to keep secrets in azure
@@ -116,7 +116,7 @@ strategy:
 
     # lint for .md files, OSX is used because there is problem to install gem on linux
     'markdownlint':
-      image: 'macOS-11'
+      image: 'macOS-12'
       cmd: "./.ci/validation.sh markdownlint"
       skipCache: true
       needMdl: true


### PR DESCRIPTION
from https://github.com/checkstyle/checkstyle/pull/15001#issuecomment-2175063950

it becomes a pain to restart.
```
##[error]This is a scheduled macOS-11 brownout. The macOS-11 environment 
is deprecated and will be removed on June 28th, 2024.
,##[error]The remote provider was unable to process the request.
Started: Yesterday at 10:53 AM
Duration: 20h 8m 52s

Job preparation parameters
9 queue time variables used
```

https://dev.azure.com/romanivanovjr/romanivanovjr/_build/results?buildId=21757&view=logs&j=d72e04f6-d294-5bfe-b3cd-ffcb523f40f9