### PR TITLE
Issue #16543: implement IDE agnostic configuration with `editorconfig.org`

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,40 @@
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+indent_style = space
+insert_final_newline = true
+
+[*.java]
+ij_continuation_indent_size = 4
+ij_java_binary_operation_sign_on_next_line = true
+ij_java_block_brace_style = end_of_line
+ij_java_catch_on_new_line = true
+ij_java_class_brace_style = end_of_line
+ij_java_class_count_to_use_import_on_demand = 999
+ij_java_do_while_brace_force = always
+ij_java_else_on_new_line = true
+ij_java_finally_on_new_line = true
+ij_java_for_brace_force = always
+ij_java_if_brace_force = always
+ij_java_imports_layout = $*, |, java.**, |, javax.**, |, org.**, |, com.**, |, *
+ij_java_keep_blank_lines_before_right_brace = 1
+ij_java_keep_blank_lines_between_package_declaration_and_header = 1
+ij_java_keep_blank_lines_in_code = 1
+ij_java_keep_blank_lines_in_declarations = 1
+ij_java_lambda_brace_style = end_of_line
+ij_java_method_brace_style = end_of_line
+ij_java_names_count_to_use_import_on_demand = 999
+ij_java_space_before_array_initializer_left_brace = true
+ij_java_space_within_empty_array_initializer_braces = false
+ij_java_spaces_within_array_initializer_braces = false
+ij_java_while_brace_force = always
+ij_java_wrap_comments = true
+indent_size = 4
+max_line_length = 100
+
+[*.xml]
+ij_continuation_indent_size = 2
+indent_size = 2
+max_line_length = 160

--- a/config/.editorconfig
+++ b/config/.editorconfig
@@ -1,0 +1,4 @@
+root = true
+
+[**spotbugs-exclude.xml]
+max_line_length = 100

--- a/config/jsoref-spellchecker/whitelist.words
+++ b/config/jsoref-spellchecker/whitelist.words
@@ -356,6 +356,7 @@ Edad
 edb
 ededed
 edef
+editorconfig
 edu
 Eghj
 Ei
@@ -570,6 +571,7 @@ ietf
 Igno
 IGNORETHIS
 igorminar
+ij
 Ilja
 illegalcatch
 illegalex

--- a/pom.xml
+++ b/pom.xml
@@ -731,6 +731,49 @@
     </pluginManagement>
     <plugins>
       <plugin>
+        <groupId>org.ec4j.maven</groupId>
+        <artifactId>editorconfig-maven-plugin</artifactId>
+        <version>0.1.3</version>
+        <executions>
+          <execution>
+            <id>editorconfig-check</id>
+            <phase>verify</phase>
+            <goals>
+              <goal>check</goal>
+            </goals>
+          </execution>
+        </executions>
+        <configuration>
+          <excludes>
+            <exclude>**/*.javadoc</exclude>
+            <exclude>**/*.jpeg</exclude>
+            <exclude>.ci-temp/**</exclude>
+            <exclude>.ci/**</exclude>
+            <exclude>.docs/**</exclude>
+            <exclude>.github/**</exclude>
+            <exclude>src/main/resources/com/puppycrawl/tools/checkstyle/meta/**/*.xml</exclude>
+            <exclude>src/main/resources/com/puppycrawl/tools/checkstyle/sarif/*.template</exclude>
+            <exclude>src/site/xdoc/*.xml</exclude>
+            <exclude>src/site/xdoc/checks/**/*.xml</exclude>
+            <exclude>src/site/xdoc/filefilters/**s/*.xml</exclude>
+            <exclude>src/site/xdoc/filefilters/beforeexecutionexclusionfilefilter.xml</exclude>
+            <exclude>src/site/xdoc/filters/**/*.xml</exclude>
+            <exclude>src/test/resources-noncompilable/**/*.java</exclude>
+            <exclude>src/test/resources/com/puppycrawl/tools/checkstyle/**/*.java</exclude>
+            <exclude>src/test/resources/com/puppycrawl/tools/checkstyle/**/*.xml</exclude>
+            <exclude>src/test/resources/com/puppycrawl/tools/checkstyle/asttreestringprinter/InputAstTreeStringPrinterFullOfBlockCommentsCR.java</exclude>
+            <exclude>src/test/resources/com/puppycrawl/tools/checkstyle/checks/newlineatendoffile/**/*</exclude>
+            <exclude>src/test/resources/com/puppycrawl/tools/checkstyle/checks/uniqueproperties/InputUniquePropertiesWithDuplicates.properties</exclude>
+            <exclude>src/test/resources/com/puppycrawl/tools/checkstyle/grammar/InputAstRegressionNewlineCrAtEndOfFile.java</exclude>
+            <exclude>src/test/resources/com/puppycrawl/tools/checkstyle/grammar/javadoc/**/*</exclude>
+            <exclude>src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/**/*.cpp</exclude>
+            <exclude>src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/**/*.txt</exclude>
+            <exclude>src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/newlineatendoffile/**/*</exclude>
+            <exclude>src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/filters/suppresswithplaintextcommentfilter/Example1.properties</exclude>
+          </excludes>
+        </configuration>
+      </plugin>
+      <plugin>
         <groupId>org.codehaus.plexus</groupId>
         <artifactId>plexus-component-metadata</artifactId>
         <version>2.2.0</version>

