### PR TITLE
supplemental: adding inputs for 4.5.1 where to break for record-class

### DIFF
--- a/config/google-java-format/excluded/compilable-input-paths.txt
+++ b/config/google-java-format/excluded/compilable-input-paths.txt
@@ -31,6 +31,8 @@ src/it/resources/com/google/checkstyle/test/chapter4formatting/rule451wheretobre
 src/it/resources/com/google/checkstyle/test/chapter4formatting/rule451wheretobreak/InputSeparatorWrapArrayDeclarator.java
 src/it/resources/com/google/checkstyle/test/chapter4formatting/rule451wheretobreak/InputLambdaBodyWrap.java
 src/it/resources/com/google/checkstyle/test/chapter4formatting/rule451wheretobreak/InputIllegalLineBreakAroundLambda.java
+src/it/resources/com/google/checkstyle/test/chapter4formatting/rule451wheretobreak/InputNoWrappingAfterRecordName.java
+src/it/resources/com/google/checkstyle/test/chapter4formatting/rule451wheretobreak/InputNoWrappingAfterRecordName2.java
 src/it/resources/com/google/checkstyle/test/chapter4formatting/rule452indentcontinuationlines/InputClassWithChainedMethods2.java
 src/it/resources/com/google/checkstyle/test/chapter4formatting/rule461verticalwhitespace/InputVerticalWhitespace.java
 src/it/resources/com/google/checkstyle/test/chapter4formatting/rule462horizontalwhitespace/InputWhitespaceAroundBasic.java

--- a/src/it/java/com/google/checkstyle/test/chapter4formatting/rule451wheretobreak/WhereToBreakTest.java
+++ b/src/it/java/com/google/checkstyle/test/chapter4formatting/rule451wheretobreak/WhereToBreakTest.java
@@ -119,4 +119,24 @@ public class WhereToBreakTest extends AbstractGoogleModuleTestSupport {
     public void testFormattedIllegalLineBreakAroundLambda() throws Exception {
         verifyWithWholeConfig(getPath("InputFormattedIllegalLineBreakAroundLambda.java"));
     }
+
+    @Test
+    public void testNoWrappingAfterRecordName1() throws Exception {
+        verifyWithWholeConfig(getPath("InputNoWrappingAfterRecordName.java"));
+    }
+
+    @Test
+    public void testNoWrappingAfterRecordNameFormatted1() throws Exception {
+        verifyWithWholeConfig(getPath("InputFormattedNoWrappingAfterRecordName.java"));
+    }
+
+    @Test
+    public void testNoWrappingAfterRecordName2() throws Exception {
+        verifyWithWholeConfig(getPath("InputNoWrappingAfterRecordName2.java"));
+    }
+
+    @Test
+    public void testNoWrappingAfterRecordNameFormatted2() throws Exception {
+        verifyWithWholeConfig(getPath("InputFormattedNoWrappingAfterRecordName2.java"));
+    }
 }

--- a/src/it/resources/com/google/checkstyle/test/chapter4formatting/rule451wheretobreak/InputFormattedNoWrappingAfterRecordName.java
+++ b/src/it/resources/com/google/checkstyle/test/chapter4formatting/rule451wheretobreak/InputFormattedNoWrappingAfterRecordName.java
@@ -1,0 +1,60 @@
+package com.google.checkstyle.test.chapter4formatting.rule451wheretobreak;
+
+/** Some javadoc. */
+public record InputFormattedNoWrappingAfterRecordName(String name) {
+  record Multi(String main, Record rec) {
+    private static boolean isSent(Object obj) {
+      int value = 0;
+      if (obj instanceof Integer i) {
+        value = i;
+      }
+      return value > 10;
+    }
+  }
+
+  record Multi2() {
+    Multi2(String s1, String s2, String s3) {
+      this();
+    }
+  }
+
+  record Multi3(Integer i, Integer node) {
+    public static void main(String... args) {
+      System.out.println("works!");
+    }
+  }
+
+  record Multi4() {
+    void foo() {}
+  }
+
+  record Multi5() {
+    private static final Multi obj = new Multi("my string", new Multi4());
+  }
+
+  record Multi6() {
+
+    public static final Multi obj = new Multi("hello", new Multi4());
+  }
+
+  class MyTestClass {
+    private final Multi obj = new Multi("my string", new Multi4());
+  }
+
+  /**
+   * Maps the ports.
+   *
+   * @param from the from param
+   */
+  record Mapping(String from) {
+
+    /**
+     * The constructor for Mapping.
+     *
+     * @param from The source
+     */
+    Mapping(String from) {
+      this.from = from;
+    }
+  }
+}

