### PR TITLE
Issue #15955:  run-checkstyle.yml use filename for download

### DIFF
--- a/.github/workflows/run-checkstyle.yml
+++ b/.github/workflows/run-checkstyle.yml
@@ -37,6 +37,7 @@ jobs:
         with:
           repository: 'checkstyle/checkstyle'
           latest: true
+          fileName: 'checkstyle-*.*.*-all.jar'
 
       - name: Download config
         run: |
@@ -54,6 +55,7 @@ jobs:
 
       - name: Run checkstyle
         run: |
+            pwd
             ls -la
             JAR_NAME=$(find . -name "*-all.jar")
             java -jar "$JAR_NAME" -c config.xml Test.java


### PR DESCRIPTION
#15955

Jar is not downloading without it.

https://github.com/checkstyle/checkstyle/actions/runs/12283085850/job/34275752229#step:6:11

```
un ls -la
  ls -la
  JAR_NAME=$(find . -name "*-all.jar")
  java -jar "$JAR_NAME" -c config.xml Test.java
  shell: /usr/bin/bash -e {0}
  env:
    JAVA_HOME: /opt/hostedtoolcache/Java_Temurin-Hotspot_jdk/17.0.13-11/x64
    JAVA_HOME_17_X64: /opt/hostedtoolcache/Java_Temurin-Hotspot_jdk/17.0.13-11/x64
total 16
drwxr-xr-x [2](https://github.com/checkstyle/checkstyle/actions/runs/12283085850/job/34275752229#step:6:2) runner docker 4096 Dec 11 19:14 .
drwxr-xr-x [3](https://github.com/checkstyle/checkstyle/actions/runs/12283085850/job/34275752229#step:6:3) runner docker 4096 Dec 11 19:14 ..
-rw-r--r-- 1 runner docker 1320 Dec 11 19:1[4](https://github.com/checkstyle/checkstyle/actions/runs/12283085850/job/34275752229#step:6:4) Test.java
-rw-r--r-- 1 runner docker 1340 Dec 11 19:14 config.xml
Error: Unable to access jarfile 
Error: Process completed with exit code 1.
```