### PR TITLE
Issue #15098: Indentation of switch block when no braces is now validated

### DIFF
--- a/config/jsoref-spellchecker/whitelist.words
+++ b/config/jsoref-spellchecker/whitelist.words
@@ -1075,6 +1075,7 @@ Popup
 Postgresql
 ppc
 prebuilts
+prefs
 PRESIZE
 prettyprint
 printf

--- a/src/it/java/com/google/checkstyle/test/chapter4formatting/rule4841indentation/IndentationTest.java
+++ b/src/it/java/com/google/checkstyle/test/chapter4formatting/rule4841indentation/IndentationTest.java
@@ -99,4 +99,14 @@ public class IndentationTest extends AbstractIndentationTestSupport {
     public void testSwitchOnTheStartOfTheLine() throws Exception {
         verifyWithWholeConfig(getNonCompilablePath("InputSwitchOnStartOfTheLine.java"));
     }
+
+    @Test
+    public void testSingleSwitchStatementWithoutCurly() throws Exception {
+        verifyWithWholeConfig(getNonCompilablePath("InputSingleSwitchStatementWithoutCurly.java"));
+    }
+
+    @Test
+    public void testSwitchWrappingIndentation() throws Exception {
+        verifyWithWholeConfig(getNonCompilablePath("InputSwitchWrappingIndentation.java"));
+    }
 }

--- a/src/it/resources-noncompilable/com/google/checkstyle/test/chapter4formatting/rule4841indentation/InputSingleSwitchStatementWithoutCurly.java
+++ b/src/it/resources-noncompilable/com/google/checkstyle/test/chapter4formatting/rule4841indentation/InputSingleSwitchStatementWithoutCurly.java
@@ -1,0 +1,60 @@
+package com.google.checkstyle.test.chapter4formatting.rule42blockindentation;
+
+/**some javadoc.*/
+public class InputSingleSwitchStatementWithoutCurly { 
+  void testCorrectIndentation(int obj) {
+    switch (obj) {
+      case 0
+          ->
+              System.out.println("Test");
+      case 1 ->
+          System.out.println("TEST");
+      case 2 -> {
+        System.out.println("Test");
+      }
+      default -> System.out.println("test");
+    }
+  }
+  
+  void testIncorrectIndentation(int obj) {
+    switch (obj) {
+      case 1
+      ->                            // violation '.* incorrect indentation level 6, expected .* 10.'
+      System.out.println("Test");
+      // violation above '.* incorrect indentation level 6, expected .* 14.'
+    case 2 ->                      // violation '.* incorrect indentation level 4, expected .* 6.'
+System.out.println("Test");        // violation '.* incorrect indentation level 0, expected .* 10.'
+      default -> System.out.println("test");
+    }
+  }
+
+  void testMixedCases(int obj) {
+    switch (obj) {
+      case 1 -> System.out.println("TEST");
+      case 2
+          -> System.out.println("Test");
+      case 3 ->
+                    System.out.println("Test");
+      // violation above '.* incorrect indentation level 20, expected .* 10.'
+      case 4 -> {
+        System.out.println("Test");
+      System.out.println("Another statement");
+      // violation above '.* incorrect indentation level 6, expected .* 8.'
+      }
+      default -> System.out.println("test");
+    }
+  }
+  
+  private boolean testLineWrapping(int x, int y, int z) {
+    return switch (x) {
+      case 1 -> true;
+      case 2 -> x != y
+          && y != 5;
+      case 3 ->
+          y != 4
+            && z != 2
+            && y != z;
+      default -> false;
+    };
+  }
+}

