### PR TITLE
Issue #14787: Resolved False Negative with new keyword

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/metrics/AbstractClassCouplingCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/metrics/AbstractClassCouplingCheck.java
@@ -189,6 +189,9 @@ public abstract class AbstractClassCouplingCheck extends AbstractCheck {
     @Override
     public void visitToken(DetailAST ast) {
         switch (ast.getType()) {
+            case TokenTypes.METHOD_REF:
+                visitMethodRef(ast);
+                break;
             case TokenTypes.PACKAGE_DEF:
                 visitPackageDef(ast);
                 break;
@@ -219,6 +222,10 @@ public abstract class AbstractClassCouplingCheck extends AbstractCheck {
             default:
                 throw new IllegalArgumentException("Unknown type: " + ast);
         }
+    }
+
+    private void visitMethodRef(DetailAST ast) {
+    classesContexts.peek().visitMethodRef(ast);
     }
 
     @Override
@@ -487,6 +494,11 @@ public abstract class AbstractClassCouplingCheck extends AbstractCheck {
             return result;
         }
 
+        public void visitMethodRef(DetailAST ast) {
+            DetailAST lastChild = ast.getLastChild();
+            if (lastChild.getType() == TokenTypes.LITERAL_NEW) {
+                addReferencedClassName(ast.getFirstChild());
+            }
+        }
     }
-
 }

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/metrics/ClassFanOutComplexityCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/metrics/ClassFanOutComplexityCheck.java
@@ -112,6 +112,7 @@ public final class ClassFanOutComplexityCheck extends AbstractClassCouplingCheck
     @Override
     public int[] getRequiredTokens() {
         return new int[] {
+            TokenTypes.METHOD_REF,
             TokenTypes.PACKAGE_DEF,
             TokenTypes.IMPORT,
             TokenTypes.CLASS_DEF,

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/metrics/ClassFanOutComplexityCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/metrics/ClassFanOutComplexityCheckTest.java
@@ -391,8 +391,9 @@ public class ClassFanOutComplexityCheckTest extends AbstractModuleTestSupport {
      */
     @Test
     public void testLambdaNew() throws Exception {
-        final String[] expected = {};
-        // no violation until #14787
+        final String[] expected = {
+                "27:1: " + getCheckMessage(MSG_KEY, 1, 0),
+        };
         verifyWithInlineConfigParser(
                 getPath("InputClassFanOutComplexityLambdaNew.java"), expected);
     }

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/metrics/classfanoutcomplexity/InputClassFanOutComplexityLambdaNew.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/metrics/classfanoutcomplexity/InputClassFanOutComplexityLambdaNew.java
@@ -24,7 +24,7 @@ import java.util.Map;
 import java.util.ArrayList;
 import java.io.File;
 
-public class InputClassFanOutComplexityLambdaNew {
+public class InputClassFanOutComplexityLambdaNew { // violation 'Complexity is 1'
     public void testMethod(Map<String, List<String>> entry) {
         List<File> files = new ArrayList<>();
         String string = "";


### PR DESCRIPTION
Issue #14787: 
 
Resolved [False Negative of ClassFanOutCheck with "new" Keyword]
- Added METHOD_REF token type detection in AbstractClassCouplingCheck
- Verified detection of both regular new expressions and method reference constructors