### PR TITLE
Issue #16738: Update SuppressWithPlainTextCommentFilterExamplesTest to use verifyFilter

### DIFF
--- a/config/checkstyle-examples-suppressions.xml
+++ b/config/checkstyle-examples-suppressions.xml
@@ -142,7 +142,7 @@
   <suppress checks="LineLength"
     files="annotation[\\/]suppresswarningsholder[\\/]Example2.java"/>
 
-  <!-- Example must show line length violations and suppressed violations -->
+  <!-- Example must show line length violations and filtered violations -->
   <suppress checks="LineLength"
     files="suppresswithplaintextcommentfilter[\\/]Example9.java"/>
   <suppress checks="LineLength"

--- a/src/site/xdoc/filters/suppresswithplaintextcommentfilter.xml
+++ b/src/site/xdoc/filters/suppresswithplaintextcommentfilter.xml
@@ -116,8 +116,7 @@
         <p id="Example1-raw">Example:</p>
         <div class="wrapper"><pre class="prettyprint"><code class="language-java">
 # // CHECKSTYLE:OFF
-# suppressed violation below
-keyB=value1
+keyB=value1 # // filtered violation 'Duplicated property 'keyB' (2 occurrence(s)).'
 keyB=value2
 # // CHECKSTYLE:ON
 # // violation below 'Duplicated property 'keyC' (2 occurrence(s)).'
@@ -146,8 +145,7 @@ keyC=value5
         <p id="Example2-raw">Example:</p>
         <div class="wrapper"><pre class="prettyprint"><code class="language-java">
 # STOP CHECK
-# suppressed violation below
-keyB=value1
+keyB=value1 # // filtered violation 'Duplicated property 'keyB' (2 occurrence(s)).'
 keyB=value2
 # RESUME CHECK
 # // violation below 'Duplicated property 'keyC' (2 occurrence(s)).'
@@ -180,8 +178,7 @@ keyC=value5
         <div class="wrapper"><pre class="prettyprint"><code class="language-java">
 # STOP UNIQUE CHECK
 # (OrderedProperties check is still enabled)
-# suppressed violation below
-keyB=value1
+keyB=value1 # // filtered violation 'Duplicated property 'keyB' (2 occurrence(s)).'
 keyB=value2
 # // violation below 'Property key 'keyA' is not in the right order with previous property 'keyB.'
 keyA=value3
@@ -222,8 +219,9 @@ keyC=value5
 &lt;!-- CSOFF: RegexpSinglelineCheck --&gt;
   &lt;macro name="example"&gt;
     &lt;param name="path" value="Example3.java"/&gt;
-    &lt;!-- suppressed violation below  --&gt;
     &lt;param name="type" value="code"/&gt;
+    &lt;!--  // filtered violation above 'Type code is not allowed. Use type raw instead'
+    --&gt;
   &lt;/macro&gt;
 &lt;!-- CSON: RegexpSinglelineCheck --&gt;
   &lt;macro name="example"&gt;
@@ -329,8 +327,9 @@ keyC=value5
   &lt;/macro&gt;
   &lt;macro name="example"&gt;
     &lt;param name="path" value="Example4.java"/&gt;
-    &lt;!-- suppressed violation below  --&gt;
     &lt;param name="type" value="code"/&gt;
+    &lt;!--  // filtered violation above 'Type code is not allowed. Use type raw instead'
+    --&gt;
 &lt;!-- CSON --&gt;
   &lt;/macro&gt;
 &lt;/project&gt;
@@ -390,8 +389,9 @@ keyC=value5
   &lt;/macro&gt;
   &lt;macro name="example"&gt;
     &lt;param name="path" value="Example4.sql"/&gt;
-    &lt;!-- suppressed violation below  --&gt;
     &lt;param name="type" value="code"/&gt;
+    &lt;!--  // filtered violation above 'Type code is not allowed. Use type raw instead'
+    --&gt;
 &lt;!-- CSON typeCode --&gt;
   &lt;/macro&gt;
 &lt;/project&gt;
