### PR TITLE
Issue #14424: Added option to skip HideUtilityClassConstructorCheck validation based on list of annotations

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/design/HideUtilityClassConstructorCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/design/HideUtilityClassConstructorCheck.java
@@ -19,10 +19,14 @@
 
 package com.puppycrawl.tools.checkstyle.checks.design;
 
+import java.util.Collections;
+import java.util.Set;
+
 import com.puppycrawl.tools.checkstyle.StatelessCheck;
 import com.puppycrawl.tools.checkstyle.api.AbstractCheck;
 import com.puppycrawl.tools.checkstyle.api.DetailAST;
 import com.puppycrawl.tools.checkstyle.api.TokenTypes;
+import com.puppycrawl.tools.checkstyle.utils.AnnotationUtil;
 
 /**
  * <div>
@@ -53,6 +57,19 @@ import com.puppycrawl.tools.checkstyle.api.TokenTypes;
  *   }
  * }
  * </pre>
+ * <ul>
+ * <li>
+ * Property {@code ignoreAnnotatedBy} - Ignore classes annotated
+ * with the specified annotation(s). Annotation names provided in this property
+ * must exactly match the annotation names on the classes. If the target class has annotations
+ * specified with their fully qualified names (including package), the annotations in this
+ * property should also be specified with their fully qualified names. Similarly, if the target
+ * class has annotations specified with their simple names, this property should contain the
+ * annotations with the same simple names.
+ * Type is {@code java.lang.String[]}.
+ * Default value is {@code ""}.
+ * </li>
+ * </ul>
  *
  * <p>
  * Parent is {@code com.puppycrawl.tools.checkstyle.TreeWalker}
@@ -78,6 +95,33 @@ public class HideUtilityClassConstructorCheck extends AbstractCheck {
      */
     public static final String MSG_KEY = "hide.utility.class";
 
