### PR TITLE
Issue #14631: Updated hash_literal in JavadocTokenTypes.java to new AST format

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/api/JavadocTokenTypes.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/api/JavadocTokenTypes.java
@@ -740,17 +740,17 @@ public final class JavadocTokenTypes {
      * <b>Tree:</b>
      * <pre>
      * {@code
-     * JAVADOC_TAG -&gt JAVADOC_TAG
-     *  |--SEE_LITERAL -&gt @see
-     *  |--WS -&gt
-     *  |--REFERENCE -&gt REFERENCE
-     *      |--PACKAGE_CLASS -&gt org.apache.utils.Lists.Comparator
-     *      |--HASH -&gt #
-     *      |--MEMBER -&gt compare
-     *      `--PARAMETERS -&gt PARAMETERS
-     *          |--LEFT_BRACE -&gt (
-     *          |--ARGUMENT -&gt Object
-     *          `--RIGHT_BRACE -&gt )
+     * JAVADOC_TAG -> JAVADOC_TAG
+     *  |--SEE_LITERAL -> @see
+     *  |--WS ->
+     *  |--REFERENCE -> REFERENCE
+     *      |--PACKAGE_CLASS -> org.apache.utils.Lists.Comparator
+     *      |--HASH -> #
+     *      |--MEMBER -> compare
+     *      `--PARAMETERS -> PARAMETERS
+     *          |--LEFT_BRACE -> (
+     *          |--ARGUMENT -> Object
+     *          `--RIGHT_BRACE -> )
      * }
      * </pre>
      */


### PR DESCRIPTION
Issue: #14631

**Command used**
java -jar checkstyle-10.21.3-all.jar -J Test.java | sed "s/\[[0-9]\+:[0-9]\+\]//g"

**Test.java**
```
/**
 * @see org.apache.utils.Lists.Comparator#compare(Object)
 */
public class Test {
}

```


```
athar@Atharv MINGW64 ~/OneDrive/Desktop/hash_literal
$ java -jar checkstyle-10.21.3-all.jar -J Test.java | sed "s/\[[0-9]\+:[0-9]\+\]//g"
COMPILATION_UNIT -> COMPILATION_UNIT
`--CLASS_DEF -> CLASS_DEF
    |--MODIFIERS -> MODIFIERS
    |   |--BLOCK_COMMENT_BEGIN -> /*
    |   |   |--COMMENT_CONTENT -> *\r\n * @see org.apache.utils.Lists.Comparator#compare(Object)\r\n
    |   |   |   `--JAVADOC -> JAVADOC
    |   |   |       |--NEWLINE -> \r\n
    |   |   |       |--LEADING_ASTERISK ->  *
    |   |   |       |--WS ->
    |   |   |       |--JAVADOC_TAG -> JAVADOC_TAG
    |   |   |       |   |--SEE_LITERAL -> @see
    |   |   |       |   |--WS ->
    |   |   |       |   |--REFERENCE -> REFERENCE
    |   |   |       |   |   |--PACKAGE_CLASS -> org.apache.utils.Lists.Comparator
    |   |   |       |   |   |--HASH -> #
    |   |   |       |   |   |--MEMBER -> compare
    |   |   |       |   |   `--PARAMETERS -> PARAMETERS
    |   |   |       |   |       |--LEFT_BRACE -> (
    |   |   |       |   |       |--ARGUMENT -> Object
    |   |   |       |   |       `--RIGHT_BRACE -> )
    |   |   |       |   |--NEWLINE -> \r\n
    |   |   |       |   `--WS ->
    |   |   |       `--EOF -> <EOF>
    |   |   `--BLOCK_COMMENT_END -> */
    |   `--LITERAL_PUBLIC -> public
    |--LITERAL_CLASS -> class
    |--IDENT -> Test
    `--OBJBLOCK -> OBJBLOCK
        |--LCURLY -> {
        `--RCURLY -> }


```