### PR TITLE
Issue #14019: Kill surviving mutation in IllegalInstantiationCheck

### DIFF
--- a/config/pitest-suppressions/pitest-coding-2-suppressions.xml
+++ b/config/pitest-suppressions/pitest-coding-2-suppressions.xml
@@ -1,13 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <suppressedMutations>
-  <mutation unstable="false">
-    <sourceFile>IllegalInstantiationCheck.java</sourceFile>
-    <mutatedClass>com.puppycrawl.tools.checkstyle.checks.coding.IllegalInstantiationCheck</mutatedClass>
-    <mutatedMethod>visitToken</mutatedMethod>
-    <mutator>org.pitest.mutationtest.engine.gregor.mutators.NonVoidMethodCallMutator</mutator>
-    <description>removed call to java/lang/String::valueOf</description>
-    <lineContent>default -&gt; throw new IllegalArgumentException(&quot;Unknown type &quot; + ast);</lineContent>
-  </mutation>
 
   <mutation unstable="false">
     <sourceFile>ModifiedControlVariableCheck.java</sourceFile>

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/coding/IllegalInstantiationCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/coding/IllegalInstantiationCheckTest.java
@@ -150,13 +150,16 @@ public class IllegalInstantiationCheckTest
 
         final DetailAstImpl lambdaAst = new DetailAstImpl();
         lambdaAst.setType(TokenTypes.LAMBDA);
+        lambdaAst.setText("LAMBDA");
 
         try {
             check.visitToken(lambdaAst);
             assertWithMessage("IllegalArgumentException is expected").fail();
         }
         catch (IllegalArgumentException exc) {
-            // it is OK
+            assertWithMessage("Message must include token name")
+                .that(exc.getMessage())
+                .contains("LAMBDA");
         }
     }
 


### PR DESCRIPTION
Issue #14019

Before this change, PIT reported one surviving mutation in `IllegalInstantiationCheck`. The mutator (`NonVoidMethodCallMutator`) removed the implicit `String.valueOf(ast)` call inside `throw new IllegalArgumentException("Unknown type " + ast);` replacing it with a `null` value.

Because the existing test `testImproperToken` only checked that an exception was thrown, not what message it contained, the mutated code (`"Unknown type null"`) still passed.

This PR updates the test to assign a token text (`lambdaAst.setText("LAMBDA")`) and assert that the exception message contains `"LAMBDA"`. The test now fails for the mutated version.

Screenshots show the PIT report before and after the fix.
<img width="835" height="203" alt="image" src="https://github.com/user-attachments/assets/8f4d6fde-b10d-4b9a-abce-d8565077df24" />
<img width="1022" height="100" alt="image" src="https://github.com/user-attachments/assets/14d11eee-229f-421b-8d84-6550c8f5c8f5" />

<img width="835" height="200" alt="image" src="https://github.com/user-attachments/assets/6cef2dbb-6cae-4003-9b8d-7ba50df0b3ae" />
<img width="728" height="36" alt="image" src="https://github.com/user-attachments/assets/6c377d59-9b8b-4d27-a94a-25c748c644f4" />
