### PR TITLE
doc: remove Localization section from system properties web page

### DIFF
--- a/src/xdocs/config_system_properties.xml
+++ b/src/xdocs/config_system_properties.xml
@@ -16,15 +16,6 @@
       </macro>
     </section>
 
-    <section name="Localization Support">
-      <p>
-        Checkstyle supports localization of the output messages.
-        If your language is not supported, please consider
-        translating the messages in the <code>messages.properties</code> file. Please let us
-        know if you translate the file.
-      </p>
-    </section>
-
     <section name="Enable External DTD load">
       <p>
         The property <code>checkstyle.enableExternalDtdLoad</code>


### PR DESCRIPTION
taken from https://github.com/checkstyle/checkstyle/pull/15102

just noticed, that content is irrelevan for system properties.

https://checkstyle.org/config.html#Custom_messages
https://checkstyle.org/checks/naming/abbreviationaswordinname.html#Violation_Messages

last list very clearly shows where are translations.