### PR TITLE
Pull #15466: grab setter types even if field exists for override

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/site/SiteUtil.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/site/SiteUtil.java
@@ -1147,17 +1147,16 @@ public final class SiteUtil {
             throws MacroExecutionException {
         Class<?> result = null;
 
-        if (field != null) {
+        if (PROPERTIES_ALLOWED_GET_TYPES_FROM_METHOD
+                .contains(moduleName + DOT + propertyName)) {
+            result = getPropertyClass(propertyName, instance);
+        }
+        if (field != null && result == null) {
             result = field.getType();
         }
         if (result == null) {
-            if (!PROPERTIES_ALLOWED_GET_TYPES_FROM_METHOD
-                    .contains(moduleName + DOT + propertyName)) {
-                throw new MacroExecutionException(
-                        "Could not find field " + propertyName + " in class " + moduleName);
-            }
-
-            result = getPropertyClass(propertyName, instance);
+            throw new MacroExecutionException(
+                    "Could not find field " + propertyName + " in class " + moduleName);
         }
         if (field != null && (result == List.class || result == Set.class)) {
             final ParameterizedType type = (ParameterizedType) field.getGenericType();

--- a/src/test/java/com/puppycrawl/tools/checkstyle/internal/XdocsPagesTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/internal/XdocsPagesTest.java
@@ -1364,21 +1364,21 @@ public class XdocsPagesTest {
             Field field, String propertyName) throws Exception {
         Class<?> result = null;
 
-        if (field != null) {
+        if (PROPERTIES_ALLOWED_GET_TYPES_FROM_METHOD.contains(sectionName + "." + propertyName)) {
+            final PropertyDescriptor descriptor = PropertyUtils.getPropertyDescriptor(instance,
+                    propertyName);
+            result = descriptor.getPropertyType();
+        }
+        if (field != null && result == null) {
             result = field.getType();
         }
         if (result == null) {
             assertWithMessage(
                     fileName + " section '" + sectionName + "' could not find field "
                             + propertyName)
-                    .that(PROPERTIES_ALLOWED_GET_TYPES_FROM_METHOD)
-                    .contains(sectionName + "." + propertyName);
-
-            final PropertyDescriptor descriptor = PropertyUtils.getPropertyDescriptor(instance,
-                    propertyName);
-            result = descriptor.getPropertyType();
+                    .fail();
         }
-        if (result == List.class || result == Set.class) {
+        if (field != null && (result == List.class || result == Set.class)) {
             final ParameterizedType type = (ParameterizedType) field.getGenericType();
             final Class<?> parameterClass = (Class<?>) type.getActualTypeArguments()[0];
 


### PR DESCRIPTION
Assist for https://github.com/checkstyle/checkstyle/pull/15376#discussion_r1706279547 ,

`PROPERTIES_ALLOWED_GET_TYPES_FROM_METHOD` allows us to use the setter's type ONLY if the field cannot be found. If we make the field invisible to use that override, we lose the default value of the field.

This updates PROPERTIES_ALLOWED_GET_TYPES_FROM_METHOD logic so it uses the setter even if the field exists. This override is only used by 4 other checks, so it should be minimal impact.
