### PR TITLE
Issue #16802: improve `spelling` and `typo` in `CheckstyleAntTask` - `spelling`

### DIFF
--- a/src/test/java/com/puppycrawl/tools/checkstyle/ant/CheckstyleAntTaskTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/ant/CheckstyleAntTaskTest.java
@@ -233,7 +233,7 @@ public class CheckstyleAntTaskTest extends AbstractPathTestSupport {
                 .isEqualTo(getPath(FLAWLESS_INPUT));
         assertWithMessage("Amount of logged messages in unexpected")
                 .that(antTask.getLoggedMessages())
-                .hasSize(8);
+                .hasSize(7);
     }
 
     @Test
@@ -882,11 +882,10 @@ public class CheckstyleAntTaskTest extends AbstractPathTestSupport {
         final String auditFinishedMessage = bundle.getString(DefaultLogger.AUDIT_FINISHED_MESSAGE);
 
         final List<MessageLevelPair> expectedList = Arrays.asList(
-                new MessageLevelPair("checkstyle version .*", Project.MSG_VERBOSE),
                 new MessageLevelPair("Adding standalone file for audit", Project.MSG_VERBOSE),
                 new MessageLevelPair("To locate the files took \\d+ ms.", Project.MSG_VERBOSE),
-                new MessageLevelPair("Running Checkstyle  on 1 files", Project.MSG_INFO),
                 new MessageLevelPair("Using configuration file:.*", Project.MSG_VERBOSE),
+                new MessageLevelPair("Running Checkstyle .* on 1 files", Project.MSG_INFO),
                 new MessageLevelPair(auditStartedMessage, Project.MSG_DEBUG),
                 new MessageLevelPair(auditFinishedMessage, Project.MSG_DEBUG),
                 new MessageLevelPair("To process the files took \\d+ ms.", Project.MSG_VERBOSE),


### PR DESCRIPTION
Issue #16802: improve `spelling` and `typo` in `CheckstyleAntTask`

- https://github.com/checkstyle/checkstyle/pull/16774

fix whitespace typo
`Running Checkstyle on 1 files.`
`Running Checkstyle  on 1 files.`

I was wondering about this issue myself and found it accidentally while refactoring this class in #16772.