### PR TITLE
Issue #17225: Extend "Since version" javadoc marking implementation

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/NonEmptyAtclauseDescriptionCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/NonEmptyAtclauseDescriptionCheck.java
@@ -43,6 +43,7 @@ import com.puppycrawl.tools.checkstyle.utils.JavadocUtil;
  * Type is {@code java.lang.String[]}.
  * Validation type is {@code tokenSet}.
  * Default value is
+ * Since version 7.3
  * <a href="https://checkstyle.org/apidocs/com/puppycrawl/tools/checkstyle/api/JavadocTokenTypes.html#PARAM_LITERAL">
  * PARAM_LITERAL</a>,
  * <a href="https://checkstyle.org/apidocs/com/puppycrawl/tools/checkstyle/api/JavadocTokenTypes.html#RETURN_LITERAL">

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/metrics/ClassDataAbstractionCouplingCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/metrics/ClassDataAbstractionCouplingCheck.java
@@ -85,6 +85,7 @@ import com.puppycrawl.tools.checkstyle.api.TokenTypes;
  * expressions to ignore classes.
  * Type is {@code java.util.regex.Pattern[]}.
  * Default value is {@code ^$}.
+ * Since version 7.7
  * </li>
  * <li>
  * Property {@code excludedClasses} - Specify user-configured class names to ignore.
@@ -103,6 +104,7 @@ import com.puppycrawl.tools.checkstyle.api.TokenTypes;
  * Property {@code excludedPackages} - Specify user-configured packages to ignore.
  * Type is {@code java.lang.String[]}.
  * Default value is {@code ""}.
+ * Since version 7.7
  * </li>
  * <li>
  * Property {@code max} - Specify the maximum threshold allowed.

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/metrics/ClassFanOutComplexityCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/metrics/ClassFanOutComplexityCheck.java
@@ -52,6 +52,7 @@ import com.puppycrawl.tools.checkstyle.api.TokenTypes;
  * expressions to ignore classes.
  * Type is {@code java.util.regex.Pattern[]}.
  * Default value is {@code ^$}.
+ * Since version 7.7
  * </li>
  * <li>
  * Property {@code excludedClasses} - Specify user-configured class names to ignore.
@@ -70,6 +71,7 @@ import com.puppycrawl.tools.checkstyle.api.TokenTypes;
  * Property {@code excludedPackages} - Specify user-configured packages to ignore.
  * Type is {@code java.lang.String[]}.
  * Default value is {@code ""}.
+ * Since version 7.7
  * </li>
  * <li>
  * Property {@code max} - Specify the maximum threshold allowed.

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/sizes/LineLengthCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/sizes/LineLengthCheck.java
@@ -64,6 +64,7 @@ import com.puppycrawl.tools.checkstyle.utils.CommonUtil;
  * Property {@code fileExtensions} - Specify the file extensions of the files to process.
  * Type is {@code java.lang.String[]}.
  * Default value is {@code ""}.
+ * Since version 8.24
  * </li>
  * <li>
  * Property {@code ignorePattern} - Specify pattern for lines to ignore.

--- a/src/main/java/com/puppycrawl/tools/checkstyle/site/SiteUtil.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/site/SiteUtil.java
@@ -183,16 +183,6 @@ public final class SiteUtil {
     /**
      * Frequent version.
      */
-    private static final String VERSION_8_24 = "8.24";
-
-    /**
-     * Frequent version.
-     */
-    private static final String VERSION_7_7 = "7.7";
-
-    /**
-     * Frequent version.
-     */
     private static final String VERSION_5_7 = "5.7";
 
     /**
@@ -213,14 +203,8 @@ public final class SiteUtil {
      * @noinspectionreason JavacQuirks until #14052
      */
     private static final Map<String, String> SINCE_VERSION_FOR_INHERITED_PROPERTY = Map.ofEntries(
-        Map.entry("ClassDataAbstractionCouplingCheck.excludeClassesRegexps", VERSION_7_7),
         Map.entry("ClassDataAbstractionCouplingCheck.excludedClasses", VERSION_5_7),
-        Map.entry("ClassDataAbstractionCouplingCheck.excludedPackages", VERSION_7_7),
-        Map.entry("ClassFanOutComplexityCheck.excludeClassesRegexps", VERSION_7_7),
         Map.entry("ClassFanOutComplexityCheck.excludedClasses", VERSION_5_7),
-        Map.entry("ClassFanOutComplexityCheck.excludedPackages", VERSION_7_7),
-        Map.entry("NonEmptyAtclauseDescriptionCheck.javadocTokens", "7.3"),
-        Map.entry("LineLengthCheck.fileExtensions", VERSION_8_24),
         // until https://github.com/checkstyle/checkstyle/issues/14052
         Map.entry("StaticVariableNameCheck.applyToPackage", VERSION_5_0),
         Map.entry("StaticVariableNameCheck.applyToPrivate", VERSION_5_0),


### PR DESCRIPTION
#17225 
Continuing #17238
