### PR TITLE
Issue #14631:  Added Javadocs for  OPTGROUP_TAG_START in JavadocTokenTypes

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/api/JavadocTokenTypes.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/api/JavadocTokenTypes.java
@@ -2864,31 +2864,33 @@ public final class JavadocTokenTypes {
     /** `optgroup` html tag. */
     public static final int OPTGROUP = JavadocParser.RULE_optgroup + RULE_TYPES_OFFSET;
 
-    /**
-    *  Optgroup HTML tag start.
+/**
+     *  Optgroup HTML tag.
      *
      *  <p><b>Example:</b></p>
-     *  <pre>{@code
-     *  <select>
-     *      <optgroup label="Fruits">
-     *          <option>Apple</option>
-     *      </optgroup>
-     *  </select>
-     *  }</pre>
+     *  <pre>{@code <select><optgroup label="Fruits"><option>Apple</option></optgroup></select>}</pre>
      *
      *  <b>Tree:</b>
      *  <pre>
      *  {@code
      *     JAVADOC -> JAVADOC
+     *      |--NEWLINE -> \r\n
+     *      |--LEADING_ASTERISK -> *
+     *      |--WS ->
      *      |--JAVADOC_TAG -> JAVADOC_TAG
-     *      |   `--HTML_ELEMENT -> HTML_ELEMENT
-     *      |       `--OPTGROUP_TAG_START -> OPTGROUP_TAG_START
-     *      |           |--START -> <
-     *      |           |--OPTGROUP_HTML_TAG_NAME -> optgroup
-     *      |           `--END -> >
-     *  }
-     *  </pre>
- */
+     *      |   |--CUSTOM_NAME -> @code
+     *      |   |--WS ->
+     *      |   `--DESCRIPTION -> DESCRIPTION
+     *      |       |--HTML_ELEMENT -> HTML_ELEMENT
+     *      |       |   `--OPTGROUP_TAG_START -> OPTGROUP_TAG_START
+     *      |       |       |--START -> <
+     *      |       |       |--OPTGROUP_HTML_TAG_NAME -> optgroup
+     *      |       |       `--END -> >
+     *      |       |--NEWLINE -> \r\n
+     *      |       `--TEXT ->
+     * }
+     * </pre>
+     */
 public static final int OPTGROUP_TAG_START =
         JavadocParser.RULE_optgroupTagStart + RULE_TYPES_OFFSET;
 


### PR DESCRIPTION
Issue #14631 

**Command used**

`java -jar checkstyle-10.26.1-all.jar -J Test.java | sed "s/\[[0-9]\+:[0-9]\+\]//g"`


**Test.java** 


```
/**
* @code <optgroup>
 */
public class Test {

}

```
```
brahm@Ashishbrahmadande MINGW64 ~/OPTGROUP_TAG_START start
$ java -jar checkstyle-10.26.1-all.jar -J Test.java | sed "s/\[[0-9]\+:[0-9]\+\]//g"
COMPILATION_UNIT -> COMPILATION_UNIT
`--CLASS_DEF -> CLASS_DEF
    |--MODIFIERS -> MODIFIERS
    |   |--BLOCK_COMMENT_BEGIN -> /*
    |   |   |--COMMENT_CONTENT -> *\r\n* @code <optgroup>\r\n
    |   |   |   `--JAVADOC -> JAVADOC
    |   |   |       |--NEWLINE -> \r\n
    |   |   |       |--LEADING_ASTERISK -> *
    |   |   |       |--WS ->
    |   |   |       |--JAVADOC_TAG -> JAVADOC_TAG
    |   |   |       |   |--CUSTOM_NAME -> @code
    |   |   |       |   |--WS ->
    |   |   |       |   `--DESCRIPTION -> DESCRIPTION
    |   |   |       |       |--HTML_ELEMENT -> HTML_ELEMENT
    |   |   |       |       |   `--OPTGROUP_TAG_START -> OPTGROUP_TAG_START
    |   |   |       |       |       |--START -> <
    |   |   |       |       |       |--OPTGROUP_HTML_TAG_NAME -> optgroup
    |   |   |       |       |       `--END -> >
    |   |   |       |       |--NEWLINE -> \r\n
    |   |   |       |       `--TEXT ->
    |   |   |       `--EOF -> <EOF>
    |   |   `--BLOCK_COMMENT_END -> */
    |   `--LITERAL_PUBLIC -> public
    |--LITERAL_CLASS -> class
    |--IDENT -> Test
    `--OBJBLOCK -> OBJBLOCK
        |--LCURLY -> {
        `--RCURLY -> }
```