### PR TITLE
Issue #13213: Remove '//ok' from Input Files(separatorwrap)

### DIFF
--- a/config/checkstyle-input-suppressions.xml
+++ b/config/checkstyle-input-suppressions.xml
@@ -1110,16 +1110,6 @@
   <suppress id="UnnecessaryOkComment"
             files="checks[\\/]whitespace[\\/]parenpad[\\/]InputParenPadWithSpaceAndDisabledLambda.java"/>
   <suppress id="UnnecessaryOkComment"
-            files="checks[\\/]whitespace[\\/]separatorwrap[\\/]InputSeparatorWrapForInvalidOption.java"/>
-  <suppress id="UnnecessaryOkComment"
-            files="checks[\\/]whitespace[\\/]separatorwrap[\\/]InputSeparatorWrapForTestTrailingWhitespace.java"/>
-  <suppress id="UnnecessaryOkComment"
-            files="checks[\\/]whitespace[\\/]separatorwrap[\\/]InputSeparatorWrapForTestTrailingWhitespace.java"/>
-  <suppress id="UnnecessaryOkComment"
-            files="checks[\\/]whitespace[\\/]separatorwrap[\\/]InputSeparatorWrapWithEmoji.java"/>
-  <suppress id="UnnecessaryOkComment"
-            files="checks[\\/]whitespace[\\/]separatorwrap[\\/]InputSeparatorWrapWithEmoji.java"/>
-  <suppress id="UnnecessaryOkComment"
             files="checks[\\/]whitespace[\\/]singlespaceseparator[\\/]InputSingleSpaceSeparatorCommentsWithEmoji.java"/>
   <suppress id="UnnecessaryOkComment"
             files="checks[\\/]whitespace[\\/]singlespaceseparator[\\/]InputSingleSpaceSeparatorCommentsWithEmoji.java"/>

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/whitespace/separatorwrap/InputSeparatorWrapForInvalidOption.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/whitespace/separatorwrap/InputSeparatorWrapForInvalidOption.java
@@ -8,7 +8,7 @@ tokens = (default)DOT, COMMA
 
 package com.puppycrawl.tools.checkstyle.checks.whitespace.separatorwrap;
 
-public class InputSeparatorWrapForInvalidOption<T extends FooForInvalidOption // ok
+public class InputSeparatorWrapForInvalidOption<T extends FooForInvalidOption
         & BarForInvalidOption> {
     public void goodCase() throws FooException4IO, BarException4IO
     {

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/whitespace/separatorwrap/InputSeparatorWrapForTestTrailingWhitespace.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/whitespace/separatorwrap/InputSeparatorWrapForTestTrailingWhitespace.java
@@ -21,10 +21,10 @@ public class InputSeparatorWrapForTestTrailingWhitespace {
     public void foo(int a,  
                     int b) {
         int r
-            , t; // OK
+            , t;
     }
 
     public void bar(int p
-            , int q) {  // OK
+            , int q) {
     }
 }

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/whitespace/separatorwrap/InputSeparatorWrapWithEmoji.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/whitespace/separatorwrap/InputSeparatorWrapWithEmoji.java
@@ -21,7 +21,7 @@ public class InputSeparatorWrapWithEmoji {
     }
 
     public void test2(String
-                          /* 👌🏻👌🏻 */    ...parameters) { // ok
+                          /* 👌🏻👌🏻 */    ...parameters) {
         String s = "ffffooooString";
         /* 🧐🥳 */ s.
             isEmpty(); // violation above ''.' should be on a new line'
@@ -30,7 +30,7 @@ public class InputSeparatorWrapWithEmoji {
         } catch (Exception e) {}
 
         test1("1"
-            /*🧐 sda 🥳 */   ,s); // ok
+            /*🧐 sda 🥳 */   ,s);
 
     }
     void goodCase() {


### PR DESCRIPTION
Issue: https://github.com/checkstyle/checkstyle/issues/13213

Removed //ok from separatorwrap module from Input files.

**PROOF**:
```
DELL@DESKTOP-KL8FGN8 MINGW64 ~/checkstyle (master)
$ grep separatorwrap config/checkstyle-input-suppressions.xml
            files="checks[\\/]whitespace[\\/]separatorwrap[\\/]InputSeparatorWrapForInvalidOption.java"/>
            files="checks[\\/]whitespace[\\/]separatorwrap[\\/]InputSeparatorWrapForTestTrailingWhitespace.java"/>
            files="checks[\\/]whitespace[\\/]separatorwrap[\\/]InputSeparatorWrapForTestTrailingWhitespace.java"/>
            files="checks[\\/]whitespace[\\/]separatorwrap[\\/]InputSeparatorWrapWithEmoji.java"/>
            files="checks[\\/]whitespace[\\/]separatorwrap[\\/]InputSeparatorWrapWithEmoji.java"/>
```

```
DELL@DESKTOP-KL8FGN8 MINGW64 ~/checkstyle (separatorWrap)
$ grep separatorwrap config/checkstyle-input-suppressions.xml

DELL@DESKTOP-KL8FGN8 MINGW64 ~/checkstyle (separatorWrap)
$ echo $?
1
```
