### PR TITLE
Issue #16850: add Maven Wrapper support with configuration files

### DIFF
--- a/.ci/bump-version.sh
+++ b/.ci/bump-version.sh
@@ -1,6 +1,8 @@
 #!/bin/bash
 set -e
 
+chmod +x ./mvnw
+
 source ./.ci/util.sh
 
 if [[ -z $1 ]]; then
@@ -65,5 +67,5 @@ elif [ "$CURRENT_VERSION_THIRD_NUMBER" != "$NEW_VERSION_THIRD_NUMBER" ]; then
 fi
 
 echo "bump version in pom.xml"
-mvn -e --no-transfer-progress versions:set -DnewVersion="$NEW_VERSION-SNAPSHOT"
-mvn -e --no-transfer-progress versions:commit
+./mvnw -e --no-transfer-progress versions:set -DnewVersion="$NEW_VERSION-SNAPSHOT"
+./mvnw -e --no-transfer-progress versions:commit

--- a/.ci/check-performance-regression.sh
+++ b/.ci/check-performance-regression.sh
@@ -2,6 +2,8 @@
 
 set -e
 
+chmod +x ./mvnw
+
 # Get the baseline seconds and config file from arguments
 if [ "$#" -ne 2 ]; then
   echo "Missing arguments!"
@@ -90,7 +92,7 @@ compare_results() {
 }
 
 # package patch
-mvn -e --no-transfer-progress -Passembly,no-validations package
+./mvnw -e --no-transfer-progress -Passembly,no-validations package
 
 # start benchmark
 echo "Benchmark launching..."

--- a/.ci/generate-website.sh
+++ b/.ci/generate-website.sh
@@ -2,6 +2,8 @@
 
 set -e
 
+chmod +x mvnw
+
 source ./.ci/util.sh
 
 if [[ -z $1 ]]; then
@@ -16,6 +18,6 @@ echo TARGET_VERSION="$TARGET_VERSION"
 git checkout "checkstyle-$TARGET_VERSION"
 
 echo "Generating web site"
-mvn -e --no-transfer-progress site -Pno-validations -Dmaven.javadoc.skip=false
+./mvnw -e --no-transfer-progress site -Pno-validations -Dmaven.javadoc.skip=false
 
 git checkout origin/master

--- a/.ci/idea-inspection.bat
+++ b/.ci/idea-inspection.bat
@@ -40,7 +40,7 @@ mkdir .idea\scopes
 copy config\intellij-idea-inspection-scope.xml .idea\scopes
 
 ::Execute compilation of Checkstyle to generate all source files
-call mvn -e compile
+call mvnw.cmd -e compile
 
 ::Launch inspections
 call "%IDEA_LOCATION%" inspect %PROJECT_DIR% %INSPECTIONS_PATH% %RESULTS_DIR% -%NOISE_LVL%

--- a/.ci/idea-inspection.sh
+++ b/.ci/idea-inspection.sh
@@ -10,6 +10,8 @@
 # export IDEA_PATH=$HOME/java/idea-IU-172.4574.11 && ./.ci/idea-inspection.sh
 #################################################
 
+chmod +x ./mvnw
+
 PROJECT_DIR=$PWD/
 INSPECTIONS_PATH=$PWD/config/intellij-idea-inspections.xml
 RESULTS_DIR=$PWD/target/inspection-results
@@ -30,7 +32,7 @@ fi
 
 # Execute compilation of Checkstyle to generate all source files
 # YOU MUST BUILD PROJECT BEFORE INSPECTION EXECUTION!!!
-mvn -e --no-transfer-progress clean compile
+./mvnw -e --no-transfer-progress clean compile
 
 echo ""
 for i in {1..100}; do echo -n "#"; done

--- a/.ci/pitest.sh
+++ b/.ci/pitest.sh
@@ -2,6 +2,8 @@
 # Attention, there is no "-x" to avoid problems on CircleCI
 set -e
 
+chmod +x ./mvnw
+
 function list_profiles() {
   POM_PATH="$(dirname "${0}")/../pom.xml"
   cat "$POM_PATH" | sed -E -n 's/^.*<id>(pitest-[^<]+)<\/id>.*$/\1/p' | sort
@@ -19,7 +21,8 @@ case $1 in
 
   if [[ $(echo "$PROFILES" | grep -w -- "${1}" | cat) != "" ]]; then
     set +e
-    mvn -e --no-transfer-progress -P"$1" clean test-compile org.pitest:pitest-maven:mutationCoverage
+    ./mvnw -e --no-transfer-progress -P"$1" \
+      clean test-compile org.pitest:pitest-maven:mutationCoverage
     EXIT_CODE=$?
     set -e
     groovy ./.ci/pitest-survival-check-xml.groovy "$1"

--- a/.ci/release-maven-perform.sh
+++ b/.ci/release-maven-perform.sh
@@ -2,6 +2,8 @@
 
 set -e
 
+chmod +x ./mvnw
+
 source ./.ci/util.sh
 
 if [[ -z $1 ]]; then
@@ -22,7 +24,7 @@ SKIP_OTHERS="-Dpmd.skip=true -Dspotbugs.skip=true -Djacoco.skip=true -Dxml.skip=
 
 git checkout "checkstyle-$TARGET_VERSION"
 echo "Deploying jars to maven central (release:perform) ..."
-mvn -e --no-transfer-progress -Pgpg -Pgpgv2 release:perform \
+./mvnw -e --no-transfer-progress -Pgpg -Pgpgv2 release:perform \
   -DconnectionUrl=scm:git:https://github.com/"$REPOSITORY_OWNER"/checkstyle.git \
   -Dtag=checkstyle-"$TARGET_VERSION" \
   -Darguments="$SKIP_TEST $SKIP_CHECKSTYLE $SKIP_OTHERS"

--- a/.ci/release-maven-prepare.sh
+++ b/.ci/release-maven-prepare.sh
@@ -2,6 +2,8 @@
 
 set -e
 
+chmod +x ./mvnw
+
 source ./.ci/util.sh
 
 if [[ -z $1 ]]; then
@@ -32,5 +34,5 @@ SKIP_CHECKSTYLE="-Dcheckstyle.ant.skip=true -Dcheckstyle.skip=true"
 SKIP_OTHERS="-Dpmd.skip=true -Dspotbugs.skip=true -Djacoco.skip=true -Dxml.skip=true -Dgpg.skip"
 
 echo "Version bump in pom.xml (release:prepare) ..."
-mvn -e --no-transfer-progress release:prepare -B -DpushChanges=false \
+./mvnw -e --no-transfer-progress release:prepare -B -DpushChanges=false \
     -Darguments="$SKIP_TEST $SKIP_CHECKSTYLE $SKIP_OTHERS"

--- a/.ci/release-publish-releasenotes-twitter.sh
+++ b/.ci/release-publish-releasenotes-twitter.sh
@@ -1,6 +1,8 @@
 #!/bin/bash
 set -e
 
+chmod +x ./mvnw
+
 source ./.ci/util.sh
 
 checkForVariable "TWITTER_CONSUMER_KEY"
@@ -13,7 +15,7 @@ checkForVariable "REPOSITORY_OWNER"
 checkout_from https://github.com/checkstyle/contribution
 
 cd .ci-temp/contribution/releasenotes-builder
-mvn -e --no-transfer-progress clean compile package
+./mvnw -e --no-transfer-progress clean compile package
 cd ../../../
 
 if [ -d .ci-temp/checkstyle ]; then

--- a/.ci/release-update-github-page.sh
+++ b/.ci/release-update-github-page.sh
@@ -1,6 +1,8 @@
 #!/bin/bash
 set -e
 
+chmod +x ./mvnw
+
 source ./.ci/util.sh
 
 if [[ -z $1 ]]; then
@@ -17,7 +19,7 @@ checkForVariable "REPOSITORY_OWNER"
 checkout_from https://github.com/checkstyle/contribution
 
 cd .ci-temp/contribution/releasenotes-builder
-mvn -e --no-transfer-progress clean compile package
+./mvnw -e --no-transfer-progress clean compile package
 cd ../../../
 
 if [ -d .ci-temp/checkstyle ]; then

--- a/.ci/release-upload-all-jar.sh
+++ b/.ci/release-upload-all-jar.sh
@@ -2,6 +2,8 @@
 
 set -e
 
+chmod +x ./mvnw
+
 source ./.ci/util.sh
 
 checkForVariable "GITHUB_TOKEN"
@@ -19,7 +21,7 @@ echo TARGET_VERSION="$TARGET_VERSION"
 git checkout checkstyle-"$TARGET_VERSION"
 
 echo "Generating uber jar ...(no clean to keep site resources just in case)"
-mvn -e --no-transfer-progress -Passembly,no-validations package
+./mvnw -e --no-transfer-progress -Passembly,no-validations package
 
 echo "Publishing 'all' jar to Github"
 UPLOAD_LINK=https://uploads.github.com/repos/"$REPOSITORY_OWNER"/checkstyle/releases

--- a/.ci/releasenotes-gen-xdoc-push.sh
+++ b/.ci/releasenotes-gen-xdoc-push.sh
@@ -1,6 +1,8 @@
 #!/bin/bash
 set -e
 
+chmod +x ./mvnw
+
 source ./.ci/util.sh
 checkForVariable "READ_ONLY_TOKEN"
 
@@ -16,7 +18,7 @@ echo TARGET_VERSION="$TARGET_VERSION"
 checkout_from https://github.com/checkstyle/contribution
 
 cd .ci-temp/contribution/releasenotes-builder
-mvn -e --no-transfer-progress clean compile package
+./mvnw -e --no-transfer-progress clean compile package
 cd ../../../
 
 if [ -d .ci-temp/checkstyle ]; then

--- a/.ci/releasenotes-gen.sh
+++ b/.ci/releasenotes-gen.sh
@@ -6,6 +6,8 @@
 
 set -e
 
+chmod +x ./mvnw
+
 if [ -z "$READ_ONLY_TOKEN" ]; then
   echo "'READ_ONLY_TOKEN' not found, exiting..."
   sleep 5s;
@@ -32,7 +34,7 @@ else
   cd ../
 fi
 cd .ci-temp/contribution/releasenotes-builder
-mvn -e --no-transfer-progress clean compile package
+./mvnw -e --no-transfer-progress clean compile package
 cd ../../../
 
 # we need to do full clone as Travis do "git clone --depth=50"
@@ -52,7 +54,7 @@ LATEST_RELEASE_TAG=$(git describe "$(git rev-list --tags --max-count=1)")
 cd ../../
 
 # shellcheck disable=2016 # we do not want to expand properties in this command
-CS_RELEASE_VERSION=$(mvn -e --no-transfer-progress -q -Dexec.executable='echo' \
+CS_RELEASE_VERSION=$(./mvnw -e --no-transfer-progress -q -Dexec.executable='echo' \
               -Dexec.args='${project.version}' \
               --non-recursive org.codehaus.mojo:exec-maven-plugin:1.3.1:exec | sed 's/-SNAPSHOT//')
 echo LATEST_RELEASE_TAG="$LATEST_RELEASE_TAG"

--- a/.ci/run-link-check-plugin.sh
+++ b/.ci/run-link-check-plugin.sh
@@ -3,11 +3,14 @@
 # Run "firefox target/site/linkcheck.html" after completion to review html report
 
 set -e
+
+chmod +x ./mvnw
+
 pwd
 uname -a
-mvn --version
+./mvnw --version
 curl --fail-with-body -I https://sourceforge.net/projects/checkstyle/
-mvn -e --no-transfer-progress clean site -Dcheckstyle.ant.skip=true -DskipTests -DskipITs \
+./mvnw -e --no-transfer-progress clean site -Dcheckstyle.ant.skip=true -DskipTests -DskipITs \
    -Dpmd.skip=true -Dspotbugs.skip=true -Djacoco.skip=true -Dcheckstyle.skip=true
 mkdir -p .ci-temp
 

--- a/.ci/sonar.sh
+++ b/.ci/sonar.sh
@@ -1,15 +1,17 @@
 #!/bin/sh
 
+chmod +x ./mvnw
+
 # set checkstyle sonar profile
 curl --fail-with-body -X POST -u admin:admin \
     -F 'backup=@config/default_sonar_profile.xml' -v http://localhost:9000/api/profiles/restore
 
 # execute inspection
-mvn -e --no-transfer-progress sonar:sonar -P sonar -Dsonar.language=java \
+./mvnw -e --no-transfer-progress sonar:sonar -P sonar -Dsonar.language=java \
   -Dsonar.profile=checkstyle-profile
 
 # Uncomment following to get HTML report.
-# mvn -e sonar:sonar -Dsonar.analysis.mode=preview -Dsonar.issuesReport.html.enable=true \
+# ./mvnw -e sonar:sonar -Dsonar.analysis.mode=preview -Dsonar.issuesReport.html.enable=true \
 #        -Dsonar.language=java -Dsonar.profile=checkstyle-profile
 
 

--- a/.ci/travis.sh
+++ b/.ci/travis.sh
@@ -2,6 +2,8 @@
 # Attention, there is no "-x" to avoid problems on Travis
 set -e
 
+chmod +x ./mvnw
+
 source ./.ci/util.sh
 
 export RUN_JOB=1
@@ -10,8 +12,9 @@ case $1 in
 
 init-m2-repo)
   if [[ $RUN_JOB == 1 ]]; then
-    MVN_REPO=$(mvn -e --no-transfer-progress help:evaluate -Dexpression=settings.localRepository \
-      -q -DforceStdout);
+    MVN_REPO=$(./mvnw -e --no-transfer-progress help:\
+    evaluate -Dexpression=settings.localRepository \
+    -q -DforceStdout);
     echo "Maven Repo Located At: " "$MVN_REPO"
     MVN_SETTINGS=${TRAVIS_HOME}/.m2/settings.xml
     if [[ -f ${MVN_SETTINGS} ]]; then
@@ -23,8 +26,8 @@ init-m2-repo)
     fi
     if [[ $USE_MAVEN_REPO == 'true' && ! -d "$HOME/.m2" ]]; then
      echo "Maven local repo cache is not found, initializing it ..."
