### PR TITLE
Issue #17139: build set JAVA_HOME and update PATH for OpenJDK installation

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -8,6 +8,8 @@ task:
     - git clone --recursive
           https://x-access-token:%CIRRUS_REPO_CLONE_TOKEN%@github.com/%CIRRUS_REPO_FULL_NAME%.git
           %CIRRUS_WORKING_DIR%/ci
+    - set "JAVA_HOME=%ProgramFiles%\OpenJDK\%OPENJDK_PATH%"
+    - set "PATH=%JAVA_HOME%\bin;%PATH%"
     - cd ci
     - cmd /c "if defined CIRRUS_PR (git fetch origin pull/%CIRRUS_PR%/head:pull/%CIRRUS_PR%)"
     - git reset --hard %CIRRUS_CHANGE_IN_REPO%
@@ -37,21 +39,31 @@ task:
     - choco upgrade -y chocolatey
     - choco install -y --no-progress ant
     - choco install -y --no-progress openjdk --version %OPENJDK_VERSION%
-    # - choco install -y --no-progress xsltproc
-    # - choco install -y --no-progress xmlstarlet
+    - set "JAVA_HOME=%ProgramFiles%\OpenJDK\%OPENJDK_PATH%"
+    - set "PATH=%JAVA_HOME%\bin;%PATH%"
+    - java -version
+    - javac -version
+
   version_script:
+    - set "JAVA_HOME=%ProgramFiles%\OpenJDK\%OPENJDK_PATH%"
+    - set "PATH=%JAVA_HOME%\bin;%PATH%"
     - set
     - ant -version
     - java --version
-    - ./mvnw --version
     # - xsltproc --version
     # - xml --version
   sevntu_script:
+    - set "JAVA_HOME=%ProgramFiles%\OpenJDK\%OPENJDK_PATH%"
+    - set "PATH=%JAVA_HOME%\bin;%PATH%"
     - cd ci
     - .ci/validation.cmd sevntu
   verify_without_checkstyle_script:
+    - set "JAVA_HOME=%ProgramFiles%\OpenJDK\%OPENJDK_PATH%"
+    - set "PATH=%JAVA_HOME%\bin;%PATH%"
     - cd ci
     - .ci/validation.cmd verify_without_checkstyle
   site_without_verify_script:
+    - set "JAVA_HOME=%ProgramFiles%\OpenJDK\%OPENJDK_PATH%"
+    - set "PATH=%JAVA_HOME%\bin;%PATH%"
     - cd ci
     - .ci/validation.cmd site_without_verify


### PR DESCRIPTION
Closes #17139

![Screenshot 2025-05-26 110914](https://github.com/user-attachments/assets/59040ead-d823-4719-824d-3368896569a1)

https://cirrus-ci.com/task/6735355057012736
```
C:\Users\ContainerAdministrator\AppData\Local\Temp\cirrus-ci-build>if 0 NEQ 0 exit /b 0 
C:\Users\ContainerAdministrator\AppData\Local\Temp\cirrus-ci-build>call ant -version 
Apache Ant(TM) version 1.10.15 compiled on August 25 2024
C:\Users\ContainerAdministrator\AppData\Local\Temp\cirrus-ci-build>if 0 NEQ 0 exit /b 0 
C:\Users\ContainerAdministrator\AppData\Local\Temp\cirrus-ci-build>call java --version 
openjdk 17 2021-09-14
OpenJDK Runtime Environment (build 17+35-2724)
OpenJDK 64-Bit Server VM (build 17+35-2724, mixed mode, sharing)
C:\Users\ContainerAdministrator\AppData\Local\Temp\cirrus-ci-build>if 0 NEQ 0 exit /b 0 
C:\Users\ContainerAdministrator\AppData\Local\Temp\cirrus-ci-build>call mvn --version 
Apache Maven 3.6.3 (cecedd343002696d0abb50b32b541b8a6ba2883f)
Maven home: C:\ProgramData\chocolatey\lib\maven\apache-maven-3.6.3\bin\..
Java version: 17, vendor: Oracle Corporation, runtime: C:\Program Files\OpenJDK\jdk-17
Default locale: en_US, platform encoding: Cp1252
OS name: "windows server 2019", version: "10.0", arch: "amd64", family: "windows"
```