### PR TITLE
New Github workflow that provide links to test-configs but reuse contribution repo for report generation

### DIFF
--- a/.github/workflows/regression-report.yml
+++ b/.github/workflows/regression-report.yml
@@ -1,0 +1,254 @@
+#####################################################################################
+# GitHub Action to generate Checkstyle report.
+#
+# Workflow starts when:
+# 1) PR comment - created
+#
+# Requirements:
+# 1) secrets.AWS_ACCESS_KEY_ID - access key for AWS S3 service user
+# 2) secrets.AWS_SECRET_ACCESS_KEY - security access key for AWS S3 service user
+#
+# If you need to change bucket name or region, change AWS_REGION and AWS_BUCKET_NAME variables.
+# For another bucket, you will need to change the secrets.
+#####################################################################################
+name: regression-report
+env:
+  AWS_REGION: us-east-2
+  AWS_BUCKET_NAME: "checkstyle-diff-reports"
+  USER_LOGIN: ${{ github.event.issue.user.login }}
+
+on:
+  issue_comment:
+    types: [ created ]
+
+permissions:
+  contents: read
+  pull-requests: write
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.issue.number }}
+  cancel-in-progress: true
+
+jobs:
+  parse_comment:
+    if: |
+      github.event.issue.pull_request
+           && (startsWith(github.event.comment.body, 'Github, generate report for ')
+              || startsWith(github.event.comment.body, 'GitHub, generate report for '))
+    runs-on: ubuntu-latest
+    outputs:
+      config_bundle_path: ${{ steps.parse.outputs.config_bundle_path }}
+      config_link: ${{ steps.set_links.outputs.config_link }}
+      projects_link: ${{ steps.set_links.outputs.projects_link }}
+      branch: ${{ steps.set_branch.outputs.ref }}
+      commit_sha: ${{ steps.set_branch.outputs.commit_sha }}
+
+    steps:
+      - name: React to comment
+        uses: actions/github-script@v6
+        with:
+          github-token: ${{secrets.GITHUB_TOKEN}}
+          script: |
+            github.rest.reactions.createForIssueComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              comment_id: context.payload.comment.id,
+              content: 'rocket'
+            })
+
+      - run: 'echo We print it here for this action to work'
+        if: 'true'
+
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Parse comment
+        id: parse
+        env:
+          COMMENT_BODY: ${{ github.event.comment.body }}
+        run: |
+          CONFIG_BUNDLE_PATH=$(echo "$COMMENT_BODY" | \
+            sed -E 's/.*(Github|GitHub), generate report for //g')
+          echo "CONFIG_BUNDLE_PATH=$CONFIG_BUNDLE_PATH"
+          ./.ci/append-to-github-output.sh "config_bundle_path" "$CONFIG_BUNDLE_PATH"
+
+      - name: Set config and projects links
+        id: set_links
+        run: |
+          BASE_URL="https://raw.githubusercontent.com/checkstyle/test-configs/main"
+          CONFIG_BUNDLE_PATH="${{ steps.parse.outputs.config_bundle_path }}"
+          CONFIG_LINK="$BASE_URL/$CONFIG_BUNDLE_PATH/config.xml"
+          PROJECTS_LINK="$BASE_URL/$CONFIG_BUNDLE_PATH/list-of-projects.properties"
+          echo "CONFIG_LINK=$CONFIG_LINK"
+          echo "PROJECTS_LINK=$PROJECTS_LINK"
+          ./.ci/append-to-github-output.sh "config_link" "$CONFIG_LINK"
+          ./.ci/append-to-github-output.sh "projects_link" "$PROJECTS_LINK"
+
+      - name: Set branch
+        env:
+          PULL_REQUEST_URL: ${{ github.event.issue.pull_request.url }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        id: set_branch
+        run: |
+          mkdir -p .ci-temp
+          curl --fail-with-body -X GET "${PULL_REQUEST_URL}" \
+              -H "Accept: application/vnd.github+json" \
+              -H "Authorization: token $GITHUB_TOKEN" \
+              -o .ci-temp/info.json
+
+          jq --raw-output .head.ref .ci-temp/info.json > .ci-temp/branch
+          jq --raw-output .head.sha .ci-temp/info.json > .ci-temp/commit_sha
+
+          ./.ci/append-to-github-output.sh "ref" "$(cat .ci-temp/branch)"
+          # shellcheck disable=SC2002
+          ./.ci/append-to-github-output.sh "commit_sha" "$(cat .ci-temp/commit_sha | cut -c 1-7)"
+
+          echo "GITHUB_OUTPUT:"
+          # need to 'echo' to see output in Github CI
+          # shellcheck disable=SC2005
+          echo "$(cat "$GITHUB_OUTPUT")"
+
+  make_report:
+    runs-on: ubuntu-latest
+    needs: parse_comment
+    if: needs.parse_comment.outputs.config_link != ''
+      || needs.parse_comment.outputs.projects_link != ''
+    outputs:
+      message: ${{ steps.out.outputs.message }}
+    steps:
+
+      - name: Download checkstyle
+        uses: actions/checkout@v4
+
+      - name: Download files
+        env:
+          DIFF_CONFIG_LINK: ${{ needs.parse_comment.outputs.config_link }}
+          DIFF_PROJECTS_LINK: ${{ needs.parse_comment.outputs.projects_link }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          ./.ci/diff-report.sh download-files
+
+      # set main checkstyle repo as an upstream
+      # Diff report will be generated taking upstream's master branch as a base branch
+      - name: set upstream
+        run: |
+          bash
+          MAIN_REPO_GIT_URL="https://github.com/checkstyle/checkstyle.git"
+          git remote add upstream "$MAIN_REPO_GIT_URL"
+          git fetch upstream
+          FORK_REPO_GIT_URL="https://github.com/$USER_LOGIN/checkstyle.git"
+          git remote add forked "$FORK_REPO_GIT_URL"
+          git fetch forked
+
+      - name: Setup local maven cache
+        uses: actions/cache@v4
+        with:
+          path: ~/.m2/repository
+          key: checkstyle-maven-cache-${{ hashFiles('**/pom.xml') }}
+
+      - name: Download contribution
+        uses: actions/checkout@v4
+        with:
+          repository: checkstyle/contribution
+          path: .ci-temp/contribution
+
+      - name: Prepare environment
+        run: |
+          mv .ci-temp/project.properties ./.ci-temp/contribution/checkstyle-tester/
+          mv .ci-temp/*.xml ./.ci-temp/contribution/checkstyle-tester/
+          sudo apt install groovy
+
+      - name: Configure AWS Credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: ${{ env.AWS_REGION }}
+
+      - name: Generate report
+        env:
+          BRANCH: ${{ needs.parse_comment.outputs.branch }}
+        run: |
+          cd .ci-temp/contribution/checkstyle-tester
+          bash
+          REF="forked/$BRANCH"
+          REPO="../../../../checkstyle"
+          BASE_BRANCH="upstream/master"
+          export MAVEN_OPTS="-Xmx5g"
+          if [ -f new_module_config.xml ]; then
+            groovy diff.groovy -r "$REPO" -p "$REF" -pc new_module_config.xml -m single\
+              -l project.properties -xm "-Dcheckstyle.failsOnError=false"\
+              --allowExcludes
+          elif [ -f patch_config.xml ]; then
+            groovy diff.groovy -r "$REPO" -b "$BASE_BRANCH" -p "$REF" -bc diff_config.xml\
+              -pc patch_config.xml -l project.properties -xm "-Dcheckstyle.failsOnError=false"\
+              --allowExcludes
+          else
+            groovy diff.groovy -r "$REPO" -b "$BASE_BRANCH" -p "$REF" -c diff_config.xml\
+              -l project.properties -xm "-Dcheckstyle.failsOnError=false"\
+              --allowExcludes
+          fi
+
+      - name: Copy Report to AWS S3 Bucket
+        run: |
+          bash
+          TIME=$(date +%Y%H%M%S)
+          FOLDER="${{needs.parse_comment.outputs.commit_sha}}_$TIME"
+          DIFF="./.ci-temp/contribution/checkstyle-tester/reports/diff"
+          LINK="https://${{env.AWS_BUCKET_NAME}}.s3.${{env.AWS_REGION}}.amazonaws.com"
+          aws s3 cp $DIFF "s3://${{env.AWS_BUCKET_NAME}}/$FOLDER/reports/diff/" --recursive
+          if [ -n "$LABEL" ]; then
+            echo "$LABEL: " > .ci-temp/message
+          fi
+          echo "$LINK/$FOLDER/reports/diff/index.html" >> .ci-temp/message
+
+      - name: Set output
+        id: out
+        run: |
+          ./.ci/append-to-github-output.sh "message" "$(cat .ci-temp/message)"
+
+  # should be always last step
+  send_message:
+    runs-on: ubuntu-latest
+    needs: [ parse_comment, make_report ]
+    if: failure() || success()
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Get message
+        env:
+          MSG: ${{ needs.make_report.outputs.message }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          mkdir -p .ci-temp
+          if [ -z "$MSG" ]; then
+            JOBS_LINK="https://github.com/checkstyle/checkstyle/actions/runs/${{github.run_id}}"
+            API_LINK="https://api.github.com/repos/checkstyle/checkstyle/actions/runs/"
+            API_LINK="${API_LINK}${{github.run_id}}/jobs"
+
+            curl --fail-with-body -X GET "${API_LINK}" \
+              -H "Accept: application/vnd.github+json" \
+              -H "Authorization: token $GITHUB_TOKEN" \
+              -o .ci-temp/info.json
+
+            jq '.jobs' .ci-temp/info.json > ".ci-temp/jobs"
+            jq '.[] | select(.conclusion == "failure") | .name' .ci-temp/jobs > .ci-temp/job_name
+            jq '.[] | select(.conclusion == "failure") | .steps' .ci-temp/jobs > .ci-temp/steps
+            jq '.[] | select(.conclusion == "failure") | .name' .ci-temp/steps > .ci-temp/step_name
+            echo "Report generation failed on phase $(cat .ci-temp/job_name)," > .ci-temp/message
+            echo "step $(cat .ci-temp/step_name).<br>Link: $JOBS_LINK" >> .ci-temp/message
+          else
+            echo "$MSG" > .ci-temp/message
+          fi
+
+      - name: Set message
+        id: out
+        run: |
+          ./.ci/append-to-github-output.sh "message" "$(cat .ci-temp/message)"
+
+      - name: Comment PR
+        uses: checkstyle/contribution/comment-action@master
+        with:
+          message: ${{steps.out.outputs.message}}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Resolves: #15234 

doc how to use: https://github.com/checkstyle/test-configs/tree/main/AbbreviationAsWordInName/Example1#example1-configs


for later: 

https://github.com/checkstyle/test-configs/issues/131
https://github.com/checkstyle/test-configs/issues/139
https://github.com/checkstyle/test-configs/issues/140

example of usage: https://github.com/checkstyle-gsoc/checkstyle/pull/7
https://github.com/checkstyle-gsoc/checkstyle/pull/16
or bunch of any other PR: https://github.com/checkstyle-gsoc/checkstyle/pulls


`also done:`
The code changes also included the rocket symbol not working. This has been fixed and tested. 
<img width="830" alt="image" src="https://github.com/user-attachments/assets/5151ce22-672e-4159-937c-9ac904540a97">
Link to the PR testing: https://github.com/checkstyle-gsoc/checkstyle/pull/7

`also done:`
We need one PR at a time. 
<img width="724" alt="Screenshot 2024-07-24 at 1 10 24 AM" src="https://github.com/user-attachments/assets/7d9b7fd3-3f8d-444b-be2d-1093ee31af3c">

As you can see with changes in workflow to option c, i can only run the latest. Others will be cancelled in the same PR.

<img width="630" alt="image" src="https://github.com/user-attachments/assets/29167e45-e0ff-4e84-ae96-0c6297c14221">
Link to PR: https://github.com/checkstyle-gsoc/checkstyle/pull/11