### PR TITLE
Issue #14631: Updated literal_exclude in JavadocTokenTypes.java to new AST format

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/api/JavadocTokenTypes.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/api/JavadocTokenTypes.java
@@ -951,10 +951,13 @@ public final class JavadocTokenTypes {
      * <pre>{@code @serial exclude}</pre>
      * <b>Tree:</b>
      * <pre>
-     * {@code |--JAVADOC_TAG[1x0] : [@serial exclude]
-     *        |--SERIAL_LITERAL[1x0] : [@serial]
-     *        |--WS[1x7] : [ ]
-     *        |--LITERAL_EXCLUDE[1x8] : [exclude]
+     * {@code
+     * JAVADOC_TAG -&gt JAVADOC_TAG
+     *  |--SERIAL_LITERAL -&gt @serial
+     *  |--WS -&gt
+     *  |--LITERAL_EXCLUDE -&gt exclude
+     *  |--NEWLINE -&gt \n
+     *  `--WS -&gt
      * }
      * </pre>
      *


### PR DESCRIPTION
Issue: #14631 

https://docs.oracle.com/javase/8/docs/technotes/tools/unix/javadoc.html#serial

**Command Used**
` java -jar checkstyle-10.21.1-all.jar -J Test.java | gsed "s/\[[0-9]\+:[0-9]\+\]//g"`

**Test.java**
```
/**
 * @serial exclude
 */
public class Test {
}
```

```
devanggupta@Devangs-MacBook-Pro Literal Exclude Ast % java -jar checkstyle-10.21.1-all.jar -J Test.java | gsed "s/\[[0-9]\+:[0-9]\+\]//g"
COMPILATION_UNIT -> COMPILATION_UNIT 
`--CLASS_DEF -> CLASS_DEF 
    |--MODIFIERS -> MODIFIERS 
    |   |--BLOCK_COMMENT_BEGIN -> /* 
    |   |   |--COMMENT_CONTENT -> *\n * @serial exclude\n  
    |   |   |   `--JAVADOC -> JAVADOC 
    |   |   |       |--NEWLINE -> \n 
    |   |   |       |--LEADING_ASTERISK ->  * 
    |   |   |       |--WS ->   
    |   |   |       |--JAVADOC_TAG -> JAVADOC_TAG 
    |   |   |       |   |--SERIAL_LITERAL -> @serial 
    |   |   |       |   |--WS ->   
    |   |   |       |   |--LITERAL_EXCLUDE -> exclude 
    |   |   |       |   |--NEWLINE -> \n 
    |   |   |       |   `--WS ->   
    |   |   |       `--EOF -> <EOF> 
    |   |   `--BLOCK_COMMENT_END -> */ 
    |   `--LITERAL_PUBLIC -> public 
    |--LITERAL_CLASS -> class 
    |--IDENT -> Test 
    `--OBJBLOCK -> OBJBLOCK 
        |--LCURLY -> { 
        `--RCURLY -> } 
```