### PR TITLE
Updated ARGUMENT in JavadocTokensTypes.java to new AST format.

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/api/JavadocTokenTypes.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/api/JavadocTokenTypes.java
@@ -810,21 +810,21 @@ public final class JavadocTokenTypes {
      * <b>Tree:</b>
      * <pre>
      * {@code
-     * JAVADOC_TAG -> JAVADOC_TAG
-     *  |--SEE_LITERAL -> @see
-     *  |--WS ->
-     *  |--REFERENCE -> REFERENCE
-     *  |   |--HASH -> #
-     *  |   |--MEMBER -> method
-     *  |   `--PARAMETERS -> PARAMETERS
-     *  |       |--LEFT_BRACE -> (
-     *  |       |--ARGUMENT -> Processor
-     *  |       |--COMMA -> ,
-     *  |       |--WS ->
-     *  |       |--ARGUMENT -> String
-     *  |       `--RIGHT_BRACE -> )
-     *  |--NEWLINE -> \r\n
-     *  `--WS ->
+     * JAVADOC_TAG -&gt; JAVADOC_TAG
+     *  |--SEE_LITERAL -&gt; @see
+     *  |--WS -&gt;
+     *  |--REFERENCE -&gt; REFERENCE
+     *  |   |--HASH -&gt; #
+     *  |   |--MEMBER -&gt; method
+     *  |   `--PARAMETERS -&gt; PARAMETERS
+     *  |       |--LEFT_BRACE -&gt; (
+     *  |       |--ARGUMENT -&gt; Processor
+     *  |       |--COMMA -&gt; ,
+     *  |       |--WS -&gt;
+     *  |       |--ARGUMENT -&gt; String
+     *  |       `--RIGHT_BRACE -&gt; )
+     *  |--NEWLINE -&gt; \r\n
+     *  `--WS -&gt;
      * }
      * </pre>
      *


### PR DESCRIPTION
**Command used:**
`java -jar checkstyle-11.0.1-all.jar -J Test.java | sed "s/\[[0-9]\+:[0-9]\+\]//g"`
```

**Test.java**

/**
 * @see #method(Processor, String)
*/
public class Test{
}

```
```
Windows@Windows MINGW64 ~/argument (master)
$ java -jar checkstyle-11.0.1-all.jar -J Test.java | sed "s/\[[0-9]\+:[0-9]\+\]//g"
COMPILATION_UNIT -> COMPILATION_UNIT
`--CLASS_DEF -> CLASS_DEF
    |--MODIFIERS -> MODIFIERS
    |   |--BLOCK_COMMENT_BEGIN -> /*
    |   |   |--COMMENT_CONTENT -> *\r\n * @see #method(Processor, String)\r\n
    |   |   |   `--JAVADOC -> JAVADOC
    |   |   |       |--NEWLINE -> \r\n
    |   |   |       |--LEADING_ASTERISK ->  *
    |   |   |       |--WS ->
    |   |   |       |--JAVADOC_TAG -> JAVADOC_TAG
    |   |   |       |   |--SEE_LITERAL -> @see
    |   |   |       |   |--WS ->
    |   |   |       |   |--REFERENCE -> REFERENCE
    |   |   |       |   |   |--HASH -> #
    |   |   |       |   |   |--MEMBER -> method
    |   |   |       |   |   `--PARAMETERS -> PARAMETERS
    |   |   |       |   |       |--LEFT_BRACE -> (
    |   |   |       |   |       |--ARGUMENT -> Processor
    |   |   |       |   |       |--COMMA -> ,
    |   |   |       |   |       |--WS ->
    |   |   |       |   |       |--ARGUMENT -> String
    |   |   |       |   |       `--RIGHT_BRACE -> )
    |   |   |       |   `--NEWLINE -> \r\n
    |   |   |       `--EOF -> <EOF>
    |   |   `--BLOCK_COMMENT_END -> */
    |   `--LITERAL_PUBLIC -> public
    |--LITERAL_CLASS -> class
    |--IDENT -> Test
    `--OBJBLOCK -> OBJBLOCK
        |--LCURLY -> {
        `--RCURLY -> }

```