### PR TITLE
Issue #11163: Enforce file size on InputDeclarationOrder.java

### DIFF
--- a/config/checkstyle-resources-suppressions.xml
+++ b/config/checkstyle-resources-suppressions.xml
@@ -456,8 +456,6 @@
   <suppress checks="FileLength"
     files="[\\/]test[\\/]resources[\\/]com[\\/]puppycrawl[\\/]tools[\\/]checkstyle[\\/]checks[\\/]coding[\\/]nofinalizer[\\/]InputNoFinalizerFallThrough\.java"/>
   <suppress checks="FileLength"
-    files="[\\/]test[\\/]resources[\\/]com[\\/]puppycrawl[\\/]tools[\\/]checkstyle[\\/]checks[\\/]coding[\\/]declarationorder[\\/]InputDeclarationOrder\.java"/>
-  <suppress checks="FileLength"
     files="[\\/]test[\\/]resources[\\/]com[\\/]puppycrawl[\\/]tools[\\/]checkstyle[\\/]checks[\\/]coding[\\/]declarationorder[\\/]InputDeclarationOrderOnlyModifiers\.java"/>
   <suppress checks="FileLength"
     files="[\\/]test[\\/]resources[\\/]com[\\/]puppycrawl[\\/]tools[\\/]checkstyle[\\/]checks[\\/]coding[\\/]declarationorder[\\/]InputDeclarationOrderOnlyConstructors\.java"/>

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/coding/DeclarationOrderCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/coding/DeclarationOrderCheckTest.java
@@ -44,7 +44,7 @@ public class DeclarationOrderCheckTest
     }
 
     @Test
-    public void testDefault() throws Exception {
+    public void testDefault1() throws Exception {
 
         final String[] expected = {
             "16:5: " + getCheckMessage(MSG_ACCESS),
@@ -56,21 +56,38 @@ public class DeclarationOrderCheckTest
             "60:9: " + getCheckMessage(MSG_STATIC),
             "69:5: " + getCheckMessage(MSG_CONSTRUCTOR),
             "95:5: " + getCheckMessage(MSG_INSTANCE),
-            "107:9: " + getCheckMessage(MSG_ACCESS),
-            "115:9: " + getCheckMessage(MSG_STATIC),
-            "121:5: " + getCheckMessage(MSG_ACCESS),
-            "126:5: " + getCheckMessage(MSG_ACCESS),
-            "131:5: " + getCheckMessage(MSG_ACCESS),
-            "134:5: " + getCheckMessage(MSG_ACCESS),
-            "140:5: " + getCheckMessage(MSG_STATIC),
-            "147:9: " + getCheckMessage(MSG_ACCESS),
-            "158:9: " + getCheckMessage(MSG_STATIC),
-            "167:5: " + getCheckMessage(MSG_CONSTRUCTOR),
-            "193:5: " + getCheckMessage(MSG_INSTANCE),
-            "198:9: " + getCheckMessage(MSG_ACCESS),
         };
         verifyWithInlineConfigParser(
-                getPath("InputDeclarationOrder.java"), expected);
+                getPath("InputDeclarationOrderDefault1.java"), expected);
+    }
+
+    @Test
+    public void testDefault2() throws Exception {
+
+        final String[] expected = {
+            "20:9: " + getCheckMessage(MSG_ACCESS),
+            "28:9: " + getCheckMessage(MSG_STATIC),
+            "34:5: " + getCheckMessage(MSG_ACCESS),
+            "39:5: " + getCheckMessage(MSG_ACCESS),
+            "44:5: " + getCheckMessage(MSG_ACCESS),
+            "47:5: " + getCheckMessage(MSG_ACCESS),
+            "53:5: " + getCheckMessage(MSG_STATIC),
+            "60:9: " + getCheckMessage(MSG_ACCESS),
+            "71:9: " + getCheckMessage(MSG_STATIC),
+            "80:5: " + getCheckMessage(MSG_CONSTRUCTOR),
+            "106:5: " + getCheckMessage(MSG_INSTANCE),
+            "111:9: " + getCheckMessage(MSG_ACCESS),
+        };
+        verifyWithInlineConfigParser(
+                getPath("InputDeclarationOrderDefault2.java"), expected);
+    }
+
+    @Test
+    public void testDefault3() throws Exception {
+        final String[] expected = CommonUtil.EMPTY_STRING_ARRAY;
+        verifyWithInlineConfigParser(
+                getPath("InputDeclarationOrderDefault3.java"),
+                expected);
     }
 
     @Test
