### PR TITLE
Removed all // ok comments from input files

### DIFF
--- a/src/it/resources/com/google/checkstyle/test/chapter4formatting/rule4861blockcommentstyle/InputCommentsIndentationCommentIsAtTheEndOfBlock.java
+++ b/src/it/resources/com/google/checkstyle/test/chapter4formatting/rule4861blockcommentstyle/InputCommentsIndentationCommentIsAtTheEndOfBlock.java
@@ -398,7 +398,6 @@ public class InputCommentsIndentationCommentIsAtTheEndOfBlock {
   public void foo49() {
     // comment
     // block
-    // ok
   }
 
   /** some javadoc. */

--- a/src/it/resources/com/google/checkstyle/test/chapter4formatting/rule4861blockcommentstyle/InputFormattedCommentsIndentationCommentIsAtTheEndOfBlock.java
+++ b/src/it/resources/com/google/checkstyle/test/chapter4formatting/rule4861blockcommentstyle/InputFormattedCommentsIndentationCommentIsAtTheEndOfBlock.java
@@ -382,7 +382,6 @@ public class InputFormattedCommentsIndentationCommentIsAtTheEndOfBlock {
   public void foo49() {
     // comment
     // block
-    // ok
   }
 
   /** some javadoc. */

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/indentation/commentsindentation/InputCommentsIndentationCommentsAfterMethodCall.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/indentation/commentsindentation/InputCommentsIndentationCommentsAfterMethodCall.java
@@ -11,14 +11,11 @@ package com.puppycrawl.tools.checkstyle.checks.indentation.commentsindentation;
 public class InputCommentsIndentationCommentsAfterMethodCall {
     public static void main() {
         InputCommentsIndentationCommentsAfterMethodCall.flatMap(4,5)
-           // ok
            .flatMap()
            .flatMap();
-        // ok
     }
     public static void main1() {
         InputCommentsIndentationCommentsAfterMethodCall.flatMap(4,5)
-                // ok
                 .flatMap()
                 .flatMap();
                // violation '.* incorrect .* level 15, expected is 8, .* same .* as line 20.'

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/indentation/commentsindentation/InputCommentsIndentationWithInMethodCallWithSameIndent.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/indentation/commentsindentation/InputCommentsIndentationWithInMethodCallWithSameIndent.java
@@ -13,7 +13,6 @@ public class InputCommentsIndentationWithInMethodCallWithSameIndent {
         // Some comment here
         s1,
         s2
-        // ok
     );
 
     private final boolean isEqualsTwo = equals(

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadocmethod/InputJavadocMethod3.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadocmethod/InputJavadocMethod3.java
@@ -6,7 +6,6 @@ validateThrows = true
 
 package com.puppycrawl.tools.checkstyle.checks.javadoc.javadocmethod;
 
-// ok
 interface Input {
 
     void setHeader(String header);

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/summaryjavadoc/InputSummaryJavadocEmptyPeriod.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/summaryjavadoc/InputSummaryJavadocEmptyPeriod.java
@@ -9,7 +9,6 @@ period =
 
 package com.puppycrawl.tools.checkstyle.checks.javadoc.summaryjavadoc;
 
-// ok
 public class InputSummaryJavadocEmptyPeriod {
 
     /**

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/summaryjavadoc/InputSummaryJavadocTestForbiddenFragments2.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/summaryjavadoc/InputSummaryJavadocTestForbiddenFragments2.java
@@ -8,7 +8,6 @@ period =
 
 package com.puppycrawl.tools.checkstyle.checks.javadoc.summaryjavadoc;
 
-// ok
 public class InputSummaryJavadocTestForbiddenFragments2 {
 
     /**

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/regexp/regexp/InputRegexpCheckB3.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/regexp/regexp/InputRegexpCheckB3.java
@@ -9,7 +9,6 @@ illegalPattern = false
 
 package com.puppycrawl.tools.checkstyle.checks.regexp.regexp;
 
-// ok
 public class InputRegexpCheckB3 {
 }
 

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/regexp/regexp/InputRegexpCheckB4.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/regexp/regexp/InputRegexpCheckB4.java
@@ -10,5 +10,4 @@ illegalPattern = false
 package com.puppycrawl.tools.checkstyle.checks.regexp.regexp;
 
 public class InputRegexpCheckB4 {
-// ok
 }

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/regexp/regexp/InputRegexpCheckEmptyLine2.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/regexp/regexp/InputRegexpCheckEmptyLine2.java
@@ -9,5 +9,4 @@ ignoreComments = true
 package com.puppycrawl.tools.checkstyle.checks.regexp.regexp;
 
 public class InputRegexpCheckEmptyLine2 {
-// ok
 }

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/regexp/regexpsingleline/InputRegexpSinglelineSemantic9.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/regexp/regexpsingleline/InputRegexpSinglelineSemantic9.java
@@ -9,7 +9,6 @@ fileExtensions = (default)all files
 
 package com.puppycrawl.tools.checkstyle.checks.regexp.regexpsingleline;
 
-// ok
 public class InputRegexpSinglelineSemantic9 {
     //
 }

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/regexp/regexpsinglelinejava/InputRegexpSinglelineJavaSemantic8.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/regexp/regexpsinglelinejava/InputRegexpSinglelineJavaSemantic8.java
@@ -8,7 +8,6 @@ message = not expected
 
 package com.puppycrawl.tools.checkstyle.checks.regexp.regexpsinglelinejava;
 
-// ok
 public class InputRegexpSinglelineJavaSemantic8 {
     //
 }

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/whitespace/emptylineseparator/InputEmptyLineSeparatorNoViolationOnEmptyLineBeforeComments.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/whitespace/emptylineseparator/InputEmptyLineSeparatorNoViolationOnEmptyLineBeforeComments.java
@@ -75,7 +75,6 @@ public class InputEmptyLineSeparatorNoViolationOnEmptyLineBeforeComments { // ok
     } // no violation
 
     // Should not have
-    // ok
     public void testNoViolationMethod3() {
 
 
@@ -331,7 +330,6 @@ public class InputEmptyLineSeparatorNoViolationOnEmptyLineBeforeComments { // ok
 
     public
 
-    // ok
     static
 
     enum Enum6 { }
@@ -365,7 +363,6 @@ public class InputEmptyLineSeparatorNoViolationOnEmptyLineBeforeComments { // ok
 
     /* no violation */
 
-    // ok
     {
         int i = 1;
     }
@@ -387,7 +384,6 @@ public class InputEmptyLineSeparatorNoViolationOnEmptyLineBeforeComments { // ok
 
 
         // no
-        // ok
     }
 
     // no violation

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/whitespace/emptylineseparator/InputEmptyLineSeparatorSingleCommentSeparatedFromPackage.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/whitespace/emptylineseparator/InputEmptyLineSeparatorSingleCommentSeparatedFromPackage.java
@@ -12,7 +12,6 @@ tokens = (default)PACKAGE_DEF, IMPORT, STATIC_IMPORT, CLASS_DEF, INTERFACE_DEF, 
 
 package com.puppycrawl.tools.checkstyle.checks.whitespace.emptylineseparator;
 
-// ok
 
 public class InputEmptyLineSeparatorSingleCommentSeparatedFromPackage // ok
 {

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/whitespace/emptylineseparator/InputEmptyLineSeparatorWithComments2.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/whitespace/emptylineseparator/InputEmptyLineSeparatorWithComments2.java
@@ -22,10 +22,8 @@ import java.lang.Object; // ok
 import java.lang.Class; // ok
 
 
-// ok
 import java.lang.Integer;
 
-// ok
 import java.lang.Long;
 
 
@@ -57,13 +55,10 @@ import java.lang.String;
 import java.lang.Object;
 
 
-// ok
 // .
 import java.lang.Boolean;
-// ok
 import java.lang.Byte;
 
-// ok
 /* javadoc */
 import java.lang.Short;
 
@@ -76,10 +71,8 @@ import java.lang.Number;
 import java.lang.Runnable;
 import java.lang.Thread;
 
-// ok
 
 
-// ok
 import java.lang.StringBuilder;
 
 
@@ -180,21 +173,16 @@ public class InputEmptyLineSeparatorWithComments2 {
 
     public static class Class2 { } // ok
 
-    // ok
     public static class Class3 { }
 
 
-    // ok
     public static class Class4 { }
 
 
-    // ok
     public
-    // ok
     static class Class5 { }
 
 
-    // ok
     public
     /* javadoc  */
     static class Class6 { }
@@ -225,17 +213,13 @@ public class InputEmptyLineSeparatorWithComments2 {
      */
     public static class Class10 {
         {
-            // ok
         }
     }
 
-    // ok
     public interface Interface1 { }
 
 
-    // ok
     public interface Interface2 { }
-    // ok
     public // violation ''INTERFACE_DEF' should be separated from previous line.'
     // .
     interface Interface3 { }
@@ -247,57 +231,43 @@ public class InputEmptyLineSeparatorWithComments2 {
     /* . */
     interface Interface4 { }
 
-    // ok
 
-    // ok
     // .
     // .
     // .
     interface Interface5 { }
 
 
-    // ok
     public enum Enum1 {
         E1, E2
     }
 
-    // ok
     public enum Enum2 { }
 
 
-    // ok
-    // ok
 
-    // ok
     public enum Enum3 { }
-    // ok
 
     public enum Enum4 { }
-    // ok
 
     public enum Enum5 { }
 
 
-    // ok
 
     public
 
 
-    // ok
     static
 
     enum Enum6 { }
 
 
-    // ok
     static {
         abs(2);
     }
 
-    // ok
 
 
-    // ok
     {
        abs(1);
     }
@@ -306,41 +276,31 @@ public class InputEmptyLineSeparatorWithComments2 {
     { }
 
 
-    // ok
     {
         int i = 1;
     }
 
 
-    // ok
     // .
     /* . */ public InputEmptyLineSeparatorWithComments2() {
         testNoViolationWithJavadoc = 1;
     }
 
-    // ok
     /* . */ public InputEmptyLineSeparatorWithComments2(int i) {
         testNoViolationWithJavadoc = 1;
     }
 
-    // ok
-    // ok
 
-    // ok
     public InputEmptyLineSeparatorWithComments2(int i, int j) {
         testNoViolationWithJavadoc = 1;
     }
 
 
-    // ok
-    // ok
-
-    // ok
 
 
 
 
-    // ok
+
     public InputEmptyLineSeparatorWithComments2(int i, int j, int k) {
         testNoViolationWithJavadoc = 1;
     }

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/whitespace/whitespaceafter/InputWhitespaceAfterWithEmoji.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/whitespace/whitespaceafter/InputWhitespaceAfterWithEmoji.java
@@ -16,7 +16,6 @@ class InputWhitespaceAfterWithEmoji {
     void foo1() {
 
         int i = 0, count = 0;
-        // ok
         do {
             count += "🎄🧐".charAt(i) == "🤩🎄".charAt(i) ? 1 : 0;
         }

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/utils/checkutil/InputCheckUtil4.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/utils/checkutil/InputCheckUtil4.java
@@ -6,7 +6,6 @@ accessModifiers = public
 
 package com.puppycrawl.tools.checkstyle.utils.checkutil;
 
-// ok
 public interface InputCheckUtil4 {
 
     /**


### PR DESCRIPTION
Issue: #13213

Removed all // ok comments from input files to reduce noise and improve readability. 
Ensured that only necessary comments are left, in accordance with the guidelines.

// ok removed: files -> 
[okremovedfiles.txt](https://github.com/user-attachments/files/18012635/okremovedfiles.txt)
 
