### PR TITLE
Issue #14631: Update ARGUMENT to new AST format in Javadoc

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/api/JavadocTokenTypes.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/api/JavadocTokenTypes.java
@@ -820,19 +820,20 @@ public final class JavadocTokenTypes {
      * <pre>{@code @see #method(Processor, String)}</pre>
      * <b>Tree:</b>
      * <pre>
-     * {@code |--JAVADOC_TAG[1x0] : [@see #method(Processor, String)]
-     *        |--SEE_LITERAL[1x0] : [@see]
-     *        |--WS[1x4] : [ ]
-     *        |--REFERENCE[1x5] : [#method(Processor, String)]
-     *            |--HASH[1x5] : [#]
-     *            |--MEMBER[1x6] : [method]
-     *            |--PARAMETERS[1x12] : [(Processor, String)]
-     *                |--LEFT_BRACE[1x12] : [(]
-     *                |--ARGUMENT[1x13] : [Processor]
-     *                |--COMMA[1x22] : [,]
-     *                |--WS[1x23] : [ ]
-     *                |--ARGUMENT[1x24] : [String]
-     *                |--RIGHT_BRACE[1x30] : [)]
+     * {@code JAVADOC_TAG -&gt JAVADOC_TAG
+     *         |--SEE_LITERAL -&gt @see
+     *         |--WS -&gt
+     *         |--REFERENCE -&gt REFERENCE
+     *         |   |--HASH -&gt #
+     *         |   |--MEMBER -&gt method
+     *         |   `--PARAMETERS -&gt PARAMETERS
+     *         |       |--LEFT_BRACE -&gt (
+     *         |       |--ARGUMENT -&gt Processor
+     *         |       |--COMMA -&gt ,
+     *         |       |--WS -&gt
+     *         |       |--ARGUMENT -&gt String
+     *         |       `--RIGHT_BRACE -&gt )
+     *         `--NEWLINE -&gt \n
      * }
      * </pre>
      */


### PR DESCRIPTION
Issue #14631:  ARGUMENT

**Command:**
```
$ java -jar checkstyle-10.13.0-all.jar -j Test.java | sed "s/\[[0-9]\+:[0-9]\+\]//g"
```

**Test.java**
```
$ cat Test.java
* @see #method(Processor, String)
```

**Output:**
```
elina@fedora:~/IdeaProjects/sandbox/java17
$ java -jar checkstyle-10.13.0-all.jar -j Test.java | sed "s/\[[0-9]\+:[0-9]\+\]//g"
JAVADOC -> JAVADOC
|--LEADING_ASTERISK -> *
|--WS ->
|--JAVADOC_TAG -> JAVADOC_TAG
|   |--SEE_LITERAL -> @see
|   |--WS ->
|   |--REFERENCE -> REFERENCE
|   |   |--HASH -> #
|   |   |--MEMBER -> method
|   |   `--PARAMETERS -> PARAMETERS
|   |       |--LEFT_BRACE -> (
|   |       |--ARGUMENT -> Processor
|   |       |--COMMA -> ,
|   |       |--WS ->
|   |       |--ARGUMENT -> String
|   |       `--RIGHT_BRACE -> )
|   `--NEWLINE -> \n
`--EOF -> <EOF>
```
