### PR TITLE
Issue #16127: Correctly handle windows file paths in SARIF and add a doc link to nvim-lint.

### DIFF
--- a/config/jsoref-spellchecker/whitelist.words
+++ b/config/jsoref-spellchecker/whitelist.words
@@ -376,6 +376,7 @@ emptystatement
 emptytag
 Emtpy
 endline
+enegger
 ENMI
 ent
 enum
@@ -819,6 +820,7 @@ methodparampad
 methodsandconstructorsannotations
 methodtypeparametername
 MEZk
+mfussenegger
 Micha
 microsoft
 minimalistic
@@ -888,6 +890,7 @@ ncss
 needbraces
 NEGS
 Nejmeh
+neovim
 NEQ
 nestedfordepth
 nestedifdepth
@@ -962,6 +965,7 @@ nullness
 numberperline
 numericliterals
 nutsandbolts
+nvim
 nvuillam
 OAuth
 objblock
@@ -1228,6 +1232,7 @@ solr
 someinner
 somename
 someoneelse
+someuser
 sonarcloud
 sonarqube
 sonarsource

--- a/src/site/xdoc/index.xml.vm
+++ b/src/site/xdoc/index.xml.vm
@@ -535,6 +535,13 @@
                   configuration could be seen at jdee-checkstyle.el</a></td>
             </tr>
             <tr>
+              <td><a href="https://neovim.io/">Neovim</a></td>
+              <td>Mathias Fußenegger</td>
+              <td><a href="https://github.com/mfussenegger/nvim-lint">nvim-lint</a></td>
+              <td>An asynchronous linter plugin for Neovim complementary to the built-in Language
+                  Server Protocol support.</td>
+            </tr>
+            <tr>
               <td><a href="https://code.visualstudio.com/">Visual Studio Code</a></td>
               <td>Sheng Chen</td>
               <td><a href="https://marketplace.visualstudio.com/items?itemName=shengchen.vscode-checkstyle">

--- a/src/test/java/com/puppycrawl/tools/checkstyle/SarifLoggerTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/SarifLoggerTest.java
@@ -211,6 +211,92 @@ public class SarifLoggerTest extends AbstractModuleTestSupport {
         verifyContent(getPath("ExpectedSarifLoggerEmpty.sarif"), outStream);
     }
 
