### PR TITLE
Issue #15340: validation that all excluded from formatting google Input files have InputFormatted

### DIFF
--- a/.ci/google-java-format.sh
+++ b/.ci/google-java-format.sh
@@ -4,6 +4,22 @@ set -e
 
 JAR_PATH="$1"
 
+echo "Checking that all excluded java files in this script have matching InputFormatted* file:"
+NOT_FOUND_CONTENT=$(grep -e '^  .*/Input' "${BASH_SOURCE}" \
+  | sed -E 's/.*Input([^\.]+)\..*java.*/\1/' \
+  | while read -r name; do \
+    [[ $(find ./src -type f -name "InputFormatted${name}.java") ]] \
+    || echo "Create InputFormatted${name}.java for Input${name}.java";\
+  done)
+
+if [[ $(echo -n "$NOT_FOUND_CONTENT" | wc --chars) -eq 0 ]]; then
+  echo "Excluded Input files matches to InputFormatted files."
+else
+  echo "not fount matches: $NOT_FOUND_CONTENT"
+  exit 1
+fi
+
+echo "Formatting all Input files file at src/it/resources/com/google/checkstyle/test :"
 INPUT_PATHS=($(find src/it/resources/com/google/checkstyle/test/ -name "Input*.java" \
     | sed "s|src/it/resources/com/google/checkstyle/test/||" \
     | grep -v "rule711generalform/InputSingleLineJavadocAndInvalidJavadocPosition.java" \


### PR DESCRIPTION
Closes #15340

output:
```
✘-1 ~/java/github/romani/checkstyle [i15449-sync-Inputs L|✚ 1⚑ 2] 
$ ./.ci/google-java-format.sh .ci-temp/google-java-format-1.23.0-all-deps.jar
Checking that all excluded java files in this script have matching InputFormatted* file:
Create InputFormattedSingleLineJavadocAndInvalidJavadocPosition.java for InputSingleLineJavadocAndInvalidJavadocPosition.java
Create InputFormattedInvalidJavadocPosition.java for InputInvalidJavadocPosition.java
Create InputFormattedCamelCaseDefined.java for InputCamelCaseDefined.java
Create InputFormattedClassNames.java for InputClassNames.java
Create InputFormattedUseOfOptionalBraces.java for InputUseOfOptionalBraces.java
Create InputFormattedEmptyBlocksAndCatchBlocks.java for InputEmptyBlocksAndCatchBlocks.java
Create InputFormattedEmptyFinallyBlocks.java for InputEmptyFinallyBlocks.java
Create InputFormattedOneVariablePerDeclaration.java for InputOneVariablePerDeclaration.java
Create InputFormattedDeclaredWhenNeeded.java for InputDeclaredWhenNeeded.java
Create InputFormattedFallThrough.java for InputFallThrough.java
Create InputFormattedAnnotationLocation.java for InputAnnotationLocation.java
Create InputFormattedAnnotationLocationVariables.java for InputAnnotationLocationVariables.java
Create InputFormattedCommentsIndentation.java for InputCommentsIndentation.java
Create InputFormattedNoWildcardImports.java for InputNoWildcardImports.java
Create InputFormattedOrderingAndSpacing1.java for InputOrderingAndSpacing1.java
Create InputFormattedOrderingAndSpacing2.java for InputOrderingAndSpacing2.java
Create InputFormattedOrderingAndSpacing3.java for InputOrderingAndSpacing3.java
Create InputFormattedOrderingAndSpacing4.java for InputOrderingAndSpacing4.java
Create InputFormattedOrderingAndSpacing5.java for InputOrderingAndSpacing5.java
Create InputFormattedOrderingAndSpacingValid.java for InputOrderingAndSpacingValid.java
Create InputFormattedOrderingAndSpacingValid2.java for InputOrderingAndSpacingValid2.java
✘-1
```

CI will fail, we should merge it after all InputFormatted are created.