-     mvn -e --no-transfer-progress -B install -Pno-validations;
-     mvn -e --no-transfer-progress clean;
+     ./mvnw -e --no-transfer-progress -B install -Pno-validations;
+     ./mvnw -e --no-transfer-progress clean;
     fi
   else
     echo "$1 is skipped";
@@ -67,14 +70,14 @@ deploy-snapshot)
           && $SKIP_DEPLOY == 'false'
      ]];
   then
-      mvn -e --no-transfer-progress -s config/deploy-settings.xml -Pno-validations deploy;
+      ./mvnw -e --no-transfer-progress -s config/deploy-settings.xml -Pno-validations deploy;
       echo "deploy to maven snapshot repository is finished";
   fi
   ;;
 
 quarterly-cache-cleanup)
-  MVN_REPO=$(mvn -e --no-transfer-progress help:evaluate -Dexpression=settings.localRepository \
-    -q -DforceStdout);
+  MVN_REPO=$(./mvnw -e --no-transfer-progress help:evaluate -Dexpression=settings.localRepository \
+    -q -DforceStdout)
   if [[ -d ${MVN_REPO} ]]; then
     find "$MVN_REPO" -maxdepth 4 -type d -mtime +90 -exec rm -rf {} \; || true;
   else

--- a/.ci/util.sh
+++ b/.ci/util.sh
@@ -2,6 +2,8 @@
 # This script contains common bash CI functions
 set -e
 
+chmod +x ./mvnw
+
 removeFolderWithProtectedFiles() {
   find "$1" -delete
 }
@@ -22,7 +24,7 @@ function checkForVariable() {
 
 function getMavenProperty {
   property="\${$1}"
-  mvn -e --no-transfer-progress -q -Dexec.executable='echo' \
+  ./mvnw -e --no-transfer-progress -q -Dexec.executable='echo' \
                       -Dexec.args="${property}" \
                       --non-recursive org.codehaus.mojo:exec-maven-plugin:1.3.1:exec
 }

--- a/.ci/validation.cmd
+++ b/.ci/validation.cmd
@@ -8,26 +8,31 @@
 
 SET OPTION=%1
 
+if not exist mvnw.cmd (
+  echo mvnw.cmd not found. Make sure Maven Wrapper is available.
+  exit /b 1
+)
+
 if "%OPTION%" == "sevntu" (
-  call mvn -e --no-transfer-progress verify -Pno-validations,sevntu^
+  call mvnw.cmd -e --no-transfer-progress verify -Pno-validations,sevntu^
     || goto :ERROR
   goto :END_CASE
 )
 
 if "%OPTION%" == "run_checkstyle" (
-  call mvn -e --no-transfer-progress clean compile antrun:run@ant-phase-verify^
+  call mvnw.cmd -e --no-transfer-progress clean compile antrun:run@ant-phase-verify^
     || goto :ERROR
   goto :END_CASE
 )
 
 if "%OPTION%" ==  "verify_without_checkstyle" (
-  call mvn -e --no-transfer-progress verify -Dcheckstyle.ant.skip=true -Dcheckstyle.skip=true^
+  call mvnw.cmd -e --no-transfer-progress verify -Dcheckstyle.ant.skip=true -Dcheckstyle.skip=true^
     || goto :ERROR
   goto :END_CASE
 )
 
 if "%OPTION%" ==  "site_without_verify" (
-  call mvn -e --no-transfer-progress -Pno-validations site^
+  call mvnw.cmd -e --no-transfer-progress -Pno-validations site^
     || goto :ERROR
   goto :END_CASE
 )

--- a/.ci/validation.sh
+++ b/.ci/validation.sh
@@ -1,6 +1,8 @@
 #!/bin/bash
 set -e
 
+chmod +x ./mvnw
+
 source ./.ci/util.sh
 
 addCheckstyleBundleToAntResolvers() {
@@ -88,7 +90,7 @@ check-missing-pitests)
   ;;
 
 eclipse-static-analysis)
-  mvn -e --no-transfer-progress clean compile exec:exec -Peclipse-compiler
+  ./mvnw -e --no-transfer-progress clean compile exec:exec -Peclipse-compiler
   ;;
 
 nondex)
@@ -96,7 +98,7 @@ nondex)
   SKIPPED_TESTS='!JavadocPropertiesGeneratorTest#testNonExistentArgument,'
   # Exclude test that fails due to stackoverflow error
   SKIPPED_TESTS+='!SingleSpaceSeparatorCheckTest#testNoStackoverflowError'
-  mvn -e --no-transfer-progress \
+  ./mvnw -e --no-transfer-progress \
     --fail-never clean nondex:nondex -DargLine='-Xms1g -Xmx2g' \
     -Dtest="$SKIPPED_TESTS"
 
@@ -133,63 +135,63 @@ pr-age)
   ;;
 
 test)
-  mvn -e --no-transfer-progress clean integration-test failsafe:verify \
+  ./mvnw -e --no-transfer-progress clean integration-test failsafe:verify \
   -DargLine='-Xms1g -Xmx2g'
   ;;
 
 test-de)
-  mvn -e --no-transfer-progress clean integration-test failsafe:verify \
+  ./mvnw -e --no-transfer-progress clean integration-test failsafe:verify \
     -Dsurefire.options='-Duser.language=de -Duser.country=DE -Xms1g -Xmx2g'
   ;;
 
 test-es)
-  mvn -e --no-transfer-progress clean integration-test failsafe:verify \
+  ./mvnw -e --no-transfer-progress clean integration-test failsafe:verify \
     -Dsurefire.options='-Duser.language=es -Duser.country=ES -Xms1g -Xmx2g'
   ;;
 
 test-fi)
-  mvn -e --no-transfer-progress clean integration-test failsafe:verify \
+  ./mvnw -e --no-transfer-progress clean integration-test failsafe:verify \
     -Dsurefire.options='-Duser.language=fi -Duser.country=FI -Xms1g -Xmx2g'
   ;;
 
 test-fr)
-  mvn -e --no-transfer-progress clean integration-test failsafe:verify \
+  ./mvnw -e --no-transfer-progress clean integration-test failsafe:verify \
     -Dsurefire.options='-Duser.language=fr -Duser.country=FR -Xms1g -Xmx2g'
   ;;
 
 test-zh)
-  mvn -e --no-transfer-progress clean integration-test failsafe:verify \
+  ./mvnw -e --no-transfer-progress clean integration-test failsafe:verify \
     -Dsurefire.options='-Duser.language=zh -Duser.country=CN -Xms1g -Xmx2g'
   ;;
 
 test-ja)
-  mvn -e --no-transfer-progress clean integration-test failsafe:verify \
+  ./mvnw -e --no-transfer-progress clean integration-test failsafe:verify \
     -Dsurefire.options='-Duser.language=ja -Duser.country=JP -Xms1g -Xmx2g'
   ;;
 
 test-pt)
-  mvn -e --no-transfer-progress clean integration-test failsafe:verify \
+  ./mvnw -e --no-transfer-progress clean integration-test failsafe:verify \
     -Dsurefire.options='-Duser.language=pt -Duser.country=PT -Xms1g -Xmx2g'
   ;;
 
 test-tr)
-  mvn -e --no-transfer-progress clean integration-test failsafe:verify \
+  ./mvnw -e --no-transfer-progress clean integration-test failsafe:verify \
     -Dsurefire.options='-Duser.language=tr -Duser.country=TR -Xms1g -Xmx2g'
   ;;
 
 test-ru)
