### PR TITLE
Issue #14019: Kill argument propogation mutation in CheckstyleAntTask

### DIFF
--- a/config/pitest-suppressions/pitest-ant-suppressions.xml
+++ b/config/pitest-suppressions/pitest-ant-suppressions.xml
@@ -84,15 +84,6 @@
   <mutation unstable="false">
     <sourceFile>CheckstyleAntTask.java</sourceFile>
     <mutatedClass>com.puppycrawl.tools.checkstyle.ant.CheckstyleAntTask</mutatedClass>
-    <mutatedMethod>getListeners</mutatedMethod>
-    <mutator>org.pitest.mutationtest.engine.gregor.mutators.experimental.ArgumentPropagationMutator</mutator>
-    <description>replaced call to java/lang/String::format with argument</description>
-    <lineContent>throw new BuildException(String.format(Locale.ROOT, &quot;Unable to create listeners: &quot;</lineContent>
-  </mutation>
-
-  <mutation unstable="false">
-    <sourceFile>CheckstyleAntTask.java</sourceFile>
-    <mutatedClass>com.puppycrawl.tools.checkstyle.ant.CheckstyleAntTask</mutatedClass>
     <mutatedMethod>processFiles</mutatedMethod>
     <mutator>org.pitest.mutationtest.engine.gregor.mutators.experimental.ArgumentPropagationMutator</mutator>
     <description>replaced call to java/util/Objects::toString with argument</description>

--- a/src/test/java/com/puppycrawl/tools/checkstyle/ant/CheckstyleAntTaskTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/ant/CheckstyleAntTaskTest.java
@@ -317,11 +317,12 @@ public class CheckstyleAntTaskTest extends AbstractPathTestSupport {
         final BuildException ex = getExpectedThrowable(BuildException.class,
                 antTask::execute,
                 "BuildException is expected");
-        final String expectedMessage = String.format(Locale.ROOT,
+        // Verify exact format of error message (testing String.format mutation)
+        final String expectedExceptionFormat = String.format(Locale.ROOT,
                 "Unable to create Root Module: config {%s}.", getPath(NOT_EXISTING_FILE));
         assertWithMessage("Error message is unexpected")
                 .that(ex.getMessage())
-                .isEqualTo(expectedMessage);
+                .isEqualTo(expectedExceptionFormat);
     }
 
     @Test
@@ -654,7 +655,8 @@ public class CheckstyleAntTaskTest extends AbstractPathTestSupport {
                 "BuildException is expected");
         assertWithMessage("Error message is unexpected")
                 .that(ex.getMessage())
-                .startsWith("Unable to create listeners: formatters");
+                .isEqualTo("Unable to create listeners: formatters "
+                        + "{" + List.of(formatter) + "}.");
     }
 
     @Test


### PR DESCRIPTION
Fixes Issue #14019 

Kills mutation: 

- ArgumentPropagationMutator on `throw new BuildException(String.format(Locale.ROOT, &quot;Unable to create listeners:`

- ArgumentPropagationMutator on `throw new BuildException(String.format(Locale.ROOT, &quot; Unable to create Root Module`