### PR TITLE
Issue #13038: handled inner class method definition in VariableDeclar…

### DIFF
--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/coding/VariableDeclarationUsageDistanceCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/coding/VariableDeclarationUsageDistanceCheckTest.java
@@ -344,6 +344,7 @@ public class VariableDeclarationUsageDistanceCheckTest extends
     public void testGeneralClass3() throws Exception {
         final String[] expected = {
             "46:9: " + getCheckMessage(MSG_KEY, "a", 2, 1),
+            "92:9: " + getCheckMessage(MSG_KEY, "t", 3, 1),
         };
 
         verifyWithInlineConfigParser(
@@ -352,9 +353,7 @@ public class VariableDeclarationUsageDistanceCheckTest extends
 
     @Test
     public void testGeneralClass4() throws Exception {
-        final String[] expected = {
-            "26:9: " + getCheckMessage(MSG_KEY, "z", 3, 1),
-        };
+        final String[] expected = {};
 
         verifyWithInlineConfigParser(
                 getPath("InputVariableDeclarationUsageDistanceGeneral4.java"), expected);
@@ -410,12 +409,81 @@ public class VariableDeclarationUsageDistanceCheckTest extends
     }
 
     @Test
-    public void testVariableDeclarationUsageDistancePatternVariables() throws Exception {
+    public void testVariableDeclarationUsageDistanceMethodDefinition() throws Exception {
         final String[] expected = {
-            "35:9: " + getCheckMessage(MSG_KEY, "b", 5, 1),
+            "18:9: " + getCheckMessage(MSG_KEY, "c", 2, 1),
         };
         verifyWithInlineConfigParser(
-                getPath("InputVariableDeclarationUsageDistancePatternVariables.java"),
+                getPath("InputVariableDeclarationUsageDistanceMethodDefinition.java"),
                 expected);
+    }
+
+    @Test
+    public void testLambdaScopeNoViolation() throws Exception {
+        final String[] expected = CommonUtil.EMPTY_STRING_ARRAY;
+        verifyWithInlineConfigParser(
+                getPath("InputVariableDeclarationUsageDistanceLambda.java"), expected);
+    }
+
+    @Test
+    public void testAnonInnerScopeNoViolation() throws Exception {
+        final String[] expected = CommonUtil.EMPTY_STRING_ARRAY;
+        verifyWithInlineConfigParser(
+                getPath("InputVariableDeclarationUsageDistanceAnonInner.java"), expected);
+    }
+
+    @Test
+    public void testDeepNestedTypesViolation() throws Exception {
+        final String[] expected = CommonUtil.EMPTY_STRING_ARRAY;
+        verifyWithInlineConfigParser(
+                getPath("InputVariableDeclarationUsageDistanceDeepNested.java"), expected);
+    }
+
+    @Test
+    public void testMultipleDeclarationSameLine() throws Exception {
+        final String[] expected = CommonUtil.EMPTY_STRING_ARRAY;
+        verifyWithInlineConfigParser(
+                getPath(
+                        "InputVariableDeclarationUsageDistanceMultipleDeclarations.java"),
+                expected);
+    }
+
+    @Test
+    public void testInnerClassInMethodDoesNotCountDistance() throws Exception {
+
+        final String[] expected = CommonUtil.EMPTY_STRING_ARRAY;
+        verifyWithInlineConfigParser(
+                getPath("InputVariableDeclarationUsageDistanceInnerClassInMethod.java"),
+                expected);
+    }
+
+    @Test
+    public void testViolationDueToRecordDistance() throws Exception {
+        final String[] expected = {};
+        verifyWithInlineConfigParser(
+                getPath("InputVariableDeclarationUsageDistanceRecordViolation.java"),
+                expected);
+    }
+
+    @Test
+    public void testLocalTypesAreSkippedWhenCountingDistance() throws Exception {
+        final String[] expected = {
+            "28:9: " + getCheckMessage(MSG_KEY_EXT, "b", 2, 1),
+        };
+
+        verifyWithInlineConfigParser(
+                getPath("InputVariableDeclarationUsageDistanceLocalType.java"),
+                expected);
+    }
+
+    @Test
+    public void testWithAnonymousBlock() throws Exception {
+        final String[] expected = {
+            "28:9: " + getCheckMessage(MSG_KEY_EXT, "b", 2, 1),
+        };
+
+        final String filePath = getPath("InputVariableDeclarationUsageDistanceLocalType.java");
+
+        verifyWithInlineConfigParser(filePath, expected);
     }
 }

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/variabledeclarationusagedistance/InputVariableDeclarationUsageDistanceAnonInner.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/variabledeclarationusagedistance/InputVariableDeclarationUsageDistanceAnonInner.java
@@ -1,0 +1,22 @@
+/*
+VariableDeclarationUsageDistance
+allowedDistance = 3
+ignoreVariablePattern = (default)
+validateBetweenScopes = true
+ignoreFinal = false
+
+
+*/
+
+package com.puppycrawl.tools.checkstyle.checks.coding.variabledeclarationusagedistance;
+
+public class InputVariableDeclarationUsageDistanceAnonInner {
+    public void testAnonymousInner() {
+        int y = 5;
+        Object o = new Object() {
+            {
+                System.out.println(y);
+            }
+        };
+    }
+}

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/variabledeclarationusagedistance/InputVariableDeclarationUsageDistanceDeepNested.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/variabledeclarationusagedistance/InputVariableDeclarationUsageDistanceDeepNested.java
@@ -1,0 +1,21 @@
+/*
+VariableDeclarationUsageDistance
+allowedDistance = 3
+ignoreVariablePattern = (default)
+validateBetweenScopes = true
+ignoreFinal = false
+
+
+*/
+
+package com.puppycrawl.tools.checkstyle.checks.coding.variabledeclarationusagedistance;
+
+public class InputVariableDeclarationUsageDistanceDeepNested {
+    public void testNestedScopes() {
+        int z = 1;
+        class Local {}
+        interface I {}
+        enum E { A, B }
+        System.out.println(z);
+    }
+}

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/variabledeclarationusagedistance/InputVariableDeclarationUsageDistanceGeneral3.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/variabledeclarationusagedistance/InputVariableDeclarationUsageDistanceGeneral3.java
@@ -88,8 +88,8 @@ public class InputVariableDeclarationUsageDistanceGeneral3 {
     }
 
     public void method7() {
-        // until https://github.com/checkstyle/checkstyle/issues/13011, the below distance is 3
-        Integer t = 5;
+
+        Integer t = 5; // violation 'Distance .* is 3.'
         nothing();
         System.out.println();
         class BClass extends Parent {

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/variabledeclarationusagedistance/InputVariableDeclarationUsageDistanceGeneral4.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/variabledeclarationusagedistance/InputVariableDeclarationUsageDistanceGeneral4.java
@@ -22,8 +22,7 @@ public class InputVariableDeclarationUsageDistanceGeneral4 {
         <T> void xx(List<T> m){}
     }
     public void method9() {
-        // until https://github.com/checkstyle/checkstyle/issues/13011
-        Integer z = 5; // violation 'Distance .* is 3.'
+        Integer z = 5;
         Iterator<Integer> mn = new HashSet<Integer>().iterator();
         class BClass extends Parent {
             Boolean h = false;

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/variabledeclarationusagedistance/InputVariableDeclarationUsageDistanceInnerClassInMethod.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/variabledeclarationusagedistance/InputVariableDeclarationUsageDistanceInnerClassInMethod.java
@@ -1,0 +1,28 @@
+/*
+VariableDeclarationUsageDistance
+allowedDistance = 3
+ignoreVariablePattern = (default)
+validateBetweenScopes = true
+ignoreFinal = false
+
+
+*/
+
+package com.puppycrawl.tools.checkstyle.checks.coding.variabledeclarationusagedistance;
+
+public class InputVariableDeclarationUsageDistanceInnerClassInMethod {
+
+    public void exampleMethod() {
+        int value = 10;
+
+        class LocalClass {
+            void inner() {
+                System.out.println("Inside local class");
+            }
+        }
+
+        if (value > 5) {
+            System.out.println(value); // use of 'value' after inner class
+        }
+    }
+}

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/variabledeclarationusagedistance/InputVariableDeclarationUsageDistanceLambda.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/variabledeclarationusagedistance/InputVariableDeclarationUsageDistanceLambda.java
@@ -1,0 +1,20 @@
+/*
+VariableDeclarationUsageDistance
+allowedDistance = 3
+ignoreVariablePattern = (default)
+validateBetweenScopes = true
+ignoreFinal = false
+
+
+*/
+
+package com.puppycrawl.tools.checkstyle.checks.coding.variabledeclarationusagedistance;
+
+public class InputVariableDeclarationUsageDistanceLambda {
+    public void testLambda() {
+        int x = 10;
+        Runnable r = () -> {
+            System.out.println(x);
+        };
+    }
+}

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/variabledeclarationusagedistance/InputVariableDeclarationUsageDistanceLocalType.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/variabledeclarationusagedistance/InputVariableDeclarationUsageDistanceLocalType.java
@@ -1,0 +1,46 @@
+/*
+VariableDeclarationUsageDistance
+allowedDistance = 1
+ignoreVariablePattern = (default)
+validateBetweenScopes = true
+ignoreFinal = (default)true
+
+
+*/
+
+package com.puppycrawl.tools.checkstyle.checks.coding.variabledeclarationusagedistance;
+
+public class InputVariableDeclarationUsageDistanceLocalType {
+
+    public void testWithLocalClass() {
+        int a = 1; // no violation expected
+
+        class LocalHelper {
+            void help() {
+                System.out.println("working");
+            }
+        }
+
+        System.out.println(a); // usage is after local class
+    }
+
+    public void testWithAnonymousBlock() {
+        int b = 2; // violation 'Distance .* is 2.'
+
+        {
+            System.out.println("inside block");
+        }
+
+        System.out.println(b); // usage after anonymous block (should count for distance)
+    }
+
+    public void testWithMultipleLocalTypes() {
+        int c = 3; // no violation expected
+
+        class First {}
+        class Second {}
+
+        System.out.println(c); // usage after multiple local classes
+    }
+}
+

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/variabledeclarationusagedistance/InputVariableDeclarationUsageDistanceLocalTypeCheck.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/variabledeclarationusagedistance/InputVariableDeclarationUsageDistanceLocalTypeCheck.java
@@ -1,0 +1,26 @@
+/*
+VariableDeclarationUsageDistance
+allowedDistance = 1
+ignoreVariablePattern = (default)
+validateBetweenScopes = true
+ignoreFinal = (default)true
+
+
+*/
+
+
+package com.puppycrawl.tools.checkstyle.checks.coding.variabledeclarationusagedistance;
+
+public class InputVariableDeclarationUsageDistanceLocalTypeCheck {
+
+    public void testWithAnonymousBlock() {
+        int b = 2; // violation 'Distance .* is 2.'
+
+        {
+            System.out.println("inside block");
+        }
+
+        System.out.println(b); // usage after anonymous block
+    }
+
+}

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/variabledeclarationusagedistance/InputVariableDeclarationUsageDistanceMethodDefinition.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/variabledeclarationusagedistance/InputVariableDeclarationUsageDistanceMethodDefinition.java
@@ -1,0 +1,30 @@
+/*
+VariableDeclarationUsageDistance
+allowedDistance = 1
+ignoreVariablePattern = (default)
+validateBetweenScopes = true
+ignoreFinal = false
+
+
+*/
+
+package com.puppycrawl.tools.checkstyle.checks.coding.variabledeclarationusagedistance;
+
+import java.util.Iterator;
+public class InputVariableDeclarationUsageDistanceMethodDefinition {
+    public void method(){
+        int a=1;
+        int b=2;
+        int c=3; // violation 'Distance .* is 2.'
+        class GeneralLogic {
+            public <T> Iterator<T> method(T[] b) throws Exception{
+                if(a>0){
+                    System.out.println(b.length);
+                }
+                return null;
+            }
+        };
+        System.out.print(b);
+        System.out.print(c);
+    }
+}

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/variabledeclarationusagedistance/InputVariableDeclarationUsageDistanceMultipleDeclarations.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/variabledeclarationusagedistance/InputVariableDeclarationUsageDistanceMultipleDeclarations.java
@@ -1,0 +1,24 @@
+/*
+VariableDeclarationUsageDistance
+allowedDistance = 3
+ignoreVariablePattern = (default)
+validateBetweenScopes = true
+ignoreFinal = false
+
+
+*/
+
+package com.puppycrawl.tools.checkstyle.checks.coding.variabledeclarationusagedistance;
+
+public class InputVariableDeclarationUsageDistanceMultipleDeclarations {
+    public void testMultipleVars() {
+        int a = 1, b = 2;
+
+        class Dummy {
+            void use() {
+                System.out.println(a);
+            }
+        }
+        // b is unused — not flagged by this check
+    }
+}

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/variabledeclarationusagedistance/InputVariableDeclarationUsageDistanceRecordViolation.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/variabledeclarationusagedistance/InputVariableDeclarationUsageDistanceRecordViolation.java
@@ -1,0 +1,26 @@
+/*
+VariableDeclarationUsageDistance
+allowedDistance = 1
+ignoreVariablePattern = (default)
+validateBetweenScopes = true
+ignoreFinal = false
+
+
+*/
+
+package com.puppycrawl.tools.checkstyle.checks.coding.variabledeclarationusagedistance;
+
+public class InputVariableDeclarationUsageDistanceRecordViolation {
+
+    public void method() {
+        int a = 5;
+
+        record MyRecord(int x) {
+            public int get() {
+                return x;
+            }
+        }
+
+        System.out.println(a);
+    }
+}

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/variabledeclarationusagedistance/InputVariableDeclarationUsageDistanceSwitchRecord.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/variabledeclarationusagedistance/InputVariableDeclarationUsageDistanceSwitchRecord.java
@@ -1,0 +1,22 @@
+/*
+VariableDeclarationUsageDistance
+allowedDistance = 2
+ignoreVariablePattern = (default)
+validateBetweenScopes = true
+ignoreFinal = false
+
+
+*/
+
+package com.puppycrawl.tools.checkstyle.checks.coding.variabledeclarationusagedistance;
+
+public class InputVariableDeclarationUsageDistanceSwitchRecord {
+    public void test() {
+        int a = 42;
+        record R(int x) {}
+        switch (a) {
+            case 1 -> System.out.println("one");
+            default -> System.out.println(a); // violation 'Distance .* is 3.'
+        }
+    }
+}


### PR DESCRIPTION
#13038 

Extends #16026 
WIP
This PR updates `VariableDeclarationUsageDistanceCheck` to properly handle inner scopes such as:

- Inner classes declared inside methods
- Lambdas
- Anonymous class overrides
- Added multiple Tests

When `validateBetweenScopes = true`, the check now treats these nested declarations as **independent scopes**, and does **not flag** variables whose usages lie fully within those inner scopes.

This prevents false positives when a variable is declared before an inner class or lambda but only used inside it — aligning the behavior with expectations documented in issue #13038.


