### PR TITLE
Issue #13213: Remove '//ok'from(suppressionxpathsinlefilter)

### DIFF
--- a/config/checkstyle-input-suppressions.xml
+++ b/config/checkstyle-input-suppressions.xml
@@ -1062,8 +1062,6 @@
   <suppress id="UnnecessaryOkComment"
             files="checks[\\/]whitespace[\\/]singlespaceseparator[\\/]InputSingleSpaceSeparatorWithEmoji.java"/>
   <suppress id="UnnecessaryOkComment"
-            files="filters[\\/]suppressionxpathsinglefilter[\\/]InputSuppressionXpathSingleFilterNullViolation.java"/>
-  <suppress id="UnnecessaryOkComment"
             files="filters[\\/]suppresswithnearbycommentfilter[\\/]InputSuppressWithNearbyCommentFilterByCheckAndInfluence.java"/>
   <suppress id="UnnecessaryOkComment"
             files="checks[\\/]javadoc[\\/]javadoctype[\\/]InputJavadocType1.java"/>

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionxpathsinglefilter/InputSuppressionXpathSingleFilterNullViolation.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionxpathsinglefilter/InputSuppressionXpathSingleFilterNullViolation.java
@@ -18,5 +18,5 @@ package com.puppycrawl.tools.checkstyle.filters.suppressionxpathsinglefilter;
 /**
  * This is javadoc.
  */
-public class InputSuppressionXpathSingleFilterNullViolation { // ok
+public class InputSuppressionXpathSingleFilterNullViolation {
 }


### PR DESCRIPTION
Issue: https://github.com/checkstyle/checkstyle/issues/13213

Removed //ok from suppressionxpathsinglefilter  module from Input files

PROOF:
```
DELL@DESKTOP-KL8FGN8 MINGW64 ~/checkstyle (master)
$ grep suppressionxpathsinglefilter config/checkstyle-input-suppressions.xml
            files="filters[\\/]suppressionxpathsinglefilter[\\/]InputSuppressionXpathSingleFilterNullViolation.java"/>
```
```
DELL@DESKTOP-KL8FGN8 MINGW64 ~/checkstyle (suppresionXPathSingleFilter)
$ grep suppressionxpathsinglefilter config/checkstyle-input-suppressions.xml

DELL@DESKTOP-KL8FGN8 MINGW64 ~/checkstyle (suppresionXPathSingleFilter)
$ echo $?
1

```
