### PR TITLE
Issue #15449: partially excluded rule48 from google-java-format.sh

### DIFF
--- a/.ci/google-java-format.sh
+++ b/.ci/google-java-format.sh
@@ -20,7 +20,17 @@ INPUT_PATHS=($(find src/it/resources/com/google/checkstyle/test/ -name "Input*.j
     | grep -v "rule45" \
     | grep -v "rule461verticalwhitespace" \
     | grep -v "rule462" \
-    | grep -v "rule48" \
+    | grep -v "rule487modifiers/InputModifierOrder.java" \
+    | grep -v "rule4821onevariableperline/InputOneVariablePerDeclaration.java" \
+    | grep -v "rule4822declaredwhenneeded/InputDeclaredWhenNeeded.java" \
+    | grep -v "rule4841indentation/ClassWithChainedMethods.java" \
+    | grep -v "rule4842fallthrough/InputFallThrough.java" \
+    | grep -v "rule485annotations/InputAnnotationLocation.java" \
+    | grep -v "rule485annotations/InputAnnotationLocationVariables.java" \
+    | grep -v "rule4852classannotations/InputClassAnnotations.java" \
+    | grep -v "rule4853methods.*/InputMethodsAndConstructorsAnnotations.java" \
+    | grep -v "rule4854fieldannotations/InputFieldAnnotations.java" \
+    | grep -v "rule4861blockcommentstyle/InputCommentsIndentation.*.java" \
     | grep -v "rule3sourcefile" \
     | grep -v "rule331nowildcard" \
     | grep -v "rule332nolinewrap" \

--- a/src/it/resources/com/google/checkstyle/test/chapter4formatting/rule4841indentation/InputIndentationCorrectIfAndParameter.java
+++ b/src/it/resources/com/google/checkstyle/test/chapter4formatting/rule4841indentation/InputIndentationCorrectIfAndParameter.java
@@ -12,7 +12,9 @@ class InputIndentationCorrectIfAndParameter {
         "Loooooooooooooooooong",
         new SecondClassLongNam3("Loooooooooooooooooog")
             .getInteger(new FooIfClass(), "Loooooooooooooooooog"),
-        new InnerClassFoo())) { /* foo */ }
+        new InnerClassFoo())) {
+      /* foo */
+    }
 
     if (conditionSecond(
             10000000000.0,
@@ -36,7 +38,9 @@ class InputIndentationCorrectIfAndParameter {
         || conditionNoArg()
         || conditionNoArg()
         || conditionNoArg()
-        || conditionNoArg()) { /* foo */ }
+        || conditionNoArg()) {
+      /* foo */
+    }
   }
 
   private boolean conditionFirst(String longString, int integer, InnerClassFoo someInstance) {
@@ -82,7 +86,9 @@ class InputIndentationCorrectIfAndParameter {
                 "Loooooooooooooooooong",
                 new SecondClassLongNam3("Loooooooooooooooooog")
                     .getInteger(new FooIfClass(), "Loooooooooooooooooog"),
-                new InnerClassFoo())) { /* foo */ }
+                new InnerClassFoo())) {
+              /* foo */
+            }
 
             if (conditionSecond(
                     10000000000.0,
@@ -106,7 +112,9 @@ class InputIndentationCorrectIfAndParameter {
                 || conditionNoArg()
                 || conditionNoArg()
                 || conditionNoArg()
-                || conditionNoArg() && fooooooooobooleanBooleanVeryLongName) { /* foo */ }
+                || conditionNoArg() && fooooooooobooleanBooleanVeryLongName) {
+              /* foo */
+            }
           }
         };
 
@@ -115,7 +123,9 @@ class InputIndentationCorrectIfAndParameter {
           "Loooooooooooooooooong",
           new SecondClassLongNam3("Loooooooooooooooooog")
               .getInteger(new FooIfClass(), "Loooooooooooooooooog"),
-          new InnerClassFoo())) { /* foo */ }
+          new InnerClassFoo())) {
+        /* foo */
+      }
 
       if (conditionSecond(
               10000000000.0,
@@ -139,7 +149,9 @@ class InputIndentationCorrectIfAndParameter {
           || conditionNoArg()
           || conditionNoArg()
           || conditionNoArg()
-          || conditionNoArg()) { /* foo */ }
+          || conditionNoArg()) {
+        /* foo */
+      }
     }
   }
 

