### PR TITLE
Issue #16981: `Migrate to Java 21 - 'collect(toUnmodifiableList())' can be replaced with 'toList()'`

### DIFF
--- a/config/checker-framework-suppressions/checker-nullness-optional-interning-suppressions.xml
+++ b/config/checker-framework-suppressions/checker-nullness-optional-interning-suppressions.xml
@@ -5487,22 +5487,6 @@
   </checkerFrameworkError>
 
   <checkerFrameworkError unstable="false">
-    <fileName>src/main/java/com/puppycrawl/tools/checkstyle/filters/XpathFilterElement.java</fileName>
-    <specifier>type.arguments.not.inferred</specifier>
-    <message>Could not infer type arguments for Stream.collect</message>
-    <lineContent>.collect(Collectors.toUnmodifiableList());</lineContent>
-    <details>
-      unsatisfiable constraint: @Initialized @PolyNull AbstractNode &lt;: @Initialized @NonNull AbstractNode
-      use of T from Collectors.toUnmodifiableList() = @Initialized @NonNull AbstractNode
-      From complementary bound.: use of T from Collectors.toUnmodifiableList() &lt;= @Initialized @NonNull AbstractNode
-      inference type: java.util.List&lt;T&gt; &lt;: @UnknownInitialization @Nullable List&lt;@Initialized @NonNull AbstractNode&gt;
-      use of R from getItems(event).stream().map(AbstractNode.class::cast).collect(Collectors.toUnmodifiableList()) &lt;: @UnknownInitialization @Nullable List&lt;@Initialized @NonNull AbstractNode&gt;
-      From complementary bound.: use of R from getItems(event).stream().map(AbstractNode.class::cast).collect(Collectors.toUnmodifiableList()) -&gt; @UnknownInitialization @Nullable List&lt;@Initialized @NonNull AbstractNode&gt;
-      From: Constraint between method call type and target type for method call:getItems(event).stream().map(AbstractNode.class::cast).collect(Collectors.toUnmodifiableList())
-    </details>
-  </checkerFrameworkError>
-
-  <checkerFrameworkError unstable="false">
     <fileName>src/main/java/com/puppycrawl/tools/checkstyle/gui/BaseCellEditor.java</fileName>
     <specifier>return</specifier>
     <message>incompatible types in return.</message>

--- a/src/it/java/org/checkstyle/base/AbstractItModuleTestSupport.java
+++ b/src/it/java/org/checkstyle/base/AbstractItModuleTestSupport.java
@@ -536,10 +536,10 @@ public abstract class AbstractItModuleTestSupport extends AbstractPathTestSuppor
         final List<Integer> actualViolationLines = actualViolations.stream()
                 .map(violation -> violation.substring(0, violation.indexOf(':')))
                 .map(Integer::valueOf)
-                .collect(Collectors.toUnmodifiableList());
+                .toList();
         final List<Integer> expectedViolationLines = testInputViolations.stream()
                 .map(TestInputViolation::getLineNo)
-                .collect(Collectors.toUnmodifiableList());
+                .toList();
         assertWithMessage("Violation lines for %s differ.", file)
                 .that(actualViolationLines)
                 .isEqualTo(expectedViolationLines);

--- a/src/main/java/com/puppycrawl/tools/checkstyle/Checker.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/Checker.java
@@ -222,7 +222,7 @@ public class Checker extends AbstractAutomaticBean implements MessageDispatcher,
 
         final List<File> targetFiles = files.stream()
                 .filter(file -> CommonUtil.matchesFileExtension(file, fileExtensions))
-                .collect(Collectors.toUnmodifiableList());
+                .toList();
         processFiles(targetFiles);
 
         // Finish up

--- a/src/main/java/com/puppycrawl/tools/checkstyle/JavaAstVisitor.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/JavaAstVisitor.java
@@ -421,7 +421,7 @@ public final class JavaAstVisitor extends JavaLanguageParserBaseVisitor<DetailAs
         // Process all children except C style array declarators
         processChildren(methodDef, ctx.children.stream()
                 .filter(child -> !(child instanceof JavaLanguageParser.ArrayDeclaratorContext))
-                .collect(Collectors.toUnmodifiableList()));
+                .toList());
 
         // We add C style array declarator brackets to TYPE ast
         final DetailAstImpl typeAst = (DetailAstImpl) methodDef.findFirstToken(TokenTypes.TYPE);
