### PR TITLE
Issue #14881: remove null from visitJavaDocToken in SummaryJavadocCheck

### DIFF
--- a/config/checker-framework-suppressions/checker-nullness-optional-interning-suppressions.xml
+++ b/config/checker-framework-suppressions/checker-nullness-optional-interning-suppressions.xml
@@ -4330,28 +4330,6 @@
 
   <checkerFrameworkError unstable="false">
     <fileName>src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/SummaryJavadocCheck.java</fileName>
-    <specifier>argument</specifier>
-    <message>incompatible argument for parameter javadocInlineTag of SummaryJavadocCheck.isInlineReturnTag.</message>
-    <lineContent>else if (inlineTag.isPresent() &amp;&amp; isInlineReturnTag(inlineTagNode)) {</lineContent>
-    <details>
-      found   : @Initialized @Nullable DetailNode
-      required: @Initialized @NonNull DetailNode
-    </details>
-  </checkerFrameworkError>
-
-  <checkerFrameworkError unstable="false">
-    <fileName>src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/SummaryJavadocCheck.java</fileName>
-    <specifier>argument</specifier>
-    <message>incompatible argument for parameter javadocInlineTag of SummaryJavadocCheck.isSummaryTag.</message>
-    <lineContent>&amp;&amp; isSummaryTag(inlineTagNode)</lineContent>
-    <details>
-      found   : @Initialized @Nullable DetailNode
-      required: @Initialized @NonNull DetailNode
-    </details>
-  </checkerFrameworkError>
-
-  <checkerFrameworkError unstable="false">
-    <fileName>src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/SummaryJavadocCheck.java</fileName>
     <specifier>return</specifier>
     <message>incompatible types in return.</message>
     <lineContent>return result;</lineContent>

--- a/pom.xml
+++ b/pom.xml
@@ -734,6 +734,10 @@
         <configuration>
           <javaVersion>${java.version}</javaVersion>
           <includeTestClasses>false</includeTestClasses>
+          <exclusionPatterns>
+            <!-- until https://github.com/gaul/modernizer-maven-plugin/issues/300 -->
+            <exclusionPattern>java/util/Optional.get:.*</exclusionPattern>
+          </exclusionPatterns>
         </configuration>
         <executions>
           <execution>

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/SummaryJavadocCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/SummaryJavadocCheck.java
@@ -210,17 +210,20 @@ public class SummaryJavadocCheck extends AbstractJavadocCheck {
 
     @Override
     public void visitJavadocToken(DetailNode ast) {
-        final Optional<DetailNode> inlineTag = getInlineTagNode(ast);
-        final DetailNode inlineTagNode = inlineTag.orElse(null);
-        if (inlineTag.isPresent()
-            && isSummaryTag(inlineTagNode)
-            && isDefinedFirst(inlineTagNode)) {
-            validateSummaryTag(inlineTagNode);
+        final Optional<DetailNode> inlineTagNode = getInlineTagNode(ast);
+        boolean shouldValidateUntaggedSummary = true;
+        if (inlineTagNode.isPresent()) {
+            final DetailNode node = inlineTagNode.get();
+            if (isSummaryTag(node) && isDefinedFirst(node)) {
+                shouldValidateUntaggedSummary = false;
+                validateSummaryTag(node);
+            }
+            else if (isInlineReturnTag(node)) {
+                shouldValidateUntaggedSummary = false;
+                validateInlineReturnTag(node);
+            }
         }
-        else if (inlineTag.isPresent() && isInlineReturnTag(inlineTagNode)) {
-            validateInlineReturnTag(inlineTagNode);
-        }
-        else if (!startsWithInheritDoc(ast)) {
+        if (shouldValidateUntaggedSummary && !startsWithInheritDoc(ast)) {
             validateUntaggedSummary(ast);
         }
     }


### PR DESCRIPTION
part of #14881 : remove null usage from `visitJavaDocToken`