### PR TITLE
Issue #14019: Resolve pitest suppressions for XMLLogger fileMessages.…

### DIFF
--- a/src/test/java/com/puppycrawl/tools/checkstyle/XMLLoggerTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/XMLLoggerTest.java
@@ -23,6 +23,7 @@ import static com.google.common.truth.Truth.assertWithMessage;
 
 import java.io.IOException;
 import java.io.PrintWriter;
+import java.util.List;
 
 import org.junit.jupiter.api.Test;
 
@@ -380,6 +381,25 @@ public class XMLLoggerTest extends AbstractXmlTestSupport {
         verifyXml(getPath("ExpectedXMLLoggerSpecialName.xml"),
                 outStream, "<file name=" + "Test&amp;.java" + ">");
 
+    }
+
+    @Test
+    public void testVerifyLogger()
+            throws Exception {
+        final String inputFileWithConfig = "InputXMLLogger.java";
+        final String xmlReport = "ExpectedXMLLoggerWithChecker.xml";
+        verifyWithInlineConfigParserAndXmlLogger(inputFileWithConfig, xmlReport);
+    }
+
+    @Test
+    public void testVerifyLoggerWithMultipleInput()
+            throws Exception {
+        final String inputFileWithConfig = "InputXMLLogger.java";
+        final String expectedXmlReport = "ExpectedXMLLoggerDuplicatedFile.xml";
+        verifyWithInlineConfigParserAndXmlLogger(
+                inputFileWithConfig,
+                expectedXmlReport,
+                List.of(inputFileWithConfig, inputFileWithConfig));
     }
 
     @Test

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/xmllogger/ExpectedXMLLoggerDuplicatedFile.xml
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/xmllogger/ExpectedXMLLoggerDuplicatedFile.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<checkstyle version="null">
+<file name="InputXMLLogger.java">
+<error column="15" line="12" message="Using the '.*' form of import should be avoided - java.io.*." severity="error" source="com.puppycrawl.tools.checkstyle.checks.imports.AvoidStarImportCheck"/>
+</file>
+<file name="InputXMLLogger.java">
+<error column="15" line="12" message="Using the '.*' form of import should be avoided - java.io.*." severity="error" source="com.puppycrawl.tools.checkstyle.checks.imports.AvoidStarImportCheck"/>
+</file>
+</checkstyle>

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/xmllogger/ExpectedXMLLoggerWithChecker.xml
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/xmllogger/ExpectedXMLLoggerWithChecker.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<checkstyle version="null">
+<file name="InputXMLLogger.java">
+<error line="12" column="15" severity="error" message="Using the '.*' form of import should be avoided - java.io.*." source="com.puppycrawl.tools.checkstyle.checks.imports.AvoidStarImportCheck"/>
+</file>
+</checkstyle>

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/xmllogger/InputXMLLogger.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/xmllogger/InputXMLLogger.java
@@ -1,0 +1,16 @@
+/*xml
+<module name="Checker">
+  <module name="TreeWalker">
+    <module name="com.puppycrawl.tools.checkstyle.checks.imports.AvoidStarImportCheck"/>
+  </module>
+</module>
+*/
+package com.puppycrawl.tools.checkstyle.xmllogger;
+
+// xdoc section -- start
+import java.util.Scanner;
+import java.io.*; // violation, 'Using the '.*' form of import should be avoided.'
+// xdoc section -- end
+
+public class InputXMLLogger {
+}


### PR DESCRIPTION
#14019 
Mutation `fileMessages.remove(fileName);` 
The test case` testFileRemovalFromLogger `ensures that calling `fileFinished` multiple times does not duplicate file entries in the log. If a violation is logged only once, it means the file was already removed in a previous call, triggering fileMessages.remove. 
 
![image](https://github.com/user-attachments/assets/716cbfaa-f632-4f06-85a0-867fadc1bfe2)
