### PR TITLE
Issue #15218: formatted input file for section 7.1.1 General form to follow google style guide rules

### DIFF
--- a/src/it/resources/com/google/checkstyle/test/chapter7javadoc/rule711generalform/InputSingleLineJavadocAndInvalidJavadocPosition.java
+++ b/src/it/resources/com/google/checkstyle/test/chapter7javadoc/rule711generalform/InputSingleLineJavadocAndInvalidJavadocPosition.java
@@ -1,118 +1,166 @@
-package /** warn */ com.google.checkstyle.test.chapter7javadoc.rule711generalform;
-// violation above 'Javadoc comment is placed in the wrong location.'
+package
+    /** warn */
+    com.google.checkstyle.test.chapter7javadoc.rule711generalform;
+// violation 2 lines above 'Javadoc comment is placed in the wrong location.'
 
-// violation below 'Javadoc comment is placed in the wrong location.'
-/** warn */
+/** warn */ // violation 'Javadoc comment is placed in the wrong location.'
 import java.lang.String;
 
 public class InputSingleLineJavadocAndInvalidJavadocPosition {
 
-    /** As of JDK 1.1, replaced by {@link #setBounds(int,int,int,int)} */
-    void foo1() {}
+  /** As of JDK 1.1, replaced by {@link #setBounds(int,int,int,int)} */
+  void foo1() {}
 
-    /**
-     * As of JDK 1.1, replaced by {@link #setBounds(int,int,int,int)}
-     */
-    void foo2() {}
+  /** As of JDK 1.1, replaced by {@link #setBounds(int,int,int,int)} */
+  void foo2() {}
 
-    /** @throws CheckstyleException if a problem occurs */
-    // violation above 'Single-line Javadoc comment should be multi-line.'
-    void foo3() {}
+  /** @throws CheckstyleException if a problem occurs */
+  // violation above 'Single-line Javadoc comment should be multi-line.'
+  void foo3() {}
 
-    /**
-     * @throws CheckstyleException if a problem occurs
-     */
-    void foo4() {}
+  /**
+   * @throws CheckstyleException if a problem occurs
+   */
+  void foo4() {}
 
-    /** An especially short bit of Javadoc. */
-    void foo5() {}
+  /** An especially short bit of Javadoc. */
+  void foo5() {}
 
-    /**
-     * An especially short bit of Javadoc.
-     */
-    void foo6() {}
+  /** An especially short bit of Javadoc. */
+  void foo6() {}
 
-    /** @inheritDoc */
-    // violation above 'Single-line Javadoc comment should be multi-line.'
-    void foo7() {}
+  /** @inheritDoc */
+  // violation above 'Single-line Javadoc comment should be multi-line.'
+  void foo7() {}
 
-    /** {@inheritDoc} */
-    void foo8() {}
+  /** {@inheritDoc} */
+  void foo8() {}
 
-    /** @customTag */
-    // violation above 'Single-line Javadoc comment should be multi-line.'
-    void bar() {}
+  /** @customTag */
+  // violation above 'Single-line Javadoc comment should be multi-line.'
+  void bar() {}
 
-    /** <h1> Some header </h1> {@inheritDoc} {@code bar1} text*/
-    void bar2() {}
+  /**
+   *
+   *
+   * <h1>Some header </h1>
+   *
+   * {@inheritDoc} {@code bar1} text
+   */
+  void bar2() {}
 
-    /** @customTag <a> href="https://github.com/checkstyle/checkstyle/"</a> text*/
-    // violation above 'Single-line Javadoc comment should be multi-line.'
-    void bar3() {}
+  /** @customTag <a> href="https://github.com/checkstyle/checkstyle/"</a>text */
+  // violation above 'Single-line Javadoc comment should be multi-line.'
+  void bar3() {}
 
-    /** Single line Javadoc that references {@link String}. */
-    void bar4() {}
+  /** Single line Javadoc that references {@link String}. */
+  void bar4() {}
 
-    /** @return in single line javadoc */
-    // violation above 'Single-line Javadoc comment should be multi-line.'
-    int bar5() { return 0; }
+  /** @return in single line javadoc */
+  // violation above 'Single-line Javadoc comment should be multi-line.'
+  int bar5() {
+    return 0;
+  }
 
-    /**
-     * @return in multi line javadoc
-     */
-    int bar6() { return 0; }
+  /**
+   * @return in multi line javadoc
+   */
+  int bar6() {
+    return 0;
+  }
 }
 
 /** warn */ // violation 'Javadoc comment is placed in the wrong location.'
 /** valid */
 class InputInvalidJavadocPosition {
-    /** warn */ // violation 'Javadoc comment is placed in the wrong location.'
+  /** warn */ // violation 'Javadoc comment is placed in the wrong location.'
 }
