### PR TITLE
supplemental: added test cases for JUnit test method names in google style guide section 5.2.3 method names

### DIFF
--- a/src/it/resources/com/google/checkstyle/test/chapter5naming/rule523methodnames/InputMethodName.java
+++ b/src/it/resources/com/google/checkstyle/test/chapter5naming/rule523methodnames/InputMethodName.java
@@ -1,5 +1,7 @@
 package com.google.checkstyle.test.chapter5naming.rule523methodnames;
 
+import org.junit.jupiter.api.Test;
+
 /**
  * Test input for MethodNameCheck specifically whether the method name equals the class name.
  *
@@ -22,6 +24,27 @@ public class InputMethodName {
 
   void fO() {} // violation 'Method name 'fO' must match pattern'
 
+  @Test
+  void testing_foo() {}
+
+  @Test
+  void testing_Foo() {}
+
+  @Test
+  void testing_fOo() {}
+
+  @Test
+  void testingFoo() {}
+
+  @Test
+  void testingFoo_foo() {}
+
+  @Test
+  void testing_0123() {}
+
+  @Test
+  void TestingFooBad() {} // violation 'Method name 'TestingFooBad' must match pattern'
+
   class InnerFoo {
     void foo() {}
 
@@ -38,6 +61,20 @@ public class InputMethodName {
     void f() {} // violation 'Method name 'f' must match pattern'
 
     void fO() {} // violation 'Method name 'fO' must match pattern'
+
+    void testing_foo() {}
+
+    void testing_Foo() {}
+
+    void testing_fOo() {}
+
+    void testingFoo() {}
+
+    void testingFoo_foo() {}
+
+    void testing_0123() {}
+
+    void TestingFooBad() {} // violation 'Method name 'TestingFooBad' must match pattern'
   }
 
   InnerFoo anon =


### PR DESCRIPTION
Detected at: https://github.com/checkstyle/checkstyle/pull/14901/files/4bcfed8ef4a4446fbda32e24fd067abd933030ce#r1679695992


Added test case for JUnit test methods. The test works same even if I remove the `@Test` annotation. I'm not sure if we should be concerned about this or not.