### PR TITLE
Issue #17487: Add `errorprone.refasterrules`

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -221,7 +221,6 @@
     <checkstyle.openrewrite.version>1.0.0-SNAPSHOT</checkstyle.openrewrite.version>
     <rewrite-migrate-java.version>3.16.0</rewrite-migrate-java.version>
     <rewrite-static-analysis.version>2.16.0</rewrite-static-analysis.version>
-    <rewrite-third-party.version>0.26.0</rewrite-third-party.version>
     <java.version>17</java.version>
     <next.java.version>21</next.java.version>
     <maven.compiler.release>${java.version}</maven.compiler.release>
@@ -5333,9 +5332,23 @@
               <skipMavenParsing>true</skipMavenParsing>
               <activeRecipes>
                 <recipe>org.checkstyle.CheckstyleAutoFix</recipe>
+                <recipe>org.openrewrite.java.RemoveUnusedImports</recipe>
+                <recipe>org.openrewrite.java.format.RemoveTrailingWhitespace</recipe>
                 <recipe>org.openrewrite.java.migrate.Java8toJava11</recipe>
                 <recipe>org.openrewrite.staticanalysis.EqualsAvoidsNull</recipe>
+                <recipe>org.openrewrite.staticanalysis.LowercasePackage</recipe>
+                <recipe>org.openrewrite.staticanalysis.MissingOverrideAnnotation</recipe>
+                <recipe>org.openrewrite.staticanalysis.ModifierOrder</recipe>
+                <recipe>org.openrewrite.staticanalysis.NoFinalizer</recipe>
+                <recipe>org.openrewrite.staticanalysis.RemoveUnusedLocalVariables</recipe>
+                <recipe>org.openrewrite.staticanalysis.RemoveUnusedPrivateFields</recipe>
+                <recipe>org.openrewrite.staticanalysis.RemoveUnusedPrivateMethods</recipe>
+                <recipe>tech.picnic.errorprone.refasterrules.BigDecimalRulesRecipes</recipe>
+                <recipe>tech.picnic.errorprone.refasterrules.CharSequenceRulesRecipes</recipe>
+                <recipe>tech.picnic.errorprone.refasterrules.ClassRulesRecipes</recipe>
+                <recipe>tech.picnic.errorprone.refasterrules.MicrometerRulesRecipes</recipe>
                 <recipe>tech.picnic.errorprone.refasterrules.StreamRulesRecipes</recipe>
+                <recipe>tech.picnic.errorprone.refasterrules.TimeRulesRecipes</recipe>
               </activeRecipes>
               <exclusions>
                 <exclusion>**.ci-temp**</exclusion>


### PR DESCRIPTION
Fixes: #16543
Fixes: #17487


- https://docs.openrewrite.org/changelog/8-51-0-Release

[tech.picnic.errorprone.refasterrules.StreamRulesRecipes$StreamMapFirstRecipe](https://docs.openrewrite.org/recipes/tech/picnic/errorprone/refasterrules/streamrulesrecipesusdstreammapfirstrecipe): Where possible, clarify that a mapping operation will be applied only to a single stream element.

```
[WARNING] Changes have been made to src/main/java/com/puppycrawl/tools/checkstyle/site/ModuleJavadocParsingUtil.java by:
[WARNING]     tech.picnic.errorprone.refasterrules.StreamRulesRecipes
[WARNING]         tech.picnic.errorprone.refasterrules.StreamRulesRecipes$StreamMapFirstRecipe
```