### PR TITLE
Issue #13345: Enable examples tests for JavadocMissingWhitespaceAfter…

### DIFF
--- a/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocMissingWhitespaceAfterAsteriskCheckExamplesTest.java
+++ b/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocMissingWhitespaceAfterAsteriskCheckExamplesTest.java
@@ -19,12 +19,12 @@
 
 package com.puppycrawl.tools.checkstyle.checks.javadoc;
 
-import org.junit.jupiter.api.Disabled;
+import static com.puppycrawl.tools.checkstyle.checks.javadoc.JavadocMissingWhitespaceAfterAsteriskCheck.MSG_KEY;
+
 import org.junit.jupiter.api.Test;
 
 import com.puppycrawl.tools.checkstyle.AbstractExamplesModuleTestSupport;
 
-@Disabled("until https://github.com/checkstyle/checkstyle/issues/13345")
 public class JavadocMissingWhitespaceAfterAsteriskCheckExamplesTest
         extends AbstractExamplesModuleTestSupport {
     @Override
@@ -36,9 +36,10 @@ public class JavadocMissingWhitespaceAfterAsteriskCheckExamplesTest
     @Test
     public void testExample1() throws Exception {
         final String[] expected = {
-
+            "14:5: " + getCheckMessage(MSG_KEY),
+            "22:6: " + getCheckMessage(MSG_KEY),
         };
 
-        verifyWithInlineConfigParser(getPath("Example1.txt"), expected);
+        verifyWithInlineConfigParser(getPath("Example1.java"), expected);
     }
 }

--- a/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadocmissingwhitespaceafterasterisk/Example1.java
+++ b/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadocmissingwhitespaceafterasterisk/Example1.java
@@ -5,13 +5,14 @@
   </module>
 </module>
 */
+package com.puppycrawl.tools.checkstyle.checks.javadoc.javadocmissingwhitespaceafterasterisk;
 
 // xdoc section -- start
 /** This is valid single-line Javadoc. */
-class TestClass {
+class Example1 {
   /**
    *This is invalid Javadoc.
-   */
+   */ // violation above, 'Missing a whitespace after the leading asterisk'
   int invalidJavaDoc;
   /**
    * This is valid Javadoc.
@@ -19,6 +20,7 @@ class TestClass {
   void validJavaDocMethod() {
   }
   /**This is invalid single-line Javadoc. */
+  // violation above, 'Missing a whitespace after the leading asterisk'
   void invalidSingleLineJavaDocMethod() {
   }
   /** This is valid single-line Javadoc. */

--- a/src/xdocs/checks/javadoc/javadocmissingwhitespaceafterasterisk.xml
+++ b/src/xdocs/checks/javadoc/javadocmissingwhitespaceafterasterisk.xml
@@ -55,10 +55,10 @@
         </p>
         <source>
 /** This is valid single-line Javadoc. */
-class TestClass {
+class Example1 {
   /**
    *This is invalid Javadoc.
-   */
+   */ // violation above, 'Missing a whitespace after the leading asterisk'
   int invalidJavaDoc;
   /**
    * This is valid Javadoc.
@@ -66,6 +66,7 @@ class TestClass {
   void validJavaDocMethod() {
   }
   /**This is invalid single-line Javadoc. */
+  // violation above, 'Missing a whitespace after the leading asterisk'
   void invalidSingleLineJavaDocMethod() {
   }
   /** This is valid single-line Javadoc. */

--- a/src/xdocs/checks/javadoc/javadocmissingwhitespaceafterasterisk.xml.template
+++ b/src/xdocs/checks/javadoc/javadocmissingwhitespaceafterasterisk.xml.template
@@ -32,7 +32,7 @@
         </p>
         <macro name="example">
           <param name="path"
-                 value="resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadocmissingwhitespaceafterasterisk/Example1.txt"/>
+                 value="resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadocmissingwhitespaceafterasterisk/Example1.java"/>
           <param name="type" value="config"/>
         </macro>
         <p id="Example1-code">
@@ -40,7 +40,7 @@
         </p>
         <macro name="example">
           <param name="path"
-                 value="resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadocmissingwhitespaceafterasterisk/Example1.txt"/>
+                 value="resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadocmissingwhitespaceafterasterisk/Example1.java"/>
           <param name="type" value="code"/>
         </macro>
       </subsection>


### PR DESCRIPTION
### Title: Enable examples tests for JavadocMissingWhitespaceAfterAsterikCheck

**Related Issue: #13345** 

**Summary**
This pull request aims to enable example tests for the **JavadocMissingWhitespaceAfterAsterikCheck** in the project. The implementation focuses on ensuring that JavadocMissingWhitespaceAfterAsterik checks are correctly validated through comprehensive test cases, improving overall code reliability and quality.

**Key Changes Made**

- Conversion of txt file to Java File
- Enable the test cases by adding expected violations in the expected array for all example tests
- Made corresponding changes in the xml and xml.template file