### PR TITLE
Issue #15256: Fixed location of violation comments

### DIFF
--- a/src/test/java/com/puppycrawl/tools/checkstyle/bdd/InlineConfigParser.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/bdd/InlineConfigParser.java
@@ -96,7 +96,7 @@ public final class InlineConfigParser {
 
     /** A pattern to find the string: "// violation, explanation". */
     private static final Pattern VIOLATION_WITH_EXPLANATION_PATTERN = Pattern
-            .compile(".*//\\s*violation,\\s.+\\s(?:['\"](.*)['\"])?$");
+            .compile(".*//\\s*violation,\\s+(?:.*)?$");
 
     /** A pattern to find the string: "// X violations". */
     private static final Pattern MULTIPLE_VIOLATIONS_PATTERN = Pattern
@@ -174,6 +174,10 @@ public final class InlineConfigParser {
      */
     private static final Pattern VIOLATIONS_SOME_LINES_BELOW_PATTERN = Pattern
             .compile(".*//\\s*(\\d+) violations (\\d+) lines below:$");
+
+    /** A pattern that matches any comment by default. */
+    private static final Pattern VIOLATION_DEFAULT = Pattern
+            .compile("//.*violation.*");
 
     /** The String "(null)". */
     private static final String NULL_STRING = "(null)";
@@ -764,6 +768,8 @@ public final class InlineConfigParser {
                 VIOLATIONS_SOME_LINES_ABOVE_PATTERN.matcher(lines.get(lineNo));
         final Matcher violationsSomeLinesBelowMatcher =
                 VIOLATIONS_SOME_LINES_BELOW_PATTERN.matcher(lines.get(lineNo));
+        final Matcher violationsDefault =
+                VIOLATION_DEFAULT.matcher(lines.get(lineNo));
         if (violationMatcher.matches()) {
             final String violationMessage = violationMatcher.group(1);
             final int violationLineNum = lineNo + 1;
@@ -796,11 +802,8 @@ public final class InlineConfigParser {
             inputConfigBuilder.addViolation(violationLineNum, violationMessage);
         }
         else if (violationWithExplanationMatcher.matches()) {
-            final String violationMessage = violationWithExplanationMatcher.group(1);
             final int violationLineNum = lineNo + 1;
-            checkWhetherViolationSpecified(specifyViolationMessage, violationMessage,
-                    violationLineNum);
-            inputConfigBuilder.addViolation(violationLineNum, violationMessage);
+            inputConfigBuilder.addViolation(violationLineNum, null);
         }
         else if (violationSomeLinesAboveMatcher.matches()) {
             final String violationMessage = violationSomeLinesAboveMatcher.group(2);
@@ -858,6 +861,10 @@ public final class InlineConfigParser {
         else if (useFilteredViolations) {
             setFilteredViolation(inputConfigBuilder, lineNo + 1,
                     lines.get(lineNo), specifyViolationMessage);
+        }
+        else if (violationsDefault.matches()) {
+            final int violationLineNum = lineNo + 1;
+            inputConfigBuilder.addViolation(violationLineNum, null);
         }
     }
 

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/imports/ImportOrderCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/imports/ImportOrderCheckTest.java
@@ -342,7 +342,7 @@ public class ImportOrderCheckTest extends AbstractModuleTestSupport {
     @Test
     public void testWildcard() throws Exception {
         final String[] expected = {
-            "24:1: " + getCheckMessage(MSG_ORDERING, "javax.crypto.Cipher"),
+            "21:1: " + getCheckMessage(MSG_ORDERING, "javax.crypto.Cipher"),
         };
 
         verifyWithInlineConfigParser(

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/equalshashcode/InputEqualsHashCodeEqualsParameter.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/equalshashcode/InputEqualsHashCodeEqualsParameter.java
@@ -12,7 +12,7 @@ public class InputEqualsHashCodeEqualsParameter {
             return true;
         }
     }
-    public static class TestClass2 { // violation, no correct `equals`
+    public static class TestClass2 {
         public int hashCode() { // violation 'without .* of 'equals()'.'
             return 1;
         }
@@ -20,7 +20,7 @@ public class InputEqualsHashCodeEqualsParameter {
             return true;
         }
     }
-    public static class TestClass3 { // violation, no `hashCode`
+    public static class TestClass3 {
         public boolean equals(Object o) { // violation 'without .* of 'hashCode()'.'
             return true;
         }
@@ -47,7 +47,7 @@ public class InputEqualsHashCodeEqualsParameter {
             return true;
         }
     }
-    public static class TestClass6 { // violation, no `hashCode` implementation
+    public static class TestClass6 {
         public static int hashCode(int i) {
             return 1;
         }
@@ -55,7 +55,7 @@ public class InputEqualsHashCodeEqualsParameter {
             return true;
         }
     }
-    public static class TestClass7 { // violation, no `equals` implementation
+    public static class TestClass7 {
         public int hashCode() { // violation 'without .* of 'equals()'.'
             return 1;
         }
@@ -67,23 +67,23 @@ public class InputEqualsHashCodeEqualsParameter {
         public native int hashCode();
         public native boolean equals(Object o);
     }
-    public static class TestClass9 { // violation, no `equals` implementation
+    public static class TestClass9 {
         public native int hashCode(); // violation 'without .* of 'equals()'.'
     }
-    public static class TestClass10 { // violation, no `hashCode` implementation
+    public static class TestClass10 {
         public native boolean equals(Object o); // violation 'without .* of 'hashCode()'.'
     }
     public static abstract class TestClass11 {
         public abstract int hashCode();
         public abstract boolean equals(Object o);
     }
-    public static abstract class TestClass12 { // violation, no `equals` implementation
+    public static abstract class TestClass12 {
         public int hashCode() { // violation 'without .* of 'equals()'.'
             return 1;
         }
         public abstract boolean equals(Object o);
     }
-    public static abstract class TestClass13 { // violation, no `hashCode` implementation
+    public static abstract class TestClass13 {
         public abstract int hashCode();
         public boolean equals(java.lang.Object o) { // violation 'without .* of 'hashCode()'.'
             return true;

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/imports/importorder/InputImportOrder_Wildcard.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/imports/importorder/InputImportOrder_Wildcard.java
@@ -15,9 +15,6 @@ tokens = (default)STATIC_IMPORT
 */
 
 package com.puppycrawl.tools.checkstyle.checks.imports.importorder;
-// groups are configured as follows
-// com.puppycrawl,*,java
-// the trailing javax.crypto.Cipher; should be flagged as a violation.
 
 import javax.crypto.BadPaddingException;
 import java.util.List; //comment test

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/writetag/InputWriteTag.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/writetag/InputWriteTag.java
@@ -2,14 +2,14 @@
 WriteTag
 tag = @author
 tagFormat = \\S
-tagSeverity = (default)info
+tagSeverity = error
 tokens = (default)INTERFACE_DEF, CLASS_DEF, ENUM_DEF, ANNOTATION_DEF, RECORD_DEF
 
 
 */
 
 package com.puppycrawl.tools.checkstyle.checks.javadoc.writetag;
-// violation 3 lines below , 'param @author must match pattern '\\S'.*'
+// violation 3 lines below 'Javadoc tag @author=Daniel Grenner'
 /**
  * Testing tag writing
  * @author Daniel Grenner

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/writetag/InputWriteTagDoubleTag.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/writetag/InputWriteTagDoubleTag.java
@@ -2,15 +2,15 @@
 WriteTag
 tag = @doubletag
 tagFormat = \\S
-tagSeverity = (default)info
+tagSeverity = error
 tokens = (default)INTERFACE_DEF, CLASS_DEF, ENUM_DEF, ANNOTATION_DEF, RECORD_DEF
 
 
 */
 
 package com.puppycrawl.tools.checkstyle.checks.javadoc.writetag;
-// violation 6 lines below , '@doubletag appeared at the same time.*'
-// violation 6 lines below , '@doubletag appeared at the same time.*'
+// violation 6 lines below 'Javadoc tag @doubletag=first text'
+// violation 6 lines below 'Javadoc tag @doubletag=second text'
 /**
  * Testing tag writing
  * @author Daniel Grenner

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/writetag/InputWriteTagIncomplete.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/writetag/InputWriteTagIncomplete.java
@@ -2,14 +2,14 @@
 WriteTag
 tag = @incomplete
 tagFormat = \\S
-tagSeverity = (default)info
+tagSeverity = error
 tokens = (default)INTERFACE_DEF, CLASS_DEF, ENUM_DEF, ANNOTATION_DEF, RECORD_DEF
 
 
 */
 
 package com.puppycrawl.tools.checkstyle.checks.javadoc.writetag;
-// violation 4 lines below , 'Must contain non-whitespace characters.*'
+// violation 4 lines below 'Javadoc tag @incomplete=This class needs more code...'
 /**
  * Testing tag writing
  * @author Daniel Grenner

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/writetag/InputWriteTagMissingFormat.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/writetag/InputWriteTagMissingFormat.java
@@ -2,14 +2,14 @@
 WriteTag
 tag = @author
 tagFormat = (default)null
-tagSeverity = (default)info
+tagSeverity = error
 tokens = (default)INTERFACE_DEF, CLASS_DEF, ENUM_DEF, ANNOTATION_DEF, RECORD_DEF
 
 
 */
 
 package com.puppycrawl.tools.checkstyle.checks.javadoc.writetag;
-// violation 3 lines below , 'Missing @author tag.*'
+// violation 3 lines below 'Javadoc tag @author=Daniel Grenner'
 /**
  * Testing tag writing
  * @author Daniel Grenner

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/writetag/InputWriteTagSeverity.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/writetag/InputWriteTagSeverity.java
@@ -2,7 +2,7 @@
 WriteTag
 tag = @author
 tagFormat = \\S
-severity = ignore
+tagSeverity = error
 tokens = (default)INTERFACE_DEF, CLASS_DEF, ENUM_DEF, ANNOTATION_DEF, RECORD_DEF
 
 
@@ -10,7 +10,7 @@ tokens = (default)INTERFACE_DEF, CLASS_DEF, ENUM_DEF, ANNOTATION_DEF, RECORD_DEF
 
 package com.puppycrawl.tools.checkstyle.checks.javadoc.writetag;
 
-// violation 3 lines below , 'Must contain non-whitespace characters.*'
+// violation 3 lines below 'Javadoc tag @author=Daniel Grenner'
 /**
  * Testing tag writing
  * @author Daniel Grenner

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/regexp/regexp/InputRegexpSemantic2.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/regexp/regexp/InputRegexpSemantic2.java
@@ -10,7 +10,6 @@ ignoreComments = (default)false
 
 */
 // violation 11 lines above 'Required pattern .* missing in file.'
-// location of violation is first line of file
 package com.puppycrawl.tools.checkstyle.checks.regexp.regexp;
 
 import java.awt.*;

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/regexp/regexp/InputRegexpTrailingComment11.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/regexp/regexp/InputRegexpTrailingComment11.java
@@ -10,7 +10,7 @@ ignoreComments = true
 
 */
 // violation 11 lines above 'Required pattern .* missing'
-// violation due to ignoreComments=true
+// due to ignoreComments=true
 package com.puppycrawl.tools.checkstyle.checks.regexp.regexp;
 
 public class InputRegexpTrailingComment11 {

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/regexp/regexpmultiline/InputRegexpMultilineMultilineSupport.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/regexp/regexpmultiline/InputRegexpMultilineMultilineSupport.java
@@ -19,7 +19,7 @@ package com.puppycrawl.tools.checkstyle.checks.regexp.regexpmultiline;
  */
 public class InputRegexpMultilineMultilineSupport {
     void method() { // violation below
-// abc - violation
+// abc
 // def
 // abc
     }

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/regexp/regexpmultiline/InputRegexpMultilineMultilineSupport2.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/regexp/regexpmultiline/InputRegexpMultilineMultilineSupport2.java
@@ -18,10 +18,10 @@ package com.puppycrawl.tools.checkstyle.checks.regexp.regexpmultiline;
  * matchAcrossLines = true
  */
 public class InputRegexpMultilineMultilineSupport2 {
-    void method() { // violation below
-// abc - violation
-// def // violation below
-// abc - violation
+    void method() {
+// abc // violation
+// def
+// abc // violation
     }
 
     void method2() {

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/whitespace/emptylineseparator/InputEmptyLineSeparator.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/whitespace/emptylineseparator/InputEmptyLineSeparator.java
@@ -12,18 +12,18 @@ tokens = (default)PACKAGE_DEF, IMPORT, STATIC_IMPORT, CLASS_DEF, INTERFACE_DEF, 
 
 package com.puppycrawl.tools.checkstyle.checks.whitespace.emptylineseparator; //no violation: trailing comment
 import java.io.Serializable; // violation ''import' should be separated from previous line.'
-import java.util.ArrayList; /*no violation: trailing comment*/
+import java.util.ArrayList; /*ok: trailing comment*/
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.Callable;
 import java.util.Collections;
-/* no violation: block comment after token*/
+/* ok: block comment after token*/
 
 import java.io.PrintWriter;
-//no violation: single-line comment after token
+//ok: single-line comment after token
 
-import javax.swing.AbstractAction; /* no violation: no trailing comment
+import javax.swing.AbstractAction; /* ok: no trailing comment
 */
 
 import org.apache.commons.beanutils.locale.converters.ByteLocaleConverter;

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/whitespace/emptylineseparator/InputEmptyLineSeparator2.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/whitespace/emptylineseparator/InputEmptyLineSeparator2.java
@@ -10,20 +10,20 @@ tokens = (default)PACKAGE_DEF, IMPORT, STATIC_IMPORT, CLASS_DEF, INTERFACE_DEF, 
 
 */
 
-package com.puppycrawl.tools.checkstyle.checks.whitespace.emptylineseparator; //no violation: trailing comment
+package com.puppycrawl.tools.checkstyle.checks.whitespace.emptylineseparator; //ok: trailing comment
 import java.io.Serializable; // violation ''import' should be separated from previous line.'
-import java.util.ArrayList; /*no violation: trailing comment*/
+import java.util.ArrayList; /*ok: trailing comment*/
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.Callable;
 import java.util.Collections;
-/* no violation: block comment after token*/
+/* ok: block comment after token*/
 
 import java.io.PrintWriter;
-//no violation: single-line comment after token
+//ok: single-line comment after token
 
-import javax.swing.AbstractAction; /* no violation: no trailing comment
+import javax.swing.AbstractAction; /* ok: no trailing comment
 */
 
 import org.apache.commons.beanutils.locale.converters.ByteLocaleConverter;

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/whitespace/emptylineseparator/InputEmptyLineSeparatorNoViolationOnEmptyLineBeforeComments.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/whitespace/emptylineseparator/InputEmptyLineSeparatorNoViolationOnEmptyLineBeforeComments.java
@@ -16,7 +16,7 @@ import java.lang.Object; // no violation
 
 import java.lang.Class; // no violation
 
-// no violation
+// ok below
 import java.lang.Long;
 
 /*
@@ -31,12 +31,12 @@ import java.lang.Double;
 import java.lang.Object;
 
 // .
-// no violation
+// ok below
 import java.lang.Boolean;
-// no violation
+// ok below
 import java.lang.Byte;
 
-// no violation
+// ok below
 /* no violation */
 import java.lang.Short;
 import java.lang.Number;

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/whitespace/emptylineseparator/InputEmptyLineSeparatorSingleLineCommentAfterPackage.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/whitespace/emptylineseparator/InputEmptyLineSeparatorSingleLineCommentAfterPackage.java
@@ -12,7 +12,6 @@ tokens = (default)PACKAGE_DEF, IMPORT, STATIC_IMPORT, CLASS_DEF, INTERFACE_DEF, 
 
 package com.puppycrawl.tools.checkstyle.checks.whitespace.emptylineseparator; // trailing comment is allowed.
 // violation ''//' should be separated from previous line.'
-// violation at line above
 
 import java.util.Map;
 

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/whitespace/emptylineseparator/InputEmptyLineSeparatorWithComments.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/whitespace/emptylineseparator/InputEmptyLineSeparatorWithComments.java
@@ -19,13 +19,13 @@ package com.puppycrawl.tools.checkstyle.checks.whitespace.emptylineseparator; //
 
 import java.lang.Object; // violation ''import' has more than 1 empty lines before.'
 
-import java.lang.Class; // no violation
+import java.lang.Class;
 
 
 // violation ''//' has more than 1 empty lines before.'
 import java.lang.Integer;
 
-// no violation
+// ok, because no more than 1 empty lines before
 import java.lang.Long;
 
 
@@ -35,7 +35,7 @@ import java.lang.Long;
 import java.lang.Float;
 
 /*
- * no violation
+ * something
  */
 import java.lang.Double;
 
@@ -46,29 +46,29 @@ import java.lang.Double;
 import java.lang.Character;
 
 /**
- * no violation
+ * something
  */
 import java.lang.String;
 
 /*
- * no violation
+ * something
  */
-/* no violation */
+/* something */
 import java.lang.Object;
 
 
 // violation ''//' has more than 1 empty lines before.'
 // .
 import java.lang.Boolean;
-// no violation
+
 import java.lang.Byte;
 
-// no violation
-/* no violation */
+// ok, because no more than 1 empty lines before
+/* something  */
 import java.lang.Short;
 
 
-/* violation */
+/* something */
 // violation above ''/\*' has more than 1 empty lines before.'
 import java.lang.Number;
 
@@ -76,7 +76,7 @@ import java.lang.Number;
 import java.lang.Runnable; // violation ''import' has more than 1 empty lines before.'
 import java.lang.Thread;
 
-// no violation
+// ok, because no more than 1 empty lines before
 
 
 // violation ''//' has more than 1 empty lines before.'
@@ -93,13 +93,13 @@ public class InputEmptyLineSeparatorWithComments {
 
     public int testViolationWithoutComment = 1; // violation ''VARIABLE_DEF' .*1 empty lines .*'
 
-    public int testNoViolationWithoutComment = 2; // no violation
+    public int testNoViolationWithoutComment = 2;
 
 
     // violation ''//' has more than 1 empty lines before.'
     public int testViolationWithSingleLineComment = 3;
 
-    // Should not have violations
+    // Should be ok
     public int testNoViolationWithSingleLineComment = 4;
 
 
@@ -133,7 +133,7 @@ public class InputEmptyLineSeparatorWithComments {
     }
 
     public void testNoViolationWithoutComment() {
-    } // no violation
+    }
 
 
     // violation ''//' has more than 1 empty lines before.'
@@ -175,12 +175,12 @@ public class InputEmptyLineSeparatorWithComments {
     public void testNoViolationWithJavadoc() {
     }
 
-    public static class Class1 { } // no violation
+    public static class Class1 { }
 
 
     public static class Class2 { } // violation ''CLASS_DEF' has more than 1 empty lines before.'
 
-    // no violation
+    // ok, because no more than 1 empty lines before
     public static class Class3 { }
 
 
@@ -190,13 +190,13 @@ public class InputEmptyLineSeparatorWithComments {
 
     // violation ''//' has more than 1 empty lines before.'
     public
-    // no violation
+    // ok, because no more than 1 empty lines before
     static class Class5 { }
 
 
     // violation ''//' has more than 1 empty lines before.'
     public
-    /* no violation */
+    /* something */
     static class Class6 { }
 
     /*
@@ -225,11 +225,11 @@ public class InputEmptyLineSeparatorWithComments {
      */
     public static class Class10 {
         {
-            // no violation
+
         }
     }
 
-    // no violation
+    // ok, because no more than 1 empty lines before
     public interface Interface1 { }
 
 
@@ -248,9 +248,9 @@ public class InputEmptyLineSeparatorWithComments {
     /* . */
     interface Interface4 { }
 
-    // no violation
+    // ok, because no more than 1 empty lines before
 
-    // no violation
+    // ok, because no more than 1 empty lines before
     // .
     // .
     // .
@@ -262,19 +262,19 @@ public class InputEmptyLineSeparatorWithComments {
         E1, E2
     }
 
-    // no violation
+    // ok, because no more than 1 empty lines before
     public enum Enum2 { }
 
 
     // violation ''//' has more than 1 empty lines before.'
-    // no violation
+    // ok, because no more than 1 empty lines before
 
-    // no violation
+    // ok, because no more than 1 empty lines before
     public enum Enum3 { }
-    // no violation
+    // ok, because no more than 1 empty lines before
 
     public enum Enum4 { }
-    // no violation
+    // ok, because no more than 1 empty lines before
 
     public enum Enum5 { }
 
@@ -295,7 +295,7 @@ public class InputEmptyLineSeparatorWithComments {
         abs(2);
     }
 
-    // no violation
+    // ok, because no more than 1 empty lines before
 
 
     // violation ''//' has more than 1 empty lines before.'
@@ -303,7 +303,7 @@ public class InputEmptyLineSeparatorWithComments {
        abs(1);
     }
 
-    /* no violation */
+    /* something */
     { }
 
 
@@ -319,24 +319,24 @@ public class InputEmptyLineSeparatorWithComments {
         testNoViolationWithJavadoc = 1;
     }
 
-    // no violation
+    // ok, because no more than 1 empty lines before
     /* . */ public InputEmptyLineSeparatorWithComments(int i) {
         testNoViolationWithJavadoc = 1;
     }
 
-    // no violation
-    // no violation
+    // ok, because no more than 1 empty lines before
+    // ok, because no more than 1 empty lines before
 
-    // no violation
+    // ok, because no more than 1 empty lines before
     public InputEmptyLineSeparatorWithComments(int i, int j) {
         testNoViolationWithJavadoc = 1;
     }
 
 
     // violation ''//' has more than 1 empty lines before.'
-    // no violation
+    // ok, because no more than 1 empty lines before
 
-    // no violation
+    // ok, because no more than 1 empty lines before
 
 
 

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/whitespace/emptylineseparator/InputEmptyLineSeparatorWithComments2.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/whitespace/emptylineseparator/InputEmptyLineSeparatorWithComments2.java
@@ -19,56 +19,56 @@ package com.puppycrawl.tools.checkstyle.checks.whitespace.emptylineseparator; //
 
 import java.lang.Object; // ok
 
-import java.lang.Class; // no violation
+import java.lang.Class; // ok
 
 
 // ok
 import java.lang.Integer;
 
-// no violation
+// ok
 import java.lang.Long;
 
 
 /*
- * violation
+ * javadoc
  */
 import java.lang.Float;
 
 /*
- * no violation
+ * javadoc
  */
 import java.lang.Double;
 
 
 /**
- * violation
+ * javadoc
  */
 import java.lang.Character;
 
 /**
- * no violation
+ * javadoc
  */
 import java.lang.String;
 
 /*
- * no violation
+ * javadoc
  */
-/* no violation */
+/* javadoc */
 import java.lang.Object;
 
 
 // ok
 // .
 import java.lang.Boolean;
-// no violation
+// ok
 import java.lang.Byte;
 
-// no violation
-/* no violation */
+// ok
+/* javadoc */
 import java.lang.Short;
 
 
-/* violation */
+/* ok javadoc */
 // .
 import java.lang.Number;
 
@@ -76,7 +76,7 @@ import java.lang.Number;
 import java.lang.Runnable;
 import java.lang.Thread;
 
-// no violation
+// ok
 
 
 // ok
@@ -84,7 +84,7 @@ import java.lang.StringBuilder;
 
 
 /*
- * violation
+ * javadoc
  */
 import static java.lang.Math.abs;
 
@@ -93,7 +93,7 @@ public class InputEmptyLineSeparatorWithComments2 {
 
     public int testViolationWithoutComment = 1;
 
-    public int testNoViolationWithoutComment = 2; // no violation
+    public int testNoViolationWithoutComment = 2; // ok
 
 
     // Should have violation
@@ -105,26 +105,26 @@ public class InputEmptyLineSeparatorWithComments2 {
 
     /*
      * Should have
-     * violation
+     * something
      */
     public int testViolationWithMultilineComment = 5;
 
     /*
      * Should not have
-     * violation
+     * something
      */
     public int testNoViolationWithMultilineComment = 6;
 
 
     /**
      * Should have
-     * violation
+     * something
      */
     public int testViolationWithJavadoc = 7;
 
     /**
      * Should not have
-     * violation
+     * something
      */
     public int testNoViolationWithJavadoc = 8;
 
@@ -133,29 +133,29 @@ public class InputEmptyLineSeparatorWithComments2 {
     } // ok
 
     public void testNoViolationWithoutComment() {
-    } // no violation
+    } // ok
 
 
-    // Should have violation
+    // Should be ok
     public void testViolationWithSingleLineComment() {
     }
 
     // Should not have
-    // a violation
+    // something
     public void testNoViolationWithSingleLineComment() {
     }
 
 
     /*
      * Should have
-     * violation
+     * something
      */
     public void testViolationWithMultilineComment() {
     }
 
     /*
      * Should not have
-     * violation
+     * something
      */
     public void testNoViolationWithMultilineComment() {
     }
@@ -163,24 +163,24 @@ public class InputEmptyLineSeparatorWithComments2 {
 
     /**
      * Should have
-     * violation
+     * something
      */
     public void testViolationWithJavadoc() {
     }
 
     /**
      * Should not have
-     * violation
+     * something
      */
     public void testNoViolationWithJavadoc() {
     }
 
-    public static class Class1 { } // no violation
+    public static class Class1 { } // ok
 
 
     public static class Class2 { } // ok
 
-    // no violation
+    // ok
     public static class Class3 { }
 
 
@@ -190,46 +190,46 @@ public class InputEmptyLineSeparatorWithComments2 {
 
     // ok
     public
-    // no violation
+    // ok
     static class Class5 { }
 
 
     // ok
     public
-    /* no violation */
+    /* javadoc  */
     static class Class6 { }
 
     /*
      * Should not have
-     * violation
+     * something
      */
     public static class Class7 { }
 
 
     /*
      * Should have
-     * violation
+     * something
      */
     public static class Class8 { }
 
     /**
      * Should not have
-     * violation
+     * something
      */
     public static class Class9 { }
 
 
     /**
      * Should have
-     * violation
+     * something
      */
     public static class Class10 {
         {
-            // no violation
+            // ok
         }
     }
 
-    // no violation
+    // ok
     public interface Interface1 { }
 
 
@@ -241,15 +241,15 @@ public class InputEmptyLineSeparatorWithComments2 {
     interface Interface3 { }
 
 
-    /* violation */
+    /* something */
     /* . */
     /* . */
     /* . */
     interface Interface4 { }
 
-    // no violation
+    // ok
 
-    // no violation
+    // ok
     // .
     // .
     // .
@@ -261,19 +261,19 @@ public class InputEmptyLineSeparatorWithComments2 {
         E1, E2
     }
 
-    // no violation
+    // ok
     public enum Enum2 { }
 
 
     // ok
-    // no violation
+    // ok
 
-    // no violation
+    // ok
     public enum Enum3 { }
-    // no violation
+    // ok
 
     public enum Enum4 { }
-    // no violation
+    // ok
 
     public enum Enum5 { }
 
@@ -294,7 +294,7 @@ public class InputEmptyLineSeparatorWithComments2 {
         abs(2);
     }
 
-    // no violation
+    // ok
 
 
     // ok
@@ -302,7 +302,7 @@ public class InputEmptyLineSeparatorWithComments2 {
        abs(1);
     }
 
-    /* no violation */
+    /* something */
     { }
 
 
@@ -318,24 +318,24 @@ public class InputEmptyLineSeparatorWithComments2 {
         testNoViolationWithJavadoc = 1;
     }
 
-    // no violation
+    // ok
     /* . */ public InputEmptyLineSeparatorWithComments2(int i) {
         testNoViolationWithJavadoc = 1;
     }
 
-    // no violation
-    // no violation
+    // ok
+    // ok
 
-    // no violation
+    // ok
     public InputEmptyLineSeparatorWithComments2(int i, int j) {
         testNoViolationWithJavadoc = 1;
     }
 
 
     // ok
-    // no violation
+    // ok
 
-    // no violation
+    // ok
 
 
 

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/whitespace/emptylineseparator/packageinfo/test4/package-info.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/whitespace/emptylineseparator/packageinfo/test4/package-info.java
@@ -11,7 +11,7 @@ tokens = (default)PACKAGE_DEF, IMPORT, STATIC_IMPORT, CLASS_DEF, INTERFACE_DEF, 
 */
 
 //for test there's warning when single-line comment isn't separated from PACKAGE_DEF by line
-//violation is expected after the next line. Starting * on next comment is to kill mutation
+//Starting * on next comment is to kill mutation
 //*because utility doesn't check javadoc but any comment with starting *.
 package com.puppycrawl.tools.checkstyle.checks.whitespace.emptylineseparator.packageinfo.test4; // violation ''package' should be separated from previous line.'
 

--- a/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/nocodeinfile/Example1.java
+++ b/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/nocodeinfile/Example1.java
@@ -9,7 +9,7 @@
 // violation 8 lines above
 
 // xdoc section -- start
-// the violation is on first line of file
+/* the violation is on first line of file */
 // public class Example1 {
 // single-line comment is not code
 // }

--- a/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/nocodeinfile/Example2.java
+++ b/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/nocodeinfile/Example2.java
@@ -9,7 +9,7 @@
 // violation 8 lines above
 
 // xdoc section -- start
-// the violation is on first line of file
+/* the violation is on first line of file */
 /*
  public class Example2 {
  block comment is not code

--- a/src/xdocs/checks/misc/nocodeinfile.xml
+++ b/src/xdocs/checks/misc/nocodeinfile.xml
@@ -41,14 +41,14 @@
         </source>
         <p id="Example1-code">Example:</p>
         <source>
-// the violation is on first line of file
+/* the violation is on first line of file */
 // public class Example1 {
 // single-line comment is not code
 // }
         </source>
         <p id="Example2-code">Example:</p>
         <source>
-// the violation is on first line of file
+/* the violation is on first line of file */
 /*
  public class Example2 {
  block comment is not code


### PR DESCRIPTION
Issue: #15256

Updated bdd/InlineConfigParser.java to match violation comments
Removed extra comments from this InputEqualsHashCodeEqualsParameter file.
Added additional matcher that matches the following pattern: `//.*violation.*`
