### PR TITLE
minor: Revert fork usage in ci validations on no-error-pmd

### DIFF
--- a/.ci/validation.sh
+++ b/.ci/validation.sh
@@ -216,17 +216,12 @@ no-error-pmd)
   echo "CS_version: ${CS_POM_VERSION}"
   mvn -e --no-transfer-progress clean install -Pno-validations
   echo "Checkout target sources ..."
-  #  checkout_from "https://github.com/pmd/build-tools.git"
-  checkout_from "https://github.com/kkoutsilis/build-tools.git"
+  checkout_from "https://github.com/pmd/build-tools.git"
   cd .ci-temp/build-tools/
-  git ls-remote
-  git checkout "66d""ed33c74662cb3da612f3d34a5ae""fa""a629b443"
   mvn -e --no-transfer-progress install
   cd ..
-  git clone https://github.com/kkoutsilis/pmd.git
+  git clone https://github.com/pmd/pmd.git
   cd pmd
-  git ls-remote
-  git checkout "fa6a862ac8278906d7bcf21852f6552d27a46a73"
   ./mvnw verify --show-version --errors --batch-mode --no-transfer-progress \
                 -DskipTests \
                 -Dmaven.javadoc.skip=true \

--- a/config/jsoref-spellchecker/whitelist.words
+++ b/config/jsoref-spellchecker/whitelist.words
@@ -743,7 +743,6 @@ KDoc
 keygen
 keyname
 keyscan
-kkoutsilis
 konstantinos
 Kordas
 Kotlin


### PR DESCRIPTION
This PR reverts the fork usage on no-error-pmd cli validations.