### PR TITLE
Issue #16077: Fixed anchor image size

### DIFF
--- a/src/site/resources/css/site.css
+++ b/src/site/resources/css/site.css
@@ -90,6 +90,10 @@ div, p, td, table.bodyTable td, th, table.bodyTable th, li, pre, #breadcrumbs sp
   padding: 8px 4px 0 12px;
 }
 
+img[src="images/anchor.png"] {
+  max-width: unset;
+}
+
 code {
   white-space: normal;
 }


### PR DESCRIPTION
part of #16077


fixed following:

> no link images as first column

problem: the anchor image was too small