### PR TITLE
Issue #17778: Added JavadocLeadingAsteriskAlign Check in google_checks.xml for Rule: 7.1.1 General Form

### DIFF
--- a/config/google-java-format/excluded/compilable-input-paths.txt
+++ b/config/google-java-format/excluded/compilable-input-paths.txt
@@ -81,6 +81,8 @@ src/it/resources/com/google/checkstyle/test/chapter7javadoc/rule711generalform/I
 src/it/resources/com/google/checkstyle/test/chapter7javadoc/rule711generalform/InputJavadocPositionOnCompactConstructorsWithAnnotation.java
 src/it/resources/com/google/checkstyle/test/chapter7javadoc/rule711generalform/InputJavadocPositionOnConstructorInRecord.java
 src/it/resources/com/google/checkstyle/test/chapter7javadoc/rule711generalform/InputRecordClassJavadocPosition.java
+src/it/resources/com/google/checkstyle/test/chapter7javadoc/rule711generalform/InputCorrectJavadocLeadingAsteriskAlignment.java
+src/it/resources/com/google/checkstyle/test/chapter7javadoc/rule711generalform/InputIncorrectJavadocLeadingAsteriskAlignment.java
 src/it/resources/com/google/checkstyle/test/chapter7javadoc/rule712paragraphs/InputIncorrectRequireEmptyLineBeforeBlockTagGroup.java
 src/it/resources/com/google/checkstyle/test/chapter7javadoc/rule712paragraphs/InputIncorrectJavadocParagraph.java
 src/it/resources/com/google/checkstyle/test/chapter7javadoc/rule713atclauses/InputJavaDocTagContinuationIndentation.java

--- a/src/it/java/com/google/checkstyle/test/chapter7javadoc/rule711generalform/GeneralFormTest.java
+++ b/src/it/java/com/google/checkstyle/test/chapter7javadoc/rule711generalform/GeneralFormTest.java
@@ -85,4 +85,25 @@ public class GeneralFormTest extends AbstractGoogleModuleTestSupport {
     public void testFormattedRecordClassJavadocPosition() throws Exception {
         verifyWithWholeConfig(getPath("InputFormattedRecordClassJavadocPosition.java"));
     }
+
+    @Test
+    public void testCorrectJavadocLeadingAsteriskAlignment() throws Exception {
+        verifyWithWholeConfig(getPath("InputCorrectJavadocLeadingAsteriskAlignment.java"));
+    }
+
+    @Test
+    public void testFormattedCorrectJavadocLeadingAsteriskAlignment() throws Exception {
+        verifyWithWholeConfig(getPath("InputFormattedCorrectJavadocLeadingAsteriskAlignment.java"));
+    }
+
+    @Test
+    public void testIncorrectJavadocLeadingAsteriskAlignment() throws Exception {
+        verifyWithWholeConfig(getPath("InputIncorrectJavadocLeadingAsteriskAlignment.java"));
+    }
+
+    @Test
+    public void testFormattedIncorrectJavadocLeadingAsteriskAlignment() throws Exception {
+        verifyWithWholeConfig(
+                    getPath("InputFormattedIncorrectJavadocLeadingAsteriskAlignment.java"));
+    }
 }

