### PR TITLE
Remove unnecessary // ok comments from UnnecessaryParenthesesCheck.java 

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/UnnecessaryParenthesesCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/UnnecessaryParenthesesCheck.java
@@ -80,7 +80,7 @@ import com.puppycrawl.tools.checkstyle.utils.TokenUtil;
  * boolean c = false, d = false;
  * if ((a &amp;&amp; b) || c) { // violation, unnecessary paren
  * }
- * if (a &amp;&amp; (b || c)) { // ok
+ * if (a &amp;&amp; (b || c)) { 
  * }
  * if ((a == b) &amp;&amp; c) { // violation, unnecessary paren
  * }
@@ -89,7 +89,7 @@ import com.puppycrawl.tools.checkstyle.utils.TokenUtil;
  * }
  * int f = 0;
  * int g = 0;
- * if (!(f &gt;= g) // ok
+ * if (!(f &gt;= g) 
  *         &amp;&amp; (g &gt; f)) { // violation, unnecessary paren
  * }
  * if ((++f) &gt; g &amp;&amp; a) { // violation, unnecessary paren

--- a/src/main/resources/com/puppycrawl/tools/checkstyle/meta/checks/coding/UnnecessaryParenthesesCheck.xml
+++ b/src/main/resources/com/puppycrawl/tools/checkstyle/meta/checks/coding/UnnecessaryParenthesesCheck.xml
@@ -52,7 +52,7 @@
  boolean c = false, d = false;
  if ((a &amp;amp;&amp;amp; b) || c) { // violation, unnecessary paren
  }
- if (a &amp;amp;&amp;amp; (b || c)) { // ok
+ if (a &amp;amp;&amp;amp; (b || c)) { 
  }
  if ((a == b) &amp;amp;&amp;amp; c) { // violation, unnecessary paren
  }
@@ -61,7 +61,7 @@
  }
  int f = 0;
  int g = 0;
- if (!(f &amp;gt;= g) // ok
+ if (!(f &amp;gt;= g) 
          &amp;amp;&amp;amp; (g &amp;gt; f)) { // violation, unnecessary paren
  }
  if ((++f) &amp;gt; g &amp;amp;&amp;amp; a) { // violation, unnecessary paren

--- a/src/xdocs/checks/coding/unnecessaryparentheses.xml
+++ b/src/xdocs/checks/coding/unnecessaryparentheses.xml
@@ -58,7 +58,7 @@ boolean a = true, b = true;
 boolean c = false, d = false;
 if ((a &amp;&amp; b) || c) { // violation, unnecessary paren
 }
-if (a &amp;&amp; (b || c)) { // ok
+if (a &amp;&amp; (b || c)) { 
 }
 if ((a == b) &amp;&amp; c) { // violation, unnecessary paren
 }
@@ -67,7 +67,7 @@ if ((e instanceof String) &amp;&amp; a || b) { // violation, unnecessary paren
 }
 int f = 0;
 int g = 0;
-if (!(f &gt;= g) // ok
+if (!(f &gt;= g) 
         &amp;&amp; (g &gt; f)) { // violation, unnecessary paren
 }
 if ((++f) &gt; g &amp;&amp; a) { // violation, unnecessary paren


### PR DESCRIPTION
This pull request removes unnecessary "// ok" comments from the src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/UnnecessaryParenthesesCheck.java
file. This change aims to enhance code clarity by eliminating comments that do not provide significant value to the codebase.