### PR TITLE
Issue #14631: Update COLGROUP_HTML_TAG_NAME to new AST format

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/api/JavadocTokenTypes.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/api/JavadocTokenTypes.java
@@ -1165,7 +1165,39 @@ public final class JavadocTokenTypes {
     /** Body tag name. */
     public static final int BODY_HTML_TAG_NAME = JavadocParser.BODY_HTML_TAG_NAME;
 
-    /** Colgroup tag name. */
+    /** Colgroup tag name.
+     * <p><b>Example:</b></p>
+     * <pre>{@code <colgroup span="2"></colgroup>}</pre>
+     * <b>Tree:</b>
+     * <pre>
+     *     {@code
+     *     JAVADOC -> JAVADOC
+     *     |--NEWLINE -> \r\n
+     *     |--LEADING_ASTERISK ->  *
+     *     |--TEXT ->
+     *     |--HTML_ELEMENT -> HTML_ELEMENT
+     *     |   `--COLGROUP -> COLGROUP
+     *     |       |--COLGROUP_TAG_START -> COLGROUP_TAG_START
+     *     |       |   |--START -> <
+     *     |       |   |--COLGROUP_HTML_TAG_NAME -> colgroup
+     *     |       |   |--WS ->
+     *     |       |   |--ATTRIBUTE -> ATTRIBUTE
+     *     |       |   |   |--HTML_TAG_NAME -> span
+     *     |       |   |   |--EQUALS -> =
+     *     |       |   |   `--ATTR_VALUE -> "2"
+     *     |       |   `--END -> >
+     *     |       `--COLGROUP_TAG_END -> COLGROUP_TAG_END
+     *     |           |--START -> <
+     *     |           |--SLASH -> /
+     *     |           |--COLGROUP_HTML_TAG_NAME -> colgroup
+     *     |           `--END -> >
+     *     |--TEXT ->
+     *     |--NEWLINE -> \r\n
+     *     |--TEXT ->
+     *     }
+     *     </pre>
+     * @see #COLGROUP_HTML_TAG_NAME
+     */
     public static final int COLGROUP_HTML_TAG_NAME = JavadocParser.COLGROUP_HTML_TAG_NAME;
 
     /** Description of a term tag name. */


### PR DESCRIPTION
Issue : #14631

**Command used:**
`java -jar checkstyle-10.21.4-all.jar -J Test.java | sed "s/\[[0-9]\+:[0-9]\+\]//g"`

**Test.java**
```
/**
 * @Colgroup
 */

public class Test {
}
```

```
~/IdeaProjects/Author AST [master L|● 8✚ 3…1] 
23:45 $ java -jar checkstyle-10.21.4-all.jar -J Test.java | sed "s/\[[0-9]\+:[0-9]\+\]//g"
COMPILATION_UNIT -> COMPILATION_UNIT 
`--CLASS_DEF -> CLASS_DEF 
    |--MODIFIERS -> MODIFIERS 
    |   |--BLOCK_COMMENT_BEGIN -> /* 
    |   |   |--COMMENT_CONTENT -> *\n * @Colgroup\n  
    |   |   |   `--JAVADOC -> JAVADOC 
    |   |   |       |--NEWLINE -> \n 
    |   |   |       |--LEADING_ASTERISK ->  * 
    |   |   |       |--WS ->   
    |   |   |       |--JAVADOC_TAG -> JAVADOC_TAG 
    |   |   |       |   |--CUSTOM_NAME -> @Colgroup 
    |   |   |       |   |--NEWLINE -> \n 
    |   |   |       |   `--WS ->   
    |   |   |       `--EOF -> <EOF> 
    |   |   `--BLOCK_COMMENT_END -> */ 
    |   `--LITERAL_PUBLIC -> public 
    |--LITERAL_CLASS -> class 
    |--IDENT -> Test 
    `--OBJBLOCK -> OBJBLOCK 
        |--LCURLY -> { 
        `--RCURLY -> } 
```
