### PR TITLE
Issue #17449: Added examples for typename  properties

### DIFF
--- a/src/site/xdoc/checks/naming/typename.xml
+++ b/src/site/xdoc/checks/naming/typename.xml
@@ -163,8 +163,32 @@ class Example3 {
   public interface I_firstName {}
   interface SecondName {} // violation 'Name 'SecondName' must match pattern'
 }
+</code></pre></div><hr class="example-separator"/>
+        <p id="Example4-config">
+          An example of how to configure the check for names that begin with a lower case letter,
+          followed by letters, digits, and underscores. Also, suppress the check from being
+          applied to public and package-private type:
+        </p>
+        <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
+&lt;module name="Checker"&gt;
+  &lt;module name="TreeWalker"&gt;
+    &lt;module name="TypeName"&gt;
+      &lt;property name="format" value="^[a-z](_?[a-zA-Z0-9]+)*$"/&gt;
+      &lt;property name="applyToPublic" value="false"/&gt;
+      &lt;property name="applyToPackage" value="false"/&gt;
+    &lt;/module&gt;
+  &lt;/module&gt;
+&lt;/module&gt;
 </code></pre></div>
-
+        <p id="Example4-code">Code Example:</p>
+        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+class Example4 {
+  public interface FirstName {}
+  public class SecondName {}
+  protected class ThirdName {}   // violation 'Name 'ThirdName' must match pattern'
+  private class FourthName {}   // violation 'Name 'FourthName' must match pattern'
+}
+</code></pre></div>
       </subsection>
 
       <subsection name="Example of Usage" id="TypeName_Example_of_Usage">

--- a/src/site/xdoc/checks/naming/typename.xml.template
+++ b/src/site/xdoc/checks/naming/typename.xml.template
@@ -71,8 +71,23 @@
           <param name="path"
                  value="resources/com/puppycrawl/tools/checkstyle/checks/naming/typename/Example3.java"/>
           <param name="type" value="code"/>
+         </macro><hr class="example-separator"/>
+        <p id="Example4-config">
+          An example of how to configure the check for names that begin with a lower case letter,
+          followed by letters, digits, and underscores. Also, suppress the check from being
+          applied to public and package-private type:
+        </p>
+        <macro name="example">
+          <param name="path"
+                 value="resources/com/puppycrawl/tools/checkstyle/checks/naming/typename/Example4.java"/>
+          <param name="type" value="config"/>
         </macro>
-
+        <p id="Example4-code">Code Example:</p>
+        <macro name="example">
+          <param name="path"
+                 value="resources/com/puppycrawl/tools/checkstyle/checks/naming/typename/Example4.java"/>
+          <param name="type" value="code"/>
+        </macro>
       </subsection>
 
       <subsection name="Example of Usage" id="TypeName_Example_of_Usage">

--- a/src/test/java/com/puppycrawl/tools/checkstyle/internal/XdocsExampleFileTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/internal/XdocsExampleFileTest.java
@@ -75,7 +75,6 @@ public class XdocsExampleFileTest {
                     "violateImpliedStaticOnNestedRecord",
                     "violateImpliedStaticOnNestedInterface"
             )),
-            Map.entry("TypeNameCheck", Set.of("applyToPublic", "applyToPackage")),
             Map.entry("DescendantTokenCheck", Set.of("minimumMessage")),
             Map.entry("InterfaceMemberImpliedModifierCheck", Set.of(
                     "violateImpliedFinalField",

--- a/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/checks/naming/TypeNameCheckExamplesTest.java
+++ b/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/checks/naming/TypeNameCheckExamplesTest.java
@@ -60,4 +60,17 @@ public class TypeNameCheckExamplesTest extends AbstractExamplesModuleTestSupport
 
         verifyWithInlineConfigParser(getPath("Example3.java"), expected);
     }
+
+    @Test
+    public void testExample4() throws Exception {
+        final String[] expected = {
+            "19:19: " + getCheckMessage(MSG_INVALID_PATTERN,
+                    "ThirdName", "^[a-z](_?[a-zA-Z0-9]+)*$"),
+            "20:17: " + getCheckMessage(MSG_INVALID_PATTERN,
+                    "FourthName", "^[a-z](_?[a-zA-Z0-9]+)*$"),
+        };
+
+        verifyWithInlineConfigParser(getPath("Example4.java"), expected);
+    }
+
 }

--- a/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/naming/typename/Example4.java
+++ b/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/naming/typename/Example4.java
@@ -1,0 +1,22 @@
+/*xml
+<module name="Checker">
+  <module name="TreeWalker">
+    <module name="TypeName">
+      <property name="format" value="^[a-z](_?[a-zA-Z0-9]+)*$"/>
+      <property name="applyToPublic" value="false"/>
+      <property name="applyToPackage" value="false"/>
+    </module>
+  </module>
+</module>
+*/
+
+package com.puppycrawl.tools.checkstyle.checks.naming.typename;
+
+// xdoc section -- start
+class Example4 {
+  public interface FirstName {}
+  public class SecondName {}
+  protected class ThirdName {}   // violation 'Name 'ThirdName' must match pattern'
+  private class FourthName {}   // violation 'Name 'FourthName' must match pattern'
+}
+// xdoc section -- end


### PR DESCRIPTION
#17449 
Added Example4 for TypeNameCheck demonstrating applyToPublic and applyToPackage properties to suppress validation for public and package-private types.