### PR TITLE
Issue #14631: Updated code_literal in JavadocTokenTypes.java to new AST format

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/api/JavadocTokenTypes.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/api/JavadocTokenTypes.java
@@ -425,12 +425,11 @@ public final class JavadocTokenTypes {
      * <pre><code>{&#64;code Comparable&lt;E&gt;}</code></pre>
      * <b>Tree:</b>
      * <pre>
-     * <code> |--JAVADOC_INLINE_TAG[3x0] : [{&#64;code Comparable&lt;E&gt;}]
-     *         |--JAVADOC_INLINE_TAG_START[3x0] : [{]
-     *         |--CODE_LITERAL[3x1] : [@code]
-     *         |--WS[3x6] : [ ]
-     *         |--TEXT[3x7] : [Comparable&lt;E&gt;]
-     *         |--JAVADOC_INLINE_TAG_END[3x21] : [}]
+     * <code>JAVADOC_TAG -&gt; JAVADOC_TAG
+     *        |--CUSTOM_NAME -&gt; @code
+     *        |--WS -&gt;
+     *        `--DESCRIPTION -&gt; DESCRIPTION
+     *            |--TEXT -&gt; Comparable&lt;E&gt;
      * </code>
      * </pre>
      *


### PR DESCRIPTION
Issue :#14631

**Command Used:**
java -jar checkstyle-10.21.0-all.jar -J Test.java | sed "s/\[[0-9]\+:[0-9]\+\]//g"


**Test.java**
```
/**
 *  @Code Comparable&lt;E&gt;
 */
public class Test {
}


```


```
COMPILATION_UNIT -> COMPILATION_UNIT
`--CLASS_DEF -> CLASS_DEF
    |--MODIFIERS -> MODIFIERS
    |   |--BLOCK_COMMENT_BEGIN -> /*
    |   |   |--COMMENT_CONTENT -> *\r\n *  @Code Comparable&lt;E&gt;\r\n
    |   |   |   `--JAVADOC -> JAVADOC
    |   |   |       |--NEWLINE -> \r\n
    |   |   |       |--LEADING_ASTERISK ->  *
    |   |   |       |--WS ->
    |   |   |       |--JAVADOC_TAG -> JAVADOC_TAG
    |   |   |       |   |--CUSTOM_NAME -> @Code
    |   |   |       |   |--WS ->
    |   |   |       |   `--DESCRIPTION -> DESCRIPTION
    |   |   |       |       |--TEXT -> Comparable&lt;E&gt;
    |   |   |       |       |--NEWLINE -> \r\n
    |   |   |       |       `--TEXT ->
    |   |   |       `--EOF -> <EOF>
    |   |   `--BLOCK_COMMENT_END -> */
    |   `--LITERAL_PUBLIC -> public
    |--LITERAL_CLASS -> class
    |--IDENT -> Test
    `--OBJBLOCK -> OBJBLOCK
        |--LCURLY -> {
        `--RCURLY -> }


```
