### PR TITLE
Pull #13213: Remove // ok comments from input files

### DIFF
--- a/src/it/resources/com/google/checkstyle/test/chapter2filebasic/rule21filename/InputFileName1.java
+++ b/src/it/resources/com/google/checkstyle/test/chapter2filebasic/rule21filename/InputFileName1.java
@@ -1,7 +1,7 @@
 package com.google.checkstyle.test.chapter2filebasic.rule21filename;
 
 // violation below 'Top-level class MyAnnotation1 has to reside in its own source file.'
-@interface MyAnnotation1 { // ok
+@interface MyAnnotation1 {
   String name();
 
   int version();
@@ -9,7 +9,7 @@ package com.google.checkstyle.test.chapter2filebasic.rule21filename;
 
 /** Some javadoc. */
 @MyAnnotation1(name = "ABC", version = 1)
-public class InputFileName1 {} // ok
+public class InputFileName1 {}
 
 // violation below 'Top-level class Enum1 has to reside in its own source file.'
 enum Enum1 {
@@ -25,7 +25,7 @@ enum Enum1 {
 }
 
 // violation below 'Top-level class TestRequireThisEnum has to reside in its own source file.'
-interface TestRequireThisEnum { // ok
+interface TestRequireThisEnum {
   enum DayOfWeek {
     SUNDAY,
     MONDAY,

--- a/src/it/resources/com/google/checkstyle/test/chapter2filebasic/rule21filename/InputFileName2.java
+++ b/src/it/resources/com/google/checkstyle/test/chapter2filebasic/rule21filename/InputFileName2.java
@@ -1,7 +1,7 @@
 package com.google.checkstyle.test.chapter2filebasic.rule21filename;
 
 /** Test for illegal tokens. */
-public class InputFileName2 { // ok
+public class InputFileName2 {
   /** Some javadoc. */
   public void defaultMethod() {
     int i = 0;

--- a/src/it/resources/com/google/checkstyle/test/chapter2filebasic/rule21filename/InputFileName3.java
+++ b/src/it/resources/com/google/checkstyle/test/chapter2filebasic/rule21filename/InputFileName3.java
@@ -9,10 +9,10 @@ package com.google.checkstyle.test.chapter2filebasic.rule21filename;
 
 // violation below 'Top-level class InputFileName3 has to reside in its own source file.'
 @MyAnnotation2(name = "ABC", version = 1)
-class InputFileName3 {} // ok
+class InputFileName3 {}
 
 // violation below 'Top-level class Enum2 has to reside in its own source file.'
-enum Enum2 { // ok
+enum Enum2 {
   A,
   B,
   C;
@@ -25,7 +25,7 @@ enum Enum2 { // ok
 }
 
 // violation below 'Top-level class TestRequireThisEnum2 has to reside in its own source file.'
-interface TestRequireThisEnum2 { // ok
+interface TestRequireThisEnum2 {
   enum DayOfWeek {
     SUNDAY,
     MONDAY,

--- a/src/it/resources/com/google/checkstyle/test/chapter2filebasic/rule233nonascii/InputNonAsciiCharacters.java
+++ b/src/it/resources/com/google/checkstyle/test/chapter2filebasic/rule233nonascii/InputNonAsciiCharacters.java
@@ -37,7 +37,7 @@ public class InputNonAsciiCharacters {
   public void multiplyString() {
     String unitAbbrev2 = "asd\u03bcsasd";
     // violation above 'Unicode escape(s) usage should be avoided.'
-    String unitAbbrev3 = "aBc\u03bcssdf\u03bc"; /* Greek letter mu, "s"*/ // ok
+    String unitAbbrev3 = "aBc\u03bcssdf\u03bc"; /* Greek letter mu, "s"*/
     String unitAbbrev4 = "\u03bcaBc\u03bcssdf\u03bc";
     // violation above 'Unicode escape(s) usage should be avoided.'
     String allCharactersEscaped = "\u03bc\u03bc";

--- a/src/it/resources/com/google/checkstyle/test/chapter4formatting/rule412nonemptyblocks/InputFormattedNonemptyBlocksLeftRightCurly.java
+++ b/src/it/resources/com/google/checkstyle/test/chapter4formatting/rule412nonemptyblocks/InputFormattedNonemptyBlocksLeftRightCurly.java
@@ -123,23 +123,23 @@ class EnumContainerLeft2 {
     HEARTS,
     SPADES,
     DIAMONDS
-  } // ok
+  }
 }
 
 // violation below 'Top-level class WithArraysLeft2 has to reside in its own source file.'
-class WithArraysLeft2 { // ok
-  String[] s1 = {""}; // ok
-  String[] empty = {}; // ok
-  String[] s2 = { // ok
+class WithArraysLeft2 {
+  String[] s1 = {""};
+  String[] empty = {};
+  String[] s2 = {
     "foo", "foo",
   };
-  String[] s3 = { // ok
+  String[] s3 = {
     "foo", "foo",
   };
-  String[] s4 = { // ok
+  String[] s4 = {
     "foo", "foo",
   };
-  String[] s5 = {"foo", "foo"}; // ok
+  String[] s5 = {"foo", "foo"};
 }
 
 // violation below 'Top-level class InputRightCurlyOther22 has to reside in its own source file.'
@@ -156,51 +156,51 @@ class InputRightCurlyOther22 {
       try {
         if (x > 0) {
           break;
-        } else if (x < 0) { // ok
+        } else if (x < 0) {
 
           ;
         } else {
           break;
-        } // ok
+        }
         switch (a) {
           case 0:
             break;
           default:
             break;
-        } // ok
+        }
       } catch (Exception e) {
         break;
-      } // ok
-    } // ok
+      }
+    }
 
     synchronized (this) {
       do {
         x = 2;
-      } while (x == 2); // ok
-    } // ok
+      } while (x == 2);
+    }
 
     this.wait(666); // Bizarre, but legal
 
     for (int k = 0; k < 1; k++) {
       String innerBlockVariable = "";
-    } // ok
+    }
 
     if (System.currentTimeMillis() > 1000) {
       return 1;
     } else {
       return 2;
     }
-  } // ok
+  }
 
   static {
     int x = 1;
-  } // ok
+  }
 
   /** some javadoc. */
   public enum GreetingsEnum {
     HELLO,
     GOODBYE
-  } // ok
+  }
 
   void method2() {
     boolean flag = true;
@@ -213,8 +213,8 @@ class InputRightCurlyOther22 {
     if (flag) {
       System.identityHashCode("some foo");
     }
-  } // ok
-} // ok
+  }
+}
 
 /**
  * Test input for closing brace if that brace terminates a statement or the body of a constructor.
@@ -244,7 +244,7 @@ class FooInner2 {
   class InnerFoo {
     public void fooInnerMethod() {}
   }
-} // ok
+}
 
 // violation below 'Top-level class EnumContainer2 has to reside in its own source file.'
 class EnumContainer2 {
@@ -253,21 +253,21 @@ class EnumContainer2 {
     HEARTS,
     SPADES,
     DIAMONDS
-  } // ok
+  }
 }
 
 // violation below 'Top-level class WithArrays2 has to reside in its own source file.'
 class WithArrays2 {
-  String[] test = {""}; // ok
-  String[] empty = {}; // ok
+  String[] test = {""};
+  String[] empty = {};
   String[] s1 = {
     "foo", "foo",
-  }; // ok
+  };
   String[] s2 = {
     "foo", "foo",
-  }; // ok
+  };
   String[] s3 = {
     "foo", "foo",
-  }; // ok
-  String[] s4 = {"foo", "foo"}; // ok
+  };
+  String[] s4 = {"foo", "foo"};
 }

--- a/src/it/resources/com/google/checkstyle/test/chapter4formatting/rule412nonemptyblocks/InputFormattedTryCatchIfElse.java
+++ b/src/it/resources/com/google/checkstyle/test/chapter4formatting/rule412nonemptyblocks/InputFormattedTryCatchIfElse.java
@@ -3,7 +3,7 @@ package com.google.checkstyle.test.chapter4formatting.rule412nonemptyblocks;
 /** some javadoc. */
 public class InputFormattedTryCatchIfElse {
 
-  @interface TesterAnnotation {} // ok
+  @interface TesterAnnotation {}
 
   void foo() throws Exception {
     int a = 90;

--- a/src/it/resources/com/google/checkstyle/test/chapter4formatting/rule413emptyblocks/InputEmptyCatchBlockViolationsByComment.java
+++ b/src/it/resources/com/google/checkstyle/test/chapter4formatting/rule413emptyblocks/InputEmptyCatchBlockViolationsByComment.java
@@ -7,7 +7,7 @@ public class InputEmptyCatchBlockViolationsByComment {
   private void foo() {
     try {
       throw new RuntimeException();
-    } catch (Exception expected) { // ok
+    } catch (Exception expected) {
       // Expected
     }
   }
@@ -51,7 +51,7 @@ public class InputEmptyCatchBlockViolationsByComment {
   private void some() {
     try {
       throw new IOException();
-    } catch (IOException e) { // ok
+    } catch (IOException e) {
       /* ololo
        * blalba
        */
@@ -61,7 +61,7 @@ public class InputEmptyCatchBlockViolationsByComment {
   private void some1() {
     try {
       throw new IOException();
-    } catch (IOException e) { // ok
+    } catch (IOException e) {
       /* lalala
        * This is expected
        */
@@ -71,7 +71,7 @@ public class InputEmptyCatchBlockViolationsByComment {
   private void some2() {
     try {
       throw new IOException();
-    } catch (IOException e) { // ok
+    } catch (IOException e) {
       /*
        * This is expected
        * lalala
@@ -82,7 +82,7 @@ public class InputEmptyCatchBlockViolationsByComment {
   private void some3() {
     try {
       throw new IOException();
-    } catch (IOException e) { // ok
+    } catch (IOException e) {
       // some comment
       // This is expected
     }
@@ -91,7 +91,7 @@ public class InputEmptyCatchBlockViolationsByComment {
   private void some4() {
     try {
       throw new IOException();
-    } catch (IOException e) { // ok
+    } catch (IOException e) {
       // This is expected
       // some comment
     }
@@ -100,7 +100,7 @@ public class InputEmptyCatchBlockViolationsByComment {
   private void some5() {
     try {
       throw new IOException();
-    } catch (IOException e) { // ok
+    } catch (IOException e) {
       /* some comment */
       // This is expected
     }

--- a/src/it/resources/com/google/checkstyle/test/chapter4formatting/rule413emptyblocks/InputEmptyCatchBlockViolationsByVariableName.java
+++ b/src/it/resources/com/google/checkstyle/test/chapter4formatting/rule413emptyblocks/InputEmptyCatchBlockViolationsByVariableName.java
@@ -7,7 +7,7 @@ public class InputEmptyCatchBlockViolationsByVariableName {
   private void foo() {
     try {
       throw new RuntimeException();
-    } catch (Exception expected) { // ok
+    } catch (Exception expected) {
 
     }
   }
@@ -22,7 +22,7 @@ public class InputEmptyCatchBlockViolationsByVariableName {
   private void foo2() {
     try {
       throw new IOException();
-    } catch (IOException | NullPointerException | ArithmeticException expected) { // ok
+    } catch (IOException | NullPointerException | ArithmeticException expected) {
     }
   }
 
@@ -36,7 +36,7 @@ public class InputEmptyCatchBlockViolationsByVariableName {
   private void foo4() {
     try {
       throw new IOException();
-    } catch (IOException | NullPointerException | ArithmeticException expected) { // ok
+    } catch (IOException | NullPointerException | ArithmeticException expected) {
     }
   }
 

--- a/src/it/resources/com/google/checkstyle/test/chapter4formatting/rule413emptyblocks/InputEmptyFinallyBlocks.java
+++ b/src/it/resources/com/google/checkstyle/test/chapter4formatting/rule413emptyblocks/InputEmptyFinallyBlocks.java
@@ -17,9 +17,9 @@ class InputEmptyFinallyBlocks {
       }
     } catch (Exception e) {
       /* ignore */
-    } finally { // ok
+    } finally {
       /* ignore */
-    } // ok
+    }
   }
 
   void foo2() {
@@ -45,9 +45,9 @@ class InputEmptyFinallyBlocks {
         }
       } catch (Exception e) {
         /* ignore */
-      } finally { // ok
+      } finally {
         /* ignore */
-      } // ok
+      }
     }
 
     void foo2() {
@@ -75,9 +75,9 @@ class InputEmptyFinallyBlocks {
             }
           } catch (Exception e) {
             /* ignore */
-          } finally { // ok
+          } finally {
             /* ignore */
-          } // ok
+          }
         }
 
         void foo2() {

--- a/src/it/resources/com/google/checkstyle/test/chapter4formatting/rule451wheretobreak/InputFormattedSeparatorWrap.java
+++ b/src/it/resources/com/google/checkstyle/test/chapter4formatting/rule451wheretobreak/InputFormattedSeparatorWrap.java
@@ -6,10 +6,10 @@ public class InputFormattedSeparatorWrap {
   public void goodCase() {
     int i = 0;
     String s = "ffffooooString";
-    s.isEmpty(); // ok
+    s.isEmpty();
     s.isEmpty();
 
-    foo(i, s); // ok
+    foo(i, s);
   }
 
   /** Some javadoc. */

--- a/src/it/resources/com/google/checkstyle/test/chapter4formatting/rule451wheretobreak/InputFormattedSeparatorWrapComma.java
+++ b/src/it/resources/com/google/checkstyle/test/chapter4formatting/rule451wheretobreak/InputFormattedSeparatorWrapComma.java
@@ -6,10 +6,10 @@ public class InputFormattedSeparatorWrapComma {
   public void goodCase() {
     int i = 0;
     String s = "ffffooooString";
-    s.isEmpty(); // ok
+    s.isEmpty();
     s.isEmpty();
 
-    foo(i, s); // ok
+    foo(i, s);
   }
 
   /** Some javadoc. */

--- a/src/it/resources/com/google/checkstyle/test/chapter4formatting/rule451wheretobreak/InputSeparatorWrap.java
+++ b/src/it/resources/com/google/checkstyle/test/chapter4formatting/rule451wheretobreak/InputSeparatorWrap.java
@@ -7,11 +7,11 @@ public class InputSeparatorWrap {
     int i = 0;
     String s = "ffffooooString";
     s
-        .isEmpty(); // ok
+        .isEmpty();
     s.isEmpty();
 
     foo(i,
-            s); // ok
+            s);
   }
 
   /** Some javadoc. */

--- a/src/it/resources/com/google/checkstyle/test/chapter4formatting/rule451wheretobreak/InputSeparatorWrapComma.java
+++ b/src/it/resources/com/google/checkstyle/test/chapter4formatting/rule451wheretobreak/InputSeparatorWrapComma.java
@@ -6,10 +6,10 @@ public class InputSeparatorWrapComma {
   public void goodCase() {
     int i = 0;
     String s = "ffffooooString";
-    s.isEmpty(); // ok
+    s.isEmpty();
     s.isEmpty();
 
-    foo(i, s); // ok
+    foo(i, s);
   }
 
   /** Some javadoc. */

--- a/src/it/resources/com/google/checkstyle/test/chapter4formatting/rule461verticalwhitespace/InputFormattedVerticalWhitespace.java
+++ b/src/it/resources/com/google/checkstyle/test/chapter4formatting/rule461verticalwhitespace/InputFormattedVerticalWhitespace.java
@@ -75,32 +75,32 @@ class InputFormattedVerticalWhitespace {
     }
   }
 
-  class InnerClass2 { // ok
-    private InnerClass2() { // ok
+  class InnerClass2 {
+    private InnerClass2() {
       // empty
     }
   }
 
-  class InnerClass3 { // ok
-    public int compareTo(InputFormattedVerticalWhitespace obj) { // ok
+  class InnerClass3 {
+    public int compareTo(InputFormattedVerticalWhitespace obj) {
       int number = 0;
       return 0;
     }
   }
 
-  class Clazz { // ok
-    private Clazz() {} // ok
+  class Clazz {
+    private Clazz() {}
   }
 
   class Class2 {
-    public int compareTo(InputFormattedVerticalWhitespace obj) { // ok
+    public int compareTo(InputFormattedVerticalWhitespace obj) {
       int number = 0;
       return 0;
     }
 
     Class2 anon =
         new Class2() {
-          public int compareTo(InputFormattedVerticalWhitespace obj) { // ok
+          public int compareTo(InputFormattedVerticalWhitespace obj) {
             int number = 0;
             return 0;
           }

--- a/src/it/resources/com/google/checkstyle/test/chapter4formatting/rule461verticalwhitespace/InputVerticalWhitespace.java
+++ b/src/it/resources/com/google/checkstyle/test/chapter4formatting/rule461verticalwhitespace/InputVerticalWhitespace.java
@@ -70,30 +70,30 @@ class InputVerticalWhitespace { // violation ''CLASS_DEF' should be separated fr
     }
   }
 
-  class InnerClass2 { // ok
-    private InnerClass2() { // ok
+  class InnerClass2 {
+    private InnerClass2() {
       // empty
     }
   }
 
-  class InnerClass3 { // ok
-    public int compareTo(InputVerticalWhitespace obj) { // ok
+  class InnerClass3 {
+    public int compareTo(InputVerticalWhitespace obj) {
       int number = 0;
       return 0;
     }
   }
 
-  class Clazz { // ok
-    private Clazz() {} // ok
+  class Clazz {
+    private Clazz() {}
   }
   class Class2 { // violation ''CLASS_DEF' should be separated from previous line.'
-    public int compareTo(InputVerticalWhitespace obj) { // ok
+    public int compareTo(InputVerticalWhitespace obj) {
       int number = 0;
       return 0;
     }
     Class2 anon = // violation ''VARIABLE_DEF' should be separated from previous line.'
             new Class2() {
-              public int compareTo(InputVerticalWhitespace obj) { // ok
+              public int compareTo(InputVerticalWhitespace obj) {
                 int number = 0;
                 return 0;
               }

--- a/src/it/resources/com/google/checkstyle/test/chapter4formatting/rule462horizontalwhitespace/InputFormattedNoWhitespaceBeforeAnnotations.java
+++ b/src/it/resources/com/google/checkstyle/test/chapter4formatting/rule462horizontalwhitespace/InputFormattedNoWhitespaceBeforeAnnotations.java
@@ -10,25 +10,25 @@ public class InputFormattedNoWhitespaceBeforeAnnotations {
   @interface NonNull {}
 
   @NonNull int @NonNull [] @NonNull [] fiel1; // ok until #8205
-  @NonNull int @NonNull [] @NonNull [] field2; // ok
+  @NonNull int @NonNull [] @NonNull [] field2;
 
   /** some javadoc. */
-  public void foo(final char @NonNull [] param) {} // ok
+  public void foo(final char @NonNull [] param) {}
 
   // @NonNull int @NonNull ... field3; // non-compilable
   // @NonNull int @NonNull... field4; // non-compilable
 
   /** some javadoc. */
-  public void foo1(final char[] param) {} // ok
+  public void foo1(final char[] param) {}
 
   /** some javadoc. */
-  public void foo2(final char[] param) {} // ok
+  public void foo2(final char[] param) {}
 
   /** some javadoc. */
   public void foo3(final char @NonNull [] param) {} // ok until #8205
 
   /** some javadoc. */
-  public void foo4(final char @NonNull [] param) {} // ok
+  public void foo4(final char @NonNull [] param) {}
 
   void test1(String... param) {} // ok until #8205
 
@@ -36,5 +36,5 @@ public class InputFormattedNoWhitespaceBeforeAnnotations {
 
   void test3(String @NonNull ... param) {} // ok until #8205
 
-  void test4(String @NonNull ... param) {} // ok
+  void test4(String @NonNull ... param) {}
 }

--- a/src/it/resources/com/google/checkstyle/test/chapter4formatting/rule4832nocstylearray/InputNoCstyleArrays.java
+++ b/src/it/resources/com/google/checkstyle/test/chapter4formatting/rule4832nocstylearray/InputNoCstyleArrays.java
@@ -6,14 +6,14 @@ public class InputNoCstyleArrays {
   private int cstyle[] = new int[0]; // violation 'Array brackets at illegal position.'
 
   /** some javadoc. */
-  public static void mainJava(String[] javastyle) {} // ok
+  public static void mainJava(String[] javastyle) {}
 
   /** some javadoc. */
   public static void mainC(String cstyle[]) { // violation 'Array brackets at illegal position.'
-    final int[] blah = new int[0]; // ok
-    final boolean isok1 = cstyle instanceof String[]; // ok
-    final boolean isok2 = cstyle instanceof java.lang.String[]; // ok
-    final boolean isok3 = blah instanceof int[]; // ok
+    final int[] blah = new int[0];
+    final boolean isok1 = cstyle instanceof String[];
+    final boolean isok2 = cstyle instanceof java.lang.String[];
+    final boolean isok3 = blah instanceof int[];
     int[] array[] = new int[2][2]; // violation 'Array brackets at illegal position.'
     int array2[][][] = new int[3][3][3];
     // 3 violations above:
@@ -24,13 +24,13 @@ public class InputNoCstyleArrays {
 
   /** some javadoc. */
   public class Test {
-    public Test[] variable; // ok
+    public Test[] variable;
 
     public Test[] getTests() {
       return null;
     }
 
-    public Test[] getNewTest() { // ok
+    public Test[] getNewTest() {
       return null;
     }
 
@@ -49,7 +49,7 @@ public class InputNoCstyleArrays {
       return null;
     }
 
-    public Test[][] getTests2() { // ok
+    public Test[][] getTests2() {
       return null;
     }
   }

--- a/src/it/resources/com/google/checkstyle/test/chapter5naming/rule521packagenames/InputPackageNameGood.java
+++ b/src/it/resources/com/google/checkstyle/test/chapter5naming/rule521packagenames/InputPackageNameGood.java
@@ -1,3 +1,3 @@
-package com.google.checkstyle.test.chapter5naming.rule521packagenames; // ok
+package com.google.checkstyle.test.chapter5naming.rule521packagenames;
 
 final class InputPackageNameGood {}

--- a/src/it/resources/com/google/checkstyle/test/chapter5naming/rule525nonconstantfieldnames/InputNonConstantNamesBasic.java
+++ b/src/it/resources/com/google/checkstyle/test/chapter5naming/rule525nonconstantfieldnames/InputNonConstantNamesBasic.java
@@ -12,10 +12,10 @@ public class InputNonConstantNamesBasic {
   int package_; // violation 'Member name 'package_' must match pattern'
   private int priva$te; // violation 'Member name 'priva\$te' must match pattern'
 
-  public int ppublic; // ok
-  protected int pprotected; // ok
-  int ppackage; // ok
-  private int pprivate; // ok
+  public int ppublic;
+  protected int pprotected;
+  int ppackage;
+  private int pprivate;
 
   int ABC = 0;
   // 2 violations above:

--- a/src/it/resources/com/google/checkstyle/test/chapter6programpractice/rule62donotignoreexceptions/InputEmptyFinallyBlock.java
+++ b/src/it/resources/com/google/checkstyle/test/chapter6programpractice/rule62donotignoreexceptions/InputEmptyFinallyBlock.java
@@ -17,9 +17,9 @@ class InputEmptyFinallyBlock {
       }
     } catch (Exception e) {
       /* ignore */
-    } finally { // ok
+    } finally {
       /* ignore */
-    } // ok
+    }
   }
 
   void foo2() {
@@ -45,9 +45,9 @@ class InputEmptyFinallyBlock {
         }
       } catch (Exception e) {
         /* ignore */
-      } finally { // ok
+      } finally {
         /* ignore */
-      } // ok
+      }
     }
 
     void foo2() {
@@ -75,9 +75,9 @@ class InputEmptyFinallyBlock {
             }
           } catch (Exception e) {
             /* ignore */
-          } finally { // ok
+          } finally {
             /* ignore */
-          } // ok
+          }
         }
 
         void foo2() {


### PR DESCRIPTION
Issue #13213: Removed redundant `// ok` comments from input files

This PR removes unnecessary `// ok` comments from several input files to improve clarity and maintain consistency across test resources. The changes are aimed at reducing noise in the input files while ensuring they still serve their purpose effectively in testing.

Changes made:
1. Removed redundant `// ok` comments across multiple input files.
2. Verified that the updated input files continue to fulfill their role in testing.