### PR TITLE
doc: Fix Example3 in MagicNumberCheck Docs

### DIFF
--- a/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/coding/magicnumber/Example3.txt
+++ b/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/coding/magicnumber/Example3.txt
@@ -2,7 +2,7 @@
 <module name="Checker">
   <module name="TreeWalker">
     <module name="MagicNumber">
-        <property name="ignoreFieldDeclaration" value="false"/>
+        <property name="ignoreFieldDeclaration" value="true"/>
     </module>
   </module>
 </module>

--- a/src/xdocs/checks/coding/magicnumber.xml
+++ b/src/xdocs/checks/coding/magicnumber.xml
@@ -211,7 +211,7 @@ class MyClass {
 &lt;module name=&quot;Checker&quot;&gt;
   &lt;module name=&quot;TreeWalker&quot;&gt;
     &lt;module name=&quot;MagicNumber&quot;&gt;
-        &lt;property name=&quot;ignoreFieldDeclaration&quot; value=&quot;false&quot;/&gt;
+        &lt;property name=&quot;ignoreFieldDeclaration&quot; value=&quot;true&quot;/&gt;
     &lt;/module&gt;
   &lt;/module&gt;
 &lt;/module&gt;


### PR DESCRIPTION
detected at https://github.com/checkstyle/checkstyle/issues/15950#issuecomment-2492867453

Old configuration was not correct

```
cat src/Test.java
record MyRecord() {
    private static int myInt = 7; // ok, field declaration

    void foo() {
        int i = myInt + 1; // no violation, 1 is defined as non-magic
        int j = myInt + 8; // violation
    }
}
D:\CS\test
cat config.xml
<?xml version="1.0"?>
<!DOCTYPE module PUBLIC
        "-//Checkstyle//DTD Checkstyle Configuration 1.3//EN"
        "https://checkstyle.org/dtds/configuration_1_3.dtd">

<module name="Checker">
    <module name="TreeWalker">
        <module name="MagicNumber">
            <property name="ignoreFieldDeclaration" value="false"/>
        </module>
        <module name="UnnecessaryParentheses"/>
    </module>
</module>
D:\CS\test
java  -jar checkstyle-10.17.0-all.jar -c config.xml src/Test.java
Starting audit...
[ERROR] D:\CS\test\src\Test.java:2:32: '7' is a magic number. [MagicNumber]
[ERROR] D:\CS\test\src\Test.java:6:25: '8' is a magic number. [MagicNumber]
Audit done.
Checkstyle ends with 2 errors.
```