### PR TITLE
Issue #14631: Updated ATTR_VALUE in JavadocTokenTypes to new AST format

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/api/JavadocTokenTypes.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/api/JavadocTokenTypes.java
@@ -1084,6 +1084,18 @@ public final class JavadocTokenTypes {
 
     /**
      * Attribute value html tag component.
+     *
+     * <p><b>Tree:</b></p>
+     * <pre>
+     * {@code
+     *  JAVADOC -> JAVADOC
+     *   |--NEWLINE -> \r\n
+     *   |--LEADING_ASTERISK ->  *
+     *   |--TEXT ->  Attribute value html tag component.
+     *   |--NEWLINE -> \r\n
+     *   |--TEXT ->
+     * }
+     * </pre>
      */
     public static final int ATTR_VALUE = JavadocParser.ATTR_VALUE;
 


### PR DESCRIPTION
**Issue: #14631** 

**Test.java file:** 
```
/**
 * Attribute value html tag component.
 */
public class Test {
}
```
command used: `java -jar checkstyle-10.21.4-all.jar -J Test.java | sed "s/\[[0-9]\+:[0-9]\+\]//g"`

**output:** 
```COMPILATION_UNIT -> COMPILATION_UNIT
`--CLASS_DEF -> CLASS_DEF
    |--MODIFIERS -> MODIFIERS
    |   |--BLOCK_COMMENT_BEGIN -> /*
    |   |   |--COMMENT_CONTENT -> *\r\n * Attribute value html tag component.\r\n
    |   |   |   `--JAVADOC -> JAVADOC
    |   |   |       |--NEWLINE -> \r\n
    |   |   |       |--LEADING_ASTERISK ->  *
    |   |   |       |--TEXT ->  Attribute value html tag component.
    |   |   |       |--NEWLINE -> \r\n
    |   |   |       |--TEXT ->
    |   |   |       `--EOF -> <EOF>
    |   |   `--BLOCK_COMMENT_END -> */
    |   `--LITERAL_PUBLIC -> public
    |--LITERAL_CLASS -> class
    |--IDENT -> Test
    `--OBJBLOCK -> OBJBLOCK
        |--LCURLY -> {
        `--RCURLY -> }
```

**Final result:**
```
    /**
     * Attribute value html tag component.
     *
     * <p><b>Tree:</b></p>
     * <pre>
     * {@code
     *  JAVADOC -> JAVADOC
     *   |--NEWLINE -> \r\n
     *   |--LEADING_ASTERISK ->  *
     *   |--TEXT ->  Attribute value html tag component.
     *   |--NEWLINE -> \r\n
     *   |--TEXT ->
     * }
     * </pre>
     */
```