-  mvn -e --no-transfer-progress clean integration-test failsafe:verify \
+  ./mvnw -e --no-transfer-progress clean integration-test failsafe:verify \
     -Dsurefire.options='-Duser.language=ru -Duser.country=RU -Xms1g -Xmx2g'
   ;;
 
 test-al)
-  mvn -e --no-transfer-progress clean integration-test failsafe:verify \
+  ./mvnw -e --no-transfer-progress clean integration-test failsafe:verify \
     -Dsurefire.options='-Duser.language=sq -Duser.country=AL -Xms1g -Xmx2g'
   ;;
 
 versions)
   if [ -v TRAVIS_EVENT_TYPE ] && [ "$TRAVIS_EVENT_TYPE" != "cron" ] ; then exit 0; fi
-  mvn -e --no-transfer-progress clean versions:dependency-updates-report \
+  ./mvnw -e --no-transfer-progress clean versions:dependency-updates-report \
     versions:plugin-updates-report
   if [ "$(grep "<nextVersion>" target/*-updates-report.xml | cat | wc -l)" -gt 0 ]; then
     echo "Version reports (dependency-updates-report.xml):"
@@ -214,11 +216,11 @@ markdownlint)
 no-error-pmd)
   CS_POM_VERSION="$(getCheckstylePomVersion)"
   echo "CS_version: ${CS_POM_VERSION}"
-  mvn -e --no-transfer-progress clean install -Pno-validations
+  ./mvnw -e --no-transfer-progress clean install -Pno-validations
   echo "Checkout target sources ..."
   checkout_from "https://github.com/pmd/build-tools.git"
   cd .ci-temp/build-tools/
-  mvn -e --no-transfer-progress install
+  ./mvnw -e --no-transfer-progress install
   cd ..
   git clone https://github.com/pmd/pmd.git
   cd pmd
@@ -237,7 +239,7 @@ no-error-pmd)
 no-violation-test-configurate)
   CS_POM_VERSION="$(getCheckstylePomVersion)"
   echo "CS_version: ${CS_POM_VERSION}"
-  mvn -e --no-transfer-progress clean install -Pno-validations
+  ./mvnw -e --no-transfer-progress clean install -Pno-validations
   echo "Checkout target sources ..."
   mkdir -p .ci-temp
   cd .ci-temp
@@ -251,7 +253,7 @@ no-violation-test-configurate)
 no-violation-test-josm)
   CS_POM_VERSION="$(getCheckstylePomVersion)"
   echo "CS_version: ${CS_POM_VERSION}"
-  mvn -e --no-transfer-progress clean install -Pno-validations
+  ./mvnw -e --no-transfer-progress clean install -Pno-validations
   echo "Checkout target sources ..."
   mkdir -p .ci-temp
   cd .ci-temp
@@ -277,29 +279,30 @@ no-error-xwiki)
   CS_POM_VERSION="$(getCheckstylePomVersion)"
   ANTLR4_VERSION="$(getMavenProperty 'antlr4.version')"
   echo "version:${CS_POM_VERSION} antlr4:${ANTLR4_VERSION}"
-  mvn -e --no-transfer-progress clean install -Pno-validations
+  ./mvnw -e --no-transfer-progress clean install -Pno-validations
   echo "Checkout target sources ..."
   checkout_from "https://github.com/xwiki/xwiki-commons.git"
   cd .ci-temp/xwiki-commons
   # Build custom Checkstyle rules
-  mvn -e --no-transfer-progress -f \
+  ./mvnw -e --no-transfer-progress -f \
     xwiki-commons-tools/xwiki-commons-tool-verification-resources/pom.xml \
     install -DskipTests -Dcheckstyle.version="${CS_POM_VERSION}" \
       -Dantlr4.version="${ANTLR4_VERSION}"
   # Validate xwiki-commons
-  mvn -e --no-transfer-progress checkstyle:check@default -Dcheckstyle.version="${CS_POM_VERSION}"
+  ./mvnw -e --no-transfer-progress checkstyle:check@default -Dcheckstyle.version="${CS_POM_VERSION}"
   # Install various required poms and extensions
-  mvn -e --no-transfer-progress install:install-file -Dfile=pom.xml -DpomFile=pom.xml
-  mvn -e --no-transfer-progress install:install-file -Dfile=xwiki-commons-tools/pom.xml \
+  ./mvnw -e --no-transfer-progress install:install-file -Dfile=pom.xml -DpomFile=pom.xml
+  ./mvnw -e --no-transfer-progress install:install-file -Dfile=xwiki-commons-tools/pom.xml \
     -DpomFile=xwiki-commons-tools/pom.xml
-  mvn -e --no-transfer-progress install:install-file \
+  ./mvnw -e --no-transfer-progress install:install-file \
     -Dfile=xwiki-commons-tools/xwiki-commons-tool-pom/pom.xml \
     -DpomFile=xwiki-commons-tools/xwiki-commons-tool-pom/pom.xml
-  mvn -e --no-transfer-progress install:install-file -Dfile=xwiki-commons-pom/pom.xml \
+  ./mvnw -e --no-transfer-progress install:install-file -Dfile=xwiki-commons-pom/pom.xml \
     -DpomFile=xwiki-commons-pom/pom.xml
-  mvn -e --no-transfer-progress -f xwiki-commons-tools/xwiki-commons-tool-webjar-handlers/pom.xml \
+  ./mvnw -e --no-transfer-progress \
+    -f xwiki-commons-tools/xwiki-commons-tool-webjar-handlers/pom.xml
     install -Dmaven.test.skip -Dcheckstyle.version="${CS_POM_VERSION}"
-  mvn -e --no-transfer-progress -f xwiki-commons-tools/xwiki-commons-tool-xar/pom.xml \
+  ./mvnw -e --no-transfer-progress -f xwiki-commons-tools/xwiki-commons-tool-xar/pom.xml \
     install -Dmaven.test.skip -Dcheckstyle.version="${CS_POM_VERSION}"
   cd ..
   removeFolderWithProtectedFiles xwiki-commons
@@ -307,14 +310,14 @@ no-error-xwiki)
   checkout_from https://github.com/xwiki/xwiki-rendering.git
   cd .ci-temp/xwiki-rendering
   # Validate xwiki-rendering
-  mvn -e --no-transfer-progress checkstyle:check@default -Dcheckstyle.version="${CS_POM_VERSION}"
+  ./mvnw -e --no-transfer-progress checkstyle:check@default -Dcheckstyle.version="${CS_POM_VERSION}"
   cd ..
   removeFolderWithProtectedFiles xwiki-rendering
   cd ..
   checkout_from https://github.com/xwiki/xwiki-platform.git
   cd .ci-temp/xwiki-platform
   # Validate xwiki-platform
-  mvn -e --no-transfer-progress checkstyle:check@default -Dcheckstyle.version="${CS_POM_VERSION}"
+  ./mvnw -e --no-transfer-progress checkstyle:check@default -Dcheckstyle.version="${CS_POM_VERSION}"
   cd ..
   removeFolderWithProtectedFiles xwiki-platform
   ;;
@@ -322,7 +325,7 @@ no-error-xwiki)
 no-error-test-sbe)
   CS_POM_VERSION="$(getCheckstylePomVersion)"
   echo version:"$CS_POM_VERSION"
-  mvn -e --no-transfer-progress clean install -Pno-validations
+  ./mvnw -e --no-transfer-progress clean install -Pno-validations
   echo "Checkout target sources ..."
   checkout_from https://github.com/real-logic/simple-binary-encoding.git
   cd .ci-temp/simple-binary-encoding
@@ -417,7 +420,7 @@ verify-regexp-id)
 
 checkstyle-and-sevntu)
   export MAVEN_OPTS='-Xmx2g'
-  mvn -e --no-transfer-progress clean verify -DskipTests -DskipITs \
+  ./mvnw -e --no-transfer-progress clean verify -DskipTests -DskipITs \
     -Dpmd.skip=true -Dspotbugs.skip=true -Djacoco.skip=true
   ;;
 
@@ -425,7 +428,7 @@ spotbugs-and-pmd)
   mkdir -p .ci-temp/spotbugs-and-pmd
   CHECKSTYLE_DIR=$(pwd)
   export MAVEN_OPTS='-Xmx2g'
-  mvn -e --no-transfer-progress clean test-compile pmd:check spotbugs:check
+  ./mvnw -e --no-transfer-progress clean test-compile pmd:check spotbugs:check
   cd .ci-temp/spotbugs-and-pmd
   grep "Processing_Errors" "$CHECKSTYLE_DIR/target/site/pmd.html" | cat > errors.log
   RESULT=$(cat errors.log | wc -l)
@@ -439,22 +442,22 @@ spotbugs-and-pmd)
 ;;
 
 site)
-  mvn -e --no-transfer-progress clean site -Pno-validations
+  ./mvnw -e --no-transfer-progress clean site -Pno-validations
   ;;
 
 release-dry-run)
   if [ "$(git log -1 | grep -E "\[maven-release-plugin\] prepare release" | cat | wc -l)" -lt 1 ]
   then
-    mvn -e --no-transfer-progress release:prepare -DdryRun=true --batch-mode \
+    ./mvnw -e --no-transfer-progress release:prepare -DdryRun=true --batch-mode \
     -Darguments='-DskipTests -DskipITs -Djacoco.skip=true -Dpmd.skip=true \
       -Dspotbugs.skip=true -Dxml.skip=true -Dcheckstyle.ant.skip=true \
       -Dcheckstyle.skip=true -Dgpg.skip=true --no-transfer-progress'
-    mvn -e --no-transfer-progress release:clean
+    ./mvnw -e --no-transfer-progress release:clean
   fi
   ;;
 
 assembly-run-all-jar)
-  mvn -e --no-transfer-progress clean package -Passembly,no-validations
+  ./mvnw -e --no-transfer-progress clean package -Passembly,no-validations
   CS_POM_VERSION="$(getCheckstylePomVersion)"
   echo version:"$CS_POM_VERSION"
   mkdir -p .ci-temp
@@ -597,8 +600,8 @@ javac21)
   ;;
 
 package-site)
-  mvn -e --no-transfer-progress package -Passembly,no-validations
-  mvn -e --no-transfer-progress site -Dlinkcheck.skip=true
+  ./mvnw -e --no-transfer-progress package -Passembly,no-validations
+  ./mvnw -e --no-transfer-progress site -Dlinkcheck.skip=true
   ;;
 
 sonarqube)
@@ -619,8 +622,8 @@ sonarqube)
   export MAVEN_OPTS='-Xmx2g'
   # until https://github.com/checkstyle/checkstyle/issues/11637
   # shellcheck disable=SC2086
