### PR TITLE
Issue #16790: Incorrect language class assigned to code blocks in documentation (e.g., logs getting language-xml, Java code getting language-xml) 

### DIFF
--- a/src/site/xdoc/beginning_development.xml
+++ b/src/site/xdoc/beginning_development.xml
@@ -26,7 +26,7 @@
         3. Clone your forked repository to your computer:
       </p>
       <div class="wrap-content">
-        <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
+        <div class="wrapper"><pre class="prettyprint"><code class="language-bash">
             git clone git@github.com:your_user_name/checkstyle.git
         </code></pre></div>
       </div>
@@ -35,7 +35,7 @@
         all needed artifacts. From the repository root folder, run:
       </p>
       <div class="wrap-content">
-        <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
+        <div class="wrapper"><pre class="prettyprint"><code class="language-bash">
             mvn install
         </code></pre></div>
       </div>

--- a/src/site/xdoc/cmdline.xml.vm
+++ b/src/site/xdoc/cmdline.xml.vm
@@ -28,7 +28,7 @@
     <section name="Command line usage">
       <p>
 
-        <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
+        <div class="wrapper"><pre class="prettyprint"><code class="language-bash">
 java -D&lt;property&gt;=&lt;value&gt;  \
      com.puppycrawl.tools.checkstyle.Main \
      -c &lt;configurationFile&gt; \
