### PR TITLE
Issue #16077: fixed #undefined links for h1 & h2 sections

### DIFF
--- a/src/site/resources/css/site.css
+++ b/src/site/resources/css/site.css
@@ -43,8 +43,12 @@ h4 {
   float: right;
 }
 
-h2:hover .anchor, h3:hover .anchor, p[id^="Example"]:hover .anchor {
+h1:hover .anchor, h2:hover .anchor, h3:hover .anchor, p[id^="Example"]:hover .anchor {
   visibility: visible;
+}
+
+h1:hover:has(> a > img:first-child) .anchor {
+  visibility: hidden;
 }
 
 .anchor {

--- a/src/site/resources/js/anchors.js
+++ b/src/site/resources/js/anchors.js
@@ -14,9 +14,9 @@
         const scriptElementSrc = scriptElement.attributes.src.textContent;
         const relativePath = scriptElementSrc.replace(/\/js\/anchors.js/, '');
 
-        var anchors = document.getElementsByTagName("h2");
+        var anchors = document.querySelectorAll("h1, h2");
         [].forEach.call(anchors, function (anchorItem) {
-            var name = anchorItem.childNodes[0].name;
+            var name = anchorItem.childNodes[0].textContent.replaceAll(" ", "_");
             var link = "" + url + "#" + name + "";
 
             var a = document.createElement("a");


### PR DESCRIPTION
part of #16077 

fixed following:

> click on name of section use to update link in browser location to have full link with anchor. Kill feature for maintainers to share link to exact place in doc. Now it is generating `#undefined`

I have fixed undefined links for h1 & h2 links. Is there any other tags like h3,h4,h5,h6 which gives `#undefined` links?