### PR TITLE
minor: removed rule485annotations from google-java-format.sh

### DIFF
--- a/.ci/google-java-format.sh
+++ b/.ci/google-java-format.sh
@@ -48,8 +48,6 @@ INPUT_PATHS=($(find src/it/resources/com/google/checkstyle/test/ -name "Input*.j
     | grep -v "rule487modifiers/InputModifierOrder.java" \
     | grep -v "rule4821onevariableperline/InputOneVariablePerDeclaration.java" \
     | grep -v "rule4841indentation/ClassWithChainedMethods.java" \
-    | grep -v "rule485annotations/InputAnnotationLocation.java" \
-    | grep -v "rule485annotations/InputAnnotationLocationVariables.java" \
     | grep -v "rule4852classannotations/InputClassAnnotations.java" \
     | grep -v "rule4853methods.*/InputMethodsAndConstructorsAnnotations.java" \
     | grep -v "rule4854fieldannotations/InputFieldAnnotations.java" \


### PR DESCRIPTION
follow up of https://github.com/checkstyle/checkstyle/pull/15600

removed rule485annotations from google-java-format.sh