### PR TITLE
Issue #17571: Update the documentation of AnnotationLocation

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/annotation/AnnotationLocationCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/annotation/AnnotationLocationCheck.java
@@ -29,10 +29,10 @@ import com.puppycrawl.tools.checkstyle.utils.TokenUtil;
 /**
  * <div>
  * Checks location of annotation on language elements.
- * By default, Check enforce to locate annotations immediately after
- * documentation block and before target element, annotation should be located
- * on separate line from target element. This check also verifies that the annotations
- * are on the same indenting level as the annotated element if they are not on the same line.
+ * By default, Check enforce to locate annotations before target element,
+ * annotation should be located on separate line from target element.
+ * This check also verifies that the annotations are on the same indenting level
+ * as the annotated element if they are not on the same line.
  * </div>
  *
  * <p>
@@ -61,6 +61,15 @@ import com.puppycrawl.tools.checkstyle.utils.TokenUtil;
  * &#64;Nullable
  * public String getNameIfPresent() { ... }
  * </code></pre></div>
+ *
+ * <p>
+ * Notes:
+ * This check does <strong>not</strong> enforce annotations to be placed
+ * immediately after the documentation block. If that behavior is desired, consider also using
+ * <a href="https://checkstyle.org/checks/javadoc/invalidjavadocposition.html#InvalidJavadocPosition">
+ * InvalidJavadocPosition</a>.
+ * </p>
+ *
  * <ul>
  * <li>
  * Property {@code allowSamelineMultipleAnnotations} - Allow annotation(s) to be located on

--- a/src/main/resources/com/puppycrawl/tools/checkstyle/meta/checks/annotation/AnnotationLocationCheck.xml
+++ b/src/main/resources/com/puppycrawl/tools/checkstyle/meta/checks/annotation/AnnotationLocationCheck.xml
@@ -6,10 +6,10 @@
              parent="com.puppycrawl.tools.checkstyle.TreeWalker">
          <description>&lt;div&gt;
  Checks location of annotation on language elements.
- By default, Check enforce to locate annotations immediately after
- documentation block and before target element, annotation should be located
- on separate line from target element. This check also verifies that the annotations
- are on the same indenting level as the annotated element if they are not on the same line.
+ By default, Check enforce to locate annotations before target element,
+ annotation should be located on separate line from target element.
+ This check also verifies that the annotations are on the same indenting level
+ as the annotated element if they are not on the same line.
  &lt;/div&gt;
 
  &lt;p&gt;
@@ -37,7 +37,15 @@
  &amp;#64;Override
  &amp;#64;Nullable
  public String getNameIfPresent() { ... }
- &lt;/code&gt;&lt;/pre&gt;&lt;/div&gt;</description>
+ &lt;/code&gt;&lt;/pre&gt;&lt;/div&gt;
+
+ &lt;p&gt;
+ Notes:
+ This check does &lt;strong&gt;not&lt;/strong&gt; enforce annotations to be placed
+ immediately after the documentation block. If that behavior is desired, consider also using
+ &lt;a href="https://checkstyle.org/checks/javadoc/invalidjavadocposition.html#InvalidJavadocPosition"&gt;
+ InvalidJavadocPosition&lt;/a&gt;.
+ &lt;/p&gt;</description>
          <properties>
             <property default-value="false"
                       name="allowSamelineMultipleAnnotations"

--- a/src/site/xdoc/checks/annotation/annotationlocation.xml
+++ b/src/site/xdoc/checks/annotation/annotationlocation.xml
@@ -12,10 +12,10 @@
       <subsection name="Description" id="Description">
         <div>
           Checks location of annotation on language elements.
-          By default, Check enforce to locate annotations immediately after
-          documentation block and before target element, annotation should be located
-          on separate line from target element. This check also verifies that the annotations
-          are on the same indenting level as the annotated element if they are not on the same line.
+          By default, Check enforce to locate annotations before target element,
+          annotation should be located on separate line from target element.
+          This check also verifies that the annotations are on the same indenting level
+          as the annotated element if they are not on the same line.
         </div>
 
         <p>
@@ -44,6 +44,15 @@ public @Nullable Long getStartTimeOrNull() { ... }
 &#64;Nullable
 public String getNameIfPresent() { ... }
         </code></pre></div>
+      </subsection>
+
+      <subsection name="Notes" id="Notes">
+        <p>
+          This check does <strong>not</strong> enforce annotations to be placed
+          immediately after the documentation block. If that behavior is desired, consider also using
+          <a href="https://checkstyle.org/checks/javadoc/invalidjavadocposition.html#InvalidJavadocPosition">
+          InvalidJavadocPosition</a>.
+        </p>
       </subsection>
 
       <subsection name="Properties" id="Properties">

--- a/src/site/xdoc/checks/annotation/annotationlocation.xml.template
+++ b/src/site/xdoc/checks/annotation/annotationlocation.xml.template
@@ -16,6 +16,13 @@
         </macro>
       </subsection>
 
+      <subsection name="Notes" id="Notes">
+        <macro name="notes">
+          <param name="modulePath"
+                value="src/main/java/com/puppycrawl/tools/checkstyle/checks/annotation/AnnotationLocationCheck.java"/>
+        </macro>
+      </subsection>
+
       <subsection name="Properties" id="Properties">
         <div class="wrapper">
           <macro name="properties">


### PR DESCRIPTION
Issue https://github.com/checkstyle/checkstyle/issues/17571
Clarified the documentation in `AnnotationLocationCheck.java` to indicate that the check does not enforce annotations to appear immediately after Javadocs, and points users to `InvalidJavadocPosition` for that purpose.
Appreciate the guidance provided in this issue.