--- a/src/it/resources/com/google/checkstyle/test/chapter4formatting/rule451wheretobreak/InputFormattedNoWrappingAfterRecordName2.java
+++ b/src/it/resources/com/google/checkstyle/test/chapter4formatting/rule451wheretobreak/InputFormattedNoWrappingAfterRecordName2.java
@@ -1,0 +1,72 @@
+package com.google.checkstyle.test.chapter4formatting.rule451wheretobreak;
+
+/** Some javadoc. */
+public class InputFormattedNoWrappingAfterRecordName2 {
+
+  @interface InSize {
+    int limit();
+  }
+
+  @InSize(limit = 2)
+  record MyRecord(String main, Record rec) {
+    private static boolean isSent(Object obj) {
+      int value = 0;
+      if (obj instanceof Integer i) {
+        value = i;
+      }
+      return value > 10;
+    }
+  }
+
+  record Multi2() {
+
+    @InSize(limit = 2)
+    public Multi2(String s1, String s2, String s3) {
+      this();
+    }
+  }
+
+  record Multi3(Integer i, Integer node) {
+    public static void main(String... args) {
+      System.out.println("works!");
+    }
+  }
+
+  record Multi4() {
+
+    @InSize(limit = 2)
+    void foo() {}
+  }
+
+  record Multi5() {
+    private static final MyRecord object = new MyRecord("my string", new Multi4());
+  }
+
+  record Multi6() {
+
+    public static final MyRecord obj = new MyRecord("hello", new Multi4());
+  }
+
+  class MyTestClass {
+    private final MyRecord obj = new MyRecord("my string", new Multi4());
+  }
+
+  /**
+   * Maps the ports.
+   *
+   * @param from the from param
+   */
+  @InSize(limit = 2)
+  record Mapping(String from) {
+
+    /**
+     * The constructor for Mapping.
+     *
+     * @param from The source
+     */
+    @InSize(limit = 3)
+    Mapping(String from) {
+      this.from = from;
+    }
+  }
+}

--- a/src/it/resources/com/google/checkstyle/test/chapter4formatting/rule451wheretobreak/InputNoWrappingAfterRecordName.java
+++ b/src/it/resources/com/google/checkstyle/test/chapter4formatting/rule451wheretobreak/InputNoWrappingAfterRecordName.java
@@ -1,0 +1,71 @@
+package com.google.checkstyle.test.chapter4formatting.rule451wheretobreak;
+
+/** Some javadoc. */
+public record InputNoWrappingAfterRecordName (String name) {
+  // violation above ''(' is preceded with whitespace'
+  record Multi (String main, Record rec) { // violation ''(' is preceded with whitespace'
+    private static boolean isSent (Object obj) { // violation ''(' is preceded with whitespace'
+      int value = 0;
+      if (obj instanceof Integer i) {
+        value = i;
+      }
+      return value > 10;
+    }
+  }
+
+  record Multi2 () { // violation ''(' is preceded with whitespace'
+    Multi2 (String s1, String s2, String s3) { // violation ''(' is preceded with whitespace'
+      this (); // violation ''(' is preceded with whitespace'
+    }
+  }
+
+  record Multi3 (Integer i, Integer node) { // violation ''(' is preceded with whitespace'
+    public static void main (String... args) { // violation ''(' is preceded with whitespace'
+      System.out.println("works!");
+    }
+  }
+
+  record Multi4 () { // violation ''(' is preceded with whitespace'
+    void foo (){} // violation ''(' is preceded with whitespace'
+  }
+
+  record Multi5() {
+    private static final Multi obj =
+        new Multi ("my string", new Multi4()); // violation ''(' is preceded with whitespace'
+  }
+
+  // violation 2 lines below ''(' has incorrect indentation level 2, expected level should be 6.'
+  record Multi6
+  () {
+    // violation above ''(' should be on the previous line.'
+
+    // violation 2 lines below ''(' has incorrect indentation level 4, expected level should be 8.'
+    public static final Multi obj = new Multi
+    ("hello", new Multi4 // violation ''(' should be on the previous line.'
+    ());
+    // violation above ''(' has incorrect indentation level 4, expected level should be 8.'
+    // violation 2 lines above ''(' should be on the previous line.'
+  }
+
+  class MyTestClass {
+    private final Multi obj =
+        new Multi ("my string", new Multi4()); // violation ''(' is preceded with whitespace'
+  }
+
+  /**
+   * Maps the ports.
+   *
+   * @param from the from param
+   */
+  record Mapping (String from) { // violation ''(' is preceded with whitespace'
+
+    /**
+     * The constructor for Mapping.
+     *
+     * @param from The source
+     */
+    Mapping (String from) { // violation ''(' is preceded with whitespace'
+      this.from = from;
+    }
+  }
+}

