### PR TITLE
Issue #17910:  Remove suppressions for the ImportControlTest rule

### DIFF
--- a/config/import-control-test.xml
+++ b/config/import-control-test.xml
@@ -11,29 +11,37 @@
         |org\.checkstyle.*)"
         regex="true">
 
-  <!-- Disallow obsolete Junit API -->
+  <!-- Disallow obsolete JUnit API -->
   <disallow pkg="org.junit" exact-match="true"/>
   <disallow pkg="junit.framework" />
   <!-- Disallow hamcrest and only allow Truth -->
-  <disallow pkg="org.hamcrest.CoreMatchers"/>
-  <disallow pkg="org.hamcrest.MatcherAssert"/>
+  <disallow class="org\.hamcrest\.CoreMatchers.*" regex="true" />
+  <disallow class="org\.hamcrest\.MatcherAssert.*" regex="true" />
   <!-- Disallow @BeforeAll, see https://github.com/checkstyle/checkstyle/issues/12100 -->
   <disallow class="org.junit.jupiter.api.BeforeAll"/>
-  <!-- Disallow Junit assert in favor of Truth asserts in few exceptions -->
+  <!-- Disallow JUnit assertion in favor of Truth asserts in few exceptions -->
   <allow class="org.junit.jupiter.api.Assertions.assertDoesNotThrow"/>
-  <disallow pkg="org.junit.jupiter.api.Assertions"/>
+  <disallow class="org\.junit\.jupiter\.api\.Assertions.*" regex="true" />
 
   <!-- Reflection shouldn't be used in tests. -->
   <disallow pkg="java\.lang\.reflect\.*" regex="true" />
 
-  <!-- see reason at https://github.com/checkstyle/checkstyle/issues/11343 -->
-  <disallow pkg="org.junit.jupiter.api.Assertions.assertThrows"/>
-  <disallow pkg="org.junit.Assert.assertThrows"/>
-
   <allow pkg=".*" regex="true" />
 
-  <subpackage name="api">
+  <subpackage name="grammar">
+    <subpackage name="javadoc">
+      <file name="GeneratedJavadocCommentsTokenTypesTest">
+        <!-- Uses reflection to validate token numbering -->
+        <allow pkg="java.lang.reflect" />
+      </file>
+    </subpackage>
+
+    <file name="GeneratedJavaTokenTypesTest">
+      <!-- Uses reflection to validate token numbering -->
+      <allow pkg="java.lang.reflect" />
+    </file>
   </subpackage>
+
   <subpackage name="internal">
     <subpackage name="utils">
       <file name="CheckUtil">
@@ -43,18 +51,33 @@
       <file name="TestUtil">
         <!-- All reflection usage should be in this class. -->
         <allow pkg="java.lang.reflect" />
+        <!-- see reason at https://github.com/checkstyle/checkstyle/issues/11343 -->
         <allow class="org.junit.jupiter.api.Assertions.assertThrows" />
       </file>
     </subpackage>
+
+    <file name="AllChecksTest">
+      <!-- Uses reflection to collect all check messages. -->
+      <allow pkg="java.lang.reflect" />
+    </file>
+
+    <file name="XdocsPagesTest">
+      <!-- BeforeAll is used to create test resources on disk, which might be slow. -->
+      <allow class="org.junit.jupiter.api.BeforeAll" />
+      <!-- Uses reflection to validate properties. -->
+      <allow pkg="java.lang.reflect" />
+    </file>
   </subpackage>
 
-  <subpackage name="bdd">
-    <file name="InlineConfigParser">
-      <!-- Use reflection to count violation messages in a check. -->
-      <allow class="java.lang.reflect.Modifier" />
-      <!-- Use reflection to validate default in a check. -->
+  <subpackage name="utils" >
+    <file name="CommonUtilTest">
+      <!-- CommonUtil.getConstructor returns a Constructor, so the test needs this import too. -->
+      <allow class="java.lang.reflect.Constructor" />
+    </file>
+
+    <file name="TokenUtilTest">
+      <!-- TokenUtil's API uses Fields,  so the test needs it too -->
       <allow class="java.lang.reflect.Field" />
-      <allow class="java.lang.reflect.Method" />
     </file>
   </subpackage>
 
@@ -63,9 +86,8 @@
     <allow pkg="java.lang.reflect" />
   </file>
 
-  <file name="SarifLoggerTest">
-    <!-- Uses reflection to inject fake module metadata for exception testing. -->
-    <allow class="java.lang.reflect.Constructor" />
+  <file name="PackageObjectFactoryTest">
+    <!-- BeforeAll is used to set up the Locale, not Checkstyle classes. -->
+    <allow class="org.junit.jupiter.api.BeforeAll" />
   </file>
-
 </import-control>

--- a/config/suppressions.xml
+++ b/config/suppressions.xml
@@ -133,50 +133,6 @@
   <!-- until https://github.com/checkstyle/checkstyle/issues/5234 -->
   <suppress id="MatchXPathBranchContains" files="[\\/]DetailAstImplTest.java"/>
 
-  <!-- until https://github.com/checkstyle/checkstyle/issues/11123 -->
-  <suppress id="ImportControlTest"
-            files="[\\/]src[\\/]test[\\/]java[\\/]com[\\/]puppycrawl[\\/]tools[\\/]checkstyle[\\/]api[\\/]JavadocCommentsTokenTypesTest.java"/>
-  <suppress id="ImportControlTest"
-            files="[\\/]src[\\/]test[\\/]java[\\/]com[\\/]puppycrawl[\\/]tools[\\/]checkstyle[\\/]checks[\\/]coding[\\/]RequireThisCheckTest.java"/>
-  <suppress id="ImportControlTest"
-            files="[\\/]src[\\/]test[\\/]java[\\/]com[\\/]puppycrawl[\\/]tools[\\/]checkstyle[\\/]grammar[\\/]GeneratedJavaTokenTypesTest.java"/>
-  <suppress id="ImportControlTest"
-            files="[\\/]src[\\/]test[\\/]java[\\/]com[\\/]puppycrawl[\\/]tools[\\/]checkstyle[\\/]grammar[\\/]javadoc[\\/]GeneratedJavadocCommentsTokenTypesTest.java"/>
-  <suppress id="ImportControlTest"
-            files="[\\/]src[\\/]test[\\/]java[\\/]com[\\/]puppycrawl[\\/]tools[\\/]checkstyle[\\/]checks[\\/]imports[\\/]CustomImportOrderCheckTest.java"/>
-  <suppress id="ImportControlTest"
-            files="[\\/]src[\\/]test[\\/]java[\\/]com[\\/]puppycrawl[\\/]tools[\\/]checkstyle[\\/]checks[\\/]imports[\\/]ImportControlLoaderTest.java"/>
-  <suppress id="ImportControlTest"
-            files="[\\/]src[\\/]test[\\/]java[\\/]com[\\/]puppycrawl[\\/]tools[\\/]checkstyle[\\/]checks[\\/]javadoc[\\/]JavadocMethodCheckTest.java"/>
-  <suppress id="ImportControlTest"
-            files="[\\/]src[\\/]test[\\/]java[\\/]com[\\/]puppycrawl[\\/]tools[\\/]checkstyle[\\/]checks[\\/]javadoc[\\/]JavadocTagInfoTest.java"/>
-  <suppress id="ImportControlTest"
-            files="[\\/]src[\\/]test[\\/]java[\\/]com[\\/]puppycrawl[\\/]tools[\\/]checkstyle[\\/]checks[\\/]SuppressWarningsHolderTest.java"/>
-  <suppress id="ImportControlTest"
-            files="[\\/]src[\\/]test[\\/]java[\\/]com[\\/]puppycrawl[\\/]tools[\\/]checkstyle[\\/]checks[\\/]TranslationCheckTest.java"/>
-  <suppress id="ImportControlTest"
-            files="[\\/]src[\\/]test[\\/]java[\\/]com[\\/]puppycrawl[\\/]tools[\\/]checkstyle[\\/]checks[\\/]UniquePropertiesCheckTest.java"/>
-  <suppress id="ImportControlTest"
-            files="[\\/]src[\\/]test[\\/]java[\\/]com[\\/]puppycrawl[\\/]tools[\\/]checkstyle[\\/]internal[\\/]AllChecksTest.java"/>
-  <suppress id="ImportControlTest"
-            files="[\\/]src[\\/]test[\\/]java[\\/]com[\\/]puppycrawl[\\/]tools[\\/]checkstyle[\\/]internal[\\/]XdocsPagesTest.java"/>
-  <suppress id="ImportControlTest"
-            files="[\\/]src[\\/]test[\\/]java[\\/]com[\\/]puppycrawl[\\/]tools[\\/]checkstyle[\\/]utils[\\/]CommonUtilTest.java"/>
-  <suppress id="ImportControlTest"
-            files="[\\/]src[\\/]test[\\/]java[\\/]com[\\/]puppycrawl[\\/]tools[\\/]checkstyle[\\/]CheckerTest.java"/>
-  <suppress id="ImportControlTest"
-            files="[\\/]src[\\/]test[\\/]java[\\/]com[\\/]puppycrawl[\\/]tools[\\/]checkstyle[\\/]ConfigurationLoaderTest.java"/>
-  <suppress id="ImportControlTest"
-            files="[\\/]src[\\/]test[\\/]java[\\/]com[\\/]puppycrawl[\\/]tools[\\/]checkstyle[\\/]DefaultLoggerTest.java"/>
-  <suppress id="ImportControlTest"
-            files="[\\/]src[\\/]test[\\/]java[\\/]com[\\/]puppycrawl[\\/]tools[\\/]checkstyle[\\/]DetailAstImplTest.java"/>
-  <suppress id="ImportControlTest"
-            files="[\\/]src[\\/]test[\\/]java[\\/]com[\\/]puppycrawl[\\/]tools[\\/]checkstyle[\\/]MainTest.java"/>
-  <suppress id="ImportControlTest"
-            files="[\\/]src[\\/]test[\\/]java[\\/]com[\\/]puppycrawl[\\/]tools[\\/]checkstyle[\\/]PackageObjectFactoryTest.java"/>
-  <suppress id="ImportControlTest"
-            files="[\\/]src[\\/]test[\\/]java[\\/]com[\\/]puppycrawl[\\/]tools[\\/]checkstyle[\\/]utils[\\/]TokenUtilTest.java"/>
-
   <!-- required by JavaAstVisitor design -->
   <suppress checks="MethodCount"
             files="[\\/]src[\\/]main[\\/]java[\\/]com[\\/]puppycrawl[\\/]tools[\\/]checkstyle[\\/]JavaAstVisitor.java"/>
