### PR TITLE
infra: replace project.properties with projects.properties

### DIFF
--- a/.ci/diff-report.sh
+++ b/.ci/diff-report.sh
@@ -39,14 +39,17 @@ download-files)
   mkdir -p .ci-temp
   echo "Downloading files..."
 
-  # check for projects link from PR, if not found use default from contribution repo
+  # Check for projects link from PR, if not found use default from contribution repo
   LINK="${DIFF_PROJECTS_LINK:-$DEFAULT_PROJECTS_LINK}"
 
-  # get projects file
+  # Determine the extension of the projects file
+  PROJECTS_FILENAME=$(basename "$LINK")
+  EXTENSION="${PROJECTS_FILENAME##*.}"
+
   curl --fail-with-body -X GET "${LINK}" \
     -H "Accept: application/vnd.github+json" \
     -H "Authorization: token $GITHUB_TOKEN" \
-    -o .ci-temp/project.properties
+    -o ".ci-temp/projects.${EXTENSION}"
 
   if [ -n "$NEW_MODULE_CONFIG_LINK" ]; then
     curl --fail-with-body -X GET "${NEW_MODULE_CONFIG_LINK}" \

--- a/.github/workflows/diff-report.yml
+++ b/.github/workflows/diff-report.yml
@@ -145,7 +145,7 @@ jobs:
 
       - name: Prepare environment
         run: |
-          mv .ci-temp/project.properties ./.ci-temp/contribution/checkstyle-tester/
+          mv .ci-temp/projects.properties ./.ci-temp/contribution/checkstyle-tester/
           mv .ci-temp/*.xml ./.ci-temp/contribution/checkstyle-tester/
           sudo apt install groovy
 
@@ -168,15 +168,15 @@ jobs:
           export MAVEN_OPTS="-Xmx5g"
           if [ -f new_module_config.xml ]; then
             groovy diff.groovy -r "$REPO" -p "$REF" -pc new_module_config.xml -m single\
-              -l project.properties -xm "-Dcheckstyle.failsOnError=false"\
+              -l projects.properties -xm "-Dcheckstyle.failsOnError=false"\
               --allowExcludes
           elif [ -f patch_config.xml ]; then
             groovy diff.groovy -r "$REPO" -b "$BASE_BRANCH" -p "$REF" -bc diff_config.xml\
-              -pc patch_config.xml -l project.properties -xm "-Dcheckstyle.failsOnError=false"\
+              -pc patch_config.xml -l projects.properties -xm "-Dcheckstyle.failsOnError=false"\
               --allowExcludes
           else
             groovy diff.groovy -r "$REPO" -b "$BASE_BRANCH" -p "$REF" -c diff_config.xml\
-              -l project.properties -xm "-Dcheckstyle.failsOnError=false"\
+              -l projects.properties -xm "-Dcheckstyle.failsOnError=false"\
               --allowExcludes
           fi
 


### PR DESCRIPTION
Replaces `project.properties` with `projects.properties` and add support for `yml` in `diff-report.sh`