### PR TITLE
Issue #14631: Added Javadoc for OPTION_HTML_TAG_NAME in JavadocTokenType.java

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/api/JavadocTokenTypes.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/api/JavadocTokenTypes.java
@@ -1616,7 +1616,40 @@ public final class JavadocTokenTypes {
     /** Html tag name. */
     public static final int HTML_HTML_TAG_NAME = JavadocParser.HTML_HTML_TAG_NAME;
 
-    /** Option tag name. */
+    /**
+     * Option tag name.
+     *
+     * <p><b>Example:</b></p>
+     * <pre>{@code &lt;option value="yes"&gt;Yes&lt;/option&gt;}</pre>
+     * <b>Tree:</b>
+     * <pre>
+     * {@code
+     * JAVADOC -> JAVADOC
+     * |--NEWLINE -> \r\n
+     * |--LEADING_ASTERISK ->  *
+     * |--HTML_ELEMENT -> HTML_ELEMENT
+     * |   `--OPTION -> OPTION
+     * |       |--OPTION_TAG_START -> OPTION_TAG_START
+     * |       |   |--START -> <
+     * |       |   |--OPTION_HTML_TAG_NAME -> option
+     * |       |   |--WS ->
+     * |       |   |--ATTRIBUTE -> ATTRIBUTE
+     * |       |   |   |--HTML_TAG_NAME -> value
+     * |       |   |   |--EQUALS -> =
+     * |       |   |   `--ATTR_VALUE -> "yes"
+     * |       |   `--END -> >
+     * |       |--TEXT -> Yes
+     * |       `--OPTION_TAG_END -> OPTION_TAG_END
+     * |           |--START -> <
+     * |           |--SLASH -> /
+     * |           |--OPTION_HTML_TAG_NAME -> option
+     * |           `--END -> >
+     * |--NEWLINE -> \r\n
+     * |--TEXT ->
+     * |--EOF -> <EOF>
+     * }
+     * </pre>
+     */
     public static final int OPTION_HTML_TAG_NAME = JavadocParser.OPTION_HTML_TAG_NAME;
 
     /** Table body tag name. */


### PR DESCRIPTION
Issue #14631 :

**Command Used**
`java -jar checkstyle-10.25.0-all.jar -J Test.java | sed "s/\[[0-9]\+:[0-9]\+\]//g"`

**Test.java**
```
/**
 *<option value="yes">Yes</option>
 */
public class Test{

}
```


```
Saloni@Sunflower MINGW64 ~/option_html_tag_name AST
$ java -jar checkstyle-10.25.0-all.jar -J Test.java | sed "s/\[[0-9]\+:[0-9]\+\]//g"
COMPILATION_UNIT -> COMPILATION_UNIT
`--CLASS_DEF -> CLASS_DEF
    |--MODIFIERS -> MODIFIERS
    |   |--BLOCK_COMMENT_BEGIN -> /*
    |   |   |--COMMENT_CONTENT -> *\r\n *<option value="yes">Yes</option>\r\n
    |   |   |   `--JAVADOC -> JAVADOC
    |   |   |       |--NEWLINE -> \r\n
    |   |   |       |--LEADING_ASTERISK ->  *
    |   |   |       |--HTML_ELEMENT -> HTML_ELEMENT
    |   |   |       |   `--OPTION -> OPTION
    |   |   |       |       |--OPTION_TAG_START -> OPTION_TAG_START
    |   |   |       |       |   |--START -> <
    |   |   |       |       |   |--OPTION_HTML_TAG_NAME -> option
    |   |   |       |       |   |--WS ->
    |   |   |       |       |   |--ATTRIBUTE -> ATTRIBUTE
    |   |   |       |       |   |   |--HTML_TAG_NAME -> value
    |   |   |       |       |   |   |--EQUALS -> =
    |   |   |       |       |   |   `--ATTR_VALUE -> "yes"
    |   |   |       |       |   `--END -> >
    |   |   |       |       |--TEXT -> Yes
    |   |   |       |       `--OPTION_TAG_END -> OPTION_TAG_END
    |   |   |       |           |--START -> <
    |   |   |       |           |--SLASH -> /
    |   |   |       |           |--OPTION_HTML_TAG_NAME -> option
    |   |   |       |           `--END -> >
    |   |   |       |--NEWLINE -> \r\n
    |   |   |       |--TEXT ->
    |   |   |       `--EOF -> <EOF>
    |   |   `--BLOCK_COMMENT_END -> */
    |   `--LITERAL_PUBLIC -> public
    |--LITERAL_CLASS -> class
    |--IDENT -> Test
    `--OBJBLOCK -> OBJBLOCK
        |--LCURLY -> {
        `--RCURLY -> }

```

