### PR TITLE
Issue #15456: Define violation message for LocalFinalVariableNameCheck

### DIFF
--- a/src/site/xdoc/checks/naming/localfinalvariablename.xml
+++ b/src/site/xdoc/checks/naming/localfinalvariablename.xml
@@ -83,10 +83,10 @@
 class Example1{
   void MyMethod() {
     try {
-      final int VAR1 = 5; // violation
+      final int VAR1 = 5; // violation 'Name 'VAR1' must match pattern'
       final int var1 = 10;
     } catch (Exception ex) {
-      final int VAR2 = 15; // violation
+      final int VAR2 = 15; // violation 'Name 'VAR2' must match pattern'
       final int var2 = 20;
     }
   }
@@ -111,10 +111,10 @@ class Example2 {
   void MyMethod() {
     try {
       final int VAR1 = 5;
-      final int var1 = 10; // violation
+      final int var1 = 10; // violation 'Name 'var1' must match pattern'
     } catch (Exception ex) {
       final int VAR2 = 15;
-      final int var2 = 20; // violation
+      final int var2 = 20; // violation 'Name 'var2' must match pattern'
     }
   }
 }
@@ -137,11 +137,12 @@ class Example2 {
         <div class="wrapper"><pre class="prettyprint"><code class="language-java">
 class Example3 {
   void MyMethod() {
-    try(Scanner scanner = new Scanner(System.in)) { // violation
+    // violation below 'Name 'scanner' must match pattern'
+    try(Scanner scanner = new Scanner(System.in)) {
 
       final int VAR1 = 5;
       final int var1 = 10;
-    } catch (final Exception ex) { // violation
+    } catch (final Exception ex) { // violation 'Name 'ex' must match pattern'
 
       final int VAR2 = 15;
       final int var2 = 20;

--- a/src/test/java/com/puppycrawl/tools/checkstyle/bdd/InlineConfigParser.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/bdd/InlineConfigParser.java
@@ -267,7 +267,6 @@ public final class InlineConfigParser {
 
             "com.puppycrawl.tools.checkstyle.checks.naming.ConstantNameCheck",
             "com.puppycrawl.tools.checkstyle.checks.naming.IllegalIdentifierNameCheck",
-            "com.puppycrawl.tools.checkstyle.checks.naming.LocalFinalVariableNameCheck",
             "com.puppycrawl.tools.checkstyle.checks.naming.LocalVariableNameCheck",
             "com.puppycrawl.tools.checkstyle.checks.naming.MethodNameCheck",
             "com.puppycrawl.tools.checkstyle.checks.naming.MethodTypeParameterNameCheck",

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/naming/LocalFinalVariableNameCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/naming/LocalFinalVariableNameCheckTest.java
@@ -101,11 +101,11 @@ public class LocalFinalVariableNameCheckTest
         final String pattern = "[A-Z]+";
 
         final String[] expected = {
-            "31:30: " + getCheckMessage(MSG_INVALID_PATTERN, "br", pattern),
-            "41:29: " + getCheckMessage(MSG_INVALID_PATTERN, "br", pattern),
-            "61:22: " + getCheckMessage(MSG_INVALID_PATTERN, "zf", pattern),
-            "79:30: " + getCheckMessage(MSG_INVALID_PATTERN, "fis8859_1", pattern),
-            "82:32: " + getCheckMessage(MSG_INVALID_PATTERN, "isrutf8", pattern),
+            "32:30: " + getCheckMessage(MSG_INVALID_PATTERN, "br", pattern),
+            "43:29: " + getCheckMessage(MSG_INVALID_PATTERN, "br", pattern),
+            "63:22: " + getCheckMessage(MSG_INVALID_PATTERN, "zf", pattern),
+            "82:30: " + getCheckMessage(MSG_INVALID_PATTERN, "fis8859_1", pattern),
+            "86:32: " + getCheckMessage(MSG_INVALID_PATTERN, "isrutf8", pattern),
         };
         verifyWithInlineConfigParser(
                 getPath("InputLocalFinalVariableNameTryResources.java"), expected);

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/naming/localfinalvariablename/InputLocalFinalVariableName.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/naming/localfinalvariablename/InputLocalFinalVariableName.java
@@ -123,7 +123,7 @@ final class InputLocalFinalVariableName
 
         // final decls
         final int cde = 0;
-        final int CDE = 0; // violation
+        final int CDE = 0; // violation 'Name 'CDE' must match pattern'
 
         // decl in for loop init statement
         for (int k = 0; k < 1; k++)

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/naming/localfinalvariablename/InputLocalFinalVariableName1.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/naming/localfinalvariablename/InputLocalFinalVariableName1.java
@@ -122,7 +122,7 @@ final class InputLocalFinalVariableName1
         int ABC = 0;
 
         // final decls
-        final int cde = 0; // violation
+        final int cde = 0; // violation 'Name 'cde' must match pattern'
         final int CDE = 0;
 
         // decl in for loop init statement

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/naming/localfinalvariablename/InputLocalFinalVariableNameTryResources.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/naming/localfinalvariablename/InputLocalFinalVariableNameTryResources.java
@@ -28,7 +28,8 @@ public class InputLocalFinalVariableNameTryResources {
 
     void method() throws Exception {
         final String fileName = "Test";
-        final BufferedReader br = new BufferedReader(new InputStreamReader( // violation
+        // violation below 'Name 'br' must match pattern'
+        final BufferedReader br = new BufferedReader(new InputStreamReader(
                 new FileInputStream(fileName), StandardCharsets.UTF_8));
         try {
         } finally {
@@ -38,7 +39,8 @@ public class InputLocalFinalVariableNameTryResources {
 
     void method2() throws Exception {
         final String fileName = "Test";
-        try (BufferedReader br = new BufferedReader(new InputStreamReader( // violation
+        // violation below 'Name 'br' must match pattern'
+        try (BufferedReader br = new BufferedReader(new InputStreamReader(
                 new FileInputStream(fileName), StandardCharsets.UTF_8))) {
         } finally {
 
@@ -58,7 +60,7 @@ public class InputLocalFinalVariableNameTryResources {
         final String fileName = "Test";
         try (BufferedReader BR = new BufferedReader(new InputStreamReader(
                 new FileInputStream(fileName), StandardCharsets.UTF_8));
-             ZipFile zf = new ZipFile(fileName)) { // violation
+             ZipFile zf = new ZipFile(fileName)) { // violation 'Name 'zf' must match pattern'
         } finally {
 
         }
@@ -76,10 +78,12 @@ public class InputLocalFinalVariableNameTryResources {
 
     void method6() throws Exception {
         String srcDir = System.getProperty("test.src", ".");
-        try (FileInputStream fis8859_1 = new FileInputStream( // violation
+        // violation below 'Name 'fis8859_1' must match pattern'
+        try (FileInputStream fis8859_1 = new FileInputStream(
                 new File(srcDir, "Bug.properties"));
              FileInputStream fisUTF8 = new FileInputStream(new File(srcDir, "Bug_Utf8.properties"));
-             InputStreamReader isrutf8 = new InputStreamReader(fisUTF8, "UTF-8")) { // violation
+             // violation below 'Name 'isrutf8' must match pattern'
+             InputStreamReader isrutf8 = new InputStreamReader(fisUTF8, "UTF-8")) {
             PropertyResourceBundle bundleUtf8 = new PropertyResourceBundle(isrutf8);
             PropertyResourceBundle bundle = new PropertyResourceBundle(fis8859_1);
             String[] arrayUtf8 = {"1", "2", "3"};

--- a/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/checks/naming/LocalFinalVariableNameCheckExamplesTest.java
+++ b/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/checks/naming/LocalFinalVariableNameCheckExamplesTest.java
@@ -54,8 +54,8 @@ public class LocalFinalVariableNameCheckExamplesTest extends AbstractExamplesMod
     @Test
     public void testExample3() throws Exception {
         final String[] expected = {
-            "19:17: " + getCheckMessage(MSG_INVALID_PATTERN, "scanner", "^[A-Z][A-Z0-9]*$"),
-            "23:30: " + getCheckMessage(MSG_INVALID_PATTERN, "ex", "^[A-Z][A-Z0-9]*$"),
+            "20:17: " + getCheckMessage(MSG_INVALID_PATTERN, "scanner", "^[A-Z][A-Z0-9]*$"),
+            "24:30: " + getCheckMessage(MSG_INVALID_PATTERN, "ex", "^[A-Z][A-Z0-9]*$"),
         };
 
         verifyWithInlineConfigParser(getPath("Example3.java"), expected);

--- a/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/naming/localfinalvariablename/Example1.java
+++ b/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/naming/localfinalvariablename/Example1.java
@@ -14,10 +14,10 @@ package com.puppycrawl.tools.checkstyle.checks.naming.localfinalvariablename;
 class Example1{
   void MyMethod() {
     try {
-      final int VAR1 = 5; // violation
+      final int VAR1 = 5; // violation 'Name 'VAR1' must match pattern'
       final int var1 = 10;
     } catch (Exception ex) {
-      final int VAR2 = 15; // violation
+      final int VAR2 = 15; // violation 'Name 'VAR2' must match pattern'
       final int var2 = 20;
     }
   }

--- a/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/naming/localfinalvariablename/Example2.java
+++ b/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/naming/localfinalvariablename/Example2.java
@@ -15,10 +15,10 @@ class Example2 {
   void MyMethod() {
     try {
       final int VAR1 = 5;
-      final int var1 = 10; // violation
+      final int var1 = 10; // violation 'Name 'var1' must match pattern'
     } catch (Exception ex) {
       final int VAR2 = 15;
-      final int var2 = 20; // violation
+      final int var2 = 20; // violation 'Name 'var2' must match pattern'
     }
   }
 }

--- a/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/naming/localfinalvariablename/Example3.java
+++ b/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/naming/localfinalvariablename/Example3.java
@@ -16,11 +16,12 @@ import java.util.Scanner;
 // xdoc section -- start
 class Example3 {
   void MyMethod() {
-    try(Scanner scanner = new Scanner(System.in)) { // violation
+    // violation below 'Name 'scanner' must match pattern'
+    try(Scanner scanner = new Scanner(System.in)) {
 
       final int VAR1 = 5;
       final int var1 = 10;
-    } catch (final Exception ex) { // violation
+    } catch (final Exception ex) { // violation 'Name 'ex' must match pattern'
 
       final int VAR2 = 15;
       final int var2 = 20;


### PR DESCRIPTION
Issue: https://github.com/checkstyle/checkstyle/issues/15456

**com.puppycrawl.tools.checkstyle.checks.coding.LocalFinalVariableNameCheck**

**Some info** 
Needed to add suppressions to ignore line length violations in test inputs, as these lines contain message required for validation