### PR TITLE
Issue #14631: Updated SLASH to new AST format

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/api/JavadocTokenTypes.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/api/JavadocTokenTypes.java
@@ -1033,7 +1033,28 @@ public final class JavadocTokenTypes {
     public static final int START = JavadocParser.START;
 
     /**
-     * Slash html tag component: {@code '/'}.
+     * Slash html tag component.
+     *
+     * <p><b>Example:</b></p>
+    * <pre>
+     * <p>Paragraph Tag.</p>
+     * </pre>
+     *
+     * <p><b>Tree:</b></p>
+     * <pre>
+     * HTML_ELEMENT -> HTML_ELEMENT
+     *  |--HTML_TAG -> HTML_TAG
+     *  |   |--HTML_ELEMENT_START -> HTML_ELEMENT_START
+     *  |   |   |--START -> <
+     *  |   |   |--HTML_TAG_NAME -> p
+     *  |   |   `--END -> >
+     *  |   |--TEXT -> Paragraph Tag.
+     *  |   `--HTML_ELEMENT_END -> HTML_ELEMENT_END
+     *  |       |--START -> <
+     *  |       |--SLASH -> /
+     *  |       |--HTML_TAG_NAME -> p
+     *  |       `--END -> >
+     * </pre>
      */
     public static final int SLASH = JavadocParser.SLASH;
 
@@ -1042,7 +1063,7 @@ public final class JavadocTokenTypes {
      */
     public static final int END = JavadocParser.END;
 
-    /**
+     /**
      * Slash close html tag component: {@code '/>'}.
      */
     public static final int SLASH_END = JavadocParser.SLASH_END;


### PR DESCRIPTION
**Test.java**
```
/**
 * <p>Paragraph Tag.</p>
 */
public class Test {
}
```

**Command**
```
java -jar checkstyle-11.0.1-all.jar -j Test.java | sed "s/\[[0-9]\+:[0-9]\+\]//g"

**AST**
```
     JAVADOC -> JAVADOC
     |--TEXT -> /**
     |--NEWLINE -> \r\n
     |--LEADING_ASTERISK ->  *
     |--TEXT ->
     |--HTML_ELEMENT -> HTML_ELEMENT
     |   `--PARAGRAPH -> PARAGRAPH
     |       |--P_TAG_START -> P_TAG_START
     |       |   |--START -> <
     |       |   |--P_HTML_TAG_NAME -> p
     |       |   `--END -> >
     |       |--TEXT -> Paragraph Tag.
     |       `--P_TAG_END -> P_TAG_END
     |           |--START -> <
     |           |--SLASH -> /
     |           |--P_HTML_TAG_NAME -> p
     |           `--END -> >
     |--NEWLINE -> \r\n
     |--LEADING_ASTERISK ->  *
     |--TEXT -> /
     |--NEWLINE -> \r\n
     |--TEXT -> public class Test {
     |--NEWLINE -> \r\n
     |--TEXT -> }
     |--NEWLINE -> \r\n
     `--EOF -> <EOF>
```
