### PR TITLE
Issue #16077: changed alignment of table header text to left and added background color

### DIFF
--- a/config/jsoref-spellchecker/whitelist.words
+++ b/config/jsoref-spellchecker/whitelist.words
@@ -352,6 +352,7 @@ ecj
 eclemma
 eclipsecommunityawards
 edb
+ededed
 edef
 edu
 Eghj

--- a/src/site/resources/css/site.css
+++ b/src/site/resources/css/site.css
@@ -92,6 +92,15 @@ div, p, td, table.bodyTable td, th, table.bodyTable th, li, pre, #breadcrumbs sp
 
 img[src="images/anchor.png"] {
   max-width: unset;
+
+table {
+  text-align: left;
+  border-spacing: 2px;
+  border-collapse: separate;
+}
+
+th {
+  background-color: #ededed;
 }
 
 code {


### PR DESCRIPTION
part of #16077 

fixed following:

> all table headers column text should be adjusted to left. Not a middle of cell.