### PR TITLE
Issue #15556: updated MethodName module in google_checks.xml to ignore methods with Test annotations

### DIFF
--- a/src/it/resources/com/google/checkstyle/test/chapter5naming/rule523methodnames/InputMethodName.java
+++ b/src/it/resources/com/google/checkstyle/test/chapter5naming/rule523methodnames/InputMethodName.java
@@ -1,6 +1,10 @@
 package com.google.checkstyle.test.chapter5naming.rule523methodnames;
 
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.RepeatedTest;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.runners.Parameterized;
 
 /**
  * Test input for MethodNameCheck specifically whether the method name equals the class name.
@@ -55,6 +59,69 @@ public class InputMethodName {
 
   @Test
   void TestingFooBad() {} // violation 'Method name 'TestingFooBad' must match pattern'
+
+  @ParameterizedTest
+  void testing_foo1() {}
+
+  @ParameterizedTest
+  void testing_Foo1() {}
+
+  @ParameterizedTest
+  void testing_fOo1() {}
+
+  @ParameterizedTest
+  void testingFoo1() {}
+
+  @ParameterizedTest
+  void testingFoo_foo1() {}
+
+  @ParameterizedTest
+  void testing_01231() {}
+
+  @ParameterizedTest
+  void Testing_Foo1() {} // violation 'Method name 'Testing_Foo1' must match pattern'
+
+  @ParameterizedTest
+  void t_esting1() {} // violation 'Method name 't_esting1' must match pattern'
+
+  @ParameterizedTest
+  void _testing1() {} // violation 'Method name '_testing1' must match pattern'
+
+  @ParameterizedTest
+  void TestingFooBad1() {} // violation 'Method name 'TestingFooBad1' must match pattern'
+
+  @RepeatedTest(0)
+  void testing_foo2() {}
+
+  @RepeatedTest(0)
+  void testing_Foo2() {}
+
+  @RepeatedTest(0)
+  void testing_fOo2() {}
+
+  @RepeatedTest(0)
+  void testingFoo2() {}
+
+  @RepeatedTest(0)
+  void testingFoo_foo2() {}
+
+  @RepeatedTest(0)
+  void testing_01232() {}
+
+  @RepeatedTest(0)
+  void Testing_Foo3() {} // violation 'Method name 'Testing_Foo3' must match pattern'
+
+  @RepeatedTest(0)
+  void t_esting2() {} // violation 'Method name 't_esting2' must match pattern'
+
+  @RepeatedTest(0)
+  void _testing2() {} // violation 'Method name '_testing2' must match pattern'
+
+  @RepeatedTest(0)
+  void TestingFooBad2() {} // violation 'Method name 'TestingFooBad2' must match pattern'
+
+  @BeforeAll
+  void _testingFoooo() {} // violation 'Method name '_testingFoooo' must match pattern'
 
   class InnerFoo {
     void foo() {}

--- a/src/main/resources/google_checks.xml
+++ b/src/main/resources/google_checks.xml
@@ -358,7 +358,7 @@
     <module name="SuppressionXpathSingleFilter">
       <property name="checks" value="MethodName"/>
       <property name="query" value="//METHOD_DEF[
-                                     .//ANNOTATION/IDENT[@text='Test']]//*"/>
+                                     .//ANNOTATION/IDENT[contains(@text, 'Test')]]//*"/>
       <property name="message" value="'[a-z][a-z0-9][_a-zA-Z0-9]*'.*"/>
     </module>
     <module name="SingleLineJavadoc"/>


### PR DESCRIPTION
#15556 

Now MethodName module is able to ignore methods with annotations that contains `Test` word.