### PR TITLE
Issue #14894: Resolve pitest suppression for UnusedLocalVariableCheck

### DIFF
--- a/config/pitest-suppressions/pitest-coding-2-suppressions.xml
+++ b/config/pitest-suppressions/pitest-coding-2-suppressions.xml
@@ -1,23 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <suppressedMutations>
-  <!-- until https://github.com/checkstyle/checkstyle/issues/14894 -->
-  <mutation unstable="false">
-    <sourceFile>UnusedLocalVariableCheck.java</sourceFile>
-    <mutatedClass>com.puppycrawl.tools.checkstyle.checks.coding.UnusedLocalVariableCheck</mutatedClass>
-    <mutatedMethod>getBlockContainingLocalAnonInnerClass</mutatedMethod>
-    <mutator>org.pitest.mutationtest.engine.gregor.mutators.NegateConditionalsMutator</mutator>
-    <description>negated conditional</description>
-    <lineContent>if (currentAst.getType() == TokenTypes.LAMBDA) {</lineContent>
-  </mutation>
-
-  <mutation unstable="false">
-    <sourceFile>UnusedLocalVariableCheck.java</sourceFile>
-    <mutatedClass>com.puppycrawl.tools.checkstyle.checks.coding.UnusedLocalVariableCheck</mutatedClass>
-    <mutatedMethod>getBlockContainingLocalAnonInnerClass</mutatedMethod>
-    <mutator>org.pitest.mutationtest.engine.gregor.mutators.RemoveConditionalMutator_EQUAL_IF</mutator>
-    <description>removed conditional - replaced equality check with true</description>
-    <lineContent>if (currentAst.getType() == TokenTypes.LAMBDA) {</lineContent>
-  </mutation>
 
   <mutation unstable="false">
     <sourceFile>UnusedLocalVariableCheck.java</sourceFile>

--- a/config/spotbugs-exclude.xml
+++ b/config/spotbugs-exclude.xml
@@ -313,13 +313,6 @@
     <Bug pattern="CT_CONSTRUCTOR_THROW"/>
   </Match>
   <Match>
-    <!-- variable is just being saved for further analysis and isn't the main decider
-         of the loop if it is done or not -->
-    <Class name="com.puppycrawl.tools.checkstyle.checks.coding.UnusedLocalVariableCheck"/>
-    <Method name="getBlockContainingLocalAnonInnerClass"/>
-    <Bug pattern="SLS_SUSPICIOUS_LOOP_SEARCH"/>
-  </Match>
-  <Match>
     <!-- conflicts with PRMC_POSSIBLY_REDUNDANT_METHOD_CALLS -->
     <Class name="com.puppycrawl.tools.checkstyle.checks.imports.PkgImportControl"/>
     <Method name="matchesAtFrontNoRegex"/>

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/UnusedLocalVariableCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/UnusedLocalVariableCheck.java
@@ -469,18 +469,12 @@ public class UnusedLocalVariableCheck extends AbstractCheck {
     private static DetailAST getBlockContainingLocalAnonInnerClass(DetailAST literalNewAst) {
         DetailAST currentAst = literalNewAst;
         DetailAST result = null;
-        DetailAST topMostLambdaAst = null;
         while (currentAst != null && !TokenUtil.isOfType(currentAst,
                 ANONYMOUS_CLASS_PARENT_TOKENS)) {
-            if (currentAst.getType() == TokenTypes.LAMBDA) {
-                topMostLambdaAst = currentAst;
-            }
             currentAst = currentAst.getParent();
-            result = currentAst;
-        }
-
-        if (currentAst == null) {
-            result = topMostLambdaAst;
+            if (currentAst != null) {
+                result = currentAst;
+            }
         }
         return result;
     }


### PR DESCRIPTION
Issue [#14894](https://github.com/checkstyle/checkstyle/issues/14894)

- Removed suppressions _pitest-coding-2-suppressions.xml_ for **UnusedLocalVariableCheck**
- Removed excluding **SLS_SUSPICIOUS_LOOP_SEARCH** bug for **UnusedLocalVariableCheck**
- Removed Lambda optimization for `getBlockContainingLocalAnonInnerClass` in  _UnusedLocalVariableCheck .java_ following [Commit becac62](https://github.com/rdiachenko/checkstyle/commit/becac625e959642a658fa0b49ce943ea6fd76365)