### PR TITLE
Issue #15716: set allowNewlineParagraph to false in google_checks.xml

### DIFF
--- a/src/it/resources/com/google/checkstyle/test/chapter7javadoc/rule712paragraphs/InputFormattedIncorrectJavadocParagraph.java
+++ b/src/it/resources/com/google/checkstyle/test/chapter7javadoc/rule712paragraphs/InputFormattedIncorrectJavadocParagraph.java
@@ -7,8 +7,10 @@ package com.google.checkstyle.test.chapter7javadoc.rule712paragraphs;
  *
  * <p>
  */
+// violation 2 lines above '<p> tag should be placed immediately before the first word'
 class InputFormattedIncorrectJavadocParagraph {
 
+  // violation 4 lines below '<p> tag should be placed immediately before the first word'
   /**
    * Some Javadoc.
    *
@@ -35,6 +37,9 @@ class InputFormattedIncorrectJavadocParagraph {
     return false;
   }
 
+  // violation 6 lines below '<p> tag should be placed immediately before the first word'
+  // violation 7 lines below '<p> tag should be placed immediately before the first word'
+  // violation 8 lines below '<p> tag should be placed immediately before the first word'
   /**
    * Some Javadoc.
    *
@@ -48,8 +53,10 @@ class InputFormattedIncorrectJavadocParagraph {
    *
    * <p>
    */
+  // violation 2 lines above '<p> tag should be placed immediately before the first word'
   class InnerInputCorrectJavaDocParagraphCheck {
 
+    // violation 4 lines below '<p> tag should be placed immediately before the first word'
     /**
      * Some Javadoc.
      *
@@ -59,6 +66,8 @@ class InputFormattedIncorrectJavadocParagraph {
      */
     public static final byte NUL = 0;
 
+    // violation 5 lines below '<p> tag should be placed immediately before the first word'
+    // violation 8 lines below '<p> tag should be placed immediately before the first word'
     /**
      * Some Javadoc.
      *
@@ -89,6 +98,7 @@ class InputFormattedIncorrectJavadocParagraph {
          */
         public static final byte NUL = 0;
 
+        // violation 4 lines below '<p> tag should be placed immediately before the first word'
         /**
          * Some Javadoc.
          *
@@ -107,7 +117,7 @@ class InputFormattedIncorrectJavadocParagraph {
         }
       };
 
-  /* 4 lines below, no violation until #15685 */
+  // violation 4 lines below '<p> tag should be placed immediately before the first word'
   /**
    * Some summary.
    *
@@ -116,7 +126,7 @@ class InputFormattedIncorrectJavadocParagraph {
    * <h1>Testing...</h1>
    */
   class InnerPrecedingPtag {
-    /* 5 lines below, no violation until #15685 */
+    // violation 4 lines below '<p> tag should be placed immediately before the first word'
     /**
      * Some summary.
      *
@@ -127,10 +137,12 @@ class InputFormattedIncorrectJavadocParagraph {
      *   <li>1 // should NOT give violation as there is not empty line before
      * </ul>
      */
-    // violation 4 lines above '<p> tag should be preceded with an empty line.'
+    // 2 violations 4 lines above:
+    //  '<p> tag should be placed immediately before the first word'
+    //  '<p> tag should be preceded with an empty line.'
     public void foo() {}
 
-    /* 5 lines below, no violation until #15685 */
+    // violation 4 lines below '<p> tag should be placed immediately before the first word'
     /**
      * Some summary.
      *
@@ -141,7 +153,7 @@ class InputFormattedIncorrectJavadocParagraph {
      */
     public void fooo() {}
 
-    /* 5 lines below, no violation until #15685 */
+    // violation 4 lines below '<p> tag should be placed immediately before the first word'
     /**
      * Some summary.
      *

--- a/src/it/resources/com/google/checkstyle/test/chapter7javadoc/rule712paragraphs/InputIncorrectJavadocParagraph.java
+++ b/src/it/resources/com/google/checkstyle/test/chapter7javadoc/rule712paragraphs/InputIncorrectJavadocParagraph.java
@@ -1,16 +1,22 @@
 package com.google.checkstyle.test.chapter7javadoc.rule712paragraphs;
 
-// violation 3 lines below '<p> tag should be preceded with an empty line.'
+// 2 violations 5 lines below:
+//  '<p> tag should be placed immediately before the first word'
+//  '<p> tag should be preceded with an empty line.'
 /**
  * Some Javadoc.
  * <p>
  * Some Javadoc.<p>
  */
-// violation 2 lines above '<p> tag should be preceded with an empty line.'
+// 2 violations 2 lines above:
+//  '<p> tag should be placed immediately before the first word'
+//  '<p> tag should be preceded with an empty line.'
 
 class InputIncorrectJavadocParagraph {
 
-  // violation 2 lines below '<p> tag should be preceded with an empty line.'
+  // 2 violations 4 lines below:
+  //  '<p> tag should be placed immediately before the first word'
+  //  '<p> tag should be preceded with an empty line.'
   /**
    * Some Javadoc.<p>
    *
@@ -35,20 +41,26 @@ class InputIncorrectJavadocParagraph {
     return false;
   }
 
-  // violation 2 lines below 'Redundant <p> tag.'
-  // violation 2 lines below '<p> tag should be preceded with an empty line.'
+  // violation 4 lines below 'Redundant <p> tag.'
+  // 2 violations 4 lines below:
+  //  '<p> tag should be placed immediately before the first word'
+  //  '<p> tag should be preceded with an empty line.'
   /**<p>Some Javadoc.
    * <p>
    * <p><p>
    * <p> Some Javadoc.<p>
    */
-  // violation 3 lines above '<p> tag should be preceded with an empty line.'
   // 2 violations 3 lines above:
+  //  '<p> tag should be placed immediately before the first word'
+  //  '<p> tag should be preceded with an empty line.'
+  // 2 violations 5 lines above:
   //  '<p> tag should be placed immediately before the first word'
   //  '<p> tag should be preceded with an empty line.'
   class InnerInputCorrectJavaDocParagraphCheck {
 
-    // violation 2 lines below '<p> tag should be preceded with an empty line.'
+    // 2 violations 4 lines below:
+    //  '<p> tag should be placed immediately before the first word'
+    //  '<p> tag should be preceded with an empty line.'
     /**
      * Some Javadoc.<p>
      *
@@ -56,7 +68,11 @@ class InputIncorrectJavadocParagraph {
      */
     public static final byte NUL = 0;
 
-    // violation below 'Redundant <p> tag.'
+    // 2 violations 5 lines below:
+    //  '<p> tag should be placed immediately before the first word'
+    //  'Redundant <p> tag.'
+    // violation 5 lines below '<p> tag should be placed immediately before the first word'
+    // violation 6 lines below '<p> tag should be placed immediately before the first word'
     /**<p>
      *  Some Javadoc.
      *
@@ -68,8 +84,10 @@ class InputIncorrectJavadocParagraph {
      *     href="http://www.gwtproject.org/doc/latest/DevGuideOrganizingProjects.html#DevGuideModules">
      *     Documentation about GWT emulated source</a>
      */
-    // violation 5 lines above '<p> tag should be preceded with an empty line.'
-    // violation 5 lines above 'Javadoc tag '@see' should be preceded with an empty line.'
+    // 2 violations 5 lines above:
+    //  '<p> tag should be placed immediately before the first word'
+    //  '<p> tag should be preceded with an empty line.'
+    // violation 7 lines above 'Javadoc tag '@see' should be preceded with an empty line.'
     boolean emulated() {
       return false;
     }
@@ -88,7 +106,9 @@ class InputIncorrectJavadocParagraph {
          */
         public static final byte NUL = 0;
 
-        // violation 3 lines below '<p> tag should be preceded with an empty line.'
+        // 2 violations 5 lines below:
+        //  '<p> tag should be placed immediately before the first word'
+        //  '<p> tag should be preceded with an empty line.'
         // violation 4 lines below '<p> tag should be placed immediately before the first word'
         /**
          *   Some Javadoc.<p>

--- a/src/main/resources/google_checks.xml
+++ b/src/main/resources/google_checks.xml
@@ -340,7 +340,9 @@
       <property name="forbiddenSummaryFragments"
                value="^@return the *|^This method returns |^A [{]@code [a-zA-Z0-9]+[}]( is a )"/>
     </module>
-    <module name="JavadocParagraph"/>
+    <module name="JavadocParagraph">
+      <property name="allowNewlineParagraph" value="false"/>
+    </module>
     <module name="RequireEmptyLineBeforeBlockTagGroup"/>
     <module name="AtclauseOrder">
       <property name="tagOrder" value="@param, @return, @throws, @deprecated"/>


### PR DESCRIPTION
fixes #15716

set `allowNewlineParagraph` property of `JavadocParagraph` to `false`

now we're able to achieve the following expected behavior in google_checks.xml:

```
$ cat Test.java 
/**
 * Some Summary.
 *
 * <p>
 * Some test.
 */
public class Test {
}

$ java -jar checkstyle-10.18.1-all.jar -c /google_checks.xml  Test.java 
Starting audit...
[WARN] /var/tmp/Test.java:4: <p> tag should be placed immediately before the first word
    , with no space after. [JavadocParagraph]
Audit done.
```

didnt needed to change inputs that much, only added the extra violation message, no new cases were added

---

Diff Regression config: https://gist.githubusercontent.com/Zopsss/eef363a452104d034a9ce7be532f647d/raw/12b3995567589f3477ff9d8b46b129dff3c0eafa/master_google_checks.xml
Diff Regression patch config: https://gist.githubusercontent.com/Zopsss/54519848c27df1fc6982fa28609b04ab/raw/dc694e5b5eaf97619f91e6223ffe23d59d5bfa9f/allownewlineparagraph_google_checks.xml
Diff Regression projects: https://gist.githubusercontent.com/Zopsss/9960953f88e763d31eea3a14447b861f/raw/edfd96ea7a5757cea2e08856be98776cbb21a171/guava-project.properties