### PR TITLE
Issue #17939: Wrap AtclauseOrder properties table to prevent horizontal scrolling

### DIFF
--- a/src/site/resources/css/site.css
+++ b/src/site/resources/css/site.css
@@ -163,6 +163,11 @@ th {
   font-size: 14px;
 }
 
+section[id$="_Properties"] .wrapper table td:nth-child(4) code {
+  white-space: normal;
+  word-break: break-word;
+}
+
 .wrapper {
   overflow-x: auto;
   margin: 1em 0;


### PR DESCRIPTION
Issue #17939 

Updated **site.css** to prevent horizontal scrolling at 
https://checkstyle.sourceforge.io/checks/javadoc/atclauseorder.html#tagOrder

```
td code {
  white-space:normal;
  word-break:break-word;
}
```