--- a/src/it/resources-noncompilable/com/google/checkstyle/test/chapter4formatting/rule4841indentation/InputSingleSwitchStatementWithoutCurlyCorrect.java
+++ b/src/it/resources-noncompilable/com/google/checkstyle/test/chapter4formatting/rule4841indentation/InputSingleSwitchStatementWithoutCurlyCorrect.java
@@ -1,0 +1,57 @@
+package com.google.checkstyle.test.chapter4formatting.rule42blockindentation;
+
+/**some javadoc.*/
+public class InputSingleSwitchStatementWithoutCurlyCorrect {
+  void testCorrectIndentation(int obj) {
+    switch (obj) {
+      case 0
+          ->
+              System.out.println("Test");
+      case 1 ->
+          System.out.println("TEST");
+      case 2 -> {
+        System.out.println("Test");
+      }
+      default -> System.out.println("test");
+    }
+  }
+  
+  void testIncorrectIndentation(int obj) {
+    switch (obj) {
+      case 1
+          ->
+              System.out.println("Test");
+      case 2 ->
+          System.out.println("Test");
+      default -> System.out.println("test");
+    }
+  }
+  
+  void testMixedCases(int obj) {
+    switch (obj) {
+      case 1 -> System.out.println("TEST");
+      case 2
+          -> System.out.println("Test");
+      case 3 ->
+          System.out.println("Test");
+      case 4 -> {
+        System.out.println("Test");
+        System.out.println("Another statement");
+      }
+      default -> System.out.println("test");
+    }
+  }
+  
+  private boolean testLineWrapping(int x, int y, int z) {
+    return switch (x) {
+      case 1 -> true;
+      case 2 -> x != y
+          && y != 5;
+      case 3 ->
+          y != 4
+            && z != 2
+            && y != z;
+      default -> false;
+    };
+  }
+}

--- a/src/it/resources-noncompilable/com/google/checkstyle/test/chapter4formatting/rule4841indentation/InputSwitchWrappingIndentation.java
+++ b/src/it/resources-noncompilable/com/google/checkstyle/test/chapter4formatting/rule4841indentation/InputSwitchWrappingIndentation.java
@@ -1,0 +1,52 @@
+package com.google.checkstyle.test.chapter4formatting.rule42blockindentation;
+
+import java.util.List;
+
+/**some javadoc.*/
+public class InputSwitchWrappingIndentation {
+  String testMethod1(int i) {
+    String name = "";
+    name =
+        switch (i) {
+          case 1 -> "one";
+          case 2 -> "two";
+          default -> "zero";
+        };
+    return name;
+  }
+
+  String testMethod2(int x, int y) {
+    return switch (x) {
+      case 1 ->
+          switch (y) {
+            case 2 -> "test";
+            default -> "inner default";
+          };
+      default -> "outer default";
+    };
+  }
+
+  String testMethod3(List<Integer> operations) {
+    return operations.stream()
+        .map(
+            op ->
+                switch (op) {
+                  case 1 -> "test";
+                  default -> "TEST";
+                })
+        .findFirst().orElse("defaultValue");
+  }
+
+  String testMethod4Invalid(int x, int y) {
+    return switch (x) {
+      case 1 ->
+        switch (y) {
+        // violation above '.* incorrect indentation level 8, expected .* 10.'
+          case 2 -> "test";
+            // violation above '.* incorrect indentation level 10, expected .* 12.'
+            default -> "inner default";
+          };
+      default -> "outer default";
+    };
+  }
+}

