### PR TITLE
Issue #17031: Fix compareTo method for TestInputViolation.java

### DIFF
--- a/src/site/xdoc/filters/suppresswithnearbycommentfilter.xml
+++ b/src/site/xdoc/filters/suppresswithnearbycommentfilter.xml
@@ -253,8 +253,9 @@ public class Example5 {
         <div class="wrapper"><pre class="prettyprint"><code class="language-java">
 public class Example6 {
   // @cs.suppress [ConstantName|NoWhitespaceAfter] A comment here
-  public static final int [] array = {}; // filtered violation
-  // filtered violation above
+  public static final int [] array = {};
+  // filtered violation above ''int' is followed by whitespace'
+  // filtered violation 2 lines above 'Name 'array' must match pattern'
 }
 </code></pre></div>
         <p>

--- a/src/site/xdoc/filters/suppresswithplaintextcommentfilter.xml
+++ b/src/site/xdoc/filters/suppresswithplaintextcommentfilter.xml
@@ -466,9 +466,9 @@ public class Example9 {
           ST001,Station 001,ZONE1,Zone 1,CP1,Competitor 1,123 Street,Unit 2,Houston,TX,77033,US,29.761496813335178,-95.53049214204984
           ST002,Station 002,ZONE2,,CP2,,668 Street,Unit 23,San Jose,CA,95191,US,37.35102477242508,-121.9209934020318
           """;
-  // filtered violation 5 lines above 'Line is longer than 100 characters (found 147).'
-  // filtered violation 5 lines above 'Line is longer than 100 characters (found 133).'
-  // filtered violation 5 lines above 'Line is longer than 100 characters (found 116).'
+  // filtered violation 4 lines above 'Line is longer than 100 characters (found 147).'
+  // filtered violation 4 lines above 'Line is longer than 100 characters (found 133).'
+  // filtered violation 4 lines above 'Line is longer than 100 characters (found 116).'
 
   // violation below, 'Line is longer than 100 characters (found 183).'
   static final String SINGLE_LINE_SAMPLE = "locationId,label,regionId,regionLabel,vendorId,vendorLabel,address,address2,city,stateProvinceCode,zipCode,countryCode,latitude,longitude";

--- a/src/test/java/com/puppycrawl/tools/checkstyle/bdd/InlineConfigParser.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/bdd/InlineConfigParser.java
@@ -1323,7 +1323,7 @@ public final class InlineConfigParser {
         }
         else if (violationSomeLinesAboveMatcher.matches()) {
             final String violationMessage = violationSomeLinesAboveMatcher.group(2);
-            final int linesAbove = Integer.parseInt(violationSomeLinesAboveMatcher.group(1)) - 1;
+            final int linesAbove = Integer.parseInt(violationSomeLinesAboveMatcher.group(1));
             final int violationLineNum = lineNo - linesAbove;
             checkWhetherViolationSpecified(specifyViolationMessage, violationMessage,
                     violationLineNum);

--- a/src/test/java/com/puppycrawl/tools/checkstyle/bdd/TestInputViolation.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/bdd/TestInputViolation.java
@@ -89,7 +89,7 @@ public final class TestInputViolation implements Comparable<TestInputViolation> 
     public int compareTo(TestInputViolation testInputViolation) {
         final int result;
         if (message != null && lineNo == testInputViolation.lineNo) {
-            result = testInputViolation.message.compareTo(message);
+            result = message.compareTo(testInputViolation.message);
         }
         else {
             result = Integer.compare(lineNo, testInputViolation.lineNo);

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppresswithnearbytextfilter/InputSuppressWithNearbyTextFilterNearbyTextPattern.css.txt
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppresswithnearbytextfilter/InputSuppressWithNearbyTextFilterNearbyTextPattern.css.txt
@@ -29,7 +29,7 @@ maximum = (default)0
 }
 
 .div-1 main>h1 {
-  // filtered violation below 'Line is longer than 90 characters (found 93).'
+  // filtered violation below 'longer than 90 characters (found 93).'
   margiin: "this should not appear"; /* -cs: Long comment explainingasdasdasdasdasdasdasda */
   // filtered violation above 'Line matches the illegal pattern .*'
 }

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppresswithplaintextcommentfilter/InputSuppressWithPlainTextCommentFilterCustomMessageFormat.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppresswithplaintextcommentfilter/InputSuppressWithPlainTextCommentFilterCustomMessageFormat.java
@@ -31,7 +31,7 @@ public class InputSuppressWithPlainTextCommentFilterCustomMessageFormat {
     // CHECKSTYLE:OFF
     private int A1; // violation 'illegal pattern'
 
-	private static final int a1 = 5; // filtered violation 'contains a tab'
+	private static final int a1 = 5; // filtered violation 'tab character'
     // violation above 'illegal pattern'
     int a2 = 100; // violation 'illegal pattern'
 

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppresswithplaintextcommentfilter/InputSuppressWithPlainTextCommentFilterSuppressById.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppresswithplaintextcommentfilter/InputSuppressWithPlainTextCommentFilterSuppressById.java
@@ -33,7 +33,7 @@ public class InputSuppressWithPlainTextCommentFilterSuppressById {
     private int A1; // violation 'illegal pattern'
 
     // @cs-: ignore (reason)
-	private static final int a1 = 5; // filtered violation 'contains a tab'
+	private static final int a1 = 5; // filtered violation 'tab character'
     // violation above 'illegal pattern'
     int a2 = 100; // violation 'illegal pattern'
     //CSON ignore

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppresswithplaintextcommentfilter/InputSuppressWithPlainTextCommentFilterSuppressById2.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppresswithplaintextcommentfilter/InputSuppressWithPlainTextCommentFilterSuppressById2.java
@@ -34,7 +34,7 @@ public class InputSuppressWithPlainTextCommentFilterSuppressById2 { // violation
 
     // @cs-: ignore (reason)
 	private static final int a1 = 5; // filtered violation 'illegal pattern'
-    // violation above 'Line contains a tab character.'
+    // violation above 'tab character.'
     int a2 = 100; // filtered violation 'illegal pattern'
     //CSON ignore
 

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppresswithplaintextcommentfilter/InputSuppressWithPlainTextCommentFilterSuppressById3.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppresswithplaintextcommentfilter/InputSuppressWithPlainTextCommentFilterSuppressById3.java
@@ -33,7 +33,7 @@ public class InputSuppressWithPlainTextCommentFilterSuppressById3 { // violation
     private int A1; // violation 'illegal pattern'
 
     // @cs-: ignore (reason)
-	private static final int a1 = 5; // filtered violation 'contains a tab'
+	private static final int a1 = 5; // filtered violation 'tab character'
     // violation above 'illegal pattern'
     int a2 = 100; // violation 'illegal pattern'
     //CSON ignore

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppresswithplaintextcommentfilter/InputSuppressWithPlainTextCommentFilterSuppressById4.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppresswithplaintextcommentfilter/InputSuppressWithPlainTextCommentFilterSuppressById4.java
@@ -34,7 +34,7 @@ public class InputSuppressWithPlainTextCommentFilterSuppressById4 { // violation
 
     // @cs-: ignore (reason)
 	private static final int a1 = 5; // violation 'illegal pattern'
-    // violation above 'contains a tab'
+    // violation above 'tab character'
     int a2 = 100; // violation 'illegal pattern'
     //CSON ignore
 

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppresswithplaintextcommentfilter/InputSuppressWithPlainTextCommentFilterSuppressById5.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppresswithplaintextcommentfilter/InputSuppressWithPlainTextCommentFilterSuppressById5.java
@@ -34,7 +34,7 @@ public class InputSuppressWithPlainTextCommentFilterSuppressById5 { // violation
 
     // @cs-: ignore (reason)
 	private static final int a1 = 5; // filtered violation 'illegal pattern'
-    // violation above 'Line contains a tab character.'
+    // violation above 'tab character'
     int a2 = 100; // filtered violation 'illegal pattern'
     //CSON ignore
 

--- a/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/filters/suppressionsinglefilter/Example3.java
+++ b/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/filters/suppressionsinglefilter/Example3.java
@@ -10,7 +10,7 @@
 </module>
 */
 package com.puppycrawl.tools.checkstyle.filters.suppressionsinglefilter;
-// filtered violation 10 lines above 'Line matches the illegal pattern'
+// filtered violation 9 lines above 'Line matches the illegal pattern'
 // xdoc section -- start
 public class Example3 {
 

--- a/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/filters/suppressionsinglefilter/Example9.java
+++ b/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/filters/suppressionsinglefilter/Example9.java
@@ -12,7 +12,7 @@
 </module>
 */
 package com.puppycrawl.tools.checkstyle.filters.suppressionsinglefilter;
-// filtered violation 15 lines above 'File length is 21 lines (max allowed is 1)'
+// filtered violation 14 lines above 'File length is 21 lines (max allowed is 1)'
 // xdoc section -- start
 /* filtered violation on 1st line  'File length is 4 lines (max allowed is 1)' */
 public class Example9 {

--- a/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/filters/suppresswithnearbycommentfilter/Example6.java
+++ b/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/filters/suppresswithnearbycommentfilter/Example6.java
@@ -16,7 +16,8 @@ package com.puppycrawl.tools.checkstyle.filters.suppresswithnearbycommentfilter;
 // xdoc section -- start
 public class Example6 {
   // @cs.suppress [ConstantName|NoWhitespaceAfter] A comment here
-  public static final int [] array = {}; // filtered violation
-  // filtered violation above
+  public static final int [] array = {};
+  // filtered violation above ''int' is followed by whitespace'
+  // filtered violation 2 lines above 'Name 'array' must match pattern'
 }
 // xdoc section -- end

--- a/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/filters/suppresswithplaintextcommentfilter/Example9.java
+++ b/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/filters/suppresswithplaintextcommentfilter/Example9.java
@@ -24,9 +24,9 @@ public class Example9 {
           ST001,Station 001,ZONE1,Zone 1,CP1,Competitor 1,123 Street,Unit 2,Houston,TX,77033,US,29.761496813335178,-95.53049214204984
           ST002,Station 002,ZONE2,,CP2,,668 Street,Unit 23,San Jose,CA,95191,US,37.35102477242508,-121.9209934020318
           """;
-  // filtered violation 5 lines above 'Line is longer than 100 characters (found 147).'
-  // filtered violation 5 lines above 'Line is longer than 100 characters (found 133).'
-  // filtered violation 5 lines above 'Line is longer than 100 characters (found 116).'
+  // filtered violation 4 lines above 'Line is longer than 100 characters (found 147).'
+  // filtered violation 4 lines above 'Line is longer than 100 characters (found 133).'
+  // filtered violation 4 lines above 'Line is longer than 100 characters (found 116).'
 
   // violation below, 'Line is longer than 100 characters (found 183).'
   static final String SINGLE_LINE_SAMPLE = "locationId,label,regionId,regionLabel,vendorId,vendorLabel,address,address2,city,stateProvinceCode,zipCode,countryCode,latitude,longitude";


### PR DESCRIPTION
Issue https://github.com/checkstyle/checkstyle/issues/17031

previous violations or filtered violations comment when lines are equal:
`// violation 'some message'` or `// filtered violation 'some message'`

now
`// violation 'num: some message'` or `// filtered violation 'num: some message'` where `num` refers to the violation that comes first, denoted by the smallest integer. We can also use the column number instead. However, it doesn't matter what we use — the `num` is only added to help with sorting, first by line number, then by message.

Previously, the `compareTo()` method sorted in reverse chronological order when the line numbers were equal. Now, it sorts in chronological order.
