### PR TITLE
Issue: #16867: Fix XXE vulnerability in DocumentBuilder initialization

### DIFF
--- a/src/test/resources/com/puppycrawl/tools/checkstyle/grammar/antlr4/InputAntlr4AstRegressionCassandraInputWithComments.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/grammar/antlr4/InputAntlr4AstRegressionCassandraInputWithComments.java
@@ -65,11 +65,17 @@ public class InputAntlr4AstRegressionCassandraInputWithComments
     private static final String SYSTEM_ERR = "";
 
     private static DocumentBuilder getDocumentBuilder() {
-        try {
-            return DocumentBuilderFactory.newInstance().newDocumentBuilder();
-        } catch (final Exception exc) {
-            throw new ExceptionInInitializerError(exc);
-        }
+      final DocumentBuilderFactory docFactory = DocumentBuilderFactory.newInstance();
+      docFactory.setAttribute(XMLConstants.ACCESS_EXTERNAL_DTD, "");
+      docFactory.setAttribute(XMLConstants.ACCESS_EXTERNAL_SCHEMA, "");
+      try
+      {
+         return docFactory.newDocumentBuilder();
+      }
+      catch (ParserConfigurationException e)
+      {
+          throw new RuntimeException(e);
+      }
     }
 
     private static final String tag = System.getProperty("cassandra.testtag", "");


### PR DESCRIPTION
This PR addresses an XML External Entity (XXE) vulnerability in the getDocumentBuilder(), to prevent server-side request forgery, Local file disclosure and Denial of service via entity expansion. The existing functionality should remain unchanged as these are defensive measures that only prevent exploitation attempts.

References
https://github.com/soartech/jsoar/commit/ae6a2ecf1c86488504c498759d9258973cc68387 
https://nvd.nist.gov/vuln/detail/CVE-2023-34610
