### PR TITLE
Issue #16564: Fixed EmptyLineSeparator validation with Javadoc

### DIFF
--- a/config/checkstyle-resources-suppressions.xml
+++ b/config/checkstyle-resources-suppressions.xml
@@ -7,6 +7,9 @@
 <suppressions>
 
   <!-- intentional problem for testing -->
+  <suppress checks="PackageDeclaration"
+            files="src[\\/]test[\\/]resources-noncompilable[\\/]com[\\/]puppycrawl[\\/]tools[\\/]checkstyle[\\/]checks[\\/]whitespace[\\/]emptylineseparator[\\/]InputEmptyLineSeparatorCompactNoPackage.java"/>
+  <!-- intentional problem for testing -->
   <suppress checks="PackageDeclarationCheck"
     files="packagedeclaration[\\/]InputPackageDeclarationNoPackage\.java"/>
   <suppress checks="PackageDeclarationCheck"

--- a/config/suppressions.xml
+++ b/config/suppressions.xml
@@ -198,6 +198,10 @@
   <suppress checks="FileTabCharacter"
     files="src[\\/]site[\\/]xdoc[\\/]checks[\\/]whitespace[\\/]filetabcharacter\.xml"/>
 
+  <!-- Apart from a complex logic there is a lot of small methods for a better readability. -->
+  <suppress checks="MethodCount"
+            files="src[\\/]main[\\/]java[\\/]com[\\/]puppycrawl[\\/]tools[\\/]checkstyle[\\/]checks[\\/]whitespace[\\/]EmptyLineSeparatorCheck.java"/>
+
   <!-- Uses non-ascii symbols intentionally -->
   <suppress id="checkASCII"
             files="[\\/]src[\\/]test[\\/]java[\\/]com[\\/]puppycrawl[\\/]tools[\\/]checkstyle[\\/]ConfigurationLoaderTest.java"/>

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/whitespace/EmptyLineSeparatorCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/whitespace/EmptyLineSeparatorCheck.java
@@ -610,9 +610,69 @@ public class EmptyLineSeparatorCheck extends AbstractCheck {
         final int number = 3;
         if (lineNo >= number) {
             final String prePreviousLine = getLine(lineNo - number);
+
             result = CommonUtil.isBlank(prePreviousLine);
+            final boolean previousLineIsEmpty = CommonUtil.isBlank(getLine(lineNo - 2));
+
+            if (previousLineIsEmpty && result) {
+                result = true;
+            }
+            else if (token.findFirstToken(TokenTypes.TYPE) != null) {
+                result = isTwoPrecedingPreviousLinesFromCommentEmpty(token);
+            }
         }
         return result;
+
+    }
+
+    /**
+     * Checks if token has two preceding lines empty, starting from its describing comment.
+     *
+     * @param token token checked.
+     * @return true, if both previous and pre-previous lines from dependent comment are empty
+     */
+    private boolean isTwoPrecedingPreviousLinesFromCommentEmpty(DetailAST token) {
+        boolean upToPrePreviousLinesEmpty = false;
+
+        for (DetailAST typeChild = token.findFirstToken(TokenTypes.TYPE).getLastChild();
+             typeChild != null; typeChild = typeChild.getPreviousSibling()) {
+
+            if (isTokenNotOnPreviousSiblingLines(typeChild, token)) {
+
+                final String commentBeginningPreviousLine =
+                    getLine(typeChild.getLineNo() - 2);
+                final String commentBeginningPrePreviousLine =
+                    getLine(typeChild.getLineNo() - 3);
+
+                if (CommonUtil.isBlank(commentBeginningPreviousLine)
+                    && CommonUtil.isBlank(commentBeginningPrePreviousLine)) {
+                    upToPrePreviousLinesEmpty = true;
+                    break;
+                }
+
+            }
+
+        }
+
+        return upToPrePreviousLinesEmpty;
+    }
+
+    /**
+     * Checks if token is not placed on the realm of previous sibling of token's parent.
+     *
+     * @param token token checked.
+     * @param parentToken parent token.
+     * @return true, if child token doesn't occupy parent token's previous sibling's realm.
+     */
+    private static boolean isTokenNotOnPreviousSiblingLines(DetailAST token,
+                                                            DetailAST parentToken) {
+        DetailAST previousSibling = parentToken.getPreviousSibling();
+        for (DetailAST astNode = previousSibling; astNode != null;
+             astNode = astNode.getLastChild()) {
+            previousSibling = astNode;
+        }
+
+        return token.getLineNo() != previousSibling.getLineNo();
     }
 
     /**
@@ -685,7 +745,21 @@ public class EmptyLineSeparatorCheck extends AbstractCheck {
         if (lineNo != 1) {
             // [lineNo - 2] is the number of the previous line as the numbering starts from zero.
             final String lineBefore = getLine(lineNo - 2);
-            result = CommonUtil.isBlank(lineBefore);
+
+            if (CommonUtil.isBlank(lineBefore)) {
+                result = true;
+            }
+            else if (token.findFirstToken(TokenTypes.TYPE) != null) {
+                for (DetailAST typeChild = token.findFirstToken(TokenTypes.TYPE).getLastChild();
+                     typeChild != null && !result && typeChild.getLineNo() > 1;
+                     typeChild = typeChild.getPreviousSibling()) {
+
+                    final String commentBeginningPreviousLine =
+                        getLine(typeChild.getLineNo() - 2);
+                    result = CommonUtil.isBlank(commentBeginningPreviousLine);
+
+                }
+            }
         }
         return result;
     }

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/whitespace/EmptyLineSeparatorCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/whitespace/EmptyLineSeparatorCheckTest.java
@@ -29,6 +29,7 @@ import org.junit.jupiter.api.Test;
 
 import com.puppycrawl.tools.checkstyle.AbstractModuleTestSupport;
 import com.puppycrawl.tools.checkstyle.DefaultConfiguration;
+import com.puppycrawl.tools.checkstyle.TreeWalker;
 import com.puppycrawl.tools.checkstyle.api.TokenTypes;
 import com.puppycrawl.tools.checkstyle.utils.CommonUtil;
 
@@ -47,6 +48,102 @@ public class EmptyLineSeparatorCheckTest
                 + "by default")
             .that(checkObj.getRequiredTokens())
             .isEqualTo(CommonUtil.EMPTY_INT_ARRAY);
+    }
+
+    @Test
+    public void testMultipleLinesEmptyWithJavadoc() throws Exception {
+
+        final String[] expected = {
+            "27:3: " + getCheckMessage(MSG_MULTIPLE_LINES, "METHOD_DEF"),
+            "43:3: " + getCheckMessage(MSG_MULTIPLE_LINES, "METHOD_DEF"),
+            "51:3: " + getCheckMessage(MSG_MULTIPLE_LINES, "METHOD_DEF"),
+            "56:3: " + getCheckMessage(MSG_SHOULD_BE_SEPARATED, "METHOD_DEF"),
+            "65:3: " + getCheckMessage(MSG_MULTIPLE_LINES, "METHOD_DEF"),
+            "75:13: " + getCheckMessage(MSG_MULTIPLE_LINES_INSIDE),
+            "86:3: " + getCheckMessage(MSG_MULTIPLE_LINES, "METHOD_DEF"),
+            "93:3: " + getCheckMessage(MSG_MULTIPLE_LINES, "METHOD_DEF"),
+            "99:3: " + getCheckMessage(MSG_MULTIPLE_LINES, "METHOD_DEF"),
+        };
+        verifyWithInlineXmlConfig(
+                getPath("InputEmptyLineSeparatorWithJavadoc.java"), expected);
+    }
+
+    @Test
+    public void testMultipleLinesEmptyWithJavadoc2() throws Exception {
+
+        final String[] expected = {
+            "65:5: " + getCheckMessage(MSG_MULTIPLE_LINES, "/*"),
+            "70:5: " + getCheckMessage(MSG_MULTIPLE_LINES, "/*"),
+            "75:5: " + getCheckMessage(MSG_MULTIPLE_LINES, "/*"),
+            "85:5: " + getCheckMessage(MSG_MULTIPLE_LINES, "/*"),
+            "96:7: " + getCheckMessage(MSG_MULTIPLE_LINES, "/*"),
+            "107:7: " + getCheckMessage(MSG_MULTIPLE_LINES, "/*"),
+        };
+        verifyWithInlineXmlConfig(
+                getPath("InputEmptyLineSeparatorWithJavadoc2.java"), expected);
+    }
+
+    @Test
+    public void testSeparationOfClassAndPackageWithComment() throws Exception {
+
+        final String[] expected = {
+            "12:1: " + getCheckMessage(MSG_SHOULD_BE_SEPARATED, "//"),
+            "13:1: " + getCheckMessage(MSG_SHOULD_BE_SEPARATED, "CLASS_DEF"),
+        };
+
+        verifyWithInlineXmlConfig(
+                getPath("InputEmptyLineSeparatorClassPackageSeparation.java"), expected);
+    }
+
+    /**
+     * Config is defined in the method because indexOutOfBond test is also required.
+     */
+    @Test
+    public void testCompactNoPackage() throws Exception {
+
+        final DefaultConfiguration checkConfig = createModuleConfig(EmptyLineSeparatorCheck.class);
+        checkConfig.addProperty("allowMultipleEmptyLines", "false");
+
+        final DefaultConfiguration treeWalkerConfig = createModuleConfig(TreeWalker.class);
+        treeWalkerConfig.addChild(checkConfig);
+
+        final DefaultConfiguration checkerConfig = createRootConfig(treeWalkerConfig);
+
+        final String[] expected = {
+            "7:5: " + getCheckMessage(MSG_SHOULD_BE_SEPARATED, "METHOD_DEF"),
+            "11:5: " + getCheckMessage(MSG_SHOULD_BE_SEPARATED, "METHOD_DEF"),
+            "16:5: " + getCheckMessage(MSG_SHOULD_BE_SEPARATED, "METHOD_DEF"),
+            "20:5: " + getCheckMessage(MSG_SHOULD_BE_SEPARATED, "METHOD_DEF"),
+            "25:5: " + getCheckMessage(MSG_SHOULD_BE_SEPARATED, "METHOD_DEF"),
+            "29:5: " + getCheckMessage(MSG_SHOULD_BE_SEPARATED, "METHOD_DEF"),
+            "34:5: " + getCheckMessage(MSG_SHOULD_BE_SEPARATED, "METHOD_DEF"),
+        };
+
+        verify(checkerConfig, getNonCompilablePath("InputEmptyLineSeparatorCompactNoPackage.java"),
+            expected);
+    }
+
+    /**
+     * Config is defined in the method because strictly the file with one line
+     * is required to be tested.
+     */
+    @Test
+    public void testMultipleEmptyLinesInOneLine() throws Exception {
+        final DefaultConfiguration checkConfig = createModuleConfig(EmptyLineSeparatorCheck.class);
+        checkConfig.addProperty("allowNoEmptyLineBetweenFields", "true");
+        checkConfig.addProperty("allowMultipleEmptyLines", "false");
+        checkConfig.addProperty("allowMultipleEmptyLinesInsideClassMembers", "false");
+
+        final DefaultConfiguration treeWalkerConfig = createModuleConfig(TreeWalker.class);
+        treeWalkerConfig.addChild(checkConfig);
+
+        final DefaultConfiguration checkerConfig = createRootConfig(treeWalkerConfig);
+
+        final String[] expected = {
+            "1:79: " + getCheckMessage(MSG_SHOULD_BE_SEPARATED, "CLASS_DEF"),
+        };
+
+        verify(checkerConfig, getPath("InputEmptyLineSeparatorOneLine.java"), expected);
     }
 
     @Test

