### PR TITLE
Issue #13494: fixed https://checkstyle.org/checks/ & config_xxxx URLs giving 404 error

### DIFF
--- a/src/site/resources/js/checkstyle.js
+++ b/src/site/resources/js/checkstyle.js
@@ -17,6 +17,38 @@ window.addEventListener("load", function () {
     });
 });
 
+window.addEventListener("load", function () {
+    const currentUrl = window.location.href;
+
+    if (currentUrl.endsWith("/checks/") || currentUrl.endsWith("/checks/index.html")) {
+        window.location.replace("../checks.html");
+    }
+    else if (document.title.startsWith("checkstyle – Redirecting to checks/")) {
+        const urlObj = new URL(currentUrl);
+        const pathSegments = urlObj.pathname.split("/");
+        const configHtmlFile = pathSegments[pathSegments.length - 1];
+        const checkType = /config_([a-z]+).html/.exec(configHtmlFile)[1];
+        const checkName = urlObj.hash.substring(1).toLowerCase();
+
+        if (checkName) {
+            if (checkType !== "filters" && checkType !== "filefilters") {
+                window.location.replace(`./checks/${checkType}/${checkName}.html`);
+            }
+            else {
+                window.location.replace(`./${checkType}/${checkName}.html`);
+            }
+        }
+        else {
+            if (checkType !== "filters" && checkType !== "filefilters") {
+                window.location.replace(`./checks/${checkType}`);
+            }
+            else {
+                window.location.replace(`./${checkType}`);
+            }
+        }
+    }
+});
+
 window.addEventListener("scroll", function () {
     "use strict";
     if (document.documentElement.scrollTop > scrollDistanceToButtonVisibility) {

--- a/src/test/java/com/puppycrawl/tools/checkstyle/internal/XdocsJavaDocsTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/internal/XdocsJavaDocsTest.java
@@ -133,7 +133,8 @@ public class XdocsJavaDocsTest extends AbstractModuleTestSupport {
             final String fileName = file.getName();
 
             if ("config_system_properties.xml".equals(fileName)
-                    || "index.xml".equals(fileName)) {
+                    || "index.xml".equals(fileName)
+                    || Pattern.matches("config_[a-z]+.xml", fileName)) {
                 continue;
             }
 

--- a/src/test/java/com/puppycrawl/tools/checkstyle/internal/XdocsPagesTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/internal/XdocsPagesTest.java
@@ -277,10 +277,15 @@ public class XdocsPagesTest {
                     .replace(".xml", ".html")
                     .replaceAll("\\\\", "/")
                     .replaceAll("src[\\\\/]xdocs[\\\\/]", "");
-            final String expectedLink = String.format(Locale.ROOT, "href=\"%s\"", expectedFile);
-            assertWithMessage("Expected to find link to '" + expectedLink + "' in " + SITE_PATH)
-                    .that(siteContent)
-                    .contains(expectedLink);
+            final boolean isConfigHtmlFile = Pattern.matches("config_[a-z]+.html", expectedFile);
+            final boolean isChecksIndexHtmlFile = "checks/index.html".equals(expectedFile);
+
+            if (!isConfigHtmlFile && !isChecksIndexHtmlFile) {
+                final String expectedLink = String.format(Locale.ROOT, "href=\"%s\"", expectedFile);
+                assertWithMessage("Expected to find link to '" + expectedLink + "' in " + SITE_PATH)
+                        .that(siteContent)
+                        .contains(expectedLink);
+            }
         }
     }
 
@@ -550,7 +555,8 @@ public class XdocsPagesTest {
             final String fileName = path.getFileName().toString();
 
             if ("config_system_properties.xml".equals(fileName)
-                    || "index.xml".equals(fileName)) {
+                    || "index.xml".equals(fileName)
+                    || Pattern.matches("config_[a-z]+.xml", fileName)) {
                 continue;
             }
 

--- a/src/xdocs/checks/index.xml
+++ b/src/xdocs/checks/index.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<document xmlns="http://maven.apache.org/XDOC/2.0"
+          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+          xsi:schemaLocation="http://maven.apache.org/XDOC/2.0 https://maven.apache.org/xsd/xdoc-2.0.xsd">
+
+  <head>
+    <title>Redirecting to checks.html</title>
+  </head>
+
+  <body>
+    <section name="Standard Checks">
+      <p>Standard Checks</p>
+    </section>
+  </body>
+</document>

--- a/src/xdocs/config_annotation.xml
+++ b/src/xdocs/config_annotation.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<document xmlns="http://maven.apache.org/XDOC/2.0"
+          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+          xsi:schemaLocation="http://maven.apache.org/XDOC/2.0 https://maven.apache.org/xsd/xdoc-2.0.xsd">
+
+  <head>
+    <title>Redirecting to checks/annotation.html</title>
+  </head>
+
+  <body>
+    <section name="Annotations Checks">
+      <p>Annotations Checks</p>
+    </section>
+  </body>
+</document>

--- a/src/xdocs/config_blocks.xml
+++ b/src/xdocs/config_blocks.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<document xmlns="http://maven.apache.org/XDOC/2.0"
+          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+          xsi:schemaLocation="http://maven.apache.org/XDOC/2.0 https://maven.apache.org/xsd/xdoc-2.0.xsd">
+
+  <head>
+    <title>Redirecting to checks/blocks.html</title>
+  </head>
+
+  <body>
+    <section name="Block Checks">
+      <p>Block Checks</p>
+    </section>
+  </body>
+</document>

--- a/src/xdocs/config_coding.xml
+++ b/src/xdocs/config_coding.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<document xmlns="http://maven.apache.org/XDOC/2.0"
+          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+          xsi:schemaLocation="http://maven.apache.org/XDOC/2.0 https://maven.apache.org/xsd/xdoc-2.0.xsd">
+
+  <head>
+    <title>Redirecting to checks/coding.html</title>
+  </head>
+
+  <body>
+    <section name="Coding Checks">
+      <p>Coding Checks</p>
+    </section>
+  </body>
+</document>

--- a/src/xdocs/config_design.xml
+++ b/src/xdocs/config_design.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<document xmlns="http://maven.apache.org/XDOC/2.0"
+          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+          xsi:schemaLocation="http://maven.apache.org/XDOC/2.0 https://maven.apache.org/xsd/xdoc-2.0.xsd">
+
+  <head>
+    <title>Redirecting to checks/design.html</title>
+  </head>
+
+  <body>
+    <section name="Design Checks">
+      <p>Design Checks</p>
+    </section>
+  </body>
+</document>

--- a/src/xdocs/config_filefilters.xml
+++ b/src/xdocs/config_filefilters.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<document xmlns="http://maven.apache.org/XDOC/2.0"
+          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+          xsi:schemaLocation="http://maven.apache.org/XDOC/2.0 https://maven.apache.org/xsd/xdoc-2.0.xsd">
+
+  <head>
+    <title>Redirecting to checks/filefilters.html</title>
+  </head>
+
+  <body>
+    <section name="File Filters Checks">
+      <p>File Filters Checks</p>
+    </section>
+  </body>
+</document>

--- a/src/xdocs/config_filters.xml
+++ b/src/xdocs/config_filters.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<document xmlns="http://maven.apache.org/XDOC/2.0"
+          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+          xsi:schemaLocation="http://maven.apache.org/XDOC/2.0 https://maven.apache.org/xsd/xdoc-2.0.xsd">
+
+  <head>
+    <title>Redirecting to checks/filters.html</title>
+  </head>
+
+  <body>
+    <section name="Filters Checks">
+      <p>Filters Checks</p>
+    </section>
+  </body>
+</document>

--- a/src/xdocs/config_headers.xml
+++ b/src/xdocs/config_headers.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<document xmlns="http://maven.apache.org/XDOC/2.0"
+          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+          xsi:schemaLocation="http://maven.apache.org/XDOC/2.0 https://maven.apache.org/xsd/xdoc-2.0.xsd">
+
+  <head>
+    <title>Redirecting to checks/headers.html</title>
+  </head>
+
+  <body>
+    <section name="Headers Checks">
+      <p>Header Checks</p>
+    </section>
+  </body>
+</document>

--- a/src/xdocs/config_imports.xml
+++ b/src/xdocs/config_imports.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<document xmlns="http://maven.apache.org/XDOC/2.0"
+          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+          xsi:schemaLocation="http://maven.apache.org/XDOC/2.0 https://maven.apache.org/xsd/xdoc-2.0.xsd">
+
+  <head>
+    <title>Redirecting to checks/imports.html</title>
+  </head>
+
+  <body>
+    <section name="Imports Checks">
+      <p>Imports Checks</p>
+    </section>
+  </body>
+</document>

--- a/src/xdocs/config_javadoc.xml
+++ b/src/xdocs/config_javadoc.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<document xmlns="http://maven.apache.org/XDOC/2.0"
+          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+          xsi:schemaLocation="http://maven.apache.org/XDOC/2.0 https://maven.apache.org/xsd/xdoc-2.0.xsd">
+
+  <head>
+    <title>Redirecting to checks/javadoc.html</title>
+  </head>
+
+  <body>
+    <section name="Javadoc Comments Checks">
+      <p>Javadoc Comments Checks</p>
+    </section>
+  </body>
+</document>

--- a/src/xdocs/config_metrics.xml
+++ b/src/xdocs/config_metrics.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<document xmlns="http://maven.apache.org/XDOC/2.0"
+          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+          xsi:schemaLocation="http://maven.apache.org/XDOC/2.0 https://maven.apache.org/xsd/xdoc-2.0.xsd">
+
+  <head>
+    <title>Redirecting to checks/metrics.html</title>
+  </head>
+
+  <body>
+    <section name="Metrics Checks">
+      <p>Metrics Checks</p>
+    </section>
+  </body>
+</document>

--- a/src/xdocs/config_misc.xml
+++ b/src/xdocs/config_misc.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<document xmlns="http://maven.apache.org/XDOC/2.0"
+          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+          xsi:schemaLocation="http://maven.apache.org/XDOC/2.0 https://maven.apache.org/xsd/xdoc-2.0.xsd">
+
+  <head>
+    <title>Redirecting to checks/misc.html</title>
+  </head>
+
+  <body>
+    <section name="Miscellaneous Checks">
+      <p>Miscellaneous Checks</p>
+    </section>
+  </body>
+</document>

--- a/src/xdocs/config_modifier.xml
+++ b/src/xdocs/config_modifier.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<document xmlns="http://maven.apache.org/XDOC/2.0"
+          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+          xsi:schemaLocation="http://maven.apache.org/XDOC/2.0 https://maven.apache.org/xsd/xdoc-2.0.xsd">
+
+  <head>
+    <title>Redirecting to checks/modifier.html</title>
+  </head>
+
+  <body>
+    <section name="Modifiers Checks">
+      <p>Modifiers Checks</p>
+    </section>
+  </body>
+</document>

--- a/src/xdocs/config_naming.xml
+++ b/src/xdocs/config_naming.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<document xmlns="http://maven.apache.org/XDOC/2.0"
+          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+          xsi:schemaLocation="http://maven.apache.org/XDOC/2.0 https://maven.apache.org/xsd/xdoc-2.0.xsd">
+
+  <head>
+    <title>Redirecting to checks/naming.html</title>
+  </head>
+
+  <body>
+    <section name="Naming Conventions Checks">
+      <p>Naming Conventions Checks</p>
+    </section>
+  </body>
+</document>

--- a/src/xdocs/config_regexp.xml
+++ b/src/xdocs/config_regexp.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<document xmlns="http://maven.apache.org/XDOC/2.0"
+          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+          xsi:schemaLocation="http://maven.apache.org/XDOC/2.0 https://maven.apache.org/xsd/xdoc-2.0.xsd">
+
+  <head>
+    <title>Redirecting to checks/regexp.html</title>
+  </head>
+
+  <body>
+    <section name="Regexp Checks">
+      <p>Regexp Checks</p>
+    </section>
+  </body>
+</document>

--- a/src/xdocs/config_sizes.xml
+++ b/src/xdocs/config_sizes.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<document xmlns="http://maven.apache.org/XDOC/2.0"
+          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+          xsi:schemaLocation="http://maven.apache.org/XDOC/2.0 https://maven.apache.org/xsd/xdoc-2.0.xsd">
+
+  <head>
+    <title>Redirecting to checks/sizes.html</title>
+  </head>
+
+  <body>
+    <section name="Size Violations Checks">
+      <p>Size Violations Checks</p>
+    </section>
+  </body>
+</document>

--- a/src/xdocs/config_whitespace.xml
+++ b/src/xdocs/config_whitespace.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<document xmlns="http://maven.apache.org/XDOC/2.0"
+          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+          xsi:schemaLocation="http://maven.apache.org/XDOC/2.0 https://maven.apache.org/xsd/xdoc-2.0.xsd">
+
+  <head>
+    <title>Redirecting to checks/whitespace.html</title>
+  </head>
+
+  <body>
+    <section name="Whitespace Checks">
+      <p>Whitespace Checks</p>
+    </section>
+  </body>
+</document>


### PR DESCRIPTION
Fixes: #13494 


added `index.xml` under `.../xdocs/checks` directory, after running `mvn clean site -Pno-validations` locally, I was able to generate `index.html` file under `.../xdocs/checks` directory. Path of that index.html file: `http://localhost:63342/checkstyle/target/site/checks/index.html`

Created `index.xml` instead of `index.html` because `index.html` gets ignored while generating the site using `mvn clean site -Pno-validations` so it does not appears in the final generated html files. Generating html files through xml files also supports `../checks.html` format.
