### PR TITLE
Issue #14697: Resolved False negative in UnusedImportCheck

### DIFF
--- a/config/checker-framework-suppressions/checker-index-suppressions.xml
+++ b/config/checker-framework-suppressions/checker-index-suppressions.xml
@@ -1079,6 +1079,17 @@
   </checkerFrameworkError>
 
   <checkerFrameworkError unstable="false">
+    <fileName>src/main/java/com/puppycrawl/tools/checkstyle/checks/imports/UnusedImportsCheck.java</fileName>
+    <specifier>return</specifier>
+    <message>incompatible types in return.</message>
+    <lineContent>return methodIndex;</lineContent>
+    <details>
+      type of expression: int
+      method return type: @LTLengthOf(&quot;input&quot;) int
+    </details>
+  </checkerFrameworkError>
+
+  <checkerFrameworkError unstable="false">
     <fileName>src/main/java/com/puppycrawl/tools/checkstyle/checks/indentation/AbstractExpressionHandler.java</fileName>
     <specifier>argument</specifier>
     <message>incompatible argument for parameter index of String.charAt.</message>

--- a/config/checker-framework-suppressions/checker-regex-property-key-compiler-message-suppressions.xml
+++ b/config/checker-framework-suppressions/checker-regex-property-key-compiler-message-suppressions.xml
@@ -298,6 +298,13 @@
   </checkerFrameworkError>
 
   <checkerFrameworkError unstable="false">
+    <fileName>src/main/java/com/puppycrawl/tools/checkstyle/checks/imports/UnusedImportsCheck.java</fileName>
+    <specifier>group.count.unknown</specifier>
+    <message>unable to verify non-literal groups parameter.</message>
+    <lineContent>final String methodPart = matcher.group(methodIndex);</lineContent>
+  </checkerFrameworkError>
+
+  <checkerFrameworkError unstable="false">
     <fileName>src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocMethodCheck.java</fileName>
     <specifier>group.count</specifier>
     <message>invalid groups parameter 1. Only 0 groups are guaranteed to exist for javadocArgMatcher.</message>

--- a/config/import-control.xml
+++ b/config/import-control.xml
@@ -184,6 +184,7 @@
     </file>
     <subpackage name="imports">
       <allow class="com.puppycrawl.tools.checkstyle.XmlLoader" local-only="true"/>
+      <allow class="org.checkerframework.checker.index.qual.IndexOrLow"/>
     </subpackage>
     <subpackage name="indentation">
       <allow pkg="java.lang.reflect"/>

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/imports/UnusedImportsCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/imports/UnusedImportsCheck.java
@@ -19,13 +19,17 @@
 
 package com.puppycrawl.tools.checkstyle.checks.imports;
 
-import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Optional;
 import java.util.Set;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import org.checkerframework.checker.index.qual.IndexOrLow;
 
 import com.puppycrawl.tools.checkstyle.FileStatefulCheck;
 import com.puppycrawl.tools.checkstyle.api.AbstractCheck;
