### PR TITLE
Issue: #15456 Defined voilation message for ClassTypeParameterName in src/test/java/com/puppycrawl/tools/checkstyle/bdd/InlineConfigParser.java

### DIFF
--- a/src/site/xdoc/checks/naming/classtypeparametername.xml
+++ b/src/site/xdoc/checks/naming/classtypeparametername.xml
@@ -48,10 +48,10 @@
         <div class="wrapper"><pre class="prettyprint"><code class="language-java">
 class Example1 {
   class MyClass1&lt;T&gt; {}
-  class MyClass2&lt;t&gt; {}        // violation
-  class MyClass3&lt;abc&gt; {}      // violation
-  class MyClass4&lt;LISTENER&gt; {} // violation
-  class MyClass5&lt;RequestT&gt; {} // violation
+  class MyClass2&lt;t&gt; {}        // violation,  Name 't' must match pattern '^[A-Z]$'
+  class MyClass3&lt;abc&gt; {}      // violation, Name 'abc' must match pattern '^[A-Z]$'
+  class MyClass4&lt;LISTENER&gt; {} // violation, Name 'LISTENER' must match pattern '^[A-Z]$'
+  class MyClass5&lt;RequestT&gt; {} // violation, Name 'RequestT' must match pattern '^[A-Z]$'
 }
 </code></pre></div>
         <p id="Example2-config">
