### PR TITLE
infra: Update azure-pipelines.yml to use macOS-14 instead of deprecat…

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -92,12 +92,12 @@ strategy:
 
     # MacOS JDK11 verify
     'MacOS JDK11 verify':
-      image: 'macOS-12'
+      image: 'macOS-14'
       cmd: "JAVA_HOME=$JAVA_HOME_11_X64 mvn -e --no-transfer-progress verify"
 
     # MacOS JDK17 verify
     'MacOS JDK17 verify':
-      image: 'macOS-12'
+      image: 'macOS-14'
       cmd: "JAVA_HOME=$JAVA_HOME_17_X64 mvn -e --no-transfer-progress verify"
 
     # moved back to Travis till we find a way to keep secrets in azure
@@ -116,7 +116,7 @@ strategy:
 
     # lint for .md files, OSX is used because there is problem to install gem on linux
     'markdownlint':
-      image: 'macOS-12'
+      image: 'macOS-14'
       cmd: "./.ci/validation.sh markdownlint"
       skipCache: true
       needMdl: true


### PR DESCRIPTION
…ed macOS-12

https://devblogs.microsoft.com/devops/upcoming-deprecation-of-macos-12-hosted-pipeline-image/