### PR TITLE
Issue #14631: Updated EXCEPTION_LITERAL in JavadocTokenTypes.java to new AST format

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/api/JavadocTokenTypes.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/api/JavadocTokenTypes.java
@@ -300,23 +300,23 @@ public final class JavadocTokenTypes {
     public static final int EXCEPTION_LITERAL = JavadocParser.EXCEPTION_LITERAL;
 
     /**
-     * '@throws' literal in {@code @throws} Javadoc tag.
+     * '@exception' literal in {@code @exception} Javadoc tag.
      *
      * <p>Such Javadoc tag can have two argument - {@link #CLASS_NAME} and {@link #DESCRIPTION}</p>
      *
      * <p><b>Example:</b></p>
-     * <pre>{@code @throws SQLException if query is not correct}</pre>
+     * <pre>{@code @exception SQLException if query is not correct}</pre>
      * <b>Tree:</b>
      * <pre>{@code
-     *   JAVADOC_TAG -> JAVADOC_TAG
-     *      |--THROWS_LITERAL -> @throws
-     *      |--WS ->
-     *      |--CLASS_NAME -> SQLException
-     *      |--WS ->
-     *      `--DESCRIPTION -> DESCRIPTION
-     *          |--TEXT -> if query is not correct
-     *          |--NEWLINE -> \r\n
-     *          `--TEXT ->
+     * JAVADOC_TAG -> JAVADOC_TAG
+     * |--EXCEPTION_LITERAL -> @exception
+     * |--WS ->
+     * |--CLASS_NAME -> SQLException
+     * |--WS ->
+     * `--DESCRIPTION -> DESCRIPTION
+     *     |--TEXT -> if query is not correct
+     *     |--NEWLINE -> \r\n
+     *     TEXT ->
      * }</pre>
      *
      * @see


### PR DESCRIPTION
Issue #14631 


**Command Used**
`java -jar checkstyle-10.21.4-all.jar -J Test.java | sed "s/\[[0-9]\+:[0-9]\+\]//g"
`


**Test.java**
```
/**
 *@exception SQLException if query is not correct
 */
public class Test {
}
```


```
C:\Gsoc\Exception_literal AST>java -jar checkstyle-10.21.4-all.jar -J Test.java | sed "s/\[[0-9]\+:[0-9]\+\]//g"
COMPILATION_UNIT -> COMPILATION_UNIT
`--CLASS_DEF -> CLASS_DEF
    |--MODIFIERS -> MODIFIERS
    |   |--BLOCK_COMMENT_BEGIN -> /*
    |   |   |--COMMENT_CONTENT -> *\r\n *@exception SQLException if query is not correct\r\n
    |   |   |   `--JAVADOC -> JAVADOC
    |   |   |       |--NEWLINE -> \r\n
    |   |   |       |--LEADING_ASTERISK ->  *
    |   |   |       |--JAVADOC_TAG -> JAVADOC_TAG
    |   |   |       |   |--EXCEPTION_LITERAL -> @exception
    |   |   |       |   |--WS ->
    |   |   |       |   |--CLASS_NAME -> SQLException
    |   |   |       |   |--WS ->
    |   |   |       |   `--DESCRIPTION -> DESCRIPTION
    |   |   |       |       |--TEXT -> if query is not correct
    |   |   |       |       |--NEWLINE -> \r\n
    |   |   |       |       `--TEXT ->
    |   |   |       `--EOF -> <EOF>
    |   |   `--BLOCK_COMMENT_END -> */
    |   `--LITERAL_PUBLIC -> public
    |--LITERAL_CLASS -> class
    |--IDENT -> Test
    `--OBJBLOCK -> OBJBLOCK
        |--LCURLY -> {
        `--RCURLY -> }
```
