### PR TITLE
Issue #15434: fixed MissingJavadocMethod module in google_checks.xml to give warning for missing javadoc for protected methods

### DIFF
--- a/src/it/resources/com/google/checkstyle/test/chapter4formatting/rule4822declaredwhenneeded/InputDeclaredWhenNeeded.java
+++ b/src/it/resources/com/google/checkstyle/test/chapter4formatting/rule4822declaredwhenneeded/InputDeclaredWhenNeeded.java
@@ -353,6 +353,7 @@ public class InputDeclaredWhenNeeded {
     }
   }
 
+  /** Some javadoc. */
   protected JmenuItem createSubMenuItem(LogLevel level) {
     final JmenuItem result = new JmenuItem(level.toString());
     final LogLevel logLevel = level;

--- a/src/it/resources/com/google/checkstyle/test/chapter7javadoc/rule731selfexplanatory/InputJavadocMethodAndMissingJavadocMethod.java
+++ b/src/it/resources/com/google/checkstyle/test/chapter7javadoc/rule731selfexplanatory/InputJavadocMethodAndMissingJavadocMethod.java
@@ -62,7 +62,7 @@ public class InputJavadocMethodAndMissingJavadocMethod extends OverrideClasss {
     foo2();
   }
 
-  // ok, methods smaller than 2 lines does not require javadoc
+  /** some javadoc. */
   protected void smallMethod2() {
     foo2();
   }

--- a/src/it/resources/com/google/checkstyle/test/chapter7javadoc/rule732exceptionoverrides/InputJavadocMethodAndMissingJavadocMethod.java
+++ b/src/it/resources/com/google/checkstyle/test/chapter7javadoc/rule732exceptionoverrides/InputJavadocMethodAndMissingJavadocMethod.java
@@ -62,7 +62,7 @@ public class InputJavadocMethodAndMissingJavadocMethod extends OverrideClass {
     foo2();
   }
 
-  // ok, methods smaller than 2 lines does not require javadoc
+  /** some javadoc. */
   protected void smallMethod2() {
     foo2();
   }

--- a/src/it/resources/com/google/checkstyle/test/chapter7javadoc/rule73wherejavadocrequired/InputJavadocMethodAndMissingJavadocMethod.java
+++ b/src/it/resources/com/google/checkstyle/test/chapter7javadoc/rule73wherejavadocrequired/InputJavadocMethodAndMissingJavadocMethod.java
@@ -62,7 +62,7 @@ public class InputJavadocMethodAndMissingJavadocMethod extends OverrideClass {
     foo2();
   }
 
-  // ok, methods smaller than 2 lines does not require javadoc
+  /** some javadoc. */
   protected void smallMethod2() {
     foo2();
   }

--- a/src/it/resources/com/google/checkstyle/test/chapter7javadoc/rule73wherejavadocrequired/InputMissingJavadocTypeCorrect.java
+++ b/src/it/resources/com/google/checkstyle/test/chapter7javadoc/rule73wherejavadocrequired/InputMissingJavadocTypeCorrect.java
@@ -6,7 +6,13 @@ public class InputMissingJavadocTypeCorrect {
   int myOtherInt;
 
   /** This is a Javadoc comment. */
-  public class InnerPublic implements MyInterfacePublic {}
+  public class InnerPublic implements MyInterfacePublic2 {
+    @Override
+    public void testPublicInterfaceMethod() {}
+
+    @Override
+    public void testPackagePrivateInterfaceMethod() {}
+  }
 
   /** This is a Javadoc comment. */
   public enum MyEnumPublic {}
@@ -22,16 +28,9 @@ public class InputMissingJavadocTypeCorrect {
   public @interface MyAnnotationPublic {}
 
   /** This is a Javadoc comment. */
-  protected class InnerProtected {}
-
-  /** This is a Javadoc comment. */
-  protected enum MyEnumProtected {}
-
-  /** This is a Javadoc comment. */
-  protected interface MyInterfaceProtected {}
-
-  /** This is a Javadoc comment. */
   protected @interface MyAnnotationProtected {}
+
+  @interface MyAnnotationPackagePrivate {}
 
   class Inner {}
 
@@ -52,5 +51,113 @@ public class InputMissingJavadocTypeCorrect {
   /** some javadoc. */
   public void myMethod() {
     class MyMethodClass {}
+  }
+
+  /** some javadoc. */
+  protected int testProtectedMethod1() {
+    return 0;
+  }
+
+  /** some javadoc. */
+  protected void testProtectedMethod2() {}
+
+  /** some javadoc. */
+  public void testPublicMethod() {}
+
+  private void testPrivateMethod() {}
+
+  void testPackagePrivateMethod() {}
+
+  /** some javadoc. */
+  protected InputMissingJavadocTypeCorrect() {}
+
+  /** some javadoc. */
+  public InputMissingJavadocTypeCorrect(String arg) {}
+
+  private InputMissingJavadocTypeCorrect(int arg) {}
+
+  InputMissingJavadocTypeCorrect(double arg) {}
+
+  /** some javadoc. */
+  protected @interface ProtectedAnnotation {}
+
+  /** some javadoc. */
+  public @interface PublicAnnotation {}
+
+  private @interface PrivateAnnotation {}
+
+  @interface PackagePrivateAnnotation {}
+
+  /** some javadoc. */
+  protected class InnerProtected {
+    protected void testProtectedInnerMethod() {}
+
+    public void testPublicInnerMethod() {}
+
+    private void testPrivateInnerMethod() {}
+
+    void testPackagePrivateInnerMethod() {}
+
+    protected InnerProtected() {}
+
+    InnerProtected(String arg) {}
+
+    private InnerProtected(double arg) {}
+  }
+
+  /** some javadoc. */
+  public enum MyEnumPublic2 {
+    TEST;
+
+    /** some javadoc. */
+    public void testPublicEnumMethod() {}
+
+    /** some javadoc. */
+    protected void testProtectedEnumMethod() {}
+
+    private void testPrivateEnumMethod() {}
+
+    void testPackagePrivateEnumMethod() {}
+
+    private MyEnumPublic2() {}
+
+    MyEnumPublic2(String arg) {}
+  }
+
+  /** some javadoc. */
+  protected enum MyEnumProtected {
+    TEST;
+
+    public void testPublicEnumMethod() {}
+
+    protected void testProtectedEnumMethod() {}
+
+    private void testPrivateEnumMethod() {}
+
+    void testPackagePrivateEnumMethod() {}
+
+    private MyEnumProtected() {}
+
+    MyEnumProtected(String arg) {}
+  }
+
+  /** some javadoc. */
+  protected interface MyInterfaceProtected {
+    public void testPublicInterfaceMethod();
+
+    private void testPrivateInterfaceMethod() {}
+
+    void testPackagePrivateInterfaceMethod();
+  }
+
+  /** some javadoc. */
+  public interface MyInterfacePublic2 {
+    /** some javadoc. */
+    public void testPublicInterfaceMethod();
+
+    private void testPrivateInterfaceMethod() {}
+
+    /** some javadoc. */
+    void testPackagePrivateInterfaceMethod();
   }
 }

--- a/src/it/resources/com/google/checkstyle/test/chapter7javadoc/rule73wherejavadocrequired/InputMissingJavadocTypeIncorrect.java
+++ b/src/it/resources/com/google/checkstyle/test/chapter7javadoc/rule73wherejavadocrequired/InputMissingJavadocTypeIncorrect.java
@@ -1,37 +1,144 @@
 package com.google.checkstyle.test.chapter7javadoc.rule73wherejavadocrequired;
 
-public class InputMissingJavadocTypeIncorrect { // violation 'Missing a Javadoc comment.'
+// violation below 'Missing a Javadoc comment.'
+public class InputMissingJavadocTypeIncorrect {
 
-  public class Inner { // violation 'Missing a Javadoc comment.'
+  // violation below 'Missing a Javadoc comment.'
+  public class InnerPublic implements MyInterfacePublic {
+    @Override
+    public void testPublicInterfaceMethod() {}
+
+    @Override
+    public void testPackagePrivateInterfaceMethod() {}
   }
 
-  public enum MyEnum { // violation 'Missing a Javadoc comment.'
+  // violation below 'Missing a Javadoc comment.'
+  public enum MyEnum {}
+
+  // violation below 'Missing a Javadoc comment.'
+  public interface MyInterface {
+    // violation below 'Missing a Javadoc comment.'
+    class MyInterfaceClass {}
   }
 
-  public interface MyInterface { // violation 'Missing a Javadoc comment.'
-    class MyInterfaceClass {} // violation 'Missing a Javadoc comment.'
-  }
+  // violation below 'Missing a Javadoc comment.'
+  public @interface MyAnnotation {}
 
-  public @interface MyAnnotation { // violation 'Missing a Javadoc comment.'
-  }
-
-  protected class InnerProtected { // violation 'Missing a Javadoc comment.'
-  }
-
-  protected enum MyEnumProtected { // violation 'Missing a Javadoc comment.'
-  }
-
-  protected interface MyInterfaceProtected { // violation 'Missing a Javadoc comment.'
-  }
-
-  protected @interface MyAnnotationProtected { // violation 'Missing a Javadoc comment.'
-  }
+  // violation below 'Missing a Javadoc comment.'
+  protected @interface MyAnnotationProtected {}
 
   /** some javadoc. */
   public void myMethod() {
     class MyMethodClass {}
   }
 
-  class AdditionalClass { // OK, not public
+  // OK, not public
+  class AdditionalClass {}
+
+  // violation below 'Missing a Javadoc comment.'
+  protected int testProtectedMethod1() {
+    return 0;
+  }
+
+  // violation below 'Missing a Javadoc comment.'
+  protected void testProtectedMethod2() {}
+
+  // violation below 'Missing a Javadoc comment.'
+  protected InputMissingJavadocTypeIncorrect() {}
+
+  // violation below 'Missing a Javadoc comment.'
+  public class InnerClass {
+    // violation below 'Missing a Javadoc comment.'
+    public void testPublicInnerMethod() {}
+
+    // violation below 'Missing a Javadoc comment.'
+    protected void testProtectedInnerMethod() {}
+
+    private void testPrivateInnerMethod() {}
+
+    void testPackagePrivateInnerMethod() {}
+
+    // violation below 'Missing a Javadoc comment.'
+    public InnerClass(int arg) {}
+
+    // violation below 'Missing a Javadoc comment.'
+    protected InnerClass() {}
+
+    InnerClass(String arg) {}
+
+    private InnerClass(double arg) {}
+  }
+
+  // violation below 'Missing a Javadoc comment.'
+  protected class InnerProtected {
+    protected void testProtectedInnerMethod() {}
+
+    public void testPublicInnerMethod() {}
+
+    private void testPrivateInnerMethod() {}
+
+    void testPackagePrivateInnerMethod() {}
+
+    protected InnerProtected() {}
+
+    InnerProtected(String arg) {}
+
+    private InnerProtected(double arg) {}
+  }
+
+  // violation below 'Missing a Javadoc comment.'
+  public enum MyEnumPublic {
+    TEST;
+
+    // violation below 'Missing a Javadoc comment.'
+    public void testPublicEnumMethod() {}
+
+    // violation below 'Missing a Javadoc comment.'
+    protected void testProtectedEnumMethod() {}
+
+    private void testPrivateEnumMethod() {}
+
+    void testPackagePrivateEnumMethod() {}
+
+    private MyEnumPublic() {}
+
+    MyEnumPublic(String arg) {}
+  }
+
+  // violation below 'Missing a Javadoc comment.'
+  protected enum MyEnumProtected {
+    TEST;
+
+    public void testPublicEnumMethod() {}
+
+    protected void testProtectedEnumMethod() {}
+
+    private void testPrivateEnumMethod() {}
+
+    void testPackagePrivateEnumMethod() {}
+
+    private MyEnumProtected() {}
+
+    MyEnumProtected(String arg) {}
+  }
+
+  // violation below 'Missing a Javadoc comment.'
+  protected interface MyInterfaceProtected {
+    public void testPublicInterfaceMethod();
+
+    private void testPrivateInterfaceMethod() {}
+
+    void testPackagePrivateInterfaceMethod();
+  }
+
+  // violation below 'Missing a Javadoc comment.'
+  public interface MyInterfacePublic {
+    // violation below 'Missing a Javadoc comment.'
+    public void testPublicInterfaceMethod();
+
+    private void testPrivateInterfaceMethod() {}
+
+    // violation below 'Missing a Javadoc comment.'
+    void testPackagePrivateInterfaceMethod();
   }
 }

--- a/src/main/resources/google_checks.xml
+++ b/src/main/resources/google_checks.xml
@@ -347,11 +347,19 @@
       <property name="tokens" value="METHOD_DEF, CTOR_DEF, ANNOTATION_FIELD_DEF, COMPACT_CTOR_DEF"/>
     </module>
     <module name="MissingJavadocMethod">
-      <property name="scope" value="public"/>
+      <property name="scope" value="protected"/>
       <property name="allowMissingPropertyJavadoc" value="true"/>
       <property name="allowedAnnotations" value="Override, Test"/>
       <property name="tokens" value="METHOD_DEF, CTOR_DEF, ANNOTATION_FIELD_DEF,
                                    COMPACT_CTOR_DEF"/>
+    </module>
+    <module name="SuppressionXpathSingleFilter">
+      <property name="checks" value="MissingJavadocMethod"/>
+      <property name="query" value="//*[self::METHOD_DEF or self::CTOR_DEF
+                                 or self::ANNOTATION_FIELD_DEF or self::COMPACT_CTOR_DEF]
+                                 [ancestor::*[self::INTERFACE_DEF or self::CLASS_DEF
+                                 or self::RECORD_DEF or self::ENUM_DEF]
+                                 [not(./MODIFIERS/LITERAL_PUBLIC)]]"/>
     </module>
     <module name="MissingJavadocType">
       <property name="scope" value="protected"/>

--- a/src/xdocs/google_style.xml
+++ b/src/xdocs/google_style.xml
@@ -2399,11 +2399,6 @@
                         alt="" />
                   </span>
                   <a href="checks/javadoc/javadocmethod.html#JavadocMethod">JavadocMethod</a>
-                  <br/>
-                  <br/>
-                  "protected" methods are not detected for missing javadoc, it will be addressed at:
-                  <a href="https://github.com/checkstyle/checkstyle/issues/15434">#15434</a>
-                  <br/>
                 </td>
                 <td>
                   <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources%20path%3A**%2Fgoogle_checks.xml+repo%3Acheckstyle%2Fcheckstyle+MissingJavadocMethod">


### PR DESCRIPTION
#15434 


From style guide: 

> At the minimum, Javadoc is present for every public class, and every public or protected member of such a class, with a few exceptions noted below.


We're required to give warning for every public/protected members of a public class but as per changes made in google_checls.xml in this PR, we're giving warning for all public/protected members of a public class as well as for all public/protected members of a protected class too, which we doesn't want.

I'm not sure how we can solve this problem. @romani looking for your help here

Diff Regression config: https://gist.githubusercontent.com/Zopsss/eef363a452104d034a9ce7be532f647d/raw/01ec2b9c4cd7afd4fb508acccf1605b57767edc0/master_google_checks.xml

Diff Regression patch config: https://gist.githubusercontent.com/Zopsss/40bbda26eff022ac495900de8931e9d9/raw/2d55e2a6fb2003129b89a86007d245c6c25d74f2/protected_methods_google_checks.xml

Diff Regression projects: https://gist.githubusercontent.com/Zopsss/9960953f88e763d31eea3a14447b861f/raw/edfd96ea7a5757cea2e08856be98776cbb21a171/guava-project.properties