### PR TITLE
Issue #17429: Relocate inputs to compilable path for Coding Module1

### DIFF
--- a/.ci/eclipse-compiler-javac.sh
+++ b/.ci/eclipse-compiler-javac.sh
@@ -53,10 +53,13 @@ echo "java -jar $ECJ_PATH -target ${JAVA_RELEASE} -source ${JAVA_RELEASE} -cp $1
 set +e
 java -jar "$ECJ_PATH" -target "${JAVA_RELEASE}" -source "${JAVA_RELEASE}" -encoding UTF-8 -cp "$1" \
         -d target/eclipse-compile \
-        -nowarn \
         -properties config/org.eclipse.jdt.core.prefs \
         -enableJavadoc \
         -nowarn:[target/generated-sources/antlr] \
+        -nowarn:[src/test/resources/] \
+        -nowarn:[src/test/resources-noncompilable/] \
+        -nowarn:[src/it/resources/] \
+        -nowarn:[src/it/resources-noncompilable/] \
         src/main/java \
         target/generated-sources/antlr \
         src/test/java \
@@ -70,11 +73,15 @@ if [[ $EXIT_CODE != 0 ]]; then
   cat $RESULT_FILE
   false
 else
+    JAVA_RELEASE=24
+    echo "In eclipse, Preview of features is supported only at the latest source level"
+    echo "JAVA_RELEASE isset to ${JAVA_RELEASE}"
     echo "Executing eclipse compiler on generated resources with all warnings suppressed..."
     set +e
     # Compile test resources with all warnings suppressed
     java -jar "$ECJ_PATH" -target "${JAVA_RELEASE}" -source "${JAVA_RELEASE}" -cp "$1" \
             -d target/eclipse-compile \
+            --enable-preview \
             -nowarn \
             src/main/java \
             src/test/java \

--- a/.ci/validation.sh
+++ b/.ci/validation.sh
@@ -510,7 +510,9 @@ check-since-version)
 compile-test-resources)
   # this task is useful during migration to new JDK to let compile resources on new jdk only
   ./mvnw -e --no-transfer-progress clean test-compile \
-  -Dcheckstyle.skipCompileInputResources=false -Dmaven.compiler.release=21
+  -Dcheckstyle.skipCompileInputResources=false \
+  -Dmaven.compiler.release=21 \
+  -Dmaven.compiler.enablePreview=true
   ;;
 
 javac17_standard)

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/coding/EqualsAvoidNullCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/coding/EqualsAvoidNullCheckTest.java
@@ -282,7 +282,7 @@ public class EqualsAvoidNullCheckTest extends AbstractModuleTestSupport {
         };
 
         verifyWithInlineConfigParser(
-                getNonCompilablePath("InputEqualsAvoidNullRecordPattern.java"),
+                getPath("InputEqualsAvoidNullRecordPattern.java"),
                 expected);
     }
 }

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/coding/UnnecessaryParenthesesCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/coding/UnnecessaryParenthesesCheckTest.java
@@ -191,7 +191,7 @@ public class UnnecessaryParenthesesCheckTest extends AbstractModuleTestSupport {
             "31:13: " + getCheckMessage(MSG_EXPR),
         };
         verifyWithInlineConfigParser(
-                getNonCompilablePath(
+                getPath(
                 "InputUnnecessaryParenthesesCheckPatterns.java"),
             expected);
     }
