### PR TITLE
Issue #15414: updated MissingJavadocMethod in google_checks.xml to allow missing javadoc for getters/setters

### DIFF
--- a/src/it/resources-noncompilable/com/google/checkstyle/test/chapter3filestructure/rule3421overloadsplit/InputOverloadsNeverSplitRecords.java
+++ b/src/it/resources-noncompilable/com/google/checkstyle/test/chapter3filestructure/rule3421overloadsplit/InputOverloadsNeverSplitRecords.java
@@ -6,6 +6,7 @@ package com.puppycrawl.tools.checkstyle.checks.coding.constructorsdeclarationgro
 public class InputOverloadsNeverSplitRecords {
   /** Some javadoc. */
   public record MyRecord1(int x, int y) {
+    /** Some javadoc. */
     public MyRecord1(int a) {
       this(a, a);
     }
@@ -14,13 +15,16 @@ public class InputOverloadsNeverSplitRecords {
 
     void foo2() {}
 
+    /** Some javadoc. */
     public MyRecord1 {} // violation 'Constructors should be grouped together.*'
 
+    /** Some javadoc. */
     public MyRecord1(int a, int b, int c, int d) {
       // violation above 'Constructors should be grouped together.*'
       this(a + b, c + d);
     }
 
+    /** Some javadoc. */
     public MyRecord1(int x, int y, int z) {
       // violation above 'Constructors should be grouped together.*'
       this(x + y, z);
@@ -43,12 +47,15 @@ public class InputOverloadsNeverSplitRecords {
 
   /** Some javadoc. */
   public record MyRecord2(double d) {
+    /** Some javadoc. */
     public MyRecord2(double a, double b, double c) {
       this(a + b + c);
     }
 
+    /** Some javadoc. */
     public MyRecord2 {}
 
+    /** Some javadoc. */
     public MyRecord2(double a, double b) {
       this(a + b);
     }
@@ -56,6 +63,7 @@ public class InputOverloadsNeverSplitRecords {
 
   /** Some javadoc. */
   public record MyRecord3(float f) {
+    /** Some javadoc. */
     public MyRecord3(float a, float b, float c) {
       this(a + b + c);
     }
@@ -63,6 +71,7 @@ public class InputOverloadsNeverSplitRecords {
 
   /** Some javadoc. */
   public record MyRecord4(String str) {
+    /** Some javadoc. */
     public MyRecord4 {}
   }
 
@@ -78,21 +87,26 @@ public class InputOverloadsNeverSplitRecords {
   /** Some javadoc. */
   public record MyRecord6(String str, int x) {}
 
+  /** Some javadoc. */
   public void overloadMethod(int i) {
     // some foo code
   }
 
+  /** Some javadoc. */
   public void overloadMethod(String s) {
     // some foo code
   }
 
+  /** Some javadoc. */
   public void overloadMethod(boolean b) {
     // some foo code
   }
 
+  /** Some javadoc. */
   public void fooMethod() {}
 
-  // violation below 'All overloaded methods should be placed next to each other. .* '89'
+  // violation 2 lines below 'All overloaded methods should be placed next to each other. .* '101'
+  /** Some javadoc. */
   public void overloadMethod(String s, Boolean b, int i) {
     // some foo code
   }

--- a/src/it/resources-noncompilable/com/google/checkstyle/test/chapter5naming/rule528typevariablenames/InputRecordTypeParameterName.java
+++ b/src/it/resources-noncompilable/com/google/checkstyle/test/chapter5naming/rule528typevariablenames/InputRecordTypeParameterName.java
@@ -9,6 +9,7 @@ import org.w3c.dom.Node;
 /** some javadoc. Config: pattern = "(^[A-Z][0-9]?)$|([A-Z][a-zA-Z0-9]*[T]$)" */
 public record InputRecordTypeParameterName<t>(Integer x, String str) {
   // violation above 'Record type name 't' must match pattern'
+  /** some javadoc. */
   public <TT> void foo() {}
 
   <T> void foo(int i) {}

--- a/src/it/resources/com/google/checkstyle/test/chapter2filebasic/rule21filename/InputFileName2.java
+++ b/src/it/resources/com/google/checkstyle/test/chapter2filebasic/rule21filename/InputFileName2.java
@@ -13,8 +13,10 @@ public class InputFileName2 { // ok
     }
   }
 
+  /** Some javadoc. */
   public native void nativeMethod();
 
+  /** Some javadoc. */
   public void methodWithLiterals() {
     final String ref = "<a href=\"";
     final String refCase = "<A hReF=\"";

--- a/src/it/resources/com/google/checkstyle/test/chapter2filebasic/rule232specialescape/InputSpecialEscapeSequences.java
+++ b/src/it/resources/com/google/checkstyle/test/chapter2filebasic/rule232specialescape/InputSpecialEscapeSequences.java
@@ -3,6 +3,7 @@ package com.google.checkstyle.test.chapter2filebasic.rule232specialescape;
 /** Test for illegal tokens. */
 public class InputSpecialEscapeSequences {
 
+  /** some javadoc. */
   public void methodWithLiterals() {
     final String ref = "<a href=\"";
     final String refCase = "<A hReF=\"";

--- a/src/it/resources/com/google/checkstyle/test/chapter3filestructure/rule332nolinewrap/InputFormattedNoLineWrapping.java
+++ b/src/it/resources/com/google/checkstyle/test/chapter3filestructure/rule332nolinewrap/InputFormattedNoLineWrapping.java
@@ -6,6 +6,7 @@ import com.google.checkstyle.test.chapter3filestructure.toolongpackagetotestcove
 /** Some javadoc. */
 public class InputFormattedNoLineWrapping {
 
+  /** Some javadoc. */
   public void fooMethod() {
     //
   }

--- a/src/it/resources/com/google/checkstyle/test/chapter3filestructure/rule332nolinewrap/InputNoLineWrapping.java
+++ b/src/it/resources/com/google/checkstyle/test/chapter3filestructure/rule332nolinewrap/InputNoLineWrapping.java
@@ -17,6 +17,7 @@ import javax.accessibility. // violation 'import statement should not be line-wr
 /** Some javadoc. */
 public class InputNoLineWrapping {
 
+  /** Some javadoc. */
   public void fooMethod() {
     //
   }

--- a/src/it/resources/com/google/checkstyle/test/chapter3filestructure/rule341onetoplevel/InputOneTopLevelClassBasic.java
+++ b/src/it/resources/com/google/checkstyle/test/chapter3filestructure/rule341onetoplevel/InputOneTopLevelClassBasic.java
@@ -2,15 +2,18 @@ package com.google.checkstyle.test.chapter3filestructure.rule341onetoplevel;
 
 /** Some javadoc. */
 public class InputOneTopLevelClassBasic {
+  /** Some javadoc. */
   public InputOneTopLevelClassBasic() throws CloneNotSupportedException {
     super.equals(new String());
     super.clone();
   }
 
+  /** Some javadoc. */
   public Object clone() throws CloneNotSupportedException {
     return super.clone();
   }
 
+  /** Some javadoc. */
   public void method() throws CloneNotSupportedException {
     super.clone();
   }

--- a/src/it/resources/com/google/checkstyle/test/chapter3filestructure/rule341onetoplevel/InputOneTopLevelClassGood.java
+++ b/src/it/resources/com/google/checkstyle/test/chapter3filestructure/rule341onetoplevel/InputOneTopLevelClassGood.java
@@ -2,15 +2,18 @@ package com.google.checkstyle.test.chapter3filestructure.rule341onetoplevel;
 
 /** Some javadoc. */
 public class InputOneTopLevelClassGood { // ok
+  /** Some javadoc. */
   public InputOneTopLevelClassGood() throws CloneNotSupportedException {
     super.equals(new String());
     super.clone();
   }
 
+  /** Some javadoc. */
   public Object clone() throws CloneNotSupportedException {
     return super.clone();
   }
 
+  /** Some javadoc. */
   public void method() throws CloneNotSupportedException {
     super.clone();
   }

--- a/src/it/resources/com/google/checkstyle/test/chapter3filestructure/rule3421overloadsplit/InputOverloadsNeverSplit.java
+++ b/src/it/resources/com/google/checkstyle/test/chapter3filestructure/rule3421overloadsplit/InputOverloadsNeverSplit.java
@@ -132,21 +132,26 @@ public class InputOverloadsNeverSplit {
 
   private class Inner5 {}
 
+  /** some javadoc. */
   public void overloadMethod(int i) {
     // some foo code
   }
 
+  /** some javadoc. */
   public void overloadMethod(String s) {
     // some foo code
   }
 
+  /** some javadoc. */
   public void overloadMethod(boolean b) {
     // some foo code
   }
 
+  /** some javadoc. */
   public void fooMethod() {}
 
-  // violation below 'All overloaded methods should be placed next to each other. .* '143'.'
+  // violation 2 lines below 'All overloaded methods should be placed next to each other. .* '146'.'
+  /** some javadoc. */
   public void overloadMethod(String s, Boolean b, int i) {
     // some foo code
   }
@@ -167,20 +172,24 @@ public class InputOverloadsNeverSplit {
 
         public void fooMethod() {}
 
-        // violation below 'All overloaded methods should be placed next to each other. .* '164'.'
+        // violation below 'All overloaded methods should be placed next to each other. .* '169'.'
         public void overloadMethod(String s, Boolean b, int i) {
           // some foo code
         }
       };
 
+  /** some javadoc. */
   public void testing() {}
 
   private void testing(int a) {}
 
+  /** some javadoc. */
   public void testing(int a, int b) {}
 
+  /** some javadoc. */
   public static void testing(String a) {}
 
+  /** some javadoc. */
   public void testing(String a, String b) {}
 
   interface Fooable {
@@ -191,7 +200,7 @@ public class InputOverloadsNeverSplit {
     public abstract void noFoo();
 
     public abstract void foo(String s, Boolean b, int i);
-    // violation above 'All overloaded methods should be placed next to each other. .* '189'.'
+    // violation above 'All overloaded methods should be placed next to each other. .* '198'.'
 
   }
 
@@ -228,7 +237,7 @@ public class InputOverloadsNeverSplit {
 
     public void fooMethod() {}
 
-    // violation below 'All overloaded methods should be placed next to each other. .* '225'.'
+    // violation below 'All overloaded methods should be placed next to each other. .* '234'.'
     public void overloadMethod(String s, Boolean b, int i) {
       // some foo code
     }

--- a/src/it/resources/com/google/checkstyle/test/chapter4formatting/rule412nonemptyblocks/InputFormattedRightCurlyDoWhile.java
+++ b/src/it/resources/com/google/checkstyle/test/chapter4formatting/rule412nonemptyblocks/InputFormattedRightCurlyDoWhile.java
@@ -5,6 +5,7 @@ import java.util.Scanner;
 /** Test input for GitHub issue #3090. https://github.com/checkstyle/checkstyle/issues/3090 . */
 public class InputFormattedRightCurlyDoWhile {
 
+  /** some javadoc. */
   public void foo1() {
     do {} while (true);
   }
@@ -57,22 +58,27 @@ public class InputFormattedRightCurlyDoWhile {
     String.CASE_INSENSITIVE_ORDER.equals("Goodbye!");
   }
 
+  /** some javadoc. */
   public void foo5() {
     do {} while (true);
   }
 
+  /** some javadoc. */
   public void foo6() {
     do {} while (true);
   }
 
+  /** some javadoc. */
   public void foo7() {
     do {} while (true);
   }
 
+  /** some javadoc. */
   public void foo8() {
     do {} while (true);
   }
 
+  /** some javadoc. */
   public void foo9() {
     do {} while (true);
   }

--- a/src/it/resources/com/google/checkstyle/test/chapter4formatting/rule412nonemptyblocks/InputFormattedRightCurlyDoWhile2.java
+++ b/src/it/resources/com/google/checkstyle/test/chapter4formatting/rule412nonemptyblocks/InputFormattedRightCurlyDoWhile2.java
@@ -6,6 +6,7 @@ import java.util.Scanner;
 /** Test input for GitHub issue #3090. https://github.com/checkstyle/checkstyle/issues/3090 . */
 public class InputFormattedRightCurlyDoWhile2 {
 
+  /** some javadoc. */
   public void foo1() {
     do {} while (true);
   }
@@ -58,22 +59,27 @@ public class InputFormattedRightCurlyDoWhile2 {
     String.CASE_INSENSITIVE_ORDER.equals("Goodbye!");
   }
 
+  /** some javadoc. */
   public void foo5() {
     do {} while (true);
   }
 
+  /** some javadoc. */
   public void foo6() {
     do {} while (true);
   }
 
+  /** some javadoc. */
   public void foo7() {
     do {} while (true);
   }
 
+  /** some javadoc. */
   public void foo8() {
     do {} while (true);
   }
 
+  /** some javadoc. */
   public void foo9() {
     do {} while (true);
   }

--- a/src/it/resources/com/google/checkstyle/test/chapter4formatting/rule412nonemptyblocks/InputRightCurlyDoWhile.java
+++ b/src/it/resources/com/google/checkstyle/test/chapter4formatting/rule412nonemptyblocks/InputRightCurlyDoWhile.java
@@ -5,6 +5,7 @@ import java.util.Scanner;
 /** Test input for GitHub issue #3090. https://github.com/checkstyle/checkstyle/issues/3090 . */
 public class InputRightCurlyDoWhile {
 
+  /** some javadoc. */
   public void foo1() {
     do {} while (true);
   }
@@ -57,25 +58,30 @@ public class InputRightCurlyDoWhile {
     String.CASE_INSENSITIVE_ORDER.equals("Goodbye!");
   }
 
+  /** some javadoc. */
   public void foo5() {
     do {} // violation ''}' at column 9 should be on the same line as the next part of .*'
     while (true);
   }
 
+  /** some javadoc. */
   public void foo6() {
     do {} // violation ''}' at column 9 should be on the same line as the next part of .*'
     while (true);
   }
 
+  /** some javadoc. */
   public void foo7() {
     do {} while (true);
   }
 
+  /** some javadoc. */
   public void foo8() {
     do {} // violation ''}' at column 9 should be on the same line as the next part of .*'
     while (true);
   }
 
+  /** some javadoc. */
   public void foo9() {
     do {} while (true);
   }

--- a/src/it/resources/com/google/checkstyle/test/chapter4formatting/rule412nonemptyblocks/InputRightCurlyDoWhile2.java
+++ b/src/it/resources/com/google/checkstyle/test/chapter4formatting/rule412nonemptyblocks/InputRightCurlyDoWhile2.java
@@ -6,6 +6,7 @@ import java.util.Scanner;
 /** Test input for GitHub issue #3090. https://github.com/checkstyle/checkstyle/issues/3090 . */
 public class InputRightCurlyDoWhile2 {
 
+  /** some javadoc. */
   public void foo1() {
     do {} while (true);
   }
@@ -58,25 +59,30 @@ public class InputRightCurlyDoWhile2 {
     String.CASE_INSENSITIVE_ORDER.equals("Goodbye!");
   }
 
+  /** some javadoc. */
   public void foo5() {
     do {} // violation ''}' at column 9 should be on the same line as the next part of .*'
     while (true);
   }
 
+  /** some javadoc. */
   public void foo6() {
     do {} // violation ''}' at column 9 should be on the same line as the next part of .*'
     while (true);
   }
 
+  /** some javadoc. */
   public void foo7() {
     do {} while (true);
   }
 
+  /** some javadoc. */
   public void foo8() {
     do {} // violation ''}' at column 9 should be on the same line as the next part of .*'
     while (true);
   }
 
+  /** some javadoc. */
   public void foo9() {
     do {} while (true);
   }

--- a/src/it/resources/com/google/checkstyle/test/chapter4formatting/rule42blockindentation/ClassWithChainedMethods.java
+++ b/src/it/resources/com/google/checkstyle/test/chapter4formatting/rule42blockindentation/ClassWithChainedMethods.java
@@ -3,6 +3,7 @@ package com.google.checkstyle.test.chapter4formatting.rule42blockindentation;
 /** some javadoc. */
 public class ClassWithChainedMethods {
 
+  /** some javadoc. */
   public ClassWithChainedMethods(Object... params) {}
 
   /** some javadoc. */
@@ -21,10 +22,12 @@ public class ClassWithChainedMethods {
     // violation above ''new' has incorrect indentation level 4, expected .* 8.'
   }
 
+  /** some javadoc. */
   public String doNothing(String something, String... uselessParams) {
     return something;
   }
 
+  /** some javadoc. */
   public ClassWithChainedMethods getInstance(String... uselessParams) {
     return this;
   }

--- a/src/it/resources/com/google/checkstyle/test/chapter4formatting/rule42blockindentation/ClassWithChainedMethodsCorrect.java
+++ b/src/it/resources/com/google/checkstyle/test/chapter4formatting/rule42blockindentation/ClassWithChainedMethodsCorrect.java
@@ -12,11 +12,13 @@ public class ClassWithChainedMethodsCorrect {
     doNothing(someString.concat("zyx").concat("255, 254, 253"));
   }
 
+  /** some javadoc. */
   public static void main(String[] args) {
     ClassWithChainedMethodsCorrect classWithChainedMethodsCorrect =
         new ClassWithChainedMethodsCorrect();
   }
 
+  /** some javadoc. */
   public String doNothing(String something) {
     return something;
   }

--- a/src/it/resources/com/google/checkstyle/test/chapter4formatting/rule42blockindentation/InputFastMatcher.java
+++ b/src/it/resources/com/google/checkstyle/test/chapter4formatting/rule42blockindentation/InputFastMatcher.java
@@ -3,31 +3,37 @@ package com.google.checkstyle.test.chapter4formatting.rule42blockindentation;
 /** some javadoc. */
 public class InputFastMatcher {
 
+  /** some javadoc. */
   public boolean matches(char c) {
     // OOOO Auto-generated method stub
     return false;
   }
 
+  /** some javadoc. */
   public String replaceFrom(CharSequence sequence, CharSequence replacement) {
     // OOOO Auto-generated method stub
     return null;
   }
 
+  /** some javadoc. */
   public String collapseFrom(CharSequence sequence, char replacement) {
     // OOOO Auto-generated method stub
     return null;
   }
 
+  /** some javadoc. */
   public String trimFrom(CharSequence s) {
     // OOOO Auto-generated method stub
     return null;
   }
 
+  /** some javadoc. */
   public String trimLeadingFrom(CharSequence sequence) {
     // OOOO Auto-generated method stub
     return null;
   }
 
+  /** some javadoc. */
   public String trimTrailingFrom(CharSequence sequence) {
     // OOOO Auto-generated method stub
     return null;

--- a/src/it/resources/com/google/checkstyle/test/chapter4formatting/rule42blockindentation/InputIndentationCorrect.java
+++ b/src/it/resources/com/google/checkstyle/test/chapter4formatting/rule42blockindentation/InputIndentationCorrect.java
@@ -19,6 +19,7 @@ public abstract class InputIndentationCorrect {
     abc = 2;
   }
 
+  /** some javadoc. */
   public boolean matches(char c) {
     return false;
   }
@@ -42,17 +43,21 @@ public abstract class InputIndentationCorrect {
     }
   }
 
+  /** some javadoc. */
   public boolean veryLongLongLongCondition() {
     return veryLongLongLongCondition2();
   }
 
+  /** some javadoc. */
   public boolean veryLongLongLongCondition2() {
     return false;
   }
 
+  /** some javadoc. */
   public void someFooMethod(
       String longString, String superLongString, String exraSuperLongString) {}
 
+  /** some javadoc. */
   public void fooThrowMethod() throws Exception {
     /* Some code*/
   }

--- a/src/it/resources/com/google/checkstyle/test/chapter4formatting/rule451wheretobreak/InputFormattedSeparatorWrap.java
+++ b/src/it/resources/com/google/checkstyle/test/chapter4formatting/rule451wheretobreak/InputFormattedSeparatorWrap.java
@@ -12,6 +12,7 @@ public class InputFormattedSeparatorWrap {
     foo(i, s); // ok
   }
 
+  /** Some javadoc. */
   public static void foo(int i, String s) {}
 }
 

--- a/src/it/resources/com/google/checkstyle/test/chapter4formatting/rule451wheretobreak/InputFormattedSeparatorWrapComma.java
+++ b/src/it/resources/com/google/checkstyle/test/chapter4formatting/rule451wheretobreak/InputFormattedSeparatorWrapComma.java
@@ -12,6 +12,7 @@ public class InputFormattedSeparatorWrapComma {
     foo(i, s); // ok
   }
 
+  /** Some javadoc. */
   public static void foo(int i, String s) {}
 }
 

--- a/src/it/resources/com/google/checkstyle/test/chapter4formatting/rule451wheretobreak/InputSeparatorWrap.java
+++ b/src/it/resources/com/google/checkstyle/test/chapter4formatting/rule451wheretobreak/InputSeparatorWrap.java
@@ -14,6 +14,7 @@ public class InputSeparatorWrap {
             s); // ok
   }
 
+  /** Some javadoc. */
   public static void foo(int i, String s) {}
 }
 

--- a/src/it/resources/com/google/checkstyle/test/chapter4formatting/rule451wheretobreak/InputSeparatorWrapComma.java
+++ b/src/it/resources/com/google/checkstyle/test/chapter4formatting/rule451wheretobreak/InputSeparatorWrapComma.java
@@ -12,6 +12,7 @@ public class InputSeparatorWrapComma {
     foo(i, s); // ok
   }
 
+  /** Some javadoc. */
   public static void foo(int i, String s) {}
 }
 

--- a/src/it/resources/com/google/checkstyle/test/chapter4formatting/rule452indentcontinuationlines/ClassWithChainedMethods.java
+++ b/src/it/resources/com/google/checkstyle/test/chapter4formatting/rule452indentcontinuationlines/ClassWithChainedMethods.java
@@ -3,6 +3,7 @@ package com.google.checkstyle.test.chapter4formatting.rule452indentcontinuationl
 /** some javadoc. */
 public class ClassWithChainedMethods {
 
+  /** some javadoc. */
   public ClassWithChainedMethods(Object... params) {}
 
   /** some javadoc. */
@@ -21,10 +22,12 @@ public class ClassWithChainedMethods {
     // violation above ''new' has incorrect indentation level 4, expected .* 8.'
   }
 
+  /** some javadoc. */
   public String doNothing(String something, String... uselessParams) {
     return something;
   }
 
+  /** some javadoc. */
   public ClassWithChainedMethods getInstance(String... uselessParams) {
     return this;
   }

--- a/src/it/resources/com/google/checkstyle/test/chapter4formatting/rule452indentcontinuationlines/ClassWithChainedMethodsCorrect.java
+++ b/src/it/resources/com/google/checkstyle/test/chapter4formatting/rule452indentcontinuationlines/ClassWithChainedMethodsCorrect.java
@@ -12,11 +12,13 @@ public class ClassWithChainedMethodsCorrect {
     doNothing(someString.concat("zyx").concat("255, 254, 253"));
   }
 
+  /** some javadoc. */
   public static void main(String[] args) {
     ClassWithChainedMethodsCorrect classWithChainedMethodsCorrect =
         new ClassWithChainedMethodsCorrect();
   }
 
+  /** some javadoc. */
   public String doNothing(String something) {
     return something;
   }

--- a/src/it/resources/com/google/checkstyle/test/chapter4formatting/rule452indentcontinuationlines/InputFastMatcher.java
+++ b/src/it/resources/com/google/checkstyle/test/chapter4formatting/rule452indentcontinuationlines/InputFastMatcher.java
@@ -3,31 +3,37 @@ package com.google.checkstyle.test.chapter4formatting.rule452indentcontinuationl
 /** some javadoc. */
 public class InputFastMatcher {
 
+  /** some javadoc. */
   public boolean matches(char c) {
     // OOOO Auto-generated method stub
     return false;
   }
 
+  /** some javadoc. */
   public String replaceFrom(CharSequence sequence, CharSequence replacement) {
     // OOOO Auto-generated method stub
     return null;
   }
 
+  /** some javadoc. */
   public String collapseFrom(CharSequence sequence, char replacement) {
     // OOOO Auto-generated method stub
     return null;
   }
 
+  /** some javadoc. */
   public String trimFrom(CharSequence s) {
     // OOOO Auto-generated method stub
     return null;
   }
 
+  /** some javadoc. */
   public String trimLeadingFrom(CharSequence sequence) {
     // OOOO Auto-generated method stub
     return null;
   }
 
+  /** some javadoc. */
   public String trimTrailingFrom(CharSequence sequence) {
     // OOOO Auto-generated method stub
     return null;

--- a/src/it/resources/com/google/checkstyle/test/chapter4formatting/rule452indentcontinuationlines/InputIndentationCorrect.java
+++ b/src/it/resources/com/google/checkstyle/test/chapter4formatting/rule452indentcontinuationlines/InputIndentationCorrect.java
@@ -19,6 +19,7 @@ public abstract class InputIndentationCorrect {
     abc = 2;
   }
 
+  /** some javadoc. */
   public boolean matches(char c) {
     return false;
   }
@@ -42,17 +43,21 @@ public abstract class InputIndentationCorrect {
     }
   }
 
+  /** some javadoc. */
   public boolean veryLongLongLongCondition() {
     return veryLongLongLongCondition2();
   }
 
+  /** some javadoc. */
   public boolean veryLongLongLongCondition2() {
     return false;
   }
 
+  /** some javadoc. */
   public void someFooMethod(
       String longString, String superLongString, String exraSuperLongString) {}
 
+  /** some javadoc. */
   public void fooThrowMethod() throws Exception {
     /* Some code*/
   }

--- a/src/it/resources/com/google/checkstyle/test/chapter4formatting/rule462horizontalwhitespace/InputFormattedMethodParamPad.java
+++ b/src/it/resources/com/google/checkstyle/test/chapter4formatting/rule462horizontalwhitespace/InputFormattedMethodParamPad.java
@@ -4,16 +4,20 @@ import java.util.Vector;
 
 /** Test input for MethodDefPadCheck. */
 public class InputFormattedMethodParamPad {
+  /** some javadoc. */
   public InputFormattedMethodParamPad() {
     super();
   }
 
+  /** some javadoc. */
   public InputFormattedMethodParamPad(int param) {
     super();
   }
 
+  /** some javadoc. */
   public void method() {}
 
+  /** some javadoc. */
   public void method(int param) {}
 
   /** some javadoc. */

--- a/src/it/resources/com/google/checkstyle/test/chapter4formatting/rule462horizontalwhitespace/InputFormattedNoWhitespaceBeforeAnnotations.java
+++ b/src/it/resources/com/google/checkstyle/test/chapter4formatting/rule462horizontalwhitespace/InputFormattedNoWhitespaceBeforeAnnotations.java
@@ -12,17 +12,22 @@ public class InputFormattedNoWhitespaceBeforeAnnotations {
   @NonNull int @NonNull [] @NonNull [] fiel1; // ok until #8205
   @NonNull int @NonNull [] @NonNull [] field2; // ok
 
+  /** some javadoc. */
   public void foo(final char @NonNull [] param) {} // ok
 
   // @NonNull int @NonNull ... field3; // non-compilable
   // @NonNull int @NonNull... field4; // non-compilable
 
+  /** some javadoc. */
   public void foo1(final char[] param) {} // ok
 
+  /** some javadoc. */
   public void foo2(final char[] param) {} // ok
 
+  /** some javadoc. */
   public void foo3(final char @NonNull [] param) {} // ok until #8205
 
+  /** some javadoc. */
   public void foo4(final char @NonNull [] param) {} // ok
 
   void test1(String... param) {} // ok until #8205

--- a/src/it/resources/com/google/checkstyle/test/chapter4formatting/rule462horizontalwhitespace/InputFormattedWhitespaceAfterGood.java
+++ b/src/it/resources/com/google/checkstyle/test/chapter4formatting/rule462horizontalwhitespace/InputFormattedWhitespaceAfterGood.java
@@ -70,11 +70,13 @@ public class InputFormattedWhitespaceAfterGood {
     }
   }
 
+  /** some javadoc. */
   public void check7() {
     synchronized (this) {
     }
   }
 
+  /** some javadoc. */
   public String check8() {
     return ("a" + "b");
   }

--- a/src/it/resources/com/google/checkstyle/test/chapter4formatting/rule462horizontalwhitespace/InputMethodParamPad.java
+++ b/src/it/resources/com/google/checkstyle/test/chapter4formatting/rule462horizontalwhitespace/InputMethodParamPad.java
@@ -4,16 +4,20 @@ import java.util.Vector;
 
 /** Test input for MethodDefPadCheck. */
 public class InputMethodParamPad {
+  /** some javadoc. */
   public InputMethodParamPad() {
     super();
   }
 
+  /** some javadoc. */
   public InputMethodParamPad (int param) { // violation ''(' is preceded with whitespace.'
     super (); // violation ''(' is preceded with whitespace.'
   }
 
+  /** some javadoc. */
   public void method() {}
 
+  /** some javadoc. */
   public void method (int param) {} // violation ''(' is preceded with whitespace.'
 
   /** some javadoc. */

--- a/src/it/resources/com/google/checkstyle/test/chapter4formatting/rule462horizontalwhitespace/InputNoWhitespaceBeforeAnnotations.java
+++ b/src/it/resources/com/google/checkstyle/test/chapter4formatting/rule462horizontalwhitespace/InputNoWhitespaceBeforeAnnotations.java
@@ -12,17 +12,22 @@ public class InputNoWhitespaceBeforeAnnotations {
   @NonNull int @NonNull [] @NonNull [] fiel1; // ok until #8205
   @NonNull int @NonNull [] @NonNull [] field2; // ok
 
+  /** some javadoc. */
   public void foo(final char @NonNull [] param) {} // ok
 
   // @NonNull int @NonNull ... field3; // non-compilable
   // @NonNull int @NonNull... field4; // non-compilable
 
+  /** some javadoc. */
   public void foo1(final char[] param) {} // ok
 
+  /** some javadoc. */
   public void foo2(final char[] param) {} // ok
 
+  /** some javadoc. */
   public void foo3(final char @NonNull [] param) {} // ok until #8205
 
+  /** some javadoc. */
   public void foo4(final char @NonNull [] param) {} // ok
 
   void test1(String... param) {} // ok until #8205

--- a/src/it/resources/com/google/checkstyle/test/chapter4formatting/rule462horizontalwhitespace/InputWhitespaceAfterGood.java
+++ b/src/it/resources/com/google/checkstyle/test/chapter4formatting/rule462horizontalwhitespace/InputWhitespaceAfterGood.java
@@ -71,11 +71,13 @@ public class InputWhitespaceAfterGood {
     }
   }
 
+  /** some javadoc. */
   public void check7() {
     synchronized (this) {
     }
   }
 
+  /** some javadoc. */
   public String check8() {
     return ("a" + "b");
   }

--- a/src/it/resources/com/google/checkstyle/test/chapter4formatting/rule4832nocstylearray/InputNoCstyleArrays.java
+++ b/src/it/resources/com/google/checkstyle/test/chapter4formatting/rule4832nocstylearray/InputNoCstyleArrays.java
@@ -5,6 +5,7 @@ public class InputNoCstyleArrays {
   private int[] javastyle = new int[0];
   private int cstyle[] = new int[0]; // violation 'Array brackets at illegal position.'
 
+  /** some javadoc. */
   public static void mainJava(String[] javastyle) {} // ok
 
   /** some javadoc. */

--- a/src/it/resources/com/google/checkstyle/test/chapter4formatting/rule4841indentation/InputClassWithChainedMethods.java
+++ b/src/it/resources/com/google/checkstyle/test/chapter4formatting/rule4841indentation/InputClassWithChainedMethods.java
@@ -3,6 +3,7 @@ package com.google.checkstyle.test.chapter4formatting.rule4841indentation;
 /** some javadoc. */
 public class InputClassWithChainedMethods {
 
+  /** some javadoc. */
   public InputClassWithChainedMethods(Object... params) {}
 
   /** some javadoc. */
@@ -21,10 +22,12 @@ public class InputClassWithChainedMethods {
     // violation above ''new' has incorrect indentation level 4, expected .* 8.'
   }
 
+  /** some javadoc. */
   public String doNothing(String something, String... uselessParams) {
     return something;
   }
 
+  /** some javadoc. */
   public InputClassWithChainedMethods getInstance(String... uselessParams) {
     return this;
   }

--- a/src/it/resources/com/google/checkstyle/test/chapter4formatting/rule4841indentation/InputClassWithChainedMethodsCorrect.java
+++ b/src/it/resources/com/google/checkstyle/test/chapter4formatting/rule4841indentation/InputClassWithChainedMethodsCorrect.java
@@ -12,11 +12,13 @@ public class InputClassWithChainedMethodsCorrect {
     doNothing(someString.concat("zyx").concat("255, 254, 253"));
   }
 
+  /** some javadoc. */
   public static void main(String[] args) {
     InputClassWithChainedMethodsCorrect classWithChainedMethodsCorrect =
         new InputClassWithChainedMethodsCorrect();
   }
 
+  /** some javadoc. */
   public String doNothing(String something) {
     return something;
   }

--- a/src/it/resources/com/google/checkstyle/test/chapter4formatting/rule4841indentation/InputFastMatcher.java
+++ b/src/it/resources/com/google/checkstyle/test/chapter4formatting/rule4841indentation/InputFastMatcher.java
@@ -3,31 +3,37 @@ package com.google.checkstyle.test.chapter4formatting.rule4841indentation;
 /** some javadoc. */
 public class InputFastMatcher {
 
+  /** some javadoc. */
   public boolean matches(char c) {
     // OOOO Auto-generated method stub
     return false;
   }
 
+  /** some javadoc. */
   public String replaceFrom(CharSequence sequence, CharSequence replacement) {
     // OOOO Auto-generated method stub
     return null;
   }
 
+  /** some javadoc. */
   public String collapseFrom(CharSequence sequence, char replacement) {
     // OOOO Auto-generated method stub
     return null;
   }
 
+  /** some javadoc. */
   public String trimFrom(CharSequence s) {
     // OOOO Auto-generated method stub
     return null;
   }
 
+  /** some javadoc. */
   public String trimLeadingFrom(CharSequence sequence) {
     // OOOO Auto-generated method stub
     return null;
   }
 
+  /** some javadoc. */
   public String trimTrailingFrom(CharSequence sequence) {
     // OOOO Auto-generated method stub
     return null;

--- a/src/it/resources/com/google/checkstyle/test/chapter4formatting/rule4841indentation/InputFormattedClassWithChainedMethods.java
+++ b/src/it/resources/com/google/checkstyle/test/chapter4formatting/rule4841indentation/InputFormattedClassWithChainedMethods.java
@@ -3,6 +3,7 @@ package com.google.checkstyle.test.chapter4formatting.rule4841indentation;
 /** some javadoc. */
 public class InputFormattedClassWithChainedMethods {
 
+  /** some javadoc. */
   public InputFormattedClassWithChainedMethods(Object... params) {}
 
   /** some javadoc. */
@@ -22,10 +23,12 @@ public class InputFormattedClassWithChainedMethods {
             .doNothing("nothing");
   }
 
+  /** some javadoc. */
   public String doNothing(String something, String... uselessParams) {
     return something;
   }
 
+  /** some javadoc. */
   public InputFormattedClassWithChainedMethods getInstance(String... uselessParams) {
     return this;
   }

--- a/src/it/resources/com/google/checkstyle/test/chapter4formatting/rule4841indentation/InputIndentationCorrect.java
+++ b/src/it/resources/com/google/checkstyle/test/chapter4formatting/rule4841indentation/InputIndentationCorrect.java
@@ -19,6 +19,7 @@ public abstract class InputIndentationCorrect {
     abc = 2;
   }
 
+  /** some javadoc. */
   public boolean matches(char c) {
     return false;
   }
@@ -42,17 +43,21 @@ public abstract class InputIndentationCorrect {
     }
   }
 
+  /** some javadoc. */
   public boolean veryLongLongLongCondition() {
     return veryLongLongLongCondition2();
   }
 
+  /** some javadoc. */
   public boolean veryLongLongLongCondition2() {
     return false;
   }
 
+  /** some javadoc. */
   public void someFooMethod(
       String longString, String superLongString, String exraSuperLongString) {}
 
+  /** some javadoc. */
   public void fooThrowMethod() throws Exception {
     /* Some code*/
   }

--- a/src/it/resources/com/google/checkstyle/test/chapter4formatting/rule4861blockcommentstyle/InputCommentsIndentationCommentIsAtTheEndOfBlock.java
+++ b/src/it/resources/com/google/checkstyle/test/chapter4formatting/rule4861blockcommentstyle/InputCommentsIndentationCommentIsAtTheEndOfBlock.java
@@ -3,6 +3,7 @@ package com.google.checkstyle.test.chapter4formatting.rule4861blockcommentstyle;
 /** Contains examples of using comments at the end of the block. */
 public class InputCommentsIndentationCommentIsAtTheEndOfBlock {
 
+  /** some javadoc. */
   public void foo1() {
     foo2();
     // OOOO: missing functionality
@@ -10,43 +11,47 @@ public class InputCommentsIndentationCommentIsAtTheEndOfBlock {
 
   /** some javadoc. */
   public void foo2() {
-    // violation 2 lines below '.* indentation should be the same level as line 14.'
+    // violation 2 lines below '.* indentation should be the same level as line 15.'
     foo3();
                        // odd indentation comment
   }
 
+  /** some javadoc. */
   public void foo3() {
     foo2();
     // refreshDisplay();
   }
 
+  /** some javadoc. */
   public void foo4() {
     foooooooooooooooooooooooooooooooooooooooooo();
     // ^-- some hint
   }
 
+  /** some javadoc. */
   public void foooooooooooooooooooooooooooooooooooooooooo() {}
 
      /////////////////////////////// odd indentation comment
-  // violation above '.* indentation should be the same level as line 34.'
+  // violation above '.* indentation should be the same level as line 38.'
 
   /** some javadoc. */
   public void foo7() {
-    // violation 2 lines below'.* indentation should be the same level as line 36.'
+    // violation 2 lines below'.* indentation should be the same level as line 40.'
     int a = 0;
 // odd indentation comment
   }
 
   /////////////////////////////// (a single-line border to separate a group of methods)
 
+  /** some javadoc. */
   public void foo8() {}
 
   /** some javadoc. */
   public class TestClass {
     /** some javadoc. */
     public void test() {
-      // violation 3 lines below '.* indentation should be the same level as line 50.'
-      // violation 4 lines below'.* indentation should be the same level as line 47.'
+      // violation 3 lines below '.* indentation should be the same level as line 55.'
+      // violation 4 lines below'.* indentation should be the same level as line 52.'
       int a = 0;
          // odd indentation comment
     }
@@ -55,7 +60,7 @@ public class InputCommentsIndentationCommentIsAtTheEndOfBlock {
 
   /** some javadoc. */
   public void foo9() {
-    // violation 2 lines below '.* indentation should be the same level as line 59.'
+    // violation 2 lines below '.* indentation should be the same level as line 64.'
     this.foo1();
          // odd indentation comment
   }
@@ -64,6 +69,7 @@ public class InputCommentsIndentationCommentIsAtTheEndOfBlock {
   //
   //    }
 
+  /** some javadoc. */
   public void foo11() {
     String.valueOf(new Integer(0)).trim().length();
     // comment
@@ -71,7 +77,7 @@ public class InputCommentsIndentationCommentIsAtTheEndOfBlock {
 
   /** some javadoc. */
   public void foo12() {
-    // violation 5 lines below '.* indentation should be the same level as line 75.'
+    // violation 5 lines below '.* indentation should be the same level as line 81.'
     String
         .valueOf(new Integer(0))
         .trim()
@@ -79,6 +85,7 @@ public class InputCommentsIndentationCommentIsAtTheEndOfBlock {
               // odd indentation comment
   }
 
+  /** some javadoc. */
   public void foo13() {
     String.valueOf(new Integer(0)).trim().length();
     // comment
@@ -86,13 +93,14 @@ public class InputCommentsIndentationCommentIsAtTheEndOfBlock {
 
   /** some javadoc. */
   public void foo14() {
-    // violation 4 lines below '.* indentation should be the same level as line 90.'
+    // violation 4 lines below '.* indentation should be the same level as line 97.'
     String.valueOf(new Integer(0))
         .trim()
         .length();
                            // odd indentation comment
   }
 
+  /** some javadoc. */
   public void foo15() {
     String.valueOf(new Integer(0));
     // comment
@@ -100,7 +108,7 @@ public class InputCommentsIndentationCommentIsAtTheEndOfBlock {
 
   /** some javadoc. */
   public void foo16() {
-    // violation 3 lines below '.* indentation should be the same level as line 104.'
+    // violation 3 lines below '.* indentation should be the same level as line 112.'
     String
         .valueOf(new Integer(0));
                  // odd indentation comment
@@ -116,7 +124,7 @@ public class InputCommentsIndentationCommentIsAtTheEndOfBlock {
 
   /** some javadoc. */
   public void foo18() {
-    // violation 4 lines below '.* indentation should be the same level as line 124.'
+    // violation 4 lines below '.* indentation should be the same level as line 132.'
     String
         .valueOf(new Integer(0))
         .trim()
@@ -137,7 +145,7 @@ public class InputCommentsIndentationCommentIsAtTheEndOfBlock {
 
   /** some javadoc. */
   public void foo20() {
-    // violation 8 lines below '.* indentation should be the same level as line 141.'
+    // violation 8 lines below '.* indentation should be the same level as line 149.'
     (new Thread(new Runnable() {
         @Override
         public void run() {
@@ -173,13 +181,14 @@ public class InputCommentsIndentationCommentIsAtTheEndOfBlock {
     for (int i = 0; i < 5; i++) {
       org.junit.Assert.assertEquals(expected.get(i), array[i]);
     }
-    // violation 4 lines below '.* indentation should be the same level as line 177.'
+    // violation 4 lines below '.* indentation should be the same level as line 185.'
     String s = String.format(java.util.Locale.ENGLISH, "The array element "
             + "immediately following the end of the collection should be nulled",
         array[1]);
                              // odd indentation comment
   }
 
+  /** some javadoc. */
   public void foo23() {
     new Object();
     // comment
@@ -187,11 +196,12 @@ public class InputCommentsIndentationCommentIsAtTheEndOfBlock {
 
   /** some javadoc. */
   public void foo24() {
-    // violation 2 lines below '.* indentation should be the same level as line 191.'
+    // violation 2 lines below '.* indentation should be the same level as line 200.'
     new Object();
                  // odd indentation comment
   }
 
+  /** some javadoc. */
   public String foo25() {
     return String.format(java.util.Locale.ENGLISH, "%d", 1);
     // comment
@@ -199,7 +209,7 @@ public class InputCommentsIndentationCommentIsAtTheEndOfBlock {
 
   /** some javadoc. */
   public String foo26() {
-    // violation 3 lines below '.* indentation should be the same level as line 203.'
+    // violation 3 lines below '.* indentation should be the same level as line 213.'
     return String.format(java.util.Locale.ENGLISH, "%d",
         1);
                               // odd indentation comment
@@ -224,7 +234,7 @@ public class InputCommentsIndentationCommentIsAtTheEndOfBlock {
   /** some javadoc. */
   public String foo29() {
     int a = 5;
-    // violation 3 lines below '.* indentation should be the same level as line 228.'
+    // violation 3 lines below '.* indentation should be the same level as line 238.'
     return String.format(java.util.Locale.ENGLISH, "%d",
         1);
                       // odd indentation comment
@@ -233,7 +243,7 @@ public class InputCommentsIndentationCommentIsAtTheEndOfBlock {
   /** some javadoc. */
   public void foo30() {
     // comment
-    // violation 2 lines below '.* indentation should be the same level as line 237.'
+    // violation 2 lines below '.* indentation should be the same level as line 247.'
     int a = 5;
 // odd indentation comment
   }
@@ -246,7 +256,7 @@ public class InputCommentsIndentationCommentIsAtTheEndOfBlock {
 
   /** some javadoc. */
   public void foo32() {
-    // violation 4 lines below '.* indentation should be the same level as line 250.'
+    // violation 4 lines below '.* indentation should be the same level as line 260.'
     String s = new String("A"
         + "B"
         + "C");
@@ -256,7 +266,7 @@ public class InputCommentsIndentationCommentIsAtTheEndOfBlock {
   /** some javadoc. */
   public void foo33() {
     // comment
-    // violation 2 lines below '.* indentation should be the same level as line 260.'
+    // violation 2 lines below '.* indentation should be the same level as line 270.'
     this.foo22();
 // odd indentation comment
   }
@@ -269,7 +279,7 @@ public class InputCommentsIndentationCommentIsAtTheEndOfBlock {
 
   /** some javadoc. */
   public void foo35() throws Exception {
-    // violation 4 lines below '.* indentation should be the same level as line 273.'
+    // violation 4 lines below '.* indentation should be the same level as line 283.'
     throw new Exception("",
         new Exception()
     );
@@ -278,13 +288,14 @@ public class InputCommentsIndentationCommentIsAtTheEndOfBlock {
 
   /** some javadoc. */
   public void foo36() throws Exception {
-    // violation 4 lines below '.* indentation should be the same level as line 282.'
+    // violation 4 lines below '.* indentation should be the same level as line 292.'
     throw new Exception("",
         new Exception()
     );
 // odd indentation comment
   }
 
+  /** some javadoc. */
   public void foo37() throws Exception {
     throw new Exception("", new Exception());
     // comment
@@ -292,14 +303,14 @@ public class InputCommentsIndentationCommentIsAtTheEndOfBlock {
 
   /** some javadoc. */
   public void foo38() throws Exception {
-    // violation 2 lines below '.* indentation should be the same level as line 296.'
+    // violation 2 lines below '.* indentation should be the same level as line 307.'
     throw new Exception("", new Exception());
           // odd indentation comment
   }
 
   /** some javadoc. */
   public void foo39() throws Exception {
-    // violation 3 lines below'.* indentation should be the same level as line 303.'
+    // violation 3 lines below'.* indentation should be the same level as line 314.'
     throw new Exception("",
         new Exception());
      // odd indentation comment
@@ -308,7 +319,7 @@ public class InputCommentsIndentationCommentIsAtTheEndOfBlock {
   /** some javadoc. */
   public void foo40() throws Exception {
     int a = 88;
-    // violation 2 lines below '.* indentation should be the same level as line 312.'
+    // violation 2 lines below '.* indentation should be the same level as line 323.'
     throw new Exception("", new Exception());
      // odd indentation comment
   }
@@ -353,14 +364,14 @@ public class InputCommentsIndentationCommentIsAtTheEndOfBlock {
   public void foo45() {
     int ar = 5;
     // comment
-    // violation 2 lines below '.* indentation should be the same level as line 357.'
+    // violation 2 lines below '.* indentation should be the same level as line 368.'
     ar = 6;
      // odd indentation comment
   }
 
   /** some javadoc. */
   public void foo46() {
-    // violation 3 lines below '.* indentation should be the same level as line 367.'
+    // violation 3 lines below '.* indentation should be the same level as line 378.'
 // comment
 // block
 // odd indentation comment
@@ -376,7 +387,7 @@ public class InputCommentsIndentationCommentIsAtTheEndOfBlock {
 
   /** some javadoc. */
   public void foo48() {
-    // violation 4 lines below '.* indentation should be the same level as line 380.'
+    // violation 4 lines below '.* indentation should be the same level as line 391.'
     int a = 5;
 // comment
 // block
@@ -399,13 +410,14 @@ public class InputCommentsIndentationCommentIsAtTheEndOfBlock {
 
   /** some javadoc. */
   public String foo51() {
-    // violation 4 lines below '.* indentation should be the same level as line 403.'
+    // violation 4 lines below '.* indentation should be the same level as line 414.'
     return String
         .valueOf("11"
         );
      // odd indentation comment
   }
 
+  /** some javadoc. */
   public String foo52() {
     return String.valueOf("11");
     // comment

--- a/src/it/resources/com/google/checkstyle/test/chapter4formatting/rule4861blockcommentstyle/InputCommentsIndentationSurroundingCode.java
+++ b/src/it/resources/com/google/checkstyle/test/chapter4formatting/rule4861blockcommentstyle/InputCommentsIndentationSurroundingCode.java
@@ -127,6 +127,7 @@ public class InputCommentsIndentationSurroundingCode {
     String someStr = new String();
   }
 
+  /** some javadoc. */
   public String foo9(String s1, String s2, String s3) {
     return "";
   }

--- a/src/it/resources/com/google/checkstyle/test/chapter4formatting/rule4861blockcommentstyle/InputFormattedCommentsIndentationCommentIsAtTheEndOfBlock.java
+++ b/src/it/resources/com/google/checkstyle/test/chapter4formatting/rule4861blockcommentstyle/InputFormattedCommentsIndentationCommentIsAtTheEndOfBlock.java
@@ -3,6 +3,7 @@ package com.google.checkstyle.test.chapter4formatting.rule4861blockcommentstyle;
 /** Contains examples of using comments at the end of the block. */
 public class InputFormattedCommentsIndentationCommentIsAtTheEndOfBlock {
 
+  /** some javadoc. */
   public void foo1() {
     foo2();
     // OOOO: missing functionality
@@ -15,16 +16,19 @@ public class InputFormattedCommentsIndentationCommentIsAtTheEndOfBlock {
     // odd indentation comment
   }
 
+  /** some javadoc. */
   public void foo3() {
     foo2();
     // refreshDisplay();
   }
 
+  /** some javadoc. */
   public void foo4() {
     foooooooooooooooooooooooooooooooooooooooooo();
     // ^-- some hint
   }
 
+  /** some javadoc. */
   public void foooooooooooooooooooooooooooooooooooooooooo() {}
 
   /////////////////////////////// odd indentation comment
@@ -38,6 +42,7 @@ public class InputFormattedCommentsIndentationCommentIsAtTheEndOfBlock {
 
   /////////////////////////////// (a single-line border to separate a group of methods)
 
+  /** some javadoc. */
   public void foo8() {}
 
   /** some javadoc. */
@@ -62,6 +67,7 @@ public class InputFormattedCommentsIndentationCommentIsAtTheEndOfBlock {
   //
   //    }
 
+  /** some javadoc. */
   public void foo11() {
     String.valueOf(new Integer(0)).trim().length();
     // comment
@@ -74,6 +80,7 @@ public class InputFormattedCommentsIndentationCommentIsAtTheEndOfBlock {
     // odd indentation comment
   }
 
+  /** some javadoc. */
   public void foo13() {
     String.valueOf(new Integer(0)).trim().length();
     // comment
@@ -86,6 +93,7 @@ public class InputFormattedCommentsIndentationCommentIsAtTheEndOfBlock {
     // odd indentation comment
   }
 
+  /** some javadoc. */
   public void foo15() {
     String.valueOf(new Integer(0));
     // comment
@@ -173,6 +181,7 @@ public class InputFormattedCommentsIndentationCommentIsAtTheEndOfBlock {
     // odd indentation comment
   }
 
+  /** some javadoc. */
   public void foo23() {
     new Object();
     // comment
@@ -185,6 +194,7 @@ public class InputFormattedCommentsIndentationCommentIsAtTheEndOfBlock {
     // odd indentation comment
   }
 
+  /** some javadoc. */
   public String foo25() {
     return String.format(java.util.Locale.ENGLISH, "%d", 1);
     // comment
@@ -270,6 +280,7 @@ public class InputFormattedCommentsIndentationCommentIsAtTheEndOfBlock {
     // odd indentation comment
   }
 
+  /** some javadoc. */
   public void foo37() throws Exception {
     throw new Exception("", new Exception());
     // comment
@@ -388,6 +399,7 @@ public class InputFormattedCommentsIndentationCommentIsAtTheEndOfBlock {
     // odd indentation comment
   }
 
+  /** some javadoc. */
   public String foo52() {
     return String.valueOf("11");
     // comment

--- a/src/it/resources/com/google/checkstyle/test/chapter4formatting/rule4861blockcommentstyle/InputFormattedCommentsIndentationSurroundingCode.java
+++ b/src/it/resources/com/google/checkstyle/test/chapter4formatting/rule4861blockcommentstyle/InputFormattedCommentsIndentationSurroundingCode.java
@@ -131,6 +131,7 @@ public class InputFormattedCommentsIndentationSurroundingCode {
     String someStr = new String();
   }
 
+  /** some javadoc. */
   public String foo9(String s1, String s2, String s3) {
     return "";
   }

--- a/src/it/resources/com/google/checkstyle/test/chapter5naming/rule528typevariablenames/InputInterfaceTypeParameterName.java
+++ b/src/it/resources/com/google/checkstyle/test/chapter5naming/rule528typevariablenames/InputInterfaceTypeParameterName.java
@@ -4,6 +4,7 @@ import java.io.Serializable;
 
 /** some javadoc. */
 public class InputInterfaceTypeParameterName<T> {
+  /** some javadoc. */
   public <TT> void foo() {}
 
   <T> void foo(int i) {}

--- a/src/it/resources/com/google/checkstyle/test/chapter6programpractice/rule64finalizers/InputNoFinalizer.java
+++ b/src/it/resources/com/google/checkstyle/test/chapter6programpractice/rule64finalizers/InputNoFinalizer.java
@@ -20,6 +20,6 @@ public class InputNoFinalizer {
     runnable.run();
   }
 
-  // should not be reported by NoFinalizer check
+  /** should not be reported by NoFinalizer check. */
   public void finalize(String x) {}
 }

--- a/src/it/resources/com/google/checkstyle/test/chapter7javadoc/rule731selfexplanatory/InputJavadocMethodAndMissingJavadocMethod.java
+++ b/src/it/resources/com/google/checkstyle/test/chapter7javadoc/rule731selfexplanatory/InputJavadocMethodAndMissingJavadocMethod.java
@@ -57,7 +57,7 @@ public class InputJavadocMethodAndMissingJavadocMethod extends OverrideClasss {
     return "Fooooooooooooooo" + "ooooo" + "ooo" + x;
   }
 
-  // ok, methods smaller than 2 lines does not require javadoc
+  /** some javadoc. */
   public void smallMethod1() {
     foo2();
   }
@@ -101,7 +101,7 @@ public class InputJavadocMethodAndMissingJavadocMethod extends OverrideClasss {
     foo3();
   }
 
-  // ok, constructors smaller than 2 lines does not require javadoc
+  /** some javadoc. */
   public InputJavadocMethodAndMissingJavadocMethod(int a, int b) {
     foo2();
   }
@@ -137,6 +137,32 @@ public class InputJavadocMethodAndMissingJavadocMethod extends OverrideClasss {
   @Override
   public String foo92() {
     return "Fooooo" + "ooo" + "ooooooo" + "ooooo" + "ooo";
+  }
+
+  int xyz = 99;
+
+  public int getXyz() {
+    return xyz;
+  }
+
+  public void setXyz(int xyz) {
+    this.xyz = xyz;
+  }
+
+  int abc = 101;
+
+  // violation below 'Missing a Javadoc comment.'
+  public int getAbc() {
+    abc = 55;
+    abc += 1;
+    return abc;
+  }
+
+  // violation below 'Missing a Javadoc comment.'
+  public void setAbc(int abc) {
+    abc = 55;
+    abc += 1;
+    this.abc = abc;
   }
 }
 

--- a/src/it/resources/com/google/checkstyle/test/chapter7javadoc/rule732exceptionoverrides/InputJavadocMethodAndMissingJavadocMethod.java
+++ b/src/it/resources/com/google/checkstyle/test/chapter7javadoc/rule732exceptionoverrides/InputJavadocMethodAndMissingJavadocMethod.java
@@ -57,7 +57,7 @@ public class InputJavadocMethodAndMissingJavadocMethod extends OverrideClass {
     return "Fooooooooooooooo" + "ooooo" + "ooo" + x;
   }
 
-  // ok, methods smaller than 2 lines does not require javadoc
+  /** some javadoc. */
   public void smallMethod1() {
     foo2();
   }
@@ -101,7 +101,7 @@ public class InputJavadocMethodAndMissingJavadocMethod extends OverrideClass {
     foo3();
   }
 
-  // ok, constructors smaller than 2 lines does not require javadoc
+  /** some javadoc. */
   public InputJavadocMethodAndMissingJavadocMethod(int a, int b) {
     foo2();
   }

--- a/src/it/resources/com/google/checkstyle/test/chapter7javadoc/rule73wherejavadocrequired/InputJavadocMethodAndMissingJavadocMethod.java
+++ b/src/it/resources/com/google/checkstyle/test/chapter7javadoc/rule73wherejavadocrequired/InputJavadocMethodAndMissingJavadocMethod.java
@@ -52,12 +52,12 @@ public class InputJavadocMethodAndMissingJavadocMethod extends OverrideClass {
     return "Fooooooooooooooo" + "ooooo" + "ooo" + param;
   }
 
-  // ok, default scope method does not require javadoc
+  /** Some javadoc. */
   String defaultScope(int x) {
     return "Fooooooooooooooo" + "ooooo" + "ooo" + x;
   }
 
-  // ok, methods smaller than 2 lines does not require javadoc
+  /** Some javadoc. */
   public void smallMethod1() {
     foo2();
   }
@@ -101,7 +101,7 @@ public class InputJavadocMethodAndMissingJavadocMethod extends OverrideClass {
     foo3();
   }
 
-  // ok, constructors smaller than 2 lines does not require javadoc
+  /** Some javadoc. */
   public InputJavadocMethodAndMissingJavadocMethod(int a, int b) {
     foo2();
   }

--- a/src/it/resources/com/google/checkstyle/test/chapter7javadoc/rule73wherejavadocrequired/InputMissingJavadocTypeCorrect.java
+++ b/src/it/resources/com/google/checkstyle/test/chapter7javadoc/rule73wherejavadocrequired/InputMissingJavadocTypeCorrect.java
@@ -49,6 +49,7 @@ public class InputMissingJavadocTypeCorrect {
 
   private @interface MyAnnotationPrivate {}
 
+  /** some javadoc. */
   public void myMethod() {
     class MyMethodClass {}
   }

--- a/src/it/resources/com/google/checkstyle/test/chapter7javadoc/rule73wherejavadocrequired/InputMissingJavadocTypeIncorrect.java
+++ b/src/it/resources/com/google/checkstyle/test/chapter7javadoc/rule73wherejavadocrequired/InputMissingJavadocTypeIncorrect.java
@@ -27,6 +27,7 @@ public class InputMissingJavadocTypeIncorrect { // violation 'Missing a Javadoc 
   protected @interface MyAnnotationProtected { // violation 'Missing a Javadoc comment.'
   }
 
+  /** some javadoc. */
   public void myMethod() {
     class MyMethodClass {}
   }

--- a/src/main/resources/google_checks.xml
+++ b/src/main/resources/google_checks.xml
@@ -338,7 +338,7 @@
     </module>
     <module name="MissingJavadocMethod">
       <property name="scope" value="public"/>
-      <property name="minLineCount" value="2"/>
+      <property name="allowMissingPropertyJavadoc" value="true"/>
       <property name="allowedAnnotations" value="Override, Test"/>
       <property name="tokens" value="METHOD_DEF, CTOR_DEF, ANNOTATION_FIELD_DEF,
                                    COMPACT_CTOR_DEF"/>

--- a/src/xdocs/google_style.xml
+++ b/src/xdocs/google_style.xml
@@ -2382,6 +2382,13 @@
                   <a href="checks/javadoc/missingjavadocmethod.html#MissingJavadocMethod">MissingJavadocMethod</a>
                   <br />
                   <br />
+                  Optional javadoc for "simple, obvious" members is only valid for
+                  getters/setters but they should follow
+                  certain rules mentioned at Check's
+                  <a href="https://checkstyle.org/checks/javadoc/missingjavadocmethod.html#Description">Description</a>
+                  section.
+                  <br />
+                  <br />
                   <span class="wrapper inline">
                     <img
                         src="images/ok_green.png"
@@ -2393,10 +2400,6 @@
                   "protected" methods are not detected for missing javadoc, it will be addressed at:
                   <a href="https://github.com/checkstyle/checkstyle/issues/15434">#15434</a>
                   <br/>
-                  <br/>
-                  Optional javadoc for "simple, obvious" members is not fully supported,
-                  it will be addressed at:
-                  <a href="https://github.com/checkstyle/checkstyle/issues/15414">#15414</a>
                 </td>
                 <td>
                   <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources%20path%3A**%2Fgoogle_checks.xml+repo%3Acheckstyle%2Fcheckstyle+MissingJavadocMethod">


### PR DESCRIPTION
#15414 


removed `minLineCount` property from `MissingJavadocMethod` in google_checks.xml and added usage of `allowMissingPropertyJavadoc`. 

based on new changes tests started failing, public methods which were smaller than 2 lines now requires javadoc, so had to add it to all places.

getter and setter does not require javadoc comments.