### PR TITLE
minor: Update spotbugs-exclude.xml to remove exclude for fixed issue

### DIFF
--- a/config/spotbugs-exclude.xml
+++ b/config/spotbugs-exclude.xml
@@ -236,11 +236,6 @@
     <Bug pattern="EI_EXPOSE_REP,EI_EXPOSE_REP2"/>
   </Match>
   <Match>
-    <!-- Till https://github.com/spotbugs/spotbugs/issues/1867 -->
-    <Class name="com.puppycrawl.tools.checkstyle.gui.ListToTreeSelectionModelWrapper"/>
-    <Bug pattern="MC_OVERRIDABLE_METHOD_CALL_IN_CONSTRUCTOR"/>
-  </Match>
-  <Match>
     <!-- Checks and filters are treated differently. -->
     <Or>
       <Class name="com.puppycrawl.tools.checkstyle.Checker"/>


### PR DESCRIPTION
Detected at https://github.com/checkstyle/checkstyle/actions/runs/10604777512/job/29392154381?pr=15570#step:6:308

https://github.com/checkstyle/checkstyle/blob/5d8229566b6bae89a7e97b7404fa45efbffcc54b/config/spotbugs-exclude.xml#L239

```
<Match>
    <!-- Till https://github.com/spotbugs/spotbugs/issues/1867 -->
    <Class name="com.puppycrawl.tools.checkstyle.gui.ListToTreeSelectionModelWrapper"/>
    <Bug pattern="MC_OVERRIDABLE_METHOD_CALL_IN_CONSTRUCTOR"/>
  </Match>
```