### PR TITLE
Issue #16155: use nio api in XpathFileGeneratorAuditListener

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/XpathFileGeneratorAuditListener.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/XpathFileGeneratorAuditListener.java
@@ -19,11 +19,11 @@
 
 package com.puppycrawl.tools.checkstyle;
 
-import java.io.File;
 import java.io.OutputStream;
 import java.io.OutputStreamWriter;
 import java.io.PrintWriter;
 import java.nio.charset.StandardCharsets;
+import java.nio.file.Path;
 
 import com.puppycrawl.tools.checkstyle.api.AuditEvent;
 import com.puppycrawl.tools.checkstyle.api.AuditListener;
@@ -96,11 +96,11 @@ public class XpathFileGeneratorAuditListener
         if (xpathQuery != null) {
             printXmlHeader();
 
-            final File file = new File(event.getFileName());
+            final Path path = Path.of(event.getFileName());
 
             writer.println("<suppress-xpath");
             writer.print("       files=\"");
-            writer.print(file.getName());
+            writer.print(path.getFileName());
             writer.println(QUOTE_CHAR);
 
             if (event.getModuleId() == null) {


### PR DESCRIPTION
Fixed Issue #16155 

Removed the `File` API usage in favour of nio `Path` API.