### PR TITLE
Issue #16077: minimize padding for some code blocks

### DIFF
--- a/src/site/resources/css/site.css
+++ b/src/site/resources/css/site.css
@@ -133,7 +133,6 @@ code {
 }
 
 .prettyprint {
-  padding: 1em !important;
   overflow: auto;
   white-space: nowrap;
 }


### PR DESCRIPTION
Issue #16077

annotationlocation.html#Description

make padding better on first single line code block, but not affecting others.
![image](https://github.com/user-attachments/assets/9b4056c8-2393-4943-a370-5f0cb0467aa5)

in old website we somehow was able to remove big padding on top and bottom of code blocks:
https://checkstyle.org/checks/annotation/annotationlocation.html#Description
![image](https://github.com/user-attachments/assets/1ec10126-9e9e-4206-8908-501f68822af8)
