### PR TITLE
Issue #14631: Updated DOC_ROOT_LITERAL in JavadocTokenTypes.java to new AST format

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/api/JavadocTokenTypes.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/api/JavadocTokenTypes.java
@@ -459,10 +459,10 @@ public final class JavadocTokenTypes {
      * <b>Tree:</b>
      * <pre>
      * <code>
-     * |--JAVADOC_INLINE_TAG -&gt; JAVADOC_INLINE_TAG
-     *      |--JAVADOC_INLINE_TAG_START -&gt; {
-     *      |--DOC_ROOT_LITERAL -&gt; @docRoot
-     *      `--JAVADOC_INLINE_TAG_END -&gt; }
+     * |--JAVADOC_INLINE_TAG -> JAVADOC_INLINE_TAG
+     *      |--JAVADOC_INLINE_TAG_START -> {
+     *      |--DOC_ROOT_LITERAL -> @docRoot
+     *      `--JAVADOC_INLINE_TAG_END -> }
      * </code>
      * </pre>
      *


### PR DESCRIPTION
issue #14631 

Command Used
java -jar checkstyle-10.21.0-all.jar -J Test.java | sed "s/[[0-9]+:[0-9]+]//g"

Test.java
```
/**
 * {@docRoot}
 */
public class Test {
}
```
```
$ java -jar checkstyle-10.21.0-all.jar -J Test.java | sed "s/\[[0-9]\+:[0-9]\+\]//g"
COMPILATION_UNIT -> COMPILATION_UNIT
`--CLASS_DEF -> CLASS_DEF
    |--MODIFIERS -> MODIFIERS
    |   |--BLOCK_COMMENT_BEGIN -> /*
    |   |   |--COMMENT_CONTENT -> *\r\n * {@docRoot}\r\n
    |   |   |   `--JAVADOC -> JAVADOC
    |   |   |       |--NEWLINE -> \r\n
    |   |   |       |--LEADING_ASTERISK ->  *
    |   |   |       |--TEXT ->
    |   |   |       |--JAVADOC_INLINE_TAG -> JAVADOC_INLINE_TAG
    |   |   |       |   |--JAVADOC_INLINE_TAG_START -> {
    |   |   |       |   |--DOC_ROOT_LITERAL -> @docRoot
    |   |   |       |   `--JAVADOC_INLINE_TAG_END -> }
    |   |   |       |--NEWLINE -> \r\n
    |   |   |       |--TEXT ->
    |   |   |       `--EOF -> <EOF>
    |   |   `--BLOCK_COMMENT_END -> */
    |   `--LITERAL_PUBLIC -> public
    |--LITERAL_CLASS -> class
    |--IDENT -> Test
    `--OBJBLOCK -> OBJBLOCK
        |--LCURLY -> {
        `--RCURLY -> }

```