### PR TITLE
Issue #14631: Add example and AST for LINK_TAG in JavadocTokenTypes.java

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/api/JavadocTokenTypes.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/api/JavadocTokenTypes.java
@@ -3028,7 +3028,32 @@ public final class JavadocTokenTypes {
      */
     public static final int ISINDEX_TAG = JavadocParser.RULE_isindexTag + RULE_TYPES_OFFSET;
 
-    /** Link html tag. */
+    /**
+     * Link html tag.
+     *
+     * <p><b>Example:</b></p>
+     * <pre>{@code <link rel="stylesheet" href="styles.css">}</pre>
+     *
+     * <b>Tree:</b>
+     * <pre>
+     * {@code
+     * HTML_ELEMENT -> HTML_ELEMENT
+     *     `--SINGLETON_ELEMENT -> SINGLETON_ELEMENT
+     *      `--LINK_TAG -> LINK_TAG
+     *          |--START -> <
+     *          |--LINK_HTML_TAG_NAME -> link
+     *          |--ATTRIBUTE -> ATTRIBUTE
+     *          |   |--HTML_TAG_NAME -> rel
+     *          |   |--EQUALS -> =
+     *          |   `--ATTR_VALUE -> "stylesheet"
+     *          |--ATTRIBUTE -> ATTRIBUTE
+     *          |   |--HTML_TAG_NAME -> href
+     *          |   |--EQUALS -> =
+     *          |   `--ATTR_VALUE -> "styles.css"
+     *          `--END -> >
+     * }
+     * </pre>
+     */
     public static final int LINK_TAG = JavadocParser.RULE_linkTag + RULE_TYPES_OFFSET;
 
     /**


### PR DESCRIPTION
Issue #14631
**Command Used**
` java -jar checkstyle-10.13.0-all.jar -J Test.java | sed "s/\[[0-9]\+:[0-9]\+\]//g"`
**Test.java**
```
/**
 * Example using {@link String#length()} to test LINK_TAG.
 */
public class Test { }
```
**Terminal Output**
```
yukti@LAPTOP-P8NBSFE2 MINGW64 ~/LINK_TAG (master)
$ java -jar checkstyle-10.13.0-all.jar -J Test.java | sed "s/\[[0-9]\+:[0-9]\+\]//g"
COMPILATION_UNIT -> COMPILATION_UNIT
`--CLASS_DEF -> CLASS_DEF
    |--MODIFIERS -> MODIFIERS
    |   |--BLOCK_COMMENT_BEGIN -> /*
    |   |   |--COMMENT_CONTENT -> *\r\n * Example using {@link String#length()} to test LINK_TAG.\r\n
    |   |   |   `--JAVADOC -> JAVADOC
    |   |   |       |--NEWLINE -> \r\n
    |   |   |       |--LEADING_ASTERISK ->  *
    |   |   |       |--TEXT ->  Example using
    |   |   |       |--JAVADOC_INLINE_TAG -> JAVADOC_INLINE_TAG
    |   |   |       |   |--JAVADOC_INLINE_TAG_START -> {
    |   |   |       |   |--LINK_LITERAL -> @link
    |   |   |       |   |--WS ->
    |   |   |       |   |--REFERENCE -> REFERENCE
    |   |   |       |   |   |--PACKAGE_CLASS -> String
    |   |   |       |   |   |--HASH -> #
    |   |   |       |   |   |--MEMBER -> length
    |   |   |       |   |   `--PARAMETERS -> PARAMETERS
    |   |   |       |   |       |--LEFT_BRACE -> (
    |   |   |       |   |       `--RIGHT_BRACE -> )
    |   |   |       |   `--JAVADOC_INLINE_TAG_END -> }
    |   |   |       |--TEXT ->  to test LINK_TAG.
    |   |   |       |--NEWLINE -> \r\n
    |   |   |       |--TEXT ->
    |   |   |       `--EOF -> <EOF>
    |   |   `--BLOCK_COMMENT_END -> */
    |   `--LITERAL_PUBLIC -> public
    |--LITERAL_CLASS -> class
    |--IDENT -> Test
    `--OBJBLOCK -> OBJBLOCK
        |--LCURLY -> {
        `--RCURLY -> }
```
