### PR TITLE
Issue #14631: Updated HR_HTML_TAG_NAME in JavadocTokenTypes.java to new AST format

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/api/JavadocTokenTypes.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/api/JavadocTokenTypes.java
@@ -1280,7 +1280,31 @@ public final class JavadocTokenTypes {
     /** Frame tag name. */
     public static final int FRAME_HTML_TAG_NAME = JavadocParser.FRAME_HTML_TAG_NAME;
 
-    /** Hr tag name. */
+    /**
+     * Hr tag name.
+     *
+     * <p><b>Example:</b></p>
+     * <pre>{@code text before horizontal rule < hr > text after horizontal rule}</pre>
+     * <b>Tree:</b>
+     * <pre>
+     * {@code
+     *   JAVADOC ->; JAVADOC
+     *        |--NEWLINE -> \r\n
+     *        |--LEADING_ASTERISK ->  *
+     *        |--TEXT ->  text before horizontal rule
+     *        |--HTML_ELEMENT -> HTML_ELEMENT
+     *        |   `--SINGLETON_ELEMENT -> SINGLETON_ELEMENT
+     *        |       `--HR_TAG -> HR_TAG
+     *        |           |--START -> <
+     *        |           |--HR_HTML_TAG_NAME -> hr
+     *        |           `--END -> >
+     *        |--TEXT ->  text after horizontal rule
+     *        |--NEWLINE -> \r\n
+     *        |--TEXT ->
+     * }
+     * </pre>
+     */
+    
     public static final int HR_HTML_TAG_NAME = JavadocParser.HR_HTML_TAG_NAME;
 
     /** Img tag name. */


### PR DESCRIPTION
Issue #14631 

**Command used** 
`java -jar checkstyle-10.21.4-all.jar -J Test.java | sed "s/\[[0-9]\+:[0-9]\+\]//g"`


**Test.java**
```
Prarthana@Prarthana MINGW64 ~/OneDrive/desktop/hr_tag
$ cat Test.java
/**
 * text before horizontal rule <hr> text after horizontal rule
 */
public class Test {
}
```

```
Prarthana@Prarthana MINGW64 ~/OneDrive/desktop/attr_value
$ java -jar checkstyle-10.21.4-all.jar -J Test.java | sed "s/\[[0-9]\+:[0-9]\+\]//g"
COMPILATION_UNIT -> COMPILATION_UNIT
`--CLASS_DEF -> CLASS_DEF
    |--MODIFIERS -> MODIFIERS
    |   |--BLOCK_COMMENT_BEGIN -> /*
    |   |   |--COMMENT_CONTENT -> *\r\n * text before horizontal rule <hr> text after horizontal rule\r\n
    |   |   |   `--JAVADOC -> JAVADOC
    |   |   |       |--NEWLINE -> \r\n
    |   |   |       |--LEADING_ASTERISK ->  *
    |   |   |       |--TEXT ->  text before horizontal rule
    |   |   |       |--HTML_ELEMENT -> HTML_ELEMENT
    |   |   |       |   `--SINGLETON_ELEMENT -> SINGLETON_ELEMENT
    |   |   |       |       `--HR_TAG -> HR_TAG
    |   |   |       |           |--START -> <
    |   |   |       |           |--HR_HTML_TAG_NAME -> hr
    |   |   |       |           `--END -> >
    |   |   |       |--TEXT ->  text after horizontal rule
    |   |   |       |--NEWLINE -> \r\n
    |   |   |       |--TEXT ->
    |   |   |       `--EOF -> <EOF>
    |   |   `--BLOCK_COMMENT_END -> */
    |   `--LITERAL_PUBLIC -> public
    |--LITERAL_CLASS -> class
    |--IDENT -> Test
    `--OBJBLOCK -> OBJBLOCK
        |--LCURLY -> {
        `--RCURLY -> }
```