### PR TITLE
Issue #11166: Removed usage of getFileContents() in EmptyLineSeparatorCheck

### DIFF
--- a/config/suppressions.xml
+++ b/config/suppressions.xml
@@ -125,7 +125,6 @@
   <suppress id="noUsageOfGetFileContentsMethod" files="WriteTagCheck.java"/>
   <suppress id="noUsageOfGetFileContentsMethod" files="RegexpCheck.java"/>
   <suppress id="noUsageOfGetFileContentsMethod" files="RegexpSinglelineJavaCheck.java"/>
-  <suppress id="noUsageOfGetFileContentsMethod" files="EmptyLineSeparatorCheck.java"/>
   <suppress id="noUsageOfGetFileContentsMethod" files="AvoidEscapedUnicodeCharactersCheck.java"/>
 
   <!-- until https://github.com/checkstyle/checkstyle/issues/5234 -->

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/whitespace/EmptyLineSeparatorCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/whitespace/EmptyLineSeparatorCheck.java
@@ -27,7 +27,6 @@ import java.util.Optional;
 import com.puppycrawl.tools.checkstyle.StatelessCheck;
 import com.puppycrawl.tools.checkstyle.api.AbstractCheck;
 import com.puppycrawl.tools.checkstyle.api.DetailAST;
-import com.puppycrawl.tools.checkstyle.api.FileContents;
 import com.puppycrawl.tools.checkstyle.api.TokenTypes;
 import com.puppycrawl.tools.checkstyle.utils.CheckUtil;
 import com.puppycrawl.tools.checkstyle.utils.CommonUtil;
@@ -661,15 +660,12 @@ public class EmptyLineSeparatorCheck extends AbstractCheck {
      * @return {@code true} if found any blank line within the range, {@code false}
      *         otherwise
      */
-    // suppress deprecation until https://github.com/checkstyle/checkstyle/issues/11166
-    @SuppressWarnings("deprecation")
     private boolean hasEmptyLine(int startLine, int endLine) {
         // Initial value is false - blank line not found
         boolean result = false;
-        final FileContents fileContents = getFileContents();
         for (int line = startLine; line <= endLine; line++) {
             // Check, if the line is blank. Lines are numbered from 0, so subtract 1
-            if (fileContents.lineIsBlank(line - 1)) {
+            if (CommonUtil.isBlank(getLine(line - 1))) {
                 result = true;
                 break;
             }


### PR DESCRIPTION
Issue: #11166

**Usage of getFileContents() removed for lline:**
` if (fileContents.lineIsBlank(line - 1))`

**Suppression removed:**
` <suppress id="noUsageOfGetFileContentsMethod" files="EmptyLineSeparatorCheck.java"/>`

**Updated Block**
```
 private boolean hasEmptyLine(int startLine, int endLine) {
        // Initial value is false - blank line not found
        boolean result = false;
        for (int line = startLine; line <= endLine; line++) {
            // Check, if the line is blank. Lines are numbered from 0, so subtract 1
            if (CommonUtil.isBlank(getLine(line - 1))) {
                result = true;
                break;
            }
        }
        return result;
    }
```

Diff Regression config: 
https://github.com/Atharv3221/checkstyle/blob/master/src/main/java/com/puppycrawl/tools/checkstyle/checks/whitespace/EmptyLineSeparatorCheck.java
Diff Regression patch config:
https://github.com/Atharv3221/checkstyle/blob/goodFifth/src/main/java/com/puppycrawl/tools/checkstyle/checks/whitespace/EmptyLineSeparatorCheck.java
New module config:
https://github.com/Atharv3221/checkstyle/blob/master/src/main/java/com/puppycrawl/tools/checkstyle/checks/whitespace/EmptyLineSeparatorCheck.java
Diff Regression Projects:
https://raw.githubusercontent.com/checkstyle/contribution/master/checkstyle-tester/projects-to-test-on.properties
GitHub, generate report