### PR TITLE
Issue #1241: Add table of contents macro to writinglisteners.xml.vm

### DIFF
--- a/src/site/xdoc/writinglisteners.xml.vm
+++ b/src/site/xdoc/writinglisteners.xml.vm
@@ -9,6 +9,12 @@
   </head>
 
   <body>
+    <section name="Content">
+      <macro name="toc">
+        <param name="fromDepth" value="1"/>
+        <param name="toDepth" value="1"/>
+      </macro>
+    </section>
 
     <section name="Overview">
       <p>


### PR DESCRIPTION
Fixes #1241 

Now https://checkstyle.org/writinglisteners.html

As mentioned in issue description to add Content section in two files but Content section was already there in config.xml. So we just need to add it to writinglisteners.xml.vm.

Here you can see content section of config.xml
![Screenshot 2025-04-07 181628](https://github.com/user-attachments/assets/376ebfd5-5316-42d5-a48c-b972b1d09154)

Build status ```mvn clean verify```
![Screenshot 2025-04-07 190443](https://github.com/user-attachments/assets/ae5d449e-fa72-49cf-8bef-a5ed0721bf62)
