### PR TITLE
infra: Update google-java-format to 1.25.0

### DIFF
--- a/.github/workflows/google-java-format.yml
+++ b/.github/workflows/google-java-format.yml
@@ -20,17 +20,17 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  VERSION: 1.24.0
+  VERSION: 1.25.0
 
 jobs:
   test:
     if: github.repository == 'checkstyle/checkstyle'
     runs-on: ubuntu-latest
     steps:
-      - name: Set up JDK 11
+      - name: Set up JDK 17
         uses: actions/setup-java@v4
         with:
-          java-version: 11
+          java-version: 17
           distribution: 'temurin'
 
       - name: Checkout Pull Request Code


### PR DESCRIPTION
https://github.com/google/google-java-format/releases/tag/v1.25.0