### PR TITLE
Issue #14019: Covered pitest survivals with tests for CheckstyleAntTask

### DIFF
--- a/config/pitest-suppressions/pitest-ant-suppressions.xml
+++ b/config/pitest-suppressions/pitest-ant-suppressions.xml
@@ -3,15 +3,6 @@
   <mutation unstable="false">
     <sourceFile>CheckstyleAntTask.java</sourceFile>
     <mutatedClass>com.puppycrawl.tools.checkstyle.ant.CheckstyleAntTask</mutatedClass>
-    <mutatedMethod>&lt;init&gt;</mutatedMethod>
-    <mutator>org.pitest.mutationtest.engine.gregor.mutators.experimental.MemberVariableMutator</mutator>
-    <description>Removed assignment to member variable maxWarnings</description>
-    <lineContent>private int maxWarnings = Integer.MAX_VALUE;</lineContent>
-  </mutation>
-
-  <mutation unstable="false">
-    <sourceFile>CheckstyleAntTask.java</sourceFile>
-    <mutatedClass>com.puppycrawl.tools.checkstyle.ant.CheckstyleAntTask</mutatedClass>
     <mutatedMethod>addProperty</mutatedMethod>
     <mutator>org.pitest.mutationtest.engine.gregor.mutators.NonVoidMethodCallMutator</mutator>
     <description>removed call to java/util/List::add</description>

--- a/src/test/java/com/puppycrawl/tools/checkstyle/ant/CheckstyleAntTaskTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/ant/CheckstyleAntTaskTest.java
@@ -21,6 +21,7 @@ package com.puppycrawl.tools.checkstyle.ant;
 
 import static com.google.common.truth.Truth.assertWithMessage;
 import static com.puppycrawl.tools.checkstyle.internal.utils.TestUtil.getExpectedThrowable;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 
 import java.io.File;
 import java.io.IOException;
@@ -976,6 +977,17 @@ public class CheckstyleAntTaskTest extends AbstractPathTestSupport {
         final Matcher matcher = Pattern.compile("(\\d+)").matcher(line);
         matcher.find();
         return Long.parseLong(matcher.group(1));
+    }
+
+    @Test
+    public void testMaxWarningDefault() throws IOException {
+        final CheckstyleAntTask antTask = getCheckstyleAntTask();
+        final File inputFile = new File(getPath(WARNING_INPUT));
+        final Location fileLocation = new Location("build.xml", 42, 10);
+
+        antTask.setFile(inputFile);
+        antTask.setLocation(fileLocation);
+        assertDoesNotThrow(antTask::execute, "BuildException is not expected");
     }
 
 }


### PR DESCRIPTION
Issue: #14019 

**Suppression removed**
  ```
<mutation unstable="false">
    <sourceFile>CheckstyleAntTask.java</sourceFile>
    <mutatedClass>com.puppycrawl.tools.checkstyle.ant.CheckstyleAntTask</mutatedClass>
    <mutatedMethod>&lt;init&gt;</mutatedMethod>
    <mutator>org.pitest.mutationtest.engine.gregor.mutators.experimental.MemberVariableMutator</mutator>
    <description>Removed assignment to member variable maxWarnings</description>
    <lineContent>private int maxWarnings = Integer.MAX_VALUE;</lineContent>
  </mutation>

```