### PR TITLE
Issue #14019: Kill mutation on SuppressionXpathSingleFilter

### DIFF
--- a/config/pitest-suppressions/pitest-filters-suppressions.xml
+++ b/config/pitest-suppressions/pitest-filters-suppressions.xml
@@ -163,15 +163,6 @@
   </mutation>
 
   <mutation unstable="false">
-    <sourceFile>SuppressionXpathSingleFilter.java</sourceFile>
-    <mutatedClass>com.puppycrawl.tools.checkstyle.filters.SuppressionXpathSingleFilter</mutatedClass>
-    <mutatedMethod>setMessage</mutatedMethod>
-    <mutator>org.pitest.mutationtest.engine.gregor.mutators.experimental.MemberVariableMutator</mutator>
-    <description>Removed assignment to member variable message</description>
-    <lineContent>this.message = null;</lineContent>
-  </mutation>
-
-  <mutation unstable="false">
     <sourceFile>XpathFilterElement.java</sourceFile>
     <mutatedClass>com.puppycrawl.tools.checkstyle.filters.XpathFilterElement</mutatedClass>
     <mutatedMethod>&lt;init&gt;</mutatedMethod>

--- a/src/test/java/com/puppycrawl/tools/checkstyle/filters/SuppressionXpathSingleFilterTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/filters/SuppressionXpathSingleFilterTest.java
@@ -492,6 +492,47 @@ public class SuppressionXpathSingleFilterTest
                 .isTrue();
     }
 
+    /**
+     * This test is required to cover pitest mutation
+     * for reset of 'message' field in SuppressionXpathSingleFilter.
+     * This not possible to reproduce by natural execution of Checkstyle
+     * as config is never changed in runtime.
+     * Projects that use us by api can reproduce this case.
+     * We need to allow users to reset module property to default state.
+     *
+     * @throws Exception when there is problem to load Input file
+     */
+
+    @Test
+    public void testSetMessageHandlesNullCorrectly() throws Exception {
+        final File file = new File(getPath("InputSuppressionXpathSingleFilterComplexQuery.java"));
+
+        final SuppressionXpathSingleFilter filter = new SuppressionXpathSingleFilter();
+        filter.setMessage("MagicNumber");
+        filter.finishLocalSetup();
+
+        final Violation violation = new Violation(27, 21, TokenTypes.NUM_DOUBLE, "",
+                "", null, null, null,
+                MagicNumberCheck.class, "MagicNumber");
+
+        final FileContents fileContents =
+                new FileContents(new FileText(file, StandardCharsets.UTF_8.name()));
+
+        final TreeWalkerAuditEvent ev = new TreeWalkerAuditEvent(fileContents, file.getName(),
+                violation, JavaParser.parseFile(file, JavaParser.Options.WITHOUT_COMMENTS));
+
+        assertWithMessage("match is expected as 'message' is set")
+                .that(filter.accept(ev))
+                .isFalse();
+
+        filter.setMessage(null);
+        filter.finishLocalSetup();
+
+        assertWithMessage("no match is expected as whole filter is defaulted (empty)")
+                .that(filter.accept(ev))
+                .isTrue();
+    }
+
     private static SuppressionXpathSingleFilter createSuppressionXpathSingleFilter(
             String files, String checks, String message, String moduleId, String query) {
         final SuppressionXpathSingleFilter filter = new SuppressionXpathSingleFilter();


### PR DESCRIPTION
For #14019 
Removed suppression
```
  <mutation unstable="false">
    <sourceFile>SuppressionXpathSingleFilter.java</sourceFile>
    <mutatedClass>com.puppycrawl.tools.checkstyle.filters.SuppressionXpathSingleFilter</mutatedClass>
    <mutatedMethod>setMessage</mutatedMethod>
    <mutator>org.pitest.mutationtest.engine.gregor.mutators.experimental.MemberVariableMutator</mutator>
    <description>Removed assignment to member variable message</description>
    <lineContent>this.message = null;</lineContent>
  </mutation>
```
**Steps followed to kill mutation**

-  Removed suppression from` pitest-filters-suppressions.xml`
- Listed pitest profiles with `groovy .ci/pitest-survival-check-xml.groovy --list` using java 11 and groovy 2.4.5
- Picked up `pitest-filters` as active profile
- Generated report locally using `mvn -e --no-transfer-progress -P"$PITEST_PROFILE" clean test-compile org.pitest:pitest-maven:mutationCoverage`
- Screenshots:
![Screenshot (15)](https://github.com/user-attachments/assets/6747930f-bb99-40bf-be4f-a0d015ca0056)
![Screenshot (16)](https://github.com/user-attachments/assets/e16b063a-19ef-4a2b-8159-6c55b39b9382)
- Analyzed report locally with `groovy .ci/pitest-survival-check-xml.groovy "$PITEST_PROFILE"`. 
Response:
```
Source File: "SuppressionXpathSingleFilter.java"
Class: "com.puppycrawl.tools.checkstyle.filters.SuppressionXpathSingleFilter"
Method: "setMessage"
Line Contents: "this.message = null;"
Mutator: "org.pitest.mutationtest.engine.gregor.mutators.experimental.MemberVariableMutator"
Description: "Removed assignment to member variable message"
Line Number: 162
```
- Added new test case
- Generated report again
- Screenshots:
![Screenshot (18)](https://github.com/user-attachments/assets/5d2096c2-0fb9-4998-87f0-031909125144)
![Screenshot (19)](https://github.com/user-attachments/assets/ca938b72-d900-4c9b-868c-ec7865b5a97c)
- Report analysis `No new surviving mutation(s) found.`