### PR TITLE
Issue #16262: update MissingSwitchDefault doc

### DIFF
--- a/src/site/xdoc/checks/coding/missingswitchdefault.xml
+++ b/src/site/xdoc/checks/coding/missingswitchdefault.xml
@@ -69,6 +69,17 @@ class Example1 {
         break;
     }
   }
+  enum Status {ACTIVE, DISABLED}
+  void testEnum(Status status) {
+    switch (status) { // violation, 'switch without "default" clause'
+      case ACTIVE:
+        System.out.println(0);
+        break;
+      case DISABLED:
+        System.out.println(1);
+        break;
+    }
+  }
 }
 </code></pre></div>
         <p id="Example2-code">

--- a/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/checks/coding/MissingSwitchDefaultCheckExamplesTest.java
+++ b/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/checks/coding/MissingSwitchDefaultCheckExamplesTest.java
@@ -34,6 +34,7 @@ public class MissingSwitchDefaultCheckExamplesTest extends AbstractExamplesModul
     public void testExample1() throws Exception {
         final String[] expected = {
             "13:5: " + getCheckMessage(MissingSwitchDefaultCheck.MSG_KEY),
+            "22:5: " + getCheckMessage(MissingSwitchDefaultCheck.MSG_KEY),
         };
 
         verifyWithInlineConfigParser(getPath("Example1.java"), expected);

--- a/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/coding/missingswitchdefault/Example1.java
+++ b/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/coding/missingswitchdefault/Example1.java
@@ -17,5 +17,16 @@ class Example1 {
         break;
     }
   }
+  enum Status {ACTIVE, DISABLED}
+  void testEnum(Status status) {
+    switch (status) { // violation, 'switch without "default" clause'
+      case ACTIVE:
+        System.out.println(0);
+        break;
+      case DISABLED:
+        System.out.println(1);
+        break;
+    }
+  }
 }
 // xdoc section -- end


### PR DESCRIPTION
Issue: #16262 

## I've updated the code as follows:

- **Removed the Default Clause:** In the switch statement (see Example3.java), I've removed the default clause.
- **Added a Comment:** I've added an inline comment on the switch to indicate that it now intentionally violates the MissingSwitchDefault rule.
- **Updated Tests:** The tests (in MissingSwitchDefaultCheckExamplesTest.java) have been adjusted to reflect this change, so they now expect the violation accordingly.
