### PR TITLE
supplemental: removed regex usage from google-java-format.sh

### DIFF
--- a/.ci/google-java-format.sh
+++ b/.ci/google-java-format.sh
@@ -48,9 +48,12 @@ INPUT_PATHS=($(find src/it/resources/com/google/checkstyle/test/ -name "Input*.j
     | grep -v "rule4821onevariableperline/InputOneVariablePerDeclaration.java" \
     | grep -v "rule4841indentation/InputClassWithChainedMethods.java" \
     | grep -v "rule4852classannotations/InputClassAnnotations.java" \
-    | grep -v "rule4853methods.*/InputMethodsAndConstructorsAnnotations.java" \
+    | grep -v "rule4853methodsandconstructorsannotations/InputMethodsAndConstructorsAnnotations.java" \
     | grep -v "rule4854fieldannotations/InputFieldAnnotations.java" \
-    | grep -v "rule4861blockcommentstyle/InputCommentsIndentation.*.java" \
+    | grep -v "rule4861blockcommentstyle/InputCommentsIndentationCommentIsAtTheEndOfBlock.java" \
+    | grep -v "rule4861blockcommentstyle/InputCommentsIndentationInEmptyBlock.java" \
+    | grep -v "rule4861blockcommentstyle/InputCommentsIndentationInSwitchBlock.java" \
+    | grep -v "rule4861blockcommentstyle/InputCommentsIndentationSurroundingCode.java" \
     | grep -v "rule3sourcefile/InputSourceFileStructure.java" \
     | grep -v "rule332nolinewrap/InputNoLineWrapping.java" \
     | grep -v "rule333orderingandspacing/InputOrderingAndSpacing1.java" \

--- a/config/checkstyle-non-main-files-suppressions.xml
+++ b/config/checkstyle-non-main-files-suppressions.xml
@@ -172,6 +172,8 @@
   <suppress id="properCurlCommand" files=".ci[\\/]validation\.sh"/>
   <!-- other images that do not support newer curl commands -->
   <suppress id="properCurlCommand" files=".ci[\\/]sonar-break-build\.sh"/>
+  <!-- a grepped command is crossing the linelength limit -->
+  <suppress id="lineLength" files=".ci[\\/]google-java-format\.sh"/>
 
   <!-- We use negative suppression to check workflow files only. -->
   <suppress id="workflowJobStepSpacing" files="^.((?!github[\\/]workflows[\\/]).)*$" />


### PR DESCRIPTION
Detected at: https://github.com/checkstyle/checkstyle/actions/runs/10683811066/job/29612742864?pr=15558

> Create InputFormattedCommentsIndentation.java for InputCommentsIndentation.java

the grepped file was like:

```
    | grep -v "rule4861blockcommentstyle/InputCommentsIndentation.*.java" \
```

`.*` was causing CI failure so had to remove it. Removed all occurrence of `.*` from the file, some line was crossing linelength limit so had to add suppression for it.