### PR TITLE
infra: Update google-java-format.yml

### DIFF
--- a/.github/workflows/google-java-format.yml
+++ b/.github/workflows/google-java-format.yml
@@ -20,7 +20,7 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  VERSION: 1.27.0
+  VERSION: 1.28.0
 
 jobs:
   test:


### PR DESCRIPTION
from https://github.com/google/google-java-format/releases/tag/v1.28.0?notification_referrer_id=NT_kwDOAAxnuLIxNzQ5MzkzNjUwMTo4MTI5ODQ