### PR TITLE
Issue #14631: Updated JAVADOC_TAG in javadocTokenType to new AST format

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/api/JavadocTokenTypes.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/api/JavadocTokenTypes.java
@@ -1329,13 +1329,15 @@ public final class JavadocTokenTypes {
      * <pre>{@code &#64;param T The bar.}</pre>
      * <b>Tree</b>
      * <pre>{@code
-     *   |--JAVADOC_TAG[4x3] : [@param T The bar.]
-     *       |--PARAM_LITERAL[4x3] : [@param]
-     *       |--WS[4x9] : [ ]
-     *       |--PARAMETER_NAME[4x10] : [T]
-     *       |--WS[4x11] : [ ]
-     *       |--DESCRIPTION[4x12] : [The bar.]
-     *           |--TEXT[4x12] : [The bar.]
+     * JAVADOC_TAG -&gt JAVADOC_TAG
+     *  |--PARAM_LITERAL -&gt @param
+     *  |--WS -&gt
+     *  |--PARAMETER_NAME -&gt T
+     *  |--WS -&gt
+     *  `--DESCRIPTION -&gt DESCRIPTION
+     *      |--TEXT -&gt The bar.
+     *      |--NEWLINE -&gt \r\n
+     *      `--TEXT -&gt
      * }</pre>
      */
 


### PR DESCRIPTION
Issue: #14631 

**Command Used:**

`java -jar checkstyle-10.21.1-all.jar -J Test.java | sed "s/\[[0-9]\+:[0-9]\+\]//g"
`
**Test.java**

```
/**
 * @param T The bar.
 */
public class Test {
}

```

```
Smita Prajapati@Smita-5ESU2EG5 MINGW64 ~/RULE_javadocTag
$ java -jar checkstyle-10.21.1-all.jar -J Test.java | sed "s/\[[0-9]\+:[0-9]\+\]//g"
COMPILATION_UNIT -> COMPILATION_UNIT
`--CLASS_DEF -> CLASS_DEF
    |--MODIFIERS -> MODIFIERS
    |   |--BLOCK_COMMENT_BEGIN -> /*
    |   |   |--COMMENT_CONTENT -> *\r\n * @param T The bar.\r\n
    |   |   |   `--JAVADOC -> JAVADOC
    |   |   |       |--NEWLINE -> \r\n
    |   |   |       |--LEADING_ASTERISK ->  *
    |   |   |       |--WS ->
    |   |   |       |--JAVADOC_TAG -> JAVADOC_TAG
    |   |   |       |   |--PARAM_LITERAL -> @param
    |   |   |       |   |--WS ->
    |   |   |       |   |--PARAMETER_NAME -> T
    |   |   |       |   |--WS ->
    |   |   |       |   `--DESCRIPTION -> DESCRIPTION
    |   |   |       |       |--TEXT -> The bar.
    |   |   |       |       |--NEWLINE -> \r\n
    |   |   |       |       `--TEXT ->
    |   |   |       `--EOF -> <EOF>
    |   |   `--BLOCK_COMMENT_END -> */
    |   `--LITERAL_PUBLIC -> public
    |--LITERAL_CLASS -> class
    |--IDENT -> Test
    `--OBJBLOCK -> OBJBLOCK
        |--LCURLY -> {
        `--RCURLY -> }

```
