### PR TITLE
Issue #14631: Updated  P_HTML_TAG_NAME in JavadocTokenTypes.java to new AST format

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/api/JavadocTokenTypes.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/api/JavadocTokenTypes.java
@@ -1128,22 +1128,18 @@ public final class JavadocTokenTypes {
      * <b>Tree:</b>
      * <pre>
      * {@code
-     *  JAVADOC ->; JAVADOC
-     *     |--NEWLINE ->; \r\n
-     *     |--LEADING_ASTERISK ->;      *
-     *     |--TEXT ->;
-     *     |--HTML_ELEMENT ->; HTML_ELEMENT
-     *         `--PARAGRAPH ->; PARAGRAPH
-     *             |--P_TAG_START ->; P_TAG_START
-     *             |   |--START ->; <;
-     *             |   |--P_HTML_TAG_NAME ->; p
-     *             |   `--END ->; >;
-     *             |--TEXT ->; Paragraph Tag.
-     *             `--P_TAG_END ->; P_TAG_END
-     *                 |--START ->; <;
-     *                 |--SLASH ->; /
-     *                 |--P_HTML_TAG_NAME ->; p
-     *                 `--END ->; >;
+     *      `--HTML_ELEMENT -> HTML_ELEMENT
+     *          `--PARAGRAPH -> PARAGRAPH
+     *              |--P_TAG_START -> P_TAG_START
+     *              |   |--START -> <
+     *              |   |--P_HTML_TAG_NAME -> p
+     *              |   `--END -> >
+     *              |--TEXT -> Paragraph Tag.
+     *              `--P_TAG_END -> P_TAG_END
+     *                  |--START -> <
+     *                  |--SLASH -> /
+     *                  |--P_HTML_TAG_NAME -> p
+     *                  `--END -> >
      * }
      * </pre>
      *


### PR DESCRIPTION
Issue: #14631

**Command Used**
java -jar checkstyle-10.21.4-all.jar -J Test.java | sed "s/\[[0-9]\+:[0-9]\+\]//g"

**Test.java**
```
/**
 * <p>Paragraph Tag.</p>}
 */
public class Test {
}
```


```
1501s@Dell_G15 MINGW64 /D/Sambhav/opensource/checkstyle/checkstyle_debugging
$ java -jar checkstyle-10.21.4-all.jar -J Test.java | sed "s/\[[0-9]\+:[0-9]\+\]//g"
COMPILATION_UNIT -> COMPILATION_UNIT
`--CLASS_DEF -> CLASS_DEF
    |--MODIFIERS -> MODIFIERS
    |   |--BLOCK_COMMENT_BEGIN -> /*
    |   |   |--COMMENT_CONTENT -> *\r\n * <p>Paragraph Tag.</p>}\r\n
    |   |   |   `--JAVADOC -> JAVADOC
    |   |   |       |--NEWLINE -> \r\n
    |   |   |       |--LEADING_ASTERISK ->  *
    |   |   |       |--TEXT ->
    |   |   |       |--HTML_ELEMENT -> HTML_ELEMENT
    |   |   |       |   `--PARAGRAPH -> PARAGRAPH
    |   |   |       |       |--P_TAG_START -> P_TAG_START
    |   |   |       |       |   |--START -> <
    |   |   |       |       |   |--P_HTML_TAG_NAME -> p
    |   |   |       |       |   `--END -> >
    |   |   |       |       |--TEXT -> Paragraph Tag.
    |   |   |       |       `--P_TAG_END -> P_TAG_END
    |   |   |       |           |--START -> <
    |   |   |       |           |--SLASH -> /
    |   |   |       |           |--P_HTML_TAG_NAME -> p
    |   |   |       |           `--END -> >
    |   |   |       |--TEXT -> }
    |   |   |       |--NEWLINE -> \r\n
    |   |   |       |--TEXT ->
    |   |   |       `--EOF -> <EOF>
    |   |   `--BLOCK_COMMENT_END -> */
    |   `--LITERAL_PUBLIC -> public
    |--LITERAL_CLASS -> class
    |--IDENT -> Test
    `--OBJBLOCK -> OBJBLOCK
        |--LCURLY -> {
        `--RCURLY -> }

```