### PR TITLE
Issue #14019: Cover pitest survivals with tests in DetailNodeTreeStringPrinter

### DIFF
--- a/config/pitest-suppressions/pitest-tree-walker-suppressions.xml
+++ b/config/pitest-suppressions/pitest-tree-walker-suppressions.xml
@@ -1,33 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <suppressedMutations>
   <mutation unstable="false">
-    <sourceFile>DetailNodeTreeStringPrinter.java</sourceFile>
-    <mutatedClass>com.puppycrawl.tools.checkstyle.DetailNodeTreeStringPrinter</mutatedClass>
-    <mutatedMethod>parseFile</mutatedMethod>
-    <mutator>org.pitest.mutationtest.engine.gregor.mutators.NonVoidMethodCallMutator</mutator>
-    <description>removed call to java/nio/charset/Charset::name</description>
-    <lineContent>System.getProperty(&quot;file.encoding&quot;, StandardCharsets.UTF_8.name()));</lineContent>
-  </mutation>
-
-  <mutation unstable="false">
-    <sourceFile>DetailNodeTreeStringPrinter.java</sourceFile>
-    <mutatedClass>com.puppycrawl.tools.checkstyle.DetailNodeTreeStringPrinter</mutatedClass>
-    <mutatedMethod>parseFile</mutatedMethod>
-    <mutator>org.pitest.mutationtest.engine.gregor.mutators.experimental.ArgumentPropagationMutator</mutator>
-    <description>replaced call to java/lang/System::getProperty with argument</description>
-    <lineContent>System.getProperty(&quot;file.encoding&quot;, StandardCharsets.UTF_8.name()));</lineContent>
-  </mutation>
-
-  <mutation unstable="false">
-    <sourceFile>DetailNodeTreeStringPrinter.java</sourceFile>
-    <mutatedClass>com.puppycrawl.tools.checkstyle.DetailNodeTreeStringPrinter</mutatedClass>
-    <mutatedMethod>parseFile</mutatedMethod>
-    <mutator>org.pitest.mutationtest.engine.gregor.mutators.experimental.NakedReceiverMutator</mutator>
-    <description>replaced call to java/io/File::getAbsoluteFile with receiver</description>
-    <lineContent>final FileText text = new FileText(file.getAbsoluteFile(),</lineContent>
-  </mutation>
-
-  <mutation unstable="false">
     <sourceFile>JavadocDetailNodeParser.java</sourceFile>
     <mutatedClass>com.puppycrawl.tools.checkstyle.JavadocDetailNodeParser</mutatedClass>
     <mutatedMethod>getMissedHtmlTag</mutatedMethod>

--- a/src/main/java/com/puppycrawl/tools/checkstyle/DetailNodeTreeStringPrinter.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/DetailNodeTreeStringPrinter.java
@@ -21,7 +21,6 @@ package com.puppycrawl.tools.checkstyle;
 
 import java.io.File;
 import java.io.IOException;
-import java.nio.charset.StandardCharsets;
 
 import com.puppycrawl.tools.checkstyle.JavadocDetailNodeParser.ParseErrorMessage;
 import com.puppycrawl.tools.checkstyle.JavadocDetailNodeParser.ParseStatus;
@@ -169,8 +168,7 @@ public final class DetailNodeTreeStringPrinter {
      * @throws IOException if the file could not be read.
      */
     private static DetailNode parseFile(File file) throws IOException {
-        final FileText text = new FileText(file.getAbsoluteFile(),
-            System.getProperty("file.encoding", StandardCharsets.UTF_8.name()));
+        final FileText text = new FileText(file, System.getProperty("file.encoding"));
         return parseJavadocAsDetailNode(text.getFullText().toString());
     }
 


### PR DESCRIPTION
Issue: #14019

**Killed Mutations**

```
<mutation unstable="false">
    <sourceFile>DetailNodeTreeStringPrinter.java</sourceFile>
    <mutatedClass>com.puppycrawl.tools.checkstyle.DetailNodeTreeStringPrinter</mutatedClass>
    <mutatedMethod>parseFile</mutatedMethod>
    <mutator>org.pitest.mutationtest.engine.gregor.mutators.NonVoidMethodCallMutator</mutator>
    <description>removed call to java/nio/charset/Charset::name</description>
    <lineContent>System.getProperty(&quot;file.encoding&quot;, StandardCharsets.UTF_8.name()));</lineContent>
  </mutation>

  <mutation unstable="false">
    <sourceFile>DetailNodeTreeStringPrinter.java</sourceFile>
    <mutatedClass>com.puppycrawl.tools.checkstyle.DetailNodeTreeStringPrinter</mutatedClass>
    <mutatedMethod>parseFile</mutatedMethod>
    <mutator>org.pitest.mutationtest.engine.gregor.mutators.experimental.ArgumentPropagationMutator</mutator>
    <description>replaced call to java/lang/System::getProperty with argument</description>
    <lineContent>System.getProperty(&quot;file.encoding&quot;, StandardCharsets.UTF_8.name()));</lineContent>
  </mutation>

  <mutation unstable="false">
    <sourceFile>DetailNodeTreeStringPrinter.java</sourceFile>
    <mutatedClass>com.puppycrawl.tools.checkstyle.DetailNodeTreeStringPrinter</mutatedClass>
    <mutatedMethod>parseFile</mutatedMethod>
    <mutator>org.pitest.mutationtest.engine.gregor.mutators.experimental.NakedReceiverMutator</mutator>
    <description>replaced call to java/io/File::getAbsoluteFile with receiver</description>
    <lineContent>final FileText text = new FileText(file.getAbsoluteFile(),</lineContent>
  </mutation>
```
