### PR TITLE
supplemental: testing suppressions by generating diff reports

### DIFF
--- a/src/main/resources/google_checks.xml
+++ b/src/main/resources/google_checks.xml
@@ -100,22 +100,25 @@
     <module name="RightCurly">
       <property name="id" value="RightCurlySame"/>
       <property name="tokens"
-               value="LITERAL_TRY, LITERAL_CATCH, LITERAL_FINALLY, LITERAL_IF, LITERAL_ELSE,
-                    LITERAL_DO"/>
+                value="LITERAL_IF, LITERAL_DO"/>
     </module>
     <module name="RightCurly">
       <property name="id" value="RightCurlyAlone"/>
       <property name="option" value="alone"/>
       <property name="tokens"
-               value="CLASS_DEF, METHOD_DEF, CTOR_DEF, LITERAL_FOR, LITERAL_WHILE, STATIC_INIT,
+                value="CLASS_DEF, METHOD_DEF, CTOR_DEF, LITERAL_FOR, LITERAL_WHILE, STATIC_INIT,
                     INSTANCE_INIT, ANNOTATION_DEF, ENUM_DEF, INTERFACE_DEF, RECORD_DEF,
-                    COMPACT_CTOR_DEF, LITERAL_SWITCH, LITERAL_CASE"/>
+                    COMPACT_CTOR_DEF, LITERAL_SWITCH, LITERAL_CASE, LITERAL_CATCH, LITERAL_FINALLY, LITERAL_ELSE, LITERAL_TRY"/>
     </module>
     <module name="SuppressionXpathSingleFilter">
       <!-- suppression is required till https://github.com/checkstyle/checkstyle/issues/7541 -->
       <property name="id" value="RightCurlyAlone"/>
       <property name="query" value="//RCURLY[parent::SLIST[count(./*)=1]
-                                     or preceding-sibling::*[last()][self::LCURLY]]"/>
+        and not(parent::*/parent::LITERAL_ELSE
+        or parent::*/parent::LITERAL_TRY
+        or parent::*/parent::LITERAL_CATCH
+        or parent::*/parent::LITERAL_FINALLY)
+        or preceding-sibling::*[last()][self::LCURLY]]"/>
     </module>
     <module name="WhitespaceAfter">
       <property name="tokens"


### PR DESCRIPTION
#15664 testing out suppressions to detect KR Style Blocks.

I used 3 different types of suppressions for generating diff report,

```xml
    <module name="SuppressionXpathSingleFilter">
      <!-- suppresion is required till https://github.com/checkstyle/checkstyle/issues/7541 -->
      <property name="id" value="RightCurlyAlone"/>
      <property name="query" value="//RCURLY[parent::SLIST[count(./*)=1]
                                    or preceding-sibling::*[last()][self::LCURLY]
                                    and not(parent::*/parent::LITERAL_ELSE or
                                    parent::*/parent::LITERAL_CATCH or
                                    parent::*/parent::LITERAL_FINALLY)]"/>
    </module>
```

and

```xml
    <module name="SuppressionXpathSingleFilter">
      <!-- suppresion is required till https://github.com/checkstyle/checkstyle/issues/7541 -->
      <property name="id" value="RightCurlyAlone"/>
      <property name="query" value="//RCURLY[parent::SLIST[count(./*)=1]
                                    and not(parent::*/parent::LITERAL_ELSE or
                                    parent::*/parent::LITERAL_CATCH or
                                    parent::*/parent::LITERAL_FINALLY)]"/>
    </module>
```

Both of this will not work, just generating diff to see how these two suppressions acts in different situations. I have explained defect of both of these suppressions [here](https://github.com/checkstyle/checkstyle/issues/15664#issuecomment-2361751694).

Third suppression was provided by @rdiachenko at https://github.com/checkstyle/checkstyle/issues/15664#issuecomment-2408964272, I modified it a bit:

```diff
$ git diff -u ruslan_original_suppression.xml  ruslan_modified_suppression.xml
diff --git a/ruslan_original_suppression.xml b/ruslan_modified_suppression.xml
index fffeb23..edd6a34 100644
--- a/ruslan_original_suppression.xml
+++ b/ruslan_modified_suppression.xml
@@ -1,7 +1,7 @@
 <module name="RightCurly">
     <property name="id" value="RightCurlySame"/>
     <property name="tokens"
-            value="LITERAL_TRY, LITERAL_IF, LITERAL_DO"/>
+            value="LITERAL_IF, LITERAL_DO"/>
 </module>
 <module name="RightCurly">
     <property name="id" value="RightCurlyAlone"/>
@@ -9,14 +9,15 @@
     <property name="tokens"
             value="CLASS_DEF, METHOD_DEF, CTOR_DEF, LITERAL_FOR, LITERAL_WHILE, STATIC_INIT,
                 INSTANCE_INIT, ANNOTATION_DEF, ENUM_DEF, INTERFACE_DEF, RECORD_DEF,
-                COMPACT_CTOR_DEF, LITERAL_SWITCH, LITERAL_CASE, LITERAL_CATCH, LITERAL_FINALLY, LITERAL_ELSE"/>
+                COMPACT_CTOR_DEF, LITERAL_SWITCH, LITERAL_CASE, LITERAL_CATCH, LITERAL_FINALLY, LITERAL_ELSE, LITERAL_TRY"/>
 </module>
 <module name="SuppressionXpathSingleFilter">
     <!-- suppression is required till https://github.com/checkstyle/checkstyle/issues/7541 -->
     <property name="id" value="RightCurlyAlone"/>
     <property name="query" value="//RCURLY[parent::SLIST[count(./*)=1]
-        and not(parent::*/parent::LITERAL_ELSE
-        or parent::*/parent::LITERAL_CATCH
-        or parent::*/parent::LITERAL_FINALLY)
-        or preceding-sibling::*[last()][self::LCURLY]]"/>
+    and not(parent::*/parent::LITERAL_ELSE
+    or parent::*/parent::LITERAL_TRY
+    or parent::*/parent::LITERAL_CATCH
+    or parent::*/parent::LITERAL_FINALLY)
+    or preceding-sibling::*[last()][self::LCURLY]]"/>
 </module>
```

to detect try's braces, for example:

```java
    try (MyResource r = new MyResource()) { }
    try (MyResource r = new MyResource()) {}
    try (MyResource r = new MyResource()) {} catch (Exception expected) {}
    try (MyResource r = new MyResource()) {} catch (Exception expected) { }
```

Diff Regression config: https://gist.githubusercontent.com/Zopsss/eef363a452104d034a9ce7be532f647d/raw/3a36ba1cad81f3dff628f24c1c9b1591a2c5ef78/master_google_checks.xml
Diff Regression patch config: https://gist.githubusercontent.com/Zopsss/f57c64b2ba592ec4d75e88996a781311/raw/bf0562845e278506cbe1f12cd49a04c0f7e69b44/ruslan_kr_block_suppression_google_checks.xml
Diff Regression projects: https://gist.githubusercontent.com/Zopsss/22adadb570e4deb95296917244c580b3/raw/144d72ee70de11891eabe4a342cbb0da37153a20/projects-to-test-on-for-github-action.properties

Report label: Ruslan's suppression