### PR TITLE
Issue #16077: fix extra links for site workflow

### DIFF
--- a/.ci/generate-extra-site-links.sh
+++ b/.ci/generate-extra-site-links.sh
@@ -67,7 +67,7 @@ do
   done < <(head -n "$EARLIEST_CHANGE_LINE_NUMBER" "$CURRENT_XDOC_PATH" | tac)
 
   # Extract file name from path, i.e. 'config_misc' and remove '.vm' if it exists.
-  CURRENT_XDOC_NAME=$(echo "$CURRENT_XDOC_PATH" | sed 's/src\/xdocs\/\(.*\)\.xml/\1/' \
+  CURRENT_XDOC_NAME=$(echo "$CURRENT_XDOC_PATH" | sed 's/src\/site\/xdoc\/\(.*\)\.xml/\1/' \
     | sed 's/.vm//')
   echo "CURRENT_XDOC_NAME=$CURRENT_XDOC_NAME"
 


### PR DESCRIPTION
extra update for initial update of Issue #16077

detected at:
https://github.com/checkstyle/checkstyle/pull/16105#issuecomment-2569731597
```
https://checkstyle-diff-reports.s3.us-east-2.amazonaws.com/bebb18d_2025194407/index.html

https://checkstyle-diff-reports.s3.us-east-2.amazonaws.com/bebb18d_2025194407/src/site/xdoc/checks/header/header.xml.html#Description
```

link to Check is broken, as xdoc location is changed.