### PR TITLE
Issue #17924: Enable CheckstyleAntTaskTest.testNoFileOrPathSpecified by making it non-static

### DIFF
--- a/src/test/java/com/puppycrawl/tools/checkstyle/ant/CheckstyleAntTaskTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/ant/CheckstyleAntTaskTest.java
@@ -290,7 +290,7 @@ public class CheckstyleAntTaskTest extends AbstractPathTestSupport {
     }
 
     @Test
-    public static void testNoFileOrPathSpecified() {
+    public void testNoFileOrPathSpecified() {
         final CheckstyleAntTask antTask = new CheckstyleAntTask();
         antTask.setProject(new Project());
 


### PR DESCRIPTION
JUnit Jupiter does not execute `static` methods annotated with `@Test`, as seen in, e.g., https://dev.azure.com/romanivanovjr/romanivanovjr/_build/results?buildId=32943&view=logs&j=c902ebb4-c9f8-5f09-4e17-ff78fbbc842e&t=9ca98c81-ff64-58f0-9d03-a23ac1c4a111&l=116:
```
(1) [WARNING] @Test method 'public static void com.puppycrawl.tools.checkstyle.ant.CheckstyleAntTaskTest.testNoFileOrPathSpecified()' must not be static. It will not be executed.
    Source: MethodSource [className = 'com.puppycrawl.tools.checkstyle.ant.CheckstyleAntTaskTest', methodName = 'testNoFileOrPathSpecified', methodParameterTypes = '']
            at com.puppycrawl.tools.checkstyle.ant.CheckstyleAntTaskTest.testNoFileOrPathSpecified(SourceFile:0)
```

This PR fixes the issue by removing the `static` modifier from that test.

Fixes #17924 