### PR TITLE
Issue #17429: Changing Comment for module compilable before jdk21

### DIFF
--- a/src/test/resources-noncompilable/com/puppycrawl/tools/checkstyle/checks/coding/modifiedcontrolvariable/InputModifiedControlVariableRecordDecomposition.java
+++ b/src/test/resources-noncompilable/com/puppycrawl/tools/checkstyle/checks/coding/modifiedcontrolvariable/InputModifiedControlVariableRecordDecomposition.java
@@ -4,7 +4,7 @@ ModifiedControlVariable
 
 */
 
-// non-compiled with javac: Compilable with Java20
+// non-compiled with javac: compiling on jdk before Java21 (java20)
 package com.puppycrawl.tools.checkstyle.checks.coding.modifiedcontrolvariable;
 
 import java.util.List;

--- a/src/test/resources-noncompilable/com/puppycrawl/tools/checkstyle/checks/finalparameters/InputFinalParametersRecordForLoopPatternVariables.java
+++ b/src/test/resources-noncompilable/com/puppycrawl/tools/checkstyle/checks/finalparameters/InputFinalParametersRecordForLoopPatternVariables.java
@@ -7,7 +7,7 @@ tokens = PATTERN_VARIABLE_DEF,FOR_EACH_CLAUSE
 
 */
 
