### PR TITLE
minor: Update README.md with never expiring invite link

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,7 +107,8 @@ information on how to build the project.
 - [Stack Overflow](https://stackoverflow.com/questions/tagged/checkstyle) is another place to
   ask questions about Checkstyle usage.
 - If you are interested in contributing to the project, you can join our
-  [Discord Contributors Chat](https://discord.com/channels/845645228467159061/1216455699488313554).
+  [Discord Contributors Chat](https://discord.com/channels/845645228467159061/1216455699488313554)
+  [with invite link](https://discord.gg/FsUsYC2ura).
 - Our [Google Groups Forum](https://groups.google.com/forum/?hl=en#!forum/checkstyle) is a
   mailing list for discussion and support; however, we may be slow to respond there.
 

--- a/config/jsoref-spellchecker/whitelist.words
+++ b/config/jsoref-spellchecker/whitelist.words
@@ -1531,6 +1531,7 @@ xzvf
 yaml
 yamllint
 Yaroslavtsev
+YC
 yml
 youtrack
 youtube


### PR DESCRIPTION
https://support.cci.drexel.edu/getting-connected/discord/create-invite-links/#:~:text=How%20to%20Customize%20a%20Discord,long%20the%20link%20will%20last.

![image](https://github.com/user-attachments/assets/8d705c83-f743-43a2-82d1-3063fbf801a6)


We deprecating Element chat.