### PR TITLE
Issue #13999: Resolve Pitest suppression for JavadocTagInfo validatio…

### DIFF
--- a/config/pitest-suppressions/pitest-javadoc-suppressions.xml
+++ b/config/pitest-suppressions/pitest-javadoc-suppressions.xml
@@ -8,40 +8,4 @@
     <description>removed call to java/util/Objects::hashCode</description>
     <lineContent>+ &quot;, children=&quot; + Objects.hashCode(children)</lineContent>
   </mutation>
-
-  <mutation unstable="false">
-    <sourceFile>JavadocTagInfo.java</sourceFile>
-    <mutatedClass>com.puppycrawl.tools.checkstyle.checks.javadoc.JavadocTagInfo$11</mutatedClass>
-    <mutatedMethod>isValidOn</mutatedMethod>
-    <mutator>org.pitest.mutationtest.engine.gregor.mutators.RemoveConditionalMutator_EQUAL_IF</mutator>
-    <description>removed conditional - replaced equality check with true</description>
-    <lineContent>return astType == TokenTypes.METHOD_DEF</lineContent>
-  </mutation>
-
-  <mutation unstable="false">
-    <sourceFile>JavadocTagInfo.java</sourceFile>
-    <mutatedClass>com.puppycrawl.tools.checkstyle.checks.javadoc.JavadocTagInfo$14</mutatedClass>
-    <mutatedMethod>isValidOn</mutatedMethod>
-    <mutator>org.pitest.mutationtest.engine.gregor.mutators.RemoveConditionalMutator_EQUAL_IF</mutator>
-    <description>removed conditional - replaced equality check with true</description>
-    <lineContent>return astType == TokenTypes.METHOD_DEF</lineContent>
-  </mutation>
-
-  <mutation unstable="false">
-    <sourceFile>JavadocTagInfo.java</sourceFile>
-    <mutatedClass>com.puppycrawl.tools.checkstyle.checks.javadoc.JavadocTagInfo$15</mutatedClass>
-    <mutatedMethod>isValidOn</mutatedMethod>
-    <mutator>org.pitest.mutationtest.engine.gregor.mutators.RemoveConditionalMutator_EQUAL_IF</mutator>
-    <description>removed conditional - replaced equality check with true</description>
-    <lineContent>&amp;&amp; varType.getFirstChild().getType() == TokenTypes.ARRAY_DECLARATOR</lineContent>
-  </mutation>
-
-  <mutation unstable="false">
-    <sourceFile>JavadocTagInfo.java</sourceFile>
-    <mutatedClass>com.puppycrawl.tools.checkstyle.checks.javadoc.JavadocTagInfo$15</mutatedClass>
-    <mutatedMethod>isValidOn</mutatedMethod>
-    <mutator>org.pitest.mutationtest.engine.gregor.mutators.RemoveConditionalMutator_EQUAL_IF</mutator>
-    <description>removed conditional - replaced equality check with true</description>
-    <lineContent>return astType == TokenTypes.VARIABLE_DEF</lineContent>
-  </mutation>
 </suppressedMutations>

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocTagInfoTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocTagInfoTest.java
@@ -334,6 +334,21 @@ public class JavadocTagInfoTest {
         assertWithMessage("Should return false when ast type is invalid for current tag")
                 .that(JavadocTagInfo.RETURN.isValidOn(ast))
                 .isFalse();
+
+        final int[] invalidTypes = {
+            TokenTypes.VARIABLE_DEF,
+            TokenTypes.CLASS_DEF,
+            TokenTypes.INTERFACE_DEF,
+            TokenTypes.CTOR_DEF,
+        };
+
+        for (int type : invalidTypes) {
+            final DetailAstImpl invalidNode = new DetailAstImpl();
+            invalidNode.setType(type);
+            assertWithMessage("RETURN tag on invalid node: " + type)
+                .that(JavadocTagInfo.RETURN.isValidOn(invalidNode))
+                .isFalse();
+        }
     }
 
     @Test
@@ -371,6 +386,34 @@ public class JavadocTagInfoTest {
         assertWithMessage("Should return false when ast type is invalid for current tag")
                 .that(JavadocTagInfo.SERIAL_FIELD.isValidOn(ast))
                 .isFalse();
+
+        ast.setType(TokenTypes.METHOD_DEF);
+        assertWithMessage("SERIAL_FIELD on METHOD_DEF (invalid node)")
+            .that(JavadocTagInfo.SERIAL_FIELD.isValidOn(ast))
+            .isFalse();
+
+        ast.setType(TokenTypes.VARIABLE_DEF);
+        astChild2.setType(TokenTypes.IDENT);
+        astChild2.setText("ObjectStreamField");
+        assertWithMessage("SERIAL_FIELD with non-array type")
+            .that(JavadocTagInfo.SERIAL_FIELD.isValidOn(ast))
+            .isFalse();
+
+        final DetailAstImpl invalidNode = new DetailAstImpl();
+        invalidNode.setType(TokenTypes.METHOD_DEF);
+
+        final DetailAstImpl typeNode = new DetailAstImpl();
+        typeNode.setType(TokenTypes.TYPE);
+        invalidNode.addChild(typeNode);
+
+        final DetailAstImpl arrayDeclarator = new DetailAstImpl();
+        arrayDeclarator.setType(TokenTypes.ARRAY_DECLARATOR);
+        arrayDeclarator.setText("ObjectStreamField");
+        typeNode.addChild(arrayDeclarator);
+
+        assertWithMessage("@serialField on METHOD_DEF with valid type/text")
+            .that(JavadocTagInfo.SERIAL_FIELD.isValidOn(invalidNode))
+            .isFalse();
     }
 
     @Test
@@ -406,6 +449,19 @@ public class JavadocTagInfoTest {
         assertWithMessage("Should return false when ast type is invalid for current tag")
                 .that(JavadocTagInfo.SERIAL_DATA.isValidOn(ast))
                 .isFalse();
+
+        final int[] invalidTypes = {
+            TokenTypes.VARIABLE_DEF,
+            TokenTypes.CLASS_DEF,
+            TokenTypes.INTERFACE_DEF,
+        };
+        for (int type : invalidTypes) {
+            ast.setType(type);
+            astChild.setText("writeObject");
+            assertWithMessage("@serialData on invalid node: " + type)
+                .that(JavadocTagInfo.SERIAL_DATA.isValidOn(ast))
+                .isFalse();
+        }
     }
 
     @Test


### PR DESCRIPTION
Issue #13999 

## Mutations Removed  
**File:** `checkstyle/config/pitest-suppressions/pitest-javadoc-suppressions.xml`  

## Summary
The added test code addresses surviving mutants by ensuring Javadoc tags like @serialField, @return, and @serialData strictly validate their allowed AST node types and structural requirements. It explicitly tests scenarios where invalid nodes (e.g., METHOD_DEF, VARIABLE_DEF) or incorrect child types (e.g., non-ARRAY_DECLARATOR) attempt to use these tags, killing mutants that would have allowed such invalid configurations.