### PR TITLE
Issue #9745: Added JavadocMethod inline return tag support

### DIFF
--- a/src/main/resources/com/puppycrawl/tools/checkstyle/meta/checks/javadoc/JavadocMethodCheck.xml
+++ b/src/main/resources/com/puppycrawl/tools/checkstyle/meta/checks/javadoc/JavadocMethodCheck.xml
@@ -74,6 +74,9 @@
                <description>Specify the access modifiers where Javadoc comments are
  checked.</description>
             </property>
+            <property default-value="false" name="allowInlineReturn" type="boolean">
+               <description>Control whether to allow inline return tags.</description>
+            </property>
             <property default-value="false" name="allowMissingParamTags" type="boolean">
                <description>Control whether to ignore violations
  when a method has parameters but does not have matching {@code param} tags in the javadoc.</description>

--- a/src/site/xdoc/checks/javadoc/javadocmethod.xml
+++ b/src/site/xdoc/checks/javadoc/javadocmethod.xml
@@ -101,6 +101,13 @@ public int checkReturnTag(final int aTagIndex,
               <td>8.42</td>
             </tr>
             <tr>
+              <td>allowInlineReturn</td>
+              <td>Control whether to allow inline return tags.</td>
+              <td><a href="../../property_types.html#boolean">boolean</a></td>
+              <td><code>false</code></td>
+              <td>10.22.1</td>
+            </tr>
+            <tr>
               <td>allowMissingParamTags</td>
               <td>Control whether to ignore violations when a method has parameters but does not have matching <code>param</code> tags in the javadoc.</td>
               <td><a href="../../property_types.html#boolean">boolean</a></td>
@@ -481,6 +488,37 @@ public class Example7 {
       System.out.println(s);
     };
   }
+}
+</code></pre></div>
+
+        <p id="Example8-config">
+          To configure the check to allow inline <code>return</code> tags,
+          you can use following config.
+        </p>
+        <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
+&lt;module name="Checker"&gt;
+  &lt;module name="TreeWalker"&gt;
+    &lt;module name="JavadocMethod"&gt;
+        &lt;property name="allowInlineReturn" value="true"/&gt;
+    &lt;/module&gt;
+  &lt;/module&gt;
+&lt;/module&gt;
+</code></pre></div>
+        <p id="Example8-code"> Example:</p>
+        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+public class Example8 {
+
+  /**
+   * {@return the foo}
+   */
+  public int getFoo() { return 0; }
+
+  /**
+   * Returns the bar
+   * @return the bar
+   */
+  public int getBar() { return 0; }
+
 }
 </code></pre></div>
       </subsection>

