### PR TITLE
Issue #6207: Xpath Regresssion test for Superfinalize

### DIFF
--- a/src/it/java/org/checkstyle/suppressionxpathfilter/XpathRegressionSuperFinalizeTest.java
+++ b/src/it/java/org/checkstyle/suppressionxpathfilter/XpathRegressionSuperFinalizeTest.java
@@ -1,0 +1,99 @@
+///////////////////////////////////////////////////////////////////////////////////////////////
+// checkstyle: Checks Java source code and other text files for adherence to a set of rules.
+// Copyright (C) 2001-2024 the original author or authors.
+//
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the GNU Lesser General Public
+// License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+//
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+// Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public
+// License along with this library; if not, write to the Free Software
+// Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+///////////////////////////////////////////////////////////////////////////////////////////////
+
+package org.checkstyle.suppressionxpathfilter;
+
+import java.io.File;
+import java.util.Collections;
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+
+import com.puppycrawl.tools.checkstyle.DefaultConfiguration;
+import com.puppycrawl.tools.checkstyle.checks.coding.AbstractSuperCheck;
+import com.puppycrawl.tools.checkstyle.checks.coding.SuperFinalizeCheck;
+
+public class XpathRegressionSuperFinalizeTest extends AbstractXpathTestSupport {
+
+    private final String checkName = SuperFinalizeCheck.class.getSimpleName();
+
+    @Override
+    protected String getCheckName() {
+        return checkName;
+    }
+
+    @Test
+    public void testDefault() throws Exception {
+        final File fileToProcess = new File(getPath("InputXpathSuperFinalizeNoFinalize.java"));
+        final DefaultConfiguration moduleConfig = createModuleConfig(SuperFinalizeCheck.class);
+
+        final String[] expectedViolation = {
+            "4:17: " + getCheckMessage(SuperFinalizeCheck.class,
+                                        AbstractSuperCheck.MSG_KEY, "finalize"),
+        };
+
+        final List<String> expectedXpathQueries = Collections.singletonList(
+            "/COMPILATION_UNIT/CLASS_DEF"
+                + "[./IDENT[@text='InputXpathSuperFinalizeNoFinalize']]"
+                + "/OBJBLOCK/METHOD_DEF/IDENT[@text='finalize']"
+        );
+        runVerifications(moduleConfig, fileToProcess, expectedViolation, expectedXpathQueries);
+    }
+
+    @Test
+    public void testInnerClass() throws Exception {
+        final File fileToProcess =
+                            new File(getPath("InputXpathSuperFinalizeInnerClass.java"));
+        final DefaultConfiguration moduleConfig = createModuleConfig(SuperFinalizeCheck.class);
+
+        final String[] expectedViolation = {
+            "5:17: " + getCheckMessage(SuperFinalizeCheck.class,
+                                        AbstractSuperCheck.MSG_KEY, "finalize"),
+        };
+
+        final List<String> expectedXpathQueries = Collections.singletonList(
+            "/COMPILATION_UNIT/CLASS_DEF"
+                + "[./IDENT[@text='InputXpathSuperFinalizeInnerClass']]"
+                + "/OBJBLOCK/METHOD_DEF/IDENT[@text='finalize']"
+        );
+        runVerifications(moduleConfig, fileToProcess, expectedViolation, expectedXpathQueries);
+    }
+
+    @Test
+    public void testAnonymousClass() throws Exception {
+        final File fileToProcess =
+                            new File(getPath("InputXpathSuperFinalizeAnonymousClass.java"));
+        final DefaultConfiguration moduleConfig = createModuleConfig(SuperFinalizeCheck.class);
+
+        final String[] expectedViolation = {
+            "9:28: " + getCheckMessage(SuperFinalizeCheck.class,
+                                        AbstractSuperCheck.MSG_KEY, "finalize"),
+        };
+
+        final List<String> expectedXpathQueries = Collections.singletonList(
+            "/COMPILATION_UNIT/CLASS_DEF"
+                + "[./IDENT[@text='InputXpathSuperFinalizeAnonymousClass']]"
+                + "/OBJBLOCK/METHOD_DEF[./IDENT[@text='createAnonymousClass']]"
+                + "/SLIST/VARIABLE_DEF[./IDENT[@text='anonymousClassObject']]"
+                + "/ASSIGN/EXPR/LITERAL_NEW[./IDENT[@text='Object']]"
+                + "/OBJBLOCK/METHOD_DEF/IDENT[@text='finalize']"
+        );
+        runVerifications(moduleConfig, fileToProcess, expectedViolation, expectedXpathQueries);
+    }
+}

