### PR TITLE
Issue #14631: Updated LITERAL_INCLUDE in JavadocTokenTypes.java to new AST format

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/api/JavadocTokenTypes.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/api/JavadocTokenTypes.java
@@ -976,10 +976,13 @@ public final class JavadocTokenTypes {
      * <pre>{@code @serial include}</pre>
      * <b>Tree:</b>
      * <pre>
-     * {@code |--JAVADOC_TAG[1x0] : [@serial include]
-     *        |--SERIAL_LITERAL[1x0] : [@serial]
-     *        |--WS[1x7] : [ ]
-     *        |--LITERAL_INCLUDE[1x8] : [include]
+     * {@code
+     * JAVADOC_TAG -> JAVADOC_TAG
+     *   |--SERIAL_LITERAL -> @serial
+     *   |--WS ->
+     *   |--LITERAL_INCLUDE -> include
+     *   |--NEWLINE -> \r\n
+     *   `--WS ->
      * }
      * </pre>
      *


### PR DESCRIPTION
Issue #14631

