### PR TITLE
minor : Extend exclude list for openjdk projects

### DIFF
--- a/config/projects-to-test/openjdk17-excluded.files
+++ b/config/projects-to-test/openjdk17-excluded.files
@@ -501,3 +501,9 @@
 <module name="BeforeExecutionExclusionFileFilter">
   <property name="fileNamePattern" value="[\\/]test[\\/]langtools[\\/]tools[\\/]javac[\\/]annotations[\\/]neg[\\/]pkg[\\/]package-info.java$"/>
 </module>
+<module name="BeforeExecutionExclusionFileFilter">
+  <property name="fileNamePattern" value="[\\/]test[\\/]langtools[\\/]tools[\\/]javac[\\/]switchextra[\\/]SwitchArrowBrokenConstant.java$"/>
+</module>
+<module name="BeforeExecutionExclusionFileFilter">
+  <property name="fileNamePattern" value="[\\/]test[\\/]langtools[\\/]tools[\\/]javac[\\/]switchexpr[\\/]ParserRecovery.java$"/>
+</module>

--- a/config/projects-to-test/openjdk19-excluded.files
+++ b/config/projects-to-test/openjdk19-excluded.files
@@ -551,3 +551,9 @@
 <module name="BeforeExecutionExclusionFileFilter">
   <property name="fileNamePattern" value="[\\/]test[\\/]langtools[\\/]tools[\\/]javac[\\/]incompleteStatements[\\/]T8000484.java$"/>
 </module>
+<module name="BeforeExecutionExclusionFileFilter">
+  <property name="fileNamePattern" value="[\\/]test[\\/]langtools[\\/]tools[\\/]javac[\\/]switchextra[\\/]SwitchArrowBrokenConstant.java$"/>
+</module>
+<module name="BeforeExecutionExclusionFileFilter">
+  <property name="fileNamePattern" value="[\\/]test[\\/]langtools[\\/]tools[\\/]javac[\\/]switchexpr[\\/]ParserRecovery.java$"/>
+</module>

--- a/config/projects-to-test/openjdk20-excluded.files
+++ b/config/projects-to-test/openjdk20-excluded.files
@@ -530,4 +530,9 @@
 <module name="BeforeExecutionExclusionFileFilter">
   <property name="fileNamePattern" value="[\\/]test[\\/]langtools[\\/]tools[\\/]javac[\\/]LabeledDeclaration.java$"/>
 </module>
-
+<module name="BeforeExecutionExclusionFileFilter">
+  <property name="fileNamePattern" value="[\\/]test[\\/]langtools[\\/]tools[\\/]javac[\\/]switchextra[\\/]SwitchArrowBrokenConstant.java$"/>
+</module>
+<module name="BeforeExecutionExclusionFileFilter">
+  <property name="fileNamePattern" value="[\\/]test[\\/]langtools[\\/]tools[\\/]javac[\\/]switchexpr[\\/]ParserRecovery.java$"/>
+</module>

--- a/config/projects-to-test/openjdk21-excluded.files
+++ b/config/projects-to-test/openjdk21-excluded.files
@@ -612,3 +612,9 @@
 <module name="BeforeExecutionExclusionFileFilter">
   <property name="fileNamePattern" value="[\\/]test[\\/]langtools[\\/]tools[\\/]javac[\\/]diags[\\/]examples[\\/]GuardNotAllowed.java$"/>
 </module>
+<module name="BeforeExecutionExclusionFileFilter">
+  <property name="fileNamePattern" value="[\\/]test[\\/]langtools[\\/]tools[\\/]javac[\\/]switchextra[\\/]SwitchArrowBrokenConstant.java$"/>
+</module>
+<module name="BeforeExecutionExclusionFileFilter">
+  <property name="fileNamePattern" value="[\\/]test[\\/]langtools[\\/]tools[\\/]javac[\\/]switchexpr[\\/]ParserRecovery.java$"/>
+</module>


### PR DESCRIPTION
NPE on non-compile able file from `MissingNullCaseInSwitch` Report:


https://checkstyle-diff-reports.s3.us-east-2.amazonaws.com/adcd467_2024031159/reports/diff/openjdk21/index.html#A968

https://checkstyle-diff-reports.s3.us-east-2.amazonaws.com/adcd467_2024031159/reports/diff/openjdk21/index.html#A976


PR: https://github.com/checkstyle/checkstyle/pull/15113
report: https://checkstyle-diff-reports.s3.us-east-2.amazonaws.com/adcd467_2024031159/reports/diff/index.html