-  mvn -e --no-transfer-progress -Pno-validations clean package sonar:sonar \
-       $SONAR_PR_VARIABLES \
+  ./mvnw -e --no-transfer-progress -Pno-validations clean package sonar:sonar \
+       "$SONAR_PR_VARIABLES" \
        -Dsonar.host.url=https://sonarcloud.io \
        -Dsonar.login="$SONAR_TOKEN" \
        -Dsonar.projectKey=org.checkstyle:checkstyle \
@@ -635,7 +638,7 @@ sonarqube)
 no-error-pgjdbc)
   CS_POM_VERSION="$(getCheckstylePomVersion)"
   echo CS_version: "${CS_POM_VERSION}"
-  mvn -e --no-transfer-progress clean install -Pno-validations
+  ./mvnw -e --no-transfer-progress clean install -Pno-validations
   echo "Checkout target sources ..."
   checkout_from https://github.com/pgjdbc/pgjdbc.git
   cd .ci-temp/pgjdbc
@@ -648,14 +651,15 @@ no-error-pgjdbc)
 no-error-orekit)
   CS_POM_VERSION="$(getCheckstylePomVersion)"
   echo CS_version: "${CS_POM_VERSION}"
-  mvn -e --no-transfer-progress clean install -Pno-validations
+  ./mvnw -e --no-transfer-progress clean install -Pno-validations
   echo "Checkout target sources ..."
   checkout_from https://github.com/Hipparchus-Math/hipparchus.git
   cd .ci-temp/hipparchus
   # checkout to version that Orekit expects
   SHA_HIPPARCHUS="815ad2bf9ce764e4498911d2145c49165f5f3333"
   git checkout $SHA_HIPPARCHUS
-  mvn -e --no-transfer-progress install -DskipTests
+  chmod +x mvnw
+  ./mvnw -e --no-transfer-progress install -DskipTests
   cd -
   checkout_from https://github.com/CS-SI/Orekit.git
   cd .ci-temp/Orekit
@@ -663,7 +667,7 @@ no-error-orekit)
   # checkout to latest release/development (annotated tag or hash) or sha that have fix we need
   # git checkout $(git describe --abbrev=0 --tags)
   git checkout "a32b4629b2890fc198b19a95a714d67b87d7943d"
-  mvn -e --no-transfer-progress compile checkstyle:check \
+  ./mvnw -e --no-transfer-progress compile checkstyle:check \
     -Dorekit.checkstyle.version="${CS_POM_VERSION}"
   cd ..
   removeFolderWithProtectedFiles Orekit
@@ -673,15 +677,15 @@ no-error-orekit)
 no-error-hibernate-search)
   CS_POM_VERSION="$(getCheckstylePomVersion)"
   echo CS_version: "${CS_POM_VERSION}"
-  mvn -e --no-transfer-progress clean install -Pno-validations
+  ./mvnw -e --no-transfer-progress clean install -Pno-validations
   echo "Checkout target sources ..."
   checkout_from https://github.com/hibernate/hibernate-search.git
   cd .ci-temp/hibernate-search
-  mvn -e --no-transfer-progress clean install -pl build/config -am \
+  ./mvnw -e --no-transfer-progress clean install -pl build/config -am \
      -DskipTests=true -Dmaven.compiler.failOnWarning=false \
      -Dcheckstyle.skip=true -Dforbiddenapis.skip=true \
      -Dversion.com.puppycrawl.tools.checkstyle="${CS_POM_VERSION}"
-  mvn -e --no-transfer-progress checkstyle:check \
+  ./mvnw -e --no-transfer-progress checkstyle:check \
      -Dversion.com.puppycrawl.tools.checkstyle="${CS_POM_VERSION}"
   cd ../
   removeFolderWithProtectedFiles hibernate-search
@@ -691,8 +695,8 @@ no-error-checkstyles-sevntu)
   set -e
   CS_POM_VERSION="$(getCheckstylePomVersion)"
   echo CS_version: "${CS_POM_VERSION}"
-  mvn -e --no-transfer-progress clean install -Pno-validations
-  mvn -e --no-transfer-progress compile verify -Psevntu \
+  ./mvnw -e --no-transfer-progress clean install -Pno-validations
+  ./mvnw -e --no-transfer-progress compile verify -Psevntu \
     -Dmaven.sevntu-checkstyle-check.checkstyle.version="${CS_POM_VERSION}" \
     -Dmaven.test.skip=true -Dpmd.skip=true -Dspotbugs.skip=true \
     -Djacoco.skip=true -Dforbiddenapis.skip=true -Dxml.skip=true
@@ -702,11 +706,12 @@ no-error-sevntu-checks)
   set -e
   CS_POM_VERSION="$(getCheckstylePomVersion)"
   echo CS_version: "${CS_POM_VERSION}"
-  mvn -e --no-transfer-progress clean install -Pno-validations
+  ./mvnw -e --no-transfer-progress clean install -Pno-validations
   echo "Checkout target sources ..."
   checkout_from https://github.com/sevntu-checkstyle/sevntu.checkstyle.git
   cd .ci-temp/sevntu.checkstyle/sevntu-checks
-  mvn -e --no-transfer-progress -Pno-validations verify  -Dcheckstyle.ant.skip=false \
+  chmod +x mvnw
+  ./mvnw -e --no-transfer-progress -Pno-validations verify  -Dcheckstyle.ant.skip=false \
      -Dcheckstyle.version="${CS_POM_VERSION}" \
      -Dcheckstyle.configLocation=../../../config/checkstyle-checks.xml \
      -Dcheckstyle.nonMain.configLocation=../../../config/checkstyle-non-main-files-checks.xml \
@@ -719,16 +724,17 @@ no-error-contribution)
   set -e
   CS_POM_VERSION="$(getCheckstylePomVersion)"
   echo CS_version: "${CS_POM_VERSION}"
-  mvn -e --no-transfer-progress clean install -Pno-validations
+  ./mvnw -e --no-transfer-progress clean install -Pno-validations
   echo "Checkout target sources ..."
   checkout_from https://github.com/checkstyle/contribution.git
   cd .ci-temp/contribution
   cd patch-diff-report-tool
-  mvn -e --no-transfer-progress verify -DskipTests -Dcheckstyle.version="${CS_POM_VERSION}" \
+  chmod +x mvnw
+  ./mvnw -e --no-transfer-progress verify -DskipTests -Dcheckstyle.version="${CS_POM_VERSION}" \
      -Dcheckstyle.configLocation=../../../config/checkstyle-checks.xml
   cd ../
   cd releasenotes-builder
-  mvn -e --no-transfer-progress verify -DskipTests -Dcheckstyle.version="${CS_POM_VERSION}" \
+  ./mvnw -e --no-transfer-progress verify -DskipTests -Dcheckstyle.version="${CS_POM_VERSION}" \
      -Dcheckstyle.configLocation=../../../config/checkstyle-checks.xml
   cd ../../
   removeFolderWithProtectedFiles contribution
@@ -738,11 +744,12 @@ no-error-methods-distance)
   set -e
   CS_POM_VERSION="$(getCheckstylePomVersion)"
   echo CS_version: "${CS_POM_VERSION}"
-  mvn -e --no-transfer-progress clean install -Pno-validations
+  ./mvnw -e --no-transfer-progress clean install -Pno-validations
   echo "Checkout target sources ..."
   checkout_from https://github.com/sevntu-checkstyle/methods-distance.git
   cd .ci-temp/methods-distance
-  mvn -e --no-transfer-progress verify -DskipTests -Dcheckstyle-version="${CS_POM_VERSION}" \
+  chmod +x mvnw
+  ./mvnw -e --no-transfer-progress verify -DskipTests -Dcheckstyle-version="${CS_POM_VERSION}" \
      -Dcheckstyle.configLocation=../../config/checkstyle-checks.xml
   cd ..
   removeFolderWithProtectedFiles  methods-distance
@@ -751,11 +758,12 @@ no-error-methods-distance)
 no-error-equalsverifier)
   CS_POM_VERSION="$(getCheckstylePomVersion)"
   echo CS_version: "${CS_POM_VERSION}"
-  mvn -e --no-transfer-progress clean install -Pno-validations
+  ./mvnw -e --no-transfer-progress clean install -Pno-validations
   echo "Checkout target sources ..."
   checkout_from https://github.com/jqno/equalsverifier.git
   cd .ci-temp/equalsverifier
-  mvn -e --no-transfer-progress -Pstatic-analysis-checkstyle compile \
+  chmod +x mvnw
+  ./mvnw -e --no-transfer-progress -Pstatic-analysis-checkstyle compile \
     checkstyle:check -Dversion.checkstyle="${CS_POM_VERSION}"
   cd ../
   removeFolderWithProtectedFiles equalsverifier
@@ -765,15 +773,15 @@ no-error-strata)
   set -e
   CS_POM_VERSION="$(getCheckstylePomVersion)"
   echo CS_version: "${CS_POM_VERSION}"
-  mvn -e --no-transfer-progress clean install -Pno-validations
+  ./mvnw -e --no-transfer-progress clean install -Pno-validations
   echo "Checkout target sources ..."
   checkout_from https://github.com/OpenGamma/Strata.git
   cd .ci-temp/Strata
   # shellcheck disable=2016 # we do not want to expand properties in this command
-  STRATA_CS_POM_VERSION=$(mvn -e --no-transfer-progress -q -Dexec.executable='echo' \
+  STRATA_CS_POM_VERSION=$(./mvnw -e --no-transfer-progress -q -Dexec.executable='echo' \
                      -Dexec.args='${checkstyle.version}' \
                      --non-recursive org.codehaus.mojo:exec-maven-plugin:1.3.1:exec)
-  mvn -e --no-transfer-progress install -B -Dstrict -DskipTests \
+  ./mvnw -e --no-transfer-progress install -B -Dstrict -DskipTests \
      -Dforbiddenapis.skip=true -Dcheckstyle.version="${CS_POM_VERSION}" \
      -Dcheckstyle.config.suffix="-v$STRATA_CS_POM_VERSION"
   cd ../
@@ -784,7 +792,7 @@ no-error-spring-integration)
   set -e
   CS_POM_VERSION="$(getCheckstylePomVersion)"
   echo CS_version: "${CS_POM_VERSION}"
-  mvn -e --no-transfer-progress clean install -Pno-validations
+  ./mvnw -e --no-transfer-progress clean install -Pno-validations
   echo "Checkout target sources ..."
   checkout_from https://github.com/spring-projects/spring-integration.git
   cd .ci-temp/spring-integration
@@ -799,11 +807,11 @@ no-error-spring-integration)
 no-error-htmlunit)
   CS_POM_VERSION="$(getCheckstylePomVersion)"
   echo CS_version: "${CS_POM_VERSION}"
