### PR TITLE
Issue #14631: Updated JAVADOC of JavadocTokenTypes.java to to new AST format

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/api/JavadocTokenTypes.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/api/JavadocTokenTypes.java
@@ -1281,20 +1281,20 @@ public final class JavadocTokenTypes {
      *
      * <p><b>Tree for example:</b></p>
      * <pre>{@code
-     * JAVADOC[3x0]
-     *   |--NEWLINE[3x0] : [\n]
-     *   |--LEADING_ASTERISK[4x0] : [ *]
-     *   |--WS[4x2] : [ ]
-     *   |--JAVADOC_TAG[4x3] : [@param T The bar.\n ]
-     *       |--PARAM_LITERAL[4x3] : [@param]
-     *       |--WS[4x9] : [ ]
-     *       |--PARAMETER_NAME[4x10] : [T]
-     *       |--WS[4x11] : [ ]
-     *       |--DESCRIPTION[4x12] : [The bar.\n ]
-     *           |--TEXT[4x12] : [The bar.]
-     *           |--NEWLINE[4x20] : [\n]
-     *           |--TEXT[5x0] : [ ]
-     *   |--EOF[5x1] : [<EOF>]
+     * JAVADOC -> JAVADOC
+     *  |--NEWLINE -> \n
+     *  |--LEADING_ASTERISK ->  *
+     *  |--WS ->
+     *  |--JAVADOC_TAG -> JAVADOC_TAG
+     *  |   |--PARAM_LITERAL -> @param
+     *  |   |--WS ->
+     *  |   |--PARAMETER_NAME -> T
+     *  |   |--WS ->
+     *  |   `--DESCRIPTION -> DESCRIPTION
+     *  |       |--TEXT -> The bar.
+     *  |       |--NEWLINE -> \n
+     *  |       `--TEXT ->
+     *  `--EOF -> <EOF>
      * }</pre>
      */
     public static final int JAVADOC = JavadocParser.RULE_javadoc + RULE_TYPES_OFFSET;


### PR DESCRIPTION
Issue: #14631

```
maximpaxim@maximpaxim-OMEN-by-HP-Laptop-15-dc0xxx:~/Desktop/javadoc test$ cat Test.java
/**
 * @param T The bar.
 */
public class Test {
}
maximpaxim@maximpaxim-OMEN-by-HP-Laptop-15-dc0xxx:~/Desktop/javadoc test$ java -jar checkstyle-10.21.2-all.jar -J Test.java | sed "s/\[[0-9]\+:[0-9]\+\]//g"
COMPILATION_UNIT -> COMPILATION_UNIT 
`--CLASS_DEF -> CLASS_DEF 
    |--MODIFIERS -> MODIFIERS 
    |   |--BLOCK_COMMENT_BEGIN -> /* 
    |   |   |--COMMENT_CONTENT -> *\n * @param T The bar.\n  
    |   |   |   `--JAVADOC -> JAVADOC 
    |   |   |       |--NEWLINE -> \n 
    |   |   |       |--LEADING_ASTERISK ->  * 
    |   |   |       |--WS ->   
    |   |   |       |--JAVADOC_TAG -> JAVADOC_TAG 
    |   |   |       |   |--PARAM_LITERAL -> @param 
    |   |   |       |   |--WS ->   
    |   |   |       |   |--PARAMETER_NAME -> T 
    |   |   |       |   |--WS ->   
    |   |   |       |   `--DESCRIPTION -> DESCRIPTION 
    |   |   |       |       |--TEXT -> The bar. 
    |   |   |       |       |--NEWLINE -> \n 
    |   |   |       |       `--TEXT ->   
    |   |   |       `--EOF -> <EOF> 
    |   |   `--BLOCK_COMMENT_END -> */ 
    |   `--LITERAL_PUBLIC -> public 
    |--LITERAL_CLASS -> class 
    |--IDENT -> Test 
    `--OBJBLOCK -> OBJBLOCK 
        |--LCURLY -> { 
        `--RCURLY -> } 
maximpaxim@maximpaxim-OMEN-by-HP-Laptop-15-dc0xxx:~/Desktop/javadoc test$ 
```
