### PR TITLE
Issue #17401: Added more macro examples to the suppressionfilter.xml.template

### DIFF
--- a/src/site/xdoc/filters/suppressionfilter.xml
+++ b/src/site/xdoc/filters/suppressionfilter.xml
@@ -188,19 +188,171 @@ public class Example1 {
   }
 }
 </code></pre></div><hr class="example-separator"/>
-        <p>
-          Suppress check by <a href="../config.html#Id">module id</a>
-          when config have two instances on the same check:
+        <p id="Example2-config">
+            The following configuration fragment directs the
+            Checker to use a <code>SuppressionFilter</code>
+            with suppressions
+            file <code>suppressionexample2.xml</code>:
+        </p>
+        <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
+&lt;module name="Checker"&gt;
+  &lt;module name="SuppressionFilter"&gt;
+    &lt;property name="file" value="suppressionexample2.xml"/&gt;
+    &lt;property name="optional" value="false"/&gt;
+  &lt;/module&gt;
+  &lt;module name="TreeWalker"&gt;
+    &lt;module name="EqualsAvoidNull"&gt;
+      &lt;property name="id" value="stringEqual"/&gt;
+    &lt;/module&gt;
+    &lt;module name="LineLength"&gt;
+      &lt;property name="id" value="lineLength"/&gt;
+    &lt;/module&gt;
+  &lt;/module&gt;
+&lt;/module&gt;
+</code></pre></div>
+        <p id="suppressionexample2-raw">
+          The following suppressions XML document directs
+          a <code>SuppressionFilter</code> to
+          reject <code>EqualsAvoidNullCheck</code> by
+          <a href="../config.html#Id">module id</a>
+          <code>stringEqual</code> violations for
+          all lines of file <code>Example2.java</code>:
+        </p>
+        <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
+&lt;?xml version="1.0"?&gt;
+
+&lt;!DOCTYPE suppressions PUBLIC
+  "-//Checkstyle//DTD SuppressionFilter Configuration 1.2//EN"
+  "https://checkstyle.org/dtds/suppressions_1_2.dtd"&gt;
+
+&lt;suppressions&gt;
+  &lt;suppress id="stringEqual" files="Example2.java"/&gt;
+&lt;/suppressions&gt;
+</code></pre></div>
+        <p id="Example2-code">Example:</p>
+        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+public class Example2 {
+
+  // violation below, 'Line is longer than 80 characters'
+  String line = "This line is long and exceeds the default limit of 80 characters.";
+
+  public void foo() {
+
+    String nullString = null;
+
+    // filtered violation below 'expressions should be on the left side'
+    nullString.equals("My_Sweet_String");
+    "My_Sweet_String".equals(nullString);
+
+    // filtered violation below 'expressions should be on the left side'
+    nullString.equalsIgnoreCase("My_Sweet_String");
+    "My_Sweet_String".equalsIgnoreCase(nullString);
+  }
+}
+</code></pre></div><hr class="example-separator"/>
+        <p id="Example3-config">
+            The following configuration fragment directs the
+            Checker to use a <code>SuppressionFilter</code>
+            with suppressions
+            file <code>suppressionexample3.xml</code>:
+        </p>
+        <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
+&lt;module name="Checker"&gt;
+  &lt;property name="fileExtensions" value="properties"/&gt;
+
+  &lt;module name="SuppressionFilter"&gt;
+    &lt;property name="file" value="suppressionexample3.xml"/&gt;
+  &lt;/module&gt;
+
+  &lt;module name="OrderedProperties"/&gt;
+  &lt;module name="UniqueProperties"/&gt;
+&lt;/module&gt;
+</code></pre></div>
+        <p id="suppressionexample3-raw">
+          The following suppressions XML document directs
+          a <code>SuppressionFilter</code> to
+          reject all checks for hidden files and folders:
+        </p>
+        <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
+&lt;?xml version="1.0"?&gt;
+
+&lt;!DOCTYPE suppressions PUBLIC
+  "-//Checkstyle//DTD SuppressionFilter Configuration 1.2//EN"
+  "https://checkstyle.org/dtds/suppressions_1_2.dtd"&gt;
+
+&lt;suppressions&gt;
+  &lt;suppress files="[/\\]\..+" checks=".*"/&gt;
+&lt;/suppressions&gt;
+</code></pre></div>
+        <p id="hidden-raw">
+          Below Example is suppressed because
+          <code>hidden.properties</code> file inside
+          the <code>.hidden</code> folder:
         </p>
         <div class="wrapper"><pre class="prettyprint"><code class="language-java">
