### PR TITLE
JavadocMethodCheck: removed unnecessary tokens from acceptable

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocMethodCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocMethodCheck.java
@@ -338,12 +338,7 @@ public class JavadocMethodCheck extends AbstractCheck {
 
     @Override
     public final int[] getRequiredTokens() {
-        return new int[] {
-            TokenTypes.CLASS_DEF,
-            TokenTypes.INTERFACE_DEF,
-            TokenTypes.ENUM_DEF,
-            TokenTypes.RECORD_DEF,
-        };
+        return CommonUtil.EMPTY_INT_ARRAY;
     }
 
     @Override
@@ -354,25 +349,16 @@ public class JavadocMethodCheck extends AbstractCheck {
     @Override
     public int[] getAcceptableTokens() {
         return new int[] {
-            TokenTypes.CLASS_DEF,
-            TokenTypes.ENUM_DEF,
-            TokenTypes.INTERFACE_DEF,
             TokenTypes.METHOD_DEF,
             TokenTypes.CTOR_DEF,
             TokenTypes.ANNOTATION_FIELD_DEF,
-            TokenTypes.RECORD_DEF,
             TokenTypes.COMPACT_CTOR_DEF,
         };
     }
 
     @Override
     public final void visitToken(DetailAST ast) {
-        if (ast.getType() == TokenTypes.METHOD_DEF
-                 || ast.getType() == TokenTypes.CTOR_DEF
-                 || ast.getType() == TokenTypes.ANNOTATION_FIELD_DEF
-                 || ast.getType() == TokenTypes.COMPACT_CTOR_DEF) {
-            processAST(ast);
-        }
+        processAST(ast);
     }
 
     /**

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocMethodCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocMethodCheckTest.java
@@ -49,13 +49,9 @@ public class JavadocMethodCheckTest extends AbstractModuleTestSupport {
 
         final int[] actual = javadocMethodCheck.getAcceptableTokens();
         final int[] expected = {
-            TokenTypes.CLASS_DEF,
-            TokenTypes.ENUM_DEF,
-            TokenTypes.INTERFACE_DEF,
             TokenTypes.METHOD_DEF,
             TokenTypes.CTOR_DEF,
             TokenTypes.ANNOTATION_FIELD_DEF,
-            TokenTypes.RECORD_DEF,
             TokenTypes.COMPACT_CTOR_DEF,
         };
 
@@ -420,12 +416,7 @@ public class JavadocMethodCheckTest extends AbstractModuleTestSupport {
 
     @Test
     public void testGetRequiredTokens() {
-        final int[] expected = {
-            TokenTypes.CLASS_DEF,
-            TokenTypes.INTERFACE_DEF,
-            TokenTypes.ENUM_DEF,
-            TokenTypes.RECORD_DEF,
-        };
+        final int[] expected = CommonUtil.EMPTY_INT_ARRAY;
         final JavadocMethodCheck check = new JavadocMethodCheck();
         final int[] actual = check.getRequiredTokens();
         assertWithMessage("Required tokens differ from expected")

--- a/src/test/resources-noncompilable/com/puppycrawl/tools/checkstyle/checks/javadoc/javadocmethod/InputJavadocMethodRecordsAndCompactCtors.java
+++ b/src/test/resources-noncompilable/com/puppycrawl/tools/checkstyle/checks/javadoc/javadocmethod/InputJavadocMethodRecordsAndCompactCtors.java
@@ -5,7 +5,7 @@ validateThrows = true
 accessModifiers = (default)public, protected, package, private
 allowMissingParamTags = (default)false
 allowMissingReturnTag = (default)false
-tokens = METHOD_DEF, CTOR_DEF, ANNOTATION_FIELD_DEF, COMPACT_CTOR_DEF, RECORD_DEF, CLASS_DEF
+tokens = METHOD_DEF, CTOR_DEF, ANNOTATION_FIELD_DEF, COMPACT_CTOR_DEF
 
 
 */


### PR DESCRIPTION
Unrelated to https://github.com/checkstyle/checkstyle/issues/15683 but noticed when looking at it and the code.

We set required tokens in this Check which aren't needed. With them removed, we are able to remove a bit of code which was blocking violations on those tokens.

Tokens to remove from acceptable:
TokenTypes.CLASS_DEF,
TokenTypes.ENUM_DEF,
TokenTypes.INTERFACE_DEF,
TokenTypes.RECORD_DEF

Regression: https://rveach.no-ip.org/checkstyle/regression/4/
No differences.


**Migration note:**
Remove above tokens from config if used.
