### PR TITLE
Issue #16385: resolved JavadocTagContinuationIndentation bug

### DIFF
--- a/.ci/validation.sh
+++ b/.ci/validation.sh
@@ -648,8 +648,6 @@ no-error-pgjdbc)
   echo "Checkout target sources ..."
   checkout_from https://github.com/pgjdbc/pgjdbc.git
   cd .ci-temp/pgjdbc
-  # pgjdbc easily damage build, we should use stable versions
-  git checkout "fcc13e70e6b6bb64b848df4b4ba6b3566b5""e95a3"
   ./gradlew --no-parallel --no-daemon checkstyleAll \
             -PenableMavenLocal -Pcheckstyle.version="${CS_POM_VERSION}"
   cd ../

--- a/config/jsoref-spellchecker/whitelist.words
+++ b/config/jsoref-spellchecker/whitelist.words
@@ -300,7 +300,6 @@ detailnodetreestringprinter
 devops
 Dexec
 Dexpression
-df
 dfa
 DFFF
 Dfile
@@ -410,7 +409,6 @@ Fannotation
 favicon
 Fblocks
 FCBL
-fcc
 FCCD
 Fchecks
 Fcheckstyle

--- a/src/it/resources/com/google/checkstyle/test/chapter7javadoc/rule713atclauses/InputJavaDocTagContinuationIndentation.java
+++ b/src/it/resources/com/google/checkstyle/test/chapter7javadoc/rule713atclauses/InputJavaDocTagContinuationIndentation.java
@@ -200,6 +200,93 @@ class InputJavaDocTagContinuationIndentation implements Serializable {
       return "null";
     }
 
+    // violation 5 lines below 'Line continuation .* expected level should be 4'
+    /**
+     * Some text.
+     *
+     * @see <a href="https://checkstyle.org/checks/javadoc/javadoctag.html">
+     *    JavadocTagContinuationIndentation: Checks the indentation </a>
+     */
+    String method6() {
+      return "null";
+    }
+
+    /**
+     * Some text.
+     *
+     * @see <a href="https://checkstyle.org/checks/javadoc/javadoctag.html">
+     *     JavadocTagContinuationIndentation: Checks the indentation </a>
+     */
+    String method7() {
+      return "null";
+    }
+
+    // violation 5 lines below 'Line continuation .* expected level should be 4'
+    /**
+     * Some text.
+     *
+     * @see reference <a href="https://checkstyle.org/checks/javadoc/javadoctag.html">
+     *    JavadocTagContinuationIndentation: Checks the indentation </a>
+     */
+    String method8() {
+      return "null";
+    }
+
+    /**
+     * Some text.
+     *
+     * @see reference <a href="https://checkstyle.org/checks/javadoc/javadoctag.html">
+     *     JavadocTagContinuationIndentation: Checks the indentation </a>
+     */
+    String method9() {
+      return "null";
+    }
+
+    // violation 5 lines below 'Line continuation .* expected level should be 4'
+    /**
+     * Something.
+     *
+     * @param source <a href="https://example.com/data-source">
+     *    Data Source Documentation </a>
+     */
+    String method10() {
+      return "null";
+    }
+
+    /**
+     * Something.
+     *
+     * @param source <a href="https://example.com/data-source">
+     *     Data Source Documentation </a>
+     */
+    String method11() {
+      return "null";
+    }
+
+    // violation 6 lines below 'Line continuation .* expected level should be 4'
+    // violation 6 lines below 'Line continuation .* expected level should be 4'
+    /**
+     * Some text.
+     *
+     * @see <a
+     *    href="https://checkstyle.org/checks/javadoc/javadoctag.html">
+     *    JavadocTagContinuationIndentation: Checks the indentation </a>
+     */
+    String method12() {
+      return "null";
+    }
+
+    /**
+     * Some text.
+     *
+     * @see <a
+     *     href="https://checkstyle.org/checks/javadoc/javadoctag.html">
+     *     JavadocTagContinuationIndentation: Checks the indentation </a>
+     */
+    String method13() {
+      return "null";
+    }
+
     /**
      * Some text.
      *
@@ -214,7 +301,7 @@ class InputJavaDocTagContinuationIndentation implements Serializable {
      * @throws Exception Some text.
      * @deprecated Some text.
      */
-    String method6(String str, int number, boolean bool) throws Exception {
+    String method14(String str, int number, boolean bool) throws Exception {
       return "null";
     }
   }

