### PR TITLE
minor: removing closed issues reference

### DIFF
--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadocparagraph/InputJavadocParagraphIncorrectOpenClosedTag.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadocparagraph/InputJavadocParagraphIncorrectOpenClosedTag.java
@@ -46,7 +46,7 @@ public class InputJavadocParagraphIncorrectOpenClosedTag {
     * Some Summary.
     *
     * <p>
-    *   Some Javadoc. // ok until #15762
+    *   Some Javadoc.
     * </p>
     */
     int d;


### PR DESCRIPTION
Removing closed issue reference from :
https://github.com/Anmol202005/checkstyle/blob/AnnotationLine/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadocparagraph/InputJavadocParagraphIncorrectOpenClosedTag.java#L49

removed until comment.
