### PR TITLE
Pull #16811: fix whitespace typo in `Note : ` -> `Note: `

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/VariableDeclarationUsageDistanceCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/VariableDeclarationUsageDistanceCheck.java
@@ -37,7 +37,7 @@ import com.puppycrawl.tools.checkstyle.utils.TokenUtil;
 /**
  * <div>
  * Checks the distance between declaration of variable and its first usage.
- * Note : Variable declaration/initialization statements are not counted while calculating length.
+ * Note: Variable declaration/initialization statements are not counted while calculating length.
  * </div>
  * <ul>
  * <li>

--- a/src/main/resources/com/puppycrawl/tools/checkstyle/meta/checks/coding/VariableDeclarationUsageDistanceCheck.xml
+++ b/src/main/resources/com/puppycrawl/tools/checkstyle/meta/checks/coding/VariableDeclarationUsageDistanceCheck.xml
@@ -6,7 +6,7 @@
              parent="com.puppycrawl.tools.checkstyle.TreeWalker">
          <description>&lt;div&gt;
  Checks the distance between declaration of variable and its first usage.
- Note : Variable declaration/initialization statements are not counted while calculating length.
+ Note: Variable declaration/initialization statements are not counted while calculating length.
  &lt;/div&gt;</description>
          <properties>
             <property default-value="3" name="allowedDistance" type="int">

--- a/src/site/xdoc/checks/coding/variabledeclarationusagedistance.xml
+++ b/src/site/xdoc/checks/coding/variabledeclarationusagedistance.xml
@@ -11,7 +11,7 @@
       <subsection name="Description" id="Description">
         <div>
           Checks the distance between declaration of variable and its first usage.
-          Note : Variable declaration/initialization statements are not counted
+          Note: Variable declaration/initialization statements are not counted
           while calculating length.
         </div>
       </subsection>

--- a/src/site/xdoc/checks/coding/variabledeclarationusagedistance.xml.template
+++ b/src/site/xdoc/checks/coding/variabledeclarationusagedistance.xml.template
@@ -11,7 +11,7 @@
       <subsection name="Description" id="Description">
         <div>
           Checks the distance between declaration of variable and its first usage.
-          Note : Variable declaration/initialization statements are not counted
+          Note: Variable declaration/initialization statements are not counted
           while calculating length.
         </div>
       </subsection>


### PR DESCRIPTION
related fix #16680

Pull #16811: fix whitespace typo in `Note : ` -> `Note: `