### PR TITLE
Issue 16361: Update SarifLoggerTest.java to use verifyWithInlineConfigParserAndLogger

### DIFF
--- a/config/checkstyle-non-main-files-checks.xml
+++ b/config/checkstyle-non-main-files-checks.xml
@@ -57,7 +57,7 @@
     <property name="id" value="lineLength"/>
     <!-- catch lines above 100 symbols -->
     <property name="format"
-             value="^(?!(.*value=.*|.*href=|.*http(s)?:|import |(.* )?package |.* files=|.*\.dtd| \* \{@code| \* com\.)).{101,}$"/>
+             value="^(?!(.*value=.*|.*href=|.*http(s)?:|import |(.* )?package |.* files=|.*file:|.*\.dtd| \* \{@code| \* com\.)).{101,}$"/>
     <property name="message" value="Line should not be longer than 100 symbols"/>
   </module>
 

--- a/src/test/java/com/puppycrawl/tools/checkstyle/AbstractModuleTestSupport.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/AbstractModuleTestSupport.java
@@ -28,6 +28,7 @@ import java.io.IOException;
 import java.io.InputStreamReader;
 import java.io.LineNumberReader;
 import java.nio.charset.StandardCharsets;
+import java.nio.file.Path;
 import java.text.MessageFormat;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -42,6 +43,7 @@ import java.util.stream.Collectors;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Maps;
 import com.puppycrawl.tools.checkstyle.LocalizedMessage.Utf8Control;
+import com.puppycrawl.tools.checkstyle.api.AuditListener;
 import com.puppycrawl.tools.checkstyle.api.Configuration;
 import com.puppycrawl.tools.checkstyle.bdd.InlineConfigParser;
 import com.puppycrawl.tools.checkstyle.bdd.TestInputConfiguration;
@@ -368,6 +370,37 @@ public abstract class AbstractModuleTestSupport extends AbstractPathTestSupport 
     }
 
     /**
+     * Verifies logger output using the inline configuration parser.
+     * Expects an input file with configuration and violations, and a report file with expected
+     * output.
+     *
+     * @param inputFile path to the file with configuration and violations
+     * @param expectedReportFile path to the expected logger report file
+     * @param logger logger to test
+     * @param outputStream output stream where the logger writes its actual output
+     * @throws Exception if an exception occurs during verification
+     */
+    protected void verifyWithInlineConfigParserAndLogger(String inputFile,
+                                                         String expectedReportFile,
+                                                         AuditListener logger,
+                                                         ByteArrayOutputStream outputStream)
+            throws Exception {
+        final TestInputConfiguration testInputConfiguration =
+                InlineConfigParser.parse(inputFile);
+        final DefaultConfiguration parsedConfig =
+                testInputConfiguration.createConfiguration();
+        final List<File> filesToCheck = Collections.singletonList(new File(inputFile));
+        final String basePath = Path.of("").toAbsolutePath().toString();
+
+        final Checker checker = createChecker(parsedConfig);
+        checker.setBasedir(basePath);
+        checker.addListener(logger);
+        checker.process(filesToCheck);
+
+        verifyContent(expectedReportFile, outputStream);
+    }
+
+    /**
      * Performs verification of the file with the given file name. Uses specified configuration.
      * Expected messages are represented by the array of strings.
      * This implementation uses overloaded
@@ -584,6 +617,24 @@ public abstract class AbstractModuleTestSupport extends AbstractPathTestSupport 
                     .that(actualViolations.get(index))
                     .matches(testInputViolations.get(index).toRegex());
         }
+    }
+
+    /**
+     * Verifies that the logger's actual output matches the expected report file.
+     *
+     * @param expectedOutputFile path to the expected logger report file
+     * @param outputStream output stream containing the actual logger output
+     * @throws IOException if an exception occurs while reading the file
+     */
+    private static void verifyContent(
+            String expectedOutputFile,
+            ByteArrayOutputStream outputStream) throws IOException {
+        final String expectedContent = readFile(expectedOutputFile);
+        final String actualContent =
+                toLfLineEnding(outputStream.toString(StandardCharsets.UTF_8));
+        assertWithMessage("Content should match")
+                .that(actualContent)
+                .isEqualTo(expectedContent);
     }
 
     /**

--- a/src/test/java/com/puppycrawl/tools/checkstyle/SarifLoggerTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/SarifLoggerTest.java
@@ -100,16 +100,14 @@ public class SarifLoggerTest extends AbstractModuleTestSupport {
     }
 
     @Test
-    public void testAddError() throws IOException {
+    public void testSingleError() throws Exception {
+        final String inputFile = "InputSarifLoggerSingleError.java";
+        final String expectedReportFile = "ExpectedSarifLoggerSingleError.sarif";
         final SarifLogger logger = new SarifLogger(outStream,
                 OutputStreamOptions.CLOSE);
-        logger.auditStarted(null);
-        final Violation violation =
-                new Violation(1, 1,
-                        "messages.properties", "ruleId", null, SeverityLevel.ERROR, null,
-                        getClass(), "found an error");
-        executeLogger(this, logger, "Test.java", violation);
-        verifyContent(getPath("ExpectedSarifLoggerSingleError.sarif"), outStream);
+
+        verifyWithInlineConfigParserAndLogger(
+                getPath(inputFile), getPath(expectedReportFile), logger, outStream);
     }
 
     @Test

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/sariflogger/ExpectedSarifLoggerSingleError.sarif
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/sariflogger/ExpectedSarifLoggerSingleError.sarif
@@ -24,19 +24,19 @@
             {
               "physicalLocation": {
                 "artifactLocation": {
-                  "uri": "file:Test.java"
+                  "uri": "file:src/test/resources/com/puppycrawl/tools/checkstyle/sariflogger/InputSarifLoggerSingleError.java"
                 },
                 "region": {
-                  "startColumn": 1,
-                  "startLine": 1
+                  "startColumn": 8,
+                  "startLine": 11
                 }
               }
             }
           ],
           "message": {
-            "text": "found an error"
+            "text": "Unused import - java.util.List."
           },
-          "ruleId": "ruleId"
+          "ruleId": "import.unused"
         }
       ]
     }

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/sariflogger/InputSarifLoggerSingleError.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/sariflogger/InputSarifLoggerSingleError.java
@@ -1,0 +1,14 @@
+/*xml
+<module name="Checker">
+  <module name="TreeWalker">
+    <module name="com.puppycrawl.tools.checkstyle.checks.imports.UnusedImportsCheck"/>
+  </module>
+</module>
+*/
+
+package com.puppycrawl.tools.checkstyle.sariflogger;
+
+import java.util.List; // violation 'Unused import - java.util.List.'
+
+public class InputSarifLoggerSingleError {
+}


### PR DESCRIPTION
Issue #16361 

- created a method `verifyWithInlineConfigParserAndLogger`  in `AbstractModuleTestSupport` for loggers with one output stream. One test case in `SarifLoggerTest` is converted to the new approach as an example. 