### PR TITLE
Issue #15689: Add JavadocParagraph violation message examples

### DIFF
--- a/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadocparagraph/Example5.java
+++ b/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadocparagraph/Example5.java
@@ -1,0 +1,22 @@
+/*xml
+<module name="Checker">
+  <module name="TreeWalker">
+    <module name="JavadocParagraph"/>
+  </module>
+</module>
+*/
+package com.puppycrawl.tools.checkstyle.checks.javadoc.javadocparagraph;
+
+// xdoc section -- start
+// violation 4 lines below 'HTML element not closed properly'
+/**
+ * This example demonstrates a missed HTML close violation.
+ *
+ * <p>Unclosed <b>bold tag (violation)
+ *
+ * <p>Correctly closed <i>italic tag</i> (ok).
+ */
+// violation 4 lines above 'HTML element not closed properly'
+public class Example5 {
+}
+// xdoc section -- end

--- a/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadocparagraph/Example6.java
+++ b/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadocparagraph/Example6.java
@@ -1,0 +1,24 @@
+/*xml
+<module name="Checker">
+  <module name="TreeWalker">
+    <module name="JavadocParagraph"/>
+  </module>
+</module>
+*/
+package com.puppycrawl.tools.checkstyle.checks.javadoc.javadocparagraph;
+
+// xdoc section -- start
+// violation 5 lines below 'redundant paragraph tag found'
+/**
+ * This example shows redundant paragraph tag usage.
+ *
+ * <p>This paragraph is ok.</p>
+ * <p><p>Nested redundant paragraph tag (violation).</p></p>
+ *
+ * <p>Another paragraph with redundant <p> tag inside (violation).
+ *
+ */
+// violation 5 lines above 'redundant paragraph tag found'
+public class Example6 {
+}
+// xdoc section -- end

--- a/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadocparagraph/Example7.java
+++ b/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadocparagraph/Example7.java
@@ -1,0 +1,22 @@
+/*xml
+<module name="Checker">
+  <module name="TreeWalker">
+    <module name="JavadocParagraph"/>
+  </module>
+</module>
+*/
+package com.puppycrawl.tools.checkstyle.checks.javadoc.javadocparagraph;
+
+// xdoc section -- start
+// violation 4 lines below '<p> tag should not precede HTML block-tag <div>'
+/**
+ * Example showing a block tag preceded by a <p> tag.
+ *
+ * <p><div>Block tag 'div' should not follow a <p> tag directly (violation).</div>
+ *
+ * <p><span>Inline tag 'span' after <p> tag is allowed (ok).</span>
+ */
+// violation 4 lines above '<p> tag should not precede HTML block-tag <div>'
+public class Example7 {
+}
+// xdoc section -- end

--- a/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadocparagraph/Example8.java
+++ b/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadocparagraph/Example8.java
@@ -1,0 +1,26 @@
+/*xml
+<module name="Checker">
+  <module name="TreeWalker">
+    <module name="JavadocParagraph"/>
+  </module>
+</module>
+*/
+package com.puppycrawl.tools.checkstyle.checks.javadoc.javadocparagraph;
+
+// xdoc section -- start
+// violation 4 lines below 'extra <p> tag after block-tag <ul>'
+/**
+ * Example of a <p> tag placed after a block-level element (violation).
+ *
+ * <ul>
+ * <li>Item 1</li>
+ * <li>Item 2</li>
+ * <li>Item 3</li>
+ * </ul>
+ *
+ * <p>Paragraph after the block element <ul> is not allowed (violation).</p>
+ */
+// violation 8 lines below 'extra <p> tag after block-tag <ul>'
+public class Example8 {
+}
+// xdoc section -- end


### PR DESCRIPTION
Closes #15689 

https://checkstyle.org/checks/javadoc/javadocparagraph.html

**Summary of changes:**

Added examples to illustrate each of the following violation messages such as:

> Redundant paragraph tag
> Unclosed HTML element
> Misplaced tag