### PR TITLE
Issue #13213: Remove '//ok' from Input Files(unnecessarysemicolon)

### DIFF
--- a/config/checkstyle-input-suppressions.xml
+++ b/config/checkstyle-input-suppressions.xml
@@ -68,9 +68,7 @@
           files="[\\/]packageobjectfactory[\\/]zoo[\\/]FooCheck.java"/>
 
   <!-- until https://github.com/checkstyle/checkstyle/issues/13213 -->
-
-  <suppress id="UnnecessaryOkComment"
-            files="checks[\\/]coding[\\/]unnecessarysemicolonaftertypememberdeclaration[\\/]InputUnnecessarySemicolonAfterTypeMemberDeclarationNullAst.java"/>
+  
   <suppress id="UnnecessaryOkComment"
             files="checks[\\/]javadoc[\\/]missingjavadocmethod[\\/]InputMissingJavadocMethodAllowedAnnotations.java"/>
   <suppress id="UnnecessaryOkComment"

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/unnecessarysemicolonaftertypememberdeclaration/InputUnnecessarySemicolonAfterTypeMemberDeclarationNullAst.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/unnecessarysemicolonaftertypememberdeclaration/InputUnnecessarySemicolonAfterTypeMemberDeclarationNullAst.java
@@ -19,7 +19,7 @@ public class InputUnnecessarySemicolonAfterTypeMemberDeclarationNullAst {
                 }
                 class Local2 {
                     int j = k;
-                }; // ok
+                };
                 class Local3 {
                     int l = 15;; //violation
                 }


### PR DESCRIPTION
Issue: https://github.com/checkstyle/checkstyle/issues/13213

Removed //ok from unnecessarysemicolonaftertypememberdeclaration module from Input files.

-> 1 //ok from 1 file

**PROOF:**
```
DELL@DESKTOP-KL8FGN8 MINGW64 ~/checkstyle (master)
$ grep unnecessarysemicolonaftertypememberdeclaration config/checkstyle-input-suppressions.xml
            files="checks[\\/]coding[\\/]unnecessarysemicolonaftertypememberdeclaration[\\/]InputUnnecessarySemicolonAfterTypeMemberDeclarationNullAst.java"/>
```
```
DELL@DESKTOP-KL8FGN8 MINGW64 ~/checkstyle (unnecessarySemicolon)
$ grep unnecessarysemicolonaftertypememberdeclaration config/checkstyle-input-suppressions.xml

DELL@DESKTOP-KL8FGN8 MINGW64 ~/checkstyle (unnecessarySemicolon)
$ echo $?
1
```