--- a/src/main/java/com/puppycrawl/tools/checkstyle/api/JavadocTokenTypes.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/api/JavadocTokenTypes.java
@@ -1198,7 +1198,7 @@ public final class JavadocTokenTypes {
      *
      * @see
      * <a href="https://docs.oracle.com/javase/8/docs/technotes/tools/unix/javadoc.html#JSSOR647">
-     * comments are written in HTML</a>
+     *     comments are written in HTML</a>
      * @see #LI_HTML_TAG_NAME
      */
     public static final int LI_HTML_TAG_NAME = JavadocParser.LI_HTML_TAG_NAME;
@@ -1249,7 +1249,7 @@ public final class JavadocTokenTypes {
      *
      *  @see
      *  <a href="https://docs.oracle.com/javase/8/docs/technotes/tools/unix/javadoc.html#JSSOR647">
-     *  comments are written in HTML</a>
+     *      comments are written in HTML</a>
      *  @see #TR_HTML_TAG_NAME
      */
     public static final int TR_HTML_TAG_NAME = JavadocParser.TR_HTML_TAG_NAME;
@@ -1299,7 +1299,7 @@ public final class JavadocTokenTypes {
      *
      *  @see
      *  <a href="https://docs.oracle.com/javase/8/docs/technotes/tools/unix/javadoc.html#JSSOR647">
-     *  comments are written in HTML</a>
+     *      comments are written in HTML</a>
      *  @see #TD_HTML_TAG_NAME
      */
     public static final int TD_HTML_TAG_NAME = JavadocParser.TD_HTML_TAG_NAME;

--- a/src/main/java/com/puppycrawl/tools/checkstyle/api/TokenTypes.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/api/TokenTypes.java
@@ -106,7 +106,7 @@ public final class TokenTypes {
      * </pre>
      *
      * @see <a
-     * href="https://docs.oracle.com/javase/specs/jls/se8/html/jls-8.html">Java
+     *     href="https://docs.oracle.com/javase/specs/jls/se8/html/jls-8.html">Java
      *     Language Specification, &sect;8</a>
      * @see #LITERAL_PUBLIC
      * @see #LITERAL_PROTECTED
@@ -387,7 +387,7 @@ public final class TokenTypes {
      * </pre>
      *
      * @see <a
-     * href="https://docs.oracle.com/javase/specs/jls/se8/html/jls-8.html#jls-8.6">Java
+     *     href="https://docs.oracle.com/javase/specs/jls/se8/html/jls-8.html#jls-8.6">Java
      *     Language Specification&sect;8.6</a>
      * @see #SLIST
      * @see #OBJBLOCK
@@ -421,7 +421,7 @@ public final class TokenTypes {
      * </pre>
      *
      * @see <a
-     * href="https://docs.oracle.com/javase/specs/jls/se8/html/jls-8.html#jls-8.7">Java
+     *     href="https://docs.oracle.com/javase/specs/jls/se8/html/jls-8.html#jls-8.7">Java
      *     Language Specification, &sect;8.7</a>
      * @see #SLIST
      * @see #OBJBLOCK
@@ -492,7 +492,7 @@ public final class TokenTypes {
      * </pre>
      *
      * @see <a
-     * href="https://docs.oracle.com/javase/specs/jls/se8/html/jls-8.html">Java
+     *     href="https://docs.oracle.com/javase/specs/jls/se8/html/jls-8.html">Java
      *     Language Specification, &sect;8</a>
      * @see #MODIFIERS
      * @see #IDENT
@@ -527,7 +527,7 @@ public final class TokenTypes {
      * </pre>
      *
      * @see <a
-     * href="https://docs.oracle.com/javase/specs/jls/se8/html/jls-9.html">Java
+     *     href="https://docs.oracle.com/javase/specs/jls/se8/html/jls-9.html">Java
      *     Language Specification, &sect;9</a>
      * @see #MODIFIERS
      * @see #IDENT
@@ -568,7 +568,7 @@ public final class TokenTypes {
      * </pre>
      *
      * @see <a
-     * href="https://docs.oracle.com/javase/specs/jls/se8/html/jls-7.html#jls-7.4">Java
+     *     href="https://docs.oracle.com/javase/specs/jls/se8/html/jls-7.html#jls-7.4">Java
      *     Language Specification &sect;7.4</a>
      * @see #DOT
      * @see #IDENT
@@ -609,7 +609,7 @@ public final class TokenTypes {
      * initialization block.</p>
      *
      * @see <a
-     * href="https://docs.oracle.com/javase/specs/jls/se8/html/jls-10.html">Java
+     *     href="https://docs.oracle.com/javase/specs/jls/se8/html/jls-10.html">Java
      *     Language Specification &sect;10</a>
      * @see #TYPE
      * @see #ARRAY_INIT
@@ -816,7 +816,7 @@ public final class TokenTypes {
      * </pre>
      *
      * @see <a
-     * href="https://docs.oracle.com/javase/specs/jls/se8/html/jls-14.html#jls-14.7">Java
+     *     href="https://docs.oracle.com/javase/specs/jls/se8/html/jls-14.html#jls-14.7">Java
      *     Language Specification, &sect;14.7</a>
      * @see #SLIST
      **/
@@ -846,7 +846,7 @@ public final class TokenTypes {
      * </pre>
      *
      * @see <a
-     * href="https://docs.oracle.com/javase/specs/jls/se8/html/jls-15.html#jls-15.16">Java
+     *     href="https://docs.oracle.com/javase/specs/jls/se8/html/jls-15.html#jls-15.16">Java
      *     Language Specification, &sect;15.16</a>
      * @see #EXPR
      * @see #TYPE
@@ -895,7 +895,7 @@ public final class TokenTypes {
      * </pre>
      *
      * @see <a
-     * href="https://docs.oracle.com/javase/specs/jls/se8/html/jls-15.html#jls-15.14.1">Java
+     *     href="https://docs.oracle.com/javase/specs/jls/se8/html/jls-15.html#jls-15.14.1">Java
      *     Language Specification, &sect;15.14.1</a>
      * @see #EXPR
      * @see #INC
@@ -918,7 +918,7 @@ public final class TokenTypes {
      * </pre>
      *
      * @see <a
-     * href="https://docs.oracle.com/javase/specs/jls/se8/html/jls-15.html#jls-15.14.2">Java
+     *     href="https://docs.oracle.com/javase/specs/jls/se8/html/jls-15.html#jls-15.14.2">Java
      *     Language Specification, &sect;15.14.2</a>
      * @see #EXPR
      * @see #DEC
@@ -1137,7 +1137,7 @@ public final class TokenTypes {
      * </pre>
      *
      * @see <a
-     * href="https://docs.oracle.com/javase/specs/jls/se8/html/jls-7.html#jls-7.5">Java
+     *     href="https://docs.oracle.com/javase/specs/jls/se8/html/jls-7.html#jls-7.5">Java
      *     Language Specification &sect;7.5</a>
      * @see #DOT
      * @see #IDENT
@@ -1165,7 +1165,7 @@ public final class TokenTypes {
      * </pre>
      *
      * @see <a
-     * href="https://docs.oracle.com/javase/specs/jls/se8/html/jls-15.html#jls-15.15.4">Java
+     *     href="https://docs.oracle.com/javase/specs/jls/se8/html/jls-15.html#jls-15.15.4">Java
      *     Language Specification, &sect;15.15.4</a>
      * @see #EXPR
      **/
@@ -1189,7 +1189,7 @@ public final class TokenTypes {
      * </pre>
      *
      * @see <a
-     * href="https://docs.oracle.com/javase/specs/jls/se8/html/jls-15.html#jls-15.15.3">Java
+     *     href="https://docs.oracle.com/javase/specs/jls/se8/html/jls-15.html#jls-15.15.3">Java
      *     Language Specification, &sect;15.15.3</a>
      * @see #EXPR
      **/
@@ -1439,7 +1439,7 @@ public final class TokenTypes {
      * </pre>
      *
      * @see <a
-     * href="https://docs.oracle.com/javase/specs/jls/se8/html/jls-14.html#jls-14.6">Java
+     *     href="https://docs.oracle.com/javase/specs/jls/se8/html/jls-14.html#jls-14.6">Java
      *     Language Specification, &sect;14.6</a>
      * @see #LITERAL_FOR
      * @see #LITERAL_WHILE
@@ -1908,10 +1908,10 @@ public final class TokenTypes {
      * </pre>
      *
      * @see <a
-     * href="https://docs.oracle.com/javase/specs/jls/se8/html/jls-7.html#jls-7.5.2">Java
+     *     href="https://docs.oracle.com/javase/specs/jls/se8/html/jls-7.html#jls-7.5.2">Java
      *     Language Specification, &sect;7.5.2</a>
      * @see <a
-     * href="https://docs.oracle.com/javase/specs/jls/se8/html/jls-15.html#jls-15.17.1">Java
+     *     href="https://docs.oracle.com/javase/specs/jls/se8/html/jls-15.html#jls-15.17.1">Java
      *     Language Specification, &sect;15.17.1</a>
      * @see #EXPR
      * @see #IMPORT
@@ -2471,7 +2471,7 @@ public final class TokenTypes {
      * </pre>
      *
      * @see <a
-     * href="https://docs.oracle.com/javase/specs/jls/se8/html/jls-15.html#jls-15.26.1">Java
+     *     href="https://docs.oracle.com/javase/specs/jls/se8/html/jls-15.html#jls-15.26.1">Java
      *     Language Specification, &sect;15.26.1</a>
      * @see #EXPR
      **/
@@ -2505,7 +2505,7 @@ public final class TokenTypes {
      * </pre>
      *
      * @see <a
-     * href="https://docs.oracle.com/javase/specs/jls/se8/html/jls-8.html#jls-8.4.4">Java
+     *     href="https://docs.oracle.com/javase/specs/jls/se8/html/jls-8.html#jls-8.4.4">Java
      *     Language Specification, &sect;8.4.4</a>
      * @see #IDENT
      * @see #DOT
@@ -2967,7 +2967,7 @@ public final class TokenTypes {
      * </pre>
      *
      * @see <a
-     * href="https://docs.oracle.com/javase/specs/jls/se8/html/jls-14.html#jls-14.10">Java
+     *     href="https://docs.oracle.com/javase/specs/jls/se8/html/jls-14.html#jls-14.10">Java
      *     Language Specification, &sect;14.10</a>
      * @see #LPAREN
      * @see #EXPR
@@ -3005,7 +3005,7 @@ public final class TokenTypes {
      * </pre>
      *
      * @see <a
-     * href="https://docs.oracle.com/javase/specs/jls/se8/html/jls-14.html#jls-14.17">Java
+     *     href="https://docs.oracle.com/javase/specs/jls/se8/html/jls-14.html#jls-14.17">Java
      *     Language Specification, &sect;14.17</a>
      * @see #SLIST
      * @see #EXPR
@@ -3180,7 +3180,7 @@ public final class TokenTypes {
      * </pre>
      *
      * @see <a
-     * href="https://docs.oracle.com/javase/specs/jls/se8/html/jls-14.html#jls-14.19">Java
+     *     href="https://docs.oracle.com/javase/specs/jls/se8/html/jls-14.html#jls-14.19">Java
      *     Language Specification, &sect;14.19</a>
      * @see #SLIST
      * @see #LITERAL_CATCH
@@ -3469,7 +3469,7 @@ public final class TokenTypes {
      * </pre>
      *
      * @see <a
-     * href="https://docs.oracle.com/javase/specs/jls/se8/html/jls-15.html#jls-15.26.2">Java
+     *     href="https://docs.oracle.com/javase/specs/jls/se8/html/jls-15.html#jls-15.26.2">Java
      *     Language Specification, &sect;15.26.2</a>
      * @see #EXPR
      **/
@@ -3492,7 +3492,7 @@ public final class TokenTypes {
      * </pre>
      *
      * @see <a
-     * href="https://docs.oracle.com/javase/specs/jls/se8/html/jls-15.html#jls-15.26.2">Java
+     *     href="https://docs.oracle.com/javase/specs/jls/se8/html/jls-15.html#jls-15.26.2">Java
      *     Language Specification, &sect;15.26.2</a>
      * @see #EXPR
      **/
@@ -3517,7 +3517,7 @@ public final class TokenTypes {
      * </pre>
      *
      * @see <a
-     * href="https://docs.oracle.com/javase/specs/jls/se8/html/jls-15.html#jls-15.26.2">Java
+     *     href="https://docs.oracle.com/javase/specs/jls/se8/html/jls-15.html#jls-15.26.2">Java
      *     Language Specification, &sect;15.26.2</a>
      * @see #EXPR
      **/
@@ -3540,7 +3540,7 @@ public final class TokenTypes {
      * </pre>
      *
      * @see <a
-     * href="https://docs.oracle.com/javase/specs/jls/se8/html/jls-15.html#jls-15.26.2">Java
+     *     href="https://docs.oracle.com/javase/specs/jls/se8/html/jls-15.html#jls-15.26.2">Java
      *     Language Specification, &sect;15.26.2</a>
      * @see #EXPR
      **/
@@ -3561,7 +3561,7 @@ public final class TokenTypes {
      * </pre>
      *
      * @see <a
-     * href="https://docs.oracle.com/javase/specs/jls/se8/html/jls-15.html#jls-15.26.2">Java
+     *     href="https://docs.oracle.com/javase/specs/jls/se8/html/jls-15.html#jls-15.26.2">Java
      *     Language Specification, &sect;15.26.2</a>
      * @see #EXPR
      **/
@@ -3585,7 +3585,7 @@ public final class TokenTypes {
      * </pre>
      *
      * @see <a
-     * href="https://docs.oracle.com/javase/specs/jls/se8/html/jls-15.html#jls-15.26.2">Java
+     *     href="https://docs.oracle.com/javase/specs/jls/se8/html/jls-15.html#jls-15.26.2">Java
      *     Language Specification, &sect;15.26.2</a>
      * @see #EXPR
      **/
@@ -3609,7 +3609,7 @@ public final class TokenTypes {
      * </pre>
      *
      * @see <a
-     * href="https://docs.oracle.com/javase/specs/jls/se8/html/jls-15.html#jls-15.26.2">Java
+     *     href="https://docs.oracle.com/javase/specs/jls/se8/html/jls-15.html#jls-15.26.2">Java
      *     Language Specification, &sect;15.26.2</a>
      * @see #EXPR
      **/
@@ -3618,7 +3618,7 @@ public final class TokenTypes {
      * The {@code <<=} (left shift assignment) operator.
      *
      * @see <a
-     * href="https://docs.oracle.com/javase/specs/jls/se8/html/jls-15.html#jls-15.26.2">Java
+     *     href="https://docs.oracle.com/javase/specs/jls/se8/html/jls-15.html#jls-15.26.2">Java
      *     Language Specification, &sect;15.26.2</a>
      * @see #EXPR
      **/
@@ -3641,7 +3641,7 @@ public final class TokenTypes {
      * </pre>
      *
      * @see <a
-     * href="https://docs.oracle.com/javase/specs/jls/se8/html/jls-15.html#jls-15.26.2">Java
+     *     href="https://docs.oracle.com/javase/specs/jls/se8/html/jls-15.html#jls-15.26.2">Java
      *     Language Specification, &sect;15.26.2</a>
      * @see #EXPR
      **/
@@ -3650,7 +3650,7 @@ public final class TokenTypes {
      * The {@code ^=} (bitwise exclusive OR assignment) operator.
      *
      * @see <a
-     * href="https://docs.oracle.com/javase/specs/jls/se8/html/jls-15.html#jls-15.26.2">Java
+     *     href="https://docs.oracle.com/javase/specs/jls/se8/html/jls-15.html#jls-15.26.2">Java
      *     Language Specification, &sect;15.26.2</a>
      * @see #EXPR
      **/
@@ -3673,7 +3673,7 @@ public final class TokenTypes {
      * </pre>
      *
      * @see <a
-     * href="https://docs.oracle.com/javase/specs/jls/se8/html/jls-15.html#jls-15.26.2">Java
+     *     href="https://docs.oracle.com/javase/specs/jls/se8/html/jls-15.html#jls-15.26.2">Java
      *     Language Specification, &sect;15.26.2</a>
      * @see #EXPR
      **/
@@ -3710,7 +3710,7 @@ public final class TokenTypes {
      * </pre>
      *
      * @see <a
-     * href="https://docs.oracle.com/javase/specs/jls/se8/html/jls-15.html#jls-15.25">Java
+     *     href="https://docs.oracle.com/javase/specs/jls/se8/html/jls-15.html#jls-15.25">Java
      *     Language Specification, &sect;15.25</a>
      * @see #EXPR
      * @see #COLON
@@ -3744,7 +3744,7 @@ public final class TokenTypes {
      * </pre>
      *
      * @see <a
-     * href="https://docs.oracle.com/javase/specs/jls/se8/html/jls-15.html#jls-15.24">Java
+     *     href="https://docs.oracle.com/javase/specs/jls/se8/html/jls-15.html#jls-15.24">Java
      *     Language Specification, &sect;15.24</a>
      * @see #EXPR
      **/
@@ -3772,7 +3772,7 @@ public final class TokenTypes {
      * </pre>
      *
      * @see <a
-     * href="https://docs.oracle.com/javase/specs/jls/se8/html/jls-15.html#jls-15.23">Java
+     *     href="https://docs.oracle.com/javase/specs/jls/se8/html/jls-15.html#jls-15.23">Java
      *     Language Specification, &sect;15.23</a>
      * @see #EXPR
      **/
@@ -3797,7 +3797,7 @@ public final class TokenTypes {
      * </pre>
      *
      * @see <a
-     * href="https://docs.oracle.com/javase/specs/jls/se8/html/jls-15.html#jls-15.22.1">Java
+     *     href="https://docs.oracle.com/javase/specs/jls/se8/html/jls-15.html#jls-15.22.1">Java
      *     Language Specification, &sect;15.22.1</a>
      * @see #EXPR
      **/
@@ -3806,7 +3806,7 @@ public final class TokenTypes {
      * The {@code ^} (bitwise exclusive OR) operator.
      *
      * @see <a
-     * href="https://docs.oracle.com/javase/specs/jls/se8/html/jls-15.html#jls-15.22.1">Java
+     *     href="https://docs.oracle.com/javase/specs/jls/se8/html/jls-15.html#jls-15.22.1">Java
      *     Language Specification, &sect;15.22.1</a>
      * @see #EXPR
      **/
@@ -3831,7 +3831,7 @@ public final class TokenTypes {
      * </pre>
      *
      * @see <a
-     * href="https://docs.oracle.com/javase/specs/jls/se8/html/jls-15.html#jls-15.22.1">Java
+     *     href="https://docs.oracle.com/javase/specs/jls/se8/html/jls-15.html#jls-15.22.1">Java
      *     Language Specification, &sect;15.22.1</a>
      * @see #EXPR
      **/
@@ -4041,7 +4041,7 @@ public final class TokenTypes {
      * </pre>
      *
      * @see <a
-     * href="https://docs.oracle.com/javase/specs/jls/se8/html/jls-15.html#jls-15.20.2">Java
+     *     href="https://docs.oracle.com/javase/specs/jls/se8/html/jls-15.html#jls-15.20.2">Java
      *     Language Specification, &sect;15.20.2</a>
      * @see #EXPR
      * @see #METHOD_CALL
@@ -4075,7 +4075,7 @@ public final class TokenTypes {
      * </pre>
      *
      * @see <a
-     * href="https://docs.oracle.com/javase/specs/jls/se8/html/jls-15.html#jls-15.19">Java
+     *     href="https://docs.oracle.com/javase/specs/jls/se8/html/jls-15.html#jls-15.19">Java
      *     Language Specification, &sect;15.19</a>
      * @see #EXPR
      **/
@@ -4100,7 +4100,7 @@ public final class TokenTypes {
      * </pre>
      *
      * @see <a
-     * href="https://docs.oracle.com/javase/specs/jls/se8/html/jls-15.html#jls-15.19">Java
+     *     href="https://docs.oracle.com/javase/specs/jls/se8/html/jls-15.html#jls-15.19">Java
      *     Language Specification, &sect;15.19</a>
      * @see #EXPR
      **/
@@ -4123,7 +4123,7 @@ public final class TokenTypes {
      * </pre>
      *
      * @see <a
-     * href="https://docs.oracle.com/javase/specs/jls/se8/html/jls-15.html#jls-15.19">Java
+     *     href="https://docs.oracle.com/javase/specs/jls/se8/html/jls-15.html#jls-15.19">Java
      *     Language Specification, &sect;15.19</a>
      * @see #EXPR
      **/
@@ -4148,7 +4148,7 @@ public final class TokenTypes {
      * </pre>
      *
      * @see <a
-     * href="https://docs.oracle.com/javase/specs/jls/se8/html/jls-15.html#jls-15.18">Java
+     *     href="https://docs.oracle.com/javase/specs/jls/se8/html/jls-15.html#jls-15.18">Java
      *     Language Specification, &sect;15.18</a>
      * @see #EXPR
      **/
@@ -4173,7 +4173,7 @@ public final class TokenTypes {
      * </pre>
      *
      * @see <a
-     * href="https://docs.oracle.com/javase/specs/jls/se8/html/jls-15.html#jls-15.18">Java
+     *     href="https://docs.oracle.com/javase/specs/jls/se8/html/jls-15.html#jls-15.18">Java
      *     Language Specification, &sect;15.18</a>
      * @see #EXPR
      **/
@@ -4198,7 +4198,7 @@ public final class TokenTypes {
      * </pre>
      *
      * @see <a
-     * href="https://docs.oracle.com/javase/specs/jls/se8/html/jls-15.html#jls-15.17.2">Java
+     *     href="https://docs.oracle.com/javase/specs/jls/se8/html/jls-15.html#jls-15.17.2">Java
      *     Language Specification, &sect;15.17.2</a>
      * @see #EXPR
      **/
@@ -4223,7 +4223,7 @@ public final class TokenTypes {
      * </pre>
      *
      * @see <a
-     * href="https://docs.oracle.com/javase/specs/jls/se8/html/jls-15.html#jls-15.17.3">Java
+     *     href="https://docs.oracle.com/javase/specs/jls/se8/html/jls-15.html#jls-15.17.3">Java
      *     Language Specification, &sect;15.17.3</a>
      * @see #EXPR
      **/
@@ -4245,7 +4245,7 @@ public final class TokenTypes {
      * </pre>
      *
      * @see <a
-     * href="https://docs.oracle.com/javase/specs/jls/se8/html/jls-15.html#jls-15.15.1">Java
+     *     href="https://docs.oracle.com/javase/specs/jls/se8/html/jls-15.html#jls-15.15.1">Java
      *     Language Specification, &sect;15.15.1</a>
      * @see #EXPR
      * @see #POST_INC
@@ -4268,7 +4268,7 @@ public final class TokenTypes {
      * </pre>
      *
      * @see <a
-     * href="https://docs.oracle.com/javase/specs/jls/se8/html/jls-15.html#jls-15.15.2">Java
+     *     href="https://docs.oracle.com/javase/specs/jls/se8/html/jls-15.html#jls-15.15.2">Java
      *     Language Specification, &sect;15.15.2</a>
      * @see #EXPR
      * @see #POST_DEC
@@ -4293,7 +4293,7 @@ public final class TokenTypes {
      * </pre>
      *
      * @see <a
-     * href="https://docs.oracle.com/javase/specs/jls/se8/html/jls-15.html#jls-15.15.5">Java
+     *     href="https://docs.oracle.com/javase/specs/jls/se8/html/jls-15.html#jls-15.15.5">Java
      *     Language Specification, &sect;15.15.5</a>
      * @see #EXPR
      **/
@@ -4317,7 +4317,7 @@ public final class TokenTypes {
      * </pre>
      *
      * @see <a
-     * href="https://docs.oracle.com/javase/specs/jls/se8/html/jls-15.html#jls-15.15.6">Java
+     *     href="https://docs.oracle.com/javase/specs/jls/se8/html/jls-15.html#jls-15.15.6">Java
      *     Language Specification, &sect;15.15.6</a>
      * @see #EXPR
      * @noinspection HtmlTagCanBeJavadocTag
@@ -4347,7 +4347,7 @@ public final class TokenTypes {
      * </pre>
      *
      * @see <a
-     * href="https://docs.oracle.com/javase/specs/jls/se8/html/jls-3.html#jls-3.10.3">Java
+     *     href="https://docs.oracle.com/javase/specs/jls/se8/html/jls-3.html#jls-3.10.3">Java
      *     Language Specification, &sect;3.10.3</a>
      * @see #EXPR
      * @see #LITERAL_FALSE
@@ -4377,7 +4377,7 @@ public final class TokenTypes {
      * </pre>
      *
      * @see <a
-     * href="https://docs.oracle.com/javase/specs/jls/se8/html/jls-3.html#jls-3.10.3">Java
+     *     href="https://docs.oracle.com/javase/specs/jls/se8/html/jls-3.html#jls-3.10.3">Java
      *     Language Specification, &sect;3.10.3</a>
      * @see #EXPR
      * @see #LITERAL_TRUE
@@ -4407,7 +4407,7 @@ public final class TokenTypes {
      * </pre>
      *
      * @see <a
-     * href="https://docs.oracle.com/javase/specs/jls/se8/html/jls-3.html#jls-3.10.7">Java
+     *     href="https://docs.oracle.com/javase/specs/jls/se8/html/jls-3.html#jls-3.10.7">Java
      *     Language Specification, &sect;3.10.7</a>
      * @see #EXPR
      **/
@@ -4562,7 +4562,7 @@ public final class TokenTypes {
      * </pre>
      *
      * @see <a
-     * href="https://docs.oracle.com/javase/specs/jls/se8/html/jls-3.html#jls-3.10.1">Java
+     *     href="https://docs.oracle.com/javase/specs/jls/se8/html/jls-3.html#jls-3.10.1">Java
      *     Language Specification, &sect;3.10.1</a>
      * @see #EXPR
      * @see #NUM_LONG
@@ -4586,7 +4586,7 @@ public final class TokenTypes {
      * </pre>
      *
      * @see <a
-     * href="https://docs.oracle.com/javase/specs/jls/se8/html/jls-3.html#jls-3.10.4">Java
+     *     href="https://docs.oracle.com/javase/specs/jls/se8/html/jls-3.html#jls-3.10.4">Java
      *     Language Specification, &sect;3.10.4</a>
      * @see #EXPR
      **/
@@ -4614,7 +4614,7 @@ public final class TokenTypes {
      * </pre>
      *
      * @see <a
-     * href="https://docs.oracle.com/javase/specs/jls/se8/html/jls-3.html#jls-3.10.5">Java
+     *     href="https://docs.oracle.com/javase/specs/jls/se8/html/jls-3.html#jls-3.10.5">Java
      *     Language Specification, &sect;3.10.5</a>
      * @see #EXPR
      **/
@@ -4640,7 +4640,7 @@ public final class TokenTypes {
      * </pre>
      *
      * @see <a
-     * href="https://docs.oracle.com/javase/specs/jls/se8/html/jls-3.html#jls-3.10.2">Java
+     *     href="https://docs.oracle.com/javase/specs/jls/se8/html/jls-3.html#jls-3.10.2">Java
      *     Language Specification, &sect;3.10.2</a>
      * @see #EXPR
      * @see #NUM_DOUBLE
@@ -4666,7 +4666,7 @@ public final class TokenTypes {
      * </pre>
      *
      * @see <a
-     * href="https://docs.oracle.com/javase/specs/jls/se8/html/jls-3.html#jls-3.10.1">Java
+     *     href="https://docs.oracle.com/javase/specs/jls/se8/html/jls-3.html#jls-3.10.1">Java
      *     Language Specification, &sect;3.10.1</a>
      * @see #EXPR
      * @see #NUM_INT
@@ -4692,7 +4692,7 @@ public final class TokenTypes {
      * </pre>
      *
      * @see <a
-     * href="https://docs.oracle.com/javase/specs/jls/se8/html/jls-3.html#jls-3.10.2">Java
+     *     href="https://docs.oracle.com/javase/specs/jls/se8/html/jls-3.html#jls-3.10.2">Java
      *     Language Specification, &sect;3.10.2</a>
      * @see #EXPR
      * @see #NUM_FLOAT

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/SingleLineJavadocCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/SingleLineJavadocCheck.java
@@ -171,7 +171,7 @@ public class SingleLineJavadocCheck extends AbstractJavadocCheck {
      * @param javadocRoot javadoc root node.
      * @return true, if comment has javadoc tags which are not ignored.
      * @see <a href=
-     * "https://docs.oracle.com/javase/7/docs/technotes/tools/windows/javadoc.html#blockandinlinetags">
+     *     "https://docs.oracle.com/javase/7/docs/technotes/tools/windows/javadoc.html#blockandinlinetags">
      *     Block and inline tags</a>
      */
     private boolean hasJavadocTags(DetailNode javadocRoot) {
@@ -186,7 +186,7 @@ public class SingleLineJavadocCheck extends AbstractJavadocCheck {
      * @param javadocRoot javadoc root node.
      * @return true, if comment has in-line tags which are not ignored.
      * @see <a href=
-     * "https://docs.oracle.com/javase/7/docs/technotes/tools/windows/javadoc.html#javadoctags">
+     *     "https://docs.oracle.com/javase/7/docs/technotes/tools/windows/javadoc.html#javadoctags">
      *     JavadocTags</a>
      */
     private boolean hasJavadocInlineTags(DetailNode javadocRoot) {

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocTagContinuationIndentationCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocTagContinuationIndentationCheckTest.java
@@ -155,4 +155,26 @@ public class JavadocTagContinuationIndentationCheckTest
                 getPath("InputJavadocTagContinuationIndentationCheck1.java"),
                 expected);
     }
+
+    @Test
+    public void testJavadocTagContinuationIndentationCheckHtml() throws Exception {
+        final String[] expected = {
+            "15: " + getCheckMessage(MSG_KEY, 4),
+            "18: " + getCheckMessage(MSG_KEY, 4),
+            "28: " + getCheckMessage(MSG_KEY, 4),
+            "29: " + getCheckMessage(MSG_KEY, 4),
+            "30: " + getCheckMessage(MSG_KEY, 4),
+            "50: " + getCheckMessage(MSG_KEY, 4),
+            "51: " + getCheckMessage(MSG_KEY, 4),
+            "52: " + getCheckMessage(MSG_KEY, 4),
+            "63: " + getCheckMessage(MSG_KEY, 4),
+            "64: " + getCheckMessage(MSG_KEY, 4),
+            "65: " + getCheckMessage(MSG_KEY, 4),
+            "75: " + getCheckMessage(MSG_KEY, 4),
+            "76: " + getCheckMessage(MSG_KEY, 4),
+        };
+        verifyWithInlineConfigParser(
+                getPath("InputJavadocTagContinuationIndentationCheckHtml.java"),
+                expected);
+    }
 }

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadoctagcontinuationindentation/InputJavadocTagContinuationIndentationCheckHtml.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadoctagcontinuationindentation/InputJavadocTagContinuationIndentationCheckHtml.java
@@ -1,0 +1,110 @@
+/*
+JavadocTagContinuationIndentation
+violateExecutionOnNonTightHtml = (default)false
+offset = (default)4
+
+
+*/
+
+package com.puppycrawl.tools.checkstyle.checks.javadoc.javadoctagcontinuationindentation;
+// violation 5 lines below 'Line continuation .* expected level should be 4'
+// violation 7 lines below 'Line continuation .* expected level should be 4'
+/**
+ *
+ * @see reference <a href="https://checkstyle.org/checks/javadoc">
+ *   JavadocTagContinuationIndentation: Checks the indentation of the continuation</a>
+ *
+ * @see <a href="https://checkstyle.org/checks/javadoc/javadoctagcontinuationindentation.html">
+ *   JavadocTagContinuationIndentation: Checks the indentation of the continuation lines.</a>
+ */
+public class InputJavadocTagContinuationIndentationCheckHtml {
+
+    // violation 6 lines below 'Line continuation .* expected level should be 4'
+    // violation 6 lines below 'Line continuation .* expected level should be 4'
+    // violation 6 lines below 'Line continuation .* expected level should be 4'
+    /**
+     *
+     * @see <a
+     *   href="https://checkstyle.org/checks/javadoc/javadoctagcontinuationindentation.html">
+     *   JavadocTagContinuationIndentation: Checks the indentation of the continuation lines
+     *   </a>
+     */
+    static class Test {}
+
+    /**
+     * This method demonstrates inline tags, which should be skipped.
+     * {@link java.util.List} {@code String} {@literal example}
+     *
+     * @see <a href="https://example.com">
+     *     This should follow correct indentation.</a>
+     */
+    static class InlineTagTest {}
+
+    // violation 7 lines below 'Line continuation .* expected level should be 4'
+    // violation 7 lines below 'Line continuation .* expected level should be 4'
+    // violation 7 lines below 'Line continuation .* expected level should be 4'
+    /**
+     * Something.
+     *
+     * @param source <a href=
+     * "https://example.com/data-source">
+     * Data Source Documentation
+     * </a>
+     */
+    static void readData(String source) {}
+
+    // violation 7 lines below 'Line continuation .* expected level should be 4'
+    // violation 7 lines below 'Line continuation .* expected level should be 4'
+    // violation 7 lines below 'Line continuation .* expected level should be 4'
+    /**
+     * Something.
+     *
+     * @deprecated Use {@link #getUserInfo()} instead. More details
+     *   <a href="https://example.com/api-changes">
+     *   here
+     *   </a>
+     */
+    @Deprecated
+    static void getUserData() {}
+
+    // violation 5 lines below 'Line continuation .* expected level should be 4'
+    // violation 5 lines below 'Line continuation .* expected level should be 4'
+    /**
+     *
+     * @see <a href="https://checkstyle.org/checks/javadoc/javadoctagcontinuationindentation.html">
+     * JavadocTagContinuationIndentation: Checks the indentation of the continuation lines
+     * </a>
+     */
+    static class Test2 {}
+
+    /**
+     * @see
+     * <a href="https://checkstyle.org"> Javadoc </a> // ok until #16656
+     */
+    static class Test3 {}
+
+    /**
+     * @see
+     *   <a href="https://checkstyle.org"> Javadoc </a> // ok until #16656
+     */
+    static class Test4 {}
+
+    /**
+     * @see
+     *     <a href="https://checkstyle.org"> Javadoc </a>
+     */
+    static class Test5 {}
+
+    /**
+     * @see
+     *       <a href="https://check.org"> Java </a> // ok, Indentation exceeding offset is allowed.
+     */
+    static class Test6 {}
+
+    /**
+     * <a href="https://checkstyle.org/checks/javadoc/javadoctagcontinuationindentation.html">
+     * JavadocTagContinuationIndentation: Checks the indentation of the continuation lines </a>
+     */
+    static class Test7 {}
+
+}


### PR DESCRIPTION
Fixes Issue #16385 and https://github.com/checkstyle/checkstyle/issues/16385
resolved JavadocTagContinuationIndentation Ignore indentation check when HTML tag break line

attention:
Block tags: Represented by JAVADOC_TAG
Inline tags: Represented by JAVADOC_INLINE_TAG