### PR TITLE
Issue #13213: remove OK comments from javadocblocktaglocation

### DIFF
--- a/config/checkstyle-input-suppressions.xml
+++ b/config/checkstyle-input-suppressions.xml
@@ -71,11 +71,7 @@
 
   <suppress id="UnnecessaryOkComment"
             files="checks[\\/]coding[\\/]unnecessarysemicolonaftertypememberdeclaration[\\/]InputUnnecessarySemicolonAfterTypeMemberDeclarationNullAst.java"/>
-  <suppress id="UnnecessaryOkComment"
-            files="checks[\\/]javadoc[\\/]javadocblocktaglocation[\\/]InputJavadocBlockTagLocationCorrect.java"/>
-  <suppress id="UnnecessaryOkComment"
-            files="checks[\\/]javadoc[\\/]javadocblocktaglocation[\\/]InputJavadocBlockTagLocationMultilineCodeBlock.java"/>
-  <suppress id="UnnecessaryOkComment"
+ <suppress id="UnnecessaryOkComment"
             files="checks[\\/]javadoc[\\/]javadoccontentlocation[\\/]InputJavadocContentLocationDefault.java"/>
   <suppress id="UnnecessaryOkComment"
             files="checks[\\/]javadoc[\\/]javadoccontentlocation[\\/]InputJavadocContentLocationDefault.java"/>

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadocblocktaglocation/InputJavadocBlockTagLocationCorrect.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadocblocktaglocation/InputJavadocBlockTagLocationCorrect.java
@@ -25,6 +25,6 @@ public class InputJavadocBlockTagLocationCorrect {
      *
      * @since 1.0
      */
-    public int field; // ok
+    public int field;
 
 }

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadocblocktaglocation/InputJavadocBlockTagLocationMultilineCodeBlock.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadocblocktaglocation/InputJavadocBlockTagLocationMultilineCodeBlock.java
@@ -29,6 +29,6 @@ public class InputJavadocBlockTagLocationMultilineCodeBlock {
      * Default value is {&#64;code &#64;author me
      * </pre>
      */
-    public int field; // ok
+    public int field;
 
 }


### PR DESCRIPTION
Issue: #13213 

Remove '// ok' comments from  javadocblocktaglocation