### PR TITLE
Issue #16738: Update SuppressionCommentFilterExamplesTest to use verifyFilterWithInlineConfigParser

### DIFF
--- a/src/site/xdoc/filters/suppressioncommentfilter.xml
+++ b/src/site/xdoc/filters/suppressioncommentfilter.xml
@@ -131,14 +131,14 @@ class Example1
   int VAR1; // violation, Name 'VAR1' must match pattern '^[a-z][a-zA-Z0-9]*$'
 
   //CHECKSTYLE:OFF
-  int VAR2; // suppressed violation
+  int VAR2; // filtered violation 'must match pattern'
   //CHECKSTYLE:ON
 
   public static final int var3 = 1;
   // violation above, 'must match pattern'
 
   //CHECKSTYLE:OFF
-  public static final int var4 = 1; // suppressed violation
+  public static final int var4 = 1; // filtered violation 'must match pattern'
   //CHECKSTYLE:ON
 
   public void method1()
@@ -149,8 +149,10 @@ class Example1
     //CHECKSTYLE:OFF
 
     try {}
-    catch(Exception ex) {} // suppressed violation
-    catch(Error err) {} // suppressed violation
+    catch(Exception ex) {}
+    // filtered violation above 'Catching 'Exception' is not allowed'
+    catch(Error err) {}
+    // filtered violation above 'Catching 'Error' is not allowed'
 
     //CHECKSTYLE:ON
   }
@@ -189,7 +191,7 @@ class Example2
   // violation above, Name 'must match pattern'
 
   //stop constant check
-  public static final int var4 = 1; // suppressed violation
+  public static final int var4 = 1; // filtered violation 'must match pattern'
   //resume constant check
 
   public void method1()
@@ -254,7 +256,8 @@ class Example3
     //ILLEGAL OFF: Exception
 
     try {}
-    catch(Exception ex) {} // suppressed violation
+    catch(Exception ex) {}
+    // filtered violation above 'Catching 'Exception' is not allowed'
     catch(Error err) {} // violation, Catching 'Error' is not allowed
 
     //ILLEGAL ON: Exception
@@ -287,14 +290,14 @@ class Example4
   int VAR1; // violation, Name 'VAR1' must match pattern '^[a-z][a-zA-Z0-9]*$'
 
   //CSOFF: MemberName
-  int VAR2; // suppressed violation
+  int VAR2; // filtered violation 'must match pattern'
   //CSON: MemberName
 
   public static final int var3 = 1;
   // violation above, 'must match pattern'
 
   //CSOFF: ConstantName
-  public static final int var4 = 1; // suppressed violation
+  public static final int var4 = 1; // filtered violation 'must match pattern'
   //CSON: ConstantName
 
   public void method1()
@@ -305,8 +308,10 @@ class Example4
     //CSOFF: IllegalCatch
 
     try {}
-    catch(Exception ex) {} // suppressed violation
-    catch(Error err) {} // suppressed violation
+    catch(Exception ex) {}
+    // filtered violation above 'Catching 'Exception' is not allowed'
+    catch(Error err) {}
+    // filtered violation above 'Catching 'Error' is not allowed'
 
     //CSON: IllegalCatch
   }
@@ -338,7 +343,7 @@ class Example5
   int VAR1; // violation, Name 'VAR1' must match pattern '^[a-z][a-zA-Z0-9]*$'
 
   //CHECKSTYLE_OFF: ALMOST_ALL
-  int VAR2; // suppressed violation
+  int VAR2; // filtered violation 'must match pattern'
   //CHECKSTYLE_ON: ALMOST_ALL
 
   public static final int var3 = 1;
@@ -357,8 +362,10 @@ class Example5
     //CHECKSTYLE_OFF: ALMOST_ALL
 
     try {}
-    catch(Exception ex) {} // suppressed violation
-    catch(Error err) {} // suppressed violation
+    catch(Exception ex) {}
+    // filtered violation above 'Catching 'Exception' is not allowed'
+    catch(Error err) {}
+    // filtered violation above 'Catching 'Error' is not allowed'
 
     //CHECKSTYLE_ON: ALMOST_ALL
   }
@@ -400,14 +407,14 @@ class Example6
   int VAR1; // violation, Name 'VAR1' must match pattern '^[a-z][a-zA-Z0-9]*$'
 
   //CSOFF MemberID
-  int VAR2; // suppressed violation
+  int VAR2; // filtered violation 'must match pattern'
   //CSON: MemberID
 
   public static final int var3 = 1;
   // violation above, 'must match pattern'
 
   //CSOFF ConstantID
