### PR TITLE
Issue #16882: Removed usage of ConcurrentLinkedQueue in JavaAstVisitor

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/JavaAstVisitor.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/JavaAstVisitor.java
@@ -19,13 +19,13 @@
 
 package com.puppycrawl.tools.checkstyle;
 
+import java.util.ArrayDeque;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Optional;
 import java.util.Queue;
-import java.util.concurrent.ConcurrentLinkedQueue;
 import java.util.stream.Collectors;
 
 import org.antlr.v4.runtime.BufferedTokenStream;
@@ -1593,7 +1593,7 @@ public final class JavaAstVisitor extends JavaLanguageParserBaseVisitor<DetailAs
             // operation
             final Queue<DetailAstImpl> descendantList = binOpList.parallelStream()
                     .map(this::getInnerBopAst)
-                    .collect(Collectors.toCollection(ConcurrentLinkedQueue::new));
+                    .collect(Collectors.toCollection(ArrayDeque::new));
 
             bop.addChild(descendantList.poll());
             DetailAstImpl pointer = bop.getFirstChild();


### PR DESCRIPTION
Issue: #16882

**Removed usage of ConcurrentLinkedQueue**

```
final Queue<DetailAstImpl> descendantList = binOpList.parallelStream()
             .map(this::getInnerBopAst)
             .collect(Collectors.toCollection(ArrayDeque::new));
```

**Used ArrayDeque instead of ConcurrentLinkedQueue**


```
PS C:\Users\athar\OneDrive\Desktop\checkstyle> mvn clean verify                                                                             
[INFO] Scanning for projects...
.
.
.
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  18:31 min
[INFO] Finished at: 2025-04-20T06:21:06+05:30
[INFO] ------------------------------------------------------------------------

```
