### PR TITLE
Issue #14019: kill mutation for SarifLogger under addError method 

### DIFF
--- a/config/pitest-suppressions/pitest-common-suppressions.xml
+++ b/config/pitest-suppressions/pitest-common-suppressions.xml
@@ -12,15 +12,6 @@
   <mutation unstable="false">
     <sourceFile>SarifLogger.java</sourceFile>
     <mutatedClass>com.puppycrawl.tools.checkstyle.SarifLogger</mutatedClass>
-    <mutatedMethod>addError</mutatedMethod>
-    <mutator>org.pitest.mutationtest.engine.gregor.mutators.experimental.ArgumentPropagationMutator</mutator>
-    <description>replaced call to com/puppycrawl/tools/checkstyle/SarifLogger::escape with argument</description>
-    <lineContent>.replace(MESSAGE_PLACEHOLDER, escape(event.getMessage()))</lineContent>
-  </mutation>
-
-  <mutation unstable="false">
-    <sourceFile>SarifLogger.java</sourceFile>
-    <mutatedClass>com.puppycrawl.tools.checkstyle.SarifLogger</mutatedClass>
     <mutatedMethod>auditFinished</mutatedMethod>
     <mutator>org.pitest.mutationtest.engine.gregor.mutators.NonVoidMethodCallMutator</mutator>
     <description>removed call to java/lang/Package::getImplementationVersion</description>

--- a/src/test/java/com/puppycrawl/tools/checkstyle/SarifLoggerTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/SarifLoggerTest.java
@@ -52,6 +52,28 @@ public class SarifLoggerTest extends AbstractModuleTestSupport {
         return "com/puppycrawl/tools/checkstyle/sariflogger";
     }
 
+    /**
+     * Executes the common logging steps for SARIF logging tests.
+     * This method mimic of natural execution at is done by Checker.
+     *
+     * <p>
+     * It starts file auditing, adds an error, and completes the audit process.
+     * </p>
+     *
+     * @param instance  the current instance of {@code SarifLoggerTest}, used for context
+     * @param logger    the {@code SarifLogger} instance to log errors
+     * @param fileName  the name of the file being audited
+     * @param violation the {@code Violation} object containing error details
+     */
+    public final void executeLogger(
+        SarifLoggerTest instance, SarifLogger logger, String fileName, Violation violation) {
+        final AuditEvent event = new AuditEvent(this, "Test.java", violation);
+        logger.fileStarted(event);
+        logger.addError(event);
+        logger.fileFinished(event);
+        logger.auditFinished(null);
+    }
+
     @Test
     public void testEscape() {
         final String[][] encodings = {
@@ -86,12 +108,34 @@ public class SarifLoggerTest extends AbstractModuleTestSupport {
                 new Violation(1, 1,
                         "messages.properties", "ruleId", null, SeverityLevel.ERROR, null,
                         getClass(), "found an error");
-        final AuditEvent ev = new AuditEvent(this, "Test.java", violation);
-        logger.fileStarted(ev);
-        logger.addError(ev);
-        logger.fileFinished(ev);
-        logger.auditFinished(null);
+        executeLogger(this, logger, "Test.java", violation);
         verifyContent(getPath("ExpectedSarifLoggerSingleError.sarif"), outStream);
+    }
+
+    @Test
+    public void testAddErrorAtColumn1() throws IOException {
+        final SarifLogger logger = new SarifLogger(outStream,
+                OutputStreamOptions.CLOSE);
+        logger.auditStarted(null);
+        final Violation violation =
+                new Violation(1, 1,
+                        "messages.properties", "ruleId", null, SeverityLevel.ERROR, null,
+                        getClass(), "found an error\ntry again");
+        executeLogger(this, logger, "Test.java", violation);
+        verifyContent(getPath("ExpectedSarifLoggerSingleErrorColumn1.sarif"), outStream);
+    }
+
+    @Test
+    public void testAddErrorAtColumn0() throws IOException {
+        final SarifLogger logger = new SarifLogger(outStream,
+                OutputStreamOptions.CLOSE);
+        logger.auditStarted(null);
+        final Violation violation =
+                new Violation(1, 0,
+                        "messages.properties", "ruleId", null, SeverityLevel.ERROR, null,
+                        getClass(), "found an error\nplease try again");
+        executeLogger(this, logger, "Test.java", violation);
+        verifyContent(getPath("ExpectedSarifLoggerSingleErrorColumn0.sarif"), outStream);
     }
 
     @Test

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/sariflogger/ExpectedSarifLoggerSingleErrorColumn0.sarif
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/sariflogger/ExpectedSarifLoggerSingleErrorColumn0.sarif
@@ -1,0 +1,43 @@
+{
+  "$schema": "https://raw.githubusercontent.com/oasis-tcs/sarif-spec/master/Schemata/sarif-schema-2.1.0.json",
+  "version": "2.1.0",
+  "runs": [
+    {
+      "tool": {
+        "driver": {
+          "downloadUri": "https://github.com/checkstyle/checkstyle/releases/",
+          "fullName": "Checkstyle",
+          "informationUri": "https://checkstyle.org/",
+          "language": "en",
+          "name": "Checkstyle",
+          "organization": "Checkstyle",
+          "rules": [
+          ],
+          "semanticVersion": "null",
+          "version": "null"
+        }
+      },
+      "results": [
+        {
+          "level": "error",
+          "locations": [
+            {
+              "physicalLocation": {
+                "artifactLocation": {
+                  "uri": "Test.java"
+                },
+                "region": {
+                  "startLine": 1
+                }
+              }
+            }
+          ],
+          "message": {
+            "text": "found an error\nplease try again"
+          },
+          "ruleId": "ruleId"
+        }
+      ]
+    }
+  ]
+}

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/sariflogger/ExpectedSarifLoggerSingleErrorColumn1.sarif
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/sariflogger/ExpectedSarifLoggerSingleErrorColumn1.sarif
@@ -1,0 +1,44 @@
+{
+  "$schema": "https://raw.githubusercontent.com/oasis-tcs/sarif-spec/master/Schemata/sarif-schema-2.1.0.json",
+  "version": "2.1.0",
+  "runs": [
+    {
+      "tool": {
+        "driver": {
+          "downloadUri": "https://github.com/checkstyle/checkstyle/releases/",
+          "fullName": "Checkstyle",
+          "informationUri": "https://checkstyle.org/",
+          "language": "en",
+          "name": "Checkstyle",
+          "organization": "Checkstyle",
+          "rules": [
+          ],
+          "semanticVersion": "null",
+          "version": "null"
+        }
+      },
+      "results": [
+        {
+          "level": "error",
+          "locations": [
+            {
+              "physicalLocation": {
+                "artifactLocation": {
+                  "uri": "Test.java"
+                },
+                "region": {
+                  "startColumn": 1,
+                  "startLine": 1
+                }
+              }
+            }
+          ],
+          "message": {
+            "text": "found an error\ntry again"
+          },
+          "ruleId": "ruleId"
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
Issue #14019

Kill mutation for `ArgumentPropagationMutator on .replace(MESSAGE_PLACEHOLDER, escape(event.getMessage()))` under `SarifLogger`

**Reason for mutation:**
The reason is related with `escape` method on `SarifLogger.java` , In `addError` method we are using `escape` method to modify some selected characters of string `event.getMessage()` ( `violation` from `event class` ) but all test cases available has not any character that need to modify and falls to default switch condition of `escape` method then the `return` string of `escape` method is similar with `parameter` string of `escape` method.

**Solution:**
Added the test case which will have the character `\n` that must need to be modify by `escape` method then mutation kill and even not creating any new mutation.
