### PR TITLE
supplemental: adding inputs for 4.6.2 single whitespace around `->`

### DIFF
--- a/src/it/java/com/google/checkstyle/test/chapter4formatting/rule462horizontalwhitespace/HorizontalWhitespaceTest.java
+++ b/src/it/java/com/google/checkstyle/test/chapter4formatting/rule462horizontalwhitespace/HorizontalWhitespaceTest.java
@@ -169,4 +169,9 @@ public class HorizontalWhitespaceTest extends AbstractGoogleModuleTestSupport {
     public void testWhitespaceAroundWhenFormatted() throws Exception {
         verifyWithWholeConfig(getNonCompilablePath("InputFormattedWhitespaceAroundWhen.java"));
     }
+
+    @Test
+    public void testWhitespaceAroundArrow() throws Exception {
+        verifyWithWholeConfig(getNonCompilablePath("InputWhitespaceAroundArrow.java"));
+    }
 }

--- a/src/it/resources-noncompilable/com/google/checkstyle/test/chapter4formatting/rule462horizontalwhitespace/InputWhitespaceAroundArrow.java
+++ b/src/it/resources-noncompilable/com/google/checkstyle/test/chapter4formatting/rule462horizontalwhitespace/InputWhitespaceAroundArrow.java
@@ -1,0 +1,100 @@
+package com.google.checkstyle.test.chapter4formatting.rule462horizontalwhitespace;
+
+/** some javadoc. */
+public class InputWhitespaceAroundArrow {
+
+  static { 
+    // violation below ''->' is not preceded with whitespace.'
+    new JCheckBox().addActionListener((final ActionEvent e)-> {
+      good();
+    });
+  }
+
+  void foo1(Object o) {
+    switch (o) {
+      case String s when (s.equals("a")) -> {}
+      case 'p' -> {
+      }
+      default -> {}
+    }
+  }
+
+  /** method. */
+  void test(Object o) {
+    switch (o) {
+      case String s when (
+          s.equals("a"))-> // violation ''->' is not preceded with whitespace.'
+        {
+        }
+      case Point(int x, int y) when !(x >= 0 && y >= 0) -> {}
+      default-> // violation ''->' is not preceded with whitespace.'
+        {}
+    }
+
+    int x = switch (o) {
+      case String s -> {
+        switch (o2) {
+          case Integer newInt-> { // violation ''->' is not preceded with whitespace.'
+            if (y == 0) {
+              System.out.println(0);
+            }
+          }
+          default -> {}
+        }
+        yield 3;
+      }
+      default -> 3;
+    };
+  }
+
+  int test2() {
+    Predicate predicate = value ->(value != null);
+    // 2 violations above:
+    //     ''->' is not followed by whitespace.'
+    //     'WhitespaceAround: '->' is not followed by whitespace. .*'
+
+    Object b = ((VoidPredicate) ()->o1 instanceof String s).get();
+    // 3 violations above:
+    //     ''->' is not followed by whitespace.'
+    //     'WhitespaceAround: '->' is not followed by whitespace. .*'
+    //     'WhitespaceAround: '->' is not preceded with whitespace.'
+
+    List<Integer> ints = new LinkedList<Integer>();
+    // 3 violations 5 lines below:
+    //     ''->' is not followed by whitespace.'
+    //     ''->' is not followed by whitespace. .*'
+    //     ''{' is not preceded with whitespace.'
+    ints.stream()
+        .map(t ->{
+            return t * 2;
+          }
+        )
+        .filter(t -> {
+          return false;
+        });
+  }
+
+  void test3() {
+    ArrayList<Boolean> boolList
+        = new ArrayList<Boolean>(Arrays.asList(false, true, false, false));
+    // violation 2 lines below 'WhitespaceAround: '->' is not preceded with whitespace.'
+    List<Boolean> filtered = boolList.stream()
+        .filter(statement-> {
+          if (!statement) {
+            return true;
+          } else {
+            return false;
+          }
+        })
+        .collect(Collectors.toList());
+
+    result = boolList.stream().filter(
+        // violation below 'WhitespaceAround: '->' is not preceded with whitespace.'
+        statement-> someFunction())
+        .findFirst()
+        .orElseThrow(() ->new IllegalStateException("big problem"));
+    // 2 violations above:
+    //     ''->' is not followed by whitespace.'
+    //     'WhitespaceAround: '->' is not followed by whitespace. .*'
+  }
+}

--- a/src/it/resources-noncompilable/com/google/checkstyle/test/chapter4formatting/rule462horizontalwhitespace/InputWhitespaceAroundArrowCorrect.java
+++ b/src/it/resources-noncompilable/com/google/checkstyle/test/chapter4formatting/rule462horizontalwhitespace/InputWhitespaceAroundArrowCorrect.java
@@ -1,0 +1,85 @@
+package com.google.checkstyle.test.chapter4formatting.rule462horizontalwhitespace;
+
+/** some javadoc. */
+public class InputWhitespaceAroundArrowCorrect {
+
+  static {
+    new JCheckBox().addActionListener((final ActionEvent e) -> {
+      good();
+    });
+  }
+
+  void foo1(Object o) {
+    switch (o) {
+      case String s when (s.equals("a")) -> {}
+      case 'p' -> {
+      }
+      default -> {}
+    }
+  }
+
+  /** method. */
+  void test(Object o) {
+    switch (o) {
+      case String s when (
+          s.equals("a")) ->
+        {
+        }
+      case Point(int x, int y) when !(x >= 0 && y >= 0) -> {}
+      default ->
+        {}
+    }
+
+    int x = switch (o) {
+      case String s -> {
+        switch (o2) {
+          case Integer newInt -> {
+            if (y == 0) {
+              System.out.println(0);
+            }
+          }
+          default -> {}
+        }
+        yield 3;
+      }
+      default -> 3;
+    };
+  }
+
+  int test2() {
+    Predicate predicate = value -> (value != null);
+
+    Object b = ((VoidPredicate) () -> o1 instanceof String s).get();
+
+    List<Integer> ints = new LinkedList<Integer>();
+
+    ints.stream()
+        .map(t -> {
+            return t * 2;
+          }
+        )
+        .filter(t -> {
+          return false;
+        });
+  }
+
+  void test3() {
+    ArrayList<Boolean> boolList
+        = new ArrayList<Boolean>(Arrays.asList(false, true, false, false));
+
+    List<Boolean> filtered = boolList.stream()
+        .filter(statement -> {
+          if (!statement) {
+            return true;
+          } else {
+            return false;
+          }
+        })
+        .collect(Collectors.toList());
+
+    result = boolList.stream().filter(
+        statement -> someFunction())
+        .findFirst()
+        .orElseThrow(() -> new IllegalStateException("big problem"));
+  }
+}


### PR DESCRIPTION
From: https://google.github.io/styleguide/javaguide.html#s4.6.2-horizontal-whitespace
>the arrow in a lambda expression: (String str) -> str.length()
or switch rule: case "FOO" -> bar();