### PR TITLE
Issue #15324: added support to check for preceding line break of `{` for switch-case-default blocks

### DIFF
--- a/src/it/resources-noncompilable/com/google/checkstyle/test/chapter4formatting/rule462horizontalwhitespace/InputWhitespaceAroundWhen.java
+++ b/src/it/resources-noncompilable/com/google/checkstyle/test/chapter4formatting/rule462horizontalwhitespace/InputWhitespaceAroundWhen.java
@@ -7,43 +7,51 @@ class InputWhitespaceAroundWhen {
   /** method. */
   void test(Object o) {
     switch (o) {
-      case Integer i when(i == 0) -> {
-      }
-      // 2 violations 2 lines above:
+      case Integer i when(i == 0) ->
+        {
+        }
+      // 2 violations 3 lines above:
       //              ''when' is not followed by whitespace.'
       //              ''when' is not followed by whitespace.'
       case String s when(
               // 2 violations above:
               //              ''when' is not followed by whitespace'
               //              ''when' is not followed by whitespace'
-              s.equals("a")) -> {
-      }
-      case Point(int x, int y) when!(x >= 0 && y >= 0) -> {
-      }
-      // 2 violations 2 lines above:
+              s.equals("a")) ->
+        {
+        }
+      case Point(int x, int y) when!(x >= 0 && y >= 0) ->
+        {
+        }
+      // 2 violations 3 lines above:
       //              ''when' is not followed by whitespace.'
       //              ''when' is not followed by whitespace.'
-      default -> {
-      }
+      default ->
+        {
+        }
     }
 
     switch (o) {
-      case Point(int x, int y)when (x < 9 && y >= 0) -> {
-      }  // violation above, ''when' is not preceded with whitespace.'
-      case Point(int x, int y)when(x >= 0 && y >= 0) -> {
-      }
-      // 3 violations 2 lines above:
+      case Point(int x, int y)when (x < 9 && y >= 0) ->
+        {
+        }  // violation 2 lines above ''when' is not preceded with whitespace.'
+      case Point(int x, int y)when(x >= 0 && y >= 0) ->
+        {
+        }
+      // 3 violations 3 lines above:
       //              ''when' is not followed by whitespace.'
       //              ''when' is not followed by whitespace.'
       //              ''when' is not preceded with whitespace.'
-      case Point(int x, int y)when!(x >= 0 && y >= 0) -> {
-      }
-      // 3 violations 2 lines above:
+      case Point(int x, int y)when!(x >= 0 && y >= 0) ->
+        {
+        }
+      // 3 violations 3 lines above:
       //              ''when' is not followed by whitespace.'
       //              ''when' is not followed by whitespace.'
       //              ''when' is not preceded with whitespace.'
-      default -> {
-      }
+      default ->
+        {
+        }
     }
   }
 
