### PR TITLE
Issue #14052: Since version is not properly calculated in properties 

### DIFF
--- a/config/import-control.xml
+++ b/config/import-control.xml
@@ -74,6 +74,7 @@
     <allow pkg="org.apache.maven" local-only="true"/>
     <allow pkg="java.nio" local-only="true"/>
     <allow pkg="org.codehaus.plexus" local-only="true"/>
+    <allow class="java.lang.module.ModuleDescriptor.Version" local-only="true"/>
     <allow class="java.lang.reflect.Field" local-only="true"/>
     <allow class="java.lang.reflect.Array" local-only="true"/>
     <allow class="java.lang.reflect.ParameterizedType" local-only="true"/>

--- a/src/main/java/com/puppycrawl/tools/checkstyle/site/SiteUtil.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/site/SiteUtil.java
@@ -22,6 +22,7 @@ package com.puppycrawl.tools.checkstyle.site;
 import java.beans.PropertyDescriptor;
 import java.io.File;
 import java.io.IOException;
+import java.lang.module.ModuleDescriptor.Version;
 import java.lang.reflect.Array;
 import java.lang.reflect.Field;
 import java.lang.reflect.InvocationTargetException;
@@ -116,6 +117,10 @@ public final class SiteUtil {
     private static final String NAMING = "naming";
     /** The string 'src'. */
     private static final String SRC = "src";
+    /** The string 'snapshot'. */
+    private static final String SNAPSHOT_SUFFIX = "-SNAPSHOT";
+    /** The string 'dot_regex'. */
+    private static final String DOT_REGEX = "\\\\.";
 
     /** Precompiled regex pattern to remove the "Setter to " prefix from strings. */
     private static final Pattern SETTER_PATTERN = Pattern.compile("^Setter to ");
@@ -173,32 +178,12 @@ public final class SiteUtil {
     /**
      * Frequent version.
      */
-    private static final String VERSION_6_9 = "6.9";
-
-    /**
-     * Frequent version.
-     */
     private static final String VERSION_5_0 = "5.0";
 
     /**
      * Frequent version.
      */
-    private static final String VERSION_3_2 = "3.2";
-
-    /**
-     * Frequent version.
-     */
     private static final String VERSION_8_24 = "8.24";
-
-    /**
-     * Frequent version.
-     */
-    private static final String VERSION_8_36 = "8.36";
-
-    /**
-     * Frequent version.
-     */
-    private static final String VERSION_3_0 = "3.0";
 
     /**
      * Frequent version.
@@ -221,90 +206,45 @@ public final class SiteUtil {
     private static final String VERSION_3_4 = "3.4";
 
     /**
+     * Frequent version.
+     */
+    private static final String VERSION_7_3 = "7.3";
+
+    /**
      * Map of properties whose since version is different from module version but
      * are not specified in code because they are inherited from their super class(es).
-     * Until <a href="https://github.com/checkstyle/checkstyle/issues/14052">#14052</a>.
      *
-     * @noinspection JavacQuirks
-     * @noinspectionreason JavacQuirks until #14052
      */
     private static final Map<String, String> SINCE_VERSION_FOR_INHERITED_PROPERTY = Map.ofEntries(
         Map.entry("MissingDeprecatedCheck.violateExecutionOnNonTightHtml", VERSION_8_24),
-        Map.entry("NonEmptyAtclauseDescriptionCheck.violateExecutionOnNonTightHtml", "8.3"),
-        Map.entry("HeaderCheck.charset", VERSION_5_0),
-        Map.entry("HeaderCheck.fileExtensions", VERSION_6_9),
-        Map.entry("HeaderCheck.headerFile", VERSION_3_2),
-        Map.entry(HEADER_CHECK_HEADER, VERSION_5_0),
-        Map.entry("RegexpHeaderCheck.charset", VERSION_5_0),
-        Map.entry("RegexpHeaderCheck.fileExtensions", VERSION_6_9),
-        Map.entry("RegexpHeaderCheck.headerFile", VERSION_3_2),
-        Map.entry(REGEXP_HEADER_CHECK_HEADER, VERSION_5_0),
         Map.entry("ClassDataAbstractionCouplingCheck.excludeClassesRegexps", VERSION_7_7),
         Map.entry("ClassDataAbstractionCouplingCheck.excludedClasses", VERSION_5_7),
         Map.entry("ClassDataAbstractionCouplingCheck.excludedPackages", VERSION_7_7),
-        Map.entry("ClassDataAbstractionCouplingCheck.max", VERSION_3_4),
         Map.entry("ClassFanOutComplexityCheck.excludeClassesRegexps", VERSION_7_7),
         Map.entry("ClassFanOutComplexityCheck.excludedClasses", VERSION_5_7),
         Map.entry("ClassFanOutComplexityCheck.excludedPackages", VERSION_7_7),
-        Map.entry("ClassFanOutComplexityCheck.max", VERSION_3_4),
-        Map.entry("NonEmptyAtclauseDescriptionCheck.javadocTokens", "7.3"),
-        Map.entry("FileTabCharacterCheck.fileExtensions", VERSION_5_0),
-        Map.entry("NewlineAtEndOfFileCheck.fileExtensions", "3.1"),
-        Map.entry("JavadocPackageCheck.fileExtensions", VERSION_5_0),
-        Map.entry("OrderedPropertiesCheck.fileExtensions", "8.22"),
-        Map.entry("UniquePropertiesCheck.fileExtensions", VERSION_5_7),
-        Map.entry("TranslationCheck.fileExtensions", VERSION_3_0),
+        Map.entry("NonEmptyAtclauseDescriptionCheck.javadocTokens", VERSION_7_3),
         Map.entry("LineLengthCheck.fileExtensions", VERSION_8_24),
-        // until https://github.com/checkstyle/checkstyle/issues/14052
-        Map.entry("JavadocBlockTagLocationCheck.violateExecutionOnNonTightHtml", VERSION_8_24),
-        Map.entry("JavadocLeadingAsteriskAlignCheck.violateExecutionOnNonTightHtml", "10.18"),
-        Map.entry("JavadocMissingLeadingAsteriskCheck.violateExecutionOnNonTightHtml", "8.38"),
-        Map.entry(
-            "RequireEmptyLineBeforeBlockTagGroupCheck.violateExecutionOnNonTightHtml",
-            VERSION_8_36),
-        Map.entry("ParenPadCheck.option", VERSION_3_0),
-        Map.entry("TypecastParenPadCheck.option", VERSION_3_2),
-        Map.entry("FileLengthCheck.fileExtensions", VERSION_5_0),
         Map.entry("StaticVariableNameCheck.applyToPackage", VERSION_5_0),
         Map.entry("StaticVariableNameCheck.applyToPrivate", VERSION_5_0),
         Map.entry("StaticVariableNameCheck.applyToProtected", VERSION_5_0),
         Map.entry("StaticVariableNameCheck.applyToPublic", VERSION_5_0),
-        Map.entry("StaticVariableNameCheck.format", VERSION_3_0),
         Map.entry("TypeNameCheck.applyToPackage", VERSION_5_0),
         Map.entry("TypeNameCheck.applyToPrivate", VERSION_5_0),
         Map.entry("TypeNameCheck.applyToProtected", VERSION_5_0),
         Map.entry("TypeNameCheck.applyToPublic", VERSION_5_0),
-        Map.entry("RegexpMultilineCheck.fileExtensions", VERSION_5_0),
-        Map.entry("RegexpOnFilenameCheck.fileExtensions", "6.15"),
-        Map.entry("RegexpSinglelineCheck.fileExtensions", VERSION_5_0),
-        Map.entry("ClassTypeParameterNameCheck.format", VERSION_5_0),
-        Map.entry("CatchParameterNameCheck.format", "6.14"),
-        Map.entry("LambdaParameterNameCheck.format", "8.11"),
-        Map.entry("IllegalIdentifierNameCheck.format", VERSION_8_36),
-        Map.entry("ConstantNameCheck.format", VERSION_3_0),
         Map.entry("ConstantNameCheck.applyToPackage", VERSION_5_0),
         Map.entry("ConstantNameCheck.applyToPrivate", VERSION_5_0),
         Map.entry("ConstantNameCheck.applyToProtected", VERSION_5_0),
         Map.entry("ConstantNameCheck.applyToPublic", VERSION_5_0),
-        Map.entry("InterfaceTypeParameterNameCheck.format", "5.8"),
-        Map.entry("LocalFinalVariableNameCheck.format", VERSION_3_0),
-        Map.entry("LocalVariableNameCheck.format", VERSION_3_0),
-        Map.entry("MemberNameCheck.format", VERSION_3_0),
         Map.entry("MemberNameCheck.applyToPackage", VERSION_3_4),
         Map.entry("MemberNameCheck.applyToPrivate", VERSION_3_4),
         Map.entry("MemberNameCheck.applyToProtected", VERSION_3_4),
         Map.entry("MemberNameCheck.applyToPublic", VERSION_3_4),
-        Map.entry("MethodNameCheck.format", VERSION_3_0),
         Map.entry("MethodNameCheck.applyToPackage", VERSION_5_1),
         Map.entry("MethodNameCheck.applyToPrivate", VERSION_5_1),
         Map.entry("MethodNameCheck.applyToProtected", VERSION_5_1),
-        Map.entry("MethodNameCheck.applyToPublic", VERSION_5_1),
-        Map.entry("MethodTypeParameterNameCheck.format", VERSION_5_0),
-        Map.entry("ParameterNameCheck.format", VERSION_3_0),
-        Map.entry("PatternVariableNameCheck.format", VERSION_8_36),
-        Map.entry("RecordTypeParameterNameCheck.format", VERSION_8_36),
-        Map.entry("RecordComponentNameCheck.format", "8.40"),
-        Map.entry("TypeNameCheck.format", VERSION_3_0)
+        Map.entry("MethodNameCheck.applyToPublic", VERSION_5_1)
     );
 
     /** Map of all superclasses properties and their javadocs. */
@@ -832,32 +772,110 @@ public final class SiteUtil {
      * @return the since version of the property.
      * @throws MacroExecutionException if the since version could not be extracted.
      */
-    public static String getSinceVersion(String moduleName, DetailNode moduleJavadoc,
-                                         String propertyName, DetailNode propertyJavadoc)
+    public static String getSinceVersion(String moduleName,
+                                         DetailNode moduleJavadoc,
+                                         String propertyName,
+                                         DetailNode propertyJavadoc)
             throws MacroExecutionException {
-        final String sinceVersion;
-        final String superClassSinceVersion = SINCE_VERSION_FOR_INHERITED_PROPERTY
-                   .get(moduleName + DOT + propertyName);
-        if (superClassSinceVersion != null) {
-            sinceVersion = superClassSinceVersion;
+        final String key = moduleName + DOT + propertyName;
+        final String fallbackSince = SINCE_VERSION_FOR_INHERITED_PROPERTY.get(key);
+
+        final String moduleSince = getSinceVersionFromJavadoc(moduleJavadoc);
+        if (moduleSince == null) {
+            throw new MacroExecutionException(
+                    "Missing @since on module " + moduleName);
         }
-        else if (TOKENS.equals(propertyName)
-                        || JAVADOC_TOKENS.equals(propertyName)) {
-            // Use module's since version for inherited properties
-            sinceVersion = getSinceVersionFromJavadoc(moduleJavadoc);
+
+        DetailNode effectiveJavadoc = propertyJavadoc;
+        if (effectiveJavadoc == null) {
+            effectiveJavadoc = SUPER_CLASS_PROPERTIES_JAVADOCS.get(key);
+        }
+        final String propertySince;
+        if (effectiveJavadoc == null) {
+            propertySince = null;
         }
         else {
-            sinceVersion = getSinceVersionFromJavadoc(propertyJavadoc);
+            propertySince = getSinceVersionFromJavadoc(effectiveJavadoc);
         }
 
-        if (sinceVersion == null) {
-            final String message = String.format(Locale.ROOT,
-                    "Failed to find '@since' version for '%s' property"
-                            + " in '%s' and all parent classes.", propertyName, moduleName);
-            throw new MacroExecutionException(message);
+        final String result;
+        if (fallbackSince != null) {
+            result = fallbackSince;
+        }
+        else if (TOKENS.equals(propertyName)
+                || JAVADOC_TOKENS.equals(propertyName)) {
+            result = moduleSince;
+        }
+        else if (propertySince == null) {
+            result = moduleSince;
+        }
+        else if (isVersionAtLeast(propertySince, moduleSince)) {
+            result = propertySince;
+        }
+        else {
+            result = moduleSince;
         }
 
-        return sinceVersion;
+        return result;
+    }
+
+    /**
+     * Returns {@code true} if {@code actualVersion} ≥ {@code requiredVersion}.
+     * Both versions have any trailing "-SNAPSHOT" stripped before comparison.
+     *
+     * @param actualVersion   e.g. "8.3" or "8.3-SNAPSHOT"
+     * @param requiredVersion e.g. "8.3"
+     * @return {@code true} if, numerically, actualVersion is at least requiredVersion
+     */
+    private static boolean isVersionAtLeast(String actualVersion,
+                                            String requiredVersion) {
+        final String actClean = actualVersion
+                .replace(SNAPSHOT_SUFFIX, "")
+                .trim();
+        final String reqClean = requiredVersion
+                .replace(SNAPSHOT_SUFFIX, "")
+                .trim();
+
+        boolean result = false;
+        try {
+            final Version vAct = Version.parse(actClean);
+            final Version vReq = Version.parse(reqClean);
+            result = vAct.compareTo(vReq) >= 0;
+        }
+        catch (IllegalArgumentException iae) {
+            // Fallback: compare each numeric segment
+            final String[] partsAct = actClean.split(DOT_REGEX);
+            final String[] partsReq = reqClean.split(DOT_REGEX);
+            final int length = Math.max(partsAct.length, partsReq.length);
+
+            boolean compared = false;
+            for (int index = 0; index < length; index++) {
+                final int a;
+                if (index < partsAct.length) {
+                    a = Integer.parseInt(partsAct[index]);
+                }
+                else {
+                    a = 0;
+                }
+                final int r;
+                if (index < partsReq.length) {
+                    r = Integer.parseInt(partsReq[index]);
+                }
+                else {
+                    r = 0;
+                }
+                if (a != r) {
+                    result = a > r;
+                    compared = true;
+                    break;
+                }
+            }
+            if (!compared) {
+                result = true;
+            }
+        }
+
+        return result;
     }
 
     /**

--- a/src/site/xdoc/checks/header/header.xml
+++ b/src/site/xdoc/checks/header/header.xml
@@ -41,7 +41,7 @@
               <td>Specify the character encoding to use when reading the headerFile.</td>
               <td><a href="../../property_types.html#String">String</a></td>
               <td><code>the charset property of the parent &lt;a href=&quot;https://checkstyle.org/config.html#Checker&quot;&gt;Checker&lt;/a&gt; module</code></td>
-              <td>5.0</td>
+              <td>6.9</td>
             </tr>
             <tr>
               <td>fileExtensions</td>
@@ -55,21 +55,21 @@
               <td>Specify the required header specified inline. Individual header lines must be separated by the string <code>"\n"</code>(even on platforms with a different line separator).</td>
               <td><a href="../../property_types.html#String">String</a></td>
               <td><code>null</code></td>
-              <td>5.0</td>
+              <td>6.9</td>
             </tr>
             <tr>
               <td>headerFile</td>
               <td>Specify the name of the file containing the required header.</td>
               <td><a href="../../property_types.html#URI">URI</a></td>
               <td><code>null</code></td>
-              <td>3.2</td>
+              <td>6.9</td>
             </tr>
             <tr>
               <td>ignoreLines</td>
               <td>Specifies the line numbers to ignore when matching lines in a content of headerFile.</td>
               <td><a href="../../property_types.html#int.5B.5D">int[]</a></td>
               <td><code>{}</code></td>
-              <td>3.2</td>
+              <td>6.9</td>
             </tr>
           </table>
         </div>

--- a/src/site/xdoc/checks/header/regexpheader.xml
+++ b/src/site/xdoc/checks/header/regexpheader.xml
@@ -31,7 +31,7 @@
               <td>Specify the character encoding to use when reading the headerFile.</td>
               <td><a href="../../property_types.html#String">String</a></td>
               <td><code>the charset property of the parent &lt;a href=&quot;https://checkstyle.org/config.html#Checker&quot;&gt;Checker&lt;/a&gt; module</code></td>
-              <td>5.0</td>
+              <td>6.9</td>
             </tr>
             <tr>
               <td>fileExtensions</td>
@@ -45,21 +45,21 @@
               <td>Define the required header specified inline. Individual header lines must be separated by the string <code>"\n"</code> (even on platforms with a different line separator). For header lines containing <code>"\n\n"</code> checkstyle will forcefully expect an empty line to exist. See examples below. Regular expressions must not span multiple lines.</td>
               <td><a href="../../property_types.html#String">String</a></td>
               <td><code>null</code></td>
-              <td>5.0</td>
+              <td>6.9</td>
             </tr>
             <tr>
               <td>headerFile</td>
               <td>Specify the name of the file containing the required header.</td>
               <td><a href="../../property_types.html#URI">URI</a></td>
               <td><code>null</code></td>
-              <td>3.2</td>
+              <td>6.9</td>
             </tr>
             <tr>
               <td>multiLines</td>
               <td>Specify the line numbers to repeat (zero or more times).</td>
               <td><a href="../../property_types.html#int.5B.5D">int[]</a></td>
               <td><code>{}</code></td>
-              <td>3.4</td>
+              <td>6.9</td>
             </tr>
           </table>
         </div>

--- a/src/site/xdoc/checks/javadoc/javadocleadingasteriskalign.xml
+++ b/src/site/xdoc/checks/javadoc/javadocleadingasteriskalign.xml
@@ -43,7 +43,7 @@
      Tight-HTML Rules</a>.</td>
               <td><a href="../../property_types.html#boolean">boolean</a></td>
               <td><code>false</code></td>
-              <td>10.18</td>
+              <td>10.18.0</td>
             </tr>
           </table>
         </div>

--- a/src/site/xdoc/checks/javadoc/javadocmissingwhitespaceafterasterisk.xml
+++ b/src/site/xdoc/checks/javadoc/javadocmissingwhitespaceafterasterisk.xml
@@ -33,7 +33,7 @@
      Tight-HTML Rules</a>.</td>
               <td><a href="../../property_types.html#boolean">boolean</a></td>
               <td><code>false</code></td>
-              <td>8.3</td>
+              <td>8.32</td>
             </tr>
           </table>
         </div>

--- a/src/site/xdoc/checks/regexp/regexpsinglelinejava.xml
+++ b/src/site/xdoc/checks/regexp/regexpsinglelinejava.xml
@@ -35,28 +35,28 @@
               <td>Specify the format of the regular expression to match.</td>
               <td><a href="../../property_types.html#Pattern">Pattern</a></td>
               <td><code>&quot;$.&quot;</code></td>
-              <td>5.0</td>
+              <td>6.0</td>
             </tr>
             <tr>
               <td>ignoreCase</td>
               <td>Control whether to ignore case when searching.</td>
               <td><a href="../../property_types.html#boolean">boolean</a></td>
               <td><code>false</code></td>
-              <td>5.0</td>
+              <td>6.0</td>
             </tr>
             <tr>
               <td>ignoreComments</td>
               <td>Control whether to ignore text in comments when searching.</td>
               <td><a href="../../property_types.html#boolean">boolean</a></td>
               <td><code>false</code></td>
-              <td>5.0</td>
+              <td>6.0</td>
             </tr>
             <tr>
               <td>maximum</td>
               <td>Specify the maximum number of matches required in each file.</td>
               <td><a href="../../property_types.html#int">int</a></td>
               <td><code>0</code></td>
-              <td>5.0</td>
+              <td>6.0</td>
             </tr>
             <tr>
               <td>message</td>
@@ -70,7 +70,7 @@
               <td>Specify the minimum number of matches required in each file.</td>
               <td><a href="../../property_types.html#int">int</a></td>
               <td><code>0</code></td>
-              <td>5.0</td>
+              <td>6.0</td>
             </tr>
           </table>
         </div>

--- a/src/site/xdoc/checks/sizes/filelength.xml
+++ b/src/site/xdoc/checks/sizes/filelength.xml
@@ -42,7 +42,7 @@
               <td>Specify the maximum number of lines allowed.</td>
               <td><a href="../../property_types.html#int">int</a></td>
               <td><code>2000</code></td>
-              <td>3.2</td>
+              <td>5.0</td>
             </tr>
           </table>
         </div>


### PR DESCRIPTION
#14052 

 **Fallback map**
- If there’s a hard-coded entry for ModuleName.propertyName in `SINCE_VERSION_FOR_INHERITED_PROPERTY`, return it.

 **Module `@since`**
- Parse the Check class’s own `@since`; if missing ⇒ error.

 **Property `@since`(incl. inherited)**
- Take the setter’s `@since` tag if present, otherwise look up any inherited‐setter Javadoc for that property.

 **Tokens special case**
- For tokens or javadocTokens, always use the module’s `@since`.

 **Pick the later version**
- If the property’s `@since` (from step 3) is ≥ the module’s, use it; otherwise use the module’s.