### PR TITLE
Pull #16628: Try SLL prediction mode for fast javadoc parsing

### DIFF
--- a/.github/workflows/check-performance-regression.yml
+++ b/.github/workflows/check-performance-regression.yml
@@ -32,7 +32,7 @@ jobs:
             BASELINE_SECONDS: 445.76
             CONFIG_FILE: './config/benchmark-config.xml'
           - target: javadoc
-            BASELINE_SECONDS: 570.62
+            BASELINE_SECONDS: 481.41
             CONFIG_FILE: './config/benchmark-javadoc-config.xml'
     runs-on: ubuntu-latest
     env:

--- a/config/jsoref-spellchecker/whitelist.words
+++ b/config/jsoref-spellchecker/whitelist.words
@@ -1221,6 +1221,7 @@ sivakumar
 Slawinski
 slf
 slist
+SLL
 SLo
 Slurper
 slurpersupport

--- a/pom.xml
+++ b/pom.xml
@@ -4718,6 +4718,14 @@
                 <avoidCallsTo>
                   org.antlr.v4.runtime.BailErrorStrategy
                 </avoidCallsTo>
+                <!-- Setting the prediction mode to SLL is an intentional optimization
+                 to speed up parsing.
+                 Since this is a deterministic change to the parser's behavior,
+                 no normal check execution test case will be able to kill the mutation, as the test
+                 will always pass regardless of the parsing strategy. -->
+                <avoidCallsTo>
+                  org.antlr.v4.runtime.atn.ParserATNSimulator
+                </avoidCallsTo>
               </avoidCallsTo>
               <coverageThreshold>100</coverageThreshold>
               <mutationThreshold>98</mutationThreshold>

--- a/src/main/java/com/puppycrawl/tools/checkstyle/JavadocDetailNodeParser.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/JavadocDetailNodeParser.java
@@ -34,6 +34,7 @@ import org.antlr.v4.runtime.ParserRuleContext;
 import org.antlr.v4.runtime.RecognitionException;
 import org.antlr.v4.runtime.Recognizer;
 import org.antlr.v4.runtime.Token;
+import org.antlr.v4.runtime.atn.PredictionMode;
 import org.antlr.v4.runtime.misc.Interval;
 import org.antlr.v4.runtime.misc.ParseCancellationException;
 import org.antlr.v4.runtime.tree.ParseTree;
@@ -168,6 +169,9 @@ public class JavadocDetailNodeParser {
         final CommonTokenStream tokens = new CommonTokenStream(lexer);
 
         final JavadocParser parser = new JavadocParser(tokens);
+
+        // set prediction mode to SLL to speed up parsing
+        parser.getInterpreter().setPredictionMode(PredictionMode.SLL);
 
         // remove default error listeners
         parser.removeErrorListeners();


### PR DESCRIPTION
> This is the fastest prediction mode, and provides correct results for many grammars

```Java
public enum PredictionMode {
	/**
	 * The SLL(*) prediction mode. This prediction mode ignores the current
	 * parser context when making predictions. This is the fastest prediction
	 * mode, and provides correct results for many grammars. This prediction
	 * mode is more powerful than the prediction mode provided by ANTLR 3, but
	 * may result in syntax errors for grammar and input combinations which are
	 * not SLL.
	 *
	 * <p>
	 * When using this prediction mode, the parser will either return a correct
	 * parse tree (i.e. the same parse tree that would be returned with the
	 * {@link #LL} prediction mode), or it will report a syntax error. If a
	 * syntax error is encountered when using the {@link #SLL} prediction mode,
	 * it may be due to either an actual syntax error in the input or indicate
	 * that the particular combination of grammar and input requires the more
	 * powerful {@link #LL} prediction abilities to complete successfully.</p>
	 *
	 * <p>
	 * This prediction mode does not provide any guarantees for prediction
	 * behavior for syntactically-incorrect inputs.</p>
	 */
	SLL,
        .....
```
Diff Regression config: https://gist.githubusercontent.com/mahfouz72/33967bf86e4a29cafa429771b0e95808/raw/f621465b3c7dd6e64ac603d396570bf92a1a69d6/check_patch.xml