### PR TITLE
Issue #14084: Resolved CheckerFramework violation

### DIFF
--- a/config/checker-framework-suppressions/checker-nullness-optional-interning-suppressions.xml
+++ b/config/checker-framework-suppressions/checker-nullness-optional-interning-suppressions.xml
@@ -487,17 +487,6 @@
     <fileName>src/main/java/com/puppycrawl/tools/checkstyle/JavadocDetailNodeParser.java</fileName>
     <specifier>return</specifier>
     <message>incompatible types in return.</message>
-    <lineContent>return offendingToken;</lineContent>
-    <details>
-      type of expression: @Initialized @Nullable CommonToken
-      method return type: @Initialized @NonNull Token
-    </details>
-  </checkerFrameworkError>
-
-  <checkerFrameworkError unstable="false">
-    <fileName>src/main/java/com/puppycrawl/tools/checkstyle/JavadocDetailNodeParser.java</fileName>
-    <specifier>return</specifier>
-    <message>incompatible types in return.</message>
     <lineContent>return nextSibling;</lineContent>
     <details>
       type of expression: @Initialized @Nullable ParseTree

--- a/config/import-control.xml
+++ b/config/import-control.xml
@@ -20,6 +20,7 @@
   <allow pkg="java.nio"/>
   <allow pkg="java.net"/>
   <allow pkg="java.util"/>
+  <allow class ="javax.annotation.Nonnull"/>
   <allow class="javax.annotation.Nullable"/>
   <allow pkg="javax.xml.parsers"/>
   <allow pkg="org.apache.commons.beanutils"/>

--- a/src/main/java/com/puppycrawl/tools/checkstyle/JavadocDetailNodeParser.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/JavadocDetailNodeParser.java
@@ -23,6 +23,9 @@ import java.util.ArrayDeque;
 import java.util.Deque;
 import java.util.List;
 
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+
 import org.antlr.v4.runtime.BaseErrorListener;
 import org.antlr.v4.runtime.BufferedTokenStream;
 import org.antlr.v4.runtime.CharStreams;
@@ -93,6 +96,7 @@ public class JavadocDetailNodeParser {
      *        DetailAST of Javadoc comment
      * @return DetailNode tree of Javadoc comment
      */
+    @Nonnull
     public ParseStatus parseJavadocAsDetailNode(DetailAST javadocCommentAst) {
         blockCommentLineNumber = javadocCommentAst.getLineNo();
 
@@ -519,6 +523,7 @@ public class JavadocDetailNodeParser {
      * @param javadocLineOffset The line number of beginning of the Javadoc comment
      * @return First non-tight HTML tag if one exists; null otherwise
      */
+    @Nullable
     private static Token getFirstNonTightHtmlTag(JavadocParser javadocParser,
             int javadocLineOffset) {
         final CommonToken offendingToken;


### PR DESCRIPTION
Issue: #14084

**Suppression removed**
 ```
<checkerFrameworkError unstable="false">
    <fileName>src/main/java/com/puppycrawl/tools/checkstyle/JavadocDetailNodeParser.java</fileName>
    <specifier>return</specifier>
    <message>incompatible types in return.</message>
    <lineContent>return offendingToken;</lineContent>
    <details>
      type of expression: @Initialized @Nullable CommonToken
      method return type: @Initialized @NonNull Token
    </details>
  </checkerFrameworkError>

```

**PS C:\Users\athar\OneDrive\Desktop\checkstyle> mvn clean verify** 

```
[INFO] Scanning for projects...
[INFO] Inspecting build with total of 1 modules...
[INFO] Installing Nexus Staging features:
[INFO]   ... total of 1 executions of maven-deploy-plugin replaced with nexus-staging-maven-plugin
.
.
.
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  25:53 min
[INFO] Finished at: 2025-03-23T23:38:35+05:30
[INFO] ------------------------------------------------------------------------

```

