### PR TITLE
infra: attempt to fix xwiki build

### DIFF
--- a/.ci/validation.sh
+++ b/.ci/validation.sh
@@ -283,14 +283,14 @@ no-error-xwiki)
   mvn -e --no-transfer-progress install:install-file \
     -Dfile=xwiki-commons-tools/xwiki-commons-tool-pom/pom.xml \
     -DpomFile=xwiki-commons-tools/xwiki-commons-tool-pom/pom.xml
+  mvn -e --no-transfer-progress -f xwiki-commons-tools/xwiki-commons-tool-xar/pom.xml \
+      install -Dmaven.test.skip -Dcheckstyle.version="${CS_POM_VERSION}"
   mvn -e --no-transfer-progress install:install-file -Dfile=xwiki-commons-pom/pom.xml \
     -DpomFile=xwiki-commons-pom/pom.xml
   mvn -e --no-transfer-progress -f xwiki-commons-tools/xwiki-commons-tool-webjar-handlers/pom.xml \
     install -Dmaven.test.skip -Dcheckstyle.version="${CS_POM_VERSION}"
   mvn -e --no-transfer-progress \
     -f xwiki-commons-tools/xwiki-commons-tool-webjar-node-handlers/pom.xml \
-    install -Dmaven.test.skip -Dcheckstyle.version="${CS_POM_VERSION}"
-  mvn -e --no-transfer-progress -f xwiki-commons-tools/xwiki-commons-tool-xar/pom.xml \
     install -Dmaven.test.skip -Dcheckstyle.version="${CS_POM_VERSION}"
   cd ..
   removeFolderWithProtectedFiles xwiki-commons


### PR DESCRIPTION
https://app.circleci.com/pipelines/github/checkstyle/checkstyle/34714/workflows/c7ff50cc-b5da-4a6b-aded-4167cf09a704/jobs/982441?invite=true#step-103-244041_73

```
[INFO] ----------------< org.xwiki.commons:xwiki-commons-pom >-----------------
[INFO] Building XWiki Commons - Root POM 17.6.0-SNAPSHOT               [11/108]
[INFO] --------------------------------[ pom ]---------------------------------
[WARNING] Failed to retrieve plugin descriptor for org.xwiki.commons:
xwiki-commons-tool-remote-resource-plugin:17.6.0-SNAPSHOT: 
Plugin org.xwiki.commons:xwiki-commons-tool-remote-resource-plugin:17.6.0-SNAPSHOT
 or one of its dependencies could not be resolved:
 Could not find artifact org.xwiki.commons:xwiki-commons-tool-remote-resource-plugin:jar:17.6.0-SNAPSHOT
[WARNING] Failed to retrieve plugin descriptor for org.xwiki.commons:
xwiki-commons-tool-xar-plugin:17.6.0-SNAPSHOT: Plugin 
org.xwiki.commons:xwiki-commons-tool-xar-plugin:17.6.0-SNAPSHOT 
or one of its dependencies could not be resolved: 
Could not find artifact org.xwiki.commons:xwiki-commons-tool-xar-plugin:jar:17.6.0-SNAPSHOT
[INFO] 

```