@@ -355,7 +355,7 @@ public class UnnecessaryParenthesesCheckTest extends AbstractModuleTestSupport {
             "40:44: " + getCheckMessage(MSG_EXPR),
         };
         verifyWithInlineConfigParser(
-                getNonCompilablePath("InputUnnecessaryParenthesesWhenExpressions.java"), expected);
+                getPath("InputUnnecessaryParenthesesWhenExpressions.java"), expected);
     }
 
     @Test

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/coding/UnusedCatchParameterShouldBeUnnamedCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/coding/UnusedCatchParameterShouldBeUnnamedCheckTest.java
@@ -73,7 +73,7 @@ public class UnusedCatchParameterShouldBeUnnamedCheckTest extends AbstractModule
             "103:16: " + getCheckMessage(MSG_UNUSED_CATCH_PARAMETER, "e"),
         };
         verifyWithInlineConfigParser(
-                getNonCompilablePath("InputUnusedCatchParameterShouldBeUnnamed.java"),
+                getPath("InputUnusedCatchParameterShouldBeUnnamed.java"),
                 expected);
     }
 
@@ -86,7 +86,7 @@ public class UnusedCatchParameterShouldBeUnnamedCheckTest extends AbstractModule
             "69:18: " + getCheckMessage(MSG_UNUSED_CATCH_PARAMETER, "e"),
         };
         verifyWithInlineConfigParser(
-                getNonCompilablePath(
+                getPath(
                         "InputUnusedCatchParameterShouldBeUnnamedWithResourceAndFinally.java"),
                 expected);
     }
@@ -101,7 +101,7 @@ public class UnusedCatchParameterShouldBeUnnamedCheckTest extends AbstractModule
             "87:22: " + getCheckMessage(MSG_UNUSED_CATCH_PARAMETER, "ex"),
         };
         verifyWithInlineConfigParser(
-                getNonCompilablePath(
+                getPath(
                         "InputUnusedCatchParameterShouldBeUnnamedNested.java"),
                 expected);
     }
@@ -117,7 +117,7 @@ public class UnusedCatchParameterShouldBeUnnamedCheckTest extends AbstractModule
             "103:18: " + getCheckMessage(MSG_UNUSED_CATCH_PARAMETER, "e"),
         };
         verifyWithInlineConfigParser(
-                getNonCompilablePath(
+                getPath(
                         "InputUnusedCatchParameterShouldBeUnnamedInsideAnonClass.java"),
                 expected);
     }
@@ -128,7 +128,7 @@ public class UnusedCatchParameterShouldBeUnnamedCheckTest extends AbstractModule
                 new UnusedCatchParameterShouldBeUnnamedCheck();
 
         final DetailAST root = JavaParser.parseFile(
-                new File(getNonCompilablePath(
+                new File(getPath(
                         "InputUnusedCatchParameterShouldBeUnnamed.java")),
                 JavaParser.Options.WITHOUT_COMMENTS);
 

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/coding/UnusedLambdaParameterShouldBeUnnamedCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/coding/UnusedLambdaParameterShouldBeUnnamedCheckTest.java
@@ -74,7 +74,7 @@ public class UnusedLambdaParameterShouldBeUnnamedCheckTest extends AbstractModul
             "54:32: " + getCheckMessage(MSG_UNUSED_LAMBDA_PARAMETER, "C"),
         };
         verifyWithInlineConfigParser(
-                getNonCompilablePath(
+                getPath(
                         "InputUnusedLambdaParameterShouldBeUnnamedSingleLambdaParameter.java"),
                 expected);
     }
@@ -96,7 +96,7 @@ public class UnusedLambdaParameterShouldBeUnnamedCheckTest extends AbstractModul
             "90:24: " + getCheckMessage(MSG_UNUSED_LAMBDA_PARAMETER, "y"),
         };
         verifyWithInlineConfigParser(
-                getNonCompilablePath(
+                getPath(
                         "InputUnusedLambdaParameterShouldBeUnnamedMultipleParameters.java"),
                 expected);
     }
@@ -119,7 +119,7 @@ public class UnusedLambdaParameterShouldBeUnnamedCheckTest extends AbstractModul
             "94:28: " + getCheckMessage(MSG_UNUSED_LAMBDA_PARAMETER, "x"),
         };
         verifyWithInlineConfigParser(
-                getNonCompilablePath(
+                getPath(
                         "InputUnusedLambdaParameterShouldBeUnnamedNested.java"),
                 expected);
     }
