### PR TITLE
Issue #15329: updated coverage table for section 4.1.2, added blue tick for LeftCurly module and a message explaining the reason

### DIFF
--- a/src/xdocs/google_style.xml
+++ b/src/xdocs/google_style.xml
@@ -655,7 +655,7 @@
                 </td>
                 <td>
                   <span class="wrapper inline">
-                    <img src="images/ok_green.png" alt="" />
+                    <img src="images/ok_blue.png" alt="" />
                   </span>
                   <a href="checks/blocks/leftcurly.html#LeftCurly">LeftCurly</a>
                   <br/>
@@ -664,6 +664,13 @@
                     <img src="images/ok_blue.png" alt="" />
                   </span>
                   <a href="checks/blocks/rightcurly.html#RightCurly">RightCurly</a>
+                  <br/>
+                  <br/>
+                  The "Exception" part of the rule is not satisfied,
+                  it will be addressed in the issue
+                  <a href="https://github.com/checkstyle/checkstyle/issues/14294">
+                    #14294
+                  </a>
                 </td>
                 <td>
                   <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources%20path%3A**%2Fgoogle_checks.xml+repo%3Acheckstyle%2Fcheckstyle+LeftCurly">


### PR DESCRIPTION
#15329


Linked #15324 

Updated coverage table of google style guide implementation for section [4.1.2 Nonempty blocks: K & R style](https://checkstyle.org/styleguides/google-java-style-20180523/javaguide.html#s4.1.2-blocks-k-r-style), added blue tick for "LeftCurly" module and a message referencing the issue.