### PR TITLE
Issue #15456: Defined violation message for ConstantNameCheck in InlineConfigParser.java

### DIFF
--- a/src/test/java/com/puppycrawl/tools/checkstyle/bdd/InlineConfigParser.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/bdd/InlineConfigParser.java
@@ -269,7 +269,6 @@ public final class InlineConfigParser {
             "com.puppycrawl.tools.checkstyle.checks.modifier.RedundantModifierCheck",
             "com.puppycrawl.tools.checkstyle.checks.naming.AbbreviationAsWordInNameCheck",
 
-            "com.puppycrawl.tools.checkstyle.checks.naming.ConstantNameCheck",
             "com.puppycrawl.tools.checkstyle.checks.naming.IllegalIdentifierNameCheck",
             "com.puppycrawl.tools.checkstyle.checks.naming.LocalVariableNameCheck",
             "com.puppycrawl.tools.checkstyle.checks.naming.MethodTypeParameterNameCheck",

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/naming/constantname/InputConstantNameInner.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/naming/constantname/InputConstantNameInner.java
@@ -28,7 +28,7 @@ class InputConstantNameInner
     interface InnerInterface2
     {
         // Ignore - should be all upper case
-        String data = "zxzc"; // violation
+        String data = "zxzc"; // violation 'Name 'data' must match pattern'
 
         // Ignore
         class InnerInterfaceInnerClass
@@ -68,7 +68,7 @@ class InputConstantNameInner
     @interface InnerAnnotation
     {
         /** Ignore - should be all upper case. */
-        String data = "zxzc"; // violation
+        String data = "zxzc"; // violation 'Name 'data' must match pattern'
     }
 
     /** enum with public member variable */

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/naming/constantname/InputConstantNameMemberExtended.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/naming/constantname/InputConstantNameMemberExtended.java
@@ -53,15 +53,15 @@ public class InputConstantNameMemberExtended
 
 interface In
 {
-    public int mPublic = 0; // violation
-    int mProtected = 0; // violation
-    int mPackage = 0; // violation
-    int mPrivate = 0; // violation
+    public int mPublic = 0; // violation 'Name 'mPublic' must match pattern'
+    int mProtected = 0; // violation 'Name 'mProtected' must match pattern'
+    int mPackage = 0; // violation 'Name 'mPackage' must match pattern'
+    int mPrivate = 0; // violation 'Name 'mPrivate' must match pattern'
 
-    public int _public = 0; // violation
-    int _protected = 0; // violation
-    int _package = 0; // violation
-    int _private = 0; // violation
+    public int _public = 0; // violation 'Name '_public' must match pattern'
+    int _protected = 0; // violation 'Name '_protected' must match pattern'
+    int _package = 0; // violation 'Name '_package' must match pattern'
+    int _private = 0; // violation 'Name '_private' must match pattern'
 }
 
 enum Direction {

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/naming/constantname/InputConstantNameSimple1.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/naming/constantname/InputConstantNameSimple1.java
@@ -28,7 +28,7 @@ final class InputConstantNameSimple1
     // Name format tests
     //
     /** Invalid format **/
-    public static final int badConstant = 2; // violation
+    public static final int badConstant = 2; // violation 'Name 'badConstant' must match pattern'
     /** Valid format **/
     public static final int MAX_ROWS = 2;
 
@@ -145,7 +145,7 @@ final class InputConstantNameSimple1
     }
 
     /** test illegal constant **/
-    private static final int BAD__NAME = 3; // violation
+    private static final int BAD__NAME = 3; // violation 'Name 'BAD__NAME' must match pattern'
 
     // A very, very long line that is OK because it matches the regexp "^.*is OK.*regexp.*$"
     // long line that has a tab ->        <- and would be OK if tab counted as 1 char

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/naming/constantname/InputConstantNameSimple2.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/naming/constantname/InputConstantNameSimple2.java
@@ -145,7 +145,7 @@ final class InputConstantNameSimple2
     }
 
     /** test illegal constant **/
-    private static final int BAD__NAME = 3; // violation
+    private static final int BAD__NAME = 3; // violation 'Name 'BAD__NAME' must match pattern'
 
     // A very, very long line that is OK because it matches the regexp "^.*is OK.*regexp.*$"
     // long line that has a tab ->        <- and would be OK if tab counted as 1 char


### PR DESCRIPTION
Issue #15456

## Test.java
```
/**
 * This is a test class for demonstrating Checkstyle violations.
 */
public class Test {
    public static final int badConstant = 2;
    private static final int BAD__NAME = 3;
    String data = "zxzc";
    public int mPublic = 0;
    int mProtected = 0;
    int mPackage = 0;
    int mPrivate = 0;

    public int _public = 0;
    int _protected = 0;
    int _package = 0;
    int _private = 0;
}
```
## config_check.xml
```
<?xml version="1.0"?>
<!DOCTYPE module PUBLIC
          "-//Checkstyle//DTD Checkstyle Configuration 1.3//EN"
          "https://checkstyle.org/dtds/configuration_1_3.dtd">

<module name="Checker">
  
  <!-- Use TreeWalker to apply checks on the AST -->
  <module name="TreeWalker">

    <!-- Enforce naming pattern for constants -->
    <module name="ConstantName">
      <property name="format" value="^[A-Z][A-Z0-9]*(_[A-Z0-9]+)*$"/>
    </module>

    <!-- Enforce same pattern for all member variables -->
    <module name="MemberName">
      <property name="format" value="^[A-Z][A-Z0-9]*(_[A-Z0-9]+)*$"/>
    </module>

  </module>
</module>
```
## Test output
```
$ java -jar checkstyle-10.23.0-all.jar -c config_check.xml Test.java
Starting audit...
[ERROR] F:\GitHub\headhtmltagname\Test.java:5:29: Name 'badConstant' must match pattern '^[A-Z][A-Z0-9]*(_[A-Z0-9]+)*$'. [ConstantName]
[ERROR] F:\GitHub\headhtmltagname\Test.java:6:30: Name 'BAD__NAME' must match pattern '^[A-Z][A-Z0-9]*(_[A-Z0-9]+)*$'. [ConstantName]
[ERROR] F:\GitHub\headhtmltagname\Test.java:7:12: Name 'data' must match pattern '^[A-Z][A-Z0-9]*(_[A-Z0-9]+)*$'. [MemberName]
[ERROR] F:\GitHub\headhtmltagname\Test.java:8:16: Name 'mPublic' must match pattern '^[A-Z][A-Z0-9]*(_[A-Z0-9]+)*$'. [MemberName]
[ERROR] F:\GitHub\headhtmltagname\Test.java:9:9: Name 'mProtected' must match pattern '^[A-Z][A-Z0-9]*(_[A-Z0-9]+)*$'. [MemberName]
[ERROR] F:\GitHub\headhtmltagname\Test.java:10:9: Name 'mPackage' must match pattern '^[A-Z][A-Z0-9]*(_[A-Z0-9]+)*$'. [MemberName]
[ERROR] F:\GitHub\headhtmltagname\Test.java:11:9: Name 'mPrivate' must match pattern '^[A-Z][A-Z0-9]*(_[A-Z0-9]+)*$'. [MemberName]
[ERROR] F:\GitHub\headhtmltagname\Test.java:13:16: Name '_public' must match pattern '^[A-Z][A-Z0-9]*(_[A-Z0-9]+)*$'. [MemberName]
[ERROR] F:\GitHub\headhtmltagname\Test.java:14:9: Name '_protected' must match pattern '^[A-Z][A-Z0-9]*(_[A-Z0-9]+)*$'. [MemberName]
[ERROR] F:\GitHub\headhtmltagname\Test.java:15:9: Name '_package' must match pattern '^[A-Z][A-Z0-9]*(_[A-Z0-9]+)*$'. [MemberName]
[ERROR] F:\GitHub\headhtmltagname\Test.java:16:9: Name '_private' must match pattern '^[A-Z][A-Z0-9]*(_[A-Z0-9]+)*$'. [MemberName]
Audit done.
Checkstyle ends with 11 errors.
```
## build output
![image](https://github.com/user-attachments/assets/8c44cf93-11bb-4f6c-a224-4160467e8295)
