### PR TITLE
Issue #14631: Updated LITERAL_LITERAL of JavadocTokenTypes to new AST…

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/api/JavadocTokenTypes.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/api/JavadocTokenTypes.java
@@ -615,12 +615,13 @@ public final class JavadocTokenTypes {
      * <pre><code>{&#64;literal #compare(Object)}</code></pre>
      * <b>Tree:</b>
      * <pre>
-     * <code> |--JAVADOC_INLINE_TAG --&gt; {&#64;literal #compare(Object)}
-     *        |--JAVADOC_INLINE_TAG_START --&gt; {
-     *        |--LITERAL_LITERAL --&gt; @literal
-     *        |--WS[1x9] --&gt;
-     *        |--TEXT[1x10] --&gt; #compare(Object)
-     *        |--JAVADOC_INLINE_TAG_END --&gt;}
+     * <code>
+     *     |--JAVADOC_INLINE_TAG -> JAVADOC_INLINE_TAG [5:27]
+     *        |--JAVADOC_INLINE_TAG_START -> { [5:27]
+     *        |--LITERAL_LITERAL -> @literal [5:28]
+     *        |--WS ->   [5:36]
+     *        |--TEXT -> #compare(Object) [5:37]
+     *        `--JAVADOC_INLINE_TAG_END -> } [5:54]
      * </code>
      * </pre>
      *

--- a/src/main/java/com/puppycrawl/tools/checkstyle/api/JavadocTokenTypes.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/api/JavadocTokenTypes.java
@@ -615,12 +615,12 @@ public final class JavadocTokenTypes {
      * <pre><code>{&#64;literal #compare(Object)}</code></pre>
      * <b>Tree:</b>
      * <pre>
-     * <code> |--JAVADOC_INLINE_TAG[1x0] : [{&#64;literal #compare(Object)}]
-     *        |--JAVADOC_INLINE_TAG_START[1x0] : [{]
-     *        |--LITERAL_LITERAL[1x1] : [@literal]
-     *        |--WS[1x9] : [ ]
-     *        |--TEXT[1x10] : [#compare(Object)]
-     *        |--JAVADOC_INLINE_TAG_END[1x27] : [}]
+     * <code> |--JAVADOC_INLINE_TAG --&gt; {&#64;literal #compare(Object)}
+     *        |--JAVADOC_INLINE_TAG_START --&gt; {
+     *        |--LITERAL_LITERAL --&gt; @literal
+     *        |--WS[1x9] --&gt;
+     *        |--TEXT[1x10] --&gt; #compare(Object)
+     *        |--JAVADOC_INLINE_TAG_END --&gt;}
      * </code>
      * </pre>
      *

--- a/src/main/java/com/puppycrawl/tools/checkstyle/api/JavadocTokenTypes.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/api/JavadocTokenTypes.java
@@ -616,12 +616,12 @@ public final class JavadocTokenTypes {
      * <b>Tree:</b>
      * <pre>
      * <code>
-     *     |--JAVADOC_INLINE_TAG -&gt; JAVADOC_INLINE_TAG [5:27]
-     *        |--JAVADOC_INLINE_TAG_START -&gt; { [5:27]
-     *        |--LITERAL_LITERAL -&gt; @literal [5:28]
-     *        |--WS -&gt;   [5:36]
-     *        |--TEXT -&gt; #compare(Object) [5:37]
-     *        `--JAVADOC_INLINE_TAG_END -&gt; } [5:54]
+     *     |--JAVADOC_INLINE_TAG -&gt; JAVADOC_INLINE_TAG
+     *        |--JAVADOC_INLINE_TAG_START -&gt; {
+     *        |--LITERAL_LITERAL -&gt; @literal
+     *        |--WS -&gt;
+     *        |--TEXT -&gt; #compare(Object)
+     *        `--JAVADOC_INLINE_TAG_END -&gt; }
      * </code>
      * </pre>
      *

--- a/src/main/java/com/puppycrawl/tools/checkstyle/api/JavadocTokenTypes.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/api/JavadocTokenTypes.java
@@ -616,12 +616,12 @@ public final class JavadocTokenTypes {
      * <b>Tree:</b>
      * <pre>
      * <code>
-     *     |--JAVADOC_INLINE_TAG -> JAVADOC_INLINE_TAG [5:27]
-     *        |--JAVADOC_INLINE_TAG_START -> { [5:27]
-     *        |--LITERAL_LITERAL -> @literal [5:28]
-     *        |--WS ->   [5:36]
-     *        |--TEXT -> #compare(Object) [5:37]
-     *        `--JAVADOC_INLINE_TAG_END -> } [5:54]
+     *     |--JAVADOC_INLINE_TAG -&gt; JAVADOC_INLINE_TAG [5:27]
+     *        |--JAVADOC_INLINE_TAG_START -&gt; { [5:27]
+     *        |--LITERAL_LITERAL -&gt; @literal [5:28]
+     *        |--WS -&gt;   [5:36]
+     *        |--TEXT -&gt; #compare(Object) [5:37]
+     *        `--JAVADOC_INLINE_TAG_END -&gt; } [5:54]
      * </code>
      * </pre>
      *


### PR DESCRIPTION
Issue #14631

test:
```
/**
 * Demonstrates the use of {@literal #compare(Object)} inline tag.
 */
public class Test {
    /**
     * Inline tag example: {@literal #compare(Object)}.
     */
    public void example() {

    }
}
```


output:
```
JAVADOC -> JAVADOC [0:0]
|--TEXT -> /** [0:0]
|--NEWLINE -> \r\n [0:3]
|--LEADING_ASTERISK ->  * [1:0]
|--TEXT ->  Demonstrates the use of  [1:2]
|--JAVADOC_INLINE_TAG -> JAVADOC_INLINE_TAG [1:27]
|   |--JAVADOC_INLINE_TAG_START -> { [1:27]
|   |--LITERAL_LITERAL -> @literal [1:28]
|   |--WS ->   [1:36]
|   |--TEXT -> #compare(Object) [1:37]
|   `--JAVADOC_INLINE_TAG_END -> } [1:54]
|--TEXT ->  inline tag. [1:55]
|--NEWLINE -> \r\n [1:67]
|--LEADING_ASTERISK ->  * [2:0]
|--TEXT -> / [2:2]
|--NEWLINE -> \r\n [2:3]
|--TEXT -> public class Test { [3:0]
|--NEWLINE -> \r\n [3:19]
|--TEXT ->     /** [4:0]
|--NEWLINE -> \r\n [4:7]
|--LEADING_ASTERISK ->      * [5:0]
|--TEXT ->  Inline tag example:  [5:6]
|--JAVADOC_INLINE_TAG -> JAVADOC_INLINE_TAG [5:27]
|   |--JAVADOC_INLINE_TAG_START -> { [5:27]
|   |--LITERAL_LITERAL -> @literal [5:28]
|   |--WS ->   [5:36]
|   |--TEXT -> #compare(Object) [5:37]
|   `--JAVADOC_INLINE_TAG_END -> } [5:54]
|--TEXT -> . [5:55]
|--NEWLINE -> \r\n [5:56]
|--LEADING_ASTERISK ->      * [6:0]
|--TEXT -> / [6:6]
|--NEWLINE -> \r\n [6:7]
|--TEXT ->     public void example() { [7:0]
|--NEWLINE -> \r\n [7:27]
|--TEXT ->         // Example method for testing [8:0]
|--NEWLINE -> \r\n [8:37]
|--TEXT ->     } [9:0]
|--NEWLINE -> \r\n [9:5]
|--TEXT -> } [10:0]
|--NEWLINE -> \r\n [10:1]
`--EOF -> <EOF> [11:0]
```