-&lt;suppress id=&quot;stringEqual&quot; files=&quot;SomeTestCode.java&quot;/&gt;
-        </code></pre></div>
-        <p>
-          Suppress all checks for hidden files and folders:
+keyB=value1 # // filtered violation 'Duplicated property 'keyB' (2 occurrence(s)).'
+keyB=value2
+# // filtered violation below 'Duplicated property 'keyC' (2 occurrence(s)).'
+keyC=value4
+keyC=value5
+</code></pre></div><hr class="example-separator"/>
+        <p id="Example4-config">
+            For example, the following configuration fragment directs the
+            Checker to use a <code>SuppressionFilter</code>
+            with suppressions
+            file <code>suppressionexample4.xml</code>:
         </p>
+        <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
+&lt;module name="Checker"&gt;
+  &lt;module name="SuppressionFilter"&gt;
+    &lt;property name="file" value="suppressionexample4.xml"/&gt;
+    &lt;property name="optional" value="false"/&gt;
+  &lt;/module&gt;
+  &lt;module name="TreeWalker"&gt;
+    &lt;module name="MemberName"&gt;
+      &lt;property name="format" value="^[A-Z][A-Z0-9]*(_[A-Z0-9]+)*$"/&gt;
+    &lt;/module&gt;
+    &lt;module name="ConstantName"/&gt;
+  &lt;/module&gt;
+&lt;/module&gt;
+</code></pre></div>
+        <p id="suppressionexample4-raw">
+          The following suppressions XML document directs
+          a <code>SuppressionFilter</code> to
+          reject violations on variable named
+          'log' in all files:
+        </p>
+        <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
+&lt;?xml version="1.0"?&gt;
+
+&lt;!DOCTYPE suppressions PUBLIC
+  "-//Checkstyle//DTD SuppressionFilter Configuration 1.2//EN"
+  "https://checkstyle.org/dtds/suppressions_1_2.dtd"&gt;
+
+&lt;suppressions&gt;
+  &lt;suppress message="Name 'log' must match pattern"/&gt;
+&lt;/suppressions&gt;
+</code></pre></div>
+        <p id="Example4-code">Example:</p>
         <div class="wrapper"><pre class="prettyprint"><code class="language-java">
-&lt;suppress files=&quot;[/\\]\..+&quot; checks=&quot;.*&quot;/&gt;
-        </code></pre></div>
+public class Example4 {
+
+  public int log;
+  // filtered violation above 'Name 'log' must match pattern'
+
+  public int constant;
+  // violation above 'Name 'constant' must match pattern'
+}
+
+class Inner {
+
+  public static final int log = 10;
+  // filtered violation above 'Name 'log' must match pattern'
+
+  public static final String line = "This is a line";
+  // violation above 'Name 'line' must match pattern'
+}
+</code></pre></div><hr class="example-separator"/>
         <p>
           Suppress all checks for Maven-generated code:
         </p>
