### PR TITLE
Infra google formatter correct

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -412,6 +412,12 @@
       <scope>test</scope>
     </dependency>
     <dependency>
+      <groupId>com.google.googlejavaformat</groupId>
+      <artifactId>google-java-format</artifactId>
+      <version>1.22.0</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
       <groupId>net.sf.saxon</groupId>
       <artifactId>Saxon-HE</artifactId>
       <version>${saxon.version}</version>

--- a/src/it/java/com/google/checkstyle/test/chapter2filebasic/rule21filename/FileNameTest.java
+++ b/src/it/java/com/google/checkstyle/test/chapter2filebasic/rule21filename/FileNameTest.java
@@ -19,9 +19,14 @@
 
 package com.google.checkstyle.test.chapter2filebasic.rule21filename;
 
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Paths;
+
 import org.junit.jupiter.api.Test;
 
 import com.google.checkstyle.test.base.AbstractGoogleModuleTestSupport;
+import com.google.googlejavaformat.java.Formatter;
 
 public class FileNameTest extends AbstractGoogleModuleTestSupport {
 
@@ -37,6 +42,11 @@ public class FileNameTest extends AbstractGoogleModuleTestSupport {
     @Test
     public void testOuterTypeFilename1() throws Exception {
         final String filePath = getPath("InputFileName1.java");
+
+        final String original = Files.readString(Paths.get(filePath));
+        final String formatted = new Formatter().formatSource(original);
+        Files.write(Paths.get(filePath), formatted.getBytes(StandardCharsets.UTF_8));
+
         verifyWithConfigParser(MODULES, filePath);
     }
 

--- a/src/it/resources/com/google/checkstyle/test/chapter2filebasic/rule21filename/InputFileName1.java
+++ b/src/it/resources/com/google/checkstyle/test/chapter2filebasic/rule21filename/InputFileName1.java
@@ -1,37 +1,37 @@
 package com.google.checkstyle.test.chapter2filebasic.rule21filename;
 
-@interface MyAnnotation1 { //ok
-    String name();
-    int version();
+@interface MyAnnotation1 { // ok
+  String name();
+
+  int version();
 }
 
 @MyAnnotation1(name = "ABC", version = 1)
-public class InputFileName1 //ok
-{
+public class InputFileName1 // ok
+ {}
 
+enum Enum1 // ok
+{
+  A,
+  B,
+  C;
+
+  Enum1() {}
+
+  public String toString() {
+    return ""; // some custom implementation
+  }
 }
 
-enum Enum1 //ok
-{
-    A, B, C;
-    Enum1() {}
-    public String toString() {
-        return ""; //some custom implementation
-    }
+interface TestRequireThisEnum // ok
+ {
+  enum DAY_OF_WEEK {
+    SUNDAY,
+    MONDAY,
+    TUESDAY,
+    WEDNESDAY,
+    THURSDAY,
+    FRIDAY,
+    SATURDAY
+  }
 }
-
-interface TestRequireThisEnum //ok
-{
-    enum DAY_OF_WEEK
-    {
-        SUNDAY,
-        MONDAY,
-        TUESDAY,
-        WEDNESDAY,
-        THURSDAY,
-        FRIDAY,
-        SATURDAY
-    }
-}
-
-

--- a/src/it/resources/com/google/checkstyle/test/chapter4formatting/rule43onestatement/InputOneStatementPerLine.java
+++ b/src/it/resources/com/google/checkstyle/test/chapter4formatting/rule43onestatement/InputOneStatementPerLine.java
@@ -1,311 +1,235 @@
 package com.google.checkstyle.test.chapter4formatting.rule43onestatement;
 
-/**
- * Two import statements on the same line are illegal.
- */
-import java.io.EOFException; import java.io.BufferedReader;
+/** Two import statements on the same line are illegal. */
+
 // violation above 'Only one statement per line allowed.'
 
 public class InputOneStatementPerLine {
 
-  /**
-   * Dummy variable to work on.
-   */
+  /** Dummy variable to work on. */
   private int one = 0;
 
-  /**
-   * Dummy variable to work on.
-   */
+  /** Dummy variable to work on. */
   private int two = 0;
 
-  /**
-   * Simple legal method.
-   */
+  /** Simple legal method. */
   public void doLegal() {
     one = 1;
     two = 2;
   }
 
-  /**
-   * The illegal format is used within a String. Therefor the whole method is legal.
-   */
+  /** The illegal format is used within a String. Therefor the whole method is legal. */
   public void doLegalString() {
     one = 1;
     two = 2;
     System.identityHashCode("one = 1; two = 2");
   }
 
-  /**
-   * Within the for-header there are 3 Statements, but this is legal.
-   */
+  /** Within the for-header there are 3 Statements, but this is legal. */
   public void doLegalForLoop() {
-    for (int i = 0, j = 0, k = 1; i < 20; i++) { //it's ok.
+    for (int i = 0, j = 0, k = 1; i < 20; i++) { // it's ok.
       one = i;
     }
   }
 
-  /**
-   * Simplest form of illegal layouts.
-   */
+  /** Simplest form of illegal layouts. */
   public void doIllegal() {
-    one = 1; two = 2; // violation 'Only one statement per line allowed.'
+    one = 1;
+    two = 2; // violation 'Only one statement per line allowed.'
     if (one == 1) {
-        one++; two++; // violation 'Only one statement per line allowed.'
+      one++;
+      two++; // violation 'Only one statement per line allowed.'
     }
-    if (one != 1) { one++; } else { one--; } // violation 'Only one statement per line allowed.'
+    if (one != 1) {
+      one++;
+    } else {
+      one--;
+    } // violation 'Only one statement per line allowed.'
     int n = 10;
 
-    doLegal(); doLegal(); // violation 'Only one statement per line allowed.'
-    while (one == 1) {one++; two--;} // violation 'Only one statement per line allowed.'
-
+    doLegal();
+    doLegal(); // violation 'Only one statement per line allowed.'
+    while (one == 1) {
+      one++;
+      two--;
+    } // violation 'Only one statement per line allowed.'
   }
 
   /**
-   * While theoretically being distributed over two lines, this is a sample
-   * of 2 statements on one line.
+   * While theoretically being distributed over two lines, this is a sample of 2 statements on one
+   * line.
    */
   public void doIllegal2() {
-    one = 1
-    ; two = 2; // violation 'Only one statement per line allowed.'
+    one = 1;
+    two = 2; // violation 'Only one statement per line allowed.'
   }
 
-  class Inner
-  {
-      /**
-       * Dummy variable to work on.
-       */
-      private int one = 0;
+  class Inner {
+    /** Dummy variable to work on. */
+    private int one = 0;
 
-      /**
-       * Dummy variable to work on.
-       */
-      private int two = 0;
+    /** Dummy variable to work on. */
+    private int two = 0;
 
-      /**
-       * Simple legal method.
-       */
-      public void doLegal() {
-        one = 1;
-        two = 2;
+    /** Simple legal method. */
+    public void doLegal() {
+      one = 1;
+      two = 2;
+    }
+
+    /** Simplest form a an illegal layout. */
+    public void doIllegal() {
+      one = 1;
+      two = 2; // violation 'Only one statement per line allowed.'
+      if (one == 1) {
+        one++;
+        two++; // violation 'Only one statement per line allowed.'
       }
+      if (one != 1) {
+        one++;
+      } else {
+        one--;
+      } // violation 'Only one statement per line allowed.'
+      int n = 10;
 
-      /**
-       * Simplest form a an illegal layout.
-       */
-      public void doIllegal() {
-        one = 1; two = 2; // violation 'Only one statement per line allowed.'
-        if (one == 1) {
-            one++; two++; // violation 'Only one statement per line allowed.'
-        }
-        if (one != 1) { one++; } else { one--; } // violation 'Only one statement per line allowed.'
-        int n = 10;
-
-        doLegal(); doLegal(); // violation 'Only one statement per line allowed.'
-        while (one == 1) {one++; two--;} // violation 'Only one statement per line allowed.'
-
-      }
+      doLegal();
+      doLegal(); // violation 'Only one statement per line allowed.'
+      while (one == 1) {
+        one++;
+        two--;
+      } // violation 'Only one statement per line allowed.'
+    }
   }
 
-  /**
-   * Two declaration statements on the same line are illegal.
-   */
-  int a; int b; // violation 'Only one statement per line allowed.'
+  /** Two declaration statements on the same line are illegal. */
+  int a;
 
-  /**
-   * Two declaration statements which are not on the same line
-   * are legal.
-   */
+  int b; // violation 'Only one statement per line allowed.'
+
+  /** Two declaration statements which are not on the same line are legal. */
   int c;
+
   int d;
 
-  /**
-   * Two assignment (declaration) statements on the same line are illegal.
-   */
-  int e = 1; int f = 2; // violation 'Only one statement per line allowed.'
+  /** Two assignment (declaration) statements on the same line are illegal. */
+  int e = 1;
 
-  /**
-   * Two assignment (declaration) statements on the different lines
-   * are legal.
-   */
+  int f = 2; // violation 'Only one statement per line allowed.'
+
+  /** Two assignment (declaration) statements on the different lines are legal. */
   int g = 1;
+
   int h = 2;
 
-  /**
-   * This method contains
-   * two object creation statements on the same line.
-   */
+  /** This method contains two object creation statements on the same line. */
   private void foo() {
-    //Two object creation statements on the same line are illegal.
-    Object obj1 = new Object(); Object obj2 = new Object();
+    // Two object creation statements on the same line are illegal.
+    Object obj1 = new Object();
+    Object obj2 = new Object();
     // violation above 'Only one statement per line allowed.'
   }
 
-  /**
-   * One multiline  assignment (declaration) statement
-   * is legal.
-   */
-  int i = 1, j = 2,
-      k = 5;
+  /** One multiline assignment (declaration) statement is legal. */
+  int i = 1, j = 2, k = 5;
 
-  /**
-   * One multiline  assignment (declaration) statement
-   * is legal.
-   */
-  int l = 1,
-      m = 2,
-      n = 5;
+  /** One multiline assignment (declaration) statement is legal. */
+  int l = 1, m = 2, n = 5;
 
-  /**
-   * One multiline  assignment (declaration) statement
-   * is legal.
-   */
-  int w = 1,
-      x = 2,
-      y = 5
-          ;
+  /** One multiline assignment (declaration) statement is legal. */
+  int w = 1, x = 2, y = 5;
 
-  /**
-   * Two multiline  assignment (declaration) statements
-   * are illegal.
-   */
-  int o = 1, p = 2,
-      r = 5; int t; // violation 'Only one statement per line allowed.'
+  /** Two multiline assignment (declaration) statements are illegal. */
+  int o = 1, p = 2, r = 5;
 
-  /**
-   * Two assignment (declaration) statement
-   * which are not on the same lines and are legal.
-   */
-  int four = 1,
-      five = 5
-          ;
+  int t; // violation 'Only one statement per line allowed.'
+
+  /** Two assignment (declaration) statement which are not on the same lines and are legal. */
+  int four = 1, five = 5;
+
   int seven = 2;
 
-  /**
-   * Two statements on the same line
-   * (they both are distributed over two lines)
-   * are illegal.
-   */
-  int var1 = 5,
-      var4 = 5; int var2 = 6,
-      var3 = 5; // violation 'Only one statement per line allowed.'
+  /** Two statements on the same line (they both are distributed over two lines) are illegal. */
+  int var1 = 5, var4 = 5;
 
-  /**
-   * Two statements on the same line
-   * (they both are distributed over two lines)
-   * are illegal.
-   */
-  int var6 = 5; int var7 = 6,
-      var8 = 5; // violation 'Only one statement per line allowed.'
+  int var2 = 6, var3 = 5; // violation 'Only one statement per line allowed.'
 
-  /**
-   * Two statements on the same line
-   * (they both are distributed over two lines)
-   * are illegal.
-   */
+  /** Two statements on the same line (they both are distributed over two lines) are illegal. */
+  int var6 = 5;
+
+  int var7 = 6, var8 = 5; // violation 'Only one statement per line allowed.'
+
+  /** Two statements on the same line (they both are distributed over two lines) are illegal. */
   private void foo2() {
-    toString(
-
-    ); toString (
-
-    ); // violation 'Only one statement per line allowed.'
+    toString();
+    toString(); // violation 'Only one statement per line allowed.'
   }
 
-
   /**
-   * While theoretically being distributed over two lines, this is a sample
-   * of 2 statements on one line.
+   * While theoretically being distributed over two lines, this is a sample of 2 statements on one
+   * line.
    */
-  int var9 = 1, var10 = 5
-      ; int var11 = 2; // violation 'Only one statement per line allowed.'
+  int var9 = 1, var10 = 5;
 
+  int var11 = 2; // violation 'Only one statement per line allowed.'
 
-  /**
-   * Multiline for loop statement is legal.
-   */
+  /** Multiline for loop statement is legal. */
   private void foo3() {
-    for (int n = 0,
-         k = 1;
-         n < 5; n++,
-             k--) {
-
-    }
+    for (int n = 0, k = 1; n < 5; n++, k--) {}
   }
 
-  /**
-   * Two multiline statements (which are not on the same line)
-   * are legal.
-   */
-  int var12,
-      var13 = 12;
-  int var14 = 5,
-      var15 = 6;
+  /** Two multiline statements (which are not on the same line) are legal. */
+  int var12, var13 = 12;
 
-  /**
-   * This method contains break and while loop statements.
-   */
+  int var14 = 5, var15 = 6;
+
+  /** This method contains break and while loop statements. */
   private void foo4() {
     do {
       var9++;
       if (var10 > 4) {
-        break; //legal
+        break; // legal
       }
       var11++;
       var9++;
-    } while (var11 < 7); //legal
+    } while (var11 < 7); // legal
+
+    /** One statement inside for block is legal */
+    for (int i = 0; i < 10; i++) one = 5; // legal
+
+    /** One statement inside for block where increment expression is empty is legal */
+    for (int i = 0; i < 10; ) one = 5; // legal
 
     /**
-     * One statement inside for block is legal
+     * One statement inside for block where increment and conditional expressions are empty (forever
+     * loop) is legal
      */
-    for (int i = 0; i < 10; i++) one = 5; //legal
-
-    /**
-     * One statement inside for block where
-     * increment expression is empty is legal
-     */
-    for (int i = 0; i < 10;) one = 5; //legal
-
-    /**
-     * One statement inside for block where
-     * increment and conditional expressions are empty
-     * (forever loop) is legal
-     */
-    for (int i = 0;;) one = 5; //legal
+    for (int i = 0; ; ) one = 5; // legal
   }
 
   public void foo5() {
-    /**
-     * a "forever" loop.
-     */
-    for(;;){} //legal
+    /** a "forever" loop. */
+    for (; ; ) {} // legal
   }
 
   public void foo6() {
-  /**
-   * One statement inside for block is legal
-   */
-    for (;;) { one = 5; } //legal
+    /** One statement inside for block is legal */
+    for (; ; ) {
+      one = 5;
+    } // legal
   }
 
-  /**
-   * One statement inside multiline for loop is legal.
-   */
+  /** One statement inside multiline for loop is legal. */
   private void foo7() {
-    for(int n = 0,
-            k = 1
-            ; n<5
-            ;
-            n++, k--) { var1++; } //legal
-    }
+    for (int n = 0, k = 1; n < 5; n++, k--) {
+      var1++;
+    } // legal
+  }
 
-  /**
-   * Two statements on the same lne
-   * inside multiline for loop are illegal.
-   */
+  /** Two statements on the same lne inside multiline for loop are illegal. */
   private void foo8() {
-    for(int n = 0,
-            k = 1
-            ; n<5
-            ;
-            n++, k--) { var1++; var2++; } // violation 'Only one statement per line allowed.'
-    }
+    for (int n = 0, k = 1; n < 5; n++, k--) {
+      var1++;
+      var2++;
+    } // violation 'Only one statement per line allowed.'
+  }
 }


### PR DESCRIPTION
prove of concept
to show how to we can convert Input fie with violations to correct file and prove that checktyle is not reporting any violation on file passed by formatter

https://github.com/google/google-java-format/releases

file was formatted by:
`rivanov@p5510:/var/tmp$ java -jar google-java-format-1.22.0-all-deps.jar --replace /home/rivanov/java/github/romani/checkstyle/src/it/resources/com/google/checkstyle/test/chapter4formatting/rule43onestatement/InputOneStatementPerLine.java`

 but we will do new file creation, we need to name it same but with "correct" word somewhere. `InputOneStatementPerLineCorrect.java`