### PR TITLE
Issue #15340: created InputFormatted file for section 4.8.5.3 Methods And Constructors Annotations

### DIFF
--- a/src/it/java/com/google/checkstyle/test/chapter4formatting/rule4853methodsandconstructorsannotations/MethodsAndConstructorsAnnotationsTest.java
+++ b/src/it/java/com/google/checkstyle/test/chapter4formatting/rule4853methodsandconstructorsannotations/MethodsAndConstructorsAnnotationsTest.java
@@ -35,4 +35,9 @@ public class MethodsAndConstructorsAnnotationsTest extends AbstractGoogleModuleT
     public void testAnnotation() throws Exception {
         verifyWithWholeConfig(getPath("InputMethodsAndConstructorsAnnotations.java"));
     }
+
+    @Test
+    public void testAnnotationFormatted() throws Exception {
+        verifyWithWholeConfig(getPath("InputFormattedMethodsAndConstructorsAnnotations.java"));
+    }
 }

--- a/src/it/resources/com/google/checkstyle/test/chapter4formatting/rule4853methodsandconstructorsannotations/InputFormattedMethodsAndConstructorsAnnotations.java
+++ b/src/it/resources/com/google/checkstyle/test/chapter4formatting/rule4853methodsandconstructorsannotations/InputFormattedMethodsAndConstructorsAnnotations.java
@@ -1,0 +1,56 @@
+package com.google.checkstyle.test.chapter4formatting.rule4853methodsandconstructorsannotations;
+
+/** Some javadoc. */
+public class InputFormattedMethodsAndConstructorsAnnotations {
+  /** Some javadoc. */
+  public @interface SomeAnnotation1 {}
+
+  /** Some javadoc. */
+  public @interface SomeAnnotation2 {}
+
+  // ********testing methods.***********
+
+  /** testing. */
+  @SomeAnnotation1
+  @SomeAnnotation2
+  void test1() {}
+
+  /** testing. */
+  @SomeAnnotation1
+  void test2() {}
+
+  /** testing. */
+  @SomeAnnotation1
+  @SomeAnnotation2
+  void test3() {}
+
+  @SomeAnnotation1
+  @SomeAnnotation2
+  void test6() {}
+
+  @SuppressWarnings("blah")
+  void test7() {}
+
+  // ********testing constructors.*********
+
+  /** testing. */
+  @SomeAnnotation1
+  @SomeAnnotation2
+  InputFormattedMethodsAndConstructorsAnnotations() {}
+
+  /** testing. */
+  @SomeAnnotation1
+  InputFormattedMethodsAndConstructorsAnnotations(float f) {}
+
+  /** testing. */
+  @SomeAnnotation1
+  @SomeAnnotation2
+  InputFormattedMethodsAndConstructorsAnnotations(int x) {}
+
+  @SomeAnnotation1
+  @SomeAnnotation2
+  InputFormattedMethodsAndConstructorsAnnotations(String a, String b) {}
+
+  @SuppressWarnings("blah")
+  InputFormattedMethodsAndConstructorsAnnotations(int x, int y) {}
+}


### PR DESCRIPTION
#15340 

Had to exclude following cases from the new input file:

```java

  @SomeAnnotation1
  @SomeAnnotation2
  /** testing. */
  void test4() {}

  @SomeAnnotation1
  @SomeAnnotation2
  /** testing. */
  InputFormattedMethodsAndConstructorsAnnotations(double d) {}
```

Formatter wasn't able to correct javadoc position so our config was complaining for it