@@ -238,12 +390,6 @@ public class Example1 {
         <div class="wrapper"><pre class="prettyprint"><code class="language-java">
 &lt;suppress checks=&quot;FileLength&quot;
 files=&quot;com[\\/]mycompany[\\/]app[\\/].*IT.java&quot;/&gt;
-        </code></pre></div>
-        <p>
-          Suppress naming violations on variable named 'log' in all files:
-        </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
-&lt;suppress message=&quot;Name 'log' must match pattern&quot;/&gt;
         </code></pre></div>
       </subsection>
       <subsection name="Example of Usage" id="Example_of_Usage">

--- a/src/site/xdoc/filters/suppressionfilter.xml.template
+++ b/src/site/xdoc/filters/suppressionfilter.xml.template
@@ -62,19 +62,95 @@
                  value="resources/com/puppycrawl/tools/checkstyle/filters/suppressionfilter/Example1.java"/>
           <param name="type" value="code"/>
         </macro><hr class="example-separator"/>
-        <p>
-          Suppress check by <a href="../config.html#Id">module id</a>
-          when config have two instances on the same check:
+        <p id="Example2-config">
+            The following configuration fragment directs the
+            Checker to use a <code>SuppressionFilter</code>
+            with suppressions
+            file <code>suppressionexample2.xml</code>:
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
-&lt;suppress id="stringEqual" files="SomeTestCode.java"/&gt;
-        </code></pre></div>
-        <p>
-          Suppress all checks for hidden files and folders:
+        <macro name="example">
+          <param name="path"
+                 value="resources/com/puppycrawl/tools/checkstyle/filters/suppressionfilter/Example2.java"/>
+          <param name="type" value="config"/>
+        </macro>
+        <p id="suppressionexample2-raw">
+          The following suppressions XML document directs
+          a <code>SuppressionFilter</code> to
+          reject <code>EqualsAvoidNullCheck</code> by
+          <a href="../config.html#Id">module id</a>
+          <code>stringEqual</code> violations for
+          all lines of file <code>Example2.java</code>:
         </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
-&lt;suppress files="[/\\]\..+" checks=".*"/&gt;
-        </code></pre></div>
+        <macro name="example">
+          <param name="path"
+                 value="resources/com/puppycrawl/tools/checkstyle/filters/suppressionfilter/suppressionexample2.xml"/>
+          <param name="type" value="raw"/>
+        </macro>
+        <p id="Example2-code">Example:</p>
+        <macro name="example">
+          <param name="path"
+                 value="resources/com/puppycrawl/tools/checkstyle/filters/suppressionfilter/Example2.java"/>
+          <param name="type" value="code"/>
+        </macro><hr class="example-separator"/>
+        <p id="Example3-config">
+            The following configuration fragment directs the
+            Checker to use a <code>SuppressionFilter</code>
+            with suppressions
+            file <code>suppressionexample3.xml</code>:
+        </p>
+        <macro name="example">
+          <param name="path"
+                 value="resources/com/puppycrawl/tools/checkstyle/filters/suppressionfilter/Example3.java"/>
+          <param name="type" value="config"/>
+        </macro>
+        <p id="suppressionexample3-raw">
+          The following suppressions XML document directs
+          a <code>SuppressionFilter</code> to
+          reject all checks for hidden files and folders:
+        </p>
+        <macro name="example">
+          <param name="path"
+                 value="resources/com/puppycrawl/tools/checkstyle/filters/suppressionfilter/suppressionexample3.xml"/>
+          <param name="type" value="raw"/>
+        </macro>
+        <p id="hidden-raw">
+          Below Example is suppressed because
+          <code>hidden.properties</code> file inside
+          the <code>.hidden</code> folder:
+        </p>
+        <macro name="example">
+          <param name="path"
+                 value="resources/com/puppycrawl/tools/checkstyle/filters/suppressionfilter/.hidden/hidden.properties"/>
+          <param name="type" value="raw"/>
+        </macro><hr class="example-separator"/>
+        <p id="Example4-config">
+            For example, the following configuration fragment directs the
+            Checker to use a <code>SuppressionFilter</code>
+            with suppressions
+            file <code>suppressionexample4.xml</code>:
+        </p>
+        <macro name="example">
+          <param name="path"
+                 value="resources/com/puppycrawl/tools/checkstyle/filters/suppressionfilter/Example4.java"/>
+          <param name="type" value="config"/>
+        </macro>
+        <p id="suppressionexample4-raw">
+          The following suppressions XML document directs
+          a <code>SuppressionFilter</code> to
+          reject violations on variable named
+          'log' in all files:
+        </p>
+        <macro name="example">
+          <param name="path"
+                 value="resources/com/puppycrawl/tools/checkstyle/filters/suppressionfilter/suppressionexample4.xml"/>
+          <param name="type" value="raw"/>
+        </macro>
+        <p id="Example4-code">Example:</p>
+        <macro name="example">
+          <param name="path"
+                 value="resources/com/puppycrawl/tools/checkstyle/filters/suppressionfilter/Example4.java"/>
+          <param name="type" value="code"/>
+        </macro><hr class="example-separator"/>
         <p>
           Suppress all checks for Maven-generated code:
         </p>
@@ -112,12 +188,6 @@
         <div class="wrapper"><pre class="prettyprint"><code class="language-java">
 &lt;suppress checks="FileLength"
 files="com[\\/]mycompany[\\/]app[\\/].*IT.java"/&gt;
-        </code></pre></div>
-        <p>
-          Suppress naming violations on variable named 'log' in all files:
-        </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
-&lt;suppress message="Name 'log' must match pattern"/&gt;
         </code></pre></div>
       </subsection>
       <subsection name="Example of Usage" id="Example_of_Usage">

--- a/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/filters/SuppressionFilterExamplesTest.java
+++ b/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/filters/SuppressionFilterExamplesTest.java
@@ -47,4 +47,59 @@ public class SuppressionFilterExamplesTest extends AbstractExamplesModuleTestSup
                 expectedWithoutFilter,
                 expectedWithFilter);
     }
