### PR TITLE
minor: trim whitespaces after regression report comment

### DIFF
--- a/.github/workflows/regression-report.yml
+++ b/.github/workflows/regression-report.yml
@@ -156,6 +156,8 @@ jobs:
         env:
           COMMENT_BODY: ${{ github.event.comment.body }}
         run: |
+          COMMENT_BODY="$(echo "$COMMENT_BODY" | tr -d '[:space:]')"
+
           NAME='^Git[Hh]ub,'
           PATTERN_FOR_DESCRIPTION=$NAME' generate report for configs in PR description[[:space:]]*$'
           PATTERN_FOR=$NAME' generate report for'


### PR DESCRIPTION
detected at https://github.com/checkstyle/checkstyle/actions/runs/16778266113/job/47515768192

Users put \n after copied content unintentionally but nobody can think that it is so critical for workflow execution, but end of message is part of path for folder where expected config files are located 