### PR TITLE
Fixes #14631  Updates SLASH token documentation to match new AST format.

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/api/JavadocTokenTypes.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/api/JavadocTokenTypes.java
@@ -1033,26 +1033,29 @@ public final class JavadocTokenTypes {
     public static final int START = JavadocParser.START;
 
     /**
-     * Slash html tag component.
+     * Slash character in HTML closing tags.
      *
      * <p><b>Example:</b></p>
-     * <pre>{@code <p>Paragraph Tag.</p>}</pre>
-     *
-     * <p><b>Tree:</b></p>
      * <pre>{@code
-     * --HTML_ELEMENT -> HTML_ELEMENT
+     * <p>Paragraph Tag.</p>
+     * }</pre>
+     * <b>Tree:</b>
+     * <pre>
+     * {@code
+     * HTML_ELEMENT -> HTML_ELEMENT
      *    `--PARAGRAPH -> PARAGRAPH
      *        |--P_TAG_START -> P_TAG_START
-     *        |   |--START -> &lt;
+     *        |   |--START ->
      *        |   |--P_HTML_TAG_NAME -> p
-     *        |   `--END -> &gt;
+     *        |   `--END -> >
      *        |--TEXT -> Paragraph Tag.
      *        `--P_TAG_END -> P_TAG_END
-     *            |--START -> &lt;
+     *            |--START ->
      *            |--SLASH -> /
      *            |--P_HTML_TAG_NAME -> p
-     *            `--END -> &gt;
-     * }</pre>
+     *            `--END -> >
+     * }
+     * </pre>
      */
     public static final int SLASH = JavadocParser.SLASH;
 


### PR DESCRIPTION
Fixes #14631

**Command used:**
`java -jar checkstyle-11.0.1-all.jar -J Test.java | sed "s/\[[0-9]\+:[0-9]\+\]//g"`

**Test.java**
```
/**
 * <p>Paragraph Tag.</p>
 */
public class Test {
}
```
```

Windows@Windows MINGW64 ~/ASt (master)
$ java -jar checkstyle-11.0.1-all.jar -J Test.java | sed "s/\[[0-9]\+:[0-9]\+\]//g"
COMPILATION_UNIT -> COMPILATION_UNIT
`--CLASS_DEF -> CLASS_DEF
    |--MODIFIERS -> MODIFIERS
    |   |--BLOCK_COMMENT_BEGIN -> /*
    |   |   |--COMMENT_CONTENT -> *\r\n * <p>Paragraph Tag.</p>\r\n
    |   |   |   `--JAVADOC -> JAVADOC
    |   |   |       |--NEWLINE -> \r\n
    |   |   |       |--LEADING_ASTERISK ->  *
    |   |   |       |--TEXT ->
    |   |   |       |--HTML_ELEMENT -> HTML_ELEMENT
    |   |   |       |   `--PARAGRAPH -> PARAGRAPH
    |   |   |       |       |--P_TAG_START -> P_TAG_START
    |   |   |       |       |   |--START -> <
    |   |   |       |       |   |--P_HTML_TAG_NAME -> p
    |   |   |       |       |   `--END -> >
    |   |   |       |       |--TEXT -> Paragraph Tag.
    |   |   |       |       `--P_TAG_END -> P_TAG_END
    |   |   |       |           |--START -> <
    |   |   |       |           |--SLASH -> /
    |   |   |       |           |--P_HTML_TAG_NAME -> p
    |   |   |       |           `--END -> >
    |   |   |       |--NEWLINE -> \r\n
    |   |   |       |--TEXT ->
    |   |   |       `--EOF -> <EOF>
    |   |   `--BLOCK_COMMENT_END -> */
    |   `--LITERAL_PUBLIC -> public
    |--LITERAL_CLASS -> class
    |--IDENT -> Test
    `--OBJBLOCK -> OBJBLOCK
        |--LCURLY -> {
        `--RCURLY -> }


```