### PR TITLE
minor #16753: remove references to freedomsponsors from pom.xml, sponsoring.xml, and whitelist.words

### DIFF
--- a/config/jsoref-spellchecker/whitelist.words
+++ b/config/jsoref-spellchecker/whitelist.words
@@ -466,7 +466,6 @@ forbiddenapis
 Foreach
 Fpuppycrawl
 fq
-freedomsponsors
 freemarker
 Fregexp
 Fresources

--- a/pom.xml
+++ b/pom.xml
@@ -2171,8 +2171,6 @@
             <excludedLink>https://opencollective.com/*</excludedLink>
             <!-- 405 Not Allowed, link present in generated website only -->
             <excludedLink>https://oss.sonatype.org/service/local/staging/deploy/maven2/</excludedLink>
-            <!-- site is too unstable, it might improve in future -->
-            <excludedLink>https://freedomsponsors.org/*</excludedLink>
             <!-- site works fine in browser but for plugin always return 500  -->
             <excludedLink>https://liberapay.com/checkstyle/</excludedLink>
             <!-- CertPathValidatorException: validity check failed  -->

--- a/src/site/xdoc/sponsoring.xml
+++ b/src/site/xdoc/sponsoring.xml
@@ -51,9 +51,6 @@
           </object>
         </span>
         <br/>
-        <a href="https://freedomsponsors.org/search/?project_name=checkstyle">
-          freedomsponsors - checkstyle</a>
-        <br/>
       </p>
 
       <p>


### PR DESCRIPTION
Fixes #16753  
Closes #16819 

I have removed freedomsponsors completely as i don't see it's replacement - till replacement we can safely remove it from site once we get it we can update it again.