@@ -431,8 +431,8 @@ SELECT name, job_name
 FROM users AS u
 -- suppressed violation below (RegexpSinglelineCheck)
 JOIN jobs AS j ON u.job_id = j.id
--- suppressed violation below (LineLengthCheck)
 WHERE u.registration_date &gt;= '2023-01-01' AND u.status = 'active';
+-- // filtered violation above 'Line is longer ...'
 </code></pre></div><hr class="example-separator"/>
         <p id="Example9-config">
           This check is not limited to comments. It can match any symbols in the given file
@@ -459,12 +459,14 @@ WHERE u.registration_date &gt;= '2023-01-01' AND u.status = 'active';
         <div class="wrapper"><pre class="prettyprint"><code class="language-java">
 public class Example9 {
 
-  // suppressed violation below, opening/closing quotes are 'offCommentFormat' and 'onCommentFormat'
   static final String LOCATION_CSV_SAMPLE = """
           locationId,label,regionId,regionLabel,vendorId,vendorLabel,address,address2,city,stateProvinceCode,zipCode,countryCode,latitude,longitude
           ST001,Station 001,ZONE1,Zone 1,CP1,Competitor 1,123 Street,Unit 2,Houston,TX,77033,US,29.761496813335178,-95.53049214204984
           ST002,Station 002,ZONE2,,CP2,,668 Street,Unit 23,San Jose,CA,95191,US,37.35102477242508,-121.9209934020318
           """;
+  // filtered violation 5 lines above 'Line is longer than 100 characters (found 147).'
+  // filtered violation 5 lines above 'Line is longer than 100 characters (found 133).'
+  // filtered violation 5 lines above 'Line is longer than 100 characters (found 116).'
 
   // violation below, 'Line is longer than 100 characters (found 183).'
   static final String SINGLE_LINE_SAMPLE = "locationId,label,regionId,regionLabel,vendorId,vendorLabel,address,address2,city,stateProvinceCode,zipCode,countryCode,latitude,longitude";

--- a/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/filters/SuppressWithPlainTextCommentFilterExamplesTest.java
+++ b/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/filters/SuppressWithPlainTextCommentFilterExamplesTest.java
@@ -36,96 +36,169 @@ public class SuppressWithPlainTextCommentFilterExamplesTest
     public void testExample1() throws Exception {
         final String fileWithConfig = getPath("Example1.java");
         final String targetFile = getPath("Example1.properties");
-        final String[] expected = {
-            "7: Duplicated property 'keyC' (2 occurrence(s)).",
+
+        final String[] expectedWithoutFilter = {
+            "2: Duplicated property 'keyB' (2 occurrence(s)).",
+            "6: Duplicated property 'keyC' (2 occurrence(s)).",
         };
 
-        verifyWithInlineConfigParserSeparateConfigAndTarget(fileWithConfig, targetFile, expected);
+        final String[] expectedWithFilter = {
+            "6: Duplicated property 'keyC' (2 occurrence(s)).",
+        };
+
+        verifyFilterWithInlineConfigParserSeparateConfigAndTarget(fileWithConfig, targetFile,
+                expectedWithoutFilter,
+                expectedWithFilter);
     }
 
     @Test
     public void testExample2() throws Exception {
         final String fileWithConfig = getPath("Example2.java");
         final String targetFile = getPath("Example2.properties");
-        final String[] expected = {
-            "7: Duplicated property 'keyC' (2 occurrence(s)).",
+
+        final String[] expectedWithoutFilter = {
+            "2: Duplicated property 'keyB' (2 occurrence(s)).",
+            "6: Duplicated property 'keyC' (2 occurrence(s)).",
         };
 
-        verifyWithInlineConfigParserSeparateConfigAndTarget(fileWithConfig, targetFile, expected);
+        final String[] expectedWithFilter = {
+            "6: Duplicated property 'keyC' (2 occurrence(s)).",
+        };
+
+        verifyFilterWithInlineConfigParserSeparateConfigAndTarget(fileWithConfig, targetFile,
+                expectedWithoutFilter,
+                expectedWithFilter);
     }
 
     @Test
     public void testExample3() throws Exception {
         final String fileWithConfig = getPath("Example3.java");
         final String targetFile = getPath("Example3.properties");
-        final String[] expected = {
-            "7: Property key 'keyA' is not in the right order with previous property 'keyB'.",
-            "10: Duplicated property 'keyC' (2 occurrence(s)).",
+
+        final String[] expectedWithoutFilter = {
+            "3: Duplicated property 'keyB' (2 occurrence(s)).",
+            "6: Property key 'keyA' is not in the right order with previous property 'keyB'.",
+            "9: Duplicated property 'keyC' (2 occurrence(s)).",
         };
 
-        verifyWithInlineConfigParserSeparateConfigAndTarget(fileWithConfig, targetFile, expected);
+        final String[] expectedWithFilter = {
+            "6: Property key 'keyA' is not in the right order with previous property 'keyB'.",
+            "9: Duplicated property 'keyC' (2 occurrence(s)).",
+        };
+
+        verifyFilterWithInlineConfigParserSeparateConfigAndTarget(fileWithConfig, targetFile,
+                expectedWithoutFilter,
+                expectedWithFilter);
     }
 
     @Test
     public void testExample4() throws Exception {
         final String fileWithConfig = getPath("Example4.java");
         final String targetFile = getPath("Example4.xml");
-        final String[] expected = {
-            "12: Type code is not allowed. Use type raw instead.",
+
+        final String[] expectedWithoutFilter = {
+            "6: Type code is not allowed. Use type raw instead.",
+            "13: Type code is not allowed. Use type raw instead.",
         };
 
-        verifyWithInlineConfigParserSeparateConfigAndTarget(fileWithConfig, targetFile, expected);
+        final String[] expectedWithFilter = {
+            "13: Type code is not allowed. Use type raw instead.",
+        };
+
+        verifyFilterWithInlineConfigParserSeparateConfigAndTarget(fileWithConfig, targetFile,
+                expectedWithoutFilter,
+                expectedWithFilter);
     }
 
     @Test
     public void testExample5() throws Exception {
         final String fileWithConfig = getPath("Example5.java");
         final String targetFile = getPath("Example5.xml");
-        final String[] expected = {
+
+        final String[] expectedWithoutFilter = {
             "6: Type code is not allowed. Use type raw instead.",
             "13: Type code is not allowed. Use type raw instead.",
         };
 
-        verifyWithInlineConfigParserSeparateConfigAndTarget(fileWithConfig, targetFile, expected);
+        final String[] expectedWithFilter = {
+            "6: Type code is not allowed. Use type raw instead.",
+            "13: Type code is not allowed. Use type raw instead.",
+        };
+
+        verifyFilterWithInlineConfigParserSeparateConfigAndTarget(fileWithConfig, targetFile,
+                expectedWithoutFilter,
+                expectedWithFilter);
     }
 
     @Test
     public void testExample6() throws Exception {
         final String fileWithConfig = getPath("Example6.java");
         final String targetFile = getPath("Example6.xml");
-        final String[] expected = {
+
+        final String[] expectedWithoutFilter = {
+            "6: Type config is not allowed in this file.",
+            "12: Type code is not allowed. Use type raw instead.",
+        };
+
+        final String[] expectedWithFilter = {
             "6: Type config is not allowed in this file.",
         };
 
-        verifyWithInlineConfigParserSeparateConfigAndTarget(fileWithConfig, targetFile, expected);
+        verifyFilterWithInlineConfigParserSeparateConfigAndTarget(fileWithConfig, targetFile,
+                expectedWithoutFilter,
+                expectedWithFilter);
     }
 
     @Test
     public void testExample7() throws Exception {
         final String fileWithConfig = getPath("Example7.java");
         final String targetFile = getPath("Example7.xml");
-        final String[] expected = {
+
+        final String[] expectedWithoutFilter = {
+            "6: Type config is not allowed in this file.",
+            "12: Type code is not allowed. Use type raw instead.",
+        };
+
+        final String[] expectedWithFilter = {
             "6: Type config is not allowed in this file.",
         };
 
-        verifyWithInlineConfigParserSeparateConfigAndTarget(fileWithConfig, targetFile, expected);
+        verifyFilterWithInlineConfigParserSeparateConfigAndTarget(fileWithConfig, targetFile,
+                expectedWithoutFilter,
+                expectedWithFilter);
     }
 
     @Test
     public void testExample8() throws Exception {
         final String fileWithConfig = getPath("Example8.java");
         final String targetFile = getPath("Example8.sql");
-        final String[] expected = CommonUtil.EMPTY_STRING_ARRAY;
 
-        verifyWithInlineConfigParserSeparateConfigAndTarget(fileWithConfig, targetFile, expected);
+        final String[] expectedWithoutFilter = {
+            "7: Line is longer than 60 characters (found 66).",
+        };
+
+        final String[] expectedWithFilter = CommonUtil.EMPTY_STRING_ARRAY;
+
+        verifyFilterWithInlineConfigParserSeparateConfigAndTarget(fileWithConfig, targetFile,
+                expectedWithoutFilter,
+                expectedWithFilter);
     }
 
     @Test
     public void testExample9() throws Exception {
-        final String[] expected = {
-            "30: Line is longer than 100 characters (found 183).",
+
+        final String[] expectedWithoutFilter = {
+            "23: Line is longer than 100 characters (found 147).",
+            "24: Line is longer than 100 characters (found 133).",
+            "25: Line is longer than 100 characters (found 116).",
+            "32: Line is longer than 100 characters (found 183).",
         };
 
-        verifyWithInlineConfigParser(getPath("Example9.java"), expected);
+        final String[] expectedWithFilter = {
+            "32: Line is longer than 100 characters (found 183).",
+        };
+
+        verifyFilterWithInlineConfigParser(getPath("Example9.java"),
+                expectedWithoutFilter, expectedWithFilter);
     }
 }

--- a/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/filters/suppresswithplaintextcommentfilter/Example1.properties
+++ b/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/filters/suppresswithplaintextcommentfilter/Example1.properties
@@ -1,6 +1,5 @@
 # // CHECKSTYLE:OFF
-# suppressed violation below
-keyB=value1
+keyB=value1 # // filtered violation 'Duplicated property 'keyB' (2 occurrence(s)).'
 keyB=value2
 # // CHECKSTYLE:ON
 # // violation below 'Duplicated property 'keyC' (2 occurrence(s)).'

--- a/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/filters/suppresswithplaintextcommentfilter/Example2.properties
+++ b/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/filters/suppresswithplaintextcommentfilter/Example2.properties
@@ -1,6 +1,5 @@
 # STOP CHECK
-# suppressed violation below
-keyB=value1
+keyB=value1 # // filtered violation 'Duplicated property 'keyB' (2 occurrence(s)).'
 keyB=value2
 # RESUME CHECK
 # // violation below 'Duplicated property 'keyC' (2 occurrence(s)).'

--- a/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/filters/suppresswithplaintextcommentfilter/Example3.properties
+++ b/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/filters/suppresswithplaintextcommentfilter/Example3.properties
@@ -1,7 +1,6 @@
 # STOP UNIQUE CHECK
 # (OrderedProperties check is still enabled)
-# suppressed violation below
-keyB=value1
+keyB=value1 # // filtered violation 'Duplicated property 'keyB' (2 occurrence(s)).'
 keyB=value2
 # // violation below 'Property key 'keyA' is not in the right order with previous property 'keyB.'
 keyA=value3

--- a/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/filters/suppresswithplaintextcommentfilter/Example4.xml
+++ b/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/filters/suppresswithplaintextcommentfilter/Example4.xml
@@ -3,8 +3,9 @@
 <!-- CSOFF: RegexpSinglelineCheck -->
   <macro name="example">
     <param name="path" value="Example3.java"/>
-    <!-- suppressed violation below  -->
     <param name="type" value="code"/>
+    <!--  // filtered violation above 'Type code is not allowed. Use type raw instead'
+    -->
   </macro>
 <!-- CSON: RegexpSinglelineCheck -->
   <macro name="example">

--- a/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/filters/suppresswithplaintextcommentfilter/Example6.xml
+++ b/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/filters/suppresswithplaintextcommentfilter/Example6.xml
@@ -9,8 +9,9 @@
   </macro>
   <macro name="example">
     <param name="path" value="Example4.java"/>
-    <!-- suppressed violation below  -->
     <param name="type" value="code"/>
+    <!--  // filtered violation above 'Type code is not allowed. Use type raw instead'
+    -->
 <!-- CSON -->
   </macro>
 </project>

--- a/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/filters/suppresswithplaintextcommentfilter/Example7.xml
+++ b/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/filters/suppresswithplaintextcommentfilter/Example7.xml
@@ -9,8 +9,9 @@
   </macro>
   <macro name="example">
     <param name="path" value="Example4.sql"/>
-    <!-- suppressed violation below  -->
     <param name="type" value="code"/>
+    <!--  // filtered violation above 'Type code is not allowed. Use type raw instead'
+    -->
 <!-- CSON typeCode -->
   </macro>
 </project>

--- a/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/filters/suppresswithplaintextcommentfilter/Example8.sql
+++ b/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/filters/suppresswithplaintextcommentfilter/Example8.sql
@@ -4,5 +4,5 @@ SELECT name, job_name
 FROM users AS u
 -- suppressed violation below (RegexpSinglelineCheck)
 JOIN jobs AS j ON u.job_id = j.id
--- suppressed violation below (LineLengthCheck)
 WHERE u.registration_date >= '2023-01-01' AND u.status = 'active';
+-- // filtered violation above 'Line is longer ...'

--- a/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/filters/suppresswithplaintextcommentfilter/Example9.java
+++ b/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/filters/suppresswithplaintextcommentfilter/Example9.java
@@ -19,12 +19,14 @@ package com.puppycrawl.tools.checkstyle.filters.suppresswithplaintextcommentfilt
 // xdoc section -- start
 public class Example9 {
 
-  // suppressed violation below, opening/closing quotes are 'offCommentFormat' and 'onCommentFormat'
   static final String LOCATION_CSV_SAMPLE = """
           locationId,label,regionId,regionLabel,vendorId,vendorLabel,address,address2,city,stateProvinceCode,zipCode,countryCode,latitude,longitude
           ST001,Station 001,ZONE1,Zone 1,CP1,Competitor 1,123 Street,Unit 2,Houston,TX,77033,US,29.761496813335178,-95.53049214204984
           ST002,Station 002,ZONE2,,CP2,,668 Street,Unit 23,San Jose,CA,95191,US,37.35102477242508,-121.9209934020318
           """;
+  // filtered violation 5 lines above 'Line is longer than 100 characters (found 147).'
+  // filtered violation 5 lines above 'Line is longer than 100 characters (found 133).'
+  // filtered violation 5 lines above 'Line is longer than 100 characters (found 116).'
 
   // violation below, 'Line is longer than 100 characters (found 183).'
   static final String SINGLE_LINE_SAMPLE = "locationId,label,regionId,regionLabel,vendorId,vendorLabel,address,address2,city,stateProvinceCode,zipCode,countryCode,latitude,longitude";


### PR DESCRIPTION
part of #16738 

updated `SuppressWithPlainTextCommentFilterExamplesTest.java` method's to use `verifyFilterWithInlineConfigParserSeparateConfigAndTarget()`.

`Example9.java` does not use any target file, so it has been updated wih `verifyFilterWithInlineConfigParser()`.
