### PR TITLE
Issue #15456: Specify violation messages for AnnotationOnSameLineCheck

### DIFF
--- a/src/test/java/com/puppycrawl/tools/checkstyle/bdd/InlineConfigParser.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/bdd/InlineConfigParser.java
@@ -204,7 +204,6 @@ public final class InlineConfigParser {
      *  Until <a href="https://github.com/checkstyle/checkstyle/issues/15456">#15456</a>.
      */
     private static final Set<String> SUPPRESSED_CHECKS = Set.of(
-            "com.puppycrawl.tools.checkstyle.checks.annotation.AnnotationOnSameLineCheck",
             "com.puppycrawl.tools.checkstyle.checks.annotation.PackageAnnotationCheck",
             "com.puppycrawl.tools.checkstyle.checks.annotation.SuppressWarningsCheck",
             "com.puppycrawl.tools.checkstyle.checks.ArrayTypeStyleCheck",

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/annotation/AnnotationOnSameLineCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/annotation/AnnotationOnSameLineCheckTest.java
@@ -75,10 +75,10 @@ public class AnnotationOnSameLineCheckTest extends AbstractModuleTestSupport {
     @Test
     public void testAnnotationOnSameLineCheckPublicMethodAndVariable() throws Exception {
         final String[] expected = {
-            "17:5: " + getCheckMessage(MSG_KEY_ANNOTATION_ON_SAME_LINE, "Annotation"),
-            "18:5: " + getCheckMessage(MSG_KEY_ANNOTATION_ON_SAME_LINE, "Annotation"),
-            "19:5: " + getCheckMessage(MSG_KEY_ANNOTATION_ON_SAME_LINE, "Deprecated"),
-            "24:18: " + getCheckMessage(MSG_KEY_ANNOTATION_ON_SAME_LINE, "Annotation"),
+            "20:5: " + getCheckMessage(MSG_KEY_ANNOTATION_ON_SAME_LINE, "Annotation"),
+            "21:5: " + getCheckMessage(MSG_KEY_ANNOTATION_ON_SAME_LINE, "Annotation"),
+            "22:5: " + getCheckMessage(MSG_KEY_ANNOTATION_ON_SAME_LINE, "Deprecated"),
+            "28:18: " + getCheckMessage(MSG_KEY_ANNOTATION_ON_SAME_LINE, "Annotation"),
         };
         verifyWithInlineConfigParser(
                 getPath("InputAnnotationOnSameLineCheckPublicMethodAndVariable.java"), expected);
@@ -87,10 +87,10 @@ public class AnnotationOnSameLineCheckTest extends AbstractModuleTestSupport {
     @Test
     public void testAnnotationOnSameLineCheckTokensOnMethodAndVar() throws Exception {
         final String[] expected = {
-            "18:5: " + getCheckMessage(MSG_KEY_ANNOTATION_ON_SAME_LINE, "Annotation3"),
-            "19:5: " + getCheckMessage(MSG_KEY_ANNOTATION_ON_SAME_LINE, "Annotation"),
-            "20:5: " + getCheckMessage(MSG_KEY_ANNOTATION_ON_SAME_LINE, "Deprecated"),
-            "25:18: " + getCheckMessage(MSG_KEY_ANNOTATION_ON_SAME_LINE, "Annotation3"),
+            "20:5: " + getCheckMessage(MSG_KEY_ANNOTATION_ON_SAME_LINE, "Annotation3"),
+            "21:5: " + getCheckMessage(MSG_KEY_ANNOTATION_ON_SAME_LINE, "Annotation"),
+            "22:5: " + getCheckMessage(MSG_KEY_ANNOTATION_ON_SAME_LINE, "Deprecated"),
+            "28:18: " + getCheckMessage(MSG_KEY_ANNOTATION_ON_SAME_LINE, "Annotation3"),
         };
         verifyWithInlineConfigParser(
                 getPath("InputAnnotationOnSameLineCheckTokensOnMethodAndVar.java"), expected);
@@ -100,9 +100,9 @@ public class AnnotationOnSameLineCheckTest extends AbstractModuleTestSupport {
     public void testAnnotationOnSameLineCheckPrivateAndDeprecatedVar() throws Exception {
         final String[] expected = {
             "19:5: " + getCheckMessage(MSG_KEY_ANNOTATION_ON_SAME_LINE, "Ann"),
-            "24:5: " + getCheckMessage(MSG_KEY_ANNOTATION_ON_SAME_LINE, "SuppressWarnings"),
-            "27:5: " + getCheckMessage(MSG_KEY_ANNOTATION_ON_SAME_LINE, "SuppressWarnings"),
-            "28:5: " + getCheckMessage(MSG_KEY_ANNOTATION_ON_SAME_LINE, "Ann"),
+            "25:5: " + getCheckMessage(MSG_KEY_ANNOTATION_ON_SAME_LINE, "SuppressWarnings"),
+            "29:5: " + getCheckMessage(MSG_KEY_ANNOTATION_ON_SAME_LINE, "SuppressWarnings"),
+            "30:5: " + getCheckMessage(MSG_KEY_ANNOTATION_ON_SAME_LINE, "Ann"),
         };
         verifyWithInlineConfigParser(
                 getPath("InputAnnotationOnSameLineCheckPrivateAndDeprecatedVar.java"), expected);
@@ -114,19 +114,19 @@ public class AnnotationOnSameLineCheckTest extends AbstractModuleTestSupport {
             "14:1: " + getCheckMessage(MSG_KEY_ANNOTATION_ON_SAME_LINE, "Ann"),
             "17:5: " + getCheckMessage(MSG_KEY_ANNOTATION_ON_SAME_LINE, "Ann"),
             "21:8: " + getCheckMessage(MSG_KEY_ANNOTATION_ON_SAME_LINE, "Ann"),
-            "22:71: " + getCheckMessage(MSG_KEY_ANNOTATION_ON_SAME_LINE, "Ann"),
-            "25:5: " + getCheckMessage(MSG_KEY_ANNOTATION_ON_SAME_LINE, "Ann"),
-            "26:35: " + getCheckMessage(MSG_KEY_ANNOTATION_ON_SAME_LINE, "Ann"),
-            "29:18: " + getCheckMessage(MSG_KEY_ANNOTATION_ON_SAME_LINE, "Ann"),
-            "32:5: " + getCheckMessage(MSG_KEY_ANNOTATION_ON_SAME_LINE, "Ann"),
-            "37:5: " + getCheckMessage(MSG_KEY_ANNOTATION_ON_SAME_LINE, "Ann"),
-            "40:5: " + getCheckMessage(MSG_KEY_ANNOTATION_ON_SAME_LINE, "Ann"),
-            "41:28: " + getCheckMessage(MSG_KEY_ANNOTATION_ON_SAME_LINE, "Ann"),
-            "42:33: " + getCheckMessage(MSG_KEY_ANNOTATION_ON_SAME_LINE, "Ann"),
-            "44:15: " + getCheckMessage(MSG_KEY_ANNOTATION_ON_SAME_LINE, "Ann"),
-            "50:17: " + getCheckMessage(MSG_KEY_ANNOTATION_ON_SAME_LINE, "Ann"),
-            "59:1: " + getCheckMessage(MSG_KEY_ANNOTATION_ON_SAME_LINE, "Ann"),
-            "62:5: " + getCheckMessage(MSG_KEY_ANNOTATION_ON_SAME_LINE, "Ann"),
+            "23:71: " + getCheckMessage(MSG_KEY_ANNOTATION_ON_SAME_LINE, "Ann"),
+            "26:5: " + getCheckMessage(MSG_KEY_ANNOTATION_ON_SAME_LINE, "Ann"),
+            "27:35: " + getCheckMessage(MSG_KEY_ANNOTATION_ON_SAME_LINE, "Ann"),
+            "31:18: " + getCheckMessage(MSG_KEY_ANNOTATION_ON_SAME_LINE, "Ann"),
+            "34:5: " + getCheckMessage(MSG_KEY_ANNOTATION_ON_SAME_LINE, "Ann"),
+            "39:5: " + getCheckMessage(MSG_KEY_ANNOTATION_ON_SAME_LINE, "Ann"),
+            "43:5: " + getCheckMessage(MSG_KEY_ANNOTATION_ON_SAME_LINE, "Ann"),
+            "45:28: " + getCheckMessage(MSG_KEY_ANNOTATION_ON_SAME_LINE, "Ann"),
+            "47:33: " + getCheckMessage(MSG_KEY_ANNOTATION_ON_SAME_LINE, "Ann"),
+            "50:15: " + getCheckMessage(MSG_KEY_ANNOTATION_ON_SAME_LINE, "Ann"),
+            "56:17: " + getCheckMessage(MSG_KEY_ANNOTATION_ON_SAME_LINE, "Ann"),
+            "65:1: " + getCheckMessage(MSG_KEY_ANNOTATION_ON_SAME_LINE, "Ann"),
+            "68:5: " + getCheckMessage(MSG_KEY_ANNOTATION_ON_SAME_LINE, "Ann"),
         };
         verifyWithInlineConfigParser(
                 getPath("InputAnnotationOnSameLineCheckInterfaceAndEnum.java"), expected);
@@ -136,13 +136,13 @@ public class AnnotationOnSameLineCheckTest extends AbstractModuleTestSupport {
     public void testAnnotationOnSameLineRecordsAndCompactCtors() throws Exception {
         final String[] expected = {
             "13:5: " + getCheckMessage(MSG_KEY_ANNOTATION_ON_SAME_LINE, "NonNull1"),
-            "17:5: " + getCheckMessage(MSG_KEY_ANNOTATION_ON_SAME_LINE, "SuppressWarnings"),
-            "22:5: " + getCheckMessage(MSG_KEY_ANNOTATION_ON_SAME_LINE, "SuppressWarnings"),
-            "27:9: " + getCheckMessage(MSG_KEY_ANNOTATION_ON_SAME_LINE, "SuppressWarnings"),
-            "32:5: " + getCheckMessage(MSG_KEY_ANNOTATION_ON_SAME_LINE, "SuppressWarnings"),
-            "35:27: " + getCheckMessage(MSG_KEY_ANNOTATION_ON_SAME_LINE, "SuppressWarnings"),
-            "44:5: " + getCheckMessage(MSG_KEY_ANNOTATION_ON_SAME_LINE, "SuppressWarnings"),
-            "50:5: " + getCheckMessage(MSG_KEY_ANNOTATION_ON_SAME_LINE, "SuppressWarnings"),
+            "18:5: " + getCheckMessage(MSG_KEY_ANNOTATION_ON_SAME_LINE, "SuppressWarnings"),
+            "24:5: " + getCheckMessage(MSG_KEY_ANNOTATION_ON_SAME_LINE, "SuppressWarnings"),
+            "29:9: " + getCheckMessage(MSG_KEY_ANNOTATION_ON_SAME_LINE, "SuppressWarnings"),
+            "35:5: " + getCheckMessage(MSG_KEY_ANNOTATION_ON_SAME_LINE, "SuppressWarnings"),
+            "38:27: " + getCheckMessage(MSG_KEY_ANNOTATION_ON_SAME_LINE, "SuppressWarnings"),
+            "49:5: " + getCheckMessage(MSG_KEY_ANNOTATION_ON_SAME_LINE, "SuppressWarnings"),
+            "56:5: " + getCheckMessage(MSG_KEY_ANNOTATION_ON_SAME_LINE, "SuppressWarnings"),
         };
         verifyWithInlineConfigParser(
                 getNonCompilablePath("InputAnnotationOnSameLineRecordsAndCompactCtors.java"),

--- a/src/test/java/com/puppycrawl/tools/checkstyle/internal/AllTestsTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/internal/AllTestsTest.java
@@ -49,7 +49,7 @@ public class AllTestsTest {
     public void testAllInputsHaveTest() throws Exception {
         final Map<String, List<String>> allTests = new HashMap<>();
 
-        walk(Paths.get("src/test/java"), filePath -> {
+        walkVisible(Paths.get("src/test/java"), filePath -> {
             grabAllTests(allTests, filePath.toFile());
         });
 
@@ -57,10 +57,10 @@ public class AllTestsTest {
             .that(allTests.keySet())
             .isNotEmpty();
 
-        walk(Paths.get("src/test/resources/com/puppycrawl"), filePath -> {
+        walkVisible(Paths.get("src/test/resources/com/puppycrawl"), filePath -> {
             verifyInputFile(allTests, filePath.toFile());
         });
-        walk(Paths.get("src/test/resources-noncompilable/com/puppycrawl"), filePath -> {
+        walkVisible(Paths.get("src/test/resources-noncompilable/com/puppycrawl"), filePath -> {
             verifyInputFile(allTests, filePath.toFile());
         });
     }
@@ -69,7 +69,7 @@ public class AllTestsTest {
     public void testAllTestsHaveProductionCode() throws Exception {
         final Map<String, List<String>> allTests = new HashMap<>();
 
-        walk(Paths.get("src/main/java"), filePath -> {
+        walkVisible(Paths.get("src/main/java"), filePath -> {
             grabAllFiles(allTests, filePath.toFile());
         });
 
@@ -77,14 +77,29 @@ public class AllTestsTest {
             .that(allTests.keySet())
             .isNotEmpty();
 
-        walk(Paths.get("src/test/java"), filePath -> {
+        walkVisible(Paths.get("src/test/java"), filePath -> {
             verifyHasProductionFile(allTests, filePath.toFile());
         });
     }
 
-    private static void walk(Path path, Consumer<Path> action) throws IOException {
+    /**
+     * Walks through the file tree rooted at the specified path and performs the given action
+     * on each visible (non-hidden) file path.
+     *
+     * <p>This method recursively traverses the directory tree starting from the specified
+     * {@code path}. It filters out hidden files and directories before applying the provided
+     * {@code action} to each visible file path. The definition of what constitutes a hidden
+     * file or directory is operating system dependent, and this method uses the underlying
+     * file system's criteria for hidden files.</p>
+     *
+     * @param path   the starting path for the file tree traversal
+     * @param action the action to be performed on each visible file path
+     * @throws IOException if an I/O error occurs while accessing the file system
+     */
+    private static void walkVisible(Path path, Consumer<Path> action) throws IOException {
         try (Stream<Path> walk = Files.walk(path)) {
-            walk.forEach(action);
+            walk.filter(filePath -> !filePath.toFile().isHidden())
+                .forEach(action);
         }
     }
 

--- a/src/test/resources-noncompilable/com/puppycrawl/tools/checkstyle/checks/annotation/annotationonsameline/InputAnnotationOnSameLineRecordsAndCompactCtors.java
+++ b/src/test/resources-noncompilable/com/puppycrawl/tools/checkstyle/checks/annotation/annotationonsameline/InputAnnotationOnSameLineRecordsAndCompactCtors.java
@@ -10,29 +10,33 @@ tokens = (default)CLASS_DEF, INTERFACE_DEF, ENUM_DEF, METHOD_DEF, CTOR_DEF, \
 package com.puppycrawl.tools.checkstyle.checks.annotation.annotationonsameline;
 
 public class InputAnnotationOnSameLineRecordsAndCompactCtors {
-    @NonNull1 // violation
+    @NonNull1 // violation, "Annotation 'NonNull1' should be on the same line with its target."
     public record MyRecord1() {
     }
 
-    @SuppressWarnings("deprecation") // violation
+    // violation below, "Annotation 'SuppressWarnings' should be on the same line with its target."
+    @SuppressWarnings("deprecation")
 
     public record MyRecord2() {
     }
 
-    @SuppressWarnings("deprecation") // violation
+    // violation below, "Annotation 'SuppressWarnings' should be on the same line with its target."
+    @SuppressWarnings("deprecation")
             record MyRecord3() {
     }
-
     @SuppressWarnings("deprecation") public record MyRecord4() {
-        @SuppressWarnings("deprecation") // violation
+    // violation below, "Annotation 'SuppressWarnings' should be on the same line with its target."
+        @SuppressWarnings("deprecation")
         public MyRecord4 {
         }
     }
 
-    @SuppressWarnings("deprecation") // violation
+    // violation below, "Annotation 'SuppressWarnings' should be on the same line with its target."
+    @SuppressWarnings("deprecation")
     public record MyRecord5() {
         record MyInnerRecord() {
-                @NonNull1 @SuppressWarnings("Annotation") // violation
+                @NonNull1 @SuppressWarnings("Annotation")
+    // violation above, "Annotation 'SuppressWarnings' should be on the same line with its target."
             public MyInnerRecord {
             }
         }
@@ -41,13 +45,15 @@ public class InputAnnotationOnSameLineRecordsAndCompactCtors {
     /**
      * @return
      */
-    @SuppressWarnings("deprecation") // violation
+    // violation below, "Annotation 'SuppressWarnings' should be on the same line with its target."
+    @SuppressWarnings("deprecation")
     public record MyRecord6() {
         record MyInnerRecord() {@SuppressWarnings("Annotation")public MyInnerRecord {}
         }
     }
 
-    @SuppressWarnings("deprecation") // violation
+    // violation below, "Annotation 'SuppressWarnings' should be on the same line with its target."
+    @SuppressWarnings("deprecation")
     /**
      * @return
      */

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/annotation/annotationonsameline/InputAnnotationOnSameLineCheckInterfaceAndEnum.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/annotation/annotationonsameline/InputAnnotationOnSameLineCheckInterfaceAndEnum.java
@@ -11,43 +11,49 @@ package com.puppycrawl.tools.checkstyle.checks.annotation.annotationonsameline;
 
 import java.util.List;
 
-@Ann        // violation
+@Ann        // violation, "Annotation 'Ann' should be on the same line with its target."
 @Ann2 interface TestInterface {
 
-    @Ann    // violation
+    @Ann    // violation, "Annotation 'Ann' should be on the same line with its target."
     @Ann2 Integer getX();
 }
 
-public @Ann     // violation
-@Ann2 class InputAnnotationOnSameLineCheckInterfaceAndEnum implements @Ann     // violation
+public @Ann     // violation, "Annotation 'Ann' should be on the same line with its target."
+                // violation below, "Annotation 'Ann' should be on the same line with its target."
+@Ann2 class InputAnnotationOnSameLineCheckInterfaceAndEnum implements @Ann
         @Ann2 TestInterface {
 
-    @Ann        // violation
-    @Ann2 private Integer x = new @Ann      // violation
+    @Ann        // violation, "Annotation 'Ann' should be on the same line with its target."
+    @Ann2 private Integer x = new @Ann // violation, should be on the same line with its target."
             @Ann2 Integer(0);
 
-    private List<@Ann       // violation
+            // violation below, "Annotation 'Ann' should be on the same line with its target."
+    private List<@Ann
             @Ann2 Integer> integerList;
 
-    @Ann        // violation
+    @Ann        // violation, "Annotation 'Ann' should be on the same line with its target."
     @Ann2 enum TestEnum {
         A1, A2
     }
 
-    @Ann        // violation
+    @Ann        // violation, "Annotation 'Ann' should be on the same line with its target."
+
     @Ann2 public InputAnnotationOnSameLineCheckInterfaceAndEnum() {}
 
-    @Ann        // violation
-    @Ann2 public void setX(@Ann             // violation
-            @Ann2 int x) throws @Ann        // violation
+    @Ann        // violation, "Annotation 'Ann' should be on the same line with its target."
+                // violation below, "Annotation 'Ann' should be on the same line with its target."
+    @Ann2 public void setX(@Ann
+
+            @Ann2 int x) throws @Ann // violation, should be on the same line with its target."
                     @Ann2 Exception {
-        this.<@Ann                          // violation
+
+        this.<@Ann // violation, "Annotation 'Ann' should be on the same line with its target."
                 @Ann2 Integer> getXAs();
         this.x = x;
     }
 
     @Override public Integer getX() {
-        return (@Ann                        // violation
+        return (@Ann // violation, "Annotation 'Ann' should be on the same line with its target."
                 @Ann2 Integer) x;
     }
 
@@ -56,9 +62,9 @@ public @Ann     // violation
     }
 }
 
-@Ann        // violation
+@Ann        // violation, "Annotation 'Ann' should be on the same line with its target."
 @Ann2 @interface TestAnnotation {
 
-    @Ann    // violation
+    @Ann    // violation, "Annotation 'Ann' should be on the same line with its target."
     @Ann2 int x();
 }

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/annotation/annotationonsameline/InputAnnotationOnSameLineCheckPrivateAndDeprecatedVar.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/annotation/annotationonsameline/InputAnnotationOnSameLineCheckPrivateAndDeprecatedVar.java
@@ -16,16 +16,19 @@ import java.util.ArrayList;
 
 public class InputAnnotationOnSameLineCheckPrivateAndDeprecatedVar {
 
-    @Ann        // violation
+    @Ann        // violation, "Annotation 'Ann' should be on the same line with its target."
     private List<String> names = new ArrayList<>();
 
     @Ann private List<String> names2 = new ArrayList<>();
 
-    @SuppressWarnings("deprecation")        // violation
+    // violation below, "Annotation 'SuppressWarnings' should be on the same line with its target."
+    @SuppressWarnings("deprecation")
     @Ann Integer x;
 
-    @SuppressWarnings("deprecation")        // violation
-    @Ann                                    // violation
+    // violation below, "Annotation 'SuppressWarnings' should be on the same line with its target."
+    @SuppressWarnings("deprecation")
+    @Ann
+    // violation above, "Annotation 'Ann' should be on the same line with its target."
     Integer x2;
 
     @SuppressWarnings("deprecation") @Ann @Ann2 @Ann3 @Ann4 Integer x3;

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/annotation/annotationonsameline/InputAnnotationOnSameLineCheckPublicMethodAndVariable.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/annotation/annotationonsameline/InputAnnotationOnSameLineCheckPublicMethodAndVariable.java
@@ -14,14 +14,18 @@ public class InputAnnotationOnSameLineCheckPublicMethodAndVariable {
 
     int y;
 
-    @Annotation             // violation
-    @SomeClass.Annotation   // violation
-    @java.lang.Deprecated   // violation
+    // violation 3 lines below "Annotation 'Annotation' should be on the same line with its target."
+    // violation 3 lines below "Annotation 'Annotation' should be on the same line with its target."
+    // violation 3 lines below "Annotation 'Deprecated' should be on the same line with its target."
+    @Annotation
+    @SomeClass.Annotation
+    @java.lang.Deprecated
     public int getX() {
         return (int) x;
     }
 
-    @Annotation2 @Annotation    // violation
+    // violation below, "Annotation 'Annotation' should be on the same line with its target."
+    @Annotation2 @Annotation
     public int field;
 
     public

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/annotation/annotationonsameline/InputAnnotationOnSameLineCheckTokensOnMethodAndVar.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/annotation/annotationonsameline/InputAnnotationOnSameLineCheckTokensOnMethodAndVar.java
@@ -15,14 +15,17 @@ public class InputAnnotationOnSameLineCheckTokensOnMethodAndVar {
 
     int y;
 
-    @Annotation3            // violation
-    @SomeClass2.Annotation  // violation
-    @java.lang.Deprecated   // violation
+
+
+    @Annotation3 // violation, "should be on the same line with its target."
+    @SomeClass2.Annotation // violation, "should be on the same line with its target."
+    @java.lang.Deprecated // violation, "should be on the same line with its target."
     public int getX() {
         return (int) x;
     }
 
-    @Annotation4 @Annotation3  // violation
+    // violation below, "Annotation 'Annotation3' should be on the same line with its target."
+    @Annotation4 @Annotation3
     public int field;
 
     public

--- a/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/checks/annotation/AnnotationOnSameLineCheckExamplesTest.java
+++ b/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/checks/annotation/AnnotationOnSameLineCheckExamplesTest.java
@@ -34,10 +34,10 @@ public class AnnotationOnSameLineCheckExamplesTest extends AbstractExamplesModul
     @Test
     public void testExample1() throws Exception {
         final String[] expected = {
-            "16:3: " + getCheckMessage(MSG_KEY_ANNOTATION_ON_SAME_LINE, "SuppressWarnings"),
-            "33:3: " + getCheckMessage(MSG_KEY_ANNOTATION_ON_SAME_LINE, "Override"),
-            "37:3: " + getCheckMessage(MSG_KEY_ANNOTATION_ON_SAME_LINE, "Before"),
-            "41:3: " + getCheckMessage(MSG_KEY_ANNOTATION_ON_SAME_LINE, "SuppressWarnings"),
+            "17:3: " + getCheckMessage(MSG_KEY_ANNOTATION_ON_SAME_LINE, "SuppressWarnings"),
+            "34:3: " + getCheckMessage(MSG_KEY_ANNOTATION_ON_SAME_LINE, "Override"),
+            "38:3: " + getCheckMessage(MSG_KEY_ANNOTATION_ON_SAME_LINE, "Before"),
+            "43:3: " + getCheckMessage(MSG_KEY_ANNOTATION_ON_SAME_LINE, "SuppressWarnings"),
         };
 
         verifyWithInlineConfigParser(getPath("Example1.java"), expected);
@@ -46,8 +46,8 @@ public class AnnotationOnSameLineCheckExamplesTest extends AbstractExamplesModul
     @Test
     public void testExample2() throws Exception {
         final String[] expected = {
-            "25:3: " + getCheckMessage(MSG_KEY_ANNOTATION_ON_SAME_LINE, "SuppressWarnings"),
-            "33:3: " + getCheckMessage(MSG_KEY_ANNOTATION_ON_SAME_LINE, "Nullable"),
+            "26:3: " + getCheckMessage(MSG_KEY_ANNOTATION_ON_SAME_LINE, "SuppressWarnings"),
+            "35:3: " + getCheckMessage(MSG_KEY_ANNOTATION_ON_SAME_LINE, "Nullable"),
         };
 
         verifyWithInlineConfigParser(getPath("Example2.java"), expected);

--- a/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/annotation/annotationonsameline/Example1.java
+++ b/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/annotation/annotationonsameline/Example1.java
@@ -13,7 +13,8 @@ import org.junit.Before;
 // xdoc section -- start
 class Example1 {
 
-  @SuppressWarnings("deprecation") // violation
+  // violation below, "should be on the same line with its target."
+  @SuppressWarnings("deprecation")
   public Example1() {
   }
 
@@ -30,15 +31,16 @@ class Example1 {
   @Deprecated public Test1() {  // OK
   }
 
-  @Override // violation
+  @Override // violation, "should be on the same line with its target."
   public void fun1() {
   }
 
-  @Before // violation
+  @Before // violation, "should be on the same line with its target."
   @Override public void fun2() {  // OK
   }
 
-  @SuppressWarnings("deprecation") // violation
+  // violation below, "should be on the same line with its target."
+  @SuppressWarnings("deprecation")
   @Before public void fun3() {
   }
 

--- a/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/annotation/annotationonsameline/Example2.java
+++ b/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/annotation/annotationonsameline/Example2.java
@@ -22,7 +22,8 @@ import javax.annotation.Nullable;
 
 class Example2 implements Foo {
 
-  @SuppressWarnings("deprecation") // violation
+  // violation below, "should be on the same line with its target."
+  @SuppressWarnings("deprecation")
   public Example2() {
   }
 
@@ -30,7 +31,8 @@ class Example2 implements Foo {
   public void doSomething() {
   }
 
-  @Nullable // violation
+  // violation below, "should be on the same line with its target."
+  @Nullable
   String s;
 
 }

--- a/src/xdocs/checks/annotation/annotationonsameline.xml
+++ b/src/xdocs/checks/annotation/annotationonsameline.xml
@@ -106,7 +106,8 @@
         <source>
 class Example1 {
 
-  @SuppressWarnings(&quot;deprecation&quot;) // violation
+  // violation below, &quot;should be on the same line with its target.&quot;
+  @SuppressWarnings(&quot;deprecation&quot;)
   public Example1() {
   }
 
@@ -123,15 +124,16 @@ class Example1 {
   @Deprecated public Test1() {  // OK
   }
 
-  @Override // violation
+  @Override // violation, &quot;should be on the same line with its target.&quot;
   public void fun1() {
   }
 
-  @Before // violation
+  @Before // violation, &quot;should be on the same line with its target.&quot;
   @Override public void fun2() {  // OK
   }
 
-  @SuppressWarnings(&quot;deprecation&quot;) // violation
+  // violation below, &quot;should be on the same line with its target.&quot;
+  @SuppressWarnings(&quot;deprecation&quot;)
   @Before public void fun3() {
   }
 
@@ -162,7 +164,8 @@ class Example1 {
 
 class Example2 implements Foo {
 
-  @SuppressWarnings(&quot;deprecation&quot;) // violation
+  // violation below, &quot;should be on the same line with its target.&quot;
+  @SuppressWarnings(&quot;deprecation&quot;)
   public Example2() {
   }
 
@@ -170,7 +173,8 @@ class Example2 implements Foo {
   public void doSomething() {
   }
 
-  @Nullable // violation
+  // violation below, &quot;should be on the same line with its target.&quot;
+  @Nullable
   String s;
 
 }


### PR DESCRIPTION
Issue #15456 


Attention: 
is given a .DS_Store as filePath input.

Since, it is OS specific and I guess it would never happen on CI, though I'm questioning whether an improvement should be considered.
For now I added a check - !file.isHidden() - here as a workaround.
For more details read https://github.com/checkstyle/checkstyle/issues/15456#issuecomment-2350937837

--------

Attention: CI can not detect this problem, as CI never open file browser to navigate on folders, browsing folder in UI creates such folders.