### PR TITLE
Issue #16332: Updated SuppressionSingleFilterExamplesTest methods to use verifyFilterWithInlineConfigParser

### DIFF
--- a/src/site/xdoc/filters/suppressionsinglefilter.xml
+++ b/src/site/xdoc/filters/suppressionsinglefilter.xml
@@ -93,15 +93,9 @@
       </subsection>
       <subsection name="Examples" id="Examples">
         <p id="Example1-config">
-          The following suppressions directs
-          a <code>SuppressionSingleFilter</code> to
-          reject <code>JavadocStyleCheck</code> violations for
-          lines 82 and 108 to 122 of
-          file <code>AbstractComplexityCheck.java</code>,
-          and <code>MagicNumberCheck</code> violations for line
-          221 of file <code>JavadocStyleCheck.java</code>,
-          and <code>'Missing a Javadoc comment'</code> violations
-          for all lines and files:
+          To configure a filter to suppress violations of <code>JavadocStyle</code> and
+          <code>MagicNumber</code> checks in <code>Example1.java</code> for specific line ranges
+          using <code>SuppressionSingleFilter</code>:
         </p>
         <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
 &lt;module name="Checker"&gt;
@@ -110,12 +104,7 @@
     &lt;module name="MagicNumber"/&gt;
   &lt;/module&gt;
   &lt;module name="SuppressionSingleFilter"&gt;
-    &lt;property name="checks" value="JavadocStyle"/&gt;
-    &lt;property name="files" value="Example1.java"/&gt;
-    &lt;property name="lines" value="1,5-100"/&gt;
-  &lt;/module&gt;
-  &lt;module name="SuppressionSingleFilter"&gt;
-    &lt;property name="checks" value="MagicNumber"/&gt;
+    &lt;property name="checks" value="JavadocStyle|MagicNumber"/&gt;
     &lt;property name="files" value="Example1.java"/&gt;
     &lt;property name="lines" value="1,5-100"/&gt;
   &lt;/module&gt;
@@ -129,23 +118,24 @@
         <div class="wrapper"><pre class="prettyprint"><code class="language-java">
 public class Example1 {
   public void exampleMethod() {
-    int value = 100;
-    // filtered violation ''100' is a magic number'
+    int value = 100; // filtered violation ''100' is a magic number'
   }
 }
 </code></pre></div>
         <p id="Example2-config">
-          Suppress check by <a href="https://checkstyle.org/config.html#Id">module id</a>
-          when config have two instances on the same check:
+          To configure a filter to suppress violations of <code>JavadocMethod</code> and
+          <code>EqualsAvoidNull</code> checks in <code>Example2.java</code> using
+          <code>SuppressionSingleFilter</code>:
         </p>
         <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
 &lt;module name="Checker"&gt;
-  &lt;module name="EqualsAvoidNull"/&gt;
-  &lt;module name="JavadocMethod"/&gt;
+  &lt;module name="TreeWalker"&gt;
+    &lt;module name="JavadocMethod"/&gt;
+    &lt;module name="EqualsAvoidNull"/&gt;
+  &lt;/module&gt;
   &lt;module name="SuppressionSingleFilter"&gt;
-    &lt;property name="id" value="stringEqual"/&gt;
     &lt;property name="files" value="Example2.java"/&gt;
-    &lt;property name="checks" value="EqualsAvoidNull, JavadocMethod"/&gt;
+    &lt;property name="checks" value="JavadocMethod|EqualsAvoidNull"/&gt;
   &lt;/module&gt;
 &lt;/module&gt;
 </code></pre></div>
