### PR TITLE
Issue #16243: Fixed extra top & bottom spacing in code blocks

### DIFF
--- a/src/site/resources/css/site.css
+++ b/src/site/resources/css/site.css
@@ -128,10 +128,6 @@ th {
   background-color: #ededed;
 }
 
-code {
-  white-space: normal;
-}
-
 .prettyprint {
   padding: 1em !important;
   overflow: auto;
@@ -139,7 +135,7 @@ code {
 }
 
 .prettyprint code {
-  font-size: 15px;
+  font-size: 17px;
   text-wrap: nowrap;
 }
 

--- a/src/site/resources/js/checkstyle.js
+++ b/src/site/resources/js/checkstyle.js
@@ -58,6 +58,16 @@ window.addEventListener("load", function () {
     externalLinks.forEach((link) => {
         link.setAttribute("target", "_blank");
     });
+
+    const codeBlocks = document.querySelectorAll(".prettyprint code");
+    codeBlocks.forEach((block) => {
+        const code = block.innerText.split("\n");
+        if (code.length > 1) {
+            code.shift();
+            code.pop();
+            block.innerText = code.join("\n");
+        }
+    });
 });
 
 window.addEventListener("scroll", function () {


### PR DESCRIPTION
#16243 

Fixed: 
> code snippets have too much in top/bottom spacing [details](https://github.com/checkstyle/checkstyle/issues/16077#issuecomment-2614139913)