### PR TITLE
Issue #16361: Update SarifLoggerTest.testAddErrorAtColumn1 to use verifyWithInlineConfigParserAndLogger

### DIFF
--- a/src/test/java/com/puppycrawl/tools/checkstyle/SarifLoggerTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/SarifLoggerTest.java
@@ -111,16 +111,13 @@ public class SarifLoggerTest extends AbstractModuleTestSupport {
     }
 
     @Test
-    public void testAddErrorAtColumn1() throws IOException {
+    public void testAddErrorAtColumn1() throws Exception {
         final SarifLogger logger = new SarifLogger(outStream,
                 OutputStreamOptions.CLOSE);
-        logger.auditStarted(null);
-        final Violation violation =
-                new Violation(1, 1,
-                        "messages.properties", "ruleId", null, SeverityLevel.ERROR, null,
-                        getClass(), "found an error\ntry again");
-        executeLogger(this, logger, "Test.java", violation);
-        verifyContent(getPath("ExpectedSarifLoggerSingleErrorColumn1.sarif"), outStream);
+        final String inputFile = "InputSarifLoggerSingleErrorColumn1.java";
+        final String expectedOutput = "ExpectedSarifLoggerSingleErrorColumn1.sarif";
+        verifyWithInlineConfigParserAndLogger(getPath(inputFile),
+                getPath(expectedOutput), logger, outStream);
     }
 
     @Test

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/sariflogger/ExpectedSarifLoggerSingleErrorColumn1.sarif
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/sariflogger/ExpectedSarifLoggerSingleErrorColumn1.sarif
@@ -24,19 +24,19 @@
             {
               "physicalLocation": {
                 "artifactLocation": {
-                  "uri": "file:Test.java"
+                  "uri": "file:src/test/resources/com/puppycrawl/tools/checkstyle/sariflogger/InputSarifLoggerSingleErrorColumn1.java"
                 },
                 "region": {
                   "startColumn": 1,
-                  "startLine": 1
+                  "startLine": 17
                 }
               }
             }
           ],
           "message": {
-            "text": "found an error\ntry again"
+            "text": "Avoid using String. \\n try again"
           },
-          "ruleId": "ruleId"
+          "ruleId": "Avoid using String. \n try again"
         }
       ]
     }

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/sariflogger/InputSarifLoggerSingleErrorColumn1.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/sariflogger/InputSarifLoggerSingleErrorColumn1.java
@@ -1,0 +1,18 @@
+/*xml
+<module name="Checker">
+  <module name="TreeWalker">
+    <module name="com.puppycrawl.tools.checkstyle.checks.coding.IllegalTokenTextCheck">
+      <property name="tokens" value="IDENT"/>
+      <property name="format" value="^^String$"/>
+      <property name="message" value="Avoid using String. \n try again"/>
+    </module>
+  </module>
+</module>
+*/
+
+package com.puppycrawl.tools.checkstyle.sariflogger;
+
+public class InputSarifLoggerSingleErrorColumn1 {
+
+String str = "test";
+}


### PR DESCRIPTION
Part of #16361 

updated `testAddErrorAtColumn1()` method to use `verifyWithInlineConfigParserAndLogger()`.
