### PR TITLE
Issue #14019: Covered pitest survival in DetailNodeTreeStringPrinter

### DIFF
--- a/config/pitest-suppressions/pitest-tree-walker-suppressions.xml
+++ b/config/pitest-suppressions/pitest-tree-walker-suppressions.xml
@@ -4,24 +4,6 @@
     <sourceFile>DetailNodeTreeStringPrinter.java</sourceFile>
     <mutatedClass>com.puppycrawl.tools.checkstyle.DetailNodeTreeStringPrinter</mutatedClass>
     <mutatedMethod>parseFile</mutatedMethod>
-    <mutator>org.pitest.mutationtest.engine.gregor.mutators.NonVoidMethodCallMutator</mutator>
-    <description>removed call to java/nio/charset/Charset::name</description>
-    <lineContent>System.getProperty(&quot;file.encoding&quot;, StandardCharsets.UTF_8.name()));</lineContent>
-  </mutation>
-
-  <mutation unstable="false">
-    <sourceFile>DetailNodeTreeStringPrinter.java</sourceFile>
-    <mutatedClass>com.puppycrawl.tools.checkstyle.DetailNodeTreeStringPrinter</mutatedClass>
-    <mutatedMethod>parseFile</mutatedMethod>
-    <mutator>org.pitest.mutationtest.engine.gregor.mutators.experimental.ArgumentPropagationMutator</mutator>
-    <description>replaced call to java/lang/System::getProperty with argument</description>
-    <lineContent>System.getProperty(&quot;file.encoding&quot;, StandardCharsets.UTF_8.name()));</lineContent>
-  </mutation>
-
-  <mutation unstable="false">
-    <sourceFile>DetailNodeTreeStringPrinter.java</sourceFile>
-    <mutatedClass>com.puppycrawl.tools.checkstyle.DetailNodeTreeStringPrinter</mutatedClass>
-    <mutatedMethod>parseFile</mutatedMethod>
     <mutator>org.pitest.mutationtest.engine.gregor.mutators.experimental.NakedReceiverMutator</mutator>
     <description>replaced call to java/io/File::getAbsoluteFile with receiver</description>
     <lineContent>final FileText text = new FileText(file.getAbsoluteFile(),</lineContent>

--- a/src/main/java/com/puppycrawl/tools/checkstyle/DetailNodeTreeStringPrinter.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/DetailNodeTreeStringPrinter.java
@@ -162,6 +162,21 @@ public final class DetailNodeTreeStringPrinter {
     }
 
     /**
+     * Retrieves the file encoding from system properties.
+     * If the provided encoding is blank, an exception is thrown.
+     *
+     * @param encode the encoding to use as a fallback if not found in system properties.
+     * @return the file encoding from system properties, or the provided fallback encoding.
+     * @throws IllegalStateException if the provided encoding is blank.
+     */
+    private static String getFileEncoding(String encode) {
+        if (encode.isBlank()) {
+            throw new IllegalStateException("Encode should not be blank");
+        }
+        return System.getProperty("file.encoding", encode);
+    }
+
+    /**
      * Parse a file and return the parse tree.
      *
      * @param file the file to parse.
@@ -170,7 +185,7 @@ public final class DetailNodeTreeStringPrinter {
      */
     private static DetailNode parseFile(File file) throws IOException {
         final FileText text = new FileText(file.getAbsoluteFile(),
-            System.getProperty("file.encoding", StandardCharsets.UTF_8.name()));
+            getFileEncoding(StandardCharsets.UTF_8.name()));
         return parseJavadocAsDetailNode(text.getFullText().toString());
     }
 

--- a/src/test/java/com/puppycrawl/tools/checkstyle/DetailNodeTreeStringPrinterTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/DetailNodeTreeStringPrinterTest.java
@@ -225,4 +225,28 @@ public class DetailNodeTreeStringPrinterTest extends AbstractTreeTestSupport {
         }
     }
 
+    @Test
+    public void testInvokeStaticMethodWithBlankEncoding() {
+        try {
+            TestUtil.invokeStaticMethod(DetailNodeTreeStringPrinter.class,
+                    "getFileEncoding", "");
+
+            assertWithMessage("Expected IllegalStateException was not thrown").fail();
+        }
+        catch (ReflectiveOperationException ex) {
+            final Throwable cause = ex.getCause();
+            final String errorMessage;
+            if (cause != null) {
+                errorMessage = cause.getMessage();
+            }
+            else {
+                errorMessage = ex.getMessage();
+            }
+
+            assertWithMessage("Exception should contain 'Encode should not be blank'")
+                    .that(errorMessage)
+                    .contains("Encode should not be blank");
+        }
+    }
+
 }


### PR DESCRIPTION
Issue: #14019

Solved Pitest Survivals:

```
 <mutation unstable="false">
    <sourceFile>DetailNodeTreeStringPrinter.java</sourceFile>
    <mutatedClass>com.puppycrawl.tools.checkstyle.DetailNodeTreeStringPrinter</mutatedClass>
    <mutatedMethod>parseFile</mutatedMethod>
    <mutator>org.pitest.mutationtest.engine.gregor.mutators.NonVoidMethodCallMutator</mutator>
    <description>removed call to java/nio/charset/Charset::name</description>
    <lineContent>System.getProperty(&quot;file.encoding&quot;, StandardCharsets.UTF_8.name()));</lineContent>
  </mutation>
```

```
**Explanation:**

final FileText text = new FileText(file.getAbsoluteFile(),
            System.getProperty("file.encoding", StandardCharsets.UTF_8.name()));
Here,   StandardCharsets.UTF_8.name() always returns "UTF-8" and that doesn't depend on anything,
   
```

Diff Regression config: https://github.com/Atharv3221/checkstyle/blob/master/src/main/java/com/puppycrawl/tools/checkstyle/DetailNodeTreeStringPrinter.java
Diff Regression patch config: https://github.com/Atharv3221/checkstyle/blob/pitestSolving/src/main/java/com/puppycrawl/tools/checkstyle/DetailNodeTreeStringPrinter.java
New module config: https://github.com/Atharv3221/checkstyle/blob/master/src/main/java/com/puppycrawl/tools/checkstyle/DetailNodeTreeStringPrinter.java
Diff Regression Projects:
https://raw.githubusercontent.com/checkstyle/contribution/master/checkstyle-tester/projects-to-test-on.properties
GitHub, generate report