### PR TITLE
Issue #14631: Update FIELD_TYPE to new AST format in Javadoc

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/api/JavadocTokenTypes.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/api/JavadocTokenTypes.java
@@ -1014,15 +1014,16 @@ public final class JavadocTokenTypes {
      * <pre>{@code @serialField counter Integer objects counter}</pre>
      * <b>Tree:</b>
      * <pre>
-     * {@code |--JAVADOC_TAG[3x0] : [@serialField counter Integer objects counter]
-     *        |--SERIAL_FIELD_LITERAL[3x0] : [@serialField]
-     *        |--WS[3x12] : [ ]
-     *        |--FIELD_NAME[3x13] : [counter]
-     *        |--WS[3x20] : [ ]
-     *        |--FIELD_TYPE[3x21] : [Integer]
-     *        |--WS[3x28] : [ ]
-     *        |--DESCRIPTION[3x29] : [objects counter]
-     *            |--TEXT[3x29] : [objects counter]
+     * {@code JAVADOC_TAG -&gt JAVADOC_TAG
+     *         |--SERIAL_FIELD_LITERAL -&gt @serialField
+     *         |--WS -&gt
+     *         |--FIELD_NAME -&gt counter
+     *         |--WS -&gt
+     *         |--FIELD_TYPE -&gt Integer
+     *         |--WS -&gt
+     *         `--DESCRIPTION -&gt DESCRIPTION
+     *             |--TEXT -&gt objects counter
+     *             `--NEWLINE -&gt \n
      * }
      * </pre>
      *


### PR DESCRIPTION
Issue #14631: FIELD_TYPE

**Command:**
```
$ java -jar checkstyle-10.13.0-all.jar -j Test.java | sed "s/\[[0-9]\+:[0-9]\+\]//g"
```

**Test.java**
```
$ cat Test.java
@serialField counter Integer objects counter
```

**Output:**
```
elina@fedora:~/IdeaProjects/sandbox/jdk17
$ java -jar checkstyle-10.13.0-all.jar -j Test.java | sed "s/\[[0-9]\+:[0-9]\+\]//g"
JAVADOC -> JAVADOC
|--JAVADOC_TAG -> JAVADOC_TAG
|   |--SERIAL_FIELD_LITERAL -> @serialField
|   |--WS ->
|   |--FIELD_NAME -> counter
|   |--WS ->
|   |--FIELD_TYPE -> Integer
|   |--WS ->
|   `--DESCRIPTION -> DESCRIPTION
|       |--TEXT -> objects counter
|       `--NEWLINE -> \n
`--EOF -> <EOF>
```