### PR TITLE
Issue #14631: Updated Hash_literal in JavadocTokenTypes.java to new AST format

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/api/JavadocTokenTypes.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/api/JavadocTokenTypes.java
@@ -715,21 +715,18 @@ public final class JavadocTokenTypes {
      * <pre>{@code @see org.apache.utils.Lists.Comparator#compare(Object)}</pre>
      * <b>Tree:</b>
      * <pre>
-     * {@code |--JAVADOC_TAG[3x0] : [@see org.apache.utils.Lists.Comparator#compare(Object)]
-     *        |--SEE_LITERAL[3x0] : [@see]
-     *        |--WS[3x4] : [ ]
-     *        |--REFERENCE[3x5] : [org.apache.utils.Lists.Comparator#compare(Object)]
-     *            |--PACKAGE_CLASS[3x5] : [org.apache.utils]
-     *            |--DOT[3x21] : [.]
-     *            |--CLASS[3x22] : [Lists]
-     *            |--DOT[3x27] : [.]
-     *            |--CLASS[3x28] : [Comparator]
-     *            |--HASH[3x38] : [#]
-     *            |--MEMBER[3x39] : [compare]
-     *            |--PARAMETERS[3x46] : [(Object)]
-     *                |--LEFT_BRACE[3x46] : [(]
-     *                |--ARGUMENT[3x47] : [Object]
-     *                |--RIGHT_BRACE[3x53] : [)]
+     * {@code
+     * JAVADOC_TAG -&gt JAVADOC_TAG
+     *  |--SEE_LITERAL -&gt @see
+     *  |--WS -&gt
+     *  |--REFERENCE -&gt REFERENCE
+     *      |--PACKAGE_CLASS -&gt org.apache.utils.Lists.Comparator
+     *      |--HASH -&gt #
+     *      |--MEMBER -&gt compare
+     *      `--PARAMETERS -&gt PARAMETERS
+     *          |--LEFT_BRACE -&gt (
+     *          |--ARGUMENT -&gt Object
+     *          `--RIGHT_BRACE -&gt )
      * }
      * </pre>
      */


### PR DESCRIPTION
Issue: #14631

**Command used:**
java -jar checkstyle-10.16.0-all.jar -j Test.java | sed "s/\[[0-9]\+:[0-9]\+\]//g"

**Test.java**
@see org.apache.utils.Lists.Comparator#compare(Object)

```
JAVADOC -> JAVADOC [0:0]
|--TEXT -> /** [0:0]
|--NEWLINE -> \r\n [0:3]
|--LEADING_ASTERISK ->  * [1:0]
|--WS ->   [1:2]
|--JAVADOC_TAG -> JAVADOC_TAG [1:3]
|   |--SEE_LITERAL -> @see [1:3]
|   |--WS ->   [1:7]
|   |--REFERENCE -> REFERENCE [1:8]
|   |   |--PACKAGE_CLASS -> org.apache.utils.Lists.Comparator [1:8]
|   |   |--HASH -> # [1:41]
|   |   |--MEMBER -> compare [1:42]
|   |   `--PARAMETERS -> PARAMETERS [1:49]
|   |       |--LEFT_BRACE -> ( [1:49]
|   |       |--ARGUMENT -> Object [1:50]
|   |       `--RIGHT_BRACE -> ) [1:56]
|   |--NEWLINE -> \r\n [1:57]
|   `--DESCRIPTION -> DESCRIPTION [2:0]
|       |--LEADING_ASTERISK ->  * [2:0]
|       |--TEXT -> / [2:2]
|       |--NEWLINE -> \r\n [2:3]
|       |--TEXT -> public class Test{ [3:0]
|       |--NEWLINE -> \r\n [3:18]
|       `--TEXT -> } [4:0]
`--EOF -> <EOF> [4:1]
```