### PR TITLE
Issue #14631: Update link_literal in JavadocTokenTypes.java to new AST format

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/api/JavadocTokenTypes.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/api/JavadocTokenTypes.java
@@ -1095,27 +1095,12 @@ public final class JavadocTokenTypes {
      *
      * <p><b>Tree:</b></p>
      * <pre>{@code
-     * JAVADOC -> JAVADOC
-     *  |--NEWLINE -> \r\n
-     *  |--LEADING_ASTERISK ->  *
-     *  |--TEXT ->
-     *  |--HTML_ELEMENT -> HTML_ELEMENT
-     *  |   `--HTML_TAG -> HTML_TAG
-     *  |       |--HTML_ELEMENT_START -> HTML_ELEMENT_START
-     *  |       |   |--START -> <
-     *  |       |   |--HTML_TAG_NAME -> tag_name
-     *  |       |   |--WS ->
-     *  |       |   |--ATTRIBUTE -> ATTRIBUTE
-     *  |       |   |   |--HTML_TAG_NAME -> attr_name
-     *  |       |   |   |--EQUALS -> =
-     *  |       |   |   `--ATTR_VALUE -> "attr_value"
-     *  |       |   `--END -> >
-     *  |       |--TEXT -> Content
-     *  |       `--HTML_ELEMENT_END -> HTML_ELEMENT_END
-     *  |           |--START -> <
-     *  |           |--SLASH -> /
-     *  |           |--HTML_TAG_NAME -> tag_name
-     *  |           `--END -> >
+     *    `--JAVADOC -> JAVADOC
+     *        |--NEWLINE -> \r\n
+     *        |--LEADING_ASTERISK ->  *
+     *        |--TEXT ->  &lt;tag_name attr_name="attr_value">Content&lt;/
+     *        |--NEWLINE -> \r\n
+     *        |--TEXT ->
      * }</pre>
      */
     public static final int ATTR_VALUE = JavadocParser.ATTR_VALUE;
@@ -1858,6 +1843,7 @@ public final class JavadocTokenTypes {
     /**
      * Newline symbol - '\n'.
      */
+
     public static final int NEWLINE = JavadocParser.NEWLINE;
 
     /**


### PR DESCRIPTION

Issue: #14631

**Command Used**
java -jar checkstyle-10.21.4-all.jar -J Test.java | sed "s/\[[0-9]\+:[0-9]\+\]//g"


**Test.java**
```
/**
 * @link org.apache.utils.Lists.Comparator#compare(Object)
 */
public class Test {
}

```

```
kushw@ASUSvivobook15 MINGW64 ~/steleo/link_literal AST (main)
$ java -jar checkstyle-10.21.4-all.jar -J Test.java | sed "s/\[[0-9]\+:[0-9]\+\]//g"
COMPILATION_UNIT -> COMPILATION_UNIT
`--CLASS_DEF -> CLASS_DEF
    |--MODIFIERS -> MODIFIERS
    |   |--BLOCK_COMMENT_BEGIN -> /*
    |   |   |--COMMENT_CONTENT -> *\r\n * @link org.apache.utils.Lists.Comparator#compare(Object)\r\n
    |   |   |   `--JAVADOC -> JAVADOC
    |   |   |       |--NEWLINE -> \r\n
    |   |   |       |--LEADING_ASTERISK ->  *
    |   |   |       |--WS ->
    |   |   |       |--JAVADOC_TAG -> JAVADOC_TAG
    |   |   |       |   |--CUSTOM_NAME -> @link
    |   |   |       |   |--WS ->
    |   |   |       |   `--DESCRIPTION -> DESCRIPTION
    |   |   |       |       |--TEXT -> org.apache.utils.Lists.Comparator#compare(Object)
    |   |   |       |       |--NEWLINE -> \r\n
    |   |   |       |       `--TEXT ->
    |   |   |       `--EOF -> <EOF>
    |   |   `--BLOCK_COMMENT_END -> */
    |   `--LITERAL_PUBLIC -> public
    |--LITERAL_CLASS -> class
    |--IDENT -> Test
    `--OBJBLOCK -> OBJBLOCK
        |--LCURLY -> {
        `--RCURLY -> }
```
