### PR TITLE
Issue #14019: Cover pitest survivals in SuppressionStringPrinter

### DIFF
--- a/config/pitest-suppressions/pitest-tree-walker-suppressions.xml
+++ b/config/pitest-suppressions/pitest-tree-walker-suppressions.xml
@@ -37,24 +37,6 @@
   </mutation>
 
   <mutation unstable="false">
-    <sourceFile>SuppressionsStringPrinter.java</sourceFile>
-    <mutatedClass>com.puppycrawl.tools.checkstyle.SuppressionsStringPrinter</mutatedClass>
-    <mutatedMethod>printSuppressions</mutatedMethod>
-    <mutator>org.pitest.mutationtest.engine.gregor.mutators.NonVoidMethodCallMutator</mutator>
-    <description>removed call to java/nio/charset/Charset::name</description>
-    <lineContent>System.getProperty(&quot;file.encoding&quot;, StandardCharsets.UTF_8.name()));</lineContent>
-  </mutation>
-
-  <mutation unstable="false">
-    <sourceFile>SuppressionsStringPrinter.java</sourceFile>
-    <mutatedClass>com.puppycrawl.tools.checkstyle.SuppressionsStringPrinter</mutatedClass>
-    <mutatedMethod>printSuppressions</mutatedMethod>
-    <mutator>org.pitest.mutationtest.engine.gregor.mutators.experimental.ArgumentPropagationMutator</mutator>
-    <description>replaced call to java/lang/System::getProperty with argument</description>
-    <lineContent>System.getProperty(&quot;file.encoding&quot;, StandardCharsets.UTF_8.name()));</lineContent>
-  </mutation>
-
-  <mutation unstable="false">
     <sourceFile>TreeWalker.java</sourceFile>
     <mutatedClass>com.puppycrawl.tools.checkstyle.TreeWalker</mutatedClass>
     <mutatedMethod>createNewCheckSortedSet</mutatedMethod>

--- a/src/main/java/com/puppycrawl/tools/checkstyle/SuppressionsStringPrinter.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/SuppressionsStringPrinter.java
@@ -21,7 +21,6 @@ package com.puppycrawl.tools.checkstyle;
 
 import java.io.File;
 import java.io.IOException;
-import java.nio.charset.StandardCharsets;
 import java.util.List;
 import java.util.Locale;
 import java.util.regex.Matcher;
@@ -73,8 +72,7 @@ public final class SuppressionsStringPrinter {
             throw new IllegalStateException(exceptionMsg);
         }
 
-        final FileText fileText = new FileText(file,
-                System.getProperty("file.encoding", StandardCharsets.UTF_8.name()));
+        final FileText fileText = new FileText(file, System.getProperty("file.encoding"));
         final DetailAST detailAST =
                 JavaParser.parseFileText(fileText, JavaParser.Options.WITH_COMMENTS);
         final int lineNumber = Integer.parseInt(matcher.group(1));


### PR DESCRIPTION
Issue: #14019

**Mutations killed**

 ```
<mutation unstable="false">
    <sourceFile>SuppressionsStringPrinter.java</sourceFile>
    <mutatedClass>com.puppycrawl.tools.checkstyle.SuppressionsStringPrinter</mutatedClass>
    <mutatedMethod>printSuppressions</mutatedMethod>
    <mutator>org.pitest.mutationtest.engine.gregor.mutators.NonVoidMethodCallMutator</mutator>
    <description>removed call to java/nio/charset/Charset::name</description>
    <lineContent>System.getProperty(&quot;file.encoding&quot;, StandardCharsets.UTF_8.name()));</lineContent>
  </mutation>

  <mutation unstable="false">
    <sourceFile>SuppressionsStringPrinter.java</sourceFile>
    <mutatedClass>com.puppycrawl.tools.checkstyle.SuppressionsStringPrinter</mutatedClass>
    <mutatedMethod>printSuppressions</mutatedMethod>
    <mutator>org.pitest.mutationtest.engine.gregor.mutators.experimental.ArgumentPropagationMutator</mutator>
    <description>replaced call to java/lang/System::getProperty with argument</description>
    <lineContent>System.getProperty(&quot;file.encoding&quot;, StandardCharsets.UTF_8.name()));</lineContent>
  </mutation>
```


```
mvn clean verify
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  24:56 min
[INFO] Finished at: 2025-03-31T19:43:37+05:30
[INFO] --------------------------------
```

