### PR TITLE
Issue #17175: Validate that all properties are used in examples

### DIFF
--- a/src/test/java/com/puppycrawl/tools/checkstyle/internal/XdocsExampleFileTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/internal/XdocsExampleFileTest.java
@@ -1,0 +1,126 @@
+///////////////////////////////////////////////////////////////////////////////////////////////
+// checkstyle: Checks Java source code and other text files for adherence to a set of rules.
+// Copyright (C) 2001-2025 the original author or authors.
+//
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the GNU Lesser General Public
+// License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+//
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+// Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public
+// License along with this library; if not, write to the Free Software
+// Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+///////////////////////////////////////////////////////////////////////////////////////////////
+
+package com.puppycrawl.tools.checkstyle.internal;
+
+import java.beans.PropertyDescriptor;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import org.apache.commons.beanutils.PropertyUtils;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import com.puppycrawl.tools.checkstyle.internal.utils.CheckUtil;
+import com.puppycrawl.tools.checkstyle.internal.utils.XdocUtil;
+
+public class XdocsExampleFileTest {
+
+    private static final Set<String> COMMON_PROPERTIES = Set.of(
+        "severity",
+        "id",
+        "fileExtensions",
+        "tabWidth",
+        "fileContents",
+        "tokens",
+        "javadocTokens",
+        "violateExecutionOnNonTightHtml"
+    );
+
+    // This list is temporarily suppressed.
+    // Until: https://github.com/checkstyle/checkstyle/issues/17449
+    private static final Map<String, Set<String>> SUPPRESSED_PROPERTIES_BY_CHECK = Map.ofEntries(
+            Map.entry("MissingJavadocMethodCheck", Set.of("minLineCount")),
+            Map.entry("TrailingCommentCheck", Set.of("legalComment")),
+            Map.entry("IllegalTypeCheck", Set.of("legalAbstractClassNames")),
+            Map.entry("MethodNameCheck", Set.of("applyToPackage", "applyToPrivate")),
+            Map.entry("JavadocMetadataScraper", Set.of("writeXmlOutput")),
+            Map.entry("MissingJavadocTypeCheck", Set.of("skipAnnotations")),
+            Map.entry("JavadocStyleCheck", Set.of("endOfSentenceFormat", "checkEmptyJavadoc")),
+            Map.entry("ConstantNameCheck", Set.of("applyToPackage", "applyToPrivate")),
+            Map.entry("JavaNCSSCheck", Set.of("recordMaximum")),
+            Map.entry("WhitespaceAroundCheck", Set.of("allowEmptySwitchBlockStatements")),
+            Map.entry("FinalLocalVariableCheck", Set.of("validateUnnamedVariables")),
+            Map.entry("SuppressWarningsHolder", Set.of("aliasList")),
+            Map.entry("IllegalTokenTextCheck", Set.of("message")),
+            Map.entry("IndentationCheck", Set.of(
+                    "basicOffset",
+                    "lineWrappingIndentation",
+                    "throwsIndent",
+                    "arrayInitIndent",
+                    "braceAdjustment"
+            )),
+            Map.entry("MethodCountCheck", Set.of("maxPrivate", "maxPackage", "maxProtected")),
+            Map.entry("ClassMemberImpliedModifierCheck", Set.of(
+                    "violateImpliedStaticOnNestedEnum",
+                    "violateImpliedStaticOnNestedRecord",
+                    "violateImpliedStaticOnNestedInterface"
+            )),
+            Map.entry("TypeNameCheck", Set.of("applyToPublic", "applyToPackage")),
+            Map.entry("DescendantTokenCheck", Set.of("minimumMessage")),
+            Map.entry("InterfaceMemberImpliedModifierCheck", Set.of(
+                    "violateImpliedFinalField",
+                    "violateImpliedPublicField",
+                    "violateImpliedStaticField",
+                    "violateImpliedPublicMethod",
+                    "violateImpliedAbstractMethod"
+            ))
+    );
+
+    @Test
+    public void testAllCheckPropertiesAreUsedInXdocsExamples() throws Exception {
+        final Map<String, Set<String>> usedPropertiesByCheck =
+            XdocUtil.extractUsedPropertiesFromXdocsExamples();
+        final List<String> failures = new ArrayList<>();
+
+        for (Class<?> checkClass : CheckUtil.getCheckstyleChecks()) {
+            final String checkSimpleName = checkClass.getSimpleName();
+
+            final Set<String> definedProperties = Arrays.stream(
+                    PropertyUtils.getPropertyDescriptors(checkClass))
+                .filter(descriptor -> descriptor.getWriteMethod() != null)
+                .map(PropertyDescriptor::getName)
+                .filter(property -> !COMMON_PROPERTIES.contains(property))
+                .collect(Collectors.toUnmodifiableSet());
+
+            final Set<String> usedProperties =
+                usedPropertiesByCheck.getOrDefault(checkSimpleName, Collections.emptySet());
+
+            final Set<String> suppressedProps =
+                SUPPRESSED_PROPERTIES_BY_CHECK.getOrDefault(
+                    checkSimpleName, Collections.emptySet());
+
+            for (String property : definedProperties) {
+                if (!usedProperties.contains(property)
+                        && !suppressedProps.contains(property)) {
+                    failures.add("Missing property in xdoc: '"
+                            + property + "' of " + checkSimpleName);
+                }
+            }
+        }
+        if (!failures.isEmpty()) {
+            Assertions.fail("Xdocs are missing properties:\n" + String.join("\n", failures));
+        }
+    }
+}

