### PR TITLE
Issue #13999: kill mutation for JavadocMethodCheck

### DIFF
--- a/config/pitest-suppressions/pitest-javadoc-suppressions.xml
+++ b/config/pitest-suppressions/pitest-javadoc-suppressions.xml
@@ -56,15 +56,6 @@
 
   <mutation unstable="false">
     <sourceFile>JavadocMethodCheck.java</sourceFile>
-    <mutatedClass>com.puppycrawl.tools.checkstyle.checks.javadoc.JavadocMethodCheck</mutatedClass>
-    <mutatedMethod>shouldCheck</mutatedMethod>
-    <mutator>org.pitest.mutationtest.engine.gregor.mutators.RemoveConditionalMutator_EQUAL_IF</mutator>
-    <description>removed conditional - replaced equality check with true</description>
-    <lineContent>return surroundingAccessModifier != null</lineContent>
-  </mutation>
-
-  <mutation unstable="false">
-    <sourceFile>JavadocMethodCheck.java</sourceFile>
     <mutatedClass>com.puppycrawl.tools.checkstyle.checks.javadoc.JavadocMethodCheck$Token</mutatedClass>
     <mutatedMethod>&lt;init&gt;</mutatedMethod>
     <mutator>org.pitest.mutationtest.engine.gregor.mutators.NonVoidMethodCallMutator</mutator>

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocMethodCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocMethodCheck.java
@@ -399,8 +399,7 @@ public class JavadocMethodCheck extends AbstractCheck {
                 .getSurroundingAccessModifier(ast);
         final AccessModifierOption accessModifier = CheckUtil
                 .getAccessModifierFromModifiersToken(ast);
-        return surroundingAccessModifier != null
-                && Arrays.stream(accessModifiers)
+        return Arrays.stream(accessModifiers)
                         .anyMatch(modifier -> modifier == surroundingAccessModifier)
                 && Arrays.stream(accessModifiers).anyMatch(modifier -> modifier == accessModifier);
     }


### PR DESCRIPTION
part of #13999:

mutation in question:
https://github.com/checkstyle/checkstyle/blob/24eedce6a64145442db5b478c7a39ce0763dad8c/config/pitest-suppressions/pitest-javadoc-suppressions.xml#L57-L64

**Rationale:**
`surroundingAccessModifier ` is one of the deciding factor if  we want to process the method/construction or not. the case `surroundingAccessModifier == null` is when we come on a overriden method. For example : 
```
final Runnable r = new Runnable() {
    public void run() {};
};
```
this condition might have been placed there because: 
 - it's better not to send surroundingAccessModifier down in camparsions because with null there is always risk of NullPointerException error. 
 - this simple checking saves us making unnecessary camparisons.

**Removal is OK**  because surroundingAccessModifier is something we are only camparing with each modifier object. we are not calling a method call on surroundingAccessModifier.
in short `==` there is no risk of running into NullPointerException error here. 