### PR TITLE
Issue #13999: Resolved Pitest Suppression in JavadocNodeImpl

### DIFF
--- a/config/error-prone-suppressions/compile-phase-suppressions.xml
+++ b/config/error-prone-suppressions/compile-phase-suppressions.xml
@@ -1,11 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <suppressedErrors>
-  <error>
-    <sourceFile>JavadocNodeImpl.java</sourceFile>
-    <bugPattern>ArrayHashCode</bugPattern>
-    <description>hashcode method on array does not hash array contents</description>
-    <lineContent>+ &quot;, children=&quot; + Objects.hashCode(children)</lineContent>
-  </error>
   <!-- Better suggestion after https://github.com/PicnicSupermarket/error-prone-support/issues/954. -->
   <error>
     <sourceFile>PropertiesMacro.java</sourceFile>

--- a/config/pitest-suppressions/pitest-javadoc-suppressions.xml
+++ b/config/pitest-suppressions/pitest-javadoc-suppressions.xml
@@ -1,15 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <suppressedMutations>
   <mutation unstable="false">
-    <sourceFile>JavadocNodeImpl.java</sourceFile>
-    <mutatedClass>com.puppycrawl.tools.checkstyle.checks.javadoc.JavadocNodeImpl</mutatedClass>
-    <mutatedMethod>toString</mutatedMethod>
-    <mutator>org.pitest.mutationtest.engine.gregor.mutators.NonVoidMethodCallMutator</mutator>
-    <description>removed call to java/util/Objects::hashCode</description>
-    <lineContent>+ &quot;, children=&quot; + Objects.hashCode(children)</lineContent>
-  </mutation>
-
-  <mutation unstable="false">
     <sourceFile>JavadocTagInfo.java</sourceFile>
     <mutatedClass>com.puppycrawl.tools.checkstyle.checks.javadoc.JavadocTagInfo$11</mutatedClass>
     <mutatedMethod>isValidOn</mutatedMethod>

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocNodeImpl.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocNodeImpl.java
@@ -19,7 +19,7 @@
 
 package com.puppycrawl.tools.checkstyle.checks.javadoc;
 
-import java.util.Objects;
+import java.util.Arrays;
 import java.util.Optional;
 
 import com.puppycrawl.tools.checkstyle.api.DetailNode;
@@ -180,7 +180,7 @@ public class JavadocNodeImpl implements DetailNode {
                 + ", text='" + text + '\''
                 + ", lineNumber=" + lineNumber
                 + ", columnNumber=" + columnNumber
-                + ", children=" + Objects.hashCode(children)
+                + ", children=" + Arrays.hashCode(children)
                 + ", parent=" + parent + ']';
     }
 

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocNodeImplTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocNodeImplTest.java
@@ -21,6 +21,8 @@ package com.puppycrawl.tools.checkstyle.checks.javadoc;
 
 import static com.google.common.truth.Truth.assertWithMessage;
 
+import java.util.Arrays;
+
 import org.junit.jupiter.api.Test;
 
 import com.puppycrawl.tools.checkstyle.api.JavadocTokenTypes;
@@ -33,13 +35,19 @@ public class JavadocNodeImplTest {
         javadocNode.setType(JavadocTokenTypes.CODE_LITERAL);
         javadocNode.setLineNumber(1);
         javadocNode.setColumnNumber(2);
+        final JavadocNodeImpl child1 = new JavadocNodeImpl();
+        final JavadocNodeImpl child2 = new JavadocNodeImpl();
+        child1.setType(JavadocTokenTypes.CODE_LITERAL);
+        child2.setType(JavadocTokenTypes.CODE_LITERAL);
+        javadocNode.setChildren(child1, child2);
 
         final String result = javadocNode.toString();
 
         assertWithMessage("Invalid toString result")
             .that(result)
             .isEqualTo("JavadocNodeImpl[index=0, type=CODE_LITERAL, text='null', lineNumber=1,"
-                + " columnNumber=2, children=0, parent=null]");
+                + " columnNumber=2, children=" + Arrays.hashCode(javadocNode.getChildren())
+                + ", parent=null]");
     }
 
     @Test


### PR DESCRIPTION
Issue: #13999 

Resolved Pitest Suppression in [JavadocNodeImpl.java](https://github.com/checkstyle/checkstyle/blob/master/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocNodeImpl.java)

**Mutation** - `toString : removed call to java/util/Objects::hashCode → SURVIVED`

- Objects.hashCode(children) returns the array's identity hash code, not a content-based hash. In assertions, this leads to incorrect evaluations since the actual contents of the array are ignored.

- Static analysis tools flag this under the ArrayHashCode bug pattern when used in logical contexts like assert. The same call in toString() is not flagged, as it's treated as non-functional and purely informational.
 
- Despite this, using Objects.hashCode() limits functionality even in toString(), as it doesn't reflect the true structure of the array.
 Thus replaced with Arrays.hashCode(children) to compute a hash based on array contents.
 
- This ensures semantic correctness and helps eliminate false positives in mutation testing.

**Mutation killed** -> `removed call to java/util/Objects::hashCode → KILLED`