### PR TITLE
Issue #15329: updated coverage table for section 4.6.2, added blue tick for WhitespaceAround module and a message referencing to the issue

### DIFF
--- a/src/xdocs/google_style.xml
+++ b/src/xdocs/google_style.xml
@@ -953,7 +953,7 @@
                 </td>
                 <td>
                   <span class="wrapper inline">
-                    <img src="images/ok_green.png" alt="" />
+                    <img src="images/ok_blue.png" alt="" />
                   </span>
                   <a href="checks/whitespace/whitespacearound.html#WhitespaceAround">
                     WhitespaceAround</a>
@@ -1004,6 +1004,13 @@
                   opposite for ellipsis. This will be addressed in the issue
                   <a href="https://github.com/checkstyle/checkstyle/issues/6707">
                     #6707</a>.
+                  <br/>
+                  <br/>
+                  There are some false positive and negative cases for "{}" and "{ }".
+                  See issue
+                  <a href="https://github.com/checkstyle/checkstyle/issues/15338">
+                    #15338</a>
+                  for more detailed explanation.
                 </td>
                 <td>
                   <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources%20path%3A**%2Fgoogle_checks.xml+repo%3Acheckstyle%2Fcheckstyle+WhitespaceAround">


### PR DESCRIPTION
#15329

Linked: #15338 


Updated coverage table for section 4.6.2 Horizontal whitespace, added blue tick for WhitespaceAround module and a message explaining the reason behind blue tick and also reference link of the issue.