### PR TITLE
Issue #3730: Add type annotation tokens to AnnotationLocation check

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/annotation/AnnotationLocationCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/annotation/AnnotationLocationCheck.java
@@ -169,6 +169,12 @@ public class AnnotationLocationCheck extends AbstractCheck {
             TokenTypes.ANNOTATION_FIELD_DEF,
             TokenTypes.RECORD_DEF,
             TokenTypes.COMPACT_CTOR_DEF,
+            TokenTypes.TYPECAST,
+            TokenTypes.TYPE_ARGUMENT,
+            TokenTypes.DOT,
+            TokenTypes.LITERAL_NEW,
+            TokenTypes.LITERAL_THROWS,
+            TokenTypes.IMPLEMENTS_CLAUSE,
         };
     }
 

--- a/src/site/xdoc/checks/annotation/annotationlocation.xml
+++ b/src/site/xdoc/checks/annotation/annotationlocation.xml
@@ -114,6 +114,18 @@ public String getNameIfPresent() { ... }
                     RECORD_DEF</a>
                 , <a href="../../apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#COMPACT_CTOR_DEF">
                     COMPACT_CTOR_DEF</a>
+                , <a href="../../apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#TYPECAST">
+                    TYPECAST</a>
+                , <a href="../../apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#TYPE_ARGUMENT">
+                    TYPE_ARGUMENT</a>
+                , <a href="../../apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#DOT">
+                    DOT</a>
+                , <a href="../../apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#LITERAL_NEW">
+                    LITERAL_NEW</a>
+                , <a href="../../apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#LITERAL_THROWS">
+                    LITERAL_THROWS</a>
+                , <a href="../../apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#IMPLEMENTS_CLAUSE">
+                    IMPLEMENTS_CLAUSE</a>
                   .
               </td>
               <td>
