### PR TITLE
Issue #15456: Defined violation message for PackageNameCheck in InlineConfigParser.java

### DIFF
--- a/src/test/java/com/puppycrawl/tools/checkstyle/bdd/InlineConfigParser.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/bdd/InlineConfigParser.java
@@ -272,7 +272,6 @@ public final class InlineConfigParser {
             "com.puppycrawl.tools.checkstyle.checks.naming.IllegalIdentifierNameCheck",
             "com.puppycrawl.tools.checkstyle.checks.naming.LocalVariableNameCheck",
             "com.puppycrawl.tools.checkstyle.checks.naming.MethodTypeParameterNameCheck",
-            "com.puppycrawl.tools.checkstyle.checks.naming.PackageNameCheck",
             "com.puppycrawl.tools.checkstyle.checks.naming.ParameterNameCheck",
             "com.puppycrawl.tools.checkstyle.checks.naming.PatternVariableNameCheck",
             "com.puppycrawl.tools.checkstyle.checks.naming.RecordComponentNameCheck",

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/naming/packagename/InputPackageNameSimple1.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/naming/packagename/InputPackageNameSimple1.java
@@ -5,7 +5,8 @@ format = [A-Z]+
 
 */
 
-package com.puppycrawl.tools.checkstyle.checks.naming.packagename; // violation
+package com.puppycrawl.tools.checkstyle.checks.naming.packagename;
+// violation above 'must match pattern'
 
 /**
  * Contains simple mistakes:


### PR DESCRIPTION
Issue #15456

## Test.java
```
package com.puppycrawl.tools.checkstyle.checks.naming.packagename;

/**
 * This is a test class for demonstrating Checkstyle violations.
 */
public class Test {
}
```
## config_check.xml
```
<?xml version="1.0"?>
<!DOCTYPE module PUBLIC
  "-//Checkstyle//DTD Checkstyle Configuration 1.3//EN"
  "https://checkstyle.org/dtds/configuration_1_3.dtd">

<module name="Checker">
  <module name="TreeWalker">
    <module name="PackageName">
      <property name="format" value="[A-Z]+"/>
    </module>
  </module>
</module>
```
## Test output
```
$ java -jar checkstyle-10.23.0-all.jar -c config_check.xml com/puppycrawl/tools/checkstyle/checks/naming/packagename/Test.java
Starting audit...
[ERROR] F:\GitHub\headhtmltagname\com\puppycrawl\tools\checkstyle\checks\naming\packagename\Test.java:1:9: Name 'com.puppycrawl.tools.checkstyle.checks.naming.packagename' must match pattern '[A-Z]+'. [PackageName]
Audit done.
Checkstyle ends with 1 errors.
```
## Build output
![image](https://github.com/user-attachments/assets/faf83b3b-d798-4f06-93d3-b6a1735cc268)
