### PR TITLE
Issue #15456: Define violation message for SuperFinalizeCheck

### DIFF
--- a/src/site/xdoc/checks/coding/superclone.xml
+++ b/src/site/xdoc/checks/coding/superclone.xml
@@ -43,8 +43,7 @@ class Example1 {
 class SuperCloneB {
   private int b;
 
-  // violation below, "Method 'clone' should call 'super.clone'."
-  public SuperCloneB clone() {
+  public SuperCloneB clone() { // violation "Overriding clone() method must invoke super.clone() to ensure proper finalization."
     SuperCloneB other = new SuperCloneB();
     other.b = this.b;
     return other;

--- a/src/site/xdoc/checks/coding/superfinalize.xml
+++ b/src/site/xdoc/checks/coding/superfinalize.xml
@@ -43,7 +43,7 @@ class Example1 {
   }
 }
 class InvalidExample {
-  // violation below, 'Method 'finalize' should call 'super.finalize''
+  // violation below, 'Overriding finalize() method must invoke super.finalize() to ensure proper finalization.'
   protected void finalize() throws Throwable {
   }
 }

--- a/src/test/java/com/puppycrawl/tools/checkstyle/bdd/InlineConfigParser.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/bdd/InlineConfigParser.java
@@ -227,7 +227,6 @@ public final class InlineConfigParser {
             "com.puppycrawl.tools.checkstyle.checks.coding.NestedTryDepthCheck",
             "com.puppycrawl.tools.checkstyle.checks.coding.SimplifyBooleanExpressionCheck",
             "com.puppycrawl.tools.checkstyle.checks.coding.StringLiteralEqualityCheck",
-            "com.puppycrawl.tools.checkstyle.checks.coding.SuperFinalizeCheck",
             "com.puppycrawl.tools.checkstyle.checks.coding"
                     + ".UnnecessarySemicolonAfterTypeMemberDeclarationCheck",
             "com.puppycrawl.tools.checkstyle.checks.coding"

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/coding/SuperCloneCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/coding/SuperCloneCheckTest.java
@@ -20,7 +20,6 @@
 package com.puppycrawl.tools.checkstyle.checks.coding;
 
 import static com.google.common.truth.Truth.assertWithMessage;
-import static com.puppycrawl.tools.checkstyle.checks.coding.AbstractSuperCheck.MSG_KEY;
 
 import java.io.File;
 import java.util.Collection;
@@ -47,9 +46,9 @@ public class SuperCloneCheckTest
     @Test
     public void testIt() throws Exception {
         final String[] expected = {
-            "33:19: " + getCheckMessage(MSG_KEY, "clone", "super.clone"),
-            "41:19: " + getCheckMessage(MSG_KEY, "clone", "super.clone"),
-            "67:48: " + getCheckMessage(MSG_KEY, "clone", "super.clone"),
+            "33:19: Overriding clone() method must invoke super.clone() to ensure proper finalization.",
+            "41:19: Overriding clone() method must invoke super.clone() to ensure proper finalization.",
+            "67:48: Overriding clone() method must invoke super.clone() to ensure proper finalization.",
         };
         verifyWithInlineConfigParser(
                 getPath("InputSuperCloneInnerAndWithArguments.java"), expected);
@@ -58,8 +57,8 @@ public class SuperCloneCheckTest
     @Test
     public void testAnotherInputFile() throws Exception {
         final String[] expected = {
-            "14:17: " + getCheckMessage(MSG_KEY, "clone", "super.clone"),
-            "48:17: " + getCheckMessage(MSG_KEY, "clone", "super.clone"),
+            "14:17: Overriding clone() method must invoke super.clone() to ensure proper finalization.",
+            "48:17: Overriding clone() method must invoke super.clone() to ensure proper finalization.",
         };
         verifyWithInlineConfigParser(
                 getPath("InputSuperClonePlainAndSubclasses.java"), expected);

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/coding/SuperFinalizeCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/coding/SuperFinalizeCheckTest.java
@@ -19,8 +19,6 @@
 
 package com.puppycrawl.tools.checkstyle.checks.coding;
 
-import static com.puppycrawl.tools.checkstyle.checks.coding.AbstractSuperCheck.MSG_KEY;
-
 import org.junit.jupiter.api.Test;
 
 import com.puppycrawl.tools.checkstyle.AbstractModuleTestSupport;
@@ -36,9 +34,9 @@ public class SuperFinalizeCheckTest
     @Test
     public void testIt() throws Exception {
         final String[] expected = {
-            "34:17: " + getCheckMessage(MSG_KEY, "finalize", "super.finalize"),
-            "41:17: " + getCheckMessage(MSG_KEY, "finalize", "super.finalize"),
-            "83:20: " + getCheckMessage(MSG_KEY, "finalize", "super.finalize"),
+            "34:17: Overriding finalize() method must invoke super.finalize() to ensure proper finalization.",
+            "41:17: Overriding finalize() method must invoke super.finalize() to ensure proper finalization.",
+            "83:20: Overriding finalize() method must invoke super.finalize() to ensure proper finalization.",
         };
         verifyWithInlineConfigParser(
                 getPath("InputSuperFinalizeVariations.java"), expected);
@@ -47,7 +45,7 @@ public class SuperFinalizeCheckTest
     @Test
     public void testMethodReference() throws Exception {
         final String[] expected = {
-            "23:20: " + getCheckMessage(MSG_KEY, "finalize", "super.finalize"),
+            "23:20: Overriding finalize() method must invoke super.finalize() to ensure proper finalization.",
         };
         verifyWithInlineConfigParser(
                 getPath("InputSuperFinalizeMethodReference.java"), expected);

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/superclone/InputSuperCloneInnerAndWithArguments.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/superclone/InputSuperCloneInnerAndWithArguments.java
@@ -30,7 +30,7 @@ public class InputSuperCloneInnerAndWithArguments
 
 class NoSuperClone
 {
-    public Object clone() // violation "Method 'clone' should call 'super.clone'"
+    public Object clone() // violation "Overriding clone() method must invoke super.clone() to ensure proper finalization."
     {
         return null;
     }
@@ -38,7 +38,7 @@ class NoSuperClone
 
 class InnerClone
 {
-    public Object clone() // violation "Method 'clone' should call 'super.clone'"
+    public Object clone() // violation "Overriding clone() method must invoke super.clone() to ensure proper finalization."
     {
         class Inner
         {
@@ -63,7 +63,7 @@ class CloneWithTypeArguments<T> extends CloneWithTypeArgumentsAndNoSuper<T>
 
 class CloneWithTypeArgumentsAndNoSuper<T>
 {
-    // violation below "Method 'clone' should call 'super.clone'"
+    // violation below "Overriding clone() method must invoke super.clone() to ensure proper finalization."
     public CloneWithTypeArgumentsAndNoSuper<T> clone()
             throws CloneNotSupportedException
     {

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/superclone/InputSuperClonePlainAndSubclasses.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/superclone/InputSuperClonePlainAndSubclasses.java
@@ -11,7 +11,7 @@ interface InputSuperClonePlainAndSubclasses {
 }
 
 class A {
-  public Object clone() { // violation "Method 'clone' should call 'super.clone'"
+  public Object clone() { // violation "Overriding clone() method must invoke super.clone() to ensure proper finalization."
       return null;
   }
 }
@@ -44,7 +44,7 @@ class C extends B {
 }
 
 class D extends B {
-  // violation below "Method 'clone' should call 'super.clone'"
+  // violation below "Overriding clone() method must invoke super.clone() to ensure proper finalization."
   public Object clone() throws CloneNotSupportedException {
     super.clone(null, null);
     return null;

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/superfinalize/InputSuperFinalizeMethodReference.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/superfinalize/InputSuperFinalizeMethodReference.java
@@ -20,6 +20,6 @@ public class InputSuperFinalizeMethodReference extends ClassWithFinalizer {
 }
 
 class ClassWithFinalizer {
-    protected void finalize() throws Throwable { // violation
+    protected void finalize() throws Throwable { // violation "Overriding finalize() method must invoke super.finalize() to ensure proper finalization."
     }
 }

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/superfinalize/InputSuperFinalizeVariations.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/superfinalize/InputSuperFinalizeVariations.java
@@ -31,14 +31,14 @@ public class InputSuperFinalizeVariations
 
 class NoSuperFinalize
 {
-    public void finalize() // violation
+    public void finalize() // violation "Overriding finalize() method must invoke super.finalize() to ensure proper finalization."
     {
     }
 }
 
 class InputInnerFinalize
 {
-    public void finalize() // violation
+    public void finalize() // violation "Overriding finalize() method must invoke super.finalize() to ensure proper finalization."
     {
         class Inner
         {
@@ -80,7 +80,7 @@ class FinalizeWithArgs {
 
 class OverrideClass extends FinalizeWithArgs {
     @Override
-    protected void finalize() throws Throwable { // violation
+    protected void finalize() throws Throwable { // violation "Overriding finalize() method must invoke super.finalize() to ensure proper finalization."
         super.finalize(new Object());
     }
 }

--- a/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/checks/coding/SuperCloneCheckExamplesTest.java
+++ b/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/checks/coding/SuperCloneCheckExamplesTest.java
@@ -19,8 +19,6 @@
 
 package com.puppycrawl.tools.checkstyle.checks.coding;
 
-import static com.puppycrawl.tools.checkstyle.checks.coding.AbstractSuperCheck.MSG_KEY;
-
 import org.junit.jupiter.api.Test;
 
 import com.puppycrawl.tools.checkstyle.AbstractExamplesModuleTestSupport;
@@ -35,7 +33,7 @@ public class SuperCloneCheckExamplesTest extends AbstractExamplesModuleTestSuppo
     @Test
     public void testExample1() throws Exception {
         final String[] expected = {
-            "22:22: " + getCheckMessage(MSG_KEY, "clone"),
+            "22:22: Overriding clone() method must invoke super.clone() to ensure proper finalization.",
         };
 
         verifyWithInlineConfigParser(getPath("Example1.java"), expected);

--- a/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/checks/coding/SuperFinalizeCheckExamplesTest.java
+++ b/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/checks/coding/SuperFinalizeCheckExamplesTest.java
@@ -19,8 +19,6 @@
 
 package com.puppycrawl.tools.checkstyle.checks.coding;
 
-import static com.puppycrawl.tools.checkstyle.checks.coding.AbstractSuperCheck.MSG_KEY;
-
 import org.junit.jupiter.api.Test;
 
 import com.puppycrawl.tools.checkstyle.AbstractExamplesModuleTestSupport;
@@ -34,7 +32,7 @@ public class SuperFinalizeCheckExamplesTest extends AbstractExamplesModuleTestSu
     @Test
     public void testExample1() throws Exception {
         final String[] expected = {
-            "18:18: " + getCheckMessage(MSG_KEY, "finalize", "super.finalize"),
+            "18:18: Overriding finalize() method must invoke super.finalize() to ensure proper finalization.",
         };
 
         verifyWithInlineConfigParser(getPath("Example1.java"), expected);

--- a/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/coding/superclone/Example1.java
+++ b/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/coding/superclone/Example1.java
@@ -18,8 +18,8 @@ class Example1 {
 class SuperCloneB {
   private int b;
 
-  // violation below, "Method 'clone' should call 'super.clone'."
-  public SuperCloneB clone() {
+
+  public SuperCloneB clone() { // violation "Overriding clone() method must invoke super.clone() to ensure proper finalization."
     SuperCloneB other = new SuperCloneB();
     other.b = this.b;
     return other;

--- a/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/coding/superfinalize/Example1.java
+++ b/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/coding/superfinalize/Example1.java
@@ -14,7 +14,7 @@ class Example1 {
   }
 }
 class InvalidExample {
-  // violation below, 'Method 'finalize' should call 'super.finalize''
+  // violation below, 'Overriding finalize() method must invoke super.finalize() to ensure proper finalization.'
   protected void finalize() throws Throwable {
   }
 }


### PR DESCRIPTION
Issue: #15456

**com.puppycrawl.tools.checkstyle.checks.coding.SuperFinalizeCheck**

**Before:**
violation Method 'clone' should call 'super.clone'
violation Method 'finalize' should call 'super.finalize'

**After:**
violation Overriding clone() method must invoke super.clone() to ensure proper finalization
violation Overriding finalize() method must invoke super.finalize() to ensure proper finalization
