### PR TITLE
Issue #16101: Fixed MagicNumber Check Bug

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/MagicNumberCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/MagicNumberCheck.java
@@ -262,19 +262,11 @@ public class MagicNumberCheck extends AbstractCheck {
         if (shouldTestAnnotationArgs(ast)
                 && shouldTestAnnotationDefaults(ast)
                 && !isInIgnoreList(ast)
-                && (!ignoreHashCodeMethod || !isInHashCodeMethod(ast))) {
+                && shouldCheckHashCodeMethod(ast)
+                && shouldCheckFieldDeclaration(ast)) {
             final DetailAST constantDefAST = findContainingConstantDef(ast);
-
-            if (constantDefAST == null) {
-                if (!ignoreFieldDeclaration || !isFieldDeclaration(ast)) {
-                    reportMagicNumber(ast);
-                }
-            }
-            else {
-                final boolean found = isMagicNumberExists(ast, constantDefAST);
-                if (found) {
-                    reportMagicNumber(ast);
-                }
+            if (isMagicNumberExists(ast, constantDefAST)) {
+                reportMagicNumber(ast);
             }
         }
     }
@@ -300,6 +292,26 @@ public class MagicNumberCheck extends AbstractCheck {
     }
 
     /**
+     * Checks if the given AST node is a HashCode Method and should be checked.
+     *
+     * @param ast the AST node to check
+     * @return true if element should be checked, false otherwise
+     */
+    private boolean shouldCheckHashCodeMethod(DetailAST ast) {
+        return !ignoreHashCodeMethod || !isInHashCodeMethod(ast);
+    }
+
+    /**
+     * Checks if the given AST node is a field declaration and should be checked.
+     *
+     * @param ast the AST node to check
+     * @return true if element should be checked, false otherwise
+     */
+    private boolean shouldCheckFieldDeclaration(DetailAST ast) {
+        return !ignoreFieldDeclaration || !isFieldDeclaration(ast);
+    }
+
+    /**
      * Is magic number somewhere at ast tree.
      *
      * @param ast ast token
@@ -311,10 +323,12 @@ public class MagicNumberCheck extends AbstractCheck {
         DetailAST astNode = ast.getParent();
         while (astNode != constantDefAST) {
             final int type = astNode.getType();
+
             if (!constantWaiverParentToken.get(type)) {
                 found = true;
                 break;
             }
+
             astNode = astNode.getParent();
         }
         return found;
@@ -451,6 +465,7 @@ public class MagicNumberCheck extends AbstractCheck {
                 && (varDefAST.getParent().getParent().getType() == TokenTypes.CLASS_DEF
                 || varDefAST.getParent().getParent().getType() == TokenTypes.RECORD_DEF
                 || varDefAST.getParent().getParent().getType() == TokenTypes.LITERAL_NEW);
+
     }
 
     /**

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/coding/MagicNumberCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/coding/MagicNumberCheckTest.java
@@ -527,6 +527,61 @@ public class MagicNumberCheckTest
     }
 
     @Test
+    public void testIgnoreFieldDeclaration4()
+            throws Exception {
+        final String[] expected = {
+            "29:27: " + getCheckMessage(MSG_KEY, "5"),
+            "36:26: " + getCheckMessage(MSG_KEY, "86400_000"),
+            "45:31: " + getCheckMessage(MSG_KEY, "5"),
+            "46:32: " + getCheckMessage(MSG_KEY, "69"),
+            "55:27: " + getCheckMessage(MSG_KEY, "5"),
+            "62:26: " + getCheckMessage(MSG_KEY, "86400_000"),
+            "71:31: " + getCheckMessage(MSG_KEY, "5"),
+            "72:32: " + getCheckMessage(MSG_KEY, "69"),
+        };
+        verifyWithInlineConfigParser(
+                getPath("InputMagicNumberIgnoreFieldDeclaration4.java"), expected);
+    }
+
+    @Test
+    public void testIgnoreFieldDeclaration5()
+            throws Exception {
+        final String[] expected = {
+            "17:32: " + getCheckMessage(MSG_KEY, "22"),
+            "17:37: " + getCheckMessage(MSG_KEY, "7.0"),
+            "23:20: " + getCheckMessage(MSG_KEY, "10"),
+            "24:20: " + getCheckMessage(MSG_KEY, "10"),
+            "24:25: " + getCheckMessage(MSG_KEY, "20"),
+            "28:30: " + getCheckMessage(MSG_KEY, "4"),
+            "28:33: " + getCheckMessage(MSG_KEY, "5"),
+            "28:36: " + getCheckMessage(MSG_KEY, "6"),
+            "28:39: " + getCheckMessage(MSG_KEY, "7"),
+            "35:26: " + getCheckMessage(MSG_KEY, "2023"),
+            "35:32: " + getCheckMessage(MSG_KEY, "11"),
+            "35:36: " + getCheckMessage(MSG_KEY, "11"),
+            "35:40: " + getCheckMessage(MSG_KEY, "11"),
+            "42:16: " + getCheckMessage(MSG_KEY, "11"),
+            "42:20: " + getCheckMessage(MSG_KEY, "11"),
+            "42:24: " + getCheckMessage(MSG_KEY, "11"),
+            "48:41: " + getCheckMessage(MSG_KEY, "3"),
+            "49:61: " + getCheckMessage(MSG_KEY, "4"),
+        };
+        verifyWithInlineConfigParser(
+                getPath("InputMagicNumberIgnoreFieldDeclaration5.java"), expected);
+    }
+
+    @Test
+    public void testIgnoreFieldDeclaration6()
+            throws Exception {
+        final String[] expected = {
+            "16:38: " + getCheckMessage(MSG_KEY, "10"),
+            "17:46: " + getCheckMessage(MSG_KEY, "15"),
+        };
+        verifyWithInlineConfigParser(
+                getPath("InputMagicNumberIgnoreFieldDeclaration6.java"), expected);
+    }
+
+    @Test
     public void testWaiverParentToken()
             throws Exception {
         final String[] expected = {

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/magicnumber/InputMagicNumberIgnoreFieldDeclaration4.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/magicnumber/InputMagicNumberIgnoreFieldDeclaration4.java
@@ -1,0 +1,76 @@
+/*
+MagicNumber
+ignoreNumbers = -2, -1, 0, 1, 2, 100
+ignoreHashCodeMethod = true
+ignoreFieldDeclaration = true
+constantWaiverParentToken = ARRAY_INIT, ASSIGN, ELIST, EXPR
+
+*/
+
+package com.puppycrawl.tools.checkstyle.checks.coding.magicnumber;
+
+import java.util.concurrent.Callable;
+import java.util.function.BiFunction;
+
+public class InputMagicNumberIgnoreFieldDeclaration4 {
+    public final int radius = 10;
+    public final double area = 22 / 7.0 * radius * radius;
+    public final int a[] = {4, 5};
+
+    public int x = 10;
+    public int y = 10 * 20;
+    public int[] z = {4, 5};
+
+    private static final Callable<Void> SLEEP_FOR_A_DAY = () -> {
+        Thread.sleep(86400_000);
+        return null;
+    };
+    private static final BiFunction<Integer, Integer, Integer> ADD_AND_SQUARE = (a, b) -> {
+        int sum = a + b + 5; // violation ''5' is a magic number'
+        return sum * sum * 69;
+    };
+
+    private static final Callable<Void> SLEEP_FOR_A_DAY_EXP = new Callable<Void>() {
+        @Override
+        public Void call() throws InterruptedException {
+            Thread.sleep(86400_000); // violation ''86400_000' is a magic number'
+            return null;
+        }
+    };
+
+    private static final BiFunction<Integer, Integer, Integer>
+            ADD_AND_SQUARE_EXP = new BiFunction<Integer, Integer, Integer>() {
+        @Override
+        public Integer apply(Integer a, Integer b) {
+            int sum = a + b + 5; // violation ''5' is a magic number'
+            return sum * sum * 69; // violation ''69' is a magic number'
+        }
+    };
+
+    private final Callable<Void> SLEEP_FOR_A_DAY_NS = () -> {
+        Thread.sleep(86400_000);
+        return null;
+    };
+    private final BiFunction<Integer, Integer, Integer> ADD_AND_SQUARE_NS = (a, b) -> {
+        int sum = a + b + 5; // violation ''5' is a magic number'
+        return sum * sum * 69;
+    };
+
+    private final Callable<Void> SLEEP_FOR_A_DAY_EXP_NS = new Callable<Void>() {
+        @Override
+        public Void call() throws InterruptedException {
+            Thread.sleep(86400_000); // violation ''86400_000' is a magic number'
+            return null;
+        }
+    };
+
+    private final BiFunction<Integer, Integer, Integer>
+            ADD_AND_SQUARE_EXP_NS = new BiFunction<Integer, Integer, Integer>() {
+        @Override
+        public Integer apply(Integer a, Integer b) {
+            int sum = a + b + 5; // violation ''5' is a magic number'
+            return sum * sum * 69; // violation ''69' is a magic number'
+        }
+    };
+
+}

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/magicnumber/InputMagicNumberIgnoreFieldDeclaration5.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/magicnumber/InputMagicNumberIgnoreFieldDeclaration5.java
@@ -1,0 +1,52 @@
+/*
+MagicNumber
+ignoreNumbers = -2, -1, 0, 1, 2, 100
+ignoreHashCodeMethod = true
+ignoreFieldDeclaration = (default)false
+constantWaiverParentToken = ARRAY_INIT, ASSIGN, ELIST, EXPR
+
+*/
+
+package com.puppycrawl.tools.checkstyle.checks.coding.magicnumber;
+
+import java.time.OffsetDateTime;
+import java.time.ZoneOffset;
+
+public class InputMagicNumberIgnoreFieldDeclaration5 {
+    public final int radius = 10;
+    public final double area = 22 / 7.0 * radius * radius;
+    // 2 violations above:
+    //                    ''22' is a magic number'
+    //                    ''7.0' is a magic number'
+    public final int a[] = {4, 5};
+
+    public int x = 10; // violation ''10' is a magic number'
+    public int y = 10 * 20;
+    // 2 violations above:
+    //                    ''10' is a magic number'
+    //                    ''20' is a magic number'
+    public static int[] z = {4, 5, 6, 7};
+    // 4 violations above:
+    //                    ''4' is a magic number'
+    //                    ''5' is a magic number'
+    //                    ''6' is a magic number'
+    //                    ''7' is a magic number'
+    private static final String TEST_TIME =
+       OffsetDateTime.of(2023, 11, 11, 11,
+       // 4 violations above:
+       //                    ''2023' is a magic number'
+       //                    ''11' is a magic number'
+       //                    ''11' is a magic number'
+       //                    ''11' is a magic number'
+
+               11, 11, 11, ZoneOffset.of("Z")).toString();
+               // 3 violations above:
+               //                    ''11' is a magic number'
+               //                    ''11' is a magic number'
+               //                    ''11' is a magic number'
+
+    public static int OFFSETOF_NAME = z[3]; // violation ''3' is a magic number'
+    public static Object[] STABLE_OBJECT_ARRAY = new Object[4];
+    // 1 violations above:
+    //                   ''4' is a magic number'
+}

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/magicnumber/InputMagicNumberIgnoreFieldDeclaration6.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/magicnumber/InputMagicNumberIgnoreFieldDeclaration6.java
@@ -1,0 +1,21 @@
+/*
+MagicNumber
+ignoreNumbers = -2, -1, 0, 1, 2, 100
+ignoreAnnotation = false
+ignoreFieldDeclaration = true
+constantWaiverParentToken = ARRAY_INIT, ASSIGN, ELIST
+
+*/
+package com.puppycrawl.tools.checkstyle.checks.coding.magicnumber;
+
+public class InputMagicNumberIgnoreFieldDeclaration6 {
+
+    @interface MyAnnotation {
+        int value() default 5; // no violation
+
+        public static int CONSTANT = 10; // violation ''10' is a magic number'
+        public static int ANOTHER_CONSTANT = 15; // violation ''15' is a magic number'
+    }
+
+    static int regularField = 42; // no violation
+}


### PR DESCRIPTION
This PR fixes Issue #16101:  where MagicNumberCheck was incorrectly flagging magic numbers in field declarations containing arithmetic operations even when ignoreFieldDeclaration=true.

The fix moves the field declaration check to the start of the visitToken method to ensure all field declarations are properly ignored when the option is enabled.
