### PR TITLE
Issue #14019: update SuppressFilterElement constructor and remove unused methods

### DIFF
--- a/config/checker-framework-suppressions/checker-nullness-optional-interning-suppressions.xml
+++ b/config/checker-framework-suppressions/checker-nullness-optional-interning-suppressions.xml
@@ -4820,10 +4820,65 @@
     <fileName>src/main/java/com/puppycrawl/tools/checkstyle/filters/SuppressFilterElement.java</fileName>
     <specifier>assignment</specifier>
     <message>incompatible types in assignment.</message>
+    <lineContent>columnFilter = null;</lineContent>
+    <details>
+      found   : null (NullType)
+      required: @Initialized @NonNull CsvFilterElement
+    </details>
+  </checkerFrameworkError>
+
+  <checkerFrameworkError unstable="false">
+    <fileName>src/main/java/com/puppycrawl/tools/checkstyle/filters/SuppressFilterElement.java</fileName>
+    <specifier>assignment</specifier>
+    <message>incompatible types in assignment.</message>
     <lineContent>lineFilter = null;</lineContent>
     <details>
       found   : null (NullType)
       required: @Initialized @NonNull CsvFilterElement
+    </details>
+  </checkerFrameworkError>
+
+  <checkerFrameworkError unstable="false">
+    <fileName>src/main/java/com/puppycrawl/tools/checkstyle/filters/SuppressFilterElement.java</fileName>
+    <specifier>assignment</specifier>
+    <message>incompatible types in assignment.</message>
+    <lineContent>lineFilter = null;</lineContent>
+    <details>
+      found   : null (NullType)
+      required: @Initialized @NonNull CsvFilterElement
+    </details>
+  </checkerFrameworkError>
+
+  <checkerFrameworkError unstable="false">
+    <fileName>src/main/java/com/puppycrawl/tools/checkstyle/filters/SuppressFilterElement.java</fileName>
+    <specifier>assignment</specifier>
+    <message>incompatible types in assignment.</message>
+    <lineContent>checkRegexp = null;</lineContent>
+    <details>
+      found   : null (NullType)
+      required: @Initialized @NonNull Pattern
+    </details>
+  </checkerFrameworkError>
+
+  <checkerFrameworkError unstable="false">
+    <fileName>src/main/java/com/puppycrawl/tools/checkstyle/filters/SuppressFilterElement.java</fileName>
+    <specifier>assignment</specifier>
+    <message>incompatible types in assignment.</message>
+    <lineContent>fileRegexp = null;</lineContent>
+    <details>
+      found   : null (NullType)
+      required: @Initialized @NonNull Pattern
+    </details>
+  </checkerFrameworkError>
+
+  <checkerFrameworkError unstable="false">
+    <fileName>src/main/java/com/puppycrawl/tools/checkstyle/filters/SuppressFilterElement.java</fileName>
+    <specifier>assignment</specifier>
+    <message>incompatible types in assignment.</message>
+    <lineContent>messageRegexp = null;</lineContent>
+    <details>
+      found   : null (NullType)
+      required: @Initialized @NonNull Pattern
     </details>
   </checkerFrameworkError>
 
@@ -4861,17 +4916,6 @@
       @Initialized @NonNull boolean equals(@Initialized @NonNull SuppressFilterElement this, @Initialized @NonNull Object p0)
       cannot override method in @Initialized @NonNull Object
       @Initialized @NonNull boolean equals(@Initialized @NonNull Object this, @Initialized @Nullable Object p0)
-    </details>
-  </checkerFrameworkError>
-
-  <checkerFrameworkError unstable="false">
-    <fileName>src/main/java/com/puppycrawl/tools/checkstyle/filters/SuppressFilterElement.java</fileName>
-    <specifier>return</specifier>
-    <message>incompatible types in return.</message>
-    <lineContent>return result;</lineContent>
-    <details>
-      type of expression: @Initialized @Nullable Pattern
-      method return type: @Initialized @NonNull Pattern
     </details>
   </checkerFrameworkError>
 

