### PR TITLE
Fix xmllogger 16360

### DIFF
--- a/src/test/java/com/puppycrawl/tools/checkstyle/XMLLoggerTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/XMLLoggerTest.java
@@ -177,6 +177,7 @@ public class XMLLoggerTest extends AbstractXmlTestSupport {
         verifyXml(getPath("ExpectedXMLLogger.xml"), outStream);
     }
 
+
     @Test
     public void testAddError() throws Exception {
         final XMLLogger logger = new XMLLogger(outStream, OutputStreamOptions.CLOSE);
@@ -380,7 +381,6 @@ public class XMLLoggerTest extends AbstractXmlTestSupport {
         logger.auditFinished(null);
         verifyXml(getPath("ExpectedXMLLoggerSpecialName.xml"),
                 outStream, "<file name=" + "Test&amp;.java" + ">");
-
     }
 
     @Test
@@ -389,6 +389,10 @@ public class XMLLoggerTest extends AbstractXmlTestSupport {
         final String inputFileWithConfig = "InputXMLLogger.java";
         final String xmlReport = "ExpectedXMLLoggerWithChecker.xml";
         verifyWithInlineConfigParserAndXmlLogger(inputFileWithConfig, xmlReport);
+        verifyWithInlineConfigParserAndXmlLogger(
+                inputFileWithConfig,
+                xmlReport
+        );
     }
 
     @Test
@@ -418,6 +422,7 @@ public class XMLLoggerTest extends AbstractXmlTestSupport {
                 .that(exception.getMessage())
                 .isEqualTo("Parameter outputStreamOptions can not be null");
         }
+
     }
 
     @Test

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/header/RegexpHeaderCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/header/RegexpHeaderCheckTest.java
@@ -123,7 +123,7 @@ public class RegexpHeaderCheckTest extends AbstractModuleTestSupport {
         final DefaultConfiguration checkConfig = createModuleConfig(RegexpHeaderCheck.class);
         createChecker(checkConfig);
         final String[] expected = CommonUtil.EMPTY_STRING_ARRAY;
-        verify(checkConfig, getPath("InputRegexpHeaderDefaultConfig.java"), expected);
+         verifyWithInlineConfigParser(getPath("InputRegexpHeaderDefaultConfig.java"), expected);
     }
 
     @Test


### PR DESCRIPTION
fix Issue: #16360 
have migrated XMLLoggerTest to use the new available verifyWithInlineConfigParserAndXmlLogger method