-  mvn -e --no-transfer-progress clean install -Pno-validations
+  ./mvnw -e --no-transfer-progress clean install -Pno-validations
   echo "Checkout target sources ..."
   checkout_from https://github.com/HtmlUnit/htmlunit
   cd .ci-temp/htmlunit
-  mvn -e --no-transfer-progress compile checkstyle:check -Dcheckstyle.version="${CS_POM_VERSION}"
+  ./mvnw -e --no-transfer-progress compile checkstyle:check -Dcheckstyle.version="${CS_POM_VERSION}"
   cd ../
   removeFolderWithProtectedFiles htmlunit
   ;;
@@ -811,7 +819,7 @@ no-error-htmlunit)
 no-error-spotbugs)
   CS_POM_VERSION="$(getCheckstylePomVersion)"
   echo CS_version: "${CS_POM_VERSION}"
-  mvn -e --no-transfer-progress clean install -Pno-validations
+  ./mvnw -e --no-transfer-progress clean install -Pno-validations
   echo "Checkout target sources ..."
   checkout_from https://github.com/spotbugs/spotbugs
   cd .ci-temp/spotbugs
@@ -1103,7 +1111,7 @@ git-check-pull-number)
 
 jacoco)
   export MAVEN_OPTS='-Xmx2g'
-  mvn -e --no-transfer-progress clean test \
+  ./mvnw -e --no-transfer-progress clean test \
     jacoco:restore-instrumented-classes \
     jacoco:report@default-report \
     jacoco:check@default-check
@@ -1168,46 +1176,47 @@ check-wildcards-on-pitest-target-classes)
   ;;
 
 verify)
-  mvn -e --no-transfer-progress clean verify
+  ./mvnw -e --no-transfer-progress clean verify
   ;;
 
 package-all-jar)
-  mvn -e --no-transfer-progress clean package -Passembly
+  ./mvnw -e --no-transfer-progress clean package -Passembly
   ;;
 
 website-only)
-  mvn -e --no-transfer-progress clean site -Pno-validations
+  ./mvnw -e --no-transfer-progress clean site -Pno-validations
   ;;
 
 pmd)
-  mvn -e --no-transfer-progress clean test-compile pmd:check
+  ./mvnw -e --no-transfer-progress clean test-compile pmd:check
   ;;
 
 spotbugs)
-  mvn -e --no-transfer-progress clean test-compile spotbugs:check
+  ./mvnw -e --no-transfer-progress clean test-compile spotbugs:check
   ;;
 
 checkstyle)
-  mvn -e --no-transfer-progress clean compile antrun:run@ant-phase-verify
+  ./mvnw -e --no-transfer-progress clean compile antrun:run@ant-phase-verify
   ;;
 
 forbiddenapis)
-  mvn -e --no-transfer-progress \
+  ./mvnw -e --no-transfer-progress \
     clean compile test-compile forbiddenapis:testCheck@forbiddenapis-test
   ;;
 
 run-test)
   if [[ -z "$2" ]] ; then
     echo "Error: test class is not defined."
-    echo "Example: mvn -e --no-transfer-progress clean test -Dtest=XdocsPagesTest,XdocsJavaDocsTest"
-    echo "Example: mvn -e --no-transfer-progress clean test -Dtest=CheckerTest#testDestroy"
+    echo "Example: ./mvnw -e --no-transfer-progress clean test \
+    -Dtest=XdocsPagesTest,XdocsJavaDocsTest"
+    echo "Example: ./mvnw -e --no-transfer-progress clean test -Dtest=CheckerTest#testDestroy"
     exit 1
   fi
-  mvn -e --no-transfer-progress clean test -Dtest="$2"
+  ./mvnw -e --no-transfer-progress clean test -Dtest="$2"
   ;;
 
 sevntu)
-  mvn -e --no-transfer-progress clean compile checkstyle:check@sevntu-checkstyle-check
+  ./mvnw -e --no-transfer-progress clean compile checkstyle:check@sevntu-checkstyle-check
   ;;
 
 *)

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,10 +9,13 @@ jobs:
     steps:
       - checkout
       - run:
+          name: Make mvnw executable
+          command: chmod +x ./mvnw
+      - run:
           name: Print versions
           command: |
             echo "Maven version:"
-            mvn --version
+            ./mvnw --version
             echo "Java version:"
             java --version
             echo "IDEA version:"

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -47,7 +47,7 @@ task:
     - set
     - ant -version
     - java --version
-    - mvn --version
+    - mvnw.cmd --version
     # - xsltproc --version
     # - xml --version
   sevntu_script:

--- a/.gitattributes
+++ b/.gitattributes
@@ -3,6 +3,7 @@
 
 # Windows files always have CRLF eol
 *.bat eol=crlf
+*.cmd eol=crlf
 
 # Binary files need to be listed explicitly as first rule makes all files text files
 *.gif binary
@@ -21,3 +22,6 @@ src/test/resources-noncompilable/com/puppycrawl/tools/checkstyle/xpath/xpathquer
 src/test/resources/com/puppycrawl/tools/checkstyle/grammar/javadoc/InputCrAsNewlineMultiline.javadoc -text
 src/test/resources/com/puppycrawl/tools/checkstyle/grammar/javadoc/InputDosLineEndingAsNewlineMultiline.javadoc eol=crlf
 src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/newlineatendoffile/Example3.java eol=crlf
+
+# This prevents repeated git diff output showing old mode 100644 → new mode 100755.
+/mvnw eol=lf text executable

--- a/.github/workflows/error-prone.yml
+++ b/.github/workflows/error-prone.yml
@@ -28,6 +28,9 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
+      - name: Make mvnw executable
+        run: chmod +x ./mvnw
+
       - name: Setup local maven cache
         uses: actions/cache@v4
         with:
@@ -40,7 +43,7 @@ jobs:
       # Require to compile again in case previous step fails and sources are not compiled
       - name: Do a clean compile
         if: always()
-        run: mvn -e --no-transfer-progress clean compile
+        run: ./mvnw -e --no-transfer-progress clean compile
 
       - name: Execute Error-Prone on test-compile phase
         if: always()

--- a/.github/workflows/site.yml
+++ b/.github/workflows/site.yml
@@ -92,11 +92,14 @@ jobs:
           path: ~/.m2/repository
           key: checkstyle-maven-cache-${{ hashFiles('**/pom.xml') }}
 
+      - name: Make mvnw executable
+        run: chmod +x .ci-temp/checkstyle/mvnw
+
       - name: Generate site
         run: |
           bash
           cd .ci-temp/checkstyle
-          mvn -e --no-transfer-progress clean site -Pno-validations -Dmaven.javadoc.skip=false
+          ./mvnw -e --no-transfer-progress clean site -Pno-validations -Dmaven.javadoc.skip=false
 
       - name: Setup local maven cache
         uses: actions/cache/save@v4

--- a/.gitignore
+++ b/.gitignore
@@ -43,6 +43,9 @@ replay_pid*
 # temp folder for files/folders of ci validations
 .ci-temp
 
+# Maven Wrapper JAR (optional, not needed with only-script setup)
+.mvn/wrapper/maven-wrapper.jar
+
 # antlr4 grammar generates these
 **/gen
 **/JavaLanguageLexer.tokens

--- a/.mvn/wrapper/maven-wrapper.properties
+++ b/.mvn/wrapper/maven-wrapper.properties
@@ -1,0 +1,19 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+wrapperVersion=3.3.2
+distributionType=only-script
+distributionUrl=https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/3.6.3/apache-maven-3.6.3-bin.zip

--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -13,6 +13,9 @@ blocks:
       prologue:
         commands:
           - checkout
+          - pwd
+          - ls -la
+          - if [ -f "./mvnw" ]; then chmod +x ./mvnw; fi
           - cache restore m2
           - eval "export M2_CACHE_SIZE=$(du -s $HOME/.m2 | cut -f1)"
           - sudo apt-get update
@@ -29,8 +32,12 @@ blocks:
       jobs:
         - name: sevntu
           commands:
-            - mvn -e --no-transfer-progress compile antrun:run@ant-phase-verify-sevntu -Psevntu
-
+            - |
+              if [ -f "./mvnw" ]; then
+                ./mvnw -e --no-transfer-progress compile antrun:run@ant-phase-verify-sevntu -Psevntu
+              else
+                echo "WARNING: mvnw not found, skipping Maven execution"
+              fi
         - name: codenarc analysis
           commands:
             - rm -rf $HOME/.m2
@@ -57,7 +64,7 @@ blocks:
                 # permanently disabled as it is very unstable in execution
                 # - .ci/validation.sh nondex
                 # until https://github.com/checkstyle/checkstyle/issues/9807
-                # - mvn -e --no-transfer-progress clean package -Passembly,no-validations
+                # - ./mvnw -e --no-transfer-progress clean package -Passembly,no-validations
                 #    && .ci/validation.sh no-violation-test-josm
           commands:
             - sem-version java 11
@@ -72,7 +79,6 @@ blocks:
             - env_var: CMD
               values:
                 - .ci/validation.sh no-error-pgjdbc
-
           commands:
             - sem-version java 17
             - echo "eval of CMD is starting";
@@ -92,7 +98,6 @@ blocks:
                 - .ci/validation.sh no-error-methods-distance
                 - .ci/validation.sh no-error-equalsverifier
                 - .ci/validation.sh jacoco
-
           commands:
             - sem-version java 11
             - echo "eval of CMD is starting";
@@ -110,7 +115,7 @@ blocks:
               values:
                 - "true"
                 # until https://github.com/checkstyle/checkstyle/issues/9248
-                # - mvn -e clean install -Pno-validations
+                # - ./mvnw -e clean install -Pno-validations
                 #    && .ci/validation.sh no-violation-test-configurate
           commands:
             - sem-version java 11

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,6 +15,7 @@ branches:
 
 before_install:
   - sudo apt update
+  - chmod +x ./mvnw
 
 install:
   - sudo apt install -y xmlstarlet
@@ -28,7 +29,7 @@ jobs:
     - jdk: openjdk11
       env:
         - DESC="tests and deploy"
-        - CMD="mvn -e --no-transfer-progress clean integration-test failsafe:verify
+        - CMD="./mvnw -e --no-transfer-progress clean integration-test failsafe:verify
           -DargLine='-Xms1g -Xmx2g'"
         - DEPLOY="true"
         - USE_MAVEN_REPO="true"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -8,24 +8,13 @@ branches:
     - master
   except:
     - gh-pages
