### PR TITLE
Issue #13213: Remove '//ok' from Input Files(parameternumber)

### DIFF
--- a/config/checkstyle-input-suppressions.xml
+++ b/config/checkstyle-input-suppressions.xml
@@ -686,8 +686,6 @@
   <suppress id="UnnecessaryOkComment"
             files="checks[\\/]sizes[\\/]executablestatementcount[\\/]InputExecutableStatementCountMaxZero.java"/>
   <suppress id="UnnecessaryOkComment"
-            files="checks[\\/]sizes[\\/]parameternumber[\\/]InputParameterNumberSimple3.java"/>
-  <suppress id="UnnecessaryOkComment"
             files="checks[\\/]whitespace[\\/]emptyforiteratorpad[\\/]InputEmptyForIteratorPad2.java"/>
   <suppress id="UnnecessaryOkComment"
             files="checks[\\/]whitespace[\\/]emptyforiteratorpad[\\/]InputEmptyForIteratorPadToCheckTrimFunctionInOptionProperty.java"/>

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/sizes/parameternumber/InputParameterNumberSimple3.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/sizes/parameternumber/InputParameterNumberSimple3.java
@@ -17,7 +17,7 @@ import java.io.*;
  * - Order of modifiers
  * @author Oliver Burn
  **/
-final class InputParameterNumberSimple3 // ok
+final class InputParameterNumberSimple3
 {
     // Long line ----------------------------------------------------------------
     // Contains a tab ->        <-


### PR DESCRIPTION
Issue: https://github.com/checkstyle/checkstyle/issues/13213

Removed //ok from parameternumber module from Input files.

**PROOF:**
```
DELL@DESKTOP-KL8FGN8 MINGW64 ~/checkstyle (master)
$ grep parameternumber config/checkstyle-input-suppressions.xml
            files="checks[\\/]sizes[\\/]parameternumber[\\/]InputParameterNumberSimple3.java"/>

```
```
DELL@DESKTOP-KL8FGN8 MINGW64 ~/checkstyle (parameterNumber)
$ grep parameternumber config/checkstyle-input-suppressions.xml

DELL@DESKTOP-KL8FGN8 MINGW64 ~/checkstyle (parameterNumber)
$ echo $?
1
```