### PR TITLE
minor: capitalize section titles for consistency

### DIFF
--- a/src/site/xdoc/beginning_development.xml
+++ b/src/site/xdoc/beginning_development.xml
@@ -15,7 +15,7 @@
         <param name="toDepth" value="1"/>
       </macro>
     </section>
-    <section name="Before development">
+    <section name="Before Development">
       <p>
         1. Ensure that Git, Java JDK >= 11 until JDK 17, maven >= 3.6.3 are installed.<br/>
         You can find information about development environment preparation here:

--- a/src/site/xdoc/config_system_properties.xml
+++ b/src/site/xdoc/config_system_properties.xml
@@ -16,7 +16,7 @@
       </macro>
     </section>
 
-    <section name="How to set system property for CLI">
+    <section name="How To Set System Property For CLI">
       <p>
         System properties should be provided to <code>java</code> command.
         Example: <code>java -D&lt;property&gt;=&lt;value&gt; -jar ... </code>
@@ -27,7 +27,7 @@
       </p>
     </section>
 
-    <section name="Enable External DTD load">
+    <section name="Enable External DTD Load">
       <p>
         The property <code>checkstyle.enableExternalDtdLoad</code>
         defines the ability to use custom DTD files in config and load them from some location.
@@ -35,7 +35,7 @@
         is <a href="property_types.html#boolean">boolean</a> and defaults
         to <code>false</code>. Disabled by default due to security concerns.
       </p>
-      <subsection name="Examples" id="Enable_External_DTD_load_Examples">
+      <subsection name="Examples" id="Enable_External_DTD_Load_Examples">
         <p>
           The following is an example of including the contents of other xml files by using the
           ENTITY feature to keep common parts of configs in a single file and then creating
@@ -137,7 +137,7 @@ Checkstyle ends with 2 errors.
       </subsection>
     </section>
 
-    <section name="Property chaining support">
+    <section name="Property Chaining Support">
       <p>
         Checkstyle supports property expansion within property definitions, also
         known as property chaining. This feature allows you to define properties
@@ -152,7 +152,7 @@ checkstyle.suppressions.file=${checkstyle.dir}/${config.dir}/suppressions.xml
         which will resolve to
         <code>/home/user/checkstyle/configs/suppressions.xml</code>.
       </p>
-      <subsection name="Notes" id="Property_chaining_support_Notes">
+      <subsection name="Notes" id="Property_Chaining_Support_Notes">
         <p>
           Note that property variable expression must be of the form
           <code>${expression}</code>.

--- a/src/site/xdoc/contributing.xml
+++ b/src/site/xdoc/contributing.xml
@@ -52,7 +52,7 @@
       </p>
     </section>
 
-    <section name="Report an issue">
+    <section name="Report An Issue">
 
       <p>
         All functional changes in the project must be linked to an approved issue.
@@ -84,7 +84,7 @@
       </p>
     </section>
 
-    <section name="Quality matters">
+    <section name="Quality Matters">
 
       <p>
         We use a set of development tools to ensure that
@@ -130,7 +130,7 @@
       </p>
     </section>
 
-    <section name="Submitting your contribution">
+    <section name="Submitting Your Contribution">
 
       <p>
         Once you have made sure that your changes pass the Maven command


### PR DESCRIPTION
minor words fixed to capitals across website.