### PR TITLE
Issue #15456: Specify violation messages for OneStatementPerLineCheck

### DIFF
--- a/src/test/java/com/puppycrawl/tools/checkstyle/bdd/InlineConfigParser.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/bdd/InlineConfigParser.java
@@ -228,7 +228,6 @@ public final class InlineConfigParser {
             "com.puppycrawl.tools.checkstyle.checks.coding.NestedForDepthCheck",
             "com.puppycrawl.tools.checkstyle.checks.coding.NestedIfDepthCheck",
             "com.puppycrawl.tools.checkstyle.checks.coding.NestedTryDepthCheck",
-            "com.puppycrawl.tools.checkstyle.checks.coding.OneStatementPerLineCheck",
             "com.puppycrawl.tools.checkstyle.checks.coding.OverloadMethodsDeclarationOrderCheck",
             "com.puppycrawl.tools.checkstyle.checks.coding.ParameterAssignmentCheck",
             "com.puppycrawl.tools.checkstyle.checks.coding.SimplifyBooleanExpressionCheck",

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/coding/OneStatementPerLineCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/coding/OneStatementPerLineCheckTest.java
@@ -40,8 +40,8 @@ public class OneStatementPerLineCheckTest extends AbstractModuleTestSupport {
     @Test
     public void testMultiCaseSmallTalkStyle() throws Exception {
         final String[] expected = {
-            "13:59: " + getCheckMessage(MSG_KEY),
-            "87:21: " + getCheckMessage(MSG_KEY),
+            "14:59: " + getCheckMessage(MSG_KEY),
+            "88:21: " + getCheckMessage(MSG_KEY),
         };
         verifyWithInlineConfigParser(
                 getPath("InputOneStatementPerLineSingleLineSmallTalkStyle.java"),
@@ -55,7 +55,7 @@ public class OneStatementPerLineCheckTest extends AbstractModuleTestSupport {
             "53:17: " + getCheckMessage(MSG_KEY),
             "65:25: " + getCheckMessage(MSG_KEY),
             "85:23: " + getCheckMessage(MSG_KEY),
-            "88:63: " + getCheckMessage(MSG_KEY),
+            "89:63: " + getCheckMessage(MSG_KEY),
         };
         verifyWithInlineConfigParser(
                 getPath("InputOneStatementPerLineSingleLineInLoops.java"),
@@ -102,8 +102,8 @@ public class OneStatementPerLineCheckTest extends AbstractModuleTestSupport {
     public void testLoopsAndTryWithResourceWithMultilineStatements() throws Exception {
         final String[] expected = {
             "53:39: " + getCheckMessage(MSG_KEY),
-            "86:44: " + getCheckMessage(MSG_KEY),
-            "97:45: " + getCheckMessage(MSG_KEY),
+            "87:44: " + getCheckMessage(MSG_KEY),
+            "99:45: " + getCheckMessage(MSG_KEY),
         };
         verifyWithInlineConfigParser(
                 getPath("InputOneStatementPerLineMultilineInLoopsAndTryWithResources.java"),
@@ -114,11 +114,11 @@ public class OneStatementPerLineCheckTest extends AbstractModuleTestSupport {
     public void oneStatementNonCompilableInputTest() throws Exception {
         final String[] expected = {
             "39:4: " + getCheckMessage(MSG_KEY),
-            "44:54: " + getCheckMessage(MSG_KEY),
-            "45:54: " + getCheckMessage(MSG_KEY),
-            "45:70: " + getCheckMessage(MSG_KEY),
-            "46:46: " + getCheckMessage(MSG_KEY),
-            "50:81: " + getCheckMessage(MSG_KEY),
+            "46:54: " + getCheckMessage(MSG_KEY),
+            "51:54: " + getCheckMessage(MSG_KEY),
+            "51:70: " + getCheckMessage(MSG_KEY),
+            "54:46: " + getCheckMessage(MSG_KEY),
+            "60:81: " + getCheckMessage(MSG_KEY),
         };
 
         verifyWithInlineConfigParser(
@@ -128,10 +128,10 @@ public class OneStatementPerLineCheckTest extends AbstractModuleTestSupport {
     @Test
     public void testResourceReferenceVariableIgnored() throws Exception {
         final String[] expected = {
-            "32:42: " + getCheckMessage(MSG_KEY),
-            "36:43: " + getCheckMessage(MSG_KEY),
-            "42:46: " + getCheckMessage(MSG_KEY),
-            "46:46: " + getCheckMessage(MSG_KEY),
+            "33:42: " + getCheckMessage(MSG_KEY),
+            "38:43: " + getCheckMessage(MSG_KEY),
+            "45:46: " + getCheckMessage(MSG_KEY),
+            "50:46: " + getCheckMessage(MSG_KEY),
         };
 
         verifyWithInlineConfigParser(

--- a/src/test/resources-noncompilable/com/puppycrawl/tools/checkstyle/checks/coding/onestatementperline/InputOneStatementPerLine.java
+++ b/src/test/resources-noncompilable/com/puppycrawl/tools/checkstyle/checks/coding/onestatementperline/InputOneStatementPerLine.java
@@ -36,18 +36,28 @@ public class InputOneStatementPerLine {
    * may be considered as two empty statements on the same line
    * and rises violation.
    */
-  ;; // violation
+  ;; // violation 'Only one statement per line allowed.'
   static {
     new JCheckBox().addActionListener((final ActionEvent e) -> {good();});
     List<Integer> ints = new LinkedList<Integer>();
     ints.stream().map( t -> { return t * 2;} ).filter( t -> { return false;});
-    ints.stream().map( t -> { int m = t * 2; return m; } ); // violation
-    ints.stream().map( t -> { int m = t * 2; return m; } ); int i = 3; // 2 violations
-    ints.stream().map( t -> t * 2); int k = 4; // violation
+
+    // violation below 'Only one statement per line allowed.'
+    ints.stream().map( t -> { int m = t * 2; return m; } );
+
+    // 2 violations 3 lines below:
+    // 'Only one statement per line allowed.'
+    // 'Only one statement per line allowed.'
+    ints.stream().map( t -> { int m = t * 2; return m; } ); int i = 3;
+
+    // violation below 'Only one statement per line allowed.'
+    ints.stream().map( t -> t * 2); int k = 4;
     ints.stream().map( t -> t * 2);
     List<Integer> ints2 = new LinkedList<Integer>();
     ints.stream().map( t -> { return ints2.stream().map(w -> { return w * 2; });});
-    ints.stream().map( t -> { return ints2.stream().map(w -> { int m=w; return m; });});// violation
+
+    // violation below 'Only one statement per line allowed.'
+    ints.stream().map( t -> { return ints2.stream().map(w -> { int m=w; return m; });});
     ints.stream().map( t -> {
       return ints2.stream().map(
           w -> {

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/onestatementperline/InputOneStatementPerLine.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/onestatementperline/InputOneStatementPerLine.java
@@ -1,2 +1,2 @@
 package com.puppycrawl.tools.checkstyle.checks.coding.onestatementperline; import java.io.IOException; import java.io.OutputStream; import java.io.PipedOutputStream; public class InputOneStatementPerLine {  int e = 1, f = 2, g = 5; private void foo2() { try (OutputStream s12 = new PipedOutputStream(); OutputStream s3 = new PipedOutputStream()) { } catch (IOException ex) { throw new RuntimeException(ex); } } private void foo() { toString(); toString(); } }
-// 7 violations above
+// 7 violations above 'Only one statement per line allowed.'

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/onestatementperline/InputOneStatementPerLineMultilineForDeclarations.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/onestatementperline/InputOneStatementPerLineMultilineForDeclarations.java
@@ -46,7 +46,7 @@ public class InputOneStatementPerLineMultilineForDeclarations {
      * on the same line are illegal.
      */
     int o = 1, p = 2,
-        r = 5; int t; // violation
+        r = 5; int t; // violation 'Only one statement per line allowed.'
 
     /**
      * Two assignment (declaration) statement
@@ -63,7 +63,7 @@ public class InputOneStatementPerLineMultilineForDeclarations {
      */
     int var1 = 5,
         var4 = 5; int var2 = 6,
-        var3 = 5; // violation
+        var3 = 5; // violation 'Only one statement per line allowed.'
 
     /**
      * Two statements on the same line
@@ -71,7 +71,7 @@ public class InputOneStatementPerLineMultilineForDeclarations {
      * are illegal.
      */
     int var6 = 5; int var7 = 6,
-        var8 = 5; // violation
+        var8 = 5; // violation 'Only one statement per line allowed.'
 
     /**
      * Two statements on the same line
@@ -83,7 +83,7 @@ public class InputOneStatementPerLineMultilineForDeclarations {
 
         );toString(
 
-        ); // violation
+        ); // violation 'Only one statement per line allowed.'
     }
 
     /**
@@ -92,7 +92,7 @@ public class InputOneStatementPerLineMultilineForDeclarations {
      */
     int var9 = 1,
         var10 = 5
-            ; int var11 = 2; // violation
+            ; int var11 = 2; // violation 'Only one statement per line allowed.'
 
     /**
      * Multiline for loop statement is legal.

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/onestatementperline/InputOneStatementPerLineMultilineInLoopsAndTryWithResources.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/onestatementperline/InputOneStatementPerLineMultilineInLoopsAndTryWithResources.java
@@ -50,7 +50,7 @@ public class InputOneStatementPerLineMultilineInLoopsAndTryWithResources {
             k = 1
             ; n<5
             ;
-            n++, k--) { var1++; var2++; } // violation
+            n++, k--) { var1++; var2++; } // violation 'Only one statement per line allowed.'
     }
 
     /**
@@ -83,7 +83,8 @@ public class InputOneStatementPerLineMultilineInLoopsAndTryWithResources {
      */
   private void issue2211fail() {
     try(
-  AutoCloseable i=new java.io.PipedReader();AutoCloseable k=new java.io.PipedReader();// violation
+            // violation below 'Only one statement per line allowed.'
+  AutoCloseable i=new java.io.PipedReader();AutoCloseable k=new java.io.PipedReader();
     ) {
     } catch (Exception e1) {
     }
@@ -94,7 +95,8 @@ public class InputOneStatementPerLineMultilineInLoopsAndTryWithResources {
      * @see <a href="https://github.com/checkstyle/checkstyle/pull/2750#issuecomment-166032327"/>
      */
   private void issue2211fail2() {
-    try(AutoCloseable i=new StringReader("");AutoCloseable k=new StringReader("");) { // violation
+      // violation below 'Only one statement per line allowed.'
+    try(AutoCloseable i=new StringReader("");AutoCloseable k=new StringReader("");) {
     } catch (Exception e1) {
     }
   }

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/onestatementperline/InputOneStatementPerLineSingleLineInLoops.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/onestatementperline/InputOneStatementPerLineSingleLineInLoops.java
@@ -24,7 +24,7 @@ public class InputOneStatementPerLineSingleLineInLoops {
      */
     public void doIllegal2() {
         one = 1
-        ; two = 2; // violation
+        ; two = 2; // violation 'Only one statement per line allowed.'
     }
 
     /**
@@ -50,7 +50,7 @@ public class InputOneStatementPerLineSingleLineInLoops {
     /**
      * Two declaration statements on the same line are illegal.
      */
-    int a; int b; // violation
+    int a; int b; // violation 'Only one statement per line allowed.'
 
     /**
      * Two declaration statements which are not on the same line
@@ -62,7 +62,7 @@ public class InputOneStatementPerLineSingleLineInLoops {
     /**
      * Two assignment (declaration) statements on the same line are illegal.
      */
-    int e = 1; int f = 2; // violation
+    int e = 1; int f = 2; // violation 'Only one statement per line allowed.'
 
     /**
      * Two assignment (declaration) statements on the different lines
@@ -82,10 +82,11 @@ public class InputOneStatementPerLineSingleLineInLoops {
         int var2 = 2;
 
         //Two increment statements on the same line are illegal.
-        var1++; var2++; // violation
+        var1++; var2++; // violation 'Only one statement per line allowed.'
 
         //Two object creation statements on the same line are illegal.
-        Object obj1 = new Object(); Object obj2 = new Object(); // violation
+        // violation below 'Only one statement per line allowed.'
+        Object obj1 = new Object(); Object obj2 = new Object();
     }
 
 }

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/onestatementperline/InputOneStatementPerLineSingleLineSmallTalkStyle.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/onestatementperline/InputOneStatementPerLineSingleLineSmallTalkStyle.java
@@ -10,7 +10,8 @@ package com.puppycrawl.tools.checkstyle.checks.coding.onestatementperline;
 /**
  * Two import statements on the same line are illegal.
  */
-import java.io.EOFException; import java.io.BufferedReader; // violation
+// violation below 'Only one statement per line allowed.'
+import java.io.EOFException; import java.io.BufferedReader;
 
 public class InputOneStatementPerLineSingleLineSmallTalkStyle {
   /**
@@ -84,7 +85,7 @@ public class InputOneStatementPerLineSingleLineSmallTalkStyle {
    * Simplest form of an illegal layout.
    */
   public void doIllegal() {
-    one = 1; two = 2; // violation
+    one = 1; two = 2; // violation 'Only one statement per line allowed.'
   }
 
   /**

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/onestatementperline/InputOneStatementPerLineTryWithResources.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/onestatementperline/InputOneStatementPerLineTryWithResources.java
@@ -29,21 +29,25 @@ public class InputOneStatementPerLineTryWithResources {
         try (s1; OutputStream s6 = new PipedOutputStream(); s2) {
         }
         try (
-OutputStream s7 = new PipedOutputStream();OutputStream s8 = new PipedOutputStream(); // violation
+                //violation below 'Only one statement per line allowed.'
+OutputStream s7 = new PipedOutputStream();OutputStream s8 = new PipedOutputStream();
            s2;
         ) {}
         try (
-OutputStream s9=new PipedOutputStream();s2;OutputStream s10 = new PipedOutputStream()) // violation
+                // violation below 'Only one statement per line allowed.'
+OutputStream s9=new PipedOutputStream();s2;OutputStream s10 = new PipedOutputStream())
         {}
         try (s1; OutputStream s11 = new PipedOutputStream();
              s2;) {
         }
         try (OutputStream
-             s12 = new PipedOutputStream();s1;OutputStream s3 = new PipedOutputStream() // violation
+                // violation below 'Only one statement per line allowed.'
+             s12 = new PipedOutputStream();s1;OutputStream s3 = new PipedOutputStream()
              ;s2;) {
         }
         try (OutputStream
-             s12 = new PipedOutputStream();s1;OutputStream s3 // violation
+                // violation below 'Only one statement per line allowed.'
+             s12 = new PipedOutputStream();s1;OutputStream s3
                 = new PipedOutputStream()) {}
         try (s1; s2; OutputStream stream3 =
              new PipedOutputStream()) {}


### PR DESCRIPTION
Issue #15456: Specify violation messages for OneStatementPerLineCheck

Regarding [InputOneStatementPerLine.java](https://github.com/checkstyle/checkstyle/compare/master...ElinaZoldnere:checkstyle:15456-specify-violation-messages/OneStatementPerLine?expand=1#diff-32263841b4aa69afe876dff943de41941f57264f790c20047fda39b0ee824a30) - I didn't find the matching violation pattern for comment
```// X violations below 'Some message here.'```
Only a pattern without a message.
```
    /** A pattern to find the string: "// X violations below". */
    private static final Pattern MULTIPLE_VIOLATIONS_BELOW_PATTERN = Pattern
            .compile(".*//\\s*(\\d+) violations below$");
```

So I utilized this:
```
    /**
     * <div>
     * Multiple violations for line. Violations are Y lines below, messages are X lines below.
     * {@code
     *   // X violations Y lines below:
     *   //                            'violation message1'
     *   //                            'violation messageX'
     * }
     *
     * Messages are matched by {@link InlineConfigParser#VIOLATION_MESSAGE_PATTERN}
     * </div>
     */
    private static final Pattern VIOLATIONS_SOME_LINES_BELOW_PATTERN = Pattern
            .compile(".*//\\s*(\\d+) violations (\\d+) lines below:$");
```