--- a/config/checker-framework-suppressions/checker-regex-property-key-compiler-message-suppressions.xml
+++ b/config/checker-framework-suppressions/checker-regex-property-key-compiler-message-suppressions.xml
@@ -411,7 +411,29 @@
     <fileName>src/main/java/com/puppycrawl/tools/checkstyle/filters/SuppressFilterElement.java</fileName>
     <specifier>argument</specifier>
     <message>incompatible argument for parameter regex of Pattern.compile.</message>
-    <lineContent>result = Pattern.compile(regex);</lineContent>
+    <lineContent>checkRegexp = Pattern.compile(checks);</lineContent>
+    <details>
+      found   : String
+      required: @Regex String
+    </details>
+  </checkerFrameworkError>
+
+  <checkerFrameworkError unstable="false">
+    <fileName>src/main/java/com/puppycrawl/tools/checkstyle/filters/SuppressFilterElement.java</fileName>
+    <specifier>argument</specifier>
+    <message>incompatible argument for parameter regex of Pattern.compile.</message>
+    <lineContent>fileRegexp = Pattern.compile(files);</lineContent>
+    <details>
+      found   : String
+      required: @Regex String
+    </details>
+  </checkerFrameworkError>
+
+  <checkerFrameworkError unstable="false">
+    <fileName>src/main/java/com/puppycrawl/tools/checkstyle/filters/SuppressFilterElement.java</fileName>
+    <specifier>argument</specifier>
+    <message>incompatible argument for parameter regex of Pattern.compile.</message>
+    <lineContent>messageRegexp = Pattern.compile(message);</lineContent>
     <details>
       found   : String
       required: @Regex String

--- a/config/pitest-suppressions/pitest-ant-suppressions.xml
+++ b/config/pitest-suppressions/pitest-ant-suppressions.xml
@@ -48,6 +48,15 @@
   <mutation unstable="false">
     <sourceFile>CheckstyleAntTask.java</sourceFile>
     <mutatedClass>com.puppycrawl.tools.checkstyle.ant.CheckstyleAntTask</mutatedClass>
+    <mutatedMethod>createOverridingProperties</mutatedMethod>
+    <mutator>org.pitest.mutationtest.engine.gregor.mutators.NonVoidMethodCallMutator</mutator>
+    <description>removed call to java/lang/String::valueOf</description>
+    <lineContent>throw new BuildException(&quot;Error loading Properties file &apos;&quot;</lineContent>
+  </mutation>
+
+  <mutation unstable="false">
+    <sourceFile>CheckstyleAntTask.java</sourceFile>
+    <mutatedClass>com.puppycrawl.tools.checkstyle.ant.CheckstyleAntTask</mutatedClass>
     <mutatedMethod>createRootModule</mutatedMethod>
     <mutator>org.pitest.mutationtest.engine.gregor.mutators.NonVoidMethodCallMutator</mutator>
     <description>removed call to java/lang/Package::getName</description>
@@ -84,9 +93,27 @@
   <mutation unstable="false">
     <sourceFile>CheckstyleAntTask.java</sourceFile>
     <mutatedClass>com.puppycrawl.tools.checkstyle.ant.CheckstyleAntTask</mutatedClass>
+    <mutatedMethod>processFiles</mutatedMethod>
+    <mutator>org.pitest.mutationtest.engine.gregor.mutators.NonVoidMethodCallMutator</mutator>
+    <description>removed call to java/lang/String::valueOf</description>
+    <lineContent>throw new BuildException(&quot;Unable to process files: &quot; + files, ex);</lineContent>
+  </mutation>
+
+  <mutation unstable="false">
+    <sourceFile>CheckstyleAntTask.java</sourceFile>
+    <mutatedClass>com.puppycrawl.tools.checkstyle.ant.CheckstyleAntTask</mutatedClass>
     <mutatedMethod>retrieveAllScannedFiles</mutatedMethod>
     <mutator>org.pitest.mutationtest.engine.gregor.mutators.NonVoidMethodCallMutator</mutator>
     <description>removed call to java/lang/Integer::valueOf</description>
     <lineContent>logIndex, fileNames.length, scanner.getBasedir()), Project.MSG_VERBOSE);</lineContent>
