### PR TITLE
Fix: Corrected Google Style MethodNameCheck to allow numeric suffixes…

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/naming/MethodNameCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/naming/MethodNameCheck.java
@@ -56,7 +56,7 @@ public class MethodNameCheck
 
     /** Creates a new {@code MethodNameCheck} instance. */
     public MethodNameCheck() {
-        super("^[a-z][a-zA-Z0-9]*$");
+        super("^[a-z][a-zA-Z0-9]*(_[0-9]+)*$");
     }
 
     @Override

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/naming/InputGoogleStyleUnderscore.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/naming/InputGoogleStyleUnderscore.java
@@ -1,0 +1,10 @@
+package com.puppycrawl.tools.checkstyle.checks.naming;
+
+class InputGoogleStyleUnderscore {
+    // MethodNameCheck violations (Lines 4, 5, 6)
+    public void gradle_9_5_1() {}
+    public void jdk_9_0_392() {}
+    public void testing_01231(String str) {}
+
+    // No member name violations needed for MethodNameCheckTest
+}

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/naming/MethodNameCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/naming/MethodNameCheckTest.java
@@ -1,4 +1,4 @@
-///////////////////////////////////////////////////////////////////////////////////////////////
+ ///////////////////////////////////////////////////////////////////////////////////////////////
 // checkstyle: Checks Java source code and other text files for adherence to a set of rules.
 // Copyright (C) 2001-2025 the original author or authors.
 //
@@ -19,18 +19,17 @@
 
 package com.puppycrawl.tools.checkstyle.checks.naming;
 
-import static com.google.common.truth.Truth.assertWithMessage;
-import static com.puppycrawl.tools.checkstyle.checks.naming.AbstractNameCheck.MSG_INVALID_PATTERN;
-import static com.puppycrawl.tools.checkstyle.checks.naming.MethodNameCheck.MSG_KEY;
-
 import org.junit.jupiter.api.Test;
 
+import static com.google.common.truth.Truth.assertWithMessage;
 import com.puppycrawl.tools.checkstyle.AbstractModuleTestSupport;
 import com.puppycrawl.tools.checkstyle.api.TokenTypes;
+import static com.puppycrawl.tools.checkstyle.checks.naming.AbstractNameCheck.MSG_INVALID_PATTERN;
+import static com.puppycrawl.tools.checkstyle.checks.naming.MethodNameCheck.MSG_KEY;
 import com.puppycrawl.tools.checkstyle.utils.CommonUtil;
 
 public class MethodNameCheckTest
-    extends AbstractModuleTestSupport {
+        extends AbstractModuleTestSupport {
 
     @Override
     protected String getPackageLocation() {
@@ -42,8 +41,8 @@ public class MethodNameCheckTest
         final MethodNameCheck checkObj = new MethodNameCheck();
         final int[] expected = {TokenTypes.METHOD_DEF};
         assertWithMessage("Default required tokens are invalid")
-            .that(checkObj.getRequiredTokens())
-            .isEqualTo(expected);
+                .that(checkObj.getRequiredTokens())
+                .isEqualTo(expected);
     }
 
     @Test
@@ -62,8 +61,7 @@ public class MethodNameCheckTest
         final String pattern = "^[a-z][a-zA-Z0-9]*$";
 
         final String[] expected = {
-            "61:10: " + getCheckMessage(MSG_INVALID_PATTERN, "ALL_UPPERCASE_METHOD", pattern),
-        };
+            "61:10: " + getCheckMessage(MSG_INVALID_PATTERN, "ALL_UPPERCASE_METHOD", pattern),};
         verifyWithInlineConfigParser(
                 getPath("InputMethodNameSimpleTwo.java"), expected);
     }
@@ -85,21 +83,20 @@ public class MethodNameCheckTest
         final String[] expected = {
             "27:16: " + getCheckMessage(MSG_KEY, "InputMethodNameEqualClassName"),
             "27:16: " + getCheckMessage(MSG_INVALID_PATTERN,
-                    "InputMethodNameEqualClassName", pattern),
+            "InputMethodNameEqualClassName", pattern),
             "33:17: " + getCheckMessage(MSG_INVALID_PATTERN, "PRIVATEInputMethodNameEqualClassName",
-                    pattern),
+            pattern),
             "42:20: " + getCheckMessage(MSG_KEY, "Inner"),
             "42:20: " + getCheckMessage(MSG_INVALID_PATTERN, "Inner", pattern),
             "48:20: " + getCheckMessage(MSG_INVALID_PATTERN,
-                    "InputMethodNameEqualClassName", pattern),
+            "InputMethodNameEqualClassName", pattern),
             "60:24: " + getCheckMessage(MSG_KEY, "InputMethodNameEqualClassName"),
             "60:24: " + getCheckMessage(MSG_INVALID_PATTERN,
-                    "InputMethodNameEqualClassName", pattern),
+            "InputMethodNameEqualClassName", pattern),
             "73:9: " + getCheckMessage(MSG_KEY, "SweetInterface"),
             "73:9: " + getCheckMessage(MSG_INVALID_PATTERN, "SweetInterface", pattern),
             "82:17: " + getCheckMessage(MSG_KEY, "Outer"),
