### PR TITLE
Issue #17449: Added examples for legalComment property in TrailingCommentCheck

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/TrailingCommentCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/TrailingCommentCheck.java
@@ -45,7 +45,7 @@ import com.puppycrawl.tools.checkstyle.utils.TokenUtil;
  * </p>
  * <div class="wrapper"><pre class="prettyprint"><code class="language-java">
  * a = b + c;      // Some insightful comment
- * d = e / f;        // Another comment for this line
+ * d = e / f;      /* Some insightful block comment &#42;/
  * </code></pre></div>
  *
  * <p>

--- a/src/main/resources/com/puppycrawl/tools/checkstyle/meta/checks/TrailingCommentCheck.xml
+++ b/src/main/resources/com/puppycrawl/tools/checkstyle/meta/checks/TrailingCommentCheck.xml
@@ -19,7 +19,7 @@
  &lt;/p&gt;
  &lt;div class="wrapper"&gt;&lt;pre class="prettyprint"&gt;&lt;code class="language-java"&gt;
  a = b + c;      // Some insightful comment
- d = e / f;        // Another comment for this line
+ d = e / f;      /* Some insightful block comment &amp;#42;/
  &lt;/code&gt;&lt;/pre&gt;&lt;/div&gt;
 
  &lt;p&gt;

--- a/src/site/xdoc/checks/misc/trailingcomment.xml
+++ b/src/site/xdoc/checks/misc/trailingcomment.xml
@@ -24,7 +24,7 @@
         </p>
         <div class="wrapper"><pre class="prettyprint"><code class="language-java">
 a = b + c;      // Some insightful comment
-d = e / f;        // Another comment for this line
+d = e / f;      /* Some insightful block comment &#42;/
         </code></pre></div>
 
         <p>
@@ -168,12 +168,8 @@ public class Example2 {
         <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
 &lt;module name="Checker"&gt;
   &lt;module name="TreeWalker"&gt;
-    &lt;module name="TrailingComment"/&gt;
-    &lt;module name="SuppressionXpathSingleFilter"&gt;
-      &lt;property name="checks" value="TrailingCommentCheck"/&gt;
-      &lt;property name="query" value="//SINGLE_LINE_COMMENT
-        [./COMMENT_CONTENT[@text=' NOSONAR\n' or @text=' NOPMD\n'
-        or @text=' SUPPRESS CHECKSTYLE\n']]"/&gt;
+    &lt;module name="TrailingComment"&gt;
+      &lt;property name="legalComment" value="^ (SUPPRESS CHECKSTYLE|NOPMD|NOSONAR)$"/&gt;
     &lt;/module&gt;
   &lt;/module&gt;
 &lt;/module&gt;
@@ -198,15 +194,8 @@ public class Example3 {
         <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
 &lt;module name="Checker"&gt;
   &lt;module name="TreeWalker"&gt;
-    &lt;module name="TrailingComment"/&gt;
-    &lt;module name="SuppressionXpathSingleFilter"&gt;
-      &lt;property name="checks" value="TrailingCommentCheck"/&gt;
-      &lt;property name="query" value="//SINGLE_LINE_COMMENT
-        [./COMMENT_CONTENT[starts-with(@text, ' NOPMD')]]"/&gt;
-      &lt;property name="query" value="//SINGLE_LINE_COMMENT
-        [./COMMENT_CONTENT[starts-with(@text, ' SUPPRESS CHECKSTYLE')]]"/&gt;
-      &lt;property name="query" value="//SINGLE_LINE_COMMENT
-        [./COMMENT_CONTENT[starts-with(@text, ' NOSONAR')]]"/&gt;
+    &lt;module name="TrailingComment"&gt;
+      &lt;property name="legalComment" value="^ (SUPPRESS CHECKSTYLE|NOPMD|NOSONAR).*"/&gt;
     &lt;/module&gt;
   &lt;/module&gt;
 &lt;/module&gt;
@@ -221,6 +210,74 @@ public class Example4 {
   int b; // NOPMD - OK, comment starts with " NOPMD"
   int c; // NOSONAR - OK, comment starts with " NOSONAR"
   int d; // violation, not suppressed
+}
+</code></pre></div><hr class="example-separator"/>
+
+        <p id="Example5-config">
+          To configure the check to allow trailing comments that match a specific pattern:
+        </p>
+        <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
+&lt;module name="Checker"&gt;
+  &lt;module name="TreeWalker"&gt;
+    &lt;module name="TrailingComment"&gt;
+      &lt;property name="legalComment" value="^ (TODO|FIXME|trailingcomment).*"/&gt;
+    &lt;/module&gt;
+  &lt;/module&gt;
+&lt;/module&gt;
+</code></pre></div>
+
+        <p id="Example5-code">
+          Example:
+        </p>
+        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+public class Example5 {
+  public static void main(String[] args) {
+    int x = 10;
+
+    if (/* OK */ x &gt; 5) {}
+    int a = 5; // TODO: refactor this - ok, matches legalComment pattern
+    doSomething(
+            "param1"
+    ); // FIXME: handle edge cases - ok, matches legalComment pattern
+
+    int b = 10; // trailingcomment - ok, matches legalComment pattern
+    int c = 15; // violation, regular comment doesn't match pattern
+  }
+
+  private static void doSomething(String param) {
+  }
+}
+</code></pre></div><hr class="example-separator"/>
+
+        <p id="Example6-config">
+          To configure the check to allow trailing multiline comments that match a specific pattern:
+        </p>
+        <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
+&lt;module name="Checker"&gt;
+  &lt;module name="TreeWalker"&gt;
+    &lt;module name="TrailingComment"&gt;
+      &lt;property name="legalComment" value="^ violation.*"/&gt;
+    &lt;/module&gt;
+    &lt;module name="SuppressionXpathSingleFilter"&gt;
+      &lt;property name="checks" value="TrailingCommentCheck"/&gt;
+      &lt;property name="query" value="//BLOCK_COMMENT_BEGIN
+        [./COMMENT_CONTENT[@text=' NOSONAR ' or @text=' NOPMD '
+        or @text=' SUPPRESS CHECKSTYLE ']]"/&gt;
+    &lt;/module&gt;
+  &lt;/module&gt;
+&lt;/module&gt;
+</code></pre></div>
+
+        <p id="Example6-code">
+          Example:
+        </p>
+        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+public class Example6 {
+  int a; /* SUPPRESS CHECKSTYLE */
+  int b; /* NOPMD */
+  int c; /* NOSONAR */
+  int d; /* there is violation because of illegal content */
+  // violation above
 }
 </code></pre></div>
 