@@ -622,7 +622,7 @@ class Test {
 
 <p><strong>Output:</strong></p>
 <div class="wrapper">
-  <pre class="prettyprint"><code class="language-bash">
+  <pre class="prettyprint"><code class="language-text">
 Starting audit...
 [ERROR] Test.java:17:17: Fall through from previous branch of the switch statement.
 [FallThrough]
@@ -1003,7 +1003,7 @@ class Test {
 
 <p><strong>Output: </strong></p>
 <div class="wrapper">
-  <pre class="prettyprint"><code class="language-bash">
+  <pre class="prettyprint"><code class="language-text">
 /COMPILATION_UNIT/CLASS_DEF[./IDENT[@text='Test']]/OBJBLOCK/METHOD_DEF
 ./IDENT[@text='foo']]/SLIST/LITERAL_WHILE/SLIST/LITERAL_SWITCH/CASE_GROUP
 [./LITERAL_CASE/EXPR/NUM_INT[@text='3']]/COMPILATION_UNIT/CLASS_DEF[./IDENT
@@ -1052,7 +1052,7 @@ class Test {
 
 <p><strong>Output: </strong></p>
 <div class="wrapper">
-  <pre class="prettyprint"><code class="language-bash">
+  <pre class="prettyprint"><code class="language-java">
 COMPILATION_UNIT -> COMPILATION_UNIT [6:0]
 `--CLASS_DEF -> CLASS_DEF [6:0]
     |--MODIFIERS -> MODIFIERS [6:0]
@@ -1165,7 +1165,7 @@ class Test {
 
 <p><strong>Output: </strong></p>
 <div class="wrapper">
-  <pre class="prettyprint"><code class="language-bash">
+  <pre class="prettyprint"><code class="language-java">
 COMPILATION_UNIT -> COMPILATION_UNIT [6:0]
 `--CLASS_DEF -> CLASS_DEF [6:0]
     |--MODIFIERS -> MODIFIERS [6:0]
@@ -1286,7 +1286,7 @@ class Test {
 
 <p><strong>Output: </strong></p>
 <div class="wrapper">
-  <pre class="prettyprint"><code class="language-bash">
+  <pre class="prettyprint"><code class="language-java">
 COMPILATION_UNIT -> COMPILATION_UNIT [6:0]
 `--CLASS_DEF -> CLASS_DEF [6:0]
     |--MODIFIERS -> MODIFIERS [6:0]
@@ -1410,7 +1410,7 @@ java -jar checkstyle-${projectVersion}-all.jar --javadocTree Javadoc.txt
 
 <p><strong>Output: </strong></p>
 <div class="wrapper">
-  <pre class="prettyprint"><code class="language-bash">
+  <pre class="prettyprint"><code class="language-java">
 JAVADOC -> JAVADOC [0:0]
  |--TEXT -> /** [0:0]
  |--NEWLINE -> \r\n [0:3]
@@ -1653,7 +1653,7 @@ java -jar checkstyle-${projectVersion}-all.jar --version
 
 <p><strong>Output: </strong></p>
 <div class="wrapper">
-  <pre class="prettyprint"><code class="language-bash">
+  <pre class="prettyprint"><code class="language-text">
 Checkstyle ${projectVersion}
   </code></pre>
 </div>
@@ -1946,7 +1946,7 @@ Checkstyle ends with 2 errors.
         Download and compile:
       </p>
       <div class="wrap-content">
-        <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
+        <div class="wrapper"><pre class="prettyprint"><code class="language-bash">
           git clone https://github.com/checkstyle/checkstyle.git
           cd checkstyle
           mvn clean compile
@@ -1956,7 +1956,7 @@ Checkstyle ends with 2 errors.
         Run validation with arguments:
       </p>
       <div class="wrap-content">
-        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+        <div class="wrapper"><pre class="prettyprint"><code class="language-bash">
           mvn exec:java -Dexec.mainClass="com.puppycrawl.tools.checkstyle.Main" \
           &#xa0;&#xa0;&#xa0;&#xa0;-Dexec.args="-c /sun_checks.xml src/main/java"
         </code></pre></div>
@@ -1965,7 +1965,7 @@ Checkstyle ends with 2 errors.
         Run UI application for file :
       </p>
       <div class="wrap-content">
-        <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
+        <div class="wrapper"><pre class="prettyprint"><code class="language-bash">
           mvn exec:java -Dexec.mainClass="com.puppycrawl.tools.checkstyle.gui.Main" -Dexec.args=\
           &#xa0;&#xa0;&#xa0;&#xa0;"src/main/java/com/puppycrawl/tools/checkstyle/Checker.java"
         </code></pre></div>
@@ -1974,7 +1974,7 @@ Checkstyle ends with 2 errors.
         Build all jars, and launch CLI from new build:
       </p>
       <div class="wrap-content">
-        <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
+        <div class="wrapper"><pre class="prettyprint"><code class="language-bash">
           mvn clean package -Passembly,no-validations
           java -jar target/checkstyle-X.X-SNAPSHOT-all.jar -c /sun_checks.xml MyClass.java
         </code></pre></div>
@@ -2005,7 +2005,7 @@ Checkstyle ends with 2 errors.
         </b>
       </p>
       <div class="wrap-content">
-        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+        <div class="wrapper"><pre class="prettyprint"><code class="language-bash">
           java com.puppycrawl.tools.checkstyle.Main -c /sun_checks.xml Check.java
         </code></pre></div>
       </div>
@@ -2017,7 +2017,7 @@ Checkstyle ends with 2 errors.
         </b>
       </p>
       <div class="wrap-content">
-        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+        <div class="wrapper"><pre class="prettyprint"><code class="language-bash">
           java com.puppycrawl.tools.checkstyle.Main -c /sun_checks.xml src/
         </code></pre></div>
       </div>
@@ -2030,7 +2030,7 @@ Checkstyle ends with 2 errors.
         </b>
       </p>
       <div class="wrap-content">
-        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+        <div class="wrapper"><pre class="prettyprint"><code class="language-bash">
           java -Dcheckstyle.cache.file=target/cachefile com.puppycrawl.tools.checkstyle.Main \
           &#xa0;&#xa0;&#xa0;&#xa0;-c /sun_checks.xml Check.java
         </code></pre></div>
@@ -2044,7 +2044,7 @@ Checkstyle ends with 2 errors.
         </b>
       </p>
       <div class="wrap-content">
-        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+        <div class="wrapper"><pre class="prettyprint"><code class="language-bash">
           java com.puppycrawl.tools.checkstyle.Main -c /sun_checks.xml \
           &#xa0;&#xa0;&#xa0;&#xa0;-p myCheckstyle.properties Check.java
         </code></pre></div>
@@ -2058,7 +2058,7 @@ Checkstyle ends with 2 errors.
         </b>
       </p>
       <div class="wrap-content">
-        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+        <div class="wrapper"><pre class="prettyprint"><code class="language-bash">
           java com.puppycrawl.tools.checkstyle.Main -c /sun_checks.xml -f xml \
           &#xa0;&#xa0;&#xa0;&#xa0;-o build/checkstyle_errors.xml Check.java
         </code></pre></div>
@@ -2071,7 +2071,7 @@ Checkstyle ends with 2 errors.
         </b>
       </p>
       <div class="wrap-content">
-        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+        <div class="wrapper"><pre class="prettyprint"><code class="language-bash">
           java -classpath MyCustom.jar;checkstyle-${projectVersion}-all.jar \
           &#xa0;&#xa0;&#xa0;&#xa0;com.puppycrawl.tools.checkstyle.Main -c config.xml Check.java
         </code></pre></div>

--- a/src/site/xdoc/report_issue.xml
+++ b/src/site/xdoc/report_issue.xml
@@ -66,7 +66,7 @@
         Example of report that we expect (you can skip <code>-Duser.language=en
         -Duser.country=US</code> if your default locale is English):
 
-        <div class="wrapper"><pre class="prettyprint"><code class="language-java"><![CDATA[
+        <div class="wrapper"><pre class="prettyprint"><code class="language-bash"><![CDATA[
 Check documentation: https://checkstyle.org/checks/whitespace/whitespacearound.html#WhitespaceAround
 
 /var/tmp $ javac Test.java
@@ -103,7 +103,7 @@ Expected: violation on first line.
         For Windows users, please use "type" command instead of "cat".
         Example of report that we expect:
 
-        <div class="wrapper"><pre class="prettyprint"><code class="language-xml"><![CDATA[
+        <div class="wrapper"><pre class="prettyprint"><code class="language-bash"><![CDATA[
 Check documentation: https://checkstyle.org/checks/misc/indentation.html
 
 D:\>type config.xml
@@ -173,7 +173,7 @@ expected level should be 12. [Indentation]
       <p>
         Example of Feature Request/Enhancement that we expect:
       </p>
-      <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+      <div class="wrapper"><pre class="prettyprint"><code class="language-bash">
 Check documentation: https://checkstyle.org/checks/whitespace/whitespacearound.html#WhitespaceAround
 
 Describe the problem in detail:

--- a/src/site/xdoc/writingchecks.xml
+++ b/src/site/xdoc/writingchecks.xml
@@ -629,7 +629,7 @@ public class MethodLimitCheck extends AbstractCheck
 
       <p>For Linux/Unix OS:</p>
       <div class="wrap-content">
-        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+        <div class="wrapper"><pre class="prettyprint"><code class="language-bash">
           java -classpath mycompanychecks.jar:checkstyle-${projectVersion}-all.jar \
           &#xa0;&#xa0;&#xa0;&#xa0;com.puppycrawl.tools.checkstyle.Main -c config.xml myproject
         </code></pre></div>

--- a/src/site/xdoc/writingjavadocchecks.xml.vm
+++ b/src/site/xdoc/writingjavadocchecks.xml.vm
@@ -522,14 +522,14 @@ JAVADOC -> JAVADOC [0:0]
 
           <tr>
             <td>
-              <div class="wrapper"><pre class="prettyprint"><code class="language-java"><![CDATA[
+              <div class="wrapper"><pre class="prettyprint"><code class="language-xml"><![CDATA[
 <p> First
 <p> Second
 ]]>
               </code></pre></div>
             </td>
             <td>
-              <div class="wrapper"><pre class="prettyprint"><code class="language-java"><![CDATA[
+              <div class="wrapper"><pre class="prettyprint"><code class="language-xml"><![CDATA[
 <p> First </p>
 <p> Second </p>
 ]]>
@@ -609,7 +609,7 @@ JAVADOC -> JAVADOC [0:0]
         Input:
       </p>
 
-      <div class="wrapper"><pre class="prettyprint"><code class="language-text"><![CDATA[
+      <div class="wrapper"><pre class="prettyprint"><code class="language-java"><![CDATA[
 /**
   * <body>
   * <p> This class is only meant for testing. </p>
@@ -667,7 +667,7 @@ JAVADOC -> JAVADOC [0:0]
             </td>
 
             <td>
-              <div class="wrapper"><pre class="prettyprint"><code class="language-xml"><![CDATA[
+              <div class="wrapper"><pre class="prettyprint"><code class="language-bash"><![CDATA[
 Starting audit...
 [ERROR] Test.java:11: Redundant <p> tag. [JavadocParagraph]
 Audit done.
@@ -701,7 +701,7 @@ Checkstyle ends with 1 errors.
             </td>
 
             <td>
-              <div class="wrapper"><pre class="prettyprint"><code class="language-xml"><![CDATA[
+              <div class="wrapper"><pre class="prettyprint"><code class="language-bash"><![CDATA[
 Starting audit...
 [ERROR] Test.java:4: Unclosed HTML tag found: p [JavadocParagraph]
 [ERROR] Test.java:11: Redundant <p> tag. [JavadocParagraph]

--- a/src/site/xdoc/writinglisteners.xml.vm
+++ b/src/site/xdoc/writinglisteners.xml.vm
@@ -221,7 +221,7 @@ public class VerboseListener
         Here is a truncated example of audit output from a <code> VerboseListener</code>:
       </p>
 
-      <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+      <div class="wrapper"><pre class="prettyprint"><code class="language-bash">
 Audit started.
 Started checking file 'CommonsLoggingListener.java'.
 Finished checking file 'CommonsLoggingListener.java'. Errors: 0
@@ -299,7 +299,7 @@ Audit finished. Total errors: 1
         in the current directory:
       </p>
 
-      <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+      <div class="wrapper"><pre class="prettyprint"><code class="language-bash">
 # Set root logger level to INFO and its only appender to A1.
 log4j.rootLogger=INFO, A1
 
@@ -316,7 +316,7 @@ log4j.appender.A1.layout.ConversionPattern=%-5p %c %x- %m%n
         (abbreviated) output:
       </p>
 
-      <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+      <div class="wrapper"><pre class="prettyprint"><code class="language-bash">
 INFO  com.puppycrawl...Checker  - Audit started.
 INFO  com.puppycrawl...Checker  - File "CommonsLoggingListener.java" started.
 INFO  com.puppycrawl...Checker  - File "CommonsLoggingListener.java" finished.


### PR DESCRIPTION
Fixes #16790 