### PR TITLE
Issue #15340: created InputFormatted file for section 7.1.1 General Form

### DIFF
--- a/src/it/java/com/google/checkstyle/test/chapter7javadoc/rule711generalform/GeneralFormTest.java
+++ b/src/it/java/com/google/checkstyle/test/chapter7javadoc/rule711generalform/GeneralFormTest.java
@@ -35,4 +35,10 @@ public class GeneralFormTest extends AbstractGoogleModuleTestSupport {
         verifyWithWholeConfig(getPath("InputSingleLineJavadocAndInvalidJavadocPosition.java"));
     }
 
+    @Test
+    public void testSingleLineJavadocAndInvalidJavadocPositionFormatted() throws Exception {
+        verifyWithWholeConfig(
+                getPath("InputFormattedSingleLineJavadocAndInvalidJavadocPosition.java"));
+    }
+
 }

--- a/src/it/resources/com/google/checkstyle/test/chapter7javadoc/rule711generalform/InputFormattedSingleLineJavadocAndInvalidJavadocPosition.java
+++ b/src/it/resources/com/google/checkstyle/test/chapter7javadoc/rule711generalform/InputFormattedSingleLineJavadocAndInvalidJavadocPosition.java
@@ -8,7 +8,7 @@ package // violation 'package statement should not be line-wrapped.'
 import javax.swing.JFrame;
 
 /** some javadoc. */
