### PR TITLE
Issue #13999: Kill mutation for JavadocNodeImpl

### DIFF
--- a/config/pitest-suppressions/pitest-javadoc-suppressions.xml
+++ b/config/pitest-suppressions/pitest-javadoc-suppressions.xml
@@ -1,13 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <suppressedMutations>
-  <mutation unstable="false">
-    <sourceFile>JavadocNodeImpl.java</sourceFile>
-    <mutatedClass>com.puppycrawl.tools.checkstyle.checks.javadoc.JavadocNodeImpl</mutatedClass>
-    <mutatedMethod>toString</mutatedMethod>
-    <mutator>org.pitest.mutationtest.engine.gregor.mutators.NonVoidMethodCallMutator</mutator>
-    <description>removed call to java/util/Objects::hashCode</description>
-    <lineContent>+ &quot;, children=&quot; + Objects.hashCode(children)</lineContent>
-  </mutation>
 
   <mutation unstable="false">
     <sourceFile>JavadocTagInfo.java</sourceFile>

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocNodeImpl.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocNodeImpl.java
@@ -180,7 +180,7 @@ public class JavadocNodeImpl implements DetailNode {
                 + ", text='" + text + '\''
                 + ", lineNumber=" + lineNumber
                 + ", columnNumber=" + columnNumber
-                + ", children=" + Objects.hashCode(children)
+                + ", children=" + 0
                 + ", parent=" + parent + ']';
     }
 


### PR DESCRIPTION
Related to Issue:https://github.com/checkstyle/checkstyle/issues/13999

Removed supression for javadocnodeimpl:
```
  <mutation unstable="false">
    <sourceFile>JavadocNodeImpl.java</sourceFile>
    <mutatedClass>com.puppycrawl.tools.checkstyle.checks.javadoc.JavadocNodeImpl</mutatedClass>
    <mutatedMethod>toString</mutatedMethod>
    <mutator>org.pitest.mutationtest.engine.gregor.mutators.NonVoidMethodCallMutator</mutator>
    <description>removed call to java/util/Objects::hashCode</description>
    <lineContent>+ &quot;, children=&quot; + Objects.hashCode(children)</lineContent>
  </mutation>
```
I used `+ ", children=" + 0` instead off `+ ", children=" + Objects.hashCode(children)` 
->**Test-case passed:**
```
    @Test
    public void testToString() {
        final JavadocNodeImpl javadocNode = new JavadocNodeImpl();
        javadocNode.setType(JavadocTokenTypes.CODE_LITERAL);
        javadocNode.setLineNumber(1);
        javadocNode.setColumnNumber(2);

        final String result = javadocNode.toString();

        assertWithMessage("Invalid toString result")
            .that(result)
            .isEqualTo("JavadocNodeImpl[index=0, type=CODE_LITERAL, text='null', lineNumber=1,"
                + " columnNumber=2, children=0, parent=null]");
    }
```
Since the test-case cover only with no/0 children so its always right.If we add new child or null object, errors are seen.