@@ -154,19 +144,25 @@ public class Example1 {
         <div class="wrapper"><pre class="prettyprint"><code class="language-java">
 public class Example2 {
 
-  public void checkStringEquality(String str1, String str2) {
-    // filtered violation ''.equals()' should be used for string comparison'
-    assert str1 == str2 ;
+  public void checkStringEquality(String s) {
+    // filtered violation below 'String literal expressions should be on the left'
+    s.equals("M");
   }
+  /**
+   * @param p1 The first number
+   */
+  // filtered violation below '@return tag should be present'
+  private int m2(int p1) { return p1; }
 }
 </code></pre></div>
         <p id="Example3-config">
-          Suppress all checks for hidden files and folders:
+          To configure a filter to suppress violations of <code>RegexpSinglelineCheck</code>
+          in <code>Example3.java</code> using <code>SuppressionSingleFilter</code>:
         </p>
         <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
 &lt;module name="Checker"&gt;
   &lt;module name="RegexpSingleline"&gt;
-    &lt;property name="format" value=".*example.*"/&gt;
+    &lt;property name="format" value="example"/&gt;
   &lt;/module&gt;
   &lt;module name="SuppressionSingleFilter"&gt;
     &lt;property name="files" value="Example3.java"/&gt;
@@ -180,26 +176,28 @@ public class Example2 {
 public class Example3 {
 
   public void printExample() {
-    // filtered violation 'Line matches the illegal pattern 'example''
     System.out.println(
-      "This is an example string."
+      "example" // filtered violation 'Line matches the illegal pattern 'example''
     );
   }
 
   public void noViolation() {
     System.out.println(
-      "This string does not contain 'example'."
+      "RegexpSingleline is case sensitive by default. 'Example' in not matching."
     );
   }
 
 }
 </code></pre></div>
         <p id="Example4-config">
-          Suppress all checks for Maven-generated code:
+          To configure a filter to suppress violations of <code>NoWhitespaceAfter</code>
+          in <code>Example4.java</code> using <code>SuppressionSingleFilter</code>:
         </p>
         <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
 &lt;module name="Checker"&gt;
-  &lt;module name="NoWhitespaceAfter"/&gt;
+  &lt;module name="TreeWalker"&gt;
+    &lt;module name="NoWhitespaceAfter"/&gt;
+  &lt;/module&gt;
   &lt;module name="SuppressionSingleFilter"&gt;
     &lt;property name="files" value="Example4.java"/&gt;
     &lt;property name="checks" value="NoWhitespaceAfter"/&gt;
@@ -211,18 +209,20 @@ public class Example3 {
         <div class="wrapper"><pre class="prettyprint"><code class="language-java">
 public class Example4 {
 
-  // filtered violation 'WhiteSpace after ',''
   public void exampleMethod(int a, int b) {
+    // filtered violation below ''.' is followed by whitespace'
+    Integer. parseInt("3");
   }
 
   public void exampleMethod2() {
-    int x = 5 ; // filtered violation 'WhiteSpace before ';''
+    int [] x; // filtered violation ''int' is followed by whitespace'
   }
 
 }
 </code></pre></div>
         <p id="Example5-config">
-          Suppress all checks for archives, classes and other binary files:
+          To configure a filter to suppress violations of <code>MethodName</code>
+          in <code>Example5.java</code> using <code>SuppressionSingleFilter</code>:
         </p>
         <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
 &lt;module name="Checker"&gt;
@@ -237,17 +237,17 @@ public class Example4 {
         </p>
         <div class="wrapper"><pre class="prettyprint"><code class="language-java">
 public class Example5 {
-  // filtered violation 'Name 'example_Method' must match pattern'
+  // filtered violation below 'Name 'example_Method' must match pattern'
   public void example_Method() {
   }
-
-  // filtered violation Name 'Another_Method' must match pattern
+  // filtered violation below 'Name 'Another_Method' must match pattern'
   public void Another_Method() {
   }
 }
 </code></pre></div>
         <p id="Example6-config">
-          Suppress all checks for image files:
+          To configure a filter to suppress violations of <code>ConstantName</code>
+          in <code>Example6.java</code> using <code>SuppressionSingleFilter</code>:
         </p>
         <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
 &lt;module name="Checker"&gt;
@@ -262,21 +262,23 @@ public class Example5 {
         </p>
         <div class="wrapper"><pre class="prettyprint"><code class="language-java">
 public class Example6 {
-
-  // filtered violation 'Name 'myConstant' must match pattern'
+  // filtered violation below 'Name 'myConstant' must match pattern'
   private static final int myConstant = 42;
 
 }
 </code></pre></div>
         <p id="Example7-config">
-          Suppress all checks for non-java files:
+          To configure a filter to suppress violations of <code>MemberName</code>
+          and <code>MethodName</code> in <code>Example7.java</code> using
+          <code>SuppressionSingleFilter</code>:
         </p>
         <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
 &lt;module name="Checker"&gt;
   &lt;module name="MemberName"/&gt;
+  &lt;module name="MethodName"/&gt;
   &lt;module name="SuppressionSingleFilter"&gt;
     &lt;property name="files" value="Example7.java"/&gt;
-    &lt;property name="checks" value="MemberName"/&gt;
+    &lt;property name="checks" value="MemberName|MethodName"/&gt;
   &lt;/module&gt;
 &lt;/module&gt;
 </code></pre></div>
@@ -284,20 +286,16 @@ public class Example6 {
         </p>
         <div class="wrapper"><pre class="prettyprint"><code class="language-java">
 public class Example7 {
-
-  // filtered violation 'Name 'MyVariable' must match pattern'
+  // filtered violation below 'Name 'MyVariable' must match pattern'
   private int MyVariable = 5;
-
-  // filtered violation 'Name 'PrintHello' must match pattern'
-  public void PrintHello() {
-  }
-
-  public void printHello() {
+  // filtered violation below 'Name 'MyMethod' must match pattern'
+  public void MyMethod() {
   }
 }
 </code></pre></div>
         <p id="Example8-config">
-          Suppress all checks in generated sources:
+          To configure a filter to suppress <code>ParameterNumber</code> violations
+          in <code>Example8.java</code> using <code>SuppressionSingleFilter</code>:
         </p>
         <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
 &lt;module name="Checker"&gt;
@@ -316,15 +314,15 @@ public class Example7 {
         </p>
         <div class="wrapper"><pre class="prettyprint"><code class="language-java">
 public class Example8 {
-  // filtered violation 'more than 5 parameters'
+  // filtered violation below 'More than 5 parameters (found 6)'
   public void exampleMethod(
-    int param1, int param2, int param3, int param4,
-    int param5
+    int param1, int param2, int param3, int param4, int param5, int param6
   ) {}
 }
 </code></pre></div>
         <p id="Example9-config">
-          Suppress FileLength check on integration tests in certain folder:
+          To configure a filter to suppress <code>FileLength</code> violations
+          in <code>Example9.java</code> using <code>SuppressionSingleFilter</code>:
         </p>
         <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
 &lt;module name="Checker"&gt;
@@ -342,12 +340,14 @@ public class Example8 {
         <p id="Example9-code">
         </p>
         <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+/* filtered violation on 1st line  'File length is 4 lines (max allowed is 1)' */
 public class Example9 {
-  //filtered violation 'File length is 19 lines (max allowed is 1)'
+
 }
 </code></pre></div>
         <p id="Example10-config">
-          Suppress naming violations on variable named 'log' in all files:
+          To configure a filter to suppress <code>MemberName</code> violations
+          in <code>Example10.java</code> using <code>SuppressionSingleFilter</code>:
         </p>
         <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
 &lt;module name="Checker"&gt;
@@ -364,8 +364,7 @@ public class Example9 {
         </p>
         <div class="wrapper"><pre class="prettyprint"><code class="language-java">
 public class Example10 {
-
-  // filtered violation 'Name 'log' must match pattern'
+  // filtered violation below 'Name 'log' must match pattern'
   private String log = "Some log message";
 
 }

--- a/src/site/xdoc/filters/suppressionsinglefilter.xml.template
+++ b/src/site/xdoc/filters/suppressionsinglefilter.xml.template
@@ -46,15 +46,9 @@
       </subsection>
       <subsection name="Examples" id="Examples">
         <p id="Example1-config">
-          The following suppressions directs
-          a <code>SuppressionSingleFilter</code> to
-          reject <code>JavadocStyleCheck</code> violations for
-          lines 82 and 108 to 122 of
-          file <code>AbstractComplexityCheck.java</code>,
-          and <code>MagicNumberCheck</code> violations for line
-          221 of file <code>JavadocStyleCheck.java</code>,
-          and <code>'Missing a Javadoc comment'</code> violations
-          for all lines and files:
+          To configure a filter to suppress violations of <code>JavadocStyle</code> and
+          <code>MagicNumber</code> checks in <code>Example1.java</code> for specific line ranges
+          using <code>SuppressionSingleFilter</code>:
         </p>
         <macro name="example">
           <param name="path"
@@ -69,8 +63,9 @@
           <param name="type" value="code"/>
         </macro>
         <p id="Example2-config">
-          Suppress check by <a href="https://checkstyle.org/config.html#Id">module id</a>
-          when config have two instances on the same check:
+          To configure a filter to suppress violations of <code>JavadocMethod</code> and
+          <code>EqualsAvoidNull</code> checks in <code>Example2.java</code> using
+          <code>SuppressionSingleFilter</code>:
         </p>
         <macro name="example">
           <param name="path"
@@ -85,7 +80,8 @@
           <param name="type" value="code"/>
         </macro>
         <p id="Example3-config">
-          Suppress all checks for hidden files and folders:
+          To configure a filter to suppress violations of <code>RegexpSinglelineCheck</code>
+          in <code>Example3.java</code> using <code>SuppressionSingleFilter</code>:
         </p>
         <macro name="example">
           <param name="path"
@@ -100,7 +96,8 @@
           <param name="type" value="code"/>
         </macro>
         <p id="Example4-config">
-          Suppress all checks for Maven-generated code:
+          To configure a filter to suppress violations of <code>NoWhitespaceAfter</code>
+          in <code>Example4.java</code> using <code>SuppressionSingleFilter</code>:
         </p>
         <macro name="example">
           <param name="path"
@@ -115,7 +112,8 @@
           <param name="type" value="code"/>
         </macro>
         <p id="Example5-config">
-          Suppress all checks for archives, classes and other binary files:
+          To configure a filter to suppress violations of <code>MethodName</code>
+          in <code>Example5.java</code> using <code>SuppressionSingleFilter</code>:
         </p>
         <macro name="example">
           <param name="path"
@@ -130,7 +128,8 @@
           <param name="type" value="code"/>
         </macro>
         <p id="Example6-config">
-          Suppress all checks for image files:
+          To configure a filter to suppress violations of <code>ConstantName</code>
+          in <code>Example6.java</code> using <code>SuppressionSingleFilter</code>:
         </p>
         <macro name="example">
           <param name="path"
@@ -145,7 +144,9 @@
           <param name="type" value="code"/>
         </macro>
         <p id="Example7-config">
-          Suppress all checks for non-java files:
+          To configure a filter to suppress violations of <code>MemberName</code>
+          and <code>MethodName</code> in <code>Example7.java</code> using
+          <code>SuppressionSingleFilter</code>:
         </p>
         <macro name="example">
           <param name="path"
@@ -160,7 +161,8 @@
           <param name="type" value="code"/>
         </macro>
         <p id="Example8-config">
-          Suppress all checks in generated sources:
+          To configure a filter to suppress <code>ParameterNumber</code> violations
+          in <code>Example8.java</code> using <code>SuppressionSingleFilter</code>:
         </p>
         <macro name="example">
           <param name="path"
@@ -175,7 +177,8 @@
           <param name="type" value="code"/>
         </macro>
         <p id="Example9-config">
-          Suppress FileLength check on integration tests in certain folder:
+          To configure a filter to suppress <code>FileLength</code> violations
+          in <code>Example9.java</code> using <code>SuppressionSingleFilter</code>:
         </p>
         <macro name="example">
           <param name="path"
@@ -190,7 +193,8 @@
           <param name="type" value="code"/>
         </macro>
         <p id="Example10-config">
-          Suppress naming violations on variable named 'log' in all files:
+          To configure a filter to suppress <code>MemberName</code> violations
+          in <code>Example10.java</code> using <code>SuppressionSingleFilter</code>:
         </p>
         <macro name="example">
           <param name="path"

--- a/src/test/java/com/puppycrawl/tools/checkstyle/bdd/InlineConfigParser.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/bdd/InlineConfigParser.java
@@ -130,6 +130,10 @@ public final class InlineConfigParser {
     private static final Pattern FILTERED_VIOLATION_BELOW_PATTERN = Pattern
             .compile(".*//\\s*filtered violation below\\s*(?:['\"](.*)['\"])?$");
 
+    /** A pattern to find the string: "// filtered violation X lines above". */
+    private static final Pattern FILTERED_VIOLATION_SOME_LINES_ABOVE_PATTERN = Pattern
+            .compile(".*//\\s*filtered violation (\\d+) lines above\\s*(?:['\"](.*)['\"])?$");
+
     /** A pattern to find the string: "// violation X lines above". */
     private static final Pattern VIOLATION_SOME_LINES_ABOVE_PATTERN = Pattern
             .compile(".*//\\s*violation (\\d+) lines above\\s*(?:['\"](.*)['\"])?$");
@@ -1099,6 +1103,8 @@ public final class InlineConfigParser {
                 FILTERED_VIOLATION_ABOVE_PATTERN.matcher(line);
         final Matcher violationBelowMatcher =
                 FILTERED_VIOLATION_BELOW_PATTERN.matcher(line);
+        final Matcher violationSomeLinesAboveMatcher =
+                FILTERED_VIOLATION_SOME_LINES_ABOVE_PATTERN.matcher(line);
         if (violationMatcher.matches()) {
             final String violationMessage = violationMatcher.group(1);
             checkWhetherViolationSpecified(specifyViolationMessage, violationMessage, lineNo);
@@ -1114,6 +1120,14 @@ public final class InlineConfigParser {
         else if (violationBelowMatcher.matches()) {
             final String violationMessage = violationBelowMatcher.group(1);
             final int violationLineNum = lineNo + 1;
+            checkWhetherViolationSpecified(specifyViolationMessage, violationMessage,
+                    violationLineNum);
+            inputConfigBuilder.addFilteredViolation(violationLineNum, violationMessage);
+        }
+        else if (violationSomeLinesAboveMatcher.matches()) {
+            final String violationMessage = violationSomeLinesAboveMatcher.group(2);
+            final int linesAbove = Integer.parseInt(violationSomeLinesAboveMatcher.group(1)) - 1;
+            final int violationLineNum = lineNo - linesAbove;
             checkWhetherViolationSpecified(specifyViolationMessage, violationMessage,
                     violationLineNum);
             inputConfigBuilder.addFilteredViolation(violationLineNum, violationMessage);

--- a/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/filters/SuppressionSingleFilterExamplesTest.java
+++ b/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/filters/SuppressionSingleFilterExamplesTest.java
@@ -19,9 +19,24 @@
 
 package com.puppycrawl.tools.checkstyle.filters;
 
+import static com.puppycrawl.tools.checkstyle.checks.coding.EqualsAvoidNullCheck.MSG_EQUALS_AVOID_NULL;
+import static com.puppycrawl.tools.checkstyle.checks.coding.MagicNumberCheck.MSG_KEY;
+import static com.puppycrawl.tools.checkstyle.checks.javadoc.JavadocMethodCheck.MSG_RETURN_EXPECTED;
+import static com.puppycrawl.tools.checkstyle.checks.regexp.RegexpCheck.MSG_ILLEGAL_REGEXP;
+
 import org.junit.jupiter.api.Test;
 
 import com.puppycrawl.tools.checkstyle.AbstractExamplesModuleTestSupport;
+import com.puppycrawl.tools.checkstyle.checks.coding.EqualsAvoidNullCheck;
+import com.puppycrawl.tools.checkstyle.checks.coding.MagicNumberCheck;
+import com.puppycrawl.tools.checkstyle.checks.javadoc.JavadocMethodCheck;
+import com.puppycrawl.tools.checkstyle.checks.naming.ConstantNameCheck;
+import com.puppycrawl.tools.checkstyle.checks.naming.MemberNameCheck;
+import com.puppycrawl.tools.checkstyle.checks.naming.MethodNameCheck;
+import com.puppycrawl.tools.checkstyle.checks.regexp.RegexpCheck;
+import com.puppycrawl.tools.checkstyle.checks.sizes.FileLengthCheck;
+import com.puppycrawl.tools.checkstyle.checks.sizes.ParameterNumberCheck;
+import com.puppycrawl.tools.checkstyle.checks.whitespace.NoWhitespaceAfterCheck;
 
 public class SuppressionSingleFilterExamplesTest extends AbstractExamplesModuleTestSupport {
     @Override
@@ -31,91 +46,126 @@ public class SuppressionSingleFilterExamplesTest extends AbstractExamplesModuleT
 
     @Test
     public void testExample1() throws Exception {
-        final String[] expected = {
-
+        final String[] expectedWithoutFilter = {
+            "21:17: " + getCheckMessage(MagicNumberCheck.class, MSG_KEY, "100"),
         };
+        final String[] expectedWithFilter = {};
 
-        verifyWithInlineConfigParser(getPath("Example1.java"), expected);
+        verifyFilterWithInlineConfigParser(getPath("Example1.java"),
+                expectedWithoutFilter, expectedWithFilter);
     }
 
     @Test
     public void testExample2() throws Exception {
-        final String[] expected = {
-
+        final String[] expectedWithoutFilter = {
+            "19:13: " + getCheckMessage(EqualsAvoidNullCheck.class, MSG_EQUALS_AVOID_NULL),
+            "25: " + getCheckMessage(JavadocMethodCheck.class, MSG_RETURN_EXPECTED),
         };
+        final String[] expectedWithFilter = {};
 
-        verifyWithInlineConfigParser(getPath("Example2.java"), expected);
+        verifyFilterWithInlineConfigParser(getPath("Example2.java"),
+                expectedWithoutFilter, expectedWithFilter);
     }
 
     @Test
     public void testExample3() throws Exception {
-        final String[] expected = {
-
+        final String[] expectedWithoutFilter = {
+            "19: " + getCheckMessage(RegexpCheck.class, MSG_ILLEGAL_REGEXP, "example"),
+            "4: " + getCheckMessage(RegexpCheck.class, MSG_ILLEGAL_REGEXP, "example"),
         };
+        final String[] expectedWithFilter = {};
 
-        verifyWithInlineConfigParser(getPath("Example3.java"), expected);
+        verifyFilterWithInlineConfigParser(getPath("Example3.java"),
+                expectedWithoutFilter, expectedWithFilter);
     }
 
     @Test
     public void testExample4() throws Exception {
-        final String[] expected = {
-
+        final String[] expectedWithoutFilter = {
+            "18:12: " + getCheckMessage(NoWhitespaceAfterCheck.class,
+                    NoWhitespaceAfterCheck.MSG_KEY, "."),
+            "22:9: " + getCheckMessage(NoWhitespaceAfterCheck.class,
+                    NoWhitespaceAfterCheck.MSG_KEY, "int"),
         };
+        final String[] expectedWithFilter = {};
 
-        verifyWithInlineConfigParser(getPath("Example4.java"), expected);
+        verifyFilterWithInlineConfigParser(getPath("Example4.java"),
+                expectedWithoutFilter, expectedWithFilter);
     }
 
     @Test
     public void testExample5() throws Exception {
-        final String[] expected = {
-
+        final String[] expectedWithoutFilter = {
+            "14:15: " + getCheckMessage(MethodNameCheck.class, "name.invalidPattern",
+                    "example_Method", "^[a-z][a-zA-Z0-9]*$"),
+            "17:15: " + getCheckMessage(MethodNameCheck.class, "name.invalidPattern",
+                    "Another_Method", "^[a-z][a-zA-Z0-9]*$"),
         };
+        final String[] expectedWithFilter = {};
 
-        verifyWithInlineConfigParser(getPath("Example5.java"), expected);
+        verifyFilterWithInlineConfigParser(getPath("Example5.java"),
+                expectedWithoutFilter, expectedWithFilter);
     }
 
     @Test
     public void testExample6() throws Exception {
-        final String[] expected = {
-
+        final String[] expectedWithoutFilter = {
+            "14:28: " + getCheckMessage(ConstantNameCheck.class, "name.invalidPattern",
+                    "myConstant", "^[A-Z][A-Z0-9]*(_[A-Z0-9]+)*$"),
         };
+        final String[] expectedWithFilter = {};
 
-        verifyWithInlineConfigParser(getPath("Example6.java"), expected);
+        verifyFilterWithInlineConfigParser(getPath("Example6.java"),
+                expectedWithoutFilter, expectedWithFilter);
     }
 
     @Test
     public void testExample7() throws Exception {
-        final String[] expected = {
-
+        final String[] expectedWithoutFilter = {
+            "15:15: " + getCheckMessage(MemberNameCheck.class, "name.invalidPattern",
+                    "MyVariable", "^[a-z][a-zA-Z0-9]*$"),
+            "17:15: " + getCheckMessage(MethodNameCheck.class, "name.invalidPattern",
+                    "MyMethod", "^[a-z][a-zA-Z0-9]*$"),
         };
+        final String[] expectedWithFilter = {};
 
-        verifyWithInlineConfigParser(getPath("Example7.java"), expected);
+        verifyFilterWithInlineConfigParser(getPath("Example7.java"),
+                expectedWithoutFilter, expectedWithFilter);
     }
 
     @Test
     public void testExample8() throws Exception {
-        final String[] expected = {
-
+        final String[] expectedWithoutFilter = {
+            "18:15: " + getCheckMessage(ParameterNumberCheck.class,
+                    ParameterNumberCheck.MSG_KEY, 5, 6),
         };
+        final String[] expectedWithFilter = {};
 
-        verifyWithInlineConfigParser(getPath("Example8.java"), expected);
+        verifyFilterWithInlineConfigParser(getPath("Example8.java"),
+                expectedWithoutFilter, expectedWithFilter);
     }
 
     @Test
     public void testExample9() throws Exception {
-        final String[] expected = {
-
+        final String[] expectedWithoutFilter = {
+            "1: " + getCheckMessage(FileLengthCheck.class,
+                    FileLengthCheck.MSG_KEY, 21, 1),
         };
+        final String[] expectedWithFilter = {};
 
-        verifyWithInlineConfigParser(getPath("Example9.java"), expected);
+        verifyFilterWithInlineConfigParser(getPath("Example9.java"),
+                expectedWithoutFilter, expectedWithFilter);
     }
 
     @Test
     public void testExample10() throws Exception {
-        final String[] expected = {
-
+        final String[] expectedWithoutFilter = {
+            "16:18: " + getCheckMessage(MemberNameCheck.class, "name.invalidPattern",
+                    "log", "^[A-Z][a-zA-Z0-9]*$"),
         };
+        final String[] expectedWithFilter = {};
 
-        verifyWithInlineConfigParser(getPath("Example10.java"), expected);
+        verifyFilterWithInlineConfigParser(getPath("Example10.java"),
+                expectedWithoutFilter, expectedWithFilter);
     }
 }

--- a/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/filters/suppressionsinglefilter/Example1.java
+++ b/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/filters/suppressionsinglefilter/Example1.java
@@ -5,12 +5,7 @@
     <module name="MagicNumber"/>
   </module>
   <module name="SuppressionSingleFilter">
-    <property name="checks" value="JavadocStyle"/>
-    <property name="files" value="Example1.java"/>
-    <property name="lines" value="1,5-100"/>
-  </module>
-  <module name="SuppressionSingleFilter">
-    <property name="checks" value="MagicNumber"/>
+    <property name="checks" value="JavadocStyle|MagicNumber"/>
     <property name="files" value="Example1.java"/>
     <property name="lines" value="1,5-100"/>
   </module>
@@ -23,8 +18,7 @@ package com.puppycrawl.tools.checkstyle.filters.suppressionsinglefilter;
 // xdoc section -- start
 public class Example1 {
   public void exampleMethod() {
-    int value = 100;
-    // filtered violation ''100' is a magic number'
+    int value = 100; // filtered violation ''100' is a magic number'
   }
 }
 // xdoc section -- end

--- a/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/filters/suppressionsinglefilter/Example10.java
+++ b/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/filters/suppressionsinglefilter/Example10.java
@@ -12,8 +12,7 @@
 package com.puppycrawl.tools.checkstyle.filters.suppressionsinglefilter;
 // xdoc section -- start
 public class Example10 {
-
-  // filtered violation 'Name 'log' must match pattern'
+  // filtered violation below 'Name 'log' must match pattern'
   private String log = "Some log message";
 
 }

--- a/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/filters/suppressionsinglefilter/Example2.java
+++ b/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/filters/suppressionsinglefilter/Example2.java
@@ -1,11 +1,12 @@
 /*xml
 <module name="Checker">
-  <module name="EqualsAvoidNull"/>
-  <module name="JavadocMethod"/>
+  <module name="TreeWalker">
+    <module name="JavadocMethod"/>
+    <module name="EqualsAvoidNull"/>
+  </module>
   <module name="SuppressionSingleFilter">
-    <property name="id" value="stringEqual"/>
     <property name="files" value="Example2.java"/>
-    <property name="checks" value="EqualsAvoidNull, JavadocMethod"/>
+    <property name="checks" value="JavadocMethod|EqualsAvoidNull"/>
   </module>
 </module>
 */
@@ -13,9 +14,14 @@ package com.puppycrawl.tools.checkstyle.filters.suppressionsinglefilter;
 // xdoc section -- start
 public class Example2 {
 
-  public void checkStringEquality(String str1, String str2) {
-    // filtered violation ''.equals()' should be used for string comparison'
-    assert str1 == str2 ;
+  public void checkStringEquality(String s) {
+    // filtered violation below 'String literal expressions should be on the left'
+    s.equals("M");
   }
+  /**
+   * @param p1 The first number
+   */
+  // filtered violation below '@return tag should be present'
+  private int m2(int p1) { return p1; }
 }
 // xdoc section -- end

--- a/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/filters/suppressionsinglefilter/Example3.java
+++ b/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/filters/suppressionsinglefilter/Example3.java
@@ -1,7 +1,7 @@
 /*xml
 <module name="Checker">
   <module name="RegexpSingleline">
-    <property name="format" value=".*example.*"/>
+    <property name="format" value="example"/>
   </module>
   <module name="SuppressionSingleFilter">
     <property name="files" value="Example3.java"/>
@@ -10,19 +10,19 @@
 </module>
 */
 package com.puppycrawl.tools.checkstyle.filters.suppressionsinglefilter;
+// filtered violation 10 lines above 'Line matches the illegal pattern'
 // xdoc section -- start
 public class Example3 {
 
   public void printExample() {
-    // filtered violation 'Line matches the illegal pattern 'example''
     System.out.println(
-      "This is an example string."
+      "example" // filtered violation 'Line matches the illegal pattern 'example''
     );
   }
 
   public void noViolation() {
     System.out.println(
-      "This string does not contain 'example'."
+      "RegexpSingleline is case sensitive by default. 'Example' in not matching."
     );
   }
 

--- a/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/filters/suppressionsinglefilter/Example4.java
+++ b/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/filters/suppressionsinglefilter/Example4.java
@@ -1,6 +1,8 @@
 /*xml
 <module name="Checker">
-  <module name="NoWhitespaceAfter"/>
+  <module name="TreeWalker">
+    <module name="NoWhitespaceAfter"/>
+  </module>
   <module name="SuppressionSingleFilter">
     <property name="files" value="Example4.java"/>
     <property name="checks" value="NoWhitespaceAfter"/>
@@ -11,12 +13,13 @@ package com.puppycrawl.tools.checkstyle.filters.suppressionsinglefilter;
 // xdoc section -- start
 public class Example4 {
 
-  // filtered violation 'WhiteSpace after ',''
   public void exampleMethod(int a, int b) {
+    // filtered violation below ''.' is followed by whitespace'
+    Integer. parseInt("3");
   }
 
   public void exampleMethod2() {
-    int x = 5 ; // filtered violation 'WhiteSpace before ';''
+    int [] x; // filtered violation ''int' is followed by whitespace'
   }
 
 }

--- a/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/filters/suppressionsinglefilter/Example5.java
+++ b/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/filters/suppressionsinglefilter/Example5.java
@@ -10,11 +10,10 @@
 package com.puppycrawl.tools.checkstyle.filters.suppressionsinglefilter;
 // xdoc section -- start
 public class Example5 {
-  // filtered violation 'Name 'example_Method' must match pattern'
+  // filtered violation below 'Name 'example_Method' must match pattern'
   public void example_Method() {
   }
-
-  // filtered violation Name 'Another_Method' must match pattern
+  // filtered violation below 'Name 'Another_Method' must match pattern'
   public void Another_Method() {
   }
 }

--- a/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/filters/suppressionsinglefilter/Example6.java
+++ b/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/filters/suppressionsinglefilter/Example6.java
@@ -10,8 +10,7 @@
 package com.puppycrawl.tools.checkstyle.filters.suppressionsinglefilter;
 // xdoc section -- start
 public class Example6 {
-
-  // filtered violation 'Name 'myConstant' must match pattern'
+  // filtered violation below 'Name 'myConstant' must match pattern'
   private static final int myConstant = 42;
 
 }

--- a/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/filters/suppressionsinglefilter/Example7.java
+++ b/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/filters/suppressionsinglefilter/Example7.java
@@ -1,24 +1,20 @@
 /*xml
 <module name="Checker">
   <module name="MemberName"/>
+  <module name="MethodName"/>
   <module name="SuppressionSingleFilter">
     <property name="files" value="Example7.java"/>
-    <property name="checks" value="MemberName"/>
+    <property name="checks" value="MemberName|MethodName"/>
   </module>
 </module>
 */
 package com.puppycrawl.tools.checkstyle.filters.suppressionsinglefilter;
 // xdoc section -- start
 public class Example7 {
-
-  // filtered violation 'Name 'MyVariable' must match pattern'
+  // filtered violation below 'Name 'MyVariable' must match pattern'
   private int MyVariable = 5;
-
-  // filtered violation 'Name 'PrintHello' must match pattern'
-  public void PrintHello() {
-  }
-
-  public void printHello() {
+  // filtered violation below 'Name 'MyMethod' must match pattern'
+  public void MyMethod() {
   }
 }
 // xdoc section -- end

--- a/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/filters/suppressionsinglefilter/Example8.java
+++ b/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/filters/suppressionsinglefilter/Example8.java
@@ -14,10 +14,9 @@
 package com.puppycrawl.tools.checkstyle.filters.suppressionsinglefilter;
 // xdoc section -- start
 public class Example8 {
-  // filtered violation 'more than 5 parameters'
+  // filtered violation below 'More than 5 parameters (found 6)'
   public void exampleMethod(
-    int param1, int param2, int param3, int param4,
-    int param5
+    int param1, int param2, int param3, int param4, int param5, int param6
   ) {}
 }
 // xdoc section -- end

--- a/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/filters/suppressionsinglefilter/Example9.java
+++ b/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/filters/suppressionsinglefilter/Example9.java
@@ -12,8 +12,10 @@
 </module>
 */
 package com.puppycrawl.tools.checkstyle.filters.suppressionsinglefilter;
+// filtered violation 15 lines above 'File length is 21 lines (max allowed is 1)'
 // xdoc section -- start
+/* filtered violation on 1st line  'File length is 4 lines (max allowed is 1)' */
 public class Example9 {
-  //filtered violation 'File length is 19 lines (max allowed is 1)'
+
 }
 // xdoc section -- end


### PR DESCRIPTION
Issue: #16332 

**Example2.java ->**
`    // filtered violation below 'String literal expressions should be on the left side of an equals comparison.'
`
Contains a filtered violation that exceeds the line length limit of 85. To address this, it has been added to checkstyle-examples-suppressions.xml.

**Example3.java ->**
`      "This is an example string." // filtered violation 'Line matches the illegal pattern 'example''`
Requires the filtered violation comment to be on the same line as the violation itself to prevent the word "example" in the comment from being incorrectly flagged. This results in a line length exceeding 85, so it has been included in checkstyle-examples-suppressions.xml.

**Example9.java ->**
```
Violation lines for C:\Users\rprar\OneDrive\Desktop\checkstyle\src\xdocs-examples\resources\com\puppycrawl\tools\checkstyle\filters\suppressionsinglefilter\Example9.java differ.
value of: iterable.onlyElement()
expected: 17
but was : 1
Expected :17
Actual   :1
```
Triggers a file length violation, which always starts at line 1. However, since line 1 must contain XML configuration, adding a filtered violation comment isn't possible. To resolve this, the maximum file length has been set higher than the actual file length, effectively preventing a violation in the file.

Please let me know if any corrections or refinements are to be made.

