### PR TITLE
Issue #16729: Update SuppressionSingleFilter examples to use all prop…

### DIFF
--- a/src/site/xdoc/filters/suppressionsinglefilter.xml.template
+++ b/src/site/xdoc/filters/suppressionsinglefilter.xml.template
@@ -209,6 +209,26 @@
           <param name="type" value="code"/>
         </macro>
       </subsection>
+      <subsection name="To use both 'id' and 'columns' properties in the same filter"
+                  id="Example11">
+        <p id="Example11-config">
+          To configure a filter to suppress violations of <code>WhitespaceAround</code> check
+          but allow <code>MethodLength</code> violations in <code>Example11.java</code> using
+          <code>SuppressionSingleFilter</code> with both 'id' and 'columns' properties:
+        </p>
+        <macro name="example">
+          <param name="path"
+                 value="resources/com/puppycrawl/tools/checkstyle/filters/suppressionsinglefilter/Example11.java"/>
+          <param name="type" value="config"/>
+        </macro>
+        <p id="Example11-code">
+        </p>
+        <macro name="example">
+          <param name="path"
+                 value="resources/com/puppycrawl/tools/checkstyle/filters/suppressionsinglefilter/Example11.java"/>
+          <param name="type" value="code"/>
+        </macro>
+      </subsection>
       <subsection name="Example of Usage" id="Example_of_Usage">
         <ul>
           <li>

--- a/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/filters/SuppressionSingleFilterExamplesTest.java
+++ b/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/filters/SuppressionSingleFilterExamplesTest.java
@@ -35,8 +35,10 @@ import com.puppycrawl.tools.checkstyle.checks.naming.MemberNameCheck;
 import com.puppycrawl.tools.checkstyle.checks.naming.MethodNameCheck;
 import com.puppycrawl.tools.checkstyle.checks.regexp.RegexpCheck;
 import com.puppycrawl.tools.checkstyle.checks.sizes.FileLengthCheck;
+import com.puppycrawl.tools.checkstyle.checks.sizes.MethodLengthCheck;
 import com.puppycrawl.tools.checkstyle.checks.sizes.ParameterNumberCheck;
 import com.puppycrawl.tools.checkstyle.checks.whitespace.NoWhitespaceAfterCheck;
+import com.puppycrawl.tools.checkstyle.checks.whitespace.WhitespaceAroundCheck;
 
 public class SuppressionSingleFilterExamplesTest extends AbstractExamplesModuleTestSupport {
     @Override
@@ -166,6 +168,23 @@ public class SuppressionSingleFilterExamplesTest extends AbstractExamplesModuleT
         final String[] expectedWithFilter = {};
 
         verifyFilterWithInlineConfigParser(getPath("Example10.java"),
+                expectedWithoutFilter, expectedWithFilter);
+    }
+
+    @Test
+    public void testExample11() throws Exception {
+        final String[] expectedWithoutFilter = {
+            "17:11: " + getCheckMessage(WhitespaceAroundCheck.class,
+                    WhitespaceAroundCheck.MSG_WS_NOT_FOLLOWED, "="),
+            "17: " + getCheckMessage(MethodLengthCheck.class,
+                    MethodLengthCheck.MSG_KEY, 5, 2),
+        };
+        final String[] expectedWithFilter = {
+            "17: " + getCheckMessage(MethodLengthCheck.class,
+                    MethodLengthCheck.MSG_KEY, 5, 2),
+        };
+
+        verifyFilterWithInlineConfigParser(getPath("Example11.java"),
                 expectedWithoutFilter, expectedWithFilter);
     }
 }

--- a/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/filters/suppressionsinglefilter/Example1.java
+++ b/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/filters/suppressionsinglefilter/Example1.java
@@ -8,6 +8,7 @@
     <property name="checks" value="JavadocStyle|MagicNumber"/>
     <property name="files" value="Example1.java"/>
     <property name="lines" value="1,5-100"/>
+    <property name="columns" value="17-30"/>
   </module>
   <module name="SuppressionSingleFilter">
     <property name="message" value="Missing a Javadoc comment"/>

--- a/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/filters/suppressionsinglefilter/Example11.java
+++ b/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/filters/suppressionsinglefilter/Example11.java
@@ -1,0 +1,32 @@
+/*xml
+<module name="Checker">
+  <module name="TreeWalker">
+    <module name="WhitespaceAround">
+      <property name="id" value="whitespaceCheck"/>
+    </module>
+    <module name="MethodLength">
+      <property name="id" value="methodLengthCheck"/>
+      <property name="max" value="2"/>
+    </module>
+  </module>
+  <module name="SuppressionSingleFilter">
+    <property name="files" value="Example11.java"/>
+    <property name="id" value="whitespaceCheck"/>
+    <property name="columns" value="12-30"/>
+    <property name="lines" value="17"/>
+  </module>
+</module>
+*/
+package com.puppycrawl.tools.checkstyle.filters.suppressionsinglefilter;
+// xdoc section -- start
+public class Example11 {
+  // This method demonstrates the combined usage of id and columns properties
+  public void exampleMethod() {
+    int x=5; // filtered violation, WhitespaceAround check will be suppressed by id and columns
+    
+    // MethodLength violation is not filtered since we only filter the whitespaceCheck id
+    int y = 10;
+    int z = 15;
+  }
+}
+// xdoc section -- end 

--- a/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/filters/suppressionsinglefilter/Example2.java
+++ b/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/filters/suppressionsinglefilter/Example2.java
@@ -1,12 +1,16 @@
 /*xml
 <module name="Checker">
   <module name="TreeWalker">
-    <module name="JavadocMethod"/>
-    <module name="EqualsAvoidNull"/>
+    <module name="JavadocMethod">
+      <property name="id" value="javadocMethod"/>
+    </module>
+    <module name="EqualsAvoidNull">
+      <property name="id" value="equalsAvoidNull"/>
+    </module>
   </module>
   <module name="SuppressionSingleFilter">
     <property name="files" value="Example2.java"/>
-    <property name="checks" value="JavadocMethod|EqualsAvoidNull"/>
+    <property name="id" value="javadocMethod"/>
   </module>
 </module>
 */


### PR DESCRIPTION
Issue: #16729

Added examples to demonstrate usage of "column" and "id" properties in SuppressionSingleFilter:
1. Added "column" property to Example1.java
2. Modified Example2.java to use "id" property instead of "checks"
3. Created Example11.java showing combined usage of both properties
4. Updated documentation in suppressionsinglefilter.xml.template
5. Added tests in SuppressionSingleFilterExamplesTest.java