-install:
-  - ps: |
-      Add-Type -AssemblyName System.IO.Compression.FileSystem
-      if (!(Test-Path -Path "C:\maven\apache-maven-3.8.8" )) {
-        (new-object System.Net.WebClient).DownloadFile(
-          'https://downloads.apache.org/maven/maven-3/3.8.8/binaries/apache-maven-3.8.8-bin.zip',
-          'C:\maven-bin.zip'
-        )
-        [System.IO.Compression.ZipFile]::ExtractToDirectory("C:\maven-bin.zip", "C:\maven")
-      }
-  - cmd: SET M2_HOME=C:\maven\apache-maven-3.8.8
-  - cmd: SET PATH=%M2_HOME%\bin;%JAVA_HOME%\bin;%PATH%
-  - cmd: git config core.autocrlf
-  - cmd: mvn --version
-  - cmd: java -version
+  install:
+    - cmd: git config core.autocrlf
+    - cmd: chmod +x mvnw
+    - cmd: ./mvnw --version
+    - cmd: java -version
 
 cache:
-  - C:\maven\apache-maven-3.8.8
   - C:\Users\appveyor\.m2
 
 matrix:
@@ -36,8 +25,8 @@ environment:
     CMD: " "
     # https://stackoverflow.com/questions/42024619/maven-build-gets-connection-reset-when-downloading-artifacts
     MAVEN_OPTS: "-Dhttp.keepAlive=false -Dmaven.wagon.http.retryHandler.count=3"
-  # We do matrix as AppVeyor could fail to finish simple "mvn -e verify"
-  #    if he loose maven cache (happens from time to time)
+  # We do matrix as AppVeyor could fail to finish simple "./mvnw -e verify"
+  # if he loose maven cache (happens from time to time)
   matrix:
     # sevntu (JDK11)
     - JAVA_HOME: C:\Program Files\Java\jdk11
@@ -72,5 +61,4 @@ build_script:
       }
   - ps: ./.ci/validation.cmd git_diff
   - ps: echo "Size of caches (bytes):"
-  - ps: Get-ChildItem -Recurse 'C:\maven\apache-maven-3.8.8' | Measure-Object -Property Length -Sum
   - ps: Get-ChildItem -Recurse 'C:\Users\appveyor\.m2' | Measure-Object -Property Length -Sum

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -88,17 +88,17 @@ strategy:
     # OpenJDK11 verify
     'OpenJDK11 verify':
       image: 'ubuntu-24.04'
-      cmd: "mvn -e --no-transfer-progress verify"
+      cmd: "./mvnw -e --no-transfer-progress verify"
 
     # MacOS JDK11 verify
     'MacOS JDK11 verify':
       image: 'macOS-14'
-      cmd: "JAVA_HOME=$JAVA_HOME_11_X64 mvn -e --no-transfer-progress verify"
+      cmd: "JAVA_HOME=$JAVA_HOME_11_X64 ./mvnw -e --no-transfer-progress verify"
 
     # MacOS JDK17 verify
     'MacOS JDK17 verify':
       image: 'macOS-14'
-      cmd: "JAVA_HOME=$JAVA_HOME_17_X64 mvn -e --no-transfer-progress verify"
+      cmd: "JAVA_HOME=$JAVA_HOME_17_X64 ./mvnw -e --no-transfer-progress verify"
 
     # versions to update
     'versions':
@@ -127,6 +127,9 @@ variables:
   BUILD_REASON: $[variables['Build.Reason']]
 
 steps:
+  - bash: |
+      chmod +x ./mvnw
+    displayName: Make mvnw executable
   - bash: |
       apt-fast install -y xmlstarlet
     condition: |
@@ -157,7 +160,7 @@ steps:
 
   - bash: |
       set -e
-      mvn --version
+      ./mvnw --version
       echo "ON_CRON_ONLY:"$ON_CRON_ONLY
       echo "BUILD_REASON:"$BUILD_REASON
       echo "cmd: "$(cmd)

--- a/config/jsoref-spellchecker/whitelist.words
+++ b/config/jsoref-spellchecker/whitelist.words
@@ -24,6 +24,7 @@ allclasses
 allowlegacy
 alot
 amazonaws
+amd
 androidx
 annotationlocation
 annotationonsameline
@@ -46,6 +47,7 @@ applet
 appveyor
 APRV
 Aqj
+ARCHITEW
 archunit
 arget
 Arial
@@ -144,6 +146,7 @@ caciocavallosilano
 calledmethods
 camelcase
 casegroup
+casesensitive
 catchparametername
 cba
 cbeaff
@@ -255,10 +258,13 @@ csv
 ctc
 ctor
 ctx
+CTYPE
 customimportorder
 CVS
 cyclomatic
 cyclomaticcomplexity
+cygpath
+cygwin
 cz
 dalvik
 Daniil
@@ -393,6 +399,7 @@ Eslint
 esslingen
 esversion
 etsy
+euf
 ev
 Evt
 exceptionoverrides
@@ -487,7 +494,7 @@ gav
 Gdrox
 generalform
 genericwhitespace
-Getenv
+getenv
 gg
 gh
 gitattributes
@@ -558,6 +565,7 @@ hurz
 hyperlinks
 hz
 iae
+icm
 ico
 icu
 identifiernames
@@ -618,6 +626,7 @@ isrutf
 isset
 issuecomment
 issuehunt
+Itemtype
 itemvalue
 ith
 itr
@@ -631,6 +640,8 @@ Jakub
 jarchitect
 javaastvisitor
 javac
+JAVACCMD
+JAVACMD
 javadoc
 javadocblocktaglocation
 javadoccontentlocation
@@ -818,6 +829,7 @@ mfussenegger
 MHTML
 Micha
 microsoft
+mingw
 minimalistic
 Mipmap
 misconfigured
@@ -834,6 +846,7 @@ missingtag
 mixin
 mkdir
 mkordas
+mktemp
 MLINKCHECK
 moby
 mockit
@@ -862,8 +875,10 @@ mutableexception
 mutationtest
 MVC
 mvn
+mvnd
 mvnrepository
 mvnw
+MWRAPPER
 Mycheckstyle
 mycompany
 mycompanychecks
@@ -934,6 +949,7 @@ nonrequiredjavadoc
 nonvalidating
 noparentfile
 NOPMD
+noprofile
 noreply
 noscript
 NOSONAR
@@ -962,6 +978,7 @@ numericliterals
 nutsandbolts
 nvim
 nvuillam
+nx
 OAuth
 objblock
 oburn
@@ -1070,6 +1087,7 @@ Pointcut
 POJO
 Popup
 Postgresql
+powershell
 ppc
 prebuilts
 PRESIZE
@@ -1086,6 +1104,8 @@ propkey
 PROTECTE
 protonpack
 Psevntu
+PSHOME
+PSMODULEP
 Pstatic
 pubconstr
 pubifc
@@ -1137,6 +1157,7 @@ relativized
 releasenotes
 remkop
 reportyml
+REPOURL
 requireemptylinebeforeblocktaggroup
 requirethis
 resourceleak
@@ -1188,6 +1209,7 @@ Schneeberger
 scm
 scp
 screenshot
+Scriptblock
 Scss
 sdk
 sealedshouldhavepermitslist
@@ -1202,6 +1224,7 @@ servlet
 severitymatchfilter
 sevntu
 shanegenschaw
+shasum
 shellcheck
 shengchen
 Shiell
@@ -1350,6 +1373,7 @@ tokentype
 tolist
 Toolbar
 toolongpackagetotestcoveragegooglesjavastylerule
+toplevel
 TOSTRING
 Touchscreen
 trailingcomment
@@ -1406,6 +1430,7 @@ upsss
 urandom
 uri
 url
+usebackq
 userguide
 username
 usr
@@ -1443,6 +1468,7 @@ Wakelock
 Warni
 wbr
 Weakento
+webclient
 Webflow
 webjar
 Weblogic
@@ -1533,6 +1559,7 @@ xxxxxx
 XXXXXXXXXXXXXXXXXXXXXXXXXXXX
 xy
 XYzz
+xzf
 xzvf
 yaml
 yamllint

