### PR TITLE
Issue #17882: Update SERIAL_DATA_BLOCK_TAG of JavadocCommentsTokenTypes.java to new AST format

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/api/JavadocCommentsTokenTypes.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/api/JavadocCommentsTokenTypes.java
@@ -330,6 +330,26 @@ public final class JavadocCommentsTokenTypes {
 
     /**
      * {@code @serialData} block tag.
+     *
+     * <p>Such Javadoc tag can have one child:</p>
+     * <ol>
+     *   <li>{@link #DESCRIPTION} – optional description text</li>
+     * </ol>
+     *
+     * <p><b>Example:</b></p>
+     * <pre>{@code * @serialData data description value}</pre>
+     *
+     * <b>Tree:</b>
+     * <pre>{@code
+     * JAVADOC_BLOCK_TAG -> JAVADOC_BLOCK_TAG
+     * `--SERIAL_DATA_BLOCK_TAG -> SERIAL_DATA_BLOCK_TAG
+     *    |--AT_SIGN -> @
+     *    |--TAG_NAME -> serialData
+     *    `--DESCRIPTION -> DESCRIPTION
+     *        `--TEXT ->  data description value
+     * }</pre>
+     *
+     * @see #JAVADOC_BLOCK_TAG
      */
     public static final int SERIAL_DATA_BLOCK_TAG = JavadocCommentsLexer.SERIAL_DATA_BLOCK_TAG;
 


### PR DESCRIPTION
Issue https://github.com/checkstyle/checkstyle/issues/17882

### Test file
```
* @serialData data description value
```

### AST output
```
JAVADOC_CONTENT -> JAVADOC_CONTENT 
|--LEADING_ASTERISK -> * 
|--TEXT ->   
`--JAVADOC_BLOCK_TAG -> JAVADOC_BLOCK_TAG 
    `--SERIAL_DATA_BLOCK_TAG -> SERIAL_DATA_BLOCK_TAG 
        |--AT_SIGN -> @ 
        |--TAG_NAME -> serialData 
        `--DESCRIPTION -> DESCRIPTION 
            `--TEXT ->  data description value
```