@@ -184,7 +140,7 @@
             files="[\\/]src[\\/]main[\\/]java[\\/]com[\\/]puppycrawl[\\/]tools[\\/]checkstyle[\\/]JavaAstVisitor.java"/>
   <suppress checks="ClassFanOutComplexity"
             files="[\\/]src[\\/]main[\\/]java[\\/]com[\\/]puppycrawl[\\/]tools[\\/]checkstyle[\\/]JavaAstVisitor.java"/>
-  
+
   <!-- required by JavadocCommentsAstVisitor design -->
   <suppress checks="MethodCount"
             files="[\\/]src[\\/]main[\\/]java[\\/]com[\\/]puppycrawl[\\/]tools[\\/]checkstyle[\\/]JavadocCommentsAstVisitor.java"/>

--- a/src/test/java/com/puppycrawl/tools/checkstyle/CheckerTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/CheckerTest.java
@@ -39,8 +39,6 @@ import java.io.LineNumberReader;
 import java.io.OutputStream;
 import java.io.Serial;
 import java.io.UnsupportedEncodingException;
-import java.lang.reflect.Field;
-import java.lang.reflect.Method;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.util.ArrayList;
@@ -114,18 +112,14 @@ public class CheckerTest extends AbstractModuleTestSupport {
         return Files.createFile(temporaryFolder.toPath().resolve(name)).toFile();
     }
 
