### PR TITLE
Issue #16880: Update IndentationCheckTest.testMethodPrecedeByAnnotationsWithParameterOnSeparateLine to use verifyWarns

### DIFF
--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/indentation/IndentationCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/indentation/IndentationCheckTest.java
@@ -2975,7 +2975,7 @@ public class IndentationCheckTest extends AbstractModuleTestSupport {
         final String fileName =
             getPath("InputIndentationMethodPrecededByAnnotationWithParameterOnSeparateLine.java");
         final String[] expected = CommonUtil.EMPTY_STRING_ARRAY;
-        verify(checkConfig, fileName, expected);
+        verifyWarns(checkConfig, fileName, expected);
     }
 
     @Test


### PR DESCRIPTION
Fix #16880 

Updated `testMethodPrecedeByAnnotationsWithParameterOnSeparateLine()` to use `verifyWarns()`.