### PR TITLE
Issue #16243: Fixed left column alignment

### DIFF
--- a/src/site/resources/css/site.css
+++ b/src/site/resources/css/site.css
@@ -163,6 +163,7 @@ code {
   display: flex;
   align-items: center;
   justify-content: flex-end;
+  margin-bottom: 5px !important;
 }
 
 #bodyColumn h2, h2 {


### PR DESCRIPTION
Fixed the gap between the left column and the top bar. Adjusted positioning to move the left column up without messing with the breadcrumb padding.

Before: 

<img width="768" alt="Screenshot 2025-02-11 at 6 25 48 PM" src="https://github.com/user-attachments/assets/e32332b5-20da-4c5c-a4d2-b8267c8c2ed6" />



After: 

<img width="741" alt="Screenshot 2025-02-11 at 6 26 24 PM" src="https://github.com/user-attachments/assets/1c4c4e9a-5fc7-456d-9d97-f3cd9e2b52ab" />




# Issue Link:
Part of: #16243 