### PR TITLE
minor: Update JavadocMethodCheck allowInlineReturn release version

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocMethodCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocMethodCheck.java
@@ -308,7 +308,7 @@ public class JavadocMethodCheck extends AbstractCheck {
      * Setter to control whether to allow inline return tags.
      *
      * @param value a {@code boolean} value
-     * @since 10.22.1
+     * @since 10.23.0
      */
     public void setAllowInlineReturn(boolean value) {
         allowInlineReturn = value;

--- a/src/site/xdoc/checks/javadoc/javadocmethod.xml
+++ b/src/site/xdoc/checks/javadoc/javadocmethod.xml
@@ -105,7 +105,7 @@ public int checkReturnTag(final int aTagIndex,
               <td>Control whether to allow inline return tags.</td>
               <td><a href="../../property_types.html#boolean">boolean</a></td>
               <td><code>false</code></td>
-              <td>10.22.1</td>
+              <td>10.23.0</td>
             </tr>
             <tr>
               <td>allowMissingParamTags</td>


### PR DESCRIPTION
This PR fixes the release version in the docs of `allowInlineReturn`  introduced in https://github.com/checkstyle/checkstyle/pull/16605 to reflect the actual released version https://github.com/checkstyle/checkstyle/releases/tag/checkstyle-10.23.0 