### PR TITLE
Issue #17845: Resolved error-prone violations

### DIFF
--- a/src/test/java/com/puppycrawl/tools/checkstyle/IndentationTrailingCommentsVerticalAlignmentTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/IndentationTrailingCommentsVerticalAlignmentTest.java
@@ -98,7 +98,8 @@ class IndentationTrailingCommentsVerticalAlignmentTest {
                     else {
                         assertWithMessage("Trailing comment alignment mismatch in file: "
                                 + testFile + " on line " + (idx + 1))
-                                .that(actualStartIndex).isEqualTo(expectedStartIndex);
+                                .that(actualStartIndex)
+                                .isEqualTo(expectedStartIndex);
                     }
                 }
             }
@@ -108,21 +109,22 @@ class IndentationTrailingCommentsVerticalAlignmentTest {
     private static Stream<Path> indentationTestFiles() {
         final Path resourcesDir = Path.of("src", "test", "resources");
         final Path indentationDir = resourcesDir.resolve(INDENTATION_TEST_FILES_PATH);
-
-        Stream<Path> testFiles;
-        try {
-            testFiles = Files.walk(indentationDir)
+        Stream<Path> result;
+        try (Stream<Path> testFiles = Files.walk(indentationDir)) {
+            final List<Path> collected = testFiles
                 .filter(path -> {
-                        final String fileName = path.getFileName().toString();
-                        return fileName.startsWith("InputIndentation")
+                    final String fileName = path.getFileName().toString();
+                    return fileName.startsWith("InputIndentation")
                             && fileName.endsWith(".java");
-                    }
-                );
+                }).toList();
+            result = collected.stream();
         }
         catch (IOException exception) {
-            assertWithMessage("Failed to find indentation test files").fail();
-            testFiles = Stream.empty();
+            assertWithMessage("Failed to find indentation test files")
+                    .that(exception)
+                    .isNull();
+            result = Stream.empty();
         }
-        return testFiles;
+        return result;
     }
 }

--- a/src/test/java/com/puppycrawl/tools/checkstyle/ant/CheckstyleAntTaskTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/ant/CheckstyleAntTaskTest.java
@@ -45,6 +45,8 @@ import org.apache.tools.ant.types.Path;
 import org.apache.tools.ant.types.resources.FileResource;
 import org.junit.jupiter.api.Test;
 
+import com.google.common.base.Splitter;
+import com.google.common.collect.Iterables;
 import com.google.common.truth.StandardSubjectBuilder;
 import com.puppycrawl.tools.checkstyle.AbstractPathTestSupport;
 import com.puppycrawl.tools.checkstyle.DefaultLogger;
@@ -290,7 +292,7 @@ public class CheckstyleAntTaskTest extends AbstractPathTestSupport {
     }
 
     @Test
