### PR TITLE
minor: Improving javadoc for Token VARIABLE_DEF

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/api/TokenTypes.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/api/TokenTypes.java
@@ -314,6 +314,7 @@ public final class TokenTypes {
      * @see #OBJBLOCK
      **/
     public static final int METHOD_DEF = JavaLanguageLexer.METHOD_DEF;
+
     /**
      * A field or local variable declaration.  The children are
      * modifiers, type, the identifier name, and an optional
@@ -330,7 +331,7 @@ public final class TokenTypes {
      *  |--MODIFIERS -&gt; MODIFIERS
      *  |   `--FINAL -&gt; final
      *  |--TYPE -&gt; TYPE
-     *  |   `--LITERAL_DOUBLE -&gt; int
+     *  |   `--LITERAL_DOUBLE -&gt; double
      *  |--IDENT -&gt; PI
      *  |--ASSIGN -&gt; =
      *  |   `--EXPR -&gt; EXPR


### PR DESCRIPTION
```
public class Test {
    final double PI = 3.14;
}
```

```
PS C:\Users\athar\OneDrive\Desktop\test> java -jar checkstyle-11.0.1-all.jar -t Test.java
COMPILATION_UNIT -> COMPILATION_UNIT [1:0]
`--CLASS_DEF -> CLASS_DEF [1:0]
    |--MODIFIERS -> MODIFIERS [1:0]
    |   `--LITERAL_PUBLIC -> public [1:0]
    |--LITERAL_CLASS -> class [1:7]
    |--IDENT -> Test [1:13]
    `--OBJBLOCK -> OBJBLOCK [1:18]
        |--LCURLY -> { [1:18]
        |--VARIABLE_DEF -> VARIABLE_DEF [2:4]
        |   |--MODIFIERS -> MODIFIERS [2:4]
        |   |   `--FINAL -> final [2:4]
        |   |--TYPE -> TYPE [2:10]
        |   |   `--LITERAL_DOUBLE -> double [2:10]
        |   |--IDENT -> PI [2:17]
        |   |--ASSIGN -> = [2:20]
        |   |   `--EXPR -> EXPR [2:22]
        |   |       `--NUM_FLOAT -> 3.14 [2:22]
        |   `--SEMI -> ; [2:26]
        `--RCURLY -> } [3:0]
```