--- a/src/it/resources/com/google/checkstyle/test/chapter4formatting/rule451wheretobreak/InputNoWrappingAfterRecordName2.java
+++ b/src/it/resources/com/google/checkstyle/test/chapter4formatting/rule451wheretobreak/InputNoWrappingAfterRecordName2.java
@@ -1,0 +1,82 @@
+package com.google.checkstyle.test.chapter4formatting.rule451wheretobreak;
+
+/** Some javadoc. */
+public class InputNoWrappingAfterRecordName2 {
+
+  @interface InSize {
+    int limit();
+  }
+
+  @InSize(limit = 2)
+  record MyRecord(String main, Record rec) {
+    private static boolean isSent(Object obj) {
+      int value = 0;
+      if (obj instanceof Integer i) {
+        value = i;
+      }
+      return value > 10;
+    }
+  }
+
+  record Multi2 () { // violation ''(' is preceded with whitespace'
+
+    @InSize(limit = 2)
+    public Multi2 (String s1, String s2, String s3) { // violation ''(' is preceded with whitespace'
+      this (); // violation ''(' is preceded with whitespace'
+    }
+  }
+
+  record Multi3 (Integer i, Integer node) { // violation ''(' is preceded with whitespace'
+    public static void main (String... args) { // violation ''(' is preceded with whitespace'
+      System.out.println("works!");
+    }
+  }
+
+  record Multi4 () { // violation ''(' is preceded with whitespace'
+
+    @InSize(limit = 2)
+    void foo (){} // violation ''(' is preceded with whitespace'
+  }
+
+  record Multi5() {
+    private static final MyRecord object =
+        new MyRecord ("my string", new Multi4()); // violation ''(' is preceded with whitespace'
+  }
+
+  // violation 2 lines below ''(' has incorrect indentation level 2, expected level should be 6.'
+  record Multi6
+  () {
+    // violation above ''(' should be on the previous line.'
+
+    // violation 2 lines below ''(' has incorrect indentation level 4, expected level should be 8.'
+    public static final MyRecord obj = new MyRecord
+    ("hello", new Multi4 // violation ''(' should be on the previous line.'
+    ());
+    // violation above ''(' has incorrect indentation level 4, expected level should be 8.'
+    // violation 2 lines above ''(' should be on the previous line.'
+  }
+
+  class MyTestClass {
+    private final MyRecord obj =
+        new MyRecord ("my string", new Multi4()); // violation ''(' is preceded with whitespace'
+  }
+
+  /**
+   * Maps the ports.
+   *
+   * @param from the from param
+   */
+  @InSize(limit = 2)
+  record Mapping (String from) { // violation ''(' is preceded with whitespace'
+
+    /**
+     * The constructor for Mapping.
+     *
+     * @param from The source
+     */
+    @InSize(limit = 3)
+    Mapping (String from) { // violation ''(' is preceded with whitespace'
+      this.from = from;
+    }
+  }
+}

