### PR TITLE
Pull #16962: include PMD `GuardLogStatement`

### DIFF
--- a/config/pmd.xml
+++ b/config/pmd.xml
@@ -8,14 +8,7 @@
     PMD common ruleset for Checkstyle main/test sourcesets
   </description>
 
-  <rule ref="category/java/bestpractices.xml">
-    <!-- The PMD mistakes the AbstractViolationReporter::log() as a debug log. -->
-    <exclude name="GuardLogStatement"/>
-    <!-- too much false-positives from 6.18.0 -->
-    <exclude name="UnusedPrivateMethod"/>
-    <!-- until https://github.com/pmd/pmd/issues/5514 -->
-    <exclude name="ExhaustiveSwitchHasDefault"/>
-  </rule>
+  <rule ref="category/java/bestpractices.xml/"/>
   <rule ref="category/java/bestpractices.xml/UnusedLocalVariable">
     <properties>
       <!-- until https://github.com/checkstyle/checkstyle/issues/14870 -->

--- a/config/pmd.xml
+++ b/config/pmd.xml
@@ -9,6 +9,8 @@
   </description>
 
   <rule ref="category/java/bestpractices.xml">
+    <!-- too much false-positives from 6.18.0 -->
+    <exclude name="UnusedPrivateMethod"/>
     <!-- until https://github.com/pmd/pmd/issues/5514 -->
     <exclude name="ExhaustiveSwitchHasDefault"/>
   </rule>

--- a/config/pmd.xml
+++ b/config/pmd.xml
@@ -8,7 +8,10 @@
     PMD common ruleset for Checkstyle main/test sourcesets
   </description>
 
-  <rule ref="category/java/bestpractices.xml/"/>
+  <rule ref="category/java/bestpractices.xml">
+    <!-- until https://github.com/pmd/pmd/issues/5514 -->
+    <exclude name="ExhaustiveSwitchHasDefault"/>
+  </rule>
   <rule ref="category/java/bestpractices.xml/UnusedLocalVariable">
     <properties>
       <!-- until https://github.com/checkstyle/checkstyle/issues/14870 -->


### PR DESCRIPTION
Pull #16962: include PMD `GuardLogStatement`
- Obsolet as bug causing code pattern is gone.
- Could use live mode to increase coverage.
- #16961 