### PR TITLE
Issue #17031: Make comparison logic more robust in AbstractModuleTest…

### DIFF
--- a/src/site/xdoc/filters/suppresswithnearbycommentfilter.xml
+++ b/src/site/xdoc/filters/suppresswithnearbycommentfilter.xml
@@ -254,8 +254,8 @@ public class Example5 {
         <div class="wrapper"><pre class="prettyprint"><code class="language-java">
 public class Example6 {
   // @cs.suppress [ConstantName|NoWhitespaceAfter] A comment here
-  public static final int [] array = {}; // filtered violation
-  // filtered violation above
+  public static final int [] array = {}; // filtered violation 'must match pattern'
+  // filtered violation above 'followed by whitespace'
 }
 </code></pre></div>
         <p>

--- a/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/filters/suppresswithnearbycommentfilter/Example6.java
+++ b/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/filters/suppresswithnearbycommentfilter/Example6.java
@@ -16,7 +16,7 @@ package com.puppycrawl.tools.checkstyle.filters.suppresswithnearbycommentfilter;
 // xdoc section -- start
 public class Example6 {
   // @cs.suppress [ConstantName|NoWhitespaceAfter] A comment here
-  public static final int [] array = {}; // filtered violation
-  // filtered violation above
+  public static final int [] array = {}; // filtered violation 'must match pattern'
+  // filtered violation above 'followed by whitespace'
 }
 // xdoc section -- end


### PR DESCRIPTION
…Support.verifyViolations()

This branch fixes Issue: #17031 "Fix compareTo method for testInputViolations".

I have read all contribution guidelines I could find.

I have ensured that `./mvnw clean verify` passes with "BUILD SUCCESS".

The problem was that `AbstractModuleTestSupport.verifyViolations()` was expecting to receive the `testInputViolations` parameter sorted in the same order that the `getActualViolationsForFile()` method would return the actual violations, and this was not actually guaranteed to happen.

The proposed solution was to add a `colNo` field to `TestInputViolation` so that its `compareTo()` method would be able to sort according to row number and then column number and match the expected order, but I decided not to do this because it is impossible to extract column number information from the test input violation message comments (the comments that specify expected violations in Java files used as input for test cases).

Instead, I modified the `verifyViolations()` method to be able to handle the case where `testInputViolations` is out of order as instructed in https://github.com/checkstyle/checkstyle/issues/17031#issuecomment-2915737919

There are actually two different `verifyViolations()` methods which had code repetition and I modified one of them to call the other to avoid code repetition.

I also modified `src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/filters/suppresswithnearbycommentfilter/Example6.java` and `src/site/xdoc/filters/suppresswithnearbycommentfilter.xml` to add in the test input violation message comments mentioned by https://github.com/checkstyle/checkstyle/issues/17031#issuecomment-2912601991 that were triggering the faulty comparison logic to go wrong in the first place.