### PR TITLE
infra: Enabling Spot-Bug in CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -197,11 +197,12 @@ workflows:
           name: "checkstyle-and-sevntu"
           image-name: *cs_img
           command: "./.ci/validation.sh checkstyle-and-sevntu"
-      # until https://github.com/spotbugs/spotbugs-maven-plugin/issues/806
-      # - validate-with-maven-script:
-      #    name: "spotbugs-and-pmd"
-      #    image-name: *cs_img
-      #    command: "./.ci/validation.sh spotbugs-and-pmd"
+      # https://github.com/spotbugs/spotbugs-maven-plugin/issues/806 explains
+      # why we need execution of spotbugs without any other maven plugins which can change binaries
+      - validate-with-maven-script:
+          name: "spotbugs-and-pmd"
+          image-name: *cs_img
+          command: "./.ci/validation.sh spotbugs-and-pmd"
       - validate-with-maven-script:
           name: "site"
           image-name: *cs_img

--- a/config/jsoref-spellchecker/whitelist.words
+++ b/config/jsoref-spellchecker/whitelist.words
@@ -17,6 +17,7 @@ Aconfig
 actionlint
 addons
 adr
+AFBR
 AFilter
 aggregators
 allchecks

--- a/config/spotbugs-exclude.xml
+++ b/config/spotbugs-exclude.xml
@@ -325,4 +325,83 @@
     <Method name="matchesAtFrontNoRegex"/>
     <Bug pattern="BAS_BLOATED_ASSIGNMENT_SCOPE"/>
   </Match>
+
+  <!-- Suppress PRMC_POSSIBLY_REDUNDANT_METHOD_CALLS -->
+  <!-- until https://github.com/checkstyle/checkstyle/issues/16979 -->
+  <Match>
+    <Class name="com.puppycrawl.tools.checkstyle.utils.JavadocUtil" />
+    <Bug pattern="PRMC_POSSIBLY_REDUNDANT_METHOD_CALLS" />
+  </Match>
+  <Match>
+    <Class name="com.puppycrawl.tools.checkstyle.DetailNodeTreeStringPrinter" />
+    <Bug pattern="PRMC_POSSIBLY_REDUNDANT_METHOD_CALLS" />
+  </Match>
+  <Match>
+    <Class name="com.puppycrawl.tools.checkstyle.JavaAstVisitor" />
+    <Bug pattern="PRMC_POSSIBLY_REDUNDANT_METHOD_CALLS" />
+  </Match>
+  <Match>
+    <Class name="com.puppycrawl.tools.checkstyle.JavaAstVisitor$DetailAstPair" />
+    <Bug pattern="PRMC_POSSIBLY_REDUNDANT_METHOD_CALLS" />
+  </Match>
+  <Match>
+    <Class name="com.puppycrawl.tools.checkstyle.checks.indentation.BlockParentHandler" />
+    <Bug pattern="PRMC_POSSIBLY_REDUNDANT_METHOD_CALLS" />
+  </Match>
+  <Match>
+    <Class name="com.puppycrawl.tools.checkstyle.checks.javadoc.AbstractJavadocCheck" />
+    <Bug pattern="PRMC_POSSIBLY_REDUNDANT_METHOD_CALLS" />
+  </Match>
+  <Match>
+    <Class name="com.puppycrawl.tools.checkstyle.meta.XmlMetaWriter" />
+    <Bug pattern="PRMC_POSSIBLY_REDUNDANT_METHOD_CALLS" />
+  </Match>
+
+  <!-- Suppress AFBR_ABNORMAL_FINALLY_BLOCK_RETURN -->
+  <!-- until https://github.com/checkstyle/checkstyle/issues/16979 -->
+  <Match>
+    <Class name="com.puppycrawl.tools.checkstyle.Main" />
+    <Bug pattern="AFBR_ABNORMAL_FINALLY_BLOCK_RETURN" />
+  </Match>
+  <Match>
+    <Class name="com.puppycrawl.tools.checkstyle.ant.CheckstyleAntTask" />
+    <Bug pattern="AFBR_ABNORMAL_FINALLY_BLOCK_RETURN" />
+  </Match>
+  <Match>
+    <Class name="com.puppycrawl.tools.checkstyle.gui.ListToTreeSelectionModelWrapper" />
+    <Bug pattern="AFBR_ABNORMAL_FINALLY_BLOCK_RETURN" />
+  </Match>
+
+  <!-- Suppress CC_CYCLOMATIC_COMPLEXITY -->
+  <!-- until https://github.com/checkstyle/checkstyle/issues/16979 -->
+  <Match>
+    <Class name="com.puppycrawl.tools.checkstyle.checks.coding.FinalLocalVariableCheck" />
+    <Method name="visitToken" />
+    <Bug pattern="CC_CYCLOMATIC_COMPLEXITY" />
+  </Match>
+  <Match>
+    <Class name="com.puppycrawl.tools.checkstyle.checks.coding.RequireThisCheck" />
+    <Method name="getClassFrameWhereViolationIsFound" />
+    <Bug pattern="CC_CYCLOMATIC_COMPLEXITY" />
+  </Match>
+
+  <!-- Suppress PSC_PRESIZE_COLLECTIONS -->
+  <!-- until https://github.com/checkstyle/checkstyle/issues/16979 -->
+  <Match>
+    <Class name="com.puppycrawl.tools.checkstyle.checks.javadoc.JavadocMethodCheck" />
+    <Method name="findTokensInAstByType" />
+    <Bug pattern="PSC_PRESIZE_COLLECTIONS" />
+  </Match>
+
+  <!-- Suppress RCN_REDUNDANT_NULLCHECK_WOULD_HAVE_BEEN_A_NPE -->
+  <!-- until https://github.com/checkstyle/checkstyle/issues/16979 -->
+  <Match>
+    <Class name="com.puppycrawl.tools.checkstyle.site.SiteUtil" />
+    <Bug pattern="RCN_REDUNDANT_NULLCHECK_WOULD_HAVE_BEEN_A_NPE" />
+  </Match>
+  <Match>
+    <Class name="com.puppycrawl.tools.checkstyle.meta.MetadataGeneratorUtil" />
+    <Method name="getTargetFiles" />
+    <Bug pattern="RCN_REDUNDANT_NULLCHECK_WOULD_HAVE_BEEN_A_NPE" />
+  </Match>
 </FindBugsFilter>


