### PR TITLE
dependency: update equalsverifier to version 4.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -386,7 +386,7 @@
     <dependency>
       <groupId>nl.jqno.equalsverifier</groupId>
       <artifactId>equalsverifier</artifactId>
-      <version>3.19.4</version>
+      <version>4.0</version>
       <scope>test</scope>
     </dependency>
     <dependency>


### PR DESCRIPTION
Bumps [nl.jqno.equalsverifier:equalsverifier](https://github.com/jqno/equalsverifier) from 3.19.4 to 4.0.

![Screenshot 2025-05-09 101609](https://github.com/user-attachments/assets/b955f4ea-921b-49f0-85a2-b13d5abed4bc)
