### PR TITLE
Issue #13132: Removed config_ prefix condition

### DIFF
--- a/src/test/java/com/puppycrawl/tools/checkstyle/internal/utils/XdocUtil.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/internal/utils/XdocUtil.java
@@ -97,9 +97,7 @@ public final class XdocUtil {
         final Set<Path> xdocs = new HashSet<>();
         for (Path entry : files) {
             final String fileName = entry.getFileName().toString();
-            // until https://github.com/checkstyle/checkstyle/issues/13132
-            if (fileName.startsWith("config_")
-                    || !entry.getParent().toString().matches("src[\\\\/]site[\\\\/]xdocs")
+            if (!entry.getParent().toString().matches("src[\\\\/]site[\\\\/]xdocs")
                     && fileName.endsWith(".xml")) {
                 xdocs.add(entry);
             }


### PR DESCRIPTION
References issue #13132 

The build was locally successful and no anomalies were detected after the changes were made. 
lets see with CI/CD

---

### context
the issue was based on the comment's 
👉 https://github.com/checkstyle/checkstyle/pull/13103#discussion_r1213522514
👉 https://github.com/checkstyle/checkstyle/issues/13097#issuecomment-1566508439

from my perspective comments' indicates that earlier  a task was carried out to split  xdoc modules into separate pages , and the new files were decided to have this `xdoc/checks/<category>/<check> - xdoc/checks/naming/abstractclassname.xml ` structure , and dropping the earlier where `config_` prefix was used .
and all the conditions where we checked for that prefix were not needed and hence needed to be removed.

@Zopsss review requested