### PR TITLE
Issue #16802: improve `spelling` and `typo` in `CheckstyleAntTask` - `whitespace`

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/ant/CheckstyleAntTask.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/ant/CheckstyleAntTask.java
@@ -335,7 +335,7 @@ public class CheckstyleAntTask extends Task {
         log("To locate the files took " + (endTime - startTime) + TIME_SUFFIX,
             Project.MSG_VERBOSE);
 
-        log("Running Checkstyle "
+        log("Running Checkstyle"
                 + checkstyleVersion
                 + " on " + files.size()
                 + " files", Project.MSG_INFO);

--- a/src/test/java/com/puppycrawl/tools/checkstyle/ant/CheckstyleAntTaskTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/ant/CheckstyleAntTaskTest.java
@@ -885,7 +885,7 @@ public class CheckstyleAntTaskTest extends AbstractPathTestSupport {
                 new MessageLevelPair("checkstyle version .*", Project.MSG_VERBOSE),
                 new MessageLevelPair("Adding standalone file for audit", Project.MSG_VERBOSE),
                 new MessageLevelPair("To locate the files took \\d+ ms.", Project.MSG_VERBOSE),
-                new MessageLevelPair("Running Checkstyle  on 1 files", Project.MSG_INFO),
+                new MessageLevelPair("Running Checkstyle on 1 files", Project.MSG_INFO),
                 new MessageLevelPair("Using configuration file:.*", Project.MSG_VERBOSE),
                 new MessageLevelPair(auditStartedMessage, Project.MSG_DEBUG),
                 new MessageLevelPair(auditFinishedMessage, Project.MSG_DEBUG),


### PR DESCRIPTION
Issue #16802: improve `spelling` and `typo` in `CheckstyleAntTask`

- https://github.com/checkstyle/checkstyle/pull/17043

fix whitespace typo
`Running Checkstyle on 1 files.`
`Running Checkstyle  on 1 files.`

I was wondering about this issue myself and found it accidentally while refactoring this class in #16772.