### PR TITLE
Issue #11163: Enforced file size on MethodName check inputs

### DIFF
--- a/config/checkstyle-resources-suppressions.xml
+++ b/config/checkstyle-resources-suppressions.xml
@@ -321,8 +321,6 @@
   <suppress checks="FileLength"
     files="[\\/]test[\\/]resources[\\/]com[\\/]puppycrawl[\\/]tools[\\/]checkstyle[\\/]checks[\\/]indentation[\\/]indentation[\\/]InputIndentationInvalidIfIndent\.java"/>
   <suppress checks="FileLength"
-    files="[\\/]test[\\/]resources[\\/]com[\\/]puppycrawl[\\/]tools[\\/]checkstyle[\\/]checks[\\/]sizes[\\/]methodlength[\\/]InputMethodLengthCountEmptyIsFalse\.java"/>
-  <suppress checks="FileLength"
     files="[\\/]test[\\/]resources[\\/]com[\\/]puppycrawl[\\/]tools[\\/]checkstyle[\\/]checks[\\/]sizes[\\/]methodcount[\\/]InputMethodCount\.java"/>
   <suppress checks="FileLength"
     files="[\\/]test[\\/]resources[\\/]com[\\/]puppycrawl[\\/]tools[\\/]checkstyle[\\/]checks[\\/]sizes[\\/]parameternumber[\\/]InputParameterNumberSimple\.java"/>

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/sizes/MethodLengthCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/sizes/MethodLengthCheckTest.java
@@ -84,6 +84,20 @@ public class MethodLengthCheckTest extends AbstractModuleTestSupport {
     }
 
     @Test
