### PR TITLE
Issue #10834: Enforce whitespace before `{` of empty method-blocks

### DIFF
--- a/src/it/resources/com/google/checkstyle/test/chapter4formatting/rule451wheretobreak/InputNoWrappingAfterRecordName.java
+++ b/src/it/resources/com/google/checkstyle/test/chapter4formatting/rule451wheretobreak/InputNoWrappingAfterRecordName.java
@@ -26,7 +26,7 @@ public record InputNoWrappingAfterRecordName (String name) {
   }
 
   record Multi4 () { // violation ''(' is preceded with whitespace'
-    void foo (){} // violation ''(' is preceded with whitespace'
+    void foo () {} // violation ''(' is preceded with whitespace'
   }
 
   record Multi5() {

--- a/src/it/resources/com/google/checkstyle/test/chapter4formatting/rule451wheretobreak/InputNoWrappingAfterRecordName2.java
+++ b/src/it/resources/com/google/checkstyle/test/chapter4formatting/rule451wheretobreak/InputNoWrappingAfterRecordName2.java
@@ -36,6 +36,7 @@ public class InputNoWrappingAfterRecordName2 {
 
     @InSize(limit = 2)
     void foo (){} // violation ''(' is preceded with whitespace'
+    // violation above 'WhitespaceAround: '{' is not preceded with whitespace'
   }
 
   record Multi5() {

--- a/src/it/resources/com/google/checkstyle/test/chapter4formatting/rule462horizontalwhitespace/InputFormattedWhitespaceBeforeLeftCurlyOfEmptyBlock.java
+++ b/src/it/resources/com/google/checkstyle/test/chapter4formatting/rule462horizontalwhitespace/InputFormattedWhitespaceBeforeLeftCurlyOfEmptyBlock.java
@@ -8,7 +8,18 @@ public class InputFormattedWhitespaceBeforeLeftCurlyOfEmptyBlock {
 
   InputFormattedWhitespaceBeforeLeftCurlyOfEmptyBlock() {}
 
-  void method() {}
+  void method1(int k) {
+    {
+    }
+  }
+
+  void method2() {}
+
+  /** some javadoc. */
+  public void method3() {}
+
+  /** some javadoc. */
+  public void method4() {}
 
   class Class {}
 

--- a/src/it/resources/com/google/checkstyle/test/chapter4formatting/rule462horizontalwhitespace/InputWhitespaceBeforeLeftCurlyOfEmptyBlock.java
+++ b/src/it/resources/com/google/checkstyle/test/chapter4formatting/rule462horizontalwhitespace/InputWhitespaceBeforeLeftCurlyOfEmptyBlock.java
@@ -9,7 +9,22 @@ public class InputWhitespaceBeforeLeftCurlyOfEmptyBlock {
   // violation below 'WhitespaceAround: '{' is not preceded with whitespace.'
   InputWhitespaceBeforeLeftCurlyOfEmptyBlock(){}
 
-  void method(){} // ok until #10834
+  void method1(int k) {
+    {}
+    // 2 violations above:
+    //   ''{' is not followed by whitespace.'
+    //   ''}' is not preceded with whitespace.'
+  }
+
+  void method2(){} // violation ''{' is not preceded with whitespace'
+
+  /** some javadoc. */
+  public void method3(){} // violation ''{' is not preceded with whitespace'
+
+  /** some javadoc. */
+  public void method4(){ // violation 'WhitespaceAround: '{' is not preceded with whitespace'
+
+  }
 
   class Class{} // ok until #10834
 
@@ -42,6 +57,8 @@ public class InputWhitespaceBeforeLeftCurlyOfEmptyBlock {
   }
 
   static{} // ok until #10834
+
+  record Record1(String name){}
 
   record Record2(String str) {
 

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/whitespace/WhitespaceAroundCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/whitespace/WhitespaceAroundCheckTest.java
@@ -680,4 +680,22 @@ public class WhitespaceAroundCheckTest
                 getPath(fileName),
                 expected);
     }
+
+    @Test
+    public void testWhitespaceAroundLeftCurlyOfEmptyMethodBlock() throws Exception {
+        final String fileName = "InputWhitespaceAroundLeftCurlyOfEmptyMethodBlock.java";
+
+        final String[] expected = {
+            "31:55: " + getCheckMessage(MSG_WS_NOT_PRECEDED, "{"),
+            "34:9: " + getCheckMessage(MSG_WS_NOT_FOLLOWED, "{"),
+            "34:10: " + getCheckMessage(MSG_WS_NOT_PRECEDED, "}"),
+            "43:9: " + getCheckMessage(MSG_WS_NOT_FOLLOWED, "}"),
+            "43:10: " + getCheckMessage(MSG_WS_NOT_PRECEDED, "}"),
+            "48:19: " + getCheckMessage(MSG_WS_NOT_PRECEDED, "{"),
+            "51:26: " + getCheckMessage(MSG_WS_NOT_PRECEDED, "{"),
+            "54:49: " + getCheckMessage(MSG_WS_NOT_PRECEDED, "}"),
+            "57:77: " + getCheckMessage(MSG_WS_NOT_PRECEDED, "}"),
+        };
+        verifyWithInlineConfigParser(getPath(fileName), expected);
+    }
 }

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/whitespace/whitespacearound/InputWhitespaceAroundLeftCurlyOfEmptyMethodBlock.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/whitespace/whitespacearound/InputWhitespaceAroundLeftCurlyOfEmptyMethodBlock.java
@@ -1,0 +1,60 @@
+/*
+WhitespaceAround
+allowEmptyConstructors = true
+allowEmptyMethods = true
+allowEmptyTypes =true
+allowEmptyLoops = true
+allowEmptyLambdas = true
+allowEmptyCatches = (default)false
+allowEmptySwitchBlockStatements = true
+ignoreEnhancedForColon = false
+tokens = (default)ASSIGN, BAND, BAND_ASSIGN, BOR, BOR_ASSIGN, BSR, BSR_ASSIGN, BXOR, \
+         BXOR_ASSIGN, COLON, DIV, DIV_ASSIGN, DO_WHILE, EQUAL, GE, GT, LAMBDA, LAND, \
+         LCURLY, LE, LITERAL_CATCH, LITERAL_DO, LITERAL_ELSE, LITERAL_FINALLY, \
+         LITERAL_FOR, LITERAL_IF, LITERAL_RETURN, LITERAL_SWITCH, LITERAL_SYNCHRONIZED, \
+         LITERAL_TRY, LITERAL_WHILE, LOR, LT, MINUS, MINUS_ASSIGN, MOD, MOD_ASSIGN, \
+         NOT_EQUAL, PLUS, PLUS_ASSIGN, QUESTION, RCURLY, SL, SLIST, SL_ASSIGN, SR, \
+         SR_ASSIGN, STAR, STAR_ASSIGN, LITERAL_ASSERT, TYPE_EXTENSION_AND
+
+
+*/
+
+package com.puppycrawl.tools.checkstyle.checks.whitespace.whitespacearound;
+
+/** some javadoc. */
+public class InputWhitespaceAroundLeftCurlyOfEmptyMethodBlock {
+
+    InputWhitespaceAroundLeftCurlyOfEmptyMethodBlock instance =
+        new InputWhitespaceAroundLeftCurlyOfEmptyMethodBlock(){}; // ok until #10834
+
+    // violation below ''{' is not preceded with whitespace'
+    InputWhitespaceAroundLeftCurlyOfEmptyMethodBlock(){}
+
+    void method1(int k) {
+        {}
+        // 2 violations above:
+        //   ''{' is not followed by whitespace.'
+        //   ''}' is not preceded with whitespace.'
+    }
+
+    void method5(int k) {
+        if (k > 5) {
+            int i = 1;
+        }}
+    // 2 violations above:
+    //   ''}' is not followed by whitespace'
+    //   ''}' is not preceded with whitespace'
+
+    void method2(){} // violation ''{' is not preceded with whitespace'
+
+    /** some javadoc. */
+    public void method3(){} // violation ''{' is not preceded with whitespace'
+
+    /** some javadoc. */
+    public static int foo(int val) { return val;}
+    // violation above ''}' is not preceded with whitespace'
+
+    class Inner { public static boolean foo2() { return "😂 ".equals("da👉🏻");}
+        // violation above ''}' is not preceded with whitespace'
+    }
+}


### PR DESCRIPTION
part of #10834 