--- a/src/test/resources/.editorconfig
+++ b/src/test/resources/.editorconfig
@@ -1,0 +1,39 @@
+root = true
+
+[*]
+charset = unset
+end_of_line = unset
+indent_style = unset
+
+[*.java]
+ij_continuation_indent_size = unset
+ij_java_binary_operation_sign_on_next_line = unset
+ij_java_block_brace_style = unset
+ij_java_catch_on_new_line = unset
+ij_java_class_brace_style = unset
+ij_java_class_count_to_use_import_on_demand = unset
+ij_java_do_while_brace_force = unset
+ij_java_else_on_new_line = unset
+ij_java_finally_on_new_line = unset
+ij_java_for_brace_force = unset
+ij_java_if_brace_force = unset
+ij_java_imports_layout = unset
+ij_java_keep_blank_lines_before_right_brace = unset
+ij_java_keep_blank_lines_between_package_declaration_and_header = unset
+ij_java_keep_blank_lines_in_code = unset
+ij_java_keep_blank_lines_in_declarations = unset
+ij_java_lambda_brace_style = unset
+ij_java_method_brace_style = unset
+ij_java_names_count_to_use_import_on_demand = unset
+ij_java_space_before_array_initializer_left_brace = unset
+ij_java_space_within_empty_array_initializer_braces = unset
+ij_java_spaces_within_array_initializer_braces = unset
+ij_java_while_brace_force = unset
+ij_java_wrap_comments = unset
+indent_size = unset
+max_line_length = unset
+
+[*.xml]
+ij_continuation_indent_size = unset
+indent_size = unset
+max_line_length = unset

--- a/src/xdocs-examples/.editorconfig
+++ b/src/xdocs-examples/.editorconfig
@@ -1,0 +1,5 @@
+root = true
+
+[*.java]
+ij_continuation_indent_size = 2
+indent_size = 2


### PR DESCRIPTION
Issue #16543: implement IDE agnostic configuration with `editorconfig.org`

Integrate [EditorConfig](https://editorconfig.org/) to add a basic configuration for common editor functions.
This will adjust some basic settings to align with the existing enforced configuration.

**Related Issue:** 
+ Issue #16427: IntelliJ IDEA Code Style configuration that matches our checkstyle_check.xml settings

https://github.com/eclipse-tractusx/ssi-dim-wallet-stub/blob/main/.editorconfig

Now, these `save-actions` are ready to use without breaking the build:

![EditorConfig Save Actions](https://github.com/user-attachments/assets/0e23e4a7-081b-43b2-a8db-1483e500138d)

Misaligned configurations will be detected by the Checkstyle runner.