### PR TITLE
Issue #16155: Used nio api in CheckUtil

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/utils/CheckUtil.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/utils/CheckUtil.java
@@ -19,7 +19,7 @@
 
 package com.puppycrawl.tools.checkstyle.utils;
 
-import java.io.File;
+import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
@@ -568,6 +568,7 @@ public final class CheckUtil {
      * @return true if the package file.
      */
     public static boolean isPackageInfo(String filePath) {
-        return "package-info.java".equals(new File(filePath).getName());
+        final Path filename = Path.of(filePath).getFileName();
+        return filename != null && "package-info.java".equals(filename.toString());
     }
 }

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/javadoc/MissingJavadocMethodCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/javadoc/MissingJavadocMethodCheckTest.java
@@ -22,7 +22,7 @@ package com.puppycrawl.tools.checkstyle.checks.javadoc;
 import static com.google.common.truth.Truth.assertWithMessage;
 import static com.puppycrawl.tools.checkstyle.checks.javadoc.MissingJavadocMethodCheck.MSG_JAVADOC_MISSING;
 
-import java.io.File;
+import java.nio.file.Path;
 
 import org.junit.jupiter.api.Test;
 
@@ -474,10 +474,9 @@ public class MissingJavadocMethodCheckTest extends AbstractModuleTestSupport {
 
     @Test
     public void testIsGetterMethod() throws Exception {
-        final File testFile =
-                new File(getPath("InputMissingJavadocMethodSetterGetter3.java"));
-        final DetailAST notGetterMethod =
-                CheckUtilTest.getNode(testFile, TokenTypes.METHOD_DEF);
+        final Path testFile = Path.of(getPath("InputMissingJavadocMethodSetterGetter3.java"));
+        final DetailAST notGetterMethod = CheckUtilTest.getNode(testFile, TokenTypes.METHOD_DEF);
+
         final DetailAST getterMethod = notGetterMethod.getNextSibling().getNextSibling();
 
         assertWithMessage("Invalid result: AST provided is getter method")
@@ -490,10 +489,9 @@ public class MissingJavadocMethodCheckTest extends AbstractModuleTestSupport {
 
     @Test
     public void testIsSetterMethod() throws Exception {
-        final File testFile =
-            new File(getPath("InputMissingJavadocMethodSetterGetter3.java"));
-        final DetailAST firstClassMethod =
-            CheckUtilTest.getNode(testFile, TokenTypes.METHOD_DEF);
+        final Path testFile = Path.of(getPath("InputMissingJavadocMethodSetterGetter3.java"));
+        final DetailAST firstClassMethod = CheckUtilTest.getNode(testFile, TokenTypes.METHOD_DEF);
+
         final DetailAST setterMethod =
             firstClassMethod.getNextSibling().getNextSibling().getNextSibling();
         final DetailAST notSetterMethod = setterMethod.getNextSibling();

--- a/src/test/java/com/puppycrawl/tools/checkstyle/utils/CheckUtilTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/utils/CheckUtilTest.java
@@ -27,7 +27,7 @@ import static com.puppycrawl.tools.checkstyle.checks.javadoc.JavadocMethodCheck.
 import static com.puppycrawl.tools.checkstyle.internal.utils.TestUtil.findTokenInAstByPredicate;
 import static com.puppycrawl.tools.checkstyle.internal.utils.TestUtil.isUtilsClassHasPrivateConstructor;
 
-import java.io.File;
+import java.nio.file.Path;
 import java.util.Arrays;
 import java.util.HashSet;
 import java.util.List;
@@ -410,8 +410,8 @@ public class CheckUtilTest extends AbstractModuleTestSupport {
     }
 
     private DetailAST getNodeFromFile(int type) throws Exception {
-        return getNode(JavaParser.parseFile(new File(getPath("InputCheckUtilTest.java")),
-            JavaParser.Options.WITH_COMMENTS), type);
+        final Path path = Path.of(getPath("InputCheckUtilTest.java"));
+        return getNode(JavaParser.parseFile(path.toFile(), JavaParser.Options.WITH_COMMENTS), type);
     }
 
     /**
@@ -419,12 +419,13 @@ public class CheckUtilTest extends AbstractModuleTestSupport {
      *
      * @param type The token type to search for in the file.
      *             This parameter determines the type of AST node to retrieve.
-     * @param file The file from which the AST node should be retrieved.
+     * @param filePath The file from which the AST node should be retrieved.
      * @return The AST node associated with the specified token type from the given file.
      * @throws Exception If there's an issue reading or parsing the file.
      */
-    public static DetailAST getNode(File file, int type) throws Exception {
-        return getNode(JavaParser.parseFile(file, JavaParser.Options.WITH_COMMENTS), type);
+    public static DetailAST getNode(Path filePath, int type) throws Exception {
+        return getNode(JavaParser.parseFile(filePath.toFile(),
+                JavaParser.Options.WITH_COMMENTS), type);
     }
 
     /**
@@ -444,4 +445,14 @@ public class CheckUtilTest extends AbstractModuleTestSupport {
 
         return node.orElseThrow();
     }
+
+    @Test
+    public void testPackageInfo() {
+        final boolean result = CheckUtil.isPackageInfo("/");
+
+        assertWithMessage("Expected isPackageInfo() to return false for ('/')")
+                .that(result)
+                .isFalse();
+    }
+
 }


### PR DESCRIPTION
Issue: #16155 

Removed usage of File.io in CheckUtil, CheckUtilTest, MissingJavadocMethodCheckTest

 ```
   public static boolean isPackageInfo(String filePath) {
        final Path path = Path.of(filePath);
        final Path filename = path.getFileName();
        return filename != null && "package-info.java".equals(filename.toString());
    }
```
Explanation:
As .toString() can cause NullPointerException, so `filename != null` was needed, as no existing test tested for `filename != null`
added new test to trigger if `filename == null` killing the possible mutations.
```
    @Test
    public void testPackageInfo() {
        final boolean result = CheckUtil.isPackageInfo("/");

        assertWithMessage("Expected isPackageInfo() to return false for ('/')")
                .that(result)
                .isFalse();
    }
```