### PR TITLE
Issue #15329: updated coverage table for section 7.3.1 Exception: self-explanatory members

### DIFF
--- a/src/xdocs/google_style.xml
+++ b/src/xdocs/google_style.xml
@@ -2280,7 +2280,7 @@
                 <td>
                   <span class="wrapper inline">
                     <img
-                        src="images/ok_green.png"
+                        src="images/ok_blue.png"
                         alt="" />
                   </span>
                   <a href="checks/javadoc/missingjavadocmethod.html#MissingJavadocMethod">MissingJavadocMethod</a>
@@ -2292,6 +2292,15 @@
                         alt="" />
                   </span>
                   <a href="checks/javadoc/javadocmethod.html#JavadocMethod">JavadocMethod</a>
+                  <br/>
+                  <br/>
+                  "protected" methods are not detected for missing javadoc, it will be addressed at:
+                  <a href="https://github.com/checkstyle/checkstyle/issues/15434">#15434</a>
+                  <br/>
+                  <br/>
+                  Optional javadoc for "simple, obvious" members is not fully supported,
+                  it will be addressed at:
+                  <a href="https://github.com/checkstyle/checkstyle/issues/15414">#15414</a>
                 </td>
                 <td>
                   <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources%20path%3A**%2Fgoogle_checks.xml+repo%3Acheckstyle%2Fcheckstyle+MissingJavadocMethod">


### PR DESCRIPTION
Issue #15329 

Updated coverage table for section [7.3.1 Exception: self-explanatory methods](https://checkstyle.sourceforge.io/styleguides/google-java-style-20180523/javaguide.html#s7.3.1-javadoc-exception-self-explanatory), referenced 2 issues: https://github.com/checkstyle/checkstyle/issues/15414 https://github.com/checkstyle/checkstyle/issues/15434