### PR TITLE
Pull #16847: `Treewalker` improve error log `TreeWalker is not allowed as a parent of java.lang.String. Please review 'Parent Module' section`

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/TreeWalker.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/TreeWalker.java
@@ -169,10 +169,11 @@ public final class TreeWalker extends AbstractFileSetCheck implements ExternalRe
             filters.add(filter);
         }
         else {
-            throw new CheckstyleException(
-                "TreeWalker is not allowed as a parent of " + name
-                        + " Please review 'Parent Module' section for this Check in web"
-                        + " documentation if Check is standard.");
+            throw new CheckstyleException("TreeWalker is not allowed as a parent of "
+                    + childConf.getName() + ". Please review 'Parent Module' section "
+                    + "(parent=\"com.puppycrawl.tools.checkstyle.TreeWalker\") "
+                    + "(parent=\"com.puppycrawl.tools.checkstyle.Checker\") "
+                    + "for this Check in web documentation if Check is standard.");
         }
     }
 

--- a/src/test/java/com/puppycrawl/tools/checkstyle/TreeWalkerTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/TreeWalkerTest.java
@@ -265,10 +265,12 @@ public class TreeWalkerTest extends AbstractModuleTestSupport {
         }
         catch (CheckstyleException ex) {
             assertWithMessage("Error message is not expected")
-                .that(ex.getMessage())
-                .isEqualTo("TreeWalker is not allowed as a parent of java.lang.String "
-                    + "Please review 'Parent Module' section for this Check in "
-                    + "web documentation if Check is standard.");
+                    .that(ex.getMessage())
+                    .isEqualTo("TreeWalker is not allowed as a parent of java.lang.String. "
+                            + "Please review 'Parent Module' section "
+                            + "(parent=\"com.puppycrawl.tools.checkstyle.TreeWalker\") "
+                            + "(parent=\"com.puppycrawl.tools.checkstyle.Checker\") "
+                            + "for this Check in web documentation if Check is standard.");
         }
     }
 


### PR DESCRIPTION
Pull #16847: `Treewalker` improve error log `TreeWalker is not allowed as a parent of java.lang.String. Please review 'Parent Module' section`

relates from: #16780
cleanup: #16849


`
TreeWalker is not allowed as a parent of com.puppycrawl.tools.checkstyle.checks.whitespace.NoWhitespaceBeforeCheck. Please review 'Parent Module' section (parent="com.puppycrawl.tools.checkstyle.TreeWalker") (parent="com.puppycrawl.tools.checkstyle.Checker") for this Check in web documentation if Check is standard.
`

```
TreeWalker is not allowed as a parent of com.puppycrawl.tools.checkstyle.checks.whitespace.NoWhitespaceBeforeCheck. Please review 'Parent Module' section (parent="com.puppycrawl.tools.checkstyle.TreeWalker") (parent="com.puppycrawl.tools.checkstyle.Checker") for this Check in web documentation if Check is standard.
```