### PR TITLE
Issue #17540: Enforce Annotation location rule in package-info.java

### DIFF
--- a/src/it/java/com/google/checkstyle/test/chapter4formatting/rule4852classannotations/ClassAnnotationsTest.java
+++ b/src/it/java/com/google/checkstyle/test/chapter4formatting/rule4852classannotations/ClassAnnotationsTest.java
@@ -56,19 +56,31 @@ public class ClassAnnotationsTest extends AbstractGoogleModuleTestSupport {
 
     @Test
     public void testPackageAnnotation() throws Exception {
-        final String filePath = getNonCompilablePath("package-info.java");
+        final String filePath = getPath("package-info.java");
         verifyWithWholeConfig(filePath);
     }
 
     @Test
     public void testPackageAnnotation2() throws Exception {
-        final String filePath = getNonCompilablePath("example1/package-info.java");
+        final String filePath = getPath("example1/package-info.java");
         verifyWithWholeConfig(filePath);
     }
 
     @Test
     public void testPackageAnnotation3() throws Exception {
-        final String filePath = getNonCompilablePath("example2/package-info.java");
+        final String filePath = getPath("example2/package-info.java");
+        verifyWithWholeConfig(filePath);
+    }
+
+    @Test
+    public void testPackageAnnotation4() throws Exception {
+        final String filePath = getPath("example3/package-info.java");
+        verifyWithWholeConfig(filePath);
+    }
+
+    @Test
+    public void testPackageAnnotation5() throws Exception {
+        final String filePath = getPath("example4/package-info.java");
         verifyWithWholeConfig(filePath);
     }
 }

--- a/src/it/resources-noncompilable/com/google/checkstyle/test/chapter4formatting/rule4852classannotations/example1/package-info.java
+++ b/src/it/resources-noncompilable/com/google/checkstyle/test/chapter4formatting/rule4852classannotations/example1/package-info.java
@@ -1,5 +1,0 @@
-// non-compiled with javac: Used for Testing purpose.
-
-/** This is a package. */
-@Deprecated @SuppressWarnings("...") // false-negative until #17540
-package com.google.checkstyle.test.chapter4formatting.rule4852classannotations;

--- a/src/it/resources-noncompilable/com/google/checkstyle/test/chapter4formatting/rule4852classannotations/package-info.java
+++ b/src/it/resources-noncompilable/com/google/checkstyle/test/chapter4formatting/rule4852classannotations/package-info.java
@@ -1,6 +1,0 @@
-// non-compiled with javac: Used for Testing purpose.
-
-/** This is a package. */
-@Deprecated
-@SuppressWarnings("...")
-package com.google.checkstyle.test.chapter4formatting.rule4852classannotations;

--- a/src/it/resources/com/google/checkstyle/test/chapter4formatting/rule4852classannotations/Name.java
+++ b/src/it/resources/com/google/checkstyle/test/chapter4formatting/rule4852classannotations/Name.java
@@ -1,0 +1,12 @@
+package com.google.checkstyle.test.chapter4formatting.rule4852classannotations;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Retention(RetentionPolicy.RUNTIME)
+@Target({ElementType.PACKAGE, ElementType.TYPE})
+public @interface Name {
+    String value();
+}

--- a/src/it/resources/com/google/checkstyle/test/chapter4formatting/rule4852classannotations/ParentPackage.java
+++ b/src/it/resources/com/google/checkstyle/test/chapter4formatting/rule4852classannotations/ParentPackage.java
@@ -1,0 +1,12 @@
+package com.google.checkstyle.test.chapter4formatting.rule4852classannotations;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Retention(RetentionPolicy.RUNTIME)
+@Target({ElementType.PACKAGE, ElementType.TYPE})
+public @interface ParentPackage {
+    String value();
+}

--- a/src/it/resources/com/google/checkstyle/test/chapter4formatting/rule4852classannotations/SizePackage.java
+++ b/src/it/resources/com/google/checkstyle/test/chapter4formatting/rule4852classannotations/SizePackage.java
@@ -1,0 +1,12 @@
+package com.google.checkstyle.test.chapter4formatting.rule4852classannotations;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Retention(RetentionPolicy.RUNTIME)
+@Target({ElementType.PACKAGE, ElementType.TYPE})
+public @interface SizePackage {
+    String value();
+}

--- a/src/it/resources/com/google/checkstyle/test/chapter4formatting/rule4852classannotations/example1/package-info.java
+++ b/src/it/resources/com/google/checkstyle/test/chapter4formatting/rule4852classannotations/example1/package-info.java
@@ -1,0 +1,4 @@
+// violation 2 lines below 'Annotation 'SuppressWarnings' should be alone on line'
+/** This is a package. */
+@Deprecated @SuppressWarnings("...")
+package com.google.checkstyle.test.chapter4formatting.rule4852classannotations.example1;

--- a/src/it/resources/com/google/checkstyle/test/chapter4formatting/rule4852classannotations/example2/package-info.java
+++ b/src/it/resources/com/google/checkstyle/test/chapter4formatting/rule4852classannotations/example2/package-info.java
@@ -1,0 +1,5 @@
+/** This is a package. */
+@Deprecated
+// testing
+@SuppressWarnings("...")
+package com.google.checkstyle.test.chapter4formatting.rule4852classannotations.example2;

