### PR TITLE
Issue #16358: Updated HeaderCheckTest to use verifyWithInlineConfigPa…

### DIFF
--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/header/HeaderCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/header/HeaderCheckTest.java
@@ -60,7 +60,7 @@ public class HeaderCheckTest extends AbstractModuleTestSupport {
         final String[] expected = {
             "1: " + getCheckMessage(MSG_MISSING),
         };
-        verify(checkConfig, getPath("InputHeader.java"), expected);
+        verifyWithInlineConfigParser(getPath("InputHeader.java"), expected);
     }
 
     @Test


### PR DESCRIPTION
Issue #[16358](https://github.com/checkstyle/checkstyle/issues/16358) 
by updating HeaderCheckTest.java to use the verifyWithInlineConfigParser method instead of the old verify method.