### PR TITLE
Update Javadoc for RETURN_BLOCK_TAG with AST example

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/api/JavadocCommentsTokenTypes.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/api/JavadocCommentsTokenTypes.java
@@ -111,7 +111,37 @@ public final class JavadocCommentsTokenTypes {
     public static final int PARAM_BLOCK_TAG = JavadocCommentsLexer.PARAM_BLOCK_TAG;
 
     /**
-     * {@code @return} block tag.
+     * {@code @return} Javadoc block tag.
+     *
+     * <p>Such Javadoc tag can have one child:</p>
+     * <ol>
+     *   <li>{@link #DESCRIPTION}</li>
+     * </ol>
+     *
+     * <p><b>Example:</b></p>
+     * <pre>{@code * @return The result of the operation.}</pre>
+     *
+     * <b>Tree:</b>
+     * <pre>{@code
+     * JAVADOC_CONTENT -> JAVADOC_CONTENT 
+     * |--TEXT -> /** 
+     * |--NEWLINE -> \n 
+     * |--LEADING_ASTERISK ->  * 
+     * |--TEXT ->  Test class for generating AST. 
+     * |--NEWLINE -> \n 
+     * |--LEADING_ASTERISK ->  * 
+     * |--NEWLINE -> \n 
+     * |--LEADING_ASTERISK ->  * 
+     * |--TEXT ->   
+     * `--JAVADOC_BLOCK_TAG -> JAVADOC_BLOCK_TAG 
+     *     `--RETURN_BLOCK_TAG -> RETURN_BLOCK_TAG 
+     *         |--AT_SIGN -> @ 
+     *         |--TAG_NAME -> return 
+     *         `--DESCRIPTION -> DESCRIPTION 
+     *             `--TEXT ->  The result of the operation.
+     * }</pre>
+     *
+     * @see #JAVADOC_BLOCK_TAG
      */
     public static final int RETURN_BLOCK_TAG = JavadocCommentsLexer.RETURN_BLOCK_TAG;
 


### PR DESCRIPTION

This PR updates the Javadoc documentation for the `RETURN_BLOCK_TAG` token in `JavadocCommentsTokenTypes.java` to include comprehensive documentation with AST examples.

## Changes
- Added detailed Javadoc documentation for `RETURN_BLOCK_TAG`
- Included example usage: `* @return The result of the operation.`
- Added complete AST tree structure showing token hierarchy
- Documented child tokens (DESCRIPTION)
- Follows the same format as existing `PARAM_BLOCK_TAG` documentation
- Generated AST using latest Checkstyle snapshot (12.0.0-SNAPSHOT)

## Testing
- Verified AST structure matches actual output from Checkstyle
- No linting errors
- Documentation format is consistent with existing patterns

## Related Issue
Contributes to issue #14631

## Checklist
- [x] Code follows existing style guidelines
- [x] Documentation is accurate and complete
- [x] No linting errors
- [x] Changes are properly tested