--- a/src/it/resources/com/google/checkstyle/test/chapter4formatting/rule451wheretobreak/InputNoWrappingAfterRecordNameCorrect.java
+++ b/src/it/resources/com/google/checkstyle/test/chapter4formatting/rule451wheretobreak/InputNoWrappingAfterRecordNameCorrect.java
@@ -1,0 +1,38 @@
+package com.google.checkstyle.test.chapter4formatting.rule451wheretobreak;
+
+/** Some javadoc. */
+public record InputNoWrappingAfterRecordNameCorrect(String name) {
+  record Multi(String string, Record rec) {
+    private boolean inRecord(Object obj) {
+      int value = 0;
+      if (obj instanceof Integer i) {
+        value = i;
+      }
+      return value > 10;
+    }
+  }
+
+  record Multi2() {
+    Multi2(String s1, String s2, String s3) {
+      this();
+    }
+  }
+
+  record Multi3(Integer i, int node) {
+    public static void main(String... args) {
+      System.out.println("works!");
+    }
+  }
+
+  record Multi4() {
+    void foo() {}
+  }
+
+  record Multi5() {
+    public static Multi5 object = new Multi5();
+  }
+
+  class MyTestClass {
+    private final Multi obj = new Multi("my string", new Multi4());
+  }
+}


### PR DESCRIPTION
From: https://google.github.io/styleguide/javaguide.html#s4.5.1-line-wrapping-where-to-break

> A method, constructor, or record-class name stays attached to the open parenthesis (() that follows it.

record-class name is newly added to this section.
```
$ cat WrappedRecord.java
/** some javadoc. */
public class WrappedRecord {

  record Multi (String string, Record rec) { // OK 
    private boolean inRecord (Object obj) { // OK
      int value = 0;
      if (obj instanceof Integer i) {
        value = i;
      }
      return value > 10;
    }
  }

  record Multi2 () { // OK
    Multi2 (String s1, String s2, String s3) { // OK
      this();
    }
  }

  record Multi3 (Integer i, Node node) { // OK  
    public static void main (String... args) { // OK
      System.out.println("works!");
    }
  }

  record Multi4 () {  // OK
    void foo(){} 
  }

  record Multi5() {
    static Multi obj =
        new Multi ("my string", new Multi4()); // OK
  }

  class MyTestClass {
    private Multi obj =
        new Multi ("my string", new Multi4()); // OK
  }
}

$ java -jar checkstyle-10.25.0-all.jar -c google_checks.xml WrappedRecord.java 
Starting audit...
[WARN] /mnt/5D92528E6B945467/test/testing/WrappedRecord.java:4:16: '(' is preceded with whitespace. [MethodParamPad]
[WARN] /mnt/5D92528E6B945467/test/testing/WrappedRecord.java:5:30: '(' is preceded with whitespace. [MethodParamPad]
[WARN] /mnt/5D92528E6B945467/test/testing/WrappedRecord.java:14:17: '(' is preceded with whitespace. [MethodParamPad]
[WARN] /mnt/5D92528E6B945467/test/testing/WrappedRecord.java:15:12: '(' is preceded with whitespace. [MethodParamPad]
[WARN] /mnt/5D92528E6B945467/test/testing/WrappedRecord.java:20:17: '(' is preceded with whitespace. [MethodParamPad]
[WARN] /mnt/5D92528E6B945467/test/testing/WrappedRecord.java:21:29: '(' is preceded with whitespace. [MethodParamPad]
[WARN] /mnt/5D92528E6B945467/test/testing/WrappedRecord.java:26:17: '(' is preceded with whitespace. [MethodParamPad]
[WARN] /mnt/5D92528E6B945467/test/testing/WrappedRecord.java:32:19: '(' is preceded with whitespace. [MethodParamPad]
[WARN] /mnt/5D92528E6B945467/test/testing/WrappedRecord.java:37:19: '(' is preceded with whitespace. [MethodParamPad]
Audit done.
```
As seen from the CLI, we already cover this rule through MethodParamPad Check.