### PR TITLE
Issue #14631: Updated LINK_LITERAL in JavadocTokenTypes.java to new AST format

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/api/JavadocTokenTypes.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/api/JavadocTokenTypes.java
@@ -501,22 +501,18 @@ public final class JavadocTokenTypes {
      * <pre>
      * <code> |--JAVADOC_INLINE_TAG[1x0] :
      *               [{&#64;link org.apache.utils.Lists.Comparator#compare(Object)}]
-     *        |--JAVADOC_INLINE_TAG_START[1x0] : [{]
-     *        |--LINK_LITERAL[1x1] : [@link]
-     *        |--WS[1x6] : [ ]
-     *        |--REFERENCE[1x7] : [org.apache.utils.Lists.Comparator#compare(Object)]
-     *            |--PACKAGE_CLASS[1x7] : [org.apache.utils]
-     *            |--DOT[1x23] : [.]
-     *            |--CLASS[1x24] : [Lists]
-     *            |--DOT[1x29] : [.]
-     *            |--CLASS[1x30] : [Comparator]
-     *            |--HASH[1x40] : [#]
-     *            |--MEMBER[1x41] : [compare]
-     *            |--PARAMETERS[1x48] : [(Object)]
-     *                |--LEFT_BRACE[1x48] : [(]
-     *                |--ARGUMENT[1x49] : [Object]
-     *                |--RIGHT_BRACE[1x55] : [)]
-     *        |--JAVADOC_INLINE_TAG_END[1x56] : [}]
+     *        |--JAVADOC_INLINE_TAG_START -&gt; {
+     *        |--LINK_LITERAL -&gt; @link
+     *        |--WS -&gt;
+     *        |--REFERENCE -&gt; REFERENCE
+     *        |    |--PACKAGE_CLASS -&gt; org.apache.utils.Lists.Comparator
+     *        |    |--HASH -&gt; #
+     *        |    |--MEMBER -&gt; compare
+     *        |    `--PARAMETERS -&gt; PARAMETERS
+     *        |        |--LEFT_BRACE -&gt; (
+     *        |        |--ARGUMENT -&gt; Object
+     *        |        `--RIGHT_BRACE -&gt; )
+     *        `--JAVADOC_INLINE_TAG_END -&gt; }
      * </code>
      * </pre>
      *


### PR DESCRIPTION
Issue: #14631

**Command used:**

` java -jar checkstyle-10.21.0-all.jar -J Test.java | sed "s/\[[0-9]\+:[0-9]\+\]//g"`

**Test.java**
```
/**
 * {@link org.apache.utils.Lists.Comparator#compare(Object)}
 */

public class Test {
}

```

```
Souvik@souvik MINGW64 ~/Desktop/checkStylee/link_literal_ast
$ java -jar checkstyle-10.21.0-all.jar -J Test.java | sed "s/\[[0-9]\+:[0-9]\+\]//g"
COMPILATION_UNIT -> COMPILATION_UNIT
`--CLASS_DEF -> CLASS_DEF
    |--MODIFIERS -> MODIFIERS
    |   |--BLOCK_COMMENT_BEGIN -> /*
    |   |   |--COMMENT_CONTENT -> *\r\n * {@link org.apache.utils.Lists.Comparator#compare(Object)}\r\n
    |   |   |   `--JAVADOC -> JAVADOC
    |   |   |       |--NEWLINE -> \r\n
    |   |   |       |--LEADING_ASTERISK ->  *
    |   |   |       |--TEXT ->
    |   |   |       |--JAVADOC_INLINE_TAG -> JAVADOC_INLINE_TAG
    |   |   |       |   |--JAVADOC_INLINE_TAG_START -> {
    |   |   |       |   |--LINK_LITERAL -> @link
    |   |   |       |   |--WS ->
    |   |   |       |   |--REFERENCE -> REFERENCE
    |   |   |       |   |   |--PACKAGE_CLASS -> org.apache.utils.Lists.Comparator
    |   |   |       |   |   |--HASH -> #
    |   |   |       |   |   |--MEMBER -> compare
    |   |   |       |   |   `--PARAMETERS -> PARAMETERS
    |   |   |       |   |       |--LEFT_BRACE -> (
    |   |   |       |   |       |--ARGUMENT -> Object
    |   |   |       |   |       `--RIGHT_BRACE -> )
    |   |   |       |   `--JAVADOC_INLINE_TAG_END -> }
    |   |   |       |--NEWLINE -> \r\n
    |   |   |       |--TEXT ->
    |   |   |       `--EOF -> <EOF>
    |   |   `--BLOCK_COMMENT_END -> */
    |   `--LITERAL_PUBLIC -> public
    |--LITERAL_CLASS -> class
    |--IDENT -> Test
    `--OBJBLOCK -> OBJBLOCK
        |--LCURLY -> {
        `--RCURLY -> }

```

