### PR TITLE
Issue #17882: Update AUTHOR_BLOCK_TAG of JavadocCommentsTokenTypes to…

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/api/JavadocCommentsTokenTypes.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/api/JavadocCommentsTokenTypes.java
@@ -74,7 +74,26 @@ public final class JavadocCommentsTokenTypes {
     public static final int AT_SIGN = JavadocCommentsLexer.AT_SIGN;
 
     /**
-     * {@code @author} block tag.
+     * {@code @author} Javadoc block tag.
+     *
+     * <p>Such Javadoc tag can have one child:</p>
+     * <ol>
+     *  <li>{@link #DESCRIPTION}</li>
+     * </ol>
+     *
+     * <p><b>Example:</b></p>
+     * <pre>{@code * @author name.}</pre>
+     * <b>Tree:</b>
+     * <pre>{@code
+     * JAVADOC_BLOCK_TAG -> JAVADOC_BLOCK_TAG
+     * `--AUTHOR_BLOCK_TAG -> AUTHOR_BLOCK_TAG
+     *    |--AT_SIGN -> @
+     *    |--TAG_NAME -> author
+     *    `--DESCRIPTION -> DESCRIPTION
+     *        `--TEXT ->  name.
+     * }</pre>
+     *
+     * @see #JAVADOC_BLOCK_TAG
      */
     public static final int AUTHOR_BLOCK_TAG = JavadocCommentsLexer.AUTHOR_BLOCK_TAG;
 


### PR DESCRIPTION
Part of #17882

### Test file
```java
class Test {

    /**
     * @author name.
     */
    void method(int value) {

    }
}
```

### AST output
```
JAVADOC_CONTENT -> JAVADOC_CONTENT [0:0]
|--TEXT -> public class Test { [0:0]
|--NEWLINE -> \n [0:19]
|--TEXT ->     /** [1:0]
|--NEWLINE -> \n [1:7]
|--LEADING_ASTERISK ->      * [2:0]
|--TEXT ->   [2:6]
|--JAVADOC_BLOCK_TAG -> JAVADOC_BLOCK_TAG [2:7]
|   `--AUTHOR_BLOCK_TAG -> AUTHOR_BLOCK_TAG [2:7]
|       |--AT_SIGN -> @ [2:7]
|       |--TAG_NAME -> author [2:8]
|       `--DESCRIPTION -> DESCRIPTION [2:14]
|           |--TEXT ->  name. [2:14]
|           |--NEWLINE -> \n [2:19]
|           |--LEADING_ASTERISK ->      * [3:0]
|           |--TEXT -> / [3:6]
|           |--NEWLINE -> \n [3:7]
|           |--TEXT ->     void method(int value) { [4:0]
|           |--NEWLINE -> \n [4:28]
|           |--NEWLINE -> \n [5:0]
|           |--TEXT ->     } [6:0]
|           |--NEWLINE -> \n [6:5]
|           `--TEXT -> } [7:0]
`--NEWLINE -> \n [7:1]
```