### PR TITLE
minor: Updated AbstractGoogleModuleTestSupport to use setProperty() instead of put()

### DIFF
--- a/src/it/java/com/google/checkstyle/test/base/AbstractGoogleModuleTestSupport.java
+++ b/src/it/java/com/google/checkstyle/test/base/AbstractGoogleModuleTestSupport.java
@@ -43,7 +43,7 @@ public abstract class AbstractGoogleModuleTestSupport extends AbstractItModuleTe
     static {
         try {
             final Properties properties = new Properties();
-            properties.put("org.checkstyle.google.severity", "error");
+            properties.setProperty("org.checkstyle.google.severity", "error");
             final PropertiesExpander expander = new PropertiesExpander(properties);
             CONFIGURATION = ConfigurationLoader.loadConfiguration(XML_NAME,
                     expander);


### PR DESCRIPTION
setProperty() ensures type safety for String keys and values instead of using put() 