### PR TITLE
Issue #14631: Updated TR_HTML_TAG_NAME in JavadocTokenTypes.java to new AST format

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/api/JavadocTokenTypes.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/api/JavadocTokenTypes.java
@@ -1509,7 +1509,34 @@ public final class JavadocTokenTypes {
     /** End list item tag. */
     public static final int LI_TAG_END = JavadocParser.RULE_liTagEnd + RULE_TYPES_OFFSET;
 
-    /** Table row html tag: {@code <tr></tr>}. */
+    /**
+     * Table row html tag.
+     *
+     * <p><b>Example:</b></p>
+     * <pre>{@code <tr></tr>}</pre>
+     * <b>Tree:</b>
+     * <pre>
+     * {@code
+     *   JAVADOC -> JAVADOC
+     *        |--NEWLINE -&gt \r\n
+     *        |--LEADING_ASTERISK -&gt  *
+     *        |--TEXT -&gt
+     *        |--HTML_ELEMENT -&gt HTML_ELEMENT
+     *        |   `--TR -&gt TR
+     *        |       |--TR_TAG_START -&gt TR_TAG_START
+     *        |       |   |--START -&gt &lt
+     *        |       |   |--TR_HTML_TAG_NAME -&gt tr
+     *        |       |   `--END -&gt &gt
+     *        |       `--TR_TAG_END -&gt TR_TAG_END
+     *        |           |--START -&gt &lt
+     *        |           |--SLASH -&gt /
+     *        |           |--TR_HTML_TAG_NAME -&gt tr
+     *        |           `--END -&gt &gt
+     *        |--NEWLINE -&gt \r\n
+     *        |--TEXT -&gt
+     * }
+     * </pre>
+     */
     public static final int TR = JavadocParser.RULE_tr + RULE_TYPES_OFFSET;
     /** Start table row tag. */
     public static final int TR_TAG_START = JavadocParser.RULE_trTagStart + RULE_TYPES_OFFSET;


### PR DESCRIPTION
Issue: #14631 

Command used:
java -jar checkstyle-10.21.1-all.jar -J Test.java | sed "s/[[0-9]+:[0-9]+]//g"

Test.java
```<tr></tr>```

```
COMPILATION_UNIT -> COMPILATION_UNIT
`--CLASS_DEF -> CLASS_DEF
    |--MODIFIERS -> MODIFIERS
    |   |--BLOCK_COMMENT_BEGIN -> /*
    |   |   |--COMMENT_CONTENT -> *\r\n * <tr></tr>\r\n
    |   |   |   `--JAVADOC -> JAVADOC
    |   |   |       |--NEWLINE -> \r\n
    |   |   |       |--LEADING_ASTERISK ->  *
    |   |   |       |--TEXT ->
    |   |   |       |--HTML_ELEMENT -> HTML_ELEMENT
    |   |   |       |   `--TR -> TR
    |   |   |       |       |--TR_TAG_START -> TR_TAG_START
    |   |   |       |       |   |--START -> <
    |   |   |       |       |   |--TR_HTML_TAG_NAME -> tr
    |   |   |       |       |   `--END -> >
    |   |   |       |       `--TR_TAG_END -> TR_TAG_END
    |   |   |       |           |--START -> <
    |   |   |       |           |--SLASH -> /
    |   |   |       |           |--TR_HTML_TAG_NAME -> tr
    |   |   |       |           `--END -> >
    |   |   |       |--NEWLINE -> \r\n
    |   |   |       |--TEXT ->
    |   |   |       `--EOF -> <EOF>
    |   |   `--BLOCK_COMMENT_END -> */
    |   `--LITERAL_PUBLIC -> public
    |--LITERAL_CLASS -> class
    |--IDENT -> Test
    `--OBJBLOCK -> OBJBLOCK
        |--LCURLY -> {
        `--RCURLY -> }
```
