### PR TITLE
Issue #14631: Updated SEE_LITERAL in JavadocTokenTypes.java to new AST format

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/api/JavadocTokenTypes.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/api/JavadocTokenTypes.java
@@ -242,6 +242,8 @@ public final class JavadocTokenTypes {
      *       |--WS
      *       |--DESCRIPTION -> DESCRIPTION
      *           |--TEXT -> serialized company name
+     *           |--NEWLINE -> \r\n
+     *           `--TEXT ->
      * }</pre>
      *
      * @see


### PR DESCRIPTION
issue #14631 

Command Used
```java -jar checkstyle-10.21.0-all.jar -J Test.java | sed "s/[[0-9]+:[0-9]+]//g"```

Test.java
```
/**
 * @serial serialized company name
 */
public class Test {
}
```
```
$ java -jar checkstyle-10.21.0-all.jar -J Test.java | sed "s/\[[0-9]\+:[0-9]\+\]//g"
COMPILATION_UNIT -> COMPILATION_UNIT
`--CLASS_DEF -> CLASS_DEF
    |--MODIFIERS -> MODIFIERS
    |   |--BLOCK_COMMENT_BEGIN -> /*
    |   |   |--COMMENT_CONTENT -> *\r\n * @serial serialized company name\r\n
    |   |   |   `--JAVADOC -> JAVADOC
    |   |   |       |--NEWLINE -> \r\n
    |   |   |       |--LEADING_ASTERISK ->  *
    |   |   |       |--WS ->
    |   |   |       |--JAVADOC_TAG -> JAVADOC_TAG
    |   |   |       |   |--SERIAL_LITERAL -> @serial
    |   |   |       |   |--WS ->
    |   |   |       |   `--DESCRIPTION -> DESCRIPTION
    |   |   |       |       |--TEXT -> serialized company name
    |   |   |       |       |--NEWLINE -> \r\n
    |   |   |       |       `--TEXT ->
    |   |   |       `--EOF -> <EOF>
    |   |   `--BLOCK_COMMENT_END -> */
    |   `--LITERAL_PUBLIC -> public
    |--LITERAL_CLASS -> class
    |--IDENT -> Test
    `--OBJBLOCK -> OBJBLOCK
        |--LCURLY -> {
        `--RCURLY -> }
```
