### PR TITLE
Issue #15456: Specify violation messages for OuterTypeFilenameCheck

### DIFF
--- a/src/test/java/com/puppycrawl/tools/checkstyle/bdd/InlineConfigParser.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/bdd/InlineConfigParser.java
@@ -313,7 +313,6 @@ public final class InlineConfigParser {
             "com.puppycrawl.tools.checkstyle.checks.naming.StaticVariableNameCheck",
             "com.puppycrawl.tools.checkstyle.checks.naming.TypeNameCheck",
             "com.puppycrawl.tools.checkstyle.checks.NoCodeInFileCheck",
-            "com.puppycrawl.tools.checkstyle.checks.OuterTypeFilenameCheck",
             "com.puppycrawl.tools.checkstyle.checks.regexp.RegexpMultilineCheck",
             "com.puppycrawl.tools.checkstyle.checks.regexp.RegexpSinglelineCheck",
             "com.puppycrawl.tools.checkstyle.checks.regexp.RegexpSinglelineJavaCheck",

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/OuterTypeFilenameCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/OuterTypeFilenameCheckTest.java
@@ -164,7 +164,7 @@ public class OuterTypeFilenameCheckTest extends AbstractModuleTestSupport {
     public void testOuterTypeFilenameRecordsMethodRecordDef() throws Exception {
 
         final String[] expected = {
-            "10:1: " + getCheckMessage(MSG_KEY),
+            "11:1: " + getCheckMessage(MSG_KEY),
         };
         verifyWithInlineConfigParser(
                 getNonCompilablePath("InputOuterTypeFilenameRecord.java"), expected);

--- a/src/test/resources-noncompilable/com/puppycrawl/tools/checkstyle/checks/outertypefilename/InputOuterTypeFilenameRecord.java
+++ b/src/test/resources-noncompilable/com/puppycrawl/tools/checkstyle/checks/outertypefilename/InputOuterTypeFilenameRecord.java
@@ -7,5 +7,6 @@ OuterTypeFilename
 //non-compiled with javac: contains different class name by demand of test
 package com.puppycrawl.tools.checkstyle.checks.outertypefilename;
 
-public record IncorrectName1(int x, int y, String str) { // violation
+// violation below 'The name of the outer type and the file do not match.'
+public record IncorrectName1(int x, int y, String str) {
 }

--- a/src/test/resources-noncompilable/com/puppycrawl/tools/checkstyle/checks/outertypefilename/InputOuterTypeFilenameRecordMethodRecordDef.java
+++ b/src/test/resources-noncompilable/com/puppycrawl/tools/checkstyle/checks/outertypefilename/InputOuterTypeFilenameRecordMethodRecordDef.java
@@ -6,8 +6,8 @@ OuterTypeFilename
 
 //non-compiled with javac: contains different class name by demand of test
 package com.puppycrawl.tools.checkstyle.checks.outertypefilename;
-
-public record IncorrectName2(int x, int y, String str) { // violation
+// violation below 'The name of the outer type and the file do not match.'
+public record IncorrectName2(int x, int y, String str) {
     class LocalRecordHelper {
         Record recordMethod(int x) {
             record R76 (int x) { }  // Issue #8598: OuterTypeFileName

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/outertypefilename/InputOuterTypeFilename1a.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/outertypefilename/InputOuterTypeFilename1a.java
@@ -5,8 +5,8 @@ OuterTypeFilename
 */
 
 package com.puppycrawl.tools.checkstyle.checks.outertypefilename;
-
-class Class1 { // violation
+// violation below 'The name of the outer type and the file do not match.'
+class Class1 {
     public interface NestedInterface {}
     public enum NestedEnum {}
     class NestedClass {}

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/outertypefilename/InputOuterTypeFilename5.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/outertypefilename/InputOuterTypeFilename5.java
@@ -6,8 +6,9 @@ OuterTypeFilename
 
 // someexamples of 1.5 extensions
 package com.puppycrawl.tools.checkstyle.checks.outertypefilename;
+// violation below 'The name of the outer type and the file do not match.'
+ class InputOuterTypeFilename5NameMismatch {
 
- class InputOuterTypeFilename5NameMismatch { // violation
 
 
 }

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/outertypefilename/InputOuterTypeFilenameNoPublic.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/outertypefilename/InputOuterTypeFilenameNoPublic.java
@@ -6,5 +6,5 @@ OuterTypeFilename
 
 package com.puppycrawl.tools.checkstyle.checks.outertypefilename;
 
-class Foo {} // violation
+class Foo {} // violation 'The name of the outer type and the file do not match.'
 enum FooEnum {}

--- a/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/checks/OuterTypeFilenameCheckExamplesTest.java
+++ b/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/checks/OuterTypeFilenameCheckExamplesTest.java
@@ -43,7 +43,7 @@ public class OuterTypeFilenameCheckExamplesTest extends AbstractExamplesModuleTe
     @Test
     public void testExample2() throws Exception {
         final String[] expected = {
-            "11:1: " + getCheckMessage(MSG_KEY),
+            "12:1: " + getCheckMessage(MSG_KEY),
         };
 
         verifyWithInlineConfigParser(getPath("Example2.java"), expected);
@@ -52,7 +52,7 @@ public class OuterTypeFilenameCheckExamplesTest extends AbstractExamplesModuleTe
     @Test
     public void testExample3() throws Exception {
         final String[] expected = {
-            "11:1: " + getCheckMessage(MSG_KEY),
+            "12:1: " + getCheckMessage(MSG_KEY),
         };
 
         verifyWithInlineConfigParser(getPath("Example3.java"), expected);
@@ -61,7 +61,7 @@ public class OuterTypeFilenameCheckExamplesTest extends AbstractExamplesModuleTe
     @Test
     public void testExample4() throws Exception {
         final String[] expected = {
-            "11:1: " + getCheckMessage(MSG_KEY),
+            "12:1: " + getCheckMessage(MSG_KEY),
         };
 
         verifyWithInlineConfigParser(getPath("Example4.java"), expected);
@@ -70,7 +70,7 @@ public class OuterTypeFilenameCheckExamplesTest extends AbstractExamplesModuleTe
     @Test
     public void testExample5() throws Exception {
         final String[] expected = {
-            "11:1: " + getCheckMessage(MSG_KEY),
+            "12:1: " + getCheckMessage(MSG_KEY),
         };
 
         verifyWithInlineConfigParser(getPath("Example5.java"), expected);

--- a/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/outertypefilename/Example2.java
+++ b/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/outertypefilename/Example2.java
@@ -8,5 +8,6 @@
 package com.puppycrawl.tools.checkstyle.checks.outertypefilename;
 
 // xdoc section -- start
-class Example2ButNotSameName {} // violation
+// violation below 'The name of the outer type and the file do not match.'
+class Example2ButNotSameName {}
 // xdoc section -- end

--- a/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/outertypefilename/Example3.java
+++ b/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/outertypefilename/Example3.java
@@ -8,5 +8,6 @@
 package com.puppycrawl.tools.checkstyle.checks.outertypefilename;
 
 // xdoc section -- start
-interface Example3ButNotSameName {} // violation
+// violation below 'The name of the outer type and the file do not match.'
+interface Example3ButNotSameName {}
 // xdoc section -- end

--- a/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/outertypefilename/Example4.java
+++ b/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/outertypefilename/Example4.java
@@ -8,5 +8,6 @@
 package com.puppycrawl.tools.checkstyle.checks.outertypefilename;
 
 // xdoc section -- start
-enum Example4ButNotSameName {} // violation
+// violation below 'The name of the outer type and the file do not match.'
+enum Example4ButNotSameName {}
 // xdoc section -- end

--- a/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/outertypefilename/Example5.java
+++ b/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/outertypefilename/Example5.java
@@ -8,5 +8,6 @@
 package com.puppycrawl.tools.checkstyle.checks.outertypefilename;
 
 // xdoc section -- start
-class Example5ButNotSameName {} // violation
+// violation below 'The name of the outer type and the file do not match.'
+class Example5ButNotSameName {}
 // xdoc section -- end

--- a/src/xdocs/checks/misc/outertypefilename.xml
+++ b/src/xdocs/checks/misc/outertypefilename.xml
@@ -37,25 +37,29 @@ public class Example1 {}
           Example file content with name of file Example2.java
         </p>
         <source>
-class Example2ButNotSameName {} // violation
+// violation below 'The name of the outer type and the file do not match.'
+class Example2ButNotSameName {}
         </source>
         <p id="Example3-code">
           Example file content with name of file Example3.java
         </p>
         <source>
-interface Example3ButNotSameName {} // violation
+// violation below 'The name of the outer type and the file do not match.'
+interface Example3ButNotSameName {}
         </source>
         <p id="Example4-code">
           Example file content with name of file Example4.java
         </p>
         <source>
-enum Example4ButNotSameName {} // violation
+// violation below 'The name of the outer type and the file do not match.'
+enum Example4ButNotSameName {}
         </source>
         <p id="Example5-code">
           Example file content with name of file Example5.java
         </p>
         <source>
-class Example5ButNotSameName {} // violation
+// violation below 'The name of the outer type and the file do not match.'
+class Example5ButNotSameName {}
         </source>
       </subsection>
 


### PR DESCRIPTION

### Issue: #15456 

**### Key Changes**

- **Added Violation Messages**: Custom violation messages have been implemented for OuterTypeFilenameCheck to improve readability and usability.
- **Updated Suppression Lis**t: The OuterTypeFilenameCheck has been removed from the suppression list.