### PR TITLE
Issue #13213: remove //ok from commentsindentation

### DIFF
--- a/config/checkstyle-input-suppressions.xml
+++ b/config/checkstyle-input-suppressions.xml
@@ -76,14 +76,6 @@
   <suppress id="UnnecessaryOkComment"
             files="checks[\\/]coding[\\/]unnecessarysemicolonaftertypememberdeclaration[\\/]InputUnnecessarySemicolonAfterTypeMemberDeclarationNullAst.java"/>
   <suppress id="UnnecessaryOkComment"
-            files="checks[\\/]indentation[\\/]commentsindentation[\\/]InputCommentsIndentationCommentsAfterMethodCall.java"/>
-  <suppress id="UnnecessaryOkComment"
-            files="checks[\\/]indentation[\\/]commentsindentation[\\/]InputCommentsIndentationCommentsAfterMethodCall.java"/>
-  <suppress id="UnnecessaryOkComment"
-            files="checks[\\/]indentation[\\/]commentsindentation[\\/]InputCommentsIndentationCommentsAfterMethodCall.java"/>
-  <suppress id="UnnecessaryOkComment"
-            files="checks[\\/]indentation[\\/]commentsindentation[\\/]InputCommentsIndentationWithInMethodCallWithSameIndent.java"/>
-  <suppress id="UnnecessaryOkComment"
             files="checks[\\/]javadoc[\\/]abstractjavadoc[\\/]InputAbstractJavadocCustomTag.java"/>
   <suppress id="UnnecessaryOkComment"
             files="checks[\\/]javadoc[\\/]abstractjavadoc[\\/]InputAbstractJavadocCustomTag.java"/>

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/indentation/commentsindentation/InputCommentsIndentationCommentsAfterMethodCall.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/indentation/commentsindentation/InputCommentsIndentationCommentsAfterMethodCall.java
@@ -11,14 +11,14 @@ package com.puppycrawl.tools.checkstyle.checks.indentation.commentsindentation;
 public class InputCommentsIndentationCommentsAfterMethodCall {
     public static void main() {
         InputCommentsIndentationCommentsAfterMethodCall.flatMap(4,5)
-           // ok
+           // Correct indentation for this method call chain
            .flatMap()
            .flatMap();
-        // ok
+        // Correct indentation for standalone comment
     }
     public static void main1() {
         InputCommentsIndentationCommentsAfterMethodCall.flatMap(4,5)
-                // ok
+                // Correct indentation for this method call chain
                 .flatMap()
                 .flatMap();
                // violation '.* incorrect .* level 15, expected is 8, .* same .* as line 20.'

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/indentation/commentsindentation/InputCommentsIndentationWithInMethodCallWithSameIndent.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/indentation/commentsindentation/InputCommentsIndentationWithInMethodCallWithSameIndent.java
@@ -13,7 +13,7 @@ public class InputCommentsIndentationWithInMethodCallWithSameIndent {
         // Some comment here
         s1,
         s2
-        // ok
+        // Correct indentation for this comment
     );
 
     private final boolean isEqualsTwo = equals(


### PR DESCRIPTION
Worked on Issue #13213: removed //ok from "commentsindentation" module and replaced them with proper comment messages.