### PR TITLE
dependency: bump org.openrewrite.recipe:rewrite-migrate-java from 3.18.0 to 3.19.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -218,7 +218,7 @@
     <maven.compiler.plugin.version>3.14.1</maven.compiler.plugin.version>
     <checkstyle.skipCompileInputResources>true</checkstyle.skipCompileInputResources>
     <checkstyle.openrewrite.version>1.0.0-SNAPSHOT</checkstyle.openrewrite.version>
-    <rewrite-migrate-java.version>3.18.0</rewrite-migrate-java.version>
+    <rewrite-migrate-java.version>3.19.0</rewrite-migrate-java.version>
     <rewrite-static-analysis.version>2.19.0</rewrite-static-analysis.version>
     <java.version>17</java.version>
     <next.java.version>21</next.java.version>

--- a/src/it/java/com/google/checkstyle/test/base/AbstractIndentationTestSupport.java
+++ b/src/it/java/com/google/checkstyle/test/base/AbstractIndentationTestSupport.java
@@ -21,7 +21,6 @@ package com.google.checkstyle.test.base;
 
 import java.io.BufferedReader;
 import java.io.IOException;
-import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.ArrayList;
@@ -74,8 +73,7 @@ public abstract class AbstractIndentationTestSupport extends AbstractGoogleModul
             final int tabWidth)
                     throws IOException {
         final List<Integer> result = new ArrayList<>();
-        try (BufferedReader br = Files.newBufferedReader(
-                Path.of(aFileName), StandardCharsets.UTF_8)) {
+        try (BufferedReader br = Files.newBufferedReader(Path.of(aFileName))) {
             int lineNumber = 1;
             for (String line = br.readLine(); line != null; line = br.readLine()) {
                 final Matcher match = LINE_WITH_COMMENT_REGEX.matcher(line);

--- a/src/it/java/org/checkstyle/base/AbstractItModuleTestSupport.java
+++ b/src/it/java/org/checkstyle/base/AbstractItModuleTestSupport.java
@@ -614,8 +614,7 @@ public abstract class AbstractItModuleTestSupport extends AbstractPathTestSuppor
      */
     protected Integer[] getLinesWithWarn(String fileName) throws IOException {
         final List<Integer> result = new ArrayList<>();
-        try (BufferedReader br = Files.newBufferedReader(
-                Path.of(fileName), StandardCharsets.UTF_8)) {
+        try (BufferedReader br = Files.newBufferedReader(Path.of(fileName))) {
             int lineNumber = 1;
             while (true) {
                 final String line = br.readLine();

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/indentation/IndentationCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/indentation/IndentationCheckTest.java
@@ -27,7 +27,6 @@ import static com.puppycrawl.tools.checkstyle.checks.indentation.IndentationChec
 
 import java.io.BufferedReader;
 import java.io.IOException;
-import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.ArrayList;
@@ -62,8 +61,7 @@ public class IndentationCheckTest extends AbstractModuleTestSupport {
             final int tabWidth)
             throws IOException {
         final List<IndentComment> result = new ArrayList<>();
-        try (BufferedReader br = Files.newBufferedReader(Path.of(aFileName),
-                StandardCharsets.UTF_8)) {
+        try (BufferedReader br = Files.newBufferedReader(Path.of(aFileName))) {
             int lineNumber = 1;
             String line = br.readLine();
             IndentComment pendingBelowComment = null;


### PR DESCRIPTION

- https://github.com/checkstyle/checkstyle/pull/17899


```
[INFO] Running recipe(s)...
[INFO] Printing available datatables to: target/rewrite/datatables/2025-10-11_12-18-09-346
[WARNING] The recipe produced 6 warning(s). Please report this to the recipe author.
[INFO] Changes have been made to src/test/java/com/puppycrawl/tools/checkstyle/checks/indentation/IndentationCheckTest.java by:
[INFO]     tech.picnic.errorprone.refasterrules.FileRulesRecipes
[INFO]         tech.picnic.errorprone.refasterrules.FileRulesRecipes$FilesNewBufferedReaderPathOfRecipe
[INFO] Changes have been made to src/it/java/org/checkstyle/base/AbstractItModuleTestSupport.java by:
[INFO]     tech.picnic.errorprone.refasterrules.FileRulesRecipes
[INFO]         tech.picnic.errorprone.refasterrules.FileRulesRecipes$FilesNewBufferedReaderPathOfRecipe
[INFO] Changes have been made to src/it/java/com/google/checkstyle/test/base/AbstractIndentationTestSupport.java by:
[INFO]     tech.picnic.errorprone.refasterrules.FileRulesRecipes
[INFO]         tech.picnic.errorprone.refasterrules.FileRulesRecipes$FilesNewBufferedReaderPathOfRecipe
[INFO] Please review and commit the results.
[INFO] Estimate time saved: 15m
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  01:21 min
[INFO] Finished at: 2025-10-11T12:18:09+02:00
[INFO] ------------------------------------------------------------------------
```