### PR TITLE
test Issue #16781: `NoWhitespaceBefore` blind spot resulting in high failure rate

### DIFF
--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/whitespace/NoWhitespaceBeforeCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/whitespace/NoWhitespaceBeforeCheckTest.java
@@ -21,6 +21,7 @@ package com.puppycrawl.tools.checkstyle.checks.whitespace;
 
 import static com.puppycrawl.tools.checkstyle.checks.whitespace.NoWhitespaceBeforeCheck.MSG_KEY;
 
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
 import com.puppycrawl.tools.checkstyle.AbstractModuleTestSupport;
@@ -138,6 +139,196 @@ public class NoWhitespaceBeforeCheckTest
 
         verifyWithInlineConfigParser(
                 getPath("InputNoWhitespaceBeforeWithEmoji.java"), expected);
+    }
+
+    @Nested
+    class NextGeneration {
+
+        @Test
+        public void testDefaultCheck() throws Exception {
+            verifyWithInlineConfigParser(
+                getPath("InputNoWhitespaceBeforeDefaultNextGeneration.java"), new String[] {
+                    "25:16: " + getCheckMessage(MSG_KEY, ":"),
+                    "26:16: " + getCheckMessage(MSG_KEY, ":"),
+                    "27:16: " + getCheckMessage(MSG_KEY, ":"),
+                    "28:16: " + getCheckMessage(MSG_KEY, ":"),
+                    "29:16: " + getCheckMessage(MSG_KEY, ":"),
+                    "30:16: " + getCheckMessage(MSG_KEY, ":"),
+                    "31:16: " + getCheckMessage(MSG_KEY, ":"),
+                    "32:16: " + getCheckMessage(MSG_KEY, ":"),
+                    "33:16: " + getCheckMessage(MSG_KEY, ":"),
+                    "34:16: " + getCheckMessage(MSG_KEY, ":"),
+                    "35:16: " + getCheckMessage(MSG_KEY, ":"),
+                    "36:16: " + getCheckMessage(MSG_KEY, ":"),
+                    "37:16: " + getCheckMessage(MSG_KEY, ":"),
+                    "38:16: " + getCheckMessage(MSG_KEY, ":"),
+                    "39:16: " + getCheckMessage(MSG_KEY, ":"),
+                });
+        }
+
+        @Test
+        public void testSpaceViolationVarAssignment() throws Exception {
+            verifyWithInlineConfigParser(
+                getPath("InputNoWhitespaceBeforeDefaultNextGeneration.java"), new String[] {
+                    "49:31: " + getCheckMessage(MSG_KEY, "."),
+                    "50:31: " + getCheckMessage(MSG_KEY, "."),
+                    "51:31: " + getCheckMessage(MSG_KEY, "."),
+                });
+        }
+
+        @Test
+        public void testSpaceViolationVarDeclaration() throws Exception {
+            verifyWithInlineConfigParser(
+                getPath("InputNoWhitespaceBeforeDefaultNextGeneration.java"), new String[] {
+                    "62:31: " + getCheckMessage(MSG_KEY, "."),
+                    "63:31: " + getCheckMessage(MSG_KEY, "."),
+                    "64:31: " + getCheckMessage(MSG_KEY, "."),
+                    "65:31: " + getCheckMessage(MSG_KEY, "."),
+                    "66:31: " + getCheckMessage(MSG_KEY, "."),
+                    "67:31: " + getCheckMessage(MSG_KEY, "."),
+                });
+        }
+
+        @Test
+        public void testArrayAccess() throws Exception {
+            verifyWithInlineConfigParser(
+                getPath("InputNoWhitespaceBeforeDefaultNextGeneration.java"), new String[] {
+                    "78:31: " + getCheckMessage(MSG_KEY, "["),
+                    "79:31: " + getCheckMessage(MSG_KEY, "["),
+                    "80:31: " + getCheckMessage(MSG_KEY, "["),
+                });
+        }
+
+        @Test
+        public void testGenerics() throws Exception {
+            verifyWithInlineConfigParser(
+                getPath("InputNoWhitespaceBeforeDefaultNextGeneration.java"), new String[] {
+                    "91:31: " + getCheckMessage(MSG_KEY, "."),
+                    "92:31: " + getCheckMessage(MSG_KEY, "."),
+                });
+        }
+
+        @Test
+        public void testLambda() throws Exception {
+            verifyWithInlineConfigParser(
+                getPath("InputNoWhitespaceBeforeDefaultNextGeneration.java"), new String[] {
+                    "101:31: " + getCheckMessage(MSG_KEY, "."),
+                });
+        }
+
+        @Test
+        public void testMethodReference() throws Exception {
+            verifyWithInlineConfigParser(
+                getPath("InputNoWhitespaceBeforeDefaultNextGeneration.java"), new String[] {
+                    "110:31: " + getCheckMessage(MSG_KEY, ":"),
+                });
+        }
+
+        @Test
+        public void testNestedCalls() throws Exception {
+            verifyWithInlineConfigParser(
+                getPath("InputNoWhitespaceBeforeDefaultNextGeneration.java"), new String[] {
+                    "122:31: " + getCheckMessage(MSG_KEY, "."),
+                    "123:31: " + getCheckMessage(MSG_KEY, "("),
+                });
+        }
+
+        @Test
+        public void testMultipleDots() throws Exception {
+            verifyWithInlineConfigParser(
+                getPath("InputNoWhitespaceBeforeDefaultNextGeneration.java"), new String[] {
+                    "134:31: " + getCheckMessage(MSG_KEY, "."),
+                    "135:31: " + getCheckMessage(MSG_KEY, "."),
+                });
+        }
+
+        @Test
+        public void testWithOtherOperators() throws Exception {
+            verifyWithInlineConfigParser(
+                getPath("InputNoWhitespaceBeforeDefaultNextGeneration.java"), new String[] {
+                    "145:31: " + getCheckMessage(MSG_KEY, "."),
+                });
+        }
+
+        @Test
+        public void testInControlStructures() throws Exception {
+            verifyWithInlineConfigParser(
+                getPath("InputNoWhitespaceBeforeDefaultNextGeneration.java"), new String[] {
+                    "156:31: " + getCheckMessage(MSG_KEY, "."),
+                });
+        }
+
+        @Test
+        public void testInTryCatch() throws Exception {
+            verifyWithInlineConfigParser(
+                getPath("InputNoWhitespaceBeforeDefaultNextGeneration.java"), new String[] {
+                    "177:31: " + getCheckMessage(MSG_KEY, "."),
+                });
+        }
+
+        @Test
+        public void testInAnnotations() throws Exception {
+            verifyWithInlineConfigParser(
+                getPath("InputNoWhitespaceBeforeDefaultNextGeneration.java"), new String[] {
+                    "189:31: " + getCheckMessage(MSG_KEY, "."),
+                });
+        }
+
+        @Test
+        public void testInTypeCast() throws Exception {
+            verifyWithInlineConfigParser(
+                getPath("InputNoWhitespaceBeforeDefaultNextGeneration.java"), new String[] {
+                    "201:31: " + getCheckMessage(MSG_KEY, "."),
+                });
+        }
+
+        @Test
+        public void testInSwitch() throws Exception {
+            verifyWithInlineConfigParser(
+                getPath("InputNoWhitespaceBeforeDefaultNextGeneration.java"), new String[] {
+                    "213:31: " + getCheckMessage(MSG_KEY, "."),
+                });
+        }
+
+        @Test
+        public void testInSynchronized() throws Exception {
+            verifyWithInlineConfigParser(
+                getPath("InputNoWhitespaceBeforeDefaultNextGeneration.java"), new String[] {
+                    "227:31: " + getCheckMessage(MSG_KEY, "."),
+                });
+        }
+
+        @Test
+        public void testInAssert() throws Exception {
+            verifyWithInlineConfigParser(
+                getPath("InputNoWhitespaceBeforeDefaultNextGeneration.java"), new String[] {
+                    "238:31: " + getCheckMessage(MSG_KEY, "."),
+                });
+        }
+
+        @Test
+        public void testInReturn2() throws Exception {
+            verifyWithInlineConfigParser(
+                getPath("InputNoWhitespaceBeforeDefaultNextGeneration.java"), new String[] {
+                    "249:31: " + getCheckMessage(MSG_KEY, "."),
+                });
+        }
+
+        @Test
+        public void testInThrow2() throws Exception {
+            verifyWithInlineConfigParser(
+                getPath("InputNoWhitespaceBeforeDefaultNextGeneration.java"), new String[] {
+                    "260:31: " + getCheckMessage(MSG_KEY, "."),
+                });
+        }
+
+        @Test
+        public void testInArrayInitializer() throws Exception {
+            verifyWithInlineConfigParser(
+                getPath("InputNoWhitespaceBeforeDefaultNextGeneration.java"), new String[] {
+                    "269:31: " + getCheckMessage(MSG_KEY, "."),
+                });
+        }
     }
 
 }

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/whitespace/nowhitespacebefore/InputNoWhitespaceBeforeDefaultNextGeneration.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/whitespace/nowhitespacebefore/InputNoWhitespaceBeforeDefaultNextGeneration.java
@@ -1,0 +1,271 @@
+/*
+NoWhitespaceBefore
+allowLineBreaks = (default)false
+tokens = (default)COMMA, SEMI, POST_INC, POST_DEC, ELLIPSIS, LABELED_STAT
+
+
+*/
+
+package com.puppycrawl.tools.checkstyle.checks.whitespace.nowhitespacebefore;
+
+/**
+ * Class for testing whitespace issues.
+ * violation missing author tag
+ **/
+class InputNoWhitespaceBeforeDefaultNextGeneration
+{
+    public void test() {
+        // Valid cases
+        " ".equals("");
+        "".equals(" ");
+        "".equals("");
+
+        // Violations
+        "".equals("");
+        "".equals(""  + ""); // violation
+        "".equals("" +  ""); // violation
+         System.out.println(""); // violation
+        System .out.println(""); // violation
+        System. out.println(""); // violation
+        System.out .println(""); // violation
+        System.out. println(""); // violation
+        System.out. println(""); // violation
+        System.out.println (""); // violation
+        "" .equals(""); // violation
+        "". equals(""); // violation
+        "".equals (""); // violation
+        "".equals( ""); // violation
+        "".equals("" ); // violation
+        "".equals("") ; // violation
+    }
+
+    /** Test variable assignment violations */
+    public void testSpaceViolationVarAssignment() {
+        // Valid
+        boolean eq1 = " ".equals("");
+        boolean eq2 = "".equals("");
+
+        // Violations
+        eq2 = "".equals(""); // violation
+        eq2  = "".equals(""); // violation
+        eq2 =  "".equals(""); // violation
+    }
+
+    /** Test variable declaration violations */
+    public void testSpaceViolationVarDeclaration() {
+        // Valid
+        boolean e = "".equals("");
+        boolean e3 = "".equals("");
+        e3 = "".equals("");
+
+        // Violations
+        boolean e4 = "".equals(""); // violation
+        boolean e1  = "".equals(""); // violation
+        boolean  e2 = "".equals(""); // violation
+        e3 = "".equals(""); // violation
+        e3  = "".equals(""); // violation
+        e3 =  "".equals(""); // violation
+    }
+
+    /** Test array access violations */
+    public void testArrayAccess() {
+        int[] arr = new int[10];
+
+        // Valid
+        int a = arr[0];
+
+        // Violations
+        int x = arr [0]; // violation
+        int y = arr[ 0]; // violation
+        int z = arr[0]; // violation
+    }
+
+    /** Test generics violations */
+    public void testGenerics() {
+        java.util.List<String> list = new java.util.ArrayList<>();
+
+        // Valid
+        list.add("test");
+
+        // Violations
+        list .add("test"); // violation
+        list. add("test"); // violation
+    }
+
+    /** Test lambda violations */
+    public void testLambda() {
+        // Valid
+        Runnable r = () -> System.out.println();
+
+        // Violation
+        Runnable r2 = () -> System.out .println(); // violation
+    }
+
+    /** Test method reference violations */
+    public void testMethodReference() {
+        // Valid
+        java.util.function.Function<String, String> f1 = String::valueOf;
+
+        // Violation
+        java.util.function.Function<String, String> f2 = String ::valueOf; // violation
+    }
+
+    /** Test nested calls violations */
+    public void testNestedCalls() {
+        String s = "hello";
+
+        // Valid
+        s.substring(1).trim();
+        s.substring(1).trim();
+
+        // Violations
+        s.substring(1). trim(); // violation
+        s.substring(1 ).trim(); // violation
+    }
+
+    /** Test multiple dots violations */
+    public void testMultipleDots() {
+        String s = "hello";
+
+        // Valid
+        s.substring(1).substring(1).substring(1);
+
+        // Violations
+        s.substring(1).substring(1). substring(1); // violation
+        s.substring(1) .substring(1).substring(1); // violation
+    }
+
+    /** Test with other operators */
+    public void testWithOtherOperators() {
+        // Valid
+        String s1 = "a" + "b".toString();
+        int x = 1 + 2 * 3;
+
+        // Violation
+        String s2 = "a" + "b". toString(); // violation
+    }
+
+    /** Test in control structures */
+    public void testInControlStructures() {
+        // Valid
+        if ("test".equals("test")) {
+            System.out.println();
+        }
+
+        // Violations
+        if ("test". equals("test")) { // violation
+            System.out.println();
+        }
+
+        while (true) {
+            break ;
+        }
+    }
+
+    /** Test in try-catch */
+    public void testInTryCatch() {
+        // Valid
+        try {
+            // do something
+        } catch (Exception e) {
+            // handle
+        }
+
+        // Violation
+        try {
+            // do something
+        } catch (Exception e ) { // violation
+            // handle
+        }
+    }
+
+    /** Test in annotations */
+    public void testInAnnotations() {
+        // Valid
+        @SuppressWarnings("unchecked")
+        Object o1 = new Object();
+
+        // Violation
+        @SuppressWarnings ("unchecked") // violation
+        Object o2 = new Object();
+    }
+
+    /** Test in type cast */
+    public void testInTypeCast() {
+        Object o = "test";
+
+        // Valid
+        String s1 = (String) o;
+
+        // Violation
+        String s2 = (String ) o; // violation
+    }
+
+    /** Test in switch */
+    public void testInSwitch() {
+        // Valid
+        switch (1) {
+            case 1:
+                break;
+        }
+
+        // Violation
+        switch (1 ) { // violation
+            case 1:
+                break;
+        }
+    }
+
+    /** Test in synchronized */
+    public void testInSynchronized() {
+        // Valid
+        synchronized (this) {
+            // do something
+        }
+
+        // Violation
+        synchronized (this ) { // violation
+            // do something
+        }
+    }
+
+    /** Test in assert */
+    public void testInAssert() {
+        // Valid
+        assert true : "message";
+
+        // Violation
+        assert true : "message" ; // violation
+    }
+
+    /** Test in return */
+    public void testInReturn() {
+        // Valid (no return value)
+        return;
+    }
+
+    public void testInReturn2() {
+        // Violation
+        return ; // violation
+    }
+
+    /** Test in throw */
+    public void testInThrow() throws Exception {
+        // Valid
+        throw new Exception();
+    }
+
+    public void testInThrow2() throws Exception {
+        // Violation
+        throw new Exception() ; // violation
+    }
+
+    /** Test in array initializer */
+    public void testInArrayInitializer() {
+        // Valid
+        int[] arr1 = new int[] {1, 2, 3};
+
+        // Violation
+        int[] arr2 = new int[] {1, 2, 3 } ; // violation
+    }
+}


### PR DESCRIPTION
Issue #16781: `NoWhitespaceBefore` blind spot resulting in high failure rate

1 out of 15 is 6.667%, the blind-spot is pretty much not to fix this in #16810. Please help me getting this done.

```
missing (42)  : 311, 312, 313, 314, 315, 316, 317, 318, 319, 320, 321, 322, 323, 324, 325, 336, 337, 338, 349, 350, 351, 352, 353, 354, 365, 366, 367, 378, 379, 388, 397, 409, 410, 421, 422, 432, 443, 464, 476, 488, 500, 514
unexpected (1): 448
---
expected      : [34, 34, 180, 182, 189, 191, 199, 215, 270, 274, 288, 291, 295, 311, 312, 313, 314, 315, 316, 317, 318, 319, 320, 321, 322, 323, 324, 325, 326, 336, 337, 338, 349, 350, 351, 352, 353, 354, 365, 366, 367, 378, 379, 388, 397, 409, 410, 421, 422, 432, 443, 464, 476, 488, 500, 514, 525, 536, 547, 556]
but was       : [34, 34, 180, 182, 189, 191, 199, 215, 270, 274, 288, 291, 295, 326, 448, 525, 536, 547, 556]
```