### PR TITLE
Issue #14220: extra fix for File#createTempFile(java.lang.String,javalang.String)

### DIFF
--- a/config/signatures-test.txt
+++ b/config/signatures-test.txt
@@ -1,5 +1,6 @@
 com.puppycrawl.tools.checkstyle.AbstractModuleTestSupport#verify(com.puppycrawl.tools.checkstyle.api.Configuration, java.lang.String, java.lang.String[]) @ Use inline config parser instead.
 java.nio.file.Files#createTempFile(java.lang.String,java.lang.String,java.nio.file.attribute.FileAttribute[]) @ Use of this method is forbidden, please use @TempDir for better temporary directory control
 java.io.File#createTempFile(java.lang.String,java.lang.String,java.io.File) @ Use of this method is forbidden, please use @TempDir for better temporary directory control
+java.io.File#createTempFile(java.lang.String,java.lang.String) @ Use of this method is forbidden, please use @TempDir for better temporary directory control
 java.nio.file.Files#createTempDirectory(java.lang.String,java.nio.file.attribute.FileAttribute[]) @ Use of this method is forbidden, please use @TempDir for better temporary directory control
 java.nio.file.Files#createTempFile(java.nio.file.Path,java.lang.String,java.lang.String,java.nio.file.attribute.FileAttribute[]) @ Use of this method is forbidden, please use @TempDir for better temporary directory control

--- a/src/test/java/com/puppycrawl/tools/checkstyle/internal/XdocsPagesTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/internal/XdocsPagesTest.java
@@ -58,6 +58,7 @@ import java.util.stream.Stream;
 import org.apache.commons.beanutils.PropertyUtils;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 import org.w3c.dom.Document;
 import org.w3c.dom.Node;
 import org.w3c.dom.NodeList;
@@ -228,6 +229,9 @@ public class XdocsPagesTest {
     private static final Set<String> GOOGLE_MODULES = Collections.unmodifiableSet(
         CheckUtil.getConfigGoogleStyleModules());
 
+    @TempDir
+    private static File temporaryFolder;
+
     /**
      * Generate xdoc content from templates before validation.
      * This method will be removed once
@@ -237,7 +241,7 @@ public class XdocsPagesTest {
      */
     @BeforeAll
     public static void generateXdocContent() throws Exception {
-        XdocGenerator.generateXdocContent();
+        XdocGenerator.generateXdocContent(temporaryFolder);
     }
 
     @Test

--- a/src/test/java/com/puppycrawl/tools/checkstyle/internal/utils/XdocGenerator.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/internal/utils/XdocGenerator.java
@@ -48,7 +48,7 @@ public final class XdocGenerator {
     private XdocGenerator() {
     }
 
-    public static void generateXdocContent() throws Exception {
+    public static void generateXdocContent(File temporaryFolder) throws Exception {
         final PlexusContainer plexus = new DefaultPlexusContainer();
         final Set<Path> templatesFilePaths = XdocUtil.getXdocsTemplatesFilePaths();
 
@@ -56,7 +56,7 @@ public final class XdocGenerator {
             final String pathToFile = path.toString();
             final File inputFile = new File(pathToFile);
             final File outputFile = new File(pathToFile.replace(".template", ""));
-            final File tempFile = File.createTempFile(outputFile.getName(), "");
+            final File tempFile = new File(temporaryFolder, outputFile.getName());
             tempFile.deleteOnExit();
             final XdocsTemplateSinkFactory sinkFactory = (XdocsTemplateSinkFactory)
                     plexus.lookup(SinkFactory.ROLE, XDOCS_TEMPLATE_HINT);


### PR DESCRIPTION
additional fix in scope of Issue #14220

detected at https://github.com/checkstyle/checkstyle/pull/15935#issuecomment-2481334319

example of violation after config change:
```
[INFO] --- forbiddenapis:3.8:testCheck (forbiddenapis-test) @ checkstyle ---
[INFO] Scanning for classes to check...
[INFO] Reading bundled API signatures: jdk-unsafe-11
[INFO] Reading bundled API signatures: jdk-deprecated-11
[INFO] Reading bundled API signatures: jdk-system-out
[INFO] Reading bundled API signatures: jdk-non-portable
[INFO] Reading API signatures: ....../checkstyle/config/signatures-test.txt
[INFO] Loading classes to check...
[INFO] Scanning classes for violations...
[ERROR] Forbidden method invocation: java.io.File#createTempFile(java.lang.String,java.lang.String) 
   [Use of this method is forbidden, please use @TempDir for better temporary directory control]
[ERROR]   in com.puppycrawl.tools.checkstyle.internal.utils.XdocGenerator (XdocGenerator.java:59)
[ERROR] Scanned 3493 class file(s) for forbidden API invocations (in 1.59s), 1 error(s).
```