### PR TITLE
Issue #14631: Update ATTRIBUTE in JavadocTokenTypes.java to new AST format

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/api/JavadocTokenTypes.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/api/JavadocTokenTypes.java
@@ -1588,6 +1588,7 @@ public final class JavadocTokenTypes {
 
     /**
      * Html tag attribute. Parent node for: {@code HTML_TAG_IDENT, EQUALS, ATTR_VALUE}.
+     *
      * <p><b>Example</b></p>
      * <pre>{@code <p class="highlight">Sample text</p>}</pre>
      * <b>Tree</b>

--- a/src/main/java/com/puppycrawl/tools/checkstyle/api/JavadocTokenTypes.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/api/JavadocTokenTypes.java
@@ -1588,6 +1588,32 @@ public final class JavadocTokenTypes {
 
     /**
      * Html tag attribute. Parent node for: {@code HTML_TAG_IDENT, EQUALS, ATTR_VALUE}.
+     * <p><b>Example</b></p>
+     * <pre>{@code <p class="highlight">Sample text</p>}</pre>
+     * <b>Tree</b>
+     * {@code
+     *    --JAVADOC -> JAVADOC
+     *       |--NEWLINE -> \n
+     *       |--LEADING_ASTERISK ->  *
+     *       |--TEXT ->
+     *       |--HTML_ELEMENT -> HTML_ELEMENT
+     *       |   `--PARAGRAPH -> PARAGRAPH
+     *       |       |--P_TAG_START -> P_TAG_START
+     *       |       |   |--START -> <
+     *       |       |   |--P_HTML_TAG_NAME -> p
+     *       |       |   |--WS ->
+     *       |       |   |--ATTRIBUTE -> ATTRIBUTE
+     *       |       |   |   |--HTML_TAG_NAME -> class
+     *       |       |   |   |--EQUALS -> =
+     *       |       |   |   `--ATTR_VALUE -> "highlight"
+     *       |       |   `--END -> >
+     *       |       |--TEXT -> Sample text
+     *       |       `--P_TAG_END -> P_TAG_END
+     *       |           |--START -> <
+     *       |           |--SLASH -> /
+     *       |           |--P_HTML_TAG_NAME -> p
+     *       |           `--END -> >
+     * }
      */
     public static final int ATTRIBUTE = JavadocParser.RULE_attribute
             + RULE_TYPES_OFFSET;

--- a/src/main/java/com/puppycrawl/tools/checkstyle/api/JavadocTokenTypes.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/api/JavadocTokenTypes.java
@@ -1623,7 +1623,7 @@ public final class JavadocTokenTypes {
     /**
      * Paragraph html tag.
      *
-     * <p><b>Example:</b></p>
+     * <p><b>Sample Text:</b></p>
      * <pre>{@code <p>Sample text</p>}</pre>
      * <b>Tree:</b>
      * <pre>

--- a/src/main/java/com/puppycrawl/tools/checkstyle/api/JavadocTokenTypes.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/api/JavadocTokenTypes.java
@@ -1130,7 +1130,7 @@ public final class JavadocTokenTypes {
      * {@code
      *  JAVADOC ->; JAVADOC
      *     |--NEWLINE ->; \r\n
-     *     |--LEADING_ASTERISK ->;      *
+     *     |--LEADING_ASTERISK ->;  *
      *     |--TEXT ->;
      *     |--HTML_ELEMENT ->; HTML_ELEMENT
      *         `--PARAGRAPH ->; PARAGRAPH


### PR DESCRIPTION
Issue #14631 

**Command Used** :

`java -jar checkstyle-10.21.4-all.jar -J Test.java | sed -E 's/\[[0-9]+:[0-9]+\]//g'`

```
Test.java
/**
 * <p class="highlight">Sample text</p>
 */
public class Test {
}
```

**terminal output:**

```
COMPILATION_UNIT -> COMPILATION_UNIT 
`--CLASS_DEF -> CLASS_DEF 
    |--MODIFIERS -> MODIFIERS 
    |   |--BLOCK_COMMENT_BEGIN -> /* 
    |   |   |--COMMENT_CONTENT -> *\n * <p class="highlight">Sample text</p>\n  
    |   |   |   `--JAVADOC -> JAVADOC 
    |   |   |       |--NEWLINE -> \n 
    |   |   |       |--LEADING_ASTERISK ->  * 
    |   |   |       |--TEXT ->   
    |   |   |       |--HTML_ELEMENT -> HTML_ELEMENT 
    |   |   |       |   `--PARAGRAPH -> PARAGRAPH 
    |   |   |       |       |--P_TAG_START -> P_TAG_START 
    |   |   |       |       |   |--START -> < 
    |   |   |       |       |   |--P_HTML_TAG_NAME -> p 
    |   |   |       |       |   |--WS ->   
    |   |   |       |       |   |--ATTRIBUTE -> ATTRIBUTE 
    |   |   |       |       |   |   |--HTML_TAG_NAME -> class 
    |   |   |       |       |   |   |--EQUALS -> = 
    |   |   |       |       |   |   `--ATTR_VALUE -> "highlight" 
    |   |   |       |       |   `--END -> > 
    |   |   |       |       |--TEXT -> Sample text 
    |   |   |       |       `--P_TAG_END -> P_TAG_END 
    |   |   |       |           |--START -> < 
    |   |   |       |           |--SLASH -> / 
    |   |   |       |           |--P_HTML_TAG_NAME -> p 
    |   |   |       |           `--END -> > 
    |   |   |       |--NEWLINE -> \n 
    |   |   |       |--TEXT ->   
    |   |   |       `--EOF -> <EOF> 
    |   |   `--BLOCK_COMMENT_END -> */ 
    |   `--LITERAL_PUBLIC -> public 
    |--LITERAL_CLASS -> class 
    |--IDENT -> Test 
    `--OBJBLOCK -> OBJBLOCK 
        |--LCURLY -> { 
        `--RCURLY -> } 
```