### PR TITLE
test:Add validation tests for filters in Xdocs and update PMD configu…

### DIFF
--- a/config/pmd-test.xml
+++ b/config/pmd-test.xml
@@ -74,7 +74,8 @@
                        //MethodDeclaration[@Name='testTokenNumbering']
                    | //ClassDeclaration[@SimpleName='GeneratedJavadocTokenTypesTest']
                        //MethodDeclaration[@Name='testTokenNumbers']
-                   | //ClassDeclaration[@SimpleName='IndentationCheckTest']"/>
+                   | //ClassDeclaration[@SimpleName='IndentationCheckTest']
+                   | //ClassDeclaration[@SimpleName='XdocsPagesTest']"/>
     </properties>
   </rule>
 


### PR DESCRIPTION
## Changes Made #17176 

I found the filters exclusion logic in `XdocsPagesTest.java` line 375-376 and noticed it lacked explanation. Based on the code analysis:

- Filters are excluded because they're not in the main `checks.xml` file
- Added explanatory comment to clarify this design decision  
- Created dedicated test method `testFiltersIndexPageTable()` for filters validation
- This ensures filters table structure is properly validated going forward

## Testing
- [x] New test validates filters table structure
- [x] Existing tests continue to pass
- [x] Filters exclusion now has clear documentation