### PR TITLE
Issue #16738: Update SeverityMatchFilter to use verifyFilterWithInlineConfigParser

### DIFF
--- a/config/pitest-suppressions/pitest-api-suppressions.xml
+++ b/config/pitest-suppressions/pitest-api-suppressions.xml
@@ -1,6 +1,33 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <suppressedMutations>
   <mutation unstable="false">
+    <sourceFile>AbstractCheck.java</sourceFile>
+    <mutatedClass>com.puppycrawl.tools.checkstyle.api.AbstractCheck</mutatedClass>
+    <mutatedMethod>log</mutatedMethod>
+    <mutator>org.pitest.mutationtest.engine.gregor.mutators.NonVoidMethodCallMutator</mutator>
+    <description>removed call to com/puppycrawl/tools/checkstyle/api/AbstractCheck::getSeverityLevel</description>
+    <lineContent>getSeverityLevel(),</lineContent>
+  </mutation>
+
+  <mutation unstable="false">
+    <sourceFile>AbstractFileSetCheck.java</sourceFile>
+    <mutatedClass>com.puppycrawl.tools.checkstyle.api.AbstractFileSetCheck</mutatedClass>
+    <mutatedMethod>log</mutatedMethod>
+    <mutator>org.pitest.mutationtest.engine.gregor.mutators.NonVoidMethodCallMutator</mutator>
+    <description>removed call to com/puppycrawl/tools/checkstyle/api/AbstractFileSetCheck::getSeverityLevel</description>
+    <lineContent>getSeverityLevel(),</lineContent>
+  </mutation>
+
+  <mutation unstable="false">
+    <sourceFile>AbstractViolationReporter.java</sourceFile>
+    <mutatedClass>com.puppycrawl.tools.checkstyle.api.AbstractViolationReporter</mutatedClass>
+    <mutatedMethod>setSeverity</mutatedMethod>
+    <mutator>org.pitest.mutationtest.engine.gregor.mutators.experimental.MemberVariableMutator</mutator>
+    <description>Removed assignment to member variable severityLevel</description>
+    <lineContent>severityLevel = SeverityLevel.getInstance(severity);</lineContent>
+  </mutation>
+
+  <mutation unstable="false">
     <sourceFile>FileText.java</sourceFile>
     <mutatedClass>com.puppycrawl.tools.checkstyle.api.FileText</mutatedClass>
     <mutatedMethod>&lt;init&gt;</mutatedMethod>

--- a/config/pitest-suppressions/pitest-tree-walker-suppressions.xml
+++ b/config/pitest-suppressions/pitest-tree-walker-suppressions.xml
@@ -12,6 +12,15 @@
   <mutation unstable="false">
     <sourceFile>TreeWalker.java</sourceFile>
     <mutatedClass>com.puppycrawl.tools.checkstyle.TreeWalker</mutatedClass>
+    <mutatedMethod>&lt;init&gt;</mutatedMethod>
+    <mutator>org.pitest.mutationtest.engine.gregor.mutators.experimental.MemberVariableMutator</mutator>
+    <description>Removed assignment to member variable javaParseExceptionSeverity</description>
+    <lineContent>private SeverityLevel javaParseExceptionSeverity = SeverityLevel.ERROR;</lineContent>
+  </mutation>
+
+  <mutation unstable="false">
+    <sourceFile>TreeWalker.java</sourceFile>
+    <mutatedClass>com.puppycrawl.tools.checkstyle.TreeWalker</mutatedClass>
     <mutatedMethod>createNewCheckSortedSet</mutatedMethod>
     <mutator>org.pitest.mutationtest.engine.gregor.mutators.experimental.NakedReceiverMutator</mutator>
     <description>replaced call to java/util/Comparator::thenComparing with receiver</description>

--- a/src/site/xdoc/checks/javadoc/writetag.xml
+++ b/src/site/xdoc/checks/javadoc/writetag.xml
@@ -191,6 +191,7 @@ public class Example3 {
 
   /** some doc */
   public void testMethod2() {}
+  // violation 1 lines above 'Type Javadoc comment is missing @since tag.'
 
 }
 </code></pre></div><hr class="example-separator"/>