+    @Test
+    public void testAddErrorWithSpaceInPath() throws IOException {
+        final SarifLogger logger = new SarifLogger(outStream,
+                OutputStreamOptions.CLOSE);
+        logger.auditStarted(null);
+        final Violation violation =
+                new Violation(1, 1,
+                        "messages.properties", "ruleId", null, SeverityLevel.ERROR, null,
+                        getClass(), "found an error");
+        final AuditEvent ev = new AuditEvent(this, "/home/someuser/Code/Test 2.java", violation);
+        logger.fileStarted(ev);
+        logger.addError(ev);
+        logger.fileFinished(ev);
+        logger.auditFinished(null);
+        verifyContent(getPath("ExpectedSarifLoggerSpaceInPath.sarif"), outStream);
+    }
+
+    @Test
+    public void testAddErrorWithAbsoluteLinuxPath() throws IOException {
+        final SarifLogger logger = new SarifLogger(outStream,
+                OutputStreamOptions.CLOSE);
+        logger.auditStarted(null);
+        final Violation violation =
+                new Violation(1, 1,
+                        "messages.properties", "ruleId", null, SeverityLevel.ERROR, null,
+                        getClass(), "found an error");
+        final AuditEvent ev = new AuditEvent(this, "/home/someuser/Code/Test.java", violation);
+        logger.fileStarted(ev);
+        logger.addError(ev);
+        logger.fileFinished(ev);
+        logger.auditFinished(null);
+        verifyContent(getPath("ExpectedSarifLoggerAbsoluteLinuxPath.sarif"), outStream);
+    }
+
+    @Test
+    public void testAddErrorWithRelativeLinuxPath() throws IOException {
+        final SarifLogger logger = new SarifLogger(outStream,
+                OutputStreamOptions.CLOSE);
+        logger.auditStarted(null);
+        final Violation violation =
+                new Violation(1, 1,
+                        "messages.properties", "ruleId", null, SeverityLevel.ERROR, null,
+                        getClass(), "found an error");
+        final AuditEvent ev = new AuditEvent(this, "./Test.java", violation);
+        logger.fileStarted(ev);
+        logger.addError(ev);
+        logger.fileFinished(ev);
+        logger.auditFinished(null);
+        verifyContent(getPath("ExpectedSarifLoggerRelativeLinuxPath.sarif"), outStream);
+    }
+
+    @Test
+    public void testAddErrorWithAbsoluteWindowsPath() throws IOException {
+        final SarifLogger logger = new SarifLogger(outStream,
+                OutputStreamOptions.CLOSE);
+        logger.auditStarted(null);
+        final Violation violation =
+                new Violation(1, 1,
+                        "messages.properties", "ruleId", null, SeverityLevel.ERROR, null,
+                        getClass(), "found an error");
+        final AuditEvent ev =
+                new AuditEvent(this, "C:\\Users\\SomeUser\\Code\\Test.java", violation);
+        logger.fileStarted(ev);
+        logger.addError(ev);
+        logger.fileFinished(ev);
+        logger.auditFinished(null);
+        verifyContent(getPath("ExpectedSarifLoggerAbsoluteWindowsPath.sarif"), outStream);
+    }
+
+    @Test
+    public void testAddErrorWithRelativeWindowsPath() throws IOException {
+        final SarifLogger logger = new SarifLogger(outStream,
+                OutputStreamOptions.CLOSE);
+        logger.auditStarted(null);
+        final Violation violation =
+                new Violation(1, 1,
+                        "messages.properties", "ruleId", null, SeverityLevel.ERROR, null,
+                        getClass(), "found an error");
+        final AuditEvent ev = new AuditEvent(this, ".\\Test.java", violation);
+        logger.fileStarted(ev);
+        logger.addError(ev);
+        logger.fileFinished(ev);
+        logger.auditFinished(null);
+        verifyContent(getPath("ExpectedSarifLoggerRelativeWindowsPath.sarif"), outStream);
+    }
+
     /**
      * We keep this test for 100% coverage. Until #12873.
      */

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/sariflogger/ExpectedSarifLoggerAbsoluteLinuxPath.sarif
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/sariflogger/ExpectedSarifLoggerAbsoluteLinuxPath.sarif
@@ -20,24 +20,23 @@
       "results": [
         {
           "level": "error",
-          "message": {
-            "text": "stackTrace\nexample"
-          }
-        },
-        {
-          "level": "error",
           "locations": [
             {
               "physicalLocation": {
                 "artifactLocation": {
-                  "uri": "file:Test.java"
+                  "uri": "file:/home/someuser/Code/Test.java"
+                },
+                "region": {
+                  "startColumn": 1,
+                  "startLine": 1
                 }
               }
             }
           ],
           "message": {
-            "text": "stackTrace\nexample"
-          }
+            "text": "found an error"
+          },
+          "ruleId": "ruleId"
         }
       ]
     }

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/sariflogger/ExpectedSarifLoggerAbsoluteWindowsPath.sarif
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/sariflogger/ExpectedSarifLoggerAbsoluteWindowsPath.sarif
@@ -20,24 +20,23 @@
       "results": [
         {
           "level": "error",
-          "message": {
-            "text": "stackTrace\nexample"
-          }
-        },
-        {
-          "level": "error",
           "locations": [
             {
               "physicalLocation": {
                 "artifactLocation": {
-                  "uri": "file:Test.java"
+                  "uri": "file:/C:/Users/SomeUser/Code/Test.java"
+                },
+                "region": {
+                  "startColumn": 1,
+                  "startLine": 1
                 }
               }
             }
           ],
           "message": {
-            "text": "stackTrace\nexample"
-          }
+            "text": "found an error"
+          },
+          "ruleId": "ruleId"
         }
       ]
     }

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/sariflogger/ExpectedSarifLoggerDoubleError.sarif
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/sariflogger/ExpectedSarifLoggerDoubleError.sarif
@@ -24,7 +24,7 @@
             {
               "physicalLocation": {
                 "artifactLocation": {
-                  "uri": "Test.java"
+                  "uri": "file:Test.java"
                 },
                 "region": {
                   "startColumn": 1,
@@ -44,7 +44,7 @@
             {
               "physicalLocation": {
                 "artifactLocation": {
-                  "uri": "Test.java"
+                  "uri": "file:Test.java"
                 },
                 "region": {
                   "startColumn": 1,

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/sariflogger/ExpectedSarifLoggerLineOnly.sarif
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/sariflogger/ExpectedSarifLoggerLineOnly.sarif
@@ -24,7 +24,7 @@
             {
               "physicalLocation": {
                 "artifactLocation": {
-                  "uri": "Test.java"
+                  "uri": "file:Test.java"
                 },
                 "region": {
                   "startLine": 1

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/sariflogger/ExpectedSarifLoggerRelativeLinuxPath.sarif
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/sariflogger/ExpectedSarifLoggerRelativeLinuxPath.sarif
@@ -20,24 +20,23 @@
       "results": [
         {
           "level": "error",
-          "message": {
-            "text": "stackTrace\nexample"
-          }
-        },
-        {
-          "level": "error",
           "locations": [
             {
               "physicalLocation": {
                 "artifactLocation": {
-                  "uri": "file:Test.java"
+                  "uri": "file:./Test.java"
+                },
+                "region": {
+                  "startColumn": 1,
+                  "startLine": 1
                 }
               }
             }
           ],
           "message": {
-            "text": "stackTrace\nexample"
-          }
+            "text": "found an error"
+          },
+          "ruleId": "ruleId"
         }
       ]
     }

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/sariflogger/ExpectedSarifLoggerRelativeWindowsPath.sarif
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/sariflogger/ExpectedSarifLoggerRelativeWindowsPath.sarif
@@ -20,24 +20,23 @@
       "results": [
         {
           "level": "error",
-          "message": {
-            "text": "stackTrace\nexample"
-          }
-        },
-        {
-          "level": "error",
           "locations": [
             {
               "physicalLocation": {
                 "artifactLocation": {
-                  "uri": "file:Test.java"
+                  "uri": "file:./Test.java"
+                },
+                "region": {
+                  "startColumn": 1,
+                  "startLine": 1
                 }
               }
             }
           ],
           "message": {
-            "text": "stackTrace\nexample"
-          }
+            "text": "found an error"
+          },
+          "ruleId": "ruleId"
         }
       ]
     }

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/sariflogger/ExpectedSarifLoggerSingleError.sarif
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/sariflogger/ExpectedSarifLoggerSingleError.sarif
@@ -24,7 +24,7 @@
             {
               "physicalLocation": {
                 "artifactLocation": {
-                  "uri": "Test.java"
+                  "uri": "file:Test.java"
                 },
                 "region": {
                   "startColumn": 1,

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/sariflogger/ExpectedSarifLoggerSingleWarning.sarif
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/sariflogger/ExpectedSarifLoggerSingleWarning.sarif
@@ -24,7 +24,7 @@
             {
               "physicalLocation": {
                 "artifactLocation": {
-                  "uri": "Test.java"
+                  "uri": "file:Test.java"
                 },
                 "region": {
                   "startColumn": 1,

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/sariflogger/ExpectedSarifLoggerSpaceInPath.sarif
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/sariflogger/ExpectedSarifLoggerSpaceInPath.sarif
@@ -20,24 +20,23 @@
       "results": [
         {
           "level": "error",
-          "message": {
-            "text": "stackTrace\nexample"
-          }
-        },
-        {
-          "level": "error",
           "locations": [
             {
               "physicalLocation": {
                 "artifactLocation": {
-                  "uri": "file:Test.java"
+                  "uri": "file:/home/someuser/Code/Test%202.java"
+                },
+                "region": {
+                  "startColumn": 1,
+                  "startLine": 1
                 }
               }
             }
           ],
           "message": {
-            "text": "stackTrace\nexample"
-          }
+            "text": "found an error"
+          },
+          "ruleId": "ruleId"
         }
       ]
     }


### PR DESCRIPTION
Issue #16127

I am not sure this covers all cases that the URIs will always be valid, but I didn't find a Java method that doesn't change relative paths to absolute paths automatically. I have already spent most of the day on this, because the test tooling for this project is quite slow.