### PR TITLE
Issue #17332: Fixed False positive for JavadocType:Unused @param tag

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -15,6 +15,7 @@
 /src/test/resources/com/puppycrawl/tools/checkstyle/checks/newlineatendoffile/InputNewlineAtEndOfFileCrlf.java eol=crlf
 /src/test/resources/com/puppycrawl/tools/checkstyle/checks/newlineatendoffile/InputNewlineAtEndOfFileCrlf2.java eol=crlf
 /src/test/resources/com/puppycrawl/tools/checkstyle/checks/newlineatendoffile/InputNewlineAtEndOfFileCrlf3.java eol=crlf
+/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadoctype/InputJavadocTypeWithBlockComment.java eol=crlf
 /src/test/resources/com/puppycrawl/tools/checkstyle/checks/newlineatendoffile/InputNewlineAtEndOfFileCr.java -text
 /src/test/resources/com/puppycrawl/tools/checkstyle/checks/newlineatendoffile/InputNewlineAtEndOfFileCr2.java -text
 src/test/resources-noncompilable/com/puppycrawl/tools/checkstyle/xpath/xpathquerygenerator/InputXpathQueryGeneratorTextBlockCrlf.java eol=crlf

--- a/config/checkstyle-resources-suppressions.xml
+++ b/config/checkstyle-resources-suppressions.xml
@@ -79,6 +79,10 @@
   <!-- intentional problem for testing -->
   <suppress checks="PackageDeclarationCheck"
     files="uncommentedmain[\\/]InputUncommentedMainBeginTreePackage2\.java"/>
+  
+  <!-- intentional problem for testing -->
+  <suppress checks="RegexpSingleline"
+    files="javadoctype[\\/]InputJavadocTypeWithBlockComment\.java"/>          
 
   <!-- intentional problem for testing -->
   <suppress checks="OuterTypeFilename"

--- a/pom.xml
+++ b/pom.xml
@@ -4632,6 +4632,7 @@
                 <param>com.puppycrawl.tools.checkstyle.checks.OuterTypeFilenameCheckTest</param>
                 <param>com.puppycrawl.tools.checkstyle.checks.sizes.LineLengthCheckTest</param>
                 <param>com.puppycrawl.tools.checkstyle.checks.javadoc.NonEmptyAtclauseDescriptionCheckTest</param>
+                <param>com.puppycrawl.tools.checkstyle.checks.javadoc.JavadocTypeCheckTest</param>
                 <param>org.checkstyle.suppressionxpathfilter.XpathRegressionUnusedLocalVariableTest</param>
                 <param>com.puppycrawl.tools.checkstyle.checks.javadoc.SummaryJavadocCheckTest</param>
                 <param>org.checkstyle.suppressionxpathfilter.XpathRegressionJavadocMethodTest</param>

