### PR TITLE
Issue #15340: created InputFormatted file for section 4.4 Column Limit: 100

### DIFF
--- a/src/it/java/com/google/checkstyle/test/chapter4formatting/rule44columnlimit/ColumnLimit100Test.java
+++ b/src/it/java/com/google/checkstyle/test/chapter4formatting/rule44columnlimit/ColumnLimit100Test.java
@@ -35,4 +35,9 @@ public class ColumnLimit100Test extends AbstractGoogleModuleTestSupport {
         verifyWithWholeConfig(getPath("InputColumnLimit.java"));
     }
 
+    @Test
+    public void testLineLengthFormatted() throws Exception {
+        verifyWithWholeConfig(getPath("InputFormattedColumnLimit.java"));
+    }
+
 }

--- a/src/it/resources/com/google/checkstyle/test/chapter4formatting/rule44columnlimit/InputFormattedColumnLimit.java
+++ b/src/it/resources/com/google/checkstyle/test/chapter4formatting/rule44columnlimit/InputFormattedColumnLimit.java
@@ -1,0 +1,43 @@
+package com.google.checkstyle.test.chapter4formatting.rule44columnlimit; // ok
+
+final class InputFormattedColumnLimit {
+
+  private int[] testing =
+      new int[] {
+        1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25,
+        26, 27
+      };
+
+  /**
+   * Some javadoc.
+   *
+   * @param badFormat1 bad format
+   * @param badFormat2 bad format
+   * @param badFormat3 bad format
+   * @return hack
+   * @throws Exception abc
+   */
+  int test1(int badFormat1, int badFormat2, final int badFormat3) throws Exception {
+    return 0;
+  }
+
+  /**
+   * Some javadoc. Very long url with https:
+   * https://github.com/checkstyle/checkstyle/blob/master/src/main/java/com/puppycrawl/tools/checkstyle/checks/AvoidEscapedUnicodeCharactersCheck.java
+   */
+  String https = "200 OK";
+
+  /**
+   * Some javadoc. Very long url with http:
+   * http://github.com/checkstyle/checkstyle/blob/master/src/main/java/com/puppycrawl/tools/checkstyle/checks/AvoidEscapedUnicodeCharactersCheck.java
+   */
+  String http = "200 OK";
+
+  // Very long url with ftp:
+  // ftp://ftp.example.com/areallyyyyyyyyyyyylongggggggggggggggggggggggurlllll.text
+  int ftp = 0;
+
+  // Very long url with valid href:
+  // href="www.google.com/search?hl=en&q=java+style+guide+checkstyle+check+href+length+limit&btnG=Google+Search"
+  int validHref = 54;
+}


### PR DESCRIPTION
#15340 

[4.4 Column limit: 100](https://checkstyle.org/styleguides/google-java-style-20180523/javaguide.html#s4.4-column-limit)

Had to exclude some examples because they were unwrap-able

```java
  // Long line
  // ----------------------------------------------------------------------------------------------------
```

```java

  // Very long url with valid href: href    =
  // "www.google.com/search?hl=en&q=java+style+guide+checkstyle+check+href+length+limit&btnG=Google+Search"
  int validHrefWithWhiteSpaces = 54;


  // Very long url with invalid href:
  // href="www.google.com/search?hl=en&q=java+style+guide+checkstyle+check+href+length+limit&btnG=Google+Search
  int invalidHref = 88;
```