--- a/mvnw
+++ b/mvnw
@@ -1,0 +1,291 @@
+#!/bin/sh
+# ----------------------------------------------------------------------------
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+# ----------------------------------------------------------------------------
+
+# ----------------------------------------------------------------------------
+# Apache Maven Wrapper startup batch script, version 3.3.2
+#
+# Optional ENV vars
+# -----------------
+#   JAVA_HOME - location of a JDK home dir, required when download maven via java source
+#   MVNW_REPOURL - repo url base for downloading maven distribution
+#   MVNW_USERNAME/MVNW_PASSWORD - user and password for downloading maven
+#   MVNW_VERBOSE - true: enable verbose log; debug: trace the mvnw script;
+#                  others: silence the output
+# ----------------------------------------------------------------------------
+
+set -euf
+[ "${MVNW_VERBOSE-}" != debug ] || set -x
+
+# OS specific support.
+native_path() { printf %s\\n "$1"; }
+case "$(uname)" in
+CYGWIN* | MINGW*)
+  [ -z "${JAVA_HOME-}" ] || JAVA_HOME="$(cygpath --unix "$JAVA_HOME")"
+  native_path() { cygpath --path --windows "$1"; }
+  ;;
+esac
+
+# set JAVACMD and JAVACCMD
+set_java_home() {
+  # For Cygwin and MinGW, ensure paths are in Unix format before anything is touched
+  if [ -n "${JAVA_HOME-}" ]; then
+    if [ -x "$JAVA_HOME/jre/sh/java" ]; then
+      # IBM's JDK on AIX uses strange locations for the executables
+      JAVACMD="$JAVA_HOME/jre/sh/java"
+      JAVACCMD="$JAVA_HOME/jre/sh/javac"
+    else
+      JAVACMD="$JAVA_HOME/bin/java"
+      JAVACCMD="$JAVA_HOME/bin/javac"
+
+      if [ ! -x "$JAVACMD" ] || [ ! -x "$JAVACCMD" ]; then
+        echo "The JAVA_HOME environment variable is not defined correctly, so mvnw cannot run." >&2
+        echo "JAVA_HOME is set to \"$JAVA_HOME\", but \"\$JAVA_HOME/bin/java\" or " \
+        "\"\$JAVA_HOME/bin/javac\" does not exist." >&2
+        return 1
+      fi
+    fi
+  else
+    JAVACMD="$(
+      'set' +e
+      'unset' -f command 2>/dev/null
+      'command' -v java
+    )" || :
+    JAVACCMD="$(
+      'set' +e
+      'unset' -f command 2>/dev/null
+      'command' -v javac
+    )" || :
+
+    if [ ! -x "${JAVACMD-}" ] || [ ! -x "${JAVACCMD-}" ]; then
+      echo "The java/javac command does not exist in PATH nor is JAVA_HOME set, " \
+      "so mvnw cannot run." >&2
+      return 1
+    fi
+  fi
+}
+
+# hash string like Java String::hashCode
+hash_string() {
+  str="${1:-}" h=0
+  while [ -n "$str" ]; do
+    char="${str%"${str#?}"}"
+    h=$(((h * 31 + $(LC_CTYPE=C printf %d "'$char")) % 4294967296))
+    str="${str#?}"
+  done
+  printf %x\\n $h
+}
+
+verbose() { :; }
+[ "${MVNW_VERBOSE-}" != true ] || verbose() { printf %s\\n "${1-}"; }
+
+die() {
+  printf %s\\n "$1" >&2
+  exit 1
+}
+
+trim() {
+  # MWRAPPER-139:
+  #   Trims trailing and leading whitespace, carriage returns, tabs, and linefeeds.
+  #   Needed for removing poorly interpreted newline sequences when running in more
+  #   exotic environments such as mingw bash on Windows.
+  printf "%s" "${1}" | tr -d '[:space:]'
+}
+
+# parse distributionUrl and optional distributionSha256Sum,
+# requires .mvn/wrapper/maven-wrapper.properties
+while IFS="=" read -r key value; do
+  case "${key-}" in
+  distributionUrl) distributionUrl=$(trim "${value-}") ;;
+  distributionSha256Sum) distributionSha256Sum=$(trim "${value-}") ;;
+  esac
+done <"${0%/*}/.mvn/wrapper/maven-wrapper.properties"
+[ -n "${distributionUrl-}" ] || die \
+  "cannot read distributionUrl property in ${0%/*}/.mvn/wrapper/maven-wrapper.properties"
+
+case "${distributionUrl##*/}" in
+maven-mvnd-*bin.*)
+  MVN_CMD=mvnd.sh _MVNW_REPO_PATTERN=/maven/mvnd/
+  case "${PROCESSOR_ARCHITECTURE-}${PROCESSOR_ARCHITEW6432-}:$(uname -a)" in
+  *AMD64:CYGWIN* | *AMD64:MINGW*) distributionPlatform=windows-amd64 ;;
+  :Darwin*x86_64) distributionPlatform=darwin-amd64 ;;
+  :Darwin*arm64) distributionPlatform=darwin-aarch64 ;;
+  :Linux*x86_64*) distributionPlatform=linux-amd64 ;;
+  *)
+    echo "Cannot detect native platform for mvnd on $(uname)-$(uname -m), use pure java version" >&2
+    distributionPlatform=linux-amd64
+    ;;
+  esac
+  distributionUrl="${distributionUrl%-bin.*}-$distributionPlatform.zip"
+  ;;
+maven-mvnd-*) MVN_CMD=mvnd.sh _MVNW_REPO_PATTERN=/maven/mvnd/ ;;
+*) MVN_CMD="mvn${0##*/mvnw}" _MVNW_REPO_PATTERN=/org/apache/maven/ ;;
+esac
+
+# apply MVNW_REPOURL and calculate MAVEN_HOME
+# maven home pattern: ~/.m2/wrapper/dists/{apache-maven-<version>,
+# maven-mvnd-<version>-<platform>}/<hash>
+# shellcheck disable=SC2140
+[ -z "${MVNW_REPOURL-}" ] || distributionUrl="$MVNW_REPOURL$_MVNW_REPO_PATTERN"\
+"${distributionUrl#*"$_MVNW_REPO_PATTERN"}"
+distributionUrlName="${distributionUrl##*/}"
+distributionUrlNameMain="${distributionUrlName%.*}"
+distributionUrlNameMain="${distributionUrlNameMain%-bin}"
+MAVEN_USER_HOME="${MAVEN_USER_HOME:-${HOME}/.m2}"
+# shellcheck disable=SC2140
+MAVEN_HOME="${MAVEN_USER_HOME}/wrapper/dists/${distributionUrlNameMain-}/"\
+"$(hash_string "$distributionUrl")"
+
+exec_maven() {
+  unset MVNW_VERBOSE MVNW_USERNAME MVNW_PASSWORD MVNW_REPOURL || :
+  exec "$MAVEN_HOME/bin/$MVN_CMD" "$@" || die "cannot exec $MAVEN_HOME/bin/$MVN_CMD"
+}
+
+if [ -d "$MAVEN_HOME" ]; then
+  verbose "found existing MAVEN_HOME at $MAVEN_HOME"
+  exec_maven "$@"
+fi
+
+case "${distributionUrl-}" in
+*?-bin.zip | *?maven-mvnd-?*-?*.zip) ;;
+*) die "distributionUrl is not valid, must match *-bin.zip or maven-mvnd-*.zip, " \
+  "but found '${distributionUrl-}'" ;;
+esac
+
+# prepare tmp dir
+if TMP_DOWNLOAD_DIR="$(mktemp -d)" && [ -d "$TMP_DOWNLOAD_DIR" ]; then
+  clean() { rm -rf -- "$TMP_DOWNLOAD_DIR"; }
+  trap clean HUP INT TERM EXIT
+else
+  die "cannot create temp dir"
+fi
+
+mkdir -p -- "${MAVEN_HOME%/*}"
+
+# Download and Install Apache Maven
+verbose "Couldn't find MAVEN_HOME, downloading and installing it ..."
+verbose "Downloading from: $distributionUrl"
+verbose "Downloading to: $TMP_DOWNLOAD_DIR/$distributionUrlName"
+
+# select .zip or .tar.gz
+if ! command -v unzip >/dev/null; then
+  distributionUrl="${distributionUrl%.zip}.tar.gz"
+  distributionUrlName="${distributionUrl##*/}"
+fi
+
+# verbose opt
+__MVNW_QUIET_WGET=--quiet __MVNW_QUIET_CURL=--silent __MVNW_QUIET_UNZIP=-q __MVNW_QUIET_TAR=''
+[ "${MVNW_VERBOSE-}" != true ] || __MVNW_QUIET_WGET='' \
+  __MVNW_QUIET_CURL='' __MVNW_QUIET_UNZIP='' __MVNW_QUIET_TAR=v
+
+# normalize http auth
+case "${MVNW_PASSWORD:+has-password}" in
+'') MVNW_USERNAME='' MVNW_PASSWORD='' ;;
+has-password) [ -n "${MVNW_USERNAME-}" ] || MVNW_USERNAME='' MVNW_PASSWORD='' ;;
+esac
+
+if [ -z "${MVNW_USERNAME-}" ] && command -v wget >/dev/null; then
+  verbose "Found wget ... using wget"
+wget ${__MVNW_QUIET_WGET:+"$__MVNW_QUIET_WGET"} "$distributionUrl" \
+  -O "$TMP_DOWNLOAD_DIR/$distributionUrlName" || \
+  die "wget: Failed to fetch $distributionUrl"
+elif [ -z "${MVNW_USERNAME-}" ] && command -v curl >/dev/null; then
+  verbose "Found curl ... using curl"
+curl ${__MVNW_QUIET_CURL:+"$__MVNW_QUIET_CURL"} -f -L \
+  -o "$TMP_DOWNLOAD_DIR/$distributionUrlName" "$distributionUrl" || \
+  die "curl: Failed to fetch $distributionUrl"
+elif set_java_home; then
+  verbose "Falling back to use Java to download"
+  javaSource="$TMP_DOWNLOAD_DIR/Downloader.java"
+  targetZip="$TMP_DOWNLOAD_DIR/$distributionUrlName"
+  cat >"$javaSource" <<-END
+	public class Downloader extends java.net.Authenticator
+	{
+	  protected java.net.PasswordAuthentication getPasswordAuthentication()
+	  {
+	    return new java.net.PasswordAuthentication( \
+      System.getenv( "MVNW_USERNAME" ), \
+      System.getenv( "MVNW_PASSWORD" ).toCharArray() );
+	  }
+	  public static void main( String[] args ) throws Exception
+	  {
+	    setDefault( new Downloader() );
+	    java.nio.file.Files.copy( \
+      java.net.URI.create( args[0] ).toURL().openStream(), \
+      java.nio.file.Paths.get( args[1] ).toAbsolutePath().normalize() );
+	  }
+	}
+	END
+  # For Cygwin/MinGW, switch paths to Windows format before running javac and java
+  verbose " - Compiling Downloader.java ..."
+  "$(native_path "$JAVACCMD")" "$(native_path "$javaSource")" || \
+  die "Failed to compile Downloader.java"
+  verbose " - Running Downloader.java ..."
+  "$(native_path "$JAVACMD")" -cp "$(native_path "$TMP_DOWNLOAD_DIR")" \
+  Downloader "$distributionUrl" "$(native_path "$targetZip")"
+fi
+
+# If specified, validate the SHA-256 sum of the Maven distribution zip file
+if [ -n "${distributionSha256Sum-}" ]; then
+  distributionSha256Result=false
+  if [ "$MVN_CMD" = mvnd.sh ]; then
+    echo "Checksum validation is not supported for maven-mvnd." >&2
+    echo "Please disable validation by removing 'distributionSha256Sum' from your " \
+     "maven-wrapper.properties." >&2
+    exit 1
+  elif command -v sha256sum >/dev/null; then
+    if echo "$distributionSha256Sum  $TMP_DOWNLOAD_DIR/$distributionUrlName" | \
+    sha256sum -c >/dev/null 2>&1; then
+      distributionSha256Result=true
+    fi
+  elif command -v shasum >/dev/null; then
+    if echo "$distributionSha256Sum  $TMP_DOWNLOAD_DIR/$distributionUrlName" | \
+    shasum -a 256 -c >/dev/null 2>&1; then
+      distributionSha256Result=true
+    fi
+  else
+    echo "Checksum validation was requested but neither 'sha256sum' or 'shasum' are available." >&2
+    echo "Please install either command, or disable validation by removing \
+    'distributionSha256Sum' from your \
+    maven-wrapper.properties." >&2
+    exit 1
+  fi
+  if [ $distributionSha256Result = false ]; then
+    echo "Error: Failed to validate Maven distribution SHA-256, your Maven distribution " \
+     "might be compromised." >&2
+    echo "If you updated your Maven version, you need to update the specified " \
+     "distributionSha256Sum property." >&2
+    exit 1
+  fi
+fi
+
+# unzip and move
+if command -v unzip >/dev/null; then
+  unzip ${__MVNW_QUIET_UNZIP:+"$__MVNW_QUIET_UNZIP"} "$TMP_DOWNLOAD_DIR/$distributionUrlName" \
+  -d "$TMP_DOWNLOAD_DIR" || die "failed to unzip"
+else
+  tar xzf${__MVNW_QUIET_TAR:+"$__MVNW_QUIET_TAR"} "$TMP_DOWNLOAD_DIR/$distributionUrlName" \
+  -C "$TMP_DOWNLOAD_DIR" || die "failed to untar"
+fi
+printf %s\\n "$distributionUrl" >"$TMP_DOWNLOAD_DIR/$distributionUrlNameMain/mvnw.url"
+mv -- "$TMP_DOWNLOAD_DIR/$distributionUrlNameMain" "$MAVEN_HOME" || \
+  [ -d "$MAVEN_HOME" ] || die "fail to move MAVEN_HOME"
+
+clean || :
+exec_maven "$@"

