### PR TITLE
Issue #17225: Extend 'Since version' javadoc marking implementation

### DIFF
--- a/.ci/validation.sh
+++ b/.ci/validation.sh
@@ -515,25 +515,6 @@ compile-test-resources)
   -Dcheckstyle.skipCompileInputResources=false -Dmaven.compiler.release=17
   ;;
 
-javac11)
-  # InputCustomImportOrderNoPackage2 - nothing is required in front of first import
-  # InputIllegalTypePackageClassName - bad import for testing
-  # InputVisibilityModifierPackageClassName - bad import for testing
-  files=($(grep -REL --include='*.java' \
-        --exclude='InputCustomImportOrderNoPackage2.java' \
-        --exclude='InputIllegalTypePackageClassName.java' \
-        --exclude='InputVisibilityModifierPackageClassName.java' \
-        '//non-compiled (syntax|with javac)?\:' \
-        src/test/resources-noncompilable \
-        src/xdocs-examples/resources-noncompilable))
-  mkdir -p target
-  for file in "${files[@]}"
-  do
-    echo "${file}"
-    javac -d target "${file}"
-  done
-  ;;
-
 javac17)
   files=($(grep -Rl --include='*.java' ': Compilable with Java17' \
         src/test/resources-noncompilable \

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -283,9 +283,6 @@ workflows:
           name: "check-since-version"
           command: "./.ci/validation.sh check-since-version"
       - validate-with-script:
-          name: "javac11"
-          command: "./.ci/validation.sh javac11"
-      - validate-with-script:
           name: "javac17"
           image-name: "cimg/openjdk:17.0.7"
           command: "./.ci/validation.sh javac17"

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/NonEmptyAtclauseDescriptionCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/NonEmptyAtclauseDescriptionCheck.java
@@ -43,6 +43,7 @@ import com.puppycrawl.tools.checkstyle.utils.JavadocUtil;
  * Type is {@code java.lang.String[]}.
  * Validation type is {@code tokenSet}.
  * Default value is
+ * Since version 7.3
  * <a href="https://checkstyle.org/apidocs/com/puppycrawl/tools/checkstyle/api/JavadocTokenTypes.html#PARAM_LITERAL">
  * PARAM_LITERAL</a>,
  * <a href="https://checkstyle.org/apidocs/com/puppycrawl/tools/checkstyle/api/JavadocTokenTypes.html#RETURN_LITERAL">

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/metrics/ClassDataAbstractionCouplingCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/metrics/ClassDataAbstractionCouplingCheck.java
@@ -85,6 +85,7 @@ import com.puppycrawl.tools.checkstyle.api.TokenTypes;
  * expressions to ignore classes.
  * Type is {@code java.util.regex.Pattern[]}.
  * Default value is {@code ^$}.
+ * Since version 7.7
  * </li>
  * <li>
  * Property {@code excludedClasses} - Specify user-configured class names to ignore.
@@ -103,6 +104,7 @@ import com.puppycrawl.tools.checkstyle.api.TokenTypes;
  * Property {@code excludedPackages} - Specify user-configured packages to ignore.
  * Type is {@code java.lang.String[]}.
  * Default value is {@code ""}.
+ * Since version 7.7
  * </li>
  * <li>
  * Property {@code max} - Specify the maximum threshold allowed.

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/metrics/ClassFanOutComplexityCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/metrics/ClassFanOutComplexityCheck.java
@@ -52,6 +52,7 @@ import com.puppycrawl.tools.checkstyle.api.TokenTypes;
  * expressions to ignore classes.
  * Type is {@code java.util.regex.Pattern[]}.
  * Default value is {@code ^$}.
+ * Since version 7.7
  * </li>
  * <li>
  * Property {@code excludedClasses} - Specify user-configured class names to ignore.
@@ -70,6 +71,7 @@ import com.puppycrawl.tools.checkstyle.api.TokenTypes;
  * Property {@code excludedPackages} - Specify user-configured packages to ignore.
  * Type is {@code java.lang.String[]}.
  * Default value is {@code ""}.
+ * Since version 7.7
  * </li>
  * <li>
  * Property {@code max} - Specify the maximum threshold allowed.

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/sizes/LineLengthCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/sizes/LineLengthCheck.java
@@ -64,6 +64,7 @@ import com.puppycrawl.tools.checkstyle.utils.CommonUtil;
  * Property {@code fileExtensions} - Specify the file extensions of the files to process.
  * Type is {@code java.lang.String[]}.
  * Default value is {@code ""}.
+ * Since version 8.24
  * </li>
  * <li>
  * Property {@code ignorePattern} - Specify pattern for lines to ignore.

--- a/src/main/java/com/puppycrawl/tools/checkstyle/site/SiteUtil.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/site/SiteUtil.java
@@ -183,16 +183,6 @@ public final class SiteUtil {
     /**
      * Frequent version.
      */
-    private static final String VERSION_8_24 = "8.24";
-
-    /**
-     * Frequent version.
-     */
-    private static final String VERSION_7_7 = "7.7";
-
-    /**
-     * Frequent version.
-     */
     private static final String VERSION_5_7 = "5.7";
 
     /**
@@ -213,14 +203,8 @@ public final class SiteUtil {
      * @noinspectionreason JavacQuirks until #14052
      */
     private static final Map<String, String> SINCE_VERSION_FOR_INHERITED_PROPERTY = Map.ofEntries(
-        Map.entry("ClassDataAbstractionCouplingCheck.excludeClassesRegexps", VERSION_7_7),
         Map.entry("ClassDataAbstractionCouplingCheck.excludedClasses", VERSION_5_7),
-        Map.entry("ClassDataAbstractionCouplingCheck.excludedPackages", VERSION_7_7),
-        Map.entry("ClassFanOutComplexityCheck.excludeClassesRegexps", VERSION_7_7),
         Map.entry("ClassFanOutComplexityCheck.excludedClasses", VERSION_5_7),
-        Map.entry("ClassFanOutComplexityCheck.excludedPackages", VERSION_7_7),
-        Map.entry("NonEmptyAtclauseDescriptionCheck.javadocTokens", "7.3"),
-        Map.entry("LineLengthCheck.fileExtensions", VERSION_8_24),
         // until https://github.com/checkstyle/checkstyle/issues/14052
         Map.entry("StaticVariableNameCheck.applyToPackage", VERSION_5_0),
         Map.entry("StaticVariableNameCheck.applyToPrivate", VERSION_5_0),


### PR DESCRIPTION
# PLEASE READ BEFORE REMOVING

**Rules:**

- **Issue Requirement**
   - The issue you are trying to fix/resolve **must** have the `"approved"` label.
   - If an issue exists, reference it in the Pull Request description:
     Example: `"Issue: #XXXXXX"`
- **Commit message** should adhere to the following rules:
   - MUST match any one of the following patterns:

     ```
     ^Issue #\d+: .*$
     ^Pull #\d+: .*$
     ^(minor|config|infra|doc|spelling|dependency): .*$
     ```

   - MUST contain only one line of text
   - MUST NOT end with a period, space, or tab
   - MUST be less than or equal to 200 characters

To avoid multiple iterations of fixes and CI failures, please read
[Contribution Guide](https://checkstyle.org/contributing.html).

**ATTENTION:** Pull Requests that do not pass our CI checks will not be merged,
but we will help to resolve issues.

---
Thanks for reading, feel free to remove this whole message and type what you need.
