### PR TITLE
Issue #14879 : Configuration website does not allow linking to Examples

### DIFF
--- a/src/site/xdoc/config.xml
+++ b/src/site/xdoc/config.xml
@@ -411,7 +411,7 @@
       </subsection>
 
       <subsection name="Examples" id="Checker_Examples">
-        <p>
+        <p id="Example-config1">
           For example, the following configuration fragment specifies base
           directory <code>src/checkstyle</code>, cache file <code>target/cachefile</code> and German
           locale for all modules:
@@ -430,7 +430,7 @@
 &lt;/module&gt;
         </code></pre></div>
 
-        <p>
+        <p id="Example-config2">
           To configure a <code>Checker</code> so that it
           handles files with the <code>ISO-8859-5</code> charset:
         </p>
@@ -442,7 +442,7 @@
 &lt;/module&gt;
         </code></pre></div>
 
-        <p>
+        <p id="Example-config3">
           To configure a <code>Checker</code> so that it
           handles files with the <code>java, xml, properties</code> extensions:
         </p>
@@ -454,7 +454,7 @@
 &lt;/module&gt;
         </code></pre></div>
 
-        <p>
+        <p id="Example-config4">
           To configure a <code>Checker</code> so that it doesn't stop execution on an
           <code>Exception</code> and instead prints it as a violation:
         </p>
@@ -466,7 +466,7 @@
 &lt;/module&gt;
         </code></pre></div>
 
-        <p>
+        <p id="Example-config5">
           To configure a <code>Checker</code> so that it
           handles files with any extension:
         </p>

--- a/src/site/xdoc/config_system_properties.xml
+++ b/src/site/xdoc/config_system_properties.xml
@@ -44,7 +44,7 @@
           Imagine we want to define different requirements for test sources
           than for main code.
         </p>
-        <p>
+        <p id="Example1-config">
           Common part <code>checkstyle-common.xml</code>:
           <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
 &lt;module name=&quot;FileLength&quot;&gt;
@@ -52,7 +52,7 @@
 &lt;/module&gt;
           </code></pre></div>
         </p>
-        <p>
+        <p id="Example1Main-config">
           Main config <code>checkstyle.xml</code>:
           <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
 &lt;?xml version=&quot;1.0&quot;?&gt;
@@ -74,7 +74,7 @@
 &lt;/module&gt;
           </code></pre></div>
         </p>
-        <p>
+        <p id="Example1Test-config">
           Test config <code>checkstyle-test.xml</code>:
           <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
 &lt;?xml version=&quot;1.0&quot;?&gt;
@@ -96,7 +96,7 @@
 &lt;/module&gt;
           </code></pre></div>
         </p>
-        <p>
+        <p id="Example1-code">
           Target file for validation <code>Test.java</code>:
           <div class="wrapper"><pre class="prettyprint"><code class="language-java">
 class Test {
@@ -104,7 +104,7 @@ class Test {
 }
           </code></pre></div>
         </p>
-        <p>
+        <p id="Example1-output1">
           Example of execution for <code>checkstyle.xml</code>. Violation from Check of
           <code>common.xml</code> is expected, validation of field name is done by main code rules:
           <div class="wrapper"><pre class="prettyprint"><code class="language-java">
@@ -117,7 +117,7 @@ Audit done.
 Checkstyle ends with 2 errors.
           </code></pre></div>
         </p>
-        <p>
+        <p id="Example1-output2">
           Example of execution for <code>checkstyle-test.xml</code>. Violation from Check of
           <code>common.xml</code> is expected, validation of field name is done by test code rules:
           <div class="wrapper"><pre class="prettyprint"><code class="language-java">


### PR DESCRIPTION
 #14879 
 
 Anchors are generated when we have an id attribute , therefore for such files [https://checkstyle.org/config.html#](https://checkstyle.org/config.html#TreeWalker_Examples) id attribute is added so that anchor.js generates linking href.
 
 Output:
 
![image](https://github.com/user-attachments/assets/a40d9d97-1397-4d69-8f01-e70f3eeb5922)
Now We can hover and create a link to it!