### PR DESCRIPTION
Earlier Disabled : https://github.com/checkstyle/checkstyle/pull/14863
Due to SpotBug Issue Mentioned in :https://github.com/spotbugs/spotbugs-maven-plugin/issues/806

Local Results on : mvn clean test-compile spotbugs
<img width="1075" alt="Screenshot 2025-03-27 at 1 16 18 AM" src="https://github.com/user-attachments/assets/55edc869-3a2d-4d06-b8f8-d9a7d69c33c3" />

### Most of the Bugs Flagged by SpotBugs are False Positives 
**For Example Lets Take This High-Confidence Error Flagges by SpotBug :**
<img width="1384" alt="Screenshot 2025-04-01 at 11 29 13 PM" src="https://github.com/user-attachments/assets/4ae3bd44-65f4-451e-9423-85a4041c6322" />
**This is the part of the code where Error is Flagged :**  
<img width="1059" alt="Screenshot 2025-04-01 at 11 30 30 PM" src="https://github.com/user-attachments/assets/a64ee26a-0dfd-461f-9cb8-f4fdcf636274" />
## What is the Error?
Ans:The error RCN_REDUNDANT_NULLCHECK_WOULD_HAVE_BEEN_A_NPE occurs because Spotbugs detects a redundant null check on a variable (stream in your code) that is guaranteed to be non-null due to prior dereferencing. In this case, this is likely a false positive caused by Spotbugs analyzing the bytecode generated for the try-with-resources block.
## What’s happening:

-Files.find(...) returns a Stream<Path>, which will never be null (it throws IOException on failure).
-The try-with-resources block auto-closes the stream, and the generated bytecode includes an implicit if (stream != null) check to avoid closing a null resource. Spotbugs flags this as redundant because stream cannot logically be null here.

## Why it’s a false positive:
The redundant check is in the bytecode (generated by try-with-resources), not our source code. Spotbugs is technically correct but overly strict here.

### Solution
- We have added all the false positives in the SpotBug-Exclusion List for now
- We can hope that with newer version of spotbug and sb-contrib have less false positives.
- we can Increase the threshold in config for spotbug from Low to Medium or High , In order to have less stricter checks.
`<threshold>Medium</threshold>`  [ But in this case we might miss out on some small actual bugs but the flase positives will be drastically reduced]