--- a/src/test/java/com/puppycrawl/tools/checkstyle/internal/utils/XdocUtil.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/internal/utils/XdocUtil.java
@@ -22,8 +22,13 @@ package com.puppycrawl.tools.checkstyle.internal.utils;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.HashMap;
 import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
 import java.util.Set;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
@@ -177,4 +182,84 @@ public final class XdocUtil {
         return modulesNamesWhichHaveXdoc;
     }
 
+    /**
+     * Extracts used properties from XDocs examples (from /*xml blocks).
+     *
+     * @return a map of Check name -> Set of used property names.
+     * @throws IOException if file I/O fails.
+     */
+    public static Map<String, Set<String>> extractUsedPropertiesFromXdocsExamples()
+            throws IOException {
+        final List<Path> roots = List.of(
+                Path.of("src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks"),
+                Path.of("src/xdocs-examples/resources-noncompilable/"
+                        + "com/puppycrawl/tools/checkstyle/checks")
+        );
+
+        final Map<String, Set<String>> checkToProperties = new HashMap<>();
+
+        for (Path root : roots) {
+            if (Files.exists(root)) {
+                try (Stream<Path> paths = Files.walk(root)) {
+                    paths.filter(path -> path.toString().endsWith(".java"))
+                            .forEach(path -> processXdocExampleFile(path, checkToProperties));
+                }
+            }
+        }
+
+        return checkToProperties;
+    }
+
+    private static void processXdocExampleFile(
+            Path file, Map<String, Set<String>> checkToProperties) {
+        try {
+            final String content = Files.readString(file);
+            final Matcher xmlBlockMatcher =
+                Pattern.compile("/\\*xml(.*?)\\*/", Pattern.DOTALL).matcher(content);
+
+            if (xmlBlockMatcher.find()) {
+                final Map.Entry<String, Set<String>> entry =
+                    parseConfigBlock(xmlBlockMatcher.group(1));
+
+                if (entry != null) {
+                    checkToProperties
+                        .computeIfAbsent(entry.getKey(), key -> new HashSet<>())
+                        .addAll(entry.getValue());
+                }
+            }
+        }
+        catch (IOException ioe) {
+            throw new IllegalStateException("Error reading file: " + file, ioe);
+        }
+    }
+
+    private static Map.Entry<String, Set<String>> parseConfigBlock(String configBlock) {
+        final Matcher moduleMatcher =
+                Pattern.compile("<module name=\"([^\"]+)\"").matcher(configBlock);
+        String lastModule = null;
+        while (moduleMatcher.find()) {
+            lastModule = moduleMatcher.group(1);
+        }
+
+        final Matcher propMatcher =
+                Pattern.compile("<property name=\"([^\"]+)\"").matcher(configBlock);
+        final Set<String> props = new HashSet<>();
+        while (propMatcher.find()) {
+            props.add(propMatcher.group(1));
+        }
+
+        Map.Entry<String, Set<String>> result = null;
+        if (lastModule != null && !props.isEmpty()) {
+            final String checkClassName;
+            if (lastModule.endsWith("Check")) {
+                checkClassName = lastModule;
+            }
+            else {
+                checkClassName = lastModule + "Check";
+            }
+            result = Map.entry(checkClassName, props);
+        }
+
+        return result;
+    }
 }


### PR DESCRIPTION
Issue #17175 

**WIP**

- For each Check class, properties are collected using `PropertyUtils.getPropertyDescriptors()`.
- All *.java files inside `src/xdocs-examples/resources/... `are scanned for a /*xml ... */ block.
- All `<property name="..."/> `tags inside the XML block are extracted.
- A validation compares defined properties with those documented in the examples.

<img width="1747" height="422" alt="image" src="https://github.com/user-attachments/assets/1fa2a419-7202-44b9-9ec5-02f5a5c8812b" />
