### PR TITLE
Issue #16077: made tables single column for mobile devices and removed .bodyTable class reference

### DIFF
--- a/src/site/resources/css/site.css
+++ b/src/site/resources/css/site.css
@@ -77,7 +77,7 @@ section {
   position: relative;
 }
 
-div, p, td, table.bodyTable td, th, table.bodyTable th, li, pre, #breadcrumbs span, .sidebar-nav h5,
+div, p, td, table td, th, table th, li, pre, #breadcrumbs span, .sidebar-nav h5,
 .sidebar-nav li, #footer, div.tip b, .releaseDate, .breadcrumb {
   font-size: 15px;
 }
@@ -278,18 +278,18 @@ span.wrapper.inline {
     word-break: break-word;
   }
 
-  table.bodyTable tr {
+   table tr {
     display: block;
     margin-bottom: 1rem;
   }
 
-  table.bodyTable th,
-  table.bodyTable td {
+   table th,
+   table td {
     display: block;
     text-align: left;
   }
 
-  section[id="Properties"] .wrapper .bodyTable tr td:first-child {
+  section[id="Properties"] .wrapper table tr td:first-child {
     font-style: italic;
   }
 }


### PR DESCRIPTION
part of #16077 

fixed following:

> mobile web site should have tables to be single column.

all tables had `tableBody` class in previous theme. Currently it is replaced with two classes: `table table-striped`.

In this PR, I removed all the `tableBody` references and replaced them with the tag name `table`, I think there should not be any problems with this change. I checked the website locally and it was looking fine to me.