### PR TITLE
Issue #14631: update ATTR_VALUE in JavadocTokenTypes.java to new AST format

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/api/JavadocTokenTypes.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/api/JavadocTokenTypes.java
@@ -1095,22 +1095,22 @@ public final class JavadocTokenTypes {
      * <b>Tree:</b>
      * <pre>
      * {@code
-     *  JAVADOC ->; JAVADOC
-     *     |--NEWLINE ->; \r\n
-     *     |--LEADING_ASTERISK ->;      *
-     *     |--TEXT ->;
-     *     |--HTML_ELEMENT ->; HTML_ELEMENT
-     *         `--PARAGRAPH ->; PARAGRAPH
-     *             |--P_TAG_START ->; P_TAG_START
-     *             |   |--START ->; <;
-     *             |   |--P_HTML_TAG_NAME ->; p
-     *             |   `--END ->; >;
-     *             |--TEXT ->; Paragraph Tag.
-     *             `--P_TAG_END ->; P_TAG_END
-     *                 |--START ->; <;
-     *                 |--SLASH ->; /
-     *                 |--P_HTML_TAG_NAME ->; p
-     *                 `--END ->; >;
+     *  —JAVADOC -> JAVADOC [1:3]
+     *     |--NEWLINE -> \n [1:3]
+     *     |--LEADING_ASTERISK ->  * [2:0]
+     *     |--TEXT ->   [2:2]
+     *     |--HTML_ELEMENT -> HTML_ELEMENT [2:3]
+     *        `--PARAGRAPH -> PARAGRAPH [2:3]
+     *           |--P_TAG_START -> P_TAG_START [2:3]
+     *              |--START -> < [2:3]
+     *              |--P_HTML_TAG_NAME -> p [2:4]
+     *              `--END -> > [2:5]
+     *           |--TEXT -> Paragraph Tag. [2:6]
+     *           `--P_TAG_END -> P_TAG_END [2:20]
+     *              |--START -> < [2:20]
+     *              |--SLASH -> / [2:21]
+     *              |--P_HTML_TAG_NAME -> p [2:22]
+     *              `--END -> > [2:23]
      * }
      * </pre>
      *


### PR DESCRIPTION
Issue : #14631

**Command Used: ATTR_VALUE AST % java -jar checkstyle-10.21.4-all.jar -J Test.java | sed 's/\[[0-9]\+:[0-9]\+\]//g'**

**cat Test.java
/**
 * <p>Paragraph Tag.</p>
 */
public class Test {
}**

```
COMPILATION_UNIT -> COMPILATION_UNIT [4:0]
`--CLASS_DEF -> CLASS_DEF [4:0]
    |--MODIFIERS -> MODIFIERS [4:0]
    |   |--BLOCK_COMMENT_BEGIN -> /* [1:0]
    |   |   |--COMMENT_CONTENT -> *\n * <p>Paragraph Tag.</p>\n  [1:2]
    |   |   |   `--JAVADOC -> JAVADOC [1:3]
    |   |   |       |--NEWLINE -> \n [1:3]
    |   |   |       |--LEADING_ASTERISK ->  * [2:0]
    |   |   |       |--TEXT ->   [2:2]
    |   |   |       |--HTML_ELEMENT -> HTML_ELEMENT [2:3]
    |   |   |       |   `--PARAGRAPH -> PARAGRAPH [2:3]
    |   |   |       |       |--P_TAG_START -> P_TAG_START [2:3]
    |   |   |       |       |   |--START -> < [2:3]
    |   |   |       |       |   |--P_HTML_TAG_NAME -> p [2:4]
    |   |   |       |       |   `--END -> > [2:5]
    |   |   |       |       |--TEXT -> Paragraph Tag. [2:6]
    |   |   |       |       `--P_TAG_END -> P_TAG_END [2:20]
    |   |   |       |           |--START -> < [2:20]
    |   |   |       |           |--SLASH -> / [2:21]
    |   |   |       |           |--P_HTML_TAG_NAME -> p [2:22]
    |   |   |       |           `--END -> > [2:23]
    |   |   |       |--NEWLINE -> \n [2:24]
    |   |   |       |--TEXT ->   [3:0]
    |   |   |       `--EOF -> <EOF> [3:1]
    |   |   `--BLOCK_COMMENT_END -> */ [3:1]
    |   `--LITERAL_PUBLIC -> public [4:0]
    |--LITERAL_CLASS -> class [4:7]
    |--IDENT -> Test [4:13]
    `--OBJBLOCK -> OBJBLOCK [4:18]
        |--LCURLY -> { [4:18]
        `--RCURLY -> } [5:0]
```