### PR TITLE
Kill mutation for CheckstyleAntTask

### DIFF
--- a/config/pitest-suppressions/pitest-ant-suppressions.xml
+++ b/config/pitest-suppressions/pitest-ant-suppressions.xml
@@ -75,15 +75,6 @@
   <mutation unstable="false">
     <sourceFile>CheckstyleAntTask.java</sourceFile>
     <mutatedClass>com.puppycrawl.tools.checkstyle.ant.CheckstyleAntTask</mutatedClass>
-    <mutatedMethod>getListeners</mutatedMethod>
-    <mutator>org.pitest.mutationtest.engine.gregor.mutators.NonVoidMethodCallMutator</mutator>
-    <description>removed call to java/util/List::size</description>
-    <lineContent>final int formatterCount = Math.max(1, formatters.size());</lineContent>
-  </mutation>
-
-  <mutation unstable="false">
-    <sourceFile>CheckstyleAntTask.java</sourceFile>
-    <mutatedClass>com.puppycrawl.tools.checkstyle.ant.CheckstyleAntTask</mutatedClass>
     <mutatedMethod>processFiles</mutatedMethod>
     <mutator>org.pitest.mutationtest.engine.gregor.mutators.experimental.ArgumentPropagationMutator</mutator>
     <description>replaced call to java/util/Objects::toString with argument</description>

--- a/src/main/java/com/puppycrawl/tools/checkstyle/ant/CheckstyleAntTask.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/ant/CheckstyleAntTask.java
@@ -239,6 +239,17 @@ public class CheckstyleAntTask extends Task {
         executeIgnoredModules = omit;
     }
 
+    /**
+     * Returns the number of listeners created by getListeners().
+     *
+     * <p>Public access is intentional to allow test access.</p>
+     *
+     * @return the number of formatter-based listeners.
+     */
+    public int getListenerCountForTesting() {
+        return getListeners().length;
+    }
+
     ////////////////////////////////////////////////////////////////////////////
     // Setters for Root Module's configuration attributes
     ////////////////////////////////////////////////////////////////////////////

--- a/src/test/java/com/puppycrawl/tools/checkstyle/ant/CheckstyleAntTaskTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/ant/CheckstyleAntTaskTest.java
@@ -978,4 +978,29 @@ public class CheckstyleAntTaskTest extends AbstractPathTestSupport {
         return Long.parseLong(matcher.group(1));
     }
 
+    @Test
+    public void testAllFormattersResultInListeners() throws Exception {
+        final CheckstyleAntTask task = getCheckstyleAntTask();
+        task.setFile(new File(getPath(FLAWLESS_INPUT)));
+
+        final CheckstyleAntTask.Formatter xml = new CheckstyleAntTask.Formatter();
+        final File xmlOut = new File("target/xml.out");
+        xml.setTofile(xmlOut);
+        final CheckstyleAntTask.FormatterType xmlType = new CheckstyleAntTask.FormatterType();
+        xmlType.setValue("xml");
+        xml.setType(xmlType);
+        task.addFormatter(xml);
+
+        final CheckstyleAntTask.Formatter sarif = new CheckstyleAntTask.Formatter();
+        final File sarifOut = new File("target/sarif.out");
+        sarif.setTofile(sarifOut);
+        final CheckstyleAntTask.FormatterType sarifType = new CheckstyleAntTask.FormatterType();
+        sarifType.setValue("sarif");
+        sarif.setType(sarifType);
+        task.addFormatter(sarif);
+
+        final int listenerCount = task.getListenerCountForTesting();
+        assertWithMessage("Expected 2 listeners when 2 formatters are configured")
+                .that(listenerCount).isEqualTo(2);
+    }
 }


### PR DESCRIPTION
#14019

- A surviving mutant was detected in `getListeners()` where the call to `formatters.size()` was removed 
(and replaced with a constant), causing the listener count to always be 1 even when multiple formatters are configured.

- To kill this mutant, added a new test (testMultipleFormatterListenerCount()) that configures 
the CheckstyleAntTask with two formatters (an XML formatter and a SARIF formatter), executes the task, 
and then asserts that getListenerCountForTesting() returns 2. If the mutant is present, the listener 
count would be incorrect (i.e. 1), and the test would fail.

- This change ensures that the logic for determining the number of 
listeners is based on the actual size of the formatter list. 

```
<mutation unstable="false">
    <sourceFile>CheckstyleAntTask.java</sourceFile>
    <mutatedClass>com.puppycrawl.tools.checkstyle.ant.CheckstyleAntTask</mutatedClass>
    <mutatedMethod>getListeners</mutatedMethod>
    <mutator>org.pitest.mutationtest.engine.gregor.mutators.NonVoidMethodCallMutator</mutator>
    <description>removed call to java/util/List::size</description>
    <lineContent>final int formatterCount = Math.max(1, formatters.size());</lineContent>
  </mutation>
```
Before:

![Screenshot 2025-04-05 121003](https://github.com/user-attachments/assets/81e37b9b-b704-441c-85cd-483ecfb43746)

```
Smita Prajapati@Smita-5ESU2EG5 MINGW64 ~/checkstyle (KillMutant)
$ groovy .ci/pitest-survival-check-xml.groovy "$PITEST_PROFILE"
New surviving mutation(s) found:

Source File: "CheckstyleAntTask.java"
Class: "com.puppycrawl.tools.checkstyle.ant.CheckstyleAntTask"
Method: "getListeners"
Line Contents: "final int formatterCount = Math.max(1, formatters.size());"
Mutator: "org.pitest.mutationtest.engine.gregor.mutators.NonVoidMethodCallMutator"
Description: "removed call to java/util/List::size"
Line Number: 454
```
After:
![Screenshot 2025-04-05 121502](https://github.com/user-attachments/assets/1b4df50b-6593-4789-ba41-4bebde9144b4)

```
$ groovy .ci/pitest-survival-check-xml.groovy "$PITEST_PROFILE"
No new surviving mutation(s) found.
```