### PR TITLE
Issue #16360: Migrate XMLLoggerTest.testErrorModuleId to use inlineConfigParser

### DIFF
--- a/src/test/java/com/puppycrawl/tools/checkstyle/XMLLoggerTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/XMLLoggerTest.java
@@ -200,17 +200,9 @@ public class XMLLoggerTest extends AbstractXmlTestSupport {
 
     @Test
     public void testAddErrorModuleId() throws Exception {
-        final XMLLogger logger = new XMLLogger(outStream, OutputStreamOptions.CLOSE);
-        logger.auditStarted(null);
-        final Violation violation =
-            new Violation(1, 1,
-                "messages.properties", "key", null, SeverityLevel.ERROR, "<i></i>-->",
-                    getClass(), null);
-        final AuditEvent ev = new AuditEvent(this, "Test.java", violation);
-        logger.addError(ev);
-        logger.auditFinished(null);
-        verifyXml(getPath("ExpectedXMLLoggerErrorModuleId.xml"), outStream,
-                violation.getViolation());
+        final String inputFile = "InputXMLLoggerErrorModuleId.java";
+        final String expectedXmlReport = "ExpectedXMLLoggerErrorModuleId.xml";
+        verifyWithInlineConfigParserAndXmlLogger(inputFile, expectedXmlReport);
     }
 
     @Test

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/xmllogger/ExpectedXMLLoggerErrorModuleId.xml
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/xmllogger/ExpectedXMLLoggerErrorModuleId.xml
@@ -1,4 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <checkstyle version="">
-<error line="1" column="1" severity="error" message="$0" source="&lt;i&gt;&lt;/i&gt;--&gt;"/>
+<file name="InputXMLLoggerErrorModuleId.java">
+<error line="11" column="17" severity="error"
+message="Name 'Method' must match pattern '^[a-z][a-zA-Z0-9]*$'."
+source="&lt;i&gt;&lt;/i&gt;--&gt;"/>
+</file>
 </checkstyle>

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/xmllogger/InputXMLLoggerErrorModuleId.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/xmllogger/InputXMLLoggerErrorModuleId.java
@@ -1,0 +1,12 @@
+/*
+com.puppycrawl.tools.checkstyle.checks.naming.MethodNameCheck
+id = <i></i>-->
+
+*/
+
+package com.puppycrawl.tools.checkstyle.xmllogger;
+
+public class InputXMLLoggerErrorModuleId {
+
+    public void Method() {}
+}


### PR DESCRIPTION
Part of #16360 

Replace the `verifyXml()` call with `verifyWithInlineConfigParserAndXmlLogger()` in the `XMLLoggerTest.testErrorModuleId` method.

### Build Output

![image](https://github.com/user-attachments/assets/77a980be-2d83-4bd6-8ce5-c9bbd4f579c7)