-  public static final int var4 = 1; // suppressed violation
+  public static final int var4 = 1; // filtered violation 'must match pattern'
   //CSON ConstantID
 
   public void method1()
@@ -418,8 +425,10 @@ class Example6
     //CSOFF IllegalID
 
     try {}
-    catch(Exception ex) {} // suppressed violation
-    catch(Error err) {} // suppressed violation
+    catch(Exception ex) {}
+    // filtered violation above 'Catching 'Exception' is not allowed'
+    catch(Error err) {}
+    // filtered violation above 'Catching 'Error' is not allowed'
 
     //CSON IllegalID
   }
@@ -449,7 +458,7 @@ class Example7
   int VAR1; // violation, Name 'VAR1' must match pattern '^[a-z][a-zA-Z0-9]*$'
 
   //csoff MemberName
-  int VAR2; // suppressed violation
+  int VAR2; // filtered violation 'must match pattern'
   //cson MemberName
 
   public static final int var3 = 1;
@@ -458,16 +467,19 @@ class Example7
   //csoff ConstantName
   //csoff IllegalCatch
 
-  public static final int var4 = 1; // suppressed violation
+  public static final int var4 = 1; // filtered violation 'must match pattern'
 
   public void method1()
   {
     try {}
-    catch(Exception ex) {} // suppressed violation
+    catch(Exception ex) {}
+    // filtered violation above 'Catching 'Exception' is not allowed'
 
     try {}
-    catch(Exception ex) {} // suppressed violation
-    catch(Error err) {} // suppressed violation
+    catch(Exception ex) {}
+    // filtered violation above 'Catching 'Exception' is not allowed'
+    catch(Error err) {}
+    // filtered violation above 'Catching 'Error' is not allowed'
   }
 
   //cson ConstantName
@@ -505,7 +517,7 @@ class Example8
   // violation above, Name 'must match pattern'
 
   /*CHECKSTYLE:OFF*/
-  public static final int var4 = 1; // suppressed violation
+  public static final int var4 = 1; // filtered violation 'must match pattern'
   /*CHECKSTYLE:ON*/
 
   public void method1()

