### PR TITLE
Issue #17128: ignore import lines during check, fix alignment in more input files

### DIFF
--- a/src/test/java/com/puppycrawl/tools/checkstyle/IndentationTrailingCommentsVerticalAlignmentTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/IndentationTrailingCommentsVerticalAlignmentTest.java
@@ -77,7 +77,6 @@ class IndentationTrailingCommentsVerticalAlignmentTest {
         "InputIndentationLambda.java",
         "InputIndentationLambda1.java",
         "InputIndentationLambda2.java",
-        "InputIndentationLineWrappedRecordDeclaration.java",
         "InputIndentationMethodPrecededByAnnotationWithParameterOnSeparateLine.java",
         "InputIndentationNewChildren.java",
         "InputIndentationNewWithForceStrictCondition.java",
@@ -86,7 +85,6 @@ class IndentationTrailingCommentsVerticalAlignmentTest {
         "InputIndentationTryResourcesNotStrict1.java",
         "InputIndentationTryWithResourcesStrict.java",
         "InputIndentationTryWithResourcesStrict1.java",
-        "InputIndentationValidBlockIndent1.java",
         "InputIndentationValidClassDefIndent.java",
         "InputIndentationValidClassDefIndent1.java",
         "InputIndentationCorrectIfAndParameter1.java",
@@ -106,6 +104,9 @@ class IndentationTrailingCommentsVerticalAlignmentTest {
 
         for (int idx = 0; idx < lines.size(); idx++) {
             final String line = lines.get(idx);
+            if (line.trim().startsWith("import ")) {
+                continue;
+            }
             final int commentStartIndex = line.indexOf("//indent:");
             if (commentStartIndex > 0) {
                 final String codePart = line.substring(0, commentStartIndex);

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/indentation/indentation/InputIndentationLineWrappedRecordDeclaration.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/indentation/indentation/InputIndentationLineWrappedRecordDeclaration.java
@@ -1,86 +1,86 @@
-// Java17                                   //indent:0 exp:0
-package com.puppycrawl.tools.checkstyle.checks.indentation.indentation;             //indent:0 exp:0
-                                                                                  //indent:82 exp:82
-import java.io.IOException;                                                         //indent:0 exp:0
-                                                                                  //indent:82 exp:82
-/* Config:                                                                          //indent:0 exp:0
- *                                                                                  //indent:1 exp:1
- * basicOffset = 4                                                                  //indent:1 exp:1
- * braceAdjustment = 0                                                              //indent:1 exp:1
- * caseIndent = 4                                                                   //indent:1 exp:1
- * throwsIndent = 4                                                                 //indent:1 exp:1
- * arrayInitIndent = 4                                                              //indent:1 exp:1
- * lineWrappingIndentation = 4                                                      //indent:1 exp:1
- * forceStrictCondition = false                                                     //indent:1 exp:1
- */                                                                                 //indent:1 exp:1
-                                                                                  //indent:82 exp:82
-class InputIndentationLineWrappedRecordDeclaration {                                //indent:0 exp:0
-    private interface Interf {                                                      //indent:4 exp:4
-        String sayHello();                                                          //indent:8 exp:8
-    }                                                                               //indent:4 exp:4
-                                                                                  //indent:82 exp:82
-    private static record ConcreteRecord(                                           //indent:4 exp:4
-        String greeting                                                             //indent:8 exp:8
-    ) implements Interf {                                                           //indent:4 exp:4
-        @Override                                                                   //indent:8 exp:8
-    public String sayHello() {                                                      //indent:4 exp:4
-            return greeting();                                                    //indent:12 exp:12
-        }                                                                           //indent:8 exp:8
-    }                                                                               //indent:4 exp:4
-                                                                                  //indent:82 exp:82
-    private static record ConcreteRecord2(                                          //indent:4 exp:4
-        String greeting                                                             //indent:8 exp:8
-) implements Interf {                                                          //indent:0 exp:4 warn
-        @Override                                                                   //indent:8 exp:8
-    public String sayHello() {                                                      //indent:4 exp:4
-            return greeting();                                                    //indent:12 exp:12
-        }                                                                           //indent:8 exp:8
-    }                                                                               //indent:4 exp:4
-                                                                                  //indent:82 exp:82
-    private static String method(                                                   //indent:4 exp:4
-        String greeting                                                             //indent:8 exp:8
-    ) throws Exception {                                                            //indent:4 exp:4
-        return greeting + "test";                                                   //indent:8 exp:8
-    }                                                                               //indent:4 exp:4
-                                                                                  //indent:82 exp:82
-    interface SimpleInterface1 {                                                    //indent:4 exp:4
-        default                                                                     //indent:8 exp:8
-            void                                                                  //indent:12 exp:12
-            method()                                                              //indent:12 exp:12
-            throws                                                                //indent:12 exp:12
-            IOException {                                                         //indent:12 exp:12
-        }                                                                           //indent:8 exp:8
-    }                                                                               //indent:4 exp:4
-                                                                                  //indent:82 exp:82
-interface SimpleInterface2 {                                                   //indent:0 exp:4 warn
-default                                                                        //indent:0 exp:8 warn
-void                                                                           //indent:0 exp:4 warn
-method()                                                                       //indent:0 exp:4 warn
-throws                                                                         //indent:0 exp:4 warn
-IOException {                                                                  //indent:0 exp:4 warn
-}                                                                              //indent:0 exp:8 warn
-}                                                                              //indent:0 exp:4 warn
-                                                                                  //indent:82 exp:82
-    record SimpleRecord1(                                                           //indent:4 exp:4
-    )                                                                               //indent:4 exp:4
-            implements                                                            //indent:12 exp:12
-            SimpleInterface1                                                      //indent:12 exp:12
-    {                                                                               //indent:4 exp:4
-        record Inner1(                                                              //indent:8 exp:8
-        )                                                                           //indent:8 exp:8
-        {                                                                           //indent:8 exp:8
-        }                                                                           //indent:8 exp:8
-    }                                                                               //indent:4 exp:4
-                                                                                  //indent:82 exp:82
-record SimpleRecord2(                                                          //indent:0 exp:4 warn
-)                                                                              //indent:0 exp:4 warn
-implements                                                                     //indent:0 exp:4 warn
-SimpleInterface2 {                                                             //indent:0 exp:4 warn
-record Inner2                                                                  //indent:0 exp:8 warn
-(                                                                              //indent:0 exp:4 warn
-)                                                                              //indent:0 exp:8 warn
-{                                                                              //indent:0 exp:8 warn
-}                                                                              //indent:0 exp:8 warn
-}                                                                              //indent:0 exp:4 warn
-                                                                                  //indent:82 exp:82
-}                                                                                   //indent:0 exp:0
+// Java17                                                               //indent:0 exp:0
+package com.puppycrawl.tools.checkstyle.checks.indentation.indentation; //indent:0 exp:0
+                                                                        //indent:72 exp:72
+import java.io.IOException;                                             //indent:0 exp:0
+                                                                        //indent:72 exp:72
+/* Config:                                                              //indent:0 exp:0
+ *                                                                      //indent:1 exp:1
+ * basicOffset = 4                                                      //indent:1 exp:1
+ * braceAdjustment = 0                                                  //indent:1 exp:1
+ * caseIndent = 4                                                       //indent:1 exp:1
+ * throwsIndent = 4                                                     //indent:1 exp:1
+ * arrayInitIndent = 4                                                  //indent:1 exp:1
+ * lineWrappingIndentation = 4                                          //indent:1 exp:1
+ * forceStrictCondition = false                                         //indent:1 exp:1
+ */                                                                     //indent:1 exp:1
+                                                                        //indent:72 exp:72
+class InputIndentationLineWrappedRecordDeclaration {                    //indent:0 exp:0
+    private interface Interf {                                          //indent:4 exp:4
+        String sayHello();                                              //indent:8 exp:8
+    }                                                                   //indent:4 exp:4
+                                                                        //indent:72 exp:72
+    private static record ConcreteRecord(                               //indent:4 exp:4
+        String greeting                                                 //indent:8 exp:8
+    ) implements Interf {                                               //indent:4 exp:4
+        @Override                                                       //indent:8 exp:8
+    public String sayHello() {                                          //indent:4 exp:4
+            return greeting();                                          //indent:12 exp:12
+        }                                                               //indent:8 exp:8
+    }                                                                   //indent:4 exp:4
+                                                                        //indent:72 exp:72
+    private static record ConcreteRecord2(                              //indent:4 exp:4
+        String greeting                                                 //indent:8 exp:8
+) implements Interf {                                                   //indent:0 exp:4 warn
+        @Override                                                       //indent:8 exp:8
+    public String sayHello() {                                          //indent:4 exp:4
+            return greeting();                                          //indent:12 exp:12
+        }                                                               //indent:8 exp:8
+    }                                                                   //indent:4 exp:4
+                                                                        //indent:72 exp:72
+    private static String method(                                       //indent:4 exp:4
+        String greeting                                                 //indent:8 exp:8
+    ) throws Exception {                                                //indent:4 exp:4
+        return greeting + "test";                                       //indent:8 exp:8
+    }                                                                   //indent:4 exp:4
+                                                                        //indent:72 exp:72
+    interface SimpleInterface1 {                                        //indent:4 exp:4
+        default                                                         //indent:8 exp:8
+            void                                                        //indent:12 exp:12
+            method()                                                    //indent:12 exp:12
+            throws                                                      //indent:12 exp:12
+            IOException {                                               //indent:12 exp:12
+        }                                                               //indent:8 exp:8
+    }                                                                   //indent:4 exp:4
+                                                                        //indent:72 exp:72
+interface SimpleInterface2 {                                            //indent:0 exp:4 warn
+default                                                                 //indent:0 exp:8 warn
+void                                                                    //indent:0 exp:4 warn
+method()                                                                //indent:0 exp:4 warn
+throws                                                                  //indent:0 exp:4 warn
+IOException {                                                           //indent:0 exp:4 warn
+}                                                                       //indent:0 exp:8 warn
+}                                                                       //indent:0 exp:4 warn
+                                                                        //indent:72 exp:72
+    record SimpleRecord1(                                               //indent:4 exp:4
+    )                                                                   //indent:4 exp:4
+            implements                                                  //indent:12 exp:12
+            SimpleInterface1                                            //indent:12 exp:12
+    {                                                                   //indent:4 exp:4
+        record Inner1(                                                  //indent:8 exp:8
+        )                                                               //indent:8 exp:8
+        {                                                               //indent:8 exp:8
+        }                                                               //indent:8 exp:8
+    }                                                                   //indent:4 exp:4
+                                                                        //indent:72 exp:72
+record SimpleRecord2(                                                   //indent:0 exp:4 warn
+)                                                                       //indent:0 exp:4 warn
+implements                                                              //indent:0 exp:4 warn
+SimpleInterface2 {                                                      //indent:0 exp:4 warn
+record Inner2                                                           //indent:0 exp:8 warn
+(                                                                       //indent:0 exp:4 warn
+)                                                                       //indent:0 exp:8 warn
+{                                                                       //indent:0 exp:8 warn
+}                                                                       //indent:0 exp:8 warn
+}                                                                       //indent:0 exp:4 warn
+                                                                        //indent:72 exp:72
+}                                                                       //indent:0 exp:0

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/indentation/indentation/InputIndentationValidBlockIndent1.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/indentation/indentation/InputIndentationValidBlockIndent1.java
@@ -1,108 +1,109 @@
-package com.puppycrawl.tools.checkstyle.checks.indentation.indentation; //indent:0 exp:0
+package com.puppycrawl.tools.checkstyle.checks.indentation.indentation;           //indent:0 exp:0
 
-import java.io.Closeable; //indent:0 exp:0
-import java.util.stream.Stream; //indent:0 exp:0
+import java.io.Closeable;                                                         //indent:0 exp:0
+import java.util.stream.Stream;                                                   //indent:0 exp:0
 
-/**                                                                           //indent:0 exp:0
- * This test-input is intended to be checked using following configuration:   //indent:1 exp:1
- *                                                                            //indent:1 exp:1
- * arrayInitIndent = 4                                                        //indent:1 exp:1
- * basicOffset = 4                                                            //indent:1 exp:1
- * braceAdjustment = 0                                                        //indent:1 exp:1
- * caseIndent = 4                                                             //indent:1 exp:1
- * forceStrictCondition = false                                               //indent:1 exp:1
- * lineWrappingIndentation = 4                                                //indent:1 exp:1
- * tabWidth = 4                                                               //indent:1 exp:1
- * throwsIndent = 4                                                           //indent:1 exp:1
- *                                                                            //indent:1 exp:1
- * @author  jrichard                                                         //indent:1 exp:1
- */                                                                           //indent:1 exp:1
-public class InputIndentationValidBlockIndent1 { //indent:0 exp:0
+/**                                                                               //indent:0 exp:0
+ * This test-input is intended to be checked using following configuration:       //indent:1 exp:1
+ *                                                                                //indent:1 exp:1
+ * arrayInitIndent = 4                                                            //indent:1 exp:1
+ * basicOffset = 4                                                                //indent:1 exp:1
+ * braceAdjustment = 0                                                            //indent:1 exp:1
+ * caseIndent = 4                                                                 //indent:1 exp:1
+ * forceStrictCondition = false                                                   //indent:1 exp:1
+ * lineWrappingIndentation = 4                                                    //indent:1 exp:1
+ * tabWidth = 4                                                                   //indent:1 exp:1
+ * throwsIndent = 4                                                               //indent:1 exp:1
+ *                                                                                //indent:1 exp:1
+ * @author  jrichard                                                              //indent:1 exp:1
+ */                                                                               //indent:1 exp:1
+public class InputIndentationValidBlockIndent1 {                                  //indent:0 exp:0
 
-    /** Creates a new instance of InputValidBlockIndent */ //indent:4 exp:4
-    public InputIndentationValidBlockIndent1() { //indent:4 exp:4
-    } //indent:4 exp:4
+    /** Creates a new instance of InputValidBlockIndent */                        //indent:4 exp:4
+    public InputIndentationValidBlockIndent1() {                                  //indent:4 exp:4
+    }                                                                             //indent:4 exp:4
 
-} //indent:0 exp:0
+}                                                                                 //indent:0 exp:0
 
-enum EquivalenceTester { //indent:0 exp:0
-    /** //indent:4 exp:4
-     * An equivalenster that decides based on {@link Object#equals(Object) equals}. //indent:5 exp:5
-     */ //indent:5 exp:5
-    OBJECT_ATTRIBUTES { //indent:4 exp:4
-        /** //indent:8 exp:8
-         * {@inheritDoc} //indent:9 exp:9
-         */ //indent:9 exp:9
-        public boolean areEqual( final Object first, final Object second ) { //indent:8 exp:8
-            return true; //indent:12 exp:12
-        } //indent:8 exp:8
+enum EquivalenceTester {                                                          //indent:0 exp:0
+    /**                                                                           //indent:4 exp:4
+     * An equivalenster that decides based on                                     //indent:5 exp:5
+     * {@link Object#equals(Object) equals}.                                      //indent:5 exp:5
+     */                                                                           //indent:5 exp:5
+    OBJECT_ATTRIBUTES {                                                           //indent:4 exp:4
+        /**                                                                       //indent:8 exp:8
+         * {@inheritDoc}                                                          //indent:9 exp:9
+         */                                                                       //indent:9 exp:9
+        public boolean areEqual( final Object first, final Object second ) {      //indent:8 exp:8
+            return true;                                                          //indent:12 exp:12
+        }                                                                         //indent:8 exp:8
 
-        /** //indent:8 exp:8
-         * {@inheritDoc} //indent:9 exp:9
-         */ //indent:9 exp:9
-        public int hashCode( final Object target ) { //indent:8 exp:8
-            return 1; //indent:12 exp:12
-        } //indent:8 exp:8
-    }, //indent:4 exp:4
+        /**                                                                       //indent:8 exp:8
+         * {@inheritDoc}                                                          //indent:9 exp:9
+         */                                                                       //indent:9 exp:9
+        public int hashCode( final Object target ) {                              //indent:8 exp:8
+            return 1;                                                             //indent:12 exp:12
+        }                                                                         //indent:8 exp:8
+    },                                                                            //indent:4 exp:4
 
-    /** //indent:4 exp:4
-     * An equivalence tester that decides based on {@code ==}. //indent:5 exp:5
-     */ //indent:5 exp:5
-    OBJECT_IDENTITIES //indent:4 exp:4
-    { //indent:4 exp:4
-        /** //indent:8 exp:8
-         * {@inheritDoc} //indent:9 exp:9
-         */ //indent:9 exp:9
-        public boolean areEqual( final Object first, final Object second ) { //indent:8 exp:8
-            return first == second; //indent:12 exp:12
-        } //indent:8 exp:8
+    /**                                                                           //indent:4 exp:4
+     * An equivalence tester that decides based on {@code ==}.                    //indent:5 exp:5
+     */                                                                           //indent:5 exp:5
+    OBJECT_IDENTITIES                                                             //indent:4 exp:4
+    {                                                                             //indent:4 exp:4
+        /**                                                                       //indent:8 exp:8
+         * {@inheritDoc}                                                          //indent:9 exp:9
+         */                                                                       //indent:9 exp:9
+        public boolean areEqual( final Object first, final Object second ) {      //indent:8 exp:8
+            return first == second;                                               //indent:12 exp:12
+        }                                                                         //indent:8 exp:8
 
-        /** //indent:8 exp:8
-         * {@inheritDoc} //indent:9 exp:9
-         */ //indent:9 exp:9
-        public int hashCode( final Object target ) { //indent:8 exp:8
-            return System.identityHashCode( target ); //indent:12 exp:12
-        } //indent:8 exp:8
-    }; //indent:4 exp:4
+        /**                                                                       //indent:8 exp:8
+         * {@inheritDoc}                                                          //indent:9 exp:9
+         */                                                                       //indent:9 exp:9
+        public int hashCode( final Object target ) {                              //indent:8 exp:8
+            return System.identityHashCode( target );                             //indent:12 exp:12
+        }                                                                         //indent:8 exp:8
+    };                                                                            //indent:4 exp:4
 
-    /** //indent:4 exp:4
-     * Tells whether the two given objects are considered equivalent. //indent:5 exp:5
-     * //indent:5 exp:5
-     * @param first first comparand //indent:5 exp:5
-     * @param second second comparand //indent:5 exp:5
+    /**                                                                           //indent:4 exp:4
+     * Tells whether the two given objects are considered equivalent.             //indent:5 exp:5
+     *                                                                            //indent:5 exp:5
+     * @param first first comparand                                               //indent:5 exp:5
+     * @param second second comparand                                             //indent:5 exp:5
      * @return whether {@code first} and {@code second} are considered equivalent //indent:5 exp:5
-     */ //indent:5 exp:5
-    public abstract boolean areEqual( Object first, Object second ); //indent:4 exp:4
+     */                                                                           //indent:5 exp:5
+    public abstract boolean areEqual( Object first, Object second );              //indent:4 exp:4
 
-    /** //indent:4 exp:4
-     * Computes a hash code for the given object. //indent:5 exp:5
-     * //indent:5 exp:5
-     * @param target object to compute a hash for //indent:5 exp:5
-     * @return the computed hash //indent:5 exp:5
-     */ //indent:5 exp:5
-    public abstract int hashCode( Object target ); //indent:4 exp:4
-} //indent:0 exp:0
+    /**                                                                           //indent:4 exp:4
+     * Computes a hash code for the given object.                                 //indent:5 exp:5
+     *                                                                            //indent:5 exp:5
+     * @param target object to compute a hash for                                 //indent:5 exp:5
+     * @return the computed hash                                                  //indent:5 exp:5
+     */                                                                           //indent:5 exp:5
+    public abstract int hashCode( Object target );                                //indent:4 exp:4
+}                                                                                 //indent:0 exp:0
 
-class AnonymousClassWithInitializer { //indent:0 exp:0
-    void create() { //indent:4 exp:4
-        new Object() { //indent:8 exp:8
-            { //indent:12 exp:12
-                new Object(); //indent:16 exp:16
-            } //indent:12 exp:12
-        }; //indent:8 exp:8
-    } //indent:4 exp:4
-} //indent:0 exp:0
+class AnonymousClassWithInitializer {                                             //indent:0 exp:0
+    void create() {                                                               //indent:4 exp:4
+        new Object() {                                                            //indent:8 exp:8
+            {                                                                     //indent:12 exp:12
+                new Object();                                                     //indent:16 exp:16
+            }                                                                     //indent:12 exp:12
+        };                                                                        //indent:8 exp:8
+    }                                                                             //indent:4 exp:4
+}                                                                                 //indent:0 exp:0
 
-class OneLineCode { //indent:0 exp:0
-    void block() { //indent:4 exp:4
-        { if (true) return; }  //indent:8 exp:8
-    } //indent:4 exp:4
-    void lambda() { //indent:4 exp:4
-        Stream.of(false).map(x -> { if (x) return 0; else return 1; }); //indent:8 exp:8
-    } //indent:4 exp:4
-    void tryCatchDoWhile(Closeable is) throws Exception { //indent:4 exp:4
-        if (is != null) { try { is.close(); } catch (Exception e) {} } //indent:8 exp:8
-        if (is != null) { do { is.close(); } while (is != null); } //indent:8 exp:8
-    } //indent:4 exp:4
-} //indent:0 exp:0
+class OneLineCode {                                                               //indent:0 exp:0
+    void block() {                                                                //indent:4 exp:4
+        { if (true) return; }                                                     //indent:8 exp:8
+    }                                                                             //indent:4 exp:4
+    void lambda() {                                                               //indent:4 exp:4
+        Stream.of(false).map(x -> { if (x) return 0; else return 1; });           //indent:8 exp:8
+    }                                                                             //indent:4 exp:4
+    void tryCatchDoWhile(Closeable is) throws Exception {                         //indent:4 exp:4
+        if (is != null) { try { is.close(); } catch (Exception e) {} }            //indent:8 exp:8
+        if (is != null) { do { is.close(); } while (is != null); }                //indent:8 exp:8
+    }                                                                             //indent:4 exp:4
+}                                                                                 //indent:0 exp:0
 


### PR DESCRIPTION
Part of Issue #17128

- Ignored import lines during alignment checking (as per [comment](https://github.com/checkstyle/checkstyle/pull/17409#issuecomment-3146724011)).
- Fixed alignment in two input files:
  - [`InputIndentationLineWrappedRecordDeclaration.java`](src/test/resources/com/puppycrawl/tools/checkstyle/checks/indentation/indentation/InputIndentationLineWrappedRecordDeclaration.java)
  - [`InputIndentationValidBlockIndent1.java`](src/test/resources/com/puppycrawl/tools/checkstyle/checks/indentation/indentation/InputIndentationValidBlockIndent1.java)
