### PR TITLE
Issue #15214: migrated section 4.1.2 non empty blocks K & R style to whole config testing

### DIFF
--- a/src/it/java/com/google/checkstyle/test/chapter4formatting/rule412nonemptyblocks/NonemptyBlocksKrStyleTest.java
+++ b/src/it/java/com/google/checkstyle/test/chapter4formatting/rule412nonemptyblocks/NonemptyBlocksKrStyleTest.java
@@ -25,12 +25,6 @@ import com.google.checkstyle.test.base.AbstractGoogleModuleTestSupport;
 
 public class NonemptyBlocksKrStyleTest extends AbstractGoogleModuleTestSupport {
 
-    private static final String[] MODULES = {
-        "LeftCurly",
-        "RightCurlySame",
-        "RightCurlyAlone",
-    };
-
     @Override
     protected String getPackageLocation() {
         return "com/google/checkstyle/test/chapter4formatting/rule412nonemptyblocks";
@@ -38,56 +32,47 @@ public class NonemptyBlocksKrStyleTest extends AbstractGoogleModuleTestSupport {
 
     @Test
     public void testLeftAndRightCurlyBraces() throws Exception {
-        final String filePath = getPath("InputNonemptyBlocksLeftRightCurly.java");
-        verifyWithConfigParser(MODULES, filePath);
+        verifyWithWholeConfig(getPath("InputNonemptyBlocksLeftRightCurly.java"));
     }
 
     @Test
     public void testLeftCurlyAnnotations() throws Exception {
-        final String filePath = getPath("InputLeftCurlyAnnotations.java");
-        verifyWithConfigParser(MODULES, filePath);
+        verifyWithWholeConfig(getPath("InputLeftCurlyAnnotations.java"));
     }
 
     @Test
     public void testLeftCurlyMethods() throws Exception {
-        final String filePath = getPath("InputLeftCurlyMethod.java");
-        verifyWithConfigParser(MODULES, filePath);
+        verifyWithWholeConfig(getPath("InputLeftCurlyMethod.java"));
     }
 
     @Test
     public void testRightCurly() throws Exception {
-        final String filePath = getPath("InputRightCurly.java");
-        verifyWithConfigParser(MODULES, filePath);
+        verifyWithWholeConfig(getPath("InputRightCurly.java"));
     }
 
     @Test
     public void testRightCurlyLiteralDoDefault() throws Exception {
-        final String filePath = getPath("InputRightCurlyDoWhile.java");
-        verifyWithConfigParser(MODULES, filePath);
+        verifyWithWholeConfig(getPath("InputRightCurlyDoWhile.java"));
     }
 
     @Test
     public void testRightCurlyOther() throws Exception {
-        final String filePath = getPath("InputRightCurlyOther.java");
-        verifyWithConfigParser(MODULES, filePath);
+        verifyWithWholeConfig(getPath("InputRightCurlyOther.java"));
     }
 
     @Test
     public void testRightCurlyLiteralDo() throws Exception {
-        final String filePath = getPath("InputRightCurlyDoWhile2.java");
-        verifyWithConfigParser(MODULES, filePath);
+        verifyWithWholeConfig(getPath("InputRightCurlyDoWhile2.java"));
     }
 
     @Test
     public void testRightCurlySwitch() throws Exception {
-        final String filePath = getPath("InputRightCurlySwitchCase.java");
-        verifyWithConfigParser(MODULES, filePath);
+        verifyWithWholeConfig(getPath("InputRightCurlySwitchCase.java"));
     }
 
     @Test
     public void testRightCurlySwitchCases() throws Exception {
-        final String filePath = getPath("InputRightCurlySwitchCasesBlocks.java");
-        verifyWithConfigParser(MODULES, filePath);
+        verifyWithWholeConfig(getPath("InputRightCurlySwitchCasesBlocks.java"));
     }
 
 }

--- a/src/it/resources/com/google/checkstyle/test/chapter4formatting/rule412nonemptyblocks/InputLeftCurlyAnnotations.java
+++ b/src/it/resources/com/google/checkstyle/test/chapter4formatting/rule412nonemptyblocks/InputLeftCurlyAnnotations.java
@@ -7,34 +7,35 @@ import java.util.List;
 
 @TestClassAnnotation
 class InputLeftCurlyAnnotations
-{ // violation ''{' at column 1 should be on the previous line.'
-  private static final int X = 10;
-
-  @Override
-  public boolean equals(
-      Object other)
   { // violation ''{' at column 3 should be on the previous line.'
-    return false;
+    private static final int X = 10;
+
+    @Override
+    public boolean equals(
+        Object other)
+    { // violation ''{' at column 5 should be on the previous line.'
+      return false;
+    }
+
+    @Override
+    @SuppressWarnings("unused")
+    public int hashCode()
+    { // violation ''{' at column 5 should be on the previous line.'
+      int a = 10;
+      return 1;
+    }
+
+    @Override
+    @SuppressWarnings({"unused", "unchecked", "static-access"})
+    public String toString()
+    { // violation ''{' at column 5 should be on the previous line.'
+      Integer i = this.X;
+      List<String> l = new ArrayList();
+      return "SomeString";
+    }
   }
 
-  @Override
-  @SuppressWarnings("unused")
-  public int hashCode()
-  { // violation ''{' at column 3 should be on the previous line.'
-    int a = 10;
-    return 1;
-  }
-
-  @Override
-  @SuppressWarnings({"unused", "unchecked", "static-access"})
-  public String toString()
-  { // violation ''{' at column 3 should be on the previous line.'
-    Integer i = this.X;
-    List<String> l = new ArrayList();
-    return "SomeString";
-  }
-}
-
+// violation below '.* InputLeftCurlyAnnotations2 has to reside in its own source file.'
 @TestClassAnnotation
 class InputLeftCurlyAnnotations2 {
   private static final int X = 10;
@@ -54,12 +55,13 @@ class InputLeftCurlyAnnotations2 {
   @Override
   @SuppressWarnings({"unused", "unchecked", "static-access"})
   public String toString()
-  { // violation ''{' at column 3 should be on the previous line.'
-    Integer i = this.X;
-    List<String> l = new ArrayList();
-    return "SomeString";
-  }
+    { // violation ''{' at column 5 should be on the previous line.'
+      Integer i = this.X;
+      List<String> l = new ArrayList();
+      return "SomeString";
+    }
 }
 
+// violation below 'Top-level class TestClassAnnotation has to reside in its own source file.'
 @Target(ElementType.TYPE)
 @interface TestClassAnnotation {}

--- a/src/it/resources/com/google/checkstyle/test/chapter4formatting/rule412nonemptyblocks/InputLeftCurlyMethod.java
+++ b/src/it/resources/com/google/checkstyle/test/chapter4formatting/rule412nonemptyblocks/InputLeftCurlyMethod.java
@@ -1,38 +1,15 @@
 package com.google.checkstyle.test.chapter4formatting.rule412nonemptyblocks;
 
 class InputLeftCurlyMethod
-{ // violation ''{' at column 1 should be on the previous line.'
-  InputLeftCurlyMethod() {}
-
-  InputLeftCurlyMethod(String aOne) {}
-
-  InputLeftCurlyMethod(int aOne)
   { // violation ''{' at column 3 should be on the previous line.'
-  }
+    InputLeftCurlyMethod() {}
 
-  void method1() {}
+    InputLeftCurlyMethod(String one) {}
 
-  void method2() {}
+    InputLeftCurlyMethod(int one)
+    { // violation ''{' at column 5 should be on the previous line.'
+    }
 
-  void method3()
-  { // violation ''{' at column 3 should be on the previous line.'
-  }
-
-  void method4()
-  { // violation ''{' at column 3 should be on the previous line.'
-  }
-
-  void method5(String aOne, String aTwo)
-  { // violation ''{' at column 3 should be on the previous line.'
-  }
-
-  void method6(String aOne, String aTwo) {}
-}
-
-enum InputLeftCurlyMethodEnum
-{ // violation ''{' at column 1 should be on the previous line.'
-  CONSTANT1("hello")
-  { // violation ''{' at column 3 should be on the previous line.'
     void method1() {}
 
     void method2() {}
@@ -45,38 +22,61 @@ enum InputLeftCurlyMethodEnum
     { // violation ''{' at column 5 should be on the previous line.'
     }
 
-    void method5(String aOne, String aTwo)
+    void method5(String one, String two)
     { // violation ''{' at column 5 should be on the previous line.'
     }
 
-    void method6(String aOne, String aTwo) {}
-  },
+    void method6(String one, String two) {}
 
-  CONSTANT2("hello") {},
+    enum InputLeftCurlyMethodEnum
+      { // violation ''{' at column 7 should be on the previous line.'
+        CONSTANT1("hello")
+                { // violation ''{' at column 17 should be on the previous line.'
+                  void method1() {}
 
-  CONSTANT3("hellohellohellohellohellohellohellohellohellohellohellohellohellohello")
-  { // violation ''{' at column 3 should be on the previous line.'
-  };
+                  void method2() {}
 
-  private InputLeftCurlyMethodEnum(String value)
-  { // violation ''{' at column 3 should be on the previous line.'
+                  void method3()
+                    { // violation ''{' at column 21 should be on the previous line.'
+                    }
+
+                  void method4()
+                    { // violation ''{' at column 21 should be on the previous line.'
+                    }
+
+                  void method5(String one, String two)
+                    { // violation ''{' at column 21 should be on the previous line.'
+                    }
+
+                  void method6(String one, String two) {}
+                },
+
+        CONSTANT2("hello") {},
+
+        CONSTANT3("hellohellohellohellohellohellohellohellohellohellohellohellohellohello")
+                { // violation ''{' at column 17 should be on the previous line.'
+                };
+
+        private InputLeftCurlyMethodEnum(String value)
+        { // violation ''{' at column 9 should be on the previous line.'
+        }
+
+        void method1() {}
+
+        void method2() {}
+
+        void method3()
+        { // violation ''{' at column 9 should be on the previous line.'
+        }
+
+        void method4()
+        { // violation ''{' at column 9 should be on the previous line.'
+        }
+
+        void method5(String one, String two)
+        { // violation ''{' at column 9 should be on the previous line.'
+        }
+
+        void method6(String one, String two) {}
+      }
   }
-
-  void method1() {}
-
-  void method2() {}
-
-  void method3()
-  { // violation ''{' at column 3 should be on the previous line.'
-  }
-
-  void method4()
-  { // violation ''{' at column 3 should be on the previous line.'
-  }
-
-  void method5(String aOne, String aTwo)
-  { // violation ''{' at column 3 should be on the previous line.'
-  }
-
-  void method6(String aOne, String aTwo) {}
-}

--- a/src/it/resources/com/google/checkstyle/test/chapter4formatting/rule412nonemptyblocks/InputNonemptyBlocksLeftRightCurly.java
+++ b/src/it/resources/com/google/checkstyle/test/chapter4formatting/rule412nonemptyblocks/InputNonemptyBlocksLeftRightCurly.java
@@ -1,102 +1,131 @@
 package com.google.checkstyle.test.chapter4formatting.rule412nonemptyblocks;
 
 class InputNonemptyBlocksLeftRightCurly
-{ // violation ''{' at column 1 should be on the previous line.'
-  /**
-   * @return helper func *
-   */
-  boolean condition()
   { // violation ''{' at column 3 should be on the previous line.'
-    return false;
-  }
-
-  /** Test do/while loops * */
-  void testDoWhile()
-  { // violation ''{' at column 3 should be on the previous line.'
-
-    do {
-      testDoWhile();
-    } // violation ''}' at column 5 should be on the same line as the next part of .*'
-    while (condition());
-
-    do testDoWhile();
-    while (condition());
-  }
-
-  /** Test while loops * */
-  void testWhile()
-  { // violation ''{' at column 3 should be on the previous line.'
-
-    while (condition()) {
-      testWhile();
+    /**
+     * summary.
+     *
+     * @return helper func *
+     */
+    boolean condition()
+    { // violation ''{' at column 5 should be on the previous line.'
+      return false;
     }
 
-    while (condition())
-      ;
-    while (condition()) testWhile();
-    while (condition()) if (condition()) testWhile();
-  }
+    /** Test do/while loops. */
+    void testDoWhile()
+    { // violation ''{' at column 5 should be on the previous line.'
 
-  /** Test for loops * */
-  void testFor()
-  { // violation ''{' at column 3 should be on the previous line.'
+      do {
+        testDoWhile();
+      } // violation ''}' at column 7 should be on the same line as the next part of .*'
+      while (condition());
 
-    for (int i = 1; i < 5; i++) {
-      testFor();
+      do {
+        testDoWhile();
+      } while (condition());
     }
 
-    for (int i = 1; i < 5; i++)
-      ;
-    for (int i = 1; i < 5; i++) testFor();
-    for (int i = 1; i < 5; i++) if (i > 2) testFor();
-  }
+    /** Test while loops. */
+    void testWhile()
+    { // violation ''{' at column 5 should be on the previous line.'
 
-  /** Test if constructs * */
-  public void testIf()
-  { // violation ''{' at column 3 should be on the previous line.'
+      while (condition()) {
+        testWhile();
+      }
 
-    if (condition()) {
-      testIf();
-    } // violation ''}' at column 5 should be on the same line as the next part of .*'
-    else if (condition()) {
-      testIf();
-    } // violation ''}' at column 5 should be on the same line as the next part of .*'
-    else {
-      testIf();
+      while (condition()) {
+        /* foo */
+      }
+      while (condition()) {
+        testWhile();
+      }
+      while (condition()) {
+        if (condition()) {
+          testWhile();
+        }
+      }
     }
 
-    if (condition())
-      ;
-    if (condition()) testIf();
-    if (condition()) testIf();
-    else testIf();
-    if (condition()) testIf();
-    else {
-      testIf();
+    /** Test for loops. */
+    void testFor()
+    { // violation ''{' at column 5 should be on the previous line.'
+
+      for (int i = 1; i < 5; i++) {
+        testFor();
+      }
+
+      for (int i = 1; i < 5; i++) {
+        /* foo */
+      }
+      for (int i = 1; i < 5; i++) {
+        testFor();
+      }
+      for (int i = 1; i < 5; i++) {
+        if (i > 2) {
+          testFor();
+        }
+      }
     }
-    if (condition()) {
-      testIf();
-    } // violation ''}' at column 5 should be on the same line as the next part of .*'
-    else testIf();
-    if (condition()) if (condition()) testIf();
+
+    /** Test if constructs. */
+    public void testIf()
+    { // violation ''{' at column 5 should be on the previous line.'
+
+      if (condition()) {
+        testIf();
+      } // violation ''}' at column 7 should be on the same line as the next part of .*'
+      else if (condition()) {
+        testIf();
+      } // violation ''}' at column 7 should be on the same line as the next part of .*'
+      else {
+        testIf();
+      }
+
+      if (condition()) { /* foo */ }
+      if (condition()) {
+        testIf();
+      }
+      if (condition()) {
+        testIf();
+      } else {
+        testIf();
+      }
+      if (condition()) {
+        testIf();
+      } else {
+        testIf();
+      }
+      if (condition()) {
+        testIf();
+      } // violation ''}' at column 7 should be on the same line as the next part of .*'
+      else {
+        testIf();
+      }
+      if (condition()) {
+        if (condition()) {
+          testIf();
+        }
+      }
+    }
+
+    void whitespaceAfterSemi()
+    { // violation ''{' at column 5 should be on the previous line.'
+
+      int i = 1;
+      int j = 2;
+
+      for (; ; ) {}
+    }
+
+    /** Empty constructor block. */
+    public InputNonemptyBlocksLeftRightCurly() {}
+
+    /** Empty method block. */
+    public void emptyImplementation() {}
   }
 
-  void whitespaceAfterSemi()
-  { // violation ''{' at column 3 should be on the previous line.'
-
-    int i = 1;
-    int j = 2;
-
-    for (; ; ) {}
-  }
-
-  /** Empty constructor block. * */
-  public InputNonemptyBlocksLeftRightCurly() {}
-
-  /** Empty method block. * */
-  public void emptyImplementation() {}
-}
-
+// violation below 'Top-level class EnumContainerLeft has to reside in its own source file.'
 class EnumContainerLeft {
   private enum Suit {
     CLUBS,
@@ -106,137 +135,151 @@ class EnumContainerLeft {
   } // ok
 }
 
+// violation below 'Top-level class WithArraysLeft has to reside in its own source file.'
 class WithArraysLeft { // ok
-  String[] s = {""}; // ok
+  String[] s1 = {""}; // ok
   String[] empty = {}; // ok
-  String[] s1 = { // ok
-    "foo", "foo",
-  };
   String[] s2 = { // ok
     "foo", "foo",
   };
   String[] s3 = { // ok
     "foo", "foo",
   };
-  String[] s4 = {"foo", "foo"}; // ok
+  String[] s4 = { // ok
+    "foo", "foo",
+  };
+  String[] s5 = {"foo", "foo"}; // ok
 }
 
+// violation below 'Top-level class InputRightCurlyOther2 has to reside in its own source file.'
 class InputRightCurlyOther2
-{ // violation ''{' at column 1 should be on the previous line.'
-  /**
-   * @see test method *
-   */
-  int foo()
-      throws InterruptedException
   { // violation ''{' at column 3 should be on the previous line.'
-    int x = 1;
-    int a = 2;
-    while (true)
+    /**
+     * summary.
+     *
+     * @see test method *
+     */
+    int foo()
+        throws InterruptedException
     { // violation ''{' at column 5 should be on the previous line.'
-      try
-      { // violation ''{' at column 7 should be on the previous line.'
-        if (x > 0)
+      int x = 1;
+      int a = 2;
+      while (true)
         { // violation ''{' at column 9 should be on the previous line.'
-          break;
-        } else if (x < 0) { // ok
+          try
+          { // violation ''{' at column 11 should be on the previous line.'
+            if (x > 0)
+              { // violation ''{' at column 15 should be on the previous line.'
+                break;
+              } else if (x < 0) { // ok
 
-          ;
-        } // violation ''}' at column 9 should be on the same line as the next part.*'
-        else
-        { // violation ''{' at column 9 should be on the previous line.'
-          break;
-        } // ok
-        switch (a)
-        { // violation ''{' at column 9 should be on the previous line.'
-          case 0:
+              ;
+            } // violation ''}' at column 13 should be on the same line as the next part.*'
+            else
+              { // violation ''{' at column 15 should be on the previous line.'
+                break;
+              } // ok
+            switch (a)
+              { // violation ''{' at column 15 should be on the previous line.'
+              case 0:
+                break;
+              default:
+                break;
+              } // ok
+          } // violation ''}' at column 11 should be on the same line as the next part of .*'
+          catch (Exception e)
+          { // violation ''{' at column 11 should be on the previous line.'
             break;
-          default:
-            break;
+          } // ok
         } // ok
-      } // violation ''}' at column 7 should be on the same line as the next part of .*'
-      catch (Exception e)
-      { // violation ''{' at column 7 should be on the previous line.'
-        break;
-      } // ok
+
+      synchronized (this)
+        { // violation ''{' at column 9 should be on the previous line.'
+          do
+          { // violation ''{' at column 11 should be on the previous line.'
+            x = 2;
+          } while (x == 2); // ok
+        } // ok
+
+      this.wait(666); // Bizarre, but legal
+
+      for (int k = 0; k < 1; k++)
+        { // violation ''{' at column 9 should be on the previous line.'
+          String innerBlockVariable = "";
+        } // ok
+
+      if (System.currentTimeMillis() > 1000) {
+        return 1;
+      } else {
+        return 2;
+      }
     } // ok
 
-    synchronized (this)
+    static
     { // violation ''{' at column 5 should be on the previous line.'
-      do
-      { // violation ''{' at column 7 should be on the previous line.'
-        x = 2;
-      } while (x == 2); // ok
+      int x = 1;
     } // ok
 
-    this.wait(666); // Bizarre, but legal
-
-    for (int k = 0; k < 1; k++)
+    /** some javadoc. */
+    public enum GreetingsEnum
     { // violation ''{' at column 5 should be on the previous line.'
-      String innerBlockVariable = "";
+      HELLO,
+      GOODBYE
     } // ok
 
-    if (System.currentTimeMillis() > 1000) return 1;
-    else return 2;
+    void method2()
+    { // violation ''{' at column 5 should be on the previous line.'
+      boolean flag = true;
+      if (flag) {
+        System.identityHashCode("heh");
+      // 2 violations 3 lines below:
+      //  ''if' child has incorrect indentation level 6, expected level should be 8.'
+      //  ''}' at column 21 should have line break before.'
+      flag = !flag; } System
+        .identityHashCode("Xe-xe");
+
+      if (flag) { System.identityHashCode("some foo"); }
+      // violation above ''{' at column 17 should have line break after.'
+    } // ok
   } // ok
-
-  static
-  { // violation ''{' at column 3 should be on the previous line.'
-    int x = 1;
-  } // ok
-
-  public enum GreetingsEnum
-  { // violation ''{' at column 3 should be on the previous line.'
-    HELLO,
-    GOODBYE
-  }; // ok
-
-  void method2()
-  { // violation ''{' at column 3 should be on the previous line.'
-    boolean flag = true;
-    if (flag) {
-      System.identityHashCode("heh");
-      flag = !flag; } System.
-      // violation above ''}' at column 21 should have line break before.'
-      identityHashCode("Xe-xe");
-
-    if (flag) { System.identityHashCode("some foo"); }
-    // violation above ''{' at column 15 should have line break after.'
-  } // ok
-} // ok
 
 /**
  * Test input for closing brace if that brace terminates a statement or the body of a constructor.
  */
+// violation below 'Top-level class FooCtor has to reside in its own source file.'
 class FooCtor
-{ // violation ''{' at column 1 should be on the previous line.'
-  int i;
+  { // violation ''{' at column 3 should be on the previous line.'
+  int i3;
 
   public FooCtor()
-  { // violation ''{' at column 3 should be on the previous line.'
-    i = 1;
-  }} // violation ''}' at column 3 should be alone on a line.'
+    { // violation ''{' at column 5 should be on the previous line.'
+      i3 = 1;
+    } } // violation ''}' at column 5 should be alone on a line.'
 
 /** Test input for closing brace if that brace terminates a statement or the body of a method. */
+// violation below 'Top-level class FooMethod has to reside in its own source file.'
 class FooMethod
-{ // violation ''{' at column 1 should be on the previous line.'
-  public void fooMethod()
   { // violation ''{' at column 3 should be on the previous line.'
-    int i = 1;
-  }} // violation ''}' at column 3 should be alone on a line.'
+    public void fooMethod()
+    { // violation ''{' at column 5 should be on the previous line.'
+      int i = 1;
+    } } // violation ''}' at column 5 should be alone on a line.'
 
 /**
  * Test input for closing brace if that brace terminates a statement or the body of a named class.
  */
+// violation below 'Top-level class FooInner has to reside in its own source file.'
 class FooInner
-{ // violation ''{' at column 1 should be on the previous line.'
-  class InnerFoo
   { // violation ''{' at column 3 should be on the previous line.'
-    public void fooInnerMethod()
+  class InnerFoo
     { // violation ''{' at column 5 should be on the previous line.'
+      public void fooInnerMethod()
+        { // violation ''{' at column 9 should be on the previous line.'
+        }
     }
-  }
-} // ok
+  } // ok
 
+// violation below 'Top-level class EnumContainer has to reside in its own source file.'
 class EnumContainer {
   private enum Suit {
     CLUBS,
@@ -246,8 +289,9 @@ class EnumContainer {
   } // ok
 }
 
+// violation below 'Top-level class WithArrays has to reside in its own source file.'
 class WithArrays {
-  String[] s = {""}; // ok
+  String[] test = {""}; // ok
   String[] empty = {}; // ok
   String[] s1 = {
     "foo", "foo",

--- a/src/it/resources/com/google/checkstyle/test/chapter4formatting/rule412nonemptyblocks/InputRightCurly.java
+++ b/src/it/resources/com/google/checkstyle/test/chapter4formatting/rule412nonemptyblocks/InputRightCurly.java
@@ -1,9 +1,12 @@
 package com.google.checkstyle.test.chapter4formatting.rule412nonemptyblocks;
 
+/** some javadoc. */
 public class InputRightCurly {
+  /** some javadoc. */
   public static void main(String[] args) {
     boolean after = false;
     try {
+      /* foo */
     } finally { after = true; }
     // violation above ''{' at column 15 should have line break after.'
   }

--- a/src/it/resources/com/google/checkstyle/test/chapter4formatting/rule412nonemptyblocks/InputRightCurlyDoWhile.java
+++ b/src/it/resources/com/google/checkstyle/test/chapter4formatting/rule412nonemptyblocks/InputRightCurlyDoWhile.java
@@ -2,13 +2,14 @@ package com.google.checkstyle.test.chapter4formatting.rule412nonemptyblocks;
 
 import java.util.Scanner;
 
-/** Test input for GitHub issue #3090. https://github.com/checkstyle/checkstyle/issues/3090 */
+/** Test input for GitHub issue #3090. https://github.com/checkstyle/checkstyle/issues/3090 . */
 public class InputRightCurlyDoWhile {
 
   public void foo1() {
     do {} while (true);
   }
 
+  /** some javadoc. */
   public void foo2() {
     int i = 1;
     while (i < 5) {
@@ -17,6 +18,7 @@ public class InputRightCurlyDoWhile {
     }
   }
 
+  /** some javadoc. */
   public void foo3() {
     int i = 1;
     do {
@@ -25,8 +27,10 @@ public class InputRightCurlyDoWhile {
     } while (i < 5);
   }
 
+  /** some javadoc. */
   public void foo4() {
-    int prog, user;
+    int prog;
+    int user;
     prog = (int) (Math.random() * 10) + 1;
     Scanner input = new Scanner(System.in, "utf-8");
     if (input.hasNextInt()) {

--- a/src/it/resources/com/google/checkstyle/test/chapter4formatting/rule412nonemptyblocks/InputRightCurlyDoWhile2.java
+++ b/src/it/resources/com/google/checkstyle/test/chapter4formatting/rule412nonemptyblocks/InputRightCurlyDoWhile2.java
@@ -3,13 +3,14 @@ package com.google.checkstyle.test.chapter4formatting.rule412nonemptyblocks;
 import java.nio.charset.StandardCharsets;
 import java.util.Scanner;
 
-/** Test input for GitHub issue #3090. https://github.com/checkstyle/checkstyle/issues/3090 */
+/** Test input for GitHub issue #3090. https://github.com/checkstyle/checkstyle/issues/3090 . */
 public class InputRightCurlyDoWhile2 {
 
   public void foo1() {
     do {} while (true);
   }
 
+  /** some javadoc. */
   public void foo2() {
     int i = 1;
     while (i < 5) {
@@ -18,6 +19,7 @@ public class InputRightCurlyDoWhile2 {
     }
   }
 
+  /** some javadoc. */
   public void foo3() {
     int i = 1;
     do {
@@ -26,8 +28,10 @@ public class InputRightCurlyDoWhile2 {
     } while (i < 5);
   }
 
+  /** some javadoc. */
   public void foo4() {
-    int prog, user;
+    int prog;
+    int user;
     prog = (int) (Math.random() * 10) + 1;
     Scanner input = new Scanner(System.in, StandardCharsets.UTF_8);
     if (input.hasNextInt()) {

--- a/src/it/resources/com/google/checkstyle/test/chapter4formatting/rule412nonemptyblocks/InputRightCurlyOther.java
+++ b/src/it/resources/com/google/checkstyle/test/chapter4formatting/rule412nonemptyblocks/InputRightCurlyOther.java
@@ -2,6 +2,8 @@ package com.google.checkstyle.test.chapter4formatting.rule412nonemptyblocks;
 
 class InputRightCurlyOther {
   /**
+   * summary.
+   *
    * @see test method *
    */
   int foo() throws InterruptedException {
@@ -42,8 +44,11 @@ class InputRightCurlyOther {
       String innerBlockVariable = "";
     }
 
-    if (System.currentTimeMillis() > 1000) return 1;
-    else return 2;
+    if (System.currentTimeMillis() > 1000) {
+      return 1;
+    } else {
+      return 2;
+    }
   }
 
   static {
@@ -53,14 +58,17 @@ class InputRightCurlyOther {
   public enum GreetingsEnum {
     HELLO,
     GOODBYE
-  };
+  }
 
   void method2() {
     boolean flag = true;
     if (flag) {
       System.identityHashCode("heh");
-      flag = !flag; } System. // violation ''}' at column 21 should have line break before.'
-      identityHashCode("Xe-xe");
+      // 2 violations 3 lines below:
+      //  ''}' at column 21 should have line break before.'
+      //  ''method def' child has incorrect indentation level 6, expected level should be 4.'
+      flag = !flag; } System
+      .identityHashCode("Xe-xe");
 
     if (flag) {
       System.identityHashCode("some foo");
@@ -72,27 +80,31 @@ class InputRightCurlyOther {
  * Test input for closing brace if that brace terminates a statement or the body of a constructor.
  */
 class FooCtorAlone {
-  int i;
+  // violation above 'Top-level class FooCtorAlone has to reside in its own source file.'
+  int test;
 
   public FooCtorAlone() {
-    i = 1;
-  }} // violation ''}' at column 3 should be alone on a line.'
+    test = 1;
+  } } // violation ''}' at column 3 should be alone on a line.'
 
 /** Test input for closing brace if that brace terminates a statement or the body of a method. */
 class FooMethodAlone {
+  // violation above 'Top-level class FooMethodAlone has to reside in its own source file.'
   public void fooMethod() {
     int i = 1;
-  }} // violation ''}' at column 3 should be alone on a line.'
+  } } // violation ''}' at column 3 should be alone on a line.'
 
 /**
  * Test input for closing brace if that brace terminates a statement or the body of a named class.
  */
 class FooInnerAlone {
+  // violation above 'Top-level class FooInnerAlone has to reside in its own source file.'
   class InnerFoo {
     public void fooInnerMethod() {}
   }
 }
 
+// violation below 'Top-level class EnumContainerAlone has to reside in its own source file.'
 class EnumContainerAlone {
   private enum Suit {
     CLUBS,
@@ -102,8 +114,9 @@ class EnumContainerAlone {
   }
 }
 
+// violation below 'Top-level class WithArraysAlone has to reside in its own source file.'
 class WithArraysAlone {
-  String[] s = {""};
+  String[] ss = {""};
   String[] empty = {};
   String[] s1 = {
     "foo", "foo",
@@ -117,6 +130,7 @@ class WithArraysAlone {
   String[] s4 = {"foo", "foo"};
 }
 
+// violation below 'Top-level class Interface has to reside in its own source file.'
 class Interface {
   public @interface TestAnnotation {}
 
@@ -137,20 +151,25 @@ class Interface {
   }
 }
 
+// violation below 'Top-level class TestEnum has to reside in its own source file.'
 enum TestEnum {}
 
+// violation below 'Top-level class TestEnum1 has to reside in its own source file.'
 enum TestEnum1 {
   SOME_VALUE;
 }
 
+// violation below 'Top-level class TestEnum2 has to reside in its own source file.'
 enum TestEnum2 {
   SOME_VALUE;
 }
 
+// violation below 'Top-level class TestEnum3 has to reside in its own source file.'
 enum TestEnum3 {
   SOME_VALUE;
 }
 
+// violation below 'Top-level class TestEnum4 has to reside in its own source file.'
 enum TestEnum4 {
   SOME_VALUE;
 }

--- a/src/it/resources/com/google/checkstyle/test/chapter4formatting/rule412nonemptyblocks/InputRightCurlySwitchCase.java
+++ b/src/it/resources/com/google/checkstyle/test/chapter4formatting/rule412nonemptyblocks/InputRightCurlySwitchCase.java
@@ -1,7 +1,9 @@
 package com.google.checkstyle.test.chapter4formatting.rule412nonemptyblocks;
 
+/** some javadoc. */
 public class InputRightCurlySwitchCase {
 
+  /** some javadoc. */
   public static void method0() {
     int mode = 0;
     switch (mode) {
@@ -12,6 +14,7 @@ public class InputRightCurlySwitchCase {
         x = 0; } // violation ''}' at column 16 should be alone on a line.'
   }
 
+  /** some javadoc. */
   public static void method1() {
     int mode = 0;
     switch (mode) {
@@ -19,6 +22,7 @@ public class InputRightCurlySwitchCase {
         int x = 0; } // violation ''}' at column 20 should be alone on a line.'
   }
 
+  /** some javadoc. */
   public static void method2() {
     int mode = 0;
     switch (mode) {
@@ -30,6 +34,7 @@ public class InputRightCurlySwitchCase {
     }
   }
 
+  /** some javadoc. */
   public static void method3() {
     int mode = 0;
     switch (mode) {
@@ -38,11 +43,13 @@ public class InputRightCurlySwitchCase {
     }
   }
 
+  /** some javadoc. */
   public static void method4() {
     int mode = 0;
     switch (mode) {
       case 1:
         int y = 2;
+        break;
       default:
         int x = 0;
     }

--- a/src/it/resources/com/google/checkstyle/test/chapter4formatting/rule412nonemptyblocks/InputRightCurlySwitchCasesBlocks.java
+++ b/src/it/resources/com/google/checkstyle/test/chapter4formatting/rule412nonemptyblocks/InputRightCurlySwitchCasesBlocks.java
@@ -1,62 +1,86 @@
 package com.google.checkstyle.test.chapter4formatting.rule412nonemptyblocks;
 
+/** some javadoc. */
 public class InputRightCurlySwitchCasesBlocks {
 
+  /** some javadoc. */
   public static void test0() {
     int mode = 0;
     switch (mode) {
-      case 1: {
-        int x = 1;
-        break;
-      }
-      case 2: {
-        int x = 0;
-        break;
-      }
+      case 1:
+        { // violation ''{' at column 9 should be on the previous line.'
+          int x = 1;
+          break;
+        }
+      case 2:
+        { // violation ''{' at column 9 should be on the previous line.'
+          int x = 0;
+          break;
+        }
+      default:
     }
   }
 
+  /** some javadoc. */
   public static void test() {
     int mode = 0;
     switch (mode) {
-      case 1: {
-        int x = 1;
-        break;
-      } default: // violation ''}' at column 7 should be alone on a line.'
-      int x = 0;
+      case 1:
+        { // violation ''{' at column 9 should be on the previous line.'
+          int x = 1;
+          break;
+        } default:
+        int x = 0;
+        // 2 violations 2 lines above:
+        //  ''}' at column 9 should be alone on a line.'
+        //  ''case' child has incorrect indentation level 8, expected level should be 6.'
     }
   }
 
+  /** some javadoc. */
   public static void test1() {
     int k = 0;
     switch (k) {
-      case 1: {
+      case 1:
+        { // violation ''{' at column 9 should be on the previous line.'
         int x = 1; } // violation ''}' at column 20 should be alone on a line.'
+        break;
       case 2:
         int x = 2;
         break;
+      default:
     }
   }
 
+  /** some javadoc. */
   public static void test2() {
     int mode = 0;
     switch (mode) {
       case 1:
         int x = 1;
-      case 2: {
         break;
-      }
+      case 2:
+        { // violation ''{' at column 9 should be on the previous line.'
+          break;
+        }
+      default:
     }
   }
 
+  /** some javadoc. */
   public static void test3() {
     int k = 0;
     switch (k) {
-      case 1: {
-        int x = 1;
-      }
-      case 2: {
+      case 1:
+        { // violation ''{' at column 9 should be on the previous line.'
+          int x = 1;
+          break;
+        }
+      case 2:
+        { // violation ''{' at column 9 should be on the previous line.'
         int x = 2; } // violation ''}' at column 20 should be alone on a line.'
+        break;
+      default:
     }
   }
 }


### PR DESCRIPTION
#15214 


  | 4.1.2 Nonempty blocks: K & R style | LeftCurly                                                                                                 RightCurly
-- | -- | --


4.1.2 Nonempty blocks: K & R style 	[LeftCurly](https://checkstyle.org/checks/blocks/leftcurly.html#LeftCurly)
[RightCurly](https://checkstyle.org/checks/blocks/rightcurly.html#RightCurly)