### PR TITLE
Issue #14631: Updated parameters in JavadocTokenTypes.java to new format of AST

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/api/JavadocTokenTypes.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/api/JavadocTokenTypes.java
@@ -1402,19 +1402,20 @@ public final class JavadocTokenTypes {
      * <pre>{@code @see #method(Processor, String)}</pre>
      * <b>Tree:</b>
      * <pre>
-     * {@code |--JAVADOC_TAG[1x0] : [@see #method(Processor, String)]
-     *        |--SEE_LITERAL[1x0] : [@see]
-     *        |--WS[1x4] : [ ]
-     *        |--REFERENCE[1x5] : [#method(Processor, String)]
-     *            |--HASH[1x5] : [#]
-     *            |--MEMBER[1x6] : [method]
-     *            |--PARAMETERS[1x12] : [(Processor, String)]
-     *                |--LEFT_BRACE[1x12] : [(]
-     *                |--ARGUMENT[1x13] : [Processor]
-     *                |--COMMA[1x22] : [,]
-     *                |--WS[1x23] : [ ]
-     *                |--ARGUMENT[1x24] : [String]
-     *                |--RIGHT_BRACE[1x30] : [)]
+     * {@code
+     *      JAVADOC_TAG -> JAVADOC_TAG
+     *          |--SEE_LITERAL -> @see
+     *          |--WS ->
+     *          |--REFERENCE -> REFERENCE
+     *              |--HASH -> #
+     *              |--MEMBER -> method
+     *              `--PARAMETERS -> PARAMETERS
+     *                  |--LEFT_BRACE -> (
+     *                  |--ARGUMENT -> Processor
+     *                  |--COMMA -> ,
+     *                  |--WS ->
+     *                  |--ARGUMENT -> String
+     *                  `--RIGHT_BRACE -> )
      * }
      * </pre>
      */


### PR DESCRIPTION
#14631 

**Command Used**
java -jar checkstyle-10.21.1-all.jar -J Test.java | sed -E "s/[[0-9]+:[0-9]+]//g"

**Test.java**

```
 /**
 * @see #method(Processor, String)
 */
 public class Test {
 
 }
```

**Output**

```
java -jar checkstyle-10.21.1-all.jar Test.java -J | sed -E "s/\[[0-9]+:[0-9]+\]//g"

COMPILATION_UNIT -> COMPILATION_UNIT 
`--CLASS_DEF -> CLASS_DEF 
    |--MODIFIERS -> MODIFIERS 
    |   |--BLOCK_COMMENT_BEGIN -> /* 
    |   |   |--COMMENT_CONTENT -> *\n * @see #method(Processor, String)\n  
    |   |   |   `--JAVADOC -> JAVADOC 
    |   |   |       |--NEWLINE -> \n 
    |   |   |       |--LEADING_ASTERISK ->  * 
    |   |   |       |--WS ->   
    |   |   |       |--JAVADOC_TAG -> JAVADOC_TAG 
    |   |   |       |   |--SEE_LITERAL -> @see 
    |   |   |       |   |--WS ->   
    |   |   |       |   |--REFERENCE -> REFERENCE 
    |   |   |       |   |   |--HASH -> # 
    |   |   |       |   |   |--MEMBER -> method 
    |   |   |       |   |   `--PARAMETERS -> PARAMETERS 
    |   |   |       |   |       |--LEFT_BRACE -> ( 
    |   |   |       |   |       |--ARGUMENT -> Processor 
    |   |   |       |   |       |--COMMA -> , 
    |   |   |       |   |       |--WS ->   
    |   |   |       |   |       |--ARGUMENT -> String 
    |   |   |       |   |       `--RIGHT_BRACE -> ) 
    |   |   |       |   |--NEWLINE -> \n 
    |   |   |       |   `--WS ->   
    |   |   |       `--EOF -> <EOF> 
    |   |   `--BLOCK_COMMENT_END -> */ 
    |   `--LITERAL_PUBLIC -> public 
    |--LITERAL_CLASS -> class 
    |--IDENT -> MyClass 
    `--OBJBLOCK -> OBJBLOCK 
        |--LCURLY -> { 
        `--RCURLY -> } 

```