### PR TITLE
Issue #12242: expand AuditEvents for fileContent

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/api/AuditEvent.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/api/AuditEvent.java
@@ -44,6 +44,8 @@ public final class AuditEvent {
     private final String fileName;
     /** Violation associated with the event. **/
     private final Violation violation;
+    /** The file contents. */
+    private final FileContents fileContents;
 
     /**
      * Creates a new instance.
@@ -70,9 +72,21 @@ public final class AuditEvent {
      * @param src source of the event
      * @param fileName file associated with the event
      * @param violation the actual violation
-     * @throws IllegalArgumentException if {@code src} is {@code null}.
      */
     public AuditEvent(Object src, String fileName, Violation violation) {
+        this(src, fileName, violation, null);
+    }
+
+    /**
+     * Creates a new {@code AuditEvent} instance.
+     *
+     * @param src source of the event
+     * @param fileName file associated with the event
+     * @param violation the actual violation
+     * @param fileContents file content associated with the event
+     * @throws IllegalArgumentException if {@code src} is {@code null}.
+     */
+    public AuditEvent(Object src, String fileName, Violation violation, FileContents fileContents) {
         if (src == null) {
             throw new IllegalArgumentException("null source");
         }
@@ -80,6 +94,7 @@ public final class AuditEvent {
         source = src;
         this.fileName = fileName;
         this.violation = violation;
+        this.fileContents = fileContents;
     }
 
     /**
@@ -99,6 +114,16 @@ public final class AuditEvent {
      */
     public String getFileName() {
         return fileName;
+    }
+
+    /**
+     * Returns the content of file beign audited.
+     *
+     * @return the file contant currently being audited or null if there is
+     *     no relation to a file.
+     */
+    public FileContents getFileContent() {
+        return fileContents;
     }
 
     /**

--- a/src/test/java/com/puppycrawl/tools/checkstyle/api/AuditEventTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/api/AuditEventTest.java
@@ -87,5 +87,8 @@ public class AuditEventTest {
         assertWithMessage("invalid source name")
                 .that(event.getSourceName())
                 .isEqualTo("com.puppycrawl.tools.checkstyle.api.AuditEventTest");
+        assertWithMessage("invalid file content")
+                .that(event.getFileContent())
+                .isEqualTo(null);
     }
 }


### PR DESCRIPTION
Issue #12242

Update the `AuditEvent` for fileContent to use in Filters
