### PR TITLE
Junit Validation Test for example separator in xdoc files

### DIFF
--- a/src/site/xdoc/checks/annotation/packageannotation.xml
+++ b/src/site/xdoc/checks/annotation/packageannotation.xml
@@ -53,7 +53,7 @@ class Example1 {}
 package com.puppycrawl.tools.checkstyle.checks.annotation.packageannotation;
 
 class Example2 {}
-</code></pre></div><hr class="example-separator"/>
+</code></pre></div>
         <p id="package-info-code">Example of validating package-info.java:</p>
         <div class="wrapper"><pre class="prettyprint"><code class="language-java">
 @Deprecated

--- a/src/site/xdoc/checks/annotation/packageannotation.xml.template
+++ b/src/site/xdoc/checks/annotation/packageannotation.xml.template
@@ -49,7 +49,7 @@
           <param name="path"
                  value="resources/com/puppycrawl/tools/checkstyle/checks/annotation/packageannotation/Example2.java"/>
           <param name="type" value="code"/>
-        </macro><hr class="example-separator"/>
+        </macro>
         <p id="package-info-code">Example of validating package-info.java:</p>
         <macro name="example">
           <param name="path"

--- a/src/site/xdoc/checks/annotation/suppresswarningsholder.xml
+++ b/src/site/xdoc/checks/annotation/suppresswarningsholder.xml
@@ -122,7 +122,7 @@ class Example2 {
   }
 
 }
-</code></pre></div>
+</code></pre></div><hr class="example-separator"/>
         <p id="Example3-config">
           You can also use simple check name like <code>ParameterNumberCheck=paramnum</code>
           instead to use fully qualified name of check in the <code>aliasList</code>:
@@ -154,7 +154,7 @@ public class Example3 {
   }
 
 }
-</code></pre></div>
+</code></pre></div><hr class="example-separator"/>
         <p id="Example4-config">
           The check can also be used without suffix of &quot;Check&quot; like
           <code>ParameterNumber=paramnum</code> in the <code>aliasList</code>:

--- a/src/site/xdoc/checks/annotation/suppresswarningsholder.xml.template
+++ b/src/site/xdoc/checks/annotation/suppresswarningsholder.xml.template
@@ -66,7 +66,7 @@
           <param name="path"
                  value="resources/com/puppycrawl/tools/checkstyle/checks/annotation/suppresswarningsholder/Example2.java"/>
           <param name="type" value="code"/>
-        </macro>
+        </macro><hr class="example-separator"/>
         <p id="Example3-config">
           You can also use simple check name like <code>ParameterNumberCheck=paramnum</code>
           instead to use fully qualified name of check in the <code>aliasList</code>:
@@ -81,7 +81,7 @@
           <param name="path"
                  value="resources/com/puppycrawl/tools/checkstyle/checks/annotation/suppresswarningsholder/Example3.java"/>
           <param name="type" value="code"/>
-        </macro>
+        </macro><hr class="example-separator"/>
         <p id="Example4-config">
           The check can also be used without suffix of &quot;Check&quot; like
           <code>ParameterNumber=paramnum</code> in the <code>aliasList</code>:

--- a/src/site/xdoc/checks/coding/innerassignment.xml
+++ b/src/site/xdoc/checks/coding/innerassignment.xml
@@ -99,7 +99,7 @@ public class Example1 {
     return val = true; // violation, 'Inner assignments should be avoided'
   }
 }
-</code></pre></div>
+</code></pre></div><hr class="example-separator"/>
         <p id="Example2-code">Example 2:</p>
         <div class="wrapper"><pre class="prettyprint"><code class="language-java">
 public class Example2 {

--- a/src/site/xdoc/checks/coding/innerassignment.xml.template
+++ b/src/site/xdoc/checks/coding/innerassignment.xml.template
@@ -61,7 +61,7 @@ while ((line = bufferedReader.readLine()) != null); // OK
           <param name="path"
                  value="resources/com/puppycrawl/tools/checkstyle/checks/coding/innerassignment/Example1.java"/>
           <param name="type" value="code"/>
-        </macro>
+        </macro><hr class="example-separator"/>
         <p id="Example2-code">Example 2:</p>
         <macro name="example">
           <param name="path"

--- a/src/site/xdoc/checks/coding/requirethis.xml
+++ b/src/site/xdoc/checks/coding/requirethis.xml
@@ -217,7 +217,7 @@ class Example3 {
     field3 = field3;
   }
 }
-</code></pre></div>
+</code></pre></div><hr class="example-separator"/>
 
         <p>
           Please, be aware of the following logic, which is implemented in the check:
