### PR TITLE
Issue #15218: formatted input files for section 4.6.2 Horizontal Whitespace to follow google style guide rules

### DIFF
--- a/src/it/resources/com/google/checkstyle/test/chapter4formatting/rule462horizontalwhitespace/InputGenericWhitespace.java
+++ b/src/it/resources/com/google/checkstyle/test/chapter4formatting/rule462horizontalwhitespace/InputGenericWhitespace.java
@@ -2,96 +2,86 @@ package com.google.checkstyle.test.chapter4formatting.rule462horizontalwhitespac
 
 import java.io.Serializable;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.Callable;
-import java.util.Collections;
-class InputGenericWhitespace implements Comparable<InputGenericWhitespace>, Serializable
-{
-    void meth()
-    {
-        List<Integer> x = new ArrayList<Integer>();
-        List<List<Integer>> y = new ArrayList<List<Integer>>();
-        List < Integer > a = new ArrayList < Integer >();
-        // 6 violations above:
-        //  ''\<' is followed by whitespace.'
-        //  ''\<' is preceded with whitespace.'
-        //  ''\>' is preceded with whitespace.'
-        //  ''\<' is followed by whitespace.'
-        //  ''\<' is preceded with whitespace.'
-        //  ''\>' is preceded with whitespace.'
-        List < List < Integer > > b = new ArrayList < List < Integer > >();
-        // 14 violations above:
-        //  ''\<' is followed by whitespace.'
-        //  ''\<' is preceded with whitespace.'
-        //  ''\<' is followed by whitespace.'
-        //  ''\<' is preceded with whitespace.'
-        //  ''\>' is followed by whitespace.'
-        //  ''\>' is preceded with whitespace.'
-        //  ''\>' is preceded with whitespace.'
-        //  ''\<' is followed by whitespace.'
-        //  ''\<' is preceded with whitespace.'
-        //  ''\<' is followed by whitespace.'
-        //  ''\<' is preceded with whitespace.'
-        //  ''\>' is followed by whitespace.'
-        //  ''\>' is preceded with whitespace.'
-        //  ''\>' is preceded with whitespace.'
-    }
 
-    public int compareTo(InputGenericWhitespace aObject)
-    {
-        return 0;
-    }
+class InputGenericWhitespace implements Comparable<InputGenericWhitespace>, Serializable {
+  <T> InputGenericWhitespace(List<T> things, int i) {}
 
-    public static <T> Callable<T> callable(Runnable task, T result)
-    {
-        return null;
-    }
+  public <T> InputGenericWhitespace(List<T> things) {}
 
-    public static<T>Callable<T> callable2(Runnable task, T result)
+  public static <T> Callable<T> callable(Runnable task, T result) {
+    return null;
+  }
+
+  // 2 violations 3 lines below:
+  //  ''\<' is not preceded with whitespace.'
+  //  ''\>' should followed by whitespace.'
+  public static<T>Callable<T> callable2(Runnable task, T result) {
+    Map<Class<?>, Integer> x = new HashMap<Class<?>, Integer>();
+    for (final Map.Entry<Class<?>, Integer> entry : x.entrySet()) {
+      entry.getValue();
+    }
+    Class<?>[] parameterClasses = new Class<?>[0];
+    return null;
+  }
+
+  void meth() {
+    List<Integer> x = new ArrayList<Integer>();
+    List<List<Integer>> y = new ArrayList<List<Integer>>();
+    List < Integer > a = new ArrayList < Integer >();
+    // 6 violations above:
+    //  ''\<' is followed by whitespace.'
+    //  ''\<' is preceded with whitespace.'
+    //  ''\>' is preceded with whitespace.'
+    //  ''\<' is followed by whitespace.'
+    //  ''\<' is preceded with whitespace.'
+    //  ''\>' is preceded with whitespace.'
+    List < List < Integer > > b = new ArrayList < List < Integer > >();
+    // 14 violations above:
+    //  ''\<' is followed by whitespace.'
+    //  ''\<' is preceded with whitespace.'
+    //  ''\<' is followed by whitespace.'
+    //  ''\<' is preceded with whitespace.'
+    //  ''\>' is followed by whitespace.'
+    //  ''\>' is preceded with whitespace.'
+    //  ''\>' is preceded with whitespace.'
+    //  ''\<' is followed by whitespace.'
+    //  ''\<' is preceded with whitespace.'
+    //  ''\<' is followed by whitespace.'
+    //  ''\<' is preceded with whitespace.'
+    //  ''\>' is followed by whitespace.'
+    //  ''\>' is preceded with whitespace.'
+    //  ''\>' is preceded with whitespace.'
+  }
+
+  public int compareTo(InputGenericWhitespace aObject) {
+    return 0;
+  }
+
+  public int getConstructor(Class<?>... parameterTypes) {
+    Collections.<Object>emptySet();
+    Collections. <Object> emptySet();
     // 2 violations above:
-    //  ''\<' is not preceded with whitespace.'
-    //  ''\>' should followed by whitespace.'
-    {
-        Map<Class<?>, Integer> x = new HashMap<Class<?>, Integer>();
-        for (final Map.Entry<Class<?>, Integer> entry : x.entrySet()) {
-            entry.getValue();
-        }
-        Class<?>[] parameterClasses = new Class<?>[0];
-        return null;
-    }
-    public int getConstructor(Class<?>... parameterTypes)
-    {
-        Collections.<Object>emptySet();
-        Collections. <Object> emptySet();
-        // 2 violations above:
-        //  ''\<' is preceded with whitespace.'
-        //  ''\>' is followed by whitespace.'
-        return 666;
-    }
+    //  ''\<' is preceded with whitespace.'
+    //  ''\>' is followed by whitespace.'
+    return 666;
+  }
 
-    <T> InputGenericWhitespace(List<T> things, int i)
-    {
-    }
+  public interface IntEnum {}
 
-    public <T> InputGenericWhitespace(List<T> things)
-    {
-    }
+  public static class IntEnumValueType<E extends Enum<E> & IntEnum> {}
 
-    public interface IntEnum {
-    }
-
-    public static class IntEnumValueType<E extends Enum<E> & IntEnum> {
-    }
-
-    public static class IntEnumValueType2<E extends Enum<E>& IntEnum> {
+  public static class IntEnumValueType2<E extends Enum<E>& IntEnum> {
     // 2 violations above:
     //  ''&' is not preceded with whitespace.'
     //  ''&' is not preceded with whitespace.'
-    }
+  }
 
-    public static class IntEnumValueType3<E extends Enum<E>  & IntEnum> {
+  public static class IntEnumValueType3<E extends Enum<E>  & IntEnum> {
     // violation above ''\>' is followed by whitespace.'
-    }
+  }
 }

--- a/src/it/resources/com/google/checkstyle/test/chapter4formatting/rule462horizontalwhitespace/InputGenericWhitespaceEndsTheLine.java
+++ b/src/it/resources/com/google/checkstyle/test/chapter4formatting/rule462horizontalwhitespace/InputGenericWhitespaceEndsTheLine.java
@@ -1,7 +1,7 @@
 package com.google.checkstyle.test.chapter4formatting.rule462horizontalwhitespace;
 
 public class InputGenericWhitespaceEndsTheLine {
-    public boolean returnsGenericObjectAtEndOfLine(Object otherObject) {
-        return otherObject instanceof Enum<?>;
-    }
+  public boolean returnsGenericObjectAtEndOfLine(Object otherObject) {
+    return otherObject instanceof Enum<?>;
+  }
 }

--- a/src/it/resources/com/google/checkstyle/test/chapter4formatting/rule462horizontalwhitespace/InputMethodParamPad.java
+++ b/src/it/resources/com/google/checkstyle/test/chapter4formatting/rule462horizontalwhitespace/InputMethodParamPad.java
@@ -1,63 +1,54 @@
 package com.google.checkstyle.test.chapter4formatting.rule462horizontalwhitespace;
+
 import java.util.Vector;
+
 /** Test input for MethodDefPadCheck */
-public class InputMethodParamPad
-{
-    public InputMethodParamPad()
-    {
-        super();
-    }
+public class InputMethodParamPad {
+  public InputMethodParamPad() {
+    super();
+  }
 
-    public InputMethodParamPad (int aParam) // violation ''(' is preceded with whitespace.'
-    {
-        super (); // violation ''(' is preceded with whitespace.'
-    }
+  public InputMethodParamPad (int aParam) { // violation ''(' is preceded with whitespace.'
+    super (); // violation ''(' is preceded with whitespace.'
+  }
 
-    public void method()
-    {
-    }
+  public void method() {}
 
-    public void method (int aParam) // violation ''(' is preceded with whitespace.'
-    {
-    }
+  public void method (int aParam) {} // violation ''(' is preceded with whitespace.'
 
-    public void
-        method(double aParam)
-    {
-        // invoke constructor
-        InputMethodParamPad pad = new InputMethodParamPad();
-        pad = new InputMethodParamPad (); // violation ''(' is preceded with whitespace.'
-        pad = new
+  public void method(double aParam) {
+    // invoke constructor
+    InputMethodParamPad pad = new InputMethodParamPad();
+    pad = new InputMethodParamPad (); // violation ''(' is preceded with whitespace.'
+    pad = new
             InputMethodParamPad();
 
-        // call method
+    // call method
+    method();
+    method (); // violation ''(' is preceded with whitespace.'
+  }
+
+  public void dottedCalls() {
+    this.method();
+    this.method (); // violation ''(' is preceded with whitespace.'
+    this.
         method();
-        method (); // violation ''(' is preceded with whitespace.'
-    }
 
-    public void dottedCalls()
-    {
-        this.method();
-        this.method (); // violation ''(' is preceded with whitespace.'
-        this.
-            method();
+    InputMethodParamPad p = new InputMethodParamPad();
+    p.method();
+    p.method (); // violation ''(' is preceded with whitespace.'
+    p.
+         method();
 
-        InputMethodParamPad p = new InputMethodParamPad();
-        p.method();
-        p.method (); // violation ''(' is preceded with whitespace.'
-        p.
-            method();
+    java.lang.Integer.parseInt("0");
+    java.lang.Integer.parseInt ("0"); // violation ''(' is preceded with whitespace.'
+    java.lang.Integer.
+       parseInt("0");
+  }
 
-        java.lang.Integer.parseInt("0");
-        java.lang.Integer.parseInt ("0"); // violation ''(' is preceded with whitespace.'
-        java.lang.Integer.
-            parseInt("0");
-    }
-
-    public void newArray()
-    {
-        int[] a = new int[]{0, 1};
-        java.util.Vector<String> v = new java.util.Vector<String>();
-        java.util.Vector<String> v1 = new Vector<String>();
-    }
+  public void newArray() {
+    int[] a = new int[]{0, 1};
+    java.util.Vector<String> v = new java.util.Vector<String>();
+    java.util.Vector<String> v1 = new Vector<String>();
+  }
 }

--- a/src/it/resources/com/google/checkstyle/test/chapter4formatting/rule462horizontalwhitespace/InputNoWhitespaceBeforeAnnotations.java
+++ b/src/it/resources/com/google/checkstyle/test/chapter4formatting/rule462horizontalwhitespace/InputNoWhitespaceBeforeAnnotations.java
@@ -4,41 +4,39 @@ import java.lang.annotation.ElementType;
 import java.lang.annotation.Target;
 
 @Target(ElementType.TYPE_USE)
-@interface NonNull {
-
-}
+@interface NonNull {}
 
 public class InputNoWhitespaceBeforeAnnotations {
 
-    public void foo(final char @NonNull [] param) {} // ok
+  @NonNull int @NonNull [] @NonNull [] fiel1; // ok until #8205
+  @NonNull int @NonNull [] @NonNull [] field2; // ok
 
-    @NonNull int @NonNull[] @NonNull[] fiel1; // ok until #8205
-    @NonNull int @NonNull [] @NonNull [] field2; // ok
-    //@NonNull int @NonNull ... field3; // non-compilable
-    //@NonNull int @NonNull... field4; // non-compilable
+  public void foo(final char @NonNull [] param) {} // ok
 
+  // @NonNull int @NonNull ... field3; // non-compilable
+  // @NonNull int @NonNull... field4; // non-compilable
 
-    public void foo1(final char[] param) { // ok
-    }
+  public void foo1(final char[] param) { // ok
+  }
 
-    public void foo2(final char [] param) { // ok
-    }
+  public void foo2(final char[] param) { // ok
+  }
 
-    public void foo3(final char @NonNull[] param) { // ok until #8205
-    }
+  public void foo3(final char @NonNull [] param) { // ok until #8205
+  }
 
-    public void foo4(final char @NonNull [] param) { // ok
-    }
+  public void foo4(final char @NonNull [] param) { // ok
+  }
 
-    void test1(String... param) { // ok until #8205
-    }
+  void test1(String... param) { // ok until #8205
+  }
 
-    void test2(String ... param) { // ok until #8205
-    }
+  void test2(String... param) { // ok until #8205
+  }
 
-    void test3(String @NonNull... param) { // ok until #8205
-    }
+  void test3(String @NonNull ... param) { // ok until #8205
+  }
 
-    void test4(String @NonNull ... param) { // ok
-    }
+  void test4(String @NonNull ... param) { // ok
+  }
 }

--- a/src/it/resources/com/google/checkstyle/test/chapter4formatting/rule462horizontalwhitespace/InputNoWhitespaceBeforeCaseDefaultColon.java
+++ b/src/it/resources/com/google/checkstyle/test/chapter4formatting/rule462horizontalwhitespace/InputNoWhitespaceBeforeCaseDefaultColon.java
@@ -1,14 +1,14 @@
 package com.google.checkstyle.test.chapter4formatting.rule462horizontalwhitespace;
 
 public class InputNoWhitespaceBeforeCaseDefaultColon {
-    {
-        switch (1) {
-            case 1 : // violation '':' is preceded with whitespace.'
-                break;
-            case 2:
-                break;
-            default : // violation '':' is preceded with whitespace.'
-                break;
-        }
+  {
+    switch (1) {
+      case 1 : // violation '':' is preceded with whitespace.'
+        break;
+      case 2:
+        break;
+      default : // violation '':' is preceded with whitespace.'
+        break;
     }
+  }
 }

--- a/src/it/resources/com/google/checkstyle/test/chapter4formatting/rule462horizontalwhitespace/InputNoWhitespaceBeforeColonOfLabel.java
+++ b/src/it/resources/com/google/checkstyle/test/chapter4formatting/rule462horizontalwhitespace/InputNoWhitespaceBeforeColonOfLabel.java
@@ -2,13 +2,15 @@ package com.google.checkstyle.test.chapter4formatting.rule462horizontalwhitespac
 
 public class InputNoWhitespaceBeforeColonOfLabel {
 
-    {
-        label1 : // violation '':' is preceded with whitespace.'
-        for (int i = 0; i < 10; i++) {}
+  {
+    label1 : // violation '':' is preceded with whitespace.'
+    for (int i = 0; i < 10; i++) {
     }
+  }
 
-    public void foo() {
-        label2:
-        while (true) {}
+  public void foo() {
+    label2:
+    while (true) {
     }
+  }
 }

--- a/src/it/resources/com/google/checkstyle/test/chapter4formatting/rule462horizontalwhitespace/InputNoWhitespaceBeforeEmptyForLoop.java
+++ b/src/it/resources/com/google/checkstyle/test/chapter4formatting/rule462horizontalwhitespace/InputNoWhitespaceBeforeEmptyForLoop.java
@@ -2,21 +2,21 @@ package com.google.checkstyle.test.chapter4formatting.rule462horizontalwhitespac
 
 public class InputNoWhitespaceBeforeEmptyForLoop {
 
-    public static void f() {
-        for (; ; ) { // ok
-            break;
-        }
-        for (int x = 0; ; ) { // ok
-            break;
-        }
-        for (int x = 0 ; ; ) { // violation '';' is preceded with whitespace.'
-            break;
-        }
-        for (int x = 0; x < 10; ) { // ok
-            break;
-        }
-        for (int x = 0; x < 10 ; ) { // violation '';' is preceded with whitespace.'
-            break;
-        }
+  public static void f() {
+    for (; ; ) { // ok
+      break;
     }
+    for (int x = 0; ; ) { // ok
+      break;
+    }
+    for (int x = 0 ; ; ) { // violation '';' is preceded with whitespace.'
+      break;
+    }
+    for (int x = 0; x < 10; ) { // ok
+      break;
+    }
+    for (int x = 0; x < 10 ; ) { // violation '';' is preceded with whitespace.'
+      break;
+    }
+  }
 }

--- a/src/it/resources/com/google/checkstyle/test/chapter4formatting/rule462horizontalwhitespace/InputParenPad.java
+++ b/src/it/resources/com/google/checkstyle/test/chapter4formatting/rule462horizontalwhitespace/InputParenPad.java
@@ -4,343 +4,362 @@ import java.io.IOException;
 import java.io.StringWriter;
 import java.io.Writer;
 
-public class InputParenPad
-{
-    class ParenPadNoSpace  {
-        ParenPadNoSpace() {
-            this(0);
-        }
-
-        ParenPadNoSpace(int i) {
-            super();
-        }
-
-        @SuppressWarnings("")
-        void method(boolean status) {
-            try (Writer writer = new StringWriter()) {
-                do {
-                    writer.append("a");
-                } while (status);
-            } catch (IOException e) {
-                while (status) {
-                    for (int i = 0; i < (long) (2 * (4 / 2)); i++) {
-                        if (i > 2) {
-                            synchronized (this) {
-                                switch (i) {
-                                    case 3:
-                                    case (4):
-                                    case 5:
-                                        break;
-                                }
-                            }
-                        }
-                    }
-                }
-            }
-        }
-    }
-
-    class ParenPadSpaceLeft {
-        ParenPadSpaceLeft( ) {
-            // 2 violations above:
-            //  ''(' is followed by whitespace.'
-            //  '')' is preceded with whitespace.'
-            this( 0); // violation ''(' is followed by whitespace.'
-        }
-
-        ParenPadSpaceLeft( int i) { // violation ''(' is followed by whitespace.'
-            super( );
-            // 2 violations above:
-            //  ''(' is followed by whitespace.'
-            //  '')' is preceded with whitespace.'
-        }
-
-        @SuppressWarnings( "") // violation ''(' is followed by whitespace.'
-        void method( boolean status) { // violation ''(' is followed by whitespace.'
-            try ( Writer writer = new StringWriter( )) {
-                // 3 violations above:
-                //  ''(' is followed by whitespace.'
-                //  ''(' is followed by whitespace.'
-                //  '')' is preceded with whitespace.'
-                do {
-                    writer.append("a");
-                } while ( status); // violation ''(' is followed by whitespace.'
-            } catch ( IOException e) { // violation ''(' is followed by whitespace.'
-                while ( status) { // violation ''(' is followed by whitespace.'
-                    for ( int i = 0; i < ( long) ( 2 * ( 4 / 2)); i++) {
-                        // 3 violations above:
-                        //  ''(' is followed by whitespace.'
-                        //  ''(' is followed by whitespace.'
-                        //  ''(' is followed by whitespace.'
-                        if ( i > 2) { // violation ''(' is followed by whitespace.'
-                            synchronized ( this) { // violation ''(' is followed by whitespace.'
-                                switch ( i) { // violation ''(' is followed by whitespace.'
-                                    case 3:
-                                    case ( 4): // violation ''(' is followed by whitespace.'
-                                    case 5:
-                                        break;
-                                }
-                            }
-                        }
-                    }
-                }
-            }
-        }
-    }
-
-    class ParenPadSpaceRight {
-        ParenPadSpaceRight( ) {
-            // 2 violations above:
-            //  ''(' is followed by whitespace.'
-            //  '')' is preceded with whitespace.'
-            this(0 ); // violation '')' is preceded with whitespace.'
-        }
-
-        ParenPadSpaceRight(int i ) { // violation '')' is preceded with whitespace.'
-            super( );
-            // 2 violations above:
-            //  ''(' is followed by whitespace.'
-            //  '')' is preceded with whitespace.'
-        }
-
-        @SuppressWarnings("" ) // violation '')' is preceded with whitespace.'
-        void method(boolean status ) { // violation '')' is preceded with whitespace.'
-            try (Writer writer = new StringWriter( ) ) {
-                // 3 violations above:
-                //  ''(' is followed by whitespace.'
-                //  '')' is preceded with whitespace.'
-                //  '')' is preceded with whitespace.'
-                do {
-                    writer.append("a" ); // violation '')' is preceded with whitespace.'
-                } while (status ); // violation '')' is preceded with whitespace.'
-            } catch (IOException e ) { // violation '')' is preceded with whitespace.'
-                while (status ) { // violation '')' is preceded with whitespace.'
-                    for (int i = 0; i < (long ) (2 * (4 / 2 ) ); i++ ) {
-                        // 3 violations above:
-                        //  '')' is preceded with whitespace.'
-                        //  '')' is preceded with whitespace.'
-                        //  '')' is preceded with whitespace.'
-                        if (i > 2 ) { // violation '')' is preceded with whitespace.'
-                            synchronized (this ) { // violation '')' is preceded with whitespace.'
-                                switch (i ) { // violation '')' is preceded with whitespace.'
-                                    case 3:
-                                    case (4 ): // violation '')' is preceded with whitespace.'
-                                    case 5:
-                                        break;
-                                }
-                            }
-                        }
-                    }
-                }
-            }
-        }
-    }
-
-    String foo() {
-        return ( (Object // violation ''(' is followed by whitespace.'
-                ) bar( ( 1 > 2 ) ?
-                // 3 violations above:
-                //  ''(' is followed by whitespace.'
-                //  ''(' is followed by whitespace.'
-                //  '')' is preceded with whitespace.'
-                        ( ( 3 < 4 ) ? false : true ) :
-                        // 4 violations above:
-                        //  ''(' is followed by whitespace.'
-                        //  ''(' is followed by whitespace.'
-                        //  '')' is preceded with whitespace.'
-                        //  '')' is preceded with whitespace.'
-                        ( ( 1 == 1 ) ? false : true) ) ).toString();
-                        // 5 violations above:
-                        //  ''(' is followed by whitespace.'
-                        //  ''(' is followed by whitespace.'
-                        //  '')' is preceded with whitespace.'
-                        //  '')' is preceded with whitespace.'
-                        //  '')' is preceded with whitespace.'
-    }
-    @MyAnnotation
-    public boolean bar(boolean a) {
-        assert ( true );
-        // 2 violations above:
-        //  ''(' is followed by whitespace.'
-        //  '')' is preceded with whitespace.'
-        return true;
-    }
-
-    boolean fooo = this.bar(( true && false ) && true);
-    // 2 violations above:
-    //  ''(' is followed by whitespace.'
-    //  '')' is preceded with whitespace.'
-
-}
-@interface MyAnnotation {
-    String someField( ) default "Hello world";
-    // 2 violations above:
-    //  ''(' is followed by whitespace.'
-    //  '')' is preceded with whitespace.'
-}
-
 enum MyEnum {
-    SOME_CONSTANT( ) {
-        // 2 violations above:
-        //  ''(' is followed by whitespace.'
-        //  '')' is preceded with whitespace.'
-        int i = (int) (2 * (4 / 2)
-                );
-    };
+  SOME_CONSTANT( ) {
+    // 2 violations above:
+    //  ''(' is followed by whitespace.'
+    //  '')' is preceded with whitespace.'
+    final int i = 2 * (4 / 2);
+  };
 
-    public void myMethod() {
-        String s = "test";
-        Object o = s;
-        ((String) o).length();
-        ( (String) o ).length();
+  private Object exam;
+
+  private static String getterName( Exception t) { // violation ''(' is followed by whitespace.'
+    if (t instanceof ClassNotFoundException ) { // violation '')' is preceded with whitespace.'
+      return ( (ClassNotFoundException) t ).getMessage();
+      // 2 violations above:
+      //  ''(' is followed by whitespace.'
+      //  '')' is preceded with whitespace.'
+    } else {
+      return "?";
+    }
+  }
+
+  public void myMethod() {
+    String s = "test";
+    Object o = s;
+    ((String) o).length();
+    ( (String) o ).length();
+    // 2 violations above:
+    //  ''(' is followed by whitespace.'
+    //  '')' is preceded with whitespace.'
+  }
+
+  public void crisRon() {
+    Object leo = "messi";
+    Object ibra = leo;
+    ((String) leo).compareTo( (String) ibra );
+    // 2 violations above:
+    //  ''(' is followed by whitespace.'
+    //  '')' is preceded with whitespace.'
+    Math.random();
+  }
+
+  public void intStringConv() {
+    Object a = 5;
+    Object b = "string";
+    int w = Integer.parseInt((String) a);
+    int x = Integer.parseInt( (String) a); // violation ''(' is followed by whitespace.'
+    double y = Double.parseDouble((String) a ); // violation '')' is preceded with whitespace.'
+    float z = Float.parseFloat( (String) a );
+    // 2 violations above:
+    //  ''(' is followed by whitespace.'
+    //  '')' is preceded with whitespace.'
+    String d = ((String) b);
+  }
+
+  public int something( Object o ) {
+    // 2 violations above:
+    //  ''(' is followed by whitespace.'
+    //  '')' is preceded with whitespace.'
+    if ( o == null || !( o instanceof Float ) ) {
+      // 4 violations above:
+      //  ''(' is followed by whitespace.'
+      //  ''(' is followed by whitespace.'
+      //  '')' is preceded with whitespace.'
+      //  '')' is preceded with whitespace.'
+      return -1;
+    }
+    return Integer.valueOf( 22 ).compareTo( (Integer) o );
+    // 4 violations above:
+    //  ''(' is followed by whitespace.'
+    //  '')' is preceded with whitespace.'
+    //  ''(' is followed by whitespace.'
+    //  '')' is preceded with whitespace.'
+  }
+
+  private void launch(Integer number ) { // violation '')' is preceded with whitespace.'
+    String myInt = ( number.toString() + '\0' );
+    // 2 violations above:
+    //  ''(' is followed by whitespace.'
+    //  '')' is preceded with whitespace.'
+    boolean result = number == 123;
+  }
+
+  public String testing() {
+    return ( this.exam != null )
         // 2 violations above:
         //  ''(' is followed by whitespace.'
         //  '')' is preceded with whitespace.'
+        ? ( ( Enum ) this.exam ).name()
+        // 2 violations above:
+        //  ''(' is followed by whitespace.'
+        //  '')' is preceded with whitespace.'
+        : null;
+  }
+
+  Object stringReturnValue( Object result ) {
+    // 2 violations above:
+    //  ''(' is followed by whitespace.'
+    //  '')' is preceded with whitespace.'
+    if ( result instanceof String ) {
+      // 2 violations above:
+      //  ''(' is followed by whitespace.'
+      //  '')' is preceded with whitespace.'
+      result = ( (String) result ).length();
+      // 2 violations above:
+      //  ''(' is followed by whitespace.'
+      //  '')' is preceded with whitespace.'
+    }
+    return result;
+  }
+
+  private void except() {
+    java.util.ArrayList<Integer> arrlist = new java.util.ArrayList<Integer>( 5 );
+    // 2 violations above:
+    //  ''(' is followed by whitespace.'
+    //  '')' is preceded with whitespace.'
+    arrlist.add( 20); // violation ''(' is followed by whitespace.'
+    arrlist.add(15 ); // violation '')' is preceded with whitespace.'
+    arrlist.add( 30 );
+    // 2 violations above:
+    //  ''(' is followed by whitespace.'
+    //  '')' is preceded with whitespace.'
+    arrlist.add(45);
+    try {
+      ( arrlist ).remove( 2);
+      // 3 violations above:
+      //  ''(' is followed by whitespace.'
+      //  '')' is preceded with whitespace.'
+      //  ''(' is followed by whitespace.'
+    } catch ( IndexOutOfBoundsException x ) {
+      // 2 violations above:
+      //  ''(' is followed by whitespace.'
+      //  '')' is preceded with whitespace.'
+      x.getMessage();
+    }
+    org.junit.Assert.assertThat( "123", org.hamcrest.CoreMatchers.is( "123" ) );
+    // 4 violations above:
+    //  ''(' is followed by whitespace.'
+    //  ''(' is followed by whitespace.'
+    //  '')' is preceded with whitespace.'
+    //  '')' is preceded with whitespace.'
+    org.junit.Assert.assertThat( "Help! Integers don't work",
+            // violation above ''(' is followed by whitespace.'
+            0, org.hamcrest.CoreMatchers.is( 1 ) );
+    // 3 violations above:
+    //  ''(' is followed by whitespace.'
+    //  '')' is preceded with whitespace.'
+    //  '')' is preceded with whitespace.'
+  }
+
+  private void tryWithResources() throws Exception {
+    try (AutoCloseable a = null) {}
+    // 2 violations above:
+    //  ''{' is not followed by whitespace.'
+    //  ''}' is not preceded with whitespace.'
+    try (AutoCloseable a = null;
+        AutoCloseable b = null) {}
+    // 2 violations above:
+    //  ''{' is not followed by whitespace.'
+    //  ''}' is not preceded with whitespace.'
+    try (AutoCloseable a = null;
+        AutoCloseable b = null) {}
+    // 2 violations above:
+    //  ''{' is not followed by whitespace.'
+    //  ''}' is not preceded with whitespace.'
+    try (AutoCloseable a = null;
+        AutoCloseable b = null) {}
+    // 2 violations above:
+    //  ''{' is not followed by whitespace.'
+    //  ''}' is not preceded with whitespace.'
+    try (AutoCloseable a = null ) {}
+    // 3 violations above:
+    //  '')' is preceded with whitespace.'
+    //  ''{' is not followed by whitespace.'
+    //  ''}' is not preceded with whitespace.'
+    try (AutoCloseable a = null;
+        AutoCloseable b = null ) {}
+    // 3 violations above:
+    //  '')' is preceded with whitespace.'
+    //  ''{' is not followed by whitespace.'
+    //  ''}' is not preceded with whitespace.'
+  }
+}
+
+@interface MyAnnotation {
+  String someField( ) default "Hello world";
+  // 2 violations above:
+  //  ''(' is followed by whitespace.'
+  //  '')' is preceded with whitespace.'
+}
+
+public class InputParenPad {
+  boolean fooo = this.bar(( true && false ) && true);
+  // 2 violations above:
+  //  ''(' is followed by whitespace.'
+  //  '')' is preceded with whitespace.'
+
+  String foo() {
+    return ( (Object // violation ''(' is followed by whitespace.'
+            )
+            bar( ( 1 > 2 ) ?
+                    // 3 violations above:
+                    //  ''(' is followed by whitespace.'
+                    //  ''(' is followed by whitespace.'
+                    //  '')' is preceded with whitespace.'
+                    ( ( 3 < 4 ) ? false : true ) :
+                    // 4 violations above:
+                    //  ''(' is followed by whitespace.'
+                    //  ''(' is followed by whitespace.'
+                    //  '')' is preceded with whitespace.'
+                    //  '')' is preceded with whitespace.'
+                    ( ( 1 == 1 ) ? false : true) ) ).toString();
+                    // 5 violations above:
+                    //  ''(' is followed by whitespace.'
+                    //  ''(' is followed by whitespace.'
+                    //  '')' is preceded with whitespace.'
+                    //  '')' is preceded with whitespace.'
+                    //  '')' is preceded with whitespace.'
+  }
+
+  @MyAnnotation
+  public boolean bar(boolean a) {
+    assert ( true );
+    // 2 violations above:
+    //  ''(' is followed by whitespace.'
+    //  '')' is preceded with whitespace.'
+    return true;
+  }
+
+  class ParenPadNoSpace {
+    ParenPadNoSpace() {
+      this(0);
     }
 
-    public void crisRon() {
-        Object leo = "messi";
-        Object ibra = leo;
-        ((String) leo).compareTo( (String) ibra );
-        // 2 violations above:
-        //  ''(' is followed by whitespace.'
-        //  '')' is preceded with whitespace.'
-        Math.random();
+    ParenPadNoSpace(int i) {
+      super();
     }
 
-    public void intStringConv() {
-        Object a = 5;
-        Object b = "string";
-        int w = Integer.parseInt((String) a);
-        int x = Integer.parseInt( (String) a); // violation ''(' is followed by whitespace.'
-        double y = Double.parseDouble((String) a ); // violation '')' is preceded with whitespace.'
-        float z = Float.parseFloat( (String) a );
-        // 2 violations above:
-        //  ''(' is followed by whitespace.'
-        //  '')' is preceded with whitespace.'
-        String d = ((String) b);
-    }
-
-    public int something( Object o ) {
-        // 2 violations above:
-        //  ''(' is followed by whitespace.'
-        //  '')' is preceded with whitespace.'
-        if ( o == null || !( o instanceof Float ) ) {
-            // 4 violations above:
-            //  ''(' is followed by whitespace.'
-            //  ''(' is followed by whitespace.'
-            //  '')' is preceded with whitespace.'
-            //  '')' is preceded with whitespace.'
-            return -1;
+    @SuppressWarnings("")
+    void method(boolean status) {
+      try (Writer writer = new StringWriter()) {
+        do {
+          writer.append("a");
+        } while (status);
+      } catch (IOException e) {
+        while (status) {
+          for (int i = 0; i < (long) (2 * (4 / 2)); i++) {
+            if (i > 2) {
+              synchronized (this) {
+                switch (i) {
+                  case 3:
+                  case (4):
+                  case 5:
+                    break;
+                }
+              }
+            }
+          }
         }
-        return Integer.valueOf( 22 ).compareTo( (Integer) o );
-        // 4 violations above:
-        //  ''(' is followed by whitespace.'
-        //  '')' is preceded with whitespace.'
-        //  ''(' is followed by whitespace.'
-        //  '')' is preceded with whitespace.'
+      }
+    }
+  }
+
+  class ParenPadSpaceLeft {
+    ParenPadSpaceLeft( ) {
+      // 2 violations above:
+      //  ''(' is followed by whitespace.'
+      //  '')' is preceded with whitespace.'
+      this( 0); // violation ''(' is followed by whitespace.'
     }
 
-    private void launch(Integer number ) { // violation '')' is preceded with whitespace.'
-        String myInt = ( number.toString() + '\0' );
-        // 2 violations above:
-        //  ''(' is followed by whitespace.'
-        //  '')' is preceded with whitespace.'
-        boolean result = false;
-        if (number == 123)
-            result = true;
+    ParenPadSpaceLeft( int i) { // violation ''(' is followed by whitespace.'
+      super( );
+      // 2 violations above:
+      //  ''(' is followed by whitespace.'
+      //  '')' is preceded with whitespace.'
     }
 
-    private static String getterName( Exception t) { // violation ''(' is followed by whitespace.'
-        if (t instanceof ClassNotFoundException ) { // violation '')' is preceded with whitespace.'
-            return ( (ClassNotFoundException) t ).getMessage();
-            // 2 violations above:
+    @SuppressWarnings( "") // violation ''(' is followed by whitespace.'
+    void method( boolean status) { // violation ''(' is followed by whitespace.'
+      try ( Writer writer = new StringWriter( )) {
+        // 3 violations above:
+        //  ''(' is followed by whitespace.'
+        //  ''(' is followed by whitespace.'
+        //  '')' is preceded with whitespace.'
+        do {
+          writer.append("a");
+        } while ( status); // violation ''(' is followed by whitespace.'
+      } catch ( IOException e) { // violation ''(' is followed by whitespace.'
+        while ( status) { // violation ''(' is followed by whitespace.'
+          for ( int i = 0; i < ( long) ( 2 * ( 4 / 2)); i++) {
+            // 3 violations above:
             //  ''(' is followed by whitespace.'
-            //  '')' is preceded with whitespace.'
-        }
-        else {
-            return "?";
-        }
-    }
-
-    private Object exam;
-
-    public String testing() {
-        return ( this.exam != null )
-                // 2 violations above:
-                //  ''(' is followed by whitespace.'
-                //  '')' is preceded with whitespace.'
-                ? ( ( Enum ) this.exam ).name()
-                // 2 violations above:
-                //  ''(' is followed by whitespace.'
-                //  '')' is preceded with whitespace.'
-                : null;
-    }
-
-    Object stringReturnValue( Object result ) {
-        // 2 violations above:
-        //  ''(' is followed by whitespace.'
-        //  '')' is preceded with whitespace.'
-        if ( result instanceof String ) {
-            // 2 violations above:
             //  ''(' is followed by whitespace.'
-            //  '')' is preceded with whitespace.'
-            result = ( (String) result ).length();
-            // 2 violations above:
             //  ''(' is followed by whitespace.'
-            //  '')' is preceded with whitespace.'
+            if ( i > 2) { // violation ''(' is followed by whitespace.'
+              synchronized ( this) { // violation ''(' is followed by whitespace.'
+                switch ( i) { // violation ''(' is followed by whitespace.'
+                  case 3:
+                  case ( 4): // violation ''(' is followed by whitespace.'
+                  case 5:
+                    break;
+                }
+              }
+            }
+          }
         }
-        return result;
+      }
+    }
+  }
+
+  class ParenPadSpaceRight {
+    ParenPadSpaceRight( ) {
+      // 2 violations above:
+      //  ''(' is followed by whitespace.'
+      //  '')' is preceded with whitespace.'
+      this(0 ); // violation '')' is preceded with whitespace.'
     }
 
+    ParenPadSpaceRight(int i ) { // violation '')' is preceded with whitespace.'
+      super( );
+      // 2 violations above:
+      //  ''(' is followed by whitespace.'
+      //  '')' is preceded with whitespace.'
+    }
 
-
-    private void except() {
-        java.util.ArrayList<Integer> arrlist = new java.util.ArrayList<Integer>( 5 );
-        // 2 violations above:
-        //  ''(' is followed by whitespace.'
-        //  '')' is preceded with whitespace.'
-        arrlist.add( 20); // violation ''(' is followed by whitespace.'
-        arrlist.add(15 ); // violation '')' is preceded with whitespace.'
-        arrlist.add( 30 );
-        // 2 violations above:
-        //  ''(' is followed by whitespace.'
-        //  '')' is preceded with whitespace.'
-        arrlist.add(45);
-        try {
-            ( arrlist ).remove( 2);
+    @SuppressWarnings("" ) // violation '')' is preceded with whitespace.'
+    void method(boolean status ) { // violation '')' is preceded with whitespace.'
+      try (Writer writer = new StringWriter( ) ) {
         // 3 violations above:
         //  ''(' is followed by whitespace.'
         //  '')' is preceded with whitespace.'
-        //  ''(' is followed by whitespace.'
-        } catch ( IndexOutOfBoundsException x ) {
-        // 2 violations above:
-        //  ''(' is followed by whitespace.'
         //  '')' is preceded with whitespace.'
-            x.getMessage();
+        do {
+          writer.append("a" ); // violation '')' is preceded with whitespace.'
+        } while (status ); // violation '')' is preceded with whitespace.'
+      } catch (IOException e ) { // violation '')' is preceded with whitespace.'
+        while (status ) { // violation '')' is preceded with whitespace.'
+          for (int i = 0; i < (long ) (2 * (4 / 2 ) ); i++ ) {
+            // 3 violations above:
+            //  '')' is preceded with whitespace.'
+            //  '')' is preceded with whitespace.'
+            //  '')' is preceded with whitespace.'
+            if (i > 2 ) { // violation '')' is preceded with whitespace.'
+              synchronized (this ) { // violation '')' is preceded with whitespace.'
+                switch (i ) { // violation '')' is preceded with whitespace.'
+                  case 3:
+                  case (4 ): // violation '')' is preceded with whitespace.'
+                  case 5:
+                    break;
+                }
+              }
+            }
+          }
         }
-        org.junit.Assert.assertThat( "123", org.hamcrest.CoreMatchers.is( "123" ) );
-        // 4 violations above:
-        //  ''(' is followed by whitespace.'
-        //  ''(' is followed by whitespace.'
-        //  '')' is preceded with whitespace.'
-        //  '')' is preceded with whitespace.'
-        org.junit.Assert.assertThat( "Help! Integers don't work",
-                // violation above ''(' is followed by whitespace.'
-                0, org.hamcrest.CoreMatchers.is( 1 ) );
-        // 3 violations above:
-        //  ''(' is followed by whitespace.'
-        //  '')' is preceded with whitespace.'
-        //  '')' is preceded with whitespace.'
+      }
     }
+  }
 
-    private void tryWithResources() throws Exception {
-        try (AutoCloseable a = null) { } // ok
-        try (AutoCloseable a = null; AutoCloseable b = null) { } // ok
-        try (AutoCloseable a = null; AutoCloseable b = null; ) { } // ok
-        try (AutoCloseable a = null; AutoCloseable b = null; ) { } // ok
-        try (AutoCloseable a = null ) { } // violation '')' is preceded with whitespace.'
-        try (AutoCloseable a = null; AutoCloseable b = null ) { }
-        // violation above '')' is preceded with whitespace.'
-    }
 }

--- a/src/it/resources/com/google/checkstyle/test/chapter4formatting/rule462horizontalwhitespace/InputWhitespaceAfterBad.java
+++ b/src/it/resources/com/google/checkstyle/test/chapter4formatting/rule462horizontalwhitespace/InputWhitespaceAfterBad.java
@@ -1,102 +1,116 @@
 package com.google.checkstyle.test.chapter4formatting.rule462horizontalwhitespace;
 
 public class InputWhitespaceAfterBad {
-    public void check1(int x,int y) { // violation '',' is not followed by whitespace.'
-        for(int a = 1,b = 2;a < 5;a++,b--);
-        // 6 violations above:
-        //  ''for' is not followed by whitespace.'
-        //  ''for' is not followed by whitespace.'
-        //  '',' is not followed by whitespace.'
-        //  '';' is not followed by whitespace.'
-        //  '';' is not followed by whitespace.'
-        //  '',' is not followed by whitespace.'
-        while(x == 0) {
-        // 2 violations above:
-        //  ''while' is not followed by whitespace.'
-        //  ''while' is not followed by whitespace.'
-            int a = 0,b = 1; // violation '',' is not followed by whitespace.'
-        }
-        do{
-        // 3 violations above:
-        //  ''do' is not followed by whitespace.'
-        //  ''do' is not followed by whitespace.'
-        //  ''{' is not preceded with whitespace.'
-            System.out.println("Testing");
-        } while(x == 0 || y == 2);
-        // 2 violations above:
-        //  ''while' is not followed by whitespace.'
-        //  ''while' is not followed by whitespace.'
+  public void check1(int x,int y) { // violation '',' is not followed by whitespace.'
+    for(int a = 1,b = 2;a < 5;a++,b--)
+      ;
+    // 6 violations 2 lines above:
+    //  ''for' is not followed by whitespace.'
+    //  ''for' is not followed by whitespace.'
+    //  '',' is not followed by whitespace.'
+    //  '';' is not followed by whitespace.'
+    //  '';' is not followed by whitespace.'
+    //  '',' is not followed by whitespace.'
+    while(x == 0) {
+      // 2 violations above:
+      //  ''while' is not followed by whitespace.'
+      //  ''while' is not followed by whitespace.'
+      int a = 0,b = 1; // violation '',' is not followed by whitespace.'
     }
-    public void check2(final int a,final int b) { // violation '',' is not followed by whitespace.'
-        if((float)a == 0.0) {
-        // 3 violations above:
-        //  ''if' is not followed by whitespace.'
-        //  ''if' is not followed by whitespace.'
-        //  ''typecast' is not followed by whitespace.'
-            System.out.println("true");
-        }
-        else{
-        // 3 violations above:
-        //  ''else' is not followed by whitespace.'
-        //  ''else' is not followed by whitespace.'
-        //  ''{' is not preceded with whitespace.'
-            System.out.println("false");
-        }
-    }
+    do{
+      // 3 violations above:
+      //  ''do' is not followed by whitespace.'
+      //  ''do' is not followed by whitespace.'
+      //  ''{' is not preceded with whitespace.'
+      System.out.println("Testing");
+    } while(x == 0 || y == 2);
+    // 2 violations above:
+    //  ''while' is not followed by whitespace.'
+    //  ''while' is not followed by whitespace.'
+  }
 
-    public void check3(int...a) { // violation ''...' is not followed by whitespace.'
-        Runnable r2 = () ->String.valueOf("Hello world two!");
-        // 2 violations above:
-        //  ''->' is not followed by whitespace.'
-        //  ''->' is not followed by whitespace.'
-        switch(a[0]) {
+  public void check2(final int a,final int b) { // violation '',' is not followed by whitespace.'
+    if((float)a == 0.0) {
+      // 3 violations above:
+      //  ''if' is not followed by whitespace.'
+      //  ''if' is not followed by whitespace.'
+      //  ''typecast' is not followed by whitespace.'
+      System.out.println("true");
+    } else{
+      // 3 violations above:
+      //  ''else' is not followed by whitespace.'
+      //  ''else' is not followed by whitespace.'
+      //  ''{' is not preceded with whitespace.'
+      System.out.println("false");
+    }
+  }
+
+  public void check3(int...a) { // violation ''...' is not followed by whitespace.'
+    Runnable r2 = () ->String.valueOf("Hello world two!");
+    // 2 violations above:
+    //  ''->' is not followed by whitespace.'
+    //  ''->' is not followed by whitespace.'
+    switch(a[0]) {
         // 2 violations above:
         //  ''switch' is not followed by whitespace.'
         //  ''switch' is not followed by whitespace.'
-            default:
-                break;
-        }
+      default:
+        break;
+    }
+  }
+
+  public void check4() throws java.io.IOException {
+    try(java.io.InputStream ignored = System.in;) {}
+    // 4 violations above:
+    //  ''try' is not followed by whitespace.'
+    //  ''try' is not followed by whitespace.'
+    //  ''{' is not followed by whitespace.'
+    //  ''}' is not preceded with whitespace.'
+  }
+
+  public void check5() {
+    try {
+
+    } finally{
+      // 3 violations above:
+      //  ''finally' is not followed by whitespace.'
+      //  ''finally' is not followed by whitespace.'
+      //  ''{' is not preceded with whitespace.'
+    }
+    try {
+    } catch (Exception e) {
+    } finally{
+      // 3 violations above:
+      //  ''finally' is not followed by whitespace.'
+      //  ''finally' is not followed by whitespace.'
+      //  ''{' is not preceded with whitespace.'
+    }
+  }
+
+  public void check6() {
+    try {
+    } catch(Exception e) {
+      // 2 violations above:
+      //  ''catch' is not followed by whitespace.'
+      //  ''catch' is not followed by whitespace.'
+    }
+  }
+
+  public void check7() {
+    synchronized(this) {
+      // 2 violations above:
+      //  ''synchronized' is not followed by whitespace.'
+      //  ''synchronized' is not followed by whitespace.'
     }
 
-    public void check4() throws java.io.IOException {
-        try(java.io.InputStream ignored = System.in;) { }
-        // 2 violations above:
-        //  ''try' is not followed by whitespace.'
-        //  ''try' is not followed by whitespace.'
+    synchronized (this) {
     }
+  }
 
-    public void check5() {
-        try { } finally{ }
-        // 3 violations above:
-        //  ''finally' is not followed by whitespace.'
-        //  ''finally' is not followed by whitespace.'
-        //  ''{' is not preceded with whitespace.'
-        try { } catch (Exception e) { } finally{ }
-        // 3 violations above:
-        //  ''finally' is not followed by whitespace.'
-        //  ''finally' is not followed by whitespace.'
-        //  ''{' is not preceded with whitespace.'
-    }
-
-    public void check6() {
-        try { } catch(Exception e) { }
-        // 2 violations above:
-        //  ''catch' is not followed by whitespace.'
-        //  ''catch' is not followed by whitespace.'
-    }
-
-    public void check7() {
-        synchronized(this) { }
-        // 2 violations above:
-        //  ''synchronized' is not followed by whitespace.'
-        //  ''synchronized' is not followed by whitespace.'
-        synchronized (this) { }
-    }
-
-    public String check8() {
-        return("a" + "b");
-        // 2 violations above:
-        //  ''return' is not followed by whitespace.'
-        //  ''return' is not followed by whitespace.'
-    }
+  public String check8() {
+    return("a" + "b");
+    // 2 violations above:
+    //  ''return' is not followed by whitespace.'
+    //  ''return' is not followed by whitespace.'
+  }
 }

--- a/src/it/resources/com/google/checkstyle/test/chapter4formatting/rule462horizontalwhitespace/InputWhitespaceAfterGood.java
+++ b/src/it/resources/com/google/checkstyle/test/chapter4formatting/rule462horizontalwhitespace/InputWhitespaceAfterGood.java
@@ -2,55 +2,66 @@ package com.google.checkstyle.test.chapter4formatting.rule462horizontalwhitespac
 
 public class InputWhitespaceAfterGood {
 
-    int xyz;       // multiple space between content and double slash.
-    int abc; //       multiple space between double slash and comment's text.
-    int pqr;       //     testing both.
+  int xyz;       // multiple space between content and double slash.
+  int abc; //       multiple space between double slash and comment's text.
+  int pqr;       //     testing both.
 
-    public void check1(int x, int y) {
-        for (int a = 1, b = 2; a < 5; a++, b--);
-        while (x == 0) {
-            int a = 0, b = 1;
-        }
-        do {
-            System.out.println("Testing");
-        } while (x == 0 || y == 2);
+  public void check1(int x, int y) {
+    for (int a = 1, b = 2; a < 5; a++, b--)
+      ;
+    while (x == 0) {
+      int a = 0, b = 1;
     }
-    public void check2(final int a, final int b) {
-        if ((float) a == 0.0) {
-            System.out.println("true");
-        }
-        else {
-            System.out.println("false");
-        }
-    }
+    do {
+      System.out.println("Testing");
+    } while (x == 0 || y == 2);
+  }
 
-    public void check3(int... a) {
-        Runnable r2 = () -> String.valueOf("Hello world two!");
-        switch (a[0]) {
-            default:
-                break;
-        }
+  public void check2(final int a, final int b) {
+    if ((float) a == 0.0) {
+      System.out.println("true");
+    } else {
+      System.out.println("false");
     }
+  }
 
-    public void check4() throws java.io.IOException {
-        try (java.io.InputStream ignored = System.in) { }
-        try { } catch (Exception e) { }
+  public void check3(int... a) {
+    Runnable r2 = () -> String.valueOf("Hello world two!");
+    switch (a[0]) {
+      default:
+        break;
     }
+  }
 
-    public void check5() {
-        try { } finally { }
-        try { } catch (Exception e) { } finally { }
+  public void check4() throws java.io.IOException {
+    try (java.io.InputStream ignored = System.in) {}
+    // 2 violations above:
+    //  ''{' is not followed by whitespace.'
+    //  ''}' is not preceded with whitespace.'
+    try {
+    } catch (Exception e) {
     }
+  }
 
-    public void check6() {
-        try { } catch (Exception e) { }
-    }
+  public void check5() {
 
-    public void check7() {
-        synchronized (this) { }
+    try {
+    } catch (Exception e) {
     }
+  }
 
-    public String check8() {
-        return ("a" + "b");
+  public void check6() {
+    try {
+    } catch (Exception e) {
     }
+  }
+
+  public void check7() {
+    synchronized (this) {
+    }
+  }
+
+  public String check8() {
+    return ("a" + "b");
+  }
 }

--- a/src/it/resources/com/google/checkstyle/test/chapter4formatting/rule462horizontalwhitespace/InputWhitespaceAroundBasic.java
+++ b/src/it/resources/com/google/checkstyle/test/chapter4formatting/rule462horizontalwhitespace/InputWhitespaceAroundBasic.java
@@ -1,277 +1,248 @@
 package com.google.checkstyle.test.chapter4formatting.rule462horizontalwhitespace;
 
 /**
- * Class for testing whitespace issues.
- * violation missing author tag
- **/
-class InputWhitespaceAroundBasic
-{
-    private int mVar1= 1; // violation ''=' is not preceded with whitespace.'
-    private int mVar2 =1; // violation ''=' is not followed by whitespace.'
-    /** Should be ok **/
-    private int mVar3 = 1;
-    int xyz;       // multiple space between content and double slash.
-    int abc; //       multiple space between double slash and comment's text.
-    int pqr;       //     testing both.
-
-    /** method **/
-    void method1()
-    {
-        final int a = 1;
-        int b= 1; // violation ''=' is not preceded with whitespace.'
-        b= 1; // violation ''=' is not preceded with whitespace.'
-        b +=1; // violation ''.*' is not followed by whitespace.'
-        b -=- 1 + (+ b); // violation ''-=' is not followed by whitespace.'
-        b = b++ + b--; // ok
-        b = ++ b - -- b; // ok
-    }
-
-    /** method **/
-    void method2()
-    {
-        synchronized(this) {
-        // 2 violations above:
-        //  ''synchronized' is not followed by whitespace.'
-        //  ''synchronized' is not followed by whitespace.'
-        }
-        try {// violation ''{' is not followed by whitespace.'
-        }
-        catch (RuntimeException e) {// violation ''{' is not followed by whitespace.'
-        }
-    }
-
-    /**
-       skip blank lines between comment and code,
-       should be ok
-    **/
-
-
-    private int mVar4 = 1;
-
-
-    /** test WS after void return */
-    private void fastExit()
-    {
-        boolean complicatedStuffNeeded = true;
-        if(!complicatedStuffNeeded)
-        // 2 violations above:
-        //  ''if' is not followed by whitespace.'
-        //  ''if' is not followed by whitespace.'
-        {
-            return; // should not complain about missing WS after return
-        }
-        else
-        {
-            // do complicated stuff
-        }
-    }
-
-
-    /** test WS after non void return
-     @return 2
-    */
-    private int nonVoid()
-    {
-        if (true)
-        {
-            return(2);
-            // 2 violations above:
-            //  ''return' is not followed by whitespace.'
-            //  ''return' is not followed by whitespace.'
-        }
-        else
-        {
-            return 2; // this is ok
-        }
-    }
-
-    /** test casts **/
-    private void testCasts()
-    {
-        Object o = (Object) new Object(); // ok
-        o = (Object) o; // ok
-        o = ( Object ) o; // ok
-        o = (Object)
-            o; // ok
-    }
-
-    /** test questions **/
-    private void testQuestions()
-    {
-
-        boolean b = (1 ==2) ? false : true; // violation ''==' is not followed by whitespace.'
-    }
-
-    /** star test **/
-    private void starTest()
-    {
-        int x = 2 * 3* 4; // violation ''*' is not preceded with whitespace.'
-    }
-
-    /** boolean test **/
-    private void boolTest()
-    {
-        boolean a = true;
-        boolean x = ! a;
-        int z = ~1 + ~ 2;
-    }
-
-    /** division test **/
-    private void divTest()
-    {
-        int a = 4 % 2;
-        int b = 4% 2; // violation ''%' is not preceded with whitespace.'
-        int c = 4 %2; // violation ''%' is not followed by whitespace.'
-        int d = 4% 2; // violation ''%' is not preceded with whitespace.'
-        int e = 4 / 2;
-        int f = 4/ 2; // violation ''/' is not preceded with whitespace.'
-        int g = 4 /2; // violation ''/' is not followed by whitespace.'
-
-    }
-
-    /** @return dot test **/
-    private java.lang.  String dotTest()
-    {
-        Object o = new java.lang.Object();
-        o.
-            toString();
-        o
-            .toString();
-        o. toString();
-        return o.toString();
-    }
-
-    /** assert statement test */
-    public void assertTest()
-    {
-        // OK
-        assert true;
-
-        // OK
-        assert true : "Whups";
-
-        // evil colons, should be OK
-        assert "OK".equals(null) ? false : true : "Whups";
-
-        // missing WS around assert
-        assert(true); // violation ''assert' is not followed by whitespace.'
-
-        // missing WS around colon
-        assert true: "Whups"; // violation '':' is not preceded with whitespace.'
-    }
-
-    /** another check */
-    void donBradman(Runnable aRun)
-    {
-        donBradman(new Runnable() {
-            public void run() {
-            }
-        });
-
-        final Runnable r = new Runnable() {
-            public void run() {
-            }
-        };
-    }
-
-    /** rfe 521323, detect whitespace before ';' */
-    void rfe521323()
-    {
-        doStuff();
-        for (int i = 0; i < 5; i++) {
-        }
-    }
-
-
-    /** bug  806243 (NoWhitespaceBeforeCheck violation for anonymous inner class) */
-    private int i;
-    private int i4, i5, i6;
-
-    /** bug  806243 (NoWhitespaceBeforeCheck violation for anonymous inner class) */
-    void bug806243()
-    {
-        Object o = new InputWhitespaceAroundBasic() {
-            private int j;
-        };
-    }
-
-    void doStuff() {
-    }
-}
-
-/**
  * Bug 806242 (NoWhitespaceBeforeCheck violation with an interface).
+ *
  * @author o_sukhodolsky
  * @version 1.0
  */
-interface IFoo
-{
+
+/** Class for testing whitespace issues. violation missing author tag */
+class InputWhitespaceAroundBasic {
+  private final int mVar1= 1; // violation ''=' is not preceded with whitespace.'
+  private final int mVar2 =1; // violation ''=' is not followed by whitespace.'
+
+  /** Should be ok * */
+  private final int mVar3 = 1;
+
+  /** skip blank lines between comment and code, should be ok */
+  private final int mVar4 = 1;
+
+  int xyz;       // multiple space between content and double slash.
+  int abc; //       multiple space between double slash and comment's text.
+  int pqr;       //     testing both.
+
+  /** bug 806243 (NoWhitespaceBeforeCheck violation for anonymous inner class) */
+  private int i;
+
+  private int i4, i5, i6;
+
+  /** method * */
+  void method1() {
+    final int a = 1;
+    int b= 1; // violation ''=' is not preceded with whitespace.'
+    b= 1; // violation ''=' is not preceded with whitespace.'
+    b +=1; // violation ''\+=' is not followed by whitespace.'
+    b -=- 1 + (+ b); // violation ''-=' is not followed by whitespace.'
+    b = b++ + b--; // ok
+    b = ++ b - -- b; // ok
+  }
+
+  /** method * */
+  void method2() {
+    synchronized(this) {
+      // 2 violations above:
+      //  ''synchronized' is not followed by whitespace.'
+      //  ''synchronized' is not followed by whitespace.'
+    }
+    try{
+      // 3 violations above:
+      //  ''try' is not followed by whitespace.'
+      //  ''try' is not followed by whitespace.'
+      //  ''{' is not preceded with whitespace.'
+    } catch (RuntimeException e) {// violation ''{' is not followed by whitespace.'
+    }
+  }
+
+  /** test WS after void return */
+  private void fastExit() {
+    boolean complicatedStuffNeeded = true;
+    if(!complicatedStuffNeeded)
+    // 2 violations above:
+    //  ''if' is not followed by whitespace.'
+    //  ''if' is not followed by whitespace.'
+    {
+      // should not complain about missing WS after return
+    } else {
+      // do complicated stuff
+    }
+  }
+
+  /**
+   * test WS after non void return
+   *
+   * @return 2
+   */
+  private int nonVoid() {
+    if (true) {
+      return(2);
+      // 2 violations above:
+      //  ''return' is not followed by whitespace.'
+      //  ''return' is not followed by whitespace.'
+    } else {
+      return 2; // this is ok
+    }
+  }
+
+  /** test casts * */
+  private void testCasts() {
+    Object o = (Object) new Object(); // ok
+    o = (Object) o; // ok
+    o = ( Object ) o; // ok
+    o = (Object)
+            o; // ok
+  }
+
+  /** test questions * */
+  private void testQuestions() {
+
+    boolean b = (1 ==2) ? false : true; // violation ''==' is not followed by whitespace.'
+  }
+
+  /** star test * */
+  private void starTest() {
+    int x = 2 * 3* 4; // violation ''*' is not preceded with whitespace.'
+  }
+
+  /** boolean test * */
+  private void boolTest() {
+    boolean a = true;
+    boolean x = !a;
+    int z = ~1 + ~2;
+  }
+
+  /** division test * */
+  private void divTest() {
+    int a = 4 % 2;
+    int b = 4% 2; // violation ''%' is not preceded with whitespace.'
+    int c = 4 %2; // violation ''%' is not followed by whitespace.'
+    int d = 4% 2; // violation ''%' is not preceded with whitespace.'
+    int e = 4 / 2;
+    int f = 4/ 2; // violation ''/' is not preceded with whitespace.'
+    int g = 4 /2; // violation ''/' is not followed by whitespace.'
+  }
+
+  /**
+   * @return dot test *
+   */
+  private java.lang.String dotTest() {
+    Object o = new java.lang.Object();
+    o.toString();
+    o.toString();
+    o.toString();
+    return o.toString();
+  }
+
+  /** assert statement test */
+  public void assertTest() {
+    // OK
+    assert true;
+
+    // OK
+    assert true : "Whups";
+
+    // evil colons, should be OK
+    assert "OK".equals(null) ? false : true : "Whups";
+
+    // missing WS around assert
+    assert(true); // violation ''assert' is not followed by whitespace.'
+
+    // missing WS around colon
+    assert true: "Whups"; // violation '':' is not preceded with whitespace.'
+  }
+
+  /** another check */
+  void donBradman(Runnable aRun) {
+    donBradman(
+        new Runnable() {
+          public void run() {}
+        });
+
+    final Runnable r =
+        new Runnable() {
+          public void run() {}
+        };
+  }
+
+  /** rfe 521323, detect whitespace before ';' */
+  void rfe521323() {
+    doStuff();
+    for (int i = 0; i < 5; i++) {}
+  }
+
+  /** bug 806243 (NoWhitespaceBeforeCheck violation for anonymous inner class) */
+  void bug806243() {
+    Object o =
+        new InputWhitespaceAroundBasic() {
+          private int j;
+        };
+  }
+
+  void doStuff() {}
+
+  interface IFoo {
     void foo();
+  }
 }
 
 /**
  * Avoid Whitespace violations in for loop.
+ *
  * @author lkuehne
  * @version 1.0
  */
-class SpecialCasesInForLoop
-{
-    void forIterator()
-    {
-        // avoid conflict between WhiteSpaceAfter ';' and ParenPad(nospace)
-        for (int i = 0; i++ < 5;) {
-        //                  ^ no whitespace
+class SpecialCasesInForLoop {
+  void forIterator() {
+    // avoid conflict between WhiteSpaceAfter ';' and ParenPad(nospace)
+    for (int i = 0; i++ < 5; ) {
+      //                  ^ no whitespace
     }
 
-        // bug 895072
+    // bug 895072
     // avoid conflict between ParenPad(space) and NoWhiteSpace before ';'
     int i = 0;
-    for ( ; i < 5; i++) {
-    //   ^ whitespace
+    for (; i < 5; i++) {
+      //   ^ whitespace
     }
-        for (int anInt : getSomeInts()) {
-            //Should be ignored
-        }
+    for (int anInt : getSomeInts()) {
+      // Should be ignored
     }
+  }
 
-    int[] getSomeInts() {
-        int i = (int) (2 / 3);
-        return null;
-    }
+  int[] getSomeInts() {
+    int i = 2 / 3;
+    return null;
+  }
 
-    void forColon() {
-        int ll[] = new int[10];
-        for (int x:ll) {}
-        // 2 violations above:
-        //  '':' is not followed by whitespace.'
-        //  '':' is not preceded with whitespace.'
-        for (int x :ll) {} // violation '':' is not followed by whitespace.'
-        for (int x: ll) {} // violation '':' is not preceded with whitespace.'
-        for (int x : ll) {} // ok
-    }
+  void forColon() {
+    int[] ll = new int[10];
+    for (int x:ll) {}
+    // 2 violations above:
+    //  '':' is not followed by whitespace.'
+    //  '':' is not preceded with whitespace.'
+    for (int x :ll) {} // violation '':' is not followed by whitespace.'
+    for (int x: ll) {} // violation '':' is not preceded with whitespace.'
+    for (int x : ll) {} // ok
+  }
 }
 
-/**
- * Operators mentioned in Google Coding Standards 2016-07-12
- */
-class NewGoogleOperators
-{
-    NewGoogleOperators()
-    {
-       Runnable l;
+/** Operators mentioned in Google Coding Standards 2016-07-12 */
+class NewGoogleOperators {
+  NewGoogleOperators() {
+    Runnable l;
 
-       l = ()-> { }; // violation ''->' is not preceded with whitespace.'
-       l = () ->{ };
-       // 2 violations above:
-       //  ''->' is not followed by whitespace.'
-       //  ''->' is not followed by whitespace.'
-       l = () -> { }; //ok
-       l = () -> {}; //ok
+    l = ()-> {}; // violation ''->' is not preceded with whitespace.'
+    l = () ->{};
+    // 2 violations above:
+    //  ''->' is not followed by whitespace.'
+    //  ''->' is not followed by whitespace.'
+    l = () -> {}; // ok
+    l = () -> {}; // ok
 
-       java.util.Arrays.sort(null, String:: compareToIgnoreCase);
-       java.util.Arrays.sort(null, String::compareToIgnoreCase);
+    java.util.Arrays.sort(null, String::compareToIgnoreCase);
+    java.util.Arrays.sort(null, String::compareToIgnoreCase);
 
-       new Object().toString();
-       new Object(). toString();
-    }
+    new Object().toString();
+    new Object().toString();
+  }
 }

--- a/src/it/resources/com/google/checkstyle/test/chapter4formatting/rule462horizontalwhitespace/InputWhitespaceAroundEmptyTypesAndCycles.java
+++ b/src/it/resources/com/google/checkstyle/test/chapter4formatting/rule462horizontalwhitespace/InputWhitespaceAroundEmptyTypesAndCycles.java
@@ -3,21 +3,20 @@ package com.google.checkstyle.test.chapter4formatting.rule462horizontalwhitespac
 import java.util.function.Function;
 import java.util.function.Supplier;
 
-class InputWhitespaceAroundEmptyTypesAndCycles
-{
-    private void foo()
-    {
-        int i = 0;
-        String[][] x = { {"foo"} };
-        for (int first = 0; first < 5; first++) {} //ok
-        int j = 0;
-        while (j == 1) {} //ok
-        do {} while (i == 1); //ok
-    }
+class InputWhitespaceAroundEmptyTypesAndCycles {
+
+  private void foo() {
+    int i = 0;
+    String[][] x = {{"foo"}};
+    for (int first = 0; first < 5; first++) {} // ok
+    int j = 0;
+    while (j == 1) {} // ok
+    do {} while (i == 1); // ok
+  }
+
+  enum EmptyFooEnum {} // ok
+
+  interface SupplierFunction<T> extends Function<Supplier<T>, T> {} // ok
+
+  class EmptyFoo {} // ok
 }
-
-interface SupplierFunction<T> extends Function<Supplier<T>, T> {} //ok
-
-class EmptyFoo {} //ok
-
-enum EmptyFooEnum {} //ok

--- a/src/it/resources/com/google/checkstyle/test/chapter4formatting/rule462horizontalwhitespace/InputWhitespaceAroundGenerics.java
+++ b/src/it/resources/com/google/checkstyle/test/chapter4formatting/rule462horizontalwhitespace/InputWhitespaceAroundGenerics.java
@@ -3,12 +3,14 @@ package com.google.checkstyle.test.chapter4formatting.rule462horizontalwhitespac
 import java.util.Collection;
 import java.util.Map;
 
-public class InputWhitespaceAroundGenerics
-{
+// we need these interfaces for generics
+interface D {}
 
-}
+interface E {}
 
-//No whitespace after commas
+public class InputWhitespaceAroundGenerics {}
+
+// No whitespace after commas
 class BadCommas < A, B, C extends Map < A, String > >
 // 7 violations above:
 //  ''\<' is followed by whitespace.'
@@ -19,39 +21,32 @@ class BadCommas < A, B, C extends Map < A, String > >
 //  ''\>' is preceded with whitespace.'
 //  ''\>' is preceded with whitespace.'
 {
-    private java.util.Hashtable < Integer, D > p =
+  private final java.util.Hashtable < Integer, D > p =
+      // 3 violations above:
+      //  ''\<' is followed by whitespace.'
+      //  ''\<' is preceded with whitespace.'
+      //  ''\>' is preceded with whitespace.'
+      new java.util.Hashtable < Integer, D >();
+  // 3 violations above:
+  //  ''\<' is followed by whitespace.'
+  //  ''\<' is preceded with whitespace.'
+  //  ''\>' is preceded with whitespace.'
+}
+
+class Wildcard {
+  public static void foo(Collection < ? extends Wildcard[] > collection) {
     // 3 violations above:
     //  ''\<' is followed by whitespace.'
     //  ''\<' is preceded with whitespace.'
     //  ''\>' is preceded with whitespace.'
-        new java.util.Hashtable < Integer, D >();
-    // 3 violations above:
-    //  ''\<' is followed by whitespace.'
-    //  ''\<' is preceded with whitespace.'
-    //  ''\>' is preceded with whitespace.'
-}
+    // A statement is important in this method to flush out any
+    // issues with parsing the wildcard in the signature
+    collection.size();
+  }
 
-class Wildcard
-{
-    public static void foo(Collection < ? extends Wildcard[] > collection) {
-        // 3 violations above:
-        //  ''\<' is followed by whitespace.'
-        //  ''\<' is preceded with whitespace.'
-        //  ''\>' is preceded with whitespace.'
-        // A statement is important in this method to flush out any
-        // issues with parsing the wildcard in the signature
-        collection.size();
-    }
-
-    public static void foo2(Collection<?extends Wildcard[]> collection) {
-        // A statement is important in this method to flush out any
-        // issues with parsing the wildcard in the signature
-        collection.size();
-    }
-}
-
-// we need these interfaces for generics
-interface D {
-}
-interface E {
+  public static void foo2(Collection<? extends Wildcard[]> collection) {
+    // A statement is important in this method to flush out any
+    // issues with parsing the wildcard in the signature
+    collection.size();
+  }
 }


### PR DESCRIPTION
#15218 

coverage page: https://checkstyle.org/google_style.html#a4.6.2

modules:

[WhitespaceAround](https://checkstyle.org/checks/whitespace/whitespacearound.html#WhitespaceAround)
[GenericWhitespace](https://checkstyle.org/checks/whitespace/genericwhitespace.html#GenericWhitespace)
[MethodParamPad](https://checkstyle.org/checks/whitespace/methodparampad.html#MethodParamPad)
[ParenPad](https://checkstyle.org/checks/whitespace/parenpad.html#ParenPad)
[WhitespaceAfter](https://checkstyle.org/checks/whitespace/whitespaceafter.html#WhitespaceAfter)
[NoWhitespaceBefore](https://checkstyle.org/checks/whitespace/nowhitespacebefore.html#NoWhitespaceBefore)
[NoWhitespaceBeforeCaseDefaultColon](https://checkstyle.org/checks/whitespace/nowhitespacebeforecasedefaultcolon.html#NoWhitespaceBeforeCaseDefaultColon)
