### PR TITLE
Issue #17845: Resolved part of error-prone violations

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -275,6 +275,8 @@
       -Xep:StaticImport:OFF
       <!-- no ability to declare noinspection tags as valid tags -->
       -Xep:InvalidBlockTag:OFF
+      <!-- We prefer UnnecessaryParenthesesCheck over error-prone's OperatorPrecedence -->
+      -Xep:OperatorPrecedence:OFF
     </error-prone.configuration-args>
   </properties>
 

--- a/src/test/java/com/puppycrawl/tools/checkstyle/AbstractAutomaticBeanTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/AbstractAutomaticBeanTest.java
@@ -345,7 +345,7 @@ public class AbstractAutomaticBeanTest {
             }
         }
 
-        public int getRegisterCount() {
+        private int getRegisterCount() {
             return registerCount;
         }
 

--- a/src/test/java/com/puppycrawl/tools/checkstyle/AbstractGuiTestSupport.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/AbstractGuiTestSupport.java
@@ -25,11 +25,14 @@ import java.awt.Component;
 import java.awt.Container;
 import java.awt.GraphicsEnvironment;
 
+import javax.swing.JComboBox;
+
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.extension.ExtendWith;
 
 import com.github.caciocavallosilano.cacio.ctc.junit.CacioExtension;
 import com.github.caciocavallosilano.cacio.ctc.junit.CacioTest;
+import com.puppycrawl.tools.checkstyle.gui.MainFrameModel;
 
 /**
  * Abstract base class for testing GUI components.
@@ -55,12 +58,12 @@ public abstract class AbstractGuiTestSupport extends AbstractPathTestSupport {
      *
      * @param root the root component to start search
      * @param name the name of component to find
+     * @param clazz the subtype of component
      * @param <T> the type of component to find
      * @return the component if found, {@code null} otherwise
-     * @noinspection unchecked
-     * @noinspectionreason unchecked - we know that any component is OK to typecast to T
      */
-    protected static <T extends Component> T findComponentByName(Component root, String name) {
+    protected static <T extends Component> T findComponentByName(Component root, String name,
+                                                                 Class<T> clazz) {
         Component result = null;
         if (name.equals(root.getName())) {
             result = root;
@@ -68,12 +71,26 @@ public abstract class AbstractGuiTestSupport extends AbstractPathTestSupport {
         else if (root instanceof Container container) {
             final Component[] children = container.getComponents();
             for (Component component : children) {
-                result = findComponentByName(component, name);
+                result = findComponentByName(component, name, clazz);
                 if (result != null) {
                     break;
                 }
             }
         }
-        return (T) result;
+        return clazz.cast(result);
+    }
+
+    /**
+     * Helper method to find a component by its name.
+     *
+     * @param root the root component to start search
+     * @param name the name of component to find
+     * @return the component if found, {@code null} otherwise
+     * @noinspection unchecked
+     * @noinspectionreason unchecked - unchecked cast is ok on test code
+     */
+    protected static JComboBox<MainFrameModel.ParseMode> findComponentComboBoxByName(
+            Component root, String name) {
+        return findComponentByName(root, name, JComboBox.class);
     }
 }

--- a/src/test/java/com/puppycrawl/tools/checkstyle/AbstractModuleTestSupport.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/AbstractModuleTestSupport.java
@@ -643,13 +643,12 @@ public abstract class AbstractModuleTestSupport extends AbstractPathTestSupport 
      */
     protected final void verifyWithLimitedResources(String fileName, String... expected)
             throws Exception {
-        // We return null here, which gives us a result to make an assertion about
-        final Void result = TestUtil.getResultWithLimitedResources(() -> {
+        TestUtil.getResultWithLimitedResources(() -> {
             verifyWithInlineConfigParser(fileName, expected);
             return null;
         });
         assertWithMessage("Verify should complete successfully.")
-                .that(result)
+                .that((Object) null)
                 .isNull();
     }
 

--- a/src/test/java/com/puppycrawl/tools/checkstyle/CheckerTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/CheckerTest.java
@@ -387,7 +387,8 @@ public class CheckerTest extends AbstractModuleTestSupport {
 
         // comparing to 1 as there is only one legal file in input
         final int numLegalFiles = 1;
-        final PropertyCacheFile cache = TestUtil.getInternalState(checker, "cacheFile");
+        final PropertyCacheFile cache = TestUtil.getInternalState(checker,
+                "cacheFile", PropertyCacheFile.class);
         assertWithMessage("There were more legal files than expected")
             .that(counter)
             .isEqualTo(numLegalFiles);
@@ -492,7 +493,7 @@ public class CheckerTest extends AbstractModuleTestSupport {
 
         checker.setModuleClassLoader(classLoader);
         checker.finishLocalSetup();
-        final Context actualCtx = TestUtil.getInternalState(checker, "childContext");
+        final Context actualCtx = TestUtil.getInternalState(checker, "childContext", Context.class);
 
         assertWithMessage("Default module factory should be created when it is not specified")
             .that(actualCtx.get("moduleFactory"))
@@ -512,7 +513,7 @@ public class CheckerTest extends AbstractModuleTestSupport {
         checker.setLocaleCountry("IT");
         checker.finishLocalSetup();
 
-        final Context context = TestUtil.getInternalState(checker, "childContext");
+        final Context context = TestUtil.getInternalState(checker, "childContext", Context.class);
         final String encoding = StandardCharsets.UTF_8.name();
         assertWithMessage("Charset was different than expected")
             .that(context.get("charset"))
@@ -580,7 +581,8 @@ public class CheckerTest extends AbstractModuleTestSupport {
             DebugAuditAdapter.class.getCanonicalName());
         checker.setupChild(config);
 
-        final List<AuditListener> listeners = TestUtil.getInternalState(checker, "listeners");
+        final List<AuditListener> listeners = TestUtil.getInternalStateListAuditListener(checker,
+                "listeners");
         assertWithMessage("Invalid child listener class")
                 .that(listeners.get(listeners.size() - 1) instanceof DebugAuditAdapter)
                 .isTrue();
@@ -761,7 +763,8 @@ public class CheckerTest extends AbstractModuleTestSupport {
         checker.process(Collections.singletonList(new File("dummy.java")));
         checker.clearCache();
         // invoke destroy to persist cache
-        final PropertyCacheFile cache = TestUtil.getInternalState(checker, "cacheFile");
+        final PropertyCacheFile cache = TestUtil.getInternalState(checker,
+                "cacheFile", PropertyCacheFile.class);
         cache.persist();
 
         final Properties cacheAfterClear = new Properties();
@@ -778,7 +781,8 @@ public class CheckerTest extends AbstractModuleTestSupport {
     public void setFileExtension() {
         final Checker checker = new Checker();
         checker.setFileExtensions(".test1", "test2");
-        final String[] actual = TestUtil.getInternalState(checker, "fileExtensions");
+        final String[] actual = TestUtil.getInternalState(checker,
+                "fileExtensions", String[].class);
         assertWithMessage("Extensions are not expected")
             .that(actual)
             .isEqualTo(new String[] {".test1", ".test2"});
@@ -790,7 +794,8 @@ public class CheckerTest extends AbstractModuleTestSupport {
         // the invocation of clearCache method does not throw an exception.
         final Checker checker = new Checker();
         checker.clearCache();
-        final PropertyCacheFile cache = TestUtil.getInternalState(checker, "cacheFile");
+        final PropertyCacheFile cache = TestUtil.getInternalState(checker,
+                "cacheFile", PropertyCacheFile.class);
         assertWithMessage("If cache file is not set the cache should default to null")
             .that(cache)
             .isNull();
@@ -1607,7 +1612,8 @@ public class CheckerTest extends AbstractModuleTestSupport {
         checker.configure(root);
         // BriefUtLogger does not print the module name or id postfix,
         // so we need to set logger manually
-        final ByteArrayOutputStream out = TestUtil.getInternalState(this, "stream");
+        final ByteArrayOutputStream out = TestUtil.getInternalState(this,
+                "stream", ByteArrayOutputStream.class);
         final DefaultLogger logger = new DefaultLogger(out, OutputStreamOptions.CLOSE, out,
                 OutputStreamOptions.NONE, new AuditEventDefaultFormatter());
         checker.addListener(logger);

--- a/src/test/java/com/puppycrawl/tools/checkstyle/DefaultLoggerTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/DefaultLoggerTest.java
@@ -148,7 +148,7 @@ public class DefaultLoggerTest extends AbstractModuleTestSupport {
         final OutputStream infoStream = new ByteArrayOutputStream();
         final DefaultLogger dl = new DefaultLogger(infoStream,
                 AutomaticBean.OutputStreamOptions.CLOSE);
-        final boolean closeInfo = TestUtil.getInternalState(dl, "closeInfo");
+        final boolean closeInfo = TestUtil.getInternalState(dl, "closeInfo", Boolean.class);
 
         assertWithMessage("closeInfo should be true")
                 .that(closeInfo)
@@ -165,7 +165,7 @@ public class DefaultLoggerTest extends AbstractModuleTestSupport {
         final OutputStream infoStream = new ByteArrayOutputStream();
         final DefaultLogger dl = new DefaultLogger(infoStream,
                 AutomaticBean.OutputStreamOptions.NONE);
-        final boolean closeInfo = TestUtil.getInternalState(dl, "closeInfo");
+        final boolean closeInfo = TestUtil.getInternalState(dl, "closeInfo", Boolean.class);
 
         assertWithMessage("closeInfo should be false")
                 .that(closeInfo)

--- a/src/test/java/com/puppycrawl/tools/checkstyle/DetailAstImplTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/DetailAstImplTest.java
@@ -439,7 +439,8 @@ public class DetailAstImplTest extends AbstractModuleTestSupport {
         for (Consumer<DetailAstImpl> method : clearChildCountCacheMethods) {
             final int startCount = parent.getChildCount();
             method.accept(null);
-            final int intermediateCount = TestUtil.getInternalState(parent, "childCount");
+            final int intermediateCount = TestUtil.getInternalState(parent, "childCount",
+                    Integer.class);
             final int finishCount = parent.getChildCount();
             assertWithMessage("Child count has changed")
                 .that(finishCount)
@@ -451,7 +452,7 @@ public class DetailAstImplTest extends AbstractModuleTestSupport {
 
         final int startCount = child.getChildCount();
         child.addChild(null);
-        final int intermediateCount = TestUtil.getInternalState(child, "childCount");
+        final int intermediateCount = TestUtil.getInternalState(child, "childCount", Integer.class);
         final int finishCount = child.getChildCount();
         assertWithMessage("Child count has changed")
             .that(finishCount)

--- a/src/test/java/com/puppycrawl/tools/checkstyle/PackageObjectFactoryTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/PackageObjectFactoryTest.java
@@ -476,8 +476,8 @@ public class PackageObjectFactoryTest {
                     .thenThrow(new IOException("mock exception"));
 
             final String internalFieldName = "thirdPartyNameToFullModuleNames";
-            final Map<String, String> nullMap = TestUtil.getInternalState(objectFactory,
-                    internalFieldName);
+            final Map<String, String> nullMap =
+                    TestUtil.getInternalStateMap(objectFactory, internalFieldName);
             assertWithMessage("Expected uninitialized field")
                     .that(nullMap)
                     .isNull();
@@ -487,8 +487,8 @@ public class PackageObjectFactoryTest {
                     .that(instance)
                     .isEqualTo("");
 
-            final Map<String, String> emptyMap = TestUtil.getInternalState(objectFactory,
-                    internalFieldName);
+            final Map<String, String> emptyMap =
+                    TestUtil.getInternalStateMap(objectFactory, internalFieldName);
             assertWithMessage("Expected empty map")
                     .that(emptyMap)
                     .isEmpty();

--- a/src/test/java/com/puppycrawl/tools/checkstyle/SarifLoggerTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/SarifLoggerTest.java
@@ -313,7 +313,7 @@ public class SarifLoggerTest extends AbstractModuleTestSupport {
         final OutputStream infoStream = new ByteArrayOutputStream();
         final SarifLogger logger = new SarifLogger(infoStream,
                 AutomaticBean.OutputStreamOptions.CLOSE);
-        final boolean closeStream = TestUtil.getInternalState(logger, "closeStream");
+        final boolean closeStream = TestUtil.getInternalState(logger, "closeStream", Boolean.class);
 
         assertWithMessage("closeStream should be true")
                 .that(closeStream)
@@ -328,7 +328,7 @@ public class SarifLoggerTest extends AbstractModuleTestSupport {
         final OutputStream infoStream = new ByteArrayOutputStream();
         final SarifLogger logger = new SarifLogger(infoStream,
                 AutomaticBean.OutputStreamOptions.NONE);
-        final boolean closeStream = TestUtil.getInternalState(logger, "closeStream");
+        final boolean closeStream = TestUtil.getInternalState(logger, "closeStream", Boolean.class);
 
         assertWithMessage("closeStream should be false")
                 .that(closeStream)

--- a/src/test/java/com/puppycrawl/tools/checkstyle/TreeWalkerTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/TreeWalkerTest.java
@@ -279,11 +279,12 @@ public class TreeWalkerTest extends AbstractModuleTestSupport {
         treeWalker.setTabWidth(1);
         treeWalker.configure(config);
 
-        final int tabWidth = TestUtil.getInternalState(treeWalker, "tabWidth");
+        final int tabWidth = TestUtil.getInternalState(treeWalker, "tabWidth", Integer.class);
         assertWithMessage("Invalid setter result")
             .that(tabWidth)
             .isEqualTo(1);
-        final Object configuration = TestUtil.getInternalState(treeWalker, "configuration");
+        final Object configuration = TestUtil.getInternalState(treeWalker, "configuration",
+                Object.class);
         assertWithMessage("Invalid configuration")
             .that(configuration)
             .isEqualTo(config);
@@ -347,7 +348,8 @@ public class TreeWalkerTest extends AbstractModuleTestSupport {
         final File file = new File(getPath("InputTreeWalkerNotJava.xml"));
         final FileText fileText = new FileText(file, StandardCharsets.ISO_8859_1.name());
         treeWalker.processFiltered(file, fileText);
-        final Collection<Checks> checks = TestUtil.getInternalState(treeWalker, "ordinaryChecks");
+        final Collection<Checks> checks =
+                TestUtil.getInternalStateCollectionChecks(treeWalker, "ordinaryChecks");
         assertWithMessage("No checks -> No parsing")
             .that(checks)
             .isEmpty();
@@ -436,7 +438,8 @@ public class TreeWalkerTest extends AbstractModuleTestSupport {
         final FileText fileText = new FileText(file, new ArrayList<>());
 
         treeWalker.processFiltered(file, fileText);
-        final Collection<Checks> checks = TestUtil.getInternalState(treeWalker, "ordinaryChecks");
+        final Collection<Checks> checks =
+                TestUtil.getInternalStateCollectionChecks(treeWalker, "ordinaryChecks");
         assertWithMessage("No checks -> No parsing")
             .that(checks)
             .isEmpty();
@@ -484,8 +487,10 @@ public class TreeWalkerTest extends AbstractModuleTestSupport {
 
         treeWalker.setupChild(config);
 
-        final Set<TreeWalkerFilter> filters = TestUtil.getInternalState(treeWalker, "filters");
-        final int tabWidth = TestUtil.getInternalState(filters.iterator().next(), "tabWidth");
+        final Set<TreeWalkerFilter> filters =
+                TestUtil.getInternalStateSetTreeWalkerFilter(treeWalker, "filters");
+        final int tabWidth = TestUtil.getInternalState(filters.iterator().next(),
+                "tabWidth", Integer.class);
 
         assertWithMessage("expected tab width")
             .that(tabWidth)
@@ -542,7 +547,8 @@ public class TreeWalkerTest extends AbstractModuleTestSupport {
         treeWalker.setTabWidth(100);
         treeWalker.finishLocalSetup();
 
-        final Context context = TestUtil.getInternalState(treeWalker, "childContext");
+        final Context context = TestUtil.getInternalState(treeWalker, "childContext",
+                Context.class);
         assertWithMessage("Severity differs from expected")
             .that(context.get("severity"))
             .isEqualTo("error");

--- a/src/test/java/com/puppycrawl/tools/checkstyle/XMLLoggerTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/XMLLoggerTest.java
@@ -409,7 +409,7 @@ public class XMLLoggerTest extends AbstractXmlTestSupport {
     @Test
     public void testCtorWithTwoParametersCloseStreamOptions() {
         final XMLLogger logger = new XMLLogger(outStream, AutomaticBean.OutputStreamOptions.CLOSE);
-        final boolean closeStream = TestUtil.getInternalState(logger, "closeStream");
+        final boolean closeStream = TestUtil.getInternalState(logger, "closeStream", Boolean.class);
 
         assertWithMessage("closeStream should be true")
                 .that(closeStream)
@@ -422,7 +422,7 @@ public class XMLLoggerTest extends AbstractXmlTestSupport {
     @Test
     public void testCtorWithTwoParametersNoneStreamOptions() {
         final XMLLogger logger = new XMLLogger(outStream, AutomaticBean.OutputStreamOptions.NONE);
-        final boolean closeStream = TestUtil.getInternalState(logger, "closeStream");
+        final boolean closeStream = TestUtil.getInternalState(logger, "closeStream", Boolean.class);
 
         assertWithMessage("closeStream should be false")
                 .that(closeStream)

--- a/src/test/java/com/puppycrawl/tools/checkstyle/XmlLoaderTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/XmlLoaderTest.java
@@ -38,7 +38,7 @@ public class XmlLoaderTest {
     @Test
     public void testParserConfiguredSuccessfully() throws Exception {
         final DummyLoader dummyLoader = new DummyLoader(new HashMap<>(1));
-        final XMLReader parser = TestUtil.getInternalState(dummyLoader, "parser");
+        final XMLReader parser = TestUtil.getInternalState(dummyLoader, "parser", XMLReader.class);
         assertWithMessage("Invalid entity resolver")
             .that(parser.getEntityResolver())
             .isEqualTo(dummyLoader);

--- a/src/test/java/com/puppycrawl/tools/checkstyle/api/FileContentsTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/api/FileContentsTest.java
@@ -321,8 +321,8 @@ public class FileContentsTest {
     public void testHasIntersectionEarlyOut() throws Exception {
         final FileContents fileContents = new FileContents(
                 new FileText(new File("filename"), Collections.emptyList()));
-        final Map<Integer, List<TextBlock>> clangComments = TestUtil.getInternalState(fileContents,
-                "clangComments");
+        final Map<Integer, List<TextBlock>> clangComments = TestUtil.getInternalStateMapIntegerList(
+                fileContents, "clangComments");
         final TextBlock textBlock = new Comment(new String[] {""}, 1, 1, 1);
         clangComments.put(1, Collections.singletonList(textBlock));
         clangComments.put(2, Collections.emptyList());

--- a/src/test/java/com/puppycrawl/tools/checkstyle/api/FileTextTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/api/FileTextTest.java
@@ -96,7 +96,7 @@ public class FileTextTest extends AbstractPathTestSupport {
         final LineColumn lineColumn = fileText.lineColumn(100);
         final FileText copy = new FileText(fileText);
         assertWithMessage("LineBreaks not copied")
-                .that(TestUtil.<int[]>getInternalState(copy, "lineBreaks"))
+                .that(TestUtil.getInternalState(copy, "lineBreaks", int[].class))
                 .isNotNull();
         final LineColumn actual = copy.lineColumn(100);
         assertWithMessage("Invalid linecolumn")
@@ -111,7 +111,7 @@ public class FileTextTest extends AbstractPathTestSupport {
         final FileText fileText = new FileText(new File(filepath), charset.name());
         final FileText copy = new FileText(fileText);
         assertWithMessage("LineBreaks not null")
-                .that(TestUtil.<int[]>getInternalState(copy, "lineBreaks"))
+                .that(TestUtil.getInternalState(copy, "lineBreaks", int[].class))
                 .isNull();
         final LineColumn lineColumn = copy.lineColumn(100);
         assertWithMessage("Invalid line")

--- a/src/test/java/com/puppycrawl/tools/checkstyle/bdd/TestInputViolation.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/bdd/TestInputViolation.java
@@ -86,6 +86,7 @@ public record TestInputViolation(int lineNo, String message)
 
     @Override
     public boolean equals(Object object) {
-        return getClass() == object.getClass() && compareTo((TestInputViolation) object) == 0;
+        return object instanceof TestInputViolation violation
+            && compareTo(violation) == 0;
     }
 }

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/AvoidEscapedUnicodeCharactersCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/AvoidEscapedUnicodeCharactersCheckTest.java
@@ -509,8 +509,9 @@ public class AvoidEscapedUnicodeCharactersCheckTest extends AbstractModuleTestSu
      */
     @Test
     public void testNonPrintableCharsAreSorted() {
-        String expression = TestUtil.<Pattern>getInternalStaticState(
-                AvoidEscapedUnicodeCharactersCheck.class, "NON_PRINTABLE_CHARS").pattern();
+        String expression = TestUtil.getInternalStaticState(
+                AvoidEscapedUnicodeCharactersCheck.class,
+                "NON_PRINTABLE_CHARS", Pattern.class).pattern();
 
         // Replacing expressions like "\\u000[bB]" with "\\u000B"
         final String[] charExpressions = {"Aa", "Bb", "Cc", "Dd", "Ee", "Ff"};

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/SuppressWarningsHolderTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/SuppressWarningsHolderTest.java
@@ -66,7 +66,7 @@ public class SuppressWarningsHolderTest extends AbstractModuleTestSupport {
 
         new SuppressWarningsHolder().beginTree(null);
 
-        final Map<String, String> map = TestUtil.getInternalStaticState(
+        final Map<String, String> map = TestUtil.getInternalStaticStateMap(
                 SuppressWarningsHolder.class, "CHECK_ALIAS_MAP");
         map.clear();
     }
@@ -450,7 +450,8 @@ public class SuppressWarningsHolderTest extends AbstractModuleTestSupport {
                 firstColumn, lastLine, lastColumn);
 
         final ThreadLocal<List<Object>> entries = TestUtil
-                .getInternalStaticState(SuppressWarningsHolder.class, "ENTRIES");
+                .getInternalStaticStateThreadLocal(SuppressWarningsHolder.class,
+                        "ENTRIES");
         entries.get().add(entryInstance);
     }
 

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/coding/HiddenFieldCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/coding/HiddenFieldCheckTest.java
@@ -545,9 +545,9 @@ public class HiddenFieldCheckTest
 
             // verify object is cleared
             if (result
-                    && (TestUtil.getInternalState(frame, "parent") != null
-                        || !TestUtil.<Boolean>getInternalState(frame, "staticType")
-                        || TestUtil.getInternalState(frame, "frameName") != null)) {
+                    && (TestUtil.getInternalState(frame, "parent", Boolean.class) != null
+                        || !TestUtil.<Boolean>getInternalState(frame, "staticType", Boolean.class)
+                        || TestUtil.getInternalState(frame, "frameName", Boolean.class) != null)) {
                 result = false;
             }
 

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/coding/IllegalTokenTextCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/coding/IllegalTokenTextCheckTest.java
@@ -150,7 +150,7 @@ public class IllegalTokenTextCheckTest
         final IllegalTokenTextCheck check = new IllegalTokenTextCheck();
         check.setFormat("test");
         check.setIgnoreCase(true);
-        final Pattern actual = TestUtil.getInternalState(check, "format");
+        final Pattern actual = TestUtil.getInternalState(check, "format", Pattern.class);
         assertWithMessage("should match")
             .that(actual.flags())
             .isEqualTo(Pattern.CASE_INSENSITIVE);

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/coding/UnusedLocalVariableCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/coding/UnusedLocalVariableCheckTest.java
@@ -530,14 +530,14 @@ public class UnusedLocalVariableCheckTest extends AbstractModuleTestSupport {
         };
         assertWithMessage("State is not cleared on beginTree")
                 .that(isClear.test(TestUtil.getInternalState(
-                        check, "anonInnerAstToTypeDeclDesc")))
+                        check, "anonInnerAstToTypeDeclDesc", Object.class)))
                 .isTrue();
         final Predicate<Object> isQueueClear = anonInnerClassHolders -> {
             return ((Collection<?>) anonInnerClassHolders).isEmpty();
         };
         assertWithMessage("State is not cleared on beginTree")
                 .that(isQueueClear.test(TestUtil.getInternalState(
-                        check, "anonInnerClassHolders")))
+                        check, "anonInnerClassHolders", Object.class)))
                 .isTrue();
     }
 

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/header/RegexpHeaderCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/header/RegexpHeaderCheckTest.java
@@ -55,7 +55,8 @@ public class RegexpHeaderCheckTest extends AbstractModuleTestSupport {
         // recreate for each test because multiple invocations fail
         final String header = null;
         instance.setHeader(header);
-        final List<Pattern> headerRegexps = TestUtil.getInternalState(instance, "headerRegexps");
+        final List<Pattern> headerRegexps = TestUtil.getInternalStateListPattern(
+                instance, "headerRegexps");
 
         assertWithMessage("When header is null regexps should not be set")
                 .that(headerRegexps)
@@ -72,7 +73,8 @@ public class RegexpHeaderCheckTest extends AbstractModuleTestSupport {
         // check empty string passes
         final String header = "";
         instance.setHeader(header);
-        final List<Pattern> headerRegexps = TestUtil.getInternalState(instance, "headerRegexps");
+        final List<Pattern> headerRegexps = TestUtil.getInternalStateListPattern(
+                instance, "headerRegexps");
 
         assertWithMessage("When header is empty regexps should not be set")
                 .that(headerRegexps)
@@ -82,13 +84,15 @@ public class RegexpHeaderCheckTest extends AbstractModuleTestSupport {
     /**
      * Test of setHeader method, of class RegexpHeaderCheck.
      */
+
     @Test
     public void testSetHeaderSimple() {
         final RegexpHeaderCheck instance = new RegexpHeaderCheck();
         // check valid header passes
         final String header = "abc.*";
         instance.setHeader(header);
-        final List<Pattern> headerRegexps = TestUtil.getInternalState(instance, "headerRegexps");
+        final List<Pattern> headerRegexps = TestUtil.getInternalStateListPattern(
+                instance, "headerRegexps");
         assertWithMessage("Expected one pattern")
             .that(headerRegexps.size())
             .isEqualTo(1);

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/javadoc/WriteTagCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/javadoc/WriteTagCheckTest.java
@@ -192,7 +192,8 @@ public class WriteTagCheckTest extends AbstractModuleTestSupport {
 
         checker.addFileSetCheck(treeWalker);
 
-        final ByteArrayOutputStream out = TestUtil.getInternalState(this, "stream");
+        final ByteArrayOutputStream out = TestUtil.getInternalState(this, "stream",
+                ByteArrayOutputStream.class);
         final DefaultLogger logger = new DefaultLogger(out,
                 AbstractAutomaticBean.OutputStreamOptions.CLOSE);
         checker.addListener(logger);

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/metrics/NPathComplexityCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/metrics/NPathComplexityCheckTest.java
@@ -177,9 +177,9 @@ public class NPathComplexityCheckTest extends AbstractModuleTestSupport {
                 .that(TestUtil.isStatefulFieldClearedDuringBeginTree(check, question.orElseThrow(),
                         "processingTokenEnd", processingTokenEnd -> {
                             return TestUtil.<Integer>getInternalState(processingTokenEnd,
-                                    "endLineNo") == 0
+                                    "endLineNo", Integer.class) == 0
                                     && TestUtil.<Integer>getInternalState(processingTokenEnd,
-                                            "endColumnNo") == 0;
+                                            "endColumnNo", Integer.class) == 0;
                         }))
                 .isTrue();
     }
@@ -395,7 +395,8 @@ public class NPathComplexityCheckTest extends AbstractModuleTestSupport {
     @Test
     public void testTokenEndIsAfterSameLineColumn() throws Exception {
         final NPathComplexityCheck check = new NPathComplexityCheck();
-        final Object tokenEnd = TestUtil.getInternalState(check, "processingTokenEnd");
+        final Object tokenEnd = TestUtil.getInternalState(check,
+                "processingTokenEnd", Object.class);
         final DetailAstImpl token = new DetailAstImpl();
         token.setLineNo(0);
         token.setColumnNo(0);

--- a/src/test/java/com/puppycrawl/tools/checkstyle/filters/SuppressWithNearbyCommentFilterTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/filters/SuppressWithNearbyCommentFilterTest.java
@@ -777,7 +777,7 @@ public class SuppressWithNearbyCommentFilterTest
         final TreeWalkerAuditEvent dummyEvent = new TreeWalkerAuditEvent(contents, filename,
                 new Violation(1, null, null, null, null, Object.class, null), null);
         filter.accept(dummyEvent);
-        return TestUtil.getInternalState(filter, "tags");
+        return TestUtil.getInternalState(filter, "tags", List.class);
     }
 
 }

--- a/src/test/java/com/puppycrawl/tools/checkstyle/filters/SuppressWithNearbyTextFilterTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/filters/SuppressWithNearbyTextFilterTest.java
@@ -585,7 +585,7 @@ public class SuppressWithNearbyTextFilterTest extends AbstractModuleTestSupport 
                                                          String filename) {
         final AuditEvent dummyEvent = buildDummyAuditEvent(filename);
         filter.accept(dummyEvent);
-        return TestUtil.getInternalState(filter, "suppressions");
+        return TestUtil.getInternalState(filter, "suppressions", List.class);
     }
 
     /**
@@ -599,7 +599,7 @@ public class SuppressWithNearbyTextFilterTest extends AbstractModuleTestSupport 
                                                                   String filename) {
         final AuditEvent dummyEvent = buildDummyAuditEvent(filename);
         filter.accept(dummyEvent);
-        return TestUtil.getInternalState(filter, "cachedFileAbsolutePath");
+        return TestUtil.getInternalState(filter, "cachedFileAbsolutePath", String.class);
     }
 
     /**

--- a/src/test/java/com/puppycrawl/tools/checkstyle/filters/SuppressWithPlainTextCommentFilterTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/filters/SuppressWithPlainTextCommentFilterTest.java
@@ -739,7 +739,7 @@ public class SuppressWithPlainTextCommentFilterTest extends AbstractModuleTestSu
 
     private static List<?> getSuppressionsAfterExecution(
                             SuppressWithPlainTextCommentFilter filter) {
-        return TestUtil.getInternalState(filter, "currentFileSuppressionCache");
+        return TestUtil.getInternalState(filter, "currentFileSuppressionCache", List.class);
     }
 
     private void verifySuppressed(String fileNameWithExtension, String[] violationMessages,

--- a/src/test/java/com/puppycrawl/tools/checkstyle/filters/SuppressionCommentFilterTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/filters/SuppressionCommentFilterTest.java
@@ -655,7 +655,7 @@ public class SuppressionCommentFilterTest
         final TreeWalkerAuditEvent dummyEvent = new TreeWalkerAuditEvent(contents, filename,
                 new Violation(1, null, null, null, null, Object.class, ""), null);
         filter.accept(dummyEvent);
-        return TestUtil.getInternalState(filter, "tags");
+        return TestUtil.getInternalStateListComparable(filter, "tags");
     }
 
     @Test

--- a/src/test/java/com/puppycrawl/tools/checkstyle/filters/SuppressionsLoaderTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/filters/SuppressionsLoaderTest.java
@@ -323,7 +323,7 @@ public class SuppressionsLoaderTest extends AbstractPathTestSupport {
         final SuppressFilterElement suppressElement = (SuppressFilterElement) fc.getFilters()
                 .toArray()[0];
 
-        final String id = TestUtil.getInternalState(suppressElement, "moduleId");
+        final String id = TestUtil.getInternalState(suppressElement, "moduleId", String.class);
         assertWithMessage("Id has to be defined")
             .that(id)
             .isEqualTo("someId");

--- a/src/test/java/com/puppycrawl/tools/checkstyle/gui/MainFrameTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/gui/MainFrameTest.java
@@ -96,7 +96,8 @@ public class MainFrameTest extends AbstractGuiTestSupport {
                         startsWith("FileNotFoundException occurred while opening file"));
             });
         }
-        final MainFrameModel model = TestUtil.getInternalState(mainFrame, "model");
+        final MainFrameModel model = TestUtil.getInternalState(mainFrame,
+                "model", MainFrameModel.class);
         assertWithMessage("Unexpected current file")
                 .that(model.getCurrentFile())
                 .isEqualTo(file);
@@ -105,10 +106,12 @@ public class MainFrameTest extends AbstractGuiTestSupport {
     @Test
     public void testChangeMode() {
         final JComboBox<MainFrameModel.ParseMode> modesCombobox =
-                findComponentByName(mainFrame, "modesCombobox");
+                findComponentComboBoxByName(mainFrame, "modesCombobox");
         modesCombobox.setSelectedIndex(MainFrameModel.ParseMode.JAVA_WITH_COMMENTS.ordinal());
-        final MainFrameModel model = TestUtil.getInternalState(mainFrame, "model");
-        final MainFrameModel.ParseMode parseMode = TestUtil.getInternalState(model, "parseMode");
+        final MainFrameModel model = TestUtil.getInternalState(mainFrame,
+                "model", MainFrameModel.class);
+        final MainFrameModel.ParseMode parseMode = TestUtil.getInternalState(model,
+                "parseMode", MainFrameModel.ParseMode.class);
         assertWithMessage("Unexpected parse mode")
                 .that(parseMode)
                 .isEqualTo(MainFrameModel.ParseMode.JAVA_WITH_COMMENTS);
@@ -122,7 +125,8 @@ public class MainFrameTest extends AbstractGuiTestSupport {
      */
     @Test
     public void testOpenFileButton() throws IOException {
-        final JButton openFileButton = findComponentByName(mainFrame, "openFileButton");
+        final JButton openFileButton = findComponentByName(mainFrame,
+                "openFileButton", JButton.class);
         final File testFile = new File(getPath(TEST_FILE_NAME));
         try (MockedConstruction<JFileChooser> mocked = mockConstruction(
                 JFileChooser.class, (mock, context) -> {
@@ -142,7 +146,8 @@ public class MainFrameTest extends AbstractGuiTestSupport {
      */
     @Test
     public void testFileFilter() {
-        final JButton openFileButton = findComponentByName(mainFrame, "openFileButton");
+        final JButton openFileButton = findComponentByName(mainFrame,
+                "openFileButton", JButton.class);
         try (MockedConstruction<JFileChooser> mocked = mockConstruction(
                 JFileChooser.class, (mock, context) -> {
                     when(mock.showOpenDialog(mainFrame)).thenReturn(JFileChooser.CANCEL_OPTION);
@@ -163,8 +168,10 @@ public class MainFrameTest extends AbstractGuiTestSupport {
 
     @Test
     public void testExpandButton() {
-        final JButton expandButton = findComponentByName(mainFrame, "expandButton");
-        final JTextArea xpathTextArea = findComponentByName(mainFrame, "xpathTextArea");
+        final JButton expandButton = findComponentByName(mainFrame,
+                "expandButton", JButton.class);
+        final JTextArea xpathTextArea = findComponentByName(mainFrame,
+                "xpathTextArea", JTextArea.class);
         expandButton.doClick();
         assertWithMessage("The XPath text area should be visible")
                 .that(xpathTextArea.isVisible())
@@ -178,8 +185,10 @@ public class MainFrameTest extends AbstractGuiTestSupport {
     @Test
     public void testFindNodeButton() throws IOException {
         mainFrame.openFile(new File(getPath(TEST_FILE_NAME)));
-        final JButton findNodeButton = findComponentByName(mainFrame, "findNodeButton");
-        final JTextArea xpathTextArea = findComponentByName(mainFrame, "xpathTextArea");
+        final JButton findNodeButton = findComponentByName(mainFrame,
+                "findNodeButton", JButton.class);
+        final JTextArea xpathTextArea = findComponentByName(mainFrame,
+                "xpathTextArea", JTextArea.class);
         findNodeButton.doClick();
         assertWithMessage("Unexpected XPath text area text")
                 .that(xpathTextArea.getText())

--- a/src/test/java/com/puppycrawl/tools/checkstyle/gui/TreeTableTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/gui/TreeTableTest.java
@@ -114,8 +114,10 @@ public class TreeTableTest extends AbstractGuiTestSupport {
     public void testFindNodesAllClassDefs() throws IOException {
         final MainFrame mainFrame = new MainFrame();
         mainFrame.openFile(new File(getPath("InputTreeTableXpathAreaPanel.java")));
-        final JButton findNodeButton = findComponentByName(mainFrame, "findNodeButton");
-        final JTextArea xpathTextArea = findComponentByName(mainFrame, "xpathTextArea");
+        final JButton findNodeButton = findComponentByName(mainFrame,
+                "findNodeButton", JButton.class);
+        final JTextArea xpathTextArea = findComponentByName(mainFrame,
+                "xpathTextArea", JTextArea.class);
         xpathTextArea.setText("//CLASS_DEF");
         findNodeButton.doClick();
 
@@ -136,8 +138,10 @@ public class TreeTableTest extends AbstractGuiTestSupport {
     public void testFindNodesIdent() throws IOException {
         final MainFrame mainFrame = new MainFrame();
         mainFrame.openFile(new File(getPath("InputTreeTableXpathAreaPanel.java")));
-        final JButton findNodeButton = findComponentByName(mainFrame, "findNodeButton");
-        final JTextArea xpathTextArea = findComponentByName(mainFrame, "xpathTextArea");
+        final JButton findNodeButton = findComponentByName(mainFrame,
+                "findNodeButton", JButton.class);
+        final JTextArea xpathTextArea = findComponentByName(mainFrame,
+                "xpathTextArea", JTextArea.class);
         xpathTextArea.setText("//IDENT");
         findNodeButton.doClick();
 
@@ -172,8 +176,10 @@ public class TreeTableTest extends AbstractGuiTestSupport {
     public void testFindNodesMissingElements() throws IOException {
         final MainFrame mainFrame = new MainFrame();
         mainFrame.openFile(new File(getPath("InputTreeTableXpathAreaPanel.java")));
-        final JButton findNodeButton = findComponentByName(mainFrame, "findNodeButton");
-        final JTextArea xpathTextArea = findComponentByName(mainFrame, "xpathTextArea");
+        final JButton findNodeButton = findComponentByName(mainFrame,
+                "findNodeButton", JButton.class);
+        final JTextArea xpathTextArea = findComponentByName(mainFrame,
+                "xpathTextArea", JTextArea.class);
         xpathTextArea.setText("//LITERAL_TRY");
         findNodeButton.doClick();
 
@@ -188,8 +194,10 @@ public class TreeTableTest extends AbstractGuiTestSupport {
     public void testFindNodesUnexpectedTokenAtStart() throws IOException {
         final MainFrame mainFrame = new MainFrame();
         mainFrame.openFile(new File(getPath("InputTreeTableXpathAreaPanel.java")));
-        final JButton findNodeButton = findComponentByName(mainFrame, "findNodeButton");
-        final JTextArea xpathTextArea = findComponentByName(mainFrame, "xpathTextArea");
+        final JButton findNodeButton = findComponentByName(mainFrame,
+                "findNodeButton", JButton.class);
+        final JTextArea xpathTextArea = findComponentByName(mainFrame,
+                "xpathTextArea", JTextArea.class);
         xpathTextArea.setText("!*7^");
         findNodeButton.doClick();
 
@@ -204,8 +212,10 @@ public class TreeTableTest extends AbstractGuiTestSupport {
     public void testFindNodesInvalidCharacterInExpression() throws IOException {
         final MainFrame mainFrame = new MainFrame();
         mainFrame.openFile(new File(getPath("InputTreeTableXpathAreaPanel.java")));
-        final JButton findNodeButton = findComponentByName(mainFrame, "findNodeButton");
-        final JTextArea xpathTextArea = findComponentByName(mainFrame, "xpathTextArea");
+        final JButton findNodeButton = findComponentByName(mainFrame,
+                "findNodeButton", JButton.class);
+        final JTextArea xpathTextArea = findComponentByName(mainFrame,
+                "xpathTextArea", JTextArea.class);
         xpathTextArea.setText("//CLASS_DEF^");
         findNodeButton.doClick();
 

--- a/src/test/java/com/puppycrawl/tools/checkstyle/internal/utils/TestUtil.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/internal/utils/TestUtil.java
@@ -27,16 +27,21 @@ import java.lang.reflect.Field;
 import java.lang.reflect.Method;
 import java.lang.reflect.Modifier;
 import java.util.Arrays;
+import java.util.Collection;
+import java.util.List;
 import java.util.Locale;
+import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.Callable;
 import java.util.concurrent.FutureTask;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Predicate;
+import java.util.regex.Pattern;
 import java.util.stream.Stream;
 
 import org.junit.jupiter.api.function.Executable;
+import org.mockito.internal.util.Checks;
 
 import com.puppycrawl.tools.checkstyle.AbstractAutomaticBean;
 import com.puppycrawl.tools.checkstyle.PackageNamesLoader;
@@ -44,8 +49,10 @@ import com.puppycrawl.tools.checkstyle.PackageObjectFactory;
 import com.puppycrawl.tools.checkstyle.TreeWalkerAuditEvent;
 import com.puppycrawl.tools.checkstyle.TreeWalkerFilter;
 import com.puppycrawl.tools.checkstyle.api.AbstractCheck;
+import com.puppycrawl.tools.checkstyle.api.AuditListener;
 import com.puppycrawl.tools.checkstyle.api.CheckstyleException;
 import com.puppycrawl.tools.checkstyle.api.DetailAST;
+import com.puppycrawl.tools.checkstyle.api.TextBlock;
 
 public final class TestUtil {
 
@@ -142,7 +149,7 @@ public final class TestUtil {
         check.beginTree(astToVisit);
         check.visitToken(astToVisit);
         check.beginTree(null);
-        return isClear.test(getInternalState(check, fieldName));
+        return isClear.test(getInternalState(check, fieldName, Object.class));
     }
 
     /**
@@ -267,13 +274,11 @@ public final class TestUtil {
      * @param instance the instance to read
      * @param fieldName the name of the field
      * @throws RuntimeException if the field  can't be read
-     * @noinspection unchecked
-     * @noinspectionreason unchecked - unchecked cast is ok on test code
      */
-    public static <T> T getInternalState(Object instance, String fieldName) {
+    public static <T> T getInternalState(Object instance, String fieldName, Class<T> clazz) {
         try {
             final Field field = getClassDeclaredField(instance.getClass(), fieldName);
-            return (T) field.get(instance);
+            return clazz.cast(field.get(instance));
         }
         catch (ReflectiveOperationException exc) {
             final String message = String.format(Locale.ROOT,
@@ -284,19 +289,115 @@ public final class TestUtil {
     }
 
     /**
-     * Reads the value of a static field using reflection. This method will traverse the
-     * super class hierarchy until a field with name {@code fieldName} is found.
+     * Helper method for casting collection type Map.
      *
-     * @param clss the class of the field
+     * @param instance the instance to read
      * @param fieldName the name of the field
      * @throws RuntimeException if the field  can't be read
      * @noinspection unchecked
      * @noinspectionreason unchecked - unchecked cast is ok on test code
      */
-    public static <T> T getInternalStaticState(Class<?> clss, String fieldName) {
+    public static Map<String, String> getInternalStateMap(Object instance, String fieldName) {
+        return getInternalState(instance, fieldName, Map.class);
+    }
+
+    /**
+     * Helper method for casting collection type Map.
+     *
+     * @param instance the instance to read
+     * @param fieldName the name of the field
+     * @throws RuntimeException if the field  can't be read
+     * @noinspection unchecked
+     * @noinspectionreason unchecked - unchecked cast is ok on test code
+     */
+    public static Map<Integer, List<TextBlock>> getInternalStateMapIntegerList(
+            Object instance, String fieldName) {
+        return getInternalState(instance, fieldName, Map.class);
+    }
+
+    /**
+     * Helper method for casting collection type List.
+     *
+     * @param instance the instance to read
+     * @param fieldName the name of the field
+     * @throws RuntimeException if the field  can't be read
+     * @noinspection unchecked
+     * @noinspectionreason unchecked - unchecked cast is ok on test code
+     */
+    public static List<AuditListener> getInternalStateListAuditListener(
+            Object instance, String fieldName) {
+        return getInternalState(instance, fieldName, List.class);
+    }
+
+    /**
+     * Helper method for casting collection type List.
+     *
+     * @param instance the instance to read
+     * @param fieldName the name of the field
+     * @throws RuntimeException if the field  can't be read
+     * @noinspection unchecked
+     * @noinspectionreason unchecked - unchecked cast is ok on test code
+     */
+    public static List<Pattern> getInternalStateListPattern(
+            Object instance, String fieldName) {
+        return getInternalState(instance, fieldName, List.class);
+    }
+
+    /**
+     * Helper method for casting collection type List.
+     *
+     * @param instance the instance to read
+     * @param fieldName the name of the field
+     * @throws RuntimeException if the field  can't be read
+     * @noinspection unchecked
+     * @noinspectionreason unchecked - unchecked cast is ok on test code
+     */
+    public static List<Comparable<Object>> getInternalStateListComparable(
+            Object instance, String fieldName) {
+        return getInternalState(instance, fieldName, List.class);
+    }
+
+    /**
+     * Helper method for casting to Collection.
+     *
+     * @param instance the instance to read
+     * @param fieldName the name of the field
+     * @throws RuntimeException if the field  can't be read
+     * @noinspection unchecked
+     * @noinspectionreason unchecked - unchecked cast is ok on test code
+     */
+    public static Collection<Checks> getInternalStateCollectionChecks(
+            Object instance, String fieldName) {
+        return getInternalState(instance, fieldName, Collection.class);
+    }
+
+    /**
+     * Helper method for casting to collection type Set.
+     *
+     * @param instance the instance to read
+     * @param fieldName the name of the field
+     * @throws RuntimeException if the field  can't be read
+     * @noinspection unchecked
+     * @noinspectionreason unchecked - unchecked cast is ok on test code
+     */
+    public static Set<TreeWalkerFilter> getInternalStateSetTreeWalkerFilter(
+            Object instance, String fieldName) {
+        return getInternalState(instance, fieldName, Set.class);
+    }
+
+    /**
+     * Reads the value of a static field using reflection. This method will traverse the
+     * super class hierarchy until a field with name {@code fieldName} is found.
+     *
+     * @param clss the class of the field
+     * @param fieldName the name of the field
+     * @param clazz the expected type of the field value, used for type-safe casting
+     * @throws RuntimeException if the field  can't be read
+     */
+    public static <T> T getInternalStaticState(Class<?> clss, String fieldName, Class<T> clazz) {
         try {
             final Field field = getClassDeclaredField(clss, fieldName);
-            return (T) field.get(null);
+            return clazz.cast(field.get(null));
         }
         catch (ReflectiveOperationException exc) {
             final String message = String.format(Locale.ROOT,
@@ -304,6 +405,33 @@ public final class TestUtil {
                     fieldName, clss);
             throw new IllegalStateException(message, exc);
         }
+    }
+
+    /**
+     * Helper method for casting to collection type Map.
+     *
+     * @param clss the class of the field
+     * @param fieldName the name of the field
+     * @throws RuntimeException if the field  can't be read
+     * @noinspection unchecked
+     * @noinspectionreason unchecked - unchecked cast is ok on test code
+     */
+    public static Map<String, String> getInternalStaticStateMap(Class<?> clss, String fieldName) {
+        return getInternalStaticState(clss, fieldName, Map.class);
+    }
+
+    /**
+     * Helper method for casting to collection type Map.
+     *
+     * @param clss the class of the field
+     * @param fieldName the name of the field
+     * @throws RuntimeException if the field  can't be read
+     * @noinspection unchecked
+     * @noinspectionreason unchecked - unchecked cast is ok on test code
+     */
+    public static ThreadLocal<List<Object>> getInternalStaticStateThreadLocal(
+            Class<?> clss, String fieldName) {
+        return getInternalStaticState(clss, fieldName, ThreadLocal.class);
     }
 
     /**


### PR DESCRIPTION
Issue: #17845 
Resolved violations:
```
[WARNING] /src/test/java/com/puppycrawl/tools/checkstyle/bdd/TestInputViolation.java:[88,20]
[EqualsGetClass] Prefer instanceof to getClass when implementing Object#equals.
    (see https://errorprone.info/bugpattern/EqualsGetClass)
  Did you mean 'return object instanceof TestInputViolation && compareTo((TestInputViolation) object) == 0;'?

[WARNING] /src/it/java/com/google/checkstyle/test/base/AbstractIndentationTestSupport.java:[185,57]
[OperatorPrecedence] Use grouping parenthesis to make the operator precedence explicit
    (see https://errorprone.info/bugpattern/OperatorPrecedence)
  Did you mean 'return (indentInComment >= expectedMinimalIndent && !isWarnComment)'?

[WARNING] /src/it/java/com/google/checkstyle/test/base/AbstractIndentationTestSupport.java:[186,60]
[OperatorPrecedence] Use grouping parenthesis to make the operator precedence explicit
    (see https://errorprone.info/bugpattern/OperatorPrecedence)
  Did you mean '|| (indentInComment < expectedMinimalIndent && isWarnComment);'?

[WARNING] /src/it/java/com/google/checkstyle/test/base/AbstractIndentationTestSupport.java:[203,49]
[OperatorPrecedence] Use grouping parenthesis to make the operator precedence explicit
    (see https://errorprone.info/bugpattern/OperatorPrecedence)
  Did you mean 'return (expectedLevel == indentInComment && !isWarnComment)'?

[WARNING] /src/it/java/com/google/checkstyle/test/base/AbstractIndentationTestSupport.java:[204,53]
[OperatorPrecedence] Use grouping parenthesis to make the operator precedence explicit
    (see https://errorprone.info/bugpattern/OperatorPrecedence)
  Did you mean '|| (expectedLevel != indentInComment && isWarnComment);'?

[WARNING] /src/it/java/com/google/checkstyle/test/base/AbstractIndentationTestSupport.java:[224,36]
[OperatorPrecedence] Use grouping parenthesis to make the operator precedence explicit
    (see https://errorprone.info/bugpattern/OperatorPrecedence)
  Did you mean 'return (containsActualLevel && !isWarnComment)'?

[WARNING] /src/it/java/com/google/checkstyle/test/base/AbstractIndentationTestSupport.java:[225,41]
[OperatorPrecedence] Use grouping parenthesis to make the operator precedence explicit
    (see https://errorprone.info/bugpattern/OperatorPrecedence)
  Did you mean '|| (!containsActualLevel && isWarnComment);'?

[WARNING] /src/test/java/com/puppycrawl/tools/checkstyle/AbstractAutomaticBeanTest.java:[348,20]
[EffectivelyPrivate] This declaration has public or protected modifiers, but is effectively private.
    (see https://errorprone.info/bugpattern/EffectivelyPrivate)
  Did you mean 'int getRegisterCount() {'?

[WARNING] /src/test/java/com/puppycrawl/tools/checkstyle/AbstractGuiTestSupport.java:[63,46]
[TypeParameterUnusedInFormals] Declaring a type parameter that is only used in the return type
is a misuse of generics: operations on the type parameter are unchecked, it hides unsafe casts
at invocations of the method, and it interacts badly with method overload resolution.
    (see https://errorprone.info/bugpattern/TypeParameterUnusedInFormals)

[WARNING] /src/test/java/com/puppycrawl/tools/checkstyle/AbstractModuleTestSupport.java:[652,23]
[VoidUsed] Using a Void-typed variable is potentially confusing, and can be replaced with a literal `null`.
    (see https://errorprone.info/bugpattern/VoidUsed)
  Did you mean '.that(null)'?

[WARNING] /src/test/java/com/puppycrawl/tools/checkstyle/internal/utils/TestUtil.java:[273,25]
[TypeParameterUnusedInFormals] Declaring a type parameter that is only used in the return type
is a misuse of generics: operations on the type parameter are unchecked, it hides unsafe casts

at invocations of the method, and it interacts badly with method overload resolution.
    (see https://errorprone.info/bugpattern/TypeParameterUnusedInFormals)

[WARNING] /src/test/java/com/puppycrawl/tools/checkstyle/internal/utils/TestUtil.java:[296,25]
[TypeParameterUnusedInFormals] Declaring a type parameter that is only used in the return type
is a misuse of generics: operations on the type parameter are unchecked, it hides unsafe casts
at invocations of the method, and it interacts badly with method overload resolution.
    (see https://errorprone.info/bugpattern/TypeParameterUnusedInFormals)
```