### PR TITLE
Issue #14019: Kill mutation in SuppressWithNearbyTextFilter

### DIFF
--- a/config/pitest-suppressions/pitest-filters-suppressions.xml
+++ b/config/pitest-suppressions/pitest-filters-suppressions.xml
@@ -109,24 +109,6 @@
   </mutation>
 
   <mutation unstable="false">
-    <sourceFile>SuppressWithNearbyTextFilter.java</sourceFile>
-    <mutatedClass>com.puppycrawl.tools.checkstyle.filters.SuppressWithNearbyTextFilter</mutatedClass>
-    <mutatedMethod>accept</mutatedMethod>
-    <mutator>org.pitest.mutationtest.engine.gregor.mutators.NonVoidMethodCallMutator</mutator>
-    <description>removed call to java/lang/String::equals</description>
-    <lineContent>if (!cachedFileAbsolutePath.equals(eventFileTextAbsolutePath)) {</lineContent>
-  </mutation>
-
-  <mutation unstable="false">
-    <sourceFile>SuppressWithNearbyTextFilter.java</sourceFile>
-    <mutatedClass>com.puppycrawl.tools.checkstyle.filters.SuppressWithNearbyTextFilter</mutatedClass>
-    <mutatedMethod>accept</mutatedMethod>
-    <mutator>org.pitest.mutationtest.engine.gregor.mutators.RemoveConditionalMutator_EQUAL_IF</mutator>
-    <description>removed conditional - replaced equality check with true</description>
-    <lineContent>if (!cachedFileAbsolutePath.equals(eventFileTextAbsolutePath)) {</lineContent>
-  </mutation>
-
-  <mutation unstable="false">
     <sourceFile>SuppressWithPlainTextCommentFilter.java</sourceFile>
     <mutatedClass>com.puppycrawl.tools.checkstyle.filters.SuppressWithPlainTextCommentFilter$Suppression</mutatedClass>
     <mutatedMethod>&lt;init&gt;</mutatedMethod>

--- a/src/test/java/com/puppycrawl/tools/checkstyle/internal/utils/FileRemovalAfterFirstUsageFilter.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/internal/utils/FileRemovalAfterFirstUsageFilter.java
@@ -1,0 +1,43 @@
+///////////////////////////////////////////////////////////////////////////////////////////////
+// checkstyle: Checks Java source code and other text files for adherence to a set of rules.
+// Copyright (C) 2001-2024 the original author or authors.
+//
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the GNU Lesser General Public
+// License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+//
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+// Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public
+// License along with this library; if not, write to the Free Software
+// Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+///////////////////////////////////////////////////////////////////////////////////////////////
+
+package com.puppycrawl.tools.checkstyle.internal.utils;
+
+import java.io.File;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import com.puppycrawl.tools.checkstyle.api.AuditEvent;
+import com.puppycrawl.tools.checkstyle.api.Filter;
+
+public final class FileRemovalAfterFirstUsageFilter implements Filter {
+
+    private final AtomicInteger violationCount = new AtomicInteger(0);
+
+    @Override
+    public boolean accept(AuditEvent event) {
+        final int currentCount = violationCount.incrementAndGet();
+
+        boolean isUsed = true;
+        if (currentCount == 2) {
+            final File file = new File(event.getFileName());
+            isUsed = !file.exists() || file.delete();
+        }
+        return isUsed;
+    }
+}


### PR DESCRIPTION
For #14019 
Removed suppressions:
```
  <mutation unstable="false">
    <sourceFile>SuppressWithNearbyTextFilter.java</sourceFile>
    <mutatedClass>com.puppycrawl.tools.checkstyle.filters.SuppressWithNearbyTextFilter</mutatedClass>
    <mutatedMethod>accept</mutatedMethod>
    <mutator>org.pitest.mutationtest.engine.gregor.mutators.NonVoidMethodCallMutator</mutator>
    <description>removed call to java/lang/String::equals</description>
    <lineContent>if (!cachedFileAbsolutePath.equals(eventFileTextAbsolutePath)) {</lineContent>
  </mutation>

  <mutation unstable="false">
    <sourceFile>SuppressWithNearbyTextFilter.java</sourceFile>
    <mutatedClass>com.puppycrawl.tools.checkstyle.filters.SuppressWithNearbyTextFilter</mutatedClass>
    <mutatedMethod>accept</mutatedMethod>
    <mutator>org.pitest.mutationtest.engine.gregor.mutators.RemoveConditionalMutator_EQUAL_IF</mutator>
    <description>removed conditional - replaced equality check with true</description>
    <lineContent>if (!cachedFileAbsolutePath.equals(eventFileTextAbsolutePath)) {</lineContent>
  </mutation>
```
**Steps followed to kill mutation**

-  Removed suppression from `pitest-filters-suppressions.xml`
- Listed pitest profiles with `groovy .ci/pitest-survival-check-xml.groovy --list` using java 11 and groovy 2.4.5
- Picked up `pitest-filters` as active profile
- Generated report locally using `mvn -e --no-transfer-progress -P"$PITEST_PROFILE" clean test-compile org.pitest:pitest-maven:mutationCoverage`
- Screenshots:
![before-result1](https://github.com/user-attachments/assets/a48f6ec8-7c00-4f1b-a1d1-f07d4cd153bb)

![before-result2](https://github.com/user-attachments/assets/33e8fc65-6a5f-42d7-b5dd-09a112113143)

- Analyzed report locally with `groovy .ci/pitest-survival-check-xml.groovy "$PITEST_PROFILE"`. 
Response:
```
New surviving mutation(s) found:

Source File: "SuppressWithNearbyTextFilter.java"
Class: "com.puppycrawl.tools.checkstyle.filters.SuppressWithNearbyTextFilter"
Method: "accept"
Line Contents: "if (!cachedFileAbsolutePath.equals(eventFileTextAbsolutePath)) {"
Mutator: "org.pitest.mutationtest.engine.gregor.mutators.NonVoidMethodCallMutator"
Description: "removed call to java/lang/String::equals"
Line Number: 198

Source File: "SuppressWithNearbyTextFilter.java"
Class: "com.puppycrawl.tools.checkstyle.filters.SuppressWithNearbyTextFilter"
Method: "accept"
Line Contents: "if (!cachedFileAbsolutePath.equals(eventFileTextAbsolutePath)) {"
Mutator: "org.pitest.mutationtest.engine.gregor.mutators.RemoveConditionalMutator_EQUAL_IF"
Description: "removed conditional - replaced equality check with true"
Line Number: 198
```
- Added new test case
- Generated report again
- Screenshots:

![after-result1](https://github.com/user-attachments/assets/f73d3fbf-5a8b-4173-9678-d73f5c388070)

![after-result2](https://github.com/user-attachments/assets/16f5f5ae-dde8-4c04-a8b3-1f3a874708cc)

- Report analysis `No new surviving mutation(s) found.`
