### PR TITLE
Issue #17701: update Cirrus CI configuration to streamline JDK setup and improve environment variable handling

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -26,7 +26,7 @@ task:
     - name: Cirrus - JDK21
       env:
         TEMURIN_VERSION: "21.0.6.7"
-        TEMURIN_PATH: 'Eclipse Adoptium\jdk-21'
+        TEMURIN_PATH: 'Eclipse Adoptium\jdk-%TEMURIN_VERSION%'
   env:
     # disable ANSI output for picocli (may affect tests)
     NO_COLOR: "1"


### PR DESCRIPTION
Testing PR https://github.com/checkstyle/checkstyle/pull/17851

Reference: PR #17702

Issue #17701 

Fixed Windows CI/CD build failure caused by incorrect Java environment setup in ```.cirrus.yml.```

Root Cause:
The CI script was using call set to configure ```JAVA_HOME``` and ```PATH```, which only scoped variables to the current script. This prevented Java from being available in later build steps, leading to:

```'java'``` is not recognized as an internal or external command