### PR TITLE
Issue #16630: fp when <p> is nested

### DIFF
--- a/src/it/resources/com/google/checkstyle/test/chapter7javadoc/rule712paragraphs/InputFormattedIncorrectJavadocParagraph.java
+++ b/src/it/resources/com/google/checkstyle/test/chapter7javadoc/rule712paragraphs/InputFormattedIncorrectJavadocParagraph.java
@@ -105,7 +105,6 @@ class InputFormattedIncorrectJavadocParagraph {
          * @see <a href="example.com">Documentation about
          *     <p>GWT emulated source</a>
          */
-        // violation 2 lines above '<p> tag should be preceded with an empty line.'
         boolean emulated() {
           return false;
         }
@@ -136,9 +135,6 @@ class InputFormattedIncorrectJavadocParagraph {
      *   <li>1 should NOT give violation as there is not empty line before
      * </ul>
      */
-    // 2 violations 4 lines above:
-    //  '<p> tag should be placed immediately before the first word'
-    //  '<p> tag should be preceded with an empty line.'
     public void foo() {}
 
     // 2 violations 6 lines below:

--- a/src/it/resources/com/google/checkstyle/test/chapter7javadoc/rule712paragraphs/InputIncorrectJavadocParagraph.java
+++ b/src/it/resources/com/google/checkstyle/test/chapter7javadoc/rule712paragraphs/InputIncorrectJavadocParagraph.java
@@ -116,9 +116,6 @@ class InputIncorrectJavadocParagraph {
          *
          * @see <a href="example.com">Documentation about <p> GWT emulated source</a>
          */
-        // 2 violations 2 lines above:
-        //  '<p> tag should be placed immediately before the first word'
-        //  '<p> tag should be preceded with an empty line.'
         boolean emulated() {
           return false;
         }

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocParagraphCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocParagraphCheck.java
@@ -247,10 +247,10 @@ public class JavadocParagraphCheck extends AbstractJavadocCheck {
      */
     private static boolean isNestedParagraph(DetailNode tag) {
         boolean nested = false;
-        DetailNode parent = tag;
+        DetailNode parent = tag.getParent();
 
         while (parent != null) {
-            if (parent.getType() == JavadocTokenTypes.PARAGRAPH) {
+            if (parent.getType() == JavadocTokenTypes.HTML_ELEMENT) {
                 nested = true;
                 break;
             }

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocParagraphCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocParagraphCheckTest.java
@@ -81,10 +81,8 @@ public class JavadocParagraphCheckTest extends AbstractModuleTestSupport {
             "87:11: " + getCheckMessage(MSG_TAG_AFTER),
             "97:27: " + getCheckMessage(MSG_LINE_BEFORE),
             "99:13: " + getCheckMessage(MSG_MISPLACED_TAG),
-            "102:36: " + getCheckMessage(MSG_MISPLACED_TAG),
-            "102:36: " + getCheckMessage(MSG_LINE_BEFORE),
-            "112:11: " + getCheckMessage(MSG_TAG_AFTER),
-            "113:11: " + getCheckMessage(MSG_TAG_AFTER),
+            "109:11: " + getCheckMessage(MSG_TAG_AFTER),
+            "110:11: " + getCheckMessage(MSG_TAG_AFTER),
         };
         verifyWithInlineConfigParser(
                 getPath("InputJavadocParagraphIncorrect.java"), expected);
@@ -95,11 +93,10 @@ public class JavadocParagraphCheckTest extends AbstractModuleTestSupport {
         final String[] expected = {
             "14:4: " + getCheckMessage(MSG_PRECEDED_BLOCK_TAG, "h1"),
             "22:7: " + getCheckMessage(MSG_PRECEDED_BLOCK_TAG, "ul"),
-            "24:11: " + getCheckMessage(MSG_LINE_BEFORE),
-            "38:8: " + getCheckMessage(MSG_PRECEDED_BLOCK_TAG, "table"),
-            "50:8: " + getCheckMessage(MSG_MISPLACED_TAG),
-            "52:8: " + getCheckMessage(MSG_MISPLACED_TAG),
-            "52:8: " + getCheckMessage(MSG_PRECEDED_BLOCK_TAG, "ol"),
+            "37:8: " + getCheckMessage(MSG_PRECEDED_BLOCK_TAG, "table"),
+            "49:8: " + getCheckMessage(MSG_MISPLACED_TAG),
+            "51:8: " + getCheckMessage(MSG_MISPLACED_TAG),
+            "51:8: " + getCheckMessage(MSG_PRECEDED_BLOCK_TAG, "ol"),
         };
         verifyWithInlineConfigParser(
                 getPath("InputJavadocParagraphIncorrect4.java"), expected);
@@ -154,10 +151,8 @@ public class JavadocParagraphCheckTest extends AbstractModuleTestSupport {
             "30:27: " + getCheckMessage(MSG_MISPLACED_TAG),
             "30:27: " + getCheckMessage(MSG_LINE_BEFORE),
             "32:13: " + getCheckMessage(MSG_MISPLACED_TAG),
-            "35:36: " + getCheckMessage(MSG_MISPLACED_TAG),
-            "35:36: " + getCheckMessage(MSG_LINE_BEFORE),
-            "45:11: " + getCheckMessage(MSG_TAG_AFTER),
-            "46:11: " + getCheckMessage(MSG_TAG_AFTER),
+            "42:11: " + getCheckMessage(MSG_TAG_AFTER),
+            "43:11: " + getCheckMessage(MSG_TAG_AFTER),
         };
         verifyWithInlineConfigParser(
                 getPath("InputJavadocParagraphIncorrect3.java"), expected);
@@ -166,19 +161,11 @@ public class JavadocParagraphCheckTest extends AbstractModuleTestSupport {
     @Test
     public void testAllowNewlineParagraph3() throws Exception {
         final String[] expected = {
-            "15:12: " + getCheckMessage(MSG_LINE_BEFORE),
-            "17:15: " + getCheckMessage(MSG_LINE_BEFORE),
-            "20:9: " + getCheckMessage(MSG_MISPLACED_TAG),
-            "20:9: " + getCheckMessage(MSG_LINE_BEFORE),
-            "34:11: " + getCheckMessage(MSG_LINE_BEFORE),
-            "38:8: " + getCheckMessage(MSG_LINE_BEFORE),
-            "44:8: " + getCheckMessage(MSG_LINE_BEFORE),
-            "48:8: " + getCheckMessage(MSG_MISPLACED_TAG),
-            "52:8: " + getCheckMessage(MSG_MISPLACED_TAG),
-            "52:8: " + getCheckMessage(MSG_PRECEDED_BLOCK_TAG, "h1"),
-            "67:11: " + getCheckMessage(MSG_LINE_BEFORE),
-            "80:8: " + getCheckMessage(MSG_MISPLACED_TAG),
-            "80:8: " + getCheckMessage(MSG_PRECEDED_BLOCK_TAG, "ul"),
+            "42:8: " + getCheckMessage(MSG_MISPLACED_TAG),
+            "46:8: " + getCheckMessage(MSG_MISPLACED_TAG),
+            "46:8: " + getCheckMessage(MSG_PRECEDED_BLOCK_TAG, "h1"),
+            "73:8: " + getCheckMessage(MSG_MISPLACED_TAG),
+            "73:8: " + getCheckMessage(MSG_PRECEDED_BLOCK_TAG, "ul"),
         };
         verifyWithInlineConfigParser(
                 getPath("InputJavadocParagraphIncorrect5.java"), expected);
@@ -191,7 +178,6 @@ public class JavadocParagraphCheckTest extends AbstractModuleTestSupport {
             "28:7: " + getCheckMessage(MSG_REDUNDANT_PARAGRAPH),
             "31:7: " + getCheckMessage(MSG_LINE_BEFORE),
             "50:7: " + getCheckMessage(MSG_PRECEDED_BLOCK_TAG, "ul"),
-            "65:8: " + getCheckMessage(MSG_LINE_BEFORE),
             "76:8: " + getCheckMessage(MSG_PRECEDED_BLOCK_TAG, "table"),
             "87:8: " + getCheckMessage(MSG_PRECEDED_BLOCK_TAG, "pre"),
         };
@@ -265,5 +251,13 @@ public class JavadocParagraphCheckTest extends AbstractModuleTestSupport {
 
         verifyWithInlineConfigParser(
                 getPath("InputJavadocParagraphIncorrect6.java"), expected);
+    }
+
+    @Test
+    public void testJavadocParagraphNested() throws Exception {
+        final String[] expected = CommonUtil.EMPTY_STRING_ARRAY;
+
+        verifyWithInlineConfigParser(
+                getPath("InputJavadocParagraphNested.java"), expected);
     }
 }

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadocparagraph/InputJavadocParagraphCheck1.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadocparagraph/InputJavadocParagraphCheck1.java
@@ -57,7 +57,7 @@ class Check {
      */
     public void foo() {}
 
-    // violation 5 lines below '<p> tag should be preceded with an empty line.'
+
     /**
      * Some summary.
      *

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadocparagraph/InputJavadocParagraphIncorrect.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadocparagraph/InputJavadocParagraphIncorrect.java
@@ -101,9 +101,6 @@ class InputJavadocParagraphIncorrect {
          * @see <a href="example.com">
          *     Documentation about <p> GWT emulated source</a>
          */
-        // 2 violations 2 lines above:
-        //  'tag should be placed immediately before the first word'
-        //  'tag should be preceded with an empty line.'
         boolean emulated() {return false;}
 
         // violation 3 lines below 'Empty line should be followed by <p> tag on the next line.'

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadocparagraph/InputJavadocParagraphIncorrect3.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadocparagraph/InputJavadocParagraphIncorrect3.java
@@ -34,9 +34,6 @@ public class InputJavadocParagraphIncorrect3 {
          * @see <a href="example.com">
          *     Documentation about <p> GWT emulated source</a>
          */
-        // 2 violations 2 lines above:
-        //  '<p> tag should be placed immediately before the first word'
-        //  '<p> tag should be preceded with an empty line.'
         boolean emulated() {return false;}
 
         // violation 3 lines below 'Empty line should be followed by <p> tag on the next line.'

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadocparagraph/InputJavadocParagraphIncorrect4.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadocparagraph/InputJavadocParagraphIncorrect4.java
@@ -28,7 +28,6 @@ public class InputJavadocParagraphIncorrect4 {
      *
      * <p><b>testing</b> ok, inline HTML tag. Not a block-level tag
      */
-    // violation 7 lines above 'tag should be preceded with an empty line.'
     public void foo() {}
 
     // violation 4 lines below '<p> tag should not precede HTML block-tag '<table>''

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadocparagraph/InputJavadocParagraphIncorrect5.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadocparagraph/InputJavadocParagraphIncorrect5.java
@@ -9,8 +9,7 @@ allowNewlineParagraph = false
 package com.puppycrawl.tools.checkstyle.checks.javadoc.javadocparagraph;
 
 public class InputJavadocParagraphIncorrect5 {
-    // violation 3 lines below 'tag should be preceded with an empty line.'
-    // violation 4 lines below 'tag should be preceded with an empty line.'
+
     /**
      * <h1><p>Testing....</h1>
      *
@@ -22,14 +21,9 @@ public class InputJavadocParagraphIncorrect5 {
      *
      * </table>
      */
-    // 2 violations 5 lines above:
-    //  '<p> tag should be placed immediately before the first word'
-    //  '<p> tag should be preceded with an empty line.'
     void fooooo() {}
 
-    // violation 4 lines below 'tag should be preceded with an empty line.'
-    // violation 7 lines below 'tag should be preceded with an empty line.'
-    // violation 12 lines below 'tag should be preceded with an empty line.'
+
     /**
      * <b><p>testtttt.....</b>
      *
@@ -68,7 +62,6 @@ public class InputJavadocParagraphIncorrect5 {
      *  </ul>
      * </ul>
      */
-    // violation 4 lines above 'tag should be preceded with an empty line.'
     void fooooooo() {}
 
     // 2 violations 6 lines below:

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadocparagraph/InputJavadocParagraphNested.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadocparagraph/InputJavadocParagraphNested.java
@@ -1,0 +1,29 @@
+/*
+JavadocParagraph
+violateExecutionOnNonTightHtml = (default)false
+allowNewlineParagraph = (default)true
+
+
+*/
+
+package com.puppycrawl.tools.checkstyle.checks.javadoc.javadocparagraph;
+
+/**
+ * The Tiles taglib and framework allows building
+  web pages by assembling reusable pieces of pages,
+  called Tiles. A Tile is usually a simple JSP page.
+
+  <div class="section">
+    <h2>Introduction</h2>
+
+    <p>The Tiles framework allows building pages
+    by assembling reusable Tiles. As an example, the page in
+    the next figure can be built by assembling a
+    header, a footer, a menu, and a body.</p>
+
+    <p><img src="doc-files/image001.gif"
+    height="169" width="145" alt="doc-files/image001"></p>
+  </div>
+ */
+public class InputJavadocParagraphNested {
+}


### PR DESCRIPTION
Fixes: https://github.com/checkstyle/checkstyle/issues/16630
Fixed false-positive and some already existing tests.
The check was built on the assumption that a nested `<p>` tag means it is nested inside another `<p>` tag.
Now, no violation will be produced if a `<p>` tag is nested inside any other tag.

This PR reintroduces the changes from the original PR (https://github.com/checkstyle/checkstyle/pull/16687), which was closed due to a required refork of the repository.