+  </mutation>
+
+  <mutation unstable="false">
+    <sourceFile>CheckstyleAntTask.java</sourceFile>
+    <mutatedClass>com.puppycrawl.tools.checkstyle.ant.CheckstyleAntTask</mutatedClass>
+    <mutatedMethod>scanPath</mutatedMethod>
+    <mutator>org.pitest.mutationtest.engine.gregor.mutators.NonVoidMethodCallMutator</mutator>
+    <description>removed call to java/lang/String::valueOf</description>
+    <lineContent>log(pathIndex + &quot;) Scanning path &quot; + path, Project.MSG_VERBOSE);</lineContent>
   </mutation>
 </suppressedMutations>

--- a/config/pitest-suppressions/pitest-coding-2-suppressions.xml
+++ b/config/pitest-suppressions/pitest-coding-2-suppressions.xml
@@ -1,6 +1,32 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <suppressedMutations>
-  <!-- until https://github.com/checkstyle/checkstyle/issues/14894 -->
+  <mutation unstable="false">
+    <sourceFile>IllegalInstantiationCheck.java</sourceFile>
+    <mutatedClass>com.puppycrawl.tools.checkstyle.checks.coding.IllegalInstantiationCheck</mutatedClass>
+    <mutatedMethod>visitToken</mutatedMethod>
+    <mutator>org.pitest.mutationtest.engine.gregor.mutators.NonVoidMethodCallMutator</mutator>
+    <description>removed call to java/lang/String::valueOf</description>
+    <lineContent>throw new IllegalArgumentException(&quot;Unknown type &quot; + ast);</lineContent>
+  </mutation>
+
+  <mutation unstable="false">
+    <sourceFile>ModifiedControlVariableCheck.java</sourceFile>
+    <mutatedClass>com.puppycrawl.tools.checkstyle.checks.coding.ModifiedControlVariableCheck</mutatedClass>
+    <mutatedMethod>leaveToken</mutatedMethod>
+    <mutator>org.pitest.mutationtest.engine.gregor.mutators.NonVoidMethodCallMutator</mutator>
+    <description>removed call to java/lang/String::valueOf</description>
+    <lineContent>throw new IllegalStateException(ILLEGAL_TYPE_OF_TOKEN + ast);</lineContent>
+  </mutation>
+
+  <mutation unstable="false">
+    <sourceFile>ModifiedControlVariableCheck.java</sourceFile>
+    <mutatedClass>com.puppycrawl.tools.checkstyle.checks.coding.ModifiedControlVariableCheck</mutatedClass>
+    <mutatedMethod>visitToken</mutatedMethod>
+    <mutator>org.pitest.mutationtest.engine.gregor.mutators.NonVoidMethodCallMutator</mutator>
+    <description>removed call to java/lang/String::valueOf</description>
+    <lineContent>throw new IllegalStateException(ILLEGAL_TYPE_OF_TOKEN + ast);</lineContent>
+  </mutation>
+
   <mutation unstable="false">
     <sourceFile>UnusedLocalVariableCheck.java</sourceFile>
     <mutatedClass>com.puppycrawl.tools.checkstyle.checks.coding.UnusedLocalVariableCheck</mutatedClass>

--- a/config/pitest-suppressions/pitest-filters-suppressions.xml
+++ b/config/pitest-suppressions/pitest-filters-suppressions.xml
@@ -5,9 +5,28 @@
     <mutatedClass>com.puppycrawl.tools.checkstyle.filters.SuppressFilterElement</mutatedClass>
     <mutatedMethod>&lt;init&gt;</mutatedMethod>
     <mutator>org.pitest.mutationtest.engine.gregor.mutators.experimental.MemberVariableMutator</mutator>
