### PR TITLE
Issue #14137: Enable `IdentityConversion` check

### DIFF
--- a/config/error-prone-suppressions/compile-phase-suppressions.xml
+++ b/config/error-prone-suppressions/compile-phase-suppressions.xml
@@ -13,4 +13,11 @@
     <description>Avoid `Collectors.to{List,Map,Set}` in favor of collectors that emphasize (im)mutability</description>
     <lineContent>}).collect(Collectors.toSet()));</lineContent>
   </error>
+  <!-- This identity conversion prevents potential `NullPointerException`s from being thrown. -->
+  <error>
+    <sourceFile>SarifLogger.java</sourceFile>
+    <bugPattern>IdentityConversion</bugPattern>
+    <description>This method invocation appears redundant; remove it or suppress this warning and add a comment explaining its purpose</description>
+    <lineContent>.replace(VERSION_PLACEHOLDER, String.valueOf(version))</lineContent>
+  </error>
 </suppressedErrors>

--- a/pom.xml
+++ b/pom.xml
@@ -248,6 +248,7 @@
       -Xep:EmptyMethod:ERROR
       -Xep:ExplicitEnumOrdering:ERROR
       -Xep:FormatStringConcatenation:ERROR
+      -Xep:IdentityConversion:ERROR
       -Xep:ImmutablesSortedSetComparator:ERROR
       -Xep:IsInstanceLambdaUsage:ERROR
       -Xep:MockitoMockClassReference:ERROR


### PR DESCRIPTION
Issue #14137.

This enables the `IdentityConversion` check, see docs here: https://error-prone.picnic.tech/bugpatterns/IdentityConversion/.

This is the last PR of #14137! 

https://github.com/checkstyle/checkstyle/blob/a2ba2b27bc7d59f9619d96663881f000260a913f/src/main/java/com/puppycrawl/tools/checkstyle/SarifLogger.java#L140-L148
