### PR TITLE
Issue #16880 IndentationCheckTest updated to use verifyWarns

### DIFF
--- a/src/test/resources-noncompilable/com/puppycrawl/tools/checkstyle/checks/indentation/indentation/InputIndentationTextBlock.java
+++ b/src/test/resources-noncompilable/com/puppycrawl/tools/checkstyle/checks/indentation/indentation/InputIndentationTextBlock.java
@@ -8,39 +8,41 @@ package com.puppycrawl.tools.checkstyle.checks.indentation.indentation;       //
  * forceStrictCondition = true                                                //indent:1 exp:1
  */                                                                           //indent:1 exp:1
 
-
 public class InputIndentationTextBlock {                      //indent:0 exp:0
+//below indent:4 exp:4
     private static final String EXAMPLE = """
         Example string""";                                    //indent:8 exp:8
-
+//below indent:4 exp:4
     private static final String GO1 = """
     GO                                                        //indent:4 exp:4
 """;                                                          //indent:0 exp:8 warn
-
+//below indent:4 exp:4
     private static final String GO2 = """
     GO                                                        //indent:4 exp:4
         """;                                                  //indent:8 exp:8
 
     public void textBlockNoIndent() {                         //indent:4 exp:4
+//below indent:8 exp:8
         String contentW = ("""
                 -----1234--                                   //indent:16 exp:16
                 -----1234--h-hh                               //indent:16 exp:16
                 """);                                         //indent:16 exp:12 warn
-
+//below indent:8 exp:8
         String contentR = ("""
                 -----1234--                                   //indent:16 exp:16
                 -----1234----                                 //indent:16 exp:16
             """);                                             //indent:12 exp:12
-
+//below indent:8 exp:8
         if ("""
               one more string""".equals(contentR)) {          //indent:14 exp:14
             System.out.println("This is string");             //indent:12 exp:12
         }                                                     //indent:8 exp:8
+//below indent:8 exp:8
         if (contentR.equals("""
           stuff""")) {                                        //indent:10 exp:10
         }                                                     //indent:8 exp:8
-
         String a =                                            //indent:8 exp:8
+//below indent:0 exp:12 warn
 """
           3                                                   //indent:10 exp:10
           4                                                   //indent:10 exp:10
@@ -50,8 +52,10 @@ public class InputIndentationTextBlock {                      //indent:0 exp:0
 """                                                           //indent:0 exp:12 warn
               ;                                               //indent:14 exp:14
     }                                                         //indent:4 exp:4
+
     private static void fooBlockAsArgument() {                //indent:4 exp:4
         String main =                                         //indent:8 exp:8
+//below indent:8 exp:12 warn
         """
         public class Main {                                   //indent:8 exp:8
           public void kit(String args) {                      //indent:10 exp:10
@@ -63,13 +67,14 @@ public class InputIndentationTextBlock {                      //indent:0 exp:0
           }                                                   //indent:10 exp:10
         }                                                     //indent:8 exp:8
             """;                                              //indent:12 exp:12
+//below indent:8 exp:8
         LOG.warn("""
                     The following settings                    //indent:20 exp:20
                     {}                                        //indent:20 exp:20
                     Therefore returning error result.""",     //indent:20 exp:20
             GO2);                                             //indent:12 exp:12
-
         LOG.warn(                                             //indent:8 exp:8
+//below indent:14 exp:12 warn
               """
               Failed to lidation; will ignore for now,        //indent:14 exp:14
               but it may fail later during runtime""",        //indent:14 exp:14
@@ -77,26 +82,33 @@ public class InputIndentationTextBlock {                      //indent:0 exp:0
     }                                                         //indent:4 exp:4
 
     public void fooBlockAsCondition() {                       //indent:4 exp:4
+//below indent:8 exp:8
         if (GO1.equalsIgnoreCase("""
+//below indent:14 exp:14
               my other string""" + """
+//below indent:14 exp:14
               plus this string""" + """
               and also this one.""")) {                       //indent:14 exp:14
             System.out.println("this is my other string");}   //indent:12 exp:12
+//below indent:8 exp:8
         if ("""
               one more string""".equals(GO2)) {               //indent:14 exp:14
             System.out.println("This is one more string");}   //indent:12 exp:12
-
+//below indent:8 exp:8
         if ("""
+//below indent:18 exp:18
                   a""" + """
                   bc""" == GO2) {                             //indent:18 exp:18
         }                                                     //indent:8 exp:8
         else {                                                //indent:8 exp:8
+//below indent:12 exp:12
             System.out.printf("""
           day of the week                                     //indent:10 exp:10
               successfully got: "%s"},                        //indent:14 exp:14
                 """, LOG.getNumberOfErrors());                //indent:16 exp:16
         }                                                     //indent:8 exp:8
     }                                                         //indent:4 exp:4
+
     public class LOG {                                        //indent:4 exp:4
         public static void warn(String block, String example){//indent:8 exp:8
         }                                                     //indent:8 exp:8

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/indentation/indentation/InputIndentationInvalidArrayInitIndentWithoutTrailingComments.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/indentation/indentation/InputIndentationInvalidArrayInitIndentWithoutTrailingComments.java
@@ -1,44 +1,48 @@
-package com.puppycrawl.tools.checkstyle.checks.indentation.indentation;
+package com.puppycrawl.tools.checkstyle.checks.indentation.indentation;     //indent:0 exp:0
 
-/**
- * This test-input is intended to be checked using following configuration:
- *
- * arrayInitIndent = 4
- * basicOffset = 4
- * braceAdjustment = 0
- * caseIndent = 4
- * forceStrictCondition = (default) false
- * lineWrappingIndentation = 4
- * tabWidth = 4
- * throwsIndent = 4
- *
- *
- */
-public class InputIndentationInvalidArrayInitIndentWithoutTrailingComments {
+/**                                                                         //indent:0 exp:0
+ * This test-input is intended to be checked using following configuration: //indent:1 exp:1
+ *                                                                          //indent:1 exp:1
+ * arrayInitIndent = 4                                                      //indent:1 exp:1
+ * basicOffset = 4                                                          //indent:1 exp:1
+ * braceAdjustment = 0                                                      //indent:1 exp:1
+ * caseIndent = 4                                                           //indent:1 exp:1
+ * forceStrictCondition = (default) false                                   //indent:1 exp:1
+ * lineWrappingIndentation = 4                                              //indent:1 exp:1
+ * tabWidth = 4                                                             //indent:1 exp:1
+ * throwsIndent = 4                                                         //indent:1 exp:1
+ *                                                                          //indent:1 exp:1
+ *                                                                          //indent:1 exp:1
+ */                                                                         //indent:1 exp:1
+public class InputIndentationInvalidArrayInitIndentWithoutTrailingComments {//indent:0 exp:0
 
-    int[] array1 = new int[]
+    int[] array1 = new int[]                          //indent:4 exp:4
+//below indent:4 exp:4
     {
 
-    };
-    interface SomeInterface1 {
-        @interface SomeAnnotation1 {
-            String[] values();
-            String[] description() default "";
-            String[] description2() default { "hello",
-            "checkstyle"};
-        }
-        @SomeInterface1.SomeAnnotation1(values =
+    };                                                //indent:4 exp:4
+    interface SomeInterface1 {                        //indent:4 exp:4
+        @interface SomeAnnotation1 {                  //indent:8 exp:8
+            String[] values();                        //indent:12 exp:12
+            String[] description() default "";        //indent:12 exp:12
+            String[] description2() default { "hello",//indent:12 exp:12
+            "checkstyle"};                            //indent:12 exp:16,46,48 warn
+        }                                             //indent:8 exp:8
+        @SomeInterface1.SomeAnnotation1(values =      //indent:8 exp:8
+//below indent:12 exp:12
             {
+//below indent:14 exp:12,16 warn
               "hello",
-            "checkstyle"
-            },
-            description = { "hello",
-              "checkstyle"
-        },
+            "checkstyle"                              //indent:12 exp:12
+            },                                        //indent:12 exp:12
+            description = { "hello",                  //indent:12 exp:12
+              "checkstyle"                            //indent:14 exp:16,28,30 warn
+        },                                            //indent:8 exp:12,16 warn
+//below indent:12 exp:12
             description2 = {
-            "hello", "chekstyle"
-            }
-        )
-      void worked();
-    }
-}
+            "hello", "chekstyle"                      //indent:12 exp:16 warn
+            }                                         //indent:12 exp:12
+        )                                             //indent:8 exp:8
+      void worked();                                  //indent:6 exp:6
+    }                                                 //indent:4 exp:4
+}                                                     //indent:0 exp:0


### PR DESCRIPTION
Issue: #16880 

All tests in IndentationCheckTest.java updated to use verifyWarns() in place of verify()

additionally added comment pattern-> "`//below indent:4 exp:8 warn`"

**Reason**

1) for `'InputIndentationTextBlock.java'` which use `"""`, adding indentation comment results in the following error->

> InputIndentationTextBlock.java:89: error: illegal text block open delimiter sequence, missing line terminator
>         if ("""                                               //indent:8 exp:8
>                                                               ^

This occurs because, according to the Java Language Specification (JLS §3.10.6), the opening delimiter of a text block (""") must be immediately followed by a line terminator — that is, a newline character.

2) for `InputIndentationInvalidArrayInitIndentWithoutTrailingComments.java` using inline comments results in surviving mutations during pitest ->
![Screenshot 2025-04-29 214437](https://github.com/user-attachments/assets/99192fdf-452e-4cce-aa44-9dd31a728cf1)
Thus using comment of format `//below indent:4 exp:8 warn` kills the mutation.