### PR TITLE
supplemental: Add coverage gap on lambda in '4.5.1' to the table

### DIFF
--- a/src/site/xdoc/google_style.xml
+++ b/src/site/xdoc/google_style.xml
@@ -903,7 +903,7 @@
                   <br />
                   <br />
                   <span class="wrapper inline">
-                    <img src="images/ok_green.png" alt="" />
+                    <img src="images/ok_blue.png" alt="" />
                   </span>
                   <a href="checks/whitespace/separatorwrap.html#SeparatorWrap">SeparatorWrap</a>
                   (<a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources%20path%3A**%2Fgoogle_checks.xml+repo%3Acheckstyle%2Fcheckstyle+SeparatorWrap">
@@ -916,6 +916,13 @@
                   <a href="checks/whitespace/methodparampad.html#MethodParamPad">MethodParamPad</a>
                   (<a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources%20path%3A**%2Fgoogle_checks.xml+repo%3Acheckstyle%2Fcheckstyle+MethodParamPad">
                   config</a>)
+                  <br />
+                  <br />
+                  Line break before and after the lambda(<code>-></code>) is not covered.
+                  It will be addressed at:
+                  <a href="https://github.com/checkstyle/checkstyle/issues/17253">
+                    #17253
+                  </a>
                 </td>
                 <td>
                   <a href="https://github.com/checkstyle/checkstyle/tree/master/src/it/resources/com/google/checkstyle/test/chapter4formatting/rule451wheretobreak">


### PR DESCRIPTION
part of #17165 and #17253 

addressing this comment - https://github.com/checkstyle/checkstyle/pull/17165/files#r2245751602