### PR TITLE
Issue #17845: Resolved error-prone violations

### DIFF
--- a/src/test/java/com/puppycrawl/tools/checkstyle/AbstractAutomaticBeanTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/AbstractAutomaticBeanTest.java
@@ -195,7 +195,7 @@ public class AbstractAutomaticBeanTest {
     @Test
     public void testRegisterIntegralTypes() throws Exception {
         final ConvertUtilsBeanStub convertUtilsBean = new ConvertUtilsBeanStub();
-        TestUtil.invokeStaticMethod(AbstractAutomaticBean.class,
+        TestUtil.invokeVoidStaticMethod(AbstractAutomaticBean.class,
                 "registerIntegralTypes", convertUtilsBean);
         assertWithMessage("Number of converters registered differs from expected")
                 .that(convertUtilsBean.getRegisterCount())

--- a/src/test/java/com/puppycrawl/tools/checkstyle/AuditEventDefaultFormatterTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/AuditEventDefaultFormatterTest.java
@@ -81,7 +81,8 @@ public class AuditEventDefaultFormatterTest {
                 getClass(), null);
         final AuditEvent auditEvent = new AuditEvent(new Object(), "fileName", violation);
         final StringBuilder result = TestUtil.invokeStaticMethod(AuditEventDefaultFormatter.class,
-                "initStringBuilderWithOptimalBuffer", auditEvent, SeverityLevel.ERROR.toString());
+                "initStringBuilderWithOptimalBuffer", StringBuilder.class,
+                auditEvent, SeverityLevel.ERROR.toString());
 
         assertWithMessage("Buffer length is not expected")
                 .that(result.capacity())

--- a/src/test/java/com/puppycrawl/tools/checkstyle/CheckerTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/CheckerTest.java
@@ -114,12 +114,12 @@ public class CheckerTest extends AbstractModuleTestSupport {
 
     private static void invokeFireAuditFinished(Checker checker)
             throws ReflectiveOperationException {
-        TestUtil.invokeMethod(checker, "fireAuditFinished");
+        TestUtil.invokeVoidMethod(checker, "fireAuditFinished");
     }
 
     private static void invokeFireAuditStartedMethod(Checker checker)
             throws ReflectiveOperationException {
-        TestUtil.invokeMethod(checker, "fireAuditStarted");
+        TestUtil.invokeVoidMethod(checker, "fireAuditStarted");
     }
 
     @Override

--- a/src/test/java/com/puppycrawl/tools/checkstyle/ConfigurationLoaderTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/ConfigurationLoaderTest.java
@@ -75,7 +75,8 @@ public class ConfigurationLoaderTest extends AbstractPathTestSupport {
     private static String invokeReplacePropertiesMethod(
             Object internalLoader, String value, String defaultValue)
             throws ReflectiveOperationException {
-        return TestUtil.invokeMethod(internalLoader, "replaceProperties", value, defaultValue);
+        return TestUtil.invokeMethod(internalLoader, "replaceProperties",
+                String.class, value, defaultValue);
     }
 
     private static void invokeParsePropertyStringMethod(
@@ -84,7 +85,7 @@ public class ConfigurationLoaderTest extends AbstractPathTestSupport {
             Collection<String> fragments,
             Collection<String> propertyRefs)
             throws ReflectiveOperationException {
-        TestUtil.invokeMethod(
+        TestUtil.invokeVoidMethod(
                 internalLoader, "parsePropertyString", value, fragments, propertyRefs);
     }
 
@@ -556,7 +557,7 @@ public class ConfigurationLoaderTest extends AbstractPathTestSupport {
         final Object obj = TestUtil.instantiate(aClass, objParent);
 
         try {
-            TestUtil.invokeMethod(obj, "startElement", "", "", "hello", null);
+            TestUtil.invokeVoidMethod(obj, "startElement", "", "", "hello", null);
 
             assertWithMessage("InvocationTargetException is expected").fail();
         }

--- a/src/test/java/com/puppycrawl/tools/checkstyle/DetailAstImplTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/DetailAstImplTest.java
@@ -71,7 +71,7 @@ public class DetailAstImplTest extends AbstractModuleTestSupport {
 
     private static void invokeSetParentMethod(DetailAST instance, DetailAstImpl parent)
             throws Exception {
-        TestUtil.invokeMethod(instance, "setParent", parent);
+        TestUtil.invokeVoidMethod(instance, "setParent", parent);
     }
 
     @Test
@@ -383,7 +383,7 @@ public class DetailAstImplTest extends AbstractModuleTestSupport {
                 child::addChild,
             ast -> {
                 try {
-                    TestUtil.invokeMethod(child, "setParent", ast);
+                    TestUtil.invokeVoidMethod(child, "setParent", ast);
                 }
                 // -@cs[IllegalCatch] Cannot avoid catching it.
                 catch (Exception exception) {
@@ -393,9 +393,11 @@ public class DetailAstImplTest extends AbstractModuleTestSupport {
         );
 
         for (Consumer<DetailAstImpl> method : clearBranchTokenTypesMethods) {
-            final BitSet branchTokenTypes = TestUtil.invokeMethod(parent, "getBranchTokenTypes");
+            final BitSet branchTokenTypes = TestUtil.invokeMethod(parent,
+                    "getBranchTokenTypes", BitSet.class);
             method.accept(null);
-            final BitSet branchTokenTypes2 = TestUtil.invokeMethod(parent, "getBranchTokenTypes");
+            final BitSet branchTokenTypes2 = TestUtil.invokeMethod(parent,
+                    "getBranchTokenTypes", BitSet.class);
             assertWithMessage("Branch token types are not equal")
                 .that(branchTokenTypes)
                 .isEqualTo(branchTokenTypes2);

--- a/src/test/java/com/puppycrawl/tools/checkstyle/DetailNodeTreeStringPrinterTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/DetailNodeTreeStringPrinterTest.java
@@ -60,7 +60,7 @@ public class DetailNodeTreeStringPrinterTest extends AbstractTreeTestSupport {
     @Test
     public void testParseErrorMessage() throws Exception {
         final String actual = TestUtil.invokeStaticMethod(DetailNodeTreeStringPrinter.class,
-                "getParseErrorMessage",
+                "getParseErrorMessage", String.class,
                 new ParseErrorMessage(10, MSG_JAVADOC_PARSE_RULE_ERROR,
                         9, "no viable alternative at input ' xyz'", "SOME_JAVADOC_ELEMENT"));
         final LocalizedMessage violation = new LocalizedMessage(
@@ -85,7 +85,7 @@ public class DetailNodeTreeStringPrinterTest extends AbstractTreeTestSupport {
         }
         catch (IllegalArgumentException exc) {
             final String expected = TestUtil.invokeStaticMethod(DetailNodeTreeStringPrinter.class,
-                    "getParseErrorMessage",
+                    "getParseErrorMessage", String.class,
                     new ParseErrorMessage(0, MSG_JAVADOC_PARSE_RULE_ERROR,
                             8, "no viable alternative at input 'see <'", "SEE_TAG"));
             assertWithMessage("Generated and expected parse error messages don't match")
@@ -104,7 +104,7 @@ public class DetailNodeTreeStringPrinterTest extends AbstractTreeTestSupport {
         }
         catch (IllegalArgumentException exc) {
             final String expected = TestUtil.invokeStaticMethod(DetailNodeTreeStringPrinter.class,
-                    "getParseErrorMessage",
+                    "getParseErrorMessage", String.class,
                     new ParseErrorMessage(0, MSG_JAVADOC_PARSE_RULE_ERROR,
                             3, "no viable alternative at input '</'", "HTML_ELEMENT"));
             assertWithMessage("Generated and expected parse error messages don't match")

--- a/src/test/java/com/puppycrawl/tools/checkstyle/JavaAstVisitorTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/JavaAstVisitorTest.java
@@ -239,7 +239,8 @@ public class JavaAstVisitorTest extends AbstractModuleTestSupport {
     @Test
     public void testNullSelfInAddLastSibling() {
         assertDoesNotThrow(() -> {
-            TestUtil.invokeStaticMethod(JavaAstVisitor.class, "addLastSibling", null, null);
+            TestUtil.invokeVoidStaticMethod(JavaAstVisitor.class, "addLastSibling",
+                    null, null);
         }, "Method should not throw exception.");
     }
     /**

--- a/src/test/java/com/puppycrawl/tools/checkstyle/MainTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/MainTest.java
@@ -508,7 +508,8 @@ public class MainTest {
     public void testGetOutputStreamOptionsMethod() throws Exception {
         final Path path = new File(getPath("InputMain.java")).toPath();
         final OutputStreamOptions option =
-                TestUtil.invokeStaticMethod(Main.class, "getOutputStreamOptions", path);
+                TestUtil.invokeStaticMethod(Main.class, "getOutputStreamOptions",
+                        OutputStreamOptions.class, path);
         assertWithMessage("Main.getOutputStreamOptions return CLOSE on not null Path")
                 .that(option)
                 .isEqualTo(OutputStreamOptions.CLOSE);
@@ -813,7 +814,8 @@ public class MainTest {
     public void testLoadPropertiesIoException() throws Exception {
         final Class<?> cliOptionsClass = Class.forName(Main.class.getName());
         try {
-            TestUtil.invokeStaticMethod(cliOptionsClass, "loadProperties", new File("."));
+            TestUtil.invokeVoidStaticMethod(cliOptionsClass,
+                    "loadProperties", new File("."));
             assertWithMessage("Exception was expected").fail();
         }
         catch (ReflectiveOperationException exc) {
@@ -911,7 +913,7 @@ public class MainTest {
             }
         };
 
-        final List<File> result = TestUtil.invokeStaticMethod(Main.class, "listFiles",
+        final List<File> result = TestUtil.invokeStaticMethodList(Main.class, "listFiles",
                 fileMock, new ArrayList<>());
         assertWithMessage("Invalid result size")
             .that(result)
@@ -948,7 +950,7 @@ public class MainTest {
             }
         };
 
-        final List<File> result = TestUtil.invokeStaticMethod(Main.class, "listFiles",
+        final List<File> result = TestUtil.invokeStaticMethodList(Main.class, "listFiles",
                 fileMock, new ArrayList<>());
         assertWithMessage("Invalid result size")
             .that(result)
@@ -1834,7 +1836,7 @@ public class MainTest {
         final List<Pattern> list = new ArrayList<>();
         list.add(Pattern.compile("BAD_PATH"));
 
-        final List<File> result = TestUtil.invokeStaticMethod(
+        final List<File> result = TestUtil.invokeStaticMethodList(
                 optionsClass, "listFiles", new File(getFilePath("")), list);
         assertWithMessage("Invalid result size")
             .that(result)

--- a/src/test/java/com/puppycrawl/tools/checkstyle/PackageObjectFactoryTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/PackageObjectFactoryTest.java
@@ -332,7 +332,8 @@ public class PackageObjectFactoryTest {
     public void testCreateObjectByBruteForce() throws Exception {
         final String className = "Checker";
         final Checker checker =
-                TestUtil.invokeMethod(factory, "createModuleByTryInEachPackage", className);
+                TestUtil.invokeMethod(factory, "createModuleByTryInEachPackage",
+                        Checker.class, className);
         assertWithMessage("Checker should not be null when creating module from name")
             .that(checker)
             .isNotNull();
@@ -345,7 +346,8 @@ public class PackageObjectFactoryTest {
             new HashSet<>(Arrays.asList(BASE_PACKAGE, BASE_PACKAGE + ".checks.annotation")),
             Thread.currentThread().getContextClassLoader(), TRY_IN_ALL_REGISTERED_PACKAGES);
         final AnnotationLocationCheck check = TestUtil.invokeMethod(
-                packageObjectFactory, "createModuleByTryInEachPackage", checkName);
+                packageObjectFactory, "createModuleByTryInEachPackage",
+                AnnotationLocationCheck.class, checkName);
         assertWithMessage("Check should not be null when creating module from name")
             .that(check)
             .isNotNull();
@@ -369,7 +371,8 @@ public class PackageObjectFactoryTest {
         final Set<String> packages = Collections.singleton("test");
         final String className = "SomeClass";
         final String actual = TestUtil.invokeStaticMethod(
-                PackageObjectFactory.class, "joinPackageNamesWithClassName", className, packages);
+                PackageObjectFactory.class, "joinPackageNamesWithClassName", String.class,
+                className, packages);
         assertWithMessage("Invalid class name")
             .that(actual)
             .isEqualTo("test." + className);

--- a/src/test/java/com/puppycrawl/tools/checkstyle/PropertyCacheFileTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/PropertyCacheFileTest.java
@@ -483,7 +483,7 @@ public class PropertyCacheFileTest extends AbstractPathTestSupport {
 
             final ReflectiveOperationException ex =
                 getExpectedThrowable(ReflectiveOperationException.class, () -> {
-                    TestUtil.invokeStaticMethod(PropertyCacheFile.class,
+                    TestUtil.invokeVoidStaticMethod(PropertyCacheFile.class,
                             "getHashCodeBasedOnObjectContent", config);
                 });
             assertWithMessage("Invalid exception cause")

--- a/src/test/java/com/puppycrawl/tools/checkstyle/api/AbstractViolationReporterTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/api/AbstractViolationReporterTest.java
@@ -44,16 +44,17 @@ public class AbstractViolationReporterTest {
     @Test
     public void testGetMessageBundleWithPackage() throws Exception {
         assertWithMessage("violation bundle differs from expected")
-                .that(TestUtil.<String>invokeStaticMethod(AbstractViolationReporter.class,
-                        "getMessageBundle", "com.mycompany.checks.MyCoolCheck"))
+                .that(TestUtil.invokeStaticMethod(AbstractViolationReporter.class,
+                        "getMessageBundle", String.class,
+                        "com.mycompany.checks.MyCoolCheck"))
                 .isEqualTo("com.mycompany.checks.messages");
     }
 
     @Test
     public void testGetMessageBundleWithoutPackage() throws Exception {
         assertWithMessage("violation bundle differs from expected")
-                .that(TestUtil.<String>invokeStaticMethod(AbstractViolationReporter.class,
-                        "getMessageBundle", "MyCoolCheck"))
+                .that(TestUtil.invokeStaticMethod(AbstractViolationReporter.class,
+                        "getMessageBundle", String.class, "MyCoolCheck"))
                 .isEqualTo("messages");
     }
 

--- a/src/test/java/com/puppycrawl/tools/checkstyle/api/FileContentsTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/api/FileContentsTest.java
@@ -328,8 +328,8 @@ public class FileContentsTest {
         clangComments.put(2, Collections.emptyList());
 
         assertWithMessage("Invalid results")
-                .that(TestUtil.<Boolean>invokeMethod(fileContents,
-                        "hasIntersectionWithBlockComment", 1, 1, 1, 1))
+                .that(TestUtil.invokeMethod(fileContents,
+                        "hasIntersectionWithBlockComment", Boolean.class, 1, 1, 1, 1))
                 .isTrue();
     }
 

--- a/src/test/java/com/puppycrawl/tools/checkstyle/api/FileTextTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/api/FileTextTest.java
@@ -159,14 +159,14 @@ public class FileTextTest extends AbstractPathTestSupport {
         final FileText fileText = new FileText(new File("fileName"), Arrays.asList("1", "2"));
 
         assertWithMessage("Invalid line breaks")
-                .that(TestUtil.<int[]>invokeMethod(fileText, "findLineBreaks"))
+                .that(TestUtil.invokeMethod(fileText, "findLineBreaks", int[].class))
                 .isEqualTo(new int[] {0, 2, 4});
 
         final FileText fileText2 = new FileText(new File("fileName"), Arrays.asList("1", "2"));
         TestUtil.setInternalState(fileText2, "fullText", "1\n2");
 
         assertWithMessage("Invalid line breaks")
-                .that(TestUtil.<int[]>invokeMethod(fileText2, "findLineBreaks"))
+                .that(TestUtil.invokeMethod(fileText2, "findLineBreaks", int[].class))
                 .isEqualTo(new int[] {0, 2, 3});
     }
 
@@ -186,7 +186,7 @@ public class FileTextTest extends AbstractPathTestSupport {
         TestUtil.setInternalState(fileText, "fullText", null);
 
         assertWithMessage("Invalid line breaks")
-                .that(TestUtil.<int[]>invokeMethod(fileText, "findLineBreaks"))
+                .that(TestUtil.invokeMethod(fileText, "findLineBreaks", int[].class))
                 .isEqualTo(lineBreaks);
     }
 

--- a/src/test/java/com/puppycrawl/tools/checkstyle/bdd/InlineConfigParser.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/bdd/InlineConfigParser.java
@@ -816,7 +816,8 @@ public final class InlineConfigParser {
         final String actualDefaultAsString;
 
         if ("tokens".equals(propertyName)) {
-            actualDefault = TestUtil.invokeMethod(checkInstance, "getDefaultTokens");
+            actualDefault = TestUtil.invokeMethod(checkInstance,
+                    "getDefaultTokens", Object.class);
             propertyType = actualDefault.getClass();
             final int[] arr = (int[]) actualDefault;
             actualDefaultAsString = Arrays.stream(arr)
@@ -824,7 +825,8 @@ public final class InlineConfigParser {
                                           .collect(Collectors.joining(", "));
         }
         else if ("javadocTokens".equals(propertyName)) {
-            actualDefault = TestUtil.invokeMethod(checkInstance, "getDefaultJavadocTokens");
+            actualDefault = TestUtil.invokeMethod(checkInstance,
+                    "getDefaultJavadocTokens", Object.class);
             propertyType = actualDefault.getClass();
             final int[] arr = (int[]) actualDefault;
             actualDefaultAsString = Arrays.stream(arr)

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/AvoidEscapedUnicodeCharactersCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/AvoidEscapedUnicodeCharactersCheckTest.java
@@ -498,7 +498,7 @@ public class AvoidEscapedUnicodeCharactersCheckTest extends AbstractModuleTestSu
     @Test
     public void testCountMatches() throws Exception {
         final AvoidEscapedUnicodeCharactersCheck check = new AvoidEscapedUnicodeCharactersCheck();
-        final int actual = TestUtil.invokeMethod(check, "countMatches",
+        final int actual = TestUtil.invokeMethod(check, "countMatches", Integer.class,
                 Pattern.compile("\\\\u[a-fA-F\\d]{4}"), "\\u1234");
         assertWithMessage("Unexpected matches count")
             .that(actual)

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/NewlineAtEndOfFileCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/NewlineAtEndOfFileCheckTest.java
@@ -196,7 +196,7 @@ public class NewlineAtEndOfFileCheckTest
     public void testWrongSeparatorLength() throws Exception {
         try (RandomAccessFile file =
                      new ReadZeroRandomAccessFile(getPath("InputNewlineAtEndOfFileLf.java"), "r")) {
-            TestUtil.invokeMethod(new NewlineAtEndOfFileCheck(), "endsWithNewline", file,
+            TestUtil.invokeVoidMethod(new NewlineAtEndOfFileCheck(), "endsWithNewline", file,
                 LineSeparatorOption.LF);
             assertWithMessage("ReflectiveOperationException is expected").fail();
         }

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/SuppressWarningsHolderTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/SuppressWarningsHolderTest.java
@@ -298,7 +298,7 @@ public class SuppressWarningsHolderTest extends AbstractModuleTestSupport {
         parent.addChild(methodDef);
 
         try {
-            TestUtil.invokeMethod(holder, "getAllAnnotationValues", parent);
+            TestUtil.invokeVoidMethod(holder, "getAllAnnotationValues", parent);
             assertWithMessage("Exception expected").fail();
         }
         catch (ReflectiveOperationException exc) {
@@ -325,7 +325,7 @@ public class SuppressWarningsHolderTest extends AbstractModuleTestSupport {
         methodDef.setColumnNo(0);
 
         try {
-            TestUtil.invokeMethod(holder, "getAnnotationValues", methodDef);
+            TestUtil.invokeVoidMethod(holder, "getAnnotationValues", methodDef);
             assertWithMessage("Exception expected").fail();
         }
         catch (ReflectiveOperationException exc) {
@@ -358,7 +358,7 @@ public class SuppressWarningsHolderTest extends AbstractModuleTestSupport {
         parent.setColumnNo(0);
 
         try {
-            TestUtil.invokeMethod(holder, "getAnnotationTarget", methodDef);
+            TestUtil.invokeVoidMethod(holder, "getAnnotationTarget", methodDef);
             assertWithMessage("Exception expected").fail();
         }
         catch (ReflectiveOperationException exc) {

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/TranslationCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/TranslationCheckTest.java
@@ -219,7 +219,7 @@ public class TranslationCheckTest extends AbstractXmlTestSupport {
         check.configure(checkConfig);
         check.setMessageDispatcher(dispatcher);
 
-        final Set<String> keys = TestUtil.invokeMethod(check, "getTranslationKeys",
+        final Set<String> keys = TestUtil.invokeMethodSet(check, "getTranslationKeys",
                 new File(".no.such.file"));
         assertWithMessage("Translation keys should be empty when File is not found")
                 .that(keys)
@@ -249,7 +249,7 @@ public class TranslationCheckTest extends AbstractXmlTestSupport {
         check.setId("ID1");
 
         final Exception exception = new IOException("test exception");
-        TestUtil.invokeMethod(check, "logException", exception, new File(""));
+        TestUtil.invokeVoidMethod(check, "logException", exception, new File(""));
 
         assertWithMessage("expected number of errors to fire")
             .that(dispatcher.savedErrors.size())

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/UniquePropertiesCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/UniquePropertiesCheckTest.java
@@ -95,7 +95,8 @@ public class UniquePropertiesCheckTest extends AbstractModuleTestSupport {
         testStrings.add("445");
         final FileText fileText = new FileText(new File("some.properties"), testStrings);
         final Object lineNumber = TestUtil.invokeStaticMethod(
-                UniquePropertiesCheck.class, "getLineNumber", fileText, "some key");
+                UniquePropertiesCheck.class, "getLineNumber", Object.class,
+                fileText, "some key");
         assertWithMessage("Line number should not be null")
             .that(lineNumber)
             .isNotNull();
@@ -153,14 +154,16 @@ public class UniquePropertiesCheckTest extends AbstractModuleTestSupport {
                 .forName("com.puppycrawl.tools.checkstyle.checks."
                     + "UniquePropertiesCheck$UniqueProperties");
         final Object uniqueProperties = TestUtil.instantiate(uniquePropertiesClass);
-        final Object result = TestUtil.invokeMethod(uniqueProperties, "put", 1, "value");
+        final Object result = TestUtil.invokeMethod(uniqueProperties, "put",
+                Object.class, 1, "value");
         final Map<Object, Object> table = new HashMap<>();
         final Object expected = table.put(1, "value");
         assertWithMessage("Invalid result of put method")
             .that(result)
             .isEqualTo(expected);
 
-        final Object result2 = TestUtil.invokeMethod(uniqueProperties, "put", 1, "value");
+        final Object result2 = TestUtil.invokeMethod(uniqueProperties, "put",
+                Object.class, 1, "value");
         final Object expected2 = table.put(1, "value");
         assertWithMessage("Value should be substituted")
             .that(result2)

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/coding/RequireThisCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/coding/RequireThisCheckTest.java
@@ -523,12 +523,13 @@ public class RequireThisCheckTest extends AbstractModuleTestSupport {
         final Class<?> cls = Class.forName(RequireThisCheck.class.getName() + "$CatchFrame");
         final Object o = TestUtil.instantiate(cls, null, ident);
 
-        final DetailAstImpl actual = TestUtil.invokeMethod(o, "getFrameNameIdent");
+        final DetailAstImpl actual = TestUtil.invokeMethod(o,
+                "getFrameNameIdent", DetailAstImpl.class);
         assertWithMessage("expected ident token")
             .that(actual)
             .isSameInstanceAs(ident);
         assertWithMessage("expected catch frame type")
-            .that(TestUtil.invokeMethod(o, "getType").toString())
+            .that(TestUtil.invokeMethod(o, "getType", Object.class).toString())
             .isEqualTo("CATCH_FRAME");
     }
 
@@ -547,7 +548,7 @@ public class RequireThisCheckTest extends AbstractModuleTestSupport {
         final Object o = TestUtil.instantiate(cls, null, ident);
 
         assertWithMessage("expected for frame type")
-            .that(TestUtil.invokeMethod(o, "getType").toString())
+            .that(TestUtil.invokeMethod(o, "getType", Object.class).toString())
             .isEqualTo("FOR_FRAME");
     }
 

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/design/VisibilityModifierCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/design/VisibilityModifierCheckTest.java
@@ -430,7 +430,8 @@ public class VisibilityModifierCheckTest
             new File(getPath("InputVisibilityModifierIsStarImport.java")),
             JavaParser.Options.WITHOUT_COMMENTS).getFirstChild().getNextSibling();
         final VisibilityModifierCheck check = new VisibilityModifierCheck();
-        final boolean actual = TestUtil.invokeMethod(check, "isStarImport", importAst);
+        final boolean actual = TestUtil.invokeMethod(check, "isStarImport",
+                Boolean.class, importAst);
 
         assertWithMessage("Should return true when star import is passed")
                 .that(actual)

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/header/HeaderCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/header/HeaderCheckTest.java
@@ -210,7 +210,7 @@ public class HeaderCheckTest extends AbstractModuleTestSupport {
 
         final ReflectiveOperationException ex =
                 getExpectedThrowable(ReflectiveOperationException.class,
-                        () -> TestUtil.invokeMethod(check, "loadHeaderFile"));
+                        () -> TestUtil.invokeVoidMethod(check, "loadHeaderFile"));
         assertWithMessage("Invalid exception cause message")
             .that(ex)
                 .hasCauseThat()
@@ -272,7 +272,7 @@ public class HeaderCheckTest extends AbstractModuleTestSupport {
         check.setHeader("Header");
         final ReflectiveOperationException ex =
                 getExpectedThrowable(ReflectiveOperationException.class,
-                        () -> TestUtil.invokeMethod(check, "loadHeaderFile"));
+                        () -> TestUtil.invokeVoidMethod(check, "loadHeaderFile"));
         assertWithMessage("Invalid exception cause message")
                 .that(ex)
                 .hasCauseThat()

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/imports/CustomImportOrderCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/imports/CustomImportOrderCheckTest.java
@@ -413,7 +413,8 @@ public class CustomImportOrderCheckTest extends AbstractModuleTestSupport {
     public void testGetFullImportIdent() throws Exception {
         final Class<?> clazz = CustomImportOrderCheck.class;
         final Object t = TestUtil.instantiate(clazz);
-        final Object actual = TestUtil.invokeMethod(t, "getFullImportIdent", new Object[] {null});
+        final Object actual = TestUtil.invokeMethod(t, "getFullImportIdent",
+                Object.class, new Object[] {null});
 
         final String expected = "";
         assertWithMessage("Invalid getFullImportIdent result")

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/imports/ImportControlLoaderTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/imports/ImportControlLoaderTest.java
@@ -98,7 +98,7 @@ public class ImportControlLoaderTest {
             };
         try {
             final Class<?> clazz = ImportControlLoader.class;
-            TestUtil.invokeStaticMethod(clazz, "safeGet", attr, "you_cannot_find_me");
+            TestUtil.invokeVoidStaticMethod(clazz, "safeGet", attr, "you_cannot_find_me");
             assertWithMessage("exception expected").fail();
         }
         catch (ReflectiveOperationException exc) {
@@ -121,7 +121,7 @@ public class ImportControlLoaderTest {
         final InputSource source = new InputSource();
         try {
             final Class<?> clazz = ImportControlLoader.class;
-            TestUtil.invokeStaticMethod(clazz, "load", source,
+            TestUtil.invokeVoidStaticMethod(clazz, "load", source,
                     new File(getPath("InputImportControlLoaderComplete.xml")).toURI());
             assertWithMessage("exception expected").fail();
         }

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocTagInfoTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocTagInfoTest.java
@@ -110,7 +110,7 @@ public class JavadocTagInfoTest {
             astParent.setType(TokenTypes.LITERAL_CATCH);
 
             final DetailAstImpl ast = new DetailAstImpl();
-            TestUtil.invokeMethod(ast, "setParent", astParent);
+            TestUtil.invokeVoidMethod(ast, "setParent", astParent);
 
             final int[] validTypes = {
                 TokenTypes.PACKAGE_DEF,
@@ -147,7 +147,7 @@ public class JavadocTagInfoTest {
         final DetailAstImpl ast = new DetailAstImpl();
         final DetailAstImpl astParent = new DetailAstImpl();
         astParent.setType(TokenTypes.LITERAL_CATCH);
-        TestUtil.invokeMethod(ast, "setParent", astParent);
+        TestUtil.invokeVoidMethod(ast, "setParent", astParent);
 
         final int[] validTypes = {
             TokenTypes.CLASS_DEF,
@@ -184,7 +184,7 @@ public class JavadocTagInfoTest {
         final DetailAstImpl ast = new DetailAstImpl();
         final DetailAstImpl astParent = new DetailAstImpl();
         astParent.setType(TokenTypes.LITERAL_CATCH);
-        TestUtil.invokeMethod(ast, "setParent", astParent);
+        TestUtil.invokeVoidMethod(ast, "setParent", astParent);
 
         final int[] validTypes = {
             TokenTypes.VARIABLE_DEF,

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/metrics/NPathComplexityCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/metrics/NPathComplexityCheckTest.java
@@ -402,7 +402,7 @@ public class NPathComplexityCheckTest extends AbstractModuleTestSupport {
         token.setColumnNo(0);
 
         assertWithMessage("isAfter must be true for same line/column")
-                .that(TestUtil.<Boolean>invokeMethod(tokenEnd, "isAfter", token))
+                .that(TestUtil.invokeMethod(tokenEnd, "isAfter", Boolean.class, token))
                 .isTrue();
     }
 

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/whitespace/ParenPadCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/whitespace/ParenPadCheckTest.java
@@ -562,7 +562,7 @@ public class ParenPadCheckTest
         for (int token : check.getAcceptableTokens()) {
             ast.setType(token);
             assertWithMessage(message + TokenUtil.getTokenName(token))
-                    .that(TestUtil.<Boolean>invokeMethod(check, "isAcceptableToken", ast))
+                    .that(TestUtil.invokeMethod(check, "isAcceptableToken", Boolean.class, ast))
                     .isTrue();
         }
     }

--- a/src/test/java/com/puppycrawl/tools/checkstyle/filters/SuppressionsLoaderTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/filters/SuppressionsLoaderTest.java
@@ -235,7 +235,7 @@ public class SuppressionsLoaderTest extends AbstractPathTestSupport {
         final String sourceName = "InputSuppressionsLoaderNone.xml";
 
         try {
-            TestUtil.invokeStaticMethod(SuppressionsLoader.class, "loadSuppressions",
+            TestUtil.invokeVoidStaticMethod(SuppressionsLoader.class, "loadSuppressions",
                     new InputSource(sourceName), sourceName);
             assertWithMessage("InvocationTargetException is expected").fail();
         }
@@ -253,7 +253,7 @@ public class SuppressionsLoaderTest extends AbstractPathTestSupport {
         final String sourceName = "InputSuppressionsLoaderNone.xml";
 
         try {
-            TestUtil.invokeStaticMethod(SuppressionsLoader.class, "loadSuppressions",
+            TestUtil.invokeVoidStaticMethod(SuppressionsLoader.class, "loadSuppressions",
                     new InputSource(), sourceName);
             assertWithMessage("InvocationTargetException is expected").fail();
         }

--- a/src/test/java/com/puppycrawl/tools/checkstyle/internal/utils/TestUtil.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/internal/utils/TestUtil.java
@@ -21,6 +21,7 @@ package com.puppycrawl.tools.checkstyle.internal.utils;
 
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
+import java.io.File;
 import java.io.OutputStream;
 import java.lang.reflect.Constructor;
 import java.lang.reflect.Field;
@@ -190,7 +191,7 @@ public final class TestUtil {
             TreeWalkerFilter filter, TreeWalkerAuditEvent event,
             String fieldName, Predicate<Object> isClear) throws Exception {
         filter.accept(event);
-        invokeMethod(filter, "finishLocalSetup");
+        invokeVoidMethod(filter, "finishLocalSetup");
         final Field resultField = getClassDeclaredField(filter.getClass(), fieldName);
         return isClear.test(resultField.get(filter));
     }
@@ -485,36 +486,97 @@ public final class TestUtil {
      *
      * @param instance the instance whose method to invoke
      * @param methodToExecute the name of the method to invoke
+     * @param resultClazz used for cast of result
      * @param arguments the optional arguments
      * @param <T> the type of the result
+     * @return the method's result
+     * @throws ReflectiveOperationException if the method invocation failed
+     */
+    public static <T> T invokeMethod(Object instance, String methodToExecute,
+                                     Class<T> resultClazz, Object... arguments)
+            throws ReflectiveOperationException {
+        final Class<?> ownerClass = instance.getClass();
+        final Method method = getClassDeclaredMethod(ownerClass, methodToExecute, arguments.length);
+        return resultClazz.cast(method.invoke(instance, arguments));
+    }
+
+    /**
+     * Helper method to invoke private method for an instance with cast to Object.
+     *
+     * @param instance the instance whose method to invoke
+     * @param methodToExecute the name of the method to invoke
+     * @param arguments the optional arguments
+     * @throws ReflectiveOperationException if the method invocation failed
+     */
+    public static void invokeVoidMethod(Object instance,
+                                        String methodToExecute, Object... arguments)
+            throws ReflectiveOperationException {
+        invokeMethod(instance, methodToExecute, Object.class, arguments);
+    }
+
+    /**
+     * Helper method to invoke private method for an instance with cast to Set.
+     *
+     * @param instance the instance whose method to invoke
+     * @param methodToExecute the name of the method to invoke
+     * @param arguments the optional arguments
      * @return the method's result
      * @throws ReflectiveOperationException if the method invocation failed
      * @noinspection unchecked
      * @noinspectionreason unchecked - unchecked cast is ok on test code
      */
-    public static <T> T invokeMethod(Object instance,
-            String methodToExecute, Object... arguments) throws ReflectiveOperationException {
-        final Class<?> clss = instance.getClass();
-        final Method method = getClassDeclaredMethod(clss, methodToExecute, arguments.length);
-        return (T) method.invoke(instance, arguments);
+    public static Set<String> invokeMethodSet(Object instance, String methodToExecute,
+                                       Object... arguments) throws ReflectiveOperationException {
+        return (Set<String>) invokeMethod(instance, methodToExecute, Set.class, arguments);
     }
 
     /**
      * Invokes a static private method for a class.
      *
-     * @param clss the class whose static method to invoke
+     * @param ownerClass the class whose static method to invoke
      * @param methodToExecute the name of the method to invoke
+     * @param resultClass used for cast of result
      * @param arguments the optional arguments
      * @param <T> the type of the result
+     * @return the method's result
+     * @throws ReflectiveOperationException if the method invocation failed
+     */
+    public static <T> T invokeStaticMethod(Class<?> ownerClass,
+            String methodToExecute, Class<T> resultClass, Object... arguments)
+            throws ReflectiveOperationException {
+        final Method method = getClassDeclaredMethod(ownerClass, methodToExecute, arguments.length);
+        return resultClass.cast(method.invoke(null, arguments));
+    }
+
+    /**
+     * Helper method to invoke static private method for an instance with cast to Object.
+     *
+     * @param ownerClass the class whose static method to invoke
+     * @param methodToExecute the name of the method to invoke
+     * @param arguments the optional arguments
+     * @throws ReflectiveOperationException if the method invocation failed
+     */
+    public static void invokeVoidStaticMethod(Class<?> ownerClass,
+                                              String methodToExecute, Object... arguments)
+            throws ReflectiveOperationException {
+        invokeStaticMethod(ownerClass, methodToExecute, Object.class, arguments);
+    }
+
+    /**
+     * Helper method to invoke static private method for an instance with cast to List.
+     *
+     * @param ownerClass the class whose static method to invoke
+     * @param methodToExecute the name of the method to invoke
+     * @param arguments the optional arguments
      * @return the method's result
      * @throws ReflectiveOperationException if the method invocation failed
      * @noinspection unchecked
      * @noinspectionreason unchecked - unchecked cast is ok on test code
      */
-    public static <T> T invokeStaticMethod(Class<?> clss,
-            String methodToExecute, Object... arguments) throws ReflectiveOperationException {
-        final Method method = getClassDeclaredMethod(clss, methodToExecute, arguments.length);
-        return (T) method.invoke(null, arguments);
+    public static List<File> invokeStaticMethodList(Class<?> ownerClass,
+                                                    String methodToExecute, Object... arguments)
+            throws ReflectiveOperationException {
+        return (List<File>) invokeStaticMethod(ownerClass, methodToExecute, List.class, arguments);
     }
 
     /**


### PR DESCRIPTION
Issue: #17845
Solved Violations https://errorprone.info/bugpattern/TypeParameterUnusedInFormals

```
[WARNING] /C:/Users/athar/OneDrive/Desktop/checkstyle/src/test/java/com/puppycrawl/tools/checkstyle/internal/utils/TestUtil.java:[495,25] [TypeParameterUnusedInFormals] Declaring a type parameter that is only used in the return type is a misuse of generics: operations on the type parameter are unchecked, it hides unsafe casts at invocations of the method, and it interacts badly with method overload resolution.
    (see https://errorprone.info/bugpattern/TypeParameterUnusedInFormals)
[WARNING] /C:/Users/athar/OneDrive/Desktop/checkstyle/src/test/java/com/puppycrawl/tools/checkstyle/internal/utils/TestUtil.java:[514,25] [TypeParameterUnusedInFormals] Declaring a type parameter that is only used in the return type is a misuse of generics: operations on the type parameter are unchecked, it hides unsafe casts at invocations of the method, and it interacts badly with method overload resolution.
    (see https://errorprone.info/bugpattern/TypeParameterUnusedInFormals)
```