### PR TITLE
Issue #16360: Migrate XMLLoggerTest.testAddIgnored to use inlineConfigParser

### DIFF
--- a/src/test/java/com/puppycrawl/tools/checkstyle/XMLLoggerTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/XMLLoggerTest.java
@@ -228,16 +228,9 @@ public class XMLLoggerTest extends AbstractXmlTestSupport {
 
     @Test
     public void testAddIgnored() throws Exception {
-        final XMLLogger logger = new XMLLogger(outStream, OutputStreamOptions.CLOSE);
-        logger.auditStarted(null);
-        final Violation violation =
-                new Violation(1, 1,
-                        "messages.properties", "key", null, SeverityLevel.IGNORE, null,
-                        getClass(), null);
-        final AuditEvent ev = new AuditEvent(this, "Test.java", violation);
-        logger.addError(ev);
-        logger.auditFinished(null);
-        verifyXml(getPath("ExpectedXMLLoggerEmpty.xml"), outStream);
+        final String inputFile = "InputXMLLoggerIgnored.java";
+        final String expectedXmlReport = "ExpectedXMLLoggerIgnored.xml";
+        verifyWithInlineConfigParserAndXmlLogger(inputFile, expectedXmlReport);
     }
 
     @Test

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/xmllogger/ExpectedXMLLoggerIgnored.xml
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/xmllogger/ExpectedXMLLoggerIgnored.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<checkstyle version="null">
+<file name="InputXMLLoggerIgnored.java">
+</file>
+</checkstyle>

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/xmllogger/InputXMLLoggerIgnored.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/xmllogger/InputXMLLoggerIgnored.java
@@ -1,0 +1,15 @@
+/*xml
+<module name="Checker">
+  <module
+      name="com.puppycrawl.tools.checkstyle.checks.sizes.LineLengthCheck">
+     <property name="severity" value="ignore"/>
+     <property name="max" value="50"/>
+  </module>
+</module>
+*/
+
+package com.puppycrawl.tools.checkstyle.xmllogger;
+
+public class InputXMLLoggerIgnored {
+    String longLine = "This line is definitely more than Fifty characters long.";
+}


### PR DESCRIPTION
Part of #16360 

Replace the `verifyXml()` call with `verifyWithInlineConfigParserAndXmlLogger()` in the `XMLLoggerTest.testAddIgnored`.