@@ -130,7 +130,7 @@ public class UnusedLambdaParameterShouldBeUnnamedCheckTest extends AbstractModul
                 new UnusedLambdaParameterShouldBeUnnamedCheck();
 
         final DetailAST root = JavaParser.parseFile(
-                new File(getNonCompilablePath(
+                new File(getPath(
                         "InputUnusedLambdaParameterShouldBeUnnamedSingleLambdaParameter.java")),
                 JavaParser.Options.WITHOUT_COMMENTS);
 

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/coding/UnusedLocalVariableCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/coding/UnusedLocalVariableCheckTest.java
@@ -430,7 +430,7 @@ public class UnusedLocalVariableCheckTest extends AbstractModuleTestSupport {
             "45:14: " + getCheckMessage(MSG_UNUSED_NAMED_LOCAL_VARIABLE, "__"),
         };
         verifyWithInlineConfigParser(
-                getNonCompilablePath("InputUnusedLocalVariableWithAllowUnnamed.java"),
+                getPath("InputUnusedLocalVariableWithAllowUnnamed.java"),
                 expected);
     }
 
@@ -446,7 +446,7 @@ public class UnusedLocalVariableCheckTest extends AbstractModuleTestSupport {
             "46:14: " + getCheckMessage(MSG_UNUSED_LOCAL_VARIABLE, "__"),
         };
         verifyWithInlineConfigParser(
-                getNonCompilablePath("InputUnusedLocalVariableWithAllowUnnamedFalse.java"),
+                getPath("InputUnusedLocalVariableWithAllowUnnamedFalse.java"),
                 expected);
     }
 

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/coding/VariableDeclarationUsageDistanceCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/coding/VariableDeclarationUsageDistanceCheckTest.java
@@ -415,7 +415,7 @@ public class VariableDeclarationUsageDistanceCheckTest extends
             "35:9: " + getCheckMessage(MSG_KEY, "b", 5, 1),
         };
         verifyWithInlineConfigParser(
-                getNonCompilablePath("InputVariableDeclarationUsageDistancePatternVariables.java"),
+                getPath("InputVariableDeclarationUsageDistancePatternVariables.java"),
                 expected);
     }
 }

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/coding/WhenShouldBeUsedCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/coding/WhenShouldBeUsedCheckTest.java
@@ -56,7 +56,7 @@ public class WhenShouldBeUsedCheckTest
     public void testSwitchStatements() throws Exception {
         final String[] expected = CommonUtil.EMPTY_STRING_ARRAY;
         verifyWithInlineConfigParser(
-                getNonCompilablePath("InputWhenShouldBeUsedSwitchStatements.java"),
+                getPath("InputWhenShouldBeUsedSwitchStatements.java"),
             expected);
     }
 
@@ -70,7 +70,7 @@ public class WhenShouldBeUsedCheckTest
             "105:13: " + getCheckMessage(MSG_KEY),
         };
         verifyWithInlineConfigParser(
-                getNonCompilablePath("InputWhenShouldBeUsedSwitchRule.java"),
+                getPath("InputWhenShouldBeUsedSwitchRule.java"),
             expected);
 
     }
@@ -79,7 +79,7 @@ public class WhenShouldBeUsedCheckTest
     public void testSwitchExpression() throws Exception {
         final String[] expected = CommonUtil.EMPTY_STRING_ARRAY;
         verifyWithInlineConfigParser(
-                getNonCompilablePath("InputWhenShouldBeUsedSwitchExpression.java"),
+                getPath("InputWhenShouldBeUsedSwitchExpression.java"),
                 expected);
     }
 
