### PR TITLE
infra: set certain sha for xwiki-platform to avoid CI failure in our PRs

### DIFF
--- a/.ci/validation.sh
+++ b/.ci/validation.sh
@@ -313,6 +313,8 @@ no-error-xwiki)
   cd ..
   checkout_from https://github.com/xwiki/xwiki-platform.git
   cd .ci-temp/xwiki-platform
+  # xwiki leaked CS violation, so we stay on commit before until they fix build
+  git checkout "815fa52c8ed3a""bc36614e2a3e91c2bf59f24f796"
   # Validate xwiki-platform
   mvn -e --no-transfer-progress checkstyle:check@default -Dcheckstyle.version="${CS_POM_VERSION}"
   cd ..


### PR DESCRIPTION
https://app.circleci.com/pipelines/github/checkstyle/checkstyle/28331/workflows/d8073709-edf6-4e99-b636-1e8d089b43bd/jobs/707482?invite=true#step-103-944586_87


caused by https://github.com/xwiki/xwiki-platform/commit/f696d5e2c519346a2e78c3d55f48c51f8921dce7

```
[INFO] --- maven-checkstyle-plugin:3.5.0:check (default) @ xwiki-platform-websocket ---
[INFO] Starting audit...
[ERROR] /home/circleci/project/.ci-temp/xwiki-platform/xwiki-platform-core/
xwiki-platform-websocket/src/main/java/org/xwiki/websocket/script/WebSocketScriptService.java:86:52:
 The String "/" appears 2 times in the file. [MultipleStringLiterals]
Audit done.
[INFO] There is 1 error reported by Checkstyle 10.19.0-SNAPSHOT with checkstyle.xml ruleset.
[ERROR] src/main/java/org/xwiki/websocket/script/WebSocketScriptService.java:[86,52]
 (coding) MultipleStringLiterals: The String "/" appears 2 times in the file.
[INFO] ------------------------------------------------------------------------
[INFO] Reactor Summary for XWiki Platform - Parent POM 16.9.0-SNAPSHOT:
```