-    private static Method getFireAuditFinished() throws NoSuchMethodException {
-        final Class<Checker> checkerClass = Checker.class;
-        final Method fireAuditFinished = checkerClass.getDeclaredMethod("fireAuditFinished");
-        fireAuditFinished.setAccessible(true);
-        return fireAuditFinished;
+    private static void invokeFireAuditFinished(Checker checker)
+            throws ReflectiveOperationException {
+        TestUtil.invokeMethod(checker, "fireAuditFinished");
     }
 
-    private static Method getFireAuditStartedMethod() throws NoSuchMethodException {
-        final Class<Checker> checkerClass = Checker.class;
-        final Method fireAuditStarted = checkerClass.getDeclaredMethod("fireAuditStarted");
-        fireAuditStarted.setAccessible(true);
-        return fireAuditStarted;
+    private static void invokeFireAuditStartedMethod(Checker checker)
+            throws ReflectiveOperationException {
+        TestUtil.invokeMethod(checker, "fireAuditStarted");
     }
 
     @Override
@@ -184,7 +178,7 @@ public class CheckerTest extends AbstractModuleTestSupport {
         checker.addListener(auditAdapter);
 
         // Let's try fire some events
-        getFireAuditStartedMethod().invoke(checker);
+        invokeFireAuditStartedMethod(checker);
         assertWithMessage("Checker.fireAuditStarted() doesn't call listener")
                 .that(auditAdapter.wasCalled())
                 .isTrue();
@@ -193,7 +187,7 @@ public class CheckerTest extends AbstractModuleTestSupport {
                 .isTrue();
 
         auditAdapter.resetListener();
-        getFireAuditFinished().invoke(checker);
+        invokeFireAuditFinished(checker);
         assertWithMessage("Checker.fireAuditFinished() doesn't call listener")
                 .that(auditAdapter.wasCalled())
                 .isTrue();
@@ -242,7 +236,7 @@ public class CheckerTest extends AbstractModuleTestSupport {
         checker.removeListener(auditAdapter);
 
         // Let's try fire some events
-        getFireAuditStartedMethod().invoke(checker);
+        invokeFireAuditStartedMethod(checker);
         assertWithMessage("Checker.fireAuditStarted() doesn't call listener")
                 .that(aa2.wasCalled())
                 .isTrue();
@@ -251,7 +245,7 @@ public class CheckerTest extends AbstractModuleTestSupport {
                 .isFalse();
 
         aa2.resetListener();
-        getFireAuditFinished().invoke(checker);
+        invokeFireAuditFinished(checker);
         assertWithMessage("Checker.fireAuditFinished() doesn't call listener")
                 .that(aa2.wasCalled())
                 .isTrue();
@@ -525,9 +519,8 @@ public class CheckerTest extends AbstractModuleTestSupport {
             .that(context.get("basedir"))
             .isEqualTo("testBaseDir");
 
-        final Field sLocale = LocalizedMessage.class.getDeclaredField("sLocale");
-        sLocale.setAccessible(true);
-        final Locale locale = (Locale) sLocale.get(null);
+        final Locale locale =
+                TestUtil.getInternalStaticState(LocalizedMessage.class, "sLocale", Locale.class);
         assertWithMessage("Locale is set to unexpected value")
             .that(locale)
             .isEqualTo(Locale.ITALY);

--- a/src/test/java/com/puppycrawl/tools/checkstyle/ConfigurationLoaderTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/ConfigurationLoaderTest.java
@@ -20,15 +20,10 @@
 package com.puppycrawl.tools.checkstyle;
 
 import static com.google.common.truth.Truth.assertWithMessage;
-import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.Mockito.mockConstruction;
 import static org.mockito.Mockito.when;
 
 import java.io.File;
-import java.lang.reflect.Constructor;
-import java.lang.reflect.Field;
-import java.lang.reflect.InvocationTargetException;
-import java.lang.reflect.Method;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.ArrayList;
@@ -70,32 +65,27 @@ public class ConfigurationLoaderTest extends AbstractPathTestSupport {
 
     private static Object getInternalLoaderInstance(PropertyResolver resolver)
              throws Exception {
-        final Constructor<ConfigurationLoader> constructor = ConfigurationLoader.class
-                .getDeclaredConstructor(PropertyResolver.class, boolean.class,
-                        ThreadModeSettings.class);
-        constructor.setAccessible(true);
-        final ConfigurationLoader loader = constructor.newInstance(resolver, false,
-                ThreadModeSettings.SINGLE_THREAD_MODE_INSTANCE);
 
-        final Field saxHandlerField = ConfigurationLoader.class.getDeclaredField("saxHandler");
-        saxHandlerField.setAccessible(true);
-        return saxHandlerField.get(loader);
+        final ConfigurationLoader loader = TestUtil.instantiate(ConfigurationLoader.class,
+                resolver, false, ThreadModeSettings.SINGLE_THREAD_MODE_INSTANCE);
+
+        return TestUtil.getInternalState(loader, "saxHandler", Object.class);
     }
 
-    private static Method getReplacePropertiesMethod(Class<?> internalLoaderClass)
-            throws NoSuchMethodException {
-        final Class<?>[] params = {String.class, String.class};
-        final Method method = internalLoaderClass.getDeclaredMethod("replaceProperties", params);
-        method.setAccessible(true);
-        return method;
+    private static String invokeReplacePropertiesMethod(
+            Object internalLoader, String value, String defaultValue)
+            throws ReflectiveOperationException {
+        return TestUtil.invokeMethod(internalLoader, "replaceProperties", value, defaultValue);
     }
 
-    private static Method getParsePropertyStringMethod(Class<?> internalLoaderClass)
-            throws NoSuchMethodException {
-        final Class<?>[] params = {String.class, Collection.class, Collection.class};
-        final Method method = internalLoaderClass.getDeclaredMethod("parsePropertyString", params);
-        method.setAccessible(true);
-        return method;
+    private static void invokeParsePropertyStringMethod(
+            Object internalLoader,
+            String value,
+            Collection<String> fragments,
+            Collection<String> propertyRefs)
+            throws ReflectiveOperationException {
+        TestUtil.invokeMethod(
+                internalLoader, "parsePropertyString", value, fragments, propertyRefs);
     }
 
     @Test
@@ -104,11 +94,9 @@ public class ConfigurationLoaderTest extends AbstractPathTestSupport {
                                      "{a}", "a}", "$a}", "$", "a$b", };
         final Properties props = initProperties();
         final Object internalLoader = getInternalLoaderInstance(new PropertiesExpander(props));
-        final Class<?> internalLoaderClass = internalLoader.getClass();
-        final Method method = getReplacePropertiesMethod(internalLoaderClass);
 
         for (String testValue : testValues) {
-            final String value = (String) method.invoke(internalLoader, testValue, null);
+            final String value = invokeReplacePropertiesMethod(internalLoader, testValue, null);
             assertWithMessage("\"" + testValue + "\"")
                 .that(testValue)
                 .isEqualTo(value);
@@ -119,14 +107,12 @@ public class ConfigurationLoaderTest extends AbstractPathTestSupport {
     public void testReplacePropertiesSyntaxError() throws Exception {
         final Properties props = initProperties();
         final Object internalLoader = getInternalLoaderInstance(new PropertiesExpander(props));
-        final Class<?> internalLoaderClass = internalLoader.getClass();
-        final Method method = getReplacePropertiesMethod(internalLoaderClass);
 
         try {
-            final String value = (String) method.invoke(internalLoader, "${a", null);
+            final String value = invokeReplacePropertiesMethod(internalLoader, "${a", null);
             assertWithMessage("expected to fail, instead got: " + value).fail();
         }
-        catch (InvocationTargetException exc) {
+        catch (ReflectiveOperationException exc) {
             assertWithMessage("Invalid exception cause message")
                 .that(exc.getCause())
                 .isInstanceOf(CheckstyleException.class);
@@ -140,14 +126,12 @@ public class ConfigurationLoaderTest extends AbstractPathTestSupport {
     public void testReplacePropertiesMissingProperty() throws Exception {
         final Properties props = initProperties();
         final Object internalLoader = getInternalLoaderInstance(new PropertiesExpander(props));
-        final Class<?> internalLoaderClass = internalLoader.getClass();
-        final Method method = getReplacePropertiesMethod(internalLoaderClass);
 
         try {
-            final String value = (String) method.invoke(internalLoader, "${c}", null);
+            final String value = invokeReplacePropertiesMethod(internalLoader, "${c}", null);
             assertWithMessage("expected to fail, instead got: " + value).fail();
         }
-        catch (InvocationTargetException exc) {
+        catch (ReflectiveOperationException exc) {
             assertWithMessage("Invalid exception cause message")
                 .that(exc.getCause())
                 .isInstanceOf(CheckstyleException.class);
@@ -175,11 +159,9 @@ public class ConfigurationLoaderTest extends AbstractPathTestSupport {
         };
         final Properties props = initProperties();
         final Object internalLoader = getInternalLoaderInstance(new PropertiesExpander(props));
-        final Class<?> internalLoaderClass = internalLoader.getClass();
-        final Method method = getReplacePropertiesMethod(internalLoaderClass);
 
         for (String[] testValue : testValues) {
-            final String value = (String) method.invoke(internalLoader, testValue[0], null);
+            final String value = invokeReplacePropertiesMethod(internalLoader, testValue[0], null);
             assertWithMessage("\"" + testValue[0] + "\"")
                 .that(value)
                 .isEqualTo(testValue[1]);
@@ -191,11 +173,10 @@ public class ConfigurationLoaderTest extends AbstractPathTestSupport {
         final Properties props = new Properties();
         final String defaultValue = "defaultValue";
         final Object internalLoader = getInternalLoaderInstance(new PropertiesExpander(props));
-        final Class<?> internalLoaderClass = internalLoader.getClass();
-        final Method method = getReplacePropertiesMethod(internalLoaderClass);
 
-        final String value = (String) method.invoke(
-            internalLoader, "${checkstyle.basedir}", defaultValue);
+        final String value =
+                invokeReplacePropertiesMethod(
+                        internalLoader, "${checkstyle.basedir}", defaultValue);
 
         assertWithMessage("Invalid property value")
             .that(value)
@@ -206,13 +187,11 @@ public class ConfigurationLoaderTest extends AbstractPathTestSupport {
     public void testParsePropertyString() throws Exception {
         final Properties props = initProperties();
         final Object internalLoader = getInternalLoaderInstance(new PropertiesExpander(props));
-        final Class<?> internalLoaderClass = internalLoader.getClass();
-        final Method method = getParsePropertyStringMethod(internalLoaderClass);
 
         final List<String> propertyRefs = new ArrayList<>();
         final List<String> fragments = new ArrayList<>();
 
-        method.invoke(internalLoader, "$", fragments, propertyRefs);
+        invokeParsePropertyStringMethod(internalLoader, "$", fragments, propertyRefs);
         assertWithMessage("Fragments list has unexpected amount of items")
             .that(fragments)
             .hasSize(1);
@@ -570,17 +549,11 @@ public class ConfigurationLoaderTest extends AbstractPathTestSupport {
     @Test
     public void testIncorrectTag() throws Exception {
         final Class<?> aClassParent = ConfigurationLoader.class;
-        final Constructor<?> ctorParent = aClassParent.getDeclaredConstructor(
-                PropertyResolver.class, boolean.class, ThreadModeSettings.class);
-        ctorParent.setAccessible(true);
-        final Object objParent = ctorParent.newInstance(null, true, null);
+        final Object objParent = TestUtil.instantiate(aClassParent, null, true, null);
 
         final Class<?> aClass = Class.forName("com.puppycrawl.tools.checkstyle."
                 + "ConfigurationLoader$InternalLoader");
-        final Constructor<?> constructor = aClass.getDeclaredConstructor(objParent.getClass());
-        constructor.setAccessible(true);
-
-        final Object obj = constructor.newInstance(objParent);
+        final Object obj = TestUtil.instantiate(aClass, objParent);
 
         try {
             TestUtil.invokeMethod(obj, "startElement", "", "", "hello", null);
@@ -757,11 +730,13 @@ public class ConfigurationLoaderTest extends AbstractPathTestSupport {
                     when(mock.getName()).thenReturn("MemberName");
                     when(mock.getProperty("severity")).thenThrow(CheckstyleException.class);
                 })) {
-            final CheckstyleException ex = assertThrows(CheckstyleException.class, () -> {
-                ConfigurationLoader.loadConfiguration(
-                        getPath("InputConfigurationLoaderModuleIgnoreSeverity.xml"),
-                        new PropertiesExpander(new Properties()), IgnoredModulesOptions.OMIT);
-            });
+            final CheckstyleException ex =
+                    TestUtil.getExpectedThrowable(CheckstyleException.class, () -> {
+                        ConfigurationLoader.loadConfiguration(
+                                getPath("InputConfigurationLoaderModuleIgnoreSeverity.xml"),
+                                new PropertiesExpander(
+                                        new Properties()), IgnoredModulesOptions.OMIT);
+                    });
             final String expectedMessage =
                 "Problem during accessing 'severity' attribute for MemberName";
             assertWithMessage("Invalid exception cause message")

--- a/src/test/java/com/puppycrawl/tools/checkstyle/DefaultLoggerTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/DefaultLoggerTest.java
@@ -20,7 +20,6 @@
 package com.puppycrawl.tools.checkstyle;
 
 import static com.google.common.truth.Truth.assertWithMessage;
-import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assumptions.assumeFalse;
 
 import java.io.ByteArrayOutputStream;
@@ -187,9 +186,10 @@ public class DefaultLoggerTest extends AbstractModuleTestSupport {
     @Test
     public void testNullInfoStreamOptions() {
         final ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
-        final IllegalArgumentException ex = assertThrows(IllegalArgumentException.class,
-                () -> new DefaultLogger(outputStream, (OutputStreamOptions) null),
-                "IllegalArgumentException expected");
+        final IllegalArgumentException ex =
+                TestUtil.getExpectedThrowable(IllegalArgumentException.class,
+                        () -> new DefaultLogger(outputStream, (OutputStreamOptions) null),
+                        "IllegalArgumentException expected");
         assertWithMessage("Invalid error message")
                 .that(ex)
                 .hasMessageThat()
@@ -199,8 +199,8 @@ public class DefaultLoggerTest extends AbstractModuleTestSupport {
     @Test
     public void testNullErrorStreamOptions() {
         final ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
-        final IllegalArgumentException ex = assertThrows(IllegalArgumentException.class,
-                () -> {
+        final IllegalArgumentException ex =
+                TestUtil.getExpectedThrowable(IllegalArgumentException.class, () -> {
                     final DefaultLogger defaultLogger = new DefaultLogger(outputStream,
                             OutputStreamOptions.CLOSE, outputStream, null);
 

--- a/src/test/java/com/puppycrawl/tools/checkstyle/DetailAstImplTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/DetailAstImplTest.java
@@ -23,7 +23,6 @@ import static com.google.common.truth.Truth.assertWithMessage;
 
 import java.io.File;
 import java.io.Writer;
-import java.lang.reflect.Method;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.text.MessageFormat;
@@ -70,12 +69,9 @@ public class DetailAstImplTest extends AbstractModuleTestSupport {
         return "com/puppycrawl/tools/checkstyle/api/detailast";
     }
 
-    private static Method getSetParentMethod() throws Exception {
-        final Class<DetailAstImpl> detailAstClass = DetailAstImpl.class;
-        final Method setParentMethod =
-            detailAstClass.getDeclaredMethod("setParent", DetailAstImpl.class);
-        setParentMethod.setAccessible(true);
-        return setParentMethod;
+    private static void invokeSetParentMethod(DetailAST instance, DetailAstImpl parent)
+            throws Exception {
+        TestUtil.invokeMethod(instance, "setParent", parent);
     }
 
     @Test
@@ -139,14 +135,13 @@ public class DetailAstImplTest extends AbstractModuleTestSupport {
 
         root.setFirstChild(firstLevelA);
 
-        final Method setParentMethod = getSetParentMethod();
-        setParentMethod.invoke(firstLevelA, root);
+        invokeSetParentMethod(firstLevelA, root);
         firstLevelA.setFirstChild(secondLevelA);
         firstLevelA.setNextSibling(firstLevelB);
 
-        setParentMethod.invoke(firstLevelB, root);
+        invokeSetParentMethod(firstLevelB, root);
 
-        setParentMethod.invoke(secondLevelA, root);
+        invokeSetParentMethod(secondLevelA, root);
 
         assertWithMessage("Invalid child count")
             .that(secondLevelA.getChildCount())
@@ -200,14 +195,13 @@ public class DetailAstImplTest extends AbstractModuleTestSupport {
 
         root.setFirstChild(firstLevelA);
 
-        final Method setParentMethod = getSetParentMethod();
-        setParentMethod.invoke(firstLevelA, root);
+        invokeSetParentMethod(firstLevelA, root);
         firstLevelA.setNextSibling(firstLevelB);
 
         firstLevelA.setType(TokenTypes.IDENT);
         firstLevelB.setType(TokenTypes.EXPR);
 
-        setParentMethod.invoke(firstLevelB, root);
+        invokeSetParentMethod(firstLevelB, root);
 
         final int childCountLevelB = firstLevelB.getChildCount(0);
         assertWithMessage("Invalid child count")
@@ -242,7 +236,7 @@ public class DetailAstImplTest extends AbstractModuleTestSupport {
             .that(root.getChildCount())
             .isEqualTo(1);
 
-        getSetParentMethod().invoke(firstLevelA, root);
+        invokeSetParentMethod(firstLevelA, root);
         firstLevelA.addPreviousSibling(null);
         firstLevelA.addNextSibling(null);
 
@@ -331,22 +325,21 @@ public class DetailAstImplTest extends AbstractModuleTestSupport {
             .isEqualTo(0);
 
         root.setFirstChild(firstLevelA);
-        final Method setParentMethod = getSetParentMethod();
-        setParentMethod.invoke(firstLevelA, root);
+        invokeSetParentMethod(firstLevelA, root);
 
         assertWithMessage("Invalid child count")
             .that(root.getChildCount())
             .isEqualTo(1);
 
         firstLevelA.addNextSibling(firstLevelB);
-        setParentMethod.invoke(firstLevelB, root);
+        invokeSetParentMethod(firstLevelB, root);
 
         assertWithMessage("Invalid next sibling")
             .that(firstLevelA.getNextSibling())
             .isEqualTo(firstLevelB);
 
         firstLevelA.addNextSibling(firstLevelC);
-        setParentMethod.invoke(firstLevelC, root);
+        invokeSetParentMethod(firstLevelC, root);
 
         assertWithMessage("Invalid next sibling")
             .that(firstLevelA.getNextSibling())

--- a/src/test/java/com/puppycrawl/tools/checkstyle/IndentationTrailingCommentsVerticalAlignmentTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/IndentationTrailingCommentsVerticalAlignmentTest.java
@@ -19,6 +19,8 @@
 
 package com.puppycrawl.tools.checkstyle;
 
+import static com.google.common.truth.Truth.assertWithMessage;
+
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -26,7 +28,6 @@ import java.util.List;
 import java.util.Set;
 import java.util.stream.Stream;
 
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Assumptions;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
@@ -97,9 +98,9 @@ class IndentationTrailingCommentsVerticalAlignmentTest {
                         expectedStartIndex = actualStartIndex;
                     }
                     else {
-                        Assertions.assertEquals(expectedStartIndex, actualStartIndex,
-                            "Trailing comment alignment mismatch in file: "
-                                + testFile + " on line " + (idx + 1));
+                        assertWithMessage("Trailing comment alignment mismatch in file: "
+                                + testFile + " on line " + (idx + 1))
+                                .that(actualStartIndex).isEqualTo(expectedStartIndex);
                     }
                 }
             }
@@ -121,7 +122,7 @@ class IndentationTrailingCommentsVerticalAlignmentTest {
                 );
         }
         catch (IOException exception) {
-            Assertions.fail("Failed to find indentation test files", exception);
+            assertWithMessage("Failed to find indentation test files").fail();
             testFiles = Stream.empty();
         }
         return testFiles;

--- a/src/test/java/com/puppycrawl/tools/checkstyle/JavaAstVisitorTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/JavaAstVisitorTest.java
@@ -20,6 +20,7 @@
 package com.puppycrawl.tools.checkstyle;
 
 import static com.google.common.truth.Truth.assertWithMessage;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 
 import java.io.File;
 import java.io.IOException;
@@ -236,13 +237,10 @@ public class JavaAstVisitorTest extends AbstractModuleTestSupport {
     }
 
     @Test
-    public void testNullSelfInAddLastSibling() throws Exception {
-        final Method addLastSibling = JavaAstVisitor.class
-                .getDeclaredMethod("addLastSibling", DetailAstImpl.class, DetailAstImpl.class);
-        addLastSibling.setAccessible(true);
-        assertWithMessage("Method should not throw exception.")
-                .that(addLastSibling.invoke(JavaAstVisitor.class, null, null))
-                .isNull();
+    public void testNullSelfInAddLastSibling() {
+        assertDoesNotThrow(() -> {
+            TestUtil.invokeStaticMethod(JavaAstVisitor.class, "addLastSibling", null, null);
+        }, "Method should not throw exception.");
     }
     /**
      * This test exists to kill surviving mutation from pitest removing expression AST building

--- a/src/test/java/com/puppycrawl/tools/checkstyle/MainTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/MainTest.java
@@ -33,7 +33,6 @@ import java.io.File;
 import java.io.IOException;
 import java.io.PrintStream;
 import java.io.Serial;
-import java.lang.reflect.Method;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -812,13 +811,9 @@ public class MainTest {
 
     @Test
     public void testLoadPropertiesIoException() throws Exception {
-        final Class<?>[] param = new Class<?>[1];
-        param[0] = File.class;
         final Class<?> cliOptionsClass = Class.forName(Main.class.getName());
-        final Method method = cliOptionsClass.getDeclaredMethod("loadProperties", param);
-        method.setAccessible(true);
         try {
-            method.invoke(null, new File("."));
+            TestUtil.invokeStaticMethod(cliOptionsClass, "loadProperties", new File("."));
             assertWithMessage("Exception was expected").fail();
         }
         catch (ReflectiveOperationException exc) {
@@ -1833,17 +1828,14 @@ public class MainTest {
             .isEqualTo("");
     }
 
-    @SuppressWarnings("unchecked")
     @Test
     public void testExcludeDirectoryNotMatch() throws Exception {
         final Class<?> optionsClass = Class.forName(Main.class.getName());
-        final Method method = optionsClass.getDeclaredMethod("listFiles", File.class, List.class);
-        method.setAccessible(true);
         final List<Pattern> list = new ArrayList<>();
         list.add(Pattern.compile("BAD_PATH"));
 
-        final List<File> result = (List<File>) method.invoke(null, new File(getFilePath("")),
-                list);
+        final List<File> result = TestUtil.invokeStaticMethod(
+                optionsClass, "listFiles", new File(getFilePath("")), list);
         assertWithMessage("Invalid result size")
             .that(result)
             .isNotEmpty();

--- a/src/test/java/com/puppycrawl/tools/checkstyle/SarifLoggerTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/SarifLoggerTest.java
@@ -26,7 +26,6 @@ import java.io.IOException;
 import java.io.OutputStream;
 import java.io.PrintWriter;
 import java.io.Serial;
-import java.lang.reflect.Constructor;
 import java.nio.charset.StandardCharsets;
 import java.util.Map;
 
@@ -477,10 +476,8 @@ public class SarifLoggerTest extends AbstractModuleTestSupport {
         final Map<Object, ModuleDetails> ruleMetadata =
                 TestUtil.getInternalState(logger, "ruleMetadata", Map.class);
         final Class<?> ruleKeyClass = TestUtil.getInnerClassType(SarifLogger.class, "RuleKey");
-        final Constructor<?> constructor =
-                ruleKeyClass.getDeclaredConstructor(String.class, String.class);
-        constructor.setAccessible(true);
-        final Object ruleKey = constructor.newInstance("com.fake.NonExistentCheck", null);
+        final Object ruleKey =
+                TestUtil.instantiate(ruleKeyClass, "com.fake.NonExistentCheck", null);
         ruleMetadata.put(ruleKey, fakeModule);
 
         logger.auditFinished(null);
@@ -508,11 +505,9 @@ public class SarifLoggerTest extends AbstractModuleTestSupport {
         final Map<Object, ModuleDetails> ruleMetadata =
                 TestUtil.getInternalState(logger, "ruleMetadata", Map.class);
         final Class<?> ruleKeyClass = TestUtil.getInnerClassType(SarifLogger.class, "RuleKey");
-        final Constructor<?> constructor =
-                ruleKeyClass.getDeclaredConstructor(String.class, String.class);
-        constructor.setAccessible(true);
-        final Object ruleKey = constructor.newInstance(
-                "com.puppycrawl.tools.checkstyle.SarifLoggerTest", null);
+        final Object ruleKey =
+                TestUtil.instantiate(ruleKeyClass,
+                        "com.puppycrawl.tools.checkstyle.SarifLoggerTest", null);
         ruleMetadata.put(ruleKey, fakeModule);
 
         logger.auditFinished(null);

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/SuppressWarningsHolderTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/SuppressWarningsHolderTest.java
@@ -24,8 +24,6 @@ import static com.puppycrawl.tools.checkstyle.checks.coding.UnusedLocalVariableC
 import static com.puppycrawl.tools.checkstyle.checks.sizes.LineLengthCheck.MSG_KEY;
 
 import java.io.File;
-import java.lang.reflect.Constructor;
-import java.lang.reflect.Method;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -283,11 +281,8 @@ public class SuppressWarningsHolderTest extends AbstractModuleTestSupport {
     }
 
     @Test
-    public void testGetAllAnnotationValuesWrongArg() throws ReflectiveOperationException {
+    public void testGetAllAnnotationValuesWrongArg() {
         final SuppressWarningsHolder holder = new SuppressWarningsHolder();
-        final Method getAllAnnotationValues = holder.getClass()
-                .getDeclaredMethod("getAllAnnotationValues", DetailAST.class);
-        getAllAnnotationValues.setAccessible(true);
 
         final DetailAstImpl methodDef = new DetailAstImpl();
         methodDef.setType(TokenTypes.METHOD_DEF);
@@ -303,7 +298,7 @@ public class SuppressWarningsHolderTest extends AbstractModuleTestSupport {
         parent.addChild(methodDef);
 
         try {
-            getAllAnnotationValues.invoke(holder, parent);
+            TestUtil.invokeMethod(holder, "getAllAnnotationValues", parent);
             assertWithMessage("Exception expected").fail();
         }
         catch (ReflectiveOperationException exc) {
@@ -320,11 +315,8 @@ public class SuppressWarningsHolderTest extends AbstractModuleTestSupport {
     }
 
     @Test
-    public void testGetAnnotationValuesWrongArg() throws ReflectiveOperationException {
+    public void testGetAnnotationValuesWrongArg() {
         final SuppressWarningsHolder holder = new SuppressWarningsHolder();
-        final Method getAllAnnotationValues = holder.getClass()
-                .getDeclaredMethod("getAnnotationValues", DetailAST.class);
-        getAllAnnotationValues.setAccessible(true);
 
         final DetailAstImpl methodDef = new DetailAstImpl();
         methodDef.setType(TokenTypes.METHOD_DEF);
@@ -333,7 +325,7 @@ public class SuppressWarningsHolderTest extends AbstractModuleTestSupport {
         methodDef.setColumnNo(0);
 
         try {
-            getAllAnnotationValues.invoke(holder, methodDef);
+            TestUtil.invokeMethod(holder, "getAnnotationValues", methodDef);
             assertWithMessage("Exception expected").fail();
         }
         catch (ReflectiveOperationException exc) {
@@ -351,11 +343,8 @@ public class SuppressWarningsHolderTest extends AbstractModuleTestSupport {
     }
 
     @Test
-    public void testGetAnnotationTargetWrongArg() throws ReflectiveOperationException {
+    public void testGetAnnotationTargetWrongArg() {
         final SuppressWarningsHolder holder = new SuppressWarningsHolder();
-        final Method getAnnotationTarget = holder.getClass()
-                .getDeclaredMethod("getAnnotationTarget", DetailAST.class);
-        getAnnotationTarget.setAccessible(true);
 
         final DetailAstImpl methodDef = new DetailAstImpl();
         methodDef.setType(TokenTypes.METHOD_DEF);
@@ -369,7 +358,7 @@ public class SuppressWarningsHolderTest extends AbstractModuleTestSupport {
         parent.setColumnNo(0);
 
         try {
-            getAnnotationTarget.invoke(holder, methodDef);
+            TestUtil.invokeMethod(holder, "getAnnotationTarget", methodDef);
             assertWithMessage("Exception expected").fail();
         }
         catch (ReflectiveOperationException exc) {
@@ -442,11 +431,8 @@ public class SuppressWarningsHolderTest extends AbstractModuleTestSupport {
                                                          int lastColumn) throws Exception {
         final Class<?> entry = Class
                 .forName("com.puppycrawl.tools.checkstyle.checks.SuppressWarningsHolder$Entry");
-        final Constructor<?> entryConstr = entry.getDeclaredConstructor(String.class, int.class,
-                int.class, int.class, int.class);
-        entryConstr.setAccessible(true);
 
-        final Object entryInstance = entryConstr.newInstance(checkName, firstLine,
+        final Object entryInstance = TestUtil.instantiate(entry, checkName, firstLine,
                 firstColumn, lastLine, lastColumn);
 
         final ThreadLocal<List<Object>> entries = TestUtil

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/TranslationCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/TranslationCheckTest.java
@@ -27,7 +27,6 @@ import java.io.ByteArrayOutputStream;
 import java.io.File;
 import java.io.IOException;
 import java.io.Writer;
-import java.lang.reflect.Field;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.util.Collections;
@@ -141,11 +140,9 @@ public class TranslationCheckTest extends AbstractXmlTestSupport {
         check.beginProcessing(charset);
         check.processFiltered(fileToProcess, new FileText(fileToProcess, charset));
         check.beginProcessing(charset);
-        final Field field = check.getClass().getDeclaredField("filesToProcess");
-        field.setAccessible(true);
 
         assertWithMessage("Stateful field is not cleared on beginProcessing")
-                .that((Iterable<?>) field.get(check))
+                .that(TestUtil.getInternalState(check, "filesToProcess", Iterable.class))
                 .isEmpty();
     }
 

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/coding/RequireThisCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/coding/RequireThisCheckTest.java
@@ -24,7 +24,6 @@ import static com.puppycrawl.tools.checkstyle.checks.coding.RequireThisCheck.MSG
 import static com.puppycrawl.tools.checkstyle.checks.coding.RequireThisCheck.MSG_VARIABLE;
 
 import java.io.File;
-import java.lang.reflect.Constructor;
 import java.util.Collection;
 import java.util.Optional;
 import java.util.SortedSet;
@@ -522,9 +521,7 @@ public class RequireThisCheckTest extends AbstractModuleTestSupport {
         ident.setText("testName");
 
         final Class<?> cls = Class.forName(RequireThisCheck.class.getName() + "$CatchFrame");
-        final Constructor<?> constructor = cls.getDeclaredConstructors()[0];
-        constructor.setAccessible(true);
-        final Object o = constructor.newInstance(null, ident);
+        final Object o = TestUtil.instantiate(cls, null, ident);
 
         final DetailAstImpl actual = TestUtil.invokeMethod(o, "getFrameNameIdent");
         assertWithMessage("expected ident token")
@@ -547,9 +544,7 @@ public class RequireThisCheckTest extends AbstractModuleTestSupport {
         ident.setText("testName");
 
         final Class<?> cls = Class.forName(RequireThisCheck.class.getName() + "$ForFrame");
-        final Constructor<?> constructor = cls.getDeclaredConstructors()[0];
-        constructor.setAccessible(true);
-        final Object o = constructor.newInstance(null, ident);
+        final Object o = TestUtil.instantiate(cls, null, ident);
 
         assertWithMessage("expected for frame type")
             .that(TestUtil.invokeMethod(o, "getType").toString())

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/header/MultiFileRegexpHeaderCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/header/MultiFileRegexpHeaderCheckTest.java
@@ -22,7 +22,9 @@ package com.puppycrawl.tools.checkstyle.checks.header;
 import static com.google.common.truth.Truth.assertWithMessage;
 import static com.puppycrawl.tools.checkstyle.checks.header.MultiFileRegexpHeaderCheck.MSG_HEADER_MISMATCH;
 import static com.puppycrawl.tools.checkstyle.checks.header.MultiFileRegexpHeaderCheck.MSG_HEADER_MISSING;
+import static com.puppycrawl.tools.checkstyle.internal.utils.TestUtil.getExpectedThrowable;
 import static com.puppycrawl.tools.checkstyle.utils.CommonUtil.EMPTY_STRING_ARRAY;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 
 import java.io.File;
 import java.io.IOException;
@@ -33,7 +35,6 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Set;
 
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 
@@ -508,12 +509,12 @@ public class MultiFileRegexpHeaderCheckTest extends AbstractModuleTestSupport {
         final MultiFileRegexpHeaderCheck check = new MultiFileRegexpHeaderCheck();
         final String headerFile = "UnExisted file";
         final IllegalArgumentException thrown =
-                Assertions.assertThrows(IllegalArgumentException.class, () -> {
+                getExpectedThrowable(IllegalArgumentException.class, () -> {
                     check.setHeaderFiles(headerFile);
                 });
-        Assertions.assertEquals("Error reading or corrupted header file: "
-                + headerFile, thrown.getMessage(),
-                "Exception message did not match for invalid file name.");
+        assertWithMessage("Exception message did not match for invalid file name.")
+                .that(thrown.getMessage())
+                .isEqualTo("Error reading or corrupted header file: " + headerFile);
     }
 
     @Test
@@ -846,18 +847,18 @@ public class MultiFileRegexpHeaderCheckTest extends AbstractModuleTestSupport {
         final MultiFileRegexpHeaderCheck check = new MultiFileRegexpHeaderCheck();
 
         final IllegalArgumentException thrown =
-                Assertions.assertThrows(IllegalArgumentException.class, () -> {
+                getExpectedThrowable(IllegalArgumentException.class, () -> {
                     check.setHeaderFiles((String) null);
                 });
-        Assertions.assertEquals("Header file is not set", thrown.getMessage(),
-                "Exception message mismatch for null header path");
+        assertWithMessage("Exception message mismatch for null header path")
+                .that(thrown.getMessage()).isEqualTo("Header file is not set");
     }
 
     @Test
     public void testSetHeaderFilesWithNullVarargsArray() {
         final MultiFileRegexpHeaderCheck check = new MultiFileRegexpHeaderCheck();
 
-        Assertions.assertDoesNotThrow(() -> {
+        assertDoesNotThrow(() -> {
             check.setHeaderFiles((String[]) null);
         });
 

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/imports/CustomImportOrderCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/imports/CustomImportOrderCheckTest.java
@@ -28,7 +28,6 @@ import static com.puppycrawl.tools.checkstyle.checks.imports.CustomImportOrderCh
 import static com.puppycrawl.tools.checkstyle.checks.imports.CustomImportOrderCheck.MSG_SEPARATED_IN_GROUP;
 
 import java.io.File;
-import java.lang.reflect.Method;
 
 import org.junit.jupiter.api.Test;
 
@@ -36,8 +35,8 @@ import com.puppycrawl.tools.checkstyle.AbstractModuleTestSupport;
 import com.puppycrawl.tools.checkstyle.Checker;
 import com.puppycrawl.tools.checkstyle.DefaultConfiguration;
 import com.puppycrawl.tools.checkstyle.api.CheckstyleException;
-import com.puppycrawl.tools.checkstyle.api.DetailAST;
 import com.puppycrawl.tools.checkstyle.api.TokenTypes;
+import com.puppycrawl.tools.checkstyle.internal.utils.TestUtil;
 import com.puppycrawl.tools.checkstyle.utils.CommonUtil;
 
 public class CustomImportOrderCheckTest extends AbstractModuleTestSupport {
@@ -413,10 +412,8 @@ public class CustomImportOrderCheckTest extends AbstractModuleTestSupport {
     // which is a candidate for utility method in the future
     public void testGetFullImportIdent() throws Exception {
         final Class<?> clazz = CustomImportOrderCheck.class;
-        final Object t = clazz.getConstructor().newInstance();
-        final Method method = clazz.getDeclaredMethod("getFullImportIdent", DetailAST.class);
-        method.setAccessible(true);
-        final Object actual = method.invoke(t, new Object[] {null});
+        final Object t = TestUtil.instantiate(clazz);
+        final Object actual = TestUtil.invokeMethod(t, "getFullImportIdent", new Object[] {null});
 
         final String expected = "";
         assertWithMessage("Invalid getFullImportIdent result")

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/imports/ImportControlLoaderTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/imports/ImportControlLoaderTest.java
@@ -20,7 +20,7 @@
 package com.puppycrawl.tools.checkstyle.checks.imports;
 
 import static com.google.common.truth.Truth.assertWithMessage;
-import static org.junit.jupiter.api.Assertions.assertThrows;
+import static com.puppycrawl.tools.checkstyle.internal.utils.TestUtil.getExpectedThrowable;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
@@ -28,19 +28,18 @@ import static org.mockito.Mockito.when;
 import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
-import java.lang.reflect.Method;
 import java.net.MalformedURLException;
 import java.net.URI;
 import java.net.URL;
 
 import org.junit.jupiter.api.Test;
-import org.xml.sax.Attributes;
 import org.xml.sax.InputSource;
 import org.xml.sax.SAXException;
 import org.xml.sax.SAXParseException;
 import org.xml.sax.helpers.AttributesImpl;
 
 import com.puppycrawl.tools.checkstyle.api.CheckstyleException;
+import com.puppycrawl.tools.checkstyle.internal.utils.TestUtil;
 
 public class ImportControlLoaderTest {
 
@@ -99,10 +98,7 @@ public class ImportControlLoaderTest {
             };
         try {
             final Class<?> clazz = ImportControlLoader.class;
-            final Method privateMethod = clazz.getDeclaredMethod("safeGet",
-                Attributes.class, String.class);
-            privateMethod.setAccessible(true);
-            privateMethod.invoke(null, attr, "you_cannot_find_me");
+            TestUtil.invokeStaticMethod(clazz, "safeGet", attr, "you_cannot_find_me");
             assertWithMessage("exception expected").fail();
         }
         catch (ReflectiveOperationException exc) {
@@ -125,10 +121,7 @@ public class ImportControlLoaderTest {
         final InputSource source = new InputSource();
         try {
             final Class<?> clazz = ImportControlLoader.class;
-            final Method privateMethod = clazz.getDeclaredMethod("load", InputSource.class,
-                URI.class);
-            privateMethod.setAccessible(true);
-            privateMethod.invoke(null, source,
+            TestUtil.invokeStaticMethod(clazz, "load", source,
                     new File(getPath("InputImportControlLoaderComplete.xml")).toURI());
             assertWithMessage("exception expected").fail();
         }
@@ -153,7 +146,7 @@ public class ImportControlLoaderTest {
             final URI uri = mock();
             when(uri.toURL()).thenReturn(url);
 
-            final CheckstyleException ex = assertThrows(CheckstyleException.class, () -> {
+            final CheckstyleException ex = getExpectedThrowable(CheckstyleException.class, () -> {
                 ImportControlLoader.load(uri);
             });
             assertWithMessage("Invalid exception class")

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocTagInfoTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocTagInfoTest.java
@@ -21,12 +21,11 @@ package com.puppycrawl.tools.checkstyle.checks.javadoc;
 
 import static com.google.common.truth.Truth.assertWithMessage;
 
-import java.lang.reflect.Method;
-
 import org.junit.jupiter.api.Test;
 
 import com.puppycrawl.tools.checkstyle.DetailAstImpl;
 import com.puppycrawl.tools.checkstyle.api.TokenTypes;
+import com.puppycrawl.tools.checkstyle.internal.utils.TestUtil;
 
 public class JavadocTagInfoTest {
 
@@ -111,10 +110,7 @@ public class JavadocTagInfoTest {
             astParent.setType(TokenTypes.LITERAL_CATCH);
 
             final DetailAstImpl ast = new DetailAstImpl();
-            final Method setParent = ast.getClass().getDeclaredMethod("setParent",
-                    DetailAstImpl.class);
-            setParent.setAccessible(true);
-            setParent.invoke(ast, astParent);
+            TestUtil.invokeMethod(ast, "setParent", astParent);
 
             final int[] validTypes = {
                 TokenTypes.PACKAGE_DEF,
@@ -151,9 +147,7 @@ public class JavadocTagInfoTest {
         final DetailAstImpl ast = new DetailAstImpl();
         final DetailAstImpl astParent = new DetailAstImpl();
         astParent.setType(TokenTypes.LITERAL_CATCH);
-        final Method setParent = ast.getClass().getDeclaredMethod("setParent", DetailAstImpl.class);
-        setParent.setAccessible(true);
-        setParent.invoke(ast, astParent);
+        TestUtil.invokeMethod(ast, "setParent", astParent);
 
         final int[] validTypes = {
             TokenTypes.CLASS_DEF,
@@ -190,9 +184,7 @@ public class JavadocTagInfoTest {
         final DetailAstImpl ast = new DetailAstImpl();
         final DetailAstImpl astParent = new DetailAstImpl();
         astParent.setType(TokenTypes.LITERAL_CATCH);
-        final Method setParent = ast.getClass().getDeclaredMethod("setParent", DetailAstImpl.class);
-        setParent.setAccessible(true);
-        setParent.invoke(ast, astParent);
+        TestUtil.invokeMethod(ast, "setParent", astParent);
 
         final int[] validTypes = {
             TokenTypes.VARIABLE_DEF,

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/naming/ParameterNameCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/naming/ParameterNameCheckTest.java
@@ -187,7 +187,7 @@ public class ParameterNameCheckTest
     }
 
     @Test
-    public void testSetAccessModifiers() throws Exception {
+    public void testSetAccessModifiers() {
         final AccessModifierOption[] input = {
             AccessModifierOption.PACKAGE,
         };
@@ -196,8 +196,8 @@ public class ParameterNameCheckTest
 
         assertWithMessage("check creates its own instance of access modifier array")
             .that(System.identityHashCode(
-                TestUtil.getClassDeclaredField(ParameterNameCheck.class, "accessModifiers")
-                        .get(check)))
+                    TestUtil.getInternalState(
+                            check, "accessModifiers", AccessModifierOption[].class)))
             .isNotEqualTo(System.identityHashCode(input));
     }
 

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/sizes/RecordComponentNumberCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/sizes/RecordComponentNumberCheckTest.java
@@ -186,11 +186,9 @@ public class RecordComponentNumberCheckTest extends AbstractModuleTestSupport {
      * the array and is not re-using and possible overwriting the one given to
      * it. Without this, pitest says {@code Arrays.copyOf} is not needed, but it
      * is needed for other style checks.
-     *
-     * @throws Exception if an error occurs.
      */
     @Test
-    public void testCloneInAccessModifiersProperty() throws Exception {
+    public void testCloneInAccessModifiersProperty() {
         final AccessModifierOption[] input = {
             AccessModifierOption.PACKAGE,
         };
@@ -199,8 +197,8 @@ public class RecordComponentNumberCheckTest extends AbstractModuleTestSupport {
 
         assertWithMessage("check creates its own instance of access modifier array")
             .that(System.identityHashCode(
-                TestUtil.getClassDeclaredField(RecordComponentNumberCheck.class, "accessModifiers")
-                        .get(check)))
+                    TestUtil.getInternalState(
+                            check, "accessModifiers", AccessModifierOption[].class)))
             .isNotEqualTo(System.identityHashCode(input));
     }
 

--- a/src/test/java/com/puppycrawl/tools/checkstyle/grammar/java21/Java21AstRegressionTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/grammar/java21/Java21AstRegressionTest.java
@@ -20,7 +20,7 @@
 package com.puppycrawl.tools.checkstyle.grammar.java21;
 
 import static com.google.common.truth.Truth.assertWithMessage;
-import static org.junit.Assert.assertThrows;
+import static com.puppycrawl.tools.checkstyle.internal.utils.TestUtil.getExpectedThrowable;
 
 import java.io.File;
 
@@ -78,9 +78,9 @@ public class Java21AstRegressionTest extends AbstractTreeTestSupport {
                 new File(getPath("InputTextBlockParsingFail.java.fail"));
 
         final Throwable throwable =
-                assertThrows("Exception should be thrown due to parsing failure.",
-                        CheckstyleException.class,
-                        () -> JavaParser.parseFile(file, JavaParser.Options.WITHOUT_COMMENTS)
+                getExpectedThrowable(CheckstyleException.class,
+                        () -> JavaParser.parseFile(file, JavaParser.Options.WITHOUT_COMMENTS),
+                        "Exception should be thrown due to parsing failure."
                 );
 
         final String incorrectThrowableCauseMessage =

--- a/src/test/java/com/puppycrawl/tools/checkstyle/internal/AllChecksTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/internal/AllChecksTest.java
@@ -296,8 +296,7 @@ public class AllChecksTest extends AbstractModuleTestSupport {
     public void testDefaultTokensAreSubsetOfAcceptableTokens() throws Exception {
         for (Class<?> check : CheckUtil.getCheckstyleChecks()) {
             if (AbstractCheck.class.isAssignableFrom(check)) {
-                final AbstractCheck testedCheck = (AbstractCheck) check.getDeclaredConstructor()
-                        .newInstance();
+                final AbstractCheck testedCheck = (AbstractCheck) TestUtil.instantiate(check);
                 final int[] defaultTokens = testedCheck.getDefaultTokens();
                 final int[] acceptableTokens = testedCheck.getAcceptableTokens();
 
@@ -313,8 +312,7 @@ public class AllChecksTest extends AbstractModuleTestSupport {
     public void testRequiredTokensAreSubsetOfAcceptableTokens() throws Exception {
         for (Class<?> check : CheckUtil.getCheckstyleChecks()) {
             if (AbstractCheck.class.isAssignableFrom(check)) {
-                final AbstractCheck testedCheck = (AbstractCheck) check.getDeclaredConstructor()
-                        .newInstance();
+                final AbstractCheck testedCheck = (AbstractCheck) TestUtil.instantiate(check);
                 final int[] requiredTokens = testedCheck.getRequiredTokens();
                 final int[] acceptableTokens = testedCheck.getAcceptableTokens();
 
@@ -330,8 +328,7 @@ public class AllChecksTest extends AbstractModuleTestSupport {
     public void testRequiredTokensAreSubsetOfDefaultTokens() throws Exception {
         for (Class<?> check : CheckUtil.getCheckstyleChecks()) {
             if (AbstractCheck.class.isAssignableFrom(check)) {
-                final AbstractCheck testedCheck = (AbstractCheck) check.getDeclaredConstructor()
-                        .newInstance();
+                final AbstractCheck testedCheck = (AbstractCheck) TestUtil.instantiate(check);
                 final int[] defaultTokens = testedCheck.getDefaultTokens();
                 final int[] requiredTokens = testedCheck.getRequiredTokens();
 

--- a/src/test/java/com/puppycrawl/tools/checkstyle/internal/XdocsExampleFileTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/internal/XdocsExampleFileTest.java
@@ -19,6 +19,8 @@
 
 package com.puppycrawl.tools.checkstyle.internal;
 
+import static com.google.common.truth.Truth.assertWithMessage;
+
 import java.beans.PropertyDescriptor;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -29,7 +31,6 @@ import java.util.Set;
 import java.util.stream.Collectors;
 
 import org.apache.commons.beanutils.PropertyUtils;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 import com.puppycrawl.tools.checkstyle.internal.utils.CheckUtil;
@@ -117,7 +118,8 @@ public class XdocsExampleFileTest {
             }
         }
         if (!failures.isEmpty()) {
-            Assertions.fail("Xdocs are missing properties:\n" + String.join("\n", failures));
+            assertWithMessage("Xdocs are missing properties:\n" + String.join("\n", failures))
+                    .fail();
         }
     }
 }

--- a/src/test/java/com/puppycrawl/tools/checkstyle/internal/utils/TestUtil.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/internal/utils/TestUtil.java
@@ -31,12 +31,14 @@ import java.util.Collection;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.Callable;
 import java.util.concurrent.FutureTask;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Predicate;
+import java.util.function.Supplier;
 import java.util.regex.Pattern;
 import java.util.stream.Stream;
 
@@ -91,8 +93,8 @@ public final class TestUtil {
      * @param fieldName the name of the field to retrieve
      * @return the class' field if found
      */
-    public static Field getClassDeclaredField(Class<?> clss, String fieldName) {
-        return Stream.<Class<?>>iterate(clss, Class::getSuperclass)
+    private static Field getClassDeclaredField(Class<?> clss, String fieldName) {
+        return Stream.<Class<?>>iterate(clss, Objects::nonNull, Class::getSuperclass)
             .flatMap(cls -> Arrays.stream(cls.getDeclaredFields()))
             .filter(field -> fieldName.equals(field.getName()))
             .findFirst()
@@ -114,23 +116,45 @@ public final class TestUtil {
      * @param parameters the expected number of parameters
      * @return the class' method
      */
-    public static Method getClassDeclaredMethod(Class<?> clss, String methodName, int parameters) {
-        return Stream.<Class<?>>iterate(clss, Class::getSuperclass)
-            .flatMap(cls -> Arrays.stream(cls.getDeclaredMethods()))
-            .filter(method -> {
-                return methodName.equals(method.getName())
-                    && parameters == method.getParameterCount();
-            })
-            .findFirst()
-            .map(method -> {
-                method.setAccessible(true);
-                return method;
-            })
-            .orElseThrow(() -> {
-                return new IllegalStateException(String.format(Locale.ROOT,
-                        "Method '%s' with %d parameters not found in '%s'",
-                        methodName, parameters, clss.getCanonicalName()));
-            });
+    private static Method getClassDeclaredMethod(Class<?> clss,
+                                                 String methodName,
+                                                 int parameters) {
+        final Stream<Method> methods = Stream.<Class<?>>iterate(clss, Class::getSuperclass)
+                .flatMap(cls -> Arrays.stream(cls.getDeclaredMethods()))
+                .filter(method -> {
+                    return methodName.equals(method.getName());
+                });
+
+        final Supplier<String> exceptionMessage = () -> {
+            return String.format(Locale.ROOT, "Method '%s' with %d parameters not found in '%s'",
+                    methodName, parameters, clss.getCanonicalName());
+        };
+
+        return getMatchingExecutable(methods, parameters, exceptionMessage);
+    }
+
+    /**
+     * Retrieves the specified executable from a class.
+     *
+     * @param <T> the type of executable to search
+     * @param execs The stream of executables to search
+     * @param parameters the expected number of parameters
+     * @param exceptionMessage the exception message to use if executable is not found
+     * @return the matching executable
+     */
+    private static <T extends java.lang.reflect.Executable> T getMatchingExecutable(
+            Stream<T> execs, int parameters, Supplier<String> exceptionMessage) {
+        return execs.filter(method -> {
+            return parameters == method.getParameterCount();
+        })
+        .findFirst()
+        .map(method -> {
+            method.setAccessible(true);
+            return method;
+        })
+        .orElseThrow(() -> {
+            return new IllegalStateException(exceptionMessage.get());
+        });
     }
 
     /**
@@ -491,6 +515,35 @@ public final class TestUtil {
             String methodToExecute, Object... arguments) throws ReflectiveOperationException {
         final Method method = getClassDeclaredMethod(clss, methodToExecute, arguments.length);
         return (T) method.invoke(null, arguments);
+    }
+
+    /**
+     * Instantiates an object of the given class with the given arguments,
+     * even if the constructor is private.
+     *
+     * @param clss The class to instantiate
+     * @param arguments The arguments to pass to the constructor
+     * @param <T> the type of the object to instantiate
+     * @return  The instantiated object
+     * @throws ReflectiveOperationException if the constructor invocation failed
+     */
+    @SuppressWarnings("unchecked")
+    public static <T> T instantiate(Class<T> clss, Object... arguments)
+            throws ReflectiveOperationException {
+
+        final Stream<Constructor<T>> ctors =
+                Arrays.stream(clss.getDeclaredConstructors()).map(Constructor.class::cast);
+
+        final Supplier<String> exceptionMessage = () -> {
+            return String.format(Locale.ROOT, "Constructor with %d parameters not found in '%s'",
+                    arguments.length, clss.getCanonicalName());
+        };
+
+        final Constructor<T> constructor =
+                getMatchingExecutable(ctors, arguments.length, exceptionMessage);
+        constructor.setAccessible(true);
+
+        return constructor.newInstance(arguments);
     }
 
     /**

--- a/src/test/java/com/puppycrawl/tools/checkstyle/utils/AnnotationUtilTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/utils/AnnotationUtilTest.java
@@ -21,7 +21,7 @@ package com.puppycrawl.tools.checkstyle.utils;
 
 import static com.google.common.truth.Truth.assertWithMessage;
 import static com.puppycrawl.tools.checkstyle.checks.annotation.SuppressWarningsCheck.MSG_KEY_SUPPRESSED_WARNING_NOT_ALLOWED;
-import static com.puppycrawl.tools.checkstyle.internal.utils.TestUtil.isUtilsClassHasPrivateConstructor;
+import static com.puppycrawl.tools.checkstyle.internal.utils.TestUtil.instantiate;
 
 import java.util.Set;
 
@@ -43,7 +43,7 @@ public class AnnotationUtilTest extends AbstractModuleTestSupport {
     @Test
     public void testIsProperUtilsClass() {
         try {
-            isUtilsClassHasPrivateConstructor(AnnotationUtil.class);
+            instantiate(AnnotationUtil.class);
             assertWithMessage("Exception is expected").fail();
         }
         catch (ReflectiveOperationException exc) {

--- a/src/test/java/com/puppycrawl/tools/checkstyle/utils/CommonUtilTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/utils/CommonUtilTest.java
@@ -21,8 +21,8 @@ package com.puppycrawl.tools.checkstyle.utils;
 
 import static com.google.common.truth.Truth.assertThat;
 import static com.google.common.truth.Truth.assertWithMessage;
+import static com.puppycrawl.tools.checkstyle.internal.utils.TestUtil.getExpectedThrowable;
 import static com.puppycrawl.tools.checkstyle.internal.utils.TestUtil.isUtilsClassHasPrivateConstructor;
-import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.Mockito.CALLS_REAL_METHODS;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.mockStatic;
@@ -119,9 +119,10 @@ public class CommonUtilTest extends AbstractPathTestSupport {
 
     @Test
     public void testBadRegex() {
-        final IllegalArgumentException ex = assertThrows(IllegalArgumentException.class, () -> {
-            CommonUtil.createPattern("[");
-        });
+        final IllegalArgumentException ex =
+                getExpectedThrowable(IllegalArgumentException.class, () -> {
+                    CommonUtil.createPattern("[");
+                });
         assertWithMessage("Invalid exception message")
                 .that(ex)
                 .hasMessageThat()
@@ -130,9 +131,10 @@ public class CommonUtilTest extends AbstractPathTestSupport {
 
     @Test
     public void testBadRegex2() {
-        final IllegalArgumentException ex = assertThrows(IllegalArgumentException.class, () -> {
-            CommonUtil.createPattern("[", Pattern.MULTILINE);
-        });
+        final IllegalArgumentException ex =
+                getExpectedThrowable(IllegalArgumentException.class, () -> {
+                    CommonUtil.createPattern("[", Pattern.MULTILINE);
+                });
         assertWithMessage("Invalid exception message")
                 .that(ex)
                 .hasMessageThat()
@@ -258,7 +260,7 @@ public class CommonUtilTest extends AbstractPathTestSupport {
 
     @Test
     public void testGetNonExistentConstructor() {
-        final IllegalStateException ex = assertThrows(IllegalStateException.class, () -> {
+        final IllegalStateException ex = getExpectedThrowable(IllegalStateException.class, () -> {
             CommonUtil.getConstructor(Math.class);
         });
         assertWithMessage("Invalid exception cause")
@@ -282,7 +284,7 @@ public class CommonUtilTest extends AbstractPathTestSupport {
     @Test
     public void testInvokeConstructorThatFails() throws NoSuchMethodException {
         final Constructor<Dictionary> constructor = Dictionary.class.getConstructor();
-        final IllegalStateException ex = assertThrows(IllegalStateException.class, () -> {
+        final IllegalStateException ex = getExpectedThrowable(IllegalStateException.class, () -> {
             CommonUtil.invokeConstructor(constructor);
         });
         assertWithMessage("Invalid exception cause")
@@ -305,7 +307,7 @@ public class CommonUtilTest extends AbstractPathTestSupport {
 
     @Test
     public void testCloseWithException() {
-        final IllegalStateException ex = assertThrows(IllegalStateException.class, () -> {
+        final IllegalStateException ex = getExpectedThrowable(IllegalStateException.class, () -> {
             CommonUtil.close(() -> {
                 throw new IOException("Test IOException");
             });
@@ -586,7 +588,7 @@ public class CommonUtilTest extends AbstractPathTestSupport {
             utilities.when(() -> CommonUtil.getCheckstyleResource(fileName))
                     .thenReturn(configUrl);
 
-            final CheckstyleException ex = assertThrows(CheckstyleException.class, () -> {
+            final CheckstyleException ex = getExpectedThrowable(CheckstyleException.class, () -> {
                 CommonUtil.getUriByFilename(fileName);
             });
             assertWithMessage("Invalid exception cause")


### PR DESCRIPTION
The `ImprotControlTest` rule should govern which imports aren't (and are) allowed in test files. However, for many tests, this rule is suppressed, so the configuration is not adhered to, leading to classes that aren't supposed to be used in tests.

This PR aims to address this issue.
It removes these suppressions, and where needed, replaces them with finer-grained "allow" entries in `import-control-test.xml`.

This PR addresses the following concerns:

**Usage of reflection**
- As per the guidelines of #11123, tests that use reflection to either introspect on the internal (private) state of an object, or execute some method/constructor that should be private, were rewritten to use the utilities from `TestUtil` that provide this functionality, so there's a clear (or at least, clearer) separation of responsibilities.
- Tests that use reflection to assert the existence/order/values of Checkstyle classes were explicitly called out with `<allow>` entries in `import-control-test.xml`. There may be room for additional improvement here in the future, but it is out of scope for this PR.
- Tests that test Checkstyle APIs that have `java.lang.reflect` parameters or return values were explicitly allowed to import those classes with `<allow>` entries.

**Usage of JUnit**
- `assertThrows` assertions were replaced with `TestUtil. getExpectedThrowable`, as per #11343 
- All JUnit assertions other than `assertDoesNotThrow` were written with Truth assertions instead of JUnit assertions.
- The `import-control-test.xml` syntax for disallowing JUnit and Hamcrest assertions was fixed.

Fixes #17910