### PR TITLE
Issue #17401: Enabled example macros for suppressionfilter.xml.template

### DIFF
--- a/config/checkstyle-non-main-files-suppressions.xml
+++ b/config/checkstyle-non-main-files-suppressions.xml
@@ -187,8 +187,6 @@
 
   <!-- Examples macro suppressions -->
   <suppress id="exampleMacroMustExist"
-         files="src[\\/]site[\\/]xdoc[\\/]filters[\\/]suppressionfilter.xml.template"/>
-  <suppress id="exampleMacroMustExist"
          files="src[\\/]site[\\/]xdoc[\\/]filters[\\/]suppressionxpathfilter.xml.template"/>
 
   <!-- there is no messages in module by design -->

--- a/config/jsoref-spellchecker/whitelist.words
+++ b/config/jsoref-spellchecker/whitelist.words
@@ -1323,6 +1323,7 @@ superfinalize
 Superinterface
 supertype
 suppressioncommentfilter
+suppressionexample
 suppressionfilter
 suppressionsinglefilter
 suppressionsloader

--- a/src/site/xdoc/filters/suppressionfilter.xml
+++ b/src/site/xdoc/filters/suppressionfilter.xml
@@ -121,46 +121,73 @@
         </div>
       </subsection>
       <subsection name="Examples" id="Examples">
-        <p>
+        <p id="Example1-config">
             For example, the following configuration fragment directs the
             Checker to use a <code>SuppressionFilter</code>
             with suppressions
-            file <code>config/suppressions.xml</code>:
+            file <code>suppressionexample1.xml</code>:
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
-&lt;module name=&quot;SuppressionFilter&quot;&gt;
-  &lt;property name=&quot;file&quot; value=&quot;config/suppressions.xml&quot;/&gt;
-  &lt;property name=&quot;optional&quot; value=&quot;false&quot;/&gt;
+        <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
+&lt;module name="Checker"&gt;
+  &lt;module name="SuppressionFilter"&gt;
+    &lt;property name="file" value="suppressionexample1.xml"/&gt;
+    &lt;property name="optional" value="false"/&gt;
+  &lt;/module&gt;
+  &lt;module name="TreeWalker"&gt;
+    &lt;module name="JavadocStyle"/&gt;
+    &lt;module name="MagicNumber"/&gt;
+    &lt;module name="com.puppycrawl.tools.checkstyle.checks.blocks.EmptyBlockCheck"/&gt;
+  &lt;/module&gt;
 &lt;/module&gt;
-        </code></pre></div>
-        <p>
+</code></pre></div>
+        <p id="suppressionexample1-raw">
           The following suppressions XML document directs
           a <code>SuppressionFilter</code> to
           reject <code>JavadocStyleCheck</code> violations for
-          lines 82 and 108 to 122 of
-          file <code>AbstractComplexityCheck.java</code>,
-          and <code>MagicNumberCheck</code> violations for line
-          221 of file <code>JavadocStyleCheck.java</code>,
+          line 4 of
+          file <code>Example1.java</code>,
+          and <code>MagicNumberCheck</code> violations for lines
+          7 and 11 of file <code>Example1.java</code>,
           and <code>'Missing a Javadoc comment'</code> violations
           for all lines and files:
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
-&lt;?xml version=&quot;1.0&quot;?&gt;
+        <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
+&lt;?xml version="1.0"?&gt;
 
 &lt;!DOCTYPE suppressions PUBLIC
-  &quot;-//Checkstyle//DTD SuppressionFilter Configuration 1.2//EN&quot;
-  &quot;https://checkstyle.org/dtds/suppressions_1_2.dtd&quot;&gt;
+  "-//Checkstyle//DTD SuppressionFilter Configuration 1.2//EN"
+  "https://checkstyle.org/dtds/suppressions_1_2.dtd"&gt;
 
 &lt;suppressions&gt;