--- a/src/it/resources/com/google/checkstyle/test/chapter4formatting/rule4843defaultlabelpresence/InputPresenceOfDefaultLabel.java
+++ b/src/it/resources/com/google/checkstyle/test/chapter4formatting/rule4843defaultlabelpresence/InputPresenceOfDefaultLabel.java
@@ -48,22 +48,22 @@ public class InputPresenceOfDefaultLabel {
             break;
         }
         Foo foo =
-                new Foo() {
-                  /** Some javadoc. */
-                  public void foo() {
-                    int i = 1;
-                    switch (i) { // violation 'switch without "default" clause.'
-                      case 1:
-                        i++;
-                        break;
-                      case 2:
-                        i--;
-                        break;
-                    }
-                    switch (i) { // violation 'switch without "default" clause.'
-                    }
-                  }
-                };
+            new Foo() {
+              /** Some javadoc. */
+              public void foo() {
+                int i = 1;
+                switch (i) { // violation 'switch without "default" clause.'
+                  case 1:
+                    i++;
+                    break;
+                  case 2:
+                    i--;
+                    break;
+                }
+                switch (i) { // violation 'switch without "default" clause.'
+                }
+              }
+            };
       }
     }
   }

--- a/src/it/resources/com/google/checkstyle/test/chapter4formatting/rule488numericliterals/InputNumericLiterals.java
+++ b/src/it/resources/com/google/checkstyle/test/chapter4formatting/rule488numericliterals/InputNumericLiterals.java
@@ -17,12 +17,12 @@ class InputNumericLiterals {
 
   private void processUpperEll(long xyz) {
     long bad =
-            (4 + 5 * 7 ^ 66l / 7 + 890) // violation 'Should use uppercase 'L'.'
-                    & (88l + 78 * 4); // violation 'Should use uppercase 'L'.'
+        (4 + 5 * 7 ^ 66l / 7 + 890) // violation 'Should use uppercase 'L'.'
+            & (88l + 78 * 4); // violation 'Should use uppercase 'L'.'
     long good = (4 + 5 * 7 ^ 66L / 7 + 890) & (88L + 78 * 4); // ok
     long[] array = {
-        66l, // violation 'Should use uppercase 'L'.'
-        66L, // ok
+      66l, // violation 'Should use uppercase 'L'.'
+      66L, // ok
     };
   }
 
@@ -45,48 +45,48 @@ class InputNumericLiterals {
 
     private void processUpperEll(long xyz) {
       long bad =
-              (4 + 5 * 7 ^ 66l / 7 + 890) // violation 'Should use uppercase 'L'.'
-                      & (88l + 78 * 4); // violation 'Should use uppercase 'L'.'
+          (4 + 5 * 7 ^ 66l / 7 + 890) // violation 'Should use uppercase 'L'.'
+              & (88l + 78 * 4); // violation 'Should use uppercase 'L'.'
       long good = (4 + 5 * 7 ^ 66L / 7 + 890) & (88L + 78 * 4); // ok
     }
 
     private void processUpperEll(String s, long l) {
       long[] array = {
-          66l, // violation 'Should use uppercase 'L'.'
-          66L, // ok
+        66l, // violation 'Should use uppercase 'L'.'
+        66L, // ok
       };
     }
 
     void fooMethod() {
       Foo foo =
-              new Foo() {
-                /** test. * */
-                private final long ignore = 666l + 666L; // violation 'Should use uppercase 'L'.'
+          new Foo() {
+            /** test. * */
+            private final long ignore = 666l + 666L; // violation 'Should use uppercase 'L'.'
 
-                private String notWarn = "666l"; // ok
+            private String notWarn = "666l"; // ok
 
-                private long foo() {
-                  processUpperEll(66l); // violation 'Should use uppercase 'L'.'
-                  processUpperEll(66L); // ok
-                  processUpperEll("s", 66l); // violation 'Should use uppercase 'L'.'
-                  processUpperEll("s", 66L); // ok
+            private long foo() {
+              processUpperEll(66l); // violation 'Should use uppercase 'L'.'
+              processUpperEll(66L); // ok
+              processUpperEll("s", 66l); // violation 'Should use uppercase 'L'.'
+              processUpperEll("s", 66L); // ok
 
-                  return 666l + 666L; // violation 'Should use uppercase 'L'.'
-                }
+              return 666l + 666L; // violation 'Should use uppercase 'L'.'
+            }
 
-                private void processUpperEll(long x) {
-                  long bad =
-                          (4 + 5 * 7 ^ 66l / 7 + 890) // violation 'Should use uppercase 'L'.'
-                                  & (88l + 78 * 4); // violation 'Should use uppercase 'L'.'
-                  long good = (4 + 5 * 7 ^ 66L / 7 + 890) & (88L + 78 * 4); // ok
-                  long[] array = {
-                      66l, // violation 'Should use uppercase 'L'.'
-                      66L, // ok
-                  };
-                }
-
-                private void processUpperEll(String s, long x) {}
+            private void processUpperEll(long x) {
+              long bad =
+                  (4 + 5 * 7 ^ 66l / 7 + 890) // violation 'Should use uppercase 'L'.'
+                      & (88l + 78 * 4); // violation 'Should use uppercase 'L'.'
+              long good = (4 + 5 * 7 ^ 66L / 7 + 890) & (88L + 78 * 4); // ok
+              long[] array = {
+                66l, // violation 'Should use uppercase 'L'.'
+                66L, // ok
               };
+            }
+
+            private void processUpperEll(String s, long x) {}
+          };
     }
   }
 
@@ -96,8 +96,8 @@ class InputNumericLiterals {
     public static final long IGNORE = 666l + 666L; // violation 'Should use uppercase 'L'.'
     public static final String notWarn = "666l"; // ok
     long bad =
-            (4 + 5 * 7 ^ 66l / 7 + 890) // violation 'Should use uppercase 'L'.'
-                    & (88l + 78 * 4); // violation 'Should use uppercase 'L'.'
+        (4 + 5 * 7 ^ 66l / 7 + 890) // violation 'Should use uppercase 'L'.'
+            & (88l + 78 * 4); // violation 'Should use uppercase 'L'.'
     long good = (4 + 5 * 7 ^ 66L / 7 + 890) & (88L + 78 * 4); // ok
   }
 }


### PR DESCRIPTION
#15449 

the grepped list became large in this PR. There were only few section under rule48 in which our config and formatter did not conflict. 

Most of the tests started failing after formatting the input files of them. 

Grepped sections:

[4.8.7 Modifiers](https://checkstyle.org/styleguides/google-java-style-20180523/javaguide.html#s4.8.7-modifiers)
[4.8.2.1 One variable per declaration](https://checkstyle.org/styleguides/google-java-style-20180523/javaguide.html#s4.8.2.1-variables-per-declaration)
[4.8.2.2 Declared when needed](https://checkstyle.org/styleguides/google-java-style-20180523/javaguide.html#s4.8.2.2-variables-limited-scope)
[4.8.4.1 Indentation](https://checkstyle.org/styleguides/google-java-style-20180523/javaguide.html#s4.8.4.1-switch-indentation) ( only ClassWithChainedMethods.java )
[4.8.4.2 Fall-through: commented](https://checkstyle.org/styleguides/google-java-style-20180523/javaguide.html#s4.8.4.2-switch-fall-through)
[4.8.6.1 Block comment style](https://checkstyle.org/styleguides/google-java-style-20180523/javaguide.html#s4.8.6.1-block-comment-style)
[4.8.5.2 Class Annotations](https://checkstyle-diff-reports.s3.us-east-2.amazonaws.com/3adc309_2024180040/styleguides/google-java-style-20220203/javaguide.html#s4.8.5.2-class-annotation-style)
[4.8.5.3 Methods And Constructors Annotations](https://checkstyle-diff-reports.s3.us-east-2.amazonaws.com/3adc309_2024180040/styleguides/google-java-style-20220203/javaguide.html#s4.8.5.3-method-annotation-style)
[4.8.5.4 Field Annotations](https://checkstyle-diff-reports.s3.us-east-2.amazonaws.com/3adc309_2024180040/styleguides/google-java-style-20220203/javaguide.html#s4.8.5.4-field-annotation-style)

Sections which didn't needed to be grepped:

[4.8.4.1 Indentation](https://checkstyle.org/styleguides/google-java-style-20180523/javaguide.html#s4.8.4.1-switch-indentation)
[4.8.4.3 The default case is present](https://checkstyle.org/styleguides/google-java-style-20180523/javaguide.html#s4.8.4.3-switch-default)
[4.8.8 Numeric Literals](https://checkstyle.org/styleguides/google-java-style-20180523/javaguide.html#s4.8.8-numeric-literals)
[4.8.3.2 No C-style array declarations](https://checkstyle.org/styleguides/google-java-style-20180523/javaguide.html#s4.8.3.2-array-declarations) ( After using formatter on input file of this section, there were no changes, the file was already formatted so you will not be able to see it in GH diff section. )