### PR TITLE
infra: fix regression-report.yml and add a new regression-report.sh

### DIFF
--- a/.github/workflows/regression-report.yml
+++ b/.github/workflows/regression-report.yml
@@ -19,7 +19,7 @@ env:
   # yamllint disable-line rule:line-length
   DEFAULT_PROJECTS_LINK: "https://raw.githubusercontent.com/checkstyle/test-configs/main/extractor/src/main/resources/list-of-projects.yml"
   BASE_TEST_CONFIGS_URL: "https://raw.githubusercontent.com/checkstyle/test-configs/main"
-  EXTRACTOR_VERSION: 2024-08-27
+  EXTRACTOR_VERSION: 2024-10-08
   DIFF_TOOL_VERSION: "1.0-SNAPSHOT-all"
   PATCH_DIFF_TOOL_VERSION: "0.1-SNAPSHOT"
   CACHE_KEY: "regression-report-${{ github.sha }}-${{ github.event.comment.id }}"
@@ -386,7 +386,12 @@ jobs:
           echo "Config link: $DIFF_CONFIG_LINK"
           echo "Projects link: $DIFF_PROJECTS_LINK"
           cp "$DIFF_CONFIG_LINK" .ci-temp/diff_config.xml
-          cp "$DIFF_PROJECTS_LINK" .ci-temp/projects.yml
+          # Determine the projects file extension
+          if [[ "$DIFF_PROJECTS_LINK" == *.properties ]]; then
+            cp "$DIFF_PROJECTS_LINK" .ci-temp/projects.properties
+          else
+            cp "$DIFF_PROJECTS_LINK" .ci-temp/projects.yml
+          fi
 
       - name: Download URL-based Config and Project File
         id: download_files
@@ -459,7 +464,7 @@ jobs:
       - name: Download DiffTool JAR
         uses: robinraju/release-downloader@v1.8
         with:
-          repository: "relentless-pursuit/test-configs"
+          repository: "checkstyle/test-configs"
           tag: "diff-java-tool-${{ env.DIFF_TOOL_VERSION }}"
           fileName: "diff-java-tool-${{ env.DIFF_TOOL_VERSION }}.jar"
           out-file-path: ".ci-temp"


### PR DESCRIPTION
Adds the new official releases for extractor and diff-java-tool and a new regression-report.sh to keep the operations and changes for diff-report.yml and regression-report.yml as separate for now. 

This PR will test on the following scenarios:
1. InputJavaFile generating projects in yml format (as we have made the default projects format as yml)
2. PR configurations with .properites file and generating the regression-report in .properties file
3. PR configurations with .yml file and generating the regression-report in .yml file
4. Using the existing config bundle commands Github, generate report for <CheckName/all-in-one-examples> using the default projects list
5. Using the existing config bundle commands Github, generate report for <CheckName/all-in-one-examples> using the custom projects list e.g. WhiteSpaceAround/Example3