### PR TITLE
Issue #14631: Add example and AST tree for EMPTY_TAG in JavadocTokenTypes.java

### DIFF
--- a/config/jsoref-spellchecker/whitelist.words
+++ b/config/jsoref-spellchecker/whitelist.words
@@ -747,6 +747,7 @@ JTool
 jtree
 junit
 junitpioneer
+justsometag
 jvm
 jxr
 kailasam

--- a/src/main/java/com/puppycrawl/tools/checkstyle/api/JavadocTokenTypes.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/api/JavadocTokenTypes.java
@@ -2750,10 +2750,25 @@ public final class JavadocTokenTypes {
             + RULE_TYPES_OFFSET;
 
     /**
-     * Non-special empty html tag.
+     * Represents an empty (self-closing) HTML tag in Javadoc comments,
+     * such as {@code <justsometag />}.
+     *
+     * <p><b>Example:</b></p>
+     * <pre>{@code <justsometag />}</pre>
+     *
+     * <p><b>AST Tree:</b></p>
+     * <pre>{@code
+     * --HTML_ELEMENT -&gt; HTML_ELEMENT
+     *   `--SINGLETON_ELEMENT -&gt; SINGLETON_ELEMENT
+     *     `--EMPTY_TAG -&gt; EMPTY_TAG
+     *       |--START -&gt; &lt;
+     *       |--HTML_TAG_NAME -&gt; justsometag
+     *       |--WS
+     *       `--SLASH_END -&gt; /&gt;
+     * }</pre>
      */
-    public static final int EMPTY_TAG = JavadocParser.RULE_emptyTag
-            + RULE_TYPES_OFFSET;
+    public static final int EMPTY_TAG =
+        JavadocParser.RULE_emptyTag + RULE_TYPES_OFFSET;
 
     /**
      * Area html tag.


### PR DESCRIPTION
Issue #14631
**Command Used**
` java -jar checkstyle-10.21.4-all.jar -J Test.java | sed "s/\[[0-9]\+:[0-9]\+\]//g"`
**Test.java**
```
/**
 * Example for empty tag.
 *
 * <justsometag />
 */
public class Test { }
```
**Terminal Output**
```
yukti@LAPTOP-P8NBSFE2 MINGW64 ~/EMPTY_TAG (master)
$ java -jar checkstyle-10.21.4-all.jar -J Test.java | sed "s/\[[0-9]\+:[0-9]\+\]//g"
COMPILATION_UNIT -> COMPILATION_UNIT
`--CLASS_DEF -> CLASS_DEF
    |--MODIFIERS -> MODIFIERS
    |   |--BLOCK_COMMENT_BEGIN -> /*
    |   |   |--COMMENT_CONTENT -> *\r\n * Example for empty tag.\r\n *\r\n * <justsometag />\r\n
    |   |   |   `--JAVADOC -> JAVADOC
    |   |   |       |--NEWLINE -> \r\n
    |   |   |       |--LEADING_ASTERISK ->  *
    |   |   |       |--TEXT ->  Example for empty tag.
    |   |   |       |--NEWLINE -> \r\n
    |   |   |       |--LEADING_ASTERISK ->  *
    |   |   |       |--NEWLINE -> \r\n
    |   |   |       |--LEADING_ASTERISK ->  *
    |   |   |       |--TEXT ->
    |   |   |       |--HTML_ELEMENT -> HTML_ELEMENT
    |   |   |       |   `--SINGLETON_ELEMENT -> SINGLETON_ELEMENT
    |   |   |       |       `--EMPTY_TAG -> EMPTY_TAG
    |   |   |       |           |--START -> <
    |   |   |       |           |--HTML_TAG_NAME -> justsometag
    |   |   |       |           |--WS ->
    |   |   |       |           `--SLASH_END -> />
    |   |   |       |--NEWLINE -> \r\n
    |   |   |       |--TEXT ->
    |   |   |       `--EOF -> <EOF>
    |   |   `--BLOCK_COMMENT_END -> */
    |   `--LITERAL_PUBLIC -> public
    |--LITERAL_CLASS -> class
    |--IDENT -> Test
    `--OBJBLOCK -> OBJBLOCK
        |--LCURLY -> {
        `--RCURLY -> }
```