--- a/src/it/resources-noncompilable/com/google/checkstyle/test/chapter4formatting/rule4841indentation/InputSwitchWrappingIndentationCorrect.java
+++ b/src/it/resources-noncompilable/com/google/checkstyle/test/chapter4formatting/rule4841indentation/InputSwitchWrappingIndentationCorrect.java
@@ -1,0 +1,50 @@
+package com.google.checkstyle.test.chapter4formatting.rule42blockindentation;
+
+import java.util.List;
+
+/**some javadoc.*/
+public class InputSwitchWrappingIndentationCorrect {
+  String testMethod1(int i) {
+    String name = "";
+    name =
+        switch (i) {
+          case 1 -> "one";
+          case 2 -> "two";
+          default -> "zero";
+        };
+    return name;
+  }
+
+  String testMethod2(int x, int y) {
+    return switch (x) {
+      case 1 ->
+          switch (y) {
+            case 2 -> "test";
+            default -> "inner default";
+          };
+      default -> "outer default";
+    };
+  }
+
+  String testMethod3(List<Integer> operations) {
+    return operations.stream()
+        .map(
+            op ->
+                switch (op) {
+                  case 1 -> "test";
+                  default -> "TEST";
+                })
+        .findFirst().orElse("defaultValue");
+  }
+
+  String testMethod4(int x, int y) {
+    return switch (x) {
+      case 1 ->
+          switch (y) {
+            case 2 -> "test";
+            default -> "inner default";
+          };
+      default -> "outer default";
+    };
+  }
+}

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/indentation/SwitchHandler.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/indentation/SwitchHandler.java
@@ -30,6 +30,17 @@ import com.puppycrawl.tools.checkstyle.utils.TokenUtil;
 public class SwitchHandler extends BlockParentHandler {
 
     /**
+     * Token types that, when appearing as a parent or grandparent of the
+     * current switch expression, indicate that the expression is likely
+     * line-wrapped and should be indented.
+     */
+    private static final int[] LINE_WRAPPING_INDENT_TRIGGERS = {
+        TokenTypes.ASSIGN,
+        TokenTypes.SWITCH_RULE,
+        TokenTypes.LAMBDA,
+    };
+
+    /**
      * Construct an instance of this handler with the given indentation check,
      * abstract syntax tree, and parent handler.
      *
@@ -81,12 +92,55 @@ public class SwitchHandler extends BlockParentHandler {
     protected IndentLevel getIndentImpl() {
         IndentLevel indentLevel = super.getIndentImpl();
         // if switch is starting the line
-        if (isOnStartOfLine(getMainAst())
-                && TokenUtil.isOfType(getMainAst().getParent().getParent(), TokenTypes.ASSIGN)) {
-            indentLevel = new IndentLevel(indentLevel,
+        if (isOnStartOfLine(getMainAst())) {
+            final DetailAST parent = getMainAst().getParent();
+            final DetailAST grandParent = parent.getParent();
+
+            if (shouldIndentDueToWrapping(parent, grandParent)) {
+                indentLevel = new IndentLevel(indentLevel,
                     getIndentCheck().getLineWrappingIndentation());
+            }
         }
         return indentLevel;
+    }
+
+    /**
+     * Determines if indentation is needed due to line wrapping caused by intermediate nodes
+     * between the current AST node and its enclosing handler node.
+     *
+     * @param directParent The immediate parent node of the current AST node
+     * @param grandParent The grandparent node of the current AST node
+     * @return true if either the direct parent or grandparent requires additional indentation,
+     *         but only when they are not the enclosing handler node itself
+     */
+    private boolean shouldIndentDueToWrapping(DetailAST directParent, DetailAST grandParent) {
+        // The enclosing handler node that already determines base indentation
+        // (e.g., method declaration containing our current node)
+        final DetailAST enclosingHandlerNode = getParent().getMainAst();
+        final boolean isDirectParentTheHandler = directParent.equals(enclosingHandlerNode);
+
+        final boolean shouldIndentForDirectParent = !isDirectParentTheHandler
+            && isWrappingTrigger(directParent);
+
+        // Check if grandparent requires extra indentation (when
+        // neither it nor direct parent is the handler)
+        final boolean shouldIndentForGrandParent = !isDirectParentTheHandler
+            && !grandParent.equals(enclosingHandlerNode)
+            && isWrappingTrigger(grandParent);
+
+        return shouldIndentForDirectParent || shouldIndentForGrandParent;
+    }
+
+    /**
+     * Checks if the given AST node represents a construct that typically causes line wrapping
+     * and therefore requires additional indentation level.
+     *
+     * @param astNode The AST node to check
+     * @return true if the node type matches one of the line-wrapping triggers
+     *         (e.g., assignments, switch rules, lambdas)
+     */
+    private static boolean isWrappingTrigger(DetailAST astNode) {
+        return TokenUtil.isOfType(astNode, LINE_WRAPPING_INDENT_TRIGGERS);
     }
 
     @Override

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/indentation/SwitchRuleHandler.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/indentation/SwitchRuleHandler.java
@@ -64,7 +64,20 @@ public class SwitchRuleHandler extends AbstractExpressionHandler {
 
     @Override
     public IndentLevel getSuggestedChildIndent(AbstractExpressionHandler child) {
-        return getIndent();
+        final IndentLevel result;
+
+        if (child instanceof SlistHandler) {
+            // switchRule with block body (enclosed in {})
+            result = getIndent();
+        }
+        else {
+            // Single-expression switchRule (no {} block):
+            // assume line wrapping and add additional indentation
+            // for the statement in the next line.
+            result = new IndentLevel(getIndent(), getIndentCheck().getLineWrappingIndentation());
+        }
+
+        return result;
     }
 
     @Override

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/indentation/IndentationCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/indentation/IndentationCheckTest.java
@@ -3712,6 +3712,29 @@ public class IndentationCheckTest extends AbstractModuleTestSupport {
     }
 
     @Test
+    public void testIndentationSwitchExpressionWrappingIndentation() throws Exception {
+        final DefaultConfiguration checkConfig = createModuleConfig(IndentationCheck.class);
+        checkConfig.addProperty("tabWidth", "4");
+        checkConfig.addProperty("basicOffset", "2");
+        checkConfig.addProperty("braceAdjustment", "2");
+        checkConfig.addProperty("caseIndent", "2");
+        checkConfig.addProperty("lineWrappingIndentation", "4");
+
+        final String fileName = getNonCompilablePath(
+                "InputIndentationSwitchExpressionWrappingIndentation.java");
+        final String[] expected = {
+            "41:7: " + getCheckMessage(MSG_ERROR, "switch", 6, 8),
+            "42:9: " + getCheckMessage(MSG_CHILD_ERROR, "case", 8, 10),
+            "43:9: " + getCheckMessage(MSG_CHILD_ERROR, "case", 8, 10),
+            "44:9: " + getCheckMessage(MSG_CHILD_ERROR, "case", 8, 10),
+            "45:7: " + getCheckMessage(MSG_ERROR, "switch rcurly", 6, 8),
+            "51:9: " + getCheckMessage(MSG_CHILD_ERROR, "lambda", 8, 10),
+            "52:11: " + getCheckMessage(MSG_CHILD_ERROR, "case", 10, 12),
+        };
+        verifyWarns(checkConfig, fileName, expected);
+    }
+
+    @Test
     public void testIndentationPatternMatchingForSwitch()
             throws Exception {
         final DefaultConfiguration checkConfig = createModuleConfig(IndentationCheck.class);
@@ -3735,6 +3758,31 @@ public class IndentationCheckTest extends AbstractModuleTestSupport {
             "88:1: " + getCheckMessage(MSG_CHILD_ERROR, "case", 0, 16),
             "89:1: " + getCheckMessage(MSG_CHILD_ERROR, "case", 0, 16),
             "90:1: " + getCheckMessage(MSG_ERROR, "lambda", 0, 16),
+            "91:1: " + getCheckMessage(MSG_CHILD_ERROR, "lambda", 0, 20),
+        };
+        verifyWarns(checkConfig, fileName, expected);
+    }
+
+    @Test
+    public void testIndentationSingleSwitchStatementsWithoutCurly()
+            throws Exception {
+        final DefaultConfiguration checkConfig = createModuleConfig(IndentationCheck.class);
+        checkConfig.addProperty("forceStrictCondition", "true");
+        checkConfig.addProperty("tabWidth", "4");
+        checkConfig.addProperty("basicOffset", "4");
+        checkConfig.addProperty("braceAdjustment", "0");
+        checkConfig.addProperty("caseIndent", "4");
+        checkConfig.addProperty("throwsIndent", "4");
+
+        final String fileName = getNonCompilablePath(
+                "InputIndentationCheckSingleSwitchStatementsWithoutCurly.java");
+        final String[] expected = {
+            "31:13: " + getCheckMessage(MSG_ERROR, "lambda", 12, 16),
+            "32:13: " + getCheckMessage(MSG_CHILD_ERROR, "lambda", 12, 20),
+            "33:9: " + getCheckMessage(MSG_CHILD_ERROR, "case", 8, 12),
+            "34:1: " + getCheckMessage(MSG_CHILD_ERROR, "lambda", 0, 16),
+            "44:25: " + getCheckMessage(MSG_CHILD_ERROR, "lambda", 24, 16),
+            "47:13: " + getCheckMessage(MSG_CHILD_ERROR, "block", 12, 16),
         };
         verifyWarns(checkConfig, fileName, expected);
     }

--- a/src/test/resources-noncompilable/com/puppycrawl/tools/checkstyle/checks/indentation/indentation/InputIndentationCheckSingleSwitchStatementsWithoutCurly.java
+++ b/src/test/resources-noncompilable/com/puppycrawl/tools/checkstyle/checks/indentation/indentation/InputIndentationCheckSingleSwitchStatementsWithoutCurly.java
@@ -1,0 +1,64 @@
+//non-compiled with javac: Compilable with Java17                      //indent:0 exp:0
+package com.puppycrawl.tools.checkstyle.checks.indentation.indentation;//indent:0 exp:0
+
+/* Config:                                                             //indent:0 exp:0
+ *                                                                     //indent:1 exp:1
+ * basicOffset = 4                                                     //indent:1 exp:1
+ * braceAdjustment = 0                                                 //indent:1 exp:1
+ * caseIndent = 4                                                      //indent:1 exp:1
+ * throwsIndent = 4                                                    //indent:1 exp:1
+ * arrayInitIndent = 4                                                 //indent:1 exp:1
+ * lineWrappingIndentation = 4                                         //indent:1 exp:1
+ * forceStrictCondition = true                                         //indent:1 exp:1
+ */                                                                    //indent:1 exp:1
+public class InputIndentationCheckSingleSwitchStatementsWithoutCurly { //indent:0 exp:0
+    void testCorrectIndentation(int obj) {                             //indent:4 exp:4
+        switch (obj) {                                                 //indent:8 exp:8
+            case 0                                                     //indent:12 exp:12
+                ->                                                     //indent:16 exp:16
+                    System.out.println("Test");                        //indent:20 exp:20
+            case 1 ->                                                  //indent:12 exp:12
+                System.out.println("TEST");                            //indent:16 exp:16
+            case 2 -> {                                                //indent:12 exp:12
+                System.out.println("Test");                            //indent:16 exp:16
+            }                                                          //indent:12 exp:12
+        }                                                              //indent:8 exp:8
+    }                                                                  //indent:4 exp:4
+
+    void testIncorrectIndentation(int obj) {                           //indent:4 exp:4
+        switch (obj) {                                                 //indent:8 exp:8
+            case 1                                                     //indent:12 exp:12
+            ->                                                         //indent:12 exp:16 warn
+            System.out.println("Test");                                //indent:12 exp:20 warn
+        case 2 ->                                                      //indent:8 exp:12 warn
+System.out.println("Test");                                            //indent:0 exp:16 warn
+        }                                                              //indent:8 exp:8
+    }                                                                  //indent:4 exp:4
+
+    void testMixedCases(int obj) {                                     //indent:4 exp:4
+        switch (obj) {                                                 //indent:8 exp:8
+            case 1 -> System.out.println("TEST");                      //indent:12 exp:12
+            case 2                                                     //indent:12 exp:12
+                -> System.out.println("Test");                         //indent:16 exp:16
+            case 3 ->                                                  //indent:12 exp:12
+                        System.out.println("Test");                    //indent:24 exp:16 warn
+            case 4 -> {                                                //indent:12 exp:12
+                System.out.println("Test");                            //indent:16 exp:16
+            System.out.println("Another statement");                   //indent:12 exp:16 warn
+            }                                                          //indent:12 exp:12
+        }                                                              //indent:8 exp:8
+    }                                                                  //indent:4 exp:4
+
+    private boolean testLineWrapping(int x, int y, int z) {            //indent:4 exp:4
+        return switch (x) {                                            //indent:8 exp:8
+            case 1 -> true;                                            //indent:12 exp:12
+            case 2 -> x != y                                           //indent:12 exp:12
+                && y != 5;                                             //indent:16 exp:16
+            case 3 ->                                                  //indent:12 exp:12
+                y != 4                                                 //indent:16 exp:16
+                    && z != 2                                          //indent:20 exp:20
+                    && y != z;                                         //indent:20 exp:20
+            default -> false;                                          //indent:12 exp:12
+        };                                                             //indent:8 exp:8
+    }                                                                  //indent:4 exp:4
+}                                                                      //indent:0 exp:0

--- a/src/test/resources-noncompilable/com/puppycrawl/tools/checkstyle/checks/indentation/indentation/InputIndentationPatternMatchingForSwitch.java
+++ b/src/test/resources-noncompilable/com/puppycrawl/tools/checkstyle/checks/indentation/indentation/InputIndentationPatternMatchingForSwitch.java
@@ -88,7 +88,7 @@ Point(int x, int y) //indent:0 exp:16 warn
 when          //indent:0 exp:16 warn
 x > 0 && y > 0          //indent:0 exp:16 warn
 ->        //indent:0 exp:16 warn
-System.out.println(x + y); //indent:0 exp:0
+System.out.println(x + y); //indent:0 exp:20 warn
             case Point(int x, int y) -> System.out.println("error"); //indent:12 exp:12
         } //indent:8 exp:8
     } //indent:4 exp:4