@@ -87,7 +87,7 @@ public class WhenShouldBeUsedCheckTest
     public void testNonPatternsSwitch() throws Exception {
         final String[] expected = CommonUtil.EMPTY_STRING_ARRAY;
         verifyWithInlineConfigParser(
-                getNonCompilablePath("InputWhenShouldBeUsedNonPatternsSwitch.java"),
+                getPath("InputWhenShouldBeUsedNonPatternsSwitch.java"),
                 expected);
     }
 }

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/equalsavoidnull/InputEqualsAvoidNullRecordPattern.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/equalsavoidnull/InputEqualsAvoidNullRecordPattern.java
@@ -5,7 +5,7 @@ ignoreEqualsIgnoreCase = (default)false
 
 */
 
-// non-compiled with javac: Compilable with Java21
+// Java21
 package com.puppycrawl.tools.checkstyle.checks.coding.equalsavoidnull;
 
 public class InputEqualsAvoidNullRecordPattern {

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/unnecessaryparentheses/InputUnnecessaryParenthesesCheckPatterns.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/unnecessaryparentheses/InputUnnecessaryParenthesesCheckPatterns.java
@@ -11,7 +11,7 @@ tokens = (default)EXPR, IDENT, NUM_DOUBLE, NUM_FLOAT, NUM_INT, NUM_LONG, \
 
 */
 
-// non-compiled with javac: Compilable with Java21
+// Java21
 package com.puppycrawl.tools.checkstyle.checks.coding.unnecessaryparentheses;
 
 public class InputUnnecessaryParenthesesCheckPatterns {

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/unnecessaryparentheses/InputUnnecessaryParenthesesWhenExpressions.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/unnecessaryparentheses/InputUnnecessaryParenthesesWhenExpressions.java
@@ -11,7 +11,7 @@ tokens = (default)EXPR, IDENT, NUM_DOUBLE, NUM_FLOAT, NUM_INT, NUM_LONG, \
 
 */
 
-// non-compiled with javac: Compilable with Java21
+// Java21
 package com.puppycrawl.tools.checkstyle.checks.coding.unnecessaryparentheses;
 
 public class InputUnnecessaryParenthesesWhenExpressions {

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/unusedcatchparametershouldbeunnamed/InputUnusedCatchParameterShouldBeUnnamed.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/unusedcatchparametershouldbeunnamed/InputUnusedCatchParameterShouldBeUnnamed.java
@@ -3,11 +3,11 @@ UnusedCatchParameterShouldBeUnnamed
 
 */
 
-// non-compiled with javac: Compilable with Java21
+// Java21
 package com.puppycrawl.tools.checkstyle.checks.coding.unusedcatchparametershouldbeunnamed;
 
 public class InputUnusedCatchParameterShouldBeUnnamed {
-    private E e;
+    private ETwo e;
     Exception exception;
 
     void test(Object o) {
@@ -63,14 +63,14 @@ public class InputUnusedCatchParameterShouldBeUnnamed {
             int x = 1/ 0;
         }
         catch (Exception A) {  // violation
-           A a;
+           ATwo a;
         }
 
         try {
             int x = 1/ 0;
         }
         catch (Exception A) {  // violation
-           Object a = new A();
+           Object a = new ATwo();
         }
 
         try {
@@ -114,5 +114,5 @@ public class InputUnusedCatchParameterShouldBeUnnamed {
     void e() { }
 }
 
-class E { void printStackTrace() {}}
-class A {}
+class ETwo { void printStackTrace() {}}
+class ATwo {}

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/unusedcatchparametershouldbeunnamed/InputUnusedCatchParameterShouldBeUnnamedInsideAnonClass.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/unusedcatchparametershouldbeunnamed/InputUnusedCatchParameterShouldBeUnnamedInsideAnonClass.java
@@ -3,7 +3,7 @@ UnusedCatchParameterShouldBeUnnamed
 
 */
 
-// non-compiled with javac: Compilable with Java21
+// Java21
 package com.puppycrawl.tools.checkstyle.checks.coding.unusedcatchparametershouldbeunnamed;
 
 public class InputUnusedCatchParameterShouldBeUnnamedInsideAnonClass {

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/unusedcatchparametershouldbeunnamed/InputUnusedCatchParameterShouldBeUnnamedNested.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/unusedcatchparametershouldbeunnamed/InputUnusedCatchParameterShouldBeUnnamedNested.java
@@ -3,7 +3,7 @@ UnusedCatchParameterShouldBeUnnamed
 
 */
 
-// non-compiled with javac: Compilable with Java21
+// Java21
 package com.puppycrawl.tools.checkstyle.checks.coding.unusedcatchparametershouldbeunnamed;
 
 public class InputUnusedCatchParameterShouldBeUnnamedNested {

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/unusedcatchparametershouldbeunnamed/InputUnusedCatchParameterShouldBeUnnamedWithResourceAndFinally.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/unusedcatchparametershouldbeunnamed/InputUnusedCatchParameterShouldBeUnnamedWithResourceAndFinally.java
@@ -3,13 +3,13 @@ UnusedCatchParameterShouldBeUnnamed
 
 */
 
-// non-compiled with javac: Compilable with Java21
+// Java21
 package com.puppycrawl.tools.checkstyle.checks.coding.unusedcatchparametershouldbeunnamed;
 
 import java.io.File;
 
 public class InputUnusedCatchParameterShouldBeUnnamedWithResourceAndFinally {
-    private E e;
+    private EOne e;
     Exception exception;
 
     void testMultiCatch() {
@@ -89,10 +89,10 @@ public class InputUnusedCatchParameterShouldBeUnnamedWithResourceAndFinally {
     }
 }
 
-class E {
+class EOne {
     void printStackTrace() {
     }
 }
 
-class A {
+class AOne {
 }

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/unusedlambdaparametershouldbeunnamed/InputUnusedLambdaParameterShouldBeUnnamedMultipleParameters.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/unusedlambdaparametershouldbeunnamed/InputUnusedLambdaParameterShouldBeUnnamedMultipleParameters.java
@@ -4,7 +4,7 @@ UnusedLambdaParameterShouldBeUnnamed
 */
 
 
-// non-compiled with javac: Compilable with Java21
+// Java21
 package com.puppycrawl.tools.checkstyle.checks.coding.unusedlambdaparametershouldbeunnamed;
 
 import java.util.function.BiFunction;

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/unusedlambdaparametershouldbeunnamed/InputUnusedLambdaParameterShouldBeUnnamedNested.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/unusedlambdaparametershouldbeunnamed/InputUnusedLambdaParameterShouldBeUnnamedNested.java
@@ -4,7 +4,7 @@ UnusedLambdaParameterShouldBeUnnamed
 */
 
 
-// non-compiled with javac: Compilable with Java21
+// Java21
 package com.puppycrawl.tools.checkstyle.checks.coding.unusedlambdaparametershouldbeunnamed;
 
 import java.util.function.BiFunction;

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/unusedlambdaparametershouldbeunnamed/InputUnusedLambdaParameterShouldBeUnnamedSingleLambdaParameter.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/unusedlambdaparametershouldbeunnamed/InputUnusedLambdaParameterShouldBeUnnamedSingleLambdaParameter.java
@@ -3,7 +3,7 @@ UnusedLambdaParameterShouldBeUnnamed
 
 */
 
-// non-compiled with javac: Compilable with Java21
+// Java21
 package com.puppycrawl.tools.checkstyle.checks.coding.unusedlambdaparametershouldbeunnamed;
 
 import java.util.List;

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/unusedlocalvariable/InputUnusedLocalVariableWithAllowUnnamed.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/unusedlocalvariable/InputUnusedLocalVariableWithAllowUnnamed.java
@@ -4,7 +4,7 @@ allowUnnamedVariables = (default)true
 
 */
 
-// non-compiled with javac: Compilable with Java21
+// Java21
 package com.puppycrawl.tools.checkstyle.checks.coding.unusedlocalvariable;
 
 import java.util.PriorityQueue;

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/unusedlocalvariable/InputUnusedLocalVariableWithAllowUnnamedFalse.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/unusedlocalvariable/InputUnusedLocalVariableWithAllowUnnamedFalse.java
@@ -4,7 +4,7 @@ allowUnnamedVariables = false
 
 */
 
-// non-compiled with javac: Compilable with Java21
+// Java21
 package com.puppycrawl.tools.checkstyle.checks.coding.unusedlocalvariable;
 
 import java.util.PriorityQueue;

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/variabledeclarationusagedistance/InputVariableDeclarationUsageDistancePatternVariables.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/variabledeclarationusagedistance/InputVariableDeclarationUsageDistancePatternVariables.java
@@ -8,7 +8,7 @@ ignoreFinal = false
 
 */
 
-// non-compiled with javac: Compilable with Java21
+// Java21
 package com.puppycrawl.tools.checkstyle.checks.coding.variabledeclarationusagedistance;
 
 public class InputVariableDeclarationUsageDistancePatternVariables {

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/whenshouldbeused/InputWhenShouldBeUsedNonPatternsSwitch.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/whenshouldbeused/InputWhenShouldBeUsedNonPatternsSwitch.java
@@ -3,7 +3,7 @@ WhenShouldBeUsed
 
 */
 
-// non-compiled with javac: Compilable with Java21
+// Java21
 package com.puppycrawl.tools.checkstyle.checks.coding.whenshouldbeused;
 
 public class InputWhenShouldBeUsedNonPatternsSwitch {

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/whenshouldbeused/InputWhenShouldBeUsedSwitchExpression.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/whenshouldbeused/InputWhenShouldBeUsedSwitchExpression.java
@@ -3,7 +3,7 @@ WhenShouldBeUsed
 
 */
 
-// non-compiled with javac: Compilable with Java21
+// Java21
 package com.puppycrawl.tools.checkstyle.checks.coding.whenshouldbeused;
 
 public class InputWhenShouldBeUsedSwitchExpression {

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/whenshouldbeused/InputWhenShouldBeUsedSwitchRule.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/whenshouldbeused/InputWhenShouldBeUsedSwitchRule.java
@@ -3,7 +3,7 @@ WhenShouldBeUsed
 
 */
 
-// non-compiled with javac: Compilable with Java21
+// Java21
 package com.puppycrawl.tools.checkstyle.checks.coding.whenshouldbeused;
 
 public class InputWhenShouldBeUsedSwitchRule {

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/whenshouldbeused/InputWhenShouldBeUsedSwitchStatements.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/whenshouldbeused/InputWhenShouldBeUsedSwitchStatements.java
@@ -3,7 +3,7 @@ WhenShouldBeUsed
 
 */
 
-// non-compiled with javac: Compilable with Java21
+// Java21
 package com.puppycrawl.tools.checkstyle.checks.coding.whenshouldbeused;
 
 public class InputWhenShouldBeUsedSwitchStatements {


### PR DESCRIPTION
part of : #17429

https://en.m.wikipedia.org/wiki/Java_version_history
https://docs.oracle.com/en/java/javase/24/migrate/significant-changes-jdk-21.html

Reason to enable preview features of jdk in checkstyle:
- Checkstyle vis always behind in jdk usage by 1 or 2 lat releases.
- Preview features are appearing and removed, good example is "String templates" in jdk21. It is very awaited feature by users, so user immediately would use it, but it challenging in consistent behavior, so it was removed few releases later. If checkstyle started to use such feature, it will be pain to refactor to stop using it. We removed support of string templates, as it was big  problem for us to support too.
- checkstyle has its own parser of java, so even jdk preview feature is in , and we enable them, on first usage of it checkstyle will fail to parse it , CI will be very red. So we naturally limited to features that checkstyle java parser supports. Adding features to our parser is huge effort, and highly unlikely to be done for preview features.