### PR TITLE
Issue #16882: Removed usage of ConcurrentHashMap in JavadocPackageCheck

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocPackageCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocPackageCheck.java
@@ -23,8 +23,8 @@ import java.io.File;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.HashSet;
 import java.util.Set;
-import java.util.concurrent.ConcurrentHashMap;
 
 import com.puppycrawl.tools.checkstyle.GlobalStatefulCheck;
 import com.puppycrawl.tools.checkstyle.api.AbstractFileSetCheck;
@@ -88,7 +88,7 @@ public class JavadocPackageCheck extends AbstractFileSetCheck {
     public static final String MSG_PACKAGE_INFO = "javadoc.packageInfo";
 
     /** The directories checked. */
-    private final Set<File> directoriesChecked = ConcurrentHashMap.newKeySet();
+    private final Set<File> directoriesChecked = new HashSet<>();
 
     /** Allow legacy {@code package.html} file to be used. */
     private boolean allowLegacy;


### PR DESCRIPTION
Issue: #16882 

**Removed usage of ConcurrentHashMap**

```
    /** The directories checked. */
    private final Set<File> directoriesChecked = new HashSet<>();
```

**Used HashSet instead of ConcurrentHashMap**

```
PS C:\Users\athar\OneDrive\Desktop\checkstyle> mvn clean verify
[INFO] Scanning for projects...
.
.
.
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  20:45 min
[INFO] Finished at: 2025-04-20T08:27:58+05:30
[INFO] ------------------------------------------------------------------------
```


