### PR TITLE
Issue #15233:  4.4 input usage of suppression for long identifiers

### DIFF
--- a/config/checkstyle-non-main-files-suppressions.xml
+++ b/config/checkstyle-non-main-files-suppressions.xml
@@ -59,7 +59,7 @@
   <suppress id="lineLength" files="config[\\/]signatures-test.txt"/>
   <!-- test resources are weird by design, no validations in them -->
   <suppress id="lineLength"
-         files="src[\\/]it[\\/]resources[\\/].*[\\/]InputColumnLimit\.java"/>
+         files="src[\\/]it[\\/]resources[\\/].*[\\/]Input.*ColumnLimit\.java"/>
   <suppress id="lineLength"
          files="src[\\/]it[\\/]resources[\\/].*[\\/]InputPackageStatement\.java"/>
   <suppress id="lineLength"

--- a/src/it/resources/com/google/checkstyle/test/chapter4formatting/rule44columnlimit/InputColumnLimit.java
+++ b/src/it/resources/com/google/checkstyle/test/chapter4formatting/rule44columnlimit/InputColumnLimit.java
@@ -1,11 +1,17 @@
-package com.google.checkstyle.test.chapter4formatting.rule44columnlimit; // ok
+package com.google.checkstyle.test.chapter4formatting.rule44columnlimit;
 
