### PR TITLE
Issue #14631: Updated BR_HTML_TAG_NAME in JavadocTokenTypes.java to new AST format

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/api/JavadocTokenTypes.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/api/JavadocTokenTypes.java
@@ -1222,23 +1222,23 @@ public final class JavadocTokenTypes {
      * Br tag name.
      *
      * <p><b>Example:</b></p>
-     * <pre>{@code text before break &lt br &gt text after break}</pre>
+     * <pre>{@code text before break < br > text after break}</pre>
      * <b>Tree:</b>
      * <pre>
      * {@code
-     *   JAVADOC -&gt; JAVADOC
-     *        |--NEWLINE -&gt; \r\n
-     *        |--LEADING_ASTERISK -&gt;  *
-     *        |--TEXT -&gt;  text before break
-     *        |--HTML_ELEMENT -&gt; HTML_ELEMENT
-     *        |   `--SINGLETON_ELEMENT -&gt; SINGLETON_ELEMENT
-     *        |       `--BR_TAG -&gt; BR_TAG
-     *        |           |--START -&gt; -&lt;
-     *        |           |--BR_HTML_TAG_NAME -&gt; br
-     *        |           `--END -&gt; &gt;
-     *        |--TEXT -&gt;  text after break
-     *        |--NEWLINE -&gt; \r\n
-     *        |--TEXT -&gt;
+     *   JAVADOC ->; JAVADOC
+     *        |--NEWLINE ->; \r\n
+     *        |--LEADING_ASTERISK ->;  *
+     *        |--TEXT ->;  text before break
+     *        |--HTML_ELEMENT ->; HTML_ELEMENT
+     *        |   `--SINGLETON_ELEMENT ->; SINGLETON_ELEMENT
+     *        |       `--BR_TAG ->; BR_TAG
+     *        |           |--START ->; -<;
+     *        |           |--BR_HTML_TAG_NAME ->; br
+     *        |           `--END ->; >;
+     *        |--TEXT ->;  text after break
+     *        |--NEWLINE ->; \r\n
+     *        |--TEXT ->;
      * }
      * </pre>
      */


### PR DESCRIPTION
Issue #14631

**Commend used**
`java -jar checkstyle-10.21.3-all.jar -J Test.java | sed "s/[[0-9]+:[0-9]+]//g"`

**Test.java**
```java
/**
 * text before break < br > text after break
 */
public class Test {
}
```

```txt
sersawy:~/project/AST/src$ java -jar checkstyle-10.13.0-all.jar -J Test.java | sed "s/\[[0-9]\+:[0-9]\+\]//g"
COMPILATION_UNIT -> COMPILATION_UNIT 
`--CLASS_DEF -> CLASS_DEF 
    |--MODIFIERS -> MODIFIERS 
    |   |--BLOCK_COMMENT_BEGIN -> /* 
    |   |   |--COMMENT_CONTENT -> *\n * text before break < br > text after break\n  
    |   |   |   `--JAVADOC -> JAVADOC 
    |   |   |       |--NEWLINE -> \n 
    |   |   |       |--LEADING_ASTERISK ->  * 
    |   |   |       |--TEXT ->  text before break < br > text after break 
    |   |   |       |--NEWLINE -> \n 
    |   |   |       |--TEXT ->   
    |   |   |       `--EOF -> <EOF> 
    |   |   `--BLOCK_COMMENT_END -> */ 
    |   `--LITERAL_PUBLIC -> public 
    |--LITERAL_CLASS -> class 
    |--IDENT -> Test 
    `--OBJBLOCK -> OBJBLOCK 
        |--LCURLY -> { 
        `--RCURLY -> } 
```