### PR TITLE
Pull #17110: fix log typo

### DIFF
--- a/config/ant-phase-verify-sevntu.xml
+++ b/config/ant-phase-verify-sevntu.xml
@@ -40,7 +40,7 @@
     <tstamp>
       <format property="FINISHED" pattern="dd/MM/yyyy hh:mm:ss aa"/>
     </tstamp>
-    <echo level="info">Checkstyle finished (${check.config}) : ${FINISHED}</echo>
+    <echo level="info">Checkstyle finished (${check.config}): ${FINISHED}</echo>
 
     <fail if="checkstyle.failure.property"
           message="Checkstyle failed: ${checkstyle.failure.property}"

--- a/config/ant-phase-verify.xml
+++ b/config/ant-phase-verify.xml
@@ -60,7 +60,7 @@
     <tstamp>
       <format property="FINISHED" pattern="dd/MM/yyyy hh:mm:ss aa"/>
     </tstamp>
-    <echo level="info">Checkstyle finished (checkstyle-checks.xml) : ${FINISHED}</echo>
+    <echo level="info">Checkstyle finished (checkstyle-checks.xml): ${FINISHED}</echo>
 
     <tstamp>
       <format property="STARTED" pattern="dd/MM/yyyy hh:mm:ss aa"/>


### PR DESCRIPTION
this the only one avoiding the common pattern:

<img width="1009" alt="image" src="https://github.com/user-attachments/assets/6ef76cad-9c76-42f6-bc8a-2e6e452140b7" />
