### PR TITLE
Issue #17882: Update USES_BLOCK_TAG of JavadocCommentsTokenTypes.java to new AST format

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/api/JavadocCommentsTokenTypes.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/api/JavadocCommentsTokenTypes.java
@@ -229,7 +229,30 @@ public final class JavadocCommentsTokenTypes {
     public static final int HIDDEN_BLOCK_TAG = JavadocCommentsLexer.HIDDEN_BLOCK_TAG;
 
     /**
-     * {@code @uses} block tag.
+     * {@code @uses} Javadoc block tag.
+     *
+     * <p>Such Javadoc tag can have one child:</p>
+     * <ol>
+     *   <li>{@link #IDENTIFIER} – the referenced service type</li>
+     * </ol>
+     *
+     * <p><b>Example:</b></p>
+     * <pre>{@code * @uses com.example.app.MyService}</pre>
+     *
+     * <b>Tree:</b>
+     * <pre>{@code
+     * JAVADOC_CONTENT -> JAVADOC_CONTENT
+     * |--LEADING_ASTERISK -> *
+     * |--TEXT ->
+     * `--JAVADOC_BLOCK_TAG -> JAVADOC_BLOCK_TAG
+     *     `--USES_BLOCK_TAG -> USES_BLOCK_TAG
+     *         |--AT_SIGN -> @
+     *         |--TAG_NAME -> uses
+     *         |--TEXT ->
+     *         `--IDENTIFIER -> com.example.app.MyService
+     * }</pre>
+     *
+     * @see #JAVADOC_BLOCK_TAG
      */
     public static final int USES_BLOCK_TAG = JavadocCommentsLexer.USES_BLOCK_TAG;
 


### PR DESCRIPTION
Issue https://github.com/checkstyle/checkstyle/issues/17882

### Test file
```
* @uses com.example.app.MyService
```

### AST output
```
JAVADOC_CONTENT -> JAVADOC_CONTENT 
|--LEADING_ASTERISK -> * 
|--TEXT ->   
`--JAVADOC_BLOCK_TAG -> JAVADOC_BLOCK_TAG 
    `--USES_BLOCK_TAG -> USES_BLOCK_TAG 
        |--AT_SIGN -> @ 
        |--TAG_NAME -> uses 
        |--TEXT ->   
        `--IDENTIFIER -> com.example.app.MyService 
```