@@ -69,11 +69,11 @@ class Example1 {
         <p id="Example2-code">Example:</p>
         <div class="wrapper"><pre class="prettyprint"><code class="language-java">
 class Example2 {
-  class MyClass1&lt;T&gt; {}        // violation
-  class MyClass2&lt;t&gt; {}        // violation
-  class MyClass3&lt;abc&gt; {}      // violation
+  class MyClass1&lt;T&gt; {}        // violation, Name 'T' must match pattern '^[A-Z]{2,}$'
+  class MyClass2&lt;t&gt; {}        // violation, Name 't' must match pattern '^[A-Z]{2,}$'
+  class MyClass3&lt;abc&gt; {}      // violation, Name 'abc' must match pattern '^[A-Z]{2,}$'
   class MyClass4&lt;LISTENER&gt; {}
-  class MyClass5&lt;RequestT&gt; {} // violation
+  class MyClass5&lt;RequestT&gt; {} // violation, Name 'RequestT' must match pattern '^[A-Z]{2,}$'
 }
 </code></pre></div>
         <p id="Example3-config">
@@ -93,9 +93,9 @@ class Example2 {
         <div class="wrapper"><pre class="prettyprint"><code class="language-java">
 class Example3 {
   class MyClass1&lt;T&gt; {}
-  class MyClass2&lt;t&gt; {}        // violation
-  class MyClass3&lt;abc&gt; {}      // violation
-  class MyClass4&lt;LISTENER&gt; {} // violation
+  class MyClass2&lt;t&gt; {}        // violation, Name 't' must match pattern '(^[A-Z][0-9]?)$|([A-Z][a-zA-Z0-9]*[T]$)'
+  class MyClass3&lt;abc&gt; {}      // violation, Name 'abc' must match pattern '(^[A-Z][0-9]?)$|([A-Z][a-zA-Z0-9]*[T]$)'
+  class MyClass4&lt;LISTENER&gt; {} // violation, Name 'LISTENER' must match pattern '(^[A-Z][0-9]?)$|([A-Z][a-zA-Z0-9]*[T]$)'
   class MyClass5&lt;RequestT&gt; {}
 }
 </code></pre></div>

--- a/src/test/java/com/puppycrawl/tools/checkstyle/bdd/InlineConfigParser.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/bdd/InlineConfigParser.java
@@ -267,7 +267,6 @@ public final class InlineConfigParser {
             "com.puppycrawl.tools.checkstyle.checks.modifier.InterfaceMemberImpliedModifierCheck",
             "com.puppycrawl.tools.checkstyle.checks.modifier.RedundantModifierCheck",
             "com.puppycrawl.tools.checkstyle.checks.naming.AbbreviationAsWordInNameCheck",
-            "com.puppycrawl.tools.checkstyle.checks.naming.ClassTypeParameterNameCheck",
             "com.puppycrawl.tools.checkstyle.checks.naming.ConstantNameCheck",
             "com.puppycrawl.tools.checkstyle.checks.naming.IllegalIdentifierNameCheck",
             "com.puppycrawl.tools.checkstyle.checks.naming.InterfaceTypeParameterNameCheck",

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/naming/classtypeparametername/InputClassTypeParameterName.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/naming/classtypeparametername/InputClassTypeParameterName.java
@@ -9,7 +9,7 @@ package com.puppycrawl.tools.checkstyle.checks.naming.classtypeparametername;
 
 import java.io.Serializable;
 
-public class InputClassTypeParameterName<t> // violation
+public class InputClassTypeParameterName<t> // violation, Name 't' must match pattern '^[A-Z]$'
 {
     public <TT> void foo() { }
 
@@ -17,7 +17,7 @@ public class InputClassTypeParameterName<t> // violation
     }
 }
 
-class Other <foo extends Serializable & Cloneable> { // violation
+class Other <foo extends Serializable & Cloneable> { // violation, Name 'foo' must match pattern '^[A-Z]$'
 
     foo getOne() {
         return null;//comment
@@ -31,7 +31,7 @@ class Other <foo extends Serializable & Cloneable> { // violation
         return null;
     }
 
-    static class Junk <foo> { // violation
+    static class Junk <foo> { // violation, Name 'foo' must match pattern '^[A-Z]$'
         <_fo extends foo> void getMoreFoo() {
         }
     }

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/naming/classtypeparametername/InputClassTypeParameterName1.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/naming/classtypeparametername/InputClassTypeParameterName1.java
@@ -9,7 +9,7 @@ package com.puppycrawl.tools.checkstyle.checks.naming.classtypeparametername;
 
 import java.io.Serializable;
 
-public class InputClassTypeParameterName1<t> // violation
+public class InputClassTypeParameterName1<t> // violation, Name 't' must match pattern '^foo$'
 {
     public <TT> void foo() { }
 
@@ -37,7 +37,7 @@ class Other1 <foo extends Serializable & Cloneable> {
     }
 }
 
-class MoreOther1 <T extends Cloneable> { // violation
+class MoreOther1 <T extends Cloneable> { // violation, Name 'T' must match pattern '^foo$'
 
     <E extends T> void getMore() {
         new Other() {

--- a/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/naming/classtypeparametername/Example1.java
+++ b/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/naming/classtypeparametername/Example1.java
@@ -11,9 +11,9 @@ package com.puppycrawl.tools.checkstyle.checks.naming.classtypeparametername;
 // xdoc section -- start
 class Example1 {
   class MyClass1<T> {}
-  class MyClass2<t> {}        // violation
-  class MyClass3<abc> {}      // violation
-  class MyClass4<LISTENER> {} // violation
-  class MyClass5<RequestT> {} // violation
+  class MyClass2<t> {}        // violation,  Name 't' must match pattern '^[A-Z]$'
+  class MyClass3<abc> {}      // violation, Name 'abc' must match pattern '^[A-Z]$'
+  class MyClass4<LISTENER> {} // violation, Name 'LISTENER' must match pattern '^[A-Z]$'
+  class MyClass5<RequestT> {} // violation, Name 'RequestT' must match pattern '^[A-Z]$'
 }
 // xdoc section -- end

--- a/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/naming/classtypeparametername/Example2.java
+++ b/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/naming/classtypeparametername/Example2.java
@@ -12,10 +12,10 @@ package com.puppycrawl.tools.checkstyle.checks.naming.classtypeparametername;
 
 // xdoc section -- start
 class Example2 {
-  class MyClass1<T> {}        // violation
-  class MyClass2<t> {}        // violation
-  class MyClass3<abc> {}      // violation
+  class MyClass1<T> {}        // violation, Name 'T' must match pattern '^[A-Z]{2,}$'
+  class MyClass2<t> {}        // violation, Name 't' must match pattern '^[A-Z]{2,}$'
+  class MyClass3<abc> {}      // violation, Name 'abc' must match pattern '^[A-Z]{2,}$'
   class MyClass4<LISTENER> {}
-  class MyClass5<RequestT> {} // violation
+  class MyClass5<RequestT> {} // violation, Name 'RequestT' must match pattern '^[A-Z]{2,}$'
 }
 // xdoc section -- end

--- a/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/naming/classtypeparametername/Example3.java
+++ b/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/naming/classtypeparametername/Example3.java
@@ -13,9 +13,9 @@ package com.puppycrawl.tools.checkstyle.checks.naming.classtypeparametername;
 // xdoc section -- start
 class Example3 {
   class MyClass1<T> {}
-  class MyClass2<t> {}        // violation
-  class MyClass3<abc> {}      // violation
-  class MyClass4<LISTENER> {} // violation
+  class MyClass2<t> {}        // violation, Name 't' must match pattern '(^[A-Z][0-9]?)$|([A-Z][a-zA-Z0-9]*[T]$)'
+  class MyClass3<abc> {}      // violation, Name 'abc' must match pattern '(^[A-Z][0-9]?)$|([A-Z][a-zA-Z0-9]*[T]$)'
+  class MyClass4<LISTENER> {} // violation, Name 'LISTENER' must match pattern '(^[A-Z][0-9]?)$|([A-Z][a-zA-Z0-9]*[T]$)'
   class MyClass5<RequestT> {}
 }
 // xdoc section -- end


### PR DESCRIPTION
**Suppression removed**
`"com.puppycrawl.tools.checkstyle.checks.naming.ClassTypeParameterNameCheck"`

**Files updated**

1. src/site/xdoc/checks/naming/classtypeparametername.xml
2. src/test/java/com/puppycrawl/tools/checkstyle/bdd/InlineConfigParser.java
3. src/test/resources/com/puppycrawl/tools/checkstyle/checks/naming/classtypeparametername/InputClassTypeParameterName.java
4. src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/naming/classtypeparametername/Example1.java
5. src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/naming/classtypeparametername/Example2.java
6. src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/naming/classtypeparametername/Example3.java
7. 
8. 