### PR TITLE
Issue #14881: use empty string when sentence ending not found

### DIFF
--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/javadoc/SummaryJavadocCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/javadoc/SummaryJavadocCheckTest.java
@@ -318,6 +318,16 @@ public class SummaryJavadocCheckTest extends AbstractModuleTestSupport {
     }
 
     @Test
+    public void testForbidden4() throws Exception {
+        final String[] expected = {
+            "15: " + getCheckMessage(MSG_SUMMARY_JAVADOC),
+        };
+
+        verifyWithInlineConfigParser(
+                getPath("InputSummaryJavadocTestForbiddenFragments4.java"), expected);
+    }
+
+    @Test
     public void testForbidden2() throws Exception {
         final String[] expected = CommonUtil.EMPTY_STRING_ARRAY;
 

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/summaryjavadoc/InputSummaryJavadocTestForbiddenFragments4.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/summaryjavadoc/InputSummaryJavadocTestForbiddenFragments4.java
@@ -1,0 +1,20 @@
+/*
+SummaryJavadoc
+violateExecutionOnNonTightHtml = (default)false
+forbiddenSummaryFragments = (default)^$
+period = (default).
+
+*/
+
+
+package com.puppycrawl.tools.checkstyle.checks.javadoc.summaryjavadoc;
+
+public class InputSummaryJavadocTestForbiddenFragments4 {
+
+    // violation below 'Forbidden summary fragment.'
+    /**.
+     * Return the specified member summary writer.
+     *
+     */
+    void foo1() {}
+}


### PR DESCRIPTION
Part of #14881 

This PR is an experiment to avoid using Optional introduced in https://github.com/checkstyle/checkstyle/pull/16020, and represent sentence ending with empty string to keep code simpler.