### PR TITLE
Issue #11163: Enforce file size under MissingJavadocType

### DIFF
--- a/config/checkstyle-resources-suppressions.xml
+++ b/config/checkstyle-resources-suppressions.xml
@@ -211,14 +211,6 @@
 
   <!-- Until https://github.com/checkstyle/checkstyle/issues/11163 -->
   <suppress checks="FileLength"
-    files="[\\/]test[\\/]resources[\\/]com[\\/]puppycrawl[\\/]tools[\\/]checkstyle[\\/]checks[\\/]javadoc[\\/]missingjavadoctype[\\/]InputMissingJavadocTypeNoJavadoc3\.java"/>
-  <suppress checks="FileLength"
-    files="[\\/]test[\\/]resources[\\/]com[\\/]puppycrawl[\\/]tools[\\/]checkstyle[\\/]checks[\\/]javadoc[\\/]missingjavadoctype[\\/]InputMissingJavadocTypeNoJavadoc2\.java"/>
-  <suppress checks="FileLength"
-    files="[\\/]test[\\/]resources[\\/]com[\\/]puppycrawl[\\/]tools[\\/]checkstyle[\\/]checks[\\/]javadoc[\\/]missingjavadoctype[\\/]InputMissingJavadocTypePublicOnly2\.java"/>
-  <suppress checks="FileLength"
-    files="[\\/]test[\\/]resources[\\/]com[\\/]puppycrawl[\\/]tools[\\/]checkstyle[\\/]checks[\\/]javadoc[\\/]missingjavadoctype[\\/]InputMissingJavadocTypePublicOnly1\.java"/>
-  <suppress checks="FileLength"
     files="[\\/]test[\\/]resources[\\/]com[\\/]puppycrawl[\\/]tools[\\/]checkstyle[\\/]checks[\\/]javadoc[\\/]javadoctagcontinuationindentation[\\/]InputJavadocTagContinuationIndentation\.java"/>
   <suppress checks="FileLength"
     files="[\\/]test[\\/]resources[\\/]com[\\/]puppycrawl[\\/]tools[\\/]checkstyle[\\/]checks[\\/]javadoc[\\/]javadocvariable[\\/]InputJavadocVariableNoJavadoc5\.java"/>

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/javadoc/MissingJavadocTypeCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/javadoc/MissingJavadocTypeCheckTest.java
@@ -112,7 +112,7 @@ public class MissingJavadocTypeCheckTest extends AbstractModuleTestSupport {
     }
 
     @Test
