### PR TITLE
Issue #16243: Remove extra spacing between top image and gray bar in header

### DIFF
--- a/src/site/resources/css/site.css
+++ b/src/site/resources/css/site.css
@@ -47,6 +47,10 @@ section p {
 
 }
 
+#bannerLeft h1 {
+  margin: 0;
+}
+
 #bannerRight h1 {
   margin: 0;
 }


### PR DESCRIPTION
This pull request solves the issue #16243 by removing the unnecessary space between top image and the gray bar. It was done by setting the .banner class height to 97px to ensure proper alignment.

Issue Link:
Fixes: #16243