### PR TITLE
Issue #17845: Part of resolving error-prone violations

### DIFF
--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/HexLiteralCaseCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/HexLiteralCaseCheckTest.java
@@ -40,8 +40,8 @@ public class HexLiteralCaseCheckTest
         final HexLiteralCaseCheck check = new HexLiteralCaseCheck();
         final int[] expectedTokens = {TokenTypes.NUM_LONG, TokenTypes.NUM_INT};
         assertWithMessage("Default required tokens are valid")
-            .that(expectedTokens)
-            .isEqualTo(check.getRequiredTokens());
+            .that(check.getRequiredTokens())
+            .isEqualTo(expectedTokens);
     }
 
     @Test

--- a/src/test/java/com/puppycrawl/tools/checkstyle/internal/XdocsPagesTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/internal/XdocsPagesTest.java
@@ -101,8 +101,6 @@ public class XdocsPagesTest {
     private static final Path AVAILABLE_FILE_FILTERS_PATH = Path.of(
         "src/site/xdoc/filefilters/index.xml");
     private static final Path AVAILABLE_FILTERS_PATH = Path.of("src/site/xdoc/filters/index.xml");
-    private static final String LINK_TEMPLATE =
-            "(?s).*<a href=\"[^\"]+#%1$s\">([\\r\\n\\s])*%1$s([\\r\\n\\s])*</a>.*";
 
     private static final Pattern VERSION = Pattern.compile("\\d+\\.\\d+(\\.\\d+)?");
 
@@ -301,7 +299,9 @@ public class XdocsPagesTest {
     }
 
     private static boolean isPresent(String availableChecks, String checkName) {
-        final String linkPattern = String.format(Locale.ROOT, LINK_TEMPLATE, checkName);
+        final String linkPattern = String.format(Locale.ROOT,
+                "(?s).*<a href=\"[^\"]+#%1$s\">([\\r\\n\\s])*%1$s([\\r\\n\\s])*</a>.*",
+                checkName);
         return availableChecks.matches(linkPattern);
     }
 

--- a/src/test/java/com/puppycrawl/tools/checkstyle/internal/utils/CheckUtil.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/internal/utils/CheckUtil.java
@@ -274,7 +274,7 @@ public final class CheckUtil {
         String checkMessage;
         try {
             final Properties pr = new Properties();
-            if (locale == Locale.ENGLISH) {
+            if (locale.equals(Locale.ENGLISH)) {
                 pr.load(module.getResourceAsStream("messages.properties"));
             }
             else {

--- a/src/test/java/com/puppycrawl/tools/checkstyle/utils/BlockCommentPositionTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/utils/BlockCommentPositionTest.java
@@ -141,21 +141,21 @@ public class BlockCommentPositionTest extends AbstractModuleTestSupport {
         /**
          * Legacy getter for fileName, for backward compatibility.
          */
-        public String getFileName() {
+        private String getFileName() {
             return fileName;
         }
 
         /**
          * Legacy getter for assertion, for backward compatibility.
          */
-        public Function<DetailAST, Boolean> getAssertion() {
+        private Function<DetailAST, Boolean> getAssertion() {
             return assertion;
         }
 
         /**
          * Legacy getter for matchesNum, for backward compatibility.
          */
-        public int getMatchesNum() {
+        private int getMatchesNum() {
             return matchesNum;
         }
     }

--- a/src/test/java/com/puppycrawl/tools/checkstyle/utils/ModuleReflectionUtilTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/utils/ModuleReflectionUtilTest.java
@@ -374,11 +374,11 @@ public class ModuleReflectionUtilTest {
 
     }
 
-    private static class InvalidNonDefaultConstructorClass extends AbstractAutomaticBean {
+    private static final class InvalidNonDefaultConstructorClass extends AbstractAutomaticBean {
 
         private int field;
 
-        protected InvalidNonDefaultConstructorClass(int data) {
+        private InvalidNonDefaultConstructorClass(int data) {
             // keep pmd calm and happy
             field = 0;
             method(data);
@@ -389,11 +389,11 @@ public class ModuleReflectionUtilTest {
          *
          * @param data of int type.
          */
-        public final void method(int data) {
+        private void method(int data) {
             field = data + 1;
         }
 
-        public int getField() {
+        private int getField() {
             return field;
         }
 

--- a/src/test/java/com/puppycrawl/tools/checkstyle/xpath/XpathQueryGeneratorTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/xpath/XpathQueryGeneratorTest.java
@@ -607,8 +607,8 @@ public class XpathQueryGeneratorTest extends AbstractModuleTestSupport {
                     + "&amp;1line\\n        &gt;2line\\n        &lt;3line\\n        ']"
             );
         assertWithMessage("Generated queries do not match expected ones")
-                .that(expected)
-                .isEqualTo(actual);
+                .that(actual)
+                .isEqualTo(expected);
     }
 
     @Test
@@ -634,8 +634,8 @@ public class XpathQueryGeneratorTest extends AbstractModuleTestSupport {
                         + "&amp;1line\\n\\n        &gt;2line\\n        &lt;3line\\n        ']"
         );
         assertWithMessage("Generated queries do not match expected ones")
-                .that(expected)
-                .isEqualTo(actual);
+                .that(actual)
+                .isEqualTo(expected);
     }
 
     @Test
@@ -662,8 +662,8 @@ public class XpathQueryGeneratorTest extends AbstractModuleTestSupport {
                         + "        ']"
         );
         assertWithMessage("Generated queries do not match expected ones")
-                .that(expected)
-                .isEqualTo(actual);
+                .that(actual)
+                .isEqualTo(expected);
     }
 
     @Test

--- a/src/test/java/com/puppycrawl/tools/checkstyle/xpath/iterators/ReverseListIteratorTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/xpath/iterators/ReverseListIteratorTest.java
@@ -31,7 +31,6 @@ import com.puppycrawl.tools.checkstyle.api.DetailAST;
 import com.puppycrawl.tools.checkstyle.xpath.AbstractNode;
 import net.sf.saxon.om.NamespaceUri;
 import net.sf.saxon.om.NodeInfo;
-import net.sf.saxon.om.TreeInfo;
 
 public class ReverseListIteratorTest {
 
@@ -61,14 +60,10 @@ public class ReverseListIteratorTest {
         }
     }
 
-    private static class TestNode extends AbstractNode {
+    private static final class TestNode extends AbstractNode {
 
         private TestNode() {
             super(null);
-        }
-
-        protected TestNode(TreeInfo treeInfo) {
-            super(treeInfo);
         }
 
         @Override


### PR DESCRIPTION
Issue: #17845

Solved violations:

```
[WARNING] /C:/Users/athar/OneDrive/Desktop/checkstyle/src/test/java/com/puppycrawl/tools/checkstyle/checks/HexLiteralCaseCheckTest.java:[44,23] [TruthAssertExpected] The actual and expected values appear to be swapped, which results in poor assertion failure messages. The actual value should come first.
    (see https://errorprone.info/bugpattern/TruthAssertExpected)
  Did you mean '.that(check.getRequiredTokens())'?
[WARNING] /C:/Users/athar/OneDrive/Desktop/checkstyle/src/test/java/com/puppycrawl/tools/checkstyle/internal/XdocsPagesTest.java:[104,33] [InlineFormatString] Prefer to create format strings inline, instead of extracting them to a single-use constant
    (see https://errorprone.info/bugpattern/InlineFormatString)
  Did you mean to remove this line?
[WARNING] /C:/Users/athar/OneDrive/Desktop/checkstyle/src/test/java/com/puppycrawl/tools/checkstyle/internal/utils/CheckUtil.java:[277,24] [ReferenceEquality] Comparison using reference equality instead of value equality
    (see https://errorprone.info/bugpattern/ReferenceEquality)
  Did you mean 'if (Objects.equals(locale, Locale.ENGLISH)) {' or 'if (locale.equals(Locale.ENGLISH)) {'?
[WARNING] /C:/Users/athar/OneDrive/Desktop/checkstyle/src/test/java/com/puppycrawl/tools/checkstyle/utils/BlockCommentPositionTest.java:[144,23] [EffectivelyPrivate] This declaration has public or protected modifiers, but is effectively private.
    (see https://errorprone.info/bugpattern/EffectivelyPrivate)
  Did you mean 'String getFileName() {'?
[WARNING] /C:/Users/athar/OneDrive/Desktop/checkstyle/src/test/java/com/puppycrawl/tools/checkstyle/utils/BlockCommentPositionTest.java:[151,45] [EffectivelyPrivate] This declaration has public or protected modifiers, but is effectively private.
    (see https://errorprone.info/bugpattern/EffectivelyPrivate)
  Did you mean 'Function<DetailAST, Boolean> getAssertion() {'?
[WARNING] /C:/Users/athar/OneDrive/Desktop/checkstyle/src/test/java/com/puppycrawl/tools/checkstyle/utils/BlockCommentPositionTest.java:[158,20] [EffectivelyPrivate] This declaration has public or protected modifiers, but is effectively private.
    (see https://errorprone.info/bugpattern/EffectivelyPrivate)
  Did you mean 'int getMatchesNum() {'?
[WARNING] /C:/Users/athar/OneDrive/Desktop/checkstyle/src/test/java/com/puppycrawl/tools/checkstyle/utils/ModuleReflectionUtilTest.java:[381,19] [EffectivelyPrivate] This declaration has public or protected modifiers, but is effectively private.
    (see https://errorprone.info/bugpattern/EffectivelyPrivate)
  Did you mean 'InvalidNonDefaultConstructorClass(int data) {'?
[WARNING] /C:/Users/athar/OneDrive/Desktop/checkstyle/src/test/java/com/puppycrawl/tools/checkstyle/utils/ModuleReflectionUtilTest.java:[392,27] [EffectivelyPrivate] This declaration has public or protected modifiers, but is effectively private.
    (see https://errorprone.info/bugpattern/EffectivelyPrivate)
  Did you mean 'final void method(int data) {'?
[WARNING] /C:/Users/athar/OneDrive/Desktop/checkstyle/src/test/java/com/puppycrawl/tools/checkstyle/utils/ModuleReflectionUtilTest.java:[396,20] [EffectivelyPrivate] This declaration has public or protected modifiers, but is effectively private.
    (see https://errorprone.info/bugpattern/EffectivelyPrivate)
  Did you mean 'int getField() {'?
[WARNING] /C:/Users/athar/OneDrive/Desktop/checkstyle/src/test/java/com/puppycrawl/tools/checkstyle/xpath/XpathQueryGeneratorTest.java:[611,27] [TruthAssertExpected] The actual and expected values appear to be swapped, which results in poor assertion failure messages. The actual value should come first.
    (see https://errorprone.info/bugpattern/TruthAssertExpected)
  Did you mean '.that(actual)'?
[WARNING] /C:/Users/athar/OneDrive/Desktop/checkstyle/src/test/java/com/puppycrawl/tools/checkstyle/xpath/XpathQueryGeneratorTest.java:[638,27] [TruthAssertExpected] The actual and expected values appear to be swapped, which results in poor assertion failure messages. The actual value should come first.
    (see https://errorprone.info/bugpattern/TruthAssertExpected)
  Did you mean '.that(actual)'?
[WARNING] /C:/Users/athar/OneDrive/Desktop/checkstyle/src/test/java/com/puppycrawl/tools/checkstyle/xpath/XpathQueryGeneratorTest.java:[666,27] [TruthAssertExpected] The actual and expected values appear to be swapped, which results in poor assertion failure messages. The actual value should come first.
    (see https://errorprone.info/bugpattern/TruthAssertExpected)
  Did you mean '.that(actual)'?
[WARNING] /C:/Users/athar/OneDrive/Desktop/checkstyle/src/test/java/com/puppycrawl/tools/checkstyle/xpath/iterators/ReverseListIteratorTest.java:[70,19] [UnusedMethod] Constructor 'TestNode' is never used.
    (see https://errorprone.info/bugpattern/UnusedMethod)
  Did you mean to remove this line?
[WARNING] /C:/Users/athar/OneDrive/Desktop/checkstyle/src/test/java/com/puppycrawl/tools/checkstyle/xpath/iterators/ReverseListIteratorTest.java:[70,19] [EffectivelyPrivate] This declaration has public or protected modifiers, but is effectively private.
    (see https://errorprone.info/bugpattern/EffectivelyPrivate)
  Did you mean 'TestNode(TreeInfo treeInfo) {'?

```