### PR TITLE
Issue #13213: Remove '//ok' comments from Input files(annotationutil)

### DIFF
--- a/config/checkstyle-input-suppressions.xml
+++ b/config/checkstyle-input-suppressions.xml
@@ -1228,8 +1228,6 @@
   <suppress id="UnnecessaryOkComment"
             files="filters[\\/]suppresswithnearbycommentfilter[\\/]InputSuppressWithNearbyCommentFilterByCheckAndInfluence.java"/>
   <suppress id="UnnecessaryOkComment"
-            files="utils[\\/]annotationutil[\\/]InputAnnotationUtil2.java"/>
-  <suppress id="UnnecessaryOkComment"
             files="utils[\\/]checkutil[\\/]InputCheckUtil4.java"/>
   <suppress id="UnnecessaryOkComment"
             files="utils[\\/]checkutil[\\/]InputCheckUtilPackage.java"/>

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/utils/annotationutil/InputAnnotationUtil2.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/utils/annotationutil/InputAnnotationUtil2.java
@@ -18,7 +18,7 @@ public class InputAnnotationUtil2 {
     public static final String UNCHECKED = "unchecked";
 
     public static void test() {
-        @SuppressWarnings(value = UNCHECKED) // ok
+        @SuppressWarnings(value = UNCHECKED)
         final List<String> dummyOne = (List<String>) new ArrayList();
     }
 }


### PR DESCRIPTION
Issue: https://github.com/checkstyle/checkstyle/issues/13213

Removed //ok from annotationutil module from Input files.

**PROOF:**
```
DELL@DESKTOP-KL8FGN8 MINGW64 ~/checkstyle (master)
$ grep annotationutil config/checkstyle-input-suppressions.xml
            files="utils[\\/]annotationutil[\\/]InputAnnotationUtil2.java"/>
```
```
DELL@DESKTOP-KL8FGN8 MINGW64 ~/checkstyle (annotationUtil)
$ grep annotationutil config/checkstyle-input-suppressions.xml

DELL@DESKTOP-KL8FGN8 MINGW64 ~/checkstyle (annotationUtil)
$ echo $?
1
```