### PR TITLE
Issue #16077: Removed text under banner images in menu

### DIFF
--- a/src/site/resources/css/site.css
+++ b/src/site/resources/css/site.css
@@ -94,6 +94,11 @@ img[src="images/anchor.png"] {
   max-width: unset;
 }
 
+a[class="builtBy"] {
+  font-size: 0;
+  margin-top: 20px;
+}
+
 table {
   text-align: left;
   border-spacing: 2px;


### PR DESCRIPTION
part of #16077

fixed following:

> remove text links under banner images in left panel, just image/banner is enough. 