### PR TITLE
Issue #13345: Enable examples tests for SimplifyBooleanReturnCheck

### DIFF
--- a/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/checks/coding/SimplifyBooleanReturnCheckExamplesTest.java
+++ b/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/checks/coding/SimplifyBooleanReturnCheckExamplesTest.java
@@ -19,12 +19,10 @@
 
 package com.puppycrawl.tools.checkstyle.checks.coding;
 
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
 import com.puppycrawl.tools.checkstyle.AbstractExamplesModuleTestSupport;
 
-@Disabled("until https://github.com/checkstyle/checkstyle/issues/13345")
 public class SimplifyBooleanReturnCheckExamplesTest extends AbstractExamplesModuleTestSupport {
     @Override
     protected String getPackageLocation() {
@@ -34,9 +32,10 @@ public class SimplifyBooleanReturnCheckExamplesTest extends AbstractExamplesModu
     @Test
     public void testExample1() throws Exception {
         final String[] expected = {
-
+            "17:5: " + getCheckMessage(SimplifyBooleanReturnCheck.MSG_KEY),
+            "29:5: " + getCheckMessage(SimplifyBooleanReturnCheck.MSG_KEY),
         };
 
-        verifyWithInlineConfigParser(getPath("Example1.txt"), expected);
+        verifyWithInlineConfigParser(getPath("Example1.java"), expected);
     }
 }

--- a/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/coding/simplifybooleanreturn/Example1.java
+++ b/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/coding/simplifybooleanreturn/Example1.java
@@ -1,0 +1,49 @@
+/*xml
+<module name="Checker">
+  <module name="TreeWalker">
+    <module name="SimplifyBooleanReturn"/>
+  </module>
+</module>
+*/
+package com.puppycrawl.tools.checkstyle.checks.coding.simplifybooleanreturn;
+
+// xdoc section -- start
+class Example1 {
+
+  boolean cond;
+  int a,b;
+
+  boolean check1() {
+    if (cond) { // violation, 'Conditional logic can be removed
+      return true;
+    } else {
+      return false;
+    }
+  }
+
+  boolean check1Simplified() {
+    return cond;
+  }
+
+  boolean check2() {
+    if (cond == true) { // violation, 'Conditional logic can be removed'
+      return false;
+    } else {
+      return true;
+    }
+  }
+
+  // Ok, can be simplified but doesn't return a Boolean
+  int choose1() {
+    if (cond) {
+      return a;
+    } else {
+      return b;
+    }
+  }
+
+  int choose1Simplified() {
+    return cond ? a: b;
+  }
+}
+// xdoc section -- end

--- a/src/xdocs/checks/coding/simplifybooleanreturn.xml
+++ b/src/xdocs/checks/coding/simplifybooleanreturn.xml
@@ -47,51 +47,43 @@ return !valid();
         </source>
         <p id="Example1-code">Example:</p>
         <source>
-public class Test {
+class Example1 {
 
- private boolean cond;
- private Foo a;
- private Foo b;
+  boolean cond;
+  int a,b;
 
- public boolean check1() {
-  if (cond) { // violation, can be simplified
-    return true;
+  boolean check1() {
+    if (cond) { // violation, 'Conditional logic can be removed
+      return true;
+    } else {
+      return false;
+    }
   }
-  else {
-    return false;
-  }
- }
 
- // Ok, simplified version of check1()
- public boolean check2() {
-  return cond;
- }
-
- // violations, can be simplified
- public boolean check3() {
-  if (cond == true) { // can be simplified to &quot;if (cond)&quot;
-    return false;
+  boolean check1Simplified() {
+    return cond;
   }
-  else {
-    return true; // can be simplified to &quot;return !cond&quot;
-  }
- }
 
- // Ok, can be simplified but doesn't return a Boolean
- public Foo choose1() {
-  if (cond) {
-    return a;
+  boolean check2() {
+    if (cond == true) { // violation, 'Conditional logic can be removed'
+      return false;
+    } else {
+      return true;
+    }
   }
-  else {
-    return b;
+
+  // Ok, can be simplified but doesn't return a Boolean
+  int choose1() {
+    if (cond) {
+      return a;
+    } else {
+      return b;
+    }
   }
- }
 
- // Ok, simplified version of choose1()
- public Foo choose2() {
-  return cond ? a: b;
- }
-
+  int choose1Simplified() {
+    return cond ? a: b;
+  }
 }
         </source>
       </subsection>

--- a/src/xdocs/checks/coding/simplifybooleanreturn.xml.template
+++ b/src/xdocs/checks/coding/simplifybooleanreturn.xml.template
@@ -40,13 +40,13 @@ return !valid();
         </p>
         <macro name="example">
           <param name="path"
-                 value="resources/com/puppycrawl/tools/checkstyle/checks/coding/simplifybooleanreturn/Example1.txt"/>
+                 value="resources/com/puppycrawl/tools/checkstyle/checks/coding/simplifybooleanreturn/Example1.java"/>
           <param name="type" value="config"/>
         </macro>
         <p id="Example1-code">Example:</p>
         <macro name="example">
           <param name="path"
-                 value="resources/com/puppycrawl/tools/checkstyle/checks/coding/simplifybooleanreturn/Example1.txt"/>
+                 value="resources/com/puppycrawl/tools/checkstyle/checks/coding/simplifybooleanreturn/Example1.java"/>
           <param name="type" value="code"/>
         </macro>
       </subsection>


### PR DESCRIPTION
### Title: Enable examples tests for  SimplifyBooleanReturnCheck

**Related Issue: #13345** 

**Summary**
This pull request aims to enable example tests for the ** SimplifyBooleanReturnCheck** in the project. The implementation focuses on ensuring that the SimplifyBooleanReturn checks are correctly validated through comprehensive test cases, improving overall code reliability and quality.

**Key Changes Made**

- Conversion of txt file to Java File
- Enable the test cases by adding expected violations in the expected array for all example tests
- Made corresponding changes in the xml and xml.template file