### PR TITLE
Pull #16559: fix `OSX build` when `.DS_Store` is present

### DIFF
--- a/src/test/java/com/puppycrawl/tools/checkstyle/internal/XpathRegressionTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/internal/XpathRegressionTest.java
@@ -97,6 +97,8 @@ public class XpathRegressionTest extends AbstractModuleTestSupport {
         getAllowedDirectoryAndChecks();
 
     private static final Set<String> INTERNAL_MODULES = getInternalModules();
+    private static final DirectoryStream.Filter<Path> IS_DIRECTORY = path
+            -> path.toFile().isDirectory();
 
     private Path javaDir;
     private Path inputDir;
@@ -212,7 +214,7 @@ public class XpathRegressionTest extends AbstractModuleTestSupport {
 
     @Test
     public void validateInputFiles() throws Exception {
-        try (DirectoryStream<Path> dirs = Files.newDirectoryStream(inputDir)) {
+        try (DirectoryStream<Path> dirs = Files.newDirectoryStream(inputDir, IS_DIRECTORY)) {
             for (Path dir : dirs) {
                 // input directory must be named in lower case
                 assertWithMessage(dir + " is not a directory")


### PR DESCRIPTION
Pull #16559: fix `OSX build` when `.DS_Store` is present

ref: https://github.com/checkstyle/checkstyle/issues/16801

https://en.m.wikipedia.org/wiki/.DS_Store#:~:text=DS_Store%20is%20a%20file%20that,positions%2C%20and%20other%20visual%20information.

this a file created while walking in file manager.