--- a/src/site/xdoc/checks/misc/trailingcomment.xml.template
+++ b/src/site/xdoc/checks/misc/trailingcomment.xml.template
@@ -98,6 +98,42 @@
           <param name="path"
                  value="resources/com/puppycrawl/tools/checkstyle/checks/trailingcomment/Example4.java"/>
           <param name="type" value="code"/>
+        </macro><hr class="example-separator"/>
+
+        <p id="Example5-config">
+          To configure the check to allow trailing comments that match a specific pattern:
+        </p>
+        <macro name="example">
+          <param name="path"
+                 value="resources/com/puppycrawl/tools/checkstyle/checks/trailingcomment/Example5.java"/>
+          <param name="type" value="config"/>
+        </macro>
+
+        <p id="Example5-code">
+          Example:
+        </p>
+        <macro name="example">
+          <param name="path"
+                 value="resources/com/puppycrawl/tools/checkstyle/checks/trailingcomment/Example5.java"/>
+          <param name="type" value="code"/>
+        </macro><hr class="example-separator"/>
+
+        <p id="Example6-config">
+          To configure the check to allow trailing multiline comments that match a specific pattern:
+        </p>
+        <macro name="example">
+          <param name="path"
+                 value="resources/com/puppycrawl/tools/checkstyle/checks/trailingcomment/Example6.java"/>
+          <param name="type" value="config"/>
+        </macro>
+
+        <p id="Example6-code">
+          Example:
+        </p>
+        <macro name="example">
+          <param name="path"
+                 value="resources/com/puppycrawl/tools/checkstyle/checks/trailingcomment/Example6.java"/>
+          <param name="type" value="code"/>
         </macro>
 
       </subsection>

