### PR TITLE
Issue #15292: add OS-specific commands to Running > Command Line > Usage by Classpath Update

### DIFF
--- a/src/xdocs/cmdline.xml.vm
+++ b/src/xdocs/cmdline.xml.vm
@@ -334,17 +334,34 @@ java -D&lt;property&gt;=&lt;value&gt;  \
           (Root module, Checks, etc)</a> in configuration file:
         </b>
       </p>
+
+      <p>For Linux/Unix OS:</p>
       <div class="wrap-content">
         <source>
-          java -classpath MyCustom.jar;checkstyle-${projectVersion}-all.jar \
+          java -classpath "MyCustom.jar:checkstyle-${projectVersion}-all.jar" \
           &#xa0;&#xa0;&#xa0;&#xa0;com.puppycrawl.tools.checkstyle.Main -c config.xml Check.java
         </source>
       </div>
+
+      <p>For Windows OS:</p>
+      <div class="wrap-content">
+        <source>
+          java -classpath "MyCustom.jar;checkstyle-${projectVersion}-all.jar" ^
+          &#xa0;&#xa0;&#xa0;&#xa0;com.puppycrawl.tools.checkstyle.Main -c config.xml Check.java
+        </source>
+      </div>
+
       <p>
         <b>Note</b>: Custom modules should be specified with the class'
         <a href="writingchecks.html#Integrating_Checks">full classpath</a>
         in the configuration file and the compiled class be located in the custom
         JAR for Checkstyle to find.
+      </p>
+
+      <p>
+        <b>Note</b>: You will need to use the appropriate path
+        separator (typically <code>;</code> on Windows, <code>:</code> on
+        Linux/Unix and macOS).
       </p>
     </section>
   </body>


### PR DESCRIPTION
Pretty straightforward: adds two different sets of commands for Windows vs Linux/Unix, quotes the entire classpath, and adds a trailing note. Open to any suggestions (copy, placement, etc.).

Closes #15292.