### PR TITLE
Issue #17882: Update HIDDEN_BLOCK_TAG of JavadocCommentsTokenTypes to new AST format

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/api/JavadocCommentsTokenTypes.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/api/JavadocCommentsTokenTypes.java
@@ -182,7 +182,27 @@ public final class JavadocCommentsTokenTypes {
     public static final int SEE_BLOCK_TAG = JavadocCommentsLexer.SEE_BLOCK_TAG;
 
     /**
-     * {@code @hidden} block tag.
+     * {@code @hidden} Javadoc block tag.
+     *
+     * <p>Such Javadoc tag can have one child:</p>
+     * <ol>
+     *   <li>{@link #DESCRIPTION} – optional description text</li>
+     * </ol>
+     *
+     * <p><b>Example:</b></p>
+     * <pre>{@code * @hidden value}</pre>
+     *
+     * <b>Tree:</b>
+     * <pre>{@code
+     * JAVADOC_BLOCK_TAG -> JAVADOC_BLOCK_TAG
+     * `--HIDDEN_BLOCK_TAG -> HIDDEN_BLOCK_TAG
+     *     |--AT_SIGN -> @
+     *     |--TAG_NAME -> hidden
+     *     `--DESCRIPTION -> DESCRIPTION
+     *         `--TEXT ->  value
+     * }</pre>
+     *
+     * @see #JAVADOC_BLOCK_TAG
      */
     public static final int HIDDEN_BLOCK_TAG = JavadocCommentsLexer.HIDDEN_BLOCK_TAG;
 


### PR DESCRIPTION
Issue: #17882

This PR updates the Javadoc for `HIDDEN_BLOCK_TAG` in `JavadocCommentsTokenTypes.java` to show the new AST format generated by checkstyle 12.0.1-SNAPSHOT.

Command used:
```
java -jar checkstyle-12.0.1-SNAPSHOT-all.jar -j  src/Test.java | ForEach-Object { $_ -replace '\[[0-9]+:[0-9]+\]', '' }        
```

Example Input:
```java
/**
 * @hidden value
 */
public class HiddenEx {
}
```

AST Output:
```
JAVADOC_CONTENT -> JAVADOC_CONTENT 
|--TEXT -> /** 
|--NEWLINE -> \r\n 
|--LEADING_ASTERISK ->  * 
|--TEXT ->   
|--JAVADOC_BLOCK_TAG -> JAVADOC_BLOCK_TAG 
|   `--HIDDEN_BLOCK_TAG -> HIDDEN_BLOCK_TAG 
|       |--AT_SIGN -> @ 
|       |--TAG_NAME -> hidden 
|       `--DESCRIPTION -> DESCRIPTION 
|           |--TEXT ->  value 
|           |--NEWLINE -> \r\n 
|           |--LEADING_ASTERISK ->  * 
|           |--TEXT -> / 
|           |--NEWLINE -> \r\n 
|           |--TEXT -> public class HiddenEx { 
|           |--NEWLINE -> \r\n 
|           `--TEXT -> } 
`--NEWLINE -> \r\n 
```