+    <description>Removed assignment to member variable checkRegexp</description>
+    <lineContent>checkRegexp = null;</lineContent>
+  </mutation>
+
+  <mutation unstable="false">
+    <sourceFile>SuppressFilterElement.java</sourceFile>
+    <mutatedClass>com.puppycrawl.tools.checkstyle.filters.SuppressFilterElement</mutatedClass>
+    <mutatedMethod>&lt;init&gt;</mutatedMethod>
+    <mutator>org.pitest.mutationtest.engine.gregor.mutators.experimental.MemberVariableMutator</mutator>
     <description>Removed assignment to member variable columnFilter</description>
     <lineContent>columnFilter = null;</lineContent>
   </mutation>
+
+  <mutation unstable="false">
+    <sourceFile>SuppressFilterElement.java</sourceFile>
+    <mutatedClass>com.puppycrawl.tools.checkstyle.filters.SuppressFilterElement</mutatedClass>
+    <mutatedMethod>&lt;init&gt;</mutatedMethod>
+    <mutator>org.pitest.mutationtest.engine.gregor.mutators.experimental.MemberVariableMutator</mutator>
+    <description>Removed assignment to member variable columnsCsv</description>
+    <lineContent>columnsCsv = columns;</lineContent>
+  </mutation>
+
   <mutation unstable="false">
     <sourceFile>SuppressFilterElement.java</sourceFile>
     <mutatedClass>com.puppycrawl.tools.checkstyle.filters.SuppressFilterElement</mutatedClass>
@@ -15,6 +34,15 @@
     <mutator>org.pitest.mutationtest.engine.gregor.mutators.experimental.MemberVariableMutator</mutator>
     <description>Removed assignment to member variable columnsCsv</description>
     <lineContent>columnsCsv = null;</lineContent>
+  </mutation>
+
+  <mutation unstable="false">
+    <sourceFile>SuppressFilterElement.java</sourceFile>
+    <mutatedClass>com.puppycrawl.tools.checkstyle.filters.SuppressFilterElement</mutatedClass>
+    <mutatedMethod>&lt;init&gt;</mutatedMethod>
+    <mutator>org.pitest.mutationtest.engine.gregor.mutators.experimental.MemberVariableMutator</mutator>
+    <description>Removed assignment to member variable fileRegexp</description>
+    <lineContent>fileRegexp = null;</lineContent>
   </mutation>
 
   <mutation unstable="false">
@@ -32,7 +60,25 @@
     <mutatedMethod>&lt;init&gt;</mutatedMethod>
     <mutator>org.pitest.mutationtest.engine.gregor.mutators.experimental.MemberVariableMutator</mutator>
     <description>Removed assignment to member variable linesCsv</description>
+    <lineContent>linesCsv = lines;</lineContent>
+  </mutation>
+
+  <mutation unstable="false">
+    <sourceFile>SuppressFilterElement.java</sourceFile>
+    <mutatedClass>com.puppycrawl.tools.checkstyle.filters.SuppressFilterElement</mutatedClass>
+    <mutatedMethod>&lt;init&gt;</mutatedMethod>
+    <mutator>org.pitest.mutationtest.engine.gregor.mutators.experimental.MemberVariableMutator</mutator>
+    <description>Removed assignment to member variable linesCsv</description>
     <lineContent>linesCsv = null;</lineContent>
+  </mutation>
+
+  <mutation unstable="false">
+    <sourceFile>SuppressFilterElement.java</sourceFile>
+    <mutatedClass>com.puppycrawl.tools.checkstyle.filters.SuppressFilterElement</mutatedClass>
+    <mutatedMethod>&lt;init&gt;</mutatedMethod>
+    <mutator>org.pitest.mutationtest.engine.gregor.mutators.experimental.MemberVariableMutator</mutator>
+    <description>Removed assignment to member variable messageRegexp</description>
+    <lineContent>messageRegexp = null;</lineContent>
   </mutation>
 
   <mutation unstable="false">
