### PR TITLE
Issue #17834: Fix DTD in suppressions.xml example

### DIFF
--- a/src/site/xdoc/cmdline.xml.vm
+++ b/src/site/xdoc/cmdline.xml.vm
@@ -1057,7 +1057,7 @@ class Test {
 
 &lt;!DOCTYPE suppressions PUBLIC
     "-//Checkstyle//DTD Checkstyle Configuration 1.2//EN"
-    "https://checkstyle.org/dtds/configuration_1_3.dtd"&gt;
+    "https://checkstyle.org/dtds/suppressions_1_2.dtd""&gt;
 
 &lt;suppressions&gt;
   &lt;suppress


### PR DESCRIPTION
Fixes #17834

**Updated**
```
&lt;!DOCTYPE suppressions PUBLIC
    "-//Checkstyle//DTD Checkstyle Configuration 1.2//EN"
    "https://checkstyle.org/dtds/suppressions_1_2.dtd"&gt;

```
