### PR TITLE
Issue #15214: Migrated section 2.1 File Name to whole config testing

### DIFF
--- a/src/it/java/com/google/checkstyle/test/chapter2filebasic/rule21filename/FileNameTest.java
+++ b/src/it/java/com/google/checkstyle/test/chapter2filebasic/rule21filename/FileNameTest.java
@@ -25,10 +25,6 @@ import com.google.checkstyle.test.base.AbstractGoogleModuleTestSupport;
 
 public class FileNameTest extends AbstractGoogleModuleTestSupport {
 
-    private static final String[] MODULES = {
-        "OuterTypeFilename",
-    };
-
     @Override
     protected String getPackageLocation() {
         return "com/google/checkstyle/test/chapter2filebasic/rule21filename";
@@ -36,20 +32,17 @@ public class FileNameTest extends AbstractGoogleModuleTestSupport {
 
     @Test
     public void testOuterTypeFilename1() throws Exception {
-        final String filePath = getPath("InputFileName1.java");
-        verifyWithConfigParser(MODULES, filePath);
+        verifyWithWholeConfig(getPath("InputFileName1.java"));
     }
 
     @Test
     public void testOuterTypeFilename2() throws Exception {
-        final String filePath = getPath("InputFileName2.java");
-        verifyWithConfigParser(MODULES, filePath);
+        verifyWithWholeConfig(getPath("InputFileName2.java"));
     }
 
     @Test
     public void testOuterTypeFilename3() throws Exception {
-        final String filePath = getPath("InputFileName3.java");
-        verifyWithConfigParser(MODULES, filePath);
+        verifyWithWholeConfig(getPath("InputFileName3.java"));
     }
 
 }

--- a/src/it/resources/com/google/checkstyle/test/chapter2filebasic/rule21filename/InputFileName1.java
+++ b/src/it/resources/com/google/checkstyle/test/chapter2filebasic/rule21filename/InputFileName1.java
@@ -1,5 +1,6 @@
 package com.google.checkstyle.test.chapter2filebasic.rule21filename;
 
+// violation below 'Top-level class MyAnnotation1 has to reside in its own source file.'
 @interface MyAnnotation1 { // ok
   String name();
 
@@ -10,6 +11,7 @@ package com.google.checkstyle.test.chapter2filebasic.rule21filename;
 @MyAnnotation1(name = "ABC", version = 1)
 public class InputFileName1 {} // ok
 
+// violation below 'Top-level class Enum1 has to reside in its own source file.'
 enum Enum1 {
   A,
   B,
@@ -22,6 +24,7 @@ enum Enum1 {
   }
 }
 
+// violation below 'Top-level class TestRequireThisEnum has to reside in its own source file.'
 interface TestRequireThisEnum { // ok
   enum DayOfWeek {
     SUNDAY,

--- a/src/it/resources/com/google/checkstyle/test/chapter2filebasic/rule21filename/InputFileName3.java
+++ b/src/it/resources/com/google/checkstyle/test/chapter2filebasic/rule21filename/InputFileName3.java
@@ -7,9 +7,11 @@ package com.google.checkstyle.test.chapter2filebasic.rule21filename;
   int version();
 }
 
+// violation below 'Top-level class InputFileName3 has to reside in its own source file.'
 @MyAnnotation2(name = "ABC", version = 1)
 class InputFileName3 {} // ok
 
+// violation below 'Top-level class Enum2 has to reside in its own source file.'
 enum Enum2 { // ok
   A,
   B,
@@ -22,6 +24,7 @@ enum Enum2 { // ok
   }
 }
 
+// violation below 'Top-level class TestRequireThisEnum2 has to reside in its own source file.'
 interface TestRequireThisEnum2 { // ok
   enum DayOfWeek {
     SUNDAY,


### PR DESCRIPTION
#15214 

> 2.1 File name | OuterTypeFilename
[2.1 File name](https://checkstyle.org/styleguides/google-java-style-20180523/javaguide.html#s2.1-file-name) 	[OuterTypeFilename](https://checkstyle.org/checks/misc/outertypefilename.html#OuterTypeFilename)

expected violation `type.file.mismatch=The name of the outer type and the file do not match.`