### PR TITLE
Issue #14019: Resolve pitest suppressions for  SuppressionsStringPrinter

### DIFF
--- a/config/pitest-suppressions/pitest-tree-walker-suppressions.xml
+++ b/config/pitest-suppressions/pitest-tree-walker-suppressions.xml
@@ -55,15 +55,6 @@
   </mutation>
 
   <mutation unstable="false">
-    <sourceFile>SuppressionsStringPrinter.java</sourceFile>
-    <mutatedClass>com.puppycrawl.tools.checkstyle.SuppressionsStringPrinter</mutatedClass>
-    <mutatedMethod>printSuppressions</mutatedMethod>
-    <mutator>org.pitest.mutationtest.engine.gregor.mutators.experimental.NakedReceiverMutator</mutator>
-    <description>replaced call to java/io/File::getAbsoluteFile with receiver</description>
-    <lineContent>final FileText fileText = new FileText(file.getAbsoluteFile(),</lineContent>
-  </mutation>
-
-  <mutation unstable="false">
     <sourceFile>TreeWalker.java</sourceFile>
     <mutatedClass>com.puppycrawl.tools.checkstyle.TreeWalker</mutatedClass>
     <mutatedMethod>createNewCheckSortedSet</mutatedMethod>

--- a/src/main/java/com/puppycrawl/tools/checkstyle/SuppressionsStringPrinter.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/SuppressionsStringPrinter.java
@@ -73,7 +73,7 @@ public final class SuppressionsStringPrinter {
             throw new IllegalStateException(exceptionMsg);
         }
 
-        final FileText fileText = new FileText(file.getAbsoluteFile(),
+        final FileText fileText = new FileText(file,
                 System.getProperty("file.encoding", StandardCharsets.UTF_8.name()));
         final DetailAST detailAST =
                 JavaParser.parseFileText(fileText, JavaParser.Options.WITH_COMMENTS);


### PR DESCRIPTION


Issue #14019
#### Removing Redundant `getAbsoluteFile()` Call  

The call to `file.getAbsoluteFile()` is unnecessary because the `File` class can handle both relative and absolute paths when reading files. Since we only need to read the file, there is no requirement to explicitly convert it to an absolute path. Additionally, calling `getAbsoluteFile()` creates a new `File` instance that points to the same file, making it redundant and adding unnecessary overhead. 
This is also done in CLI options with the `printFileAst` method, which handles files in the same structure without using getAbsoluteFile().

https://github.com/checkstyle/checkstyle/blob/20284e326cdff304f569b4ff0ebca3a4ddf511de/src/main/java/com/puppycrawl/tools/checkstyle/JavaParser.java#L137
