### PR TITLE
Issue #16880: Update IndentationCheckTest.testTextBlockLiteral to use verifyWarns

### DIFF
--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/indentation/IndentationCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/indentation/IndentationCheckTest.java
@@ -1262,6 +1262,7 @@ public class IndentationCheckTest extends AbstractModuleTestSupport {
         verifyWarns(checkConfig, getPath("InputIndentationNew.java"), expected);
     }
 
+    // we can not use verifyWarns() due to usage of multi line string syntax in input
     @Test
     public void testTextBlockLiteral() throws Exception {
         final DefaultConfiguration checkConfig = createModuleConfig(IndentationCheck.class);


### PR DESCRIPTION
Fix #16880

Updated `testTextBlockLiteral()` to use `verifyWarns()` method.