--- a/src/it/resources/com/google/checkstyle/test/chapter7javadoc/rule711generalform/InputCorrectJavadocLeadingAsteriskAlignment.java
+++ b/src/it/resources/com/google/checkstyle/test/chapter7javadoc/rule711generalform/InputCorrectJavadocLeadingAsteriskAlignment.java
@@ -1,0 +1,98 @@
+package com.google.checkstyle.test.chapter7javadoc.rule711generalform;
+
+/**
+ * This file contains violations, still it is named "Correct"
+ * because it doesn't contain any violations regarding
+ * Javadoc's Leading Asterisk Alignments.
+ * Other violations are kept to ensure that we cover all the edge cases.
+ */
+public class InputCorrectJavadocLeadingAsteriskAlignment {
+
+  /** javadoc for instance variable. */
+  private int int1;
+
+  /** */ // violation "Summary javadoc is missing."
+  private int int2;
+
+  /***/ // violation "Summary javadoc is missing."
+  private String str;
+
+  /** */ // violation "Summary javadoc is missing."
+  private String str1;
+
+  /**
+    No leading asterisk present. False negative until #17778, Subproblem 2.
+   */
+  public InputCorrectJavadocLeadingAsteriskAlignment() {}
+
+  // violation 2 lines below "Summary javadoc is missing."
+  // violation 2 lines below "Javadoc tag '@param' should be preceded with an empty line."
+  /***
+   * @param a testing....
+   */
+  public InputCorrectJavadocLeadingAsteriskAlignment(int a) {}
+
+  /*************************************************
+   *** @param str testing.....
+   **********************************/
+  // False negative for above javadoc, until #17778, Subproblem 1 & 3.
+  public InputCorrectJavadocLeadingAsteriskAlignment(String str) {}
+
+  /** * */ // violation "Summary javadoc is missing."
+  private String str2;
+
+  /****/ // violation "Summary javadoc is missing."
+  private String str3;
+
+  /**
+   * This method does nothing.
+   */
+  private void foo() {}
+
+  /** Opening tag should be alone on line. // False negative until #17778, Subproblem 1.
+   * This method does nothing.
+   */
+  private void foo2() {}
+
+  /**
+   * Javadoc for foo3.
+   Closing tag should be alone on line. */ // False negative until #17778, Subproblem 3.
+  private void foo3() {
+    // foo2 code goes here
+  }
+
+  /**
+   * Javadoc for enum.
+   * */ // False negative until #17778, Subproblem 3.
+  private enum CorrectJavadocEnum {
+    // violation 2 lines below "Summary javadoc is missing."
+    // False negative until #17778, Subproblem 2.
+    /**
+
+     */
+    ONE,
+
+    // False negative until #17778, Subproblem 2.
+    /**
+     Not allowed. No leading asterisk present.
+     */
+    TWO,
+
+    // False negative until #17778, Subproblem 1 & 2.
+    /** Not allowed. Opening javadoc tag should be alone on line.
+
+     */
+    THREE,
+
+    // False negative until #17778, Subproblem 3.
+    /**
+     * Not allowed. Closing javadoc tag should be alone on line. */
+    FOUR,
+
+    // violation below "Summary javadoc is missing."
+    /**
+
+     */
+    FIVE
+  }
+}

--- a/src/it/resources/com/google/checkstyle/test/chapter7javadoc/rule711generalform/InputFormattedCorrectJavadocLeadingAsteriskAlignment.java
+++ b/src/it/resources/com/google/checkstyle/test/chapter7javadoc/rule711generalform/InputFormattedCorrectJavadocLeadingAsteriskAlignment.java
@@ -1,0 +1,88 @@
+package com.google.checkstyle.test.chapter7javadoc.rule711generalform;
+
+/**
+ * This file contains violations, still it is named "Correct" because it doesn't contain any
+ * violations regarding Javadoc's Leading Asterisk Alignments. Other violations are kept to ensure
+ * that we cover all the edge cases.
+ */
+public class InputFormattedCorrectJavadocLeadingAsteriskAlignment {
+
+  /** javadoc for instance variable. */
+  private int int1;
+
+  /** */
+  // violation above "Summary javadoc is missing."
+  private int int2;
+
+  /***/
+  // violation above "Summary javadoc is missing."
+  private String str;
+
+  /** */
+  // violation above "Summary javadoc is missing."
+  private String str1;
+
+  /** No leading asterisk present. False negative until #17778, Subproblem 2. */
+  public InputFormattedCorrectJavadocLeadingAsteriskAlignment() {}
+
+  // violation 2 lines below "Summary javadoc is missing."
+  // violation 2 lines below "Javadoc tag '@param' should be preceded with an empty line."
+  /***
+   * @param a testing....
+   */
+  public InputFormattedCorrectJavadocLeadingAsteriskAlignment(int a) {}
+
+  /*************************************************
+   *** @param str testing.....
+   **********************************/
+  // False negative for above javadoc, until #17778, Subproblem 1 & 3.
+  public InputFormattedCorrectJavadocLeadingAsteriskAlignment(String str) {}
+
+  /** * */
+  // violation above "Summary javadoc is missing."
+  private String str2;
+
+  /****/
+  // violation above "Summary javadoc is missing."
+  private String str3;
+
+  /** This method does nothing. */
+  private void foo() {}
+
+  /**
+   * Opening tag should be alone on line. // False negative until #17778, Subproblem 1. This method
+   * does nothing.
+   */
+  private void foo2() {}
+
+  /** Javadoc for foo3. Closing tag should be alone on line. */
+  // False negative until #17778, Subproblem 3.
+  private void foo3() {
+    // foo2 code goes here
+  }
+
+  /** Javadoc for enum. */
+  // False negative until #17778, Subproblem 3.
+  private enum CorrectJavadocEnum {
+    // violation 2 lines below "Summary javadoc is missing."
+    // False negative until #17778, Subproblem 2.
+    /** */
+    ONE,
+
+    // False negative until #17778, Subproblem 2.
+    /** Not allowed. No leading asterisk present. */
+    TWO,
+
+    // False negative until #17778, Subproblem 1 & 2.
+    /** Not allowed. Opening javadoc tag should be alone on line. */
+    THREE,
+
+    // False negative until #17778, Subproblem 3.
+    /** Not allowed. Closing javadoc tag should be alone on line. */
+    FOUR,
+
+    // violation below "Summary javadoc is missing."
+    /** */
+    FIVE
+  }
+}