@@ -240,7 +240,7 @@ class Example5 {
     field2 *= field1;
   }
 }
-</code></pre></div>
+</code></pre></div><hr class="example-separator"/>
         <p id="Example6-code">
           2) If method parameter is returned from the method, the check will not raise violation for
              returned variable/parameter, for example:

--- a/src/site/xdoc/checks/coding/requirethis.xml.template
+++ b/src/site/xdoc/checks/coding/requirethis.xml.template
@@ -115,7 +115,7 @@
           <param name="path"
                  value="resources/com/puppycrawl/tools/checkstyle/checks/coding/requirethis/Example3.java"/>
           <param name="type" value="code"/>
-        </macro>
+        </macro><hr class="example-separator"/>
 
         <p>
           Please, be aware of the following logic, which is implemented in the check:
@@ -128,7 +128,7 @@
           <param name="path"
                  value="resources/com/puppycrawl/tools/checkstyle/checks/coding/requirethis/Example5.java"/>
           <param name="type" value="code"/>
-        </macro>
+        </macro><hr class="example-separator"/>
         <p id="Example6-code">
           2) If method parameter is returned from the method, the check will not raise violation for
              returned variable/parameter, for example:

--- a/src/site/xdoc/checks/imports/customimportorder.xml
+++ b/src/site/xdoc/checks/imports/customimportorder.xml
@@ -625,7 +625,7 @@ import java.awt.Dialog;
 import java.awt.Window;
 import java.awt.color.ColorSpace;
 import java.awt.Frame; // violation, in ASCII order all uppercase comes before lowercase letters
-</code></pre></div>
+</code></pre></div><hr class="example-separator"/>
         <p id="Example15-code">
           To force checking imports sequence such as:
         </p>
@@ -642,7 +642,7 @@ import static java.util.Collections.emptyList;
 import com.google.common.annotations.GwtCompatible; // violation, 'wrong order'
 
 import java.lang.String;
-</code></pre></div><hr class="example-separator"/>
+</code></pre></div>
         <p id="Example15-config">
           configure as follows:
         </p>

--- a/src/site/xdoc/checks/imports/customimportorder.xml.template
+++ b/src/site/xdoc/checks/imports/customimportorder.xml.template
@@ -393,7 +393,7 @@ import com.puppycrawl.tools.checkstyle.checks.imports.AvoidStarImportCheck;
           <param name="path"
                  value="resources/com/puppycrawl/tools/checkstyle/checks/imports/customimportorder/Example14.java"/>
           <param name="type" value="code"/>
-        </macro>
+        </macro><hr class="example-separator"/>
         <p id="Example15-code">
           To force checking imports sequence such as:
         </p>
@@ -401,7 +401,7 @@ import com.puppycrawl.tools.checkstyle.checks.imports.AvoidStarImportCheck;
           <param name="path"
                  value="resources/com/puppycrawl/tools/checkstyle/checks/imports/customimportorder/Example15.java"/>
           <param name="type" value="code"/>
-        </macro><hr class="example-separator"/>
+        </macro>
         <p id="Example15-config">
           configure as follows:
         </p>

--- a/src/site/xdoc/checks/javadoc/javadocleadingasteriskalign.xml
+++ b/src/site/xdoc/checks/javadoc/javadocleadingasteriskalign.xml
@@ -100,7 +100,7 @@ public class Example1 {
     TWO
   }
 }
-</code></pre></div>
+</code></pre></div><hr class="example-separator"/>
 
         <p id="Example2-code">
           Example with incorrect alignment:

--- a/src/site/xdoc/checks/javadoc/javadocleadingasteriskalign.xml.template
+++ b/src/site/xdoc/checks/javadoc/javadocleadingasteriskalign.xml.template
@@ -52,7 +52,7 @@
           <param name="path"
                  value="resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadocleadingasteriskalign/Example1.java"/>
           <param name="type" value="code"/>
-        </macro>
+        </macro><hr class="example-separator"/>
 
         <p id="Example2-code">
           Example with incorrect alignment:

--- a/src/site/xdoc/checks/javadoc/javadocpackage.xml
+++ b/src/site/xdoc/checks/javadoc/javadocpackage.xml
@@ -70,7 +70,7 @@
 package com.puppycrawl.tools.checkstyle.checks.javadoc.javadocpackage.nonlegacy;
 /* violation on first line 'Missing package-info.java file' */
 public class Example1 { }