@@ -277,6 +289,133 @@ class Example4 {
   @SuppressWarnings("deprecation") public int foo() { return 1; }
   // violation above, 'Annotation 'SuppressWarnings' should be alone on line.'
   @NotNull @Mock DataLoader loader2;
+}
+</code></pre></div><hr class="example-separator"/>
+        <p id="Example5-config">
+          To configure the check to validate annotations on type arguments:
+        </p>
+        <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
+&lt;module name="Checker"&gt;
+  &lt;module name="TreeWalker"&gt;
+    &lt;module name="AnnotationLocation"&gt;
+      &lt;property name="tokens" value="TYPE_ARGUMENT"/&gt;
+    &lt;/module&gt;
+  &lt;/module&gt;
+&lt;/module&gt;
+</code></pre></div>
+        <p id="Example5-code">Example:</p>
+        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+class Example5 {
+  List&lt;@TypeArgAnnotation1 String&gt; names; // ok
+  List&lt;@TypeArgAnnotation1 @TypeArgAnnotation2 String&gt; data;
+  // violation above, 'Annotation 'TypeArgAnnotation2' should be alone on line.'
+  Map&lt;@TypeArgAnnotation1 String, @TypeArgAnnotation1 Integer&gt; map; // ok
+}
+</code></pre></div><hr class="example-separator"/>
+        <p id="Example6-config">
+          To configure the check to validate annotations on typecasts:
+        </p>
+        <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
+&lt;module name="Checker"&gt;
+  &lt;module name="TreeWalker"&gt;
+    &lt;module name="AnnotationLocation"&gt;
+      &lt;property name="tokens" value="TYPECAST"/&gt;
+    &lt;/module&gt;
+  &lt;/module&gt;
+&lt;/module&gt;
+</code></pre></div>
+        <p id="Example6-code">Example:</p>
+        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+class Example6 {
+  void method(Object obj) {
+    String s1 = (@TypeCastAnnotation1 String) obj; // ok
+    String s2 = (@TypeCastAnnotation1 @TypeCastAnnotation2 String) obj;
+    // violation above, 'Annotation 'TypeCastAnnotation2' should be alone on line.'
+  }
+}
+</code></pre></div><hr class="example-separator"/>
+        <p id="Example7-config">
+          To configure the check to validate annotations on constructor invocations:
+        </p>
+        <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
+&lt;module name="Checker"&gt;
+  &lt;module name="TreeWalker"&gt;
+    &lt;module name="AnnotationLocation"&gt;
+      &lt;property name="tokens" value="LITERAL_NEW"/&gt;
+    &lt;/module&gt;
+  &lt;/module&gt;
+&lt;/module&gt;
+</code></pre></div>
+        <p id="Example7-code">Example:</p>
+        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+class Example7 {
+  void method() {
+    String[] arr1 = new @NewObjectAnnotation1 String[10]; // ok
+    String[] arr2 = new @NewObjectAnnotation1 @NewObjectAnnotation2 String[10];
+    // violation above, 'Annotation 'NewObjectAnnotation2' should be alone on line.'
+    Object obj = new @NewObjectAnnotation1 Object(); // ok
+  }
+}
+</code></pre></div><hr class="example-separator"/>
+        <p id="Example8-config">
+          To configure the check to validate annotations on exception types in throws clause:
+        </p>
+        <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
+&lt;module name="Checker"&gt;
+  &lt;module name="TreeWalker"&gt;
+    &lt;module name="AnnotationLocation"&gt;
+      &lt;property name="tokens" value="LITERAL_THROWS"/&gt;
+    &lt;/module&gt;
+  &lt;/module&gt;
+&lt;/module&gt;
+</code></pre></div>
+        <p id="Example8-code">Example:</p>
+        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+class Example8 {
+  void method1() throws @ThrowsAnnotation1 IOException { } // ok
+  void method2() throws @ThrowsAnnotation1 @ThrowsAnnotation2 IOException { }
+  // violation above, 'Annotation 'ThrowsAnnotation2' should be alone on line.'
+}
+</code></pre></div><hr class="example-separator"/>
+        <p id="Example9-config">
+          To configure the check to validate annotations on interface types in implements clause:
+        </p>
+        <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
+&lt;module name="Checker"&gt;
+  &lt;module name="TreeWalker"&gt;
+    &lt;module name="AnnotationLocation"&gt;
+      &lt;property name="tokens" value="IMPLEMENTS_CLAUSE"/&gt;
+    &lt;/module&gt;
+  &lt;/module&gt;
+&lt;/module&gt;
+</code></pre></div>
+        <p id="Example9-code">Example:</p>
+        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+class Example9 implements @ImplementsAnnotation1 Serializable { } // ok
+class Example9a implements @ImplementsAnnotation1 @ImplementsAnnotation2
+        Serializable { }
+// violation above, 'Annotation 'ImplementsAnnotation2' should be alone on line.'
+</code></pre></div><hr class="example-separator"/>
+        <p id="Example10-config">
+          To configure the check to validate annotations on qualified types:
+        </p>
+        <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
+&lt;module name="Checker"&gt;
+  &lt;module name="TreeWalker"&gt;
+    &lt;module name="AnnotationLocation"&gt;
+      &lt;property name="tokens" value="DOT"/&gt;
+    &lt;/module&gt;
+  &lt;/module&gt;
+&lt;/module&gt;
+</code></pre></div>
+        <p id="Example10-code">Example:</p>
+        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+class Example10 {
+  void method() {
+    java.lang.@DotAnnotation1 String s; // ok
+    java.lang.@DotAnnotation1 @DotAnnotation2 String s2;
+    // violation above, 'Annotation 'DotAnnotation2' should be alone on line.'
+  }
 }
 </code></pre></div>
       </subsection>

--- a/src/site/xdoc/checks/annotation/annotationlocation.xml.template
+++ b/src/site/xdoc/checks/annotation/annotationlocation.xml.template
@@ -91,6 +91,90 @@
           <param name="path"
                    value="resources/com/puppycrawl/tools/checkstyle/checks/annotation/annotationlocation/Example4.java"/>
             <param name="type" value="code"/>
