### PR TITLE
Issue #17031: Fix compareTo method for TestInputViolation.java

### DIFF
--- a/src/it/resources/com/google/checkstyle/test/chapter4formatting/rule462horizontalwhitespace/InputFormattedNoWhitespaceBeforeAnnotations.java
+++ b/src/it/resources/com/google/checkstyle/test/chapter4formatting/rule462horizontalwhitespace/InputFormattedNoWhitespaceBeforeAnnotations.java
@@ -9,7 +9,7 @@ public class InputFormattedNoWhitespaceBeforeAnnotations {
   @Target(ElementType.TYPE_USE)
   @interface NonNull {}
 
-  @NonNull int @NonNull [] @NonNull [] fiel1; // ok until #8205
+  @NonNull int @NonNull [] @NonNull [] fiel1; // ok until #17451
   @NonNull int @NonNull [] @NonNull [] field2;
 
   /** some javadoc. */
@@ -25,7 +25,7 @@ public class InputFormattedNoWhitespaceBeforeAnnotations {
   public void foo2(final char[] param) {}
 
   /** some javadoc. */
-  public void foo3(final char @NonNull [] param) {} // ok until #8205
+  public void foo3(final char @NonNull [] param) {} // ok until #17451
 
   /** some javadoc. */
   public void foo4(final char @NonNull [] param) {}

--- a/src/it/resources/com/google/checkstyle/test/chapter4formatting/rule462horizontalwhitespace/InputNoWhitespaceBeforeAnnotations.java
+++ b/src/it/resources/com/google/checkstyle/test/chapter4formatting/rule462horizontalwhitespace/InputNoWhitespaceBeforeAnnotations.java
@@ -9,7 +9,7 @@ public class InputNoWhitespaceBeforeAnnotations {
   @Target(ElementType.TYPE_USE)
   @interface NonNull {}
 
-  @NonNull int @NonNull [] @NonNull [] fiel1; // ok until #8205
+  @NonNull int @NonNull [] @NonNull [] fiel1; // ok until #17451
   @NonNull int @NonNull [] @NonNull [] field2; // ok
 
   /** some javadoc. */
@@ -25,7 +25,7 @@ public class InputNoWhitespaceBeforeAnnotations {
   public void foo2(final char[] param) {} // ok
 
   /** some javadoc. */
-  public void foo3(final char @NonNull [] param) {} // ok until #8205
+  public void foo3(final char @NonNull [] param) {} // ok until #17451
 
   /** some javadoc. */
   public void foo4(final char @NonNull [] param) {} // ok

--- a/src/site/xdoc/filters/suppresswithnearbycommentfilter.xml
+++ b/src/site/xdoc/filters/suppresswithnearbycommentfilter.xml
@@ -253,8 +253,9 @@ public class Example5 {
         <div class="wrapper"><pre class="prettyprint"><code class="language-java">
 public class Example6 {
   // @cs.suppress [ConstantName|NoWhitespaceAfter] A comment here
-  public static final int [] array = {}; // filtered violation
-  // filtered violation above
+  public static final int [] array = {};
+  // filtered violation above '1: followed by whitespace'
+  // filtered violation 3 lines above '2: must match pattern'
 }
 </code></pre></div>
         <p>

--- a/src/test/java/com/puppycrawl/tools/checkstyle/bdd/TestInputViolation.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/bdd/TestInputViolation.java
@@ -76,7 +76,13 @@ public final class TestInputViolation implements Comparable<TestInputViolation> 
     public String toRegex() {
         String regex = lineNo + ":(?:\\d+:)?\\s.*";
         if (message != null) {
-            String rawMessage = message;
+            String rawMessage;
+            if (message.matches("^\\d+:\\s.*")) {
+                rawMessage = message.replaceFirst("^\\d+:\\s*", "");
+            }
+            else {
+                rawMessage = message;
+            }
             rawMessage = OPEN_CURLY_PATTERN.matcher(rawMessage).replaceAll("\\\\{");
             rawMessage = OPEN_PAREN_PATTERN.matcher(rawMessage).replaceAll("\\\\(");
             rawMessage = CLOSE_PAREN_PATTERN.matcher(rawMessage).replaceAll("\\\\)");
@@ -89,7 +95,7 @@ public final class TestInputViolation implements Comparable<TestInputViolation> 
     public int compareTo(TestInputViolation testInputViolation) {
         final int result;
         if (message != null && lineNo == testInputViolation.lineNo) {
-            result = testInputViolation.message.compareTo(message);
+            result = message.compareTo(testInputViolation.message);
         }
         else {
             result = Integer.compare(lineNo, testInputViolation.lineNo);

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppresswithnearbytextfilter/InputSuppressWithNearbyTextFilterNearbyTextPattern.css.txt
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppresswithnearbytextfilter/InputSuppressWithNearbyTextFilterNearbyTextPattern.css.txt
@@ -29,9 +29,9 @@ maximum = (default)0
 }
 
 .div-1 main>h1 {
-  // filtered violation below 'Line is longer than 90 characters (found 93).'
+  // filtered violation below '2: Line is longer than 90 characters (found 93).'
   margiin: "this should not appear"; /* -cs: Long comment explainingasdasdasdasdasdasdasda */
-  // filtered violation above 'Line matches the illegal pattern .*'
+  // filtered violation above '1: Line matches the illegal pattern .*'
 }
 
 .div-1 input[type="date"]::-webkit-calendar-picker-indicator {

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppresswithplaintextcommentfilter/InputSuppressWithPlainTextCommentFilterCustomMessageFormat.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppresswithplaintextcommentfilter/InputSuppressWithPlainTextCommentFilterCustomMessageFormat.java
@@ -31,8 +31,8 @@ public class InputSuppressWithPlainTextCommentFilterCustomMessageFormat {
     // CHECKSTYLE:OFF
     private int A1; // violation 'illegal pattern'
 
-	private static final int a1 = 5; // filtered violation 'contains a tab'
-    // violation above 'illegal pattern'
+	private static final int a1 = 5; // filtered violation '2: contains a tab'
+    // violation above '1: illegal pattern'
     int a2 = 100; // violation 'illegal pattern'
 
     // CHECKSTYLE:ON

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppresswithplaintextcommentfilter/InputSuppressWithPlainTextCommentFilterSuppressById.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppresswithplaintextcommentfilter/InputSuppressWithPlainTextCommentFilterSuppressById.java
@@ -33,8 +33,8 @@ public class InputSuppressWithPlainTextCommentFilterSuppressById {
     private int A1; // violation 'illegal pattern'
 
     // @cs-: ignore (reason)
-	private static final int a1 = 5; // filtered violation 'contains a tab'
-    // violation above 'illegal pattern'
+	private static final int a1 = 5; // filtered violation '2: contains a tab'
+    // violation above '1: illegal pattern'
     int a2 = 100; // violation 'illegal pattern'
     //CSON ignore
 

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppresswithplaintextcommentfilter/InputSuppressWithPlainTextCommentFilterSuppressById2.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppresswithplaintextcommentfilter/InputSuppressWithPlainTextCommentFilterSuppressById2.java
@@ -33,8 +33,8 @@ public class InputSuppressWithPlainTextCommentFilterSuppressById2 { // violation
     private int A1; // filtered violation 'illegal pattern'
 
     // @cs-: ignore (reason)
-	private static final int a1 = 5; // filtered violation 'illegal pattern'
-    // violation above 'Line contains a tab character.'
+	private static final int a1 = 5; // filtered violation '1: illegal pattern'
+    // violation above '2: Line contains a tab character.'
     int a2 = 100; // filtered violation 'illegal pattern'
     //CSON ignore
 

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppresswithplaintextcommentfilter/InputSuppressWithPlainTextCommentFilterSuppressById3.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppresswithplaintextcommentfilter/InputSuppressWithPlainTextCommentFilterSuppressById3.java
@@ -33,8 +33,8 @@ public class InputSuppressWithPlainTextCommentFilterSuppressById3 { // violation
     private int A1; // violation 'illegal pattern'
 
     // @cs-: ignore (reason)
-	private static final int a1 = 5; // filtered violation 'contains a tab'
-    // violation above 'illegal pattern'
+	private static final int a1 = 5; // filtered violation '2: contains a tab'
+    // violation above '1: illegal pattern'
     int a2 = 100; // violation 'illegal pattern'
     //CSON ignore
 

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppresswithplaintextcommentfilter/InputSuppressWithPlainTextCommentFilterSuppressById4.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppresswithplaintextcommentfilter/InputSuppressWithPlainTextCommentFilterSuppressById4.java
@@ -33,8 +33,8 @@ public class InputSuppressWithPlainTextCommentFilterSuppressById4 { // violation
     private int A1; // violation 'illegal pattern'
 
     // @cs-: ignore (reason)
-	private static final int a1 = 5; // violation 'illegal pattern'
-    // violation above 'contains a tab'
+	private static final int a1 = 5; // violation '1: illegal pattern'
+    // violation above '2: contains a tab'
     int a2 = 100; // violation 'illegal pattern'
     //CSON ignore
 

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppresswithplaintextcommentfilter/InputSuppressWithPlainTextCommentFilterSuppressById5.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppresswithplaintextcommentfilter/InputSuppressWithPlainTextCommentFilterSuppressById5.java
@@ -33,8 +33,8 @@ public class InputSuppressWithPlainTextCommentFilterSuppressById5 { // violation
     private int A1; // filtered violation 'illegal pattern'
 
     // @cs-: ignore (reason)
-	private static final int a1 = 5; // filtered violation 'illegal pattern'
-    // violation above 'Line contains a tab character.'
+	private static final int a1 = 5; // filtered violation '1: illegal pattern'
+    // violation above '2: Line contains a tab character.'
     int a2 = 100; // filtered violation 'illegal pattern'
     //CSON ignore
 

--- a/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/filters/suppresswithnearbycommentfilter/Example6.java
+++ b/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/filters/suppresswithnearbycommentfilter/Example6.java
@@ -16,7 +16,8 @@ package com.puppycrawl.tools.checkstyle.filters.suppresswithnearbycommentfilter;
 // xdoc section -- start
 public class Example6 {
   // @cs.suppress [ConstantName|NoWhitespaceAfter] A comment here
-  public static final int [] array = {}; // filtered violation
-  // filtered violation above
+  public static final int [] array = {};
+  // filtered violation above '1: followed by whitespace'
+  // filtered violation 3 lines above '2: must match pattern'
 }
 // xdoc section -- end


### PR DESCRIPTION
Issue #17031

previous violations or filtered violations comment when lines are equal:
`// violation 'some message'` or `// filtered violation 'some message'`

now
`// violation 'num: some message'` or `// filtered violation 'num: some message'` where `num` refers to the violation that comes first, denoted by the smallest integer. We can also use the column number instead. However, it doesn't matter what we use — the `num` is only added to help with sorting, first by line number, then by message.

Previously, the `compareTo()` method sorted in reverse chronological order when the line numbers were equal. Now, it sorts in chronological order.