+
+    @Test
+    public void testExample2() throws Exception {
+
+        final String[] expectedWithoutFilter = {
+            "23: Line is longer than 80 characters (found 84).",
+            "30:22: String literal expressions should be on the left side of an equals comparison.",
+            "34:32: String literal expressions should be on the left side of "
+                    + "an equalsIgnoreCase comparison.",
+        };
+
+        final String[] expectedWithFilter = {
+            "23: Line is longer than 80 characters (found 84).",
+        };
+
+        verifyFilterWithInlineConfigParser(getPath("Example2.java"),
+                expectedWithoutFilter,
+                expectedWithFilter);
+    }
+
+    @Test
+    public void testExample3() throws Exception {
+
+        final String[] expectedWithoutFilter = {
+            "1: Duplicated property 'keyB' (2 occurrence(s)).",
+            "4: Duplicated property 'keyC' (2 occurrence(s)).",
+        };
+
+        final String[] expectedWithFilter = {};
+
+        verifyFilterWithInlineConfigParserSeparateConfigAndTarget(
+                getPath("Example3.java"),
+                getPath(".hidden/hidden.properties"),
+                expectedWithoutFilter,
+                expectedWithFilter);
+    }
+
+    @Test
+    public void testExample4() throws Exception {
+
+        final String[] expectedWithoutFilter = {
+            "20:14: Name 'log' must match pattern '^[A-Z][A-Z0-9]*(_[A-Z0-9]+)*$'.",
+            "23:14: Name 'constant' must match pattern '^[A-Z][A-Z0-9]*(_[A-Z0-9]+)*$'.",
+            "29:27: Name 'log' must match pattern '^[A-Z][A-Z0-9]*(_[A-Z0-9]+)*$'.",
+            "32:30: Name 'line' must match pattern '^[A-Z][A-Z0-9]*(_[A-Z0-9]+)*$'.",
+        };
+
+        final String[] expectedWithFilter = {
+            "23:14: Name 'constant' must match pattern '^[A-Z][A-Z0-9]*(_[A-Z0-9]+)*$'.",
+            "32:30: Name 'line' must match pattern '^[A-Z][A-Z0-9]*(_[A-Z0-9]+)*$'.",
+        };
+
+        verifyFilterWithInlineConfigParser(getPath("Example4.java"),
+                expectedWithoutFilter, expectedWithFilter);
+    }
 }

--- a/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/filters/suppressionfilter/.hidden/hidden.properties
+++ b/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/filters/suppressionfilter/.hidden/hidden.properties
@@ -1,0 +1,5 @@
+keyB=value1 # // filtered violation 'Duplicated property 'keyB' (2 occurrence(s)).'
+keyB=value2
+# // filtered violation below 'Duplicated property 'keyC' (2 occurrence(s)).'
+keyC=value4
+keyC=value5

