### PR TITLE
Issue #11163: Enforce file size for IndentationInvalidMethodIndent

### DIFF
--- a/config/checkstyle-resources-suppressions.xml
+++ b/config/checkstyle-resources-suppressions.xml
@@ -279,8 +279,6 @@
   <suppress checks="FileLength"
     files="[\\/]test[\\/]resources[\\/]com[\\/]puppycrawl[\\/]tools[\\/]checkstyle[\\/]checks[\\/]avoidescapedunicodecharacters[\\/]InputAvoidEscapedUnicodeCharacters3\.java"/>
   <suppress checks="FileLength"
-    files="[\\/]test[\\/]resources[\\/]com[\\/]puppycrawl[\\/]tools[\\/]checkstyle[\\/]checks[\\/]indentation[\\/]indentation[\\/]InputIndentationInvalidMethodIndent\.java"/>
-  <suppress checks="FileLength"
     files="[\\/]test[\\/]resources[\\/]com[\\/]puppycrawl[\\/]tools[\\/]checkstyle[\\/]checks[\\/]indentation[\\/]indentation[\\/]InputIndentationValidMethodIndent\.java"/>
   <suppress checks="FileLength"
     files="[\\/]test[\\/]resources[\\/]com[\\/]puppycrawl[\\/]tools[\\/]checkstyle[\\/]checks[\\/]indentation[\\/]indentation[\\/]InputIndentationInvalidClassDefIndent\.java"/>

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/indentation/IndentationCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/indentation/IndentationCheckTest.java
@@ -832,7 +832,7 @@ public class IndentationCheckTest extends AbstractModuleTestSupport {
     }
 
     @Test
