### PR TITLE
Issue #14631: Update JAVADOC_INLINE_TAG in JavadocTokenTypes

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/api/JavadocTokenTypes.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/api/JavadocTokenTypes.java
@@ -1362,14 +1362,15 @@ public final class JavadocTokenTypes {
      * <pre><code>{&#64;link String}</code></pre>
      * <b>Tree:</b>
      * <pre>
-     * <code> |--JAVADOC_INLINE_TAG[4x3] : [&#64;link String}]
-     *        |--JAVADOC_INLINE_TAG_START[4x3] : [{]
-     *        |--LINK_LITERAL[4x4] : [@link]
-     *        |--WS[4x9] : [ ]
-     *        |--REFERENCE[4x10] : [String]
-     *            |--CLASS[4x10] : [String]
-     *        |--JAVADOC_INLINE_TAG_END[4x16] : [}]
-     * </code>
+     * {@code
+     *  JAVADOC_INLINE_TAG -> JAVADOC_INLINE_TAG
+     *      |--JAVADOC_INLINE_TAG_START -> {
+     *      |--LINK_LITERAL -> @link
+     *      |--WS ->
+     *      |--REFERENCE -> REFERENCE
+     *          `--PACKAGE_CLASS -> String
+     *      `--JAVADOC_INLINE_TAG_END -> }
+     * }
      * </pre>
      *
      * @noinspection HtmlTagCanBeJavadocTag


### PR DESCRIPTION
#14631 

**Command Used**
java -jar checkstyle-10.21.1-all.jar -J Test.java | sed -E "s/[[0-9]+:[0-9]+]//g"

**Test.java**

```
 /**
 * {@link String}
 */
 public class Test {
 
 }
```

**Output**

```
java -jar checkstyle-10.21.1-all.jar Test.java -J | sed -E "s/\[[0-9]+:[0-9]+\]//g"

COMPILATION_UNIT -> COMPILATION_UNIT 
`--CLASS_DEF -> CLASS_DEF 
    |--MODIFIERS -> MODIFIERS 
    |   |--BLOCK_COMMENT_BEGIN -> /* 
    |   |   |--COMMENT_CONTENT -> *\n * {@link String}\n  
    |   |   |   `--JAVADOC -> JAVADOC 
    |   |   |       |--NEWLINE -> \n 
    |   |   |       |--LEADING_ASTERISK ->  * 
    |   |   |       |--TEXT ->   
    |   |   |       |--JAVADOC_INLINE_TAG -> JAVADOC_INLINE_TAG 
    |   |   |       |   |--JAVADOC_INLINE_TAG_START -> { 
    |   |   |       |   |--LINK_LITERAL -> @link 
    |   |   |       |   |--WS ->   
    |   |   |       |   |--REFERENCE -> REFERENCE 
    |   |   |       |   |   `--PACKAGE_CLASS -> String 
    |   |   |       |   `--JAVADOC_INLINE_TAG_END -> } 
    |   |   |       |--NEWLINE -> \n 
    |   |   |       |--TEXT ->   
    |   |   |       `--EOF -> <EOF> 
    |   |   `--BLOCK_COMMENT_END -> */ 
    |   `--LITERAL_PUBLIC -> public 
    |--LITERAL_CLASS -> class 
    |--IDENT -> MyClass 
    `--OBJBLOCK -> OBJBLOCK 
        |--LCURLY -> { 
        `--RCURLY -> } 

```