--- a/src/site/xdoc/checks/javadoc/javadocmethod.xml.template
+++ b/src/site/xdoc/checks/javadoc/javadocmethod.xml.template
@@ -195,6 +195,22 @@ public int checkReturnTag(final int aTagIndex,
                  value="resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadocmethod/Example7.java"/>
           <param name="type" value="code"/>
         </macro>
+
+        <p id="Example8-config">
+          To configure the check to allow inline <code>return</code> tags,
+          you can use following config.
+        </p>
+        <macro name="example">
+          <param name="path"
+                 value="resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadocmethod/Example8.java"/>
+          <param name="type" value="config"/>
+        </macro>
+        <p id="Example8-code"> Example:</p>
+        <macro name="example">
+          <param name="path"
+                 value="resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadocmethod/Example8.java"/>
+          <param name="type" value="code"/>
+        </macro>
       </subsection>
       <subsection name="Example of Usage" id="Example_of_Usage">
         <ul>

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocMethodCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocMethodCheckTest.java
@@ -590,4 +590,25 @@ public class JavadocMethodCheckTest extends AbstractModuleTestSupport {
         verifyWithInlineConfigParser(
                 getPath("InputJavadocMethodAboveComments.java"), expected);
     }
+
+    @Test
+    public void testJavadocMethodAllowInlineReturn() throws Exception {
+        final String[] expected = {
+            "32: " + getCheckMessage(MSG_RETURN_EXPECTED),
+            "39: " + getCheckMessage(MSG_RETURN_EXPECTED),
+        };
+        verifyWithInlineConfigParser(
+                getPath("InputJavadocMethodAllowInlineReturn.java"), expected);
+    }
+
+    @Test
+    public void testJavadocMethodDoNotAllowInlineReturn() throws Exception {
+        final String[] expected = {
+            "21: " + getCheckMessage(MSG_RETURN_EXPECTED),
+            "33: " + getCheckMessage(MSG_RETURN_EXPECTED),
+            "40: " + getCheckMessage(MSG_RETURN_EXPECTED),
+        };
+        verifyWithInlineConfigParser(
+                getPath("InputJavadocMethodDoNotAllowInlineReturn.java"), expected);
+    }
 }

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadocmethod/InputJavadocMethodAllowInlineReturn.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadocmethod/InputJavadocMethodAllowInlineReturn.java
@@ -1,0 +1,41 @@
+/*
+JavadocMethod
+allowInlineReturn = true
+allowedAnnotations = (default)Override
+validateThrows = (default)false
+accessModifiers = (default)public, protected, package, private
+allowMissingParamTags = (default)false
+allowMissingReturnTag = (default)false
+tokens = (default)METHOD_DEF, CTOR_DEF, ANNOTATION_FIELD_DEF, COMPACT_CTOR_DEF
+
+
+*/
+
+package com.puppycrawl.tools.checkstyle.checks.javadoc.javadocmethod;
+
+public class InputJavadocMethodAllowInlineReturn {
+
+    /**
+     * {@return the foo}
+     */
+    public int getFoo() { return 0; }
+
+    /**
+     * Returns the bar
+     * @return the bar
+     */
+    public int getBar() { return 0; }
+
+    /**
+     * Returns the fiz
+     */
+    public int getFiz() { return 0; }
+    // violation above, '@return tag should be present and have description.'
+
+    /**
+     * Returns the baz
+     * @see "getFoo"
+     */
+    public int getBaz() { return 0; }
+    // violation above, '@return tag should be present and have description.'
+}

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadocmethod/InputJavadocMethodDoNotAllowInlineReturn.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadocmethod/InputJavadocMethodDoNotAllowInlineReturn.java
@@ -1,0 +1,42 @@
+/*
+JavadocMethod
+allowInlineReturn = (default)false
+allowedAnnotations = (default)Override
+validateThrows = (default)false
+accessModifiers = (default)public, protected, package, private
+allowMissingParamTags = (default)false
+allowMissingReturnTag = (default)false
+tokens = (default)METHOD_DEF, CTOR_DEF, ANNOTATION_FIELD_DEF, COMPACT_CTOR_DEF
+
+
+*/
+
+package com.puppycrawl.tools.checkstyle.checks.javadoc.javadocmethod;
+
+public class InputJavadocMethodDoNotAllowInlineReturn {
+
+    /**
+     * {@return the foo}
+     */
+    public int getFoo() { return 0; }
+    // violation above, '@return tag should be present and have description.'
+
+    /**
+     * Returns the bar
+     * @return the bar
+     */
+    public int getBar() { return 0; }
+
+    /**
+     * Returns the fiz
+     */
+    public int getFiz() { return 0; }
+    // violation above, '@return tag should be present and have description.'
+
+    /**
+     * Returns the baz
+     * @see "getFoo"
+     */
+    public int getBaz() { return 0; }
+    // violation above, '@return tag should be present and have description.'
+}

--- a/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadocmethod/Example8.java
+++ b/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadocmethod/Example8.java
@@ -1,0 +1,27 @@
+/*xml
+<module name="Checker">
+  <module name="TreeWalker">
+    <module name="JavadocMethod">
+        <property name="allowInlineReturn" value="true"/>
+    </module>
+  </module>
+</module>
+*/
+package com.puppycrawl.tools.checkstyle.checks.javadoc.javadocmethod;
+
+// xdoc section -- start
+public class Example8 {
+
+  /**
+   * {@return the foo}
+   */
+  public int getFoo() { return 0; }
+
+  /**
+   * Returns the bar
+   * @return the bar
+   */
+  public int getBar() { return 0; }
+
+}
+// xdoc section -- end


### PR DESCRIPTION
Aims to close #9745 
Added new `allowInlineReturn` property in JavadocMethodCheck to control whether to allow inline return tags in javadoc.
Default. value is `false` to not break compatibility
