### PR TITLE
Pull #16931: `AvoidInlineConditionalsCheck` fix format of examples

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/AvoidInlineConditionalsCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/AvoidInlineConditionalsCheck.java
@@ -30,7 +30,7 @@ import com.puppycrawl.tools.checkstyle.api.TokenTypes;
  * </div>
  * <pre>
  * String a = getParameter("a");
- * String b = (a==null || a.length()&lt;1) ? null : a.substring(1);
+ * String b = (a == null || a.length() &lt; 1) ? null : a.substring(1);
  * </pre>
  *
  * <p>

--- a/src/main/resources/com/puppycrawl/tools/checkstyle/meta/checks/coding/AvoidInlineConditionalsCheck.xml
+++ b/src/main/resources/com/puppycrawl/tools/checkstyle/meta/checks/coding/AvoidInlineConditionalsCheck.xml
@@ -9,7 +9,7 @@
  &lt;/div&gt;
  &lt;pre&gt;
  String a = getParameter("a");
- String b = (a==null || a.length()&amp;lt;1) ? null : a.substring(1);
+ String b = (a == null || a.length() &amp;lt; 1) ? null : a.substring(1);
  &lt;/pre&gt;
 
  &lt;p&gt;

--- a/src/site/xdoc/checks/coding/avoidinlineconditionals.xml
+++ b/src/site/xdoc/checks/coding/avoidinlineconditionals.xml
@@ -14,7 +14,7 @@
         </div>
         <source>
 String a = getParameter(&quot;a&quot;);
-String b = (a==null || a.length()&lt;1) ? null : a.substring(1);
+String b = (a == null || a.length() &lt; 1) ? null : a.substring(1);
         </source>
 
         <p>
@@ -40,7 +40,7 @@ public class Example1 {
   public void InvalidExample( String str) {
     int x = 5;
     boolean foobar = (x == 5);
-    String text=null;
+    String text = null;
     text = (text == null) ? "" : text; // violation, 'Avoid inline conditionals'
     String b;
     if (str != null &amp;&amp; str.length() &gt;= 1) {

--- a/src/site/xdoc/checks/coding/avoidinlineconditionals.xml.template
+++ b/src/site/xdoc/checks/coding/avoidinlineconditionals.xml.template
@@ -14,7 +14,7 @@
         </div>
         <source>
 String a = getParameter("a");
-String b = (a==null || a.length()&lt;1) ? null : a.substring(1);
+String b = (a == null || a.length() &lt; 1) ? null : a.substring(1);
         </source>
 
         <p>


### PR DESCRIPTION
Pull #16931: `AvoidInlineConditionalsCheck` fix format of examples
Issue #16934: `Improve Example Formatting` for Rule Exclusions 


extract:
<img width="1684" alt="image" src="https://github.com/user-attachments/assets/cda28ce3-3fa8-41d9-8630-39750cfc1253" />