--- a/mvnw.cmd
+++ b/mvnw.cmd
@@ -1,0 +1,179 @@
+<# : batch portion
+@REM ----------------------------------------------------------------------------
+@REM Licensed to the Apache Software Foundation (ASF) under one
+@REM or more contributor license agreements.  See the NOTICE file
+@REM distributed with this work for additional information
+@REM regarding copyright ownership.  The ASF licenses this file
+@REM to you under the Apache License, Version 2.0 (the
+@REM "License"); you may not use this file except in compliance
+@REM with the License.  You may obtain a copy of the License at
+@REM
+@REM    http://www.apache.org/licenses/LICENSE-2.0
+@REM
+@REM Unless required by applicable law or agreed to in writing,
+@REM software distributed under the License is distributed on an
+@REM "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+@REM KIND, either express or implied.  See the License for the
+@REM specific language governing permissions and limitations
+@REM under the License.
+@REM ----------------------------------------------------------------------------
+
+@REM ----------------------------------------------------------------------------
+@REM Apache Maven Wrapper startup batch script, version 3.3.2
+@REM
+@REM Optional ENV vars
+@REM   MVNW_REPOURL - repo url base for downloading maven distribution
+@REM   MVNW_USERNAME/MVNW_PASSWORD - user and password for downloading maven
+@REM   MVNW_VERBOSE - true: enable verbose log; others: silence the output
+@REM ----------------------------------------------------------------------------
+
+@IF "%__MVNW_ARG0_NAME__%"=="" (SET __MVNW_ARG0_NAME__=%~nx0)
+@SET __MVNW_CMD__=
+@SET __MVNW_ERROR__=
+@SET __MVNW_PSMODULEP_SAVE=%PSModulePath%
+@SET PSModulePath=
+@FOR /F "usebackq tokens=1* delims==" %%A IN (`powershell -noprofile "& {$scriptDir='%~dp0'; \
+  $script='%__MVNW_ARG0_NAME__%'; icm -ScriptBlock ([Scriptblock]::Create((Get-Content -Raw \
+  '%~f0'))) -NoNewScope}"`) DO @(
+  IF "%%A"=="MVN_CMD" (set __MVNW_CMD__=%%B) ELSE IF "%%B"=="" (echo %%A) ELSE (echo %%A=%%B)
+)
+@SET PSModulePath=%__MVNW_PSMODULEP_SAVE%
+@SET __MVNW_PSMODULEP_SAVE=
+@SET __MVNW_ARG0_NAME__=
+@SET MVNW_USERNAME=
+@SET MVNW_PASSWORD=
+@IF NOT "%__MVNW_CMD__%"=="" (%__MVNW_CMD__% %*)
+@echo Cannot start maven from wrapper >&2 && exit /b 1
+@GOTO :EOF
+: end batch / begin powershell #>
+
+$ErrorActionPreference = "Stop"
+if ($env:MVNW_VERBOSE -eq "true") {
+  $VerbosePreference = "Continue"
+}
+
+# calculate distributionUrl, requires .mvn/wrapper/maven-wrapper.properties
+$distributionUrl = (Get-Content -Raw "$scriptDir/.mvn/wrapper/maven-wrapper.properties" | \
+  ConvertFrom-StringData).distributionUrl
+if (!$distributionUrl) {
+  Write-Error "cannot read distributionUrl property in " `
+            "$scriptDir/.mvn/wrapper/" `
+            "maven-wrapper.properties"
+}
+
+switch -wildcard -casesensitive ( $($distributionUrl -replace '^.*/','') ) {
+  "maven-mvnd-*" {
+    $USE_MVND = $true
+    $distributionUrl = $distributionUrl -replace '-bin\.[^.]*$',"-windows-amd64.zip"
+    $MVN_CMD = "mvnd.cmd"
+    break
+  }
+  default {
+    $USE_MVND = $false
+    $MVN_CMD = $script -replace '^mvnw','mvn'
+    break
+  }
+}
+
+# apply MVNW_REPOURL and calculate MAVEN_HOME
+# Maven home pattern:
+# ~/.m2/wrapper/dists/{apache-maven-<version>,
+# maven-mvnd-<version>-<platform>}/<hash>
+if ($env:MVNW_REPOURL) {
+  $MVNW_REPO_PATTERN = if ($USE_MVND) { "/org/apache/maven/" } else { "/maven/mvnd/" }
+  $distributionUrl = "$env:MVNW_REPOURL" +
+                   "$MVNW_REPO_PATTERN" +
+                   ($distributionUrl -replace '^.*' + $MVNW_REPO_PATTERN, '')
+}
+$distributionUrlName = $distributionUrl -replace '^.*/',''
+$distributionUrlNameMain = $distributionUrlName -replace '\.[^.]*$','' -replace '-bin$',''
+$MAVEN_HOME_PARENT = "$HOME/.m2/wrapper/dists/$distributionUrlNameMain"
+if ($env:MAVEN_USER_HOME) {
+  $MAVEN_HOME_PARENT = "$env:MAVEN_USER_HOME/wrapper/dists/$distributionUrlNameMain"
+}
+$MAVEN_HOME_NAME = (
+  [System.Security.Cryptography.MD5]::Create().ComputeHash(
+    [byte[]][char[]]$distributionUrl
+  ) | ForEach-Object {
+    $_.ToString("x2")
+  }
+) -join ''
+$MAVEN_HOME = "$MAVEN_HOME_PARENT/$MAVEN_HOME_NAME"
+
+if (Test-Path -Path "$MAVEN_HOME" -PathType Container) {
+  Write-Verbose "found existing MAVEN_HOME at $MAVEN_HOME"
+  Write-Output "MVN_CMD=$MAVEN_HOME/bin/$MVN_CMD"
+  exit $?
+}
+
+if (! $distributionUrlNameMain -or ($distributionUrlName -eq $distributionUrlNameMain)) {
+  Write-Error "distributionUrl is not valid, must end with *-bin.zip, " +
+            "but found $distributionUrl"
+}
+
+# prepare tmp dir
+$TMP_DOWNLOAD_DIR_HOLDER = New-TemporaryFile
+$TMP_DOWNLOAD_DIR = New-Item -Itemtype Directory -Path "$TMP_DOWNLOAD_DIR_HOLDER.dir"
+$TMP_DOWNLOAD_DIR_HOLDER.Delete() | Out-Null
+trap {
+  if ($TMP_DOWNLOAD_DIR.Exists) {
+    try { Remove-Item $TMP_DOWNLOAD_DIR -Recurse -Force | Out-Null }
+    catch { Write-Warning "Cannot remove $TMP_DOWNLOAD_DIR" }
+  }
+}
+
+New-Item -Itemtype Directory -Path "$MAVEN_HOME_PARENT" -Force | Out-Null
+
+# Download and Install Apache Maven
+Write-Verbose "Couldn't find MAVEN_HOME, downloading and installing it ..."
+Write-Verbose "Downloading from: $distributionUrl"
+Write-Verbose "Downloading to: $TMP_DOWNLOAD_DIR/$distributionUrlName"
+
+$webclient = New-Object System.Net.WebClient
+if ($env:MVNW_USERNAME -and $env:MVNW_PASSWORD) {
+  $webclient.Credentials = New-Object System.Net.NetworkCredential(
+    $env:MVNW_USERNAME,
+    $env:MVNW_PASSWORD
+)
+}
+[Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
+$webclient.DownloadFile($distributionUrl, "$TMP_DOWNLOAD_DIR/$distributionUrlName") | Out-Null
+
+# If specified, validate the SHA-256 sum of the Maven distribution zip file
+$distributionSha256Sum = (
+  Get-Content -Raw "$scriptDir/.mvn/wrapper/maven-wrapper.properties" |
+    ConvertFrom-StringData
+).distributionSha256Sum
+if ($distributionSha256Sum) {
+  if ($USE_MVND) {
+    Write-Error "Checksum validation is not supported for maven-mvnd.`n" `
+    + "Please disable validation by " `
+    + "removing 'distributionSha256Sum' from your maven-wrapper.properties."
+  }
+  Import-Module $PSHOME\Modules\Microsoft.PowerShell.Utility -Function Get-FileHash
+  if (
+  (Get-FileHash "$TMP_DOWNLOAD_DIR/$distributionUrlName" -Algorithm SHA256).Hash.ToLower() -ne
+    $distributionSha256Sum
+  ) {
+    Write-Error "Error: Failed to validate Maven distribution SHA-256, your Maven distribution " `
+    + "might be compromised. If you updated your Maven version, you need to update the " `
+    + "specified distributionSha256Sum property."
+  }
+}
+
+# unzip and move
+Expand-Archive "$TMP_DOWNLOAD_DIR/$distributionUrlName" `
+    -DestinationPath "$TMP_DOWNLOAD_DIR" | Out-Null
+Rename-Item -Path "$TMP_DOWNLOAD_DIR/$distributionUrlNameMain" -NewName $MAVEN_HOME_NAME | Out-Null
+try {
+  Move-Item -Path "$TMP_DOWNLOAD_DIR/$MAVEN_HOME_NAME" -Destination $MAVEN_HOME_PARENT | Out-Null
+} catch {
+  if (! (Test-Path -Path "$MAVEN_HOME" -PathType Container)) {
+    Write-Error "fail to move MAVEN_HOME"
+  }
+} finally {
+  try { Remove-Item $TMP_DOWNLOAD_DIR -Recurse -Force | Out-Null }
+  catch { Write-Warning "Cannot remove $TMP_DOWNLOAD_DIR" }
+}
+
+Write-Output "MVN_CMD=$MAVEN_HOME/bin/$MVN_CMD"


### PR DESCRIPTION
Fixes #16850 
Closes #16747

Adding support for maven wrapper to the repo.
Used modern version so that we really not need mavan wrapper jar file.

We are using latest maven stable version ```3.9.9``` which needs Java Version support 8 or more and we use 11 so good to go.
for maven wrapper we using ```3.3.2``` which is again latest version.

Passes - Build Success

1. ```./mvnw validate```
2.``` ./mvnw compile```
3.``` ./mvnw test```
4. ```./mvnw clean verify -U```
5. ```./mvnw dependency:analyze ```


As maven wrapper is setup we can use ```./mvnw clean verify``` too/instead of ```mvn clean verify```


![Screenshot 2025-04-14 102741](https://github.com/user-attachments/assets/1c2ab881-7451-4c27-b321-d024061e464b)

Updates in workflows / ci

- ```Possible github actions```
- ``` All the possible circle ci```

Complete updated ci to use maven wrapper instead just maven are listed below:
1. ```appveyor.yml```
2. ``` semaphore.yml```
3. ```config.yml```
4. ```azure-pipelines.yml```
5. ```.cirrus.yml```