### PR TITLE
Issue #13345: Enable example test for OrderedPropertiesCheck

### DIFF
--- a/src/site/xdoc/checks/misc/orderedproperties.xml
+++ b/src/site/xdoc/checks/misc/orderedproperties.xml
@@ -63,15 +63,16 @@
   &lt;module name=&quot;OrderedProperties&quot;/&gt;
 &lt;/module&gt;
         </source>
-        <p id="Example1-code">
+        <p id="Example1-raw">
           Example properties file:
         </p>
         <source>
-A =65
-a =97
-key =107 than nothing
-key.sub =k is 107 and dot is 46
-key.png =value - violation
+A=65
+a=97
+key=107 than nothing
+key.sub=k is 107 and dot is 46
+key.png=value
+# // violation above 'Property key 'key.png' is not in the right order with previous property 'key.sub''
         </source>
         <p>
           We check order of key's only. Here we would like to use a Locale independent

--- a/src/site/xdoc/checks/misc/orderedproperties.xml.template
+++ b/src/site/xdoc/checks/misc/orderedproperties.xml.template
@@ -48,16 +48,16 @@
         </p>
         <macro name="example">
           <param name="path"
-                 value="resources/com/puppycrawl/tools/checkstyle/checks/orderedproperties/Example1.txt"/>
+                 value="resources/com/puppycrawl/tools/checkstyle/checks/orderedproperties/Example1.java"/>
           <param name="type" value="config"/>
         </macro>
-        <p id="Example1-code">
+        <p id="Example1-raw">
           Example properties file:
         </p>
         <macro name="example">
           <param name="path"
-                 value="resources/com/puppycrawl/tools/checkstyle/checks/orderedproperties/Example1.txt"/>
-          <param name="type" value="code"/>
+                 value="resources/com/puppycrawl/tools/checkstyle/checks/orderedproperties/Example1.properties"/>
+          <param name="type" value="raw"/>
         </macro>
         <p>
           We check order of key's only. Here we would like to use a Locale independent

--- a/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/checks/OrderedPropertiesCheckExamplesTest.java
+++ b/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/checks/OrderedPropertiesCheckExamplesTest.java
@@ -19,12 +19,12 @@
 
 package com.puppycrawl.tools.checkstyle.checks;
 
-import org.junit.jupiter.api.Disabled;
+import static com.puppycrawl.tools.checkstyle.checks.OrderedPropertiesCheck.MSG_KEY;
+
 import org.junit.jupiter.api.Test;
 
 import com.puppycrawl.tools.checkstyle.AbstractExamplesModuleTestSupport;
 
-@Disabled("until https://github.com/checkstyle/checkstyle/issues/13345")
 public class OrderedPropertiesCheckExamplesTest extends AbstractExamplesModuleTestSupport {
     @Override
     protected String getPackageLocation() {
@@ -34,9 +34,10 @@ public class OrderedPropertiesCheckExamplesTest extends AbstractExamplesModuleTe
     @Test
     public void testExample1() throws Exception {
         final String[] expected = {
-
+            "5: " + getCheckMessage(MSG_KEY, "key.png", "key.sub"),
         };
 
-        verifyWithInlineConfigParser(getPath("Example1.txt"), expected);
+        verifyWithInlineConfigParserSeparateConfigAndTarget(
+                getPath("Example1.java"), getPath("Example1.properties"), expected);
     }
 }

--- a/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/orderedproperties/Example1.java
+++ b/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/orderedproperties/Example1.java
@@ -3,11 +3,8 @@
   <module name="OrderedProperties"/>
 </module>
 */
+package com.puppycrawl.tools.checkstyle.checks.orderedproperties;
 
+public class Example1 { }
 // xdoc section -- start
-A =65
-a =97
-key =107 than nothing
-key.sub =k is 107 and dot is 46
-key.png =value - violation
 // xdoc section -- end

--- a/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/orderedproperties/Example1.properties
+++ b/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/orderedproperties/Example1.properties
@@ -1,0 +1,6 @@
+A=65
+a=97
+key=107 than nothing
+key.sub=k is 107 and dot is 46
+key.png=value
+# // violation above 'Property key 'key.png' is not in the right order with previous property 'key.sub''


### PR DESCRIPTION
Issue https://github.com/checkstyle/checkstyle/issues/13345
Enable examples tests for `OrderedPropertiesCheck`

- .txt converted to .java + .properties
- xml updated
- enabled example tests
- used new method in `AbstractModuleTestSupport`

https://checkstyle.org/checks/misc/orderedproperties.html#Examples