### PR TITLE
Issue #14019: kill mutation of SarifLogger readResource Method

### DIFF
--- a/config/pitest-suppressions/pitest-common-suppressions.xml
+++ b/config/pitest-suppressions/pitest-common-suppressions.xml
@@ -19,15 +19,6 @@
   </mutation>
 
   <mutation unstable="false">
-    <sourceFile>SarifLogger.java</sourceFile>
-    <mutatedClass>com.puppycrawl.tools.checkstyle.SarifLogger</mutatedClass>
-    <mutatedMethod>readResource</mutatedMethod>
-    <mutator>org.pitest.mutationtest.engine.gregor.mutators.NonVoidMethodCallMutator</mutator>
-    <description>removed call to java/io/InputStream::read</description>
-    <lineContent>int length = inputStream.read(buffer);</lineContent>
-  </mutation>
-
-  <mutation unstable="false">
     <sourceFile>XMLLogger.java</sourceFile>
     <mutatedClass>com.puppycrawl.tools.checkstyle.XMLLogger</mutatedClass>
     <mutatedMethod>auditStarted</mutatedMethod>

--- a/src/main/java/com/puppycrawl/tools/checkstyle/SarifLogger.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/SarifLogger.java
@@ -356,7 +356,7 @@ public class SarifLogger extends AbstractAutomaticBean implements AuditListener 
                 throw new IOException("Cannot find the resource " + name);
             }
             final byte[] buffer = new byte[BUFFER_SIZE];
-            int length = inputStream.read(buffer);
+            int length = 0;
             while (length != -1) {
                 result.write(buffer, 0, length);
                 length = inputStream.read(buffer);


### PR DESCRIPTION
Issue #14019

Kill mutation for `SarifLogger` `NonVoidMethodCallMutator on final String version = SarifLogger.class.getPackage().getImplementationVersion();`

**Reason for Mutation:**
On `readResource` method under `SarifLogger.java`, we are writing the `buffer` on `result` variable in some `n iterations of while loop` but by the mutation it makes the `initial assignment` of `length` variable as `0` and this will not affect the `result` variable so all test cases passed.

**Kill mutation:**
Makes the `initial assignment` of `length` variable as `0` by own. By this, all logic remains as usual, and it can't change because it will affect the `result` variable, and test cases will fail.