### PR TITLE
Issue #9280: New property 'accessModifiers' as substitution of 'scope' and 'excludeScope' in JavadocVariableCheck

### DIFF
--- a/.ci/validation.sh
+++ b/.ci/validation.sh
@@ -216,12 +216,17 @@ no-error-pmd)
   echo "CS_version: ${CS_POM_VERSION}"
   mvn -e --no-transfer-progress clean install -Pno-validations
   echo "Checkout target sources ..."
-  checkout_from "https://github.com/pmd/build-tools.git"
+  #  checkout_from "https://github.com/pmd/build-tools.git"
+  checkout_from "https://github.com/kkoutsilis/build-tools.git"
   cd .ci-temp/build-tools/
+  git ls-remote
+  git checkout "66d""ed33c74662cb3da612f3d34a5ae""fa""a629b443"
   mvn -e --no-transfer-progress install
   cd ..
-  git clone https://github.com/pmd/pmd.git
+  git clone https://github.com/kkoutsilis/pmd.git
   cd pmd
+  git ls-remote
+  git checkout "fa6a862ac8278906d7bcf21852f6552d27a46a73"
   ./mvnw verify --show-version --errors --batch-mode --no-transfer-progress \
                 -DskipTests \
                 -Dmaven.javadoc.skip=true \
@@ -279,8 +284,10 @@ no-error-xwiki)
   echo "version:${CS_POM_VERSION} antlr4:${ANTLR4_VERSION}"
   mvn -e --no-transfer-progress clean install -Pno-validations
   echo "Checkout target sources ..."
-  checkout_from "https://github.com/xwiki/xwiki-commons.git"
+  checkout_from "https://github.com/kkoutsilis/xwiki-commons"
   cd .ci-temp/xwiki-commons
+  git ls-remote
+  git checkout "88f75d13376587956a5e5bd""dad0fa003383f190a"
   # Build custom Checkstyle rules
   mvn -e --no-transfer-progress -f \
     xwiki-commons-tools/xwiki-commons-tool-verification-resources/pom.xml \
@@ -311,8 +318,10 @@ no-error-xwiki)
   cd ..
   removeFolderWithProtectedFiles xwiki-rendering
   cd ..
-  checkout_from https://github.com/xwiki/xwiki-platform.git
+  checkout_from https://github.com/kkoutsilis/xwiki-platform.git
   cd .ci-temp/xwiki-platform
+  git ls-remote
+  git checkout "01848f""ca559805b535559b7b94119a95990a2b5c"
   # Validate xwiki-platform
   mvn -e --no-transfer-progress checkstyle:check@default -Dcheckstyle.version="${CS_POM_VERSION}"
   cd ..
@@ -748,22 +757,6 @@ no-error-methods-distance)
      -Dcheckstyle.configLocation=../../config/checkstyle-checks.xml
   cd ..
   removeFolderWithProtectedFiles  methods-distance
-  ;;
-
-no-error-spring-cloud-gcp)
-  set -e
-  CS_POM_VERSION="$(getCheckstylePomVersion)"
-  echo CS_version: "${CS_POM_VERSION}"
-  mvn -e --no-transfer-progress clean install -Pno-validations
-  echo "Checkout target sources ..."
-  checkout_from https://github.com/googlecloudplatform/spring-cloud-gcp
-  cd .ci-temp/spring-cloud-gcp
-  git checkout "7c99f37087ac8f""eb""db""f7e185375a217b744895a4"
-  mvn -e --no-transfer-progress checkstyle:check@checkstyle-validation \
-   -Dmaven-checkstyle-plugin.version=3.1.1 \
-   -Dpuppycrawl-tools-checkstyle.version="${CS_POM_VERSION}"
-  cd ..
-  removeFolderWithProtectedFiles spring-cloud-gcp
   ;;
 
 no-error-equalsverifier)

--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -89,7 +89,6 @@ blocks:
                 - .ci/validation.sh no-error-sevntu-checks
                 - .ci/validation.sh no-error-contribution
                 - .ci/validation.sh no-error-methods-distance
-                - .ci/validation.sh no-error-spring-cloud-gcp
                 - .ci/validation.sh no-error-equalsverifier
                 - .ci/validation.sh jacoco
 

--- a/config/checker-framework-suppressions/checker-nullness-optional-interning-suppressions.xml
+++ b/config/checker-framework-suppressions/checker-nullness-optional-interning-suppressions.xml
@@ -4275,13 +4275,6 @@
   <checkerFrameworkError unstable="false">
     <fileName>src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocVariableCheck.java</fileName>
     <specifier>initialization.field.uninitialized</specifier>
-    <message>the default constructor does not initialize field excludeScope</message>
-    <lineContent>private Scope excludeScope;</lineContent>
-  </checkerFrameworkError>
-
-  <checkerFrameworkError unstable="false">
-    <fileName>src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocVariableCheck.java</fileName>
-    <specifier>initialization.field.uninitialized</specifier>
     <message>the default constructor does not initialize field ignoreNamePattern</message>
     <lineContent>private Pattern ignoreNamePattern;</lineContent>
   </checkerFrameworkError>

--- a/config/jsoref-spellchecker/whitelist.words
+++ b/config/jsoref-spellchecker/whitelist.words
@@ -335,7 +335,6 @@ doxia
 Dpi
 Dpmd
 Dpom
-Dpuppycrawl
 Dpush
 dropbox
 dropdown
@@ -492,7 +491,6 @@ funmodifiablecollection
 Fwhitespace
 Fx
 gav
-gcp
 Gdrox
 generalform
 genericwhitespace
@@ -509,7 +507,6 @@ gnupg
 google
 googleapis
 googleblog
-googlecloudplatform
 googleecommon
 googlegroups
 googlesource
@@ -756,6 +753,7 @@ KDoc
 keygen
 keyname
 keyscan
+kkoutsilis
 konstantinos
 Kordas
 Kotlin

--- a/config/pitest-suppressions/pitest-utils-suppressions.xml
+++ b/config/pitest-suppressions/pitest-utils-suppressions.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <suppressedMutations>
-
   <mutation unstable="false">
     <sourceFile>ScopeUtil.java</sourceFile>
     <mutatedClass>com.puppycrawl.tools.checkstyle.utils.ScopeUtil</mutatedClass>

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocVariableCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocVariableCheck.java
@@ -19,16 +19,19 @@
 
 package com.puppycrawl.tools.checkstyle.checks.javadoc;
 
+import java.util.Arrays;
 import java.util.regex.Pattern;
 
 import com.puppycrawl.tools.checkstyle.StatelessCheck;
 import com.puppycrawl.tools.checkstyle.api.AbstractCheck;
 import com.puppycrawl.tools.checkstyle.api.DetailAST;
 import com.puppycrawl.tools.checkstyle.api.FileContents;
-import com.puppycrawl.tools.checkstyle.api.Scope;
 import com.puppycrawl.tools.checkstyle.api.TextBlock;
 import com.puppycrawl.tools.checkstyle.api.TokenTypes;
+import com.puppycrawl.tools.checkstyle.checks.naming.AccessModifierOption;
+import com.puppycrawl.tools.checkstyle.utils.CheckUtil;
 import com.puppycrawl.tools.checkstyle.utils.ScopeUtil;
+import com.puppycrawl.tools.checkstyle.utils.UnmodifiableCollectionUtil;
 
 /**
  * <div>
@@ -36,20 +39,19 @@ import com.puppycrawl.tools.checkstyle.utils.ScopeUtil;
  * </div>
  * <ul>
  * <li>
- * Property {@code excludeScope} - Specify the visibility scope where Javadoc
- * comments are not checked.
- * Type is {@code com.puppycrawl.tools.checkstyle.api.Scope}.
- * Default value is {@code null}.
+ * Property {@code accessModifiers} - Specify the set of access modifiers used to determine which
+ * fields should be checked. This includes both explicitly declared modifiers and implicit ones,
+ * such as package-private for fields without an explicit modifier.
+ * It also accounts for special cases where fields have implicit modifiers,
+ * such as {@code public static final} for interface fields and {@code public static}
+ * for enum constants. Only fields matching the specified modifiers will be analyzed.
+ * Type is {@code com.puppycrawl.tools.checkstyle.checks.naming.AccessModifierOption[]}.
+ * Default value is {@code public, protected, package, private}.
  * </li>
  * <li>
  * Property {@code ignoreNamePattern} - Specify the regexp to define variable names to ignore.
  * Type is {@code java.util.regex.Pattern}.
  * Default value is {@code null}.
- * </li>
- * <li>
- * Property {@code scope} - Specify the visibility scope where Javadoc comments are checked.
- * Type is {@code com.puppycrawl.tools.checkstyle.api.Scope}.
- * Default value is {@code private}.
  * </li>
  * <li>
  * Property {@code tokens} - tokens to check
@@ -84,35 +86,40 @@ public class JavadocVariableCheck
      * A key is pointing to the warning message text in "messages.properties"
      * file.
      */
+
     public static final String MSG_JAVADOC_MISSING = "javadoc.missing";
-
-    /** Specify the visibility scope where Javadoc comments are checked. */
-    private Scope scope = Scope.PRIVATE;
-
-    /** Specify the visibility scope where Javadoc comments are not checked. */
-    private Scope excludeScope;
+    /**
+     * Specify the set of access modifiers used to determine which fields should be checked.
+     *  This includes both explicitly declared modifiers and implicit ones, such as package-private
+     *  for fields without an explicit modifier. It also accounts for special cases where fields
+     *  have implicit modifiers, such as {@code public static final} for interface fields and
+     *  {@code public static} for enum constants.
+     *  Only fields matching the specified modifiers will be analyzed.
+     */
+    private AccessModifierOption[] accessModifiers = {
+        AccessModifierOption.PUBLIC,
+        AccessModifierOption.PROTECTED,
+        AccessModifierOption.PACKAGE,
+        AccessModifierOption.PRIVATE,
+    };
 
     /** Specify the regexp to define variable names to ignore. */
     private Pattern ignoreNamePattern;
 
     /**
-     * Setter to specify the visibility scope where Javadoc comments are checked.
+     * Setter to specify the set of access modifiers used to determine which fields should be
+     * checked. This includes both explicitly declared modifiers and implicit ones, such as
+     * package-private for fields without an explicit modifier. It also accounts for special
+     * cases where fields have implicit modifiers, such as {@code public static final}
+     * for interface fields and {@code public static} for enum constants.
+     * Only fields matching the specified modifiers will be analyzed.
      *
-     * @param scope a scope.
-     * @since 3.0
+     * @param accessModifiers access modifiers of fields to check.
+     * @since 10.22.0
      */
