### PR TITLE
Issue #14631: Updated BODY_TAG_START BODY_TAG_END  of JavadocTokenTypes

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/api/JavadocTokenTypes.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/api/JavadocTokenTypes.java
@@ -1701,9 +1701,99 @@ public final class JavadocTokenTypes {
 
     /** Body html tag. */
     public static final int BODY = JavadocParser.RULE_body + RULE_TYPES_OFFSET;
-    /** Start body tag. */
+
+    /**
+     * Start body tag.
+     *
+     * <p><b>Example:</b></p>
+     * <pre>{@code
+     * &lt;body&gt;
+     * This is a test
+     * &lt;/body&gt;
+     * }</pre>
+     * <b>Tree:</b>
+     * <pre>
+     * {@code
+     *   JAVADOC -> JAVADOC
+     *        |--TEXT -> /**
+     *        |--NEWLINE -> \n
+     *        |--LEADING_ASTERISK ->  *
+     *        |--TEXT ->
+     *        |--HTML_ELEMENT -> HTML_ELEMENT
+     *        |    `--BODY -> BODY
+     *        |         |--BODY_TAG_START -> BODY_TAG_START
+     *        |         |    |--START -> <
+     *        |         |    |--BODY_HTML_TAG_NAME -> body
+     *        |         |    `--END -> >
+     *        |         |--NEWLINE -> \n
+     *        |         |--LEADING_ASTERISK ->  *
+     *        |         |--TEXT ->  This is inside the body tag.
+     *        |         |--NEWLINE -> \n
+     *        |         |--LEADING_ASTERISK ->  *
+     *        |         |--TEXT ->
+     *        |         `--BODY_TAG_END -> BODY_TAG_END
+     *        |             |--START -> <
+     *        |             |--SLASH -> /
+     *        |             |--BODY_HTML_TAG_NAME -> body
+     *        |             `--END -> >
+     *          |--NEWLINE -> \n
+     *          |--LEADING_ASTERISK ->  *
+     *          |--TEXT -> /
+     *          |--NEWLINE -> \n
+     *          |--TEXT -> public class Test {
+     *          |--NEWLINE -> \n
+     *          |--TEXT -> }
+     *          |--NEWLINE -> \n
+     * }
+     * </pre>
+     */
     public static final int BODY_TAG_START = JavadocParser.RULE_bodyTagStart + RULE_TYPES_OFFSET;
-    /** End body tag. */
+
+    /**
+     * End body tag.
+     *
+     * <p><b>Example:</b></p>
+     * <pre>{@code
+     *  &lt;body&gt;
+     *     This is a test
+     * &lt;/body&gt;
+     * }</pre>
+     * <b>Tree:</b>
+     * <pre>
+     * {@code
+     *   JAVADOC -> JAVADOC
+     *        |--TEXT -> /**
+     *        |--NEWLINE -> \n
+     *        |--LEADING_ASTERISK ->  *
+     *        |--TEXT ->
+     *        |--HTML_ELEMENT -> HTML_ELEMENT
+     *        |    `--BODY -> BODY
+     *        |         |--BODY_TAG_START -> BODY_TAG_START
+     *        |         |    |--START -> <
+     *        |         |    |--BODY_HTML_TAG_NAME -> body
+     *        |         |    `--END -> >
+     *        |         |--NEWLINE -> \n
+     *        |         |--LEADING_ASTERISK ->  *
+     *        |         |--TEXT ->  This is inside the body tag.
+     *        |         |--NEWLINE -> \n
+     *        |         |--LEADING_ASTERISK ->  *
+     *        |         |--TEXT ->
+     *        |         `--BODY_TAG_END -> BODY_TAG_END
+     *        |             |--START -> <
+     *        |             |--SLASH -> /
+     *        |             |--BODY_HTML_TAG_NAME -> body
+     *        |             `--END -> >
+     *        |--NEWLINE -> \n
+     *        |--LEADING_ASTERISK ->  *
+     *        |--TEXT -> /
+     *        |--NEWLINE -> \n
+     *        |--TEXT -> public class Test {
+     *        |--NEWLINE -> \n
+     *        |--TEXT -> }
+     *        |--NEWLINE -> \n
+     * }
+     * </pre>
+     */
     public static final int BODY_TAG_END = JavadocParser.RULE_bodyTagEnd + RULE_TYPES_OFFSET;
 
     /** Colgroup html tag. */


### PR DESCRIPTION
Begins https://github.com/checkstyle/checkstyle/issues/14631

cat Test.java
/**
 * <body>
 * This is inside the body tag.
 * </body>
 */
public class TestBodyTag {
}

(base) youyun@youyundeMacBook-Air checkstyle % java -jar target/checkstyle-10.21.4-SNAPSHOT-all.jar -j Test.java | sed -E "s/\[[0-9]+:[0-9]+\]//g"
JAVADOC -> JAVADOC 
|--TEXT -> /** 
|--NEWLINE -> \n 
|--LEADING_ASTERISK ->  * 
|--TEXT ->   
|--HTML_ELEMENT -> HTML_ELEMENT 
|   `--BODY -> BODY 
|       |--BODY_TAG_START -> BODY_TAG_START 
|       |   |--START -> < 
|       |   |--BODY_HTML_TAG_NAME -> body 
|       |   `--END -> > 
|       |--NEWLINE -> \n 
|       |--LEADING_ASTERISK ->  * 
|       |--TEXT ->  This is inside the body tag. 
|       |--NEWLINE -> \n 
|       |--LEADING_ASTERISK ->  * 
|       |--TEXT ->   
|       `--BODY_TAG_END -> BODY_TAG_END 
|           |--START -> < 
|           |--SLASH -> / 
|           |--BODY_HTML_TAG_NAME -> body 
|           `--END -> > 
|--NEWLINE -> \n 
|--LEADING_ASTERISK ->  * 
|--TEXT -> / 
|--NEWLINE -> \n 
|--TEXT -> public class TestBodyTag { 
|--NEWLINE -> \n 
|--TEXT -> } 
|--NEWLINE -> \n 

