### PR TITLE
Issue #14631: Updated exception_literal in JavadocTokenTypes.java to new format of AST

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/api/JavadocTokenTypes.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/api/JavadocTokenTypes.java
@@ -283,13 +283,13 @@ public final class JavadocTokenTypes {
      * <pre>{@code @exception SQLException if query is not correct}</pre>
      * <b>Tree:</b>
      * <pre>{@code
-     *   JAVADOC_TAG -> JAVADOC_TAG
-     *    |--EXCEPTION_LITERAL -> @exception
-     *    |--WS ->
-     *    |--CLASS_NAME -> SQLException
-     *    |--WS ->
-     *    `--DESCRIPTION -> DESCRIPTION
-     *        `--TEXT -> if query is not correct
+     *   --JAVADOC_TAG -> JAVADOC_TAG
+     *      |--EXCEPTION_LITERAL -> @exception
+     *      |--WS ->
+     *      |--CLASS_NAME -> SQLException
+     *      |--WS ->
+     *      `--DESCRIPTION -> DESCRIPTION
+     *          `--TEXT -> if query is not correct
      * }</pre>
      *
      * @see


### PR DESCRIPTION
#14631 

**Command Used**
java -jar checkstyle-10.21.1-all.jar -J Test.java | sed "s/\[[0-9]\+:[0-9]\+\]//g"

**Test.java**

```
/**
 * @exception SQLException if query is not correct
 */
public class Test {
}
```
```
prave@DESKTOP-ONMIJ3B MINGW64 /e/Projects/TestProject
$ java -jar checkstyle-10.21.1-all.jar -J Test.java | sed "s/\[[0-9]\+:[0-9]\+\]//g"
COMPILATION_UNIT -> COMPILATION_UNIT
`--CLASS_DEF -> CLASS_DEF
    |--MODIFIERS -> MODIFIERS
    |   |--BLOCK_COMMENT_BEGIN -> /*
    |   |   |--COMMENT_CONTENT -> *\r\n * @exception SQLException if query is not correct\r\n
    |   |   |   `--JAVADOC -> JAVADOC
    |   |   |       |--NEWLINE -> \r\n
    |   |   |       |--LEADING_ASTERISK ->  *
    |   |   |       |--WS ->
    |   |   |       |--JAVADOC_TAG -> JAVADOC_TAG
    |   |   |       |   |--EXCEPTION_LITERAL -> @exception
    |   |   |       |   |--WS ->
    |   |   |       |   |--CLASS_NAME -> SQLException
    |   |   |       |   |--WS ->
    |   |   |       |   `--DESCRIPTION -> DESCRIPTION
    |   |   |       |       |--TEXT -> if query is not correct
    |   |   |       |       |--NEWLINE -> \r\n
    |   |   |       |       `--TEXT ->
    |   |   |       `--EOF -> <EOF>
    |   |   `--BLOCK_COMMENT_END -> */
    |   `--LITERAL_PUBLIC -> public
    |--LITERAL_CLASS -> class
    |--IDENT -> Test
    `--OBJBLOCK -> OBJBLOCK
        |--LCURLY -> {
        `--RCURLY -> }
```

