### PR TITLE
Issue #16759: Removed Broken Flattr Link and Image on Sponsoring Page

### DIFF
--- a/config/jsoref-spellchecker/whitelist.words
+++ b/config/jsoref-spellchecker/whitelist.words
@@ -456,7 +456,6 @@ FIXME
 Fjava
 Fjavadoc
 Flas
-flattr
 fluido
 Fmain
 Fmessages

--- a/pom.xml
+++ b/pom.xml
@@ -2133,10 +2133,6 @@
             <!-- Excluded due to linkcheck's issue #22:
                  https://issues.apache.org/jira/browse/MLINKCHECK-22 -->
             <excludedLink>https://twitter.com/checkstyle_java/</excludedLink>
-            <!-- linkcheck plugin can not resolve &amps; inside url -->
-            <excludedLink>https://flattr.com/submit/</excludedLink>
-            <!-- 403 forbidden for linkcheck, works in the browser -->
-            <excludedLink>https://button.flattr.com/flattr-badge-large.png</excludedLink>
             <!-- Too unstable sites to keep validate them -->
             <excludedLink>http://tide.olympe.in/*</excludedLink>
             <excludedLink>http://dl.acm.org/*</excludedLink>

--- a/src/site/xdoc/sponsoring.xml
+++ b/src/site/xdoc/sponsoring.xml
@@ -19,16 +19,6 @@
 
       <p>
         <span class="wrapper">
-          <a href="https://flattr.com/submit/auto?fid=g39d10&amp;url=https%3A%2F%2Fcheckstyle.org"
-             target="_blank">
-            <span class="wrapper inline">
-              <img src="https://button.flattr.com/flattr-badge-large.png"
-                   alt="Flattr this" title="Flattr this" border="0"/>
-            </span>
-          </a>
-        </span>
-        <br/>
-        <span class="wrapper">
           <a href="https://liberapay.com/checkstyle/">
             <span class="wrapper inline">
               <img src="https://liberapay.com/assets/widgets/donate.svg"


### PR DESCRIPTION
Fixes : #16759 
Closes: #16767 

Build status:

![Screenshot 2025-04-06 184418](https://github.com/user-attachments/assets/cb129e7f-d790-46c3-bdd3-58ff25eaac49)