--- a/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/filters/suppressionfilter/Example2.java
+++ b/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/filters/suppressionfilter/Example2.java
@@ -1,0 +1,38 @@
+/*xml
+<module name="Checker">
+  <module name="SuppressionFilter">
+    <property name="file" value="suppressionexample2.xml"/>
+    <property name="optional" value="false"/>
+  </module>
+  <module name="TreeWalker">
+    <module name="EqualsAvoidNull">
+      <property name="id" value="stringEqual"/>
+    </module>
+    <module name="LineLength">
+      <property name="id" value="lineLength"/>
+    </module>
+  </module>
+</module>
+*/
+
+package com.puppycrawl.tools.checkstyle.filters.suppressionfilter;
+// xdoc section -- start
+public class Example2 {
+
+  // violation below, 'Line is longer than 80 characters'
+  String line = "This line is long and exceeds the default limit of 80 characters.";
+
+  public void foo() {
+
+    String nullString = null;
+
+    // filtered violation below 'expressions should be on the left side'
+    nullString.equals("My_Sweet_String");
+    "My_Sweet_String".equals(nullString);
+
+    // filtered violation below 'expressions should be on the left side'
+    nullString.equalsIgnoreCase("My_Sweet_String");
+    "My_Sweet_String".equalsIgnoreCase(nullString);
+  }
+}
+// xdoc section -- end

--- a/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/filters/suppressionfilter/Example3.java
+++ b/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/filters/suppressionfilter/Example3.java
@@ -1,0 +1,19 @@
+/*xml
+<module name="Checker">
+  <property name="fileExtensions" value="properties"/>
+
+  <module name="SuppressionFilter">
+    <property name="file" value="suppressionexample3.xml"/>
+  </module>
+
+  <module name="OrderedProperties"/>
+  <module name="UniqueProperties"/>
+</module>
+*/
+
+package com.puppycrawl.tools.checkstyle.filters.suppressionfilter;
+
+public class Example3 {}
+
+// xdoc section -- start
+// xdoc section -- end

--- a/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/filters/suppressionfilter/Example4.java
+++ b/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/filters/suppressionfilter/Example4.java
@@ -1,0 +1,35 @@
+/*xml
+<module name="Checker">
+  <module name="SuppressionFilter">
+    <property name="file" value="suppressionexample4.xml"/>
+    <property name="optional" value="false"/>
+  </module>
+  <module name="TreeWalker">
+    <module name="MemberName">
+      <property name="format" value="^[A-Z][A-Z0-9]*(_[A-Z0-9]+)*$"/>
+    </module>
+    <module name="ConstantName"/>
+  </module>
+</module>
+*/
+
+package com.puppycrawl.tools.checkstyle.filters.suppressionfilter;
+// xdoc section -- start
+public class Example4 {
+
+  public int log;
+  // filtered violation above 'Name 'log' must match pattern'
+
+  public int constant;
+  // violation above 'Name 'constant' must match pattern'
+}
+
+class Inner {
+
+  public static final int log = 10;
+  // filtered violation above 'Name 'log' must match pattern'
+
+  public static final String line = "This is a line";
+  // violation above 'Name 'line' must match pattern'
+}
+// xdoc section -- end

--- a/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/filters/suppressionfilter/suppressionexample2.xml
+++ b/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/filters/suppressionfilter/suppressionexample2.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0"?>
+
+<!DOCTYPE suppressions PUBLIC
+  "-//Checkstyle//DTD SuppressionFilter Configuration 1.2//EN"
+  "https://checkstyle.org/dtds/suppressions_1_2.dtd">
+
+<suppressions>
+  <suppress id="stringEqual" files="Example2.java"/>
+</suppressions>

--- a/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/filters/suppressionfilter/suppressionexample3.xml
+++ b/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/filters/suppressionfilter/suppressionexample3.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0"?>
+
+<!DOCTYPE suppressions PUBLIC
+  "-//Checkstyle//DTD SuppressionFilter Configuration 1.2//EN"
+  "https://checkstyle.org/dtds/suppressions_1_2.dtd">
+
+<suppressions>
+  <suppress files="[/\\]\..+" checks=".*"/>
+</suppressions>

--- a/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/filters/suppressionfilter/suppressionexample4.xml
+++ b/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/filters/suppressionfilter/suppressionexample4.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0"?>
+
+<!DOCTYPE suppressions PUBLIC
+  "-//Checkstyle//DTD SuppressionFilter Configuration 1.2//EN"
+  "https://checkstyle.org/dtds/suppressions_1_2.dtd">
+
+<suppressions>
+  <suppress message="Name 'log' must match pattern"/>
+</suppressions>


### PR DESCRIPTION
part of #17401

Added examples 2, 3 and4 to the `suppressionfilter.xml.template`.

I am unable to add example for maven-generated code because `target` folder is ignored by git.