### PR TITLE
infra: allow cirrus to run on PR from its own repository

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -1,4 +1,4 @@
-only_if: $CIRRUS_BRANCH == $CIRRUS_DEFAULT_BRANCH
+only_if: $CIRRUS_BRANCH == $CIRRUS_DEFAULT_BRANCH || $CIRRUS_BRANCH !=~ 'pull/.*'
 task:
   name: Windows build
   windows_container:


### PR DESCRIPTION
https://cirrus-ci.org/guide/writing-tasks/#supported-operators

to test updates to this CI, as it is not running in CI pulls