+        </macro><hr class="example-separator"/>
+        <p id="Example5-config">
+          To configure the check to validate annotations on type arguments:
+        </p>
+        <macro name="example">
+          <param name="path"
+                 value="resources/com/puppycrawl/tools/checkstyle/checks/annotation/annotationlocation/Example5.java"/>
+          <param name="type" value="config"/>
+        </macro>
+        <p id="Example5-code">Example:</p>
+        <macro name="example">
+          <param name="path"
+                   value="resources/com/puppycrawl/tools/checkstyle/checks/annotation/annotationlocation/Example5.java"/>
+            <param name="type" value="code"/>
+        </macro><hr class="example-separator"/>
+        <p id="Example6-config">
+          To configure the check to validate annotations on typecasts:
+        </p>
+        <macro name="example">
+          <param name="path"
+                 value="resources/com/puppycrawl/tools/checkstyle/checks/annotation/annotationlocation/Example6.java"/>
+          <param name="type" value="config"/>
+        </macro>
+        <p id="Example6-code">Example:</p>
+        <macro name="example">
+          <param name="path"
+                   value="resources/com/puppycrawl/tools/checkstyle/checks/annotation/annotationlocation/Example6.java"/>
+            <param name="type" value="code"/>
+        </macro><hr class="example-separator"/>
+        <p id="Example7-config">
+          To configure the check to validate annotations on constructor invocations:
+        </p>
+        <macro name="example">
+          <param name="path"
+                 value="resources/com/puppycrawl/tools/checkstyle/checks/annotation/annotationlocation/Example7.java"/>
+          <param name="type" value="config"/>
+        </macro>
+        <p id="Example7-code">Example:</p>
+        <macro name="example">
+          <param name="path"
+                   value="resources/com/puppycrawl/tools/checkstyle/checks/annotation/annotationlocation/Example7.java"/>
+            <param name="type" value="code"/>
+        </macro><hr class="example-separator"/>
+        <p id="Example8-config">
+          To configure the check to validate annotations on exception types in throws clause:
+        </p>
+        <macro name="example">
+          <param name="path"
+                 value="resources/com/puppycrawl/tools/checkstyle/checks/annotation/annotationlocation/Example8.java"/>
+          <param name="type" value="config"/>
+        </macro>
+        <p id="Example8-code">Example:</p>
+        <macro name="example">
+          <param name="path"
+                   value="resources/com/puppycrawl/tools/checkstyle/checks/annotation/annotationlocation/Example8.java"/>
+            <param name="type" value="code"/>
+        </macro><hr class="example-separator"/>
+        <p id="Example9-config">
+          To configure the check to validate annotations on interface types in implements clause:
+        </p>
+        <macro name="example">
+          <param name="path"
+                 value="resources/com/puppycrawl/tools/checkstyle/checks/annotation/annotationlocation/Example9.java"/>
+          <param name="type" value="config"/>
+        </macro>
+        <p id="Example9-code">Example:</p>
+        <macro name="example">
+          <param name="path"
+                   value="resources/com/puppycrawl/tools/checkstyle/checks/annotation/annotationlocation/Example9.java"/>
+            <param name="type" value="code"/>
+        </macro><hr class="example-separator"/>
+        <p id="Example10-config">
+          To configure the check to validate annotations on qualified types:
+        </p>
+        <macro name="example">
+          <param name="path"
+                 value="resources/com/puppycrawl/tools/checkstyle/checks/annotation/annotationlocation/Example10.java"/>
+          <param name="type" value="config"/>
+        </macro>
+        <p id="Example10-code">Example:</p>
+        <macro name="example">
+          <param name="path"
+                   value="resources/com/puppycrawl/tools/checkstyle/checks/annotation/annotationlocation/Example10.java"/>
+            <param name="type" value="code"/>
         </macro>
       </subsection>
 

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/annotation/AnnotationLocationCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/annotation/AnnotationLocationCheckTest.java
@@ -150,6 +150,12 @@ public class AnnotationLocationCheckTest extends AbstractModuleTestSupport {
             TokenTypes.ANNOTATION_FIELD_DEF,
             TokenTypes.RECORD_DEF,
             TokenTypes.COMPACT_CTOR_DEF,
+            TokenTypes.TYPECAST,
+            TokenTypes.TYPE_ARGUMENT,
+            TokenTypes.DOT,
+            TokenTypes.LITERAL_NEW,
+            TokenTypes.LITERAL_THROWS,
+            TokenTypes.IMPLEMENTS_CLAUSE,
         };
         assertWithMessage("Default acceptable tokens are invalid")
                 .that(actual)

