### PR TITLE
Issue #15499: Changed default for IllegalIdentifierName

### DIFF
--- a/config/checkstyle-examples-suppressions.xml
+++ b/config/checkstyle-examples-suppressions.xml
@@ -153,6 +153,9 @@
   <!-- Example needs to exclude fully qualified name longer than 85 characters  -->
   <suppress checks="LineLength" files="classdataabstractioncoupling[\\/]Example11.java"/>
 
+  <!-- Example needs to have really long regex format properly shown in config  -->
+  <suppress checks="LineLength" files="illegalidentifiername[\\/]Example[2].java"/>
+
   <!-- Example must show PackageDeclaration violations -->
   <suppress checks="PackageDeclaration"
     files="packagedeclaration[\\/]Example\d+.*"/>

--- a/src/it/java/org/checkstyle/suppressionxpathfilter/XpathRegressionIllegalIdentifierNameTest.java
+++ b/src/it/java/org/checkstyle/suppressionxpathfilter/XpathRegressionIllegalIdentifierNameTest.java
@@ -46,17 +46,17 @@ public class XpathRegressionIllegalIdentifierNameTest extends AbstractXpathTestS
         final DefaultConfiguration moduleConfig =
             createModuleConfig(IllegalIdentifierNameCheck.class);
 
-        final String format = "(?i)^(?!(record|yield|var|permits|sealed)$).+$";
+        final String format = "^(?!var$|\\S*\\$)\\S+$";
 
         final String[] expectedViolation = {
             "10:20: " + getCheckMessage(IllegalIdentifierNameCheck.class,
-                AbstractNameCheck.MSG_INVALID_PATTERN, "yield", format),
+                AbstractNameCheck.MSG_INVALID_PATTERN, "var", format),
             };
 
         final List<String> expectedXpathQueries = Collections.singletonList(
             "/COMPILATION_UNIT/RECORD_DEF"
                 + "[./IDENT[@text='InputXpathIllegalIdentifierNameOne'"
-                + "]]/RECORD_COMPONENTS/RECORD_COMPONENT_DEF/IDENT[@text='yield']"
+                + "]]/RECORD_COMPONENTS/RECORD_COMPONENT_DEF/IDENT[@text='var']"
         );
 
         runVerifications(moduleConfig, fileToProcess, expectedViolation,
@@ -71,18 +71,18 @@ public class XpathRegressionIllegalIdentifierNameTest extends AbstractXpathTestS
         final DefaultConfiguration moduleConfig =
             createModuleConfig(IllegalIdentifierNameCheck.class);
 
-        final String format = "(?i)^(?!(record|yield|var|permits|sealed)$).+$";
+        final String format = "^(?!var$|\\S*\\$)\\S+$";
 
         final String[] expectedViolation = {
             "9:17: " + getCheckMessage(IllegalIdentifierNameCheck.class,
-                AbstractNameCheck.MSG_INVALID_PATTERN, "yield", format),
+                AbstractNameCheck.MSG_INVALID_PATTERN, "te$t", format),
             };
 
         final List<String> expectedXpathQueries = Collections.singletonList(
             "/COMPILATION_UNIT/CLASS_DEF"
                 + "[./IDENT[@text='InputXpathIllegalIdentifierNameTwo']"
                 + "]/OBJBLOCK/METHOD_DEF[./IDENT[@text='foo']]/PARAMETERS/PARAMETER_DEF"
-                + "/IDENT[@text='yield']"
+                + "/IDENT[@text='te$t']"
         );
 
         runVerifications(moduleConfig, fileToProcess, expectedViolation,

--- a/src/it/resources-noncompilable/org/checkstyle/suppressionxpathfilter/illegalidentifiername/InputXpathIllegalIdentifierNameOne.java
+++ b/src/it/resources-noncompilable/org/checkstyle/suppressionxpathfilter/illegalidentifiername/InputXpathIllegalIdentifierNameOne.java
@@ -7,6 +7,6 @@ package org.checkstyle.suppressionxpathfilter.illegalidentifiername;
  */
 public record InputXpathIllegalIdentifierNameOne
         (String string,
-            String yield, // warn
+            String var, // warn
             String otherString){
 }

--- a/src/it/resources-noncompilable/org/checkstyle/suppressionxpathfilter/illegalidentifiername/InputXpathIllegalIdentifierNameTwo.java
+++ b/src/it/resources-noncompilable/org/checkstyle/suppressionxpathfilter/illegalidentifiername/InputXpathIllegalIdentifierNameTwo.java
@@ -6,8 +6,8 @@ package org.checkstyle.suppressionxpathfilter.illegalidentifiername;
  * default
  */
 public class InputXpathIllegalIdentifierNameTwo {
-    int foo(int yield) { // warn
-        return switch (yield) {
+    int foo(int te$t) { // warn
+        return switch (te$t) {
             case 1 -> 2;
             case 2 -> 3;
             case 3 -> 4;

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/naming/IllegalIdentifierNameCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/naming/IllegalIdentifierNameCheck.java
@@ -26,20 +26,17 @@ import com.puppycrawl.tools.checkstyle.utils.CommonUtil;
 
 /**
  * <div>
- * Checks identifiers with a pattern for a set of illegal names, such as those
- * that are restricted or contextual keywords. Examples include "yield", "record", and
- * "var". Please read more at
- * <a href="https://docs.oracle.com/javase/specs/jls/se22/html/jls-3.html#jls-3.9">
- * Java Language Specification</a> to get to know more about restricted keywords. Since this
- * check uses a pattern to specify valid identifiers, users can also prohibit the usage
- * of certain symbols, such as "$", or any non-ascii character.
+ * Checks identifiers against a regular expression pattern to detect illegal names. Since this
+ * check uses a pattern to define <i>valid</i> identifiers, users will need to use negative
+ * lookaheads to explicitly ban certain names (e.g., "var") or patterns (e.g., any identifier
+ * containing $) while still allowing all other valid identifiers.
  * </div>
  *
  * <ul>
  * <li>
  * Property {@code format} - Sets the pattern to match valid identifiers.
  * Type is {@code java.util.regex.Pattern}.
- * Default value is {@code "(?i)^(?!(record|yield|var|permits|sealed)$).+$"}.
+ * Default value is {@code "^(?!var$|\S*\$)\S+$"}.
  * </li>
  * <li>
  * Property {@code tokens} - tokens to check
@@ -97,7 +94,7 @@ public class IllegalIdentifierNameCheck extends AbstractNameCheck {
      * Creates a new {@code IllegalIdentifierNameCheck} instance.
      */
     public IllegalIdentifierNameCheck() {
-        super("(?i)^(?!(record|yield|var|permits|sealed)$).+$");
+        super("^(?!var$|\\S*\\$)\\S+$");
     }
 
     @Override

--- a/src/main/resources/com/puppycrawl/tools/checkstyle/meta/checks/naming/IllegalIdentifierNameCheck.xml
+++ b/src/main/resources/com/puppycrawl/tools/checkstyle/meta/checks/naming/IllegalIdentifierNameCheck.xml
@@ -5,16 +5,13 @@
              name="IllegalIdentifierName"
              parent="com.puppycrawl.tools.checkstyle.TreeWalker">
          <description>&lt;div&gt;
- Checks identifiers with a pattern for a set of illegal names, such as those
- that are restricted or contextual keywords. Examples include "yield", "record", and
- "var". Please read more at
- &lt;a href="https://docs.oracle.com/javase/specs/jls/se22/html/jls-3.html#jls-3.9"&gt;
- Java Language Specification&lt;/a&gt; to get to know more about restricted keywords. Since this
- check uses a pattern to specify valid identifiers, users can also prohibit the usage
- of certain symbols, such as "$", or any non-ascii character.
+ Checks identifiers against a regular expression pattern to detect illegal names. Since this
+ check uses a pattern to define &lt;i&gt;valid&lt;/i&gt; identifiers, users will need to use negative
+ lookaheads to explicitly ban certain names (e.g., "var") or patterns (e.g., any identifier
+ containing $) while still allowing all other valid identifiers.
  &lt;/div&gt;</description>
          <properties>
-            <property default-value="(?i)^(?!(record|yield|var|permits|sealed)$).+$"
+            <property default-value="^(?!var$|\S*\$)\S+$"
                       name="format"
                       type="java.util.regex.Pattern">
                <description>Sets the pattern to match valid identifiers.</description>

--- a/src/site/xdoc/checks.xml
+++ b/src/site/xdoc/checks.xml
@@ -449,8 +449,7 @@
               </a>
             </td>
             <td>
-              Checks identifiers with a pattern for a set of illegal names, such as those
-              that are restricted or contextual keywords.
+              Checks identifiers against a regular expression pattern to detect illegal names.
             </td>
           </tr>
           <tr>

--- a/src/site/xdoc/checks/naming/illegalidentifiername.xml
+++ b/src/site/xdoc/checks/naming/illegalidentifiername.xml
@@ -10,14 +10,10 @@
       <p>Since Checkstyle 8.36</p>
       <subsection name="Description" id="Description">
         <div>
-          Checks identifiers with a pattern for a set of illegal names, such as those
-          that are restricted or contextual keywords. Examples include &quot;yield&quot;, &quot;record&quot;,
-          and &quot;var&quot;. Please read more at
-          <a href="https://docs.oracle.com/javase/specs/jls/se22/html/jls-3.html#jls-3.9">
-          Java Language Specification
-          </a>to get to know more about restricted keywords. Since this check uses a
-          pattern to specify valid identifiers, users can also prohibit the usage
-          of certain symbols, such as &quot;$&quot;, or any non-ascii character.
+          Checks identifiers against a regular expression pattern to detect illegal names. Since
+          this check uses a pattern to define <i>valid</i> identifiers, users will need to use
+          negative lookaheads to explicitly ban certain names (e.g., &quot;var&quot;) or patterns
+          (e.g., any identifier containing $) while still allowing all other valid identifiers.
         </div>
       </subsection>
 
@@ -35,7 +31,7 @@
               <td>format</td>
               <td>Sets the pattern to match valid identifiers.</td>
               <td><a href="../../property_types.html#Pattern">Pattern</a></td>
-              <td><code>&quot;(?i)^(?!(record|yield|var|permits|sealed)$).+$&quot;</code></td>
+              <td><code>&quot;^(?!var$|\S*\$)\S+$&quot;</code></td>
               <td>8.36</td>
             </tr>
             <tr>
@@ -121,34 +117,34 @@
         <div class="wrapper"><pre class="prettyprint"><code class="language-java">
 public class Example1 {
   Integer var = 4; // violation, 'Name 'var' must match pattern'
-  int record = 15; // violation, 'Name 'record' must match pattern'
+  int record = 15;
   String yield = "yield";
-  // violation above, 'Name 'yield' must match pattern'
 
-  record Record(Record r){} // violation, 'Name 'Record' must match pattern'
+  String test$stuff = "test"; // violation, 'must match pattern'
+  String when = "today";
+  record Record(Record r){}
 
-  record R(Record record){} // violation, 'Name 'record' must match pattern'
+  record R(Record record){}
 
   String yieldString = "yieldString";
-  // ok above, word 'yield' is not used as an identifier by itself
-  record MyRecord(){}
-  // ok above, word 'Record' is not used as an identifier by itself
-  Integer variable = 2;
-  // ok above, word 'var' is not used as an identifier by itself
 
-  int open = 4; // ok, word 'open' can be used as an identifier
+  record MyRecord(){}
+
+  Integer variable = 2;
+
+  int open = 4;
   Object transitive = "transitive";
-  // ok above, word 'transitive' can be used as an identifier
 
   int openInt = 4;
-  // ok above, word 'openInt' can be used as an identifier
+
   Object transitiveObject = "transitiveObject";
-  // ok above, word 'transitiveObject' can be used as an identifier
+
 }
 </code></pre></div>
         <p>
-          To configure the check to include &quot;open&quot; and &quot;transitive&quot; in the set of
-          illegal identifiers:
+          To configure the check to include some of JLS Keywords in the
+          set of illegal identifiers (See <a href="https://docs.oracle.com/javase/specs/jls/se22/html/jls-3.html#jls-3.9">
+          Java Language Specification </a>for the full list of JLS keywords):
         </p>
         <p id="Example2-config">Configuration:</p>
         <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
@@ -156,7 +152,7 @@ public class Example1 {
   &lt;module name="TreeWalker"&gt;
     &lt;module name="IllegalIdentifierName"&gt;
       &lt;property name="format"
-        value="(?i)^(?!(record|yield|var|permits|sealed|open|transitive|_)$).+$"/&gt;
+        value="(?i)^(?!(when|record|yield|var|permits|sealed|open|transitive|_)$|(.*\$)).+$"/&gt;
     &lt;/module&gt;
   &lt;/module&gt;
 &lt;/module&gt;
@@ -168,7 +164,8 @@ public class Example2 {
   int record = 15; // violation, 'Name 'record' must match pattern'
   String yield = "yield";
   // violation above, 'Name 'yield' must match pattern'
-
+  String test$stuff = "test"; // violation, 'must match pattern'
+  String when = "today"; // violation, 'Name 'when' must match pattern'
   record Record(Record r){} // violation, 'Name 'Record' must match pattern'
 
   record R(Record record){} // violation, 'Name 'record' must match pattern'
@@ -179,11 +176,9 @@ public class Example2 {
   // ok above, word 'Record' is not used as an identifier by itself
   Integer variable = 2;
   // ok above, word 'var' is not used as an identifier by itself
-
   int open = 4; // violation, 'Name 'open' must match pattern'
   Object transitive = "transitive";
   // violation above, 'Name 'transitive' must match pattern'
-
   int openInt = 4;
   // ok above, word 'open' is not used as an identifier by itself
   Object transitiveObject = "transitiveObject";

--- a/src/site/xdoc/checks/naming/illegalidentifiername.xml.template
+++ b/src/site/xdoc/checks/naming/illegalidentifiername.xml.template
@@ -10,14 +10,10 @@
       <p>Since Checkstyle 8.36</p>
       <subsection name="Description" id="Description">
         <div>
-          Checks identifiers with a pattern for a set of illegal names, such as those
-          that are restricted or contextual keywords. Examples include "yield", "record",
-          and "var". Please read more at
-          <a href="https://docs.oracle.com/javase/specs/jls/se22/html/jls-3.html#jls-3.9">
-          Java Language Specification
-          </a>to get to know more about restricted keywords. Since this check uses a
-          pattern to specify valid identifiers, users can also prohibit the usage
-          of certain symbols, such as "$", or any non-ascii character.
+          Checks identifiers against a regular expression pattern to detect illegal names. Since
+          this check uses a pattern to define <i>valid</i> identifiers, users will need to use
+          negative lookaheads to explicitly ban certain names (e.g., "var") or patterns
+          (e.g., any identifier containing $) while still allowing all other valid identifiers.
         </div>
       </subsection>
 
@@ -47,8 +43,9 @@
           <param name="type" value="code"/>
         </macro>
         <p>
-          To configure the check to include "open" and "transitive" in the set of
-          illegal identifiers:
+          To configure the check to include some of JLS Keywords in the
+          set of illegal identifiers (See <a href="https://docs.oracle.com/javase/specs/jls/se22/html/jls-3.html#jls-3.9">
+          Java Language Specification </a>for the full list of JLS keywords):
         </p>
         <p id="Example2-config">Configuration:</p>
         <macro name="example">

--- a/src/site/xdoc/checks/naming/index.xml
+++ b/src/site/xdoc/checks/naming/index.xml
@@ -77,8 +77,7 @@
               </a>
             </td>
             <td>
-              Checks identifiers with a pattern for a set of illegal names, such as those
-            that are restricted or contextual keywords.
+              Checks identifiers against a regular expression pattern to detect illegal names.
             </td>
           </tr>
           <tr>

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/naming/IllegalIdentifierNameCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/naming/IllegalIdentifierNameCheckTest.java
@@ -74,22 +74,13 @@ public class IllegalIdentifierNameCheckTest extends AbstractModuleTestSupport {
     @Test
     public void testIllegalIdentifierNameDefault() throws Exception {
 
-        final String format = "(?i)^(?!(record|yield|var|permits|sealed)$).+$";
+        final String format = "^(?!var$|\\S*\\$)\\S+$";
 
         final String[] expected = {
-            "21:25: " + getCheckMessage(MSG_INVALID_PATTERN, "record", format),
-            "22:24: " + getCheckMessage(MSG_INVALID_PATTERN, "record", format),
-            "28:13: " + getCheckMessage(MSG_INVALID_PATTERN, "yield", format),
-            "30:21: " + getCheckMessage(MSG_INVALID_PATTERN, "yield", format),
-            "45:9: " + getCheckMessage(MSG_INVALID_PATTERN, "yield", format),
             "57:13: " + getCheckMessage(MSG_INVALID_PATTERN, "var", format),
-            "59:13: " + getCheckMessage(MSG_INVALID_PATTERN, "record", format),
-            "61:16: " + getCheckMessage(MSG_INVALID_PATTERN, "yield", format),
-            "63:16: " + getCheckMessage(MSG_INVALID_PATTERN, "Record", format),
-            "64:25: " + getCheckMessage(MSG_INVALID_PATTERN, "record", format),
-            "74:37: " + getCheckMessage(MSG_INVALID_PATTERN, "record", format),
-            "74:52: " + getCheckMessage(MSG_INVALID_PATTERN, "yield", format),
-            "74:69: " + getCheckMessage(MSG_INVALID_PATTERN, "var", format),
+            "59:13: " + getCheckMessage(MSG_INVALID_PATTERN, "$amt", format),
+            "74:52: " + getCheckMessage(MSG_INVALID_PATTERN, "yield$text", format),
+            "74:74: " + getCheckMessage(MSG_INVALID_PATTERN, "var", format),
         };
         verifyWithInlineConfigParser(
                 getNonCompilablePath("InputIllegalIdentifierName.java"), expected);
@@ -142,14 +133,13 @@ public class IllegalIdentifierNameCheckTest extends AbstractModuleTestSupport {
 
     @Test
     public void testIllegalIdentifierNameLambda() throws Exception {
-        final String format = "(?i)^(?!(record|yield|var|permits|sealed)$).+$";
+        final String format = "^(?!var$|\\S*\\$)\\S+$";
 
         final String[] expected = {
-            "19:39: " + getCheckMessage(MSG_INVALID_PATTERN, "var", format),
+            "19:39: " + getCheckMessage(MSG_INVALID_PATTERN, "param$", format),
             "20:40: " + getCheckMessage(MSG_INVALID_PATTERN, "var", format),
             "32:9: " + getCheckMessage(MSG_INVALID_PATTERN, "var", format),
-            "35:9: " + getCheckMessage(MSG_INVALID_PATTERN, "yield", format),
-            "42:47: " + getCheckMessage(MSG_INVALID_PATTERN, "var", format),
+            "42:47: " + getCheckMessage(MSG_INVALID_PATTERN, "te$t", format),
         };
         verifyWithInlineConfigParser(
                 getNonCompilablePath("InputIllegalIdentifierNameLambda.java"), expected);
@@ -166,16 +156,11 @@ public class IllegalIdentifierNameCheckTest extends AbstractModuleTestSupport {
 
     @Test
     public void testIllegalIdentifierNameRecordPattern() throws Exception {
-        final String format = "(?i)^(?!(record|yield|var|permits|sealed)$).+$";
+        final String format = "^(?!var$|\\S*\\$)\\S+$";
 
         final String[] expected = {
             "16:36: " + getCheckMessage(MSG_INVALID_PATTERN, "var", format),
-            "17:47: " + getCheckMessage(MSG_INVALID_PATTERN, "record", format),
-            "17:59: " + getCheckMessage(MSG_INVALID_PATTERN, "yield", format),
-            "17:74: " + getCheckMessage(MSG_INVALID_PATTERN, "sealed", format),
-            "26:28: " + getCheckMessage(MSG_INVALID_PATTERN, "permits", format),
-            "26:41: " + getCheckMessage(MSG_INVALID_PATTERN, "yield", format),
-            "30:39: " + getCheckMessage(MSG_INVALID_PATTERN, "permits", format),
+            "23:39: " + getCheckMessage(MSG_INVALID_PATTERN, "permit$", format),
         };
         verifyWithInlineConfigParser(
                 getNonCompilablePath("InputIllegalIdentifierNameRecordPattern.java"), expected);

--- a/src/test/resources-noncompilable/com/puppycrawl/tools/checkstyle/checks/naming/illegalidentifiername/InputIllegalIdentifierName.java
+++ b/src/test/resources-noncompilable/com/puppycrawl/tools/checkstyle/checks/naming/illegalidentifiername/InputIllegalIdentifierName.java
@@ -1,6 +1,6 @@
 /*
 IllegalIdentifierName
-format = (default)(?i)^(?!(record|yield|var|permits|sealed)$).+$
+format = (default)^(?!var$|\\S*\\$)\\S+$
 tokens = (default)CLASS_DEF, INTERFACE_DEF, ENUM_DEF, ANNOTATION_DEF, ANNOTATION_FIELD_DEF, \
          PARAMETER_DEF, VARIABLE_DEF, METHOD_DEF, ENUM_CONSTANT_DEF, PATTERN_VARIABLE_DEF, \
          RECORD_DEF, RECORD_COMPONENT_DEF, LAMBDA
@@ -18,16 +18,16 @@ public class InputIllegalIdentifierName {
         return Record[].class;
     }
 
-    private static void record(LogRecord... logArray) { // violation
-        for (LogRecord record : logArray) { // violation
+    private static void record(LogRecord... logArray) {
+        for (LogRecord record : logArray) {
             record.getLevel();
         }
     }
 
     class yieldClass {
-        int yield = 6; // violation
+        int yield = 6;
 
-        public void yield() { // violation
+        public void yield() {
 
         }
     }
@@ -42,36 +42,39 @@ public class InputIllegalIdentifierName {
         SUN,
     }
 
-    int yield(Day day) { // violation
+    int yield(Day day) {
         return switch (day) {
             case MON, TUE -> Math.addExact(0, 1);
             case WED -> Math.addExact(1, 1);
             case THU, SAT, FRI, SUN -> 0;
             default -> {
-                yield Math.addExact(2, 1); // ok, yield statement
+                yield Math.addExact(2, 1);
             }
         };
     }
 
     public static void main(String... args) {
-        var var = 4; // violation
+        var var = 4; // violation, 'Name 'var' must match pattern'
 
-        int record = 15; // violation
+        int $amt = 15; // violation, 'must match pattern'
 
-        String yield = "yield"; // violation
+        String yield = "yield";
 
-        record Record // violation
-                (Record record) { // violation
+        record Record
+                (Record record) {
         }
 
-        String yieldString = "yieldString"; // ok, part of another word
-        record MyRecord() {} // ok, part of another word
+        String yieldString = "yield$String"; // ok, part of another word
+        record MyRecord() {}
         var variable = 2; // ok, part of another word
 
         String recordString = "record";
-        recordString = recordString.substring(record, 20);
+        recordString = recordString.substring($amt, 20);
 
-        record MyOtherRecord(String record, String yield, String... var) { // 3 violations
+        record MyOtherRecord(String record, String yield$text, String... var) {
+        // 2 violations above:
+        //            'must match pattern'
+        //            'Name 'var' must match pattern'
         }
     }
 }

--- a/src/test/resources-noncompilable/com/puppycrawl/tools/checkstyle/checks/naming/illegalidentifiername/InputIllegalIdentifierNameLambda.java
+++ b/src/test/resources-noncompilable/com/puppycrawl/tools/checkstyle/checks/naming/illegalidentifiername/InputIllegalIdentifierNameLambda.java
@@ -1,6 +1,6 @@
 /*
 IllegalIdentifierName
-format = (default)(?i)^(?!(record|yield|var|permits|sealed)$).+$
+format = (default)^(?!var$|\\S*\\$)\\S+$
 tokens = (default)CLASS_DEF, INTERFACE_DEF, ENUM_DEF, ANNOTATION_DEF, ANNOTATION_FIELD_DEF, \
          PARAMETER_DEF, VARIABLE_DEF, METHOD_DEF, ENUM_CONSTANT_DEF, PATTERN_VARIABLE_DEF, \
          RECORD_DEF, RECORD_COMPONENT_DEF, LAMBDA
@@ -16,8 +16,8 @@ import java.util.function.Function;
 public class InputIllegalIdentifierNameLambda {
 
     public static void main(String... args) {
-        Function<String, String> f1 = var -> var; // violation
-        Function<String, String> f2 = (var) -> var; // violation
+        Function<String, String> f1 = param$ -> param$; // violation, 'must match pattern'
+        Function<String, String> f2 = (var) -> var; // violation, 'Name 'var' must match pattern'
         Function<String, String> f3 = myLambdaParam -> myLambdaParam;
     }
 
@@ -29,18 +29,18 @@ public class InputIllegalIdentifierNameLambda {
         FRI,
         SAT,
         SUN,
-        var, // violation
+        var, // violation, 'Name 'var' must match pattern'
     }
 
-    int yield(Day day) { // violation
+    int yield(Day day) {
         return switch (day) {
             case MON, TUE -> Math.addExact(0, 1);
             case WED -> Math.addExact(1, 1);
             case THU, SAT, FRI, SUN -> 0;
             case var -> 23; // ok, caught above in initialization
             default -> {
-                Function<String, String> f4 = var -> var; // violation
-                yield Math.addExact(2, 1); // ok, yield statement
+                Function<String, String> f4 = te$t -> te$t; // violation, 'must match pattern'
+                yield Math.addExact(2, 1);
             }
         };
     }

--- a/src/test/resources-noncompilable/com/puppycrawl/tools/checkstyle/checks/naming/illegalidentifiername/InputIllegalIdentifierNameParameterReceiver.java
+++ b/src/test/resources-noncompilable/com/puppycrawl/tools/checkstyle/checks/naming/illegalidentifiername/InputIllegalIdentifierNameParameterReceiver.java
@@ -1,6 +1,6 @@
 /*
 IllegalIdentifierName
-format = (default)(?i)^(?!(record|yield|var|permits|sealed)$).+$
+format = (default)^(?!var$|\\S*\\$)\\S+$
 tokens = (default)CLASS_DEF, INTERFACE_DEF, ENUM_DEF, ANNOTATION_DEF, ANNOTATION_FIELD_DEF, \
          PARAMETER_DEF, VARIABLE_DEF, METHOD_DEF, ENUM_CONSTANT_DEF, PATTERN_VARIABLE_DEF, \
          RECORD_DEF, RECORD_COMPONENT_DEF, LAMBDA

--- a/src/test/resources-noncompilable/com/puppycrawl/tools/checkstyle/checks/naming/illegalidentifiername/InputIllegalIdentifierNameRecordPattern.java
+++ b/src/test/resources-noncompilable/com/puppycrawl/tools/checkstyle/checks/naming/illegalidentifiername/InputIllegalIdentifierNameRecordPattern.java
@@ -1,6 +1,6 @@
 /*
 IllegalIdentifierName
-format = (default)(?i)^(?!(record|yield|var|permits|sealed)$).+$
+format = (default)^(?!var$|\\S*\\$)\\S+$
 tokens = (default)CLASS_DEF, INTERFACE_DEF, ENUM_DEF, ANNOTATION_DEF, ANNOTATION_FIELD_DEF, \
          PARAMETER_DEF, VARIABLE_DEF, METHOD_DEF, ENUM_CONSTANT_DEF, PATTERN_VARIABLE_DEF, \
          RECORD_DEF, RECORD_COMPONENT_DEF, LAMBDA
@@ -13,22 +13,15 @@ package com.puppycrawl.tools.checkstyle.checks.naming.illegalidentifiername;
 public class InputIllegalIdentifierNameRecordPattern {
 
     void m(Object o) {
-        if (o instanceof Point(int var, int _)) { } // violation, 'Name 'var' must match *.'
+        if (o instanceof Point(int var, int _)) { } // violation, 'Name 'var' must match pattern'
         if (o instanceof ColorPoint(Point(int record, int yield), String sealed)) { }
-        // 3 violations above:
-        //                    'Name 'record' must match *.'
-        //                    'Name 'yield' must match *.'
-        //                    'Name 'sealed' must match *.'
     }
 
     void m2(Object o) {
         switch (o) {
             case Point(int permits, int yield): {} break;
-            // 2 violations above:
-            //                    'Name 'permits' must match *.'
-            //                    'Name 'yield' must match *.'
-            case ColorPoint(Point(int permits, int _), String _): {}
-            // violation above, 'Name 'permits' must match *.'
+            case ColorPoint(Point(int permit$, int _), String _): {}
+            // violation above, 'must match pattern'
             default: {}
         }
     }

--- a/src/test/resources-noncompilable/com/puppycrawl/tools/checkstyle/checks/naming/illegalidentifiername/InputIllegalIdentifierNameUnnamedVariables.java
+++ b/src/test/resources-noncompilable/com/puppycrawl/tools/checkstyle/checks/naming/illegalidentifiername/InputIllegalIdentifierNameUnnamedVariables.java
@@ -1,6 +1,6 @@
 /*
 IllegalIdentifierName
-format = (default)(?i)^(?!(record|yield|var|permits|sealed)$).+$
+format = (default)^(?!var$|\\S*\\$)\\S+$
 tokens = (default)CLASS_DEF, INTERFACE_DEF, ENUM_DEF, ANNOTATION_DEF, ANNOTATION_FIELD_DEF, \
          PARAMETER_DEF, VARIABLE_DEF, METHOD_DEF, ENUM_CONSTANT_DEF, PATTERN_VARIABLE_DEF, \
          RECORD_DEF, RECORD_COMPONENT_DEF, LAMBDA

--- a/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/checks/naming/IllegalIdentifierNameCheckExamplesTest.java
+++ b/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/checks/naming/IllegalIdentifierNameCheckExamplesTest.java
@@ -33,14 +33,11 @@ public class IllegalIdentifierNameCheckExamplesTest extends AbstractExamplesModu
 
     @Test
     public void testExample1() throws Exception {
-        final String format = "(?i)^(?!(record|yield|var|permits|sealed)$).+$";
+        final String format = "^(?!var$|\\S*\\$)\\S+$";
 
         final String[] expected = {
             "17:11: " + getCheckMessage(MSG_INVALID_PATTERN, "var", format),
-            "18:7: " + getCheckMessage(MSG_INVALID_PATTERN, "record", format),
-            "19:10: " + getCheckMessage(MSG_INVALID_PATTERN, "yield", format),
-            "22:10: " + getCheckMessage(MSG_INVALID_PATTERN, "Record", format),
-            "24:19: " + getCheckMessage(MSG_INVALID_PATTERN, "record", format),
+            "21:10: " + getCheckMessage(MSG_INVALID_PATTERN, "test$stuff", format),
         };
 
         verifyWithInlineConfigParser(getNonCompilablePath("Example1.java"), expected);
@@ -48,14 +45,17 @@ public class IllegalIdentifierNameCheckExamplesTest extends AbstractExamplesModu
 
     @Test
     public void testExample2() throws Exception {
-        final String format = "(?i)^(?!(record|yield|var|permits|sealed|open|transitive|_)$).+$";
+        final String format =
+            "(?i)^(?!(when|record|yield|var|permits|sealed|open|transitive|_)$|(.*\\$)).+$";
 
         final String[] expected = {
             "17:11: " + getCheckMessage(MSG_INVALID_PATTERN, "var", format),
             "18:7: " + getCheckMessage(MSG_INVALID_PATTERN, "record", format),
             "19:10: " + getCheckMessage(MSG_INVALID_PATTERN, "yield", format),
-            "22:10: " + getCheckMessage(MSG_INVALID_PATTERN, "Record", format),
-            "24:19: " + getCheckMessage(MSG_INVALID_PATTERN, "record", format),
+            "21:10: " + getCheckMessage(MSG_INVALID_PATTERN, "test$stuff", format),
+            "22:10: " + getCheckMessage(MSG_INVALID_PATTERN, "when", format),
+            "23:10: " + getCheckMessage(MSG_INVALID_PATTERN, "Record", format),
+            "25:19: " + getCheckMessage(MSG_INVALID_PATTERN, "record", format),
             "33:7: " + getCheckMessage(MSG_INVALID_PATTERN, "open", format),
             "34:10: " + getCheckMessage(MSG_INVALID_PATTERN, "transitive", format),
         };

--- a/src/xdocs-examples/resources-noncompilable/com/puppycrawl/tools/checkstyle/checks/naming/illegalidentifiername/Example1.java
+++ b/src/xdocs-examples/resources-noncompilable/com/puppycrawl/tools/checkstyle/checks/naming/illegalidentifiername/Example1.java
@@ -15,28 +15,27 @@ package com.puppycrawl.tools.checkstyle.checks.naming.illegalidentifiername;
 // xdoc section -- start
 public class Example1 {
   Integer var = 4; // violation, 'Name 'var' must match pattern'
-  int record = 15; // violation, 'Name 'record' must match pattern'
+  int record = 15;
   String yield = "yield";
-  // violation above, 'Name 'yield' must match pattern'
 
-  record Record(Record r){} // violation, 'Name 'Record' must match pattern'
+  String test$stuff = "test"; // violation, 'must match pattern'
+  String when = "today";
+  record Record(Record r){}
 
-  record R(Record record){} // violation, 'Name 'record' must match pattern'
+  record R(Record record){}
 
   String yieldString = "yieldString";
-  // ok above, word 'yield' is not used as an identifier by itself
-  record MyRecord(){}
-  // ok above, word 'Record' is not used as an identifier by itself
-  Integer variable = 2;
-  // ok above, word 'var' is not used as an identifier by itself
 
-  int open = 4; // ok, word 'open' can be used as an identifier
+  record MyRecord(){}
+
+  Integer variable = 2;
+
+  int open = 4;
   Object transitive = "transitive";
-  // ok above, word 'transitive' can be used as an identifier
 
   int openInt = 4;
-  // ok above, word 'openInt' can be used as an identifier
+
   Object transitiveObject = "transitiveObject";
-  // ok above, word 'transitiveObject' can be used as an identifier
+
 }
 // xdoc section -- end

--- a/src/xdocs-examples/resources-noncompilable/com/puppycrawl/tools/checkstyle/checks/naming/illegalidentifiername/Example2.java
+++ b/src/xdocs-examples/resources-noncompilable/com/puppycrawl/tools/checkstyle/checks/naming/illegalidentifiername/Example2.java
@@ -3,7 +3,7 @@
   <module name="TreeWalker">
     <module name="IllegalIdentifierName">
       <property name="format"
-        value="(?i)^(?!(record|yield|var|permits|sealed|open|transitive|_)$).+$"/>
+        value="(?i)^(?!(when|record|yield|var|permits|sealed|open|transitive|_)$|(.*\$)).+$"/>
     </module>
   </module>
 </module>
@@ -18,7 +18,8 @@ public class Example2 {
   int record = 15; // violation, 'Name 'record' must match pattern'
   String yield = "yield";
   // violation above, 'Name 'yield' must match pattern'
-
+  String test$stuff = "test"; // violation, 'must match pattern'
+  String when = "today"; // violation, 'Name 'when' must match pattern'
   record Record(Record r){} // violation, 'Name 'Record' must match pattern'
 
   record R(Record record){} // violation, 'Name 'record' must match pattern'
@@ -29,11 +30,9 @@ public class Example2 {
   // ok above, word 'Record' is not used as an identifier by itself
   Integer variable = 2;
   // ok above, word 'var' is not used as an identifier by itself
-
   int open = 4; // violation, 'Name 'open' must match pattern'
   Object transitive = "transitive";
   // violation above, 'Name 'transitive' must match pattern'
-
   int openInt = 4;
   // ok above, word 'open' is not used as an identifier by itself
   Object transitiveObject = "transitiveObject";


### PR DESCRIPTION
Issue: #15499  
https://checkstyle.org/checks/naming/illegalidentifiername.html#IllegalIdentifierName

Changed default value to the newer regex that checks for "var" and $ components in the variable names

Will resolve rest of the CI errors later