### PR TITLE
Issue #14137: Enable `ImmutablesSortedSetComparator` check

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -243,11 +243,12 @@
       -Xep:AssertJIsNull:ERROR
       -Xep:AutowiredConstructor:ERROR
       -Xep:CanonicalAnnotationSyntax:ERROR
-      -Xep:DirectReturn:ERROR
       -Xep:CollectorMutability:ERROR
+      -Xep:DirectReturn:ERROR
       -Xep:EmptyMethod:ERROR
       -Xep:ExplicitEnumOrdering:ERROR
       -Xep:FormatStringConcatenation:ERROR
+      -Xep:ImmutablesSortedSetComparator:ERROR
       -Xep:IsInstanceLambdaUsage:ERROR
       -Xep:MockitoMockClassReference:ERROR
       -Xep:MockitoStubbing:ERROR


### PR DESCRIPTION
Issue #14137.

This enables the `ImmutablesSortedSetComparator` check, see docs here: https://error-prone.picnic.tech/bugpatterns/ImmutablesSortedSetComparator/.

Sorry for the delay on the last PRs of #14137. I'm back to file the last two PRs and get it merged!