--- a/src/it/resources/org/checkstyle/suppressionxpathfilter/superfinalize/InputXpathSuperFinalizeAnonymousClass.java
+++ b/src/it/resources/org/checkstyle/suppressionxpathfilter/superfinalize/InputXpathSuperFinalizeAnonymousClass.java
@@ -1,0 +1,14 @@
+package org.checkstyle.suppressionxpathfilter.superfinalize;
+
+public class InputXpathSuperFinalizeAnonymousClass
+{
+    public void createAnonymousClass()
+    {
+        Object anonymousClassObject = new Object() {
+            @Override
+            protected void finalize() // warn
+            {
+            }
+        };
+    }
+}

--- a/src/it/resources/org/checkstyle/suppressionxpathfilter/superfinalize/InputXpathSuperFinalizeInnerClass.java
+++ b/src/it/resources/org/checkstyle/suppressionxpathfilter/superfinalize/InputXpathSuperFinalizeInnerClass.java
@@ -1,0 +1,15 @@
+package org.checkstyle.suppressionxpathfilter.superfinalize;
+
+class InputXpathSuperFinalizeInnerClass
+{
+    public void finalize() // warn
+    {
+        class InnerClass
+        {
+            public void finalize() throws Throwable
+            {
+                super.finalize();
+            }
+        }
+    }
+}

--- a/src/it/resources/org/checkstyle/suppressionxpathfilter/superfinalize/InputXpathSuperFinalizeNoFinalize.java
+++ b/src/it/resources/org/checkstyle/suppressionxpathfilter/superfinalize/InputXpathSuperFinalizeNoFinalize.java
@@ -1,0 +1,7 @@
+package org.checkstyle.suppressionxpathfilter.superfinalize;
+
+public class InputXpathSuperFinalizeNoFinalize{
+    public void finalize() // warn
+    {
+    }
+}

--- a/src/test/java/com/puppycrawl/tools/checkstyle/internal/XpathRegressionTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/internal/XpathRegressionTest.java
@@ -95,8 +95,7 @@ public class XpathRegressionTest extends AbstractModuleTestSupport {
             "DescendantToken",
             "DesignForExtension",
             "HideUtilityClassConstructor",
-            "RedundantModifier",
-            "SuperFinalize");
+            "RedundantModifier");
 
     // Modules that will never have xpath support ever because they not report violations
     private static final Set<String> NO_VIOLATION_MODULES = Set.of(


### PR DESCRIPTION
### Issue #6207: 

**Xpath Regresssion test for Superfinalize**

### New Test Class and Input Files:

* [`src/it/java/org/checkstyle/suppressionxpathfilter/XpathRegressionSuperFinalizeTest.java`](diffhunk://#diff-5502589ccdf2d7cd1bc12c8ce8b31eb64d9528809bd77e155768c41b1c29d73dR1-R76)
* [`src/it/resources/org/checkstyle/suppressionxpathfilter/superfinalize/InputXpathSuperFinalizeMethodReference.java`](diffhunk://#diff-046c742554230f7c88efe927b402ffa6299f56cc8205ca899cb6e8bb1eaccf64R1-R16)
* [`src/it/resources/org/checkstyle/suppressionxpathfilter/superfinalize/InputXpathSuperFinalizeNoFinalize.java`](diffhunk://#diff-51e8c7c7c44a6adac410f5c33072477603faee7f7a4222e8a4084e31f125b0a8R1-R7)

* Removal of `SuperFinalize` from Regression Test