### PR TITLE
Issue #14631 : Updated VALUE_LITERAL to to new format of AST format

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/api/JavadocTokenTypes.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/api/JavadocTokenTypes.java
@@ -648,15 +648,15 @@ public final class JavadocTokenTypes {
      * <pre><code>{&#64;value Integer#MAX_VALUE}</code></pre>
      * <b>Tree:</b>
      * <pre>
-     * <code> |--JAVADOC_INLINE_TAG[1x0] : [&#64;value Integer#MAX_VALUE}]
-     *        |--JAVADOC_INLINE_TAG_START[1x0] : [{]
-     *        |--VALUE_LITERAL[1x1] : [@value]
-     *        |--WS[1x7] : [ ]
-     *        |--REFERENCE[1x8] : [Integer#MAX_VALUE]
-     *            |--CLASS[1x8] : [Integer]
-     *            |--HASH[1x15] : [#]
-     *            |--MEMBER[1x16] : [MAX_VALUE]
-     *        |--JAVADOC_INLINE_TAG_END[1x25] : [}]
+     * <code> JAVADOC_INLINE_TAG --&gt; JAVADOC_INLINE_TAG
+     *         |--JAVADOC_INLINE_TAG_START --&gt; {
+     *         |--VALUE_LITERAL --&gt; @value
+     *         |--WS --&gt;
+     *         |--REFERENCE --&gt; REFERENCE
+     *         |   |--PACKAGE_CLASS --&gt; Integer
+     *         |   |--HASH --&gt; #
+     *         |   `--MEMBER --&gt; MAX_VALUE
+     *         `--JAVADOC_INLINE_TAG_END --&gt; }
      * </code>
      * </pre>
      *


### PR DESCRIPTION
Issue #14631 : Updated VALUE_LITERAL of JavadocTokenTypes to new AST format

```
$  cat Test.java
{@value Integer#MAX_VALUE}%     
                                                                                                                                  
$ java -jar checkstyle-10.20.0-all.jar -j Test.java | sed "s/\[[0-9]\+:[0-9]\+\]//g"

JAVADOC_INLINE_TAG -> JAVADOC_INLINE_TAG [0:0]
|--JAVADOC_INLINE_TAG_START -> { [0:0]
|--VALUE_LITERAL -> @value [0:1]
|--WS ->   [0:7]
|--REFERENCE -> REFERENCE [0:8]
|   |--PACKAGE_CLASS -> Integer [0:8]
|   |--HASH -> # [0:15]
|   `--MEMBER -> MAX_VALUE [0:16]
`--JAVADOC_INLINE_TAG_END -> } [0:25]