### PR TITLE
Fix #16358: Replace verify() with verifyWithInlineConfigParser() in H…

### DIFF
--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/header/HeaderCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/header/HeaderCheckTest.java
@@ -60,7 +60,7 @@ public class HeaderCheckTest extends AbstractModuleTestSupport {
         final String[] expected = {
             "1: " + getCheckMessage(MSG_MISSING),
         };
-        verify(checkConfig, getPath("InputHeader.java"), expected);
+        verifyWithInlineConfigParser(getPath("InputHeader.java"), expected);
     }
 
     @Test


### PR DESCRIPTION
fixed #16358 
 replaced the old verify() method with verifyWithInlineConfigParser() in HeaderCheckTest.java. This aligns the test with the modern testing approach used in other checks.

- Updated method at Line 63
