### PR TITLE
Issue #15685: fixed JavadocParagraph to detect paragraph tag when they have their corresponding closing tag

### DIFF
--- a/.ci/validation.sh
+++ b/.ci/validation.sh
@@ -640,7 +640,7 @@ no-error-pgjdbc)
   checkout_from https://github.com/pgjdbc/pgjdbc.git
   cd .ci-temp/pgjdbc
   # pgjdbc easily damage build, we should use stable versions
-  git checkout "cf7afb6c210b6841a232ef27591230fc78a""fa6a5"
+  git checkout "fcc13e70e6b6bb64b848df4b4ba6b3566b5""e95a3"
   ./gradlew --no-parallel --no-daemon checkstyleAll \
             -PenableMavenLocal -Pcheckstyle.version="${CS_POM_VERSION}"
   cd ../

--- a/config/checkstyle-checks.xml
+++ b/config/checkstyle-checks.xml
@@ -46,6 +46,18 @@
     <property name="files"
               value=".*[\\/]src[\\/](test|it|xdocs-examples)[\\/].*(?&lt;!Support)\.java"/>
   </module>
+  <!--
+    Until we fully support opening-closing paragraph tag
+    https://github.com/checkstyle/checkstyle/issues/15763
+   -->
+  <module name="SuppressionSingleFilter">
+    <property name="checks" value="JavadocParagraph"/>
+    <property name="message" value="tag should be preceded with an empty line."/>
+  </module>
+  <module name="SuppressionSingleFilter">
+    <property name="checks" value="JavadocParagraph"/>
+    <property name="message" value="Redundant .* tag."/>
+  </module>
   <module name="SuppressWarningsFilter"/>
   <module name="SuppressWithPlainTextCommentFilter">
     <!--

--- a/config/jsoref-spellchecker/whitelist.words
+++ b/config/jsoref-spellchecker/whitelist.words
@@ -298,6 +298,7 @@ detailnodetreestringprinter
 devops
 Dexec
 Dexpression
+df
 dfa
 DFFF
 Dfile
@@ -404,6 +405,7 @@ Fannotation
 favicon
 Fblocks
 FCBL
+fcc
 FCCD
 Fchecks
 Fcheckstyle

