### PR TITLE
Issue #16786: Ensure enum constants accessibility is properly evaluated

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocVariableCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocVariableCheck.java
@@ -44,7 +44,8 @@ import com.puppycrawl.tools.checkstyle.utils.UnmodifiableCollectionUtil;
  * such as package-private for fields without an explicit modifier.
  * It also accounts for special cases where fields have implicit modifiers,
  * such as {@code public static final} for interface fields and {@code public static}
- * for enum constants. Only fields matching the specified modifiers will be analyzed.
+ * for enum constants, or where the nesting types accessibility is more restrictive and hides the
+ * nested field. Only fields matching the specified modifiers will be analyzed.
  * Type is {@code com.puppycrawl.tools.checkstyle.checks.naming.AccessModifierOption[]}.
  * Default value is {@code public, protected, package, private}.
  * </li>
@@ -93,7 +94,8 @@ public class JavadocVariableCheck
      *  This includes both explicitly declared modifiers and implicit ones, such as package-private
      *  for fields without an explicit modifier. It also accounts for special cases where fields
      *  have implicit modifiers, such as {@code public static final} for interface fields and
-     *  {@code public static} for enum constants.
+     *  {@code public static} for enum constants, or where the nesting types accessibility is more
+     *  restrictive and hides the nested field.
      *  Only fields matching the specified modifiers will be analyzed.
      */
     private AccessModifierOption[] accessModifiers = {
@@ -111,7 +113,8 @@ public class JavadocVariableCheck
      * checked. This includes both explicitly declared modifiers and implicit ones, such as
      * package-private for fields without an explicit modifier. It also accounts for special
      * cases where fields have implicit modifiers, such as {@code public static final}
-     * for interface fields and {@code public static} for enum constants.
+     * for interface fields and {@code public static} for enum constants, or where the nesting
+     * types accessibility is more restrictive and hides the nested field.
      * Only fields matching the specified modifiers will be analyzed.
      *
      * @param accessModifiers access modifiers of fields to check.

--- a/src/main/java/com/puppycrawl/tools/checkstyle/utils/CheckUtil.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/utils/CheckUtil.java
@@ -314,20 +314,27 @@ public final class CheckUtil {
      * @return the access modifier of the method/constructor.
      */
     public static AccessModifierOption getAccessModifierFromModifiersToken(DetailAST ast) {
-        AccessModifierOption accessModifier;
-        if (ast.getType() == TokenTypes.ENUM_CONSTANT_DEF) {
-            accessModifier = AccessModifierOption.PUBLIC;
-        }
-        else {
-            final DetailAST modsToken = ast.findFirstToken(TokenTypes.MODIFIERS);
-            accessModifier = getAccessModifierFromModifiersTokenDirectly(modsToken);
+        // In some scenarios we want to investigate a parent AST instead
+        DetailAST selectedAst = ast;
+
+        if (selectedAst.getType() == TokenTypes.ENUM_CONSTANT_DEF) {
+            // Enum constants don't have modifiers
+            // implicitly public but validate against parent(s)
+            while (selectedAst.getType() != TokenTypes.ENUM_DEF) {
+                selectedAst = selectedAst.getParent();
+            }
         }
 
+        final DetailAST modsToken = selectedAst.findFirstToken(TokenTypes.MODIFIERS);
+        AccessModifierOption accessModifier =
+                getAccessModifierFromModifiersTokenDirectly(modsToken);
+
         if (accessModifier == AccessModifierOption.PACKAGE) {
-            if (ScopeUtil.isInEnumBlock(ast) && ast.getType() == TokenTypes.CTOR_DEF) {
+            if (ScopeUtil.isInEnumBlock(selectedAst)
+                    && selectedAst.getType() == TokenTypes.CTOR_DEF) {
                 accessModifier = AccessModifierOption.PRIVATE;
             }
-            else if (ScopeUtil.isInInterfaceOrAnnotationBlock(ast)) {
+            else if (ScopeUtil.isInInterfaceOrAnnotationBlock(selectedAst)) {
                 accessModifier = AccessModifierOption.PUBLIC;
             }
         }

--- a/src/main/resources/com/puppycrawl/tools/checkstyle/meta/checks/javadoc/JavadocVariableCheck.xml
+++ b/src/main/resources/com/puppycrawl/tools/checkstyle/meta/checks/javadoc/JavadocVariableCheck.xml
@@ -16,7 +16,8 @@
  such as package-private for fields without an explicit modifier.
  It also accounts for special cases where fields have implicit modifiers,
  such as {@code public static final} for interface fields and {@code public static}
- for enum constants. Only fields matching the specified modifiers will be analyzed.</description>
+ for enum constants, or where the nesting types accessibility is more restrictive and hides the
+ nested field. Only fields matching the specified modifiers will be analyzed.</description>
             </property>
             <property name="ignoreNamePattern" type="java.util.regex.Pattern">
                <description>Specify the regexp to define variable names to ignore.</description>

--- a/src/site/xdoc/checks/javadoc/javadocvariable.xml
+++ b/src/site/xdoc/checks/javadoc/javadocvariable.xml
@@ -27,7 +27,7 @@
             </tr>
             <tr>
               <td>accessModifiers</td>
-              <td>Specify the set of access modifiers used to determine which fields should be checked. This includes both explicitly declared modifiers and implicit ones, such as package-private for fields without an explicit modifier. It also accounts for special cases where fields have implicit modifiers, such as <code>public static final</code> for interface fields and <code>public static</code> for enum constants. Only fields matching the specified modifiers will be analyzed.</td>
+              <td>Specify the set of access modifiers used to determine which fields should be checked. This includes both explicitly declared modifiers and implicit ones, such as package-private for fields without an explicit modifier. It also accounts for special cases where fields have implicit modifiers, such as <code>public static final</code> for interface fields and <code>public static</code> for enum constants, or where the nesting types accessibility is more restrictive and hides the nested field. Only fields matching the specified modifiers will be analyzed.</td>
               <td><a href="../../property_types.html#AccessModifierOption.5B.5D">AccessModifierOption[]</a></td>
               <td><code>public, protected, package, private</code></td>
               <td>10.22.0</td>
@@ -85,6 +85,13 @@ public class Example1 {
   public int d; // violation, 'Missing a Javadoc comment'
   /*package*/ int e; // violation, 'Missing a Javadoc comment'
 
+  public enum PublicEnum {
+    CONSTANT // violation, 'Missing a Javadoc comment'
+  }
+
+  private enum PrivateEnum {
+    CONSTANT // violation, 'Missing a Javadoc comment'
+  }
 }
 </code></pre></div><hr class="example-separator"/>
         <p id="Example2-config">
@@ -116,6 +123,14 @@ public class Example2 {
   protected int c;
   public int d; // violation, 'Missing a Javadoc comment'
   /*package*/ int e;
+
+  public enum PublicEnum {
+    CONSTANT // violation, 'Missing a Javadoc comment'
+  }
+
+  private enum PrivateEnum {
+    CONSTANT
+  }
 }
 </code></pre></div><hr class="example-separator"/>
         <p id="Example3-config">
@@ -147,6 +162,14 @@ public class Example3 {
   protected int c;
   public int d;
   /*package*/ int e; // violation, 'Missing a Javadoc comment'
+
+  public enum PublicEnum {
+    CONSTANT
+  }
+
+  private enum PrivateEnum {
+    CONSTANT // violation, 'Missing a Javadoc comment'
+  }
 }
 </code></pre></div><hr class="example-separator"/>
         <p id="Example4-config">
@@ -179,6 +202,14 @@ public class Example4 {
   protected int c; // violation, 'Missing a Javadoc comment'
   public int d; // violation, 'Missing a Javadoc comment'
   /*package*/ int e; // violation, 'Missing a Javadoc comment'
+
+  public enum PublicEnum {
+    CONSTANT // violation, 'Missing a Javadoc comment'
+  }
+
+  private enum PrivateEnum {
+    CONSTANT // violation, 'Missing a Javadoc comment'
+  }
 }
 </code></pre></div>
 
@@ -192,6 +223,14 @@ public class Example5 {
   protected int variableProtected; // violation, 'Missing a Javadoc comment'
   int variablePackage; // violation, 'Missing a Javadoc comment'
   private int variablePrivate; // violation, 'Missing a Javadoc comment'
+
+  public enum PublicEnum {
+    CONSTANT // violation, 'Missing a Javadoc comment'
+  }
+
+  private enum PrivateEnum {
+    CONSTANT // violation, 'Missing a Javadoc comment'
+  }
 
   public void testMethodInnerClass() {
 

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocVariableCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocVariableCheckTest.java
@@ -201,6 +201,7 @@ public class JavadocVariableCheckTest
             "97:9: " + getCheckMessage(MSG_JAVADOC_MISSING),
             "108:9: " + getCheckMessage(MSG_JAVADOC_MISSING),
             "109:9: " + getCheckMessage(MSG_JAVADOC_MISSING),
+            "130:9: " + getCheckMessage(MSG_JAVADOC_MISSING),
         };
         verifyWithInlineConfigParser(
                 getPath("InputJavadocVariableNoJavadoc2.java"),

--- a/src/test/java/com/puppycrawl/tools/checkstyle/utils/CheckUtilTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/utils/CheckUtilTest.java
@@ -227,7 +227,7 @@ public class CheckUtilTest extends AbstractModuleTestSupport {
                 .getAccessModifierFromModifiersToken(enumConstantDefinition);
         assertWithMessage("Invalid access modifier")
                 .that(modifierEnumConstant)
-                .isEqualTo(AccessModifierOption.PUBLIC);
+                .isEqualTo(AccessModifierOption.PACKAGE);
     }
 
     @Test

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadocvariable/InputJavadocVariableNoJavadoc2.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadocvariable/InputJavadocVariableNoJavadoc2.java
@@ -125,4 +125,12 @@ class  PackageClass2 {
 
     /**/
     void methodWithTwoStarComment() {}
+
+    public enum PublicEnum {
+        CONSTANT // violation, 'Missing a Javadoc comment'
+    }
+
+    private enum PrivateEnum {
+        CONSTANT
+    }
 }

--- a/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocVariableCheckExamplesTest.java
+++ b/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocVariableCheckExamplesTest.java
@@ -38,6 +38,8 @@ public class JavadocVariableCheckExamplesTest extends AbstractExamplesModuleTest
             "18:3: " + getCheckMessage(MSG_JAVADOC_MISSING),
             "19:3: " + getCheckMessage(MSG_JAVADOC_MISSING),
             "20:15: " + getCheckMessage(MSG_JAVADOC_MISSING),
+            "23:5: " + getCheckMessage(MSG_JAVADOC_MISSING),
+            "27:5: " + getCheckMessage(MSG_JAVADOC_MISSING),
         };
         verifyWithInlineConfigParser(getPath("Example1.java"), expected);
     }
@@ -46,6 +48,7 @@ public class JavadocVariableCheckExamplesTest extends AbstractExamplesModuleTest
     public void testExample2() throws Exception {
         final String[] expected = {
             "21:3: " + getCheckMessage(MSG_JAVADOC_MISSING),
+            "25:5: " + getCheckMessage(MSG_JAVADOC_MISSING),
         };
 
         verifyWithInlineConfigParser(getPath("Example2.java"), expected);
@@ -56,6 +59,7 @@ public class JavadocVariableCheckExamplesTest extends AbstractExamplesModuleTest
         final String[] expected = {
             "14:3: " + getCheckMessage(MSG_JAVADOC_MISSING),
             "22:15: " + getCheckMessage(MSG_JAVADOC_MISSING),
+            "29:5: " + getCheckMessage(MSG_JAVADOC_MISSING),
         };
 
         verifyWithInlineConfigParser(getPath("Example3.java"), expected);
@@ -68,8 +72,24 @@ public class JavadocVariableCheckExamplesTest extends AbstractExamplesModuleTest
             "20:3: " + getCheckMessage(MSG_JAVADOC_MISSING),
             "21:3: " + getCheckMessage(MSG_JAVADOC_MISSING),
             "22:15: " + getCheckMessage(MSG_JAVADOC_MISSING),
+            "25:5: " + getCheckMessage(MSG_JAVADOC_MISSING),
+            "29:5: " + getCheckMessage(MSG_JAVADOC_MISSING),
         };
 
         verifyWithInlineConfigParser(getPath("Example4.java"), expected);
+    }
+
+    @Test
+    public void testExample5() throws Exception {
+        final String[] expected = {
+            "12:3: " + getCheckMessage(MSG_JAVADOC_MISSING),
+            "13:3: " + getCheckMessage(MSG_JAVADOC_MISSING),
+            "14:3: " + getCheckMessage(MSG_JAVADOC_MISSING),
+            "15:3: " + getCheckMessage(MSG_JAVADOC_MISSING),
+            "18:5: " + getCheckMessage(MSG_JAVADOC_MISSING),
+            "22:5: " + getCheckMessage(MSG_JAVADOC_MISSING),
+        };
+
+        verifyWithInlineConfigParser(getPath("Example5.java"), expected);
     }
 }

--- a/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadocvariable/Example1.java
+++ b/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadocvariable/Example1.java
@@ -19,5 +19,12 @@ public class Example1 {
   public int d; // violation, 'Missing a Javadoc comment'
   /*package*/ int e; // violation, 'Missing a Javadoc comment'
 
+  public enum PublicEnum {
+    CONSTANT // violation, 'Missing a Javadoc comment'
+  }
+
+  private enum PrivateEnum {
+    CONSTANT // violation, 'Missing a Javadoc comment'
+  }
 }
 // xdoc section -- end

--- a/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadocvariable/Example2.java
+++ b/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadocvariable/Example2.java
@@ -20,5 +20,13 @@ public class Example2 {
   protected int c;
   public int d; // violation, 'Missing a Javadoc comment'
   /*package*/ int e;
+
+  public enum PublicEnum {
+    CONSTANT // violation, 'Missing a Javadoc comment'
+  }
+
+  private enum PrivateEnum {
+    CONSTANT
+  }
 }
 // xdoc section -- end

--- a/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadocvariable/Example3.java
+++ b/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadocvariable/Example3.java
@@ -20,5 +20,13 @@ public class Example3 {
   protected int c;
   public int d;
   /*package*/ int e; // violation, 'Missing a Javadoc comment'
+
+  public enum PublicEnum {
+    CONSTANT
+  }
+
+  private enum PrivateEnum {
+    CONSTANT // violation, 'Missing a Javadoc comment'
+  }
 }
 // xdoc section -- end

--- a/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadocvariable/Example4.java
+++ b/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadocvariable/Example4.java
@@ -20,5 +20,13 @@ public class Example4 {
   protected int c; // violation, 'Missing a Javadoc comment'
   public int d; // violation, 'Missing a Javadoc comment'
   /*package*/ int e; // violation, 'Missing a Javadoc comment'
+
+  public enum PublicEnum {
+    CONSTANT // violation, 'Missing a Javadoc comment'
+  }
+
+  private enum PrivateEnum {
+    CONSTANT // violation, 'Missing a Javadoc comment'
+  }
 }
 // xdoc section -- end

--- a/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadocvariable/Example5.java
+++ b/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadocvariable/Example5.java
@@ -14,6 +14,14 @@ public class Example5 {
   int variablePackage; // violation, 'Missing a Javadoc comment'
   private int variablePrivate; // violation, 'Missing a Javadoc comment'
 
+  public enum PublicEnum {
+    CONSTANT // violation, 'Missing a Javadoc comment'
+  }
+
+  private enum PrivateEnum {
+    CONSTANT // violation, 'Missing a Javadoc comment'
+  }
+
   public void testMethodInnerClass() {
 
     // This check ignores local classes.


### PR DESCRIPTION
Extends change in https://github.com/checkstyle/checkstyle/pull/16049, in the case of an enum constant, it's accessibility will be derived based on the enclosing enum (which could be `private`) rather than being assumed to be implicitly public.

Test(s) added to validate.

Fixes: https://github.com/checkstyle/checkstyle/issues/16786
Closes: https://github.com/checkstyle/checkstyle/pull/17112