### PR TITLE
Issue #14631: Updated ISINDEX_TAG to new AST format

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/api/JavadocTokenTypes.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/api/JavadocTokenTypes.java
@@ -2820,7 +2820,50 @@ public final class JavadocTokenTypes {
      */
     public static final int INPUT_TAG = JavadocParser.RULE_inputTag + RULE_TYPES_OFFSET;
 
-    /** Isindex html tag. */
+    /**
+     * Isindex tag name.
+     *
+     * <p><b>Example:</b></p>
+     * <pre>{@code
+     * &lt;head&gt;
+     *    &lt;isindex prompt="search"&gt;
+     * &lt;/head&gt;
+     * }</pre>
+     * <b>Tree:</b>
+     * <pre>
+     * {@code
+     *   |--HTML_ELEMENT -> HTML_ELEMENT
+     *   |   `--HEAD -> HEAD
+     *   |       |--HEAD_TAG_START -> HEAD_TAG_START
+     *   |       |   |--START -> <
+     *   |       |   |--HEAD_HTML_TAG_NAME -> head
+     *   |       |   `--END -> >
+     *   |       |--NEWLINE -> \r\n
+     *   |       |--LEADING_ASTERISK ->  *
+     *   |       |--TEXT ->
+     *   |       |--SINGLETON_ELEMENT -> SINGLETON_ELEMENT
+     *   |       |   `--ISINDEX_TAG -> ISINDEX_TAG
+     *   |       |       |--START -> <
+     *   |       |       |--ISINDEX_HTML_TAG_NAME -> isindex
+     *   |       |       |--WS ->
+     *   |       |       |--ATTRIBUTE -> ATTRIBUTE
+     *   |       |       |   |--HTML_TAG_NAME -> prompt
+     *   |       |       |   |--EQUALS -> =
+     *   |       |       |   `--ATTR_VALUE -> "search"
+     *   |       |       `--END -> >
+     *   |       |--NEWLINE -> \r\n
+     *   |       |--LEADING_ASTERISK ->  *
+     *   |       |--TEXT ->
+     *   |       `--HEAD_TAG_END -> HEAD_TAG_END
+     *   |           |--START -> <
+     *   |           |--SLASH -> /
+     *   |           |--HEAD_HTML_TAG_NAME -> head
+     *   |           `--END -> >
+     *   |--NEWLINE -> \r\n
+     *   |--TEXT ->
+     * }
+     * </pre>
+     */
     public static final int ISINDEX_TAG = JavadocParser.RULE_isindexTag + RULE_TYPES_OFFSET;
 
     /** Link html tag. */


### PR DESCRIPTION
Issue #14631 

Command Used
```
java -jar checkstyle-10.22.0-all.jar -J Test.java | sed "s/[[0-9]+:[0-9]+]//g"
```

Test.java
```
/**
 * <isindex prompt="search">
 */
public class Test {
}

```
```

$ java -jar checkstyle-10.22.0-all.jar -J Test.java | sed "s/\[[0-9]\+:[0-9]\+\]//g"
COMPILATION_UNIT -> COMPILATION_UNIT
`--CLASS_DEF -> CLASS_DEF
    |--MODIFIERS -> MODIFIERS
    |   |--BLOCK_COMMENT_BEGIN -> /*
    |   |   |--COMMENT_CONTENT -> *\r\n * <isindex prompt="search">\r\n
    |   |   |   `--JAVADOC -> JAVADOC
    |   |   |       |--NEWLINE -> \r\n
    |   |   |       |--LEADING_ASTERISK ->  *
    |   |   |       |--TEXT ->
    |   |   |       |--HTML_ELEMENT -> HTML_ELEMENT
    |   |   |       |   `--SINGLETON_ELEMENT -> SINGLETON_ELEMENT
    |   |   |       |       `--ISINDEX_TAG -> ISINDEX_TAG
    |   |   |       |           |--START -> <
    |   |   |       |           |--ISINDEX_HTML_TAG_NAME -> isindex
    |   |   |       |           |--WS ->
    |   |   |       |           |--ATTRIBUTE -> ATTRIBUTE
    |   |   |       |           |   |--HTML_TAG_NAME -> prompt
    |   |   |       |           |   |--EQUALS -> =
    |   |   |       |           |   `--ATTR_VALUE -> "search"
    |   |   |       |           `--END -> >
    |   |   |       |--NEWLINE -> \r\n
    |   |   |       |--TEXT ->
    |   |   |       `--EOF -> <EOF>
    |   |   `--BLOCK_COMMENT_END -> */
    |   `--LITERAL_PUBLIC -> public
    |--LITERAL_CLASS -> class
    |--IDENT -> Test
    `--OBJBLOCK -> OBJBLOCK
        |--LCURLY -> {
        `--RCURLY -> }

```
![Screenshot 2025-03-31 125309](https://github.com/user-attachments/assets/c00c7895-2a2b-494a-840d-86ba4a1d31bd)

