### PR TITLE
Issue #16882: Removed suppression in spotbugs-exclude

### DIFF
--- a/config/spotbugs-exclude.xml
+++ b/config/spotbugs-exclude.xml
@@ -327,11 +327,6 @@
   </Match>
   <Match>
     <!-- we are single thread tool for now -->
-    <Class name="com.puppycrawl.tools.checkstyle.checks.metrics.NPathComplexityCheck"/>
-    <Bug pattern="AT_STALE_THREAD_WRITE_OF_PRIMITIVE"/>
-  </Match>
-  <Match>
-    <!-- we are single thread tool for now -->
     <Class name="com.puppycrawl.tools.checkstyle.checks.sizes.RecordComponentNumberCheck"/>
     <Bug pattern="AT_STALE_THREAD_WRITE_OF_PRIMITIVE"/>
   </Match>


### PR DESCRIPTION
Issue: #16882 

**Suppression removed**
 ```
 <Match>
    <!-- we are single thread tool for now -->
    <Class name="com.puppycrawl.tools.checkstyle.checks.metrics.NPathComplexityCheck"/>
    <Bug pattern="AT_STALE_THREAD_WRITE_OF_PRIMITIVE"/>
  </Match>

```
