### PR TITLE
Issue #17882: Update PROVIDES_BLOCK_TAG of JavadocCommentsTokenTypes.java to new AST format

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/api/JavadocCommentsTokenTypes.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/api/JavadocCommentsTokenTypes.java
@@ -274,6 +274,32 @@ public final class JavadocCommentsTokenTypes {
 
     /**
      * {@code @provides} block tag.
+     *
+     * <p>Such Javadoc tag can have two children:</p>
+     * <ol>
+     *  <li>{@link #IDENTIFIER}</li>
+     *  <li>{@link #DESCRIPTION}</li>
+     * </ol>
+     *
+     * <p><b>Example:</b></p>
+     * <pre>{@code * @provides com.example.MyService with com.example.MyServiceImpl}</pre>
+     *
+     * <b>Tree:</b>
+     * <pre>{@code
+     * JAVADOC_CONTENT -> JAVADOC_CONTENT
+     * |--LEADING_ASTERISK -> *
+     * |--TEXT ->
+     * `--JAVADOC_BLOCK_TAG -> JAVADOC_BLOCK_TAG
+     *     `--PROVIDES_BLOCK_TAG -> PROVIDES_BLOCK_TAG
+     *         |--AT_SIGN -> @
+     *         |--TAG_NAME -> provides
+     *         |--TEXT ->
+     *         |--IDENTIFIER -> com.example.MyService
+     *         `--DESCRIPTION -> DESCRIPTION
+     *             `--TEXT ->  with com.example.MyServiceImpl
+     * }</pre>
+     *
+     * @see #JAVADOC_BLOCK_TAG
      */
     public static final int PROVIDES_BLOCK_TAG = JavadocCommentsLexer.PROVIDES_BLOCK_TAG;
 


### PR DESCRIPTION
Issue https://github.com/checkstyle/checkstyle/issues/17882

### Test file
```
* @provides com.example.MyService with com.example.MyServiceImpl
```

### AST output
```
JAVADOC_CONTENT -> JAVADOC_CONTENT 
|--LEADING_ASTERISK -> * 
|--TEXT ->   
`--JAVADOC_BLOCK_TAG -> JAVADOC_BLOCK_TAG 
    `--PROVIDES_BLOCK_TAG -> PROVIDES_BLOCK_TAG 
        |--AT_SIGN -> @ 
        |--TAG_NAME -> provides 
        |--TEXT ->   
        |--IDENTIFIER -> com.example.MyService 
        `--DESCRIPTION -> DESCRIPTION 
            `--TEXT ->  with com.example.MyServiceImpl
```