### PR TITLE
Issue #16798: Update in blue tick of google style coverage page

### DIFF
--- a/src/main/resources/google_checks.xml
+++ b/src/main/resources/google_checks.xml
@@ -412,7 +412,7 @@
     </module>
     <module name="SingleLineJavadoc"/>
     <module name="EmptyCatchBlock">
-      <property name="exceptionVariableName" value="expected"/>
+      <property name="exceptionVariableName" value="expected.*"/>
     </module>
     <module name="CommentsIndentation">
       <property name="tokens" value="SINGLE_LINE_COMMENT, BLOCK_COMMENT_BEGIN"/>

--- a/src/site/xdoc/google_style.xml
+++ b/src/site/xdoc/google_style.xml
@@ -2001,6 +2001,12 @@
                   <a href="checks/blocks/emptycatchblock.html#EmptyCatchBlock">EmptyCatchBlock</a>
                   (<a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources%20path%3A**%2Fgoogle_checks.xml+repo%3Acheckstyle%2Fcheckstyle+EmptyCatchBlock">
                   config</a>)
+                  <br />
+                  <br />
+                  Currently, ignored catch blocks skip the comment check if the
+                  exception variable is named "expected", regardless of method type.
+                  However, according to the rule, this exemption should apply only
+                  in test methods, which we don't yet differentiate in Checkstyle
                 </td>
                 <td>
                   <a href="https://github.com/checkstyle/checkstyle/tree/master/src/it/resources/com/google/checkstyle/test/chapter6programpractice/rule62donotignoreexceptions">


### PR DESCRIPTION
this PR references issue #16798 #16603 

### Preview of changes made :

1) regex update to enforce the rule `name is or begins with expected`  in the google style guide here https://google.github.io/styleguide/javaguide.html#s6.2-caught-exceptions

2) provided the blue tick description as per the discussion in the issue #16798 