-public class InputSingleLineJavadocAndInvalidJavadocPosition {
+public class InputFormattedSingleLineJavadocAndInvalidJavadocPosition {
 
   /** As of JDK 1.1, replaced by {@link #setBounds(int,int,int,int)}. */
   void foo1() {}
@@ -16,11 +16,10 @@ public class InputSingleLineJavadocAndInvalidJavadocPosition {
   /** As of JDK 1.1, replaced by {@link #setBounds(int,int,int,int)}. */
   void foo2() {}
 
-  /** @throws CheckstyleException if a problem occurs */
-  // 3 violations above:
-  //  'Javadoc tag '@throws' should be preceded with an empty line.'
-  //  'Single-line Javadoc comment should be multi-line.'
-  //  'Summary javadoc is missing.'
+  // violation below 'Summary javadoc is missing.'
+  /**
+   * @throws CheckstyleException if a problem occurs
+   */
   void foo3() {}
 
   /**
@@ -36,21 +35,19 @@ public class InputSingleLineJavadocAndInvalidJavadocPosition {
   /** An especially short bit of Javadoc. */
   void foo6() {}
 
-  // 3 violations 4 lines below:
-  //  'Javadoc tag '@inheritDoc' should be preceded with an empty line.'
-  //  'Single-line Javadoc comment should be multi-line.'
-  //  'Summary javadoc is missing.'
-  /** @inheritDoc */
+  // violation below 'Summary javadoc is missing.'
+  /**
+   * @inheritDoc
+   */
   void foo7() {}
 
   /** {@inheritDoc} */
   void foo8() {}
 
-  // 3 violations 4 lines below:
-  //  'Javadoc tag '@customTag' should be preceded with an empty line.'
-  //  'Single-line Javadoc comment should be multi-line.'
-  //  'Summary javadoc is missing.'
-  /** @customTag */
+  // violation below 'Summary javadoc is missing.'
+  /**
+   * @customTag
+   */
   void bar() {}
 
   /**
@@ -62,21 +59,19 @@ public class InputSingleLineJavadocAndInvalidJavadocPosition {
    */
   void bar2() {}
 
-  // 3 violations 4 lines below:
-  //  'Javadoc tag '@customTag' should be preceded with an empty line.'
-  //  'Single-line Javadoc comment should be multi-line.'
-  //  'Summary javadoc is missing.'
-  /** @customTag <a> href="https://github.com/checkstyle/checkstyle/"</a>text */
+  // violation below 'Summary javadoc is missing.'
+  /**
+   * @customTag <a> href="https://github.com/checkstyle/checkstyle/"</a>text
+   */
   void bar3() {}
 
   /** Single line Javadoc that references {@link String}. */
   void bar4() {}
 
-  // 3 violations 4 lines below:
-  //  'Javadoc tag '@return' should be preceded with an empty line.'
-  //  'Single-line Javadoc comment should be multi-line.'
-  //  'Summary javadoc is missing.'
-  /** @return in single line javadoc */
+  // violation below 'Summary javadoc is missing.'
+  /**
+   * @return in single line javadoc
+   */
   int bar5() {
     return 0;
   }
@@ -94,16 +89,16 @@ public class InputSingleLineJavadocAndInvalidJavadocPosition {
 // violation below 'Javadoc comment is placed in the wrong location.'
 /** invalid javadoc. */
 /** valid javadoc. */
-class InputInvalidJavadocPosition {
-  // violation above '.* InputInvalidJavadocPosition has to reside in its own source file.'
+class ExtraInputInvalidJavadocPosition {
+  // violation above '.* ExtraInputInvalidJavadocPosition has to reside in its own source file.'
   // violation below 'Javadoc comment is placed in the wrong location.'
   /** invalid javadoc. */
 }
 
 /** valid javadoc. */
 /* ignore */
-class InputInvalidJavadocPosition2 {
-  // violation above '.* InputInvalidJavadocPosition2 has to reside in its own source file.'
+class ExtraInputInvalidJavadocPosition2 {
+  // violation above '.* ExtraInputInvalidJavadocPosition2 has to reside in its own source file.'
   // violation below 'Javadoc comment is placed in the wrong location.'
   /** invalid javadoc. */
   static {
@@ -161,18 +156,28 @@ class InputInvalidJavadocPosition2 {
 
   // violation 2 lines below 'Javadoc comment is placed in the wrong location.'
   void method21
-  /** invalid javadoc. */
-  () {} // violation ''(' should be on the previous line.'
+      /** invalid javadoc. */
+      () {}
+
+  // 2 violations 2 lines above:
+  //  ''method def lparen' has incorrect indentation level 6, expected .* 2.'
+  //  ''(' should be on the previous line.'
 
   // violation 2 lines below 'Javadoc comment is placed in the wrong location.'
   void method22(
-  /** invalid javadoc. */
-  ) {}
+      /** invalid javadoc. */
+      ) {}
 
-  // violation 2 lines below 'Javadoc comment is placed in the wrong location.'
+  // violation 2 lines above ''method def rparen' has incorrect indentation level 6, expected .* 2.'
+
+  // 2 violations 4 lines below:
+  //  '.* indentation should be the same level as line 178.'
+  //  'Javadoc comment is placed in the wrong location.'
   void method23()
-    /** invalid javadoc. */
-    {}
+        /** invalid javadoc. */
+      {}
+
+  // violation 2 lines above ''method def lcurly' has incorrect indentation level 6, expected .* 4.'
 
   // violation 2 lines below 'Javadoc comment is placed in the wrong location.'
   void method24() {
@@ -186,29 +191,32 @@ class InputInvalidJavadocPosition2 {
   }
 }
 
-// violation 2 lines below '.* InputInvalidJavadocPosition3 has to reside in its own source file.'
+// violation 2 lines below '.* has to reside in its own source file.'
 // violation 2 lines below 'Javadoc comment is placed in the wrong location.'
 @Deprecated
 /** invalid javadoc. */
-class InputInvalidJavadocPosition3 {}
+class ExtraInputInvalidJavadocPosition3 {}
 
-// violation 2 lines below '.* InputInvalidJavadocPosition4 has to reside in its own source file.'
+// violation 2 lines below '.* has to reside in its own source file.'
 /** valid javadoc. */
 @Deprecated
-class InputInvalidJavadocPosition4 {}
+class ExtraInputInvalidJavadocPosition4 {}
 
-// violation 2 lines below '.* InputInvalidJavadocPosition5 has to reside in its own source file.'
+// violation 2 lines below '.* has to reside in its own source file.'
 // violation 2 lines below 'Javadoc comment is placed in the wrong location.'
 class
 /** invalid javadoc. */
-InputInvalidJavadocPosition5 {}
-// violation above ''InputInvalidJavadocPosition5' has incorrect indentation .* 0, expected .* 4.'
+ExtraInputInvalidJavadocPosition5 {}
 
-// violation 2 lines below '.* InputInvalidJavadocPosition6 has to reside in its own source file.'
+// violation 2 lines above '.* has incorrect indentation .* 0, expected .* 4.'
+
+// violation 2 lines below '.* has to reside in its own source file.'
 // violation 2 lines below 'Javadoc comment is placed in the wrong location.'
-class InputInvalidJavadocPosition6
-  /** invalid javadoc. */
-  {}
+class ExtraInputInvalidJavadocPosition6
 /** invalid javadoc. */
-// violation 2 lines above''}' at column 4 should be alone on a line.'
-// violation 2 lines above 'Javadoc comment is placed in the wrong location.'
+{}
+/** invalid javadoc. */
+// 2 violations 2 lines above:
+//  ''class def lcurly' has incorrect indentation level 0, expected level should be 2.'
+//  ''}' at column 2 should be alone on a line.'
+// violation 4 lines above 'Javadoc comment is placed in the wrong location.'


### PR DESCRIPTION
#15340

```diff
$ diff -u src/it/resources/com/google/checkstyle/test/chapter7javadoc/rule711generalform/InputSingleLineJavadocAndInvalidJavadocPosition.java src/it/resources/com/google/checkstyle/test/chapter7javadoc/rule711generalform/InputFormattedSingleLineJavadocAndInvalidJavadocPosition.java
--- src/it/resources/com/google/checkstyle/test/chapter7javadoc/rule711generalform/InputSingleLineJavadocAndInvalidJavadocPosition.java 2024-08-31 15:32:12.072778300 +0530
+++ src/it/resources/com/google/checkstyle/test/chapter7javadoc/rule711generalform/InputFormattedSingleLineJavadocAndInvalidJavadocPosition.java        2024-08-31 15:54:48.865630200 +0530
@@ -1,12 +1,14 @@
 package // violation 'package statement should not be line-wrapped.'
-    /** invalid javadoc. */ // violation 'Javadoc comment is placed in the wrong location.'
+    /** invalid javadoc. */
+    // violation above 'Javadoc comment is placed in the wrong location.'
     com.google.checkstyle.test.chapter7javadoc.rule711generalform;
 
-/** invalid javadoc. */ // violation 'Javadoc comment is placed in the wrong location.'
+/** invalid javadoc. */
+// violation above 'Javadoc comment is placed in the wrong location.'
 import javax.swing.JFrame;
 
 /** some javadoc. */
-public class InputSingleLineJavadocAndInvalidJavadocPosition {
+public class InputFormattedSingleLineJavadocAndInvalidJavadocPosition {
 
   /** As of JDK 1.1, replaced by {@link #setBounds(int,int,int,int)}. */
   void foo1() {}
@@ -14,11 +16,10 @@
   /** As of JDK 1.1, replaced by {@link #setBounds(int,int,int,int)}. */
   void foo2() {}
 
-  /** @throws CheckstyleException if a problem occurs */
-  // 3 violations above:
-  //  'Javadoc tag '@throws' should be preceded with an empty line.'
-  //  'Single-line Javadoc comment should be multi-line.'
-  //  'Summary javadoc is missing.'
+  /**
+   * @throws CheckstyleException if a problem occurs
+   */
+  // violation 3 lines above 'Summary javadoc is missing.'
   void foo3() {}
 
   /**
@@ -34,21 +35,19 @@
   /** An especially short bit of Javadoc. */
   void foo6() {}

-  /** @inheritDoc */
-  // 3 violations above:
-  //  'Javadoc tag '@inheritDoc' should be preceded with an empty line.'
-  //  'Single-line Javadoc comment should be multi-line.'
-  //  'Summary javadoc is missing.'
+  /**
+   * @inheritDoc
+   */
+  // violation 3 lines above 'Summary javadoc is missing.'
   void foo7() {}

   /** {@inheritDoc} */
   void foo8() {}

-  /** @customTag */
-  // 3 violations above:
-  //  'Javadoc tag '@customTag' should be preceded with an empty line.'
-  //  'Single-line Javadoc comment should be multi-line.'
-  //  'Summary javadoc is missing.'
+  /**
+   * @customTag
+   */
+  // violation 3 lines above 'Summary javadoc is missing.'
   void bar() {}

   /**
@@ -60,21 +59,19 @@
    */
   void bar2() {}

-  /** @customTag <a> href="https://github.com/checkstyle/checkstyle/"</a>text */
-  // 3 violations above:
-  //  'Javadoc tag '@customTag' should be preceded with an empty line.'
-  //  'Single-line Javadoc comment should be multi-line.'
-  //  'Summary javadoc is missing.'
+  /**
+   * @customTag <a> href="https://github.com/checkstyle/checkstyle/"</a>text
+   */
+  // violation 3 lines above 'Summary javadoc is missing.'
   void bar3() {}

   /** Single line Javadoc that references {@link String}. */
   void bar4() {}

-  /** @return in single line javadoc */
-  // 3 violations above:
-  //  'Javadoc tag '@return' should be preceded with an empty line.'
-  //  'Single-line Javadoc comment should be multi-line.'
-  //  'Summary javadoc is missing.'
+  /**
+   * @return in single line javadoc
+   */
+  // violation 3 lines above 'Summary javadoc is missing.'
   int bar5() {
     return 0;
   }
@@ -89,23 +86,27 @@
   }
 }

-/** invalid javadoc. */ // violation 'Javadoc comment is placed in the wrong location.'
+/** invalid javadoc. */
+// violation above 'Javadoc comment is placed in the wrong location.'
 /** valid javadoc. */
-class InputInvalidJavadocPosition {
-  // violation above '.* InputInvalidJavadocPosition has to reside in its own source file.'
-  /** invalid javadoc. */ // violation 'Javadoc comment is placed in the wrong location.'
+class ExtraInputInvalidJavadocPosition {
+  // violation above '.* ExtraInputInvalidJavadocPosition has to reside in its own source file.'
+  /** invalid javadoc. */
+  // violation above 'Javadoc comment is placed in the wrong location.'
 }

 /** valid javadoc. */
 /* ignore */
-class InputInvalidJavadocPosition2 {
-  // violation above '.* InputInvalidJavadocPosition2 has to reside in its own source file.'
-  /** invalid javadoc. */ // violation 'Javadoc comment is placed in the wrong location.'
+class ExtraInputInvalidJavadocPosition2 {
+  // violation above '.* ExtraInputInvalidJavadocPosition2 has to reside in its own source file.'
+  /** invalid javadoc. */
+  // violation above 'Javadoc comment is placed in the wrong location.'
   static {
     /* ignore */
   }

-  /** invalid javadoc. */ // violation 'Javadoc comment is placed in the wrong location.'
+  /** invalid javadoc. */
+  // violation above 'Javadoc comment is placed in the wrong location.'
   /** valid javadoc. */
   int field1;

@@ -119,13 +120,17 @@
   @Deprecated int field4;

   int
-      /** invalid javadoc. */ // violation 'Javadoc comment is placed in the wrong location.'
+      /** invalid javadoc. */
+      // violation above 'Javadoc comment is placed in the wrong location.'
       field20;
   int field21
-      /** invalid javadoc. */  // violation 'Javadoc comment is placed in the wrong location.'
+      /** invalid javadoc. */
+      // violation above 'Javadoc comment is placed in the wrong location.'
       ;
+
   @Deprecated
-  /** invalid javadoc. */ // violation 'Javadoc comment is placed in the wrong location.'
+  /** invalid javadoc. */
+  // violation above 'Javadoc comment is placed in the wrong location.'
   JFrame frame = new JFrame();

   void method1() {}
@@ -144,49 +149,64 @@
   }

   void
-      /** invalid javadoc. */ // violation 'Javadoc comment is placed in the wrong location.'
+      /** invalid javadoc. */
+      // violation above 'Javadoc comment is placed in the wrong location.'
       method20() {}

   void method21
-      /** invalid javadoc. */ // violation 'Javadoc comment is placed in the wrong location.'
-  () {} // violation ''(' should be on the previous line.'
+      /** invalid javadoc. */
+      // violation above 'Javadoc comment is placed in the wrong location.'
+      () {}
+  // 2 violations above:
+  //  ''method def lparen' has incorrect indentation level 6, expected level should be 2.'
+  //  ''(' should be on the previous line.'

   void method22(
-      /** invalid javadoc. */ // violation 'Javadoc comment is placed in the wrong location.'
-  ) {}
+      /** invalid javadoc. */
+      // violation above 'Javadoc comment is placed in the wrong location.'
+      ) {} // violation ''method def rparen' has incorrect indentation level 6, expected .* 2.'

   void method23()
-      /** invalid javadoc. */ // violation 'Javadoc comment is placed in the wrong location.'
-    {}
+        /** invalid javadoc. */ // violation 'Javadoc .* placed in the wrong location.'
+      {} // violation ''method def lcurly' has incorrect indentation level 6, expected .* 4.'

   void method24() {
-    /** invalid javadoc. */ // violation 'Javadoc comment is placed in the wrong location.'
+    /** invalid javadoc. */
+    // violation above 'Javadoc comment is placed in the wrong location.'
   }

   void method25() {
-    /** invalid javadoc. */ // violation 'Javadoc comment is placed in the wrong location.'
+    /** invalid javadoc. */
+    // violation above 'Javadoc comment is placed in the wrong location.'
     int variable;
   }
 }

-// violation below '.* InputInvalidJavadocPosition3 has to reside in its own source file.'
+// violation below '.* ExtraInputInvalidJavadocPosition3 has to reside in its own source file.'
 @Deprecated
-/** invalid javadoc. */ // violation 'Javadoc comment is placed in the wrong location.'
-class InputInvalidJavadocPosition3 {}
+/** invalid javadoc. */
+// violation above 'Javadoc comment is placed in the wrong location.'
+class ExtraInputInvalidJavadocPosition3 {}

-// violation 2 lines below '.* InputInvalidJavadocPosition4 has to reside in its own source file.'
+// violation 2 lines below '.* has to reside in its own source file.'
 /** valid javadoc. */
 @Deprecated
-class InputInvalidJavadocPosition4 {}
+class ExtraInputInvalidJavadocPosition4 {}

-// violation below '.* InputInvalidJavadocPosition5 has to reside in its own source file.'
+// violation below '.* ExtraInputInvalidJavadocPosition5 has to reside in its own source file.'
 class
-/** invalid javadoc. */ // violation 'Javadoc comment is placed in the wrong location.'
-InputInvalidJavadocPosition5 {}
-// violation above ''InputInvalidJavadocPosition5' has incorrect indentation .*, expected .* 4.'
-
-// violation below '.* InputInvalidJavadocPosition6 has to reside in its own source file.'
-class InputInvalidJavadocPosition6
-/** invalid javadoc. */ // violation 'Javadoc comment is placed in the wrong location.'
-  {} // violation ''}' at column 4 should be alone on a line.'
+/** invalid javadoc. */
+// violation above 'Javadoc comment is placed in the wrong location.'
+ExtraInputInvalidJavadocPosition5 {}
+
+// violation 2 lines above '.* incorrect indentation .*, expected .* 4.'
+
+// violation below '.* ExtraInputInvalidJavadocPosition6 has to reside in its own source file.'
+class ExtraInputInvalidJavadocPosition6
+/** invalid javadoc. */
+// violation above 'Javadoc comment is placed in the wrong location.'
+{}
+// 2 violations above:
+//  ''class def lcurly' has incorrect indentation level 0, expected level should be 2.'
+//  ''}' at column 2 should be alone on a line.'
 /** invalid javadoc. */ // violation 'Javadoc comment is placed in the wrong location.'
```

there were few violations removed.

new violation: `//  ''class def lcurly' has incorrect indentation level 0, expected level should be 2.'`  was added at the end of the file