### PR TITLE
Issue #11641: allow usage of simple name of checks in aliasList by SuppressWarningsHolder

### DIFF
--- a/config/checkstyle-examples-suppressions.xml
+++ b/config/checkstyle-examples-suppressions.xml
@@ -138,6 +138,10 @@
   <suppress checks="NewlineAtEndOfFile"
     files="newlineatendoffile[\\/]Example\d+.*"/>
 
+  <!-- We need to maintain indentation on xml part -->
+  <suppress checks="LineLength"
+    files="annotation[\\/]suppresswarningsholder[\\/]Example2.java"/>
+
   <!-- Example must show line length violations and suppressed violations -->
   <suppress checks="LineLength"
     files="suppresswithplaintextcommentfilter[\\/]Example9.java"/>

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/SuppressWarningsHolder.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/SuppressWarningsHolder.java
@@ -28,11 +28,14 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.regex.Pattern;
 
+import javax.annotation.Nullable;
+
 import com.puppycrawl.tools.checkstyle.StatelessCheck;
 import com.puppycrawl.tools.checkstyle.api.AbstractCheck;
 import com.puppycrawl.tools.checkstyle.api.AuditEvent;
 import com.puppycrawl.tools.checkstyle.api.DetailAST;
 import com.puppycrawl.tools.checkstyle.api.TokenTypes;
