### PR TITLE
Issue #17017: Rename all 'ex' variable to 'exc' and forbid 'ex'.

### DIFF
--- a/config/checker-framework-suppressions/checker-methods-resource-fenum-suppressions.xml
+++ b/config/checker-framework-suppressions/checker-methods-resource-fenum-suppressions.xml
@@ -172,7 +172,7 @@
     <lineContent>moduleDetails = read(XmlMetaReader.class.getResourceAsStream(&quot;/&quot; + fileName),</lineContent>
     <details>
       The type of object is: java.io.InputStream.
-      Reason for going out of scope: possible exceptional exit due to throw new IllegalStateException(&quot;Problem to read all modules including third party if any. Problem detected at file: &quot; + fileName, ex); with exception type java.lang.IllegalStateException
+      Reason for going out of scope: possible exceptional exit due to throw new IllegalStateException(&quot;Problem to read all modules including third party if any. Problem detected at file: &quot; + fileName, exc); with exception type java.lang.IllegalStateException
     </details>
   </checkerFrameworkError>
 

--- a/config/checker-framework-suppressions/checker-nullness-optional-interning-suppressions.xml
+++ b/config/checker-framework-suppressions/checker-nullness-optional-interning-suppressions.xml
@@ -25,7 +25,7 @@
     <fileName>src/main/java/com/puppycrawl/tools/checkstyle/Checker.java</fileName>
     <specifier>argument</specifier>
     <message>incompatible argument for parameter args of Checker.getLocalizedMessage.</message>
-    <lineContent>getLocalizedMessage(&quot;Checker.setupChildModule&quot;, name, ex.getMessage()), ex);</lineContent>
+    <lineContent>getLocalizedMessage(&quot;Checker.setupChildModule&quot;, name, exc.getMessage()), exc);</lineContent>
     <details>
       found   : @Initialized @Nullable String
       required: @Initialized @NonNull Object
@@ -884,7 +884,7 @@
     <fileName>src/main/java/com/puppycrawl/tools/checkstyle/TreeWalker.java</fileName>
     <specifier>argument</specifier>
     <message>incompatible argument for parameter args of Violation constructor.</message>
-    <lineContent>new Object[] {ex.getMessage()}, javaParseExceptionSeverity, null,</lineContent>
+    <lineContent>new Object[] {exc.getMessage()}, javaParseExceptionSeverity, null,</lineContent>
     <details>
       found   : @Initialized @Nullable Object @Initialized @NonNull []
       required: @Initialized @NonNull Object @Initialized @NonNull []
@@ -917,7 +917,7 @@
     <fileName>src/main/java/com/puppycrawl/tools/checkstyle/TreeWalker.java</fileName>
     <specifier>argument</specifier>
     <message>incompatible argument for parameter moduleId of Violation constructor.</message>
-    <lineContent>new Object[] {ex.getMessage()}, javaParseExceptionSeverity, null,</lineContent>
+    <lineContent>new Object[] {exc.getMessage()}, javaParseExceptionSeverity, null,</lineContent>
     <details>
       found   : null (NullType)
       required: @Initialized @NonNull String
@@ -1444,7 +1444,7 @@
     <fileName>src/main/java/com/puppycrawl/tools/checkstyle/checks/OrderedPropertiesCheck.java</fileName>
     <specifier>argument</specifier>
     <message>incompatible argument for parameter args of AbstractFileSetCheck.log.</message>
-    <lineContent>log(1, MSG_IO_EXCEPTION_KEY, file.getPath(), ex.getLocalizedMessage());</lineContent>
+    <lineContent>log(1, MSG_IO_EXCEPTION_KEY, file.getPath(), exc.getLocalizedMessage());</lineContent>
     <details>
       found   : @Initialized @Nullable String
       required: @Initialized @NonNull Object
@@ -1626,7 +1626,7 @@
     <fileName>src/main/java/com/puppycrawl/tools/checkstyle/checks/UniquePropertiesCheck.java</fileName>
     <specifier>argument</specifier>
     <message>incompatible argument for parameter args of AbstractFileSetCheck.log.</message>
-    <lineContent>ex.getLocalizedMessage());</lineContent>
+    <lineContent>exc.getLocalizedMessage());</lineContent>
     <details>
       found   : @Initialized @Nullable String
       required: @Initialized @NonNull Object

--- a/config/checker-framework-suppressions/checker-signature-gui-units-init-suppressions.xml
+++ b/config/checker-framework-suppressions/checker-signature-gui-units-init-suppressions.xml
@@ -170,7 +170,7 @@
     <fileName>src/main/java/com/puppycrawl/tools/checkstyle/gui/MainFrame.java</fileName>
     <specifier>call.ui</specifier>
     <message>Calling a method with UIEffect effect from a context limited to SafeEffect effects.</message>
-    <lineContent>JOptionPane.showMessageDialog(this, ex.getMessage());</lineContent>
+    <lineContent>JOptionPane.showMessageDialog(this, exc.getMessage());</lineContent>
   </checkerFrameworkError>
 
   <checkerFrameworkError unstable="false">

--- a/config/checkstyle-checks.xml
+++ b/config/checkstyle-checks.xml
@@ -865,7 +865,7 @@
       <property name="format" value="^(id)|([a-z][a-z0-9][a-zA-Z0-9]+)$"/>
     </module>
     <module name="CatchParameterName">
-      <property name="format" value="^(ex|[a-z][a-z][a-zA-Z]+)$"/>
+      <property name="format" value="^[a-z][a-z][a-zA-Z]+$"/>
     </module>
     <module name="StaticVariableName">
       <property name="format" value="^(id)|([a-z][a-z0-9][a-zA-Z0-9]+)$"/>

--- a/config/pitest-suppressions/pitest-ant-suppressions.xml
+++ b/config/pitest-suppressions/pitest-ant-suppressions.xml
@@ -15,7 +15,7 @@
     <mutatedMethod>createOverridingProperties</mutatedMethod>
     <mutator>org.pitest.mutationtest.engine.gregor.mutators.NonVoidMethodCallMutator</mutator>
     <description>removed call to com/puppycrawl/tools/checkstyle/ant/CheckstyleAntTask::getLocation</description>
-    <lineContent>+ properties + &quot;&apos;&quot;, ex, getLocation());</lineContent>
+    <lineContent>+ properties + &quot;&apos;&quot;, exc, getLocation());</lineContent>
   </mutation>
 
   <mutation unstable="false">
@@ -75,15 +75,6 @@
   <mutation unstable="false">
     <sourceFile>CheckstyleAntTask.java</sourceFile>
     <mutatedClass>com.puppycrawl.tools.checkstyle.ant.CheckstyleAntTask</mutatedClass>
-    <mutatedMethod>getListeners</mutatedMethod>
-    <mutator>org.pitest.mutationtest.engine.gregor.mutators.NonVoidMethodCallMutator</mutator>
-    <description>removed call to java/util/List::size</description>
-    <lineContent>final int formatterCount = Math.max(1, formatters.size());</lineContent>
-  </mutation>
-
-  <mutation unstable="false">
-    <sourceFile>CheckstyleAntTask.java</sourceFile>
-    <mutatedClass>com.puppycrawl.tools.checkstyle.ant.CheckstyleAntTask</mutatedClass>
     <mutatedMethod>execute</mutatedMethod>
     <mutator>org.pitest.mutationtest.engine.gregor.mutators.experimental.ArgumentPropagationMutator</mutator>
     <description>replaced call to java/util/Objects::toString with argument</description>
@@ -93,10 +84,19 @@
   <mutation unstable="false">
     <sourceFile>CheckstyleAntTask.java</sourceFile>
     <mutatedClass>com.puppycrawl.tools.checkstyle.ant.CheckstyleAntTask</mutatedClass>
+    <mutatedMethod>getListeners</mutatedMethod>
+    <mutator>org.pitest.mutationtest.engine.gregor.mutators.NonVoidMethodCallMutator</mutator>
+    <description>removed call to java/util/List::size</description>
+    <lineContent>final int formatterCount = Math.max(1, formatters.size());</lineContent>
+  </mutation>
+
+  <mutation unstable="false">
+    <sourceFile>CheckstyleAntTask.java</sourceFile>
+    <mutatedClass>com.puppycrawl.tools.checkstyle.ant.CheckstyleAntTask</mutatedClass>
     <mutatedMethod>processFiles</mutatedMethod>
     <mutator>org.pitest.mutationtest.engine.gregor.mutators.NonVoidMethodCallMutator</mutator>
     <description>removed call to java/lang/String::valueOf</description>
-    <lineContent>throw new BuildException(&quot;Unable to process files: &quot; + files, ex);</lineContent>
+    <lineContent>throw new BuildException(&quot;Unable to process files: &quot; + files, exc);</lineContent>
   </mutation>
 
   <mutation unstable="false">

--- a/config/pitest-suppressions/pitest-imports-suppressions.xml
+++ b/config/pitest-suppressions/pitest-imports-suppressions.xml
@@ -6,7 +6,7 @@
     <mutatedMethod>setFile</mutatedMethod>
     <mutator>org.pitest.mutationtest.engine.gregor.mutators.NonVoidMethodCallMutator</mutator>
     <description>removed call to java/lang/String::valueOf</description>
-    <lineContent>throw new IllegalArgumentException(UNABLE_TO_LOAD + uri, ex);</lineContent>
+    <lineContent>throw new IllegalArgumentException(UNABLE_TO_LOAD + uri, exc);</lineContent>
   </mutation>
 
   <mutation unstable="false">
@@ -15,7 +15,7 @@
     <mutatedMethod>load</mutatedMethod>
     <mutator>org.pitest.mutationtest.engine.gregor.mutators.NonVoidMethodCallMutator</mutator>
     <description>removed call to java/lang/String::valueOf</description>
-    <lineContent>throw new CheckstyleException(&quot;unable to read &quot; + uri, ex);</lineContent>
+    <lineContent>throw new CheckstyleException(&quot;unable to read &quot; + uri, exc);</lineContent>
   </mutation>
 
   <mutation unstable="false">
@@ -24,7 +24,7 @@
     <mutatedMethod>loadUri</mutatedMethod>
     <mutator>org.pitest.mutationtest.engine.gregor.mutators.NonVoidMethodCallMutator</mutator>
     <description>removed call to java/lang/String::valueOf</description>
-    <lineContent>throw new CheckstyleException(&quot;syntax error in url &quot; + uri, ex);</lineContent>
+    <lineContent>throw new CheckstyleException(&quot;syntax error in url &quot; + uri, exc);</lineContent>
   </mutation>
 
   <mutation unstable="false">
@@ -33,7 +33,7 @@
     <mutatedMethod>loadUri</mutatedMethod>
     <mutator>org.pitest.mutationtest.engine.gregor.mutators.NonVoidMethodCallMutator</mutator>
     <description>removed call to java/lang/String::valueOf</description>
-    <lineContent>throw new CheckstyleException(&quot;unable to find &quot; + uri, ex);</lineContent>
+    <lineContent>throw new CheckstyleException(&quot;unable to find &quot; + uri, exc);</lineContent>
   </mutation>
 
   <mutation unstable="false">

--- a/config/pitest-suppressions/pitest-packagenamesloader-suppressions.xml
+++ b/config/pitest-suppressions/pitest-packagenamesloader-suppressions.xml
@@ -6,6 +6,6 @@
     <mutatedMethod>processFile</mutatedMethod>
     <mutator>org.pitest.mutationtest.engine.gregor.mutators.NonVoidMethodCallMutator</mutator>
     <description>removed call to java/lang/String::valueOf</description>
-    <lineContent>throw new CheckstyleException(&quot;unable to open &quot; + packageFile, ex);</lineContent>
+    <lineContent>throw new CheckstyleException(&quot;unable to open &quot; + packageFile, exc);</lineContent>
   </mutation>
 </suppressedMutations>

--- a/src/it/java/com/google/checkstyle/test/base/AbstractGoogleModuleTestSupport.java
+++ b/src/it/java/com/google/checkstyle/test/base/AbstractGoogleModuleTestSupport.java
@@ -48,14 +48,14 @@ public abstract class AbstractGoogleModuleTestSupport extends AbstractItModuleTe
             CONFIGURATION = ConfigurationLoader.loadConfiguration(XML_NAME,
                     expander);
         }
-        catch (CheckstyleException ex) {
-            throw new IllegalStateException(ex);
+        catch (CheckstyleException exc) {
+            throw new IllegalStateException(exc);
         }
         try {
             CHECKSTYLE_MODULES = CheckUtil.getCheckstyleModules();
         }
-        catch (IOException ex) {
-            throw new IllegalStateException(ex);
+        catch (IOException exc) {
+            throw new IllegalStateException(exc);
         }
     }
 

--- a/src/it/java/com/sun/checkstyle/test/base/AbstractSunModuleTestSupport.java
+++ b/src/it/java/com/sun/checkstyle/test/base/AbstractSunModuleTestSupport.java
@@ -44,14 +44,14 @@ public abstract class AbstractSunModuleTestSupport extends AbstractItModuleTestS
             CONFIGURATION = ConfigurationLoader.loadConfiguration(XML_NAME,
                     new PropertiesExpander(System.getProperties()));
         }
-        catch (CheckstyleException ex) {
-            throw new IllegalStateException(ex);
+        catch (CheckstyleException exc) {
+            throw new IllegalStateException(exc);
         }
         try {
             CHECKSTYLE_MODULES = CheckUtil.getCheckstyleModules();
         }
-        catch (IOException ex) {
-            throw new IllegalStateException(ex);
+        catch (IOException exc) {
+            throw new IllegalStateException(exc);
         }
     }
 

--- a/src/it/java/org/checkstyle/base/AbstractItModuleTestSupport.java
+++ b/src/it/java/org/checkstyle/base/AbstractItModuleTestSupport.java
@@ -154,8 +154,8 @@ public abstract class AbstractItModuleTestSupport extends AbstractPathTestSuppor
         try {
             return conf.getProperty("id").equals(moduleId);
         }
-        catch (CheckstyleException ex) {
-            throw new IllegalStateException("problem to get ID attribute from " + conf, ex);
+        catch (CheckstyleException exc) {
+            throw new IllegalStateException("problem to get ID attribute from " + conf, exc);
         }
     }
 

--- a/src/it/resources/com/google/checkstyle/test/chapter3filestructure/rule331nowildcard/InputNoWildcardImports.java
+++ b/src/it/resources/com/google/checkstyle/test/chapter3filestructure/rule331nowildcard/InputNoWildcardImports.java
@@ -29,8 +29,8 @@ class InputNoWildcardImports {
     try {
       createTempFile("temp", ".txt");
       File[] roots = listRoots();
-    } catch (IOException e) {
-      e.printStackTrace();
+    } catch (IOException exc) {
+      exc.printStackTrace();
     }
     int closeOperation = EXIT_ON_CLOSE;
 

--- a/src/it/resources/com/google/checkstyle/test/chapter3filestructure/rule333orderingandspacing/InputFormattedOrderingAndSpacing2.java
+++ b/src/it/resources/com/google/checkstyle/test/chapter3filestructure/rule333orderingandspacing/InputFormattedOrderingAndSpacing2.java
@@ -19,8 +19,8 @@ public class InputFormattedOrderingAndSpacing2 {
   public static void main(String[] args) {
     try {
       createTempFile("temp", ".txt");
-    } catch (Exception e) {
-      e.printStackTrace();
+    } catch (Exception exc) {
+      exc.printStackTrace();
     }
     int abortAction = ABORT;
     int closeOperation = EXIT_ON_CLOSE;

--- a/src/it/resources/com/google/checkstyle/test/chapter3filestructure/rule333orderingandspacing/InputFormattedOrderingAndSpacing3.java
+++ b/src/it/resources/com/google/checkstyle/test/chapter3filestructure/rule333orderingandspacing/InputFormattedOrderingAndSpacing3.java
@@ -24,8 +24,8 @@ public class InputFormattedOrderingAndSpacing3 {
 
     try {
       createTempFile("temp", ".txt");
-    } catch (Exception e) {
-      e.printStackTrace();
+    } catch (Exception exc) {
+      exc.printStackTrace();
     }
 
     // Use of java.awt and javax.swing classes

--- a/src/main/java/com/puppycrawl/tools/checkstyle/AbstractAutomaticBean.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/AbstractAutomaticBean.java
@@ -241,19 +241,19 @@ public abstract class AbstractAutomaticBean
             beanUtils.copyProperty(this, key, value);
         }
         catch (final InvocationTargetException | IllegalAccessException
-                | NoSuchMethodException ex) {
+                | NoSuchMethodException exc) {
             // There is no way to catch IllegalAccessException | NoSuchMethodException
             // as we do PropertyUtils.getPropertyDescriptor before beanUtils.copyProperty,
             // so we have to join these exceptions with InvocationTargetException
             // to satisfy UTs coverage
             final String message = String.format(Locale.ROOT,
                     "Cannot set property '%s' to '%s'", key, value);
-            throw new CheckstyleException(message, ex);
+            throw new CheckstyleException(message, exc);
         }
-        catch (final IllegalArgumentException | ConversionException ex) {
+        catch (final IllegalArgumentException | ConversionException exc) {
             final String message = String.format(Locale.ROOT, "illegal value '%s' for property "
                     + "'%s'", value, key);
-            throw new CheckstyleException(message, ex);
+            throw new CheckstyleException(message, exc);
         }
     }
 
@@ -371,8 +371,8 @@ public abstract class AbstractAutomaticBean
                 try {
                     result = CommonUtil.getUriByFilename(url);
                 }
-                catch (CheckstyleException ex) {
-                    throw new IllegalArgumentException(ex);
+                catch (CheckstyleException exc) {
+                    throw new IllegalArgumentException(exc);
                 }
             }
 

--- a/src/main/java/com/puppycrawl/tools/checkstyle/Checker.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/Checker.java
@@ -184,8 +184,8 @@ public class Checker extends AbstractAutomaticBean implements MessageDispatcher,
             try {
                 cacheFile.persist();
             }
-            catch (IOException ex) {
-                throw new IllegalStateException("Unable to persist cache file.", ex);
+            catch (IOException exc) {
+                throw new IllegalStateException("Unable to persist cache file.", exc);
             }
         }
     }
@@ -302,14 +302,14 @@ public class Checker extends AbstractAutomaticBean implements MessageDispatcher,
             }
             // -@cs[IllegalCatch] There is no other way to deliver filename that was under
             // processing. See https://github.com/checkstyle/checkstyle/issues/2285
-            catch (Exception ex) {
+            catch (Exception exc) {
                 if (fileName != null && cacheFile != null) {
                     cacheFile.remove(fileName);
                 }
 
                 // We need to catch all exceptions to put a reason failure (file name) in exception
                 throw new CheckstyleException(
-                        getLocalizedMessage("Checker.processFilesException", filePath), ex);
+                        getLocalizedMessage("Checker.processFilesException", filePath), exc);
             }
             catch (Error error) {
                 if (fileName != null && cacheFile != null) {
@@ -347,17 +347,17 @@ public class Checker extends AbstractAutomaticBean implements MessageDispatcher,
                     new String[] {ioe.getMessage()}, null, getClass(), null));
         }
         // -@cs[IllegalCatch] There is no other way to obey haltOnException field
-        catch (Exception ex) {
+        catch (Exception exc) {
             if (haltOnException) {
-                throw ex;
+                throw exc;
             }
 
-            log.debug("Exception occurred.", ex);
+            log.debug("Exception occurred.", exc);
 
             final StringWriter sw = new StringWriter();
             final PrintWriter pw = new PrintWriter(sw, true);
 
-            ex.printStackTrace(pw);
+            exc.printStackTrace(pw);
 
             fileMessages.add(new Violation(1,
                     Definitions.CHECKSTYLE_BUNDLE, EXCEPTION_MSG,
@@ -479,9 +479,9 @@ public class Checker extends AbstractAutomaticBean implements MessageDispatcher,
                 bean.configure(childConf);
             }
         }
-        catch (final CheckstyleException ex) {
+        catch (final CheckstyleException exc) {
             throw new CheckstyleException(
-                    getLocalizedMessage("Checker.setupChildModule", name, ex.getMessage()), ex);
+                    getLocalizedMessage("Checker.setupChildModule", name, exc.getMessage()), exc);
         }
         if (child instanceof FileSetCheck) {
             final FileSetCheck fsc = (FileSetCheck) child;

--- a/src/main/java/com/puppycrawl/tools/checkstyle/ConfigurationLoader.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/ConfigurationLoader.java
@@ -310,14 +310,14 @@ public final class ConfigurationLoader {
                             omitIgnoreModules, threadModeSettings);
             return loader.parseInputSource(configSource);
         }
-        catch (final SAXParseException ex) {
+        catch (final SAXParseException exc) {
             final String message = String.format(Locale.ROOT, SAX_PARSE_EXCEPTION_FORMAT,
                     UNABLE_TO_PARSE_EXCEPTION_PREFIX,
-                    ex.getMessage(), ex.getLineNumber(), ex.getColumnNumber());
-            throw new CheckstyleException(message, ex);
+                    exc.getMessage(), exc.getLineNumber(), exc.getColumnNumber());
+            throw new CheckstyleException(message, exc);
         }
-        catch (final ParserConfigurationException | IOException | SAXException ex) {
-            throw new CheckstyleException(UNABLE_TO_PARSE_EXCEPTION_PREFIX, ex);
+        catch (final ParserConfigurationException | IOException | SAXException exc) {
+            throw new CheckstyleException(UNABLE_TO_PARSE_EXCEPTION_PREFIX, exc);
         }
     }
 
@@ -526,10 +526,10 @@ public final class ConfigurationLoader {
                     value = replaceProperties(attributesValue,
                         overridePropsResolver, attributes.getValue(DEFAULT));
                 }
-                catch (final CheckstyleException ex) {
+                catch (final CheckstyleException exc) {
                     // -@cs[IllegalInstantiation] SAXException is in the overridden
                     // method signature
-                    throw new SAXException(ex);
+                    throw new SAXException(exc);
                 }
 
                 final String name = attributes.getValue(NAME);
@@ -570,12 +570,12 @@ public final class ConfigurationLoader {
                         final String severity = recentModule.getProperty(SEVERITY);
                         level = SeverityLevel.getInstance(severity);
                     }
-                    catch (final CheckstyleException ex) {
+                    catch (final CheckstyleException exc) {
                         // -@cs[IllegalInstantiation] SAXException is in the overridden
                         // method signature
                         throw new SAXException(
                                 "Problem during accessing '" + SEVERITY + "' attribute for "
-                                        + recentModule.getName(), ex);
+                                        + recentModule.getName(), exc);
                     }
                 }
 

--- a/src/main/java/com/puppycrawl/tools/checkstyle/JavaParser.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/JavaParser.java
@@ -97,11 +97,11 @@ public final class JavaParser {
         try {
             compilationUnit = parser.compilationUnit();
         }
-        catch (IllegalStateException ex) {
+        catch (IllegalStateException exc) {
             final String exceptionMsg = String.format(Locale.ROOT,
                 "%s occurred while parsing file %s.",
-                ex.getClass().getSimpleName(), contents.getFileName());
-            throw new CheckstyleException(exceptionMsg, ex);
+                exc.getClass().getSimpleName(), contents.getFileName());
+            throw new CheckstyleException(exceptionMsg, exc);
         }
 
         return new JavaAstVisitor(tokenStream).visit(compilationUnit);

--- a/src/main/java/com/puppycrawl/tools/checkstyle/JavadocDetailNodeParser.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/JavadocDetailNodeParser.java
@@ -125,12 +125,12 @@ public class JavadocDetailNodeParser {
             result.firstNonTightHtmlTag = getFirstNonTightHtmlTag(javadocParser,
                     errorListener.offset);
         }
-        catch (ParseCancellationException | IllegalArgumentException ex) {
+        catch (ParseCancellationException | IllegalArgumentException exc) {
             ParseErrorMessage parseErrorMessage = null;
 
-            if (ex.getCause() instanceof FailedPredicateException
-                    || ex.getCause() instanceof NoViableAltException) {
-                final RecognitionException recognitionEx = (RecognitionException) ex.getCause();
+            if (exc.getCause() instanceof FailedPredicateException
+                    || exc.getCause() instanceof NoViableAltException) {
+                final RecognitionException recognitionEx = (RecognitionException) exc.getCause();
                 if (recognitionEx.getCtx() instanceof JavadocParser.HtmlTagContext) {
                     final Token htmlTagNameStart = getMissedHtmlTag(recognitionEx);
                     parseErrorMessage = new ParseErrorMessage(

--- a/src/main/java/com/puppycrawl/tools/checkstyle/JavadocPropertiesGenerator.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/JavadocPropertiesGenerator.java
@@ -87,9 +87,9 @@ public final class JavadocPropertiesGenerator {
                 writePropertiesFile(cliOptions);
             }
         }
-        catch (ParameterException ex) {
-            System.err.println(ex.getMessage());
-            ex.getCommandLine().usage(System.err);
+        catch (ParameterException exc) {
+            System.err.println(exc.getMessage());
+            exc.getCommandLine().usage(System.err);
         }
     }
 
@@ -108,9 +108,9 @@ public final class JavadocPropertiesGenerator {
                 iteratePublicStaticIntFields(objBlock, writer::println);
             }
         }
-        catch (IOException ex) {
+        catch (IOException exc) {
             throw new CheckstyleException("Failed to write javadoc properties of '"
-                    + options.inputFile + "' to '" + options.outputFile + "'", ex);
+                    + options.inputFile + "' to '" + options.outputFile + "'", exc);
         }
     }
 

--- a/src/main/java/com/puppycrawl/tools/checkstyle/Main.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/Main.java
@@ -131,16 +131,16 @@ public final class Main {
                 errorCounter = exitStatus;
             }
         }
-        catch (ParameterException ex) {
+        catch (ParameterException exc) {
             exitStatus = EXIT_WITH_INVALID_USER_INPUT_CODE;
-            System.err.println(ex.getMessage());
+            System.err.println(exc.getMessage());
             System.err.println("Usage: checkstyle [OPTIONS]... file(s) or folder(s) ...");
             System.err.println("Try 'checkstyle --help' for more information.");
         }
-        catch (CheckstyleException ex) {
+        catch (CheckstyleException exc) {
             exitStatus = EXIT_WITH_CHECKSTYLE_EXCEPTION_CODE;
             errorCounter = 1;
-            ex.printStackTrace();
+            exc.printStackTrace();
         }
         finally {
             // return exit code base on validation of Checker
@@ -446,11 +446,11 @@ public final class Main {
         try (InputStream stream = Files.newInputStream(file.toPath())) {
             properties.load(stream);
         }
-        catch (final IOException ex) {
+        catch (final IOException exc) {
             final LocalizedMessage loadPropertiesExceptionMessage = new LocalizedMessage(
                     Definitions.CHECKSTYLE_BUNDLE, Main.class,
                     LOAD_PROPERTIES_EXCEPTION, file.getAbsolutePath());
-            throw new CheckstyleException(loadPropertiesExceptionMessage.getMessage(), ex);
+            throw new CheckstyleException(loadPropertiesExceptionMessage.getMessage(), exc);
         }
 
         return ChainedPropertyUtil.getResolvedProperties(properties);

--- a/src/main/java/com/puppycrawl/tools/checkstyle/PackageNamesLoader.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/PackageNamesLoader.java
@@ -152,11 +152,11 @@ public final class PackageNamesLoader
 
             result = namesLoader.packageNames;
         }
-        catch (IOException ex) {
-            throw new CheckstyleException("unable to get package file resources", ex);
+        catch (IOException exc) {
+            throw new CheckstyleException("unable to get package file resources", exc);
         }
-        catch (ParserConfigurationException | SAXException ex) {
-            throw new CheckstyleException("unable to open one of package files", ex);
+        catch (ParserConfigurationException | SAXException exc) {
+            throw new CheckstyleException("unable to open one of package files", exc);
         }
 
         return Collections.unmodifiableSet(result);
@@ -176,8 +176,8 @@ public final class PackageNamesLoader
             final InputSource source = new InputSource(stream);
             namesLoader.parseInputSource(source);
         }
-        catch (IOException ex) {
-            throw new CheckstyleException("unable to open " + packageFile, ex);
+        catch (IOException exc) {
+            throw new CheckstyleException("unable to open " + packageFile, exc);
         }
     }
 

--- a/src/main/java/com/puppycrawl/tools/checkstyle/PackageObjectFactory.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/PackageObjectFactory.java
@@ -369,8 +369,8 @@ public class PackageObjectFactory implements ModuleFactory {
             try {
                 instance = clazz.getDeclaredConstructor().newInstance();
             }
-            catch (final ReflectiveOperationException ex) {
-                throw new CheckstyleException("Unable to instantiate " + className, ex);
+            catch (final ReflectiveOperationException exc) {
+                throw new CheckstyleException("Unable to instantiate " + className, exc);
             }
         }
 

--- a/src/main/java/com/puppycrawl/tools/checkstyle/PropertyCacheFile.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/PropertyCacheFile.java
@@ -223,9 +223,9 @@ public final class PropertyCacheFile {
 
             return new BigInteger(1, digest.digest()).toString(BASE_16).toUpperCase(Locale.ROOT);
         }
-        catch (final IOException | NoSuchAlgorithmException ex) {
+        catch (final IOException | NoSuchAlgorithmException exc) {
             // rethrow as unchecked exception
-            throw new IllegalStateException("Unable to calculate hashcode.", ex);
+            throw new IllegalStateException("Unable to calculate hashcode.", exc);
         }
     }
 
@@ -272,12 +272,12 @@ public final class PropertyCacheFile {
                 resources.add(new ExternalResource(EXTERNAL_RESOURCE_KEY_PREFIX + location,
                         contentHashSum));
             }
-            catch (CheckstyleException | IOException ex) {
+            catch (CheckstyleException | IOException exc) {
                 // if exception happened (configuration resource was not found, connection is not
                 // available, resource is broken, etc.), we need to calculate hash sum based on
                 // exception object content in order to check whether problem is resolved later
                 // and/or the configuration is changed.
-                final String contentHashSum = getHashCodeBasedOnObjectContent(ex);
+                final String contentHashSum = getHashCodeBasedOnObjectContent(exc);
                 resources.add(new ExternalResource(EXTERNAL_RESOURCE_KEY_PREFIX + location,
                         contentHashSum));
             }

--- a/src/main/java/com/puppycrawl/tools/checkstyle/TreeWalker.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/TreeWalker.java
@@ -155,9 +155,9 @@ public final class TreeWalker extends AbstractFileSetCheck implements ExternalRe
                 bean.configure(childConf);
             }
         }
-        catch (final CheckstyleException ex) {
+        catch (final CheckstyleException exc) {
             throw new CheckstyleException("cannot initialize module " + name
-                    + " - " + ex.getMessage(), ex);
+                    + " - " + exc.getMessage(), exc);
         }
         if (module instanceof AbstractCheck) {
             final AbstractCheck check = (AbstractCheck) module;
@@ -195,13 +195,13 @@ public final class TreeWalker extends AbstractFileSetCheck implements ExternalRe
                 rootAST = JavaParser.parse(contents);
             }
             // -@cs[IllegalCatch] There is no other way to obey skipFileOnJavaParseException field
-            catch (Exception ex) {
+            catch (Exception exc) {
                 if (!skipFileOnJavaParseException) {
-                    throw ex;
+                    throw exc;
                 }
                 skip = true;
                 violations.add(new Violation(1, Definitions.CHECKSTYLE_BUNDLE, PARSE_EXCEPTION_MSG,
-                            new Object[] {ex.getMessage()}, javaParseExceptionSeverity, null,
+                            new Object[] {exc.getMessage()}, javaParseExceptionSeverity, null,
                             getClass(), null));
                 addViolations(violations);
             }

--- a/src/main/java/com/puppycrawl/tools/checkstyle/ant/CheckstyleAntTask.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/ant/CheckstyleAntTask.java
@@ -350,8 +350,8 @@ public class CheckstyleAntTask extends Task {
             log("To process the files took " + (processingEndTime - processingStartTime)
                 + TIME_SUFFIX, Project.MSG_VERBOSE);
         }
-        catch (CheckstyleException ex) {
-            throw new BuildException("Unable to process files: " + files, ex);
+        catch (CheckstyleException exc) {
+            throw new BuildException("Unable to process files: " + files, exc);
         }
         final int numWarnings = warningCounter.getCount();
         final boolean okStatus = numErrs <= maxErrors && numWarnings <= maxWarnings;
@@ -404,9 +404,9 @@ public class CheckstyleAntTask extends Task {
             rootModule.setModuleClassLoader(moduleClassLoader);
             rootModule.configure(configuration);
         }
-        catch (final CheckstyleException ex) {
+        catch (final CheckstyleException exc) {
             throw new BuildException(String.format(Locale.ROOT, "Unable to create Root Module: "
-                    + "config {%s}.", config), ex);
+                    + "config {%s}.", config), exc);
         }
         return rootModule;
     }
@@ -426,9 +426,9 @@ public class CheckstyleAntTask extends Task {
             try (InputStream inStream = Files.newInputStream(properties)) {
                 returnValue.load(inStream);
             }
-            catch (final IOException ex) {
+            catch (final IOException exc) {
                 throw new BuildException("Error loading Properties file '"
-                        + properties + "'", ex, getLocation());
+                        + properties + "'", exc, getLocation());
             }
         }
 
@@ -473,9 +473,9 @@ public class CheckstyleAntTask extends Task {
                 }
             }
         }
-        catch (IOException ex) {
+        catch (IOException exc) {
             throw new BuildException(String.format(Locale.ROOT, "Unable to create listeners: "
-                    + "formatters {%s}.", formatters), ex);
+                    + "formatters {%s}.", formatters), exc);
         }
         return listeners;
     }

--- a/src/main/java/com/puppycrawl/tools/checkstyle/api/FileText.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/api/FileText.java
@@ -159,9 +159,9 @@ public final class FileText {
             decoder.onMalformedInput(CodingErrorAction.REPLACE);
             decoder.onUnmappableCharacter(CodingErrorAction.REPLACE);
         }
-        catch (final UnsupportedCharsetException ex) {
+        catch (final UnsupportedCharsetException exc) {
             final String message = "Unsupported charset: " + charsetName;
-            throw new IllegalStateException(message, ex);
+            throw new IllegalStateException(message, exc);
         }
 
         fullText = readFile(file, decoder);

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/OrderedPropertiesCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/OrderedPropertiesCheck.java
@@ -116,8 +116,8 @@ public class OrderedPropertiesCheck extends AbstractFileSetCheck {
         try (InputStream inputStream = Files.newInputStream(file.toPath())) {
             properties.load(inputStream);
         }
-        catch (IOException | IllegalArgumentException ex) {
-            log(1, MSG_IO_EXCEPTION_KEY, file.getPath(), ex.getLocalizedMessage());
+        catch (IOException | IllegalArgumentException exc) {
+            log(1, MSG_IO_EXCEPTION_KEY, file.getPath(), exc.getLocalizedMessage());
         }
 
         String previousProp = "";

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/TranslationCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/TranslationCheck.java
@@ -535,8 +535,8 @@ public class TranslationCheck extends AbstractFileSetCheck {
         }
         // -@cs[IllegalCatch] It is better to catch all exceptions since it can throw
         // a runtime exception.
-        catch (final Exception ex) {
-            logException(ex, file);
+        catch (final Exception exc) {
+            logException(exc, file);
         }
         return keys;
     }

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/UniquePropertiesCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/UniquePropertiesCheck.java
@@ -100,9 +100,9 @@ public class UniquePropertiesCheck extends AbstractFileSetCheck {
         try (InputStream inputStream = Files.newInputStream(file.toPath())) {
             properties.load(inputStream);
         }
-        catch (IOException ex) {
+        catch (IOException exc) {
             log(1, MSG_IO_EXCEPTION_KEY, file.getPath(),
-                    ex.getLocalizedMessage());
+                    exc.getLocalizedMessage());
         }
 
         for (Entry<String, Integer> duplication : properties

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/MatchXpathCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/MatchXpathCheck.java
@@ -111,8 +111,8 @@ public class MatchXpathCheck extends AbstractCheck {
                         new XPathEvaluator(Configuration.newConfiguration());
                 xpathExpression = xpathEvaluator.createExpression(query);
             }
-            catch (XPathException ex) {
-                throw new IllegalStateException("Creating Xpath expression failed: " + query, ex);
+            catch (XPathException exc) {
+                throw new IllegalStateException("Creating Xpath expression failed: " + query, exc);
             }
         }
     }
@@ -162,8 +162,8 @@ public class MatchXpathCheck extends AbstractCheck {
                     .map(item -> (DetailAST) ((AbstractNode) item).getUnderlyingNode())
                     .collect(Collectors.toUnmodifiableList());
         }
-        catch (XPathException ex) {
-            throw new IllegalStateException("Evaluation of Xpath query failed: " + query, ex);
+        catch (XPathException exc) {
+            throw new IllegalStateException("Evaluation of Xpath query failed: " + query, exc);
         }
     }
 }

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/header/AbstractHeaderCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/header/AbstractHeaderCheck.java
@@ -111,9 +111,9 @@ public abstract class AbstractHeaderCheck extends AbstractFileSetCheck
                     headerFile.toURL().openStream()), charset)) {
             loadHeader(headerReader);
         }
-        catch (final IOException ex) {
+        catch (final IOException exc) {
             throw new CheckstyleException(
-                    "unable to load header file " + headerFile, ex);
+                    "unable to load header file " + headerFile, exc);
         }
     }
 
@@ -163,8 +163,8 @@ public abstract class AbstractHeaderCheck extends AbstractFileSetCheck
             try (Reader headerReader = new StringReader(headerExpandedNewLines)) {
                 loadHeader(headerReader);
             }
-            catch (final IOException ex) {
-                throw new IllegalArgumentException("unable to load header", ex);
+            catch (final IOException exc) {
+                throw new IllegalArgumentException("unable to load header", exc);
             }
         }
     }

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/header/RegexpHeaderCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/header/RegexpHeaderCheck.java
@@ -224,11 +224,11 @@ public class RegexpHeaderCheck extends AbstractHeaderCheck {
                     headerRegexps.add(Pattern.compile(line));
                 }
             }
-            catch (final PatternSyntaxException ex) {
+            catch (final PatternSyntaxException exc) {
                 throw new IllegalArgumentException("line "
                         + (headerRegexps.size() + 1)
                         + " in header specification"
-                        + " is not a regular expression", ex);
+                        + " is not a regular expression", exc);
             }
         }
     }

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/imports/ImportControlCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/imports/ImportControlCheck.java
@@ -301,8 +301,8 @@ public class ImportControlCheck extends AbstractCheck implements ExternalResourc
                 root = ImportControlLoader.load(uri);
                 file = uri;
             }
-            catch (CheckstyleException ex) {
-                throw new IllegalArgumentException(UNABLE_TO_LOAD + uri, ex);
+            catch (CheckstyleException exc) {
+                throw new IllegalArgumentException(UNABLE_TO_LOAD + uri, exc);
             }
         }
     }

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/imports/ImportControlLoader.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/imports/ImportControlLoader.java
@@ -270,12 +270,12 @@ public final class ImportControlLoader extends XmlLoader {
             loader.parseInputSource(source);
             return loader.getRoot();
         }
