### PR TITLE
Issue #14019: Kill mutation for getMissedHtmlTag

### DIFF
--- a/config/checker-framework-suppressions/checker-nullness-optional-interning-suppressions.xml
+++ b/config/checker-framework-suppressions/checker-nullness-optional-interning-suppressions.xml
@@ -441,7 +441,7 @@
     <fileName>src/main/java/com/puppycrawl/tools/checkstyle/JavadocDetailNodeParser.java</fileName>
     <specifier>dereference.of.nullable</specifier>
     <message>dereference of possibly-null reference stack.peek()</message>
-    <lineContent>if (stack.peek().getText().equals(token.getText())) {</lineContent>
+    <lineContent>&amp;&amp; stack.peek().getText().equals(token.getText())) {</lineContent>
   </checkerFrameworkError>
 
   <checkerFrameworkError unstable="false">

--- a/config/pitest-suppressions/pitest-tree-walker-suppressions.xml
+++ b/config/pitest-suppressions/pitest-tree-walker-suppressions.xml
@@ -1,15 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <suppressedMutations>
   <mutation unstable="false">
-    <sourceFile>JavadocDetailNodeParser.java</sourceFile>
-    <mutatedClass>com.puppycrawl.tools.checkstyle.JavadocDetailNodeParser</mutatedClass>
-    <mutatedMethod>getMissedHtmlTag</mutatedMethod>
-    <mutator>org.pitest.mutationtest.engine.gregor.mutators.NonVoidMethodCallMutator</mutator>
-    <description>removed call to java/util/Deque::pop</description>
-    <lineContent>htmlTagNameStart = stack.pop();</lineContent>
-  </mutation>
-
-  <mutation unstable="false">
     <sourceFile>TreeWalker.java</sourceFile>
     <mutatedClass>com.puppycrawl.tools.checkstyle.TreeWalker</mutatedClass>
     <mutatedMethod>&lt;init&gt;</mutatedMethod>

--- a/src/main/java/com/puppycrawl/tools/checkstyle/JavadocDetailNodeParser.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/JavadocDetailNodeParser.java
@@ -484,7 +484,6 @@ public class JavadocDetailNodeParser {
      *     null otherwise
      */
     private static Token getMissedHtmlTag(RecognitionException exception) {
-        Token htmlTagNameStart = null;
         final Interval sourceInterval = exception.getCtx().getSourceInterval();
         final List<Token> tokenList = ((BufferedTokenStream) exception.getInputStream())
                 .getTokens(sourceInterval.a, sourceInterval.b);
@@ -496,20 +495,13 @@ public class JavadocDetailNodeParser {
                     && prevTokenType == JavadocTokenTypes.START) {
                 stack.push(token);
             }
-            else if (tokenType == JavadocTokenTypes.HTML_TAG_NAME && !stack.isEmpty()) {
-                if (stack.peek().getText().equals(token.getText())) {
-                    stack.pop();
-                }
-                else {
-                    htmlTagNameStart = stack.pop();
-                }
+            else if (tokenType == JavadocTokenTypes.HTML_TAG_NAME
+                    && stack.peek().getText().equals(token.getText())) {
+                stack.pop();
             }
             prevTokenType = tokenType;
         }
-        if (htmlTagNameStart == null) {
-            htmlTagNameStart = stack.pop();
-        }
-        return htmlTagNameStart;
+        return stack.pop();
     }
 
     /**


### PR DESCRIPTION
For #14019 

# Mutation

```xml
  <mutation unstable="false">
    <sourceFile>JavadocDetailNodeParser.java</sourceFile>
    <mutatedClass>com.puppycrawl.tools.checkstyle.JavadocDetailNodeParser</mutatedClass>
    <mutatedMethod>getMissedHtmlTag</mutatedMethod>
    <mutator>org.pitest.mutationtest.engine.gregor.mutators.NonVoidMethodCallMutator</mutator>
    <description>removed call to java/util/Deque::pop</description>
    <lineContent>htmlTagNameStart = stack.pop();</lineContent>
  </mutation>

```

# Modules

- `JavadocDetailNodeParser`

# Steps

- First, I hardcoded the mutation
- I ran `mvn clean verify` and all tests passed
- I generated the pitest report and there were no new surviving mutations
- I generated the diff report for `JavadocChecks` and there were no diff

# Analysis
- After hardcoding the mutation, I analyzed its behaviour and the impact on the code:
<img width="1757" height="817" alt="image" src="https://github.com/user-attachments/assets/c63d77a2-4829-4412-8cd9-a497993d6b65" />

1. Removal of `!stack.isEmpty()` check:
    1. I’ve reviewed the scenarios where the token type will be `HTML_TAG_NAME`, the stack is empty, and the previous token type is not `START`: 
        - For example, in cases like `</test>`, the method `getMissedHtmlTag()` is not invoked because `recognitionEx.getCtx()` is **not** an instance of `JavadocParser.HtmlTagContext`.
    - This suggests that removing the `stack.isEmpty()` check does not introduce incorrect behavior under currently handled scenarios.
    - **However**, there might still be an unhandled edge case (in both codes). @romani , maybe this could be an issue?
        - If a user writes something like this `<test test="hello">content` in Javadoc (attribute name is same as tag name), it will crash the program. so maybe we should add `&& prevToken == JavadocTokenTypes.SLASH`?
<img width="1209" height="530" alt="image (1)" src="https://github.com/user-attachments/assets/012ead61-eb18-4207-86ed-523bf426249e" />


2. Removal of `htmlTagNameStart` , because `stack.top()` will always provide the same logic (which is the latest unclosed html tag).


Attention:
updated method is used only in when parse exception happening, so it is not that easy to reproduce, and behavior on excpeption is not deterministic and users unlikely to be affected.
```
        catch (ParseCancellationException | IllegalArgumentException exc) {
            ParseErrorMessage parseErrorMessage = null;

            if (exc.getCause() instanceof FailedPredicateException
                    || exc.getCause() instanceof NoViableAltException) {
                final RecognitionException recognitionEx = (RecognitionException) exc.getCause();
                if (recognitionEx.getCtx() instanceof JavadocParser.HtmlTagContext) {
                    final Token htmlTagNameStart = getMissedHtmlTag(recognitionEx); <!----- here is target merthod
                    parseErrorMessage = new ParseErrorMessage(
                            errorListener.offset + htmlTagNameStart.getLine(),
                            MSG_JAVADOC_MISSED_HTML_CLOSE,
                            htmlTagNameStart.getCharPositionInLine(),
                            htmlTagNameStart.getText());
                }
            }
```