### PR TITLE
Enabled xml plugin in pom.xml

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1690,8 +1690,6 @@
           </execution>
         </executions>
         <configuration>
-          <!-- until #16242 -->
-          <skip>true</skip>
           <catalogHandling>strict</catalogHandling>
           <!-- We need to exclude some files, so the default configuration is not suitable. -->
           <useDefaultFormatFileSet>false</useDefaultFormatFileSet>


### PR DESCRIPTION
#16242   
1. enable xml plugin in pom.xml , check if this case will be violated https://github.com/checkstyle/checkstyle/pull/16467#discussion_r1978658705

Enabled xml Plugin in pom.xml.
checked if this case [https://github.com/checkstyle/checkstyle/pull/16467#discussion_r1978658705](url) is getting violated.

I found that No such case is getting violated instead:
![image](https://github.com/user-attachments/assets/8edb1cfa-3c72-45dd-8f78-ee1b43aa31d0)
these Errors are there.. majorly indentation and spacing xml violations.. appear in the terminal log
`[ERROR] Failed to execute goal org.codehaus.mojo:xml-maven-plugin:1.1.0:check-format (default) on project checkstyle: There are XML formatting violations. Check the above log for details. -> [Help 1]`