--- a/src/test/resources-noncompilable/com/puppycrawl/tools/checkstyle/checks/indentation/indentation/InputIndentationSwitchExpressionWrappingIndentation.java
+++ b/src/test/resources-noncompilable/com/puppycrawl/tools/checkstyle/checks/indentation/indentation/InputIndentationSwitchExpressionWrappingIndentation.java
@@ -1,0 +1,69 @@
+//non-compiled with javac: Compilable with Java17                           //indent:0 exp:0
+
+package com.puppycrawl.tools.checkstyle.checks.indentation.indentation;     //indent:0 exp:0
+
+import java.util.List;                                                      //indent:0 exp:0
+/* Config:                                                                  //indent:0 exp:0
+ * This test-input is intended to be checked using following configuration: //indent:1 exp:1
+ * basicOffset = 2                                                          //indent:1 exp:1
+ * braceAdjustment = 2                                                      //indent:1 exp:1
+ * caseIndent = 2                                                           //indent:1 exp:1
+ * tabWidth = 4                                                             //indent:1 exp:1
+ * lineWrappingIndentation = 4                                              //indent:1 exp:1
+ */                                                                         //indent:1 exp:1
+
+public class InputIndentationSwitchExpressionWrappingIndentation {          //indent:0 exp:0
+  String testMethod1(int i) {                                               //indent:2 exp:2
+    String name = "";                                                       //indent:4 exp:4
+    name =                                                                  //indent:4 exp:4
+        switch (i) {                                                        //indent:8 exp:8
+          case 1 -> "one";                                                  //indent:10 exp:10
+          case 2 -> "two";                                                  //indent:10 exp:10
+          default -> "zero";                                                //indent:10 exp:10
+        };                                                                  //indent:8 exp:8
+    return name;                                                            //indent:4 exp:4
+  }                                                                         //indent:2 exp:2
+
+  String testMethod2(int x, int y) {                                        //indent:2 exp:2
+    return switch (x) {                                                     //indent:4 exp:4
+      case 1 ->                                                             //indent:6 exp:6
+          switch (y) {                                                      //indent:10 exp:10
+            case 2 -> "test";                                               //indent:12 exp:12
+            default -> "inner default";                                     //indent:12 exp:12
+          };                                                                //indent:10 exp:10
+      default -> "outer default";                                           //indent:6 exp:6
+    };                                                                      //indent:4 exp:4
+  }                                                                         //indent:2 exp:2
+
+  void testMethod3_invalid(int num) {                                       //indent:2 exp:2
+    int odd = 0;                                                            //indent:4 exp:4
+    odd =                                                                   //indent:4 exp:4
+      switch (num) {                                                        //indent:6 exp:8 warn
+        case 1, 3, 7 -> 1;                                                  //indent:8 exp:10 warn
+        case 2, 4, 6 -> 2;                                                  //indent:8 exp:10 warn
+        default -> 0;                                                       //indent:8 exp:10 warn
+      };                                                                    //indent:6 exp:8 warn
+  }                                                                         //indent:2 exp:2
+
+  String testMethod4_invalid(int x, int y) {                                //indent:2 exp:2
+    return switch (x) {                                                     //indent:4 exp:4
+      case 1 ->                                                             //indent:6 exp:6
+        switch (y) {                                                        //indent:8 exp:10 warn
+          case 2 -> "test";                                                 //indent:10 exp:12 warn
+            default -> "inner default";                                     //indent:12 exp:12
+          };                                                                //indent:10 exp:10
+      default -> "outer default";                                           //indent:6 exp:6
+    };                                                                      //indent:4 exp:4
+  }                                                                         //indent:2 exp:2
+
+  String testMethod3(List<Integer> operations) {                            //indent:2 exp:2
+    return operations.stream()                                              //indent:4 exp:4
+        .map(                                                               //indent:8 exp:8
+            op ->                                                           //indent:12 exp:12
+                switch (op) {                                               //indent:16 exp:16
+                  case 1 -> "test";                                         //indent:18 exp:18
+                  default -> "TEST";                                        //indent:18 exp:18
+                })                                                          //indent:16 exp:16
+        .findFirst().orElse("defaultValue");                                //indent:8 exp:8
+  }                                                                         //indent:2 exp:2
+}                                                                           //indent:0 exp:0


### PR DESCRIPTION
fixes: #15098 , #16762
This PR reintroduces the changes from the original PR ([#16647](https://github.com/checkstyle/checkstyle/pull/16647)), which was closed due to a required refork of the repository.

New module config: https://gist.githubusercontent.com/mohitsatr/937e10572dd412961b61c77577619dff/raw/7a47240f8793e7335adbd81c2806b375f0394815/google_checks_indentation.xml
---Diff-- Regression config: https://gist.githubusercontent.com/mohitsatr/937e10572dd412961b61c77577619dff/raw/7a47240f8793e7335adbd81c2806b375f0394815/google_checks_indentation.xml
Diff Regression projects: https://gist.githubusercontent.com/mohitsatr/68b0817ac52ff7773d35585ee12fc1cc/raw/9ba8e4fb324e1daf589874c6992f2aa87b03079a/list-of-projects.properties