### PR TITLE
Issue #13538: Added documenation on no lombok support

### DIFF
--- a/src/site/xdoc/writingchecks.xml
+++ b/src/site/xdoc/writingchecks.xml
@@ -691,6 +691,12 @@ public class MethodLimitCheck extends AbstractCheck
         <li>You cannot determine the type of an expression.
         Example: "getValue() + getValue2()"</li>
         <li>You cannot determine the full inheritance hierarchy of type.</li>
+        <li>There is currently no support for analyzing code generated at compile time
+          by libraries such as Lombok or AutoValue using annotations like
+          <code>@Getter</code> or <code>@Data</code>. See
+          <a href="https://github.com/checkstyle/checkstyle/issues/13538">issue #13538</a>
+          for more details and potential workarounds.
+        </li>
       </ul>
       <p>
         In addition to Java files, there are similar limitations that apply to all
@@ -724,7 +730,6 @@ public class MethodLimitCheck extends AbstractCheck
         - a Check that validate that user custom Exception class inherited from
           java.lang.Exception class.
       </p>
-
     </section>
 
     <section name="Writing FileSetChecks">


### PR DESCRIPTION
Issue #13538 

Extends the documentation on no lombok support inside [Limitations](https://checkstyle.org/writingchecks.html#Limitations).
Added separate sub-section for it.

## Build output
![image](https://github.com/user-attachments/assets/425d52c5-b229-4c2b-981d-41567f0cf21e)