+
 /** valid */
 /* ignore */
 class InputInvalidJavadocPosition2 {
+  /** warn */ // violation 'Javadoc comment is placed in the wrong location.'
+  static {
+    /* ignore */
+  }
+
+  /** warn */ // violation 'Javadoc comment is placed in the wrong location.'
+  /** valid */
+  int field1;
+
+  /** valid */
+  int[] field2;
+
+  /** valid */
+  public int[] field3;
+
+  /** valid */
+  @Deprecated int field4;
+
+  int
+      /** warn */ // violation 'Javadoc comment is placed in the wrong location.'
+      field20;
+  int field21
+      /** warn */  // violation 'Javadoc comment is placed in the wrong location.'
+      ;
+  @Deprecated
+  /** warn */ // violation 'Javadoc comment is placed in the wrong location.'
+  int field22;
+
+  void method1() {}
+
+  /** valid */
+  void method2() {}
+
+  /** valid */
+  <T> T method3() {
+    return null;
+  }
+
+  /** valid */
+  String[] method4() {
+    return null;
+  }
+
+  void
+      /** warn */ // violation 'Javadoc comment is placed in the wrong location.'
+      method20() {}
+
+  void method21
+      /** warn */ // violation 'Javadoc comment is placed in the wrong location.'
+      () {}
+
+  void method22(
+      /** warn */ // violation 'Javadoc comment is placed in the wrong location.'
+      ) {}
+
+  void method23()
+      /** warn */ // violation 'Javadoc comment is placed in the wrong location.'
+      {}
+
+  void method24() {
     /** warn */ // violation 'Javadoc comment is placed in the wrong location.'
-    static { /* ignore */ }
+  }
 
+  void method25() {
     /** warn */ // violation 'Javadoc comment is placed in the wrong location.'
-    /** valid */
-    int field1;
-    /** valid */
-    int[] field2;
-    /** valid */
-    public int[] field3;
-    /** valid */
-    @Deprecated int field4;
-
-    int /** warn */ field20; // violation 'Javadoc comment is placed in the wrong location.'
-    int field21 /** warn */; // violation 'Javadoc comment is placed in the wrong location.'
-    @Deprecated /** warn */ int field22;
-    // violation above 'Javadoc comment is placed in the wrong location.'
-
-    void method1() {}
-    /** valid */
-    void method2() {}
-    /** valid */
-    <T> T method3() { return null; }
-    /** valid */
-    String[] method4() { return null; }
-
-    void /** warn */ method20() {} // violation 'Javadoc comment is placed in the wrong location.'
-    void method21 /** warn */ () {} // violation 'Javadoc comment is placed in the wrong location.'
-    void method22(/** warn */) {} // violation 'Javadoc comment is placed in the wrong location.'
-    void method23() /** warn */ {} // violation 'Javadoc comment is placed in the wrong location.'
-    void method24() { /** warn */ } // violation 'Javadoc comment is placed in the wrong location.'
-    void method25() { /** warn */ int variable; }
-    // violation above 'Javadoc comment is placed in the wrong location.'
+    int variable;
+  }
 }
+
 @Deprecated
 /** warn */ // violation 'Javadoc comment is placed in the wrong location.'
 class InputInvalidJavadocPosition3 {}
+
 /** valid */
 @Deprecated
 class InputInvalidJavadocPosition4 {}
-class /** warn */ InputInvalidJavadocPosition5 {}
-// violation above 'Javadoc comment is placed in the wrong location.'
-class InputInvalidJavadocPosition6 /** warn */ {}
-// violation above 'Javadoc comment is placed in the wrong location.'
+
+class
+/** warn */ // violation 'Javadoc comment is placed in the wrong location.'
+InputInvalidJavadocPosition5 {}
+
+class InputInvalidJavadocPosition6
+/** warn */ // violation 'Javadoc comment is placed in the wrong location.'
+ {}
 /** warn */ // violation 'Javadoc comment is placed in the wrong location.'


### PR DESCRIPTION
#15218 

https://checkstyle.org/google_style.html#a7.1.1

>[SingleLineJavadoc](https://checkstyle.org/checks/javadoc/singlelinejavadoc.html#SingleLineJavadoc) Recent update for guide that clarify requirements will be addressed at[ #4052](https://github.com/checkstyle/checkstyle/issues/4052)
InvalidJavadocPosition


https://checkstyle.org/styleguides/google-java-style-20180523/javaguide.html#s7.1.1-javadoc-multi-line

>The basic form is always acceptable. The single-line form may be substituted when the entirety of the Javadoc block (including comment markers) can fit on a single-line. Note that this only applies when there are no block tags such as `@return`. 

attention; InvalidJavadocPosition is in use , but old version of syle guide is not released yet.
but this check is in covergate already: https://github.com/checkstyle/checkstyle/blob/981c0cb87eb58cafef5c84014f94ba1f05080a46/src/xdocs/google_style.xml#L2089C21-L2089C43