### PR TITLE
Issue #17168: Migrating CI to JDK17 - no-exception-samples-ant

### DIFF
--- a/.ci/no-exception-test.sh
+++ b/.ci/no-exception-test.sh
@@ -234,6 +234,18 @@ no-exception-samples-ant)
     `"s|name=\"checkstyle\" rev=\".*\""`
     `"|name=\"checkstyle\" rev=\"$CS_POM_VERSION\"|g" ivy.xml
 
+  # Resolve certificate directory conflict
+  sudo rm -rf /etc/ssl/certs/java
+  sudo mkdir -p /etc/ssl/certs/java
+  sudo apt-get update -y
+
+  sudo apt-get install -y --reinstall --allow-downgrades --fix-broken \
+       ca-certificates-java openjdk-17-jre-headless
+
+  sudo update-ca-certificates -f
+
+  sudo apt-get install -y ant
+
   ant checkstyle
 
   cd ../..

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -243,7 +243,7 @@ workflows:
 
       - validate-with-maven-script:
           name: "no-exception-samples-ant"
-          image-name: "circleci/openjdk:11-jdk"
+          image-name: "cimg/openjdk:17.0.7"
           command: "./.ci/no-exception-test.sh no-exception-samples-ant"
       - validate-with-maven-script:
           name: "no-error-hazelcast"


### PR DESCRIPTION
Part of : #17168

When I used cimg/17.0.7 ant was not installed by default : https://app.circleci.com/pipelines/github/checkstyle/checkstyle/34458/workflows/d527afa1-538f-431e-b630-9115bc073fa6/jobs/970268

https://app.circleci.com/pipelines/github/checkstyle/checkstyle/34459/workflows/cbaaf5cd-748f-4d83-97c9-b670c8f041de/jobs/970313/parallel-runs/0/steps/0-103

```
Setting up ant (1.10.12-1) ...
Setting up ca-certificates-java (20190909ubuntu1.2) ...
cp: -r not specified; omitting directory '/etc/ssl/certs/java/cacerts'
dpkg: error processing package ca-certificates-java (--configure):
 installed ca-certificates-java package post-installation script subprocess returned error exit status 1
Setting up ant-optional (1.10.12-1) ...
Processing triggers for ca-certificates (20211016ubuntu0.22.04.1) ...
Updating certificates in /etc/ssl/certs...
0 added, 0 removed; done.
Running hooks in /etc/ca-certificates/update.d...

Exception in thread "main" java.io.FileNotFoundException: /etc/ssl/certs/java/cacerts (Is a directory)
	at java.base/java.io.FileInputStream.open0(Native Method)
	at java.base/java.io.FileInputStream.open(FileInputStream.java:219)
	at java.base/java.io.FileInputStream.<init>(FileInputStream.java:157)
	at org.debian.security.KeyStoreHandler.load(KeyStoreHandler.java:63)
	at org.debian.security.KeyStoreHandler.<init>(KeyStoreHandler.java:52)
	at org.debian.security.UpdateCertificates.<init>(UpdateCertificates.java:65)
	at org.debian.security.UpdateCertificates.main(UpdateCertificates.java:51)
E: /etc/ca-certificates/update.d/jks-keystore exited with code 1.
done.
Processing triggers for libc-bin (2.35-0ubuntu3.1) ...
Errors were encountered while processing:
 ca-certificates-java
E: Sub-process /usr/bin/dpkg returned an error code (1)
```