### PR TITLE
Add GSoC guide tip on learning beyond code, link article on coding review

### DIFF
--- a/.github/GSOC.md
+++ b/.github/GSOC.md
@@ -111,5 +111,12 @@ you are excited to work with us.
     accumulate contributions, and refine your proposal.
 - **Communicate Effectively.** We are looking for participants who can communicate effectively. This
     includes using clear and concise language, being responsive to feedback, and being proactive.
+- **Learn About Software Development Beyond Just Code.** To be a great open-source
+    contributor, it helps to understand more than just writing code. Knowing about
+    common practices like code reviews, and how developers feel about them, is
+    valuable. This article on developer feelings about code reviews is a good example:
+    "[Developer Sentiment in Code Reviews][code-review-feelings-article-link]".
 - **Contribute, Contribute, Contribute.** This is the single best way to show us that you are
     serious becoming a valuable member of our community.
+
+[code-review-feelings-article-link]: https://roman-ivanov.blogspot.com/2022/04/comments-on-predicting-developers.html


### PR DESCRIPTION
Based on https://github.com/checkstyle/checkstyle/pull/16625#issuecomment-2868000748

This PR updates the GSoC participant guide (`.github/GSOC.md`) with a new tip encouraging contributors to understand the broader context of software development. It includes a link to an article on developer sentiment in code reviews to help new contributors appreciate the human aspect of collaboration.

### Changes

* Added a new tip to the GSoC participant guide.
* Linked to an article on developer sentiment in code reviews as a suggested resource.
* Simplified the tip’s wording for clarity and approachability.

### Preview

![Preview of new tip](https://github.com/user-attachments/assets/16ca4cbd-1fb0-441e-9696-debdef06c25e)

### Demo

[Video showing how the link works](https://github.com/user-attachments/assets/6a3dd5ff-e324-4287-8d48-3bae564e00b7)