### PR TITLE
Issue #13345: Enable examples tests for PackageDeclarationCheck

### DIFF
--- a/config/checkstyle-examples-suppressions.xml
+++ b/config/checkstyle-examples-suppressions.xml
@@ -97,6 +97,8 @@
   <!-- Example needs to exclude fully qualified name longer than 85 characters  -->
   <suppress checks="LineLength" files="classdataabstractioncoupling[\\/]Example11.java"/>
 
-
+  <!-- Example must show PackageDeclaration violations -->
+  <suppress checks="PackageDeclaration"
+    files="packagedeclaration[\\/]Example\d+.*"/>
 
 </suppressions>

--- a/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/checks/coding/PackageDeclarationCheckExamplesTest.java
+++ b/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/checks/coding/PackageDeclarationCheckExamplesTest.java
@@ -19,12 +19,13 @@
 
 package com.puppycrawl.tools.checkstyle.checks.coding;
 
-import org.junit.jupiter.api.Disabled;
+import static com.puppycrawl.tools.checkstyle.checks.coding.PackageDeclarationCheck.MSG_KEY_MISSING;
+
 import org.junit.jupiter.api.Test;
 
 import com.puppycrawl.tools.checkstyle.AbstractExamplesModuleTestSupport;
+import com.puppycrawl.tools.checkstyle.utils.CommonUtil;
 