@@ -60,6 +106,15 @@
     <mutator>org.pitest.mutationtest.engine.gregor.mutators.experimental.MemberVariableMutator</mutator>
     <description>Removed assignment to member variable tagMessageRegexp</description>
     <lineContent>tagMessageRegexp = null;</lineContent>
+  </mutation>
+
+  <mutation unstable="false">
+    <sourceFile>SuppressWithNearbyCommentFilter.java</sourceFile>
+    <mutatedClass>com.puppycrawl.tools.checkstyle.filters.SuppressWithNearbyCommentFilter$Tag</mutatedClass>
+    <mutatedMethod>toString</mutatedMethod>
+    <mutator>org.pitest.mutationtest.engine.gregor.mutators.NonVoidMethodCallMutator</mutator>
+    <description>removed call to java/lang/String::valueOf</description>
+    <lineContent>return &quot;Tag[text=&apos;&quot; + text + &apos;\&apos;&apos;</lineContent>
   </mutation>
 
   <mutation unstable="false">
@@ -96,6 +151,15 @@
     <mutator>org.pitest.mutationtest.engine.gregor.mutators.experimental.MemberVariableMutator</mutator>
     <description>Removed assignment to member variable tagMessageRegexp</description>
     <lineContent>tagMessageRegexp = null;</lineContent>
+  </mutation>
+
+  <mutation unstable="false">
+    <sourceFile>SuppressionCommentFilter.java</sourceFile>
+    <mutatedClass>com.puppycrawl.tools.checkstyle.filters.SuppressionCommentFilter$Tag</mutatedClass>
+    <mutatedMethod>toString</mutatedMethod>
+    <mutator>org.pitest.mutationtest.engine.gregor.mutators.NonVoidMethodCallMutator</mutator>
+    <description>removed call to java/lang/String::valueOf</description>
+    <lineContent>return &quot;Tag[text=&apos;&quot; + text + &apos;\&apos;&apos;</lineContent>
   </mutation>
 
   <mutation unstable="false">

--- a/config/pitest-suppressions/pitest-header-suppressions.xml
+++ b/config/pitest-suppressions/pitest-header-suppressions.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<suppressedMutations>
+  <mutation unstable="false">
+    <sourceFile>AbstractHeaderCheck.java</sourceFile>
+    <mutatedClass>com.puppycrawl.tools.checkstyle.checks.header.AbstractHeaderCheck</mutatedClass>
+    <mutatedMethod>loadHeaderFile</mutatedMethod>
+    <mutator>org.pitest.mutationtest.engine.gregor.mutators.NonVoidMethodCallMutator</mutator>
+    <description>removed call to java/lang/String::valueOf</description>
+    <lineContent>throw new CheckstyleException(</lineContent>
+  </mutation>
+</suppressedMutations>

--- a/config/pitest-suppressions/pitest-imports-suppressions.xml
+++ b/config/pitest-suppressions/pitest-imports-suppressions.xml
@@ -1,6 +1,51 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <suppressedMutations>
   <mutation unstable="false">
+    <sourceFile>ImportControlCheck.java</sourceFile>
+    <mutatedClass>com.puppycrawl.tools.checkstyle.checks.imports.ImportControlCheck</mutatedClass>
+    <mutatedMethod>setFile</mutatedMethod>
+    <mutator>org.pitest.mutationtest.engine.gregor.mutators.NonVoidMethodCallMutator</mutator>
+    <description>removed call to java/lang/String::valueOf</description>
+    <lineContent>throw new IllegalArgumentException(UNABLE_TO_LOAD + uri, ex);</lineContent>
+  </mutation>
+
+  <mutation unstable="false">
+    <sourceFile>ImportControlLoader.java</sourceFile>
+    <mutatedClass>com.puppycrawl.tools.checkstyle.checks.imports.ImportControlLoader</mutatedClass>
+    <mutatedMethod>load</mutatedMethod>
+    <mutator>org.pitest.mutationtest.engine.gregor.mutators.NonVoidMethodCallMutator</mutator>
+    <description>removed call to java/lang/String::valueOf</description>
+    <lineContent>throw new CheckstyleException(&quot;unable to read &quot; + uri, ex);</lineContent>
+  </mutation>
+
+  <mutation unstable="false">
+    <sourceFile>ImportControlLoader.java</sourceFile>
+    <mutatedClass>com.puppycrawl.tools.checkstyle.checks.imports.ImportControlLoader</mutatedClass>
+    <mutatedMethod>loadUri</mutatedMethod>
+    <mutator>org.pitest.mutationtest.engine.gregor.mutators.NonVoidMethodCallMutator</mutator>
+    <description>removed call to java/lang/String::valueOf</description>
+    <lineContent>throw new CheckstyleException(&quot;syntax error in url &quot; + uri, ex);</lineContent>
+  </mutation>
+
+  <mutation unstable="false">
+    <sourceFile>ImportControlLoader.java</sourceFile>
+    <mutatedClass>com.puppycrawl.tools.checkstyle.checks.imports.ImportControlLoader</mutatedClass>
+    <mutatedMethod>loadUri</mutatedMethod>
+    <mutator>org.pitest.mutationtest.engine.gregor.mutators.NonVoidMethodCallMutator</mutator>
+    <description>removed call to java/lang/String::valueOf</description>
+    <lineContent>throw new CheckstyleException(&quot;unable to find &quot; + uri, ex);</lineContent>
+  </mutation>
+
+  <mutation unstable="false">
+    <sourceFile>ImportOrderCheck.java</sourceFile>
+    <mutatedClass>com.puppycrawl.tools.checkstyle.checks.imports.ImportOrderCheck</mutatedClass>
+    <mutatedMethod>visitToken</mutatedMethod>
+    <mutator>org.pitest.mutationtest.engine.gregor.mutators.NonVoidMethodCallMutator</mutator>
+    <description>removed call to java/lang/String::valueOf</description>
+    <lineContent>throw new IllegalStateException(</lineContent>
+  </mutation>
+
+  <mutation unstable="false">
     <sourceFile>PkgImportControl.java</sourceFile>
     <mutatedClass>com.puppycrawl.tools.checkstyle.checks.imports.PkgImportControl</mutatedClass>
     <mutatedMethod>&lt;init&gt;</mutatedMethod>

--- a/config/pitest-suppressions/pitest-javadoc-suppressions.xml
+++ b/config/pitest-suppressions/pitest-javadoc-suppressions.xml
@@ -1,6 +1,15 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <suppressedMutations>
   <mutation unstable="false">
+    <sourceFile>JavadocNodeImpl.java</sourceFile>
+    <mutatedClass>com.puppycrawl.tools.checkstyle.checks.javadoc.JavadocNodeImpl</mutatedClass>
+    <mutatedMethod>toString</mutatedMethod>
+    <mutator>org.pitest.mutationtest.engine.gregor.mutators.NonVoidMethodCallMutator</mutator>
+    <description>removed call to java/lang/String::valueOf</description>
+    <lineContent>+ ", children=" + Arrays.hashCode(children)</lineContent>
+  </mutation>
+
+  <mutation unstable="false">
     <sourceFile>JavadocTagInfo.java</sourceFile>
     <mutatedClass>com.puppycrawl.tools.checkstyle.checks.javadoc.JavadocTagInfo$11</mutatedClass>
     <mutatedMethod>isValidOn</mutatedMethod>

--- a/config/pitest-suppressions/pitest-packagenamesloader-suppressions.xml
+++ b/config/pitest-suppressions/pitest-packagenamesloader-suppressions.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<suppressedMutations>
+  <mutation unstable="false">
+    <sourceFile>PackageNamesLoader.java</sourceFile>
+    <mutatedClass>com.puppycrawl.tools.checkstyle.PackageNamesLoader</mutatedClass>
+    <mutatedMethod>processFile</mutatedMethod>
+    <mutator>org.pitest.mutationtest.engine.gregor.mutators.NonVoidMethodCallMutator</mutator>
+    <description>removed call to java/lang/String::valueOf</description>
+    <lineContent>throw new CheckstyleException(&quot;unable to open &quot; + packageFile, ex);</lineContent>
+  </mutation>
+</suppressedMutations>

--- a/src/main/java/com/puppycrawl/tools/checkstyle/filters/SuppressFilterElement.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/filters/SuppressFilterElement.java
@@ -65,6 +65,54 @@ public class SuppressFilterElement
     private final String columnsCsv;
 
     /**
+     * Constructs a {@code SuppressFilterElement} for a
+     * file name pattern.
+     *
+     * @param files   regular expression for names of filtered files.
+     * @param checks  regular expression for filtered check classes.
+     * @param message regular expression for messages.
+     * @param modId   the id
+     * @param lines   lines CSV values and ranges for line number filtering.
+     * @param columns columns CSV values and ranges for column number filtering.
+     */
+    public SuppressFilterElement(String files, String checks,
+                                 String message, String modId, String lines, String columns) {
+        if (files == null) {
+            fileRegexp = null;
+        }
+        else {
+            fileRegexp = Pattern.compile(files);
+        }
+        if (checks == null) {
+            checkRegexp = null;
+        }
+        else {
+            checkRegexp = Pattern.compile(checks);
+        }
+        if (message == null) {
+            messageRegexp = null;
+        }
+        else {
+            messageRegexp = Pattern.compile(message);
+        }
+        moduleId = modId;
+        linesCsv = lines;
+        if (lines == null) {
+            lineFilter = null;
+        }
+        else {
+            lineFilter = new CsvFilterElement(lines);
+        }
+        columnsCsv = columns;
+        if (columns == null) {
+            columnFilter = null;
+        }
+        else {
+            columnFilter = new CsvFilterElement(columns);
+        }
+    }
+
+    /**
      * Creates a {@code SuppressFilterElement} instance.
      *
      * @param files regular expression for filtered file names
@@ -96,42 +144,6 @@ public class SuppressFilterElement
             columnsCsv = columns;
             columnFilter = new CsvFilterElement(columns);
         }
-    }
-
-    /**
-     * Constructs a {@code SuppressFilterElement} using regular expressions
-     * as {@code String}s. These are internally compiled into {@code Pattern}
-     * objects and passed to the main constructor.
-     *
-     * @param files   regular expression for names of filtered files.
-     * @param checks  regular expression for filtered check classes.
-     * @param message regular expression for messages.
-     * @param modId   the id
-     * @param lines   lines CSV values and ranges for line number filtering.
-     * @param columns columns CSV values and ranges for column number filtering.
-     */
-    public SuppressFilterElement(String files, String checks, String message,
-                                 String modId, String lines, String columns) {
-        this(toPattern(files), toPattern(checks), toPattern(message),
-                modId, lines, columns);
-    }
-
-    /**
-     * Converts a string into a compiled {@code Pattern}, or returns {@code null}
-     * if the input is {@code null}.
-     *
-     * @param regex the regular expression as a string, may be {@code null}.
-     * @return the compiled {@code Pattern}, or {@code null} if input is {@code null}.
-     */
-    private static Pattern toPattern(String regex) {
-        final Pattern result;
-        if (regex != null) {
-            result = Pattern.compile(regex);
-        }
-        else {
-            result = null;
-        }
-        return result;
     }
 
     @Override


### PR DESCRIPTION
Fixes #16937 
Revert PR - Issue #14019
Reference #16938 
Closes #16938 , #16945 

Build status 
```
mvn -e --no-transfer-progress -P"pitest-tree-walker" clean test-compile org.pitest:pitest-maven:mutationCoverage
```

![Screenshot 2025-04-24 224939](https://github.com/user-attachments/assets/2c974c43-dd15-4472-8907-342807bb99dd)

Report

![Screenshot 2025-04-24 230024](https://github.com/user-attachments/assets/e420d892-8ac0-49f4-ad9a-32bb147f40f4)

![Screenshot 2025-04-24 230234](https://github.com/user-attachments/assets/78d6c597-f74e-4a73-b072-acbe211a6c35)
