### PR TITLE
dependency: bump pmd.version from 7.10.0 to 7.11.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -210,7 +210,7 @@
     <maven.site.plugin.version>3.21.0</maven.site.plugin.version>
     <maven.spotbugs.plugin.version>4.9.1.0</maven.spotbugs.plugin.version>
     <maven.pmd.plugin.version>3.26.0</maven.pmd.plugin.version>
-    <pmd.version>7.10.0</pmd.version>
+    <pmd.version>7.11.0</pmd.version>
     <maven.jacoco.plugin.version>0.8.12</maven.jacoco.plugin.version>
     <mockito.version>5.2.0</mockito.version>
     <saxon.version>12.5</saxon.version>

--- a/src/it/java/org/checkstyle/suppressionxpathfilter/XpathRegressionAvoidDoubleBraceInitializationTest.java
+++ b/src/it/java/org/checkstyle/suppressionxpathfilter/XpathRegressionAvoidDoubleBraceInitializationTest.java
@@ -30,12 +30,12 @@ import com.puppycrawl.tools.checkstyle.checks.coding.AvoidDoubleBraceInitializat
 
 public class XpathRegressionAvoidDoubleBraceInitializationTest extends AbstractXpathTestSupport {
 
-    private final Class<AvoidDoubleBraceInitializationCheck> clazz =
+    private static final Class<AvoidDoubleBraceInitializationCheck> CLAZZ =
         AvoidDoubleBraceInitializationCheck.class;
 
     @Override
     protected String getCheckName() {
-        return clazz.getSimpleName();
+        return CLAZZ.getSimpleName();
     }
 
     @Test
@@ -43,10 +43,10 @@ public class XpathRegressionAvoidDoubleBraceInitializationTest extends AbstractX
         final File fileToProcess = new File(
             getPath("InputXpathAvoidDoubleBraceInitializationClassFields.java"));
 
-        final DefaultConfiguration moduleConfig = createModuleConfig(clazz);
+        final DefaultConfiguration moduleConfig = createModuleConfig(CLAZZ);
 
         final String[] expectedViolation = {
-            "6:41: " + getCheckMessage(clazz, AvoidDoubleBraceInitializationCheck.MSG_KEY),
+            "6:41: " + getCheckMessage(CLAZZ, AvoidDoubleBraceInitializationCheck.MSG_KEY),
         };
 
         final List<String> expectedXpathQueries = Arrays.asList(
@@ -68,10 +68,10 @@ public class XpathRegressionAvoidDoubleBraceInitializationTest extends AbstractX
         final File fileToProcess = new File(
             getPath("InputXpathAvoidDoubleBraceInitializationMethodDef.java"));
 
-        final DefaultConfiguration moduleConfig = createModuleConfig(clazz);
+        final DefaultConfiguration moduleConfig = createModuleConfig(CLAZZ);
 
         final String[] expectedViolation = {
-            "7:31: " + getCheckMessage(clazz, AvoidDoubleBraceInitializationCheck.MSG_KEY),
+            "7:31: " + getCheckMessage(CLAZZ, AvoidDoubleBraceInitializationCheck.MSG_KEY),
         };
 
         final List<String> expectedXpathQueries = Arrays.asList(

--- a/src/it/java/org/checkstyle/suppressionxpathfilter/XpathRegressionConstructorsDeclarationGroupingTest.java
+++ b/src/it/java/org/checkstyle/suppressionxpathfilter/XpathRegressionConstructorsDeclarationGroupingTest.java
@@ -30,12 +30,12 @@ import com.puppycrawl.tools.checkstyle.checks.coding.ConstructorsDeclarationGrou
 
 public class XpathRegressionConstructorsDeclarationGroupingTest extends AbstractXpathTestSupport {
 
-    private final Class<ConstructorsDeclarationGroupingCheck> clazz =
+    private static final Class<ConstructorsDeclarationGroupingCheck> CLAZZ =
             ConstructorsDeclarationGroupingCheck.class;
 
     @Override
     protected String getCheckName() {
-        return clazz.getSimpleName();
+        return CLAZZ.getSimpleName();
     }
 
     @Test
@@ -43,10 +43,10 @@ public class XpathRegressionConstructorsDeclarationGroupingTest extends Abstract
         final File fileToProcess = new File(
                 getPath("InputXpathConstructorsDeclarationGroupingClass.java"));
 
-        final DefaultConfiguration moduleConfig = createModuleConfig(clazz);
+        final DefaultConfiguration moduleConfig = createModuleConfig(CLAZZ);
 
         final String[] expectedViolation = {
-            "10:5: " + getCheckMessage(clazz,
+            "10:5: " + getCheckMessage(CLAZZ,
                     ConstructorsDeclarationGroupingCheck.MSG_KEY, 6),
         };
 
@@ -75,10 +75,10 @@ public class XpathRegressionConstructorsDeclarationGroupingTest extends Abstract
         final File fileToProcess = new File(
                 getPath("InputXpathConstructorsDeclarationGroupingEnum.java"));
 
-        final DefaultConfiguration moduleConfig = createModuleConfig(clazz);
+        final DefaultConfiguration moduleConfig = createModuleConfig(CLAZZ);
 
         final String[] expectedViolation = {
-            "12:5: " + getCheckMessage(clazz,
+            "12:5: " + getCheckMessage(CLAZZ,
                     ConstructorsDeclarationGroupingCheck.MSG_KEY, 8),
         };
 
@@ -108,10 +108,10 @@ public class XpathRegressionConstructorsDeclarationGroupingTest extends Abstract
         final File fileToProcess = new File(
                 getNonCompilablePath("InputXpathConstructorsDeclarationGroupingRecords.java"));
 
-        final DefaultConfiguration moduleConfig = createModuleConfig(clazz);
+        final DefaultConfiguration moduleConfig = createModuleConfig(CLAZZ);
 
         final String[] expectedViolation = {
-            "14:5: " + getCheckMessage(clazz,
+            "14:5: " + getCheckMessage(CLAZZ,
                     ConstructorsDeclarationGroupingCheck.MSG_KEY, 8),
         };
 

--- a/src/it/java/org/checkstyle/suppressionxpathfilter/XpathRegressionEmptyCatchBlockTest.java
+++ b/src/it/java/org/checkstyle/suppressionxpathfilter/XpathRegressionEmptyCatchBlockTest.java
@@ -30,12 +30,12 @@ import com.puppycrawl.tools.checkstyle.checks.blocks.EmptyCatchBlockCheck;
 
 public class XpathRegressionEmptyCatchBlockTest extends AbstractXpathTestSupport {
 
-    private final Class<EmptyCatchBlockCheck> clazz =
+    private static final Class<EmptyCatchBlockCheck> CLAZZ =
         EmptyCatchBlockCheck.class;
 
     @Override
     protected String getCheckName() {
-        return clazz.getSimpleName();
+        return CLAZZ.getSimpleName();
     }
 
     @Test
@@ -43,10 +43,10 @@ public class XpathRegressionEmptyCatchBlockTest extends AbstractXpathTestSupport
         final File fileToProcess = new File(
             getPath("InputXpathEmptyCatchBlockOne.java"));
 
-        final DefaultConfiguration moduleConfig = createModuleConfig(clazz);
+        final DefaultConfiguration moduleConfig = createModuleConfig(CLAZZ);
 
         final String[] expectedViolation = {
-            "8:38: " + getCheckMessage(clazz, EmptyCatchBlockCheck.MSG_KEY_CATCH_BLOCK_EMPTY),
+            "8:38: " + getCheckMessage(CLAZZ, EmptyCatchBlockCheck.MSG_KEY_CATCH_BLOCK_EMPTY),
         };
 
         final List<String> expectedXpathQueries = Collections.singletonList(
@@ -64,10 +64,10 @@ public class XpathRegressionEmptyCatchBlockTest extends AbstractXpathTestSupport
         final File fileToProcess = new File(
             getPath("InputXpathEmptyCatchBlockTwo.java"));
 
-        final DefaultConfiguration moduleConfig = createModuleConfig(clazz);
+        final DefaultConfiguration moduleConfig = createModuleConfig(CLAZZ);
 
         final String[] expectedViolation = {
-            "8:47: " + getCheckMessage(clazz, EmptyCatchBlockCheck.MSG_KEY_CATCH_BLOCK_EMPTY),
+            "8:47: " + getCheckMessage(CLAZZ, EmptyCatchBlockCheck.MSG_KEY_CATCH_BLOCK_EMPTY),
         };
 
         final List<String> expectedXpathQueries = Collections.singletonList(

--- a/src/it/java/org/checkstyle/suppressionxpathfilter/XpathRegressionEqualsAvoidNullTest.java
+++ b/src/it/java/org/checkstyle/suppressionxpathfilter/XpathRegressionEqualsAvoidNullTest.java
@@ -30,11 +30,11 @@ import com.puppycrawl.tools.checkstyle.checks.coding.EqualsAvoidNullCheck;
 
 public class XpathRegressionEqualsAvoidNullTest extends AbstractXpathTestSupport {
 
-    private final Class<EqualsAvoidNullCheck> clazz = EqualsAvoidNullCheck.class;
+    private static final Class<EqualsAvoidNullCheck> CLAZZ = EqualsAvoidNullCheck.class;
 
     @Override
     protected String getCheckName() {
-        return clazz.getSimpleName();
+        return CLAZZ.getSimpleName();
     }
 
     @Test
@@ -42,10 +42,10 @@ public class XpathRegressionEqualsAvoidNullTest extends AbstractXpathTestSupport
         final File fileToProcess = new File(
             getPath("InputXpathEqualsAvoidNull.java"));
 
-        final DefaultConfiguration moduleConfig = createModuleConfig(clazz);
+        final DefaultConfiguration moduleConfig = createModuleConfig(CLAZZ);
 
         final String[] expectedViolation = {
-            "6:26: " + getCheckMessage(clazz,
+            "6:26: " + getCheckMessage(CLAZZ,
                     EqualsAvoidNullCheck.MSG_EQUALS_AVOID_NULL),
         };
 
@@ -65,10 +65,10 @@ public class XpathRegressionEqualsAvoidNullTest extends AbstractXpathTestSupport
         final File fileToProcess = new File(
             getPath("InputXpathEqualsAvoidNullIgnoreCase.java"));
 
-        final DefaultConfiguration moduleConfig = createModuleConfig(clazz);
+        final DefaultConfiguration moduleConfig = createModuleConfig(CLAZZ);
 
         final String[] expectedViolation = {
-            "6:36: " + getCheckMessage(clazz,
+            "6:36: " + getCheckMessage(CLAZZ,
                     EqualsAvoidNullCheck.MSG_EQUALS_IGNORE_CASE_AVOID_NULL),
         };
 

--- a/src/it/java/org/checkstyle/suppressionxpathfilter/XpathRegressionMissingSwitchDefaultTest.java
+++ b/src/it/java/org/checkstyle/suppressionxpathfilter/XpathRegressionMissingSwitchDefaultTest.java
@@ -31,11 +31,11 @@ import com.puppycrawl.tools.checkstyle.checks.coding.MissingSwitchDefaultCheck;
 
 public class XpathRegressionMissingSwitchDefaultTest extends AbstractXpathTestSupport {
 
-    private final Class<MissingSwitchDefaultCheck> clss = MissingSwitchDefaultCheck.class;
+    private static final Class<MissingSwitchDefaultCheck> CLAZZ = MissingSwitchDefaultCheck.class;
 
     @Override
     protected String getCheckName() {
-        return clss.getSimpleName();
+        return CLAZZ.getSimpleName();
     }
 
     @Test
@@ -43,9 +43,9 @@ public class XpathRegressionMissingSwitchDefaultTest extends AbstractXpathTestSu
         final File fileToProcess =
                 new File(getPath("InputXpathMissingSwitchDefaultSimple.java"));
 
-        final DefaultConfiguration moduleConfig = createModuleConfig(clss);
+        final DefaultConfiguration moduleConfig = createModuleConfig(CLAZZ);
         final String[] expectedViolation = {
-            "6:9: " + getCheckMessage(clss, MissingSwitchDefaultCheck.MSG_KEY),
+            "6:9: " + getCheckMessage(CLAZZ, MissingSwitchDefaultCheck.MSG_KEY),
         };
 
         final List<String> expectedXpathQueries = Collections.singletonList(
@@ -63,10 +63,10 @@ public class XpathRegressionMissingSwitchDefaultTest extends AbstractXpathTestSu
         final File fileToProcess =
                 new File(getPath("InputXpathMissingSwitchDefaultNested.java"));
 
-        final DefaultConfiguration moduleConfig = createModuleConfig(clss);
+        final DefaultConfiguration moduleConfig = createModuleConfig(CLAZZ);
 
         final String[] expectedViolation = {
-            "12:17: " + getCheckMessage(clss, MissingSwitchDefaultCheck.MSG_KEY),
+            "12:17: " + getCheckMessage(CLAZZ, MissingSwitchDefaultCheck.MSG_KEY),
         };
 
         final List<String> expectedXpathQueries = Arrays.asList(

--- a/src/it/java/org/checkstyle/suppressionxpathfilter/XpathRegressionModifiedControlVariableTest.java
+++ b/src/it/java/org/checkstyle/suppressionxpathfilter/XpathRegressionModifiedControlVariableTest.java
@@ -29,21 +29,21 @@ import com.puppycrawl.tools.checkstyle.DefaultConfiguration;
 import com.puppycrawl.tools.checkstyle.checks.coding.ModifiedControlVariableCheck;
 
 public class XpathRegressionModifiedControlVariableTest extends AbstractXpathTestSupport {
-    private final Class<ModifiedControlVariableCheck> checkClass =
+    private static final Class<ModifiedControlVariableCheck> CLAZZ =
             ModifiedControlVariableCheck.class;
 
     @Override
     protected String getCheckName() {
-        return checkClass.getSimpleName();
+        return CLAZZ.getSimpleName();
     }
 
     @Test
     public void testDefaultForLoop() throws Exception {
         final File fileToProcess = new File(
                 getPath("InputXpathModifiedControlVariableWithFor.java"));
-        final DefaultConfiguration moduleConfig = createModuleConfig(checkClass);
+        final DefaultConfiguration moduleConfig = createModuleConfig(CLAZZ);
         final String[] expectedViolation = {
-            "6:14: " + getCheckMessage(checkClass,
+            "6:14: " + getCheckMessage(CLAZZ,
                     ModifiedControlVariableCheck.MSG_KEY, "i"),
         };
 
@@ -63,9 +63,9 @@ public class XpathRegressionModifiedControlVariableTest extends AbstractXpathTes
     public void testDefaultForeach() throws Exception {
         final File fileToProcess = new File(
                 getPath("InputXpathModifiedControlVariableWithForeach.java"));
-        final DefaultConfiguration moduleConfig = createModuleConfig(checkClass);
+        final DefaultConfiguration moduleConfig = createModuleConfig(CLAZZ);
         final String[] expectedViolation = {
-            "7:15: " + getCheckMessage(checkClass,
+            "7:15: " + getCheckMessage(CLAZZ,
                         ModifiedControlVariableCheck.MSG_KEY, "s"),
         };
         final List<String> expectedXpathQueries = Arrays.asList(
@@ -84,10 +84,10 @@ public class XpathRegressionModifiedControlVariableTest extends AbstractXpathTes
     public void testSkipEnhancedForLoop() throws Exception {
         final File fileToProcess = new File(
                 getPath("InputXpathModifiedControlVariableSkipEnhancedForLoop.java"));
-        final DefaultConfiguration moduleConfig = createModuleConfig(checkClass);
+        final DefaultConfiguration moduleConfig = createModuleConfig(CLAZZ);
         moduleConfig.addProperty("skipEnhancedForLoopVariable", "true");
         final String[] expectedViolation = {
-            "10:14: " + getCheckMessage(checkClass,
+            "10:14: " + getCheckMessage(CLAZZ,
                         ModifiedControlVariableCheck.MSG_KEY, "i"),
         };
 
@@ -107,9 +107,9 @@ public class XpathRegressionModifiedControlVariableTest extends AbstractXpathTes
     public void testDefaultNestedForLoop() throws Exception {
         final File fileToProcess = new File(
                 getPath("InputXpathModifiedControlVariableNestedWithFor.java"));
-        final DefaultConfiguration moduleConfig = createModuleConfig(checkClass);
+        final DefaultConfiguration moduleConfig = createModuleConfig(CLAZZ);
         final String[] expectedViolation = {
-            "7:19: " + getCheckMessage(checkClass,
+            "7:19: " + getCheckMessage(CLAZZ,
                     ModifiedControlVariableCheck.MSG_KEY, "j"),
         };
 
@@ -131,9 +131,9 @@ public class XpathRegressionModifiedControlVariableTest extends AbstractXpathTes
     public void testForeachNested() throws Exception {
         final File fileToProcess = new File(
                 getPath("InputXpathModifiedControlVariableNestedWithForeach.java"));
-        final DefaultConfiguration moduleConfig = createModuleConfig(checkClass);
+        final DefaultConfiguration moduleConfig = createModuleConfig(CLAZZ);
         final String[] expectedViolation = {
-            "8:19: " + getCheckMessage(checkClass,
+            "8:19: " + getCheckMessage(CLAZZ,
                     ModifiedControlVariableCheck.MSG_KEY, "s"),
         };
 
@@ -155,10 +155,10 @@ public class XpathRegressionModifiedControlVariableTest extends AbstractXpathTes
     public void testSkipEnhancedForLoopNested() throws Exception {
         final File fileToProcess = new File(
                 getPath("InputXpathModifiedControlVariableNestedSkipEnhancedForLoop.java"));
-        final DefaultConfiguration moduleConfig = createModuleConfig(checkClass);
+        final DefaultConfiguration moduleConfig = createModuleConfig(CLAZZ);
         moduleConfig.addProperty("skipEnhancedForLoopVariable", "true");
         final String[] expectedViolation = {
-            "10:15: " + getCheckMessage(checkClass,
+            "10:15: " + getCheckMessage(CLAZZ,
                     ModifiedControlVariableCheck.MSG_KEY, "i"),
         };
 

--- a/src/it/java/org/checkstyle/suppressionxpathfilter/XpathRegressionModifierOrderTest.java
+++ b/src/it/java/org/checkstyle/suppressionxpathfilter/XpathRegressionModifierOrderTest.java
@@ -31,11 +31,11 @@ import com.puppycrawl.tools.checkstyle.checks.modifier.ModifierOrderCheck;
 
 public class XpathRegressionModifierOrderTest extends AbstractXpathTestSupport {
 
-    private final Class<ModifierOrderCheck> clazz = ModifierOrderCheck.class;
+    private static final Class<ModifierOrderCheck> CLAZZ = ModifierOrderCheck.class;
 
     @Override
     protected String getCheckName() {
-        return clazz.getSimpleName();
+        return CLAZZ.getSimpleName();
     }
 
     @Test
@@ -43,10 +43,10 @@ public class XpathRegressionModifierOrderTest extends AbstractXpathTestSupport {
         final File fileToProcess = new File(
             getPath("InputXpathModifierOrderMethod.java"));
 
-        final DefaultConfiguration moduleConfig = createModuleConfig(clazz);
+        final DefaultConfiguration moduleConfig = createModuleConfig(CLAZZ);
 
         final String[] expectedViolation = {
-            "4:13: " + getCheckMessage(clazz,
+            "4:13: " + getCheckMessage(CLAZZ,
                     ModifierOrderCheck.MSG_ANNOTATION_ORDER, "@MethodAnnotation"),
         };
 
@@ -68,10 +68,10 @@ public class XpathRegressionModifierOrderTest extends AbstractXpathTestSupport {
         final File fileToProcess = new File(
             getPath("InputXpathModifierOrderVariable.java"));
 
-        final DefaultConfiguration moduleConfig = createModuleConfig(clazz);
+        final DefaultConfiguration moduleConfig = createModuleConfig(CLAZZ);
 
         final String[] expectedViolation = {
-            "3:12: " + getCheckMessage(clazz,
+            "3:12: " + getCheckMessage(CLAZZ,
                     ModifierOrderCheck.MSG_MODIFIER_ORDER, "private"),
         };
 
@@ -88,10 +88,10 @@ public class XpathRegressionModifierOrderTest extends AbstractXpathTestSupport {
         final File fileToProcess = new File(
             getPath("InputXpathModifierOrderAnnotation.java"));
 
-        final DefaultConfiguration moduleConfig = createModuleConfig(clazz);
+        final DefaultConfiguration moduleConfig = createModuleConfig(CLAZZ);
 
         final String[] expectedViolation = {
-            "3:8: " + getCheckMessage(clazz,
+            "3:8: " + getCheckMessage(CLAZZ,
                     ModifierOrderCheck.MSG_ANNOTATION_ORDER, "@InterfaceAnnotation"),
         };
 

--- a/src/it/java/org/checkstyle/suppressionxpathfilter/XpathRegressionOverloadMethodsDeclarationOrderTest.java
+++ b/src/it/java/org/checkstyle/suppressionxpathfilter/XpathRegressionOverloadMethodsDeclarationOrderTest.java
@@ -30,12 +30,12 @@ import com.puppycrawl.tools.checkstyle.checks.coding.OverloadMethodsDeclarationO
 
 public class XpathRegressionOverloadMethodsDeclarationOrderTest extends AbstractXpathTestSupport {
 
-    private final Class<OverloadMethodsDeclarationOrderCheck> clazz =
+    private static final Class<OverloadMethodsDeclarationOrderCheck> CLAZZ =
             OverloadMethodsDeclarationOrderCheck.class;
 
     @Override
     protected String getCheckName() {
-        return clazz.getSimpleName();
+        return CLAZZ.getSimpleName();
     }
 
     @Test
@@ -43,10 +43,10 @@ public class XpathRegressionOverloadMethodsDeclarationOrderTest extends Abstract
         final File fileToProcess = new File(
                 getPath("InputXpathOverloadMethodsDeclarationOrderDefault.java"));
 
-        final DefaultConfiguration moduleConfig = createModuleConfig(clazz);
+        final DefaultConfiguration moduleConfig = createModuleConfig(CLAZZ);
 
         final String[] expectedViolation = {
-            "14:5: " + getCheckMessage(clazz,
+            "14:5: " + getCheckMessage(CLAZZ,
                         OverloadMethodsDeclarationOrderCheck.MSG_KEY, "5"),
         };
 
@@ -71,10 +71,10 @@ public class XpathRegressionOverloadMethodsDeclarationOrderTest extends Abstract
         final File fileToProcess = new File(
                 getPath("InputXpathOverloadMethodsDeclarationOrderAnonymous.java"));
 
-        final DefaultConfiguration moduleConfig = createModuleConfig(clazz);
+        final DefaultConfiguration moduleConfig = createModuleConfig(CLAZZ);
 
         final String[] expectedViolation = {
-            "30:9: " + getCheckMessage(clazz,
+            "30:9: " + getCheckMessage(CLAZZ,
                     OverloadMethodsDeclarationOrderCheck.MSG_KEY, "21"),
         };
 

--- a/src/it/java/org/checkstyle/suppressionxpathfilter/XpathRegressionUncommentedMainTest.java
+++ b/src/it/java/org/checkstyle/suppressionxpathfilter/XpathRegressionUncommentedMainTest.java
@@ -30,12 +30,12 @@ import com.puppycrawl.tools.checkstyle.checks.UncommentedMainCheck;
 
 public class XpathRegressionUncommentedMainTest extends AbstractXpathTestSupport {
 
-    private final Class<UncommentedMainCheck> clazz =
+    private static final Class<UncommentedMainCheck> CLAZZ =
             UncommentedMainCheck.class;
 
     @Override
     protected String getCheckName() {
-        return clazz.getSimpleName();
+        return CLAZZ.getSimpleName();
     }
 
     @Test


### PR DESCRIPTION
solves -#16447  : dependency bump  bump pmd.version from 7.10.0 to 7.11.0

https://dev.azure.com/romanivanovjr/romanivanovjr/_build/results?buildId=26513&view=logs&j=7c725a47-0ff7-59ff-90e3-3cd594a39550&t=8f072c98-5edb-5957-d66c-9e7f0eebe900&l=1869

```
[INFO] --- pmd:3.26.0:check (default) @ checkstyle ---
[WARNING] PMD Failure: org.checkstyle.suppressionxpathfilter.XpathRegressionAvoidDoubleBraceInitializationTest:33 Rule:FinalFieldCouldBeStatic Priority:3 This final field could be made static.
[WARNING] PMD Failure: org.checkstyle.suppressionxpathfilter.XpathRegressionConstructorsDeclarationGroupingTest:33 Rule:FinalFieldCouldBeStatic Priority:3 This final field could be made static.
[WARNING] PMD Failure: org.checkstyle.suppressionxpathfilter.XpathRegressionEmptyCatchBlockTest:33 Rule:FinalFieldCouldBeStatic Priority:3 This final field could be made static.
[WARNING] PMD Failure: org.checkstyle.suppressionxpathfilter.XpathRegressionEqualsAvoidNullTest:33 Rule:FinalFieldCouldBeStatic Priority:3 This final field could be made static.
[WARNING] PMD Failure: org.checkstyle.suppressionxpathfilter.XpathRegressionMissingSwitchDefaultTest:34 Rule:FinalFieldCouldBeStatic Priority:3 This final field could be made static.
[WARNING] PMD Failure: org.checkstyle.suppressionxpathfilter.XpathRegressionModifiedControlVariableTest:32 Rule:FinalFieldCouldBeStatic Priority:3 This final field could be made static.
[WARNING] PMD Failure: org.checkstyle.suppressionxpathfilter.XpathRegressionModifierOrderTest:34 Rule:FinalFieldCouldBeStatic Priority:3 This final field could be made static.
[WARNING] PMD Failure: org.checkstyle.suppressionxpathfilter.XpathRegressionOverloadMethodsDeclarationOrderTest:33 Rule:FinalFieldCouldBeStatic Priority:3 This final field could be made static.
[WARNING] PMD Failure: org.checkstyle.suppressionxpathfilter.XpathRegressionUncommentedMainTest:33 Rule:FinalFieldCouldBeStatic Priority:3 This final field could be made static.

```