### PR TITLE
Issue #14631: Added example and AST for TRACK_TAG in JavadocTokenTypes.java

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/api/JavadocTokenTypes.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/api/JavadocTokenTypes.java
@@ -3163,9 +3163,34 @@ public final class JavadocTokenTypes {
     /**
      * HTML void element {@code <track>}.
      *
+     * <p><b>Example:</b></p>
+     * <pre>{@code
+     * <track kind="subtitles" src="subtitles_en.vtt" />
+     * }</pre>
+     *
+     * <p><b>AST Tree:</b></p>
+     * <pre>{@code
+     * --HTML_ELEMENT -> HTML_ELEMENT
+     *   `--SINGLETON_ELEMENT -> SINGLETON_ELEMENT
+     *     `--TRACK_TAG -> TRACK_TAG
+     *       |--START -> <
+     *       |--TRACK_HTML_TAG_NAME -> track
+     *       |--WS ->
+     *       |--ATTRIBUTE -> ATTRIBUTE
+     *       |   |--HTML_TAG_NAME -> kind
+     *       |   |--EQUALS -> =
+     *       |   `--ATTR_VALUE -> "subtitles"
+     *       |--WS ->
+     *       |--ATTRIBUTE -> ATTRIBUTE
+     *       |   |--HTML_TAG_NAME -> src
+     *       |   |--EQUALS -> =
+     *       |   `--ATTR_VALUE -> "subtitles_en.vtt"
+     *       |--WS ->
+     *       `--SLASH_END -> />
+     * }</pre>
+     *
      * @see #SINGLETON_ELEMENT
-     * @see <a
-     *     href="https://www.w3.org/TR/html51/semantics-embedded-content.html#elementdef-track">
+     * @see <a href="https://www.w3.org/TR/html51/semantics-embedded-content.html#elementdef-track">
      *     W3 docs</a>
      */
     public static final int TRACK_TAG = JavadocParser.RULE_trackTag + RULE_TYPES_OFFSET;


### PR DESCRIPTION
Issue #14631
**Command Used**
` java -jar checkstyle-10.13.0-all.jar -J Test.java | sed "s/\[[0-9]\+:[0-9]\+\]//g"`
**Test.java**
```
/**
 * <track kind="subtitles" src="subtitles_en.vtt" />
 */
public class Test {
}
```
**Terminal Output**
```
yukti@LAPTOP-P8NBSFE2 MINGW64 ~/TRACK_TAG
$ java -jar checkstyle-10.13.0-all.jar -J Test.java | sed "s/\[[0-9]\+:[0-9]\+\]//g"
COMPILATION_UNIT -> COMPILATION_UNIT
`--CLASS_DEF -> CLASS_DEF
    |--MODIFIERS -> MODIFIERS
    |   |--BLOCK_COMMENT_BEGIN -> /*
    |   |   |--COMMENT_CONTENT -> *\r\n * <track kind="subtitles" src="subtitles_en.vtt" />\r\n
    |   |   |   `--JAVADOC -> JAVADOC
    |   |   |       |--NEWLINE -> \r\n
    |   |   |       |--LEADING_ASTERISK ->  *
    |   |   |       |--TEXT ->
    |   |   |       |--HTML_ELEMENT -> HTML_ELEMENT
    |   |   |       |   `--SINGLETON_ELEMENT -> SINGLETON_ELEMENT
    |   |   |       |       `--TRACK_TAG -> TRACK_TAG
    |   |   |       |           |--START -> <
    |   |   |       |           |--TRACK_HTML_TAG_NAME -> track
    |   |   |       |           |--WS ->
    |   |   |       |           |--ATTRIBUTE -> ATTRIBUTE
    |   |   |       |           |   |--HTML_TAG_NAME -> kind
    |   |   |       |           |   |--EQUALS -> =
    |   |   |       |           |   `--ATTR_VALUE -> "subtitles"
    |   |   |       |           |--WS ->
    |   |   |       |           |--ATTRIBUTE -> ATTRIBUTE
    |   |   |       |           |   |--HTML_TAG_NAME -> src
    |   |   |       |           |   |--EQUALS -> =
    |   |   |       |           |   `--ATTR_VALUE -> "subtitles_en.vtt"
    |   |   |       |           |--WS ->
    |   |   |       |           `--SLASH_END -> />
    |   |   |       |--NEWLINE -> \r\n
    |   |   |       |--TEXT ->
    |   |   |       `--EOF -> <EOF>
    |   |   `--BLOCK_COMMENT_END -> */
    |   `--LITERAL_PUBLIC -> public
    |--LITERAL_CLASS -> class
    |--IDENT -> Test
    `--OBJBLOCK -> OBJBLOCK
        |--LCURLY -> {
        `--RCURLY -> }
```