### PR TITLE
Fix: Include Javadoc grammar check in performance regression workflow

### DIFF
--- a/config/benchmark-config.xml
+++ b/config/benchmark-config.xml
@@ -6,7 +6,7 @@
 
   <property name="severity" value="ignore"/>
   <module name="TreeWalker">
-    <module name="NoCodeInFileCheck">
+    <module name="JavadocGrammarCheck">
     </module>
   </module>
 </module>


### PR DESCRIPTION
Issue: #16482 

### What was the problem?
- Performance tests were not checking Javadoc grammar.
- The configuration was using 'NoCodeInFileCheck', preventing Javadoc for parsing.

### What is the fix?
- Removed 'NoCodeInFileCheck,.
- Added 'JavadocGrammarCheck' to include Javadoc parsing in to the benchmark.

### How was this tested?
- Ran 'mvn clean verify' and all the tests passed.