-@Disabled("until https://github.com/checkstyle/checkstyle/issues/13345")
 public class PackageDeclarationCheckExamplesTest extends AbstractExamplesModuleTestSupport {
     @Override
     protected String getPackageLocation() {
@@ -34,18 +35,15 @@ public class PackageDeclarationCheckExamplesTest extends AbstractExamplesModuleT
     @Test
     public void testExample1() throws Exception {
         final String[] expected = {
-
+            "10:1: " + getCheckMessage(MSG_KEY_MISSING),
         };
 
-        verifyWithInlineConfigParser(getPath("Example1.txt"), expected);
+        verifyWithInlineConfigParser(getPath("Example1.java"), expected);
     }
 
     @Test
     public void testExample2() throws Exception {
-        final String[] expected = {
-
-        };
-
-        verifyWithInlineConfigParser(getPath("Example2.txt"), expected);
+        final String[] expected = CommonUtil.EMPTY_STRING_ARRAY;
+        verifyWithInlineConfigParser(getPath("Example2.java"), expected);
     }
 }

--- a/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/coding/packagedeclaration/Example1.java
+++ b/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/coding/packagedeclaration/Example1.java
@@ -7,8 +7,7 @@
 */
 
 // xdoc section -- start
-package com.puppycrawl.tools.checkstyle.checks; //Violation
-public class AnnotationLocationCheck extends AbstractCheck {
-  //...
+public class Example1{ // violation, 'Missing package declaration'
+  String str = "Some Content";
 }
 // xdoc section -- end

--- a/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/coding/packagedeclaration/Example2.java
+++ b/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/coding/packagedeclaration/Example2.java
@@ -8,10 +8,10 @@
 </module>
 */
 
-// xdoc section -- start
-package com.puppycrawl.tools.checkstyle.checks;  //No Violation
 
-public class AnnotationLocationCheck extends AbstractCheck {
-  //...
+// xdoc section -- start
+package com.nonexistent.packages;
+public class Example2{
+  String str = "Some Content";
 }
 // xdoc section -- end

--- a/src/xdocs/checks/coding/packagedeclaration.xml
+++ b/src/xdocs/checks/coding/packagedeclaration.xml
@@ -57,20 +57,14 @@
   &lt;/module&gt;
 &lt;/module&gt;
         </source>
-        <p id="Example1-code">
-          Let us consider the class AnnotationLocationCheck which is in the directory
-          /com/puppycrawl/tools/checkstyle/checks/annotations/
-        </p>
+        <p id="Example1-code">Example1:</p>
         <source>
-package com.puppycrawl.tools.checkstyle.checks; //Violation
-public class AnnotationLocationCheck extends AbstractCheck {
-  //...
+public class Example1{ // violation, 'Missing package declaration'
+  String str = &quot;Some Content&quot;;
 }
         </source>
         <p id="Example2-config">
           Example of how the check works when matchDirectoryStructure option is set to false.
-          Let us again consider the AnnotationLocationCheck class located at directory
-          /com/puppycrawl/tools/checkstyle/checks/annotations/ along with the following setup,
         </p>
         <source>
 &lt;module name=&quot;Checker&quot;&gt;
@@ -81,12 +75,11 @@ public class AnnotationLocationCheck extends AbstractCheck {
   &lt;/module&gt;
 &lt;/module&gt;
         </source>
-        <p id="Example2-code">Example:</p>
+        <p id="Example2-code">Example2:</p>
         <source>
-package com.puppycrawl.tools.checkstyle.checks;  //No Violation
-
-public class AnnotationLocationCheck extends AbstractCheck {
-  //...
+package com.nonexistent.packages;
+public class Example2{
+  String str = &quot;Some Content&quot;;
 }
         </source>
       </subsection>

--- a/src/xdocs/checks/coding/packagedeclaration.xml.template
+++ b/src/xdocs/checks/coding/packagedeclaration.xml.template
@@ -40,32 +40,27 @@
         </p>
         <macro name="example">
           <param name="path"
-                 value="resources/com/puppycrawl/tools/checkstyle/checks/coding/packagedeclaration/Example1.txt"/>
+                 value="resources/com/puppycrawl/tools/checkstyle/checks/coding/packagedeclaration/Example1.java"/>
           <param name="type" value="config"/>
         </macro>
-        <p id="Example1-code">
-          Let us consider the class AnnotationLocationCheck which is in the directory
-          /com/puppycrawl/tools/checkstyle/checks/annotations/
-        </p>
+        <p id="Example1-code">Example1:</p>
         <macro name="example">
           <param name="path"
-                 value="resources/com/puppycrawl/tools/checkstyle/checks/coding/packagedeclaration/Example1.txt"/>
+                 value="resources/com/puppycrawl/tools/checkstyle/checks/coding/packagedeclaration/Example1.java"/>
           <param name="type" value="code"/>
         </macro>
         <p id="Example2-config">
           Example of how the check works when matchDirectoryStructure option is set to false.
-          Let us again consider the AnnotationLocationCheck class located at directory
-          /com/puppycrawl/tools/checkstyle/checks/annotations/ along with the following setup,
         </p>
         <macro name="example">
           <param name="path"
-                 value="resources/com/puppycrawl/tools/checkstyle/checks/coding/packagedeclaration/Example2.txt"/>
+                 value="resources/com/puppycrawl/tools/checkstyle/checks/coding/packagedeclaration/Example2.java"/>
           <param name="type" value="config"/>
         </macro>
-        <p id="Example2-code">Example:</p>
+        <p id="Example2-code">Example2:</p>
         <macro name="example">
           <param name="path"
-                 value="resources/com/puppycrawl/tools/checkstyle/checks/coding/packagedeclaration/Example2.txt"/>
+                 value="resources/com/puppycrawl/tools/checkstyle/checks/coding/packagedeclaration/Example2.java"/>
           <param name="type" value="code"/>
         </macro>
       </subsection>


### PR DESCRIPTION
### Title: Enable examples tests for PackageDeclarationCheck
**Related Issue: #13345** 


**Summary**
This pull request aims to enable example tests for the ** PackageDeclarationCheck** in the project. The implementation focuses on ensuring that  PackageDeclaration checks are correctly validated through comprehensive test cases, improving overall code reliability and quality.

**Key Changes Made**

- Conversion of txt file to Java File
- Enable the test cases by adding expected violations in the expected array for all example tests
- Made corresponding changes in the xml and xml.template file
- Adding suppression in config for PackageDeclaration check