### PR TITLE
Issue #14631: Updated LITERAL_INCLUDE in JavadocTokenTypes.java in new AST format

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/api/JavadocTokenTypes.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/api/JavadocTokenTypes.java
@@ -976,10 +976,13 @@ public final class JavadocTokenTypes {
      * <pre>{@code @serial include}</pre>
      * <b>Tree:</b>
      * <pre>
-     * {@code |--JAVADOC_TAG[1x0] : [@serial include]
-     *        |--SERIAL_LITERAL[1x0] : [@serial]
-     *        |--WS[1x7] : [ ]
-     *        |--LITERAL_INCLUDE[1x8] : [include]
+     * {@code
+     * JAVADOC_TAG -&gt JAVADOC_TAG
+     *  |--SERIAL_LITERAL -&gt @serial
+     *  |--WS -&gt
+     *  |--LITERAL_INCLUDE -&gt include
+     *  |--NEWLINE -&gt \r\n
+     *  `--WS -&gt
      * }
      * </pre>
      *


### PR DESCRIPTION
Issue #14631

**comment used**
`java -jar checkstyle-10.21.1-all.jar -J Test.java | sed "s/\[[0-9]\+:[0-9]\+\]//g"`

**Test.java**
```
/**
 *@serial include
 */
public class Test {
}
```


```
AHIL@DESKTOP-17M5Q0M MINGW64 ~/IdeaProjects/literal_include AST
$ java -jar checkstyle-10.21.1-all.jar -J Test.java | sed "s/\[[0-9]\+:[0-9]\+\]//g"
COMPILATION_UNIT -> COMPILATION_UNIT
`--CLASS_DEF -> CLASS_DEF
    |--MODIFIERS -> MODIFIERS
    |   |--BLOCK_COMMENT_BEGIN -> /*
    |   |   |--COMMENT_CONTENT -> *\r\n *@serial include\r\n
    |   |   |   `--JAVADOC -> JAVADOC
    |   |   |       |--NEWLINE -> \r\n
    |   |   |       |--LEADING_ASTERISK ->  *
    |   |   |       |--JAVADOC_TAG -> JAVADOC_TAG
    |   |   |       |   |--SERIAL_LITERAL -> @serial
    |   |   |       |   |--WS ->
    |   |   |       |   |--LITERAL_INCLUDE -> include
    |   |   |       |   |--NEWLINE -> \r\n
    |   |   |       |   `--WS ->
    |   |   |       `--EOF -> <EOF>
    |   |   `--BLOCK_COMMENT_END -> */
    |   `--LITERAL_PUBLIC -> public
    |--LITERAL_CLASS -> class
    |--IDENT -> Test
    `--OBJBLOCK -> OBJBLOCK
        |--LCURLY -> {
        `--RCURLY -> }

```

**Final Changes**
```
     * JAVADOC_TAG -&gt JAVADOC_TAG
     *  |--SERIAL_LITERAL -&gt @serial
     *  |--WS -&gt
     *  |--LITERAL_INCLUDE -&gt include
     *  |--NEWLINE -&gt \r\n
     *  `--WS -&gt
```