### PR TITLE
infra: use last commit of pgjdbc before they migrated to jdk21

### DIFF
--- a/.ci/validation.sh
+++ b/.ci/validation.sh
@@ -639,6 +639,8 @@ no-error-pgjdbc)
   echo "Checkout target sources ..."
   checkout_from https://github.com/pgjdbc/pgjdbc.git
   cd .ci-temp/pgjdbc
+  # until https://github.com/checkstyle/checkstyle/issues/17001
+  git checkout "24c49425dc""ad91d9cb""e493810d38d""fe4c6de6504"
   ./gradlew --no-parallel --no-daemon checkstyleAll \
             -PenableMavenLocal -Pcheckstyle.version="${CS_POM_VERSION}"
   cd ../


### PR DESCRIPTION
simple bump of version does not work https://github.com/checkstyle/checkstyle/pull/16996

we will do it sepate activity https://github.com/checkstyle/checkstyle/issues/17001
for now we need to unblock all PRs