### PR TITLE
Issue #14019: Resolve pitest suppressions for XMLLogger  FileOpeningTag

### DIFF
--- a/config/pitest-suppressions/pitest-common-suppressions.xml
+++ b/config/pitest-suppressions/pitest-common-suppressions.xml
@@ -92,15 +92,6 @@
 
   <mutation unstable="false">
     <sourceFile>XMLLogger.java</sourceFile>
-    <mutatedClass>com.puppycrawl.tools.checkstyle.XMLLogger</mutatedClass>
-    <mutatedMethod>writeFileOpeningTag</mutatedMethod>
-    <mutator>org.pitest.mutationtest.engine.gregor.mutators.experimental.ArgumentPropagationMutator</mutator>
-    <description>replaced call to com/puppycrawl/tools/checkstyle/XMLLogger::encode with argument</description>
-    <lineContent>writer.println(&quot;&lt;file name=\&quot;&quot; + encode(fileName) + &quot;\&quot;&gt;&quot;);</lineContent>
-  </mutation>
-
-  <mutation unstable="false">
-    <sourceFile>XMLLogger.java</sourceFile>
     <mutatedClass>com.puppycrawl.tools.checkstyle.XMLLogger$FileMessages</mutatedClass>
     <mutatedMethod>&lt;init&gt;</mutatedMethod>
     <mutator>org.pitest.mutationtest.engine.gregor.mutators.experimental.ArgumentPropagationMutator</mutator>

--- a/src/test/java/com/puppycrawl/tools/checkstyle/XMLLoggerTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/XMLLoggerTest.java
@@ -370,6 +370,19 @@ public class XMLLoggerTest extends AbstractXmlTestSupport {
     }
 
     @Test
+    public void testFileOpenTag()
+            throws Exception {
+        final XMLLogger logger = new XMLLogger(outStream, OutputStreamOptions.CLOSE);
+        logger.auditStarted(null);
+        final AuditEvent ev = new AuditEvent(this, "Test&.java");
+        logger.fileFinished(ev);
+        logger.auditFinished(null);
+        verifyXml(getPath("ExpectedXMLLoggerSpecialName.xml"),
+                outStream, "<file name=" + "Test&amp;.java" + ">");
+
+    }
+
+    @Test
     public void testNullOutputStreamOptions() {
         try {
             final XMLLogger logger = new XMLLogger(outStream,

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/xmllogger/ExpectedXMLLoggerSpecialName.xml
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/xmllogger/ExpectedXMLLoggerSpecialName.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<checkstyle version="">
+<file name="Test&amp;.java">
+</file>
+</checkstyle>


### PR DESCRIPTION
Issue #14019  
using command  
` mvn -e --no-transfer-progress -Ppitest-common clean test-compile org.pitest:pitest-maven:mutationCoverage
`
Kill mutation for removing the call to the encoding method
Kill mutation for removing the call to the `writer.println` in writeFileClosingTag Method
![image](https://github.com/user-attachments/assets/7eb0ce37-9fca-44e0-90ca-814ea5a675c1)

