### PR TITLE
Issue #17362: Corrected the usages of html entities in the javadoc

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/api/JavadocTokenTypes.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/api/JavadocTokenTypes.java
@@ -690,19 +690,19 @@ public final class JavadocTokenTypes {
      * <b>Tree:</b>
      * <pre>
      * {@code
-     * JAVADOC_TAG -&gt JAVADOC_TAG
-     *  |--SEE_LITERAL -&gt @see
-     *  |--WS -&gt
-     *  |--REFERENCE -&gt REFERENCE
-     *  |   |--PACKAGE_CLASS -&gt org.apache.utils.Lists.Comparator
-     *  |   |--HASH -&gt #
-     *  |   |--MEMBER -&gt compare
-     *  |   `--PARAMETERS -&gt PARAMETERS
-     *  |       |--LEFT_BRACE -&gt (
-     *  |       |--ARGUMENT -&gt Object
-     *  |       `--RIGHT_BRACE -&gt )
-     *  |--NEWLINE -&gt \r\n
-     *  `--WS -&gt
+     * JAVADOC_TAG -> JAVADOC_TAG
+     *  |--SEE_LITERAL -> @see
+     *  |--WS ->
+     *  |--REFERENCE -> REFERENCE
+     *  |   |--PACKAGE_CLASS -> org.apache.utils.Lists.Comparator
+     *  |   |--HASH -> #
+     *  |   |--MEMBER -> compare
+     *  |   `--PARAMETERS -> PARAMETERS
+     *  |       |--LEFT_BRACE -> (
+     *  |       |--ARGUMENT -> Object
+     *  |       `--RIGHT_BRACE -> )
+     *  |--NEWLINE -> \r\n
+     *  `--WS ->
      * }
      * </pre>
      */
@@ -717,17 +717,17 @@ public final class JavadocTokenTypes {
      * <b>Tree:</b>
      * <pre>
      * {@code
-     * JAVADOC_TAG -&gt JAVADOC_TAG
-     *  |--SEE_LITERAL -&gt @see
-     *  |--WS -&gt
-     *  |--REFERENCE -&gt REFERENCE
-     *      |--PACKAGE_CLASS -&gt org.apache.utils.Lists.Comparator
-     *      |--HASH -&gt #
-     *      |--MEMBER -&gt compare
-     *      `--PARAMETERS -&gt PARAMETERS
-     *          |--LEFT_BRACE -&gt (
-     *          |--ARGUMENT -&gt Object
-     *          `--RIGHT_BRACE -&gt )
+     * JAVADOC_TAG -> JAVADOC_TAG
+     *  |--SEE_LITERAL -> @see
+     *  |--WS ->
+     *  |--REFERENCE -> REFERENCE
+     *      |--PACKAGE_CLASS -> org.apache.utils.Lists.Comparator
+     *      |--HASH -> #
+     *      |--MEMBER -> compare
+     *      `--PARAMETERS -> PARAMETERS
+     *          |--LEFT_BRACE -> (
+     *          |--ARGUMENT -> Object
+     *          `--RIGHT_BRACE -> )
      * }
      * </pre>
      */
