### PR TITLE
Issue #15734: updated JavadocParagraphCheck documentation and added examples for P tag should not precede block-tag

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocParagraphCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocParagraphCheck.java
@@ -40,6 +40,9 @@ import com.puppycrawl.tools.checkstyle.utils.JavadocUtil;
  * <li>There is one blank line between each of two paragraphs.</li>
  * <li>Each paragraph but the first has &lt;p&gt; immediately
  * before the first word, with no space after.</li>
+ * <li>First paragraph tag should not precede
+ * <a href="https://www.w3schools.com/html/html_blocks.asp">HTML block-tag</a>,
+ * nested paragraph tags are allowed to do that.</li>
  * </ul>
  * <ul>
  * <li>

--- a/src/main/resources/com/puppycrawl/tools/checkstyle/meta/checks/javadoc/JavadocParagraphCheck.xml
+++ b/src/main/resources/com/puppycrawl/tools/checkstyle/meta/checks/javadoc/JavadocParagraphCheck.xml
@@ -14,6 +14,9 @@
  &lt;li&gt;There is one blank line between each of two paragraphs.&lt;/li&gt;
  &lt;li&gt;Each paragraph but the first has &amp;lt;p&amp;gt; immediately
  before the first word, with no space after.&lt;/li&gt;
+ &lt;li&gt;First paragraph tag should not precede
+ &lt;a href="https://www.w3schools.com/html/html_blocks.asp"&gt;HTML block-tag&lt;/a&gt;,
+ nested paragraph tags are allowed to do that.&lt;/li&gt;
  &lt;/ul&gt;</description>
          <properties>
             <property default-value="true" name="allowNewlineParagraph" type="boolean">

--- a/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocParagraphCheckExamplesTest.java
+++ b/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocParagraphCheckExamplesTest.java
@@ -21,6 +21,7 @@ package com.puppycrawl.tools.checkstyle.checks.javadoc;
 
 import static com.puppycrawl.tools.checkstyle.checks.javadoc.JavadocParagraphCheck.MSG_LINE_BEFORE;
 import static com.puppycrawl.tools.checkstyle.checks.javadoc.JavadocParagraphCheck.MSG_MISPLACED_TAG;
+import static com.puppycrawl.tools.checkstyle.checks.javadoc.JavadocParagraphCheck.MSG_PRECEDED_BLOCK_TAG;
 
 import org.junit.jupiter.api.Test;
 
@@ -51,5 +52,29 @@ public class JavadocParagraphCheckExamplesTest extends AbstractExamplesModuleTes
         };
 
         verifyWithInlineConfigParser(getPath("Example2.java"), expected);
+    }
+
+    @Test
+    public void testExample3() throws Exception {
+        final String[] expected = {
+            "15:4: " + getCheckMessage(MSG_PRECEDED_BLOCK_TAG, "h1"),
+            "25:6: " + getCheckMessage(MSG_PRECEDED_BLOCK_TAG, "ul"),
+            "32:6: " + getCheckMessage(MSG_PRECEDED_BLOCK_TAG, "pre"),
+        };
+
+        verifyWithInlineConfigParser(getPath("Example3.java"), expected);
+    }
+
+    @Test
+    public void testExample4() throws Exception {
+        final String[] expected = {
+            "17:4: " + getCheckMessage(MSG_PRECEDED_BLOCK_TAG, "h1"),
+            "29:6: " + getCheckMessage(MSG_MISPLACED_TAG),
+            "29:6: " + getCheckMessage(MSG_PRECEDED_BLOCK_TAG, "ul"),
+            "36:6: " + getCheckMessage(MSG_MISPLACED_TAG),
+            "36:6: " + getCheckMessage(MSG_PRECEDED_BLOCK_TAG, "pre"),
+        };
+
+        verifyWithInlineConfigParser(getPath("Example4.java"), expected);
     }
 }

--- a/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadocparagraph/Example3.java
+++ b/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadocparagraph/Example3.java
@@ -1,0 +1,53 @@
+/*xml
+<module name="Checker">
+  <module name="TreeWalker">
+    <module name="JavadocParagraph"/>
+  </module>
+</module>
+*/
+package com.puppycrawl.tools.checkstyle.checks.javadoc.javadocparagraph;
+
+// xdoc section -- start
+// violation 4 lines below '<p> tag should not precede HTML block-tag '<h1>''
+/**
+ * No tag (ok).
+ *
+ * <p><h1>P tag is preceding block-tag h1, not allowed</h1>
+ *
+ * <p><b>P tag is preceding an inline-tag b, this is allowed</b>
+ */
+public class Example3 {
+
+  // violation 4 lines below '<p> tag should not precede HTML block-tag '<ul>''
+  /**
+   * No tag (ok).
+   *
+   * <p>
+   * <ul>
+   * <li>item 1</li>
+   * <li>item 2</li>
+   * <li>item 3</li>
+   * </ul>
+   *
+   * <p>
+   * <pre>block-tag is preceded by P tag, not allowed.</pre>
+   */
+  // violation 3 lines above '<p> tag should not precede HTML block-tag '<pre>''
+  void foo1() {}
+
+  /**
+   * No tag (ok).
+   *
+   * <table>
+   * <tbody>
+   * <p>
+   * <tr>
+   * nested paragraph preceding block tag, this allowed.
+   * </tr>
+   * </tbody>
+   * </table>
+   *
+   */
+  void foo2() {}
+}
+// xdoc section -- end

