### PR TITLE
supplemental: IT for 4.6.2 whitespace before '{' of empty blocks

### DIFF
--- a/.ci/google-java-format.sh
+++ b/.ci/google-java-format.sh
@@ -69,6 +69,7 @@ COMPILABLE_INPUT_PATHS=($(find src/it/resources/com/google/checkstyle/test/ -nam
     | grep -v "rule462horizontalwhitespace/InputWhitespaceAroundGenerics.java" \
     | grep -v "rule462horizontalwhitespace/InputGenericWhitespace.java" \
     | grep -v "rule462horizontalwhitespace/InputWhitespaceAfterDoubleSlashes.java" \
+    | grep -v "rule462horizontalwhitespace/InputWhitespaceBeforeLeftCurlyOfEmptyBlock.java" \
     | grep -v "rule4821onevariableperline/InputOneVariablePerDeclaration.java" \
     | grep -v "rule4841indentation/InputClassWithChainedMethods.java" \
     | grep -v "rule4841indentation/InputAnnotationArrayInitMultiline.java" \

--- a/src/it/java/com/google/checkstyle/test/chapter4formatting/rule462horizontalwhitespace/HorizontalWhitespaceTest.java
+++ b/src/it/java/com/google/checkstyle/test/chapter4formatting/rule462horizontalwhitespace/HorizontalWhitespaceTest.java
@@ -189,4 +189,14 @@ public class HorizontalWhitespaceTest extends AbstractGoogleModuleTestSupport {
     public void testWhitespaceAfterDoubleSlashesFormatted() throws Exception {
         verifyWithWholeConfig(getPath("InputFormattedWhitespaceAfterDoubleSlashes.java"));
     }
+
+    @Test
+    public void testWhitespaceBeforeLeftCurlyOfEmptyBlocks() throws Exception {
+        verifyWithWholeConfig(getPath("InputWhitespaceBeforeLeftCurlyOfEmptyBlock.java"));
+    }
+
+    @Test
+    public void testWhitespaceBeforeLeftCurlyOfEmptyBlocksFormatted() throws Exception {
+        verifyWithWholeConfig(getPath("InputFormattedWhitespaceBeforeLeftCurlyOfEmptyBlock.java"));
+    }
 }

--- a/src/it/resources/com/google/checkstyle/test/chapter4formatting/rule462horizontalwhitespace/InputFormattedWhitespaceBeforeLeftCurlyOfEmptyBlock.java
+++ b/src/it/resources/com/google/checkstyle/test/chapter4formatting/rule462horizontalwhitespace/InputFormattedWhitespaceBeforeLeftCurlyOfEmptyBlock.java
@@ -1,0 +1,44 @@
+package com.google.checkstyle.test.chapter4formatting.rule462horizontalwhitespace;
+
+/** some javadoc. */
+public class InputFormattedWhitespaceBeforeLeftCurlyOfEmptyBlock {
+
+  InputFormattedWhitespaceBeforeLeftCurlyOfEmptyBlock instance =
+      new InputFormattedWhitespaceBeforeLeftCurlyOfEmptyBlock() {};
+
+  InputFormattedWhitespaceBeforeLeftCurlyOfEmptyBlock() {}
+
+  void method() {}
+
+  class Class {}
+
+  interface Interface {}
+
+  @interface Annotation {}
+
+  enum Enum {}
+
+  record Record() {}
+
+  /** some javadoc. */
+  public static void main(String... args) {
+
+    boolean b = System.currentTimeMillis() < 0;
+
+    while (b) {}
+
+    for (int i = 1; i > 1; i++) {}
+
+    do {} while (b);
+
+    Runnable noop = () -> {};
+  }
+
+  static {
+  }
+
+  record Record2(String str) {
+
+    public Record2 {}
+  }
+}

--- a/src/it/resources/com/google/checkstyle/test/chapter4formatting/rule462horizontalwhitespace/InputWhitespaceBeforeLeftCurlyOfEmptyBlock.java
+++ b/src/it/resources/com/google/checkstyle/test/chapter4formatting/rule462horizontalwhitespace/InputWhitespaceBeforeLeftCurlyOfEmptyBlock.java
@@ -1,0 +1,51 @@
+package com.google.checkstyle.test.chapter4formatting.rule462horizontalwhitespace;
+
+/** some javadoc. */
+public class InputWhitespaceBeforeLeftCurlyOfEmptyBlock {
+
+  InputWhitespaceBeforeLeftCurlyOfEmptyBlock instance =
+      new InputWhitespaceBeforeLeftCurlyOfEmptyBlock(){}; // ok until #10834
+
+  // violation below 'WhitespaceAround: '{' is not preceded with whitespace.'
+  InputWhitespaceBeforeLeftCurlyOfEmptyBlock(){}
+
+  void method(){} // ok until #10834
+
+  class Class{} // ok until #10834
+
+  interface Interface{} // ok until #10834
+
+  @interface Annotation{} // ok until #10834
+
+  enum Enum{} // ok until #10834
+
+  record Record(){} // ok until #10834
+
+  /** some javadoc. */
+  public static void main(String... args) {
+
+    boolean b = System.currentTimeMillis() < 0;
+
+    while (b){} // ok until #10834
+
+    for (int i = 1; i > 1; i++){} // ok until #10834
+
+    do{} while (b);
+    // 2 violations above:
+    //   ''do' is not followed by whitespace.'
+    //   'WhitespaceAround: 'do' is not followed by whitespace. *'
+
+    Runnable noop = () ->{};
+    // 2 violations above:
+    //   ''->' is not followed by whitespace.'
+    //   'WhitespaceAround: '->' is not followed by whitespace. *'
+  }
+
+  static{} // ok until #10834
+
+  record Record2(String str) {
+
+    public Record2{} // violation 'WhitespaceAround: '{' is not preceded with whitespace.'
+
+  }
+}


### PR DESCRIPTION
part of #10834