### PR TITLE
Update sponsoring.xml

### DIFF
--- a/src/site/xdoc/sponsoring.xml
+++ b/src/site/xdoc/sponsoring.xml
@@ -19,16 +19,6 @@
 
       <p>
         <span class="wrapper">
-          <a href="https://flattr.com/submit/auto?fid=g39d10&amp;url=https%3A%2F%2Fcheckstyle.org"
-             target="_blank">
-            <span class="wrapper inline">
-              <img src="https://button.flattr.com/flattr-badge-large.png"
-                   alt="Flattr this" title="Flattr this" border="0"/>
-            </span>
-          </a>
-        </span>
-        <br/>
-        <span class="wrapper">
           <a href="https://liberapay.com/checkstyle/">
             <span class="wrapper inline">
               <img src="https://liberapay.com/assets/widgets/donate.svg"


### PR DESCRIPTION
### Fixes #16759

Flattr donation link has been removed from the Sponsoring page because the Flattr service was officially discontinued.

- Removed broken Flattr link and image.
- Verified other donation links are still working (Liberapay, OpenCollective, FreedomSponsors).

Let me know if you'd like me to add a replacement donation method.