-        catch (ParserConfigurationException | SAXException ex) {
+        catch (ParserConfigurationException | SAXException exc) {
             throw new CheckstyleException("unable to parse " + uri
-                    + " - " + ex.getMessage(), ex);
+                    + " - " + exc.getMessage(), exc);
         }
-        catch (IOException ex) {
-            throw new CheckstyleException("unable to read " + uri, ex);
+        catch (IOException exc) {
+            throw new CheckstyleException("unable to read " + uri, exc);
         }
     }
 
@@ -291,11 +291,11 @@ public final class ImportControlLoader extends XmlLoader {
             final InputSource source = new InputSource(inputStream);
             return load(source, uri);
         }
-        catch (MalformedURLException ex) {
-            throw new CheckstyleException("syntax error in url " + uri, ex);
+        catch (MalformedURLException exc) {
+            throw new CheckstyleException("syntax error in url " + uri, exc);
         }
-        catch (IOException ex) {
-            throw new CheckstyleException("unable to find " + uri, ex);
+        catch (IOException exc) {
+            throw new CheckstyleException("unable to find " + uri, exc);
         }
     }
 

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocPackageCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocPackageCheck.java
@@ -109,9 +109,9 @@ public class JavadocPackageCheck extends AbstractFileSetCheck {
         try {
             dir = file.getCanonicalFile().getParentFile();
         }
-        catch (IOException ex) {
+        catch (IOException exc) {
             throw new CheckstyleException(
-                    "Exception while getting canonical path to file " + file.getPath(), ex);
+                    "Exception while getting canonical path to file " + file.getPath(), exc);
         }
         final boolean isDirChecked = !directoriesChecked.add(dir);
         if (!isDirChecked) {

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/regexp/RegexpOnFilenameCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/regexp/RegexpOnFilenameCheck.java
@@ -225,9 +225,9 @@ public class RegexpOnFilenameCheck extends AbstractFileSetCheck {
         try {
             return file.getCanonicalFile().getParent();
         }
-        catch (IOException ex) {
+        catch (IOException exc) {
             throw new CheckstyleException("unable to create canonical path names for "
-                    + file.getAbsolutePath(), ex);
+                    + file.getAbsolutePath(), exc);
         }
     }
 

--- a/src/main/java/com/puppycrawl/tools/checkstyle/filters/SuppressWithNearbyCommentFilter.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/filters/SuppressWithNearbyCommentFilter.java
@@ -425,9 +425,9 @@ public class SuppressWithNearbyCommentFilter
                     lastLine = line;
                 }
             }
-            catch (final PatternSyntaxException ex) {
+            catch (final PatternSyntaxException exc) {
                 throw new IllegalArgumentException(
-                    "unable to parse expanded comment " + format, ex);
+                    "unable to parse expanded comment " + format, exc);
             }
         }
 
@@ -444,9 +444,9 @@ public class SuppressWithNearbyCommentFilter
             try {
                 return Integer.parseInt(format);
             }
-            catch (final NumberFormatException ex) {
+            catch (final NumberFormatException exc) {
                 throw new IllegalArgumentException("unable to parse influence from '" + text
-                        + "' using " + influenceFormat, ex);
+                        + "' using " + influenceFormat, exc);
             }
         }
 

--- a/src/main/java/com/puppycrawl/tools/checkstyle/filters/SuppressWithNearbyTextFilter.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/filters/SuppressWithNearbyTextFilter.java
@@ -234,8 +234,8 @@ public class SuppressWithNearbyTextFilter extends AbstractAutomaticBean implemen
             try {
                 result = new FileText(file, StandardCharsets.UTF_8.name());
             }
-            catch (IOException ex) {
-                throw new IllegalStateException("Cannot read source file: " + fileName, ex);
+            catch (IOException exc) {
+                throw new IllegalStateException("Cannot read source file: " + fileName, exc);
             }
         }
 
@@ -351,9 +351,9 @@ public class SuppressWithNearbyTextFilter extends AbstractAutomaticBean implemen
                 firstLine = Math.min(lineNo, lineNo + range);
                 lastLine = Math.max(lineNo, lineNo + range);
             }
-            catch (final PatternSyntaxException ex) {
+            catch (final PatternSyntaxException exc) {
                 throw new IllegalArgumentException(
-                    "unable to parse expanded comment " + format, ex);
+                    "unable to parse expanded comment " + format, exc);
             }
         }
 
@@ -370,9 +370,9 @@ public class SuppressWithNearbyTextFilter extends AbstractAutomaticBean implemen
             try {
                 return Integer.parseInt(format);
             }
-            catch (final NumberFormatException ex) {
+            catch (final NumberFormatException exc) {
                 throw new IllegalArgumentException("unable to parse line range from '" + text
-                        + "' using " + lineRange, ex);
+                        + "' using " + lineRange, exc);
             }
         }
 

--- a/src/main/java/com/puppycrawl/tools/checkstyle/filters/SuppressWithPlainTextCommentFilter.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/filters/SuppressWithPlainTextCommentFilter.java
@@ -229,8 +229,8 @@ public class SuppressWithPlainTextCommentFilter extends AbstractAutomaticBean im
             try {
                 result = new FileText(file, StandardCharsets.UTF_8.name());
             }
-            catch (IOException ex) {
-                throw new IllegalStateException("Cannot read source file: " + fileName, ex);
+            catch (IOException exc) {
+                throw new IllegalStateException("Cannot read source file: " + fileName, exc);
             }
         }
 
@@ -372,9 +372,9 @@ public class SuppressWithPlainTextCommentFilter extends AbstractAutomaticBean im
                     eventIdRegexp = Pattern.compile(format);
                 }
             }
-            catch (final PatternSyntaxException ex) {
+            catch (final PatternSyntaxException exc) {
                 throw new IllegalArgumentException(
-                    "unable to parse expanded comment " + format, ex);
+                    "unable to parse expanded comment " + format, exc);
             }
         }
 

--- a/src/main/java/com/puppycrawl/tools/checkstyle/filters/SuppressionCommentFilter.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/filters/SuppressionCommentFilter.java
@@ -472,9 +472,9 @@ public class SuppressionCommentFilter
                     tagIdRegexp = Pattern.compile(format);
                 }
             }
-            catch (final PatternSyntaxException ex) {
+            catch (final PatternSyntaxException exc) {
                 throw new IllegalArgumentException(
-                    "unable to parse expanded comment " + format, ex);
+                    "unable to parse expanded comment " + format, exc);
             }
         }
 

--- a/src/main/java/com/puppycrawl/tools/checkstyle/filters/SuppressionsLoader.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/filters/SuppressionsLoader.java
@@ -171,9 +171,9 @@ public final class SuppressionsLoader
             final String columns = attributes.getValue(ATTRIBUTE_NAME_COLUMNS);
             suppress = new SuppressFilterElement(files, checks, message, modId, lines, columns);
         }
-        catch (final PatternSyntaxException ex) {
+        catch (final PatternSyntaxException exc) {
             // -@cs[IllegalInstantiation] SAXException is in the overridden method signature
-            throw new SAXException("invalid files or checks or message format", ex);
+            throw new SAXException("invalid files or checks or message format", exc);
         }
         return suppress;
     }
@@ -200,10 +200,10 @@ public final class SuppressionsLoader
             final String xpathQuery = attributes.getValue(ATTRIBUTE_NAME_QUERY);
             filter = new XpathFilterElement(files, checks, message, modId, xpathQuery);
         }
-        catch (final PatternSyntaxException ex) {
+        catch (final PatternSyntaxException exc) {
             // -@cs[IllegalInstantiation] SAXException is in the overridden method signature
             throw new SAXException("invalid files or checks or message format for suppress-xpath",
-                    ex);
+                    exc);
         }
         return filter;
     }
@@ -276,21 +276,21 @@ public final class SuppressionsLoader
             suppressionsLoader.parseInputSource(source);
             return suppressionsLoader;
         }
-        catch (final FileNotFoundException ex) {
-            throw new CheckstyleException(UNABLE_TO_FIND_ERROR_MESSAGE + sourceName, ex);
+        catch (final FileNotFoundException exc) {
+            throw new CheckstyleException(UNABLE_TO_FIND_ERROR_MESSAGE + sourceName, exc);
         }
-        catch (final ParserConfigurationException | SAXException ex) {
+        catch (final ParserConfigurationException | SAXException exc) {
             final String message = String.format(Locale.ROOT, "Unable to parse %s - %s",
-                    sourceName, ex.getMessage());
-            throw new CheckstyleException(message, ex);
+                    sourceName, exc.getMessage());
+            throw new CheckstyleException(message, exc);
         }
-        catch (final IOException ex) {
-            throw new CheckstyleException("Unable to read " + sourceName, ex);
+        catch (final IOException exc) {
+            throw new CheckstyleException("Unable to read " + sourceName, exc);
         }
-        catch (final NumberFormatException ex) {
+        catch (final NumberFormatException exc) {
             final String message = String.format(Locale.ROOT, "Number format exception %s - %s",
-                    sourceName, ex.getMessage());
-            throw new CheckstyleException(message, ex);
+                    sourceName, exc.getMessage());
+            throw new CheckstyleException(message, exc);
         }
     }
 

--- a/src/main/java/com/puppycrawl/tools/checkstyle/filters/XpathFilterElement.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/filters/XpathFilterElement.java
@@ -110,8 +110,8 @@ public class XpathFilterElement implements TreeWalkerFilter {
             try {
                 xpathExpression = xpathEvaluator.createExpression(xpathQuery);
             }
-            catch (XPathException ex) {
-                throw new IllegalArgumentException("Incorrect xpath query: " + xpathQuery, ex);
+            catch (XPathException exc) {
+                throw new IllegalArgumentException("Incorrect xpath query: " + xpathQuery, exc);
             }
         }
         isEmptyConfig = fileRegexp == null
@@ -202,9 +202,9 @@ public class XpathFilterElement implements TreeWalkerFilter {
                     xpathExpression.createDynamicContext(rootNode);
             items = xpathExpression.evaluate(xpathDynamicContext);
         }
-        catch (XPathException ex) {
+        catch (XPathException exc) {
             throw new IllegalStateException("Cannot initialize context and evaluate query: "
-                    + xpathQuery, ex);
+                    + xpathQuery, exc);
         }
         return items;
     }

--- a/src/main/java/com/puppycrawl/tools/checkstyle/gui/MainFrame.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/gui/MainFrame.java
@@ -204,8 +204,8 @@ public class MainFrame extends JFrame {
             textArea.setText(model.getText());
             treeTable.setLinePositionList(model.getLinesToPosition());
         }
-        catch (final CheckstyleException ex) {
-            JOptionPane.showMessageDialog(this, ex.getMessage());
+        catch (final CheckstyleException exc) {
+            JOptionPane.showMessageDialog(this, exc.getMessage());
         }
     }
 

--- a/src/main/java/com/puppycrawl/tools/checkstyle/gui/MainFrameModel.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/gui/MainFrameModel.java
@@ -232,11 +232,11 @@ public class MainFrameModel {
                 linesToPosition = linesToPositionTemp;
                 text = sb.toString();
             }
-            catch (IOException ex) {
+            catch (IOException exc) {
                 final String exceptionMsg = String.format(Locale.ROOT,
                     "%s occurred while opening file %s.",
-                    ex.getClass().getSimpleName(), file.getPath());
-                throw new CheckstyleException(exceptionMsg, ex);
+                    exc.getClass().getSimpleName(), file.getPath());
+                throw new CheckstyleException(exceptionMsg, exc);
             }
         }
     }

--- a/src/main/java/com/puppycrawl/tools/checkstyle/meta/JavadocMetadataScraper.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/meta/JavadocMetadataScraper.java
@@ -239,10 +239,10 @@ public class JavadocMetadataScraper extends AbstractJavadocCheck {
                 try {
                     XmlMetaWriter.write(moduleDetails);
                 }
-                catch (TransformerException | ParserConfigurationException ex) {
+                catch (TransformerException | ParserConfigurationException exc) {
                     throw new IllegalStateException(
                             "Failed to write metadata into XML file for module: "
-                                    + getModuleSimpleName(), ex);
+                                    + getModuleSimpleName(), exc);
                 }
             }
             if (!writeXmlOutput) {

--- a/src/main/java/com/puppycrawl/tools/checkstyle/meta/XmlMetaReader.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/meta/XmlMetaReader.java
@@ -100,9 +100,9 @@ public final class XmlMetaReader {
                 moduleDetails = read(XmlMetaReader.class.getResourceAsStream("/" + fileName),
                         moduleType);
             }
-            catch (ParserConfigurationException | IOException | SAXException ex) {
+            catch (ParserConfigurationException | IOException | SAXException exc) {
                 throw new IllegalStateException("Problem to read all modules including third "
-                        + "party if any. Problem detected at file: " + fileName, ex);
+                        + "party if any. Problem detected at file: " + fileName, exc);
             }
             result.add(moduleDetails);
         }

--- a/src/main/java/com/puppycrawl/tools/checkstyle/site/SiteUtil.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/site/SiteUtil.java
@@ -395,10 +395,10 @@ public final class SiteUtil {
 
             return checkstyleMessages;
         }
-        catch (ClassNotFoundException ex) {
+        catch (ClassNotFoundException exc) {
             final String message = String.format(Locale.ROOT, "Couldn't find class: %s",
                     module.getName());
-            throw new MacroExecutionException(message, ex);
+            throw new MacroExecutionException(message, exc);
         }
     }
 
@@ -417,8 +417,8 @@ public final class SiteUtil {
             field.trySetAccessible();
             return field.get(instance);
         }
-        catch (IllegalAccessException ex) {
-            throw new MacroExecutionException("Couldn't get field value", ex);
+        catch (IllegalAccessException exc) {
+            throw new MacroExecutionException("Couldn't get field value", exc);
         }
     }
 
