### PR TITLE
Revert "dependency: bump aws-actions/configure-aws-credentials from 5 to 6"

### DIFF
--- a/.github/workflows/diff-report.yml
+++ b/.github/workflows/diff-report.yml
@@ -150,7 +150,7 @@ jobs:
           sudo apt install groovy
 
       - name: Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@v6
+        uses: aws-actions/configure-aws-credentials@v5
         with:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}

--- a/.github/workflows/regression-report.yml
+++ b/.github/workflows/regression-report.yml
@@ -497,7 +497,7 @@ jobs:
           java-version: '21'
 
       - name: Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@v6
+        uses: aws-actions/configure-aws-credentials@v5
         with:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}

--- a/.github/workflows/site.yml
+++ b/.github/workflows/site.yml
@@ -129,7 +129,7 @@ jobs:
           key: checkstyle-site-cache-${{ github.run_id }}
 
       - name: Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@v6
+        uses: aws-actions/configure-aws-credentials@v5
         with:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}


### PR DESCRIPTION
Reverts checkstyle/checkstyle#17885

No 6.0 version.
https://github.com/aws-actions/configure-aws-credentials/tags latest is 5.1.0