### PR TITLE
Issue checkstyle#16543: implement IDE agnostic `editorconfig-maven-plugin`

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,25 @@
+[*]
+charset = utf-8
+end_of_line = lf
+ij_continuation_indent_size = 8
+indent_size = 4
+indent_style = space
+insert_final_newline = true
+max_line_length = 100
+
+[*.xml]
+indent_size = 2
+
+[pom.xml]
+max_line_length = 140
+
+[*.java]
+ij_java_class_count_to_use_import_on_demand = 999
+ij_java_else_on_new_line = true
+ij_java_imports_layout = $*, |, java.**, |, javax.**, |, org.**, |, net.**, |, com.**, |, *
+ij_java_names_count_to_use_import_on_demand = 999
+ij_java_space_before_array_initializer_left_brace = true
+
+[**xdocs-examples**.java]
+ij_continuation_indent_size = 2
+indent_size = 2

--- a/config/jsoref-spellchecker/whitelist.words
+++ b/config/jsoref-spellchecker/whitelist.words
@@ -357,6 +357,7 @@ Edad
 edb
 ededed
 edef
+editorconfig
 edu
 Eghj
 Ei
@@ -572,6 +573,7 @@ ietf
 Igno
 IGNORETHIS
 igorminar
+ij
 Ilja
 illegalcatch
 illegalex

--- a/pom.xml
+++ b/pom.xml
@@ -208,7 +208,7 @@
     <projectVersion>${project.version}</projectVersion>
     <antlr4.version>4.13.2</antlr4.version>
     <maven.site.plugin.version>3.21.0</maven.site.plugin.version>
-    <maven.spotbugs.plugin.version>4.9.2.0</maven.spotbugs.plugin.version>
+    <maven.spotbugs.plugin.version>4.9.3.0</maven.spotbugs.plugin.version>
     <maven.pmd.plugin.version>3.26.0</maven.pmd.plugin.version>
     <pmd.version>7.11.0</pmd.version>
     <maven.jacoco.plugin.version>0.8.12</maven.jacoco.plugin.version>
@@ -223,7 +223,7 @@
     <maven.compiler.plugin.version>3.14.0</maven.compiler.plugin.version>
     <java.version>11</java.version>
     <maven.compiler.release>${java.version}</maven.compiler.release>
-    <pitest.plugin.version>1.18.2</pitest.plugin.version>
+    <pitest.plugin.version>1.19.0</pitest.plugin.version>
     <pitest.plugin.timeout.factor>10</pitest.plugin.timeout.factor>
     <pitest.plugin.output.formats>HTML,XML</pitest.plugin.output.formats>
     <pitest.plugin.timeout.constant>50000</pitest.plugin.timeout.constant>
@@ -730,6 +730,45 @@
       </plugins>
     </pluginManagement>
     <plugins>
+      <plugin>
+        <groupId>org.ec4j.maven</groupId>
+        <artifactId>editorconfig-maven-plugin</artifactId>
+        <version>0.1.3</version>
+        <executions>
+          <execution>
+            <id>editorconfig</id>
+            <phase>verify</phase>
+            <goals>
+              <goal>check</goal>
+            </goals>
+          </execution>
+        </executions>
+        <configuration>
+          <excludes>
+            <exclude>**/*.javadoc</exclude>
+            <exclude>**/*.jpeg</exclude>
+            <exclude>.ci/**</exclude>
+            <exclude>.ci-temp/**</exclude>
+            <exclude>.docs/**</exclude>
+            <exclude>.github/**</exclude>
+            <exclude>src/main/resources/com/puppycrawl/tools/checkstyle/meta/**/*.xml</exclude>
+            <exclude>src/main/resources/com/puppycrawl/tools/checkstyle/sarif/*.template</exclude>
+            <exclude>src/site/xdoc/*.xml</exclude>
+            <exclude>src/site/xdoc/checks/**/*.xml</exclude>
+            <exclude>src/site/xdoc/filefilters/**/*.xml</exclude>
+            <exclude>src/site/xdoc/filters/**/*.xml</exclude>
+            <exclude>src/test/resources-noncompilable/**/*.java</exclude>
+            <exclude>src/test/resources/com/puppycrawl/tools/checkstyle/**/*.java</exclude>
+            <exclude>src/test/resources/com/puppycrawl/tools/checkstyle/**/*.xml</exclude>
+            <exclude>src/test/resources/com/puppycrawl/tools/checkstyle/checks/uniqueproperties/*.properties</exclude>
+            <exclude>src/test/resources/com/puppycrawl/tools/checkstyle/grammar/javadoc/**/*</exclude>
+            <exclude>src/xdocs-examples/resources/**/*.java</exclude>
+            <exclude>src/xdocs-examples/resources/**/*.properties</exclude>
+            <exclude>src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/**/*.cpp</exclude>
+            <exclude>src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/**/*.txt</exclude>
+          </excludes>
+        </configuration>
+      </plugin>
       <plugin>
         <groupId>org.codehaus.plexus</groupId>
         <artifactId>plexus-component-metadata</artifactId>