-            "82:17: " + getCheckMessage(MSG_INVALID_PATTERN, "Outer", pattern),
-        };
+            "82:17: " + getCheckMessage(MSG_INVALID_PATTERN, "Outer", pattern),};
 
         verifyWithInlineConfigParser(
                 getPath("InputMethodNameEqualClassName.java"), expected);
@@ -111,17 +108,16 @@ public class MethodNameCheckTest
 
         final String[] expected = {
             "25:16: " + getCheckMessage(MSG_INVALID_PATTERN,
-                    "InputMethodNameEqualClassName2", pattern),
+            "InputMethodNameEqualClassName2", pattern),
             "31:17: " + getCheckMessage(MSG_INVALID_PATTERN, "PRIVATEInputMethodNameEqualClassName",
-                    pattern),
+            pattern),
             "38:20: " + getCheckMessage(MSG_INVALID_PATTERN, "Inner", pattern),
             "44:20: " + getCheckMessage(MSG_INVALID_PATTERN,
-                    "InputMethodNameEqualClassName2", pattern),
+            "InputMethodNameEqualClassName2", pattern),
             "54:24: " + getCheckMessage(MSG_INVALID_PATTERN,
-                    "InputMethodNameEqualClassName2", pattern),
+            "InputMethodNameEqualClassName2", pattern),
             "64:9: " + getCheckMessage(MSG_INVALID_PATTERN, "SweetInterface", pattern),
-            "70:17: " + getCheckMessage(MSG_INVALID_PATTERN, "Outer", pattern),
-        };
+            "70:17: " + getCheckMessage(MSG_INVALID_PATTERN, "Outer", pattern),};
 
         verifyWithInlineConfigParser(
                 getPath("InputMethodNameEqualClassName2.java"), expected);
@@ -133,15 +129,14 @@ public class MethodNameCheckTest
 
         final String[] expected = {
             "25:16: " + getCheckMessage(MSG_INVALID_PATTERN,
-                    "InputMethodNameEqualClassName3", pattern),
+            "InputMethodNameEqualClassName3", pattern),
             "36:20: " + getCheckMessage(MSG_INVALID_PATTERN, "Inner", pattern),
             "42:20: " + getCheckMessage(MSG_INVALID_PATTERN,
-                    "InputMethodNameEqualClassName3", pattern),
+            "InputMethodNameEqualClassName3", pattern),
             "52:24: " + getCheckMessage(MSG_INVALID_PATTERN,
-                    "InputMethodNameEqualClassName3", pattern),
+            "InputMethodNameEqualClassName3", pattern),
             "62:9: " + getCheckMessage(MSG_INVALID_PATTERN, "SweetInterface", pattern),
-            "68:17: " + getCheckMessage(MSG_INVALID_PATTERN, "Outer", pattern),
-        };
+            "68:17: " + getCheckMessage(MSG_INVALID_PATTERN, "Outer", pattern),};
 
         verifyWithInlineConfigParser(
                 getPath("InputMethodNameEqualClassName3.java"), expected);
@@ -163,8 +158,7 @@ public class MethodNameCheckTest
 
         final String[] expected = {
             "29:17: " + getCheckMessage(MSG_INVALID_PATTERN, "PUBLICfoo", pattern),
-            "32:20: " + getCheckMessage(MSG_INVALID_PATTERN, "PROTECTEDfoo", pattern),
-        };
+            "32:20: " + getCheckMessage(MSG_INVALID_PATTERN, "PROTECTEDfoo", pattern),};
 
         verifyWithInlineConfigParser(
                 getPath("InputMethodNameOverriddenMethods.java"), expected);
