### PR TITLE
Issue #17954: Suppress JVM warnings seen in tests

### DIFF
--- a/config/jsoref-spellchecker/whitelist.words
+++ b/config/jsoref-spellchecker/whitelist.words
@@ -1563,6 +1563,7 @@ Xpkginfo
 Xplugin
 xright
 xsd
+Xshare
 xsi
 xsl
 xslt

--- a/pom.xml
+++ b/pom.xml
@@ -1705,6 +1705,8 @@
             --add-opens=java.desktop/java.awt=ALL-UNNAMED
             --add-opens=java.desktop/sun.java2d=ALL-UNNAMED
             --add-opens=java.base/java.lang.reflect=ALL-UNNAMED
+            -XX:+EnableDynamicAgentLoading
+            -Xshare:off
           </argLine>
           <additionalClasspathElements>
             <additionalClasspathElement>


### PR DESCRIPTION
Fix JVM warnings about sharing and about dynamic agent loading seen in the CI (e.g, from https://dev.azure.com/romanivanovjr/romanivanovjr/_build/results?buildId=32993&view=logs&j=c902ebb4-c9f8-5f09-4e17-ff78fbbc842e&t=9ca98c81-ff64-58f0-9d03-a23ac1c4a111&l=104):

```
[INFO] --- surefire:3.5.4:test (default-test) @ checkstyle ---
[INFO] Surefire report directory: /home/vsts/work/1/s/target/surefire-reports
[INFO] Using auto detected provider org.apache.maven.surefire.junitplatform.JUnitPlatformProvider
[INFO] 
[INFO] -------------------------------------------------------
[INFO]  T E S T S
[INFO] -------------------------------------------------------
SLF4J: Failed to load class "org.slf4j.impl.StaticLoggerBinder".
SLF4J: Defaulting to no-operation (NOP) logger implementation
SLF4J: See http://www.slf4j.org/codes.html#StaticLoggerBinder for further details.
[INFO] Running com.puppycrawl.tools.checkstyle.api.FileContentsTest
[INFO] Tests run: 23, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.192 s -- in com.puppycrawl.tools.checkstyle.api.FileContentsTest
[INFO] Running com.puppycrawl.tools.checkstyle.api.FileTextTest
[INFO] Tests run: 10, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.166 s -- in com.puppycrawl.tools.checkstyle.api.FileTextTest
[INFO] Running com.puppycrawl.tools.checkstyle.api.AbstractViolationReporterTest
[INFO] Tests run: 7, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.045 s -- in com.puppycrawl.tools.checkstyle.api.AbstractViolationReporterTest
[INFO] Running com.puppycrawl.tools.checkstyle.api.FileSetCheckTest
[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 1.313 s -- in com.puppycrawl.tools.checkstyle.api.FileSetCheckTest
[INFO] Running com.puppycrawl.tools.checkstyle.api.LineColumnTest
OpenJDK 64-Bit Server VM warning: Sharing is only supported for boot loader classes because bootstrap classpath has been appended
WARNING: A Java agent has been loaded dynamically (/home/vsts/work/1/.m2/repository/net/bytebuddy/byte-buddy-agent/1.14.11/byte-buddy-agent-1.14.11.jar)
WARNING: If a serviceability tool is in use, please run with -XX:+EnableDynamicAgentLoading to hide this warning
WARNING: If a serviceability tool is not in use, please run with -Djdk.instrument.traceUsage for more information
WARNING: Dynamic loading of agents will be disallowed by default in a future release
```

Fixes #17954
