### PR TITLE
Issue #15503: Added support for violation of p tag if it precedes a block tag

### DIFF
--- a/src/it/resources/com/google/checkstyle/test/chapter7javadoc/rule712paragraphs/InputCorrectJavadocParagraph.java
+++ b/src/it/resources/com/google/checkstyle/test/chapter7javadoc/rule712paragraphs/InputCorrectJavadocParagraph.java
@@ -28,9 +28,7 @@ class InputCorrectJavadocParagraph {
    * }
    * </pre>
    *
-   * @see <a
-   *     href="http://www.gwtproject.org/doc/latest/DevGuideOrganizingProjects.html#DevGuideModules">
-   *     Documentation about GWT emulated source</a>
+   * @see <a href="example.com">Documentation about GWT emulated source</a>
    */
   boolean emulated() {
     return false;
@@ -59,9 +57,7 @@ class InputCorrectJavadocParagraph {
      *
      * <p>Some Javadoc.
      *
-     * @see <a
-     *     href="http://www.gwtproject.org/doc/latest/DevGuideOrganizingProjects.html#DevGuideModules">
-     *     Documentation about GWT emulated source</a>
+     * @see <a href="example.com">Documentation about GWT emulated source</a>
      */
     boolean emulated() {
       return false;
@@ -89,9 +85,7 @@ class InputCorrectJavadocParagraph {
          *
          * <p>Some Javadoc.
          *
-         * @see <a
-         *     href="http://www.gwtproject.org/doc/latest/DevGuideOrganizingProjects.html#DevGuideModules">
-         *     Documentation about GWT emulated source</a>
+         * @see <a href="example.com">Documentation about GWT emulated source</a>
          */
         boolean emulated() {
           return false;

--- a/src/it/resources/com/google/checkstyle/test/chapter7javadoc/rule712paragraphs/InputFormattedCorrectJavadocParagraph.java
+++ b/src/it/resources/com/google/checkstyle/test/chapter7javadoc/rule712paragraphs/InputFormattedCorrectJavadocParagraph.java
@@ -28,9 +28,7 @@ class InputFormattedCorrectJavadocParagraph {
    * }
    * </pre>
    *
-   * @see <a
-   *     href="http://www.gwtproject.org/doc/latest/DevGuideOrganizingProjects.html#DevGuideModules">
-   *     Documentation about GWT emulated source</a>
+   * @see <a href="example.com">Documentation about GWT emulated source</a>
    */
   boolean emulated() {
     return false;
@@ -59,9 +57,7 @@ class InputFormattedCorrectJavadocParagraph {
      *
      * <p>Some Javadoc.
      *
-     * @see <a
-     *     href="http://www.gwtproject.org/doc/latest/DevGuideOrganizingProjects.html#DevGuideModules">
-     *     Documentation about GWT emulated source</a>
+     * @see <a href="example.com">Documentation about GWT emulated source</a>
      */
     boolean emulated() {
       return false;
@@ -89,9 +85,7 @@ class InputFormattedCorrectJavadocParagraph {
          *
          * <p>Some Javadoc.
          *
-         * @see <a
-         *     href="http://www.gwtproject.org/doc/latest/DevGuideOrganizingProjects.html#DevGuideModules">
-         *     Documentation about GWT emulated source</a>
+         * @see <a href="example.com">Documentation about GWT emulated source</a>
          */
         boolean emulated() {
           return false;

--- a/src/it/resources/com/google/checkstyle/test/chapter7javadoc/rule712paragraphs/InputFormattedIncorrectJavadocParagraph.java
+++ b/src/it/resources/com/google/checkstyle/test/chapter7javadoc/rule712paragraphs/InputFormattedIncorrectJavadocParagraph.java
@@ -29,9 +29,7 @@ class InputFormattedIncorrectJavadocParagraph {
    *
    * <p>Some Javadoc.
    *
-   * @see <a
-   *     href="http://www.gwtproject.org/doc/latest/DevGuideOrganizingProjects.html#DevGuideModules">
-   *     Documentation about GWT emulated source</a>
+   * @see <a href="example.com">Documentation about GWT emulated source</a>
    */
   boolean emulated() {
     return false;
@@ -77,9 +75,7 @@ class InputFormattedIncorrectJavadocParagraph {
      *
      * <p>
      *
-     * @see <a
-     *     href="http://www.gwtproject.org/doc/latest/DevGuideOrganizingProjects.html#DevGuideModules">
-     *     Documentation about GWT emulated source</a>
+     * @see <a href="example.com">Documentation about GWT emulated source</a>
      */
     boolean emulated() {
       return false;
@@ -106,9 +102,7 @@ class InputFormattedIncorrectJavadocParagraph {
          *
          * <p>Some Javadoc.
          *
-         * @see <a
-         *     href="http://www.gwtproject.org/doc/latest/DevGuideOrganizingProjects.html#DevGuideModules">
-         *     Documentation about
+         * @see <a href="example.com">Documentation about
          *     <p>GWT emulated source</a>
          */
         // violation 2 lines above '<p> tag should be preceded with an empty line.'
@@ -117,7 +111,9 @@ class InputFormattedIncorrectJavadocParagraph {
         }
       };
 
-  // violation 4 lines below '<p> tag should be placed immediately before the first word'
+  // 2 violations 6 lines below:
+  //  '<p> tag should be placed immediately before the first word'
+  //  '<p> tag should not precede HTML block-tag '<h1>''
   /**
    * Some summary.
    *
@@ -126,7 +122,10 @@ class InputFormattedIncorrectJavadocParagraph {
    * <h1>Testing...</h1>
    */
   class InnerPrecedingPtag {
-    // violation 4 lines below '<p> tag should be placed immediately before the first word'
+
+    // 2 violations 6 lines below:
+    //  '<p> tag should be placed immediately before the first word'
+    //  '<p> tag should not precede HTML block-tag '<ul>''
     /**
      * Some summary.
      *
@@ -134,7 +133,7 @@ class InputFormattedIncorrectJavadocParagraph {
      *
      * <ul>
      *   <p>
-     *   <li>1 // should NOT give violation as there is not empty line before
+     *   <li>1 should NOT give violation as there is not empty line before
      * </ul>
      */
     // 2 violations 4 lines above:
@@ -142,7 +141,9 @@ class InputFormattedIncorrectJavadocParagraph {
     //  '<p> tag should be preceded with an empty line.'
     public void foo() {}
 
-    // violation 4 lines below '<p> tag should be placed immediately before the first word'
+    // 2 violations 6 lines below:
+    //  '<p> tag should be placed immediately before the first word'
+    //  '<p> tag should not precede HTML block-tag '<table>''
     /**
      * Some summary.
      *
@@ -153,7 +154,9 @@ class InputFormattedIncorrectJavadocParagraph {
      */
     public void fooo() {}
 
-    // violation 4 lines below '<p> tag should be placed immediately before the first word'
+    // 2 violations 6 lines below:
+    //  '<p> tag should be placed immediately before the first word'
+    //  '<p> tag should not precede HTML block-tag '<pre>''
     /**
      * Some summary.
      *

--- a/src/it/resources/com/google/checkstyle/test/chapter7javadoc/rule712paragraphs/InputIncorrectJavadocParagraph.java
+++ b/src/it/resources/com/google/checkstyle/test/chapter7javadoc/rule712paragraphs/InputIncorrectJavadocParagraph.java
@@ -33,8 +33,7 @@ class InputIncorrectJavadocParagraph {
    *
    * <p>Some Javadoc.
    *
-   * @see <a
-   *     href="http://www.gwtproject.org/doc/latest/DevGuideOrganizingProjects.html#DevGuideModules">
+   * @see <a href="example.com">
    *     Documentation about GWT emulated source</a>
    */
   boolean emulated() {
@@ -80,14 +79,13 @@ class InputIncorrectJavadocParagraph {
      *
      * <p>
      *   Some Javadoc.<p>
-     * @see <a
-     *     href="http://www.gwtproject.org/doc/latest/DevGuideOrganizingProjects.html#DevGuideModules">
+     * @see <a href="example.com">
      *     Documentation about GWT emulated source</a>
      */
-    // 2 violations 5 lines above:
+    // 2 violations 4 lines above:
     //  '<p> tag should be placed immediately before the first word'
     //  '<p> tag should be preceded with an empty line.'
-    // violation 7 lines above 'Javadoc tag '@see' should be preceded with an empty line.'
+    // violation 6 lines above 'Javadoc tag '@see' should be preceded with an empty line.'
     boolean emulated() {
       return false;
     }
@@ -115,7 +113,7 @@ class InputIncorrectJavadocParagraph {
          *
          *  <p>  Some Javadoc.
          *
-         * @see <a href="http://www.gwtproject.org/doc/latest/DevGuideOrganizingProjects.html#DevGuideModules">
+         * @see <a href="example.com">
          *     Documentation about <p> GWT emulated source</a>
          */
         // 2 violations 2 lines above:
@@ -140,7 +138,7 @@ class InputIncorrectJavadocParagraph {
      *<p>
      *  <ul>
      *    <p>
-     *      <li>1</li> // should NOT give violation as there is not empty line before
+     *      <li>1</li> should NOT give violation as there is not empty line before
      *    </p>
      *  </ul>
      *</p>

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocParagraphCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocParagraphCheck.java
@@ -19,6 +19,10 @@
 
 package com.puppycrawl.tools.checkstyle.checks.javadoc;
 
+import java.util.Set;
+
+import javax.annotation.Nullable;
+
 import com.puppycrawl.tools.checkstyle.StatelessCheck;
 import com.puppycrawl.tools.checkstyle.api.DetailNode;
 import com.puppycrawl.tools.checkstyle.api.JavadocTokenTypes;
@@ -70,6 +74,9 @@ import com.puppycrawl.tools.checkstyle.utils.JavadocUtil;
  * {@code javadoc.paragraph.misplaced.tag}
  * </li>
  * <li>
+ * {@code javadoc.paragraph.preceded.block.tag}
+ * </li>
+ * <li>
  * {@code javadoc.paragraph.redundant.paragraph}
  * </li>
  * <li>
@@ -114,6 +121,20 @@ public class JavadocParagraphCheck extends AbstractJavadocCheck {
      * file.
      */
     public static final String MSG_MISPLACED_TAG = "javadoc.paragraph.misplaced.tag";
+
+    /**
+     * A key is pointing to the warning message text in "messages.properties"
+     * file.
+     */
+    public static final String MSG_PRECEDED_BLOCK_TAG = "javadoc.paragraph.preceded.block.tag";
+
+    /**
+     * Set of block tags supported by this check.
+     */
+    private static final Set<String> BLOCK_TAGS =
+            Set.of("address", "blockquote", "div", "dl",
+                   "h1", "h2", "h3", "h4", "h5", "h6", "hr",
+                   "ol", "p", "pre", "table", "ul");
 
     /**
      * Control whether the &lt;p&gt; tag should be placed immediately before the first word.
@@ -181,12 +202,79 @@ public class JavadocParagraphCheck extends AbstractJavadocCheck {
         else if (newLine == null || tag.getLineNumber() - newLine.getLineNumber() != 1) {
             log(tag.getLineNumber(), MSG_LINE_BEFORE);
         }
+
+        final String blockTagName = findFollowedBlockTagName(tag);
+        if (blockTagName != null) {
+            log(tag.getLineNumber(), MSG_PRECEDED_BLOCK_TAG, blockTagName);
+        }
+
         if (!allowNewlineParagraph && isImmediatelyFollowedByNewLine(tag)) {
             log(tag.getLineNumber(), MSG_MISPLACED_TAG);
         }
         if (isImmediatelyFollowedByText(tag)) {
             log(tag.getLineNumber(), MSG_MISPLACED_TAG);
         }
+    }
+
+    /**
+     * Determines whether or not the paragraph tag is followed by block tag.
+     *
+     * @param tag html tag.
+     * @return block tag if the paragraph tag is followed by block tag or null if not found.
+     */
+    @Nullable
+    private static String findFollowedBlockTagName(DetailNode tag) {
+        final DetailNode htmlElement = findFirstHtmlElementAfter(tag);
+        String blockTagName = null;
+
+        if (htmlElement != null) {
+            blockTagName = getHtmlElementName(htmlElement);
+        }
+
+        return blockTagName;
+    }
+
+    /**
+     * Finds and returns first html element after the tag.
+     *
+     * @param tag html tag.
+     * @return first html element after the paragraph tag or null if not found.
+     */
+    @Nullable
+    private static DetailNode findFirstHtmlElementAfter(DetailNode tag) {
+        DetailNode htmlElement = JavadocUtil.getNextSibling(tag);
+
+        while (htmlElement != null && htmlElement.getType() != JavadocTokenTypes.HTML_ELEMENT) {
+            if ((htmlElement.getType() == JavadocTokenTypes.TEXT
+                    || htmlElement.getType() == JavadocTokenTypes.JAVADOC_INLINE_TAG)
+                    && !CommonUtil.isBlank(htmlElement.getText())) {
+                htmlElement = null;
+                break;
+            }
+            htmlElement = JavadocUtil.getNextSibling(htmlElement);
+        }
+
+        return htmlElement;
+    }
+
+    /**
+     * Finds and returns first block-level html element name.
+     *
+     * @param htmlElement block-level html tag.
+     * @return block-level html element name or null if not found.
+     */
+    @Nullable
+    private static String getHtmlElementName(DetailNode htmlElement) {
+        final DetailNode htmlTag = JavadocUtil.getFirstChild(htmlElement);
+        final DetailNode htmlTagFirstChild = JavadocUtil.getFirstChild(htmlTag);
+        final DetailNode htmlTagName =
+                JavadocUtil.findFirstToken(htmlTagFirstChild, JavadocTokenTypes.HTML_TAG_NAME);
+        String blockTagName = null;
+        if (htmlTagName != null && BLOCK_TAGS.contains(htmlTagName.getText())) {
+            blockTagName = htmlTagName.getText();
+        }
+
+        return blockTagName;
     }
 
     /**
@@ -288,5 +376,4 @@ public class JavadocParagraphCheck extends AbstractJavadocCheck {
         final DetailNode nextSibling = JavadocUtil.getNextSibling(tag);
         return nextSibling.getType() == JavadocTokenTypes.NEWLINE;
     }
-
 }

--- a/src/main/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/messages.properties
+++ b/src/main/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/messages.properties
@@ -20,6 +20,7 @@ javadoc.noPeriod=First sentence should end with a period.
 javadoc.packageInfo=Missing package-info.java file.
 javadoc.paragraph.line.before=<p> tag should be preceded with an empty line.
 javadoc.paragraph.misplaced.tag=<p> tag should be placed immediately before the first word, with no space after.
+javadoc.paragraph.preceded.block.tag=<p> tag should not precede HTML block-tag ''<{0}>'', <p> tag should be removed.
 javadoc.paragraph.redundant.paragraph=Redundant <p> tag.
 javadoc.paragraph.tag.after=Empty line should be followed by <p> tag on the next line.
 javadoc.parse.rule.error=Javadoc comment at column {0} has parse error. Details: {1} while parsing {2}

--- a/src/main/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/messages_de.properties
+++ b/src/main/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/messages_de.properties
@@ -20,6 +20,7 @@ javadoc.noPeriod=Der erste Satz sollte mit einem Punkt enden.
 javadoc.packageInfo=Es fehlt eine package-info.java.
 javadoc.paragraph.line.before=Einem <p>-Tag im Javadoc sollte eine leere Zeile vorangestellt werden.
 javadoc.paragraph.misplaced.tag=<p>-Tag sollte unmittelbar vor dem ersten Wort platziert werden, ohne Leerzeichen dazwischen.
+javadoc.paragraph.preceded.block.tag=Das <p>-Tag sollte nicht vor dem HTML-Block-Tag „<{0}>“ stehen. Das <p>-Tag sollte entfernt werden.
 javadoc.paragraph.redundant.paragraph=Redundantes <p>-Tag.
 javadoc.paragraph.tag.after=Auf eine leere Zeile im Javadoc sollte ein <p>-Tag in der nächsten Zeile folgen.
 javadoc.parse.rule.error=Der Javadoc-Kommentar an Position {0} führt zu einem Parserfehler. Details: {1} beim Parsen von {2}

--- a/src/main/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/messages_es.properties
+++ b/src/main/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/messages_es.properties
@@ -20,6 +20,7 @@ javadoc.noPeriod=La primera frase debería finalizar con un punto.
 javadoc.packageInfo=Falta el archivo package-info.java.
 javadoc.paragraph.line.before=<p> etiqueta debe ir precedida de una línea vacía.
 javadoc.paragraph.misplaced.tag=<p> etiqueta debe colocarse inmediatamente antes de la primera palabra, sin espacio después.
+javadoc.paragraph.preceded.block.tag=La etiqueta <p> no debe preceder a la etiqueta de bloque HTML ''<{0}>'', la etiqueta <p> debe eliminarse.
 javadoc.paragraph.redundant.paragraph=Redundante etiqueta <p>.
 javadoc.paragraph.tag.after=Línea de vacío debe ser seguido por etiqueta <p> en la línea siguiente.
 javadoc.parse.rule.error=Javadoc comentario en la columna {0} tiene parse error. Detalles: {1} al analizar {2}

--- a/src/main/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/messages_fi.properties
+++ b/src/main/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/messages_fi.properties
@@ -20,6 +20,7 @@ javadoc.noPeriod=Ensimmäinen virke pitäisi päättyä aikana.
 javadoc.packageInfo=Puuttuu package-info.java tiedosto.
 javadoc.paragraph.line.before=<P> tag pitäisi edeltää tyhjä rivi.
 javadoc.paragraph.misplaced.tag=<P> tag olisi sijoitettava välittömästi ennen ensimmäistä sanaa, jossa ei ole tilaa jälkeen.
+javadoc.paragraph.preceded.block.tag=<p>-tunniste ei saa edeltää HTML-lohkotunnistetta ''<{0}>'', <p>-tunniste tulee poistaa.
 javadoc.paragraph.redundant.paragraph=Turhat <p> tag.
 javadoc.paragraph.tag.after=Tyhjä rivi jälkeen olisi <p> ​​tag seuraavalla rivillä.
 javadoc.parse.rule.error=Javadoc kommentti sarakkeessa {0} on Jäsennysvirhe. Tiedot: {1} jäsennettäessä {2}

--- a/src/main/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/messages_fr.properties
+++ b/src/main/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/messages_fr.properties
@@ -20,6 +20,7 @@ javadoc.noPeriod=La première ligne de la Javadoc doit se terminer avec un point
 javadoc.packageInfo=Le fichier package-info.java est manquant.
 javadoc.paragraph.line.before=La balise <p> doit être précédée d''une ligne vide.
 javadoc.paragraph.misplaced.tag=La balise <p> doit être placée immédiatement avant le premier mot, sans espace après.
+javadoc.paragraph.preceded.block.tag=La balise <p> ne doit pas précéder la balise de bloc HTML ''<{0}>'', la balise <p> doit être supprimée.
 javadoc.paragraph.redundant.paragraph=Balise <p> redondante.
 javadoc.paragraph.tag.after=Une ligne vide doit être suivie par une balise <p> sur la ligne suivante.
 javadoc.parse.rule.error=Le commentaire Javadoc à la colonne {0} ne peut être analysé. Détails : {1} lors de l''analyse {2}

--- a/src/main/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/messages_ja.properties
+++ b/src/main/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/messages_ja.properties
@@ -20,6 +20,7 @@ javadoc.noPeriod=最初の一文はピリオドで終わらなければなりま
 javadoc.packageInfo=package-info.javaファイルがありません。
 javadoc.paragraph.line.before=<p> タグの前には空行を入れてください。
 javadoc.paragraph.misplaced.tag=<p> タグは、最初の単語のすぐ前に記載してください。タグの後ろにスペースを入れないでください。
+javadoc.paragraph.preceded.block.tag=<p> タグを HTML ブロックタグ ''<{0}>'' の前に置くことはできません。<p> タグは削除する必要があります。
 javadoc.paragraph.redundant.paragraph=冗長な <p> タグです。
 javadoc.paragraph.tag.after=<p> タグの次の行には空行を入れてください。
 javadoc.parse.rule.error={0} 桁目の Javadoc コメントでパースエラーが発生しました。詳細: {1}、{2} の解析中に発生。

--- a/src/main/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/messages_pt.properties
+++ b/src/main/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/messages_pt.properties
@@ -20,6 +20,7 @@ javadoc.noPeriod=A primeira frase do Javadoc deveria acabar num ponto final.
 javadoc.packageInfo=O arquivo package-info.java está faltando.
 javadoc.paragraph.line.before=A tag <p> deveria ser precedida por uma linha vazia.
 javadoc.paragraph.misplaced.tag=A tag <p> deveria ser colocada imediatamente antes da primeira palavra, sem espaço depois.
+javadoc.paragraph.preceded.block.tag=A tag <p> não deve preceder a tag de bloco HTML ''<{0}>'', a tag <p> deve ser removida.
 javadoc.paragraph.redundant.paragraph=Tag <p> redundante.
 javadoc.paragraph.tag.after=A linha vazia deveria ser seguida por uma tag <p> na linha seguinte.
 javadoc.parse.rule.error=O comentário Javadoc na coluna {0} tem um erro sintático. Detalhes: {1} ao analisar {2}

--- a/src/main/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/messages_ru.properties
+++ b/src/main/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/messages_ru.properties
@@ -20,6 +20,7 @@ javadoc.noPeriod=Первое предложение Javadoc должно зак
 javadoc.packageInfo=Пропущен файл package-info.java.
 javadoc.paragraph.line.before=Перед тегом <p> должна быть пустая строка.
 javadoc.paragraph.misplaced.tag=Тег <p> должен стоять перед первым символом, сразу после последнего, без пробелов между ними.
+javadoc.paragraph.preceded.block.tag=Тег <p> не должен предшествовать блочному тегу HTML ''<{0}>'', тег <p> следует удалить.
 javadoc.paragraph.redundant.paragraph=Лишний тег <p>.
 javadoc.paragraph.tag.after=После тега <p> должна быть пустая строка.
 javadoc.parse.rule.error=Ошибка синтаксического анализа Javadoc в символе {0}. Подробнее: {1} во время разбора {2}

--- a/src/main/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/messages_tr.properties
+++ b/src/main/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/messages_tr.properties
@@ -20,6 +20,7 @@ javadoc.noPeriod=İlk cümle nokta ile bitmeli.
 javadoc.packageInfo=package-info.java dosyası eksik.
 javadoc.paragraph.line.before=<p> etiketi boş bir çizgi ile gelmelidir.
 javadoc.paragraph.misplaced.tag=<p> etiketi sonra boşluk, ilk kelimenin hemen önce konulmalıdır.
+javadoc.paragraph.preceded.block.tag=<p> etiketi, HTML blok etiketi ''<{0}>'''den önce gelmemeli, <p> etiketi kaldırılmalıdır.
 javadoc.paragraph.redundant.paragraph=Yedek <p> etiketi.
 javadoc.paragraph.tag.after=Boş satır bir sonraki satırda <p> etiketi ile takip edilmelidir.
 javadoc.parse.rule.error=Sütununda Javadoc comment {0} hatası ayrıştırmak vardır. Detaylar: {1} ayrıştırılırken {2}

--- a/src/main/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/messages_zh.properties
+++ b/src/main/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/messages_zh.properties
@@ -20,6 +20,7 @@ javadoc.noPeriod=Javadoc 首句应以句号结尾。
 javadoc.packageInfo=缺少 package-info.java 文件。
 javadoc.paragraph.line.before=<p> 标签前应有空行。
 javadoc.paragraph.misplaced.tag=<p> 标签应在第一个字符之前，紧邻后者，之间不允许有空格。
+javadoc.paragraph.preceded.block.tag=<p> 标记不应位于 HTML 块标记 ''<{0}>'' 之前，应删除 <p> 标记。
 javadoc.paragraph.redundant.paragraph=多余的 <p> 标签。
 javadoc.paragraph.tag.after=空行后应有 <p> 标签。
 javadoc.parse.rule.error=Javadoc 第 {0} 个字符解析错误。解析 {2} ，详情： {1}

--- a/src/main/resources/com/puppycrawl/tools/checkstyle/meta/checks/javadoc/JavadocParagraphCheck.xml
+++ b/src/main/resources/com/puppycrawl/tools/checkstyle/meta/checks/javadoc/JavadocParagraphCheck.xml
@@ -33,6 +33,7 @@
             <message-key key="javadoc.missed.html.close"/>
             <message-key key="javadoc.paragraph.line.before"/>
             <message-key key="javadoc.paragraph.misplaced.tag"/>
+            <message-key key="javadoc.paragraph.preceded.block.tag"/>
             <message-key key="javadoc.paragraph.redundant.paragraph"/>
             <message-key key="javadoc.paragraph.tag.after"/>
             <message-key key="javadoc.parse.rule.error"/>

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocParagraphCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocParagraphCheckTest.java
@@ -22,6 +22,7 @@ package com.puppycrawl.tools.checkstyle.checks.javadoc;
 import static com.google.common.truth.Truth.assertWithMessage;
 import static com.puppycrawl.tools.checkstyle.checks.javadoc.JavadocParagraphCheck.MSG_LINE_BEFORE;
 import static com.puppycrawl.tools.checkstyle.checks.javadoc.JavadocParagraphCheck.MSG_MISPLACED_TAG;
+import static com.puppycrawl.tools.checkstyle.checks.javadoc.JavadocParagraphCheck.MSG_PRECEDED_BLOCK_TAG;
 import static com.puppycrawl.tools.checkstyle.checks.javadoc.JavadocParagraphCheck.MSG_REDUNDANT_PARAGRAPH;
 import static com.puppycrawl.tools.checkstyle.checks.javadoc.JavadocParagraphCheck.MSG_TAG_AFTER;
 
@@ -87,6 +88,21 @@ public class JavadocParagraphCheckTest extends AbstractModuleTestSupport {
     }
 
     @Test
+    public void testIncorrect2() throws Exception {
+        final String[] expected = {
+            "14: " + getCheckMessage(MSG_PRECEDED_BLOCK_TAG, "h1"),
+            "22: " + getCheckMessage(MSG_PRECEDED_BLOCK_TAG, "ul"),
+            "24: " + getCheckMessage(MSG_LINE_BEFORE),
+            "38: " + getCheckMessage(MSG_PRECEDED_BLOCK_TAG, "table"),
+            "50: " + getCheckMessage(MSG_MISPLACED_TAG),
+            "52: " + getCheckMessage(MSG_MISPLACED_TAG),
+            "52: " + getCheckMessage(MSG_PRECEDED_BLOCK_TAG, "ol"),
+        };
+        verifyWithInlineConfigParser(
+                getPath("InputJavadocParagraphIncorrect4.java"), expected);
+    }
+
+    @Test
     public void testAllowNewlineParagraph() throws Exception {
         final String[] expected = {
             "16: " + getCheckMessage(MSG_MISPLACED_TAG),
@@ -137,6 +153,27 @@ public class JavadocParagraphCheckTest extends AbstractModuleTestSupport {
         };
         verifyWithInlineConfigParser(
                 getPath("InputJavadocParagraphIncorrect3.java"), expected);
+    }
+
+    @Test
+    public void testAllowNewlineParagraph3() throws Exception {
+        final String[] expected = {
+            "15: " + getCheckMessage(MSG_LINE_BEFORE),
+            "17: " + getCheckMessage(MSG_LINE_BEFORE),
+            "20: " + getCheckMessage(MSG_MISPLACED_TAG),
+            "20: " + getCheckMessage(MSG_LINE_BEFORE),
+            "34: " + getCheckMessage(MSG_LINE_BEFORE),
+            "38: " + getCheckMessage(MSG_LINE_BEFORE),
+            "44: " + getCheckMessage(MSG_LINE_BEFORE),
+            "48: " + getCheckMessage(MSG_MISPLACED_TAG),
+            "52: " + getCheckMessage(MSG_MISPLACED_TAG),
+            "52: " + getCheckMessage(MSG_PRECEDED_BLOCK_TAG, "h1"),
+            "67: " + getCheckMessage(MSG_LINE_BEFORE),
+            "80: " + getCheckMessage(MSG_MISPLACED_TAG),
+            "80: " + getCheckMessage(MSG_PRECEDED_BLOCK_TAG, "ul"),
+        };
+        verifyWithInlineConfigParser(
+                getPath("InputJavadocParagraphIncorrect5.java"), expected);
     }
 
     @Test

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadocparagraph/InputJavadocParagraphIncorrect4.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadocparagraph/InputJavadocParagraphIncorrect4.java
@@ -1,0 +1,60 @@
+/*
+JavadocParagraph
+violateExecutionOnNonTightHtml = (default)false
+allowNewlineParagraph = (default)true
+
+
+*/
+
+package com.puppycrawl.tools.checkstyle.checks.javadoc.javadocparagraph;
+
+/**
+ * Some summary.
+ *
+ * <p><h1>Testing...</h1>
+ */
+// violation 2 lines above '<p> tag should not precede HTML block-tag '<h1>''
+public class InputJavadocParagraphIncorrect4 {
+    // violation 4 lines below '<p> tag should not precede HTML block-tag '<ul>''
+    /**
+     * Some summary.
+     *
+     *<p>
+     *  <ul>
+     *    <p>
+     *      <li>1</li> should NOT give violation as there is not empty line before
+     *  </ul>
+     *
+     *
+     * <p><b>testing</b> ok, inline HTML tag. Not a block-level tag
+     */
+    // violation 7 lines above 'tag should be preceded with an empty line.'
+    public void foo() {}
+
+    // violation 4 lines below '<p> tag should not precede HTML block-tag '<table>''
+    /**
+     *  Some summary.
+     *
+     * <p>
+     *  <table>
+     *  </table>
+     *
+     * <p>This is allowed<h1>Testing....</h1>
+     */
+    public void fooo() {}
+
+    // violation 4 lines below '<p> tag should be placed immediately before the first word'
+    /**
+     * <h1>Testing....</h1>
+     *
+     * <p>     Test<h1>test</h1>
+     *
+     * <p>    <ol>test</ol>
+     *
+     * <p><b><h1>Nesting....</h1></b>
+     */
+    // 2 violations 4 lines above:
+    // '<p> tag should be placed immediately before the first word'
+    // '<p> tag should not precede HTML block-tag '<ol>''
+    void foooo() {}
+}

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadocparagraph/InputJavadocParagraphIncorrect5.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadocparagraph/InputJavadocParagraphIncorrect5.java
@@ -1,0 +1,101 @@
+/*
+JavadocParagraph
+violateExecutionOnNonTightHtml = (default)false
+allowNewlineParagraph = false
+
+
+*/
+
+package com.puppycrawl.tools.checkstyle.checks.javadoc.javadocparagraph;
+
+public class InputJavadocParagraphIncorrect5 {
+    // violation 3 lines below 'tag should be preceded with an empty line.'
+    // violation 4 lines below 'tag should be preceded with an empty line.'
+    /**
+     * <h1><p>Testing....</h1>
+     *
+     * <h6><b><p>Test</b></h6>
+     *
+     * <table>
+     *  <p>
+     *    test
+     *
+     * </table>
+     */
+    // 2 violations 5 lines above:
+    //  '<p> tag should be placed immediately before the first word'
+    //  '<p> tag should be preceded with an empty line.'
+    void fooooo() {}
+
+    // violation 4 lines below 'tag should be preceded with an empty line.'
+    // violation 7 lines below 'tag should be preceded with an empty line.'
+    // violation 12 lines below 'tag should be preceded with an empty line.'
+    /**
+     * <b><p>testtttt.....</b>
+     *
+     * <b>
+     *
+     * <p>testtttt.....
+     *
+     * </b>
+     *
+     * <h1>
+     *
+     * <p>testtttt.....
+     *
+     * </h1>
+     *
+     * <p> test...
+     *
+     * <h1></h1>
+     *
+     * <p>
+     *
+     * <h1></h1>
+     */
+    // violation 8 lines above '<p> tag should be placed immediately before the first word'
+    // 2 violations 5 lines above:
+    //  '<p> tag should be placed immediately before the first word'
+    //  '<p> tag should not precede HTML block-tag '<h1>''
+    void foooooo() {}
+
+    /**
+     * <ul>
+     *  <li>1</li>
+     *  <li>1</li>
+     *  <ul>
+     *    <p>test
+     *  </ul>
+     * </ul>
+     */
+    // violation 4 lines above 'tag should be preceded with an empty line.'
+    void fooooooo() {}
+
+    // 2 violations 6 lines below:
+    //  '<p> tag should be placed immediately before the first word'
+    //  '<p> tag should not precede HTML block-tag '<ul>''
+    /**
+     * Some Summary.
+     *
+     * <p>
+     *  <!-- THIS COMMENT WILL GET IGNORED -->
+     *  <ul>
+     *      <li>Item 1</li>
+     *      <li>Item 2</li>
+     *      <li>Item 3</li>
+     *  </ul>
+     */
+    private static final String NAME = "Heisenberg";
+
+    /**
+     * Some Summary.
+     *
+     * <p>{@code com.company.MyClass$Nested#myMethod(String, int)}
+     * <ul>
+     *     <li>Item 1</li>
+     *     <li>Item 2</li>
+     *     <li>Item 3</li>
+     * </ul>
+     */
+    private static final String NAME2 = "Jesse Pinkman";
+}

--- a/src/xdocs/checks/javadoc/javadocparagraph.xml
+++ b/src/xdocs/checks/javadoc/javadocparagraph.xml
@@ -154,6 +154,11 @@ public class Example2 {
             </a>
           </li>
           <li>
+            <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources%2Fcom%2Fpuppycrawl%2Ftools%2Fcheckstyle%2Fchecks%2Fjavadoc%20path%3A**%2Fmessages*.properties+repo%3Acheckstyle%2Fcheckstyle+%22javadoc.paragraph.preceded.block.tag%22">
+              javadoc.paragraph.preceded.block.tag
+            </a>
+          </li>
+          <li>
             <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources%2Fcom%2Fpuppycrawl%2Ftools%2Fcheckstyle%2Fchecks%2Fjavadoc%20path%3A**%2Fmessages*.properties+repo%3Acheckstyle%2Fcheckstyle+%22javadoc.paragraph.redundant.paragraph%22">
               javadoc.paragraph.redundant.paragraph
             </a>


### PR DESCRIPTION
fixes #15503 

added support to check and violate block-tag if they're followed by p tag.

created a new violation message for it.

wrote new test cases.

took the HTML tags list from: https://checkstyle.sourceforge.io/checks/javadoc/javadocstyle.html#JavadocStyle

`Check for allowed HTML tags. The list of allowed HTML tags is "a", "abbr", "acronym", "address", "area", "b", "bdo", "big", "blockquote", "br", "caption", "cite", "code", "colgroup", "dd", "del", "dfn", "div", "dl", "dt", "em", "fieldset", "font", "h1", "h2", "h3", "h4", "h5", "h6", "hr", "i", "img", "ins", "kbd", "li", "ol", "p", "pre", "q", "samp", "small", "span", "strong", "sub", "sup", "table", "tbody", "td", "tfoot", "th", "thead", "tr", "tt", "u", "ul", "var".`

and filtered out block-level tags. 

---

Diff Regression config: https://gist.githubusercontent.com/Zopsss/013f379d4c821f2d624be56212a64575/raw/5f17ec9186d4421396429ab38cbac3e4663bf4eb/javadocparagraph_config.xml
Diff Regression projects: https://raw.githubusercontent.com/checkstyle/contribution/master/checkstyle-tester/projects-to-test-on-for-github-action.properties