### PR TITLE
Issue #17701: fix Cirrus CI Windows JDK21 installation by switching to Temurin

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -8,7 +8,7 @@ task:
     - git clone --recursive
           https://x-access-token:%CIRRUS_REPO_CLONE_TOKEN%@github.com/%CIRRUS_REPO_FULL_NAME%.git
           %CIRRUS_WORKING_DIR%/ci
-    - set "JAVA_HOME=%ProgramFiles%\OpenJDK\%OPENJDK_PATH%"
+    - set "JAVA_HOME=%ProgramFiles%\%TEMURIN_PATH%"
     - set "PATH=%JAVA_HOME%\bin;%PATH%"
     - cd ci
     - cmd /c "if defined CIRRUS_PR (git fetch origin pull/%CIRRUS_PR%/head:pull/%CIRRUS_PR%)"
@@ -25,8 +25,8 @@ task:
     # add more JDK versions here
     - name: Cirrus - JDK21
       env:
-        OPENJDK_VERSION: "21.0.6"
-        OPENJDK_PATH: "jdk-21"
+        TEMURIN_VERSION: "21.0.6.7"
+        TEMURIN_PATH: 'Eclipse Adoptium\jdk-21'
   env:
     # disable ANSI output for picocli (may affect tests)
     NO_COLOR: "1"
@@ -38,14 +38,15 @@ task:
     - choco config set cacheLocation %CIRRUS_WORKING_DIR%/.chocolatey
     - choco upgrade -y chocolatey
     - choco install -y --no-progress ant
-    - choco install -y --no-progress openjdk --version %OPENJDK_VERSION%
-    - set "JAVA_HOME=%ProgramFiles%\OpenJDK\%OPENJDK_PATH%"
+    - choco install -y --no-progress temurin --version %TEMURIN_VERSION%
+    - refreshenv
+    - set "JAVA_HOME=%ProgramFiles%\%TEMURIN_PATH%"
     - set "PATH=%JAVA_HOME%\bin;%PATH%"
     - java -version
     - javac -version
 
   version_script:
-    - set "JAVA_HOME=%ProgramFiles%\OpenJDK\%OPENJDK_PATH%"
+    - set "JAVA_HOME=%ProgramFiles%\%TEMURIN_PATH%"
     - set "PATH=%JAVA_HOME%\bin;%PATH%"
     - set
     - ant -version
@@ -53,17 +54,17 @@ task:
     # - xsltproc --version
     # - xml --version
   sevntu_script:
-    - set "JAVA_HOME=%ProgramFiles%\OpenJDK\%OPENJDK_PATH%"
+    - set "JAVA_HOME=%ProgramFiles%\%TEMURIN_PATH%"
     - set "PATH=%JAVA_HOME%\bin;%PATH%"
     - cd ci
     - .ci/validation.cmd sevntu
   verify_without_checkstyle_script:
-    - set "JAVA_HOME=%ProgramFiles%\OpenJDK\%OPENJDK_PATH%"
+    - set "JAVA_HOME=%ProgramFiles%\%TEMURIN_PATH%"
     - set "PATH=%JAVA_HOME%\bin;%PATH%"
     - cd ci
     - .ci/validation.cmd verify_without_checkstyle
   site_without_verify_script:
-    - set "JAVA_HOME=%ProgramFiles%\OpenJDK\%OPENJDK_PATH%"
+    - set "JAVA_HOME=%ProgramFiles%\%TEMURIN_PATH%"
     - set "PATH=%JAVA_HOME%\bin;%PATH%"
     - cd ci
     - .ci/validation.cmd site_without_verify

--- a/config/jsoref-spellchecker/whitelist.words
+++ b/config/jsoref-spellchecker/whitelist.words
@@ -14,6 +14,7 @@ acm
 Aconfig
 actionlint
 addons
+Adoptium
 adr
 AFBR
 AFilter
@@ -1166,6 +1167,7 @@ redundantmodifier
 refactor
 refactoring
 refid
+refreshenv
 regex
 regexp
 regexpheader


### PR DESCRIPTION
Fixes #17701 

This PR fixes the Windows build on Cirrus CI, which was failing due to an unavailable JDK version.

-   Previously, `.cirrus.yml` tried to install **OpenJDK 21.0.6** via Chocolatey:

    `choco install -y --no-progress openjdk --version 21.0.6`

    but Chocolatey's `openjdk` package only provides `21.0.0`, so the job failed.

-   Updated `.cirrus.yml` to install **Eclipse Temurin 21.0.6.7**, which is available on Chocolatey.

-   Updated `JAVA_HOME` to point to the Temurin install path:

    `C:\Program Files\Eclipse Adoptium\jdk-21`

-   Added `refreshenv` to reload environment variables after the install step.
