### PR TITLE
Issue #15217: added missing sections in google style guide coverage table

### DIFF
--- a/src/xdocs/google_style.xml
+++ b/src/xdocs/google_style.xml
@@ -202,6 +202,22 @@
                 <td/>
               </tr>
               <tr>
+                <td><a name="2.3"/>
+                  <a href="#2.3">
+                    <span class="wrapper inline">
+                      <img src="images/anchor.png" alt=""/>
+                    </span>
+                  </a>
+                </td>
+                <td>
+                  <a href="styleguides/google-java-style-20220203/javaguide.html#s2.3-special-characters">
+                    2.3 Special characters
+                  </a>
+                </td>
+                <td>↓</td>
+                <td/>
+              </tr>
+              <tr>
                 <td><a name="2.3.1"/>
                   <a href="#2.3.1">
                     <span class="wrapper inline">
@@ -1484,6 +1500,30 @@
                   <a href="https://github.com/checkstyle/checkstyle/blob/master/src/it/java/com/google/checkstyle/test/chapter4formatting/rule4854fieldannotations/FieldAnnotationsTest.java">
                     test</a>
                 </td>
+              </tr>
+              <tr>
+                <td><a name="4.8.5.5"/>
+                  <a href="#4.8.5.5">
+                    <span class="wrapper inline">
+                      <img src="images/anchor.png" alt=""/>
+                    </span>
+                  </a>
+                </td>
+                <td>
+                  <a href="styleguides/google-java-style-20220203/javaguide.html#s4.8.5.5-local-parameter-annotation-style  ">
+                    4.8.5.5 Parameter and local variable annotations
+                  </a>
+                </td>
+                <td>
+                  --
+                  <br/>
+                  <br/>
+                  For type-use annotations see
+                  <a href="#a4.8.5.1">
+                    4.8.5.1 Type-use annotations
+                  </a>
+                </td>
+                <td/>
               </tr>
               <tr>
                 <td><a name="4.8.6"/>


### PR DESCRIPTION
#15217 

Added missing sections `2.3 Special characters` & `4.8.5.5 Parameter and local variable annotations` to coverage table.