### PR TITLE
Issue #14631: Update Javadoc for FRAME_HTML_TAG_NAME with AST example

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/api/JavadocTokenTypes.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/api/JavadocTokenTypes.java
@@ -1713,7 +1713,29 @@ public final class JavadocTokenTypes {
     /** Col tag name. */
     public static final int COL_HTML_TAG_NAME = JavadocParser.COL_HTML_TAG_NAME;
 
-    /** Frame tag name. */
+    /**
+     * Frame tag name.
+     *
+     * <p><b>Example:</b></p>
+     * <pre>{@code <frame src="frame_a.html">}</pre>
+     *
+     * <p><b>Tree:</b></p>
+     * <pre>
+     * {@code
+     * |--HTML_ELEMENT -> HTML_ELEMENT
+     * |   `--SINGLETON_ELEMENT -> SINGLETON_ELEMENT
+     * |       `--FRAME_TAG -> FRAME_TAG
+     * |           |--START -> <
+     * |           |--FRAME_HTML_TAG_NAME -> frame
+     * |           |--WS ->
+     * |           |--ATTRIBUTE -> ATTRIBUTE
+     * |           |   |--HTML_TAG_NAME -> src
+     * |           |   |--EQUALS -> =
+     * |           |   `--ATTR_VALUE -> "frame_a.html"
+     * |           `--END -> >
+     * }
+     * </pre>
+     */
     public static final int FRAME_HTML_TAG_NAME = JavadocParser.FRAME_HTML_TAG_NAME;
 
     /**


### PR DESCRIPTION
Issue #14631
**Command Used**
`java -jar checkstyle-10.21.4-all.jar -J Test.java | sed "s/\[[0-9]\+:[0-9]\+\]//g"`
**Test.java**
```
/**
 * <frame src="frame_a.html"> 
 */
public class Test {
}
```
**Terminal Output**
```
yukti@LAPTOP-P8NBSFE2 MINGW64 ~/FRAME_HTML_TAG_NAME (master)
$ java -jar checkstyle-10.21.4-all.jar -J Test.java | sed "s/\[[0-9]\+:[0-9]\+\]//g"
COMPILATION_UNIT -> COMPILATION_UNIT
`--CLASS_DEF -> CLASS_DEF
    |--MODIFIERS -> MODIFIERS
    |   |--BLOCK_COMMENT_BEGIN -> /*
    |   |   |--COMMENT_CONTENT -> *\r\n * <frame src="frame_a.html"> - Test for FRAME_HTML_TAG_NAME\r\n
    |   |   |   `--JAVADOC -> JAVADOC
    |   |   |       |--NEWLINE -> \r\n
    |   |   |       |--LEADING_ASTERISK ->  *
    |   |   |       |--TEXT ->
    |   |   |       |--HTML_ELEMENT -> HTML_ELEMENT
    |   |   |       |   `--SINGLETON_ELEMENT -> SINGLETON_ELEMENT
    |   |   |       |       `--FRAME_TAG -> FRAME_TAG
    |   |   |       |           |--START -> <
    |   |   |       |           |--FRAME_HTML_TAG_NAME -> frame
    |   |   |       |           |--WS ->
    |   |   |       |           |--ATTRIBUTE -> ATTRIBUTE
    |   |   |       |           |   |--HTML_TAG_NAME -> src
    |   |   |       |           |   |--EQUALS -> =
    |   |   |       |           |   `--ATTR_VALUE -> "frame_a.html"
    |   |   |       |           `--END -> >
    |   |   |       |--TEXT ->  - Test for FRAME_HTML_TAG_NAME
    |   |   |       |--NEWLINE -> \r\n
    |   |   |       |--TEXT ->
    |   |   |       `--EOF -> <EOF>
    |   |   `--BLOCK_COMMENT_END -> */
    |   `--LITERAL_PUBLIC -> public
    |--LITERAL_CLASS -> class
    |--IDENT -> Test
    `--OBJBLOCK -> OBJBLOCK
        |--LCURLY -> {
        `--RCURLY -> }
```


