### PR TITLE
Issue #13999: Resolve Pitest Suppression for findFirstToken in Javado…

### DIFF
--- a/config/checker-framework-suppressions/checker-nullness-optional-interning-suppressions.xml
+++ b/config/checker-framework-suppressions/checker-nullness-optional-interning-suppressions.xml
@@ -4159,20 +4159,6 @@
     <fileName>src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocMethodCheck.java</fileName>
     <specifier>not.interned</specifier>
     <message>attempting to use a non-@Interned comparison operand</message>
-    <lineContent>while (curNode != root &amp;&amp; curNode.getNextSibling() == null) {</lineContent>
-  </checkerFrameworkError>
-
-  <checkerFrameworkError unstable="false">
-    <fileName>src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocMethodCheck.java</fileName>
-    <specifier>not.interned</specifier>
-    <message>attempting to use a non-@Interned comparison operand</message>
-    <lineContent>while (curNode != root &amp;&amp; curNode.getNextSibling() == null) {</lineContent>
-  </checkerFrameworkError>
-
-  <checkerFrameworkError unstable="false">
-    <fileName>src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocMethodCheck.java</fileName>
-    <specifier>not.interned</specifier>
-    <message>attempting to use a non-@Interned comparison operand</message>
     <lineContent>} while (curNode != root);</lineContent>
   </checkerFrameworkError>
 

--- a/config/pitest-suppressions/pitest-javadoc-suppressions.xml
+++ b/config/pitest-suppressions/pitest-javadoc-suppressions.xml
@@ -20,15 +20,6 @@
 
   <mutation unstable="false">
     <sourceFile>JavadocMethodCheck.java</sourceFile>
-    <mutatedClass>com.puppycrawl.tools.checkstyle.checks.javadoc.JavadocMethodCheck</mutatedClass>
-    <mutatedMethod>getThrowed</mutatedMethod>
-    <mutator>org.pitest.mutationtest.engine.gregor.mutators.experimental.NakedReceiverMutator</mutator>
-    <description>replaced call to com/puppycrawl/tools/checkstyle/api/DetailAST::findFirstToken with receiver</description>
-    <lineContent>final DetailAST blockAst = methodAst.findFirstToken(TokenTypes.SLIST);</lineContent>
-  </mutation>
-
-  <mutation unstable="false">
-    <sourceFile>JavadocMethodCheck.java</sourceFile>
     <mutatedClass>com.puppycrawl.tools.checkstyle.checks.javadoc.JavadocMethodCheck$Token</mutatedClass>
     <mutatedMethod>&lt;init&gt;</mutatedMethod>
     <mutator>org.pitest.mutationtest.engine.gregor.mutators.NonVoidMethodCallMutator</mutator>

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocMethodCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocMethodCheck.java
@@ -623,17 +623,14 @@ public class JavadocMethodCheck extends AbstractCheck {
      */
     private static List<ExceptionInfo> getThrowed(DetailAST methodAst) {
         final List<ExceptionInfo> returnValue = new ArrayList<>();
-        final DetailAST blockAst = methodAst.findFirstToken(TokenTypes.SLIST);
-        if (blockAst != null) {
-            final List<DetailAST> throwLiterals = findTokensInAstByType(blockAst,
-                    TokenTypes.LITERAL_THROW);
-            for (DetailAST throwAst : throwLiterals) {
-                if (!isInIgnoreBlock(blockAst, throwAst)) {
-                    final DetailAST newAst = throwAst.getFirstChild().getFirstChild();
-                    if (newAst.getType() == TokenTypes.LITERAL_NEW) {
-                        final DetailAST child = newAst.getFirstChild();
-                        returnValue.add(getExceptionInfo(child));
-                    }
+        final List<DetailAST> throwLiterals = findTokensInAstByType(methodAst,
+                TokenTypes.LITERAL_THROW);
+        for (DetailAST throwAst : throwLiterals) {
+            if (!isInIgnoreBlock(methodAst, throwAst)) {
+                final DetailAST newAst = throwAst.getFirstChild().getFirstChild();
+                if (newAst.getType() == TokenTypes.LITERAL_NEW) {
+                    final DetailAST child = newAst.getFirstChild();
+                    returnValue.add(getExceptionInfo(child));
                 }
             }
         }
@@ -738,7 +735,7 @@ public class JavadocMethodCheck extends AbstractCheck {
                 continue;
             }
             // backtrack to parent if last child, stopping at root
-            while (curNode != root && curNode.getNextSibling() == null) {
+            while (curNode.getNextSibling() == null) {
                 curNode = curNode.getParent();
             }
             // explore siblings if not root


### PR DESCRIPTION
- Part of #13999 

# Mutations

> NakedReceiverMutator on `final DetailAST blockAst = methodAst.findFirstToken(TokenTypes.SLIST)`

https://github.com/checkstyle/checkstyle/blob/3e2cae75d7c52a6dab307ceacd8b3986be29d97c/config/pitest-suppressions/pitest-javadoc-suppressions.xml#L21-L28

- Killing the above mutation led to the following mutation survival:

```yaml
New surviving mutation(s) found:

Source File: "JavadocMethodCheck.java"
Class: "com.puppycrawl.tools.checkstyle.checks.javadoc.JavadocMethodCheck"
Method: "findTokensInAstByType"
Line Contents: "while (curNode != root &amp;&amp; curNode.getNextSibling() == null) {"
Mutator: "org.pitest.mutationtest.engine.gregor.mutators.RemoveConditionalMutator_EQUAL_IF"
Description: "removed conditional - replaced equality check with true"
Line Number: 738
```

# Steps

- The first mutation:
    - I removed the suppression from `pitest-javadoc-suppressions.xml`.
    - I hardcoded the mutation and changed `final DetailAST blockAst = methodAst.findFirstToken(TokenTypes.SLIST);` to `final DetailAST blockAst = methodAst;`
    - I noticed there was no case where the input to the method `getThrowed` (`methodAst` ) is `null` as there was no null check, so I removed the line `if (blockAst != null)` to prevent code coverage loss.
- The second mutation:
    - Hardcoded and changed the while loop condition from `while (curNode.getNextSibling() == null)`  to `while (curNode != root && curNode.getNextSibling() == null)`
        - Why not `while (curr.getNextSibling() == null)` ? Because, it won’t make sense to go to backtrack to root and skipping next siblings always, also tests fails with that.
- I ran `mvn clean verify` and there were no failures.
- I ran the pitest and no new mutations survived.
- I ran the regression report locally and there were no differences.

# Explanation of Code Removal

## First Mutation
https://github.com/checkstyle/checkstyle/blob/51bd12c32d84205c231aeb1ab8c209686d59f645/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocMethodCheck.java#L624-L641

- Removing `.findFirstToken(TokenTypes.SLIST)` causes no problem because:
    - For `final List<DetailAST> throwLiterals = findTokensInAstByType(methodAST, TokenTypes.LITERAL_THROW);` :
        - Inside `findTokensInAstByType`, we perform a Depth-First Search to find nodes of type `LITERAL_THROW`. Before I removed the mutation, the search started from `SLIST`, but now it starts from the parent of `SLIST`. Since this is a Depth-First Search, we will always find tokens containing `LITERAL_THROW`.
    https://github.com/checkstyle/checkstyle/blob/51bd12c32d84205c231aeb1ab8c209686d59f645/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocMethodCheck.java#L726
        
    - For `!isInIgnoreBlock(methodAST, throwAst)`:
        - Inside `isInIgnoreBlock` , we only use `methodAst` to determine when to break out of the while loop. So, it doesn’t really matter whether the root is `SLIST` or not, as long as it's an ancestor of `throwAst`, because the main purpose of this method is to check whether we are in an ignore block or not.
https://github.com/checkstyle/checkstyle/blob/51bd12c32d84205c231aeb1ab8c209686d59f645/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocMethodCheck.java#L679        

    - I also tested a case without an `SLIST` token (to ensure that removing `if (blockAst != null)` didn’t cause any issues) using the following example locally: 

```java
public interface InputJavadocMethodThrowsDetectionThree {
    /**
     * Test comment
     *
     * @param num test number
     * @throws Exception if there is a error.
     */
    void doSomething(int num) throws Exception;
}
```
        
- There was no problem, as `findTokensInAstByType(methodAST, TokenTypes.LITERAL_THROW)` returned an empty List. (we can't have `LITERAL_THROW` without `SLIST`)

## Second Mutation

https://github.com/checkstyle/checkstyle/blob/51bd12c32d84205c231aeb1ab8c209686d59f645/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocMethodCheck.java#L726-L750

- Why this new mutation survived after hardcoding the first?
    - Because, before hardcoding first mutation, root was `SLIST` and `SLIST`  sometimes have no next siblings, so the `curNode != root` was necessary to prevent null pointer exception. but now, since the root is something like `METHOD_DEF` or `LITERAL_IF`..., it will always have something a next sibling because there is always be at least (`RCURLY`) closing the bigger scope.
- Removing `curNode != root` causes no problem because:
    - Because when `curNode == root` , the `curNode.getNextSibling()`  won’t return `null`   **BUT NOTE:** in my opinion that only works in this case only (`getThrows` method) because the root is always something that has a next sibling (which is at least `RCURLY`), and this method is not used except here so I think we should at least warn of its usage, if change is accepted as it is.
 
# Modules

- `JavadocMethodCheck`