### PR TITLE
Issue #16233: Fix PackageObjectFactoryTest before/after annotations

### DIFF
--- a/src/test/java/com/puppycrawl/tools/checkstyle/PackageObjectFactoryTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/PackageObjectFactoryTest.java
@@ -47,8 +47,8 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 
-import org.junit.AfterClass;
-import org.junit.BeforeClass;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.mockito.MockedStatic;
 import org.mockito.Mockito;
@@ -72,13 +72,13 @@ public class PackageObjectFactoryTest {
     private final PackageObjectFactory factory = new PackageObjectFactory(
             BASE_PACKAGE, Thread.currentThread().getContextClassLoader());
 
-    @BeforeClass
+    @BeforeAll
     public static void setupLocale() {
         defaultLocale = Locale.getDefault();
         Locale.setDefault(Locale.ENGLISH);
     }
 
-    @AfterClass
+    @AfterAll
     public static void restoreLocale() {
         Locale.setDefault(defaultLocale);
     }


### PR DESCRIPTION
Follow up on #16500 - since PackageObjectFactoryTest is executed using the JUnit Jupiter teset executor, the `org.junit.BeforeClass` and `org.junit.AfterClass` JUnit 4 annotations aren't picked up, and the methods annotated with them are never executed.

This patch follows up on the work done in #16233 and replaces these annotations with `org.junit.jupiter.api.BeforeAll` and `org.junit.jupiter.api.AfterAll`, respectively, so that these methods are indeed executed as part of the test lifecycle.