@@ -485,7 +485,7 @@ public final class JavaAstVisitor extends JavaLanguageParserBaseVisitor<DetailAs
         final List<ParseTree> children = ctx.children
                 .stream()
                 .filter(child -> !(child instanceof JavaLanguageParser.ArrayDeclaratorContext))
-                .collect(Collectors.toUnmodifiableList());
+                .toList();
         processChildren(methodDef, children);
 
         // We add C style array declarator brackets to TYPE ast
@@ -836,7 +836,7 @@ public final class JavaAstVisitor extends JavaLanguageParserBaseVisitor<DetailAs
         // Process all children except C style array declarators
         processChildren(annotationFieldDef, ctx.children.stream()
                 .filter(child -> !(child instanceof JavaLanguageParser.ArrayDeclaratorContext))
-                .collect(Collectors.toUnmodifiableList()));
+                .toList());
 
         // We add C style array declarator brackets to TYPE ast
         final DetailAstImpl typeAst =
@@ -883,7 +883,7 @@ public final class JavaAstVisitor extends JavaLanguageParserBaseVisitor<DetailAs
         // filter 'LITERAL_SUPER'
         processChildren(primaryCtorCall, ctx.children.stream()
                    .filter(child -> !child.equals(ctx.LITERAL_SUPER()))
-                   .collect(Collectors.toUnmodifiableList()));
+                   .toList());
         return primaryCtorCall;
     }
 
@@ -1121,7 +1121,7 @@ public final class JavaAstVisitor extends JavaLanguageParserBaseVisitor<DetailAs
         // filter mods
         processChildren(catchParameterDef, ctx.children.stream()
                 .filter(child -> !(child instanceof JavaLanguageParser.VariableModifierContext))
-                .collect(Collectors.toUnmodifiableList()));
+                .toList());
         return catchParameterDef;
     }
 
@@ -1556,7 +1556,7 @@ public final class JavaAstVisitor extends JavaLanguageParserBaseVisitor<DetailAs
                 (Token) ctx.DOUBLE_COLON().getPayload());
         final List<ParseTree> children = ctx.children.stream()
                 .filter(child -> !child.equals(ctx.DOUBLE_COLON()))
-                .collect(Collectors.toUnmodifiableList());
+                .toList();
         processChildren(doubleColon, children);
         return doubleColon;
     }
@@ -1566,7 +1566,7 @@ public final class JavaAstVisitor extends JavaLanguageParserBaseVisitor<DetailAs
         final DetailAstImpl root = create(ctx.QUESTION());
         processChildren(root, ctx.children.stream()
                 .filter(child -> !child.equals(ctx.QUESTION()))
-                .collect(Collectors.toUnmodifiableList()));
+                .toList());
         return root;
     }
 

