### PR TITLE
Pull #14631: Updated THROWS_LITERAL of JavadocTokenTypes to new AST

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/api/JavadocTokenTypes.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/api/JavadocTokenTypes.java
@@ -308,13 +308,13 @@ public final class JavadocTokenTypes {
      * <pre>{@code @throws SQLException if query is not correct}</pre>
      * <b>Tree:</b>
      * <pre>{@code
-     *   JAVADOC_TAG -> JAVADOC_TAG
-     *    |--THROWS_LITERAL -> @throws
-     *    |--WS ->
-     *    |--CLASS_NAME -> SQLException
-     *    |--WS ->
-     *    `--DESCRIPTION -> DESCRIPTION
-     *        `--TEXT -> if query is not correct
+     *   JAVADOC_TAG -&gt; JAVADOC_TAG
+     *    |--THROWS_LITERAL -&gt; @throws
+     *    |--WS -&gt;
+     *    |--CLASS_NAME -&gt; SQLException
+     *    |--WS -&gt;
+     *    `--DESCRIPTION -&gt; DESCRIPTION
+     *        `--TEXT -&gt; if query is not correct
      * }</pre>
      *
      * @see


### PR DESCRIPTION
Issue #14631 

Test
```
$ cat Test.java 
public class Test {
/**
 * @throws SQLException if query is not correct
*/
  void foo() {}
}

:/var/tmp$ java -jar checkstyle-10.20.2-all.jar -J Test.java
COMPILATION_UNIT -> COMPILATION_UNIT [1:0]
`--CLASS_DEF -> CLASS_DEF [1:0]
    |--MODIFIERS -> MODIFIERS [1:0]
    |   `--LITERAL_PUBLIC -> public [1:0]
    |--LITERAL_CLASS -> class [1:7]
    |--IDENT -> Test [1:13]
    `--OBJBLOCK -> OBJBLOCK [1:18]
        |--LCURLY -> { [1:18]
        |--METHOD_DEF -> METHOD_DEF [5:2]
        |   |--MODIFIERS -> MODIFIERS [5:2]
        |   |--TYPE -> TYPE [5:2]
        |   |   |--BLOCK_COMMENT_BEGIN -> /* [2:0]
        |   |   |   |--COMMENT_CONTENT -> *\n * @throws SQLException if query is not correct\n [2:2]
        |   |   |   |   `--JAVADOC -> JAVADOC [2:3]
        |   |   |   |       |--NEWLINE -> \n [2:3]
        |   |   |   |       |--LEADING_ASTERISK ->  * [3:0]
        |   |   |   |       |--WS ->   [3:2]
        |   |   |   |       |--JAVADOC_TAG -> JAVADOC_TAG [3:3]
        |   |   |   |       |   |--THROWS_LITERAL -> @throws [3:3]
        |   |   |   |       |   |--WS ->   [3:10]
        |   |   |   |       |   |--CLASS_NAME -> SQLException [3:11]
        |   |   |   |       |   |--WS ->   [3:23]
        |   |   |   |       |   `--DESCRIPTION -> DESCRIPTION [3:24]
        |   |   |   |       |       |--TEXT -> if query is not correct [3:24]
        |   |   |   |       |       `--NEWLINE -> \n [3:47]
        |   |   |   |       `--EOF -> <EOF> [4:0]
        |   |   |   `--BLOCK_COMMENT_END -> */ [4:0]
        |   |   `--LITERAL_VOID -> void [5:2]
        |   |--IDENT -> foo [5:7]
        |   |--LPAREN -> ( [5:10]
        |   |--PARAMETERS -> PARAMETERS [5:11]
        |   |--RPAREN -> ) [5:11]
        |   `--SLIST -> { [5:13]
        |       `--RCURLY -> } [5:14]
        `--RCURLY -> } [6:0]

```