### PR TITLE
Pull #15937: avoid reliance on `File.createTempFile` implementation d…

### DIFF
--- a/src/test/java/com/puppycrawl/tools/checkstyle/internal/utils/XdocGenerator.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/internal/utils/XdocGenerator.java
@@ -55,7 +55,8 @@ public final class XdocGenerator {
         for (Path path : templatesFilePaths) {
             final String pathToFile = path.toString();
             final File inputFile = new File(pathToFile);
-            final File tempFile = File.createTempFile(pathToFile.replace(".template", ""), "");
+            final File outputFile = new File(pathToFile.replace(".template", ""));
+            final File tempFile = File.createTempFile(outputFile.getName(), "");
             tempFile.deleteOnExit();
             final XdocsTemplateSinkFactory sinkFactory = (XdocsTemplateSinkFactory)
                     plexus.lookup(SinkFactory.ROLE, XDOCS_TEMPLATE_HINT);
@@ -70,7 +71,6 @@ public final class XdocGenerator {
             finally {
                 sink.close();
             }
-            final File outputFile = new File(pathToFile.replace(".template", ""));
             final StandardCopyOption copyOption = StandardCopyOption.REPLACE_EXISTING;
             Files.copy(tempFile.toPath(), outputFile.toPath(), copyOption);
         }


### PR DESCRIPTION
copy of PR https://github.com/checkstyle/checkstyle/pull/15935

This change follows a debug session in the context of PicnicSupermarket/error-prone-support#1424, where we [learned](https://github.com/PicnicSupermarket/error-prone-support/pull/1424/files#diff-d32ed66e5eac3f2fd2daeca9a4b5d49b1ccc5b0f138e3239859f8e0b69f1bf0c) that [`File.createTempFile`](https://github.com/openjdk/jdk/blob/aa10ec7c96bc50057e07fe2733079a1b3fa13a03/src/java.base/share/classes/java/io/File.java#L2025-L2061) [ignores](https://github.com/openjdk/jdk/blob/aa10ec7c96bc50057e07fe2733079a1b3fa13a03/src/java.base/share/classes/java/io/File.java#L1850-L1851) all characters in the given prefix, up to and including the final file separator.

(This change unblocks application of the [`FilesCreateTempFileToFile`](https://error-prone.picnic.tech/refasterrules/FileRules/#filescreatetempfiletofile) Refaster rule, but that's something to be proposed in a separate pull request, in the larger context of unblocking #15856.)

![image](https://github.com/user-attachments/assets/ca039e29-6820-4156-b7e9-ece1b4d40bc9)