-import com.google.checkstyle.test.chapter3filestructure.toolongpackagetotestcoveragegooglesjavastylerule.PackageStatementTest; // ok
+// ok above, longer package statements are allowed
+
+// ok below, longer imports are allowed
+import com.google.checkstyle.test.chapter3filestructure.toolongpackagetotestcoveragegooglesjavastylerule.PackageStatementTest;
+import java.io.IOException;
 
 final class InputColumnLimit {
   // Long line
   // ----------------------------------------------------------------------------------------------------
   // violation above 'Line is longer than 100 characters (found 105).'
+
+  PackageStatementTest pckgStmt = new PackageStatementTest();
 
   private int[] testing =
       new int[] {
@@ -50,4 +56,144 @@ final class InputColumnLimit {
 
   // Very long url with valid href: href    = "www.google.com/search?hl=en&q=java+style+guide+checkstyle+check+href+length+limit&btnG=Google+Search"
   int validHrefWithWhiteSpaces = 54;
+
+  // violation below 'Line is longer than 100 characters (found 118).'
+  int aaaarealllllllllllllllllyyyyyyyyyyylllllllloooooooooooooooonnnnnnnnnnnnnnnnnggggggggggvvvvvvaarriaaabllee1 = 99;
+
+  // CHECKSTYLE.SUPPRESS: LineLength for +1 lines
+  int aaaarealllllllllllllllllyyyyyyyyyyylllllllloooooooooooooooonnnnnnnnnnnnnnnnnggggggggggvvvvvvaarriaaabllee2 = 99;
+  // suppressed above.
+
+  // violation below 'Line is longer than 100 characters (found 109).'
+  void longggggggggggggggggggggmethoooooooooooooooooooooodddddddddddddddddddddddddddddddddddddddddddddd1() {}
+
+  // CHECKSTYLE.SUPPRESS: LineLength for +1 lines
+  void longggggggggggggggggggggmethoooooooooooooooooooooodddddddddddddddddddddddddddddddddddddddddddddd2() {}
+  // suppressed above.
+
+  final boolean isValid = true;
+  final boolean isValid2 = true;
+  final boolean isValid3 = true;
+  final boolean isValid4 = true;
+  final boolean isValid5 = true;
+
+  void testingNestedIf1() {
+    if (isValid) {
+      if (isValid2) {
+        if (isValid3) {
+          if (isValid4) {
+            if (isValid5) {
+              // CHECKSTYLE.SUPPRESS: LineLength for +1 lines
+              longggggggggggggggggggggmethoooooooooooooooooooooodddddddddddddddddddddddddddddddddddddddddddddd1();
+            }
+          }
+        }
+      }
+    }
+  }
+
+  void testingNestedIf2() {
+    if (isValid) {
+      if (isValid2) {
+        if (isValid3) {
+          if (isValid4) {
+            if (isValid5) {
+              // violation below 'Line is longer than 100 characters (found 114).'
+              longggggggggggggggggggggmethoooooooooooooooooooooodddddddddddddddddddddddddddddddddddddddddddddd2();
+            }
+          }
+        }
+      }
+    }
+  }
+
+  // violation below 'Line is longer than 100 characters (found 179).'
+  void testingParametersNames1(int areallllllyyyyyyyyyyyyyyyyyylonnnnggggggggggnameeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee, int anotherlongnameblahblahblah) {}
+
+  // CHECKSTYLE.SUPPRESS: LineLength for +1 lines
+  void testingParametersNames2(int areallllllyyyyyyyyyyyyyyyyyylonnnnggggggggggnameeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee, int anotherlongnameblahblahblah) {}
+  // suppressed above.
+
+  // violation below 'Line is longer than 100 characters (found 156).'
+  InputColumnLimit inputColumnLimit1 = (InputColumnLimit) ((Object) new com.google.checkstyle.test.chapter4formatting.rule44columnlimit.InputColumnLimit());
+
+  // CHECKSTYLE.SUPPRESS: LineLength for +1 lines
+  InputColumnLimit inputColumnLimit2 = (InputColumnLimit) ((Object) new com.google.checkstyle.test.chapter4formatting.rule44columnlimit.InputColumnLimit());
+  // suppressed above.
+  // Above code is wrap-able, user should not use suppression for such cases
+
+  void testing1() {
+    try {
+      throwExceptionBasedOnCondition1();
+      // violation below 'Line is longer than 100 characters (found 111).'
+    } catch (IOException | NullPointerException | ArrayIndexOutOfBoundsException | ClassNotFoundException ex) {
+      System.out.println(ex.getMessage());
+    }
+  }
+
+  void testing2() {
+    try {
+      throwExceptionBasedOnCondition2();
+      // CHECKSTYLE.SUPPRESS: LineLength for +1 lines
+    } catch (IOException | NullPointerException | ArrayIndexOutOfBoundsException | ClassNotFoundException ex) {
+      // Above code is wrap-able. User should not use suppression for such cases
+      System.out.println(ex.getMessage());
+    }
+  }
+
+  // violation 2 lines below 'Line is longer than 100 characters (found 104).'
+  void throwExceptionBasedOnCondition1()
+      throws IOException, NullPointerException, ArrayIndexOutOfBoundsException, ClassNotFoundException {
+    int condition = new java.util.Random().nextInt(3);
+    switch (condition) {
+      case 0:
+        throw new IOException("Test IOException");
+      case 1:
+        throw new NullPointerException("Test NullPointerException");
+      case 2:
+        throw new ArrayIndexOutOfBoundsException("Test ArrayIndexOutOfBoundsException");
+      case 3:
+        throw new ClassNotFoundException("Test ClassNotFoundException");
+      default:
+    }
+  }
+
+  // CHECKSTYLE.SUPPRESS: LineLength for +2 lines
+  void throwExceptionBasedOnCondition2()
+          throws IOException, NullPointerException, ArrayIndexOutOfBoundsException, ClassNotFoundException {
+    // suppressed above.
+    // Above code is wrap-able. User should not use suppression for such cases
+    int condition = new java.util.Random().nextInt(3);
+    switch (condition) {
+      case 0:
+        throw new IOException("Test IOException");
+      case 1:
+        throw new NullPointerException("Test NullPointerException");
+      case 2:
+        throw new ArrayIndexOutOfBoundsException("Test ArrayIndexOutOfBoundsException");
+      case 3:
+        throw new ClassNotFoundException("Test ClassNotFoundException");
+      default:
+    }
+  }
+
+  // CHECKSTYLE.SUPPRESS: LineLength for +1 lines
+  class LonggggggggggggggggggggggggggggClassssssssssssssssssssssssssNameeeeeeeeeeeeeeSoooooBoooooorrriinngggg1 {
+    // ok below, as it is suppressed.
+    void longggggggggggggggggggggmethooooooooooooooooooooooddddddddddddddddddddddddddddddddddddddddddddddddddddddd(int x, int y) {}
+    // CHECKSTYLE.SUPPRESS: LineLength for -1 lines
+
+    // ok below, as it is suppressed.
+    int aaaarealllllllllllllllllyyyyyyyyyyylllllllloooooooooooooooonnnnnnnnnnnnnnnnnggggggggggvvvvvvaarriaaablleeeeeeeeeeee = 99;
+    // CHECKSTYLE.SUPPRESS: LineLength for -1 lines
+  }
+
+  // violation below 'Line is longer than 100 characters (found 112).'
+  class LonggggggggggggggggggggggggggggClassssssssssssssssssssssssssNameeeeeeeeeeeeeeSoooooBoooooorrriinngggg2 {
+    // violation below 'Line is longer than 100 characters (found 131).'
+    void longggggggggggggggggggggmethooooooooooooooooooooooddddddddddddddddddddddddddddddddddddddddddddddddddddddd(int x, int y) {}
+
+    // violation below 'Line is longer than 100 characters (found 129).'
+    int aaaarealllllllllllllllllyyyyyyyyyyylllllllloooooooooooooooonnnnnnnnnnnnnnnnnggggggggggvvvvvvaarriaaablleeeeeeeeeeee = 99;
+  }
 }

--- a/src/it/resources/com/google/checkstyle/test/chapter4formatting/rule44columnlimit/InputFormattedColumnLimit.java
+++ b/src/it/resources/com/google/checkstyle/test/chapter4formatting/rule44columnlimit/InputFormattedColumnLimit.java
@@ -1,6 +1,17 @@
-package com.google.checkstyle.test.chapter4formatting.rule44columnlimit; // ok
+package com.google.checkstyle.test.chapter4formatting.rule44columnlimit;
+
+// ok above, longer package statements are allowed
+
+// ok below, longer imports are allowed
+import com.google.checkstyle.test.chapter3filestructure.toolongpackagetotestcoveragegooglesjavastylerule.PackageStatementTest;
+import java.io.IOException;
 
 final class InputFormattedColumnLimit {
+  // Long line
+  // ----------------------------------------------------------------------------------------------------
+  // violation above 'Line is longer than 100 characters (found 105).'
+
+  PackageStatementTest pckgStmt = new PackageStatementTest();
 
   private int[] testing =
       new int[] {
@@ -15,9 +26,9 @@ final class InputFormattedColumnLimit {
    * @param badFormat2 bad format
    * @param badFormat3 bad format
    * @return hack
-   * @throws Exception abc
+   * @throws java.lang.Exception abc
    */
-  int test1(int badFormat1, int badFormat2, final int badFormat3) throws Exception {
+  int test1(int badFormat1, int badFormat2, final int badFormat3) throws java.lang.Exception {
     return 0;
   }
 
@@ -37,7 +48,200 @@ final class InputFormattedColumnLimit {
   // ftp://ftp.example.com/areallyyyyyyyyyyyylongggggggggggggggggggggggurlllll.text
   int ftp = 0;
 
+  // violation 2 lines below 'Line is longer than 100 characters (found 111).'
+  // Very long url with invalid href:
+  // href="www.google.com/search?hl=en&q=java+style+guide+checkstyle+check+href+length+limit&btnG=Google+Search
+  int invalidHref = 88;
+
   // Very long url with valid href:
   // href="www.google.com/search?hl=en&q=java+style+guide+checkstyle+check+href+length+limit&btnG=Google+Search"
   int validHref = 54;
+
+  // violation 2 lines below 'Line is longer than 100 characters (found 107).'
+  // Very long url with valid href: href    =
+  // "www.google.com/search?hl=en&q=java+style+guide+checkstyle+check+href+length+limit&btnG=Google+Search"
+  int validHrefWithWhiteSpaces = 54;
+
+  // violation 2 lines below 'Line is longer than 100 characters (found 114).'
+  int
+      aaaarealllllllllllllllllyyyyyyyyyyylllllllloooooooooooooooonnnnnnnnnnnnnnnnnggggggggggvvvvvvaarriaaabllee1 =
+          99;
+
+  // CHECKSTYLE.SUPPRESS: LineLength for +2 lines
+  int
+      aaaarealllllllllllllllllyyyyyyyyyyylllllllloooooooooooooooonnnnnnnnnnnnnnnnnggggggggggvvvvvvaarriaaabllee2 =
+          99;
+
+  // suppressed above.
+
+  // violation 2 lines below 'Line is longer than 100 characters (found 108).'
+  void
+      longggggggggggggggggggggmethoooooooooooooooooooooodddddddddddddddddddddddddddddddddddddddddddddd1() {}
+
+  // CHECKSTYLE.SUPPRESS: LineLength for +2 lines
+  void
+      longggggggggggggggggggggmethoooooooooooooooooooooodddddddddddddddddddddddddddddddddddddddddddddd2() {}
+
+  // suppressed above.
+
+  final boolean isValid = true;
+  final boolean isValid2 = true;
+  final boolean isValid3 = true;
+  final boolean isValid4 = true;
+  final boolean isValid5 = true;
+
+  void testingNestedIf1() {
+    if (isValid) {
+      if (isValid2) {
+        if (isValid3) {
+          if (isValid4) {
+            if (isValid5) {
+              // CHECKSTYLE.SUPPRESS: LineLength for +1 lines
+              longggggggggggggggggggggmethoooooooooooooooooooooodddddddddddddddddddddddddddddddddddddddddddddd1();
+            }
+          }
+        }
+      }
+    }
+  }
+
+  void testingNestedIf2() {
+    if (isValid) {
+      if (isValid2) {
+        if (isValid3) {
+          if (isValid4) {
+            if (isValid5) {
+              // violation below 'Line is longer than 100 characters (found 114).'
+              longggggggggggggggggggggmethoooooooooooooooooooooodddddddddddddddddddddddddddddddddddddddddddddd2();
+            }
+          }
+        }
+      }
+    }
+  }
+
+  // violation 3 lines below 'Line is longer than 100 characters (found 118).'
+  void testingParametersNames1(
+      int
+          areallllllyyyyyyyyyyyyyyyyyylonnnnggggggggggnameeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee,
+      int anotherlongnameblahblahblah) {}
+
+  // CHECKSTYLE.SUPPRESS: LineLength for +3 lines
+  void testingParametersNames2(
+      int
+          areallllllyyyyyyyyyyyyyyyyyylonnnnggggggggggnameeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee,
+      int anotherlongnameblahblahblah) {}
+
+  // suppressed above.
+
+  InputColumnLimit inputColumnLimit1 =
+      (InputColumnLimit)
+          ((Object)
+              new com.google.checkstyle.test.chapter4formatting.rule44columnlimit
+                  .InputColumnLimit());
+
+  // CHECKSTYLE.SUPPRESS: LineLength for +1 lines
+  InputColumnLimit inputColumnLimit2 =
+      (InputColumnLimit)
+          ((Object)
+              new com.google.checkstyle.test.chapter4formatting.rule44columnlimit
+                  .InputColumnLimit());
+
+  // suppressed above.
+  // Above code is wrap-able, user should not use suppression for such cases
+
+  void testing1() {
+    try {
+      throwExceptionBasedOnCondition1();
+    } catch (IOException
+        | NullPointerException
+        | ArrayIndexOutOfBoundsException
+        | ClassNotFoundException ex) {
+      System.out.println(ex.getMessage());
+    }
+  }
+
+  void testing2() {
+    try {
+      throwExceptionBasedOnCondition2();
+      // CHECKSTYLE.SUPPRESS: LineLength for +1 lines
+    } catch (IOException
+        | NullPointerException
+        | ArrayIndexOutOfBoundsException
+        | ClassNotFoundException ex) {
+      // Above code is wrap-able. User should not use suppression for such cases
+      System.out.println(ex.getMessage());
+    }
+  }
+
+  void throwExceptionBasedOnCondition1()
+      throws IOException,
+          NullPointerException,
+          ArrayIndexOutOfBoundsException,
+          ClassNotFoundException {
+    int condition = new java.util.Random().nextInt(3);
+    switch (condition) {
+      case 0:
+        throw new IOException("Test IOException");
+      case 1:
+        throw new NullPointerException("Test NullPointerException");
+      case 2:
+        throw new ArrayIndexOutOfBoundsException("Test ArrayIndexOutOfBoundsException");
+      case 3:
+        throw new ClassNotFoundException("Test ClassNotFoundException");
+      default:
+    }
+  }
+
+  // CHECKSTYLE.SUPPRESS: LineLength for +2 lines
+  void throwExceptionBasedOnCondition2()
+      throws IOException,
+          NullPointerException,
+          ArrayIndexOutOfBoundsException,
+          ClassNotFoundException {
+    // suppressed above.
+    // Above code is wrap-able. User should not use suppression for such cases
+    int condition = new java.util.Random().nextInt(3);
+    switch (condition) {
+      case 0:
+        throw new IOException("Test IOException");
+      case 1:
+        throw new NullPointerException("Test NullPointerException");
+      case 2:
+        throw new ArrayIndexOutOfBoundsException("Test ArrayIndexOutOfBoundsException");
+      case 3:
+        throw new ClassNotFoundException("Test ClassNotFoundException");
+      default:
+    }
+  }
+
+  // CHECKSTYLE.SUPPRESS: LineLength for +1 lines
+  class LonggggggggggggggggggggggggggggClassssssssssssssssssssssssssNameeeeeeeeeeeeeeSoooooBoooooorrriinngggg1 {
+    // ok below, as it is suppressed.
+    void
+        longggggggggggggggggggggmethooooooooooooooooooooooddddddddddddddddddddddddddddddddddddddddddddddddddddddd(
+            int x, int y) {}
+
+    // CHECKSTYLE.SUPPRESS: LineLength for -3 lines
+
+    // ok below, as it is suppressed.
+    // violation 4 lines below '.* indentation should be the same level as line 231.'
+    int
+        aaaarealllllllllllllllllyyyyyyyyyyylllllllloooooooooooooooonnnnnnnnnnnnnnnnnggggggggggvvvvvvaarriaaablleeeeeeeeeeee =
+            99;
+    // CHECKSTYLE.SUPPRESS: LineLength for -2 lines
+  }
+
+  // violation below 'Line is longer than 100 characters (found 112).'
+  class LonggggggggggggggggggggggggggggClassssssssssssssssssssssssssNameeeeeeeeeeeeeeSoooooBoooooorrriinngggg2 {
+    // violation 2 lines below 'Line is longer than 100 characters (found 114).'
+    void
+        longggggggggggggggggggggmethooooooooooooooooooooooddddddddddddddddddddddddddddddddddddddddddddddddddddddd(
+            int x, int y) {}
+
+    // violation 2 lines below 'Line is longer than 100 characters (found 125).'
+    int
+        aaaarealllllllllllllllllyyyyyyyyyyylllllllloooooooooooooooonnnnnnnnnnnnnnnnnggggggggggvvvvvvaarriaaablleeeeeeeeeeee =
+            99;
+  }
 }

--- a/src/main/resources/google_checks.xml
+++ b/src/main/resources/google_checks.xml
@@ -17,7 +17,6 @@
  -->
 
 <module name="Checker">
-  <module name="SuppressWarningsFilter"/>
 
   <property name="charset" value="UTF-8"/>
 
@@ -29,11 +28,22 @@
   <module name="BeforeExecutionExclusionFileFilter">
     <property name="fileNamePattern" value="module\-info\.java$"/>
   </module>
+
+  <module name="SuppressWarningsFilter"/>
+
   <!-- https://checkstyle.org/filters/suppressionfilter.html -->
   <module name="SuppressionFilter">
     <property name="file" value="${org.checkstyle.google.suppressionfilter.config}"
            default="checkstyle-suppressions.xml" />
     <property name="optional" value="true"/>
+  </module>
+
+  <!-- https://checkstyle.org/filters/suppresswithnearbytextfilter.html -->
+  <module name="SuppressWithNearbyTextFilter">
+    <property name="nearbyTextPattern"
+              value="CHECKSTYLE.SUPPRESS\: (\w+) for ([+-]\d+) lines"/>
+    <property name="checkPattern" value="$1"/>
+    <property name="lineRange" value="$2"/>
   </module>
 
   <!-- Checks for whitespace                               -->

--- a/src/test/java/com/puppycrawl/tools/checkstyle/internal/XdocsPagesTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/internal/XdocsPagesTest.java
@@ -1668,6 +1668,7 @@ public class XdocsPagesTest {
             styleChecks.remove("SuppressionCommentFilter");
             styleChecks.remove("SuppressWarningsFilter");
             styleChecks.remove("SuppressWarningsHolder");
+            styleChecks.remove("SuppressWithNearbyTextFilter");
 
             assertWithMessage(
                     fileName + " requires the following check(s) to appear: " + styleChecks)

--- a/src/xdocs/filters/suppresswithnearbytextfilter.xml
+++ b/src/xdocs/filters/suppresswithnearbytextfilter.xml
@@ -283,6 +283,10 @@ public static final boolean SOME_FLAG = false;
             <a href="https://github.com/search?q=path%3Aconfig%20path%3A**%2Fcheckstyle-checks.xml+repo%3Acheckstyle%2Fcheckstyle+SuppressWithNearbyTextFilter">
             Checkstyle Style</a>
           </li>
+          <li>
+            <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources%20path%3A**%2Fgoogle_checks.xml+repo%3Acheckstyle%2Fcheckstyle+SuppressWithNearbyTextFilter">
+            Google Style</a>
+          </li>
         </ul>
       </subsection>
       <subsection name="Package" id="Package">

--- a/src/xdocs/filters/suppresswithnearbytextfilter.xml.template
+++ b/src/xdocs/filters/suppresswithnearbytextfilter.xml.template
@@ -190,6 +190,10 @@
             <a href="https://github.com/search?q=path%3Aconfig%20path%3A**%2Fcheckstyle-checks.xml+repo%3Acheckstyle%2Fcheckstyle+SuppressWithNearbyTextFilter">
             Checkstyle Style</a>
           </li>
+          <li>
+            <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources%20path%3A**%2Fgoogle_checks.xml+repo%3Acheckstyle%2Fcheckstyle+SuppressWithNearbyTextFilter">
+            Google Style</a>
+          </li>
         </ul>
       </subsection>
       <subsection name="Package" id="Package">

--- a/src/xdocs/google_style.xml
+++ b/src/xdocs/google_style.xml
@@ -823,8 +823,12 @@
                     #14938</a>.
                   <br />
                   <br />
-                  Long identifiers will be handled at
-                  <a href="https://github.com/checkstyle/checkstyle/issues/15233">#15233</a>.
+                  To suppress this rule for longer identifiers, please use
+                  <a href="filters/suppresswithnearbytextfilter.html#SuppressWithNearbyTextFilter">
+                    SuppressWithNearbyTextFilter
+                  </a>.
+                  Check out <a href="#Google_Suppressions">Suppressions</a>
+                  section to learn how to use this suppression.
                   <br/>
                 </td>
                 <td>
@@ -1381,7 +1385,7 @@
                         alt="" />
                   </span>
                   Type-use annotations cannot be detected by Checkstyle due to it's
-                  <a href="https://checkstyle.org/writingchecks.html#Limitations">
+                  <a href="writingchecks.html#Limitations">
                     limitations</a>,
                   see issue
                   <a href="https://github.com/checkstyle/checkstyle/issues/15416">
@@ -2509,10 +2513,12 @@
           <a href="filters/suppresswithnearbycommentfilter.html#SuppressWithNearbyCommentFilter">
             SuppressWithNearbyCommentFilter</a>,
           <a href="filters/suppressioncommentfilter.html#SuppressionCommentFilter">
-            SuppressionCommentFilter</a>
-          and
+            SuppressionCommentFilter</a>,
           <a href="filters/suppresswarningsfilter.html#SuppressWarningsFilter">
-            SuppressWarningsFilter</a>.
+            SuppressWarningsFilter</a>
+          and
+          <a href="filters/suppresswithnearbytextfilter.html#SuppressWithNearbyTextFilter">
+            SuppressWithNearbyTextFilter</a>.
         </p>
         <p>
           Location of config file for
@@ -2551,6 +2557,19 @@
           format.
         </p>
         <p>
+          To suppress a check for few lines below or above, use
+          <a href="filters/suppresswithnearbytextfilter.html#SuppressWithNearbyTextFilter">
+            SuppressWithNearbyTextFilter
+          </a>
+          suppression, use
+          <code>// CHECKSTYLE.SUPPRESS: NameOfCheck for ([+-]\d+) lines</code> comment.
+          ( replace NameOfCheck with the check you want to suppress.
+          For suppressing a check few lines below,
+          replace <i>([+-]\d+)</i> with <i>+NumberOfLines</i> where <i>NumberOfLines</i>
+          is number of the lines below from the comment's line number,
+          for suppressing a check few lines above, use &quot;-&quot; instead of &quot;+&quot;. )
+        </p>
+        <p>
           For more details please review exact configuration of Filters in google_checks.xml:
           <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources%20path%3A**%2Fgoogle_checks.xml+repo%3Acheckstyle%2Fcheckstyle+SuppressionFilter">
                     SuppressionFilter</a>,
@@ -2562,6 +2581,8 @@
                     SuppressionCommentFilter</a>,
           <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources%20path%3A**%2Fgoogle_checks.xml+repo%3Acheckstyle%2Fcheckstyle+SuppressWarningsFilter">
                     SuppressWarningsFilter</a>,
+          <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources%20path%3A**%2Fgoogle_checks.xml+repo%3Acheckstyle%2Fcheckstyle+SuppressWithNearbyTextFilter">
+                    SuppressWithNearbyTextFilter</a>
         </p>
       </subsection>
     </section>


### PR DESCRIPTION
#15233 

Added test cases with `@SuppressWarnings({"LineLength"})` for long identifiers for section 4.4 input file. Updated section on the coverage table to show how to avoid violation for such long identifiers with suppression.