### PR TITLE
Issue #16243: remove top/bottom spacing on code snippets

### DIFF
--- a/src/site/resources/css/site.css
+++ b/src/site/resources/css/site.css
@@ -141,7 +141,7 @@ th {
 }
 
 .prettyprint {
-  padding: 1em !important;
+  padding: 0.5em !important;
   overflow: auto;
   white-space: nowrap;
 }
@@ -149,6 +149,7 @@ th {
 .prettyprint code {
   font-size: 17px;
   text-wrap: nowrap;
+  line-height: 1.625;
 }
 
 .externalLink {


### PR DESCRIPTION
Issue #16243

Too much top/bottom spacing was present on code snippets then remove the spacing on code snippets.

This is not overlapping with https://github.com/checkstyle/checkstyle/pull/16250 as it fixes different kind of code blocks.