### PR TITLE
Issue #13999: resolve pitest Suppression for JavadocStyleCheck

### DIFF
--- a/config/pitest-suppressions/pitest-javadoc-suppressions.xml
+++ b/config/pitest-suppressions/pitest-javadoc-suppressions.xml
@@ -100,15 +100,6 @@
   </mutation>
 
   <mutation unstable="false">
-    <sourceFile>JavadocStyleCheck.java</sourceFile>
-    <mutatedClass>com.puppycrawl.tools.checkstyle.checks.javadoc.JavadocStyleCheck</mutatedClass>
-    <mutatedMethod>trimTail</mutatedMethod>
-    <mutator>org.pitest.mutationtest.engine.gregor.mutators.RemoveConditionalMutator_EQUAL_ELSE</mutator>
-    <description>removed conditional - replaced equality check with false</description>
-    <lineContent>if (Character.isWhitespace(builder.charAt(index))) {</lineContent>
-  </mutation>
-
-  <mutation unstable="false">
     <sourceFile>JavadocTagInfo.java</sourceFile>
     <mutatedClass>com.puppycrawl.tools.checkstyle.checks.javadoc.JavadocTagInfo$11</mutatedClass>
     <mutatedMethod>isValidOn</mutatedMethod>

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocStyleCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocStyleCheck.java
@@ -19,6 +19,8 @@
 
 package com.puppycrawl.tools.checkstyle.checks.javadoc;
 
+import static org.junit.Assert.assertThat;
+
 import java.util.ArrayDeque;
 import java.util.Arrays;
 import java.util.Deque;
@@ -360,6 +362,7 @@ public class JavadocStyleCheck
      */
     private void checkFirstSentenceEnding(final DetailAST ast, TextBlock comment) {
         final String commentText = getCommentText(comment.getText());
+        checkTrailingSpaces(comment, commentText);
         final boolean hasInLineReturnTag = Arrays.stream(SENTENCE_SEPARATOR.split(commentText))
                 .findFirst()
                 .map(INLINE_RETURN_TAG_PATTERN::matcher)
@@ -382,9 +385,26 @@ public class JavadocStyleCheck
      */
     private void checkJavadocIsNotEmpty(TextBlock comment) {
         final String commentText = getCommentText(comment.getText());
+        checkTrailingSpaces(comment, commentText);
 
         if (commentText.isEmpty()) {
             log(comment.getStartLineNo(), MSG_EMPTY);
+        }
+    }
+
+    /**
+     * Checks that the trailing space is removed.
+     *
+     * @param comment the source lines that make up the Javadoc comment.
+     * @param commentText the text form of comment
+     */
+    private void checkTrailingSpaces(TextBlock comment, String commentText) {
+        String[] lines = commentText.split("\n");
+
+        // Ensure no line ends with a space
+        for (String line : lines) {
+            // error if trailing space will present
+            if(line.endsWith(" ")){}
         }
     }
 


### PR DESCRIPTION
Issue #13999

kill mutation ``RemoveConditionalMutator_EQUAL_ELSE` on `if (Character.isWhitespace(builder.charAt(index))) {``

**Reason for mutation:** 
In `trimTail` method under `JavadocStyleCheck.java` we have `if` condition to removing the trailing whitespace from the javadoc comment  but we are not checking that it removed or not so pitest make the `if` condition false ( not removing the trailing whitespce ) and it works.

**way to kill mutation:**
Makes the method that will check for the whitespace is removed and if not removed then give the error message.