--- a/src/test/java/com/puppycrawl/tools/checkstyle/internal/XdocsExampleFileTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/internal/XdocsExampleFileTest.java
@@ -52,7 +52,6 @@ public class XdocsExampleFileTest {
     // This list is temporarily suppressed.
     // Until: https://github.com/checkstyle/checkstyle/issues/17449
     private static final Map<String, Set<String>> SUPPRESSED_PROPERTIES_BY_CHECK = Map.ofEntries(
-            Map.entry("TrailingCommentCheck", Set.of("legalComment")),
             Map.entry("IllegalTypeCheck", Set.of("legalAbstractClassNames")),
             Map.entry("MissingJavadocTypeCheck", Set.of("skipAnnotations")),
             Map.entry("JavadocStyleCheck", Set.of("endOfSentenceFormat", "checkEmptyJavadoc")),

--- a/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/checks/TrailingCommentCheckExamplesTest.java
+++ b/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/checks/TrailingCommentCheckExamplesTest.java
@@ -53,7 +53,7 @@ public class TrailingCommentCheckExamplesTest extends AbstractExamplesModuleTest
     @Test
     public void testExample3() throws Exception {
         final String[] expected = {
-            "22:10: " + getCheckMessage(MSG_KEY),
+            "18:10: " + getCheckMessage(MSG_KEY),
         };
 
         verifyWithInlineConfigParser(getPath("Example3.java"), expected);
@@ -62,9 +62,27 @@ public class TrailingCommentCheckExamplesTest extends AbstractExamplesModuleTest
     @Test
     public void testExample4() throws Exception {
         final String[] expected = {
-            "25:10: " + getCheckMessage(MSG_KEY),
+            "18:10: " + getCheckMessage(MSG_KEY),
         };
 
         verifyWithInlineConfigParser(getPath("Example4.java"), expected);
+    }
+
+    @Test
+    public void testExample5() throws Exception {
+        final String[] expected = {
+            "25:17: " + getCheckMessage(MSG_KEY),
+        };
+
+        verifyWithInlineConfigParser(getPath("Example5.java"), expected);
+    }
+
+    @Test
+    public void testExample6() throws Exception {
+        final String[] expected = {
+            "24:10: " + getCheckMessage(MSG_KEY),
+        };
+
+        verifyWithInlineConfigParser(getPath("Example6.java"), expected);
     }
 }

--- a/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/trailingcomment/Example3.java
+++ b/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/trailingcomment/Example3.java
@@ -1,12 +1,8 @@
 /*xml
 <module name="Checker">
   <module name="TreeWalker">
-    <module name="TrailingComment"/>
-    <module name="SuppressionXpathSingleFilter">
-      <property name="checks" value="TrailingCommentCheck"/>
-      <property name="query" value="//SINGLE_LINE_COMMENT
-        [./COMMENT_CONTENT[@text=' NOSONAR\n' or @text=' NOPMD\n'
-        or @text=' SUPPRESS CHECKSTYLE\n']]"/>
+    <module name="TrailingComment">
+      <property name="legalComment" value="^ (SUPPRESS CHECKSTYLE|NOPMD|NOSONAR)$"/>
     </module>
   </module>
 </module>

--- a/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/trailingcomment/Example4.java
+++ b/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/trailingcomment/Example4.java
@@ -1,15 +1,8 @@
 /*xml
 <module name="Checker">
   <module name="TreeWalker">
-    <module name="TrailingComment"/>
-    <module name="SuppressionXpathSingleFilter">
-      <property name="checks" value="TrailingCommentCheck"/>
-      <property name="query" value="//SINGLE_LINE_COMMENT
-        [./COMMENT_CONTENT[starts-with(@text, ' NOPMD')]]"/>
-      <property name="query" value="//SINGLE_LINE_COMMENT
-        [./COMMENT_CONTENT[starts-with(@text, ' SUPPRESS CHECKSTYLE')]]"/>
-      <property name="query" value="//SINGLE_LINE_COMMENT
-        [./COMMENT_CONTENT[starts-with(@text, ' NOSONAR')]]"/>
+    <module name="TrailingComment">
+      <property name="legalComment" value="^ (SUPPRESS CHECKSTYLE|NOPMD|NOSONAR).*"/>
     </module>
   </module>
 </module>

--- a/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/trailingcomment/Example5.java
+++ b/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/trailingcomment/Example5.java
@@ -1,0 +1,31 @@
+/*xml
+<module name="Checker">
+  <module name="TreeWalker">
+    <module name="TrailingComment">
+      <property name="legalComment" value="^ (TODO|FIXME|trailingcomment).*"/>
+    </module>
+  </module>
+</module>
+*/
+
+package com.puppycrawl.tools.checkstyle.checks.trailingcomment;
+
+// xdoc section -- start
+public class Example5 {
+  public static void main(String[] args) {
+    int x = 10;
+
+    if (/* OK */ x > 5) {}
+    int a = 5; // TODO: refactor this - ok, matches legalComment pattern
+    doSomething(
+            "param1"
+    ); // FIXME: handle edge cases - ok, matches legalComment pattern
+
+    int b = 10; // trailingcomment - ok, matches legalComment pattern
+    int c = 15; // violation, regular comment doesn't match pattern
+  }
+
+  private static void doSomething(String param) {
+  }
+}
+// xdoc section -- end

--- a/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/trailingcomment/Example6.java
+++ b/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/trailingcomment/Example6.java
@@ -1,0 +1,27 @@
+/*xml
+<module name="Checker">
+  <module name="TreeWalker">
+    <module name="TrailingComment">
+      <property name="legalComment" value="^ violation.*"/>
+    </module>
+    <module name="SuppressionXpathSingleFilter">
+      <property name="checks" value="TrailingCommentCheck"/>
+      <property name="query" value="//BLOCK_COMMENT_BEGIN
+        [./COMMENT_CONTENT[@text=' NOSONAR ' or @text=' NOPMD '
+        or @text=' SUPPRESS CHECKSTYLE ']]"/>
+    </module>
+  </module>
+</module>
+*/
+
+package com.puppycrawl.tools.checkstyle.checks.trailingcomment;
+
+// xdoc section -- start
+public class Example6 {
+  int a; /* SUPPRESS CHECKSTYLE */
+  int b; /* NOPMD */
+  int c; /* NOSONAR */
+  int d; /* there is violation because of illegal content */
+  // violation above
+}
+// xdoc section -- end


### PR DESCRIPTION
Issue: #17449 

Changes made:

- Added examples for legalComment property in TrailingCommentCheck (nside the appropriate /*xml block).
- Updated the XDoc template/resource file to reference the new example.
- Removed legalComment from the suppression list in XdocsExampleFileTest.
- Verified that XdocsExampleFileTest passes without relying on suppression.