### PR TITLE
Issue #15340: created InputFormatted file for section 2.3.1 whitespace characters

### DIFF
--- a/config/checkstyle-resources-suppressions.xml
+++ b/config/checkstyle-resources-suppressions.xml
@@ -135,7 +135,7 @@
   <suppress checks="FileTabCharacter"
     files="src[\\/]test[\\/]resources[\\/]com[\\/]puppycrawl[\\/]tools[\\/]checkstyle[\\/]filters[\\/]suppresswithplaintextcommentfilter[\\/]Input.*"/>
   <suppress checks="FileTabCharacter"
-    files="[\\/]it[\\/]resources[\\/]com[\\/]google[\\/]checkstyle[\\/]test[\\/]chapter2filebasic[\\/]rule231filetab[\\/]InputWhitespaceCharacters\.java"/>
+    files="[\\/]it[\\/]resources[\\/]com[\\/]google[\\/]checkstyle[\\/]test[\\/]chapter2filebasic[\\/]rule231filetab[\\/]Input.*\.java"/>
   <suppress checks="FileTabCharacter"
     files="[\\/]InputRegressionJavaClass1\.java"/>
   <suppress checks="FileTabCharacter"

--- a/src/it/java/com/google/checkstyle/test/chapter2filebasic/rule231filetab/WhitespaceCharactersTest.java
+++ b/src/it/java/com/google/checkstyle/test/chapter2filebasic/rule231filetab/WhitespaceCharactersTest.java
@@ -35,4 +35,9 @@ public class WhitespaceCharactersTest extends AbstractGoogleModuleTestSupport {
         verifyWithWholeConfig(getPath("InputWhitespaceCharacters.java"));
     }
 
+    @Test
+    public void testFileTabFormatted() throws Exception {
+        verifyWithWholeConfig(getPath("InputFormattedWhitespaceCharacters.java"));
+    }
+
 }

--- a/src/it/resources/com/google/checkstyle/test/chapter2filebasic/rule231filetab/InputFormattedWhitespaceCharacters.java
+++ b/src/it/resources/com/google/checkstyle/test/chapter2filebasic/rule231filetab/InputFormattedWhitespaceCharacters.java
@@ -1,0 +1,39 @@
+package com.google.checkstyle.test.chapter2filebasic.rule231filetab;
+
+final class InputFormattedWhitespaceCharacters {
+  // Long line ----------------------------------------------------------------
+  // Contains a tab ->	<- // violation 'Line contains a tab character.'
+  // Contains trailing whitespace ->
+
+  /**
+   * Some javadoc.
+   *
+   * @param badFormat1 bad format
+   * @param badFormat2 bad format
+   * @param badFormat3 bad format
+   * @return hack
+   * @throws Exception abc
+   */
+  int test1(int badFormat1, int badFormat2, final int badFormat3) throws Exception {
+    return 0;
+  }
+
+  // A very, very long line that is OK because it matches the regexp "^.*is OK.*regexp.*$"
+  // long line that has a tab ->	<- and would be OK if tab counted as 1 char
+  // violation above 'Line contains a tab character.'
+
+  // tabs that count as one char because of their position ->	<-   ->	<-
+  // violation above 'Line contains a tab character.'
+
+  /** some lines to test the column after tabs. */
+  void violateColumnAfterTabs() {
+    // with tab-width 8 all statements below start at the same column,
+    // with different combinations of ' ' and '\t' before the statement
+    int tab0 = 1;
+    int tab1 = 1;
+    int tab2 = 1;
+    int tab3 = 1;
+    int tab4 = 1;
+    int tab5 = 1;
+  }
+}


### PR DESCRIPTION
#15340


original input file: [InputWhitespaceCharacters.java](https://github.com/checkstyle/checkstyle/blob/master/src/it/resources/com/google/checkstyle/test/chapter2filebasic/rule231filetab/InputWhitespaceCharacters.java) contained violations only about tabs usage. Formatter just removed the tabs and used spaces instead though it wasn't able to remove tabs from certain places so had to add violation comments for it