### PR TITLE
Issue #16882: Replace AtomicInteger with int[] in countCaseConstants

### DIFF
--- a/.ci/release-copy-github-io-to-sourceforge.sh
+++ b/.ci/release-copy-github-io-to-sourceforge.sh
@@ -84,7 +84,7 @@ tar -xzvf htdocs-archive/htdocs-$PREV_RELEASE.tar.gz -C htdocs-version/ --same-o
 --exclude="*/xref" --exclude="*/xref-test" --exclude="*/cobertura" --exclude="*/dsm" \
 --exclude="*/api" --exclude="reports" --exclude="jacoco" --exclude="dtds" \
 --exclude="dependency-updates-report.html" --exclude="plugin-updates-report.html" \
---exclude="jdepend-report.html" --exclude="failsafe-report.html" \
+--exclude="failsafe-report.html" \
 --exclude="surefire-report.html" \
 --exclude="linkcheck.html" --exclude="findbugs.html" --exclude="taglist.html" \
 --exclude="releasenotes_old_6-0_7-8.html" --exclude="releasenotes_old_1-0_5-9.html" \

--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,25 @@
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+indent_style = space
+indent_size = 4
+insert_final_newline = true
+max_line_length = 100
+
+[*.xml]
+indent_size = 2
+
+[pom.xml]
+max_line_length = 140
+
+[*.java]
+ij_java_class_count_to_use_import_on_demand = 999
+ij_java_else_on_new_line = true
+ij_java_imports_layout = $*, |, java.**, |, javax.**, |, org.**, |, net.**, |, com.**, |, *
+ij_java_names_count_to_use_import_on_demand = 999
+
+[**xdocs-examples**.java]
+ij_continuation_indent_size = 2
+indent_size = 2

--- a/src/it/resources/com/google/checkstyle/test/chapter4formatting/rule4822declaredwhenneeded/InputDeclaredWhenNeeded.java
+++ b/src/it/resources/com/google/checkstyle/test/chapter4formatting/rule4822declaredwhenneeded/InputDeclaredWhenNeeded.java
@@ -547,7 +547,7 @@ public class InputDeclaredWhenNeeded {
   }
 
   /** Some javadoc. */
