### PR TITLE
Issue #15449: partially excluded rule41 from google-java-format.sh

### DIFF
--- a/.ci/google-java-format.sh
+++ b/.ci/google-java-format.sh
@@ -13,7 +13,16 @@ INPUT_PATHS=($(find src/it/resources/com/google/checkstyle/test/ -name "Input*.j
     | grep -v "rule734nonrequiredjavadoc" \
     | grep -v "rule53camelcase" \
     | grep -v "rule522classnames" \
-    | grep -v "rule41" \
+    | grep -v "rule411optionalbracesusage" \
+    | grep -v "rule412nonemptyblocks/InputNonemptyBlocksLeftRightCurly.java" \
+    | grep -v "rule412nonemptyblocks/InputLeftCurlyAnnotations.java" \
+    | grep -v "rule412nonemptyblocks/InputLeftCurlyMethod.java" \
+    | grep -v "rule412nonemptyblocks/InputRightCurly.java" \
+    | grep -v "rule412nonemptyblocks/InputRightCurlyOther.java" \
+    | grep -v "rule412nonemptyblocks/InputRightCurlySwitchCase.java" \
+    | grep -v "rule412nonemptyblocks/InputRightCurlySwitchCasesBlocks.java" \
+    | grep -v "rule413emptyblocks/InputEmptyBlocksAndCatchBlocks.java" \
+    | grep -v "rule413emptyblocks/InputEmptyFinallyBlocks.java" \
     | grep -v "rule42/ClassWithChainedMethods.java" \
     | grep -v "rule43onestatement" \
     | grep -v "rule44columnlimit" \


### PR DESCRIPTION
#15449 

Affected sections:

[4.1.1 Use of optional braces](https://checkstyle-diff-reports.s3.us-east-2.amazonaws.com/2d35464_2024232909/styleguides/google-java-style-20220203/javaguide.html#s4.1.1-braces-always-used) ( grepped entirely )
[4.1.2 Nonempty blocks: K & R style](https://checkstyle-diff-reports.s3.us-east-2.amazonaws.com/2d35464_2024232909/styleguides/google-java-style-20220203/javaguide.html#s4.1.2-blocks-k-r-style) ( partially grepped )
[4.1.3 Empty blocks: may be concise](https://checkstyle-diff-reports.s3.us-east-2.amazonaws.com/2d35464_2024232909/styleguides/google-java-style-20220203/javaguide.html#s4.1.3-braces-empty-blocks) ( partially grepped)