@@ -234,14 +251,6 @@ public class DeclarationOrderCheckTest
         };
         verifyWithInlineConfigParser(
                 getPath("InputDeclarationOrderAvoidDuplicatesInStaticFinalFields.java"),
-                expected);
-    }
-
-    @Test
-    public void test() throws Exception {
-        final String[] expected = CommonUtil.EMPTY_STRING_ARRAY;
-        verifyWithInlineConfigParser(
-                getPath("InputDeclarationOrder2.java"),
                 expected);
     }
 

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/declarationorder/InputDeclarationOrderDefault1.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/declarationorder/InputDeclarationOrderDefault1.java
@@ -1,0 +1,96 @@
+/*
+DeclarationOrder
+ignoreConstructors = (default)false
+ignoreModifiers = (default)false
+
+
+*/
+
+package com.puppycrawl.tools.checkstyle.checks.coding.declarationorder;
+
+public class InputDeclarationOrderDefault1
+{
+    static final int FOO2 = 3;
+
+    // public before package
+    public static final int FOO = 3; // violation 'Variable.*access.*wrong.*order'
+
+    private static final int FOO3 = 3;
+
+    // public before package and private
+    public static final int FOO4 = 3; // violation 'Variable.*access.*wrong.*order'
+
+    private static final String ERROR = "error";
+
+    // protected before private
+    protected static final String ERROR1 = "error"; // violation 'Variable.*access.*wrong.*order'
+
+    // public before private
+    public static final String WARNING = "warning"; // violation 'Variable.*access.*wrong.*order'
+
+    private int mMaxInitVars = 3;
+
+    // statics should be before instance members
+    // publics before private
+    public static final int MAX_ITER_VARS = 3; // violation 'Static.*variable.*wrong.*order'
+
+    private class InnerClass
+    {
+        private static final int INNER_FOO = 2;
+
+        // public before private
+        public static final int INNER_FOO2 = 2; // violation 'Variable.*access.*wrong.*order'
+
+        public InnerClass()
+        {
+            int foo = INNER_FOO;
+            foo += INNER_FOO2;
+            foo += INNER_FOO3;
+        }
+
+        public InnerClass(int start)
+        {
+            int foo = start;
+            foo += INNER_FOO2;
+            foo += INNER_FOO3;
+        }
+
+        // member variables should be before methods or ctors
+        // public before private
+        public static final int INNER_FOO3 = 2; // violation 'Static.*variable.*wrong.*order'
+    }
+
+    public int getFoo1()
+    {
+        return mFoo;
+    }
+
+    //  ctors before methods
+    public InputDeclarationOrderDefault1() // violation 'Constructor.*in.*wrong.*order'
+    {
+        String foo = ERROR;
+        foo += ERROR1;
+        foo += WARNING;
+        int fooInt = mMaxInitVars;
+        fooInt += MAX_ITER_VARS;
+        fooInt += mFoo;
+    }
+
+    public static int getFoo2()
+    {
+        return 13;
+    }
+
+    public int getFoo()
+    {
+        return mFoo;
+    }
+
+    private static int getFoo21()
+    {
+        return 14;
+    }
+
+    // member variables should be before methods or ctors
+    private int mFoo = 0; // violation 'Instance variable definition in wrong order.'
+}

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/declarationorder/InputDeclarationOrderDefault2.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/declarationorder/InputDeclarationOrderDefault2.java
@@ -8,94 +8,7 @@ ignoreModifiers = (default)false
 
 package com.puppycrawl.tools.checkstyle.checks.coding.declarationorder;
 
