### PR TITLE
Issue #17168: Remove Jdk11 Site Validation Job

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -311,9 +311,5 @@ workflows:
     jobs:
       - validate-with-maven-script:
           name: "jdk17-package-site"
-          image-name: "cimg/openjdk:17.0.7"
-          command: "./.ci/validation.sh package-site"
-      - validate-with-maven-script:
-          name: "jdk11-package-site"
           image-name: *cs_img
           command: "./.ci/validation.sh package-site"


### PR DESCRIPTION
part of : #17168
Redundant Job, since anchor image is already update to jdk 17 and we already have a package site validation for jdk17.