### PR TITLE
Issue #16882: Removed usage of AtomicInteger for UniquePropertiesCheck

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/UniquePropertiesCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/UniquePropertiesCheck.java
@@ -27,7 +27,6 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Properties;
-import java.util.concurrent.atomic.AtomicInteger;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -106,12 +105,12 @@ public class UniquePropertiesCheck extends AbstractFileSetCheck {
                     ex.getLocalizedMessage());
         }
 
-        for (Entry<String, AtomicInteger> duplication : properties
+        for (Entry<String, Integer> duplication : properties
                 .getDuplicatedKeys().entrySet()) {
             final String keyName = duplication.getKey();
             final int lineNumber = getLineNumber(fileText, keyName);
             // Number of occurrences is number of duplications + 1
-            log(lineNumber, MSG_KEY, keyName, duplication.getValue().get() + 1);
+            log(lineNumber, MSG_KEY, keyName, duplication.getValue() + 1);
         }
     }
 
@@ -174,7 +173,7 @@ public class UniquePropertiesCheck extends AbstractFileSetCheck {
          * Map, holding duplicated keys and their count. Keys are added here only if they
          * already exist in Properties' inner map.
          */
-        private final Map<String, AtomicInteger> duplicatedKeys = new HashMap<>();
+        private final Map<String, Integer> duplicatedKeys = new HashMap<>();
 
         /**
          * Puts the value into properties by the key specified.
@@ -185,8 +184,8 @@ public class UniquePropertiesCheck extends AbstractFileSetCheck {
             if (oldValue != null && key instanceof String) {
                 final String keyString = (String) key;
 
-                duplicatedKeys.computeIfAbsent(keyString, empty -> new AtomicInteger(0))
-                        .incrementAndGet();
+                duplicatedKeys.put(keyString,
+                        duplicatedKeys.getOrDefault(keyString, 0) + 1);
             }
             return oldValue;
         }
@@ -196,7 +195,7 @@ public class UniquePropertiesCheck extends AbstractFileSetCheck {
          *
          * @return A collection of duplicated keys.
          */
-        public Map<String, AtomicInteger> getDuplicatedKeys() {
+        public Map<String, Integer> getDuplicatedKeys() {
             return new HashMap<>(duplicatedKeys);
         }
 


### PR DESCRIPTION
Issue: #16882 

**Removed usage of AtomicInteger for UniquePropertiesCheck**

```
PS C:\Users\athar\OneDrive\Desktop\checkstyle> mvn clean verify
[INFO] Scanning for projects...
[INFO] Inspecting build with total of 1 modules...
.
.
.
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  17:27 min
[INFO] Finished at: 2025-04-20T01:33:42+05:30
[INFO] ------------------------------------------------------------------------


```