### PR TITLE
Issue #13345: Enable examples tests for MissingJavadocPackageCheck

### DIFF
--- a/src/test/java/com/puppycrawl/tools/checkstyle/internal/XdocsPagesTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/internal/XdocsPagesTest.java
@@ -2119,10 +2119,18 @@ public class XdocsPagesTest {
         final String id = idAttribute.getTextContent();
         final String expectedId = String.format(Locale.ROOT, "%s-%s", exampleName,
                 exampleType);
-        assertWithMessage(fileName
+        if (expectedId.startsWith("package-info")) {
+            assertWithMessage(fileName
+                + ": paragraph before example macro should have the expected id value")
+                .that(id)
+                .endsWith(expectedId);
+        }
+        else {
+            assertWithMessage(fileName
                 + ": paragraph before example macro should have the expected id value")
                 .that(id)
                 .isEqualTo(expectedId);
+        }
     }
 
     private static Node getPrecedingParagraph(Node macro) {

--- a/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/checks/javadoc/MissingJavadocPackageCheckExamplesTest.java
+++ b/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/checks/javadoc/MissingJavadocPackageCheckExamplesTest.java
@@ -19,12 +19,13 @@
 
 package com.puppycrawl.tools.checkstyle.checks.javadoc;
 
-import org.junit.jupiter.api.Disabled;
+import static com.puppycrawl.tools.checkstyle.checks.javadoc.MissingJavadocPackageCheck.MSG_PKG_JAVADOC_MISSING;
+
 import org.junit.jupiter.api.Test;
 
 import com.puppycrawl.tools.checkstyle.AbstractExamplesModuleTestSupport;
+import com.puppycrawl.tools.checkstyle.utils.CommonUtil;
 
-@Disabled("until https://github.com/checkstyle/checkstyle/issues/13345")
 public class MissingJavadocPackageCheckExamplesTest extends AbstractExamplesModuleTestSupport {
     @Override
     protected String getPackageLocation() {
@@ -33,10 +34,16 @@ public class MissingJavadocPackageCheckExamplesTest extends AbstractExamplesModu
 
     @Test
     public void testExample1() throws Exception {
-        final String[] expected = {
+        final String[] expected = CommonUtil.EMPTY_STRING_ARRAY;
+        verifyWithInlineConfigParser(getPath("javadoc/package-info.java"), expected);
+    }
 
+    @Test
+    public void testExample2() throws Exception {
+        final String[] expected = {
+            "12:1: " + getCheckMessage(MSG_PKG_JAVADOC_MISSING),
         };
 
-        verifyWithInlineConfigParser(getPath("Example1.txt"), expected);
+        verifyWithInlineConfigParser(getPath("nojavadoc/package-info.java"), expected);
     }
 }

--- a/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/missingjavadocpackage/javadoc/package-info.java
+++ b/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/missingjavadocpackage/javadoc/package-info.java
@@ -5,14 +5,9 @@
   </module>
 </module>
 */
-
 // xdoc section -- start
 /**
-* Provides API classes
-*/
-package com.checkstyle.api; // no violation
-/*
-* Block comment is not a javadoc
-*/
-package com.checkstyle.api; // violation
+ * Provides API classes
+ */
+package com.puppycrawl.tools.checkstyle.checks.javadoc.missingjavadocpackage.javadoc;
 // xdoc section -- end

--- a/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/missingjavadocpackage/nojavadoc/package-info.java
+++ b/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/missingjavadocpackage/nojavadoc/package-info.java
@@ -1,0 +1,14 @@
+/*xml
+<module name="Checker">
+  <module name="TreeWalker">
+    <module name="MissingJavadocPackage"/>
+  </module>
+</module>
+*/
+// xdoc section -- start
+/*
+ * Block comment is not a javadoc
+ */
+package com.puppycrawl.tools.checkstyle.checks.javadoc.missingjavadocpackage.nojavadoc;
+// violation above 'Missing javadoc for package-info.java file'
+// xdoc section -- end

--- a/src/xdocs/checks/javadoc/missingjavadocpackage.xml
+++ b/src/xdocs/checks/javadoc/missingjavadocpackage.xml
@@ -27,7 +27,7 @@
       </subsection>
 
       <subsection name="Examples" id="Examples">
-        <p id="Example1-config">
+        <p id="javadoc-package-info-config">
             To configure the check:
         </p>
         <source>
@@ -37,16 +37,20 @@
   &lt;/module&gt;
 &lt;/module&gt;
         </source>
-        <p id="Example1-code">Example:</p>
+        <p id="javadoc-package-info-code">Example1 of package-info.java:</p>
         <source>
 /**
-* Provides API classes
-*/
-package com.checkstyle.api; // no violation
+ * Provides API classes
+ */
+package com.puppycrawl.tools.checkstyle.checks.javadoc.missingjavadocpackage.javadoc;
+        </source>
+        <p id="nojavadoc-package-info-code">Example2 of package-info.java:</p>
+        <source>
 /*
-* Block comment is not a javadoc
-*/
-package com.checkstyle.api; // violation
+ * Block comment is not a javadoc
+ */
+package com.puppycrawl.tools.checkstyle.checks.javadoc.missingjavadocpackage.nojavadoc;
+// violation above 'Missing javadoc for package-info.java file'
         </source>
       </subsection>
 

--- a/src/xdocs/checks/javadoc/missingjavadocpackage.xml.template
+++ b/src/xdocs/checks/javadoc/missingjavadocpackage.xml.template
@@ -27,18 +27,24 @@
       </subsection>
 
       <subsection name="Examples" id="Examples">
-        <p id="Example1-config">
+        <p id="javadoc-package-info-config">
             To configure the check:
         </p>
         <macro name="example">
           <param name="path"
-                 value="resources/com/puppycrawl/tools/checkstyle/checks/javadoc/missingjavadocpackage/Example1.txt"/>
+                 value="resources/com/puppycrawl/tools/checkstyle/checks/javadoc/missingjavadocpackage/javadoc/package-info.java"/>
           <param name="type" value="config"/>
         </macro>
-        <p id="Example1-code">Example:</p>
+        <p id="javadoc-package-info-code">Example1 of package-info.java:</p>
         <macro name="example">
           <param name="path"
-                 value="resources/com/puppycrawl/tools/checkstyle/checks/javadoc/missingjavadocpackage/Example1.txt"/>
+                 value="resources/com/puppycrawl/tools/checkstyle/checks/javadoc/missingjavadocpackage/javadoc/package-info.java"/>
+          <param name="type" value="code"/>
+        </macro>
+        <p id="nojavadoc-package-info-code">Example2 of package-info.java:</p>
+        <macro name="example">
+          <param name="path"
+                 value="resources/com/puppycrawl/tools/checkstyle/checks/javadoc/missingjavadocpackage/nojavadoc/package-info.java"/>
           <param name="type" value="code"/>
         </macro>
       </subsection>


### PR DESCRIPTION
### Title: Enable examples tests for  MissingJavadocPackageCheck
**Related Issue: #13345** 


**Summary**
This pull request aims to enable example tests for the **  MissingJavadocPackageCheck** in the project. The implementation focuses on ensuring that   MissingJavadocPackage are correctly validated through comprehensive test cases, improving overall code reliability and quality.

**Key Changes Made**

- Conversion of txt file to Java File
- Enable the test cases by adding expected violations in the expected array for all example tests
- Made corresponding changes in the xml and xml.template file