### PR TITLE
Issue #17186: fixing separator between examples for javadoc package

### DIFF
--- a/src/site/xdoc/checks/javadoc/javadocpackage.xml
+++ b/src/site/xdoc/checks/javadoc/javadocpackage.xml
@@ -70,7 +70,7 @@
 package com.puppycrawl.tools.checkstyle.checks.javadoc.javadocpackage.nonlegacy;
 /* violation on first line 'Missing package-info.java file' */
 public class Example1 { }
-</code></pre></div>
+</code></pre></div><hr class="example-separator"/>
 
         <p id="Example2-config">
           To configure the check with allowlegacy set to true:
@@ -95,7 +95,7 @@ public class Example1 { }
 package com.puppycrawl.tools.checkstyle.checks.javadoc.javadocpackage.legacy;
 // ok as package.html file is present in directory
 public class Example2 { }
-</code></pre></div>
+</code></pre></div><hr class="example-separator"/>
 
         <p id="Example3-config">
           To configure the check with allowlegacy set to true:

--- a/src/site/xdoc/checks/javadoc/javadocpackage.xml.template
+++ b/src/site/xdoc/checks/javadoc/javadocpackage.xml.template
@@ -51,7 +51,7 @@
           <param name="path"
                  value="resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadocpackage/nonlegacy/Example1.java"/>
           <param name="type" value="code"/>
-        </macro>
+        </macro><hr class="example-separator"/>
 
         <p id="Example2-config">
           To configure the check with allowlegacy set to true:
@@ -74,7 +74,7 @@
           <param name="path"
                  value="resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadocpackage/legacy/Example2.java"/>
           <param name="type" value="code"/>
-        </macro>
+        </macro><hr class="example-separator"/>
 
         <p id="Example3-config">
           To configure the check with allowlegacy set to true:


### PR DESCRIPTION
#17186 
This PR fixes the missing hr separator in `checks/javadoc/javadocpackage.html `