### PR TITLE
Issue #15340: created InputFormatted file for section 4.8.5.4 Field Annotations

### DIFF
--- a/src/it/java/com/google/checkstyle/test/chapter4formatting/rule4854fieldannotations/FieldAnnotationsTest.java
+++ b/src/it/java/com/google/checkstyle/test/chapter4formatting/rule4854fieldannotations/FieldAnnotationsTest.java
@@ -33,4 +33,9 @@ public class FieldAnnotationsTest extends AbstractGoogleModuleTestSupport {
     public void testAnnotations() throws Exception {
         verifyWithWholeConfig(getPath("InputFieldAnnotations.java"));
     }
+
+    @Test
+    public void testAnnotationsFormatted() throws Exception {
+        verifyWithWholeConfig(getPath("InputFormattedFieldAnnotations.java"));
+    }
 }

--- a/src/it/resources/com/google/checkstyle/test/chapter4formatting/rule4854fieldannotations/InputFormattedFieldAnnotations.java
+++ b/src/it/resources/com/google/checkstyle/test/chapter4formatting/rule4854fieldannotations/InputFormattedFieldAnnotations.java
@@ -1,0 +1,48 @@
+package com.google.checkstyle.test.chapter4formatting.rule4854fieldannotations;
+
+/** Some javadoc. */
+public class InputFormattedFieldAnnotations {
+  /** Some javadoc. */
+  public @interface SomeAnnotation1 {}
+
+  /** Some javadoc. */
+  public @interface SomeAnnotation2 {}
+
+  /** Some javadoc. */
+  public @interface SomeAnnotation3 {
+    /** Some javadoc. */
+    int x();
+  }
+
+  /** testing. */
+  @SomeAnnotation1 @SomeAnnotation2 String name = "Zops";
+
+  /** testing. */
+  @SomeAnnotation1 @SomeAnnotation2 int age = 19;
+
+  /** testing. */
+  @SomeAnnotation1 @SomeAnnotation2 String favLanguage = "Java";
+
+  /** testing. */
+  @SomeAnnotation1
+  @SomeAnnotation3(x = 90)
+  String favPet = "Dog";
+
+  @SomeAnnotation1 @SomeAnnotation2 boolean test = false;
+
+  @SuppressWarnings("bla")
+  @SomeAnnotation3(x = 0)
+  float pi = 3.14f;
+
+  /** testing. */
+  @SomeAnnotation1
+  @SomeAnnotation2
+  void test1() {}
+
+  @SomeAnnotation1
+  @SomeAnnotation2
+  void test2() {}
+
+  @SomeAnnotation3(x = 78)
+  void test3() {}
+}


### PR DESCRIPTION
#15340 

Had to exclude following cases from the new input file:

```java
  @SomeAnnotation1
  @SomeAnnotation3(x = 14)
  /** testing. */
  List<String> list = new ArrayList<>();

  @SuppressWarnings("bla")
  @SomeAnnotation1
  /** testing. */
  InputFormattedFieldAnnotations obj = new InputFormattedFieldAnnotations();
```

Formatter wasn't able to correct javadoc position so our config was complaining for it