### PR TITLE
minor: codeclimate.com is skipped from link validation; permanent 403

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -2182,6 +2182,7 @@
             <excludedLink>https://maven-doccheck.sourceforge.net/</excludedLink>
             <excludedLink>http://jdee.sourceforge.net/</excludedLink>
             <excludedLink>https://qalab.sourceforge.net/</excludedLink>
+            <excludedLink>https://codeclimate.com</excludedLink>
             <excludedLink>https://saxon.sourceforge.net/saxon7.1/expressions.html</excludedLink>
             <!-- until https://github.com/checkstyle/checkstyle/issues/11754 -->
             <excludedLink>https://checkstyle.sourceforge.io/version/6.18</excludedLink>


### PR DESCRIPTION
from:
https://github.com/checkstyle/checkstyle/actions/runs/12587684935/job/35084028290#step:4:2642

```
------------ grep of linkcheck.html--BEGIN
Checking internal (checkstyle website) and external links.
--- .ci-temp/linkcheck-suppressions-sorted.txt	2025-01-02 19:31:24.433823367 +0000
+++ .ci-temp/linkcheck-errors-sorted.txt	2025-01-02 19:31:24.429823366 +0000
@@ -1,3 +1,4 @@
+<a class="externalLink" href="https://codeclimate.com/">https://codeclimate.com/</a>: 403 Forbidden

```