@@ -51,25 +59,33 @@ class InputWhitespaceAroundWhen {
   void test2(Object o) {
 
     switch (o) {
-      case Integer i when (i == 0) -> {
-      }
-      case String s when (s.equals("a")) -> {
-      }
-      case Point(int x, int y) when (x >= 0 && y >= 0) -> {
-      }
-      default -> {
-      }
+      case Integer i when (i == 0) ->
+        {
+        }
+      case String s when (s.equals("a")) ->
+        {
+        }
+      case Point(int x, int y) when (x >= 0 && y >= 0) ->
+        {
+        }
+      default ->
+        {
+        }
     }
 
     switch (o) {
-      case Integer i when i == 0 -> {
-      }
-      case String s when s.equals("a") -> {
-      }
-      case Point(int x, int y) when x >= 0 && y >= 0 -> {
-      }
-      default -> {
-      }
+      case Integer i when i == 0 ->
+        {
+        }
+      case String s when s.equals("a") ->
+        {
+        }
+      case Point(int x, int y) when x >= 0 && y >= 0 ->
+        {
+        }
+      default ->
+        {
+        }
     }
   }
 

--- a/src/it/resources/com/google/checkstyle/test/chapter4formatting/rule412nonemptyblocks/InputFormattedRightCurlySwitchCasesBlocks.java
+++ b/src/it/resources/com/google/checkstyle/test/chapter4formatting/rule412nonemptyblocks/InputFormattedRightCurlySwitchCasesBlocks.java
@@ -9,17 +9,18 @@ public class InputFormattedRightCurlySwitchCasesBlocks {
     switch (mode) {
       case 1:
         {
-          // violation above ''{' at column 9 should be on the previous line.'
           int x = 1;
           break;
         }
       case 2:
         {
-          // violation above ''{' at column 9 should be on the previous line.'
           int x = 0;
           break;
         }
       default:
+        {
+          int x = 0;
+        }
     }
   }
 
@@ -29,7 +30,6 @@ public class InputFormattedRightCurlySwitchCasesBlocks {
     switch (mode) {
       case 1:
         {
-          // violation above ''{' at column 9 should be on the previous line.'
           int x = 1;
           break;
         }
@@ -44,7 +44,6 @@ public class InputFormattedRightCurlySwitchCasesBlocks {
     switch (k) {
       case 1:
         {
-          // violation above ''{' at column 9 should be on the previous line.'
           int x = 1;
         }
         break;
@@ -64,10 +63,12 @@ public class InputFormattedRightCurlySwitchCasesBlocks {
         break;
       case 2:
         {
-          // violation above ''{' at column 9 should be on the previous line.'
           break;
         }
       default:
+        {
+          break;
+        }
     }
   }
 
@@ -77,17 +78,81 @@ public class InputFormattedRightCurlySwitchCasesBlocks {
     switch (k) {
       case 1:
         {
-          // violation above ''{' at column 9 should be on the previous line.'
           int x = 1;
           break;
         }
       case 2:
         {
-          // violation above ''{' at column 9 should be on the previous line.'
           int x = 2;
         }
         break;
       default:
+        {
+          int x = 2;
+        }
+    }
+  }
+
+  /** some javadoc. */
+  public static void test4() {
+    int mode = 0;
+    switch (mode) {
+      case 1:
+        {
+          int x = 1;
+          break;
+        }
+      default:
+        {
+          int x = 0;
+        }
+    }
+  }
+
+  /** some javadoc. */
+  public static void test5() {
+    int k = 0;
+    switch (k) {
+      case 1:
+        {
+          int x = 1;
+        }
+        break;
+      default:
+        {
+          int a = 2;
+        }
+    }
+  }
+
+  /** some javadoc. */
+  public static void test6() {
+    int mode = 0;
+    switch (mode) {
+      case 1:
+        int x = 1;
+        break;
+      case 2:
+        {
+          break;
+        }
+      default:
+    }
+  }
+
+  /** some javadoc. */
+  public static void test7() {
+    int k = 0;
+    switch (k) {
+      case 1:
+        {
+          int x = 1;
+          break;
+        }
+      default:
+        {
+          int x = 2;
+        }
     }
   }
 }

--- a/src/it/resources/com/google/checkstyle/test/chapter4formatting/rule412nonemptyblocks/InputRightCurlySwitchCasesBlocks.java
+++ b/src/it/resources/com/google/checkstyle/test/chapter4formatting/rule412nonemptyblocks/InputRightCurlySwitchCasesBlocks.java
@@ -8,16 +8,19 @@ public class InputRightCurlySwitchCasesBlocks {
     int mode = 0;
     switch (mode) {
       case 1:
-        { // violation ''{' at column 9 should be on the previous line.'
+        {
           int x = 1;
           break;
         }
       case 2:
-        { // violation ''{' at column 9 should be on the previous line.'
+        {
           int x = 0;
           break;
         }
       default:
+        {
+          int x = 0;
+        }
     }
   }
 
@@ -26,7 +29,7 @@ public class InputRightCurlySwitchCasesBlocks {
     int mode = 0;
     switch (mode) {
       case 1:
-        { // violation ''{' at column 9 should be on the previous line.'
+        {
           int x = 1;
           break;
         } default:
@@ -42,7 +45,7 @@ public class InputRightCurlySwitchCasesBlocks {
     int k = 0;
     switch (k) {
       case 1:
-        { // violation ''{' at column 9 should be on the previous line.'
+        {
         int x = 1; } // violation ''}' at column 20 should be alone on a line.'
         break;
       case 2:
@@ -60,10 +63,13 @@ public class InputRightCurlySwitchCasesBlocks {
         int x = 1;
         break;
       case 2:
-        { // violation ''{' at column 9 should be on the previous line.'
+        {
           break;
         }
       default:
+        {
+          break;
+        }
     }
   }
 
@@ -72,15 +78,71 @@ public class InputRightCurlySwitchCasesBlocks {
     int k = 0;
     switch (k) {
       case 1:
-        { // violation ''{' at column 9 should be on the previous line.'
+        {
           int x = 1;
           break;
         }
-      case 2:
-        { // violation ''{' at column 9 should be on the previous line.'
-        int x = 2; } // violation ''}' at column 20 should be alone on a line.'
-        break;
       default:
+        {
+          int x = 2; } // false-negative until #15324
+    }
+  }
+
+  /** some javadoc. */
+  public static void test4() {
+    int mode = 0;
+    switch (mode) {
+      case 1: { // violation ''{' at column 15 should be on a new line.'
+          int x = 1; // violation '.* incorrect indentation level 10, expected level should be 8.'
+          break; // violation '.* incorrect indentation level 10, expected level should be 8.'
+          // 2 violations 3 lines below:
+          //  ''block rcurly' has incorrect indentation level 8, expected level should be 6.'
+          //  ''}' at column 9 should be alone on a line.'
+        } default:
+          { // violation '.* incorrect indentation level 10, expected level should be 8.'
+                  int x = 0; // violation '.* incorrect indentation .*, expected .* 8, 10.'
+          } // violation '.* incorrect indentation level 10, expected level should be 8.'
+    }
+  }
+
+  /** some javadoc. */
+  public static void test5() {
+    int k = 0;
+    switch (k) {
+      case 1: { // violation ''{' at column 15 should be on a new line.'
+        int x = 1; } // violation ''}' at column 20 should be alone on a line.'
+        break;
+      default: { // violation ''{' at column 16 should be on a new line.'
+  int a = 2; // violation '.* incorrect indentation level 2, expected level should be 8.'
+      }
+    }
+  }
+
+  /** some javadoc. */
+  public static void test6() {
+    int mode = 0;
+    switch (mode) {
+      case 1:
+        int x = 1;
+        break;
+      case 2: { // violation ''{' at column 15 should be on a new line.'
+          break; // violation '.* incorrect indentation level 10, expected level should be 8.'
+        } // violation '.* incorrect indentation level 8, expected level should be 6.'
+      default:
+    }
+  }
+
+  /** some javadoc. */
+  public static void test7() {
+    int k = 0;
+    switch (k) {
+      case 1:
+        {
+            int x = 1; // violation '.* incorrect indentation .* 12, expected .* following: 8, 10.'
+            break; // violation '.* incorrect indentation .* 12, expected .* following: 8, 10.'
+        }
+      default: { // violation ''{' at column 16 should be on a new line.'
+        int x = 2; } // false-negative until #15324
     }
   }
 }

--- a/src/it/resources/com/google/checkstyle/test/chapter4formatting/rule413emptyblocks/InputEmptyBlocksAndCatchBlocks.java
+++ b/src/it/resources/com/google/checkstyle/test/chapter4formatting/rule413emptyblocks/InputEmptyBlocksAndCatchBlocks.java
@@ -63,8 +63,8 @@ class InputEmptyBlocksAndCatchBlocks {
     // violation above 'Empty blocks should have no spaces. .* may only be represented as {}'
     try (MyResource r = new MyResource()) {;}
     // 3 violations above:
-    //  ''{' at column 43 should have line break after.'
     //  'WhitespaceAround: '{' is not followed by whitespace.'
+    //  ''{' at column 43 should have line break after.'
     //  'WhitespaceAround: '}' is not preceded with whitespace.'
   }
 

--- a/src/it/resources/com/google/checkstyle/test/chapter4formatting/rule4842fallthrough/InputFallThrough.java
+++ b/src/it/resources/com/google/checkstyle/test/chapter4formatting/rule4842fallthrough/InputFallThrough.java
@@ -21,23 +21,23 @@ public class InputFallThrough {
         case 6:
           continue;
         case 7:
-          { // violation 'should be on the previous line'
+          {
             break;
           }
         case 8:
-          { // violation 'should be on the previous line'
+          {
             return;
           }
         case 9:
-          { // violation 'should be on the previous line'
+          {
             throw new RuntimeException("");
           }
         case 10:
-          { // violation 'should be on the previous line'
+          {
             continue;
           }
         case 11:
-          { // violation 'should be on the previous line'
+          {
             i++;
           }
         case 12: // violation 'Fall through from previous branch of the switch statement.'
@@ -158,23 +158,23 @@ public class InputFallThrough {
         case 6:
           continue;
         case 7:
-          { // violation 'should be on the previous line'
+          {
             break;
           }
         case 8:
-          { // violation 'should be on the previous line'
+          {
             return;
           }
         case 9:
-          { // violation 'should be on the previous line'
+          {
             throw new RuntimeException("");
           }
         case 10:
-          { // violation 'should be on the previous line'
+          {
             continue;
           }
         case 11:
-          { // violation 'should be on the previous line'
+          {
             i++;
           }
           // fallthru
@@ -297,7 +297,7 @@ public class InputFallThrough {
           i++;
           // fallthru
         case 2:
-          { // violation 'should be on the previous line'
+          {
             i++;
           }
           // fallthru

--- a/src/it/resources/com/google/checkstyle/test/chapter4formatting/rule4861blockcommentstyle/InputCommentsIndentationInSwitchBlock.java
+++ b/src/it/resources/com/google/checkstyle/test/chapter4formatting/rule4861blockcommentstyle/InputCommentsIndentationInSwitchBlock.java
@@ -41,51 +41,61 @@ public class InputCommentsIndentationInSwitchBlock {
       case "9":
         foo1();
         // fall through
-      case "10": {
-        if (true) { /* foo */ }
-      }
+      case "10":
+        {
+          if (true) { /* foo */ }
+        }
       // fall through
-      case "11": {
-      }
+      case "11":
+        {
+        }
       // fall through
-      case "28": {
-      }
+      case "28":
+        {
+        }
       // fall through
-      case "12": {
+      case "12":
+        {
   // odd indentation comment
-        // violation above '.* indentation should be the same level as line 57.'
-        int i;
-      }
-      break;
-      case "13": {
-        // some comment in empty case block
-      }
-      break;
-      case "14": {
+          // violation above '.* indentation should be the same level as line 61.'
+          int i;
+        }
+        break;
+      case "13":
+        {
+          // some comment in empty case block
+        }
+        break;
+      case "14":
+        {
     // odd indentation comment
-        // violation above '.* indentation should be the same level as line 67.'
-      }
-      break;
-      case "15": {
-        // violation 2 lines below '.* indentation should be the same level as line 71.'
-        foo1();
+          // violation above '.* indentation should be the same level as line 73.'
+        }
+        break;
+      case "15":
+        {
+          // violation 2 lines below '.* indentation should be the same level as line 78.'
+          foo1();
               // odd indentation comment
-      }
-      break;
-      case "16": {
-        int a;
-      }
+        }
+        break;
+      case "16":
+        {
+          int a;
+        }
       // fall through
-      case "17": {
-        int a;
-      }
-      // violation below '.* indentation should be the same level as line 84.'
+      case "17":
+        {
+          int a;
+        }
+        // violation below '.* indentation should be the same level as line 93.'
   // odd indentation comment
-      break;
-      case "18": {
-        System.lineSeparator();
-      } // trailing comment
-      break;
+        break;
+      case "18":
+        {
+          System.lineSeparator();
+        } // trailing comment
+        break;
       case "19":
         // comment
       case "20":
@@ -103,7 +113,7 @@ public class InputCommentsIndentationInSwitchBlock {
         case 0:
 
         case 1:
-          // violation below '.* indentation should be the same level as line 108.'
+          // violation below '.* indentation should be the same level as line 118.'
               // odd indentation comment
           int b = 10;
           break;
@@ -129,7 +139,7 @@ public class InputCommentsIndentationInSwitchBlock {
         break;
       case -1:
         // what
-        // violation 2 lines below '.* indentation should be the same .* as line 135.'
+        // violation 2 lines below '.* indentation should be the same .* as line 145.'
         s.indexOf("no way");
        // odd indentation comment
         break;
@@ -137,15 +147,16 @@ public class InputCommentsIndentationInSwitchBlock {
       case 2:
         i--;
         break;
-      case 3: {
-      }
+      case 3:
+        {
+        }
       // fall through
       default:
     }
 
     String breaks =
             ""
-                    // violation below '.* indentation should be the same level as line 150.'
+                    // violation below '.* indentation should be the same level as line 161.'
                         // odd indentation comment
                     + "</table>"
                     // middle
@@ -162,7 +173,7 @@ public class InputCommentsIndentationInSwitchBlock {
       default:
   // odd indentation comment
     }
-    // violation 2 lines above'.* indentation should be the same level as line 164.'
+    // violation 2 lines above'.* indentation should be the same level as line 175.'
   }
 
   /** some javadoc. */
@@ -181,7 +192,7 @@ public class InputCommentsIndentationInSwitchBlock {
     int a = 1;
     switch (a) {
       case 1:
-        // violation 2 lines below '.* indentation should be the same .* as line 187.'
+        // violation 2 lines below '.* indentation should be the same .* as line 198.'
         int b;
           // odd indentation comment
         break;
@@ -232,13 +243,13 @@ public class InputCommentsIndentationInSwitchBlock {
         // comment
         // comment
         // comment
-        // violation 2 lines below'.* indentation should be the same .* as line 236, 238.'
+        // violation 2 lines below'.* indentation should be the same .* as line 247, 249.'
       case 4:
   // odd indentation comment
       case 5:
-        // violation 4 lines below 'indentation should be the same level as line 246.'
-        // violation 4 lines below 'indentation should be the same level as line 246.'
-        // violation 4 lines below 'indentation should be the same level as line 246.'
+        // violation 4 lines below 'indentation should be the same level as line 257.'
+        // violation 4 lines below 'indentation should be the same level as line 257.'
+        // violation 4 lines below 'indentation should be the same level as line 257.'
         s.toString().toString().toString();
               // odd indentation comment
            // odd indentation comment
@@ -268,7 +279,7 @@ public class InputCommentsIndentationInSwitchBlock {
         // comment
         s.toString().toString().toString();
         // comment
-        // violation 3 lines below '.* indentation should be the same level as line 273, 275.'
+        // violation 3 lines below '.* indentation should be the same level as line 284, 286.'
         break;
       case 4:
   // odd indentation comment

--- a/src/it/resources/com/google/checkstyle/test/chapter4formatting/rule4861blockcommentstyle/InputFormattedCommentsIndentationInSwitchBlock.java
+++ b/src/it/resources/com/google/checkstyle/test/chapter4formatting/rule4861blockcommentstyle/InputFormattedCommentsIndentationInSwitchBlock.java
@@ -42,7 +42,6 @@ public class InputFormattedCommentsIndentationInSwitchBlock {
         foo1();
         // fall through
       case "10":
-        // violation below ''{' at column 9 should be on the previous line.'
         {
           if (true) {
             /* foo */
@@ -50,17 +49,14 @@ public class InputFormattedCommentsIndentationInSwitchBlock {
         }
         // fall through
       case "11":
-        // violation below ''{' at column 9 should be on the previous line.'
         {
         }
         // fall through
       case "28":
-        // violation below ''{' at column 9 should be on the previous line.'
         {
         }
         // fall through
       case "12":
-        // violation below ''{' at column 9 should be on the previous line.'
         {
           // odd indentation comment
 
@@ -68,33 +64,28 @@ public class InputFormattedCommentsIndentationInSwitchBlock {
         }
         break;
       case "13":
-        // violation below ''{' at column 9 should be on the previous line.'
         {
           // some comment in empty case block
         }
         break;
       case "14":
-        // violation below ''{' at column 9 should be on the previous line.'
         {
           // odd indentation comment
 
         }
         break;
       case "15":
-        // violation below ''{' at column 9 should be on the previous line.'
         {
           foo1();
           // odd indentation comment
         }
         break;
       case "16":
-        // violation below ''{' at column 9 should be on the previous line.'
         {
           int a;
         }
         // fall through
       case "17":
-        // violation below ''{' at column 9 should be on the previous line.'
         {
           int a;
         }
@@ -102,7 +93,6 @@ public class InputFormattedCommentsIndentationInSwitchBlock {
         // odd indentation comment
         break;
       case "18":
-        // violation below ''{' at column 9 should be on the previous line.'
         {
           System.lineSeparator();
         } // trailing comment
@@ -159,7 +149,6 @@ public class InputFormattedCommentsIndentationInSwitchBlock {
         i--;
         break;
       case 3:
-        // violation below ''{' at column 9 should be on the previous line.'
         {
         }
         // fall through
@@ -238,7 +227,7 @@ public class InputFormattedCommentsIndentationInSwitchBlock {
   public void foo7() {
     int a = 2;
     String s = "";
-    // violation 4 lines below '.* indentation should be the same level as line 246.'
+    // violation 4 lines below '.* indentation should be the same level as line 235.'
     switch (a) {
         // comment
         // comment
@@ -271,7 +260,7 @@ public class InputFormattedCommentsIndentationInSwitchBlock {
   public void foo8() {
     int a = 2;
     String s = "";
-    // violation 4 lines below '.* indentation should be the same level as line 279.'
+    // violation 4 lines below '.* indentation should be the same level as line 268.'
     switch (a) {
         // comment
         // comment
@@ -331,7 +320,7 @@ public class InputFormattedCommentsIndentationInSwitchBlock {
   /** some javadoc. */
   public void foo12() {
     int a = 5;
-    // violation 2 lines below '.* indentation should be the same level as line 337.'
+    // violation 2 lines below '.* indentation should be the same level as line 326.'
     switch (a) {
         // comment
       case 1:

--- a/src/main/resources/google_checks.xml
+++ b/src/main/resources/google_checks.xml
@@ -83,12 +83,19 @@
                value="LITERAL_DO, LITERAL_ELSE, LITERAL_FOR, LITERAL_IF, LITERAL_WHILE"/>
     </module>
     <module name="LeftCurly">
+      <property name="id" value="LeftCurlyEol"/>
       <property name="tokens"
-               value="ANNOTATION_DEF, CLASS_DEF, CTOR_DEF, ENUM_CONSTANT_DEF, ENUM_DEF,
-                    INTERFACE_DEF, LAMBDA, LITERAL_CASE, LITERAL_CATCH, LITERAL_DEFAULT,
+                value="ANNOTATION_DEF, CLASS_DEF, CTOR_DEF, ENUM_CONSTANT_DEF, ENUM_DEF,
+                    INTERFACE_DEF, LAMBDA, LITERAL_CATCH,
                     LITERAL_DO, LITERAL_ELSE, LITERAL_FINALLY, LITERAL_FOR, LITERAL_IF,
                     LITERAL_SWITCH, LITERAL_SYNCHRONIZED, LITERAL_TRY, LITERAL_WHILE, METHOD_DEF,
                     OBJBLOCK, STATIC_INIT, RECORD_DEF, COMPACT_CTOR_DEF"/>
+    </module>
+    <module name="LeftCurly">
+      <property name="id" value="LeftCurlyNl"/>
+      <property name="option" value="nl"/>
+      <property name="tokens"
+                value="LITERAL_CASE, LITERAL_DEFAULT"/>
     </module>
     <module name="RightCurly">
       <property name="id" value="RightCurlySame"/>

--- a/src/test/java/com/puppycrawl/tools/checkstyle/MainTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/MainTest.java
@@ -1355,7 +1355,7 @@ public class MainTest {
                     + "/METHOD_DEF[./IDENT[@text='provokeNpathIntegerOverflow']]\"/>",
                 "<suppress-xpath",
                 "       files=\"InputMainComplexityOverflow.java\"",
-                "       checks=\"LeftCurlyCheck\"",
+                "       id=\"LeftCurlyEol\"",
                 "       query=\"/COMPILATION_UNIT/CLASS_DEF"
                     + "[./IDENT[@text='InputMainComplexityOverflow']]/OBJBLOCK"
                     + "/METHOD_DEF[./IDENT[@text='provokeNpathIntegerOverflow']]/SLIST\"/>",


### PR DESCRIPTION
part of #15324 

Suggestions taken from: https://github.com/checkstyle/checkstyle/issues/15324#issuecomment-2375361863

Added support to check for preceding line break before `{` for switch-case-default ( [4.1.2 Nonempty blocks: K & R style](https://checkstyle.org/google_style.html#a4.1.2) )
Some new tests were added to:

https://github.com/checkstyle/checkstyle/compare/master...Zopsss:15324-switch-case-lcurly?expand=1#diff-aff628179d81aea067e835af1af5587bc7f1a1a797f41835546d40ea0f3997e4

https://github.com/checkstyle/checkstyle/compare/master...Zopsss:15324-switch-case-lcurly?expand=1#diff-8e4bfd0f5535171a324423e3cc959fc50f3c7759555973e6084110dae5f1fd20

I didn't needed to change input files that much because they already contained the required cases.

I had to make changes to some other sections too to make their tests happy.

----

Diff Regression config: https://gist.githubusercontent.com/Zopsss/eef363a452104d034a9ce7be532f647d/raw/1c54b992d22ec9aa23a0b05f6ed19e780a566857/master_google_checks.xml

Diff Regression patch config: https://gist.githubusercontent.com/Zopsss/1c312decead5034cad98ad25c18d3467/raw/748eb6499439ef13cf694e27bdaed9498d6fdfd6/switch_case_default_google_checks.xml

Diff Regression projects: https://raw.githubusercontent.com/checkstyle/contribution/master/checkstyle-tester/projects-to-test-on-for-github-action.properties