### PR TITLE
Issue #15939: false-positive for text-block-literal at indentation fix

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/indentation/LineWrappingHandler.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/indentation/LineWrappingHandler.java
@@ -164,7 +164,8 @@ public class LineWrappingHandler {
 
         for (DetailAST node : firstNodesOnLines.values()) {
             final int currentType = node.getType();
-            if (checkForNullParameterChild(node) || checkForMethodLparenNewLine(node)) {
+            if (checkForNullParameterChild(node) || checkForMethodLparenNewLine(node)
+                    || !shouldProcessTextBlockLiteral(node)) {
                 continue;
             }
             if (currentType == TokenTypes.RPAREN) {
@@ -270,6 +271,18 @@ public class LineWrappingHandler {
             curNode = getNextCurNode(curNode);
         }
         return result;
+    }
+
+    /**
+     * Checks whether indentation of {@code TEXT_BLOCK_LITERAL_END}
+     *     needs to be checked. Yes if it is first on start of the line.
+     *
+     * @param node the node
+     * @return true if node is line-starting node.
+     */
+    private boolean shouldProcessTextBlockLiteral(DetailAST node) {
+        return node.getType() != TokenTypes.TEXT_BLOCK_LITERAL_END
+                || expandedTabsColumnNo(node) == getLineStart(node);
     }
 
     /**

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/indentation/IndentationCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/indentation/IndentationCheckTest.java
@@ -1099,6 +1099,25 @@ public class IndentationCheckTest extends AbstractModuleTestSupport {
     }
 
     @Test
+    public void testTextBlockLiteral() throws Exception {
+        final DefaultConfiguration checkConfig = createModuleConfig(IndentationCheck.class);
+
+        checkConfig.addProperty("lineWrappingIndentation", "4");
+        checkConfig.addProperty("forceStrictCondition", "true");
+        checkConfig.addProperty("tabWidth", "4");
+        final String[] expected = {
+            "18:1: " + getCheckMessage(MSG_ERROR, "\"\"\"", 0, 8),
+            "28:17: " + getCheckMessage(MSG_ERROR, "\"\"\"", 16, 12),
+            "44:1: " + getCheckMessage(MSG_ERROR, "\"\"\"", 0, 12),
+            "50:1: " + getCheckMessage(MSG_ERROR, "\"\"\"", 0, 12),
+            "55:9: " + getCheckMessage(MSG_ERROR, "\"\"\"", 8, 12),
+            "73:15: " + getCheckMessage(MSG_ERROR, "\"\"\"", 14, 12),
+        };
+        verify(checkConfig, getNonCompilablePath("InputIndentationTextBlock.java"),
+            expected);
+    }
+
+    @Test
     public void testValidNewKeywordWithForceStrictCondition() throws Exception {
         final DefaultConfiguration checkConfig = createModuleConfig(IndentationCheck.class);
 

--- a/src/test/resources-noncompilable/com/puppycrawl/tools/checkstyle/checks/indentation/indentation/InputIndentationTextBlock.java
+++ b/src/test/resources-noncompilable/com/puppycrawl/tools/checkstyle/checks/indentation/indentation/InputIndentationTextBlock.java
@@ -1,0 +1,107 @@
+//non-compiled with javac: Compilable with Java17                             //indent:0 exp:0
+package com.puppycrawl.tools.checkstyle.checks.indentation.indentation;       //indent:0 exp:0
+
+/* Config:                                                                    //indent:0 exp:0
+ * This test-input is intended to be checked using following configuration:   //indent:1 exp:1
+ * tabWidth = 4                                                               //indent:1 exp:1
+ * lineWrappingIndentation = 4                                                //indent:1 exp:1
+ * forceStrictCondition = true                                                //indent:1 exp:1
+ */                                                                           //indent:1 exp:1
+
+
+public class InputIndentationTextBlock {                      //indent:0 exp:0
+    private static final String EXAMPLE = """
+        Example string""";                                    //indent:8 exp:8
+
+    private static final String GO1 = """
+    GO                                                        //indent:4 exp:4
+""";                                                          //indent:0 exp:8 warn
+
+    private static final String GO2 = """
+    GO                                                        //indent:4 exp:4
+        """;                                                  //indent:8 exp:8
+
+    public void textBlockNoIndent() {                         //indent:4 exp:4
+        String contentW = ("""
+                -----1234--                                   //indent:16 exp:16
+                -----1234--h-hh                               //indent:16 exp:16
+                """);                                         //indent:16 exp:12 warn
+
+        String contentR = ("""
+                -----1234--                                   //indent:16 exp:16
+                -----1234----                                 //indent:16 exp:16
+            """);                                             //indent:12 exp:12
+
+        if ("""
+              one more string""".equals(contentR)) {          //indent:14 exp:14
+            System.out.println("This is string");             //indent:12 exp:12
+        }                                                     //indent:8 exp:8
+        if (contentR.equals("""
+          stuff""")) {                                        //indent:10 exp:10
+        }                                                     //indent:8 exp:8
+
+        String a =                                            //indent:8 exp:8
+"""
+          3                                                   //indent:10 exp:10
+          4                                                   //indent:10 exp:10
+          5                                                   //indent:10 exp:10
+          6                                                   //indent:10 exp:10
+          7                                                   //indent:10 exp:10
+"""                                                           //indent:0 exp:12 warn
+              ;                                               //indent:14 exp:14
+    }                                                         //indent:4 exp:4
+    private static void fooBlockAsArgument() {                //indent:4 exp:4
+        String main =                                         //indent:8 exp:8
+        """
+        public class Main {                                   //indent:8 exp:8
+          public void kit(String args) {                      //indent:10 exp:10
+            System.out.println("hello, world!");              //indent:12 exp:12
+            if (args.length > 0) {                            //indent:12 exp:12
+              long pid = ProcessHandle.current().pid();       //indent:14 exp:14
+              System.exit(process.exitValue());               //indent:14 exp:14
+            }                                                 //indent:12 exp:12
+          }                                                   //indent:10 exp:10
+        }                                                     //indent:8 exp:8
+            """;                                              //indent:12 exp:12
+        LOG.warn("""
+                    The following settings                    //indent:20 exp:20
+                    {}                                        //indent:20 exp:20
+                    Therefore returning error result.""",     //indent:20 exp:20
+            GO2);                                             //indent:12 exp:12
+
+        LOG.warn(                                             //indent:8 exp:8
+              """
+              Failed to lidation; will ignore for now,        //indent:14 exp:14
+              but it may fail later during runtime""",        //indent:14 exp:14
+            GO1);                                             //indent:12 exp:12
+    }                                                         //indent:4 exp:4
+
+    public void fooBlockAsCondition() {                       //indent:4 exp:4
+        if (GO1.equalsIgnoreCase("""
+              my other string""" + """
+              plus this string""" + """
+              and also this one.""")) {                       //indent:14 exp:14
+            System.out.println("this is my other string");}   //indent:12 exp:12
+        if ("""
+              one more string""".equals(GO2)) {               //indent:14 exp:14
+            System.out.println("This is one more string");}   //indent:12 exp:12
+
+        if ("""
+                  a""" + """
+                  bc""" == GO2) {                             //indent:18 exp:18
+        }                                                     //indent:8 exp:8
+        else {                                                //indent:8 exp:8
+            System.out.printf("""
+          day of the week                                     //indent:10 exp:10
+              successfully got: "%s"},                        //indent:14 exp:14
+                """, LOG.getNumberOfErrors());                //indent:16 exp:16
+        }                                                     //indent:8 exp:8
+    }                                                         //indent:4 exp:4
+    public class LOG {                                        //indent:4 exp:4
+        public static void warn(String block, String example){//indent:8 exp:8
+        }                                                     //indent:8 exp:8
+        static String getNumberOfErrors() {                   //indent:8 exp:8
+            return "Example";                                 //indent:12 exp:12
+        }                                                     //indent:8 exp:8
+    }                                                         //indent:4 exp:4
+}                                                             //indent:0 exp:0


### PR DESCRIPTION
resolves #15939 

main point:
>Whitespaces on the end line of the text block are not part of the string and there is nothing visible before the end of the text block. It should be indented by this check because it is code and it starts the line.


```xml
$ cat testconfig.xml 
<?xml version="1.0"?>
<!DOCTYPE module PUBLIC
        "-//Checkstyle//DTD Checkstyle Configuration 1.3//EN"
        "https://checkstyle.org/dtds/configuration_1_3.dtd">

<module name="Checker">

    <property name="charset" value="UTF-8"/>

    <property name="severity" value="${org.checkstyle.google.severity}" default="warning"/>

    <property name="fileExtensions" value="java, properties, xml"/>

    <module name="SuppressWarningsFilter"/>

    <module name="TreeWalker">
        <module name="SuppressWarningsHolder"/>

        <module name="Indentation">
            <property name="lineWrappingIndentation" value="4"/>
            <property name="forceStrictCondition" value="true"/>
        </module>
    </module>
</module>
```

```java
public class Test {
    private static final String EXAMPLE = """
                Example string
        EXample2
            example3
        """;    
} 
```
```
java -jar checkstyle-10.21.1-SNAPSHOT-all.jar -c testconfig.xml Test.java
Starting audit...
Audit done.
```
this implementation completely ignores `TEXT_BLOCK_LITERAL_BEGIN/END/CONTENT`