### PR TITLE
Issue #17240: Added Trino to no error testing in CI

### DIFF
--- a/.ci/validation.sh
+++ b/.ci/validation.sh
@@ -824,6 +824,22 @@ no-error-spotbugs)
   removeFolderWithProtectedFiles spotbugs
   ;;
 
+no-error-trino)
+  echo "Building checkstyle..."
+  ./mvnw -e --no-transfer-progress clean install -Pno-validations -DskipTests
+  echo "Resolving Checkstyle version from pom.xml..."
+  CS_POM_VERSION="$(getCheckstylePomVersion)"
+  echo "CS_version: ${CS_POM_VERSION}"
+  echo "Cloning Trino sources..."
+  checkout_from https://github.com/trinodb/trino.git
+  cd .ci-temp/trino
+  echo "Running Checkstyle ${CS_POM_VERSION} on Trino..."
+  ./mvnw -e --no-transfer-progress checkstyle:check -Dcheckstyle.version="${CS_POM_VERSION}"
+  cd ../
+  echo "Cleaning up cloned Trino repo..."
+  removeFolderWithProtectedFiles trino
+  ;;
+
 no-exception-struts)
   CS_POM_VERSION="$(getCheckstylePomVersion)"
   BRANCH=$(git rev-parse --abbrev-ref HEAD)

--- a/.github/workflows/no-error-trino.yml
+++ b/.github/workflows/no-error-trino.yml
@@ -1,0 +1,27 @@
+name: Trino
+
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+    branches: '*'
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  trino-check:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: 23
+
+      - name: Run Checkstyle on Trino
+        run: ./.ci/validation.sh no-error-trino

--- a/config/jsoref-spellchecker/whitelist.words
+++ b/config/jsoref-spellchecker/whitelist.words
@@ -1394,6 +1394,8 @@ treemap
 treeset
 treetable
 treewalker
+trino
+trinodb
 tschneeberger
 tstamp
 tt


### PR DESCRIPTION
Issue: #17240 

```
no-error-trino)
  echo "Building checkstyle..."
  ./mvnw -e --no-transfer-progress clean install -Pno-validations -DskipTests
  echo "Resolving Checkstyle version from pom.xml..."
  CS_POM_VERSION="$(getCheckstylePomVersion)"
  echo "CS_version: ${CS_POM_VERSION}"
  echo "Cloning Trino sources..."
  checkout_from https://github.com/trinodb/trino.git
  cd .ci-temp/trino
  echo "Running Checkstyle ${CS_POM_VERSION} on Trino..."
  ./mvnw -e --no-transfer-progress checkstyle:check -Dcheckstyle.version="${CS_POM_VERSION}"
  cd ../
  echo "Cleaning up cloned Trino repo..."
  removeFolderWithProtectedFiles trino
  ;;


```
Trino CI failure for checkstyle violations
https://github.com/trinodb/trino/actions/runs/16391578147/job/46318251496?pr=26242


