### PR TITLE
Issue #13999: Resolve Pitest AbstractJavadocCheck mutation-1 suppression

### DIFF
--- a/config/checker-framework-suppressions/checker-nullness-optional-interning-suppressions.xml
+++ b/config/checker-framework-suppressions/checker-nullness-optional-interning-suppressions.xml
@@ -3993,9 +3993,9 @@
     <fileName>src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/AbstractJavadocCheck.java</fileName>
     <specifier>type.argument</specifier>
     <message>incompatible type argument for type parameter T of ThreadLocal.</message>
-    <lineContent>private static final ThreadLocal&lt;Map&lt;LineColumn, ParseStatus&gt;&gt; TREE_CACHE =</lineContent>
+    <lineContent>private static final ThreadLocal&lt;Map&lt;Integer, ParseStatus&gt;&gt; TREE_CACHE =</lineContent>
     <details>
-      found   : @Initialized @NonNull Map&lt;@Initialized @NonNull LineColumn, @Initialized @NonNull ParseStatus&gt;
+      found   : @Initialized @NonNull Map&lt;@Initialized @NonNull Integer, @Initialized @NonNull ParseStatus&gt;
       required: [extends @Initialized @Nullable Object super null (NullType)]
     </details>
   </checkerFrameworkError>

--- a/config/pitest-suppressions/pitest-javadoc-suppressions.xml
+++ b/config/pitest-suppressions/pitest-javadoc-suppressions.xml
@@ -3,15 +3,6 @@
   <mutation unstable="false">
     <sourceFile>AbstractJavadocCheck.java</sourceFile>
     <mutatedClass>com.puppycrawl.tools.checkstyle.checks.javadoc.AbstractJavadocCheck</mutatedClass>
-    <mutatedMethod>visitToken</mutatedMethod>
-    <mutator>org.pitest.mutationtest.engine.gregor.mutators.NonVoidMethodCallMutator</mutator>
-    <description>removed call to com/puppycrawl/tools/checkstyle/api/DetailAST::getColumnNo</description>
-    <lineContent>blockCommentNode.getColumnNo());</lineContent>
-  </mutation>
-
-  <mutation unstable="false">
-    <sourceFile>AbstractJavadocCheck.java</sourceFile>
-    <mutatedClass>com.puppycrawl.tools.checkstyle.checks.javadoc.AbstractJavadocCheck</mutatedClass>
     <mutatedMethod>walk</mutatedMethod>
     <mutator>org.pitest.mutationtest.engine.gregor.mutators.RemoveConditionalMutator_EQUAL_ELSE</mutator>
     <description>removed conditional - replaced equality check with false</description>

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/javadoc/AbstractJavadocCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/javadoc/AbstractJavadocCheckTest.java
@@ -190,6 +190,20 @@ public class AbstractJavadocCheckTest extends AbstractModuleTestSupport {
     }
 
     @Test
+    public void testCacheWithBlockCommentInSingleLineComment() throws Exception {
+        final String[] expected = {};
+        verifyWithInlineConfigParser(getPath("InputAbstractJavadocCache3.java"), expected);
+    }
+
+    @Test
+    public void testCacheWithTwoBlockCommentAtSameLine() throws Exception {
+        final String[] expected = {
+            "13: " + getCheckMessage(SummaryJavadocCheck.class, MSG_SUMMARY_FIRST_SENTENCE),
+        };
+        verifyWithInlineConfigParser(getPath("InputAbstractJavadocCache4.java"), expected);
+    }
+
+    @Test
     public void testPositionOne() throws Exception {
         JavadocCatchCheck.clearCounter();
         final String[] expected = CommonUtil.EMPTY_STRING_ARRAY;
@@ -735,7 +749,7 @@ public class AbstractJavadocCheckTest extends AbstractModuleTestSupport {
         @Override
         public void visitJavadocToken(DetailNode ast) {
             if (reportVisitJavadocToken) {
-                // We reusing messages from JavadocTypeCheck
+                // We're reusing messages from JavadocTypeCheck
                 // it is not possible to use test specific bundle of messages
                 log(ast.getLineNumber(), ast.getColumnNumber(), MSG_TAG_FORMAT, ast.getText());
             }

--- a/src/test/java/com/puppycrawl/tools/checkstyle/meta/MetadataGeneratorUtilTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/meta/MetadataGeneratorUtilTest.java
@@ -80,7 +80,7 @@ public final class MetadataGeneratorUtilTest extends AbstractModuleTestSupport {
         final String[] expectedErrorMessages = {
             "31: " + getCheckMessage(MSG_DESC_MISSING, "AbstractSuperCheck"),
             "43: " + getCheckMessage(MSG_DESC_MISSING, "AbstractHeaderCheck"),
-            "43: " + getCheckMessage(MSG_DESC_MISSING, "AbstractJavadocCheck"),
+            "42: " + getCheckMessage(MSG_DESC_MISSING, "AbstractJavadocCheck"),
             "45: " + getCheckMessage(MSG_DESC_MISSING, "AbstractClassCouplingCheck"),
             "26: " + getCheckMessage(MSG_DESC_MISSING, "AbstractAccessControlNameCheck"),
             "30: " + getCheckMessage(MSG_DESC_MISSING, "AbstractNameCheck"),

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/abstractjavadoc/InputAbstractJavadocCache3.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/abstractjavadoc/InputAbstractJavadocCache3.java
@@ -1,0 +1,14 @@
+/*
+SummaryJavadoc
+violateExecutionOnNonTightHtml = (default)false
+forbiddenSummaryFragments = (default)^$
+period = (default).
+
+
+*/
+
+package com.puppycrawl.tools.checkstyle.checks.javadoc.abstractjavadoc;
+
+// Comment /**Javadoc*/
+public class InputAbstractJavadocCache3 {
+}

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/abstractjavadoc/InputAbstractJavadocCache4.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/abstractjavadoc/InputAbstractJavadocCache4.java
@@ -1,0 +1,15 @@
+/*
+SummaryJavadoc
+violateExecutionOnNonTightHtml = (default)false
+forbiddenSummaryFragments = (default)^$
+period = (default).
+
+
+*/
+
+package com.puppycrawl.tools.checkstyle.checks.javadoc.abstractjavadoc;
+
+// violation below 'First sentence of Javadoc is missing an ending period.'
+/** Summary. */ /** some text*/
+public class InputAbstractJavadocCache4 {
+}


### PR DESCRIPTION
Part of Issue #13999
 
[AbstractJavadocCheck Documentation](https://checkstyle.org/apidocs/com/puppycrawl/tools/checkstyle/checks/javadoc/AbstractJavadocCheck.html)

Mutation - 1
https://github.com/checkstyle/checkstyle/blob/42f3c4f33790050b75341b6ad1c5afe0083e762c/config/pitest-suppressions/pitest-javadoc-suppressions.xml#L3-L10


Caching by column was removed , see reason at https://github.com/checkstyle/checkstyle/pull/15798#issuecomment-2429262257 and [why it works ](https://github.com/checkstyle/checkstyle/pull/15798#discussion_r1814893199)