@@ -765,19 +765,19 @@ public final class JavadocTokenTypes {
      * <pre>{@code @see #method(Processor, String)}</pre>
      * <b>Tree:</b>
      * <pre>
-     * {@code JAVADOC_TAG -&gt JAVADOC_TAG
-     *         |--SEE_LITERAL -&gt @see
-     *         |--WS -&gt
-     *         |--REFERENCE -&gt REFERENCE
-     *         |   |--HASH -&gt #
-     *         |   |--MEMBER -&gt method
-     *         |   `--PARAMETERS -&gt PARAMETERS
-     *         |       |--LEFT_BRACE -&gt (
-     *         |       |--ARGUMENT -&gt Processor
-     *         |       |--COMMA -&gt ,
-     *         |       |--WS -&gt
-     *         |       |--ARGUMENT -&gt String
-     *         |       `--RIGHT_BRACE -&gt )
+     * {@code JAVADOC_TAG -> JAVADOC_TAG
+     *         |--SEE_LITERAL -> @see
+     *         |--WS ->
+     *         |--REFERENCE -> REFERENCE
+     *         |   |--HASH -> #
+     *         |   |--MEMBER -> method
+     *         |   `--PARAMETERS -> PARAMETERS
+     *         |       |--LEFT_BRACE -> (
+     *         |       |--ARGUMENT -> Processor
+     *         |       |--COMMA -> ,
+     *         |       |--WS ->
+     *         |       |--ARGUMENT -> String
+     *         |       `--RIGHT_BRACE -> )
      * }
      * </pre>
      */
@@ -790,19 +790,19 @@ public final class JavadocTokenTypes {
      * <pre>{@code @see #method(Processor, String)}</pre>
      * <b>Tree:</b>
      * <pre>
-     * {@code JAVADOC_TAG -&gt JAVADOC_TAG
-     *         |--SEE_LITERAL -&gt @see
-     *         |--WS -&gt
-     *         |--REFERENCE -&gt REFERENCE
-     *         |   |--HASH -&gt #
-     *         |   |--MEMBER -&gt method
-     *         |   `--PARAMETERS -&gt PARAMETERS
-     *         |       |--LEFT_BRACE -&gt (
-     *         |       |--ARGUMENT -&gt Processor
-     *         |       |--COMMA -&gt ,
-     *         |       |--WS -&gt
-     *         |       |--ARGUMENT -&gt String
-     *         |       `--RIGHT_BRACE -&gt )
+     * {@code JAVADOC_TAG -> JAVADOC_TAG
+     *         |--SEE_LITERAL -> @see
+     *         |--WS ->
+     *         |--REFERENCE -> REFERENCE
+     *         |   |--HASH -> #
+     *         |   |--MEMBER -> method
+     *         |   `--PARAMETERS -> PARAMETERS
+     *         |       |--LEFT_BRACE -> (
+     *         |       |--ARGUMENT -> Processor
+     *         |       |--COMMA -> ,
+     *         |       |--WS ->
+     *         |       |--ARGUMENT -> String
+     *         |       `--RIGHT_BRACE -> )
      * }
      * </pre>
      */
@@ -815,20 +815,20 @@ public final class JavadocTokenTypes {
      * <pre>{@code @see #method(Processor, String)}</pre>
      * <b>Tree:</b>
      * <pre>
-     * {@code JAVADOC_TAG -&gt JAVADOC_TAG
-     *         |--SEE_LITERAL -&gt @see
-     *         |--WS -&gt
-     *         |--REFERENCE -&gt REFERENCE
-     *         |   |--HASH -&gt #
-     *         |   |--MEMBER -&gt method
-     *         |   `--PARAMETERS -&gt PARAMETERS
-     *         |       |--LEFT_BRACE -&gt (
-     *         |       |--ARGUMENT -&gt Processor
-     *         |       |--COMMA -&gt ,
-     *         |       |--WS -&gt
-     *         |       |--ARGUMENT -&gt String
-     *         |       `--RIGHT_BRACE -&gt )
-     *         `--NEWLINE -&gt \n
+     * {@code JAVADOC_TAG -> JAVADOC_TAG
+     *         |--SEE_LITERAL -> @see
+     *         |--WS ->
+     *         |--REFERENCE -> REFERENCE
+     *         |   |--HASH -> #
+     *         |   |--MEMBER -> method
+     *         |   `--PARAMETERS -> PARAMETERS
+     *         |       |--LEFT_BRACE -> (
+     *         |       |--ARGUMENT -> Processor
+     *         |       |--COMMA -> ,
+     *         |       |--WS ->
+     *         |       |--ARGUMENT -> String
+     *         |       `--RIGHT_BRACE -> )
+     *         `--NEWLINE -> \n
      * }
      * </pre>
      */
@@ -842,21 +842,21 @@ public final class JavadocTokenTypes {
      * <b>Tree:</b>
      * <pre>
      * {@code
-     * JAVADOC_TAG -&gt JAVADOC_TAG
-     *  |--SEE_LITERAL -&gt @see
-     *  |--WS -&gt
-     *  |--REFERENCE -&gt REFERENCE
-     *  |   |--HASH -&gt #
-     *  |   |--MEMBER -&gt method
-     *  |   `--PARAMETERS -&gt PARAMETERS
-     *  |       |--LEFT_BRACE -&gt (
-     *  |       |--ARGUMENT -&gt Processor
-     *  |       |--COMMA -&gt ,
-     *  |       |--WS -&gt
-     *  |       |--ARGUMENT -&gt String
-     *  |       `--RIGHT_BRACE -&gt )
-     *  |--NEWLINE -&gt \r\n
-     *  `--WS -&gt
+     * JAVADOC_TAG -> JAVADOC_TAG
+     *  |--SEE_LITERAL -> @see
+     *  |--WS ->
+     *  |--REFERENCE -> REFERENCE
+     *  |   |--HASH -> #
+     *  |   |--MEMBER -> method
+     *  |   `--PARAMETERS -> PARAMETERS
+     *  |       |--LEFT_BRACE -> (
+     *  |       |--ARGUMENT -> Processor
+     *  |       |--COMMA -> ,
+     *  |       |--WS ->
+     *  |       |--ARGUMENT -> String
+     *  |       `--RIGHT_BRACE -> )
+     *  |--NEWLINE -> \r\n
+     *  `--WS ->
      * }
      * </pre>
      *
@@ -1089,9 +1089,9 @@ public final class JavadocTokenTypes {
      *
      * <p><b>Example:</b></p>
      *
-     * <pre>{@code
+     * <pre>
      * &lt;tag_name attr_name="attr_value">Content&lt;/tag_name&gt;
-     * }</pre>
+     * </pre>
      *
      * <p><b>Tree:</b></p>
      * <pre>{@code
@@ -1358,11 +1358,11 @@ public final class JavadocTokenTypes {
      * Body tag name.
      *
      *  <p><b>Example:</b></p>
-     *  <pre>{@code
+     *  <pre>
      *  &lt;body&gt;
      *     &lt;p&gt;Body Content&lt;/p&gt;
      *  &lt;/body&gt;
-     *  }</pre>
+     *  </pre>
      *  <b>Tree:</b>
      *  <pre>
      *  {@code
@@ -1558,12 +1558,12 @@ public final class JavadocTokenTypes {
      * Head tag name.
      *
      * <p><b>Example:</b></p>
-     * <pre>{@code
+     * <pre>
      * &lt;head&gt;
      *   &lt;title&gt;Page Title&lt;/title&gt;
      *   &lt;meta charset="UTF-8"&gt;
      * &lt;/head&gt;
-     * }</pre>
+     * </pre>
      * <b>Tree:</b>
      * <pre>{@code
      *  HEAD -> HEAD
@@ -1620,7 +1620,7 @@ public final class JavadocTokenTypes {
      * Option tag name.
      *
      * <p><b>Example:</b></p>
-     * <pre>{@code &lt;option value="yes"&gt;Yes&lt;/option&gt;}</pre>
+     * <pre>&lt;option value="yes"&gt;Yes&lt;/option&gt;</pre>
      * <b>Tree:</b>
      * <pre>
      * {@code
@@ -1834,7 +1834,7 @@ public final class JavadocTokenTypes {
      * Area tag name.
      *
      * <p><b>Example:</b></p>
-     * <pre>{@code &lt area shape="rect" &gt}</pre>
+     * <pre>{@code < area shape="rect" >}</pre>
      * <b>Tree:</b>
      * <pre>
      * {@code
@@ -2029,7 +2029,7 @@ public final class JavadocTokenTypes {
      *  Meta tag name.
      *
      *   <p><b>Example:</b></p>
-     *   <pre>{@code &lt;meta charset="UTF-8"&gt;}</pre>
+     *   <pre>{@code <meta charset="UTF-8">}</pre>
      *   <b>Tree:</b>
      *   <pre>
      *   {@code
@@ -2068,10 +2068,10 @@ public final class JavadocTokenTypes {
      *
      * <p><b>Example:</b></p>
      * <pre>{@code
-     * &lt;!--
+     * <!--
      * This is an HTML multi-line comment:
      * This is another comment
-     * --&gt;
+     * -->
      * }</pre>
      * <b>Tree:</b>
      * <pre>
@@ -2098,10 +2098,10 @@ public final class JavadocTokenTypes {
      *
      * <p><b>Example:</b></p>
      * <pre>{@code
-     * &lt;!--
+     * <!--
      * This is an HTML multi-line comment:
      * This is another comment
-     * --&gt;
+     * -->
      * }</pre>
      * <b>Tree:</b>
      * <pre>
@@ -2583,11 +2583,11 @@ public final class JavadocTokenTypes {
      * Start body tag.
      *
      * <p><b>Example:</b></p>
-     * <pre>{@code
+     * <pre>
      * &lt;body&gt;
      * This is a test
      * &lt;/body&gt;
-     * }</pre>
+     * </pre>
      * <b>Tree:</b>
      * <pre>
      * {@code
@@ -2630,11 +2630,11 @@ public final class JavadocTokenTypes {
      * End body tag.
      *
      * <p><b>Example:</b></p>
-     * <pre>{@code
+     * <pre>
      *  &lt;body&gt;
      *     This is a test
      * &lt;/body&gt;
-     * }</pre>
+     * </pre>
      * <b>Tree:</b>
      * <pre>
      * {@code
@@ -2943,13 +2943,13 @@ public final class JavadocTokenTypes {
      *
      * <p><b>AST Tree:</b></p>
      * <pre>{@code
-     * --HTML_ELEMENT -&gt; HTML_ELEMENT
-     *   `--SINGLETON_ELEMENT -&gt; SINGLETON_ELEMENT
-     *     `--EMPTY_TAG -&gt; EMPTY_TAG
-     *       |--START -&gt; &lt;
-     *       |--HTML_TAG_NAME -&gt; justsometag
+     * --HTML_ELEMENT -> HTML_ELEMENT
+     *   `--SINGLETON_ELEMENT -> SINGLETON_ELEMENT
+     *     `--EMPTY_TAG -> EMPTY_TAG
+     *       |--START -> <
+     *       |--HTML_TAG_NAME -> justsometag
      *       |--WS
-     *       `--SLASH_END -&gt; /&gt;
+     *       `--SLASH_END -> >
      * }</pre>
      */
     public static final int EMPTY_TAG =
@@ -2959,7 +2959,7 @@ public final class JavadocTokenTypes {
      * Area html tag.
      *
      * <p><b>Example:</b></p>
-     * <pre>{@code &lt area shape="rect" &gt}</pre>
+     * <pre>{@code < area shape="rect" >}</pre>
      * <b>Tree:</b>
      * <pre>
      * {@code
@@ -3029,9 +3029,11 @@ public final class JavadocTokenTypes {
      * Frame html tag.
      *
      * <p><b>Example:</b></p>
-     * <pre>{@code &lt;frameset cols="50%,50%"&gt;
+     * <pre>
+     * &lt;frameset cols="50%,50%"&gt;
      * &lt;frame src="page1.html"&gt;
-     * &lt;/frameset&gt;}</pre>
+     * &lt;/frameset&gt;
+     * </pre>
      * <b>Tree:</b>
      * <pre>
      * {@code
@@ -3186,11 +3188,11 @@ public final class JavadocTokenTypes {
      * Isindex tag name.
      *
      * <p><b>Example:</b></p>
-     * <pre>{@code
+     * <pre>
      * &lt;head&gt;
      *    &lt;isindex prompt="search"&gt;
      * &lt;/head&gt;
-     * }</pre>
+     * </pre>
      * <b>Tree:</b>
      * <pre>
      * {@code


### PR DESCRIPTION
Issue #17362
corrected the usage of HTML entities ` &gt; ` and ` &lt;` in the javadoc of 
https://github.com/checkstyle/checkstyle/blob/master/src/main/java/com/puppycrawl/tools/checkstyle/api/JavadocTokenTypes.java