@@ -434,8 +434,8 @@ public final class SiteUtil {
         try {
             return factory.createModule(moduleName);
         }
-        catch (CheckstyleException ex) {
-            throw new MacroExecutionException("Couldn't find class: " + moduleName, ex);
+        catch (CheckstyleException exc) {
+            throw new MacroExecutionException("Couldn't find class: " + moduleName, exc);
         }
     }
 
@@ -451,8 +451,8 @@ public final class SiteUtil {
             final Set<String> packageNames = PackageNamesLoader.getPackageNames(cl);
             return new PackageObjectFactory(packageNames, cl);
         }
-        catch (CheckstyleException ex) {
-            throw new MacroExecutionException("Couldn't load checkstyle modules", ex);
+        catch (CheckstyleException exc) {
+            throw new MacroExecutionException("Couldn't load checkstyle modules", exc);
         }
     }
 

--- a/src/main/java/com/puppycrawl/tools/checkstyle/utils/CommonUtil.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/utils/CommonUtil.java
@@ -104,9 +104,9 @@ public final class CommonUtil {
         try {
             return Pattern.compile(pattern, flags);
         }
-        catch (final PatternSyntaxException ex) {
+        catch (final PatternSyntaxException exc) {
             throw new IllegalArgumentException(
-                "Failed to initialise regular expression " + pattern, ex);
+                "Failed to initialise regular expression " + pattern, exc);
         }
     }
 
@@ -287,8 +287,8 @@ public final class CommonUtil {
         try {
             return targetClass.getConstructor(parameterTypes);
         }
-        catch (NoSuchMethodException ex) {
-            throw new IllegalStateException(ex);
+        catch (NoSuchMethodException exc) {
+            throw new IllegalStateException(exc);
         }
     }
 
@@ -309,8 +309,8 @@ public final class CommonUtil {
         try {
             return constructor.newInstance(parameters);
         }
-        catch (InstantiationException | IllegalAccessException | InvocationTargetException ex) {
-            throw new IllegalStateException(ex);
+        catch (InstantiationException | IllegalAccessException | InvocationTargetException exc) {
+            throw new IllegalStateException(exc);
         }
     }
 
@@ -326,8 +326,8 @@ public final class CommonUtil {
             try {
                 closeable.close();
             }
-            catch (IOException ex) {
-                throw new IllegalStateException("Cannot close the stream", ex);
+            catch (IOException exc) {
+                throw new IllegalStateException("Cannot close the stream", exc);
             }
         }
     }
@@ -435,8 +435,8 @@ public final class CommonUtil {
         try {
             uri = configUrl.toURI();
         }
-        catch (final URISyntaxException ex) {
-            throw new CheckstyleException(UNABLE_TO_FIND_EXCEPTION_PREFIX + filename, ex);
+        catch (final URISyntaxException exc) {
+            throw new CheckstyleException(UNABLE_TO_FIND_EXCEPTION_PREFIX + filename, exc);
         }
 
         return uri;

--- a/src/main/java/com/puppycrawl/tools/checkstyle/utils/XpathUtil.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/utils/XpathUtil.java
@@ -192,10 +192,10 @@ public final class XpathUtil {
                 .map(AstTreeStringPrinter::printBranch)
                 .collect(Collectors.joining(DELIMITER));
         }
-        catch (XPathException ex) {
+        catch (XPathException exc) {
             final String errMsg = String.format(Locale.ROOT,
                 "Error during evaluation for xpath: %s, file: %s", xpath, file.getCanonicalPath());
-            throw new CheckstyleException(errMsg, ex);
+            throw new CheckstyleException(errMsg, exc);
         }
     }
 

--- a/src/test/java/com/puppycrawl/tools/checkstyle/AbstractAutomaticBeanTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/AbstractAutomaticBeanTest.java
@@ -49,13 +49,13 @@ public class AbstractAutomaticBeanTest {
             assertWithMessage("Exception is expected")
                     .fail();
         }
-        catch (CheckstyleException ex) {
+        catch (CheckstyleException exc) {
             assertWithMessage("Exceptions cause should be null")
-                    .that(ex)
+                    .that(exc)
                     .hasCauseThat()
                     .isNull();
             assertWithMessage("Invalid exception message")
-                    .that(ex)
+                    .that(exc)
                     .hasMessageThat()
                     .isEqualTo("Property 'NonExistent' does not exist,"
                             + " please check the documentation");
@@ -72,13 +72,13 @@ public class AbstractAutomaticBeanTest {
             assertWithMessage("Exception is expected")
                     .fail();
         }
-        catch (CheckstyleException ex) {
+        catch (CheckstyleException exc) {
             assertWithMessage("Exceptions cause should be null")
-                    .that(ex)
+                    .that(exc)
                     .hasCauseThat()
                     .isNull();
             assertWithMessage("Invalid exception message")
-                    .that(ex)
+                    .that(exc)
                     .hasMessageThat()
                     .isEqualTo("Property 'privateField' does not exist,"
                             + " please check the documentation");
@@ -95,12 +95,12 @@ public class AbstractAutomaticBeanTest {
             assertWithMessage("Exception is expected")
                     .fail();
         }
-        catch (CheckstyleException ex) {
+        catch (CheckstyleException exc) {
             final String expectedMessage = "dummy is not allowed as a child in bean config. "
                     + "Please review 'Parent Module' section for this Check"
                     + " in web documentation if Check is standard.";
             assertWithMessage("Invalid exception message")
-                    .that(ex)
+                    .that(exc)
                     .hasMessageThat()
                     .isEqualTo(expectedMessage);
         }
@@ -118,9 +118,9 @@ public class AbstractAutomaticBeanTest {
             assertWithMessage("expecting checkstyle exception")
                     .fail();
         }
-        catch (CheckstyleException ex) {
+        catch (CheckstyleException exc) {
             assertWithMessage("Invalid exception message")
-                    .that(ex)
+                    .that(exc)
                     .hasMessageThat()
                     .isEqualTo("childConf is not allowed as a "
                             + "child in parentConf. Please review 'Parent Module' section "
@@ -138,14 +138,14 @@ public class AbstractAutomaticBeanTest {
             assertWithMessage("InvocationTargetException is expected")
                     .fail();
         }
-        catch (CheckstyleException ex) {
+        catch (CheckstyleException exc) {
             final String expected = "Cannot set property 'exceptionalMethod' to '123.0'";
             assertWithMessage("Invalid exception cause, should be: ReflectiveOperationException")
-                    .that(ex)
+                    .that(exc)
                     .hasCauseThat()
                     .isInstanceOf(ReflectiveOperationException.class);
             assertWithMessage("Invalid exception message, should start with: " + expected)
-                    .that(ex)
+                    .that(exc)
                     .hasMessageThat()
                     .isEqualTo(expected);
         }
@@ -161,14 +161,14 @@ public class AbstractAutomaticBeanTest {
             assertWithMessage("InvocationTargetException is expected")
                     .fail();
         }
-        catch (CheckstyleException ex) {
+        catch (CheckstyleException exc) {
             final String expected = "illegal value ";
             assertWithMessage("Invalid exception cause, should be: ConversionException")
-                    .that(ex)
+                    .that(exc)
                     .hasCauseThat()
                     .isInstanceOf(ConversionException.class);
             assertWithMessage("Invalid exception message, should start with: " + expected)
-                    .that(ex)
+                    .that(exc)
                     .hasMessageThat()
                     .startsWith(expected);
         }
@@ -185,9 +185,9 @@ public class AbstractAutomaticBeanTest {
             assertWithMessage("exception expected")
                     .fail();
         }
-        catch (IllegalStateException ex) {
+        catch (IllegalStateException exc) {
             assertWithMessage("Invalid exception message")
-                    .that(ex)
+                    .that(exc)
                     .hasMessageThat()
                     .isEqualTo("null,wrongVal,0,someValue");
         }
@@ -272,9 +272,9 @@ public class AbstractAutomaticBeanTest {
             assertWithMessage("Exception is expected")
                     .fail();
         }
-        catch (CheckstyleException ex) {
+        catch (CheckstyleException exc) {
             assertWithMessage("Error message is not expected")
-                    .that(ex)
+                    .that(exc)
                     .hasMessageThat()
                     .isEqualTo("illegal value 'BAD' for property 'uri'");
         }

--- a/src/test/java/com/puppycrawl/tools/checkstyle/AstTreeStringPrinterTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/AstTreeStringPrinterTest.java
@@ -55,12 +55,12 @@ public class AstTreeStringPrinterTest extends AbstractTreeTestSupport {
             AstTreeStringPrinter.printFileAst(input, JavaParser.Options.WITHOUT_COMMENTS);
             assertWithMessage("exception expected").fail();
         }
-        catch (CheckstyleException ex) {
+        catch (CheckstyleException exc) {
             assertWithMessage("Invalid class")
-                .that(ex.getCause())
+                .that(exc.getCause())
                 .isInstanceOf(IllegalStateException.class);
             assertWithMessage("Invalid exception message")
-                .that(ex.getCause().getMessage())
+                .that(exc.getCause().getMessage())
                 .isEqualTo("2:0: no viable alternative at input 'classD'");
         }
     }

--- a/src/test/java/com/puppycrawl/tools/checkstyle/CheckerTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/CheckerTest.java
@@ -446,9 +446,9 @@ public class CheckerTest extends AbstractModuleTestSupport {
             checker.setCharset("UNKNOWN-CHARSET");
             assertWithMessage("Exception is expected").fail();
         }
-        catch (UnsupportedEncodingException ex) {
+        catch (UnsupportedEncodingException exc) {
             assertWithMessage("Error message is not expected")
-                .that(ex.getMessage())
+                .that(exc.getMessage())
                 .isEqualTo("unsupported charset: 'UNKNOWN-CHARSET'");
         }
     }
@@ -468,9 +468,9 @@ public class CheckerTest extends AbstractModuleTestSupport {
             checker.finishLocalSetup();
             assertWithMessage("Exception is expected").fail();
         }
-        catch (CheckstyleException ex) {
+        catch (CheckstyleException exc) {
             assertWithMessage("Error message is not expected")
-                .that(ex.getMessage())
+                .that(exc.getMessage())
                 .isEqualTo("if no custom moduleFactory is set,"
                     + " moduleClassLoader must be specified");
         }
@@ -535,9 +535,9 @@ public class CheckerTest extends AbstractModuleTestSupport {
             checker.setupChild(config);
             assertWithMessage("Exception is expected").fail();
         }
-        catch (CheckstyleException ex) {
+        catch (CheckstyleException exc) {
             assertWithMessage("Error message is not expected")
-                .that(ex.getMessage())
+                .that(exc.getMessage())
                 .isEqualTo("java.lang.String is not allowed as a child in Checker");
         }
     }
@@ -550,9 +550,9 @@ public class CheckerTest extends AbstractModuleTestSupport {
             createChecker(checkConfig);
             assertWithMessage("Exception is expected").fail();
         }
-        catch (CheckstyleException ex) {
+        catch (CheckstyleException exc) {
             assertWithMessage("Error message is not expected")
-                .that(ex.getMessage())
+                .that(exc.getMessage())
                 .isEqualTo("cannot initialize module com.puppycrawl.tools.checkstyle.TreeWalker"
                         + " - cannot initialize module " + checkConfig.getName()
                         + " - Property '$$No such property'"
@@ -592,9 +592,9 @@ public class CheckerTest extends AbstractModuleTestSupport {
             checker.destroy();
             assertWithMessage("Exception did not happen").fail();
         }
-        catch (IllegalStateException ex) {
+        catch (IllegalStateException exc) {
             assertWithMessage("Cause of exception differs from IOException")
-                    .that(ex.getCause())
+                    .that(exc.getCause())
                     .isInstanceOf(IOException.class);
         }
     }
@@ -1075,9 +1075,9 @@ public class CheckerTest extends AbstractModuleTestSupport {
             execute(checkConfig, filePath);
             assertWithMessage("Exception is expected").fail();
         }
-        catch (CheckstyleException ex) {
+        catch (CheckstyleException exc) {
             assertWithMessage("Error message is not expected")
-                .that(ex.getMessage())
+                .that(exc.getMessage())
                 .isEqualTo("Exception was thrown while processing " + filePath);
         }
     }
@@ -1105,9 +1105,9 @@ public class CheckerTest extends AbstractModuleTestSupport {
             checker.process(Collections.singletonList(new File(filePath)));
             assertWithMessage("Exception is expected").fail();
         }
-        catch (CheckstyleException ex) {
+        catch (CheckstyleException exc) {
             assertWithMessage("Error message is not expected")
-                .that(ex.getMessage())
+                .that(exc.getMessage())
                 .isEqualTo("Exception was thrown while processing " + filePath);
 
             // destroy is called by Main
@@ -1311,13 +1311,13 @@ public class CheckerTest extends AbstractModuleTestSupport {
             checker.process(filesToProcess);
             assertWithMessage("SecurityException is expected!").fail();
         }
-        catch (CheckstyleException ex) {
+        catch (CheckstyleException exc) {
             assertWithMessage("Error cause differs from SecurityException")
-                    .that(ex)
+                    .that(exc)
                     .hasCauseThat()
                     .isInstanceOf(SecurityException.class);
             assertWithMessage("Error message is not expected")
-                    .that(ex)
+                    .that(exc)
                     .hasCauseThat()
                     .hasMessageThat()
                     .isEqualTo(errorMessage);
@@ -1367,13 +1367,13 @@ public class CheckerTest extends AbstractModuleTestSupport {
             checker.process(filesToProcess);
             assertWithMessage("SecurityException is expected!").fail();
         }
-        catch (CheckstyleException ex) {
+        catch (CheckstyleException exc) {
             assertWithMessage("Error cause differs from SecurityException")
-                    .that(ex)
+                    .that(exc)
                     .hasCauseThat()
                     .isInstanceOf(SecurityException.class);
             assertWithMessage("Error message is not expected")
-                    .that(ex)
+                    .that(exc)
                     .hasCauseThat()
                     .hasMessageThat()
                     .isEqualTo(errorMessage);

--- a/src/test/java/com/puppycrawl/tools/checkstyle/ConfigurationLoaderTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/ConfigurationLoaderTest.java
@@ -109,9 +109,9 @@ public class ConfigurationLoaderTest extends AbstractPathTestSupport {
                 configPath, propertiesExpander, multiThreadModeSettings);
             assertWithMessage("An exception is expected").fail();
         }
-        catch (IllegalArgumentException ex) {
+        catch (IllegalArgumentException exc) {
             assertWithMessage("Invalid exception message")
-                .that(ex.getMessage())
+                .that(exc.getMessage())
                 .isEqualTo("Multi thread mode for Checker module is not implemented");
         }
     }
@@ -157,15 +157,15 @@ public class ConfigurationLoaderTest extends AbstractPathTestSupport {
             loadConfiguration("InputConfigurationLoaderMissingPropertyName.xml");
             assertWithMessage("missing property name").fail();
         }
-        catch (CheckstyleException ex) {
-            assertWithMessage("Invalid exception message: " + ex.getMessage())
-                    .that(ex.getMessage())
+        catch (CheckstyleException exc) {
+            assertWithMessage("Invalid exception message: " + exc.getMessage())
+                    .that(exc.getMessage())
                     .contains("\"name\"");
-            assertWithMessage("Invalid exception message: " + ex.getMessage())
-                    .that(ex.getMessage())
+            assertWithMessage("Invalid exception message: " + exc.getMessage())
+                    .that(exc.getMessage())
                     .contains("\"property\"");
-            assertWithMessage("Invalid exception message: " + ex.getMessage())
-                    .that(ex.getMessage())
+            assertWithMessage("Invalid exception message: " + exc.getMessage())
+                    .that(exc.getMessage())
                     .endsWith(":8:41");
         }
     }
@@ -179,15 +179,15 @@ public class ConfigurationLoaderTest extends AbstractPathTestSupport {
 
             assertWithMessage("missing property name").fail();
         }
-        catch (CheckstyleException ex) {
-            assertWithMessage("Invalid exception message: " + ex.getMessage())
-                    .that(ex.getMessage())
+        catch (CheckstyleException exc) {
+            assertWithMessage("Invalid exception message: " + exc.getMessage())
+                    .that(exc.getMessage())
                     .contains("\"name\"");
-            assertWithMessage("Invalid exception message: " + ex.getMessage())
-                    .that(ex.getMessage())
+            assertWithMessage("Invalid exception message: " + exc.getMessage())
+                    .that(exc.getMessage())
                     .contains("\"property\"");
-            assertWithMessage("Invalid exception message: " + ex.getMessage())
-                    .that(ex.getMessage())
+            assertWithMessage("Invalid exception message: " + exc.getMessage())
+                    .that(exc.getMessage())
                     .endsWith(":8:41");
         }
     }
@@ -198,15 +198,15 @@ public class ConfigurationLoaderTest extends AbstractPathTestSupport {
             loadConfiguration("InputConfigurationLoaderMissingPropertyValue.xml");
             assertWithMessage("missing property value").fail();
         }
-        catch (CheckstyleException ex) {
-            assertWithMessage("Invalid exception message: " + ex.getMessage())
-                    .that(ex.getMessage())
+        catch (CheckstyleException exc) {
+            assertWithMessage("Invalid exception message: " + exc.getMessage())
+                    .that(exc.getMessage())
                     .contains("\"value\"");
-            assertWithMessage("Invalid exception message: " + ex.getMessage())
-                    .that(ex.getMessage())
+            assertWithMessage("Invalid exception message: " + exc.getMessage())
+                    .that(exc.getMessage())
                     .contains("\"property\"");
-            assertWithMessage("Invalid exception message: " + ex.getMessage())
-                    .that(ex.getMessage())
+            assertWithMessage("Invalid exception message: " + exc.getMessage())
+                    .that(exc.getMessage())
                     .endsWith(":8:43");
         }
     }
@@ -217,15 +217,15 @@ public class ConfigurationLoaderTest extends AbstractPathTestSupport {
             loadConfiguration("InputConfigurationLoaderMissingConfigName.xml");
             assertWithMessage("missing module name").fail();
         }
-        catch (CheckstyleException ex) {
-            assertWithMessage("Invalid exception message: " + ex.getMessage())
-                    .that(ex.getMessage())
+        catch (CheckstyleException exc) {
+            assertWithMessage("Invalid exception message: " + exc.getMessage())
+                    .that(exc.getMessage())
                     .contains("\"name\"");
-            assertWithMessage("Invalid exception message: " + ex.getMessage())
-                    .that(ex.getMessage())
+            assertWithMessage("Invalid exception message: " + exc.getMessage())
+                    .that(exc.getMessage())
                     .contains("\"module\"");
-            assertWithMessage("Invalid exception message: " + ex.getMessage())
-                    .that(ex.getMessage())
+            assertWithMessage("Invalid exception message: " + exc.getMessage())
+                    .that(exc.getMessage())
                     .endsWith(":7:23");
         }
     }
@@ -236,15 +236,15 @@ public class ConfigurationLoaderTest extends AbstractPathTestSupport {
             loadConfiguration("InputConfigurationLoaderMissingConfigParent.xml");
             assertWithMessage("missing module parent").fail();
         }
-        catch (CheckstyleException ex) {
-            assertWithMessage("Invalid exception message: " + ex.getMessage())
-                    .that(ex.getMessage())
+        catch (CheckstyleException exc) {
+            assertWithMessage("Invalid exception message: " + exc.getMessage())
+                    .that(exc.getMessage())
                     .contains("\"property\"");
-            assertWithMessage("Invalid exception message: " + ex.getMessage())
-                    .that(ex.getMessage())
+            assertWithMessage("Invalid exception message: " + exc.getMessage())
+                    .that(exc.getMessage())
                     .contains("\"module\"");
-            assertWithMessage("Invalid exception message: " + ex.getMessage())
-                    .that(ex.getMessage())
+            assertWithMessage("Invalid exception message: " + exc.getMessage())
+                    .that(exc.getMessage())
                     .endsWith(":8:38");
         }
     }
@@ -370,9 +370,9 @@ public class ConfigurationLoaderTest extends AbstractPathTestSupport {
                 null, "${a", new PropertiesExpander(props), null);
             assertWithMessage("expected to fail, instead got: " + value).fail();
         }
-        catch (ReflectiveOperationException ex) {
+        catch (ReflectiveOperationException exc) {
             assertWithMessage("Invalid exception cause message")
-                .that(ex)
+                .that(exc)
                 .hasCauseThat()
                 .hasMessageThat()
                 .isEqualTo("Syntax error in property: ${a");
@@ -387,9 +387,9 @@ public class ConfigurationLoaderTest extends AbstractPathTestSupport {
                 null, "${c}", new PropertiesExpander(props), null);
             assertWithMessage("expected to fail, instead got: " + value).fail();
         }
-        catch (ReflectiveOperationException ex) {
+        catch (ReflectiveOperationException exc) {
             assertWithMessage("Invalid exception cause message")
-                .that(ex)
+                .that(exc)
                 .hasCauseThat()
                 .hasMessageThat()
                 .isEqualTo("Property ${c} has not been set");
@@ -520,9 +520,9 @@ public class ConfigurationLoaderTest extends AbstractPathTestSupport {
 
             assertWithMessage("InvocationTargetException is expected").fail();
         }
-        catch (ReflectiveOperationException ex) {
+        catch (ReflectiveOperationException exc) {
             assertWithMessage("Invalid exception cause message")
-                .that(ex)
+                .that(exc)
                     .hasCauseThat()
                         .hasMessageThat()
                         .isEqualTo("Unknown name:" + "hello" + ".");
@@ -535,18 +535,18 @@ public class ConfigurationLoaderTest extends AbstractPathTestSupport {
             loadConfiguration("InputConfigurationLoaderNonexistentProperty.xml");
             assertWithMessage("exception in expected").fail();
         }
-        catch (CheckstyleException ex) {
+        catch (CheckstyleException exc) {
             assertWithMessage("Invalid exception message")
-                .that(ex.getMessage())
+                .that(exc.getMessage())
                 .isEqualTo("unable to parse configuration stream");
             assertWithMessage("Expected cause of type SAXException")
-                .that(ex.getCause())
+                .that(exc.getCause())
                 .isInstanceOf(SAXException.class);
             assertWithMessage("Expected cause of type CheckstyleException")
-                .that(ex.getCause().getCause())
+                .that(exc.getCause().getCause())
                 .isInstanceOf(CheckstyleException.class);
             assertWithMessage("Invalid exception cause message")
-                .that(ex)
+                .that(exc)
                 .hasCauseThat()
                 .hasCauseThat()
                 .hasMessageThat()
@@ -605,9 +605,9 @@ public class ConfigurationLoaderTest extends AbstractPathTestSupport {
 
             assertWithMessage("Exception is expected").fail();
         }
-        catch (CheckstyleException ex) {
+        catch (CheckstyleException exc) {
             assertWithMessage("Invalid exception message")
-                .that(ex.getMessage())
+                .that(exc.getMessage())
                 .isEqualTo("Unable to find: ;InputConfigurationLoaderModuleIgnoreSeverity.xml");
         }
     }

--- a/src/test/java/com/puppycrawl/tools/checkstyle/DetailNodeTreeStringPrinterTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/DetailNodeTreeStringPrinterTest.java
@@ -60,12 +60,12 @@ public class DetailNodeTreeStringPrinterTest extends AbstractTreeTestSupport {
             DetailNodeTreeStringPrinter.printFileAst(file);
             assertWithMessage("Javadoc parser didn't fail on missing end tag").fail();
         }
-        catch (IllegalArgumentException ex) {
+        catch (IllegalArgumentException exc) {
             final String expected = TestUtil.invokeStaticMethod(DetailNodeTreeStringPrinter.class,
                     "getParseErrorMessage",
                     new ParseErrorMessage(0, MSG_JAVADOC_MISSED_HTML_CLOSE, 1, "qwe"));
             assertWithMessage("Generated and expected parse error messages don't match")
-                .that(ex.getMessage())
+                .that(exc.getMessage())
                 .isEqualTo(expected);
         }
     }
@@ -141,12 +141,12 @@ public class DetailNodeTreeStringPrinterTest extends AbstractTreeTestSupport {
             DetailNodeTreeStringPrinter.printFileAst(file);
             assertWithMessage("Exception is expected").fail();
         }
-        catch (IllegalArgumentException ex) {
+        catch (IllegalArgumentException exc) {
             final String expected = TestUtil.invokeStaticMethod(DetailNodeTreeStringPrinter.class,
                     "getParseErrorMessage",
                     new ParseErrorMessage(35, MSG_JAVADOC_MISSED_HTML_CLOSE, 7, "parsing"));
             assertWithMessage("Generated and expected parse error messages don't match")
-                .that(ex.getMessage())
+                .that(exc.getMessage())
                 .isEqualTo(expected);
         }
     }
@@ -159,13 +159,13 @@ public class DetailNodeTreeStringPrinterTest extends AbstractTreeTestSupport {
             DetailNodeTreeStringPrinter.printFileAst(file);
             assertWithMessage("Exception is expected").fail();
         }
-        catch (IllegalArgumentException ex) {
+        catch (IllegalArgumentException exc) {
             final String expected = TestUtil.invokeStaticMethod(DetailNodeTreeStringPrinter.class,
                     "getParseErrorMessage",
                     new ParseErrorMessage(0, MSG_JAVADOC_PARSE_RULE_ERROR,
                             9, "no viable alternative at input '<<'", "HTML_ELEMENT"));
             assertWithMessage("Generated and expected parse error messages don't match")
-                .that(ex.getMessage())
+                .that(exc.getMessage())
                 .isEqualTo(expected);
         }
     }
@@ -178,13 +178,13 @@ public class DetailNodeTreeStringPrinterTest extends AbstractTreeTestSupport {
             DetailNodeTreeStringPrinter.printFileAst(file);
             assertWithMessage("Exception is expected").fail();
         }
-        catch (IllegalArgumentException ex) {
+        catch (IllegalArgumentException exc) {
             final String expected = TestUtil.invokeStaticMethod(DetailNodeTreeStringPrinter.class,
                     "getParseErrorMessage",
                     new ParseErrorMessage(0, MSG_JAVADOC_PARSE_RULE_ERROR,
                             4, "no viable alternative at input '</tag'", "HTML_ELEMENT"));
             assertWithMessage("Generated and expected parse error messages don't match")
-                .that(ex.getMessage())
+                .that(exc.getMessage())
                 .isEqualTo(expected);
         }
     }
@@ -197,12 +197,12 @@ public class DetailNodeTreeStringPrinterTest extends AbstractTreeTestSupport {
             DetailNodeTreeStringPrinter.printFileAst(file);
             assertWithMessage("Exception is expected").fail();
         }
-        catch (IllegalArgumentException ex) {
+        catch (IllegalArgumentException exc) {
             final String expected = TestUtil.invokeStaticMethod(DetailNodeTreeStringPrinter.class,
                     "getParseErrorMessage",
                     new ParseErrorMessage(0, MSG_JAVADOC_MISSED_HTML_CLOSE, 10, "tag2"));
             assertWithMessage("Generated and expected parse error messages don't match")
-                .that(ex.getMessage())
+                .that(exc.getMessage())
                 .isEqualTo(expected);
         }
     }
@@ -215,12 +215,12 @@ public class DetailNodeTreeStringPrinterTest extends AbstractTreeTestSupport {
             DetailNodeTreeStringPrinter.printFileAst(file);
             assertWithMessage("Exception is expected").fail();
         }
-        catch (IllegalArgumentException ex) {
+        catch (IllegalArgumentException exc) {
             final String expected = TestUtil.invokeStaticMethod(DetailNodeTreeStringPrinter.class,
                     "getParseErrorMessage",
                     new ParseErrorMessage(0, MSG_JAVADOC_MISSED_HTML_CLOSE, 3, "a"));
             assertWithMessage("Generated and expected parse error messages don't match")
-                .that(ex.getMessage())
+                .that(exc.getMessage())
                 .isEqualTo(expected);
         }
     }

--- a/src/test/java/com/puppycrawl/tools/checkstyle/JavaParserTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/JavaParserTest.java
@@ -199,17 +199,17 @@ public class JavaParserTest extends AbstractModuleTestSupport {
             JavaParser.parseFile(input, JavaParser.Options.WITH_COMMENTS);
             assertWithMessage("exception expected").fail();
         }
-        catch (CheckstyleException ex) {
+        catch (CheckstyleException exc) {
             assertWithMessage("Invalid exception message")
-                .that(ex.toString())
+                .that(exc.toString())
                 .isEqualTo(CheckstyleException.class.getName()
                             + ": IllegalStateException occurred while parsing file "
                             + input.getAbsolutePath() + ".");
             assertWithMessage("Invalid class")
-                .that(ex.getCause())
+                .that(exc.getCause())
                 .isInstanceOf(IllegalStateException.class);
             assertWithMessage("Invalid exception message")
-                .that(ex.getCause().toString())
+                .that(exc.getCause().toString())
                 .isEqualTo(IllegalStateException.class.getName()
                             + ": 2:0: no viable alternative at input 'classD'");
         }

--- a/src/test/java/com/puppycrawl/tools/checkstyle/JavadocPropertiesGeneratorTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/JavadocPropertiesGeneratorTest.java
@@ -169,13 +169,13 @@ public class JavadocPropertiesGeneratorTest extends AbstractPathTestSupport {
                 "--destfile", DESTFILE_ABSOLUTE_PATH, "NotExistent.java");
             assertWithMessage("Exception was expected").fail();
         }
-        catch (CheckstyleException ex) {
+        catch (CheckstyleException exc) {
             assertWithMessage("Invalid error message")
-                .that(ex.getMessage())
+                .that(exc.getMessage())
                 .isEqualTo("Failed to write javadoc properties of 'NotExistent.java' to '"
                     + DESTFILE_ABSOLUTE_PATH + "'");
 
-            final Throwable cause = ex.getCause();
+            final Throwable cause = exc.getCause();
             assertWithMessage("Invalid error message")
                     .that(cause)
                     .isInstanceOf(FileNotFoundException.class);
@@ -201,14 +201,14 @@ public class JavadocPropertiesGeneratorTest extends AbstractPathTestSupport {
                 getPath("InputJavadocPropertiesGeneratorCorrect.java"));
             assertWithMessage("Exception was expected").fail();
         }
-        catch (CheckstyleException ex) {
+        catch (CheckstyleException exc) {
             final String expectedError = "Failed to write javadoc properties of '"
                 + getPath("InputJavadocPropertiesGeneratorCorrect.java") + "' to '..'";
             assertWithMessage("Invalid error message")
-                .that(ex.getMessage())
+                .that(exc.getMessage())
                 .isEqualTo(expectedError);
 
-            final Throwable cause = ex.getCause();
+            final Throwable cause = exc.getCause();
             assertWithMessage("Invalid error message")
                     .that(cause)
                     .isInstanceOf(FileNotFoundException.class);
@@ -303,9 +303,9 @@ public class JavadocPropertiesGeneratorTest extends AbstractPathTestSupport {
             JavadocPropertiesGenerator.main(path, "--destfile", DESTFILE_ABSOLUTE_PATH);
             assertWithMessage("Exception was expected").fail();
         }
-        catch (IllegalArgumentException ex) {
+        catch (IllegalArgumentException exc) {
             assertWithMessage("Invalid error message")
-                    .that(ex.getMessage())
+                    .that(exc.getMessage())
                     .contains("mismatched input '<EOF>' expecting JAVADOC_INLINE_TAG_END");
         }
         final long size = FileUtils.sizeOf(DESTFILE);
@@ -321,9 +321,9 @@ public class JavadocPropertiesGeneratorTest extends AbstractPathTestSupport {
             JavadocPropertiesGenerator.main(path, "--destfile", DESTFILE_ABSOLUTE_PATH);
             assertWithMessage("Exception was expected").fail();
         }
-        catch (CheckstyleException ex) {
+        catch (CheckstyleException exc) {
             assertWithMessage("Invalid error message")
-                .that(ex.getMessage())
+                .that(exc.getMessage())
                 .isEqualTo("Unsupported inline tag LINK_LITERAL");
         }
         final long size = FileUtils.sizeOf(DESTFILE);
@@ -339,12 +339,12 @@ public class JavadocPropertiesGeneratorTest extends AbstractPathTestSupport {
             JavadocPropertiesGenerator.main(path, "--destfile", DESTFILE_ABSOLUTE_PATH);
             assertWithMessage("Exception was expected").fail();
         }
-        catch (CheckstyleException ex) {
+        catch (CheckstyleException exc) {
             assertWithMessage("Invalid error message")
-                    .that(ex.getMessage())
+                    .that(exc.getMessage())
                     .contains("InputJavadocPropertiesGeneratorParseError.java");
 
-            final Throwable cause = ex.getCause();
+            final Throwable cause = exc.getCause();
             assertWithMessage("Invalid error message")
                     .that(cause)
                     .isInstanceOf(IllegalStateException.class);

--- a/src/test/java/com/puppycrawl/tools/checkstyle/MainTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/MainTest.java
@@ -807,9 +807,9 @@ public class MainTest {
             method.invoke(null, new File("."));
             assertWithMessage("Exception was expected").fail();
         }
-        catch (ReflectiveOperationException ex) {
+        catch (ReflectiveOperationException exc) {
             assertWithMessage("Invalid error cause")
-                    .that(ex)
+                    .that(exc)
                     .hasCauseThat()
                     .isInstanceOf(CheckstyleException.class);
             // We do separate validation for message as in Windows
@@ -818,7 +818,7 @@ public class MainTest {
             final Violation loadPropertiesMessage = new Violation(1,
                     Definitions.CHECKSTYLE_BUNDLE, Main.LOAD_PROPERTIES_EXCEPTION,
                     new String[] {""}, null, getClass(), null);
-            final String causeMessage = ex.getCause().getLocalizedMessage();
+            final String causeMessage = exc.getCause().getLocalizedMessage();
             final String violation = loadPropertiesMessage.getViolation();
             final boolean samePrefix = causeMessage.substring(0, causeMessage.indexOf(' '))
                     .equals(violation

--- a/src/test/java/com/puppycrawl/tools/checkstyle/PackageNamesLoaderTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/PackageNamesLoaderTest.java
@@ -166,9 +166,9 @@ public class PackageNamesLoaderTest extends AbstractPathTestSupport {
             PackageNamesLoader.getPackageNames(new TestUrlsClassLoader(enumeration));
             assertWithMessage("CheckstyleException is expected").fail();
         }
-        catch (CheckstyleException ex) {
+        catch (CheckstyleException exc) {
             assertWithMessage("Invalid exception cause class")
-                    .that(ex)
+                    .that(exc)
                     .hasCauseThat()
                     .isInstanceOf(SAXException.class);
         }
@@ -200,13 +200,13 @@ public class PackageNamesLoaderTest extends AbstractPathTestSupport {
             PackageNamesLoader.getPackageNames(new TestUrlsClassLoader(enumeration));
             assertWithMessage("CheckstyleException is expected").fail();
         }
-        catch (CheckstyleException ex) {
+        catch (CheckstyleException exc) {
             assertWithMessage("Invalid exception cause class")
-                    .that(ex)
+                    .that(exc)
                     .hasCauseThat()
                     .isInstanceOf(IOException.class);
             assertWithMessage("Invalid exception message")
-                    .that(ex)
+                    .that(exc)
                     .hasMessageThat()
                     .isNotEqualTo("unable to get package file resources");
         }
@@ -218,13 +218,13 @@ public class PackageNamesLoaderTest extends AbstractPathTestSupport {
             PackageNamesLoader.getPackageNames(new TestIoExceptionClassLoader());
             assertWithMessage("CheckstyleException is expected").fail();
         }
-        catch (CheckstyleException ex) {
+        catch (CheckstyleException exc) {
             assertWithMessage("Invalid exception cause class")
-                    .that(ex)
+                    .that(exc)
                     .hasCauseThat()
                     .isInstanceOf(IOException.class);
             assertWithMessage("Invalid exception message")
-                .that(ex.getMessage())
+                .that(exc.getMessage())
                 .isEqualTo("unable to get package file resources");
         }
     }

--- a/src/test/java/com/puppycrawl/tools/checkstyle/PackageObjectFactoryTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/PackageObjectFactoryTest.java
@@ -89,9 +89,9 @@ public class PackageObjectFactoryTest {
             final Object test = new PackageObjectFactory(new HashSet<>(), null);
             assertWithMessage("Exception is expected but got " + test).fail();
         }
-        catch (IllegalArgumentException ex) {
+        catch (IllegalArgumentException exc) {
             assertWithMessage("Invalid exception message")
-                .that(ex.getMessage())
+                .that(exc.getMessage())
                 .isEqualTo(NULL_LOADER_MESSAGE);
         }
     }
@@ -102,9 +102,9 @@ public class PackageObjectFactoryTest {
             final Object test = new PackageObjectFactory("test", null);
             assertWithMessage("Exception is expected but got " + test).fail();
         }
-        catch (IllegalArgumentException ex) {
+        catch (IllegalArgumentException exc) {
             assertWithMessage("Invalid exception message")
-                .that(ex.getMessage())
+                .that(exc.getMessage())
                 .isEqualTo(NULL_LOADER_MESSAGE);
         }
     }
@@ -116,9 +116,9 @@ public class PackageObjectFactoryTest {
             final Object test = new PackageObjectFactory(Collections.singleton(null), classLoader);
             assertWithMessage("Exception is expected but got " + test).fail();
         }
-        catch (IllegalArgumentException ex) {
+        catch (IllegalArgumentException exc) {
             assertWithMessage("Invalid exception message")
-                .that(ex.getMessage())
+                .that(exc.getMessage())
                 .isEqualTo(NULL_PACKAGE_MESSAGE);
         }
     }
@@ -130,9 +130,9 @@ public class PackageObjectFactoryTest {
             final Object test = new PackageObjectFactory((String) null, classLoader);
             assertWithMessage("Exception is expected but got " + test).fail();
         }
-        catch (IllegalArgumentException ex) {
+        catch (IllegalArgumentException exc) {
             assertWithMessage("Invalid exception message")
-                .that(ex.getMessage())
+                .that(exc.getMessage())
                 .isEqualTo(NULL_PACKAGE_MESSAGE);
         }
     }
@@ -145,9 +145,9 @@ public class PackageObjectFactoryTest {
                     TRY_IN_ALL_REGISTERED_PACKAGES);
             assertWithMessage("Exception is expected but got " + test).fail();
         }
-        catch (IllegalArgumentException ex) {
+        catch (IllegalArgumentException exc) {
             assertWithMessage("Invalid exception message")
-                .that(ex.getMessage())
+                .that(exc.getMessage())
                 .isEqualTo(NULL_PACKAGE_MESSAGE);
         }
     }
@@ -170,12 +170,12 @@ public class PackageObjectFactoryTest {
             factory.createModule(name);
             assertWithMessage("Exception is expected").fail();
         }
-        catch (CheckstyleException ex) {
+        catch (CheckstyleException exc) {
             final LocalizedMessage exceptionMessage = new LocalizedMessage(
                     Definitions.CHECKSTYLE_BUNDLE, factory.getClass(),
                     UNABLE_TO_INSTANTIATE_EXCEPTION_MESSAGE, name, null);
             assertWithMessage("Invalid exception message")
-                .that(ex.getMessage())
+                .that(exc.getMessage())
                 .isEqualTo(exceptionMessage.getMessage());
         }
     }
@@ -188,7 +188,7 @@ public class PackageObjectFactoryTest {
                 factory.createModule(name);
                 assertWithMessage("Exception is expected").fail();
             }
-            catch (CheckstyleException ex) {
+            catch (CheckstyleException exc) {
                 final String attemptedNames = BASE_PACKAGE + PACKAGE_SEPARATOR + name
                     + STRING_SEPARATOR + name + CHECK_SUFFIX + STRING_SEPARATOR
                     + BASE_PACKAGE + PACKAGE_SEPARATOR + name + CHECK_SUFFIX;
@@ -196,7 +196,7 @@ public class PackageObjectFactoryTest {
                     Definitions.CHECKSTYLE_BUNDLE, factory.getClass(),
                     UNABLE_TO_INSTANTIATE_EXCEPTION_MESSAGE, name, attemptedNames);
                 assertWithMessage("Invalid exception message")
-                    .that(ex.getMessage())
+                    .that(exc.getMessage())
                     .isEqualTo(exceptionMessage.getMessage());
             }
         }
@@ -262,14 +262,14 @@ public class PackageObjectFactoryTest {
             objectFactory.createModule(name);
             assertWithMessage("Exception is expected").fail();
         }
-        catch (CheckstyleException ex) {
+        catch (CheckstyleException exc) {
             final String optionalNames = barPackage + PACKAGE_SEPARATOR + name
                     + STRING_SEPARATOR + fooPackage + PACKAGE_SEPARATOR + name;
             final LocalizedMessage exceptionMessage = new LocalizedMessage(
                     Definitions.CHECKSTYLE_BUNDLE, getClass(),
                     AMBIGUOUS_MODULE_NAME_EXCEPTION_MESSAGE, name, optionalNames);
             assertWithMessage("Invalid exception message")
-                .that(ex.getMessage())
+                .that(exc.getMessage())
                 .isEqualTo(exceptionMessage.getMessage());
         }
     }
@@ -287,7 +287,7 @@ public class PackageObjectFactoryTest {
             objectFactory.createModule(name);
             assertWithMessage("Exception is expected").fail();
         }
-        catch (CheckstyleException ex) {
+        catch (CheckstyleException exc) {
             final String attemptedNames = package1 + PACKAGE_SEPARATOR + name + STRING_SEPARATOR
                     + package2 + PACKAGE_SEPARATOR + name + STRING_SEPARATOR
                     + checkName + STRING_SEPARATOR
@@ -297,7 +297,7 @@ public class PackageObjectFactoryTest {
                     Definitions.CHECKSTYLE_BUNDLE, getClass(),
                     UNABLE_TO_INSTANTIATE_EXCEPTION_MESSAGE, name, attemptedNames);
             assertWithMessage("Invalid exception message")
-                .that(ex.getMessage())
+                .that(exc.getMessage())
                 .isEqualTo(exceptionMessage.getMessage());
         }
     }
@@ -316,7 +316,7 @@ public class PackageObjectFactoryTest {
             objectFactory.createModule(name);
             assertWithMessage("Exception is expected").fail();
         }
-        catch (CheckstyleException ex) {
+        catch (CheckstyleException exc) {
             final String attemptedNames = package1 + PACKAGE_SEPARATOR + name + STRING_SEPARATOR
                     + package2 + PACKAGE_SEPARATOR + name + STRING_SEPARATOR
                     + checkName + STRING_SEPARATOR
@@ -326,7 +326,7 @@ public class PackageObjectFactoryTest {
                     Definitions.CHECKSTYLE_BUNDLE, UNABLE_TO_INSTANTIATE_EXCEPTION_MESSAGE,
                     new String[] {name, attemptedNames}, null, getClass(), null);
             assertWithMessage("Invalid exception message")
-                .that(ex.getMessage())
+                .that(exc.getMessage())
                 .isEqualTo(exceptionMessage.getViolation());
         }
     }
@@ -419,13 +419,13 @@ public class PackageObjectFactoryTest {
             factory.createModule(FailConstructorFileSet.class.getName());
             assertWithMessage("Exception is expected").fail();
         }
-        catch (CheckstyleException ex) {
+        catch (CheckstyleException exc) {
             assertWithMessage("Invalid exception message")
-                .that(ex.getMessage())
+                .that(exc.getMessage())
                 .isEqualTo("Unable to instantiate com.puppycrawl.tools.checkstyle."
                     + "PackageObjectFactoryTest$FailConstructorFileSet");
             assertWithMessage("Invalid exception cause class")
-                .that(ex.getCause().getClass().getSimpleName())
+                .that(exc.getCause().getClass().getSimpleName())
                 .isEqualTo("IllegalAccessException");
         }
     }
@@ -574,7 +574,7 @@ public class PackageObjectFactoryTest {
             objectFactory.createModule(name);
             assertWithMessage("Exception is expected").fail();
         }
-        catch (CheckstyleException ex) {
+        catch (CheckstyleException exc) {
             final String optionalNames = abcPackage + PACKAGE_SEPARATOR + name
                     + STRING_SEPARATOR + barPackage + PACKAGE_SEPARATOR + name
                     + STRING_SEPARATOR + fooPackage + PACKAGE_SEPARATOR + name
@@ -583,7 +583,7 @@ public class PackageObjectFactoryTest {
                     Definitions.CHECKSTYLE_BUNDLE, getClass(),
                     AMBIGUOUS_MODULE_NAME_EXCEPTION_MESSAGE, name, optionalNames);
             assertWithMessage("Invalid exception message")
-                .that(ex.getMessage())
+                .that(exc.getMessage())
                 .isEqualTo(exceptionMessage.getMessage());
         }
     }

--- a/src/test/java/com/puppycrawl/tools/checkstyle/PropertiesExpanderTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/PropertiesExpanderTest.java
@@ -33,9 +33,9 @@ public class PropertiesExpanderTest {
             final Object test = new PropertiesExpander(null);
             assertWithMessage("exception expected but got " + test).fail();
         }
-        catch (IllegalArgumentException ex) {
+        catch (IllegalArgumentException exc) {
             assertWithMessage("Invalid exception message")
-                    .that(ex.getMessage())
+                    .that(exc.getMessage())
                     .isEqualTo("cannot pass null");
         }
     }

--- a/src/test/java/com/puppycrawl/tools/checkstyle/PropertyCacheFileTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/PropertyCacheFileTest.java
@@ -72,9 +72,9 @@ public class PropertyCacheFileTest extends AbstractPathTestSupport {
             final Object test = new PropertyCacheFile(null, "");
             assertWithMessage("exception expected but got " + test).fail();
         }
-        catch (IllegalArgumentException ex) {
+        catch (IllegalArgumentException exc) {
             assertWithMessage("Invalid exception message")
-                .that(ex.getMessage())
+                .that(exc.getMessage())
                 .isEqualTo("config can not be null");
         }
         final Configuration config = new DefaultConfiguration("myName");
@@ -82,9 +82,9 @@ public class PropertyCacheFileTest extends AbstractPathTestSupport {
             final Object test = new PropertyCacheFile(config, null);
             assertWithMessage("exception expected but got " + test).fail();
         }
-        catch (IllegalArgumentException ex) {
+        catch (IllegalArgumentException exc) {
             assertWithMessage("Invalid exception message")
-                .that(ex.getMessage())
+                .that(exc.getMessage())
                 .isEqualTo("fileName can not be null");
         }
     }

--- a/src/test/java/com/puppycrawl/tools/checkstyle/SuppressionsStringPrinterTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/SuppressionsStringPrinterTest.java
@@ -109,9 +109,9 @@ public class SuppressionsStringPrinterTest extends AbstractTreeTestSupport {
                     invalidLineAndColumnNumber, tabWidth);
             assertWithMessage("exception expected").fail();
         }
-        catch (IllegalStateException ex) {
+        catch (IllegalStateException exc) {
             assertWithMessage("Invalid exception message")
-                .that(ex.getMessage())
+                .that(exc.getMessage())
                 .isEqualTo("abc-432 does not match valid format 'line:column'.");
         }
     }
@@ -126,12 +126,12 @@ public class SuppressionsStringPrinterTest extends AbstractTreeTestSupport {
                     lineAndColumnNumber, tabWidth);
             assertWithMessage("exception expected").fail();
         }
-        catch (CheckstyleException ex) {
+        catch (CheckstyleException exc) {
             assertWithMessage("Invalid class")
-                .that(ex.getCause())
+                .that(exc.getCause())
                 .isInstanceOf(IllegalStateException.class);
             assertWithMessage("Invalid exception message")
-                .that(ex.getCause().toString())
+                .that(exc.getCause().toString())
                 .isEqualTo(IllegalStateException.class.getName()
                             + ": 2:0: no viable alternative at input 'classD'");
         }

--- a/src/test/java/com/puppycrawl/tools/checkstyle/ThreadModeSettingsTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/ThreadModeSettingsTest.java
@@ -48,9 +48,9 @@ public class ThreadModeSettingsTest {
             configuration.resolveName(ThreadModeSettings.CHECKER_MODULE_NAME);
             assertWithMessage("An exception is expected").fail();
         }
-        catch (IllegalArgumentException ex) {
+        catch (IllegalArgumentException exc) {
             assertWithMessage("Invalid exception message")
-                    .that(ex.getMessage())
+                    .that(exc.getMessage())
                     .isEqualTo("Multi thread mode for Checker module is not implemented");
         }
     }
@@ -73,9 +73,9 @@ public class ThreadModeSettingsTest {
             configuration.resolveName(ThreadModeSettings.TREE_WALKER_MODULE_NAME);
             assertWithMessage("Exception is expected").fail();
         }
-        catch (IllegalArgumentException ex) {
+        catch (IllegalArgumentException exc) {
             assertWithMessage("Invalid exception message")
-                    .that(ex.getMessage())
+                    .that(exc.getMessage())
                     .isEqualTo("Multi thread mode for TreeWalker module is not implemented");
         }
     }

--- a/src/test/java/com/puppycrawl/tools/checkstyle/TreeWalkerTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/TreeWalkerTest.java
@@ -206,8 +206,8 @@ public class TreeWalkerTest extends AbstractModuleTestSupport {
             execute(checkConfig, getPath("InputTreeWalker.java"));
             assertWithMessage("CheckstyleException is expected").fail();
         }
-        catch (CheckstyleException ex) {
-            final String errorMsg = ex.getMessage();
+        catch (CheckstyleException exc) {
+            final String errorMsg = exc.getMessage();
             final Pattern expected = Pattern.compile(Pattern.quote("cannot initialize module"
                     + " com.puppycrawl.tools.checkstyle.TreeWalker - Token ")
                     + "\"(ENUM_DEF|CLASS_DEF|METHOD_DEF|IMPORT)\""
@@ -263,9 +263,9 @@ public class TreeWalkerTest extends AbstractModuleTestSupport {
             treeWalker.setupChild(config);
             assertWithMessage("Exception is expected").fail();
         }
-        catch (CheckstyleException ex) {
+        catch (CheckstyleException exc) {
             assertWithMessage("Error message is not expected")
-                .that(ex.getMessage())
+                .that(exc.getMessage())
                 .isEqualTo("TreeWalker is not allowed as a parent of java.lang.String "
                     + "Please review 'Parent Module' section for this Check in "
                     + "web documentation if Check is standard.");
@@ -299,16 +299,16 @@ public class TreeWalkerTest extends AbstractModuleTestSupport {
             execute(checkConfig, pathToEmptyFile.toString());
             assertWithMessage("Exception is expected").fail();
         }
-        catch (CheckstyleException ex) {
+        catch (CheckstyleException exc) {
             assertWithMessage("Error message is unexpected")
-                    .that(ex.getMessage())
+                    .that(exc.getMessage())
                     .isEqualTo("cannot initialize module com.puppycrawl.tools.checkstyle."
                             + "TreeWalker - Check 'com.puppycrawl.tools.checkstyle."
                             + "TreeWalkerTest$BadJavaDocCheck' waits for comment type token "
                             + "('SINGLE_LINE_COMMENT') and should override "
                             + "'isCommentNodesRequired()' method to return 'true'");
             assertWithMessage("Error message is unexpected")
-                    .that(ex.getMessage())
+                    .that(exc.getMessage())
                     .contains("isCommentNodesRequired");
         }
     }
@@ -332,9 +332,9 @@ public class TreeWalkerTest extends AbstractModuleTestSupport {
             treeWalker.processFiltered(file, fileText);
             assertWithMessage("Exception expected").fail();
         }
-        catch (CheckstyleException ex) {
+        catch (CheckstyleException exc) {
             assertWithMessage("Invalid exception message")
-                .that(ex.getMessage())
+                .that(exc.getMessage())
                 .isEqualTo("IllegalStateException occurred while parsing file input.java.");
         }
     }

--- a/src/test/java/com/puppycrawl/tools/checkstyle/XpathFileGeneratorAuditListenerTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/XpathFileGeneratorAuditListenerTest.java
@@ -67,8 +67,8 @@ public class XpathFileGeneratorAuditListenerTest {
         try {
             constructEvents();
         }
-        catch (Exception ex) {
-            throw new ExceptionInInitializerError(ex);
+        catch (Exception exc) {
+            throw new ExceptionInInitializerError(exc);
         }
     }
 
@@ -150,9 +150,9 @@ public class XpathFileGeneratorAuditListenerTest {
             logger.addException(ev, null);
             assertWithMessage("Exception is excepted").fail();
         }
-        catch (UnsupportedOperationException ex) {
+        catch (UnsupportedOperationException exc) {
             assertWithMessage("Invalid exception message")
-                .that(ex.getMessage())
+                .that(exc.getMessage())
                 .isEqualTo("Operation is not supported");
         }
     }

--- a/src/test/java/com/puppycrawl/tools/checkstyle/api/AbstractFileSetCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/api/AbstractFileSetCheckTest.java
@@ -119,10 +119,10 @@ public class AbstractFileSetCheckTest extends AbstractModuleTestSupport {
             assertWithMessage("Exception is expected")
                     .fail();
         }
-        catch (IllegalArgumentException ex) {
+        catch (IllegalArgumentException exc) {
             // exception is expected
             assertWithMessage("Invalid exception message")
-                    .that(ex.getMessage())
+                    .that(exc.getMessage())
                     .isEqualTo("Test");
         }
 
@@ -140,10 +140,10 @@ public class AbstractFileSetCheckTest extends AbstractModuleTestSupport {
             assertWithMessage("Exception is expected")
                 .fail();
         }
-        catch (IllegalArgumentException ex) {
+        catch (IllegalArgumentException exc) {
             // exception is expected
             assertWithMessage("Invalid exception message")
-                    .that(ex.getMessage())
+                    .that(exc.getMessage())
                     .isEqualTo("Test");
         }
 

--- a/src/test/java/com/puppycrawl/tools/checkstyle/api/AbstractViolationReporterTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/api/AbstractViolationReporterTest.java
@@ -126,9 +126,9 @@ public class AbstractViolationReporterTest {
             assertWithMessage("exception expected")
                     .fail();
         }
-        catch (IllegalArgumentException ex) {
+        catch (IllegalArgumentException exc) {
             assertWithMessage("Error violation is unexpected")
-                    .that(ex.getMessage())
+                    .that(exc.getMessage())
                     .isEqualTo("Unmatched braces in the pattern.");
         }
     }

--- a/src/test/java/com/puppycrawl/tools/checkstyle/api/FileTextTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/api/FileTextTest.java
@@ -53,9 +53,9 @@ public class FileTextTest extends AbstractPathTestSupport {
             assertWithMessage("UnsupportedEncodingException is expected but got %s", test)
                     .fail();
         }
-        catch (IllegalStateException ex) {
+        catch (IllegalStateException exc) {
             assertWithMessage("Invalid exception message")
-                    .that(ex)
+                    .that(exc)
                     .hasMessageThat()
                     .isEqualTo("Unsupported charset: " + charsetName);
         }
@@ -70,9 +70,9 @@ public class FileTextTest extends AbstractPathTestSupport {
             assertWithMessage("FileNotFoundException is expected but got " + test)
                     .fail();
         }
-        catch (FileNotFoundException ex) {
+        catch (FileNotFoundException exc) {
             assertWithMessage("Invalid exception message")
-                    .that(ex)
+                    .that(exc)
                     .hasMessageThat()
                     .isEqualTo("any name (No such file or directory)");
         }

--- a/src/test/java/com/puppycrawl/tools/checkstyle/api/ScopeTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/api/ScopeTest.java
@@ -58,9 +58,9 @@ public class ScopeTest {
             Scope.getInstance("unknown");
             assertWithMessage("exception expected").fail();
         }
-        catch (IllegalArgumentException ex) {
+        catch (IllegalArgumentException exc) {
             assertWithMessage("Invalid error message")
-                .that(ex.getMessage())
+                .that(exc.getMessage())
                 .isEqualTo("No enum constant com.puppycrawl.tools.checkstyle.api.Scope.UNKNOWN");
         }
     }

--- a/src/test/java/com/puppycrawl/tools/checkstyle/api/SeverityLevelCounterTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/api/SeverityLevelCounterTest.java
@@ -32,9 +32,9 @@ public class SeverityLevelCounterTest {
             assertWithMessage("exception expected but got %s", test)
                     .fail();
         }
-        catch (IllegalArgumentException ex) {
+        catch (IllegalArgumentException exc) {
             assertWithMessage("Invalid exception message")
-                    .that(ex)
+                    .that(exc)
                     .hasMessageThat()
                     .isEqualTo("'level' cannot be null");
         }

--- a/src/test/java/com/puppycrawl/tools/checkstyle/api/SeverityLevelTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/api/SeverityLevelTest.java
@@ -58,9 +58,9 @@ public class SeverityLevelTest {
             SeverityLevel.getInstance("unknown");
             assertWithMessage("exception expected").fail();
         }
-        catch (IllegalArgumentException ex) {
+        catch (IllegalArgumentException exc) {
             assertWithMessage("Invalid exception message")
-                .that(ex.getMessage())
+                .that(exc.getMessage())
                 .isEqualTo("No enum constant "
                     + "com.puppycrawl.tools.checkstyle.api.SeverityLevel.UNKNOWN");
         }

--- a/src/test/java/com/puppycrawl/tools/checkstyle/bdd/InlineConfigParser.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/bdd/InlineConfigParser.java
@@ -406,15 +406,15 @@ public final class InlineConfigParser {
         try {
             setModules(testInputConfigBuilder, inputFilePath, lines);
         }
-        catch (Exception ex) {
+        catch (Exception exc) {
             throw new CheckstyleException("Config comment not specified properly in "
-                    + inputFilePath, ex);
+                    + inputFilePath, exc);
         }
         try {
             setViolations(testInputConfigBuilder, lines, setFilteredViolations);
         }
-        catch (CheckstyleException ex) {
-            throw new CheckstyleException(ex.getMessage() + " in " + inputFilePath, ex);
+        catch (CheckstyleException exc) {
+            throw new CheckstyleException(exc.getMessage() + " in " + inputFilePath, exc);
         }
         return testInputConfigBuilder.build();
     }
@@ -431,8 +431,8 @@ public final class InlineConfigParser {
                 setViolations(testInputConfigBuilder, lines, false, lineNo, true);
             }
         }
-        catch (CheckstyleException ex) {
-            throw new CheckstyleException(ex.getMessage() + " in " + inputFilePath, ex);
+        catch (CheckstyleException exc) {
+            throw new CheckstyleException(exc.getMessage() + " in " + inputFilePath, exc);
         }
 
         return testInputConfigBuilder.build().getViolations();
@@ -477,8 +477,8 @@ public final class InlineConfigParser {
         try {
             setViolations(testInputConfigBuilder, lines, false);
         }
-        catch (CheckstyleException ex) {
-            throw new CheckstyleException(ex.getMessage() + " in " + inputFilePath, ex);
+        catch (CheckstyleException exc) {
+            throw new CheckstyleException(exc.getMessage() + " in " + inputFilePath, exc);
         }
         return testInputConfigBuilder.buildWithXmlConfiguration();
     }
@@ -633,8 +633,8 @@ public final class InlineConfigParser {
         try {
             return Files.readAllLines(filePath);
         }
-        catch (IOException ex) {
-            throw new CheckstyleException("Failed to read " + filePath, ex);
+        catch (IOException exc) {
+            throw new CheckstyleException("Failed to read " + filePath, exc);
         }
     }
 
@@ -1194,7 +1194,7 @@ public final class InlineConfigParser {
                 result = field.get(checkInstance);
                 break;
             }
-            catch (NoSuchFieldException ex) {
+            catch (NoSuchFieldException exc) {
                 currentClass = currentClass.getSuperclass();
             }
         }

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/NewlineAtEndOfFileCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/NewlineAtEndOfFileCheckTest.java
@@ -129,9 +129,9 @@ public class NewlineAtEndOfFileCheckTest
             createChecker(checkConfig);
             assertWithMessage("exception expected").fail();
         }
-        catch (CheckstyleException ex) {
+        catch (CheckstyleException exc) {
             assertWithMessage("Error message is unexpected")
-                    .that(ex.getMessage())
+                    .that(exc.getMessage())
                     .isEqualTo("cannot initialize module com.puppycrawl.tools.checkstyle."
                             + "checks.NewlineAtEndOfFileCheck - "
                             + "Cannot set property 'lineSeparator' to 'ct'");
@@ -203,9 +203,9 @@ public class NewlineAtEndOfFileCheckTest
                 LineSeparatorOption.LF);
             assertWithMessage("ReflectiveOperationException is expected").fail();
         }
-        catch (ReflectiveOperationException ex) {
+        catch (ReflectiveOperationException exc) {
             assertWithMessage("Error message is unexpected")
-                .that(ex)
+                .that(exc)
                     .hasCauseThat()
                         .hasMessageThat()
                         .isEqualTo("Unable to read 1 bytes, got 0");

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/OrderedPropertiesCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/OrderedPropertiesCheckTest.java
@@ -200,8 +200,8 @@ public class OrderedPropertiesCheckTest extends AbstractModuleTestSupport {
         try (InputStream stream = Files.newInputStream(file.toPath())) {
             throw new IllegalStateException("File " + file.getPath() + " should not exist");
         }
-        catch (IOException ex) {
-            return ex.getLocalizedMessage();
+        catch (IOException exc) {
+            return exc.getLocalizedMessage();
         }
     }
 }

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/SuppressWarningsHolderTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/SuppressWarningsHolderTest.java
@@ -152,9 +152,9 @@ public class SuppressWarningsHolderTest extends AbstractModuleTestSupport {
             holder.setAliasList("=SomeAlias");
             assertWithMessage("Exception expected").fail();
         }
-        catch (IllegalArgumentException ex) {
+        catch (IllegalArgumentException exc) {
             assertWithMessage("Error message is unexpected")
-                .that(ex.getMessage())
+                .that(exc.getMessage())
                 .isEqualTo("'=' expected in alias list item: =SomeAlias");
         }
     }
@@ -306,13 +306,13 @@ public class SuppressWarningsHolderTest extends AbstractModuleTestSupport {
             getAllAnnotationValues.invoke(holder, parent);
             assertWithMessage("Exception expected").fail();
         }
-        catch (ReflectiveOperationException ex) {
+        catch (ReflectiveOperationException exc) {
             assertWithMessage("Error type is unexpected")
-                    .that(ex)
+                    .that(exc)
                     .hasCauseThat()
                     .isInstanceOf(IllegalArgumentException.class);
             assertWithMessage("Error message is unexpected")
-                .that(ex)
+                .that(exc)
                 .hasCauseThat()
                 .hasMessageThat()
                 .isEqualTo("Unexpected AST: Method Def[0x0]");
@@ -336,13 +336,13 @@ public class SuppressWarningsHolderTest extends AbstractModuleTestSupport {
             getAllAnnotationValues.invoke(holder, methodDef);
             assertWithMessage("Exception expected").fail();
         }
-        catch (ReflectiveOperationException ex) {
+        catch (ReflectiveOperationException exc) {
             assertWithMessage("Error type is unexpected")
-                    .that(ex)
+                    .that(exc)
                     .hasCauseThat()
                     .isInstanceOf(IllegalArgumentException.class);
             assertWithMessage("Error message is unexpected")
-                .that(ex)
+                .that(exc)
                 .hasCauseThat()
                 .hasMessageThat()
                 .isEqualTo("Expression or annotation array initializer AST expected: "
@@ -372,13 +372,13 @@ public class SuppressWarningsHolderTest extends AbstractModuleTestSupport {
             getAnnotationTarget.invoke(holder, methodDef);
             assertWithMessage("Exception expected").fail();
         }
-        catch (ReflectiveOperationException ex) {
+        catch (ReflectiveOperationException exc) {
             assertWithMessage("Error type is unexpected")
-                    .that(ex)
+                    .that(exc)
                     .hasCauseThat()
                     .isInstanceOf(IllegalArgumentException.class);
             assertWithMessage("Error message is unexpected")
-                .that(ex)
+                .that(exc)
                 .hasCauseThat()
                 .hasMessageThat()
                 .isEqualTo("Unexpected container AST: Parent ast[0x0]");
@@ -395,9 +395,9 @@ public class SuppressWarningsHolderTest extends AbstractModuleTestSupport {
             holder.visitToken(methodDef);
             assertWithMessage("Exception expected").fail();
         }
-        catch (IllegalArgumentException ex) {
+        catch (IllegalArgumentException exc) {
             assertWithMessage("Error message is unexpected")
-                .that(ex.getMessage())
+                .that(exc.getMessage())
                 .isEqualTo("Identifier AST expected, but get null.");
         }
     }

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/TranslationCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/TranslationCheckTest.java
@@ -603,8 +603,8 @@ public class TranslationCheckTest extends AbstractXmlTestSupport {
                     "IllegalArgumentException is expected. Specified language code is incorrect.")
                             .fail();
         }
-        catch (IllegalArgumentException ex) {
-            final String exceptionMessage = ex.getMessage();
+        catch (IllegalArgumentException exc) {
+            final String exceptionMessage = exc.getMessage();
             assertWithMessage("Error message is unexpected")
                     .that(exceptionMessage)
                     .contains("11");

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/UncommentedMainCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/UncommentedMainCheckTest.java
@@ -124,9 +124,9 @@ public class UncommentedMainCheckTest
             check.visitToken(ast);
             assertWithMessage("IllegalStateException is expected").fail();
         }
-        catch (IllegalStateException ex) {
+        catch (IllegalStateException exc) {
             assertWithMessage("Error message is unexpected")
-                .that(ex.getMessage())
+                .that(exc.getMessage())
                 .isEqualTo(ast.toString());
         }
     }

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/UniquePropertiesCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/UniquePropertiesCheckTest.java
@@ -190,8 +190,8 @@ public class UniquePropertiesCheckTest extends AbstractModuleTestSupport {
         try (InputStream stream = Files.newInputStream(file.toPath())) {
             throw new IllegalStateException("File " + file.getPath() + " should not exist");
         }
-        catch (IOException ex) {
-            return ex.getLocalizedMessage();
+        catch (IOException exc) {
+            return exc.getLocalizedMessage();
         }
     }
 

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/annotation/AnnotationUseStyleCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/annotation/AnnotationUseStyleCheckTest.java
@@ -331,11 +331,11 @@ public class AnnotationUseStyleCheckTest extends AbstractModuleTestSupport {
             check.setElementStyle("SHOULD_PRODUCE_ERROR");
             assertWithMessage("ConversionException is expected").fail();
         }
-        catch (IllegalArgumentException ex) {
+        catch (IllegalArgumentException exc) {
             final String messageStart = "unable to parse";
 
             assertWithMessage("Invalid exception message, should start with: " + messageStart)
-                    .that(ex.getMessage())
+                    .that(exc.getMessage())
                     .startsWith(messageStart);
         }
     }

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/blocks/EmptyBlockCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/blocks/EmptyBlockCheckTest.java
@@ -131,9 +131,9 @@ public class EmptyBlockCheckTest
                     getPath("InputEmptyBlockSemanticInvalid.java"), expected);
             assertWithMessage("exception expected").fail();
         }
-        catch (CheckstyleException ex) {
+        catch (CheckstyleException exc) {
             assertWithMessage("Invalid exception message")
-                .that(ex.getMessage())
+                .that(exc.getMessage())
                 .isEqualTo("cannot initialize module com.puppycrawl.tools.checkstyle.TreeWalker - "
                         + "cannot initialize module com.puppycrawl.tools.checkstyle.checks."
                         + "blocks.EmptyBlockCheck - "

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/blocks/LeftCurlyCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/blocks/LeftCurlyCheckTest.java
@@ -502,9 +502,9 @@ public class LeftCurlyCheckTest extends AbstractModuleTestSupport {
                     getPath("InputLeftCurlyTestInvalidOption.java"), expected);
             assertWithMessage("exception expected").fail();
         }
-        catch (CheckstyleException ex) {
+        catch (CheckstyleException exc) {
             assertWithMessage("Invalid exception message")
-                .that(ex.getMessage())
+                .that(exc.getMessage())
                 .isEqualTo("cannot initialize module com.puppycrawl.tools.checkstyle.TreeWalker - "
                     + "cannot initialize module com.puppycrawl.tools.checkstyle.checks."
                     + "blocks.LeftCurlyCheck - "

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/blocks/RightCurlyCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/blocks/RightCurlyCheckTest.java
@@ -341,9 +341,9 @@ public class RightCurlyCheckTest extends AbstractModuleTestSupport {
                     getPath("InputRightCurlyTestInvalidOption.java"), expected);
             assertWithMessage("exception expected").fail();
         }
-        catch (CheckstyleException ex) {
+        catch (CheckstyleException exc) {
             assertWithMessage("Invalid exception message")
-                .that(ex.getMessage())
+                .that(exc.getMessage())
                 .isEqualTo("cannot initialize module com.puppycrawl.tools.checkstyle.TreeWalker - "
                     + "cannot initialize module com.puppycrawl.tools.checkstyle.checks."
                     + "blocks.RightCurlyCheck - "

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/coding/FinalLocalVariableCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/coding/FinalLocalVariableCheckTest.java
@@ -255,7 +255,7 @@ public class FinalLocalVariableCheckTest
             check.visitToken(lambdaAst);
             assertWithMessage("IllegalStateException is expected").fail();
         }
-        catch (IllegalStateException ex) {
+        catch (IllegalStateException exc) {
             // it is OK
         }
     }

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/coding/IllegalInstantiationCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/coding/IllegalInstantiationCheckTest.java
@@ -155,7 +155,7 @@ public class IllegalInstantiationCheckTest
             check.visitToken(lambdaAst);
             assertWithMessage("IllegalArgumentException is expected").fail();
         }
-        catch (IllegalArgumentException ex) {
+        catch (IllegalArgumentException exc) {
             // it is OK
         }
     }

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/coding/IllegalTypeCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/coding/IllegalTypeCheckTest.java
@@ -423,7 +423,7 @@ public class IllegalTypeCheckTest extends AbstractModuleTestSupport {
             check.visitToken(classDefAst);
             assertWithMessage("IllegalStateException is expected").fail();
         }
-        catch (IllegalStateException ex) {
+        catch (IllegalStateException exc) {
             // it is OK
         }
     }

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/coding/ModifiedControlVariableCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/coding/ModifiedControlVariableCheckTest.java
@@ -118,7 +118,7 @@ public class ModifiedControlVariableCheckTest
             check.visitToken(classDefAst);
             assertWithMessage("IllegalStateException is expected").fail();
         }
-        catch (IllegalStateException ex) {
+        catch (IllegalStateException exc) {
             // it is OK
         }
 
@@ -126,7 +126,7 @@ public class ModifiedControlVariableCheckTest
             check.leaveToken(classDefAst);
             assertWithMessage("IllegalStateException is expected").fail();
         }
-        catch (IllegalStateException ex) {
+        catch (IllegalStateException exc) {
             // it is OK
         }
     }

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/coding/ReturnCountCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/coding/ReturnCountCheckTest.java
@@ -123,7 +123,7 @@ public class ReturnCountCheckTest extends AbstractModuleTestSupport {
             check.visitToken(classDefAst);
             assertWithMessage("IllegalStateException is expected").fail();
         }
-        catch (IllegalStateException ex) {
+        catch (IllegalStateException exc) {
             // it is OK
         }
 
@@ -131,7 +131,7 @@ public class ReturnCountCheckTest extends AbstractModuleTestSupport {
             check.leaveToken(classDefAst);
             assertWithMessage("IllegalStateException is expected").fail();
         }
-        catch (IllegalStateException ex) {
+        catch (IllegalStateException exc) {
             // it is OK
         }
     }

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/design/FinalClassCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/design/FinalClassCheckTest.java
@@ -133,9 +133,9 @@ public class FinalClassCheckTest
             finalClassCheck.visitToken(badAst);
             assertWithMessage("IllegalStateException is expected").fail();
         }
-        catch (IllegalStateException ex) {
+        catch (IllegalStateException exc) {
             assertWithMessage("Invalid exception message")
-                .that(ex.getMessage())
+                .that(exc.getMessage())
                 .isEqualTo(badAst.toString());
         }
     }

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/design/MutableExceptionCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/design/MutableExceptionCheckTest.java
@@ -135,10 +135,10 @@ public class MutableExceptionCheckTest extends AbstractModuleTestSupport {
             assertWithMessage("IllegalStateException is expected")
                     .fail();
         }
-        catch (IllegalStateException ex) {
+        catch (IllegalStateException exc) {
             // exception is expected
             assertWithMessage("Invalid exception message")
-                    .that(ex.getMessage())
+                    .that(exc.getMessage())
                     .isEqualTo("interface[0x-1]");
         }
     }

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/design/ThrowsCountCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/design/ThrowsCountCheckTest.java
@@ -88,9 +88,9 @@ public class ThrowsCountCheckTest extends AbstractModuleTestSupport {
             obj.visitToken(ast);
             assertWithMessage("IllegalStateException is expected").fail();
         }
-        catch (IllegalStateException ex) {
+        catch (IllegalStateException exc) {
             assertWithMessage("Invalid exception message")
-                .that(ex.getMessage())
+                .that(exc.getMessage())
                 .isEqualTo(ast.toString());
         }
     }

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/design/VisibilityModifierCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/design/VisibilityModifierCheckTest.java
@@ -364,9 +364,9 @@ public class VisibilityModifierCheckTest
             obj.visitToken(ast);
             assertWithMessage("exception expected").fail();
         }
-        catch (IllegalArgumentException ex) {
+        catch (IllegalArgumentException exc) {
             assertWithMessage("Invalid exception message")
-                .that(ex.getMessage())
+                .that(exc.getMessage())
                 .isEqualTo("Unexpected token type: class");
         }
     }

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/header/RegexpHeaderCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/header/RegexpHeaderCheckTest.java
@@ -110,9 +110,9 @@ public class RegexpHeaderCheckTest extends AbstractModuleTestSupport {
             assertWithMessage(String.format(Locale.ROOT, "%s should have been thrown",
                     IllegalArgumentException.class)).fail();
         }
-        catch (IllegalArgumentException ex) {
+        catch (IllegalArgumentException exc) {
             assertWithMessage("Invalid exception message")
-                .that(ex.getMessage())
+                .that(exc.getMessage())
                 .isEqualTo("Unable to parse format: ^/**\\n *"
                     + " Licensed to the Apache Software Foundation (ASF)");
         }
@@ -135,9 +135,9 @@ public class RegexpHeaderCheckTest extends AbstractModuleTestSupport {
             createChecker(checkConfig);
             assertWithMessage("Checker creation should not succeed with invalid headerFile").fail();
         }
-        catch (CheckstyleException ex) {
+        catch (CheckstyleException exc) {
             assertWithMessage("Invalid exception message")
-                .that(ex.getMessage())
+                .that(exc.getMessage())
                 .isEqualTo("cannot initialize module"
                     + " com.puppycrawl.tools.checkstyle.checks.header.RegexpHeaderCheck"
                     + " - Cannot set property 'headerFile' to ''");
@@ -204,9 +204,9 @@ public class RegexpHeaderCheckTest extends AbstractModuleTestSupport {
             assertWithMessage(
                     "Checker creation should not succeed when regexp spans multiple lines").fail();
         }
-        catch (CheckstyleException ex) {
+        catch (CheckstyleException exc) {
             assertWithMessage("Invalid exception message")
-                .that(ex.getMessage())
+                .that(exc.getMessage())
                 .isEqualTo("cannot initialize module"
                     + " com.puppycrawl.tools.checkstyle.checks.header.RegexpHeaderCheck"
                     + " - Cannot set property 'header' to '^(.*\\n.*)'");
@@ -373,9 +373,9 @@ public class RegexpHeaderCheckTest extends AbstractModuleTestSupport {
             verify(checkConfig, path, expected);
             assertWithMessage("IllegalArgumentException is expected").fail();
         }
-        catch (IllegalArgumentException ex) {
+        catch (IllegalArgumentException exc) {
             assertWithMessage("Invalid exception message")
-                .that(ex.getMessage())
+                .that(exc.getMessage())
                 .isEqualTo("line 3 in header specification is not a regular expression");
         }
     }

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/imports/CustomImportOrderCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/imports/CustomImportOrderCheckTest.java
@@ -490,9 +490,9 @@ public class CustomImportOrderCheckTest extends AbstractModuleTestSupport {
                     getPath("InputCustomImportOrderDefault5.java"), expected);
             assertWithMessage("exception expected").fail();
         }
-        catch (CheckstyleException ex) {
+        catch (CheckstyleException exc) {
             assertWithMessage("Invalid exception message")
-                .that(ex)
+                .that(exc)
                 .hasMessageThat()
                 .isEqualTo("cannot initialize module com.puppycrawl.tools.checkstyle.TreeWalker - "
                         + "cannot initialize module com.puppycrawl.tools.checkstyle.checks"
@@ -500,7 +500,7 @@ public class CustomImportOrderCheckTest extends AbstractModuleTestSupport {
                         + "Cannot set property 'customImportOrderRules' to "
                         + "'SAME_PACKAGE(-1)'");
             assertWithMessage("Invalid exception message")
-                .that(ex.getCause().getCause().getCause().getCause().getMessage())
+                .that(exc.getCause().getCause().getCause().getCause().getMessage())
                 .isEqualTo("SAME_PACKAGE rule parameter should be positive integer: "
                         + "SAME_PACKAGE(-1)");
         }
@@ -515,16 +515,16 @@ public class CustomImportOrderCheckTest extends AbstractModuleTestSupport {
                     getPath("InputCustomImportOrderDefault6.java"), expected);
             assertWithMessage("exception expected").fail();
         }
-        catch (CheckstyleException ex) {
+        catch (CheckstyleException exc) {
             assertWithMessage("Invalid exception message")
-                .that(ex.getMessage())
+                .that(exc.getMessage())
                 .isEqualTo("cannot initialize module com.puppycrawl.tools.checkstyle.TreeWalker - "
                         + "cannot initialize module com.puppycrawl.tools.checkstyle.checks"
                         + ".imports.CustomImportOrderCheck - "
                         + "Cannot set property 'customImportOrderRules' to "
                         + "'SAME_PACKAGE(0)'");
             assertWithMessage("Invalid exception message")
-                .that(ex.getCause().getCause().getCause().getCause().getMessage())
+                .that(exc.getCause().getCause().getCause().getCause().getMessage())
                 .isEqualTo("SAME_PACKAGE rule parameter should be positive integer: "
                         + "SAME_PACKAGE(0)");
         }
@@ -539,16 +539,16 @@ public class CustomImportOrderCheckTest extends AbstractModuleTestSupport {
                     getPath("InputCustomImportOrderDefault7.java"), expected);
             assertWithMessage("exception expected").fail();
         }
-        catch (CheckstyleException ex) {
+        catch (CheckstyleException exc) {
             assertWithMessage("Invalid exception message")
-                .that(ex.getMessage())
+                .that(exc.getMessage())
                 .isEqualTo("cannot initialize module com.puppycrawl.tools.checkstyle.TreeWalker - "
                         + "cannot initialize module com.puppycrawl.tools.checkstyle.checks"
                         + ".imports.CustomImportOrderCheck - "
                         + "Cannot set property 'customImportOrderRules' to "
                         + "'SAME_PACKAGE(3)###UNSUPPORTED_RULE'");
             assertWithMessage("Invalid exception message")
-                .that(ex.getCause().getCause().getCause().getCause().getMessage())
+                .that(exc.getCause().getCause().getCause().getCause().getMessage())
                 .isEqualTo("Unexpected rule: UNSUPPORTED_RULE");
         }
     }
@@ -562,16 +562,16 @@ public class CustomImportOrderCheckTest extends AbstractModuleTestSupport {
                     getPath("InputCustomImportOrderDefault8.java"), expected);
             assertWithMessage("exception expected").fail();
         }
-        catch (CheckstyleException ex) {
+        catch (CheckstyleException exc) {
             assertWithMessage("Invalid exception message")
-                .that(ex.getMessage())
+                .that(exc.getMessage())
                 .isEqualTo("cannot initialize module com.puppycrawl.tools.checkstyle.TreeWalker - "
                         + "cannot initialize module com.puppycrawl.tools.checkstyle.checks"
                         + ".imports.CustomImportOrderCheck - "
                         + "Cannot set property 'customImportOrderRules' to "
                         + "'SAME_PACKAGE(INT_IS_REQUIRED_HERE)'");
             assertWithMessage("Invalid exception message")
-                .that(ex.getCause().getCause().getCause().getCause().getMessage())
+                .that(exc.getCause().getCause().getCause().getCause().getMessage())
                 .isEqualTo("For input string: \"INT_IS_REQUIRED_HERE\"");
         }
     }

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/imports/ImportControlCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/imports/ImportControlCheckTest.java
@@ -121,8 +121,8 @@ public class ImportControlCheckTest extends AbstractModuleTestSupport {
                     getPath("InputImportControl7.java"), expected);
             assertWithMessage("Test should fail if exception was not thrown").fail();
         }
-        catch (CheckstyleException ex) {
-            final String message = getCheckstyleExceptionMessage(ex);
+        catch (CheckstyleException exc) {
+            final String message = getCheckstyleExceptionMessage(exc);
             final String messageStart = "Unable to find: ";
 
             assertWithMessage("Invalid message, should start with: %s", messageStart)
@@ -138,8 +138,8 @@ public class ImportControlCheckTest extends AbstractModuleTestSupport {
             verifyWithInlineConfigParser(getPath("InputImportControl8.java"), expected);
             assertWithMessage("Test should fail if exception was not thrown").fail();
         }
-        catch (CheckstyleException ex) {
-            final String message = getCheckstyleExceptionMessage(ex);
+        catch (CheckstyleException exc) {
+            final String message = getCheckstyleExceptionMessage(exc);
             final String messageStart = "Unable to load ";
 
             assertWithMessage("Invalid message, should start with: %s", messageStart)
@@ -296,8 +296,8 @@ public class ImportControlCheckTest extends AbstractModuleTestSupport {
             verifyWithInlineConfigParser(getPath("InputImportControl18.java"), expected);
             assertWithMessage("Test should fail if exception was not thrown").fail();
         }
-        catch (CheckstyleException ex) {
-            final String message = getCheckstyleExceptionMessage(ex);
+        catch (CheckstyleException exc) {
+            final String message = getCheckstyleExceptionMessage(exc);
             final String messageStart = "Unable to find: ";
 
             assertWithMessage("Invalid message, should start with: %s", messageStart)
@@ -323,8 +323,8 @@ public class ImportControlCheckTest extends AbstractModuleTestSupport {
                     getPath("InputImportControl20.java"), expected);
             assertWithMessage("Test should fail if exception was not thrown").fail();
         }
-        catch (CheckstyleException ex) {
-            final String message = getCheckstyleExceptionMessage(ex);
+        catch (CheckstyleException exc) {
+            final String message = getCheckstyleExceptionMessage(exc);
             final String messageStart = "Unable to load ";
 
             assertWithMessage("Invalid message, should start with: %s", messageStart)

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/imports/ImportControlLoaderTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/imports/ImportControlLoaderTest.java
@@ -66,12 +66,12 @@ public class ImportControlLoaderTest {
                     + getPath("InputImportControlLoaderComplete.xml")));
             assertWithMessage("exception expected").fail();
         }
-        catch (CheckstyleException ex) {
+        catch (CheckstyleException exc) {
             assertWithMessage("Invalid exception class")
-                .that(ex.getCause())
+                .that(exc.getCause())
                 .isInstanceOf(MalformedURLException.class);
             assertWithMessage("Invalid exception message")
-                .that(ex)
+                .that(exc)
                 .hasCauseThat()
                 .hasMessageThat()
                 .isEqualTo("unknown protocol: aaa");
@@ -105,12 +105,12 @@ public class ImportControlLoaderTest {
             privateMethod.invoke(null, attr, "you_cannot_find_me");
             assertWithMessage("exception expected").fail();
         }
-        catch (ReflectiveOperationException ex) {
+        catch (ReflectiveOperationException exc) {
             assertWithMessage("Invalid exception class")
-                .that(ex.getCause())
+                .that(exc.getCause())
                 .isInstanceOf(SAXException.class);
             assertWithMessage("Invalid exception message")
-                .that(ex)
+                .that(exc)
                 .hasCauseThat()
                 .hasMessageThat()
                 .isEqualTo("missing attribute you_cannot_find_me");
@@ -132,12 +132,12 @@ public class ImportControlLoaderTest {
                     new File(getPath("InputImportControlLoaderComplete.xml")).toURI());
             assertWithMessage("exception expected").fail();
         }
-        catch (ReflectiveOperationException ex) {
+        catch (ReflectiveOperationException exc) {
             assertWithMessage("Invalid exception class")
-                .that(ex.getCause())
+                .that(exc.getCause())
                 .isInstanceOf(CheckstyleException.class);
-            assertWithMessage("Invalid exception message: " + ex.getCause().getMessage())
-                    .that(ex)
+            assertWithMessage("Invalid exception message: " + exc.getCause().getMessage())
+                    .that(exc)
                     .hasCauseThat()
                     .hasMessageThat()
                     .startsWith("unable to read");

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/imports/ImportOrderCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/imports/ImportOrderCheckTest.java
@@ -233,9 +233,9 @@ public class ImportOrderCheckTest extends AbstractModuleTestSupport {
                     getPath("InputImportOrder_Top1.java"), expected);
             assertWithMessage("exception expected").fail();
         }
-        catch (CheckstyleException ex) {
+        catch (CheckstyleException exc) {
             assertWithMessage("Invalid exception message")
-                .that(ex.getMessage())
+                .that(exc.getMessage())
                 .isEqualTo("cannot initialize module com.puppycrawl.tools.checkstyle.TreeWalker - "
                         + "cannot initialize module com.puppycrawl.tools.checkstyle.checks"
                         + ".imports.ImportOrderCheck - "
@@ -549,15 +549,15 @@ public class ImportOrderCheckTest extends AbstractModuleTestSupport {
             execute(checkConfig, getNonCompilablePath("InputImportOrder5.java"));
             assertWithMessage("exception expected").fail();
         }
-        catch (CheckstyleException ex) {
+        catch (CheckstyleException exc) {
             assertWithMessage("Invalid exception message")
-                .that(ex.getMessage())
+                .that(exc.getMessage())
                 .isEqualTo("cannot initialize module com.puppycrawl.tools.checkstyle.TreeWalker - "
                         + "cannot initialize module com.puppycrawl.tools.checkstyle.checks"
                         + ".imports.ImportOrderCheck - "
                         + "Cannot set property 'groups' to '/^javax'");
             assertWithMessage("Invalid exception message")
-                .that(ex.getCause().getCause().getCause().getCause().getMessage())
+                .that(exc.getCause().getCause().getCause().getCause().getMessage())
                 .isEqualTo("Invalid group: /^javax");
         }
     }
@@ -608,9 +608,9 @@ public class ImportOrderCheckTest extends AbstractModuleTestSupport {
             mock.visitToken(astImport);
             assertWithMessage("An exception is expected").fail();
         }
-        catch (IllegalStateException ex) {
+        catch (IllegalStateException exc) {
             assertWithMessage("invalid exception message")
-                    .that(ex.getMessage())
+                    .that(exc.getMessage())
                     .endsWith(": null");
         }
     }

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/indentation/CommentsIndentationCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/indentation/CommentsIndentationCheckTest.java
@@ -283,8 +283,8 @@ public class CommentsIndentationCheckTest extends AbstractModuleTestSupport {
             check.visitToken(methodDef);
             assertWithMessage("IllegalArgumentException should have been thrown!").fail();
         }
-        catch (IllegalArgumentException ex) {
-            final String msg = ex.getMessage();
+        catch (IllegalArgumentException exc) {
+            final String msg = exc.getMessage();
             assertWithMessage("Invalid exception message")
                 .that(msg)
                 .isEqualTo("Unexpected token type: methodStub");

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/javadoc/AbstractJavadocCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/javadoc/AbstractJavadocCheckTest.java
@@ -338,13 +338,13 @@ public class AbstractJavadocCheckTest extends AbstractModuleTestSupport {
             verifyWithInlineConfigParser(path, expected);
             assertWithMessage("CheckstyleException is expected").fail();
         }
-        catch (IllegalStateException ex) {
+        catch (IllegalStateException exc) {
             final String expected = "Javadoc Token "
                     + "\"RETURN_LITERAL\" was not found in "
                     + "Acceptable javadoc tokens list in check "
                     + TokenIsNotInAcceptablesCheck.class.getName();
             assertWithMessage("Invalid exception, should start with: " + expected)
-                    .that(ex.getMessage())
+                    .that(exc.getMessage())
                     .startsWith(expected);
         }
     }
@@ -366,13 +366,13 @@ public class AbstractJavadocCheckTest extends AbstractModuleTestSupport {
             execute(checkConfig, pathToEmptyFile.toString());
             assertWithMessage("CheckstyleException is expected").fail();
         }
-        catch (IllegalStateException ex) {
+        catch (IllegalStateException exc) {
             final String expected = "Javadoc Token \""
                     + JavadocTokenTypes.RETURN_LITERAL + "\" from required"
                     + " javadoc tokens was not found in default javadoc tokens list in check "
                     + RequiredTokenIsNotInDefaultsJavadocCheck.class.getName();
             assertWithMessage("Invalid exception, should start with: " + expected)
-                    .that(ex.getMessage())
+                    .that(exc.getMessage())
                     .startsWith(expected);
         }
     }

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocPackageCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocPackageCheckTest.java
@@ -122,9 +122,9 @@ public class JavadocPackageCheckTest
             check.processFiltered(fileWithInvalidPath, mockFileText);
             assertWithMessage("CheckstyleException expected to be thrown").fail();
         }
-        catch (CheckstyleException ex) {
+        catch (CheckstyleException exc) {
             assertWithMessage("Invalid exception message. Expected: " + expectedExceptionMessage)
-                .that(ex.getMessage())
+                .that(exc.getMessage())
                 .isEqualTo(expectedExceptionMessage);
         }
     }

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocTagInfoTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocTagInfoTest.java
@@ -422,9 +422,9 @@ public class JavadocTagInfoTest {
             JavadocTagInfo.fromName(null);
             assertWithMessage("IllegalArgumentException is expected").fail();
         }
-        catch (IllegalArgumentException ex) {
+        catch (IllegalArgumentException exc) {
             assertWithMessage("Invalid exception message")
-                .that(ex.getMessage())
+                .that(exc.getMessage())
                 .isEqualTo("the name is null");
         }
 
@@ -432,9 +432,9 @@ public class JavadocTagInfoTest {
             JavadocTagInfo.fromName("myname");
             assertWithMessage("IllegalArgumentException is expected").fail();
         }
-        catch (IllegalArgumentException ex) {
+        catch (IllegalArgumentException exc) {
             assertWithMessage("Invalid exception message")
-                .that(ex.getMessage())
+                .that(exc.getMessage())
                 .isEqualTo("the name [myname] is not a valid Javadoc tag name");
         }
 
@@ -442,9 +442,9 @@ public class JavadocTagInfoTest {
             JavadocTagInfo.fromText(null);
             assertWithMessage("IllegalArgumentException is expected").fail();
         }
-        catch (IllegalArgumentException ex) {
+        catch (IllegalArgumentException exc) {
             assertWithMessage("Invalid exception message")
-                .that(ex.getMessage())
+                .that(exc.getMessage())
                 .isEqualTo("the text is null");
         }
 
@@ -452,9 +452,9 @@ public class JavadocTagInfoTest {
             JavadocTagInfo.fromText("myname");
             assertWithMessage("IllegalArgumentException is expected").fail();
         }
-        catch (IllegalArgumentException ex) {
+        catch (IllegalArgumentException exc) {
             assertWithMessage("Invalid exception message")
-                .that(ex.getMessage())
+                .that(exc.getMessage())
                 .isEqualTo("the text [myname] is not a valid Javadoc tag text");
         }
 

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/javadoc/utils/InlineTagUtilTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/javadoc/utils/InlineTagUtilTest.java
@@ -109,9 +109,9 @@ public class InlineTagUtilTest {
             InlineTagUtil.extractInlineTags("abc\ndef");
             assertWithMessage("IllegalArgumentException expected").fail();
         }
-        catch (IllegalArgumentException ex) {
+        catch (IllegalArgumentException exc) {
             assertWithMessage("Unexpected error message")
-                    .that(ex.getMessage())
+                    .that(exc.getMessage())
                     .contains("newline");
         }
     }
@@ -122,9 +122,9 @@ public class InlineTagUtilTest {
             InlineTagUtil.extractInlineTags("abc\rdef");
             assertWithMessage("IllegalArgumentException expected").fail();
         }
-        catch (IllegalArgumentException ex) {
+        catch (IllegalArgumentException exc) {
             assertWithMessage("Invalid error message")
-                    .that(ex.getMessage())
+                    .that(exc.getMessage())
                     .contains("newline");
         }
     }

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/metrics/BooleanExpressionComplexityCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/metrics/BooleanExpressionComplexityCheckTest.java
@@ -80,9 +80,9 @@ public class BooleanExpressionComplexityCheckTest extends AbstractModuleTestSupp
             booleanExpressionComplexityCheckObj.visitToken(ast);
             assertWithMessage("exception expected").fail();
         }
-        catch (IllegalArgumentException ex) {
+        catch (IllegalArgumentException exc) {
             assertWithMessage("Invalid exception message")
-                .that(ex.getMessage())
+                .that(exc.getMessage())
                 .isEqualTo("Unknown type: interface[0x-1]");
         }
     }

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/metrics/ClassDataAbstractionCouplingCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/metrics/ClassDataAbstractionCouplingCheckTest.java
@@ -105,16 +105,16 @@ public class ClassDataAbstractionCouplingCheckTest extends AbstractModuleTestSup
             createChecker(checkConfig);
             assertWithMessage("exception expected").fail();
         }
-        catch (CheckstyleException ex) {
+        catch (CheckstyleException exc) {
             assertWithMessage("Invalid exception message")
-                .that(ex.getMessage())
+                .that(exc.getMessage())
                 .isEqualTo("cannot initialize module com.puppycrawl.tools.checkstyle.TreeWalker - "
                     + "cannot initialize module com.puppycrawl.tools.checkstyle.checks."
                     + "metrics.ClassDataAbstractionCouplingCheck - "
                     + "Cannot set property 'excludedPackages' to "
                     + "'com.puppycrawl.tools.checkstyle.checks.metrics.inputs.a.'");
             assertWithMessage("Invalid exception message,")
-                .that(ex.getCause().getCause().getCause().getCause().getMessage())
+                .that(exc.getCause().getCause().getCause().getCause().getMessage())
                 .isEqualTo("the following values are not valid identifiers: ["
                     + "com.puppycrawl.tools.checkstyle.checks.metrics.inputs.a.]");
         }
@@ -145,9 +145,9 @@ public class ClassDataAbstractionCouplingCheckTest extends AbstractModuleTestSup
             classDataAbstractionCouplingCheckObj.visitToken(ast);
             assertWithMessage("exception expected").fail();
         }
-        catch (IllegalArgumentException ex) {
+        catch (IllegalArgumentException exc) {
             assertWithMessage("Invalid exception message")
-                .that(ex.getMessage())
+                .that(exc.getMessage())
                 .isEqualTo("Unknown type: ctor[0x-1]");
         }
     }

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/metrics/ClassFanOutComplexityCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/metrics/ClassFanOutComplexityCheckTest.java
@@ -91,16 +91,16 @@ public class ClassFanOutComplexityCheckTest extends AbstractModuleTestSupport {
             createChecker(checkConfig);
             assertWithMessage("exception expected").fail();
         }
-        catch (CheckstyleException ex) {
+        catch (CheckstyleException exc) {
             assertWithMessage("Invalid exception message")
-                .that(ex.getMessage())
+                .that(exc.getMessage())
                 .isEqualTo("cannot initialize module com.puppycrawl.tools.checkstyle.TreeWalker - "
                     + "cannot initialize module com.puppycrawl.tools.checkstyle.checks."
                     + "metrics.ClassFanOutComplexityCheck - "
                     + "Cannot set property 'excludedPackages' to "
                     + "'com.puppycrawl.tools.checkstyle.checks.metrics.inputs.a.'");
             assertWithMessage("Invalid exception message,")
-                .that(ex.getCause().getCause().getCause().getCause().getMessage())
+                .that(exc.getCause().getCause().getCause().getCause().getMessage())
                 .isEqualTo("the following values are not valid identifiers: ["
                             + "com.puppycrawl.tools.checkstyle.checks.metrics.inputs.a.]");
         }

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/modifier/ClassMemberImpliedModifierCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/modifier/ClassMemberImpliedModifierCheckTest.java
@@ -159,9 +159,9 @@ public class ClassMemberImpliedModifierCheckTest
             check.visitToken(init);
             assertWithMessage("IllegalStateException is expected").fail();
         }
-        catch (IllegalStateException ex) {
+        catch (IllegalStateException exc) {
             assertWithMessage("Error message is unexpected")
-                .that(ex.getMessage())
+                .that(exc.getMessage())
                 .isEqualTo(init.toString());
         }
     }

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/modifier/InterfaceMemberImpliedModifierCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/modifier/InterfaceMemberImpliedModifierCheckTest.java
@@ -378,9 +378,9 @@ public class InterfaceMemberImpliedModifierCheckTest
             check.visitToken(init);
             assertWithMessage("IllegalStateException is expected").fail();
         }
-        catch (IllegalStateException ex) {
+        catch (IllegalStateException exc) {
             assertWithMessage("Error message is unexpected")
-                .that(ex.getMessage())
+                .that(exc.getMessage())
                 .isEqualTo(init.toString());
         }
     }

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/naming/ConstantNameCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/naming/ConstantNameCheckTest.java
@@ -57,9 +57,9 @@ public class ConstantNameCheckTest
             createChecker(checkConfig);
             assertWithMessage("CheckstyleException is expected").fail();
         }
-        catch (CheckstyleException ex) {
+        catch (CheckstyleException exc) {
             assertWithMessage("Invalid exception message")
-                .that(ex.getMessage())
+                .that(exc.getMessage())
                 .isEqualTo("cannot initialize module com.puppycrawl.tools.checkstyle.TreeWalker - "
                     + "cannot initialize module com.puppycrawl.tools.checkstyle.checks."
                     + "naming.ConstantNameCheck - "

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/sizes/ExecutableStatementCountCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/sizes/ExecutableStatementCountCheckTest.java
@@ -136,9 +136,9 @@ public class ExecutableStatementCountCheckTest
             checkObj.visitToken(ast);
             assertWithMessage("exception expected").fail();
         }
-        catch (IllegalStateException ex) {
+        catch (IllegalStateException exc) {
             assertWithMessage("Invalid exception message")
-                .that(ex.getMessage())
+                .that(exc.getMessage())
                 .isEqualTo("ENUM[0x-1]");
         }
     }
@@ -154,9 +154,9 @@ public class ExecutableStatementCountCheckTest
             checkObj.leaveToken(ast);
             assertWithMessage("exception expected").fail();
         }
-        catch (IllegalStateException ex) {
+        catch (IllegalStateException exc) {
             assertWithMessage("Invalid exception message")
-                .that(ex.getMessage())
+                .that(exc.getMessage())
                 .isEqualTo("ENUM[0x-1]");
         }
     }

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/sizes/FileLengthCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/sizes/FileLengthCheckTest.java
@@ -76,9 +76,9 @@ public class FileLengthCheckTest
             createChecker(checkConfig);
             assertWithMessage("Should indicate illegal args").fail();
         }
-        catch (CheckstyleException ex) {
+        catch (CheckstyleException exc) {
             assertWithMessage("Invalid exception message")
-                .that(ex.getMessage())
+                .that(exc.getMessage())
                 .isEqualTo("cannot initialize module com.puppycrawl.tools.checkstyle.checks."
                     + "sizes.FileLengthCheck - "
                     + "illegal value 'abc' for property 'max'");
@@ -108,9 +108,9 @@ public class FileLengthCheckTest
             check.setFileExtensions((String[]) null);
             assertWithMessage("IllegalArgumentException is expected").fail();
         }
-        catch (IllegalArgumentException ex) {
+        catch (IllegalArgumentException exc) {
             assertWithMessage("Invalid exception message")
-                .that(ex.getMessage())
+                .that(exc.getMessage())
                 .isEqualTo("Extensions array can not be null");
         }
     }

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/whitespace/EmptyForInitializerPadCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/whitespace/EmptyForInitializerPadCheckTest.java
@@ -126,9 +126,9 @@ public class EmptyForInitializerPadCheckTest
                     getPath("InputEmptyForInitializerPad2.java"), expected);
             assertWithMessage("exception expected").fail();
         }
-        catch (CheckstyleException ex) {
+        catch (CheckstyleException exc) {
             assertWithMessage("Invalid exception message")
-                .that(ex.getMessage())
+                .that(exc.getMessage())
                 .isEqualTo("cannot initialize module com.puppycrawl.tools.checkstyle.TreeWalker - "
                     + "cannot initialize module com.puppycrawl.tools.checkstyle.checks."
                     + "whitespace.EmptyForInitializerPadCheck - "

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/whitespace/EmptyForIteratorPadCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/whitespace/EmptyForIteratorPadCheckTest.java
@@ -97,9 +97,9 @@ public class EmptyForIteratorPadCheckTest
             verifyWithInlineConfigParser(getPath("InputEmptyForIteratorPad2.java"), expected);
             assertWithMessage("exception expected").fail();
         }
-        catch (CheckstyleException ex) {
+        catch (CheckstyleException exc) {
             assertWithMessage("Invalid exception message")
-                .that(ex.getMessage())
+                .that(exc.getMessage())
                 .isEqualTo("cannot initialize module com.puppycrawl.tools.checkstyle.TreeWalker - "
                     + "cannot initialize module com.puppycrawl.tools.checkstyle.checks."
                     + "whitespace.EmptyForIteratorPadCheck - "

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/whitespace/GenericWhitespaceCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/whitespace/GenericWhitespaceCheckTest.java
@@ -323,9 +323,9 @@ public class GenericWhitespaceCheckTest
             genericWhitespaceCheckObj.visitToken(ast);
             assertWithMessage("exception expected").fail();
         }
-        catch (IllegalArgumentException ex) {
+        catch (IllegalArgumentException exc) {
             assertWithMessage("Invalid exception message")
-                .that(ex.getMessage())
+                .that(exc.getMessage())
                 .isEqualTo("Unknown type interface[0x-1]");
         }
     }

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/whitespace/MethodParamPadCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/whitespace/MethodParamPadCheckTest.java
@@ -206,9 +206,9 @@ public class MethodParamPadCheckTest
             verifyWithInlineConfigParser(getPath("InputMethodParamPad4.java"), expected);
             assertWithMessage("exception expected").fail();
         }
-        catch (CheckstyleException ex) {
+        catch (CheckstyleException exc) {
             assertWithMessage("Invalid exception message")
-                .that(ex.getMessage())
+                .that(exc.getMessage())
                 .isEqualTo("cannot initialize module com.puppycrawl.tools.checkstyle.TreeWalker - "
                     + "cannot initialize module com.puppycrawl.tools.checkstyle.checks."
                     + "whitespace.MethodParamPadCheck - "

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/whitespace/NoWhitespaceAfterCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/whitespace/NoWhitespaceAfterCheckTest.java
@@ -235,9 +235,9 @@ public class NoWhitespaceAfterCheckTest
             check.visitToken(astArrayDeclarator);
             assertWithMessage("no intended exception thrown").fail();
         }
-        catch (IllegalStateException ex) {
+        catch (IllegalStateException exc) {
             assertWithMessage("Invalid exception message")
-                .that(ex.getMessage())
+                .that(exc.getMessage())
                 .isEqualTo("unexpected ast syntax import[0x-1]");
         }
     }

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/whitespace/OperatorWrapCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/whitespace/OperatorWrapCheckTest.java
@@ -173,9 +173,9 @@ public class OperatorWrapCheckTest
                     getPath("InputOperatorWrap6.java"), expected);
             assertWithMessage("exception expected").fail();
         }
-        catch (CheckstyleException ex) {
+        catch (CheckstyleException exc) {
             assertWithMessage("Invalid exception message")
-                .that(ex.getMessage())
+                .that(exc.getMessage())
                 .isEqualTo("cannot initialize module com.puppycrawl.tools.checkstyle.TreeWalker - "
                     + "cannot initialize module com.puppycrawl.tools.checkstyle.checks."
                     + "whitespace.OperatorWrapCheck - "

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/whitespace/ParenPadCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/whitespace/ParenPadCheckTest.java
@@ -326,9 +326,9 @@ public class ParenPadCheckTest
                     getPath("InputParenPadLeftRightAndNoSpace3.java"), expected);
             assertWithMessage("exception expected").fail();
         }
-        catch (CheckstyleException ex) {
+        catch (CheckstyleException exc) {
             assertWithMessage("Invalid exception message")
-                .that(ex.getMessage())
+                .that(exc.getMessage())
                 .isEqualTo("cannot initialize module com.puppycrawl.tools.checkstyle.TreeWalker - "
                     + "cannot initialize module com.puppycrawl.tools.checkstyle.checks."
                     + "whitespace.ParenPadCheck - "

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/whitespace/SeparatorWrapCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/whitespace/SeparatorWrapCheckTest.java
@@ -89,9 +89,9 @@ public class SeparatorWrapCheckTest
                     getPath("InputSeparatorWrapForInvalidOption.java"), expected);
             assertWithMessage("exception expected").fail();
         }
-        catch (CheckstyleException ex) {
+        catch (CheckstyleException exc) {
             assertWithMessage("Invalid exception message")
-                .that(ex.getMessage())
+                .that(exc.getMessage())
                 .isEqualTo("cannot initialize module com.puppycrawl.tools.checkstyle.TreeWalker - "
                     + "cannot initialize module com.puppycrawl.tools.checkstyle.checks."
                     + "whitespace.SeparatorWrapCheck - "

--- a/src/test/java/com/puppycrawl/tools/checkstyle/filters/SuppressWithNearbyCommentFilterTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/filters/SuppressWithNearbyCommentFilterTest.java
@@ -392,9 +392,9 @@ public class SuppressWithNearbyCommentFilterTest
                     getPath("InputSuppressWithNearbyCommentFilterByCheckAndInfluence.java"));
             assertWithMessage("Exception is expected").fail();
         }
-        catch (CheckstyleException ex) {
+        catch (CheckstyleException exc) {
             assertWithMessage("Invalid exception message")
-                .that(ex)
+                .that(exc)
                 .hasCauseThat()
                 .hasMessageThat()
                 .isEqualTo("unable to parse influence"
@@ -452,8 +452,8 @@ public class SuppressWithNearbyCommentFilterTest
                     getPath("InputSuppressWithNearbyCommentFilterByCheckAndInfluence.java"));
             assertWithMessage("Exception is expected").fail();
         }
-        catch (CheckstyleException ex) {
-            final IllegalArgumentException cause = (IllegalArgumentException) ex.getCause();
+        catch (CheckstyleException exc) {
+            final IllegalArgumentException cause = (IllegalArgumentException) exc.getCause();
             assertWithMessage("Invalid exception message")
                 .that(cause)
                 .hasMessageThat()

--- a/src/test/java/com/puppycrawl/tools/checkstyle/filters/SuppressWithNearbyTextFilterTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/filters/SuppressWithNearbyTextFilterTest.java
@@ -344,8 +344,8 @@ public class SuppressWithNearbyTextFilterTest extends AbstractModuleTestSupport 
             );
             assertWithMessage("CheckstyleException is expected").fail();
         }
-        catch (CheckstyleException ex) {
-            final IllegalArgumentException cause = (IllegalArgumentException) ex.getCause();
+        catch (CheckstyleException exc) {
+            final IllegalArgumentException cause = (IllegalArgumentException) exc.getCause();
             assertWithMessage("Invalid exception message")
                 .that(cause)
                 .hasMessageThat()
@@ -366,8 +366,8 @@ public class SuppressWithNearbyTextFilterTest extends AbstractModuleTestSupport 
             );
             assertWithMessage("CheckstyleException is expected").fail();
         }
-        catch (CheckstyleException ex) {
-            final IllegalArgumentException cause = (IllegalArgumentException) ex.getCause();
+        catch (CheckstyleException exc) {
+            final IllegalArgumentException cause = (IllegalArgumentException) exc.getCause();
             assertWithMessage("Invalid exception message")
                 .that(cause)
                 .hasMessageThat()
@@ -388,8 +388,8 @@ public class SuppressWithNearbyTextFilterTest extends AbstractModuleTestSupport 
             );
             assertWithMessage("CheckstyleException is expected").fail();
         }
-        catch (CheckstyleException ex) {
-            final IllegalArgumentException cause = (IllegalArgumentException) ex.getCause();
+        catch (CheckstyleException exc) {
+            final IllegalArgumentException cause = (IllegalArgumentException) exc.getCause();
             assertWithMessage("Invalid exception message")
                 .that(cause)
                 .hasMessageThat()
@@ -410,9 +410,9 @@ public class SuppressWithNearbyTextFilterTest extends AbstractModuleTestSupport 
             );
             assertWithMessage("CheckstyleException is expected").fail();
         }
-        catch (CheckstyleException ex) {
+        catch (CheckstyleException exc) {
             assertWithMessage("Invalid exception message")
-                .that(ex)
+                .that(exc)
                 .hasCauseThat()
                 .hasMessageThat()
                 .isEqualTo("unable to parse line range"
@@ -492,12 +492,12 @@ public class SuppressWithNearbyTextFilterTest extends AbstractModuleTestSupport 
             filter.accept(auditEvent);
             assertWithMessage(IllegalStateException.class.getSimpleName() + " is expected").fail();
         }
-        catch (IllegalStateException ex) {
+        catch (IllegalStateException exc) {
             assertWithMessage("Invalid exception message")
-                .that(ex.getMessage())
+                .that(exc.getMessage())
                 .isEqualTo("Cannot read source file: " + fileName);
 
-            final Throwable cause = ex.getCause();
+            final Throwable cause = exc.getCause();
             assertWithMessage("Exception cause has invalid type")
                     .that(cause)
                     .isInstanceOf(FileNotFoundException.class);

--- a/src/test/java/com/puppycrawl/tools/checkstyle/filters/SuppressWithPlainTextCommentFilterTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/filters/SuppressWithPlainTextCommentFilterTest.java
@@ -223,8 +223,8 @@ public class SuppressWithPlainTextCommentFilterTest extends AbstractModuleTestSu
             );
             assertWithMessage("CheckstyleException is expected").fail();
         }
-        catch (CheckstyleException ex) {
-            final IllegalArgumentException cause = (IllegalArgumentException) ex.getCause();
+        catch (CheckstyleException exc) {
+            final IllegalArgumentException cause = (IllegalArgumentException) exc.getCause();
             assertWithMessage("Invalid exception message")
                 .that(cause)
                 .hasMessageThat()
@@ -250,8 +250,8 @@ public class SuppressWithPlainTextCommentFilterTest extends AbstractModuleTestSu
             );
             assertWithMessage("CheckstyleException is expected").fail();
         }
-        catch (CheckstyleException ex) {
-            final IllegalArgumentException cause = (IllegalArgumentException) ex.getCause();
+        catch (CheckstyleException exc) {
+            final IllegalArgumentException cause = (IllegalArgumentException) exc.getCause();
             assertWithMessage("Invalid exception message")
                 .that(cause)
                 .hasMessageThat()
@@ -286,8 +286,8 @@ public class SuppressWithPlainTextCommentFilterTest extends AbstractModuleTestSu
             );
             assertWithMessage("CheckstyleException is expected").fail();
         }
-        catch (CheckstyleException ex) {
-            final IllegalArgumentException cause = (IllegalArgumentException) ex.getCause();
+        catch (CheckstyleException exc) {
+            final IllegalArgumentException cause = (IllegalArgumentException) exc.getCause();
             assertWithMessage("Invalid exception message")
                 .that(cause)
                 .hasMessageThat()
@@ -320,8 +320,8 @@ public class SuppressWithPlainTextCommentFilterTest extends AbstractModuleTestSu
             );
             assertWithMessage("CheckstyleException is expected").fail();
         }
-        catch (CheckstyleException ex) {
-            final IllegalArgumentException cause = (IllegalArgumentException) ex.getCause();
+        catch (CheckstyleException exc) {
+            final IllegalArgumentException cause = (IllegalArgumentException) exc.getCause();
             assertWithMessage("Invalid exception message")
                 .that(cause)
                 .hasMessageThat()
@@ -537,12 +537,12 @@ public class SuppressWithPlainTextCommentFilterTest extends AbstractModuleTestSu
             filter.accept(auditEvent);
             assertWithMessage(IllegalStateException.class.getSimpleName() + " is expected").fail();
         }
-        catch (IllegalStateException ex) {
+        catch (IllegalStateException exc) {
             assertWithMessage("Invalid exception message")
-                .that(ex.getMessage())
+                .that(exc.getMessage())
                 .isEqualTo("Cannot read source file: " + fileName);
 
-            final Throwable cause = ex.getCause();
+            final Throwable cause = exc.getCause();
             assertWithMessage("Exception cause has invalid type")
                     .that(cause)
                     .isInstanceOf(FileNotFoundException.class);

--- a/src/test/java/com/puppycrawl/tools/checkstyle/filters/SuppressionCommentFilterTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/filters/SuppressionCommentFilterTest.java
@@ -370,8 +370,8 @@ public class SuppressionCommentFilterTest
             execute(treeWalkerConfig, getPath("InputSuppressionCommentFilter10.java"));
             assertWithMessage("Exception is expected").fail();
         }
-        catch (CheckstyleException ex) {
-            final IllegalArgumentException cause = (IllegalArgumentException) ex.getCause();
+        catch (CheckstyleException exc) {
+            final IllegalArgumentException cause = (IllegalArgumentException) exc.getCause();
             assertWithMessage("Invalid exception message")
                 .that(cause)
                 .hasMessageThat()
@@ -395,8 +395,8 @@ public class SuppressionCommentFilterTest
             execute(treeWalkerConfig, getPath("InputSuppressionCommentFilter11.java"));
             assertWithMessage("Exception is expected").fail();
         }
-        catch (CheckstyleException ex) {
-            final IllegalArgumentException cause = (IllegalArgumentException) ex.getCause();
+        catch (CheckstyleException exc) {
+            final IllegalArgumentException cause = (IllegalArgumentException) exc.getCause();
             assertWithMessage("Invalid exception message")
                 .that(cause)
                 .hasMessageThat()

--- a/src/test/java/com/puppycrawl/tools/checkstyle/filters/SuppressionFilterTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/filters/SuppressionFilterTest.java
@@ -100,9 +100,9 @@ public class SuppressionFilterTest extends AbstractModuleTestSupport {
             createSuppressionFilter(fileName, optional);
             assertWithMessage("Exception is expected").fail();
         }
-        catch (CheckstyleException ex) {
+        catch (CheckstyleException exc) {
             assertWithMessage("Invalid error message")
-                .that(ex.getMessage())
+                .that(exc.getMessage())
                 .isEqualTo("Unable to find: " + fileName);
         }
     }
@@ -115,9 +115,9 @@ public class SuppressionFilterTest extends AbstractModuleTestSupport {
             createSuppressionFilter(fileName, optional);
             assertWithMessage("Exception is expected").fail();
         }
-        catch (CheckstyleException ex) {
+        catch (CheckstyleException exc) {
             assertWithMessage("Invalid error message")
-                .that(ex.getMessage())
+                .that(exc.getMessage())
                 .isEqualTo("Unable to parse " + fileName
                         + " - invalid files or checks or message format");
         }
@@ -236,16 +236,17 @@ public class SuppressionFilterTest extends AbstractModuleTestSupport {
                     available = stream.read() != -1;
                     break;
                 }
-                catch (IOException ex) {
+                catch (IOException exc) {
                     // for some reason Travis CI failed sometimes (unstable) on reading the file
-                    if (attemptCount < attemptLimit && ex.getMessage().contains("Unable to read")) {
+                    if (attemptCount < attemptLimit && exc.getMessage()
+                            .contains("Unable to read")) {
                         attemptCount++;
                         available = false;
                         // wait for bad / disconnection time to pass
                         Thread.sleep(1000);
                     }
                     else {
-                        throw ex;
+                        throw exc;
                     }
                 }
             }

--- a/src/test/java/com/puppycrawl/tools/checkstyle/filters/SuppressionXpathFilterTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/filters/SuppressionXpathFilterTest.java
@@ -86,9 +86,9 @@ public class SuppressionXpathFilterTest extends AbstractModuleTestSupport {
             createSuppressionXpathFilter(fileName, optional);
             assertWithMessage("Exception is expected").fail();
         }
-        catch (CheckstyleException ex) {
+        catch (CheckstyleException exc) {
             assertWithMessage("Invalid error message")
-                .that(ex.getMessage())
+                .that(exc.getMessage())
                 .isEqualTo("Unable to find: " + fileName);
         }
     }
@@ -101,9 +101,9 @@ public class SuppressionXpathFilterTest extends AbstractModuleTestSupport {
             createSuppressionXpathFilter(fileName, optional);
             assertWithMessage("Exception is expected").fail();
         }
-        catch (CheckstyleException ex) {
+        catch (CheckstyleException exc) {
             assertWithMessage("Invalid error message")
-                .that(ex.getMessage())
+                .that(exc.getMessage())
                 .isEqualTo("Unable to parse " + fileName
                     + " - invalid files or checks or message format for suppress-xpath");
         }

--- a/src/test/java/com/puppycrawl/tools/checkstyle/filters/SuppressionXpathSingleFilterTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/filters/SuppressionXpathSingleFilterTest.java
@@ -134,9 +134,9 @@ public class SuppressionXpathSingleFilterTest
                     null, null, xpath);
             assertWithMessage("Exception was expected but got " + test).fail();
         }
-        catch (IllegalArgumentException ex) {
+        catch (IllegalArgumentException exc) {
             assertWithMessage("Message should be: Unexpected xpath query")
-                    .that(ex.getMessage())
+                    .that(exc.getMessage())
                     .contains("Incorrect xpath query");
         }
     }
@@ -189,9 +189,9 @@ public class SuppressionXpathSingleFilterTest
             filter.setFiles("e[l");
             assertWithMessage("PatternSyntaxException is expected").fail();
         }
-        catch (PatternSyntaxException ex) {
+        catch (PatternSyntaxException exc) {
             assertWithMessage("Message should be: Unclosed character class")
-                    .that(ex.getMessage())
+                    .that(exc.getMessage())
                     .contains("Unclosed character class");
         }
     }
@@ -203,9 +203,9 @@ public class SuppressionXpathSingleFilterTest
             filter.setChecks("e[l");
             assertWithMessage("PatternSyntaxException is expected").fail();
         }
-        catch (PatternSyntaxException ex) {
+        catch (PatternSyntaxException exc) {
             assertWithMessage("Message should be: Unclosed character class")
-                    .that(ex.getMessage())
+                    .that(exc.getMessage())
                     .contains("Unclosed character class");
         }
     }
@@ -322,9 +322,9 @@ public class SuppressionXpathSingleFilterTest
             filter.accept(ev);
             assertWithMessage("Exception is expected").fail();
         }
-        catch (IllegalStateException ex) {
+        catch (IllegalStateException exc) {
             assertWithMessage("Exception message does not match expected one")
-                    .that(ex.getMessage())
+                    .that(exc.getMessage())
                     .contains("Cannot initialize context and evaluate query");
         }
     }

--- a/src/test/java/com/puppycrawl/tools/checkstyle/filters/SuppressionsLoaderTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/filters/SuppressionsLoaderTest.java
@@ -87,9 +87,9 @@ public class SuppressionsLoaderTest extends AbstractPathTestSupport {
             SuppressionsLoader.loadSuppressions("http");
             assertWithMessage("exception expected").fail();
         }
-        catch (CheckstyleException ex) {
+        catch (CheckstyleException exc) {
             assertWithMessage("Invalid error message")
-                .that(ex.getMessage())
+                .that(exc.getMessage())
                 .isEqualTo("Unable to find: http");
         }
     }
@@ -100,9 +100,9 @@ public class SuppressionsLoaderTest extends AbstractPathTestSupport {
             SuppressionsLoader.loadSuppressions("http://^%$^* %&% %^&");
             assertWithMessage("exception expected").fail();
         }
-        catch (CheckstyleException ex) {
+        catch (CheckstyleException exc) {
             assertWithMessage("Invalid error message")
-                .that(ex.getMessage())
+                .that(exc.getMessage())
                 .isEqualTo("Unable to find: http://^%$^* %&% %^&");
         }
     }
@@ -140,16 +140,16 @@ public class SuppressionsLoaderTest extends AbstractPathTestSupport {
             SuppressionsLoader.loadSuppressions(fn);
             assertWithMessage("Exception is expected").fail();
         }
-        catch (CheckstyleException ex) {
+        catch (CheckstyleException exc) {
             final String messageStart = "Unable to parse " + fn;
             assertWithMessage("Exception message should start with: " + messageStart)
-                    .that(ex.getMessage())
+                    .that(exc.getMessage())
                     .startsWith("Unable to parse " + fn);
             assertWithMessage("Exception message should contain \"files\"")
-                    .that(ex.getMessage())
+                    .that(exc.getMessage())
                     .contains("\"files\"");
             assertWithMessage("Exception message should contain \"suppress\"")
-                    .that(ex.getMessage())
+                    .that(exc.getMessage())
                     .contains("\"suppress\"");
         }
     }
@@ -161,16 +161,16 @@ public class SuppressionsLoaderTest extends AbstractPathTestSupport {
             SuppressionsLoader.loadSuppressions(fn);
             assertWithMessage("Exception is expected").fail();
         }
-        catch (CheckstyleException ex) {
+        catch (CheckstyleException exc) {
             final String messageStart = "Unable to parse " + fn;
             assertWithMessage("Exception message should start with: " + messageStart)
-                    .that(ex.getMessage())
+                    .that(exc.getMessage())
                     .startsWith(messageStart);
             assertWithMessage("Exception message should contain \"checks\"")
-                    .that(ex.getMessage())
+                    .that(exc.getMessage())
                     .contains("\"checks\"");
             assertWithMessage("Exception message should contain \"suppress\"")
-                    .that(ex.getMessage())
+                    .that(exc.getMessage())
                     .contains("\"suppress\"");
         }
     }
@@ -182,9 +182,9 @@ public class SuppressionsLoaderTest extends AbstractPathTestSupport {
             SuppressionsLoader.loadSuppressions(fn);
             assertWithMessage("Exception is expected").fail();
         }
-        catch (CheckstyleException ex) {
-            assertWithMessage(ex.getMessage())
-                .that(ex.getMessage())
+        catch (CheckstyleException exc) {
+            assertWithMessage(exc.getMessage())
+                .that(exc.getMessage())
                 .startsWith("Number format exception " + fn + " - For input string: \"a\"");
         }
     }
@@ -201,15 +201,16 @@ public class SuppressionsLoaderTest extends AbstractPathTestSupport {
                     filterSet = SuppressionsLoader.loadSuppressions(url);
                     break;
                 }
-                catch (CheckstyleException ex) {
+                catch (CheckstyleException exc) {
                     // for some reason Travis CI failed sometimes (unstable) on reading this file
-                    if (attemptCount < attemptLimit && ex.getMessage().contains("Unable to read")) {
+                    if (attemptCount < attemptLimit && exc.getMessage()
+                            .contains("Unable to read")) {
                         attemptCount++;
                         // wait for bad/disconnection time to pass
                         Thread.sleep(1000);
                     }
                     else {
-                        throw ex;
+                        throw exc;
                     }
                 }
             }
@@ -239,9 +240,9 @@ public class SuppressionsLoaderTest extends AbstractPathTestSupport {
                     new InputSource(sourceName), sourceName);
             assertWithMessage("InvocationTargetException is expected").fail();
         }
-        catch (ReflectiveOperationException ex) {
+        catch (ReflectiveOperationException exc) {
             assertWithMessage("Invalid exception cause message")
-                .that(ex)
+                .that(exc)
                     .hasCauseThat()
                         .hasMessageThat()
                         .isEqualTo("Unable to find: " + sourceName);
@@ -257,9 +258,9 @@ public class SuppressionsLoaderTest extends AbstractPathTestSupport {
                     new InputSource(), sourceName);
             assertWithMessage("InvocationTargetException is expected").fail();
         }
-        catch (ReflectiveOperationException ex) {
+        catch (ReflectiveOperationException exc) {
             assertWithMessage("Invalid exception cause message")
-                .that(ex)
+                .that(exc)
                     .hasCauseThat()
                         .hasMessageThat()
                         .isEqualTo("Unable to read " + sourceName);
@@ -273,9 +274,9 @@ public class SuppressionsLoaderTest extends AbstractPathTestSupport {
             SuppressionsLoader.loadSuppressions(fn);
             assertWithMessage("Exception is expected").fail();
         }
-        catch (CheckstyleException ex) {
+        catch (CheckstyleException exc) {
             assertWithMessage("Invalid error message")
-                .that(ex.getMessage())
+                .that(exc.getMessage())
                 .isEqualTo("Unable to parse " + fn
                         + " - missing checks or id or message attribute");
         }
@@ -298,9 +299,9 @@ public class SuppressionsLoaderTest extends AbstractPathTestSupport {
             SuppressionsLoader.loadSuppressions(fn);
             assertWithMessage("Exception is expected").fail();
         }
-        catch (CheckstyleException ex) {
+        catch (CheckstyleException exc) {
             assertWithMessage("Invalid error message")
-                .that(ex.getMessage())
+                .that(exc.getMessage())
                 .isEqualTo("Unable to parse " + fn
                         + " - invalid files or checks or message format");
         }
@@ -353,9 +354,9 @@ public class SuppressionsLoaderTest extends AbstractPathTestSupport {
             SuppressionsLoader.loadXpathSuppressions(fn);
             assertWithMessage("Exception should be thrown").fail();
         }
-        catch (CheckstyleException ex) {
+        catch (CheckstyleException exc) {
             assertWithMessage("Invalid error message")
-                .that(ex.getMessage())
+                .that(exc.getMessage())
                 .isEqualTo("Unable to parse " + fn
                         + " - invalid files or checks or message format for suppress-xpath");
         }
@@ -369,9 +370,9 @@ public class SuppressionsLoaderTest extends AbstractPathTestSupport {
             SuppressionsLoader.loadXpathSuppressions(fn);
             assertWithMessage("Exception should be thrown").fail();
         }
-        catch (CheckstyleException ex) {
+        catch (CheckstyleException exc) {
             assertWithMessage("Invalid error message")
-                .that(ex.getMessage())
+                .that(exc.getMessage())
                 .isEqualTo("Unable to parse " + fn
                         + " - missing checks or id or message attribute for suppress-xpath");
         }

--- a/src/test/java/com/puppycrawl/tools/checkstyle/filters/XpathFilterElementTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/filters/XpathFilterElementTest.java
@@ -137,9 +137,9 @@ public class XpathFilterElementTest extends AbstractModuleTestSupport {
                     ".*", "e[l", ".*", "moduleId", "query");
             assertWithMessage("Exception is expected but got " + test).fail();
         }
-        catch (IllegalArgumentException ex) {
+        catch (IllegalArgumentException exc) {
             assertWithMessage("Message should be: Failed to initialise regular expression")
-                    .that(ex.getMessage())
+                    .that(exc.getMessage())
                     .contains("Failed to initialise regular expression");
         }
     }
@@ -152,9 +152,9 @@ public class XpathFilterElementTest extends AbstractModuleTestSupport {
                     "Test", null, null, xpath);
             assertWithMessage("Exception is expected but got " + test).fail();
         }
-        catch (IllegalArgumentException ex) {
+        catch (IllegalArgumentException exc) {
             assertWithMessage("Message should be: Incorrect xpath query")
-                    .that(ex.getMessage())
+                    .that(exc.getMessage())
                     .contains("Incorrect xpath query");
         }
     }
@@ -336,9 +336,9 @@ public class XpathFilterElementTest extends AbstractModuleTestSupport {
             filter.accept(ev);
             assertWithMessage("Exception is expected").fail();
         }
-        catch (IllegalStateException ex) {
+        catch (IllegalStateException exc) {
             assertWithMessage("Exception message does not match expected one")
-                    .that(ex.getMessage())
+                    .that(exc.getMessage())
                     .contains("Cannot initialize context and evaluate query");
         }
     }

--- a/src/test/java/com/puppycrawl/tools/checkstyle/gui/MainFrameModelTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/gui/MainFrameModelTest.java
@@ -144,13 +144,13 @@ public class MainFrameModelTest extends AbstractModuleTestSupport {
 
             assertWithMessage("Expected CheckstyleException is not thrown.").fail();
         }
-        catch (CheckstyleException ex) {
+        catch (CheckstyleException exc) {
             final String expectedMsg = String.format(Locale.ROOT,
                     "FileNotFoundException occurred while opening file %s.",
                     nonExistentFile.getPath());
 
             assertWithMessage("Invalid exception message")
-                .that(ex.getMessage())
+                .that(exc.getMessage())
                 .isEqualTo(expectedMsg);
         }
     }
@@ -164,13 +164,13 @@ public class MainFrameModelTest extends AbstractModuleTestSupport {
 
             assertWithMessage("Expected CheckstyleException is not thrown.").fail();
         }
-        catch (CheckstyleException ex) {
+        catch (CheckstyleException exc) {
             final String expectedMsg = String.format(Locale.ROOT,
                     "IllegalStateException occurred while parsing file %s.",
                     nonCompilableFile.getPath());
 
             assertWithMessage("Invalid exception message")
-                .that(ex.getMessage())
+                .that(exc.getMessage())
                 .isEqualTo(expectedMsg);
         }
     }

--- a/src/test/java/com/puppycrawl/tools/checkstyle/gui/ParseTreeTableModelTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/gui/ParseTreeTableModelTest.java
@@ -275,9 +275,9 @@ public class ParseTreeTableModelTest extends AbstractPathTestSupport {
             parseTree.getValueAt(classIdentNode, parseTree.getColumnCount());
             assertWithMessage("IllegalStateException expected").fail();
         }
-        catch (IllegalStateException ex) {
+        catch (IllegalStateException exc) {
             assertWithMessage("Invalid error message")
-                .that(ex.getMessage())
+                .that(exc.getMessage())
                 .isEqualTo("Unknown column");
         }
     }
@@ -354,9 +354,9 @@ public class ParseTreeTableModelTest extends AbstractPathTestSupport {
             parseTree.getColumnClass(parseTree.getColumnCount());
             assertWithMessage("IllegalStateException expected").fail();
         }
-        catch (IllegalStateException ex) {
+        catch (IllegalStateException exc) {
             assertWithMessage("Invalid error message")
-                .that(ex.getMessage())
+                .that(exc.getMessage())
                 .isEqualTo("Unknown column");
         }
 

--- a/src/test/java/com/puppycrawl/tools/checkstyle/gui/ParseTreeTablePresentationTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/gui/ParseTreeTablePresentationTest.java
@@ -297,9 +297,9 @@ public class ParseTreeTablePresentationTest extends AbstractPathTestSupport {
             parseTree.getValueAt(node, parseTree.getColumnCount());
             assertWithMessage("IllegalStateException expected").fail();
         }
-        catch (IllegalStateException ex) {
+        catch (IllegalStateException exc) {
             assertWithMessage("Invalid error message")
-                .that(ex.getMessage())
+                .that(exc.getMessage())
                 .isEqualTo("Unknown column");
         }
     }
@@ -355,9 +355,9 @@ public class ParseTreeTablePresentationTest extends AbstractPathTestSupport {
             parseTree.getValueAt(child, parseTree.getColumnCount());
             assertWithMessage("IllegalStateException expected").fail();
         }
-        catch (IllegalStateException ex) {
+        catch (IllegalStateException exc) {
             assertWithMessage("Invalid error message")
-                .that(ex.getMessage())
+                .that(exc.getMessage())
                 .isEqualTo("Unknown column");
         }
     }
@@ -385,9 +385,9 @@ public class ParseTreeTablePresentationTest extends AbstractPathTestSupport {
             parseTree.getColumnClass(parseTree.getColumnCount());
             assertWithMessage("IllegalStateException expected").fail();
         }
-        catch (IllegalStateException ex) {
+        catch (IllegalStateException exc) {
             assertWithMessage("Invalid error message")
-                .that(ex.getMessage())
+                .that(exc.getMessage())
                 .isEqualTo("Unknown column");
         }
 

--- a/src/test/java/com/puppycrawl/tools/checkstyle/internal/AllChecksTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/internal/AllChecksTest.java
@@ -411,8 +411,8 @@ public class AllChecksTest extends AbstractModuleTestSupport {
             try {
                 instance = moduleFactory.createModule(checkName);
             }
-            catch (CheckstyleException ex) {
-                throw new CheckstyleException("Couldn't find check: " + checkName, ex);
+            catch (CheckstyleException exc) {
+                throw new CheckstyleException("Couldn't find check: " + checkName, exc);
             }
             final AbstractCheck check;
             if (instance instanceof AbstractCheck
@@ -447,7 +447,7 @@ public class AllChecksTest extends AbstractModuleTestSupport {
                 configTokens.addAll(Arrays.asList(checkConfig.getProperty("tokens").trim()
                         .split(",\\s*")));
             }
-            catch (CheckstyleException ex) {
+            catch (CheckstyleException exc) {
                 // no tokens defined, so it is using default
                 if (defaultTokensMustBeExplicit) {
                     validateDefaultTokens(checkConfig, check, configTokens);
@@ -598,10 +598,10 @@ public class AllChecksTest extends AbstractModuleTestSupport {
                 result = CheckUtil.getCheckMessage(module, locale, messageString);
             }
             // -@cs[IllegalCatch] There is no other way to deliver filename that was used
-            catch (Exception ex) {
+            catch (Exception exc) {
                 assertWithMessage(module.getSimpleName() + " with the message '" + messageString
                         + "' in locale '" + locale.getLanguage() + "' failed with: "
-                        + ex.getClass().getSimpleName() + " - " + ex.getMessage()).fail();
+                        + exc.getClass().getSimpleName() + " - " + exc.getMessage()).fail();
             }
 
             assertWithMessage(module.getSimpleName() + " should have text for the message '"

--- a/src/test/java/com/puppycrawl/tools/checkstyle/internal/AllTestsTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/internal/AllTestsTest.java
@@ -110,8 +110,8 @@ public class AllTestsTest {
                 path = getSimplePath(file.getCanonicalPath()).replace("CheckTest.java", "")
                         .replace("Test.java", "");
             }
-            catch (IOException ex) {
-                throw new IllegalStateException(ex);
+            catch (IOException exc) {
+                throw new IllegalStateException(exc);
             }
 
             // override for 'AbstractCheck' naming
@@ -134,8 +134,8 @@ public class AllTestsTest {
             try {
                 path = getSimplePath(file.getCanonicalPath());
             }
-            catch (IOException ex) {
-                throw new IllegalStateException(ex);
+            catch (IOException exc) {
+                throw new IllegalStateException(exc);
             }
 
             final int slash = path.lastIndexOf(File.separatorChar);
@@ -153,8 +153,8 @@ public class AllTestsTest {
             try {
                 path = getSimplePath(file.getCanonicalPath());
             }
-            catch (IOException ex) {
-                throw new IllegalStateException(ex);
+            catch (IOException exc) {
+                throw new IllegalStateException(exc);
             }
 
             // until https://github.com/checkstyle/checkstyle/issues/5105
@@ -240,8 +240,8 @@ public class AllTestsTest {
                 try {
                     path = getSimplePath(file.getCanonicalPath());
                 }
-                catch (IOException ex) {
-                    throw new IllegalStateException(ex);
+                catch (IOException exc) {
+                    throw new IllegalStateException(exc);
                 }
 
                 if (!path.contains(File.separatorChar + "grammar" + File.separatorChar)

--- a/src/test/java/com/puppycrawl/tools/checkstyle/internal/XdocsJavaDocsTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/internal/XdocsJavaDocsTest.java
@@ -159,8 +159,8 @@ public class XdocsJavaDocsTest extends AbstractModuleTestSupport {
         try {
             instance = moduleFactory.createModule(sectionName);
         }
-        catch (CheckstyleException ex) {
-            throw new CheckstyleException(fileName + " couldn't find class: " + sectionName, ex);
+        catch (CheckstyleException exc) {
+            throw new CheckstyleException(fileName + " couldn't find class: " + sectionName, exc);
         }
 
         CHECK_TEXT.clear();
@@ -710,8 +710,8 @@ public class XdocsJavaDocsTest extends AbstractModuleTestSupport {
                 result = getNodeText(XmlUtil.getRawXml(checkName, text, text).getFirstChild())
                         .replace("\r", "");
             }
-            catch (ParserConfigurationException ex) {
-                assertWithMessage("Exception: " + ex.getClass() + " - " + ex.getMessage()).fail();
+            catch (ParserConfigurationException exc) {
+                assertWithMessage("Exception: " + exc.getClass() + " - " + exc.getMessage()).fail();
             }
 
             return result;

--- a/src/test/java/com/puppycrawl/tools/checkstyle/internal/XdocsPagesTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/internal/XdocsPagesTest.java
@@ -718,9 +718,9 @@ public class XdocsPagesTest {
                     checker.destroy();
                 }
             }
-            catch (CheckstyleException ex) {
+            catch (CheckstyleException exc) {
                 throw new CheckstyleException(fileName + " has invalid Checkstyle xml ("
-                        + ex.getMessage() + "): " + unserializedSource, ex);
+                        + exc.getMessage() + "): " + unserializedSource, exc);
             }
         }
         return true;
@@ -808,8 +808,8 @@ public class XdocsPagesTest {
         try {
             instance = moduleFactory.createModule(sectionName);
         }
-        catch (CheckstyleException ex) {
-            throw new CheckstyleException(fileName + " couldn't find class: " + sectionName, ex);
+        catch (CheckstyleException exc) {
+            throw new CheckstyleException(fileName + " couldn't find class: " + sectionName, exc);
         }
 
         int subSectionPos = 0;

--- a/src/test/java/com/puppycrawl/tools/checkstyle/internal/XpathRegressionTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/internal/XpathRegressionTest.java
@@ -107,8 +107,8 @@ public class XpathRegressionTest extends AbstractModuleTestSupport {
         try {
             return CheckUtil.getSimpleNames(CheckUtil.getCheckstyleChecks());
         }
-        catch (IOException ex) {
-            throw new ExceptionInInitializerError(ex);
+        catch (IOException exc) {
+            throw new ExceptionInInitializerError(exc);
         }
     }
 

--- a/src/test/java/com/puppycrawl/tools/checkstyle/internal/utils/TestUtil.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/internal/utils/TestUtil.java
@@ -275,11 +275,11 @@ public final class TestUtil {
             final Field field = getClassDeclaredField(instance.getClass(), fieldName);
             return (T) field.get(instance);
         }
-        catch (ReflectiveOperationException ex) {
+        catch (ReflectiveOperationException exc) {
             final String message = String.format(Locale.ROOT,
                     "Failed to get field '%s' for instance of class '%s'",
                     fieldName, instance.getClass().getSimpleName());
-            throw new IllegalStateException(message, ex);
+            throw new IllegalStateException(message, exc);
         }
     }
 
@@ -298,11 +298,11 @@ public final class TestUtil {
             final Field field = getClassDeclaredField(clss, fieldName);
             return (T) field.get(null);
         }
-        catch (ReflectiveOperationException ex) {
+        catch (ReflectiveOperationException exc) {
             final String message = String.format(Locale.ROOT,
                     "Failed to get static field '%s' for class '%s'",
                     fieldName, clss);
-            throw new IllegalStateException(message, ex);
+            throw new IllegalStateException(message, exc);
         }
     }
 
@@ -320,11 +320,11 @@ public final class TestUtil {
             final Field field = getClassDeclaredField(instance.getClass(), fieldName);
             field.set(instance, value);
         }
-        catch (ReflectiveOperationException ex) {
+        catch (ReflectiveOperationException exc) {
             final String message = String.format(Locale.ROOT,
                     "Failed to set field '%s' for instance of class '%s'",
                     fieldName, instance.getClass().getSimpleName());
-            throw new IllegalStateException(message, ex);
+            throw new IllegalStateException(message, exc);
         }
     }
 

--- a/src/test/java/com/puppycrawl/tools/checkstyle/internal/utils/XmlUtil.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/internal/utils/XmlUtil.java
@@ -64,8 +64,8 @@ public final class XmlUtil {
 
             rawXml = builder.parse(new InputSource(new StringReader(code)));
         }
-        catch (IOException | SAXException ex) {
-            assertWithMessage(fileName + " has invalid xml (" + ex.getMessage() + "): "
+        catch (IOException | SAXException exc) {
+            assertWithMessage(fileName + " has invalid xml (" + exc.getMessage() + "): "
                     + unserializedSource).fail();
         }
 

--- a/src/test/java/com/puppycrawl/tools/checkstyle/utils/AnnotationUtilTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/utils/AnnotationUtilTest.java
@@ -46,9 +46,9 @@ public class AnnotationUtilTest extends AbstractModuleTestSupport {
             isUtilsClassHasPrivateConstructor(AnnotationUtil.class);
             assertWithMessage("Exception is expected").fail();
         }
-        catch (ReflectiveOperationException ex) {
+        catch (ReflectiveOperationException exc) {
             assertWithMessage("Invalid exception message")
-                .that(ex)
+                .that(exc)
                 .hasCauseThat()
                 .hasMessageThat()
                 .isEqualTo("do not instantiate.");
@@ -61,9 +61,9 @@ public class AnnotationUtilTest extends AbstractModuleTestSupport {
             AnnotationUtil.containsAnnotation(null);
             assertWithMessage("IllegalArgumentException is expected").fail();
         }
-        catch (IllegalArgumentException ex) {
+        catch (IllegalArgumentException exc) {
             assertWithMessage("Invalid exception message")
-                .that(ex.getMessage())
+                .that(exc.getMessage())
                 .isEqualTo("the ast is null");
         }
     }
@@ -74,9 +74,9 @@ public class AnnotationUtilTest extends AbstractModuleTestSupport {
             AnnotationUtil.containsAnnotation(null, "");
             assertWithMessage("IllegalArgumentException is expected").fail();
         }
-        catch (IllegalArgumentException ex) {
+        catch (IllegalArgumentException exc) {
             assertWithMessage("Invalid exception message")
-                .that(ex.getMessage())
+                .that(exc.getMessage())
                 .isEqualTo("the ast is null");
         }
     }
@@ -123,9 +123,9 @@ public class AnnotationUtilTest extends AbstractModuleTestSupport {
             AnnotationUtil.getAnnotationHolder(null);
             assertWithMessage("IllegalArgumentException is expected").fail();
         }
-        catch (IllegalArgumentException ex) {
+        catch (IllegalArgumentException exc) {
             assertWithMessage("Invalid exception message")
-                .that(ex.getMessage())
+                .that(exc.getMessage())
                 .isEqualTo("the ast is null");
         }
     }
@@ -136,9 +136,9 @@ public class AnnotationUtilTest extends AbstractModuleTestSupport {
             AnnotationUtil.getAnnotation(null, null);
             assertWithMessage("IllegalArgumentException is expected").fail();
         }
-        catch (IllegalArgumentException ex) {
+        catch (IllegalArgumentException exc) {
             assertWithMessage("Invalid exception message")
-                .that(ex.getMessage())
+                .that(exc.getMessage())
                 .isEqualTo("the ast is null");
         }
     }
@@ -149,9 +149,9 @@ public class AnnotationUtilTest extends AbstractModuleTestSupport {
             AnnotationUtil.getAnnotation(new DetailAstImpl(), null);
             assertWithMessage("IllegalArgumentException is expected").fail();
         }
-        catch (IllegalArgumentException ex) {
+        catch (IllegalArgumentException exc) {
             assertWithMessage("Invalid exception message")
-                .that(ex.getMessage())
+                .that(exc.getMessage())
                 .isEqualTo("the annotation is null");
         }
     }
@@ -162,9 +162,9 @@ public class AnnotationUtilTest extends AbstractModuleTestSupport {
             AnnotationUtil.getAnnotation(new DetailAstImpl(), "");
             assertWithMessage("IllegalArgumentException is expected").fail();
         }
-        catch (IllegalArgumentException ex) {
+        catch (IllegalArgumentException exc) {
             assertWithMessage("Invalid exception message")
-                .that(ex.getMessage())
+                .that(exc.getMessage())
                 .isEqualTo("the annotation is empty or spaces");
         }
     }
@@ -175,9 +175,9 @@ public class AnnotationUtilTest extends AbstractModuleTestSupport {
             AnnotationUtil.getAnnotation(null, "");
             assertWithMessage("IllegalArgumentException is expected").fail();
         }
-        catch (IllegalArgumentException ex) {
+        catch (IllegalArgumentException exc) {
             assertWithMessage("Invalid exception message")
-                .that(ex.getMessage())
+                .that(exc.getMessage())
                 .isEqualTo("the ast is null");
         }
     }
@@ -188,9 +188,9 @@ public class AnnotationUtilTest extends AbstractModuleTestSupport {
             AnnotationUtil.containsAnnotation(null, Set.of("Override"));
             assertWithMessage("IllegalArgumentException is expected").fail();
         }
-        catch (IllegalArgumentException ex) {
+        catch (IllegalArgumentException exc) {
             assertWithMessage("Invalid exception message")
-                .that(ex.getMessage())
+                .that(exc.getMessage())
                 .isEqualTo("the ast is null");
         }
     }
@@ -203,9 +203,9 @@ public class AnnotationUtilTest extends AbstractModuleTestSupport {
             AnnotationUtil.containsAnnotation(ast, annotations);
             assertWithMessage("IllegalArgumentException is expected").fail();
         }
-        catch (IllegalArgumentException ex) {
+        catch (IllegalArgumentException exc) {
             assertWithMessage("Invalid exception message")
-                .that(ex.getMessage())
+                .that(exc.getMessage())
                 .isEqualTo("annotations cannot be null");
         }
     }

--- a/src/test/java/com/puppycrawl/tools/checkstyle/utils/ChainedPropertyUtilTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/utils/ChainedPropertyUtilTest.java
@@ -133,8 +133,8 @@ public class ChainedPropertyUtilTest extends AbstractModuleTestSupport {
         try (InputStream stream = Files.newInputStream(file.toPath())) {
             properties.load(stream);
         }
-        catch (final IOException ex) {
-            throw new CheckstyleException(ex.getMessage(), ex);
+        catch (final IOException exc) {
+            throw new CheckstyleException(exc.getMessage(), exc);
         }
 
         return properties;

--- a/src/test/java/com/puppycrawl/tools/checkstyle/utils/JavadocUtilTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/utils/JavadocUtilTest.java
@@ -284,9 +284,9 @@ public class JavadocUtilTest {
             JavadocUtil.getTokenName(30073);
             assertWithMessage("exception expected").fail();
         }
-        catch (IllegalArgumentException ex) {
+        catch (IllegalArgumentException exc) {
             assertWithMessage("Invalid exception message")
-                .that(ex.getMessage())
+                .that(exc.getMessage())
                 .isEqualTo("Unknown javadoc token id. Given id: 30073");
         }
     }
@@ -297,9 +297,9 @@ public class JavadocUtilTest {
             JavadocUtil.getTokenName(110);
             assertWithMessage("exception expected").fail();
         }
-        catch (IllegalArgumentException ex) {
+        catch (IllegalArgumentException exc) {
             assertWithMessage("Invalid exception message")
-                .that(ex.getMessage())
+                .that(exc.getMessage())
                 .isEqualTo("Unknown javadoc token id. Given id: 110");
         }
     }
@@ -310,9 +310,9 @@ public class JavadocUtilTest {
             JavadocUtil.getTokenName(10095);
             assertWithMessage("exception expected").fail();
         }
-        catch (IllegalArgumentException ex) {
+        catch (IllegalArgumentException exc) {
             assertWithMessage("Invalid exception message")
-                .that(ex.getMessage())
+                .that(exc.getMessage())
                 .isEqualTo("Unknown javadoc token id. Given id: 10095");
         }
     }
@@ -323,9 +323,9 @@ public class JavadocUtilTest {
             JavadocUtil.getTokenId("");
             assertWithMessage("exception expected").fail();
         }
-        catch (IllegalArgumentException ex) {
+        catch (IllegalArgumentException exc) {
             assertWithMessage("Invalid exception message")
-                .that(ex.getMessage())
+                .that(exc.getMessage())
                 .isEqualTo("Unknown javadoc token name. Given name ");
         }
     }

--- a/src/test/java/com/puppycrawl/tools/checkstyle/utils/XpathUtilTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/utils/XpathUtilTest.java
@@ -178,12 +178,12 @@ public class XpathUtilTest {
             XpathUtil.printXpathBranch(invalidXpath, file);
             assertWithMessage("Should end with exception").fail();
         }
-        catch (CheckstyleException ex) {
+        catch (CheckstyleException exc) {
             final String expectedMessage =
                 "Error during evaluation for xpath: " + invalidXpath
                     + ", file: " + file.getCanonicalPath();
             assertWithMessage("Exception message is different")
-                .that(ex.getMessage())
+                .that(exc.getMessage())
                 .isEqualTo(expectedMessage);
         }
     }

--- a/src/test/java/com/puppycrawl/tools/checkstyle/xpath/AttributeNodeTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/xpath/AttributeNodeTest.java
@@ -58,9 +58,9 @@ public class AttributeNodeTest {
             attributeNode.compareOrder(null);
             assertWithMessage("Exception is excepted").fail();
         }
-        catch (UnsupportedOperationException ex) {
+        catch (UnsupportedOperationException exc) {
             assertWithMessage("Invalid exception message")
-                .that(ex.getMessage())
+                .that(exc.getMessage())
                 .isEqualTo("Operation is not supported");
         }
     }
@@ -88,9 +88,9 @@ public class AttributeNodeTest {
             attributeNode.getAttributeValue("", "");
             assertWithMessage("Exception is excepted").fail();
         }
-        catch (UnsupportedOperationException ex) {
+        catch (UnsupportedOperationException exc) {
             assertWithMessage("Invalid exception message")
-                .that(ex.getMessage())
+                .that(exc.getMessage())
                 .isEqualTo("Operation is not supported");
         }
     }
@@ -111,9 +111,9 @@ public class AttributeNodeTest {
             attributeNode.getParent();
             assertWithMessage("Exception is excepted").fail();
         }
-        catch (UnsupportedOperationException ex) {
+        catch (UnsupportedOperationException exc) {
             assertWithMessage("Invalid exception message")
-                .that(ex.getMessage())
+                .that(exc.getMessage())
                 .isEqualTo("Operation is not supported");
         }
     }
@@ -124,9 +124,9 @@ public class AttributeNodeTest {
             attributeNode.getRoot();
             assertWithMessage("Exception is excepted").fail();
         }
-        catch (UnsupportedOperationException ex) {
+        catch (UnsupportedOperationException exc) {
             assertWithMessage("Invalid exception message")
-                .that(ex.getMessage())
+                .that(exc.getMessage())
                 .isEqualTo("Operation is not supported");
         }
     }
@@ -143,9 +143,9 @@ public class AttributeNodeTest {
         try (AxisIterator ignored = attributeNode.iterateAxis(AxisInfo.SELF)) {
             assertWithMessage("Exception is excepted").fail();
         }
-        catch (UnsupportedOperationException ex) {
+        catch (UnsupportedOperationException exc) {
             assertWithMessage("Invalid exception message")
-                .that(ex.getMessage())
+                .that(exc.getMessage())
                 .isEqualTo("Operation is not supported");
         }
     }
@@ -156,9 +156,9 @@ public class AttributeNodeTest {
             attributeNode.getLineNumber();
             assertWithMessage("Exception is excepted").fail();
         }
-        catch (UnsupportedOperationException ex) {
+        catch (UnsupportedOperationException exc) {
             assertWithMessage("Invalid exception message")
-                .that(ex.getMessage())
+                .that(exc.getMessage())
                 .isEqualTo("Operation is not supported");
         }
     }
@@ -169,9 +169,9 @@ public class AttributeNodeTest {
             attributeNode.getColumnNumber();
             assertWithMessage("Exception is excepted").fail();
         }
-        catch (UnsupportedOperationException ex) {
+        catch (UnsupportedOperationException exc) {
             assertWithMessage("Invalid exception message")
-                .that(ex.getMessage())
+                .that(exc.getMessage())
                 .isEqualTo("Operation is not supported");
         }
     }
@@ -182,9 +182,9 @@ public class AttributeNodeTest {
             attributeNode.getTokenType();
             assertWithMessage("Exception is excepted").fail();
         }
-        catch (UnsupportedOperationException ex) {
+        catch (UnsupportedOperationException exc) {
             assertWithMessage("Invalid exception message")
-                .that(ex.getMessage())
+                .that(exc.getMessage())
                 .isEqualTo("Operation is not supported");
         }
     }
@@ -195,9 +195,9 @@ public class AttributeNodeTest {
             attributeNode.getUnderlyingNode();
             assertWithMessage("Exception is excepted").fail();
         }
-        catch (UnsupportedOperationException ex) {
+        catch (UnsupportedOperationException exc) {
             assertWithMessage("Invalid exception message")
-                .that(ex.getMessage())
+                .that(exc.getMessage())
                 .isEqualTo("Operation is not supported");
         }
     }
@@ -208,9 +208,9 @@ public class AttributeNodeTest {
             attributeNode.getAllNamespaces();
             assertWithMessage("Exception is excepted").fail();
         }
-        catch (UnsupportedOperationException ex) {
+        catch (UnsupportedOperationException exc) {
             assertWithMessage("Invalid exception message")
-                .that(ex.getMessage())
+                .that(exc.getMessage())
                 .isEqualTo("Operation is not supported");
         }
     }

--- a/src/test/java/com/puppycrawl/tools/checkstyle/xpath/RootNodeTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/xpath/RootNodeTest.java
@@ -60,9 +60,9 @@ public class RootNodeTest extends AbstractPathTestSupport {
             rootNode.compareOrder(null);
             assertWithMessage("Exception is excepted").fail();
         }
-        catch (UnsupportedOperationException ex) {
+        catch (UnsupportedOperationException exc) {
             assertWithMessage("Invalid exception message")
-                .that(ex.getMessage())
+                .that(exc.getMessage())
                 .isEqualTo("Operation is not supported");
         }
     }
@@ -195,9 +195,9 @@ public class RootNodeTest extends AbstractPathTestSupport {
             rootNode.getStringValue();
             assertWithMessage("Exception is excepted").fail();
         }
-        catch (UnsupportedOperationException ex) {
+        catch (UnsupportedOperationException exc) {
             assertWithMessage("Invalid exception message")
-                .that(ex.getMessage())
+                .that(exc.getMessage())
                 .isEqualTo("Operation is not supported");
         }
     }
@@ -208,9 +208,9 @@ public class RootNodeTest extends AbstractPathTestSupport {
             rootNode.getAttributeValue("", "");
             assertWithMessage("Exception is excepted").fail();
         }
-        catch (UnsupportedOperationException ex) {
+        catch (UnsupportedOperationException exc) {
             assertWithMessage("Invalid exception message")
-                .that(ex.getMessage())
+                .that(exc.getMessage())
                 .isEqualTo("Operation is not supported");
         }
     }
@@ -221,9 +221,9 @@ public class RootNodeTest extends AbstractPathTestSupport {
             rootNode.getDeclaredNamespaces(null);
             assertWithMessage("Exception is excepted").fail();
         }
-        catch (UnsupportedOperationException ex) {
+        catch (UnsupportedOperationException exc) {
             assertWithMessage("Invalid exception message")
-                .that(ex.getMessage())
+                .that(exc.getMessage())
                 .isEqualTo("Operation is not supported");
         }
     }
@@ -234,9 +234,9 @@ public class RootNodeTest extends AbstractPathTestSupport {
             rootNode.isId();
             assertWithMessage("Exception is excepted").fail();
         }
-        catch (UnsupportedOperationException ex) {
+        catch (UnsupportedOperationException exc) {
             assertWithMessage("Invalid exception message")
-                .that(ex.getMessage())
+                .that(exc.getMessage())
                 .isEqualTo("Operation is not supported");
         }
     }
@@ -247,9 +247,9 @@ public class RootNodeTest extends AbstractPathTestSupport {
             rootNode.isIdref();
             assertWithMessage("Exception is excepted").fail();
         }
-        catch (UnsupportedOperationException ex) {
+        catch (UnsupportedOperationException exc) {
             assertWithMessage("Invalid exception message")
-                .that(ex.getMessage())
+                .that(exc.getMessage())
                 .isEqualTo("Operation is not supported");
         }
     }
@@ -260,9 +260,9 @@ public class RootNodeTest extends AbstractPathTestSupport {
             rootNode.isNilled();
             assertWithMessage("Exception is excepted").fail();
         }
-        catch (UnsupportedOperationException ex) {
+        catch (UnsupportedOperationException exc) {
             assertWithMessage("Invalid exception message")
-                .that(ex.getMessage())
+                .that(exc.getMessage())
                 .isEqualTo("Operation is not supported");
         }
     }
@@ -273,9 +273,9 @@ public class RootNodeTest extends AbstractPathTestSupport {
             rootNode.isStreamed();
             assertWithMessage("Exception is excepted").fail();
         }
-        catch (UnsupportedOperationException ex) {
+        catch (UnsupportedOperationException exc) {
             assertWithMessage("Invalid exception message")
-                .that(ex.getMessage())
+                .that(exc.getMessage())
                 .isEqualTo("Operation is not supported");
         }
     }
@@ -286,9 +286,9 @@ public class RootNodeTest extends AbstractPathTestSupport {
             rootNode.getConfiguration();
             assertWithMessage("Exception is excepted").fail();
         }
-        catch (UnsupportedOperationException ex) {
+        catch (UnsupportedOperationException exc) {
             assertWithMessage("Invalid exception message")
-                .that(ex.getMessage())
+                .that(exc.getMessage())
                 .isEqualTo("Operation is not supported");
         }
     }
@@ -299,9 +299,9 @@ public class RootNodeTest extends AbstractPathTestSupport {
             rootNode.setSystemId("1");
             assertWithMessage("Exception is excepted").fail();
         }
-        catch (UnsupportedOperationException ex) {
+        catch (UnsupportedOperationException exc) {
             assertWithMessage("Invalid exception message")
-                .that(ex.getMessage())
+                .that(exc.getMessage())
                 .isEqualTo("Operation is not supported");
         }
     }
@@ -312,9 +312,9 @@ public class RootNodeTest extends AbstractPathTestSupport {
             rootNode.getSystemId();
             assertWithMessage("Exception is excepted").fail();
         }
-        catch (UnsupportedOperationException ex) {
+        catch (UnsupportedOperationException exc) {
             assertWithMessage("Invalid exception message")
-                .that(ex.getMessage())
+                .that(exc.getMessage())
                 .isEqualTo("Operation is not supported");
         }
     }
@@ -325,9 +325,9 @@ public class RootNodeTest extends AbstractPathTestSupport {
             rootNode.getPublicId();
             assertWithMessage("Exception is excepted").fail();
         }
-        catch (UnsupportedOperationException ex) {
+        catch (UnsupportedOperationException exc) {
             assertWithMessage("Invalid exception message")
-                .that(ex.getMessage())
+                .that(exc.getMessage())
                 .isEqualTo("Operation is not supported");
         }
     }
@@ -338,9 +338,9 @@ public class RootNodeTest extends AbstractPathTestSupport {
             rootNode.getBaseURI();
             assertWithMessage("Exception is excepted").fail();
         }
-        catch (UnsupportedOperationException ex) {
+        catch (UnsupportedOperationException exc) {
             assertWithMessage("Invalid exception message")
-                .that(ex.getMessage())
+                .that(exc.getMessage())
                 .isEqualTo("Operation is not supported");
         }
     }
@@ -351,9 +351,9 @@ public class RootNodeTest extends AbstractPathTestSupport {
             rootNode.saveLocation();
             assertWithMessage("Exception is excepted").fail();
         }
-        catch (UnsupportedOperationException ex) {
+        catch (UnsupportedOperationException exc) {
             assertWithMessage("Invalid exception message")
-                .that(ex.getMessage())
+                .that(exc.getMessage())
                 .isEqualTo("Operation is not supported");
         }
     }
@@ -364,9 +364,9 @@ public class RootNodeTest extends AbstractPathTestSupport {
             rootNode.getUnicodeStringValue();
             assertWithMessage("Exception is excepted").fail();
         }
-        catch (UnsupportedOperationException ex) {
+        catch (UnsupportedOperationException exc) {
             assertWithMessage("Invalid exception message")
-                .that(ex.getMessage())
+                .that(exc.getMessage())
                 .isEqualTo("Operation is not supported");
         }
     }
@@ -377,9 +377,9 @@ public class RootNodeTest extends AbstractPathTestSupport {
             rootNode.getFingerprint();
             assertWithMessage("Exception is excepted").fail();
         }
-        catch (UnsupportedOperationException ex) {
+        catch (UnsupportedOperationException exc) {
             assertWithMessage("Invalid exception message")
-                .that(ex.getMessage())
+                .that(exc.getMessage())
                 .isEqualTo("Operation is not supported");
         }
     }
@@ -390,9 +390,9 @@ public class RootNodeTest extends AbstractPathTestSupport {
             rootNode.getDisplayName();
             assertWithMessage("Exception is excepted").fail();
         }
-        catch (UnsupportedOperationException ex) {
+        catch (UnsupportedOperationException exc) {
             assertWithMessage("Invalid exception message")
-                .that(ex.getMessage())
+                .that(exc.getMessage())
                 .isEqualTo("Operation is not supported");
         }
     }
@@ -403,9 +403,9 @@ public class RootNodeTest extends AbstractPathTestSupport {
             rootNode.getPrefix();
             assertWithMessage("Exception is excepted").fail();
         }
-        catch (UnsupportedOperationException ex) {
+        catch (UnsupportedOperationException exc) {
             assertWithMessage("Invalid exception message")
-                .that(ex.getMessage())
+                .that(exc.getMessage())
                 .isEqualTo("Operation is not supported");
         }
     }
@@ -416,9 +416,9 @@ public class RootNodeTest extends AbstractPathTestSupport {
             rootNode.getSchemaType();
             assertWithMessage("Exception is excepted").fail();
         }
-        catch (UnsupportedOperationException ex) {
+        catch (UnsupportedOperationException exc) {
             assertWithMessage("Invalid exception message")
-                .that(ex.getMessage())
+                .that(exc.getMessage())
                 .isEqualTo("Operation is not supported");
         }
     }
@@ -429,9 +429,9 @@ public class RootNodeTest extends AbstractPathTestSupport {
             rootNode.atomize();
             assertWithMessage("Exception is excepted").fail();
         }
-        catch (UnsupportedOperationException ex) {
+        catch (UnsupportedOperationException exc) {
             assertWithMessage("Invalid exception message")
-                .that(ex.getMessage())
+                .that(exc.getMessage())
                 .isEqualTo("Operation is not supported");
         }
     }
@@ -442,9 +442,9 @@ public class RootNodeTest extends AbstractPathTestSupport {
             rootNode.generateId(null);
             assertWithMessage("Exception is excepted").fail();
         }
-        catch (UnsupportedOperationException ex) {
+        catch (UnsupportedOperationException exc) {
             assertWithMessage("Invalid exception message")
-                .that(ex.getMessage())
+                .that(exc.getMessage())
                 .isEqualTo("Operation is not supported");
         }
     }
@@ -455,9 +455,9 @@ public class RootNodeTest extends AbstractPathTestSupport {
             rootNode.copy(null, -1, null);
             assertWithMessage("Exception is excepted").fail();
         }
-        catch (UnsupportedOperationException ex) {
+        catch (UnsupportedOperationException exc) {
             assertWithMessage("Invalid exception message")
-                .that(ex.getMessage())
+                .that(exc.getMessage())
                 .isEqualTo("Operation is not supported");
         }
     }
@@ -468,9 +468,9 @@ public class RootNodeTest extends AbstractPathTestSupport {
             rootNode.getAllNamespaces();
             assertWithMessage("Exception is excepted").fail();
         }
-        catch (UnsupportedOperationException ex) {
+        catch (UnsupportedOperationException exc) {
             assertWithMessage("Invalid exception message")
-                .that(ex.getMessage())
+                .that(exc.getMessage())
                 .isEqualTo("Operation is not supported");
         }
     }

--- a/src/test/java/com/puppycrawl/tools/checkstyle/xpath/XpathMapperTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/xpath/XpathMapperTest.java
@@ -534,9 +534,9 @@ public class XpathMapperTest extends AbstractModuleTestSupport {
             getXpathItems(xpath, rootNode);
             assertWithMessage("Exception is excepted").fail();
         }
-        catch (UnsupportedOperationException ex) {
+        catch (UnsupportedOperationException exc) {
             assertWithMessage("Invalid exception")
-                    .that(ex.getMessage())
+                    .that(exc.getMessage())
                     .isEqualTo("Operation is not supported");
         }
     }
@@ -549,9 +549,9 @@ public class XpathMapperTest extends AbstractModuleTestSupport {
             getXpathItems(xpath, rootNode);
             assertWithMessage("Exception is excepted").fail();
         }
-        catch (UnsupportedOperationException ex) {
+        catch (UnsupportedOperationException exc) {
             assertWithMessage("Invalid exception")
-                    .that(ex.getMessage())
+                    .that(exc.getMessage())
                     .isEqualTo("Operation is not supported");
         }
     }


### PR DESCRIPTION
Fix #17017

Rename `ex` variable to `exc` in all files and forbid the `ex` from the `CatchParameterName`.