### PR TITLE
Issue #14631: Updated PARAMETER_NAME in Javadoc to new AST format

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/api/JavadocTokenTypes.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/api/JavadocTokenTypes.java
@@ -951,10 +951,12 @@ public final class JavadocTokenTypes {
      * <pre>{@code @serial exclude}</pre>
      * <b>Tree:</b>
      * <pre>
-     * {@code |--JAVADOC_TAG[1x0] : [@serial exclude]
-     *        |--SERIAL_LITERAL[1x0] : [@serial]
-     *        |--WS[1x7] : [ ]
-     *        |--LITERAL_EXCLUDE[1x8] : [exclude]
+     * {@code JAVADOC_TAG -&gt JAVADOC_TAG
+     *         |--SERIAL_LITERAL -&gt @serial
+     *         |--WS -&gt
+     *         |--LITERAL_EXCLUDE -&gt exclude
+     *         |--NEWLINE -&gt \r\n
+     *         `--WS -&gt
      * }
      * </pre>
      *


### PR DESCRIPTION
Issue #14631

**Command:**
```
java -jar checkstyle-10.21.1-all.jar -J Test.java | sed "s/\[[0-9]\+:[0-9]\+\]//g"
```

**Test.java**
```
/**
 * @serial exclude
 */
public class Test {
}
```

**Output:**
```
Harsh@LAPTOP-G8FFVU8Q MINGW64 /d/contribute/PARAMETER_NAME AST
$ java -jar checkstyle-10.21.1-all.jar -J Test.java | sed "s/\[[0-9]\+:[0-9]\+\]//g"
COMPILATION_UNIT -> COMPILATION_UNIT
`--CLASS_DEF -> CLASS_DEF
    |--MODIFIERS -> MODIFIERS
    |   |--BLOCK_COMMENT_BEGIN -> /*
    |   |   |--COMMENT_CONTENT -> *\r\n * @serial exclude\r\n
    |   |   |   `--JAVADOC -> JAVADOC
    |   |   |       |--NEWLINE -> \r\n
    |   |   |       |--LEADING_ASTERISK ->  *
    |   |   |       |--WS ->
    |   |   |       |--JAVADOC_TAG -> JAVADOC_TAG
    |   |   |       |   |--SERIAL_LITERAL -> @serial
    |   |   |       |   |--WS ->
    |   |   |       |   |--LITERAL_EXCLUDE -> exclude
    |   |   |       |   |--NEWLINE -> \r\n
    |   |   |       |   `--WS ->
    |   |   |       `--EOF -> <EOF>
    |   |   `--BLOCK_COMMENT_END -> */
    |   `--LITERAL_PUBLIC -> public
    |--LITERAL_CLASS -> class
    |--IDENT -> Test
    `--OBJBLOCK -> OBJBLOCK
        |--LCURLY -> {
        `--RCURLY -> }
```
