### PR TITLE
Issue #15053: Made google style guide severity property define-able by  variable

### DIFF
--- a/src/main/resources/google_checks.xml
+++ b/src/main/resources/google_checks.xml
@@ -21,7 +21,7 @@
 
   <property name="charset" value="UTF-8"/>
 
-  <property name="severity" value="warning"/>
+  <property name="severity" value="${org.checkstyle.google.severity}" default="warning"/>
 
   <property name="fileExtensions" value="java, properties, xml"/>
   <!-- Excludes all 'module-info.java' files              -->

--- a/src/test/java/com/puppycrawl/tools/checkstyle/MainTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/MainTest.java
@@ -345,6 +345,45 @@ public class MainTest {
     }
 
     @Test
+    public void testCustomSeverityVariableForGoogleConfig(@SysOut Capturable systemOut) {
+        assertMainReturnCode(1, "-c", "/google_checks.xml",
+                "-p", getPath("InputMainCustomSeverityForGoogleConfig.properties"),
+                getPath("InputMainCustomSeverityForGoogleConfig.java"));
+
+        final String expectedOutputStart = addEndOfLine(auditStartMessage.getMessage())
+            + "[ERROR] ";
+        final String expectedOutputEnd = addEndOfLine(
+                "InputMainCustomSeverityForGoogleConfig.java:3:1:"
+                    + " Missing a Javadoc comment. [MissingJavadocType]",
+                auditFinishMessage.getMessage());
+        assertWithMessage("Unexpected output log")
+            .that(systemOut.getCapturedData())
+            .startsWith(expectedOutputStart);
+        assertWithMessage("Unexpected output log")
+            .that(systemOut.getCapturedData())
+            .endsWith(expectedOutputEnd);
+    }
+
+    @Test
+    public void testDefaultSeverityVariableForGoogleConfig(@SysOut Capturable systemOut) {
+        assertMainReturnCode(0, "-c", "/google_checks.xml",
+                getPath("InputMainCustomSeverityForGoogleConfig.java"));
+
+        final String expectedOutputStart = addEndOfLine(auditStartMessage.getMessage())
+                + "[WARN] ";
+        final String expectedOutputEnd = addEndOfLine(
+                "InputMainCustomSeverityForGoogleConfig.java:3:1:"
+                        + " Missing a Javadoc comment. [MissingJavadocType]",
+                auditFinishMessage.getMessage());
+        assertWithMessage("Unexpected output log")
+                .that(systemOut.getCapturedData())
+                .startsWith(expectedOutputStart);
+        assertWithMessage("Unexpected output log")
+                .that(systemOut.getCapturedData())
+                .endsWith(expectedOutputEnd);
+    }
+
+    @Test
     public void testNonExistentConfigFile(@SysErr Capturable systemErr,
             @SysOut Capturable systemOut) {
         assertMainReturnCode(-1, "-c", "src/main/resources/non_existent_config.xml",

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/main/InputMainCustomSeverityForGoogleConfig.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/main/InputMainCustomSeverityForGoogleConfig.java
@@ -1,0 +1,5 @@
+package com.puppycrawl.tools.checkstyle.main;
+
+public class InputMainCustomSeverityForGoogleConfig {
+
+}

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/main/InputMainCustomSeverityForGoogleConfig.properties
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/main/InputMainCustomSeverityForGoogleConfig.properties
@@ -1,0 +1,1 @@
+org.checkstyle.google.severity=error

--- a/src/xdocs/google_style.xml
+++ b/src/xdocs/google_style.xml
@@ -2432,6 +2432,23 @@
           </table>
         </div>
       </subsection>
+      <subsection name="Severity Level" id="Google_Severity_Level">
+        <p>
+          To adjust the default severity level for violations using Checkstyle's
+          Google style configuration, set the following system property:
+        </p>
+        <p>
+          <code>org.checkstyle.google.severity</code>
+        </p>
+        <p>
+          For detailed guidance on severity levels, refer to the
+          <a href="./property_types.html#SeverityLevel">Severity Level</a>.
+          To configure this property, see the instructions for the
+          <a href="./cmdline.html#Command_line_usage">CLI's <code>-p</code> option</a> , or use the
+          <a href="./anttask.html#Parameters"><code>properties</code> parameter in Ant</a>,
+          or set the Java system property before running Checkstyle.
+        </p>
+      </subsection>
       <subsection name="Suppressions" id="Google_Suppressions">
         <p>
           It is possible to suppress some violations by embeded filters


### PR DESCRIPTION
issue #15053 

 Made google style guide severity property define-able by system variable. Added a new `Overrides` section in google coverage page about this and wrote test case for it