-// non-compiled with javac: Compilable with Java20
+// non-compiled with javac: compiling on jdk before Java21 (java20)
 package com.puppycrawl.tools.checkstyle.checks.finalparameters;
 
 public class InputFinalParametersRecordForLoopPatternVariables {

--- a/src/test/resources-noncompilable/com/puppycrawl/tools/checkstyle/checks/whitespace/operatorwrap/InputOperatorWrapGuardedPatterns.java
+++ b/src/test/resources-noncompilable/com/puppycrawl/tools/checkstyle/checks/whitespace/operatorwrap/InputOperatorWrapGuardedPatterns.java
@@ -7,7 +7,7 @@ tokens = (default)QUESTION, COLON, EQUAL, NOT_EQUAL, DIV, PLUS, MINUS, STAR, MOD
 
 
 */
-// non-compiled with javac: compilable with java21
+// non-compiled with javac: compiling on jdk before Java21 (java20)
 
 package com.puppycrawl.tools.checkstyle.checks.whitespace.operatorwrap;
 

--- a/src/test/resources-noncompilable/com/puppycrawl/tools/checkstyle/grammar/java19/InputGenericRecordDeconstructionPattern.java
+++ b/src/test/resources-noncompilable/com/puppycrawl/tools/checkstyle/grammar/java19/InputGenericRecordDeconstructionPattern.java
@@ -1,4 +1,4 @@
-// non-compiled with javac: Compilable with Java19
+// non-compiled with javac: compiling on jdk before Java21 (java19)
 package com.puppycrawl.tools.checkstyle.grammar.java19;
 
 import java.util.Objects;

--- a/src/test/resources-noncompilable/com/puppycrawl/tools/checkstyle/grammar/java19/InputJava19BindingWithModifiers.java
+++ b/src/test/resources-noncompilable/com/puppycrawl/tools/checkstyle/grammar/java19/InputJava19BindingWithModifiers.java
@@ -1,4 +1,4 @@
-// non-compiled with javac: Compilable with Java19
+// non-compiled with javac: compiling on jdk before Java21 (java19)
 package com.puppycrawl.tools.checkstyle.grammar.java19;
 
 public class InputJava19BindingWithModifiers {

--- a/src/test/resources-noncompilable/com/puppycrawl/tools/checkstyle/grammar/java19/InputJava19BindingsWithLotsOfOperators.java
+++ b/src/test/resources-noncompilable/com/puppycrawl/tools/checkstyle/grammar/java19/InputJava19BindingsWithLotsOfOperators.java
@@ -1,4 +1,4 @@
-// non-compiled with javac: Compilable with Java19
+// non-compiled with javac: compiling on jdk before Java21 (java19)
 package com.puppycrawl.tools.checkstyle.grammar.java19;
 
 public class InputJava19BindingsWithLotsOfOperators {

--- a/src/test/resources-noncompilable/com/puppycrawl/tools/checkstyle/grammar/java19/InputJava19GuardsWithExtraParenthesis.java
+++ b/src/test/resources-noncompilable/com/puppycrawl/tools/checkstyle/grammar/java19/InputJava19GuardsWithExtraParenthesis.java
@@ -1,4 +1,4 @@
-// non-compiled with javac: Compilable with Java19
+// non-compiled with javac: compiling on jdk before Java21 (java19)
 package com.puppycrawl.tools.checkstyle.grammar.java19;
 
 import java.util.Objects;

--- a/src/test/resources-noncompilable/com/puppycrawl/tools/checkstyle/grammar/java19/InputJava19PatternsAnnotationsOnBinding.java
+++ b/src/test/resources-noncompilable/com/puppycrawl/tools/checkstyle/grammar/java19/InputJava19PatternsAnnotationsOnBinding.java
@@ -1,4 +1,4 @@
-// non-compiled with javac: Compilable with Java19
+// non-compiled with javac: compiling on jdk before Java21 (java19)
 package com.puppycrawl.tools.checkstyle.grammar.java19;
 
 public class InputJava19PatternsAnnotationsOnBinding {

--- a/src/test/resources-noncompilable/com/puppycrawl/tools/checkstyle/grammar/java19/InputJava19PatternsInNullSwitch1.java
+++ b/src/test/resources-noncompilable/com/puppycrawl/tools/checkstyle/grammar/java19/InputJava19PatternsInNullSwitch1.java
@@ -1,4 +1,4 @@
-// non-compiled with javac: Compilable with Java19
+// non-compiled with javac: compiling on jdk before Java21 (java19)
 package com.puppycrawl.tools.checkstyle.grammar.java19;
 
 public class InputJava19PatternsInNullSwitch1 {

--- a/src/test/resources-noncompilable/com/puppycrawl/tools/checkstyle/grammar/java19/InputJava19PatternsInNullSwitch2.java
+++ b/src/test/resources-noncompilable/com/puppycrawl/tools/checkstyle/grammar/java19/InputJava19PatternsInNullSwitch2.java
@@ -1,4 +1,4 @@
-// non-compiled with javac: Compilable with Java19
+// non-compiled with javac: compiling on jdk before Java21 (java19)
 package com.puppycrawl.tools.checkstyle.grammar.java19;
 
 public class InputJava19PatternsInNullSwitch2 {

--- a/src/test/resources-noncompilable/com/puppycrawl/tools/checkstyle/grammar/java19/InputJava19PatternsInSwitchLabels.java
+++ b/src/test/resources-noncompilable/com/puppycrawl/tools/checkstyle/grammar/java19/InputJava19PatternsInSwitchLabels.java
@@ -1,4 +1,4 @@
-// non-compiled with javac: Compilable with Java19
+// non-compiled with javac: compiling on jdk before Java21 (java19)
 package com.puppycrawl.tools.checkstyle.grammar.java19;
 
 import java.util.ArrayList;

--- a/src/test/resources-noncompilable/com/puppycrawl/tools/checkstyle/grammar/java19/InputJava19PatternsTrickyWhenUsage.java
+++ b/src/test/resources-noncompilable/com/puppycrawl/tools/checkstyle/grammar/java19/InputJava19PatternsTrickyWhenUsage.java
@@ -1,4 +1,4 @@
-// non-compiled with javac: Compilable with Java19
+// non-compiled with javac: compiling on jdk before Java21 (java19)
 package com.puppycrawl.tools.checkstyle.grammar.java19;
 
 public class InputJava19PatternsTrickyWhenUsage {

--- a/src/test/resources-noncompilable/com/puppycrawl/tools/checkstyle/grammar/java19/InputJava19RecordDecompositionWithConditionInLoops.java
+++ b/src/test/resources-noncompilable/com/puppycrawl/tools/checkstyle/grammar/java19/InputJava19RecordDecompositionWithConditionInLoops.java
@@ -1,4 +1,4 @@
-// non-compiled with javac: Compilable with Java19
+// non-compiled with javac: compiling on jdk before Java21 (java19)
 package com.puppycrawl.tools.checkstyle.grammar.java19;
 
 import java.util.Iterator;

--- a/src/test/resources-noncompilable/com/puppycrawl/tools/checkstyle/grammar/java19/InputRecordPatternsPreview.java
+++ b/src/test/resources-noncompilable/com/puppycrawl/tools/checkstyle/grammar/java19/InputRecordPatternsPreview.java
@@ -1,4 +1,4 @@
-// non-compiled with javac: Compilable with Java19
+// non-compiled with javac: compiling on jdk before Java21 (java19)
 package com.puppycrawl.tools.checkstyle.grammar.java19;
 
 public class InputRecordPatternsPreview {

--- a/src/test/resources-noncompilable/com/puppycrawl/tools/checkstyle/grammar/java19/InputRecordPatternsPreviewNestedDecomposition.java
+++ b/src/test/resources-noncompilable/com/puppycrawl/tools/checkstyle/grammar/java19/InputRecordPatternsPreviewNestedDecomposition.java
@@ -1,4 +1,4 @@
-// non-compiled with javac: Compilable with Java19
+// non-compiled with javac: compiling on jdk before Java21 (java19)
 package com.puppycrawl.tools.checkstyle.grammar.java19;
 
 public class InputRecordPatternsPreviewNestedDecomposition {

--- a/src/test/resources-noncompilable/com/puppycrawl/tools/checkstyle/grammar/java20/InputJava20RecordDecompositionEnhancedForLoop.java
+++ b/src/test/resources-noncompilable/com/puppycrawl/tools/checkstyle/grammar/java20/InputJava20RecordDecompositionEnhancedForLoop.java
@@ -1,4 +1,4 @@
-// non-compiled with javac: Compilable with Java20
+// non-compiled with javac: compiling on jdk before Java21 (java20)
 package com.puppycrawl.tools.checkstyle.grammar.java20;
 
 import java.util.ArrayList;

--- a/src/test/resources-noncompilable/com/puppycrawl/tools/checkstyle/grammar/java20/InputJava20RecordDecompositionEnhancedForLoopTricky.java
+++ b/src/test/resources-noncompilable/com/puppycrawl/tools/checkstyle/grammar/java20/InputJava20RecordDecompositionEnhancedForLoopTricky.java
@@ -1,4 +1,4 @@
-// non-compiled with javac: Compilable with Java20
+// non-compiled with javac: compiling on jdk before Java21 (java20)
 package com.puppycrawl.tools.checkstyle.grammar.java20;
 
 import java.util.List;


### PR DESCRIPTION
part of : #17429
All these changes were supported before jdk21
Report of changes :
1. Parenthesized Patterns Removed

Java 19 preview (JEP 405) allowed extra parentheses around record patterns for flexibility, e.g.:

`case (Box<Box<String>>(Box<String>(String s) box)) -> ...`


Java 21 (JEP 441) removed parenthesized patterns:

> “Remove parenthesized patterns, since they did not have sufficient value.”

✅ Java 21 requires:

`case Box<Box<String>>(Box<String>(String s) box) -> ...`

2. Guards (when clauses) Simplified

Java 19 preview allowed overly nested/casted expressions in guards:
`
case Box(Box(String s) box) when (boolean)"test".equals(s) -> 1;`


Java 21 (JEP 441) requires plain boolean conditions without unnecessary casts/extra parentheses.

✅ Legal in Java 21:

`case Box(Box(String s) box) when "test".equals(s) -> 1;`

3. Multiple Bindings in Nested Patterns Restricted

Java 19 allowed constructs like:

`case Box<Box<String>>(Object o) b2 -> ...`


(two names bound to the same nested value).

Java 21 disallows this. Only one binding per nested pattern is allowed.

4. case null, default Order

Java 19 preview permitted flexibility in label ordering.

Java 21 (JEP 441) explicitly requires:

`case null, default -> ...`


❌ case default, null -> ... is illegal because default must appear last.

5. Modifiers and Annotations in Record Patterns

Java 19 (JEP 405) permitted annotations and modifiers (final, @Anno) almost anywhere in record patterns:

`if (p instanceof Pair<I>(final @MyAnno C c, I i)) { ... }`


Java 21 (JEP 440) restricted placement:

Pattern variables are implicitly final, so final is redundant.

Annotations are allowed, but must appear in stricter positions (directly before the type).

Parenthesized + annotated patterns `(final @Anno1 @Anno2 Integer x)` are no longer legal.

6. instanceof with Record Patterns

Java 19 preview allowed deeply parenthesized instanceof checks:

`if (when instanceof when<String>(when<String>(when<String> s1)) w1) { ... }`


Java 21 disallows redundant parentheses; only clean nested record patterns are valid.

 Sources:

JEP 405: Record Patterns (Preview, Java 19)
👉 https://openjdk.org/jeps/405

JEP 432: Record Patterns (Second Preview, Java 20)
👉 https://openjdk.org/jeps/432

JEP 440: Record Patterns (Final, Java 21)
👉 https://openjdk.org/jeps/440

JEP 441: Pattern Matching for switch (Final, Java 21)
👉 https://openjdk.org/jeps/441

Java 19 Language Guide (Pattern Matching & Record Patterns)
👉 https://docs.oracle.com/en/java/javase/19/language/pattern-matching.html

Java 21 Language Guide (Pattern Matching Updates)
👉 https://docs.oracle.com/en/java/javase/21/language/pattern-matching-switch.html