### PR TITLE
Issue #13213: removed //ok from InputRegexpCheck

### DIFF
--- a/config/checkstyle-input-suppressions.xml
+++ b/config/checkstyle-input-suppressions.xml
@@ -470,14 +470,6 @@
   <suppress id="UnnecessaryOkComment"
             files="checks[\\/]javadoc[\\/]writetag[\\/]InputWriteTagSeverity.java"/>
   <suppress id="UnnecessaryOkComment"
-            files="checks[\\/]regexp[\\/]regexp[\\/]InputRegexpCheckB3.java"/>
-  <suppress id="UnnecessaryOkComment"
-            files="checks[\\/]regexp[\\/]regexp[\\/]InputRegexpCheckB4.java"/>
-  <suppress id="UnnecessaryOkComment"
-            files="checks[\\/]regexp[\\/]regexp[\\/]InputRegexpCheckEmptyLine2.java"/>
-  <suppress id="UnnecessaryOkComment"
-            files="checks[\\/]regexp[\\/]regexp[\\/]InputRegexpCheckStopEarly.java"/>
-  <suppress id="UnnecessaryOkComment"
             files="checks[\\/]regexp[\\/]regexp[\\/]InputRegexpSemantic.java"/>
   <suppress id="UnnecessaryOkComment"
             files="checks[\\/]regexp[\\/]regexp[\\/]InputRegexpSemantic.java"/>

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/regexp/regexp/InputRegexpCheckB3.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/regexp/regexp/InputRegexpCheckB3.java
@@ -9,7 +9,7 @@ illegalPattern = false
 
 package com.puppycrawl.tools.checkstyle.checks.regexp.regexp;
 
-// ok
+
 public class InputRegexpCheckB3 {
 }
 

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/regexp/regexp/InputRegexpCheckB4.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/regexp/regexp/InputRegexpCheckB4.java
@@ -10,5 +10,5 @@ illegalPattern = false
 package com.puppycrawl.tools.checkstyle.checks.regexp.regexp;
 
 public class InputRegexpCheckB4 {
-// ok
+
 }

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/regexp/regexp/InputRegexpCheckEmptyLine2.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/regexp/regexp/InputRegexpCheckEmptyLine2.java
@@ -9,5 +9,5 @@ ignoreComments = true
 package com.puppycrawl.tools.checkstyle.checks.regexp.regexp;
 
 public class InputRegexpCheckEmptyLine2 {
-// ok
+
 }

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/regexp/regexp/InputRegexpCheckStopEarly.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/regexp/regexp/InputRegexpCheckStopEarly.java
@@ -12,7 +12,7 @@ ignoreComments = (default)false
 
 package com.puppycrawl.tools.checkstyle.checks.regexp.regexp;
 
-public class InputRegexpCheckStopEarly { // ok
+public class InputRegexpCheckStopEarly {
     // a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a
     // a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a
     // a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a


### PR DESCRIPTION
Issue #13213

Removed `//ok` comments from:
- InputRegexpCheckB3.java
- InputRegexpCheckB4.java
- InputRegexpCheckEmptyLine2.java
- InputRegexpCheckStopEarly.java

and Updated _checkstyle-input-suppressions.xml_ to handle the affected checks appropriately.