### PR TITLE
Issue #13999: Kill NonVoidMethodCallMutator on .getColumnNo());

### DIFF
--- a/config/pitest-suppressions/pitest-javadoc-suppressions.xml
+++ b/config/pitest-suppressions/pitest-javadoc-suppressions.xml
@@ -39,24 +39,6 @@
   <mutation unstable="false">
     <sourceFile>JavadocMethodCheck.java</sourceFile>
     <mutatedClass>com.puppycrawl.tools.checkstyle.checks.javadoc.JavadocMethodCheck</mutatedClass>
-    <mutatedMethod>checkThrowsTags</mutatedMethod>
-    <mutator>org.pitest.mutationtest.engine.gregor.mutators.NonVoidMethodCallMutator</mutator>
-    <description>removed call to com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocTag::getColumnNo</description>
-    <lineContent>.getColumnNo());</lineContent>
-  </mutation>
-
-  <mutation unstable="false">
-    <sourceFile>JavadocMethodCheck.java</sourceFile>
-    <mutatedClass>com.puppycrawl.tools.checkstyle.checks.javadoc.JavadocMethodCheck</mutatedClass>
-    <mutatedMethod>checkThrowsTags</mutatedMethod>
-    <mutator>org.pitest.mutationtest.engine.gregor.mutators.NonVoidMethodCallMutator</mutator>
-    <description>removed call to com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocTag::getLineNo</description>
-    <lineContent>final Token token = new Token(tag.getFirstArg(), tag.getLineNo(), tag</lineContent>
-  </mutation>
-
-  <mutation unstable="false">
-    <sourceFile>JavadocMethodCheck.java</sourceFile>
-    <mutatedClass>com.puppycrawl.tools.checkstyle.checks.javadoc.JavadocMethodCheck</mutatedClass>
     <mutatedMethod>getThrowed</mutatedMethod>
     <mutator>org.pitest.mutationtest.engine.gregor.mutators.experimental.NakedReceiverMutator</mutator>
     <description>replaced call to com/puppycrawl/tools/checkstyle/api/DetailAST::findFirstToken with receiver</description>
@@ -79,24 +61,6 @@
     <mutator>org.pitest.mutationtest.engine.gregor.mutators.RemoveConditionalMutator_EQUAL_IF</mutator>
     <description>removed conditional - replaced equality check with true</description>
     <lineContent>if (class1.contains(separator) || class2.contains(separator)) {</lineContent>
-  </mutation>
-
-  <mutation unstable="false">
-    <sourceFile>JavadocMethodCheck.java</sourceFile>
-    <mutatedClass>com.puppycrawl.tools.checkstyle.checks.javadoc.JavadocMethodCheck</mutatedClass>
-    <mutatedMethod>processThrows</mutatedMethod>
-    <mutator>org.pitest.mutationtest.engine.gregor.mutators.NonVoidMethodCallMutator</mutator>
-    <description>removed call to com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocMethodCheck$Token::getText</description>
-    <lineContent>foundThrows.add(documentedClassInfo.getName().getText());</lineContent>
-  </mutation>
-
-  <mutation unstable="false">
-    <sourceFile>JavadocMethodCheck.java</sourceFile>
-    <mutatedClass>com.puppycrawl.tools.checkstyle.checks.javadoc.JavadocMethodCheck</mutatedClass>
-    <mutatedMethod>processThrows</mutatedMethod>
-    <mutator>org.pitest.mutationtest.engine.gregor.mutators.NonVoidMethodCallMutator</mutator>
-    <description>removed call to java/util/Set::add</description>
-    <lineContent>foundThrows.add(documentedClassInfo.getName().getText());</lineContent>
   </mutation>
 
   <mutation unstable="false">

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocMethodCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocMethodCheck.java
@@ -22,7 +22,6 @@ package com.puppycrawl.tools.checkstyle.checks.javadoc;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
-import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
 import java.util.ListIterator;
@@ -915,8 +914,6 @@ public class JavadocMethodCheck extends AbstractCheck {
     private void checkThrowsTags(List<JavadocTag> tags,
             List<ExceptionInfo> throwsList, boolean reportExpectedTags) {
         // Loop over the tags, checking to see they exist in the throws.
-        // The foundThrows used for performance only
-        final Set<String> foundThrows = new HashSet<>();
         final ListIterator<JavadocTag> tagIt = tags.listIterator();
         while (tagIt.hasNext()) {
             final JavadocTag tag = tagIt.next();
@@ -927,10 +924,7 @@ public class JavadocMethodCheck extends AbstractCheck {
             tagIt.remove();
 
             // Loop looking for matching throw
-            final Token token = new Token(tag.getFirstArg(), tag.getLineNo(), tag
-                    .getColumnNo());
-            final ClassInfo documentedClassInfo = new ClassInfo(token);
-            processThrows(throwsList, documentedClassInfo, foundThrows);
+            processThrows(throwsList, tag.getFirstArg());
         }
         // Now dump out all throws without tags :- unless
         // the user has chosen to suppress these problems
@@ -949,25 +943,16 @@ public class JavadocMethodCheck extends AbstractCheck {
      * Verifies that documented exception is in throws.
      *
      * @param throwsIterable collection of throws
-     * @param documentedClassInfo documented exception class info
-     * @param foundThrows previously found throws
+     * @param documentedClassName documented exception class name
      */
     private static void processThrows(Iterable<ExceptionInfo> throwsIterable,
-                                      ClassInfo documentedClassInfo, Set<String> foundThrows) {
-        ExceptionInfo foundException = null;
-
-        // First look for matches on the exception name
+                                      String documentedClassName) {
         for (ExceptionInfo exceptionInfo : throwsIterable) {
             if (isClassNamesSame(exceptionInfo.getName().getText(),
-                    documentedClassInfo.getName().getText())) {
-                foundException = exceptionInfo;
+                    documentedClassName)) {
+                exceptionInfo.setFound();
                 break;
             }
-        }
-
-        if (foundException != null) {
-            foundException.setFound();
-            foundThrows.add(documentedClassInfo.getName().getText());
         }
     }
 


### PR DESCRIPTION
Part of #13999 
Removed suppression https://github.com/checkstyle/checkstyle/blob/42621ebbd4f3b61a8dec15c2f939562530c0a8b3/config/pitest-suppressions/pitest-javadoc-suppressions.xml#L39-L46

Also, the following suppressions were removed as a side effect of refactoring

https://github.com/checkstyle/checkstyle/blob/42621ebbd4f3b61a8dec15c2f939562530c0a8b3/config/pitest-suppressions/pitest-javadoc-suppressions.xml#L48-L55
https://github.com/checkstyle/checkstyle/blob/42621ebbd4f3b61a8dec15c2f939562530c0a8b3/config/pitest-suppressions/pitest-javadoc-suppressions.xml#L84-L100 

## Steps followed to kill mutation

- Removed suppression from [pitest-javadoc-suppressions.xml](https://github.com/checkstyle/checkstyle/blob/master/config/pitest-suppressions/pitest-javadoc-suppressions.xml)
- Selected `pitest-javadoc` as active profile
- Run `mvn -e --no-transfer-progress -P"$PITEST_PROFILE" clean test-compile org.pitest:pitest-maven:mutationCoverage` 
- Analyzed report using `groovy .ci/pitest-survival-check-xml.groovy "$PITEST_PROFILE"`
  ```
  New surviving mutation(s) found:
  Source File: "JavadocMethodCheck.java"
  Class: "com.puppycrawl.tools.checkstyle.checks.javadoc.JavadocMethodCheck"
  Method: "checkThrowsTags"
  Line Contents: ".getColumnNo());"
  Mutator: "org.pitest.mutationtest.engine.gregor.mutators.NonVoidMethodCallMutator"
  Description: "removed call to com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocTag::getColumnNo"
  Line Number: 931
  ```
    Having a look at the code, we can see that [getColumnNo](https://github.com/checkstyle/checkstyle/blob/42621ebbd4f3b61a8dec15c2f939562530c0a8b3/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocMethodCheck.java#L931) is irrelevant in the check. 
    By following the code, we can see that `tag.getColumnNo());` is used to [instantiate a Token](https://github.com/checkstyle/checkstyle/blob/42621ebbd4f3b61a8dec15c2f939562530c0a8b3/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocMethodCheck.java#L930) object, which is used to [instantiate a ClassInfo](https://github.com/checkstyle/checkstyle/blob/master/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocMethodCheck.java#L932) object to be passed down to [processThrows](https://github.com/checkstyle/checkstyle/blob/master/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocMethodCheck.java#L933) method call. 
    In the [processThrow method](https://github.com/checkstyle/checkstyle/blob/master/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocMethodCheck.java#L955-L972), we can see that the ClassInfo object is used like `documentedClassInfo.getName().getText()` ([here](https://github.com/checkstyle/checkstyle/blob/master/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocMethodCheck.java#L962) and [here](https://github.com/checkstyle/checkstyle/blob/master/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocMethodCheck.java#L970)), this corresponds to [`tag.getFirstArg()`](https://github.com/checkstyle/checkstyle/blob/master/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocMethodCheck.java#L930) which was used to instantiate the Token object.
    We can remove the two objects and directly pass `tag.getFirstArg()` down to `processThrow`.
  
- After refactoring code, report analysis is:
	```
	New surviving mutation(s) found:
	
	Source File: "JavadocMethodCheck.java"
	Class: "com.puppycrawl.tools.checkstyle.checks.javadoc.JavadocMethodCheck"
	Method: "processThrows"
	Line Contents: "foundThrows.add(documentedClassName);"
	Mutator: "org.pitest.mutationtest.engine.gregor.mutators.NonVoidMethodCallMutator"
	Description: "removed call to java/util/Set::add"
	Line Number: 967
	
	Unnecessary suppressed mutation(s) found and should be removed:
	
	Source File: "JavadocMethodCheck.java"
	Class: "com.puppycrawl.tools.checkstyle.checks.javadoc.JavadocMethodCheck"
	Method: "checkThrowsTags"
	Line Contents: ".getColumnNo());"
	Mutator: "org.pitest.mutationtest.engine.gregor.mutators.NonVoidMethodCallMutator"
	Description: "removed call to com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocTag::getColumnNo"
	
	
	Source File: "JavadocMethodCheck.java"
	Class: "com.puppycrawl.tools.checkstyle.checks.javadoc.JavadocMethodCheck"
	Method: "checkThrowsTags"
	Line Contents: "final Token token = new Token(tag.getFirstArg(), tag.getLineNo(), tag"
	Mutator: "org.pitest.mutationtest.engine.gregor.mutators.NonVoidMethodCallMutator"
	Description: "removed call to com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocTag::getLineNo"
	
	
	Source File: "JavadocMethodCheck.java"
	Class: "com.puppycrawl.tools.checkstyle.checks.javadoc.JavadocMethodCheck"
	Method: "processThrows"
	Line Contents: "foundThrows.add(documentedClassInfo.getName().getText());"
	Mutator: "org.pitest.mutationtest.engine.gregor.mutators.NonVoidMethodCallMutator"
	Description: "removed call to com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocMethodCheck$Token::getText"
	
	
	Source File: "JavadocMethodCheck.java"
	Class: "com.puppycrawl.tools.checkstyle.checks.javadoc.JavadocMethodCheck"
	Method: "processThrows"
	Line Contents: "foundThrows.add(documentedClassInfo.getName().getText());"
	Mutator: "org.pitest.mutationtest.engine.gregor.mutators.NonVoidMethodCallMutator"
	Description: "removed call to java/util/Set::add"
	
	
	```

- From the analysis, we can see that the mutations were killed, but a new mutation was introduced. 
After reviewing the code one more time, it seems that [foundThrows](https://github.com/checkstyle/checkstyle/blob/master/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocMethodCheck.java#L919) set is dead code. It is [populated in processThrows](https://github.com/checkstyle/checkstyle/blob/master/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocMethodCheck.java#L970C13-L970C24), but it does not seem to be doing anything. We can remove the set and refactor the `processThrows` method not to populate the set.

- After refactoring a second time, report analysis is:
 ```
 Unnecessary suppressed mutation(s) found and should be removed:

Source File: "JavadocMethodCheck.java"
Class: "com.puppycrawl.tools.checkstyle.checks.javadoc.JavadocMethodCheck"
Method: "processThrows"
Line Contents: "foundThrows.add(documentedClassName);"
Mutator: "org.pitest.mutationtest.engine.gregor.mutators.NonVoidMethodCallMutator"
Description: "removed call to java/util/Set::add"
``` 