-  &lt;suppress checks=&quot;JavadocStyleCheck&quot;
-    files=&quot;AbstractComplexityCheck.java&quot;
-    lines=&quot;82,108-122&quot;/&gt;
-  &lt;suppress checks=&quot;MagicNumberCheck&quot;
-    files=&quot;JavadocStyleCheck.java&quot;
-    lines=&quot;221&quot;/&gt;
-  &lt;suppress message=&quot;Missing a Javadoc comment&quot;/&gt;
+  &lt;suppress checks="JavadocStyle"
+    files="Example1.java"
+    lines="20"/&gt;
+  &lt;suppress checks="MagicNumber"
+    files="Example1.java"
+    lines="23,27"/&gt;
+  &lt;suppress message="Missing a Javadoc comment"/&gt;
 &lt;/suppressions&gt;
-        </code></pre></div>
+</code></pre></div>
+        <p id="Example1-code">Example:</p>
+        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+public class Example1 {
+
+  // filtered violation below 'First sentence should end with a period.'
+  /**
+   * This field a is missing period
+   */
+  int a = 10; // filtered violation ''10' is a magic number.'
+
+  public void exampleMethod() {
+
+    int num = 100; // filtered violation ''100' is a magic number.'
+
+    if (true) {
+      // violation above 'Must have at least one statement.'
+    }
+  }
+}
+</code></pre></div><hr class="example-separator"/>
         <p>
           Suppress check by <a href="../config.html#Id">module id</a>
           when config have two instances on the same check:

--- a/src/site/xdoc/filters/suppressionfilter.xml.template
+++ b/src/site/xdoc/filters/suppressionfilter.xml.template
@@ -29,46 +29,39 @@
         </div>
       </subsection>
       <subsection name="Examples" id="Examples">
-        <p>
+        <p id="Example1-config">
             For example, the following configuration fragment directs the
             Checker to use a <code>SuppressionFilter</code>
             with suppressions
-            file <code>config/suppressions.xml</code>:
+            file <code>suppressionexample1.xml</code>:
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
-&lt;module name="SuppressionFilter"&gt;
-  &lt;property name="file" value="config/suppressions.xml"/&gt;
-  &lt;property name="optional" value="false"/&gt;
-&lt;/module&gt;
-        </code></pre></div>
-        <p>
+        <macro name="example">
+          <param name="path"
+                 value="resources/com/puppycrawl/tools/checkstyle/filters/suppressionfilter/Example1.java"/>
+          <param name="type" value="config"/>
+        </macro>
+        <p id="suppressionexample1-raw">
           The following suppressions XML document directs
           a <code>SuppressionFilter</code> to
           reject <code>JavadocStyleCheck</code> violations for
-          lines 82 and 108 to 122 of
-          file <code>AbstractComplexityCheck.java</code>,
-          and <code>MagicNumberCheck</code> violations for line
-          221 of file <code>JavadocStyleCheck.java</code>,
+          line 4 of
+          file <code>Example1.java</code>,
+          and <code>MagicNumberCheck</code> violations for lines
+          7 and 11 of file <code>Example1.java</code>,
           and <code>'Missing a Javadoc comment'</code> violations
           for all lines and files:
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
-&lt;?xml version="1.0"?&gt;
-
-&lt;!DOCTYPE suppressions PUBLIC
-  "-//Checkstyle//DTD SuppressionFilter Configuration 1.2//EN"
-  "https://checkstyle.org/dtds/suppressions_1_2.dtd"&gt;
-
-&lt;suppressions&gt;
-  &lt;suppress checks="JavadocStyleCheck"
-    files="AbstractComplexityCheck.java"
-    lines="82,108-122"/&gt;
-  &lt;suppress checks="MagicNumberCheck"
-    files="JavadocStyleCheck.java"
-    lines="221"/&gt;
-  &lt;suppress message="Missing a Javadoc comment"/&gt;
-&lt;/suppressions&gt;
-        </code></pre></div>
+        <macro name="example">
+          <param name="path"
+                 value="resources/com/puppycrawl/tools/checkstyle/filters/suppressionfilter/suppressionexample1.xml"/>
+          <param name="type" value="raw"/>
+        </macro>
+        <p id="Example1-code">Example:</p>
+        <macro name="example">
+          <param name="path"
+                 value="resources/com/puppycrawl/tools/checkstyle/filters/suppressionfilter/Example1.java"/>
+          <param name="type" value="code"/>
+        </macro><hr class="example-separator"/>
         <p>
           Suppress check by <a href="../config.html#Id">module id</a>
           when config have two instances on the same check:

--- a/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/filters/SuppressionFilterExamplesTest.java
+++ b/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/filters/SuppressionFilterExamplesTest.java
@@ -1,0 +1,50 @@
+///////////////////////////////////////////////////////////////////////////////////////////////
+// checkstyle: Checks Java source code and other text files for adherence to a set of rules.
+// Copyright (C) 2001-2025 the original author or authors.
+//
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the GNU Lesser General Public
+// License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+//
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+// Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public
+// License along with this library; if not, write to the Free Software
+// Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+///////////////////////////////////////////////////////////////////////////////////////////////
+
+package com.puppycrawl.tools.checkstyle.filters;
+
+import org.junit.jupiter.api.Test;
+
+import com.puppycrawl.tools.checkstyle.AbstractExamplesModuleTestSupport;
+
+public class SuppressionFilterExamplesTest extends AbstractExamplesModuleTestSupport {
+    @Override
+    protected String getPackageLocation() {
+        return "com/puppycrawl/tools/checkstyle/filters/suppressionfilter";
+    }
+
+    @Test
+    public void testExample1() throws Exception {
+
+        final String[] expectedWithoutFilter = {
+            "20: First sentence should end with a period.",
+            "23:11: '10' is a magic number.",
+            "27:15: '100' is a magic number.",
+            "29:15: Must have at least one statement.",
+        };
+
+        final String[] expectedWithFilter = {
+            "29:15: Must have at least one statement.",
+        };
+
+        verifyFilterWithInlineConfigParser(getPath("Example1.java"),
+                expectedWithoutFilter,
+                expectedWithFilter);
+    }
+}

--- a/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/filters/suppressionfilter/Example1.java
+++ b/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/filters/suppressionfilter/Example1.java
@@ -1,0 +1,34 @@
+/*xml
+<module name="Checker">
+  <module name="SuppressionFilter">
+    <property name="file" value="suppressionexample1.xml"/>
+    <property name="optional" value="false"/>
+  </module>
+  <module name="TreeWalker">
+    <module name="JavadocStyle"/>
+    <module name="MagicNumber"/>
+    <module name="com.puppycrawl.tools.checkstyle.checks.blocks.EmptyBlockCheck"/>
+  </module>
+</module>
+*/
+
+package com.puppycrawl.tools.checkstyle.filters.suppressionfilter;
+// xdoc section -- start
+public class Example1 {
+
+  // filtered violation below 'First sentence should end with a period.'
+  /**
+   * This field a is missing period
+   */
+  int a = 10; // filtered violation ''10' is a magic number.'
+
+  public void exampleMethod() {
+
+    int num = 100; // filtered violation ''100' is a magic number.'
+
+    if (true) {
+      // violation above 'Must have at least one statement.'
+    }
+  }
+}
+// xdoc section -- end

--- a/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/filters/suppressionfilter/suppressionexample1.xml
+++ b/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/filters/suppressionfilter/suppressionexample1.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0"?>
+
+<!DOCTYPE suppressions PUBLIC
+  "-//Checkstyle//DTD SuppressionFilter Configuration 1.2//EN"
+  "https://checkstyle.org/dtds/suppressions_1_2.dtd">
+
+<suppressions>
+  <suppress checks="JavadocStyle"
+    files="Example1.java"
+    lines="20"/>
+  <suppress checks="MagicNumber"
+    files="Example1.java"
+    lines="23,27"/>
+  <suppress message="Missing a Javadoc comment"/>
+</suppressions>


### PR DESCRIPTION
Issue #17401 

Added new files `SuppressionFilterExamplesTest.java`, `Example1.java`,  `suppressionexample1.xml` and `suppressionexample1.txt`

The reason of adding `suppressionexample1.txt` to parse within the `XdocsPagesTest.java`
