### PR TITLE
Issue checkstyle#14631: Updated BODY_TAG_END and BODY_TAG_START to new AST format

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ class Test {
   }
 }
 
-$ java -jar checkstyle-10.18.1-all.jar -c config.xml Test.java
+$ java -jar /target/checkstyle-10.21.3.jar -c config.xml Test.java
 Starting audit...
 [ERROR] Test.java:9:9: Fall through from previous branch of switch statement [FallThrough]
 Audit done.

--- a/src/main/java/com/puppycrawl/tools/checkstyle/api/JavadocTokenTypes.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/api/JavadocTokenTypes.java
@@ -1705,6 +1705,47 @@ public final class JavadocTokenTypes {
     public static final int BODY_TAG_START = JavadocParser.RULE_bodyTagStart + RULE_TYPES_OFFSET;
     /** End body tag. */
     public static final int BODY_TAG_END = JavadocParser.RULE_bodyTagEnd + RULE_TYPES_OFFSET;
+    /**
+     * Body html tag.
+     *
+     * <p><b>Example:</b></p>
+     * <pre>{@code <body></body>}</pre>
+     * <b>Tree:</b>
+     * <pre>
+     * {@code
+     *   JAVADOC -> JAVADOC
+     *        |--TEXT -> /**
+     *        |--NEWLINE -> \n
+     *        |--LEADING_ASTERISK ->  *
+     *        |--TEXT ->
+     *        |--HTML_ELEMENT -> HTML_ELEMENT
+     *        |    `--BODY -> BODY
+     *        |         |--BODY_TAG_START -> BODY_TAG_START
+     *        |         |    |--START -> <
+     *        |         |    |--BODY_HTML_TAG_NAME -> body
+     *        |         |    `--END -> >
+     *        |         |--NEWLINE -> \n
+     *        |         |--LEADING_ASTERISK ->  *
+     *        |         |--TEXT ->  This is inside the body tag.
+     *        |         |--NEWLINE -> \n
+     *        |         |--LEADING_ASTERISK ->  *
+     *        |         |--TEXT ->
+     *        |         `--BODY_TAG_END -> BODY_TAG_END
+     *        |             |--START -> <
+     *        |             |--SLASH -> /
+     *        |             |--BODY_HTML_TAG_NAME -> body
+     *        |             `--END -> >
+     *          |--NEWLINE -> \n
+     *          |--LEADING_ASTERISK ->  *
+     *          |--TEXT -> /
+     *          |--NEWLINE -> \n
+     *          |--TEXT -> public class Test {
+     *          |--NEWLINE -> \n
+     *          |--TEXT -> }
+     *          |--NEWLINE -> \n
+     * }
+     * </pre>
+     */
 
     /** Colgroup html tag. */
     public static final int COLGROUP = JavadocParser.RULE_colgroup + RULE_TYPES_OFFSET;


### PR DESCRIPTION
Issue: https://github.com/checkstyle/checkstyle/issues/14631

`$ cat Test.java
/**
 * <body>
 * This is inside the body tag.
 * </body>
 */
public class Test {
}
$  java -jar target/checkstyle-10.21.4-SNAPSHOT-all.jar -j Test.java | sed -E "s/\[[0-9]+:[0-9]+\]//g"
JAVADOC -> JAVADOC 
|--TEXT -> /** 
|--NEWLINE -> \n 
|--LEADING_ASTERISK ->  * 
|--TEXT ->   
|--HTML_ELEMENT -> HTML_ELEMENT 
|   `--BODY -> BODY 
|       |--BODY_TAG_START -> BODY_TAG_START 
|       |   |--START -> < 
|       |   |--BODY_HTML_TAG_NAME -> body 
|       |   `--END -> > 
|       |--NEWLINE -> \n 
|       |--LEADING_ASTERISK ->  * 
|       |--TEXT ->  This is inside the body tag. 
|       |--NEWLINE -> \n 
|       |--LEADING_ASTERISK ->  * 
|       |--TEXT ->   
|       `--BODY_TAG_END -> BODY_TAG_END 
|           |--START -> < 
|           |--SLASH -> / 
|           |--BODY_HTML_TAG_NAME -> body 
|           `--END -> > 
|--NEWLINE -> \n 
|--LEADING_ASTERISK ->  * 
|--TEXT -> / 
|--NEWLINE -> \n 
|--TEXT -> public class Test { 
|--NEWLINE -> \n 
|--TEXT -> } 
|--NEWLINE -> \n 
`--EOF -> <EOF> `

