### PR TITLE
Issue #14631: Updated JAVADOC_INLINE_TAG_END to to new format of AST format

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/api/JavadocTokenTypes.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/api/JavadocTokenTypes.java
@@ -395,12 +395,13 @@ public final class JavadocTokenTypes {
      * <pre><code>{&#64;code Comparable&lt;E&gt;}</code></pre>
      * <b>Tree:</b>
      * <pre>
-     * <code> |--JAVADOC_INLINE_TAG[3x0] : [{&#64;code Comparable&lt;E&gt;}]
-     *         |--JAVADOC_INLINE_TAG_START[3x0] : [{]
-     *         |--CODE_LITERAL[3x1] : [@code]
-     *         |--WS[3x6] : [ ]
-     *         |--TEXT[3x7] : [Comparable&lt;E&gt;]
-     *         |--JAVADOC_INLINE_TAG_END[3x21] : [}]
+     * <code>JAVADOC_INLINE_TAG --&gt; JAVADOC_INLINE_TAG
+     *        |--JAVADOC_INLINE_TAG_START --&gt; {
+     *        |--CODE_LITERAL --&gt; @code
+     *        |--WS --&gt;
+     *        |--TEXT --&gt; Comparable&lt;E&gt;
+     *        `--JAVADOC_INLINE_TAG_END --&gt; }
+     *
      * </code>
      * </pre>
      *


### PR DESCRIPTION
Issue #14631: Updated JAVADOC_INLINE_TAG_END to to new format of AST format

```java

$ cat Test.java                                                                                              
{@code Comparable&lt;E&gt;}%                                                                                          
$ java -jar checkstyle-10.20.0-all.jar -j Test.java | sed "s/\[[0-9]\+:[0-9]\+\]//g"                         
JAVADOC -> JAVADOC [0:0]
|--JAVADOC_INLINE_TAG -> JAVADOC_INLINE_TAG [0:0]
|   |--JAVADOC_INLINE_TAG_START -> { [0:0]
|   |--CODE_LITERAL -> @code [0:1]
|   |--WS ->   [0:6]
|   |--TEXT -> Comparable&lt;E&gt; [0:7]
|   `--JAVADOC_INLINE_TAG_END -> } [0:27]
`--EOF -> <EOF> [0:28]