--- a/src/test/java/com/puppycrawl/tools/checkstyle/internal/AllChecksTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/internal/AllChecksTest.java
@@ -151,7 +151,10 @@ public class AllChecksTest extends AbstractModuleTestSupport {
         CHECKSTYLE_TOKENS_IN_CONFIG_TO_IGNORE.put("AnnotationLocation",
                 Stream.of("CLASS_DEF", "CTOR_DEF", "ENUM_DEF", "INTERFACE_DEF",
                         "METHOD_DEF", "VARIABLE_DEF",
-                        "RECORD_DEF", "COMPACT_CTOR_DEF")
+                        "RECORD_DEF", "COMPACT_CTOR_DEF",
+                        // Type annotation tokens - opt-in only, not used by default
+                        "TYPECAST", "TYPE_ARGUMENT", "DOT", "LITERAL_NEW",
+                        "LITERAL_THROWS", "IMPLEMENTS_CLAUSE")
                         .collect(Collectors.toUnmodifiableSet()));
         CHECKSTYLE_TOKENS_IN_CONFIG_TO_IGNORE.put("NoLineWrap", Stream.of(
                 // method/constructor declaration could be long due to "parameters/exceptions", it
@@ -188,7 +191,10 @@ public class AllChecksTest extends AbstractModuleTestSupport {
         GOOGLE_TOKENS_IN_CONFIG_TO_IGNORE.put("AnnotationLocation", Stream.of(
                 // state of the configuration when test was made until reason found in
                 // https://github.com/checkstyle/checkstyle/issues/3730
-                "ANNOTATION_DEF", "ANNOTATION_FIELD_DEF", "ENUM_CONSTANT_DEF", "PACKAGE_DEF")
+                "ANNOTATION_DEF", "ANNOTATION_FIELD_DEF", "ENUM_CONSTANT_DEF", "PACKAGE_DEF",
+                // Type annotation tokens - opt-in only, not used by default
+                "TYPECAST", "TYPE_ARGUMENT", "DOT", "LITERAL_NEW",
+                "LITERAL_THROWS", "IMPLEMENTS_CLAUSE")
                 .collect(Collectors.toUnmodifiableSet()));
         GOOGLE_TOKENS_IN_CONFIG_TO_IGNORE.put("AbbreviationAsWordInName", Stream.of(
                 // enum values should be uppercase

--- a/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/annotation/annotationlocation/Example10.java
+++ b/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/annotation/annotationlocation/Example10.java
@@ -1,0 +1,30 @@
+/*xml
+<module name="Checker">
+  <module name="TreeWalker">
+    <module name="AnnotationLocation">
+      <property name="tokens" value="DOT"/>
+    </module>
+  </module>
+</module>
+*/
+
+package com.puppycrawl.tools.checkstyle.checks.annotation.annotationlocation;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Target;
+
+@Target(ElementType.TYPE_USE)
+@interface DotAnnotation1 {}
+
+@Target(ElementType.TYPE_USE)
+@interface DotAnnotation2 {}
+
+// xdoc section -- start
+class Example10 {
+  void method() {
+    java.lang.@DotAnnotation1 String s; // ok
+    java.lang.@DotAnnotation1 @DotAnnotation2 String s2;
+    // violation above, 'Annotation 'DotAnnotation2' should be alone on line.'
+  }
+}
+// xdoc section -- end

--- a/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/annotation/annotationlocation/Example5.java
+++ b/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/annotation/annotationlocation/Example5.java
@@ -1,0 +1,31 @@
+/*xml
+<module name="Checker">
+  <module name="TreeWalker">
+    <module name="AnnotationLocation">
+      <property name="tokens" value="TYPE_ARGUMENT"/>
+    </module>
+  </module>
+</module>
+*/
+
+package com.puppycrawl.tools.checkstyle.checks.annotation.annotationlocation;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Target;
+import java.util.List;
+import java.util.Map;
+
+@Target(ElementType.TYPE_USE)
+@interface TypeArgAnnotation1 {}
+
+@Target(ElementType.TYPE_USE)
+@interface TypeArgAnnotation2 {}
+
+// xdoc section -- start
+class Example5 {
+  List<@TypeArgAnnotation1 String> names; // ok
+  List<@TypeArgAnnotation1 @TypeArgAnnotation2 String> data;
+  // violation above, 'Annotation 'TypeArgAnnotation2' should be alone on line.'
+  Map<@TypeArgAnnotation1 String, @TypeArgAnnotation1 Integer> map; // ok
+}
+// xdoc section -- end

--- a/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/annotation/annotationlocation/Example6.java
+++ b/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/annotation/annotationlocation/Example6.java
@@ -1,0 +1,30 @@
+/*xml
+<module name="Checker">
+  <module name="TreeWalker">
+    <module name="AnnotationLocation">
+      <property name="tokens" value="TYPECAST"/>
+    </module>
+  </module>
+</module>
+*/
+
+package com.puppycrawl.tools.checkstyle.checks.annotation.annotationlocation;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Target;
+
+@Target(ElementType.TYPE_USE)
+@interface TypeCastAnnotation1 {}
+
+@Target(ElementType.TYPE_USE)
+@interface TypeCastAnnotation2 {}
+
+// xdoc section -- start
+class Example6 {
+  void method(Object obj) {
+    String s1 = (@TypeCastAnnotation1 String) obj; // ok
+    String s2 = (@TypeCastAnnotation1 @TypeCastAnnotation2 String) obj;
+    // violation above, 'Annotation 'TypeCastAnnotation2' should be alone on line.'
+  }
+}
+// xdoc section -- end

--- a/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/annotation/annotationlocation/Example7.java
+++ b/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/annotation/annotationlocation/Example7.java
@@ -1,0 +1,31 @@
+/*xml
+<module name="Checker">
+  <module name="TreeWalker">
+    <module name="AnnotationLocation">
+      <property name="tokens" value="LITERAL_NEW"/>
+    </module>
+  </module>
+</module>
+*/
+
+package com.puppycrawl.tools.checkstyle.checks.annotation.annotationlocation;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Target;
+
+@Target(ElementType.TYPE_USE)
+@interface NewObjectAnnotation1 {}
+
+@Target(ElementType.TYPE_USE)
+@interface NewObjectAnnotation2 {}
+
+// xdoc section -- start
+class Example7 {
+  void method() {
+    String[] arr1 = new @NewObjectAnnotation1 String[10]; // ok
+    String[] arr2 = new @NewObjectAnnotation1 @NewObjectAnnotation2 String[10];
+    // violation above, 'Annotation 'NewObjectAnnotation2' should be alone on line.'
+    Object obj = new @NewObjectAnnotation1 Object(); // ok
+  }
+}
+// xdoc section -- end

--- a/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/annotation/annotationlocation/Example8.java
+++ b/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/annotation/annotationlocation/Example8.java
@@ -1,0 +1,29 @@
+/*xml
+<module name="Checker">
+  <module name="TreeWalker">
+    <module name="AnnotationLocation">
+      <property name="tokens" value="LITERAL_THROWS"/>
+    </module>
+  </module>
+</module>
+*/
+
+package com.puppycrawl.tools.checkstyle.checks.annotation.annotationlocation;
+
+import java.io.IOException;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Target;
+
+@Target(ElementType.TYPE_USE)
+@interface ThrowsAnnotation1 {}
+
+@Target(ElementType.TYPE_USE)
+@interface ThrowsAnnotation2 {}
+
+// xdoc section -- start
+class Example8 {
+  void method1() throws @ThrowsAnnotation1 IOException { } // ok
+  void method2() throws @ThrowsAnnotation1 @ThrowsAnnotation2 IOException { }
+  // violation above, 'Annotation 'ThrowsAnnotation2' should be alone on line.'
+}
+// xdoc section -- end

--- a/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/annotation/annotationlocation/Example9.java
+++ b/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/annotation/annotationlocation/Example9.java
@@ -1,0 +1,28 @@
+/*xml
+<module name="Checker">
+  <module name="TreeWalker">
+    <module name="AnnotationLocation">
+      <property name="tokens" value="IMPLEMENTS_CLAUSE"/>
+    </module>
+  </module>
+</module>
+*/
+
+package com.puppycrawl.tools.checkstyle.checks.annotation.annotationlocation;
+
+import java.io.Serializable;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Target;
+
+@Target(ElementType.TYPE_USE)
+@interface ImplementsAnnotation1 {}
+
+@Target(ElementType.TYPE_USE)
+@interface ImplementsAnnotation2 {}
+
+// xdoc section -- start
+class Example9 implements @ImplementsAnnotation1 Serializable { } // ok
+class Example9a implements @ImplementsAnnotation1 @ImplementsAnnotation2
+        Serializable { }
+// violation above, 'Annotation 'ImplementsAnnotation2' should be alone on line.'
+// xdoc section -- end


### PR DESCRIPTION
#3730 
Summary:
**New tokens:**
- `TYPECAST` - Annotations on type casts
- `TYPE_ARGUMENT` - Annotations on generic type arguments  
- `DOT` - Annotations in qualified type names
- `LITERAL_NEW` - Annotations on constructor invocations
- `LITERAL_THROWS` - Annotations on exception types in throws clauses
- `IMPLEMENTS_CLAUSE` - Annotations on interface types in implements clauses

**Decision:**
- Tokens are  opt-in only (not enabled in default configurations)
- Added to `getAcceptableTokens()` but not `getDefaultTokens()`
- Type annotations are less common and inline formatting is often preferred
- Users can explicitly enable these tokens when needed for their codebase

**Changes:**
- Updated `AnnotationLocationCheck.java` to accept the six new tokens
- Added comprehensive documentation examples (Example5-Example10)
- Updated xdocs template with new example sections
- Added tokens to test ignore lists for checkstyle and google configs
