### PR TITLE
Issue #16300: Move Syntax Highlighting to Site Generation Phase

### DIFF
--- a/config/jsoref-spellchecker/whitelist.words
+++ b/config/jsoref-spellchecker/whitelist.words
@@ -149,13 +149,12 @@ casegroup
 catchparametername
 cba
 cbeaff
+ccc
 CComments
 cdata
 cde
 cdfd
 Cdi
-cdn
-cdnjs
 Cfg
 Cfml
 Cfoo
@@ -207,7 +206,6 @@ clazz
 clemens
 Clickable
 Cloneable
-cloudflare
 clss
 cmdline
 cmp
@@ -508,7 +506,6 @@ globbing
 GMetrics
 gnupg
 google
-googleapis
 googleblog
 googlecloudplatform
 googleecommon
@@ -721,11 +718,9 @@ jpg
 jprofiler
 jq
 jqno
-jquery
 jre
 JScroll
 Jscs
-jsdelivr
 jsecurity
 Jsf
 jshiell
@@ -928,6 +923,7 @@ NODESET
 noembed
 noenumtrailingcomma
 nofinalizer
+nohighlight
 noinspection
 noinspectionreason
 nojavadoc
@@ -1284,7 +1280,6 @@ STT
 Studman
 Styleable
 styleguide
-stylesheet
 subdir
 subelements
 subext
@@ -1444,6 +1439,7 @@ VK
 Vladislav
 Vladlis
 vm
+vmatchive
 vnd
 vscode
 Vtl

--- a/src/main/java/com/puppycrawl/tools/checkstyle/site/ExampleMacro.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/site/ExampleMacro.java
@@ -190,7 +190,7 @@ public class ExampleMacro extends AbstractMacro {
         else {
             languageClass = "language-java";
         }
-        sink.rawText("<pre class=\"prettyprint\"><code class=\"" + languageClass + "\">" + NEWLINE);
+        sink.rawText("<pre><code class=\"" + languageClass + "\">" + NEWLINE);
         sink.rawText(escapeHtml(snippet).trim() + NEWLINE);
         sink.rawText("</code></pre>");
         sink.rawText("</div>");

--- a/src/site/resources/css/site.css
+++ b/src/site/resources/css/site.css
@@ -2,6 +2,20 @@ body, td, select, input, li {
   font-family: Verdana, Helvetica, Arial, sans-serif;
 }
 
+:not(pre) > code {
+  padding: 4px 6px !important;
+  margin: 0 2px !important;
+  display: inline !important;
+}
+
+code, pre {
+  white-space: pre !important;
+  overflow-x: auto !important;
+  line-height: 20px !important;
+  padding: 9.5px !important;
+  text-indent: -9.5px;
+}
+
 h1 {
   text-transform: capitalize;
   font-size: x-large;
@@ -90,12 +104,15 @@ h1:hover:has(> a > img:first-child) .anchor {
   white-space: nowrap;
   padding: 0;
   overflow-x: auto;
+  background-color: #f5f5f5;
+  border: 1px solid #ccc;
 }
 
 .source > pre {
   margin: 0;
-  padding: 12px;
-  width: max-content;
+  padding: 9.5px;
+  font-size: 13px;
+  line-height: 20px;
 }
 
 .wrap-content pre {
@@ -110,7 +127,7 @@ section {
 div, p, td, table td, th, table th, li, pre, #breadcrumbs span,
 #footer, div.tip b, .releaseDate, .breadcrumb {
   font-size: 17px;
-  line-height: 1.925;
+  line-height: 1.625;
 }
 
 .sidebar-nav h5,
@@ -144,24 +161,12 @@ th {
   background-color: #ededed;
 }
 
-.prettyprint {
-  padding: 0.5em !important;
-  overflow: auto;
-  white-space: nowrap;
-  margin-left: 0 !important;
-}
-
-.prettyprint code {
-  font-size: 16px;
-  text-wrap: nowrap;
-  line-height: 1.625;
-}
-
 .inline-command code {
   display: inline;
-  white-space: normal;
+  white-space: normal !important;
   overflow-wrap: break-word;
   font-size: 14px;
+  word-break: break-word !important;
 }
 
 .externalLink {
@@ -201,6 +206,7 @@ th {
 
 .wrapper {
   overflow-y: auto;
+  overflow-x: auto !important;
 }
 
 span.wrapper.block {

--- a/src/site/resources/js/checkstyle.js
+++ b/src/site/resources/js/checkstyle.js
@@ -58,25 +58,6 @@ window.addEventListener("load", function () {
     externalLinks.forEach((link) => {
         link.setAttribute("target", "_blank");
     });
-
-    const codeBlocks = document.querySelectorAll(".prettyprint code");
-    codeBlocks.forEach((block) => {
-        const code = block.innerText.split("\n");
-        if (code.length > 1) {
-            if (code[0].trim() === "") {
-                code.shift();
-            }
-            if (code[code.length -1].trim() === "") {
-                code.pop();
-            }
-            const pre = block.closest("pre.prettyprint");
-            if (pre) {
-            pre.classList.remove("prettyprinted");
-            }
-            block.innerText = code.join("\n");
-        }
-    });
-    prettyPrint();
 });
 
 window.addEventListener("scroll", function () {
@@ -151,6 +132,37 @@ function resetStyling() {
     document.querySelector("#bodyColumn").style.removeProperty("position");
     document.querySelector("#hamburger").remove();
     document.querySelector(".xright").lastChild.remove();
+}
+
+window.addEventListener("load", function () {
+    document.querySelectorAll('pre code').forEach(block => {
+        const nodes = Array.from(block.childNodes);
+
+        // Remove leading empty nodes
+        while (nodes.length > 0 && isNodeEmpty(nodes[0])) {
+            nodes.shift();
+        }
+
+        // Remove trailing empty nodes
+        while (nodes.length > 0 && isNodeEmpty(nodes[nodes.length - 1])) {
+            nodes.pop();
+        }
+
+        // Rebuild the block while preserving syntax highlighting
+        block.innerHTML = '';
+        nodes.forEach(node => block.appendChild(node.cloneNode(true)));
+    });
+});
+
+// Helper: Check if a node is empty
+function isNodeEmpty(node) {
+    if (node.nodeType === Node.TEXT_NODE) {
+        return node.textContent.trim() === '';
+    } else if (node.nodeType === Node.ELEMENT_NODE) {
+        return node.textContent.trim() === ''
+            && !node.querySelector(':not(span)');
+    }
+    return false;
 }
 
 window.addEventListener("load", setBodyColumnMargin);

--- a/src/site/resources/styleguides/google-java-style-20180523/javaguide.css
+++ b/src/site/resources/styleguides/google-java-style-20180523/javaguide.css
@@ -424,11 +424,6 @@ pre {
   overflow:auto;
 }
 
-pre.prettyprint {
-  padding:6px 10px !important;
-  border:1px solid #bbb !important;
-}
-
 code.bad, code.badcode {
   color: magenta;
 }

--- a/src/site/resources/styleguides/google-java-style-20180523/javaguide.html
+++ b/src/site/resources/styleguides/google-java-style-20180523/javaguide.html
@@ -35,7 +35,7 @@ avoids giving <em>advice</em> that isn't clearly enforceable (whether by human o
 
 <ol>
   <li>The term <em>class</em> is used inclusively to mean an "ordinary" class, enum class,
-  interface or annotation type (<code class="prettyprint lang-java">@interface</code>).</li>
+  interface or annotation type (<code class="language-java">@interface</code>).</li>
 
   <li>The term <em>member</em> (of a class) is used inclusively to mean a nested class, field,
   method, <em>or constructor</em>; that is, all top-level contents of a class except initializers
@@ -85,14 +85,14 @@ anywhere in a source file. This implies that:</p>
 <p>For any character that has a
 <a href="https://docs.oracle.com/javase/tutorial/java/data/characters.html">
   special escape sequence</a>
-(<code class="prettyprint lang-java">\b</code>,
-<code class="prettyprint lang-java">\t</code>,
-<code class="prettyprint lang-java">\n</code>,
-<code class="prettyprint lang-java">\f</code>,
-<code class="prettyprint lang-java">\r</code>,
-<code class="prettyprint lang-java">\"</code>,
-<code class="prettyprint lang-java">\'</code> and
-<code class="prettyprint lang-java">\\</code>), that sequence
+(<code class="language-java">\b</code>,
+<code class="language-java">\t</code>,
+<code class="language-java">\n</code>,
+<code class="language-java">\f</code>,
+<code class="language-java">\r</code>,
+<code class="language-java">\"</code>,
+<code class="language-java">\'</code> and
+<code class="language-java">\\</code>), that sequence
 is used rather than the corresponding octal
 (e.g.&#160;<code class="badcode">\012</code>) or Unicode
 (e.g.&#160;<code class="badcode">\u000a</code>) escape.</p>
@@ -100,8 +100,8 @@ is used rather than the corresponding octal
 <h4 id="s2.3.3-non-ascii-characters">2.3.3 Non-ASCII characters</h4>
 
 <p>For the remaining non-ASCII characters, either the actual Unicode character
-(e.g.&#160;<code class="prettyprint lang-java">&#8734;</code>) or the equivalent Unicode escape
-(e.g.&#160;<code class="prettyprint lang-java">\u221e</code>) is used. The choice depends only on
+(e.g.&#160;<code class="language-java">&#8734;</code>) or the equivalent Unicode escape
+(e.g.&#160;<code class="language-java">\u221e</code>) is used. The choice depends only on
 which makes the code <strong>easier to read and understand</strong>, although Unicode escapes
 outside string literals and comments are strongly discouraged.</p>
 
@@ -117,17 +117,17 @@ Unicode characters are used, an explanatory comment can be very helpful.</p>
   </tr>
 
   <tr>
-    <td><code class="prettyprint lang-java">String unitAbbrev = "&#956;s";</code></td>
+    <td><code class="language-java">String unitAbbrev = "&#956;s";</code></td>
     <td>Best: perfectly clear even without a comment.</td>
   </tr>
 
   <tr>
-    <td><code class="prettyprint lang-java">String unitAbbrev = "\u03bcs"; // "&#956;s"</code></td>
+    <td><code class="language-java">String unitAbbrev = "\u03bcs"; // "&#956;s"</code></td>
     <td>Allowed, but there's no reason to do this.</td>
   </tr>
 
   <tr>
-    <td><code class="prettyprint lang-java">String unitAbbrev = "\u03bcs";
+    <td><code class="language-java">String unitAbbrev = "\u03bcs";
       // Greek letter mu, "s"</code></td>
     <td>Allowed, but awkward and prone to mistakes.</td>
   </tr>
@@ -138,7 +138,7 @@ Unicode characters are used, an explanatory comment can be very helpful.</p>
   </tr>
 
   <tr>
-     <td><code class="prettyprint lang-java">return '\ufeff' + content;
+     <td><code class="language-java">return '\ufeff' + content;
        // byte order mark</code></td>
      <td>Good: use escapes for non-printable characters, and comment if necessary.</td>
   </tr>
@@ -252,11 +252,11 @@ the body of a class, method or constructor. Note that, by Section 4.8.3.1 on
 <h4 id="s4.1.1-braces-always-used">4.1.1 Braces are used where optional</h4>
 
 <p>Braces are used with
-<code class="prettyprint lang-java">if</code>,
-<code class="prettyprint lang-java">else</code>,
-<code class="prettyprint lang-java">for</code>,
-<code class="prettyprint lang-java">do</code> and
-<code class="prettyprint lang-java">while</code> statements, even when the
+<code class="language-java">if</code>,
+<code class="language-java">else</code>,
+<code class="language-java">for</code>,
+<code class="language-java">do</code> and
+<code class="language-java">while</code> statements, even when the
 body is empty or contains only a single statement.</p>
 
 <h4 id="s4.1.2-blocks-k-r-style">4.1.2 Nonempty blocks: K &amp; R style</h4>
@@ -275,12 +275,12 @@ for <em>nonempty</em> blocks and block-like constructs:</p>
   <li>Line break after the closing brace, <em>only if</em> that brace terminates a statement or
   terminates the body of a method, constructor, or <em>named</em> class.
   For example, there is <em>no</em> line break after the brace if it is followed by
-  <code class="prettyprint lang-java">else</code> or a comma.</li>
+  <code class="language-java">else</code> or a comma.</li>
 </ul>
 
 <p>Examples:</p>
 
-<pre class="prettyprint lang-java">return () -&gt; {
+<pre class="language-java">return () -&gt; {
   while (condition()) {
     method();
   }
@@ -312,21 +312,21 @@ return new MyClass() {
 <p>An empty block or block-like construct may be in K &amp; R style (as described in
 <a href="#s4.1.2-blocks-k-r-style">Section 4.1.2</a>). Alternatively, it may be closed immediately
 after it is opened, with no characters or line break in between
-(<code class="prettyprint lang-java">{}</code>), <strong>unless</strong> it is part of a
+(<code class="language-java">{}</code>), <strong>unless</strong> it is part of a
 <em>multi-block statement</em> (one that directly contains multiple blocks:
-<code class="prettyprint lang-java">if/else</code> or
-<code class="prettyprint lang-java">try/catch/finally</code>).</p>
+<code class="language-java">if/else</code> or
+<code class="language-java">try/catch/finally</code>).</p>
 
 <p>Examples:</p>
 
-<pre class="prettyprint lang-java">  // This is acceptable
+<pre class="language-java">  // This is acceptable
   void doNothing() {}
 
   // This is equally acceptable
   void doNothingElse() {
   }
 </pre>
-<pre class="prettyprint lang-java badcode">  // This is not acceptable: No concise empty blocks in a multi-block statement
+<pre class="language-java badcode">  // This is not acceptable: No concise empty blocks in a multi-block statement
   try {
     doSomething();
   } catch (Exception e) {}
@@ -362,8 +362,8 @@ you may choose to wrap the line earlier than where this rule strictly requires.<
   <li>Lines where obeying the column limit is not possible (for example, a long URL in Javadoc,
   or a long JSNI method reference).</li>
 
-  <li><code class="prettyprint lang-java">package</code> and
-  <code class="prettyprint lang-java">import</code> statements (see Sections
+  <li><code class="language-java">package</code> and
+  <code class="language-java">import</code> statements (see Sections
   3.2 <a href="#s3.2-package-statement">Package statement</a> and
   3.3 <a href="#s3.3-import-statements">Import statements</a>).</li>
 
@@ -398,13 +398,13 @@ without the need to line-wrap.</p>
     <ul>
       <li>This also applies to the following "operator-like" symbols:
         <ul>
-          <li>the dot separator (<code class="prettyprint lang-java">.</code>)</li>
+          <li>the dot separator (<code class="language-java">.</code>)</li>
           <li>the two colons of a method reference
-          (<code class="prettyprint lang-java">::</code>)</li>
+          (<code class="language-java">::</code>)</li>
           <li>an ampersand in a type bound
-          (<code class="prettyprint lang-java">&lt;T extends Foo &amp; Bar&gt;</code>)</li>
+          (<code class="language-java">&lt;T extends Foo &amp; Bar&gt;</code>)</li>
           <li>a pipe in a catch block
-          (<code class="prettyprint lang-java">catch (FooException | BarException e)</code>).</li>
+          (<code class="language-java">catch (FooException | BarException e)</code>).</li>
         </ul>
       </li>
     </ul>
@@ -414,20 +414,20 @@ without the need to line-wrap.</p>
   <em>after</em> the symbol, but either way is acceptable.
     <ul>
       <li>This also applies to the "assignment-operator-like" colon in an enhanced
-      <code class="prettyprint lang-java">for</code> ("foreach") statement.</li>
+      <code class="language-java">for</code> ("foreach") statement.</li>
     </ul>
   </li>
 
   <li>A method or constructor name stays attached to the open parenthesis
-  (<code class="prettyprint lang-java">(</code>) that follows it.</li>
+  (<code class="language-java">(</code>) that follows it.</li>
 
-  <li>A comma (<code class="prettyprint lang-java">,</code>) stays attached to the token that
+  <li>A comma (<code class="language-java">,</code>) stays attached to the token that
   precedes it.</li>
 
   <li>A line is never broken adjacent to the arrow in a lambda, except that a
   break may come immediately after the arrow if the body of the lambda consists
   of a single unbraced expression. Examples:
-<pre class="prettyprint lang-java">MyLambda&lt;String, Long, Object&gt; lambda =
+<pre class="language-java">MyLambda&lt;String, Long, Object&gt; lambda =
     (String label, Long value, Object obj) -&gt; {
         ...
     };
@@ -492,24 +492,24 @@ Javadoc, a single ASCII space also appears in the following places <strong>only<
 
 <ol>
   <li>Separating any reserved word, such as
-  <code class="prettyprint lang-java">if</code>,
-  <code class="prettyprint lang-java">for</code> or
-  <code class="prettyprint lang-java">catch</code>, from an open parenthesis
-  (<code class="prettyprint lang-java">(</code>)
+  <code class="language-java">if</code>,
+  <code class="language-java">for</code> or
+  <code class="language-java">catch</code>, from an open parenthesis
+  (<code class="language-java">(</code>)
   that follows it on that line</li>
 
   <li>Separating any reserved word, such as
-  <code class="prettyprint lang-java">else</code> or
-  <code class="prettyprint lang-java">catch</code>, from a closing curly brace
-  (<code class="prettyprint lang-java">}</code>) that precedes it on that line</li>
+  <code class="language-java">else</code> or
+  <code class="language-java">catch</code>, from a closing curly brace
+  (<code class="language-java">}</code>) that precedes it on that line</li>
 
   <li>Before any open curly brace
-  (<code class="prettyprint lang-java">{</code>), with two exceptions:
+  (<code class="language-java">{</code>), with two exceptions:
   <ul>
-    <li><code class="prettyprint lang-java">@SomeAnnotation({a, b})</code> (no space is used)</li>
+    <li><code class="language-java">@SomeAnnotation({a, b})</code> (no space is used)</li>
 
-    <li><code class="prettyprint lang-java">String[][] x = {{"foo"}};</code> (no space is required
-    between <code class="prettyprint lang-java">{{</code>, by item 8 below)</li>
+    <li><code class="language-java">String[][] x = {{"foo"}};</code> (no space is required
+    between <code class="language-java">{{</code>, by item 8 below)</li>
   </ul>
   </li>
 
@@ -517,45 +517,45 @@ Javadoc, a single ASCII space also appears in the following places <strong>only<
   "operator-like" symbols:
   <ul>
     <li>the ampersand in a conjunctive type bound:
-    <code class="prettyprint lang-java">&lt;T extends Foo &amp; Bar&gt;</code></li>
+    <code class="language-java">&lt;T extends Foo &amp; Bar&gt;</code></li>
 
     <li>the pipe for a catch block that handles multiple exceptions:
-    <code class="prettyprint lang-java">catch (FooException | BarException e)</code></li>
+    <code class="language-java">catch (FooException | BarException e)</code></li>
 
-    <li>the colon (<code class="prettyprint lang-java">:</code>) in an enhanced
-    <code class="prettyprint lang-java">for</code> ("foreach") statement</li>
+    <li>the colon (<code class="language-java">:</code>) in an enhanced
+    <code class="language-java">for</code> ("foreach") statement</li>
 
     <li>the arrow in a lambda expression:
-    <code class="prettyprint lang-java">(String str) -&gt; str.length()</code></li>
+    <code class="language-java">(String str) -&gt; str.length()</code></li>
   </ul>
     but not
 
   <ul>
-    <li>the two colons (<code class="prettyprint lang-java">::</code>) of a method reference, which
-    is written like <code class="prettyprint lang-java">Object::toString</code></li>
-    <li>the dot separator (<code class="prettyprint lang-java">.</code>), which is written like
-    <code class="prettyprint lang-java">object.toString()</code></li>
+    <li>the two colons (<code class="language-java">::</code>) of a method reference, which
+    is written like <code class="language-java">Object::toString</code></li>
+    <li>the dot separator (<code class="language-java">.</code>), which is written like
+    <code class="language-java">object.toString()</code></li>
   </ul>
   </li>
 
-  <li>After <code class="prettyprint lang-java">,:;</code> or the closing parenthesis
-  (<code class="prettyprint lang-java">)</code>) of a cast</li>
+  <li>After <code class="language-java">,:;</code> or the closing parenthesis
+  (<code class="language-java">)</code>) of a cast</li>
 
-  <li>On both sides of the double slash (<code class="prettyprint lang-java">//</code>) that
+  <li>On both sides of the double slash (<code class="language-java">//</code>) that
   begins an end-of-line comment. Here, multiple spaces are allowed, but not required.</li>
 
   <li>Between the type and variable of a declaration:
-  <code class="prettyprint lang-java">List&lt;String&gt; list</code></li>
+  <code class="language-java">List&lt;String&gt; list</code></li>
 
   <li><em>Optional</em> just inside both braces of an array initializer
   <ul>
-    <li><code class="prettyprint lang-java">new int[] {5, 6}</code> and
-    <code class="prettyprint lang-java">new int[] { 5, 6 }</code> are both valid</li>
+    <li><code class="language-java">new int[] {5, 6}</code> and
+    <code class="language-java">new int[] { 5, 6 }</code> are both valid</li>
   </ul>
   </li>
 
-  <li>Between a type annotation and <code class="prettyprint lang-java">[]</code> or
-  <code class="prettyprint lang-java">...</code>.</li>
+  <li>Between a type annotation and <code class="language-java">[]</code> or
+  <code class="language-java">...</code>.</li>
 </ol>
 
 <p>This rule is never interpreted as requiring or forbidding additional space at the start or
@@ -572,7 +572,7 @@ even required to <em>maintain</em> horizontal alignment in places where it was a
 
 <p>Here is an example without alignment, then using alignment:</p>
 
-<pre class="prettyprint lang-java">private int x; // this is fine
+<pre class="language-java">private int x; // this is fine
 private Color color; // this too
 
 private int   x;      // permitted, but future edits
@@ -602,7 +602,7 @@ operator precedence table memorized.</p>
 <p>After each comma that follows an enum constant, a line break is optional. Additional blank
 lines (usually just one) are also allowed. This is one possibility:
 
-</p><pre class="prettyprint lang-java">private enum Answer {
+</p><pre class="language-java">private enum Answer {
   YES {
     @Override public String toString() {
       return "yes";
@@ -618,7 +618,7 @@ lines (usually just one) are also allowed. This is one possibility:
 as if it were an array initializer (see Section 4.8.3.1 on
 <a href="#s4.8.3.1-array-initializers">array initializers</a>).</p>
 
-<pre class="prettyprint lang-java">private enum Suit { CLUBS, HEARTS, SPADES, DIAMONDS }
+<pre class="language-java">private enum Suit { CLUBS, HEARTS, SPADES, DIAMONDS }
 </pre>
 
 <p>Since enum classes <em>are classes</em>, all other rules for formatting classes apply.</p>
@@ -632,7 +632,7 @@ as if it were an array initializer (see Section 4.8.3.1 on
 <code class="badcode">int a, b;</code> are not used.</p>
 
 <p><strong>Exception:</strong> Multiple variable declarations are acceptable in the header of a
-<code class="prettyprint lang-java">for</code> loop.</p>
+<code class="language-java">for</code> loop.</p>
 
 <h5 id="s4.8.2.2-variables-limited-scope">4.8.2.2 Declared when needed</h5>
 
@@ -649,7 +649,7 @@ initializers, or are initialized immediately after declaration.</p>
 construct." For example, the following are all valid (<strong>not</strong> an exhaustive
 list):</p>
 
-<pre class="prettyprint lang-java">new int[] {           new int[] {
+<pre class="language-java">new int[] {           new int[] {
   0, 1, 2, 3            0,
 }                       1,
                         2,
@@ -663,7 +663,7 @@ new int[] {             3,
 <h5 id="s4.8.3.2-array-declarations">4.8.3.2 No C-style array declarations</h5>
 
 <p>The square brackets form a part of the <em>type</em>, not the variable:
-<code class="prettyprint lang-java">String[] args</code>, not
+<code class="language-java">String[] args</code>, not
 <code class="badcode">String args[]</code>.</p>
 
 <h4 id="s4.8.4-switch">4.8.4 Switch statements</h4>
@@ -672,8 +672,8 @@ new int[] {             3,
 
 <p class="terminology"><strong>Terminology Note:</strong> Inside the braces of a
 <em>switch block</em> are one or more <em>statement groups</em>. Each statement group consists of
-one or more <em>switch labels</em> (either <code class="prettyprint lang-java">case FOO:</code> or
-<code class="prettyprint lang-java">default:</code>), followed by one or more statements (or, for
+one or more <em>switch labels</em> (either <code class="language-java">case FOO:</code> or
+<code class="language-java">default:</code>), followed by one or more statements (or, for
 the <em>last</em> statement group, <em>zero</em> or more statements).</p>
 
 <h5 id="s4.8.4.1-switch-indentation">4.8.4.1 Indentation</h5>
@@ -688,15 +688,15 @@ level, as if a block had been closed.</p>
 <h5 id="s4.8.4.2-switch-fall-through">4.8.4.2 Fall-through: commented</h5>
 
 <p>Within a switch block, each statement group either terminates abruptly (with a
-<code class="prettyprint lang-java">break</code>,
-<code class="prettyprint lang-java">continue</code>,
-<code class="prettyprint lang-java">return</code> or thrown exception), or is marked with a comment
+<code class="language-java">break</code>,
+<code class="language-java">continue</code>,
+<code class="language-java">return</code> or thrown exception), or is marked with a comment
 to indicate that execution will or <em>might</em> continue into the next statement group. Any
 comment that communicates the idea of fall-through is sufficient (typically
-<code class="prettyprint lang-java">// fall through</code>). This special comment is not required in
+<code class="language-java">// fall through</code>). This special comment is not required in
 the last statement group of the switch block. Example:</p>
 
-<pre class="prettyprint lang-java">switch (input) {
+<pre class="language-java">switch (input) {
   case 1:
   case 2:
     prepareOneOrTwo();
@@ -709,16 +709,16 @@ the last statement group of the switch block. Example:</p>
 }
 </pre>
 
-<p>Notice that no comment is needed after <code class="prettyprint lang-java">case 1:</code>, only
+<p>Notice that no comment is needed after <code class="language-java">case 1:</code>, only
 at the end of the statement group.</p>
 
 <h5 id="s4.8.4.3-switch-default">4.8.4.3 The <code>default</code> case is present</h5>
 
-<p>Each switch statement includes a <code class="prettyprint lang-java">default</code> statement
+<p>Each switch statement includes a <code class="language-java">default</code> statement
 group, even if it contains no code.</p>
 
 <p><strong>Exception:</strong> A switch statement for an <code>enum</code> type <em>may</em> omit
-the <code class="prettyprint lang-java">default</code> statement group, <em>if</em> it includes
+the <code class="language-java">default</code> statement group, <em>if</em> it includes
 explicit cases covering <em>all</em> possible values of that type. This enables IDEs or other static
 analysis tools to issue a warning if any cases were missed.
 
@@ -733,7 +733,7 @@ per line). These line breaks do not constitute line-wrapping (Section
 4.5, <a href="#s4.5-line-wrapping">Line-wrapping</a>), so the indentation level is not
 increased. Example:</p>
 
-<pre class="prettyprint lang-java">@Override
+<pre class="language-java">@Override
 @Nullable
 public String getNameIfPresent() { ... }
 </pre>
@@ -741,14 +741,14 @@ public String getNameIfPresent() { ... }
 <p class="exception"><strong>Exception:</strong> A <em>single</em> parameterless annotation
 <em>may</em> instead appear together with the first line of the signature, for example:</p>
 
-<pre class="prettyprint lang-java">@Override public int hashCode() { ... }
+<pre class="language-java">@Override public int hashCode() { ... }
 </pre>
 
 <p>Annotations applying to a field also appear immediately after the documentation block, but in
 this case, <em>multiple</em> annotations (possibly parameterized) may be listed on the same line;
 for example:</p>
 
-<pre class="prettyprint lang-java">@Partial @Mock DataLoader loader;
+<pre class="language-java">@Partial @Mock DataLoader loader;
 </pre>
 
 <p>There are no specific rules for formatting annotations on parameters, local variables, or types.
@@ -766,12 +766,12 @@ Such a comment renders the line non-blank.</p>
 <h5 id="s4.8.6.1-block-comment-style">4.8.6.1 Block comment style</h5>
 
 <p>Block comments are indented at the same level as the surrounding code. They may be in
-<code class="prettyprint lang-java">/* ... */</code> style or
-<code class="prettyprint lang-java">// ...</code> style. For multi-line
-<code class="prettyprint lang-java">/* ... */</code> comments, subsequent lines must start with
+<code class="language-java">/* ... */</code> style or
+<code class="language-java">// ...</code> style. For multi-line
+<code class="language-java">/* ... */</code> comments, subsequent lines must start with
 <code>*</code> aligned with the <code>*</code> on the previous line.</p>
 
-<pre class="prettyprint lang-java">/*
+<pre class="language-java">/*
  * This is          // And so           /* Or you can
  * okay.            // is this.          * even do this. */
  */
@@ -781,9 +781,9 @@ Such a comment renders the line non-blank.</p>
 <p>Comments are not enclosed in boxes drawn with asterisks or other characters.</p>
 
 <p class="tip"><strong>Tip:</strong> When writing multi-line comments, use the
-<code class="prettyprint lang-java">/* ... */</code> style if you want automatic code formatters to
+<code class="language-java">/* ... */</code> style if you want automatic code formatters to
 re-wrap the lines when necessary (paragraph-style). Most formatters don't re-wrap lines in
-<code class="prettyprint lang-java">// ...</code> style comment blocks.</p>
+<code class="language-java">// ...</code> style comment blocks.</p>
 
  
 
@@ -830,37 +830,37 @@ underscores). For example, <code>com.example.deepspace</code>, not
 <p>Class names are written in <a href="#s5.3-camel-case">UpperCamelCase</a>.</p>
 
 <p>Class names are typically nouns or noun phrases. For example,
-<code class="prettyprint lang-java">Character</code> or
-<code class="prettyprint lang-java">ImmutableList</code>. Interface names may also be nouns or
-noun phrases (for example, <code class="prettyprint lang-java">List</code>), but may sometimes be
+<code class="language-java">Character</code> or
+<code class="language-java">ImmutableList</code>. Interface names may also be nouns or
+noun phrases (for example, <code class="language-java">List</code>), but may sometimes be
 adjectives or adjective phrases instead (for example,
-<code class="prettyprint lang-java">Readable</code>).</p>
+<code class="language-java">Readable</code>).</p>
 
 <p>There are no specific rules or even well-established conventions for naming annotation types.</p>
 
 <p><em>Test</em> classes are named starting with the name of the class they are testing, and ending
-with <code class="prettyprint lang-java">Test</code>. For example,
-<code class="prettyprint lang-java">HashTest</code> or
-<code class="prettyprint lang-java">HashIntegrationTest</code>.</p>
+with <code class="language-java">Test</code>. For example,
+<code class="language-java">HashTest</code> or
+<code class="language-java">HashIntegrationTest</code>.</p>
 
 <h4 id="s5.2.3-method-names">5.2.3 Method names</h4>
 
 <p>Method names are written in <a href="#s5.3-camel-case">lowerCamelCase</a>.</p>
 
 <p>Method names are typically verbs or verb phrases. For example,
-<code class="prettyprint lang-java">sendMessage</code> or
-<code class="prettyprint lang-java">stop</code>.</p>
+<code class="language-java">sendMessage</code> or
+<code class="language-java">stop</code>.</p>
 
 <p>Underscores may appear in JUnit <em>test</em> method names to separate logical components of the
 name, with <em>each</em> component written in <a href="#s5.3-camel-case">lowerCamelCase</a>.
 One typical pattern is <code><i>&lt;methodUnderTest&gt;</i>_<i>&lt;state&gt;</i></code>,
-for example <code class="prettyprint lang-java">pop_emptyStack</code>. There is no One Correct
+for example <code class="language-java">pop_emptyStack</code>. There is no One Correct
 Way to name test methods.</p>
 
 <a name="constants"></a>
 <h4 id="s5.2.4-constant-names">5.2.4 Constant names</h4>
 
-<p>Constant names use <code class="prettyprint lang-java">CONSTANT_CASE</code>: all uppercase
+<p>Constant names use <code class="language-java">CONSTANT_CASE</code>: all uppercase
 letters, with each word separated from the next by a single underscore. But what <em>is</em> a
 constant, exactly?</p>
 
@@ -869,7 +869,7 @@ detectable side effects. This includes primitives, Strings, immutable types, and
 collections of immutable types. If any of the instance's observable state can change, it is not a
 constant. Merely <em>intending</em> to never mutate the object is not enough. Examples:</p>
 
-<pre class="prettyprint lang-java">// Constants
+<pre class="language-java">// Constants
 static final int NUMBER = 5;
 static final ImmutableList&lt;String&gt; NAMES = ImmutableList.of("Ed", "Ann");
 static final ImmutableMap&lt;String, Integer&gt; AGES = ImmutableMap.of("Ed", 35, "Ann", 32);
@@ -896,8 +896,8 @@ static final String[] nonEmptyArray = {"these", "can", "change"};
 in <a href="#s5.3-camel-case">lowerCamelCase</a>.</p>
 
 <p>These names are typically nouns or noun phrases.  For example,
-<code class="prettyprint lang-java">computedValues</code> or
-<code class="prettyprint lang-java">index</code>.</p>
+<code class="language-java">computedValues</code> or
+<code class="language-java">index</code>.</p>
 
 <h4 id="s5.2.6-parameter-names">5.2.6 Parameter names</h4>
 
@@ -918,15 +918,15 @@ be styled as constants.</p>
 
 <ul>
   <li>A single capital letter, optionally followed by a single numeral (such as
-  <code class="prettyprint lang-java">E</code>, <code class="prettyprint lang-java">T</code>,
-  <code class="prettyprint lang-java">X</code>, <code class="prettyprint lang-java">T2</code>)
+  <code class="language-java">E</code>, <code class="language-java">T</code>,
+  <code class="language-java">X</code>, <code class="language-java">T2</code>)
   </li>
 
   <li>A name in the form used for classes (see Section 5.2.2,
   <a href="#s5.2.2-class-names">Class names</a>), followed by the capital letter
-  <code class="prettyprint lang-java">T</code> (examples:
-  <code class="prettyprint lang-java">RequestT</code>,
-  <code class="prettyprint lang-java">FooBarT</code>).</li>
+  <code class="language-java">T</code> (examples:
+  <code class="language-java">RequestT</code>,
+  <code class="language-java">FooBarT</code>).</li>
 </ul>
 
 <a name="acronyms"></a>
@@ -975,28 +975,28 @@ predictability, Google Style specifies the following (nearly) deterministic sche
   </tr>
   <tr>
     <td>"XML HTTP request"</td>
-    <td><code class="prettyprint lang-java">XmlHttpRequest</code></td>
+    <td><code class="language-java">XmlHttpRequest</code></td>
     <td><code class="badcode">XMLHTTPRequest</code></td>
   </tr>
   <tr>
     <td>"new customer ID"</td>
-    <td><code class="prettyprint lang-java">newCustomerId</code></td>
+    <td><code class="language-java">newCustomerId</code></td>
     <td><code class="badcode">newCustomerID</code></td>
   </tr>
   <tr>
     <td>"inner stopwatch"</td>
-    <td><code class="prettyprint lang-java">innerStopwatch</code></td>
+    <td><code class="language-java">innerStopwatch</code></td>
     <td><code class="badcode">innerStopWatch</code></td>
   </tr>
   <tr>
     <td>"supports IPv6 on iOS?"</td>
-    <td><code class="prettyprint lang-java">supportsIpv6OnIos</code></td>
+    <td><code class="language-java">supportsIpv6OnIos</code></td>
     <td><code class="badcode">supportsIPv6OnIOS</code></td>
   </tr>
   <tr>
     <td>"YouTube importer"</td>
-    <td><code class="prettyprint lang-java">YouTubeImporter</code><br>
-        <code class="prettyprint lang-java">YoutubeImporter</code>*</td>
+    <td><code class="language-java">YouTubeImporter</code><br>
+        <code class="language-java">YoutubeImporter</code>*</td>
     <td></td>
   </tr>
 </tbody></table>
@@ -1005,34 +1005,34 @@ predictability, Google Style specifies the following (nearly) deterministic sche
 
 <p class="note"><strong>Note:</strong> Some words are ambiguously hyphenated in the English
 language: for example "nonempty" and "non-empty" are both correct, so the method names
-<code class="prettyprint lang-java">checkNonempty</code> and
-<code class="prettyprint lang-java">checkNonEmpty</code> are likewise both correct.</p>
+<code class="language-java">checkNonempty</code> and
+<code class="language-java">checkNonEmpty</code> are likewise both correct.</p>
 
 
 <h2 id="s6-programming-practices">6 Programming Practices</h2>
 
 <h3 id="s6.1-override-annotation">6.1 <code>@Override</code>: always used</h3>
 
-<p>A method is marked with the <code class="prettyprint lang-java">@Override</code> annotation
+<p>A method is marked with the <code class="language-java">@Override</code> annotation
 whenever it is legal.  This includes a class method overriding a superclass method, a class method
 implementing an interface method, and an interface method respecifying a superinterface
 method.</p>
 
 <p class="exception"><strong>Exception:</strong>
-<code class="prettyprint lang-java">@Override</code> may be omitted when the parent method is
-<code class="prettyprint lang-java">@Deprecated</code>.</p>
+<code class="language-java">@Override</code> may be omitted when the parent method is
+<code class="language-java">@Deprecated</code>.</p>
 
 <a name="caughtexceptions"></a>
 <h3 id="s6.2-caught-exceptions">6.2 Caught exceptions: not ignored</h3>
 
 <p>Except as noted below, it is very rarely correct to do nothing in response to a caught
 exception. (Typical responses are to log it, or if it is considered "impossible", rethrow it as an
-<code class="prettyprint lang-java">AssertionError</code>.)</p>
+<code class="language-java">AssertionError</code>.)</p>
 
 <p>When it truly is appropriate to take no action whatsoever in a catch block, the reason this is
 justified is explained in a comment.</p>
 
-<pre class="prettyprint lang-java">try {
+<pre class="language-java">try {
   int i = Integer.parseInt(response);
   return handleNumericResponse(i);
 } catch (NumberFormatException ok) {
@@ -1042,11 +1042,11 @@ return handleTextResponse(response);
 </pre>
 
 <p class="exception"><strong>Exception:</strong> In tests, a caught exception may be ignored
-without comment <em>if</em> its name is or begins with <code class="prettyprint lang-java">expected</code>. The
+without comment <em>if</em> its name is or begins with <code class="language-java">expected</code>. The
 following is a very common idiom for ensuring that the code under test <em>does</em> throw an
 exception of the expected type, so a comment is unnecessary here.</p>
 
-<pre class="prettyprint lang-java">try {
+<pre class="language-java">try {
   emptyStack.pop();
   fail();
 } catch (NoSuchElementException expected) {
@@ -1058,7 +1058,7 @@ exception of the expected type, so a comment is unnecessary here.</p>
 <p>When a reference to a static class member must be qualified, it is qualified with that class's
 name, not with a reference or expression of that class's type.</p>
 
-<pre class="prettyprint lang-java">Foo aFoo = ...;
+<pre class="language-java">Foo aFoo = ...;
 Foo.aStaticMethod(); // good
 <span class="badcode">aFoo.aStaticMethod();</span> // bad
 <span class="badcode">somethingThatYieldsAFoo().aStaticMethod();</span> // very bad
@@ -1067,8 +1067,8 @@ Foo.aStaticMethod(); // good
 <a name="finalizers"></a>
 <h3 id="s6.4-finalizers">6.4 Finalizers: not used</h3>
 
-<p>It is <strong>extremely rare</strong> to override <code class="prettyprint
-lang-java">Object.finalize</code>.</p>
+<p>It is <strong>extremely rare</strong> to override <code class="
+  language-java">Object.finalize</code>.</p>
 
 <p class="tip"><strong>Tip:</strong> Don't do it. If you absolutely must, first read and understand
 
@@ -1089,7 +1089,7 @@ lang-java">Object.finalize</code>.</p>
 
 <p>The <em>basic</em> formatting of Javadoc blocks is as seen in this example:</p>
 
-<pre class="prettyprint lang-java">/**
+<pre class="language-java">/**
  * Multiple lines of Javadoc text are written here,
  * wrapped normally...
  */
@@ -1098,7 +1098,7 @@ public int method(String p1) { ... }
 
 <p>... or in this single-line example:</p>
 
-<pre class="prettyprint lang-java">/** An especially short bit of Javadoc. */
+<pre class="language-java">/** An especially short bit of Javadoc. */
 </pre>
 
 <p>The basic form is always acceptable. The single-line form may be substituted when the entirety
@@ -1136,15 +1136,15 @@ punctuated as if it were a complete sentence.</p>
 
 <p class="tip"><strong>Tip:</strong> A common mistake is to write simple Javadoc in the form
 <code class="badcode">/** @return the customer ID */</code>. This is incorrect, and should be
-changed to <code class="prettyprint lang-java">/** Returns the customer ID. */</code>.</p>
+changed to <code class="language-java">/** Returns the customer ID. */</code>.</p>
 
 <a name="s7.3.3-javadoc-optional"></a> 
 <h3 id="s7.3-javadoc-where-required">7.3 Where Javadoc is used</h3>
 
 <p>At the <em>minimum</em>, Javadoc is present for every
-<code class="prettyprint lang-java">public</code> class, and every
-<code class="prettyprint lang-java">public</code> or
-<code class="prettyprint lang-java">protected</code> member of such a class, with a few exceptions
+<code class="language-java">public</code> class, and every
+<code class="language-java">public</code> or
+<code class="language-java">protected</code> member of such a class, with a few exceptions
 noted below.</p>
 
 <p>Additional Javadoc content may also be present, as explained in Section 7.3.4,
@@ -1153,12 +1153,12 @@ noted below.</p>
 <h4 id="s7.3.1-javadoc-exception-self-explanatory">7.3.1 Exception: self-explanatory methods</h4>
 
 <p>Javadoc is optional for "simple, obvious" methods like
-<code class="prettyprint lang-java">getFoo</code>, in cases where there <em>really and truly</em> is
+<code class="language-java">getFoo</code>, in cases where there <em>really and truly</em> is
 nothing else worthwhile to say but "Returns the foo".</p>
 
 <p class="note"><strong>Important:</strong> it is not appropriate to cite this exception to justify
 omitting relevant information that a typical reader might need to know. For example, for a method
-named <code class="prettyprint lang-java">getCanonicalName</code>, don't omit its documentation
+named <code class="language-java">getCanonicalName</code>, don't omit its documentation
 (with the rationale that it would say only
 <code class="badcode">/** Returns the canonical name. */</code>) if a typical reader may have no idea
 what the term "canonical name" means!</p>

--- a/src/site/resources/styleguides/google-java-style-20220203/javaguide.css
+++ b/src/site/resources/styleguides/google-java-style-20220203/javaguide.css
@@ -432,11 +432,6 @@ pre {
   overflow: auto;
 }
 
-pre.prettyprint {
-  padding: 6px 10px !important;
-  border: 1px solid #bbb !important;
-}
-
 code.bad,
 code.badcode {
   color: magenta;

--- a/src/site/resources/styleguides/google-java-style-20220203/javaguide.html
+++ b/src/site/resources/styleguides/google-java-style-20220203/javaguide.html
@@ -35,7 +35,7 @@ avoids giving <em>advice</em> that isn't clearly enforceable (whether by human o
 
 <ol>
   <li>The term <em>class</em> is used inclusively to mean an "ordinary" class, enum class,
-  interface or annotation type (<code class="prettyprint lang-java">@interface</code>).</li>
+  interface or annotation type (<code class="language-java">@interface</code>).</li>
 
   <li>The term <em>member</em> (of a class) is used inclusively to mean a nested class, field,
   method, <em>or constructor</em>; that is, all top-level contents of a class except initializers
@@ -85,14 +85,14 @@ anywhere in a source file. This implies that:</p>
 <p>For any character that has a
 <a href="http://docs.oracle.com/javase/tutorial/java/data/characters.html">
   special escape sequence</a>
-(<code class="prettyprint lang-java">\b</code>,
-<code class="prettyprint lang-java">\t</code>,
-<code class="prettyprint lang-java">\n</code>,
-<code class="prettyprint lang-java">\f</code>,
-<code class="prettyprint lang-java">\r</code>,
-<code class="prettyprint lang-java">\"</code>,
-<code class="prettyprint lang-java">\'</code> and
-<code class="prettyprint lang-java">\\</code>), that sequence
+(<code class="language-java">\b</code>,
+<code class="language-java">\t</code>,
+<code class="language-java">\n</code>,
+<code class="language-java">\f</code>,
+<code class="language-java">\r</code>,
+<code class="language-java">\"</code>,
+<code class="language-java">\'</code> and
+<code class="language-java">\\</code>), that sequence
 is used rather than the corresponding octal
 (e.g.&#160;<code class="badcode">\012</code>) or Unicode
 (e.g.&#160;<code class="badcode">\u000a</code>) escape.</p>
@@ -100,8 +100,8 @@ is used rather than the corresponding octal
 <h4 id="s2.3.3-non-ascii-characters">2.3.3 Non-ASCII characters</h4>
 
 <p>For the remaining non-ASCII characters, either the actual Unicode character
-(e.g.&#160;<code class="prettyprint lang-java">&#8734;</code>) or the equivalent Unicode escape
-(e.g.&#160;<code class="prettyprint lang-java">\u221e</code>) is used. The choice depends only on
+(e.g.&#160;<code class="language-java">&#8734;</code>) or the equivalent Unicode escape
+(e.g.&#160;<code class="language-java">\u221e</code>) is used. The choice depends only on
 which makes the code <strong>easier to read and understand</strong>, although Unicode escapes
 outside string literals and comments are strongly discouraged.</p>
 
@@ -117,17 +117,17 @@ Unicode characters are used, an explanatory comment can be very helpful.</p>
   </tr>
 
   <tr>
-    <td><code class="prettyprint lang-java">String unitAbbrev = "&#956;s";</code></td>
+    <td><code class="language-java">String unitAbbrev = "&#956;s";</code></td>
     <td>Best: perfectly clear even without a comment.</td>
   </tr>
 
   <tr>
-    <td><code class="prettyprint lang-java">String unitAbbrev = "\u03bcs"; // "&#956;s"</code></td>
+    <td><code class="language-java">String unitAbbrev = "\u03bcs"; // "&#956;s"</code></td>
     <td>Allowed, but there's no reason to do this.</td>
   </tr>
 
   <tr>
-    <td><code class="prettyprint lang-java">String unitAbbrev = "\u03bcs";
+    <td><code class="language-java">String unitAbbrev = "\u03bcs";
       // Greek letter mu, "s"</code></td>
     <td>Allowed, but awkward and prone to mistakes.</td>
   </tr>
@@ -138,7 +138,7 @@ Unicode characters are used, an explanatory comment can be very helpful.</p>
   </tr>
 
   <tr>
-     <td><code class="prettyprint lang-java">return '\ufeff' + content;
+     <td><code class="language-java">return '\ufeff' + content;
        // byte order mark</code></td>
      <td>Good: use escapes for non-printable characters, and comment if necessary.</td>
   </tr>
@@ -238,8 +238,8 @@ ordering.</p>
 
 <p>Methods of a class that share the same name appear in a single contiguous group with no other
 members in between. The same applies to multiple constructors (which always have the same name).
-This rule applies even when modifiers such as <code class="prettyprint lang-java">static</code> or
-<code class="prettyprint lang-java">private</code> differ between the methods.</p>
+This rule applies even when modifiers such as <code class="language-java">static</code> or
+<code class="language-java">private</code> differ between the methods.</p>
 
 <h2 id="s4-formatting">4 Formatting</h2>
 
@@ -254,11 +254,11 @@ the body of a class, method or constructor. Note that, by Section 4.8.3.1 on
 <h4 id="s4.1.1-braces-always-used">4.1.1 Use of optional braces</h4>
 
 <p>Braces are used with
-<code class="prettyprint lang-java">if</code>,
-<code class="prettyprint lang-java">else</code>,
-<code class="prettyprint lang-java">for</code>,
-<code class="prettyprint lang-java">do</code> and
-<code class="prettyprint lang-java">while</code> statements, even when the
+<code class="language-java">if</code>,
+<code class="language-java">else</code>,
+<code class="language-java">for</code>,
+<code class="language-java">do</code> and
+<code class="language-java">while</code> statements, even when the
 body is empty or contains only a single statement.</p>
 
 <p>Other optional braces, such as those in a lambda expression, remain optional.</p>
@@ -279,17 +279,17 @@ for <em>nonempty</em> blocks and block-like constructs:</p>
   <li>Line break after the closing brace, <em>only if</em> that brace terminates a statement or
   terminates the body of a method, constructor, or <em>named</em> class.
   For example, there is <em>no</em> line break after the brace if it is followed by
-  <code class="prettyprint lang-java">else</code> or a comma.</li>
+  <code class="language-java">else</code> or a comma.</li>
 </ul>
 
 <p>Exception: In places where these rules allow a single statement ending with a semicolon
-(<code class="prettyprint lang-java">;</code>), a block of statements can appear, and the opening
+(<code class="language-java">;</code>), a block of statements can appear, and the opening
 brace of this block is preceded by a line break. Blocks like these are typically introduced to
 limit the scope of local variables, for example inside switch statements.</p>
 
 <p>Examples:</p>
 
-<pre class="prettyprint lang-java">return () -&gt; {
+<pre class="language-java">return () -&gt; {
   while (condition()) {
     method();
   }
@@ -325,21 +325,21 @@ return new MyClass() {
 <p>An empty block or block-like construct may be in K &amp; R style (as described in
 <a href="#s4.1.2-blocks-k-r-style">Section 4.1.2</a>). Alternatively, it may be closed immediately
 after it is opened, with no characters or line break in between
-(<code class="prettyprint lang-java">{}</code>), <strong>unless</strong> it is part of a
+(<code class="language-java">{}</code>), <strong>unless</strong> it is part of a
 <em>multi-block statement</em> (one that directly contains multiple blocks:
-<code class="prettyprint lang-java">if/else</code> or
-<code class="prettyprint lang-java">try/catch/finally</code>).</p>
+<code class="language-java">if/else</code> or
+<code class="language-java">try/catch/finally</code>).</p>
 
 <p>Examples:</p>
 
-<pre class="prettyprint lang-java">  // This is acceptable
+<pre class="language-java">  // This is acceptable
   void doNothing() {}
 
   // This is equally acceptable
   void doNothingElse() {
   }
 </pre>
-<pre class="prettyprint lang-java badcode">  // This is not acceptable: No concise empty blocks in a multi-block statement
+<pre class="language-java badcode">  // This is not acceptable: No concise empty blocks in a multi-block statement
   try {
     doSomething();
   } catch (Exception e) {}
@@ -375,8 +375,8 @@ you may choose to wrap the line earlier than where this rule strictly requires.<
   <li>Lines where obeying the column limit is not possible (for example, a long URL in Javadoc,
   or a long JSNI method reference).</li>
 
-  <li><code class="prettyprint lang-java">package</code> and
-  <code class="prettyprint lang-java">import</code> statements (see Sections
+  <li><code class="language-java">package</code> and
+  <code class="language-java">import</code> statements (see Sections
   3.2 <a href="#s3.2-package-statement">Package statement</a> and
   3.3 <a href="#s3.3-import-statements">Import statements</a>).</li>
 
@@ -418,13 +418,13 @@ without the need to line-wrap.</p>
     <ul>
       <li>This also applies to the following "operator-like" symbols:
         <ul>
-          <li>the dot separator (<code class="prettyprint lang-java">.</code>)</li>
+          <li>the dot separator (<code class="language-java">.</code>)</li>
           <li>the two colons of a method reference
-          (<code class="prettyprint lang-java">::</code>)</li>
+          (<code class="language-java">::</code>)</li>
           <li>an ampersand in a type bound
-          (<code class="prettyprint lang-java">&lt;T extends Foo &amp; Bar&gt;</code>)</li>
+          (<code class="language-java">&lt;T extends Foo &amp; Bar&gt;</code>)</li>
           <li>a pipe in a catch block
-          (<code class="prettyprint lang-java">catch (FooException | BarException e)</code>).</li>
+          (<code class="language-java">catch (FooException | BarException e)</code>).</li>
         </ul>
       </li>
     </ul>
@@ -434,20 +434,20 @@ without the need to line-wrap.</p>
   <em>after</em> the symbol, but either way is acceptable.
     <ul>
       <li>This also applies to the "assignment-operator-like" colon in an enhanced
-      <code class="prettyprint lang-java">for</code> ("foreach") statement.</li>
+      <code class="language-java">for</code> ("foreach") statement.</li>
     </ul>
   </li>
 
   <li>A method or constructor name stays attached to the open parenthesis
-  (<code class="prettyprint lang-java">(</code>) that follows it.</li>
+  (<code class="language-java">(</code>) that follows it.</li>
 
-  <li>A comma (<code class="prettyprint lang-java">,</code>) stays attached to the token that
+  <li>A comma (<code class="language-java">,</code>) stays attached to the token that
   precedes it.</li>
 
   <li>A line is never broken adjacent to the arrow in a lambda, except that a
   break may come immediately after the arrow if the body of the lambda consists
   of a single unbraced expression. Examples:
-<pre class="prettyprint lang-java">MyLambda&lt;String, Long, Object&gt; lambda =
+<pre class="language-java">MyLambda&lt;String, Long, Object&gt; lambda =
     (String label, Long value, Object obj) -&gt; {
         ...
     };
@@ -512,24 +512,24 @@ Javadoc, a single ASCII space also appears in the following places <strong>only<
 
 <ol>
   <li>Separating any reserved word, such as
-  <code class="prettyprint lang-java">if</code>,
-  <code class="prettyprint lang-java">for</code> or
-  <code class="prettyprint lang-java">catch</code>, from an open parenthesis
-  (<code class="prettyprint lang-java">(</code>)
+  <code class="language-java">if</code>,
+  <code class="language-java">for</code> or
+  <code class="language-java">catch</code>, from an open parenthesis
+  (<code class="language-java">(</code>)
   that follows it on that line</li>
 
   <li>Separating any reserved word, such as
-  <code class="prettyprint lang-java">else</code> or
-  <code class="prettyprint lang-java">catch</code>, from a closing curly brace
-  (<code class="prettyprint lang-java">}</code>) that precedes it on that line</li>
+  <code class="language-java">else</code> or
+  <code class="language-java">catch</code>, from a closing curly brace
+  (<code class="language-java">}</code>) that precedes it on that line</li>
 
   <li>Before any open curly brace
-  (<code class="prettyprint lang-java">{</code>), with two exceptions:
+  (<code class="language-java">{</code>), with two exceptions:
   <ul>
-    <li><code class="prettyprint lang-java">@SomeAnnotation({a, b})</code> (no space is used)</li>
+    <li><code class="language-java">@SomeAnnotation({a, b})</code> (no space is used)</li>
 
-    <li><code class="prettyprint lang-java">String[][] x = {{"foo"}};</code> (no space is required
-    between <code class="prettyprint lang-java">{{</code>, by item 9 below)</li>
+    <li><code class="language-java">String[][] x = {{"foo"}};</code> (no space is required
+    between <code class="language-java">{{</code>, by item 9 below)</li>
   </ul>
   </li>
 
@@ -537,48 +537,48 @@ Javadoc, a single ASCII space also appears in the following places <strong>only<
   "operator-like" symbols:
   <ul>
     <li>the ampersand in a conjunctive type bound:
-    <code class="prettyprint lang-java">&lt;T extends Foo &amp; Bar&gt;</code></li>
+    <code class="language-java">&lt;T extends Foo &amp; Bar&gt;</code></li>
 
     <li>the pipe for a catch block that handles multiple exceptions:
-    <code class="prettyprint lang-java">catch (FooException | BarException e)</code></li>
+    <code class="language-java">catch (FooException | BarException e)</code></li>
 
-    <li>the colon (<code class="prettyprint lang-java">:</code>) in an enhanced
-    <code class="prettyprint lang-java">for</code> ("foreach") statement</li>
+    <li>the colon (<code class="language-java">:</code>) in an enhanced
+    <code class="language-java">for</code> ("foreach") statement</li>
 
     <li>the arrow in a lambda expression:
-    <code class="prettyprint lang-java">(String str) -&gt; str.length()</code></li>
+    <code class="language-java">(String str) -&gt; str.length()</code></li>
   </ul>
     but not
 
   <ul>
-    <li>the two colons (<code class="prettyprint lang-java">::</code>) of a method reference, which
-    is written like <code class="prettyprint lang-java">Object::toString</code></li>
-    <li>the dot separator (<code class="prettyprint lang-java">.</code>), which is written like
-    <code class="prettyprint lang-java">object.toString()</code></li>
+    <li>the two colons (<code class="language-java">::</code>) of a method reference, which
+    is written like <code class="language-java">Object::toString</code></li>
+    <li>the dot separator (<code class="language-java">.</code>), which is written like
+    <code class="language-java">object.toString()</code></li>
   </ul>
   </li>
 
-  <li>After <code class="prettyprint lang-java">,:;</code> or the closing parenthesis
-  (<code class="prettyprint lang-java">)</code>) of a cast</li>
+  <li>After <code class="language-java">,:;</code> or the closing parenthesis
+  (<code class="language-java">)</code>) of a cast</li>
 
-  <li>Between any content and a double slash (<code class="prettyprint lang-java">//</code>) which
+  <li>Between any content and a double slash (<code class="language-java">//</code>) which
   begins a comment. Multiple spaces are allowed.</li>
 
-  <li>Between a double slash (<code class="prettyprint lang-java">//</code>) which begins a comment
+  <li>Between a double slash (<code class="language-java">//</code>) which begins a comment
   and the comment's text. Multiple spaces are allowed.</li>
 
   <li>Between the type and variable of a declaration:
-  <code class="prettyprint lang-java">List&lt;String&gt; list</code></li>
+  <code class="language-java">List&lt;String&gt; list</code></li>
 
   <li><em>Optional</em> just inside both braces of an array initializer
   <ul>
-    <li><code class="prettyprint lang-java">new int[] {5, 6}</code> and
-    <code class="prettyprint lang-java">new int[] { 5, 6 }</code> are both valid</li>
+    <li><code class="language-java">new int[] {5, 6}</code> and
+    <code class="language-java">new int[] { 5, 6 }</code> are both valid</li>
   </ul>
   </li>
 
-  <li>Between a type annotation and <code class="prettyprint lang-java">[]</code> or
-  <code class="prettyprint lang-java">...</code>.</li>
+  <li>Between a type annotation and <code class="language-java">[]</code> or
+  <code class="language-java">...</code>.</li>
 </ol>
 
 <p>This rule is never interpreted as requiring or forbidding additional space at the start or
@@ -595,7 +595,7 @@ even required to <em>maintain</em> horizontal alignment in places where it was a
 
 <p>Here is an example without alignment, then using alignment:</p>
 
-<pre class="prettyprint lang-java">private int x; // this is fine
+<pre class="language-java">private int x; // this is fine
 private Color color; // this too
 
 private int   x;      // permitted, but future edits
@@ -625,7 +625,7 @@ operator precedence table memorized.</p>
 <p>After each comma that follows an enum constant, a line break is optional. Additional blank
 lines (usually just one) are also allowed. This is one possibility:
 
-</p><pre class="prettyprint lang-java">private enum Answer {
+</p><pre class="language-java">private enum Answer {
   YES {
     @Override public String toString() {
       return "yes";
@@ -641,7 +641,7 @@ lines (usually just one) are also allowed. This is one possibility:
 as if it were an array initializer (see Section 4.8.3.1 on
 <a href="#s4.8.3.1-array-initializers">array initializers</a>).</p>
 
-<pre class="prettyprint lang-java">private enum Suit { CLUBS, HEARTS, SPADES, DIAMONDS }
+<pre class="language-java">private enum Suit { CLUBS, HEARTS, SPADES, DIAMONDS }
 </pre>
 
 <p>Since enum classes <em>are classes</em>, all other rules for formatting classes apply.</p>
@@ -655,7 +655,7 @@ as if it were an array initializer (see Section 4.8.3.1 on
 <code class="badcode">int a, b;</code> are not used.</p>
 
 <p><strong>Exception:</strong> Multiple variable declarations are acceptable in the header of a
-<code class="prettyprint lang-java">for</code> loop.</p>
+<code class="language-java">for</code> loop.</p>
 
 <h5 id="s4.8.2.2-variables-limited-scope">4.8.2.2 Declared when needed</h5>
 
@@ -672,7 +672,7 @@ initializers, or are initialized immediately after declaration.</p>
 construct." For example, the following are all valid (<strong>not</strong> an exhaustive
 list):</p>
 
-<pre class="prettyprint lang-java">new int[] {           new int[] {
+<pre class="language-java">new int[] {           new int[] {
   0, 1, 2, 3            0,
 }                       1,
                         2,
@@ -686,7 +686,7 @@ new int[] {             3,
 <h5 id="s4.8.3.2-array-declarations">4.8.3.2 No C-style array declarations</h5>
 
 <p>The square brackets form a part of the <em>type</em>, not the variable:
-<code class="prettyprint lang-java">String[] args</code>, not
+<code class="language-java">String[] args</code>, not
 <code class="badcode">String args[]</code>.</p>
 
 <h4 id="s4.8.4-switch">4.8.4 Switch statements</h4>
@@ -695,8 +695,8 @@ new int[] {             3,
 
 <p class="terminology"><strong>Terminology Note:</strong> Inside the braces of a
 <em>switch block</em> are one or more <em>statement groups</em>. Each statement group consists of
-one or more <em>switch labels</em> (either <code class="prettyprint lang-java">case FOO:</code> or
-<code class="prettyprint lang-java">default:</code>), followed by one or more statements (or, for
+one or more <em>switch labels</em> (either <code class="language-java">case FOO:</code> or
+<code class="language-java">default:</code>), followed by one or more statements (or, for
 the <em>last</em> statement group, <em>zero</em> or more statements).</p>
 
 <h5 id="s4.8.4.1-switch-indentation">4.8.4.1 Indentation</h5>
@@ -711,15 +711,15 @@ level, as if a block had been closed.</p>
 <h5 id="s4.8.4.2-switch-fall-through">4.8.4.2 Fall-through: commented</h5>
 
 <p>Within a switch block, each statement group either terminates abruptly (with a
-<code class="prettyprint lang-java">break</code>,
-<code class="prettyprint lang-java">continue</code>,
-<code class="prettyprint lang-java">return</code> or thrown exception), or is marked with a comment
+<code class="language-java">break</code>,
+<code class="language-java">continue</code>,
+<code class="language-java">return</code> or thrown exception), or is marked with a comment
 to indicate that execution will or <em>might</em> continue into the next statement group. Any
 comment that communicates the idea of fall-through is sufficient (typically
-<code class="prettyprint lang-java">// fall through</code>). This special comment is not required in
+<code class="language-java">// fall through</code>). This special comment is not required in
 the last statement group of the switch block. Example:</p>
 
-<pre class="prettyprint lang-java">switch (input) {
+<pre class="language-java">switch (input) {
   case 1:
   case 2:
     prepareOneOrTwo();
@@ -732,16 +732,16 @@ the last statement group of the switch block. Example:</p>
 }
 </pre>
 
-<p>Notice that no comment is needed after <code class="prettyprint lang-java">case 1:</code>, only
+<p>Notice that no comment is needed after <code class="language-java">case 1:</code>, only
 at the end of the statement group.</p>
 
 <h5 id="s4.8.4.3-switch-default">4.8.4.3 Presence of the <code>default</code> label</h5>
 
-<p>Each switch statement includes a <code class="prettyprint lang-java">default</code> statement
+<p>Each switch statement includes a <code class="language-java">default</code> statement
 group, even if it contains no code.</p>
 
 <p><strong>Exception:</strong> A switch statement for an <code>enum</code> type <em>may</em> omit
-the <code class="prettyprint lang-java">default</code> statement group, <em>if</em> it includes
+the <code class="language-java">default</code> statement group, <em>if</em> it includes
 explicit cases covering <em>all</em> possible values of that type. This enables IDEs or other static
 analysis tools to issue a warning if any cases were missed.
 
@@ -754,9 +754,9 @@ analysis tools to issue a warning if any cases were missed.
 
 <p>Type-use annotations appear immediately before the annotated type. An annotation is a type-use
 annotation if it is meta-annotated with
-<code class="prettyprint lang-java">@Target(ElementType.TYPE_USE)</code>. Example:</p>
+<code class="language-java">@Target(ElementType.TYPE_USE)</code>. Example:</p>
 
-<pre class="prettyprint lang-java">final @Nullable String name;
+<pre class="language-java">final @Nullable String name;
 
 public @Nullable Person getPersonByName(String name);
 </pre>
@@ -769,7 +769,7 @@ per line). These line breaks do not constitute line-wrapping (Section
 4.5, <a href="#s4.5-line-wrapping">Line-wrapping</a>), so the indentation level is not
 increased. Example:</p>
 
-<pre class="prettyprint lang-java">@Deprecated
+<pre class="language-java">@Deprecated
 @CheckReturnValue
 public final class Frozzler { ... }
 </pre>
@@ -779,7 +779,7 @@ public final class Frozzler { ... }
 <p>The rules for annotations on method and constructor declarations are the same as the
 <a href="#s4.8.5.2-class-annotation-style">previous section</a>. Example: </p>
 
-<pre class="prettyprint lang-java">@Deprecated
+<pre class="language-java">@Deprecated
 @Override
 public String getNameIfPresent() { ... }
 </pre>
@@ -787,7 +787,7 @@ public String getNameIfPresent() { ... }
 <p class="exception"><strong>Exception:</strong> A <em>single</em> parameterless annotation
 <em>may</em> instead appear together with the first line of the signature, for example:</p>
 
-<pre class="prettyprint lang-java">@Override public int hashCode() { ... }
+<pre class="language-java">@Override public int hashCode() { ... }
 </pre>
 
 <h5 id="s4.8.5.4-field-annotation-style">4.8.5.4 Field annotations</h5>
@@ -796,7 +796,7 @@ public String getNameIfPresent() { ... }
 this case, <em>multiple</em> annotations (possibly parameterized) may be listed on the same line;
 for example:</p>
 
-<pre class="prettyprint lang-java">@Partial @Mock DataLoader loader;
+<pre class="language-java">@Partial @Mock DataLoader loader;
 </pre>
 
 <h5 id="s4.8.5.5-local-parameter-annotation-style">4.8.5.5 Parameter and local variable annotations</h5>
@@ -816,12 +816,12 @@ Such a comment renders the line non-blank.</p>
 <h5 id="s4.8.6.1-block-comment-style">4.8.6.1 Block comment style</h5>
 
 <p>Block comments are indented at the same level as the surrounding code. They may be in
-<code class="prettyprint lang-java">/* ... */</code> style or
-<code class="prettyprint lang-java">// ...</code> style. For multi-line
-<code class="prettyprint lang-java">/* ... */</code> comments, subsequent lines must start with
+<code class="language-java">/* ... */</code> style or
+<code class="language-java">// ...</code> style. For multi-line
+<code class="language-java">/* ... */</code> comments, subsequent lines must start with
 <code>*</code> aligned with the <code>*</code> on the previous line.</p>
 
-<pre class="prettyprint lang-java">/*
+<pre class="language-java">/*
  * This is          // And so           /* Or you can
  * okay.            // is this.          * even do this. */
  */
@@ -831,9 +831,9 @@ Such a comment renders the line non-blank.</p>
 <p>Comments are not enclosed in boxes drawn with asterisks or other characters.</p>
 
 <p class="tip"><strong>Tip:</strong> When writing multi-line comments, use the
-<code class="prettyprint lang-java">/* ... */</code> style if you want automatic code formatters to
+<code class="language-java">/* ... */</code> style if you want automatic code formatters to
 re-wrap the lines when necessary (paragraph-style). Most formatters don't re-wrap lines in
-<code class="prettyprint lang-java">// ...</code> style comment blocks.</p>
+<code class="language-java">// ...</code> style comment blocks.</p>
 
  
 
@@ -880,37 +880,37 @@ simply concatenated together. For example, <code>com.example.deepspace</code>, n
 <p>Class names are written in <a href="#s5.3-camel-case">UpperCamelCase</a>.</p>
 
 <p>Class names are typically nouns or noun phrases. For example,
-<code class="prettyprint lang-java">Character</code> or
-<code class="prettyprint lang-java">ImmutableList</code>. Interface names may also be nouns or
-noun phrases (for example, <code class="prettyprint lang-java">List</code>), but may sometimes be
+<code class="language-java">Character</code> or
+<code class="language-java">ImmutableList</code>. Interface names may also be nouns or
+noun phrases (for example, <code class="language-java">List</code>), but may sometimes be
 adjectives or adjective phrases instead (for example,
-<code class="prettyprint lang-java">Readable</code>).</p>
+<code class="language-java">Readable</code>).</p>
 
 <p>There are no specific rules or even well-established conventions for naming annotation types.</p>
 
-<p>A <em>test</em> class has a name that ends with <code class="prettyprint lang-java">Test</code>,
-for example, <code class="prettyprint lang-java">HashIntegrationTest</code>.
+<p>A <em>test</em> class has a name that ends with <code class="language-java">Test</code>,
+for example, <code class="language-java">HashIntegrationTest</code>.
 If it covers a single class, its name is the name of that class
-plus <code class="prettyprint lang-java">Test</code>, for example <code class="prettyprint
-  lang-java">HashImplTest</code>.</p>
+plus <code class="language-java">Test</code>, for example <code class="
+language-java">HashImplTest</code>.</p>
 
 <h4 id="s5.2.3-method-names">5.2.3 Method names</h4>
 
 <p>Method names are written in <a href="#s5.3-camel-case">lowerCamelCase</a>.</p>
 
 <p>Method names are typically verbs or verb phrases. For example,
-<code class="prettyprint lang-java">sendMessage</code> or
-<code class="prettyprint lang-java">stop</code>.</p>
+<code class="language-java">sendMessage</code> or
+<code class="language-java">stop</code>.</p>
 
 <p>Underscores may appear in JUnit <em>test</em> method names to separate logical components of the
 name, with <em>each</em> component written in <a href="#s5.3-camel-case">lowerCamelCase</a>, for
-example <code class="prettyprint lang-java">transferMoney_deductsFromSource</code>. There is no One
+example <code class="language-java">transferMoney_deductsFromSource</code>. There is no One
 Correct Way to name test methods.</p>
 
 <a name="constants"></a>
 <h4 id="s5.2.4-constant-names">5.2.4 Constant names</h4>
 
-<p>Constant names use <code class="prettyprint lang-java">UPPER_SNAKE_CASE</code>: all uppercase
+<p>Constant names use <code class="language-java">UPPER_SNAKE_CASE</code>: all uppercase
 letters, with each word separated from the next by a single underscore. But what <em>is</em> a
 constant, exactly?</p>
 
@@ -919,7 +919,7 @@ detectable side effects. Examples include primitives, strings, immutable value c
 set to <code>null</code>. If any of the instance's observable state can change, it is not a
 constant. Merely <em>intending</em> to never mutate the object is not enough. Examples:</p>
 
-<pre class="prettyprint lang-java">// Constants
+<pre class="language-java">// Constants
 static final int NUMBER = 5;
 static final ImmutableList&lt;String&gt; NAMES = ImmutableList.of("Ed", "Ann");
 static final Map&lt;String, Integer&gt; AGES = ImmutableMap.of("Ed", 35, "Ann", 32);
@@ -945,8 +945,8 @@ static final String[] nonEmptyArray = {"these", "can", "change"};
 in <a href="#s5.3-camel-case">lowerCamelCase</a>.</p>
 
 <p>These names are typically nouns or noun phrases.  For example,
-<code class="prettyprint lang-java">computedValues</code> or
-<code class="prettyprint lang-java">index</code>.</p>
+<code class="language-java">computedValues</code> or
+<code class="language-java">index</code>.</p>
 
 <h4 id="s5.2.6-parameter-names">5.2.6 Parameter names</h4>
 
@@ -967,15 +967,15 @@ be styled as constants.</p>
 
 <ul>
   <li>A single capital letter, optionally followed by a single numeral (such as
-  <code class="prettyprint lang-java">E</code>, <code class="prettyprint lang-java">T</code>,
-  <code class="prettyprint lang-java">X</code>, <code class="prettyprint lang-java">T2</code>)
+  <code class="language-java">E</code>, <code class="language-java">T</code>,
+  <code class="language-java">X</code>, <code class="language-java">T2</code>)
   </li>
 
   <li>A name in the form used for classes (see Section 5.2.2,
   <a href="#s5.2.2-class-names">Class names</a>), followed by the capital letter
-  <code class="prettyprint lang-java">T</code> (examples:
-  <code class="prettyprint lang-java">RequestT</code>,
-  <code class="prettyprint lang-java">FooBarT</code>).</li>
+  <code class="language-java">T</code> (examples:
+  <code class="language-java">RequestT</code>,
+  <code class="language-java">FooBarT</code>).</li>
 </ul>
 
 <a name="acronyms"></a>
@@ -1024,28 +1024,28 @@ predictability, Google Style specifies the following (nearly) deterministic sche
   </tr>
   <tr>
     <td>"XML HTTP request"</td>
-    <td><code class="prettyprint lang-java">XmlHttpRequest</code></td>
+    <td><code class="language-java">XmlHttpRequest</code></td>
     <td><code class="badcode">XMLHTTPRequest</code></td>
   </tr>
   <tr>
     <td>"new customer ID"</td>
-    <td><code class="prettyprint lang-java">newCustomerId</code></td>
+    <td><code class="language-java">newCustomerId</code></td>
     <td><code class="badcode">newCustomerID</code></td>
   </tr>
   <tr>
     <td>"inner stopwatch"</td>
-    <td><code class="prettyprint lang-java">innerStopwatch</code></td>
+    <td><code class="language-java">innerStopwatch</code></td>
     <td><code class="badcode">innerStopWatch</code></td>
   </tr>
   <tr>
     <td>"supports IPv6 on iOS?"</td>
-    <td><code class="prettyprint lang-java">supportsIpv6OnIos</code></td>
+    <td><code class="language-java">supportsIpv6OnIos</code></td>
     <td><code class="badcode">supportsIPv6OnIOS</code></td>
   </tr>
   <tr>
     <td>"YouTube importer"</td>
-    <td><code class="prettyprint lang-java">YouTubeImporter</code><br>
-        <code class="prettyprint lang-java">YoutubeImporter</code>*</td>
+    <td><code class="language-java">YouTubeImporter</code><br>
+        <code class="language-java">YoutubeImporter</code>*</td>
     <td></td>
   </tr>
 </tbody></table>
@@ -1054,34 +1054,34 @@ predictability, Google Style specifies the following (nearly) deterministic sche
 
 <p class="note"><strong>Note:</strong> Some words are ambiguously hyphenated in the English
 language: for example "nonempty" and "non-empty" are both correct, so the method names
-<code class="prettyprint lang-java">checkNonempty</code> and
-<code class="prettyprint lang-java">checkNonEmpty</code> are likewise both correct.</p>
+<code class="language-java">checkNonempty</code> and
+<code class="language-java">checkNonEmpty</code> are likewise both correct.</p>
 
 
 <h2 id="s6-programming-practices">6 Programming Practices</h2>
 
 <h3 id="s6.1-override-annotation">6.1 <code>@Override</code>: always used</h3>
 
-<p>A method is marked with the <code class="prettyprint lang-java">@Override</code> annotation
+<p>A method is marked with the <code class="language-java">@Override</code> annotation
 whenever it is legal.  This includes a class method overriding a superclass method, a class method
 implementing an interface method, and an interface method respecifying a superinterface
 method.</p>
 
 <p class="exception"><strong>Exception:</strong>
-<code class="prettyprint lang-java">@Override</code> may be omitted when the parent method is
-<code class="prettyprint lang-java">@Deprecated</code>.</p>
+<code class="language-java">@Override</code> may be omitted when the parent method is
+<code class="language-java">@Deprecated</code>.</p>
 
 <a name="caughtexceptions"></a>
 <h3 id="s6.2-caught-exceptions">6.2 Caught exceptions: not ignored</h3>
 
 <p>Except as noted below, it is very rarely correct to do nothing in response to a caught
 exception. (Typical responses are to log it, or if it is considered "impossible", rethrow it as an
-<code class="prettyprint lang-java">AssertionError</code>.)</p>
+<code class="language-java">AssertionError</code>.)</p>
 
 <p>When it truly is appropriate to take no action whatsoever in a catch block, the reason this is
 justified is explained in a comment.</p>
 
-<pre class="prettyprint lang-java">try {
+<pre class="language-java">try {
   int i = Integer.parseInt(response);
   return handleNumericResponse(i);
 } catch (NumberFormatException ok) {
@@ -1091,11 +1091,11 @@ return handleTextResponse(response);
 </pre>
 
 <p class="exception"><strong>Exception:</strong> In tests, a caught exception may be ignored
-without comment <em>if</em> its name is or begins with <code class="prettyprint lang-java">expected</code>. The
+without comment <em>if</em> its name is or begins with <code class="language-java">expected</code>. The
 following is a very common idiom for ensuring that the code under test <em>does</em> throw an
 exception of the expected type, so a comment is unnecessary here.</p>
 
-<pre class="prettyprint lang-java">try {
+<pre class="language-java">try {
   emptyStack.pop();
   fail();
 } catch (NoSuchElementException expected) {
@@ -1107,7 +1107,7 @@ exception of the expected type, so a comment is unnecessary here.</p>
 <p>When a reference to a static class member must be qualified, it is qualified with that class's
 name, not with a reference or expression of that class's type.</p>
 
-<pre class="prettyprint lang-java">Foo aFoo = ...;
+<pre class="language-java">Foo aFoo = ...;
 Foo.aStaticMethod(); // good
 <span class="badcode">aFoo.aStaticMethod();</span> // bad
 <span class="badcode">somethingThatYieldsAFoo().aStaticMethod();</span> // very bad
@@ -1116,8 +1116,8 @@ Foo.aStaticMethod(); // good
 <a name="finalizers"></a>
 <h3 id="s6.4-finalizers">6.4 Finalizers: not used</h3>
 
-<p>It is <strong>extremely rare</strong> to override <code class="prettyprint
-lang-java">Object.finalize</code>.</p>
+<p>It is <strong>extremely rare</strong> to override <code class="
+  language-java">Object.finalize</code>.</p>
 
 <p class="tip"><strong>Tip:</strong> Don't do it. If you absolutely must, first read and understand
 
@@ -1138,7 +1138,7 @@ lang-java">Object.finalize</code>.</p>
 
 <p>The <em>basic</em> formatting of Javadoc blocks is as seen in this example:</p>
 
-<pre class="prettyprint lang-java">/**
+<pre class="language-java">/**
  * Multiple lines of Javadoc text are written here,
  * wrapped normally...
  */
@@ -1147,7 +1147,7 @@ public int method(String p1) { ... }
 
 <p>... or in this single-line example:</p>
 
-<pre class="prettyprint lang-java">/** An especially short bit of Javadoc. */
+<pre class="language-java">/** An especially short bit of Javadoc. */
 </pre>
 
 <p>The basic form is always acceptable. The single-line form may be substituted when the entirety
@@ -1185,17 +1185,17 @@ like <code class="badcode">Save the record.</code>. However, the fragment is cap
 punctuated as if it were a complete sentence.</p>
 
 <p class="tip"><strong>Tip:</strong> A common mistake is to write simple Javadoc in the form
-<code class="badcode prettyprint lang-java">/** @return the customer ID */</code>. This is
+<code class="badcode  language-java">/** @return the customer ID */</code>. This is
 incorrect, and should be changed to
-<code class="prettyprint lang-java">/** Returns the customer ID. */</code>.</p>
+<code class="language-java">/** Returns the customer ID. */</code>.</p>
 
 <a name="s7.3.3-javadoc-optional"></a> 
 <h3 id="s7.3-javadoc-where-required">7.3 Where Javadoc is used</h3>
 
 <p>At the <em>minimum</em>, Javadoc is present for every
-<code class="prettyprint lang-java">public</code> class, and every
-<code class="prettyprint lang-java">public</code> or
-<code class="prettyprint lang-java">protected</code> member of such a class, with a few exceptions
+<code class="language-java">public</code> class, and every
+<code class="language-java">public</code> or
+<code class="language-java">protected</code> member of such a class, with a few exceptions
 noted below.</p>
 
 <p>Additional Javadoc content may also be present, as explained in Section 7.3.4,
@@ -1204,12 +1204,12 @@ noted below.</p>
 <h4 id="s7.3.1-javadoc-exception-self-explanatory">7.3.1 Exception: self-explanatory members</h4>
 
 <p>Javadoc is optional for "simple, obvious" members like
-<code class="prettyprint lang-java">getFoo()</code>, in cases where there <em>really and truly</em>
+<code class="language-java">getFoo()</code>, in cases where there <em>really and truly</em>
  is nothing else worthwhile to say but "Returns the foo".</p>
 
 <p class="note"><strong>Important:</strong> it is not appropriate to cite this exception to justify
 omitting relevant information that a typical reader might need to know. For example, for a method
-named <code class="prettyprint lang-java">getCanonicalName</code>, don't omit its documentation
+named <code class="language-java">getCanonicalName</code>, don't omit its documentation
 (with the rationale that it would say only
 <code class="badcode">/** Returns the canonical name. */</code>) if a typical reader may have no idea
 what the term "canonical name" means!</p>

--- a/src/site/site.vm
+++ b/src/site/site.vm
@@ -1,0 +1,26 @@
+#* @vmatchive *#
+<div id="contentBox" class="container-fluid">
+  <div class="row">
+    <div id="leftColumn" class="col-md-2">
+      #parse("menu.vm")
+    </div>
+    <div id="bodyColumn" class="col-md-10 $bodyColumnClass">
+      #if ($bodyContent)
+        #set($bodyContent = $bodyContent.replaceAll(
+          '<pre>(<code[ >](?!.*class="nohighlight nocode"))',
+          '<pre class="prettyprint">$1'
+        ))
+        #set($bodyContent = $bodyContent.replace(
+          'class="bodyTable"',
+          'class="table table-striped"'
+        ))
+        #set($bodyContent = $bodyContent.replace(
+          'class="bodyTable bodyTableBorder"',
+          'class="table table-bordered table-striped"'
+        ))
+        $bodyContent
+      #end
+    </div>
+  </div>
+</div>
+#parse("footer.vm")

--- a/src/site/site.xml
+++ b/src/site/site.xml
@@ -10,6 +10,7 @@
     <artifactId>maven-fluido-skin</artifactId>
     <version>2.0.1</version>
   </skin>
+
   <bannerLeft href="https://checkstyle.org">
     <image src="images/header-checkstyle-logo.png" alt="Checkstyle"/>
   </bannerLeft>
@@ -39,23 +40,24 @@
     </logo>
   </poweredBy>
 
+  <custom>
+    <fluidoSkin>
+      <sourceLineNumbersEnabled>false</sourceLineNumbersEnabled>
+    </fluidoSkin>
+  </custom>
+
   <body>
     <head>
       <!-- Will be added to every generated page -->
       <![CDATA[
         <script type="text/javascript" src="$relativePath/js/checkstyle.js"></script>
-        <script type="text/javascript"
-              src="https://ajax.googleapis.com/ajax/libs/jquery/2.1.3/jquery.min.js"></script>
         <script type="text/javascript" src="$relativePath/js/anchors.js"></script>
         <script type="text/javascript" src="$relativePath/js/google-analytics.js"></script>
-        <script src="https://cdnjs.cloudflare.com/ajax/libs/prettify/r298/prettify.min.js"></script>
-        <script type="text/javascript"
-              src="https://cdn.jsdelivr.net/gh/google/code-prettify@master/loader/run_prettify.js"></script>
-        <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/prettify/r298/prettify.min.css">
         <link rel="icon" href="$relativePath/images/favicon.png" type="image/x-icon" />
         <link rel="shortcut icon" href="$relativePath/images/favicon.ico" type="image/ico" />
       ]]>
     </head>
+
     <links>
       <item name="toTop"/>
     </links>

--- a/src/site/xdoc/anttask.xml.vm
+++ b/src/site/xdoc/anttask.xml.vm
@@ -45,7 +45,7 @@
         <code>taskdef</code> declaration:
       </p>
 
-      <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
+      <div class="wrapper"><pre><code class="language-xml">
 &lt;taskdef resource=&quot;com/puppycrawl/tools/checkstyle/ant/checkstyle-ant-task.properties&quot;
          classpath=&quot;/path/to/checkstyle-${projectVersion}-all.jar&quot;/&gt;
       </code></pre></div>
@@ -56,7 +56,7 @@
         declaration:
       </p>
 
-      <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
+      <div class="wrapper"><pre><code class="language-xml">
 &lt;taskdef
   resource=&quot;com/puppycrawl/tools/checkstyle/ant/checkstyle-ant-task.properties&quot;/&gt;
       </code></pre></div>
@@ -70,7 +70,7 @@
         for more details).  For example:
       </p>
 
-      <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
+      <div class="wrapper"><pre><code class="language-xml">
 &lt;project name="foo" ...
          xmlns:cs="antlib:com.puppycrawl.tools.checkstyle.ant"&gt;
 ...
@@ -346,7 +346,7 @@
         </b>
       </p>
 
-      <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
+      <div class="wrapper"><pre><code class="language-xml">
 &lt;checkstyle config=&quot;docs/sun_checks.xml&quot; file=&quot;Check.java&quot;/&gt;
       </code></pre></div>
 
@@ -356,7 +356,7 @@
           and an expanded property value
         </b>
       </p>
-      <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
+      <div class="wrapper"><pre><code class="language-xml">
 &lt;checkstyle config=&quot;/path/to/site/sun_checks.xml&quot;&gt;
   &lt;fileset dir=&quot;src/checkstyle&quot; includes=&quot;**/*.java&quot;/&gt;
 
@@ -370,7 +370,7 @@
           Run checkstyle on a previously defined source path.
         </b>
       </p>
-      <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
+      <div class="wrapper"><pre><code class="language-xml">
 &lt;!-- Somewhere in your config --&gt;
 &lt;path id="project.sourcepath"&gt;
   &lt;fileset dir="src"
@@ -391,7 +391,7 @@
           output in plain format, and files in XML &amp; SARIF format
         </b>
       </p>
-      <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
+      <div class="wrapper"><pre><code class="language-xml">
 &lt;checkstyle config=&quot;docs/sun_checks.xml&quot;&gt;
   &lt;fileset dir=&quot;src/checkstyle&quot; includes=&quot;**/*.java&quot;/&gt;
   &lt;formatter type=&quot;plain&quot;/&gt;
@@ -407,7 +407,7 @@
           names file
         </b>
       </p>
-      <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
+      <div class="wrapper"><pre><code class="language-xml">
 &lt;checkstyle config=&quot;docs/sun_checks.xml&quot;
             packageNamesFile=&quot;myPackageNames.xml&quot;
             file=&quot;Check.java&quot;/&gt;
@@ -419,7 +419,7 @@
           style violations are detected
         </b>
       </p>
-      <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
+      <div class="wrapper"><pre><code class="language-xml">
 &lt;target name=&quot;checkstyle&quot;
         description=&quot;Generates a report of code convention violations.&quot;>
 

--- a/src/site/xdoc/beginning_development.xml
+++ b/src/site/xdoc/beginning_development.xml
@@ -26,7 +26,7 @@
         3. Clone your forked repository to your computer:
       </p>
       <div class="wrap-content">
-        <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
+        <div class="wrapper"><pre><code class="language-xml">
             git clone git@github.com:your_user_name/checkstyle.git
         </code></pre></div>
       </div>
@@ -35,7 +35,7 @@
         all needed artifacts. From the repository root folder, run:
       </p>
       <div class="wrap-content">
-        <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
+        <div class="wrapper"><pre><code class="language-xml">
             mvn install
         </code></pre></div>
       </div>
@@ -61,7 +61,7 @@
         naming it "upstream":
       </p>
       <div class="wrap-content">
-        <div class="wrapper"><pre class="prettyprint"><code class="language-text">
+        <div class="wrapper"><pre><code class="language-text">
           git remote add upstream https://github.com/checkstyle/checkstyle
         </code></pre></div>
       </div>
@@ -69,7 +69,7 @@
            2) Create a branch for a new check:
       </p>
       <div class="wrap-content">
-        <div class="wrapper"><pre class="prettyprint"><code class="language-text">
+        <div class="wrapper"><pre><code class="language-text">
           git checkout -b my-new-check
         </code></pre></div>
       </div>
@@ -77,7 +77,7 @@
            3) Commit changes to my-new-check branch:
       </p>
       <div class="wrap-content">
-        <div class="wrapper"><pre class="prettyprint"><code class="language-text">
+        <div class="wrapper"><pre><code class="language-text">
           git add .
           git commit -m "commit message"
         </code></pre></div>
@@ -86,7 +86,7 @@
            4) Push branch to GitHub, to allow your mentor to review your code:
       </p>
       <div class="wrap-content">
-        <div class="wrapper"><pre class="prettyprint"><code class="language-text">
+        <div class="wrapper"><pre><code class="language-text">
           git push origin my-new-check
         </code></pre></div>
       </div>
@@ -97,7 +97,7 @@
            our <a href="https://github.com/checkstyle/checkstyle/wiki/PR-rules">wiki</a>.
       </p>
       <div class="wrap-content">
-        <div class="wrapper"><pre class="prettyprint"><code class="language-text">
+        <div class="wrapper"><pre><code class="language-text">
           git rebase -i master
           git push --force origin my-new-check
         </code></pre></div>
@@ -107,7 +107,7 @@
            by other contributors:
       </p>
       <div class="wrap-content">
-        <div class="wrapper"><pre class="prettyprint"><code class="language-text">
+        <div class="wrapper"><pre><code class="language-text">
           git checkout master
           git pull upstream master
           git push origin master
@@ -117,7 +117,7 @@
            7) Rebase your branch on your updated master:
       </p>
       <div class="wrap-content">
-        <div class="wrapper"><pre class="prettyprint"><code class="language-text">
+        <div class="wrapper"><pre><code class="language-text">
           git checkout my-new-check
           git rebase master
         </code></pre></div>
@@ -127,12 +127,12 @@
            In that case it will stop and allow you to fix the conflicts.<br/>
            After fixing conflicts, use
       </p>
-      <div class="wrapper"><pre class="prettyprint"><code class="language-text">
+      <div class="wrapper"><pre><code class="language-text">
         git add .
       </code></pre></div>
       <p> to update the index with those contents, and then just run:</p>
       <div class="wrap-content">
-        <div class="wrapper"><pre class="prettyprint"><code class="language-text">
+        <div class="wrapper"><pre><code class="language-text">
           git rebase --continue
         </code></pre></div>
       </div>
@@ -140,7 +140,7 @@
            9) Push branch to GitHub (with all your final changes and actual code of Checkstyle):
       </p>
       <div class="wrap-content">
-        <div class="wrapper"><pre class="prettyprint"><code class="language-text">
+        <div class="wrapper"><pre><code class="language-text">
           git push --force origin my-new-check
         </code></pre></div>
       </div>

--- a/src/site/xdoc/checks/annotation/annotationlocation.xml
+++ b/src/site/xdoc/checks/annotation/annotationlocation.xml
@@ -140,7 +140,7 @@ public String getNameIfPresent() { ... }
           To configure the default check to allow one single parameterless annotation on the same
             line:
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
+        <div class="wrapper"><pre><code class="language-xml">
 &lt;module name="Checker"&gt;
   &lt;module name="TreeWalker"&gt;
     &lt;module name="AnnotationLocation"/&gt;
@@ -148,7 +148,7 @@ public String getNameIfPresent() { ... }
 &lt;/module&gt;
 </code></pre></div>
         <p id="Example1-code">Example:</p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+        <div class="wrapper"><pre><code class="language-java">
 class Example1 {
   @Nonnull
   private boolean field1; // ok
@@ -169,7 +169,7 @@ class Example1 {
         <p id="Example2-config">
           Use the following configuration to allow multiple annotations on the same line:
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
+        <div class="wrapper"><pre><code class="language-xml">
 &lt;module name="Checker"&gt;
   &lt;module name="TreeWalker"&gt;
     &lt;module name="AnnotationLocation"&gt;
@@ -182,7 +182,7 @@ class Example1 {
 &lt;/module&gt;
 </code></pre></div>
         <p id="Example2-code">Example:</p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+        <div class="wrapper"><pre><code class="language-java">
 class Example2 {
   @Nonnull
   private boolean field1;
@@ -203,7 +203,7 @@ class Example2 {
           Use the following configuration to allow only one and only parameterized annotation
           on the same line:
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
+        <div class="wrapper"><pre><code class="language-xml">
 &lt;module name="Checker"&gt;
   &lt;module name="TreeWalker"&gt;
     &lt;module name="AnnotationLocation"&gt;
@@ -216,7 +216,7 @@ class Example2 {
 &lt;/module&gt;
 </code></pre></div>
         <p id="Example3-code">Example:</p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+        <div class="wrapper"><pre><code class="language-java">
 class Example3 {
   // violation below, 'Annotation 'Nonnull' should be alone on line.'
   @Nonnull private boolean field1;
@@ -239,7 +239,7 @@ class Example3 {
           Use the following configuration to only validate annotations on methods to allow one
           single parameterless annotation on the same line:
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
+        <div class="wrapper"><pre><code class="language-xml">
 &lt;module name="Checker"&gt;
   &lt;module name="TreeWalker"&gt;
     &lt;module name="AnnotationLocation"&gt;
@@ -253,7 +253,7 @@ class Example3 {
 &lt;/module&gt;
 </code></pre></div>
         <p id="Example4-code">Example:</p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+        <div class="wrapper"><pre><code class="language-java">
 class Example4 {
   @NotNull private boolean field1; // ok, as 'tokens' property set to METHOD_DEF only
   @Override public int hashCode() { return 1; }

--- a/src/site/xdoc/checks/annotation/annotationonsameline.xml
+++ b/src/site/xdoc/checks/annotation/annotationonsameline.xml
@@ -95,7 +95,7 @@
         <p id="Example1-config">
           To configure the check:
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
+        <div class="wrapper"><pre><code class="language-xml">
 &lt;module name="Checker"&gt;
   &lt;module name="TreeWalker"&gt;
     &lt;module name="AnnotationOnSameLine"/&gt;
@@ -103,7 +103,7 @@
 &lt;/module&gt;
 </code></pre></div>
         <p id="Example1-code">Example:</p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+        <div class="wrapper"><pre><code class="language-java">
 class Example1 {
 
   // violation below, "should be on the same line with its target."
@@ -144,7 +144,7 @@ class Example1 {
           To configure the check to check for annotations applied on
           interfaces, variables and constructors:
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
+        <div class="wrapper"><pre><code class="language-xml">
 &lt;module name="Checker"&gt;
   &lt;module name="TreeWalker"&gt;
     &lt;module name="AnnotationOnSameLine"&gt;
@@ -155,7 +155,7 @@ class Example1 {
 &lt;/module&gt;
 </code></pre></div>
         <p id="Example2-code">Example:</p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+        <div class="wrapper"><pre><code class="language-java">
 @Deprecated interface Foo {  // OK
 
   void doSomething();

--- a/src/site/xdoc/checks/annotation/annotationusestyle.xml
+++ b/src/site/xdoc/checks/annotation/annotationusestyle.xml
@@ -124,7 +124,7 @@
         <p id="Example1-config">
           To configure the check:
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
+        <div class="wrapper"><pre><code class="language-xml">
 &lt;module name="Checker"&gt;
   &lt;module name="TreeWalker"&gt;
     &lt;module name="AnnotationUseStyle"/&gt;
@@ -132,7 +132,7 @@
 &lt;/module&gt;
 </code></pre></div>
         <p id="Example1-code">Example:</p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+        <div class="wrapper"><pre><code class="language-java">
 @SuppressWarnings("unchecked") // ok as it's in implied style
 @Deprecated // ok as it matches closingParens default property
 @SomeArrays({"unchecked","unused"}) // ok as it's in implied style
@@ -156,7 +156,7 @@ class TestStyle1
           To configure the check to enforce an <code>expanded</code> style,
           with a closing parenthesis and a trailing array comma set to <code>never</code>.
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
+        <div class="wrapper"><pre><code class="language-xml">
 &lt;module name="Checker"&gt;
   &lt;module name="TreeWalker"&gt;
     &lt;module name="AnnotationUseStyle"&gt;
@@ -168,7 +168,7 @@ class TestStyle1
 &lt;/module&gt;
 </code></pre></div>
         <p id="Example2-code">Example:</p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+        <div class="wrapper"><pre><code class="language-java">
 @SuppressWarnings("unchecked") // violation 'Annotation style must be 'EXPANDED''
 @Deprecated // ok as closingParens property set to never
 // violation below 'Annotation style must be 'EXPANDED''
@@ -191,7 +191,7 @@ class TestStyle2 {
           To configure the check to enforce an <code>expanded</code> style,
           with a closing parenthesis and a trailing array comma set to <code>never</code>.
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
+        <div class="wrapper"><pre><code class="language-xml">
 &lt;module name="Checker"&gt;
   &lt;module name="TreeWalker"&gt;
     &lt;module name="AnnotationUseStyle"&gt;
@@ -203,7 +203,7 @@ class TestStyle2 {
 &lt;/module&gt;
 </code></pre></div>
         <p id="Example3-code">Example:</p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+        <div class="wrapper"><pre><code class="language-java">
 @SuppressWarnings("unchecked") // ok as element style set to compact
 @Deprecated // violation 'Annotation must have closing parenthesis'
 @SomeArrays({"unchecked","unused"}) // ok as it's in compact style
@@ -226,7 +226,7 @@ class TestStyle3 {
           To configure the check to enforce a trailing array comma,
           with ignoring the elementStyle and a closing parenthesis.
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
+        <div class="wrapper"><pre><code class="language-xml">
 &lt;module name="Checker"&gt;
   &lt;module name="TreeWalker"&gt;
     &lt;module name="AnnotationUseStyle"&gt;
@@ -238,7 +238,7 @@ class TestStyle3 {
 &lt;/module&gt;
 </code></pre></div>
         <p id="Example4-code">Example:</p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+        <div class="wrapper"><pre><code class="language-java">
 @SuppressWarnings("unchecked") // ok as element style set to 'ignore'
 @Deprecated // ok as 'closingParens' is set to 'ignore
 // violation below 'Annotation array values must contain trailing comma'

--- a/src/site/xdoc/checks/annotation/missingdeprecated.xml
+++ b/src/site/xdoc/checks/annotation/missingdeprecated.xml
@@ -74,7 +74,7 @@
         <p id="Example1-config">
           To configure the check:
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
+        <div class="wrapper"><pre><code class="language-xml">
 &lt;module name="Checker"&gt;
   &lt;module name="TreeWalker"&gt;
     &lt;module name="MissingDeprecated"/&gt;
@@ -82,7 +82,7 @@
 &lt;/module&gt;
 </code></pre></div>
         <p id="Example1-code">Example:</p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+        <div class="wrapper"><pre><code class="language-java">
 class Example1 {
   @Deprecated
   public static final int MY_CONST = 13; // ok
@@ -112,7 +112,7 @@ class Example1 {
           To configure the check such that it prints violation
           messages if tight HTML rules are not obeyed
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
+        <div class="wrapper"><pre><code class="language-xml">
 &lt;module name="Checker"&gt;
   &lt;module name="TreeWalker"&gt;
     &lt;module name="MissingDeprecated"&gt;
@@ -122,7 +122,7 @@ class Example1 {
 &lt;/module&gt;
 </code></pre></div>
         <p id="Example2-code">Example:</p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+        <div class="wrapper"><pre><code class="language-java">
 class Example2 {
   @Deprecated
   public static final int MY_CONST = 13; // ok

--- a/src/site/xdoc/checks/annotation/missingoverride.xml
+++ b/src/site/xdoc/checks/annotation/missingoverride.xml
@@ -66,7 +66,7 @@
       </subsection>
       <subsection name="Examples" id="Examples">
         <p id="Example1-config"> To configure the check:</p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
+        <div class="wrapper"><pre><code class="language-xml">
 &lt;module name="Checker"&gt;
   &lt;module name="TreeWalker"&gt;
     &lt;module name="MissingOverride"/&gt;
@@ -74,7 +74,7 @@
 &lt;/module&gt;
 </code></pre></div>
         <p id="Example1-code">Example:</p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+        <div class="wrapper"><pre><code class="language-java">
 class Example1 extends ParentClass1 {
 
   /** {@inheritDoc} */
@@ -105,7 +105,7 @@ class Example1 extends ParentClass1 {
           To configure the check for the <code>javaFiveCompatibility</code>
           mode:
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
+        <div class="wrapper"><pre><code class="language-xml">
 &lt;module name="Checker"&gt;
   &lt;module name="TreeWalker"&gt;
     &lt;module name="MissingOverride"&gt;
@@ -116,7 +116,7 @@ class Example1 extends ParentClass1 {
 &lt;/module&gt;
 </code></pre></div>
         <p id="Example2-code">Example:</p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+        <div class="wrapper"><pre><code class="language-java">
 class Example2 {
   /** {@inheritDoc} */
   public boolean equals(Object o) { // violation, 'include @java.lang.Override'

--- a/src/site/xdoc/checks/annotation/packageannotation.xml
+++ b/src/site/xdoc/checks/annotation/packageannotation.xml
@@ -33,7 +33,7 @@
 
       <subsection name="Examples" id="Examples">
         <p id="Example1-config"> To configure the check:</p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
+        <div class="wrapper"><pre><code class="language-xml">
 &lt;module name="Checker"&gt;
   &lt;module name="TreeWalker"&gt;
     &lt;module name="PackageAnnotation"/&gt;
@@ -41,7 +41,7 @@
 &lt;/module&gt;
 </code></pre></div>
         <p id="Example1-code">Example of class with violation:</p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+        <div class="wrapper"><pre><code class="language-java">
 @Deprecated
 package com.puppycrawl.tools.checkstyle.checks.annotation.packageannotation;
 // violation above, 'Package annotations must be in the package-info.java info.'
@@ -49,13 +49,13 @@ package com.puppycrawl.tools.checkstyle.checks.annotation.packageannotation;
 class Example1 {}
 </code></pre></div>
         <p id="Example2-code">Example of class without violation:</p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+        <div class="wrapper"><pre><code class="language-java">
 package com.puppycrawl.tools.checkstyle.checks.annotation.packageannotation;
 
 class Example2 {}
 </code></pre></div>
         <p id="package-info-code">Example of validating package-info.java:</p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+        <div class="wrapper"><pre><code class="language-java">
 @Deprecated
 package com.puppycrawl.tools.checkstyle.checks.annotation.packageannotation.example3;
 </code></pre></div>

--- a/src/site/xdoc/checks/annotation/suppresswarnings.xml
+++ b/src/site/xdoc/checks/annotation/suppresswarnings.xml
@@ -139,7 +139,7 @@
         <p id="Example1-config">
           To configure the check:
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
+        <div class="wrapper"><pre><code class="language-xml">
 &lt;module name="Checker"&gt;
   &lt;module name="TreeWalker"&gt;
     &lt;module name="SuppressWarnings"/&gt;
@@ -147,7 +147,7 @@
 &lt;/module&gt;
 </code></pre></div>
         <p id="Example1-code">Example:</p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+        <div class="wrapper"><pre><code class="language-java">
 // violation below 'The warning '' cannot be suppressed at this location'
 @SuppressWarnings("")
 class Example1 {
@@ -180,7 +180,7 @@ class Test1 {}
           warnings cannot be suppressed on anything
           but variable and parameter declarations.
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
+        <div class="wrapper"><pre><code class="language-xml">
 &lt;module name="Checker"&gt;
   &lt;module name="TreeWalker"&gt;
     &lt;module name="SuppressWarnings"&gt;
@@ -197,7 +197,7 @@ class Test1 {}
 &lt;/module&gt;
 </code></pre></div>
         <p id="Example2-code">Example:</p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+        <div class="wrapper"><pre><code class="language-java">
 // ok below, since we are only checking for '^unchecked$|^unused$'
 @SuppressWarnings("")
 class Example2 {

--- a/src/site/xdoc/checks/annotation/suppresswarningsholder.xml
+++ b/src/site/xdoc/checks/annotation/suppresswarningsholder.xml
@@ -47,7 +47,7 @@
 
       <subsection name="Examples" id="Examples">
         <p id="Example1-config">To use default module configuration:</p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
+        <div class="wrapper"><pre><code class="language-xml">
 &lt;module name="Checker"&gt;
   &lt;module name="TreeWalker"&gt;
   &lt;module name="MemberName"/&gt;
@@ -63,7 +63,7 @@
 &lt;/module&gt;
 </code></pre></div>
         <p id="Example1-code">Example:</p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+        <div class="wrapper"><pre><code class="language-java">
 class Example1 {
   private int K; // violation, 'Name 'K' must match pattern'
   @SuppressWarnings({"membername"})
@@ -94,7 +94,7 @@ class Example1 {
           code will work if there was provided a <code>ParameterNumberCheck=paramnum</code> in
           the <code>aliasList</code>:
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
+        <div class="wrapper"><pre><code class="language-xml">
 &lt;module name="Checker"&gt;
   &lt;module name="TreeWalker"&gt;
   &lt;module name="ParameterNumber"/&gt;
@@ -107,7 +107,7 @@ class Example1 {
 &lt;/module&gt;
 </code></pre></div>
         <p id="Example2-code">Example:</p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+        <div class="wrapper"><pre><code class="language-java">
 class Example2 {
   // violation below, 'More than 7 parameters (found 8)'
   public void needsLotsOfParameters (int a,

--- a/src/site/xdoc/checks/blocks/avoidnestedblocks.xml
+++ b/src/site/xdoc/checks/blocks/avoidnestedblocks.xml
@@ -72,7 +72,7 @@ public void guessTheOutput()
 
       <subsection name="Examples" id="Examples">
         <p id="Example1-config">To configure the check:</p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
+        <div class="wrapper"><pre><code class="language-xml">
 &lt;module name="Checker"&gt;
   &lt;module name="TreeWalker"&gt;
     &lt;module name="AvoidNestedBlocks"/&gt;
@@ -80,7 +80,7 @@ public void guessTheOutput()
 &lt;/module&gt;
 </code></pre></div>
         <p id="Example1-code">Example:</p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+        <div class="wrapper"><pre><code class="language-java">
 public class Example1 {
   public void foo() {
     int myInteger = 0;
@@ -102,7 +102,7 @@ public class Example1 {
 }
 </code></pre></div>
         <p id="Example2-config">To configure the check to allow nested blocks in switch case:</p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
+        <div class="wrapper"><pre><code class="language-xml">
 &lt;module name="Checker"&gt;
   &lt;module name="TreeWalker"&gt;
     &lt;module name="AvoidNestedBlocks"&gt;
@@ -112,7 +112,7 @@ public class Example1 {
 &lt;/module&gt;
 </code></pre></div>
         <p id="Example2-code">Example:</p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+        <div class="wrapper"><pre><code class="language-java">
 public class Example2 {
   public void foo() {
     int myInteger = 0;

--- a/src/site/xdoc/checks/blocks/emptyblock.xml
+++ b/src/site/xdoc/checks/blocks/emptyblock.xml
@@ -106,7 +106,7 @@
 
       <subsection name="Examples" id="Examples">
         <p id="Example1-config"> To configure the check: </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
+        <div class="wrapper"><pre><code class="language-xml">
 &lt;module name="Checker"&gt;
   &lt;module name="TreeWalker"&gt;
     &lt;module name="EmptyBlock"/&gt;
@@ -114,7 +114,7 @@
 &lt;/module&gt;
 </code></pre></div>
         <p id="Example1-code">Example:</p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+        <div class="wrapper"><pre><code class="language-java">
 public class Example1 {
   private void emptyLoop() {
     for (int i = 0; i &lt; 10; i++) { // violation 'Must have at least one statement'
@@ -132,7 +132,7 @@ public class Example1 {
           To configure the check for the <code>text</code>
           policy and only <code> try</code> blocks:
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
+        <div class="wrapper"><pre><code class="language-xml">
 &lt;module name="Checker"&gt;
   &lt;module name="TreeWalker"&gt;
     &lt;module name="EmptyBlock"&gt;
@@ -143,7 +143,7 @@ public class Example1 {
 &lt;/module&gt;
 </code></pre></div>
         <p id="Example2-code">Example:</p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+        <div class="wrapper"><pre><code class="language-java">
 public class Example2 {
   private void emptyLoop() {
     for (int i = 0; i &lt; 10; i++) {
@@ -161,7 +161,7 @@ public class Example2 {
         <p id="Example3-config">
           To configure the check for case and default in switch block:
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
+        <div class="wrapper"><pre><code class="language-xml">
 &lt;module name="Checker"&gt;
   &lt;module name="TreeWalker"&gt;
     &lt;module name="EmptyBlock"&gt;
@@ -171,7 +171,7 @@ public class Example2 {
 &lt;/module&gt;
 </code></pre></div>
         <p id="Example3-code">Example:</p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+        <div class="wrapper"><pre><code class="language-java">
 public class Example3 {
 
   private void testBadSwitchStatement(int a) {

--- a/src/site/xdoc/checks/blocks/emptycatchblock.xml
+++ b/src/site/xdoc/checks/blocks/emptycatchblock.xml
@@ -55,7 +55,7 @@
         <p id="Example1-config">
           To configure the check:
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
+        <div class="wrapper"><pre><code class="language-xml">
 &lt;module name="Checker"&gt;
   &lt;module name="TreeWalker"&gt;
     &lt;module name="EmptyCatchBlock"/&gt;
@@ -63,7 +63,7 @@
 &lt;/module&gt;
 </code></pre></div>
         <p id="Example1-code">Such empty blocks would be both suppressed:</p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+        <div class="wrapper"><pre><code class="language-java">
 public class Example1 {
   private void exampleMethod1() {
     try {
@@ -101,7 +101,7 @@ public class Example1 {
           To configure the check to suppress empty catch block if exception's variable name is
           <code>expected</code> or <code>ignore</code> or there's any comment inside:
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
+        <div class="wrapper"><pre><code class="language-xml">
 &lt;module name="Checker"&gt;
   &lt;module name="TreeWalker"&gt;
     &lt;module name="EmptyCatchBlock"&gt;
@@ -111,7 +111,7 @@ public class Example1 {
 &lt;/module&gt;
 </code></pre></div>
         <p id="Example2-code">Such empty blocks would be both suppressed:</p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+        <div class="wrapper"><pre><code class="language-java">
 public class Example2 {
   private void exampleMethod1() {
     try {
@@ -149,7 +149,7 @@ public class Example2 {
           To configure the check to suppress empty catch block if single-line comment inside
            is &quot;This is expected&quot;:
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
+        <div class="wrapper"><pre><code class="language-xml">
 &lt;module name="Checker"&gt;
   &lt;module name="TreeWalker"&gt;
     &lt;module name="EmptyCatchBlock"&gt;
@@ -159,7 +159,7 @@ public class Example2 {
 &lt;/module&gt;
 </code></pre></div>
         <p id="Example3-code">Such empty blocks would be both suppressed:</p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+        <div class="wrapper"><pre><code class="language-java">
 public class Example3 {
   private void exampleMethod1() {
     try {
@@ -197,7 +197,7 @@ public class Example3 {
           To configure the check to suppress empty catch block if single-line comment inside
           is &quot;This is expected&quot;:
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
+        <div class="wrapper"><pre><code class="language-xml">
 &lt;module name="Checker"&gt;
   &lt;module name="TreeWalker"&gt;
     &lt;module name="EmptyCatchBlock"&gt;
@@ -207,7 +207,7 @@ public class Example3 {
 &lt;/module&gt;
 </code></pre></div>
         <p id="Example4-code">Such empty blocks would be both suppressed:</p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+        <div class="wrapper"><pre><code class="language-java">
 public class Example4 {
   private void exampleMethod1() {
     try {
@@ -260,7 +260,7 @@ public class Example4 {
           To configure the check to suppress empty catch block if
           exception's variable name is &quot;myException&quot;:
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
+        <div class="wrapper"><pre><code class="language-xml">
 &lt;module name="Checker"&gt;
   &lt;module name="TreeWalker"&gt;
     &lt;module name="EmptyCatchBlock"&gt;
@@ -270,7 +270,7 @@ public class Example4 {
 &lt;/module&gt;
 </code></pre></div>
         <p id="Example5-code">Such empty blocks would be both suppressed:</p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+        <div class="wrapper"><pre><code class="language-java">
 public class Example5 {
   private void exampleMethod1() {
     try {

--- a/src/site/xdoc/checks/blocks/leftcurly.xml
+++ b/src/site/xdoc/checks/blocks/leftcurly.xml
@@ -152,7 +152,7 @@
 
       <subsection name="Examples" id="Examples">
         <p id="Example1-config"> To configure the check: </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
+        <div class="wrapper"><pre><code class="language-xml">
 &lt;module name="Checker"&gt;
   &lt;module name="TreeWalker"&gt;
     &lt;module name="LeftCurly"/&gt;
@@ -161,7 +161,7 @@
 </code></pre></div>
 
         <p id="Example1-code">Example: </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+        <div class="wrapper"><pre><code class="language-java">
 class Example1
 { // violation, ''{' at column 1 should be on the previous line.'
   private interface TestInterface
@@ -183,7 +183,7 @@ class Example1
           To configure the check to apply the <code>nl</code> policy to
           type blocks:
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
+        <div class="wrapper"><pre><code class="language-xml">
 &lt;module name="Checker"&gt;
   &lt;module name="TreeWalker"&gt;
     &lt;module name="LeftCurly"&gt;
@@ -194,7 +194,7 @@ class Example1
 &lt;/module&gt;
 </code></pre></div>
         <p id="Example2-code">Example: </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+        <div class="wrapper"><pre><code class="language-java">
 class Example2
 { // OK
   private interface TestInterface
@@ -216,7 +216,7 @@ class Example2
           To configure the check to apply the <code>nlow</code> policy to
           type blocks:
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
+        <div class="wrapper"><pre><code class="language-xml">
 &lt;module name="Checker"&gt;
   &lt;module name="TreeWalker"&gt;
     &lt;module name="LeftCurly"&gt;
@@ -227,7 +227,7 @@ class Example2
 &lt;/module&gt;
 </code></pre></div>
         <p id="Example3-code">Example: </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+        <div class="wrapper"><pre><code class="language-java">
 class Example3
 { // violation, ''{' at column 1 should be on the previous line.'
   private interface TestInterface { // OK
@@ -247,7 +247,7 @@ class Example3
         <p id="Example4-config">
           An example of how to configure the check to validate enum definitions:
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
+        <div class="wrapper"><pre><code class="language-xml">
 &lt;module name="Checker"&gt;
   &lt;module name="TreeWalker"&gt;
     &lt;module name="LeftCurly"&gt;
@@ -257,7 +257,7 @@ class Example3
 &lt;/module&gt;
 </code></pre></div>
         <p id="Example4-code">Example: </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+        <div class="wrapper"><pre><code class="language-java">
 class Example4
 { // violation, ''{' at column 1 should be on the previous line.'
   private interface TestInterface

--- a/src/site/xdoc/checks/blocks/needbraces.xml
+++ b/src/site/xdoc/checks/blocks/needbraces.xml
@@ -80,7 +80,7 @@
 
       <subsection name="Examples" id="Examples">
         <p id="Example1-config"> To configure the check: </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
+        <div class="wrapper"><pre><code class="language-xml">
 &lt;module name="Checker"&gt;
   &lt;module name="TreeWalker"&gt;
     &lt;module name="NeedBraces"/&gt;
@@ -88,7 +88,7 @@
 &lt;/module&gt;
 </code></pre></div>
         <p id="Example1-code">Example:</p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+        <div class="wrapper"><pre><code class="language-java">
 class Example1 {
   String obj = new String();
   String value = new String();
@@ -130,7 +130,7 @@ class Example1 {
           To configure the check for <code>if</code> and
           <code> else</code> blocks:
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
+        <div class="wrapper"><pre><code class="language-xml">
 &lt;module name="Checker"&gt;
   &lt;module name="TreeWalker"&gt;
     &lt;module name="NeedBraces"&gt;
@@ -140,7 +140,7 @@ class Example1 {
 &lt;/module&gt;
 </code></pre></div>
         <p id="Example2-code">Example:</p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+        <div class="wrapper"><pre><code class="language-java">
 class Example2 {
   String obj = new String();
   String value = new String();
@@ -182,7 +182,7 @@ class Example2 {
           To configure the check to allow single-line statements
           (<code>if, while, do-while, for</code>) without braces:
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
+        <div class="wrapper"><pre><code class="language-xml">
 &lt;module name="Checker"&gt;
   &lt;module name="TreeWalker"&gt;
     &lt;module name="NeedBraces"&gt;
@@ -194,7 +194,7 @@ class Example2 {
 &lt;/module&gt;
 </code></pre></div>
         <p id="Example3-code">Example:</p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+        <div class="wrapper"><pre><code class="language-java">
 class Example3 {
   String obj = new String();
   String value = new String();
@@ -236,7 +236,7 @@ class Example3 {
           To configure the check to allow <code>case, default</code> single-line statements
           without braces:
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
+        <div class="wrapper"><pre><code class="language-xml">
 &lt;module name="Checker"&gt;
   &lt;module name="TreeWalker"&gt;
     &lt;module name="NeedBraces"&gt;
@@ -249,7 +249,7 @@ class Example3 {
         <p id="Example4-code">
         Next statements won't be violated by check:
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+        <div class="wrapper"><pre><code class="language-java">
 class Example4 {
   String obj = new String();
   String value = new String();
@@ -291,7 +291,7 @@ class Example4 {
         <p id="Example5-config">
           To configure the check to allow loops (<code>while, for</code>) with empty bodies:
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
+        <div class="wrapper"><pre><code class="language-xml">
 &lt;module name="Checker"&gt;
   &lt;module name="TreeWalker"&gt;
     &lt;module name="NeedBraces"&gt;
@@ -302,7 +302,7 @@ class Example4 {
 &lt;/module&gt;
 </code></pre></div>
         <p id="Example5-code">Example:</p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+        <div class="wrapper"><pre><code class="language-java">
 class Example5 {
   String obj = new String();
   String value = new String();
@@ -343,7 +343,7 @@ class Example5 {
         <p id="Example6-config">
           To configure the check to lambdas:
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
+        <div class="wrapper"><pre><code class="language-xml">
 &lt;module name="Checker"&gt;
   &lt;module name="TreeWalker"&gt;
     &lt;module name="NeedBraces"&gt;
@@ -354,7 +354,7 @@ class Example5 {
 &lt;/module&gt;
 </code></pre></div>
         <p id="Example6-code">Results in following:</p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+        <div class="wrapper"><pre><code class="language-java">
 class Example6 {
   enum HttpMethod {GET, OPTIONS}
   Object result = new Object();

--- a/src/site/xdoc/checks/blocks/rightcurly.xml
+++ b/src/site/xdoc/checks/blocks/rightcurly.xml
@@ -106,7 +106,7 @@
 
       <subsection name="Examples" id="Examples">
         <p id="Example1-config"> To configure the check: </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
+        <div class="wrapper"><pre><code class="language-xml">
 &lt;module name="Checker"&gt;
   &lt;module name="TreeWalker"&gt;
     &lt;module name="RightCurly"/&gt;
@@ -114,7 +114,7 @@
 &lt;/module&gt;
 </code></pre></div>
         <p id="Example1-code">Example:</p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+        <div class="wrapper"><pre><code class="language-java">
 public class Example1 {
 
   public void test() {
@@ -170,7 +170,7 @@ public class Example1 {
           METHOD_DEF</a>
           tokens:
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
+        <div class="wrapper"><pre><code class="language-xml">
 &lt;module name="Checker"&gt;
   &lt;module name="TreeWalker"&gt;
     &lt;module name="RightCurly"&gt;
@@ -181,7 +181,7 @@ public class Example1 {
 &lt;/module&gt;
 </code></pre></div>
         <p id="Example2-code">Example:</p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+        <div class="wrapper"><pre><code class="language-java">
 public class Example2 {
 
   public void test() {
@@ -224,7 +224,7 @@ public class Example2 {
           Switch</a>
           Statements and Switch Cases:
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
+        <div class="wrapper"><pre><code class="language-xml">
 &lt;module name="Checker"&gt;
   &lt;module name="TreeWalker"&gt;
     &lt;module name="RightCurly"&gt;
@@ -235,7 +235,7 @@ public class Example2 {
 &lt;/module&gt;
 </code></pre></div>
         <p id="Example3-code">Example:</p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+        <div class="wrapper"><pre><code class="language-java">
 class Example3 {
 
   public void method0() {
@@ -271,7 +271,7 @@ class Example3 {
           METHOD_DEF</a>
           tokens:
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
+        <div class="wrapper"><pre><code class="language-xml">
 &lt;module name="Checker"&gt;
   &lt;module name="TreeWalker"&gt;
     &lt;module name="RightCurly"&gt;
@@ -282,7 +282,7 @@ class Example3 {
 &lt;/module&gt;
 </code></pre></div>
         <p id="Example4-code">Example:</p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+        <div class="wrapper"><pre><code class="language-java">
 public class Example4 {
 
   public void test() {
@@ -321,7 +321,7 @@ public class Example4 {
           Switch</a>
           Statements and Switch Cases:
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
+        <div class="wrapper"><pre><code class="language-xml">
 &lt;module name="Checker"&gt;
   &lt;module name="TreeWalker"&gt;
     &lt;module name="RightCurly"&gt;
@@ -332,7 +332,7 @@ public class Example4 {
 &lt;/module&gt;
 </code></pre></div>
         <p id="Example5-code">Example:</p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+        <div class="wrapper"><pre><code class="language-java">
 class Example5 {
 
   public void method0() {

--- a/src/site/xdoc/checks/coding/arraytrailingcomma.xml
+++ b/src/site/xdoc/checks/coding/arraytrailingcomma.xml
@@ -105,7 +105,7 @@ return new int[] {
         <p id="Example1-config">
           To configure the check:
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
+        <div class="wrapper"><pre><code class="language-xml">
 &lt;module name="Checker"&gt;
   &lt;module name="TreeWalker"&gt;
     &lt;module name="ArrayTrailingComma"/&gt;
@@ -115,7 +115,7 @@ return new int[] {
         <p id="Example1-code">
           Which results in the following violations:
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+        <div class="wrapper"><pre><code class="language-java">
 public class Example1 {
   int[] numbers = {1, 2, 3};
   boolean[] bools = {
@@ -152,7 +152,7 @@ public class Example1 {
 </code></pre></div>
 
         <p id="Example2-config">To configure check to always validate trailing comma:</p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
+        <div class="wrapper"><pre><code class="language-xml">
 &lt;module name="Checker"&gt;
   &lt;module name="TreeWalker"&gt;
     &lt;module name="ArrayTrailingComma"&gt;
@@ -162,7 +162,7 @@ public class Example1 {
 &lt;/module&gt;
 </code></pre></div>
         <p id="Example2-code">Example:</p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+        <div class="wrapper"><pre><code class="language-java">
 public class Example2 {
   int[] numbers = {1, 2, 3}; // violation 'Array should contain trailing comma.'
   boolean[] bools = {

--- a/src/site/xdoc/checks/coding/avoiddoublebraceinitialization.xml
+++ b/src/site/xdoc/checks/coding/avoiddoublebraceinitialization.xml
@@ -35,7 +35,7 @@
         <p id="Example1-config">
           To configure the check:
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
+        <div class="wrapper"><pre><code class="language-xml">
 &lt;module name="Checker"&gt;
   &lt;module name="TreeWalker"&gt;
     &lt;module name="AvoidDoubleBraceInitialization"/&gt;
@@ -45,7 +45,7 @@
         <p id="Example1-code">
           Which results in the following violations:
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+        <div class="wrapper"><pre><code class="language-java">
 class Example1 {
   // violation below 'Avoid double brace initialization.'
   List&lt;Integer&gt; list1 = new ArrayList&lt;&gt;() {

--- a/src/site/xdoc/checks/coding/avoidinlineconditionals.xml
+++ b/src/site/xdoc/checks/coding/avoidinlineconditionals.xml
@@ -27,7 +27,7 @@ String b = (a==null || a.length()&lt;1) ? null : a.substring(1);
         <p id="Example1-config">
           To configure the check:
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
+        <div class="wrapper"><pre><code class="language-xml">
 &lt;module name="Checker"&gt;
   &lt;module name="TreeWalker"&gt;
     &lt;module name="AvoidInlineConditionals"/&gt;
@@ -35,7 +35,7 @@ String b = (a==null || a.length()&lt;1) ? null : a.substring(1);
 &lt;/module&gt;
 </code></pre></div>
         <p id="Example1-code">Example:</p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+        <div class="wrapper"><pre><code class="language-java">
 public class Example1 {
   public void InvalidExample( String str) {
     int x = 5;

--- a/src/site/xdoc/checks/coding/avoidnoargumentsuperconstructorcall.xml
+++ b/src/site/xdoc/checks/coding/avoidnoargumentsuperconstructorcall.xml
@@ -22,7 +22,7 @@
         <p id="Example1-config">
           To configure the check:
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
+        <div class="wrapper"><pre><code class="language-xml">
 &lt;module name="Checker"&gt;
   &lt;module name="TreeWalker"&gt;
     &lt;module name="AvoidNoArgumentSuperConstructorCall"/&gt;
@@ -32,7 +32,7 @@
         <p id="Example1-code">
           Example of violations
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+        <div class="wrapper"><pre><code class="language-java">
 class SuperClass {
   public SuperClass() {}
   public SuperClass(int arg) {}

--- a/src/site/xdoc/checks/coding/constructorsdeclarationgrouping.xml
+++ b/src/site/xdoc/checks/coding/constructorsdeclarationgrouping.xml
@@ -28,7 +28,7 @@
 
       <subsection name="Examples" id="Examples">
         <p id="Example1-config">To configure the check:</p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
+        <div class="wrapper"><pre><code class="language-xml">
 &lt;module name="Checker"&gt;
   &lt;module name="TreeWalker"&gt;
     &lt;module name="ConstructorsDeclarationGrouping"/&gt;
@@ -36,7 +36,7 @@
 &lt;/module&gt;
 </code></pre></div>
         <p id="Example1-code">Example of correct grouping of constructors:</p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+        <div class="wrapper"><pre><code class="language-java">
 public class Example1 {
 
   int x;
@@ -69,7 +69,7 @@ public class Example1 {
 }
 </code></pre></div>
         <p id="Example2-code">Example of incorrect grouping of constructors:</p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+        <div class="wrapper"><pre><code class="language-java">
 public class Example2 {
 
   int x;

--- a/src/site/xdoc/checks/coding/covariantequals.xml
+++ b/src/site/xdoc/checks/coding/covariantequals.xml
@@ -67,7 +67,7 @@ public boolean equals(Foo obj) {...}
         <p id="Example1-config">
           To configure the check:
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
+        <div class="wrapper"><pre><code class="language-xml">
 &lt;module name="Checker"&gt;
   &lt;module name="TreeWalker"&gt;
     &lt;module name="CovariantEquals"/&gt;
@@ -78,7 +78,7 @@ public boolean equals(Foo obj) {...}
         <p id="Example1-code">
           For example:
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+        <div class="wrapper"><pre><code class="language-java">
 public class Example1 {
   public boolean equals(Example1 same) {  // violation
     return false;
@@ -94,7 +94,7 @@ public class Example1 {
         <p id="Example2-code">
           The same class without violations:
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+        <div class="wrapper"><pre><code class="language-java">
 public class Example2 {
   public boolean equals(Example2 same) {  // no violation
     return false;

--- a/src/site/xdoc/checks/coding/declarationorder.xml
+++ b/src/site/xdoc/checks/coding/declarationorder.xml
@@ -92,7 +92,7 @@ public class A {
         <p id="Example1-config">
           To configure the check:
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
+        <div class="wrapper"><pre><code class="language-xml">
 &lt;module name="Checker"&gt;
   &lt;module name="TreeWalker"&gt;
     &lt;module name="DeclarationOrder"/&gt;
@@ -100,7 +100,7 @@ public class A {
 &lt;/module&gt;
 </code></pre></div>
         <p id="Example1-code">Example:</p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+        <div class="wrapper"><pre><code class="language-java">
 public class Example1 {
 
   public int a;
@@ -125,7 +125,7 @@ public class Example1 {
         <p id="Example2-config">
           To configure the check to ignore validation of constructors:
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
+        <div class="wrapper"><pre><code class="language-xml">
 &lt;module name="Checker"&gt;
   &lt;module name="TreeWalker"&gt;
     &lt;module name="DeclarationOrder"&gt;
@@ -135,7 +135,7 @@ public class Example1 {
 &lt;/module&gt;
 </code></pre></div>
         <p id="Example2-code">Example:</p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+        <div class="wrapper"><pre><code class="language-java">
 public class Example2 {
 
   public int a;
@@ -160,7 +160,7 @@ public class Example2 {
         <p id="Example3-config">
           To configure the check to ignore modifiers:
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
+        <div class="wrapper"><pre><code class="language-xml">
 &lt;module name="Checker"&gt;
   &lt;module name="TreeWalker"&gt;
     &lt;module name="DeclarationOrder"&gt;
@@ -170,7 +170,7 @@ public class Example2 {
 &lt;/module&gt;
 </code></pre></div>
         <p id="Example3-code">Example:</p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+        <div class="wrapper"><pre><code class="language-java">
 public class Example3 {
 
   public int a;

--- a/src/site/xdoc/checks/coding/defaultcomeslast.xml
+++ b/src/site/xdoc/checks/coding/defaultcomeslast.xml
@@ -44,7 +44,7 @@
         <p id="Example1-config">
           To configure the check:
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
+        <div class="wrapper"><pre><code class="language-xml">
 &lt;module name="Checker"&gt;
   &lt;module name="TreeWalker"&gt;
     &lt;module name="DefaultComesLast"/&gt;
@@ -54,7 +54,7 @@
         <p id="Example1-code">
           Example:
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+        <div class="wrapper"><pre><code class="language-java">
 public class Example1 {
 
   public void method() {
@@ -103,7 +103,7 @@ public class Example1 {
         <p id="Example2-config">
           To configure the check to allow default label to be not last if it is shared with case:
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
+        <div class="wrapper"><pre><code class="language-xml">
 &lt;module name="Checker"&gt;
   &lt;module name="TreeWalker"&gt;
     &lt;module name="DefaultComesLast"&gt;
@@ -115,7 +115,7 @@ public class Example1 {
         <p id="Example2-code">
           Example:
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+        <div class="wrapper"><pre><code class="language-java">
 public class Example2 {
 
   public void method() {

--- a/src/site/xdoc/checks/coding/emptystatement.xml
+++ b/src/site/xdoc/checks/coding/emptystatement.xml
@@ -19,7 +19,7 @@
         <p id="Example1-config">
           To configure the check:
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
+        <div class="wrapper"><pre><code class="language-xml">
 &lt;module name="Checker"&gt;
   &lt;module name="TreeWalker"&gt;
     &lt;module name="EmptyStatement"/&gt;
@@ -29,7 +29,7 @@
         <p id="Example1-code">
             Example:
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+        <div class="wrapper"><pre><code class="language-java">
 public class Example1 {
   public void foo() {
     int i = 5;

--- a/src/site/xdoc/checks/coding/equalsavoidnull.xml
+++ b/src/site/xdoc/checks/coding/equalsavoidnull.xml
@@ -51,7 +51,7 @@
         <p id="Example1-config">
           To configure the check:
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
+        <div class="wrapper"><pre><code class="language-xml">
 &lt;module name="Checker"&gt;
   &lt;module name="TreeWalker"&gt;
     &lt;module name="EqualsAvoidNull"/&gt;
@@ -61,7 +61,7 @@
         <p id="Example1-code">
          Example:
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+        <div class="wrapper"><pre><code class="language-java">
 public class Example1 {
   public void foo() {
     String nullString = null;
@@ -79,7 +79,7 @@ public class Example1 {
         <p id="Example2-config">
          To configure the check to allow ignoreEqualsIgnoreCase:
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
+        <div class="wrapper"><pre><code class="language-xml">
 &lt;module name="Checker"&gt;
   &lt;module name="TreeWalker"&gt;
     &lt;module name="EqualsAvoidNull"&gt;
@@ -91,7 +91,7 @@ public class Example1 {
         <p id="Example2-code">
          Example:
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+        <div class="wrapper"><pre><code class="language-java">
 public class Example2 {
   public void foo() {
     String nullString = null;

--- a/src/site/xdoc/checks/coding/equalshashcode.xml
+++ b/src/site/xdoc/checks/coding/equalshashcode.xml
@@ -31,7 +31,7 @@
         <p id="Example1-config">
           To configure the check:
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
+        <div class="wrapper"><pre><code class="language-xml">
 &lt;module name="Checker"&gt;
   &lt;module name="TreeWalker"&gt;
     &lt;module name="EqualsHashCode"/&gt;
@@ -39,7 +39,7 @@
 &lt;/module&gt;
 </code></pre></div>
         <p id="Example1-code">Example:</p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+        <div class="wrapper"><pre><code class="language-java">
 class Example1 {
   public int hashCode() { // violation, no valid 'equals'
     return 0;

--- a/src/site/xdoc/checks/coding/explicitinitialization.xml
+++ b/src/site/xdoc/checks/coding/explicitinitialization.xml
@@ -49,7 +49,7 @@
         <p id="Example1-config">
           To configure the check:
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
+        <div class="wrapper"><pre><code class="language-xml">
 &lt;module name="Checker"&gt;
   &lt;module name="TreeWalker"&gt;
     &lt;module name="ExplicitInitialization"/&gt;
@@ -57,7 +57,7 @@
 &lt;/module&gt;
 </code></pre></div>
         <p id="Example1-code">Example:</p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+        <div class="wrapper"><pre><code class="language-java">
 public class Example1 {
   private int intField1 = 0; // violation
   private int intField2 = 1;
@@ -84,7 +84,7 @@ public class Example1 {
           To configure the check so that it only checks
           for objects that explicitly initialize to null:
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
+        <div class="wrapper"><pre><code class="language-xml">
 &lt;module name="Checker"&gt;
   &lt;module name="TreeWalker"&gt;
     &lt;module name="ExplicitInitialization"&gt;
@@ -94,7 +94,7 @@ public class Example1 {
 &lt;/module&gt;
 </code></pre></div>
         <p id="Example2-code">Example:</p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+        <div class="wrapper"><pre><code class="language-java">
 public class Example2 {
   private int intField1 = 0; // ignored
   private int intField2 = 1;

--- a/src/site/xdoc/checks/coding/fallthrough.xml
+++ b/src/site/xdoc/checks/coding/fallthrough.xml
@@ -68,7 +68,7 @@
         <p id="Example1-config">
           To configure the check:
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
+        <div class="wrapper"><pre><code class="language-xml">
 &lt;module name="Checker"&gt;
   &lt;module name="TreeWalker"&gt;
     &lt;module name="FallThrough"/&gt;
@@ -78,7 +78,7 @@
         <p id="Example1-code">
           Example:
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+        <div class="wrapper"><pre><code class="language-java">
 class Example1 {
   public void foo() throws Exception {
     int i = 0;
@@ -112,7 +112,7 @@ class Example1 {
         <p id="Example2-config">
             To configure the check to enable check for last case group:
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
+        <div class="wrapper"><pre><code class="language-xml">
 &lt;module name="Checker"&gt;
   &lt;module name="TreeWalker"&gt;
     &lt;module name="FallThrough"&gt;
@@ -124,7 +124,7 @@ class Example1 {
         <p id="Example2-code">
             Example:
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+        <div class="wrapper"><pre><code class="language-java">
 class Example2 {
   public void foo() throws Exception {
     int i = 0;
@@ -157,7 +157,7 @@ class Example2 {
         <p id="Example3-config">
             To configure the check with custom relief pattern:
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
+        <div class="wrapper"><pre><code class="language-xml">
 &lt;module name="Checker"&gt;
   &lt;module name="TreeWalker"&gt;
     &lt;module name="FallThrough"&gt;
@@ -167,7 +167,7 @@ class Example2 {
 &lt;/module&gt;
 </code></pre></div>
         <p id="Example3-code">Example:</p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+        <div class="wrapper"><pre><code class="language-java">
 class Example3 {
   public void foo() throws Exception {
     int i = 0;

--- a/src/site/xdoc/checks/coding/finallocalvariable.xml
+++ b/src/site/xdoc/checks/coding/finallocalvariable.xml
@@ -74,7 +74,7 @@
         <p id="Example1-config">
           To configure the check:
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
+        <div class="wrapper"><pre><code class="language-xml">
 &lt;module name="Checker"&gt;
   &lt;module name="TreeWalker"&gt;
     &lt;module name="FinalLocalVariable"/&gt;
@@ -82,7 +82,7 @@
 &lt;/module&gt;
 </code></pre></div>
         <p id="Example1-code">Example:</p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+        <div class="wrapper"><pre><code class="language-java">
 class Example1
 {
   static int foo(int x, int y) {
@@ -103,7 +103,7 @@ class Example1
           To configure the check so that it checks local variables and
           parameters:
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
+        <div class="wrapper"><pre><code class="language-xml">
 &lt;module name="Checker"&gt;
   &lt;module name="TreeWalker"&gt;
     &lt;module name="FinalLocalVariable"&gt;
@@ -113,7 +113,7 @@ class Example1
 &lt;/module&gt;
 </code></pre></div>
         <p id="Example2-code">Example:</p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+        <div class="wrapper"><pre><code class="language-java">
 class Example2
 {
   static int foo(int x, int y) {
@@ -145,7 +145,7 @@ class Example2
           An example of how to configure the check so that it also validates enhanced For Loop
           Variable is:
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
+        <div class="wrapper"><pre><code class="language-xml">
 &lt;module name="Checker"&gt;
   &lt;module name="TreeWalker"&gt;
     &lt;module name="FinalLocalVariable"&gt;
@@ -156,7 +156,7 @@ class Example2
 &lt;/module&gt;
 </code></pre></div>
         <p id="Example3-code">Example:</p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+        <div class="wrapper"><pre><code class="language-java">
 class Example3
 {
   static int foo(int x, int y) {
@@ -177,7 +177,7 @@ class Example3
           An example of how to configure check on local variables and parameters
           but do not validate loop variables:
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
+        <div class="wrapper"><pre><code class="language-xml">
 &lt;module name="Checker"&gt;
   &lt;module name="TreeWalker"&gt;
     &lt;module name="FinalLocalVariable"&gt;
@@ -188,7 +188,7 @@ class Example3
 &lt;/module&gt;
 </code></pre></div>
         <p id="Example4-code">Example:</p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+        <div class="wrapper"><pre><code class="language-java">
 class Example4
 {
   static int foo(int x, int y) {

--- a/src/site/xdoc/checks/coding/hiddenfield.xml
+++ b/src/site/xdoc/checks/coding/hiddenfield.xml
@@ -135,7 +135,7 @@ class PageBuilder {
         <p id="Example1-config">
           To configure the check:
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
+        <div class="wrapper"><pre><code class="language-xml">
 &lt;module name="Checker"&gt;
   &lt;module name="TreeWalker"&gt;
     &lt;module name="HiddenField"/&gt;
@@ -143,7 +143,7 @@ class PageBuilder {
 &lt;/module&gt;
 </code></pre></div>
         <p id="Example1-code">Example:</p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+        <div class="wrapper"><pre><code class="language-java">
 class Example1 {
 
   private String field;
@@ -171,7 +171,7 @@ class Example1 {
           To configure the check so that it checks local variables but not
           parameters:
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
+        <div class="wrapper"><pre><code class="language-xml">
 &lt;module name="Checker"&gt;
   &lt;module name="TreeWalker"&gt;
     &lt;module name="HiddenField"&gt;
@@ -181,7 +181,7 @@ class Example1 {
 &lt;/module&gt;
 </code></pre></div>
         <p id="Example2-code">Example:</p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+        <div class="wrapper"><pre><code class="language-java">
 class Example2 {
 
   private String field;
@@ -209,7 +209,7 @@ class Example2 {
           To configure the check so that it ignores the variables and parameters named
           &quot;test&quot;:
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
+        <div class="wrapper"><pre><code class="language-xml">
 &lt;module name="Checker"&gt;
   &lt;module name="TreeWalker"&gt;
     &lt;module name="HiddenField"&gt;
@@ -219,7 +219,7 @@ class Example2 {
 &lt;/module&gt;
 </code></pre></div>
         <p id="Example3-code">Example:</p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+        <div class="wrapper"><pre><code class="language-java">
 class Example3 {
 
   private String field;
@@ -246,7 +246,7 @@ class Example3 {
         <p id="Example4-config">
           To configure the check so that it ignores constructor parameters:
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
+        <div class="wrapper"><pre><code class="language-xml">
 &lt;module name="Checker"&gt;
   &lt;module name="TreeWalker"&gt;
     &lt;module name="HiddenField"&gt;
@@ -256,7 +256,7 @@ class Example3 {
 &lt;/module&gt;
 </code></pre></div>
         <p id="Example4-code">Example:</p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+        <div class="wrapper"><pre><code class="language-java">
 class Example4 {
 
   private String field;
@@ -284,7 +284,7 @@ class Example4 {
           To configure the check so that it ignores the parameter of setter
           methods:
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
+        <div class="wrapper"><pre><code class="language-xml">
 &lt;module name="Checker"&gt;
   &lt;module name="TreeWalker"&gt;
     &lt;module name="HiddenField"&gt;
@@ -294,7 +294,7 @@ class Example4 {
 &lt;/module&gt;
 </code></pre></div>
         <p id="Example5-code">Example:</p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+        <div class="wrapper"><pre><code class="language-java">
 class Example5 {
 
   private String field;
@@ -323,7 +323,7 @@ class Example5 {
           methods recognizing setter as returning either <code>void</code> or
           a class in which it is declared:
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
+        <div class="wrapper"><pre><code class="language-xml">
 &lt;module name="Checker"&gt;
   &lt;module name="TreeWalker"&gt;
     &lt;module name="HiddenField"&gt;
@@ -334,7 +334,7 @@ class Example5 {
 &lt;/module&gt;
 </code></pre></div>
         <p id="Example6-code">Example:</p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+        <div class="wrapper"><pre><code class="language-java">
 class Example6 {
 
   private String field;
@@ -360,7 +360,7 @@ class Example6 {
         <p id="Example7-config">
           To configure the check so that it ignores parameters of abstract methods:
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
+        <div class="wrapper"><pre><code class="language-xml">
 &lt;module name="Checker"&gt;
   &lt;module name="TreeWalker"&gt;
     &lt;module name="HiddenField"&gt;
@@ -370,7 +370,7 @@ class Example6 {
 &lt;/module&gt;
 </code></pre></div>
         <p id="Example7-code">Example:</p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+        <div class="wrapper"><pre><code class="language-java">
 class Example7 {
 
   private String field;

--- a/src/site/xdoc/checks/coding/illegalcatch.xml
+++ b/src/site/xdoc/checks/coding/illegalcatch.xml
@@ -49,7 +49,7 @@
         <p id="Example1-config">
           To configure the check:
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
+        <div class="wrapper"><pre><code class="language-xml">
 &lt;module name="Checker"&gt;
   &lt;module name="TreeWalker"&gt;
     &lt;module name="IllegalCatch"/&gt;
@@ -59,7 +59,7 @@
         <p id="Example1-code">
           Example:
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+        <div class="wrapper"><pre><code class="language-java">
 class Example1 {
   void exampleMethod1() {
     try {
@@ -109,7 +109,7 @@ class Example1 {
           To configure the check to override the default list with
           ArithmeticException and OutOfMemoryError:
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
+        <div class="wrapper"><pre><code class="language-xml">
 &lt;module name="Checker"&gt;
   &lt;module name="TreeWalker"&gt;
     &lt;module name="IllegalCatch"&gt;
@@ -122,7 +122,7 @@ class Example1 {
         <p id="Example2-code">
             Example:
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+        <div class="wrapper"><pre><code class="language-java">
 class Example2 {
   void exampleMethod1() {
     try {

--- a/src/site/xdoc/checks/coding/illegalinstantiation.xml
+++ b/src/site/xdoc/checks/coding/illegalinstantiation.xml
@@ -67,7 +67,7 @@
         <p id="Example1-config">
           To configure the check:
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
+        <div class="wrapper"><pre><code class="language-xml">
 &lt;module name="Checker"&gt;
   &lt;module name="TreeWalker"&gt;
     &lt;module name="IllegalInstantiation"/&gt;
@@ -75,7 +75,7 @@
 &lt;/module&gt;
 </code></pre></div>
         <p id="Example1-code">Example:</p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+        <div class="wrapper"><pre><code class="language-java">
 class Example1 {
   class Boolean {
     boolean a;
@@ -101,7 +101,7 @@ class Example1 {
           To configure the check to find instantiations of <code>java.lang.Boolean</code>
           and <code>java.lang.Integer</code>:
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
+        <div class="wrapper"><pre><code class="language-xml">
 &lt;module name="Checker"&gt;
   &lt;module name="TreeWalker"&gt;
     &lt;module name="IllegalInstantiation"&gt;
@@ -112,7 +112,7 @@ class Example1 {
 &lt;/module&gt;
 </code></pre></div>
         <p id="Example2-code">Example:</p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+        <div class="wrapper"><pre><code class="language-java">
 class Example2 {
   class Boolean {
     boolean a;
@@ -137,7 +137,7 @@ class Example2 {
         <p id="Example3-config">
           Finally, there is a limitation that it is currently not possible to specify array classes:
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
+        <div class="wrapper"><pre><code class="language-xml">
 &lt;module name="Checker"&gt;
   &lt;module name="TreeWalker"&gt;
     &lt;module name="IllegalInstantiation"&gt;
@@ -148,7 +148,7 @@ class Example2 {
 &lt;/module&gt;
 </code></pre></div>
         <p id="Example3-code">Example:</p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+        <div class="wrapper"><pre><code class="language-java">
 class Example3 {
   class Boolean {
     boolean a;

--- a/src/site/xdoc/checks/coding/illegalthrows.xml
+++ b/src/site/xdoc/checks/coding/illegalthrows.xml
@@ -55,7 +55,7 @@
         <p id="Example1-config">
           To configure the check:
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
+        <div class="wrapper"><pre><code class="language-xml">
 &lt;module name="Checker"&gt;
   &lt;module name="TreeWalker"&gt;
     &lt;module name="IllegalThrows"/&gt;
@@ -63,7 +63,7 @@
 &lt;/module&gt;
 </code></pre></div>
         <p id="Example1-code">Example:</p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+        <div class="wrapper"><pre><code class="language-java">
 public class Example1 {
   // violation below, 'Throwing 'RuntimeException' is not allowed'
   void f1() throws RuntimeException {}
@@ -81,7 +81,7 @@ public class Example1 {
         <p id="Example2-config">
           To configure the check rejecting throws NullPointerException from methods:
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
+        <div class="wrapper"><pre><code class="language-xml">
 &lt;module name="Checker"&gt;
   &lt;module name="TreeWalker"&gt;
     &lt;module name="IllegalThrows"&gt;
@@ -91,7 +91,7 @@ public class Example1 {
 &lt;/module&gt;
 </code></pre></div>
         <p id="Example2-code">Example:</p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+        <div class="wrapper"><pre><code class="language-java">
 public class Example2 {
   void f1() throws RuntimeException {}
   void f2() throws Exception {}
@@ -109,7 +109,7 @@ public class Example2 {
         <p id="Example3-config">
           To configure the check ignoring method named &quot;func1()&quot;:
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
+        <div class="wrapper"><pre><code class="language-xml">
 &lt;module name="Checker"&gt;
   &lt;module name="TreeWalker"&gt;
     &lt;module name="IllegalThrows"&gt;
@@ -119,7 +119,7 @@ public class Example2 {
 &lt;/module&gt;
 </code></pre></div>
         <p id="Example3-code">Example:</p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+        <div class="wrapper"><pre><code class="language-java">
 public class Example3 {
   void f1() throws RuntimeException {}
   void f2() throws Exception {}
@@ -136,7 +136,7 @@ public class Example3 {
         <p id="Example4-config">
           To configure the check to warn on overridden methods:
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
+        <div class="wrapper"><pre><code class="language-xml">
 &lt;module name="Checker"&gt;
   &lt;module name="TreeWalker"&gt;
     &lt;module name="IllegalThrows"&gt;
@@ -146,7 +146,7 @@ public class Example3 {
 &lt;/module&gt;
 </code></pre></div>
         <p id="Example4-code">Example:</p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+        <div class="wrapper"><pre><code class="language-java">
 public class Example4 {
   // violation below, 'Throwing 'RuntimeException' is not allowed'
   void f1() throws RuntimeException {}

--- a/src/site/xdoc/checks/coding/illegaltoken.xml
+++ b/src/site/xdoc/checks/coding/illegaltoken.xml
@@ -53,7 +53,7 @@
         <p id="Example1-config">
           To configure the check:
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
+        <div class="wrapper"><pre><code class="language-xml">
 &lt;module name="Checker"&gt;
   &lt;module name="TreeWalker"&gt;
     &lt;module name="IllegalToken"/&gt;
@@ -61,7 +61,7 @@
 &lt;/module&gt;
 </code></pre></div>
         <p id="Example1-code">Example:</p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+        <div class="wrapper"><pre><code class="language-java">
 class Example1 {
   void InvalidExample() {
     outer: // violation, 'Using 'outer:' is not allowed'
@@ -76,7 +76,7 @@ class Example1 {
         <p id="Example2-config">
           To configure the check to report violation on token LITERAL_NATIVE:
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
+        <div class="wrapper"><pre><code class="language-xml">
 &lt;module name="Checker"&gt;
   &lt;module name="TreeWalker"&gt;
     &lt;module name="IllegalToken"&gt;
@@ -86,7 +86,7 @@ class Example1 {
 &lt;/module&gt;
 </code></pre></div>
         <p id="Example2-code">Example:</p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+        <div class="wrapper"><pre><code class="language-java">
 class Example2 {
   native void InvalidExample(); // violation, 'Using 'native' is not allowed'
 }

--- a/src/site/xdoc/checks/coding/illegaltokentext.xml
+++ b/src/site/xdoc/checks/coding/illegaltokentext.xml
@@ -82,7 +82,7 @@
           To configure the check to forbid String literals containing
           <code>&quot;a href&quot;</code>:
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
+        <div class="wrapper"><pre><code class="language-xml">
 &lt;module name="Checker"&gt;
   &lt;module name="TreeWalker"&gt;
     &lt;module name="IllegalTokenText"&gt;
@@ -93,7 +93,7 @@
 &lt;/module&gt;
 </code></pre></div>
         <p id="Example1-code">Example:</p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+        <div class="wrapper"><pre><code class="language-java">
 public class Example1 {
   public void myTest() {
     String test  = "a href"; // violation
@@ -105,7 +105,7 @@ public class Example1 {
           To configure the check to forbid String literals containing
           <code>&quot;a href&quot;</code> for the ignoreCase mode:
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
+        <div class="wrapper"><pre><code class="language-xml">
 &lt;module name="Checker"&gt;
   &lt;module name="TreeWalker"&gt;
     &lt;module name="IllegalTokenText"&gt;
@@ -117,7 +117,7 @@ public class Example1 {
 &lt;/module&gt;
 </code></pre></div>
         <p id="Example2-code">Example:</p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+        <div class="wrapper"><pre><code class="language-java">
 public class Example2 {
   public void myTest() {
     String test  = "a href"; // violation
@@ -129,7 +129,7 @@ public class Example2 {
           To configure the check to forbid string literal text blocks containing
           <code>&quot;</code>:
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
+        <div class="wrapper"><pre><code class="language-xml">
 &lt;module name="Checker"&gt;
   &lt;module name="TreeWalker"&gt;
     &lt;module name="IllegalTokenText"&gt;
@@ -140,7 +140,7 @@ public class Example2 {
 &lt;/module&gt;
 </code></pre></div>
         <p id="Example3-code">Example:</p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+        <div class="wrapper"><pre><code class="language-java">
 public class Example3 {
   public void myTest() {
     final String quote = """
@@ -152,7 +152,7 @@ public class Example3 {
           To configure the check to forbid leading zeros in an integer
           literal, other than zero and a hex literal:
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
+        <div class="wrapper"><pre><code class="language-xml">
 &lt;module name="Checker"&gt;
   &lt;module name="TreeWalker"&gt;
     &lt;module name="IllegalTokenText"&gt;
@@ -164,7 +164,7 @@ public class Example3 {
 &lt;/module&gt;
 </code></pre></div>
         <p id="Example4-code">Example:</p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+        <div class="wrapper"><pre><code class="language-java">
 public class Example4 {
   public void myTest() {
     int test1 = 0; // OK

--- a/src/site/xdoc/checks/coding/illegaltype.xml
+++ b/src/site/xdoc/checks/coding/illegaltype.xml
@@ -179,7 +179,7 @@ List list; //No violation here
         <p id="Example1-config">
             To configure the default check:
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
+        <div class="wrapper"><pre><code class="language-xml">
 &lt;module name="Checker"&gt;
   &lt;module name="TreeWalker"&gt;
     &lt;module name="IllegalType"/&gt;
@@ -187,7 +187,7 @@ List list; //No violation here
 &lt;/module&gt;
 </code></pre></div>
         <p id="Example1-code">Example:</p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+        <div class="wrapper"><pre><code class="language-java">
 // violation below 'Usage of type 'TreeSet' is not allowed'
 public class Example1 extends TreeSet {
   // violation below 'Usage of type 'java.util.HashSet' is not allowed'
@@ -247,7 +247,7 @@ public class Example1 extends TreeSet {
         <p id="Example2-config">
           To configure the Check so that particular tokens are checked:
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
+        <div class="wrapper"><pre><code class="language-xml">
 &lt;module name="Checker"&gt;
   &lt;module name="TreeWalker"&gt;
     &lt;module name="IllegalType"&gt;
@@ -257,7 +257,7 @@ public class Example1 extends TreeSet {
 &lt;/module&gt;
 </code></pre></div>
         <p id="Example2-code">Example:</p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+        <div class="wrapper"><pre><code class="language-java">
 public class Example2 extends TreeSet {
   // violation below 'Usage of type 'java.util.HashSet' is not allowed'
   public &lt;T extends java.util.HashSet&gt; void method() {
@@ -316,7 +316,7 @@ public class Example2 extends TreeSet {
         <p id="Example3-config">
           To configure the Check so that it ignores function() methods:
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
+        <div class="wrapper"><pre><code class="language-xml">
 &lt;module name="Checker"&gt;
   &lt;module name="TreeWalker"&gt;
     &lt;module name="IllegalType"&gt;
@@ -326,7 +326,7 @@ public class Example2 extends TreeSet {
 &lt;/module&gt;
 </code></pre></div>
         <p id="Example3-code">Example:</p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+        <div class="wrapper"><pre><code class="language-java">
 // violation below 'Usage of type 'TreeSet' is not allowed'
 public class Example3 extends TreeSet {
   // violation below 'Usage of type 'java.util.HashSet' is not allowed'
@@ -386,7 +386,7 @@ public class Example3 extends TreeSet {
         <p id="Example4-config">
           To configure the Check so that it validates abstract class names:
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
+        <div class="wrapper"><pre><code class="language-xml">
 &lt;module name="Checker"&gt;
   &lt;module name="TreeWalker"&gt;
     &lt;module name="IllegalType"&gt;
@@ -397,7 +397,7 @@ public class Example3 extends TreeSet {
 &lt;/module&gt;
 </code></pre></div>
         <p id="Example4-code">Example:</p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+        <div class="wrapper"><pre><code class="language-java">
 // violation below 'Usage of type 'TreeSet' is not allowed'
 public class Example4 extends TreeSet {
   // violation below 'Usage of type 'java.util.HashSet' is not allowed'
@@ -458,7 +458,7 @@ public class Example4 extends TreeSet {
           To configure the Check so that it verifies only public, protected or static
            methods and fields:
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
+        <div class="wrapper"><pre><code class="language-xml">
 &lt;module name="Checker"&gt;
   &lt;module name="TreeWalker"&gt;
     &lt;module name="IllegalType"&gt;
@@ -469,7 +469,7 @@ public class Example4 extends TreeSet {
 &lt;/module&gt;
 </code></pre></div>
         <p id="Example5-code">Example:</p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+        <div class="wrapper"><pre><code class="language-java">
 // violation below 'Usage of type 'TreeSet' is not allowed'
 public class Example5 extends TreeSet {
   // violation below 'Usage of type 'java.util.HashSet' is not allowed'
@@ -529,7 +529,7 @@ public class Example5 extends TreeSet {
         <p id="Example6-config">
           To configure the check so that it verifies usage of types Boolean and Foo:
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
+        <div class="wrapper"><pre><code class="language-xml">
 &lt;module name="Checker"&gt;
   &lt;module name="TreeWalker"&gt;
     &lt;module name="IllegalType"&gt;
@@ -540,7 +540,7 @@ public class Example5 extends TreeSet {
 </code></pre></div>
 
         <p id="Example6-code">Example:</p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+        <div class="wrapper"><pre><code class="language-java">
 public class Example6 extends TreeSet {
 
   public &lt;T extends java.util.HashSet&gt; void method() {
@@ -599,7 +599,7 @@ public class Example6 extends TreeSet {
         <p id="Example7-config">
           To configure the check to target fields types only:
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
+        <div class="wrapper"><pre><code class="language-xml">
 &lt;module name="Checker"&gt;
   &lt;module name="TreeWalker"&gt;
     &lt;module name="IllegalType"&gt;
@@ -615,7 +615,7 @@ public class Example6 extends TreeSet {
 &lt;/module&gt;
 </code></pre></div>
         <p id="Example7-code">Example:</p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+        <div class="wrapper"><pre><code class="language-java">
 public class Example7 extends TreeSet {
 
   public &lt;T extends java.util.HashSet&gt; void method() {

--- a/src/site/xdoc/checks/coding/innerassignment.xml
+++ b/src/site/xdoc/checks/coding/innerassignment.xml
@@ -51,7 +51,7 @@ while ((line = bufferedReader.readLine()) != null); // OK
         <p id="Example1-config">
           To configure the check:
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
+        <div class="wrapper"><pre><code class="language-xml">
 &lt;module name="Checker"&gt;
   &lt;module name="TreeWalker"&gt;
     &lt;module name="InnerAssignment"/&gt;
@@ -59,7 +59,7 @@ while ((line = bufferedReader.readLine()) != null); // OK
 &lt;/module&gt;
 </code></pre></div>
         <p id="Example1-code">Example 1:</p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+        <div class="wrapper"><pre><code class="language-java">
 public class Example1 {
   void foo() throws IOException {
     int a, b;
@@ -101,7 +101,7 @@ public class Example1 {
 }
 </code></pre></div>
         <p id="Example2-code">Example 2:</p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+        <div class="wrapper"><pre><code class="language-java">
 public class Example2 {
   public void test1(int mode) {
     int x = 0;

--- a/src/site/xdoc/checks/coding/magicnumber.xml
+++ b/src/site/xdoc/checks/coding/magicnumber.xml
@@ -177,7 +177,7 @@ static final Integer ANSWER_TO_THE_ULTIMATE_QUESTION_OF_LIFE = new Integer(42);
         <p id="Example1-config">
           To configure the check with default configuration:
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
+        <div class="wrapper"><pre><code class="language-xml">
 &lt;module name="Checker"&gt;
   &lt;module name="TreeWalker"&gt;
     &lt;module name="MagicNumber"/&gt;
@@ -187,7 +187,7 @@ static final Integer ANSWER_TO_THE_ULTIMATE_QUESTION_OF_LIFE = new Integer(42);
         <p id="Example1-code">
           results in the following violations:
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+        <div class="wrapper"><pre><code class="language-java">
 @Example1.Annotation(6) // violation, ''6' is a magic number.'
 public class Example1 {
   private int field = 7; // violation, ''7' is a magic number.'
@@ -229,7 +229,7 @@ public class Example1 {
           To configure the check so that it checks floating-point numbers
           that are not 0, 0.5, or 1:
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
+        <div class="wrapper"><pre><code class="language-xml">
 &lt;module name="Checker"&gt;
   &lt;module name="TreeWalker"&gt;
     &lt;module name="MagicNumber"&gt;
@@ -244,7 +244,7 @@ public class Example1 {
         <p id="Example2-code">
           results in no violations:
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+        <div class="wrapper"><pre><code class="language-java">
 @Example2.Annotation(6)
 public class Example2 {
   private int field = 7;
@@ -284,7 +284,7 @@ public class Example2 {
         <p id="Example3-config">
           To configure the check so that it ignores magic numbers in field declarations:
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
+        <div class="wrapper"><pre><code class="language-xml">
 &lt;module name="Checker"&gt;
   &lt;module name="TreeWalker"&gt;
     &lt;module name="MagicNumber"&gt;
@@ -296,7 +296,7 @@ public class Example2 {
         <p id="Example3-code">
           results in the following violations:
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+        <div class="wrapper"><pre><code class="language-java">
 @Example3.Annotation(6) // violation, ''6' is a magic number.'
 public class Example3 {
   private int field = 7;
@@ -336,7 +336,7 @@ public class Example3 {
         <p id="Example4-config">
         To configure the check to check annotation element defaults:
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
+        <div class="wrapper"><pre><code class="language-xml">
 &lt;module name="Checker"&gt;
   &lt;module name="TreeWalker"&gt;
     &lt;module name="MagicNumber"&gt;
@@ -348,7 +348,7 @@ public class Example3 {
         <p id="Example4-code">
           results in the following violations:
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+        <div class="wrapper"><pre><code class="language-java">
 @Example4.Annotation(6) // violation, ''6' is a magic number.'
 public class Example4 {
   private int field = 7; // violation, ''7' is a magic number.'
@@ -388,7 +388,7 @@ public class Example4 {
         <p id="Example5-config">
         Config example of constantWaiverParentToken option:
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
+        <div class="wrapper"><pre><code class="language-xml">
 &lt;module name="Checker"&gt;
   &lt;module name="TreeWalker"&gt;
     &lt;module name="MagicNumber"&gt;
@@ -399,7 +399,7 @@ public class Example4 {
 &lt;/module&gt;
 </code></pre></div>
         <p id="Example5-code">results in the following violations:</p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+        <div class="wrapper"><pre><code class="language-java">
 @Example5.Annotation(6) // violation, ''6' is a magic number.'
 public class Example5 {
   private int field = 7; // violation, ''7' is a magic number.'
@@ -450,7 +450,7 @@ public class Example5 {
         <p id="Example6-config">
         Config example of ignoreHashCodeMethod option:
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
+        <div class="wrapper"><pre><code class="language-xml">
 &lt;module name="Checker"&gt;
   &lt;module name="TreeWalker"&gt;
     &lt;module name="MagicNumber"&gt;
@@ -460,7 +460,7 @@ public class Example5 {
 &lt;/module&gt;
 </code></pre></div>
         <p id="Example6-code">results in the following violations:</p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+        <div class="wrapper"><pre><code class="language-java">
 @Example6.Annotation(6) // violation, ''6' is a magic number.'
 public class Example6 {
   private int field = 7; // violation, ''7' is a magic number.'

--- a/src/site/xdoc/checks/coding/matchxpath.xml
+++ b/src/site/xdoc/checks/coding/matchxpath.xml
@@ -107,7 +107,7 @@ CLASS_DEF -&gt; CLASS_DEF [1:0]
         <p id="Example1-config">
           The following example demonstrates validation of methods order, so that public methods
           should come before the private ones:</p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
+        <div class="wrapper"><pre><code class="language-xml">
 &lt;module name="Checker"&gt;
   &lt;module name="TreeWalker"&gt;
     &lt;module name="MatchXpath"&gt;
@@ -121,7 +121,7 @@ CLASS_DEF -&gt; CLASS_DEF [1:0]
 &lt;/module&gt;
 </code></pre></div>
         <p id="Example1-code">Example:</p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+        <div class="wrapper"><pre><code class="language-java">
 public class Example1 {
   public void method1() { }
   private void method2() { } // violation
@@ -132,7 +132,7 @@ public class Example1 {
 }
 </code></pre></div>
         <p id="Example2-config">To violate if there are any parametrized constructors</p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
+        <div class="wrapper"><pre><code class="language-xml">
 &lt;module name="Checker"&gt;
   &lt;module name="TreeWalker"&gt;
     &lt;module name="MatchXpath"&gt;
@@ -145,7 +145,7 @@ public class Example1 {
 &lt;/module&gt;
 </code></pre></div>
         <p id="Example2-code">Example:</p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+        <div class="wrapper"><pre><code class="language-java">
 public class Example2 {
   public Example2(Object c) { } // violation
   public Example2(int a, HashMap&lt;String, Integer&gt; b) { } // violation
@@ -153,7 +153,7 @@ public class Example2 {
 }
 </code></pre></div>
         <p id="Example3-config">To violate if method name is 'test' or 'foo'</p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
+        <div class="wrapper"><pre><code class="language-xml">
 &lt;module name="Checker"&gt;
   &lt;module name="TreeWalker"&gt;
     &lt;module name="MatchXpath"&gt;
@@ -166,7 +166,7 @@ public class Example2 {
 &lt;/module&gt;
 </code></pre></div>
         <p id="Example3-code">Example:</p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+        <div class="wrapper"><pre><code class="language-java">
 public class Example3 {
   public void test() {} // violation
   public void getName() {}
@@ -177,7 +177,7 @@ public class Example3 {
         <p id="Example4-config">
           To violate if new instance creation was done without <b>var</b> type
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
+        <div class="wrapper"><pre><code class="language-xml">
 &lt;module name="Checker"&gt;
   &lt;module name="TreeWalker"&gt;
     &lt;module name="MatchXpath"&gt;
@@ -192,7 +192,7 @@ public class Example3 {
 &lt;/module&gt;
 </code></pre></div>
         <p id="Example4-code">Example:</p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+        <div class="wrapper"><pre><code class="language-java">
 public class Example4 {
   public void foo() {
     Object a = new Object(); // violation

--- a/src/site/xdoc/checks/coding/missingctor.xml
+++ b/src/site/xdoc/checks/coding/missingctor.xml
@@ -19,7 +19,7 @@
         <p id="Example1-config">
           To configure the check:
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
+        <div class="wrapper"><pre><code class="language-xml">
 &lt;module name="Checker"&gt;
   &lt;module name="TreeWalker"&gt;
     &lt;module name="MissingCtor"/&gt;
@@ -27,7 +27,7 @@
 &lt;/module&gt;
 </code></pre></div>
         <p id="Example1-code">Example:</p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+        <div class="wrapper"><pre><code class="language-java">
 public class Example1 {
   private int a;
   Example1(int a) {

--- a/src/site/xdoc/checks/coding/missingnullcaseinswitch.xml
+++ b/src/site/xdoc/checks/coding/missingnullcaseinswitch.xml
@@ -45,7 +45,7 @@
         <p id="Example1-config">
           To configure the check:
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
+        <div class="wrapper"><pre><code class="language-xml">
 &lt;module name="Checker"&gt;
   &lt;module name="TreeWalker"&gt;
     &lt;module name="MissingNullCaseInSwitch"/&gt;
@@ -55,7 +55,7 @@
         <p id="Example1-code">
           Example of violation:
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+        <div class="wrapper"><pre><code class="language-java">
 public class Example1 {
 
   void testString(String obj) {

--- a/src/site/xdoc/checks/coding/missingswitchdefault.xml
+++ b/src/site/xdoc/checks/coding/missingswitchdefault.xml
@@ -49,7 +49,7 @@
         <p id="Example1-config">
           To configure the check:
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
+        <div class="wrapper"><pre><code class="language-xml">
 &lt;module name="Checker"&gt;
   &lt;module name="TreeWalker"&gt;
     &lt;module name="MissingSwitchDefault"/&gt;
@@ -59,7 +59,7 @@
         <p id="Example1-code">
           Example of violation:
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+        <div class="wrapper"><pre><code class="language-java">
 class Example1 {
   void Example1(int i) {
     switch (i) { // violation, 'switch without "default" clause'
@@ -85,7 +85,7 @@ class Example1 {
         <p id="Example2-code">
           Example of correct code:
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+        <div class="wrapper"><pre><code class="language-java">
 class Example2 {
   Example2(int i){
     switch (i) {
@@ -114,7 +114,7 @@ class Example2 {
         <p id="Example3-code">
           Example of correct code which does not require default labels:
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+        <div class="wrapper"><pre><code class="language-java">
 sealed interface S permits A, B, C {}
 final class A implements S {}
 final class B implements S {}

--- a/src/site/xdoc/checks/coding/modifiedcontrolvariable.xml
+++ b/src/site/xdoc/checks/coding/modifiedcontrolvariable.xml
@@ -69,7 +69,7 @@ for (int a[]={0};a[0] &lt; 10;a[0]++) {
         <p id="Example1-config">
           To configure the check:
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
+        <div class="wrapper"><pre><code class="language-xml">
 &lt;module name="Checker"&gt;
   &lt;module name="TreeWalker"&gt;
     &lt;module name="ModifiedControlVariable"/&gt;
@@ -79,7 +79,7 @@ for (int a[]={0};a[0] &lt; 10;a[0]++) {
         <p id="Example1-code">
           Example:
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+        <div class="wrapper"><pre><code class="language-java">
 class Example1 {
   void InvalidExample() {
     for(int i=0;i &lt; 8;i++) {
@@ -104,7 +104,7 @@ class Example1 {
         <p id="Example2-config">
           An example of how to configure the check so that it skips enhanced For Loop Variable is:
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
+        <div class="wrapper"><pre><code class="language-xml">
 &lt;module name="Checker"&gt;
   &lt;module name="TreeWalker"&gt;
     &lt;module name="ModifiedControlVariable"&gt;
@@ -114,7 +114,7 @@ class Example1 {
 &lt;/module&gt;
 </code></pre></div>
         <p id="Example2-code">Example:</p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+        <div class="wrapper"><pre><code class="language-java">
 class Example2 {
   void InvalidExample() {
     for(int i=0;i &lt; 8;i++) {

--- a/src/site/xdoc/checks/coding/multiplestringliterals.xml
+++ b/src/site/xdoc/checks/coding/multiplestringliterals.xml
@@ -62,7 +62,7 @@
         <p id="Example1-config">
           To configure the check:
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
+        <div class="wrapper"><pre><code class="language-xml">
 &lt;module name="Checker"&gt;
   &lt;module name="TreeWalker"&gt;
     &lt;module name="MultipleStringLiterals"/&gt;
@@ -70,7 +70,7 @@
 &lt;/module&gt;
 </code></pre></div>
         <p id="Example1-code">Example:</p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+        <div class="wrapper"><pre><code class="language-java">
 public class Example1 {
   String a = "StringContents"; // violation, "StringContents" occurs twice
   String a1 = "unchecked";
@@ -87,7 +87,7 @@ public class Example1 {
           To configure the check so that it allows two occurrences of each
           string:
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
+        <div class="wrapper"><pre><code class="language-xml">
 &lt;module name="Checker"&gt;
   &lt;module name="TreeWalker"&gt;
     &lt;module name="MultipleStringLiterals"&gt;
@@ -97,7 +97,7 @@ public class Example1 {
 &lt;/module&gt;
 </code></pre></div>
         <p id="Example2-code">Example:</p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+        <div class="wrapper"><pre><code class="language-java">
 public class Example2 {
   String a = "StringContents"; // OK, two occurrences are allowed
   String a1 = "unchecked";
@@ -113,7 +113,7 @@ public class Example2 {
         <p id="Example3-config">
           To configure the check so that it ignores &quot;, &quot; and empty strings:
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
+        <div class="wrapper"><pre><code class="language-xml">
 &lt;module name="Checker"&gt;
   &lt;module name="TreeWalker"&gt;
     &lt;module name="MultipleStringLiterals"&gt;
@@ -124,7 +124,7 @@ public class Example2 {
 &lt;/module&gt;
 </code></pre></div>
         <p id="Example3-code">Example:</p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+        <div class="wrapper"><pre><code class="language-java">
 public class Example3 {
   String a = "StringContents"; // violation, "StringContents" occurs twice
   String a1 = "unchecked";
@@ -142,7 +142,7 @@ public class Example3 {
           syntactical contexts, even in annotations like
           <code>@SuppressWarnings(&quot;unchecked&quot;)</code>:
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
+        <div class="wrapper"><pre><code class="language-xml">
 &lt;module name="Checker"&gt;
   &lt;module name="TreeWalker"&gt;
     &lt;module name="MultipleStringLiterals"&gt;
@@ -152,7 +152,7 @@ public class Example3 {
 &lt;/module&gt;
 </code></pre></div>
         <p id="Example4-code">Example:</p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+        <div class="wrapper"><pre><code class="language-java">
 public class Example4 {
   String a = "StringContents"; // violation, "StringContents" occurs twice
   String a1 = "unchecked"; // // violation, "unchecked" occurs twice

--- a/src/site/xdoc/checks/coding/multiplevariabledeclarations.xml
+++ b/src/site/xdoc/checks/coding/multiplevariabledeclarations.xml
@@ -26,7 +26,7 @@
         <p id="Example1-config">
           To configure the check:
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
+        <div class="wrapper"><pre><code class="language-xml">
 &lt;module name="Checker"&gt;
   &lt;module name="TreeWalker"&gt;
     &lt;module name="MultipleVariableDeclarations"/&gt;
@@ -36,7 +36,7 @@
         <p id="Example1-code">
           Example:
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+        <div class="wrapper"><pre><code class="language-java">
 public class Example1 {
   public void myTest() {
     int mid = 0;

--- a/src/site/xdoc/checks/coding/nestedfordepth.xml
+++ b/src/site/xdoc/checks/coding/nestedfordepth.xml
@@ -37,7 +37,7 @@
         <p id="Example1-config">
           To configure the check:
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
+        <div class="wrapper"><pre><code class="language-xml">
 &lt;module name="Checker"&gt;
   &lt;module name="TreeWalker"&gt;
     &lt;module name="NestedForDepth"/&gt;
@@ -45,7 +45,7 @@
 &lt;/module&gt;
 </code></pre></div>
         <p id="Example1-code">Example:</p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+        <div class="wrapper"><pre><code class="language-java">
 public class Example1 {
 
   public void myTest() {
@@ -78,7 +78,7 @@ public class Example1 {
         <p id="Example2-config">
           To configure the check to allow nesting depth 2:
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
+        <div class="wrapper"><pre><code class="language-xml">
 &lt;module name="Checker"&gt;
   &lt;module name="TreeWalker"&gt;
     &lt;module name="NestedForDepth"&gt;
@@ -88,7 +88,7 @@ public class Example1 {
 &lt;/module&gt;
 </code></pre></div>
         <p id="Example2-code">Example:</p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+        <div class="wrapper"><pre><code class="language-java">
 public class Example2 {
 
   public void myTest() {

--- a/src/site/xdoc/checks/coding/nestedifdepth.xml
+++ b/src/site/xdoc/checks/coding/nestedifdepth.xml
@@ -37,7 +37,7 @@
         <p id="Example1-config">
           To configure the check:
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
+        <div class="wrapper"><pre><code class="language-xml">
 &lt;module name="Checker"&gt;
   &lt;module name="TreeWalker"&gt;
     &lt;module name="NestedIfDepth"/&gt;
@@ -45,7 +45,7 @@
 &lt;/module&gt;
 </code></pre></div>
         <p id="Example1-code">Example:</p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+        <div class="wrapper"><pre><code class="language-java">
 class Example1 {
   void Example1() {
     if (true) {
@@ -87,7 +87,7 @@ class Example1 {
         <p id="Example2-config">
           To configure the check to allow nesting depth 3:
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
+        <div class="wrapper"><pre><code class="language-xml">
 &lt;module name="Checker"&gt;
   &lt;module name="TreeWalker"&gt;
     &lt;module name="NestedIfDepth"&gt;
@@ -97,7 +97,7 @@ class Example1 {
 &lt;/module&gt;
 </code></pre></div>
         <p id="Example2-code">Example:</p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+        <div class="wrapper"><pre><code class="language-java">
 class Example2 {
   void Example2() {
     if (true) {

--- a/src/site/xdoc/checks/coding/nestedtrydepth.xml
+++ b/src/site/xdoc/checks/coding/nestedtrydepth.xml
@@ -37,7 +37,7 @@
         <p id="Example1-config">
           To configure the check:
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
+        <div class="wrapper"><pre><code class="language-xml">
 &lt;module name="Checker"&gt;
   &lt;module name="TreeWalker"&gt;
     &lt;module name="NestedTryDepth"/&gt;
@@ -47,7 +47,7 @@
         <p id="Example1-code">
           Example1:
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+        <div class="wrapper"><pre><code class="language-java">
 public class Example1 {
   void testMethod() {
     try {
@@ -78,7 +78,7 @@ public class Example1 {
         <p id="Example2-config">
           To configure the check to allow nesting depth 3:
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
+        <div class="wrapper"><pre><code class="language-xml">
 &lt;module name="Checker"&gt;
   &lt;module name="TreeWalker"&gt;
     &lt;module name="NestedTryDepth"&gt;
@@ -90,7 +90,7 @@ public class Example1 {
         <p id="Example2-code">
           Example2:
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+        <div class="wrapper"><pre><code class="language-java">
 public class Example2 {
   void testMethod() {
     try {

--- a/src/site/xdoc/checks/coding/noarraytrailingcomma.xml
+++ b/src/site/xdoc/checks/coding/noarraytrailingcomma.xml
@@ -35,7 +35,7 @@ String[] foo = new String[] {
         <p id="Example1-config">
           To configure the check:
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
+        <div class="wrapper"><pre><code class="language-xml">
 &lt;module name="Checker"&gt;
   &lt;module name="TreeWalker"&gt;
     &lt;module name="NoArrayTrailingComma"/&gt;
@@ -45,7 +45,7 @@ String[] foo = new String[] {
         <p id="Example1-code">
           Which results in the following violations:
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+        <div class="wrapper"><pre><code class="language-java">
 class Example1 {
   void InvalidExample() {
     String[] foo1 = {

--- a/src/site/xdoc/checks/coding/noclone.xml
+++ b/src/site/xdoc/checks/coding/noclone.xml
@@ -115,7 +115,7 @@ System.out.println(s2 instanceof Square); //true
         <p id="Example1-config">
           To configure the check:
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
+        <div class="wrapper"><pre><code class="language-xml">
 &lt;module name="Checker"&gt;
   &lt;module name="TreeWalker"&gt;
     &lt;module name="NoClone"/&gt;
@@ -123,7 +123,7 @@ System.out.println(s2 instanceof Square); //true
 &lt;/module&gt;
 </code></pre></div>
         <p id="Example1-code">Example: </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+        <div class="wrapper"><pre><code class="language-java">
 public class Example1 {
   public Example1 clone() {return null;} // violation, overrides the clone method
   public static Object clone(Object o) {return null;}

--- a/src/site/xdoc/checks/coding/noenumtrailingcomma.xml
+++ b/src/site/xdoc/checks/coding/noenumtrailingcomma.xml
@@ -37,7 +37,7 @@ enum Foo1 {
         <p id="Example1-config">
           To configure the check:
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
+        <div class="wrapper"><pre><code class="language-xml">
 &lt;module name="Checker"&gt;
   &lt;module name="TreeWalker"&gt;
     &lt;module name="NoEnumTrailingComma"/&gt;
@@ -47,7 +47,7 @@ enum Foo1 {
         <p id="Example1-code">
           Which results in the following violations:
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+        <div class="wrapper"><pre><code class="language-java">
 class Example1 {
   enum Foo1 {
     FOO,

--- a/src/site/xdoc/checks/coding/nofinalizer.xml
+++ b/src/site/xdoc/checks/coding/nofinalizer.xml
@@ -26,7 +26,7 @@
         <p id="Example1-config">
           To configure the check:
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
+        <div class="wrapper"><pre><code class="language-xml">
 &lt;module name="Checker"&gt;
   &lt;module name="TreeWalker"&gt;
     &lt;module name="NoFinalizer"/&gt;
@@ -34,7 +34,7 @@
 &lt;/module&gt;
 </code></pre></div>
         <p id="Example1-code">Example:</p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+        <div class="wrapper"><pre><code class="language-java">
 public class Example1 {
   // violation below, 'Avoid using finalizer method'
   protected void finalize() throws Throwable {

--- a/src/site/xdoc/checks/coding/onestatementperline.xml
+++ b/src/site/xdoc/checks/coding/onestatementperline.xml
@@ -54,7 +54,7 @@
         <p id="Example1-config">
           To configure the check:
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
+        <div class="wrapper"><pre><code class="language-xml">
 &lt;module name="Checker"&gt;
   &lt;module name="TreeWalker"&gt;
     &lt;module name="OneStatementPerLine"/&gt;
@@ -64,7 +64,7 @@
         <p id="Example1-code">
           The following examples will be flagged as a violation:
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+        <div class="wrapper"><pre><code class="language-java">
 import java.io.IOException;
 import java.io.OutputStream;
 import java.io.PipedOutputStream;
@@ -106,7 +106,7 @@ public class Example1 {
           An example of how to configure the check to treat resources
           in a try statement as statements to require them on their own line:
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
+        <div class="wrapper"><pre><code class="language-xml">
 &lt;module name="Checker"&gt;
   &lt;module name="TreeWalker"&gt;
     &lt;module name="OneStatementPerLine"&gt;
@@ -125,7 +125,7 @@ public class Example1 {
           there is no violation.
           The following examples will illustrate difference:
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+        <div class="wrapper"><pre><code class="language-java">
 import java.io.IOException;
 import java.io.OutputStream;
 import java.io.PipedOutputStream;

--- a/src/site/xdoc/checks/coding/overloadmethodsdeclarationorder.xml
+++ b/src/site/xdoc/checks/coding/overloadmethodsdeclarationorder.xml
@@ -18,7 +18,7 @@
 
       <subsection name="Examples" id="Examples">
         <p id="Example1-config">To configure the check:</p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
+        <div class="wrapper"><pre><code class="language-xml">
 &lt;module name="Checker"&gt;
   &lt;module name="TreeWalker"&gt;
     &lt;module name="OverloadMethodsDeclarationOrder"/&gt;
@@ -26,7 +26,7 @@
 &lt;/module&gt;
 </code></pre></div>
         <p id="Example1-code">Example of correct and incorrect grouping of overloaded methods:</p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+        <div class="wrapper"><pre><code class="language-java">
 class Example1 {
   void same(int i) {}
   // comments between overloaded methods are allowed.

--- a/src/site/xdoc/checks/coding/packagedeclaration.xml
+++ b/src/site/xdoc/checks/coding/packagedeclaration.xml
@@ -50,7 +50,7 @@
         <p id="Example1-config">
           To configure the check:
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
+        <div class="wrapper"><pre><code class="language-xml">
 &lt;module name="Checker"&gt;
   &lt;module name="TreeWalker"&gt;
     &lt;module name="PackageDeclaration"/&gt;
@@ -58,7 +58,7 @@
 &lt;/module&gt;
 </code></pre></div>
         <p id="Example1-code">Example1:</p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+        <div class="wrapper"><pre><code class="language-java">
 public class Example1{ // violation, 'Missing package declaration'
   String str = "Some Content";
 }
@@ -66,7 +66,7 @@ public class Example1{ // violation, 'Missing package declaration'
         <p id="Example2-config">
           Example of how the check works when matchDirectoryStructure option is set to false.
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
+        <div class="wrapper"><pre><code class="language-xml">
 &lt;module name="Checker"&gt;
   &lt;module name="TreeWalker"&gt;
     &lt;module name="PackageDeclaration"&gt;
@@ -76,7 +76,7 @@ public class Example1{ // violation, 'Missing package declaration'
 &lt;/module&gt;
 </code></pre></div>
         <p id="Example2-code">Example2:</p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+        <div class="wrapper"><pre><code class="language-java">
 package com.nonexistent.packages;
 public class Example2{
   String str = "Some Content";

--- a/src/site/xdoc/checks/coding/parameterassignment.xml
+++ b/src/site/xdoc/checks/coding/parameterassignment.xml
@@ -22,7 +22,7 @@
         <p id="Example1-config">
           To configure the check:
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
+        <div class="wrapper"><pre><code class="language-xml">
 &lt;module name="Checker"&gt;
   &lt;module name="TreeWalker"&gt;
     &lt;module name="ParameterAssignment"/&gt;
@@ -32,7 +32,7 @@
         <p id="Example1-code">
           Example:
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+        <div class="wrapper"><pre><code class="language-java">
 class Example1 {
   int methodOne(int parameter) {
     if (parameter &lt;= 0 ) {

--- a/src/site/xdoc/checks/coding/requirethis.xml
+++ b/src/site/xdoc/checks/coding/requirethis.xml
@@ -85,7 +85,7 @@
         <p id="Example1-config">
           To configure the default check:
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
+        <div class="wrapper"><pre><code class="language-xml">
 &lt;module name="Checker"&gt;
   &lt;module name="TreeWalker"&gt;
     &lt;module name="RequireThis"/&gt;
@@ -93,7 +93,7 @@
 &lt;/module&gt;
 </code></pre></div>
         <p id="Example1-code">Example:</p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+        <div class="wrapper"><pre><code class="language-java">
 class Example1 {
   int field1,field2,field3;
 
@@ -120,7 +120,7 @@ class Example1 {
         <p id="Example4-config">
             To configure the check demand methods and fields to have 'this.'
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
+        <div class="wrapper"><pre><code class="language-xml">
 &lt;module name="Checker"&gt;
   &lt;module name="TreeWalker"&gt;
     &lt;module name="RequireThis"&gt;
@@ -130,7 +130,7 @@ class Example1 {
 &lt;/module&gt;
 </code></pre></div>
         <p id="Example4-code">Example:</p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+        <div class="wrapper"><pre><code class="language-java">
 class Example4 {
   int field1,field2,field3;
 
@@ -153,7 +153,7 @@ class Example4 {
         <p id="Example2-config">
           To configure the check demand fields only to have 'this.'
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
+        <div class="wrapper"><pre><code class="language-xml">
 &lt;module name="Checker"&gt;
   &lt;module name="TreeWalker"&gt;
     &lt;module name="RequireThis"&gt;
@@ -164,7 +164,7 @@ class Example4 {
 &lt;/module&gt;
 </code></pre></div>
         <p id="Example2-code">Example:</p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+        <div class="wrapper"><pre><code class="language-java">
 class Example2 {
   int field1,field2,field3;
 
@@ -187,7 +187,7 @@ class Example2 {
         <p id="Example3-config">
             To configure the check demand methods only to have 'this.'
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
+        <div class="wrapper"><pre><code class="language-xml">
 &lt;module name="Checker"&gt;
   &lt;module name="TreeWalker"&gt;
     &lt;module name="RequireThis"&gt;
@@ -198,7 +198,7 @@ class Example2 {
 &lt;/module&gt;
 </code></pre></div>
         <p id="Example3-code">Example:</p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+        <div class="wrapper"><pre><code class="language-java">
 class Example3 {
   int field1,field2,field3;
 
@@ -226,7 +226,7 @@ class Example3 {
           1) If you arrange 'this' in your code on your own, the check will not raise violation for
           variables which use 'this' to reference a class field, for example:
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+        <div class="wrapper"><pre><code class="language-java">
 class Example5 {
   int field1,field2;
 
@@ -245,7 +245,7 @@ class Example5 {
           2) If method parameter is returned from the method, the check will not raise violation for
              returned variable/parameter, for example:
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+        <div class="wrapper"><pre><code class="language-java">
 class Example6 {
   String prefix;
 

--- a/src/site/xdoc/checks/coding/returncount.xml
+++ b/src/site/xdoc/checks/coding/returncount.xml
@@ -97,7 +97,7 @@
           return statements per method (ignoring the <code>equals()</code>
           method):
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
+        <div class="wrapper"><pre><code class="language-xml">
 &lt;module name="Checker"&gt;
   &lt;module name="TreeWalker"&gt;
     &lt;module name="ReturnCount"&gt;
@@ -109,7 +109,7 @@
         <p id="Example1-code">
             Example:
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+        <div class="wrapper"><pre><code class="language-java">
 public class Example1 {
     public Example1() {}
     // ok below, because default void restriction is 1
@@ -144,7 +144,7 @@ public class Example1 {
           To configure the check so that it doesn't allow any
           return statements per void method:
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
+        <div class="wrapper"><pre><code class="language-xml">
 &lt;module name="Checker"&gt;
   &lt;module name="TreeWalker"&gt;
     &lt;module name="ReturnCount"&gt;
@@ -156,7 +156,7 @@ public class Example1 {
         <p id="Example2-code">
             Example:
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+        <div class="wrapper"><pre><code class="language-java">
 public class Example2 {
     public Example2() {}
     // violation below, 'max allowed for void methods/constructors/lambdas is 0'
@@ -192,7 +192,7 @@ public class Example2 {
           return statements per method (ignoring the <code>equals()</code>
           method) and more than 1 return statements per void method:
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
+        <div class="wrapper"><pre><code class="language-xml">
 &lt;module name="Checker"&gt;
   &lt;module name="TreeWalker"&gt;
     &lt;module name="ReturnCount"&gt;
@@ -205,7 +205,7 @@ public class Example2 {
         <p id="Example3-code">
             Example:
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+        <div class="wrapper"><pre><code class="language-java">
 public class Example3 {
     public Example3() {}
     // ok below, because default void restriction is 1
@@ -240,7 +240,7 @@ public class Example3 {
           To configure the check so that it doesn't allow more than three
           return statements per method for all methods:
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
+        <div class="wrapper"><pre><code class="language-xml">
 &lt;module name="Checker"&gt;
   &lt;module name="TreeWalker"&gt;
     &lt;module name="ReturnCount"&gt;
@@ -253,7 +253,7 @@ public class Example3 {
         <p id="Example4-code">
             Example:
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+        <div class="wrapper"><pre><code class="language-java">
 public class Example4 {
     public Example4() {}
     // ok below, because default void restriction is 1
@@ -289,7 +289,7 @@ public class Example4 {
           in constructors, more than one return statement in all lambda
           expressions and more than two return statements in methods:
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
+        <div class="wrapper"><pre><code class="language-xml">
 &lt;module name="Checker"&gt;
   &lt;module name="TreeWalker"&gt;
     &lt;module name="ReturnCount"&gt;
@@ -310,7 +310,7 @@ public class Example4 {
         <p id="Example5-code">
             Example:
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+        <div class="wrapper"><pre><code class="language-java">
 public class Example5 {
     public Example5() {}
     // violation below, 'max allowed for void methods/constructors/lambdas is 0'

--- a/src/site/xdoc/checks/coding/simplifybooleanexpression.xml
+++ b/src/site/xdoc/checks/coding/simplifybooleanexpression.xml
@@ -26,7 +26,7 @@
         <p id="Example1-config">
           To configure the check:
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
+        <div class="wrapper"><pre><code class="language-xml">
 &lt;module name="Checker"&gt;
   &lt;module name="TreeWalker"&gt;
     &lt;module name="SimplifyBooleanExpression"/&gt;
@@ -34,7 +34,7 @@
 &lt;/module&gt;
 </code></pre></div>
         <p id="Example1-code">Example:</p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+        <div class="wrapper"><pre><code class="language-java">
 class Example1 {
   void InvalidExample() {
     boolean a=true;

--- a/src/site/xdoc/checks/coding/simplifybooleanreturn.xml
+++ b/src/site/xdoc/checks/coding/simplifybooleanreturn.xml
@@ -38,7 +38,7 @@ return !valid();
         <p id="Example1-config">
           To configure the check:
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
+        <div class="wrapper"><pre><code class="language-xml">
 &lt;module name="Checker"&gt;
   &lt;module name="TreeWalker"&gt;
     &lt;module name="SimplifyBooleanReturn"/&gt;
@@ -46,7 +46,7 @@ return !valid();
 &lt;/module&gt;
 </code></pre></div>
         <p id="Example1-code">Example:</p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+        <div class="wrapper"><pre><code class="language-java">
 class Example1 {
 
   boolean cond;

--- a/src/site/xdoc/checks/coding/stringliteralequality.xml
+++ b/src/site/xdoc/checks/coding/stringliteralequality.xml
@@ -37,7 +37,7 @@ if (&quot;something&quot;.equals(x))
         <p id="Example1-config">
           To configure the check:
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
+        <div class="wrapper"><pre><code class="language-xml">
 &lt;module name="Checker"&gt;
   &lt;module name="TreeWalker"&gt;
     &lt;module name="StringLiteralEquality"/&gt;
@@ -47,7 +47,7 @@ if (&quot;something&quot;.equals(x))
         <p id="Example1-code">
           Examples of violations:
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+        <div class="wrapper"><pre><code class="language-java">
 class Example1 {
   String getName(){
     return "Y";

--- a/src/site/xdoc/checks/coding/superclone.xml
+++ b/src/site/xdoc/checks/coding/superclone.xml
@@ -25,7 +25,7 @@
         <p id="Example1-config">
           To configure the check:
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
+        <div class="wrapper"><pre><code class="language-xml">
 &lt;module name="Checker"&gt;
   &lt;module name="TreeWalker"&gt;
     &lt;module name="SuperClone"/&gt;
@@ -33,7 +33,7 @@
 &lt;/module&gt;
 </code></pre></div>
         <p id="Example1-code">Example:</p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+        <div class="wrapper"><pre><code class="language-java">
 class Example1 {
   public Object clone() throws CloneNotSupportedException {
     return super.clone();

--- a/src/site/xdoc/checks/coding/superfinalize.xml
+++ b/src/site/xdoc/checks/coding/superfinalize.xml
@@ -28,7 +28,7 @@
         <p id="Example1-config">
           To configure the check:
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
+        <div class="wrapper"><pre><code class="language-xml">
 &lt;module name="Checker"&gt;
   &lt;module name="TreeWalker"&gt;
     &lt;module name="SuperFinalize"/&gt;
@@ -36,7 +36,7 @@
 &lt;/module&gt;
 </code></pre></div>
         <p id="Example1-code">Example:</p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+        <div class="wrapper"><pre><code class="language-java">
 class Example1 {
   protected void finalize() throws Throwable {
     super.finalize(); // OK, calls super.finalize()

--- a/src/site/xdoc/checks/coding/unnecessaryparentheses.xml
+++ b/src/site/xdoc/checks/coding/unnecessaryparentheses.xml
@@ -276,7 +276,7 @@ if ((++f) &gt; g &amp;&amp; a) { // violation, unnecessary paren
         <p id="Example1-config">
           To configure the check:
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
+        <div class="wrapper"><pre><code class="language-xml">
 &lt;module name="Checker"&gt;
   &lt;module name="TreeWalker"&gt;
     &lt;module name="UnnecessaryParentheses"/&gt;
@@ -286,7 +286,7 @@ if ((++f) &gt; g &amp;&amp; a) { // violation, unnecessary paren
         <p id="Example1-code">
           Which results in the following violations:
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+        <div class="wrapper"><pre><code class="language-java">
 class Example1 {
 
   public int square(int a, int b) {
@@ -340,7 +340,7 @@ class Example1 {
           <code> '|' </code>, bitwise AND <code> '&amp;' </code>, bitwise exclusive OR
           <code> '^' </code>:
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
+        <div class="wrapper"><pre><code class="language-xml">
 &lt;module name="Checker"&gt;
   &lt;module name="TreeWalker"&gt;
     &lt;module name="UnnecessaryParentheses"&gt;
@@ -350,7 +350,7 @@ class Example1 {
 &lt;/module&gt;
 </code></pre></div>
         <p id="Example2-code">Example:</p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+        <div class="wrapper"><pre><code class="language-java">
 class Example2 {
 
   void method() {
@@ -382,7 +382,7 @@ class Example2 {
           To configure the check to detect unnecessary parentheses around conditional expressions
           <code> '?' </code>:
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
+        <div class="wrapper"><pre><code class="language-xml">
 &lt;module name="Checker"&gt;
   &lt;module name="TreeWalker"&gt;
     &lt;module name="UnnecessaryParentheses"&gt;
@@ -392,7 +392,7 @@ class Example2 {
 &lt;/module&gt;
 </code></pre></div>
         <p id="Example3-code">Example:</p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+        <div class="wrapper"><pre><code class="language-java">
 class Example3 {
 
   void method() {

--- a/src/site/xdoc/checks/coding/unnecessarysemicolonafteroutertypedeclaration.xml
+++ b/src/site/xdoc/checks/coding/unnecessarysemicolonafteroutertypedeclaration.xml
@@ -69,7 +69,7 @@
         <p id="Example1-config">
           To configure the check:
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
+        <div class="wrapper"><pre><code class="language-xml">
 &lt;module name="Checker"&gt;
   &lt;module name="TreeWalker"&gt;
     &lt;module name="UnnecessarySemicolonAfterOuterTypeDeclaration"/&gt;
@@ -79,7 +79,7 @@
         <p id="Example1-code">
           Example:
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+        <div class="wrapper"><pre><code class="language-java">
 class Example1 {
   class Nested {
 
@@ -103,7 +103,7 @@ enum C {
            To configure the check to detect unnecessary semicolon only after top level class
            definitions:
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
+        <div class="wrapper"><pre><code class="language-xml">
 &lt;module name="Checker"&gt;
   &lt;module name="TreeWalker"&gt;
     &lt;module name="UnnecessarySemicolonAfterOuterTypeDeclaration"&gt;
@@ -115,7 +115,7 @@ enum C {
         <p id="Example2-code">
           Example:
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+        <div class="wrapper"><pre><code class="language-java">
 class Example2 {
   class Nested {
 

--- a/src/site/xdoc/checks/coding/unnecessarysemicolonaftertypememberdeclaration.xml
+++ b/src/site/xdoc/checks/coding/unnecessarysemicolonaftertypememberdeclaration.xml
@@ -103,7 +103,7 @@
         <p id="Example1-config">
           To configure the check:
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
+        <div class="wrapper"><pre><code class="language-xml">
 &lt;module name="Checker"&gt;
   &lt;module name="TreeWalker"&gt;
     &lt;module name="UnnecessarySemicolonAfterTypeMemberDeclaration"/&gt;
@@ -113,7 +113,7 @@
         <p id="Example1-code">
           Results in following:
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+        <div class="wrapper"><pre><code class="language-java">
 class Example1 {
   ; // violation, 'Unnecessary semicolon'
   {}; // violation, 'Unnecessary semicolon'

--- a/src/site/xdoc/checks/coding/unnecessarysemicoloninenumeration.xml
+++ b/src/site/xdoc/checks/coding/unnecessarysemicoloninenumeration.xml
@@ -19,7 +19,7 @@
         <p id="Example1-config">
           To configure the check:
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
+        <div class="wrapper"><pre><code class="language-xml">
 &lt;module name="Checker"&gt;
   &lt;module name="TreeWalker"&gt;
     &lt;module name="UnnecessarySemicolonInEnumeration"/&gt;
@@ -29,7 +29,7 @@
         <p id="Example1-code">
           Example of violations
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+        <div class="wrapper"><pre><code class="language-java">
 enum One {
     A,B; // violation 'Unnecessary semicolon'
 }
@@ -51,7 +51,7 @@ enum Five {
         <p id="Example2-code">
           Example of good cases
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+        <div class="wrapper"><pre><code class="language-java">
 enum Normal {
     A,
     B,

--- a/src/site/xdoc/checks/coding/unnecessarysemicolonintrywithresources.xml
+++ b/src/site/xdoc/checks/coding/unnecessarysemicolonintrywithresources.xml
@@ -39,7 +39,7 @@
         <p id="Example1-config">
           To configure the check:
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
+        <div class="wrapper"><pre><code class="language-xml">
 &lt;module name="Checker"&gt;
   &lt;module name="TreeWalker"&gt;
     &lt;module name="UnnecessarySemicolonInTryWithResources"/&gt;
@@ -49,7 +49,7 @@
         <p id="Example1-code">
           Example of violations
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+        <div class="wrapper"><pre><code class="language-java">
 class Example1 {
   void method() throws IOException {
     try (Reader r1 = new PipedReader();) {} // violation, 'Unnecessary semicolon'
@@ -66,7 +66,7 @@ class Example1 {
           To configure the check to detect unnecessary semicolon
           if closing parenthesis is not on the same line
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
+        <div class="wrapper"><pre><code class="language-xml">
 &lt;module name="Checker"&gt;
   &lt;module name="TreeWalker"&gt;
     &lt;module name="UnnecessarySemicolonInTryWithResources"&gt;
@@ -78,7 +78,7 @@ class Example1 {
         <p id="Example2-code">
           Example of exclusion
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+        <div class="wrapper"><pre><code class="language-java">
 class Example2 {
   void method() throws IOException {
     try (Reader r1 = new PipedReader();) {} // violation, 'Unnecessary semicolon'

--- a/src/site/xdoc/checks/coding/unusedcatchparametershouldbeunnamed.xml
+++ b/src/site/xdoc/checks/coding/unusedcatchparametershouldbeunnamed.xml
@@ -40,7 +40,7 @@
         <p id="Example1-config">
           To configure the check:
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
+        <div class="wrapper"><pre><code class="language-xml">
 &lt;module name="Checker"&gt;
   &lt;module name="TreeWalker"&gt;
     &lt;module name="UnusedCatchParameterShouldBeUnnamed"/&gt;
@@ -50,7 +50,7 @@
         <p id="Example1-code">
           Example:
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+        <div class="wrapper"><pre><code class="language-java">
 class Example1 {
 
   void test() {

--- a/src/site/xdoc/checks/coding/unusedlambdaparametershouldbeunnamed.xml
+++ b/src/site/xdoc/checks/coding/unusedlambdaparametershouldbeunnamed.xml
@@ -40,7 +40,7 @@
         <p id="Example1-config">
           To configure the check:
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
+        <div class="wrapper"><pre><code class="language-xml">
 &lt;module name="Checker"&gt;
   &lt;module name="TreeWalker"&gt;
     &lt;module name="UnusedLambdaParameterShouldBeUnnamed"/&gt;
@@ -50,7 +50,7 @@
         <p id="Example1-code">
           Example:
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+        <div class="wrapper"><pre><code class="language-java">
 class Example1 {
 
   int x;

--- a/src/site/xdoc/checks/coding/unusedlocalvariable.xml
+++ b/src/site/xdoc/checks/coding/unusedlocalvariable.xml
@@ -43,7 +43,7 @@
         <p id="Example1-config">
           To configure the check:
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
+        <div class="wrapper"><pre><code class="language-xml">
 &lt;module name="Checker"&gt;
   &lt;module name="TreeWalker"&gt;
     &lt;module name="UnusedLocalVariable"&gt;
@@ -54,7 +54,7 @@
         <p id="Example1-code">
           Example:
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+        <div class="wrapper"><pre><code class="language-java">
 class Example1 {
   {
     int k = 12; // violation, assign and update but never use 'k'
@@ -105,7 +105,7 @@ class Example1 {
            To configure the check to violate variables named with a single underscore
            if they are not used:
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
+        <div class="wrapper"><pre><code class="language-xml">
 &lt;module name="Checker"&gt;
   &lt;module name="TreeWalker"&gt;
     &lt;module name="UnusedLocalVariable"&gt;
@@ -117,7 +117,7 @@ class Example1 {
         <p id="Example2-code">
           Example:
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+        <div class="wrapper"><pre><code class="language-java">
 class Example1 {
   {
     int k = 12; // violation, assign and update but never use 'k'

--- a/src/site/xdoc/checks/coding/variabledeclarationusagedistance.xml
+++ b/src/site/xdoc/checks/coding/variabledeclarationusagedistance.xml
@@ -62,7 +62,7 @@
         <p id="Example1-config">
             To configure the check with default config:
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
+        <div class="wrapper"><pre><code class="language-xml">
 &lt;module name="Checker"&gt;
   &lt;module name="TreeWalker"&gt;
     &lt;module name="VariableDeclarationUsageDistance"/&gt;
@@ -70,7 +70,7 @@
 &lt;/module&gt;
 </code></pre></div>
         <p id="Example1-code">Example:</p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+        <div class="wrapper"><pre><code class="language-java">
 public class Example1 {
 
   public void foo1() {
@@ -138,7 +138,7 @@ cal.set(Calendar.MINUTE, minutes);
         <p id="Example2-config">
             To configure the check to set allowed distance:
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
+        <div class="wrapper"><pre><code class="language-xml">
 &lt;module name="Checker"&gt;
   &lt;module name="TreeWalker"&gt;
     &lt;module name="VariableDeclarationUsageDistance"&gt;
@@ -148,7 +148,7 @@ cal.set(Calendar.MINUTE, minutes);
 &lt;/module&gt;
 </code></pre></div>
         <p id="Example2-code">Example:</p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+        <div class="wrapper"><pre><code class="language-java">
 public class Example2 {
 
   public void foo1() {
@@ -178,7 +178,7 @@ public class Example2 {
         <p id="Example3-config">
             To configure the check to ignore certain variables:
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
+        <div class="wrapper"><pre><code class="language-xml">
 &lt;module name="Checker"&gt;
   &lt;module name="TreeWalker"&gt;
     &lt;module name="VariableDeclarationUsageDistance"&gt;
@@ -191,7 +191,7 @@ public class Example2 {
             This configuration ignores variables named &quot;num&quot;.
         </p>
         <p id="Example3-code">Example:</p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+        <div class="wrapper"><pre><code class="language-java">
 public class Example3 {
 
   public void foo1() {
@@ -221,7 +221,7 @@ public class Example3 {
         <p id="Example4-config">
             To configure the check to force validation between scopes:
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
+        <div class="wrapper"><pre><code class="language-xml">
 &lt;module name="Checker"&gt;
   &lt;module name="TreeWalker"&gt;
     &lt;module name="VariableDeclarationUsageDistance"&gt;
@@ -231,7 +231,7 @@ public class Example3 {
 &lt;/module&gt;
 </code></pre></div>
         <p id="Example4-code">Example:</p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+        <div class="wrapper"><pre><code class="language-java">
 public class Example4 {
 
   public void foo1() {
@@ -261,7 +261,7 @@ public class Example4 {
         <p id="Example5-config">
             To configure the check to check final variables:
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
+        <div class="wrapper"><pre><code class="language-xml">
 &lt;module name="Checker"&gt;
   &lt;module name="TreeWalker"&gt;
     &lt;module name="VariableDeclarationUsageDistance"&gt;
@@ -271,7 +271,7 @@ public class Example4 {
 &lt;/module&gt;
 </code></pre></div>
         <p id="Example5-code">Example:</p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+        <div class="wrapper"><pre><code class="language-java">
 public class Example5 {
 
   public void foo1() {

--- a/src/site/xdoc/checks/coding/whenshouldbeused.xml
+++ b/src/site/xdoc/checks/coding/whenshouldbeused.xml
@@ -36,7 +36,7 @@
         <p id="Example1-config">
           To configure the check:
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
+        <div class="wrapper"><pre><code class="language-xml">
 &lt;module name="Checker"&gt;
   &lt;module name="TreeWalker"&gt;
     &lt;module name="WhenShouldBeUsed"/&gt;
@@ -46,7 +46,7 @@
         <p id="Example1-code">
           Example of violation:
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+        <div class="wrapper"><pre><code class="language-java">
 public class Example1 {
 
   void testNoGuard(Object o) {

--- a/src/site/xdoc/checks/design/designforextension.xml
+++ b/src/site/xdoc/checks/design/designforextension.xml
@@ -160,7 +160,7 @@ public abstract class Plant {
         <p id="Example1-config">
           To configure the check:
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
+        <div class="wrapper"><pre><code class="language-xml">
 &lt;module name="Checker"&gt;
   &lt;module name="TreeWalker"&gt;
     &lt;module name="DesignForExtension"/&gt;
@@ -168,7 +168,7 @@ public abstract class Plant {
 &lt;/module&gt;
 </code></pre></div>
         <p id="Example1-code">Example:</p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+        <div class="wrapper"><pre><code class="language-java">
 public abstract class Example1 {
   private int bar;
 
@@ -210,7 +210,7 @@ public abstract class Example1 {
           To configure the check to allow methods which have @Override annotations to be
           designed for extension.
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
+        <div class="wrapper"><pre><code class="language-xml">
 &lt;module name="Checker"&gt;
   &lt;module name="TreeWalker"&gt;
     &lt;module name="DesignForExtension"&gt;
@@ -220,7 +220,7 @@ public abstract class Example1 {
 &lt;/module&gt;
 </code></pre></div>
         <p id="Example2-code">Example:</p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+        <div class="wrapper"><pre><code class="language-java">
 public abstract class Example2 {
   private int bar;
 
@@ -262,7 +262,7 @@ public abstract class Example2 {
           To configure the check to allow methods which contain a specified comment text pattern in
           their javadoc to be designed for extension.
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
+        <div class="wrapper"><pre><code class="language-xml">
 &lt;module name="Checker"&gt;
   &lt;module name="TreeWalker"&gt;
     &lt;module name="DesignForExtension"&gt;
@@ -272,7 +272,7 @@ public abstract class Example2 {
 &lt;/module&gt;
 </code></pre></div>
         <p id="Example3-code">Example:</p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+        <div class="wrapper"><pre><code class="language-java">
 public abstract class Example3 {
   private int bar;
 
@@ -314,7 +314,7 @@ public abstract class Example3 {
           To configure the check to allow methods which contain a specified comment text pattern in
           their javadoc which can span multiple lines to be designed for extension.
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
+        <div class="wrapper"><pre><code class="language-xml">
 &lt;module name="Checker"&gt;
   &lt;module name="TreeWalker"&gt;
     &lt;module name="DesignForExtension"&gt;
@@ -325,7 +325,7 @@ public abstract class Example3 {
 &lt;/module&gt;
 </code></pre></div>
         <p id="Example4-code">Example:</p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+        <div class="wrapper"><pre><code class="language-java">
 public abstract class Example4 {
   private int bar;
 

--- a/src/site/xdoc/checks/design/finalclass.xml
+++ b/src/site/xdoc/checks/design/finalclass.xml
@@ -38,7 +38,7 @@
         <p id="Example1-config">
           To configure the check:
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
+        <div class="wrapper"><pre><code class="language-xml">
 &lt;module name="Checker"&gt;
   &lt;module name="TreeWalker"&gt;
     &lt;module name="FinalClass"/&gt;
@@ -46,7 +46,7 @@
 &lt;/module&gt;
 </code></pre></div>
         <p id="Example1-code">Example:</p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+        <div class="wrapper"><pre><code class="language-java">
 public class Example1 { // ok, since it has a public constructor
 
   final class A {

--- a/src/site/xdoc/checks/design/hideutilityclassconstructor.xml
+++ b/src/site/xdoc/checks/design/hideutilityclassconstructor.xml
@@ -67,7 +67,7 @@ public class StringUtils // not final to allow subclassing
         <p id="Example1-config">
           To configure the check:
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
+        <div class="wrapper"><pre><code class="language-xml">
 &lt;module name="Checker"&gt;
   &lt;module name="TreeWalker"&gt;
     &lt;module name="HideUtilityClassConstructor"/&gt;
@@ -75,7 +75,7 @@ public class StringUtils // not final to allow subclassing
 &lt;/module&gt;
 </code></pre></div>
         <p id="Example1-code">Example:</p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+        <div class="wrapper"><pre><code class="language-java">
 // violation below, 'should not have a public or default constructor'
 @java.lang.Deprecated
 class Example1 {
@@ -121,7 +121,7 @@ class Application1 {
           To configure the check to ignore classes annotated with <code>SpringBootApplication</code>
           or <code>java.lang.Deprecated</code>.
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
+        <div class="wrapper"><pre><code class="language-xml">
 &lt;module name="Checker"&gt;
   &lt;module name="TreeWalker"&gt;
     &lt;module name="HideUtilityClassConstructor"&gt;
@@ -132,7 +132,7 @@ class Application1 {
 &lt;/module&gt;
 </code></pre></div>
         <p id="Example2-code">Example:</p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+        <div class="wrapper"><pre><code class="language-java">
 // ok below, skipped by annotation
 @java.lang.Deprecated
 class Example2 {

--- a/src/site/xdoc/checks/design/innertypelast.xml
+++ b/src/site/xdoc/checks/design/innertypelast.xml
@@ -20,7 +20,7 @@
         <p id="Example1-config">
           To configure the check:
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
+        <div class="wrapper"><pre><code class="language-xml">
 &lt;module name="Checker"&gt;
   &lt;module name="TreeWalker"&gt;
     &lt;module name="InnerTypeLast"/&gt;
@@ -28,7 +28,7 @@
 &lt;/module&gt;
 </code></pre></div>
         <p id="Example1-code">Example:</p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+        <div class="wrapper"><pre><code class="language-java">
 class Test1 {
   private String s;
   class InnerTest1 {}

--- a/src/site/xdoc/checks/design/interfaceistype.xml
+++ b/src/site/xdoc/checks/design/interfaceistype.xml
@@ -54,7 +54,7 @@
         <p id="Example1-config">
           To configure the check:
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
+        <div class="wrapper"><pre><code class="language-xml">
 &lt;module name="Checker"&gt;
   &lt;module name="TreeWalker"&gt;
     &lt;module name="InterfaceIsType"/&gt;
@@ -62,7 +62,7 @@
 &lt;/module&gt;
 </code></pre></div>
         <p id="Example1-code">Example:</p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+        <div class="wrapper"><pre><code class="language-java">
 class Example1 {
   // violation below, 'interfaces should describe a type and hence have methods.'
   interface Test1 {
@@ -83,7 +83,7 @@ class Example1 {
         <p id="Example2-config">
           To configure the check to report violation so that it doesn't allow Marker Interfaces:
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
+        <div class="wrapper"><pre><code class="language-xml">
 &lt;module name="Checker"&gt;
   &lt;module name="TreeWalker"&gt;
     &lt;module name="InterfaceIsType"&gt;
@@ -93,7 +93,7 @@ class Example1 {
 &lt;/module&gt;
 </code></pre></div>
         <p id="Example2-code">Example:</p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+        <div class="wrapper"><pre><code class="language-java">
 class Example2 {
   // violation below, 'interfaces should describe a type and hence have methods.'
   interface Test1 {

--- a/src/site/xdoc/checks/design/mutableexception.xml
+++ b/src/site/xdoc/checks/design/mutableexception.xml
@@ -65,7 +65,7 @@
         <p id="Example1-config">
           To configure the check:
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
+        <div class="wrapper"><pre><code class="language-xml">
 &lt;module name="Checker"&gt;
   &lt;module name="TreeWalker"&gt;
     &lt;module name="MutableException"/&gt;
@@ -73,7 +73,7 @@
 &lt;/module&gt;
 </code></pre></div>
         <p id="Example1-code">Example:</p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+        <div class="wrapper"><pre><code class="language-java">
 class Example1 extends Exception {
   private int code; // OK, class name doesn't match with default pattern
 
@@ -113,7 +113,7 @@ class FirstBadException extends java.lang.Exception {
           To configure the check so that it checks for class name that ends
           with 'Exception':
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
+        <div class="wrapper"><pre><code class="language-xml">
 &lt;module name="Checker"&gt;
   &lt;module name="TreeWalker"&gt;
     &lt;module name="MutableException"&gt;
@@ -123,7 +123,7 @@ class FirstBadException extends java.lang.Exception {
 &lt;/module&gt;
 </code></pre></div>
         <p id="Example2-code">Example:</p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+        <div class="wrapper"><pre><code class="language-java">
 class Example2 extends Exception {
   private int code; // OK, class name doesn't match with given pattern
 
@@ -163,7 +163,7 @@ class SecondBadException extends java.lang.Exception {
           To configure the check so that it checks for type name that is used in
           'extends' and ends with 'Throwable':
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
+        <div class="wrapper"><pre><code class="language-xml">
 &lt;module name="Checker"&gt;
   &lt;module name="TreeWalker"&gt;
     &lt;module name="MutableException"&gt;
@@ -173,7 +173,7 @@ class SecondBadException extends java.lang.Exception {
 &lt;/module&gt;
 </code></pre></div>
         <p id="Example3-code">Example:</p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+        <div class="wrapper"><pre><code class="language-java">
 class Example3 extends Exception {
   private int code; // OK, extended class name doesn't match with given pattern
 

--- a/src/site/xdoc/checks/design/onetoplevelclass.xml
+++ b/src/site/xdoc/checks/design/onetoplevelclass.xml
@@ -23,7 +23,7 @@
         <p id="Example1-config">
           To configure the check:
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
+        <div class="wrapper"><pre><code class="language-xml">
 &lt;module name="Checker"&gt;
   &lt;module name="TreeWalker"&gt;
     &lt;module name="OneTopLevelClass"/&gt;
@@ -37,7 +37,7 @@
         <p id="Example1-code">
           An example of code with violations:
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+        <div class="wrapper"><pre><code class="language-java">
 public class Example1 { // OK, first top-level class
   // methods
 }
@@ -49,7 +49,7 @@ class ViolationExample1 { // violation, "has to reside in its own source file."
         <p id="Example2-code">
           An example of code without public top-level type:
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+        <div class="wrapper"><pre><code class="language-java">
 class Example2 { // OK, first top-level class
   // methods
 }
@@ -61,7 +61,7 @@ class ViolationExample2 { // violation, "has to reside in its own source file."
         <p id="Example3-code">
           An example of code without violations:
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+        <div class="wrapper"><pre><code class="language-java">
 public class Example3 { // OK, only one top-level class
   // methods
 }

--- a/src/site/xdoc/checks/design/sealedshouldhavepermitslist.xml
+++ b/src/site/xdoc/checks/design/sealedshouldhavepermitslist.xml
@@ -31,7 +31,7 @@
         <p id="Example1-config">
           To configure the check:
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
+        <div class="wrapper"><pre><code class="language-xml">
 &lt;module name="Checker"&gt;
   &lt;module name="TreeWalker"&gt;
     &lt;module name="SealedShouldHavePermitsList"/&gt;
@@ -41,7 +41,7 @@
         <p id="Example1-code">
           Example:
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+        <div class="wrapper"><pre><code class="language-java">
 public class Example1 {
 
   // imagine hundreds of lines of code...

--- a/src/site/xdoc/checks/design/throwscount.xml
+++ b/src/site/xdoc/checks/design/throwscount.xml
@@ -68,7 +68,7 @@
         <p id="Example1-config">
           To configure check:
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
+        <div class="wrapper"><pre><code class="language-xml">
 &lt;module name="Checker"&gt;
   &lt;module name="TreeWalker"&gt;
     &lt;module name="ThrowsCount"/&gt;
@@ -78,7 +78,7 @@
         <p id="Example1-code">
           Example:
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+        <div class="wrapper"><pre><code class="language-java">
 public class Example1 {
   // violation below, 'Throws count is 5 (max allowed is 4)'
   public void myFunction() throws CloneNotSupportedException,
@@ -109,7 +109,7 @@ public class Example1 {
           To configure the check so that it doesn't allow more than two throws
           per method:
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
+        <div class="wrapper"><pre><code class="language-xml">
 &lt;module name="Checker"&gt;
   &lt;module name="TreeWalker"&gt;
     &lt;module name="ThrowsCount"&gt;
@@ -121,7 +121,7 @@ public class Example1 {
         <p id="Example2-code">
           Example:
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+        <div class="wrapper"><pre><code class="language-java">
 public class Example2 {
   // violation below, 'Throws count is 5 (max allowed is 2)'
   public void myFunction() throws CloneNotSupportedException,
@@ -151,7 +151,7 @@ public class Example2 {
         <p id="Example3-config">
           To configure the check so that it doesn't skip private methods:
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
+        <div class="wrapper"><pre><code class="language-xml">
 &lt;module name="Checker"&gt;
   &lt;module name="TreeWalker"&gt;
     &lt;module name="ThrowsCount"&gt;
@@ -163,7 +163,7 @@ public class Example2 {
         <p id="Example3-code">
           Example:
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+        <div class="wrapper"><pre><code class="language-java">
 public class Example3 {
   // violation below, 'Throws count is 5 (max allowed is 4)'
   public void myFunction() throws CloneNotSupportedException,

--- a/src/site/xdoc/checks/design/visibilitymodifier.xml
+++ b/src/site/xdoc/checks/design/visibilitymodifier.xml
@@ -145,7 +145,7 @@
         <p id="Example1-config">
           To configure the check:
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
+        <div class="wrapper"><pre><code class="language-xml">
 &lt;module name="Checker"&gt;
   &lt;module name="TreeWalker"&gt;
     &lt;module name="VisibilityModifier"/&gt;
@@ -153,7 +153,7 @@
 &lt;/module&gt;
 </code></pre></div>
         <p id="Example1-code">Example with default values:</p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+        <div class="wrapper"><pre><code class="language-java">
 class Example1 {
   private int myPrivateField1;
 
@@ -196,7 +196,7 @@ class Example1 {
         <p id="Example2-config">
           To configure the check so that it allows package visible members:
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
+        <div class="wrapper"><pre><code class="language-xml">
 &lt;module name="Checker"&gt;
   &lt;module name="TreeWalker"&gt;
     &lt;module name="VisibilityModifier"&gt;
@@ -206,7 +206,7 @@ class Example1 {
 &lt;/module&gt;
 </code></pre></div>
         <p id="Example2-code">Example of allowed package visible members:</p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+        <div class="wrapper"><pre><code class="language-java">
 class Example2 {
   private int myPrivateField1;
 
@@ -249,7 +249,7 @@ class Example2 {
         <p id="Example3-config">
           To configure the check so that it allows protected visible members:
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
+        <div class="wrapper"><pre><code class="language-xml">
 &lt;module name="Checker"&gt;
   &lt;module name="TreeWalker"&gt;
     &lt;module name="VisibilityModifier"&gt;
@@ -259,7 +259,7 @@ class Example2 {
 &lt;/module&gt;
 </code></pre></div>
         <p id="Example3-code">Example of allowed protected visible members:</p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+        <div class="wrapper"><pre><code class="language-java">
 class Example3 {
   private int myPrivateField1;
 
@@ -303,7 +303,7 @@ class Example3 {
         <p id="Example4-config">
           To configure the check so that it allows no public members:
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
+        <div class="wrapper"><pre><code class="language-xml">
 &lt;module name="Checker"&gt;
   &lt;module name="TreeWalker"&gt;
     &lt;module name="VisibilityModifier"&gt;
@@ -313,7 +313,7 @@ class Example3 {
 &lt;/module&gt;
 </code></pre></div>
         <p id="Example4-code">Example of not allowed public members:</p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+        <div class="wrapper"><pre><code class="language-java">
 class Example4 {
   private int myPrivateField1;
 
@@ -359,7 +359,7 @@ class Example4 {
           To configure the Check so that it allows public immutable fields
           (mostly for immutable classes):
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
+        <div class="wrapper"><pre><code class="language-xml">
 &lt;module name="Checker"&gt;
   &lt;module name="TreeWalker"&gt;
     &lt;module name="VisibilityModifier"&gt;
@@ -371,7 +371,7 @@ class Example4 {
         <p id="Example5-code">
           Example of allowed public immutable fields:
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+        <div class="wrapper"><pre><code class="language-java">
 class Example5 {
   private int myPrivateField1;
 
@@ -413,7 +413,7 @@ class Example5 {
         <p id="Example6-config">
           To configure the Check in order to allow user specified immutable class names:
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
+        <div class="wrapper"><pre><code class="language-xml">
 &lt;module name="Checker"&gt;
   &lt;module name="TreeWalker"&gt;
     &lt;module name="VisibilityModifier"&gt;
@@ -428,7 +428,7 @@ class Example5 {
         <p id="Example6-code">
           Example of allowed public immutable fields:
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+        <div class="wrapper"><pre><code class="language-java">
 class Example6 {
   private int myPrivateField1;
 
@@ -472,7 +472,7 @@ class Example6 {
           generic type parameters are immutable. If at least one generic type parameter is mutable,
           there will be a violation.
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
+        <div class="wrapper"><pre><code class="language-xml">
 &lt;module name="Checker"&gt;
   &lt;module name="TreeWalker"&gt;
     &lt;module name="VisibilityModifier"&gt;
@@ -487,7 +487,7 @@ class Example6 {
         <p id="Example7-code">
           Example of how the check works:
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+        <div class="wrapper"><pre><code class="language-java">
 class Example7 {
   private int myPrivateField1;
 
@@ -529,7 +529,7 @@ class Example7 {
         <p id="Example8-config">
           To configure the Check passing fields annotated with @java.lang.Deprecated:
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
+        <div class="wrapper"><pre><code class="language-xml">
 &lt;module name="Checker"&gt;
   &lt;module name="TreeWalker"&gt;
     &lt;module name="VisibilityModifier"&gt;
@@ -542,7 +542,7 @@ class Example7 {
         <p id="Example8-code">
           Example of allowed field:
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+        <div class="wrapper"><pre><code class="language-java">
 class Example8 {
   private int myPrivateField1;
 
@@ -586,7 +586,7 @@ class Example8 {
           To configure the Check passing fields annotated with @org.junit.Rule,
           @org.junit.ClassRule and @com.google.common.annotations.VisibleForTesting annotations:
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
+        <div class="wrapper"><pre><code class="language-xml">
 &lt;module name="Checker"&gt;
   &lt;module name="TreeWalker"&gt;
     &lt;module name="VisibilityModifier"/&gt;
@@ -596,7 +596,7 @@ class Example8 {
         <p id="Example9-code">
           Example of allowed fields:
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+        <div class="wrapper"><pre><code class="language-java">
 class Example9 {
   private int myPrivateField1;
 
@@ -638,7 +638,7 @@ class Example9 {
         <p id="Example10-config">
           To configure the Check passing fields annotated with short annotation name:
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
+        <div class="wrapper"><pre><code class="language-xml">
 &lt;module name="Checker"&gt;
   &lt;module name="TreeWalker"&gt;
     &lt;module name="VisibilityModifier"&gt;
@@ -650,7 +650,7 @@ class Example9 {
         <p id="Example10-code">
           Example of allowed fields:
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+        <div class="wrapper"><pre><code class="language-java">
 class Example10 {
   private int myPrivateField1;
 
@@ -696,7 +696,7 @@ class Example10 {
         <p id="Example11-config">
            1) To configure the check to use only 'allowPublicImmutableFields' option:
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
+        <div class="wrapper"><pre><code class="language-xml">
 &lt;module name="Checker"&gt;
   &lt;module name="TreeWalker"&gt;
     &lt;module name="VisibilityModifier"&gt;
@@ -708,7 +708,7 @@ class Example10 {
         <p id="Example11-code">
           Code example:
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+        <div class="wrapper"><pre><code class="language-java">
 class Example11 {
   public final int someIntValue = 0; // violation 'must be private'
 
@@ -724,7 +724,7 @@ class Example11 {
         <p id="Example12-config">
           2) To configure the check to use only 'allowPublicFinalFields' option:
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
+        <div class="wrapper"><pre><code class="language-xml">
 &lt;module name="Checker"&gt;
   &lt;module name="TreeWalker"&gt;
     &lt;module name="VisibilityModifier"&gt;
@@ -736,7 +736,7 @@ class Example11 {
         <p id="Example12-code">
           Code example:
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+        <div class="wrapper"><pre><code class="language-java">
 class Example12 {
   public final int someIntValue = 0;
 

--- a/src/site/xdoc/checks/header/header.xml
+++ b/src/site/xdoc/checks/header/header.xml
@@ -81,13 +81,13 @@
           Default values of properties are used.
         </p>
 
-        <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
+        <div class="wrapper"><pre><code class="language-xml">
 &lt;module name="Checker"&gt;
   &lt;module name="Header"/&gt;
 &lt;/module&gt;
 </code></pre></div>
         <p id="Example1-code">Example1:</p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+        <div class="wrapper"><pre><code class="language-java">
 package com.puppycrawl.tools.checkstyle.checks.header.header;
 // OK, as by default there is not specific header defined to validate it presence
 public class Example1 { }
@@ -100,7 +100,7 @@ public class Example1 { }
           copyright dates or other content that slightly different in some files:
         </p>
 
-        <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
+        <div class="wrapper"><pre><code class="language-xml">
 &lt;module name="Checker"&gt;
   &lt;module name="Header"&gt;
     &lt;property name="headerFile" value="${config.folder}/java.header"/&gt;
@@ -110,7 +110,7 @@ public class Example1 { }
 &lt;/module&gt;
 </code></pre></div>
         <p id="java-raw">content of &quot;java.header&quot; file:</p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+        <div class="wrapper"><pre><code class="language-java">
 ///////////////////////////////////////////////////////////////////////////////////////////////
 // checkstyle: Checks Java source code and other text files for adherence to a set of rules.
 // Copyright (C) 20XX-20XX the original author or authors.
@@ -131,7 +131,7 @@ public class Example1 { }
 ///////////////////////////////////////////////////////////////////////////////////////////////
 </code></pre></div>
         <p id="Example2-code">Example2:</p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+        <div class="wrapper"><pre><code class="language-java">
 package com.puppycrawl.tools.checkstyle.checks.header.header;
 /* violation on first line 'Line does not match expected header line of' */
 // because headerFile is bigger then target java file
@@ -141,7 +141,7 @@ public class Example2 { }
         <p id="Example3-config">
           Without the need for an external header file:
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
+        <div class="wrapper"><pre><code class="language-xml">
 &lt;module name="Checker"&gt;
   &lt;module name="Header"&gt;
     &lt;property name="header"
@@ -150,7 +150,7 @@ public class Example2 { }
 &lt;/module&gt;
 </code></pre></div>
         <p id="Example3-code">Example3:</p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+        <div class="wrapper"><pre><code class="language-java">
 package com.puppycrawl.tools.checkstyle.checks.header.header;
 /* violation on first line 'Line does not match expected header' */
 public class Example3 { }
@@ -159,7 +159,7 @@ public class Example3 { }
         <p id="Example4-config">
           In case target file is less in size than header file:
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
+        <div class="wrapper"><pre><code class="language-xml">
 &lt;module name="Checker"&gt;
   &lt;module name="Header"&gt;
     &lt;property name="headerFile" value="${config.folder}/java.header"/&gt;
@@ -169,7 +169,7 @@ public class Example3 { }
 &lt;/module&gt;
 </code></pre></div>
         <p id="Example4-code">Example:</p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+        <div class="wrapper"><pre><code class="language-java">
 package com.puppycrawl.tools.checkstyle.checks.header.header;
 /* violation on first line 'Missing a header - not enough lines in file' */
 // because content defined in 'headerFile' is bigger then target java file

--- a/src/site/xdoc/checks/header/regexpheader.xml
+++ b/src/site/xdoc/checks/header/regexpheader.xml
@@ -70,13 +70,13 @@
             To configure the check such that no violations arise.
             Default values of properties are used.
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
+        <div class="wrapper"><pre><code class="language-xml">
 &lt;module name="Checker"&gt;
   &lt;module name="RegexpHeader"/&gt;
 &lt;/module&gt;
 </code></pre></div>
         <p id="Example1-code">Example1:</p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+        <div class="wrapper"><pre><code class="language-java">
 package com.puppycrawl.tools.checkstyle.checks.header.header;
 // OK, as by default there is not specific header defined to validate it presence
 public class Example1 { }
@@ -86,7 +86,7 @@ public class Example1 { }
           To configure the check to use header file <code>&quot;java.header&quot;</code> and
           <code>10</code> and <code>13</code> multi-lines:
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
+        <div class="wrapper"><pre><code class="language-xml">
 &lt;module name="Checker"&gt;
   &lt;module name="RegexpHeader"&gt;
     &lt;property name="headerFile" value="${config.folder}/java.header"/&gt;
@@ -95,7 +95,7 @@ public class Example1 { }
 &lt;/module&gt;
 </code></pre></div>
         <p id="java-raw">content of &quot;java.header&quot; file:</p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+        <div class="wrapper"><pre><code class="language-java">
 ///////////////////////////////////////////////////////////////////////////////////////////////
 // checkstyle: Checks Java source code and other text files for adherence to a set of rules.
 // Copyright (C) 20XX-20XX the original author or authors.
@@ -116,7 +116,7 @@ public class Example1 { }
 ///////////////////////////////////////////////////////////////////////////////////////////////
 </code></pre></div>
         <p id="Example2-code">Example2:</p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+        <div class="wrapper"><pre><code class="language-java">
 package com.puppycrawl.tools.checkstyle.checks.header.header;
 /* violation on first line 'Line does not match expected header line of' */
 // because headerFile is bigger then target java file
@@ -127,7 +127,7 @@ public class Example2 { }
           To configure the check to verify that each file starts with the
           header
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
+        <div class="wrapper"><pre><code class="language-xml">
 &lt;module name="Checker"&gt;
   &lt;module name="RegexpHeader"&gt;
     &lt;property
@@ -138,7 +138,7 @@ public class Example2 { }
 &lt;/module&gt;
 </code></pre></div>
         <p id="Example3-code">Example3:</p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+        <div class="wrapper"><pre><code class="language-java">
 package com.puppycrawl.tools.checkstyle.checks.header.regexpheader;
 /* violation on first line 'Line does not match expected header line' */
 public class Example3 { }
@@ -147,7 +147,7 @@ public class Example3 { }
         <p id="Example4-config">
           For regex containing <code>&quot;.*&quot;</code>
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
+        <div class="wrapper"><pre><code class="language-xml">
 &lt;module name="Checker"&gt;
   &lt;module name="RegexpHeader"&gt;
     &lt;property
@@ -160,7 +160,7 @@ public class Example3 { }
           <code>&quot;.*&quot;</code> will match all lines and
           expect no violation. For example -
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+        <div class="wrapper"><pre><code class="language-java">
 package com.puppycrawl.tools.checkstyle.checks.header.regexpheader;
 //OK, as regex value matches all lines
 public class Example4 { }

--- a/src/site/xdoc/checks/imports/avoidstarimport.xml
+++ b/src/site/xdoc/checks/imports/avoidstarimport.xml
@@ -67,7 +67,7 @@
         <p id="Example1-config">
           To configure the check:
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
+        <div class="wrapper"><pre><code class="language-xml">
 &lt;module name="Checker"&gt;
   &lt;module name="TreeWalker"&gt;
     &lt;module name="AvoidStarImport"/&gt;
@@ -77,7 +77,7 @@
         <p id="Example1-code">
           Example:
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+        <div class="wrapper"><pre><code class="language-java">
 import java.util.Scanner;
 import java.io.*; // violation, 'Using the '.*' form of import should be avoided.'
 import static java.lang.Math.*; // violation, 'form of import should be avoided.'
@@ -89,7 +89,7 @@ import java.net.*; // violation, 'Using the '.*' form of import should be avoide
           <code>java.io and java.net</code> as well as static members from class
           <code>java.lang.Math</code> are allowed:
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
+        <div class="wrapper"><pre><code class="language-xml">
 &lt;module name="Checker"&gt;
   &lt;module name="TreeWalker"&gt;
     &lt;module name="AvoidStarImport"&gt;
@@ -101,7 +101,7 @@ import java.net.*; // violation, 'Using the '.*' form of import should be avoide
         <p id="Example2-code">
           Example:
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+        <div class="wrapper"><pre><code class="language-java">
 import java.util.Scanner;
 import java.io.*;
 import static java.lang.Math.*;
@@ -112,7 +112,7 @@ import java.net.*;
           To configure the check so that star imports
           from all packages are allowed:
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
+        <div class="wrapper"><pre><code class="language-xml">
 &lt;module name="Checker"&gt;
   &lt;module name="TreeWalker"&gt;
     &lt;module name="AvoidStarImport"&gt;
@@ -124,7 +124,7 @@ import java.net.*;
         <p id="Example3-code">
           Example:
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+        <div class="wrapper"><pre><code class="language-java">
 import java.util.Scanner;
 import java.io.*;
 import static java.lang.Math.*; // violation, 'form of import should be avoided.'
@@ -135,7 +135,7 @@ import java.net.*;
           To configure the check so that starred static member imports
           from all packages are allowed:
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
+        <div class="wrapper"><pre><code class="language-xml">
 &lt;module name="Checker"&gt;
   &lt;module name="TreeWalker"&gt;
     &lt;module name="AvoidStarImport"&gt;
@@ -147,7 +147,7 @@ import java.net.*;
         <p id="Example4-code">
           Example:
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+        <div class="wrapper"><pre><code class="language-java">
 import java.util.Scanner;
 import java.io.*; // violation, 'Using the '.*' form of import should be avoided.'
 import static java.lang.Math.*;
@@ -158,7 +158,7 @@ import java.net.*; // violation, 'Using the '.*' form of import should be avoide
           To configure the check so that star imports from packages
           <code>java.io and java.net</code> are allowed:
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
+        <div class="wrapper"><pre><code class="language-xml">
 &lt;module name="Checker"&gt;
   &lt;module name="TreeWalker"&gt;
     &lt;module name="AvoidStarImport"&gt;
@@ -171,7 +171,7 @@ import java.net.*; // violation, 'Using the '.*' form of import should be avoide
         <p id="Example5-code">
           Example:
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+        <div class="wrapper"><pre><code class="language-java">
 import java.util.Scanner;
 import java.io.*;
 import static java.lang.Math.*; // violation, 'form of import should be avoided.'
@@ -183,7 +183,7 @@ import java.net.*;
           <code>java.io and java.net</code> as well as static members imports
           from all packages are allowed:
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
+        <div class="wrapper"><pre><code class="language-xml">
 &lt;module name="Checker"&gt;
   &lt;module name="TreeWalker"&gt;
     &lt;module name="AvoidStarImport"&gt;
@@ -196,7 +196,7 @@ import java.net.*;
         <p id="Example6-code">
           Example:
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+        <div class="wrapper"><pre><code class="language-java">
 import java.util.Scanner;
 import java.io.*;
 import static java.lang.Math.*;

--- a/src/site/xdoc/checks/imports/avoidstaticimport.xml
+++ b/src/site/xdoc/checks/imports/avoidstaticimport.xml
@@ -58,7 +58,7 @@
         <p id="Example1-config">
           To configure the check:
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
+        <div class="wrapper"><pre><code class="language-xml">
 &lt;module name="Checker"&gt;
   &lt;module name="TreeWalker"&gt;
     &lt;module name="AvoidStaticImport"/&gt;
@@ -68,7 +68,7 @@
         <p id="Example1-code">
           Example:
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+        <div class="wrapper"><pre><code class="language-java">
 import static java.lang.Math.pow;          // violation, 'Using a static member import should be avoided.'
 import static java.lang.System.*;          // violation, 'Using a static member import should be avoided.'
 import java.io.File;                       // OK
@@ -78,7 +78,7 @@ import java.util.*;                        // OK
           To configure the check so that the <code>java.lang.System.out</code>
           member and all members from <code>java.lang.Math</code> are allowed:
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
+        <div class="wrapper"><pre><code class="language-xml">
 &lt;module name="Checker"&gt;
   &lt;module name="TreeWalker"&gt;
     &lt;module name="AvoidStaticImport"&gt;
@@ -90,7 +90,7 @@ import java.util.*;                        // OK
         <p id="Example2-code">
          Example:
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+        <div class="wrapper"><pre><code class="language-java">
 import static java.lang.Math.*;            // OK
 import static java.lang.System.out;        // OK
 import static java.lang.Integer.parseInt;  // violation, 'Using a static member import should be avoided.'

--- a/src/site/xdoc/checks/imports/customimportorder.xml
+++ b/src/site/xdoc/checks/imports/customimportorder.xml
@@ -176,7 +176,7 @@ import com.puppycrawl.tools.checkstyle.checks.imports.AvoidStarImportCheck;
         <p id="Example1-config">
           To configure the check :
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
+        <div class="wrapper"><pre><code class="language-xml">
 &lt;module name="Checker"&gt;
   &lt;module name="TreeWalker"&gt;
     &lt;module name="CustomImportOrder"/&gt;
@@ -186,7 +186,7 @@ import com.puppycrawl.tools.checkstyle.checks.imports.AvoidStarImportCheck;
         <p id="Example1-code">
           Example:
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+        <div class="wrapper"><pre><code class="language-java">
 package com.puppycrawl.tools.checkstyle.checks.imports.customimportorder;
 import org.apache.commons.io.FileUtils;
 import static java.util.Collections.*;
@@ -199,7 +199,7 @@ import com.puppycrawl.tools.checkstyle.checks.imports.ImportOrderCheck;
           To configure the check so that it checks in the order
           (static imports,standard java packages,third party package):
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
+        <div class="wrapper"><pre><code class="language-xml">
 &lt;module name="Checker"&gt;
   &lt;module name="TreeWalker"&gt;
     &lt;module name="CustomImportOrder"&gt;
@@ -212,7 +212,7 @@ import com.puppycrawl.tools.checkstyle.checks.imports.ImportOrderCheck;
         <p id="Example2-code">
           Example:
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+        <div class="wrapper"><pre><code class="language-java">
 package com.puppycrawl.tools.checkstyle.checks.imports.customimportorder;
 import static java.util.Collections.*;
 
@@ -227,7 +227,7 @@ import com.puppycrawl.tools.checkstyle.checks.imports.ImportOrderCheck;
         <p id="Example3-config">
           To configure the check such that only java packages are included in standard java packages
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
+        <div class="wrapper"><pre><code class="language-xml">
 &lt;module name="Checker"&gt;
   &lt;module name="TreeWalker"&gt;
     &lt;module name="CustomImportOrder"&gt;
@@ -241,7 +241,7 @@ import com.puppycrawl.tools.checkstyle.checks.imports.ImportOrderCheck;
         <p id="Example3-code">
         Example:
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+        <div class="wrapper"><pre><code class="language-java">
 package com.puppycrawl.tools.checkstyle.checks.imports.customimportorder;
 
 import static java.util.Collections.*;
@@ -258,7 +258,7 @@ import com.puppycrawl.tools.checkstyle.checks.imports.ImportOrderCheck;
           To configure the check to include only &quot;com&quot; packages
           as third party group imports:
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
+        <div class="wrapper"><pre><code class="language-xml">
 &lt;module name="Checker"&gt;
   &lt;module name="TreeWalker"&gt;
     &lt;module name="CustomImportOrder"&gt;
@@ -272,7 +272,7 @@ import com.puppycrawl.tools.checkstyle.checks.imports.ImportOrderCheck;
         <p id="Example4-code">
           Example:
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+        <div class="wrapper"><pre><code class="language-java">
 package com.puppycrawl.tools.checkstyle.checks.imports.customimportorder;
 
 import static java.util.Collections.*;
@@ -288,7 +288,7 @@ import com.puppycrawl.tools.checkstyle.checks.imports.ImportOrderCheck;
         <p id="Example5-config">
           To configure the check to force some packages in special import group:
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
+        <div class="wrapper"><pre><code class="language-xml">
 &lt;module name="Checker"&gt;
   &lt;module name="TreeWalker"&gt;
     &lt;module name="CustomImportOrder"&gt;
@@ -302,7 +302,7 @@ import com.puppycrawl.tools.checkstyle.checks.imports.ImportOrderCheck;
         <p id="Example5-code">
         Example:
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+        <div class="wrapper"><pre><code class="language-java">
 package com.puppycrawl.tools.checkstyle.checks.imports.customimportorder;
 
 import static java.util.Collections.*;
@@ -318,7 +318,7 @@ import org.apache.commons.io.FileUtils; // violation, 'wrong order'
         <p id="Example6-config">
           To configure the check such that empty line separator between two groups is enabled:
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
+        <div class="wrapper"><pre><code class="language-xml">
 &lt;module name="Checker"&gt;
   &lt;module name="TreeWalker"&gt;
     &lt;module name="CustomImportOrder"&gt;
@@ -334,7 +334,7 @@ import org.apache.commons.io.FileUtils; // violation, 'wrong order'
         <p id="Example6-code">
           Example:
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+        <div class="wrapper"><pre><code class="language-java">
 package com.puppycrawl.tools.checkstyle.checks.imports.customimportorder;
 
 import static java.util.Collections.*;
@@ -349,7 +349,7 @@ import com.puppycrawl.tools.checkstyle.checks.imports.ImportOrderCheck;
         <p id="Example7-config">
           To configure the check such that import groups are forced to be sorted alphabetically:
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
+        <div class="wrapper"><pre><code class="language-xml">
 &lt;module name="Checker"&gt;
   &lt;module name="TreeWalker"&gt;
     &lt;module name="CustomImportOrder"&gt;
@@ -366,7 +366,7 @@ import com.puppycrawl.tools.checkstyle.checks.imports.ImportOrderCheck;
         <p id="Example7-code">
           Example:
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+        <div class="wrapper"><pre><code class="language-java">
 package com.puppycrawl.tools.checkstyle.checks.imports.customimportorder;
 
 import static java.util.Collections.*;
@@ -394,7 +394,7 @@ import com.puppycrawl.tools.checkstyle.checks.imports.ImportOrderCheck;
           <li>configuration below doesn't work in all 100% cases due to inconsistent behavior
               prior to Mars release, but covers most scenarios</li>
         </ul>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
+        <div class="wrapper"><pre><code class="language-xml">
 &lt;module name="Checker"&gt;
   &lt;module name="TreeWalker"&gt;
     &lt;module name="CustomImportOrder"&gt;
@@ -410,7 +410,7 @@ import com.puppycrawl.tools.checkstyle.checks.imports.ImportOrderCheck;
         <p id="Example8-code">
           Example:
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+        <div class="wrapper"><pre><code class="language-java">
 package com.puppycrawl.tools.checkstyle.checks.imports.customimportorder;
 
 import static java.util.Collections.*;
@@ -433,7 +433,7 @@ import com.puppycrawl.tools.checkstyle.checks.imports.ImportOrderCheck;
           <li>imports will be sorted in the groups</li>
           <li>groups are separated by one blank line</li>
         </ul>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
+        <div class="wrapper"><pre><code class="language-xml">
 &lt;module name="Checker"&gt;
   &lt;module name="TreeWalker"&gt;
     &lt;module name="CustomImportOrder"&gt;
@@ -450,7 +450,7 @@ import com.puppycrawl.tools.checkstyle.checks.imports.ImportOrderCheck;
         <p id="Example9-code">
           Example:
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+        <div class="wrapper"><pre><code class="language-java">
 package com.puppycrawl.tools.checkstyle.checks.imports.customimportorder;
 
 import static java.io.File.separator;
@@ -480,7 +480,7 @@ import org.apache.commons.io.FileUtils;
         &quot;javax&quot; and &quot;java&quot;
         </p>
 
-        <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
+        <div class="wrapper"><pre><code class="language-xml">
 &lt;module name="Checker"&gt;
   &lt;module name="TreeWalker"&gt;
     &lt;module name="CustomImportOrder"&gt;
@@ -497,7 +497,7 @@ import org.apache.commons.io.FileUtils;
         <p id="Example10-code">
           Example:
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+        <div class="wrapper"><pre><code class="language-java">
 package com.puppycrawl.tools.checkstyle.checks.imports.customimportorder;
 
 import static java.io.File.separator;
@@ -521,7 +521,7 @@ import com.puppycrawl.tools.checkstyle.checks.imports.ImportOrderCheck; // viola
           <li>static imports are not separated, they will be sorted along with other imports</li>
         </ul>
 
-        <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
+        <div class="wrapper"><pre><code class="language-xml">
 &lt;module name="Checker"&gt;
   &lt;module name="TreeWalker"&gt;
     &lt;module name="CustomImportOrder"/&gt;
@@ -531,7 +531,7 @@ import com.puppycrawl.tools.checkstyle.checks.imports.ImportOrderCheck; // viola
         <p id="Example11-code">
           Example:
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+        <div class="wrapper"><pre><code class="language-java">
 package com.puppycrawl.tools.checkstyle.checks.imports.customimportorder;
 
 import static java.io.File.separator;
@@ -547,7 +547,7 @@ import org.apache.commons.io.FileUtils; // violation, 'Extra separation'
           To set RegExps for THIRD_PARTY_PACKAGE and STANDARD_JAVA_PACKAGE groups use
           thirdPartyPackageRegExp and standardPackageRegExp options.
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
+        <div class="wrapper"><pre><code class="language-xml">
 &lt;module name="Checker"&gt;
   &lt;module name="TreeWalker"&gt;
     &lt;module name="CustomImportOrder"&gt;
@@ -562,7 +562,7 @@ import org.apache.commons.io.FileUtils; // violation, 'Extra separation'
         <p id="Example12-code">
           Example:
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+        <div class="wrapper"><pre><code class="language-java">
 package com.puppycrawl.tools.checkstyle.checks.imports.customimportorder;
 
 import static java.io.File.separator;
@@ -579,7 +579,7 @@ import org.apache.commons.io.FileUtils;
           Also, this check can be configured to force empty line separator between
           import groups. For example.
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
+        <div class="wrapper"><pre><code class="language-xml">
 &lt;module name="Checker"&gt;
   &lt;module name="TreeWalker"&gt;
     &lt;module name="CustomImportOrder"&gt;
@@ -591,7 +591,7 @@ import org.apache.commons.io.FileUtils;
         <p id="Example13-code">
           Example:
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+        <div class="wrapper"><pre><code class="language-java">
 package com.puppycrawl.tools.checkstyle.checks.imports.customimportorder;
 
 import static java.io.File.separator;
@@ -607,7 +607,7 @@ import org.apache.commons.io.FileUtils;
           ASCII sort order</a>
           of imports in groups using the following configuration:
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
+        <div class="wrapper"><pre><code class="language-xml">
 &lt;module name="Checker"&gt;
   &lt;module name="TreeWalker"&gt;
     &lt;module name="CustomImportOrder"&gt;
@@ -619,7 +619,7 @@ import org.apache.commons.io.FileUtils;
         <p id="Example14-code">
           Example of ASCII order:
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+        <div class="wrapper"><pre><code class="language-java">
 package com.puppycrawl.tools.checkstyle.checks.imports.customimportorder;
 
 import java.awt.Dialog;
@@ -630,7 +630,7 @@ import java.awt.Frame; // violation, in ASCII order all uppercase comes before l
         <p id="Example15-code">
           To force checking imports sequence such as:
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+        <div class="wrapper"><pre><code class="language-java">
 package com.puppycrawl.tools.checkstyle.checks.imports.customimportorder;
 
 import com.google.common.annotations.GwtCompatible;
@@ -647,7 +647,7 @@ import java.lang.String;
         <p id="Example15-config">
           configure as follows:
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
+        <div class="wrapper"><pre><code class="language-xml">
 &lt;module name="Checker"&gt;
   &lt;module name="TreeWalker"&gt;
     &lt;module name="CustomImportOrder"&gt;

--- a/src/site/xdoc/checks/imports/illegalimport.xml
+++ b/src/site/xdoc/checks/imports/illegalimport.xml
@@ -64,7 +64,7 @@
         <p id="Example1-config">
           To configure the check:
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
+        <div class="wrapper"><pre><code class="language-xml">
 &lt;module name="Checker"&gt;
   &lt;module name="TreeWalker"&gt;
     &lt;module name="IllegalImport"/&gt;
@@ -74,7 +74,7 @@
         <p id="Example1-code">
             The following example shows class with no illegal imports
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+        <div class="wrapper"><pre><code class="language-java">
 import java.io.*;
 import java.lang.ArithmeticException;
 import java.sql.Connection;
@@ -91,7 +91,7 @@ public class Example1 {}
           To configure the check so that it rejects packages <code>java.io.*</code>
           and <code>java.sql.*</code>:
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
+        <div class="wrapper"><pre><code class="language-xml">
 &lt;module name="Checker"&gt;
   &lt;module name="TreeWalker"&gt;
     &lt;module name="IllegalImport"&gt;
@@ -107,7 +107,7 @@ public class Example1 {}
           <li><b>java.io.*</b>, illegalPkgs property contains this package</li>
           <li><b>java.sql.Connection</b> is inside java.sql package</li>
         </ul>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+        <div class="wrapper"><pre><code class="language-java">
 import java.io.*; // violation, 'Illegal import'
 import java.lang.ArithmeticException;
 import java.sql.Connection; // violation, 'Illegal import'
@@ -124,7 +124,7 @@ public class Example2 {}
           To configure the check so that it rejects classes <code>java.util.Date</code> and
           <code>java.sql.Connection</code>:
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
+        <div class="wrapper"><pre><code class="language-xml">
 &lt;module name="Checker"&gt;
   &lt;module name="TreeWalker"&gt;
     &lt;module name="IllegalImport"&gt;
@@ -141,7 +141,7 @@ public class Example2 {}
           <li><b>java.sql.Connection</b>, illegalClasses property contains this class</li>
           <li><b>java.util.Date</b>, illegalClasses property contains this class</li>
         </ul>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+        <div class="wrapper"><pre><code class="language-java">
 import java.io.*;
 import java.lang.ArithmeticException;
 import java.sql.Connection; // violation, 'Illegal import'
@@ -158,7 +158,7 @@ public class Example3 {}
           To configure the check so that it rejects packages not satisfying to regular
           expression <code>java\.util</code>:
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
+        <div class="wrapper"><pre><code class="language-xml">
 &lt;module name="Checker"&gt;
   &lt;module name="TreeWalker"&gt;
     &lt;module name="IllegalImport"&gt;
@@ -180,7 +180,7 @@ public class Example3 {}
         <p id="Example4-code">
           All four imports match &quot;java\.util&quot; regular expression
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+        <div class="wrapper"><pre><code class="language-java">
 import java.io.*;
 import java.lang.ArithmeticException;
 import java.sql.Connection;
@@ -198,7 +198,7 @@ public class Example4 {}
           expression <code>^java\.util\.(List|Arrays)</code> and
           <code>^java\.sql\.Connection</code>:
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
+        <div class="wrapper"><pre><code class="language-xml">
 &lt;module name="Checker"&gt;
   &lt;module name="TreeWalker"&gt;
     &lt;module name="IllegalImport"&gt;
@@ -217,7 +217,7 @@ public class Example4 {}
           <li><b>java.util.List</b> matches &quot;^java\.util\.(List|Arrays)&quot; regular expression</li>
           <li><b>java.util.Arrays</b> matches &quot;^java\.util\.(List|Arrays)&quot; regular expression</li>
         </ul>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+        <div class="wrapper"><pre><code class="language-java">
 import java.io.*;
 import java.lang.ArithmeticException;
 import java.sql.Connection; // violation, 'Illegal import'

--- a/src/site/xdoc/checks/imports/importorder.xml
+++ b/src/site/xdoc/checks/imports/importorder.xml
@@ -114,7 +114,7 @@
         <p id="Example1-config">
           To configure the check:
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
+        <div class="wrapper"><pre><code class="language-xml">
 &lt;module name="Checker"&gt;
   &lt;module name="TreeWalker"&gt;
     &lt;module name="ImportOrder"/&gt;
@@ -124,7 +124,7 @@
         <p id="Example1-code">
           Example:
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+        <div class="wrapper"><pre><code class="language-java">
 import java.io.IOException;
 import java.net.URL;
 
@@ -157,7 +157,7 @@ import com.neurologic.http.impl.ApacheHttpClient;
           <li>configuration below doesn't work in all 100% cases due to inconsistent behavior
               prior to Mars release, but covers most scenarios</li>
         </ul>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
+        <div class="wrapper"><pre><code class="language-xml">
 &lt;module name="Checker"&gt;
   &lt;module name="TreeWalker"&gt;
     &lt;module name="ImportOrder"&gt;
@@ -173,7 +173,7 @@ import com.neurologic.http.impl.ApacheHttpClient;
         <p id="Example2-code">
           Example:
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+        <div class="wrapper"><pre><code class="language-java">
 import static java.lang.System.out;
 import static java.lang.Math; // violation, alphabetical case-sensitive ASCII order, 'M' &lt; 'S'
 import java.io.IOException;
@@ -199,7 +199,7 @@ import org.apache.http.conn.ClientConnectionManager;
           <li>groups are separated by, at least, one blank line and aren't separated internally</li>
         </ul>
 
-        <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
+        <div class="wrapper"><pre><code class="language-xml">
 &lt;module name="Checker"&gt;
   &lt;module name="TreeWalker"&gt;
     &lt;module name="ImportOrder"&gt;
@@ -215,7 +215,7 @@ import org.apache.http.conn.ClientConnectionManager;
         <p id="Example3-code">
           Example:
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+        <div class="wrapper"><pre><code class="language-java">
 import static java.io.File.createTempFile;
 import static java.lang.Math.abs; // OK, alphabetical case-sensitive ASCII order, 'i' &lt; 'l'
 import java.lang.Math.sqrt; // OK, follows property 'Option' value 'above'
@@ -257,7 +257,7 @@ import com.neurologic.http.impl.ApacheHttpClient;
           Note: &quot;separated&quot; option is disabled because IDEA default has blank line
           between &quot;java&quot; and static imports, and no blank line between &quot;javax&quot; and &quot;java&quot;.
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
+        <div class="wrapper"><pre><code class="language-xml">
 &lt;module name="Checker"&gt;
   &lt;module name="TreeWalker"&gt;
     &lt;module name="ImportOrder"&gt;
@@ -277,7 +277,7 @@ import com.neurologic.http.impl.ApacheHttpClient;
         <p id="Example4-code">
           Example:
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+        <div class="wrapper"><pre><code class="language-java">
 import com.neurologic.http.impl.ApacheHttpClient;
 import static java.awt.Button.A;
 import javax.swing.JComponent;
@@ -297,7 +297,7 @@ import com.neurologic.http.HttpClient; // violation, wrong order, 'com' imports 
               group</li>
           <li>static imports are not separated, they will be sorted along with other imports</li>
         </ul>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
+        <div class="wrapper"><pre><code class="language-xml">
 &lt;module name="Checker"&gt;
   &lt;module name="TreeWalker"&gt;
     &lt;module name="ImportOrder"&gt;
@@ -309,7 +309,7 @@ import com.neurologic.http.HttpClient; // violation, wrong order, 'com' imports 
         <p id="Example5-code">
           Example:
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+        <div class="wrapper"><pre><code class="language-java">
 import static java.io.File.createTempFile;
 import java.lang.Math.sqrt;
 
@@ -342,7 +342,7 @@ import static javax.windowConstants.*;
           To configure the Check allows static imports grouped to the <b>top</b> being sorted
           alphabetically:
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
+        <div class="wrapper"><pre><code class="language-xml">
 &lt;module name="Checker"&gt;
   &lt;module name="TreeWalker"&gt;
     &lt;module name="ImportOrder"&gt;
@@ -356,7 +356,7 @@ import static javax.windowConstants.*;
         <p id="Example6-code">
           Example:
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+        <div class="wrapper"><pre><code class="language-java">
 import static java.lang.Math.PI;
 import static java.lang.Math.abs; // OK, alphabetical case-sensitive ASCII order, 'P' &lt; 'a'
 import static org.abego.treelayout.Configuration.AlignmentInLevel; // OK, alphabetical order
@@ -370,7 +370,7 @@ import org.abego.*;
           To configure the Check with groups of static imports:
         </p>
 
-        <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
+        <div class="wrapper"><pre><code class="language-xml">
 &lt;module name="Checker"&gt;
   &lt;module name="TreeWalker"&gt;
     &lt;module name="ImportOrder"&gt;
@@ -384,7 +384,7 @@ import org.abego.*;
         <p id="Example7-code">
           Example:
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+        <div class="wrapper"><pre><code class="language-java">
 import static org.abego.treelayout.Configuration.AlignmentInLevel; // Group 1
 import static java.lang.Math.abs; // Group 2
 import static java.lang.String.format; // Group 2
@@ -414,7 +414,7 @@ import static HttpHeaders.Names.DATE  =&gt; HttpHeaders.Names
         <p id="Example8-config">
           Example for <code>useContainerOrderingForStatic=true</code>
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
+        <div class="wrapper"><pre><code class="language-xml">
 &lt;module name="Checker"&gt;
   &lt;module name="TreeWalker"&gt;
     &lt;module name="ImportOrder"&gt;
@@ -430,7 +430,7 @@ import static HttpHeaders.Names.DATE  =&gt; HttpHeaders.Names
         <p id="Example8-code">
           Example:
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+        <div class="wrapper"><pre><code class="language-java">
 import static io.netty.handler.codec.http.HttpConstants.COLON;
 import static io.netty.handler.codec.http.HttpHeaders.addHeader;
 import static io.netty.handler.codec.http.HttpHeaders.setHeader;
@@ -439,7 +439,7 @@ import static io.netty.handler.codec.http.HttpHeaders.Names.DATE;
         <p id="Example9-config">
           Example for <code>useContainerOrderingForStatic=false</code>
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
+        <div class="wrapper"><pre><code class="language-xml">
 &lt;module name="Checker"&gt;
   &lt;module name="TreeWalker"&gt;
     &lt;module name="ImportOrder"&gt;
@@ -469,7 +469,7 @@ public class Example9 { }
         <p id="Example10-config">
           Example for <code>separatedStaticGroups=true</code>
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
+        <div class="wrapper"><pre><code class="language-xml">
 &lt;module name="Checker"&gt;
   &lt;module name="TreeWalker"&gt;
     &lt;module name="ImportOrder"&gt;
@@ -483,7 +483,7 @@ public class Example9 { }
         <p id="Example10-code">
           Example:
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+        <div class="wrapper"><pre><code class="language-java">
 import static java.lang.Math.PI;
 import static java.io.File.createTempFile;
 import static javax.swing.JComponent; // violation, should be separated from previous imports
@@ -495,7 +495,7 @@ import java.net.URL;
           To configure the Check with groups of static imports when staticGroups=&quot;&quot;
           represents all imports as {@code everything else} group:
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
+        <div class="wrapper"><pre><code class="language-xml">
 &lt;module name="Checker"&gt;
   &lt;module name="TreeWalker"&gt;
     &lt;module name="ImportOrder"&gt;
@@ -508,7 +508,7 @@ import java.net.URL;
         <p id="Example11-code">
           Example:
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+        <div class="wrapper"><pre><code class="language-java">
 import static java.io.File.listRoots;
 import static javax.swing.WindowConstants.*;
 import static java.io.File.createTempFile;
@@ -521,7 +521,7 @@ import static com.puppycrawl.tools.checkstyle;
           should be in last group:
         </p>
 
-        <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
+        <div class="wrapper"><pre><code class="language-xml">
 &lt;module name="Checker"&gt;
   &lt;module name="TreeWalker"&gt;
     &lt;module name="ImportOrder"&gt;
@@ -534,7 +534,7 @@ import static com.puppycrawl.tools.checkstyle;
         <p id="Example12-code">
           Example:
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+        <div class="wrapper"><pre><code class="language-java">
 import static java.io.File.listRoots;
 import static javax.swing.WindowConstants.*;
 import static java.io.File.createTempFile; // violation, should be before javax

--- a/src/site/xdoc/checks/imports/redundantimport.xml
+++ b/src/site/xdoc/checks/imports/redundantimport.xml
@@ -33,7 +33,7 @@
         <p id="Example1-config">
           To configure the check:
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
+        <div class="wrapper"><pre><code class="language-xml">
 &lt;module name="Checker"&gt;
   &lt;module name="TreeWalker"&gt;
     &lt;module name="RedundantImport"/&gt;
@@ -43,7 +43,7 @@
         <p id="Example1-code">
             Example:
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+        <div class="wrapper"><pre><code class="language-java">
 import static com.puppycrawl.tools.checkstyle.checks.imports.redundantimport.Example1.*; // OK, static import
 import static java.lang.Integer.MAX_VALUE; // OK, static import
 

--- a/src/site/xdoc/checks/imports/unusedimports.xml
+++ b/src/site/xdoc/checks/imports/unusedimports.xml
@@ -86,7 +86,7 @@
         <p id="Example1-config">
           To configure the check:
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
+        <div class="wrapper"><pre><code class="language-xml">
 &lt;module name="Checker"&gt;
   &lt;module name="TreeWalker"&gt;
     &lt;module name="UnusedImports"/&gt;
@@ -94,7 +94,7 @@
 &lt;/module&gt;
 </code></pre></div>
         <p id="Example1-code">Example:</p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+        <div class="wrapper"><pre><code class="language-java">
 // limitation as it match field name in code
 import java.awt.Component; //OK
 
@@ -126,7 +126,7 @@ class Example1{
         <p id="Example2-config">
           To configure the check so that it ignores the imports referenced in Javadoc comments:
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
+        <div class="wrapper"><pre><code class="language-xml">
 &lt;module name="Checker"&gt;
   &lt;module name="TreeWalker"&gt;
     &lt;module name="UnusedImports"&gt;
@@ -136,7 +136,7 @@ class Example1{
 &lt;/module&gt;
 </code></pre></div>
         <p id="Example2-code">Example:</p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+        <div class="wrapper"><pre><code class="language-java">
 // limitation as it match field name in code
 import java.awt.Component; //OK
 

--- a/src/site/xdoc/checks/javadoc/atclauseorder.xml
+++ b/src/site/xdoc/checks/javadoc/atclauseorder.xml
@@ -76,7 +76,7 @@
         <p id="Example1-config">
             To configure the default check:
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
+        <div class="wrapper"><pre><code class="language-xml">
 &lt;module name="Checker"&gt;
   &lt;module name="TreeWalker"&gt;
     &lt;module name="AtclauseOrder"/&gt;
@@ -86,7 +86,7 @@
         <p id="Example1-code">
           Example:
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+        <div class="wrapper"><pre><code class="language-java">
 /**
 * Some javadoc.
 *
@@ -130,7 +130,7 @@ enum Test1 {}
         <p id="Example2-config">
             To configure the check such that it checks in the custom order:
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
+        <div class="wrapper"><pre><code class="language-xml">
 &lt;module name="Checker"&gt;
   &lt;module name="TreeWalker"&gt;
     &lt;module name="AtclauseOrder"&gt;
@@ -145,7 +145,7 @@ enum Test1 {}
         <p id="Example2-code">
           Example:
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+        <div class="wrapper"><pre><code class="language-java">
 /**
 * Some javadoc.
 *
@@ -189,7 +189,7 @@ enum Test2 {}
         <p id="Example3-config">
             To configure the check such that it targets only enums:
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
+        <div class="wrapper"><pre><code class="language-xml">
 &lt;module name="Checker"&gt;
   &lt;module name="TreeWalker"&gt;
     &lt;module name="AtclauseOrder"&gt;
@@ -205,7 +205,7 @@ enum Test2 {}
         <p id="Example3-code">
           Example:
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+        <div class="wrapper"><pre><code class="language-java">
 /**
 * Some javadoc.
 *

--- a/src/site/xdoc/checks/javadoc/invalidjavadocposition.xml
+++ b/src/site/xdoc/checks/javadoc/invalidjavadocposition.xml
@@ -25,7 +25,7 @@
         <p id="Example1-config">
           To configure the check:
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
+        <div class="wrapper"><pre><code class="language-xml">
 &lt;module name="Checker"&gt;
   &lt;module name="TreeWalker"&gt;
     &lt;module name="InvalidJavadocPosition"/&gt;
@@ -36,7 +36,7 @@
           The following code produces a violation because Javadocs should be before all
           annotations of the Javadoc's target:
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+        <div class="wrapper"><pre><code class="language-java">
 @SuppressWarnings("serial")
 // violation below, 'Javadoc comment is placed in the wrong location'
 /**

--- a/src/site/xdoc/checks/javadoc/javadocblocktaglocation.xml
+++ b/src/site/xdoc/checks/javadoc/javadocblocktaglocation.xml
@@ -75,7 +75,7 @@
         <p id="Example1-config">
           To configure the default check:
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
+        <div class="wrapper"><pre><code class="language-xml">
 &lt;module name="Checker"&gt;
   &lt;module name="TreeWalker"&gt;
     &lt;module name="JavadocBlockTagLocation"/&gt;
@@ -83,7 +83,7 @@
 &lt;/module&gt;
 </code></pre></div>
         <p id="Example1-code">Example:</p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+        <div class="wrapper"><pre><code class="language-java">
 /**
  * Escaped tag &amp;#64;version (OK)
  * Plain text with {@code @see} (OK)
@@ -95,7 +95,7 @@
           To configure the check to verify tags from
           <a href="https://openjdk.org/jeps/8068562">JEP 8068562</a> only:
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
+        <div class="wrapper"><pre><code class="language-xml">
 &lt;module name="Checker"&gt;
   &lt;module name="TreeWalker"&gt;
     &lt;module name="JavadocBlockTagLocation"&gt;
@@ -107,7 +107,7 @@
         <p id="Example3-config">
           To configure the check to verify all default tags and some custom tags in addition:
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
+        <div class="wrapper"><pre><code class="language-xml">
 &lt;module name="Checker"&gt;
   &lt;module name="TreeWalker"&gt;
     &lt;module name="JavadocBlockTagLocation"&gt;

--- a/src/site/xdoc/checks/javadoc/javadoccontentlocation.xml
+++ b/src/site/xdoc/checks/javadoc/javadoccontentlocation.xml
@@ -97,7 +97,7 @@ public void method();
           To configure the default check to validate that the Javadoc content starts from the
           second line:
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
+        <div class="wrapper"><pre><code class="language-xml">
 &lt;module name="Checker"&gt;
   &lt;module name="TreeWalker"&gt;
     &lt;module name="JavadocContentLocation"/&gt;
@@ -108,7 +108,7 @@ public void method();
           This setting produces a violation for each multi-line comment
           starting on the same line as the initial asterisks:
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+        <div class="wrapper"><pre><code class="language-java">
 class Example1 {
 
   // violation below 'Javadoc content should start from the next line.'
@@ -131,7 +131,7 @@ class Example1 {
         <p id="Example2-config">
           To ensure that Javadoc content starts from the first line:
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
+        <div class="wrapper"><pre><code class="language-xml">
 &lt;module name="Checker"&gt;
   &lt;module name="TreeWalker"&gt;
     &lt;module name="JavadocContentLocation"&gt;
@@ -144,7 +144,7 @@ class Example1 {
           This setting produces a violation for each comment not
           starting on the same line as the initial asterisks:
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+        <div class="wrapper"><pre><code class="language-java">
 class Example2 {
 
   /** This comment is OK because it starts on the first line.

--- a/src/site/xdoc/checks/javadoc/javadocleadingasteriskalign.xml
+++ b/src/site/xdoc/checks/javadoc/javadocleadingasteriskalign.xml
@@ -53,7 +53,7 @@
         <p id="Example1-config">
           To configure the check:
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
+        <div class="wrapper"><pre><code class="language-xml">
 &lt;module name="Checker"&gt;
   &lt;module name="TreeWalker"&gt;
     &lt;module name="JavadocLeadingAsteriskAlign" /&gt;
@@ -63,7 +63,7 @@
         <p id="Example1-code">
           Example with correct alignment:
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+        <div class="wrapper"><pre><code class="language-java">
 /** Title
  * Javadoc for class
  */
@@ -105,7 +105,7 @@ public class Example1 {
         <p id="Example2-code">
           Example with incorrect alignment:
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+        <div class="wrapper"><pre><code class="language-java">
 /** Title
 * Javadoc for class // violation
     */ // violation
@@ -150,7 +150,7 @@ public class Example2 {
         <p id="Example3-config">
           To configure the check with <code>tabWidth</code> property:
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
+        <div class="wrapper"><pre><code class="language-xml">
 &lt;module name="Checker"&gt;
   &lt;module name="TreeWalker"&gt;
     &lt;module name="JavadocLeadingAsteriskAlign"&gt;
@@ -162,7 +162,7 @@ public class Example2 {
         <p id="Example3-code">
           Example:
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+        <div class="wrapper"><pre><code class="language-java">
 /**
  * Example with `tabWidth` property.
  * This example contains Tabs as well as Spaces.

--- a/src/site/xdoc/checks/javadoc/javadocmethod.xml
+++ b/src/site/xdoc/checks/javadoc/javadocmethod.xml
@@ -163,7 +163,7 @@ public int checkReturnTag(final int aTagIndex,
         <p id="Example1-config">
           To configure the default check:
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
+        <div class="wrapper"><pre><code class="language-xml">
 &lt;module name="Checker"&gt;
   &lt;module name="TreeWalker"&gt;
     &lt;module name="JavadocMethod"/&gt;
@@ -171,7 +171,7 @@ public int checkReturnTag(final int aTagIndex,
 &lt;/module&gt;
 </code></pre></div>
         <p id="Example1-code"> Example:</p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+        <div class="wrapper"><pre><code class="language-java">
 public class Example1 {
 
   /** */
@@ -200,7 +200,7 @@ public class Example1 {
           modifier, ignoring any missing param tags is:
         </p>
 
-        <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
+        <div class="wrapper"><pre><code class="language-xml">
 &lt;module name="Checker"&gt;
   &lt;module name="TreeWalker"&gt;
     &lt;module name="JavadocMethod"&gt;
@@ -211,7 +211,7 @@ public class Example1 {
 &lt;/module&gt;
 </code></pre></div>
         <p id="Example2-code">Example: </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+        <div class="wrapper"><pre><code class="language-java">
 public class Example2 {
 
   /** */
@@ -239,7 +239,7 @@ public class Example2 {
             To configure the check for methods which are in <code>private</code> and
           <code>package</code>, but not any other modifier:
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
+        <div class="wrapper"><pre><code class="language-xml">
 &lt;module name="Checker"&gt;
   &lt;module name="TreeWalker"&gt;
     &lt;module name="JavadocMethod"&gt;
@@ -249,7 +249,7 @@ public class Example2 {
 &lt;/module&gt;
 </code></pre></div>
         <p id="Example3-code"> Example:</p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+        <div class="wrapper"><pre><code class="language-java">
 public class Example3 {
 
   /** */
@@ -276,7 +276,7 @@ public class Example3 {
         <p id="Example4-config">
               To configure the check to ignore any missing return tags:
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
+        <div class="wrapper"><pre><code class="language-xml">
 &lt;module name="Checker"&gt;
   &lt;module name="TreeWalker"&gt;
     &lt;module name="JavadocMethod"&gt;
@@ -286,7 +286,7 @@ public class Example3 {
 &lt;/module&gt;
 </code></pre></div>
         <p id="Example4-code"> Example:</p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+        <div class="wrapper"><pre><code class="language-java">
 public class Example4 {
 
   /** */
@@ -313,7 +313,7 @@ public class Example4 {
         <p id="Example5-config">
               To configure the check to ignore Methods with annotation <code>Deprecated</code>:
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
+        <div class="wrapper"><pre><code class="language-xml">
 &lt;module name="Checker"&gt;
   &lt;module name="TreeWalker"&gt;
     &lt;module name="JavadocMethod"&gt;
@@ -323,7 +323,7 @@ public class Example4 {
 &lt;/module&gt;
 </code></pre></div>
         <p id="Example5-code"> Example:</p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+        <div class="wrapper"><pre><code class="language-java">
 public class Example5 {
 
   /** */
@@ -350,7 +350,7 @@ public class Example5 {
         <p id="Example6-config">
               To configure the check only for tokens which are Constructor Definitions:
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
+        <div class="wrapper"><pre><code class="language-xml">
 &lt;module name="Checker"&gt;
   &lt;module name="TreeWalker"&gt;
     &lt;module name="JavadocMethod"&gt;
@@ -360,7 +360,7 @@ public class Example5 {
 &lt;/module&gt;
 </code></pre></div>
         <p id="Example6-code"> Example:</p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+        <div class="wrapper"><pre><code class="language-java">
 public class Example6 {
 
   /** */
@@ -388,7 +388,7 @@ public class Example6 {
         <p id="Example7-config">
           To configure the check to validate <code>throws</code> tags, you can use following config.
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
+        <div class="wrapper"><pre><code class="language-xml">
 &lt;module name="Checker"&gt;
   &lt;module name="TreeWalker"&gt;
     &lt;module name="JavadocMethod"&gt;
@@ -398,7 +398,7 @@ public class Example6 {
 &lt;/module&gt;
 </code></pre></div>
         <p id="Example7-code"> Example:</p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+        <div class="wrapper"><pre><code class="language-java">
 public class Example7 {
 
   /**

--- a/src/site/xdoc/checks/javadoc/javadocmissingleadingasterisk.xml
+++ b/src/site/xdoc/checks/javadoc/javadocmissingleadingasterisk.xml
@@ -49,7 +49,7 @@
         <p id="Example1-config">
           To configure the check:
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
+        <div class="wrapper"><pre><code class="language-xml">
 &lt;module name="Checker"&gt;
   &lt;module name="TreeWalker"&gt;
     &lt;module name="JavadocMissingLeadingAsterisk"/&gt;
@@ -57,7 +57,7 @@
 &lt;/module&gt;
 </code></pre></div>
         <p id="Example1-code">Example:</p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+        <div class="wrapper"><pre><code class="language-java">
 /**
  * Valid Java-style comment.
  *

--- a/src/site/xdoc/checks/javadoc/javadocmissingwhitespaceafterasterisk.xml
+++ b/src/site/xdoc/checks/javadoc/javadocmissingwhitespaceafterasterisk.xml
@@ -43,7 +43,7 @@
         <p id="Example1-config">
           To configure the default check:
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
+        <div class="wrapper"><pre><code class="language-xml">
 &lt;module name="Checker"&gt;
   &lt;module name="TreeWalker"&gt;
     &lt;module name="JavadocMissingWhitespaceAfterAsterisk"/&gt;
@@ -53,7 +53,7 @@
         <p id="Example1-code">
           Code Example:
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+        <div class="wrapper"><pre><code class="language-java">
 /** This is valid single-line Javadoc. */
 class Example1 {
   /**

--- a/src/site/xdoc/checks/javadoc/javadocpackage.xml
+++ b/src/site/xdoc/checks/javadoc/javadocpackage.xml
@@ -53,7 +53,7 @@
         <p id="Example1-config">
           To configure the check:
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
+        <div class="wrapper"><pre><code class="language-xml">
 &lt;module name="Checker"&gt;
   &lt;module name="JavadocPackage"/&gt;
 &lt;/module&gt;
@@ -66,7 +66,7 @@
           The following violation is raised in default when
           package-info.java file is missing from directory.
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+        <div class="wrapper"><pre><code class="language-java">
 package com.puppycrawl.tools.checkstyle.checks.javadoc.javadocpackage.nonlegacy;
 /* violation on first line 'Missing package-info.java file' */
 public class Example1 { }
@@ -75,7 +75,7 @@ public class Example1 { }
         <p id="Example2-config">
           To configure the check with allowlegacy set to true:
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
+        <div class="wrapper"><pre><code class="language-xml">
 &lt;module name="Checker"&gt;
   &lt;module name="JavadocPackage"&gt;
     &lt;property name="allowLegacy" value="true"/&gt;
@@ -91,7 +91,7 @@ public class Example1 { }
           The legacy configuration (allowLegacy=true) allows the use of the legacy package.html
           file as an alternative to package-info.java removing violation
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+        <div class="wrapper"><pre><code class="language-java">
 package com.puppycrawl.tools.checkstyle.checks.javadoc.javadocpackage.legacy;
 // OK as package.html file is present in directory
 public class Example2 { }
@@ -100,7 +100,7 @@ public class Example2 { }
         <p id="Example3-config">
           To configure the check with allowlegacy set to true:
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
+        <div class="wrapper"><pre><code class="language-xml">
 &lt;module name="Checker"&gt;
   &lt;module name="JavadocPackage"&gt;
     &lt;property name="allowLegacy" value="true"/&gt;
@@ -119,7 +119,7 @@ public class Example2 { }
           in place of package-info.java but still enforces that only one file
           (either package-info.java or package.html) exists in a package.
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+        <div class="wrapper"><pre><code class="language-java">
 package com.puppycrawl.tools.checkstyle.checks.javadoc.javadocpackage.legacywithboth;
 /* violation on first line 'Legacy package.html file should be removed' */
 public class Example3 { }

--- a/src/site/xdoc/checks/javadoc/javadocparagraph.xml
+++ b/src/site/xdoc/checks/javadoc/javadocparagraph.xml
@@ -74,7 +74,7 @@
         <p id="Example1-config">
           To configure the default check:
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
+        <div class="wrapper"><pre><code class="language-xml">
 &lt;module name="Checker"&gt;
   &lt;module name="TreeWalker"&gt;
     &lt;module name="JavadocParagraph"/&gt;
@@ -83,7 +83,7 @@
 </code></pre></div>
         <p id="Example1-code">By default, the check will report a violation if there is
           no empty line before or whitespace after the &lt;p&gt; tag: </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+        <div class="wrapper"><pre><code class="language-java">
 // violation 5 lines below '&lt;p&gt; tag should be preceded with an empty line'
 /**
  * No tag
@@ -144,7 +144,7 @@ public class Example1 {
         <p id="Example2-config">
           To not allow newlines and spaces immediately after the &lt;p&gt; tag:
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
+        <div class="wrapper"><pre><code class="language-xml">
 &lt;module name="Checker"&gt;
   &lt;module name="TreeWalker"&gt;
     &lt;module name="JavadocParagraph"&gt;
@@ -157,7 +157,7 @@ public class Example1 {
           In case of <code>allowNewlineParagraph</code> set to <code>false</code>
           the following example will have violations:
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+        <div class="wrapper"><pre><code class="language-java">
 // violation 5 lines below '&lt;p&gt; tag should be preceded with an empty line'
 /**
  * No tag

--- a/src/site/xdoc/checks/javadoc/javadocstyle.xml
+++ b/src/site/xdoc/checks/javadoc/javadocstyle.xml
@@ -185,7 +185,7 @@
           To configure the default check:
         </p>
 
-        <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
+        <div class="wrapper"><pre><code class="language-xml">
 &lt;module name="Checker"&gt;
   &lt;module name="TreeWalker"&gt;
     &lt;module name="JavadocStyle"/&gt;
@@ -194,7 +194,7 @@
 </code></pre></div>
 
         <p id="Example1-code">Example1:</p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+        <div class="wrapper"><pre><code class="language-java">
 /**
  * Some description here
  */
@@ -246,7 +246,7 @@ public class Example1 {
         <p id="Example2-config">
           To configure the check for <code>public</code> scope:
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
+        <div class="wrapper"><pre><code class="language-xml">
 &lt;module name="Checker"&gt;
   &lt;module name="TreeWalker"&gt;
     &lt;module name="JavadocStyle"&gt;
@@ -256,7 +256,7 @@ public class Example1 {
 &lt;/module&gt;
 </code></pre></div>
         <p id="Example2-code">Example2:</p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+        <div class="wrapper"><pre><code class="language-java">
 /**
  * Some description here
  */
@@ -310,7 +310,7 @@ public class Example2 {
           <code>package</code> scope:
         </p>
 
-        <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
+        <div class="wrapper"><pre><code class="language-xml">
 &lt;module name="Checker"&gt;
   &lt;module name="TreeWalker"&gt;
     &lt;module name="JavadocStyle"&gt;
@@ -321,7 +321,7 @@ public class Example2 {
 &lt;/module&gt;
 </code></pre></div>
         <p id="Example3-code">Example3:</p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+        <div class="wrapper"><pre><code class="language-java">
 /**
  * Some description here
  */
@@ -374,7 +374,7 @@ public class Example3 {
           To configure the check to turn off first sentence checking:
         </p>
 
-        <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
+        <div class="wrapper"><pre><code class="language-xml">
 &lt;module name="Checker"&gt;
   &lt;module name="TreeWalker"&gt;
     &lt;module name="JavadocStyle"&gt;
@@ -384,7 +384,7 @@ public class Example3 {
 &lt;/module&gt;
 </code></pre></div>
         <p id="Example4-code">Example4:</p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+        <div class="wrapper"><pre><code class="language-java">
 /**
  * Some description here
  */
@@ -436,7 +436,7 @@ public class Example4 {
         <p id="Example5-config">
           To configure the check to turn off validation of incomplete html tags:
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
+        <div class="wrapper"><pre><code class="language-xml">
 &lt;module name="Checker"&gt;
   &lt;module name="TreeWalker"&gt;
     &lt;module name="JavadocStyle"&gt;
@@ -447,7 +447,7 @@ public class Example4 {
 </code></pre></div>
 
         <p id="Example5-code">Example5:</p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+        <div class="wrapper"><pre><code class="language-java">
 /**
  * Some description here
  */
@@ -499,7 +499,7 @@ public class Example5 {
         <p id="Example6-config">
           To configure the check for only class definitions:
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
+        <div class="wrapper"><pre><code class="language-xml">
 &lt;module name="Checker"&gt;
   &lt;module name="TreeWalker"&gt;
     &lt;module name="JavadocStyle"&gt;
@@ -510,7 +510,7 @@ public class Example5 {
 </code></pre></div>
 
         <p id="Example6-code">Example6:</p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+        <div class="wrapper"><pre><code class="language-java">
 /**
  * Some description here
  */

--- a/src/site/xdoc/checks/javadoc/javadoctagcontinuationindentation.xml
+++ b/src/site/xdoc/checks/javadoc/javadoctagcontinuationindentation.xml
@@ -52,7 +52,7 @@
         <p id="Example1-config">
           To configure the default check:
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
+        <div class="wrapper"><pre><code class="language-xml">
 &lt;module name="Checker"&gt;
   &lt;module name="TreeWalker"&gt;
     &lt;module name="JavadocTagContinuationIndentation"/&gt;
@@ -62,7 +62,7 @@
         <p id="Example1-code">
           Example:
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+        <div class="wrapper"><pre><code class="language-java">
 /**
  * &lt;p&gt; 'p' tag is unclosed
  * &lt;p&gt; 'p' tag is closed&lt;/p&gt;
@@ -89,7 +89,7 @@ class Example1 {
         <p id="Example2-config">
           To configure the check with two spaces indentation:
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
+        <div class="wrapper"><pre><code class="language-xml">
 &lt;module name="Checker"&gt;
   &lt;module name="TreeWalker"&gt;
     &lt;module name="JavadocTagContinuationIndentation"&gt;
@@ -101,7 +101,7 @@ class Example1 {
         <p id="Example2-code">
           Example:
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+        <div class="wrapper"><pre><code class="language-java">
 /**
  * &lt;p&gt; 'p' tag is unclosed
  * &lt;p&gt; 'p' tag is closed&lt;/p&gt;
@@ -128,7 +128,7 @@ class Example2 {
         <p id="Example3-config">
           To configure the check to show violations for Tight-HTML Rules:
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
+        <div class="wrapper"><pre><code class="language-xml">
 &lt;module name="Checker"&gt;
   &lt;module name="TreeWalker"&gt;
     &lt;module name="JavadocTagContinuationIndentation"&gt;
@@ -140,7 +140,7 @@ class Example2 {
         <p id="Example3-code">
           Example:
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+        <div class="wrapper"><pre><code class="language-java">
 /**
  * &lt;p&gt; 'p' tag is unclosed
  * &lt;p&gt; 'p' tag is closed&lt;/p&gt;

--- a/src/site/xdoc/checks/javadoc/javadoctype.xml
+++ b/src/site/xdoc/checks/javadoc/javadoctype.xml
@@ -134,7 +134,7 @@
         <p id="Example1-config">
           To configure the default check:
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
+        <div class="wrapper"><pre><code class="language-xml">
 &lt;module name="Checker"&gt;
   &lt;module name="TreeWalker"&gt;
     &lt;module name="JavadocType"/&gt;
@@ -142,7 +142,7 @@
 &lt;/module&gt;
 </code></pre></div>
         <p id="Example1-code">Example1:</p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+        <div class="wrapper"><pre><code class="language-java">
 /**
  * @author a
  * @version $Revision1$
@@ -182,7 +182,7 @@ public class Example1 {
         <p id="Example2-config">
           To configure the check for <code>public</code> scope:
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
+        <div class="wrapper"><pre><code class="language-xml">
 &lt;module name="Checker"&gt;
   &lt;module name="TreeWalker"&gt;
     &lt;module name="JavadocType"&gt;
@@ -192,7 +192,7 @@ public class Example1 {
 &lt;/module&gt;
 </code></pre></div>
         <p id="Example2-code">Example2:</p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+        <div class="wrapper"><pre><code class="language-java">
 /**
  * @author a
  * @version $Revision1$
@@ -232,7 +232,7 @@ public class Example2 {
         <p id="Example3-config">
           To configure the check for an <code>@author</code> tag:
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
+        <div class="wrapper"><pre><code class="language-xml">
 &lt;module name="Checker"&gt;
   &lt;module name="TreeWalker"&gt;
     &lt;module name="JavadocType"&gt;
@@ -242,7 +242,7 @@ public class Example2 {
 &lt;/module&gt;
 </code></pre></div>
         <p id="Example3-code">Example3:</p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+        <div class="wrapper"><pre><code class="language-java">
 /**
  * @author a
  * @version $Revision1$
@@ -282,7 +282,7 @@ public class Example3 {
         <p id="Example4-config">
           To configure the check for a CVS revision version tag:
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
+        <div class="wrapper"><pre><code class="language-xml">
 &lt;module name="Checker"&gt;
   &lt;module name="TreeWalker"&gt;
     &lt;module name="JavadocType"&gt;
@@ -292,7 +292,7 @@ public class Example3 {
 &lt;/module&gt;
 </code></pre></div>
         <p id="Example4-code">Example4:</p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+        <div class="wrapper"><pre><code class="language-java">
 /**
  * @author a
  * @version $Revision1$
@@ -332,7 +332,7 @@ public class Example4 {
         <p id="Example5-config">
           To configure the check for <code>private</code> classes only:
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
+        <div class="wrapper"><pre><code class="language-xml">
 &lt;module name="Checker"&gt;
   &lt;module name="TreeWalker"&gt;
     &lt;module name="JavadocType"&gt;
@@ -343,7 +343,7 @@ public class Example4 {
 &lt;/module&gt;
 </code></pre></div>
         <p id="Example5-code">Example5:</p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+        <div class="wrapper"><pre><code class="language-java">
 /**
  * @author a
  * @version $Revision1$
@@ -383,7 +383,7 @@ public class Example5 {
         <p id="Example6-config">
           To configure the check that allows missing <code>@param</code> tags:
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
+        <div class="wrapper"><pre><code class="language-xml">
 &lt;module name="Checker"&gt;
   &lt;module name="TreeWalker"&gt;
     &lt;module name="JavadocType"&gt;
@@ -393,7 +393,7 @@ public class Example5 {
 &lt;/module&gt;
 </code></pre></div>
         <p id="Example6-code">Example6:</p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+        <div class="wrapper"><pre><code class="language-java">
 /**
  * @author a
  * @version $Revision1$
@@ -433,7 +433,7 @@ public class Example6 {
         <p id="Example7-config">
             To configure the check that allows unknown tags:
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
+        <div class="wrapper"><pre><code class="language-xml">
 &lt;module name="Checker"&gt;
   &lt;module name="TreeWalker"&gt;
     &lt;module name="JavadocType"&gt;
@@ -443,7 +443,7 @@ public class Example6 {
 &lt;/module&gt;
 </code></pre></div>
         <p id="Example7-code">Example7:</p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+        <div class="wrapper"><pre><code class="language-java">
 /**
  * @author a
  * @version $Revision1$
@@ -484,7 +484,7 @@ public class Example7 {
           To configure a check that allows skipping validation at all
           for classes annotated with <code>@unknownTag</code>
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
+        <div class="wrapper"><pre><code class="language-xml">
 &lt;module name="Checker"&gt;
   &lt;module name="TreeWalker"&gt;
     &lt;module name="JavadocType"&gt;
@@ -496,7 +496,7 @@ public class Example7 {
         <p id="Example8-code">
           Example8:
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+        <div class="wrapper"><pre><code class="language-java">
 /**
  * @author a
  * @version $Revision1$

--- a/src/site/xdoc/checks/javadoc/javadocvariable.xml
+++ b/src/site/xdoc/checks/javadoc/javadocvariable.xml
@@ -69,7 +69,7 @@
         <p id="Example1-config">
           To configure the default check:
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
+        <div class="wrapper"><pre><code class="language-xml">
 &lt;module name="Checker"&gt;
   &lt;module name="TreeWalker"&gt;
     &lt;module name="JavadocVariable"/&gt;
@@ -80,7 +80,7 @@
           By default, this setting will report a violation if
           there is no javadoc for any scope member.
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+        <div class="wrapper"><pre><code class="language-java">
 public class Example1 {
   private int a; // violation
 
@@ -100,7 +100,7 @@ public class Example1 {
           scope:
         </p>
 
-        <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
+        <div class="wrapper"><pre><code class="language-xml">
 &lt;module name="Checker"&gt;
   &lt;module name="TreeWalker"&gt;
     &lt;module name="JavadocVariable"&gt;
@@ -113,7 +113,7 @@ public class Example1 {
           This setting will report a violation if there
           is no javadoc for <code>public</code> member.
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+        <div class="wrapper"><pre><code class="language-java">
 public class Example2 {
   private int a;
 
@@ -132,7 +132,7 @@ public class Example2 {
           <code>protected</code> scope:
         </p>
 
-        <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
+        <div class="wrapper"><pre><code class="language-xml">
 &lt;module name="Checker"&gt;
   &lt;module name="TreeWalker"&gt;
     &lt;module name="JavadocVariable"&gt;
@@ -147,7 +147,7 @@ public class Example2 {
           javadoc for <code>private</code> member and
           ignores <code>protected</code> member.
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+        <div class="wrapper"><pre><code class="language-java">
 public class Example3 {
   private int a; // violation
 
@@ -165,7 +165,7 @@ public class Example3 {
           <code>logger</code>:
         </p>
 
-        <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
+        <div class="wrapper"><pre><code class="language-xml">
 &lt;module name="Checker"&gt;
   &lt;module name="TreeWalker"&gt;
     &lt;module name="JavadocVariable"&gt;
@@ -179,7 +179,7 @@ public class Example3 {
           javadoc for any scope member and ignores members with
           name <code>log</code> or <code>logger</code>.
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+        <div class="wrapper"><pre><code class="language-java">
 public class Example4 {
   private int a; // violation
 

--- a/src/site/xdoc/checks/javadoc/missingjavadocmethod.xml
+++ b/src/site/xdoc/checks/javadoc/missingjavadocmethod.xml
@@ -136,7 +136,7 @@ public boolean isSomething()
         <p id="Example1-config">
           To configure the default check:
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
+        <div class="wrapper"><pre><code class="language-xml">
 &lt;module name="Checker"&gt;
   &lt;module name="TreeWalker"&gt;
     &lt;module name="MissingJavadocMethod"/&gt;
@@ -146,7 +146,7 @@ public boolean isSomething()
         <p id="Example1-code">
           Example:
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+        <div class="wrapper"><pre><code class="language-java">
 public class Example1 {
   public Example1() {} // violation, 'Missing a Javadoc comment'
   public void testMethod1() {} // violation, 'Missing a Javadoc comment'
@@ -170,7 +170,7 @@ public class Example1 {
           To configure the check for <code>private</code>
           scope:
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
+        <div class="wrapper"><pre><code class="language-xml">
 &lt;module name="Checker"&gt;
   &lt;module name="TreeWalker"&gt;
     &lt;module name="MissingJavadocMethod"&gt;
@@ -180,7 +180,7 @@ public class Example1 {
 &lt;/module&gt;
 </code></pre></div>
         <p id="Example2-code">Example:</p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+        <div class="wrapper"><pre><code class="language-java">
 public class Example2 {
   public Example2() {} // violation, 'Missing a Javadoc comment'
   public void testMethod1() {} // violation, 'Missing a Javadoc comment'
@@ -204,7 +204,7 @@ public class Example2 {
           To configure the check for methods which are in <code>private</code>,
           but not in <code>protected</code> scope:
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
+        <div class="wrapper"><pre><code class="language-xml">
 &lt;module name="Checker"&gt;
   &lt;module name="TreeWalker"&gt;
     &lt;module name="MissingJavadocMethod"&gt;
@@ -215,7 +215,7 @@ public class Example2 {
 &lt;/module&gt;
 </code></pre></div>
         <p id="Example3-code">Example:</p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+        <div class="wrapper"><pre><code class="language-java">
 public class Example3 {
   public Example3() {} // violation, 'Missing a Javadoc comment'
   public void testMethod1() {} // violation, 'Missing a Javadoc comment'
@@ -238,7 +238,7 @@ public class Example3 {
         <p id="Example4-config">
           To configure the check for ignoring methods named <code>foo(),foo1(),foo2()</code>, etc.:
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
+        <div class="wrapper"><pre><code class="language-xml">
 &lt;module name="Checker"&gt;
   &lt;module name="TreeWalker"&gt;
     &lt;module name="MissingJavadocMethod"&gt;
@@ -248,7 +248,7 @@ public class Example3 {
 &lt;/module&gt;
 </code></pre></div>
         <p id="Example4-code">Example:</p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+        <div class="wrapper"><pre><code class="language-java">
 public class Example4 {
   public Example4() {} // violation, 'Missing a Javadoc comment'
   public void testMethod1() {}
@@ -271,7 +271,7 @@ public class Example4 {
         <p id="Example5-config">
           To configure the check for ignoring missing javadoc for accessor methods:
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
+        <div class="wrapper"><pre><code class="language-xml">
 &lt;module name="Checker"&gt;
   &lt;module name="TreeWalker"&gt;
     &lt;module name="MissingJavadocMethod"&gt;
@@ -281,7 +281,7 @@ public class Example4 {
 &lt;/module&gt;
 </code></pre></div>
         <p id="Example5-code">Example:</p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+        <div class="wrapper"><pre><code class="language-java">
 public class Example5 {
   public Example5() {} // violation, 'Missing a Javadoc comment'
   public void testMethod1() {} // violation, 'Missing a Javadoc comment'
@@ -304,7 +304,7 @@ public class Example5 {
         <p id="Example6-config">
           To configure the check with annotations that allow missed documentation:
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
+        <div class="wrapper"><pre><code class="language-xml">
 &lt;module name="Checker"&gt;
   &lt;module name="TreeWalker"&gt;
     &lt;module name="MissingJavadocMethod"&gt;
@@ -314,7 +314,7 @@ public class Example5 {
 &lt;/module&gt;
 </code></pre></div>
         <p id="Example6-code">Example:</p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+        <div class="wrapper"><pre><code class="language-java">
 public class Example6 {
   public Example6() {} // violation, 'Missing a Javadoc comment'
   public void testMethod1() {} // violation, 'Missing a Javadoc comment'

--- a/src/site/xdoc/checks/javadoc/missingjavadocpackage.xml
+++ b/src/site/xdoc/checks/javadoc/missingjavadocpackage.xml
@@ -30,7 +30,7 @@
         <p id="javadoc-package-info-config">
             To configure the check:
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
+        <div class="wrapper"><pre><code class="language-xml">
 &lt;module name="Checker"&gt;
   &lt;module name="TreeWalker"&gt;
     &lt;module name="MissingJavadocPackage"/&gt;
@@ -38,14 +38,14 @@
 &lt;/module&gt;
 </code></pre></div>
         <p id="javadoc-package-info-code">Example1 of package-info.java:</p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+        <div class="wrapper"><pre><code class="language-java">
 /**
  * Provides API classes
  */
 package com.puppycrawl.tools.checkstyle.checks.javadoc.missingjavadocpackage.javadoc;
 </code></pre></div>
         <p id="nojavadoc-package-info-code">Example2 of package-info.java:</p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+        <div class="wrapper"><pre><code class="language-java">
 /*
  * Block comment is not a javadoc
  */

--- a/src/site/xdoc/checks/javadoc/missingjavadoctype.xml
+++ b/src/site/xdoc/checks/javadoc/missingjavadoctype.xml
@@ -89,7 +89,7 @@
           To configure the default check to make sure all public class, enum, interface, and
           annotation interface, definitions have javadocs:
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
+        <div class="wrapper"><pre><code class="language-xml">
 &lt;module name="Checker"&gt;
   &lt;module name="TreeWalker"&gt;
     &lt;module name="MissingJavadocType"/&gt;
@@ -98,7 +98,7 @@
 </code></pre></div>
 
         <p id="Example1-code">Example1:</p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+        <div class="wrapper"><pre><code class="language-java">
 class Example1 {
   /** Javadoc.*/
   public class testClass0 {}
@@ -112,7 +112,7 @@ class Example1 {
         <p id="Example2-config">
           To configure the check for <code>private</code> scope:
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
+        <div class="wrapper"><pre><code class="language-xml">
 &lt;module name="Checker"&gt;
   &lt;module name="TreeWalker"&gt;
     &lt;module name="MissingJavadocType"&gt;
@@ -123,7 +123,7 @@ class Example1 {
 </code></pre></div>
 
         <p id="Example2-code">Example2:</p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+        <div class="wrapper"><pre><code class="language-java">
 class Example2 { // violation, 'Missing a Javadoc comment'
   /** Javadoc.*/
   public class testClass0 {}
@@ -137,7 +137,7 @@ class Example2 { // violation, 'Missing a Javadoc comment'
         <p id="Example3-config">
           To configure the check for <code>private</code> classes only:
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
+        <div class="wrapper"><pre><code class="language-xml">
 &lt;module name="Checker"&gt;
   &lt;module name="TreeWalker"&gt;
     &lt;module name="MissingJavadocType"&gt;
@@ -149,7 +149,7 @@ class Example2 { // violation, 'Missing a Javadoc comment'
 </code></pre></div>
 
         <p id="Example3-code">Example3:</p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+        <div class="wrapper"><pre><code class="language-java">
 class Example3 {
   /** Javadoc.*/
   public class testClass0 {}
@@ -165,7 +165,7 @@ class Example3 {
           To configure a check that allows missing comments for classes annotated with
           <code>@SpringBootApplication</code> and <code>@Configuration</code>:
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
+        <div class="wrapper"><pre><code class="language-xml">
 &lt;module name="Checker"&gt;
   &lt;module name="TreeWalker"&gt;
     &lt;module name="MissingJavadocType"&gt;
@@ -175,7 +175,7 @@ class Example3 {
 &lt;/module&gt;
 </code></pre></div>
         <p id="Example4-code">Example4:</p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+        <div class="wrapper"><pre><code class="language-java">
 @SpringBootApplication // no violations about missing comment on class
 public class Application {}
 
@@ -187,7 +187,7 @@ class DatabaseConfiguration {}
           To configure a check that allows missing comments for classes annotated with
           <code>@Annotation</code> and <code>@MyClass.Annotation</code>:
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
+        <div class="wrapper"><pre><code class="language-xml">
 &lt;module name="Checker"&gt;
   &lt;module name="TreeWalker"&gt;
     &lt;module name="MissingJavadocType"&gt;
@@ -199,7 +199,7 @@ class DatabaseConfiguration {}
         <p id="Example5-code">
           Example5:
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+        <div class="wrapper"><pre><code class="language-java">
 @Annotation // ok
 class Class1 {}
 

--- a/src/site/xdoc/checks/javadoc/nonemptyatclausedescription.xml
+++ b/src/site/xdoc/checks/javadoc/nonemptyatclausedescription.xml
@@ -72,7 +72,7 @@
           To configure the default check that will check <code>@param</code>,
           <code>@deprecated</code>,<code>@throws</code>,<code>@return</code>:
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
+        <div class="wrapper"><pre><code class="language-xml">
 &lt;module name="Checker"&gt;
   &lt;module name="TreeWalker"&gt;
     &lt;module name="NonEmptyAtclauseDescription"/&gt;
@@ -82,7 +82,7 @@
         <p id="Example1-code">
         Example1:
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+        <div class="wrapper"><pre><code class="language-java">
 class Example1 {
 
   /**
@@ -106,7 +106,7 @@ class Example1 {
           To configure the check to validate <code>@param</code>,
           <code>@throws</code> tags:
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
+        <div class="wrapper"><pre><code class="language-xml">
 &lt;module name="Checker"&gt;
   &lt;module name="TreeWalker"&gt;
     &lt;module name="NonEmptyAtclauseDescription"&gt;
@@ -118,7 +118,7 @@ class Example1 {
         <p id="Example2-code">
         Example2:
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+        <div class="wrapper"><pre><code class="language-java">
 class Example2 {
 
   /**

--- a/src/site/xdoc/checks/javadoc/requireemptylinebeforeblocktaggroup.xml
+++ b/src/site/xdoc/checks/javadoc/requireemptylinebeforeblocktaggroup.xml
@@ -40,7 +40,7 @@
         <p id="Example1-config">
           To configure the check:
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
+        <div class="wrapper"><pre><code class="language-xml">
 &lt;module name="Checker"&gt;
   &lt;module name="TreeWalker"&gt;
     &lt;module name="RequireEmptyLineBeforeBlockTagGroup"/&gt;
@@ -51,7 +51,7 @@
           The check will report a violation if there is no blank line before the
           block tag, like in the example below.
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+        <div class="wrapper"><pre><code class="language-java">
 class Example1 {
   /**
    * ValidMethod's javadoc.

--- a/src/site/xdoc/checks/javadoc/singlelinejavadoc.xml
+++ b/src/site/xdoc/checks/javadoc/singlelinejavadoc.xml
@@ -58,7 +58,7 @@
         <p id="Example1-config">
           To configure the check:
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
+        <div class="wrapper"><pre><code class="language-xml">
 &lt;module name="Checker"&gt;
   &lt;module name="TreeWalker"&gt;
     &lt;module name="SingleLineJavadoc"/&gt;
@@ -68,7 +68,7 @@
         <p id="Example1-code">
           Example:
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+        <div class="wrapper"><pre><code class="language-java">
 public class Example1 {
   /** @see Math */ // violation, 'Javadoc comment should be multi-line'
   public int foo() {
@@ -105,7 +105,7 @@ public class Example1 {
         <p id="Example2-config">
           To configure the check with a list of ignored block tags:
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
+        <div class="wrapper"><pre><code class="language-xml">
 &lt;module name="Checker"&gt;
   &lt;module name="TreeWalker"&gt;
     &lt;module name="SingleLineJavadoc"&gt;
@@ -117,7 +117,7 @@ public class Example1 {
         <p id="Example2-code">
           Example:
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+        <div class="wrapper"><pre><code class="language-java">
 public class Example2 {
   /** @see Math */
   public int foo() {
@@ -154,7 +154,7 @@ public class Example2 {
         <p id="Example3-config">
           To configure the check to not ignore inline tags:
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
+        <div class="wrapper"><pre><code class="language-xml">
 &lt;module name="Checker"&gt;
   &lt;module name="TreeWalker"&gt;
     &lt;module name="SingleLineJavadoc"&gt;
@@ -166,7 +166,7 @@ public class Example2 {
         <p id="Example3-code">
           Example:
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+        <div class="wrapper"><pre><code class="language-java">
 public class Example3 {
   /** @see Math */ // violation, 'Javadoc comment should be multi-line'
   public int foo() {
@@ -203,7 +203,7 @@ public class Example3 {
         <p id="Example4-config">
           To configure the check to report violations for Tight-HTML Rules:
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
+        <div class="wrapper"><pre><code class="language-xml">
 &lt;module name="Checker"&gt;
   &lt;module name="TreeWalker"&gt;
     &lt;module name="SingleLineJavadoc"&gt;
@@ -215,7 +215,7 @@ public class Example3 {
         <p id="Example4-code">
           Example:
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+        <div class="wrapper"><pre><code class="language-java">
 public class Example4 {
   /** @see Math */ // violation, 'Javadoc comment should be multi-line'
   public int foo() {

--- a/src/site/xdoc/checks/javadoc/summaryjavadoc.xml
+++ b/src/site/xdoc/checks/javadoc/summaryjavadoc.xml
@@ -61,7 +61,7 @@
           To configure the default check to validate that first sentence is not empty and first
           sentence is not missing:
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
+        <div class="wrapper"><pre><code class="language-xml">
 &lt;module name="Checker"&gt;
   &lt;module name="TreeWalker"&gt;
     &lt;module name="SummaryJavadoc"/&gt;
@@ -69,7 +69,7 @@
 &lt;/module&gt;
 </code></pre></div>
         <p id="Example1-code"> Example1: </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+        <div class="wrapper"><pre><code class="language-java">
 class Example1 {
 
   /**
@@ -121,7 +121,7 @@ class Example1 {
           To ensure that summary does not contain phrase like &quot;This method returns&quot;, use
           following config:
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
+        <div class="wrapper"><pre><code class="language-xml">
 &lt;module name="Checker"&gt;
   &lt;module name="TreeWalker"&gt;
     &lt;module name="SummaryJavadoc"&gt;
@@ -132,7 +132,7 @@ class Example1 {
 &lt;/module&gt;
 </code></pre></div>
         <p id="Example2-code"> Example2: </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+        <div class="wrapper"><pre><code class="language-java">
 class Example2 {
 
   /**
@@ -183,7 +183,7 @@ class Example2 {
         <p id="Example3-config">
           To specify period symbol at the end of first javadoc sentence:
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
+        <div class="wrapper"><pre><code class="language-xml">
 &lt;module name="Checker"&gt;
   &lt;module name="TreeWalker"&gt;
     &lt;module name="SummaryJavadoc"&gt;
@@ -193,7 +193,7 @@ class Example2 {
 &lt;/module&gt;
 </code></pre></div>
         <p id="Example3-code"> Example3: </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+        <div class="wrapper"><pre><code class="language-java">
 class Example3 {
 
   /**

--- a/src/site/xdoc/checks/javadoc/writetag.xml
+++ b/src/site/xdoc/checks/javadoc/writetag.xml
@@ -97,7 +97,7 @@
         <p id="Example1-config">
           Example of default Check configuration that do nothing.
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
+        <div class="wrapper"><pre><code class="language-xml">
 &lt;module name="Checker"&gt;
   &lt;module name="TreeWalker"&gt;
     &lt;module name="WriteTag"/&gt;
@@ -107,7 +107,7 @@
         <p id="Example1-code">
         Example:
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+        <div class="wrapper"><pre><code class="language-java">
 /**
  * Some class
  */
@@ -128,7 +128,7 @@ public class Example1 {
           To configure Check to demand some special tag (for example <code>@since</code>)
           to be present on classes javadoc.
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
+        <div class="wrapper"><pre><code class="language-xml">
 &lt;module name="Checker"&gt;
   &lt;module name="TreeWalker"&gt;
     &lt;module name="WriteTag"&gt;
@@ -140,7 +140,7 @@ public class Example1 {
         <p id="Example2-code">
         Example:
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+        <div class="wrapper"><pre><code class="language-java">
 /**
  * Some class
  */
@@ -161,7 +161,7 @@ public class Example2 {
           To configure Check to demand some special tag (for example <code>@since</code>)
           to be present on method javadocs also in addition to default tokens.
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
+        <div class="wrapper"><pre><code class="language-xml">
 &lt;module name="Checker"&gt;
   &lt;module name="TreeWalker"&gt;
     &lt;module name="WriteTag"&gt;
@@ -176,7 +176,7 @@ public class Example2 {
         <p id="Example3-code">
         Example:
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+        <div class="wrapper"><pre><code class="language-java">
 /**
  * Some class
  */
@@ -199,7 +199,7 @@ public class Example3 {
           to be present with digital value on method javadocs also in addition to default tokens.
           Attention: it is required to set &quot;ignore&quot; in tagSeverity.
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
+        <div class="wrapper"><pre><code class="language-xml">
 &lt;module name="Checker"&gt;
   &lt;module name="TreeWalker"&gt;
     &lt;module name="WriteTag"&gt;
@@ -216,7 +216,7 @@ public class Example3 {
         <p id="Example4-code">
         Example:
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+        <div class="wrapper"><pre><code class="language-java">
 /**
  * Some class
  * @since 1.2
@@ -238,7 +238,7 @@ public class Example4 {
           To configure Check to demand <code>@since</code> tag
           and in the same time print violation with specific severity on each presence of such tag.
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
+        <div class="wrapper"><pre><code class="language-xml">
 &lt;module name="Checker"&gt;
   &lt;module name="TreeWalker"&gt;
     &lt;module name="WriteTag"&gt;
@@ -255,7 +255,7 @@ public class Example4 {
         <p id="Example5-code">
         Example:
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+        <div class="wrapper"><pre><code class="language-java">
 // violation 3 lines below 'Javadoc tag @since=1.2'
 /**
  * Some class

--- a/src/site/xdoc/checks/metrics/booleanexpressioncomplexity.xml
+++ b/src/site/xdoc/checks/metrics/booleanexpressioncomplexity.xml
@@ -90,7 +90,7 @@
         <p id="Example1-config">
           To configure the check:
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
+        <div class="wrapper"><pre><code class="language-xml">
 &lt;module name="Checker"&gt;
   &lt;module name="TreeWalker"&gt;
     &lt;module name="BooleanExpressionComplexity"/&gt;
@@ -98,7 +98,7 @@
 &lt;/module&gt;
 </code></pre></div>
         <p id="Example1-code">Code Example:</p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+        <div class="wrapper"><pre><code class="language-java">
 public class Example1
 {
   public static void main(String ... args)
@@ -122,7 +122,7 @@ public class Example1
           To configure the check with 5 allowed operation in boolean
           expression:
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
+        <div class="wrapper"><pre><code class="language-xml">
 &lt;module name="Checker"&gt;
   &lt;module name="TreeWalker"&gt;
     &lt;module name="BooleanExpressionComplexity"&gt;
@@ -132,7 +132,7 @@ public class Example1
 &lt;/module&gt;
 </code></pre></div>
         <p id="Example2-code">Code Example:</p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+        <div class="wrapper"><pre><code class="language-java">
 public class Example2
 {
   public static void main(String ... args)
@@ -155,7 +155,7 @@ public class Example2
           To configure the check to ignore <code>&amp;</code> and
           <code>|</code>:
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
+        <div class="wrapper"><pre><code class="language-xml">
 &lt;module name="Checker"&gt;
   &lt;module name="TreeWalker"&gt;
     &lt;module name="BooleanExpressionComplexity"&gt;
@@ -165,7 +165,7 @@ public class Example2
 &lt;/module&gt;
 </code></pre></div>
         <p id="Example3-code">Code Example:</p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+        <div class="wrapper"><pre><code class="language-java">
 public class Example3
 {
   public static void main(String ... args)

--- a/src/site/xdoc/checks/metrics/classdataabstractioncoupling.xml
+++ b/src/site/xdoc/checks/metrics/classdataabstractioncoupling.xml
@@ -115,7 +115,7 @@
         <p id="Example1-config">
           To configure the check:
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
+        <div class="wrapper"><pre><code class="language-xml">
 &lt;module name="Checker"&gt;
   &lt;module name="TreeWalker"&gt;
     &lt;module name="ClassDataAbstractionCoupling"/&gt;
@@ -129,7 +129,7 @@
         <p id="Example1-code">
           The check passes without violations in the following:
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+        <div class="wrapper"><pre><code class="language-java">
 public class Example1 {
   private Set&lt;Object&gt; set = new HashSet&lt;&gt;(); // Ignored by default
   private Map&lt;Object,Object&gt; map = new HashMap&lt;&gt;(); // Ignored by default
@@ -143,7 +143,7 @@ public class Example1 {
         <p id="Example2-code">
           The check results in a violation in the following:
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+        <div class="wrapper"><pre><code class="language-java">
 // violation below, "Class Data Abstraction Coupling is 8 (max allowed is 7)."
 public class Example2 {
   Set set = new HashSet(); // Ignored by default
@@ -163,7 +163,7 @@ public class Example2 {
         <p id="Example3-config">
           To configure the check with a threshold of 2:
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
+        <div class="wrapper"><pre><code class="language-xml">
 &lt;module name="Checker"&gt;
   &lt;module name="TreeWalker"&gt;
     &lt;module name="ClassDataAbstractionCoupling"&gt;
@@ -179,7 +179,7 @@ public class Example2 {
         <p id="Example3-code">
           The check passes without violations in the following:
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+        <div class="wrapper"><pre><code class="language-java">
 public class Example3 {
   Set set = new HashSet(); // Ignored by default
   Map map = new HashMap(); // Ignored by default
@@ -191,7 +191,7 @@ public class Example3 {
         <p id="Example4-code">
           The check results in a violation in the following:
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+        <div class="wrapper"><pre><code class="language-java">
 // violation below, "Class Data Abstraction Coupling is 3 (max allowed is 2)."
 public class Example4 {
   Set set = new HashSet(); // Ignored by default
@@ -206,7 +206,7 @@ public class Example4 {
           To configure the check with three excluded classes <code>HashMap</code>,
           <code>HashSet</code> and <code>Example1</code>:
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
+        <div class="wrapper"><pre><code class="language-xml">
 &lt;module name="Checker"&gt;
   &lt;module name="TreeWalker"&gt;
     &lt;module name="ClassDataAbstractionCoupling"&gt;
@@ -222,7 +222,7 @@ public class Example4 {
         <p id="Example5-code">
           The check passes without violations in the following:
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+        <div class="wrapper"><pre><code class="language-java">
 public class Example5 {
   Set set = new HashSet(); // Ignored 1
   Map map = new HashMap(); // Ignored 2
@@ -241,7 +241,7 @@ public class Example5 {
         <p id="Example6-code">
           The check results in a violation in the following:
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+        <div class="wrapper"><pre><code class="language-java">
 // violation below, "Class Data Abstraction Coupling is 8 (max allowed is 7)."
 public class Example6 {
   Set set = new HashSet(); // Ignored by default
@@ -262,7 +262,7 @@ public class Example6 {
           To configure the check to exclude classes with a regular expression
           <code>.*Reader$</code>:
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
+        <div class="wrapper"><pre><code class="language-xml">
 &lt;module name="Checker"&gt;
   &lt;module name="TreeWalker"&gt;
     &lt;module name="ClassDataAbstractionCoupling"&gt;
@@ -278,7 +278,7 @@ public class Example6 {
         <p id="Example7-code">
           The check passes without violations in the following:
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+        <div class="wrapper"><pre><code class="language-java">
 public class Example7 {
   Set set = new HashSet(); // Ignored by default
   Map map = new HashMap(); // Ignored by default
@@ -299,7 +299,7 @@ public class Example7 {
         <p id="Example8-code">
           The check results in a violation in the following:
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+        <div class="wrapper"><pre><code class="language-java">
 // violation below, "Class Data Abstraction Coupling is 8 (max allowed is 7)."
 public class Example8 {
   Set set = new HashSet(); // Ignored by default
@@ -320,7 +320,7 @@ public class Example8 {
           To configure the check with an excluded package <code>java.io</code>:
         </p>
 
-        <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
+        <div class="wrapper"><pre><code class="language-xml">
 &lt;module name="Checker"&gt;
   &lt;module name="TreeWalker"&gt;
     &lt;module name="ClassDataAbstractionCoupling"&gt;
@@ -336,7 +336,7 @@ public class Example8 {
         <p id="Example9-code">
           The check passes without violations in the following:
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+        <div class="wrapper"><pre><code class="language-java">
 import java.io.BufferedReader;
 
 public class Example9 {
@@ -359,7 +359,7 @@ public class Example9 {
         <p id="Example10-code">
           The check results in a violation in the following:
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+        <div class="wrapper"><pre><code class="language-java">
 import com.puppycrawl.tools.checkstyle.checks.metrics.classdataabstractioncoupling.Example2;
 import com.puppycrawl.tools.checkstyle.checks.metrics.classdataabstractioncoupling.Example3;
 import com.puppycrawl.tools.checkstyle.checks.metrics.classdataabstractioncoupling.ignore.deeper.Example4;
@@ -431,7 +431,7 @@ class Example10 {
           even if it was listed in the <code>excludedPackages</code> parameter. For example,
           assuming the config is
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
+        <div class="wrapper"><pre><code class="language-xml">
 &lt;module name="Checker"&gt;
   &lt;module name="TreeWalker"&gt;
     &lt;module name="ClassDataAbstractionCoupling"&gt;
@@ -443,7 +443,7 @@ class Example10 {
         <p id="Example11-code">
           And the file <code>a.b.Foo.java</code> is:
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+        <div class="wrapper"><pre><code class="language-java">
 import com.puppycrawl.tools.checkstyle.checks.metrics.classdataabstractioncoupling.ignore.Example7;
 import com.puppycrawl.tools.checkstyle.checks.metrics.classdataabstractioncoupling.ignore.Example8;
 import com.puppycrawl.tools.checkstyle.checks.metrics.classdataabstractioncoupling.ignore.Example9;

--- a/src/site/xdoc/checks/metrics/classfanoutcomplexity.xml
+++ b/src/site/xdoc/checks/metrics/classfanoutcomplexity.xml
@@ -81,7 +81,7 @@
         <p id="Example1-config">
           To configure the check:
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
+        <div class="wrapper"><pre><code class="language-xml">
 &lt;module name="Checker"&gt;
   &lt;module name="TreeWalker"&gt;
     &lt;module name="ClassFanOutComplexity"/&gt;
@@ -94,7 +94,7 @@
         <p id="Example1-code">
           The check passes without violations in the following:
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+        <div class="wrapper"><pre><code class="language-java">
 class Example1{
   Set set = new HashSet(); // Set, HashSet ignored
   Map map = new HashMap(); // Map, HashMap ignored
@@ -114,7 +114,7 @@ class Time1 {}
         <p id="Example2-config">
           To configure the check with a threshold of 2:
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
+        <div class="wrapper"><pre><code class="language-xml">
 &lt;module name="Checker"&gt;
   &lt;module name="TreeWalker"&gt;
     &lt;module name="ClassFanOutComplexity"&gt;
@@ -129,7 +129,7 @@ class Time1 {}
         <p id="Example2-code">
           The check results in a violation in the following:
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+        <div class="wrapper"><pre><code class="language-java">
 class Example2{ // violation 'Class Fan-Out Complexity is 5 (max allowed is 2)'
   Set set = new HashSet(); // Set, HashSet ignored
   Map map = new HashMap(); // Map, HashMap ignored
@@ -151,7 +151,7 @@ class Time2 {}
           To configure the check with three excluded classes <code>HashMap</code>,
           <code>HashSet</code> and <code>Place3</code>:
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
+        <div class="wrapper"><pre><code class="language-xml">
 &lt;module name="Checker"&gt;
   &lt;module name="TreeWalker"&gt;
     &lt;module name="ClassFanOutComplexity"&gt;
@@ -167,7 +167,7 @@ class Time2 {}
         <p id="Example3-code">
           The check results in a violation in the following:
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+        <div class="wrapper"><pre><code class="language-java">
 class Example3{ // violation 'Class Fan-Out Complexity is 7 (max allowed is 3)'
   Set set = new HashSet(); // Set counted 1, HashSet ignored
   Map map = new HashMap(); // Map counted 2, HashMap ignored
@@ -188,7 +188,7 @@ class Time3 {}
           To configure the check to exclude classes with a regular expression
           <code>.*Reader$</code>:
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
+        <div class="wrapper"><pre><code class="language-xml">
 &lt;module name="Checker"&gt;
   &lt;module name="TreeWalker"&gt;
     &lt;module name="ClassFanOutComplexity"&gt;
@@ -204,7 +204,7 @@ class Time3 {}
         <p id="Example4-code">
           The check results in a violation in the following:
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+        <div class="wrapper"><pre><code class="language-java">
 class Example4{ // violation 'Class Fan-Out Complexity is 4 (max allowed is 3)'
   Set set = new HashSet(); // Set, HashSet ignored
   Map map = new HashMap(); // Map, HashMap ignored
@@ -225,7 +225,7 @@ class Time4 {}
         <p id="Example5-config">
           To configure the check with an excluded package <code>java.io</code>:
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
+        <div class="wrapper"><pre><code class="language-xml">
 &lt;module name="Checker"&gt;
   &lt;module name="TreeWalker"&gt;
     &lt;module name="ClassFanOutComplexity"&gt;
@@ -241,7 +241,7 @@ class Time4 {}
         <p id="Example5-code">
           The check passes without violations in the following:
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+        <div class="wrapper"><pre><code class="language-java">
 class Example5{
   Set set = new HashSet(); // Set, HashSet ignored
   Map map = new HashMap(); // Map, HashMap ignored
@@ -289,7 +289,7 @@ class Time5 {}
           even if it was listed in the <code>excludedPackages</code> parameter. For example,
           assuming the config is
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
+        <div class="wrapper"><pre><code class="language-xml">
 &lt;module name="Checker"&gt;
   &lt;module name="TreeWalker"&gt;
     &lt;module name="ClassFanOutComplexity"&gt;
@@ -305,7 +305,7 @@ class Time5 {}
         <p id="Example6-code">
           And the file is:
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+        <div class="wrapper"><pre><code class="language-java">
 class Example6{ // violation 'Class Fan-Out Complexity is 4 (max allowed is 3)'
   Set set = new HashSet(); // Set, HashSet ignored
   Map map = new HashMap(); // Map, HashMap ignored

--- a/src/site/xdoc/checks/metrics/cyclomaticcomplexity.xml
+++ b/src/site/xdoc/checks/metrics/cyclomaticcomplexity.xml
@@ -137,7 +137,7 @@
         <p id="Example1-config">
           To configure the check:
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
+        <div class="wrapper"><pre><code class="language-xml">
 &lt;module name="Checker"&gt;
   &lt;module name="TreeWalker"&gt;
     &lt;module name="CyclomaticComplexity"/&gt;
@@ -147,7 +147,7 @@
         <p id="Example1-code">
           Example:
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+        <div class="wrapper"><pre><code class="language-java">
 class Example1 {
   int a, b, c, d, e, n;
 
@@ -208,7 +208,7 @@ class Example1 {
         <p id="Example2-config">
           To configure the check with a threshold of 4 and check only for while and do-while loops:
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
+        <div class="wrapper"><pre><code class="language-xml">
 &lt;module name="Checker"&gt;
   &lt;module name="TreeWalker"&gt;
     &lt;module name="CyclomaticComplexity"&gt;
@@ -221,7 +221,7 @@ class Example1 {
         <p id="Example2-code">
           Example:
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+        <div class="wrapper"><pre><code class="language-java">
 class Example2 {
   int a, b, c, d, e, n;
   // violation below, 'Cyclomatic Complexity is 5 (max allowed is 4)'
@@ -282,7 +282,7 @@ class Example2 {
         <p id="Example3-config">
           To configure the check to consider switch-case block as one decision point.
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
+        <div class="wrapper"><pre><code class="language-xml">
 &lt;module name="Checker"&gt;
   &lt;module name="TreeWalker"&gt;
     &lt;module name="CyclomaticComplexity"&gt;
@@ -294,7 +294,7 @@ class Example2 {
         <p id="Example3-code">
           Example:
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+        <div class="wrapper"><pre><code class="language-java">
 class Example3 {
   int a, b, c, d, e, n;
 

--- a/src/site/xdoc/checks/metrics/javancss.xml
+++ b/src/site/xdoc/checks/metrics/javancss.xml
@@ -86,7 +86,7 @@
         <p id="Example1-config">
           To configure the check:
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
+        <div class="wrapper"><pre><code class="language-xml">
 &lt;module name="Checker"&gt;
   &lt;module name="TreeWalker"&gt;
     &lt;module name="JavaNCSS"/&gt;
@@ -96,7 +96,7 @@
         <p id="Example1-code">
           Example1:
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+        <div class="wrapper"><pre><code class="language-java">
 package com.puppycrawl.tools.checkstyle.checks.metrics.javancss;
 
 class Example1 {
@@ -119,7 +119,7 @@ class Example1 {
         <p id="Example2-config">
           To configure the check with 4 allowed non commented lines for a method:
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
+        <div class="wrapper"><pre><code class="language-xml">
 &lt;module name="Checker"&gt;
   &lt;module name="TreeWalker"&gt;
     &lt;module name="JavaNCSS"&gt;
@@ -131,7 +131,7 @@ class Example1 {
         <p id="Example2-code">
           Example2:
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+        <div class="wrapper"><pre><code class="language-java">
 package com.puppycrawl.tools.checkstyle.checks.metrics.javancss;
 
 class Example2 {
@@ -154,7 +154,7 @@ class Example2 {
         <p id="Example3-config">
           To configure the check to set limit of non commented lines in class to 10:
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
+        <div class="wrapper"><pre><code class="language-xml">
 &lt;module name="Checker"&gt;
   &lt;module name="TreeWalker"&gt;
     &lt;module name="JavaNCSS"&gt;
@@ -164,7 +164,7 @@ class Example2 {
 &lt;/module&gt;
 </code></pre></div>
         <p id="Example3-code">Example3:</p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+        <div class="wrapper"><pre><code class="language-java">
 package com.puppycrawl.tools.checkstyle.checks.metrics.javancss;
 
 class Example3 {
@@ -187,7 +187,7 @@ class Example3 {
         <p id="Example4-config">
           To configure the check to set limit of non commented lines in file to 10:
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
+        <div class="wrapper"><pre><code class="language-xml">
 &lt;module name="Checker"&gt;
   &lt;module name="TreeWalker"&gt;
     &lt;module name="JavaNCSS"&gt;
@@ -197,7 +197,7 @@ class Example3 {
 &lt;/module&gt;
 </code></pre></div>
         <p id="Example4-code">Example4:</p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+        <div class="wrapper"><pre><code class="language-java">
 package com.puppycrawl.tools.checkstyle.checks.metrics.javancss;
 // violation above, 'NCSS for this file is 12 (max allowed is 10)'
 class Example4 {

--- a/src/site/xdoc/checks/metrics/npathcomplexity.xml
+++ b/src/site/xdoc/checks/metrics/npathcomplexity.xml
@@ -129,7 +129,7 @@
         <p id="Example1-config">
           To configure the check:
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
+        <div class="wrapper"><pre><code class="language-xml">
 &lt;module name="Checker"&gt;
   &lt;module name="TreeWalker"&gt;
     &lt;module name="NPathComplexity"/&gt;
@@ -139,7 +139,7 @@
         <p id="Example1-code">
           Example:
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+        <div class="wrapper"><pre><code class="language-java">
 public abstract class Example1 {
   final int a = 0;
   int b = 0;
@@ -193,7 +193,7 @@ public abstract class Example1 {
         <p id="Example2-config">
           To configure the check with a threshold of 100:
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
+        <div class="wrapper"><pre><code class="language-xml">
 &lt;module name="Checker"&gt;
   &lt;module name="TreeWalker"&gt;
     &lt;module name="NPathComplexity"&gt;
@@ -205,7 +205,7 @@ public abstract class Example1 {
         <p id="Example2-code">
           Example:
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+        <div class="wrapper"><pre><code class="language-java">
 public abstract class Example2 {
   public void foo() { // violation, NPath complexity is 128 (max allowed is 100)
     int a,b,t,m,n;

--- a/src/site/xdoc/checks/misc/arraytypestyle.xml
+++ b/src/site/xdoc/checks/misc/arraytypestyle.xml
@@ -51,7 +51,7 @@
         <p id="Example1-config">
           To configure the check to enforce Java style:
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
+        <div class="wrapper"><pre><code class="language-xml">
 &lt;module name="Checker"&gt;
   &lt;module name="TreeWalker"&gt;
     &lt;module name="ArrayTypeStyle"/&gt;
@@ -61,7 +61,7 @@
         <p id="Example1-code">
           Example:
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+        <div class="wrapper"><pre><code class="language-java">
 public class Example1 {
   int[] nums; // ok since default format checks for Java style
   String strings[]; // violation, 'Array brackets at illegal position'
@@ -78,7 +78,7 @@ public class Example1 {
         <p id="Example2-config">
           To configure the check to enforce C style:
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
+        <div class="wrapper"><pre><code class="language-xml">
 &lt;module name="Checker"&gt;
   &lt;module name="TreeWalker"&gt;
     &lt;module name="ArrayTypeStyle"&gt;
@@ -90,7 +90,7 @@ public class Example1 {
         <p id="Example2-code">
           Example:
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+        <div class="wrapper"><pre><code class="language-java">
 public class Example2 {
   int[] nums; // violation, 'Array brackets at illegal position'
   String strings[]; // OK as follows C style since 'javaStyle' set to false

--- a/src/site/xdoc/checks/misc/avoidescapedunicodecharacters.xml
+++ b/src/site/xdoc/checks/misc/avoidescapedunicodecharacters.xml
@@ -68,7 +68,7 @@
         <p id="Example1-config">
             To configure the check:
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
+        <div class="wrapper"><pre><code class="language-xml">
 &lt;module name="Checker"&gt;
     &lt;module name="TreeWalker"&gt;
         &lt;module name="AvoidEscapedUnicodeCharacters"/&gt;
@@ -78,7 +78,7 @@
         <p id="Example1-code">
           Examples of using Unicode:
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+        <div class="wrapper"><pre><code class="language-java">
 public class Example1 {
   // OK, perfectly clear even without a comment.
   String unitAbbrev = "μs";
@@ -101,7 +101,7 @@ public class Example1 {
           An example of how to configure the check to allow using escapes
           for non-printable, control characters:
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
+        <div class="wrapper"><pre><code class="language-xml">
 &lt;module name="Checker"&gt;
   &lt;module name="TreeWalker"&gt;
     &lt;module name="AvoidEscapedUnicodeCharacters"&gt;
@@ -113,7 +113,7 @@ public class Example1 {
         <p id="Example2-code">
           Example of using escapes for non-printable, control characters:
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+        <div class="wrapper"><pre><code class="language-java">
 public class Example2 {
   // OK, a normal String below
   String unitAbbrev = "μs";
@@ -136,7 +136,7 @@ public class Example2 {
           An example of how to configure the check to allow using escapes
           if trail comment is present:
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
+        <div class="wrapper"><pre><code class="language-xml">
 &lt;module name="Checker"&gt;
   &lt;module name="TreeWalker"&gt;
     &lt;module name="AvoidEscapedUnicodeCharacters"&gt;
@@ -148,7 +148,7 @@ public class Example2 {
         <p id="Example3-code">
           Example of using escapes if trail comment is present:
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+        <div class="wrapper"><pre><code class="language-java">
 public class Example3 {
   // OK, a normal String below
   String unitAbbrev = "μs";
@@ -171,7 +171,7 @@ public class Example3 {
           An example of how to configure the check to allow if
           all characters in literal are escaped.
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
+        <div class="wrapper"><pre><code class="language-xml">
 &lt;module name="Checker"&gt;
   &lt;module name="TreeWalker"&gt;
     &lt;module name="AvoidEscapedUnicodeCharacters"&gt;
@@ -181,7 +181,7 @@ public class Example3 {
 &lt;/module&gt;
 </code></pre></div>
         <p id="Example4-code">Example of using escapes if all characters in literal are escaped:</p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+        <div class="wrapper"><pre><code class="language-java">
 public class Example4 {
   // OK, a normal String below
   String unitAbbrev = "μs";
@@ -204,7 +204,7 @@ public class Example4 {
           An example of how to configure the check to allow using escapes
           for non-printable whitespace characters:
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
+        <div class="wrapper"><pre><code class="language-xml">
 &lt;module name="Checker"&gt;
   &lt;module name="TreeWalker"&gt;
     &lt;module name="AvoidEscapedUnicodeCharacters"&gt;
@@ -214,7 +214,7 @@ public class Example4 {
 &lt;/module&gt;
 </code></pre></div>
         <p id="Example5-code">Example of using escapes for non-printable whitespace characters:</p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+        <div class="wrapper"><pre><code class="language-java">
 public class Example5 {
   // OK, a normal String below.
   String unitAbbrev = "μs";

--- a/src/site/xdoc/checks/misc/commentsindentation.xml
+++ b/src/site/xdoc/checks/misc/commentsindentation.xml
@@ -56,7 +56,7 @@
           To configure the Check
           where both single-line and block comments are checked for indentation violations:
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
+        <div class="wrapper"><pre><code class="language-xml">
 &lt;module name="Checker"&gt;
   &lt;module name="TreeWalker"&gt;
     &lt;module name="CommentsIndentation"/&gt;
@@ -67,7 +67,7 @@
         <p id="Example1-code">
         Example:
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+        <div class="wrapper"><pre><code class="language-java">
 public class Example1 {
   void testMethod() {
     /*
@@ -96,7 +96,7 @@ public class Example1 {
         <p id="Example2-config">
           To configure the Check to validate only single-line comments:
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
+        <div class="wrapper"><pre><code class="language-xml">
 &lt;module name="Checker"&gt;
   &lt;module name="TreeWalker"&gt;
     &lt;module name="CommentsIndentation"&gt;
@@ -109,7 +109,7 @@ public class Example1 {
         <p id="Example2-code">
           Example:
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+        <div class="wrapper"><pre><code class="language-java">
 public class Example2 {
   void testMethod() {
     /*
@@ -139,7 +139,7 @@ public class Example2 {
         <p id="Example3-code">
           Example #3: Comment is used as a single-line border to separate groups of methods.
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+        <div class="wrapper"><pre><code class="language-java">
 public class Example3 {
   /////////////////////////////// it is OK
 
@@ -160,7 +160,7 @@ public class Example3 {
           code block has indentation level that is lower than the indentation level of the closing
           right curly brace.
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+        <div class="wrapper"><pre><code class="language-java">
 public class Example4 {
   public void foo1() {
     // comment
@@ -183,7 +183,7 @@ public class Example4 {
            within the empty case block has indentation level that is lower than the
            indentation level of the next case.
           token.</p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+        <div class="wrapper"><pre><code class="language-java">
 public class Example5 {
   void testMethod(String a) {
     switch(a) {
@@ -208,7 +208,7 @@ public class Example5 {
 }
 </code></pre></div>
         <p id="Example6-code">Example #6: Comment is placed within a distributed statement.</p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+        <div class="wrapper"><pre><code class="language-java">
 public class Example6 {
   void testMethod() {
     // violation 2 lines below 'Comment has incorrect indentation level 4'
@@ -227,7 +227,7 @@ public class Example6 {
         <p id="Example7-code">
           Example #7: Single line block comment has previous and next statement.
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+        <div class="wrapper"><pre><code class="language-java">
 public class Example7 {
   void testMethod() {
     String s1 = "Clean code!";
@@ -252,7 +252,7 @@ public class Example7 {
         <p id="Example8-code">
           Example #8: Comment within the block tries to describe the next code block.
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+        <div class="wrapper"><pre><code class="language-java">
 public class Example8 {
   public void foo42() {
     int a = 5;

--- a/src/site/xdoc/checks/misc/descendanttoken.xml
+++ b/src/site/xdoc/checks/misc/descendanttoken.xml
@@ -108,7 +108,7 @@
           To configure the check to produce a violation on a switch statement
           with no default case:
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
+        <div class="wrapper"><pre><code class="language-xml">
 &lt;module name="Checker"&gt;
   &lt;module name="TreeWalker"&gt;
     &lt;module name="DescendantToken"&gt;
@@ -123,7 +123,7 @@
         <p id="Example1-code">
           Example:
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+        <div class="wrapper"><pre><code class="language-java">
 class Example1 {
   void testMethod1() {
     int x = 1;
@@ -192,7 +192,7 @@ class Example1 {
         <p id="Example2-config">
           To configure the check to produce a violation on a switch with too many cases:
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
+        <div class="wrapper"><pre><code class="language-xml">
 &lt;module name="Checker"&gt;
   &lt;module name="TreeWalker"&gt;
     &lt;module name="DescendantToken"&gt;
@@ -207,7 +207,7 @@ class Example1 {
         <p id="Example2-code">
           Example:
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+        <div class="wrapper"><pre><code class="language-java">
 class Example2 {
   void testMethod1() {
     int x = 1;
@@ -277,7 +277,7 @@ class Example2 {
           To configure the check to produce a violation on a switch that is
           nested in another switch:
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
+        <div class="wrapper"><pre><code class="language-xml">
 &lt;module name="Checker"&gt;
   &lt;module name="TreeWalker"&gt;
     &lt;module name="DescendantToken"&gt;
@@ -292,7 +292,7 @@ class Example2 {
         <p id="Example3-code">
           Example:
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+        <div class="wrapper"><pre><code class="language-java">
 class Example3 {
   void testMethod1() {
     int x = 1;
@@ -362,7 +362,7 @@ class Example3 {
           To configure the check to produce a violation on a
           condition in <code>for</code> which performs no check:
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
+        <div class="wrapper"><pre><code class="language-xml">
 &lt;module name="Checker"&gt;
   &lt;module name="TreeWalker"&gt;
     &lt;module name="DescendantToken"&gt;
@@ -376,7 +376,7 @@ class Example3 {
         <p id="Example4-code">
           Example:
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+        <div class="wrapper"><pre><code class="language-java">
 class Example4 {
   void testMethod1() {
     for (int i = 0; i != 10; i++) {
@@ -408,7 +408,7 @@ class Example4 {
           <code>for</code> performs no setup (where a <code>while</code>
           statement could be used instead):
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
+        <div class="wrapper"><pre><code class="language-xml">
 &lt;module name="Checker"&gt;
   &lt;module name="TreeWalker"&gt;
     &lt;module name="DescendantToken"&gt;
@@ -422,7 +422,7 @@ class Example4 {
         <p id="Example5-code">
           Example:
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+        <div class="wrapper"><pre><code class="language-java">
 class Example5 {
   void testMethod1() {
     for (int i = 0; i != 10; i++) {
@@ -453,7 +453,7 @@ class Example5 {
           To configure the check to produce a violation on a return statement
           from within a catch or finally block:
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
+        <div class="wrapper"><pre><code class="language-xml">
 &lt;module name="Checker"&gt;
   &lt;module name="TreeWalker"&gt;
     &lt;module name="DescendantToken"&gt;
@@ -467,7 +467,7 @@ class Example5 {
         <p id="Example6-code">
           Example:
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+        <div class="wrapper"><pre><code class="language-java">
 class Example6 {
   void testMethod1() {
     try {}
@@ -510,7 +510,7 @@ class Example6 {
           To configure the check to produce a violation on a try statement
           within a catch or finally block:
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
+        <div class="wrapper"><pre><code class="language-xml">
 &lt;module name="Checker"&gt;
   &lt;module name="TreeWalker"&gt;
     &lt;module name="DescendantToken"&gt;
@@ -524,7 +524,7 @@ class Example6 {
         <p id="Example7-code">
           Example:
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+        <div class="wrapper"><pre><code class="language-java">
 class Example7 {
   void testMethod1() {
     try {}
@@ -567,7 +567,7 @@ class Example7 {
           To configure the check to produce a violation on a method with
           too many local variables:
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
+        <div class="wrapper"><pre><code class="language-xml">
 &lt;module name="Checker"&gt;
   &lt;module name="TreeWalker"&gt;
     &lt;module name="DescendantToken"&gt;
@@ -582,7 +582,7 @@ class Example7 {
         <p id="Example8-code">
           Example:
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+        <div class="wrapper"><pre><code class="language-java">
 class Example8 {
   void testMethod1() {
     int var1 = 1;
@@ -619,7 +619,7 @@ class Example8 {
           To configure the check to produce a violation on a method
           with too many returns:
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
+        <div class="wrapper"><pre><code class="language-xml">
 &lt;module name="Checker"&gt;
   &lt;module name="TreeWalker"&gt;
     &lt;module name="DescendantToken"&gt;
@@ -633,7 +633,7 @@ class Example8 {
         <p id="Example9-code">
           Example:
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+        <div class="wrapper"><pre><code class="language-java">
 class Example9 {
   void testMethod1() {
     int var1 = 1;
@@ -670,7 +670,7 @@ class Example9 {
           To configure the check to produce a violation on a method
           which throws too many exceptions:
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
+        <div class="wrapper"><pre><code class="language-xml">
 &lt;module name="Checker"&gt;
   &lt;module name="TreeWalker"&gt;
     &lt;module name="DescendantToken"&gt;
@@ -684,7 +684,7 @@ class Example9 {
         <p id="Example10-code">
           Example:
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+        <div class="wrapper"><pre><code class="language-java">
 class Example10 {
   void testMethod1() throws ArithmeticException {
       // ...
@@ -700,7 +700,7 @@ class Example10 {
           To configure the check to produce a violation on a method
           with too many expressions:
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
+        <div class="wrapper"><pre><code class="language-xml">
 &lt;module name="Checker"&gt;
   &lt;module name="TreeWalker"&gt;
     &lt;module name="DescendantToken"&gt;
@@ -714,7 +714,7 @@ class Example10 {
         <p id="Example11-code">
           Example:
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+        <div class="wrapper"><pre><code class="language-java">
 class Example11 {
   void testMethod1() {
     int x = 1;
@@ -732,7 +732,7 @@ class Example11 {
         <p id="Example12-config">
           To configure the check to produce a violation on an empty statement:
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
+        <div class="wrapper"><pre><code class="language-xml">
 &lt;module name="Checker"&gt;
   &lt;module name="TreeWalker"&gt;
     &lt;module name="DescendantToken"&gt;
@@ -749,7 +749,7 @@ class Example11 {
         <p id="Example12-code">
           Example:
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+        <div class="wrapper"><pre><code class="language-java">
 class Example12 {
   void testMethod1 () {
     System.out.println("Hello");
@@ -764,7 +764,7 @@ class Example12 {
           To configure the check to produce a violation on a class or interface
           with too many fields:
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
+        <div class="wrapper"><pre><code class="language-xml">
 &lt;module name="Checker"&gt;
   &lt;module name="TreeWalker"&gt;
     &lt;module name="DescendantToken"&gt;
@@ -779,7 +779,7 @@ class Example12 {
         <p id="Example13-code">
           Example:
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+        <div class="wrapper"><pre><code class="language-java">
 class Example13 {
   private int field1;
 
@@ -806,7 +806,7 @@ interface Test2 {
           To configure the check to produce a violation on
           comparing <code>this</code> with <code>null</code>:
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
+        <div class="wrapper"><pre><code class="language-xml">
 &lt;module name="Checker"&gt;
   &lt;module name="TreeWalker"&gt;
     &lt;module name="DescendantToken"&gt;
@@ -822,7 +822,7 @@ interface Test2 {
         <p id="Example14-code">
           Example:
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+        <div class="wrapper"><pre><code class="language-java">
 class Example14 {
   void testMethod1() {
     // violation below, 'Total count of 2 exceeds maximum count 1'
@@ -849,7 +849,7 @@ class Example14 {
           To configure the check to produce a violation on a <code>String</code>
           literal equality check:
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
+        <div class="wrapper"><pre><code class="language-xml">
 &lt;module name="Checker"&gt;
   &lt;module name="TreeWalker"&gt;
     &lt;module name="DescendantToken"&gt;
@@ -864,7 +864,7 @@ class Example14 {
         <p id="Example15-code">
           Example:
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+        <div class="wrapper"><pre><code class="language-java">
 class Example15 {
   void testMethod1() {
     String str = "abc";
@@ -882,7 +882,7 @@ class Example15 {
           To configure the check to produce a violation on an assert statement
           that may have side effects:
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
+        <div class="wrapper"><pre><code class="language-xml">
 &lt;module name="Checker"&gt;
   &lt;module name="TreeWalker"&gt;
     &lt;module name="DescendantToken"&gt;
@@ -899,7 +899,7 @@ class Example15 {
         <p id="Example16-code">
           Example:
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+        <div class="wrapper"><pre><code class="language-java">
 class Example16 {
   void testMethod1() {
     int a = 5;

--- a/src/site/xdoc/checks/misc/finalparameters.xml
+++ b/src/site/xdoc/checks/misc/finalparameters.xml
@@ -81,7 +81,7 @@
           To configure the check to enforce final parameters for methods and
           constructors:
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
+        <div class="wrapper"><pre><code class="language-xml">
 &lt;module name="Checker"&gt;
   &lt;module name="TreeWalker"&gt;
     &lt;module name="FinalParameters"/&gt;
@@ -91,7 +91,7 @@
         <p id="Example1-code">
           Example:
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+        <div class="wrapper"><pre><code class="language-java">
 public class Example1 {
   public Example1() { }
   public Example1(final int m) { }
@@ -105,7 +105,7 @@ public class Example1 {
           To configure the check to enforce final parameters only for
           constructors:
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
+        <div class="wrapper"><pre><code class="language-xml">
 &lt;module name="Checker"&gt;
   &lt;module name="TreeWalker"&gt;
     &lt;module name="FinalParameters"&gt;
@@ -117,7 +117,7 @@ public class Example1 {
         <p id="Example2-code">
           Example:
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+        <div class="wrapper"><pre><code class="language-java">
 public class Example2 {
   public Example2() { }
   public Example2(final int m) { }
@@ -132,7 +132,7 @@ public class Example2 {
           <a href="https://docs.oracle.com/javase/tutorial/java/nutsandbolts/datatypes.html">
            primitive datatypes</a> as parameters:
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
+        <div class="wrapper"><pre><code class="language-xml">
 &lt;module name="Checker"&gt;
   &lt;module name="TreeWalker"&gt;
     &lt;module name="FinalParameters"&gt;
@@ -144,7 +144,7 @@ public class Example2 {
         <p id="Example3-code">
           Example:
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+        <div class="wrapper"><pre><code class="language-java">
 public class Example3 {
   public Example3() { }
   public Example3(final int m) { }
@@ -158,7 +158,7 @@ public class Example3 {
           To configure the check to enforce final parameters for catch and
           for-each blocks while ignoring unnamed parameters:
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
+        <div class="wrapper"><pre><code class="language-xml">
 &lt;module name="Checker"&gt;
   &lt;module name="TreeWalker"&gt;
     &lt;module name="FinalParameters"&gt;
@@ -171,7 +171,7 @@ public class Example3 {
         <p id="Example4-code">
           Example:
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+        <div class="wrapper"><pre><code class="language-java">
 public class Example4 {
 
   void testCatchParameters() {

--- a/src/site/xdoc/checks/misc/indentation.xml
+++ b/src/site/xdoc/checks/misc/indentation.xml
@@ -114,7 +114,7 @@ if ((condition1 &amp;&amp; condition2)
         <p id="Example1-config">
           To configure the default check:
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
+        <div class="wrapper"><pre><code class="language-xml">
 &lt;module name="Checker"&gt;
   &lt;module name="TreeWalker"&gt;
     &lt;module name="Indentation"/&gt;
@@ -125,7 +125,7 @@ if ((condition1 &amp;&amp; condition2)
           Example of Compliant code for default configuration
           (in comment name of property that controls indentations):
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+        <div class="wrapper"><pre><code class="language-java">
 class Example1 {
     String field = "example";                  // basicOffset
     int[] values = {                           // basicOffset
@@ -174,7 +174,7 @@ class Example1 {
           Oracle:
         </p>
 
-        <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
+        <div class="wrapper"><pre><code class="language-xml">
 &lt;module name="Checker"&gt;
   &lt;module name="TreeWalker"&gt;
     &lt;module name="Indentation"&gt;
@@ -187,7 +187,7 @@ class Example1 {
           Example of Compliant code for default configuration
           (in comment name of property that controls indentation):
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+        <div class="wrapper"><pre><code class="language-java">
 class Example2 {
     String field = "example";                  // basicOffset
     int[] values = {                           // basicOffset
@@ -234,7 +234,7 @@ class Example2 {
         <p id="Example3-config">
           To configure the Check to enforce strict condition in line-wrapping validation.
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
+        <div class="wrapper"><pre><code class="language-xml">
 &lt;module name="Checker"&gt;
   &lt;module name="TreeWalker"&gt;
     &lt;module name="Indentation"&gt;
@@ -247,7 +247,7 @@ class Example2 {
           Such config doesn't allow next cases
           even code is aligned further to the right for better reading:
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+        <div class="wrapper"><pre><code class="language-java">
 class Example3 {
     String field = "example";                  // basicOffset
     int[] values = {                           // basicOffset
@@ -294,7 +294,7 @@ class Example3 {
         <p id="Example4-code">
           But if forceStrictCondition = false, this code is valid:
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+        <div class="wrapper"><pre><code class="language-java">
 class Example4 {
     String field = "example";                   // basicOffset
     int[] values = {                            // basicOffset

--- a/src/site/xdoc/checks/misc/newlineatendoffile.xml
+++ b/src/site/xdoc/checks/misc/newlineatendoffile.xml
@@ -92,20 +92,20 @@ StaticMethodCandidateCheck.name = Static Method Candidate
         <p id="Example1-config">
           To configure the check:
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
+        <div class="wrapper"><pre><code class="language-xml">
 &lt;module name="Checker"&gt;
   &lt;module name="NewlineAtEndOfFile"/&gt;
 &lt;/module&gt;
 </code></pre></div>
         <p id="Example1-code">Correct Example:</p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+        <div class="wrapper"><pre><code class="language-java">
 public class Example1 { // ⤶
 // ⤶
 } // ⤶ // ok, file ends with a new line.
 </code></pre></div>
 
         <p id="Example2-code">Violation Example:</p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+        <div class="wrapper"><pre><code class="language-java">
 public class Example2 { // ⤶
 // ⤶
 } // no ⤶ below it is violation
@@ -114,7 +114,7 @@ public class Example2 { // ⤶
         <p id="Example3-config">
           To configure the check to always use Unix-style line separators:
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
+        <div class="wrapper"><pre><code class="language-xml">
 &lt;module name="Checker"&gt;
   &lt;module name="NewlineAtEndOfFile"&gt;
     &lt;property name="lineSeparator" value="lf"/&gt;
@@ -122,7 +122,7 @@ public class Example2 { // ⤶
 &lt;/module&gt;
 </code></pre></div>
         <p id="Example3-code">Example:</p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+        <div class="wrapper"><pre><code class="language-java">
 public class Example3 { // ⤶
 } // ␍⤶  it is violation as line ending is different from expected
 </code></pre></div>
@@ -130,7 +130,7 @@ public class Example3 { // ⤶
         <p id="Example4-config">
           To configure the check to work only on Java, XML and Cpp files:
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
+        <div class="wrapper"><pre><code class="language-xml">
 &lt;module name="Checker"&gt;
   &lt;module name="NewlineAtEndOfFile"&gt;
     &lt;property name="fileExtensions" value="java, xml, cpp"/&gt;
@@ -138,21 +138,21 @@ public class Example3 { // ⤶
 &lt;/module&gt;
 </code></pre></div>
         <p id="Example4-code">Cpp file <code>Example4.cpp</code>:</p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+        <div class="wrapper"><pre><code class="language-java">
 int main() { // ⤶
     return 0;// ⤶
 } // no ⤶ below it is violation
 </code></pre></div>
 
         <p id="Example5-code">Java file <code>Example5.java</code>:</p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+        <div class="wrapper"><pre><code class="language-java">
 public class Example5 { // ⤶
 // ⤶
 } // no ⤶ below it is violation
 </code></pre></div>
 
         <p id="Example6-code">Text file <code>Example6.txt</code>:</p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+        <div class="wrapper"><pre><code class="language-java">
 Sample txt file. // ok, this file is not specified in the config.
 </code></pre></div>
       </subsection>

--- a/src/site/xdoc/checks/misc/nocodeinfile.xml
+++ b/src/site/xdoc/checks/misc/nocodeinfile.xml
@@ -33,7 +33,7 @@
         <p id="Example1-config">
           To configure the check:
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
+        <div class="wrapper"><pre><code class="language-xml">
 &lt;module name="Checker"&gt;
   &lt;module name="TreeWalker"&gt;
     &lt;module name="NoCodeInFile"/&gt;
@@ -41,14 +41,14 @@
 &lt;/module&gt;
 </code></pre></div>
         <p id="Example1-code">Example:</p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+        <div class="wrapper"><pre><code class="language-java">
 /* the violation is on first line of file */
 // public class Example1 {
 // single-line comment is not code
 // }
 </code></pre></div>
         <p id="Example2-code">Example:</p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+        <div class="wrapper"><pre><code class="language-java">
 /* the violation is on first line of file */
 /*
  public class Example2 {

--- a/src/site/xdoc/checks/misc/orderedproperties.xml
+++ b/src/site/xdoc/checks/misc/orderedproperties.xml
@@ -58,7 +58,7 @@
         <p id="Example1-config">
           To configure the check:
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
+        <div class="wrapper"><pre><code class="language-xml">
 &lt;module name="Checker"&gt;
   &lt;module name="OrderedProperties"/&gt;
 &lt;/module&gt;
@@ -66,7 +66,7 @@
         <p id="Example1-raw">
           Example properties file:
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+        <div class="wrapper"><pre><code class="language-java">
 A=65
 a=97
 key=107 than nothing

--- a/src/site/xdoc/checks/misc/outertypefilename.xml
+++ b/src/site/xdoc/checks/misc/outertypefilename.xml
@@ -20,7 +20,7 @@
         <p id="Example1-config">
           To configure the check:
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
+        <div class="wrapper"><pre><code class="language-xml">
 &lt;module name="Checker"&gt;
   &lt;module name="TreeWalker"&gt;
     &lt;module name="OuterTypeFilename"/&gt;
@@ -30,34 +30,34 @@
         <p id="Example1-code">
           Example file content with name of file Example1.java
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+        <div class="wrapper"><pre><code class="language-java">
 public class Example1 {}
 </code></pre></div>
         <p id="Example2-code">
           Example file content with name of file Example2.java
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+        <div class="wrapper"><pre><code class="language-java">
 // violation below 'The name of the outer type and the file do not match.'
 class Example2ButNotSameName {}
 </code></pre></div>
         <p id="Example3-code">
           Example file content with name of file Example3.java
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+        <div class="wrapper"><pre><code class="language-java">
 // violation below 'The name of the outer type and the file do not match.'
 interface Example3ButNotSameName {}
 </code></pre></div>
         <p id="Example4-code">
           Example file content with name of file Example4.java
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+        <div class="wrapper"><pre><code class="language-java">
 // violation below 'The name of the outer type and the file do not match.'
 enum Example4ButNotSameName {}
 </code></pre></div>
         <p id="Example5-code">
           Example file content with name of file Example5.java
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+        <div class="wrapper"><pre><code class="language-java">
 // violation below 'The name of the outer type and the file do not match.'
 class Example5ButNotSameName {}
 </code></pre></div>

--- a/src/site/xdoc/checks/misc/todocomment.xml
+++ b/src/site/xdoc/checks/misc/todocomment.xml
@@ -52,7 +52,7 @@
         <p id="Example1-config">
           To configure the check:
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
+        <div class="wrapper"><pre><code class="language-xml">
 &lt;module name="Checker"&gt;
   &lt;module name="TreeWalker"&gt;
     &lt;module name="TodoComment"/&gt;
@@ -62,7 +62,7 @@
         <p id="Example1-code">
           Example:
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+        <div class="wrapper"><pre><code class="language-java">
 public class Example1 {
   int i;
   int x;
@@ -78,7 +78,7 @@ public class Example1 {
           To configure the check for comments that contain <code>TODO</code> and <code>FIXME</code>,
           case-insensitive:
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
+        <div class="wrapper"><pre><code class="language-xml">
 &lt;module name="Checker"&gt;
   &lt;module name="TreeWalker"&gt;
     &lt;module name="TodoComment"&gt;
@@ -90,7 +90,7 @@ public class Example1 {
         <p id="Example2-code">
           Example:
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+        <div class="wrapper"><pre><code class="language-java">
 public class Example2 {
   int i;
   int x;

--- a/src/site/xdoc/checks/misc/trailingcomment.xml
+++ b/src/site/xdoc/checks/misc/trailingcomment.xml
@@ -103,7 +103,7 @@ d = e / f;        // Another comment for this line
         <p id="Example1-config">
           To configure the check:
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
+        <div class="wrapper"><pre><code class="language-xml">
 &lt;module name="Checker"&gt;
   &lt;module name="TreeWalker"&gt;
     &lt;module name="TrailingComment"/&gt;
@@ -114,7 +114,7 @@ d = e / f;        // Another comment for this line
         <p id="Example1-code">
           Example:
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+        <div class="wrapper"><pre><code class="language-java">
 public class Example1 {
   public static void main(String[] args) {
     int x = 10;
@@ -135,7 +135,7 @@ public class Example1 {
         <p id="Example2-config">
           To configure the check to enforce only comment on a line:
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
+        <div class="wrapper"><pre><code class="language-xml">
 &lt;module name="Checker"&gt;
   &lt;module name="TreeWalker"&gt;
     &lt;module name="TrailingComment"&gt;
@@ -148,7 +148,7 @@ public class Example1 {
         <p id="Example2-code">
           Example:
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+        <div class="wrapper"><pre><code class="language-java">
 public class Example2 {
   public static void main(String[] args) {
     int x = new Random().nextInt(100);
@@ -170,7 +170,7 @@ public class Example2 {
           &quot;SUPPRESS CHECKSTYLE&quot;, &quot;NOPMD&quot;, &quot;NOSONAR&quot;
           are suppressed:
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
+        <div class="wrapper"><pre><code class="language-xml">
 &lt;module name="Checker"&gt;
   &lt;module name="TreeWalker"&gt;
     &lt;module name="TrailingComment"/&gt;
@@ -187,7 +187,7 @@ public class Example2 {
         <p id="Example3-code">
           Example for trailing comments check to suppress specific trailing comment:
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+        <div class="wrapper"><pre><code class="language-java">
 public class Example3 {
   int a; // SUPPRESS CHECKSTYLE
   int b; // NOPMD
@@ -200,7 +200,7 @@ public class Example3 {
           To configure check so that trailing comment starting with &quot;SUPPRESS CHECKSTYLE&quot;,
           &quot;NOPMD&quot;, &quot;NOSONAR&quot; are suppressed:
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
+        <div class="wrapper"><pre><code class="language-xml">
 &lt;module name="Checker"&gt;
   &lt;module name="TreeWalker"&gt;
     &lt;module name="TrailingComment"/&gt;
@@ -220,7 +220,7 @@ public class Example3 {
         <p id="Example4-code">
           Example:
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+        <div class="wrapper"><pre><code class="language-java">
 public class Example4 {
   int a; // SUPPRESS CHECKSTYLE - OK, comment starts with " SUPPRESS CHECKSTYLE"
   int b; // NOPMD - OK, comment starts with " NOPMD"

--- a/src/site/xdoc/checks/misc/translation.xml
+++ b/src/site/xdoc/checks/misc/translation.xml
@@ -93,7 +93,7 @@
         <p id="Example1-config">
           To configure the check to check existence of Japanese and French translations:
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
+        <div class="wrapper"><pre><code class="language-xml">
 &lt;module name="Checker"&gt;
   &lt;module name="Translation"&gt;
     &lt;property name="requiredTranslations" value="es, fr"/&gt;
@@ -107,22 +107,22 @@ messages_fr.properties
 messages_es.properties
         </source>
         <p id="messages-raw">Contents of messages.properties file:</p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+        <div class="wrapper"><pre><code class="language-java">
 hello=Hello
 cancel=Cancel
 </code></pre></div>
         <p id="messages_es-raw">Contents of messages_es.properties file:</p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+        <div class="wrapper"><pre><code class="language-java">
 greeting=Saludo
 age=Edad
 </code></pre></div>
         <p id="messages_fr-raw">Contents of messages_fr.properties file:</p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+        <div class="wrapper"><pre><code class="language-java">
 greeting=Bonjour
 name=Nom
 </code></pre></div>
         <p id="Example1-code">Validation for Example1:</p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+        <div class="wrapper"><pre><code class="language-java">
 messages.properties     // violation 'Key 'age', 'name' and 'greeting' missing.'
 messages_fr.properties  // violation 'Key 'age', 'cancel' and 'hello' missing.'
 messages_es.properties  // violation 'Key 'cancel', 'name' and 'hello' missing.'
@@ -131,7 +131,7 @@ messages_es.properties  // violation 'Key 'cancel', 'name' and 'hello' missing.'
           An example of how to configure the check to validate only bundles which base names
           start with &quot;ButtonLabels&quot;:
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
+        <div class="wrapper"><pre><code class="language-xml">
 &lt;module name="Checker"&gt;
   &lt;module name="Translation"&gt;
     &lt;property name="baseName" value="^ButtonLabels.*$"/&gt;
@@ -145,17 +145,17 @@ ButtonLabels.properties
 ButtonLabels_fr.properties
         </source>
         <p id="ButtonLabels-raw">Contents of ButtonLabels.properties file:</p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+        <div class="wrapper"><pre><code class="language-java">
 hello=Hello
 cancel=Cancel
 </code></pre></div>
         <p id="ButtonLabels_fr-raw">Contents of ButtonLabels_fr.properties file:</p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+        <div class="wrapper"><pre><code class="language-java">
 hello=Bonjour
 name=Nom
 </code></pre></div>
         <p id="Example2-code">Validation for Example2:</p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+        <div class="wrapper"><pre><code class="language-java">
 ButtonLabels.properties     // violation 'Key 'name' is missing.'
 ButtonLabels_fr.properties  // violation 'Key 'cancel' is missing.'
 </code></pre></div>
@@ -163,7 +163,7 @@ ButtonLabels_fr.properties  // violation 'Key 'cancel' is missing.'
           To configure the check to check only files which have '.properties' and '.translations'
           extensions:
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
+        <div class="wrapper"><pre><code class="language-xml">
 &lt;module name="Checker"&gt;
   &lt;module name="Translation"&gt;
     &lt;property name="fileExtensions" value="properties"/&gt;
@@ -178,17 +178,17 @@ messages_home.properties
 messages_home.translations
         </source>
         <p id="messages_home-raw">Contents of messages_home.properties file:</p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+        <div class="wrapper"><pre><code class="language-java">
 hello=Hello
 cancel=Cancel
 </code></pre></div>
         <p id="messages_home-code">Contents of messages_home.translations file:</p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+        <div class="wrapper"><pre><code class="language-java">
 hello=Hallo
 ok=OK
 </code></pre></div>
         <p id="Example3-code">Validation for Example3:</p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+        <div class="wrapper"><pre><code class="language-java">
 messages_home.properties   // violation,
                           'Properties file 'messages_home_fr.properties' missing.'
 messages_home.translations // violation,

--- a/src/site/xdoc/checks/misc/uncommentedmain.xml
+++ b/src/site/xdoc/checks/misc/uncommentedmain.xml
@@ -48,7 +48,7 @@
         <p id="Example1-config">
           To configure the check:
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
+        <div class="wrapper"><pre><code class="language-xml">
 &lt;module name="Checker"&gt;
   &lt;module name="TreeWalker"&gt;
     &lt;module name="UncommentedMain"/&gt;
@@ -56,7 +56,7 @@
 &lt;/module&gt;
 </code></pre></div>
         <p id="Example1-code">Example:</p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+        <div class="wrapper"><pre><code class="language-java">
 class Example1 {
   // violation below, 'Uncommented main method found'
   public static void main(String... args){}
@@ -87,7 +87,7 @@ record MyRecord2() {
           To configure the check to allow the <code>main</code> method for all classes
           with &quot;Main&quot; name:
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
+        <div class="wrapper"><pre><code class="language-xml">
 &lt;module name="Checker"&gt;
   &lt;module name="TreeWalker"&gt;
     &lt;module name="UncommentedMain"&gt;
@@ -97,7 +97,7 @@ record MyRecord2() {
 &lt;/module&gt;
 </code></pre></div>
         <p id="Example2-code">Example:</p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+        <div class="wrapper"><pre><code class="language-java">
 class Example2 {
   // violation below, 'Uncommented main method found'
   public static void main(String... args){}

--- a/src/site/xdoc/checks/misc/uniqueproperties.xml
+++ b/src/site/xdoc/checks/misc/uniqueproperties.xml
@@ -47,7 +47,7 @@
         <p id="Example1-config">
           To configure the check:
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
+        <div class="wrapper"><pre><code class="language-xml">
 &lt;module name="Checker"&gt;
   &lt;module name="UniqueProperties"/&gt;
 &lt;/module&gt;
@@ -55,7 +55,7 @@
         <p id="Example1-raw">
           Example: in foo.properties file
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+        <div class="wrapper"><pre><code class="language-java">
 # // violation below 'Duplicated property 'key.one' (2 occurrence(s)).'
 key.one=44
 key.two=32
@@ -64,7 +64,7 @@ key.one=54
         <p id="Example2-config">
           To configure the check to scan custom file extensions:
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
+        <div class="wrapper"><pre><code class="language-xml">
 &lt;module name="Checker"&gt;
   &lt;module name="UniqueProperties"&gt;
     &lt;property name="fileExtensions" value="customProperties"/&gt;
@@ -74,7 +74,7 @@ key.one=54
         <p id="Example2-raw">
           Example: in foo.customProperties file
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+        <div class="wrapper"><pre><code class="language-java">
 # // violation below 'Duplicated property 'key.one' (2 occurrence(s)).'
 key.one=44
 key.two=32
@@ -83,7 +83,7 @@ key.one=54
         <p id="Example3-raw">
           Example: in foo.properties file
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+        <div class="wrapper"><pre><code class="language-java">
 # OK below, no duplication violation, as the file is not checked
 key.one=44
 key.two=32

--- a/src/site/xdoc/checks/misc/upperell.xml
+++ b/src/site/xdoc/checks/misc/upperell.xml
@@ -25,7 +25,7 @@
         <p id="Example1-config">
           To configure the check:
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
+        <div class="wrapper"><pre><code class="language-xml">
 &lt;module name="Checker"&gt;
   &lt;module name="TreeWalker"&gt;
     &lt;module name="UpperEll"/&gt;
@@ -33,7 +33,7 @@
 &lt;/module&gt;
 </code></pre></div>
         <p id="Example1-code">Example:</p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+        <div class="wrapper"><pre><code class="language-java">
 class Example1 {
   long var1 = 508987; // OK
   long var2 = 508987l; // violation

--- a/src/site/xdoc/checks/modifier/classmemberimpliedmodifier.xml
+++ b/src/site/xdoc/checks/modifier/classmemberimpliedmodifier.xml
@@ -82,7 +82,7 @@ public final class Person {
         <p id="Example1-config">
           Configuration:
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
+        <div class="wrapper"><pre><code class="language-xml">
 &lt;module name="Checker"&gt;
   &lt;module name="TreeWalker"&gt;
     &lt;module name="ClassMemberImpliedModifier" /&gt;
@@ -92,7 +92,7 @@ public final class Person {
         <p id="Example1-code">
           Code:
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+        <div class="wrapper"><pre><code class="language-java">
 public final class Example1 {
   static interface Address1 {
   }

--- a/src/site/xdoc/checks/modifier/interfacememberimpliedmodifier.xml
+++ b/src/site/xdoc/checks/modifier/interfacememberimpliedmodifier.xml
@@ -152,7 +152,7 @@ public interface AddressFactory {
         <p id="Example1-config">
           Configuration:
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
+        <div class="wrapper"><pre><code class="language-xml">
 &lt;module name="Checker"&gt;
   &lt;module name="TreeWalker"&gt;
     &lt;module name="InterfaceMemberImpliedModifier"/&gt;
@@ -162,7 +162,7 @@ public interface AddressFactory {
         <p id="Example1-code">
           Code:
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+        <div class="wrapper"><pre><code class="language-java">
 public interface Example1 {
 
   public static final String UNKNOWN = "Unknown";
@@ -196,7 +196,7 @@ public interface Example1 {
         <p id="Example2-config">
           Configuration:
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
+        <div class="wrapper"><pre><code class="language-xml">
 &lt;module name="Checker"&gt;
   &lt;module name="TreeWalker"&gt;
     &lt;module name="InterfaceMemberImpliedModifier"&gt;
@@ -209,7 +209,7 @@ public interface Example1 {
         <p id="Example2-code">
           Code:
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+        <div class="wrapper"><pre><code class="language-java">
 public interface Example2 {
 
   public static final String UNKNOWN = "Unknown";

--- a/src/site/xdoc/checks/modifier/modifierorder.xml
+++ b/src/site/xdoc/checks/modifier/modifierorder.xml
@@ -77,7 +77,7 @@
 
       <subsection name="Examples" id="Examples">
         <p id="Example1-config"> To configure the check: </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
+        <div class="wrapper"><pre><code class="language-xml">
 &lt;module name="Checker"&gt;
   &lt;module name="TreeWalker"&gt;
     &lt;module name="ModifierOrder"/&gt;
@@ -85,7 +85,7 @@
 &lt;/module&gt;
 </code></pre></div>
         <p id="Example1-code"> Code: </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+        <div class="wrapper"><pre><code class="language-java">
 public class Example1 {
   public static final int MAX_VALUE = 100;
 

--- a/src/site/xdoc/checks/modifier/redundantmodifier.xml
+++ b/src/site/xdoc/checks/modifier/redundantmodifier.xml
@@ -236,7 +236,7 @@ public class ClassExtending extends ClassExample {
 
       <subsection name="Examples" id="Examples">
         <p id="Example1-config"> To configure the check: </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
+        <div class="wrapper"><pre><code class="language-xml">
 &lt;module name="Checker"&gt;
   &lt;module name="TreeWalker"&gt;
     &lt;module name="RedundantModifier"/&gt;
@@ -246,7 +246,7 @@ public class ClassExtending extends ClassExample {
         <p id="Example1-code">
           Example:
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+        <div class="wrapper"><pre><code class="language-java">
 public class Example1 {
 
   void test() {
@@ -284,7 +284,7 @@ public class Example1 {
         <p id="Example2-config">
           To configure the check to check only methods:
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
+        <div class="wrapper"><pre><code class="language-xml">
 &lt;module name="Checker"&gt;
   &lt;module name="TreeWalker"&gt;
     &lt;module name="RedundantModifier"&gt;
@@ -296,7 +296,7 @@ public class Example1 {
         <p id="Example2-code">
           Example:
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+        <div class="wrapper"><pre><code class="language-java">
 public class Example2 {
 
   void test() {
@@ -329,7 +329,7 @@ public class Example2 {
         <p id="Example3-config">
           To configure the check if you are using JDK 11:
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
+        <div class="wrapper"><pre><code class="language-xml">
 &lt;module name="Checker"&gt;
   &lt;module name="TreeWalker"&gt;
     &lt;module name="RedundantModifier"&gt;
@@ -341,7 +341,7 @@ public class Example2 {
         <p id="Example3-code">
           Example:
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+        <div class="wrapper"><pre><code class="language-java">
 public class Example3 {
 
   void test() {

--- a/src/site/xdoc/checks/naming/abbreviationaswordinname.xml
+++ b/src/site/xdoc/checks/naming/abbreviationaswordinname.xml
@@ -155,7 +155,7 @@
 
       <subsection name="Examples" id="Examples">
         <p id="Example1-config">To configure the check:</p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
+        <div class="wrapper"><pre><code class="language-xml">
 &lt;module name="Checker"&gt;
   &lt;module name="TreeWalker"&gt;
     &lt;module name="AbbreviationAsWordInName"/&gt;
@@ -163,7 +163,7 @@
 &lt;/module&gt;
 </code></pre></div>
         <p id="Example1-code">Example:</p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+        <div class="wrapper"><pre><code class="language-java">
 class Example1 extends SuperClass { // OK, camel case
   int CURRENT_COUNTER; // violation 'no more than '4' consecutive capital letters'
   static int GLOBAL_COUNTER; // OK, static is ignored
@@ -188,7 +188,7 @@ class Example1 extends SuperClass { // OK, camel case
           methods tagged with <code>@Override</code> annotation.
         </p>
         <p id="Example2-config">Configuration:</p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
+        <div class="wrapper"><pre><code class="language-xml">
 &lt;module name="Checker"&gt;
   &lt;module name="TreeWalker"&gt;
     &lt;module name="AbbreviationAsWordInName"&gt;
@@ -199,7 +199,7 @@ class Example1 extends SuperClass { // OK, camel case
 &lt;/module&gt;
 </code></pre></div>
         <p id="Example2-code">Example:</p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+        <div class="wrapper"><pre><code class="language-java">
 class Example2 extends SuperClass { // OK, camel case
   int CURRENT_COUNTER; // violation 'no more than '4' consecutive capital letters'
   // violation below 'no more than '4' consecutive capital letters'
@@ -227,7 +227,7 @@ class Example2 extends SuperClass { // OK, camel case
           words like 'XML' and 'URL'.
         </p>
         <p id="Example3-config">Configuration:</p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
+        <div class="wrapper"><pre><code class="language-xml">
 &lt;module name="Checker"&gt;
   &lt;module name="TreeWalker"&gt;
     &lt;module name="AbbreviationAsWordInName"&gt;
@@ -240,7 +240,7 @@ class Example2 extends SuperClass { // OK, camel case
 &lt;/module&gt;
 </code></pre></div>
         <p id="Example3-code">Example:</p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+        <div class="wrapper"><pre><code class="language-java">
 class Example3 {
   int firstNum;
   int secondNUM; // violation 'no more than '1' consecutive capital letters'
@@ -261,7 +261,7 @@ class Example3 {
           consecutive capital letters ignoring the longer word 'CSV'.
         </p>
         <p id="Example4-config">Configuration:</p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
+        <div class="wrapper"><pre><code class="language-xml">
 &lt;module name="Checker"&gt;
   &lt;module name="TreeWalker"&gt;
     &lt;module name="AbbreviationAsWordInName"&gt;
@@ -274,7 +274,7 @@ class Example3 {
 &lt;/module&gt;
 </code></pre></div>
         <p id="Example4-code">Example:</p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+        <div class="wrapper"><pre><code class="language-java">
 class Example4 { // OK, ignore checking the class name
   int firstNum; // OK, abbreviation "N" is of allowed length 1
   int secondNUm;
@@ -292,7 +292,7 @@ class Example4 { // OK, ignore checking the class name
           except for variables that are both static and final.
         </p>
         <p id="Example5-config">Configuration:</p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
+        <div class="wrapper"><pre><code class="language-xml">
 &lt;module name="Checker"&gt;
   &lt;module name="TreeWalker"&gt;
     &lt;module name="AbbreviationAsWordInName"&gt;
@@ -306,7 +306,7 @@ class Example4 { // OK, ignore checking the class name
 &lt;/module&gt;
 </code></pre></div>
         <p id="Example5-code">Example:</p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+        <div class="wrapper"><pre><code class="language-java">
 class Example5 {
   int counterXYZ = 1; // violation 'no more than '1' consecutive capital letters'
   // violation below 'no more than '1' consecutive capital letters'
@@ -320,7 +320,7 @@ class Example5 {
           and ignoring static (but non-final) variables only.
         </p>
         <p id="Example6-config">Configuration:</p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
+        <div class="wrapper"><pre><code class="language-xml">
 &lt;module name="Checker"&gt;
   &lt;module name="TreeWalker"&gt;
     &lt;module name="AbbreviationAsWordInName"&gt;
@@ -334,7 +334,7 @@ class Example5 {
 &lt;/module&gt;
 </code></pre></div>
         <p id="Example6-code">Example:</p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+        <div class="wrapper"><pre><code class="language-java">
 class Example6 {
   int counterXYZ = 1; // violation 'no more than '1' consecutive capital letters'
   // violation below 'no more than '1' consecutive capital letters'
@@ -350,7 +350,7 @@ class Example6 {
           words like 'ALLOWED'.
         </p>
         <p id="Example7-config">Configuration:</p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
+        <div class="wrapper"><pre><code class="language-xml">
 &lt;module name="Checker"&gt;
   &lt;module name="TreeWalker"&gt;
     &lt;module name="AbbreviationAsWordInName"&gt;
@@ -361,7 +361,7 @@ class Example6 {
 &lt;/module&gt;
 </code></pre></div>
         <p id="Example7-code">Example:</p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+        <div class="wrapper"><pre><code class="language-java">
 class Example7 {
   int counterXYZ = 1;
   final int customerID = 2;

--- a/src/site/xdoc/checks/naming/abstractclassname.xml
+++ b/src/site/xdoc/checks/naming/abstractclassname.xml
@@ -59,7 +59,7 @@
         <p id="Example1-config">
           To configure the check:
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
+        <div class="wrapper"><pre><code class="language-xml">
 &lt;module name="Checker"&gt;
   &lt;module name="TreeWalker"&gt;
     &lt;module name="AbstractClassName"/&gt;
@@ -67,7 +67,7 @@
 &lt;/module&gt;
 </code></pre></div>
         <p id="Example1-code">Example:</p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+        <div class="wrapper"><pre><code class="language-java">
 class Example1 {
   abstract class AbstractFirst {}
   abstract class Second {} // violation 'must match pattern'
@@ -82,7 +82,7 @@ class Example1 {
           To configure the check so that it check name
           but ignore <code>abstract</code> modifier:
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
+        <div class="wrapper"><pre><code class="language-xml">
 &lt;module name="Checker"&gt;
   &lt;module name="TreeWalker"&gt;
     &lt;module name="AbstractClassName"&gt;
@@ -92,7 +92,7 @@ class Example1 {
 &lt;/module&gt;
 </code></pre></div>
         <p id="Example2-code">Example:</p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+        <div class="wrapper"><pre><code class="language-java">
 class Example2 {
   abstract class AbstractFirst {}
   abstract class Second {} // violation 'must match pattern'
@@ -107,7 +107,7 @@ class Example2 {
             To configure the check to ignore name
             validation when class declared as 'abstract'
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
+        <div class="wrapper"><pre><code class="language-xml">
 &lt;module name="Checker"&gt;
   &lt;module name="TreeWalker"&gt;
     &lt;module name="AbstractClassName"&gt;
@@ -117,7 +117,7 @@ class Example2 {
 &lt;/module&gt;
 </code></pre></div>
         <p id="Example3-code">Example:</p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+        <div class="wrapper"><pre><code class="language-java">
 class Example3 {
   abstract class AbstractFirst {}
   abstract class Second {}
@@ -131,7 +131,7 @@ class Example3 {
           To configure the check
           with <code>format</code>:
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
+        <div class="wrapper"><pre><code class="language-xml">
 &lt;module name="Checker"&gt;
   &lt;module name="TreeWalker"&gt;
     &lt;module name="AbstractClassName"&gt;
@@ -141,7 +141,7 @@ class Example3 {
 &lt;/module&gt;
 </code></pre></div>
         <p id="Example4-code">Example:</p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+        <div class="wrapper"><pre><code class="language-java">
 class Example4 {
   // violation below 'must match pattern'
   abstract class AbstractFirst {}

--- a/src/site/xdoc/checks/naming/catchparametername.xml
+++ b/src/site/xdoc/checks/naming/catchparametername.xml
@@ -54,7 +54,7 @@
         <p id="Example1-config">
           To configure the check:
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
+        <div class="wrapper"><pre><code class="language-xml">
 &lt;module name="Checker"&gt;
   &lt;module name="TreeWalker"&gt;
     &lt;module name="CatchParameterName"/&gt;
@@ -63,7 +63,7 @@
 </code></pre></div>
         <p id="Example1-code">Example:
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+        <div class="wrapper"><pre><code class="language-java">
 public class Example1 {
   public void myTest() {
     try {
@@ -90,7 +90,7 @@ public class Example1 {
           a lower case letter, followed by any letters or digits is:
         </p>
         <p id="Example2-config">Configuration:</p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
+        <div class="wrapper"><pre><code class="language-xml">
 &lt;module name="Checker"&gt;
   &lt;module name="TreeWalker"&gt;
     &lt;module name="CatchParameterName"&gt;
@@ -100,7 +100,7 @@ public class Example1 {
 &lt;/module&gt;
 </code></pre></div>
         <p id="Example2-code">Example:</p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+        <div class="wrapper"><pre><code class="language-java">
 public class Example2 {
   public void myTest() {
     try {

--- a/src/site/xdoc/checks/naming/classtypeparametername.xml
+++ b/src/site/xdoc/checks/naming/classtypeparametername.xml
@@ -37,7 +37,7 @@
         <p id="Example1-config">
           To configure the check:
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
+        <div class="wrapper"><pre><code class="language-xml">
 &lt;module name="Checker"&gt;
   &lt;module name="TreeWalker"&gt;
     &lt;module name="ClassTypeParameterName"/&gt;
@@ -45,7 +45,7 @@
 &lt;/module&gt;
 </code></pre></div>
         <p id="Example1-code">Example:</p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+        <div class="wrapper"><pre><code class="language-java">
 class Example1 {
   class MyClass1&lt;T&gt; {}
   class MyClass2&lt;t&gt; {}        // violation
@@ -57,7 +57,7 @@ class Example1 {
         <p id="Example2-config">
           To configure the check for names that are uppercase word:
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
+        <div class="wrapper"><pre><code class="language-xml">
 &lt;module name="Checker"&gt;
   &lt;module name="TreeWalker"&gt;
     &lt;module name="ClassTypeParameterName"&gt;
@@ -67,7 +67,7 @@ class Example1 {
 &lt;/module&gt;
 </code></pre></div>
         <p id="Example2-code">Example:</p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+        <div class="wrapper"><pre><code class="language-java">
 class Example2 {
   class MyClass1&lt;T&gt; {}        // violation
   class MyClass2&lt;t&gt; {}        // violation
@@ -80,7 +80,7 @@ class Example2 {
           To configure the check for names that are camel case word with T as suffix
           (<a href="../../styleguides/google-java-style-20220203/javaguide.html#s5.2.8-type-variable-names">Google Style</a>):
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
+        <div class="wrapper"><pre><code class="language-xml">
 &lt;module name="Checker"&gt;
   &lt;module name="TreeWalker"&gt;
     &lt;module name="ClassTypeParameterName"&gt;
@@ -90,7 +90,7 @@ class Example2 {
 &lt;/module&gt;
 </code></pre></div>
         <p id="Example3-code">Example:</p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+        <div class="wrapper"><pre><code class="language-java">
 class Example3 {
   class MyClass1&lt;T&gt; {}
   class MyClass2&lt;t&gt; {}        // violation

--- a/src/site/xdoc/checks/naming/constantname.xml
+++ b/src/site/xdoc/checks/naming/constantname.xml
@@ -70,7 +70,7 @@
         <p id="Example1-config">
           To configure the check:
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
+        <div class="wrapper"><pre><code class="language-xml">
 &lt;module name="Checker"&gt;
   &lt;module name="TreeWalker"&gt;
     &lt;module name="ConstantName"/&gt;
@@ -78,7 +78,7 @@
 &lt;/module&gt;
 </code></pre></div>
         <p id="Example1-code">Example:</p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+        <div class="wrapper"><pre><code class="language-java">
 class Example1 {
   public final static int FIRST_CONSTANT1 = 10;
   protected final static int SECOND_CONSTANT2 = 100;
@@ -96,7 +96,7 @@ class Example1 {
           or <code>logger</code>:
         </p>
 
-        <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
+        <div class="wrapper"><pre><code class="language-xml">
 &lt;module name="Checker"&gt;
   &lt;module name="TreeWalker"&gt;
     &lt;module name="ConstantName"&gt;
@@ -107,7 +107,7 @@ class Example1 {
 &lt;/module&gt;
 </code></pre></div>
         <p id="Example2-code">Code Example:</p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+        <div class="wrapper"><pre><code class="language-java">
 class Example2 {
   public final static int FIRST_CONSTANT1 = 10;
   protected final static int SECOND_CONSTANT2 = 100;
@@ -124,7 +124,7 @@ class Example2 {
           The following configuration skip validation on
           public constant field and protected constant field.
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
+        <div class="wrapper"><pre><code class="language-xml">
 &lt;module name="Checker"&gt;
   &lt;module name="TreeWalker"&gt;
     &lt;module name="ConstantName"&gt;
@@ -135,7 +135,7 @@ class Example2 {
 &lt;/module&gt;
 </code></pre></div>
         <p id="Example3-code">Code Example:</p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+        <div class="wrapper"><pre><code class="language-java">
 class Example3 {
   public final static int FIRST_CONSTANT1 = 10;
   protected final static int SECOND_CONSTANT2 = 100;

--- a/src/site/xdoc/checks/naming/illegalidentifiername.xml
+++ b/src/site/xdoc/checks/naming/illegalidentifiername.xml
@@ -110,7 +110,7 @@
           To configure the check:
         </p>
         <p id="Example1-config">Configuration:</p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
+        <div class="wrapper"><pre><code class="language-xml">
 &lt;module name="Checker"&gt;
   &lt;module name="TreeWalker"&gt;
     &lt;module name="IllegalIdentifierName"/&gt;
@@ -118,7 +118,7 @@
 &lt;/module&gt;
 </code></pre></div>
         <p id="Example1-code">Example:</p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+        <div class="wrapper"><pre><code class="language-java">
 public class Example1 {
   Integer var = 4; // violation, 'Name 'var' must match pattern'
   int record = 15; // violation, 'Name 'record' must match pattern'
@@ -151,7 +151,7 @@ public class Example1 {
           illegal identifiers:
         </p>
         <p id="Example2-config">Configuration:</p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
+        <div class="wrapper"><pre><code class="language-xml">
 &lt;module name="Checker"&gt;
   &lt;module name="TreeWalker"&gt;
     &lt;module name="IllegalIdentifierName"&gt;
@@ -162,7 +162,7 @@ public class Example1 {
 &lt;/module&gt;
 </code></pre></div>
         <p id="Example2-code">Example:</p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+        <div class="wrapper"><pre><code class="language-java">
 public class Example2 {
   Integer var = 4; // violation, 'Name 'var' must match pattern'
   int record = 15; // violation, 'Name 'record' must match pattern'

--- a/src/site/xdoc/checks/naming/interfacetypeparametername.xml
+++ b/src/site/xdoc/checks/naming/interfacetypeparametername.xml
@@ -39,7 +39,7 @@
         <p id="Example1-config">
           To configure the check:
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
+        <div class="wrapper"><pre><code class="language-xml">
 &lt;module name="Checker"&gt;
   &lt;module name="TreeWalker"&gt;
     &lt;module name="InterfaceTypeParameterName"/&gt;
@@ -47,7 +47,7 @@
 &lt;/module&gt;
 </code></pre></div>
         <p id="Example1-code">Code Example:</p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+        <div class="wrapper"><pre><code class="language-java">
 class Example1 {
   interface FirstInterface&lt;T&gt; {}
   interface SecondInterface&lt;t&gt; {} // violation
@@ -57,7 +57,7 @@ class Example1 {
           An example of how to configure the check for names that are only a single
           letter is:
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
+        <div class="wrapper"><pre><code class="language-xml">
 &lt;module name="Checker"&gt;
   &lt;module name="TreeWalker"&gt;
     &lt;module name="InterfaceTypeParameterName"&gt;
@@ -67,7 +67,7 @@ class Example1 {
 &lt;/module&gt;
 </code></pre></div>
         <p id="Example2-code">Code Example:</p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+        <div class="wrapper"><pre><code class="language-java">
 class Example2 {
   interface FirstInterface&lt;T&gt; {}
   interface SecondInterface&lt;t&gt; {}

--- a/src/site/xdoc/checks/naming/lambdaparametername.xml
+++ b/src/site/xdoc/checks/naming/lambdaparametername.xml
@@ -39,7 +39,7 @@
         <p id="Example1-config">
           To configure the check:
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
+        <div class="wrapper"><pre><code class="language-xml">
 &lt;module name="Checker"&gt;
   &lt;module name="TreeWalker"&gt;
     &lt;module name="LambdaParameterName"/&gt;
@@ -47,7 +47,7 @@
 &lt;/module&gt;
 </code></pre></div>
         <p id="Example1-code">Code Example:</p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+        <div class="wrapper"><pre><code class="language-java">
 class Example1 {
   Function&lt;String, String&gt; function1 = s -&gt; s.toLowerCase();
   Function&lt;String, String&gt; function2 =
@@ -58,7 +58,7 @@ class Example1 {
           An example of how to configure the check for names that begin with a lower case letter,
           followed by letters is:
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
+        <div class="wrapper"><pre><code class="language-xml">
 &lt;module name="Checker"&gt;
   &lt;module name="TreeWalker"&gt;
     &lt;module name="LambdaParameterName"&gt;
@@ -68,7 +68,7 @@ class Example1 {
 &lt;/module&gt;
 </code></pre></div>
         <p id="Example2-code">Code Example:</p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+        <div class="wrapper"><pre><code class="language-java">
 class Example2 {
   Function&lt;String, String&gt; function1 = str -&gt; str.toUpperCase().trim();
   Function&lt;String, String&gt; function2 = _s -&gt; _s.trim();

--- a/src/site/xdoc/checks/naming/localfinalvariablename.xml
+++ b/src/site/xdoc/checks/naming/localfinalvariablename.xml
@@ -69,7 +69,7 @@
         <p id="Example1-config">
           To configure the check:
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
+        <div class="wrapper"><pre><code class="language-xml">
 &lt;module name="Checker"&gt;
   &lt;module name="TreeWalker"&gt;
     &lt;module name="LocalFinalVariableName"&gt;
@@ -79,7 +79,7 @@
 &lt;/module&gt;
 </code></pre></div>
         <p id="Example1-code">Code Example:</p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+        <div class="wrapper"><pre><code class="language-java">
 class Example1{
   void MyMethod() {
     try {
@@ -96,7 +96,7 @@ class Example1{
           An example of how to configure the check for names that are only upper case letters and
           digits is:
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
+        <div class="wrapper"><pre><code class="language-xml">
 &lt;module name="Checker"&gt;
   &lt;module name="TreeWalker"&gt;
     &lt;module name="LocalFinalVariableName"&gt;
@@ -106,7 +106,7 @@ class Example1{
 &lt;/module&gt;
 </code></pre></div>
         <p id="Example2-code">Code Example:</p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+        <div class="wrapper"><pre><code class="language-java">
 class Example2 {
   void MyMethod() {
     try {
@@ -123,7 +123,7 @@ class Example2 {
           An example of how to configure the check for names of local final parameters and
           resources in try statements (without checks on variables):
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
+        <div class="wrapper"><pre><code class="language-xml">
 &lt;module name="Checker"&gt;
   &lt;module name="TreeWalker"&gt;
     &lt;module name="LocalFinalVariableName"&gt;
@@ -134,7 +134,7 @@ class Example2 {
 &lt;/module&gt;
 </code></pre></div>
         <p id="Example3-code">Code Example:</p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+        <div class="wrapper"><pre><code class="language-java">
 class Example3 {
   void MyMethod() {
     try(Scanner scanner = new Scanner(System.in)) { // violation

--- a/src/site/xdoc/checks/naming/localvariablename.xml
+++ b/src/site/xdoc/checks/naming/localvariablename.xml
@@ -54,7 +54,7 @@
           To configure the check:
         </p>
 
-        <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
+        <div class="wrapper"><pre><code class="language-xml">
 &lt;module name="Checker"&gt;
   &lt;module name="TreeWalker"&gt;
     &lt;module name="LocalVariableName"/&gt;
@@ -62,7 +62,7 @@
 &lt;/module&gt;
 </code></pre></div>
         <p id="Example1-code">Code Example:</p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+        <div class="wrapper"><pre><code class="language-java">
 class Example1 {
   void MyMethod() {
     for (int var = 1; var &lt; 10; var++) {}
@@ -76,7 +76,7 @@ class Example1 {
           An example of how to configure the check for names that begin with a lower
           case letter, followed by letters, digits, and underscores is:
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
+        <div class="wrapper"><pre><code class="language-xml">
 &lt;module name="Checker"&gt;
   &lt;module name="TreeWalker"&gt;
     &lt;module name="LocalVariableName"&gt;
@@ -86,7 +86,7 @@ class Example1 {
 &lt;/module&gt;
 </code></pre></div>
         <p id="Example2-code">Code Example:</p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+        <div class="wrapper"><pre><code class="language-java">
 class Example2 {
   void MyMethod() {
     for (int var = 1; var &lt; 10; var++) {}
@@ -100,7 +100,7 @@ class Example2 {
           An example of one character variable name in initialization expression(like &quot;i&quot;)
           in FOR loop:
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+        <div class="wrapper"><pre><code class="language-java">
 class Example3 {
   void myMethod () {
     for(int i = 1; i &lt; 10; i++) {}
@@ -117,7 +117,7 @@ class Example3 {
           <a href="https://docs.oracle.com/javase/tutorial/java/nutsandbolts/for.html">
           initialization expressions</a> in FOR loop, where regexp allows 2 or more chars:
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
+        <div class="wrapper"><pre><code class="language-xml">
 &lt;module name="Checker"&gt;
   &lt;module name="TreeWalker"&gt;
     &lt;module name="LocalVariableName"&gt;
@@ -128,7 +128,7 @@ class Example3 {
 &lt;/module&gt;
 </code></pre></div>
         <p id="Example4-code">Code Example:</p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+        <div class="wrapper"><pre><code class="language-java">
 class Example4 {
   void MyMethod() {
     int good = 1;
@@ -152,7 +152,7 @@ class Example4 {
         <p id="Example5-config">
         An example of how to configure the check to that all variables have 3 or more chars in name:
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
+        <div class="wrapper"><pre><code class="language-xml">
 &lt;module name="Checker"&gt;
   &lt;module name="TreeWalker"&gt;
     &lt;module name="LocalVariableName"&gt;
@@ -162,7 +162,7 @@ class Example4 {
 &lt;/module&gt;
 </code></pre></div>
         <p id="Example5-code">Code Example:</p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+        <div class="wrapper"><pre><code class="language-java">
 class Example5 {
   void MyMethod() {
     int goodName = 0;

--- a/src/site/xdoc/checks/naming/membername.xml
+++ b/src/site/xdoc/checks/naming/membername.xml
@@ -67,7 +67,7 @@
         <p id="Example1-config">
          To configure the check:
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
+        <div class="wrapper"><pre><code class="language-xml">
 &lt;module name="Checker"&gt;
   &lt;module name="TreeWalker"&gt;
     &lt;module name="MemberName"/&gt;
@@ -75,7 +75,7 @@
 &lt;/module&gt;
 </code></pre></div>
         <p id="Example1-code">Code Example:</p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+        <div class="wrapper"><pre><code class="language-java">
 class Example1 {
   public int num1;
   protected int num2;
@@ -102,7 +102,7 @@ class Example1 {
           and package-private member:
         </p>
 
-        <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
+        <div class="wrapper"><pre><code class="language-xml">
 &lt;module name="Checker"&gt;
   &lt;module name="TreeWalker"&gt;
     &lt;module name="MemberName"&gt;
@@ -114,7 +114,7 @@ class Example1 {
 &lt;/module&gt;
 </code></pre></div>
         <p id="Example2-code">Code Example:</p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+        <div class="wrapper"><pre><code class="language-java">
 class Example2 {
   public int num1; // violation
 
@@ -128,7 +128,7 @@ class Example2 {
           An example of how to suppress the check which is applied to
           public and private member:
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
+        <div class="wrapper"><pre><code class="language-xml">
 &lt;module name="Checker"&gt;
   &lt;module name="TreeWalker"&gt;
     &lt;module name="MemberName"&gt;
@@ -139,7 +139,7 @@ class Example2 {
 &lt;/module&gt;
 </code></pre></div>
         <p id="Example3-code">Code Example:</p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+        <div class="wrapper"><pre><code class="language-java">
 class Example3 {
   public int NUM1;
   protected int NUM2; // violation

--- a/src/site/xdoc/checks/naming/methodname.xml
+++ b/src/site/xdoc/checks/naming/methodname.xml
@@ -82,7 +82,7 @@
         <p id="Example1-config">
           To configure the check:
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
+        <div class="wrapper"><pre><code class="language-xml">
 &lt;module name="Checker"&gt;
   &lt;module name="TreeWalker"&gt;
     &lt;module name="MethodName"/&gt;
@@ -90,7 +90,7 @@
 &lt;/module&gt;
 </code></pre></div>
         <p id="Example1-code">Code Example:</p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+        <div class="wrapper"><pre><code class="language-java">
 class Example1 {
   public void method1() {}
   protected void method2() {}
@@ -102,7 +102,7 @@ class Example1 {
           An example of how to configure the check for names that begin with a lower case letter,
           followed by letters, digits, and underscores is:
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
+        <div class="wrapper"><pre><code class="language-xml">
 &lt;module name="Checker"&gt;
   &lt;module name="TreeWalker"&gt;
     &lt;module name="MethodName"&gt;
@@ -112,7 +112,7 @@ class Example1 {
 &lt;/module&gt;
 </code></pre></div>
         <p id="Example2-code">Code Example:</p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+        <div class="wrapper"><pre><code class="language-java">
 class Example2 {
   public void method1() {}
   public void Method2() {} // violation
@@ -122,7 +122,7 @@ class Example2 {
           An example of how to configure the check to allow method names to be equal to the
           residing class name is:
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
+        <div class="wrapper"><pre><code class="language-xml">
 &lt;module name="Checker"&gt;
   &lt;module name="TreeWalker"&gt;
     &lt;module name="MethodName"&gt;
@@ -133,7 +133,7 @@ class Example2 {
 &lt;/module&gt;
 </code></pre></div>
         <p id="Example3-code">Code Example:</p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+        <div class="wrapper"><pre><code class="language-java">
 class Example3 {
   public Example3() {}
   public void Example3() {}
@@ -143,7 +143,7 @@ class Example3 {
           An example of how to configure the check to disallow method names to be equal to the
           residing class name is:
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
+        <div class="wrapper"><pre><code class="language-xml">
 &lt;module name="Checker"&gt;
   &lt;module name="TreeWalker"&gt;
     &lt;module name="MethodName"&gt;
@@ -154,7 +154,7 @@ class Example3 {
 &lt;/module&gt;
 </code></pre></div>
         <p id="Example4-code">Code Example:</p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+        <div class="wrapper"><pre><code class="language-java">
 class Example4 {
   public Example4() {}
   public void Example4() {} // violation
@@ -163,7 +163,7 @@ class Example4 {
         <p id="Example5-config">
           An example of how to suppress the check to public and protected methods:
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
+        <div class="wrapper"><pre><code class="language-xml">
 &lt;module name="Checker"&gt;
   &lt;module name="TreeWalker"&gt;
     &lt;module name="MethodName"&gt;
@@ -175,7 +175,7 @@ class Example4 {
 &lt;/module&gt;
 </code></pre></div>
         <p id="Example5-code">Code Example:</p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+        <div class="wrapper"><pre><code class="language-java">
 class Example5 {
   public void Method1() {}
   protected void Method2() {}

--- a/src/site/xdoc/checks/naming/methodtypeparametername.xml
+++ b/src/site/xdoc/checks/naming/methodtypeparametername.xml
@@ -39,7 +39,7 @@
         <p id="Example1-config">
           To configure the check:
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
+        <div class="wrapper"><pre><code class="language-xml">
 &lt;module name="Checker"&gt;
   &lt;module name="TreeWalker"&gt;
     &lt;module name="MethodTypeParameterName"/&gt;
@@ -47,7 +47,7 @@
 &lt;/module&gt;
 </code></pre></div>
         <p id="Example1-code">Code Example:</p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+        <div class="wrapper"><pre><code class="language-java">
 class Example1 {
   public &lt;T&gt; void method1() {}
   public &lt;a&gt; void method2() {} // violation
@@ -58,7 +58,7 @@ class Example1 {
         <p id="Example2-config">
           An example of how to configure the check for names that are only a single letter is:
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
+        <div class="wrapper"><pre><code class="language-xml">
 &lt;module name="Checker"&gt;
   &lt;module name="TreeWalker"&gt;
     &lt;module name="MethodTypeParameterName"&gt;
@@ -68,7 +68,7 @@ class Example1 {
 &lt;/module&gt;
 </code></pre></div>
         <p id="Example2-code">Code Example:</p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+        <div class="wrapper"><pre><code class="language-java">
 class Example2 {
   public &lt;T&gt; void method1() {}
   public &lt;a&gt; void method2() {}

--- a/src/site/xdoc/checks/naming/packagename.xml
+++ b/src/site/xdoc/checks/naming/packagename.xml
@@ -49,7 +49,7 @@
         <p id="Example1-config">
           To configure the check:
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
+        <div class="wrapper"><pre><code class="language-xml">
 &lt;module name="Checker"&gt;
   &lt;module name="TreeWalker"&gt;
     &lt;module name="PackageName"/&gt;
@@ -57,7 +57,7 @@
 &lt;/module&gt;
 </code></pre></div>
         <p id="Example1-code">Code Example:</p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+        <div class="wrapper"><pre><code class="language-java">
 package com.puppycrawl.tools.checkstyle.checks.naming.packagename;
 
 public class Example1 {
@@ -67,7 +67,7 @@ public class Example1 {
           An example of how to configure the check to ensure with packages start with a upper case
           letter and only contains lowercase letters or numbers is:
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
+        <div class="wrapper"><pre><code class="language-xml">
 &lt;module name="Checker"&gt;
   &lt;module name="TreeWalker"&gt;
     &lt;module name="PackageName"&gt;
@@ -78,7 +78,7 @@ public class Example1 {
 &lt;/module&gt;
 </code></pre></div>
         <p id="Example2-code">Code Example:</p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+        <div class="wrapper"><pre><code class="language-java">
 package com.puppycrawl.tools.checkstyle.checks.naming.packagename;
 // violation above 'must match pattern'
 

--- a/src/site/xdoc/checks/naming/parametername.xml
+++ b/src/site/xdoc/checks/naming/parametername.xml
@@ -67,7 +67,7 @@
         <p id="Example1-config">
           To configure the check:
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
+        <div class="wrapper"><pre><code class="language-xml">
 &lt;module name="Checker"&gt;
   &lt;module name="TreeWalker"&gt;
     &lt;module name="ParameterName"/&gt;
@@ -75,7 +75,7 @@
 &lt;/module&gt;
 </code></pre></div>
         <p id="Example1-code">Code Example:</p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+        <div class="wrapper"><pre><code class="language-java">
 class Example1 {
   void method1(int v1) {}
   void method2(int V2) {} // violation
@@ -85,7 +85,7 @@ class Example1 {
           An example of how to configure the check for names that begin with a lower case letter,
           followed by letters, digits, and underscores:
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
+        <div class="wrapper"><pre><code class="language-xml">
 &lt;module name="Checker"&gt;
   &lt;module name="TreeWalker"&gt;
     &lt;module name="ParameterName"&gt;
@@ -95,7 +95,7 @@ class Example1 {
 &lt;/module&gt;
 </code></pre></div>
         <p id="Example2-code">Code Example:</p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+        <div class="wrapper"><pre><code class="language-java">
 class Example2 {
   void method1(int v1) {}
   void method2(int v_2) {}
@@ -107,7 +107,7 @@ class Example2 {
             An example of how to configure the check to skip methods with Override annotation from
             validation:
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
+        <div class="wrapper"><pre><code class="language-xml">
 &lt;module name="Checker"&gt;
   &lt;module name="TreeWalker"&gt;
     &lt;module name="ParameterName"&gt;
@@ -117,7 +117,7 @@ class Example2 {
 &lt;/module&gt;
 </code></pre></div>
         <p id="Example3-code">Code Example:</p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+        <div class="wrapper"><pre><code class="language-java">
 class Example3 {
   void method1(int v1) {}
   void method2(int V2) {} // violation
@@ -131,7 +131,7 @@ class Example3 {
           An example of how to configure the check for names that begin with
           a lower case letter, followed by letters and digits is:
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
+        <div class="wrapper"><pre><code class="language-xml">
 &lt;module name="Checker"&gt;
   &lt;module name="TreeWalker"&gt;
     &lt;module name="ParameterName"&gt;
@@ -141,7 +141,7 @@ class Example3 {
 &lt;/module&gt;
 </code></pre></div>
         <p id="Example4-code">Code Example:</p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+        <div class="wrapper"><pre><code class="language-java">
 class Example4 {
   void method1(int v1) {}
   void method2(int v_2) {} // violation
@@ -153,7 +153,7 @@ class Example4 {
           lowercase characters and, in addition, that public method parameters cannot be one
           character long:
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
+        <div class="wrapper"><pre><code class="language-xml">
 &lt;module name="Checker"&gt;
   &lt;module name="TreeWalker"&gt;
     &lt;module name="ParameterName"&gt;
@@ -172,7 +172,7 @@ class Example4 {
 &lt;/module&gt;
 </code></pre></div>
         <p id="Example5-code">Code Example:</p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+        <div class="wrapper"><pre><code class="language-java">
 class Example5 {
   void fn1(int v1) {}
   protected void fn2(int V2) {} // violation "Parameter name 'V2' must match pattern"

--- a/src/site/xdoc/checks/naming/patternvariablename.xml
+++ b/src/site/xdoc/checks/naming/patternvariablename.xml
@@ -40,7 +40,7 @@
           To configure the check:
         </p>
 
-        <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
+        <div class="wrapper"><pre><code class="language-xml">
 &lt;module name="Checker"&gt;
   &lt;module name="TreeWalker"&gt;
     &lt;module name="PatternVariableName"/&gt;
@@ -48,7 +48,7 @@
 &lt;/module&gt;
 </code></pre></div>
         <p id="Example1-code">Code Example:</p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+        <div class="wrapper"><pre><code class="language-java">
 class Example1 {
   void foo(Object o1){
     if (o1 instanceof String STRING) {} // violation
@@ -62,7 +62,7 @@ class Example1 {
           An example of how to configure the check for names that have a lower case letter,
           followed by letters and digits, optionally separated by underscore:
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
+        <div class="wrapper"><pre><code class="language-xml">
 &lt;module name="Checker"&gt;
   &lt;module name="TreeWalker"&gt;
     &lt;module name="PatternVariableName"&gt;
@@ -72,7 +72,7 @@ class Example1 {
 &lt;/module&gt;
 </code></pre></div>
         <p id="Example2-code">Code Example:</p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+        <div class="wrapper"><pre><code class="language-java">
 class Example2 {
   void foo(Object o1){
     if (o1 instanceof String STRING) {} // violation
@@ -86,7 +86,7 @@ class Example2 {
           An example of how to configure the check to that all variables have 3 or more
           chars in name:
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
+        <div class="wrapper"><pre><code class="language-xml">
 &lt;module name="Checker"&gt;
   &lt;module name="TreeWalker"&gt;
     &lt;module name="PatternVariableName"&gt;
@@ -96,7 +96,7 @@ class Example2 {
 &lt;/module&gt;
 </code></pre></div>
         <p id="Example3-code">Code Example:</p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+        <div class="wrapper"><pre><code class="language-java">
 class Example3 {
   void foo(Object o1){
     if (o1 instanceof String STRING) {} // violation
@@ -110,7 +110,7 @@ class Example3 {
           An example of how to configure the check with different format for final and non-final
           pattern variables:
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
+        <div class="wrapper"><pre><code class="language-xml">
 &lt;module name="Checker"&gt;
   &lt;module name="TreeWalker"&gt;
     &lt;module name="PatternVariableName"&gt;
@@ -138,7 +138,7 @@ class Example3 {
 &lt;/module&gt;
 </code></pre></div>
         <p id="Example4-code">Code Example:</p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+        <div class="wrapper"><pre><code class="language-java">
 class Example4 {
   void foo(Object o1){
     if (o1 instanceof String BAD) {} // violation

--- a/src/site/xdoc/checks/naming/recordcomponentname.xml
+++ b/src/site/xdoc/checks/naming/recordcomponentname.xml
@@ -37,7 +37,7 @@
         <p id="Example1-config">
           To configure the check:
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
+        <div class="wrapper"><pre><code class="language-xml">
 &lt;module name="Checker"&gt;
   &lt;module name="TreeWalker"&gt;
     &lt;module name="RecordComponentName"/&gt;
@@ -45,7 +45,7 @@
 &lt;/module&gt;
 </code></pre></div>
         <p id="Example1-code">Example:</p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+        <div class="wrapper"><pre><code class="language-java">
 class Example1 {
   record Rec1(int other) {}
 
@@ -58,7 +58,7 @@ class Example1 {
           An example of how to configure the check for names that are only letters in lowercase:
         </p>
         <p id="Example2-config">Configuration:</p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
+        <div class="wrapper"><pre><code class="language-xml">
 &lt;module name="Checker"&gt;
   &lt;module name="TreeWalker"&gt;
     &lt;module name="RecordComponentName"&gt;
@@ -68,7 +68,7 @@ class Example1 {
 &lt;/module&gt;
 </code></pre></div>
         <p id="Example2-code">Example:</p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+        <div class="wrapper"><pre><code class="language-java">
 class Example2 {
   record Rec1(int other) {}
 

--- a/src/site/xdoc/checks/naming/recordtypeparametername.xml
+++ b/src/site/xdoc/checks/naming/recordtypeparametername.xml
@@ -37,7 +37,7 @@
         <p id="Example1-config">
           To configure the check:
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
+        <div class="wrapper"><pre><code class="language-xml">
 &lt;module name="Checker"&gt;
   &lt;module name="TreeWalker"&gt;
     &lt;module name="RecordTypeParameterName"/&gt;
@@ -45,7 +45,7 @@
 &lt;/module&gt;
 </code></pre></div>
         <p id="Example1-code">Example:</p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+        <div class="wrapper"><pre><code class="language-java">
 class Example1 {
   record Record1&lt;T&gt;() {}
 
@@ -58,7 +58,7 @@ class Example1 {
           An example of how to configure the check for names that are only a single letter is:
         </p>
         <p id="Example2-config">Configuration:</p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
+        <div class="wrapper"><pre><code class="language-xml">
 &lt;module name="Checker"&gt;
   &lt;module name="TreeWalker"&gt;
     &lt;module name="RecordTypeParameterName"&gt;
@@ -68,7 +68,7 @@ class Example1 {
 &lt;/module&gt;
 </code></pre></div>
         <p id="Example2-code">Example:</p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+        <div class="wrapper"><pre><code class="language-java">
 class Example2 {
   record Record1&lt;T&gt;() {}
 

--- a/src/site/xdoc/checks/naming/staticvariablename.xml
+++ b/src/site/xdoc/checks/naming/staticvariablename.xml
@@ -68,7 +68,7 @@
         <p id="Example1-config">
           To configure the check:
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
+        <div class="wrapper"><pre><code class="language-xml">
 &lt;module name="Checker"&gt;
   &lt;module name="TreeWalker"&gt;
     &lt;module name="StaticVariableName"/&gt;
@@ -76,7 +76,7 @@
 &lt;/module&gt;
 </code></pre></div>
         <p id="Example1-code">Code Example:</p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+        <div class="wrapper"><pre><code class="language-java">
 class Example1 {
   public static int goodStatic = 2;
   private static int badStatic = 2;
@@ -92,7 +92,7 @@ class Example1 {
         <p id="Example2-config">
           An example of how to suppress the check to public and protected types is:
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
+        <div class="wrapper"><pre><code class="language-xml">
 &lt;module name="Checker"&gt;
   &lt;module name="TreeWalker"&gt;
     &lt;module name="StaticVariableName"&gt;
@@ -103,7 +103,7 @@ class Example1 {
 &lt;/module&gt;
 </code></pre></div>
         <p id="Example2-code">Code Example:</p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+        <div class="wrapper"><pre><code class="language-java">
 class Example2 {
   public static int goodStatic = 2;
   private static int badStatic = 2;
@@ -121,7 +121,7 @@ class Example2 {
           followed by letters, digits, and underscores. Also, suppress the check from being
           applied to private and package-private types:
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
+        <div class="wrapper"><pre><code class="language-xml">
 &lt;module name="Checker"&gt;
   &lt;module name="TreeWalker"&gt;
     &lt;module name="StaticVariableName"&gt;
@@ -133,7 +133,7 @@ class Example2 {
 &lt;/module&gt;
 </code></pre></div>
         <p id="Example3-code">Code Example:</p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+        <div class="wrapper"><pre><code class="language-java">
 class Example3 {
   public static int goodStatic = 2;
   private static int badStatic = 2;

--- a/src/site/xdoc/checks/naming/typename.xml
+++ b/src/site/xdoc/checks/naming/typename.xml
@@ -99,7 +99,7 @@
           To configure the check:
         </p>
 
-        <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
+        <div class="wrapper"><pre><code class="language-xml">
 &lt;module name="Checker"&gt;
   &lt;module name="TreeWalker"&gt;
     &lt;module name="TypeName"/&gt;
@@ -107,7 +107,7 @@
 &lt;/module&gt;
 </code></pre></div>
         <p id="Example1-code">Code Example:</p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+        <div class="wrapper"><pre><code class="language-java">
 class Example1 {
   public interface FirstName {}
   protected class SecondName {}
@@ -120,7 +120,7 @@ class Example1 {
           followed by letters, digits, and underscores. Also, suppress the check from being
           applied to protected and private type:
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
+        <div class="wrapper"><pre><code class="language-xml">
 &lt;module name="Checker"&gt;
   &lt;module name="TreeWalker"&gt;
     &lt;module name="TypeName"&gt;
@@ -132,7 +132,7 @@ class Example1 {
 &lt;/module&gt;
 </code></pre></div>
         <p id="Example2-code">Code Example:</p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+        <div class="wrapper"><pre><code class="language-java">
 class Example2 {   // violation
   public interface firstName {}
   public class SecondName {} // violation
@@ -145,7 +145,7 @@ class Example2 {   // violation
           interface names begin with <code>&quot;I_&quot;</code>, followed by
           letters and digits:
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
+        <div class="wrapper"><pre><code class="language-xml">
 &lt;module name="Checker"&gt;
   &lt;module name="TreeWalker"&gt;
     &lt;module name="TypeName"&gt;
@@ -158,7 +158,7 @@ class Example2 {   // violation
 &lt;/module&gt;
 </code></pre></div>
         <p id="Example3-code">Code Example:</p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+        <div class="wrapper"><pre><code class="language-java">
 class Example3 {
   public interface I_firstName {}
   interface SecondName {} // violation

--- a/src/site/xdoc/checks/regexp/regexp.xml
+++ b/src/site/xdoc/checks/regexp/regexp.xml
@@ -123,7 +123,7 @@
 
       <subsection name="Examples" id="Examples">
         <p id="Example0-config"> Default configuration does nothing: </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
+        <div class="wrapper"><pre><code class="language-xml">
 &lt;module name="Checker"&gt;
   &lt;module name="TreeWalker"&gt;
     &lt;module name="Regexp"/&gt;
@@ -134,7 +134,7 @@
           An example of how to configure the check to make sure a copyright
           statement is included in the file:
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
+        <div class="wrapper"><pre><code class="language-xml">
 &lt;module name="Checker"&gt;
   &lt;module name="TreeWalker"&gt;
     &lt;module name="Regexp"&gt;
@@ -144,12 +144,12 @@
 &lt;/module&gt;
 </code></pre></div>
         <p id="Example1-code"> Example1: </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+        <div class="wrapper"><pre><code class="language-java">
 // This code is copyrighted.
 public class Example1 {}
 </code></pre></div>
         <p id="Example2-code">Example2 with violation:</p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+        <div class="wrapper"><pre><code class="language-java">
 /* violation on first line 'Required pattern missing in a file.' */
 /*
  * Some Copyright
@@ -157,7 +157,7 @@ public class Example1 {}
 public class Example2 {}
 </code></pre></div>
         <p id="Example3-config"> Your statement may be multiline. </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
+        <div class="wrapper"><pre><code class="language-xml">
 &lt;module name="Checker"&gt;
   &lt;module name="TreeWalker"&gt;
     &lt;module name="Regexp"&gt;
@@ -168,13 +168,13 @@ public class Example2 {}
 &lt;/module&gt;
 </code></pre></div>
         <p id="Example3-code">Example3:</p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+        <div class="wrapper"><pre><code class="language-java">
 // This code is copyrighted
 // (c) MyCompany
 public class Example3 {}
 </code></pre></div>
         <p id="Example4-config">Configure Check to make sure that it appear only once:</p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
+        <div class="wrapper"><pre><code class="language-xml">
 &lt;module name="Checker"&gt;
   &lt;module name="TreeWalker"&gt;
     &lt;module name="Regexp"&gt;
@@ -186,7 +186,7 @@ public class Example3 {}
 &lt;/module&gt;
 </code></pre></div>
         <p id="Example4-code">Example4:</p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+        <div class="wrapper"><pre><code class="language-java">
 // This code is copyrighted
 // (c) MyCompany
 public class Example4 {}
@@ -199,7 +199,7 @@ class Example41 {}
         <p id="Example5-config">Instead of printing whole regexp that might be unnecessary for
           user, you can substitute it to some static text:
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
+        <div class="wrapper"><pre><code class="language-xml">
 &lt;module name="Checker"&gt;
   &lt;module name="TreeWalker"&gt;
     &lt;module name="Regexp"&gt;
@@ -211,7 +211,7 @@ class Example41 {}
 &lt;/module&gt;
 </code></pre></div>
         <p id="Example5-code">Example5 with violation:</p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+        <div class="wrapper"><pre><code class="language-java">
 /*
  * violation on first line 'Required pattern 'Copyright' missing in file.'
 */
@@ -221,7 +221,7 @@ public class Example5 {}
         <p id="Example6-config">
           Configure the check to make sure there are no calls to <code>System.out.println</code>:
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
+        <div class="wrapper"><pre><code class="language-xml">
 &lt;module name="Checker"&gt;
   &lt;module name="TreeWalker"&gt;
     &lt;module name="Regexp"&gt;
@@ -232,7 +232,7 @@ public class Example5 {}
 &lt;/module&gt;
 </code></pre></div>
         <p id="Example6-code">Example6:</p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+        <div class="wrapper"><pre><code class="language-java">
 public class Example6 {
   private void foo() {
     System.out.println(""); // violation, 'Line matches the illegal pattern'
@@ -244,7 +244,7 @@ public class Example6 {
 }
 </code></pre></div>
         <p id="Example7-config">Configure to ignore comments:</p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
+        <div class="wrapper"><pre><code class="language-xml">
 &lt;module name="Checker"&gt;
   &lt;module name="TreeWalker"&gt;
     &lt;module name="Regexp"&gt;
@@ -256,7 +256,7 @@ public class Example6 {
 &lt;/module&gt;
 </code></pre></div>
         <p id="Example7-code">Example7:</p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+        <div class="wrapper"><pre><code class="language-java">
 public class Example7 {
   private void foo() {
     System.out.println(""); // violation, 'Line matches the illegal pattern'
@@ -270,7 +270,7 @@ public class Example7 {
         <p id="Example8-config">
           Configure the check to find trailing whitespace at the end of a line:
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
+        <div class="wrapper"><pre><code class="language-xml">
 &lt;module name="Checker"&gt;
   &lt;module name="TreeWalker"&gt;
     &lt;module name="Regexp"&gt;
@@ -282,7 +282,7 @@ public class Example7 {
 &lt;/module&gt;
 </code></pre></div>
         <p id="Example8-code">Example8:</p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+        <div class="wrapper"><pre><code class="language-java">
 public class Example8 {
   private void foo() { 
     // violation above 'Trailing whitespace'
@@ -292,7 +292,7 @@ public class Example8 {
         <p id="Example9-config">
           Configure the check to find case-insensitive occurrences of &quot;debug&quot;:
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
+        <div class="wrapper"><pre><code class="language-xml">
 &lt;module name="Checker"&gt;
   &lt;module name="TreeWalker"&gt;
     &lt;module name="Regexp"&gt;
@@ -307,7 +307,7 @@ public class Example8 {
           tells the regexp engine to ignore the case.
         </p>
         <p id="Example9-code">Example9:</p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+        <div class="wrapper"><pre><code class="language-java">
 public class Example9 {
   private void foo() {
     // fix me.
@@ -320,7 +320,7 @@ public class Example9 {
           When the limit is reached the check aborts with a message
           reporting that the limit has been reached.
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
+        <div class="wrapper"><pre><code class="language-xml">
 &lt;module name="Checker"&gt;
   &lt;module name="TreeWalker"&gt;
     &lt;module name="Regexp"&gt;
@@ -332,7 +332,7 @@ public class Example9 {
 &lt;/module&gt;
 </code></pre></div>
         <p id="Example10-code">Example10:</p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+        <div class="wrapper"><pre><code class="language-java">
 public class Example10 {
   private void foo() {
     // fix me.
@@ -348,7 +348,7 @@ public class Example10 {
           To configure the check to verify that each file has the
           multiline header where year could be any digits.
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
+        <div class="wrapper"><pre><code class="language-xml">
 &lt;module name="Checker"&gt;
   &lt;module name="TreeWalker"&gt;
     &lt;module name="Regexp"&gt;
@@ -360,7 +360,7 @@ public class Example10 {
 &lt;/module&gt;
 </code></pre></div>
         <p id="Example11-code">Example:</p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+        <div class="wrapper"><pre><code class="language-java">
 // Copyright (C) 2004 MyCompany
 // All rights reserved
 public class Example11 {}

--- a/src/site/xdoc/checks/regexp/regexpmultiline.xml
+++ b/src/site/xdoc/checks/regexp/regexpmultiline.xml
@@ -87,7 +87,7 @@
         <p id="Example1-config">
         To run the check with its default configuration (no matches will be):
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
+        <div class="wrapper"><pre><code class="language-xml">
 &lt;module name="Checker"&gt;
   &lt;module name="RegexpMultiline"/&gt;
 &lt;/module&gt;
@@ -95,7 +95,7 @@
         <p id="Example1-code">
         Example:
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+        <div class="wrapper"><pre><code class="language-java">
 class Example1 {
   void testMethod1() {
 
@@ -132,7 +132,7 @@ class Example1 {
         <p id="Example2-config">
           To configure the check to find calls to print to the console:
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
+        <div class="wrapper"><pre><code class="language-xml">
 &lt;module name="Checker"&gt;
   &lt;module name="RegexpMultiline"&gt;
     &lt;property name="format" value="System\.(out)|(err)\.print(ln)?\("/&gt;
@@ -142,7 +142,7 @@ class Example1 {
         <p id="Example2-code">
           Example:
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+        <div class="wrapper"><pre><code class="language-java">
 class Example2 {
   void testMethod1() {
     // violation below, 'Line matches the illegal pattern'
@@ -180,7 +180,7 @@ class Example2 {
           To configure the check to match text that spans multiple lines,
           like normal code in a Java file:
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
+        <div class="wrapper"><pre><code class="language-xml">
 &lt;module name="Checker"&gt;
   &lt;module name="RegexpMultiline"&gt;
     &lt;property name="matchAcrossLines" value="true"/&gt;
@@ -191,7 +191,7 @@ class Example2 {
         <p id="Example3-code">
           Example:
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+        <div class="wrapper"><pre><code class="language-java">
 class Example3 {
   void testMethod1() {
     // violation below, 'Line matches the illegal pattern'
@@ -236,7 +236,7 @@ class Example3 {
         <p id="Example4-config">
         To configure the check to match a maximum of three test strings:
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
+        <div class="wrapper"><pre><code class="language-xml">
 &lt;module name="Checker"&gt;
   &lt;module name="RegexpMultiline"&gt;
     &lt;property name="format" value="Test #[0-9]+:[A-Za-z ]+"/&gt;
@@ -248,7 +248,7 @@ class Example3 {
         <p id="Example4-code">
           Example:
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+        <div class="wrapper"><pre><code class="language-java">
 class Example4 {
   void testMethod1() {
 
@@ -285,7 +285,7 @@ class Example4 {
         <p id="Example5-config">
         To configure the check to match a minimum of two test strings:
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
+        <div class="wrapper"><pre><code class="language-xml">
 &lt;module name="Checker"&gt;
   &lt;module name="RegexpMultiline"&gt;
     &lt;property name="format" value="Test #[0-9]+:[A-Za-z ]+"/&gt;
@@ -296,7 +296,7 @@ class Example4 {
         <p id="Example5-code">
           Example:
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+        <div class="wrapper"><pre><code class="language-java">
 class Example5 {
   void testMethod1() {
 
@@ -333,7 +333,7 @@ class Example5 {
         <p id="Example6-config">
           To configure the check to restrict an empty file:
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
+        <div class="wrapper"><pre><code class="language-xml">
 &lt;module name="Checker"&gt;
   &lt;module name="RegexpMultiline"&gt;
       &lt;property name="format" value="^\s*$" /&gt;
@@ -346,7 +346,7 @@ class Example5 {
           Example of violation from the above config:
         </p>
 
-        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+        <div class="wrapper"><pre><code class="language-java">
 /var/tmp$ cat -n Test.java
 1
 2

--- a/src/site/xdoc/checks/regexp/regexponfilename.xml
+++ b/src/site/xdoc/checks/regexp/regexponfilename.xml
@@ -102,13 +102,13 @@
         <p id="Example1-config">
           To configure the check to report file names that contain a space:
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
+        <div class="wrapper"><pre><code class="language-xml">
 &lt;module name="Checker"&gt;
   &lt;module name="RegexpOnFilename"/&gt;
 &lt;/module&gt;
 </code></pre></div>
         <p id="Example1-code">Example1:</p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+        <div class="wrapper"><pre><code class="language-java">
 .../checkstyle.xml
 .../Test Example1.xml // violation, 'File match folder pattern '' and file pattern '\s'.'
 .../TestExample2.xml
@@ -118,7 +118,7 @@
         <p id="Example2-config">
           To configure the check to forbid 'xml' files in folders:
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
+        <div class="wrapper"><pre><code class="language-xml">
 &lt;module name="Checker"&gt;
   &lt;module name="RegexpOnFilename"&gt;
     &lt;property name="fileNamePattern" value="^TestExample\d+\.xml$"/&gt;
@@ -128,7 +128,7 @@
 &lt;/module&gt;
 </code></pre></div>
         <p id="Example2-code">Example2:</p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+        <div class="wrapper"><pre><code class="language-java">
 .../checkstyle.xml
 .../Test Example1.xml
 .../TestExample2.xml // violation, 'xml files should not match '^TestExample\d+\.xml$''
@@ -139,7 +139,7 @@
           To configure the check to forbid 'md' files except 'README.md file' in folders,
           with custom message:
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
+        <div class="wrapper"><pre><code class="language-xml">
 &lt;module name="Checker"&gt;
   &lt;module name="RegexpOnFilename"&gt;
     &lt;property name="fileNamePattern" value="README"/&gt;
@@ -151,7 +151,7 @@
 &lt;/module&gt;
 </code></pre></div>
         <p id="Example3-code">Example3:</p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+        <div class="wrapper"><pre><code class="language-java">
 .../checkstyle.xml
 .../Test Example1.xml
 .../TestExample2.xml
@@ -162,7 +162,7 @@
           To configure the check to only allow property and xml files to be located
           in the resource folder:
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
+        <div class="wrapper"><pre><code class="language-xml">
 &lt;module name="Checker"&gt;
   &lt;module name="RegexpOnFilename"&gt;
     &lt;property name="fileNamePattern" value=".*\.(properties|xml)$"/&gt;
@@ -173,7 +173,7 @@
 &lt;/module&gt;
 </code></pre></div>
         <p id="Example4-code">Example4:</p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+        <div class="wrapper"><pre><code class="language-java">
 .../checkstyle.xml
 .../Test Example1.xml
 .../TestExample2.xml
@@ -183,7 +183,7 @@
         <p id="Example5-config">
           To configure the check to only allow only camelcase
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
+        <div class="wrapper"><pre><code class="language-xml">
 &lt;module name="Checker"&gt;
   &lt;module name="RegexpOnFilename"&gt;
     &lt;property name="fileNamePattern" value="^([A-Z][a-z0-9]+\.?)+$"/&gt;
@@ -195,7 +195,7 @@
 &lt;/module&gt;
 </code></pre></div>
         <p id="Example5-code">Example5:</p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+        <div class="wrapper"><pre><code class="language-java">
 .../checkstyle.xml    // violation, 'only filenames in camelcase is allowed'
 .../Test Example1.xml // violation, 'only filenames in camelcase is allowed'
 .../TestExample2.xml

--- a/src/site/xdoc/checks/regexp/regexpsingleline.xml
+++ b/src/site/xdoc/checks/regexp/regexpsingleline.xml
@@ -80,7 +80,7 @@
         <p id="Example1-config">
         To configure the default check:
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
+        <div class="wrapper"><pre><code class="language-xml">
 &lt;module name="Checker"&gt;
   &lt;module name="RegexpSingleline" /&gt;
 &lt;/module&gt;
@@ -94,7 +94,7 @@
         To configure the check to find occurrences of 'System.exit('
         with some <i>slack</i> of allowing only one occurrence per file:
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
+        <div class="wrapper"><pre><code class="language-xml">
 &lt;module name="Checker"&gt;
   &lt;module name="RegexpSingleline"&gt;
     &lt;property name="format" value="System.exit\("/&gt;
@@ -106,7 +106,7 @@
 </code></pre></div>
 
         <p id="Example2-code">Example:</p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+        <div class="wrapper"><pre><code class="language-java">
 public class Example2 {
   void myFunction() {
     try {
@@ -120,7 +120,7 @@ public class Example2 {
 }
 </code></pre></div>
         <p id="Example3-code">Example with violation:</p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+        <div class="wrapper"><pre><code class="language-java">
 public class Example3 {
   void myFunction() {
     try {
@@ -138,7 +138,7 @@ public class Example3 {
           An example of how to configure the check to make sure a copyright
           statement is included in the file:
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
+        <div class="wrapper"><pre><code class="language-xml">
 &lt;module name="Checker"&gt;
   &lt;module name="RegexpSingleline"&gt;
     &lt;property name="format" value="^[ ]*\* This file is copyrighted"/&gt;
@@ -149,7 +149,7 @@ public class Example3 {
 &lt;/module&gt;
 </code></pre></div>
         <p id="Example4-code">Example:</p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+        <div class="wrapper"><pre><code class="language-java">
 /**
 * This file is copyrighted under CC.
 */
@@ -159,7 +159,7 @@ public class Example4 {}
           An example of how to configure the check to make sure a copyright
           statement is included in the file:
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
+        <div class="wrapper"><pre><code class="language-xml">
 &lt;module name="Checker"&gt;
   &lt;module name="RegexpSingleline"&gt;
     &lt;property name="format" value="^[ ]*\* This file is copyrighted"/&gt;
@@ -172,7 +172,7 @@ public class Example4 {}
 &lt;/module&gt;
 </code></pre></div>
         <p id="Example5-code">Example with violation:</p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+        <div class="wrapper"><pre><code class="language-java">
 package com.puppycrawl.tools.checkstyle.checks.regexp.regexpsingleline;
 /* violation on first line 'File must contain copyright statement' */
 /**
@@ -184,7 +184,7 @@ public class Example5 {}
           An example of how to configure the check to make sure sql files contains the term
           'license'.
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
+        <div class="wrapper"><pre><code class="language-xml">
 &lt;module name="Checker"&gt;
   &lt;module name="RegexpSingleline"&gt;
       &lt;property name="format" value="license"/&gt;
@@ -200,14 +200,14 @@ public class Example5 {}
 &lt;/module&gt;
 </code></pre></div>
         <p id="Example6-raw">Example:</p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+        <div class="wrapper"><pre><code class="language-java">
 /*
  AP 2.0 License. // Ok, Check ignores the case of the term.
 */
 CREATE DATABASE MyDB;
 </code></pre></div>
         <p id="Example7-raw">Example with violation:</p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+        <div class="wrapper"><pre><code class="language-java">
 /* // violation, file doesn't contain the term.
  Example sql file.
 */

--- a/src/site/xdoc/checks/regexp/regexpsinglelinejava.xml
+++ b/src/site/xdoc/checks/regexp/regexpsinglelinejava.xml
@@ -80,7 +80,7 @@
         <p id="Example1-config">
           To configure the default check:
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
+        <div class="wrapper"><pre><code class="language-xml">
 &lt;module name="Checker"&gt;
   &lt;module name="TreeWalker"&gt;
     &lt;module name="RegexpSinglelineJava"/&gt;
@@ -88,7 +88,7 @@
 &lt;/module&gt;
 </code></pre></div>
         <p id="Example1-code">Example1:</p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+        <div class="wrapper"><pre><code class="language-java">
 class Example1 {
 
   private void testMethod1() {
@@ -123,7 +123,7 @@ class Example1 {
         <p id="Example2-config">
           To configure the check for calls to <code>System.out.println</code>, except in comments:
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
+        <div class="wrapper"><pre><code class="language-xml">
 &lt;module name="Checker"&gt;
   &lt;module name="TreeWalker"&gt;
     &lt;module name="RegexpSinglelineJava"&gt;
@@ -136,7 +136,7 @@ class Example1 {
 &lt;/module&gt;
 </code></pre></div>
         <p id="Example2-code">Example2:</p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+        <div class="wrapper"><pre><code class="language-java">
 class Example2 {
 
   private void testMethod1() {
@@ -172,7 +172,7 @@ class Example2 {
           To configure the check to find case-insensitive occurrences of
           &quot;debug&quot;:
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
+        <div class="wrapper"><pre><code class="language-xml">
 &lt;module name="Checker"&gt;
   &lt;module name="TreeWalker"&gt;
     &lt;module name="RegexpSinglelineJava"&gt;
@@ -184,7 +184,7 @@ class Example2 {
 &lt;/module&gt;
 </code></pre></div>
         <p id="Example3-code">Example3:</p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+        <div class="wrapper"><pre><code class="language-java">
 class Example3 {
 
   private void testMethod1() {
@@ -221,7 +221,7 @@ class Example3 {
           &quot;\.read(.*)|\.write(.*)&quot;
           and display &quot;IO found&quot; for each violation.
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
+        <div class="wrapper"><pre><code class="language-xml">
 &lt;module name="Checker"&gt;
   &lt;module name="TreeWalker"&gt;
     &lt;module name="RegexpSinglelineJava"&gt;
@@ -232,7 +232,7 @@ class Example3 {
 &lt;/module&gt;
 </code></pre></div>
         <p id="Example4-code">Example4:</p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+        <div class="wrapper"><pre><code class="language-java">
 class Example4 {
 
   private void testMethod1() {
@@ -268,7 +268,7 @@ class Example4 {
           To configure the check to find occurrences of
           &quot;\.log(.*)&quot;. We want to allow a maximum of 2 occurrences.
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
+        <div class="wrapper"><pre><code class="language-xml">
 &lt;module name="Checker"&gt;
   &lt;module name="TreeWalker"&gt;
     &lt;module name="RegexpSinglelineJava"&gt;
@@ -279,7 +279,7 @@ class Example4 {
 &lt;/module&gt;
 </code></pre></div>
         <p id="Example5-code">Example5:</p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+        <div class="wrapper"><pre><code class="language-java">
 class Example5 {
 
   private void testMethod1() {
@@ -317,7 +317,7 @@ class Example5 {
           display &quot;public member found&quot; for each violation
           and say if less than 1 occurrences.
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
+        <div class="wrapper"><pre><code class="language-xml">
 &lt;module name="Checker"&gt;
   &lt;module name="TreeWalker"&gt;
     &lt;module name="RegexpSinglelineJava"&gt;
@@ -330,7 +330,7 @@ class Example5 {
 &lt;/module&gt;
 </code></pre></div>
         <p id="Example6-code">Example6:</p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+        <div class="wrapper"><pre><code class="language-java">
 class Example6 {
 
   private void testMethod1() {
@@ -368,7 +368,7 @@ class Example6 {
           display &quot;private member found&quot; for each violation
           and say if less than 2 occurrences.
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
+        <div class="wrapper"><pre><code class="language-xml">
 &lt;module name="Checker"&gt;
   &lt;module name="TreeWalker"&gt;
     &lt;module name="RegexpSinglelineJava"&gt;
@@ -381,7 +381,7 @@ class Example6 {
 &lt;/module&gt;
 </code></pre></div>
         <p id="Example7-code">Example7:</p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+        <div class="wrapper"><pre><code class="language-java">
 class Example7 {
   // violation below, 'private member found'
   private void testMethod1() {

--- a/src/site/xdoc/checks/sizes/anoninnerlength.xml
+++ b/src/site/xdoc/checks/sizes/anoninnerlength.xml
@@ -47,7 +47,7 @@
         <p id="Example1-config">
           To configure the check to accept anonymous classes with up to 20 lines by default:
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
+        <div class="wrapper"><pre><code class="language-xml">
 &lt;module name="Checker"&gt;
   &lt;module name="TreeWalker"&gt;
     &lt;module name="AnonInnerLength"/&gt;
@@ -55,7 +55,7 @@
 &lt;/module&gt;
 </code></pre></div>
         <p id="Example1-code">Example1:</p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+        <div class="wrapper"><pre><code class="language-java">
 class Example1 {
   void testMethod() {
     Runnable shortAnonClass = new Runnable() {
@@ -82,7 +82,7 @@ class Example1 {
         <p id="Example2-config">
           To configure the check to accept anonymous classes with up to 7 lines:
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
+        <div class="wrapper"><pre><code class="language-xml">
 &lt;module name="Checker"&gt;
   &lt;module name="TreeWalker"&gt;
     &lt;module name="AnonInnerLength"&gt;
@@ -92,7 +92,7 @@ class Example1 {
 &lt;/module&gt;
 </code></pre></div>
         <p id="Example2-code">Example2:</p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+        <div class="wrapper"><pre><code class="language-java">
 class Example2 {
   void testMethod() {
     Runnable shortAnonClass = new Runnable() {

--- a/src/site/xdoc/checks/sizes/executablestatementcount.xml
+++ b/src/site/xdoc/checks/sizes/executablestatementcount.xml
@@ -72,7 +72,7 @@
         <p id="Example1-config">
           To configure the check:
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
+        <div class="wrapper"><pre><code class="language-xml">
 &lt;module name="Checker"&gt;
   &lt;module name="TreeWalker"&gt;
     &lt;module name="ExecutableStatementCount"/&gt;
@@ -80,7 +80,7 @@
 &lt;/module&gt;
 </code></pre></div>
         <p id="Example1-code">Example1:</p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+        <div class="wrapper"><pre><code class="language-java">
 class Example1 {
 
   Example1() {
@@ -99,7 +99,7 @@ class Example1 {
         <p id="Example2-config">
           To configure the check with a threshold of 2 for constructor:
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
+        <div class="wrapper"><pre><code class="language-xml">
 &lt;module name="Checker"&gt;
   &lt;module name="TreeWalker"&gt;
     &lt;module name="ExecutableStatementCount"&gt;
@@ -110,7 +110,7 @@ class Example1 {
 &lt;/module&gt;
 </code></pre></div>
         <p id="Example2-code">Example2:</p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+        <div class="wrapper"><pre><code class="language-java">
 class Example2 {
 
   Example2() { // violation, 'Executable statement count is 3 (max allowed is 2)'
@@ -129,7 +129,7 @@ class Example2 {
         <p id="Example3-config">
           To configure the check with a threshold of 2 for method definitions:
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
+        <div class="wrapper"><pre><code class="language-xml">
 &lt;module name="Checker"&gt;
   &lt;module name="TreeWalker"&gt;
     &lt;module name="ExecutableStatementCount"&gt;
@@ -140,7 +140,7 @@ class Example2 {
 &lt;/module&gt;
 </code></pre></div>
         <p id="Example3-code">Example3:</p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+        <div class="wrapper"><pre><code class="language-java">
 class Example3 {
 
   Example3() {

--- a/src/site/xdoc/checks/sizes/filelength.xml
+++ b/src/site/xdoc/checks/sizes/filelength.xml
@@ -52,13 +52,13 @@
         <p id="Example1-config">
          To configure the check to accept files with up to 2000 lines:
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
+        <div class="wrapper"><pre><code class="language-xml">
 &lt;module name="Checker"&gt;
   &lt;module name="FileLength"/&gt;
 &lt;/module&gt;
 </code></pre></div>
         <p id="Example1-code">Example:</p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+        <div class="wrapper"><pre><code class="language-java">
 public class Example1 {
   public void myTest() {
     // small class less than 2000 lines
@@ -69,7 +69,7 @@ public class Example1 {
         <p id="Example2-config">
           To configure the check to accept files with up to 5 lines:
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
+        <div class="wrapper"><pre><code class="language-xml">
 &lt;module name="Checker"&gt;
   &lt;module name="FileLength"&gt;
     &lt;property name="max" value="5"/&gt;
@@ -77,7 +77,7 @@ public class Example1 {
 &lt;/module&gt;
 </code></pre></div>
         <p id="Example2-code">Example:</p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+        <div class="wrapper"><pre><code class="language-java">
 public class Example2 {
   public void myTest() {
     // small class with more than 5 lines
@@ -88,7 +88,7 @@ public class Example2 {
         <p id="Example3-config">
           To configure the check to accept files with up to 5 lines and with txt extension only:
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
+        <div class="wrapper"><pre><code class="language-xml">
 &lt;module name="Checker"&gt;
   &lt;module name="FileLength"&gt;
     &lt;property name="max" value="5"/&gt;
@@ -97,7 +97,7 @@ public class Example2 {
 &lt;/module&gt;
 </code></pre></div>
         <p id="Example3-code">Example:</p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+        <div class="wrapper"><pre><code class="language-java">
 public class Example3 {
   public void myTest() {
     // small class with more than 5 lines

--- a/src/site/xdoc/checks/sizes/lambdabodylength.xml
+++ b/src/site/xdoc/checks/sizes/lambdabodylength.xml
@@ -46,7 +46,7 @@
         <p id="Example1-config">
           To configure the check to accept lambda bodies with up to 10 lines:
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
+        <div class="wrapper"><pre><code class="language-xml">
 &lt;module name="Checker"&gt;
   &lt;module name="TreeWalker"&gt;
     &lt;module name="LambdaBodyLength"/&gt;
@@ -56,7 +56,7 @@
         <p id="Example1-code">
         Example:
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+        <div class="wrapper"><pre><code class="language-java">
 class Example1 {
   Runnable r = () -&gt; { // OK, length is 10
     System.out.println(2); // line 2 of lambda
@@ -96,7 +96,7 @@ class Example1 {
         <p id="Example2-config">
           To configure the check to accept lambda bodies with max 5 lines:
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
+        <div class="wrapper"><pre><code class="language-xml">
 &lt;module name="Checker"&gt;
   &lt;module name="TreeWalker"&gt;
     &lt;module name="LambdaBodyLength"&gt;
@@ -108,7 +108,7 @@ class Example1 {
         <p id="Example2-code">
           Example:
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+        <div class="wrapper"><pre><code class="language-java">
 class Example2 {
   Runnable r = () -&gt; { // OK, length is 5
     System.out.println(2);

--- a/src/site/xdoc/checks/sizes/linelength.xml
+++ b/src/site/xdoc/checks/sizes/linelength.xml
@@ -60,7 +60,7 @@
         <p id="Example1-config">
           To configure the check to accept lines up to 80 characters long:
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
+        <div class="wrapper"><pre><code class="language-xml">
 &lt;module name="Checker"&gt;
   &lt;module name="LineLength"/&gt;
 &lt;/module&gt;
@@ -68,7 +68,7 @@
         <p id="Example1-code">
           Example1:
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+        <div class="wrapper"><pre><code class="language-java">
 package com.puppycrawl.tools.checkstyle.checks.sizes.linelength;
 
 import static com.puppycrawl.tools.checkstyle.checks.sizes.LineLengthCheck.MSG_KEY;
@@ -91,7 +91,7 @@ class Example1 {
         <p id="Example2-config">
           To configure the check to accept lines up to 120 characters long:
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
+        <div class="wrapper"><pre><code class="language-xml">
 &lt;module name="Checker"&gt;
   &lt;module name="LineLength"&gt;
     &lt;property name="max" value="120"/&gt;
@@ -101,7 +101,7 @@ class Example1 {
         <p id="Example2-code">
           Example2:
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+        <div class="wrapper"><pre><code class="language-java">
 package com.puppycrawl.tools.checkstyle.checks.sizes.linelength;
 
 import static com.puppycrawl.tools.checkstyle.checks.sizes.LineLengthCheck.MSG_KEY;
@@ -125,7 +125,7 @@ class Example2 {
           To configure the check to ignore lines that begin with <code>&quot; * &quot;</code>code,
           followed by just one word, such as within a Javadoc comment:
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
+        <div class="wrapper"><pre><code class="language-xml">
 &lt;module name="Checker"&gt;
   &lt;module name="LineLength"&gt;
     &lt;property name="ignorePattern" value="^ *\* *[^ ]+$"/&gt;
@@ -135,7 +135,7 @@ class Example2 {
         <p id="Example3-code">
           Example3:
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+        <div class="wrapper"><pre><code class="language-java">
 package com.puppycrawl.tools.checkstyle.checks.sizes.linelength;
 // violation below, 'Line is longer than 80 characters'
 import static com.puppycrawl.tools.checkstyle.checks.sizes.LineLengthCheck.MSG_KEY;
@@ -159,7 +159,7 @@ class Example3 {
           To configure the check to only validate xml and property files and ignore other
           extensions:
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
+        <div class="wrapper"><pre><code class="language-xml">
 &lt;module name="Checker"&gt;
   &lt;module name="LineLength"&gt;
     &lt;property name="fileExtensions" value="xml, properties"/&gt;
@@ -169,7 +169,7 @@ class Example3 {
         <p id="Example4-code">
           Example4:
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+        <div class="wrapper"><pre><code class="language-java">
 package com.puppycrawl.tools.checkstyle.checks.sizes.linelength;
 
 import static com.puppycrawl.tools.checkstyle.checks.sizes.LineLengthCheck.MSG_KEY;
@@ -192,7 +192,7 @@ class Example4 {
         <p id="Example5-config">
           To configure check to validate <code>import</code> statements:
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
+        <div class="wrapper"><pre><code class="language-xml">
 &lt;module name="Checker"&gt;
   &lt;module name="LineLength"&gt;
     &lt;property name="ignorePattern"
@@ -204,7 +204,7 @@ class Example4 {
         <p id="Example5-code">
           Example:
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+        <div class="wrapper"><pre><code class="language-java">
 package com.puppycrawl.tools.checkstyle.checks.sizes.linelength;
 // violation above, 'Line is longer than 60 characters'
 import static com.puppycrawl.tools.checkstyle.checks.sizes.LineLengthCheck.MSG_KEY;

--- a/src/site/xdoc/checks/sizes/methodcount.xml
+++ b/src/site/xdoc/checks/sizes/methodcount.xml
@@ -141,7 +141,7 @@ public class ExampleClass {
         <p id="Example1-config">
           To configure the default check:
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
+        <div class="wrapper"><pre><code class="language-xml">
 &lt;module name="Checker"&gt;
   &lt;module name="TreeWalker"&gt;
     &lt;module name="MethodCount"/&gt;
@@ -149,7 +149,7 @@ public class ExampleClass {
 &lt;/module&gt;
 </code></pre></div>
         <p id="Example1-code">Example:</p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+        <div class="wrapper"><pre><code class="language-java">
 class Example1 {
 
   public void outerMethod1(int i) {}
@@ -174,7 +174,7 @@ class Example1 {
         <p id="Example2-config">
           To configure the check to allow no more than 5 methods per type declaration:
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
+        <div class="wrapper"><pre><code class="language-xml">
 &lt;module name="Checker"&gt;
   &lt;module name="TreeWalker"&gt;
     &lt;module name="MethodCount"&gt;
@@ -184,7 +184,7 @@ class Example1 {
 &lt;/module&gt;
 </code></pre></div>
         <p id="Example2-code">Example:</p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+        <div class="wrapper"><pre><code class="language-java">
 class Example2 { // violation, 'Total number of methods is 6 (max allowed is 5)'
 
   public void outerMethod1(int i) {}
@@ -210,7 +210,7 @@ class Example2 { // violation, 'Total number of methods is 6 (max allowed is 5)'
           To configure the check to allow no more than 2 public methods per
           type declaration, and 6 methods in total:
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
+        <div class="wrapper"><pre><code class="language-xml">
 &lt;module name="Checker"&gt;
   &lt;module name="TreeWalker"&gt;
     &lt;module name="MethodCount"&gt;
@@ -221,7 +221,7 @@ class Example2 { // violation, 'Total number of methods is 6 (max allowed is 5)'
 &lt;/module&gt;
 </code></pre></div>
         <p id="Example3-code">Example:</p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+        <div class="wrapper"><pre><code class="language-java">
 class Example3 { // violation, 'Number of public methods is 3 (max allowed is 2)'
 
   public void outerMethod1(int i) {}

--- a/src/site/xdoc/checks/sizes/methodlength.xml
+++ b/src/site/xdoc/checks/sizes/methodlength.xml
@@ -76,7 +76,7 @@
           To configure the check so that it accepts at most 4
           lines:
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
+        <div class="wrapper"><pre><code class="language-xml">
 &lt;module name="Checker"&gt;
   &lt;module name="TreeWalker"&gt;
     &lt;module name="MethodLength"&gt;
@@ -86,7 +86,7 @@
 &lt;/module&gt;
 </code></pre></div>
         <p id="Example1-code">Example:</p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+        <div class="wrapper"><pre><code class="language-java">
 public class Example1 {
 
   // violation below, 'Method Example1 length is 5 lines (max allowed is 4)'
@@ -136,7 +136,7 @@ public class Example1 {
           To configure the check so that it accepts methods with at most 4
           lines:
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
+        <div class="wrapper"><pre><code class="language-xml">
 &lt;module name="Checker"&gt;
   &lt;module name="TreeWalker"&gt;
     &lt;module name="MethodLength"&gt;
@@ -147,7 +147,7 @@ public class Example1 {
 &lt;/module&gt;
 </code></pre></div>
         <p id="Example2-code">Example:</p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+        <div class="wrapper"><pre><code class="language-java">
 public class Example2 {
 
   // ok, CTOR_DEF is not in configured tokens
@@ -197,7 +197,7 @@ public class Example2 {
           To configure the check so that it accepts methods with at most 4
           lines, not counting empty lines and comments:
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
+        <div class="wrapper"><pre><code class="language-xml">
 &lt;module name="Checker"&gt;
   &lt;module name="TreeWalker"&gt;
     &lt;module name="MethodLength"&gt;
@@ -209,7 +209,7 @@ public class Example2 {
 &lt;/module&gt;
 </code></pre></div>
         <p id="Example3-code">Example:</p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+        <div class="wrapper"><pre><code class="language-java">
 public class Example3 {
 
   // ok, CTOR_DEF is not in configured tokens

--- a/src/site/xdoc/checks/sizes/outertypenumber.xml
+++ b/src/site/xdoc/checks/sizes/outertypenumber.xml
@@ -45,7 +45,7 @@
         <p id="Example1-config">
           To configure the check to accept 1 outer type per file:
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
+        <div class="wrapper"><pre><code class="language-xml">
 &lt;module name="Checker"&gt;
   &lt;module name="TreeWalker"&gt;
     &lt;module name="OuterTypeNumber"/&gt;
@@ -53,7 +53,7 @@
 &lt;/module&gt;
 </code></pre></div>
         <p id="Example1-code">Example:</p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+        <div class="wrapper"><pre><code class="language-java">
 // violation 2 lines above 'Outer types defined is 3 (max allowed is 1)'
 
 public class Example1 {
@@ -70,7 +70,7 @@ enum outer {
         <p id="Example2-config">
           To configure the check to accept 2 outer types per file:
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
+        <div class="wrapper"><pre><code class="language-xml">
 &lt;module name="Checker"&gt;
   &lt;module name="TreeWalker"&gt;
     &lt;module name="OuterTypeNumber"&gt;
@@ -80,7 +80,7 @@ enum outer {
 &lt;/module&gt;
 </code></pre></div>
         <p id="Example2-code">Example:</p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+        <div class="wrapper"><pre><code class="language-java">
 public class Example2 {
 }
 

--- a/src/site/xdoc/checks/sizes/parameternumber.xml
+++ b/src/site/xdoc/checks/sizes/parameternumber.xml
@@ -72,7 +72,7 @@
         <p id="Example1-config">
           To configure the check:
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
+        <div class="wrapper"><pre><code class="language-xml">
 &lt;module name="Checker"&gt;
   &lt;module name="TreeWalker"&gt;
     &lt;module name="ParameterNumber"/&gt;
@@ -80,7 +80,7 @@
 &lt;/module&gt;
 </code></pre></div>
         <p id="Example1-code">Example:</p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+        <div class="wrapper"><pre><code class="language-java">
 class Example1 extends ExternalService1 {
 
   @JsonCreator
@@ -110,7 +110,7 @@ class ExternalService1 {
         <p id="Example2-config">
           To configure the check to allow 10 parameters for a method:
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
+        <div class="wrapper"><pre><code class="language-xml">
 &lt;module name="Checker"&gt;
   &lt;module name="TreeWalker"&gt;
     &lt;module name="ParameterNumber"&gt;
@@ -121,7 +121,7 @@ class ExternalService1 {
 &lt;/module&gt;
 </code></pre></div>
         <p id="Example2-code">Example:</p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+        <div class="wrapper"><pre><code class="language-java">
 class Example2 extends ExternalService2 {
 
   @JsonCreator
@@ -157,7 +157,7 @@ class ExternalService2 {
           3-rd party library.
           In this case developer has no control over number of parameters.
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
+        <div class="wrapper"><pre><code class="language-xml">
 &lt;module name="Checker"&gt;
   &lt;module name="TreeWalker"&gt;
     &lt;module name="ParameterNumber"&gt;
@@ -167,7 +167,7 @@ class ExternalService2 {
 &lt;/module&gt;
 </code></pre></div>
         <p id="Example3-code">Example:</p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+        <div class="wrapper"><pre><code class="language-java">
 class Example3 extends ExternalService3 {
 
   @JsonCreator
@@ -198,7 +198,7 @@ class ExternalService3 {
           To configure the check to ignore methods and constructors annotated with
           <code>JsonCreator</code> annotation:
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
+        <div class="wrapper"><pre><code class="language-xml">
 &lt;module name="Checker"&gt;
   &lt;module name="TreeWalker"&gt;
     &lt;module name="ParameterNumber"&gt;
@@ -208,7 +208,7 @@ class ExternalService3 {
 &lt;/module&gt;
 </code></pre></div>
         <p id="Example4-code">Example:</p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+        <div class="wrapper"><pre><code class="language-java">
 class Example4 extends ExternalService4 {
 
   @JsonCreator

--- a/src/site/xdoc/checks/sizes/recordcomponentnumber.xml
+++ b/src/site/xdoc/checks/sizes/recordcomponentnumber.xml
@@ -50,7 +50,7 @@
         <p id="Example1-config">
           To configure the check:
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
+        <div class="wrapper"><pre><code class="language-xml">
 &lt;module name="Checker"&gt;
   &lt;module name="TreeWalker"&gt;
     &lt;module name="RecordComponentNumber"/&gt;
@@ -60,7 +60,7 @@
         <p id="Example1-code">
           Java code example:
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+        <div class="wrapper"><pre><code class="language-java">
 class Example1{
   public record MyRecord1(int x, int y, String str) {}
 
@@ -78,7 +78,7 @@ class Example1{
           To configure the check to allow 5 record components at all access modifier
           levels for record definitions:
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
+        <div class="wrapper"><pre><code class="language-xml">
 &lt;module name="Checker"&gt;
   &lt;module name="TreeWalker"&gt;
     &lt;module name="RecordComponentNumber"&gt;
@@ -90,7 +90,7 @@ class Example1{
         <p id="Example2-code">
           Java code example:
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+        <div class="wrapper"><pre><code class="language-java">
 class Example2{
   public record MyRecord1(int x, int y, String str) {}
 
@@ -108,7 +108,7 @@ class Example2{
           To configure the check to allow 10 record components for a public record definition,
           but 3 for private record definitions:
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
+        <div class="wrapper"><pre><code class="language-xml">
 &lt;module name="Checker"&gt;
   &lt;module name="TreeWalker"&gt;
     &lt;module name="RecordComponentNumber"&gt;
@@ -125,7 +125,7 @@ class Example2{
         <p id="Example3-code">
           Java code example:
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+        <div class="wrapper"><pre><code class="language-java">
 class Example3 {
   public record MyRecord1(int x, int y, String str) {}
 

--- a/src/site/xdoc/checks/whitespace/emptyforinitializerpad.xml
+++ b/src/site/xdoc/checks/whitespace/emptyforinitializerpad.xml
@@ -47,7 +47,7 @@ for (
         <p id="Example1-config">
           To configure the check:
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
+        <div class="wrapper"><pre><code class="language-xml">
 &lt;module name="Checker"&gt;
   &lt;module name="TreeWalker"&gt;
     &lt;module name="EmptyForInitializerPad"/&gt;
@@ -57,7 +57,7 @@ for (
         <p id="Example1-code">
           Example:
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+        <div class="wrapper"><pre><code class="language-java">
 class Example1 {
   int i = 0;
   void example() {
@@ -75,7 +75,7 @@ class Example1 {
           To configure the check to require white space at an empty for
           iterator:
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
+        <div class="wrapper"><pre><code class="language-xml">
 &lt;module name="Checker"&gt;
   &lt;module name="TreeWalker"&gt;
     &lt;module name="EmptyForInitializerPad"&gt;
@@ -87,7 +87,7 @@ class Example1 {
         <p id="Example2-code">
           Example:
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+        <div class="wrapper"><pre><code class="language-java">
 class Example2 {
   int i = 0;
   void example() {

--- a/src/site/xdoc/checks/whitespace/emptyforiteratorpad.xml
+++ b/src/site/xdoc/checks/whitespace/emptyforiteratorpad.xml
@@ -47,7 +47,7 @@ for (Iterator foo = very.long.line.iterator();
         <p id="Example1-config">
           To configure the check:
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
+        <div class="wrapper"><pre><code class="language-xml">
 &lt;module name="Checker"&gt;
   &lt;module name="TreeWalker"&gt;
     &lt;module name="EmptyForIteratorPad"/&gt;
@@ -57,7 +57,7 @@ for (Iterator foo = very.long.line.iterator();
         <p id="Example1-code">
           Example:
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+        <div class="wrapper"><pre><code class="language-java">
 class Example1 {
   Map&lt;String, String&gt; map = new HashMap&lt;&gt;();
   void example() {
@@ -75,7 +75,7 @@ class Example1 {
           To configure the check to require white space at an empty for
           iterator:
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
+        <div class="wrapper"><pre><code class="language-xml">
 &lt;module name="Checker"&gt;
   &lt;module name="TreeWalker"&gt;
     &lt;module name="EmptyForIteratorPad"&gt;
@@ -87,7 +87,7 @@ class Example1 {
         <p id="Example2-code">
           Example:
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+        <div class="wrapper"><pre><code class="language-java">
 class Example2 {
   Map&lt;String, String&gt; map = new HashMap&lt;&gt;();
   void example() {

--- a/src/site/xdoc/checks/whitespace/emptylineseparator.xml
+++ b/src/site/xdoc/checks/whitespace/emptylineseparator.xml
@@ -129,7 +129,7 @@
         <p id="Example1-config">
             To configure the default check:
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
+        <div class="wrapper"><pre><code class="language-xml">
 &lt;module name="Checker"&gt;
   &lt;module name="TreeWalker"&gt;
     &lt;module name="EmptyLineSeparator"/&gt;
@@ -139,7 +139,7 @@
         <p id="Example1-code">
           Example of declarations without empty line separator:
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+        <div class="wrapper"><pre><code class="language-java">
 ///////////////////////////////////////////////////
 //HEADER
 ///////////////////////////////////////////////////
@@ -173,7 +173,7 @@ class Example1 {
           <a href="../../apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#METHOD_DEF">
                   METHOD_DEF</a>:
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
+        <div class="wrapper"><pre><code class="language-xml">
 &lt;module name="Checker"&gt;
   &lt;module name="TreeWalker"&gt;
     &lt;module name="EmptyLineSeparator"&gt;
@@ -183,7 +183,7 @@ class Example1 {
 &lt;/module&gt;
 </code></pre></div>
         <p id="Example2-code">Example:</p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+        <div class="wrapper"><pre><code class="language-java">
 ///////////////////////////////////////////////////
 //HEADER
 ///////////////////////////////////////////////////
@@ -212,7 +212,7 @@ class Example2 {
         <p id="Example3-config">
           To allow no empty line between fields:
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
+        <div class="wrapper"><pre><code class="language-xml">
 &lt;module name="Checker"&gt;
   &lt;module name="TreeWalker"&gt;
     &lt;module name="EmptyLineSeparator"&gt;
@@ -224,7 +224,7 @@ class Example2 {
         <p id="Example3-code">
           Example:
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+        <div class="wrapper"><pre><code class="language-java">
 ///////////////////////////////////////////////////
 //HEADER
 ///////////////////////////////////////////////////
@@ -254,7 +254,7 @@ class Example3 {
         <p id="Example4-config">
           To disallow multiple empty lines between class members:
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
+        <div class="wrapper"><pre><code class="language-xml">
 &lt;module name="Checker"&gt;
   &lt;module name="TreeWalker"&gt;
     &lt;module name="EmptyLineSeparator"&gt;
@@ -264,7 +264,7 @@ class Example3 {
 &lt;/module&gt;
 </code></pre></div>
         <p id="Example4-code">Example:</p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+        <div class="wrapper"><pre><code class="language-java">
 ///////////////////////////////////////////////////
 //HEADER
 ///////////////////////////////////////////////////
@@ -295,7 +295,7 @@ class Example4 {
           To disallow multiple empty lines inside constructor,
             initialization block and method:
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
+        <div class="wrapper"><pre><code class="language-xml">
 &lt;module name="Checker"&gt;
   &lt;module name="TreeWalker"&gt;
     &lt;module name="EmptyLineSeparator"&gt;
@@ -327,7 +327,7 @@ class Example4 {
         <p id="Example5-code">
           Example of declarations with multiple empty lines inside method:
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+        <div class="wrapper"><pre><code class="language-java">
 ///////////////////////////////////////////////////
 //HEADER
 ///////////////////////////////////////////////////

--- a/src/site/xdoc/checks/whitespace/filetabcharacter.xml
+++ b/src/site/xdoc/checks/whitespace/filetabcharacter.xml
@@ -70,13 +70,13 @@
         <p id="Example1-config">
           To configure the check to report only the first instance in each file:
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
+        <div class="wrapper"><pre><code class="language-xml">
 &lt;module name="Checker"&gt;
   &lt;module name="FileTabCharacter"/&gt;
 &lt;/module&gt;
 </code></pre></div>
         <p id="Example1-code">Example - Test.java:</p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+        <div class="wrapper"><pre><code class="language-java">
 class Example1 {
   int a; // violation 'File contains tab characters'
 
@@ -86,7 +86,7 @@ class Example1 {
 }
 </code></pre></div>
         <p id="Example2-config">To configure the check to report each instance in each file:</p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
+        <div class="wrapper"><pre><code class="language-xml">
 &lt;module name="Checker"&gt;
   &lt;module name="FileTabCharacter"&gt;
     &lt;property name="eachLine" value="true"/&gt;
@@ -94,7 +94,7 @@ class Example1 {
 &lt;/module&gt;
 </code></pre></div>
         <p id="Example2-code">Example - Test.java:</p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+        <div class="wrapper"><pre><code class="language-java">
 class Example2 {
   int a; // violation 'contains a tab character'
 
@@ -106,7 +106,7 @@ class Example2 {
         <p id="Example3-config">
           To configure the check to report instances on only certain file types:
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
+        <div class="wrapper"><pre><code class="language-xml">
 &lt;module name="Checker"&gt;
   &lt;module name="FileTabCharacter"&gt;
     &lt;property name="fileExtensions" value="java, xml"/&gt;
@@ -114,7 +114,7 @@ class Example2 {
 &lt;/module&gt;
 </code></pre></div>
         <p id="Example3-code">Example - Test.java:</p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+        <div class="wrapper"><pre><code class="language-java">
 class Example3 {
   int a; // violation 'File contains tab characters'
 
@@ -124,7 +124,7 @@ class Example3 {
 }
 </code></pre></div>
         <p id="Example4-code">Example - Test.xml:</p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
+        <div class="wrapper"><pre><code class="language-xml">
 &lt;?xml version="1.0" encoding="UTF-8" ?&gt;
 &lt;UserAccount&gt;
   &lt;FirstName&gt;John&lt;/FirstName&gt; // violation 'File contains tab characters'
@@ -132,7 +132,7 @@ class Example3 {
 &lt;/UserAccount&gt;
 </code></pre></div>
         <p id="Example5-code">Example - Test.html:</p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+        <div class="wrapper"><pre><code class="language-java">
 &lt;head&gt;
   &lt;title&gt;Page Title&lt;/title&gt; &lt;!-- OK, no check performed on html file extension --&gt;
 &lt;/head&gt;                       &lt;!-- not specified in check config --&gt;

--- a/src/site/xdoc/checks/whitespace/genericwhitespace.xml
+++ b/src/site/xdoc/checks/whitespace/genericwhitespace.xml
@@ -38,7 +38,7 @@
         <p id="Example1-config">
           To configure the check:
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
+        <div class="wrapper"><pre><code class="language-xml">
 &lt;module name="Checker"&gt;
   &lt;module name="TreeWalker"&gt;
     &lt;module name="GenericWhitespace"/&gt;
@@ -48,7 +48,7 @@
         <p id="Example1-code">
           Examples with correct spacing:
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+        <div class="wrapper"><pre><code class="language-java">
 class Example1 {
   List&lt;String&gt; l;
   public &lt;T&gt; void foo() {}
@@ -61,7 +61,7 @@ class Example1 {
         <p id="Example2-code">
           Examples with incorrect spacing:
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+        <div class="wrapper"><pre><code class="language-java">
 class Example2 {
   List &lt;String&gt; l; // violation, "&lt;" followed by whitespace
   public&lt;T&gt; void foo() {} // violation, "&lt;" not preceded with whitespace

--- a/src/site/xdoc/checks/whitespace/methodparampad.xml
+++ b/src/site/xdoc/checks/whitespace/methodparampad.xml
@@ -101,7 +101,7 @@
         <p id="Example1-config">
           To configure the check:
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
+        <div class="wrapper"><pre><code class="language-xml">
 &lt;module name="Checker"&gt;
   &lt;module name="TreeWalker"&gt;
     &lt;module name="MethodParamPad"/&gt;
@@ -109,7 +109,7 @@
 &lt;/module&gt;
 </code></pre></div>
         <p id="Example1-code">Example:</p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+        <div class="wrapper"><pre><code class="language-java">
 class Example1 {
   public Example1() {
     super();
@@ -131,7 +131,7 @@ class Example1 {
           method definition, except if the left parenthesis occurs on a new
           line:
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
+        <div class="wrapper"><pre><code class="language-xml">
 &lt;module name="Checker"&gt;
   &lt;module name="TreeWalker"&gt;
     &lt;module name="MethodParamPad"&gt;
@@ -143,7 +143,7 @@ class Example1 {
 &lt;/module&gt;
 </code></pre></div>
         <p id="Example2-code">Example:</p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+        <div class="wrapper"><pre><code class="language-java">
 class Example2 {
   public Example2() {
     super();

--- a/src/site/xdoc/checks/whitespace/nolinewrap.xml
+++ b/src/site/xdoc/checks/whitespace/nolinewrap.xml
@@ -72,7 +72,7 @@
           To configure the check to force no line-wrapping
           in package and import statements (default values):
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
+        <div class="wrapper"><pre><code class="language-xml">
 &lt;module name="Checker"&gt;
   &lt;module name="TreeWalker"&gt;
     &lt;module name="NoLineWrap"/&gt;
@@ -82,7 +82,7 @@
         <p id="Example1-code">
           Examples of line-wrapped statements (bad case):
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+        <div class="wrapper"><pre><code class="language-java">
 package com.puppycrawl. // violation 'should not be line-wrapped'
   tools.checkstyle.checks.whitespace.nolinewrap;
 
@@ -95,7 +95,7 @@ import static java.math. // violation 'should not be line-wrapped'
         <p id="Example2-code">
           Examples:
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+        <div class="wrapper"><pre><code class="language-java">
 package com.puppycrawl.tools.checkstyle. // violation 'should not be line-wrapped'
   checks.whitespace.nolinewrap;
 
@@ -107,7 +107,7 @@ import static java.math. // violation 'should not be line-wrapped'
   BigInteger.TEN;
 </code></pre></div>
         <p id="Example3-code">Example:</p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+        <div class="wrapper"><pre><code class="language-java">
 package com.puppycrawl.tools.checkstyle.checks.whitespace.nolinewrap;
 
 import java.lang. // violation 'should not be line-wrapped'
@@ -119,7 +119,7 @@ import static java.math.BigInteger.ONE;
           To configure the check to force no line-wrapping only
           in import statements:
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
+        <div class="wrapper"><pre><code class="language-xml">
 &lt;module name="Checker"&gt;
   &lt;module name="TreeWalker"&gt;
     &lt;module name="NoLineWrap"&gt;
@@ -131,7 +131,7 @@ import static java.math.BigInteger.ONE;
         <p id="Example4-code">
           Example:
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+        <div class="wrapper"><pre><code class="language-java">
 package com.puppycrawl. // OK, PACKAGE_DEF is not part of the tokens
   tools.checkstyle.checks.whitespace.nolinewrap;
 
@@ -146,7 +146,7 @@ import static java.math. // OK, STATIC_IMPORT is not part of the tokens
           To configure the check to force no line-wrapping only
           in class, method and constructor definitions:
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
+        <div class="wrapper"><pre><code class="language-xml">
 &lt;module name="Checker"&gt;
   &lt;module name="TreeWalker"&gt;
     &lt;module name="NoLineWrap"&gt;
@@ -158,7 +158,7 @@ import static java.math. // OK, STATIC_IMPORT is not part of the tokens
         <p id="Example5-code">
           Example:
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+        <div class="wrapper"><pre><code class="language-java">
 import com.puppycrawl.tools.checkstyle.api.AbstractCheck;
 import static java.math.BigInteger.ZERO;
 

--- a/src/site/xdoc/checks/whitespace/nowhitespaceafter.xml
+++ b/src/site/xdoc/checks/whitespace/nowhitespaceafter.xml
@@ -134,7 +134,7 @@
         <p id="Example1-config">
           To configure the check:
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
+        <div class="wrapper"><pre><code class="language-xml">
 &lt;module name="Checker"&gt;
   &lt;module name="TreeWalker"&gt;
     &lt;module name="NoWhitespaceAfter"/&gt;
@@ -142,7 +142,7 @@
 &lt;/module&gt;
 </code></pre></div>
         <p id="Example1-code">Example:</p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+        <div class="wrapper"><pre><code class="language-java">
 class Example1 {
   public void lineBreak(String x) {
     Integer.
@@ -169,7 +169,7 @@ class Example1 {
         <p id="Example2-config">
           To configure the check to forbid linebreaks after a DOT token:
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
+        <div class="wrapper"><pre><code class="language-xml">
 &lt;module name="Checker"&gt;
   &lt;module name="TreeWalker"&gt;
     &lt;module name="NoWhitespaceAfter"&gt;
@@ -180,7 +180,7 @@ class Example1 {
 &lt;/module&gt;
 </code></pre></div>
         <p id="Example2-code">Example:</p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+        <div class="wrapper"><pre><code class="language-java">
 class Example2 {
   public void lineBreak(String x) {
     Integer.

--- a/src/site/xdoc/checks/whitespace/nowhitespacebefore.xml
+++ b/src/site/xdoc/checks/whitespace/nowhitespacebefore.xml
@@ -87,7 +87,7 @@
         <p id="Example1-config">
           To configure the check:
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
+        <div class="wrapper"><pre><code class="language-xml">
 &lt;module name="Checker"&gt;
   &lt;module name="TreeWalker"&gt;
     &lt;module name="NoWhitespaceBefore"/&gt;
@@ -95,7 +95,7 @@
 &lt;/module&gt;
 </code></pre></div>
         <p id="Example1-code">Example:</p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+        <div class="wrapper"><pre><code class="language-java">
 class Example1 {
   int foo = 5;
   void example() {
@@ -125,7 +125,7 @@ class Example1 {
         <p id="Example2-config">
             To configure the check to allow linebreaks before default tokens:
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
+        <div class="wrapper"><pre><code class="language-xml">
 &lt;module name="Checker"&gt;
   &lt;module name="TreeWalker"&gt;
     &lt;module name="NoWhitespaceBefore"&gt;
@@ -135,7 +135,7 @@ class Example1 {
 &lt;/module&gt;
 </code></pre></div>
         <p id="Example2-code">Example:</p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+        <div class="wrapper"><pre><code class="language-java">
 class Example2 {
   int[][] array = { { 1, 2 }
                   , { 3, 4 } };
@@ -154,7 +154,7 @@ class Example2 {
         <p id="Example3-config">
         To Configure the check to restrict the use of whitespace before METHOD_REF and DOT tokens:
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
+        <div class="wrapper"><pre><code class="language-xml">
 &lt;module name="Checker"&gt;
   &lt;module name="TreeWalker"&gt;
     &lt;module name="NoWhitespaceBefore"&gt;
@@ -164,7 +164,7 @@ class Example2 {
 &lt;/module&gt;
 </code></pre></div>
         <p id="Example3-code">Example:</p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+        <div class="wrapper"><pre><code class="language-java">
 class Example3 {
   void example() {
     Lists.charactersOf("foo").listIterator()
@@ -179,7 +179,7 @@ class Example3 {
         <p id="Example4-config">
            To configure the check to allow linebreak before METHOD_REF and DOT tokens:
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
+        <div class="wrapper"><pre><code class="language-xml">
 &lt;module name="Checker"&gt;
   &lt;module name="TreeWalker"&gt;
     &lt;module name="NoWhitespaceBefore"&gt;
@@ -190,7 +190,7 @@ class Example3 {
 &lt;/module&gt;
 </code></pre></div>
         <p id="Example4-code">Example:</p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+        <div class="wrapper"><pre><code class="language-java">
 class Example4 {
   void example() {
     Lists .charactersOf("foo") // violation ''.' is preceded with whitespace'

--- a/src/site/xdoc/checks/whitespace/nowhitespacebeforecasedefaultcolon.xml
+++ b/src/site/xdoc/checks/whitespace/nowhitespacebeforecasedefaultcolon.xml
@@ -18,7 +18,7 @@
         <p id="Example1-config">
           To configure the check:
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
+        <div class="wrapper"><pre><code class="language-xml">
 &lt;module name="Checker"&gt;
   &lt;module name="TreeWalker"&gt;
     &lt;module name="NoWhitespaceBeforeCaseDefaultColon"/&gt;
@@ -26,7 +26,7 @@
 &lt;/module&gt;
 </code></pre></div>
         <p id="Example1-code">Example:</p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+        <div class="wrapper"><pre><code class="language-java">
 class Example1 {
   void example() {
     switch(1) {

--- a/src/site/xdoc/checks/whitespace/operatorwrap.xml
+++ b/src/site/xdoc/checks/whitespace/operatorwrap.xml
@@ -174,7 +174,7 @@
         <p id="Example1-config">
           To configure the check:
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
+        <div class="wrapper"><pre><code class="language-xml">
 &lt;module name="Checker"&gt;
   &lt;module name="TreeWalker"&gt;
     &lt;module name="OperatorWrap"/&gt;
@@ -184,7 +184,7 @@
         <p id="Example1-code">
          Example:
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+        <div class="wrapper"><pre><code class="language-java">
 class Example1 {
   void example() {
     String s = "Hello" + // violation ''\+' should be on a new line'
@@ -209,7 +209,7 @@ class Example1 {
         <p id="Example2-config">
           To configure the check for assignment operators at the end of a line:
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
+        <div class="wrapper"><pre><code class="language-xml">
 &lt;module name="Checker"&gt;
   &lt;module name="TreeWalker"&gt;
     &lt;module name="OperatorWrap"&gt;
@@ -225,7 +225,7 @@ class Example1 {
         <p id="Example2-code">
          Example:
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+        <div class="wrapper"><pre><code class="language-java">
 class Example2 {
   void example() {
     int b

--- a/src/site/xdoc/checks/whitespace/parenpad.xml
+++ b/src/site/xdoc/checks/whitespace/parenpad.xml
@@ -155,7 +155,7 @@
         <p id="Example1-config">
           To configure the check:
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
+        <div class="wrapper"><pre><code class="language-xml">
 &lt;module name="Checker"&gt;
   &lt;module name="TreeWalker"&gt;
     &lt;module name="ParenPad"/&gt;
@@ -165,7 +165,7 @@
         <p id="Example1-code">
           Example:
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+        <div class="wrapper"><pre><code class="language-java">
 class Example1 {
   int n;
 
@@ -194,7 +194,7 @@ class Example1 {
           To configure the check to require spaces for the parentheses of
           constructor, method, and super constructor calls:
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
+        <div class="wrapper"><pre><code class="language-xml">
 &lt;module name="Checker"&gt;
   &lt;module name="TreeWalker"&gt;
     &lt;module name="ParenPad"&gt;
@@ -208,7 +208,7 @@ class Example1 {
         <p id="Example2-code">
           Example:
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+        <div class="wrapper"><pre><code class="language-java">
 class Example2 {
   int x;
 

--- a/src/site/xdoc/checks/whitespace/separatorwrap.xml
+++ b/src/site/xdoc/checks/whitespace/separatorwrap.xml
@@ -74,7 +74,7 @@
         <p id="Example1-config">
           To configure the check:
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
+        <div class="wrapper"><pre><code class="language-xml">
 &lt;module name="Checker"&gt;
   &lt;module name="TreeWalker"&gt;
     &lt;module name="SeparatorWrap"/&gt;
@@ -84,7 +84,7 @@
         <p id="Example1-code">
           Example:
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+        <div class="wrapper"><pre><code class="language-java">
 import java.io.
           IOException; // OK, dot is on the previous line
 
@@ -108,7 +108,7 @@ class Example1 {
           <a href="../../apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#METHOD_REF">
             METHOD_REF</a> at new line:
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
+        <div class="wrapper"><pre><code class="language-xml">
 &lt;module name="Checker"&gt;
   &lt;module name="TreeWalker"&gt;
     &lt;module name="SeparatorWrap"&gt;
@@ -121,7 +121,7 @@ class Example1 {
         <p id="Example2-code">
           Example:
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+        <div class="wrapper"><pre><code class="language-java">
 import java.util.Arrays;
 
 class Example2 {
@@ -139,7 +139,7 @@ class Example2 {
         <p id="Example3-config">
           To configure the check for comma at the new line:
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
+        <div class="wrapper"><pre><code class="language-xml">
 &lt;module name="Checker"&gt;
   &lt;module name="TreeWalker"&gt;
     &lt;module name="SeparatorWrap"&gt;
@@ -152,7 +152,7 @@ class Example2 {
         <p id="Example3-code">
           Example:
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+        <div class="wrapper"><pre><code class="language-java">
 class Example3 {
   String s;
 

--- a/src/site/xdoc/checks/whitespace/singlespaceseparator.xml
+++ b/src/site/xdoc/checks/whitespace/singlespaceseparator.xml
@@ -65,7 +65,7 @@ public long toMicros(long d) { return d / (C1 / C0); }
           To configure the check:
         </p>
 
-        <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
+        <div class="wrapper"><pre><code class="language-xml">
 &lt;module name="Checker"&gt;
   &lt;module name="TreeWalker"&gt;
     &lt;module name="SingleSpaceSeparator"/&gt;
@@ -73,7 +73,7 @@ public long toMicros(long d) { return d / (C1 / C0); }
 &lt;/module&gt;
 </code></pre></div>
         <p id="Example1-code">Example:</p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+        <div class="wrapper"><pre><code class="language-java">
 class Example1 {
   int foo()   { // violation 'Use a single space'
     return  1; // violation 'Use a single space'
@@ -88,7 +88,7 @@ class Example1 {
           To configure the check so that it validates comments:
         </p>
 
-        <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
+        <div class="wrapper"><pre><code class="language-xml">
 &lt;module name="Checker"&gt;
   &lt;module name="TreeWalker"&gt;
     &lt;module name="SingleSpaceSeparator"&gt;
@@ -98,7 +98,7 @@ class Example1 {
 &lt;/module&gt;
 </code></pre></div>
         <p id="Example2-code">Example:</p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+        <div class="wrapper"><pre><code class="language-java">
 class Example2 {
   // violation below 'Use a single space'
   void fun1() {}  // 2 whitespaces before the comment starts

--- a/src/site/xdoc/checks/whitespace/typecastparenpad.xml
+++ b/src/site/xdoc/checks/whitespace/typecastparenpad.xml
@@ -41,7 +41,7 @@
         <p id="Example1-config">
           To configure the check:
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
+        <div class="wrapper"><pre><code class="language-xml">
 &lt;module name="Checker"&gt;
   &lt;module name="TreeWalker"&gt;
     &lt;module name="TypecastParenPad"/&gt;
@@ -51,7 +51,7 @@
         <p id="Example1-code">
           Example:
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+        <div class="wrapper"><pre><code class="language-java">
 class Example1 {
   float f1 = 3.14f;
 
@@ -70,7 +70,7 @@ class Example1 {
         <p id="Example2-config">
           To configure the check to require spaces:
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
+        <div class="wrapper"><pre><code class="language-xml">
 &lt;module name="Checker"&gt;
   &lt;module name="TreeWalker"&gt;
     &lt;module name="TypecastParenPad"&gt;
@@ -82,7 +82,7 @@ class Example1 {
         <p id="Example2-code">
           Example:
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+        <div class="wrapper"><pre><code class="language-java">
 class Example2 {
   double d1 = 3.14;
 

--- a/src/site/xdoc/checks/whitespace/whitespaceafter.xml
+++ b/src/site/xdoc/checks/whitespace/whitespaceafter.xml
@@ -126,7 +126,7 @@
         <p id="Example1-config">
           To configure the check:
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
+        <div class="wrapper"><pre><code class="language-xml">
 &lt;module name="Checker"&gt;
   &lt;module name="TreeWalker"&gt;
     &lt;module name="WhitespaceAfter"/&gt;
@@ -134,7 +134,7 @@
 &lt;/module&gt;
 </code></pre></div>
         <p id="Example1-code">Example:</p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+        <div class="wrapper"><pre><code class="language-java">
 class Example1 {
   void example() throws Exception {
     if (true) {
@@ -190,7 +190,7 @@ class Example1 {
           To configure the check for whitespace only after COMMA and SEMI
           tokens:
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
+        <div class="wrapper"><pre><code class="language-xml">
 &lt;module name="Checker"&gt;
   &lt;module name="TreeWalker"&gt;
     &lt;module name="WhitespaceAfter"&gt;
@@ -200,7 +200,7 @@ class Example1 {
 &lt;/module&gt;
 </code></pre></div>
         <p id="Example2-code">Example:</p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+        <div class="wrapper"><pre><code class="language-java">
 class Example2 {
   void example() {
     int a = 0; int b = 1;

--- a/src/site/xdoc/checks/whitespace/whitespacearound.xml
+++ b/src/site/xdoc/checks/whitespace/whitespacearound.xml
@@ -368,7 +368,7 @@ try {
         <p id="Example1-config">
           To configure the check:
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
+        <div class="wrapper"><pre><code class="language-xml">
 &lt;module name="Checker"&gt;
   &lt;module name="TreeWalker"&gt;
     &lt;module name="WhitespaceAround"/&gt;
@@ -376,7 +376,7 @@ try {
 &lt;/module&gt;
 </code></pre></div>
         <p id="Example1-code">Example:</p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+        <div class="wrapper"><pre><code class="language-java">
 class Example1 {
   public Example1(){} // 3 violations
   // no space after ')' and '{', no space before '}'
@@ -404,7 +404,7 @@ class Example1 {
         <p id="Example2-config">
           To configure the check for whitespace only around assignment operators:
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
+        <div class="wrapper"><pre><code class="language-xml">
 &lt;module name="Checker"&gt;
   &lt;module name="TreeWalker"&gt;
     &lt;module name="WhitespaceAround"&gt;
@@ -417,7 +417,7 @@ class Example1 {
 &lt;/module&gt;
 </code></pre></div>
         <p id="Example2-code">Example:</p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+        <div class="wrapper"><pre><code class="language-java">
 class Example2 {
   void example() {
     int b=10; // 2 violations
@@ -450,7 +450,7 @@ class Example2 {
         <p id="Example3-config">
           To configure the check for whitespace only around curly braces:
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
+        <div class="wrapper"><pre><code class="language-xml">
 &lt;module name="Checker"&gt;
   &lt;module name="TreeWalker"&gt;
     &lt;module name="WhitespaceAround"&gt;
@@ -460,7 +460,7 @@ class Example2 {
 &lt;/module&gt;
 </code></pre></div>
         <p id="Example3-code">Example:</p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+        <div class="wrapper"><pre><code class="language-java">
 class Example3 {
   void myFunction() {} // violation ''}' is not preceded with whitespace'
   void myFunction2() { }
@@ -469,7 +469,7 @@ class Example3 {
         <p id="Example4-config">
           To configure the check to allow empty method bodies:
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
+        <div class="wrapper"><pre><code class="language-xml">
 &lt;module name="Checker"&gt;
   &lt;module name="TreeWalker"&gt;
     &lt;module name="WhitespaceAround"&gt;
@@ -479,7 +479,7 @@ class Example3 {
 &lt;/module&gt;
 </code></pre></div>
         <p id="Example4-code">Example:</p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+        <div class="wrapper"><pre><code class="language-java">
 class Example4 {
   public void muFunction() {}
   int a=4; // 2 violations
@@ -489,7 +489,7 @@ class Example4 {
         <p id="Example5-config">
           To configure the check to allow empty constructor bodies:
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
+        <div class="wrapper"><pre><code class="language-xml">
 &lt;module name="Checker"&gt;
   &lt;module name="TreeWalker"&gt;
     &lt;module name="WhitespaceAround"&gt;
@@ -499,7 +499,7 @@ class Example4 {
 &lt;/module&gt;
 </code></pre></div>
         <p id="Example5-code">Example:</p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+        <div class="wrapper"><pre><code class="language-java">
 class Example5 {
   public Example5() {}
   public void myFunction() {} // 2 violations
@@ -509,7 +509,7 @@ class Example5 {
         <p id="Example6-config">
           To configure the check to allow empty type bodies:
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
+        <div class="wrapper"><pre><code class="language-xml">
 &lt;module name="Checker"&gt;
   &lt;module name="TreeWalker"&gt;
     &lt;module name="WhitespaceAround"&gt;
@@ -519,7 +519,7 @@ class Example5 {
 &lt;/module&gt;
 </code></pre></div>
         <p id="Example6-code">Example:</p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+        <div class="wrapper"><pre><code class="language-java">
 class Example6 {
   class Test {}
   interface testInterface{}
@@ -532,7 +532,7 @@ class Example6 {
         <p id="Example7-config">
           To configure the check to allow empty loop bodies:
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
+        <div class="wrapper"><pre><code class="language-xml">
 &lt;module name="Checker"&gt;
   &lt;module name="TreeWalker"&gt;
     &lt;module name="WhitespaceAround"&gt;
@@ -542,7 +542,7 @@ class Example6 {
 &lt;/module&gt;
 </code></pre></div>
         <p id="Example7-code">Example:</p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+        <div class="wrapper"><pre><code class="language-java">
 class Example7 {
   int y = 0;
   void example() {
@@ -556,7 +556,7 @@ class Example7 {
         <p id="Example8-config">
           To configure the check to allow empty lambda bodies:
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
+        <div class="wrapper"><pre><code class="language-xml">
 &lt;module name="Checker"&gt;
   &lt;module name="TreeWalker"&gt;
     &lt;module name="WhitespaceAround"&gt;
@@ -566,7 +566,7 @@ class Example7 {
 &lt;/module&gt;
 </code></pre></div>
         <p id="Example8-code">Example:</p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+        <div class="wrapper"><pre><code class="language-java">
 class Example8 {
   void example() {
     Runnable noop = () -&gt; {};
@@ -578,7 +578,7 @@ class Example8 {
         <p id="Example9-config">
           To configure the check to allow empty catch bodies:
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
+        <div class="wrapper"><pre><code class="language-xml">
 &lt;module name="Checker"&gt;
   &lt;module name="TreeWalker"&gt;
     &lt;module name="WhitespaceAround"&gt;
@@ -588,7 +588,7 @@ class Example8 {
 &lt;/module&gt;
 </code></pre></div>
         <p id="Example9-code">Example:</p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+        <div class="wrapper"><pre><code class="language-java">
 class Example9 {
   void example() {
     int a=4; // 2 violations
@@ -605,7 +605,7 @@ class Example9 {
         <p id="Example10-config">
           To configure the check to ignore the colon:
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
+        <div class="wrapper"><pre><code class="language-xml">
 &lt;module name="Checker"&gt;
   &lt;module name="TreeWalker"&gt;
     &lt;module name="WhitespaceAround"&gt;
@@ -615,7 +615,7 @@ class Example9 {
 &lt;/module&gt;
 </code></pre></div>
         <p id="Example10-code">Example:</p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+        <div class="wrapper"><pre><code class="language-java">
 class Example10 {
   void example() {
     int a=4; // 2 violations

--- a/src/site/xdoc/cmdline.xml.vm
+++ b/src/site/xdoc/cmdline.xml.vm
@@ -28,7 +28,7 @@
     <section name="Command line usage">
       <p>
 
-        <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
+        <div class="wrapper"><pre><code class="language-xml">
 java -D&lt;property&gt;=&lt;value&gt;  \
      com.puppycrawl.tools.checkstyle.Main \
      -c &lt;configurationFile&gt; \
@@ -419,7 +419,7 @@ java -D&lt;property&gt;=&lt;value&gt;  \
         An example of run would be:
       </p>
       <div class="wrap-content">
-        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+        <div class="wrapper"><pre><code class="language-java">
           java -jar checkstyle-${projectVersion}-all.jar -c /sun_checks.xml MyClass.java
           java -jar checkstyle-${projectVersion}-all.jar -c /google_checks.xml MyClass.java
         </code></pre></div>
@@ -443,7 +443,7 @@ java -D&lt;property&gt;=&lt;value&gt;  \
         An example of run would be (path to java file is optional):
       </p>
       <div class="wrap-content">
-        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+        <div class="wrapper"><pre><code class="language-java">
           java -cp checkstyle-${projectVersion}-all.jar com.puppycrawl.tools.checkstyle.gui.Main \
           &#xa0;&#xa0;&#xa0;&#xa0;MyClass.java
         </code></pre></div>
@@ -1738,7 +1738,7 @@ Audit done.
         Download and compile:
       </p>
       <div class="wrap-content">
-        <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
+        <div class="wrapper"><pre><code class="language-xml">
           git clone https://github.com/checkstyle/checkstyle.git
           cd checkstyle
           mvn clean compile
@@ -1748,7 +1748,7 @@ Audit done.
         Run validation with arguments:
       </p>
       <div class="wrap-content">
-        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+        <div class="wrapper"><pre><code class="language-java">
           mvn exec:java -Dexec.mainClass="com.puppycrawl.tools.checkstyle.Main" \
           &#xa0;&#xa0;&#xa0;&#xa0;-Dexec.args="-c /sun_checks.xml src/main/java"
         </code></pre></div>
@@ -1757,7 +1757,7 @@ Audit done.
         Run UI application for file :
       </p>
       <div class="wrap-content">
-        <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
+        <div class="wrapper"><pre><code class="language-xml">
           mvn exec:java -Dexec.mainClass="com.puppycrawl.tools.checkstyle.gui.Main" -Dexec.args=\
           &#xa0;&#xa0;&#xa0;&#xa0;"src/main/java/com/puppycrawl/tools/checkstyle/Checker.java"
         </code></pre></div>
@@ -1766,7 +1766,7 @@ Audit done.
         Build all jars, and launch CLI from new build:
       </p>
       <div class="wrap-content">
-        <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
+        <div class="wrapper"><pre><code class="language-xml">
           mvn clean package -Passembly,no-validations
           java -jar target/checkstyle-X.X-SNAPSHOT-all.jar -c /sun_checks.xml MyClass.java
         </code></pre></div>
@@ -1797,7 +1797,7 @@ Audit done.
         </b>
       </p>
       <div class="wrap-content">
-        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+        <div class="wrapper"><pre><code class="language-java">
           java com.puppycrawl.tools.checkstyle.Main -c /sun_checks.xml Check.java
         </code></pre></div>
       </div>
@@ -1809,7 +1809,7 @@ Audit done.
         </b>
       </p>
       <div class="wrap-content">
-        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+        <div class="wrapper"><pre><code class="language-java">
           java com.puppycrawl.tools.checkstyle.Main -c /sun_checks.xml src/
         </code></pre></div>
       </div>
@@ -1822,7 +1822,7 @@ Audit done.
         </b>
       </p>
       <div class="wrap-content">
-        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+        <div class="wrapper"><pre><code class="language-java">
           java -Dcheckstyle.cache.file=target/cachefile com.puppycrawl.tools.checkstyle.Main \
           &#xa0;&#xa0;&#xa0;&#xa0;-c /sun_checks.xml Check.java
         </code></pre></div>
@@ -1836,7 +1836,7 @@ Audit done.
         </b>
       </p>
       <div class="wrap-content">
-        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+        <div class="wrapper"><pre><code class="language-java">
           java com.puppycrawl.tools.checkstyle.Main -c /sun_checks.xml \
           &#xa0;&#xa0;&#xa0;&#xa0;-p myCheckstyle.properties Check.java
         </code></pre></div>
@@ -1850,7 +1850,7 @@ Audit done.
         </b>
       </p>
       <div class="wrap-content">
-        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+        <div class="wrapper"><pre><code class="language-java">
           java com.puppycrawl.tools.checkstyle.Main -c /sun_checks.xml -f xml \
           &#xa0;&#xa0;&#xa0;&#xa0;-o build/checkstyle_errors.xml Check.java
         </code></pre></div>
@@ -1863,7 +1863,7 @@ Audit done.
         </b>
       </p>
       <div class="wrap-content">
-        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+        <div class="wrapper"><pre><code class="language-java">
           java -classpath MyCustom.jar;checkstyle-${projectVersion}-all.jar \
           &#xa0;&#xa0;&#xa0;&#xa0;com.puppycrawl.tools.checkstyle.Main -c config.xml Check.java
         </code></pre></div>

--- a/src/site/xdoc/config.xml
+++ b/src/site/xdoc/config.xml
@@ -71,7 +71,7 @@
         Here is a fragment of a typical configuration document:
       </p>
 
-      <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
+      <div class="wrapper"><pre><code class="language-xml">
 &lt;module name=&quot;Checker&quot;&gt;
   &lt;module name=&quot;JavadocPackage&quot;/&gt;
   &lt;module name=&quot;TreeWalker&quot;&gt;
@@ -117,7 +117,7 @@
           Load a class directly according to a package-qualified <code>name</code>, such as loading
           class <code>com.puppycrawl.tools.checkstyle.TreeWalker</code> for element:
 
-          <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
+          <div class="wrapper"><pre><code class="language-xml">
 &lt;module name=&quot;com.puppycrawl.tools.checkstyle.TreeWalker&quot;/&gt;
           </code></pre></div>
 
@@ -128,7 +128,7 @@
           Load a class of a pre-specified package, such as loading class
           <code>com.puppycrawl.tools.checkstyle.checks.AvoidStarImport</code>
           for element
-          <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
+          <div class="wrapper"><pre><code class="language-xml">
 &lt;module name=&quot;AvoidStarImport&quot;/&gt;
           </code></pre></div>
 
@@ -150,7 +150,7 @@
           such as loading class
           <code>com.puppycrawl.tools.checkstyle.checks.ConstantNameCheck</code>
           for element
-          <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
+          <div class="wrapper"><pre><code class="language-xml">
 &lt;module name=&quot;ConstantName&quot;/&gt;
           </code></pre></div>
         </li>
@@ -176,7 +176,7 @@
         than <code>60</code> lines:
       </p>
 
-      <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
+      <div class="wrapper"><pre><code class="language-xml">
 &lt;module name=&quot;MethodLength&quot;&gt;
   &lt;property name=&quot;max&quot; value=&quot;60&quot;/&gt;
 &lt;/module&gt;
@@ -193,7 +193,7 @@
         applies to <code>TreeWalker</code> and its submodules:
       </p>
 
-      <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
+      <div class="wrapper"><pre><code class="language-xml">
 &lt;module name=&quot;Checker&quot;&gt;
   &lt;module name=&quot;JavadocPackage&quot;/&gt;
   &lt;module name=&quot;TreeWalker&quot;&gt;
@@ -216,7 +216,7 @@
         property <code>checkstyle.header.file</code>:
       </p>
 
-      <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
+      <div class="wrapper"><pre><code class="language-xml">
 &lt;module name=&quot;Header&quot;&gt;
   &lt;property name=&quot;headerFile&quot; value=&quot;${checkstyle.header.file}&quot;/&gt;
 &lt;/module&gt;
@@ -236,7 +236,7 @@
         command line property <code>checkstyle.javadoc.severity</code>:
       </p>
 
-      <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
+      <div class="wrapper"><pre><code class="language-xml">
 &lt;module name=&quot;JavadocMethod&quot;&gt;
   &lt;property name=&quot;severity&quot;
     value=&quot;${checkstyle.javadoc.severity}&quot;
@@ -401,7 +401,7 @@
           Example:
         </p>
 
-        <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
+        <div class="wrapper"><pre><code class="language-xml">
 &lt;module name=&quot;Checker&quot;&gt;
   &lt;metadata name=&quot;com.myproject.cs-version&quot; value=&quot;4.4&quot;/&gt;
   &lt;metadata name=&quot;com.myproject.cs-version.desc&quot; value=&quot;legacy config&quot;/&gt;
@@ -417,7 +417,7 @@
           locale for all modules:
         </p>
 
-        <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
+        <div class="wrapper"><pre><code class="language-xml">
 &lt;module name=&quot;Checker&quot;&gt;
   &lt;property name=&quot;basedir&quot; value=&quot;src/checkstyle&quot;/&gt;
   &lt;property name=&quot;cacheFile&quot; value=&quot;target/cachefile&quot;/&gt;
@@ -435,7 +435,7 @@
           handles files with the <code>ISO-8859-5</code> charset:
         </p>
 
-        <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
+        <div class="wrapper"><pre><code class="language-xml">
 &lt;module name=&quot;Checker&quot;&gt;
   &lt;property name=&quot;charset&quot; value=&quot;ISO-8859-5&quot;/&gt;
   ...
@@ -447,7 +447,7 @@
           handles files with the <code>java, xml, properties</code> extensions:
         </p>
 
-        <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
+        <div class="wrapper"><pre><code class="language-xml">
 &lt;module name=&quot;Checker&quot;&gt;
   &lt;property name=&quot;fileExtensions&quot; value=&quot;java, xml, properties&quot;/&gt;
   ...
@@ -459,7 +459,7 @@
           <code>Exception</code> and instead prints it as a violation:
         </p>
 
-        <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
+        <div class="wrapper"><pre><code class="language-xml">
 &lt;module name=&quot;Checker&quot;&gt;
   &lt;property name=&quot;haltOnException&quot; value=&quot;false&quot;/&gt;
   ...
@@ -471,14 +471,14 @@
           handles files with any extension:
         </p>
 
-        <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
+        <div class="wrapper"><pre><code class="language-xml">
 &lt;module name=&quot;Checker&quot;&gt;
   &lt;property name=&quot;fileExtensions&quot; value=&quot;null&quot;/&gt;
   ...
 &lt;/module&gt;
         </code></pre></div>
         <p>OR</p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
+        <div class="wrapper"><pre><code class="language-xml">
 &lt;module name=&quot;Checker&quot;&gt;
   &lt;property name=&quot;fileExtensions&quot; value=&quot;&quot;/&gt;
   ...
@@ -563,7 +563,7 @@
           <code>TreeWalker</code> a <code>tabWidth</code> of <code>4</code>:
         </p>
 
-        <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
+        <div class="wrapper"><pre><code class="language-xml">
 &lt;module name=&quot;Checker&quot;&gt;
   &lt;module name=&quot;TreeWalker&quot;&gt;
     &lt;property name=&quot;tabWidth&quot; value=&quot;4&quot;/&gt;
@@ -580,7 +580,7 @@
           To integrate Checkstyle with BEA Weblogic Workshop 8.1:
         </p>
 
-        <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
+        <div class="wrapper"><pre><code class="language-xml">
 &lt;module name=&quot;Checker&quot;&gt;
   &lt;module name=&quot;TreeWalker&quot;&gt;
     &lt;property name=&quot;fileExtensions&quot; value=&quot;java,ejb,jpf&quot;/&gt;
@@ -594,7 +594,7 @@
           handles files with the <code>java</code> extension:
         </p>
 
-        <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
+        <div class="wrapper"><pre><code class="language-xml">
 &lt;module name=&quot;TreeWalker&quot;&gt;
   &lt;property name=&quot;fileExtensions&quot; value=&quot;java&quot;/&gt;
   ...
@@ -606,14 +606,14 @@
           handles files with any extension:
         </p>
 
-        <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
+        <div class="wrapper"><pre><code class="language-xml">
 &lt;module name=&quot;TreeWalker&quot;&gt;
   &lt;property name=&quot;fileExtensions&quot; value=&quot;null&quot;/&gt;
   ...
 &lt;/module&gt;
         </code></pre></div>
         <p>OR</p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
+        <div class="wrapper"><pre><code class="language-xml">
 &lt;module name=&quot;TreeWalker&quot;&gt;
   &lt;property name=&quot;fileExtensions&quot; value=&quot;&quot;/&gt;
   ...
@@ -630,7 +630,7 @@
           preventing execution from stopping on an exception and instead
           printing it as a violation:
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
+        <div class="wrapper"><pre><code class="language-xml">
 &lt;module name=&quot;TreeWalker&quot;&gt;
    &lt;property name=&quot;skipFileOnJavaParseException&quot; value=&quot;true&quot;/&gt;
    ...
@@ -642,7 +642,7 @@
           preventing execution from stopping on an exception and does not
           print it as a violation:
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
+        <div class="wrapper"><pre><code class="language-xml">
 &lt;module name=&quot;TreeWalker&quot;&gt;
    &lt;property name=&quot;skipFileOnJavaParseException&quot; value=&quot;true&quot;/&gt;
    &lt;property name=&quot;javaParseExceptionSeverity&quot; value=&quot;ignore&quot;/&gt;
@@ -702,7 +702,7 @@
         <code>MethodLength</code>:
       </p>
 
-      <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
+      <div class="wrapper"><pre><code class="language-xml">
 &lt;module name=&quot;MethodLength&quot;/&gt;
       </code></pre></div>
 
@@ -721,7 +721,7 @@
         of lines of methods only:
       </p>
 
-      <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
+      <div class="wrapper"><pre><code class="language-xml">
 &lt;module name=&quot;MethodLength&quot;&gt;
   &lt;property name=&quot;tokens&quot; value=&quot;METHOD_DEF&quot;/&gt;
 &lt;/module&gt;
@@ -735,7 +735,7 @@
         at most 60 lines, include the following in the <code>TreeWalker</code> configuration:
       </p>
 
-      <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
+      <div class="wrapper"><pre><code class="language-xml">
 &lt;module name=&quot;MethodLength&quot;&gt;
   &lt;property name=&quot;tokens&quot; value=&quot;METHOD_DEF&quot;/&gt;
 &lt;/module&gt;
@@ -771,7 +771,7 @@
         plain formatter outputs warnings for translation violations:
       </p>
 
-      <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
+      <div class="wrapper"><pre><code class="language-xml">
 &lt;module name=&quot;Translation&quot;&gt;
   &lt;property name=&quot;severity&quot; value=&quot;warning&quot;/&gt;
 &lt;/module&gt;
@@ -791,7 +791,7 @@
         This is only used to control the spacing when violations from modules are printed.
       </p>
 
-      <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
+      <div class="wrapper"><pre><code class="language-xml">
 &lt;module name=&quot;Checker&quot;&gt;
   &lt;property name=&quot;tabWidth&quot; value=&quot;4&quot;/&gt;
 &lt;/module&gt;
@@ -810,7 +810,7 @@
         it is harder to differentiate one module's violations from the other.
       </p>
 
-      <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
+      <div class="wrapper"><pre><code class="language-xml">
 &lt;module name=&quot;DescendantToken&quot;&gt;
   &lt;property name=&quot;id&quot; value=&quot;stringEqual&quot;/&gt;
   &lt;property name=&quot;tokens&quot; value=&quot;EQUAL,NOT_EQUAL&quot;/&gt;
@@ -842,7 +842,7 @@
 
       <p>An example usage is:</p>
 
-      <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
+      <div class="wrapper"><pre><code class="language-xml">
 &lt;module name=&quot;MemberName&quot;&gt;
   &lt;property name=&quot;format&quot; value=&quot;^m[a-zA-Z0-9]*$&quot;/&gt;
   &lt;message key=&quot;name.invalidPattern&quot;
@@ -923,7 +923,7 @@
         include the following module in the configuration file:
       </p>
 
-      <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
+      <div class="wrapper"><pre><code class="language-xml">
 &lt;module name=&quot;com.mycompany.listeners.VerboseListener&quot;&gt;
   &lt;property name=&quot;file&quot; value=&quot;audit.txt&quot;/&gt;
 &lt;/module&gt;
@@ -967,7 +967,7 @@
         com.puppycrawl.tools.checkstyle.checks</code>:
       </p>
 
-      <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
+      <div class="wrapper"><pre><code class="language-xml">
 &lt;checkstyle-packages&gt;
   &lt;package name=&quot;com.puppycrawl.tools.checkstyle&quot;&gt;
     &lt;package name=&quot;checks&quot;/&gt;
@@ -993,7 +993,7 @@
         The XML file must be named exactly <code>checkstyle_packages.xml</code>:
       </p>
 
-      <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
+      <div class="wrapper"><pre><code class="language-xml">
 &lt;?xml version=&quot;1.0&quot; encoding=&quot;UTF-8&quot;?&gt;
 
 &lt;!DOCTYPE checkstyle-packages PUBLIC
@@ -1011,7 +1011,7 @@
         element in the configuration document:
       </p>
 
-      <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
+      <div class="wrapper"><pre><code class="language-xml">
 &lt;module name=&quot;MethodLimit&quot;/&gt;
       </code></pre></div>
 
@@ -1042,7 +1042,7 @@
         configuration XML document:
       </p>
 
-      <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
+      <div class="wrapper"><pre><code class="language-xml">
 &lt;!DOCTYPE module PUBLIC
   &quot;-//Checkstyle//DTD Checkstyle Configuration 1.3//EN&quot;
   &quot;https://checkstyle.org/dtds/configuration_1_3.dtd&quot;&gt;

--- a/src/site/xdoc/config_system_properties.xml
+++ b/src/site/xdoc/config_system_properties.xml
@@ -46,7 +46,7 @@
         </p>
         <p>
           Common part <code>checkstyle-common.xml</code>:
-          <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
+          <div class="wrapper"><pre><code class="language-xml">
 &lt;module name=&quot;FileLength&quot;&gt;
   &lt;property name=&quot;max&quot; value=&quot;1&quot;/&gt;
 &lt;/module&gt;
@@ -54,7 +54,7 @@
         </p>
         <p>
           Main config <code>checkstyle.xml</code>:
-          <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
+          <div class="wrapper"><pre><code class="language-xml">
 &lt;?xml version=&quot;1.0&quot;?&gt;
 &lt;!DOCTYPE module PUBLIC
           &quot;-//Checkstyle//DTD Checkstyle Configuration 1.3//EN&quot;
@@ -76,7 +76,7 @@
         </p>
         <p>
           Test config <code>checkstyle-test.xml</code>:
-          <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
+          <div class="wrapper"><pre><code class="language-xml">
 &lt;?xml version=&quot;1.0&quot;?&gt;
 &lt;!DOCTYPE module PUBLIC
           &quot;-//Checkstyle//DTD Checkstyle Configuration 1.3//EN&quot;
@@ -98,7 +98,7 @@
         </p>
         <p>
           Target file for validation <code>Test.java</code>:
-          <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+          <div class="wrapper"><pre><code class="language-java">
 class Test {
   int i = 0;
 }
@@ -107,7 +107,7 @@ class Test {
         <p>
           Example of execution for <code>checkstyle.xml</code>. Violation from Check of
           <code>common.xml</code> is expected, validation of field name is done by main code rules:
-          <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+          <div class="wrapper"><pre><code class="language-java">
 $ java -Dcheckstyle.enableExternalDtdLoad=true -classpath checkstyle-XX.X-all.jar \
         com.puppycrawl.tools.checkstyle.Main -c checkstyle.xml Test.java
 Starting audit...
@@ -120,7 +120,7 @@ Checkstyle ends with 2 errors.
         <p>
           Example of execution for <code>checkstyle-test.xml</code>. Violation from Check of
           <code>common.xml</code> is expected, validation of field name is done by test code rules:
-          <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+          <div class="wrapper"><pre><code class="language-java">
 $ java -Dcheckstyle.enableExternalDtdLoad=true -classpath checkstyle-XX.X-all.jar \
           com.puppycrawl.tools.checkstyle.Main -c checkstyle-test.xml Test.java
 Starting audit...
@@ -142,7 +142,7 @@ Checkstyle ends with 2 errors.
         Checkstyle supports property expansion within property definitions, also
         known as property chaining. This feature allows you to define properties
         using other properties. For example:
-        <div class="wrapper"><pre class="prettyprint"><code class="language-text">
+        <div class="wrapper"><pre><code class="language-text">
 checkstyle.dir=/home/user/checkstyle
 config.dir=configs
 checkstyle.suppressions.file=${checkstyle.dir}/${config.dir}/suppressions.xml

--- a/src/site/xdoc/filefilters/beforeexecutionexclusionfilefilter.xml
+++ b/src/site/xdoc/filefilters/beforeexecutionexclusionfilefilter.xml
@@ -54,7 +54,7 @@
           With the default configuration, no files are matched against the
           <code>fileNamePattern</code>, so the filter does not affect the audit:
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
+        <div class="wrapper"><pre><code class="language-xml">
 &lt;module name="Checker"&gt;
 
   &lt;module name="RegexpOnFilename"&gt;
@@ -69,7 +69,7 @@
 &lt;/module&gt;
 </code></pre></div>
         <p id="Example1-code">Example:</p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+        <div class="wrapper"><pre><code class="language-java">
 .../Example1.java
 .../Example2.java
 .../Example3.java
@@ -82,7 +82,7 @@
         <p id="Example2-config">
           To configure the filter to exclude all 'module-info.java' files:
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
+        <div class="wrapper"><pre><code class="language-xml">
 &lt;module name="Checker"&gt;
 
   &lt;module name="RegexpOnFilename"&gt;
@@ -99,7 +99,7 @@
 &lt;/module&gt;
 </code></pre></div>
         <p id="Example2-code">Example:</p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+        <div class="wrapper"><pre><code class="language-java">
 .../Example1.java
 .../Example2.java
 .../Example3.java
@@ -114,7 +114,7 @@
           or end with &quot;Client&quot; in names or named as &quot;Remote.java&quot; or &quot;Client.java&quot;
           use <a href="https://www.regular-expressions.info/lookaround.html">negative lookahead</a>:
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
+        <div class="wrapper"><pre><code class="language-xml">
 &lt;module name="Checker"&gt;
 
   &lt;module name="RegexpOnFilename"&gt;
@@ -132,7 +132,7 @@
 &lt;/module&gt;
 </code></pre></div>
         <p id="Example3-code">Example:</p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+        <div class="wrapper"><pre><code class="language-java">
 .../Example1.java
 .../Example2.java
 .../Example3.java
@@ -146,7 +146,7 @@
           To configure the filter to exclude all 'test' folder files and all 'module-info.java'
           files:
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
+        <div class="wrapper"><pre><code class="language-xml">
 &lt;module name="Checker"&gt;
 
   &lt;module name="RegexpOnFilename"&gt;
@@ -164,7 +164,7 @@
 &lt;/module&gt;
 </code></pre></div>
         <p id="Example4-code">Example:</p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+        <div class="wrapper"><pre><code class="language-java">
 .../Example1.java
 .../Example2.java
 .../Example3.java

--- a/src/site/xdoc/filters/severitymatchfilter.xml
+++ b/src/site/xdoc/filters/severitymatchfilter.xml
@@ -53,7 +53,7 @@
           Checker to not report audit events with severity
           level <code>info</code>:
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
+        <div class="wrapper"><pre><code class="language-xml">
 &lt;module name="Checker"&gt;
   &lt;module name="TreeWalker"&gt;
     &lt;module name="ParameterName"&gt;
@@ -70,7 +70,7 @@
         <p id="Example1-code">
             Example code:
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+        <div class="wrapper"><pre><code class="language-java">
 public class Example1 {
   public void method1(int V1){} // ok, ParameterName's severity is info
 

--- a/src/site/xdoc/filters/suppressioncommentfilter.xml
+++ b/src/site/xdoc/filters/suppressioncommentfilter.xml
@@ -114,7 +114,7 @@
           between a comment containing <code>CHECKSTYLE:OFF</code> and a comment containing
           <code>CHECKSTYLE:ON</code>:
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
+        <div class="wrapper"><pre><code class="language-xml">
 &lt;module name="Checker"&gt;
   &lt;module name="TreeWalker"&gt;
     &lt;module name="SuppressionCommentFilter"/&gt;
@@ -125,7 +125,7 @@
 &lt;/module&gt;
 </code></pre></div>
         <p id="Example1-code">Example:</p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+        <div class="wrapper"><pre><code class="language-java">
 class Example1
 {
   int VAR1; // violation, Name 'VAR1' must match pattern '^[a-z][a-zA-Z0-9]*$'
@@ -161,7 +161,7 @@ class Example1
           check</code> and <code>// resume constant check</code> marks
           legitimate constant names:
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
+        <div class="wrapper"><pre><code class="language-xml">
 &lt;module name="Checker"&gt;
   &lt;module name="TreeWalker"&gt;
     &lt;module name="SuppressionCommentFilter"&gt;
@@ -176,7 +176,7 @@ class Example1
 &lt;/module&gt;
 </code></pre></div>
         <p id="Example2-code">Example:</p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+        <div class="wrapper"><pre><code class="language-java">
 class Example2
 {
   int VAR1; // violation, Name 'VAR1' must match pattern '^[a-z][a-zA-Z0-9]*$'
@@ -213,7 +213,7 @@ class Example2
           variable or parameter known not to be used by the code by
           matching the variable name in the message through a specified message in messageFormat:
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
+        <div class="wrapper"><pre><code class="language-xml">
 &lt;module name="Checker"&gt;
   &lt;module name="TreeWalker"&gt;
     &lt;module name="SuppressionCommentFilter"&gt;
@@ -229,7 +229,7 @@ class Example2
 &lt;/module&gt;
 </code></pre></div>
         <p id="Example3-code">Example:</p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+        <div class="wrapper"><pre><code class="language-java">
 class Example3
 {
   int VAR1; // violation, Name 'VAR1' must match pattern '^[a-z][a-zA-Z0-9]*$'
@@ -266,7 +266,7 @@ class Example3
           in comment <code>CSOFF: <i>regexp</i></code>
           and <code>CSON: <i>regexp</i></code> mark a matching check:
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
+        <div class="wrapper"><pre><code class="language-xml">
 &lt;module name="Checker"&gt;
   &lt;module name="TreeWalker"&gt;
     &lt;module name="SuppressionCommentFilter"&gt;
@@ -281,7 +281,7 @@ class Example3
 &lt;/module&gt;
 </code></pre></div>
         <p id="Example4-code">Example:</p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+        <div class="wrapper"><pre><code class="language-java">
 class Example4
 {
   int VAR1; // violation, Name 'VAR1' must match pattern '^[a-z][a-zA-Z0-9]*$'
@@ -317,7 +317,7 @@ class Example4
           containing <code>CHECKSTYLE_OFF: ALMOST_ALL</code> and a comment containing
           <code>CHECKSTYLE_OFF: ALMOST_ALL</code> except for the <em>ConstantName</em> check:
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
+        <div class="wrapper"><pre><code class="language-xml">
 &lt;module name="Checker"&gt;
   &lt;module name="TreeWalker"&gt;
     &lt;module name="SuppressionCommentFilter"&gt;
@@ -332,7 +332,7 @@ class Example4
 &lt;/module&gt;
 </code></pre></div>
         <p id="Example5-code">Example:</p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+        <div class="wrapper"><pre><code class="language-java">
 class Example5
 {
   int VAR1; // violation, Name 'VAR1' must match pattern '^[a-z][a-zA-Z0-9]*$'
@@ -373,7 +373,7 @@ class Example5
           to the ID written in the offCommentFormat and onCommentFormat. Config for such a
           case is written below:
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
+        <div class="wrapper"><pre><code class="language-xml">
 &lt;module name="Checker"&gt;
   &lt;module name="TreeWalker"&gt;
     &lt;module name="SuppressionCommentFilter"&gt;
@@ -394,7 +394,7 @@ class Example5
 &lt;/module&gt;
 </code></pre></div>
         <p id="Example6-code">Example:</p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+        <div class="wrapper"><pre><code class="language-java">
 class Example6
 {
   int VAR1; // violation, Name 'VAR1' must match pattern '^[a-z][a-zA-Z0-9]*$'
@@ -428,7 +428,7 @@ class Example6
         <p id="Example7-config">
           Example of how to configure the check to suppress checks by name defined in comment.
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
+        <div class="wrapper"><pre><code class="language-xml">
 &lt;module name="Checker"&gt;
   &lt;module name="TreeWalker"&gt;
     &lt;module name="SuppressionCommentFilter"&gt;
@@ -443,7 +443,7 @@ class Example6
 &lt;/module&gt;
 </code></pre></div>
         <p id="Example7-code">Example:</p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+        <div class="wrapper"><pre><code class="language-java">
 class Example7
 {
   int VAR1; // violation, Name 'VAR1' must match pattern '^[a-z][a-zA-Z0-9]*$'
@@ -478,7 +478,7 @@ class Example7
         <p id="Example8-config">
           Example depicting use of checkC and checkCPP style comments
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
+        <div class="wrapper"><pre><code class="language-xml">
 &lt;module name="Checker"&gt;
   &lt;module name="TreeWalker"&gt;
     &lt;module name="SuppressionCommentFilter"&gt;
@@ -492,7 +492,7 @@ class Example7
 &lt;/module&gt;
 </code></pre></div>
         <p id="Example8-code">Example:</p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+        <div class="wrapper"><pre><code class="language-java">
 class Example8
 {
   int VAR1; // violation, Name 'VAR1' must match pattern '^[a-z][a-zA-Z0-9]*$'

--- a/src/site/xdoc/filters/suppressionsinglefilter.xml
+++ b/src/site/xdoc/filters/suppressionsinglefilter.xml
@@ -103,7 +103,7 @@
           and <code>'Missing a Javadoc comment'</code> violations
           for all lines and files:
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
+        <div class="wrapper"><pre><code class="language-xml">
 &lt;module name="Checker"&gt;
   &lt;module name="TreeWalker"&gt;
     &lt;module name="JavadocStyle"/&gt;
@@ -126,7 +126,7 @@
 </code></pre></div>
         <p id="Example1-code">
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+        <div class="wrapper"><pre><code class="language-java">
 public class Example1 {
   public void exampleMethod() {
     int value = 100;
@@ -138,7 +138,7 @@ public class Example1 {
           Suppress check by <a href="https://checkstyle.org/config.html#Id">module id</a>
           when config have two instances on the same check:
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
+        <div class="wrapper"><pre><code class="language-xml">
 &lt;module name="Checker"&gt;
   &lt;module name="EqualsAvoidNull"/&gt;
   &lt;module name="JavadocMethod"/&gt;
@@ -151,7 +151,7 @@ public class Example1 {
 </code></pre></div>
         <p id="Example2-code">
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+        <div class="wrapper"><pre><code class="language-java">
 public class Example2 {
 
   public void checkStringEquality(String str1, String str2) {
@@ -163,7 +163,7 @@ public class Example2 {
         <p id="Example3-config">
           Suppress all checks for hidden files and folders:
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
+        <div class="wrapper"><pre><code class="language-xml">
 &lt;module name="Checker"&gt;
   &lt;module name="RegexpSingleline"&gt;
     &lt;property name="format" value=".*example.*"/&gt;
@@ -176,7 +176,7 @@ public class Example2 {
 </code></pre></div>
         <p id="Example3-code">
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+        <div class="wrapper"><pre><code class="language-java">
 public class Example3 {
 
   public void printExample() {
@@ -197,7 +197,7 @@ public class Example3 {
         <p id="Example4-config">
           Suppress all checks for Maven-generated code:
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
+        <div class="wrapper"><pre><code class="language-xml">
 &lt;module name="Checker"&gt;
   &lt;module name="NoWhitespaceAfter"/&gt;
   &lt;module name="SuppressionSingleFilter"&gt;
@@ -208,7 +208,7 @@ public class Example3 {
 </code></pre></div>
         <p id="Example4-code">
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+        <div class="wrapper"><pre><code class="language-java">
 public class Example4 {
 
   // filtered violation 'WhiteSpace after ',''
@@ -224,7 +224,7 @@ public class Example4 {
         <p id="Example5-config">
           Suppress all checks for archives, classes and other binary files:
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
+        <div class="wrapper"><pre><code class="language-xml">
 &lt;module name="Checker"&gt;
   &lt;module name="MethodName"/&gt;
   &lt;module name="SuppressionSingleFilter"&gt;
@@ -235,7 +235,7 @@ public class Example4 {
 </code></pre></div>
         <p id="Example5-code">
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+        <div class="wrapper"><pre><code class="language-java">
 public class Example5 {
   // filtered violation 'Name 'example_Method' must match pattern'
   public void example_Method() {
@@ -249,7 +249,7 @@ public class Example5 {
         <p id="Example6-config">
           Suppress all checks for image files:
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
+        <div class="wrapper"><pre><code class="language-xml">
 &lt;module name="Checker"&gt;
   &lt;module name="ConstantName"/&gt;
   &lt;module name="SuppressionSingleFilter"&gt;
@@ -260,7 +260,7 @@ public class Example5 {
 </code></pre></div>
         <p id="Example6-code">
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+        <div class="wrapper"><pre><code class="language-java">
 public class Example6 {
 
   // filtered violation 'Name 'myConstant' must match pattern'
@@ -271,7 +271,7 @@ public class Example6 {
         <p id="Example7-config">
           Suppress all checks for non-java files:
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
+        <div class="wrapper"><pre><code class="language-xml">
 &lt;module name="Checker"&gt;
   &lt;module name="MemberName"/&gt;
   &lt;module name="SuppressionSingleFilter"&gt;
@@ -282,7 +282,7 @@ public class Example6 {
 </code></pre></div>
         <p id="Example7-code">
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+        <div class="wrapper"><pre><code class="language-java">
 public class Example7 {
 
   // filtered violation 'Name 'MyVariable' must match pattern'
@@ -299,7 +299,7 @@ public class Example7 {
         <p id="Example8-config">
           Suppress all checks in generated sources:
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
+        <div class="wrapper"><pre><code class="language-xml">
 &lt;module name="Checker"&gt;
   &lt;module name="TreeWalker"&gt;
     &lt;module name="ParameterNumber"&gt;
@@ -314,7 +314,7 @@ public class Example7 {
 </code></pre></div>
         <p id="Example8-code">
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+        <div class="wrapper"><pre><code class="language-java">
 public class Example8 {
   // filtered violation 'more than 5 parameters'
   public void exampleMethod(
@@ -326,7 +326,7 @@ public class Example8 {
         <p id="Example9-config">
           Suppress FileLength check on integration tests in certain folder:
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
+        <div class="wrapper"><pre><code class="language-xml">
 &lt;module name="Checker"&gt;
   &lt;module name="TreeWalker"&gt;
     &lt;module name="FileLength"&gt;
@@ -341,7 +341,7 @@ public class Example8 {
 </code></pre></div>
         <p id="Example9-code">
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+        <div class="wrapper"><pre><code class="language-java">
 public class Example9 {
   //filtered violation 'File length is 19 lines (max allowed is 1)'
 }
@@ -349,7 +349,7 @@ public class Example9 {
         <p id="Example10-config">
           Suppress naming violations on variable named 'log' in all files:
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
+        <div class="wrapper"><pre><code class="language-xml">
 &lt;module name="Checker"&gt;
   &lt;module name="MemberName"&gt;
     &lt;property name="format" value="^[A-Z][a-zA-Z0-9]*$"/&gt;
@@ -362,7 +362,7 @@ public class Example9 {
 </code></pre></div>
         <p id="Example10-code">
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+        <div class="wrapper"><pre><code class="language-java">
 public class Example10 {
 
   // filtered violation 'Name 'log' must match pattern'

--- a/src/site/xdoc/filters/suppressionxpathsinglefilter.xml
+++ b/src/site/xdoc/filters/suppressionxpathsinglefilter.xml
@@ -90,7 +90,7 @@
           for all methods with name MyMethod
           inside Example1 and Example3 files:
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
+        <div class="wrapper"><pre><code class="language-xml">
 &lt;module name="Checker"&gt;
   &lt;module name="TreeWalker"&gt;
     &lt;module name="MethodName"/&gt;
@@ -106,7 +106,7 @@
 &lt;/module&gt;
 </code></pre></div>
         <p id="Example1-code">Code example:</p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+        <div class="wrapper"><pre><code class="language-java">
 public class Example1 {
   public void MyMethod() {}
   // filtered violation above 'Name 'MyMethod' must match pattern'
@@ -115,7 +115,7 @@ public class Example1 {
         <p id="Example2-config">
           To suppress MethodName check for method names matched pattern 'MyMethod[0-9]':
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
+        <div class="wrapper"><pre><code class="language-xml">
 &lt;module name="Checker"&gt;
   &lt;module name="TreeWalker"&gt;
     &lt;module name="MethodName"/&gt;
@@ -127,7 +127,7 @@ public class Example1 {
 &lt;/module&gt;
 </code></pre></div>
         <p id="Example2-code">Code Example:</p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+        <div class="wrapper"><pre><code class="language-java">
 public class Example2 {
   // filtered violation below 'Name 'MyMethod1' must match pattern'
   public void MyMethod1() {}
@@ -140,7 +140,7 @@ public class Example2 {
         <p id="Example3-config">
           To suppress checks being specified by id property:
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
+        <div class="wrapper"><pre><code class="language-xml">
 &lt;module name="Checker"&gt;
   &lt;module name="TreeWalker"&gt;
     &lt;module name="MethodName"&gt;
@@ -154,7 +154,7 @@ public class Example2 {
 &lt;/module&gt;
 </code></pre></div>
         <p id="Example3-code">Code example:</p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+        <div class="wrapper"><pre><code class="language-java">
 public class Example3 {
   // filtered violation below 'Name 'MyMethod' must match pattern'
   public void MyMethod() {}
@@ -163,7 +163,7 @@ public class Example3 {
         <p id="Example4-config">
           To suppress checks for all package definitions:
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
+        <div class="wrapper"><pre><code class="language-xml">
 &lt;module name="Checker"&gt;
   &lt;module name="TreeWalker"&gt;
     &lt;module name="PackageName"&gt;
@@ -180,7 +180,7 @@ public class Example3 {
 &lt;/module&gt;
 </code></pre></div>
         <p id="Example4-code">Code example:</p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+        <div class="wrapper"><pre><code class="language-java">
 package com.puppycrawl.tools.checkstyle.filters.suppressionxpathsinglefilter;
 // filtered violation above 'must match pattern'
 
@@ -189,7 +189,7 @@ public class Example4 {}
         <p id="Example5-config">
           To suppress RedundantModifier check for interface definitions:
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
+        <div class="wrapper"><pre><code class="language-xml">
 &lt;module name="Checker"&gt;
   &lt;module name="TreeWalker"&gt;
     &lt;module name="RedundantModifier"/&gt;
@@ -201,7 +201,7 @@ public class Example4 {}
 &lt;/module&gt;
 </code></pre></div>
         <p id="Example5-code">Code Example:</p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+        <div class="wrapper"><pre><code class="language-java">
 public interface Example5 {
   public int CONSTANT1 = 1; // filtered violation 'Redundant 'public' modifier.'
 }
@@ -209,7 +209,7 @@ public interface Example5 {
         <p id="Example6-config">
           To suppress checks in the Example6 file by non-query:
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
+        <div class="wrapper"><pre><code class="language-xml">
 &lt;module name="Checker"&gt;
   &lt;module name="TreeWalker"&gt;
     &lt;module name="MagicNumber"/&gt;
@@ -221,7 +221,7 @@ public interface Example5 {
 &lt;/module&gt;
 </code></pre></div>
         <p id="Example6-code">Code example:</p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+        <div class="wrapper"><pre><code class="language-java">
 public class Example6 {
   private int field = 177; // filtered violation ''177' is a magic number.'
 }
@@ -230,7 +230,7 @@ public class Example6 {
           Suppress checks for elements which are either class definitions,
           or method definitions:
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
+        <div class="wrapper"><pre><code class="language-xml">
 &lt;module name="Checker"&gt;
   &lt;module name="TreeWalker"&gt;
     &lt;module name="AbstractClassName"/&gt;
@@ -246,7 +246,7 @@ public class Example6 {
 &lt;/module&gt;
 </code></pre></div>
         <p id="Example7-code">Code example:</p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+        <div class="wrapper"><pre><code class="language-java">
 // filtered violation below 'Name 'Example7' must match pattern'
 abstract class Example7 {
   public void MyMethod() {}
@@ -262,7 +262,7 @@ abstract class AnotherClass {
         <p id="Example8-config">
           Suppress checks for MyMethod1 or MyMethod2 methods:
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
+        <div class="wrapper"><pre><code class="language-xml">
 &lt;module name="Checker"&gt;
   &lt;module name="TreeWalker"&gt;
     &lt;module name="MethodName"/&gt;
@@ -275,7 +275,7 @@ abstract class AnotherClass {
 &lt;/module&gt;
 </code></pre></div>
         <p id="Example8-code">Code example:</p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+        <div class="wrapper"><pre><code class="language-java">
 class Example8 {
   // filtered violation below 'Name 'MyMethod1' must match pattern'
   public void MyMethod1() {}
@@ -289,7 +289,7 @@ class Example8 {
           Suppress checks for variable testVariable1 inside
           testMethod method inside Example9 class:
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
+        <div class="wrapper"><pre><code class="language-xml">
 &lt;module name="Checker"&gt;
   &lt;module name="TreeWalker"&gt;
     &lt;module name="LocalFinalVariableName"&gt;
@@ -305,7 +305,7 @@ class Example8 {
 &lt;/module&gt;
 </code></pre></div>
         <p id="Example9-code">Code Example:</p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+        <div class="wrapper"><pre><code class="language-java">
 public class Example9 {
   public void testMethod() {
     // filtered violation below 'Name 'testVariable1' must match pattern'
@@ -320,7 +320,7 @@ public class Example9 {
           will be suppressed for methods with name testMethod1 inside
           Example10 file.
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
+        <div class="wrapper"><pre><code class="language-xml">
 &lt;module name="Checker"&gt;
   &lt;module name="TreeWalker"&gt;
     &lt;module name="LeftCurly"/&gt;
@@ -333,7 +333,7 @@ public class Example9 {
 &lt;/module&gt;
 </code></pre></div>
         <p id="Example10-code">Code Example:</p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+        <div class="wrapper"><pre><code class="language-java">
 public class Example10 {
   public void testMethod1()
   { // filtered violation ''{' at column 3 should be on the previous line.'
@@ -348,7 +348,7 @@ public class Example10 {
           The following example demonstrates how to suppress
           RequireThis violations for variable age inside changeAge method.
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
+        <div class="wrapper"><pre><code class="language-xml">
 &lt;module name="Checker"&gt;
   &lt;module name="TreeWalker"&gt;
     &lt;module name="RequireThis"&gt;
@@ -363,7 +363,7 @@ public class Example10 {
 &lt;/module&gt;
 </code></pre></div>
         <p id="Example11-code">Code Example:</p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+        <div class="wrapper"><pre><code class="language-java">
 public class Example11 {
   private int age = 23;
   private int number = 100;
@@ -386,7 +386,7 @@ public class Example11 {
           <code>METHOD_DEF</code> and name <i>throwsMethod</i>. Please read more about xpath axes at
           <a href="https://www.w3schools.com/xml/xpath_axes.asp">W3Schools Xpath Axes</a>.
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
+        <div class="wrapper"><pre><code class="language-xml">
 &lt;module name="Checker"&gt;
   &lt;module name="TreeWalker"&gt;
     &lt;module name="IllegalThrows"/&gt;
@@ -399,7 +399,7 @@ public class Example11 {
 &lt;/module&gt;
 </code></pre></div>
         <p id="Example12-code">Code Example:</p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+        <div class="wrapper"><pre><code class="language-java">
 public class Example12 {
   // filtered violation below 'Throwing 'RuntimeException' is not allowed.'
   public void throwsMethod() throws RuntimeException {
@@ -417,7 +417,7 @@ public class Example12 {
           Please read more about xpath syntax at
           <a href="https://www.w3schools.com/xml/xpath_syntax.asp">W3Schools Xpath Syntax</a>.
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
+        <div class="wrapper"><pre><code class="language-xml">
 &lt;module name="Checker"&gt;
   &lt;module name="TreeWalker"&gt;
     &lt;module name="LocalFinalVariableName"&gt;
@@ -435,7 +435,7 @@ public class Example12 {
 &lt;/module&gt;
 </code></pre></div>
         <p id="Example13-code">Code Example:</p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+        <div class="wrapper"><pre><code class="language-java">
 public class Example13 {
   // filtered violation below 'Name 'TestMethod1' must match pattern'
   public void TestMethod1() {
@@ -456,7 +456,7 @@ public class Example13 {
           Please find more information at:
           <a href="https://github.com/spring-io/spring-javaformat">spring-javaformat</a>
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
+        <div class="wrapper"><pre><code class="language-xml">
 &lt;module name="Checker"&gt;
   &lt;module name="TreeWalker"&gt;
     &lt;module name="IllegalIdentifierName"&gt;
@@ -479,7 +479,7 @@ public class Example13 {
 &lt;/module&gt;
 </code></pre></div>
         <p id="Example14-code">Code Example:</p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+        <div class="wrapper"><pre><code class="language-java">
 .../src/myApplication.java // violation, Name 'myApplication' must match pattern.
 .../src/myApplicationTests.java // filtered violation 'must match pattern'
 .../src/test/java/insidePackage.java // filtered violation 'must match pattern'

--- a/src/site/xdoc/filters/suppresswarningsfilter.xml
+++ b/src/site/xdoc/filters/suppresswarningsfilter.xml
@@ -42,7 +42,7 @@
       </subsection>
       <subsection name="Examples" id="Examples">
         <p id="Example1-config">Example of suppression by name of Check in annotation:</p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
+        <div class="wrapper"><pre><code class="language-xml">
 &lt;module name="Checker"&gt;
   &lt;module name="TreeWalker"&gt;
     &lt;module name="SuppressWarningsHolder" /&gt;
@@ -53,7 +53,7 @@
 &lt;/module&gt;
 </code></pre></div>
         <p id="Example1-code">Java code:</p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+        <div class="wrapper"><pre><code class="language-java">
 public class Example1 {
   @SuppressWarnings("memberName")
   int J; // ok only because there is annotation
@@ -75,7 +75,7 @@ public class Example1 {
           you want to suppress.
         </p>
         <p id="Example2-config">Example of suppression by prefix &quot;checkstyle:&quot;:</p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
+        <div class="wrapper"><pre><code class="language-xml">
 &lt;module name="Checker"&gt;
   &lt;module name="TreeWalker"&gt;
     &lt;module name="SuppressWarningsHolder" /&gt;
@@ -90,7 +90,7 @@ public class Example1 {
 &lt;/module&gt;
 </code></pre></div>
         <p id="Example2-code">Java code:</p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+        <div class="wrapper"><pre><code class="language-java">
 package com.puppycrawl.tools.checkstyle.filters.suppresswarningsfilter;
 
 public class Example2 {

--- a/src/site/xdoc/filters/suppresswithnearbycommentfilter.xml
+++ b/src/site/xdoc/filters/suppresswithnearbycommentfilter.xml
@@ -103,7 +103,7 @@
           To configure a filter to suppress audit events for <i>check</i>
           on any line with a comment <code>SUPPRESS CHECKSTYLE <i>check</i></code>:
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
+        <div class="wrapper"><pre><code class="language-xml">
 &lt;module name="Checker"&gt;
   &lt;module name="TreeWalker"&gt;
     &lt;module name="SuppressWithNearbyCommentFilter"/&gt;
@@ -112,7 +112,7 @@
 &lt;/module&gt;
 </code></pre></div>
         <p id="Example1-code">Example:</p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+        <div class="wrapper"><pre><code class="language-java">
 public class Example1 {
   private int [] array; // SUPPRESS CHECKSTYLE NoWhitespaceAfter
 }
@@ -121,7 +121,7 @@ public class Example1 {
           To configure a filter to suppress all audit events on any line
           containing the comment <code>CHECKSTYLE IGNORE THIS LINE</code>:
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
+        <div class="wrapper"><pre><code class="language-xml">
 &lt;module name="Checker"&gt;
   &lt;module name="TreeWalker"&gt;
     &lt;module name="SuppressWithNearbyCommentFilter"&gt;
@@ -134,7 +134,7 @@ public class Example1 {
 &lt;/module&gt;
 </code></pre></div>
         <p id="Example2-code">Example:</p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+        <div class="wrapper"><pre><code class="language-java">
 public class Example2 {
   public static final int lowerCaseConstant = 1; // CHECKSTYLE IGNORE THIS LINE
 }
@@ -145,7 +145,7 @@ public class Example2 {
           permits the current and previous line to avoid generating an IllegalCatch
           audit event:
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
+        <div class="wrapper"><pre><code class="language-xml">
 &lt;module name="Checker"&gt;
   &lt;module name="TreeWalker"&gt;
     &lt;module name="SuppressWithNearbyCommentFilter"&gt;
@@ -159,7 +159,7 @@ public class Example2 {
 &lt;/module&gt;
 </code></pre></div>
         <p id="Example3-code">Example:</p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+        <div class="wrapper"><pre><code class="language-java">
 public class Example3 {
   public void doStuff() {
     try {
@@ -177,7 +177,7 @@ public class Example3 {
           avoids triggering any audits for the given check for
           the current line and the next <i>var</i> lines (for a total of <i>var</i>+1 lines):
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
+        <div class="wrapper"><pre><code class="language-xml">
 &lt;module name="Checker"&gt;
   &lt;module name="TreeWalker"&gt;
     &lt;module name="SuppressWithNearbyCommentFilter"&gt;
@@ -191,7 +191,7 @@ public class Example3 {
 &lt;/module&gt;
 </code></pre></div>
         <p id="Example4-code">Example:</p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+        <div class="wrapper"><pre><code class="language-java">
 public class Example4 {
   // CHECKSTYLE IGNORE ConstantNameCheck FOR NEXT 4 LINES
   static final int lowerCaseConstant1 = 1;
@@ -204,7 +204,7 @@ public class Example4 {
         <p id="Example5-config">
           To configure a filter to avoid any audits on code like:
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
+        <div class="wrapper"><pre><code class="language-xml">
 &lt;module name="Checker"&gt;
   &lt;module name="TreeWalker"&gt;
     &lt;module name="SuppressWithNearbyCommentFilter"&gt;
@@ -217,7 +217,7 @@ public class Example4 {
 &lt;/module&gt;
 </code></pre></div>
         <p id="Example5-code">Example:</p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+        <div class="wrapper"><pre><code class="language-java">
 public class Example5 {
   private int D2;
   // ALLOW MemberName ON PREVIOUS LINE
@@ -228,7 +228,7 @@ public class Example5 {
           To configure a filter to allow suppress one or more Checks
           (separated by &quot;|&quot;) and demand comment no less than 14 symbols:
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
+        <div class="wrapper"><pre><code class="language-xml">
 &lt;module name="Checker"&gt;
   &lt;module name="TreeWalker"&gt;
     &lt;module name="SuppressWithNearbyCommentFilter"&gt;
@@ -243,7 +243,7 @@ public class Example5 {
 &lt;/module&gt;
 </code></pre></div>
         <p id="Example6-code">Example:</p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+        <div class="wrapper"><pre><code class="language-java">
 public class Example6 {
   // @cs.suppress [ConstantName|NoWhitespaceAfter] A comment here
   public static final int [] array = {};
@@ -262,7 +262,7 @@ public class Example6 {
           is set to '$1' points that ID of the checks is in the first group of
           commentFormat regular expressions):
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
+        <div class="wrapper"><pre><code class="language-xml">
 &lt;module name="Checker"&gt;
   &lt;module name="TreeWalker"&gt;
     &lt;module name="SuppressWithNearbyCommentFilter"&gt;
@@ -285,7 +285,7 @@ public class Example6 {
 &lt;/module&gt;
 </code></pre></div>
         <p id="Example7-code">Example:</p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+        <div class="wrapper"><pre><code class="language-java">
 public class Example7 {
   @Ignore // @cs-: ignore (test has not been implemented yet)
   @Test
@@ -301,7 +301,7 @@ public class Example7 {
           Example of how to configure the check to suppress more than one checks.
           The influence format is specified in the second regexp group.
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
+        <div class="wrapper"><pre><code class="language-xml">
 &lt;module name="Checker"&gt;
   &lt;module name="TreeWalker"&gt;
     &lt;module name="SuppressWithNearbyCommentFilter"&gt;
@@ -317,7 +317,7 @@ public class Example7 {
 &lt;/module&gt;
 </code></pre></div>
         <p id="Example8-code">Example:</p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+        <div class="wrapper"><pre><code class="language-java">
 // @cs-: ClassDataAbstractionCoupling influence 2
 // @cs-: MagicNumber influence 4
 public class Example8 { // no violations from ClassDataAbstractionCoupling here

--- a/src/site/xdoc/filters/suppresswithnearbytextfilter.xml
+++ b/src/site/xdoc/filters/suppresswithnearbytextfilter.xml
@@ -75,7 +75,7 @@
         <p id="Example1-config">
           To configure the filter to suppress audit events on the same line:
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
+        <div class="wrapper"><pre><code class="language-xml">
 &lt;module name="Checker"&gt;
   &lt;module name="SuppressWithNearbyTextFilter"/&gt;
   &lt;module name="TreeWalker"&gt;
@@ -86,7 +86,7 @@
         <p id="Example1-code">
           Example:
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+        <div class="wrapper"><pre><code class="language-java">
 public class Example1 {
   int hoursInDay = 24; // SUPPRESS CHECKSTYLE because it is too obvious
   int daysInWeek = 7; // violation, "'7' is a magic number."
@@ -96,7 +96,7 @@ public class Example1 {
           To configure the filter to suppress audit events on any line that contains
           <code>DO NOT CHECK THIS LINE</code>:
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
+        <div class="wrapper"><pre><code class="language-xml">
 &lt;module name="Checker"&gt;
   &lt;module name="SuppressWithNearbyTextFilter"&gt;
     &lt;property name="nearbyTextPattern" value="DO NOT CHECK THIS LINE"/&gt;
@@ -109,7 +109,7 @@ public class Example1 {
         <p id="Example2-code">
           Example:
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+        <div class="wrapper"><pre><code class="language-java">
 public class Example2 {
   int a = 42; // DO NOT CHECK THIS LINE
   int b = 43; // violation, "'43' is a magic number."
@@ -120,7 +120,7 @@ public class Example2 {
             the word <code>Line</code>. In this case, <code>LineLengthCheck</code>'s violation
             message contains it:
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
+        <div class="wrapper"><pre><code class="language-xml">
 &lt;module name="Checker"&gt;
   &lt;module name="SuppressWithNearbyTextFilter"&gt;
     &lt;property name="messagePattern" value=".*Line.*"/&gt;
@@ -134,7 +134,7 @@ public class Example2 {
         <p id="Example3-code">
           Example:
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+        <div class="wrapper"><pre><code class="language-java">
 public class Example3 {
   // ok, because violation message is matching suppress pattern
   int a_really_long_variable_name = 10;
@@ -144,7 +144,7 @@ public class Example3 {
           To configure the filter to suppress audit events only on a check whose id is
           <code>ignoreMe</code>:
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
+        <div class="wrapper"><pre><code class="language-xml">
 &lt;module name="Checker"&gt;
   &lt;module name="SuppressWithNearbyTextFilter"&gt;
     &lt;property name="idPattern" value="ignoreMe"/&gt;
@@ -162,7 +162,7 @@ public class Example3 {
         <p id="Example4-code">
           Example:
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+        <div class="wrapper"><pre><code class="language-java">
 public class Example4 {
   int a = 42; // SUPPRESS CHECKSTYLE because I want to
   static final int LONG_VAR_NAME_TO_TAKE_MORE_THAN_55_CHARS = 22;
@@ -172,7 +172,7 @@ public class Example4 {
         <p id="Example5-config">
           To configure the filter to suppress audit events for the current and next 2 lines:
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
+        <div class="wrapper"><pre><code class="language-xml">
 &lt;module name="Checker"&gt;
   &lt;module name="SuppressWithNearbyTextFilter"&gt;
     &lt;property name="lineRange" value="2"/&gt;
@@ -183,7 +183,7 @@ public class Example4 {
         <p id="Example5-raw">
           Example:
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+        <div class="wrapper"><pre><code class="language-java">
 key.one=41 # // SUPPRESS CHECKSTYLE because I want to
 key.one=42 # ok as within line range
 key.one=43 # ok as within line range
@@ -193,7 +193,7 @@ key.two=45
         <p id="Example6-config">
           To configure the filter to suppress audit events for the current and previous line:
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
+        <div class="wrapper"><pre><code class="language-xml">
 &lt;module name="Checker"&gt;
   &lt;module name="SuppressWithNearbyTextFilter"&gt;
     &lt;property name="lineRange" value="-1"/&gt;
@@ -204,7 +204,7 @@ key.two=45
         <p id="Example6-raw">
           Example:
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+        <div class="wrapper"><pre><code class="language-java">
 key.one=41 # ok as within line range
 key.one=42 # SUPPRESS CHECKSTYLE because I want to
 key.two=43 # // violation 'Duplicated property 'key.two' (2 occurrence(s)).'
@@ -214,7 +214,7 @@ key.two=44
           To configure the filter with a more compact <code>nearbyTextPattern</code>
           to accept variable <code>checkPattern</code>:
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
+        <div class="wrapper"><pre><code class="language-xml">
 &lt;module name="Checker"&gt;
   &lt;module name="SuppressWithNearbyTextFilter"&gt;
     &lt;property name="nearbyTextPattern"
@@ -229,7 +229,7 @@ key.two=44
         <p id="Example7-code">
           Example:
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+        <div class="wrapper"><pre><code class="language-java">
 public class Example7 {
   int a = 42; // -@cs[MagicNumber] We do not consider this number as magic.
   int b = 43; // violation "'43' is a magic number."
@@ -239,7 +239,7 @@ public class Example7 {
           To configure the filter to accept variable <code>checkPattern</code>
           and <code>lineRange</code>:
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
+        <div class="wrapper"><pre><code class="language-xml">
 &lt;module name="Checker"&gt;
   &lt;module name="SuppressWithNearbyTextFilter"&gt;
     &lt;property name="nearbyTextPattern"
@@ -255,7 +255,7 @@ public class Example7 {
         <p id="Example8-code">
           Example:
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+        <div class="wrapper"><pre><code class="language-java">
 public class Example8 {
   int a = 42; // @cs-: MagicNumber for +3 lines
   int b = 43;
@@ -268,7 +268,7 @@ public class Example8 {
           To configure the filter to suppress <code>LineLength</code>
           violations for lines containing a URL:
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
+        <div class="wrapper"><pre><code class="language-xml">
 &lt;module name="Checker"&gt;
   &lt;module name="SuppressWithNearbyTextFilter"&gt;
     &lt;property name="checkPattern" value="LineLength"/&gt;
@@ -283,7 +283,7 @@ public class Example8 {
         <p id="Example9-code">
           Example:
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+        <div class="wrapper"><pre><code class="language-java">
 public class Example9 {
   /**
    * Flag description.

--- a/src/site/xdoc/filters/suppresswithplaintextcommentfilter.xml
+++ b/src/site/xdoc/filters/suppresswithplaintextcommentfilter.xml
@@ -104,7 +104,7 @@
           <code>// CHECKSTYLE:ON</code> (the default comments).
           Checker is configured to check only properties files using UniqueProperties check:
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
+        <div class="wrapper"><pre><code class="language-xml">
 &lt;module name="Checker"&gt;
   &lt;property name="fileExtensions" value="properties"/&gt;
 
@@ -114,7 +114,7 @@
 &lt;/module&gt;
 </code></pre></div>
         <p id="Example1-raw">Example:</p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+        <div class="wrapper"><pre><code class="language-java">
 # // CHECKSTYLE:OFF
 # suppressed violation below
 keyB=value1
@@ -130,7 +130,7 @@ keyC=value5
           containing <code>RESUME CHECK</code>.
           Checker is configured to check only properties files using UniqueProperties check:
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
+        <div class="wrapper"><pre><code class="language-xml">
 &lt;module name="Checker"&gt;
   &lt;property name="fileExtensions" value="properties"/&gt;
 
@@ -144,7 +144,7 @@ keyC=value5
 &lt;/module&gt;
 </code></pre></div>
         <p id="Example2-raw">Example:</p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+        <div class="wrapper"><pre><code class="language-java">
 # STOP CHECK
 # suppressed violation below
 keyB=value1
@@ -161,7 +161,7 @@ keyC=value5
           Checker is configured to check only properties files using both UniqueProperties check
           and OrderedProperties check:
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
+        <div class="wrapper"><pre><code class="language-xml">
 &lt;module name="Checker"&gt;
   &lt;property name="fileExtensions" value="properties"/&gt;
 
@@ -177,7 +177,7 @@ keyC=value5
 &lt;/module&gt;
 </code></pre></div>
         <p id="Example3-raw">Example:</p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+        <div class="wrapper"><pre><code class="language-java">
 # STOP UNIQUE CHECK
 # (OrderedProperties check is still enabled)
 # suppressed violation below
@@ -196,7 +196,7 @@ keyC=value5
           Checker is configured to check only XML files using RegexpSingleline check to detect
           disallowed 'code' values for the 'type' parameter:
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
+        <div class="wrapper"><pre><code class="language-xml">
 &lt;module name="Checker"&gt;
   &lt;property name="fileExtensions" value="xml"/&gt;
 
@@ -216,7 +216,7 @@ keyC=value5
 &lt;/module&gt;
 </code></pre></div>
         <p id="Example4-raw">Example:</p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+        <div class="wrapper"><pre><code class="language-java">
 &lt;project&gt;
   &lt;p&gt;Examples:&lt;/p&gt;
 &lt;!-- CSOFF: RegexpSinglelineCheck --&gt;
@@ -242,7 +242,7 @@ keyC=value5
           Checker is configured to check only XML files using RegexpSingleline check to detect
           disallowed 'code' values for the 'type' parameter:
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
+        <div class="wrapper"><pre><code class="language-xml">
 &lt;module name="Checker"&gt;
   &lt;property name="fileExtensions" value="xml"/&gt;
 
@@ -262,7 +262,7 @@ keyC=value5
 &lt;/module&gt;
 </code></pre></div>
         <p id="Example5-raw">Example:</p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+        <div class="wrapper"><pre><code class="language-java">
 &lt;project&gt;
   &lt;p&gt;Examples:&lt;/p&gt;
 &lt;!-- CSOFF: ALMOST_ALL --&gt;
@@ -290,7 +290,7 @@ keyC=value5
           Checker is configured to check only XML files using RegexpSingleline check to detect
           disallowed 'code' and 'config' values for the 'type' parameter:
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
+        <div class="wrapper"><pre><code class="language-xml">
 &lt;module name="Checker"&gt;
   &lt;property name="fileExtensions" value="xml"/&gt;
 
@@ -317,7 +317,7 @@ keyC=value5
 &lt;/module&gt;
 </code></pre></div>
         <p id="Example6-raw">Example:</p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+        <div class="wrapper"><pre><code class="language-java">
 &lt;project&gt;
   &lt;p&gt;Examples:&lt;/p&gt;
 &lt;!-- CSOFF --&gt;
@@ -350,7 +350,7 @@ keyC=value5
           Checker is configured to check only XML files using RegexpSingleline check to detect
           disallowed 'code' and 'config' values for the 'type' parameter:
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
+        <div class="wrapper"><pre><code class="language-xml">
 &lt;module name="Checker"&gt;
   &lt;property name="fileExtensions" value="xml"/&gt;
 
@@ -378,7 +378,7 @@ keyC=value5
 &lt;/module&gt;
 </code></pre></div>
         <p id="Example7-raw">Example:</p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+        <div class="wrapper"><pre><code class="language-java">
 &lt;project&gt;
   &lt;p&gt;Examples:&lt;/p&gt;
 &lt;!-- CSOFF typeCode (OK to use examples of type code here) --&gt;
@@ -402,7 +402,7 @@ keyC=value5
           usage of JOIN operations and LineLength check to detect lines exceeding 60
           characters:
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
+        <div class="wrapper"><pre><code class="language-xml">
 &lt;module name="Checker"&gt;
   &lt;property name="fileExtensions" value="sql"/&gt;
 
@@ -424,7 +424,7 @@ keyC=value5
 &lt;/module&gt;
 </code></pre></div>
         <p id="Example8-raw">Example:</p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+        <div class="wrapper"><pre><code class="language-java">
 -- CSOFF: RegexpSinglelineCheck
 -- CSOFF: LineLengthCheck
 SELECT name, job_name
@@ -442,7 +442,7 @@ WHERE u.registration_date &gt;= '2023-01-01' AND u.status = 'active';
           Checker is configured to use LineLength check to detect lines exceeding the maximum
           length of 100 characters:
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
+        <div class="wrapper"><pre><code class="language-xml">
 &lt;module name="Checker"&gt;
   &lt;module name="LineLength"&gt;
       &lt;property name="max" value="100"/&gt;
@@ -456,7 +456,7 @@ WHERE u.registration_date &gt;= '2023-01-01' AND u.status = 'active';
 &lt;/module&gt;
 </code></pre></div>
         <p id="Example9-code">Example:</p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+        <div class="wrapper"><pre><code class="language-java">
 public class Example9 {
 
   // suppressed violation below, opening/closing quotes are 'offCommentFormat' and 'onCommentFormat'

--- a/src/site/xdoc/property_types.xml
+++ b/src/site/xdoc/property_types.xml
@@ -95,11 +95,11 @@
         is equivalent to a set of comma separated integers. For example, the
         following:
       </p>
-      <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
+      <div class="wrapper"><pre><code class="language-xml">
 &lt;property name=&quot;tokens&quot; value=&quot;0.42,0.666&quot;/&gt;
       </code></pre></div>
       <p>can instead be expressed as:</p>
-      <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
+      <div class="wrapper"><pre><code class="language-xml">
 &lt;property name=&quot;tokens&quot; value=&quot;0.42&quot;/&gt;
 &lt;property name=&quot;tokens&quot; value=&quot;0.666&quot;/&gt;
       </code></pre></div>
@@ -142,11 +142,11 @@
         is equivalent to a set of comma separated integers. For example, the
         following:
       </p>
-      <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
+      <div class="wrapper"><pre><code class="language-xml">
 &lt;property name=&quot;tokens&quot; value=&quot;42,666&quot;/&gt;
       </code></pre></div>
       <p>can instead be expressed as:</p>
-      <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
+      <div class="wrapper"><pre><code class="language-xml">
 &lt;property name=&quot;tokens&quot; value=&quot;42&quot;/&gt;
 &lt;property name=&quot;tokens&quot; value=&quot;666&quot;/&gt;
       </code></pre></div>
@@ -684,11 +684,11 @@
         times which is equivalent to a set of comma separated patterns.
         For example, the following:
       </p>
-      <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
+      <div class="wrapper"><pre><code class="language-xml">
 &lt;property name=&quot;patterns&quot; value=&quot;^prefix*$, ^*suffix$&quot;/&gt;
       </code></pre></div>
       <p>can instead be expressed as:</p>
-      <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
+      <div class="wrapper"><pre><code class="language-xml">
 &lt;property name=&quot;patterns&quot; value=&quot;^prefix*&quot;/&gt;
 &lt;property name=&quot;patterns&quot; value=&quot;^*suffix$&quot;/&gt;
       </code></pre></div>
@@ -949,11 +949,11 @@
         is equivalent to a set of comma separated strings. For example, the
         following:
       </p>
-      <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
+      <div class="wrapper"><pre><code class="language-xml">
 &lt;property name=&quot;tokens&quot; value=&quot;DIV_ASSIGN, PLUS_ASSIGN&quot;/&gt;
       </code></pre></div>
       <p>can instead be expressed as:</p>
-      <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
+      <div class="wrapper"><pre><code class="language-xml">
 &lt;property name=&quot;tokens&quot; value=&quot;DIV_ASSIGN&quot;/&gt;
 &lt;property name=&quot;tokens&quot; value=&quot;PLUS_ASSIGN&quot;/&gt;
       </code></pre></div>

--- a/src/site/xdoc/releasenotes_old_1-0_5-9.xml
+++ b/src/site/xdoc/releasenotes_old_1-0_5-9.xml
@@ -721,7 +721,7 @@
         TreeWalker module anymore. For example, the following Checkstyle
         4.4 configuration file:
       </p>
-      <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
+      <div class="wrapper"><pre><code class="language-xml">
 &lt;module name=&quot;Checker&quot;&gt;
   &lt;module name=&quot;TreeWalker&quot;&gt;
     &lt;module name=&quot;Header&quot;&gt;
@@ -732,7 +732,7 @@
       </code></pre></div>
 
       <p>becomes the following Checkstyle 5.0 configuration file:</p>
-      <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
+      <div class="wrapper"><pre><code class="language-xml">
 &lt;module name=&quot;Checker&quot;&gt;
   &lt;module name=&quot;Header&quot;&gt;
     &lt;property name=&quot;headerFile&quot; value=&quot;${checkstyle.header.file}&quot;/&gt;

--- a/src/site/xdoc/report_issue.xml
+++ b/src/site/xdoc/report_issue.xml
@@ -66,7 +66,7 @@
         Example of report that we expect (you can skip <code>-Duser.language=en
         -Duser.country=US</code> if your default locale is English):
 
-        <div class="wrapper"><pre class="prettyprint"><code class="language-java"><![CDATA[
+        <div class="wrapper"><pre><code class="language-java"><![CDATA[
 Check documentation: https://checkstyle.org/checks/whitespace/whitespacearound.html#WhitespaceAround
 
 /var/tmp $ javac Test.java
@@ -103,7 +103,7 @@ Expected: violation on first line.
         For Windows users, please use "type" command instead of "cat".
         Example of report that we expect:
 
-        <div class="wrapper"><pre class="prettyprint"><code class="language-xml"><![CDATA[
+        <div class="wrapper"><pre><code class="language-xml"><![CDATA[
 Check documentation: https://checkstyle.org/checks/misc/indentation.html
 
 D:\>type config.xml
@@ -173,7 +173,7 @@ expected level should be 12. [Indentation]
       <p>
         Example of Feature Request/Enhancement that we expect:
       </p>
-      <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+      <div class="wrapper"><pre><code class="language-java">
 Check documentation: https://checkstyle.org/checks/whitespace/whitespacearound.html#WhitespaceAround
 
 Describe the problem in detail:
@@ -229,7 +229,7 @@ Additional context, screenshots or examples:
       <p>
         Example of Check/Module Request that we expect:
       </p>
-      <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
+      <div class="wrapper"><pre><code class="language-xml">
 Describe the problem in detail:
 
 /var/tmp $ cat config.xml

--- a/src/site/xdoc/writingchecks.xml
+++ b/src/site/xdoc/writingchecks.xml
@@ -119,7 +119,7 @@
         providing the java file.
       </p>
       <p>For example, take this MyClass.java file:</p>
-      <div class="wrapper"><pre class="prettyprint"><code class="language-java"><![CDATA[
+      <div class="wrapper"><pre><code class="language-java"><![CDATA[
 /**
  * My <b>class</b>.
  * @see AbstractClass
@@ -145,7 +145,7 @@ public class MyClass {
 
           <tr>
             <td>
-              <div class="wrapper"><pre class="prettyprint"><code class="language-java"><![CDATA[
+              <div class="wrapper"><pre><code class="language-java"><![CDATA[
 CLASS_DEF -> CLASS_DEF [5:0]
 |--MODIFIERS -> MODIFIERS [5:0]
 |   `--LITERAL_PUBLIC -> public [5:0]
@@ -158,7 +158,7 @@ CLASS_DEF -> CLASS_DEF [5:0]
               </code></pre></div>
             </td>
             <td>
-              <div class="wrapper"><pre class="prettyprint"><code class="language-java"><![CDATA[
+              <div class="wrapper"><pre><code class="language-java"><![CDATA[
 CLASS_DEF -> CLASS_DEF [5:0]
 |--MODIFIERS -> MODIFIERS [5:0]
 |   |--BLOCK_COMMENT_BEGIN -> /* [1:0]
@@ -190,7 +190,7 @@ CLASS_DEF -> CLASS_DEF [5:0]
         Run the gui with the command:
       </p>
       <div class="wrap-content">
-        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+        <div class="wrapper"><pre><code class="language-java">
           java -cp checkstyle-${projectVersion}-all.jar com.puppycrawl.tools.checkstyle.gui.Main
         </code></pre></div>
       </div>
@@ -344,7 +344,7 @@ CLASS_DEF -> CLASS_DEF [5:0]
         Check implementation:
       </p>
 
-      <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+      <div class="wrapper"><pre><code class="language-java">
 package com.mycompany.checks;
 import com.puppycrawl.tools.checkstyle.api.*;
 
@@ -515,7 +515,7 @@ public class MethodLimitCheck extends AbstractCheck
         to the Check:
       </p>
 
-      <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+      <div class="wrapper"><pre><code class="language-java">
 public class MethodLimitCheck extends AbstractCheck
 {
   // code from above omitted for brevity
@@ -599,7 +599,7 @@ public class MethodLimitCheck extends AbstractCheck
         Your configuration file <code>config.xml</code> should look something like this:
       </p>
 
-      <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
+      <div class="wrapper"><pre><code class="language-xml">
 &lt;?xml version=&quot;1.0&quot;?&gt;
 &lt;!DOCTYPE module PUBLIC
     &quot;-//Checkstyle//DTD Checkstyle Configuration 1.3//EN&quot;
@@ -629,7 +629,7 @@ public class MethodLimitCheck extends AbstractCheck
 
       <p>For Linux/Unix OS:</p>
       <div class="wrap-content">
-        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+        <div class="wrapper"><pre><code class="language-java">
           java -classpath mycompanychecks.jar:checkstyle-${projectVersion}-all.jar \
           &#xa0;&#xa0;&#xa0;&#xa0;com.puppycrawl.tools.checkstyle.Main -c config.xml myproject
         </code></pre></div>
@@ -637,7 +637,7 @@ public class MethodLimitCheck extends AbstractCheck
 
       <p>For Windows OS:</p>
       <div class="wrap-content">
-        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+        <div class="wrapper"><pre><code class="language-java">
           java -classpath mycompanychecks.jar;checkstyle-${projectVersion}-all.jar ^
           &#xa0;&#xa0;&#xa0;&#xa0;com.puppycrawl.tools.checkstyle.Main -c config.xml myproject
         </code></pre></div>
@@ -743,7 +743,7 @@ public class MethodLimitCheck extends AbstractCheck
         of files exceeds a certain limit. Here is a FileSetCheck that does just that:
       </p>
 
-      <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+      <div class="wrapper"><pre><code class="language-java">
 package com.mycompany.checks;
 import java.io.File;
 import java.util.List;

--- a/src/site/xdoc/writingfilefilters.xml
+++ b/src/site/xdoc/writingfilefilters.xml
@@ -54,7 +54,7 @@
         introspection to set JavaBean properties such as <code>files</code>.
       </p>
 
-      <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+      <div class="wrapper"><pre><code class="language-java">
 package com.mycompany.filefilters;
 
 import java.util.regex.Matcher;
@@ -103,7 +103,7 @@ public class FilesBeforeExecutionFileFilter
         include the following module in the configuration file:
       </p>
 
-      <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
+      <div class="wrapper"><pre><code class="language-xml">
 &lt;module name=&quot;com.mycompany.filters.FilesBeforeExecutionFileFilter&quot;&gt;
   &lt;property name=&quot;files&quot; value=&quot;Generated&quot;/&gt;
 &lt;/module&gt;

--- a/src/site/xdoc/writingfilters.xml
+++ b/src/site/xdoc/writingfilters.xml
@@ -59,7 +59,7 @@
         introspection to set JavaBean properties such as <code>files</code>.
       </p>
 
-      <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+      <div class="wrapper"><pre><code class="language-java">
 package com.mycompany.filters;
 
 import java.util.regex.Matcher;
@@ -117,7 +117,7 @@ public class FilesFilter
         include the following module in the configuration file:
       </p>
 
-      <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
+      <div class="wrapper"><pre><code class="language-xml">
 &lt;module name=&quot;com.mycompany.filters.FilesFilter&quot;&gt;
   &lt;property name=&quot;files&quot; value=&quot;Generated&quot;/&gt;
 &lt;/module&gt;

--- a/src/site/xdoc/writingjavadocchecks.xml.vm
+++ b/src/site/xdoc/writingjavadocchecks.xml.vm
@@ -36,7 +36,7 @@
         (ignoring leading asterisks, white space, and leading separator <code>/**</code>).
       </p>
       <p>For example, here is java file:</p>
-      <div class="wrapper"><pre class="prettyprint"><code class="language-java"><![CDATA[
+      <div class="wrapper"><pre><code class="language-java"><![CDATA[
 /**
  * My <b>class</b>.
  *
@@ -67,13 +67,13 @@ public class MyClass {
 }
       ]]></code></pre></div>
       <p>Javadoc content for the MyClass will be:</p>
-      <div class="wrapper"><pre class="prettyprint"><code class="language-java"><![CDATA[
+      <div class="wrapper"><pre><code class="language-java"><![CDATA[
     My <b>class</b>.
 
     @see Annotation
       ]]></code></pre></div>
       <p>Javadoc content for the MyClass.method will be:</p>
-      <div class="wrapper"><pre class="prettyprint"><code class="language-java"><![CDATA[
+      <div class="wrapper"><pre><code class="language-java"><![CDATA[
     Doubles the value.
     The long and detailed explanation what the method does.
 
@@ -221,7 +221,7 @@ public class MyClass {
       checkstyle jar file with the <b>-J</b> argument, providing a java file.
       </p>
       <p>For example, here is MyClass.java file:</p>
-      <div class="wrapper"><pre class="prettyprint"><code class="language-java"><![CDATA[
+      <div class="wrapper"><pre><code class="language-java"><![CDATA[
 /**
  * My <b>class</b>.
  * @see AbstractClass
@@ -232,12 +232,12 @@ public class MyClass {
       ]]></code></pre></div>
       <p>Command:</p>
       <div class="wrap-content">
-        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+        <div class="wrapper"><pre><code class="language-java">
           java -jar checkstyle-X.XX-all.jar -J MyClass.java
         </code></pre></div>
       </div>
       <p>Output:</p>
-      <div class="wrapper"><pre class="prettyprint"><code class="language-java"><![CDATA[
+      <div class="wrapper"><pre><code class="language-java"><![CDATA[
 CLASS_DEF -> CLASS_DEF [5:0]
 |--MODIFIERS -> MODIFIERS [5:0]
 |   |--BLOCK_COMMENT_BEGIN -> /* [1:0]
@@ -285,19 +285,19 @@ CLASS_DEF -> CLASS_DEF [5:0]
         <b>-j</b> argument.
       </p>
       <p>MyJavadocComment.javadoc file:</p>
-      <div class="wrapper"><pre class="prettyprint"><code class="language-java"><![CDATA[
+      <div class="wrapper"><pre><code class="language-java"><![CDATA[
  * My <b>class</b>.
  * @see AbstractClass
       ]]></code></pre></div>
       <p>Command:</p>
       <div class="wrap-content">
-        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+        <div class="wrapper"><pre><code class="language-java">
           java -jar checkstyle-X.XX-all.jar \
           &#xa0;&#xa0;&#xa0;&#xa0;-j MyJavadocComment.javadoc
         </code></pre></div>
       </div>
       <p>Output:</p>
-      <div class="wrapper"><pre class="prettyprint"><code class="language-java"><![CDATA[
+      <div class="wrapper"><pre><code class="language-java"><![CDATA[
 JAVADOC -> JAVADOC [0:0]
 |--LEADING_ASTERISK ->  * [0:0]
 |--TEXT ->  My  [0:2]
@@ -347,7 +347,7 @@ JAVADOC -> JAVADOC [0:0]
       <p>
         Example:
       </p>
-      <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+      <div class="wrapper"><pre><code class="language-java">
 class MyCheck extends AbstractJavadocCheck {
 
     @Override
@@ -415,11 +415,11 @@ class MyCheck extends AbstractJavadocCheck {
         Always follow <a href="#Tight-HTML_rules">Tight-HTML rules</a> to make the
         Checkstyle javadoc parser create nested ASTs, even though tags are unknown.
 
-        <div class="wrapper"><pre class="prettyprint"><code class="language-xml"><![CDATA[
+        <div class="wrapper"><pre><code class="language-xml"><![CDATA[
 <audio><source src="horse.ogg" type="audio/ogg"/></audio>
         ]]></code></pre></div>
 
-        <div class="wrapper"><pre class="prettyprint"><code class="language-java"><![CDATA[
+        <div class="wrapper"><pre><code class="language-java"><![CDATA[
 JAVADOC -> JAVADOC [0:0]
 |--HTML_ELEMENT -> HTML_ELEMENT [0:0]
 |   `--HTML_TAG -> HTML_TAG [0:0]
@@ -456,13 +456,13 @@ JAVADOC -> JAVADOC [0:0]
         This is an example of parsing an unknown tag that doesn't have a matching end tag (for
         example, HTML5 tag &lt;audio&gt;): <br/>
         Input:
-        <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
+        <div class="wrapper"><pre><code class="language-xml">
         &lt;audio&gt;test
         </code></pre></div>
         Output:
       </p>
       <div class="wrap-content">
-        <div class="wrapper"><pre class="prettyprint"><code class="language-text">
+        <div class="wrapper"><pre><code class="language-text">
           [ERROR:0] Javadoc comment at column 1 has parse error. Missed HTML close tag 'audio'.
           Sometimes it means that close tag missed for one of previous tags.
         </code></pre></div>
@@ -482,13 +482,13 @@ JAVADOC -> JAVADOC [0:0]
         Example:
         <br/>
         Input:
-        <div class="wrapper"><pre class="prettyprint"><code class="language-xml"><![CDATA[
+        <div class="wrapper"><pre><code class="language-xml"><![CDATA[
 <acronym title="as soon as possible">ASAP</acronym>
 ]]>
         </code></pre></div>
         <br/>
         Output:
-        <div class="wrapper"><pre class="prettyprint"><code class="language-java"><![CDATA[
+        <div class="wrapper"><pre><code class="language-java"><![CDATA[
 JAVADOC -> JAVADOC [0:0]
 |--HTML_ELEMENT -> HTML_ELEMENT [0:0]
 |   `--HTML_TAG -> HTML_TAG [0:0]
@@ -531,14 +531,14 @@ JAVADOC -> JAVADOC [0:0]
 
           <tr>
             <td>
-              <div class="wrapper"><pre class="prettyprint"><code class="language-java"><![CDATA[
+              <div class="wrapper"><pre><code class="language-java"><![CDATA[
 <p> First
 <p> Second
 ]]>
               </code></pre></div>
             </td>
             <td>
-              <div class="wrapper"><pre class="prettyprint"><code class="language-java"><![CDATA[
+              <div class="wrapper"><pre><code class="language-java"><![CDATA[
 <p> First </p>
 <p> Second </p>
 ]]>
@@ -548,7 +548,7 @@ JAVADOC -> JAVADOC [0:0]
 
           <tr>
             <td>
-              <div class="wrapper"><pre class="prettyprint"><code class="language-java"><![CDATA[
+              <div class="wrapper"><pre><code class="language-java"><![CDATA[
 JAVADOC -> JAVADOC [0:0]
 |--HTML_ELEMENT -> HTML_ELEMENT [0:0]
 |   `--P_TAG_START -> P_TAG_START [0:0]
@@ -568,7 +568,7 @@ JAVADOC -> JAVADOC [0:0]
               </code></pre></div>
             </td>
             <td>
-              <div class="wrapper"><pre class="prettyprint"><code class="language-java"><![CDATA[
+              <div class="wrapper"><pre><code class="language-java"><![CDATA[
 JAVADOC -> JAVADOC [0:0]
 |--HTML_ELEMENT -> HTML_ELEMENT [0:0]
 |   `--PARAGRAPH -> PARAGRAPH [0:0]
@@ -618,7 +618,7 @@ JAVADOC -> JAVADOC [0:0]
         Input:
       </p>
 
-      <div class="wrapper"><pre class="prettyprint"><code class="language-text"><![CDATA[
+      <div class="wrapper"><pre><code class="language-text"><![CDATA[
 /**
   * <body>
   * <p> This class is only meant for testing. </p>
@@ -661,7 +661,7 @@ JAVADOC -> JAVADOC [0:0]
         <table>
           <tr>
             <td>
-              <div class="wrapper"><pre class="prettyprint"><code class="language-xml"><![CDATA[
+              <div class="wrapper"><pre><code class="language-xml"><![CDATA[
 <!DOCTYPE module PUBLIC
           "-//Checkstyle//DTD Checkstyle Configuration 1.3//EN"
           "https://checkstyle.org/dtds/configuration_1_3.dtd">
@@ -676,7 +676,7 @@ JAVADOC -> JAVADOC [0:0]
             </td>
 
             <td>
-              <div class="wrapper"><pre class="prettyprint"><code class="language-xml"><![CDATA[
+              <div class="wrapper"><pre><code class="language-xml"><![CDATA[
 Starting audit...
 [ERROR] Test.java:11: Redundant <p> tag. [JavadocParagraph]
 Audit done.
@@ -695,7 +695,7 @@ Checkstyle ends with 1 errors.
         <table>
           <tr>
             <td>
-              <div class="wrapper"><pre class="prettyprint"><code class="language-xml"><![CDATA[
+              <div class="wrapper"><pre><code class="language-xml"><![CDATA[
 <!DOCTYPE module PUBLIC
           "-//Checkstyle//DTD Checkstyle Configuration 1.3//EN"
           "https://checkstyle.org/dtds/configuration_1_3.dtd">
@@ -710,7 +710,7 @@ Checkstyle ends with 1 errors.
             </td>
 
             <td>
-              <div class="wrapper"><pre class="prettyprint"><code class="language-xml"><![CDATA[
+              <div class="wrapper"><pre><code class="language-xml"><![CDATA[
 Starting audit...
 [ERROR] Test.java:4: Unclosed HTML tag found: p [JavadocParagraph]
 [ERROR] Test.java:11: Redundant <p> tag. [JavadocParagraph]
@@ -732,7 +732,7 @@ Checkstyle ends with 5 errors.
        use
       </p>
       <div class="wrap-content">
-        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+        <div class="wrapper"><pre><code class="language-java">
           java -cp checkstyle-${projectVersion}-all.jar com.puppycrawl.tools.checkstyle.gui.Main
         </code></pre></div>
       </div>

--- a/src/site/xdoc/writinglisteners.xml.vm
+++ b/src/site/xdoc/writinglisteners.xml.vm
@@ -91,7 +91,7 @@
         <code>setFile(String)</code>.
       </p>
 
-      <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+      <div class="wrapper"><pre><code class="language-java">
 package com.mycompany.listeners;
 
 import java.io.FileNotFoundException;
@@ -205,7 +205,7 @@ public class VerboseListener
         in the configuration file:
       </p>
 
-      <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
+      <div class="wrapper"><pre><code class="language-xml">
 &lt;module name=&quot;com.mycompany.listeners.VerboseListener&quot;&gt;
   &lt;property name=&quot;file&quot; value=&quot;audit.txt&quot;/&gt;
 &lt;/module&gt;
@@ -215,7 +215,7 @@ public class VerboseListener
         Here is a truncated example of audit output from a <code> VerboseListener</code>:
       </p>
 
-      <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+      <div class="wrapper"><pre><code class="language-java">
 Audit started.
 Started checking file 'CommonsLoggingListener.java'.
 Finished checking file 'CommonsLoggingListener.java'. Errors: 0
@@ -293,7 +293,7 @@ Audit finished. Total errors: 1
         in the current directory:
       </p>
 
-      <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+      <div class="wrapper"><pre><code class="language-java">
 # Set root logger level to INFO and its only appender to A1.
 log4j.rootLogger=INFO, A1
 
@@ -310,7 +310,7 @@ log4j.appender.A1.layout.ConversionPattern=%-5p %c %x- %m%n
         (abbreviated) output:
       </p>
 
-      <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+      <div class="wrapper"><pre><code class="language-java">
 INFO  com.puppycrawl...Checker  - Audit started.
 INFO  com.puppycrawl...Checker  - File "CommonsLoggingListener.java" started.
 INFO  com.puppycrawl...Checker  - File "CommonsLoggingListener.java" finished.
@@ -350,7 +350,7 @@ INFO  com.puppycrawl...Checker  - Audit finished.
         directory:
       </p>
 
-      <div class="wrapper"><pre class="prettyprint"><code class="language-text">
+      <div class="wrapper"><pre><code class="language-text">
 MailLogger.from=user@example.org
 MailLogger.failure.to=user@example.org
 MailLogger.success.to=user@example.org


### PR DESCRIPTION
This PR addresses the issue where syntax highlighting is performed at runtime using JavaScript, which impacts website stability and performance. The goal was to move syntax highlighting to the site generation phase using the Maven Fluido Skin built in capabilities, that I successfully did.
However, after doing so, a layout issue emerged where the body content appears below the left sidebar, creating gaps on the right and left sides.

Here is the video: 

https://github.com/user-attachments/assets/f14070eb-72d1-4257-a1d0-45b6f8ac14b6


## Issue Link:
Fixes: #16300 