### PR TITLE
Issue #14019: Kill Mutation For CheckstyleAntTask: processFiles()

### DIFF
--- a/config/pitest-suppressions/pitest-ant-suppressions.xml
+++ b/config/pitest-suppressions/pitest-ant-suppressions.xml
@@ -93,15 +93,6 @@
   <mutation unstable="false">
     <sourceFile>CheckstyleAntTask.java</sourceFile>
     <mutatedClass>com.puppycrawl.tools.checkstyle.ant.CheckstyleAntTask</mutatedClass>
-    <mutatedMethod>processFiles</mutatedMethod>
-    <mutator>org.pitest.mutationtest.engine.gregor.mutators.NonVoidMethodCallMutator</mutator>
-    <description>removed call to com/puppycrawl/tools/checkstyle/ant/CheckstyleAntTask::getLocation</description>
-    <lineContent>throw new BuildException(failureMsg, getLocation());</lineContent>
-  </mutation>
-
-  <mutation unstable="false">
-    <sourceFile>CheckstyleAntTask.java</sourceFile>
-    <mutatedClass>com.puppycrawl.tools.checkstyle.ant.CheckstyleAntTask</mutatedClass>
     <mutatedMethod>retrieveAllScannedFiles</mutatedMethod>
     <mutator>org.pitest.mutationtest.engine.gregor.mutators.NonVoidMethodCallMutator</mutator>
     <description>removed call to java/lang/Integer::valueOf</description>

--- a/src/test/java/com/puppycrawl/tools/checkstyle/ant/CheckstyleAntTaskTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/ant/CheckstyleAntTaskTest.java
@@ -358,12 +358,18 @@ public class CheckstyleAntTaskTest extends AbstractPathTestSupport {
         final CheckstyleAntTask antTask = getCheckstyleAntTask();
         antTask.setFile(new File(getPath(WARNING_INPUT)));
         antTask.setMaxWarnings(0);
+        final Location fileLocation = new Location("build.xml", 42, 10);
+        antTask.setLocation(fileLocation);
+
         final BuildException ex = getExpectedThrowable(BuildException.class,
                 antTask::execute,
                 "BuildException is expected");
         assertWithMessage("Error message is unexpected")
                 .that(ex.getMessage())
                 .isEqualTo("Got 0 errors (max allowed: 0) and 1 warnings.");
+        assertWithMessage("Location is missing in exception")
+                .that(ex.getLocation())
+                .isEqualTo(fileLocation);
     }
 
     @Test


### PR DESCRIPTION
issue #14019 

removed call to com/puppycrawl/tools/checkstyle/ant/CheckstyleAntTask::getLocation
```xml
<mutation unstable="false">
  <sourceFile>CheckstyleAntTask.java</sourceFile>
  <mutatedClass>com.puppycrawl.tools.checkstyle.ant.CheckstyleAntTask</mutatedClass>
  <mutatedMethod>processFiles</mutatedMethod>
  <mutator>org.pitest.mutationtest.engine.gregor.mutators.NonVoidMethodCallMutator</mutator>
  <description>removed call to com/puppycrawl/tools/checkstyle/ant/CheckstyleAntTask::getLocation</description>
  <lineContent>throw new BuildException(failureMsg, getLocation());</lineContent>
</mutation>
 ```