-  public int testIssue3211(String toDir) throws Exception {
+  public int testIssue3211(String target) throws Exception {
     int count = 0;
     // violation above 'Distance between variable 'count' .* first usage is 4, but allowed 3.'
     String[] files = {};

--- a/src/main/java/com/puppycrawl/tools/checkstyle/ant/CheckstyleAntTask.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/ant/CheckstyleAntTask.java
@@ -635,7 +635,7 @@ public class CheckstyleAntTask extends Task {
          *
          * @param destination destination the file to output to
          */
-        public void setTofile(File destination) {
+        public void setToFile(File destination) {
             toFile = destination;
         }
 

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/metrics/NPathComplexityCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/metrics/NPathComplexityCheck.java
@@ -548,18 +548,19 @@ public final class NPathComplexityCheck extends AbstractCheck {
      * @return number of case constant tokens.
      */
     private static int countCaseConstants(DetailAST ast) {
-        final AtomicInteger counter = new AtomicInteger();
-        final DetailAST literalCase = ast.getFirstChild();
+    final int[] counter = {0};
+    final DetailAST literalCase = ast.getFirstChild();
 
-        for (DetailAST node = literalCase.getFirstChild(); node != null;
-                    node = node.getNextSibling()) {
-            if (TokenUtil.isOfType(node, CASE_LABEL_TOKENS)) {
-                counter.getAndIncrement();
-            }
+    for (DetailAST node = literalCase.getFirstChild(); node != null;
+            node = node.getNextSibling()) {
+        if (TokenUtil.isOfType(node, CASE_LABEL_TOKENS)) {
+            counter[0]++;
         }
-
-        return counter.get();
     }
+
+    return counter[0];
+}
+
 
     /**
      * Coordinates of token end. Used to prevent inline ternary

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/metrics/NPathComplexityCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/metrics/NPathComplexityCheck.java
@@ -548,19 +548,18 @@ public final class NPathComplexityCheck extends AbstractCheck {
      * @return number of case constant tokens.
      */
     private static int countCaseConstants(DetailAST ast) {
-    final int[] counter = {0};
-    final DetailAST literalCase = ast.getFirstChild();
+        final AtomicInteger counter = new AtomicInteger();
+        final DetailAST literalCase = ast.getFirstChild();
 
-    for (DetailAST node = literalCase.getFirstChild(); node != null;
-            node = node.getNextSibling()) {
-        if (TokenUtil.isOfType(node, CASE_LABEL_TOKENS)) {
-            counter[0]++;
+        for (DetailAST node = literalCase.getFirstChild(); node != null;
+                    node = node.getNextSibling()) {
+            if (TokenUtil.isOfType(node, CASE_LABEL_TOKENS)) {
+                counter.getAndIncrement();
+            }
         }
+
+        return counter.get();
     }
-
-    return counter[0];
-}
-
 
     /**
      * Coordinates of token end. Used to prevent inline ternary

--- a/src/test/java/com/puppycrawl/tools/checkstyle/ant/CheckstyleAntTaskTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/ant/CheckstyleAntTaskTest.java
@@ -153,7 +153,7 @@ public class CheckstyleAntTaskTest extends AbstractPathTestSupport {
 
         assertWithMessage("Scanning path was not logged")
                 .that(loggedMessages.stream().filter(
-                        msg -> msg.getMsg().startsWith("1) Adding 1 files from path")).count())
+                        msg -> msg.getMsg().startsWith("1) Adding 1 file from path")).count())
                 .isEqualTo(1);
 
         assertWithMessage("Scanning empty was logged")
@@ -454,7 +454,7 @@ public class CheckstyleAntTaskTest extends AbstractPathTestSupport {
 
         final CheckstyleAntTask.Formatter formatter = new CheckstyleAntTask.Formatter();
         final File outputFile = new File("target/ant_task_plain_output.txt");
-        formatter.setTofile(outputFile);
+        formatter.setToFile(outputFile);
         final CheckstyleAntTask.FormatterType formatterType = new CheckstyleAntTask.FormatterType();
         formatterType.setValue("plain");
         formatter.setType(formatterType);
@@ -499,7 +499,7 @@ public class CheckstyleAntTaskTest extends AbstractPathTestSupport {
 
         final CheckstyleAntTask.Formatter formatter = new CheckstyleAntTask.Formatter();
         final File outputFile = new File("target/ant_task_config_by_url.txt");
-        formatter.setTofile(outputFile);
+        formatter.setToFile(outputFile);
         final CheckstyleAntTask.FormatterType formatterType = new CheckstyleAntTask.FormatterType();
         formatterType.setValue("plain");
         formatter.setType(formatterType);
@@ -524,7 +524,7 @@ public class CheckstyleAntTaskTest extends AbstractPathTestSupport {
 
         final CheckstyleAntTask.Formatter formatter = new CheckstyleAntTask.Formatter();
         final File outputFile = new File("target/ant_task_config_by_url.txt");
-        formatter.setTofile(outputFile);
+        formatter.setToFile(outputFile);
         final CheckstyleAntTask.FormatterType formatterType = new CheckstyleAntTask.FormatterType();
         formatterType.setValue("plain");
         formatter.setType(formatterType);
@@ -591,7 +591,7 @@ public class CheckstyleAntTaskTest extends AbstractPathTestSupport {
         antTask.setFailOnViolation(false);
         final CheckstyleAntTask.Formatter formatter = new CheckstyleAntTask.Formatter();
         final File outputFile = new File("target/log.xml");
-        formatter.setTofile(outputFile);
+        formatter.setToFile(outputFile);
         final CheckstyleAntTask.FormatterType formatterType = new CheckstyleAntTask.FormatterType();
         formatterType.setValue("xml");
         formatter.setType(formatterType);
@@ -618,7 +618,7 @@ public class CheckstyleAntTaskTest extends AbstractPathTestSupport {
         antTask.setFailOnViolation(false);
         final CheckstyleAntTask.Formatter formatter = new CheckstyleAntTask.Formatter();
         final File outputFile = new File("target/log.sarif");
-        formatter.setTofile(outputFile);
+        formatter.setToFile(outputFile);
         final CheckstyleAntTask.FormatterType formatterType = new CheckstyleAntTask.FormatterType();
         formatterType.setValue("sarif");
         formatter.setType(formatterType);
@@ -654,7 +654,7 @@ public class CheckstyleAntTaskTest extends AbstractPathTestSupport {
         antTask.setFile(new File(getPath(FLAWLESS_INPUT)));
         final CheckstyleAntTask.Formatter formatter = new CheckstyleAntTask.Formatter();
         final File outputFile = new File("target/");
-        formatter.setTofile(outputFile);
+        formatter.setToFile(outputFile);
         antTask.addFormatter(formatter);
         final BuildException ex = getExpectedThrowable(BuildException.class,
                 antTask::execute,
@@ -671,7 +671,7 @@ public class CheckstyleAntTaskTest extends AbstractPathTestSupport {
         antTask.setFile(new File(getPath(FLAWLESS_INPUT)));
         final CheckstyleAntTask.Formatter formatter = new CheckstyleAntTask.Formatter();
         final File outputFile = new File("target/");
-        formatter.setTofile(outputFile);
+        formatter.setToFile(outputFile);
         final CheckstyleAntTask.FormatterType formatterType = new CheckstyleAntTask.FormatterType();
         formatterType.setValue("xml");
         formatter.setType(formatterType);
@@ -690,7 +690,7 @@ public class CheckstyleAntTaskTest extends AbstractPathTestSupport {
         antTask.setFile(new File(getPath(FLAWLESS_INPUT)));
         final CheckstyleAntTask.Formatter formatter = new CheckstyleAntTask.Formatter();
         final File outputFile = new File("target/");
-        formatter.setTofile(outputFile);
+        formatter.setToFile(outputFile);
         final CheckstyleAntTask.FormatterType formatterType = new CheckstyleAntTask.FormatterType();
         formatterType.setValue("sarif");
         formatter.setType(formatterType);
@@ -737,7 +737,7 @@ public class CheckstyleAntTaskTest extends AbstractPathTestSupport {
     public void testDefaultLoggerListenerWithToFile() throws IOException {
         final CheckstyleAntTask.Formatter formatter = new CheckstyleAntTask.Formatter();
         formatter.setUseFile(false);
-        formatter.setTofile(new File("target/"));
+        formatter.setToFile(new File("target/"));
         assertWithMessage("Listener instance has unexpected type")
                 .that(formatter.createListener(null))
                 .isInstanceOf(DefaultLogger.class);
@@ -762,7 +762,7 @@ public class CheckstyleAntTaskTest extends AbstractPathTestSupport {
         final CheckstyleAntTask.Formatter formatter = new CheckstyleAntTask.Formatter();
         formatter.setType(formatterType);
         formatter.setUseFile(false);
-        formatter.setTofile(new File("target/"));
+        formatter.setToFile(new File("target/"));
         assertWithMessage("Listener instance has unexpected type")
                 .that(formatter.createListener(null))
                 .isInstanceOf(XMLLogger.class);
@@ -771,7 +771,7 @@ public class CheckstyleAntTaskTest extends AbstractPathTestSupport {
     @Test
     public void testDefaultLoggerWithNullToFile() throws IOException {
         final CheckstyleAntTask.Formatter formatter = new CheckstyleAntTask.Formatter();
-        formatter.setTofile(null);
+        formatter.setToFile(null);
         assertWithMessage("Listener instance has unexpected type")
             .that(formatter.createListener(null))
             .isInstanceOf(DefaultLogger.class);
@@ -783,7 +783,7 @@ public class CheckstyleAntTaskTest extends AbstractPathTestSupport {
         formatterType.setValue("xml");
         final CheckstyleAntTask.Formatter formatter = new CheckstyleAntTask.Formatter();
         formatter.setType(formatterType);
-        formatter.setTofile(null);
+        formatter.setToFile(null);
         assertWithMessage("Listener instance has unexpected type")
             .that(formatter.createListener(null))
             .isInstanceOf(XMLLogger.class);
@@ -808,7 +808,7 @@ public class CheckstyleAntTaskTest extends AbstractPathTestSupport {
         final CheckstyleAntTask.Formatter formatter = new CheckstyleAntTask.Formatter();
         formatter.setType(formatterType);
         formatter.setUseFile(false);
-        formatter.setTofile(new File("target/"));
+        formatter.setToFile(new File("target/"));
         assertWithMessage("Listener instance has unexpected type")
                 .that(formatter.createListener(null))
                 .isInstanceOf(SarifLogger.class);
@@ -820,7 +820,7 @@ public class CheckstyleAntTaskTest extends AbstractPathTestSupport {
         formatterType.setValue("sarif");
         final CheckstyleAntTask.Formatter formatter = new CheckstyleAntTask.Formatter();
         formatter.setType(formatterType);
-        formatter.setTofile(null);
+        formatter.setToFile(null);
         assertWithMessage("Listener instance has unexpected type")
                 .that(formatter.createListener(null))
                 .isInstanceOf(SarifLogger.class);
@@ -946,7 +946,7 @@ public class CheckstyleAntTaskTest extends AbstractPathTestSupport {
 
         assertLoggedTime(loggedMessages, testingTime, "Total execution");
         assertLoggedTime(loggedMessages, testingTime, "To locate the files");
-        assertLoggedTime(loggedMessages, testingTime, "To process the files");
+        assertLoggedTime(loggedMessages, testingTime, "File processing");
     }
 
     private static void assertLoggedTime(List<MessageLevelPair> loggedMessages,

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/indentation/IndentationCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/indentation/IndentationCheckTest.java
@@ -151,18 +151,18 @@ public class IndentationCheckTest extends AbstractModuleTestSupport {
         final int tabWidth = Integer.parseInt(config.getProperty("tabWidth"));
         final IndentComment[] linesWithWarn =
                         getLinesWithWarnAndCheckComments(filePath, tabWidth);
-        verify(config, filePath, expected, linesWithWarn);
+        verifyWarns(config, filePath, expected, linesWithWarn);
         assertWithMessage("Expected warning count in UT does not match warn comment count "
                 + "in input file")
             .that(expected.length)
             .isEqualTo(linesWithWarn.length);
     }
 
-    private void verify(Configuration config, String filePath, String[] expected,
+    private void verifyWarns(Configuration config, String filePath, String[] expected,
             final IndentComment... linesWithWarn) throws Exception {
         final Checker checker = createChecker(config);
         checker.addListener(new IndentAudit(linesWithWarn));
-        verify(checker, filePath, expected);
+        verifyWarns(checker, filePath, expected);
     }
 
     @Override

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/indentation/IndentationCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/indentation/IndentationCheckTest.java
@@ -1277,7 +1277,7 @@ public class IndentationCheckTest extends AbstractModuleTestSupport {
             "55:9: " + getCheckMessage(MSG_ERROR, "\"\"\"", 8, 12),
             "73:15: " + getCheckMessage(MSG_ERROR, "\"\"\"", 14, 12),
         };
-        verify(checkConfig, getNonCompilablePath("InputIndentationTextBlock.java"),
+        verifyWarns(checkConfig, getNonCompilablePath("InputIndentationTextBlock.java"),
             expected);
     }
 
@@ -1531,7 +1531,7 @@ public class IndentationCheckTest extends AbstractModuleTestSupport {
         };
 
         // Test input for this test case is not checked due to issue #693.
-        verify(checkConfig, fileName, expected);
+        verifyWarns(checkConfig, fileName, expected);
     }
 
     @Test
@@ -1573,7 +1573,7 @@ public class IndentationCheckTest extends AbstractModuleTestSupport {
         };
 
         // Test input for this test case is not checked due to issue #693.
-        verify(checkConfig, fileName, expected);
+        verifyWarns(checkConfig, fileName, expected);
     }
 
     @Test
@@ -2754,7 +2754,7 @@ public class IndentationCheckTest extends AbstractModuleTestSupport {
         checkConfig.addProperty("tabWidth", "4");
         final String fileName = getPath("InputIndentationSeparatedStatementWithSpaces.java");
         final String[] expected = CommonUtil.EMPTY_STRING_ARRAY;
-        verify(checkConfig, fileName, expected);
+        verifyWarns(checkConfig, fileName, expected);
     }
 
     @Test
@@ -2814,7 +2814,7 @@ public class IndentationCheckTest extends AbstractModuleTestSupport {
         final String fileName =
             getPath("InputIndentationMethodPrecededByAnnotationWithParameterOnSeparateLine.java");
         final String[] expected = CommonUtil.EMPTY_STRING_ARRAY;
-        verify(checkConfig, fileName, expected);
+        verifyWarns(checkConfig, fileName, expected);
     }
 
     @Test
@@ -2831,7 +2831,7 @@ public class IndentationCheckTest extends AbstractModuleTestSupport {
             "14:9: " + getCheckMessage(MSG_ERROR, "(", 8, 12),
             "19:5: " + getCheckMessage(MSG_ERROR, "(", 4, 8),
         };
-        verify(checkConfig, fileName, expected);
+        verifyWarns(checkConfig, fileName, expected);
     }
 
     @Test

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/variabledeclarationusagedistance/InputVariableDeclarationUsageDistance.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/variabledeclarationusagedistance/InputVariableDeclarationUsageDistance.java
@@ -510,7 +510,7 @@ public class InputVariableDeclarationUsageDistance {
     }
 
 
-    public int testIssue32_11(String toDir)
+    public int testIssue32_11(String target)
             throws Exception
     {
         int count = 0; // violation 'Distance .* is 4.'

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/variabledeclarationusagedistance/InputVariableDeclarationUsageDistanceDefault.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/variabledeclarationusagedistance/InputVariableDeclarationUsageDistanceDefault.java
@@ -510,7 +510,7 @@ public class InputVariableDeclarationUsageDistanceDefault {
     }
 
 
-    public int testIssue32_11(String toDir)
+    public int testIssue32_11(String target)
             throws Exception
     {
         int count = 0;  // violation 'Distance .* is 4.'

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/variabledeclarationusagedistance/InputVariableDeclarationUsageDistanceFinal.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/variabledeclarationusagedistance/InputVariableDeclarationUsageDistanceFinal.java
@@ -510,7 +510,7 @@ public class InputVariableDeclarationUsageDistanceFinal {
     }
 
 
-    public int testIssue32_11(String toDir)
+    public int testIssue32_11(String target)
             throws Exception
     {
         int count = 0; // violation 'Distance between .* declaration and its first usage is 4.'

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/variabledeclarationusagedistance/InputVariableDeclarationUsageDistanceGeneral.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/variabledeclarationusagedistance/InputVariableDeclarationUsageDistanceGeneral.java
@@ -510,7 +510,7 @@ public class InputVariableDeclarationUsageDistanceGeneral {
     }
 
 
-    public int testIssue32_11(String toDir)
+    public int testIssue32_11(String target)
             throws Exception
     {
         int count = 0; // violation 'Distance between .* declaration and its first usage is 4.'

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/variabledeclarationusagedistance/InputVariableDeclarationUsageDistanceRegExp.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/variabledeclarationusagedistance/InputVariableDeclarationUsageDistanceRegExp.java
@@ -510,7 +510,7 @@ public class InputVariableDeclarationUsageDistanceRegExp {
     }
 
 
-    public int testIssue32_11(String toDir)
+    public int testIssue32_11(String target)
             throws Exception
     {
         int count = 0; // violation 'Distance between .* declaration and its first usage is 4.'

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/variabledeclarationusagedistance/InputVariableDeclarationUsageDistanceScopes.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/variabledeclarationusagedistance/InputVariableDeclarationUsageDistanceScopes.java
@@ -510,7 +510,7 @@ public class InputVariableDeclarationUsageDistanceScopes {
     }
 
 
-    public int testIssue32_11(String toDir)
+    public int testIssue32_11(String target)
             throws Exception
     {
         int count = 0; // violation 'Distance .* is 4.'


### PR DESCRIPTION
Replaced java.util.concurrent.atomic.AtomicInteger with int[] in the countCaseConstants method of NPathComplexityCheck.java.  
Fixes: #16882
