### PR TITLE
Issue #15340: added support to check InputFormatted files in google-java-format.sh and created InputFormatted file for section 4.3 one statement per line

### DIFF
--- a/.ci/google-java-format.sh
+++ b/.ci/google-java-format.sh
@@ -58,3 +58,10 @@ INPUT_PATHS=($(find src/it/resources/com/google/checkstyle/test/ -name "Input*.j
 for INPUT_PATH in "${INPUT_PATHS[@]}"; do
   java -jar "$JAR_PATH" --replace src/it/resources/com/google/checkstyle/test/"$INPUT_PATH"
 done
+
+INPUT_PATHS_FOR_FORMATTED_INPUTS=($(find src/it/resources/com/google/checkstyle/test/ \
+    -name "InputFormatted*.java" | sed "s|src/it/resources/com/google/checkstyle/test/||"))
+
+for INPUT_PATH in "${INPUT_PATHS_FOR_FORMATTED_INPUTS[@]}"; do
+  java -jar "$JAR_PATH" --replace src/it/resources/com/google/checkstyle/test/"$INPUT_PATH"
+done

--- a/src/it/java/com/google/checkstyle/test/chapter4formatting/rule43onestatement/OneStatementPerLineTest.java
+++ b/src/it/java/com/google/checkstyle/test/chapter4formatting/rule43onestatement/OneStatementPerLineTest.java
@@ -36,6 +36,11 @@ public class OneStatementPerLineTest extends AbstractGoogleModuleTestSupport {
     }
 
     @Test
+    public void testOneStatementFormatted() throws Exception {
+        verifyWithWholeConfig(getPath("InputFormattedOneStatementPerLine.java"));
+    }
+
+    @Test
     public void testOneStatementNonCompilableInput() throws Exception {
         verifyWithWholeConfig(getNonCompilablePath("InputOneStatementPerLine.java"));
     }

--- a/src/it/resources/com/google/checkstyle/test/chapter4formatting/rule43onestatement/InputFormattedOneStatementPerLine.java
+++ b/src/it/resources/com/google/checkstyle/test/chapter4formatting/rule43onestatement/InputFormattedOneStatementPerLine.java
@@ -1,0 +1,220 @@
+package com.google.checkstyle.test.chapter4formatting.rule43onestatement;
+
+// Two import statements on the same line are illegal.
+
+/** Some javadoc. */
+public class InputFormattedOneStatementPerLine {
+
+  /** Dummy variable to work on. */
+  private int one = 0;
+
+  /** Dummy variable to work on. */
+  private int two = 0;
+
+  /** Simple legal method. */
+  public void doLegal() {
+    one = 1;
+    two = 2;
+  }
+
+  /** The illegal format is used within a String. Therefor the whole method is legal. */
+  public void doLegalString() {
+    one = 1;
+    two = 2;
+    System.identityHashCode("one = 1; two = 2");
+  }
+
+  /** Within the for-header there are 3 Statements, but this is legal. */
+  public void doLegalForLoop() {
+    for (int i = 0, j = 0, k = 1; i < 20; i++) { // it's ok.
+      one = i;
+    }
+  }
+
+  /** Simplest form of illegal layouts. */
+  public void doIllegal() {
+    one = 1;
+    two = 2;
+    if (one == 1) {
+      one++;
+      two++;
+    }
+    if (one != 1) {
+      one++;
+    } else {
+      one--;
+    }
+    int n = 10;
+
+    doLegal();
+    doLegal();
+    while (one == 1) {
+      one++;
+      two--;
+    }
+  }
+
+  /**
+   * While theoretically being distributed over two lines, this is a sample of 2 statements on one
+   * line.
+   */
+  public void doIllegal2() {
+    one = 1;
+    two = 2;
+  }
+
+  class Inner {
+    /** Dummy variable to work on. */
+    private int one = 0;
+
+    /** Dummy variable to work on. */
+    private int two = 0;
+
+    /** Simple legal method. */
+    public void doLegal() {
+      one = 1;
+      two = 2;
+    }
+
+    /** Simplest form a an illegal layout. */
+    public void doIllegal() {
+      one = 1;
+      two = 2;
+      if (one == 1) {
+        one++;
+        two++;
+      }
+      if (one != 1) {
+        one++;
+      } else {
+        one--;
+      }
+      int n = 10;
+
+      doLegal();
+      doLegal();
+      while (one == 1) {
+        one++;
+        two--;
+      }
+    }
+  }
+
+  /** Two declaration statements on the same line are illegal. */
+  int aaaa;
+
+  int bbb;
+
+  /** Two declaration statements which are not on the same line are legal. */
+  int ccc;
+
+  int dddd;
+
+  /** Two assignment (declaration) statements on the same line are illegal. */
+  int dog = 1;
+
+  int cow = 2;
+
+  /** Two assignment (declaration) statements on the different lines are legal. */
+  int test1 = 1;
+
+  int test2 = 2;
+
+  /** This method contains two object creation statements on the same line. */
+  private void foo() {
+    // Two object creation statements on the same line are illegal.
+    Object obj1 = new Object();
+    Object obj2 = new Object();
+  }
+
+  int blah;
+
+  int seven = 2;
+
+  /** Two statements on the same line (they both are distributed over two lines) are illegal. */
+  int var6 = 5;
+
+  /** Two statements on the same line (they both are distributed over two lines) are illegal. */
+  private void foo2() {
+    toString();
+    toString();
+  }
+
+  int var11 = 2;
+
+  /** Multiline for loop statement is legal. */
+  private void foo3() {
+    for (int n = 0, k = 1; n < 5; n++, k--) {}
+  }
+
+  /** This method contains break and while loop statements. */
+  private void foo4() {
+    int var9 = 0;
+    int var10 = 0;
+
+    do {
+      var9++;
+      if (var10 > 4) {
+        break; // legal
+      }
+      var11++;
+      var9++;
+    } while (var11 < 7); // legal
+
+    /*
+     * One statement inside for block is legal
+     */
+    for (int i = 0; i < 10; i++) {
+      one = 5;
+    } // legal
+
+    /*
+     * One statement inside for block where
+     * increment expression is empty is legal
+     */
+    for (int i = 0; i < 10; ) {
+      one = 5;
+    } // legal
+
+    /*
+     One statement inside for block where
+     increment and conditional expressions are empty
+     (forever loop) is legal
+    */
+    for (int i = 0; ; ) {
+      one = 5;
+    } // legal
+  }
+
+  /** Some javadoc. */
+  public void foo5() {
+    // a "forever" loop.
+    for (; ; ) {} // legal
+  }
+
+  /** Some javadoc. */
+  public void foo6() {
+    // One statement inside for block is legal
+    for (; ; ) {
+      one = 5;
+    } // legal
+  }
+
+  int var1 = 0;
+  int var2 = 0;
+
+  /** One statement inside multiline for loop is legal. */
+  private void foo7() {
+    for (int n = 0, k = 1; n < 5; n++, k--) {
+      var1++;
+    } // legal
+  }
+
+  /** Two statements on the same lne inside multiline for loop are illegal. */
+  private void foo8() {
+    for (int n = 0, k = 1; n < 5; n++, k--) {
+      var1++;
+      var2++;
+    }
+  }
+}


### PR DESCRIPTION
#15340

Added support to check for `InputFormatted` files in google-java-format.sh, created a list `INPUT_PATHS_FOR_FORMATTED_INPUTS` to store formatted inputs on which we will run the formatter via CI. The formatted inputs should not collide with our google config and should pass the test. If test fails then something is wrong with our config or with formatter.

Created `InputFormatted` file for OneStatementPerLineTest.java

The formatter was not able to convert following type of code:

```java
int var1 = 9, var2 = 99;
```

to 

```java
int var1 = 9;
int var2 = 99;
```

I guess this is a limitation of formatter as it cannot change and create new variables.  So I had to manually change such type of code.

This was the actual code:

https://github.com/checkstyle/checkstyle/blob/d71c8982953412035def51e30b33f26fefff7cba/src/it/resources/com/google/checkstyle/test/chapter4formatting/rule43onestatement/InputOneStatementPerLine.java#L211-L216

I removed the violation comments and formatter formatted it to:

```java
  int var1 = 5, var4 = 5;
  int var2 = 6, var3 = 5;
```

Config was giving violation for it: `Each variable declaration must be in its own statement.`