and
```
Cloning into 'xwiki-rendering'...
remote: Enumerating objects: 132244, done.        
remote: Counting objects: 100% (109/109), done.        
remote: Compressing objects: 100% (104/104), done.        
remote: Total 132244 (delta 45), reused 57 (delta 2), pack-reused 132135 (from 1)        
Receiving objects: 100% (132244/132244), 14.95 MiB | 32.78 MiB/s, done.
Resolving deltas: 100% (58088/58088), done.
[INFO] Error stacktraces are turned on.
[INFO] Scanning for projects...
[ERROR] [ERROR] Some problems were encountered while processing the POMs:
[FATAL] Non-resolvable parent POM for
 org.xwiki.rendering:xwiki-rendering:17.6.0-SNAPSHOT: 
Could not find artifact org.xwiki.commons:xwiki-commons-pom:pom:17.5.0-SNAPSHOT
 and 'parent.relativePath' points at no local POM @ line 23, column 11
 @ 
[ERROR] Error executing a DevelocityListener callback
org.apache.maven.MavenExecutionException: Failed to evaluate custom user data Groovy script: /home/circleci/project/.ci-temp/xwiki-rendering/.mvn/develocity-custom-user-data.groovy
    at com.gradle.GroovyScriptUserData.evaluateGroovyScript (GroovyScriptUserData.java:43)
    at com.gradle.GroovyScriptUserData.evaluate (GroovyScriptUserData.java:18)
    at com.gradle.CommonCustomUserDataListener.configure (CommonCustomUserDataListener.java:32)
    at com.gradle.CommonCustomUserDataDevelocityListener.configure (CommonCustomUserDataDevelocityListener.java:13)
    at com.gradle.maven.internal.DevelocityLifecycleManager.a (SourceFile:400)
    at java.lang.Iterable.forEach (Iterable.java:75)
    at java.util.Collections$UnmodifiableCollection.forEach (Collections.java:1092)
    at com.gradle.maven.internal.DevelocityLifecycleManager.b (SourceFile:398)
    at com.gradle.maven.internal.DevelocityLifecycleManager.c (SourceFile:370)
    at java.util.stream.ForEachOps$ForEachOp$OfRef.accept (ForEachOps.java:183)
    at java.util.stream.ReferencePipeline$15$1.accept (ReferencePipeline.java:541)
    at java.util.stream.IntPipeline$1$1.accept (IntPipeline.java:180)
    at java.util.stream.Streams$RangeIntSpliterator.forEachRemaining (Streams.java:104)
    at java.util.Spliterator$OfInt.forEachRemaining (Spliterator.java:711)
    at java.util.stream.AbstractPipeline.copyInto (AbstractPipeline.java:509)
    at java.util.stream.AbstractPipeline.wrapAndCopyInto (AbstractPipeline.java:499)
    at java.util.stream.ForEachOps$ForEachOp.evaluateSequential (ForEachOps.java:150)
    at java.util.stream.ForEachOps$ForEachOp$OfRef.evaluateSequential (ForEachOps.java:173)
    at java.util.stream.AbstractPipeline.evaluate (AbstractPipeline.java:234)
    at java.util.stream.ReferencePipeline.forEach (ReferencePipeline.java:596)
    at com.gradle.maven.internal.DevelocityLifecycleManager.a (SourceFile:370)
    at com.gradle.maven.internal.DevelocityLifecycleManager.onEvent (SourceFile:313)
    at org.apache.maven.eventspy.internal.EventSpyDispatcher.onEvent (EventSpyDispatcher.java:104)
    at org.apache.maven.cli.MavenCli.execute (MavenCli.java:962)
    at org.apache.maven.cli.MavenCli.doMain (MavenCli.java:293)
    at org.apache.maven.cli.MavenCli.main (MavenCli.java:196)
    at jdk.internal.reflect.DirectMethodHandleAccessor.invoke (DirectMethodHandleAccessor.java:104)
    at java.lang.reflect.Method.invoke (Method.java:577)
    at org.codehaus.plexus.classworlds.launcher.Launcher.launchEnhanced (Launcher.java:282)
    at org.codehaus.plexus.classworlds.launcher.Launcher.launch (Launcher.java:225)
    at org.codehaus.plexus.classworlds.launcher.Launcher.mainWithExitCode (Launcher.java:406)
    at org.codehaus.plexus.classworlds.launcher.Launcher.main (Launcher.java:347)
Caused by: java.lang.NullPointerException: Cannot get property 'activeProfiles' on null object
    at org.codehaus.groovy.runtime.NullObject.getProperty (NullObject.java:92)
    at org.codehaus.groovy.vmplugin.v8.IndyInterface.fromCache (IndyInterface.java:321)
    at develocity-custom-user-data$_run_closure1.doCall (develocity-custom-user-data.groovy:29)
    at jdk.internal.reflect.DirectMethodHandleAccessor.invoke (DirectMethodHandleAccessor.java:104)
    at java.lang.reflect.Method.invoke (Method.java:577)
    at org.codehaus.groovy.reflection.CachedMethod.invoke (CachedMethod.java:343)
    at groovy.lang.MetaMethod.doMethodInvoke (MetaMethod.java:328)
    at org.codehaus.groovy.runtime.metaclass.ClosureMetaClass.invokeMethod (ClosureMetaClass.java:280)
    at groovy.lang.MetaClassImpl.invokeMethod (MetaClassImpl.java:1007)
    at groovy.lang.Closure.call (Closure.java:433)
    at org.codehaus.groovy.runtime.ConvertedClosure.invokeCustom (ConvertedClosure.java:52)
    at org.codehaus.groovy.runtime.ConversionHandler.invoke (ConversionHandler.java:113)
    at jdk.proxy1.$Proxy61.accept (Unknown Source)
    at com.gradle.develocity.agent.maven.adapters.develocity.DevelocityBuildScanApiAdapter.lambda$executeOnce$13 (DevelocityBuildScanApiAdapter.java:165)
    at com.gradle.develocity.agent.maven.scan.extension.internal.api.DefaultBuildScanApi.lambda$executeOnce$21 (SourceFile:258)
    at com.gradle.develocity.agent.maven.scan.extension.internal.api.DefaultBuildScanApi.ifNotBuildFinished (SourceFile:343)
    at com.gradle.develocity.agent.maven.scan.extension.internal.api.DefaultBuildScanApi.executeOnce (SourceFile:256)
    at com.gradle.develocity.agent.maven.adapters.develocity.DevelocityBuildScanApiAdapter.executeOnce (DevelocityBuildScanApiAdapter.java:165)
    at org.codehaus.groovy.vmplugin.v8.IndyInterface.fromCache (IndyInterface.java:321)
    at develocity-custom-user-data.run (develocity-custom-user-data.groovy:27)
    at groovy.lang.GroovyShell.evaluate (GroovyShell.java:460)
    at groovy.lang.GroovyShell.evaluate (GroovyShell.java:504)
    at com.gradle.GroovyScriptUserData.evaluateGroovyScript (GroovyScriptUserData.java:41)
    at com.gradle.GroovyScriptUserData.evaluate (GroovyScriptUserData.java:18)
    at com.gradle.CommonCustomUserDataListener.configure (CommonCustomUserDataListener.java:32)
    at com.gradle.CommonCustomUserDataDevelocityListener.configure (CommonCustomUserDataDevelocityListener.java:13)
    at com.gradle.maven.internal.DevelocityLifecycleManager.a (SourceFile:400)
    at java.lang.Iterable.forEach (Iterable.java:75)
    at java.util.Collections$UnmodifiableCollection.forEach (Collections.java:1092)
    at com.gradle.maven.internal.DevelocityLifecycleManager.b (SourceFile:398)
    at com.gradle.maven.internal.DevelocityLifecycleManager.c (SourceFile:370)
    at java.util.stream.ForEachOps$ForEachOp$OfRef.accept (ForEachOps.java:183)
    at java.util.stream.ReferencePipeline$15$1.accept (ReferencePipeline.java:541)
    at java.util.stream.IntPipeline$1$1.accept (IntPipeline.java:180)
    at java.util.stream.Streams$RangeIntSpliterator.forEachRemaining (Streams.java:104)
    at java.util.Spliterator$OfInt.forEachRemaining (Spliterator.java:711)
    at java.util.stream.AbstractPipeline.copyInto (AbstractPipeline.java:509)
    at java.util.stream.AbstractPipeline.wrapAndCopyInto (AbstractPipeline.java:499)
    at java.util.stream.ForEachOps$ForEachOp.evaluateSequential (ForEachOps.java:150)
    at java.util.stream.ForEachOps$ForEachOp$OfRef.evaluateSequential (ForEachOps.java:173)
    at java.util.stream.AbstractPipeline.evaluate (AbstractPipeline.java:234)
    at java.util.stream.ReferencePipeline.forEach (ReferencePipeline.java:596)
    at com.gradle.maven.internal.DevelocityLifecycleManager.a (SourceFile:370)
    at com.gradle.maven.internal.DevelocityLifecycleManager.onEvent (SourceFile:313)
    at org.apache.maven.eventspy.internal.EventSpyDispatcher.onEvent (EventSpyDispatcher.java:104)
    at org.apache.maven.cli.MavenCli.execute (MavenCli.java:962)
    at org.apache.maven.cli.MavenCli.doMain (MavenCli.java:293)
    at org.apache.maven.cli.MavenCli.main (MavenCli.java:196)
    at jdk.internal.reflect.DirectMethodHandleAccessor.invoke (DirectMethodHandleAccessor.java:104)
    at java.lang.reflect.Method.invoke (Method.java:577)
    at org.codehaus.plexus.classworlds.launcher.Launcher.launchEnhanced (Launcher.java:282)
    at org.codehaus.plexus.classworlds.launcher.Launcher.launch (Launcher.java:225)
    at org.codehaus.plexus.classworlds.launcher.Launcher.mainWithExitCode (Launcher.java:406)
    at org.codehaus.plexus.classworlds.launcher.Launcher.main (Launcher.java:347)
[INFO] 0 goals, 0 executed
[ERROR] The build could not read 1 project -> [Help 1]
org.apache.maven.project.ProjectBuildingException: Some problems were encountered while processing the POMs:
[FATAL] Non-resolvable parent POM for org.xwiki.rendering:xwiki-rendering:17.6.0-SNAPSHOT: Could not find artifact org.xwiki.commons:xwiki-commons-pom:pom:17.5.0-SNAPSHOT and 'parent.relativePath' points at no local POM @ line 23, column 11

    at org.apache.maven.project.DefaultProjectBuilder.build (DefaultProjectBuilder.java:397)
    at org.apache.maven.graph.DefaultGraphBuilder.collectProjects (DefaultGraphBuilder.java:414)
    at org.apache.maven.graph.DefaultGraphBuilder.getProjectsForMavenReactor (DefaultGraphBuilder.java:405)
    at org.apache.maven.graph.DefaultGraphBuilder.build (DefaultGraphBuilder.java:82)
    at org.apache.maven.DefaultMaven.buildGraph (DefaultMaven.java:532)
    at org.apache.maven.DefaultMaven.doExecute (DefaultMaven.java:219)
    at org.apache.maven.DefaultMaven.doExecute (DefaultMaven.java:192)
    at org.apache.maven.DefaultMaven.execute (DefaultMaven.java:105)
    at org.apache.maven.cli.MavenCli.execute (MavenCli.java:960)
    at org.apache.maven.cli.MavenCli.doMain (MavenCli.java:293)
    at org.apache.maven.cli.MavenCli.main (MavenCli.java:196)
    at jdk.internal.reflect.DirectMethodHandleAccessor.invoke (DirectMethodHandleAccessor.java:104)
    at java.lang.reflect.Method.invoke (Method.java:577)
    at org.codehaus.plexus.classworlds.launcher.Launcher.launchEnhanced (Launcher.java:282)
    at org.codehaus.plexus.classworlds.launcher.Launcher.launch (Launcher.java:225)
    at org.codehaus.plexus.classworlds.launcher.Launcher.mainWithExitCode (Launcher.java:406)
    at org.codehaus.plexus.classworlds.launcher.Launcher.main (Launcher.java:347)
[ERROR]   
[ERROR]   The project org.xwiki.rendering:xwiki-rendering:17.6.0-SNAPSHOT (/home/circleci/project/.ci-temp/xwiki-rendering/pom.xml) has 1 error
[ERROR]     Non-resolvable parent POM for org.xwiki.rendering:xwiki-rendering:17.6.0-SNAPSHOT: Could not find artifact org.xwiki.commons:xwiki-commons-pom:pom:17.5.0-SNAPSHOT and 'parent.relativePath' points at no local POM @ line 23, column 11 -> [Help 2]
org.apache.maven.model.resolution.UnresolvableModelException: Could not find artifact org.xwiki.commons:xwiki-commons-pom:pom:17.5.0-SNAPSHOT
    at org.apache.maven.project.ProjectModelResolver.resolveModel (ProjectModelResolver.java:196)
    at org.apache.maven.project.ProjectModelResolver.resolveModel (ProjectModelResolver.java:242)
    at org.apache.maven.model.building.DefaultModelBuilder.readParentExternally (DefaultModelBuilder.java:1150)
    at org.apache.maven.model.building.DefaultModelBuilder.readParent (DefaultModelBuilder.java:916)
    at org.apache.maven.model.building.DefaultModelBuilder.build (DefaultModelBuilder.java:361)
    at org.apache.maven.model.building.DefaultModelBuilder.build (DefaultModelBuilder.java:267)
    at org.apache.maven.project.DefaultProjectBuilder.build (DefaultProjectBuilder.java:448)
    at org.apache.maven.project.DefaultProjectBuilder.build (DefaultProjectBuilder.java:414)
    at org.apache.maven.project.DefaultProjectBuilder.build (DefaultProjectBuilder.java:377)
    at org.apache.maven.graph.DefaultGraphBuilder.collectProjects (DefaultGraphBuilder.java:414)
    at org.apache.maven.graph.DefaultGraphBuilder.getProjectsForMavenReactor (DefaultGraphBuilder.java:405)
    at org.apache.maven.graph.DefaultGraphBuilder.build (DefaultGraphBuilder.java:82)
    at org.apache.maven.DefaultMaven.buildGraph (DefaultMaven.java:532)
    at org.apache.maven.DefaultMaven.doExecute (DefaultMaven.java:219)
    at org.apache.maven.DefaultMaven.doExecute (DefaultMaven.java:192)
    at org.apache.maven.DefaultMaven.execute (DefaultMaven.java:105)
    at org.apache.maven.cli.MavenCli.execute (MavenCli.java:960)
    at org.apache.maven.cli.MavenCli.doMain (MavenCli.java:293)
    at org.apache.maven.cli.MavenCli.main (MavenCli.java:196)
    at jdk.internal.reflect.DirectMethodHandleAccessor.invoke (DirectMethodHandleAccessor.java:104)
    at java.lang.reflect.Method.invoke (Method.java:577)
    at org.codehaus.plexus.classworlds.launcher.Launcher.launchEnhanced (Launcher.java:282)
    at org.codehaus.plexus.classworlds.launcher.Launcher.launch (Launcher.java:225)
    at org.codehaus.plexus.classworlds.launcher.Launcher.mainWithExitCode (Launcher.java:406)
    at org.codehaus.plexus.classworlds.launcher.Launcher.main (Launcher.java:347)
Caused by: org.eclipse.aether.resolution.ArtifactResolutionException: Could not find artifact org.xwiki.commons:xwiki-commons-pom:pom:17.5.0-SNAPSHOT
    at org.eclipse.aether.internal.impl.DefaultArtifactResolver.resolve (DefaultArtifactResolver.java:425)
    at org.eclipse.aether.internal.impl.DefaultArtifactResolver.resolveArtifacts (DefaultArtifactResolver.java:229)
    at org.eclipse.aether.internal.impl.DefaultArtifactResolver.resolveArtifact (DefaultArtifactResolver.java:207)
    at org.eclipse.aether.internal.impl.DefaultRepositorySystem.resolveArtifact (DefaultRepositorySystem.java:262)
    at org.apache.maven.project.ProjectModelResolver.resolveModel (ProjectModelResolver.java:192)
    at org.apache.maven.project.ProjectModelResolver.resolveModel (ProjectModelResolver.java:242)
    at org.apache.maven.model.building.DefaultModelBuilder.readParentExternally (DefaultModelBuilder.java:1150)
    at org.apache.maven.model.building.DefaultModelBuilder.readParent (DefaultModelBuilder.java:916)
    at org.apache.maven.model.building.DefaultModelBuilder.build (DefaultModelBuilder.java:361)
    at org.apache.maven.model.building.DefaultModelBuilder.build (DefaultModelBuilder.java:267)
    at org.apache.maven.project.DefaultProjectBuilder.build (DefaultProjectBuilder.java:448)
    at org.apache.maven.project.DefaultProjectBuilder.build (DefaultProjectBuilder.java:414)
    at org.apache.maven.project.DefaultProjectBuilder.build (DefaultProjectBuilder.java:377)
    at org.apache.maven.graph.DefaultGraphBuilder.collectProjects (DefaultGraphBuilder.java:414)
    at org.apache.maven.graph.DefaultGraphBuilder.getProjectsForMavenReactor (DefaultGraphBuilder.java:405)
    at org.apache.maven.graph.DefaultGraphBuilder.build (DefaultGraphBuilder.java:82)
    at org.apache.maven.DefaultMaven.buildGraph (DefaultMaven.java:532)
    at org.apache.maven.DefaultMaven.doExecute (DefaultMaven.java:219)
    at org.apache.maven.DefaultMaven.doExecute (DefaultMaven.java:192)
    at org.apache.maven.DefaultMaven.execute (DefaultMaven.java:105)
    at org.apache.maven.cli.MavenCli.execute (MavenCli.java:960)
    at org.apache.maven.cli.MavenCli.doMain (MavenCli.java:293)
    at org.apache.maven.cli.MavenCli.main (MavenCli.java:196)
    at jdk.internal.reflect.DirectMethodHandleAccessor.invoke (DirectMethodHandleAccessor.java:104)
    at java.lang.reflect.Method.invoke (Method.java:577)
    at org.codehaus.plexus.classworlds.launcher.Launcher.launchEnhanced (Launcher.java:282)
    at org.codehaus.plexus.classworlds.launcher.Launcher.launch (Launcher.java:225)
    at org.codehaus.plexus.classworlds.launcher.Launcher.mainWithExitCode (Launcher.java:406)
    at org.codehaus.plexus.classworlds.launcher.Launcher.main (Launcher.java:347)
Caused by: org.eclipse.aether.transfer.ArtifactNotFoundException: Could not find artifact org.xwiki.commons:xwiki-commons-pom:pom:17.5.0-SNAPSHOT
    at org.eclipse.aether.internal.impl.DefaultArtifactResolver.resolve (DefaultArtifactResolver.java:415)
    at org.eclipse.aether.internal.impl.DefaultArtifactResolver.resolveArtifacts (DefaultArtifactResolver.java:229)
    at org.eclipse.aether.internal.impl.DefaultArtifactResolver.resolveArtifact (DefaultArtifactResolver.java:207)
    at org.eclipse.aether.internal.impl.DefaultRepositorySystem.resolveArtifact (DefaultRepositorySystem.java:262)
    at org.apache.maven.project.ProjectModelResolver.resolveModel (ProjectModelResolver.java:192)
    at org.apache.maven.project.ProjectModelResolver.resolveModel (ProjectModelResolver.java:242)
    at org.apache.maven.model.building.DefaultModelBuilder.readParentExternally (DefaultModelBuilder.java:1150)
    at org.apache.maven.model.building.DefaultModelBuilder.readParent (DefaultModelBuilder.java:916)
    at org.apache.maven.model.building.DefaultModelBuilder.build (DefaultModelBuilder.java:361)
    at org.apache.maven.model.building.DefaultModelBuilder.build (DefaultModelBuilder.java:267)
    at org.apache.maven.project.DefaultProjectBuilder.build (DefaultProjectBuilder.java:448)
    at org.apache.maven.project.DefaultProjectBuilder.build (DefaultProjectBuilder.java:414)
    at org.apache.maven.project.DefaultProjectBuilder.build (DefaultProjectBuilder.java:377)
    at org.apache.maven.graph.DefaultGraphBuilder.collectProjects (DefaultGraphBuilder.java:414)
    at org.apache.maven.graph.DefaultGraphBuilder.getProjectsForMavenReactor (DefaultGraphBuilder.java:405)
    at org.apache.maven.graph.DefaultGraphBuilder.build (DefaultGraphBuilder.java:82)
    at org.apache.maven.DefaultMaven.buildGraph (DefaultMaven.java:532)
    at org.apache.maven.DefaultMaven.doExecute (DefaultMaven.java:219)
    at org.apache.maven.DefaultMaven.doExecute (DefaultMaven.java:192)
    at org.apache.maven.DefaultMaven.execute (DefaultMaven.java:105)
    at org.apache.maven.cli.MavenCli.execute (MavenCli.java:960)
    at org.apache.maven.cli.MavenCli.doMain (MavenCli.java:293)
    at org.apache.maven.cli.MavenCli.main (MavenCli.java:196)
    at jdk.internal.reflect.DirectMethodHandleAccessor.invoke (DirectMethodHandleAccessor.java:104)
    at java.lang.reflect.Method.invoke (Method.java:577)
    at org.codehaus.plexus.classworlds.launcher.Launcher.launchEnhanced (Launcher.java:282)
    at org.codehaus.plexus.classworlds.launcher.Launcher.launch (Launcher.java:225)
    at org.codehaus.plexus.classworlds.launcher.Launcher.mainWithExitCode (Launcher.java:406)
    at org.codehaus.plexus.classworlds.launcher.Launcher.main (Launcher.java:347)
[ERROR] 
[ERROR] Re-run Maven using the -X switch to enable full debug logging.
[ERROR] 
[ERROR] For more information about the errors and possible solutions, please read the following articles:
[ERROR] [Help 1] http://cwiki.apache.org/confluence/display/MAVEN/ProjectBuildingException
[ERROR] [Help 2] http://cwiki.apache.org/confluence/display/MAVEN/UnresolvableModelException

Exited with code exit status 1
```