### PR TITLE
Issue #16738: Update SuppressWithNearbyTextFilterExamplesTest to use verifyFilterWithInlineConfigParserSeparateConfigAndTarget

### DIFF
--- a/src/site/xdoc/filters/suppresswithnearbytextfilter.xml
+++ b/src/site/xdoc/filters/suppresswithnearbytextfilter.xml
@@ -189,6 +189,7 @@ public class Example4 {
         </p>
         <div class="wrapper"><pre class="prettyprint"><code class="language-java">
 key.one=41 # // SUPPRESS CHECKSTYLE because I want to
+# // filtered violation above 'Duplicated property 'key.one' (3 occurrence(s)).'
 key.one=42 # ok as within line range
 key.one=43 # ok as within line range
 key.two=44 # // violation 'Duplicated property 'key.two' (2 occurrence(s)).'
@@ -209,6 +210,7 @@ key.two=45
           Example:
         </p>
         <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+# // filtered violation below 'Duplicated property 'key.one' (2 occurrence(s)).'
 key.one=41 # ok as within line range
 key.one=42 # SUPPRESS CHECKSTYLE because I want to
 key.two=43 # // violation 'Duplicated property 'key.two' (2 occurrence(s)).'

--- a/src/test/java/com/puppycrawl/tools/checkstyle/AbstractModuleTestSupport.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/AbstractModuleTestSupport.java
@@ -367,6 +367,42 @@ public abstract class AbstractModuleTestSupport extends AbstractPathTestSupport 
 
     /**
      * Performs verification of the file with the given file path using specified configuration
+     * and the array of expected messages. Also performs verification of the config with filters
+     * specified in the input file.
+     *
+     * @param fileWithConfig file path of the configuration file.
+     * @param targetFilePath file path of the target file to be verified.
+     * @param expectedUnfiltered an array of expected unfiltered config.
+     * @param expectedFiltered an array of expected config with filters.
+     * @throws Exception if exception occurs during verification process.
+     */
+    protected final void verifyFilterWithInlineConfigParserSeparateConfigAndTarget(
+            String fileWithConfig,
+            String targetFilePath,
+            String[] expectedUnfiltered,
+            String... expectedFiltered)
+            throws Exception {
+        final TestInputConfiguration testInputConfiguration =
+                InlineConfigParser.parseWithFilteredViolations(fileWithConfig);
+        final DefaultConfiguration configWithoutFilters =
+                testInputConfiguration.createConfigurationWithoutFilters();
+        final List<TestInputViolation> violationsWithoutFilters = new ArrayList<>(
+                InlineConfigParser.getFilteredViolationsFromInputFile(targetFilePath));
+        violationsWithoutFilters.addAll(
+                InlineConfigParser.getViolationsFromInputFile(targetFilePath));
+        Collections.sort(violationsWithoutFilters);
+        verifyViolations(configWithoutFilters, targetFilePath, violationsWithoutFilters);
+        verify(configWithoutFilters, targetFilePath, expectedUnfiltered);
+        final DefaultConfiguration configWithFilters =
+                testInputConfiguration.createConfiguration();
+        final List<TestInputViolation> violationsWithFilters =
+                InlineConfigParser.getViolationsFromInputFile(targetFilePath);
+        verifyViolations(configWithFilters, targetFilePath, violationsWithFilters);
+        verify(configWithFilters, targetFilePath, expectedFiltered);
+    }
+
+    /**
+     * Performs verification of the file with the given file path using specified configuration
      * and the array expected messages. Also performs verification of the config specified in
      * input file
      *

--- a/src/test/java/com/puppycrawl/tools/checkstyle/bdd/InlineConfigParser.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/bdd/InlineConfigParser.java
@@ -508,6 +508,25 @@ public final class InlineConfigParser {
         return testInputConfigBuilder.build().getViolations();
     }
 
+    public static List<TestInputViolation> getFilteredViolationsFromInputFile(String inputFilePath)
+            throws Exception {
+        final TestInputConfiguration.Builder testInputConfigBuilder =
+                new TestInputConfiguration.Builder();
+        final Path filePath = Path.of(inputFilePath);
+        final List<String> lines = readFile(filePath);
+
+        try {
+            for (int lineNo = 0; lineNo < lines.size(); lineNo++) {
+                setViolations(testInputConfigBuilder, lines, true, lineNo, true);
+            }
+        }
+        catch (CheckstyleException exc) {
+            throw new CheckstyleException(exc.getMessage() + " in " + inputFilePath, exc);
+        }
+
+        return testInputConfigBuilder.build().getFilteredViolations();
+    }
+
     public static TestInputConfiguration parseWithFilteredViolations(String inputFilePath)
             throws Exception {
         return parse(inputFilePath, true);

--- a/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/filters/SuppressWithNearbyTextFilterExamplesTest.java
+++ b/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/filters/SuppressWithNearbyTextFilterExamplesTest.java
@@ -92,26 +92,42 @@ public class SuppressWithNearbyTextFilterExamplesTest extends AbstractExamplesMo
                 expectedWithoutFilter, expectedWithFilter);
     }
 
-    // Not updated with verifyFilterWithInlineConfigParser due to usage of .properties file
     @Test
     public void testExample5() throws Exception {
-        final String[] expected = {
+
+        final String[] expectedWithoutFilters = {
+            "1: Duplicated property 'key.one' (3 occurrence(s)).",
+            "5: Duplicated property 'key.two' (2 occurrence(s)).",
+        };
+
+        final String[] expectedWithFilters = {
+            "5: Duplicated property 'key.two' (2 occurrence(s)).",
+        };
+
+        verifyFilterWithInlineConfigParserSeparateConfigAndTarget(
+                getPath("Example5.java"),
+                getPath("Example5.properties"),
+                expectedWithoutFilters,
+                expectedWithFilters);
+    }
+
+    @Test
+    public void testExample6() throws Exception {
+
+        final String[] expectedWithoutFilters = {
+            "2: Duplicated property 'key.one' (2 occurrence(s)).",
             "4: Duplicated property 'key.two' (2 occurrence(s)).",
         };
 
-        verifyWithInlineConfigParserSeparateConfigAndTarget(
-                getPath("Example5.java"), getPath("Example5.properties"), expected);
-    }
-
-    // Not updating with verifyFilterWithInlineConfigParser due to usage of .properties file
-    @Test
-    public void testExample6() throws Exception {
-        final String[] expected = {
-            "3: Duplicated property 'key.two' (2 occurrence(s)).",
+        final String[] expectedWithFilters = {
+            "4: Duplicated property 'key.two' (2 occurrence(s)).",
         };
 
-        verifyWithInlineConfigParserSeparateConfigAndTarget(
-                getPath("Example6.java"), getPath("Example6.properties"), expected);
+        verifyFilterWithInlineConfigParserSeparateConfigAndTarget(
+                getPath("Example6.java"),
+                getPath("Example6.properties"),
+                expectedWithoutFilters,
+                expectedWithFilters);
     }
 
     @Test

--- a/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/filters/suppresswithnearbytextfilter/Example5.properties
+++ b/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/filters/suppresswithnearbytextfilter/Example5.properties
@@ -1,4 +1,5 @@
 key.one=41 # // SUPPRESS CHECKSTYLE because I want to
+# // filtered violation above 'Duplicated property 'key.one' (3 occurrence(s)).'
 key.one=42 # ok as within line range
 key.one=43 # ok as within line range
 key.two=44 # // violation 'Duplicated property 'key.two' (2 occurrence(s)).'

--- a/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/filters/suppresswithnearbytextfilter/Example6.properties
+++ b/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/filters/suppresswithnearbytextfilter/Example6.properties
@@ -1,3 +1,4 @@
+# // filtered violation below 'Duplicated property 'key.one' (2 occurrence(s)).'
 key.one=41 # ok as within line range
 key.one=42 # SUPPRESS CHECKSTYLE because I want to
 key.two=43 # // violation 'Duplicated property 'key.two' (2 occurrence(s)).'


### PR DESCRIPTION
part of #16738 

There was no method named `verifyFilterWithInlineConfigParserSeparateConfigAndTarget()` to update `Example5` and `Example6`.
https://github.com/checkstyle/checkstyle/blob/master/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/filters/SuppressWithNearbyTextFilterExamplesTest.java

I created the `verifyFilterWithInlineConfigParserSeparateConfigAndTarget()` method, as well as a `getFilteredViolation()` method to retrieve filtered violations for verification.

I then updated `Example5` and `Example6` in `SuppressWithNearbyTextFilterExamplesTest.java` to use this new method. 

The main reason for doing this is that some examples in `SuppressWithPlainTextCommentFilterExamplesTest.java` also uses `.properties` as a target files.

This update will help in modifying those examples similarly.