### PR TITLE
Issue #15456: Specify violation messages for nested for loops depth

### DIFF
--- a/src/test/java/com/puppycrawl/tools/checkstyle/bdd/InlineConfigParser.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/bdd/InlineConfigParser.java
@@ -226,7 +226,6 @@ public final class InlineConfigParser {
             "com.puppycrawl.tools.checkstyle.checks.coding.MissingSwitchDefaultCheck",
             "com.puppycrawl.tools.checkstyle.checks.coding.ModifiedControlVariableCheck",
             "com.puppycrawl.tools.checkstyle.checks.coding.MultipleStringLiteralsCheck",
-            "com.puppycrawl.tools.checkstyle.checks.coding.NestedForDepthCheck",
             "com.puppycrawl.tools.checkstyle.checks.coding.NestedIfDepthCheck",
             "com.puppycrawl.tools.checkstyle.checks.coding.NestedTryDepthCheck",
             "com.puppycrawl.tools.checkstyle.checks.coding.NoArrayTrailingCommaCheck",

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/coding/NestedForDepthCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/coding/NestedForDepthCheckTest.java
@@ -47,9 +47,9 @@ public class NestedForDepthCheckTest extends AbstractModuleTestSupport {
     public void testNestedForDepthCheckCustomMaxLevelTwo() throws Exception {
 
         final String[] expected = {
-            "32:11: " + getCheckMessage(MSG_KEY, 3, 2),
-            "33:13: " + getCheckMessage(MSG_KEY, 4, 2),
-            "36:13: " + getCheckMessage(MSG_KEY, 4, 2),
+            "33:11: " + getCheckMessage(MSG_KEY, 3, 2),
+            "35:13: " + getCheckMessage(MSG_KEY, 4, 2),
+            "39:13: " + getCheckMessage(MSG_KEY, 5, 2),
         };
 
         verifyWithInlineConfigParser(
@@ -69,8 +69,10 @@ public class NestedForDepthCheckTest extends AbstractModuleTestSupport {
      */
     @Test
     public void testNestedForDepthCheckCustomMaxLevelFour() throws Exception {
+        final String[] expected = {
+            "39:9: " + getCheckMessage(MSG_KEY, 5, 4),
+        };
 
-        final String[] expected = CommonUtil.EMPTY_STRING_ARRAY;
 
         verifyWithInlineConfigParser(
                 getPath("InputNestedForDepthCheckCustomMaxLevelFour.java"),
@@ -94,7 +96,7 @@ public class NestedForDepthCheckTest extends AbstractModuleTestSupport {
     @Test
     public void testNestedForDepthCheckDefaultMaxLevel() throws Exception {
         final String[] expected = {
-            "27:9: " + getCheckMessage(MSG_KEY, 2, 1),
+            "28:9: " + getCheckMessage(MSG_KEY, 2, 1),
         };
 
         verifyWithInlineConfigParser(

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/nestedfordepth/InputNestedForDepthCheckCustomMaxLevelFour.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/nestedfordepth/InputNestedForDepthCheckCustomMaxLevelFour.java
@@ -36,6 +36,7 @@ public class InputNestedForDepthCheckCustomMaxLevelFour {
             for (int i5a = 0; i5a < 10; i5a++) {
                 i += 1;
               }
+             // violation above 'Nested for depth is 5 (max allowed is 4)'
           }
         }
       }

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/nestedfordepth/InputNestedForDepthCheckCustomMaxLevelTwo.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/nestedfordepth/InputNestedForDepthCheckCustomMaxLevelTwo.java
@@ -29,11 +29,14 @@ public class InputNestedForDepthCheckCustomMaxLevelTwo {
     for (i1 = 0; i1 < 10; i1++) {
       for (i2 = 0; i2 < 10; i2++) {
         for (i3 = 0; i3 < 10; i3++) {
-          for (i4 = 0; i4 < 10; i4++) { // violation
-            for (i5 = 0; i5 < 10; i5++) { // violation
+          for (i4 = 0; i4 < 10; i4++) {
+            // violation above 'Nested for depth is 3 (max allowed is 2)'
+            for (i5 = 0; i5 < 10; i5++) {
+              // violation above 'Nested for depth is 4 (max allowed is 2)'
               i += 1;
             }
-            for (int i5a = 0; i5a < 10; i5a++) { // violation
+            for (int i5a = 0; i5a < 10; i5a++) {
+              // violation above 'Nested for depth is 5 (max allowed is 2)'
                 i += 1;
               }
           }


### PR DESCRIPTION
Specified violation massages for nested for loops depth for each of the depth tests provided which are 1,2,and 4.