### PR TITLE
Issue #15449: partially excluded rule333orderingandspacing from google-java-format.sh

### DIFF
--- a/.ci/google-java-format.sh
+++ b/.ci/google-java-format.sh
@@ -24,7 +24,13 @@ INPUT_PATHS=($(find src/it/resources/com/google/checkstyle/test/ -name "Input*.j
     | grep -v "rule3sourcefile" \
     | grep -v "rule331nowildcard" \
     | grep -v "rule332nolinewrap" \
-    | grep -v "rule333orderingandspacing" \
+    | grep -v "rule333orderingandspacing/InputOrderingAndSpacing1.java" \
+    | grep -v "rule333orderingandspacing/InputOrderingAndSpacing2.java" \
+    | grep -v "rule333orderingandspacing/InputOrderingAndSpacing3.java" \
+    | grep -v "rule333orderingandspacing/InputOrderingAndSpacing4.java" \
+    | grep -v "rule333orderingandspacing/InputOrderingAndSpacing5.java" \
+    | grep -v "rule333orderingandspacing/InputOrderingAndSpacingValid.java" \
+    | grep -v "rule333orderingandspacing/InputOrderingAndSpacingValid2.java" \
     | grep -v "rule3421overloadsplit" \
     | grep -v "rule231filetab" \
     ))

--- a/src/it/resources/com/google/checkstyle/test/chapter3filestructure/rule333orderingandspacing/InputOrderingAndSpacingNoImports.java
+++ b/src/it/resources/com/google/checkstyle/test/chapter3filestructure/rule333orderingandspacing/InputOrderingAndSpacingNoImports.java
@@ -1,5 +1,4 @@
 package com.google.checkstyle.test.chapter3filestructure.rule333orderingandspacing;
 
 /** Some javadoc. */
-public class InputOrderingAndSpacingNoImports {
-}
+public class InputOrderingAndSpacingNoImports {}


### PR DESCRIPTION
#15449

Only InputOrderingAndSpacingNoImports .java is excluded other than that all of the inputs needed to be grepped cuz they're based on unused imports and formatter will remove those during formatting process.