### PR TITLE
Issue #16291: Fixed UI overlap issue in documentation sidebar

### DIFF
--- a/src/site/resources/css/site.css
+++ b/src/site/resources/css/site.css
@@ -179,7 +179,8 @@ code {
 
 #leftColumn {
   min-width: 250px;
-  width: fit-content;
+  overflow-wrap: break-word;
+  word-wrap: break-word;
 }
 
 .releaseDate {


### PR DESCRIPTION
Fixed the left column alignment issue that caused text to misalign due to improper width handling with minimal changes. It was previously using width: fit-content which led to inconsistent wrapping, especially for long words.

Before:

<img width="1571" alt="Screenshot 2025-02-10 at 2 29 42 PM" src="https://github.com/user-attachments/assets/26c16133-b6ba-4b35-a47b-69c2ee0eea22" />


After:


<img width="1536" alt="Screenshot 2025-02-10 at 2 38 54 PM" src="https://github.com/user-attachments/assets/53a1db27-8cf8-4d66-ac4b-55fe1614e63f" />


Issue Link: 
Fixes: #16291 