### PR TITLE
Issue #14019: Remove suppression for pitest-ant profile : retrieveAll…

### DIFF
--- a/config/pitest-suppressions/pitest-ant-suppressions.xml
+++ b/config/pitest-suppressions/pitest-ant-suppressions.xml
@@ -174,15 +174,6 @@
   <mutation unstable="false">
     <sourceFile>CheckstyleAntTask.java</sourceFile>
     <mutatedClass>com.puppycrawl.tools.checkstyle.ant.CheckstyleAntTask</mutatedClass>
-    <mutatedMethod>retrieveAllScannedFiles</mutatedMethod>
-    <mutator>org.pitest.mutationtest.engine.gregor.mutators.NonVoidMethodCallMutator</mutator>
-    <description>removed call to org/apache/tools/ant/DirectoryScanner::getBasedir</description>
-    <lineContent>logIndex, fileNames.length, scanner.getBasedir()), Project.MSG_VERBOSE);</lineContent>
-  </mutation>
-
-  <mutation unstable="false">
-    <sourceFile>CheckstyleAntTask.java</sourceFile>
-    <mutatedClass>com.puppycrawl.tools.checkstyle.ant.CheckstyleAntTask</mutatedClass>
     <mutatedMethod>setMaxErrors</mutatedMethod>
     <mutator>org.pitest.mutationtest.engine.gregor.mutators.experimental.MemberVariableMutator</mutator>
     <description>Removed assignment to member variable maxErrors</description>

--- a/src/main/java/com/puppycrawl/tools/checkstyle/ant/CheckstyleAntTask.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/ant/CheckstyleAntTask.java
@@ -35,6 +35,7 @@ import java.util.stream.Collectors;
 
 import org.apache.tools.ant.BuildException;
 import org.apache.tools.ant.DirectoryScanner;
+import org.apache.tools.ant.FileScanner;
 import org.apache.tools.ant.Project;
 import org.apache.tools.ant.Task;
 import org.apache.tools.ant.taskdefs.LogOutputStream;
@@ -579,13 +580,14 @@ public class CheckstyleAntTask extends Task {
      * @param logIndex A log entry index. Used only for log messages.
      * @return A list of files, retrieved from the given scanner.
      */
-    private List<File> retrieveAllScannedFiles(DirectoryScanner scanner, int logIndex) {
+    private List<File> retrieveAllScannedFiles(FileScanner scanner, int logIndex) {
+        final File baseDir = scanner.getBasedir();
         final String[] fileNames = scanner.getIncludedFiles();
         log(String.format(Locale.ROOT, "%d) Adding %d files from directory %s",
-            logIndex, fileNames.length, scanner.getBasedir()), Project.MSG_VERBOSE);
+            logIndex, fileNames.length, baseDir), Project.MSG_VERBOSE);
 
         return Arrays.stream(fileNames)
-            .map(name -> scanner.getBasedir() + File.separator + name)
+            .map(name -> baseDir + File.separator + name)
             .map(File::new)
             .collect(Collectors.toUnmodifiableList());
     }


### PR DESCRIPTION
part of #14019 

**Explaination:**
Usage of `scanner.getDir()` is being done twice dynamically but only second usage has been covered by tests. And since both the function calls returns the same value then we can store it once and reuse it everytime we need that will ensure the testing of variable in the second time by test that was testing the s`canner.baseDir()` call the second time. 
This function has not very much of dependencies of other modules hence I dont think it affect other places in the code. 

**Target mutation :**
https://github.com/checkstyle/checkstyle/blob/aac3e77caa63afd4a9c0340688bf486705bbac5f/config/pitest-suppressions/pitest-ant-suppressions.xml#L174-L181