+    public void testCountEmptyIsFalseTwo() throws Exception {
+        final String[] expected = CommonUtil.EMPTY_STRING_ARRAY;
+        verifyWithInlineConfigParser(
+                getPath("InputMethodLengthCountEmptyIsFalseTwo.java"), expected);
+    }
+
+    @Test
+    public void testCountEmptyIsFalseThree() throws Exception {
+        final String[] expected = CommonUtil.EMPTY_STRING_ARRAY;
+        verifyWithInlineConfigParser(
+                getPath("InputMethodLengthCountEmptyIsFalseThree.java"), expected);
+    }
+
+    @Test
     public void testWithComments() throws Exception {
         final String[] expected = {
             "35:5: " + getCheckMessage(MSG_KEY, 8, 7, "visit"),

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/sizes/methodlength/InputMethodLengthCountEmptyIsFalse.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/sizes/methodlength/InputMethodLengthCountEmptyIsFalse.java
@@ -4,12 +4,10 @@ max = 19
 countEmpty = false
 tokens = (default)METHOD_DEF , CTOR_DEF , COMPACT_CTOR_DEF
 
-
 */
 
 package com.puppycrawl.tools.checkstyle.checks.sizes.methodlength;
 import java.io.*;
-
 final class InputMethodLengthCountEmptyIsFalse
 {
     // Long line ----------------------------------------------------------------
@@ -93,130 +91,6 @@ final class InputMethodLengthCountEmptyIsFalse
         // a line
         // a line
         // a line
+
     }
-
-    /** constructor that is 10 lines long **/
-    private InputMethodLengthCountEmptyIsFalse()
-    {
-        // a line
-        // a line
-        // a line
-        // a line
-        // a line
-        // a line
-        // a line
-        // a line
-    }
-
-    /** test local variables */
-    private void localVariables()
-    {
-        // normal decl
-        int abc = 0;
-        int ABC = 0;
-
-        // final decls
-        final int cde = 0;
-        final int CDE = 0;
-
-        // decl in for loop init statement
-        for (int k = 0; k < 1; k++)
-        {
-            String innerBlockVariable = "";
-        }
-        for (int I = 0; I < 1; I++)
-        {
-            String InnerBlockVariable = "";
-        }
-    }
-
-    /** test method pattern */
-    void ALL_UPPERCASE_METHOD()
-    {
-    }
-
-    /** test illegal constant **/
-    private static final int BAD__NAME = 3;
-
-    // A very, very long line that is OK because it matches the regexp "^.*is OK.*regexp.*$"
-    // long line that has a tab ->        <- and would be OK if tab counted as 1 char
-    // tabs that count as one char because of their position ->        <-   ->        <-, OK
-
-    /** some lines to test the violation column after tabs */
-    void errorColumnAfterTabs()
-    {
-        // with tab-width 8 all statements below start at the same column,
-        // with different combinations of ' ' and '\t' before the statement
-                int tab0 =1;
-                int tab1 =1;
-                 int tab2 =1;
-                int tab3 =1;
-                    int tab4 =1;
-                  int tab5 =1;
-    }
-
-    // MEMME:
-    /* MEMME: a
-     * MEMME:
-     * OOOO
-     */
-    /* NOTHING */
-    /* YES */ /* MEMME: x */ /* YES!! */
-
-    /** test long comments **/
-    void veryLong()
-    {
-        /*
-          blah blah blah blah
-          blah blah blah blah
-          blah blah blah blah
-          blah blah blah blah
-          blah blah blah blah
-          blah blah blah blah
-          blah blah blah blah
-          blah blah blah blah
-          blah blah blah blah
-          blah blah blah blah
-          blah blah blah blah
-          blah blah blah blah
-          blah blah blah blah
-          blah blah blah blah
-          blah blah blah blah
-          enough talk */
-    }
-
-    /**
-     * @see to lazy to document all args. Testing excessive # args
-     **/
-    void toManyArgs(int aArg1, int aArg2, int aArg3, int aArg4, int aArg5,
-                    int aArg6, int aArg7, int aArg8, int aArg9)
-    {
-    }
-}
-
-/** Test class for variable naming in for each clause. */
-class InputSimple3
-{
-    /** Some more Javadoc. */
-    public void doSomething()
-    {
-        //"O" should be named "o"
-        for (Object O : new java.util.ArrayList())
-        {
-
-        }
-    }
-}
-
-/** Test enum for member naming check */
-enum MyEnum2
-{
-    /** ABC constant */
-    ABC,
-
-    /** XYZ constant */
-    XYZ;
-
-    /** Should be mSomeMember */
-    private int someMember;
 }

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/sizes/methodlength/InputMethodLengthCountEmptyIsFalseThree.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/sizes/methodlength/InputMethodLengthCountEmptyIsFalseThree.java
@@ -1,0 +1,41 @@
+/*
+MethodLength
+max = 19
+countEmpty = false
+tokens = (default)METHOD_DEF , CTOR_DEF , COMPACT_CTOR_DEF
+
+*/
+
+package com.puppycrawl.tools.checkstyle.checks.sizes.methodlength;
+import java.io.*;
+final class InputMethodLengthCountEmptyIsFalseThree {
+
+}
+
+    /** Test class for variable naming in for each clause. */
+class InputSimple3
+{
+    /** Some more Javadoc. */
+    public void doSomething()
+    {
+        //"O" should be named "o"
+        for (Object O : new java.util.ArrayList())
+        {
+
+        }
+    }
+}
+
+/** Test enum for member naming check */
+enum MyEnum2
+{
+    /** ABC constant */
+    ABC,
+
+    /** XYZ constant */
+    XYZ;
+
+    /** Should be mSomeMember */
+    private int someMember;
+}
+

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/sizes/methodlength/InputMethodLengthCountEmptyIsFalseTwo.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/sizes/methodlength/InputMethodLengthCountEmptyIsFalseTwo.java
@@ -1,0 +1,111 @@
+/*
+MethodLength
+max = 19
+countEmpty = false
+tokens = (default)METHOD_DEF , CTOR_DEF , COMPACT_CTOR_DEF
+
+*/
+
+package com.puppycrawl.tools.checkstyle.checks.sizes.methodlength;
+import java.io.*;
+final class InputMethodLengthCountEmptyIsFalseTwo
+{
+    /** constructor that is 10 lines long **/
+    private InputMethodLengthCountEmptyIsFalseTwo()
+    {
+        // a line
+        // a line
+        // a line
+        // a line
+        // a line
+        // a line
+        // a line
+        // a line
+    }
+
+    /** test local variables */
+    private void localVariables()
+    {
+        // normal decl
+        int abc = 0;
+        int ABC = 0;
+
+        // final decls
+        final int cde = 0;
+        final int CDE = 0;
+
+        // decl in for loop init statement
+        for (int k = 0; k < 1; k++)
+        {
+            String innerBlockVariable = "";
+        }
+        for (int I = 0; I < 1; I++)
+        {
+            String InnerBlockVariable = "";
+        }
+    }
+
+    /** test method pattern */
+    void ALL_UPPERCASE_METHOD()
+    {
+    }
+
+    /** test illegal constant **/
+    private static final int BAD__NAME = 3;
+
+    // A very, very long line that is OK because it matches the regexp "^.*is OK.*regexp.*$"
+    // long line that has a tab ->        <- and would be OK if tab counted as 1 char
+    // tabs that count as one char because of their position ->        <-   ->        <-, OK
+
+    /** some lines to test the violation column after tabs */
+    void errorColumnAfterTabs()
+    {
+        // with tab-width 8 all statements below start at the same column,
+        // with different combinations of ' ' and '\t' before the statement
+                int tab0 =1;
+                int tab1 =1;
+                 int tab2 =1;
+                int tab3 =1;
+                    int tab4 =1;
+                  int tab5 =1;
+    }
+
+    // MEMME:
+    /* MEMME: a
+     * MEMME:
+     * OOOO
+     */
+    /* NOTHING */
+    /* YES */ /* MEMME: x */ /* YES!! */
+
+    /** test long comments **/
+    void veryLong()
+    {
+        /*
+          blah blah blah blah
+          blah blah blah blah
+          blah blah blah blah
+          blah blah blah blah
+          blah blah blah blah
+          blah blah blah blah
+          blah blah blah blah
+          blah blah blah blah
+          blah blah blah blah
+          blah blah blah blah
+          blah blah blah blah
+          blah blah blah blah
+          blah blah blah blah
+          blah blah blah blah
+          blah blah blah blah
+          enough talk */
+    }
+
+    /**
+     * @see to lazy to document all args. Testing excessive # args
+     **/
+    void toManyArgs(int aArg1, int aArg2, int aArg3, int aArg4, int aArg5,
+                    int aArg6, int aArg7, int aArg8, int aArg9)
+    {
+    }
+
+}


### PR DESCRIPTION
this PR addresses issue #11163 

preview of changes made:
1.` MethodLength/InputMethodLengthCountEmptyIsFalse.java`  file was split into 3 files ensuring  _file length < 120_   for all inputs

2. test methods were introduced in `Sizes/InputMethodLengthCheckTest.java` to ensure the new files were thoroughly tested 

3. Removed suppressions for file length for `InputMethodLengthCountEmptyIsFalse.java`