### PR TITLE
Issue #14084: Remove CF warning from Violation.java for nullness profile

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/api/Violation.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/api/Violation.java
@@ -24,6 +24,8 @@ import java.util.Arrays;
 import java.util.Locale;
 import java.util.Objects;
 
+import javax.annotation.Nullable;
+
 import com.puppycrawl.tools.checkstyle.LocalizedMessage;
 import com.puppycrawl.tools.checkstyle.utils.UnmodifiableCollectionUtil;
 
@@ -101,7 +103,7 @@ public final class Violation
                             SeverityLevel severityLevel,
                             String moduleId,
                             Class<?> sourceClass,
-                            String customMessage) {
+                            @Nullable String customMessage) {
         this.lineNo = lineNo;
         this.columnNo = columnNo;
         this.columnCharIndex = columnCharIndex;
@@ -148,7 +150,7 @@ public final class Violation
                             SeverityLevel severityLevel,
                             String moduleId,
                             Class<?> sourceClass,
-                            String customMessage) {
+                            @Nullable String customMessage) {
         this(lineNo, columnNo, columnNo, tokenType, bundle, key, args, severityLevel, moduleId,
                 sourceClass, customMessage);
     }
@@ -178,7 +180,7 @@ public final class Violation
                             SeverityLevel severityLevel,
                             String moduleId,
                             Class<?> sourceClass,
-                            String customMessage) {
+                            @Nullable String customMessage) {
         this(lineNo, columnNo, 0, bundle, key, args, severityLevel, moduleId, sourceClass,
                 customMessage);
     }
@@ -206,7 +208,7 @@ public final class Violation
                             Object[] args,
                             String moduleId,
                             Class<?> sourceClass,
-                            String customMessage) {
+                            @Nullable String customMessage) {
         this(lineNo,
                 columnNo,
              bundle,
@@ -241,7 +243,7 @@ public final class Violation
                             SeverityLevel severityLevel,
                             String moduleId,
                             Class<?> sourceClass,
-                            String customMessage) {
+                            @Nullable String customMessage) {
         this(lineNo, 0, bundle, key, args, severityLevel, moduleId,
                 sourceClass, customMessage);
     }
@@ -265,7 +267,7 @@ public final class Violation
         Object[] args,
         String moduleId,
         Class<?> sourceClass,
-        String customMessage) {
+        @Nullable String customMessage) {
         this(lineNo, 0, bundle, key, args, DEFAULT_SEVERITY, moduleId,
                 sourceClass, customMessage);
     }


### PR DESCRIPTION
part of #14084 

### Explanation
Since customMessages param of Violation ctr is optional and provided to override the default value. Then it is nullable. Hence this annotation just says CF the same. 
