### PR TITLE
Issue #17276: Add CSS rules to enable wrapping for table cells in Properties section

### DIFF
--- a/src/site/resources/css/site.css
+++ b/src/site/resources/css/site.css
@@ -401,3 +401,11 @@ span.wrapper.inline {
     font-style: italic;
   }
 }
+
+section[id="Properties"] .wrapper table tr td:nth-child(4),
+section[id="Properties"] .wrapper table tr td:nth-child(4) pre,
+section[id="Properties"] .wrapper table tr td:nth-child(4) code {
+  white-space: pre-wrap !important;
+  word-break: break-word !important;
+  overflow-wrap: break-word;
+}


### PR DESCRIPTION
Fixes #17276 

Before fix: 

![image](https://github.com/user-attachments/assets/b1dd7c2b-b8db-486e-9109-503ef5ebf99c)


After fix:

![Screenshot 2025-06-25 105457](https://github.com/user-attachments/assets/573a2629-b94f-4f82-bd96-dc2bd4f0d1b3)
