### PR TITLE
#ISSUE 14631 Update Javadoc for SINCE_BLOCK_TAG with AST example

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/api/JavadocCommentsTokenTypes.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/api/JavadocCommentsTokenTypes.java
@@ -189,7 +189,27 @@ public final class JavadocCommentsTokenTypes {
     public static final int EXCEPTION_BLOCK_TAG = JavadocCommentsLexer.EXCEPTION_BLOCK_TAG;
 
     /**
-     * {@code @since} block tag.
+     * {@code @since} Javadoc block tag.
+     *
+     * <p>Such Javadoc tag can have one child:</p>
+     * <ol>
+     *   <li>{@link #DESCRIPTION}</li>
+     * </ol>
+     *
+     * <p><b>Example:</b></p>
+     * <pre>{@code * @since 1.0}</pre>
+     *
+     * <b>Tree:</b>
+     * <pre>{@code
+     * JAVADOC_BLOCK_TAG -> JAVADOC_BLOCK_TAG
+     * `--SINCE_BLOCK_TAG -> SINCE_BLOCK_TAG
+     *    |--AT_SIGN -> @
+     *    |--TAG_NAME -> since
+     *    `--DESCRIPTION -> DESCRIPTION
+     *        `--TEXT ->  1.0
+     * }</pre>
+     *
+     * @see #JAVADOC_BLOCK_TAG
      */
     public static final int SINCE_BLOCK_TAG = JavadocCommentsLexer.SINCE_BLOCK_TAG;
 


### PR DESCRIPTION
## Description
This PR updates the Javadoc documentation for the `SINCE_BLOCK_TAG` token in `JavadocCommentsTokenTypes.java` to include comprehensive documentation with AST examples.

## Changes
- Added detailed Javadoc documentation for `SINCE_BLOCK_TAG`
- Included example usage: `* @since 1.0`
- Added complete AST tree structure showing token hierarchy
- Documented child tokens (DESCRIPTION)
- Follows the same format as other updated Javadoc token documentation
- Generated AST using latest Checkstyle snapshot (12.0.0-SNAPSHOT)

## Testing
- Verified AST structure matches actual output from Checkstyle
- No linting errors
- Documentation format is consistent with existing patterns

## Related Work
This continues the effort to improve Javadoc token type documentation, following the same pattern as other taqs.

## Checklist
-  Code follows existing style guidelines
- Documentation is accurate and complete
- No linting errors
-  Changes are properly tested