### PR TITLE
Issue #15664: moved LITERAL_FINALLY to RightCurlyAlone in google_checks.xml

### DIFF
--- a/src/it/resources/com/google/checkstyle/test/chapter4formatting/rule412nonemptyblocks/InputRightCurly.java
+++ b/src/it/resources/com/google/checkstyle/test/chapter4formatting/rule412nonemptyblocks/InputRightCurly.java
@@ -8,6 +8,8 @@ public class InputRightCurly {
     try {
       /* foo */
     } finally { after = true; }
-    // violation above ''{' at column 15 should have line break after.'
+    // 2 violations above
+    //  ''{' at column 15 should have line break after.'
+    //  ''}' at column 30 should be alone on a line.'
   }
 }

--- a/src/it/resources/com/google/checkstyle/test/chapter4formatting/rule412nonemptyblocks/InputTryCatchIfElse2.java
+++ b/src/it/resources/com/google/checkstyle/test/chapter4formatting/rule412nonemptyblocks/InputTryCatchIfElse2.java
@@ -5,10 +5,6 @@ public class InputTryCatchIfElse2 {
   /** some javadoc. */
   public static void main(String[] args) {
     boolean after = false;
-    try {
-      /* foo */
-    } finally { after = true; }
-    // violation above ''{' at column 15 should have line break after.'
 
     try {
       /* foo */

--- a/src/main/resources/google_checks.xml
+++ b/src/main/resources/google_checks.xml
@@ -100,7 +100,7 @@
     <module name="RightCurly">
       <property name="id" value="RightCurlySame"/>
       <property name="tokens"
-               value="LITERAL_TRY, LITERAL_CATCH, LITERAL_FINALLY, LITERAL_IF, LITERAL_ELSE,
+               value="LITERAL_TRY, LITERAL_CATCH, LITERAL_IF, LITERAL_ELSE,
                     LITERAL_DO"/>
     </module>
     <module name="RightCurly">
@@ -109,7 +109,7 @@
       <property name="tokens"
                value="CLASS_DEF, METHOD_DEF, CTOR_DEF, LITERAL_FOR, LITERAL_WHILE, STATIC_INIT,
                     INSTANCE_INIT, ANNOTATION_DEF, ENUM_DEF, INTERFACE_DEF, RECORD_DEF,
-                    COMPACT_CTOR_DEF, LITERAL_SWITCH, LITERAL_CASE"/>
+                    COMPACT_CTOR_DEF, LITERAL_SWITCH, LITERAL_CASE, LITERAL_FINALLY"/>
     </module>
     <module name="SuppressionXpathSingleFilter">
       <!-- suppression is required till https://github.com/checkstyle/checkstyle/issues/7541 -->


### PR DESCRIPTION
part of #15664 

moved LITERAL_FINALLY to RightCurlyAlone, didnt needed to modify suppression, all tests were passing by default.
