### PR TITLE
Issue #14019: kill mutation of encode(event.getMessage()) in XMLLogger

### DIFF
--- a/config/pitest-suppressions/pitest-common-suppressions.xml
+++ b/config/pitest-suppressions/pitest-common-suppressions.xml
@@ -8,13 +8,4 @@
     <description>Removed assignment to member variable args</description>
     <lineContent>this.args = null;</lineContent>
   </mutation>
-
-  <mutation unstable="false">
-    <sourceFile>XMLLogger.java</sourceFile>
-    <mutatedClass>com.puppycrawl.tools.checkstyle.XMLLogger</mutatedClass>
-    <mutatedMethod>writeFileError</mutatedMethod>
-    <mutator>org.pitest.mutationtest.engine.gregor.mutators.experimental.ArgumentPropagationMutator</mutator>
-    <description>replaced call to com/puppycrawl/tools/checkstyle/XMLLogger::encode with argument</description>
-    <lineContent>+ encode(event.getMessage())</lineContent>
-  </mutation>
 </suppressedMutations>

--- a/src/test/java/com/puppycrawl/tools/checkstyle/XMLLoggerTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/XMLLoggerTest.java
@@ -224,6 +224,13 @@ public class XMLLoggerTest extends AbstractXmlTestSupport {
     }
 
     @Test
+    public void testAddErrorWithEncodedMessage() throws Exception {
+        final String inputFileWithConfig = "InputXMLLoggerEncodedMessage.java";
+        final String expectedXmlReport = "ExpectedXMLLoggerEncodedMessage.xml";
+        verifyWithInlineConfigParserAndXmlLogger(inputFileWithConfig, expectedXmlReport);
+    }
+
+    @Test
     public void testAddErrorOnZeroColumns() throws Exception {
         final XMLLogger logger = new XMLLogger(outStream, OutputStreamOptions.CLOSE);
         logger.auditStarted(null);

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/xmllogger/ExpectedXMLLoggerEncodedMessage.xml
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/xmllogger/ExpectedXMLLoggerEncodedMessage.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<checkstyle version="">
+<file name="InputXMLLoggerEncodedMessage.java">
+<error line="15" column="17" severity="error" message="Test XML encoding: &lt;tag&gt; &amp; &quot;quotes&quot; &amp; apos; Existing entities: &amp; &lt;" source="com.puppycrawl.tools.checkstyle.checks.naming.MemberNameCheck"/>
+</file>
+</checkstyle>

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/xmllogger/InputXMLLoggerEncodedMessage.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/xmllogger/InputXMLLoggerEncodedMessage.java
@@ -1,0 +1,16 @@
+/*xml
+<module name="Checker">
+  <module name="TreeWalker">
+    <module name="com.puppycrawl.tools.checkstyle.checks.naming.MemberNameCheck">
+      <property name="format" value="^[a-z][a-zA-Z0-9]*$"/>
+      <message key="name.invalidPattern"
+               value="Test XML encoding: &lt;tag&gt; &amp; &quot;quotes&quot; &amp; 'apos'; Existing entities: &amp; &lt;"/>
+    </module>
+  </module>
+</module>
+*/
+package com.puppycrawl.tools.checkstyle.xmllogger;
+
+public class InputXMLLoggerEncodedMessage {
+    private int XML_Chars;
+}


### PR DESCRIPTION
Issue #14019: Kill mutation for XMLLogger ArgumentPropagationMutator on + encode(event.getMessage())

Reason for Mutation: In the writeFileError method of XMLLogger.java, we normally encode the error message to escape special XML characters (like <, >, and &). However, the mutation replaces the call to encode(event.getMessage()) with event.getMessage(), so special characters aren’t escaped. As a result, the XML output may be malformed, yet all test cases pass.

Kill mutation: Simulate the mutation by directly using event.getMessage() in place of encode(event.getMessage()). This change exposes the missing encoding of special characters, causing tests that expect correctly escaped XML to fail

@romani waiting for your review