--- a/src/test/resources-noncompilable/com/puppycrawl/tools/checkstyle/checks/whitespace/emptylineseparator/InputEmptyLineSeparatorCompactNoPackage.java
+++ b/src/test/resources-noncompilable/com/puppycrawl/tools/checkstyle/checks/whitespace/emptylineseparator/InputEmptyLineSeparatorCompactNoPackage.java
@@ -1,0 +1,38 @@
+/* /nodynamiccopyright/ */ class InputEmptyLineSeparatorCompactNoPackage { // test
+    // add two lines
+    // to check separator capabilities
+    void top() {
+        return;
+    }
+    void nemcp2(int eights) { // violation 'should be separated from previous line'
+        top();
+        return;
+    }
+    void nemcp1() { // violation 'should be separated from previous line'
+        int rot = 4;
+        nemcp2(888);
+        return;
+    }
+    void emcp2() { // violation 'should be separated from previous line'
+        nemcp1();
+        return;
+    }
+    void emcp1(int myArg) { // violation 'should be separated from previous line'
+        int paramy = 12;
+        emcp2();
+        return;
+    }
+    void bottom() { // violation 'should be separated from previous line'
+        emcp1(56);
+        return;
+    }
+    static void stnemcp() { // violation 'should be separated from previous line'
+        (new InputEmptyLineSeparatorCompactNoPackage()).bottom();
+
+        return;
+    }
+    static void stemcp() { // violation 'should be separated from previous line'
+        stnemcp();
+        return;
+    }
+}

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/whitespace/emptylineseparator/InputEmptyLineSeparatorClassPackageSeparation.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/whitespace/emptylineseparator/InputEmptyLineSeparatorClassPackageSeparation.java
@@ -1,0 +1,24 @@
+/*xml
+<module name="Checker">
+  <module name="TreeWalker">
+    <module name="EmptyLineSeparator">
+      <property name="allowMultipleEmptyLines" value="false"/>
+    </module>
+  </module>
+</module>
+*/
+
+package com.puppycrawl.tools.checkstyle.checks.whitespace.emptylineseparator;
+// test
+public class InputEmptyLineSeparatorClassPackageSeparation {
+  // violation 2 lines above "'//' should be separated from previous line"
+  // violation 2 lines above "'CLASS_DEF' should be separated from previous line"
+  /**
+  * Lines <b>method</b>.
+  *
+  * @return string.
+  */
+  int test0(int badFormat1, int badFormat2, final int badFormat3) throws Exception {
+    return 0;
+  }
+}

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/whitespace/emptylineseparator/InputEmptyLineSeparatorOneLine.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/whitespace/emptylineseparator/InputEmptyLineSeparatorOneLine.java
@@ -1,0 +1,1 @@
+package com.puppycrawl.tools.checkstyle.checks.whitespace.emptylineseparator; public class InputEmptyLineSeparatorOneLine { void myMethod() {} } // violation "'CLASS_DEF' should be separated from previous line"

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/whitespace/emptylineseparator/InputEmptyLineSeparatorWithJavadoc.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/whitespace/emptylineseparator/InputEmptyLineSeparatorWithJavadoc.java
@@ -1,0 +1,108 @@
+/*xml
+<module name="Checker">
+  <module name="TreeWalker">
+    <module name="EmptyLineSeparator">
+      <property name="allowNoEmptyLineBetweenFields" value="true"/>
+      <property name="allowMultipleEmptyLines" value="false"/>
+      <property name="allowMultipleEmptyLinesInsideClassMembers" value="false"/>
+    </module>
+  </module>
+</module>
+*/
+
+package com.puppycrawl.tools.checkstyle.checks.whitespace.emptylineseparator;
+
+import org.junit.Ignore;
+
+public class InputEmptyLineSeparatorWithJavadoc {
+  /** Some javadoc. */
+  int test0(int badFormat1, int badFormat2, final int badFormat3) throws Exception {
+    return 0;
+  }
+
+
+  /**
+   * Test.
+   */
+  void myMethod() {}
+  // violation above "'METHOD_DEF' has more than 1 empty lines before"
+
+  /** some lines to test the one line javadoc. */
+  void myMethod2() {
+    int tab0 = 1;
+  }
+
+  /** Some javadoc. */
+  int test1(int badFormat1, int badFormat2, final int badFormat3) throws Exception {
+    return 0;
+  }
+
+  /** Some javadoc. */
+
+
+  int test2(int badFormat1, int badFormat2, final int badFormat3) throws Exception {
+    // violation above "'METHOD_DEF' has more than 1 empty lines before"
+    return 0;
+  }
+
+
+  /** Some javadoc. */
+
+  int test3(int badFormat1, int badFormat2, final int badFormat3) throws Exception {
+    // violation above "'METHOD_DEF' has more than 1 empty lines before"
+    return 0;
+  }
+  /** Some javadoc. */
+  int test4(int badFormat1, int badFormat2, final int badFormat3) throws Exception {
+    // violation above "'METHOD_DEF' should be separated from previous line"
+    return 0;
+  }
+
+
+  // test
+  /** Some javadoc. */
+
+  int test5(int badFormat1, int badFormat2, final int badFormat3) throws Exception {
+    // violation above "'METHOD_DEF' has more than 1 empty lines before"
+    return 0;
+  }
+
+  // test
+  /** Some javadoc. */
+
+  int test6(int badFormat1, int badFormat2, final int badFormat3) throws Exception {
+    // violation below "There is more than 1 empty line after this line"
+    return 0;
+
+
+  } // test
+
+  int test7(int badFormat1, int badFormat2, final int badFormat3) throws Exception {
+    return 0;
+  }
+
+
+  /** Some javadoc. */
+  int test8(int badFormat1, int badFormat2, final int badFormat3) throws Exception {
+    // violation above "'METHOD_DEF' has more than 1 empty lines before"
+    return 0;
+  } // test
+
+
+  /** Some javadoc. */
+  int test9(int badFormat1, int badFormat2, final int badFormat3) throws Exception {
+    // violation above "'METHOD_DEF' has more than 1 empty lines before"
+    return 0;
+  }
+
+
+  @Ignore
+  /**
+   * comment
+   */
+  @Deprecated
+  public void foo6() {
+      // violation 6 lines above "'METHOD_DEF' has more than 1 empty lines before"
+      return;
+  }
+}

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/whitespace/emptylineseparator/InputEmptyLineSeparatorWithJavadoc2.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/whitespace/emptylineseparator/InputEmptyLineSeparatorWithJavadoc2.java
@@ -1,0 +1,118 @@
+/*xml
+<module name="Checker">
+  <module name="TreeWalker">
+    <module name="EmptyLineSeparator">
+      <property name="allowNoEmptyLineBetweenFields" value="true"/>
+      <property name="allowMultipleEmptyLines" value="false"/>
+      <property name="allowMultipleEmptyLinesInsideClassMembers" value="false"/>
+    </module>
+  </module>
+</module>
+*/
+
+package com.puppycrawl.tools.checkstyle.checks.whitespace.emptylineseparator;
+
+import javax.annotation.Nullable;
+
+public class InputEmptyLineSeparatorWithJavadoc2 {
+
+  public static class Good {
+      /** my javadoc */
+      public int [][] myInt = null;
+
+      /** my javadoc */
+      public int myOtherInt[][] = null;
+
+      /**
+        * My javadoc...
+        */
+      public static
+          int [][] test10() throws Exception {
+        return new int [][] {};
+      }
+
+      /**
+        * My javadoc...
+        *
+        */
+      public static
+          int [] test11() throws Exception {
+        return new int [] {};
+      }
+
+        /**
+        * My javadoc...
+        *
+        */
+      public static
+          int [] test12() throws Exception {
+        return new int [] {};
+      }
+
+        /**
+        * My javadoc...
+        *
+        */
+      public static
+          @Nullable int [] test13() throws Exception {
+        return new int [] {};
+      }
+  }
+
+  public static class Bad {
+
+
+    /** my javadoc */
+    public int [][] myInt = null;
+    // violation 2 lines above "has more than 1 empty lines before"
+
+
+    /** my javadoc */
+    public int myOtherInt[][] = null;
+    // violation 2 lines above "has more than 1 empty lines before"
+
+
+    /**
+      * My javadoc...
+      */
+    public static
+        int [][] test10() throws Exception {
+      // violation 5 lines above "has more than 1 empty lines before"
+      return new int [][] {};
+    }
+
+
+    /**
+      * My javadoc...
+      *
+      */
+    public static
+        int [] test11() throws Exception {
+      // violation 6 lines above "has more than 1 empty lines before"
+      return new int [] {};
+    }
+
+
+      /**
+      * My javadoc...
+      *
+      */
+    public static
+        int [] test12() throws Exception {
+      // violation 6 lines above "has more than 1 empty lines before"
+      return new int [] {};
+    }
+
+
+      /**
+      * My javadoc...
+      *
+      */
+    public static
+        @Nullable int [] test13() throws Exception {
+      // violation 6 lines above "has more than 1 empty lines before"
+      return new int [] {};
+    }
+
+  }
+}