-    public static void testNoFileOrPathSpecified() {
+    public void testNoFileOrPathSpecified() {
         final CheckstyleAntTask antTask = new CheckstyleAntTask();
         antTask.setProject(new Project());
 
@@ -634,7 +636,8 @@ public class CheckstyleAntTaskTest extends AbstractPathTestSupport {
             final StandardSubjectBuilder assertWithMessage =
                     assertWithMessage("Content of file with violations differs from expected");
             if (line.trim().startsWith("\"uri\"")) {
-                final String expectedPathEnd = line.split("\\*\\*")[1];
+                final String expectedPathEnd = Iterables.get(
+                        Splitter.on("**").split(line), 1);
                 // normalize windows path
                 final String actualLine = actual.get(lineNumber).replaceAll("\\\\", "/");
                 assertWithMessage

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/AvoidEscapedUnicodeCharactersCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/AvoidEscapedUnicodeCharactersCheckTest.java
@@ -23,12 +23,14 @@ import static com.google.common.truth.Truth.assertWithMessage;
 import static com.puppycrawl.tools.checkstyle.checks.AvoidEscapedUnicodeCharactersCheck.MSG_KEY;
 
 import java.util.Arrays;
+import java.util.List;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import java.util.stream.IntStream;
 
 import org.junit.jupiter.api.Test;
 
+import com.google.common.base.Splitter;
 import com.puppycrawl.tools.checkstyle.AbstractModuleTestSupport;
 import com.puppycrawl.tools.checkstyle.api.TokenTypes;
 import com.puppycrawl.tools.checkstyle.internal.utils.TestUtil;
@@ -531,11 +533,11 @@ public class AvoidEscapedUnicodeCharactersCheckTest extends AbstractModuleTestSu
         }
 
         // Verifying character order
-        final String[] expressionParts = expression.split("\\|");
+        final List<String> expressionParts = Splitter.on("|").splitToList(expression);
         final Pattern unicodeCharPattern = Pattern.compile("^\\\\\\\\u[\\dA-F]{4}$");
         String lastChar = null;
-        for (int i = 0; i < expressionParts.length; i++) {
-            final String currentChar = expressionParts[i];
+        for (int i = 0; i < expressionParts.size(); i++) {
+            final String currentChar = expressionParts.get(i);
             final Matcher matcher = unicodeCharPattern.matcher(currentChar);
             if (!matcher.matches()) {
                 final String message = "Character '" + currentChar + "' (at position " + i

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/indentation/IndentationCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/indentation/IndentationCheckTest.java
@@ -201,8 +201,8 @@ public class IndentationCheckTest extends AbstractModuleTestSupport {
         verify(config, filePath, expected, linesWithWarn);
         assertWithMessage("Expected warning count in UT does not match warn comment count "
                 + "in input file")
-            .that(expected.length)
-            .isEqualTo(linesWithWarn.length);
+            .that(linesWithWarn.length)
+            .isEqualTo(expected.length);
     }
 
     private void verify(Configuration config, String filePath, String[] expected,
@@ -4144,7 +4144,7 @@ public class IndentationCheckTest extends AbstractModuleTestSupport {
             warning = match.group(5) != null;
         }
 
-        public String[] getExpectedMessages() {
+        private String[] getExpectedMessages() {
             final String[] expectedMessages;
             if (expectedWarning.contains(",")) {
                 expectedMessages = new String[] {
@@ -4169,27 +4169,27 @@ public class IndentationCheckTest extends AbstractModuleTestSupport {
             return msg.substring(indexOfMsgPostfix);
         }
 
-        public int getLineNumber() {
+        private int getLineNumber() {
             return lineNumber;
         }
 
-        public int getIndent() {
+        private int getIndent() {
             return indent;
         }
 
-        public int getIndentOffset() {
+        private int getIndentOffset() {
             return indentOffset;
         }
 
-        public boolean isExpectedNonStrict() {
+        private boolean isExpectedNonStrict() {
             return expectedNonStrict;
         }
 
-        public String getExpectedWarning() {
+        private String getExpectedWarning() {
             return expectedWarning;
         }
 
-        public boolean isWarning() {
+        private boolean isWarning() {
             return warning;
         }
 

--- a/src/test/java/com/puppycrawl/tools/checkstyle/grammar/GeneratedJavaTokenTypesTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/grammar/GeneratedJavaTokenTypesTest.java
@@ -785,8 +785,8 @@ public class GeneratedJavaTokenTypesTest {
                 + " lexer grammar.";
 
         assertWithMessage(message)
-                .that(expectedNumberOfUsedTokens)
-                .isEqualTo(lastIndexOfSublist);
+                .that(lastIndexOfSublist)
+                .isEqualTo(expectedNumberOfUsedTokens);
     }
 
     /**

--- a/src/test/java/com/puppycrawl/tools/checkstyle/gui/MainFrameTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/gui/MainFrameTest.java
@@ -107,7 +107,7 @@ public class MainFrameTest extends AbstractGuiTestSupport {
     public void testChangeMode() {
         final JComboBox<MainFrameModel.ParseMode> modesCombobox =
                 findComponentComboBoxByName(mainFrame, "modesCombobox");
-        modesCombobox.setSelectedIndex(MainFrameModel.ParseMode.JAVA_WITH_COMMENTS.ordinal());
+        modesCombobox.setSelectedItem(MainFrameModel.ParseMode.JAVA_WITH_COMMENTS);
         final MainFrameModel model = TestUtil.getInternalState(mainFrame,
                 "model", MainFrameModel.class);
         final MainFrameModel.ParseMode parseMode = TestUtil.getInternalState(model,

--- a/src/test/java/com/puppycrawl/tools/checkstyle/internal/AllChecksTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/internal/AllChecksTest.java
@@ -40,6 +40,7 @@ import java.util.stream.Stream;
 
 import org.junit.jupiter.api.Test;
 
+import com.google.common.base.Splitter;
 import com.puppycrawl.tools.checkstyle.AbstractModuleTestSupport;
 import com.puppycrawl.tools.checkstyle.DefaultConfiguration;
 import com.puppycrawl.tools.checkstyle.Definitions;
@@ -260,8 +261,9 @@ public class AllChecksTest extends AbstractModuleTestSupport {
                 "ELLIPSIS").collect(Collectors.toUnmodifiableSet()));
         INTERNAL_MODULES = Definitions.INTERNAL_MODULES.stream()
                 .map(moduleName -> {
-                    final String[] packageTokens = moduleName.split("\\.");
-                    return packageTokens[packageTokens.length - 1];
+                    final List<String> packageTokens = Splitter
+                            .on(".").splitToList(moduleName);
+                    return packageTokens.get(packageTokens.size() - 1);
                 })
                 .collect(Collectors.toUnmodifiableSet());
     }

--- a/src/test/java/com/puppycrawl/tools/checkstyle/internal/ArchUnitSuperClassTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/internal/ArchUnitSuperClassTest.java
@@ -137,10 +137,11 @@ public class ArchUnitSuperClassTest {
             if (superclassOptional.isPresent()) {
                 final JavaClass superclass = superclassOptional.get().toErasure();
                 if (!superclass.isEquivalentTo(expectedSuperclass)) {
-                    final String format = "<%s> is subclass of <%s> instead of <%s>";
-                    final String message = String
-                        .format(Locale.ROOT, format, item.getFullName(), superclass.getFullName(),
-                                expectedSuperclass.getName());
+                    final String message = String.format(Locale.ROOT,
+                            "<%s> is subclass of <%s> instead of <%s>",
+                            item.getFullName(),
+                            superclass.getFullName(),
+                            expectedSuperclass.getName());
                     events.add(SimpleConditionEvent.violated(item, message));
                 }
             }

--- a/src/test/java/com/puppycrawl/tools/checkstyle/internal/CommitValidationTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/internal/CommitValidationTest.java
@@ -22,9 +22,9 @@ package com.puppycrawl.tools.checkstyle.internal;
 import static com.google.common.truth.Truth.assertWithMessage;
 
 import java.io.IOException;
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Iterator;
-import java.util.LinkedList;
 import java.util.List;
 import java.util.Spliterator;
 import java.util.Spliterators;
@@ -270,7 +270,7 @@ public class CommitValidationTest {
     }
 
     private static List<RevCommit> filterValidCommits(List<RevCommit> revCommits) {
-        final List<RevCommit> filteredCommits = new LinkedList<>();
+        final List<RevCommit> filteredCommits = new ArrayList<>();
         for (RevCommit commit : revCommits) {
             final String commitAuthor = commit.getAuthorIdent().getName();
             if (!USERS_EXCLUDED_FROM_VALIDATION.contains(commitAuthor)) {
@@ -326,7 +326,7 @@ public class CommitValidationTest {
 
     private static List<RevCommit> getCommitsByLastCommitAuthor(
             Iterator<RevCommit> previousCommitsIterator) {
-        final List<RevCommit> commits = new LinkedList<>();
+        final List<RevCommit> commits = new ArrayList<>();
 
         if (previousCommitsIterator.hasNext()) {
             final RevCommit lastCommit = previousCommitsIterator.next();
@@ -392,11 +392,11 @@ public class CommitValidationTest {
             this.second = second;
         }
 
-        public Iterator<RevCommit> getFirst() {
+        private Iterator<RevCommit> getFirst() {
             return first;
         }
 
-        public Iterator<RevCommit> getSecond() {
+        private Iterator<RevCommit> getSecond() {
             return second;
         }
 

--- a/src/test/java/com/puppycrawl/tools/checkstyle/internal/XdocsCategoryIndexTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/internal/XdocsCategoryIndexTest.java
@@ -86,9 +86,8 @@ public class XdocsCategoryIndexTest extends AbstractModuleTestSupport {
             final Map<String, CheckIndexInfo> indexedChecks = parseCategoryIndex(categoryIndexFile);
             final Set<String> foundKeys = indexedChecks.keySet();
 
-            final String checkNotFoundFmt = "Check '%s' from %s not in %s. Found Checks: %s";
             final String checkNotFoundMsg = String.format(Locale.ROOT,
-                    checkNotFoundFmt,
+                    "Check '%s' from %s not in %s. Found Checks: %s",
                     mainSectionName, checkXdocFile.getFileName(), categoryIndexFile, foundKeys);
             assertWithMessage(checkNotFoundMsg)
                     .that(indexedChecks.containsKey(mainSectionName)).isTrue();
@@ -107,10 +106,8 @@ public class XdocsCategoryIndexTest extends AbstractModuleTestSupport {
                     + "#" + mainSectionName;
             final String actualHref = checkInfoFromIndex.href();
 
-            final String hrefMismatchFmt = "Href mismatch for '%s' in %s."
-                    + "Expected: '%s', Found: '%s'";
             final String hrefMismatchMsg = String.format(Locale.ROOT,
-                    hrefMismatchFmt,
+                    "Href mismatch for '%s' in %s." + "Expected: '%s', Found: '%s'",
                     mainSectionName, categoryIndexFile, expectedHref, actualHref);
             assertWithMessage(hrefMismatchMsg)
                     .that(actualHref).isEqualTo(expectedHref);
@@ -121,10 +118,9 @@ public class XdocsCategoryIndexTest extends AbstractModuleTestSupport {
             final String normalizedIndexDesc = normalizeText(descriptionFromIndex);
             final String normalizedXdocDesc = normalizeText(descriptionFromXdoc);
 
-            final String descMismatchFmt = "Check '%s' in index '%s': "
-                    + "index description is not a prefix of XDoc description.";
             final String descMismatchMsg = String.format(Locale.ROOT,
-                    descMismatchFmt,
+                    "Check '%s' in index '%s': "
+                            + "index description is not a prefix of XDoc description.",
                     mainSectionName, categoryIndexFile);
             assertWithMessage(descMismatchMsg)
                     .that(normalizedXdocDesc)
@@ -173,8 +169,9 @@ public class XdocsCategoryIndexTest extends AbstractModuleTestSupport {
                 return sectionElement.getAttribute("name");
             }
         }
-        final String errorFormat = "No <section name=...> found in %s";
-        final String errorMsg = String.format(Locale.ROOT, errorFormat, checkXdocFile);
+
+        final String errorMsg = String.format(Locale.ROOT,
+                "No <section name=...> found in %s", checkXdocFile);
         throw new AssertionError(errorMsg);
     }
 
@@ -208,9 +205,9 @@ public class XdocsCategoryIndexTest extends AbstractModuleTestSupport {
                 }
             }
         }
-        final String errorFormat =
-                "No <subsection name=\"Description\"> with suitable content in %s";
-        final String errorMsg = String.format(Locale.ROOT, errorFormat, checkXdocFile);
+        final String errorMsg = String.format(Locale.ROOT,
+                "No <subsection name=\"Description\"> with suitable content in %s",
+                checkXdocFile);
         throw new AssertionError(errorMsg);
     }
 
@@ -475,7 +472,7 @@ public class XdocsCategoryIndexTest extends AbstractModuleTestSupport {
          *
          * @return The href string.
          */
-        public String href() {
+        private String href() {
             return hrefValue;
         }
 
@@ -484,7 +481,7 @@ public class XdocsCategoryIndexTest extends AbstractModuleTestSupport {
          *
          * @return The description string.
          */
-        public String description() {
+        private String description() {
             return descriptionText;
         }
     }

--- a/src/test/java/com/puppycrawl/tools/checkstyle/internal/XdocsJavaDocsTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/internal/XdocsJavaDocsTest.java
@@ -39,6 +39,7 @@ import org.w3c.dom.NamedNodeMap;
 import org.w3c.dom.Node;
 import org.w3c.dom.NodeList;
 
+import com.google.common.base.Splitter;
 import com.puppycrawl.tools.checkstyle.AbstractModuleTestSupport;
 import com.puppycrawl.tools.checkstyle.Checker;
 import com.puppycrawl.tools.checkstyle.DefaultConfiguration;
@@ -138,7 +139,7 @@ public class XdocsJavaDocsTest extends AbstractModuleTestSupport {
 
         for (Node child = node.getFirstChild(); child != null; child = child.getNextSibling()) {
             if (child.getNodeType() == Node.TEXT_NODE) {
-                for (String temp : child.getTextContent().split("\n")) {
+                for (String temp : Splitter.on("\n").split(child.getTextContent())) {
                     final String text = temp.trim();
 
                     if (!text.isEmpty()) {
@@ -345,25 +346,16 @@ public class XdocsJavaDocsTest extends AbstractModuleTestSupport {
                 final DetailAST parentNode = getParent(ast);
 
                 switch (parentNode.getType()) {
-                    case TokenTypes.CLASS_DEF:
-                        // ignore;
-                        break;
-                    case TokenTypes.METHOD_DEF:
-                        visitMethod(ast, parentNode);
-                        break;
-                    case TokenTypes.VARIABLE_DEF:
-                        visitField(ast, parentNode);
-                        break;
-                    case TokenTypes.CTOR_DEF:
-                    case TokenTypes.ENUM_DEF:
-                    case TokenTypes.ENUM_CONSTANT_DEF:
+                    case TokenTypes.CLASS_DEF, TokenTypes.CTOR_DEF, TokenTypes.ENUM_DEF,
+                         TokenTypes.ENUM_CONSTANT_DEF -> {
                         // ignore
-                        break;
-                    default:
+                    }
+                    case TokenTypes.METHOD_DEF -> visitMethod(ast, parentNode);
+                    case TokenTypes.VARIABLE_DEF -> visitField(ast, parentNode);
+                    default ->
                         assertWithMessage(
                                 "Unknown token '" + TokenUtil.getTokenName(parentNode.getType())
                                         + "': " + ast.getLineNo()).fail();
-                        break;
                 }
             }
         }

--- a/src/test/java/com/puppycrawl/tools/checkstyle/internal/XdocsPagesTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/internal/XdocsPagesTest.java
@@ -1244,7 +1244,7 @@ public class XdocsPagesTest {
                 .map(nonNullField -> nonNullField.getAnnotation(XdocsPropertyType.class))
                 .map(propertyType -> propertyType.value().getDescription())
                 .map(SiteUtil::simplifyTypeName)
-                .orElse(fieldClass.getSimpleName());
+                .orElseGet(fieldClass::getSimpleName);
         final String expectedValue = getModulePropertyExpectedValue(sectionName, propertyName,
                 field, fieldClass, instance);
 

--- a/src/test/java/com/puppycrawl/tools/checkstyle/internal/XdocsUrlTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/internal/XdocsUrlTest.java
@@ -26,6 +26,7 @@ import java.io.InputStream;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Locale;
@@ -164,14 +165,14 @@ public class XdocsUrlTest {
         public void startElement(String uri, String localName, String qName,
                                  Attributes attributes) {
             if (NODE_NAME.equals(qName)) {
-                final String[] moduleAndCheckName =
-                        attributes.getValue(0).split(SPLIT_CHECK_NAME_IN_ATTRIBUTE);
-                if (moduleAndCheckName[0].startsWith(PREFIX_CONFIG)) {
+                final List<String> moduleAndCheckName =
+                       Arrays.asList(attributes.getValue(0).split(SPLIT_CHECK_NAME_IN_ATTRIBUTE));
+                if (moduleAndCheckName.get(0).startsWith(PREFIX_CONFIG)) {
                     singleCheckNameList = new ArrayList<>();
                     final String moduleName =
-                            moduleAndCheckName[0].replaceAll("(.*config_)|(\\.html.*)", "");
+                            moduleAndCheckName.get(0).replaceAll("(.*config_)|(\\.html.*)", "");
                     singleCheckNameList.add(moduleName);
-                    singleCheckNameList.add(moduleAndCheckName[1]);
+                    singleCheckNameList.add(moduleAndCheckName.get(1));
                 }
             }
             currentTag = qName;

--- a/src/test/java/com/puppycrawl/tools/checkstyle/internal/XpathRegressionTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/internal/XpathRegressionTest.java
@@ -39,6 +39,7 @@ import java.util.stream.Stream;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
+import com.google.common.base.Splitter;
 import com.puppycrawl.tools.checkstyle.AbstractModuleTestSupport;
 import com.puppycrawl.tools.checkstyle.Definitions;
 import com.puppycrawl.tools.checkstyle.checks.javadoc.AbstractJavadocCheck;
@@ -124,8 +125,8 @@ public class XpathRegressionTest extends AbstractModuleTestSupport {
     private static Set<String> getInternalModules() {
         return Definitions.INTERNAL_MODULES.stream()
             .map(moduleName -> {
-                final String[] packageTokens = moduleName.split("\\.");
-                return packageTokens[packageTokens.length - 1];
+                final List<String> packageTokens = Splitter.on(".").splitToList(moduleName);
+                return packageTokens.get(packageTokens.size() - 1);
             })
             .collect(Collectors.toUnmodifiableSet());
     }


### PR DESCRIPTION
Issue: #17845

https://errorprone.info/bugpattern/StringSplitter


Fixed warnings:
```
[WARNING] java/com/puppycrawl/tools/checkstyle/IndentationTrailingCommentsVerticalAlignmentTest.java:
[126,35]
[StreamResourceLeak] Streams that encapsulate a closeable resource should be closed 
using try-with-resources
    (see https://errorprone.info/bugpattern/StreamResourceLeak)
[INFO] /src/test/java/com/puppycrawl/tools/checkstyle/PropertyCacheFileTest.java:[533,5]
[LexicographicalAnnotationAttributeListing] Where possible, 
sort annotation array attributes lexicographically
    (see https://error-prone.picnic.tech/bugpatterns/LexicographicalAnnotationAttributeListing)
  Did you mean '@ValueSource(strings = {"First;Second", "Same;Same"})'?

[WARNING] /src/test/java/com/puppycrawl/tools/checkstyle/PropertyCacheFileTest.java:[537,52]
[StringSplitter] String.split(String) has surprising behavior
    (see https://errorprone.info/bugpattern/StringSplitter)
  Did you mean 'final List<String> messages = Splitter.on(';').splitToList(rawMessages);'?

[WARNING] /src/test/java/com/puppycrawl/tools/checkstyle/XpathFileGeneratorAuditListenerTest.java:[334,43]
[DefaultCharset] Implicit use of the platform default charset, which can result in differing
behaviour between JVM executions or incorrect behavior if the encoding of the 
data source doesn't match expectations.
    (see https://errorprone.info/bugpattern/DefaultCharset)
  Did you mean 'final String actual = out.toString(UTF_8);' 
or 'final String actual = out.toString(Charset.defaultCharset());'?

[WARNING] /src/test/java/com/puppycrawl/tools/checkstyle/ant/CheckstyleAntTaskTest.java:[637,58]
[StringSplitter] String.split(String) has surprising behavior
    (see https://errorprone.info/bugpattern/StringSplitter)
  Did you mean 'final String expectedPathEnd = Iterables.get(Splitter.on("**").split(line), 1);'?

[WARNING] /src/test/java/com/puppycrawl/tools/checkstyle/bdd/InlineConfigParser.java:[665,21]
[OperatorPrecedence] Use grouping parenthesis to make the operator precedence explicit
    (see https://errorprone.info/bugpattern/OperatorPrecedence)
  Did you mean '} while ((lineNo < lines.size()'?

[WARNING] /src/test/java/com/puppycrawl/tools/checkstyle/checks/
AvoidEscapedUnicodeCharactersCheckTest.java:[533,58]
[StringSplitter] String.split(String) has surprising behavior
    (see https://errorprone.info/bugpattern/StringSplitter)
  Did you mean 'final List<String> expressionParts = Splitter.on('|').splitToList(expression);'?

[WARNING] /src/test/java/com/puppycrawl/tools/checkstyle/checks/TranslationCheckTest.java:[629,13]
[OperatorPrecedence] Use grouping parenthesis to make the operator precedence explicit
    (see https://errorprone.info/bugpattern/OperatorPrecedence)
  Did you mean '|| (XmlUtil.getNameAttributeOfNode(expected)'?

[WARNING] /src/test/java/com/puppycrawl/tools/checkstyle/checks/indentation/
IndentationCheckTest.java:[207,23]
[TruthAssertExpected] The actual and expected values appear to be swapped, which results
in poor assertion failure messages. The actual value should come first.
    (see https://errorprone.info/bugpattern/TruthAssertExpected)
  Did you mean '.that(linesWithWarn.length)'?

[WARNING] /src/test/java/com/puppycrawl/tools/checkstyle/checks/indentation/
IndentationCheckTest.java:[4149,25]
[EffectivelyPrivate] This declaration has public or protected modifiers, but is effectively private.
    (see https://errorprone.info/bugpattern/EffectivelyPrivate)
  Did you mean 'String[] getExpectedMessages() {'?

[WARNING] /src/test/java/com/puppycrawl/tools/checkstyle/checks/indentation/
IndentationCheckTest.java:[4174,20]
[EffectivelyPrivate] This declaration has public or protected modifiers, but is effectively private.
    (see https://errorprone.info/bugpattern/EffectivelyPrivate)
  Did you mean 'int getLineNumber() {'?

[WARNING] /src/test/java/com/puppycrawl/tools/checkstyle/checks/indentation/
IndentationCheckTest.java:[4178,20]
[EffectivelyPrivate] This declaration has public or protected modifiers, but is effectively private.
    (see https://errorprone.info/bugpattern/EffectivelyPrivate)
  Did you mean 'int getIndent() {'?

[WARNING] /src/test/java/com/puppycrawl/tools/checkstyle/checks/indentation/
IndentationCheckTest.java:[4182,20]
[EffectivelyPrivate] This declaration has public or protected modifiers, but is effectively private.
    (see https://errorprone.info/bugpattern/EffectivelyPrivate)
  Did you mean 'int getIndentOffset() {'?

[WARNING] /src/test/java/com/puppycrawl/tools/checkstyle/checks/indentation/
IndentationCheckTest.java:[4186,24]
[EffectivelyPrivate] This declaration has public or protected modifiers, but is effectively private.
    (see https://errorprone.info/bugpattern/EffectivelyPrivate)
  Did you mean 'boolean isExpectedNonStrict() {'?

[WARNING] /src/test/java/com/puppycrawl/tools/checkstyle/checks/indentation/
IndentationCheckTest.java:[4190,23]
[EffectivelyPrivate] This declaration has public or protected modifiers, but is effectively private.
    (see https://errorprone.info/bugpattern/EffectivelyPrivate)
  Did you mean 'String getExpectedWarning() {'?

[WARNING] /src/test/java/com/puppycrawl/tools/checkstyle/checks/indentation/
IndentationCheckTest.java:[4194,24]
[EffectivelyPrivate] This declaration has public or protected modifiers, but is effectively private.
    (see https://errorprone.info/bugpattern/EffectivelyPrivate)
  Did you mean 'boolean isWarning() {'?

```