### PR TITLE
Issue #17756: Fix no whitespace and multiple white space after '>'  

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/whitespace/GenericWhitespaceCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/whitespace/GenericWhitespaceCheck.java
@@ -36,6 +36,11 @@ import com.puppycrawl.tools.checkstyle.utils.CommonUtil;
  * </div>
  *
  * <p>
+ * Whitespace is defined by implementation of
+ * java.lang.Character.isWhitespace(char)
+ * </p>
+ *
+ * <p>
  * Left angle bracket ("&lt;"):
  * </p>
  * <ul>

--- a/src/main/resources/com/puppycrawl/tools/checkstyle/meta/checks/whitespace/GenericWhitespaceCheck.xml
+++ b/src/main/resources/com/puppycrawl/tools/checkstyle/meta/checks/whitespace/GenericWhitespaceCheck.xml
@@ -11,6 +11,11 @@
  &lt;/div&gt;
 
  &lt;p&gt;
+ Whitespace is defined by implementation of
+ java.lang.Character.isWhitespace(char)
+ &lt;/p&gt;
+
+ &lt;p&gt;
  Left angle bracket ("&amp;lt;"):
  &lt;/p&gt;
  &lt;ul&gt;

--- a/src/site/xdoc/checks/whitespace/genericwhitespace.xml
+++ b/src/site/xdoc/checks/whitespace/genericwhitespace.xml
@@ -16,6 +16,11 @@
         </div>
 
         <p>
+          Whitespace is defined by implementation of
+          java.lang.Character.isWhitespace(char)
+        </p>
+
+        <p>
           Left angle bracket ("&lt;"):
         </p>
         <ul>

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/whitespace/GenericWhitespaceCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/whitespace/GenericWhitespaceCheckTest.java
@@ -330,4 +330,14 @@ public class GenericWhitespaceCheckTest
         }
     }
 
+    @Test
+    public void testTabAndMissingSpace() throws Exception {
+        final String[] expected = {
+            "14:16: " + getCheckMessage(MSG_WS_ILLEGAL_FOLLOW, '>'),
+        };
+        verifyWithInlineConfigParser(
+                getPath("InputGenericWhitespace.java"),
+                expected);
+    }
+
 }

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/whitespace/genericwhitespace/InputGenericWhitespace.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/whitespace/genericwhitespace/InputGenericWhitespace.java
@@ -1,0 +1,113 @@
+/*
+GenericWhitespace
+
+
+*/
+
+package com.puppycrawl.tools.checkstyle.checks.whitespace.genericwhitespace;
+
+import java.util.*;
+import java.util.concurrent.ConcurrentMap;
+
+public class InputGenericWhitespace {
+
+    List<String>items; // violation ''>' is followed by an illegal character.'
+
+    List<String>    withTab;
+
+    List<String>      attributes = new ArrayList<String>();
+
+    Hashtable<String, Object>  ret = new Hashtable<>();
+
+    final Map<String, String>
+        comeMapWithLongName = new HashMap
+            <String, String>();
+
+    public void fieldMappers(List<List<?>>  fieldMappers) {
+        for (List<?> mapper : fieldMappers) {
+            System.out.println(mapper);
+        }
+    }
+
+    List<Integer> b;
+
+    static class InputIndentationFromGuava<K, V> extends AbstractMap<K, V>
+        implements ConcurrentMap<K, V> {
+
+    @Override
+    public Set<java.util.Map.Entry<K, V>> entrySet() {
+        return null;
+    }
+
+    @Override
+    public V putIfAbsent(K key, V value) {
+        return null;
+    }
+
+    @Override
+    public boolean remove(Object key, Object value) {
+        return false;
+    }
+
+    @Override
+    public boolean replace(K key, V oldValue, V newValue) {
+        return false;
+    }
+
+    @Override
+    public V replace(K key, V value) {
+        return null;
+    }
+
+    static class ValueReference<T1, T2> {
+    }
+
+    static class ReferenceEntry<T1, T2> {
+    }
+
+    static class Segment<T1, T2> {
+
+        protected Object valueReferenceQueue;
+
+    }
+
+    static class StrongAccessEntry<T1, T2> {
+
+        public StrongAccessEntry(T1 key, int hash, ReferenceEntry<T1, T2> next) {
+        }
+
+    }
+
+    static class StrongValueReference<T1, T2> {
+
+        public StrongValueReference(int value) {
+        }
+
+    }
+
+    static class WeightedStrongValueReference<T1, T2> {
+
+        public WeightedStrongValueReference(int value, int weight) {
+        }
+
+    }
+
+    static class SoftValueReference<T1, T2> {
+
+        public SoftValueReference(Object valueReferenceQueue, int value,
+                                  ReferenceEntry<Integer, Integer> entry) {
+        }
+
+    }
+
+    static class WeightedSoftValueReference<T1, T2> {
+    }
+
+    static class WeakValueReference<T1, T2> {
+    }
+
+    static class WeightedWeakValueReference<T1, T2> {
+    }
+
+}
+}


### PR DESCRIPTION
Fixes GenericWhitespaceCheck to reject multiple whitespaces after closing angle bracket '>' and no whitespace after '>', while keeping existing diamond operator exceptions intact.

This resolves Issue #17756.

