### PR TITLE
minor: fix bash spelling SC2086 and SC2317

### DIFF
--- a/.ci/check-performance-regression.sh
+++ b/.ci/check-performance-regression.sh
@@ -62,7 +62,7 @@ compare_results() {
   local EXECUTION_TIME_SECONDS=$1
   if [ -z "$EXECUTION_TIME_SECONDS" ]; then
         echo "Missing EXECUTION_TIME_SECONDS as an argument."
-        exit 1
+        return 1
     fi
   # Calculate absolute percentage difference for execution time
   local DEVIATION_IN_SECONDS=$(echo "scale=4; \
@@ -76,11 +76,11 @@ compare_results() {
   if (( $(echo "$DEVIATION_IN_SECONDS > $THRESHOLD_PERCENTAGE" | bc -l) )); then
     echo "Difference exceeds the maximum allowed difference (${DEVIATION_IN_SECONDS}% \
      > ${THRESHOLD_PERCENTAGE}%)!"
-    exit 1
+    return 1
   else
     echo "Difference is within the maximum allowed difference (${DEVIATION_IN_SECONDS}% \
      <= ${THRESHOLD_PERCENTAGE}%)."
-    exit 0
+    return 0
   fi
 }
 

--- a/.ci/validation.sh
+++ b/.ci/validation.sh
@@ -405,7 +405,7 @@ verify-regexp-id)
   do
     a=$(grep -c "<module name=\"Regexp.*" "$FILE") || a=0
     b=$(grep "<module name=\"Regexp" -A 1 "$FILE" | grep -c "<property name=\"id\"") || b=0
-    if [ ${a} != ${b} ]
+    if [ "${a}" != "${b}" ]
     then
       echo "Error: $FILE has Regexp modules without id property immediately after module name."
       fail=1


### PR DESCRIPTION
from https://github.com/checkstyle/checkstyle/actions/runs/12589564511/job/35089604527?pr=16078#step:4:8

```
In ./.ci/check-performance-regression.sh line 106:
exit $?
^-----^ SC2317 (info): Command appears to be unreachable. Check usage (or ignore if invoked indirectly).


In ./.ci/validation.sh line 408:
    if [ ${a} != ${b} ]
         ^--^ SC208[6](https://github.com/checkstyle/checkstyle/actions/runs/12589564511/job/35089604527?pr=16078#step:4:7) (info): Double quote to prevent globbing and word splitting.
                 ^--^ SC2086 (info): Double quote to prevent globbing and word splitting.

Did you mean: 
    if [ "${a}" != "${b}" ]

For more information:
  https://www.shellcheck.net/wiki/SC2086 -- Double quote to prevent globbing ...
  https://www.shellcheck.net/wiki/SC231[7](https://github.com/checkstyle/checkstyle/actions/runs/12589564511/job/35089604527?pr=16078#step:4:8) -- Command appears to be unreachable...
```