### PR TITLE
Issue #13213: remove ok from InputPackageDeclarationPlain

### DIFF
--- a/config/checkstyle-input-suppressions.xml
+++ b/config/checkstyle-input-suppressions.xml
@@ -70,10 +70,6 @@
   <!-- until https://github.com/checkstyle/checkstyle/issues/13213 -->
 
   <suppress id="UnnecessaryOkComment"
-            files="checks[\\/]coding[\\/]packagedeclaration[\\/]InputPackageDeclarationPlain.java"/>
-  <suppress id="UnnecessaryOkComment"
-            files="checks[\\/]coding[\\/]packagedeclaration[\\/]InputPackageDeclarationWithCommentOnly.java"/>
-  <suppress id="UnnecessaryOkComment"
             files="checks[\\/]coding[\\/]unnecessarysemicolonaftertypememberdeclaration[\\/]InputUnnecessarySemicolonAfterTypeMemberDeclarationNullAst.java"/>
   <suppress id="UnnecessaryOkComment"
             files="checks[\\/]javadoc[\\/]abstractjavadoc[\\/]InputAbstractJavadocCustomTag.java"/>

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/packagedeclaration/InputPackageDeclarationPlain.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/packagedeclaration/InputPackageDeclarationPlain.java
@@ -5,7 +5,7 @@ matchDirectoryStructure = (default)true
 
 */
 
-package com.puppycrawl.tools.checkstyle.checks.coding.packagedeclaration; // ok
+package com.puppycrawl.tools.checkstyle.checks.coding.packagedeclaration;
 
 class InputPackageDeclarationPlain {
     public String value;

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/packagedeclaration/InputPackageDeclarationWithCommentOnly.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/packagedeclaration/InputPackageDeclarationWithCommentOnly.java
@@ -5,4 +5,4 @@ matchDirectoryStructure = (default)true
 
 */
 
-/* Comment only */ // ok
+/* Comment only */


### PR DESCRIPTION
Issue: #13213 

This PR addresses the removal of //ok comments from the file InputPackageDeclarationPlain

