### PR TITLE
Issue #14631: Updated DD  in JavadocTokenTypes.java to new AST format

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/api/JavadocTokenTypes.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/api/JavadocTokenTypes.java
@@ -2322,7 +2322,28 @@ public final class JavadocTokenTypes {
     public static final int COLGROUP_TAG_END = JavadocParser.RULE_colgroupTagEnd
             + RULE_TYPES_OFFSET;
 
-    /** Description of a term html tag: {@code <dd></dd>}. */
+    /**
+     * DD html tag.
+     *
+     * <p><b>Example AST:</b></p>
+     * <pre>{@code <dd>Description content</dd>}</pre>
+     * <pre>
+     * {@code
+     *   --HTML_ELEMENT -> HTML_ELEMENT
+     *      `--DD -> DD
+     *          |--DD_TAG_START -> DD_TAG_START
+     *          |   |--START -> <
+     *          |   |--DD_HTML_TAG_NAME -> dd
+     *          |   `--END -> >
+     *          |--TEXT -> "Description content"
+     *          `--DD_TAG_END -> DD_TAG_END
+     *              |--START -> <
+     *              |--SLASH -> /
+     *              |--DD_HTML_TAG_NAME -> dd
+     *              `--END -> >
+     * }
+     * </pre>
+     */
     public static final int DD = JavadocParser.RULE_dd + RULE_TYPES_OFFSET;
     /** Start description of a term tag. */
     public static final int DD_TAG_START = JavadocParser.RULE_ddTagStart + RULE_TYPES_OFFSET;


### PR DESCRIPTION
Issue: #14631

**Command**
`java -jar checkstyle-10.21.4-all.jar -J Test.java | sed "s/\[[0-9]\+:[0-9]\+\]//g"`

**Test.java**
```
/**
 * <dd></dd>
 */
public class Test {
}
```

```
--HTML_ELEMENT -> HTML_ELEMENT
    `--DD -> DD
        |--DD_TAG_START -> DD_TAG_START
        |   |--START -> <
        |   |--DD_HTML_TAG_NAME -> dd
        |   `--END -> >
        |--TEXT -> "Description content"
        `--DD_TAG_END -> DD_TAG_END
            |--START -> <
            |--SLASH -> /
            |--DD_HTML_TAG_NAME -> dd
            `--END -> >
```