### PR TITLE
Issue #15429: Added SuppressionXpathSingleFilter suppression ignore Test Methods for section 5.2.3 Method Names

### DIFF
--- a/src/it/resources/com/google/checkstyle/test/chapter4formatting/rule4822declaredwhenneeded/InputDeclaredWhenNeeded.java
+++ b/src/it/resources/com/google/checkstyle/test/chapter4formatting/rule4822declaredwhenneeded/InputDeclaredWhenNeeded.java
@@ -430,7 +430,7 @@ public class InputDeclaredWhenNeeded {
   }
 
   /** Some javadoc. */
-  public void testIssue32_1() {
+  public void testIssue321() {
     Option srcDdlFile = OptionBuilder.create("f");
     Option logDdlFile = OptionBuilder.create("o");
     Option help = OptionBuilder.create("h");
@@ -444,7 +444,7 @@ public class InputDeclaredWhenNeeded {
   }
 
   /** Some javadoc. */
-  public void testIssue32_2() {
+  public void testIssue322() {
     int mm = Integer.parseInt("2");
     long timeNow = 0;
     Calendar cal = Calendar.getInstance(TimeZone.getDefault(), Locale.getDefault());
@@ -456,7 +456,7 @@ public class InputDeclaredWhenNeeded {
   }
 
   /** Some javadoc. */
-  public void testIssue32_3(MyObject[] objects) {
+  public void testIssue323(MyObject[] objects) {
     Calendar cal = Calendar.getInstance(TimeZone.getDefault(), Locale.getDefault());
     for (int i = 0; i < objects.length; i++) {
       objects[i].setEnabled(true);
@@ -468,7 +468,7 @@ public class InputDeclaredWhenNeeded {
   }
 
   /** Some javadoc. */
-  public String testIssue32_4(boolean flag) {
+  public String testIssue324(boolean flag) {
     StringBuilder builder = new StringBuilder();
     builder.append("flag is ");
     builder.append(flag);
@@ -483,7 +483,7 @@ public class InputDeclaredWhenNeeded {
   }
 
   /** Some javadoc. */
-  public void testIssue32_5() {
+  public void testIssue325() {
     Option a = null;
     Option b = null;
     Option c = null;
@@ -493,7 +493,7 @@ public class InputDeclaredWhenNeeded {
   }
 
   /** Some javadoc. */
-  public void testIssue32_6() {
+  public void testIssue326() {
     Option aopt = null;
     Option bopt = null;
     Option copt = null;
@@ -503,7 +503,7 @@ public class InputDeclaredWhenNeeded {
   }
 
   /** Some javadoc. */
-  public void testIssue32_7() {
+  public void testIssue327() {
     String line = "abc";
     OtherWriter.write(line);
     line.charAt(1);
@@ -512,14 +512,14 @@ public class InputDeclaredWhenNeeded {
   }
 
   /** Some javadoc. */
-  public void testIssue32_8(Writer w1, Writer w2, Writer w3) {
+  public void testIssue328(Writer w1, Writer w2, Writer w3) {
     String l1 = "1";
 
     w3.write(l1); // distance=3
   }
 
   /** Some javadoc. */
-  public void testIssue32_9() {
+  public void testIssue329() {
     Options options = new Options();
     Option myOption = null;
     // violation above 'Distance between variable 'myOption' .* usage is 7, but allowed 3.'
@@ -533,7 +533,7 @@ public class InputDeclaredWhenNeeded {
   }
 
   /** Some javadoc. */
-  public void testIssue32_10() {
+  public void testIssue3210() {
     Options options = new Options();
     Option myOption = null;
     // violation above 'Distance between variable 'myOption' .* usage is 6, but allowed 3.'
@@ -546,7 +546,7 @@ public class InputDeclaredWhenNeeded {
   }
 
   /** Some javadoc. */
-  public int testIssue32_11(String toDir) throws Exception {
+  public int testIssue3211(String toDir) throws Exception {
     int count = 0;
     // violation above 'Distance between variable 'count' .* first usage is 4, but allowed 3.'
     String[] files = {};

--- a/src/it/resources/com/google/checkstyle/test/chapter5naming/rule523methodnames/InputMethodName.java
+++ b/src/it/resources/com/google/checkstyle/test/chapter5naming/rule523methodnames/InputMethodName.java
@@ -43,6 +43,17 @@ public class InputMethodName {
   void testing_0123() {}
 
   @Test
+  void Testing_Foo() {} // violation 'Method name 'Testing_Foo' must match pattern'
+
+  @Test
+  void t_esting() {} // violation 'Method name 't_esting' must match pattern'
+
+  @Test
+  void _testing() {} // violation 'Method name '_testing' must match pattern'
+
+  void Testing_Foo2() {} // violation 'Method name 'Testing_Foo2' must match pattern'
+
+  @Test
   void TestingFooBad() {} // violation 'Method name 'TestingFooBad' must match pattern'
 
   class InnerFoo {
@@ -62,17 +73,17 @@ public class InputMethodName {
 
     void fO() {} // violation 'Method name 'fO' must match pattern'
 
-    void testing_foo() {}
+    void testing_foo() {} // violation 'Method name 'testing_foo' must match pattern'
 
-    void testing_Foo() {}
+    void testing_Foo() {} // violation 'Method name 'testing_Foo' must match pattern'
 
-    void testing_fOo() {}
+    void testing_fOo() {} // violation 'Method name 'testing_fOo' must match pattern'
 
     void testingFoo() {}
 
-    void testingFoo_foo() {}
+    void testingFoo_foo() {} // violation 'Method name 'testingFoo_foo' must match pattern'
 
-    void testing_0123() {}
+    void testing_0123() {} // violation 'Method name 'testing_0123' must match pattern'
 
     void TestingFooBad() {} // violation 'Method name 'TestingFooBad' must match pattern'
   }

--- a/src/main/resources/google_checks.xml
+++ b/src/main/resources/google_checks.xml
@@ -105,6 +105,12 @@
       <property name="query" value="//RCURLY[parent::SLIST[count(./*)=1]
                                      or preceding-sibling::*[last()][self::LCURLY]]"/>
     </module>
+    <module name="SuppressionXpathSingleFilter">
+      <property name="checks" value="MethodName"/>
+      <property name="query" value="//METHOD_DEF[
+                                     .//ANNOTATION/IDENT[@text='Test']]//*"/>
+      <property name="message" value="'[a-z][a-z0-9][_a-zA-Z0-9]*'.*"/>
+    </module>
     <module name="WhitespaceAfter">
       <property name="tokens"
                value="COMMA, SEMI, TYPECAST, LITERAL_IF, LITERAL_ELSE, LITERAL_RETURN,
@@ -351,7 +357,7 @@
       <property name="excludeScope" value="nothing"/>
     </module>
     <module name="MethodName">
-      <property name="format" value="^[a-z][a-z0-9]\w*$"/>
+      <property name="format" value="^[a-z][a-z0-9][a-zA-Z0-9]*$"/>
       <message key="name.invalidPattern"
              value="Method name ''{0}'' must match pattern ''{1}''."/>
     </module>


### PR DESCRIPTION
#15429 


Added [SuppressionXpathSingleFilter](https://checkstyle.sourceforge.io/filters/suppressionxpathsinglefilter.html) suppression in google_checks.xml and updated regex at MethodName module to allow test methods to have `_` in their name for section [5.2.3 Method Names](https://checkstyle-diff-reports.s3.us-east-2.amazonaws.com/bcdd4d1_2024123825/google_style.html#a5.2.3), for other methods, module will give violation if `_` is used in method name