### PR TITLE
Issue #13213 Remove //ok comment from Variabledeclarationusagedistance

### DIFF
--- a/config/checkstyle-input-suppressions.xml
+++ b/config/checkstyle-input-suppressions.xml
@@ -76,16 +76,6 @@
   <suppress id="UnnecessaryOkComment"
             files="checks[\\/]coding[\\/]unnecessarysemicolonaftertypememberdeclaration[\\/]InputUnnecessarySemicolonAfterTypeMemberDeclarationNullAst.java"/>
   <suppress id="UnnecessaryOkComment"
-            files="checks[\\/]coding[\\/]variabledeclarationusagedistance[\\/]InputVariableDeclarationUsageDistance3.java"/>
-  <suppress id="UnnecessaryOkComment"
-            files="checks[\\/]coding[\\/]variabledeclarationusagedistance[\\/]InputVariableDeclarationUsageDistance3.java"/>
-  <suppress id="UnnecessaryOkComment"
-            files="checks[\\/]coding[\\/]variabledeclarationusagedistance[\\/]InputVariableDeclarationUsageDistanceDefault2.java"/>
-  <suppress id="UnnecessaryOkComment"
-            files="checks[\\/]coding[\\/]variabledeclarationusagedistance[\\/]InputVariableDeclarationUsageDistanceIfStatements.java"/>
-  <suppress id="UnnecessaryOkComment"
-            files="checks[\\/]coding[\\/]variabledeclarationusagedistance[\\/]InputVariableDeclarationUsageDistanceLabels.java"/>
-  <suppress id="UnnecessaryOkComment"
             files="checks[\\/]indentation[\\/]commentsindentation[\\/]InputCommentsIndentationCommentsAfterMethodCall.java"/>
   <suppress id="UnnecessaryOkComment"
             files="checks[\\/]indentation[\\/]commentsindentation[\\/]InputCommentsIndentationCommentsAfterMethodCall.java"/>

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/variabledeclarationusagedistance/InputVariableDeclarationUsageDistance3.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/variabledeclarationusagedistance/InputVariableDeclarationUsageDistance3.java
@@ -20,8 +20,8 @@ public class InputVariableDeclarationUsageDistance3 {
          byte[] data, int offset, int length, OutputStream out)
          throws IOException {
          out.write((byte) ((length & 0x3F) + ' '));
-         byte a;  // ok
-         byte b; // ok
+         byte a;
+         byte b;
          byte c;
 
          for (int i = 0; i < length;) {

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/variabledeclarationusagedistance/InputVariableDeclarationUsageDistanceDefault2.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/variabledeclarationusagedistance/InputVariableDeclarationUsageDistanceDefault2.java
@@ -13,7 +13,7 @@ package com.puppycrawl.tools.checkstyle.checks.coding.variabledeclarationusagedi
 public class InputVariableDeclarationUsageDistanceDefault2 {
 
     void method() {
-        int VARIABLE_DEF = 12; // ok
+        int VARIABLE_DEF = 12;
         method();
         method();
         method();

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/variabledeclarationusagedistance/InputVariableDeclarationUsageDistanceIfStatements.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/variabledeclarationusagedistance/InputVariableDeclarationUsageDistanceIfStatements.java
@@ -45,7 +45,7 @@ public class InputVariableDeclarationUsageDistanceIfStatements {
     }
 
     void testConsecutiveIfStatements() {
-        int a = 12; // ok
+        int a = 12;
         int b = 13; // violation 'Distance between .* declaration and its first usage is 2.'
         int c = 14; // violation 'Distance between .* declaration and its first usage is 3.'
         int d = 15; // violation 'Distance between .* declaration and its first usage is 4.'

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/variabledeclarationusagedistance/InputVariableDeclarationUsageDistanceLabels.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/variabledeclarationusagedistance/InputVariableDeclarationUsageDistanceLabels.java
@@ -18,7 +18,7 @@ public class InputVariableDeclarationUsageDistanceLabels {
         nothing();
         nothing();
         nothing();
-        myLoop: // ok
+        myLoop:
         for (int i = 0; i < 5; i++) {
             if (i == 5) {
                 eol = true;


### PR DESCRIPTION
Part of #13213 

Link to check documentation: https://checkstyle.org/checks/coding/variabledeclarationusagedistance.html

Proof that all suppression for this check are removed:

```shell
➜  checkstyle git:(master) grep variabledeclarationusagedistance config/checkstyle-input-suppressions.xml
            files="checks[\\/]coding[\\/]variabledeclarationusagedistance[\\/]InputVariableDeclarationUsageDistance3.java"/>
            files="checks[\\/]coding[\\/]variabledeclarationusagedistance[\\/]InputVariableDeclarationUsageDistance3.java"/>
            files="checks[\\/]coding[\\/]variabledeclarationusagedistance[\\/]InputVariableDeclarationUsageDistanceDefault2.java"/>
            files="checks[\\/]coding[\\/]variabledeclarationusagedistance[\\/]InputVariableDeclarationUsageDistanceIfStatements.java"/>
            files="checks[\\/]coding[\\/]variabledeclarationusagedistance[\\/]InputVariableDeclarationUsageDistanceLabels.java"/>

➜  checkstyle git:(b13213) grep variabledeclarationusagedistance config/checkstyle-input-suppressions.xml

➜  checkstyle git:(b13213) echo $?
``` 