### PR TITLE
Issue #17059: Add example to MatchXpath for Constructor Count

### DIFF
--- a/src/site/xdoc/checks/coding/matchxpath.xml
+++ b/src/site/xdoc/checks/coding/matchxpath.xml
@@ -124,9 +124,11 @@ CLASS_DEF -&gt; CLASS_DEF [1:0]
         <div class="wrapper"><pre class="prettyprint"><code class="language-java">
 public class Example1 {
   public void method1() { }
-  private void method2() { } // violation
+  // violation below 'Private methods must appear after public methods'
+  private void method2() { }
   public void method3() { }
-  private void method4() { } // violation
+  // violation below 'Private methods must appear after public methods'
+  private void method4() { }
   public void method5() { }
   private void method6() { }
 }
@@ -147,8 +149,10 @@ public class Example1 {
         <p id="Example2-code">Example:</p>
         <div class="wrapper"><pre class="prettyprint"><code class="language-java">
 public class Example2 {
-  public Example2(Object c) { } // violation
-  public Example2(int a, HashMap&lt;String, Integer&gt; b) { } // violation
+  // violation below 'Parameterized constructors are not allowed'
+  public Example2(Object c) { }
+  // violation below 'Parameterized constructors are not allowed'
+  public Example2(int a, HashMap&lt;String, Integer&gt; b) { }
   public Example2() { }
 }
 </code></pre></div><hr class="example-separator"/>
@@ -168,14 +172,17 @@ public class Example2 {
         <p id="Example3-code">Example:</p>
         <div class="wrapper"><pre class="prettyprint"><code class="language-java">
 public class Example3 {
-  public void test() {} // violation
+  // violation below 'Method name should not be test or foo'
+  public void test() {}
   public void getName() {}
-  public void foo() {} // violation
+  // violation below 'Method name should not be test or foo'
+  public void foo() {}
   public void sayHello() {}
 }
 </code></pre></div><hr class="example-separator"/>
         <p id="Example4-config">
-          To violate if new instance creation was done without <b>var</b> type
+          To violate if new instance creation was done without <b>var</b> type to avoid duplication
+          of reference in statement
         </p>
         <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
 &lt;module name="Checker"&gt;
@@ -185,8 +192,7 @@ public class Example3 {
            value="//VARIABLE_DEF[./ASSIGN/EXPR/LITERAL_NEW
                   and not(./TYPE/IDENT[@text='var'])]"/&gt;
       &lt;message key="matchxpath.match"
-           value="New instances should be created via 'var' keyword
-                  to avoid duplication of type reference in statement"/&gt;
+           value="New instances should be created via var keyword"/&gt;
     &lt;/module&gt;
   &lt;/module&gt;
 &lt;/module&gt;
@@ -195,8 +201,35 @@ public class Example3 {
         <div class="wrapper"><pre class="prettyprint"><code class="language-java">
 public class Example4 {
   public void foo() {
-    Object a = new Object(); // violation
+    // violation below 'New instances should be created via var keyword'
+    Object a = new Object();
     var b = new Object();
+  }
+}
+</code></pre></div><hr class="example-separator"/>
+        <p id="Example5-config">
+          To violate if class has more than <b>1</b> constructor
+        </p>
+        <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
+&lt;module name="Checker"&gt;
+  &lt;module name="TreeWalker"&gt;
+    &lt;module name="MatchXpath"&gt;
+      &lt;property name="query"
+           value="//CLASS_DEF[count(./OBJBLOCK/CTOR_DEF) &gt; 1]"/&gt;
+      &lt;message key="matchxpath.match"
+           value="Classes with more than 1 constructor are not allowed"/&gt;
+    &lt;/module&gt;
+  &lt;/module&gt;
+&lt;/module&gt;
+</code></pre></div>
+        <p id="Example5-code">Example:</p>
+        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+public class Example5 {
+  public Example5() { }
+  // violation below 'Classes with more than 1 constructor are not allowed'
+  class Inner {
+    public Inner(int a) { }
+    public Inner() { }
   }
 }
 </code></pre></div>

--- a/src/site/xdoc/checks/coding/matchxpath.xml.template
+++ b/src/site/xdoc/checks/coding/matchxpath.xml.template
@@ -131,7 +131,8 @@ CLASS_DEF -&gt; CLASS_DEF [1:0]
           <param name="type" value="code"/>
         </macro><hr class="example-separator"/>
         <p id="Example4-config">
-          To violate if new instance creation was done without <b>var</b> type
+          To violate if new instance creation was done without <b>var</b> type to avoid duplication
+          of reference in statement
         </p>
         <macro name="example">
           <param name="path"
@@ -142,6 +143,20 @@ CLASS_DEF -&gt; CLASS_DEF [1:0]
         <macro name="example">
           <param name="path"
                  value="resources/com/puppycrawl/tools/checkstyle/checks/coding/matchxpath/Example4.java"/>
+          <param name="type" value="code"/>
+                  </macro><hr class="example-separator"/>
+        <p id="Example5-config">
+          To violate if class has more than <b>1</b> constructor
+        </p>
+        <macro name="example">
+          <param name="path"
+                 value="resources/com/puppycrawl/tools/checkstyle/checks/coding/matchxpath/Example5.java"/>
+          <param name="type" value="config"/>
+        </macro>
+        <p id="Example5-code">Example:</p>
+        <macro name="example">
+          <param name="path"
+                 value="resources/com/puppycrawl/tools/checkstyle/checks/coding/matchxpath/Example5.java"/>
           <param name="type" value="code"/>
         </macro>
       </subsection>

--- a/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/checks/coding/MatchXpathCheckExamplesTest.java
+++ b/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/checks/coding/MatchXpathCheckExamplesTest.java
@@ -32,8 +32,8 @@ public class MatchXpathCheckExamplesTest extends AbstractExamplesModuleTestSuppo
     @Test
     public void testExample1() throws Exception {
         final String[] expected = {
-            "19:3: " + "Private methods must appear after public methods",
-            "21:3: " + "Private methods must appear after public methods",
+            "20:3: " + "Private methods must appear after public methods",
+            "23:3: " + "Private methods must appear after public methods",
         };
 
         verifyWithInlineConfigParser(getPath("Example1.java"), expected);
@@ -42,8 +42,8 @@ public class MatchXpathCheckExamplesTest extends AbstractExamplesModuleTestSuppo
     @Test
     public void testExample2() throws Exception {
         final String[] expected = {
-            "19:3: " + "Parameterized constructors are not allowed",
             "20:3: " + "Parameterized constructors are not allowed",
+            "22:3: " + "Parameterized constructors are not allowed",
         };
 
         verifyWithInlineConfigParser(getPath("Example2.java"), expected);
@@ -52,8 +52,8 @@ public class MatchXpathCheckExamplesTest extends AbstractExamplesModuleTestSuppo
     @Test
     public void testExample3() throws Exception {
         final String[] expected = {
-            "17:3: " + "Method name should not be test or foo",
-            "19:3: " + "Method name should not be test or foo",
+            "18:3: " + "Method name should not be test or foo",
+            "21:3: " + "Method name should not be test or foo",
         };
 
         verifyWithInlineConfigParser(getPath("Example3.java"), expected);
@@ -62,11 +62,18 @@ public class MatchXpathCheckExamplesTest extends AbstractExamplesModuleTestSuppo
     @Test
     public void testExample4() throws Exception {
         final String[] expected = {
-            "20:5: " + "New instances should be created via var keyword"
-                     + "                  "
-                     + "to avoid duplication of type reference in statement",
+            "20:5: " + "New instances should be created via var keyword",
         };
 
         verifyWithInlineConfigParser(getPath("Example4.java"), expected);
+    }
+
+    @Test
+    public void testExample5() throws Exception {
+        final String[] expected = {
+            "19:3: " + "Classes with more than 1 constructor are not allowed",
+        };
+
+        verifyWithInlineConfigParser(getPath("Example5.java"), expected);
     }
 }

--- a/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/coding/matchxpath/Example1.java
+++ b/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/coding/matchxpath/Example1.java
@@ -16,9 +16,11 @@ package com.puppycrawl.tools.checkstyle.checks.coding.matchxpath;
 // xdoc section -- start
 public class Example1 {
   public void method1() { }
-  private void method2() { } // violation
+  // violation below 'Private methods must appear after public methods'
+  private void method2() { }
   public void method3() { }
-  private void method4() { } // violation
+  // violation below 'Private methods must appear after public methods'
+  private void method4() { }
   public void method5() { }
   private void method6() { }
 }

--- a/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/coding/matchxpath/Example2.java
+++ b/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/coding/matchxpath/Example2.java
@@ -16,8 +16,10 @@ import java.util.HashMap;
 
 // xdoc section -- start
 public class Example2 {
-  public Example2(Object c) { } // violation
-  public Example2(int a, HashMap<String, Integer> b) { } // violation
+  // violation below 'Parameterized constructors are not allowed'
+  public Example2(Object c) { }
+  // violation below 'Parameterized constructors are not allowed'
+  public Example2(int a, HashMap<String, Integer> b) { }
   public Example2() { }
 }
 // xdoc section -- end

--- a/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/coding/matchxpath/Example3.java
+++ b/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/coding/matchxpath/Example3.java
@@ -14,9 +14,11 @@ package com.puppycrawl.tools.checkstyle.checks.coding.matchxpath;
 
 // xdoc section -- start
 public class Example3 {
-  public void test() {} // violation
+  // violation below 'Method name should not be test or foo'
+  public void test() {}
   public void getName() {}
-  public void foo() {} // violation
+  // violation below 'Method name should not be test or foo'
+  public void foo() {}
   public void sayHello() {}
 }
 // xdoc section -- end

--- a/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/coding/matchxpath/Example4.java
+++ b/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/coding/matchxpath/Example4.java
@@ -6,8 +6,7 @@
            value="//VARIABLE_DEF[./ASSIGN/EXPR/LITERAL_NEW
                   and not(./TYPE/IDENT[@text='var'])]"/>
       <message key="matchxpath.match"
-           value="New instances should be created via 'var' keyword
-                  to avoid duplication of type reference in statement"/>
+           value="New instances should be created via var keyword"/>
     </module>
   </module>
 </module>
@@ -17,7 +16,8 @@ package com.puppycrawl.tools.checkstyle.checks.coding.matchxpath;
 // xdoc section -- start
 public class Example4 {
   public void foo() {
-    Object a = new Object(); // violation
+    // violation below 'New instances should be created via var keyword'
+    Object a = new Object();
     var b = new Object();
   }
 }

--- a/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/coding/matchxpath/Example5.java
+++ b/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/coding/matchxpath/Example5.java
@@ -1,0 +1,24 @@
+/*xml
+<module name="Checker">
+  <module name="TreeWalker">
+    <module name="MatchXpath">
+      <property name="query"
+           value="//CLASS_DEF[count(./OBJBLOCK/CTOR_DEF) > 1]"/>
+      <message key="matchxpath.match"
+           value="Classes with more than 1 constructor are not allowed"/>
+    </module>
+  </module>
+</module>
+*/
+package com.puppycrawl.tools.checkstyle.checks.coding.matchxpath;
+
+// xdoc section -- start
+public class Example5 {
+  public Example5() { }
+  // violation below 'Classes with more than 1 constructor are not allowed'
+  class Inner {
+    public Inner(int a) { }
+    public Inner() { }
+  }
+}
+// xdoc section -- end


### PR DESCRIPTION
Issue: #17059

```
<?xml version="1.0" encoding="UTF-8"?>
<!DOCTYPE module PUBLIC
          "-//Checkstyle//DTD Checkstyle Configuration 1.3//EN"
          "https://checkstyle.org/dtds/configuration_1_3.dtd">

<module name="Checker">
  <module name="TreeWalker">
    <module name="MatchXpath">
      <property name="query"
           value="//CLASS_DEF[count(./OBJBLOCK/CTOR_DEF) > 1]"/>
      <message key="matchxpath.match"
           value="Classes with more than 1 constructor are not allowed"/>
    </module>
  </module>
</module>
```
```
public class Example5 {
    public Example5() { }
    class Inner { // violation
        public Inner(int a) { }
        public Inner() { }
    }
}
```

```
C:\Users\athar\OneDrive\Desktop\test2>java -jar checkstyle-10.23.1-all.jar -c config.xml Example5.java
Starting audit...
[ERROR] C:\Users\athar\OneDrive\Desktop\test2\Example5.java:3:5: Classes with more than 1 constructor are not allowed [MatchXpath]
Audit done.
Checkstyle ends with 1 errors.
```