### PR TITLE
Issue #15449: partially excluded rule713atclauses from google-java-format.sh

### DIFF
--- a/.ci/google-java-format.sh
+++ b/.ci/google-java-format.sh
@@ -9,7 +9,7 @@ INPUT_PATHS=($(find src/it/resources/com/google/checkstyle/test/ -name "Input*.j
     | grep -v "rule711generalform" \
     | grep -v "rule712paragraphs/InputIncorrectRequireEmptyLineBeforeBlockTagGroup.java" \
     | grep -v "rule712paragraphs/InputIncorrectJavadocParagraph.java" \
-    | grep -v "rule713atclauses" \
+    | grep -v "rule713atclauses/InputJavaDocTagContinuationIndentation.java" \
     | grep -v "rule734nonrequiredjavadoc" \
     | grep -v "rule53camelcase" \
     | grep -v "rule522classnames" \


### PR DESCRIPTION
#15449

Doc:- [7.1.3 Block tags](https://checkstyle.org/styleguides/google-java-style-20180523/javaguide.html#s7.1.3-javadoc-at-clauses)

grepped InputJavaDocTagContinuationIndentation.java because it is indentation based input which contains violations. Formatter will correct the violations and test will start to fail