### PR TITLE
Issue #14631: Updated BR_TAG to new AST format

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/api/JavadocTokenTypes.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/api/JavadocTokenTypes.java
@@ -2702,7 +2702,34 @@ public final class JavadocTokenTypes {
     /** Basefont html tag. */
     public static final int BASEFONT_TAG = JavadocParser.RULE_basefontTag + RULE_TYPES_OFFSET;
 
-    /** Br html tag. */
+    /**
+     * Br html tag.
+     *
+     * <p><b>Example:</b></p>
+     * <pre>{@code <br> line breaks<br/>}</pre>
+     * <b>Tree:</b>
+     * <pre>
+     * {@code
+     * JAVADOC -> JAVADOC
+     * |--NEWLINE -> \r\n
+     * |--LEADING_ASTERISK ->  *
+     * |--TEXT ->
+     * |--HTML_ELEMENT -> HTML_ELEMENT
+     * |   `--SINGLETON_ELEMENT -> SINGLETON_ELEMENT
+     * |       `--BR_TAG -> BR_TAG
+     * |           |--START -> <
+     * |           |--BR_HTML_TAG_NAME -> br
+     * |           `--END -> >
+     * |--TEXT ->  line breaks
+     * |--HTML_ELEMENT -> HTML_ELEMENT
+     * |   `--SINGLETON_ELEMENT -> SINGLETON_ELEMENT
+     * |       `--BR_TAG -> BR_TAG
+     * |           |--START -> <
+     * |           |--BR_HTML_TAG_NAME -> br
+     * |           `--SLASH_END -> />
+     * }
+     * </pre>
+     */
     public static final int BR_TAG = JavadocParser.RULE_brTag + RULE_TYPES_OFFSET;
 
     /** Col html tag. */


### PR DESCRIPTION
Issue #14631
**Command Used**
`java -jar checkstyle-10.21.4-all.jar -J Test.java | sed "s/\[[0-9]\+:[0-9]\+\]//g"`
**Test.java**
```
/**
 * <br> line breaks<br/>
 */
public class Test {
}
```
**Terminal Output**
```
yukti@LAPTOP-P8NBSFE2 MINGW64 ~/BR_TAG (hide)
$ java -jar checkstyle-10.21.4-all.jar -J Test.java | sed "s/\[[0-9]\+:[0-9]\+\]//g"
COMPILATION_UNIT -> COMPILATION_UNIT
`--CLASS_DEF -> CLASS_DEF
    |--MODIFIERS -> MODIFIERS
    |   |--BLOCK_COMMENT_BEGIN -> /*
    |   |   |--COMMENT_CONTENT -> *\r\n * <br> line breaks<br/>\r\n
    |   |   |   `--JAVADOC -> JAVADOC
    |   |   |       |--NEWLINE -> \r\n
    |   |   |       |--LEADING_ASTERISK ->  *
    |   |   |       |--TEXT ->
    |   |   |       |--HTML_ELEMENT -> HTML_ELEMENT
    |   |   |       |   `--SINGLETON_ELEMENT -> SINGLETON_ELEMENT
    |   |   |       |       `--BR_TAG -> BR_TAG
    |   |   |       |           |--START -> <
    |   |   |       |           |--BR_HTML_TAG_NAME -> br
    |   |   |       |           `--END -> >
    |   |   |       |--TEXT ->  line breaks
    |   |   |       |--HTML_ELEMENT -> HTML_ELEMENT
    |   |   |       |   `--SINGLETON_ELEMENT -> SINGLETON_ELEMENT
    |   |   |       |       `--BR_TAG -> BR_TAG
    |   |   |       |           |--START -> <
    |   |   |       |           |--BR_HTML_TAG_NAME -> br
    |   |   |       |           `--SLASH_END -> />
    |   |   |       |--NEWLINE -> \r\n
    |   |   |       |--TEXT ->
    |   |   |       `--EOF -> <EOF>
    |   |   `--BLOCK_COMMENT_END -> */
    |   `--LITERAL_PUBLIC -> public
    |--LITERAL_CLASS -> class
    |--IDENT -> Test
    `--OBJBLOCK -> OBJBLOCK
        |--LCURLY -> {
        `--RCURLY -> }
```
