### PR TITLE
Issue #17882: Update {@index} of JavadocCommentsTokenTypes to new AST format

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/api/JavadocCommentsTokenTypes.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/api/JavadocCommentsTokenTypes.java
@@ -389,6 +389,29 @@ public final class JavadocCommentsTokenTypes {
 
     /**
      * {@code {@index}} inline tag.
+     *
+     * <p>Such Javadoc tag can have one child:</p>
+     * <ol>
+     *   <li>{@link #DESCRIPTION} – description of the parameter</li>
+     * </ol>
+     *
+     * <p><b>Example:</b></p>
+     * <pre>{@code * @index This parameter specifies the position.}</pre>
+     *
+     * <b>Tree:</b>
+     * <pre>{@code
+     * JAVADOC_INLINE_TAG -> JAVADOC_INLINE_TAG
+     *  `--INDEX_INLINE_TAG -> INDEX_INLINE_TAG
+     *      |--JAVADOC_INLINE_TAG_START -> {
+     *      |--TAG_NAME -> index
+     *      |--TEXT ->
+     *      |--INDEX_TERM -> list
+     *      |--DESCRIPTION -> DESCRIPTION
+     *      |   `--TEXT ->
+     *      `--JAVADOC_INLINE_TAG_END -> }
+     * }</pre>
+     *
+     * @see #JAVADOC_BLOCK_TAG
      */
     public static final int INDEX_INLINE_TAG = JavadocCommentsLexer.INDEX_INLINE_TAG;
 


### PR DESCRIPTION
Issue #17882 

```
JAVADOC -> JAVADOC
`--JAVADOC_CONTENT -> JAVADOC_CONTENT
    |--NEWLINE -> \n
    |--LEADING_ASTERISK ->      *
    |--TEXT ->  {@code {@index}} inline tag.
    |--NEWLINE -> \n
    |--LEADING_ASTERISK ->      *
    |--NEWLINE -> \n
    |--LEADING_ASTERISK ->      *
    |--TEXT ->  
    |--JAVADOC_BLOCK_TAG -> JAVADOC_BLOCK_TAG
    |   `--PARAM_BLOCK_TAG -> PARAM_BLOCK_TAG
    |       |--AT_SIGN -> @
    |       |--TAG_NAME -> param
    |       |--TEXT ->  
    |       |--PARAMETER_NAME -> value
    |       `--DESCRIPTION -> DESCRIPTION
    |           `--TEXT ->  The parameter of the method.

```