--- a/src/main/java/com/puppycrawl/tools/checkstyle/api/FileContents.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/api/FileContents.java
@@ -239,16 +239,31 @@ public final class FileContents implements CommentListener {
         return values.stream()
             .flatMap(List::stream)
             .filter(comment -> !javadocComments.containsValue(comment))
-            .anyMatch(comment -> {
-                final boolean lineInSideBlockComment = lineNo >= comment.getStartLineNo()
-                                                    && lineNo <= comment.getEndLineNo();
-                boolean lineHasOnlyBlockComment = true;
-                if (comment.getStartLineNo() == comment.getEndLineNo()) {
-                    final String line = line(comment.getStartLineNo() - 1).trim();
-                    lineHasOnlyBlockComment = line.startsWith("/*") && line.endsWith("*/");
-                }
-                return lineInSideBlockComment && lineHasOnlyBlockComment;
-            });
+            .anyMatch(comment -> isLineBlockComment(lineNo, comment));
+    }
+
+    /**
+     * Checks if the given line is inside a block comment
+     * and both the start and end lines contain only the comment.
+     *
+     * @param lineNo the line number to check
+     * @param comment the block comment to inspect
+     * @return {@code true} line is in block comment, {@code false} otherwise
+     */
+    private boolean isLineBlockComment(int lineNo, TextBlock comment) {
+        final boolean lineInSideBlockComment = lineNo >= comment.getStartLineNo()
+                && lineNo <= comment.getEndLineNo();
+        boolean lineHasOnlyBlockComment = true;
+        final String startLine = line(comment.getStartLineNo() - 1).trim();
+        if (!startLine.startsWith("/*")) {
+            lineHasOnlyBlockComment = false;
+        }
+
+        final String endLine = line(comment.getEndLineNo() - 1).trim();
+        if (!endLine.endsWith("*/")) {
+            lineHasOnlyBlockComment = false;
+        }
+        return lineInSideBlockComment && lineHasOnlyBlockComment;
     }
 
     /**

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocTypeCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocTypeCheckTest.java
@@ -480,4 +480,20 @@ public class JavadocTypeCheckTest extends AbstractModuleTestSupport {
         verifyWithInlineConfigParser(
                 getPath("InputJavadocTypeAboveComments.java"), expected);
     }
+
+    @Test
+    public void testJavadocWithNative() throws Exception {
+        final String[] expected = CommonUtil.EMPTY_STRING_ARRAY;
+        verifyWithInlineConfigParser(
+                getPath("InputJavadocTypeWithNative.java"), expected);
+    }
+
+    @Test
+    public void testJavadocTypeWithBlockComment() throws Exception {
+        final String[] expected = {
+            "21:5: " + getCheckMessage(MSG_UNUSED_TAG, "@param", "<T>"),
+        };
+        verifyWithInlineConfigParser(
+                getPath("InputJavadocTypeWithBlockComment.java"), expected);
+    }
 }

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadoctype/InputJavadocTypeWithBlockComment.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadoctype/InputJavadocTypeWithBlockComment.java
@@ -1,0 +1,28 @@
+/*
+JavadocType
+scope = (default)private
+excludeScope = (default)null
+authorFormat = (default)null
+versionFormat = (default)null
+allowMissingParamTags = (default)false
+allowUnknownTags = (default)false
+allowedAnnotations = (default)Generated
+tokens = (default)INTERFACE_DEF, CLASS_DEF, ENUM_DEF, ANNOTATION_DEF, RECORD_DEF
+
+
+*/
+
+package com.puppycrawl.tools.checkstyle.checks.javadoc.javadoctype;
+
+// violation 4 lines below 'Unused @param tag for '<T>'.'
+/**
+ *  InputJavadocTypeUnusedParamInJavadocForClass.
+ *
+ *  @param <T> This is type parameter.
+ */
+   /* This is Block Comment
+      This is part of block comment
+      This is also part of block comment
+   */  
+public class InputJavadocTypeWithBlockComment {
+}

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadoctype/InputJavadocTypeWithNative.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadoctype/InputJavadocTypeWithNative.java
@@ -1,0 +1,31 @@
+/*
+JavadocType
+scope = (default)private
+excludeScope = (default)null
+authorFormat = (default)null
+versionFormat = \\S
+allowMissingParamTags = true
+allowUnknownTags = true
+allowedAnnotations = (default)Generated
+tokens = (default)INTERFACE_DEF, CLASS_DEF, ENUM_DEF, ANNOTATION_DEF, RECORD_DEF
+
+
+*/
+
+package com.puppycrawl.tools.checkstyle.checks.javadoc.javadoctype;
+
+public class InputJavadocTypeWithNative {
+
+    /**
+     * Creates Plugin
+     *
+     * @param chartComponent chart component
+     * @return plugin
+     */
+    private native String createPlugin(Long chartComponent) /*-{
+        return pluginModel;
+    }-*/;
+
+    private interface PluginModel {
+    }
+}


### PR DESCRIPTION
Issue: #17332

Fixed logic for determining valid block comment 
```
                if (comment.getStartLineNo() == comment.getEndLineNo()) {
                    final String line = line(comment.getStartLineNo() - 1).trim();
                    lineHasOnlyBlockComment = line.startsWith("/*") && line.endsWith("*/");
                }
```

is updated to

```
        final String startLine = line(comment.getStartLineNo() - 1).trim();
        if (!startLine.startsWith("/*")) {
            lineHasOnlyBlockComment = false;
        }

        final String endLine = line(comment.getEndLineNo() - 1).trim();
        if (!endLine.endsWith("*/")) {
            lineHasOnlyBlockComment = false;
        }
```