@@ -130,6 +134,18 @@ public class UnusedImportsCheck extends AbstractCheck {
     /** Regexp pattern to match java.lang package. */
     private static final Pattern JAVA_LANG_PACKAGE_PATTERN =
         CommonUtil.createPattern("^java\\.lang\\.[a-zA-Z]+$");
+
+    /** Reference pattern. */
+    private static final Pattern REFERENCE = Pattern.compile(
+            "^([a-z_$][a-z\\d_$<>.]*)?(#(.*))?$",
+            Pattern.CASE_INSENSITIVE
+    );
+
+    /** Method pattern. */
+    private static final Pattern METHOD = Pattern.compile(
+            "^([a-z_$#][a-z\\d_$]*)(\\([^)]*\\))?$",
+            Pattern.CASE_INSENSITIVE
+    );
 
     /** Suffix for the star import. */
     private static final String STAR_IMPORT_SUFFIX = ".*";
@@ -343,16 +359,18 @@ public class UnusedImportsCheck extends AbstractCheck {
      * @return a set of classes referenced in the javadoc block
      */
     private static Set<String> collectReferencesFromJavadoc(TextBlock textBlock) {
-        final List<JavadocTag> tags = new ArrayList<>();
-        // gather all the inline tags, like @link
-        // INLINE tags inside BLOCKs get hidden when using ALL
-        tags.addAll(getValidTags(textBlock, JavadocUtil.JavadocTagType.INLINE));
-        // gather all the block-level tags, like @throws and @see
-        tags.addAll(getValidTags(textBlock, JavadocUtil.JavadocTagType.BLOCK));
+        // Process INLINE tags
+        final List<JavadocTag> inlineTags = getTargetTags(textBlock,
+                JavadocUtil.JavadocTagType.INLINE);
+        // Process BLOCK tags
+        final List<JavadocTag> blockTags = getTargetTags(textBlock,
+                JavadocUtil.JavadocTagType.BLOCK);
+        final List<JavadocTag> targetTags = Stream.concat(inlineTags.stream(), blockTags.stream())
+                .collect(Collectors.toUnmodifiableList());
 
         final Set<String> references = new HashSet<>();
 
-        tags.stream()
+        targetTags.stream()
             .filter(JavadocTag::canReferenceImports)
             .forEach(tag -> references.addAll(processJavadocTag(tag)));
         return references;
@@ -360,14 +378,22 @@ public class UnusedImportsCheck extends AbstractCheck {
 
     /**
      * Returns the list of valid tags found in a javadoc {@link TextBlock}.
+     * Filters tags based on whether they are inline or block tags, ensuring they match
+     * the correct format supported.
      *
      * @param cmt The javadoc block to parse
-     * @param tagType The type of tags we're interested in
+     * @param javadocTagType The type of tags we're interested in
      * @return the list of tags
      */
-    private static List<JavadocTag> getValidTags(TextBlock cmt,
-            JavadocUtil.JavadocTagType tagType) {
-        return JavadocUtil.getJavadocTags(cmt, tagType).getValidTags();
+    private static List<JavadocTag> getTargetTags(TextBlock cmt,
+            JavadocUtil.JavadocTagType javadocTagType) {
+        return JavadocUtil.getJavadocTags(cmt, javadocTagType)
+            .getValidTags()
+            .stream()
+            .filter(tag -> isMatchingTagType(tag, javadocTagType))
+            .map(UnusedImportsCheck::bestTryToMatchReference)
+            .flatMap(Optional::stream)
+            .collect(Collectors.toUnmodifiableList());
     }
 
     /**
@@ -421,6 +447,95 @@ public class UnusedImportsCheck extends AbstractCheck {
             topLevelType = type.substring(0, dotIndex);
         }
         return topLevelType;
+    }
+
+    /**
+     * Checks if a Javadoc tag matches the expected type based on its extraction format.
+     * This method checks if an inline tag is extracted as a block tag or vice versa.
+     * It ensures that block tags are correctly recognized as block tags and inline tags
+     * as inline tags during processing.
+     *
+     * @param tag The Javadoc tag to check.
+     * @param javadocTagType The expected type of the tag (BLOCK or INLINE).
+     * @return {@code true} if the tag matches the expected type, otherwise {@code false}.
+     */
+    private static boolean isMatchingTagType(JavadocTag tag,
+                                             JavadocUtil.JavadocTagType javadocTagType) {
+        final boolean isInlineTag = tag.isInlineTag();
+        final boolean isBlockTagType = javadocTagType == JavadocUtil.JavadocTagType.BLOCK;
+
+        return isBlockTagType != isInlineTag;
+    }
+
+    /**
+     * Attempts to match a reference string against a predefined pattern
+     * and extracts valid reference.
+     *
+     * @param tag the input tag to check
+     * @return Optional of extracted references
+     */
+    public static Optional<JavadocTag> bestTryToMatchReference(JavadocTag tag) {
+        final String content = tag.getFirstArg();
+        final int referenceIndex = extractReferencePart(content);
+        Optional<JavadocTag> validTag = Optional.empty();
+
+        if (referenceIndex != -1) {
+            final String referenceString;
+            if (referenceIndex == 0) {
+                referenceString = content;
+            }
+            else {
+                referenceString = content.substring(0, referenceIndex);
+            }
+            final Matcher matcher = REFERENCE.matcher(referenceString);
+            if (matcher.matches()) {
+                final int methodIndex = 3;
+                final String methodPart = matcher.group(methodIndex);
+                final boolean isValid = methodPart == null
+                        || METHOD.matcher(methodPart).matches();
+                if (isValid) {
+                    validTag = Optional.of(tag);
+                }
+            }
+        }
+        return validTag;
+    }
+
+    /**
+     * Extracts the reference part from an input string while ensuring balanced parentheses.
+     *
+     * @param input the input string
+     * @return -1 if parentheses are unbalanced, 0 if no method is found,
+     *         or the index of the first space outside parentheses.
+     */
+    private static @IndexOrLow("#1")int extractReferencePart(String input) {
+        int parenthesesCount = 0;
+        int firstSpaceOutsideParens = -1;
+        for (int index = 0; index < input.length(); index++) {
+            final char currentCharacter = input.charAt(index);
+
+            if (currentCharacter == '(') {
+                parenthesesCount++;
+            }
+            else if (currentCharacter == ')') {
+                parenthesesCount--;
+            }
+            else if (currentCharacter == ' ' && parenthesesCount == 0) {
+                firstSpaceOutsideParens = index;
+                break;
+            }
+        }
+
+        int methodIndex = -1;
+        if (parenthesesCount == 0) {
+            if (firstSpaceOutsideParens == -1) {
+                methodIndex = 0;
+            }
+            else {
+                methodIndex = firstSpaceOutsideParens;
+            }
+        }
+        return methodIndex;
     }
 
     /**

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocTag.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocTag.java
@@ -163,4 +163,13 @@ public class JavadocTag {
                 || tagInfo == JavadocTagInfo.EXCEPTION;
     }
 
+    /**
+     * Checks that the tag is a inline tag.
+     *
+     * @return whether the tag is a inline tag
+     */
+    public boolean isInlineTag() {
+        return tagInfo.getType() == JavadocTagInfo.Type.INLINE;
+    }
+
 }

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/imports/UnusedImportsCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/imports/UnusedImportsCheckTest.java
@@ -390,4 +390,32 @@ public class UnusedImportsCheckTest extends AbstractModuleTestSupport {
                 getPath("InputUnusedImportsJavadocAboveComments.java"), expected);
     }
 
+    @Test
+    public void testImportJavaLinkTag() throws Exception {
+        final String[] expected = {
+            "10:8: " + getCheckMessage(MSG_KEY, "java.util.List"),
+            "12:8: " + getCheckMessage(MSG_KEY, "java.util.TreeSet"),
+
+        };
+        verifyWithInlineConfigParser(
+                getPath("InputUnusedImportsWithLinkTag.java"), expected);
+
+    }
+
+    @Test
+    public void testImportJavaLinkTagWithMethod() throws Exception {
+        final String[] expected = {
+            "10:8: " + getCheckMessage(MSG_KEY, "java.util.Collections"),
+            "12:8: " + getCheckMessage(MSG_KEY, "java.util.Set"),
+            "14:8: " + getCheckMessage(MSG_KEY, "java.util.PriorityQueue"),
+            "16:8: " + getCheckMessage(MSG_KEY, "java.util.Queue"),
+            "20:8: " + getCheckMessage(MSG_KEY, "java.util.LinkedList"),
+            "24:8: " + getCheckMessage(MSG_KEY, "java.time.LocalDateTime"),
+            "27:8: " + getCheckMessage(MSG_KEY, "java.util.concurrent.TimeUnit"),
+        };
+        verifyWithInlineConfigParser(
+                getPath("InputUnusedImportsWithLinkAndMethodTag.java"), expected);
+
+    }
+
 }

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocTagTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocTagTest.java
@@ -86,4 +86,12 @@ public class JavadocTagTest {
                 .isFalse();
     }
 
+    @Test
+    public void testJavadocTagIsInlineTag() {
+        assertThat(new JavadocTag(0, 0, "link", null).isInlineTag()).isTrue();
+        assertThat(new JavadocTag(0, 0, "value", null).isInlineTag()).isTrue();
+        assertThat(new JavadocTag(0, 0, "see", null).isInlineTag()).isFalse();
+
+    }
+
 }

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/imports/unusedimports/InputUnusedImportsWithLinkAndMethodTag.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/imports/unusedimports/InputUnusedImportsWithLinkAndMethodTag.java
@@ -1,0 +1,54 @@
+/*
+UnusedImports
+processJavadoc = (default)true
+
+
+*/
+
+package com.puppycrawl.tools.checkstyle.checks.imports.unusedimports;
+
+import java.util.Collections; // violation 'Unused import - java.util.Collections.'
+import java.util.List;
+import java.util.Set;         // violation 'Unused import - java.util.Set.'
+import java.util.ArrayList;
+import java.util.PriorityQueue; // violation 'Unused import - java.util.PriorityQueue.'
+import java.time.Duration;
+import java.util.Queue;         // violation 'Unused import - java.util.Queue.'
+import java.util.HashSet;
+import java.util.TreeSet;
+import java.util.Random;
+import java.util.LinkedList;   // violation 'Unused import - java.util.LinkedList.'
+import java.net.URI;
+import java.util.Collection;
+import java.time.LocalDate;
+import java.time.LocalDateTime; // violation 'Unused import - java.time.LocalDateTime.'
+import java.time.LocalTime;
+import java.time.Month;
+import java.util.concurrent.TimeUnit; // violation 'Unused import - java.util.concurrent.TimeUnit.'
+
+
+/**
+ * @link {Collections::emptyEnumeration}
+ * {@link TreeSet}
+ * {@see TimeUnit#SECONDS}
+ * {@link List#size}
+ * {@link Set::add}
+ * {@link ArrayList<LocalTime>#add( LocalTime )},
+ * {@link LinkedList<Integer>#set(int index(,int element)}
+ * {@link Random#ints},
+ * {@link PriorityQueue#123invalid}
+ *  {@link 123invalid}
+ * {@link Queue# }
+ * {@linkplain HashSet}
+ *  @see Duration#ZERO
+ *  {@link #setUrl(URI)}
+ *  {@link #Test(LocalDate, Collection)}
+ *  {@link #Test(LocalDateTime}}
+ *  {@link #extractParameters(double[], Month)}
+ *
+ */
+class InputUnusedImportsWithLinkAndMethodTag extends
+        InputUnusedImportsWithLinkAndMethodTagSuperClass {
+
+
+}

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/imports/unusedimports/InputUnusedImportsWithLinkAndMethodTagSuperClass.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/imports/unusedimports/InputUnusedImportsWithLinkAndMethodTagSuperClass.java
@@ -1,0 +1,12 @@
+package com.puppycrawl.tools.checkstyle.checks.imports.unusedimports;
+
+import java.net.URI;
+import java.time.LocalDate;
+import java.time.Month;
+import java.util.Collection;
+
+public class InputUnusedImportsWithLinkAndMethodTagSuperClass {
+        public void Test(LocalDate date, Collection s){}
+        public void setUrl(URI url){}
+        public void extractParameters(double[] d, Month month){}
+}

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/imports/unusedimports/InputUnusedImportsWithLinkTag.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/imports/unusedimports/InputUnusedImportsWithLinkTag.java
@@ -1,0 +1,22 @@
+/*
+UnusedImports
+processJavadoc = (default)true
+
+
+*/
+
+package com.puppycrawl.tools.checkstyle.checks.imports.unusedimports;
+
+import java.util.List; // violation 'Unused import - java.util.List.'
+import java.util.Set;
+import java.util.TreeSet; // violation 'Unused import - java.util.TreeSet.'
+
+/**
+ * @link List
+ * {@link Set Set of items}
+ * @link TreeSet tree conatins items
+ *
+ */
+class InputUnusedImportsWithLinkTag {
+
+}


### PR DESCRIPTION
#14697 

The issue was  `@link` tag being considered valid. The root cause lies in the **`BLOCK_TAG_PATTERN`**, which retrieves all regex expressions containing `@` within Javadoc comments. This pattern incorrectly identifies `@link` as an valid reference for imports.

https://github.com/checkstyle/checkstyle/blob/1fa0377d6892f12e544e7c56acec4cf38c23d15e/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/utils/BlockTagUtil.java#L41
To resolve this, we filter patterns with `@link` since they are considered invalid references for imports.

---

Another issue arises with `{@link Set::add}`, which is an invalid link. correct one `{@link ClassName#methodName}`

The probelm was in extraction of  INLINE_TAG_PATTERN regex  
https://github.com/checkstyle/checkstyle/blob/1fa0377d6892f12e544e7c56acec4cf38c23d15e/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/utils/InlineTagUtil.java#L39    
