### PR TITLE
Issue #14631: Add Javadoc for META_HTML_TAG_NAME token

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/api/JavadocTokenTypes.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/api/JavadocTokenTypes.java
@@ -1818,7 +1818,28 @@ public final class JavadocTokenTypes {
      */
     public static final int LINK_HTML_TAG_NAME = JavadocParser.LINK_HTML_TAG_NAME;
 
-    /** Meta tag name. */
+    /**
+     *  Meta tag name.
+     *
+     *   <p><b>Example:</b></p>
+     *   <pre>{@code &lt;meta charset="UTF-8"&gt;}</pre>
+     *   <b>Tree:</b>
+     *   <pre>
+     *   {@code
+     *   HTML_ELEMENT -> HTML_ELEMENT
+     *    `--SINGLETON_ELEMENT -> SINGLETON_ELEMENT
+     *       `--META_TAG -> META_TAG
+     *          |--START -> <
+     *          |--META_HTML_TAG_NAME -> meta
+     *          |--WS ->
+     *          |--ATTRIBUTE -> ATTRIBUTE
+     *          |   |--HTML_TAG_NAME -> charset
+     *          |   |--EQUALS -> =
+     *          |   `--ATTR_VALUE -> "UTF-8"
+     *           `--END -> >
+     *  }
+     * </pre>
+     */
     public static final int META_HTML_TAG_NAME = JavadocParser.META_HTML_TAG_NAME;
 
     /** Param tag name. */


### PR DESCRIPTION
Issue #14631
**Command Used**
java -jar checkstyle-10.21.4-all.jar -J Test.java | sed "s/\[[0-9]\+:[0-9]\+\]//g"
**Test.java**
/**
 * <meta charset="UTF-8">
 */
public class Test {}
**Terminal Output**

```
yukti@LAPTOP-P8NBSFE2 MINGW64 ~/META_HTML_TAG_NAME 
$ java -jar checkstyle-10.21.4-all.jar -J Test.java | sed "s/\[[0-9]\+:[0-9]\+\]//g"
COMPILATION_UNIT -> COMPILATION_UNIT
`--CLASS_DEF -> CLASS_DEF
    |--MODIFIERS -> MODIFIERS
    |   |--BLOCK_COMMENT_BEGIN -> /*
    |   |   |--COMMENT_CONTENT -> *\r\n * <meta charset="UTF-8">\r\n
    |   |   |   `--JAVADOC -> JAVADOC
    |   |   |       |--NEWLINE -> \r\n
    |   |   |       |--LEADING_ASTERISK ->  *
    |   |   |       |--TEXT ->
    |   |   |       |--HTML_ELEMENT -> HTML_ELEMENT
    |   |   |       |   `--SINGLETON_ELEMENT -> SINGLETON_ELEMENT
    |   |   |       |       `--META_TAG -> META_TAG
    |   |   |       |           |--START -> <
    |   |   |       |           |--META_HTML_TAG_NAME -> meta
    |   |   |       |           |--WS ->
    |   |   |       |           |--ATTRIBUTE -> ATTRIBUTE
    |   |   |       |           |   |--HTML_TAG_NAME -> charset
    |   |   |       |           |   |--EQUALS -> =
    |   |   |       |           |   `--ATTR_VALUE -> "UTF-8"
    |   |   |       |           `--END -> >
    |   |   |       |--NEWLINE -> \r\n
    |   |   |       |--TEXT ->
    |   |   |       `--EOF -> <EOF>
    |   |   `--BLOCK_COMMENT_END -> */
    |   `--LITERAL_PUBLIC -> public
    |--LITERAL_CLASS -> class
    |--IDENT -> Test
    `--OBJBLOCK -> OBJBLOCK
        |--LCURLY -> {
        `--RCURLY -> }
```