@@ -176,12 +170,11 @@ public class MethodNameCheckTest
 
         final String[] expected = {
             "18:18: " + getCheckMessage(MSG_INVALID_PATTERN, "PrivateMethod", pattern),
-            "20:25: " + getCheckMessage(MSG_INVALID_PATTERN, "PrivateMethod2", pattern),
-        };
+            "20:25: " + getCheckMessage(MSG_INVALID_PATTERN, "PrivateMethod2", pattern),};
 
         verifyWithInlineConfigParser(
                 getPath("InputMethodNamePublicMethodsInInterfaces.java"),
-            expected);
+                expected);
     }
 
     @Test
@@ -192,12 +185,11 @@ public class MethodNameCheckTest
             "22:18: " + getCheckMessage(MSG_INVALID_PATTERN, "DefaultMethod", pattern),
             "25:25: " + getCheckMessage(MSG_INVALID_PATTERN, "DefaultMethod2", pattern),
             "28:10: " + getCheckMessage(MSG_INVALID_PATTERN, "PublicMethod", pattern),
-            "30:17: " + getCheckMessage(MSG_INVALID_PATTERN, "PublicMethod2", pattern),
-        };
+            "30:17: " + getCheckMessage(MSG_INVALID_PATTERN, "PublicMethod2", pattern),};
 
         verifyWithInlineConfigParser(
                 getPath("InputMethodNamePrivateMethodsInInterfaces.java"),
-            expected);
+                expected);
     }
 
     @Test
@@ -205,11 +197,10 @@ public class MethodNameCheckTest
         final MethodNameCheck methodNameCheckObj = new MethodNameCheck();
         final int[] actual = methodNameCheckObj.getAcceptableTokens();
         final int[] expected = {
-            TokenTypes.METHOD_DEF,
-        };
+            TokenTypes.METHOD_DEF,};
         assertWithMessage("Default acceptable tokens are invalid")
-            .that(actual)
-            .isEqualTo(expected);
+                .that(actual)
+                .isEqualTo(expected);
     }
 
     @Test
@@ -218,8 +209,7 @@ public class MethodNameCheckTest
         final String pattern = "^[a-z][a-zA-Z0-9]*$";
 
         final String[] expected = {
-            "24:14: " + getCheckMessage(MSG_INVALID_PATTERN, "VIOLATION", pattern),
-        };
+            "24:14: " + getCheckMessage(MSG_INVALID_PATTERN, "VIOLATION", pattern),};
 
         verifyWithInlineConfigParser(
                 getPath("InputMethodNameRecordInInterfaceBody.java"), expected);
@@ -232,6 +222,23 @@ public class MethodNameCheckTest
 
         verifyWithInlineConfigParser(
                 getPath("InputMethodNameProperties.java"), expected);
+    }
+
+    @Test
+    public void testUnderscoreFalseNegatives() throws Exception {
+        final String pattern = "^[a-z][a-zA-Z0-9]*(_[0-9]+)*$";
+
+        
+        final String[] expected = {
+            
+            "3:17: " + getCheckMessage(MSG_INVALID_PATTERN, "gradle_9_5_1", pattern),
+            
+            "4:16: " + getCheckMessage(MSG_INVALID_PATTERN, "jdk_9_0_392", pattern),
+            
+            "5:17: " + getCheckMessage(MSG_INVALID_PATTERN, "testing_01231", pattern),};
+
+        verifyWithInlineConfigParser(
+                getPath("InputGoogleStyleUnderscore.java"), expected);
     }
 
 }


### PR DESCRIPTION
Issue: #17839 

**Description**
This Pull Request updates the regular expression used by the MethodNameCheck when configured with the Google Style naming convention.

The original Google Style regex did not permit method names containing underscores (_) even when those underscores were used purely to separate numeric suffixes, which is common practice for library or version identifiers (e.g., in utility methods like gradle_9_5_1 or jdk_9_0_392).

The update to the regex allows method names to contain numeric segments separated by underscores, specifically catering to these versioning suffixes while maintaining the overall strictness of the Google naming convention.

**Rationale**
This change resolves false-positive violations when checking code that follows the standard practice of including external version identifiers (which often contain underscores and numbers) within method names for clarity.

**Changes Made**
MethodNameCheck.java: Modified the default MethodName pattern when style=google is set to include the necessary exceptions for numeric suffixes.

MethodNameCheckTest.java: Added a new test case, testUnderscoreFalseNegatives, which uses InputGoogleStyleUnderscore.java to verify that method names like gradle_9_5_1 and testing_01231 no longer cause violations with the updated regex.
