### PR TITLE
Issue #17402: Use example macro in suppressionxpathfilter.xml.template

### DIFF
--- a/src/site/xdoc/filters/suppressionxpathfilter.xml.template
+++ b/src/site/xdoc/filters/suppressionxpathfilter.xml.template
@@ -37,7 +37,7 @@
         </p>
         <div class="wrapper"><pre class="prettyprint"><code class="language-java">
 &lt;module name="SuppressionXpathFilter"&gt;
-  &lt;property name="file" value="config/suppressions.xml"/&gt;
+  &lt;property name="file" value="${config_loc}/suppressions.xml"/&gt;
   &lt;property name="optional" value="false"/&gt;
 &lt;/module&gt;
         </code></pre></div>


### PR DESCRIPTION
### What was the problem?

The file `suppressionxpathfilter.xml.template` was using a hardcoded file path (`config/suppressions.xml`) instead of the standard `${config_loc}` macro used in other examples.

### What was changed?

- Replaced `config/suppressions.xml` with `${config_loc}/suppressions.xml` in `suppressionxpathfilter.xml.template`.

This improves consistency across all example configuration files and aligns with the way other examples reference configuration files.

### Notes:
- No logic or code behavior was changed — only documentation/example XML.
- All CI checks pass locally.
- Requesting review. Thanks!
