### PR TITLE
Issue #13213: Remove '//ok' From Input File(checkutil)

### DIFF
--- a/config/checkstyle-input-suppressions.xml
+++ b/config/checkstyle-input-suppressions.xml
@@ -1066,12 +1066,6 @@
   <suppress id="UnnecessaryOkComment"
             files="filters[\\/]suppresswithnearbycommentfilter[\\/]InputSuppressWithNearbyCommentFilterByCheckAndInfluence.java"/>
   <suppress id="UnnecessaryOkComment"
-            files="utils[\\/]checkutil[\\/]InputCheckUtil4.java"/>
-  <suppress id="UnnecessaryOkComment"
-            files="utils[\\/]checkutil[\\/]InputCheckUtilPackage.java"/>
-  <suppress id="UnnecessaryOkComment"
-            files="utils[\\/]checkutil[\\/]package-info.java"/>
-  <suppress id="UnnecessaryOkComment"
             files="checks[\\/]javadoc[\\/]javadoctype[\\/]InputJavadocType1.java"/>
   <suppress id="UnnecessaryOkComment"
             files="checks[\\/]javadoc[\\/]javadoctype[\\/]InputJavadocType3.java"/>
@@ -1079,6 +1073,4 @@
             files="checks[\\/]whitespace[\\/]emptylineseparator[\\/]InputEmptyLineSeparator.java"/>
   <suppress id="UnnecessaryOkComment"
             files="checks[\\/]whitespace[\\/]emptylineseparator[\\/]InputEmptyLineSeparator2.java"/>
-  <suppress id="UnnecessaryOkComment"
-            files="utils[\\/]checkutil[\\/]InputCheckUtil7.java"/>
 </suppressions>

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/utils/checkutil/InputCheckUtil4.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/utils/checkutil/InputCheckUtil4.java
@@ -6,7 +6,7 @@ accessModifiers = public
 
 package com.puppycrawl.tools.checkstyle.utils.checkutil;
 
-// ok
+
 public interface InputCheckUtil4 {
 
     /**

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/utils/checkutil/InputCheckUtil7.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/utils/checkutil/InputCheckUtil7.java
@@ -14,8 +14,8 @@ package com.puppycrawl.tools.checkstyle.utils.checkutil;
 
 public class InputCheckUtil7 {
 
-    static public class TestException3 extends Exception { // ok
-        TestException3(String messg) { // ok
+    static public class TestException3 extends Exception {
+        TestException3(String messg) {
             super(messg);
         }
 

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/utils/checkutil/InputCheckUtilPackage.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/utils/checkutil/InputCheckUtilPackage.java
@@ -1,4 +1,4 @@
-package com.puppycrawl.tools.checkstyle.utils.checkutil; // ok
+package com.puppycrawl.tools.checkstyle.utils.checkutil;
 
 public class InputCheckUtilPackage {
 }

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/utils/checkutil/package-info.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/utils/checkutil/package-info.java
@@ -1,1 +1,1 @@
-package com.puppycrawl.tools.checkstyle.utils.checkutil; // ok
+package com.puppycrawl.tools.checkstyle.utils.checkutil;


### PR DESCRIPTION
Issue: https://github.com/checkstyle/checkstyle/issues/13213

Removed //ok from checkutil module from Input files

PROOF:
```
DELL@DESKTOP-KL8FGN8 MINGW64 ~/checkstyle (master)
$  grep checkutil config/checkstyle-input-suppressions.xml
            files="utils[\\/]checkutil[\\/]InputCheckUtil4.java"/>
            files="utils[\\/]checkutil[\\/]InputCheckUtilPackage.java"/>
            files="utils[\\/]checkutil[\\/]package-info.java"/>
            files="utils[\\/]checkutil[\\/]InputCheckUtil7.java"/>
```

```
DELL@DESKTOP-KL8FGN8 MINGW64 ~/checkstyle (checkUtil)
$  grep checkutil config/checkstyle-input-suppressions.xml

DELL@DESKTOP-KL8FGN8 MINGW64 ~/checkstyle (checkUtil)
$ echo $?
1
```
