### PR TITLE
Commentcheck

### DIFF
--- a/src/site/xdoc/checks/coding/variabledeclarationusagedistance.xml
+++ b/src/site/xdoc/checks/coding/variabledeclarationusagedistance.xml
@@ -76,7 +76,7 @@ public class Example1 {
   public void foo1() {
     // violation below, 'variable 'num' declaration and its first usage is 4.'
     int num;
-    final double PI;   // OK, final variables not checked
+    final double PI;   // ok, final variables not checked
     System.out.println("Statement 1");
     System.out.println("Statement 2");
     System.out.println("Statement 3");
@@ -85,9 +85,9 @@ public class Example1 {
   }
 
   public void foo2() {
-    int a;          // OK, used in different scope
-    int b;          // OK, used in different scope
-    int count = 0;  // OK, used in different scope
+    int a;          // ok, used in different scope
+    int b;          // ok, used in different scope
+    int count = 0;  // ok, used in different scope
 
     {
       System.out.println("Inside inner scope");
@@ -118,7 +118,7 @@ public class Example1 {
 public class Example2 {
 
   public void case1(long timeNow, int hh, int min) {
-    int minutes = min + 5; // Ok, No violation reported
+    int minutes = min + 5; // ok, No violation reported
     Calendar cal = Calendar.getInstance();
     cal.setTimeInMillis(timeNow);
     cal.set(Calendar.SECOND, 0);
@@ -166,8 +166,8 @@ public class Example2 {
 public class Example3 {
 
   public void foo1() {
-    int num;        // OK, distance = 4
-    final double PI;   // OK, final variables not checked
+    int num;        // ok, distance = 4
+    final double PI;   // ok, final variables not checked
     System.out.println("Statement 1");
     System.out.println("Statement 2");
     System.out.println("Statement 3");
@@ -176,9 +176,9 @@ public class Example3 {
   }
 
   public void foo2() {
-    int a;          // OK, used in different scope
-    int b;          // OK, used in different scope
-    int count = 0;  // OK, used in different scope
+    int a;          // ok, used in different scope
+    int b;          // ok, used in different scope
+    int count = 0;  // ok, used in different scope
 
     {
       System.out.println("Inside inner scope");
@@ -209,8 +209,8 @@ public class Example3 {
 public class Example4 {
 
   public void foo1() {
-    int num;        // OK, variable ignored
-    final double PI;   // OK, final variables not checked
+    int num;        // ok, variable ignored
+    final double PI;   // ok, final variables not checked
     System.out.println("Statement 1");
     System.out.println("Statement 2");
     System.out.println("Statement 3");
@@ -219,9 +219,9 @@ public class Example4 {
   }
 
   public void foo2() {
-    int a;          // OK, used in different scope
-    int b;          // OK, used in different scope
-    int count = 0;  // OK, used in different scope
+    int a;          // ok, used in different scope
+    int b;          // ok, used in different scope
+    int count = 0;  // ok, used in different scope
 
     {
       System.out.println("Inside inner scope");
@@ -251,7 +251,7 @@ public class Example5 {
   public void foo1() {
     // violation below, 'variable 'num' declaration and its first usage is 4.'
     int num;
-    final double PI;   // OK, final variables not checked
+    final double PI;   // ok, final variables not checked
     System.out.println("Statement 1");
     System.out.println("Statement 2");
     System.out.println("Statement 3");
@@ -260,8 +260,8 @@ public class Example5 {
   }
 
   public void foo2() {
-    int a;          // OK, distance = 2
-    int b;          // OK, distance = 3
+    int a;          // ok, distance = 2
+    int b;          // ok, distance = 3
     // violation below, 'variable 'count' declaration and its first usage is 4.'
     int count = 0;
 
@@ -303,9 +303,9 @@ public class Example6 {
   }
 
   public void foo2() {
-    int a;          // OK, used in different scope
-    int b;          // OK, used in different scope
-    int count = 0;  // OK, used in different scope
+    int a;          // ok, used in different scope
+    int b;          // ok, used in different scope
+    int count = 0;  // ok, used in different scope
 
     {
       System.out.println("Inside inner scope");

--- a/src/site/xdoc/filters/suppresswithnearbycommentfilter.xml
+++ b/src/site/xdoc/filters/suppresswithnearbycommentfilter.xml
@@ -149,7 +149,8 @@ public class Example2 {
 &lt;module name="Checker"&gt;
   &lt;module name="TreeWalker"&gt;
     &lt;module name="SuppressWithNearbyCommentFilter"&gt;
-      &lt;property name="commentFormat" value="OK to catch (\w+) here"/&gt;
+      &lt;property name="commentFormat"
+                value="ok,?\s*(?:allowed\s+)?to catch (\w+) here"/&gt;
       &lt;property name="checkFormat" value="IllegalCatchCheck"/&gt;
       &lt;property name="messageFormat" value="$1"/&gt;
       &lt;property name="influenceFormat" value="-1"/&gt;
@@ -166,7 +167,7 @@ public class Example3 {
       // blah blah blah
     }
     catch(RuntimeException re) {
-      // OK to catch RuntimeException here
+      // ok, allowed to catch RuntimeException here
     }
   }
 }

--- a/src/test/java/com/puppycrawl/tools/checkstyle/bdd/InlineConfigParser.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/bdd/InlineConfigParser.java
@@ -200,6 +200,20 @@ public final class InlineConfigParser {
             ConfigurationLoader.DTD_PUBLIC_CS_ID_1_3);
 
     /**
+     * ALLOWED: any code, then "// ok" or "// violation" (lowercase),
+     * optionally followed by either a space or a comma (with optional spaces)
+     * plus explanation text.
+     */
+    private static final Pattern ALLOWED_OK_VIOLATION_PATTERN =
+            Pattern.compile(".*//\\s*(ok|violation)\\b(?:[ ,]\\s*.*)?$");
+
+    /**
+     * DETECT any comment containing ok/violation in any case/spacing.
+     */
+    private static final Pattern ANY_OK_VIOLATION_PATTERN =
+            Pattern.compile(".*//\\s*(?i)(ok|violation).*");
+
+    /**
      *  Inlined configs can not be used in non-java checks, as Inlined config is java style
      *  multiline comment.
      *  Such check files needs to be permanently suppressed.
@@ -922,6 +936,13 @@ public final class InlineConfigParser {
                                       List<String> lines, boolean useFilteredViolations,
                                       int lineNo, boolean specifyViolationMessage)
             throws CheckstyleException {
+        final String line = lines.get(lineNo);
+        if (ANY_OK_VIOLATION_PATTERN.matcher(line).matches()
+                && !ALLOWED_OK_VIOLATION_PATTERN.matcher(line).matches()) {
+            throw new CheckstyleException(
+                    "Invalid format (must be \"// ok...\" or \"// violation...\"): " + line);
+        }
+
         final Matcher violationMatcher =
                 VIOLATION_PATTERN.matcher(lines.get(lineNo));
         final Matcher violationAboveMatcher =

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/whitespace/emptylineseparator/InputEmptyLineSeparatorNoViolationOnEmptyLineBeforeComments.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/whitespace/emptylineseparator/InputEmptyLineSeparatorNoViolationOnEmptyLineBeforeComments.java
@@ -52,8 +52,7 @@ public class InputEmptyLineSeparatorNoViolationOnEmptyLineBeforeComments {
 
     // Should
     // not
-    // have
-    // oks
+    // have ok
     public int testNoViolation3 = 3;
 
     /*

--- a/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/coding/variabledeclarationusagedistance/Example1.java
+++ b/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/coding/variabledeclarationusagedistance/Example1.java
@@ -15,7 +15,7 @@ public class Example1 {
   public void foo1() {
     // violation below, 'variable 'num' declaration and its first usage is 4.'
     int num;
-    final double PI;   // OK, final variables not checked
+    final double PI;   // ok, final variables not checked
     System.out.println("Statement 1");
     System.out.println("Statement 2");
     System.out.println("Statement 3");
@@ -24,9 +24,9 @@ public class Example1 {
   }
 
   public void foo2() {
-    int a;          // OK, used in different scope
-    int b;          // OK, used in different scope
-    int count = 0;  // OK, used in different scope
+    int a;          // ok, used in different scope
+    int b;          // ok, used in different scope
+    int count = 0;  // ok, used in different scope
 
     {
       System.out.println("Inside inner scope");

--- a/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/coding/variabledeclarationusagedistance/Example2.java
+++ b/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/coding/variabledeclarationusagedistance/Example2.java
@@ -14,7 +14,7 @@ import java.util.Calendar;
 public class Example2 {
 
   public void case1(long timeNow, int hh, int min) {
-    int minutes = min + 5; // Ok, No violation reported
+    int minutes = min + 5; // ok, No violation reported
     Calendar cal = Calendar.getInstance();
     cal.setTimeInMillis(timeNow);
     cal.set(Calendar.SECOND, 0);

--- a/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/coding/variabledeclarationusagedistance/Example3.java
+++ b/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/coding/variabledeclarationusagedistance/Example3.java
@@ -13,8 +13,8 @@ package com.puppycrawl.tools.checkstyle.checks.coding.variabledeclarationusagedi
 public class Example3 {
 
   public void foo1() {
-    int num;        // OK, distance = 4
-    final double PI;   // OK, final variables not checked
+    int num;        // ok, distance = 4
+    final double PI;   // ok, final variables not checked
     System.out.println("Statement 1");
     System.out.println("Statement 2");
     System.out.println("Statement 3");
@@ -23,9 +23,9 @@ public class Example3 {
   }
 
   public void foo2() {
-    int a;          // OK, used in different scope
-    int b;          // OK, used in different scope
-    int count = 0;  // OK, used in different scope
+    int a;          // ok, used in different scope
+    int b;          // ok, used in different scope
+    int count = 0;  // ok, used in different scope
 
     {
       System.out.println("Inside inner scope");

--- a/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/coding/variabledeclarationusagedistance/Example4.java
+++ b/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/coding/variabledeclarationusagedistance/Example4.java
@@ -13,8 +13,8 @@ package com.puppycrawl.tools.checkstyle.checks.coding.variabledeclarationusagedi
 public class Example4 {
 
   public void foo1() {
-    int num;        // OK, variable ignored
-    final double PI;   // OK, final variables not checked
+    int num;        // ok, variable ignored
+    final double PI;   // ok, final variables not checked
     System.out.println("Statement 1");
     System.out.println("Statement 2");
     System.out.println("Statement 3");
@@ -23,9 +23,9 @@ public class Example4 {
   }
 
   public void foo2() {
-    int a;          // OK, used in different scope
-    int b;          // OK, used in different scope
-    int count = 0;  // OK, used in different scope
+    int a;          // ok, used in different scope
+    int b;          // ok, used in different scope
+    int count = 0;  // ok, used in different scope
 
     {
       System.out.println("Inside inner scope");

--- a/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/coding/variabledeclarationusagedistance/Example5.java
+++ b/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/coding/variabledeclarationusagedistance/Example5.java
@@ -15,7 +15,7 @@ public class Example5 {
   public void foo1() {
     // violation below, 'variable 'num' declaration and its first usage is 4.'
     int num;
-    final double PI;   // OK, final variables not checked
+    final double PI;   // ok, final variables not checked
     System.out.println("Statement 1");
     System.out.println("Statement 2");
     System.out.println("Statement 3");
@@ -24,8 +24,8 @@ public class Example5 {
   }
 
   public void foo2() {
-    int a;          // OK, distance = 2
-    int b;          // OK, distance = 3
+    int a;          // ok, distance = 2
+    int b;          // ok, distance = 3
     // violation below, 'variable 'count' declaration and its first usage is 4.'
     int count = 0;
 

--- a/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/coding/variabledeclarationusagedistance/Example6.java
+++ b/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/coding/variabledeclarationusagedistance/Example6.java
@@ -25,9 +25,9 @@ public class Example6 {
   }
 
   public void foo2() {
-    int a;          // OK, used in different scope
-    int b;          // OK, used in different scope
-    int count = 0;  // OK, used in different scope
+    int a;          // ok, used in different scope
+    int b;          // ok, used in different scope
+    int count = 0;  // ok, used in different scope
 
     {
       System.out.println("Inside inner scope");

--- a/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/filters/suppresswithnearbycommentfilter/Example3.java
+++ b/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/filters/suppresswithnearbycommentfilter/Example3.java
@@ -2,7 +2,8 @@
 <module name="Checker">
   <module name="TreeWalker">
     <module name="SuppressWithNearbyCommentFilter">
-      <property name="commentFormat" value="OK to catch (\w+) here"/>
+      <property name="commentFormat"
+                value="ok,?\s*(?:allowed\s+)?to catch (\w+) here"/>
       <property name="checkFormat" value="IllegalCatchCheck"/>
       <property name="messageFormat" value="$1"/>
       <property name="influenceFormat" value="-1"/>
@@ -19,7 +20,7 @@ public class Example3 {
       // blah blah blah
     }
     catch(RuntimeException re) {
-      // OK to catch RuntimeException here
+      // ok, allowed to catch RuntimeException here
     }
   }
 }


### PR DESCRIPTION
#11249 

**✅ Allowed (will pass the check)**
```
// ok
// ok explanation
// ok, explanation
someCode(); // ok
foo();      // ok, because we know it’s safe
```
```
// violation
// violation explanation
// violation, missing semicolon
bar();      // violation, need to handle this
```

**🚫 Flagged (will fail the check)**

```
//OK                          ← uppercase
// OK                         ← uppercase
//ok                          ← no space before word
//violation                   ← no space before word
//okapi                       ← glued into larger word
// violationBad               ← glued word
// Violation                   ← uppercase
foo(); // Violation, reason  ← uppercase V
someCode(); // OK, reason     ← uppercase OK
//VIOLATION                   ← uppercase Letters
```

InlineConfigParser: added `ALLOWED_OK_VIOLATION_PATTERN + ANY_OK_VIOLATION_PATTERN` and a top‐of‐`setViolations(...)` guard to reject any comment that contains the words ok or violation but doesn’t exactly match one of these two allowed forms (all lowercase, one space, optional comma/explanation).

Checkstyle config (config/checkstyle_checks.xml)
Added a new `<module name="RegexpSingleline" id="okViolationCommentFormat">` under `<module name="Checker">`
Regex anchored to // ok or // violation (lowercase, one space) with a negative look‐ahead forbidding all other forms.

Testing on local Output:
Introduced few wrong comment patterns:
![okays](https://github.com/user-attachments/assets/39bf93f4-cd56-4a15-8780-8bbfff11a470)
![vilation](https://github.com/user-attachments/assets/ee9c40e2-568c-4288-87b6-ab367616a451)
