### PR TITLE
Issue #17642: enable javadoc warning but disable missing

### DIFF
--- a/config/jsoref-spellchecker/whitelist.words
+++ b/config/jsoref-spellchecker/whitelist.words
@@ -330,6 +330,7 @@ Dnew
 doccheck
 Dockter
 doclet
+doclint
 doctype
 documentationcomments
 donotignoreexceptions

--- a/pom.xml
+++ b/pom.xml
@@ -553,8 +553,8 @@
             <source>${java.version}</source>
             <show>private</show>
             <failOnError>true</failOnError>
-            <!-- disabled till https://github.com/checkstyle/checkstyle/issues/17642 -->
-            <failOnWarnings>false</failOnWarnings>
+            <failOnWarnings>true</failOnWarnings>
+            <doclint>-missing</doclint>
             <linksource>true</linksource>
             <tags>
               <tag>


### PR DESCRIPTION
fixes #17642

based on https://stackoverflow.com/a/71785465
https://maven.apache.org/plugins/maven-javadoc-plugin/javadoc-mojo.html#doclint
https://docs.oracle.com/en/java/javase/17/docs/specs/man/javadoc.html#additional-options-provided-by-the-standard-doclet

>missing: Checks for missing documentation comments or tags (for example, a missing comment or class, or a missing `@return` tag or similar tag on a method).


it is not ideal fix, but we enable warning and disable specific validations, we disabling a bit more than required, but it is limitation of javadoc tool