--- a/src/it/resources/com/google/checkstyle/test/chapter7javadoc/rule711generalform/InputFormattedIncorrectJavadocLeadingAsteriskAlignment.java
+++ b/src/it/resources/com/google/checkstyle/test/chapter7javadoc/rule711generalform/InputFormattedIncorrectJavadocLeadingAsteriskAlignment.java
@@ -1,0 +1,54 @@
+package com.google.checkstyle.test.chapter7javadoc.rule711generalform;
+
+/** Extra violations are kept in this file to cover edge cases. */
+public class InputFormattedIncorrectJavadocLeadingAsteriskAlignment {
+  /** Javadoc for instance variable. */
+  private int age;
+
+  /** Misaligned leading asterisk. */
+  private String name;
+
+  /** Javadoc for foo. */
+  public void foo() {}
+
+  // violation below "Summary javadoc is missing."
+  /** */
+  public void foo2() {}
+
+  /** Misaligned leading asterisk. */
+  public void foo3() {}
+
+  /** Misaligned leading asterisk. */
+  public void foo4() {}
+
+  /** Default Constructor. */
+  public InputFormattedIncorrectJavadocLeadingAsteriskAlignment() {}
+
+  /** Parameterized Constructor. */
+  public InputFormattedIncorrectJavadocLeadingAsteriskAlignment(String a) {}
+
+  /** Misaligned leading asterisk. Inner Class. */
+  private static class Inner {
+    // No leading asterisk present. False-negative until #17778, Subproblem 2
+    // violation below "Summary javadoc is missing."
+    /** */
+    private Object obj;
+
+    // violation below "Summary javadoc is missing."
+    /**
+     * @param testing Testing......
+     */
+    void foo(String testing) {}
+  }
+
+  private enum IncorrectJavadocEnum {
+
+    // violation below "Summary javadoc is missing."
+    /** */
+    ONE,
+
+    // Closing tag should be alone on line. False negative until #17778, subproblem 3
+    /** Wrong Alignment. */
+    TWO
+  }
+}

