### PR TITLE
Issue #14631: Updated BASEFONT_HTML_TAG_NAME in JavadocTokenTypes.java to new AST format

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/api/JavadocTokenTypes.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/api/JavadocTokenTypes.java
@@ -1497,19 +1497,19 @@ public final class JavadocTokenTypes {
      * <b>Tree:</b>
      * <pre>
      * {@code
-     *   JAVADOC ->; JAVADOC
-     *        |--NEWLINE ->; \r\n
-     *        |--LEADING_ASTERISK ->;  *
-     *        |--TEXT ->;  text before break
-     *        |--HTML_ELEMENT ->; HTML_ELEMENT
-     *        |   `--SINGLETON_ELEMENT ->; SINGLETON_ELEMENT
-     *        |       `--BR_TAG ->; BR_TAG
-     *        |           |--START ->; -<;
-     *        |           |--BR_HTML_TAG_NAME ->; br
-     *        |           `--END ->; >;
-     *        |--TEXT ->;  text after break
-     *        |--NEWLINE ->; \r\n
-     *        |--TEXT ->;
+     *   `--JAVADOC -> JAVADOC
+     *       |--NEWLINE -> \r\n
+     *       |--LEADING_ASTERISK ->  *
+     *       |--TEXT ->  text before break
+     *       |--HTML_ELEMENT -> HTML_ELEMENT
+     *       |   `--SINGLETON_ELEMENT -> SINGLETON_ELEMENT
+     *       |       `--BR_TAG -> BR_TAG
+     *       |           |--START -> <
+     *       |           |--BR_HTML_TAG_NAME -> br
+     *       |           `--END -> >
+     *       |--TEXT ->  text after break
+     *       |--NEWLINE -> \r\n
+     *       |--TEXT ->
      * }
      * </pre>
      */


### PR DESCRIPTION
issue #14631 

Command Used
```java -jar checkstyle-10.21.0-all.jar -J Test.java | sed "s/[[0-9]+:[0-9]+]//g"```

Test.java
```
/**
 * text before break < br > text after break
 */
public class Test {
}
```
```
$ java -jar checkstyle-10.21.0-all.jar -J Test.java | sed "s/\[[0-9]\+:[0-9]\+\]//g"
COMPILATION_UNIT -> COMPILATION_UNIT
`--CLASS_DEF -> CLASS_DEF
    |--MODIFIERS -> MODIFIERS
    |   |--BLOCK_COMMENT_BEGIN -> /*
    |   |   |--COMMENT_CONTENT -> *\r\n * text before break < br > text after break\r\n
    |   |   |   `--JAVADOC -> JAVADOC
    |   |   |       |--NEWLINE -> \r\n
    |   |   |       |--LEADING_ASTERISK ->  *
    |   |   |       |--TEXT ->  text before break < br > text after break
    |   |   |       |--NEWLINE -> \r\n
    |   |   |       |--TEXT ->
    |   |   |       `--EOF -> <EOF>
    |   |   `--BLOCK_COMMENT_END -> */
    |   `--LITERAL_PUBLIC -> public
    |--LITERAL_CLASS -> class
    |--IDENT -> Test
    `--OBJBLOCK -> OBJBLOCK
        |--LCURLY -> {
        `--RCURLY -> }
```
```mvn clean verify``` Status
![Screenshot 2025-03-28 214059](https://github.com/user-attachments/assets/edb08c71-8672-4aba-a9ee-69ff61e0835b)


