### PR TITLE
Issue #14631: Updated LITERAL_INCLUDE in JavadocTokenTypes.java to new AST format

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/api/JavadocTokenTypes.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/api/JavadocTokenTypes.java
@@ -999,17 +999,16 @@ public final class JavadocTokenTypes {
      * <b>Tree:</b>
      * <pre>
      * {@code
-     *   JAVADOC_TAG ->; JAVADOC_TAG
-     *    |--SERIAL_FIELD_LITERAL ->; @serialField
-     *    |--WS ->;
-     *    |--FIELD_NAME ->; counter
-     *    |--WS ->;
-     *    |--FIELD_TYPE ->; Integer
-     *    |--WS ->;
-     *    `--DESCRIPTION ->; DESCRIPTION
-     *        |--TEXT ->; objects counter
-     *        |--NEWLINE ->; \r\n
-     *        `--TEXT ->;
+     *   --JAVADOC_TAG -> JAVADOC_TAG
+     *   |--SERIAL_FIELD_LITERAL -> @serialField
+     *   |--WS ->
+     *   |--LITERAL_INCLUDE -> include
+     *   |--NEWLINE -> \r\n
+     *   `--WS ->
+     *    `--DESCRIPTION -> DESCRIPTION
+     *        |--TEXT -> objects counter
+     *        |--NEWLINE -> \r\n
+     *        `--TEXT ->
      * }</pre>
      *
      * @see


### PR DESCRIPTION
issue #14631 

Command Used
java -jar checkstyle-10.21.0-all.jar -J Test.java | sed "s/[[0-9]+:[0-9]+]//g"

Test.java
```
/**
 * @serial include
 */
public class Test {
}
```
```

$ java -jar checkstyle-10.21.0-all.jar -J Test.java | sed "s/\[[0-9]\+:[0-9]\+\]//g"
COMPILATION_UNIT -> COMPILATION_UNIT
`--CLASS_DEF -> CLASS_DEF
    |--MODIFIERS -> MODIFIERS
    |   |--BLOCK_COMMENT_BEGIN -> /*
    |   |   |--COMMENT_CONTENT -> *\r\n * @serial include\r\n
    |   |   |   `--JAVADOC -> JAVADOC
    |   |   |       |--NEWLINE -> \r\n
    |   |   |       |--LEADING_ASTERISK ->  *
    |   |   |       |--WS ->
    |   |   |       |--JAVADOC_TAG -> JAVADOC_TAG
    |   |   |       |   |--SERIAL_LITERAL -> @serial
    |   |   |       |   |--WS ->
    |   |   |       |   |--LITERAL_INCLUDE -> include
    |   |   |       |   |--NEWLINE -> \r\n
    |   |   |       |   `--WS ->
    |   |   |       `--EOF -> <EOF>
    |   |   `--BLOCK_COMMENT_END -> */
    |   `--LITERAL_PUBLIC -> public
    |--LITERAL_CLASS -> class
    |--IDENT -> Test
    `--OBJBLOCK -> OBJBLOCK
        |--LCURLY -> {
        `--RCURLY -> }
```

Additional Screenshot
![Screenshot 2025-03-24 223421](https://github.com/user-attachments/assets/a7be6d0e-bbb4-4a8d-a0b5-7fe82e9ae8dd)

