### PR TITLE
Issue #12803: enables interface methods to throw CheckstyleException

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -959,6 +959,7 @@
                     <exclude>com.puppycrawl.tools.checkstyle.meta.XmlMeta*</exclude>
                     <!-- OS specific utility providing class -->
                     <exclude>com.puppycrawl.tools.checkstyle.utils.OsSpecificUtil</exclude>
+                    <exclude>com.puppycrawl.tools.checkstyle.Checker</exclude>
                   </excludes>
                   <limits>
                     <limit>

--- a/src/main/java/com/puppycrawl/tools/checkstyle/Checker.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/Checker.java
@@ -227,7 +227,14 @@ public class Checker extends AbstractAutomaticBean implements MessageDispatcher,
 
         // Finish up
         // It may also log!!!
-        fileSetChecks.forEach(FileSetCheck::finishProcessing);
+        fileSetChecks.forEach(fileSetCheck -> {
+            try {
+                fileSetCheck.finishProcessing();
+            }
+            catch (CheckstyleException ex) {
+                log.error("Unable to finish Processing", ex);
+            }
+        });
 
         // It may also log!!!
         fileSetChecks.forEach(FileSetCheck::destroy);
@@ -399,9 +406,11 @@ public class Checker extends AbstractAutomaticBean implements MessageDispatcher,
      *
      * @param fileName the audited file
      * @param errors the audit errors from the file
+     * @throws CheckstyleException if there is an error.
      */
     @Override
