### PR TITLE
Issue #14631: Update serial literal to new AST format

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/api/JavadocTokenTypes.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/api/JavadocTokenTypes.java
@@ -227,21 +227,21 @@ public final class JavadocTokenTypes {
      * <pre>{@code @serial include}</pre>
      * <b>Tree:</b>
      * <pre>{@code
-     *   |--JAVADOC_TAG[3x0] : [@serial include]
-     *       |--SERIAL_LITERAL[3x0] : [@serial]
-     *       |--WS[3x7] : [ ]
-     *       |--LITERAL_INCLUDE[3x8] : [include]
+     *   |--JAVADOC_TAG -> JAVADOC_TAG
+     *       |--SERIAL_LITERAL -> @serial
+     *       |--WS
+     *       |--LITERAL_INCLUDE -> include
      * }</pre>
      *
      * <p><b>Example:</b></p>
      * <pre>{@code @serial serialized company name}</pre>
      * <b>Tree:</b>
      * <pre>{@code
-     *   |--JAVADOC_TAG[3x0] : [@serial serialized company name]
-     *       |--SERIAL_LITERAL[3x0] : [@serial]
-     *       |--WS[3x7] : [ ]
-     *       |--DESCRIPTION[3x8] : [serialized company name]
-     *           |--TEXT[3x8] : [serialized company name]
+     *   |--JAVADOC_TAG-> JAVADOC_TAG
+     *       |--SERIAL_LITERAL -> @serial
+     *       |--WS
+     *       |--DESCRIPTION -> DESCRIPTION
+     *           |--TEXT -> serialized company name
      * }</pre>
      *
      * @see


### PR DESCRIPTION
Issue #14631

``` java
/**
 * @serial include
 */
public class Test {
    /**
   * Some Java doc.
   *
   * @serial serialized company name.
   */
    private String companyName;
}
```
``` console
target % java -jar checkstyle-10.18.2-SNAPSHOT-all.jar -J ../Test.java | sed "s/\[[0-9]\+:[0-9]\+\]//g"

COMPILATION_UNIT -> COMPILATION_UNIT [4:0]
`--CLASS_DEF -> CLASS_DEF [4:0]
    |--MODIFIERS -> MODIFIERS [4:0]
    |   |--BLOCK_COMMENT_BEGIN -> /* [1:0]
    |   |   |--COMMENT_CONTENT -> *\n * @serial include\n  [1:2]
    |   |   |   `--JAVADOC -> JAVADOC [1:3]
    |   |   |       |--NEWLINE -> \n [1:3]
    |   |   |       |--LEADING_ASTERISK ->  * [2:0]
    |   |   |       |--WS ->   [2:2]
    |   |   |       |--JAVADOC_TAG -> JAVADOC_TAG [2:3]
    |   |   |       |   |--SERIAL_LITERAL -> @serial [2:3]
    |   |   |       |   |--WS ->   [2:10]
    |   |   |       |   |--LITERAL_INCLUDE -> include [2:11]
    |   |   |       |   |--NEWLINE -> \n [2:18]
    |   |   |       |   `--WS ->   [3:0]
    |   |   |       `--EOF -> <EOF> [3:1]
    |   |   `--BLOCK_COMMENT_END -> */ [3:1]
    |   `--LITERAL_PUBLIC -> public [4:0]
    |--LITERAL_CLASS -> class [4:7]
    |--IDENT -> Test [4:13]
    `--OBJBLOCK -> OBJBLOCK [4:18]
        |--LCURLY -> { [4:18]
        |--VARIABLE_DEF -> VARIABLE_DEF [10:4]
        |   |--MODIFIERS -> MODIFIERS [10:4]
        |   |   |--BLOCK_COMMENT_BEGIN -> /* [5:4]
        |   |   |   |--COMMENT_CONTENT -> *\n   * Some Java doc.\n   *\n   * @serial serialized company name.\n    [5:6]
        |   |   |   |   `--JAVADOC -> JAVADOC [5:7]
        |   |   |   |       |--NEWLINE -> \n [5:7]
        |   |   |   |       |--LEADING_ASTERISK ->    * [6:0]
        |   |   |   |       |--TEXT ->  Some Java doc. [6:4]
        |   |   |   |       |--NEWLINE -> \n [6:19]
        |   |   |   |       |--LEADING_ASTERISK ->    * [7:0]
        |   |   |   |       |--NEWLINE -> \n [7:4]
        |   |   |   |       |--LEADING_ASTERISK ->    * [8:0]
        |   |   |   |       |--WS ->   [8:4]
        |   |   |   |       |--JAVADOC_TAG -> JAVADOC_TAG [8:5]
        |   |   |   |       |   |--SERIAL_LITERAL -> @serial [8:5]
        |   |   |   |       |   |--WS ->   [8:12]
        |   |   |   |       |   `--DESCRIPTION -> DESCRIPTION [8:13]
        |   |   |   |       |       |--TEXT -> serialized company name. [8:13]
        |   |   |   |       |       |--NEWLINE -> \n [8:37]
        |   |   |   |       |       `--TEXT ->     [9:0]
        |   |   |   |       `--EOF -> <EOF> [9:3]
        |   |   |   `--BLOCK_COMMENT_END -> */ [9:3]
        |   |   `--LITERAL_PRIVATE -> private [10:4]
        |   |--TYPE -> TYPE [10:12]
        |   |   `--IDENT -> String [10:12]
        |   |--IDENT -> companyName [10:19]
        |   `--SEMI -> ; [10:30]
        `--RCURLY -> } [11:0]
```

-- 
```console
target % java -version
openjdk version "11.0.16.1" 2022-08-12
OpenJDK Runtime Environment Temurin-11.0.16.1+1 (build 11.0.16.1+1)
OpenJDK 64-Bit Server VM Temurin-11.0.16.1+1 (build 11.0.16.1+1, mixed mode)
```
I don't know why the command still prints [index:index] at the end of each line.
I'm using zsh on MacOS, I tried with bash, same result. 

Any input appreciated.
