### PR TITLE
supplemental: Documentation to disable LineLength Check on Text-blocks

### DIFF
--- a/src/site/xdoc/checks/sizes/linelength.xml
+++ b/src/site/xdoc/checks/sizes/linelength.xml
@@ -246,6 +246,40 @@ class Example5 {
     System.out.println("This line is long and exceeds the default limit of 80 characters.");
   }
 }
+</code></pre></div><hr class="example-separator"/>
+        <p id="Example6-config">
+          To prevent this check from flagging lines in text-blocks, with
+          <a href="https://github.com/checkstyle/checkstyle/issues/17707">side effects</a>:
+        </p>
+        <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
+&lt;module name="Checker"&gt;
+  &lt;module name="LineLength"&gt;
+    &lt;property name="max" value="70"/&gt;
+  &lt;/module&gt;
+  &lt;module name="SuppressWithPlainTextCommentFilter"&gt;
+    &lt;property name="checkFormat" value="LineLength"/&gt;
+    &lt;property name="offCommentFormat" value='^.*"""$'/&gt;
+    &lt;property name="onCommentFormat" value='^\s*"""\s*(?:[,;]|.+)$'/&gt;
+  &lt;/module&gt;
+&lt;/module&gt;
+</code></pre></div>
+        <p id="Example6-code">
+          Example:
+        </p>
+        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+package com.puppycrawl.tools.checkstyle.checks.sizes.linelength;
+
+public class Example6 {
+  void testMethod() {
+    String str1 = """
+        This is a very really long string that exceeds the limit but no error....
+        """;
+    String str2 =
+        """
+        This is a very really long string that exceeds the limit but no error.....
+        """;
+  }
+}
 </code></pre></div>
       </subsection>
 

--- a/src/site/xdoc/checks/sizes/linelength.xml.template
+++ b/src/site/xdoc/checks/sizes/linelength.xml.template
@@ -117,6 +117,23 @@
           <param name="path"
                  value="resources/com/puppycrawl/tools/checkstyle/checks/sizes/linelength/Example5.java"/>
           <param name="type" value="code"/>
+        </macro><hr class="example-separator"/>
+        <p id="Example6-config">
+          To prevent this check from flagging lines in text-blocks, with
+          <a href="https://github.com/checkstyle/checkstyle/issues/17707">side effects</a>:
+        </p>
+        <macro name="example">
+          <param name="path"
+               value="resources/com/puppycrawl/tools/checkstyle/checks/sizes/linelength/Example6.java"/>
+          <param name="type" value="config"/>
+        </macro>
+        <p id="Example6-code">
+          Example:
+        </p>
+        <macro name="example">
+          <param name="path"
+                 value="resources/com/puppycrawl/tools/checkstyle/checks/sizes/linelength/Example6.java"/>
+          <param name="type" value="code"/>
         </macro>
       </subsection>
 

--- a/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/sizes/linelength/Example6.java
+++ b/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/sizes/linelength/Example6.java
@@ -1,0 +1,27 @@
+/*xml
+<module name="Checker">
+  <module name="LineLength">
+    <property name="max" value="70"/>
+  </module>
+  <module name="SuppressWithPlainTextCommentFilter">
+    <property name="checkFormat" value="LineLength"/>
+    <property name="offCommentFormat" value='^.*"""$'/>
+    <property name="onCommentFormat" value='^\s*"""\s*(?:[,;]|.+)$'/>
+  </module>
+</module>
+*/
+// xdoc section -- start
+package com.puppycrawl.tools.checkstyle.checks.sizes.linelength;
+
+public class Example6 {
+  void testMethod() {
+    String str1 = """
+        This is a very really long string that exceeds the limit but no error....
+        """;
+    String str2 =
+        """
+        This is a very really long string that exceeds the limit but no error.....
+        """;
+  }
+}
+// xdoc section -- end


### PR DESCRIPTION
part of #11867
