### PR TITLE
Issue #15252: added usage of EmptyCatchBlock for section 6.2 in google style coverage page

### DIFF
--- a/src/xdocs/google_style.xml
+++ b/src/xdocs/google_style.xml
@@ -1968,10 +1968,17 @@
                         alt="" />
                   </span>
                   <a href="checks/blocks/emptyblock.html#EmptyBlock">EmptyBlock</a>
-                  with option=text.
+                  <br />
+                  <br />
+                  <span class="wrapper inline">
+                    <img src="images/ok_green.png" alt="" />
+                  </span>
+                  <a href="checks/blocks/emptycatchblock.html#EmptyCatchBlock">EmptyCatchBlock</a>
                 </td>
                 <td>
                   <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources%20path%3A**%2Fgoogle_checks.xml+repo%3Acheckstyle%2Fcheckstyle+EmptyBlock">
+                    config</a><br/>
+                  <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources%20path%3A**%2Fgoogle_checks.xml+repo%3Acheckstyle%2Fcheckstyle+EmptyCatchBlock">
                     config</a><br/>
                   <a href="https://github.com/checkstyle/checkstyle/blob/master/src/it/java/com/google/checkstyle/test/chapter6programpractice/rule62donotignoreexceptions/CaughtExceptionsNotIgnoredTest.java">
                     test</a>


### PR DESCRIPTION
#15252

Updated google style guide coverage page and added usage of [EmptyCatchBlock](https://checkstyle.sourceforge.io/checks/blocks/emptycatchblock.html) module. There were already test cases for this module so no need to update them.