### PR TITLE
Issue #14631: Updated THROWS_LITERAL of JavadocTokenTypes to new AST format

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/api/JavadocTokenTypes.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/api/JavadocTokenTypes.java
@@ -308,13 +308,13 @@ public final class JavadocTokenTypes {
      * <pre>{@code @throws SQLException if query is not correct}</pre>
      * <b>Tree:</b>
      * <pre>{@code
-     *   |--JAVADOC_TAG[3x0] : [@throws SQLException if query is not correct]
-     *       |--THROWS_LITERAL[3x0] : [@throws]
-     *       |--WS[3x7] : [ ]
-     *       |--CLASS_NAME[3x8] : [SQLException]
-     *       |--WS[3x20] : [ ]
-     *       |--DESCRIPTION[3x21] : [if query is not correct]
-     *           |--TEXT[3x21] : [if query is not correct]
+     *   JAVADOC_TAG -> JAVADOC_TAG
+     *    |--THROWS_LITERAL -> @throws
+     *    |--WS ->
+     *    |--CLASS_NAME -> SQLException
+     *    |--WS ->
+     *    `--DESCRIPTION -> DESCRIPTION
+     *        `--TEXT -> if query is not correct
      * }</pre>
      *
      * @see


### PR DESCRIPTION
Issue #14631: Updated THROWS_LITERAL of JavadocTokenTypes to new AST format


```
$ cat Test.java 
/** some text.
 * @throws SQLException if query is not correct
 * */
public class Test {
}

$ java -jar checkstyle-10.19.0-SNAPSHOT-all.jar -J Test.java 
COMPILATION_UNIT -> COMPILATION_UNIT [4:0]
`--CLASS_DEF -> CLASS_DEF [4:0]
    |--MODIFIERS -> MODIFIERS [4:0]
    |   |--BLOCK_COMMENT_BEGIN -> /* [1:0]
    |   |   |--COMMENT_CONTENT -> * some text.\n * @throws SQLException if query is not correct\n *  [1:2]
    |   |   |   `--JAVADOC -> JAVADOC [1:3]
    |   |   |       |--TEXT ->  some text. [1:3]
    |   |   |       |--NEWLINE -> \n [1:14]
    |   |   |       |--LEADING_ASTERISK ->  * [2:0]
    |   |   |       |--WS ->   [2:2]
    |   |   |       |--JAVADOC_TAG -> JAVADOC_TAG [2:3]
    |   |   |       |   |--THROWS_LITERAL -> @throws [2:3]
    |   |   |       |   |--WS ->   [2:10]
    |   |   |       |   |--CLASS_NAME -> SQLException [2:11]
    |   |   |       |   |--WS ->   [2:23]
    |   |   |       |   `--DESCRIPTION -> DESCRIPTION [2:24]
    |   |   |       |       |--TEXT -> if query is not correct [2:24]
    |   |   |       |       |--NEWLINE -> \n [2:47]
    |   |   |       |       |--LEADING_ASTERISK ->  * [3:0]
    |   |   |       |       `--TEXT ->   [3:2]
    |   |   |       `--EOF -> <EOF> [3:3]
    |   |   `--BLOCK_COMMENT_END -> */ [3:3]
    |   `--LITERAL_PUBLIC -> public [4:0]
    |--LITERAL_CLASS -> class [4:7]
    |--IDENT -> Test [4:13]
    `--OBJBLOCK -> OBJBLOCK [4:18]
        |--LCURLY -> { [4:18]
        `--RCURLY -> } [5:0]

```