### PR TITLE
Issue #16225: Update FileTabCharacter documentation with default config behaviour in case of suppressions

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/whitespace/FileTabCharacterCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/whitespace/FileTabCharacterCheck.java
@@ -44,6 +44,12 @@ import com.puppycrawl.tools.checkstyle.api.FileText;
  * read if you use tabs.
  * </li>
  * </ul>
+ *
+ * <p>
+ * When the {@code FileTabCharacter} check is used with the default configuration,
+ * only the first instance of a tab character is reported.
+ * </p>
+ *
  * <ul>
  * <li>
  * Property {@code eachLine} - Control whether to report on each line containing a tab,

--- a/src/main/resources/com/puppycrawl/tools/checkstyle/meta/checks/whitespace/FileTabCharacterCheck.xml
+++ b/src/main/resources/com/puppycrawl/tools/checkstyle/meta/checks/whitespace/FileTabCharacterCheck.xml
@@ -21,7 +21,12 @@
  when the commit messages get sent to a mailing list, they are almost impossible to
  read if you use tabs.
  &lt;/li&gt;
- &lt;/ul&gt;</description>
+ &lt;/ul&gt;
+
+ &lt;p&gt;
+ When the {@code FileTabCharacter} check is used with the default configuration,
+ only the first instance of a tab character is reported.
+ &lt;/p&gt;</description>
          <properties>
             <property default-value="false" name="eachLine" type="boolean">
                <description>Control whether to report on each line containing a tab,

--- a/src/site/xdoc/checks/whitespace/filetabcharacter.xml
+++ b/src/site/xdoc/checks/whitespace/filetabcharacter.xml
@@ -31,6 +31,13 @@
         </ul>
       </subsection>
 
+      <subsection name="Notes" id="Notes">
+        <p>
+          When the <code>FileTabCharacter</code> check is used with the default configuration,
+          only the first instance of a tab character is reported.
+        </p>
+      </subsection>
+
       <subsection name="Properties" id="Properties">
         <div class="wrapper">
           <table>

--- a/src/site/xdoc/checks/whitespace/filetabcharacter.xml.template
+++ b/src/site/xdoc/checks/whitespace/filetabcharacter.xml.template
@@ -31,6 +31,13 @@
         </ul>
       </subsection>
 
+      <subsection name="Notes" id="Notes">
+        <p>
+          When the <code>FileTabCharacter</code> check is used with the default configuration,
+          only the first instance of a tab character is reported.
+        </p>
+      </subsection>
+
       <subsection name="Properties" id="Properties">
         <div class="wrapper">
           <macro name="properties">


### PR DESCRIPTION
Issue #16225 

This PR adds an explicit Note about checks default behaviour:

 When the `FileTabCharacter` check is used with the default configuration,
 only the first instance of a tab character is reported.
