### PR TITLE
infra: fix links to google style to be relative

### DIFF
--- a/src/xdocs/checks/naming/abbreviationaswordinname.xml
+++ b/src/xdocs/checks/naming/abbreviationaswordinname.xml
@@ -12,7 +12,7 @@
         <p>
           Validates abbreviations (consecutive capital letters) length in identifier name,
           it also allows to enforce camel case naming. Please read more at
-          <a href="https://checkstyle.org/styleguides/google-java-style-20220203/javaguide.html#s5.3-camel-case">
+          <a href="../../styleguides/google-java-style-20220203/javaguide.html#s5.3-camel-case">
           Google Style Guide</a>
           to get to know how to avoid long abbreviations in names.
         </p>

--- a/src/xdocs/checks/naming/abbreviationaswordinname.xml.template
+++ b/src/xdocs/checks/naming/abbreviationaswordinname.xml.template
@@ -12,7 +12,7 @@
         <p>
           Validates abbreviations (consecutive capital letters) length in identifier name,
           it also allows to enforce camel case naming. Please read more at
-          <a href="https://checkstyle.org/styleguides/google-java-style-20220203/javaguide.html#s5.3-camel-case">
+          <a href="../../styleguides/google-java-style-20220203/javaguide.html#s5.3-camel-case">
           Google Style Guide</a>
           to get to know how to avoid long abbreviations in names.
         </p>

--- a/src/xdocs/checks/naming/classtypeparametername.xml
+++ b/src/xdocs/checks/naming/classtypeparametername.xml
@@ -78,7 +78,7 @@ class Example2 {
         </source>
         <p id="Example3-config">
           To configure the check for names that are camel case word with T as suffix
-          (<a href="https://checkstyle.org/styleguides/google-java-style-20220203/javaguide.html#s5.2.8-type-variable-names">Google Style</a>):
+          (<a href="../../styleguides/google-java-style-20220203/javaguide.html#s5.2.8-type-variable-names">Google Style</a>):
         </p>
         <source>
 &lt;module name=&quot;Checker&quot;&gt;

--- a/src/xdocs/checks/naming/classtypeparametername.xml.template
+++ b/src/xdocs/checks/naming/classtypeparametername.xml.template
@@ -52,7 +52,7 @@
         </macro>
         <p id="Example3-config">
           To configure the check for names that are camel case word with T as suffix
-          (<a href="https://checkstyle.org/styleguides/google-java-style-20220203/javaguide.html#s5.2.8-type-variable-names">Google Style</a>):
+          (<a href="../../styleguides/google-java-style-20220203/javaguide.html#s5.2.8-type-variable-names">Google Style</a>):
         </p>
         <macro name="example">
           <param name="path"


### PR DESCRIPTION
problem detected at https://github.com/checkstyle/checkstyle/actions/runs/9913652978/job/27391115727#step:4:2422

```
Checking internal (checkstyle website) and external links.
--- .ci-temp/linkcheck-suppressions-sorted.txt	2024-07-12 20:21:26.341087606 +0000
+++ .ci-temp/linkcheck-errors-sorted.txt	2024-07-12 20:21:26.341087606 +0000
@@ -1,3 +1,7 @@
+<a class="externalLink" href="https://checkstyle.org/styleguides/google-java-style-20220203/javaguide.html#s4.8.6.1-block-comment-style">https://checkstyle.org/styleguides/google-java-style-20220203/javaguide.html#s4.8.6.1-block-comment-style</a>: 404 Not Found
+<a class="externalLink" href="https://checkstyle.org/styleguides/google-java-style-20220203/javaguide.html#s5.2.8-type-variable-names">https://checkstyle.org/styleguides/google-java-style-20220203/javaguide.html#s5.2.8-type-variable-names</a>: 404 Not Found
+<a class="externalLink" href="https://checkstyle.org/styleguides/google-java-style-20220203/javaguide.html#s5.3-camel-case">https://checkstyle.org/styleguides/google-java-style-20220203/javaguide.html#s5.3-camel-case</a>: 404 Not Found
+<a class="externalLink" href="https://checkstyle.org/styleguides/google-java-style-20220203/javaguide.html#s5.3-camel-case">https://checkstyle.org/styleguides/google-java-style-20220203/javaguide.html#s5.3-camel-case</a>: 404 Not Found

```