### PR TITLE
Issue #8807: reuse suppressions on SuppressWithPlainTextCommentFilter

### DIFF
--- a/config/checker-framework-suppressions/checker-lock-tainting-suppressions.xml
+++ b/config/checker-framework-suppressions/checker-lock-tainting-suppressions.xml
@@ -1021,6 +1021,21 @@
 
   <checkerFrameworkError unstable="false">
     <fileName>src/main/java/com/puppycrawl/tools/checkstyle/filters/SuppressWithPlainTextCommentFilter.java</fileName>
+    <specifier>methodref.receiver.bound</specifier>
+    <message>Incompatible receiver type</message>
+    <lineContent>suppression.ifPresent(currentFileSuppressionCache::add);</lineContent>
+    <details>
+      found   : @GuardedBy Collection&lt;@GuardedBy Suppression&gt;
+      required: @GuardSatisfied Collection&lt;@GuardedBy Suppression&gt;
+      Consequence: method
+      @GuardedBy Collection&lt;@GuardedBy Suppression&gt;
+      is not a valid method reference for method in @GuardedBy Collection&lt;@GuardedBy Suppression&gt;
+      @GuardedBy boolean add(@GuardSatisfied Collection&lt;@GuardedBy Suppression&gt; this, @GuardedBy Suppression p0)
+    </details>
+  </checkerFrameworkError>
+
+  <checkerFrameworkError unstable="false">
+    <fileName>src/main/java/com/puppycrawl/tools/checkstyle/filters/SuppressWithPlainTextCommentFilter.java</fileName>
     <specifier>override.param</specifier>
     <message>Incompatible parameter type for other.</message>
     <lineContent>public boolean equals(Object other) {</lineContent>

--- a/src/main/java/com/puppycrawl/tools/checkstyle/filters/SuppressWithPlainTextCommentFilter.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/filters/SuppressWithPlainTextCommentFilter.java
@@ -24,7 +24,6 @@ import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Collection;
-import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.regex.Matcher;
@@ -127,6 +126,12 @@ public class SuppressWithPlainTextCommentFilter extends AbstractAutomaticBean im
     /** Default check format to suppress. By default, the filter suppress all checks. */
     private static final String DEFAULT_CHECK_FORMAT = ".*";
 
+    /** List of suppressions from the file. By default, Its null. */
+    private final Collection<Suppression> currentFileSuppressionCache = new ArrayList<>();
+
+    /** File name that was suppressed. By default, Its empty. */
+    private String currentFileName = "";
+
     /** Specify comment pattern to trigger filter to begin suppression. */
     private Pattern offCommentFormat = CommonUtil.createPattern(DEFAULT_OFF_FORMAT);
 
@@ -199,11 +204,18 @@ public class SuppressWithPlainTextCommentFilter extends AbstractAutomaticBean im
     public boolean accept(AuditEvent event) {
         boolean accepted = true;
         if (event.getViolation() != null) {
-            final FileText fileText = getFileText(event.getFileName());
-            if (fileText != null) {
-                final List<Suppression> suppressions = getSuppressions(fileText);
-                accepted = getNearestSuppression(suppressions, event) == null;
+            final String eventFileName = event.getFileName();
+
+            if (!currentFileName.equals(eventFileName)) {
+                currentFileName = eventFileName;
+                final FileText fileText = getFileText(eventFileName);
+                currentFileSuppressionCache.clear();
+                if (fileText != null) {
+                    cacheSuppressions(fileText);
+                }
             }
+
+            accepted = getNearestSuppression(currentFileSuppressionCache, event) == null;
         }
         return accepted;
     }
@@ -214,7 +226,7 @@ public class SuppressWithPlainTextCommentFilter extends AbstractAutomaticBean im
     }
 
     /**
-     * Returns {@link FileText} instance created based on the given file name.
+     * Caches {@link FileText} instance created based on the given file name.
      *
      * @param fileName the name of the file.
      * @return {@link FileText} instance.
@@ -238,18 +250,15 @@ public class SuppressWithPlainTextCommentFilter extends AbstractAutomaticBean im
     }
 
     /**
-     * Returns the list of {@link Suppression} instances retrieved from the given {@link FileText}.
+     * Collects the list of {@link Suppression} instances retrieved from the given {@link FileText}.
      *
      * @param fileText {@link FileText} instance.
-     * @return list of {@link Suppression} instances.
      */
-    private List<Suppression> getSuppressions(FileText fileText) {
-        final List<Suppression> suppressions = new ArrayList<>();
+    private void cacheSuppressions(FileText fileText) {
         for (int lineNo = 0; lineNo < fileText.size(); lineNo++) {
             final Optional<Suppression> suppression = getSuppression(fileText, lineNo);
-            suppression.ifPresent(suppressions::add);
+            suppression.ifPresent(currentFileSuppressionCache::add);
         }
-        return suppressions;
     }
 
     /**


### PR DESCRIPTION
Issue #8807

`SuppressWithPlainTextCommentFilter` was slow on files with multiple errors
Reuse the `suppressions` for the file and use it again if the file name is the same as the last file name we used.