### PR TITLE
Issue #10086:Fix default AtclauseOrder and preserve order for documen…

### DIFF
--- a/config/checker-framework-suppressions/checker-nullness-optional-interning-suppressions.xml
+++ b/config/checker-framework-suppressions/checker-nullness-optional-interning-suppressions.xml
@@ -9118,11 +9118,16 @@
   <checkerFrameworkError unstable="false">
     <fileName>src/main/java/com/puppycrawl/tools/checkstyle/site/SiteUtil.java</fileName>
     <specifier>type.arguments.not.inferred</specifier>
-    <message>Could not infer type arguments for Stream.map</message>
-    <lineContent>.map(Pattern.class::cast)</lineContent>
+    <message>Could not infer type arguments for Stream.collect</message>
+    <lineContent>.collect(Collectors.toCollection(ArrayList&lt;String&gt;::new));</lineContent>
     <details>
-      unsatisfiable constraint: capture extends @Initialized @Nullable Object &lt;: @Initialized @PolyNull Object
-      Pattern.class::cast -&gt; inference type: java.util.function.Function&lt;? super capture of ?,? extends R&gt;
+      unsatisfiable constraint: @Initialized @PolyNull String &lt;: @Initialized @NonNull String
+      @Initialized @NonNull String = use of T from Collectors.toCollection(ArrayList&lt;String&gt;::new)
+      From complementary bound.: @Initialized @NonNull String &lt;= use of T from Collectors.toCollection(ArrayList&lt;String&gt;::new)
+      @Initialized @NonNull ArrayList&lt;@Initialized @NonNull String&gt; &lt;: inference type: java.util.Collection&lt;T&gt;
+      @Initialized @NonNull ArrayList&lt;@Initialized @NonNull String&gt; &lt;: use of C from Collectors.toCollection(ArrayList&lt;String&gt;::new)
+      From complementary bound.: @Initialized @NonNull ArrayList&lt;@Initialized @NonNull String&gt; -&gt; use of C from Collectors.toCollection(ArrayList&lt;String&gt;::new)
+      ArrayList&lt;String&gt;::new -&gt; inference type: java.util.function.Supplier&lt;C&gt;
       From: Argument constraint
     </details>
   </checkerFrameworkError>
@@ -9131,10 +9136,10 @@
     <fileName>src/main/java/com/puppycrawl/tools/checkstyle/site/SiteUtil.java</fileName>
     <specifier>type.arguments.not.inferred</specifier>
     <message>Could not infer type arguments for Stream.map</message>
-    <lineContent>.map(String.class::cast)</lineContent>
+    <lineContent>.map(Pattern.class::cast)</lineContent>
     <details>
       unsatisfiable constraint: capture extends @Initialized @Nullable Object &lt;: @Initialized @PolyNull Object
-      String.class::cast -&gt; inference type: java.util.function.Function&lt;? super capture of ?,? extends R&gt;
+      Pattern.class::cast -&gt; inference type: java.util.function.Function&lt;? super capture of ?,? extends R&gt;
       From: Argument constraint
     </details>
   </checkerFrameworkError>

--- a/config/import-control.xml
+++ b/config/import-control.xml
@@ -103,6 +103,7 @@
     <allow class="com.puppycrawl.tools.checkstyle.PackageObjectFactory" local-only="true"/>
     <allow class="com.puppycrawl.tools.checkstyle.meta.JavadocMetadataScraperUtil"
            local-only="true"/>
+    <allow class="com.puppycrawl.tools.checkstyle.internal.annotation.PreserveOrder"/>
     <allow class="com.puppycrawl.tools.checkstyle.utils.CommonUtil" local-only="true"/>
     <allow class="com.puppycrawl.tools.checkstyle.utils.BlockCommentPosition" local-only="true"/>
     <allow class="com.puppycrawl.tools.checkstyle.utils.CheckUtil" local-only="true"/>
@@ -187,6 +188,7 @@
     <allow class="com.puppycrawl.tools.checkstyle.StatelessCheck"/>
     <allow class="com.puppycrawl.tools.checkstyle.FileStatefulCheck"/>
     <allow class="com.puppycrawl.tools.checkstyle.GlobalStatefulCheck"/>
+    <allow class="com.puppycrawl.tools.checkstyle.internal.annotation.PreserveOrder"/>
 
     <file name="TranslationCheck">
       <allow class="com.puppycrawl.tools.checkstyle.LocalizedMessage"/>
@@ -216,6 +218,12 @@
         <allow pkg="net.sf.saxon"/>
         <allow pkg="com.puppycrawl.tools.checkstyle.xpath"/>
       </file>
