### PR TITLE
Issue #15449: excluded rule73 from google-java-format.sh

### DIFF
--- a/.ci/google-java-format.sh
+++ b/.ci/google-java-format.sh
@@ -10,15 +10,21 @@ INPUT_PATHS=($(find src/it/resources/com/google/checkstyle/test/ -name "Input*.j
     | grep -v "rule712paragraphs/InputIncorrectRequireEmptyLineBeforeBlockTagGroup.java" \
     | grep -v "rule712paragraphs/InputIncorrectJavadocParagraph.java" \
     | grep -v "rule713atclauses" \
-    | grep -v "rule73" \
+    | grep -v "rule734nonrequiredjavadoc" \
     | grep -v "rule64" \
     | grep -v "rule53camelcase" \
     | grep -v "rule522classnames" \
-    | grep -v "rule41" | grep -v "rule42" | grep -v "rule43onestatement" \
+    | grep -v "rule41" \
+    | grep -v "rule42" \
+    | grep -v "rule43onestatement" \
     | grep -v "rule44columnlimit" \
-    | grep -v "rule45" | grep -v "rule461verticalwhitespace" | grep -v "rule462" \
+    | grep -v "rule45" \
+    | grep -v "rule461verticalwhitespace" \
+    | grep -v "rule462" \
     | grep -v "rule48" \
-    | grep -v "rule3sourcefile" | grep -v "rule331nowildcard" | grep -v "rule332nolinewrap" \
+    | grep -v "rule3sourcefile" \
+    | grep -v "rule331nowildcard" \
+    | grep -v "rule332nolinewrap" \
     | grep -v "rule333orderingandspacing" \
     | grep -v "rule3421overloadsplit" \
     | grep -v "rule231filetab" \


### PR DESCRIPTION
#15449

7.3 Where Javadoc is used
https://checkstyle.org/google_style.html#a7.3

