### PR TITLE
Issue #13999: Resolved Pitest Suppression in Pitest-Javadoc for AbstractJavadocCheck 

### DIFF
--- a/config/pitest-suppressions/pitest-javadoc-suppressions.xml
+++ b/config/pitest-suppressions/pitest-javadoc-suppressions.xml
@@ -4,15 +4,6 @@
     <sourceFile>AbstractJavadocCheck.java</sourceFile>
     <mutatedClass>com.puppycrawl.tools.checkstyle.checks.javadoc.AbstractJavadocCheck</mutatedClass>
     <mutatedMethod>walk</mutatedMethod>
-    <mutator>org.pitest.mutationtest.engine.gregor.mutators.RemoveConditionalMutator_EQUAL_ELSE</mutator>
-    <description>removed conditional - replaced equality check with false</description>
-    <lineContent>if (curNode != null) {</lineContent>
-  </mutation>
-
-  <mutation unstable="false">
-    <sourceFile>AbstractJavadocCheck.java</sourceFile>
-    <mutatedClass>com.puppycrawl.tools.checkstyle.checks.javadoc.AbstractJavadocCheck</mutatedClass>
-    <mutatedMethod>walk</mutatedMethod>
     <mutator>org.pitest.mutationtest.engine.gregor.mutators.NonVoidMethodCallMutator</mutator>
     <description>removed call to com/puppycrawl/tools/checkstyle/checks/javadoc/AbstractJavadocCheck::shouldBeProcessed</description>
     <lineContent>waitsForProcessing = shouldBeProcessed(curNode);</lineContent>

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/AbstractJavadocCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/AbstractJavadocCheck.java
@@ -375,6 +375,7 @@ public abstract class AbstractJavadocCheck extends AbstractCheck {
      *        the root of tree for process
      */
     private void walk(DetailNode root) {
+        if (root == null) return;
         DetailNode curNode = root;
         while (curNode != null) {
             boolean waitsForProcessing = shouldBeProcessed(curNode);


### PR DESCRIPTION
Issue: #13999

```
diff --git a/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/AbstractJavadocCheck.java b/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/AbstractJavadocCheck.java
index d3635015a2..997d50fb8c 100644
--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/AbstractJavadocCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/AbstractJavadocCheck.java
@@ -375,6 +375,7 @@ public abstract class AbstractJavadocCheck extends AbstractCheck {
      *        the root of tree for process
      */

```

**mvn clean test**

```
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  11:11 min
[INFO] Finished at: 2025-03-11T14:14:43+05:30
[INFO] ------------------------------------------------------------------------


```

**Suppressed mutation removed:**

 ```
<mutation unstable="false">
    <sourceFile>AbstractJavadocCheck.java</sourceFile>
    <mutatedClass>com.puppycrawl.tools.checkstyle.checks.javadoc.AbstractJavadocCheck</mutatedClass>
    <mutatedMethod>walk</mutatedMethod>
    <mutator>org.pitest.mutationtest.engine.gregor.mutators.RemoveConditionalMutator_EQUAL_ELSE</mutator>
    <description>removed conditional - replaced equality check with false</description>
    <lineContent>if (curNode != null) {</lineContent>
  </mutation>

```