--- a/src/it/resources/com/google/checkstyle/test/chapter4formatting/rule4852classannotations/example3/package-info.java
+++ b/src/it/resources/com/google/checkstyle/test/chapter4formatting/rule4852classannotations/example3/package-info.java
@@ -1,0 +1,10 @@
+/*
+ * Licensed to the Software Foundation under one
+ * or more contributor license agreements.
+*/
+
+@ParentPackage("person") // violation below 'Annotation 'Name' should be alone on line'
+@Name("/") package com.google.checkstyle.test.chapter4formatting.rule4852classannotations.example3;
+
+import com.google.checkstyle.test.chapter4formatting.rule4852classannotations.Name;
+import com.google.checkstyle.test.chapter4formatting.rule4852classannotations.ParentPackage;

--- a/src/it/resources/com/google/checkstyle/test/chapter4formatting/rule4852classannotations/example4/package-info.java
+++ b/src/it/resources/com/google/checkstyle/test/chapter4formatting/rule4852classannotations/example4/package-info.java
@@ -1,0 +1,14 @@
+/*
+ * All rights reserved.
+ */
+
+// 3 violations 4 lines below:
+//   'Annotation 'ParentPackage' should be alone on line'
+//   'Annotation 'Name' should be alone on line'
+//   'Annotation 'SizePackage' should be alone on line'
+@ParentPackage("val") @Name("1") @SizePackage("2")
+package com.google.checkstyle.test.chapter4formatting.rule4852classannotations.example4;
+
+import com.google.checkstyle.test.chapter4formatting.rule4852classannotations.Name;
+import com.google.checkstyle.test.chapter4formatting.rule4852classannotations.ParentPackage;
+import com.google.checkstyle.test.chapter4formatting.rule4852classannotations.SizePackage;

--- a/src/it/resources/com/google/checkstyle/test/chapter4formatting/rule4852classannotations/example5/package-info.java
+++ b/src/it/resources/com/google/checkstyle/test/chapter4formatting/rule4852classannotations/example5/package-info.java
@@ -1,0 +1,12 @@
+/*
+ * All rights reserved.
+ */
+
+@ParentPackage("val")
+@Name("1")
+@SizePackage("2")
+package com.google.checkstyle.test.chapter4formatting.rule4852classannotations.example5;
+
+import com.google.checkstyle.test.chapter4formatting.rule4852classannotations.Name;
+import com.google.checkstyle.test.chapter4formatting.rule4852classannotations.ParentPackage;
+import com.google.checkstyle.test.chapter4formatting.rule4852classannotations.SizePackage;

--- a/src/it/resources/com/google/checkstyle/test/chapter4formatting/rule4852classannotations/package-info.java
+++ b/src/it/resources/com/google/checkstyle/test/chapter4formatting/rule4852classannotations/package-info.java
@@ -1,7 +1,4 @@
-// non-compiled with javac: Used for Testing purpose.
-
 /** This is a package. */
 @Deprecated
-// testing
 @SuppressWarnings("...")
 package com.google.checkstyle.test.chapter4formatting.rule4852classannotations;

--- a/src/main/resources/google_checks.xml
+++ b/src/main/resources/google_checks.xml
@@ -381,7 +381,7 @@
       <property name="id" value="AnnotationLocationMostCases"/>
       <property name="tokens"
                value="CLASS_DEF, INTERFACE_DEF, ENUM_DEF, METHOD_DEF, CTOR_DEF,
-                      RECORD_DEF, COMPACT_CTOR_DEF"/>
+                      RECORD_DEF, COMPACT_CTOR_DEF, PACKAGE_DEF"/>
     </module>
     <module name="AnnotationLocation">
       <property name="id" value="AnnotationLocationVariables"/>

--- a/src/site/xdoc/google_style.xml
+++ b/src/site/xdoc/google_style.xml
@@ -1476,19 +1476,12 @@
                 </td>
                 <td>
                   <span class="wrapper inline">
-                    <img src="images/ok_blue.png" alt="" />
+                    <img src="images/ok_green.png" alt="" />
                   </span>
                   <a href="checks/annotation/annotationlocation.html#AnnotationLocation">
                     AnnotationLocation</a>
                   (<a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources%20path%3A**%2Fgoogle_checks.xml+repo%3Acheckstyle%2Fcheckstyle+AnnotationLocation">
                   config</a>)
-                  <br />
-                  <br />
-                  Annotation location rule is not covered in <code>package-info.java</code>
-                  file. It will be addressed at:
-                  <a href="https://github.com/checkstyle/checkstyle/issues/17540">
-                    #17540
-                  </a>
                   <br />
                   <br />
                   <span class="wrapper inline">


### PR DESCRIPTION
resolves #17540


Diff Regression config: https://gist.githubusercontent.com/mohitsatr/f3d0e6d4aa5b6e25a9d3a6b9d5425972/raw/82af3a37f61201b3c95b3094391da73115bc3809/master_annotationlocation.xml
Diff Regression patch config: https://gist.githubusercontent.com/mohitsatr/b53a185be531c4ac11653a45b478e2a1/raw/5751b1e4812eb9e659b4c19cc49da1a109942f73/patch_annotationlocation.xml