### PR TITLE
supplemental: IT and Table update for '4.1.2 Nonempty blocks: K & R style'

### DIFF
--- a/config/google-java-format/excluded/compilable-input-paths.txt
+++ b/config/google-java-format/excluded/compilable-input-paths.txt
@@ -17,6 +17,7 @@ src/it/resources/com/google/checkstyle/test/chapter4formatting/rule412nonemptybl
 src/it/resources/com/google/checkstyle/test/chapter4formatting/rule412nonemptyblocks/InputRightCurlySwitchCasesBlocks.java
 src/it/resources/com/google/checkstyle/test/chapter4formatting/rule412nonemptyblocks/InputTryCatchIfElse.java
 src/it/resources/com/google/checkstyle/test/chapter4formatting/rule412nonemptyblocks/InputTryCatchIfElse2.java
+src/it/resources/com/google/checkstyle/test/chapter4formatting/rule412nonemptyblocks/InputKrStyleExceptionLocalVariables.java
 src/it/resources/com/google/checkstyle/test/chapter4formatting/rule413emptyblocks/InputEmptyBlocksAndCatchBlocks.java
 src/it/resources/com/google/checkstyle/test/chapter4formatting/rule42blockindentation/InputClassWithChainedMethods3.java
 src/it/resources/com/google/checkstyle/test/chapter4formatting/rule42blockindentation/InputIndentationCodeBlocks.java

--- a/src/it/java/com/google/checkstyle/test/chapter4formatting/rule412nonemptyblocks/NonemptyBlocksKrStyleTest.java
+++ b/src/it/java/com/google/checkstyle/test/chapter4formatting/rule412nonemptyblocks/NonemptyBlocksKrStyleTest.java
@@ -140,4 +140,13 @@ public class NonemptyBlocksKrStyleTest extends AbstractGoogleModuleTestSupport {
         verifyWithWholeConfig(getPath("InputFormattedTryCatchIfElse2.java"));
     }
 
+    @Test
+    public void testKrStyleExceptionLocalVariables() throws Exception {
+        verifyWithWholeConfig(getPath("InputKrStyleExceptionLocalVariables.java"));
+    }
+
+    @Test
+    public void testFormattedKrStyleExceptionLocalVariables() throws Exception {
+        verifyWithWholeConfig(getPath("InputFormattedKrStyleExceptionLocalVariables.java"));
+    }
 }

--- a/src/it/resources/com/google/checkstyle/test/chapter4formatting/rule412nonemptyblocks/InputFormattedKrStyleExceptionLocalVariables.java
+++ b/src/it/resources/com/google/checkstyle/test/chapter4formatting/rule412nonemptyblocks/InputFormattedKrStyleExceptionLocalVariables.java
@@ -1,0 +1,28 @@
+package com.google.checkstyle.test.chapter4formatting.rule412nonemptyblocks;
+
+/** some javadoc. */
+public class InputFormattedKrStyleExceptionLocalVariables {
+
+  void test1(int[] nums) {
+    if (nums.length > 2) {
+      int temp = nums[0];
+      use(temp);
+    }
+
+    for (int i = 1; i < nums.length; i++) {
+      int k = i * 2;
+      use(k);
+    }
+  }
+
+  void test2(int k) {
+    {
+      int x = k + 2;
+      use(x);
+    }
+  }
+
+  void use(int n) {
+    n++;
+  }
+}

--- a/src/it/resources/com/google/checkstyle/test/chapter4formatting/rule412nonemptyblocks/InputKrStyleExceptionLocalVariables.java
+++ b/src/it/resources/com/google/checkstyle/test/chapter4formatting/rule412nonemptyblocks/InputKrStyleExceptionLocalVariables.java
@@ -1,0 +1,38 @@
+package com.google.checkstyle.test.chapter4formatting.rule412nonemptyblocks;
+
+/** some javadoc. */
+public class InputKrStyleExceptionLocalVariables {
+
+  void test1(int[] nums) {
+    if (nums.length > 2)
+    { // false-positive, ok until #17569
+      // 2 violations above:
+      //   ''if lcurly' has incorrect indentation level 4, expected level should be 6'
+      //   ''{' at column 5 should be on the previous line'
+      int temp = nums[0];
+      use(temp);
+    } // violation ''if rcurly' has incorrect indentation level 4, expected level should be 6'
+    // false-positive above, ok until #17569
+
+    for (int i = 1; i < nums.length; i++)
+    { // false-positive, ok until #17569
+      // 2 violations above:
+      //   ''for lcurly' has incorrect indentation level 4, expected level should be 6'
+      //   ''{' at column 5 should be on the previous line'
+      int k = i * 2;
+      use(k);
+    } // violation 'for rcurly' has incorrect indentation level 4, expected level should be 6'
+    // false-positive above, ok until 17569
+  }
+
+  void test2(int k) {
+    {
+      int x = k + 2;
+      use(x);
+    }
+  }
+
+  void use(int n) {
+    n++;
+  }
+}

--- a/src/site/xdoc/google_style.xml
+++ b/src/site/xdoc/google_style.xml
@@ -749,6 +749,13 @@
                   </a>
                   and
                   <a href="https://github.com/checkstyle/checkstyle/issues/14782">#14782</a>
+                  <br/>
+                  <br/>
+                  Coverage is missing on Exception to K&amp;R style blocks. It will be addressed
+                  at:
+                  <a href="https://github.com/checkstyle/checkstyle/issues/17569">
+                    #17569
+                  </a>
                 </td>
                 <td>
                   <a href="https://github.com/checkstyle/checkstyle/tree/master/src/it/resources/com/google/checkstyle/test/chapter4formatting/rule412nonemptyblocks">


### PR DESCRIPTION
from: https://github.com/checkstyle/checkstyle/pull/17165#discussion_r2233986700 and https://github.com/checkstyle/checkstyle/issues/17569
