### PR TITLE
Issue #14019: Kill mutation in SuppressWithNearbyTextFilter

### DIFF
--- a/config/pitest-suppressions/pitest-filters-suppressions.xml
+++ b/config/pitest-suppressions/pitest-filters-suppressions.xml
@@ -109,24 +109,6 @@
   </mutation>
 
   <mutation unstable="false">
-    <sourceFile>SuppressWithNearbyTextFilter.java</sourceFile>
-    <mutatedClass>com.puppycrawl.tools.checkstyle.filters.SuppressWithNearbyTextFilter</mutatedClass>
-    <mutatedMethod>accept</mutatedMethod>
-    <mutator>org.pitest.mutationtest.engine.gregor.mutators.NonVoidMethodCallMutator</mutator>
-    <description>removed call to java/lang/String::equals</description>
-    <lineContent>if (!cachedFileAbsolutePath.equals(eventFileTextAbsolutePath)) {</lineContent>
-  </mutation>
-
-  <mutation unstable="false">
-    <sourceFile>SuppressWithNearbyTextFilter.java</sourceFile>
-    <mutatedClass>com.puppycrawl.tools.checkstyle.filters.SuppressWithNearbyTextFilter</mutatedClass>
-    <mutatedMethod>accept</mutatedMethod>
-    <mutator>org.pitest.mutationtest.engine.gregor.mutators.RemoveConditionalMutator_EQUAL_IF</mutator>
-    <description>removed conditional - replaced equality check with true</description>
-    <lineContent>if (!cachedFileAbsolutePath.equals(eventFileTextAbsolutePath)) {</lineContent>
-  </mutation>
-
-  <mutation unstable="false">
     <sourceFile>SuppressWithPlainTextCommentFilter.java</sourceFile>
     <mutatedClass>com.puppycrawl.tools.checkstyle.filters.SuppressWithPlainTextCommentFilter$Suppression</mutatedClass>
     <mutatedMethod>&lt;init&gt;</mutatedMethod>

--- a/src/test/java/com/puppycrawl/tools/checkstyle/filters/SuppressWithNearbyTextFilterTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/filters/SuppressWithNearbyTextFilterTest.java
@@ -23,11 +23,15 @@ import static com.google.common.truth.Truth.assertWithMessage;
 import static com.puppycrawl.tools.checkstyle.checks.naming.AbstractNameCheck.MSG_INVALID_PATTERN;
 import static com.puppycrawl.tools.checkstyle.checks.sizes.LineLengthCheck.MSG_KEY;
 
+import java.io.File;
 import java.io.FileNotFoundException;
 import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.StandardCopyOption;
 import java.util.List;
 
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 
 import com.puppycrawl.tools.checkstyle.AbstractModuleTestSupport;
 import com.puppycrawl.tools.checkstyle.api.AuditEvent;
@@ -44,6 +48,9 @@ import com.puppycrawl.tools.checkstyle.internal.utils.TestUtil;
 public class SuppressWithNearbyTextFilterTest extends AbstractModuleTestSupport {
 
     private static final String REGEXP_SINGLELINE_CHECK_FORMAT = "this should not appear";
+
+    @TempDir
+    public File temporaryFolder;
 
     @Override
     protected String getPackageLocation() {
@@ -411,6 +418,43 @@ public class SuppressWithNearbyTextFilterTest extends AbstractModuleTestSupport 
                 .isEqualTo("unable to parse line range"
                         + " from 'SUPPRESS CHECKSTYLE LineLengthCheck' using a!b");
         }
+    }
+
+    /**
+     * Calls the filter twice and removes input file in between to ensure that
+     * the cached file is not read twice.
+     * We cannot use {@link AbstractModuleTestSupport#verifyFilterWithInlineConfigParser}
+     * because to kill pitest survival we need to remove target file between
+     * filter execution to accept violation
+     */
+    @Test
+    public void testCachingExecution() throws Exception {
+        final SuppressWithNearbyTextFilter suppressFilter = new SuppressWithNearbyTextFilter();
+        final String inputPath =
+                getPath("InputSuppressWithNearbyTextFilterDefaultConfig.java");
+        final File tempFile = new File(temporaryFolder,
+                "InputSuppressWithNearbyTextFilterDefaultConfig.java");
+        Files.copy(new File(inputPath).toPath(), tempFile.toPath(),
+                StandardCopyOption.REPLACE_EXISTING);
+
+        final AuditEvent auditEvent1 = new AuditEvent(
+                tempFile.getPath(), tempFile.getPath(),
+                new Violation(1, null, null, null, null,
+                        Object.class, null)
+        );
+        suppressFilter.accept(auditEvent1);
+        final boolean deleted = tempFile.delete();
+        assertWithMessage("Temporary file should be deleted.")
+                .that(deleted).isTrue();
+        final AuditEvent auditEvent2 = new AuditEvent(
+                tempFile.getPath(), tempFile.getPath(),
+                new Violation(2, null, null, null, null,
+                        Object.class, null)
+        );
+        suppressFilter.accept(auditEvent2);
+
+        assertWithMessage("Cache should handle missing file.")
+                .that(tempFile.exists()).isFalse();
     }
 
     /**


### PR DESCRIPTION
#14019 

https://github.com/checkstyle/checkstyle/blob/dcc81520f445d456dbaafc4447071fb4ef74b9fe/src/main/java/com/puppycrawl/tools/checkstyle/filters/SuppressWithNearbyTextFilter.java#L194-L200

this optimization is for make sure that `getFileText` and  `collectSuppressions` is called ones on a file, performance optimization, functioanlly and behavior that user see  all stays the same, that is why pitest see it un necessary code. 

we can try to remove target file while between  execution of `accept`, so this will throw exception.
[getFileText](https://github.com/checkstyle/checkstyle/blob/dcc81520f445d456dbaafc4447071fb4ef74b9fe/src/main/java/com/puppycrawl/tools/checkstyle/filters/SuppressWithNearbyTextFilter.java#L228-L233)

