### PR TITLE
Issue #14631: Updated LI_HTML_TAG_NAME to new AST format

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/api/JavadocTokenTypes.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/api/JavadocTokenTypes.java
@@ -1150,7 +1150,55 @@ public final class JavadocTokenTypes {
      */
     public static final int P_HTML_TAG_NAME = JavadocParser.P_HTML_TAG_NAME;
 
-    /** List item tag name. */
+    /**
+     * List item tag name.
+     *
+     * <p><b>Example:</b></p>
+     * <pre>{@code
+     *  <ol>
+     *    <li>banana</li>
+     *  </ol>
+     *  }</pre>
+     *  <b>Tree:</b>
+     *  <pre>
+     *  {@code
+     *   HTML_ELEMENT -> HTML_ELEMENT
+     *    `--HTML_TAG -> HTML_TAG
+     *       |--HTML_ELEMENT_START -> HTML_ELEMENT_START
+     *       |   |--START -> <
+     *       |   |--HTML_TAG_NAME -> ol
+     *       |   `--END -> >
+     *       |--NEWLINE -> \r\n
+     *       |--LEADING_ASTERISK ->  *
+     *       |--TEXT ->
+     *       |--HTML_ELEMENT -> HTML_ELEMENT
+     *       |   `--LI -> LI
+     *       |       |--LI_TAG_START -> LI_TAG_START
+     *       |       |   |--START -> <
+     *       |       |   |--LI_HTML_TAG_NAME -> li
+     *       |       |   `--END -> >
+     *       |       |--TEXT -> banana
+     *       |       `--LI_TAG_END -> LI_TAG_END
+     *       |           |--START -> <
+     *       |           |--SLASH -> /
+     *       |           |--LI_HTML_TAG_NAME -> li
+     *       |           `--END -> >
+     *       |--NEWLINE -> \r\n
+     *       |--LEADING_ASTERISK ->  *
+     *       |--TEXT ->
+     *       `--HTML_ELEMENT_END -> HTML_ELEMENT_END
+     *           |--START -> <
+     *           |--SLASH -> /
+     *           |--HTML_TAG_NAME -> ol
+     *           `--END -> >
+     *  }
+     *  </pre>
+     *
+     * @see
+     * <a href="https://docs.oracle.com/javase/8/docs/technotes/tools/unix/javadoc.html#JSSOR647">
+     * comments are written in HTML</a>
+     * @see #LI_HTML_TAG_NAME
+     */
     public static final int LI_HTML_TAG_NAME = JavadocParser.LI_HTML_TAG_NAME;
 
     /** Table row tag name. */


### PR DESCRIPTION
**Issue**: #14631 

**Command**: 
`java -jar checkstyle-10.21.4-all.jar -j Test.java | sed "s/\[[0-9]\+:[0-9]\+\]//g"`

**Test.java**

```
/**
 * <ol>
 *   <li>banana</li>
 * </ol>
 */
public class Test {
}
```

```
noman@ANIS MINGW64 /d/zaid/zaid/codes/checkstyle/LI_HTML_TAG_NAME AST
$ java -jar checkstyle-10.21.4-all.jar -j Test.java | sed "s/\[[0-9]\+:[0-9]\+\]//g"
JAVADOC -> JAVADOC
|--TEXT -> /**
|--NEWLINE -> \r\n
|--LEADING_ASTERISK ->  *
|--TEXT ->
|--HTML_ELEMENT -> HTML_ELEMENT
|   `--HTML_TAG -> HTML_TAG
|       |--HTML_ELEMENT_START -> HTML_ELEMENT_START
|       |   |--START -> <
|       |   |--HTML_TAG_NAME -> ol
|       |   `--END -> >
|       |--NEWLINE -> \r\n
|       |--LEADING_ASTERISK ->  *
|       |--TEXT ->
|       |--HTML_ELEMENT -> HTML_ELEMENT
|       |   `--LI -> LI
|       |       |--LI_TAG_START -> LI_TAG_START
|       |       |   |--START -> <
|       |       |   |--LI_HTML_TAG_NAME -> li
|       |       |   `--END -> >
|       |       |--TEXT -> banana
|       |       `--LI_TAG_END -> LI_TAG_END
|       |           |--START -> <
|       |           |--SLASH -> /
|       |           |--LI_HTML_TAG_NAME -> li
|       |           `--END -> >
|       |--NEWLINE -> \r\n
|       |--LEADING_ASTERISK ->  *
|       |--TEXT ->
|       `--HTML_ELEMENT_END -> HTML_ELEMENT_END
|           |--START -> <
|           |--SLASH -> /
|           |--HTML_TAG_NAME -> ol
|           `--END -> >
|--NEWLINE -> \r\n
|--LEADING_ASTERISK ->  *
|--TEXT -> /
|--NEWLINE -> \r\n
|--TEXT -> public class Test {
|--NEWLINE -> \r\n
|--TEXT -> }
|--NEWLINE -> \r\n
|--NEWLINE -> \r\n
`--EOF -> <EOF>

```