-</code></pre></div>
+</code></pre></div><hr class="example-separator"/>
 
         <p id="Example2-config">
           To configure the check with allowlegacy set to true:
@@ -95,7 +95,7 @@ public class Example1 { }
 package com.puppycrawl.tools.checkstyle.checks.javadoc.javadocpackage.legacy;
 // ok as package.html file is present in directory
 public class Example2 { }
-</code></pre></div>
+</code></pre></div><hr class="example-separator"/>
 
         <p id="Example3-config">
           To configure the check with allowlegacy set to true:

--- a/src/site/xdoc/checks/javadoc/javadocpackage.xml.template
+++ b/src/site/xdoc/checks/javadoc/javadocpackage.xml.template
@@ -51,7 +51,7 @@
           <param name="path"
                  value="resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadocpackage/nonlegacy/Example1.java"/>
           <param name="type" value="code"/>
-        </macro>
+        </macro><hr class="example-separator"/>
 
         <p id="Example2-config">
           To configure the check with allowlegacy set to true:
@@ -74,7 +74,7 @@
           <param name="path"
                  value="resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadocpackage/legacy/Example2.java"/>
           <param name="type" value="code"/>
-        </macro>
+        </macro><hr class="example-separator"/>
 
         <p id="Example3-config">
           To configure the check with allowlegacy set to true:

--- a/src/site/xdoc/checks/javadoc/javadocvariable.xml
+++ b/src/site/xdoc/checks/javadoc/javadocvariable.xml
@@ -211,7 +211,7 @@ public class Example4 {
     CONSTANT // violation, 'Missing a Javadoc comment'
   }
 }
-</code></pre></div>
+</code></pre></div><hr class="example-separator"/>
 
         <p id="Example5-code">
           This check will not report a violation for local and

--- a/src/site/xdoc/checks/javadoc/javadocvariable.xml.template
+++ b/src/site/xdoc/checks/javadoc/javadocvariable.xml.template
@@ -99,7 +99,7 @@
           <param name="path"
                  value="resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadocvariable/Example4.java"/>
           <param name="type" value="code"/>
-        </macro>
+        </macro><hr class="example-separator"/>
 
         <p id="Example5-code">
           This check will not report a violation for local and