### PR DESCRIPTION
Issue: #16564  

here is AST for the input:

```
COMPILATION_UNIT -> COMPILATION_UNIT [13:0]
|--BLOCK_COMMENT_BEGIN -> /* [1:0]
|   |--COMMENT_CONTENT -> xml\r\n<module name="Checker">\r\n  <module name="TreeWalker">\r\n    <module name="EmptyLineSeparator">\r\n      <property name="allowNoEmptyLineBetweenFields" value="true"/
>\r\n      <property name="allowMultipleEmptyLines" value="false"/>\r\n      <property name="allowMultipleEmptyLinesInsideClassMembers" value="false"/>\r\n    </module>\r\n  </module>\r\n</module>\r\n
 [1:2]
|   `--BLOCK_COMMENT_END -> */ [11:0]
|--PACKAGE_DEF -> package [13:0]
|   |--ANNOTATIONS -> ANNOTATIONS [13:57]
|   |--DOT -> . [13:57]
|   |   |--DOT -> . [13:46]
|   |   |   |--DOT -> . [13:39]
|   |   |   |   |--DOT -> . [13:28]
|   |   |   |   |   |--DOT -> . [13:22]
|   |   |   |   |   |   |--DOT -> . [13:11]
|   |   |   |   |   |   |   |--IDENT -> com [13:8]
|   |   |   |   |   |   |   `--IDENT -> puppycrawl [13:12]
|   |   |   |   |   |   `--IDENT -> tools [13:23]
|   |   |   |   |   `--IDENT -> checkstyle [13:29]
|   |   |   |   `--IDENT -> checks [13:40]
|   |   |   `--IDENT -> whitespace [13:47]
|   |   `--IDENT -> emptylineseparator [13:58]
|   `--SEMI -> ; [13:76]
`--CLASS_DEF -> CLASS_DEF [15:0]
    |--MODIFIERS -> MODIFIERS [15:0]
    |   `--LITERAL_PUBLIC -> public [15:0]
    |--LITERAL_CLASS -> class [15:7]
    |--IDENT -> InputEmptyLineSeparatorWithJavadoc [15:13]
    `--OBJBLOCK -> OBJBLOCK [15:48]
        |--LCURLY -> { [15:48]
        |--METHOD_DEF -> METHOD_DEF [21:4]
        |   |--MODIFIERS -> MODIFIERS [21:4]
        |   |--TYPE -> TYPE [21:4]
        |   |   |--BLOCK_COMMENT_BEGIN -> /* [18:4]
        |   |   |   |--COMMENT_CONTENT -> *\r\n     * Test.\r\n      [18:6]
        |   |   |   `--BLOCK_COMMENT_END -> */ [20:5]
        |   |   `--LITERAL_VOID -> void [21:4]
        |   |--IDENT -> myMethod [21:9]
        |   |--LPAREN -> ( [21:17]
        |   |--PARAMETERS -> PARAMETERS [21:18]
        |   |--RPAREN -> ) [21:18]
        |   `--SLIST -> { [21:20]
        |       `--RCURLY -> } [21:21]
        |--SINGLE_LINE_COMMENT -> // [22:4]
        |   `--COMMENT_CONTENT ->  violation above "'METHOD_DEF' has more than 1 empty lines before"\r\n [22:6]
        `--RCURLY -> } [23:0]

```