--- a/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadocparagraph/Example4.java
+++ b/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadocparagraph/Example4.java
@@ -1,0 +1,58 @@
+/*xml
+<module name="Checker">
+  <module name="TreeWalker">
+    <module name="JavadocParagraph">
+      <property name="allowNewlineParagraph" value="false"/>
+    </module>
+  </module>
+</module>
+*/
+package com.puppycrawl.tools.checkstyle.checks.javadoc.javadocparagraph;
+
+// xdoc section -- start
+// violation 4 lines below '<p> tag should not precede HTML block-tag '<h1>''
+/**
+ * No tag (ok).
+ *
+ * <p><h1>P tag is preceding block-tag h1, not allowed</h1>
+ *
+ * <p><b>P tag is preceding an inline-tag b, this is allowed</b>
+ */
+public class Example4 {
+
+  // 2 violations 6 lines below:
+  //  'tag should be placed immediately before the first word'
+  //  '<p> tag should not precede HTML block-tag '<ul>''
+  /**
+   * No tag (ok).
+   *
+   * <p>
+   * <ul>
+   * <li>item 1</li>
+   * <li>item 2</li>
+   * <li>item 3</li>
+   * </ul>
+   *
+   * <p>
+   * <pre>block-tag is preceded by P tag, not allowed.</pre>
+   */
+  // 2 violations 3 lines above:
+  //  'tag should be placed immediately before the first word'
+  //  '<p> tag should not precede HTML block-tag '<pre>''
+  void foo1() {}
+
+  /**
+   * No tag (ok).
+   *
+   * <table>
+   * <tbody>
+   * <p>
+   * <tr>
+   * nested paragraph preceding block tag, this allowed.
+   * </tr>
+   * </tbody>
+   * </table>
+   */
+  void foo2() {}
+}
+// xdoc section -- end

--- a/src/xdocs/checks/javadoc/javadocparagraph.xml
+++ b/src/xdocs/checks/javadoc/javadocparagraph.xml
@@ -23,6 +23,11 @@
             Each paragraph but the first has &lt;p&gt; immediately before the first word, with
             no space after.
           </li>
+          <li>
+            First paragraph tag should not precede
+            <a href="https://www.w3schools.com/html/html_blocks.asp">HTML block-tag</a>,
+            nested paragraph tags are allowed to do that.
+          </li>
         </ul>
       </subsection>
 
