### PR TITLE
Issue #8244: Added expandable menu for mobile/tablet devices

### DIFF
--- a/config/jsoref-spellchecker/whitelist.words
+++ b/config/jsoref-spellchecker/whitelist.words
@@ -1147,6 +1147,7 @@ revwalk
 rfc
 rfe
 Rgb
+rgba
 rhs
 rhysd
 rickgiles
@@ -1421,6 +1422,7 @@ verticalwhitespace
 Vetrenko
 Veyor
 Vfs
+vh
 viesure
 visibilitymodifier
 visualstudio

--- a/src/site/resources/css/site.css
+++ b/src/site/resources/css/site.css
@@ -138,11 +138,70 @@ a[title="toTop"] {
   display: block;
 }
 
+#hamburger {
+  display: flex;
+  flex-direction: column;
+  justify-content: space-around;
+  align-items: center;
+  width: 20px;
+  height: 20px;
+  cursor: pointer;
+  margin-top: 5px;
+  margin-bottom: 5px;
+}
+
+#hamburger span {
+  display: block;
+  width: 100%;
+  height: 2px;
+  background-color: #333;
+  border-radius: 2px;
+}
+
+#hamburger.openMenu span:nth-child(1) {
+  transform: rotate(45deg);
+  position: absolute;
+  width: 3%;
+}
+
+#hamburger.openMenu span:nth-child(2) {
+  opacity: 0;
+}
+
+#hamburger.openMenu span:nth-child(3) {
+  transform: rotate(-45deg);
+  position: absolute;
+  width: 3%;
+}
+
+#hamburger span {
+  transition: transform 0.3s ease, opacity 0.3s ease;
+}
+
 @media screen and (max-width: 823px) {
   #leftColumn {
     float: none;
     width: auto;
     margin: 1.5em;
+    position: sticky;
+    z-index: 1;
+    box-shadow: rgba(0, 0, 0, 0.7) 0 5px 10px -3px;
+    overflow-y: auto;
+    display: none;
+  }
+
+  .xright {
+    padding: 2px;
+    display: flex;
+    align-items: center;
+    gap: 7px;
+  }
+
+  #breadcrumbs {
+    position: sticky;
+    top: 0;
+    z-index: 10;
+    box-shadow: 0 5px 10px -3px rgba(0,0,0,0.5);
   }
 
   #bodyColumn {

--- a/src/site/resources/js/checkstyle.js
+++ b/src/site/resources/js/checkstyle.js
@@ -62,9 +62,16 @@ function setBodyColumnMargin() {
     const leftColumn = document.querySelector('#leftColumn');
     const bodyColumn = document.querySelector('#bodyColumn');
 
+    if (window.innerWidth > 823 && document.querySelector("#hamburger")) {
+        resetStyling();
+    }
+
     // If in mobile view use margin as defined in site.css
     if (window.innerWidth < 823) {
         bodyColumn.style.marginLeft = '1.5em';
+        if (!document.querySelector("#hamburger")) {
+            setCollapsableMenuButton();
+        }
         return;
     }
 
@@ -73,5 +80,58 @@ function setBodyColumnMargin() {
     bodyColumn.style.marginLeft = `${leftColumnWidth + 27}px`;
 }
 
-window.addEventListener('load', setBodyColumnMargin);
-window.addEventListener('resize', setBodyColumnMargin);
+function setCollapsableMenuButton() {
+    const hamburger = document.createElement("div");
+    hamburger.id = "hamburger";
+
+    for (let i = 0; i < 3; i++) {
+        const line = document.createElement("span");
+        hamburger.appendChild(line);
+    }
+
+    const xright = document.querySelector(".xright");
+    xright.appendChild(document.createTextNode(" | "));
+    xright.appendChild(hamburger);
+
+    hamburger.addEventListener("click", (e) => {
+        e.preventDefault();
+
+        const menu = document.querySelector("#leftColumn");
+        const breadcrumbs = document.querySelector("#breadcrumbs");
+        const body = document.querySelector("#bodyColumn");
+
+        menu.style.top = `${breadcrumbs.offsetHeight + 10}px`;
+        menu.style.height = `calc(100vh - ${breadcrumbs.offsetHeight + 10}px)`;
+
+        if (hamburger.classList.contains("openMenu")) {
+            hamburger.classList.remove("openMenu");
+            menu.style.display = "none";
+
+            body.style.removeProperty("position");
+
+            // Restore scroll
+            window.scrollTo({ top: Number(body.dataset.scrollTop), behavior: "auto" });
+            delete body.dataset.scrollTop;
+        } else {
+            hamburger.classList.add("openMenu");
+            menu.style.display = "block";
+
+            // Preserve current scroll position
+            body.dataset.scrollTop = String(window.scrollY);
+
+            // Prevent scrolling
+            body.style.position = "fixed";
+        }
+    });
+}
+
+function resetStyling() {
+    document.querySelector("#leftColumn").removeAttribute("style");
+    document.querySelector("body").removeAttribute("style");
+    document.querySelector("#bodyColumn").style.removeProperty("position");
+    document.querySelector("#hamburger").remove();
+    document.querySelector(".xright").lastChild.remove();
+}
+
+window.addEventListener("load", setBodyColumnMargin);
+window.addEventListener("resize", setBodyColumnMargin);


### PR DESCRIPTION
Resolves #8244

Added a hamburger for the mobile/tablet view. User can toggle the menu's visibility using that.

The hamburger is added in the `breadcrumbs` bar and I have made it stick to the top for mobile view. 

Currently, if the user makes the menu visible, he isn't automatically scrolled to the top to see the menu, he will still need to manually scroll up. @rnveach @nrmancuso @romani, do you want to automatically scroll user to the top when he makes the menu visible?

Also, I haven't changed anything in Menu's styling for mobile view, if any maintainer requests for that, I will gladly do it :)