### PR TITLE
Issue #17449: Add XDoc examples for MethodNameCheck properties

### DIFF
--- a/src/test/java/com/puppycrawl/tools/checkstyle/internal/XdocsExampleFileTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/internal/XdocsExampleFileTest.java
@@ -54,7 +54,6 @@ public class XdocsExampleFileTest {
             Map.entry("MissingJavadocMethodCheck", Set.of("minLineCount")),
             Map.entry("TrailingCommentCheck", Set.of("legalComment")),
             Map.entry("IllegalTypeCheck", Set.of("legalAbstractClassNames")),
-            Map.entry("MethodNameCheck", Set.of("applyToPackage", "applyToPrivate")),
             Map.entry("MissingJavadocTypeCheck", Set.of("skipAnnotations")),
             Map.entry("JavadocStyleCheck", Set.of("endOfSentenceFormat", "checkEmptyJavadoc")),
             Map.entry("ConstantNameCheck", Set.of("applyToPackage", "applyToPrivate")),

--- a/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/naming/methodname/Example6.java
+++ b/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/naming/methodname/Example6.java
@@ -1,0 +1,21 @@
+/*xml
+<module name="Checker">
+  <module name="TreeWalker">
+    <module name="MethodName">
+       <property name="format" value="^[a-z](_?[a-zA-Z0-9]+)*$"/>
+       <property name="applyToPrivate" value="false"/>
+    </module>
+  </module>
+</module>
+*/
+
+package com.puppycrawl.tools.checkstyle.checks.naming.methodname;
+
+// xdoc section -- start
+class Example6 {
+  public void Method1() {} // violation 'Name 'Method1' must match pattern'
+  protected void Method2() {} // violation 'Name 'Method2' must match pattern'
+  private void Method3() {} // OK, private methods ignored
+  void Method4() {} // violation 'Name 'Method4' must match pattern'
+}
+// xdoc section -- end

--- a/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/naming/methodname/Example7.java
+++ b/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/naming/methodname/Example7.java
@@ -1,0 +1,21 @@
+/*xml
+<module name="Checker">
+  <module name="TreeWalker">
+    <module name="MethodName">
+       <property name="format" value="^[a-z](_?[a-zA-Z0-9]+)*$"/>
+       <property name="applyToPackage" value="false"/>
+    </module>
+  </module>
+</module>
+*/
+
+package com.puppycrawl.tools.checkstyle.checks.naming.methodname;
+
+// xdoc section -- start
+class Example7 {
+  public void Method1() {} // violation 'Name 'Method1' must match pattern'
+  protected void Method2() {} // violation 'Name 'Method2' must match pattern'
+  private void Method3() {} // violation 'Name 'Method3' must match pattern'
+  void Method4() {} // OK, package-private methods ignored
+}
+// xdoc section -- end


### PR DESCRIPTION
#17449 
```
Added missing XDoc examples for MethodNameCheck:
applyToPrivate (Example 6)
applyToPackage (Example 7)
```