### PR TITLE
Issue #13213: Remove '//ok' comments from Input files(javaastvisitor)

### DIFF
--- a/config/checkstyle-input-suppressions.xml
+++ b/config/checkstyle-input-suppressions.xml
@@ -1232,8 +1232,6 @@
   <suppress id="UnnecessaryOkComment"
             files="filters[\\/]suppresswithnearbycommentfilter[\\/]InputSuppressWithNearbyCommentFilterByCheckAndInfluence.java"/>
   <suppress id="UnnecessaryOkComment"
-            files="javaastvisitor[\\/]InputJavaAstVisitorNoStackOverflowOnDeepStringConcat.java"/>
-  <suppress id="UnnecessaryOkComment"
             files="utils[\\/]annotationutil[\\/]InputAnnotationUtil2.java"/>
   <suppress id="UnnecessaryOkComment"
             files="utils[\\/]checkutil[\\/]InputCheckUtil4.java"/>

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/javaastvisitor/InputJavaAstVisitorNoStackOverflowOnDeepStringConcat.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/javaastvisitor/InputJavaAstVisitorNoStackOverflowOnDeepStringConcat.java
@@ -43,5 +43,5 @@ public class InputJavaAstVisitorNoStackOverflowOnDeepStringConcat {
  "a"+"a"+"a"+"a"+"a"+"a"+"a"+"a"+"a"+"a"+"a"+"a"+"a"+"a"+"a"+"a"+"a"+"a"+"a"+"a"+
  "a"+"a"+"a"+"a"+"a"+"a"+"a"+"a"+"a"+"a"+"a"+"a"+"a"+"a"+"a"+"a"+"a"+"a"+"a"+"a"+
 
-         "b"; // ok
+         "b";
 }


### PR DESCRIPTION
Issue: https://github.com/checkstyle/checkstyle/issues/13213

Removed //ok from javaastvisitor module from Input files.

**PROOF:**
```
DELL@DESKTOP-KL8FGN8 MINGW64 ~/checkstyle (master)
$ grep javaastvisitor config/checkstyle-input-suppressions.xml
            files="javaastvisitor[\\/]InputJavaAstVisitorNoStackOverflowOnDeepStringConcat.java"/>
```
```

DELL@DESKTOP-KL8FGN8 MINGW64 ~/checkstyle (javaAstVisitor)
$ grep javaastvisitor config/checkstyle-input-suppressions.xml

DELL@DESKTOP-KL8FGN8 MINGW64 ~/checkstyle (javaAstVisitor)
$ echo $?
1
```
