### PR TITLE
Issue #14631: Updated area_html_tag_name in JavadocTokenTypes.java to new AST format

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/api/JavadocTokenTypes.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/api/JavadocTokenTypes.java
@@ -1853,17 +1853,18 @@ public final class JavadocTokenTypes {
      *
      * <p><b>Tree:</b></p>
      * <pre>{@code
-     * --HTML_ELEMENT -> HTML_ELEMENT
-     *    `--SINGLETON_ELEMENT -> SINGLETON_ELEMENT
-     *        `--BASE_TAG -> BASE_TAG
-     *            |--START -> <
-     *            |--BASE_HTML_TAG_NAME -> base
-     *            |--WS ->
-     *            |--ATTRIBUTE -> ATTRIBUTE
-     *            |   |--HTML_TAG_NAME -> href
-     *            |   |--EQUALS -> =
-     *            |   `--ATTR_VALUE -> "https://example.com/"
-     *            `--END -> >
+     * --HTML_ELEMENT -&gt; HTML_ELEMENT
+     *    `--SINGLETON_ELEMENT -&gt; SINGLETON_ELEMENT
+     *        `--BASE_TAG -&gt; BASE_TAG
+     *            |--START -&gt; &lt;
+     *            |--BASE_HTML_TAG_NAME -&gt; base
+     *            |--WS -&gt;
+     *            |--ATTRIBUTE -&gt; ATTRIBUTE
+     *            |   |--HTML_TAG_NAME -&gt; href
+     *            |   |--EQUALS -&gt; =
+     *            |   `--ATTR_VALUE -&gt; "https://example.com/"
+     *            `--END -&gt; &gt;
+
      * }
      * </pre>
      */


### PR DESCRIPTION
Issue: #14631

**Command used**
java -jar checkstyle-11.0.1-all.jar -J Test.java | sed "s/\[[0-9]\+:[0-9]\+\]//g"

**Test.java**
...

/**
 * <base href="https://example.com/">
*/
public class Test{
}
...

...
Windows@Windows MINGW64 ~/area_html_tag_name (master)
$ java -jar checkstyle-11.0.1-all.jar -J Test.java | sed "s/\[[0-9]\+:[0-9]\+\]//g"
COMPILATION_UNIT -> COMPILATION_UNIT
`--CLASS_DEF -> CLASS_DEF
    |--MODIFIERS -> MODIFIERS
    |   |--BLOCK_COMMENT_BEGIN -> /*
    |   |   |--COMMENT_CONTENT -> *\r\n * <base href="https://example.com/">\r\n
    |   |   |   `--JAVADOC -> JAVADOC
    |   |   |       |--NEWLINE -> \r\n
    |   |   |       |--LEADING_ASTERISK ->  *
    |   |   |       |--TEXT ->
    |   |   |       |--HTML_ELEMENT -> HTML_ELEMENT
    |   |   |       |   `--SINGLETON_ELEMENT -> SINGLETON_ELEMENT
    |   |   |       |       `--BASE_TAG -> BASE_TAG
    |   |   |       |           |--START -> <
    |   |   |       |           |--BASE_HTML_TAG_NAME -> base
    |   |   |       |           |--WS ->
    |   |   |       |           |--ATTRIBUTE -> ATTRIBUTE
    |   |   |       |           |   |--HTML_TAG_NAME -> href
    |   |   |       |           |   |--EQUALS -> =
    |   |   |       |           |   `--ATTR_VALUE -> "https://example.com/"
    |   |   |       |           `--END -> >
    |   |   |       |--NEWLINE -> \r\n
    |   |   |       `--EOF -> <EOF>
    |   |   `--BLOCK_COMMENT_END -> */
    |   `--LITERAL_PUBLIC -> public
    |--LITERAL_CLASS -> class
    |--IDENT -> Test
    `--OBJBLOCK -> OBJBLOCK
        |--LCURLY -> {
        `--RCURLY -> }
...