--- a/src/it/resources/com/google/checkstyle/test/chapter7javadoc/rule711generalform/InputIncorrectJavadocLeadingAsteriskAlignment.java
+++ b/src/it/resources/com/google/checkstyle/test/chapter7javadoc/rule711generalform/InputIncorrectJavadocLeadingAsteriskAlignment.java
@@ -1,0 +1,95 @@
+package com.google.checkstyle.test.chapter7javadoc.rule711generalform;
+
+/**
+* Extra violations are kept in this file to cover edge cases.
+ */
+// violation 2 lines above 'Leading asterisk has .* indentation .* 1, expected is 2.'
+public class InputIncorrectJavadocLeadingAsteriskAlignment {
+  /**
+    * Javadoc for instance variable.
+   */
+  // violation 2 lines above 'Leading asterisk has .* indentation .* 5, expected is 4.'
+  private int age;
+
+  /**
+  *  Misaligned leading asterisk.
+   */
+  // violation 2 lines above 'Leading asterisk has .* indentation .* 3, expected is 4.'
+  private String name;
+
+  /**
+   * Javadoc for foo.
+    */
+  // violation above 'Leading asterisk has .* indentation .* 5, expected is 4.'
+  public void foo() {}
+
+  // violation below "Summary javadoc is missing."
+  /**
+  */
+  // violation above 'Leading asterisk has .* indentation .* 3, expected is 4.'
+  public void foo2() {}
+
+  // violation 2 lines below 'Leading asterisk has .* indentation .* 7, expected is 4.'
+  /**
+      * Misaligned leading asterisk.
+   */
+  public void foo3() {}
+
+  // violation 2 lines below 'Leading asterisk has .* indentation .* 1, expected is 4.'
+  /**
+*   Misaligned leading asterisk.
+   */
+  public void foo4() {}
+
+  /**
+   * Default Constructor.
+      */
+  // violation above 'Leading asterisk has .* indentation .* 7, expected is 4.'
+  public InputIncorrectJavadocLeadingAsteriskAlignment() {}
+
+  /**
+   * Parameterized Constructor.
+*/
+  // violation above 'Leading asterisk has .* indentation .* 1, expected is 4.'
+  public InputIncorrectJavadocLeadingAsteriskAlignment(String a) {}
+
+  // violation 2 lines below 'Leading asterisk has .* indentation .* 7, expected is 4.'
+  /**
+      * Misaligned leading asterisk.
+    * Inner Class. */
+  // violation above 'Leading asterisk has .* indentation .* 5, expected is 4.'
+  private static class Inner {
+    // No leading asterisk present. False-negative until #17778, Subproblem 2
+    // violation below "Summary javadoc is missing."
+    /**
+
+        */
+    // violation above 'Leading asterisk has .* indentation .* 9, expected is 6.'
+    private Object obj;
+
+    // violation below "Summary javadoc is missing."
+    /**
+     * @param testing
+       *         Testing......
+     *
+     */
+    // violation 3 lines above 'Leading asterisk has .* indentation .* 8, expected is 6.'
+    void foo(String testing) {}
+  }
+
+  private enum IncorrectJavadocEnum {
+
+    // violation below "Summary javadoc is missing."
+    /**
+   */
+    // violation above 'Leading asterisk has .* indentation .* 4, expected is 6.'
+    ONE,
+
+
+    // Closing tag should be alone on line. False negative until #17778, subproblem 3
+    /**
+      * Wrong Alignment. */
+    // violation above 'Leading asterisk has .* indentation .* 7, expected is 6'
+    TWO
+  }
+}

