### PR TITLE
dependency: Update Google Java Format version to 1.29.0

### DIFF
--- a/.github/workflows/google-java-format.yml
+++ b/.github/workflows/google-java-format.yml
@@ -20,7 +20,7 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  VERSION: 1.28.0
+  VERSION: 1.29.0
 
 jobs:
   test:


### PR DESCRIPTION
https://github.com/google/google-java-format/releases/tag/v1.29.0