+    /**
+     * Ignore classes annotated with the specified annotation(s). Annotation names
+     * provided in this property must exactly match the annotation names on the classes.
+     * If the target class has annotations specified with their fully qualified names
+     * (including package), the annotations in this property should also be specified with
+     * their fully qualified names. Similarly, if the target class has annotations specified
+     * with their simple names, this property should contain the annotations with the same
+     * simple names.
+     */
+    private Set<String> ignoreAnnotatedBy = Collections.emptySet();
+
+    /**
+     * Setter to ignore classes annotated with the specified annotation(s). Annotation names
+     * provided in this property must exactly match the annotation names on the classes.
+     * If the target class has annotations specified with their fully qualified names
+     * (including package), the annotations in this property should also be specified with
+     * their fully qualified names. Similarly, if the target class has annotations specified
+     * with their simple names, this property should contain the annotations with the same
+     * simple names.
+     *
+     * @param annotationNames specified annotation(s)
+     * @since 10.20.0
+     */
+    public void setIgnoreAnnotatedBy(String... annotationNames) {
+        ignoreAnnotatedBy = Set.of(annotationNames);
+    }
+
     @Override
     public int[] getDefaultTokens() {
         return getRequiredTokens();
@@ -96,7 +140,7 @@ public class HideUtilityClassConstructorCheck extends AbstractCheck {
     @Override
     public void visitToken(DetailAST ast) {
         // abstract class could not have private constructor
-        if (!isAbstract(ast)) {
+        if (!isAbstract(ast) && !shouldIgnoreClass(ast)) {
             final boolean hasStaticModifier = isStatic(ast);
 
             final Details details = new Details(ast);
@@ -144,6 +188,16 @@ public class HideUtilityClassConstructorCheck extends AbstractCheck {
     private static boolean isStatic(DetailAST ast) {
         return ast.findFirstToken(TokenTypes.MODIFIERS)
             .findFirstToken(TokenTypes.LITERAL_STATIC) != null;
+    }
+
+    /**
+     * Checks if class is annotated by specific annotation(s) to skip.
+     *
+     * @param ast class to check
+     * @return true if annotated by ignored annotations
+     */
+    private boolean shouldIgnoreClass(DetailAST ast) {
+        return AnnotationUtil.containsAnnotation(ast, ignoreAnnotatedBy);
     }
 
     /**

--- a/src/main/resources/com/puppycrawl/tools/checkstyle/meta/checks/design/HideUtilityClassConstructorCheck.xml
+++ b/src/main/resources/com/puppycrawl/tools/checkstyle/meta/checks/design/HideUtilityClassConstructorCheck.xml
@@ -32,6 +32,17 @@
    }
  }
  &lt;/pre&gt;</description>
+         <properties>
+            <property default-value="" name="ignoreAnnotatedBy" type="java.lang.String[]">
+               <description>Ignore classes annotated
+ with the specified annotation(s). Annotation names provided in this property
+ must exactly match the annotation names on the classes. If the target class has annotations
+ specified with their fully qualified names (including package), the annotations in this
+ property should also be specified with their fully qualified names. Similarly, if the target
+ class has annotations specified with their simple names, this property should contain the
+ annotations with the same simple names.</description>
+            </property>
+         </properties>
          <message-keys>
             <message-key key="hide.utility.class"/>
          </message-keys>

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/design/HideUtilityClassConstructorCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/design/HideUtilityClassConstructorCheckTest.java
@@ -146,4 +146,26 @@ public class HideUtilityClassConstructorCheckTest
             .isEqualTo(expected);
     }
 
+    @Test
+    public void testIgnoreAnnotatedBy() throws Exception {
+        final String[] expected = {
+            "30:1: " + getCheckMessage(MSG_KEY),
+        };
+        verifyWithInlineConfigParser(
+                getPath("InputHideUtilityClassConstructorIgnoreAnnotationBy.java"),
+                expected
+        );
+    }
+
+    @Test
+    public void testIgnoreAnnotatedByFullQualifier() throws Exception {
+        final String[] expected = {
+            "9:1: " + getCheckMessage(MSG_KEY),
+        };
+        verifyWithInlineConfigParser(
+                getPath("InputHideUtilityClassConstructor"
+                        + "IgnoreAnnotationByFullyQualifiedName.java"),
+                expected
+        );
+    }
 }

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/design/hideutilityclassconstructor/InputHideUtilityClassConstructorIgnoreAnnotationBy.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/design/hideutilityclassconstructor/InputHideUtilityClassConstructorIgnoreAnnotationBy.java
@@ -1,0 +1,46 @@
+/*
+HideUtilityClassConstructor
+ignoreAnnotatedBy = Skip, SkipWithParam, SkipWithAnnotationAsParam
+
+*/
+
+package com.puppycrawl.tools.checkstyle.checks.design.hideutilityclassconstructor;
+
+@Skip
+public class InputHideUtilityClassConstructorIgnoreAnnotationBy {
+  public static void func() {}
+}
+
+@SkipWithParam(name = "tool1")
+class ToolClass1 {
+  public static void func() {}
+}
+
+@SkipWithAnnotationAsParam(skip = @Skip)
+class ToolClass2 {
+  public static void func() {}
+}
+
+@CommonAnnot
+@Skip
+class ToolClass3 {
+  public static void func() {}
+}
+
+@CommonAnnot // violation
+class ToolClass4 {
+  public static void func() {}
+}
+
+
+@interface Skip {}
+
+@interface SkipWithParam {
+  String name();
+}
+
+@interface SkipWithAnnotationAsParam {
+  Skip skip();
+}
+
+@interface CommonAnnot {}

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/design/hideutilityclassconstructor/InputHideUtilityClassConstructorIgnoreAnnotationByFullyQualifiedName.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/design/hideutilityclassconstructor/InputHideUtilityClassConstructorIgnoreAnnotationByFullyQualifiedName.java
@@ -1,0 +1,19 @@
+/*
+HideUtilityClassConstructor
+ignoreAnnotatedBy = java.lang.Deprecated
+
+*/
+
+package com.puppycrawl.tools.checkstyle.checks.design.hideutilityclassconstructor;
+
+@Deprecated // violation
+public class InputHideUtilityClassConstructorIgnoreAnnotationByFullyQualifiedName {
+  public static void func() {}
+}
+
+@java.lang.Deprecated
+class DeprecatedClass {
+  public static void func() {}
+}
+
+@interface Deprecated {}

--- a/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/checks/design/HideUtilityClassConstructorCheckExamplesTest.java
+++ b/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/checks/design/HideUtilityClassConstructorCheckExamplesTest.java
@@ -36,9 +36,19 @@ public class HideUtilityClassConstructorCheckExamplesTest
     public void testExample1() throws Exception {
         final String[] expected = {
             "12:1: " + getCheckMessage(MSG_KEY),
-            "37:1: " + getCheckMessage(MSG_KEY),
+            "38:1: " + getCheckMessage(MSG_KEY),
+            "44:1: " + getCheckMessage(MSG_KEY),
         };
 
         verifyWithInlineConfigParser(getPath("Example1.java"), expected);
+    }
+
+    @Test
+    public void testExample2() throws Exception {
+        final String[] expected = {
+            "41:1: " + getCheckMessage(MSG_KEY),
+        };
+
+        verifyWithInlineConfigParser(getPath("Example2.java"), expected);
     }
 }

--- a/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/design/hideutilityclassconstructor/Example1.java
+++ b/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/design/hideutilityclassconstructor/Example1.java
@@ -9,7 +9,8 @@
 package com.puppycrawl.tools.checkstyle.checks.design.hideutilityclassconstructor;
 
 // xdoc section -- start
-class Example1 { // violation
+@java.lang.Deprecated // violation
+class Example1 {
 
   public Example1() {
   }
@@ -18,7 +19,7 @@ class Example1 { // violation
   }
 }
 
-class Foo { // OK
+class Foo {
 
   private Foo() {
   }
@@ -26,7 +27,7 @@ class Foo { // OK
   static int n;
 }
 
-class Bar { // OK
+class Bar {
 
   protected Bar() {
     // prevents calls from subclass
@@ -34,8 +35,17 @@ class Bar { // OK
   }
 }
 
-class UtilityClass { // violation
+@Deprecated // violation
+class UtilityClass {
 
   static float f;
 }
+
+@SpringBootApplication // violation
+class Application1 {
+
+  public static void main(String[] args) {
+  }
+}
 // xdoc section -- end
+@interface SpringBootApplication {}

--- a/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/design/hideutilityclassconstructor/Example2.java
+++ b/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/design/hideutilityclassconstructor/Example2.java
@@ -1,0 +1,52 @@
+/*xml
+<module name="Checker">
+  <module name="TreeWalker">
+    <module name="HideUtilityClassConstructor">
+      <property name="ignoreAnnotatedBy"
+        value="SpringBootApplication, java.lang.Deprecated" />
+    </module>
+   </module>
+</module>
+*/
+
+package com.puppycrawl.tools.checkstyle.checks.design.hideutilityclassconstructor;
+
+// xdoc section -- start
+@java.lang.Deprecated
+class Example2 { // ok, skipped by annotation
+
+  public Example2() {
+  }
+
+  public static void fun() {
+  }
+}
+
+class Foo2 {
+
+  private Foo2() {
+  }
+
+  static int n;
+}
+
+class Bar2 {
+
+  protected Bar2() {
+    // prevents calls from subclass
+    throw new UnsupportedOperationException();
+  }
+}
+
+@Deprecated // violation, annotation not exact match
+class UtilityClass2 {
+
+  static float f;
+}
+
+@SpringBootApplication
+class Application2 { // ok, skipped by annotation
+  public static void main(String[] args) {
+  }
+}
+// xdoc section -- end

--- a/src/xdocs/checks/design/hideutilityclassconstructor.xml
+++ b/src/xdocs/checks/design/hideutilityclassconstructor.xml
@@ -42,6 +42,27 @@ public class StringUtils // not final to allow subclassing
         </source>
       </subsection>
 
+      <subsection name="Properties" id="Properties">
+        <div class="wrapper">
+          <table>
+            <tr>
+              <th>name</th>
+              <th>description</th>
+              <th>type</th>
+              <th>default value</th>
+              <th>since</th>
+            </tr>
+            <tr>
+              <td>ignoreAnnotatedBy</td>
+              <td>Ignore classes annotated with the specified annotation(s). Annotation names provided in this property must exactly match the annotation names on the classes. If the target class has annotations specified with their fully qualified names (including package), the annotations in this property should also be specified with their fully qualified names. Similarly, if the target class has annotations specified with their simple names, this property should contain the annotations with the same simple names.</td>
+              <td><a href="../../property_types.html#String.5B.5D">String[]</a></td>
+              <td><code>{}</code></td>
+              <td>10.20.0</td>
+            </tr>
+          </table>
+        </div>
+      </subsection>
+
       <subsection name="Examples" id="Examples">
         <p id="Example1-config">
           To configure the check:
@@ -55,7 +76,8 @@ public class StringUtils // not final to allow subclassing
         </source>
         <p id="Example1-code">Example:</p>
         <source>
-class Example1 { // violation
+@java.lang.Deprecated // violation
+class Example1 {
 
   public Example1() {
   }
@@ -64,7 +86,7 @@ class Example1 { // violation
   }
 }
 
-class Foo { // OK
+class Foo {
 
   private Foo() {
   }
@@ -72,7 +94,7 @@ class Foo { // OK
   static int n;
 }
 
-class Bar { // OK
+class Bar {
 
   protected Bar() {
     // prevents calls from subclass
@@ -80,9 +102,72 @@ class Bar { // OK
   }
 }
 
-class UtilityClass { // violation
+@Deprecated // violation
+class UtilityClass {
 
   static float f;
+}
+
+@SpringBootApplication // violation
+class Application1 {
+
+  public static void main(String[] args) {
+  }
+}
+        </source>
+
+        <p id="Example2-config">
+          To configure the check to ignore classes annotated with <code>SpringBootApplication</code>
+          or <code>java.lang.Deprecated</code>.
+        </p>
+        <source>
+&lt;module name=&quot;Checker&quot;&gt;
+  &lt;module name=&quot;TreeWalker&quot;&gt;
+    &lt;module name=&quot;HideUtilityClassConstructor&quot;&gt;
+      &lt;property name=&quot;ignoreAnnotatedBy&quot;
+        value=&quot;SpringBootApplication, java.lang.Deprecated&quot; /&gt;
+    &lt;/module&gt;
+   &lt;/module&gt;
+&lt;/module&gt;
+        </source>
+        <p id="Example2-code">Example:</p>
+        <source>
+@java.lang.Deprecated
+class Example2 { // ok, skipped by annotation
+
+  public Example2() {
+  }
+
+  public static void fun() {
+  }
+}
+
+class Foo2 {
+
+  private Foo2() {
+  }
+
+  static int n;
+}
+
+class Bar2 {
+
+  protected Bar2() {
+    // prevents calls from subclass
+    throw new UnsupportedOperationException();
+  }
+}
+
+@Deprecated // violation, annotation not exact match
+class UtilityClass2 {
+
+  static float f;
+}
+
+@SpringBootApplication
+class Application2 { // ok, skipped by annotation
+  public static void main(String[] args) {
+  }
 }
         </source>
       </subsection>

--- a/src/xdocs/checks/design/hideutilityclassconstructor.xml.template
+++ b/src/xdocs/checks/design/hideutilityclassconstructor.xml.template
@@ -42,6 +42,15 @@ public class StringUtils // not final to allow subclassing
         </source>
       </subsection>
 
+      <subsection name="Properties" id="Properties">
+        <div class="wrapper">
+          <macro name="properties">
+            <param name="modulePath"
+                   value="src/main/java/com/puppycrawl/tools/checkstyle/checks/design/HideUtilityClassConstructorCheck.java"/>
+          </macro>
+        </div>
+      </subsection>
+
       <subsection name="Examples" id="Examples">
         <p id="Example1-config">
           To configure the check:
@@ -55,6 +64,22 @@ public class StringUtils // not final to allow subclassing
         <macro name="example">
           <param name="path"
                    value="resources/com/puppycrawl/tools/checkstyle/checks/design/hideutilityclassconstructor/Example1.java"/>
+            <param name="type" value="code"/>
+        </macro>
+
+        <p id="Example2-config">
+          To configure the check to ignore classes annotated with <code>SpringBootApplication</code>
+          or <code>java.lang.Deprecated</code>.
+        </p>
+        <macro name="example">
+          <param name="path"
+                 value="resources/com/puppycrawl/tools/checkstyle/checks/design/hideutilityclassconstructor/Example2.java"/>
+          <param name="type" value="config"/>
+        </macro>
+        <p id="Example2-code">Example:</p>
+        <macro name="example">
+          <param name="path"
+                   value="resources/com/puppycrawl/tools/checkstyle/checks/design/hideutilityclassconstructor/Example2.java"/>
             <param name="type" value="code"/>
         </macro>
       </subsection>


### PR DESCRIPTION
Aims to close #14424 
Continuation of abandoned  #14701 