### PR TITLE
minor: added missing closing curly bracket for img[src=images/anchor.png]

### DIFF
--- a/src/site/resources/css/site.css
+++ b/src/site/resources/css/site.css
@@ -92,6 +92,7 @@ div, p, td, table.bodyTable td, th, table.bodyTable th, li, pre, #breadcrumbs sp
 
 img[src="images/anchor.png"] {
   max-width: unset;
+}
 
 table {
   text-align: left;


### PR DESCRIPTION
added missing `}` in site.css

it was removed at commit: https://github.com/checkstyle/checkstyle/commit/45fca03deaff04c202469ff2c3192ba4c573ec57#diff-864a902184d44aa82cfc0242b94b8fec71ff45299594744e94ca51d95e5da822R93-R104