@@ -119,6 +124,125 @@ public class Example1 {
 // violation 6 lines above 'tag should be placed immediately before the first word'
 // violation 4 lines above 'tag should be placed immediately before the first word'
 public class Example2 {
+}
+        </source>
+        <p id="Example3-config">
+          Paragraph tag preceding block-level tags, with default properties:
+        </p>
+        <source>
+&lt;module name=&quot;Checker&quot;&gt;
+  &lt;module name=&quot;TreeWalker&quot;&gt;
+    &lt;module name=&quot;JavadocParagraph&quot;/&gt;
+  &lt;/module&gt;
+&lt;/module&gt;
+        </source>
+        <p id="Example3-code">Example:</p>
+        <source>
+// violation 4 lines below '&lt;p&gt; tag should not precede HTML block-tag '&lt;h1&gt;''
+/**
+ * No tag (ok).
+ *
+ * &lt;p&gt;&lt;h1&gt;P tag is preceding block-tag h1, not allowed&lt;/h1&gt;
+ *
+ * &lt;p&gt;&lt;b&gt;P tag is preceding an inline-tag b, this is allowed&lt;/b&gt;
+ */
+public class Example3 {
+
+  // violation 4 lines below '&lt;p&gt; tag should not precede HTML block-tag '&lt;ul&gt;''
+  /**
+   * No tag (ok).
+   *
+   * &lt;p&gt;
+   * &lt;ul&gt;
+   * &lt;li&gt;item 1&lt;/li&gt;
+   * &lt;li&gt;item 2&lt;/li&gt;
+   * &lt;li&gt;item 3&lt;/li&gt;
+   * &lt;/ul&gt;
+   *
+   * &lt;p&gt;
+   * &lt;pre&gt;block-tag is preceded by P tag, not allowed.&lt;/pre&gt;
+   */
+  // violation 3 lines above '&lt;p&gt; tag should not precede HTML block-tag '&lt;pre&gt;''
+  void foo1() {}
+
+  /**
+   * No tag (ok).
+   *
+   * &lt;table&gt;
+   * &lt;tbody&gt;
+   * &lt;p&gt;
+   * &lt;tr&gt;
+   * nested paragraph preceding block tag, this allowed.
+   * &lt;/tr&gt;
+   * &lt;/tbody&gt;
+   * &lt;/table&gt;
+   *
+   */
+  void foo2() {}
+}
+        </source>
+        <p id="Example4-config">
+          Paragraph tag preceding block-level tags,
+          with <code>allowNewlineParagraph</code> set to false:
+        </p>
+        <source>
+&lt;module name=&quot;Checker&quot;&gt;
+  &lt;module name=&quot;TreeWalker&quot;&gt;
+    &lt;module name=&quot;JavadocParagraph&quot;&gt;
+      &lt;property name=&quot;allowNewlineParagraph&quot; value=&quot;false&quot;/&gt;
+    &lt;/module&gt;
+  &lt;/module&gt;
+&lt;/module&gt;
+        </source>
+        <p id="Example4-code">
+          In case of <code>allowNewlineParagraph</code> set to <code>false</code>,
+          previous example will give some extra violations:
+        </p>
+        <source>
+// violation 4 lines below '&lt;p&gt; tag should not precede HTML block-tag '&lt;h1&gt;''
+/**
+ * No tag (ok).
+ *
+ * &lt;p&gt;&lt;h1&gt;P tag is preceding block-tag h1, not allowed&lt;/h1&gt;
+ *
+ * &lt;p&gt;&lt;b&gt;P tag is preceding an inline-tag b, this is allowed&lt;/b&gt;
+ */
+public class Example4 {
+
+  // 2 violations 6 lines below:
+  //  'tag should be placed immediately before the first word'
+  //  '&lt;p&gt; tag should not precede HTML block-tag '&lt;ul&gt;''
+  /**
+   * No tag (ok).
+   *
+   * &lt;p&gt;
+   * &lt;ul&gt;
+   * &lt;li&gt;item 1&lt;/li&gt;
+   * &lt;li&gt;item 2&lt;/li&gt;
+   * &lt;li&gt;item 3&lt;/li&gt;
+   * &lt;/ul&gt;
+   *
+   * &lt;p&gt;
+   * &lt;pre&gt;block-tag is preceded by P tag, not allowed.&lt;/pre&gt;
+   */
+  // 2 violations 3 lines above:
+  //  'tag should be placed immediately before the first word'
+  //  '&lt;p&gt; tag should not precede HTML block-tag '&lt;pre&gt;''
+  void foo1() {}
+
+  /**
+   * No tag (ok).
+   *
+   * &lt;table&gt;
+   * &lt;tbody&gt;
+   * &lt;p&gt;
+   * &lt;tr&gt;
+   * nested paragraph preceding block tag, this allowed.
+   * &lt;/tr&gt;
+   * &lt;/tbody&gt;
+   * &lt;/table&gt;
+   */
+  void foo2() {}
 }
         </source>
       </subsection>

--- a/src/xdocs/checks/javadoc/javadocparagraph.xml.template
+++ b/src/xdocs/checks/javadoc/javadocparagraph.xml.template
@@ -23,6 +23,11 @@
             Each paragraph but the first has &lt;p&gt; immediately before the first word, with
             no space after.
           </li>
+          <li>
+            First paragraph tag should not precede
+            <a href="https://www.w3schools.com/html/html_blocks.asp">HTML block-tag</a>,
+            nested paragraph tags are allowed to do that.
+          </li>
         </ul>
       </subsection>
 
@@ -66,6 +71,38 @@
         <macro name="example">
           <param name="path"
                  value="resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadocparagraph/Example2.java"/>
+          <param name="type" value="code"/>
+        </macro>
+        <p id="Example3-config">
+          Paragraph tag preceding block-level tags, with default properties:
+        </p>
+        <macro name="example">
+          <param name="path"
+                 value="resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadocparagraph/Example3.java"/>
+          <param name="type" value="config"/>
+        </macro>
+        <p id="Example3-code">Example:</p>
+        <macro name="example">
+          <param name="path"
+                 value="resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadocparagraph/Example3.java"/>
+          <param name="type" value="code"/>
+        </macro>
+        <p id="Example4-config">
+          Paragraph tag preceding block-level tags,
+          with <code>allowNewlineParagraph</code> set to false:
+        </p>
+        <macro name="example">
+          <param name="path"
+                 value="resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadocparagraph/Example4.java"/>
+          <param name="type" value="config"/>
+        </macro>
+        <p id="Example4-code">
+          In case of <code>allowNewlineParagraph</code> set to <code>false</code>,
+          previous example will give some extra violations:
+        </p>
+        <macro name="example">
+          <param name="path"
+                 value="resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadocparagraph/Example4.java"/>
           <param name="type" value="code"/>
         </macro>
       </subsection>


### PR DESCRIPTION
closes #15734 

updated doc and added example for new violation previously added.

2 new examples were added, one with default `allowNewlineParagraph` and other with `allowNewlineParagraph = false`