### PR TITLE
Issue #14881: remove null from ValidateUntaggedSummary in SummaryJavadocCheck

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/SummaryJavadocCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/SummaryJavadocCheck.java
@@ -27,8 +27,6 @@ import java.util.Optional;
 import java.util.regex.Pattern;
 import java.util.stream.Stream;
 
-import javax.annotation.Nullable;
-
 import com.puppycrawl.tools.checkstyle.StatelessCheck;
 import com.puppycrawl.tools.checkstyle.api.DetailNode;
 import com.puppycrawl.tools.checkstyle.api.JavadocTokenTypes;
@@ -240,12 +238,15 @@ public class SummaryJavadocCheck extends AbstractJavadocCheck {
         }
         else if (!period.isEmpty()) {
             if (summaryDoc.contains(period)) {
-                final String firstSentence = getFirstSentenceOrNull(ast, period);
-                if (firstSentence == null) {
-                    log(ast.getLineNumber(), MSG_SUMMARY_FIRST_SENTENCE);
+                final Optional<String> firstSentence = getFirstSentence(ast, period);
+
+                if (firstSentence.isPresent()) {
+                    if (containsForbiddenFragment(firstSentence.get())) {
+                        log(ast.getLineNumber(), MSG_SUMMARY_JAVADOC);
+                    }
                 }
-                else if (containsForbiddenFragment(firstSentence)) {
-                    log(ast.getLineNumber(), MSG_SUMMARY_JAVADOC);
+                else {
+                    log(ast.getLineNumber(), MSG_SUMMARY_FIRST_SENTENCE);
                 }
             }
             else {
@@ -600,28 +601,30 @@ public class SummaryJavadocCheck extends AbstractJavadocCheck {
     }
 
     /**
-     * Finds and returns the first sentence.
+     * Finds the first sentence.
      *
      * @param ast The Javadoc root node.
      * @param period The configured period symbol.
-     * @return The first sentence up to and excluding the period, or null if no ending was found.
+     * @return An Optional containing the first sentence
+     *     up to and excluding the period, or an empty
+     *     Optional if no ending was found.
      */
-    @Nullable
-    private static String getFirstSentenceOrNull(DetailNode ast, String period) {
+    private static Optional<String> getFirstSentence(DetailNode ast, String period) {
         final List<String> sentenceParts = new ArrayList<>();
-        String sentence = null;
+        Optional<String> result = Optional.empty();
         for (String text : (Iterable<String>) streamTextParts(ast)::iterator) {
-            final String sentenceEnding = findSentenceEndingOrNull(text, period);
-            if (sentenceEnding != null) {
-                sentenceParts.add(sentenceEnding);
-                sentence = String.join("", sentenceParts);
+            final Optional<String> sentenceEnding = findSentenceEnding(text, period);
+
+            if (sentenceEnding.isPresent()) {
+                sentenceParts.add(sentenceEnding.get());
+                result = Optional.of(String.join("", sentenceParts));
                 break;
             }
             else {
                 sentenceParts.add(text);
             }
         }
-        return sentence;
+        return result;
     }
 
     /**
@@ -643,18 +646,17 @@ public class SummaryJavadocCheck extends AbstractJavadocCheck {
     }
 
     /**
-     * Finds the end of a sentence. If a sentence ending period was found, returns the whole string
-     * up to and excluding that period. The end of sentence detection here could be replaced in the
+     * Finds the end of a sentence. The end of sentence detection here could be replaced in the
      * future by Java's built-in BreakIterator class.
      *
      * @param text The string to search.
      * @param period The period character to find.
-     * @return The string up to and excluding the period, or null if no ending was found.
+     * @return An Optional containing the string up to and excluding the period,
+     *     or empty Optional if no ending was found.
      */
-    @Nullable
-    private static String findSentenceEndingOrNull(String text, String period) {
+    private static Optional<String> findSentenceEnding(String text, String period) {
         int periodIndex = text.indexOf(period);
-        String sentenceEnding = null;
+        Optional<String> result = Optional.empty();
         while (periodIndex >= 0) {
             final int afterPeriodIndex = periodIndex + period.length();
 
@@ -663,13 +665,14 @@ public class SummaryJavadocCheck extends AbstractJavadocCheck {
             if (!DEFAULT_PERIOD.equals(period)
                 || afterPeriodIndex >= text.length()
                 || Character.isWhitespace(text.charAt(afterPeriodIndex))) {
-                sentenceEnding = text.substring(0, periodIndex);
+                final String resultStr = text.substring(0, periodIndex);
+                result = Optional.of(resultStr);
                 break;
             }
             else {
                 periodIndex = text.indexOf(period, afterPeriodIndex);
             }
         }
-        return sentenceEnding;
+        return result;
     }
 }


### PR DESCRIPTION
part of #14881 : remove null usage from methods : `untaggedSummary`, `findSentenceEndingOrNull` , `getFirstSentenceOrNull`
 