-    public void testInvalidMethodWithChecker()
+    public void testInvalidMethodWithChecker1()
             throws Exception {
         final DefaultConfiguration checkConfig = createModuleConfig(IndentationCheck.class);
 
@@ -844,7 +844,7 @@ public class IndentationCheckTest extends AbstractModuleTestSupport {
         checkConfig.addProperty("lineWrappingIndentation", "4");
         checkConfig.addProperty("tabWidth", "4");
         checkConfig.addProperty("throwsIndent", "4");
-        final String fileName = getPath("InputIndentationInvalidMethodIndent.java");
+        final String fileName = getPath("InputIndentationInvalidMethodIndent1.java");
         final String[] expected = {
             "23:7: " + getCheckMessage(MSG_ERROR, "ctor def rcurly", 6, 4),
             "26:7: " + getCheckMessage(MSG_ERROR, "ctor def modifier", 6, 4),
@@ -856,31 +856,50 @@ public class IndentationCheckTest extends AbstractModuleTestSupport {
             "70:6: " + getCheckMessage(MSG_ERROR, "final", 5, 9),
             "71:6: " + getCheckMessage(MSG_ERROR, "void", 5, 9),
             "72:5: " + getCheckMessage(MSG_ERROR, "method5", 4, 9),
-            "80:4: " + getCheckMessage(MSG_ERROR, "method def modifier", 3, 4),
-            "81:4: " + getCheckMessage(MSG_ERROR, "final", 3, 7),
-            "82:4: " + getCheckMessage(MSG_ERROR, "void", 3, 7),
-            "83:6: " + getCheckMessage(MSG_ERROR, "method6", 5, 7),
-            "93:5: " + getCheckMessage(MSG_CHILD_ERROR, "ctor def", 4, 8),
-            "98:7: " + getCheckMessage(MSG_CHILD_ERROR, "method def", 6, 8),
-            "99:7: " + getCheckMessage(MSG_ERROR, "if", 6, 8),
-            "100:11: " + getCheckMessage(MSG_CHILD_ERROR, "if", 10, 12),
-            "101:7: " + getCheckMessage(MSG_ERROR, "if rcurly", 6, 8),
-            "104:11: " + getCheckMessage(MSG_ERROR, "Arrays", 10, 12),
-            "110:15: " + getCheckMessage(MSG_ERROR, "new", 14, 16),
-            "113:11: " + getCheckMessage(MSG_CHILD_ERROR, "method call", 10, 12),
-            "118:15: " + getCheckMessage(MSG_ERROR, "new", 14, 16),
-            "122:11: " + getCheckMessage(MSG_ERROR, "new", 10, 12),
-            "126:11: " + getCheckMessage(MSG_ERROR, "new", 10, 12),
-            "127:7: " + getCheckMessage(MSG_ERROR, ")", 6, 8),
-            "131:7: " + getCheckMessage(MSG_ERROR, "method call rparen", 6, 8),
-            "145:11: " + getCheckMessage(MSG_CHILD_ERROR, "method call", 10, 12),
-            "148:11: " + getCheckMessage(MSG_CHILD_ERROR, "method call", 10, 12),
-            "158:7: " + getCheckMessage(MSG_CHILD_ERROR, "method call", 6, 12),
-            "170:5: " + getCheckMessage(MSG_CHILD_ERROR, "method def", 4, 8),
-            "175:5: " + getCheckMessage(MSG_CHILD_ERROR, "method def", 4, 8),
-            "179:1: " + getCheckMessage(MSG_ERROR, "int", 0, 8),
-            "180:5: " + getCheckMessage(MSG_ERROR, "method9", 4, 8),
-            "190:13: " + getCheckMessage(MSG_CHILD_ERROR, "method def", 12, 8),
+            "86:11: " + getCheckMessage(MSG_CHILD_ERROR, "method call", 10, 12),
+            "89:11: " + getCheckMessage(MSG_CHILD_ERROR, "method call", 10, 12),
+            "99:7: " + getCheckMessage(MSG_CHILD_ERROR, "method call", 6, 12),
+        };
+        verifyWarns(checkConfig, fileName, expected);
+    }
+
+    @Test
+    public void testInvalidMethodWithChecker2()
+            throws Exception {
+        final DefaultConfiguration checkConfig = createModuleConfig(IndentationCheck.class);
+
+        checkConfig.addProperty("arrayInitIndent", "4");
+        checkConfig.addProperty("basicOffset", "4");
+        checkConfig.addProperty("braceAdjustment", "0");
+        checkConfig.addProperty("caseIndent", "4");
+        checkConfig.addProperty("forceStrictCondition", "false");
+        checkConfig.addProperty("lineWrappingIndentation", "4");
+        checkConfig.addProperty("tabWidth", "4");
+        checkConfig.addProperty("throwsIndent", "4");
+        final String fileName = getPath("InputIndentationInvalidMethodIndent2.java");
+        final String[] expected = {
+            "23:5: " + getCheckMessage(MSG_CHILD_ERROR, "ctor def", 4, 8),
+            "26:4: " + getCheckMessage(MSG_ERROR, "method def modifier", 3, 4),
+            "27:4: " + getCheckMessage(MSG_ERROR, "final", 3, 7),
+            "28:4: " + getCheckMessage(MSG_ERROR, "void", 3, 7),
+            "29:6: " + getCheckMessage(MSG_ERROR, "method6", 5, 7),
+            "39:7: " + getCheckMessage(MSG_CHILD_ERROR, "method def", 6, 8),
+            "40:7: " + getCheckMessage(MSG_ERROR, "if", 6, 8),
+            "41:11: " + getCheckMessage(MSG_CHILD_ERROR, "if", 10, 12),
+            "42:7: " + getCheckMessage(MSG_ERROR, "if rcurly", 6, 8),
+            "45:11: " + getCheckMessage(MSG_ERROR, "Arrays", 10, 12),
+            "51:15: " + getCheckMessage(MSG_ERROR, "new", 14, 16),
+            "54:11: " + getCheckMessage(MSG_CHILD_ERROR, "method call", 10, 12),
+            "59:15: " + getCheckMessage(MSG_ERROR, "new", 14, 16),
+            "63:11: " + getCheckMessage(MSG_ERROR, "new", 10, 12),
+            "67:11: " + getCheckMessage(MSG_ERROR, "new", 10, 12),
+            "68:7: " + getCheckMessage(MSG_ERROR, ")", 6, 8),
+            "72:7: " + getCheckMessage(MSG_ERROR, "method call rparen", 6, 8),
+            "86:5: " + getCheckMessage(MSG_CHILD_ERROR, "method def", 4, 8),
+            "91:5: " + getCheckMessage(MSG_CHILD_ERROR, "method def", 4, 8),
+            "95:1: " + getCheckMessage(MSG_ERROR, "int", 0, 8),
+            "96:5: " + getCheckMessage(MSG_ERROR, "method9", 4, 8),
+            "106:13: " + getCheckMessage(MSG_CHILD_ERROR, "method def", 12, 8),
         };
         verifyWarns(checkConfig, fileName, expected);
     }

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/indentation/indentation/InputIndentationInvalidMethodIndent1.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/indentation/indentation/InputIndentationInvalidMethodIndent1.java
@@ -1,0 +1,103 @@
+package com.puppycrawl.tools.checkstyle.checks.indentation.indentation; //indent:0 exp:0
+
+
+
+/**                                                                           //indent:0 exp:0
+ * This test-input is intended to be checked using following configuration:   //indent:1 exp:1
+ *                                                                            //indent:1 exp:1
+ * arrayInitIndent = 4                                                        //indent:1 exp:1
+ * basicOffset = 4                                                            //indent:1 exp:1
+ * braceAdjustment = 0                                                        //indent:1 exp:1
+ * caseIndent = 4                                                             //indent:1 exp:1
+ * forceStrictCondition = false                                               //indent:1 exp:1
+ * lineWrappingIndentation = 4                                                //indent:1 exp:1
+ * tabWidth = 4                                                               //indent:1 exp:1
+ * throwsIndent = 4                                                           //indent:1 exp:1
+ *                                                                            //indent:1 exp:1
+ * @author  jrichard                                                         //indent:1 exp:1
+ */                                                                           //indent:1 exp:1
+public class InputIndentationInvalidMethodIndent1 { //indent:0 exp:0
+
+    /** Creates a new instance of InputInvalidMethodIndent */ //indent:4 exp:4
+    public InputIndentationInvalidMethodIndent1() { //indent:4 exp:4
+      } //indent:6 exp:4 warn
+
+    // ctor with rcurly on next line //indent:4 exp:4
+      public InputIndentationInvalidMethodIndent1(int dummy) //indent:6 exp:4 warn
+  { //indent:2 exp:4 warn
+      } //indent:6 exp:4 warn
+
+    // method with rcurly on same line //indent:4 exp:4
+  public void method() { //indent:2 exp:4 warn
+      } //indent:6 exp:4 warn
+
+    // method with rcurly on next line //indent:4 exp:4
+    public void method2() //indent:4 exp:4
+    { //indent:4 exp:4
+    } //indent:4 exp:4
+
+    // method with a bunch of params //indent:4 exp:4
+    public int method2(int x, int y, int w, int h) { //indent:4 exp:4
+        return 1; //indent:8 exp:8
+    } //indent:4 exp:4
+
+    // params on multiple lines //indent:4 exp:4
+    public void method2(int x, int y, int w, int h, //indent:4 exp:4
+        int x1, int y1, int w1, int h1) //indent:8 exp:8
+    { //indent:4 exp:4
+    } //indent:4 exp:4
+
+    // params on multiple lines //indent:4 exp:4
+    public void method3(int x, int y, int w, int h, //indent:4 exp:4
+        int x1, int y1, int w1, int h1) //indent:8 exp:8
+    { //indent:4 exp:4
+        System.getProperty("foo"); //indent:8 exp:8
+    } //indent:4 exp:4
+
+
+
+    // params on multiple lines //indent:4 exp:4
+    public void method4(int x, int y, int w, int h, //indent:4 exp:4
+        int x1, int y1, int w1, int h1) //indent:8 exp:8
+    { //indent:4 exp:4
+        boolean test = true; //indent:8 exp:8
+        if (test) { //indent:8 exp:8
+            System.getProperty("foo"); //indent:12 exp:12
+        } //indent:8 exp:8
+    } //indent:4 exp:4
+
+     public //indent:5 exp:4 warn
+     final //indent:5 exp:9 warn
+     void //indent:5 exp:9 warn
+    method5() //indent:4 exp:9 warn
+    { //indent:4 exp:4
+        boolean test = true; //indent:8 exp:8
+        if (test) { //indent:8 exp:8
+            System.getProperty("foo"); //indent:12 exp:12
+        } //indent:8 exp:8
+    } //indent:4 exp:4
+
+    private void myfunc2(int a, int b, int c, int d, int e, int f, int g) { //indent:4 exp:4
+    } //indent:4 exp:4
+
+    private void myMethod() //indent:4 exp:4
+    { //indent:4 exp:4
+        myfunc2(3, 4, 5, //indent:8 exp:8
+          6, 7, 8, 9); //indent:10 exp:12 warn
+
+        myfunc2(3, 4, method2(3, 4, 5, 6) + 5, //indent:8 exp:8
+          6, 7, 8, 9); //indent:10 exp:12 warn
+
+
+//     : this is not illegal, but probably should be //indent:0 exp:0
+//        myfunc3(11, 11, Integer. //indent:0 exp:0
+//            getInteger("mytest").intValue(), //indent:0 exp:0
+//            11); //indent:0 exp:0
+
+
+        String.CASE_INSENSITIVE_ORDER.toString() //indent:8 exp:8
+      .equals("blah"); //indent:6 exp:12 warn
+
+
+    } //indent:4 exp:4
+} //indent:0 exp:0

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/indentation/indentation/InputIndentationInvalidMethodIndent2.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/indentation/indentation/InputIndentationInvalidMethodIndent2.java
@@ -16,65 +16,11 @@ import java.util.Arrays; //indent:0 exp:0
  *                                                                            //indent:1 exp:1
  * @author  jrichard                                                         //indent:1 exp:1
  */                                                                           //indent:1 exp:1
-public class InputIndentationInvalidMethodIndent { //indent:0 exp:0
+public class InputIndentationInvalidMethodIndent2 { //indent:0 exp:0
 
-    /** Creates a new instance of InputInvalidMethodIndent */ //indent:4 exp:4
-    public InputIndentationInvalidMethodIndent() { //indent:4 exp:4
-      } //indent:6 exp:4 warn
-
-    // ctor with rcurly on next line //indent:4 exp:4
-      public InputIndentationInvalidMethodIndent(int dummy) //indent:6 exp:4 warn
-  { //indent:2 exp:4 warn
-      } //indent:6 exp:4 warn
-
-    // method with rcurly on same line //indent:4 exp:4
-  public void method() { //indent:2 exp:4 warn
-      } //indent:6 exp:4 warn
-
-    // method with rcurly on next line //indent:4 exp:4
-    public void method2() //indent:4 exp:4
+    public InputIndentationInvalidMethodIndent2(int dummy, int dummy2) //indent:4 exp:4
     { //indent:4 exp:4
-    } //indent:4 exp:4
-
-    // method with a bunch of params //indent:4 exp:4
-    public int method2(int x, int y, int w, int h) { //indent:4 exp:4
-        return 1; //indent:8 exp:8
-    } //indent:4 exp:4
-
-    // params on multiple lines //indent:4 exp:4
-    public void method2(int x, int y, int w, int h, //indent:4 exp:4
-        int x1, int y1, int w1, int h1) //indent:8 exp:8
-    { //indent:4 exp:4
-    } //indent:4 exp:4
-
-    // params on multiple lines //indent:4 exp:4
-    public void method3(int x, int y, int w, int h, //indent:4 exp:4
-        int x1, int y1, int w1, int h1) //indent:8 exp:8
-    { //indent:4 exp:4
-        System.getProperty("foo"); //indent:8 exp:8
-    } //indent:4 exp:4
-
-
-
-    // params on multiple lines //indent:4 exp:4
-    public void method4(int x, int y, int w, int h, //indent:4 exp:4
-        int x1, int y1, int w1, int h1) //indent:8 exp:8
-    { //indent:4 exp:4
-        boolean test = true; //indent:8 exp:8
-        if (test) { //indent:8 exp:8
-            System.getProperty("foo"); //indent:12 exp:12
-        } //indent:8 exp:8
-    } //indent:4 exp:4
-
-     public //indent:5 exp:4 warn
-     final //indent:5 exp:9 warn
-     void //indent:5 exp:9 warn
-    method5() //indent:4 exp:9 warn
-    { //indent:4 exp:4
-        boolean test = true; //indent:8 exp:8
-        if (test) { //indent:8 exp:8
-            System.getProperty("foo"); //indent:12 exp:12
-        } //indent:8 exp:8
+    System.getProperty("foo"); //indent:4 exp:8 warn
     } //indent:4 exp:4
 
    public //indent:3 exp:4 warn
@@ -86,11 +32,6 @@ public class InputIndentationInvalidMethodIndent { //indent:0 exp:0
         if (test) { //indent:8 exp:8
             System.getProperty("foo"); //indent:12 exp:12
         } //indent:8 exp:8
-    } //indent:4 exp:4
-
-    public InputIndentationInvalidMethodIndent(int dummy, int dummy2) //indent:4 exp:4
-    { //indent:4 exp:4
-    System.getProperty("foo"); //indent:4 exp:8 warn
     } //indent:4 exp:4
 
     void method6a() //indent:4 exp:4
@@ -131,33 +72,8 @@ public class InputIndentationInvalidMethodIndent { //indent:0 exp:0
       ); //indent:6 exp:8 warn
     } //indent:4 exp:4
 
-
-    private void myfunc2(int a, int b, int c, int d, int e, int f, int g) { //indent:4 exp:4
-    } //indent:4 exp:4
-
     private int myfunc3(int a, int b, int c, int d) { //indent:4 exp:4
         return 1; //indent:8 exp:8
-    } //indent:4 exp:4
-
-    private void myMethod() //indent:4 exp:4
-    { //indent:4 exp:4
-        myfunc2(3, 4, 5, //indent:8 exp:8
-          6, 7, 8, 9); //indent:10 exp:12 warn
-
-        myfunc2(3, 4, method2(3, 4, 5, 6) + 5, //indent:8 exp:8
-          6, 7, 8, 9); //indent:10 exp:12 warn
-
-
-//     : this is not illegal, but probably should be //indent:0 exp:0
-//        myfunc3(11, 11, Integer. //indent:0 exp:0
-//            getInteger("mytest").intValue(), //indent:0 exp:0
-//            11); //indent:0 exp:0
-
-
-        String.CASE_INSENSITIVE_ORDER.toString() //indent:8 exp:8
-      .equals("blah"); //indent:6 exp:12 warn
-
-
     } //indent:4 exp:4
 
     private void myFunc() //indent:4 exp:4


### PR DESCRIPTION
Issue #11163

Enforce file size for `InputIndentationInvalidMethodIndent.java` splits into 2 class i.e `InputIndentationInvalidMethodIndent1.java` and `InputIndentationInvalidMethodIndent2.java`, both file size are below 120 lines of code.

## Build output
![image](https://github.com/user-attachments/assets/31bebfdf-0a32-41d6-b977-072aa1cc3314)