--- a/src/main/java/com/puppycrawl/tools/checkstyle/PackageObjectFactory.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/PackageObjectFactory.java
@@ -389,7 +389,7 @@ public class PackageObjectFactory implements ModuleFactory {
         final List<String> possibleNames = packages.stream()
             .map(packageName -> packageName + PACKAGE_SEPARATOR + name)
             .flatMap(className -> Stream.of(className, className + CHECK_SUFFIX))
-            .collect(Collectors.toUnmodifiableList());
+            .toList();
         Object instance = null;
         for (String possibleName : possibleNames) {
             instance = createObject(possibleName);

--- a/src/main/java/com/puppycrawl/tools/checkstyle/ant/CheckstyleAntTask.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/ant/CheckstyleAntTask.java
@@ -498,7 +498,7 @@ public class CheckstyleAntTask extends Task {
         final List<Path> filesFromPaths = scanPaths();
         allFiles.addAll(filesFromPaths.stream()
             .map(Path::toFile)
-            .collect(Collectors.toUnmodifiableList()));
+            .toList());
 
         return allFiles;
     }
@@ -573,7 +573,7 @@ public class CheckstyleAntTask extends Task {
 
         return allFiles.stream()
             .map(Path::toFile)
-            .collect(Collectors.toUnmodifiableList());
+            .toList();
     }
 
     /**
@@ -591,7 +591,7 @@ public class CheckstyleAntTask extends Task {
 
         return Arrays.stream(fileNames)
           .map(scanner.getBasedir().toPath()::resolve)
-          .collect(Collectors.toUnmodifiableList());
+          .toList();
     }
 
     /**

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/ConstructorsDeclarationGroupingCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/ConstructorsDeclarationGroupingCheck.java
@@ -121,7 +121,7 @@ public class ConstructorsDeclarationGroupingCheck extends AbstractCheck {
             // create a list of all constructors that are not grouped to log
             final List<DetailAST> constructorsToLog = childrenAfterFirstNonConstructor.stream()
                     .filter(ConstructorsDeclarationGroupingCheck::isConstructor)
-                    .collect(Collectors.toUnmodifiableList());
+                    .toList();
 
             // find the last grouped constructor
             final DetailAST lastGroupedConstructor = childrenAfterFirstConstructor.stream()

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/MatchXpathCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/MatchXpathCheck.java
@@ -160,7 +160,7 @@ public class MatchXpathCheck extends AbstractCheck {
             final List<Item> matchingItems = xpathExpression.evaluate(xpathDynamicContext);
             return matchingItems.stream()
                     .map(item -> (DetailAST) ((AbstractNode) item).getUnderlyingNode())
-                    .collect(Collectors.toUnmodifiableList());
+                    .toList();
         }
         catch (XPathException ex) {
             throw new IllegalStateException("Evaluation of Xpath query failed: " + query, ex);

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/UnusedLocalVariableCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/UnusedLocalVariableCheck.java
@@ -600,7 +600,7 @@ public class UnusedLocalVariableCheck extends AbstractCheck {
                 .filter(typeDeclDesc -> {
                     return hasSameNameAsSuperClass(superClassName, typeDeclDesc);
                 })
-                .collect(Collectors.toUnmodifiableList());
+                .toList();
     }
 
     /**

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/imports/UnusedImportsCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/imports/UnusedImportsCheck.java
@@ -366,7 +366,7 @@ public class UnusedImportsCheck extends AbstractCheck {
         final List<JavadocTag> blockTags = getTargetTags(textBlock,
                 JavadocUtil.JavadocTagType.BLOCK);
         final List<JavadocTag> targetTags = Stream.concat(inlineTags.stream(), blockTags.stream())
-                .collect(Collectors.toUnmodifiableList());
+                .toList();
 
         final Set<String> references = new HashSet<>();
 
@@ -393,7 +393,7 @@ public class UnusedImportsCheck extends AbstractCheck {
             .filter(tag -> isMatchingTagType(tag, javadocTagType))
             .map(UnusedImportsCheck::bestTryToMatchReference)
             .flatMap(Optional::stream)
-            .collect(Collectors.toUnmodifiableList());
+            .toList();
     }
 
     /**

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/AbstractJavadocCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/AbstractJavadocCheck.java
@@ -196,7 +196,7 @@ public abstract class AbstractJavadocCheck extends AbstractCheck {
         if (javadocTokens.isEmpty()) {
             javadocTokens.addAll(
                     Arrays.stream(getDefaultJavadocTokens()).boxed()
-                        .collect(Collectors.toUnmodifiableList()));
+                        .toList());
         }
         else {
             final int[] acceptableJavadocTokens = getAcceptableJavadocTokens();
@@ -225,7 +225,7 @@ public abstract class AbstractJavadocCheck extends AbstractCheck {
         final List<Integer> missingRequiredTokenNames = Arrays.stream(getRequiredJavadocTokens())
                 .boxed()
                 .filter(token -> !defaultTokens.contains(token))
-                .collect(Collectors.toUnmodifiableList());
+                .toList();
 
         if (!missingRequiredTokenNames.isEmpty()) {
             final String message = String.format(Locale.ROOT,

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/metrics/AbstractClassCouplingCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/metrics/AbstractClassCouplingCheck.java
@@ -169,7 +169,7 @@ public abstract class AbstractClassCouplingCheck extends AbstractCheck {
     public final void setExcludedPackages(String... excludedPackages) {
         final List<String> invalidIdentifiers = Arrays.stream(excludedPackages)
             .filter(Predicate.not(CommonUtil::isName))
-            .collect(Collectors.toUnmodifiableList());
+            .toList();
         if (!invalidIdentifiers.isEmpty()) {
             throw new IllegalArgumentException(
                 "the following values are not valid identifiers: " + invalidIdentifiers);

--- a/src/main/java/com/puppycrawl/tools/checkstyle/filters/XpathFilterElement.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/filters/XpathFilterElement.java
@@ -168,7 +168,7 @@ public class XpathFilterElement implements TreeWalkerFilter {
             isMatching = false;
             final List<AbstractNode> nodes = getItems(event)
                 .stream().map(AbstractNode.class::cast)
-                .collect(Collectors.toUnmodifiableList());
+                .toList();
             for (AbstractNode abstractNode : nodes) {
                 isMatching = abstractNode.getTokenType() == event.getTokenType()
                         && abstractNode.getLineNumber() == event.getLine()

--- a/src/main/java/com/puppycrawl/tools/checkstyle/meta/MetadataGeneratorUtil.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/meta/MetadataGeneratorUtil.java
@@ -98,7 +98,7 @@ public final class MetadataGeneratorUtil {
                                     || fileName.endsWith("Check.java")
                                     || fileName.endsWith("Filter.java");
                         })
-                        .collect(Collectors.toUnmodifiableList()));
+                        .toList());
             }
         }
 

--- a/src/main/java/com/puppycrawl/tools/checkstyle/site/PropertiesMacro.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/site/PropertiesMacro.java
@@ -348,7 +348,7 @@ public class PropertiesMacro extends AbstractMacro {
                                 check.getRequiredTokens())
                         .stream()
                         .map(TokenUtil::getTokenName)
-                        .collect(Collectors.toUnmodifiableList());
+                        .toList();
                 sink.text("subset of tokens");
 
                 writeTokensList(sink, configurableTokens, SiteUtil.PATH_TO_TOKEN_TYPES, true);
@@ -361,7 +361,7 @@ public class PropertiesMacro extends AbstractMacro {
                             check.getRequiredJavadocTokens())
                     .stream()
                     .map(JavadocUtil::getTokenName)
-                    .collect(Collectors.toUnmodifiableList());
+                    .toList();
             sink.text("subset of javadoc tokens");
             writeTokensList(sink, configurableTokens, SiteUtil.PATH_TO_JAVADOC_TOKEN_TYPES, true);
         }
@@ -503,7 +503,7 @@ public class PropertiesMacro extends AbstractMacro {
                                 check.getRequiredTokens())
                         .stream()
                         .map(TokenUtil::getTokenName)
-                        .collect(Collectors.toUnmodifiableList());
+                        .toList();
                 writeTokensList(sink, configurableTokens, SiteUtil.PATH_TO_TOKEN_TYPES, true);
             }
         }
@@ -514,7 +514,7 @@ public class PropertiesMacro extends AbstractMacro {
                             check.getRequiredJavadocTokens())
                     .stream()
                     .map(JavadocUtil::getTokenName)
-                    .collect(Collectors.toUnmodifiableList());
+                    .toList();
             writeTokensList(sink, configurableTokens, SiteUtil.PATH_TO_JAVADOC_TOKEN_TYPES, true);
         }
         else {

--- a/src/main/java/com/puppycrawl/tools/checkstyle/site/SiteUtil.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/site/SiteUtil.java
@@ -1219,7 +1219,7 @@ public final class SiteUtil {
         return Arrays.stream(tokens)
                 .boxed()
                 .filter(token -> !subtractionsSet.contains(token))
-                .collect(Collectors.toUnmodifiableList());
+                .toList();
     }
 
     /**

--- a/src/main/java/com/puppycrawl/tools/checkstyle/utils/UnmodifiableCollectionUtil.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/utils/UnmodifiableCollectionUtil.java
@@ -66,7 +66,7 @@ public final class UnmodifiableCollectionUtil {
     public static <S, T> List<T> unmodifiableList(Collection<S> items, Class<T> elementType) {
         return items.stream()
                 .map(elementType::cast)
-                .collect(Collectors.toUnmodifiableList());
+                .toList();
     }
 
     /**

--- a/src/main/java/com/puppycrawl/tools/checkstyle/xpath/XpathQueryGenerator.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/xpath/XpathQueryGenerator.java
@@ -145,7 +145,7 @@ public class XpathQueryGenerator {
         return getMatchingAstElements()
             .stream()
             .map(XpathQueryGenerator::generateXpathQuery)
-            .collect(Collectors.toUnmodifiableList());
+            .toList();
     }
 
     /**

--- a/src/test/java/com/puppycrawl/tools/checkstyle/AbstractAutomaticBeanTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/AbstractAutomaticBeanTest.java
@@ -291,7 +291,7 @@ public class AbstractAutomaticBeanTest {
 
         final List<String> actualPatternStrings = Arrays.stream(bean.patterns)
                 .map(Pattern::pattern)
-                .collect(Collectors.toUnmodifiableList());
+                .toList();
 
         assertWithMessage("invalid size of result")
                 .that(bean.patterns)
@@ -312,7 +312,7 @@ public class AbstractAutomaticBeanTest {
 
         final List<String> actualPatternStrings = Arrays.stream(bean.patterns)
                 .map(Pattern::pattern)
-                .collect(Collectors.toUnmodifiableList());
+                .toList();
 
         assertWithMessage("invalid size of result")
                 .that(bean.patterns)

--- a/src/test/java/com/puppycrawl/tools/checkstyle/AbstractModuleTestSupport.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/AbstractModuleTestSupport.java
@@ -542,7 +542,7 @@ public abstract class AbstractModuleTestSupport extends AbstractPathTestSupport 
         final Checker checker = createChecker(config);
         final List<File> files = Arrays.stream(filenames)
                 .map(File::new)
-                .collect(Collectors.toUnmodifiableList());
+                .toList();
         checker.process(files);
         checker.destroy();
     }
@@ -557,7 +557,7 @@ public abstract class AbstractModuleTestSupport extends AbstractPathTestSupport 
     protected static void execute(Checker checker, String... filenames) throws Exception {
         final List<File> files = Arrays.stream(filenames)
                 .map(File::new)
-                .collect(Collectors.toUnmodifiableList());
+                .toList();
         checker.process(files);
         checker.destroy();
     }
@@ -578,10 +578,10 @@ public abstract class AbstractModuleTestSupport extends AbstractPathTestSupport 
         final List<Integer> actualViolationLines = actualViolations.stream()
                 .map(violation -> violation.substring(0, violation.indexOf(':')))
                 .map(Integer::valueOf)
-                .collect(Collectors.toUnmodifiableList());
+                .toList();
         final List<Integer> expectedViolationLines = testInputViolations.stream()
                 .map(TestInputViolation::getLineNo)
-                .collect(Collectors.toUnmodifiableList());
+                .toList();
         assertWithMessage("Violation lines for %s differ.", file)
                 .that(actualViolationLines)
                 .isEqualTo(expectedViolationLines);
@@ -605,10 +605,10 @@ public abstract class AbstractModuleTestSupport extends AbstractPathTestSupport 
         final List<Integer> actualViolationLines = actualViolations.stream()
                 .map(violation -> violation.substring(0, violation.indexOf(':')))
                 .map(Integer::valueOf)
-                .collect(Collectors.toUnmodifiableList());
+                .toList();
         final List<Integer> expectedViolationLines = testInputViolations.stream()
                 .map(TestInputViolation::getLineNo)
-                .collect(Collectors.toUnmodifiableList());
+                .toList();
         assertWithMessage("Violation lines for %s differ.", file)
                 .that(actualViolationLines)
                 .isEqualTo(expectedViolationLines);

--- a/src/test/java/com/puppycrawl/tools/checkstyle/CheckerTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/CheckerTest.java
@@ -1610,7 +1610,7 @@ public class CheckerTest extends AbstractModuleTestSupport {
                     .filter(line -> !getCheckMessage(AUDIT_FINISHED_MESSAGE).equals(line))
                     .limit(expected.length)
                     .sorted()
-                    .collect(Collectors.toUnmodifiableList());
+                    .toList();
             Arrays.sort(expected);
 
             for (int i = 0; i < expected.length; i++) {

--- a/src/test/java/com/puppycrawl/tools/checkstyle/bdd/InlineConfigParser.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/bdd/InlineConfigParser.java
@@ -512,7 +512,7 @@ public final class InlineConfigParser {
         return lines.stream()
                 .skip(1)
                 .takeWhile(line -> !line.startsWith("*/"))
-                .collect(Collectors.toUnmodifiableList());
+                .toList();
     }
 
     private static void handleXmlConfig(TestInputConfiguration.Builder testInputConfigBuilder,

--- a/src/test/java/com/puppycrawl/tools/checkstyle/grammar/GeneratedJavaTokenTypesTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/grammar/GeneratedJavaTokenTypesTest.java
@@ -772,7 +772,7 @@ public class GeneratedJavaTokenTypesTest {
         final String[] nullableSymbolicNames = vocabulary.getSymbolicNames();
         final List<String> allTokenNames = Arrays.stream(nullableSymbolicNames)
                 .filter(Objects::nonNull)
-                .collect(Collectors.toUnmodifiableList());
+                .toList();
 
         // Get the starting index of the sublist of tokens, or -1 if sublist
         // is not present.

--- a/src/test/java/com/puppycrawl/tools/checkstyle/internal/CliOptionsXdocsSyncTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/internal/CliOptionsXdocsSyncTest.java
@@ -139,7 +139,7 @@ public class CliOptionsXdocsSyncTest {
             final Set<Node> rows = XmlUtil.findChildElementsByTag(tbodyNode, "tr");
             final List<List<Node>> columns = rows.stream()
                     .map(row -> new ArrayList<>(XmlUtil.getChildrenElements(row)))
-                    .collect(Collectors.toUnmodifiableList());
+                    .toList();
             for (List<Node> column : columns) {
                 final Node command = column.get(1);
                 final Node description = column.get(2);

--- a/src/test/java/com/puppycrawl/tools/checkstyle/internal/CommitValidationTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/internal/CommitValidationTest.java
@@ -319,7 +319,7 @@ public class CommitValidationTest {
         final Spliterator<RevCommit> spliterator =
             Spliterators.spliteratorUnknownSize(previousCommitsIterator, Spliterator.ORDERED);
         return StreamSupport.stream(spliterator, false).limit(PREVIOUS_COMMITS_TO_CHECK_COUNT)
-            .collect(Collectors.toUnmodifiableList());
+            .toList();
     }
 
     private static List<RevCommit> getCommitsByLastCommitAuthor(

--- a/src/test/java/com/puppycrawl/tools/checkstyle/internal/XdocsPagesTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/internal/XdocsPagesTest.java
@@ -404,7 +404,7 @@ public class XdocsPagesTest {
                 final List<String> groupNames = getNames(current);
                 final List<String> groupNamesSorted = groupNames.stream()
                         .sorted()
-                        .collect(Collectors.toUnmodifiableList());
+                        .toList();
 
                 assertWithMessage("Group" + NAMES_MUST_BE_IN_ALPHABETICAL_ORDER_SITE_PATH)
                         .that(groupNames)
@@ -419,7 +419,7 @@ public class XdocsPagesTest {
                         final List<String> checkNames = getNames(groupNode);
                         final List<String> checkNamesSorted = checkNames.stream()
                                 .sorted()
-                                .collect(Collectors.toUnmodifiableList());
+                                .toList();
                         assertWithMessage("Check" + NAMES_MUST_BE_IN_ALPHABETICAL_ORDER_SITE_PATH)
                                 .that(checkNames)
                                 .containsExactlyElementsIn(checkNamesSorted)
@@ -433,7 +433,7 @@ public class XdocsPagesTest {
                 final List<String> filterNames = getNames(current);
                 final List<String> filterNamesSorted = filterNames.stream()
                         .sorted()
-                        .collect(Collectors.toUnmodifiableList());
+                        .toList();
                 assertWithMessage("Filter" + NAMES_MUST_BE_IN_ALPHABETICAL_ORDER_SITE_PATH)
                         .that(filterNames)
                         .containsExactlyElementsIn(filterNamesSorted)
@@ -443,7 +443,7 @@ public class XdocsPagesTest {
                 final List<String> fileFilterNames = getNames(current);
                 final List<String> fileFilterNamesSorted = fileFilterNames.stream()
                         .sorted()
-                        .collect(Collectors.toUnmodifiableList());
+                        .toList();
                 assertWithMessage("File Filter" + NAMES_MUST_BE_IN_ALPHABETICAL_ORDER_SITE_PATH)
                         .that(fileFilterNames)
                         .containsExactlyElementsIn(fileFilterNamesSorted)
@@ -481,7 +481,7 @@ public class XdocsPagesTest {
             final List<String> names = getNamesFromIndexPage(current);
             final List<String> namesSorted = names.stream()
                     .sorted()
-                    .collect(Collectors.toUnmodifiableList());
+                    .toList();
 
             assertWithMessage(name + NAMES_MUST_BE_IN_ALPHABETICAL_ORDER_SITE_PATH + path)
                     .that(names)


### PR DESCRIPTION
Issue #16981: `Migrate to Java 21 - 'collect(toUnmodifiableList())' can be replaced with 'toList()'`
- #16980