### PR TITLE
infra: update sbe project to use jdk17 to fix build problem

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -216,7 +216,7 @@ workflows:
           command: "./.ci/validation.sh assembly-run-all-jar"
       - validate-with-maven-script:
           name: "no-error-test-sbe"
-          image-name: *cs_img
+          image-name: "cimg/openjdk:17.0.1"
           command: "./.ci/validation.sh no-error-test-sbe"
       - validate-with-maven-script:
           name: "no-error-spotbugs"


### PR DESCRIPTION
https://app.circleci.com/pipelines/github/checkstyle/checkstyle/27670/workflows/f0ba2fb2-5a67-4c61-91aa-e06efccf88ad/jobs/679943

```
Starting a Gradle Daemon (subsequent builds will be faster)
Executing Gradle on JVM versions 16 and lower has been deprecated. 
This will fail with an error in Gradle 9.0. Use JVM 17 or greater to execute Gradle. 
Projects can continue to use older JVM versions via toolchains. 
Consult the upgrading guide for further information: 
https://docs.gradle.org/8.10/userguide/upgrading_version_8.html#minimum_daemon_jvm_version
	at org.gradle.launcher.exec.RootBuildLifecycleBuildActionExecutor
   .execute(RootBuildLifecycleBuildActionExecutor.java:50)
	
```