### PR TITLE
Issue #14631: Updated LINK_HTML_TAG_NAME to AST format

### DIFF
--- a/config/jsoref-spellchecker/whitelist.words
+++ b/config/jsoref-spellchecker/whitelist.words
@@ -1278,6 +1278,7 @@ STT
 Studman
 Styleable
 styleguide
+stylesheet
 subdir
 subelements
 subext

--- a/src/main/java/com/puppycrawl/tools/checkstyle/api/JavadocTokenTypes.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/api/JavadocTokenTypes.java
@@ -1492,7 +1492,38 @@ public final class JavadocTokenTypes {
     /** Isindex tag name. */
     public static final int ISINDEX_HTML_TAG_NAME = JavadocParser.ISINDEX_HTML_TAG_NAME;
 
-    /** Link tag name. */
+    /**
+     *  Link tag name.
+     *
+     *  <p><b>Example:</b></p>
+     *  <pre>{@code <link rel="stylesheet" href="Style.css">}</pre>
+     *  <b>Tree:</b>
+     *  <pre>
+     *  {@code
+     *  HTML_ELEMENT -> HTML_ELEMENT
+     *  `--SINGLETON_ELEMENT -> SINGLETON_ELEMENT
+     *      `--LINK_TAG -> LINK_TAG
+     *          |--START -> <
+     *          |--LINK_HTML_TAG_NAME -> link
+     *          |--WS ->
+     *          |--ATTRIBUTE -> ATTRIBUTE
+     *          |   |--HTML_TAG_NAME -> rel
+     *          |   |--EQUALS -> =
+     *          |   `--ATTR_VALUE -> "stylesheet"
+     *          |--WS ->
+     *          |--ATTRIBUTE -> ATTRIBUTE
+     *          |   |--HTML_TAG_NAME -> href
+     *          |   |--EQUALS -> =
+     *          |   `--ATTR_VALUE -> "Style.css"
+     *          `--END -> >
+     *  }
+     *  </pre>
+     *
+     *  @see
+     *  <a href="https://docs.oracle.com/javase/8/docs/technotes/tools/unix/javadoc.html#JSSOR647">
+     *  comments are written in HTML</a>
+     *  @see #LINK_HTML_TAG_NAME
+     */
     public static final int LINK_HTML_TAG_NAME = JavadocParser.LINK_HTML_TAG_NAME;
 
     /** Meta tag name. */


### PR DESCRIPTION
Issue #14631 

**Command Used**
`java -jar checkstyle-10.21.4-all.jar -J Test.java | sed "s/\[[0-9]\+:[0-9]\+\]//g"`

**Test.java**
```
/**
 * <link rel="stylesheet" href="Style.css">
 */
public class Test {
}
```
**Terminal Output**

```
yukti@LAPTOP-P8NBSFE2 MINGW64 ~/LINK_HTML_TAG_NAME
$ java -jar checkstyle-10.21.4-all.jar -J Test.java | sed "s/\[[0-9]\+:[0-9]\+\]//g"
COMPILATION_UNIT -> COMPILATION_UNIT
`--CLASS_DEF -> CLASS_DEF
    |--MODIFIERS -> MODIFIERS
    |   |--BLOCK_COMMENT_BEGIN -> /*
    |   |   |--COMMENT_CONTENT -> *\r\n * <link rel="stylesheet" href="Style.css">\r\n
    |   |   |   `--JAVADOC -> JAVADOC
    |   |   |       |--NEWLINE -> \r\n
    |   |   |       |--LEADING_ASTERISK ->  *
    |   |   |       |--TEXT ->
    |   |   |       |--HTML_ELEMENT -> HTML_ELEMENT
    |   |   |       |   `--SINGLETON_ELEMENT -> SINGLETON_ELEMENT
    |   |   |       |       `--LINK_TAG -> LINK_TAG
    |   |   |       |           |--START -> <
    |   |   |       |           |--LINK_HTML_TAG_NAME -> link
    |   |   |       |           |--WS ->
    |   |   |       |           |--ATTRIBUTE -> ATTRIBUTE
    |   |   |       |           |   |--HTML_TAG_NAME -> rel
    |   |   |       |           |   |--EQUALS -> =
    |   |   |       |           |   `--ATTR_VALUE -> "stylesheet"
    |   |   |       |           |--WS ->
    |   |   |       |           |--ATTRIBUTE -> ATTRIBUTE
    |   |   |       |           |   |--HTML_TAG_NAME -> href
    |   |   |       |           |   |--EQUALS -> =
    |   |   |       |           |   `--ATTR_VALUE -> "Style.css"
    |   |   |       |           `--END -> >
    |   |   |       |--NEWLINE -> \r\n
    |   |   |       |--TEXT ->
    |   |   |       `--EOF -> <EOF>
    |   |   `--BLOCK_COMMENT_END -> */
    |   `--LITERAL_PUBLIC -> public
    |--LITERAL_CLASS -> class
    |--IDENT -> Test
    `--OBJBLOCK -> OBJBLOCK
        |--LCURLY -> {
        `--RCURLY -> }


```