-    public void setScope(Scope scope) {
-        this.scope = scope;
-    }
-
-    /**
-     * Setter to specify the visibility scope where Javadoc comments are not checked.
-     *
-     * @param excludeScope a scope.
-     * @since 3.4
-     */
-    public void setExcludeScope(Scope excludeScope) {
-        this.excludeScope = excludeScope;
+    public void setAccessModifiers(AccessModifierOption... accessModifiers) {
+        this.accessModifiers =
+            UnmodifiableCollectionUtil.copyOfArray(accessModifiers, accessModifiers.length);
     }
 
     /**
@@ -177,6 +184,17 @@ public class JavadocVariableCheck
     }
 
     /**
+     * Checks whether a method has the correct access modifier to be checked.
+     *
+     * @param accessModifier the access modifier of the method.
+     * @return whether the method matches the expected access modifier.
+     */
+    private boolean matchAccessModifiers(AccessModifierOption accessModifier) {
+        return Arrays.stream(accessModifiers)
+            .anyMatch(modifier -> modifier == accessModifier);
+    }
+
+    /**
      * Whether we should check this node.
      *
      * @param ast a given node.
@@ -185,14 +203,10 @@ public class JavadocVariableCheck
     private boolean shouldCheck(final DetailAST ast) {
         boolean result = false;
         if (!ScopeUtil.isInCodeBlock(ast) && !isIgnored(ast)) {
-            final Scope customScope = ScopeUtil.getScope(ast);
-            final Scope surroundingScope = ScopeUtil.getSurroundingScope(ast);
-            result = customScope.isIn(scope) && surroundingScope.isIn(scope)
-                && (excludeScope == null
-                    || !customScope.isIn(excludeScope)
-                    || !surroundingScope.isIn(excludeScope));
+            final AccessModifierOption accessModifier =
+                    CheckUtil.getAccessModifierFromModifiersToken(ast);
+            result = matchAccessModifiers(accessModifier);
         }
         return result;
     }
-
 }

--- a/src/main/java/com/puppycrawl/tools/checkstyle/utils/CheckUtil.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/utils/CheckUtil.java
@@ -314,9 +314,14 @@ public final class CheckUtil {
      * @return the access modifier of the method/constructor.
      */
     public static AccessModifierOption getAccessModifierFromModifiersToken(DetailAST ast) {
-        final DetailAST modsToken = ast.findFirstToken(TokenTypes.MODIFIERS);
-        AccessModifierOption accessModifier =
-                getAccessModifierFromModifiersTokenDirectly(modsToken);
+        AccessModifierOption accessModifier;
+        if (ast.getType() == TokenTypes.ENUM_CONSTANT_DEF) {
+            accessModifier = AccessModifierOption.PUBLIC;
+        }
+        else {
+            final DetailAST modsToken = ast.findFirstToken(TokenTypes.MODIFIERS);
+            accessModifier = getAccessModifierFromModifiersTokenDirectly(modsToken);
+        }
 
         if (accessModifier == AccessModifierOption.PACKAGE) {
             if (ScopeUtil.isInEnumBlock(ast) && ast.getType() == TokenTypes.CTOR_DEF) {

--- a/src/main/resources/com/puppycrawl/tools/checkstyle/meta/checks/javadoc/JavadocVariableCheck.xml
+++ b/src/main/resources/com/puppycrawl/tools/checkstyle/meta/checks/javadoc/JavadocVariableCheck.xml
@@ -8,17 +8,18 @@
  Checks that a variable has a Javadoc comment. Ignores {@code serialVersionUID} fields.
  &lt;/div&gt;</description>
          <properties>
-            <property name="excludeScope" type="com.puppycrawl.tools.checkstyle.api.Scope">
-               <description>Specify the visibility scope where Javadoc
- comments are not checked.</description>
+            <property default-value="public, protected, package, private"
+                      name="accessModifiers"
+                      type="com.puppycrawl.tools.checkstyle.checks.naming.AccessModifierOption[]">
+               <description>Specify the set of access modifiers used to determine which
+ fields should be checked. This includes both explicitly declared modifiers and implicit ones,
+ such as package-private for fields without an explicit modifier.
+ It also accounts for special cases where fields have implicit modifiers,
+ such as {@code public static final} for interface fields and {@code public static}
+ for enum constants. Only fields matching the specified modifiers will be analyzed.</description>
             </property>
             <property name="ignoreNamePattern" type="java.util.regex.Pattern">
                <description>Specify the regexp to define variable names to ignore.</description>
-            </property>
-            <property default-value="private"
-                      name="scope"
-                      type="com.puppycrawl.tools.checkstyle.api.Scope">
-               <description>Specify the visibility scope where Javadoc comments are checked.</description>
             </property>
             <property default-value="ENUM_CONSTANT_DEF"
                       name="tokens"

--- a/src/site/xdoc/checks/javadoc/javadocvariable.xml
+++ b/src/site/xdoc/checks/javadoc/javadocvariable.xml
@@ -26,11 +26,11 @@
               <th>since</th>
             </tr>
             <tr>
-              <td>excludeScope</td>
-              <td>Specify the visibility scope where Javadoc comments are not checked.</td>
-              <td><a href="../../property_types.html#Scope">Scope</a></td>
-              <td><code>null</code></td>
-              <td>3.4</td>
+              <td>accessModifiers</td>
+              <td>Specify the set of access modifiers used to determine which fields should be checked. This includes both explicitly declared modifiers and implicit ones, such as package-private for fields without an explicit modifier. It also accounts for special cases where fields have implicit modifiers, such as <code>public static final</code> for interface fields and <code>public static</code> for enum constants. Only fields matching the specified modifiers will be analyzed.</td>
+              <td><a href="../../property_types.html#AccessModifierOption.5B.5D">AccessModifierOption[]</a></td>
+              <td><code>public, protected, package, private</code></td>
+              <td>10.22.0</td>
             </tr>
             <tr>
               <td>ignoreNamePattern</td>
@@ -38,13 +38,6 @@
               <td><a href="../../property_types.html#Pattern">Pattern</a></td>
               <td><code>null</code></td>
               <td>5.8</td>
-            </tr>
-            <tr>
-              <td>scope</td>
-              <td>Specify the visibility scope where Javadoc comments are checked.</td>
-              <td><a href="../../property_types.html#Scope">Scope</a></td>
-              <td><code>private</code></td>
-              <td>3.0</td>
             </tr>
             <tr>
               <td>tokens</td>
@@ -78,40 +71,40 @@
 </code></pre></div>
         <p id="Example1-code">
           By default, this setting will report a violation if
-          there is no javadoc for any scope member.
+          there is no javadoc for a field with any access modifier.
         </p>
         <div class="wrapper"><pre class="prettyprint"><code class="language-java">
 public class Example1 {
-  private int a; // violation
+  private int a; // violation, 'Missing a Javadoc comment'
 
   /**
    * Some description here
    */
   private int b;
-  protected int c; // violation
-  public int d; // violation
-  /*package*/ int e; // violation
+  protected int c; // violation, 'Missing a Javadoc comment'
+  public int d; // violation, 'Missing a Javadoc comment'
+  /*package*/ int e; // violation, 'Missing a Javadoc comment'
 
 }
 </code></pre></div>
 
         <p id="Example2-config">
-          To configure the check for <code>public</code>
-          scope:
+          To configure the check <code>public</code>
+          access modifier:
         </p>
 
         <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
 &lt;module name="Checker"&gt;
   &lt;module name="TreeWalker"&gt;
     &lt;module name="JavadocVariable"&gt;
-      &lt;property name="scope" value="public"/&gt;
+      &lt;property name="accessModifiers" value="public"/&gt;
     &lt;/module&gt;
   &lt;/module&gt;
 &lt;/module&gt;
 </code></pre></div>
         <p id="Example2-code">
           This setting will report a violation if there
-          is no javadoc for <code>public</code> member.
+          is no javadoc for <code>public</code> field.
         </p>
         <div class="wrapper"><pre class="prettyprint"><code class="language-java">
 public class Example2 {
@@ -122,34 +115,32 @@ public class Example2 {
    */
   private int b;
   protected int c;
-  public int d; // violation
+  public int d; // violation, 'Missing a Javadoc comment'
   /*package*/ int e;
 }
 </code></pre></div>
 
         <p id="Example3-config">
-          To configure the check for members which are in <code>private</code>, but not in
-          <code>protected</code> scope:
+          To configure the check for fields which are in <code>private</code> or
+          <code>package</code> access modifier:
         </p>
 
         <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
 &lt;module name="Checker"&gt;
   &lt;module name="TreeWalker"&gt;
     &lt;module name="JavadocVariable"&gt;
-      &lt;property name="scope" value="private"/&gt;
-      &lt;property name="excludeScope" value="protected"/&gt;
+      &lt;property name="accessModifiers" value="private,package"/&gt;
     &lt;/module&gt;
   &lt;/module&gt;
 &lt;/module&gt;
 </code></pre></div>
         <p id="Example3-code">
           This setting will report a violation if there is no
-          javadoc for <code>private</code> member and
-          ignores <code>protected</code> member.
+          javadoc for <code>private</code>  or <code>package</code> field.
         </p>
         <div class="wrapper"><pre class="prettyprint"><code class="language-java">
 public class Example3 {
-  private int a; // violation
+  private int a; // violation, 'Missing a Javadoc comment'
 
   /**
    * Some description here
@@ -157,11 +148,11 @@ public class Example3 {
   private int b;
   protected int c;
   public int d;
-  /*package*/ int e; // violation
+  /*package*/ int e; // violation, 'Missing a Javadoc comment'
 }
 </code></pre></div>
         <p id="Example4-config">
-          To ignore absence of Javadoc comments for variables with names <code>log</code> or
+          To ignore absence of Javadoc comments for fields with names <code>log</code> or
           <code>logger</code>:
         </p>
 
@@ -176,20 +167,56 @@ public class Example3 {
 </code></pre></div>
         <p id="Example4-code">
           This setting will report a violation if there is no
-          javadoc for any scope member and ignores members with
+          javadoc for any scope field and ignores fields with
           name <code>log</code> or <code>logger</code>.
         </p>
         <div class="wrapper"><pre class="prettyprint"><code class="language-java">
 public class Example4 {
-  private int a; // violation
+  private int a; // violation, 'Missing a Javadoc comment'
 
   /**
    * Some description here
   */
   private int b;
-  protected int c; // violation
-  public int d; // violation
-  /*package*/ int e; // violation
+  protected int c; // violation, 'Missing a Javadoc comment'
+  public int d; // violation, 'Missing a Javadoc comment'
+  /*package*/ int e; // violation, 'Missing a Javadoc comment'
+}
+</code></pre></div>
+
+        <p id="Example5-code">
+          This check will not report a violation for local and
+           anonymous inner classes with any configuration.
+        </p>
+        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+public class Example5 {
+  public int variablePublic; // violation, 'Missing a Javadoc comment'
+  protected int variableProtected; // violation, 'Missing a Javadoc comment'
+  int variablePackage; // violation, 'Missing a Javadoc comment'
+  private int variablePrivate; // violation, 'Missing a Javadoc comment'
+
+  public void testMethodInnerClass() {
+
+    // This check ignores local classes.
+    class InnerClass {
+      public int innerClassVariablePublic;
+      protected int innerClassVariableProtected;
+      int innerClassVariablePackage;
+      private int innerClassVariablePrivate;
+    }
+
+    // This check ignores anonymous inner classes.
+    Runnable runnable = new Runnable() {
+      public int innerClassVariablePublic;
+      protected int innerClassVariableProtected;
+      int innerClassVariablePackage;
+      private int innerClassVariablePrivate;
+      public void run()
+        {
+          System.identityHashCode("running");
+        }
+    };
+  }
 }
 </code></pre></div>
       </subsection>

--- a/src/site/xdoc/checks/javadoc/javadocvariable.xml.template
+++ b/src/site/xdoc/checks/javadoc/javadocvariable.xml.template
@@ -35,7 +35,7 @@
         </macro>
         <p id="Example1-code">
           By default, this setting will report a violation if
-          there is no javadoc for any scope member.
+          there is no javadoc for a field with any access modifier.
         </p>
         <macro name="example">
           <param name="path"
@@ -44,8 +44,8 @@
         </macro>
 
         <p id="Example2-config">
-          To configure the check for <code>public</code>
-          scope:
+          To configure the check <code>public</code>
+          access modifier:
         </p>
 
         <macro name="example">
@@ -55,7 +55,7 @@
         </macro>
         <p id="Example2-code">
           This setting will report a violation if there
-          is no javadoc for <code>public</code> member.
+          is no javadoc for <code>public</code> field.
         </p>
         <macro name="example">
           <param name="path"
@@ -64,8 +64,8 @@
         </macro>
 
         <p id="Example3-config">
-          To configure the check for members which are in <code>private</code>, but not in
-          <code>protected</code> scope:
+          To configure the check for fields which are in <code>private</code> or
+          <code>package</code> access modifier:
         </p>
 
         <macro name="example">
@@ -75,8 +75,7 @@
         </macro>
         <p id="Example3-code">
           This setting will report a violation if there is no
-          javadoc for <code>private</code> member and
-          ignores <code>protected</code> member.
+          javadoc for <code>private</code>  or <code>package</code> field.
         </p>
         <macro name="example">
           <param name="path"
@@ -84,7 +83,7 @@
           <param name="type" value="code"/>
         </macro>
         <p id="Example4-config">
-          To ignore absence of Javadoc comments for variables with names <code>log</code> or
+          To ignore absence of Javadoc comments for fields with names <code>log</code> or
           <code>logger</code>:
         </p>
 
@@ -95,12 +94,22 @@
         </macro>
         <p id="Example4-code">
           This setting will report a violation if there is no
-          javadoc for any scope member and ignores members with
+          javadoc for any scope field and ignores fields with
           name <code>log</code> or <code>logger</code>.
         </p>
         <macro name="example">
           <param name="path"
                  value="resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadocvariable/Example4.java"/>
+          <param name="type" value="code"/>
+        </macro>
+
+        <p id="Example5-code">
+          This check will not report a violation for local and
+           anonymous inner classes with any configuration.
+        </p>
+        <macro name="example">
+          <param name="path"
+                 value="resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadocvariable/Example5.java"/>
           <param name="type" value="code"/>
         </macro>
       </subsection>

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocVariableCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocVariableCheckTest.java
@@ -26,7 +26,6 @@ import org.junit.jupiter.api.Test;
 
 import com.puppycrawl.tools.checkstyle.AbstractModuleTestSupport;
 import com.puppycrawl.tools.checkstyle.api.TokenTypes;
-import com.puppycrawl.tools.checkstyle.utils.CommonUtil;
 
 public class JavadocVariableCheckTest
     extends AbstractModuleTestSupport {
@@ -67,10 +66,11 @@ public class JavadocVariableCheckTest
     public void testDefault()
             throws Exception {
         final String[] expected = {
-            "18:5: " + getCheckMessage(MSG_JAVADOC_MISSING),
-            "311:5: " + getCheckMessage(MSG_JAVADOC_MISSING),
-            "318:5: " + getCheckMessage(MSG_JAVADOC_MISSING),
-            "337:5: " + getCheckMessage(MSG_JAVADOC_MISSING),
+            "16:5: " + getCheckMessage(MSG_JAVADOC_MISSING),
+            "309:5: " + getCheckMessage(MSG_JAVADOC_MISSING),
+            "316:5: " + getCheckMessage(MSG_JAVADOC_MISSING),
+            "335:5: " + getCheckMessage(MSG_JAVADOC_MISSING),
+
         };
         verifyWithInlineConfigParser(
                 getPath("InputJavadocVariableTags.java"), expected);
@@ -80,9 +80,9 @@ public class JavadocVariableCheckTest
     public void testAnother()
             throws Exception {
         final String[] expected = {
-            "23:9: " + getCheckMessage(MSG_JAVADOC_MISSING),
-            "30:9: " + getCheckMessage(MSG_JAVADOC_MISSING),
-            "36:13: " + getCheckMessage(MSG_JAVADOC_MISSING),
+            "21:9: " + getCheckMessage(MSG_JAVADOC_MISSING),
+            "28:9: " + getCheckMessage(MSG_JAVADOC_MISSING),
+            "34:13: " + getCheckMessage(MSG_JAVADOC_MISSING),
         };
         verifyWithInlineConfigParser(
                 getPath("InputJavadocVariableInner.java"), expected);
@@ -91,7 +91,9 @@ public class JavadocVariableCheckTest
     @Test
     public void testAnother2()
             throws Exception {
-        final String[] expected = CommonUtil.EMPTY_STRING_ARRAY;
+        final String[] expected = {
+            "26:9: " + getCheckMessage(MSG_JAVADOC_MISSING),
+        };
         verifyWithInlineConfigParser(
                 getPath("InputJavadocVariableInner2.java"), expected);
     }
@@ -100,13 +102,13 @@ public class JavadocVariableCheckTest
     public void testAnother3()
             throws Exception {
         final String[] expected = {
-            "17:9: " + getCheckMessage(MSG_JAVADOC_MISSING),
-            "22:13: " + getCheckMessage(MSG_JAVADOC_MISSING),
-            "42:9: " + getCheckMessage(MSG_JAVADOC_MISSING),
+            "15:9: " + getCheckMessage(MSG_JAVADOC_MISSING),
+            "20:13: " + getCheckMessage(MSG_JAVADOC_MISSING),
+            "40:9: " + getCheckMessage(MSG_JAVADOC_MISSING),
+            "47:5: " + getCheckMessage(MSG_JAVADOC_MISSING),
+            "48:5: " + getCheckMessage(MSG_JAVADOC_MISSING),
             "49:5: " + getCheckMessage(MSG_JAVADOC_MISSING),
             "50:5: " + getCheckMessage(MSG_JAVADOC_MISSING),
-            "51:5: " + getCheckMessage(MSG_JAVADOC_MISSING),
-            "52:5: " + getCheckMessage(MSG_JAVADOC_MISSING),
         };
         verifyWithInlineConfigParser(
                 getPath("InputJavadocVariablePublicOnly.java"), expected);
@@ -116,7 +118,8 @@ public class JavadocVariableCheckTest
     public void testAnother4()
             throws Exception {
         final String[] expected = {
-            "52:5: " + getCheckMessage(MSG_JAVADOC_MISSING),
+            "15:9: " + getCheckMessage(MSG_JAVADOC_MISSING),
+            "50:5: " + getCheckMessage(MSG_JAVADOC_MISSING),
         };
         verifyWithInlineConfigParser(
                 getPath("InputJavadocVariablePublicOnly2.java"), expected);
@@ -125,22 +128,22 @@ public class JavadocVariableCheckTest
     @Test
     public void testJavadocVariableOnInnerClassFields() throws Exception {
         final String[] expected = {
+            "13:5: " + getCheckMessage(MSG_JAVADOC_MISSING),
+            "14:5: " + getCheckMessage(MSG_JAVADOC_MISSING),
             "15:5: " + getCheckMessage(MSG_JAVADOC_MISSING),
             "16:5: " + getCheckMessage(MSG_JAVADOC_MISSING),
-            "17:5: " + getCheckMessage(MSG_JAVADOC_MISSING),
-            "18:5: " + getCheckMessage(MSG_JAVADOC_MISSING),
+            "24:9: " + getCheckMessage(MSG_JAVADOC_MISSING),
+            "25:9: " + getCheckMessage(MSG_JAVADOC_MISSING),
             "26:9: " + getCheckMessage(MSG_JAVADOC_MISSING),
             "27:9: " + getCheckMessage(MSG_JAVADOC_MISSING),
-            "28:9: " + getCheckMessage(MSG_JAVADOC_MISSING),
-            "29:9: " + getCheckMessage(MSG_JAVADOC_MISSING),
+            "36:9: " + getCheckMessage(MSG_JAVADOC_MISSING),
+            "37:9: " + getCheckMessage(MSG_JAVADOC_MISSING),
             "38:9: " + getCheckMessage(MSG_JAVADOC_MISSING),
             "39:9: " + getCheckMessage(MSG_JAVADOC_MISSING),
-            "40:9: " + getCheckMessage(MSG_JAVADOC_MISSING),
-            "41:9: " + getCheckMessage(MSG_JAVADOC_MISSING),
+            "48:9: " + getCheckMessage(MSG_JAVADOC_MISSING),
+            "49:9: " + getCheckMessage(MSG_JAVADOC_MISSING),
             "50:9: " + getCheckMessage(MSG_JAVADOC_MISSING),
             "51:9: " + getCheckMessage(MSG_JAVADOC_MISSING),
-            "52:9: " + getCheckMessage(MSG_JAVADOC_MISSING),
-            "53:9: " + getCheckMessage(MSG_JAVADOC_MISSING),
         };
         verifyWithInlineConfigParser(
                 getPath("InputJavadocVariableOnInnerClassFields.java"),
@@ -150,27 +153,27 @@ public class JavadocVariableCheckTest
     @Test
     public void testJavadocVariableOnPublicInnerClassFields() throws Exception {
         final String[] expected = {
+            "12:5: " + getCheckMessage(MSG_JAVADOC_MISSING),
+            "13:5: " + getCheckMessage(MSG_JAVADOC_MISSING),
             "14:5: " + getCheckMessage(MSG_JAVADOC_MISSING),
             "15:5: " + getCheckMessage(MSG_JAVADOC_MISSING),
-            "16:5: " + getCheckMessage(MSG_JAVADOC_MISSING),
-            "17:5: " + getCheckMessage(MSG_JAVADOC_MISSING),
+            "23:9: " + getCheckMessage(MSG_JAVADOC_MISSING),
+            "24:9: " + getCheckMessage(MSG_JAVADOC_MISSING),
             "25:9: " + getCheckMessage(MSG_JAVADOC_MISSING),
             "26:9: " + getCheckMessage(MSG_JAVADOC_MISSING),
-            "27:9: " + getCheckMessage(MSG_JAVADOC_MISSING),
-            "28:9: " + getCheckMessage(MSG_JAVADOC_MISSING),
+            "35:9: " + getCheckMessage(MSG_JAVADOC_MISSING),
+            "36:9: " + getCheckMessage(MSG_JAVADOC_MISSING),
             "37:9: " + getCheckMessage(MSG_JAVADOC_MISSING),
             "38:9: " + getCheckMessage(MSG_JAVADOC_MISSING),
-            "39:9: " + getCheckMessage(MSG_JAVADOC_MISSING),
-            "40:9: " + getCheckMessage(MSG_JAVADOC_MISSING),
+            "47:9: " + getCheckMessage(MSG_JAVADOC_MISSING),
+            "48:9: " + getCheckMessage(MSG_JAVADOC_MISSING),
             "49:9: " + getCheckMessage(MSG_JAVADOC_MISSING),
             "50:9: " + getCheckMessage(MSG_JAVADOC_MISSING),
-            "51:9: " + getCheckMessage(MSG_JAVADOC_MISSING),
-            "52:9: " + getCheckMessage(MSG_JAVADOC_MISSING),
+            "59:9: " + getCheckMessage(MSG_JAVADOC_MISSING),
+            "60:9: " + getCheckMessage(MSG_JAVADOC_MISSING),
             "61:9: " + getCheckMessage(MSG_JAVADOC_MISSING),
             "62:9: " + getCheckMessage(MSG_JAVADOC_MISSING),
-            "63:9: " + getCheckMessage(MSG_JAVADOC_MISSING),
-            "64:9: " + getCheckMessage(MSG_JAVADOC_MISSING),
-            "74:9: " + getCheckMessage(MSG_JAVADOC_MISSING),
+            "72:9: " + getCheckMessage(MSG_JAVADOC_MISSING),
         };
         verifyWithInlineConfigParser(
                 getPath("InputJavadocVariableOnPublicInnerClassFields.java"),
@@ -178,12 +181,26 @@ public class JavadocVariableCheckTest
     }
 
     @Test
-    public void testScopes2() throws Exception {
+    public void testAccessModifiersPublicProtected() throws Exception {
         final String[] expected = {
-            "15:5: " + getCheckMessage(MSG_JAVADOC_MISSING),
-            "16:5: " + getCheckMessage(MSG_JAVADOC_MISSING),
-            "26:9: " + getCheckMessage(MSG_JAVADOC_MISSING),
-            "27:9: " + getCheckMessage(MSG_JAVADOC_MISSING),
+            "13:5: " + getCheckMessage(MSG_JAVADOC_MISSING),
+            "14:5: " + getCheckMessage(MSG_JAVADOC_MISSING),
+            "24:9: " + getCheckMessage(MSG_JAVADOC_MISSING),
+            "25:9: " + getCheckMessage(MSG_JAVADOC_MISSING),
+            "36:9: " + getCheckMessage(MSG_JAVADOC_MISSING),
+            "37:9: " + getCheckMessage(MSG_JAVADOC_MISSING),
+            "48:9: " + getCheckMessage(MSG_JAVADOC_MISSING),
+            "49:9: " + getCheckMessage(MSG_JAVADOC_MISSING),
+            "61:5: " + getCheckMessage(MSG_JAVADOC_MISSING),
+            "62:5: " + getCheckMessage(MSG_JAVADOC_MISSING),
+            "72:9: " + getCheckMessage(MSG_JAVADOC_MISSING),
+            "73:9: " + getCheckMessage(MSG_JAVADOC_MISSING),
+            "84:9: " + getCheckMessage(MSG_JAVADOC_MISSING),
+            "85:9: " + getCheckMessage(MSG_JAVADOC_MISSING),
+            "96:9: " + getCheckMessage(MSG_JAVADOC_MISSING),
+            "97:9: " + getCheckMessage(MSG_JAVADOC_MISSING),
+            "108:9: " + getCheckMessage(MSG_JAVADOC_MISSING),
+            "109:9: " + getCheckMessage(MSG_JAVADOC_MISSING),
         };
         verifyWithInlineConfigParser(
                 getPath("InputJavadocVariableNoJavadoc2.java"),
@@ -191,41 +208,27 @@ public class JavadocVariableCheckTest
     }
 
     @Test
-    public void testExcludeScope() throws Exception {
+    public void testAccessModifiersPackagePrivate() throws Exception {
         final String[] expected = {
-            "17:5: " + getCheckMessage(MSG_JAVADOC_MISSING),
-            "18:5: " + getCheckMessage(MSG_JAVADOC_MISSING),
-            "28:9: " + getCheckMessage(MSG_JAVADOC_MISSING),
-            "29:9: " + getCheckMessage(MSG_JAVADOC_MISSING),
+            "15:5: " + getCheckMessage(MSG_JAVADOC_MISSING),
+            "16:5: " + getCheckMessage(MSG_JAVADOC_MISSING),
+            "26:9: " + getCheckMessage(MSG_JAVADOC_MISSING),
+            "27:9: " + getCheckMessage(MSG_JAVADOC_MISSING),
             "38:9: " + getCheckMessage(MSG_JAVADOC_MISSING),
             "39:9: " + getCheckMessage(MSG_JAVADOC_MISSING),
-            "40:9: " + getCheckMessage(MSG_JAVADOC_MISSING),
-            "41:9: " + getCheckMessage(MSG_JAVADOC_MISSING),
             "50:9: " + getCheckMessage(MSG_JAVADOC_MISSING),
             "51:9: " + getCheckMessage(MSG_JAVADOC_MISSING),
-            "52:9: " + getCheckMessage(MSG_JAVADOC_MISSING),
-            "53:9: " + getCheckMessage(MSG_JAVADOC_MISSING),
             "63:5: " + getCheckMessage(MSG_JAVADOC_MISSING),
             "64:5: " + getCheckMessage(MSG_JAVADOC_MISSING),
-            "65:5: " + getCheckMessage(MSG_JAVADOC_MISSING),
-            "66:5: " + getCheckMessage(MSG_JAVADOC_MISSING),
             "74:9: " + getCheckMessage(MSG_JAVADOC_MISSING),
             "75:9: " + getCheckMessage(MSG_JAVADOC_MISSING),
-            "76:9: " + getCheckMessage(MSG_JAVADOC_MISSING),
-            "77:9: " + getCheckMessage(MSG_JAVADOC_MISSING),
             "86:9: " + getCheckMessage(MSG_JAVADOC_MISSING),
             "87:9: " + getCheckMessage(MSG_JAVADOC_MISSING),
-            "88:9: " + getCheckMessage(MSG_JAVADOC_MISSING),
-            "89:9: " + getCheckMessage(MSG_JAVADOC_MISSING),
             "98:9: " + getCheckMessage(MSG_JAVADOC_MISSING),
             "99:9: " + getCheckMessage(MSG_JAVADOC_MISSING),
-            "100:9: " + getCheckMessage(MSG_JAVADOC_MISSING),
-            "101:9: " + getCheckMessage(MSG_JAVADOC_MISSING),
             "110:9: " + getCheckMessage(MSG_JAVADOC_MISSING),
             "111:9: " + getCheckMessage(MSG_JAVADOC_MISSING),
-            "112:9: " + getCheckMessage(MSG_JAVADOC_MISSING),
-            "113:9: " + getCheckMessage(MSG_JAVADOC_MISSING),
-            "123:9: " + getCheckMessage(MSG_JAVADOC_MISSING),
+            "121:9: " + getCheckMessage(MSG_JAVADOC_MISSING),
         };
         verifyWithInlineConfigParser(
                 getPath("InputJavadocVariableNoJavadoc3.java"),
@@ -236,42 +239,42 @@ public class JavadocVariableCheckTest
     public void testIgnoredVariableNames()
             throws Exception {
         final String[] expected = {
+            "13:5: " + getCheckMessage(MSG_JAVADOC_MISSING),
+            "14:5: " + getCheckMessage(MSG_JAVADOC_MISSING),
             "15:5: " + getCheckMessage(MSG_JAVADOC_MISSING),
             "16:5: " + getCheckMessage(MSG_JAVADOC_MISSING),
-            "17:5: " + getCheckMessage(MSG_JAVADOC_MISSING),
-            "18:5: " + getCheckMessage(MSG_JAVADOC_MISSING),
+            "24:9: " + getCheckMessage(MSG_JAVADOC_MISSING),
+            "25:9: " + getCheckMessage(MSG_JAVADOC_MISSING),
             "26:9: " + getCheckMessage(MSG_JAVADOC_MISSING),
             "27:9: " + getCheckMessage(MSG_JAVADOC_MISSING),
-            "28:9: " + getCheckMessage(MSG_JAVADOC_MISSING),
-            "29:9: " + getCheckMessage(MSG_JAVADOC_MISSING),
+            "36:9: " + getCheckMessage(MSG_JAVADOC_MISSING),
+            "37:9: " + getCheckMessage(MSG_JAVADOC_MISSING),
             "38:9: " + getCheckMessage(MSG_JAVADOC_MISSING),
             "39:9: " + getCheckMessage(MSG_JAVADOC_MISSING),
-            "40:9: " + getCheckMessage(MSG_JAVADOC_MISSING),
-            "41:9: " + getCheckMessage(MSG_JAVADOC_MISSING),
+            "48:9: " + getCheckMessage(MSG_JAVADOC_MISSING),
+            "49:9: " + getCheckMessage(MSG_JAVADOC_MISSING),
             "50:9: " + getCheckMessage(MSG_JAVADOC_MISSING),
             "51:9: " + getCheckMessage(MSG_JAVADOC_MISSING),
-            "52:9: " + getCheckMessage(MSG_JAVADOC_MISSING),
-            "53:9: " + getCheckMessage(MSG_JAVADOC_MISSING),
+            "61:5: " + getCheckMessage(MSG_JAVADOC_MISSING),
+            "62:5: " + getCheckMessage(MSG_JAVADOC_MISSING),
             "63:5: " + getCheckMessage(MSG_JAVADOC_MISSING),
             "64:5: " + getCheckMessage(MSG_JAVADOC_MISSING),
-            "65:5: " + getCheckMessage(MSG_JAVADOC_MISSING),
-            "66:5: " + getCheckMessage(MSG_JAVADOC_MISSING),
+            "72:9: " + getCheckMessage(MSG_JAVADOC_MISSING),
+            "73:9: " + getCheckMessage(MSG_JAVADOC_MISSING),
             "74:9: " + getCheckMessage(MSG_JAVADOC_MISSING),
             "75:9: " + getCheckMessage(MSG_JAVADOC_MISSING),
-            "76:9: " + getCheckMessage(MSG_JAVADOC_MISSING),
-            "77:9: " + getCheckMessage(MSG_JAVADOC_MISSING),
+            "84:9: " + getCheckMessage(MSG_JAVADOC_MISSING),
+            "85:9: " + getCheckMessage(MSG_JAVADOC_MISSING),
             "86:9: " + getCheckMessage(MSG_JAVADOC_MISSING),
             "87:9: " + getCheckMessage(MSG_JAVADOC_MISSING),
-            "88:9: " + getCheckMessage(MSG_JAVADOC_MISSING),
-            "89:9: " + getCheckMessage(MSG_JAVADOC_MISSING),
+            "96:9: " + getCheckMessage(MSG_JAVADOC_MISSING),
+            "97:9: " + getCheckMessage(MSG_JAVADOC_MISSING),
             "98:9: " + getCheckMessage(MSG_JAVADOC_MISSING),
             "99:9: " + getCheckMessage(MSG_JAVADOC_MISSING),
-            "100:9: " + getCheckMessage(MSG_JAVADOC_MISSING),
-            "101:9: " + getCheckMessage(MSG_JAVADOC_MISSING),
+            "108:9: " + getCheckMessage(MSG_JAVADOC_MISSING),
+            "109:9: " + getCheckMessage(MSG_JAVADOC_MISSING),
             "110:9: " + getCheckMessage(MSG_JAVADOC_MISSING),
             "111:9: " + getCheckMessage(MSG_JAVADOC_MISSING),
-            "112:9: " + getCheckMessage(MSG_JAVADOC_MISSING),
-            "113:9: " + getCheckMessage(MSG_JAVADOC_MISSING),
         };
         verifyWithInlineConfigParser(
                 getPath("InputJavadocVariableNoJavadoc4.java"),
@@ -282,43 +285,43 @@ public class JavadocVariableCheckTest
     public void testDoNotIgnoreAnythingWhenIgnoreNamePatternIsEmpty()
             throws Exception {
         final String[] expected = {
+            "13:5: " + getCheckMessage(MSG_JAVADOC_MISSING),
+            "14:5: " + getCheckMessage(MSG_JAVADOC_MISSING),
             "15:5: " + getCheckMessage(MSG_JAVADOC_MISSING),
             "16:5: " + getCheckMessage(MSG_JAVADOC_MISSING),
-            "17:5: " + getCheckMessage(MSG_JAVADOC_MISSING),
-            "18:5: " + getCheckMessage(MSG_JAVADOC_MISSING),
+            "24:9: " + getCheckMessage(MSG_JAVADOC_MISSING),
+            "25:9: " + getCheckMessage(MSG_JAVADOC_MISSING),
             "26:9: " + getCheckMessage(MSG_JAVADOC_MISSING),
             "27:9: " + getCheckMessage(MSG_JAVADOC_MISSING),
-            "28:9: " + getCheckMessage(MSG_JAVADOC_MISSING),
-            "29:9: " + getCheckMessage(MSG_JAVADOC_MISSING),
+            "36:9: " + getCheckMessage(MSG_JAVADOC_MISSING),
+            "37:9: " + getCheckMessage(MSG_JAVADOC_MISSING),
             "38:9: " + getCheckMessage(MSG_JAVADOC_MISSING),
             "39:9: " + getCheckMessage(MSG_JAVADOC_MISSING),
-            "40:9: " + getCheckMessage(MSG_JAVADOC_MISSING),
-            "41:9: " + getCheckMessage(MSG_JAVADOC_MISSING),
+            "48:9: " + getCheckMessage(MSG_JAVADOC_MISSING),
+            "49:9: " + getCheckMessage(MSG_JAVADOC_MISSING),
             "50:9: " + getCheckMessage(MSG_JAVADOC_MISSING),
             "51:9: " + getCheckMessage(MSG_JAVADOC_MISSING),
-            "52:9: " + getCheckMessage(MSG_JAVADOC_MISSING),
-            "53:9: " + getCheckMessage(MSG_JAVADOC_MISSING),
+            "61:5: " + getCheckMessage(MSG_JAVADOC_MISSING),
+            "62:5: " + getCheckMessage(MSG_JAVADOC_MISSING),
             "63:5: " + getCheckMessage(MSG_JAVADOC_MISSING),
             "64:5: " + getCheckMessage(MSG_JAVADOC_MISSING),
-            "65:5: " + getCheckMessage(MSG_JAVADOC_MISSING),
-            "66:5: " + getCheckMessage(MSG_JAVADOC_MISSING),
+            "72:9: " + getCheckMessage(MSG_JAVADOC_MISSING),
+            "73:9: " + getCheckMessage(MSG_JAVADOC_MISSING),
             "74:9: " + getCheckMessage(MSG_JAVADOC_MISSING),
             "75:9: " + getCheckMessage(MSG_JAVADOC_MISSING),
-            "76:9: " + getCheckMessage(MSG_JAVADOC_MISSING),
-            "77:9: " + getCheckMessage(MSG_JAVADOC_MISSING),
+            "84:9: " + getCheckMessage(MSG_JAVADOC_MISSING),
+            "85:9: " + getCheckMessage(MSG_JAVADOC_MISSING),
             "86:9: " + getCheckMessage(MSG_JAVADOC_MISSING),
             "87:9: " + getCheckMessage(MSG_JAVADOC_MISSING),
-            "88:9: " + getCheckMessage(MSG_JAVADOC_MISSING),
-            "89:9: " + getCheckMessage(MSG_JAVADOC_MISSING),
+            "96:9: " + getCheckMessage(MSG_JAVADOC_MISSING),
+            "97:9: " + getCheckMessage(MSG_JAVADOC_MISSING),
             "98:9: " + getCheckMessage(MSG_JAVADOC_MISSING),
             "99:9: " + getCheckMessage(MSG_JAVADOC_MISSING),
-            "100:9: " + getCheckMessage(MSG_JAVADOC_MISSING),
-            "101:9: " + getCheckMessage(MSG_JAVADOC_MISSING),
+            "108:9: " + getCheckMessage(MSG_JAVADOC_MISSING),
+            "109:9: " + getCheckMessage(MSG_JAVADOC_MISSING),
             "110:9: " + getCheckMessage(MSG_JAVADOC_MISSING),
             "111:9: " + getCheckMessage(MSG_JAVADOC_MISSING),
-            "112:9: " + getCheckMessage(MSG_JAVADOC_MISSING),
-            "113:9: " + getCheckMessage(MSG_JAVADOC_MISSING),
-            "123:9: " + getCheckMessage(MSG_JAVADOC_MISSING),
+            "121:9: " + getCheckMessage(MSG_JAVADOC_MISSING),
         };
         verifyWithInlineConfigParser(
                 getPath("InputJavadocVariableNoJavadoc5.java"),
@@ -328,7 +331,7 @@ public class JavadocVariableCheckTest
     @Test
     public void testLambdaLocalVariablesDoNotNeedJavadoc() throws Exception {
         final String[] expected = {
-            "16:5: " + getCheckMessage(MSG_JAVADOC_MISSING),
+            "15:5: " + getCheckMessage(MSG_JAVADOC_MISSING),
         };
         verifyWithInlineConfigParser(
                 getPath("InputJavadocVariableNoJavadocNeededInLambda.java"),
@@ -338,13 +341,25 @@ public class JavadocVariableCheckTest
     @Test
     public void testInterfaceMemberScopeIsPublic() throws Exception {
         final String[] expected = {
+            "16:5: " + getCheckMessage(MSG_JAVADOC_MISSING),
             "18:5: " + getCheckMessage(MSG_JAVADOC_MISSING),
-            "20:5: " + getCheckMessage(MSG_JAVADOC_MISSING),
-            "27:9: " + getCheckMessage(MSG_JAVADOC_MISSING),
+            "25:9: " + getCheckMessage(MSG_JAVADOC_MISSING),
         };
         verifyWithInlineConfigParser(
                 getPath("InputJavadocVariableInterfaceMemberScopeIsPublic.java"),
                 expected);
     }
 
+    @Test
+    public void testMethodInnerClass() throws Exception {
+        final String[] expected = {
+            "9:5: " + getCheckMessage(MSG_JAVADOC_MISSING),
+            "10:5: " + getCheckMessage(MSG_JAVADOC_MISSING),
+            "11:5: " + getCheckMessage(MSG_JAVADOC_MISSING),
+            "12:5: " + getCheckMessage(MSG_JAVADOC_MISSING),
+        };
+        verifyWithInlineConfigParser(
+            getPath("InputJavadocVariableMethodInnerClass.java"),
+            expected);
+    }
 }

--- a/src/test/java/com/puppycrawl/tools/checkstyle/utils/CheckUtilTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/utils/CheckUtilTest.java
@@ -221,6 +221,13 @@ public class CheckUtilTest extends AbstractModuleTestSupport {
         assertWithMessage("Invalid access modifier")
             .that(modifierPackage)
             .isEqualTo(AccessModifierOption.PACKAGE);
+
+        final DetailAST enumConstantDefinition = getNodeFromFile(TokenTypes.ENUM_CONSTANT_DEF);
+        final AccessModifierOption modifierEnumConstant = CheckUtil
+                .getAccessModifierFromModifiersToken(enumConstantDefinition);
+        assertWithMessage("Invalid access modifier")
+                .that(modifierEnumConstant)
+                .isEqualTo(AccessModifierOption.PUBLIC);
     }
 
     @Test

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadocvariable/InputJavadocVariableInner.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadocvariable/InputJavadocVariableInner.java
@@ -1,10 +1,8 @@
 /*
 JavadocVariable
-scope = (default)private
-excludeScope = (default)null
+accessModifiers = (default)public,protected,package,private
 ignoreNamePattern = (default)null
 tokens = (default)ENUM_CONSTANT_DEF
-
 
 */
 
@@ -20,20 +18,20 @@ class InputJavadocVariableInner
     class InnerInner2
     {
         // Ignore
-        public int fData; // violation
+        public int fData; // violation, 'Missing a Javadoc comment'
     }
 
     // Ignore - 2 violations
     interface InnerInterface2
     {
         // Ignore - should be all upper case
-        String data = "zxzc"; // violation
+        String data = "zxzc"; // violation, 'Missing a Javadoc comment'
 
         // Ignore
         class InnerInterfaceInnerClass
         {
             // Ignore - need Javadoc and made private
-            public int rData; // violation
+            public int rData; // violation, 'Missing a Javadoc comment'
 
             /** needs to be made private unless allowProtected. */
             protected int protectedVariable;

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadocvariable/InputJavadocVariableInner2.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadocvariable/InputJavadocVariableInner2.java
@@ -1,10 +1,8 @@
 /*
 JavadocVariable
-scope = public
-excludeScope = (default)null
+accessModifiers = public
 ignoreNamePattern = (default)null
 tokens = (default)ENUM_CONSTANT_DEF
-
 
 */
 
@@ -16,24 +14,22 @@ package com.puppycrawl.tools.checkstyle.checks.javadoc.javadocvariable;
  */
 class InputJavadocVariableInner2
 {
-    // Ignore - two violations
     class InnerInner2
     {
-        // Ignore
-        public int fData;
+        int fData;
     }
 
-    // Ignore - 2 violations
+    // Ignore - 1 violations
     interface InnerInterface2
     {
-        // Ignore - should be all upper case
-        String data = "zxzc";
+
+        String data = "zxzc"; // violation, 'Missing a Javadoc comment'
 
         // Ignore
         class InnerInterfaceInnerClass
         {
             // Ignore - need Javadoc and made private
-            public int rData;
+            private int rData;
 
             /** needs to be made private unless allowProtected. */
             protected int protectedVariable;

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadocvariable/InputJavadocVariableInterfaceMemberScopeIsPublic.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadocvariable/InputJavadocVariableInterfaceMemberScopeIsPublic.java
@@ -1,30 +1,28 @@
 /*
 JavadocVariable
-scope = public
-excludeScope = (default)null
+accessModifiers = public
 ignoreNamePattern = (default)null
 tokens = ENUM_CONSTANT_DEF, VARIABLE_DEF
-
 
 */
 
 package com.puppycrawl.tools.checkstyle.checks.javadoc.javadocvariable;
 
-public interface InputJavadocVariableInterfaceMemberScopeIsPublic {
+interface InputJavadocVariableInterfaceMemberScopeIsPublic {
 
     /** First field */
     public static int field1 = 0;
 
-    public static int field2 = 0; // violation
+    public static int field2 = 0; // violation, 'Missing a Javadoc comment'
 
-    int field3 = 0; // violation
+    int field3 = 0; // violation, 'Missing a Javadoc comment'
 
     enum Enum {
 
         /** First constant */
         A,
 
-        B; // violation
+        B; // violation, 'Missing a Javadoc comment'
 
     }
 

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadocvariable/InputJavadocVariableMethodInnerClass.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadocvariable/InputJavadocVariableMethodInnerClass.java
@@ -1,0 +1,34 @@
+/*
+JavadocVariable
+
+*/
+
+package com.puppycrawl.tools.checkstyle.checks.javadoc.javadocvariable;
+
+public class InputJavadocVariableMethodInnerClass {
+    public int variablePublic; // violation, 'Missing a Javadoc comment'
+    protected int variableProtected; // violation, 'Missing a Javadoc comment'
+    int variablePackage; // violation, 'Missing a Javadoc comment'
+    private int variablePrivate; // violation, 'Missing a Javadoc comment'
+
+    public void testMethodInnerClass() {
+        // this check ignores local classes
+        class InnerClass {
+            public int innerClassVariablePublic;
+            protected int innerClassVariableProtected;
+            int innerClassVariablePackage;
+            private int innerClassVariablePrivate;
+        }
+        // this check ignores anonymous inner classes
+        Runnable runnable = new Runnable() {
+            public int innerClassVariablePublic;
+            protected int innerClassVariableProtected;
+            int innerClassVariablePackage;
+            private int innerClassVariablePrivate;
+            public void run()
+            {
+                System.identityHashCode("running");
+            }
+        };
+    }
+}

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadocvariable/InputJavadocVariableNoJavadoc2.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadocvariable/InputJavadocVariableNoJavadoc2.java
@@ -1,10 +1,8 @@
 /*
 JavadocVariable
-scope = protected
-excludeScope = (default)null
+accessModifiers = public, protected
 ignoreNamePattern = (default)null
 tokens = (default)ENUM_CONSTANT_DEF
-
 
 */
 
@@ -12,8 +10,8 @@ package com.puppycrawl.tools.checkstyle.checks.javadoc.javadocvariable;
 
 public class InputJavadocVariableNoJavadoc2 //comment test
 {
-    public int i1; // violation
-    protected int i2; // violation
+    public int i1; // violation, 'Missing a Javadoc comment'
+    protected int i2; // violation, 'Missing a Javadoc comment'
     int i3;
     private int i4;
 
@@ -23,8 +21,8 @@ public class InputJavadocVariableNoJavadoc2 //comment test
     private void foo4() {}
 
     protected class ProtectedInner {
-        public int i1; // violation
-        protected int i2; // violation
+        public int i1; // violation, 'Missing a Javadoc comment'
+        protected int i2; // violation, 'Missing a Javadoc comment'
         int i3;
         private int i4;
 
@@ -35,8 +33,8 @@ public class InputJavadocVariableNoJavadoc2 //comment test
     }
 
     class PackageInner {
-        public int i1;
-        protected int i2;
+        public int i1; // violation, 'Missing a Javadoc comment'
+        protected int i2; // violation, 'Missing a Javadoc comment'
         int i3;
         private int i4;
 
@@ -47,8 +45,8 @@ public class InputJavadocVariableNoJavadoc2 //comment test
     }
 
     private class PrivateInner {
-        public int i1;
-        protected int i2;
+        public int i1; // violation, 'Missing a Javadoc comment'
+        protected int i2; // violation, 'Missing a Javadoc comment'
         int i3;
         private int i4;
 
@@ -60,8 +58,8 @@ public class InputJavadocVariableNoJavadoc2 //comment test
 }
 
 class  PackageClass2 {
-    public int i1;
-    protected int i2;
+    public int i1; // violation, 'Missing a Javadoc comment'
+    protected int i2; // violation, 'Missing a Javadoc comment'
     int i3;
     private int i4;
 
@@ -71,8 +69,8 @@ class  PackageClass2 {
     private void foo4() {}
 
     public class PublicInner {
-        public int i1;
-        protected int i2;
+        public int i1; // violation, 'Missing a Javadoc comment'
+        protected int i2; // violation, 'Missing a Javadoc comment'
         int i3;
         private int i4;
 
@@ -83,8 +81,8 @@ class  PackageClass2 {
     }
 
     protected class ProtectedInner {
-        public int i1;
-        protected int i2;
+        public int i1; // violation, 'Missing a Javadoc comment'
+        protected int i2; // violation, 'Missing a Javadoc comment'
         int i3;
         private int i4;
 
@@ -95,8 +93,8 @@ class  PackageClass2 {
     }
 
     class PackageInner {
-        public int i1;
-        protected int i2;
+        public int i1; // violation, 'Missing a Javadoc comment'
+        protected int i2; // violation, 'Missing a Javadoc comment'
         int i3;
         private int i4;
 
@@ -107,8 +105,8 @@ class  PackageClass2 {
     }
 
     private class PrivateInner {
-        public int i1;
-        protected int i2;
+        public int i1; // violation, 'Missing a Javadoc comment'
+        protected int i2; // violation, 'Missing a Javadoc comment'
         int i3;
         private int i4;
 

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadocvariable/InputJavadocVariableNoJavadoc3.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadocvariable/InputJavadocVariableNoJavadoc3.java
@@ -1,10 +1,8 @@
 /*
 JavadocVariable
-scope = (default)private
-excludeScope = protected
+accessModifiers = package, private
 ignoreNamePattern = (default)null
 tokens = (default)ENUM_CONSTANT_DEF
-
 
 */
 
@@ -14,8 +12,8 @@ public class InputJavadocVariableNoJavadoc3 //comment test
 {
     public int i1;
     protected int i2;
-    int i3; // violation
-    private int i4; // violation
+    int i3; // violation, 'Missing a Javadoc comment'
+    private int i4;// violation, 'Missing a Javadoc comment'
 
     public void foo1() {}
     protected void foo2() {}
@@ -25,8 +23,8 @@ public class InputJavadocVariableNoJavadoc3 //comment test
     protected class ProtectedInner {
         public int i1;
         protected int i2;
-        int i3; // violation
-        private int i4; // violation
+        int i3; // violation, 'Missing a Javadoc comment'
+        private int i4;// violation, 'Missing a Javadoc comment'
 
         public void foo1() {}
         protected void foo2() {}
@@ -35,10 +33,10 @@ public class InputJavadocVariableNoJavadoc3 //comment test
     }
 
     class PackageInner {
-        public int i1; // violation
-        protected int i2; // violation
-        int i3; // violation
-        private int i4; // violation
+        public int i1;
+        protected int i2;
+        int i3; // violation, 'Missing a Javadoc comment'
+        private int i4; // violation, 'Missing a Javadoc comment'
 
         public void foo1() {}
         protected void foo2() {}
@@ -47,10 +45,10 @@ public class InputJavadocVariableNoJavadoc3 //comment test
     }
 
     private class PrivateInner {
-        public int i1; // violation
-        protected int i2; // violation
-        int i3; // violation
-        private int i4; // violation
+        public int i1;
+        protected int i2;
+        int i3; // violation, 'Missing a Javadoc comment'
+        private int i4; // violation, 'Missing a Javadoc comment'
 
         public void foo1() {}
         protected void foo2() {}
@@ -60,10 +58,10 @@ public class InputJavadocVariableNoJavadoc3 //comment test
 }
 
 class PackageClass3 {
-    public int i1; // violation
-    protected int i2; // violation
-    int i3; // violation
-    private int i4; // violation
+    public int i1;
+    protected int i2;
+    int i3; // violation, 'Missing a Javadoc comment'
+    private int i4; // violation, 'Missing a Javadoc comment'
 
     public void foo1() {}
     protected void foo2() {}
@@ -71,10 +69,10 @@ class PackageClass3 {
     private void foo4() {}
 
     public class PublicInner {
-        public int i1; // violation
-        protected int i2; // violation
-        int i3; // violation
-        private int i4; // violation
+        public int i1;
+        protected int i2;
+        int i3; // violation, 'Missing a Javadoc comment'
+        private int i4; // violation, 'Missing a Javadoc comment'
 
         public void foo1() {}
         protected void foo2() {}
@@ -83,10 +81,10 @@ class PackageClass3 {
     }
 
     protected class ProtectedInner {
-        public int i1; // violation
-        protected int i2; // violation
-        int i3; // violation
-        private int i4; // violation
+        public int i1;
+        protected int i2;
+        int i3; // violation, 'Missing a Javadoc comment'
+        private int i4; // violation, 'Missing a Javadoc comment'
 
         public void foo1() {}
         protected void foo2() {}
@@ -95,10 +93,10 @@ class PackageClass3 {
     }
 
     class PackageInner {
-        public int i1; // violation
-        protected int i2; // violation
-        int i3; // violation
-        private int i4; // violation
+        public int i1;
+        protected int i2;
+        int i3; // violation, 'Missing a Javadoc comment'
+        private int i4; // violation, 'Missing a Javadoc comment'
 
         public void foo1() {}
         protected void foo2() {}
@@ -107,10 +105,10 @@ class PackageClass3 {
     }
 
     private class PrivateInner {
-        public int i1; // violation
-        protected int i2; // violation
-        int i3; // violation
-        private int i4; // violation
+        public int i1;
+        protected int i2;
+        int i3; // violation, 'Missing a Javadoc comment'
+        private int i4; // violation, 'Missing a Javadoc comment'
 
         public void foo1() {}
         protected void foo2() {}

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadocvariable/InputJavadocVariableNoJavadoc4.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadocvariable/InputJavadocVariableNoJavadoc4.java
@@ -1,10 +1,8 @@
 /*
 JavadocVariable
-scope = (default)private
-excludeScope = (default)null
+accessModifiers = (default)public,protected,package,private
 ignoreNamePattern = log|logger
 tokens = (default)ENUM_CONSTANT_DEF
-
 
 */
 
@@ -12,10 +10,10 @@ package com.puppycrawl.tools.checkstyle.checks.javadoc.javadocvariable;
 
 public class InputJavadocVariableNoJavadoc4 //comment test
 {
-    public int i1; // violation
-    protected int i2; // violation
-    int i3; // violation
-    private int i4; // violation
+    public int i1; // violation, 'Missing a Javadoc comment'
+    protected int i2; // violation, 'Missing a Javadoc comment'
+    int i3; // violation, 'Missing a Javadoc comment'
+    private int i4; // violation, 'Missing a Javadoc comment'
 
     public void foo1() {}
     protected void foo2() {}
@@ -23,10 +21,10 @@ public class InputJavadocVariableNoJavadoc4 //comment test
     private void foo4() {}
 
     protected class ProtectedInner {
-        public int i1; // violation
-        protected int i2; // violation
-        int i3; // violation
-        private int i4; // violation
+        public int i1; // violation, 'Missing a Javadoc comment'
+        protected int i2; // violation, 'Missing a Javadoc comment'
+        int i3; // violation, 'Missing a Javadoc comment'
+        private int i4; // violation, 'Missing a Javadoc comment'
 
         public void foo1() {}
         protected void foo2() {}
@@ -35,10 +33,10 @@ public class InputJavadocVariableNoJavadoc4 //comment test
     }
 
     class PackageInner {
-        public int i1; // violation
-        protected int i2; // violation
-        int i3; // violation
-        private int i4; // violation
+        public int i1; // violation, 'Missing a Javadoc comment'
+        protected int i2; // violation, 'Missing a Javadoc comment'
+        int i3; // violation, 'Missing a Javadoc comment'
+        private int i4; // violation, 'Missing a Javadoc comment'
 
         public void foo1() {}
         protected void foo2() {}
@@ -47,10 +45,10 @@ public class InputJavadocVariableNoJavadoc4 //comment test
     }
 
     private class PrivateInner {
-        public int i1; // violation
-        protected int i2; // violation
-        int i3; // violation
-        private int i4; // violation
+        public int i1; // violation, 'Missing a Javadoc comment'
+        protected int i2; // violation, 'Missing a Javadoc comment'
+        int i3; // violation, 'Missing a Javadoc comment'
+        private int i4; // violation, 'Missing a Javadoc comment'
 
         public void foo1() {}
         protected void foo2() {}
@@ -60,10 +58,10 @@ public class InputJavadocVariableNoJavadoc4 //comment test
 }
 
 class PackageClass4 {
-    public int i1; // violation
-    protected int i2; // violation
-    int i3; // violation
-    private int i4; // violation
+    public int i1; // violation, 'Missing a Javadoc comment'
+    protected int i2; // violation, 'Missing a Javadoc comment'
+    int i3; // violation, 'Missing a Javadoc comment'
+    private int i4; // violation, 'Missing a Javadoc comment'
 
     public void foo1() {}
     protected void foo2() {}
@@ -71,10 +69,10 @@ class PackageClass4 {
     private void foo4() {}
 
     public class PublicInner {
-        public int i1; // violation
-        protected int i2; // violation
-        int i3; // violation
-        private int i4; // violation
+        public int i1; // violation, 'Missing a Javadoc comment'
+        protected int i2; // violation, 'Missing a Javadoc comment'
+        int i3; // violation, 'Missing a Javadoc comment'
+        private int i4; // violation, 'Missing a Javadoc comment'
 
         public void foo1() {}
         protected void foo2() {}
@@ -83,10 +81,10 @@ class PackageClass4 {
     }
 
     protected class ProtectedInner {
-        public int i1; // violation
-        protected int i2; // violation
-        int i3; // violation
-        private int i4; // violation
+        public int i1; // violation, 'Missing a Javadoc comment'
+        protected int i2; // violation, 'Missing a Javadoc comment'
+        int i3; // violation, 'Missing a Javadoc comment'
+        private int i4; // violation, 'Missing a Javadoc comment'
 
         public void foo1() {}
         protected void foo2() {}
@@ -95,10 +93,10 @@ class PackageClass4 {
     }
 
     class PackageInner {
-        public int i1; // violation
-        protected int i2; // violation
-        int i3; // violation
-        private int i4; // violation
+        public int i1; // violation, 'Missing a Javadoc comment'
+        protected int i2; // violation, 'Missing a Javadoc comment'
+        int i3; // violation, 'Missing a Javadoc comment'
+        private int i4; // violation, 'Missing a Javadoc comment'
 
         public void foo1() {}
         protected void foo2() {}
@@ -107,10 +105,10 @@ class PackageClass4 {
     }
 
     private class PrivateInner {
-        public int i1; // violation
-        protected int i2; // violation
-        int i3; // violation
-        private int i4; // violation
+        public int i1; // violation, 'Missing a Javadoc comment'
+        protected int i2; // violation, 'Missing a Javadoc comment'
+        int i3; // violation, 'Missing a Javadoc comment'
+        private int i4; // violation, 'Missing a Javadoc comment'
 
         public void foo1() {}
         protected void foo2() {}

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadocvariable/InputJavadocVariableNoJavadoc5.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadocvariable/InputJavadocVariableNoJavadoc5.java
@@ -1,10 +1,8 @@
 /*
 JavadocVariable
-scope = (default)private
-excludeScope = (default)null
+accessModifiers = (default)public,protected,package,private
 ignoreNamePattern =
 tokens = (default)ENUM_CONSTANT_DEF
-
 
 */
 
@@ -12,10 +10,10 @@ package com.puppycrawl.tools.checkstyle.checks.javadoc.javadocvariable;
 
 public class InputJavadocVariableNoJavadoc5 //comment test
 {
-    public int i1; // violation
-    protected int i2; // violation
-    int i3; // violation
-    private int i4; // violation
+    public int i1; // violation, 'Missing a Javadoc comment'
+    protected int i2; // violation, 'Missing a Javadoc comment'
+    int i3; // violation, 'Missing a Javadoc comment'
+    private int i4; // violation, 'Missing a Javadoc comment'
 
     public void foo1() {}
     protected void foo2() {}
@@ -23,10 +21,10 @@ public class InputJavadocVariableNoJavadoc5 //comment test
     private void foo4() {}
 
     protected class ProtectedInner {
-        public int i1; // violation
-        protected int i2; // violation
-        int i3; // violation
-        private int i4; // violation
+        public int i1; // violation, 'Missing a Javadoc comment'
+        protected int i2; // violation, 'Missing a Javadoc comment'
+        int i3; // violation, 'Missing a Javadoc comment'
+        private int i4; // violation, 'Missing a Javadoc comment'
 
         public void foo1() {}
         protected void foo2() {}
@@ -35,10 +33,10 @@ public class InputJavadocVariableNoJavadoc5 //comment test
     }
 
     class PackageInner {
-        public int i1; // violation
-        protected int i2; // violation
-        int i3; // violation
-        private int i4; // violation
+        public int i1; // violation, 'Missing a Javadoc comment'
+        protected int i2; // violation, 'Missing a Javadoc comment'
+        int i3; // violation, 'Missing a Javadoc comment'
+        private int i4; // violation, 'Missing a Javadoc comment'
 
         public void foo1() {}
         protected void foo2() {}
@@ -47,10 +45,10 @@ public class InputJavadocVariableNoJavadoc5 //comment test
     }
 
     private class PrivateInner {
-        public int i1; // violation
-        protected int i2; // violation
-        int i3; // violation
-        private int i4; // violation
+        public int i1; // violation, 'Missing a Javadoc comment'
+        protected int i2; // violation, 'Missing a Javadoc comment'
+        int i3; // violation, 'Missing a Javadoc comment'
+        private int i4; // violation, 'Missing a Javadoc comment'
 
         public void foo1() {}
         protected void foo2() {}
@@ -60,10 +58,10 @@ public class InputJavadocVariableNoJavadoc5 //comment test
 }
 
 class PackageClass5 {
-    public int i1; // violation
-    protected int i2; // violation
-    int i3; // violation
-    private int i4; // violation
+    public int i1; // violation, 'Missing a Javadoc comment'
+    protected int i2; // violation, 'Missing a Javadoc comment'
+    int i3; // violation, 'Missing a Javadoc comment'
+    private int i4; // violation, 'Missing a Javadoc comment'
 
     public void foo1() {}
     protected void foo2() {}
@@ -71,10 +69,10 @@ class PackageClass5 {
     private void foo4() {}
 
     public class PublicInner {
-        public int i1; // violation
-        protected int i2; // violation
-        int i3; // violation
-        private int i4; // violation
+        public int i1; // violation, 'Missing a Javadoc comment'
+        protected int i2; // violation, 'Missing a Javadoc comment'
+        int i3; // violation, 'Missing a Javadoc comment'
+        private int i4; // violation, 'Missing a Javadoc comment'
 
         public void foo1() {}
         protected void foo2() {}
@@ -83,10 +81,10 @@ class PackageClass5 {
     }
 
     protected class ProtectedInner {
-        public int i1; // violation
-        protected int i2; // violation
-        int i3; // violation
-        private int i4; // violation
+        public int i1; // violation, 'Missing a Javadoc comment'
+        protected int i2; // violation, 'Missing a Javadoc comment'
+        int i3; // violation, 'Missing a Javadoc comment'
+        private int i4; // violation, 'Missing a Javadoc comment'
 
         public void foo1() {}
         protected void foo2() {}
@@ -95,10 +93,10 @@ class PackageClass5 {
     }
 
     class PackageInner {
-        public int i1; // violation
-        protected int i2; // violation
-        int i3; // violation
-        private int i4; // violation
+        public int i1; // violation, 'Missing a Javadoc comment'
+        protected int i2; // violation, 'Missing a Javadoc comment'
+        int i3; // violation, 'Missing a Javadoc comment'
+        private int i4; // violation, 'Missing a Javadoc comment'
 
         public void foo1() {}
         protected void foo2() {}
@@ -107,10 +105,10 @@ class PackageClass5 {
     }
 
     private class PrivateInner {
-        public int i1; // violation
-        protected int i2; // violation
-        int i3; // violation
-        private int i4; // violation
+        public int i1; // violation, 'Missing a Javadoc comment'
+        protected int i2; // violation, 'Missing a Javadoc comment'
+        int i3; // violation, 'Missing a Javadoc comment'
+        private int i4; // violation, 'Missing a Javadoc comment'
 
         public void foo1() {}
         protected void foo2() {}
@@ -120,7 +118,7 @@ class PackageClass5 {
 
     class IgnoredName {
         // ignore by name
-        private int logger; // violation
+        private int logger; // violation, 'Missing a Javadoc comment'
         // no warning, 'serialVersionUID' fields do not require Javadoc
         private static final long serialVersionUID = 0;
     }

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadocvariable/InputJavadocVariableNoJavadocNeededInLambda.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadocvariable/InputJavadocVariableNoJavadocNeededInLambda.java
@@ -1,10 +1,8 @@
 /*
 JavadocVariable
-scope = (default)private
-excludeScope = (default)null
+accessModifiers = (default)public,protected,package,private
 ignoreNamePattern = (default)null
 tokens = (default)ENUM_CONSTANT_DEF
-
 
 */
 
@@ -13,7 +11,8 @@ package com.puppycrawl.tools.checkstyle.checks.javadoc.javadocvariable;
 import java.util.function.Function;
 
 public class InputJavadocVariableNoJavadocNeededInLambda {
-    private static final Function<String, String> FUNCTION1 = (String it) -> { // violation
+    // violation below, 'Missing a Javadoc comment'
+    private static final Function<String, String> FUNCTION1 = (String it) -> {
         String stuff = it;
         return stuff + it;
     };

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadocvariable/InputJavadocVariableOnInnerClassFields.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadocvariable/InputJavadocVariableOnInnerClassFields.java
@@ -1,10 +1,8 @@
 /*
 JavadocVariable
-scope = (default)private
-excludeScope = (default)null
+accessModifiers = (default)public,protected,package,private
 ignoreNamePattern = (default)null
 tokens = (default)ENUM_CONSTANT_DEF
-
 
 */
 
@@ -12,10 +10,10 @@ package com.puppycrawl.tools.checkstyle.checks.javadoc.javadocvariable;
 
 public class InputJavadocVariableOnInnerClassFields //comment test
 {
-    public int i1; // violation
-    protected int i2; // violation
-    int i3; // violation
-    private int i4; // violation
+    public int i1; // violation, 'Missing a Javadoc comment'
+    protected int i2; // violation, 'Missing a Javadoc comment'
+    int i3; // violation, 'Missing a Javadoc comment'
+    private int i4; // violation, 'Missing a Javadoc comment'
 
     public void foo1() {}
     protected void foo2() {}
@@ -23,10 +21,10 @@ public class InputJavadocVariableOnInnerClassFields //comment test
     private void foo4() {}
 
     protected class ProtectedInner {
-        public int i1; // violation
-        protected int i2; // violation
-        int i3; // violation
-        private int i4; // violation
+        public int i1; // violation, 'Missing a Javadoc comment'
+        protected int i2; // violation, 'Missing a Javadoc comment'
+        int i3; // violation, 'Missing a Javadoc comment'
+        private int i4; // violation, 'Missing a Javadoc comment'
 
         public void foo1() {}
         protected void foo2() {}
@@ -35,10 +33,10 @@ public class InputJavadocVariableOnInnerClassFields //comment test
     }
 
     class PackageInner {
-        public int i1; // violation
-        protected int i2; // violation
-        int i3; // violation
-        private int i4; // violation
+        public int i1; // violation, 'Missing a Javadoc comment'
+        protected int i2; // violation, 'Missing a Javadoc comment'
+        int i3; // violation, 'Missing a Javadoc comment'
+        private int i4; // violation, 'Missing a Javadoc comment'
 
         public void foo1() {}
         protected void foo2() {}
@@ -47,10 +45,10 @@ public class InputJavadocVariableOnInnerClassFields //comment test
     }
 
     private class PrivateInner {
-        public int i1; // violation
-        protected int i2; // violation
-        int i3; // violation
-        private int i4; // violation
+        public int i1; // violation, 'Missing a Javadoc comment'
+        protected int i2; // violation, 'Missing a Javadoc comment'
+        int i3; // violation, 'Missing a Javadoc comment'
+        private int i4; // violation, 'Missing a Javadoc comment'
 
         public void foo1() {}
         protected void foo2() {}

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadocvariable/InputJavadocVariableOnPublicInnerClassFields.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadocvariable/InputJavadocVariableOnPublicInnerClassFields.java
@@ -1,20 +1,18 @@
 /*
 JavadocVariable
-scope = (default)private
-excludeScope = (default)null
+accessModifiers = (default)public,protected,package,private
 ignoreNamePattern = (default)null
 tokens = (default)ENUM_CONSTANT_DEF
-
 
 */
 
 package com.puppycrawl.tools.checkstyle.checks.javadoc.javadocvariable;
 
 public class InputJavadocVariableOnPublicInnerClassFields {
-    public int i1; // violation
-    protected int i2; // violation
-    int i3; // violation
-    private int i4; // violation
+    public int i1; // violation, 'Missing a Javadoc comment'
+    protected int i2; // violation, 'Missing a Javadoc comment'
+    int i3; // violation, 'Missing a Javadoc comment'
+    private int i4; // violation, 'Missing a Javadoc comment'
 
     public void foo1() {}
     protected void foo2() {}
@@ -22,10 +20,10 @@ public class InputJavadocVariableOnPublicInnerClassFields {
     private void foo4() {}
 
     public class PublicInner {
-        public int i1; // violation
-        protected int i2; // violation
-        int i3; // violation
-        private int i4; // violation
+        public int i1; // violation, 'Missing a Javadoc comment'
+        protected int i2; // violation, 'Missing a Javadoc comment'
+        int i3; // violation, 'Missing a Javadoc comment'
+        private int i4; // violation, 'Missing a Javadoc comment'
 
         public void foo1() {}
         protected void foo2() {}
@@ -34,10 +32,10 @@ public class InputJavadocVariableOnPublicInnerClassFields {
     }
 
     protected class ProtectedInner {
-        public int i1; // violation
-        protected int i2; // violation
-        int i3; // violation
-        private int i4; // violation
+        public int i1; // violation, 'Missing a Javadoc comment'
+        protected int i2; // violation, 'Missing a Javadoc comment'
+        int i3; // violation, 'Missing a Javadoc comment'
+        private int i4; // violation, 'Missing a Javadoc comment'
 
         public void foo1() {}
         protected void foo2() {}
@@ -46,10 +44,10 @@ public class InputJavadocVariableOnPublicInnerClassFields {
     }
 
     class PackageInner {
-        public int i1; // violation
-        protected int i2; // violation
-        int i3; // violation
-        private int i4; // violation
+        public int i1; // violation, 'Missing a Javadoc comment'
+        protected int i2; // violation, 'Missing a Javadoc comment'
+        int i3; // violation, 'Missing a Javadoc comment'
+        private int i4; // violation, 'Missing a Javadoc comment'
 
         public void foo1() {}
         protected void foo2() {}
@@ -58,10 +56,10 @@ public class InputJavadocVariableOnPublicInnerClassFields {
     }
 
     private class PrivateInner {
-        public int i1; // violation
-        protected int i2; // violation
-        int i3; // violation
-        private int i4; // violation
+        public int i1; // violation, 'Missing a Javadoc comment'
+        protected int i2; // violation, 'Missing a Javadoc comment'
+        int i3; // violation, 'Missing a Javadoc comment'
+        private int i4; // violation, 'Missing a Javadoc comment'
 
         public void foo1() {}
         protected void foo2() {}
@@ -71,7 +69,7 @@ public class InputJavadocVariableOnPublicInnerClassFields {
 
     class IgnoredName {
 
-        private int logger; // violation
+        private int logger; // violation, 'Missing a Javadoc comment'
         // no warning, 'serialVersionUID' fields do not require Javadoc
         private static final long serialVersionUID = 0;
     }

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadocvariable/InputJavadocVariablePublicOnly.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadocvariable/InputJavadocVariablePublicOnly.java
@@ -1,10 +1,8 @@
 /*
 JavadocVariable
-scope = (default)private
-excludeScope = (default)null
+accessModifiers = (default)public,protected,package,private
 ignoreNamePattern = (default)null
 tokens = (default)ENUM_CONSTANT_DEF
-
 
 */
 
@@ -14,12 +12,12 @@ public class InputJavadocVariablePublicOnly // ignore - need javadoc
 {
     private interface InnerInterface // ignore - when not relaxed about Javadoc
     {
-        String CONST = "InnerInterface"; // violation
+        String CONST = "InnerInterface"; // violation, 'Missing a Javadoc comment'
         void method(); // ignore - when not relaxed about Javadoc
 
         class InnerInnerClass // ignore - when not relaxed about Javadoc
         {
-            private int mData; // violation
+            private int mData; // violation, 'Missing a Javadoc comment'
 
             private InnerInnerClass()
             {
@@ -39,17 +37,17 @@ public class InputJavadocVariablePublicOnly // ignore - need javadoc
 
     private class InnerClass // ignore
     {
-        private int mDiff; // violation
+        private int mDiff; // violation, 'Missing a Javadoc comment'
 
         void method() // ignore - when not relaxed about Javadoc
         {
         }
     }
 
-    private int mSize; // violation
-    int mLen; // violation
-    protected int mDeer; // violation
-    public int aFreddo; // violation
+    private int mSize; // violation, 'Missing a Javadoc comment'
+    int mLen; // violation, 'Missing a Javadoc comment'
+    protected int mDeer; // violation, 'Missing a Javadoc comment'
+    public int aFreddo; // violation, 'Missing a Javadoc comment'
 
     // ignore - need Javadoc
     private InputJavadocVariablePublicOnly(int aA)

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadocvariable/InputJavadocVariablePublicOnly2.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadocvariable/InputJavadocVariablePublicOnly2.java
@@ -1,10 +1,8 @@
 /*
 JavadocVariable
-scope = public
-excludeScope = (default)null
+accessModifiers = public
 ignoreNamePattern = (default)null
 tokens = (default)ENUM_CONSTANT_DEF
-
 
 */
 
@@ -14,7 +12,7 @@ public class InputJavadocVariablePublicOnly2 // ignore - need javadoc
 {
     private interface InnerInterface // ignore - when not relaxed about Javadoc
     {
-        String CONST = "InnerInterface"; // ignore - w.n.r.a.j
+        String CONST = "InnerInterface"; // violation, 'Missing a Javadoc comment'
         void method(); // ignore - when not relaxed about Javadoc
 
         class InnerInnerClass // ignore - when not relaxed about Javadoc
@@ -49,7 +47,7 @@ public class InputJavadocVariablePublicOnly2 // ignore - need javadoc
     private int mSize; // ignore - when not relaxed about Javadoc
     int mLen; // ignore - when not relaxed about Javadoc
     protected int mDeer; // ignore
-    public int aFreddo; // violation
+    public int aFreddo; // violation, 'Missing a Javadoc comment'
 
     // ignore - need Javadoc
     private InputJavadocVariablePublicOnly2(int aA)

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadocvariable/InputJavadocVariableTags.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadocvariable/InputJavadocVariableTags.java
@@ -1,10 +1,8 @@
 /*
 JavadocVariable
-scope = (default)private
-excludeScope = (default)null
+accessModifiers = (default)public,protected,package,private
 ignoreNamePattern = (default)null
 tokens = (default)ENUM_CONSTANT_DEF
-
 
 */
 
@@ -15,7 +13,7 @@ import java.io.IOException;
 class InputJavadocVariableTags1
 {
     // Invalid - should be Javadoc
-    private int mMissingJavadoc; // violation
+    private int mMissingJavadoc; // violation, 'Missing a Javadoc comment'
 
     // Invalid - should be Javadoc
     void method1()
@@ -308,14 +306,14 @@ class InputJavadocVariableTags1
 
 enum InputJavadocVariableTagsEnum
 {
-    CONSTANT_A, // violation
+    CONSTANT_A, // violation, 'Missing a Javadoc comment
 
     /**
      *
      */
     CONSTANT_B,
 
-    CONSTANT_C // violation
+    CONSTANT_C // violation, 'Missing a Javadoc comment'
     {
         /**
          *
@@ -334,7 +332,7 @@ enum InputJavadocVariableTagsEnum
 @interface InputJavadocVariableTagsAnnotation
 {
     String someField();
-    int A_CONSTANT = 0; // violation
+    int A_CONSTANT = 0; // violation, 'Missing a Javadoc comment'
     /** Some javadoc. */
     int B_CONSTANT = 1;
     /** @return This tag is valid here and expected with Java 8 */

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/utils/checkutil/InputCheckUtilTest.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/utils/checkutil/InputCheckUtilTest.java
@@ -71,4 +71,8 @@ public class InputCheckUtilTest<V, C> {
     public interface Example {
         void method();
     }
+
+    enum Enum {
+        A;
+    }
 }

--- a/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocVariableCheckExamplesTest.java
+++ b/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocVariableCheckExamplesTest.java
@@ -54,8 +54,8 @@ public class JavadocVariableCheckExamplesTest extends AbstractExamplesModuleTest
     @Test
     public void testExample3() throws Exception {
         final String[] expected = {
-            "15:3: " + getCheckMessage(MSG_JAVADOC_MISSING),
-            "23:15: " + getCheckMessage(MSG_JAVADOC_MISSING),
+            "14:3: " + getCheckMessage(MSG_JAVADOC_MISSING),
+            "22:15: " + getCheckMessage(MSG_JAVADOC_MISSING),
         };
 
         verifyWithInlineConfigParser(getPath("Example3.java"), expected);

--- a/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadocvariable/Example1.java
+++ b/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadocvariable/Example1.java
@@ -9,15 +9,15 @@ package com.puppycrawl.tools.checkstyle.checks.javadoc.javadocvariable;
 
 // xdoc section -- start
 public class Example1 {
-  private int a; // violation
+  private int a; // violation, 'Missing a Javadoc comment'
 
   /**
    * Some description here
    */
   private int b;
-  protected int c; // violation
-  public int d; // violation
-  /*package*/ int e; // violation
+  protected int c; // violation, 'Missing a Javadoc comment'
+  public int d; // violation, 'Missing a Javadoc comment'
+  /*package*/ int e; // violation, 'Missing a Javadoc comment'
 
 }
 // xdoc section -- end

--- a/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadocvariable/Example2.java
+++ b/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadocvariable/Example2.java
@@ -2,7 +2,7 @@
 <module name="Checker">
   <module name="TreeWalker">
     <module name="JavadocVariable">
-      <property name="scope" value="public"/>
+      <property name="accessModifiers" value="public"/>
     </module>
   </module>
 </module>
@@ -18,7 +18,7 @@ public class Example2 {
    */
   private int b;
   protected int c;
-  public int d; // violation
+  public int d; // violation, 'Missing a Javadoc comment'
   /*package*/ int e;
 }
 // xdoc section -- end

--- a/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadocvariable/Example3.java
+++ b/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadocvariable/Example3.java
@@ -2,8 +2,7 @@
 <module name="Checker">
   <module name="TreeWalker">
     <module name="JavadocVariable">
-      <property name="scope" value="private"/>
-      <property name="excludeScope" value="protected"/>
+      <property name="accessModifiers" value="private,package"/>
     </module>
   </module>
 </module>
@@ -12,7 +11,7 @@ package com.puppycrawl.tools.checkstyle.checks.javadoc.javadocvariable;
 
 // xdoc section -- start
 public class Example3 {
-  private int a; // violation
+  private int a; // violation, 'Missing a Javadoc comment'
 
   /**
    * Some description here
@@ -20,6 +19,6 @@ public class Example3 {
   private int b;
   protected int c;
   public int d;
-  /*package*/ int e; // violation
+  /*package*/ int e; // violation, 'Missing a Javadoc comment'
 }
 // xdoc section -- end

--- a/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadocvariable/Example4.java
+++ b/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadocvariable/Example4.java
@@ -11,14 +11,14 @@ package com.puppycrawl.tools.checkstyle.checks.javadoc.javadocvariable;
 
 // xdoc section -- start
 public class Example4 {
-  private int a; // violation
+  private int a; // violation, 'Missing a Javadoc comment'
 
   /**
    * Some description here
   */
   private int b;
-  protected int c; // violation
-  public int d; // violation
-  /*package*/ int e; // violation
+  protected int c; // violation, 'Missing a Javadoc comment'
+  public int d; // violation, 'Missing a Javadoc comment'
+  /*package*/ int e; // violation, 'Missing a Javadoc comment'
 }
 // xdoc section -- end

--- a/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadocvariable/Example5.java
+++ b/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadocvariable/Example5.java
@@ -1,0 +1,40 @@
+/*xml
+<module name="Checker">
+  <module name="TreeWalker">
+    <module name="JavadocVariable"/>
+  </module>
+</module>
+*/
+package com.puppycrawl.tools.checkstyle.checks.javadoc.javadocvariable;
+
+// xdoc section -- start
+public class Example5 {
+  public int variablePublic; // violation, 'Missing a Javadoc comment'
+  protected int variableProtected; // violation, 'Missing a Javadoc comment'
+  int variablePackage; // violation, 'Missing a Javadoc comment'
+  private int variablePrivate; // violation, 'Missing a Javadoc comment'
+
+  public void testMethodInnerClass() {
+
+    // This check ignores local classes.
+    class InnerClass {
+      public int innerClassVariablePublic;
+      protected int innerClassVariableProtected;
+      int innerClassVariablePackage;
+      private int innerClassVariablePrivate;
+    }
+
+    // This check ignores anonymous inner classes.
+    Runnable runnable = new Runnable() {
+      public int innerClassVariablePublic;
+      protected int innerClassVariableProtected;
+      int innerClassVariablePackage;
+      private int innerClassVariablePrivate;
+      public void run()
+        {
+          System.identityHashCode("running");
+        }
+    };
+  }
+}
+// xdoc section -- end


### PR DESCRIPTION
> [!CAUTION]
> Breaking change

Aims to close #9280 
This PR removes `scope` and `excludeScope` from [JavadocVariableCheck](https://checkstyle.org/checks/javadoc/javadocvariable.html#JavadocVariable) while substitutes with new `accessModifers` property.