-public class InputDeclarationOrder
-{
-    static final int FOO2 = 3;
-
-    // public before package
-    public static final int FOO = 3; // violation 'Variable.*access.*wrong.*order'
-
-    private static final int FOO3 = 3;
-
-    // public before package and private
-    public static final int FOO4 = 3; // violation 'Variable.*access.*wrong.*order'
-
-    private static final String ERROR = "error";
-
-    // protected before private
-    protected static final String ERROR1 = "error"; // violation 'Variable.*access.*wrong.*order'
-
-    // public before private
-    public static final String WARNING = "warning"; // violation 'Variable.*access.*wrong.*order'
-
-    private int mMaxInitVars = 3;
-
-    // statics should be before instance members
-    // publics before private
-    public static final int MAX_ITER_VARS = 3; // violation 'Static.*variable.*wrong.*order'
-
-    private class InnerClass
-    {
-        private static final int INNER_FOO = 2;
-
-        // public before private
-        public static final int INNER_FOO2 = 2; // violation 'Variable.*access.*wrong.*order'
-
-        public InnerClass()
-        {
-            int foo = INNER_FOO;
-            foo += INNER_FOO2;
-            foo += INNER_FOO3;
-        }
-
-        public InnerClass(int start)
-        {
-            int foo = start;
-            foo += INNER_FOO2;
-            foo += INNER_FOO3;
-        }
-
-        // member variables should be before methods or ctors
-        // public before private
-        public static final int INNER_FOO3 = 2; // violation 'Static.*variable.*wrong.*order'
-    }
-
-    public int getFoo1()
-    {
-        return mFoo;
-    }
-
-    //  ctors before methods
-    public InputDeclarationOrder() // violation 'Constructor.*in.*wrong.*order'
-    {
-        String foo = ERROR;
-        foo += ERROR1;
-        foo += WARNING;
-        int fooInt = mMaxInitVars;
-        fooInt += MAX_ITER_VARS;
-        fooInt += mFoo;
-    }
-
-    public static int getFoo2()
-    {
-        return 13;
-    }
-
-    public int getFoo()
-    {
-        return mFoo;
-    }
-
-    private static int getFoo21()
-    {
-        return 14;
-    }
-
-    // member variables should be before methods or ctors
-    private int mFoo = 0; // violation 'Instance variable definition in wrong order.'
-}
-
-enum InputDeclarationOrderEnum
+enum InputDeclarationOrderDefault2
 {
     ENUM_VALUE_1,
     ENUM_VALUE_2,
@@ -164,7 +77,7 @@ enum InputDeclarationOrderEnum
     }
 
     //  ctors before methods
-    InputDeclarationOrderEnum() // violation 'Constructor.*in.*wrong.*order'
+    InputDeclarationOrderDefault2() // violation 'Constructor.*in.*wrong.*order'
     {
         String foo = ERROR;
         foo += ERROR1;

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/declarationorder/InputDeclarationOrderDefault3.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/declarationorder/InputDeclarationOrderDefault3.java
@@ -8,7 +8,7 @@ ignoreModifiers = (default)false
 
 package com.puppycrawl.tools.checkstyle.checks.coding.declarationorder;
 
-public class InputDeclarationOrder2 {
+public class InputDeclarationOrderDefault3 {
     private static char[] sHexChars = {
             '0', '1', '2', '3', '4', '5', '6', '7', '8', '9',
             'A', 'B', 'C', 'D', 'E', 'F' };


### PR DESCRIPTION
Part of #11163: Enforce file size on InputDeclarationOrder.java

Additionally, renamed `InputDeclarationOrder2.java` to `InputDeclarationOrderDefault3.java` for naming consistency and moved it to be grouped with the other two tests that verify checkstyle behavior on default configurations, since this class appears to also test default behavior.