### PR TITLE
Issue #17225: Added new data to javadoc of module to extract true version of its properties

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/annotation/MissingDeprecatedCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/annotation/MissingDeprecatedCheck.java
@@ -78,6 +78,7 @@ import com.puppycrawl.tools.checkstyle.utils.TokenUtil;
  * Tight-HTML Rules</a>.
  * Type is {@code boolean}.
  * Default value is {@code false}.
+ * Since version 8.24
  * </li>
  * </ul>
  *

--- a/src/main/java/com/puppycrawl/tools/checkstyle/site/SiteUtil.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/site/SiteUtil.java
@@ -103,6 +103,8 @@ public final class SiteUtil {
     /** The path to the JavadocTokenTypes.html file. */
     public static final String PATH_TO_JAVADOC_TOKEN_TYPES =
             "apidocs/com/puppycrawl/tools/checkstyle/api/JavadocTokenTypes.html";
+    /** The string of JavaDoc module marking 'Since version'. */
+    public static final String SINCE_VERSION = "Since version";
     /** The url of the checkstyle website. */
     private static final String CHECKSTYLE_ORG_URL = "https://checkstyle.org/";
     /** The string 'charset'. */
@@ -117,6 +119,8 @@ public final class SiteUtil {
     private static final String NAMING = "naming";
     /** The string 'src'. */
     private static final String SRC = "src";
+    /** The whitespace. */
+    private static final String WHITESPACE = " ";
 
     /** Precompiled regex pattern to remove the "Setter to " prefix from strings. */
     private static final Pattern SETTER_PATTERN = Pattern.compile("^Setter to ");
@@ -209,7 +213,6 @@ public final class SiteUtil {
      * @noinspectionreason JavacQuirks until #14052
      */
     private static final Map<String, String> SINCE_VERSION_FOR_INHERITED_PROPERTY = Map.ofEntries(
-        Map.entry("MissingDeprecatedCheck.violateExecutionOnNonTightHtml", VERSION_8_24),
         Map.entry("ClassDataAbstractionCouplingCheck.excludeClassesRegexps", VERSION_7_7),
         Map.entry("ClassDataAbstractionCouplingCheck.excludedClasses", VERSION_5_7),
         Map.entry("ClassDataAbstractionCouplingCheck.excludedPackages", VERSION_7_7),
@@ -401,7 +404,7 @@ public final class SiteUtil {
      * @return the constructed string.
      */
     public static String getNewlineAndIndentSpaces(int amountOfSpaces) {
-        return System.lineSeparator() + " ".repeat(amountOfSpaces);
+        return System.lineSeparator() + WHITESPACE.repeat(amountOfSpaces);
     }
 
     /**
@@ -770,9 +773,14 @@ public final class SiteUtil {
 
         final String hardCodedPropertyVersion = SINCE_VERSION_FOR_INHERITED_PROPERTY.get(
             moduleName + DOT + propertyName);
+        final Optional<String> specifiedPropertyVersion =
+            getSpecifiedPropertyVersion(propertyName, moduleJavadoc);
 
         if (hardCodedPropertyVersion != null) {
             sinceVersion = hardCodedPropertyVersion;
+        }
+        else if (specifiedPropertyVersion.isPresent()) {
+            sinceVersion = specifiedPropertyVersion.get();
         }
         else {
             final String moduleSince = getSinceVersionFromJavadoc(moduleJavadoc);
@@ -796,6 +804,114 @@ public final class SiteUtil {
         }
 
         return sinceVersion;
+    }
+
+    /**
+     * Gets the specifically indicated version of module's property from the javadoc of module.
+     *
+     * @param propertyName the name of property.
+     * @param moduleJavadoc the javadoc of module.
+     * @return the specific since version of module's property.
+     * @throws MacroExecutionException if the module since version could not be extracted.
+     */
+    private static Optional<String> getSpecifiedPropertyVersion(String propertyName,
+                                                      DetailNode moduleJavadoc)
+            throws MacroExecutionException {
+        Optional<String> specifiedVersion = Optional.empty();
+
+        final Optional<DetailNode> propertyModuleJavadoc =
+            getPropertyJavadocNodeInModule(propertyName, moduleJavadoc);
+
+        if (propertyModuleJavadoc.isPresent()) {
+            final DetailNode primaryJavadocInlineTag = JavadocUtil.findFirstToken(
+                propertyModuleJavadoc.get(), JavadocTokenTypes.JAVADOC_INLINE_TAG);
+
+            for (DetailNode textNode = JavadocUtil
+                .getNextSibling(primaryJavadocInlineTag, JavadocTokenTypes.TEXT);
+                 textNode != null && specifiedVersion.isEmpty();
+                 textNode = JavadocUtil.getNextSibling(
+                     textNode, JavadocTokenTypes.TEXT)) {
+
+                final String textNodeText = textNode.getText();
+
+                if (textNodeText.startsWith(WHITESPACE + SINCE_VERSION)) {
+                    final int sinceVersionIndex = textNodeText.indexOf('.') - 1;
+
+                    if (sinceVersionIndex > 0) {
+                        specifiedVersion = Optional.of(textNodeText.substring(sinceVersionIndex));
+                    }
+                    else {
+                        throw new MacroExecutionException(textNodeText
+                            + " has no valid version, at least one '.' is expected.");
+                    }
+
+                }
+            }
+        }
+
+        return specifiedVersion;
+    }
+
+    /**
+     * Gets the javadoc node part of the property from the javadoc of the module.
+     *
+     * @param propertyName the name of property.
+     * @param moduleJavadoc the javadoc of module.
+     * @return the Optional of javadoc node part of the property.
+     */
+    private static Optional<DetailNode> getPropertyJavadocNodeInModule(String propertyName,
+                                                             DetailNode moduleJavadoc) {
+        Optional<DetailNode> propertyJavadocNode = Optional.empty();
+
+        for (DetailNode htmlElement = JavadocUtil.getNextSibling(
+                JavadocUtil.getFirstChild(moduleJavadoc), JavadocTokenTypes.HTML_ELEMENT);
+            htmlElement != null && propertyJavadocNode.isEmpty();
+            htmlElement = JavadocUtil.getNextSibling(
+                htmlElement, JavadocTokenTypes.HTML_ELEMENT)) {
+
+            final DetailNode htmlTag = JavadocUtil.findFirstToken(
+                htmlElement, JavadocTokenTypes.HTML_TAG);
+            final Optional<String> htmlTagName = Optional.ofNullable(htmlTag)
+                .map(JavadocUtil::getFirstChild)
+                .map(htmlStart -> {
+                    return JavadocUtil.findFirstToken(htmlStart, JavadocTokenTypes.HTML_TAG_NAME);
+                })
+                .map(DetailNode::getText);
+
+            if (htmlTag != null && "ul".equals(htmlTagName.orElse(null))) {
+
+                boolean foundProperty = false;
+
+                for (DetailNode innerHtmlElement = JavadocUtil.getNextSibling(
+                        JavadocUtil.getFirstChild(htmlTag), JavadocTokenTypes.HTML_ELEMENT);
+                    innerHtmlElement != null && !foundProperty;
+                    innerHtmlElement = JavadocUtil.getNextSibling(
+                        innerHtmlElement, JavadocTokenTypes.HTML_ELEMENT)) {
+
+                    final DetailNode liTag = JavadocUtil.getFirstChild(innerHtmlElement);
+
+                    if (liTag.getType() == JavadocTokenTypes.LI) {
+
+                        final DetailNode primeJavadocInlineTag = JavadocUtil.findFirstToken(liTag,
+                            JavadocTokenTypes.JAVADOC_INLINE_TAG);
+
+                        if (primeJavadocInlineTag == null) {
+                            break;
+                        }
+
+                        final String examinedPropertyName = JavadocUtil.findFirstToken(
+                            primeJavadocInlineTag, JavadocTokenTypes.TEXT).getText();
+
+                        if (examinedPropertyName.equals(propertyName)) {
+                            propertyJavadocNode = Optional.ofNullable(liTag);
+                            foundProperty = true;
+                        }
+                    }
+                }
+            }
+        }
+
+        return propertyJavadocNode;
     }
 
     /**

--- a/src/test/java/com/puppycrawl/tools/checkstyle/internal/XdocsJavaDocsTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/internal/XdocsJavaDocsTest.java
@@ -20,6 +20,7 @@
 package com.puppycrawl.tools.checkstyle.internal;
 
 import static com.google.common.truth.Truth.assertWithMessage;
+import static com.puppycrawl.tools.checkstyle.site.SiteUtil.SINCE_VERSION;
 
 import java.io.File;
 import java.net.URI;
@@ -700,11 +701,17 @@ public class XdocsJavaDocsTest extends AbstractModuleTestSupport {
         }
 
         private static String getJavaDocText(DetailAST node) {
-            final String text = "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<document>\n"
+            String text = "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<document>\n"
                     + node.getFirstChild().getText().replaceAll("(^|\\r?\\n)\\s*\\* ?", "\n")
                             .replaceAll("\\n?@noinspection.*\\r?\\n[^@]*", "\n")
                             .trim() + "\n</document>";
             String result = null;
+
+            // until https://github.com/checkstyle/checkstyle/issues/17251
+            if (text.contains("\n" + SINCE_VERSION)) {
+                final String sinceVersionLine = "\n" + SINCE_VERSION + " .*";
+                text = text.replaceAll(sinceVersionLine, "");
+            }
 
             try {
                 result = getNodeText(XmlUtil.getRawXml(checkName, text, text).getFirstChild())


### PR DESCRIPTION
Issue: #17225

https://github.com/checkstyle/checkstyle/blob/97fae48600dc7650b69e0c5088ea25c6be791713/src/main/java/com/puppycrawl/tools/checkstyle/checks/annotation/MissingDeprecatedCheck.java#L36

Example AST tree of MissingDeprecated check's module javadoc
```
JAVADOC -> JAVADOC [0:0]
|--NEWLINE -> \r\n [0:0]
|--NEWLINE -> \r\n [1:0]
|--NEWLINE -> \r\n [2:0]
|--NEWLINE -> \r\n [3:0]
|--NEWLINE -> \r\n [4:0]
|--NEWLINE -> \r\n [5:0]
|--NEWLINE -> \r\n [6:0]
|--NEWLINE -> \r\n [7:0]
|--NEWLINE -> \r\n [8:0]
|--NEWLINE -> \r\n [9:0]
|--NEWLINE -> \r\n [10:0]
|--NEWLINE -> \r\n [11:0]
|--NEWLINE -> \r\n [12:0]
|--NEWLINE -> \r\n [13:0]
|--NEWLINE -> \r\n [14:0]
|--NEWLINE -> \r\n [15:0]
|--NEWLINE -> \r\n [16:0]
|--NEWLINE -> \r\n [17:0]
|--NEWLINE -> \r\n [18:0]
|--NEWLINE -> \r\n [19:0]
|--NEWLINE -> \r\n [20:0]
|--NEWLINE -> \r\n [21:0]
|--NEWLINE -> \r\n [22:0]
|--NEWLINE -> \r\n [23:0]
|--NEWLINE -> \r\n [24:0]
|--NEWLINE -> \r\n [25:0]
|--NEWLINE -> \r\n [26:0]
|--NEWLINE -> \r\n [27:0]
|--NEWLINE -> \r\n [28:0]
|--NEWLINE -> \r\n [29:0]
|--NEWLINE -> \r\n [30:0]
|--NEWLINE -> \r\n [31:0]
|--NEWLINE -> \r\n [32:0]
|--TEXT -> /** [33:0]
|--NEWLINE -> \r\n [33:3]
|--LEADING_ASTERISK ->  * [34:0]
|--TEXT ->   [34:2]
|--HTML_ELEMENT -> HTML_ELEMENT [34:3]
|   `--HTML_TAG -> HTML_TAG [34:3]
|       |--HTML_ELEMENT_START -> HTML_ELEMENT_START [34:3]
|       |   |--START -> < [34:3]
|       |   |--HTML_TAG_NAME -> div [34:4]
|       |   `--END -> > [34:7]
|       |--NEWLINE -> \r\n [34:8]
|       |--LEADING_ASTERISK ->  * [35:0]
|       |--TEXT ->  Verifies that the annotation  [35:2]
|       |--JAVADOC_INLINE_TAG -> JAVADOC_INLINE_TAG [35:32]
|       |   |--JAVADOC_INLINE_TAG_START -> { [35:32]
|       |   |--CODE_LITERAL -> @code [35:33]
|       |   |--WS ->   [35:38]
|       |   |--TEXT -> @Deprecated [35:39]
|       |   `--JAVADOC_INLINE_TAG_END -> } [35:51]
|       |--TEXT ->  and the Javadoc tag [35:52]
|       |--NEWLINE -> \r\n [35:72]
|       |--LEADING_ASTERISK ->  * [36:0]
|       |--TEXT ->   [36:2]
|       |--JAVADOC_INLINE_TAG -> JAVADOC_INLINE_TAG [36:3]
|       |   |--JAVADOC_INLINE_TAG_START -> { [36:3]
|       |   |--CODE_LITERAL -> @code [36:4]
|       |   |--WS ->   [36:9]
|       |   |--TEXT -> @deprecated [36:10]
|       |   `--JAVADOC_INLINE_TAG_END -> } [36:22]
|       |--TEXT ->  are both present when either of them is present. [36:23]
|       |--NEWLINE -> \r\n [36:72]
|       |--LEADING_ASTERISK ->  * [37:0]
|       |--TEXT ->   [37:2]
|       `--HTML_ELEMENT_END -> HTML_ELEMENT_END [37:3]
|           |--START -> < [37:3]
|           |--SLASH -> / [37:4]
|           |--HTML_TAG_NAME -> div [37:5]
|           `--END -> > [37:8]
|--NEWLINE -> \r\n [37:9]
|--LEADING_ASTERISK ->  * [38:0]
|--NEWLINE -> \r\n [38:2]
|--LEADING_ASTERISK ->  * [39:0]
|--TEXT ->   [39:2]
|--HTML_ELEMENT -> HTML_ELEMENT [39:3]
|   `--PARAGRAPH -> PARAGRAPH [39:3]
|       |--P_TAG_START -> P_TAG_START [39:3]
|       |   |--START -> < [39:3]
|       |   |--P_HTML_TAG_NAME -> p [39:4]
|       |   `--END -> > [39:5]
|       |--NEWLINE -> \r\n [39:6]
|       |--LEADING_ASTERISK ->  * [40:0]
|       |--TEXT ->  Both ways of flagging deprecation serve their own purpose. [40:2]
|       |--NEWLINE -> \r\n [40:61]
|       |--LEADING_ASTERISK ->  * [41:0]
|       |--TEXT ->  The &#64;Deprecated annotation is used for compilers and development tools. [41:2]
|       |--NEWLINE -> \r\n [41:78]
|       |--LEADING_ASTERISK ->  * [42:0]
|       |--TEXT ->  The &#64;deprecated javadoc tag is used to document why something is deprecated [42:2]
|       |--NEWLINE -> \r\n [42:82]
|       |--LEADING_ASTERISK ->  * [43:0]
|       |--TEXT ->  and what, if any, alternatives exist. [43:2]
|       |--NEWLINE -> \r\n [43:40]
|       |--LEADING_ASTERISK ->  * [44:0]
|       |--TEXT ->   [44:2]
|       `--P_TAG_END -> P_TAG_END [44:3]
|           |--START -> < [44:3]
|           |--SLASH -> / [44:4]
|           |--P_HTML_TAG_NAME -> p [44:5]
|           `--END -> > [44:6]
|--NEWLINE -> \r\n [44:7]
|--LEADING_ASTERISK ->  * [45:0]
|--NEWLINE -> \r\n [45:2]
|--LEADING_ASTERISK ->  * [46:0]
|--TEXT ->   [46:2]
|--HTML_ELEMENT -> HTML_ELEMENT [46:3]
|   `--PARAGRAPH -> PARAGRAPH [46:3]
|       |--P_TAG_START -> P_TAG_START [46:3]
|       |   |--START -> < [46:3]
|       |   |--P_HTML_TAG_NAME -> p [46:4]
|       |   `--END -> > [46:5]
|       |--NEWLINE -> \r\n [46:6]
|       |--LEADING_ASTERISK ->  * [47:0]
|       |--TEXT ->  In order to properly mark something as deprecated both forms of [47:2]
|       |--NEWLINE -> \r\n [47:66]
|       |--LEADING_ASTERISK ->  * [48:0]
|       |--TEXT ->  deprecation should be present. [48:2]
|       |--NEWLINE -> \r\n [48:33]
|       |--LEADING_ASTERISK ->  * [49:0]
|       |--TEXT ->   [49:2]
|       `--P_TAG_END -> P_TAG_END [49:3]
|           |--START -> < [49:3]
|           |--SLASH -> / [49:4]
|           |--P_HTML_TAG_NAME -> p [49:5]
|           `--END -> > [49:6]
|--NEWLINE -> \r\n [49:7]
|--LEADING_ASTERISK ->  * [50:0]
|--NEWLINE -> \r\n [50:2]
|--LEADING_ASTERISK ->  * [51:0]
|--TEXT ->   [51:2]
|--HTML_ELEMENT -> HTML_ELEMENT [51:3]
|   `--PARAGRAPH -> PARAGRAPH [51:3]
|       |--P_TAG_START -> P_TAG_START [51:3]
|       |   |--START -> < [51:3]
|       |   |--P_HTML_TAG_NAME -> p [51:4]
|       |   `--END -> > [51:5]
|       |--NEWLINE -> \r\n [51:6]
|       |--LEADING_ASTERISK ->  * [52:0]
|       |--TEXT ->  Package deprecation is an exception to the rule of always using the [52:2]
|       |--NEWLINE -> \r\n [52:70]
|       |--LEADING_ASTERISK ->  * [53:0]
|       |--TEXT ->  javadoc tag and annotation to deprecate.  It is not clear if the javadoc [53:2]
|       |--NEWLINE -> \r\n [53:75]
|       |--LEADING_ASTERISK ->  * [54:0]
|       |--TEXT ->  tool will support it or not as newer versions keep flip-flopping on if [54:2]
|       |--NEWLINE -> \r\n [54:73]
|       |--LEADING_ASTERISK ->  * [55:0]
|       |--TEXT ->  it is supported or will cause an error. See [55:2]
|       |--NEWLINE -> \r\n [55:46]
|       |--LEADING_ASTERISK ->  * [56:0]
|       |--TEXT ->   [56:2]
|       |--HTML_TAG -> HTML_TAG [56:3]
|       |   |--HTML_ELEMENT_START -> HTML_ELEMENT_START [56:3]
|       |   |   |--START -> < [56:3]
|       |   |   |--HTML_TAG_NAME -> a [56:4]
|       |   |   |--WS ->   [56:5]
|       |   |   |--ATTRIBUTE -> ATTRIBUTE [56:6]
|       |   |   |   |--HTML_TAG_NAME -> href [56:6]
|       |   |   |   |--EQUALS -> = [56:10]
|       |   |   |   `--ATTR_VALUE -> "https://bugs.openjdk.org/browse/JDK-8160601" [56:11]
|       |   |   `--END -> > [56:57]
|       |   |--TEXT -> JDK-8160601 [56:58]
|       |   `--HTML_ELEMENT_END -> HTML_ELEMENT_END [56:69]
|       |       |--START -> < [56:69]
|       |       |--SLASH -> / [56:70]
|       |       |--HTML_TAG_NAME -> a [56:71]
|       |       `--END -> > [56:72]
|       |--TEXT -> . [56:73]
|       |--NEWLINE -> \r\n [56:74]
|       |--LEADING_ASTERISK ->  * [57:0]
|       |--TEXT ->  The deprecated javadoc tag is currently the only way to say why the package [57:2]
|       |--NEWLINE -> \r\n [57:78]
|       |--LEADING_ASTERISK ->  * [58:0]
|       |--TEXT ->  is deprecated and what to use instead.  Until this is resolved, if you don't [58:2]
|       |--NEWLINE -> \r\n [58:79]
|       |--LEADING_ASTERISK ->  * [59:0]
|       |--TEXT ->  want to print violations on package-info, you can use a [59:2]
|       |--NEWLINE -> \r\n [59:58]
|       |--LEADING_ASTERISK ->  * [60:0]
|       |--TEXT ->   [60:2]
|       |--HTML_TAG -> HTML_TAG [60:3]
|       |   |--HTML_ELEMENT_START -> HTML_ELEMENT_START [60:3]
|       |   |   |--START -> < [60:3]
|       |   |   |--HTML_TAG_NAME -> a [60:4]
|       |   |   |--WS ->   [60:5]
|       |   |   |--ATTRIBUTE -> ATTRIBUTE [60:6]
|       |   |   |   |--HTML_TAG_NAME -> href [60:6]
|       |   |   |   |--EQUALS -> = [60:10]
|       |   |   |   `--ATTR_VALUE -> "https://checkstyle.org/filters/index.html" [60:11]
|       |   |   `--END -> > [60:55]
|       |   |--TEXT -> filter [60:56]
|       |   `--HTML_ELEMENT_END -> HTML_ELEMENT_END [60:62]
|       |       |--START -> < [60:62]
|       |       |--SLASH -> / [60:63]
|       |       |--HTML_TAG_NAME -> a [60:64]
|       |       `--END -> > [60:65]
|       |--TEXT ->  to ignore [60:66]
|       |--NEWLINE -> \r\n [60:76]
|       |--LEADING_ASTERISK ->  * [61:0]
|       |--TEXT ->  these files until the javadoc tool faithfully supports it. An example config [61:2]
|       |--NEWLINE -> \r\n [61:79]
|       |--LEADING_ASTERISK ->  * [62:0]
|       |--TEXT ->  using SuppressionSingleFilter is: [62:2]
|       |--NEWLINE -> \r\n [62:36]
|       |--LEADING_ASTERISK ->  * [63:0]
|       |--TEXT ->   [63:2]
|       `--P_TAG_END -> P_TAG_END [63:3]
|           |--START -> < [63:3]
|           |--SLASH -> / [63:4]
|           |--P_HTML_TAG_NAME -> p [63:5]
|           `--END -> > [63:6]
|--NEWLINE -> \r\n [63:7]
|--LEADING_ASTERISK ->  * [64:0]
|--TEXT ->   [64:2]
|--HTML_ELEMENT -> HTML_ELEMENT [64:3]
|   `--HTML_TAG -> HTML_TAG [64:3]
|       |--HTML_ELEMENT_START -> HTML_ELEMENT_START [64:3]
|       |   |--START -> < [64:3]
|       |   |--HTML_TAG_NAME -> pre [64:4]
|       |   `--END -> > [64:7]
|       |--NEWLINE -> \r\n [64:8]
|       |--LEADING_ASTERISK ->  * [65:0]
|       |--TEXT ->  &lt;!-- required till https://bugs.openjdk.org/browse/JDK-8160601 --&gt; [65:2]
|       |--NEWLINE -> \r\n [65:75]
|       |--LEADING_ASTERISK ->  * [66:0]
|       |--TEXT ->  &lt;module name="SuppressionSingleFilter"&gt; [66:2]
|       |--NEWLINE -> \r\n [66:48]
|       |--LEADING_ASTERISK ->  * [67:0]
|       |--TEXT ->      &lt;property name="checks" value="MissingDeprecatedCheck"/&gt; [67:2]
|       |--NEWLINE -> \r\n [67:69]
|       |--LEADING_ASTERISK ->  * [68:0]
|       |--TEXT ->      &lt;property name="files" value="package-info\.java"/&gt; [68:2]
|       |--NEWLINE -> \r\n [68:64]
|       |--LEADING_ASTERISK ->  * [69:0]
|       |--TEXT ->  &lt;/module&gt; [69:2]
|       |--NEWLINE -> \r\n [69:18]
|       |--LEADING_ASTERISK ->  * [70:0]
|       |--TEXT ->   [70:2]
|       `--HTML_ELEMENT_END -> HTML_ELEMENT_END [70:3]
|           |--START -> < [70:3]
|           |--SLASH -> / [70:4]
|           |--HTML_TAG_NAME -> pre [70:5]
|           `--END -> > [70:8]
|--NEWLINE -> \r\n [70:9]
|--LEADING_ASTERISK ->  * [71:0]
|--TEXT ->   [71:2]
|--HTML_ELEMENT -> HTML_ELEMENT [71:3]
|   `--HTML_TAG -> HTML_TAG [71:3]
|       |--HTML_ELEMENT_START -> HTML_ELEMENT_START [71:3]
|       |   |--START -> < [71:3]
|       |   |--HTML_TAG_NAME -> ul [71:4]
|       |   `--END -> > [71:6]
|       |--NEWLINE -> \r\n [71:7]
|       |--LEADING_ASTERISK ->  * [72:0]
|       |--TEXT ->   [72:2]
|       |--HTML_ELEMENT -> HTML_ELEMENT [72:3]
|       |   `--LI -> LI [72:3]
|       |       |--LI_TAG_START -> LI_TAG_START [72:3]
|       |       |   |--START -> < [72:3]
|       |       |   |--LI_HTML_TAG_NAME -> li [72:4]
|       |       |   `--END -> > [72:6]
|       |       |--NEWLINE -> \r\n [72:7]
|       |       |--LEADING_ASTERISK ->  * [73:0]
|       |       |--TEXT ->  Property  [73:2]
|       |       |--JAVADOC_INLINE_TAG -> JAVADOC_INLINE_TAG [73:12]
|       |       |   |--JAVADOC_INLINE_TAG_START -> { [73:12]
|       |       |   |--CODE_LITERAL -> @code [73:13]
|       |       |   |--WS ->   [73:18]
|       |       |   |--TEXT -> violateExecutionOnNonTightHtml [73:19]
|       |       |   `--JAVADOC_INLINE_TAG_END -> } [73:50]
|       |       |--TEXT ->  - Control when to [73:51]
|       |       |--NEWLINE -> \r\n [73:69]
|       |       |--LEADING_ASTERISK ->  * [74:0]
|       |       |--TEXT ->  print violations if the Javadoc being examined by this check violates the [74:2]
|       |       |--NEWLINE -> \r\n [74:76]
|       |       |--LEADING_ASTERISK ->  * [75:0]
|       |       |--TEXT ->  tight html rules defined at [75:2]
|       |       |--NEWLINE -> \r\n [75:30]
|       |       |--LEADING_ASTERISK ->  * [76:0]
|       |       |--TEXT ->   [76:2]
|       |       |--HTML_TAG -> HTML_TAG [76:3]
|       |       |   |--HTML_ELEMENT_START -> HTML_ELEMENT_START [76:3]
|       |       |   |   |--START -> < [76:3]
|       |       |   |   |--HTML_TAG_NAME -> a [76:4]
|       |       |   |   |--WS ->   [76:5]
|       |       |   |   |--ATTRIBUTE -> ATTRIBUTE [76:6]
|       |       |   |   |   |--HTML_TAG_NAME -> href [76:6]
|       |       |   |   |   |--EQUALS -> = [76:10]
|       |       |   |   |   `--ATTR_VALUE -> "https://checkstyle.org/writingjavadocchecks.html#Tight-HTML_rules" [76:11]
|       |       |   |   `--END -> > [76:79]
|       |       |   |--NEWLINE -> \r\n [76:80]
|       |       |   |--LEADING_ASTERISK ->  * [77:0]
|       |       |   |--TEXT ->  Tight-HTML Rules [77:2]
|       |       |   `--HTML_ELEMENT_END -> HTML_ELEMENT_END [77:19]
|       |       |       |--START -> < [77:19]
|       |       |       |--SLASH -> / [77:20]
|       |       |       |--HTML_TAG_NAME -> a [77:21]
|       |       |       `--END -> > [77:22]
|       |       |--TEXT -> . [77:23]
|       |       |--NEWLINE -> \r\n [77:24]
|       |       |--LEADING_ASTERISK ->  * [78:0]
|       |       |--TEXT ->  Type is  [78:2]
|       |       |--JAVADOC_INLINE_TAG -> JAVADOC_INLINE_TAG [78:11]
|       |       |   |--JAVADOC_INLINE_TAG_START -> { [78:11]
|       |       |   |--CODE_LITERAL -> @code [78:12]
|       |       |   |--WS ->   [78:17]
|       |       |   |--TEXT -> boolean [78:18]
|       |       |   `--JAVADOC_INLINE_TAG_END -> } [78:26]
|       |       |--TEXT -> . [78:27]
|       |       |--NEWLINE -> \r\n [78:28]
|       |       |--LEADING_ASTERISK ->  * [79:0]
|       |       |--TEXT ->  Default value is  [79:2]
|       |       |--JAVADOC_INLINE_TAG -> JAVADOC_INLINE_TAG [79:20]
|       |       |   |--JAVADOC_INLINE_TAG_START -> { [79:20]
|       |       |   |--CODE_LITERAL -> @code [79:21]
|       |       |   |--WS ->   [79:26]
|       |       |   |--TEXT -> false [79:27]
|       |       |   `--JAVADOC_INLINE_TAG_END -> } [79:33]
|       |       |--TEXT -> . [79:34]
|       |       |--NEWLINE -> \r\n [79:35]
|       |       |--LEADING_ASTERISK ->  * [80:0]
|       |       |--TEXT ->  Since version 8.24 [80:2]
|       |       |--NEWLINE -> \r\n [80:21]
|       |       |--LEADING_ASTERISK ->  * [81:0]
|       |       |--TEXT ->   [81:2]
|       |       `--LI_TAG_END -> LI_TAG_END [81:3]
|       |           |--START -> < [81:3]
|       |           |--SLASH -> / [81:4]
|       |           |--LI_HTML_TAG_NAME -> li [81:5]
|       |           `--END -> > [81:7]
|       |--NEWLINE -> \r\n [81:8]
|       |--LEADING_ASTERISK ->  * [82:0]
|       |--TEXT ->   [82:2]
|       `--HTML_ELEMENT_END -> HTML_ELEMENT_END [82:3]
|           |--START -> < [82:3]
|           |--SLASH -> / [82:4]
|           |--HTML_TAG_NAME -> ul [82:5]
|           `--END -> > [82:7]
|--NEWLINE -> \r\n [82:8]
|--LEADING_ASTERISK ->  * [83:0]
|--NEWLINE -> \r\n [83:2]
|--LEADING_ASTERISK ->  * [84:0]
|--TEXT ->   [84:2]
|--HTML_ELEMENT -> HTML_ELEMENT [84:3]
|   `--PARAGRAPH -> PARAGRAPH [84:3]
|       |--P_TAG_START -> P_TAG_START [84:3]
|       |   |--START -> < [84:3]
|       |   |--P_HTML_TAG_NAME -> p [84:4]
|       |   `--END -> > [84:5]
|       |--NEWLINE -> \r\n [84:6]
|       |--LEADING_ASTERISK ->  * [85:0]
|       |--TEXT ->  Parent is  [85:2]
|       |--JAVADOC_INLINE_TAG -> JAVADOC_INLINE_TAG [85:13]
|       |   |--JAVADOC_INLINE_TAG_START -> { [85:13]
|       |   |--CODE_LITERAL -> @code [85:14]
|       |   |--WS ->   [85:19]
|       |   |--TEXT -> com.puppycrawl.tools.checkstyle.TreeWalker [85:20]
|       |   `--JAVADOC_INLINE_TAG_END -> } [85:63]
|       |--NEWLINE -> \r\n [85:64]
|       |--LEADING_ASTERISK ->  * [86:0]
|       |--TEXT ->   [86:2]
|       `--P_TAG_END -> P_TAG_END [86:3]
|           |--START -> < [86:3]
|           |--SLASH -> / [86:4]
|           |--P_HTML_TAG_NAME -> p [86:5]
|           `--END -> > [86:6]
|--NEWLINE -> \r\n [86:7]
|--LEADING_ASTERISK ->  * [87:0]
|--NEWLINE -> \r\n [87:2]
|--LEADING_ASTERISK ->  * [88:0]
|--TEXT ->   [88:2]
|--HTML_ELEMENT -> HTML_ELEMENT [88:3]
|   `--PARAGRAPH -> PARAGRAPH [88:3]
|       |--P_TAG_START -> P_TAG_START [88:3]
|       |   |--START -> < [88:3]
|       |   |--P_HTML_TAG_NAME -> p [88:4]
|       |   `--END -> > [88:5]
|       |--NEWLINE -> \r\n [88:6]
|       |--LEADING_ASTERISK ->  * [89:0]
|       |--TEXT ->  Violation Message Keys: [89:2]
|       |--NEWLINE -> \r\n [89:26]
|       |--LEADING_ASTERISK ->  * [90:0]
|       |--TEXT ->   [90:2]
|       `--P_TAG_END -> P_TAG_END [90:3]
|           |--START -> < [90:3]
|           |--SLASH -> / [90:4]
|           |--P_HTML_TAG_NAME -> p [90:5]
|           `--END -> > [90:6]
|--NEWLINE -> \r\n [90:7]
|--LEADING_ASTERISK ->  * [91:0]
|--TEXT ->   [91:2]
|--HTML_ELEMENT -> HTML_ELEMENT [91:3]
|   `--HTML_TAG -> HTML_TAG [91:3]
|       |--HTML_ELEMENT_START -> HTML_ELEMENT_START [91:3]
|       |   |--START -> < [91:3]
|       |   |--HTML_TAG_NAME -> ul [91:4]
|       |   `--END -> > [91:6]
|       |--NEWLINE -> \r\n [91:7]
|       |--LEADING_ASTERISK ->  * [92:0]
|       |--TEXT ->   [92:2]
|       |--HTML_ELEMENT -> HTML_ELEMENT [92:3]
|       |   `--LI -> LI [92:3]
|       |       |--LI_TAG_START -> LI_TAG_START [92:3]
|       |       |   |--START -> < [92:3]
|       |       |   |--LI_HTML_TAG_NAME -> li [92:4]
|       |       |   `--END -> > [92:6]
|       |       |--NEWLINE -> \r\n [92:7]
|       |       |--LEADING_ASTERISK ->  * [93:0]
|       |       |--TEXT ->   [93:2]
|       |       |--JAVADOC_INLINE_TAG -> JAVADOC_INLINE_TAG [93:3]
|       |       |   |--JAVADOC_INLINE_TAG_START -> { [93:3]
|       |       |   |--CODE_LITERAL -> @code [93:4]
|       |       |   |--WS ->   [93:9]
|       |       |   |--TEXT -> annotation.missing.deprecated [93:10]
|       |       |   `--JAVADOC_INLINE_TAG_END -> } [93:40]
|       |       |--NEWLINE -> \r\n [93:41]
|       |       |--LEADING_ASTERISK ->  * [94:0]
|       |       |--TEXT ->   [94:2]
|       |       `--LI_TAG_END -> LI_TAG_END [94:3]
|       |           |--START -> < [94:3]
|       |           |--SLASH -> / [94:4]
|       |           |--LI_HTML_TAG_NAME -> li [94:5]
|       |           `--END -> > [94:7]
|       |--NEWLINE -> \r\n [94:8]
|       |--LEADING_ASTERISK ->  * [95:0]
|       |--TEXT ->   [95:2]
|       |--HTML_ELEMENT -> HTML_ELEMENT [95:3]
|       |   `--LI -> LI [95:3]
|       |       |--LI_TAG_START -> LI_TAG_START [95:3]
|       |       |   |--START -> < [95:3]
|       |       |   |--LI_HTML_TAG_NAME -> li [95:4]
|       |       |   `--END -> > [95:6]
|       |       |--NEWLINE -> \r\n [95:7]
|       |       |--LEADING_ASTERISK ->  * [96:0]
|       |       |--TEXT ->   [96:2]
|       |       |--JAVADOC_INLINE_TAG -> JAVADOC_INLINE_TAG [96:3]
|       |       |   |--JAVADOC_INLINE_TAG_START -> { [96:3]
|       |       |   |--CODE_LITERAL -> @code [96:4]
|       |       |   |--WS ->   [96:9]
|       |       |   |--TEXT -> javadoc.duplicateTag [96:10]
|       |       |   `--JAVADOC_INLINE_TAG_END -> } [96:31]
|       |       |--NEWLINE -> \r\n [96:32]
|       |       |--LEADING_ASTERISK ->  * [97:0]
|       |       |--TEXT ->   [97:2]
|       |       `--LI_TAG_END -> LI_TAG_END [97:3]
|       |           |--START -> < [97:3]
|       |           |--SLASH -> / [97:4]
|       |           |--LI_HTML_TAG_NAME -> li [97:5]
|       |           `--END -> > [97:7]
|       |--NEWLINE -> \r\n [97:8]
|       |--LEADING_ASTERISK ->  * [98:0]
|       |--TEXT ->   [98:2]
|       |--HTML_ELEMENT -> HTML_ELEMENT [98:3]
|       |   `--LI -> LI [98:3]
|       |       |--LI_TAG_START -> LI_TAG_START [98:3]
|       |       |   |--START -> < [98:3]
|       |       |   |--LI_HTML_TAG_NAME -> li [98:4]
|       |       |   `--END -> > [98:6]
|       |       |--NEWLINE -> \r\n [98:7]
|       |       |--LEADING_ASTERISK ->  * [99:0]
|       |       |--TEXT ->   [99:2]
|       |       |--JAVADOC_INLINE_TAG -> JAVADOC_INLINE_TAG [99:3]
|       |       |   |--JAVADOC_INLINE_TAG_START -> { [99:3]
|       |       |   |--CODE_LITERAL -> @code [99:4]
|       |       |   |--WS ->   [99:9]
|       |       |   |--TEXT -> javadoc.missed.html.close [99:10]
|       |       |   `--JAVADOC_INLINE_TAG_END -> } [99:36]
|       |       |--NEWLINE -> \r\n [99:37]
|       |       |--LEADING_ASTERISK ->  * [100:0]
|       |       |--TEXT ->   [100:2]
|       |       `--LI_TAG_END -> LI_TAG_END [100:3]
|       |           |--START -> < [100:3]
|       |           |--SLASH -> / [100:4]
|       |           |--LI_HTML_TAG_NAME -> li [100:5]
|       |           `--END -> > [100:7]
|       |--NEWLINE -> \r\n [100:8]
|       |--LEADING_ASTERISK ->  * [101:0]
|       |--TEXT ->   [101:2]
|       |--HTML_ELEMENT -> HTML_ELEMENT [101:3]
|       |   `--LI -> LI [101:3]
|       |       |--LI_TAG_START -> LI_TAG_START [101:3]
|       |       |   |--START -> < [101:3]
|       |       |   |--LI_HTML_TAG_NAME -> li [101:4]
|       |       |   `--END -> > [101:6]
|       |       |--NEWLINE -> \r\n [101:7]
|       |       |--LEADING_ASTERISK ->  * [102:0]
|       |       |--TEXT ->   [102:2]
|       |       |--JAVADOC_INLINE_TAG -> JAVADOC_INLINE_TAG [102:3]
|       |       |   |--JAVADOC_INLINE_TAG_START -> { [102:3]
|       |       |   |--CODE_LITERAL -> @code [102:4]
|       |       |   |--WS ->   [102:9]
|       |       |   |--TEXT -> javadoc.parse.rule.error [102:10]
|       |       |   `--JAVADOC_INLINE_TAG_END -> } [102:35]
|       |       |--NEWLINE -> \r\n [102:36]
|       |       |--LEADING_ASTERISK ->  * [103:0]
|       |       |--TEXT ->   [103:2]
|       |       `--LI_TAG_END -> LI_TAG_END [103:3]
|       |           |--START -> < [103:3]
|       |           |--SLASH -> / [103:4]
|       |           |--LI_HTML_TAG_NAME -> li [103:5]
|       |           `--END -> > [103:7]
|       |--NEWLINE -> \r\n [103:8]
|       |--LEADING_ASTERISK ->  * [104:0]
|       |--TEXT ->   [104:2]
|       |--HTML_ELEMENT -> HTML_ELEMENT [104:3]
|       |   `--LI -> LI [104:3]
|       |       |--LI_TAG_START -> LI_TAG_START [104:3]
|       |       |   |--START -> < [104:3]
|       |       |   |--LI_HTML_TAG_NAME -> li [104:4]
|       |       |   `--END -> > [104:6]
|       |       |--NEWLINE -> \r\n [104:7]
|       |       |--LEADING_ASTERISK ->  * [105:0]
|       |       |--TEXT ->   [105:2]
|       |       |--JAVADOC_INLINE_TAG -> JAVADOC_INLINE_TAG [105:3]
|       |       |   |--JAVADOC_INLINE_TAG_START -> { [105:3]
|       |       |   |--CODE_LITERAL -> @code [105:4]
|       |       |   |--WS ->   [105:9]
|       |       |   |--TEXT -> javadoc.unclosedHtml [105:10]
|       |       |   `--JAVADOC_INLINE_TAG_END -> } [105:31]
|       |       |--NEWLINE -> \r\n [105:32]
|       |       |--LEADING_ASTERISK ->  * [106:0]
|       |       |--TEXT ->   [106:2]
|       |       `--LI_TAG_END -> LI_TAG_END [106:3]
|       |           |--START -> < [106:3]
|       |           |--SLASH -> / [106:4]
|       |           |--LI_HTML_TAG_NAME -> li [106:5]
|       |           `--END -> > [106:7]
|       |--NEWLINE -> \r\n [106:8]
|       |--LEADING_ASTERISK ->  * [107:0]
|       |--TEXT ->   [107:2]
|       |--HTML_ELEMENT -> HTML_ELEMENT [107:3]
|       |   `--LI -> LI [107:3]
|       |       |--LI_TAG_START -> LI_TAG_START [107:3]
|       |       |   |--START -> < [107:3]
|       |       |   |--LI_HTML_TAG_NAME -> li [107:4]
|       |       |   `--END -> > [107:6]
|       |       |--NEWLINE -> \r\n [107:7]
|       |       |--LEADING_ASTERISK ->  * [108:0]
|       |       |--TEXT ->   [108:2]
|       |       |--JAVADOC_INLINE_TAG -> JAVADOC_INLINE_TAG [108:3]
|       |       |   |--JAVADOC_INLINE_TAG_START -> { [108:3]
|       |       |   |--CODE_LITERAL -> @code [108:4]
|       |       |   |--WS ->   [108:9]
|       |       |   |--TEXT -> javadoc.wrong.singleton.html.tag [108:10]
|       |       |   `--JAVADOC_INLINE_TAG_END -> } [108:43]
|       |       |--NEWLINE -> \r\n [108:44]
|       |       |--LEADING_ASTERISK ->  * [109:0]
|       |       |--TEXT ->   [109:2]
|       |       `--LI_TAG_END -> LI_TAG_END [109:3]
|       |           |--START -> < [109:3]
|       |           |--SLASH -> / [109:4]
|       |           |--LI_HTML_TAG_NAME -> li [109:5]
|       |           `--END -> > [109:7]
|       |--NEWLINE -> \r\n [109:8]
|       |--LEADING_ASTERISK ->  * [110:0]
|       |--TEXT ->   [110:2]
|       `--HTML_ELEMENT_END -> HTML_ELEMENT_END [110:3]
|           |--START -> < [110:3]
|           |--SLASH -> / [110:4]
|           |--HTML_TAG_NAME -> ul [110:5]
|           `--END -> > [110:7]
|--NEWLINE -> \r\n [110:8]
|--LEADING_ASTERISK ->  * [111:0]
|--NEWLINE -> \r\n [111:2]
|--LEADING_ASTERISK ->  * [112:0]
|--WS ->   [112:2]
|--JAVADOC_TAG -> JAVADOC_TAG [112:3]
|   |--SINCE_LITERAL -> @since [112:3]
|   |--WS ->   [112:9]
|   `--DESCRIPTION -> DESCRIPTION [112:10]
|       |--TEXT -> 5.0 [112:10]
|       |--NEWLINE -> \r\n [112:13]
|       |--LEADING_ASTERISK ->  * [113:0]
|       `--TEXT -> / [113:2]
`--EOF -> <EOF> [113:3]
```

Focus on:
```
|       |       |--LEADING_ASTERISK ->  * [80:0]
|       |       |--TEXT ->  Since version 8.24 [80:2]
|       |       |--NEWLINE -> \r\n [80:21]
|       |       |--LEADING_ASTERISK ->  * [81:0]
|       |       |--TEXT ->   [81:2]
```
