### PR TITLE
Issue #17168: Fix inspection for private methods used from inner class

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/ConfigurationLoader.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/ConfigurationLoader.java
@@ -322,133 +322,6 @@ public final class ConfigurationLoader {
     }
 
     /**
-     * Replaces {@code ${xxx}} style constructions in the given value
-     * with the string value of the corresponding data types. This method must remain
-     * outside inner class for easier testing since inner class requires an instance.
-     *
-     * <p>Code copied from
-     * <a href="https://github.com/apache/ant/blob/master/src/main/org/apache/tools/ant/ProjectHelper.java">
-     * ant
-     * </a>
-     *
-     * @param value The string to be scanned for property references. Must
-     *              not be {@code null}.
-     * @param props Mapping (String to String) of property names to their
-     *              values. Must not be {@code null}.
-     * @param defaultValue default to use if one of the properties in value
-     *              cannot be resolved from props.
-     *
-     * @return the original string with the properties replaced.
-     * @throws CheckstyleException if the string contains an opening
-     *                           {@code ${} without a closing
-     *                           {@code }}
-     */
-    private static String replaceProperties(
-            String value, PropertyResolver props, String defaultValue)
-            throws CheckstyleException {
-
-        final List<String> fragments = new ArrayList<>();
-        final List<String> propertyRefs = new ArrayList<>();
-        parsePropertyString(value, fragments, propertyRefs);
-
-        final StringBuilder sb = new StringBuilder(256);
-        final Iterator<String> fragmentsIterator = fragments.iterator();
-        final Iterator<String> propertyRefsIterator = propertyRefs.iterator();
-        while (fragmentsIterator.hasNext()) {
-            String fragment = fragmentsIterator.next();
-            if (fragment == null) {
-                final String propertyName = propertyRefsIterator.next();
-                fragment = props.resolve(propertyName);
-                if (fragment == null) {
-                    if (defaultValue != null) {
-                        sb.replace(0, sb.length(), defaultValue);
-                        break;
-                    }
-                    throw new CheckstyleException(
-                        "Property ${" + propertyName + "} has not been set");
-                }
-            }
-            sb.append(fragment);
-        }
-
-        return sb.toString();
-    }
-
-    /**
-     * Parses a string containing {@code ${xxx}} style property
-     * references into two collections. The first one is a collection
-     * of text fragments, while the other is a set of string property names.
-     * {@code null} entries in the first collection indicate a property
-     * reference from the second collection.
-     *
-     * <p>Code copied from
-     * <a href="https://github.com/apache/ant/blob/master/src/main/org/apache/tools/ant/ProjectHelper.java">
-     * ant
-     * </a>
-     *
-     * @param value     Text to parse. Must not be {@code null}.
-     * @param fragments Collection to add text fragments to.
-     *                  Must not be {@code null}.
-     * @param propertyRefs Collection to add property names to.
-     *                     Must not be {@code null}.
-     *
-     * @throws CheckstyleException if the string contains an opening
-     *                           {@code ${} without a closing
-     *                           {@code }}
-     */
-    private static void parsePropertyString(String value,
-                                           Collection<String> fragments,
-                                           Collection<String> propertyRefs)
-            throws CheckstyleException {
-        int prev = 0;
-        // search for the next instance of $ from the 'prev' position
-        int pos = value.indexOf(DOLLAR_SIGN, prev);
-        while (pos >= 0) {
-            // if there was any text before this, add it as a fragment
-            if (pos > 0) {
-                fragments.add(value.substring(prev, pos));
-            }
-            // if we are at the end of the string, we tack on a $
-            // then move past it
-            if (pos == value.length() - 1) {
-                fragments.add(DOLLAR_SIGN_STRING);
-                prev = pos + 1;
-            }
-            else if (value.charAt(pos + 1) == '{') {
-                // property found, extract its name or bail on a typo
-                final int endName = value.indexOf('}', pos);
-                if (endName == -1) {
-                    throw new CheckstyleException("Syntax error in property: "
-                                                    + value);
-                }
-                final String propertyName = value.substring(pos + 2, endName);
-                fragments.add(null);
-                propertyRefs.add(propertyName);
-                prev = endName + 1;
-            }
-            else {
-                if (value.charAt(pos + 1) == DOLLAR_SIGN) {
-                    // backwards compatibility two $ map to one mode
-                    fragments.add(DOLLAR_SIGN_STRING);
-                }
-                else {
-                    // new behaviour: $X maps to $X for all values of X!='$'
-                    fragments.add(value.substring(pos, pos + 2));
-                }
-                prev = pos + 2;
-            }
-
-            // search for the next instance of $ from the 'prev' position
-            pos = value.indexOf(DOLLAR_SIGN, prev);
-        }
-        // no more $ signs found
-        // if there is any tail to the file, append it
-        if (prev < value.length()) {
-            fragments.add(value.substring(prev));
-        }
-    }
-
-    /**
      * Implements the SAX document handler interfaces, so they do not
      * appear in the public API of the ConfigurationLoader.
      */