-    public void testStrict() throws Exception {
+    public void testMissingJavadocTypePublicOnly1One() throws Exception {
         final String[] expected = {
             "13:1: " + getCheckMessage(MSG_JAVADOC_MISSING),
             "15:5: " + getCheckMessage(MSG_JAVADOC_MISSING),
@@ -120,16 +120,34 @@ public class MissingJavadocTypeCheckTest extends AbstractModuleTestSupport {
             "40:5: " + getCheckMessage(MSG_JAVADOC_MISSING),
         };
         verifyWithInlineConfigParser(
-                getPath("InputMissingJavadocTypePublicOnly1.java"), expected);
+                getPath("InputMissingJavadocTypePublicOnly1One.java"), expected);
     }
 
     @Test
-    public void testProtected() throws Exception {
+    public void testMissingJavadocTypePublicOnly1Two() throws Exception {
         final String[] expected = {
             "13:1: " + getCheckMessage(MSG_JAVADOC_MISSING),
         };
         verifyWithInlineConfigParser(
-                getPath("InputMissingJavadocTypePublicOnly2.java"), expected);
+                getPath("InputMissingJavadocTypePublicOnly1Two.java"), expected);
+    }
+
+    @Test
+    public void testMissingJavadocTypePublicOnly2One() throws Exception {
+        final String[] expected = {
+            "13:1: " + getCheckMessage(MSG_JAVADOC_MISSING),
+        };
+        verifyWithInlineConfigParser(
+                getPath("InputMissingJavadocTypePublicOnly2One.java"), expected);
+    }
+
+    @Test
+    public void testMissingJavadocTypePublicOnly2Two() throws Exception {
+        final String[] expected = {
+            "13:1: " + getCheckMessage(MSG_JAVADOC_MISSING),
+        };
+        verifyWithInlineConfigParser(
+                getPath("InputMissingJavadocTypePublicOnly2Two.java"), expected);
     }
 
     @Test
@@ -216,30 +234,49 @@ public class MissingJavadocTypeCheckTest extends AbstractModuleTestSupport {
     }
 
     @Test
-    public void testScopes2() throws Exception {
+    public void testMissingJavadocTypeNoJavadoc2One() throws Exception {
         final String[] expected = {
             "13:1: " + getCheckMessage(MSG_JAVADOC_MISSING),
             "25:5: " + getCheckMessage(MSG_JAVADOC_MISSING),
         };
         verifyWithInlineConfigParser(
-                getPath("InputMissingJavadocTypeNoJavadoc2.java"),
+                getPath("InputMissingJavadocTypeNoJavadoc2One.java"),
                expected);
     }
 
     @Test
-    public void testExcludeScope() throws Exception {
+    public void testMissingJavadocTypeNoJavadoc2Two() throws Exception {
+        final String[] expected = {
+            "13:1: " + getCheckMessage(MSG_JAVADOC_MISSING),
+        };
+        verifyWithInlineConfigParser(
+                getPath("InputMissingJavadocTypeNoJavadoc2Two.java"),
+               expected);
+    }
+
+    @Test
+    public void testMissingJavadocTypeNoJavadoc3One() throws Exception {
         final String[] expected = {
             "37:5: " + getCheckMessage(MSG_JAVADOC_MISSING),
             "49:5: " + getCheckMessage(MSG_JAVADOC_MISSING),
-            "62:1: " + getCheckMessage(MSG_JAVADOC_MISSING),
-            "73:5: " + getCheckMessage(MSG_JAVADOC_MISSING),
-            "85:5: " + getCheckMessage(MSG_JAVADOC_MISSING),
-            "97:5: " + getCheckMessage(MSG_JAVADOC_MISSING),
-            "109:5: " + getCheckMessage(MSG_JAVADOC_MISSING),
-            "121:5: " + getCheckMessage(MSG_JAVADOC_MISSING),
         };
         verifyWithInlineConfigParser(
-                getPath("InputMissingJavadocTypeNoJavadoc3.java"),
+                getPath("InputMissingJavadocTypeNoJavadoc3One.java"),
+               expected);
+    }
+
+    @Test
+    public void testMissingJavadocTypeNoJavadoc3Two() throws Exception {
+        final String[] expected = {
+            "15:1: " + getCheckMessage(MSG_JAVADOC_MISSING),
+            "26:5: " + getCheckMessage(MSG_JAVADOC_MISSING),
+            "38:5: " + getCheckMessage(MSG_JAVADOC_MISSING),
+            "50:5: " + getCheckMessage(MSG_JAVADOC_MISSING),
+            "62:5: " + getCheckMessage(MSG_JAVADOC_MISSING),
+            "74:5: " + getCheckMessage(MSG_JAVADOC_MISSING),
+        };
+        verifyWithInlineConfigParser(
+                getPath("InputMissingJavadocTypeNoJavadoc3Two.java"),
                expected);
     }
 

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/missingjavadoctype/InputMissingJavadocTypeNoJavadoc2One.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/missingjavadoctype/InputMissingJavadocTypeNoJavadoc2One.java
@@ -1,0 +1,60 @@
+/*
+MissingJavadocType
+scope = protected
+excludeScope = (default)null
+skipAnnotations = (default)Generated
+tokens = (default)INTERFACE_DEF, CLASS_DEF, ENUM_DEF, ANNOTATION_DEF, RECORD_DEF
+
+
+*/
+
+package com.puppycrawl.tools.checkstyle.checks.javadoc.missingjavadoctype;
+
+public class InputMissingJavadocTypeNoJavadoc2One // violation
+{
+    public int i1;
+    protected int i2;
+    int i3;
+    private int i4;
+
+    public void foo1() {}
+    protected void foo2() {}
+    void foo3() {}
+    private void foo4() {}
+
+    protected class ProtectedInner { // violation
+        public int i1;
+        protected int i2;
+        int i3;
+        private int i4;
+
+        public void foo1() {}
+        protected void foo2() {}
+        void foo3() {}
+        private void foo4() {}
+    }
+
+    class PackageInner {
+        public int i1;
+        protected int i2;
+        int i3;
+        private int i4;
+
+        public void foo1() {}
+        protected void foo2() {}
+        void foo3() {}
+        private void foo4() {}
+    }
+
+    private class PrivateInner {
+        public int i1;
+        protected int i2;
+        int i3;
+        private int i4;
+
+        public void foo1() {}
+        protected void foo2() {}
+        void foo3() {}
+        private void foo4() {}
+    }
+}

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/missingjavadoctype/InputMissingJavadocTypeNoJavadoc2Two.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/missingjavadoctype/InputMissingJavadocTypeNoJavadoc2Two.java
@@ -10,54 +10,7 @@ tokens = (default)INTERFACE_DEF, CLASS_DEF, ENUM_DEF, ANNOTATION_DEF, RECORD_DEF
 
 package com.puppycrawl.tools.checkstyle.checks.javadoc.missingjavadoctype;
 
-public class InputMissingJavadocTypeNoJavadoc2 // violation
-{
-    public int i1;
-    protected int i2;
-    int i3;
-    private int i4;
-
-    public void foo1() {}
-    protected void foo2() {}
-    void foo3() {}
-    private void foo4() {}
-
-    protected class ProtectedInner { // violation
-        public int i1;
-        protected int i2;
-        int i3;
-        private int i4;
-
-        public void foo1() {}
-        protected void foo2() {}
-        void foo3() {}
-        private void foo4() {}
-    }
-
-    class PackageInner {
-        public int i1;
-        protected int i2;
-        int i3;
-        private int i4;
-
-        public void foo1() {}
-        protected void foo2() {}
-        void foo3() {}
-        private void foo4() {}
-    }
-
-    private class PrivateInner {
-        public int i1;
-        protected int i2;
-        int i3;
-        private int i4;
-
-        public void foo1() {}
-        protected void foo2() {}
-        void foo3() {}
-        private void foo4() {}
-    }
-}
+public class InputMissingJavadocTypeNoJavadoc2Two {} // violation
 
 class PackageClass2 {
     public int i1;

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/missingjavadoctype/InputMissingJavadocTypeNoJavadoc3One.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/missingjavadoctype/InputMissingJavadocTypeNoJavadoc3One.java
@@ -1,0 +1,60 @@
+/*
+MissingJavadocType
+scope = private
+excludeScope = protected
+skipAnnotations = (default)Generated
+tokens = (default)INTERFACE_DEF, CLASS_DEF, ENUM_DEF, ANNOTATION_DEF, RECORD_DEF
+
+
+*/
+
+package com.puppycrawl.tools.checkstyle.checks.javadoc.missingjavadoctype;
+
+public class InputMissingJavadocTypeNoJavadoc3One
+{
+    public int i1;
+    protected int i2;
+    int i3;
+    private int i4;
+
+    public void foo1() {}
+    protected void foo2() {}
+    void foo3() {}
+    private void foo4() {}
+
+    protected class ProtectedInner {
+        public int i1;
+        protected int i2;
+        int i3;
+        private int i4;
+
+        public void foo1() {}
+        protected void foo2() {}
+        void foo3() {}
+        private void foo4() {}
+    }
+
+    class PackageInner { // violation
+        public int i1;
+        protected int i2;
+        int i3;
+        private int i4;
+
+        public void foo1() {}
+        protected void foo2() {}
+        void foo3() {}
+        private void foo4() {}
+    }
+
+    private class PrivateInner { // violation
+        public int i1;
+        protected int i2;
+        int i3;
+        private int i4;
+
+        public void foo1() {}
+        protected void foo2() {}
+        void foo3() {}
+        private void foo4() {}
+    }
+}

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/missingjavadoctype/InputMissingJavadocTypeNoJavadoc3Two.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/missingjavadoctype/InputMissingJavadocTypeNoJavadoc3Two.java
@@ -10,54 +10,7 @@ tokens = (default)INTERFACE_DEF, CLASS_DEF, ENUM_DEF, ANNOTATION_DEF, RECORD_DEF
 
 package com.puppycrawl.tools.checkstyle.checks.javadoc.missingjavadoctype;
 
-public class InputMissingJavadocTypeNoJavadoc3
-{
-    public int i1;
-    protected int i2;
-    int i3;
-    private int i4;
-
-    public void foo1() {}
-    protected void foo2() {}
-    void foo3() {}
-    private void foo4() {}
-
-    protected class ProtectedInner {
-        public int i1;
-        protected int i2;
-        int i3;
-        private int i4;
-
-        public void foo1() {}
-        protected void foo2() {}
-        void foo3() {}
-        private void foo4() {}
-    }
-
-    class PackageInner { // violation
-        public int i1;
-        protected int i2;
-        int i3;
-        private int i4;
-
-        public void foo1() {}
-        protected void foo2() {}
-        void foo3() {}
-        private void foo4() {}
-    }
-
-    private class PrivateInner { // violation
-        public int i1;
-        protected int i2;
-        int i3;
-        private int i4;
-
-        public void foo1() {}
-        protected void foo2() {}
-        void foo3() {}
-        private void foo4() {}
-    }
-}
+public class InputMissingJavadocTypeNoJavadoc3Two {}
 
 class PackageClass3 { // violation
     public int i1;

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/missingjavadoctype/InputMissingJavadocTypePublicOnly1One.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/missingjavadoctype/InputMissingJavadocTypePublicOnly1One.java
@@ -1,0 +1,48 @@
+/*
+MissingJavadocType
+scope = PRIVATE
+excludeScope = (default)null
+skipAnnotations = (default)Generated
+tokens = (default)INTERFACE_DEF, CLASS_DEF, ENUM_DEF, ANNOTATION_DEF, RECORD_DEF
+
+
+*/
+
+package com.puppycrawl.tools.checkstyle.checks.javadoc.missingjavadoctype;
+
+public class InputMissingJavadocTypePublicOnly1One { // violation
+
+    private interface InnerInterface // violation
+    {
+        String CONST = "InnerInterface"; // ignore - w.n.r.a.j
+        void method(); // ignore - when not relaxed about Javadoc
+
+        class InnerInnerClass // violation
+        {
+            private int mData; // ignore - when not relaxed about Javadoc
+
+            private InnerInnerClass()
+            {
+                final Runnable r = new Runnable() {
+                        public void run() {};
+                    };
+            }
+
+            void method2() // ignore - when not relaxed about Javadoc
+            {
+                final Runnable r = new Runnable() {
+                        public void run() {};
+                    };
+            }
+        }
+    }
+
+    private class InnerClass // violation
+    {
+        private int mDiff; // ignore - when not relaxed about Javadoc
+
+        void method() // ignore - when not relaxed about Javadoc
+        {
+        }
+    }
+}

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/missingjavadoctype/InputMissingJavadocTypePublicOnly1Two.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/missingjavadoctype/InputMissingJavadocTypePublicOnly1Two.java
@@ -10,64 +10,30 @@ tokens = (default)INTERFACE_DEF, CLASS_DEF, ENUM_DEF, ANNOTATION_DEF, RECORD_DEF
 
 package com.puppycrawl.tools.checkstyle.checks.javadoc.missingjavadoctype;
 
-public class InputMissingJavadocTypePublicOnly1 // violation
+public class InputMissingJavadocTypePublicOnly1Two // violation
 {
-    private interface InnerInterface // violation
-    {
-        String CONST = "InnerInterface"; // ignore - w.n.r.a.j
-        void method(); // ignore - when not relaxed about Javadoc
-
-        class InnerInnerClass // violation
-        {
-            private int mData; // ignore - when not relaxed about Javadoc
-
-            private InnerInnerClass()
-            {
-                final Runnable r = new Runnable() {
-                        public void run() {};
-                    };
-            }
-
-            void method2() // ignore - when not relaxed about Javadoc
-            {
-                final Runnable r = new Runnable() {
-                        public void run() {};
-                    };
-            }
-        }
-    }
-
-    private class InnerClass // violation
-    {
-        private int mDiff; // ignore - when not relaxed about Javadoc
-
-        void method() // ignore - when not relaxed about Javadoc
-        {
-        }
-    }
-
     private int mSize; // ignore - when not relaxed about Javadoc
     int mLen; // ignore - when not relaxed about Javadoc
     protected int mDeer; // ignore
     public int aFreddo; // ignore
 
     // ignore - need Javadoc
-    private InputMissingJavadocTypePublicOnly1(int aA)
+    private InputMissingJavadocTypePublicOnly1Two(int aA)
     {
     }
 
     // ignore - need Javadoc when not relaxed
-    InputMissingJavadocTypePublicOnly1(String aA)
+    InputMissingJavadocTypePublicOnly1Two(String aA)
     {
     }
 
     // ignore - always need javadoc
-    protected InputMissingJavadocTypePublicOnly1(Object aA)
+    protected InputMissingJavadocTypePublicOnly1Two(Object aA)
     {
     }
 
     // ignore - always need javadoc
-    public InputMissingJavadocTypePublicOnly1(Class<Object> aA)
+    public InputMissingJavadocTypePublicOnly1Two(Class<Object> aA)
     {
     }
 

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/missingjavadoctype/InputMissingJavadocTypePublicOnly2One.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/missingjavadoctype/InputMissingJavadocTypePublicOnly2One.java
@@ -1,0 +1,48 @@
+/*
+MissingJavadocType
+scope = protected
+excludeScope = (default)null
+skipAnnotations = (default)Generated
+tokens = (default)INTERFACE_DEF, CLASS_DEF, ENUM_DEF, ANNOTATION_DEF, RECORD_DEF
+
+
+*/
+
+package com.puppycrawl.tools.checkstyle.checks.javadoc.missingjavadoctype;
+
+public class InputMissingJavadocTypePublicOnly2One // violation
+{
+    private interface InnerInterface
+    {
+        String CONST = "InnerInterface"; // ignore - w.n.r.a.j
+        void method(); // ignore - when not relaxed about Javadoc
+
+        class InnerInnerClass
+        {
+            private int mData; // ignore - when not relaxed about Javadoc
+
+            private InnerInnerClass()
+            {
+                final Runnable r = new Runnable() {
+                    public void run() {};
+                };
+            }
+
+            void method2() // ignore - when not relaxed about Javadoc
+            {
+                final Runnable r = new Runnable() {
+                    public void run() {};
+                };
+            }
+        }
+    }
+
+    private class InnerClass
+    {
+        private int mDiff; // ignore - when not relaxed about Javadoc
+
+        void method() // ignore - when not relaxed about Javadoc
+        {
+        }
+    }
+}

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/missingjavadoctype/InputMissingJavadocTypePublicOnly2Two.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/missingjavadoctype/InputMissingJavadocTypePublicOnly2Two.java
@@ -10,64 +10,30 @@ tokens = (default)INTERFACE_DEF, CLASS_DEF, ENUM_DEF, ANNOTATION_DEF, RECORD_DEF
 
 package com.puppycrawl.tools.checkstyle.checks.javadoc.missingjavadoctype;
 
-public class InputMissingJavadocTypePublicOnly2 // violation
+public class InputMissingJavadocTypePublicOnly2Two // violation
 {
-    private interface InnerInterface
-    {
-        String CONST = "InnerInterface"; // ignore - w.n.r.a.j
-        void method(); // ignore - when not relaxed about Javadoc
-
-        class InnerInnerClass
-        {
-            private int mData; // ignore - when not relaxed about Javadoc
-
-            private InnerInnerClass()
-            {
-                final Runnable r = new Runnable() {
-                    public void run() {};
-                };
-            }
-
-            void method2() // ignore - when not relaxed about Javadoc
-            {
-                final Runnable r = new Runnable() {
-                    public void run() {};
-                };
-            }
-        }
-    }
-
-    private class InnerClass
-    {
-        private int mDiff; // ignore - when not relaxed about Javadoc
-
-        void method() // ignore - when not relaxed about Javadoc
-        {
-        }
-    }
-
     private int mSize; // ignore - when not relaxed about Javadoc
     int mLen; // ignore - when not relaxed about Javadoc
     protected int mDeer; // ignore
     public int aFreddo; // ignore
 
     // ignore - need Javadoc
-    private InputMissingJavadocTypePublicOnly2(int aA)
+    private InputMissingJavadocTypePublicOnly2Two(int aA)
     {
     }
 
     // ignore - need Javadoc when not relaxed
-    InputMissingJavadocTypePublicOnly2(String aA)
+    InputMissingJavadocTypePublicOnly2Two(String aA)
     {
     }
 
     // ignore - always need javadoc
-    protected InputMissingJavadocTypePublicOnly2(Object aA)
+    protected InputMissingJavadocTypePublicOnly2Two(Object aA)
     {
     }
 
     // ignore - always need javadoc
-    public InputMissingJavadocTypePublicOnly2(Class<Object> aA)
+    public InputMissingJavadocTypePublicOnly2Two(Class<Object> aA)
     {
     }
 


### PR DESCRIPTION
Issue #11163

Resolves the file size under MissingJavadocType from exceeding 120 lines and removed related suppressions