### PR DESCRIPTION
prerequisite: https://github.com/checkstyle/checkstyle/pull/16574

the plugin will ensure the config is applied, if not it has the ability `to fix them automagically`:

Simply run: `mvn editorconfig:format`

#### editorconfig-maven-plugin
```
[INFO] --- editorconfig:0.1.3:check (check) @ checkstyle ---
line 1:38 mismatched input '\n// violation above 'files with pattern ^TestExample\d+\.xml$ not allowed'\n' expecting {COMMENT, SEA_WS, '<', PI}
line 1:38 mismatched input '\n// violation above 'pattern mismatch'\n' expecting {COMMENT, SEA_WS, '<', PI}
line 1:38 mismatched input '\n// violation above 'By default file name without whitespace is allowed'\n' expecting {COMMENT, SEA_WS, '<', PI}
line 1:38 mismatched input '\n// violation above 'only filenames in camelcase is allowed'\n' expecting {COMMENT, SEA_WS, '<', PI}
line 1:0 extraneous input '/*xml\n' expecting {COMMENT, SEA_WS, '<', XMLDeclOpen, PI}
[ERROR] src/main/resources/com/puppycrawl/tools/checkstyle/sarif/ResultErrorOnly.template@6,10: Insert lf - violates insert_final_newline = true, reported by org.ec4j.linters.TextLinter
[ERROR] src/main/resources/com/puppycrawl/tools/checkstyle/sarif/ResultLineColumn.template@20,10: Insert lf - violates insert_final_newline = true, reported by org.ec4j.linters.TextLinter
[ERROR] src/main/resources/com/puppycrawl/tools/checkstyle/sarif/ResultLineOnly.template@19,10: Insert lf - violates insert_final_newline = true, reported by org.ec4j.linters.TextLinter
[ERROR] src/main/resources/com/puppycrawl/tools/checkstyle/sarif/ResultFileOnly.template@15,10: Insert lf - violates insert_final_newline = true, reported by org.ec4j.linters.TextLinter
[INFO] Checked 2857 files
[INFO] ------------------------------------------------------------------------
[INFO] BUILD FAILURE
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  14.603 s
[INFO] Finished at: 2025-03-18T07:27:41+01:00
[INFO] ------------------------------------------------------------------------
[ERROR] Failed to execute goal org.ec4j.maven:editorconfig-maven-plugin:0.1.3:check (check) on project checkstyle: 
[ERROR] 
[ERROR] There are .editorconfig violations. You may want to run
[ERROR] 
[ERROR]     mvn editorconfig:format
[ERROR] 
[ERROR] to fix them automagically.
[ERROR] 
[ERROR] 
[ERROR] -> [Help 1]
[ERROR] 
[ERROR] To see the full stack trace of the errors, re-run Maven with the -e switch.
[ERROR] Re-run Maven using the -X switch to enable full debug logging.
[ERROR] 
[ERROR] For more information about the errors and possible solutions, please read the following articles:
[ERROR] [Help 1] http://cwiki.apache.org/confluence/display/MAVEN/MojoFailureException
➜  checkstyle git:(add-editorconfig-editorconfig-maven-plugin) ✗ 
```


Misaligned configurations will be detected by the Checkstyle runner.

**Related Issue:** [checkstyle/checkstyle#16543](https://github.com/checkstyle/checkstyle/issues/16543)
