### PR TITLE
Issue #16882: Removed usage of ConcurrentHashMap in TranslationCheck

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/TranslationCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/TranslationCheck.java
@@ -35,7 +35,6 @@ import java.util.Set;
 import java.util.SortedSet;
 import java.util.TreeMap;
 import java.util.TreeSet;
-import java.util.concurrent.ConcurrentHashMap;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
@@ -195,7 +194,7 @@ public class TranslationCheck extends AbstractFileSetCheck {
     private final Log log;
 
     /** The files to process. */
-    private final Set<File> filesToProcess = ConcurrentHashMap.newKeySet();
+    private final Set<File> filesToProcess = new HashSet<>();
 
     /**
      * Specify


### PR DESCRIPTION
Issue: #16882

**Removed usage of ConcurrentHashMap**

 `final Set<ResourceBundle> resourceBundles = new HashSet<>();`

**Using HashSet instead of  ConcurrentHashMap.newKeySet()**

```
PS C:\Users\athar\OneDrive\Desktop\checkstyle> mvn clean verify
[INFO] Scanning for projects...
.
.
.
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  16:32 min
[INFO] Finished at: 2025-04-20T07:51:26+05:30
[INFO] ------------------------------------------------------------------------
```
