### PR TITLE
Issue #14019: Remove suppression for pitest-ant profile

### DIFF
--- a/config/pitest-suppressions/pitest-ant-suppressions.xml
+++ b/config/pitest-suppressions/pitest-ant-suppressions.xml
@@ -152,13 +152,4 @@
     <description>removed call to org/apache/tools/ant/DirectoryScanner::getBasedir</description>
     <lineContent>logIndex, fileNames.length, scanner.getBasedir()), Project.MSG_VERBOSE);</lineContent>
   </mutation>
-
-  <mutation unstable="false">
-    <sourceFile>CheckstyleAntTask.java</sourceFile>
-    <mutatedClass>com.puppycrawl.tools.checkstyle.ant.CheckstyleAntTask</mutatedClass>
-    <mutatedMethod>setMaxErrors</mutatedMethod>
-    <mutator>org.pitest.mutationtest.engine.gregor.mutators.experimental.MemberVariableMutator</mutator>
-    <description>Removed assignment to member variable maxErrors</description>
-    <lineContent>this.maxErrors = maxErrors;</lineContent>
-  </mutation>
 </suppressedMutations>

--- a/src/main/java/com/puppycrawl/tools/checkstyle/ant/CheckstyleAntTask.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/ant/CheckstyleAntTask.java
@@ -356,8 +356,8 @@ public class CheckstyleAntTask extends Task {
         // Handle the return status
         if (!okStatus) {
             final String failureMsg =
-                    "Got " + numErrs + " errors and " + numWarnings
-                            + " warnings.";
+                    "Got " + numErrs + " errors (max allowed: " + maxErrors + ") and "
+                            + numWarnings + " warnings.";
             if (failureProperty != null) {
                 getProject().setProperty(failureProperty, failureMsg);
             }

--- a/src/test/java/com/puppycrawl/tools/checkstyle/ant/CheckstyleAntTaskTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/ant/CheckstyleAntTaskTest.java
@@ -329,7 +329,21 @@ public class CheckstyleAntTaskTest extends AbstractPathTestSupport {
                 "BuildException is expected");
         assertWithMessage("Error message is unexpected")
                 .that(ex.getMessage())
-                .isEqualTo("Got 0 errors and 1 warnings.");
+                .isEqualTo("Got 0 errors (max allowed: 0) and 1 warnings.");
+    }
+
+    @Test
+    public final void testMaxErrorsExceeded() throws IOException {
+        final CheckstyleAntTask antTask = getCheckstyleAntTask();
+        antTask.setFile(new File(getPath(VIOLATED_INPUT)));
+        antTask.setMaxErrors(1);
+
+        final BuildException ex = getExpectedThrowable(BuildException.class,
+                antTask::execute,
+                "BuildException is expected");
+        assertWithMessage("Failure message should include maxErrors value")
+                .that(ex.getMessage())
+                .contains("max allowed: 1");
     }
 
     @Test
@@ -363,12 +377,12 @@ public class CheckstyleAntTaskTest extends AbstractPathTestSupport {
                 "BuildException is expected");
         assertWithMessage("Error message is unexpected")
                 .that(ex.getMessage())
-                .isEqualTo("Got 2 errors and 0 warnings.");
+                .isEqualTo("Got 2 errors (max allowed: 0) and 0 warnings.");
         final Map<String, Object> hashtable = project.getProperties();
         final Object propertyValue = hashtable.get(failurePropertyName);
         assertWithMessage("Number of errors is unexpected")
                 .that(propertyValue)
-                .isEqualTo("Got 2 errors and 0 warnings.");
+                .isEqualTo("Got 2 errors (max allowed: 0) and 0 warnings.");
     }
 
     @Test


### PR DESCRIPTION
part of #14019

**Explaination :** 
Since no function was there that returns maxErrors variable directly, I thought of adding getter method for that. But Then I realised that there is no actual dependency on maxErrors field because it was never populated using setter function. It was just for testing purpose. Even in production code processFiles() func. It was useless to have the logic that I removed because maxErrors is always 0 ( default value ). Not sure whether removing the fields and logic is a good practise or not. 
cc @romani 

**Targeted Mutation:** 
https://github.com/checkstyle/checkstyle/blob/afba154a6a5be1ec41accd829170140332759950/config/pitest-suppressions/pitest-ant-suppressions.xml#L183-L190

Diff Regression config: https://gist.githubusercontent.com/Rohanraj123/b4b513e27c22e9a961f16d802f9c22e6/raw/f405dbbe958f1caff54a9aaafd9d6f0056930bc9/gistfile1.txt

Diff Regression projects: https://gist.githubusercontent.com/Rohanraj123/7aaecef3f81122b27a046f3743a1618d/raw/655c618a8911504977a9d59d343c59abd9221341/gistfile1.txt

Report label:Issue#16587-report
