### PR TITLE
Issue: #14631 Updated ATTRIBUTE in JavadocTokenTypes to new AST format

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/api/JavadocTokenTypes.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/api/JavadocTokenTypes.java
@@ -1640,7 +1640,7 @@ public final class JavadocTokenTypes {
      * }
      * </pre>
      */
-    
+
     public static final int PARAGRAPH = JavadocParser.RULE_paragraph + RULE_TYPES_OFFSET;
     /** Start paragraph tag. */
     public static final int P_TAG_START = JavadocParser.RULE_pTagStart + RULE_TYPES_OFFSET;

--- a/src/main/java/com/puppycrawl/tools/checkstyle/api/JavadocTokenTypes.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/api/JavadocTokenTypes.java
@@ -1588,6 +1588,24 @@ public final class JavadocTokenTypes {
 
     /**
      * Html tag attribute. Parent node for: {@code HTML_TAG_IDENT, EQUALS, ATTR_VALUE}.
+     * <p><b>Example</b></p>
+     * <pre>{@code <p>Sample Text</p>}</pre>
+     * <b>Tree:</b>
+     * <pre>
+     * {@code
+     *   `--JAVADOC -> JAVADOC
+     *       |--NEWLINE -> \n
+     *       |--LEADING_ASTERISK ->  *
+     *       |--WS ->
+     *       |--JAVADOC_TAG -> JAVADOC_TAG
+     *       |  |--CUSTOM_NAME -> @code
+     *       |  |--WS ->
+     *       |  `--DESCRIPTION -> DESCRIPTION
+     *       |     |--TEXT -> HTML_TAG_IDENT, EQUALS, ATTR_VALUE
+     *       |     |--NEWLINE -> \n
+     *       |     `--TEXT ->
+     *}
+     * </pre>
      */
     public static final int ATTRIBUTE = JavadocParser.RULE_attribute
             + RULE_TYPES_OFFSET;

--- a/src/main/java/com/puppycrawl/tools/checkstyle/api/JavadocTokenTypes.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/api/JavadocTokenTypes.java
@@ -1640,6 +1640,7 @@ public final class JavadocTokenTypes {
      * }
      * </pre>
      */
+    
     public static final int PARAGRAPH = JavadocParser.RULE_paragraph + RULE_TYPES_OFFSET;
     /** Start paragraph tag. */
     public static final int P_TAG_START = JavadocParser.RULE_pTagStart + RULE_TYPES_OFFSET;


### PR DESCRIPTION
Issue: #14631 

**Command Used** : 
java -jar checkstyle-10.21.4-all.jar -J Test.java | sed "s/\[[0-9]\+:[0-9]\+\]//g"

Test.java
```
/**
 * @code HTML_TAG_IDENT, EQUALS, ATTR_VALUE
 */
public class Test {

}
```

```
COMPILATION_UNIT -> COMPILATION_UNIT [4:0]
`--CLASS_DEF -> CLASS_DEF [4:0]
    |--MODIFIERS -> MODIFIERS [4:0]
    |   |--BLOCK_COMMENT_BEGIN -> /* [1:0]
    |   |   |--COMMENT_CONTENT -> *\n * @code HTML_TAG_IDENT, EQUALS, ATTR_VALUE\n  [1:2]
    |   |   |   `--JAVADOC -> JAVADOC [1:3]
    |   |   |       |--NEWLINE -> \n [1:3]
    |   |   |       |--LEADING_ASTERISK ->  * [2:0]
    |   |   |       |--WS ->   [2:2]
    |   |   |       |--JAVADOC_TAG -> JAVADOC_TAG [2:3]
    |   |   |       |   |--CUSTOM_NAME -> @code [2:3]
    |   |   |       |   |--WS ->   [2:8]
    |   |   |       |   `--DESCRIPTION -> DESCRIPTION [2:9]
    |   |   |       |       |--TEXT -> HTML_TAG_IDENT, EQUALS, ATTR_VALUE [2:9]
    |   |   |       |       |--NEWLINE -> \n [2:43]
    |   |   |       |       `--TEXT ->   [3:0]
    |   |   |       `--EOF -> <EOF> [3:1]
    |   |   `--BLOCK_COMMENT_END -> */ [3:1]
    |   `--LITERAL_PUBLIC -> public [4:0]
    |--LITERAL_CLASS -> class [4:7]
    |--IDENT -> Test [4:13]
    `--OBJBLOCK -> OBJBLOCK [4:18]
        |--LCURLY -> { [4:18]
        `--RCURLY -> } [6:0]
```
