### PR TITLE
Issue #16641: FileContents.getJavadocBefore should skip block comment…

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/api/FileContents.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/api/FileContents.java
@@ -240,8 +240,14 @@ public final class FileContents implements CommentListener {
             .flatMap(List::stream)
             .filter(comment -> !javadocComments.containsValue(comment))
             .anyMatch(comment -> {
-                return lineNo >= comment.getStartLineNo()
-                                        && lineNo <= comment.getEndLineNo();
+                final boolean lineInSideBlockComment = lineNo >= comment.getStartLineNo()
+                                                    && lineNo <= comment.getEndLineNo();
+                boolean lineHasOnlyBlockComment = true;
+                if (comment.getStartLineNo() == comment.getEndLineNo()) {
+                    final String line = line(comment.getStartLineNo() - 1).trim();
+                    lineHasOnlyBlockComment = line.startsWith("/*") && line.endsWith("*/");
+                }
+                return lineInSideBlockComment && lineHasOnlyBlockComment;
             });
     }
 

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocStyleCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocStyleCheckTest.java
@@ -827,6 +827,7 @@ public class JavadocStyleCheckTest
     public void testJavadocStyleAboveComments() throws Exception {
         final String[] expected = {
             "13: " + getCheckMessage(MSG_NO_PERIOD),
+            "20: " + getCheckMessage(MSG_NO_PERIOD),
         };
 
         verifyWithInlineConfigParser(

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocTypeCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocTypeCheckTest.java
@@ -475,6 +475,7 @@ public class JavadocTypeCheckTest extends AbstractModuleTestSupport {
     public void testJavadocTypeAboveComments() throws Exception {
         final String[] expected = {
             "15:1: " + getCheckMessage(MSG_MISSING_TAG, "@author"),
+            "41:15: " + getCheckMessage(MSG_MISSING_TAG, "@author"),
         };
         verifyWithInlineConfigParser(
                 getPath("InputJavadocTypeAboveComments.java"), expected);

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocVariableCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocVariableCheckTest.java
@@ -26,7 +26,6 @@ import org.junit.jupiter.api.Test;
 
 import com.puppycrawl.tools.checkstyle.AbstractModuleTestSupport;
 import com.puppycrawl.tools.checkstyle.api.TokenTypes;
-import com.puppycrawl.tools.checkstyle.utils.CommonUtil;
 
 public class JavadocVariableCheckTest
     extends AbstractModuleTestSupport {
@@ -376,7 +375,9 @@ public class JavadocVariableCheckTest
 
     @Test
     public void testJavadocVariableAboveComment() throws Exception {
-        final String[] expected = CommonUtil.EMPTY_STRING_ARRAY;
+        final String[] expected = {
+            "23:5: " + getCheckMessage(MSG_JAVADOC_MISSING),
+        };
         verifyWithInlineConfigParser(
             getPath("InputJavadocVariableAboveComment.java"),
             expected);

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/javadoc/MissingJavadocMethodCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/javadoc/MissingJavadocMethodCheckTest.java
@@ -533,6 +533,7 @@ public class MissingJavadocMethodCheckTest extends AbstractModuleTestSupport {
     public void testMissingJavadocMethodAboveComments() throws Exception {
         final String[] expected = {
             "18:5: " + getCheckMessage(MSG_JAVADOC_MISSING),
+            "36:5: " + getCheckMessage(MSG_JAVADOC_MISSING),
         };
         verifyWithInlineConfigParser(
                 getPath("InputMissingJavadocMethodAboveComments.java"),

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/javadoc/MissingJavadocTypeCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/javadoc/MissingJavadocTypeCheckTest.java
@@ -440,6 +440,7 @@ public class MissingJavadocTypeCheckTest extends AbstractModuleTestSupport {
     public void testMissingJavadocTypeAboveComments() throws Exception {
         final String[] expected = {
             "13:1: " + getCheckMessage(MSG_JAVADOC_MISSING),
+            "27:5: " + getCheckMessage(MSG_JAVADOC_MISSING),
         };
         verifyWithInlineConfigParser(
             getPath("InputMissingJavadocTypeAboveComments.java"),

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadocmethod/InputJavadocMethodAboveComments.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadocmethod/InputJavadocMethodAboveComments.java
@@ -99,4 +99,21 @@ public class InputJavadocMethodAboveComments {
     public int foo5() {
         return 0;
     }
+
+    /**
+     * A Javadoc comment.
+     * @return 0
+     */
+    /*@ A JML Annotation */ public int foo6() { return 0; }
+
+
+    public void foo7() throws Exception { }
+
+    /**
+     * A Javadoc comment.
+     * @return 0
+     */
+    public int foo8() { return 0; } /* @ A JML Annotation */
+
+    public void foo9() throws Exception { }
 }

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadocstyle/InputJavadocStyleAboveComments.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadocstyle/InputJavadocStyleAboveComments.java
@@ -15,4 +15,12 @@ public class InputJavadocStyleAboveComments {
         field
      */
     public String field;
+
+    // violation below, 'First sentence should end with a period'
+    /**
+     * A Javadoc comment
+     */
+    /* package */ String field2;
+
+    private String field3;
 }

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadoctype/InputJavadocTypeAboveComments.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadoctype/InputJavadocTypeAboveComments.java
@@ -26,3 +26,18 @@ public class InputJavadocTypeAboveComments {
 class MyClass {
 
 }
+
+/**
+ * Test class for variable naming in for each clause.*
+ * @author Mohamed Mahfouz
+ */
+class MyClass2 /* Comment */{
+
+}
+
+/**
+ * Test class for variable naming in for each clause.*
+ */
+/* Comment */ class MyClass3 {
+// violation above, 'Type Javadoc comment is missing @author tag'
+}

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadocvariable/InputJavadocVariableAboveComment.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadocvariable/InputJavadocVariableAboveComment.java
@@ -13,4 +13,12 @@ public class InputJavadocVariableAboveComment {
        test comment
      */
     public int variablePublic;
+
+
+    /**
+     * A package variable
+     */
+    /* package */ int variablePackage;
+
+    public int x;  // violation, 'Missing a Javadoc comment.'
 }

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/missingjavadocmethod/InputMissingJavadocMethodAboveComments.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/missingjavadocmethod/InputMissingJavadocMethodAboveComments.java
@@ -15,7 +15,7 @@ package com.puppycrawl.tools.checkstyle.checks.javadoc.missingjavadocmethod;
 
 public class InputMissingJavadocMethodAboveComments {
 
-    public InputMissingJavadocMethodAboveComments() { }// violation
+    public InputMissingJavadocMethodAboveComments() { } // violation, 'Missing a Javadoc comment.'
 
     /**
      *
@@ -24,5 +24,16 @@ public class InputMissingJavadocMethodAboveComments {
      */
     public InputMissingJavadocMethodAboveComments(String p1) {
 
+    }
+
+
+    /**
+     * A Javadoc comment.
+     * @return 0
+     */
+    public int method() /* comment */ { return 0;}
+
+    public int method2() { // violation, 'Missing a Javadoc comment.'
+        return 0;
     }
 }

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/missingjavadoctype/InputMissingJavadocTypeAboveComments.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/missingjavadoctype/InputMissingJavadocTypeAboveComments.java
@@ -11,12 +11,18 @@ tokens = (default)INTERFACE_DEF, CLASS_DEF, ENUM_DEF, ANNOTATION_DEF, RECORD_DEF
 package com.puppycrawl.tools.checkstyle.checks.javadoc.missingjavadoctype;
 
 public class InputMissingJavadocTypeAboveComments { // violation, 'Missing a Javadoc comment.'
-}
 
-/**
- *
- */
-/* */
-class InputMissingJavadocTypeAboveComments2 {
-}
+    /**
+     *
+     */
+    /* */
+    public class InputMissingJavadocTypeAboveComments2 {
+    }
 
+    /**
+     *
+     */
+    public class Myclass { } /* My class */
+
+    public class Myclass2 { } // violation, 'Missing a Javadoc comment.'
+}


### PR DESCRIPTION
closes #16641 

Diff Regression config: https://raw.githubusercontent.com/mahfouz72/test-configs/refs/heads/javadoc-checks/JavadocChecks/config.xml