--- a/src/site/xdoc/filters/severitymatchfilter.xml
+++ b/src/site/xdoc/filters/severitymatchfilter.xml
@@ -72,6 +72,7 @@
         </p>
         <div class="wrapper"><pre class="prettyprint"><code class="language-java">
 public class Example1 {
+  // filtered violation below 'must match pattern'
   public void method1(int V1){} // ok, ParameterName's severity is info
 
   public void Method2(){} // violation, MethodName's severity is defaulted to error

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/coding/UnusedLocalVariableCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/coding/UnusedLocalVariableCheckTest.java
@@ -307,7 +307,9 @@ public class UnusedLocalVariableCheckTest extends AbstractModuleTestSupport {
 
     @Test
     public void testUnusedLocalVarTestWarningSeverity() throws Exception {
-        final String[] expected = CommonUtil.EMPTY_STRING_ARRAY;
+        final String[] expected = {
+            "14:19: " + getCheckMessage(MSG_UNUSED_LOCAL_VARIABLE, "p2"),
+        };
 
         verifyWithInlineConfigParser(
                 getPath("InputUnusedLocalVariableTestWarningSeverity.java"),

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/javadoc/WriteTagCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/javadoc/WriteTagCheckTest.java
@@ -107,7 +107,7 @@ public class WriteTagCheckTest extends AbstractModuleTestSupport {
     @Test
     public void testEmptyTag() throws Exception {
         final String[] expected = {
-            "19: " + getCheckMessage(MSG_WRITE_TAG, "@emptytag", ""),
+            "20: " + getCheckMessage(MSG_WRITE_TAG, "@emptytag", ""),
         };
         verifyWithInlineConfigParserTwice(
                 getPath("InputWriteTagEmptyTag.java"), expected);
@@ -245,7 +245,10 @@ public class WriteTagCheckTest extends AbstractModuleTestSupport {
 
     @Test
     public void testRegularEx() throws Exception {
-        final String[] expected = CommonUtil.EMPTY_STRING_ARRAY;
+        final String[] expected = {
+            "16: " + getCheckMessage(MSG_WRITE_TAG, "@author", "Daniel Grenner"),
+        };
+
         verifyWithInlineConfigParserTwice(
                 getPath("InputWriteTagRegularExpression.java"), expected);
     }

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/unusedlocalvariable/InputUnusedLocalVariableTestWarningSeverity.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/unusedlocalvariable/InputUnusedLocalVariableTestWarningSeverity.java
@@ -11,7 +11,7 @@ public class InputUnusedLocalVariableTestWarningSeverity {
 
     void m() {
      @Test.A Outer p1 = new @Test.A Outer();
-     @Test.A Outer.@Test.B Inner p2 = p1.new @Test.B Inner();
+     @Test.A Outer.@Test.B Inner p2 = p1.new @Test.B Inner(); // violation, unused variable 'ab'
      // ok above until https://github.com/checkstyle/checkstyle/issues/12980
     }
 

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/writetag/InputWriteTagEmptyTag.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/writetag/InputWriteTagEmptyTag.java
@@ -10,6 +10,7 @@ tokens = (default)INTERFACE_DEF, CLASS_DEF, ENUM_DEF, ANNOTATION_DEF, RECORD_DEF
 
 package com.puppycrawl.tools.checkstyle.checks.javadoc.writetag;
 
+// violation 7 lines below 'Javadoc tag @emptytag='
 /**
  * Testing tag writing
  * @author Daniel Grenner

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/writetag/InputWriteTagEnumsAndAnnotations.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/writetag/InputWriteTagEnumsAndAnnotations.java
@@ -11,24 +11,24 @@ tokens = ANNOTATION_DEF, ENUM_DEF, ANNOTATION_FIELD_DEF, ENUM_CONSTANT_DEF
 package com.puppycrawl.tools.checkstyle.checks.javadoc.writetag;
 
 class InputWriteTagEnumsAndAnnotations {
-    // violation 2 lines below , '@incomplete should not be used in ANNOTATION.*'
+    // violation 2 lines below 'Javadoc tag @incomplete=This enum needs more code...'
     /**
      * @incomplete This enum needs more code...
      */
     enum InputWriteTag {
-        // violation 2 lines below , '@incomplete should not be used in ENUM.*'
+        // violation 2 lines below 'Javadoc tag @incomplete=This enum constant needs more code...'
         /**
          * @incomplete This enum constant needs more code...
          */
         FOO;
     }
 
-    // violation 2 lines below , '@incomplete should not be used in ANNOTATION_FIELD.*'
+    // violation 2 lines below 'Javadoc tag @incomplete=This annotation needs more code...'
     /**
      * @incomplete This annotation needs more code...
      */
     @interface InputWriteTag2a {
-        // violation 2 lines below , '@incomplete should not be used in ENUM_CONSTANT.*'
+        // violation 2 lines below '@incomplete=This annotation field needs more code...'
         /**
          * @incomplete This annotation field needs more code...
          */

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/writetag/InputWriteTagMethod.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/writetag/InputWriteTagMethod.java
@@ -19,7 +19,7 @@ package com.puppycrawl.tools.checkstyle.checks.javadoc.writetag;
  */
 class InputWriteTagMethod
 {
-    // violation 2 lines below , 'Add a constructor comment.*'
+    // violation 2 lines below 'Javadoc tag @todo=Add a constructor comment'
     /**
      * @todo Add a constructor comment
      */
@@ -31,7 +31,7 @@ class InputWriteTagMethod
     {
     }
 
-    // violation 2 lines below , 'Add a comment.*'
+    // violation 2 lines below 'Javadoc tag @todo=Add a comment'
     /**
      * @todo Add a comment
      */

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/writetag/InputWriteTagRegularExpression.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/writetag/InputWriteTagRegularExpression.java
@@ -10,6 +10,7 @@ tokens = (default)INTERFACE_DEF, CLASS_DEF, ENUM_DEF, ANNOTATION_DEF, RECORD_DEF
 
 package com.puppycrawl.tools.checkstyle.checks.javadoc.writetag;
 
+// violation 3 lines below 'Javadoc tag @author=Daniel Grenner'
 /**
  * Testing tag writing
  * @author Daniel Grenner

--- a/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/checks/javadoc/WriteTagCheckExamplesTest.java
+++ b/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/checks/javadoc/WriteTagCheckExamplesTest.java
@@ -50,6 +50,7 @@ public class WriteTagCheckExamplesTest extends AbstractExamplesModuleTestSupport
         final String[] expected = {
             "19: " + getCheckMessage(WriteTagCheck.MSG_MISSING_TAG, "@since"),
             "24: " + getCheckMessage(WriteTagCheck.MSG_WRITE_TAG, "@since", ""),
+            "29: " + getCheckMessage(WriteTagCheck.MSG_MISSING_TAG, "@since"),
         };
 
         verifyWithInlineConfigParser(getPath("Example3.java"), expected);

--- a/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/filters/SeverityMatchFilterExamplesTest.java
+++ b/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/filters/SeverityMatchFilterExamplesTest.java
@@ -35,10 +35,17 @@ public class SeverityMatchFilterExamplesTest extends AbstractExamplesModuleTestS
     public void testExample1() throws Exception {
         final String pattern = "^[a-z][a-zA-Z0-9]*$";
 
-        final String[] expected = {
-            "21:15: " + getCheckMessage(MSG_INVALID_PATTERN, "Method2", pattern),
+        final String[] expectedWithoutFilter = {
+            "20:27: Name 'V1' must match pattern '^[a-z][a-zA-Z0-9]*$'.",
+            "22:15: " + getCheckMessage(MSG_INVALID_PATTERN, "Method2", pattern),
         };
 
-        verifyWithInlineConfigParser(getPath("Example1.java"), expected);
+        final String[] expectedWithFilter = {
+            "22:15: " + getCheckMessage(MSG_INVALID_PATTERN, "Method2", pattern),
+        };
+
+        verifyFilterWithInlineConfigParser(getPath("Example1.java"),
+                expectedWithoutFilter,
+                expectedWithFilter);
     }
 }

--- a/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/writetag/Example3.java
+++ b/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/writetag/Example3.java
@@ -27,6 +27,7 @@ public class Example3 {
 
   /** some doc */
   public void testMethod2() {}
+  // violation 1 lines above 'Type Javadoc comment is missing @since tag.'
 
 }
 // xdoc section -- end

--- a/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/filters/severitymatchfilter/Example1.java
+++ b/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/filters/severitymatchfilter/Example1.java
@@ -16,6 +16,7 @@ package com.puppycrawl.tools.checkstyle.filters.severitymatchfilter;
 
 // xdoc section -- start
 public class Example1 {
+  // filtered violation below 'must match pattern'
   public void method1(int V1){} // ok, ParameterName's severity is info
 
   public void Method2(){} // violation, MethodName's severity is defaulted to error


### PR DESCRIPTION
Fixes #16738 

- Updated `SeverityMatchFilter.java` to use `verifyFilterWithInlineConfigParsar()`.

- Modified `getActualViolations()` in `AbstractModuleTestSupport.java`: removed `errorCount` logic and added a new logic which passes all the test cases.

- `getActualViolations()` no longer depends on the severity level, meaning it now allows violations with any severity level.

- After adding the new logic, multiple test cases that were previously failing are now working properly.

Please verify issue #12980 as well; I believe this issue is now resolved by this PR.