+    </subpackage>
+  </subpackage>
+
+  <subpackage name="internal">
+    <subpackage name="annotation">
+      <allow pkg="java.lang"/>
     </subpackage>
   </subpackage>
 

--- a/pom.xml
+++ b/pom.xml
@@ -3263,6 +3263,7 @@
               </mutators>
               <targetClasses>
                 <param>com.puppycrawl.tools.checkstyle.checks.ArrayTypeStyleCheck*</param>
+                <param>com.puppycrawl.tools.checkstyle.internal.annotation.*</param>
                 <param>
                   com.puppycrawl.tools.checkstyle.checks.AvoidEscapedUnicodeCharactersCheck*
                 </param>

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/AtclauseOrderCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/AtclauseOrderCheck.java
@@ -30,6 +30,7 @@ import com.puppycrawl.tools.checkstyle.api.DetailAST;
 import com.puppycrawl.tools.checkstyle.api.DetailNode;
 import com.puppycrawl.tools.checkstyle.api.JavadocCommentsTokenTypes;
 import com.puppycrawl.tools.checkstyle.api.TokenTypes;
+import com.puppycrawl.tools.checkstyle.internal.annotation.PreserveOrder;
 import com.puppycrawl.tools.checkstyle.utils.JavadocUtil;
 import com.puppycrawl.tools.checkstyle.utils.TokenUtil;
 
@@ -84,7 +85,12 @@ public class AtclauseOrderCheck extends AbstractJavadocCheck {
 
     /**
      * Specify the order by tags.
+     * Default value is
+     * {@literal @}author, {@literal @}version, {@literal @}param, {@literal @}return,
+     * {@literal @}throws, {@literal @}exception, {@literal @}see, {@literal @}since,
+     * {@literal @}serial, {@literal @}serialField, {@literal @}serialData, {@literal @}deprecated.
      */
+    @PreserveOrder
     private List<String> tagOrder = Arrays.asList(DEFAULT_ORDER);
 
     /**

--- a/src/main/java/com/puppycrawl/tools/checkstyle/internal/annotation/PreserveOrder.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/internal/annotation/PreserveOrder.java
@@ -1,0 +1,38 @@
+///////////////////////////////////////////////////////////////////////////////////////////////
+// checkstyle: Checks Java source code and other text files for adherence to a set of rules.
+// Copyright (C) 2001-2025 the original author or authors.
+//
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the GNU Lesser General Public
+// License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+//
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+// Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public
+// License along with this library; if not, write to the Free Software
+// Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+///////////////////////////////////////////////////////////////////////////////////////////////
+
+package com.puppycrawl.tools.checkstyle.internal.annotation;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Indicates that the order of array or collection elements
+ * in a property should be preserved and not auto-sorted
+ * during Xdocs verification.
+ */
+@Documented
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.FIELD)
+public @interface PreserveOrder {
+    // marker annotation
+}

--- a/src/main/java/com/puppycrawl/tools/checkstyle/internal/annotation/package-info.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/internal/annotation/package-info.java
@@ -1,0 +1,23 @@
+///////////////////////////////////////////////////////////////////////////////////////////////
+// checkstyle: Checks Java source code and other text files for adherence to a set of rules.
+// Copyright (C) 2001-2025 the original author or authors.
+//
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the GNU Lesser General Public
+// License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+//
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+// Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public
+// License along with this library; if not, write to the Free Software
+// Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+///////////////////////////////////////////////////////////////////////////////////////////////
+
+/**
+ * Contains annotations used internally by Checkstyle for metadata and testing purposes.
+ */
+package com.puppycrawl.tools.checkstyle.internal.annotation;

--- a/src/main/resources/com/puppycrawl/tools/checkstyle/meta/checks/javadoc/AtclauseOrderCheck.xml
+++ b/src/main/resources/com/puppycrawl/tools/checkstyle/meta/checks/javadoc/AtclauseOrderCheck.xml
@@ -14,7 +14,7 @@
  Note: Google used the term "at-clauses" for block tags in their guide till 2017-02-28.
  &lt;/p&gt;</description>
          <properties>
-            <property default-value="@author, @deprecated, @exception, @param, @return, @see, @serial, @serialData, @serialField, @since, @throws, @version"
+            <property default-value="@author, @version, @param, @return, @throws, @exception, @see, @since, @serial, @serialField, @serialData, @deprecated"
                       name="tagOrder"
                       type="java.lang.String[]">
                <description>Specify the order by tags.</description>

--- a/src/site/xdoc/checks/javadoc/atclauseorder.xml
+++ b/src/site/xdoc/checks/javadoc/atclauseorder.xml
@@ -34,7 +34,7 @@
               <td><a id="tagOrder"/><a href="#tagOrder">tagOrder</a></td>
               <td>Specify the order by tags.</td>
               <td><a href="../../property_types.html#String.5B.5D">String[]</a></td>
