### PR TITLE
Issue #16738: Update SuppressWithNearbyCommentFilterExamplesTest to use verifyFilterWithInlineConfigParser

### DIFF
--- a/src/site/xdoc/filters/suppresswithnearbycommentfilter.xml
+++ b/src/site/xdoc/filters/suppresswithnearbycommentfilter.xml
@@ -114,6 +114,7 @@
         <p id="Example1-code">Example:</p>
         <div class="wrapper"><pre class="prettyprint"><code class="language-java">
 public class Example1 {
+  // filtered violation below
   private int [] array; // SUPPRESS CHECKSTYLE NoWhitespaceAfter
 }
 </code></pre></div>
@@ -136,6 +137,7 @@ public class Example1 {
         <p id="Example2-code">Example:</p>
         <div class="wrapper"><pre class="prettyprint"><code class="language-java">
 public class Example2 {
+  // filtered violation below
   public static final int lowerCaseConstant = 1; // CHECKSTYLE IGNORE THIS LINE
 }
 </code></pre></div>
@@ -165,6 +167,7 @@ public class Example3 {
     try {
       // blah blah blah
     }
+    // filtered violation below
     catch(RuntimeException re) {
       // OK to catch RuntimeException here
     }
@@ -193,10 +196,14 @@ public class Example3 {
         <p id="Example4-code">Example:</p>
         <div class="wrapper"><pre class="prettyprint"><code class="language-java">
 public class Example4 {
-  // CHECKSTYLE IGNORE ConstantNameCheck FOR NEXT 4 LINES
+  // CHECKSTYLE IGNORE ConstantNameCheck FOR NEXT 8 LINES
+  // filtered violation below
   static final int lowerCaseConstant1 = 1;
+  // filtered violation below
   static final int lowerCaseConstant2 = 2;
+  // filtered violation below
   static final int lowerCaseConstant3 = 3;
+  // filtered violation below
   static final int lowerCaseConstant4 = 4;
   static final int lowerCaseConstant5 = 5; // violation 'must match pattern'
 }
@@ -219,6 +226,7 @@ public class Example4 {
         <p id="Example5-code">Example:</p>
         <div class="wrapper"><pre class="prettyprint"><code class="language-java">
 public class Example5 {
+  // filtered violation below
   private int D2;
   // ALLOW MemberName ON PREVIOUS LINE
 }
@@ -246,7 +254,8 @@ public class Example5 {
         <div class="wrapper"><pre class="prettyprint"><code class="language-java">
 public class Example6 {
   // @cs.suppress [ConstantName|NoWhitespaceAfter] A comment here
-  public static final int [] array = {};
+  public static final int [] array = {}; // filtered violation
+  // filtered violation above
 }
 </code></pre></div>
         <p>
@@ -320,10 +329,10 @@ public class Example7 {
         <div class="wrapper"><pre class="prettyprint"><code class="language-java">
 // @cs-: ClassDataAbstractionCoupling influence 2
 // @cs-: MagicNumber influence 4
-public class Example8 { // no violations from ClassDataAbstractionCoupling here
+public class Example8 { // filtered violation
   private Example1 foo = new Example1();
   private Example2 bar = new Example2();
-  private int value = 10022; // no violations from MagicNumber here
+  private int value = 10022; // filtered violation
 }
 </code></pre></div>
       </subsection>

--- a/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/filters/SuppressWithNearbyCommentFilterExamplesTest.java
+++ b/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/filters/SuppressWithNearbyCommentFilterExamplesTest.java
@@ -31,73 +31,112 @@ public class SuppressWithNearbyCommentFilterExamplesTest extends AbstractExample
 
     @Test
     public void testExample1() throws Exception {
-        final String[] expected = {
+        final String[] expectedWithFilter = {
 
         };
+        final String[] expectedWithoutFilter = {
+            "13:15: 'int' is followed by whitespace.",
+        };
 
-        verifyWithInlineConfigParser(getPath("Example1.java"), expected);
+        verifyFilterWithInlineConfigParser(getPath("Example1.java"), expectedWithoutFilter,
+                expectedWithFilter);
     }
 
     @Test
     public void testExample2() throws Exception {
-        final String[] expected = {
+        final String[] expectedWithFilter = {
 
         };
+        final String[] expectedWithoutFilter = {
+            "17:27: Name 'lowerCaseConstant' must match pattern '^[A-Z][A-Z0-9]*(_[A-Z0-9]+)*$'.",
+        };
 
-        verifyWithInlineConfigParser(getPath("Example2.java"), expected);
+        verifyFilterWithInlineConfigParser(getPath("Example2.java"), expectedWithoutFilter,
+                expectedWithFilter);
     }
 
     @Test
     public void testExample3() throws Exception {
-        final String[] expected = {
+        final String[] expectedWithFilter = {
 
         };
+        final String[] expectedWithoutFilter = {
+            "22:5: Catching 'RuntimeException' is not allowed.",
+        };
 
-        verifyWithInlineConfigParser(getPath("Example3.java"), expected);
+        verifyFilterWithInlineConfigParser(getPath("Example3.java"), expectedWithoutFilter,
+                expectedWithFilter);
     }
 
     @Test
     public void testExample4() throws Exception {
-        final String[] expected = {
-            "22:20: Name 'lowerCaseConstant5' must match pattern '^[A-Z][A-Z0-9]*(_[A-Z0-9]+)*$'.",
+        final String[] expectedWithFilter = {
+            "26:20: Name 'lowerCaseConstant5' must match pattern '^[A-Z][A-Z0-9]*(_[A-Z0-9]+)*$'.",
+        };
+        final String[] expectedWithoutFilter = {
+            "19:20: Name 'lowerCaseConstant1' must match pattern '^[A-Z][A-Z0-9]*(_[A-Z0-9]+)*$'.",
+            "21:20: Name 'lowerCaseConstant2' must match pattern '^[A-Z][A-Z0-9]*(_[A-Z0-9]+)*$'.",
+            "23:20: Name 'lowerCaseConstant3' must match pattern '^[A-Z][A-Z0-9]*(_[A-Z0-9]+)*$'.",
+            "25:20: Name 'lowerCaseConstant4' must match pattern '^[A-Z][A-Z0-9]*(_[A-Z0-9]+)*$'.",
+            "26:20: Name 'lowerCaseConstant5' must match pattern '^[A-Z][A-Z0-9]*(_[A-Z0-9]+)*$'.",
         };
 
-        verifyWithInlineConfigParser(getPath("Example4.java"), expected);
+        verifyFilterWithInlineConfigParser(getPath("Example4.java"), expectedWithoutFilter,
+                expectedWithFilter);
     }
 
     @Test
     public void testExample5() throws Exception {
-        final String[] expected = {
+        final String[] expectedWithFilter = {
 
         };
+        final String[] expectedWithoutFilter = {
+            "17:15: Name 'D2' must match pattern '^[a-z][a-zA-Z0-9]*$'.",
+        };
 
-        verifyWithInlineConfigParser(getPath("Example5.java"), expected);
+        verifyFilterWithInlineConfigParser(getPath("Example5.java"), expectedWithoutFilter,
+                expectedWithFilter);
     }
 
     @Test
     public void testExample6() throws Exception {
-        final String[] expected = {
+        final String[] expectedWithFilters = {
 
         };
+        final String[] expectedWithoutFilters = {
+            "19:27: 'int' is followed by whitespace.",
+            "19:30: Name 'array' must match pattern '^[A-Z][A-Z0-9]*(_[A-Z0-9]+)*$'.",
+        };
 
-        verifyWithInlineConfigParser(getPath("Example6.java"), expected);
+        verifyFilterWithInlineConfigParser(getPath("Example6.java"), expectedWithoutFilters,
+                expectedWithFilters);
     }
 
     @Test
     public void testExample7() throws Exception {
-        final String[] expected = {
+        final String[] expectedWithFilter = {
+
+        };
+        final String[] expectedWithoutFilter = {
 
         };
 
-        verifyWithInlineConfigParser(getPath("Example7.java"), expected);
+        verifyFilterWithInlineConfigParser(getPath("Example7.java"), expectedWithoutFilter,
+                expectedWithFilter);
     }
 
     @Test
     public void testExample8() throws Exception {
-        final String[] expected = {
+        final String[] expectedWithFilter = {
 
         };
+        final String[] expectedWithoutFilter = {
+            "21:1: Class Data Abstraction Coupling is 2 (max allowed is 1) "
+                    + "classes [Example1, Example2].",
+            "24:23: '10022' is a magic number.",
+        };
 
-        verifyWithInlineConfigParser(getPath("Example8.java"), expected);
+        verifyFilterWithInlineConfigParser(getPath("Example8.java"), expectedWithoutFilter,
+                expectedWithFilter);
     }
 }

--- a/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/filters/suppresswithnearbycommentfilter/Example1.java
+++ b/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/filters/suppresswithnearbycommentfilter/Example1.java
@@ -9,6 +9,7 @@
 package com.puppycrawl.tools.checkstyle.filters.suppresswithnearbycommentfilter;
 // xdoc section -- start
 public class Example1 {
+  // filtered violation below
   private int [] array; // SUPPRESS CHECKSTYLE NoWhitespaceAfter
 }
 // xdoc section -- end

--- a/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/filters/suppresswithnearbycommentfilter/Example2.java
+++ b/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/filters/suppresswithnearbycommentfilter/Example2.java
@@ -13,6 +13,7 @@
 package com.puppycrawl.tools.checkstyle.filters.suppresswithnearbycommentfilter;
 // xdoc section -- start
 public class Example2 {
+  // filtered violation below
   public static final int lowerCaseConstant = 1; // CHECKSTYLE IGNORE THIS LINE
 }
 // xdoc section -- end

--- a/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/filters/suppresswithnearbycommentfilter/Example3.java
+++ b/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/filters/suppresswithnearbycommentfilter/Example3.java
@@ -18,6 +18,7 @@ public class Example3 {
     try {
       // blah blah blah
     }
+    // filtered violation below
     catch(RuntimeException re) {
       // OK to catch RuntimeException here
     }

--- a/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/filters/suppresswithnearbycommentfilter/Example4.java
+++ b/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/filters/suppresswithnearbycommentfilter/Example4.java
@@ -14,10 +14,14 @@
 package com.puppycrawl.tools.checkstyle.filters.suppresswithnearbycommentfilter;
 // xdoc section -- start
 public class Example4 {
-  // CHECKSTYLE IGNORE ConstantNameCheck FOR NEXT 4 LINES
+  // CHECKSTYLE IGNORE ConstantNameCheck FOR NEXT 8 LINES
+  // filtered violation below
   static final int lowerCaseConstant1 = 1;
+  // filtered violation below
   static final int lowerCaseConstant2 = 2;
+  // filtered violation below
   static final int lowerCaseConstant3 = 3;
+  // filtered violation below
   static final int lowerCaseConstant4 = 4;
   static final int lowerCaseConstant5 = 5; // violation 'must match pattern'
 }

--- a/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/filters/suppresswithnearbycommentfilter/Example5.java
+++ b/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/filters/suppresswithnearbycommentfilter/Example5.java
@@ -13,6 +13,7 @@
 package com.puppycrawl.tools.checkstyle.filters.suppresswithnearbycommentfilter;
 // xdoc section -- start
 public class Example5 {
+  // filtered violation below
   private int D2;
   // ALLOW MemberName ON PREVIOUS LINE
 }

--- a/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/filters/suppresswithnearbycommentfilter/Example6.java
+++ b/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/filters/suppresswithnearbycommentfilter/Example6.java
@@ -16,6 +16,7 @@ package com.puppycrawl.tools.checkstyle.filters.suppresswithnearbycommentfilter;
 // xdoc section -- start
 public class Example6 {
   // @cs.suppress [ConstantName|NoWhitespaceAfter] A comment here
-  public static final int [] array = {};
+  public static final int [] array = {}; // filtered violation
+  // filtered violation above
 }
 // xdoc section -- end

--- a/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/filters/suppresswithnearbycommentfilter/Example8.java
+++ b/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/filters/suppresswithnearbycommentfilter/Example8.java
@@ -18,9 +18,9 @@ package com.puppycrawl.tools.checkstyle.filters.suppresswithnearbycommentfilter;
 // xdoc section -- start
 // @cs-: ClassDataAbstractionCoupling influence 2
 // @cs-: MagicNumber influence 4
-public class Example8 { // no violations from ClassDataAbstractionCoupling here
+public class Example8 { // filtered violation
   private Example1 foo = new Example1();
   private Example2 bar = new Example2();
-  private int value = 10022; // no violations from MagicNumber here
+  private int value = 10022; // filtered violation
 }
 // xdoc section -- end


### PR DESCRIPTION
Update `SuppressWithNearbyCommentFilterExamplesTest` to use `verifyFilterWithInlineConfigParser`
Issue: #16738