--- a/src/it/resources/com/google/checkstyle/test/chapter7javadoc/rule712paragraphs/InputIncorrectJavadocParagraph.java
+++ b/src/it/resources/com/google/checkstyle/test/chapter7javadoc/rule712paragraphs/InputIncorrectJavadocParagraph.java
@@ -33,8 +33,7 @@ class InputIncorrectJavadocParagraph {
    *
    * <p>Some Javadoc.
    *
-   * @see <a href="example.com">
-   *     Documentation about GWT emulated source</a>
+   * @see <a href="example.com">Documentation about GWT emulated source</a>
    */
   boolean emulated() {
     return false;
@@ -82,13 +81,12 @@ class InputIncorrectJavadocParagraph {
      *
      * <p>
      *   Some Javadoc.<p>
-     * @see <a href="example.com">
-     *     Documentation about GWT emulated source</a>
+     * @see <a href="example.com">Documentation about GWT emulated source</a>
      */
-    // 2 violations 4 lines above:
+    // 2 violations 3 lines above:
     //  '<p> tag should be placed immediately before the first word'
     //  '<p> tag should be preceded with an empty line.'
-    // violation 6 lines above 'Javadoc tag '@see' should be preceded with an empty line.'
+    // violation 5 lines above 'Javadoc tag '@see' should be preceded with an empty line.'
     boolean emulated() {
       return false;
     }
@@ -116,8 +114,7 @@ class InputIncorrectJavadocParagraph {
          *
          *  <p>  Some Javadoc.
          *
-         * @see <a href="example.com">
-         *     Documentation about <p> GWT emulated source</a>
+         * @see <a href="example.com">Documentation about <p> GWT emulated source</a>
          */
         // 2 violations 2 lines above:
         //  '<p> tag should be placed immediately before the first word'
@@ -127,14 +124,16 @@ class InputIncorrectJavadocParagraph {
         }
       };
 
-  /* 4 lines below, no violation until #15685 */
   /**
    * Some summary.
    *
    * <p><h1>Testing...</h1></p>
    */
+  // violation 2 lines above '<p> tag should not precede HTML block-tag '<h1>''
   class InnerPrecedingPtag {
-    /* 5 lines below, no violation until #15685 */
+    // 2 violations 6 lines below:
+    //  '<p> tag should be placed immediately before the first word'
+    //  '<p> tag should not precede HTML block-tag '<ul>''
     /**
      * Some summary.
      *
@@ -148,7 +147,9 @@ class InputIncorrectJavadocParagraph {
      */
     public void foo() {}
 
-    /* 5 lines below, no violation until #15685 */
+    // 2 violations 6 lines below:
+    //  '<p> tag should be placed immediately before the first word'
+    //  '<p> tag should not precede HTML block-tag '<table>''
     /**
      *  Some summary.
      *
@@ -159,7 +160,9 @@ class InputIncorrectJavadocParagraph {
      */
     public void fooo() {}
 
-    /* 5 lines below, no violation until #15685 */
+    // 2 violations 6 lines below:
+    //  '<p> tag should be placed immediately before the first word'
+    //  '<p> tag should not precede HTML block-tag '<pre>''
     /**
      * Some summary.
      *

--- a/src/main/java/com/puppycrawl/tools/checkstyle/api/TokenTypes.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/api/TokenTypes.java
@@ -1215,7 +1215,7 @@ public final class TokenTypes {
      * <pre>
      * new ArrayList(50);
      * </pre>
-     * <p> parses as:</p>
+     * <p>parses as:</p>
      * <pre>
      * |--EXPR -&gt; EXPR
      * |   `--LITERAL_NEW -&gt; new
@@ -5184,7 +5184,7 @@ public final class TokenTypes {
 
     /**
      * The type that refers to all types. This node has no children.
-     * <p> For example: </p>
+     * <p>For example: </p>
      * <pre>
      *
      * List&lt;?&gt; list;

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocParagraphCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocParagraphCheck.java
@@ -44,6 +44,10 @@ import com.puppycrawl.tools.checkstyle.utils.JavadocUtil;
  * <a href="https://www.w3schools.com/html/html_blocks.asp">HTML block-tag</a>,
  * nested paragraph tags are allowed to do that.</li>
  * </ul>
+ * <p><b>ATTENTION:</b></p>
+ * <p>This Check ignores HTML comments.</p>
+ * <p>The Check ignores all the nested paragraph tags,
+ * it will not give any kind of violation if the paragraph tag is nested.</p>
  * <ul>
  * <li>
  * Property {@code allowNewlineParagraph} - Control whether the &lt;p&gt; tag
@@ -174,7 +178,8 @@ public class JavadocParagraphCheck extends AbstractJavadocCheck {
             checkEmptyLine(ast);
         }
         else if (ast.getType() == JavadocTokenTypes.HTML_ELEMENT
-                && JavadocUtil.getFirstChild(ast).getType() == JavadocTokenTypes.P_TAG_START) {
+                && (JavadocUtil.getFirstChild(ast).getType() == JavadocTokenTypes.P_TAG_START
+                    || JavadocUtil.getFirstChild(ast).getType() == JavadocTokenTypes.PARAGRAPH)) {
             checkParagraphTag(ast);
         }
     }
@@ -198,25 +203,49 @@ public class JavadocParagraphCheck extends AbstractJavadocCheck {
      * @param tag html tag.
      */
     private void checkParagraphTag(DetailNode tag) {
-        final DetailNode newLine = getNearestEmptyLine(tag);
-        if (isFirstParagraph(tag)) {
-            log(tag.getLineNumber(), tag.getColumnNumber(), MSG_REDUNDANT_PARAGRAPH);
+        if (!isNestedParagraph(tag)) {
+            final DetailNode newLine = getNearestEmptyLine(tag);
+            if (isFirstParagraph(tag)) {
+                log(tag.getLineNumber(), tag.getColumnNumber(), MSG_REDUNDANT_PARAGRAPH);
+            }
+            else if (newLine == null || tag.getLineNumber() - newLine.getLineNumber() != 1) {
+                log(tag.getLineNumber(), tag.getColumnNumber(), MSG_LINE_BEFORE);
+            }
+
+            final String blockTagName = findFollowedBlockTagName(tag);
+            if (blockTagName != null) {
+                log(tag.getLineNumber(), tag.getColumnNumber(),
+                        MSG_PRECEDED_BLOCK_TAG, blockTagName);
+            }
+
+            if (!allowNewlineParagraph && isImmediatelyFollowedByNewLine(tag)) {
+                log(tag.getLineNumber(), tag.getColumnNumber(), MSG_MISPLACED_TAG);
+            }
+            if (isImmediatelyFollowedByText(tag)) {
+                log(tag.getLineNumber(), tag.getColumnNumber(), MSG_MISPLACED_TAG);
+            }
         }
-        else if (newLine == null || tag.getLineNumber() - newLine.getLineNumber() != 1) {
-            log(tag.getLineNumber(), tag.getColumnNumber(), MSG_LINE_BEFORE);
+    }
+
+    /**
+     * Determines whether the paragraph tag is nested.
+     *
+     * @param tag html tag.
+     * @return true, if the paragraph tag is nested.
+     */
+    private static boolean isNestedParagraph(DetailNode tag) {
+        boolean nested = false;
+        DetailNode parent = tag;
+
+        while (parent != null) {
+            if (parent.getType() == JavadocTokenTypes.PARAGRAPH) {
+                nested = true;
+                break;
+            }
+            parent = parent.getParent();
         }
 
-        final String blockTagName = findFollowedBlockTagName(tag);
-        if (blockTagName != null) {
-            log(tag.getLineNumber(), tag.getColumnNumber(), MSG_PRECEDED_BLOCK_TAG, blockTagName);
-        }
-
-        if (!allowNewlineParagraph && isImmediatelyFollowedByNewLine(tag)) {
-            log(tag.getLineNumber(), tag.getColumnNumber(), MSG_MISPLACED_TAG);
-        }
-        if (isImmediatelyFollowedByText(tag)) {
-            log(tag.getLineNumber(), tag.getColumnNumber(), MSG_MISPLACED_TAG);
-        }
+        return nested;
     }
 
     /**
@@ -245,9 +274,11 @@ public class JavadocParagraphCheck extends AbstractJavadocCheck {
      */
     @Nullable
     private static DetailNode findFirstHtmlElementAfter(DetailNode tag) {
-        DetailNode htmlElement = JavadocUtil.getNextSibling(tag);
+        DetailNode htmlElement = getNextSibling(tag);
 
-        while (htmlElement != null && htmlElement.getType() != JavadocTokenTypes.HTML_ELEMENT) {
+        while (htmlElement != null
+                && htmlElement.getType() != JavadocTokenTypes.HTML_ELEMENT
+                && htmlElement.getType() != JavadocTokenTypes.HTML_TAG) {
             if ((htmlElement.getType() == JavadocTokenTypes.TEXT
                     || htmlElement.getType() == JavadocTokenTypes.JAVADOC_INLINE_TAG)
                     && !CommonUtil.isBlank(htmlElement.getText())) {
@@ -268,7 +299,13 @@ public class JavadocParagraphCheck extends AbstractJavadocCheck {
      */
     @Nullable
     private static String getHtmlElementName(DetailNode htmlElement) {
-        final DetailNode htmlTag = JavadocUtil.getFirstChild(htmlElement);
+        final DetailNode htmlTag;
+        if (htmlElement.getType() == JavadocTokenTypes.HTML_TAG) {
+            htmlTag = htmlElement;
+        }
+        else {
+            htmlTag = JavadocUtil.getFirstChild(htmlElement);
+        }
         final DetailNode htmlTagFirstChild = JavadocUtil.getFirstChild(htmlTag);
         final DetailNode htmlTagName =
                 JavadocUtil.findFirstToken(htmlTagFirstChild, JavadocTokenTypes.HTML_TAG_NAME);
@@ -364,7 +401,8 @@ public class JavadocParagraphCheck extends AbstractJavadocCheck {
      * @return true, if the paragraph tag is immediately followed by the text.
      */
     private static boolean isImmediatelyFollowedByText(DetailNode tag) {
-        final DetailNode nextSibling = JavadocUtil.getNextSibling(tag);
+        final DetailNode nextSibling = getNextSibling(tag);
+
         return nextSibling.getType() == JavadocTokenTypes.EOF
                 || nextSibling.getText().startsWith(" ");
     }
@@ -373,10 +411,35 @@ public class JavadocParagraphCheck extends AbstractJavadocCheck {
      * Tests whether the paragraph tag is immediately followed by the new line.
      *
      * @param tag html tag.
-     * @return true, if the paragraph tag is immediately followed by the text.
+     * @return true, if the paragraph tag is immediately followed by the new line.
      */
     private static boolean isImmediatelyFollowedByNewLine(DetailNode tag) {
-        final DetailNode nextSibling = JavadocUtil.getNextSibling(tag);
-        return nextSibling.getType() == JavadocTokenTypes.NEWLINE;
+        return getNextSibling(tag).getType() == JavadocTokenTypes.NEWLINE;
+    }
+
+    /**
+     * Custom getNextSibling method to handle different types of paragraph tag.
+     * It works for both {@code <p>} and {@code <p></p>} tags.
+     *
+     * @param tag HTML_ELEMENT tag.
+     * @return next sibling of the tag.
+     */
+    private static DetailNode getNextSibling(DetailNode tag) {
+        DetailNode nextSibling;
+
+        if (JavadocUtil.getFirstChild(tag).getType() == JavadocTokenTypes.PARAGRAPH) {
+            final DetailNode paragraphToken = JavadocUtil.getFirstChild(tag);
+            final DetailNode paragraphStartTagToken = JavadocUtil.getFirstChild(paragraphToken);
+            nextSibling = JavadocUtil.getNextSibling(paragraphStartTagToken);
+        }
+        else {
+            nextSibling = JavadocUtil.getNextSibling(tag);
+        }
+
+        if (nextSibling.getType() == JavadocTokenTypes.HTML_COMMENT) {
+            nextSibling = JavadocUtil.getNextSibling(nextSibling);
+        }
+
+        return nextSibling;
     }
 }

--- a/src/main/resources/com/puppycrawl/tools/checkstyle/meta/checks/javadoc/JavadocParagraphCheck.xml
+++ b/src/main/resources/com/puppycrawl/tools/checkstyle/meta/checks/javadoc/JavadocParagraphCheck.xml
@@ -17,7 +17,11 @@
  &lt;li&gt;First paragraph tag should not precede
  &lt;a href="https://www.w3schools.com/html/html_blocks.asp"&gt;HTML block-tag&lt;/a&gt;,
  nested paragraph tags are allowed to do that.&lt;/li&gt;
- &lt;/ul&gt;</description>
+ &lt;/ul&gt;
+ &lt;p&gt;&lt;b&gt;ATTENTION:&lt;/b&gt;&lt;/p&gt;
+ &lt;p&gt;This Check ignores HTML comments.&lt;/p&gt;
+ &lt;p&gt;The Check ignores all the nested paragraph tags,
+ it will not give any kind of violation if the paragraph tag is nested.&lt;/p&gt;</description>
          <properties>
             <property default-value="true" name="allowNewlineParagraph" type="boolean">
                <description>Control whether the &amp;lt;p&amp;gt; tag

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocParagraphCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocParagraphCheckTest.java
@@ -188,10 +188,82 @@ public class JavadocParagraphCheckTest extends AbstractModuleTestSupport {
     public void testJavadocParagraph() throws Exception {
         final String[] expected = {
             "19:4: " + getCheckMessage(MSG_LINE_BEFORE),
-            "30:7: " + getCheckMessage(MSG_LINE_BEFORE),
+            "28:7: " + getCheckMessage(MSG_REDUNDANT_PARAGRAPH),
+            "31:7: " + getCheckMessage(MSG_LINE_BEFORE),
+            "50:7: " + getCheckMessage(MSG_PRECEDED_BLOCK_TAG, "ul"),
+            "65:8: " + getCheckMessage(MSG_LINE_BEFORE),
+            "76:8: " + getCheckMessage(MSG_PRECEDED_BLOCK_TAG, "table"),
+            "87:8: " + getCheckMessage(MSG_PRECEDED_BLOCK_TAG, "pre"),
         };
 
         verifyWithInlineConfigParser(
                 getPath("InputJavadocParagraphCheck1.java"), expected);
+    }
+
+    @Test
+    public void testJavadocParagraphOpenClosedTag() throws Exception {
+        final String[] expected = {
+            "14:4: " + getCheckMessage(MSG_MISPLACED_TAG),
+            "21:7: " + getCheckMessage(MSG_LINE_BEFORE),
+            "28:20: " + getCheckMessage(MSG_LINE_BEFORE),
+            "29:20: " + getCheckMessage(MSG_LINE_BEFORE),
+            "35:8: " + getCheckMessage(MSG_REDUNDANT_PARAGRAPH),
+            "36:6: " + getCheckMessage(MSG_TAG_AFTER),
+            "38:6: " + getCheckMessage(MSG_TAG_AFTER),
+            "58:7: " + getCheckMessage(MSG_PRECEDED_BLOCK_TAG, "ul"),
+            "73:7: " + getCheckMessage(MSG_PRECEDED_BLOCK_TAG, "h1"),
+            "85:7: " + getCheckMessage(MSG_PRECEDED_BLOCK_TAG, "h1"),
+        };
+
+        verifyWithInlineConfigParser(
+                getPath("InputJavadocParagraphIncorrectOpenClosedTag.java"), expected);
+    }
+
+    @Test
+    public void testJavadocParagraphOpenClosedTag2() throws Exception {
+        final String[] expected = {
+            "14:4: " + getCheckMessage(MSG_MISPLACED_TAG),
+            "21:7: " + getCheckMessage(MSG_LINE_BEFORE),
+            "30:20: " + getCheckMessage(MSG_MISPLACED_TAG),
+            "30:20: " + getCheckMessage(MSG_LINE_BEFORE),
+            "31:20: " + getCheckMessage(MSG_LINE_BEFORE),
+            "37:8: " + getCheckMessage(MSG_REDUNDANT_PARAGRAPH),
+            "38:6: " + getCheckMessage(MSG_TAG_AFTER),
+            "40:6: " + getCheckMessage(MSG_TAG_AFTER),
+            "50:7: " + getCheckMessage(MSG_MISPLACED_TAG),
+            "63:7: " + getCheckMessage(MSG_MISPLACED_TAG),
+            "63:7: " + getCheckMessage(MSG_PRECEDED_BLOCK_TAG, "ul"),
+            "78:7: " + getCheckMessage(MSG_PRECEDED_BLOCK_TAG, "h1"),
+            "87:7: " + getCheckMessage(MSG_MISPLACED_TAG),
+            "91:7: " + getCheckMessage(MSG_MISPLACED_TAG),
+            "91:7: " + getCheckMessage(MSG_PRECEDED_BLOCK_TAG, "h1"),
+        };
+
+        verifyWithInlineConfigParser(
+                getPath("InputJavadocParagraphIncorrectOpenClosedTag2.java"), expected);
+    }
+
+    @Test
+    public void testJavadocParagraphOpenClosedTag3() throws Exception {
+        final String[] expected = {
+            "15:7: " + getCheckMessage(MSG_MISPLACED_TAG),
+            "23:7: " + getCheckMessage(MSG_MISPLACED_TAG),
+            "31:7: " + getCheckMessage(MSG_MISPLACED_TAG),
+        };
+
+        verifyWithInlineConfigParser(
+                getPath("InputJavadocParagraphIncorrectOpenClosedTag3.java"), expected);
+    }
+
+    @Test
+    public void testIncorrect3() throws Exception {
+        final String[] expected = {
+            "15:7: " + getCheckMessage(MSG_MISPLACED_TAG),
+            "23:7: " + getCheckMessage(MSG_MISPLACED_TAG),
+            "31:7: " + getCheckMessage(MSG_MISPLACED_TAG),
+        };
+
+        verifyWithInlineConfigParser(
+                getPath("InputJavadocParagraphIncorrect6.java"), expected);
     }
 }

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadocparagraph/InputJavadocParagraphCheck1.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadocparagraph/InputJavadocParagraphCheck1.java
@@ -23,6 +23,7 @@ public class InputJavadocParagraphCheck1 {
 // violation 4 lines above '<p> tag should be preceded with an empty line'
 class Check {
 
+   // violation 2 lines below 'Redundant <p> tag.'
    /**
     * <p>
     * Checks whether file contains code. Files which are considered to have no code:
@@ -31,4 +32,62 @@ class Check {
     */
    // violation 2 lines above '<p> tag should be preceded with an empty line.'
     void inheritDocWithThrows() {}
+
+    /**
+     * Some summary.
+     *
+     * <p>The following package declaration:</p>
+     * <pre>
+     * package com.puppycrawl.tools.checkstyle;
+     * </pre>
+     */
+    int iamtoolazyyyyyyy = 45;
+
+    // violation 4 lines below '<p> tag should not precede HTML block-tag '<ul>''
+    /**
+     * Some summary.
+     *
+     *<p>
+     *  <ul> // ok until #15762
+     *    <p> // ok until #15762
+     *      <li>1</li> should NOT give violation as there is not empty line before
+     *    </p> // false-negative on this line & above until #15762
+     *  </ul> // ok until #15762
+     *</p>
+     */
+    public void foo() {}
+
+    // violation 5 lines below '<p> tag should be preceded with an empty line.'
+    /**
+     * Some summary.
+     *
+     * <b>
+     * <p>
+     *  <br/>
+     * </p>
+     * </b>
+     */
+    public void fooo() {}
+
+    // violation 4 lines below '<p> tag should not precede HTML block-tag '<table>''
+    /**
+     *  Some summary.
+     *
+     * <p>
+     *  <table> // ok until #15762
+     *  </table> // ok until #15762
+     * </p>
+     */
+    public void foooo() {}
+
+    // violation 4 lines below '<p> tag should not precede HTML block-tag '<pre>''
+    /**
+     * Some summary.
+     *
+     * <p>
+     *   <pre>testing...</pre> // ok until #15762
+     *   <pre>testing...</pre> // ok until #15762
+     * </p>
+     */
+    public void fooooo() {}
 }

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadocparagraph/InputJavadocParagraphIncorrect6.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadocparagraph/InputJavadocParagraphIncorrect6.java
@@ -1,0 +1,42 @@
+/*
+JavadocParagraph
+violateExecutionOnNonTightHtml = (default)false
+allowNewlineParagraph = (default)true
+
+
+*/
+
+package com.puppycrawl.tools.checkstyle.checks.javadoc.javadocparagraph;
+
+public class InputJavadocParagraphIncorrect6 {
+    /**
+    * Some Summary.
+    *
+    * <p><!-- comment is required --> extra space in paragraph after comment is violation
+    */
+    // violation 2 lines above '<p> tag should be placed immediately before the first word'
+    int a;
+
+    /**
+    * Some Summary.
+    *
+    * <p> <!-- comment is required -->extra space in paragraph before comment is violation
+    */
+    // violation 2 lines above '<p> tag should be placed immediately before the first word'
+    int b;
+
+    /**
+    * Some Summary.
+    *
+    * <p> <!-- comment is required --> both cases combined, this is also violation
+    */
+    // violation 2 lines above '<p> tag should be placed immediately before the first word'
+    int c;
+
+    /**
+    * Some Summary.
+    *
+    * <p><!-- comment is required -->no extra spaces, this is okay
+    */
+    int d;
+}

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadocparagraph/InputJavadocParagraphIncorrectOpenClosedTag.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadocparagraph/InputJavadocParagraphIncorrectOpenClosedTag.java
@@ -1,0 +1,91 @@
+/*
+JavadocParagraph
+violateExecutionOnNonTightHtml = (default)false
+allowNewlineParagraph = (default)true
+
+
+*/
+
+package com.puppycrawl.tools.checkstyle.checks.javadoc.javadocparagraph;
+
+/**
+ * Some summary.
+ *
+ * <p>  Some Javadoc. </p>
+ */
+// violation 2 lines above '<p> tag should be placed immediately before the first word'
+public class InputJavadocParagraphIncorrectOpenClosedTag {
+
+    /**
+    * some javadoc.
+    * <p></p>
+    */
+    // violation 2 lines above '<p> tag should be preceded with an empty line.'
+    int a;
+
+    // violation 2 lines below '<p> tag should be preceded with an empty line.'
+    /**
+    * Some Javadoc.<P>
+    * Some Javadoc.<P></P>
+    */
+    // violation 2 lines above '<p> tag should be preceded with an empty line.'
+    int b;
+
+    // violation below 'Redundant <p> tag.'
+    /**<p>some javadoc.</p>
+    *
+    * Some <p>Javadoc.</p>
+    *
+    * Some <p>Javadoc.</p>
+    */
+    // violation 5 lines above 'Empty line should be followed by <p> tag on the next line.'
+    // violation 4 lines above 'Empty line should be followed by <p> tag on the next line.'
+    int c;
+
+    /**
+    * Some Summary.
+    *
+    * <p>
+    *   Some Javadoc. // ok until #15762
+    * </p>
+    */
+    int d;
+
+    // violation 4 lines below '<p> tag should not precede HTML block-tag '<ul>''
+    /**
+    * Some Summary.
+    *
+    * <p>
+    *   <ul> // ok until #15762
+    *     <li>Item 1</li> // ok until #15762
+    *     <li>Item 2</li> // ok until #15762
+    *     <li>Item 3</li> // ok until #15762
+    *   </ul> // ok until #15762
+    * </p>
+    */
+    int e;
+
+    /**
+    * Some Summary.
+    *
+    * <p><b>testing....</b></p>
+    *
+    * <p><h1>testing....</h1></p>
+    */
+    // violation 2 lines above '<p> tag should not precede HTML block-tag '<h1>''
+    int f;
+
+    /**
+    * Some Summary.
+    *
+    * <p>
+    *     <b>testing....</b> // ok until #15762
+    * </p>
+    *
+    * <p>
+    *     <h1>testing....</h1> // ok until #15762
+    * </p>
+    */
+    // violation 4 lines above '<p> tag should not precede HTML block-tag '<h1>''
+    int g;
+}

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadocparagraph/InputJavadocParagraphIncorrectOpenClosedTag2.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadocparagraph/InputJavadocParagraphIncorrectOpenClosedTag2.java
@@ -1,0 +1,99 @@
+/*
+JavadocParagraph
+violateExecutionOnNonTightHtml = (default)false
+allowNewlineParagraph = false
+
+
+*/
+
+package com.puppycrawl.tools.checkstyle.checks.javadoc.javadocparagraph;
+
+/**
+ * Some summary.
+ *
+ * <p>  Some Javadoc. </p>
+ */
+// violation 2 lines above '<p> tag should be placed immediately before the first word'
+public class InputJavadocParagraphIncorrectOpenClosedTag2 {
+
+    /**
+    * some javadoc.
+    * <p></p>
+    */
+    // violation 2 lines above '<p> tag should be preceded with an empty line.'
+    int a;
+
+    // 2 violations 4 lines below:
+    //  '<p> tag should be placed immediately before the first word'
+    //  '<p> tag should be preceded with an empty line.'
+    /**
+    * Some Javadoc.<P>
+    * Some Javadoc.<P></P>
+    */
+    // violation 2 lines above '<p> tag should be preceded with an empty line.'
+    int b;
+
+    // violation below 'Redundant <p> tag.'
+    /**<p>some javadoc.</p>
+    *
+    * Some <p>Javadoc.</p>
+    *
+    * Some <p>Javadoc.</p>
+    */
+    // violation 5 lines above 'Empty line should be followed by <p> tag on the next line.'
+    // violation 4 lines above 'Empty line should be followed by <p> tag on the next line.'
+    int c;
+
+    /**
+    * Some Summary.
+    *
+    * <p>
+    *   Some Javadoc. // ok until #15762
+    * </p>
+    */
+    // violation 4 lines above '<p> tag should be placed immediately before the first word'
+    int d;
+
+    // 2 violations 6 lines below:
+    //  '<p> tag should be placed immediately before the first word'
+    //  '<p> tag should not precede HTML block-tag '<ul>''
+    /**
+    * Some Summary.
+    *
+    * <p>
+    *   <ul> // ok until #15762
+    *     <li>Item 1</li> // ok until #15762
+    *     <li>Item 2</li> // ok until #15762
+    *     <li>Item 3</li> // ok until #15762
+    *   </ul> // ok until #15762
+    * </p>
+    */
+    int e;
+
+    /**
+    * Some Summary.
+    *
+    * <p><b>testing....</b></p>
+    *
+    * <p><h1>testing....</h1></p>
+    */
+    // violation 2 lines above '<p> tag should not precede HTML block-tag '<h1>''
+    int f;
+
+    // violation 4 lines below '<p> tag should be placed immediately before the first word'
+    /**
+    * Some Summary.
+    *
+    * <p>
+    *     <b>testing....</b>
+    * </p>
+    *
+    * <p>
+    *     <h1>testing....</h1>
+    * </p>
+    */
+    // 2 violations 4 lines above:
+    //  '<p> tag should be placed immediately before the first word'
+    //  '<p> tag should not precede HTML block-tag '<h1>''
+    int g;
+}

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadocparagraph/InputJavadocParagraphIncorrectOpenClosedTag3.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadocparagraph/InputJavadocParagraphIncorrectOpenClosedTag3.java
@@ -1,0 +1,42 @@
+/*
+JavadocParagraph
+violateExecutionOnNonTightHtml = (default)false
+allowNewlineParagraph = (default)true
+
+
+*/
+
+package com.puppycrawl.tools.checkstyle.checks.javadoc.javadocparagraph;
+
+public class InputJavadocParagraphIncorrectOpenClosedTag3 {
+    /**
+    * Some Summary.
+    *
+    * <p><!-- comment is required --> extra space in paragraph after comment is violation</p>
+    */
+    // violation 2 lines above '<p> tag should be placed immediately before the first word'
+    int a;
+
+    /**
+    * Some Summary.
+    *
+    * <p> <!-- comment is required -->extra space in paragraph before comment is violation</p>
+    */
+    // violation 2 lines above '<p> tag should be placed immediately before the first word'
+    int b;
+
+    /**
+    * Some Summary.
+    *
+    * <p> <!-- comment is required --> both cases combined, this is also violation</p>
+    */
+    // violation 2 lines above '<p> tag should be placed immediately before the first word'
+    int c;
+
+    /**
+    * Some Summary.
+    *
+    * <p><!-- comment is required -->no extra spaces, this is okay</p>
+    */
+    int d;
+}

--- a/src/xdocs/checks/javadoc/javadocparagraph.xml
+++ b/src/xdocs/checks/javadoc/javadocparagraph.xml
@@ -29,6 +29,10 @@
             nested paragraph tags are allowed to do that.
           </li>
         </ul>
+        <p><b>ATTENTION:</b></p>
+        <p>This Check ignores HTML comments.</p>
+        <p>The Check ignores all the nested paragraph tags,
+        it will not give any kind of violation if the paragraph tag is nested.</p>
       </subsection>
 
       <subsection name="Properties" id="Properties">

--- a/src/xdocs/checks/javadoc/javadocparagraph.xml.template
+++ b/src/xdocs/checks/javadoc/javadocparagraph.xml.template
@@ -29,6 +29,10 @@
             nested paragraph tags are allowed to do that.
           </li>
         </ul>
+        <p><b>ATTENTION:</b></p>
+        <p>This Check ignores HTML comments.</p>
+        <p>The Check ignores all the nested paragraph tags,
+        it will not give any kind of violation if the paragraph tag is nested.</p>
       </subsection>
 
       <subsection name="Properties" id="Properties">


### PR DESCRIPTION
fixes #15685 https://github.com/checkstyle/checkstyle/issues/15732

tried fixing the implementation of JavadocParagraph ~might have introduced new false-negatives :p~

I tried to make the Check work same way when the paragraph tag's corresponding closing tag is also present.

when I tried to run build command locally, I got so many errors for different files like checks, filters, etc for `<p>` tag. Most of them were for:

```
<p> tag should be placed immediately before the first word, with no space after.
```

@romani need your help here

---

Diff Regression config: https://gist.githubusercontent.com/Zopsss/013f379d4c821f2d624be56212a64575/raw/5f17ec9186d4421396429ab38cbac3e4663bf4eb/javadocparagraph_config.xml
Diff Regression projects: https://raw.githubusercontent.com/checkstyle/contribution/master/checkstyle-tester/projects-to-test-on-for-github-action.properties