### PR TITLE
Issue #16882: Removed usage of AtomicInteger from RecordComponentNumberCheck

### DIFF
--- a/config/spotbugs-exclude.xml
+++ b/config/spotbugs-exclude.xml
@@ -325,9 +325,4 @@
     <Method name="matchesAtFrontNoRegex"/>
     <Bug pattern="BAS_BLOATED_ASSIGNMENT_SCOPE"/>
   </Match>
-  <Match>
-    <!-- we are single thread tool for now -->
-    <Class name="com.puppycrawl.tools.checkstyle.checks.sizes.RecordComponentNumberCheck"/>
-    <Bug pattern="AT_STALE_THREAD_WRITE_OF_PRIMITIVE"/>
-  </Match>
 </FindBugsFilter>

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/sizes/RecordComponentNumberCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/sizes/RecordComponentNumberCheck.java
@@ -20,7 +20,6 @@
 package com.puppycrawl.tools.checkstyle.checks.sizes;
 
 import java.util.Arrays;
-import java.util.concurrent.atomic.AtomicInteger;
 
 import com.puppycrawl.tools.checkstyle.StatelessCheck;
 import com.puppycrawl.tools.checkstyle.api.AbstractCheck;
@@ -28,7 +27,6 @@ import com.puppycrawl.tools.checkstyle.api.DetailAST;
 import com.puppycrawl.tools.checkstyle.api.TokenTypes;
 import com.puppycrawl.tools.checkstyle.checks.naming.AccessModifierOption;
 import com.puppycrawl.tools.checkstyle.utils.CheckUtil;
-import com.puppycrawl.tools.checkstyle.utils.TokenUtil;
 
 /**
  * <div>
@@ -156,11 +154,7 @@ public class RecordComponentNumberCheck extends AbstractCheck {
      * @return the number of record components in this record definition
      */
     private static int countComponents(DetailAST recordComponents) {
-        final AtomicInteger count = new AtomicInteger(0);
-        TokenUtil.forEachChild(recordComponents,
-            TokenTypes.RECORD_COMPONENT_DEF,
-            node -> count.getAndIncrement());
-        return count.get();
+        return recordComponents.getChildCount(TokenTypes.RECORD_COMPONENT_DEF);
     }
 
     /**


### PR DESCRIPTION
Issue: #16882

**Suppression removed**

 ```
 <Match>
    <!-- we are single thread tool for now -->
    <Class name="com.puppycrawl.tools.checkstyle.checks.sizes.RecordComponentNumberCheck"/>
    <Bug pattern="AT_STALE_THREAD_WRITE_OF_PRIMITIVE"/>
  </Match>
```
**Method updated**

```
    private static int countComponents(DetailAST recordComponents) {
        return recordComponents.getChildCount(TokenTypes.RECORD_COMPONENT_DEF);
    }

```