@@ -491,6 +364,130 @@ public final class ConfigurationLoader {
             super(createIdToResourceNameMap());
         }
 
+        /**
+         * Replaces {@code ${xxx}} style constructions in the given value
+         * with the string value of the corresponding data types.
+         *
+         * <p>Code copied from
+         * <a href="https://github.com/apache/ant/blob/master/src/main/org/apache/tools/ant/ProjectHelper.java">
+         * ant
+         * </a>
+         *
+         * @param value The string to be scanned for property references. Must
+         *              not be {@code null}.
+         * @param defaultValue default to use if one of the properties in value
+         *              cannot be resolved from props.
+         *
+         * @return the original string with the properties replaced.
+         * @throws CheckstyleException if the string contains an opening
+         *                           {@code ${} without a closing
+         *                           {@code }}
+         */
+        private String replaceProperties(
+                String value, String defaultValue)
+                throws CheckstyleException {
+
+            final List<String> fragments = new ArrayList<>();
+            final List<String> propertyRefs = new ArrayList<>();
+            parsePropertyString(value, fragments, propertyRefs);
+
+            final StringBuilder sb = new StringBuilder(256);
+            final Iterator<String> fragmentsIterator = fragments.iterator();
+            final Iterator<String> propertyRefsIterator = propertyRefs.iterator();
+            while (fragmentsIterator.hasNext()) {
+                String fragment = fragmentsIterator.next();
+                if (fragment == null) {
+                    final String propertyName = propertyRefsIterator.next();
+                    fragment = overridePropsResolver.resolve(propertyName);
+                    if (fragment == null) {
+                        if (defaultValue != null) {
+                            sb.replace(0, sb.length(), defaultValue);
+                            break;
+                        }
+                        throw new CheckstyleException(
+                            "Property ${" + propertyName + "} has not been set");
+                    }
+                }
+                sb.append(fragment);
+            }
+
+            return sb.toString();
+        }
+
+        /**
+         * Parses a string containing {@code ${xxx}} style property
+         * references into two collections. The first one is a collection
+         * of text fragments, while the other is a set of string property names.
+         * {@code null} entries in the first collection indicate a property
+         * reference from the second collection.
+         *
+         * <p>Code copied from
+         * <a href="https://github.com/apache/ant/blob/master/src/main/org/apache/tools/ant/ProjectHelper.java">
+         * ant
+         * </a>
+         *
+         * @param value     Text to parse. Must not be {@code null}.
+         * @param fragments Collection to add text fragments to.
+         *                  Must not be {@code null}.
+         * @param propertyRefs Collection to add property names to.
+         *                     Must not be {@code null}.
+         *
+         * @throws CheckstyleException if the string contains an opening
+         *                           {@code ${} without a closing
+         *                           {@code }}
+         */
+        private void parsePropertyString(String value,
+                                               Collection<String> fragments,
+                                               Collection<String> propertyRefs)
+                throws CheckstyleException {
+            int prev = 0;
+            // search for the next instance of $ from the 'prev' position
+            int pos = value.indexOf(DOLLAR_SIGN, prev);
+            while (pos >= 0) {
+                // if there was any text before this, add it as a fragment
+                if (pos > 0) {
+                    fragments.add(value.substring(prev, pos));
+                }
+                // if we are at the end of the string, we tack on a $
+                // then move past it
+                if (pos == value.length() - 1) {
+                    fragments.add(DOLLAR_SIGN_STRING);
+                    prev = pos + 1;
+                }
+                else if (value.charAt(pos + 1) == '{') {
+                    // property found, extract its name or bail on a typo
+                    final int endName = value.indexOf('}', pos);
+                    if (endName == -1) {
+                        throw new CheckstyleException("Syntax error in property: "
+                                                        + value);
+                    }
+                    final String propertyName = value.substring(pos + 2, endName);
+                    fragments.add(null);
+                    propertyRefs.add(propertyName);
+                    prev = endName + 1;
+                }
+                else {
+                    if (value.charAt(pos + 1) == DOLLAR_SIGN) {
+                        // backwards compatibility two $ map to one mode
+                        fragments.add(DOLLAR_SIGN_STRING);
+                    }
+                    else {
+                        // new behaviour: $X maps to $X for all values of X!='$'
+                        fragments.add(value.substring(pos, pos + 2));
+                    }
+                    prev = pos + 2;
+                }
+
+                // search for the next instance of $ from the 'prev' position
+                pos = value.indexOf(DOLLAR_SIGN, prev);
+            }
+            // no more $ signs found
+            // if there is any tail to the file, append it
+            if (prev < value.length()) {
+                fragments.add(value.substring(prev));
+            }
+        }
+
         @Override
         public void startElement(String uri,
                                  String localName,
@@ -523,8 +520,7 @@ public final class ConfigurationLoader {
 
                 final String value;
                 try {
-                    value = replaceProperties(attributesValue,
-                        overridePropsResolver, attributes.getValue(DEFAULT));
+                    value = replaceProperties(attributesValue, attributes.getValue(DEFAULT));
                 }
                 catch (final CheckstyleException exc) {
                     // -@cs[IllegalInstantiation] SAXException is in the overridden


### PR DESCRIPTION
part of : #17168
From comment : https://github.com/checkstyle/checkstyle/pull/17259#issuecomment-3019192404

Need for this changes : Inspection error :
[home/circleci/project/target/inspection-results/MethodOnlyUsedFromInnerClass.xml](https://output.circle-artifacts.com/output/job/355610cc-e057-4d11-a6ae-6c9ec5da37cd/artifacts/0/home/circleci/project/target/inspection-results/MethodOnlyUsedFromInnerClass.xml)

```

<problems is_local_tool="true">
<problem>
<file>file://$PROJECT_DIR$/src/main/java/com/puppycrawl/tools/checkstyle/ConfigurationLoader.java</file>
<line>346</line>
<module>project</module>
<package>com.puppycrawl.tools.checkstyle</package>
<entry_point TYPE="method" FQNAME="com.puppycrawl.tools.checkstyle.ConfigurationLoader java.lang.String replaceProperties(java.lang.String value, com.puppycrawl.tools.checkstyle.PropertyResolver props, java.lang.String defaultValue)"/>
<problem_class id="MethodOnlyUsedFromInnerClass" severity="ERROR" attribute_key="ERRORS_ATTRIBUTES">Private method only used from inner class</problem_class>
<description>Method <code>replaceProperties()</code>#loc is only used from inner class 'InternalLoader' #loc</description>
<highlighted_element>replaceProperties</highlighted_element>
<language>JAVA</language>
<offset>26</offset>
<length>17</length>
</problem>
<problem>
<file>file://$PROJECT_DIR$/src/main/java/com/puppycrawl/tools/checkstyle/ConfigurationLoader.java</file>
<line>169</line>
<module>project</module>
<package>com.puppycrawl.tools.checkstyle</package>
<entry_point TYPE="method" FQNAME="com.puppycrawl.tools.checkstyle.ConfigurationLoader java.util.Map<java.lang.String,java.lang.String> createIdToResourceNameMap()"/>
<problem_class id="MethodOnlyUsedFromInnerClass" severity="ERROR" attribute_key="ERRORS_ATTRIBUTES">Private method only used from inner class</problem_class>
<description>Method <code>createIdToResourceNameMap()</code>#loc is only used from inner class 'InternalLoader' #loc</description>
<highlighted_element>createIdToResourceNameMap</highlighted_element>
<language>JAVA</language>
<offset>39</offset>
<length>25</length>
</problem>
</problems>
```

### Changes I have done ConfigurationLoader.java :
1)Relocated replaceProperties() and parsePropertyString() from outer class to InternalLoader
2) Adjusted the method calls to use ConfigurationLoader.this.overridePropsResolver directly
3)Addressed PMD violation:
Added /* default access */ comment to createIdToResourceNameMap() [ suggested in warning on local]

Now since we have made changes in the config loader, corresponding tests should also be modified:

- I read about reflection based testing and tried to implement the same for the above , so I added helper methods to access inner class via reflection.
- then I reimplemented the test cases via reflection helpers , so that we don't have any coverage Issue.