### PR TITLE
Issue #16738: Update SuppressWithNearbyTextFilterExamplesTest to use verifyFilterWithInlineConfigParser

### DIFF
--- a/src/site/xdoc/filters/suppresswithnearbytextfilter.xml
+++ b/src/site/xdoc/filters/suppresswithnearbytextfilter.xml
@@ -88,6 +88,7 @@
         </p>
         <div class="wrapper"><pre class="prettyprint"><code class="language-java">
 public class Example1 {
+  // filtered violation below ''24' is a magic number'
   int hoursInDay = 24; // SUPPRESS CHECKSTYLE because it is too obvious
   int daysInWeek = 7; // violation, "'7' is a magic number."
 }
@@ -111,6 +112,7 @@ public class Example1 {
         </p>
         <div class="wrapper"><pre class="prettyprint"><code class="language-java">
 public class Example2 {
+  // filtered violation below ''42' is a magic number'
   int a = 42; // DO NOT CHECK THIS LINE
   int b = 43; // violation, "'43' is a magic number."
 }
@@ -127,7 +129,7 @@ public class Example2 {
     &lt;property name="nearbyTextPattern" value=".*"/&gt;
   &lt;/module&gt;
   &lt;module name="LineLength"&gt;
-    &lt;property name="max" value="10"/&gt;
+    &lt;property name="max" value="70"/&gt;
   &lt;/module&gt;
 &lt;/module&gt;
 </code></pre></div>
@@ -137,7 +139,8 @@ public class Example2 {
         <div class="wrapper"><pre class="prettyprint"><code class="language-java">
 public class Example3 {
   // ok, because violation message is matching suppress pattern
-  int a_really_long_variable_name = 10;
+  String a_really_long_variable_name = "A sentence greater than 70 chars";
+  // filtered violation above 'Line is longer ...'
 }
 </code></pre></div><hr class="example-separator"/>
         <p id="Example4-config">
@@ -164,6 +167,7 @@ public class Example3 {
         </p>
         <div class="wrapper"><pre class="prettyprint"><code class="language-java">
 public class Example4 {
+  // filtered violation below ''42' is a magic number'
   int a = 42; // SUPPRESS CHECKSTYLE because I want to
   static final int LONG_VAR_NAME_TO_TAKE_MORE_THAN_55_CHARS = 22;
   // violation above 'Line is longer ...'
@@ -231,6 +235,7 @@ key.two=44
         </p>
         <div class="wrapper"><pre class="prettyprint"><code class="language-java">
 public class Example7 {
+  // filtered violation below ''42' is a magic number'
   int a = 42; // -@cs[MagicNumber] We do not consider this number as magic.
   int b = 43; // violation "'43' is a magic number."
 }
@@ -257,10 +262,11 @@ public class Example7 {
         </p>
         <div class="wrapper"><pre class="prettyprint"><code class="language-java">
 public class Example8 {
+  // filtered violation below ''42' is a magic number'
   int a = 42; // @cs-: MagicNumber for +3 lines
-  int b = 43;
-  int c = 44;
-  int d = 45;
+  int b = 43; // filtered violation ''43' is a magic number'
+  int c = 44; // filtered violation ''44' is a magic number'
+  int d = 45; // filtered violation ''45' is a magic number'
   int e = 46; // violation "'46' is a magic number."
 }
 </code></pre></div><hr class="example-separator"/>
@@ -288,6 +294,7 @@ public class Example9 {
   /**
    * Flag description.
    * Disabled until &lt;a href="www.github.com/owner/repo/issue/9#comment"&gt;
+   * // filtered violation above 'Line is longer ...'
    */
   public static final boolean SOME_FLAG = false;
 }

--- a/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/filters/SuppressWithNearbyTextFilterExamplesTest.java
+++ b/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/filters/SuppressWithNearbyTextFilterExamplesTest.java
@@ -31,40 +31,68 @@ public class SuppressWithNearbyTextFilterExamplesTest extends AbstractExamplesMo
 
     @Test
     public void testExample1() throws Exception {
-        final String[] expected = {
-            "13:20: '7' is a magic number.",
+
+        final String[] expectedWithoutFilter = {
+            "13:20: '24' is a magic number.",
+            "14:20: '7' is a magic number.",
         };
 
-        verifyWithInlineConfigParser(getPath("Example1.java"), expected);
+        final String[] expectedWithFilter = {
+            "14:20: '7' is a magic number.",
+        };
+
+        verifyFilterWithInlineConfigParser(getPath("Example1.java"),
+                expectedWithoutFilter, expectedWithFilter);
     }
 
     @Test
     public void testExample2() throws Exception {
-        final String[] expected = {
-            "15:11: '43' is a magic number.",
+
+        final String[] expectedWithoutFilter = {
+            "15:11: '42' is a magic number.",
+            "16:11: '43' is a magic number.",
         };
 
-        verifyWithInlineConfigParser(getPath("Example2.java"), expected);
+        final String[] expectedWithFilter = {
+            "16:11: '43' is a magic number.",
+        };
+
+        verifyFilterWithInlineConfigParser(getPath("Example2.java"),
+                expectedWithoutFilter, expectedWithFilter);
     }
 
     @Test
     public void testExample3() throws Exception {
-        final String[] expected = {
+
+        final String[] expectedWithoutFilter = {
+            "16: Line is longer than 70 characters (found 74).",
+        };
+
+        final String[] expectedWithFilter = {
 
         };
 
-        verifyWithInlineConfigParser(getPath("Example3.java"), expected);
+        verifyFilterWithInlineConfigParser(getPath("Example3.java"),
+                expectedWithoutFilter, expectedWithFilter);
     }
 
     @Test
     public void testExample4() throws Exception {
-        final String[] expected = {
-            "20: Line is longer than 55 characters (found 65).",
+
+        final String[] expectedWithoutFilter = {
+            "20:11: '42' is a magic number.",
+            "21: Line is longer than 55 characters (found 65).",
         };
 
-        verifyWithInlineConfigParser(getPath("Example4.java"), expected);
+        final String[] expectedWithFilter = {
+            "21: Line is longer than 55 characters (found 65).",
+        };
+
+        verifyFilterWithInlineConfigParser(getPath("Example4.java"),
+                expectedWithoutFilter, expectedWithFilter);
     }
 
+    // Not updated with verifyFilterWithInlineConfigParser due to usage of .properties file
     @Test
     public void testExample5() throws Exception {
         final String[] expected = {
@@ -75,6 +103,7 @@ public class SuppressWithNearbyTextFilterExamplesTest extends AbstractExamplesMo
                 getPath("Example5.java"), getPath("Example5.properties"), expected);
     }
 
+    // Not updating with verifyFilterWithInlineConfigParser due to usage of .properties file
     @Test
     public void testExample6() throws Exception {
         final String[] expected = {
@@ -87,28 +116,51 @@ public class SuppressWithNearbyTextFilterExamplesTest extends AbstractExamplesMo
 
     @Test
     public void testExample7() throws Exception {
-        final String[] expected = {
-            "17:11: '43' is a magic number.",
+
+        final String[] expectedWithoutFilter = {
+            "17:11: '42' is a magic number.",
+            "18:11: '43' is a magic number.",
         };
 
-        verifyWithInlineConfigParser(getPath("Example7.java"), expected);
+        final String[] expectedWithFilter = {
+            "18:11: '43' is a magic number.",
+        };
+
+        verifyFilterWithInlineConfigParser(getPath("Example7.java"),
+                expectedWithoutFilter, expectedWithFilter);
     }
 
     @Test
     public void testExample8() throws Exception {
-        final String[] expected = {
-            "21:11: '46' is a magic number.",
+
+        final String[] expectedWithoutFilter = {
+            "18:11: '42' is a magic number.",
+            "19:11: '43' is a magic number.",
+            "20:11: '44' is a magic number.",
+            "21:11: '45' is a magic number.",
+            "22:11: '46' is a magic number.",
         };
 
-        verifyWithInlineConfigParser(getPath("Example8.java"), expected);
+        final String[] expectedWithFilter = {
+            "22:11: '46' is a magic number.",
+        };
+
+        verifyFilterWithInlineConfigParser(getPath("Example8.java"),
+                expectedWithoutFilter, expectedWithFilter);
     }
 
     @Test
     public void testExample9() throws Exception {
-        final String[] expected = {
+
+        final String[] expectedWithoutFilter = {
+            "19: Line is longer than 70 characters (found 72).",
+        };
+
+        final String[] expectedWithFilter = {
 
         };
 
-        verifyWithInlineConfigParser(getPath("Example9.java"), expected);
+        verifyFilterWithInlineConfigParser(getPath("Example9.java"),
+                expectedWithoutFilter, expectedWithFilter);
     }
 }

--- a/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/filters/suppresswithnearbytextfilter/Example1.java
+++ b/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/filters/suppresswithnearbytextfilter/Example1.java
@@ -9,6 +9,7 @@
 package com.puppycrawl.tools.checkstyle.filters.suppresswithnearbytextfilter;
 // xdoc section -- start
 public class Example1 {
+  // filtered violation below ''24' is a magic number'
   int hoursInDay = 24; // SUPPRESS CHECKSTYLE because it is too obvious
   int daysInWeek = 7; // violation, "'7' is a magic number."
 }

--- a/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/filters/suppresswithnearbytextfilter/Example2.java
+++ b/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/filters/suppresswithnearbytextfilter/Example2.java
@@ -11,6 +11,7 @@
 package com.puppycrawl.tools.checkstyle.filters.suppresswithnearbytextfilter;
 // xdoc section -- start
 public class Example2 {
+  // filtered violation below ''42' is a magic number'
   int a = 42; // DO NOT CHECK THIS LINE
   int b = 43; // violation, "'43' is a magic number."
 }

--- a/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/filters/suppresswithnearbytextfilter/Example3.java
+++ b/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/filters/suppresswithnearbytextfilter/Example3.java
@@ -5,7 +5,7 @@
     <property name="nearbyTextPattern" value=".*"/>
   </module>
   <module name="LineLength">
-    <property name="max" value="10"/>
+    <property name="max" value="70"/>
   </module>
 </module>
 */
@@ -13,6 +13,7 @@ package com.puppycrawl.tools.checkstyle.filters.suppresswithnearbytextfilter;
 // xdoc section -- start
 public class Example3 {
   // ok, because violation message is matching suppress pattern
-  int a_really_long_variable_name = 10;
+  String a_really_long_variable_name = "A sentence greater than 70 chars";
+  // filtered violation above 'Line is longer ...'
 }
 // xdoc section -- end

--- a/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/filters/suppresswithnearbytextfilter/Example4.java
+++ b/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/filters/suppresswithnearbytextfilter/Example4.java
@@ -16,6 +16,7 @@
 package com.puppycrawl.tools.checkstyle.filters.suppresswithnearbytextfilter;
 // xdoc section -- start
 public class Example4 {
+  // filtered violation below ''42' is a magic number'
   int a = 42; // SUPPRESS CHECKSTYLE because I want to
   static final int LONG_VAR_NAME_TO_TAKE_MORE_THAN_55_CHARS = 22;
   // violation above 'Line is longer ...'

--- a/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/filters/suppresswithnearbytextfilter/Example7.java
+++ b/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/filters/suppresswithnearbytextfilter/Example7.java
@@ -13,6 +13,7 @@
 package com.puppycrawl.tools.checkstyle.filters.suppresswithnearbytextfilter;
 // xdoc section -- start
 public class Example7 {
+  // filtered violation below ''42' is a magic number'
   int a = 42; // -@cs[MagicNumber] We do not consider this number as magic.
   int b = 43; // violation "'43' is a magic number."
 }

--- a/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/filters/suppresswithnearbytextfilter/Example8.java
+++ b/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/filters/suppresswithnearbytextfilter/Example8.java
@@ -14,10 +14,11 @@
 package com.puppycrawl.tools.checkstyle.filters.suppresswithnearbytextfilter;
 // xdoc section -- start
 public class Example8 {
+  // filtered violation below ''42' is a magic number'
   int a = 42; // @cs-: MagicNumber for +3 lines
-  int b = 43;
-  int c = 44;
-  int d = 45;
+  int b = 43; // filtered violation ''43' is a magic number'
+  int c = 44; // filtered violation ''44' is a magic number'
+  int d = 45; // filtered violation ''45' is a magic number'
   int e = 46; // violation "'46' is a magic number."
 }
 // xdoc section -- end

--- a/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/filters/suppresswithnearbytextfilter/Example9.java
+++ b/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/filters/suppresswithnearbytextfilter/Example9.java
@@ -17,6 +17,7 @@ public class Example9 {
   /**
    * Flag description.
    * Disabled until <a href="www.github.com/owner/repo/issue/9#comment">
+   * // filtered violation above 'Line is longer ...'
    */
   public static final boolean SOME_FLAG = false;
 }


### PR DESCRIPTION
part of #16738 

update `SuppressWithNearbyTextFilterExamplesTest` method's to use `verifyFilterWithInlineConfigParser()`.