--- a/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/filters/SuppressionCommentFilterExamplesTest.java
+++ b/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/filters/SuppressionCommentFilterExamplesTest.java
@@ -31,18 +31,39 @@ public class SuppressionCommentFilterExamplesTest extends AbstractExamplesModule
 
     @Test
     public void testExample1() throws Exception {
-        final String[] expected = {
+        final String[] expectedWithoutFilter = {
+            "16:7: Name 'VAR1' must match pattern '^[a-z][a-zA-Z0-9]*$'.",
+            "19:7: Name 'VAR2' must match pattern '^[a-z][a-zA-Z0-9]*$'.",
+            "22:27: Name 'var3' must match pattern '^[A-Z][A-Z0-9]*(_[A-Z0-9]+)*$'.",
+            "26:27: Name 'var4' must match pattern '^[A-Z][A-Z0-9]*(_[A-Z0-9]+)*$'.",
+            "32:5: Catching 'Exception' is not allowed.",
+            "37:5: Catching 'Exception' is not allowed.",
+            "39:5: Catching 'Error' is not allowed.",
+        };
+
+        final String[] expectedWithFilter = {
             "16:7: Name 'VAR1' must match pattern '^[a-z][a-zA-Z0-9]*$'.",
             "22:27: Name 'var3' must match pattern '^[A-Z][A-Z0-9]*(_[A-Z0-9]+)*$'.",
             "32:5: Catching 'Exception' is not allowed.",
         };
 
-        verifyWithInlineConfigParser(getPath("Example1.java"), expected);
+        verifyFilterWithInlineConfigParser(getPath("Example1.java"),
+                expectedWithoutFilter, expectedWithFilter);
     }
 
     @Test
     public void testExample2() throws Exception {
-        final String[] expected = {
+        final String[] expectedWithoutFilter = {
+            "21:7: Name 'VAR1' must match pattern '^[a-z][a-zA-Z0-9]*$'.",
+            "24:7: Name 'VAR2' must match pattern '^[a-z][a-zA-Z0-9]*$'.",
+            "27:27: Name 'var3' must match pattern '^[A-Z][A-Z0-9]*(_[A-Z0-9]+)*$'.",
+            "31:27: Name 'var4' must match pattern '^[A-Z][A-Z0-9]*(_[A-Z0-9]+)*$'.",
+            "37:5: Catching 'Exception' is not allowed.",
+            "42:5: Catching 'Exception' is not allowed.",
+            "43:5: Catching 'Error' is not allowed.",
+        };
+
+        final String[] expectedWithFilter = {
             "21:7: Name 'VAR1' must match pattern '^[a-z][a-zA-Z0-9]*$'.",
             "24:7: Name 'VAR2' must match pattern '^[a-z][a-zA-Z0-9]*$'.",
             "27:27: Name 'var3' must match pattern '^[A-Z][A-Z0-9]*(_[A-Z0-9]+)*$'.",
@@ -51,70 +72,136 @@ public class SuppressionCommentFilterExamplesTest extends AbstractExamplesModule
             "43:5: Catching 'Error' is not allowed.",
         };
 
-        verifyWithInlineConfigParser(getPath("Example2.java"), expected);
+        verifyFilterWithInlineConfigParser(getPath("Example2.java"),
+                expectedWithoutFilter, expectedWithFilter);
     }
 
     @Test
     public void testExample3() throws Exception {
-        final String[] expected = {
+        final String[] expectedWithoutFilter = {
             "21:7: Name 'VAR1' must match pattern '^[a-z][a-zA-Z0-9]*$'.",
             "24:7: Name 'VAR2' must match pattern '^[a-z][a-zA-Z0-9]*$'.",
             "27:27: Name 'var3' must match pattern '^[A-Z][A-Z0-9]*(_[A-Z0-9]+)*$'.",
             "31:27: Name 'var4' must match pattern '^[A-Z][A-Z0-9]*(_[A-Z0-9]+)*$'.",
             "38:5: Catching 'Exception' is not allowed.",
-            "44:5: Catching 'Error' is not allowed.",
+            "43:5: Catching 'Exception' is not allowed.",
+            "45:5: Catching 'Error' is not allowed.",
         };
 
-        verifyWithInlineConfigParser(getPath("Example3.java"), expected);
+        final String[] expectedWithFilter = {
+            "21:7: Name 'VAR1' must match pattern '^[a-z][a-zA-Z0-9]*$'.",
+            "24:7: Name 'VAR2' must match pattern '^[a-z][a-zA-Z0-9]*$'.",
+            "27:27: Name 'var3' must match pattern '^[A-Z][A-Z0-9]*(_[A-Z0-9]+)*$'.",
+            "31:27: Name 'var4' must match pattern '^[A-Z][A-Z0-9]*(_[A-Z0-9]+)*$'.",
+            "38:5: Catching 'Exception' is not allowed.",
+            "45:5: Catching 'Error' is not allowed.",
+        };
+
+        verifyFilterWithInlineConfigParser(getPath("Example3.java"),
+                expectedWithoutFilter, expectedWithFilter);
     }
 
     @Test
     public void testExample4() throws Exception {
-        final String[] expected = {
+        final String[] expectedWithoutFilter = {
+            "20:7: Name 'VAR1' must match pattern '^[a-z][a-zA-Z0-9]*$'.",
+            "23:7: Name 'VAR2' must match pattern '^[a-z][a-zA-Z0-9]*$'.",
+            "26:27: Name 'var3' must match pattern '^[A-Z][A-Z0-9]*(_[A-Z0-9]+)*$'.",
+            "30:27: Name 'var4' must match pattern '^[A-Z][A-Z0-9]*(_[A-Z0-9]+)*$'.",
+            "36:5: Catching 'Exception' is not allowed.",
+            "41:5: Catching 'Exception' is not allowed.",
+            "43:5: Catching 'Error' is not allowed.",
+        };
+
+        final String[] expectedWithFilter = {
             "20:7: Name 'VAR1' must match pattern '^[a-z][a-zA-Z0-9]*$'.",
             "26:27: Name 'var3' must match pattern '^[A-Z][A-Z0-9]*(_[A-Z0-9]+)*$'.",
             "36:5: Catching 'Exception' is not allowed.",
         };
 
-        verifyWithInlineConfigParser(getPath("Example4.java"), expected);
+        verifyFilterWithInlineConfigParser(getPath("Example4.java"),
+                expectedWithoutFilter, expectedWithFilter);
     }
 
     @Test
     public void testExample5() throws Exception {
-        final String[] expected = {
+        final String[] expectedWithoutFilter = {
+            "20:7: Name 'VAR1' must match pattern '^[a-z][a-zA-Z0-9]*$'.",
+            "23:7: Name 'VAR2' must match pattern '^[a-z][a-zA-Z0-9]*$'.",
+            "26:27: Name 'var3' must match pattern '^[A-Z][A-Z0-9]*(_[A-Z0-9]+)*$'.",
+            "30:27: Name 'var4' must match pattern '^[A-Z][A-Z0-9]*(_[A-Z0-9]+)*$'.",
+            "37:5: Catching 'Exception' is not allowed.",
+            "42:5: Catching 'Exception' is not allowed.",
+            "44:5: Catching 'Error' is not allowed.",
+        };
+
+        final String[] expectedWithFilter = {
             "20:7: Name 'VAR1' must match pattern '^[a-z][a-zA-Z0-9]*$'.",
             "26:27: Name 'var3' must match pattern '^[A-Z][A-Z0-9]*(_[A-Z0-9]+)*$'.",
             "30:27: Name 'var4' must match pattern '^[A-Z][A-Z0-9]*(_[A-Z0-9]+)*$'.",
             "37:5: Catching 'Exception' is not allowed.",
         };
 
-        verifyWithInlineConfigParser(getPath("Example5.java"), expected);
+        verifyFilterWithInlineConfigParser(getPath("Example5.java"),
+                expectedWithoutFilter, expectedWithFilter);
     }
 
     @Test
     public void testExample6() throws Exception {
-        final String[] expected = {
+        final String[] expectedWithoutFilter = {
+            "25:7: Name 'VAR1' must match pattern '^[a-z][a-zA-Z0-9]*$'.",
+            "28:7: Name 'VAR2' must match pattern '^[a-z][a-zA-Z0-9]*$'.",
+            "31:27: Name 'var3' must match pattern '^[A-Z][A-Z0-9]*(_[A-Z0-9]+)*$'.",
+            "35:27: Name 'var4' must match pattern '^[A-Z][A-Z0-9]*(_[A-Z0-9]+)*$'.",
+            "41:5: Catching 'Exception' is not allowed.",
+            "46:5: Catching 'Exception' is not allowed.",
+            "48:5: Catching 'Error' is not allowed.",
+        };
+
+        final String[] expectedWithFilter = {
             "25:7: Name 'VAR1' must match pattern '^[a-z][a-zA-Z0-9]*$'.",
             "31:27: Name 'var3' must match pattern '^[A-Z][A-Z0-9]*(_[A-Z0-9]+)*$'.",
             "41:5: Catching 'Exception' is not allowed.",
         };
 
-        verifyWithInlineConfigParser(getPath("Example6.java"), expected);
+        verifyFilterWithInlineConfigParser(getPath("Example6.java"),
+                expectedWithoutFilter, expectedWithFilter);
     }
 
     @Test
     public void testExample7() throws Exception {
-        final String[] expected = {
+        final String[] expectedWithoutFilter = {
+            "19:7: Name 'VAR1' must match pattern '^[a-z][a-zA-Z0-9]*$'.",
+            "22:7: Name 'VAR2' must match pattern '^[a-z][a-zA-Z0-9]*$'.",
+            "25:27: Name 'var3' must match pattern '^[A-Z][A-Z0-9]*(_[A-Z0-9]+)*$'.",
+            "31:27: Name 'var4' must match pattern '^[A-Z][A-Z0-9]*(_[A-Z0-9]+)*$'.",
+            "36:5: Catching 'Exception' is not allowed.",
+            "40:5: Catching 'Exception' is not allowed.",
+            "42:5: Catching 'Error' is not allowed.",
+        };
+
+        final String[] expectedWithFilter = {
             "19:7: Name 'VAR1' must match pattern '^[a-z][a-zA-Z0-9]*$'.",
             "25:27: Name 'var3' must match pattern '^[A-Z][A-Z0-9]*(_[A-Z0-9]+)*$'.",
         };
 
-        verifyWithInlineConfigParser(getPath("Example7.java"), expected);
+        verifyFilterWithInlineConfigParser(getPath("Example7.java"),
+                expectedWithoutFilter, expectedWithFilter);
     }
 
     @Test
     public void testExample8() throws Exception {
-        final String[] expected = {
+        final String[] expectedWithoutFilter = {
+            "18:7: Name 'VAR1' must match pattern '^[a-z][a-zA-Z0-9]*$'.",
+            "21:7: Name 'VAR2' must match pattern '^[a-z][a-zA-Z0-9]*$'.",
+            "24:27: Name 'var3' must match pattern '^[A-Z][A-Z0-9]*(_[A-Z0-9]+)*$'.",
+            "28:27: Name 'var4' must match pattern '^[A-Z][A-Z0-9]*(_[A-Z0-9]+)*$'.",
+            "34:5: Catching 'Exception' is not allowed.",
+            "39:5: Catching 'Exception' is not allowed.",
+            "40:5: Catching 'Error' is not allowed.",
+        };
+
+        final String[] expectedWithFilter = {
             "18:7: Name 'VAR1' must match pattern '^[a-z][a-zA-Z0-9]*$'.",
             "21:7: Name 'VAR2' must match pattern '^[a-z][a-zA-Z0-9]*$'.",
             "24:27: Name 'var3' must match pattern '^[A-Z][A-Z0-9]*(_[A-Z0-9]+)*$'.",
@@ -123,6 +210,7 @@ public class SuppressionCommentFilterExamplesTest extends AbstractExamplesModule
             "40:5: Catching 'Error' is not allowed.",
         };
 
-        verifyWithInlineConfigParser(getPath("Example8.java"), expected);
+        verifyFilterWithInlineConfigParser(getPath("Example8.java"),
+                expectedWithoutFilter, expectedWithFilter);
     }
 }

--- a/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/filters/suppressioncommentfilter/Example1.java
+++ b/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/filters/suppressioncommentfilter/Example1.java
@@ -16,14 +16,14 @@ class Example1
   int VAR1; // violation, Name 'VAR1' must match pattern '^[a-z][a-zA-Z0-9]*$'
 
   //CHECKSTYLE:OFF
-  int VAR2; // suppressed violation
+  int VAR2; // filtered violation 'must match pattern'
   //CHECKSTYLE:ON
 
   public static final int var3 = 1;
   // violation above, 'must match pattern'
 
   //CHECKSTYLE:OFF
-  public static final int var4 = 1; // suppressed violation
+  public static final int var4 = 1; // filtered violation 'must match pattern'
   //CHECKSTYLE:ON
 
   public void method1()
@@ -34,8 +34,10 @@ class Example1
     //CHECKSTYLE:OFF
 
     try {}
-    catch(Exception ex) {} // suppressed violation
-    catch(Error err) {} // suppressed violation
+    catch(Exception ex) {}
+    // filtered violation above 'Catching 'Exception' is not allowed'
+    catch(Error err) {}
+    // filtered violation above 'Catching 'Error' is not allowed'
 
     //CHECKSTYLE:ON
   }

--- a/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/filters/suppressioncommentfilter/Example2.java
+++ b/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/filters/suppressioncommentfilter/Example2.java
@@ -28,7 +28,7 @@ class Example2
   // violation above, Name 'must match pattern'
 
   //stop constant check
-  public static final int var4 = 1; // suppressed violation
+  public static final int var4 = 1; // filtered violation 'must match pattern'
   //resume constant check
 
   public void method1()

--- a/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/filters/suppressioncommentfilter/Example3.java
+++ b/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/filters/suppressioncommentfilter/Example3.java
@@ -40,7 +40,8 @@ class Example3
     //ILLEGAL OFF: Exception
 
     try {}
-    catch(Exception ex) {} // suppressed violation
+    catch(Exception ex) {}
+    // filtered violation above 'Catching 'Exception' is not allowed'
     catch(Error err) {} // violation, Catching 'Error' is not allowed
 
     //ILLEGAL ON: Exception

--- a/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/filters/suppressioncommentfilter/Example4.java
+++ b/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/filters/suppressioncommentfilter/Example4.java
@@ -20,14 +20,14 @@ class Example4
   int VAR1; // violation, Name 'VAR1' must match pattern '^[a-z][a-zA-Z0-9]*$'
 
   //CSOFF: MemberName
-  int VAR2; // suppressed violation
+  int VAR2; // filtered violation 'must match pattern'
   //CSON: MemberName
 
   public static final int var3 = 1;
   // violation above, 'must match pattern'
 
   //CSOFF: ConstantName
-  public static final int var4 = 1; // suppressed violation
+  public static final int var4 = 1; // filtered violation 'must match pattern'
   //CSON: ConstantName
 
   public void method1()
@@ -38,8 +38,10 @@ class Example4
     //CSOFF: IllegalCatch
 
     try {}
-    catch(Exception ex) {} // suppressed violation
-    catch(Error err) {} // suppressed violation
+    catch(Exception ex) {}
+    // filtered violation above 'Catching 'Exception' is not allowed'
+    catch(Error err) {}
+    // filtered violation above 'Catching 'Error' is not allowed'
 
     //CSON: IllegalCatch
   }

--- a/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/filters/suppressioncommentfilter/Example5.java
+++ b/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/filters/suppressioncommentfilter/Example5.java
@@ -20,7 +20,7 @@ class Example5
   int VAR1; // violation, Name 'VAR1' must match pattern '^[a-z][a-zA-Z0-9]*$'
 
   //CHECKSTYLE_OFF: ALMOST_ALL
-  int VAR2; // suppressed violation
+  int VAR2; // filtered violation 'must match pattern'
   //CHECKSTYLE_ON: ALMOST_ALL
 
   public static final int var3 = 1;
@@ -39,8 +39,10 @@ class Example5
     //CHECKSTYLE_OFF: ALMOST_ALL
 
     try {}
-    catch(Exception ex) {} // suppressed violation
-    catch(Error err) {} // suppressed violation
+    catch(Exception ex) {}
+    // filtered violation above 'Catching 'Exception' is not allowed'
+    catch(Error err) {}
+    // filtered violation above 'Catching 'Error' is not allowed'
 
     //CHECKSTYLE_ON: ALMOST_ALL
   }

--- a/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/filters/suppressioncommentfilter/Example6.java
+++ b/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/filters/suppressioncommentfilter/Example6.java
@@ -25,14 +25,14 @@ class Example6
   int VAR1; // violation, Name 'VAR1' must match pattern '^[a-z][a-zA-Z0-9]*$'
 
   //CSOFF MemberID
-  int VAR2; // suppressed violation
+  int VAR2; // filtered violation 'must match pattern'
   //CSON: MemberID
 
   public static final int var3 = 1;
   // violation above, 'must match pattern'
 
   //CSOFF ConstantID
-  public static final int var4 = 1; // suppressed violation
+  public static final int var4 = 1; // filtered violation 'must match pattern'
   //CSON ConstantID
 
   public void method1()
@@ -43,8 +43,10 @@ class Example6
     //CSOFF IllegalID
 
     try {}
-    catch(Exception ex) {} // suppressed violation
-    catch(Error err) {} // suppressed violation
+    catch(Exception ex) {}
+    // filtered violation above 'Catching 'Exception' is not allowed'
+    catch(Error err) {}
+    // filtered violation above 'Catching 'Error' is not allowed'
 
     //CSON IllegalID
   }

--- a/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/filters/suppressioncommentfilter/Example7.java
+++ b/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/filters/suppressioncommentfilter/Example7.java
@@ -19,7 +19,7 @@ class Example7
   int VAR1; // violation, Name 'VAR1' must match pattern '^[a-z][a-zA-Z0-9]*$'
 
   //csoff MemberName
-  int VAR2; // suppressed violation
+  int VAR2; // filtered violation 'must match pattern'
   //cson MemberName
 
   public static final int var3 = 1;
@@ -28,16 +28,19 @@ class Example7
   //csoff ConstantName
   //csoff IllegalCatch
 
-  public static final int var4 = 1; // suppressed violation
+  public static final int var4 = 1; // filtered violation 'must match pattern'
 
   public void method1()
   {
     try {}
-    catch(Exception ex) {} // suppressed violation
+    catch(Exception ex) {}
+    // filtered violation above 'Catching 'Exception' is not allowed'
 
     try {}
-    catch(Exception ex) {} // suppressed violation
-    catch(Error err) {} // suppressed violation
+    catch(Exception ex) {}
+    // filtered violation above 'Catching 'Exception' is not allowed'
+    catch(Error err) {}
+    // filtered violation above 'Catching 'Error' is not allowed'
   }
 
   //cson ConstantName

--- a/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/filters/suppressioncommentfilter/Example8.java
+++ b/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/filters/suppressioncommentfilter/Example8.java
@@ -25,7 +25,7 @@ class Example8
   // violation above, Name 'must match pattern'
 
   /*CHECKSTYLE:OFF*/
-  public static final int var4 = 1; // suppressed violation
+  public static final int var4 = 1; // filtered violation 'must match pattern'
   /*CHECKSTYLE:ON*/
 
   public void method1()


### PR DESCRIPTION
Update `SuppressionCommentFilterExamplesTest` to use `verifyFilterWithInlineConfigParser`
Issue: https://github.com/checkstyle/checkstyle/issues/16738