+import com.puppycrawl.tools.checkstyle.utils.CommonUtil;
 
 /**
  * <div>
@@ -123,6 +126,30 @@ public class SuppressWarningsHolder
     }
 
     /**
+     * Returns the alias of simple check name for a check, The alias is
+     * for the form of CheckNameCheck or CheckName.
+     *
+     * @param sourceName the source name of the check (generally the class
+     *        name)
+     * @return the alias of the simple check name for the given check
+     */
+    @Nullable
+    private static String getSimpleNameAlias(String sourceName) {
+        final String checkName = CommonUtil.baseClassName(sourceName);
+        final String checkNameSuffix = "Check";
+        // check alias for the CheckNameCheck
+        String checkAlias = CHECK_ALIAS_MAP.get(checkName);
+        if (checkAlias == null && checkName.endsWith(checkNameSuffix)) {
+            final int checkStartIndex = checkName.length() - checkNameSuffix.length();
+            final String checkNameWithoutSuffix = checkName.substring(0, checkStartIndex);
+            // check alias for the CheckName
+            checkAlias = CHECK_ALIAS_MAP.get(checkNameWithoutSuffix);
+        }
+
+        return checkAlias;
+    }
+
+    /**
      * Returns the alias for the source name of a check. If an alias has been
      * explicitly registered via {@link #setAliasList(String...)}, that
      * alias is returned; otherwise, the default alias is used.
@@ -133,6 +160,9 @@ public class SuppressWarningsHolder
      */
     public static String getAlias(String sourceName) {
         String checkAlias = CHECK_ALIAS_MAP.get(sourceName);
+        if (checkAlias == null) {
+            checkAlias = getSimpleNameAlias(sourceName);
+        }
         if (checkAlias == null) {
             checkAlias = getDefaultAlias(sourceName);
         }

--- a/src/site/xdoc/checks/annotation/suppresswarningsholder.xml
+++ b/src/site/xdoc/checks/annotation/suppresswarningsholder.xml
@@ -50,14 +50,13 @@
         <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
 &lt;module name="Checker"&gt;
   &lt;module name="TreeWalker"&gt;
-  &lt;module name="MemberName"/&gt;
-  &lt;module name="ConstantName"/&gt;
-  &lt;module name="ParameterNumber"&gt;
-    &lt;property name="id" value="ParamNumberId"/&gt;
-  &lt;/module&gt;
-  &lt;module name=
-    "NoWhitespaceAfter"/&gt;
-  &lt;module name="SuppressWarningsHolder"/&gt;
+    &lt;module name="MemberName"/&gt;
+    &lt;module name="ConstantName"/&gt;
+    &lt;module name="ParameterNumber"&gt;
+      &lt;property name="id" value="ParamNumberId"/&gt;
+    &lt;/module&gt;
+    &lt;module name="NoWhitespaceAfter"/&gt;
+    &lt;module name="SuppressWarningsHolder"/&gt;
   &lt;/module&gt;
   &lt;module name="SuppressWarningsFilter"/&gt;
 &lt;/module&gt;
@@ -91,17 +90,18 @@ class Example1 {
         </p>
         <p id="Example2-config">
           If <code>aliasList</code> property was provided you can use your own names e.g. below
-          code will work if there was provided a <code>ParameterNumberCheck=paramnum</code> in
-          the <code>aliasList</code>:
+          code will work if there was provided a
+          <code>com.puppycrawl.tools.checkstyle.checks.sizes.ParameterNumberCheck=paramnum</code>
+          in the <code>aliasList</code>:
         </p>
         <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
 &lt;module name="Checker"&gt;
   &lt;module name="TreeWalker"&gt;
-  &lt;module name="ParameterNumber"/&gt;
-  &lt;module name="SuppressWarningsHolder"&gt;
-    &lt;property name="aliasList" value=
-      "com.puppycrawl.tools.checkstyle.checks.sizes.ParameterNumberCheck=paramnum"/&gt;
-  &lt;/module&gt;
+    &lt;module name="ParameterNumber"/&gt;
+    &lt;module name="SuppressWarningsHolder"&gt;
+      &lt;property name="aliasList"
+        value="com.puppycrawl.tools.checkstyle.checks.sizes.ParameterNumberCheck=paramnum"/&gt;
+    &lt;/module&gt;
   &lt;/module&gt;
   &lt;module name="SuppressWarningsFilter"/&gt;
 &lt;/module&gt;
@@ -109,6 +109,70 @@ class Example1 {
         <p id="Example2-code">Example:</p>
         <div class="wrapper"><pre class="prettyprint"><code class="language-java">
 class Example2 {
+  // violation below, 'More than 7 parameters (found 8)'
+  public void needsLotsOfParameters (int a,
+    int b, int c, int d, int e, int f, int g, int h) {
+    // ...
+  }
+
+  @SuppressWarnings("paramnum")
+  public void needsLotsOfParameters1 (int a, // violation suppressed
+    int b, int c, int d, int e, int f, int g, int h) {
+    // ...
+  }
+
+}
+</code></pre></div>
+        <p id="Example3-config">
+          You can also use simple check name like <code>ParameterNumberCheck=paramnum</code>
+          instead to use fully qualified name of check in the <code>aliasList</code>:
+        </p>
+        <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
+&lt;module name="Checker"&gt;
+  &lt;module name="TreeWalker"&gt;
+    &lt;module name="ParameterNumber"/&gt;
+    &lt;module name="SuppressWarningsHolder"&gt;
+      &lt;property name="aliasList" value="ParameterNumberCheck=paramnum"/&gt;
+    &lt;/module&gt;
+  &lt;/module&gt;
+  &lt;module name="SuppressWarningsFilter"/&gt;
+&lt;/module&gt;
+</code></pre></div>
+        <p id="Example3-code">Example:</p>
+        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+public class Example3 {
+  // violation below, 'More than 7 parameters (found 8)'
+  public void needsLotsOfParameters (int a,
+    int b, int c, int d, int e, int f, int g, int h) {
+    // ...
+  }
+
+  @SuppressWarnings("paramnum")
+  public void needsLotsOfParameters1 (int a, // violation suppressed
+    int b, int c, int d, int e, int f, int g, int h) {
+    // ...
+  }
+
+}
+</code></pre></div>
+        <p id="Example4-config">
+          The check can also be used without suffix of &quot;Check&quot; like
+          <code>ParameterNumber=paramnum</code> in the <code>aliasList</code>:
+        </p>
+        <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
+&lt;module name="Checker"&gt;
+  &lt;module name="TreeWalker"&gt;
+    &lt;module name="ParameterNumber"/&gt;
+    &lt;module name="SuppressWarningsHolder"&gt;
+      &lt;property name="aliasList" value="ParameterNumber=paramnum"/&gt;
+    &lt;/module&gt;
+  &lt;/module&gt;
+  &lt;module name="SuppressWarningsFilter"/&gt;
+&lt;/module&gt;
+</code></pre></div>
+        <p id="Example4-code">Example:</p>
+        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+public class Example4 {
   // violation below, 'More than 7 parameters (found 8)'
   public void needsLotsOfParameters (int a,
     int b, int c, int d, int e, int f, int g, int h) {

--- a/src/site/xdoc/checks/annotation/suppresswarningsholder.xml.template
+++ b/src/site/xdoc/checks/annotation/suppresswarningsholder.xml.template
@@ -52,8 +52,9 @@
         </p>
         <p id="Example2-config">
           If <code>aliasList</code> property was provided you can use your own names e.g. below
-          code will work if there was provided a <code>ParameterNumberCheck=paramnum</code> in
-          the <code>aliasList</code>:
+          code will work if there was provided a
+          <code>com.puppycrawl.tools.checkstyle.checks.sizes.ParameterNumberCheck=paramnum</code>
+          in the <code>aliasList</code>:
         </p>
         <macro name="example">
           <param name="path"
@@ -64,6 +65,36 @@
         <macro name="example">
           <param name="path"
                  value="resources/com/puppycrawl/tools/checkstyle/checks/annotation/suppresswarningsholder/Example2.java"/>
+          <param name="type" value="code"/>
+        </macro>
+        <p id="Example3-config">
+          You can also use simple check name like <code>ParameterNumberCheck=paramnum</code>
+          instead to use fully qualified name of check in the <code>aliasList</code>:
+        </p>
+        <macro name="example">
+          <param name="path"
+                 value="resources/com/puppycrawl/tools/checkstyle/checks/annotation/suppresswarningsholder/Example3.java"/>
+          <param name="type" value="config"/>
+        </macro>
+        <p id="Example3-code">Example:</p>
+        <macro name="example">
+          <param name="path"
+                 value="resources/com/puppycrawl/tools/checkstyle/checks/annotation/suppresswarningsholder/Example3.java"/>
+          <param name="type" value="code"/>
+        </macro>
+        <p id="Example4-config">
+          The check can also be used without suffix of &quot;Check&quot; like
+          <code>ParameterNumber=paramnum</code> in the <code>aliasList</code>:
+        </p>
+        <macro name="example">
+          <param name="path"
+                 value="resources/com/puppycrawl/tools/checkstyle/checks/annotation/suppresswarningsholder/Example4.java"/>
+          <param name="type" value="config"/>
+        </macro>
+        <p id="Example4-code">Example:</p>
+        <macro name="example">
+          <param name="path"
+                 value="resources/com/puppycrawl/tools/checkstyle/checks/annotation/suppresswarningsholder/Example4.java"/>
           <param name="type" value="code"/>
         </macro>
 

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/SuppressWarningsHolderTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/SuppressWarningsHolderTest.java
@@ -21,6 +21,7 @@ package com.puppycrawl.tools.checkstyle.checks;
 
 import static com.google.common.truth.Truth.assertWithMessage;
 import static com.puppycrawl.tools.checkstyle.checks.coding.UnusedLocalVariableCheck.MSG_UNUSED_LOCAL_VARIABLE;
+import static com.puppycrawl.tools.checkstyle.checks.sizes.LineLengthCheck.MSG_KEY;
 
 import java.io.File;
 import java.lang.reflect.Constructor;
@@ -44,6 +45,8 @@ import com.puppycrawl.tools.checkstyle.checks.coding.UnusedLocalVariableCheck;
 import com.puppycrawl.tools.checkstyle.checks.naming.AbstractNameCheck;
 import com.puppycrawl.tools.checkstyle.checks.naming.ConstantNameCheck;
 import com.puppycrawl.tools.checkstyle.checks.naming.MemberNameCheck;
+import com.puppycrawl.tools.checkstyle.checks.naming.MethodNameCheck;
+import com.puppycrawl.tools.checkstyle.checks.sizes.LineLengthCheck;
 import com.puppycrawl.tools.checkstyle.checks.sizes.ParameterNumberCheck;
 import com.puppycrawl.tools.checkstyle.checks.whitespace.AbstractParenPadCheck;
 import com.puppycrawl.tools.checkstyle.checks.whitespace.TypecastParenPadCheck;
@@ -514,6 +517,83 @@ public class SuppressWarningsHolderTest extends AbstractModuleTestSupport {
 
         verifyWithInlineConfigParser(
                 getPath("InputSuppressWarningsHolderAlias2.java"),
+                expected);
+    }
+
+    @Test
+    public void testAliasList3() throws Exception {
+        final String[] expected = {
+            "16:17: " + getCheckMessage(ParameterNumberCheck.class,
+                    ParameterNumberCheck.MSG_KEY, 7, 8),
+            "28:17: " + getCheckMessage(ParameterNumberCheck.class,
+                    ParameterNumberCheck.MSG_KEY, 7, 8),
+        };
+
+        verifyWithInlineConfigParser(
+                getPath("InputSuppressWarningsHolderAlias5.java"),
+                expected);
+    }
+
+    @Test
+    public void testAliasList4() throws Exception {
+        final String pattern = "^[A-Z][A-Z0-9]*(_[A-Z0-9]+)*$";
+        final String[] expected = {
+            "16:30: " + getCheckMessage(ConstantNameCheck.class,
+                AbstractNameCheck.MSG_INVALID_PATTERN, "a", pattern),
+            "19:30: " + getCheckMessage(ConstantNameCheck.class,
+                AbstractNameCheck.MSG_INVALID_PATTERN, "b", pattern),
+        };
+
+        verifyWithInlineConfigParser(
+                getPath("InputSuppressWarningsHolderAlias4.java"),
+                expected);
+    }
+
+    @Test
+    public void testAliasList5() throws Exception {
+        final String[] expected = {
+            "18: " + getCheckMessage(LineLengthCheck.class, MSG_KEY, 80, 83),
+            "28: " + getCheckMessage(LineLengthCheck.class, MSG_KEY, 75, 96),
+            "28: " + getCheckMessage(LineLengthCheck.class, MSG_KEY, 80, 96),
+            "58: " + getCheckMessage(LineLengthCheck.class, MSG_KEY, 75, 76),
+            "65: " + getCheckMessage(LineLengthCheck.class, MSG_KEY, 75, 87),
+        };
+
+        verifyWithInlineConfigParser(
+                getPath("InputSuppressWarningsHolderAlias6.java"),
+                expected);
+    }
+
+    @Test
+    public void testAliasList6() throws Exception {
+        final String pattern1 = "^[a-z][a-zA-Z0-9]*$";
+        final String pattern2 = "^[A-Z][a-zA-Z0-9]*$";
+
+        final String[] expected = {
+            "25:18: " + getCheckMessage(MethodNameCheck.class,
+                    AbstractNameCheck.MSG_INVALID_PATTERN, "Method3", pattern1),
+            "30:20: " + getCheckMessage(MethodNameCheck.class,
+                    AbstractNameCheck.MSG_INVALID_PATTERN, "Method5", pattern1),
+            "35:17: " + getCheckMessage(MethodNameCheck.class,
+                    AbstractNameCheck.MSG_INVALID_PATTERN, "method7", pattern2),
+            "40:18: " + getCheckMessage(MethodNameCheck.class,
+                    AbstractNameCheck.MSG_INVALID_PATTERN, "method9", pattern2),
+            "45:20: " + getCheckMessage(MethodNameCheck.class,
+                    AbstractNameCheck.MSG_INVALID_PATTERN, "method11", pattern2),
+            "47:17: " + getCheckMessage(MethodNameCheck.class,
+                    AbstractNameCheck.MSG_INVALID_PATTERN, "_methodCheck1", pattern2),
+            "53:18: " + getCheckMessage(MethodNameCheck.class,
+                    AbstractNameCheck.MSG_INVALID_PATTERN, "_methodCheck3", pattern2),
+            "53:18: " + getCheckMessage(MethodNameCheck.class,
+                    AbstractNameCheck.MSG_INVALID_PATTERN, "_methodCheck3", pattern1),
+            "61:20: " + getCheckMessage(MethodNameCheck.class,
+                    AbstractNameCheck.MSG_INVALID_PATTERN, "_methodCheck5", pattern2),
+            "61:20: " + getCheckMessage(MethodNameCheck.class,
+                    AbstractNameCheck.MSG_INVALID_PATTERN, "_methodCheck5", pattern1),
+        };
+
+        verifyWithInlineConfigParser(
+                getPath("InputSuppressWarningsHolderAlias7.java"),
                 expected);
     }
 

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/suppresswarningsholder/InputSuppressWarningsHolderAlias4.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/suppresswarningsholder/InputSuppressWarningsHolderAlias4.java
@@ -1,0 +1,26 @@
+/*
+com.puppycrawl.tools.checkstyle.checks.SuppressWarningsHolder
+aliasList = ConstantNameCheck=constant
+
+com.puppycrawl.tools.checkstyle.filters.SuppressWarningsFilter
+
+com.puppycrawl.tools.checkstyle.checks.naming.ConstantNameCheck
+format = (default)^[A-Z][A-Z0-9]*(_[A-Z0-9]+)*$
+
+
+*/
+
+package com.puppycrawl.tools.checkstyle.checks.suppresswarningsholder;
+
+public class InputSuppressWarningsHolderAlias4 {
+    private static final int a = 0; // violation 'Name 'a' must match pattern'
+
+    @SuppressWarnings("Notconstant")
+    private static final int b = 0; // violation 'Name 'b' must match pattern'
+
+    @SuppressWarnings("CONSTANT") // filtered violation 'invalid pattern'
+    private static final int c = 0;
+
+    @SuppressWarnings("CONstant") // filtered violation 'invalid pattern'
+    private static final int d = 0;
+}

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/suppresswarningsholder/InputSuppressWarningsHolderAlias5.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/suppresswarningsholder/InputSuppressWarningsHolderAlias5.java
@@ -1,0 +1,44 @@
+/*
+com.puppycrawl.tools.checkstyle.checks.SuppressWarningsHolder
+aliasList = ParameterNumber=paramnum
+
+com.puppycrawl.tools.checkstyle.filters.SuppressWarningsFilter
+
+com.puppycrawl.tools.checkstyle.checks.sizes.ParameterNumberCheck
+max = (default)7
+
+
+*/
+
+package com.puppycrawl.tools.checkstyle.checks.suppresswarningsholder;
+
+public class InputSuppressWarningsHolderAlias5 {
+    public void needsLotsOfParameters0(int a, // violation 'More than 7 parameters (found 8)'
+        int b, int c, int d, int e, int f, int g, int h) {
+        // ...
+    }
+
+    @SuppressWarnings("paramnum")
+    public void needsLotsOfParameters(int a, // filtered violation 'max parameter'
+        int b, int c, int d, int e, int f, int g, int h) {
+        // ...
+    }
+
+    @SuppressWarnings("ParamnumUnknown")
+    public void needsLotsOfParameters2(int a, // violation 'More than 7 parameters (found 8)'
+        int b, int c, int d, int e, int f, int g, int h) {
+        // ...
+    }
+
+    @SuppressWarnings("PAramnuM")
+    public void needsLotsOfParameters3(int a, // filtered violation 'max parameter'
+        int b, int c, int d, int e, int f, int g, int h) {
+        // ...
+    }
+
+    @SuppressWarnings("PARAMNUM")
+    public void needsLotsOfParameters4(int a, // filtered violation 'max parameter'
+        int b, int c, int d, int e, int f, int g, int h) {
+        // ...
+    }
+}

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/suppresswarningsholder/InputSuppressWarningsHolderAlias6.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/suppresswarningsholder/InputSuppressWarningsHolderAlias6.java
@@ -1,0 +1,82 @@
+/*
+com.puppycrawl.tools.checkstyle.checks.SuppressWarningsHolder
+aliasList = LineLengthCheck=line
+
+com.puppycrawl.tools.checkstyle.filters.SuppressWarningsFilter
+
+com.puppycrawl.tools.checkstyle.checks.sizes.LineLengthCheck
+ignorePattern = ^ *\\* *[^ ]+$
+
+com.puppycrawl.tools.checkstyle.checks.sizes.LineLengthCheck
+max = 75
+
+
+*/
+
+package com.puppycrawl.tools.checkstyle.checks.suppresswarningsholder;
+
+import static com.puppycrawl.tools.checkstyle.checks.sizes.LineLengthCheck.MSG_KEY;
+// violation above, 'Line is longer than 80 characters'
+
+
+public class InputSuppressWarningsHolderAlias6 {
+
+    void testMethod(String str) {
+        str = MSG_KEY;
+        System.out.println("This is a short line.");
+
+        System.out.println("This line is long and exceeds the default limit of 80 characters.");
+        // 2 violations above:
+        //  'Line is longer than 75 characters'
+        //  'Line is longer than 80 characters'
+    }
+
+    @SuppressWarnings("Line")
+    void testMethod2(String str) {
+        str = MSG_KEY;
+        System.out.println("This is a short line.");
+
+        System.out.println("This line is long and exceeds the default limit of 80 characters.");
+        // filtered 2 violations above:
+        //  'Line is longer than 75 characters'
+        //  'Line is longer than 80 characters'
+    }
+
+    @SuppressWarnings("LIne")
+    void testMethod3(String str) {
+        str = MSG_KEY;
+        System.out.println("This is a short line.");
+
+        System.out.println("This line exceeds the limit of 75 characters.");
+        // filtered violation above, 'Line is longer than 75 characters'
+    }
+
+    void testMethod4(String str) {
+        str = MSG_KEY;
+        System.out.println("This is a short line.");
+
+        System.out.println("This line exceeds the limit of 75 characters.");
+        // violation above, 'Line is longer than 75 characters'
+    }
+
+    // violation 3 lines below 'Line is longer than 75 characters'
+    /**
+    * This is a short Javadoc comment.
+    * ThisJavadocCommentIsAReallyLongWordThatExceedsDefaultLineLimitOfEightyCharacters.
+    */
+    void testMethod5(String str) {
+        str = MSG_KEY;
+        System.out.println("This is a short line.");
+    }
+
+    @SuppressWarnings("LINE")
+    // filtered violation 3 lines below, 'Line is longer than 75 characters'
+    /**
+    * This is a short Javadoc comment.
+    * ThisJavadocCommentIsAReallyLongWordThatExceedsDefaultLineLimitOfEightyCharacters.
+    */
+    void testMethod6(String str) {
+        str = MSG_KEY;
+        System.out.println("This is a short line.");
+    }
+}

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/suppresswarningsholder/InputSuppressWarningsHolderAlias7.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/suppresswarningsholder/InputSuppressWarningsHolderAlias7.java
@@ -1,0 +1,69 @@
+/*
+com.puppycrawl.tools.checkstyle.checks.SuppressWarningsHolder
+aliasList = MethodName=name
+
+com.puppycrawl.tools.checkstyle.filters.SuppressWarningsFilter
+
+com.puppycrawl.tools.checkstyle.checks.naming.MethodNameCheck
+format = ^[A-Z][a-zA-Z0-9]*$
+
+com.puppycrawl.tools.checkstyle.checks.naming.MethodNameCheck
+applyToPublic = false
+
+
+*/
+
+package com.puppycrawl.tools.checkstyle.checks.suppresswarningsholder;
+
+public class InputSuppressWarningsHolderAlias7 {
+
+    public void Method1() {}
+
+    @SuppressWarnings("Name")
+    private void Method2() {}
+
+    private void Method3() {} // violation 'Name 'Method3' must match pattern.'
+
+    @SuppressWarnings("NAme")
+    protected void Method4() {}
+
+    protected void Method5() {} // violation 'Name 'Method5' must match pattern.'
+
+    @SuppressWarnings("NaMe")
+    public void method6() {}
+
+    public void method7() {} // violation 'Name 'method7' must match pattern.'
+
+    @SuppressWarnings("NAME")
+    private void method8() {}
+
+    private void method9() {} // violation 'Name 'method9' must match pattern.'
+
+    @SuppressWarnings("NAME")
+    protected void method10() {}
+
+    protected void method11() {} // violation 'Name 'method11' must match pattern.'
+
+    public void _methodCheck1() {}
+    // violation above 'Name '_methodCheck1' must match pattern.'
+
+    @SuppressWarnings("name")
+    public void _methodCheck2() {}
+
+    private void _methodCheck3() {}
+    // 2 violations above:
+    //  'Name '_methodCheck3' must match pattern.'
+    //  'Name '_methodCheck3' must match pattern.'
+
+    @SuppressWarnings("NAME")
+    private void _methodCheck4() {}
+
+    protected void _methodCheck5() {}
+    // 2 violations above:
+    //  'Name '_methodCheck5' must match pattern.'
+    //  'Name '_methodCheck5' must match pattern.'
+
+    @SuppressWarnings("Name")
+    protected void _methodCheck6() {}
+
+}

--- a/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/checks/annotation/SuppressWarningsHolderExamplesTest.java
+++ b/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/checks/annotation/SuppressWarningsHolderExamplesTest.java
@@ -39,13 +39,13 @@ public class SuppressWarningsHolderExamplesTest extends AbstractExamplesModuleTe
         final String pattern1 = "^[a-z][a-zA-Z0-9]*$";
         final String pattern2 = "^[A-Z][A-Z0-9]*(_[A-Z0-9]+)*$";
         final String[] expected = {
-            "21:15: " + getCheckMessage(MemberNameCheck.class,
+            "20:15: " + getCheckMessage(MemberNameCheck.class,
                         AbstractNameCheck.MSG_INVALID_PATTERN, "K", pattern1),
-            "25:28: " + getCheckMessage(ConstantNameCheck.class,
+            "24:28: " + getCheckMessage(ConstantNameCheck.class,
                         AbstractNameCheck.MSG_INVALID_PATTERN, "i", pattern2),
-            "35:15: " + getCheckMessage(NoWhitespaceAfterCheck.class,
+            "34:15: " + getCheckMessage(NoWhitespaceAfterCheck.class,
                         NoWhitespaceAfterCheck.MSG_KEY, "int"),
-            "35:18: " + getCheckMessage(MemberNameCheck.class,
+            "34:18: " + getCheckMessage(MemberNameCheck.class,
                         AbstractNameCheck.MSG_INVALID_PATTERN, "ARR", pattern1),
 
         };
@@ -62,5 +62,25 @@ public class SuppressWarningsHolderExamplesTest extends AbstractExamplesModuleTe
         };
 
         verifyWithInlineConfigParser(getPath("Example2.java"), expected);
+    }
+
+    @Test
+    public void testExample3() throws Exception {
+        final String[] expected = {
+            "18:15: " + getCheckMessage(ParameterNumberCheck.class,
+                        ParameterNumberCheck.MSG_KEY, 7, 8),
+        };
+
+        verifyWithInlineConfigParser(getPath("Example3.java"), expected);
+    }
+
+    @Test
+    public void testExample4() throws Exception {
+        final String[] expected = {
+            "18:15: " + getCheckMessage(ParameterNumberCheck.class,
+                        ParameterNumberCheck.MSG_KEY, 7, 8),
+        };
+
+        verifyWithInlineConfigParser(getPath("Example4.java"), expected);
     }
 }

--- a/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/annotation/suppresswarningsholder/Example1.java
+++ b/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/annotation/suppresswarningsholder/Example1.java
@@ -1,14 +1,13 @@
 /*xml
 <module name="Checker">
   <module name="TreeWalker">
-  <module name="MemberName"/>
-  <module name="ConstantName"/>
-  <module name="ParameterNumber">
-    <property name="id" value="ParamNumberId"/>
-  </module>
-  <module name=
-    "NoWhitespaceAfter"/>
-  <module name="SuppressWarningsHolder"/>
+    <module name="MemberName"/>
+    <module name="ConstantName"/>
+    <module name="ParameterNumber">
+      <property name="id" value="ParamNumberId"/>
+    </module>
+    <module name="NoWhitespaceAfter"/>
+    <module name="SuppressWarningsHolder"/>
   </module>
   <module name="SuppressWarningsFilter"/>
 </module>

--- a/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/annotation/suppresswarningsholder/Example3.java
+++ b/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/annotation/suppresswarningsholder/Example3.java
@@ -3,8 +3,7 @@
   <module name="TreeWalker">
     <module name="ParameterNumber"/>
     <module name="SuppressWarningsHolder">
-      <property name="aliasList"
-        value="com.puppycrawl.tools.checkstyle.checks.sizes.ParameterNumberCheck=paramnum"/>
+      <property name="aliasList" value="ParameterNumberCheck=paramnum"/>
     </module>
   </module>
   <module name="SuppressWarningsFilter"/>
@@ -14,7 +13,7 @@
 package com.puppycrawl.tools.checkstyle.checks.annotation.suppresswarningsholder;
 
 // xdoc section -- start
-class Example2 {
+public class Example3 {
   // violation below, 'More than 7 parameters (found 8)'
   public void needsLotsOfParameters (int a,
     int b, int c, int d, int e, int f, int g, int h) {

--- a/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/annotation/suppresswarningsholder/Example4.java
+++ b/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/annotation/suppresswarningsholder/Example4.java
@@ -3,8 +3,7 @@
   <module name="TreeWalker">
     <module name="ParameterNumber"/>
     <module name="SuppressWarningsHolder">
-      <property name="aliasList"
-        value="com.puppycrawl.tools.checkstyle.checks.sizes.ParameterNumberCheck=paramnum"/>
+      <property name="aliasList" value="ParameterNumber=paramnum"/>
     </module>
   </module>
   <module name="SuppressWarningsFilter"/>
@@ -14,7 +13,7 @@
 package com.puppycrawl.tools.checkstyle.checks.annotation.suppresswarningsholder;
 
 // xdoc section -- start
-class Example2 {
+public class Example4 {
   // violation below, 'More than 7 parameters (found 8)'
   public void needsLotsOfParameters (int a,
     int b, int c, int d, int e, int f, int g, int h) {


### PR DESCRIPTION
Issue #11641 

Allow SuppressWarningsHolder to use simple name of checks in aliasList

simple name of checks like CheckNameCheck and CheckName will now also allow in aliasList.

Added the test cases:
  - with the suppressed check NOT having "Check' appended to the end of the name, ex: https://github.com/checkstyle/checkstyle/issues/11641#issuecomment-1127006448
  - a case with two modules of the same check, with different configs, and show that we filter out unique violations for each