### PR TITLE
Issue #16880: Update IndentationCheckTest.testAnnotationIncorrect to use verifyWarns

### DIFF
--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/indentation/IndentationCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/indentation/IndentationCheckTest.java
@@ -2992,7 +2992,7 @@ public class IndentationCheckTest extends AbstractModuleTestSupport {
             "14:9: " + getCheckMessage(MSG_ERROR, "(", 8, 12),
             "19:5: " + getCheckMessage(MSG_ERROR, "(", 4, 8),
         };
-        verify(checkConfig, fileName, expected);
+        verifyWarns(checkConfig, fileName, expected);
     }
 
     @Test

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/indentation/indentation/InputIndentationAnnotationIncorrect.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/indentation/indentation/InputIndentationAnnotationIncorrect.java
@@ -8,15 +8,15 @@ class InputIndentationAnnotationIncorrect { //indent:0 exp:0
 
     @MyAnnotation2 //indent:4 exp:4
     @MyAnnotation1 //indent:4 exp:4
-    (value = "") //indent:4 exp:8
+    (value = "") //indent:4 exp:8 warn
     class innerClass { //indent:4 exp:4
         @MyAnnotation2 @MyAnnotation1 //indent:8 exp:8
-        (value = "") //indent:8 exp:12
+        (value = "") //indent:8 exp:12 warn
         public int a; //indent:8 exp:8
     } //indent:4 exp:4
 
     @MyAnnotation2 @MyAnnotation1 //indent:4 exp:4
-    (value = "") //indent:4 exp:8
+    (value = "") //indent:4 exp:8 warn
     class InputIndentationAnnotationInnerClass { //indent:4 exp:4
 
     } //indent:4 exp:4


### PR DESCRIPTION
Fix #16880

Updated `testAnnotationIncorrect()` to use `verifyWarns()`.
