### PR TITLE
Issue #15456: Defined violation message for MethodName in InlineConfigParser.java

### DIFF
--- a/src/site/xdoc/checks/naming/methodname.xml
+++ b/src/site/xdoc/checks/naming/methodname.xml
@@ -94,8 +94,8 @@
 class Example1 {
   public void method1() {}
   protected void method2() {}
-  private void Method3() {} // violation
-  public void Method4() {} // violation
+  private void Method3() {} // violation 'Name 'Method3' must match pattern'
+  public void Method4() {} // violation 'Name 'Method4' must match pattern'
 }
 </code></pre></div>
         <p id="Example2-config">
@@ -115,7 +115,7 @@ class Example1 {
         <div class="wrapper"><pre class="prettyprint"><code class="language-java">
 class Example2 {
   public void method1() {}
-  public void Method2() {} // violation
+  public void Method2() {} // violation 'Name 'Method2' must match pattern'
 }
 </code></pre></div>
         <p id="Example3-config">
@@ -157,7 +157,8 @@ class Example3 {
         <div class="wrapper"><pre class="prettyprint"><code class="language-java">
 class Example4 {
   public Example4() {}
-  public void Example4() {} // violation
+  // violation below 'Name 'Example4' must not equal the enclosing class name.'
+  public void Example4() {}
 }
 </code></pre></div>
         <p id="Example5-config">
@@ -179,8 +180,8 @@ class Example4 {
 class Example5 {
   public void Method1() {}
   protected void Method2() {}
-  private void Method3() {} // violation
-  void Method4() {} // violation
+  private void Method3() {} // violation 'Name 'Method3' must match pattern'
+  void Method4() {} // violation 'Name 'Method4' must match pattern'
 }
 </code></pre></div>
       </subsection>

--- a/src/test/java/com/puppycrawl/tools/checkstyle/bdd/InlineConfigParser.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/bdd/InlineConfigParser.java
@@ -269,7 +269,6 @@ public final class InlineConfigParser {
             "com.puppycrawl.tools.checkstyle.checks.naming.IllegalIdentifierNameCheck",
             "com.puppycrawl.tools.checkstyle.checks.naming.LocalFinalVariableNameCheck",
             "com.puppycrawl.tools.checkstyle.checks.naming.LocalVariableNameCheck",
-            "com.puppycrawl.tools.checkstyle.checks.naming.MethodNameCheck",
             "com.puppycrawl.tools.checkstyle.checks.naming.MethodTypeParameterNameCheck",
             "com.puppycrawl.tools.checkstyle.checks.naming.PackageNameCheck",
             "com.puppycrawl.tools.checkstyle.checks.naming.ParameterNameCheck",

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/naming/MethodNameCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/naming/MethodNameCheckTest.java
@@ -83,22 +83,22 @@ public class MethodNameCheckTest
         final String pattern = "^[a-z][a-zA-Z0-9]*$";
 
         final String[] expected = {
-            "24:16: " + getCheckMessage(MSG_KEY, "InputMethodNameEqualClassName"),
-            "24:16: " + getCheckMessage(MSG_INVALID_PATTERN,
+            "27:16: " + getCheckMessage(MSG_KEY, "InputMethodNameEqualClassName"),
+            "27:16: " + getCheckMessage(MSG_INVALID_PATTERN,
                     "InputMethodNameEqualClassName", pattern),
-            "29:17: " + getCheckMessage(MSG_INVALID_PATTERN, "PRIVATEInputMethodNameEqualClassName",
+            "33:17: " + getCheckMessage(MSG_INVALID_PATTERN, "PRIVATEInputMethodNameEqualClassName",
                     pattern),
-            "35:20: " + getCheckMessage(MSG_KEY, "Inner"),
-            "35:20: " + getCheckMessage(MSG_INVALID_PATTERN, "Inner", pattern),
-            "40:20: " + getCheckMessage(MSG_INVALID_PATTERN,
+            "42:20: " + getCheckMessage(MSG_KEY, "Inner"),
+            "42:20: " + getCheckMessage(MSG_INVALID_PATTERN, "Inner", pattern),
+            "48:20: " + getCheckMessage(MSG_INVALID_PATTERN,
                     "InputMethodNameEqualClassName", pattern),
-            "49:24: " + getCheckMessage(MSG_KEY, "InputMethodNameEqualClassName"),
-            "49:24: " + getCheckMessage(MSG_INVALID_PATTERN,
+            "60:24: " + getCheckMessage(MSG_KEY, "InputMethodNameEqualClassName"),
+            "60:24: " + getCheckMessage(MSG_INVALID_PATTERN,
                     "InputMethodNameEqualClassName", pattern),
-            "59:9: " + getCheckMessage(MSG_KEY, "SweetInterface"),
-            "59:9: " + getCheckMessage(MSG_INVALID_PATTERN, "SweetInterface", pattern),
-            "65:17: " + getCheckMessage(MSG_KEY, "Outer"),
-            "65:17: " + getCheckMessage(MSG_INVALID_PATTERN, "Outer", pattern),
+            "73:9: " + getCheckMessage(MSG_KEY, "SweetInterface"),
+            "73:9: " + getCheckMessage(MSG_INVALID_PATTERN, "SweetInterface", pattern),
+            "82:17: " + getCheckMessage(MSG_KEY, "Outer"),
+            "82:17: " + getCheckMessage(MSG_INVALID_PATTERN, "Outer", pattern),
         };
 
         verifyWithInlineConfigParser(
@@ -110,17 +110,17 @@ public class MethodNameCheckTest
         final String pattern = "^[a-z][a-zA-Z0-9]*$";
 
         final String[] expected = {
-            "24:16: " + getCheckMessage(MSG_INVALID_PATTERN,
+            "25:16: " + getCheckMessage(MSG_INVALID_PATTERN,
                     "InputMethodNameEqualClassName2", pattern),
-            "29:17: " + getCheckMessage(MSG_INVALID_PATTERN, "PRIVATEInputMethodNameEqualClassName",
+            "31:17: " + getCheckMessage(MSG_INVALID_PATTERN, "PRIVATEInputMethodNameEqualClassName",
                     pattern),
-            "35:20: " + getCheckMessage(MSG_INVALID_PATTERN, "Inner", pattern),
-            "40:20: " + getCheckMessage(MSG_INVALID_PATTERN,
+            "38:20: " + getCheckMessage(MSG_INVALID_PATTERN, "Inner", pattern),
+            "44:20: " + getCheckMessage(MSG_INVALID_PATTERN,
                     "InputMethodNameEqualClassName2", pattern),
-            "49:24: " + getCheckMessage(MSG_INVALID_PATTERN,
+            "54:24: " + getCheckMessage(MSG_INVALID_PATTERN,
                     "InputMethodNameEqualClassName2", pattern),
-            "59:9: " + getCheckMessage(MSG_INVALID_PATTERN, "SweetInterface", pattern),
-            "65:17: " + getCheckMessage(MSG_INVALID_PATTERN, "Outer", pattern),
+            "64:9: " + getCheckMessage(MSG_INVALID_PATTERN, "SweetInterface", pattern),
+            "70:17: " + getCheckMessage(MSG_INVALID_PATTERN, "Outer", pattern),
         };
 
         verifyWithInlineConfigParser(
@@ -132,15 +132,15 @@ public class MethodNameCheckTest
         final String pattern = "^[a-z][a-zA-Z0-9]*$";
 
         final String[] expected = {
-            "24:16: " + getCheckMessage(MSG_INVALID_PATTERN,
+            "25:16: " + getCheckMessage(MSG_INVALID_PATTERN,
                     "InputMethodNameEqualClassName3", pattern),
-            "35:20: " + getCheckMessage(MSG_INVALID_PATTERN, "Inner", pattern),
-            "40:20: " + getCheckMessage(MSG_INVALID_PATTERN,
+            "36:20: " + getCheckMessage(MSG_INVALID_PATTERN, "Inner", pattern),
+            "42:20: " + getCheckMessage(MSG_INVALID_PATTERN,
                     "InputMethodNameEqualClassName3", pattern),
-            "49:24: " + getCheckMessage(MSG_INVALID_PATTERN,
+            "52:24: " + getCheckMessage(MSG_INVALID_PATTERN,
                     "InputMethodNameEqualClassName3", pattern),
-            "59:9: " + getCheckMessage(MSG_INVALID_PATTERN, "SweetInterface", pattern),
-            "65:17: " + getCheckMessage(MSG_INVALID_PATTERN, "Outer", pattern),
+            "62:9: " + getCheckMessage(MSG_INVALID_PATTERN, "SweetInterface", pattern),
+            "68:17: " + getCheckMessage(MSG_INVALID_PATTERN, "Outer", pattern),
         };
 
         verifyWithInlineConfigParser(

--- a/src/test/resources-noncompilable/com/puppycrawl/tools/checkstyle/checks/naming/methodname/InputMethodNameRecordInInterfaceBody.java
+++ b/src/test/resources-noncompilable/com/puppycrawl/tools/checkstyle/checks/naming/methodname/InputMethodNameRecordInInterfaceBody.java
@@ -21,7 +21,7 @@ public interface InputMethodNameRecordInInterfaceBody {
         String record() {
             return null;
         }
-        void VIOLATION() { // violation
+        void VIOLATION() { // violation 'Name 'VIOLATION' must match pattern'
 
         }
     }

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/naming/methodname/InputMethodNameEqualClassName.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/naming/methodname/InputMethodNameEqualClassName.java
@@ -20,24 +20,32 @@ package com.puppycrawl.tools.checkstyle.checks.naming.methodname;
  */
 public class InputMethodNameEqualClassName {
 
-        //illegal name
-    public int InputMethodNameEqualClassName() { // 2 violations
+    //illegal name
+    // 2 violations 3 lines below:
+    //        'Method Name 'InputMethodNameEqualClassName' must not equal the enclosing class name.'
+    //        'Name 'InputMethodNameEqualClassName' must match pattern.'
+    public int InputMethodNameEqualClassName() {
         return 0;
     }
 
     //illegal name
-    private int PRIVATEInputMethodNameEqualClassName() { // violation
+    // violation below 'Name 'PRIVATEInputMethodNameEqualClassName' must match pattern.'
+    private int PRIVATEInputMethodNameEqualClassName() {
         return 0;
     }
 
     class Inner {
-                //illegal name
-        public int Inner() { // 2 violations
+        //illegal name
+        // 2 violations 3 lines below:
+        //        'Method Name 'Inner' must not equal the enclosing class name.'
+        //        'Name 'Inner' must match pattern.'
+        public int Inner() {
                         return 0;
-                }
+        }
 
-                //OK name - name of the outter class's ctor
-        public int InputMethodNameEqualClassName() { // violation
+        //OK name - name of the outter class's ctor
+        // violation below 'Name 'InputMethodNameEqualClassName' must match pattern.'
+        public int InputMethodNameEqualClassName() {
                         return 0;
                 }
         }
@@ -45,8 +53,11 @@ public class InputMethodNameEqualClassName {
         public void anotherMethod() {
                 new InputMethodNameEqualClassName() {
 
-                        //illegal name
-            public int InputMethodNameEqualClassName() { // 2 violations
+        //illegal name
+        // 2 violations 3 lines below:
+        //  'Method Name 'InputMethodNameEqualClassName' must not equal the enclosing class name.'
+        //  'Name 'InputMethodNameEqualClassName' must match pattern.'
+            public int InputMethodNameEqualClassName() {
                                 return 1;
                         }
                 };
@@ -55,14 +66,20 @@ public class InputMethodNameEqualClassName {
 
 interface SweetInterface {
 
-        //illegal name
-    int SweetInterface(); // 2 violations
+    //illegal name
+    // 2 violations 3 lines below:
+    //       'Method Name 'SweetInterface' must not equal the enclosing class name.'
+    //       'Name 'SweetInterface' must match pattern.'
+    int SweetInterface();
 }
 
 class Outer {
 
-        //illegal name
-    public void Outer() { // 2 violations
+    //illegal name
+    // 2 violations 3 lines below:
+    //       'Method Name 'Outer' must not equal the enclosing class name.'
+    //       'Name 'Outer' must match pattern.'
+    public void Outer() {
 
-        }
+    }
 }

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/naming/methodname/InputMethodNameEqualClassName2.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/naming/methodname/InputMethodNameEqualClassName2.java
@@ -20,24 +20,28 @@ package com.puppycrawl.tools.checkstyle.checks.naming.methodname;
  */
 public class InputMethodNameEqualClassName2 {
 
-        //illegal name
-    public int InputMethodNameEqualClassName2() { // violation
+    //illegal name
+    // violation below 'Name 'InputMethodNameEqualClassName2' must match pattern.'
+    public int InputMethodNameEqualClassName2() {
         return 0;
     }
 
     //illegal name
-    private int PRIVATEInputMethodNameEqualClassName() { // violation
+    // violation below 'Name 'PRIVATEInputMethodNameEqualClassName' must match pattern.'
+    private int PRIVATEInputMethodNameEqualClassName() {
         return 0;
     }
 
     class Inner {
-                //illegal name
-        public int Inner() { // violation
+        //illegal name
+        // violation below 'Name 'Inner' must match pattern.'
+        public int Inner() {
                         return 0;
                 }
 
-                //OK name - name of the outter class's ctor
-        public int InputMethodNameEqualClassName2() { // violation
+        //OK name - name of the outter class's ctor
+        // violation below 'Name 'InputMethodNameEqualClassName2' must match pattern.'
+        public int InputMethodNameEqualClassName2() {
                         return 0;
                 }
         }
@@ -45,8 +49,9 @@ public class InputMethodNameEqualClassName2 {
         public void anotherMethod() {
                 new InputMethodNameEqualClassName() {
 
-                        //illegal name
-            public int InputMethodNameEqualClassName2() { // violation
+            //illegal name
+            // violation below 'Name 'InputMethodNameEqualClassName2' must match pattern.'
+            public int InputMethodNameEqualClassName2() {
                                 return 1;
                         }
                 };
@@ -56,13 +61,13 @@ public class InputMethodNameEqualClassName2 {
 interface SweetInterface2 {
 
         //illegal name
-    int SweetInterface(); // violation
+    int SweetInterface(); // violation 'Name 'SweetInterface' must match pattern'
 }
 
 class Outer2 {
 
         //illegal name
-    public void Outer() { // violation
+    public void Outer() { // violation 'Name 'Outer' must match pattern'
 
         }
 }

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/naming/methodname/InputMethodNameEqualClassName3.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/naming/methodname/InputMethodNameEqualClassName3.java
@@ -20,8 +20,9 @@ package com.puppycrawl.tools.checkstyle.checks.naming.methodname;
  */
 public class InputMethodNameEqualClassName3 {
 
-        //illegal name
-    public int InputMethodNameEqualClassName3() { // violation
+    //illegal name
+    // violation below 'Name 'InputMethodNameEqualClassName3' must match pattern'
+    public int InputMethodNameEqualClassName3() {
         return 0;
     }
 
@@ -32,12 +33,13 @@ public class InputMethodNameEqualClassName3 {
 
     class Inner {
                 //illegal name
-        public int Inner() { // violation
+        public int Inner() {  // violation 'Name 'Inner' must match pattern'
                         return 0;
                 }
 
                 //OK name - name of the outter class's ctor
-        public int InputMethodNameEqualClassName3() { // violation
+        // violation below 'Name 'InputMethodNameEqualClassName3' must match pattern'
+        public int InputMethodNameEqualClassName3() {
                         return 0;
                 }
         }
@@ -45,8 +47,9 @@ public class InputMethodNameEqualClassName3 {
         public void anotherMethod() {
                 new InputMethodNameEqualClassName() {
 
-                        //illegal name
-            public int InputMethodNameEqualClassName3() { // violation
+             //illegal name
+             // violation below 'Name 'InputMethodNameEqualClassName3' must match pattern'
+            public int InputMethodNameEqualClassName3() {
                                 return 1;
                         }
                 };
@@ -56,13 +59,13 @@ public class InputMethodNameEqualClassName3 {
 interface SweetInterface3 {
 
         //illegal name
-    int SweetInterface(); // violation
+    int SweetInterface(); // violation 'Name 'SweetInterface' must match pattern'
 }
 
 class Outer3 {
 
         //illegal name
-    public void Outer() { // violation
+    public void Outer() { // violation 'Name 'Outer' must match pattern'
 
         }
 }

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/naming/methodname/InputMethodNameOverriddenMethods.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/naming/methodname/InputMethodNameOverriddenMethods.java
@@ -26,10 +26,10 @@ public class InputMethodNameOverriddenMethods extends SomeClass
 }
 
 class SomeClass {
-    public void PUBLICfoo() {  // violation
+    public void PUBLICfoo() {  // violation 'Name 'PUBLICfoo' must match pattern'
 
     }
-    protected void PROTECTEDfoo() { // violation
+    protected void PROTECTEDfoo() { // violation 'Name 'PROTECTEDfoo' must match pattern'
 
     }
 }

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/naming/methodname/InputMethodNamePrivateMethodsInInterfaces.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/naming/methodname/InputMethodNamePrivateMethodsInInterfaces.java
@@ -19,14 +19,14 @@ public interface InputMethodNamePrivateMethodsInInterfaces {
 
     private static void PrivateMethod2() {}
 
-    default void DefaultMethod() { // violation
+    default void DefaultMethod() { // violation 'Name 'DefaultMethod' must match pattern'
     }
 
-    public default void DefaultMethod2() { // violation
+    public default void DefaultMethod2() { // violation 'Name 'DefaultMethod2' must match pattern'
     }
 
-    void PublicMethod(); // violation
+    void PublicMethod(); // violation 'Name 'PublicMethod' must match pattern'
 
-    public void PublicMethod2(); // violation
+    public void PublicMethod2(); // violation 'Name 'PublicMethod2' must match pattern'
 
 }

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/naming/methodname/InputMethodNamePublicMethodsInInterfaces.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/naming/methodname/InputMethodNamePublicMethodsInInterfaces.java
@@ -15,9 +15,9 @@ package com.puppycrawl.tools.checkstyle.checks.naming.methodname;
 
 public interface InputMethodNamePublicMethodsInInterfaces {
 
-    private void PrivateMethod() {} // violation
+    private void PrivateMethod() {} // violation 'Name 'PrivateMethod' must match pattern'
 
-    private static void PrivateMethod2() {} // violation
+    private static void PrivateMethod2() {} // violation 'Name 'PrivateMethod2' must match pattern'
 
     default void DefaultMethod() {
     }

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/naming/methodname/InputMethodNameSimpleTwo.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/naming/methodname/InputMethodNameSimpleTwo.java
@@ -58,7 +58,7 @@ final class InputMethodNameSimpleTwo {
     }
 
     /** test method pattern */
-    void ALL_UPPERCASE_METHOD() // violation
+    void ALL_UPPERCASE_METHOD() // violation 'Name 'ALL_UPPERCASE_METHOD' must match pattern'
     {
     }
 

--- a/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/checks/naming/MethodNameCheckExamplesTest.java
+++ b/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/checks/naming/MethodNameCheckExamplesTest.java
@@ -63,7 +63,7 @@ public class MethodNameCheckExamplesTest extends AbstractExamplesModuleTestSuppo
     @Test
     public void testExample4() throws Exception {
         final String[] expected = {
-            "17:15: " + getCheckMessage(MSG_KEY, "Example4"),
+            "18:15: " + getCheckMessage(MSG_KEY, "Example4"),
         };
 
         verifyWithInlineConfigParser(getPath("Example4.java"), expected);

--- a/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/naming/methodname/Example1.java
+++ b/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/naming/methodname/Example1.java
@@ -12,7 +12,7 @@ package com.puppycrawl.tools.checkstyle.checks.naming.methodname;
 class Example1 {
   public void method1() {}
   protected void method2() {}
-  private void Method3() {} // violation
-  public void Method4() {} // violation
+  private void Method3() {} // violation 'Name 'Method3' must match pattern'
+  public void Method4() {} // violation 'Name 'Method4' must match pattern'
 }
 // xdoc section -- end

--- a/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/naming/methodname/Example2.java
+++ b/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/naming/methodname/Example2.java
@@ -13,6 +13,6 @@ package com.puppycrawl.tools.checkstyle.checks.naming.methodname;
 // xdoc section -- start
 class Example2 {
   public void method1() {}
-  public void Method2() {} // violation
+  public void Method2() {} // violation 'Name 'Method2' must match pattern'
 }
 // xdoc section -- end

--- a/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/naming/methodname/Example4.java
+++ b/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/naming/methodname/Example4.java
@@ -14,6 +14,7 @@ package com.puppycrawl.tools.checkstyle.checks.naming.methodname;
 // xdoc section -- start
 class Example4 {
   public Example4() {}
-  public void Example4() {} // violation
+  // violation below 'Name 'Example4' must not equal the enclosing class name.'
+  public void Example4() {}
 }
 // xdoc section -- end

--- a/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/naming/methodname/Example5.java
+++ b/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/naming/methodname/Example5.java
@@ -16,7 +16,7 @@ package com.puppycrawl.tools.checkstyle.checks.naming.methodname;
 class Example5 {
   public void Method1() {}
   protected void Method2() {}
-  private void Method3() {} // violation
-  void Method4() {} // violation
+  private void Method3() {} // violation 'Name 'Method3' must match pattern'
+  void Method4() {} // violation 'Name 'Method4' must match pattern'
 }
 // xdoc section -- end


### PR DESCRIPTION
### Improved violation messages for all input files of MethodName check

This PR addresses **issue** #15456

**Example preview of changes made:**
```
    // 2 violations 3 lines below:
    //        'Method Name 'InputMethodNameEqualClassName' must not equal the enclosing class name.'
    //        'Name 'InputMethodNameEqualClassName' must match pattern.'
    public int InputMethodNameEqualClassName() {
        return 0;
    }
```



