### PR TITLE
Issue 16360: Migrate XMLLoggerTest to use inlineConfigParser

### DIFF
--- a/src/test/java/com/puppycrawl/tools/checkstyle/XMLLoggerTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/XMLLoggerTest.java
@@ -179,18 +179,8 @@ public class XMLLoggerTest extends AbstractXmlTestSupport {
 
     @Test
     public void testAddError() throws Exception {
-        final XMLLogger logger = new XMLLogger(outStream, OutputStreamOptions.CLOSE);
-        logger.auditStarted(null);
-        final Violation violation =
-            new Violation(1, 1,
-                "messages.properties", "key", null, SeverityLevel.ERROR, null,
-                    getClass(), null);
-        final AuditEvent ev = new AuditEvent(this, "Test.java", violation);
-        logger.fileStarted(ev);
-        logger.addError(ev);
-        logger.fileFinished(ev);
-        logger.auditFinished(null);
-        verifyXml(getPath("ExpectedXMLLoggerError.xml"), outStream, violation.getViolation());
+        verifyWithInlineConfigParserAndXmlLogger("InputXMLLoggerAddError.java",
+                "ExpectedXMLLoggerAddError.xml");
     }
 
     @Test

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/xmllogger/ExpectedXMLLoggerAddError.xml
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/xmllogger/ExpectedXMLLoggerAddError.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<checkstyle version="">
+<file name="InputXMLLoggerAddError.java">
+<error line="1" severity="error" message="Line does not match expected header line of 'Test'."
+       source="com.puppycrawl.tools.checkstyle.checks.header.HeaderCheck"/>
+</file>
+</checkstyle>

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/xmllogger/InputXMLLoggerAddError.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/xmllogger/InputXMLLoggerAddError.java
@@ -1,0 +1,13 @@
+/*xml
+<module name="Checker">
+  <module name="TreeWalker">
+    <module name="com.puppycrawl.tools.checkstyle.checks.header.HeaderCheck">
+      <property name="header" value="Test"/>
+    </module>
+  </module>
+</module>
+*/
+package com.puppycrawl.tools.checkstyle.xmllogger;
+
+public class InputXMLLoggerAddError {
+}


### PR DESCRIPTION
Fixes Issue #16360

Change `testAddError` method to use `verifyWithInlineConfigParserAndXmlLogger`.
