### PR TITLE
supplemental: IT for Unicode and Octal values of '\s'

### DIFF
--- a/src/it/java/com/google/checkstyle/test/chapter2filebasic/rule232specialescape/SpecialEscapeSequencesTest.java
+++ b/src/it/java/com/google/checkstyle/test/chapter2filebasic/rule232specialescape/SpecialEscapeSequencesTest.java
@@ -46,4 +46,9 @@ public class SpecialEscapeSequencesTest extends AbstractGoogleModuleTestSupport 
         verifyWithWholeConfig(
             getPath("InputSpecialEscapeSequencesInTextBlockForUnicodeValues.java"));
     }
+
+    @Test
+    public void testIllegalTokensEscapedForEscapedS() throws Exception {
+        verifyWithWholeConfig(getPath("InputSpecialEscapeSequencesForEscapedS.java"));
+    }
 }

--- a/src/it/resources/com/google/checkstyle/test/chapter2filebasic/rule232specialescape/InputSpecialEscapeSequencesForEscapedS.java
+++ b/src/it/resources/com/google/checkstyle/test/chapter2filebasic/rule232specialescape/InputSpecialEscapeSequencesForEscapedS.java
@@ -1,0 +1,28 @@
+package com.google.checkstyle.test.chapter2filebasic.rule232specialescape;
+
+class InputSpecialEscapeSequencesForEscapedS {
+
+  void unicode() {
+    final String r0 = "\s";
+    final String r1 = "\u000b"; // false-negative ok until #17551
+    final String r2 = "\u000c"; // violation 'Consider using special escape sequence'
+    final String r3 = "\u001c"; // false-negative ok until #17551
+    final String r4 = "\u001D"; // false-negative ok until #17551
+    final String r5 = "\u001E"; // false-negative ok until #17551
+    final String r6 = "\u001F"; // false-negative ok until #17551
+    final String r7 = "\u1680"; // false-negative ok until #17551
+    final String r8 = "\u2000"; // false-negative ok until #17551
+    final String r9 = "\u200A"; // false-negative ok until #17551
+    final String r10 = "\u2028"; // false-negative ok until #17551
+    final String r12 = "\u2029"; // false-negative ok until #17551
+    final String r13 = "\u202F"; // false-negative ok until #17551
+    final String r14 = "\u205F"; // false-negative ok until #17551
+    final String r15 = "\u3000"; // false-negative ok until #17551
+  }
+
+  void octal() {
+    final String r1 = "\040"; // false-negative ok until #17551
+    final String r2 = "\011"; // violation 'Consider using special escape sequence'
+    final String r3 = "\012"; // violation 'Consider using special escape sequence'
+  }
+}

--- a/src/site/xdoc/google_style.xml
+++ b/src/site/xdoc/google_style.xml
@@ -256,13 +256,20 @@
                 </td>
                 <td>
                   <span class="wrapper inline">
-                    <img src="images/ok_green.png" alt="" />
+                    <img src="images/ok_blue.png" alt="" />
                   </span>
                   <a href="checks/coding/illegaltokentext.html#IllegalTokenText">
                     IllegalTokenText
                   </a>
                   (<a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources%20path%3A**%2Fgoogle_checks.xml+repo%3Acheckstyle%2Fcheckstyle+IllegalTokenText">
                   config</a>)
+                  <br/>
+                  <br/>
+                  Coverage is missing for Unicode and Octal values of <code>\s</code>.
+                  It will be addressed at:
+                  <a href="https://github.com/checkstyle/checkstyle/issues/17551">
+                    #17551
+                  </a>
                 </td>
                 <td>
                   <a href="https://github.com/checkstyle/checkstyle/tree/master/src/it/resources/com/google/checkstyle/test/chapter2filebasic/rule232specialescape">


### PR DESCRIPTION
and update coverage table
from: https://github.com/checkstyle/checkstyle/pull/17165#discussion_r2233985913 and https://github.com/checkstyle/checkstyle/issues/17551