### PR TITLE
Issue #14019: Kill this.checks = null mutation on SuppressionXpathSingleFilter

### DIFF
--- a/config/pitest-suppressions/pitest-filters-suppressions.xml
+++ b/config/pitest-suppressions/pitest-filters-suppressions.xml
@@ -165,15 +165,6 @@
   <mutation unstable="false">
     <sourceFile>SuppressionXpathSingleFilter.java</sourceFile>
     <mutatedClass>com.puppycrawl.tools.checkstyle.filters.SuppressionXpathSingleFilter</mutatedClass>
-    <mutatedMethod>setChecks</mutatedMethod>
-    <mutator>org.pitest.mutationtest.engine.gregor.mutators.experimental.MemberVariableMutator</mutator>
-    <description>Removed assignment to member variable checks</description>
-    <lineContent>this.checks = null;</lineContent>
-  </mutation>
-
-  <mutation unstable="false">
-    <sourceFile>SuppressionXpathSingleFilter.java</sourceFile>
-    <mutatedClass>com.puppycrawl.tools.checkstyle.filters.SuppressionXpathSingleFilter</mutatedClass>
     <mutatedMethod>setMessage</mutatedMethod>
     <mutator>org.pitest.mutationtest.engine.gregor.mutators.experimental.MemberVariableMutator</mutator>
     <description>Removed assignment to member variable message</description>


### PR DESCRIPTION
Part of #14019 
Removed suppression
https://github.com/checkstyle/checkstyle/blob/954a9f121861cd71ddd8838fa2233384e62ded12/config/pitest-suppressions/pitest-filters-suppressions.xml#L165-L172

Followed https://github.com/checkstyle/checkstyle/pull/13794 as they are similar

## Steps followed to kill mutation 
This steps are better described [here](https://github.com/checkstyle/checkstyle/wiki/How-to-Generate-and-Analyze-Pitest-Reports),
- Removed suppression from `pitest-filters-suppressions.xml`
- Listed pitest profiles with `groovy .ci/pitest-survival-check-xml.groovy --list` using java 11 and groovy 2.4.5
- Picked up `pitest-filters` as active profile
- Generated report locally using `mvn -e --no-transfer-progress -P"$PITEST_PROFILE" clean test-compile org.pitest:pitest-maven:mutationCoverage`  
  <details>
  <summary> Screenshots </summary>
  
  ![Screenshot from 2024-10-15 20-49-37](https://github.com/user-attachments/assets/ef5f7a3b-7be9-48ba-bbd7-78e82ab6165c) 
  
  ![Screenshot from 2024-10-15 19-14-54](https://github.com/user-attachments/assets/6e0f1d85-a2de-4cf3-81a2-be3440491640)
  </details>

- Analyzed report localy using `groovy .ci/pitest-survival-check-xml.groovy "$PITEST_PROFILE"`. Response:
	```shell
	Source File: "SuppressionXpathSingleFilter.java"
	Class: "com.puppycrawl.tools.checkstyle.filters.SuppressionXpathSingleFilter"
	Method: "setChecks"
	Line Contents: "this.checks = null;"
	Mutator: "org.pitest.mutationtest.engine.gregor.mutators.experimental.MemberVariableMutator"
	Description: "Removed assignment to member variable checks"
	Line Number: 141
	```
- Added extra test case
- Generated report again
    <details>
    <summary> Screenshots </summary>
    
    
    ![Screenshot from 2024-10-15 20-37-32](https://github.com/user-attachments/assets/63721edd-bc30-4828-895a-91929cedb051)
    ![Screenshot from 2024-10-15 20-35-18](https://github.com/user-attachments/assets/8ae12bbe-2e73-4daa-80e1-aaff446f10e7)
</details>

- Report analysis `No new surviving mutation(s) found.`