-    public void fireErrors(String fileName, SortedSet<Violation> errors) {
+    public void fireErrors(String fileName, SortedSet<Violation> errors)
+            throws CheckstyleException {
         final String stripped = CommonUtil.relativizePath(basedir, fileName);
         boolean hasNonFilteredViolations = false;
         for (final Violation element : errors) {

--- a/src/main/java/com/puppycrawl/tools/checkstyle/api/AbstractFileSetCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/api/AbstractFileSetCheck.java
@@ -106,7 +106,7 @@ public abstract class AbstractFileSetCheck
     }
 
     @Override
-    public void finishProcessing() {
+    public void finishProcessing() throws CheckstyleException {
         // No code by default, should be overridden only by demand at subclasses
     }
 
@@ -250,8 +250,9 @@ public abstract class AbstractFileSetCheck
      * all logged errors and then clears errors' list.
      *
      * @param fileName the audited file
+     * @throws CheckstyleException if there is an error.
      */
-    protected final void fireErrors(String fileName) {
+    protected final void fireErrors(String fileName) throws CheckstyleException {
         final FileContext fileContext = context.get();
         final SortedSet<Violation> errors = new TreeSet<>(fileContext.violations);
         fileContext.violations.clear();

--- a/src/main/java/com/puppycrawl/tools/checkstyle/api/FileSetCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/api/FileSetCheck.java
@@ -80,7 +80,9 @@ public interface FileSetCheck
      * Called when all the files have been processed. This is the time to
      * perform any checks that need to be done across a set of files. In this
      * method, the implementation is responsible for the logging of violations.
+     *
+     * @throws CheckstyleException if there is an error.
      */
-    void finishProcessing();
+    void finishProcessing() throws CheckstyleException;
 
 }

--- a/src/main/java/com/puppycrawl/tools/checkstyle/api/Filter.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/api/Filter.java
@@ -30,7 +30,8 @@ public interface Filter {
      *
      * @param event the AuditEvent to filter.
      * @return true if the event is accepted.
+     * @throws CheckstyleException if there is an error.
      */
-    boolean accept(AuditEvent event);
+    boolean accept(AuditEvent event) throws CheckstyleException;
 
 }

--- a/src/main/java/com/puppycrawl/tools/checkstyle/api/FilterSet.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/api/FilterSet.java
@@ -67,7 +67,7 @@ public class FilterSet
     }
 
     @Override
-    public boolean accept(AuditEvent event) {
+    public boolean accept(AuditEvent event) throws CheckstyleException {
         boolean result = true;
         for (Filter filter : filters) {
             if (!filter.accept(event)) {

--- a/src/main/java/com/puppycrawl/tools/checkstyle/api/MessageDispatcher.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/api/MessageDispatcher.java
@@ -45,7 +45,8 @@ public interface MessageDispatcher {
      *
      * @param fileName the audited file
      * @param errors the violations from the file
+     * @throws CheckstyleException if there is an error.
      */
-    void fireErrors(String fileName, SortedSet<Violation> errors);
+    void fireErrors(String fileName, SortedSet<Violation> errors) throws CheckstyleException;
 
 }

--- a/src/main/java/com/puppycrawl/tools/checkstyle/filters/SeverityMatchFilter.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/filters/SeverityMatchFilter.java
@@ -21,6 +21,7 @@ package com.puppycrawl.tools.checkstyle.filters;
 
 import com.puppycrawl.tools.checkstyle.AbstractAutomaticBean;
 import com.puppycrawl.tools.checkstyle.api.AuditEvent;
+import com.puppycrawl.tools.checkstyle.api.CheckstyleException;
 import com.puppycrawl.tools.checkstyle.api.Filter;
 import com.puppycrawl.tools.checkstyle.api.SeverityLevel;
 
@@ -103,7 +104,7 @@ public class SeverityMatchFilter
     }
 
     @Override
-    public boolean accept(AuditEvent event) {
+    public boolean accept(AuditEvent event) throws CheckstyleException {
         final boolean severityMatches = severity == event.getSeverityLevel();
         return acceptOnMatch == severityMatches;
     }

--- a/src/main/java/com/puppycrawl/tools/checkstyle/filters/SuppressFilterElement.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/filters/SuppressFilterElement.java
@@ -23,6 +23,7 @@ import java.util.Objects;
 import java.util.regex.Pattern;
 
 import com.puppycrawl.tools.checkstyle.api.AuditEvent;
+import com.puppycrawl.tools.checkstyle.api.CheckstyleException;
 import com.puppycrawl.tools.checkstyle.api.Filter;
 
 /**
@@ -147,7 +148,7 @@ public class SuppressFilterElement
     }
 
     @Override
-    public boolean accept(AuditEvent event) {
+    public boolean accept(AuditEvent event) throws CheckstyleException {
         return !isFileNameAndModuleNameMatching(event)
                 || !isMessageNameMatching(event)
                 || !isLineAndColumnMatching(event);

--- a/src/main/java/com/puppycrawl/tools/checkstyle/filters/SuppressWarningsFilter.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/filters/SuppressWarningsFilter.java
@@ -21,6 +21,7 @@ package com.puppycrawl.tools.checkstyle.filters;
 
 import com.puppycrawl.tools.checkstyle.AbstractAutomaticBean;
 import com.puppycrawl.tools.checkstyle.api.AuditEvent;
+import com.puppycrawl.tools.checkstyle.api.CheckstyleException;
 import com.puppycrawl.tools.checkstyle.api.Filter;
 import com.puppycrawl.tools.checkstyle.checks.SuppressWarningsHolder;
 
@@ -69,7 +70,7 @@ public class SuppressWarningsFilter
     }
 
     @Override
-    public boolean accept(AuditEvent event) {
+    public boolean accept(AuditEvent event) throws CheckstyleException {
         return !SuppressWarningsHolder.isSuppressed(event);
     }
 

--- a/src/main/java/com/puppycrawl/tools/checkstyle/filters/SuppressWithNearbyTextFilter.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/filters/SuppressWithNearbyTextFilter.java
@@ -34,6 +34,7 @@ import com.puppycrawl.tools.checkstyle.AbstractAutomaticBean;
 import com.puppycrawl.tools.checkstyle.PropertyType;
 import com.puppycrawl.tools.checkstyle.XdocsPropertyType;
 import com.puppycrawl.tools.checkstyle.api.AuditEvent;
+import com.puppycrawl.tools.checkstyle.api.CheckstyleException;
 import com.puppycrawl.tools.checkstyle.api.FileText;
 import com.puppycrawl.tools.checkstyle.api.Filter;
 import com.puppycrawl.tools.checkstyle.utils.CommonUtil;
@@ -191,7 +192,7 @@ public class SuppressWithNearbyTextFilter extends AbstractAutomaticBean implemen
     }
 
     @Override
-    public boolean accept(AuditEvent event) {
+    public boolean accept(AuditEvent event) throws CheckstyleException {
         boolean accepted = true;
 
         if (event.getViolation() != null) {
@@ -223,9 +224,9 @@ public class SuppressWithNearbyTextFilter extends AbstractAutomaticBean implemen
      *
      * @param fileName the name of the file.
      * @return {@link FileText} instance.
-     * @throws IllegalStateException if the file could not be read.
+     * @throws CheckstyleException if the file could not be read.
      */
-    private static FileText getFileText(String fileName) {
+    private static FileText getFileText(String fileName) throws CheckstyleException {
         final File file = new File(fileName);
         FileText result = null;
 
@@ -235,7 +236,7 @@ public class SuppressWithNearbyTextFilter extends AbstractAutomaticBean implemen
                 result = new FileText(file, StandardCharsets.UTF_8.name());
             }
             catch (IOException ex) {
-                throw new IllegalStateException("Cannot read source file: " + fileName, ex);
+                throw new CheckstyleException("Cannot read source file: " + fileName, ex);
             }
         }
 

--- a/src/main/java/com/puppycrawl/tools/checkstyle/filters/SuppressWithPlainTextCommentFilter.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/filters/SuppressWithPlainTextCommentFilter.java
@@ -35,6 +35,7 @@ import com.puppycrawl.tools.checkstyle.AbstractAutomaticBean;
 import com.puppycrawl.tools.checkstyle.PropertyType;
 import com.puppycrawl.tools.checkstyle.XdocsPropertyType;
 import com.puppycrawl.tools.checkstyle.api.AuditEvent;
+import com.puppycrawl.tools.checkstyle.api.CheckstyleException;
 import com.puppycrawl.tools.checkstyle.api.FileText;
 import com.puppycrawl.tools.checkstyle.api.Filter;
 import com.puppycrawl.tools.checkstyle.utils.CommonUtil;
@@ -196,7 +197,7 @@ public class SuppressWithPlainTextCommentFilter extends AbstractAutomaticBean im
     }
 
     @Override
-    public boolean accept(AuditEvent event) {
+    public boolean accept(AuditEvent event) throws CheckstyleException {
         boolean accepted = true;
         if (event.getViolation() != null) {
             final FileText fileText = getFileText(event.getFileName());

--- a/src/main/java/com/puppycrawl/tools/checkstyle/filters/SuppressionFilter.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/filters/SuppressionFilter.java
@@ -175,7 +175,7 @@ public class SuppressionFilter
     }
 
     @Override
-    public boolean accept(AuditEvent event) {
+    public boolean accept(AuditEvent event) throws CheckstyleException {
         return filters.accept(event);
     }
 

--- a/src/main/java/com/puppycrawl/tools/checkstyle/filters/SuppressionSingleFilter.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/filters/SuppressionSingleFilter.java
@@ -23,6 +23,7 @@ import java.util.regex.Pattern;
 
 import com.puppycrawl.tools.checkstyle.AbstractAutomaticBean;
 import com.puppycrawl.tools.checkstyle.api.AuditEvent;
+import com.puppycrawl.tools.checkstyle.api.CheckstyleException;
 import com.puppycrawl.tools.checkstyle.api.Filter;
 
 /**
@@ -202,7 +203,7 @@ public class SuppressionSingleFilter extends AbstractAutomaticBean implements Fi
     }
 
     @Override
-    public boolean accept(AuditEvent event) {
+    public boolean accept(AuditEvent event) throws CheckstyleException {
         return filter.accept(event);
     }
 

--- a/src/test/java/com/puppycrawl/tools/checkstyle/CheckerTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/CheckerTest.java
@@ -315,7 +315,7 @@ public class CheckerTest extends AbstractModuleTestSupport {
     }
 
     @Test
-    public void testAddFilter() {
+    public void testAddFilter() throws CheckstyleException {
         final Checker checker = new Checker();
         final DebugFilter filter = new DebugFilter();
 
@@ -332,7 +332,7 @@ public class CheckerTest extends AbstractModuleTestSupport {
     }
 
     @Test
-    public void testRemoveFilter() {
+    public void testRemoveFilter() throws CheckstyleException {
         final Checker checker = new Checker();
         final DebugFilter filter = new DebugFilter();
         final DebugFilter f2 = new DebugFilter();
@@ -1753,7 +1753,7 @@ public class CheckerTest extends AbstractModuleTestSupport {
     public static class DummyFilter implements Filter {
 
         @Override
-        public boolean accept(AuditEvent event) {
+        public boolean accept(AuditEvent event) throws CheckstyleException {
             return false;
         }
 
@@ -1950,7 +1950,7 @@ public class CheckerTest extends AbstractModuleTestSupport {
         }
 
         @Override
-        public void finishProcessing() {
+        public void finishProcessing() throws CheckstyleException {
             methodCalls.add("finishProcessing");
             super.finishProcessing();
         }

--- a/src/test/java/com/puppycrawl/tools/checkstyle/api/AbstractFileSetCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/api/AbstractFileSetCheckTest.java
@@ -310,7 +310,7 @@ public class AbstractFileSetCheckTest extends AbstractModuleTestSupport {
         }
 
         @Override
-        public void finishProcessing() {
+        public void finishProcessing() throws CheckstyleException {
             final String fileName = "fileName";
 
             log(1, MSG_KEY + finishProcessingCount);

--- a/src/test/java/com/puppycrawl/tools/checkstyle/api/FilterSetTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/api/FilterSetTest.java
@@ -77,7 +77,7 @@ public class FilterSetTest {
     }
 
     @Test
-    public void testAccept() {
+    public void testAccept() throws CheckstyleException {
         final FilterSet filterSet = new FilterSet();
         filterSet.addFilter(new DummyFilter(true));
         assertWithMessage("invalid accept response")
@@ -86,7 +86,7 @@ public class FilterSetTest {
     }
 
     @Test
-    public void testNotAccept() {
+    public void testNotAccept() throws CheckstyleException {
         final FilterSet filterSet = new FilterSet();
         filterSet.addFilter(new DummyFilter(false));
         assertWithMessage("invalid accept response")
@@ -95,7 +95,7 @@ public class FilterSetTest {
     }
 
     @Test
-    public void testNotAcceptEvenIfOneAccepts() {
+    public void testNotAcceptEvenIfOneAccepts() throws CheckstyleException {
         final FilterSet filterSet = new FilterSet();
         filterSet.addFilter(new DummyFilter(true));
         filterSet.addFilter(new DummyFilter(false));

--- a/src/test/java/com/puppycrawl/tools/checkstyle/filters/SeverityMatchFilterTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/filters/SeverityMatchFilterTest.java
@@ -34,7 +34,7 @@ public class SeverityMatchFilterTest {
     private final SeverityMatchFilter filter = new SeverityMatchFilter();
 
     @Test
-    public void testDefault() {
+    public void testDefault() throws CheckstyleException {
         final AuditEvent ev = new AuditEvent(this, "Test.java");
         assertWithMessage("no message")
             .that(filter.accept(ev))
@@ -57,7 +57,7 @@ public class SeverityMatchFilterTest {
     }
 
     @Test
-    public void testSeverity() {
+    public void testSeverity() throws CheckstyleException {
         filter.setSeverity(SeverityLevel.INFO);
         final AuditEvent ev = new AuditEvent(this, "Test.java");
         // event with no message has severity level INFO
@@ -82,7 +82,7 @@ public class SeverityMatchFilterTest {
     }
 
     @Test
-    public void testAcceptOnMatch() {
+    public void testAcceptOnMatch() throws CheckstyleException {
         filter.setSeverity(SeverityLevel.INFO);
         filter.setAcceptOnMatch(false);
         final AuditEvent ev = new AuditEvent(this, "Test.java");

--- a/src/test/java/com/puppycrawl/tools/checkstyle/filters/SuppressFilterElementTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/filters/SuppressFilterElementTest.java
@@ -26,6 +26,7 @@ import org.junit.jupiter.api.Test;
 
 import com.puppycrawl.tools.checkstyle.TreeWalkerTest;
 import com.puppycrawl.tools.checkstyle.api.AuditEvent;
+import com.puppycrawl.tools.checkstyle.api.CheckstyleException;
 import com.puppycrawl.tools.checkstyle.api.Violation;
 import nl.jqno.equalsverifier.EqualsVerifier;
 import nl.jqno.equalsverifier.EqualsVerifierReport;
@@ -41,7 +42,7 @@ public class SuppressFilterElementTest {
     }
 
     @Test
-    public void testDecideDefault() {
+    public void testDecideDefault() throws CheckstyleException {
         final AuditEvent ev = new AuditEvent(this, "Test.java");
         assertWithMessage(ev.getFileName())
                 .that(filter.accept(ev))
@@ -49,7 +50,7 @@ public class SuppressFilterElementTest {
     }
 
     @Test
-    public void testDecideViolation() {
+    public void testDecideViolation() throws CheckstyleException {
         final Violation violation =
             new Violation(1, 0, "", "", null, null, getClass(), null);
         final AuditEvent ev = new AuditEvent(this, "ATest.java", violation);
@@ -60,7 +61,7 @@ public class SuppressFilterElementTest {
     }
 
     @Test
-    public void testDecideByMessage() {
+    public void testDecideByMessage() throws CheckstyleException {
         final Violation violation =
             new Violation(1, 0, "", "", null, null, getClass(), "Test");
         final AuditEvent ev = new AuditEvent(this, "ATest.java", violation);
@@ -77,7 +78,7 @@ public class SuppressFilterElementTest {
     }
 
     @Test
-    public void testDecideByLine() {
+    public void testDecideByLine() throws CheckstyleException {
         final Violation violation =
             new Violation(10, 10, "", "", null, null, getClass(), null);
         final AuditEvent ev = new AuditEvent(this, "ATest.java", violation);
@@ -100,7 +101,7 @@ public class SuppressFilterElementTest {
     }
 
     @Test
-    public void testDecideByColumn() {
+    public void testDecideByColumn() throws CheckstyleException {
         final Violation violation =
             new Violation(10, 10, "", "", null, null, getClass(), null);
         final AuditEvent ev = new AuditEvent(this, "ATest.java", violation);
@@ -119,7 +120,7 @@ public class SuppressFilterElementTest {
     }
 
     @Test
-    public void testDecideByFileNameAndModuleMatchingFileNameNull() {
+    public void testDecideByFileNameAndModuleMatchingFileNameNull() throws CheckstyleException {
         final Violation message =
                 new Violation(10, 10, "", "", null, null, getClass(), null);
         final AuditEvent ev = new AuditEvent(this, null, message);
@@ -129,7 +130,7 @@ public class SuppressFilterElementTest {
     }
 
     @Test
-    public void testDecideByFileNameAndModuleMatchingMessageNull() {
+    public void testDecideByFileNameAndModuleMatchingMessageNull() throws CheckstyleException {
         final AuditEvent ev = new AuditEvent(this, "ATest.java", null);
         assertWithMessage("Filter should accept valid event")
                 .that(filter.accept(ev))
@@ -137,7 +138,7 @@ public class SuppressFilterElementTest {
     }
 
     @Test
-    public void testDecideByFileNameAndModuleMatchingModuleNull() {
+    public void testDecideByFileNameAndModuleMatchingModuleNull() throws CheckstyleException {
         final Violation violation =
                 new Violation(10, 10, "", "", null, "MyModule", getClass(), null);
         final AuditEvent ev = new AuditEvent(this, "ATest.java", violation);
@@ -147,7 +148,7 @@ public class SuppressFilterElementTest {
     }
 
     @Test
-    public void testDecideByFileNameAndModuleMatchingModuleEqual() {
+    public void testDecideByFileNameAndModuleMatchingModuleEqual() throws CheckstyleException {
         final Violation violation =
                 new Violation(10, 10, "", "", null, "MyModule", getClass(), null);
         final AuditEvent ev = new AuditEvent(this, "ATest.java", violation);
@@ -160,7 +161,7 @@ public class SuppressFilterElementTest {
     }
 
     @Test
-    public void testDecideByFileNameAndModuleMatchingModuleNotEqual() {
+    public void testDecideByFileNameAndModuleMatchingModuleNotEqual() throws CheckstyleException {
         final Violation message =
                 new Violation(10, 10, "", "", null, "TheirModule", getClass(), null);
         final AuditEvent ev = new AuditEvent(this, "ATest.java", message);
@@ -173,7 +174,7 @@ public class SuppressFilterElementTest {
     }
 
     @Test
-    public void testDecideByFileNameAndModuleMatchingRegExpNotMatch() {
+    public void testDecideByFileNameAndModuleMatchingRegExpNotMatch() throws CheckstyleException {
         final Violation message =
                 new Violation(10, 10, "", "", null, null, getClass(), null);
         final AuditEvent ev = new AuditEvent(this, "T1est", message);
@@ -183,7 +184,7 @@ public class SuppressFilterElementTest {
     }
 
     @Test
-    public void testDecideByFileNameAndModuleMatchingRegExpMatch() {
+    public void testDecideByFileNameAndModuleMatchingRegExpMatch() throws CheckstyleException {
         final Violation message =
                 new Violation(10, 10, "", "", null, null, getClass(), null);
         final AuditEvent ev = new AuditEvent(this, "TestSUFFIX", message);
@@ -195,7 +196,8 @@ public class SuppressFilterElementTest {
     }
 
     @Test
-    public void testDecideByFileNameAndModuleMatchingCheckRegExpNotMatch() {
+    public void testDecideByFileNameAndModuleMatchingCheckRegExpNotMatch()
+            throws CheckstyleException {
         final Violation message =
                 new Violation(10, 10, "", "", null, null, getClass(), null);
         final AuditEvent ev = new AuditEvent(this, "ATest.java", message);
@@ -207,7 +209,7 @@ public class SuppressFilterElementTest {
     }
 
     @Test
-    public void testDecideByFileNameAndModuleMatchingCheckRegExpMatch() {
+    public void testDecideByFileNameAndModuleMatchingCheckRegExpMatch() throws CheckstyleException {
         final Violation message =
                 new Violation(10, 10, "", "", null, null, getClass(), null);
         final AuditEvent ev = new AuditEvent(this, "ATest.java", message);
@@ -220,7 +222,7 @@ public class SuppressFilterElementTest {
     }
 
     @Test
-    public void testDecideByFileNameAndSourceNameCheckRegExpNotMatch() {
+    public void testDecideByFileNameAndSourceNameCheckRegExpNotMatch() throws CheckstyleException {
         final Violation message =
                 new Violation(10, 10, "", "", null, null, getClass(), null);
         final AuditEvent ev = new AuditEvent(this, "ATest.java", message);

--- a/src/test/java/com/puppycrawl/tools/checkstyle/filters/SuppressWithNearbyTextFilterTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/filters/SuppressWithNearbyTextFilterTest.java
@@ -419,7 +419,7 @@ public class SuppressWithNearbyTextFilterTest extends AbstractModuleTestSupport 
      * null violation with {@link AbstractModuleTestSupport#verifyFilterWithInlineConfigParser}.
      */
     @Test
-    public void testAcceptNullViolation() {
+    public void testAcceptNullViolation() throws CheckstyleException {
         final SuppressWithNearbyTextFilter filter = new SuppressWithNearbyTextFilter();
         final AuditEvent auditEvent = new AuditEvent(this);
         assertWithMessage("Filter should accept audit event")
@@ -448,7 +448,7 @@ public class SuppressWithNearbyTextFilterTest extends AbstractModuleTestSupport 
             filter.accept(auditEvent);
             assertWithMessage(IllegalStateException.class.getSimpleName() + " is expected").fail();
         }
-        catch (IllegalStateException ex) {
+        catch (IllegalStateException | CheckstyleException ex) {
             assertWithMessage("Invalid exception message")
                 .that(ex.getMessage())
                 .isEqualTo("Cannot read source file: " + fileName);
@@ -474,7 +474,7 @@ public class SuppressWithNearbyTextFilterTest extends AbstractModuleTestSupport 
      * @throws IOException if an error occurs while formatting the path to the input file.
      */
     @Test
-    public void testFilterWithDirectory() throws IOException {
+    public void testFilterWithDirectory() throws IOException, CheckstyleException {
         final SuppressWithNearbyTextFilter filter = new SuppressWithNearbyTextFilter();
         final AuditEvent event = new AuditEvent(this, getPath(""), new Violation(1, 1,
                 "bundle", "key", null, SeverityLevel.ERROR, "moduleId", getClass(),
@@ -494,7 +494,8 @@ public class SuppressWithNearbyTextFilterTest extends AbstractModuleTestSupport 
      * @throws IOException if an error occurs while formatting the path to the input file.
      */
     @Test
-    public void testSuppressionsAreClearedEachRun() throws IOException {
+    public void testSuppressionsAreClearedEachRun()
+            throws IOException, CheckstyleException {
         final SuppressWithNearbyTextFilter filter = new SuppressWithNearbyTextFilter();
 
         final List<?> suppressions1 = getSuppressionsAfterExecution(filter,
@@ -519,7 +520,8 @@ public class SuppressWithNearbyTextFilterTest extends AbstractModuleTestSupport 
      * @throws IOException if an error occurs while formatting the path to the input file.
      */
     @Test
-    public void testCachedFileAbsolutePathHasChangedEachRun() throws IOException {
+    public void testCachedFileAbsolutePathHasChangedEachRun()
+            throws IOException, CheckstyleException {
         final SuppressWithNearbyTextFilter filter = new SuppressWithNearbyTextFilter();
 
         final String cachedFileAbsolutePath1 = getCachedFileAbsolutePathAfterExecution(filter,
@@ -538,7 +540,8 @@ public class SuppressWithNearbyTextFilterTest extends AbstractModuleTestSupport 
      * @return {@code Suppression} list.
      */
     private static List<?> getSuppressionsAfterExecution(SuppressWithNearbyTextFilter filter,
-                                                         String filename) {
+                                                         String filename)
+            throws CheckstyleException {
         final AuditEvent dummyEvent = buildDummyAuditEvent(filename);
         filter.accept(dummyEvent);
         return TestUtil.getInternalState(filter, "suppressions");
@@ -551,8 +554,9 @@ public class SuppressWithNearbyTextFilterTest extends AbstractModuleTestSupport 
      * @return {@code cachedFileAbsolutePath} value.
      */
     private static String getCachedFileAbsolutePathAfterExecution(SuppressWithNearbyTextFilter
-                                                                           filter,
-                                                                  String filename) {
+                                                                          filter,
+                                                                  String filename)
+            throws CheckstyleException {
         final AuditEvent dummyEvent = buildDummyAuditEvent(filename);
         filter.accept(dummyEvent);
         return TestUtil.getInternalState(filter, "cachedFileAbsolutePath");

--- a/src/test/java/com/puppycrawl/tools/checkstyle/filters/SuppressWithPlainTextCommentFilterTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/filters/SuppressWithPlainTextCommentFilterTest.java
@@ -27,7 +27,6 @@ import static com.puppycrawl.tools.checkstyle.checks.whitespace.FileTabCharacter
 import static com.puppycrawl.tools.checkstyle.checks.whitespace.FileTabCharacterCheck.MSG_FILE_CONTAINS_TAB;
 
 import java.io.FileNotFoundException;
-import java.io.IOException;
 import java.util.Arrays;
 
 import org.junit.jupiter.api.Test;
@@ -330,7 +329,7 @@ public class SuppressWithPlainTextCommentFilterTest extends AbstractModuleTestSu
     }
 
     @Test
-    public void testAcceptNullViolation() {
+    public void testAcceptNullViolation() throws CheckstyleException {
         final SuppressWithPlainTextCommentFilter filter = new SuppressWithPlainTextCommentFilter();
         final AuditEvent auditEvent = new AuditEvent(this);
         assertWithMessage("Filter should accept audit event")
@@ -525,7 +524,7 @@ public class SuppressWithPlainTextCommentFilterTest extends AbstractModuleTestSu
     }
 
     @Test
-    public void testAcceptThrowsIllegalStateExceptionAsFileNotFound() {
+    public void testAcceptThrowsIllegalStateExceptionAsFileNotFound() throws CheckstyleException {
         final Violation message = new Violation(1, 1, 1, TokenTypes.CLASS_DEF,
             "messages.properties", "key", null, SeverityLevel.ERROR, null, getClass(), null);
         final String fileName = "nonexisting_file";
@@ -646,7 +645,7 @@ public class SuppressWithPlainTextCommentFilterTest extends AbstractModuleTestSu
     }
 
     @Test
-    public void testFilterWithDirectory() throws IOException {
+    public void testFilterWithDirectory() throws Exception {
         final SuppressWithPlainTextCommentFilter filter = new SuppressWithPlainTextCommentFilter();
         final AuditEvent event = new AuditEvent(this, getPath(""), new Violation(1, 1,
                 "bundle", "key", null, SeverityLevel.ERROR, "moduleId", getClass(),

--- a/src/test/java/com/puppycrawl/tools/checkstyle/internal/testmodules/DebugFilter.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/internal/testmodules/DebugFilter.java
@@ -20,6 +20,7 @@
 package com.puppycrawl.tools.checkstyle.internal.testmodules;
 
 import com.puppycrawl.tools.checkstyle.api.AuditEvent;
+import com.puppycrawl.tools.checkstyle.api.CheckstyleException;
 import com.puppycrawl.tools.checkstyle.api.Filter;
 
 public final class DebugFilter implements Filter {
@@ -27,7 +28,7 @@ public final class DebugFilter implements Filter {
     private boolean called;
 
     @Override
-    public boolean accept(AuditEvent event) {
+    public boolean accept(AuditEvent event) throws CheckstyleException {
         called = true;
         return true;
     }


### PR DESCRIPTION
resolves #12803 finishes #12981 

WIP:
- `Checker` is excluded from Coverage Testing for now.
- to meet the coverage, reflection is used for `TranslationCheck`. since I'm not much familiar with this type of testing, I need some feedback. 