### PR TITLE
Issue #14019: Remove suppression for pitest-ant profile

### DIFF
--- a/config/pitest-suppressions/pitest-ant-suppressions.xml
+++ b/config/pitest-suppressions/pitest-ant-suppressions.xml
@@ -1,13 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <suppressedMutations>
-  <mutation unstable="false">
-    <sourceFile>CheckstyleAntTask.java</sourceFile>
-    <mutatedClass>com.puppycrawl.tools.checkstyle.ant.CheckstyleAntTask</mutatedClass>
-    <mutatedMethod>&lt;init&gt;</mutatedMethod>
-    <mutator>org.pitest.mutationtest.engine.gregor.mutators.experimental.MemberVariableMutator</mutator>
-    <description>Removed assignment to member variable maxWarnings</description>
-    <lineContent>private int maxWarnings = Integer.MAX_VALUE;</lineContent>
-  </mutation>
 
   <mutation unstable="false">
     <sourceFile>CheckstyleAntTask.java</sourceFile>


### PR DESCRIPTION
[Issue #14019](https://github.com/checkstyle/checkstyle/issues/14019)

- Removed the suppression on MemberVariableMutator for `private int maxWarnings = Integer.MAX_VALUE`