### PR TITLE
infra: fix link in exclude for jdepend-maven-plugin to fix run of maven-linkcheck-plugin

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -2087,9 +2087,10 @@
             <!-- Excluded due to Maven Codehaus Plugin's issue #4:
                  https://github.com/mojohaus/mojohaus.github.io/issues/4 -->
             <excludedLink>http://mojo.codehaus.org/antlr-maven-plugin</excludedLink>
-            <!-- Excluded due to Maven JDepend Plugin's issue #2:
-                 https://github.com/mojohaus/jdepend-maven-plugin/issues/2 -->
-            <excludedLink>http://mojo.codehaus.org/jdepend-maven-plugin</excludedLink>
+            <!-- Excluded due to long lasting problem with link that they do not want to fix -->
+            <excludedLink>
+              https://www.mojohaus.org/jdepend-maven-plugin/jdepend-maven-plugin
+            </excludedLink>
             <!-- Excluded due to Maven Taglist Plugin's issue #3:
                  https://github.com/mojohaus/taglist-maven-plugin/issues/3 -->
             <excludedLink>http://mojo.codehaus.org/taglist-maven-plugin</excludedLink>


### PR DESCRIPTION
https://github.com/mojohaus/jdepend-maven-plugin/issues/2


https://github.com/checkstyle/checkstyle/actions/runs/11084772897/job/30800440141#step:4:2626


```
Checking internal (checkstyle website) and external links.
--- .ci-temp/linkcheck-suppressions-sorted.txt	2024-09-28 14:48:12.325455794 +0000
+++ .ci-temp/linkcheck-errors-sorted.txt	2024-09-28 14:48:12.323455782 +0000
@@ -1,3 +1,4 @@
+<a class="externalLink" href="https://www.mojohaus.org/jdepend-maven-plugin/jdepend-maven-plugin">https://www.mojohaus.org/jdepend-maven-plugin/jdepend-maven-plugin</a>: 404 Not Found
```