### PR TITLE
Issue #11163: Enforced file size on VisibilityModifierCheck

### DIFF
--- a/config/checkstyle-resources-suppressions.xml
+++ b/config/checkstyle-resources-suppressions.xml
@@ -570,8 +570,6 @@
   <suppress checks="FileLength"
     files="[\\/]test[\\/]resources[\\/]com[\\/]puppycrawl[\\/]tools[\\/]checkstyle[\\/]checks[\\/]blocks[\\/]leftcurly[\\/]InputLeftCurlyTestNewLine3\.java"/>
   <suppress checks="FileLength"
-    files="[\\/]test[\\/]resources[\\/]com[\\/]puppycrawl[\\/]tools[\\/]checkstyle[\\/]checks[\\/]design[\\/]visibilitymodifier[\\/]InputVisibilityModifierSimple\.java"/>
-  <suppress checks="FileLength"
     files="[\\/]test[\\/]resources[\\/]com[\\/]puppycrawl[\\/]tools[\\/]checkstyle[\\/]checks[\\/]design[\\/]designforextension[\\/]InputDesignForExtensionIgnoredAnnotations\.java"/>
   <suppress checks="FileLength"
     files="[\\/]test[\\/]resources[\\/]com[\\/]puppycrawl[\\/]tools[\\/]checkstyle[\\/]checks[\\/]design[\\/]designforextension[\\/]InputDesignForExtension\.java"/>

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/design/VisibilityModifierCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/design/VisibilityModifierCheckTest.java
@@ -83,7 +83,7 @@ public class VisibilityModifierCheckTest
     }
 
     @Test
-    public void testSimple() throws Exception {
+    public void testSimple1() throws Exception {
         final String[] expected = {
             "49:19: " + getCheckMessage(MSG_KEY, "mNumCreated2"),
             "59:23: " + getCheckMessage(MSG_KEY, "sTest1"),
@@ -94,6 +94,14 @@ public class VisibilityModifierCheckTest
         };
         verifyWithInlineConfigParser(
                 getPath("InputVisibilityModifierSimple.java"), expected);
+    }
+
+    @Test
+    public void testSimple2() throws Exception {
+        final String[] expected = {
+        };
+        verifyWithInlineConfigParser(
+                getPath("InputVisibilityModifierSimple2.java"), expected);
     }
 
     @Test

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/design/visibilitymodifier/InputVisibilityModifierSimple.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/design/visibilitymodifier/InputVisibilityModifierSimple.java
@@ -106,30 +106,3 @@ final class InputVisibilityModifierSimple
     /** test illegal constant **/
     private static final int BAD__NAME = 3;
 }
-
-/** Test class for variable naming in for each clause. */
-class InputVisibilityModifierSimple2
-{
-    /** Some more Javadoc. */
-    public void doSomething()
-    {
-        //"O" should be named "o"
-        for (Object O : new java.util.ArrayList())
-        {
-
-        }
-    }
-}
-
-/** Test enum for member naming check */
-enum MyEnum1
-{
-    /** ABC constant */
-    ABC,
-
-    /** XYZ constant */
-    XYZ;
-
-    /** Should be mSomeMember */
-    private int someMember;
-}

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/design/visibilitymodifier/InputVisibilityModifierSimple2.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/design/visibilitymodifier/InputVisibilityModifierSimple2.java
@@ -1,0 +1,49 @@
+/*
+VisibilityModifier
+packageAllowed = (default)false
+protectedAllowed = (default)false
+publicMemberPattern = ^f[A-Z][a-zA-Z0-9]*$
+allowPublicFinalFields = (default)false
+allowPublicImmutableFields = (default)false
+immutableClassCanonicalNames = (default)java.io.File, java.lang.Boolean, java.lang.Byte, \
+                               java.lang.Character, java.lang.Double, java.lang.Float, \
+                               java.lang.Integer, java.lang.Long, java.lang.Short, \
+                               java.lang.StackTraceElement, java.lang.String, \
+                               java.math.BigDecimal, java.math.BigInteger, \
+                               java.net.Inet4Address, java.net.Inet6Address, \
+                               java.net.InetSocketAddress, java.net.URI, java.net.URL, \
+                               java.util.Locale, java.util.UUID
+ignoreAnnotationCanonicalNames = (default)com.google.common.annotations.VisibleForTesting, \
+                                 org.junit.ClassRule, org.junit.Rule
+
+
+*/
+
+package com.puppycrawl.tools.checkstyle.checks.design.visibilitymodifier;
+import java.io.*;
+/** Test class for variable naming in for each clause. */
+final class InputVisibilityModifierSimple2
+{
+    /** Some more Javadoc. */
+    public void doSomething()
+    {
+        //"O" should be named "o"
+        for (Object O : new java.util.ArrayList())
+        {
+
+        }
+    }
+}
+
+/** Test enum for member naming check */
+enum MyEnum1
+{
+    /** ABC constant */
+    ABC,
+
+    /** XYZ constant */
+    XYZ;
+
+    /** Should be mSomeMember */
+    private int someMember;
+}


### PR DESCRIPTION
Issue #11163
Enforced file size on VisibilityModifierCheck inputs.
Split `InputVisibilityModifierSimple.java` in two files