### PR TITLE
Issue #16360: Migrate XMLLoggerTest.testAddErrorOnZeroColumns to use inlineConfigParser

### DIFF
--- a/src/test/java/com/puppycrawl/tools/checkstyle/XMLLoggerTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/XMLLoggerTest.java
@@ -232,19 +232,8 @@ public class XMLLoggerTest extends AbstractXmlTestSupport {
 
     @Test
     public void testAddErrorOnZeroColumns() throws Exception {
-        final XMLLogger logger = new XMLLogger(outStream, OutputStreamOptions.CLOSE);
-        logger.auditStarted(null);
-        final Violation violation =
-                new Violation(1, 0,
-                        "messages.properties", "key", null, SeverityLevel.ERROR, null,
-                        getClass(), null);
-        final AuditEvent ev = new AuditEvent(this, "Test.java", violation);
-        logger.fileStarted(ev);
-        logger.addError(ev);
-        logger.fileFinished(ev);
-        logger.auditFinished(null);
-        verifyXml(getPath("ExpectedXMLLoggerErrorZeroColumn.xml"), outStream,
-                violation.getViolation());
+        verifyWithInlineConfigParserAndXmlLogger("InputXMLLoggerErrorOnZeroColumn.java",
+                "ExpectedXMLLoggerErrorZeroColumn.xml");
     }
 
     @Test

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/xmllogger/ExpectedXMLLoggerErrorZeroColumn.xml
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/xmllogger/ExpectedXMLLoggerErrorZeroColumn.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <checkstyle version="">
-<file name="Test.java">
-<error line="1" severity="error" message="$0" source="com.puppycrawl.tools.checkstyle.XMLLoggerTest"/>
+<file name="InputXMLLoggerErrorOnZeroColumn.java">
+<error line="14" severity="error" message="Javadoc line should start with leading asterisk." source="com.puppycrawl.tools.checkstyle.checks.javadoc.JavadocMissingLeadingAsteriskCheck"/>
 </file>
 </checkstyle>

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/xmllogger/InputXMLLoggerErrorOnZeroColumn.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/xmllogger/InputXMLLoggerErrorOnZeroColumn.java
@@ -1,0 +1,21 @@
+/*xml
+<module name="Checker">
+  <module name="TreeWalker">
+    <module
+        name="com.puppycrawl.tools.checkstyle.checks.javadoc.JavadocMissingLeadingAsteriskCheck">
+    </module>
+  </module>
+</module>
+*/
+
+package com.puppycrawl.tools.checkstyle.xmllogger;
+
+/**
+  Test for {@link com.puppycrawl.tools.checkstyle.xmllogger} when
+ * the column number is 0.
+ * <p>
+ * The test is to ensure that the column number is set to 0 in the XML output.
+ * </p>
+ */
+public class InputXMLLoggerErrorOnZeroColumn {
+}


### PR DESCRIPTION
Fixes Issue https://github.com/checkstyle/checkstyle/issues/16360

Change the `XMLLoggerTest.testAddErrorOnZeroColumns` method to use `verifyWithInlineConfigParserAndXmlLogger`.
