### PR TITLE
Issue #15329: removed explanation message for issue #6707 from section 4.6.2 in google style guide

### DIFF
--- a/src/xdocs/google_style.xml
+++ b/src/xdocs/google_style.xml
@@ -1010,13 +1010,6 @@
                   <a href="checks/whitespace/nowhitespacebeforecasedefaultcolon.html#NoWhitespaceBeforeCaseDefaultColon">
                     NoWhitespaceBeforeCaseDefaultColon</a>
                   <br />
-                  <br />
-                  Between a type annotation and "[]" or "..." cannot be checked
-                  yet and actually "NoWhitespaceBefore" configuration checks the
-                  opposite for ellipsis. This will be addressed in the issue
-                  <a href="https://github.com/checkstyle/checkstyle/issues/6707">
-                    #6707</a>.
-                  <br/>
                   <br/>
                   There are some false positive and negative cases for "{}" and "{ }".
                   See issue


### PR DESCRIPTION
#15442


removed explanation message for issue #6707 from section [4.6.2 Horizontal whitespace](https://checkstyle-diff-reports.s3.us-east-2.amazonaws.com/b4c7950_2024151443/styleguides/google-java-style-20220203/javaguide.html#s4.6.2-horizontal-whitespace)