### PR TITLE
Updated url flagged by linkcheck

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/InvalidJavadocPositionCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/InvalidJavadocPositionCheck.java
@@ -28,7 +28,7 @@ import com.puppycrawl.tools.checkstyle.utils.JavadocUtil;
 /**
  * <div>
  * Checks that Javadocs are located at the correct position. As specified at
- * <a href="https://docs.oracle.com/en/java/javase/17/docs/specs/doc-comment-spec.html">
+ * <a href="https://docs.oracle.com/en/java/javase/17/docs/specs/javadoc/doc-comment-spec.html">
  * Documentation Comment Specification for the Standard Doclet</a>, Javadocs are recognized
  * only when placed immediately before module, package, class, interface,
  * constructor, method, or field declarations. Any other position, like in the

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocBlockTagLocationCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocBlockTagLocationCheck.java
@@ -32,7 +32,7 @@ import com.puppycrawl.tools.checkstyle.api.JavadocTokenTypes;
 /**
  * <div>
  * Checks that a
- * <a href="https://docs.oracle.com/en/java/javase/17/docs/specs/doc-comment-spec.html#block-tags">
+ * <a href="https://docs.oracle.com/en/java/javase/17/docs/specs/javadoc/doc-comment-spec.html#block-tags">
  * javadoc block tag</a> appears only at the beginning of a line, ignoring
  * leading asterisks and white space. A block tag is a token that starts with
  * {@code @} symbol and is preceded by a whitespace. This check ignores block
@@ -41,7 +41,7 @@ import com.puppycrawl.tools.checkstyle.api.JavadocTokenTypes;
  *
  * <p>
  * Rationale: according to
- * <a href="https://docs.oracle.com/en/java/javase/17/docs/specs/doc-comment-spec.html#block-tags">
+ * <a href="https://docs.oracle.com/en/java/javase/17/docs/specs/javadoc/doc-comment-spec.html#block-tags">
  * the specification</a> all javadoc block tags should be placed at the beginning
  * of a line. Tags that are not placed at the beginning are treated as plain text.
  * To recognize intentional tag placement to text area it is better to escape the
@@ -116,7 +116,7 @@ public class JavadocBlockTagLocationCheck extends AbstractJavadocCheck {
 
     /**
      * Block tags from Java 11
-     * <a href="https://docs.oracle.com/en/java/javase/17/docs/specs/doc-comment-spec.html">
+     * <a href="https://docs.oracle.com/en/java/javase/17/docs/specs/javadoc/doc-comment-spec.html">
      * Documentation Comment Specification</a>.
      */
     private static final String[] DEFAULT_TAGS = {
@@ -161,7 +161,7 @@ public class JavadocBlockTagLocationCheck extends AbstractJavadocCheck {
 
     /**
      * The javadoc tokens that this check must be registered for. According to
-     * <a href="https://docs.oracle.com/en/java/javase/17/docs/specs/doc-comment-spec.html#block-tags">
+     * <a href="https://docs.oracle.com/en/java/javase/17/docs/specs/javadoc/doc-comment-spec.html#block-tags">
      * the specs</a> each block tag must appear at the beginning of a line, otherwise
      * it will be interpreted as a plain text. This check looks for a block tag
      * in the javadoc text, thus it needs the {@code TEXT} tokens.

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocContentLocationCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocContentLocationCheck.java
@@ -69,7 +69,7 @@ import com.puppycrawl.tools.checkstyle.utils.TokenUtil;
  * </p>
  *
  * <p>
- * The <a href="https://docs.oracle.com/en/java/javase/17/docs/specs/doc-comment-spec.html">
+ * The <a href="https://docs.oracle.com/en/java/javase/17/docs/specs/javadoc/doc-comment-spec.html">
  * Documentation Comment Specification</a> permits leading asterisks on the first line.
  * For these Javadoc comments:
  * </p>

--- a/src/main/resources/com/puppycrawl/tools/checkstyle/meta/checks/javadoc/InvalidJavadocPositionCheck.xml
+++ b/src/main/resources/com/puppycrawl/tools/checkstyle/meta/checks/javadoc/InvalidJavadocPositionCheck.xml
@@ -6,7 +6,7 @@
              parent="com.puppycrawl.tools.checkstyle.TreeWalker">
          <description>&lt;div&gt;
  Checks that Javadocs are located at the correct position. As specified at
- &lt;a href="https://docs.oracle.com/en/java/javase/17/docs/specs/doc-comment-spec.html"&gt;
+ &lt;a href="https://docs.oracle.com/en/java/javase/17/docs/specs/javadoc/doc-comment-spec.html"&gt;
  Documentation Comment Specification for the Standard Doclet&lt;/a&gt;, Javadocs are recognized
  only when placed immediately before module, package, class, interface,
  constructor, method, or field declarations. Any other position, like in the

--- a/src/main/resources/com/puppycrawl/tools/checkstyle/meta/checks/javadoc/JavadocBlockTagLocationCheck.xml
+++ b/src/main/resources/com/puppycrawl/tools/checkstyle/meta/checks/javadoc/JavadocBlockTagLocationCheck.xml
@@ -6,7 +6,7 @@
              parent="com.puppycrawl.tools.checkstyle.TreeWalker">
          <description>&lt;div&gt;
  Checks that a
- &lt;a href="https://docs.oracle.com/en/java/javase/17/docs/specs/doc-comment-spec.html#block-tags"&gt;
+ &lt;a href="https://docs.oracle.com/en/java/javase/17/docs/specs/javadoc/doc-comment-spec.html#block-tags"&gt;
  javadoc block tag&lt;/a&gt; appears only at the beginning of a line, ignoring
  leading asterisks and white space. A block tag is a token that starts with
  &lt;code&gt;@&lt;/code&gt; symbol and is preceded by a whitespace. This check ignores block
@@ -15,7 +15,7 @@
 
  &lt;p&gt;
  Rationale: according to
- &lt;a href="https://docs.oracle.com/en/java/javase/17/docs/specs/doc-comment-spec.html#block-tags"&gt;
+ &lt;a href="https://docs.oracle.com/en/java/javase/17/docs/specs/javadoc/doc-comment-spec.html#block-tags"&gt;
  the specification&lt;/a&gt; all javadoc block tags should be placed at the beginning
  of a line. Tags that are not placed at the beginning are treated as plain text.
  To recognize intentional tag placement to text area it is better to escape the

--- a/src/main/resources/com/puppycrawl/tools/checkstyle/meta/checks/javadoc/JavadocContentLocationCheck.xml
+++ b/src/main/resources/com/puppycrawl/tools/checkstyle/meta/checks/javadoc/JavadocContentLocationCheck.xml
@@ -44,7 +44,7 @@
  &lt;/p&gt;
 
  &lt;p&gt;
- The &lt;a href="https://docs.oracle.com/en/java/javase/17/docs/specs/doc-comment-spec.html"&gt;
+ The &lt;a href="https://docs.oracle.com/en/java/javase/17/docs/specs/javadoc/doc-comment-spec.html"&gt;
  Documentation Comment Specification&lt;/a&gt; permits leading asterisks on the first line.
  For these Javadoc comments:
  &lt;/p&gt;

--- a/src/site/xdoc/checks/javadoc/invalidjavadocposition.xml
+++ b/src/site/xdoc/checks/javadoc/invalidjavadocposition.xml
@@ -11,7 +11,7 @@
       <subsection name="Description" id="Description">
         <div>
           Checks that Javadocs are located at the correct position. As specified at
-          <a href="https://docs.oracle.com/en/java/javase/17/docs/specs/doc-comment-spec.html">
+          <a href="https://docs.oracle.com/en/java/javase/17/docs/specs/javadoc/doc-comment-spec.html">
           Documentation Comment Specification for the Standard Doclet</a>, Javadocs are recognized
           only when placed immediately before module, package, class, interface,
           constructor, method, or field declarations. Any other position, like in the

--- a/src/site/xdoc/checks/javadoc/javadocblocktaglocation.xml
+++ b/src/site/xdoc/checks/javadoc/javadocblocktaglocation.xml
@@ -11,7 +11,7 @@
       <subsection name="Description" id="Description">
         <div>
           Checks that a
-          <a href="https://docs.oracle.com/en/java/javase/17/docs/specs/doc-comment-spec.html#block-tags">
+          <a href="https://docs.oracle.com/en/java/javase/17/docs/specs/javadoc/doc-comment-spec.html#block-tags">
           javadoc block tag</a> appears only at the beginning of a line, ignoring
           leading asterisks and white space. A block tag is a token that starts
           with <code>@</code> symbol and is preceded by a whitespace. This check
@@ -20,7 +20,7 @@
         </div>
         <p>
           Rationale: according to
-          <a href="https://docs.oracle.com/en/java/javase/17/docs/specs/doc-comment-spec.html#block-tags">
+          <a href="https://docs.oracle.com/en/java/javase/17/docs/specs/javadoc/doc-comment-spec.html#block-tags">
           the specification</a> all javadoc block tags should be placed at the
           beginning of a line. Tags that are not placed at the beginning are treated
           as plain text. To recognize intentional tag placement to text area

--- a/src/site/xdoc/checks/javadoc/javadocblocktaglocation.xml.template
+++ b/src/site/xdoc/checks/javadoc/javadocblocktaglocation.xml.template
@@ -11,7 +11,7 @@
       <subsection name="Description" id="Description">
         <div>
           Checks that a
-          <a href="https://docs.oracle.com/en/java/javase/17/docs/specs/doc-comment-spec.html#block-tags">
+          <a href="https://docs.oracle.com/en/java/javase/17/docs/specs/javadoc/doc-comment-spec.html#block-tags">
           javadoc block tag</a> appears only at the beginning of a line, ignoring
           leading asterisks and white space. A block tag is a token that starts
           with <code>@</code> symbol and is preceded by a whitespace. This check
@@ -20,7 +20,7 @@
         </div>
         <p>
           Rationale: according to
-          <a href="https://docs.oracle.com/en/java/javase/17/docs/specs/doc-comment-spec.html#block-tags">
+          <a href="https://docs.oracle.com/en/java/javase/17/docs/specs/javadoc/doc-comment-spec.html#block-tags">
           the specification</a> all javadoc block tags should be placed at the
           beginning of a line. Tags that are not placed at the beginning are treated
           as plain text. To recognize intentional tag placement to text area

--- a/src/site/xdoc/checks/javadoc/javadoccontentlocation.xml
+++ b/src/site/xdoc/checks/javadoc/javadoccontentlocation.xml
@@ -48,7 +48,7 @@ public void method();
           SummaryJavadoc</a> check.
         </p>
         <p>
-          The <a href="https://docs.oracle.com/en/java/javase/17/docs/specs/doc-comment-spec.html">
+          The <a href="https://docs.oracle.com/en/java/javase/17/docs/specs/javadoc/doc-comment-spec.html">
           Documentation Comment Specification</a> permits leading asterisks on the first line.
           For these Javadoc comments:
         </p>

--- a/src/site/xdoc/checks/javadoc/javadoccontentlocation.xml.template
+++ b/src/site/xdoc/checks/javadoc/javadoccontentlocation.xml.template
@@ -48,7 +48,7 @@ public void method();
           SummaryJavadoc</a> check.
         </p>
         <p>
-          The <a href="https://docs.oracle.com/en/java/javase/17/docs/specs/doc-comment-spec.html">
+          The <a href="https://docs.oracle.com/en/java/javase/17/docs/specs/javadoc/doc-comment-spec.html">
           Documentation Comment Specification</a> permits leading asterisks on the first line.
           For these Javadoc comments:
         </p>


### PR DESCRIPTION
https://github.com/checkstyle/checkstyle/actions/runs/16238202146/job/45851065652

```
------------ grep of linkcheck.html--BEGIN
Checking internal (checkstyle website) and external links.
--- .ci-temp/linkcheck-suppressions-sorted.txt	2025-07-12 12:56:37.554866043 +0000
+++ .ci-temp/linkcheck-errors-sorted.txt	2025-07-12 12:56:37.552866051 +0000
@@ -1,3 +1,21 @@
+<a class="externalLink" href="https://docs.oracle.com/en/java/javase/17/docs/specs/doc-comment-spec.html">https://docs.oracle.com/en/java/javase/17/docs/specs/doc-comment-spec.html</a>: 404 Not Found
```