### PR TITLE
Issue #14631: Update Javadoc for RP_HTML_TAG_NAME in JavadocTokenTypes.java

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/api/JavadocTokenTypes.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/api/JavadocTokenTypes.java
@@ -1640,8 +1640,34 @@ public final class JavadocTokenTypes {
     /** `rtc` tag name. */
     public static final int RTC_HTML_TAG_NAME = JavadocParser.RTC_HTML_TAG_NAME;
 
-    /** `rp` tag name. */
+    /**
+     * RP tag name.
+     *
+     * <p><b>Example:</b></p>
+     * <pre>
+     * &lt;rp&gt;Fallback&lt;/rp&gt;
+     * </pre>
+     *
+     * <b>Tree:</b>
+     * <pre>
+     * {@code
+     * HTML_ELEMENT -> HTML_ELEMENT
+     *     `--RP -> RP
+     *         |--RP_TAG_START -> RP_TAG_START
+     *         |   |--START -> <
+     *         |   |--RP_HTML_TAG_NAME -> rp
+     *         |   `--END -> >
+     *         |--TEXT -> Fallback
+     *         `--RP_TAG_END -> RP_TAG_END
+     *             |--START -> <
+     *             |--SLASH -> /
+     *             |--RP_HTML_TAG_NAME -> rp
+     *             `--END -> >
+     * }
+     * </pre>
+     */
     public static final int RP_HTML_TAG_NAME = JavadocParser.RP_HTML_TAG_NAME;
+
     ///////////////////////////////////////////////////////////////////////////////////////////////
 
     /////////////////////// SINGLETON HTML TAGS  //////////////////////////////////////////////////


### PR DESCRIPTION
Issue #14631
**Command Used**
` java -jar checkstyle-10.13.0-all.jar -J Test.java | sed "s/\[[0-9]\+:[0-9]\+\]//g"`
**Test.java**
```
/**
 * <rp>Fallback</rp>
 */
public class Test {}
```
**Terminal Output**

```
yukti@LAPTOP-P8NBSFE2 MINGW64 ~/RP_HTML_TAG_NAME
$ java -jar checkstyle-10.13.0-all.jar -J Test.java | sed "s/\[[0-9]\+:[0-9]\+\]//g"
COMPILATION_UNIT -> COMPILATION_UNIT
`--CLASS_DEF -> CLASS_DEF
    |--MODIFIERS -> MODIFIERS
    |   |--BLOCK_COMMENT_BEGIN -> /*
    |   |   |--COMMENT_CONTENT -> *\r\n * <rp>Fallback</rp>\r\n
    |   |   |   `--JAVADOC -> JAVADOC
    |   |   |       |--NEWLINE -> \r\n
    |   |   |       |--LEADING_ASTERISK ->  *
    |   |   |       |--TEXT ->
    |   |   |       |--HTML_ELEMENT -> HTML_ELEMENT
    |   |   |       |   `--RP -> RP
    |   |   |       |       |--RP_TAG_START -> RP_TAG_START
    |   |   |       |       |   |--START -> <
    |   |   |       |       |   |--RP_HTML_TAG_NAME -> rp
    |   |   |       |       |   `--END -> >
    |   |   |       |       |--TEXT -> Fallback
    |   |   |       |       `--RP_TAG_END -> RP_TAG_END
    |   |   |       |           |--START -> <
    |   |   |       |           |--SLASH -> /
    |   |   |       |           |--RP_HTML_TAG_NAME -> rp
    |   |   |       |           `--END -> >
    |   |   |       |--NEWLINE -> \r\n
    |   |   |       |--TEXT ->
    |   |   |       `--EOF -> <EOF>
    |   |   `--BLOCK_COMMENT_END -> */
    |   `--LITERAL_PUBLIC -> public
    |--LITERAL_CLASS -> class
    |--IDENT -> Test
    `--OBJBLOCK -> OBJBLOCK
        |--LCURLY -> {
        `--RCURLY -> }

```