--- a/src/it/resources/com/google/checkstyle/test/chapter7javadoc/rule734nonrequiredjavadoc/InputInvalidJavadocPositionRecord.java
+++ b/src/it/resources/com/google/checkstyle/test/chapter7javadoc/rule734nonrequiredjavadoc/InputInvalidJavadocPositionRecord.java
@@ -62,10 +62,10 @@ public record InputInvalidJavadocPositionRecord(String containerPath, String... 
 // violation below 'Javadoc comment is placed in the wrong location.'
 /** invalid comment. */
 /**
-* The configuration.
-*
-* @param text the text
-*/
+ * The configuration.
+ *
+ * @param text the text
+ */
 record MyRecord(String text) {
   // violation above 'Top-level class MyRecord has to reside in its own source file'
 

--- a/src/main/resources/google_checks.xml
+++ b/src/main/resources/google_checks.xml
@@ -195,6 +195,7 @@
     <module name="OneStatementPerLine"/>
     <module name="MultipleVariableDeclarations"/>
     <module name="ArrayTypeStyle"/>
+    <module name="JavadocLeadingAsteriskAlign"/>
     <module name="MissingSwitchDefault"/>
     <module name="FallThrough"/>
     <module name="UpperEll"/>

--- a/src/site/xdoc/checks/javadoc/javadocleadingasteriskalign.xml
+++ b/src/site/xdoc/checks/javadoc/javadocleadingasteriskalign.xml
@@ -202,6 +202,10 @@ public class Example3 {
             <a href="https://github.com/search?q=path%3Aconfig%20path%3A**%2Fcheckstyle-checks.xml+repo%3Acheckstyle%2Fcheckstyle+JavadocLeadingAsteriskAlign">
             Checkstyle Style</a>
           </li>
+          <li>
+            <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources%20path%3A**%2Fgoogle_checks.xml+repo%3Acheckstyle%2Fcheckstyle+JavadocLeadingAsteriskAlign">
+            Google Style</a>
+          </li>
         </ul>
       </subsection>
 

--- a/src/site/xdoc/checks/javadoc/javadocleadingasteriskalign.xml.template
+++ b/src/site/xdoc/checks/javadoc/javadocleadingasteriskalign.xml.template
@@ -74,6 +74,10 @@
             <a href="https://github.com/search?q=path%3Aconfig%20path%3A**%2Fcheckstyle-checks.xml+repo%3Acheckstyle%2Fcheckstyle+JavadocLeadingAsteriskAlign">
             Checkstyle Style</a>
           </li>
+          <li>
+            <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources%20path%3A**%2Fgoogle_checks.xml+repo%3Acheckstyle%2Fcheckstyle+JavadocLeadingAsteriskAlign">
+            Google Style</a>
+          </li>
         </ul>
       </subsection>
 

--- a/src/site/xdoc/google_style.xml
+++ b/src/site/xdoc/google_style.xml
@@ -2355,6 +2355,17 @@
                   <br />
                   <span class="wrapper inline">
                     <img
+                            src="images/ok_green.png"
+                            alt="" />
+                  </span>
+                  <a href="checks/javadoc/javadocleadingasteriskalign.html#JavadocLeadingAsteriskAlign">
+                    JavadocLeadingAsteriskAlign</a>
+                  (<a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources%20path%3A**%2Fgoogle_checks.xml+repo%3Acheckstyle%2Fcheckstyle+JavadocLeadingAsteriskAlign">
+                  config</a>)
+                  <br />
+                  <br />
+                  <span class="wrapper inline">
+                    <img
                             src="images/ok_blue.png"
                             alt="" />
                   </span>


### PR DESCRIPTION
Issue: #17778 

Added [JavadocLeadingAsteriskAlign](https://checkstyle.org/checks/javadoc/javadocleadingasteriskalign.html#JavadocLeadingAsteriskAlign) in google_checks.xml to ensure javadoc's leading asterisks alignment based on rule [7.1.1 General Form](https://google.github.io/styleguide/javaguide.html#s7.1.1-javadoc-multi-line).


The input files are directly copied from Check's input files:  https://github.com/checkstyle/checkstyle/tree/master/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadocleadingasteriskalign

I didn't copied the [InputJavadocLeadingAsteriskAlignTabs.java](https://github.com/checkstyle/checkstyle/blob/master/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadocleadingasteriskalign/InputJavadocLeadingAsteriskAlignTabs.java) because style guide doesn't allow using tabs:

https://google.github.io/styleguide/javaguide.html#s2.3.1-whitespace-characters
> Tab characters are not used for indentation.

That whole file would give violation for every line where tabs are used. 

---

The newly added input file contains extra violations which are not related to leading asterisks' alignment. I kept those violations to cover edge cases.

---

Diff Regression config: https://gist.githubusercontent.com/Zopsss/102e6cfcaa8df9de7c8def2b9bd9b963/raw/beb28c4bf1aef7078ba87afe83a7b777e5b96a58/leadingasterisk-google-checks-master.xml
Diff Regression patch config: https://gist.githubusercontent.com/Zopsss/6b69d3014a087bb057f2361bdc5501d6/raw/d95a5f601bb1b849852374df1485128debcef23a/leadingasterisk-google-checks-pr.xml
Diff Regression projects: https://gist.githubusercontent.com/mohitsatr/68b0817ac52ff7773d35585ee12fc1cc/raw/f9c7774ca78df1f48f34bf30799bd3952abd9e2a/list-of-projects.properties