### PR TITLE
Issue #13213: Remove '//ok' comments from Input files(outertypenumber)

### DIFF
--- a/config/checkstyle-input-suppressions.xml
+++ b/config/checkstyle-input-suppressions.xml
@@ -686,10 +686,6 @@
   <suppress id="UnnecessaryOkComment"
             files="checks[\\/]sizes[\\/]executablestatementcount[\\/]InputExecutableStatementCountMaxZero.java"/>
   <suppress id="UnnecessaryOkComment"
-            files="checks[\\/]sizes[\\/]outertypenumber[\\/]InputOuterTypeNumberEmptyInner.java"/>
-  <suppress id="UnnecessaryOkComment"
-            files="checks[\\/]sizes[\\/]outertypenumber[\\/]InputOuterTypeNumberSimple1.java"/>
-  <suppress id="UnnecessaryOkComment"
             files="checks[\\/]sizes[\\/]parameternumber[\\/]InputParameterNumberSimple3.java"/>
   <suppress id="UnnecessaryOkComment"
             files="checks[\\/]whitespace[\\/]emptyforiteratorpad[\\/]InputEmptyForIteratorPad2.java"/>

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/sizes/outertypenumber/InputOuterTypeNumberEmptyInner.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/sizes/outertypenumber/InputOuterTypeNumberEmptyInner.java
@@ -5,7 +5,7 @@ max = (default)1
 
 */
 
-package com.puppycrawl.tools.checkstyle.checks.sizes.outertypenumber; // ok
+package com.puppycrawl.tools.checkstyle.checks.sizes.outertypenumber;
 
 /**Contains empty inner class for OuterTypeNumberCheckTest*/
 public class InputOuterTypeNumberEmptyInner {

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/sizes/outertypenumber/InputOuterTypeNumberSimple1.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/sizes/outertypenumber/InputOuterTypeNumberSimple1.java
@@ -5,7 +5,7 @@ max = 30
 
 */
 
-package com.puppycrawl.tools.checkstyle.checks.sizes.outertypenumber; // ok
+package com.puppycrawl.tools.checkstyle.checks.sizes.outertypenumber;
 
 /**
  * Contains simple mistakes:


### PR DESCRIPTION
 ISSUE : https://github.com/checkstyle/checkstyle/issues/13213

Removed //ok from outerTypeNumber module from Input files.

**PROOF:**
```
DELL@DESKTOP-KL8FGN8 MINGW64 ~/checkstyle (master)
$ grep outertypenumber config/checkstyle-input-suppressions.xml
            files="checks[\\/]sizes[\\/]outertypenumber[\\/]InputOuterTypeNumberEmptyInner.java"/>
            files="checks[\\/]sizes[\\/]outertypenumber[\\/]InputOuterTypeNumberSimple1.java"/>
```
```
DELL@DESKTOP-KL8FGN8 MINGW64 ~/checkstyle (removeOk)
$ grep outertypenumber config/checkstyle-input-suppressions.xml

DELL@DESKTOP-KL8FGN8 MINGW64 ~/checkstyle (removeOk)
$ echo $?
1
```


