### PR TITLE
Issue #14631: Updated JAVADOC_INLINE_TAG_START of JavadocTokenTypes to new AST format

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/api/JavadocTokenTypes.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/api/JavadocTokenTypes.java
@@ -333,7 +333,7 @@ public final class JavadocTokenTypes {
      * <pre>{@code @author Baratali Izmailov}</pre>
      * <b>Tree:</b>
      * <pre>{@code
-     *   --JAVADOC_TAG -> JAVADOC_TAG
+     *   JAVADOC_TAG -> JAVADOC_TAG
      *      |--AUTHOR_LITERAL -> @author
      *      |--WS ->
      *      `--DESCRIPTION -> DESCRIPTION
@@ -357,11 +357,11 @@ public final class JavadocTokenTypes {
      * <pre>{@code @myJavadocTag some magic}</pre>
      * <b>Tree:</b>
      * <pre>{@code
-     *   |--JAVADOC_TAG[3x0] : [@myJavadocTag some magic]
-     *       |--CUSTOM_NAME[3x0] : [@myJavadocTag]
-     *       |--WS[3x13] : [ ]
-     *       |--DESCRIPTION[3x14] : [some magic]
-     *           |--TEXT[3x14] : [some magic]
+     *   JAVADOC_TAG --> JAVADOC_TAG
+     *       |--CUSTOM_NAME --> @myJavadocTag
+     *       |--WS -->
+     *       `--DESCRIPTION --> DESCRIPTION
+     *           |--TEXT --> some magic
      * }</pre>
      */
     public static final int CUSTOM_NAME = JavadocParser.CUSTOM_NAME;

--- a/src/main/java/com/puppycrawl/tools/checkstyle/api/JavadocTokenTypes.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/api/JavadocTokenTypes.java
@@ -373,12 +373,12 @@ public final class JavadocTokenTypes {
      * <pre><code>{&#64;code Comparable&lt;E&gt;}</code></pre>
      * <b>Tree:</b>
      * <pre>
-     * <code> |--JAVADOC_INLINE_TAG[3x0] : [{&#64;code Comparable&lt;E&gt;}]
-     *         |--JAVADOC_INLINE_TAG_START[3x0] : [{]
-     *         |--CODE_LITERAL[3x1] : [@code]
-     *         |--WS[3x6] : [ ]
-     *         |--TEXT[3x7] : [Comparable&lt;E&gt;]
-     *         |--JAVADOC_INLINE_TAG_END[3x21] : [}]
+     * <code> |--JAVADOC_INLINE_TAG --> JAVADOC_INLINE_TAG
+     *         |--JAVADOC_INLINE_TAG_START --> {
+     *         |--CODE_LITERAL --> @code
+     *         |--WS -->
+     *         |--TEXT --> Comparable&lt;E&gt;
+     *         `--JAVADOC_INLINE_TAG_END --> }
      * </code>
      * </pre>
      *


### PR DESCRIPTION
Issue #14631: 
```
$ cat Test.java                                                                     
{@code Comparable&lt;E&gt;}

 $  java -jar checkstyle-10.20.0-all.jar -j Test.java | sed "s/\[[0-9]\+:[0-9]\+\]//g"
JAVADOC -> JAVADOC [0:0]
|--JAVADOC_INLINE_TAG -> JAVADOC_INLINE_TAG [0:0]
|   |--JAVADOC_INLINE_TAG_START -> { [0:0]
|   |--CODE_LITERAL -> @code [0:1]
|   |--WS ->   [0:6]
|   |--TEXT -> Comparable&lt;E&gt; [0:7]
|   `--JAVADOC_INLINE_TAG_END -> } [0:27]
|--NEWLINE -> \n [0:28]
|--NEWLINE -> \n [1:0]
`--EOF -> <EOF> [2:0]