### PR TITLE
Issue #16666: Updated Broken Link - Javadoc OpenJDK 8 Report in website, 404 Error

### DIFF
--- a/src/site/xdoc/sun_style.xml
+++ b/src/site/xdoc/sun_style.xml
@@ -22,10 +22,6 @@
         </p>
 
         <p>
-          <a href="reports/javadoc/openjdk8/">
-            Checkstyle's html report for Open JDK library (javadoc validation)</a>
-        </p>
-        <p>
           <a href="https://github.com/checkstyle/checkstyle/blob/master/src/main/resources/sun_checks.xml">
             incomplete Checkstyle configuration for 'Sun's Java Style'</a>
         </p>


### PR DESCRIPTION
fixes #16666 