--- a/src/site/xdoc/checks/metrics/classdataabstractioncoupling.xml
+++ b/src/site/xdoc/checks/metrics/classdataabstractioncoupling.xml
@@ -328,7 +328,7 @@ public class Example8 {
     &lt;/module&gt;
   &lt;/module&gt;
 &lt;/module&gt;
-</code></pre></div><hr class="example-separator"/>
+</code></pre></div>
 
         <p>
           Example:
@@ -425,7 +425,7 @@ class Example10 {
           Also note, that <code>excludedPackages</code> will not exclude classes, imported via
           wildcard (e.g. <code>import java.math.*</code>). Instead of wildcard import you should
           use direct import (e.g. <code>import java.math.BigDecimal</code>).
-        </p>
+        </p> <hr class="example-separator"/>
         <p id="Example11-config">
           Also note, that checkstyle will not exclude classes within the same file
           even if it was listed in the <code>excludedPackages</code> parameter. For example,

--- a/src/site/xdoc/checks/metrics/classdataabstractioncoupling.xml.template
+++ b/src/site/xdoc/checks/metrics/classdataabstractioncoupling.xml.template
@@ -209,7 +209,7 @@
           <param name="path"
                  value="resources/com/puppycrawl/tools/checkstyle/checks/metrics/classdataabstractioncoupling/ignore/Example9.java"/>
           <param name="type" value="config"/>
-        </macro><hr class="example-separator"/>
+        </macro>
 
         <p>
           Example:
@@ -257,7 +257,7 @@
           Also note, that <code>excludedPackages</code> will not exclude classes, imported via
           wildcard (e.g. <code>import java.math.*</code>). Instead of wildcard import you should
           use direct import (e.g. <code>import java.math.BigDecimal</code>).
-        </p>
+        </p> <hr class="example-separator"/>
         <p id="Example11-config">
           Also note, that checkstyle will not exclude classes within the same file
           even if it was listed in the <code>excludedPackages</code> parameter. For example,

--- a/src/test/java/com/puppycrawl/tools/checkstyle/internal/XdocsPagesTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/internal/XdocsPagesTest.java
@@ -19,6 +19,7 @@
 
 package com.puppycrawl.tools.checkstyle.internal;
 
+import static com.google.common.collect.ImmutableList.toImmutableList;
 import static com.google.common.truth.Truth.assertWithMessage;
 import static java.lang.Integer.parseInt;
 
@@ -55,11 +56,15 @@ import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 import java.util.stream.Stream;
 
+import javax.xml.parsers.DocumentBuilder;
+import javax.xml.parsers.DocumentBuilderFactory;
+
 import org.apache.commons.beanutils.PropertyUtils;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 import org.w3c.dom.Document;
+import org.w3c.dom.Element;
 import org.w3c.dom.Node;
 import org.w3c.dom.NodeList;
 import org.xml.sax.InputSource;
@@ -2246,5 +2251,85 @@ public class XdocsPagesTest {
             precedingNode = precedingNode.getPreviousSibling();
         }
         return precedingNode;
+    }
+
+    @Test
+    public void validateExampleSectionSeparation() throws Exception {
+        final List<Path> templates = collectAllXmlTemplatesUnderSrcSite();
+
+        for (final Path template : templates) {
+            final Document doc = parseXmlToDomDocument(template);
+            final NodeList subsectionList = doc.getElementsByTagName("subsection");
+
+            for (int index = 0; index < subsectionList.getLength(); index++) {
+                final Element subsection = (Element) subsectionList.item(index);
+                if (!"Examples".equals(subsection.getAttribute("name"))) {
+                    continue;
+                }
+
+                final NodeList children = subsection.getChildNodes();
+                String lastExampleIdPrefix = null;
+                boolean separatorSeen = false;
+
+                for (int childIndex = 0; childIndex < children.getLength(); childIndex++) {
+                    final Node child = children.item(childIndex);
+                    if (child.getNodeType() != Node.ELEMENT_NODE) {
+                        continue;
+                    }
+
+                    final Element element = (Element) child;
+                    if ("hr".equals(element.getTagName())
+                            && "example-separator".equals(element.getAttribute("class"))) {
+                        separatorSeen = true;
+                        continue;
+                    }
+
+                    final String currentId = element.getAttribute("id");
+                    if (currentId != null && currentId.startsWith("Example")) {
+                        final String currentExPrefix = getExamplePrefix(currentId);
+                        if (lastExampleIdPrefix != null
+                                && !lastExampleIdPrefix.equals(currentExPrefix)) {
+                            assertWithMessage("Missing <hr class=\"example-separator\"/> "
+                                    + "between " + lastExampleIdPrefix + " and " + currentExPrefix
+                                    + " in file: " + template)
+                                    .that(separatorSeen)
+                                    .isTrue();
+                            separatorSeen = false;
+                        }
+                        lastExampleIdPrefix = currentExPrefix;
+                    }
+                }
+            }
+        }
+    }
+
+    private static List<Path> collectAllXmlTemplatesUnderSrcSite() throws IOException {
+        final Path root = Paths.get("src/site/xdoc");
+        try (Stream<Path> walk = Files.walk(root)) {
+            return walk
+                    .filter(path -> path.getFileName().toString().endsWith(".xml.template"))
+                    .collect(toImmutableList());
+        }
+    }
+
+    private static Document parseXmlToDomDocument(Path template) throws Exception {
+        final DocumentBuilderFactory dbFactory = DocumentBuilderFactory.newInstance();
+        dbFactory.setNamespaceAware(true);
+        final DocumentBuilder dBuilder = dbFactory.newDocumentBuilder();
+        final Document doc = dBuilder.parse(template.toFile());
+        doc.getDocumentElement().normalize();
+        return doc;
+    }
+
+    private static String getExamplePrefix(String id) {
+        final int dash = id.indexOf('-');
+        final String result;
+        if (dash == -1) {
+            result = id;
+        }
+        else {
+            result = id.substring(0, dash);
+        }
+        return result;
     }
 }


### PR DESCRIPTION
#17186 

This PR adds a test `validateExampleSectionSeparation()` to validate the structure of Examples subsections within XDoc .xml.template files.

The test ensures that:
Each transition between distinct example groups (e.g., Example1 → Example2) is separated by an `<hr class="example-separator"/>` tag.
The test: 
- Parses each .xml.template as a DOM document.
- Finds all <subsection name="Examples"> blocks.
- Iterates over their child elements.
- Tracks the current example prefix (from id attributes like `Example1-desc` or` Example2-code`).
- On detecting a change in prefix (i.e., a new example block), asserts that an `<hr>` was seen since the last example group.
- Fails if a transition occurs without the required separator.

![image](https://github.com/user-attachments/assets/331fb12f-de42-4061-8e71-693ccabf7c76)
Result of assertion.

Also added `hr` separator to the files that gave error after adding test.