-              <td><code>@author, @deprecated, @exception, @param, @return, @see, @serial, @serialData, @serialField, @since, @throws, @version</code></td>
+              <td><code>@author, @version, @param, @return, @throws, @exception, @see, @since, @serial, @serialField, @serialData, @deprecated</code></td>
               <td>6.0</td>
             </tr>
             <tr>

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/atclauseorder/InputAtclauseOrderLotsOfRecords1.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/atclauseorder/InputAtclauseOrderLotsOfRecords1.java
@@ -3,8 +3,8 @@ AtclauseOrder
 violateExecutionOnNonTightHtml = (default)false
 target = (default)CLASS_DEF, INTERFACE_DEF, ENUM_DEF, METHOD_DEF, \
          CTOR_DEF, VARIABLE_DEF, RECORD_DEF, COMPACT_CTOR_DEF
-tagOrder = @author, @version, @param, @return, @throws, @exception, @see, @since, @serial, \
-           @serialField, @serialData, @deprecated
+tagOrder = (default)@author, @version, @param, @return, @throws, @exception, @see, @since, \
+           @serial, @serialField, @serialData, @deprecated
 
 
 */

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/atclauseorder/InputAtclauseOrderLotsOfRecords2.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/atclauseorder/InputAtclauseOrderLotsOfRecords2.java
@@ -3,8 +3,8 @@ AtclauseOrder
 violateExecutionOnNonTightHtml = (default)false
 target = (default)CLASS_DEF, INTERFACE_DEF, ENUM_DEF, METHOD_DEF, \
          CTOR_DEF, VARIABLE_DEF, RECORD_DEF, COMPACT_CTOR_DEF
-tagOrder = @author, @version, @param, @return, @throws, @exception, @see, @since, @serial, \
-           @serialField, @serialData, @deprecated
+tagOrder = (default)@author, @version, @param, @return, @throws, @exception, @see, @since, \
+           @serial, @serialField, @serialData, @deprecated
 
 
 */

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/atclauseorder/InputAtclauseOrderLotsOfRecords3.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/atclauseorder/InputAtclauseOrderLotsOfRecords3.java
@@ -3,8 +3,9 @@ AtclauseOrder
 violateExecutionOnNonTightHtml = (default)false
 target = (default)CLASS_DEF, INTERFACE_DEF, ENUM_DEF, METHOD_DEF, \
          CTOR_DEF, VARIABLE_DEF, RECORD_DEF, COMPACT_CTOR_DEF
-tagOrder = @author, @version, @param, @return, @throws, @exception, @see, @since, @serial, \
-           @serialField, @serialData, @deprecated
+tagOrder = (default)@author, @version, @param, @return, @throws, @exception, @see, @since, \
+           @serial, @serialField, @serialData, @deprecated
+
 
 
 */

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/atclauseorder/InputAtclauseOrderLotsOfRecords4.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/atclauseorder/InputAtclauseOrderLotsOfRecords4.java
@@ -3,8 +3,8 @@ AtclauseOrder
 violateExecutionOnNonTightHtml = (default)false
 target = (default)CLASS_DEF, INTERFACE_DEF, ENUM_DEF, METHOD_DEF, \
          CTOR_DEF, VARIABLE_DEF, RECORD_DEF, COMPACT_CTOR_DEF
-tagOrder = @author, @version, @param, @return, @throws, @exception, @see, @since, @serial, \
-           @serialField, @serialData, @deprecated
+tagOrder = (default)@author, @version, @param, @return, @throws, @exception, @see, @since, \
+           @serial, @serialField, @serialData, @deprecated
 
 
 */

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/atclauseorder/InputAtclauseOrderRecords.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/atclauseorder/InputAtclauseOrderRecords.java
@@ -3,8 +3,8 @@ AtclauseOrder
 violateExecutionOnNonTightHtml = (default)false
 target = (default)CLASS_DEF, INTERFACE_DEF, ENUM_DEF, METHOD_DEF, \
          CTOR_DEF, VARIABLE_DEF, RECORD_DEF, COMPACT_CTOR_DEF
-tagOrder = @author, @version, @param, @return, @throws, @exception, @see, @since, @serial, \
-           @serialField, @serialData, @deprecated
+tagOrder = (default)@author, @version, @param, @return, @throws, @exception, @see, @since, \
+           @serial, @serialField, @serialData, @deprecated
 
 
 */


### PR DESCRIPTION
#10086 
- Created @PreserveOrder annotation to mark properties that should not be auto-sorted
- Applied @PreserveOrder to AtclauseOrderCheck.tagOrder field
- Updated XdocsPagesTest 
- Updated Javadoc