### PR TITLE
Issue #15340: Created InputFormatted file for section 4.8.5.2 Class Annotations

### DIFF
--- a/src/it/java/com/google/checkstyle/test/chapter4formatting/rule4852classannotations/ClassAnnotationsTest.java
+++ b/src/it/java/com/google/checkstyle/test/chapter4formatting/rule4852classannotations/ClassAnnotationsTest.java
@@ -35,4 +35,10 @@ public class ClassAnnotationsTest extends AbstractGoogleModuleTestSupport {
         final String filePath = getPath("InputClassAnnotations.java");
         verifyWithWholeConfig(filePath);
     }
+
+    @Test
+    public void testAnnotationFormatted() throws Exception {
+        final String filePath = getPath("InputFormattedClassAnnotations.java");
+        verifyWithWholeConfig(filePath);
+    }
 }

--- a/src/it/resources/com/google/checkstyle/test/chapter4formatting/rule4852classannotations/InputFormattedClassAnnotations.java
+++ b/src/it/resources/com/google/checkstyle/test/chapter4formatting/rule4852classannotations/InputFormattedClassAnnotations.java
@@ -1,0 +1,20 @@
+package com.google.checkstyle.test.chapter4formatting.rule4852classannotations;
+
+/** Test class for checking the rule 4852. */
+public class InputFormattedClassAnnotations {
+  /** Custom annotation 1. */
+  public @interface SomeAnnotation1 {}
+
+  /** Custom annotation 2. */
+  public @interface SomeAnnotation2 {}
+
+  /** Inner class 2. */
+  @SomeAnnotation1
+  @SomeAnnotation2
+  class Inner1 {}
+
+  /** Inner class 3. */
+  @SomeAnnotation1
+  @SomeAnnotation2
+  class Inner3 {}
+}


### PR DESCRIPTION
#15340 

Had to exclude following cases from the new input file:

```java
  @SomeAnnotation1
  @SomeAnnotation2
  /** Inner class 2. */
  class Inner2 {}
```

Formatter wasn't able to correct javadoc position so our config was complaining for it