### PR TITLE
Issue #15449: partially excluded rule45 from google-java-format.sh

### DIFF
--- a/.ci/google-java-format.sh
+++ b/.ci/google-java-format.sh
@@ -17,7 +17,8 @@ INPUT_PATHS=($(find src/it/resources/com/google/checkstyle/test/ -name "Input*.j
     | grep -v "rule42/ClassWithChainedMethods.java" \
     | grep -v "rule43onestatement" \
     | grep -v "rule44columnlimit" \
-    | grep -v "rule45" \
+    | grep -v "rule452indentcontinuationlines/ClassWithChainedMethods.java" \
+    | grep -v "rule451wheretobreak" \
     | grep -v "rule461verticalwhitespace" \
     | grep -v "rule462" \
     | grep -v "rule48" \

--- a/config/jsoref-spellchecker/whitelist.words
+++ b/config/jsoref-spellchecker/whitelist.words
@@ -240,7 +240,6 @@ Contextualizable
 contextualization
 contextualized
 Contextualizing
-continuationlines
 courtlink
 courtlinkkk
 covariantequals

--- a/src/it/java/com/google/checkstyle/test/chapter4formatting/rule452indentcontinuationlines/IndentContinuationLinesAtLeast4SpacesTest.java
+++ b/src/it/java/com/google/checkstyle/test/chapter4formatting/rule452indentcontinuationlines/IndentContinuationLinesAtLeast4SpacesTest.java
@@ -17,7 +17,7 @@
 // Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 ///////////////////////////////////////////////////////////////////////////////////////////////
 
-package com.google.checkstyle.test.chapter4formatting.rule452continuationlines;
+package com.google.checkstyle.test.chapter4formatting.rule452indentcontinuationlines;
 
 import org.junit.jupiter.api.Test;
 

--- a/src/it/resources/com/google/checkstyle/test/chapter4formatting/rule452indentcontinuationlines/InputIndentationCorrectIfAndParameter.java
+++ b/src/it/resources/com/google/checkstyle/test/chapter4formatting/rule452indentcontinuationlines/InputIndentationCorrectIfAndParameter.java
@@ -12,7 +12,9 @@ class InputIndentationCorrectIfAndParameter {
         "Loooooooooooooooooong",
         new SecondClassLongNam3("Loooooooooooooooooog")
             .getInteger(new FooIfClass(), "Loooooooooooooooooog"),
-        new InnerClassFoo())) { /* foo */ }
+        new InnerClassFoo())) {
+      /* foo */
+    }
 
     if (conditionSecond(
             10000000000.0,
@@ -36,7 +38,9 @@ class InputIndentationCorrectIfAndParameter {
         || conditionNoArg()
         || conditionNoArg()
         || conditionNoArg()
-        || conditionNoArg()) { /* foo */ }
+        || conditionNoArg()) {
+      /* foo */
+    }
   }
 
   private boolean conditionFirst(String longString, int integer, InnerClassFoo someInstance) {
@@ -82,7 +86,9 @@ class InputIndentationCorrectIfAndParameter {
                 "Loooooooooooooooooong",
                 new SecondClassLongNam3("Loooooooooooooooooog")
                     .getInteger(new FooIfClass(), "Loooooooooooooooooog"),
-                new InnerClassFoo())) { /* foo */ }
+                new InnerClassFoo())) {
+              /* foo */
+            }
 
             if (conditionSecond(
                     10000000000.0,
@@ -106,7 +112,9 @@ class InputIndentationCorrectIfAndParameter {
                 || conditionNoArg()
                 || conditionNoArg()
                 || conditionNoArg()
-                || conditionNoArg() && fooooooooobooleanBooleanVeryLongName) { /* foo */ }
+                || conditionNoArg() && fooooooooobooleanBooleanVeryLongName) {
+              /* foo */
+            }
           }
         };
 
@@ -115,7 +123,9 @@ class InputIndentationCorrectIfAndParameter {
           "Loooooooooooooooooong",
           new SecondClassLongNam3("Loooooooooooooooooog")
               .getInteger(new FooIfClass(), "Loooooooooooooooooog"),
-          new InnerClassFoo())) { /* foo */ }
+          new InnerClassFoo())) {
+        /* foo */
+      }
 
       if (conditionSecond(
               10000000000.0,
@@ -139,7 +149,9 @@ class InputIndentationCorrectIfAndParameter {
           || conditionNoArg()
           || conditionNoArg()
           || conditionNoArg()
-          || conditionNoArg()) { /* foo */ }
+          || conditionNoArg()) {
+        /* foo */
+      }
     }
   }
 

--- a/src/xdocs/google_style.xml
+++ b/src/xdocs/google_style.xml
@@ -900,7 +900,7 @@
                 <td>
                   <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources%20path%3A**%2Fgoogle_checks.xml+repo%3Acheckstyle%2Fcheckstyle+Indentation">
                     config</a><br/>
-                  <a href="https://github.com/checkstyle/checkstyle/blob/master/src/it/java/com/google/checkstyle/test/chapter4formatting/rule452continuationlines/IndentContinuationLinesAtLeast4SpacesTest.java">
+                  <a href="https://github.com/checkstyle/checkstyle/blob/master/src/it/java/com/google/checkstyle/test/chapter4formatting/rule452indentcontinuationlines/IndentContinuationLinesAtLeast4SpacesTest.java">
                     test</a>
                 </td>
               </tr>


### PR DESCRIPTION
#15449

Affected sections:

[4.5.2 Indent continuation lines at least +4 spaces](https://checkstyle.org/styleguides/google-java-style-20180523/javaguide.html#s4.5.2-line-wrapping-indent)
[4.5.1 Where to break](https://checkstyle.org/styleguides/google-java-style-20180523/javaguide.html#s4.5.1-line-wrapping-where-to-break)

all inputs of 4.5.1 started failing after formatting so had to grep it entirely 