### PR TITLE
Issue #16360: Added comment to testAddErrorWithNullFileName

### DIFF
--- a/src/test/java/com/puppycrawl/tools/checkstyle/XMLLoggerTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/XMLLoggerTest.java
@@ -179,6 +179,10 @@ public class XMLLoggerTest extends AbstractXmlTestSupport {
                 "ExpectedXMLLoggerAddError.xml");
     }
 
+    /**
+     * This test cannot use the standard input/expected XML approach
+     * because it requires an AuditEvent with a null fileName.
+     */
     @Test
     public void testAddErrorWithNullFileName() throws Exception {
         final XMLLogger logger = new XMLLogger(outStream, OutputStreamOptions.CLOSE);


### PR DESCRIPTION
Issue #16360
The `testAddErrorWithNullFileName` method in `XMLLoggerTest` cannot be updated to use the standard `verifyWithInlineConfigParserAndXmlLogger` approach.

Reason: the test requires creating an AuditEvent with a null fileName, which cannot be represented by a standard input Java file.

A comment has been added above the method to explain why this test deviates from the usual input/expected XML pattern.