### PR TITLE
Issue #17845: Resolved error-prone violations

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -246,8 +246,10 @@
       -Xep:CanonicalAnnotationSyntax:ERROR
       -Xep:CollectorMutability:ERROR
       -Xep:ConstantNaming:ERROR
+      -Xep:DefaultCharset:ERROR
       -Xep:DirectReturn:ERROR
       -Xep:EmptyMethod:ERROR
+      -Xep:EnumOrdinal:ERROR
       -Xep:ExplicitArgumentEnumeration:ERROR
       -Xep:ExplicitEnumOrdering:ERROR
       -Xep:FormatStringConcatenation:ERROR
@@ -259,13 +261,27 @@
       -Xep:MockitoMockClassReference:ERROR
       -Xep:MockitoStubbing:ERROR
       -Xep:NestedOptionals:ERROR
+      -Xep:OptionalOrElseGet:ERROR
       -Xep:PrimitiveComparison:ERROR
       -Xep:RedundantStringConversion:ERROR
       -Xep:RedundantStringEscape:ERROR
+      -Xep:ReferenceEquality:ERROR
       -Xep:Slf4jLogStatement:ERROR
+      -Xep:StreamResourceLeak:ERROR
       -Xep:StringJoin:ERROR
       -Xep:StringJoining:ERROR
       -Xep:TimeZoneUsage:ERROR
+      -Xep:TruthAssertExpected:ERROR
+      -Xep:TypeParameterUnusedInFormals:ERROR
+      -Xep:UnusedMethod:ERROR
+      -Xep:VoidUsed:ERROR
+      <!-- Reason at https://github.com/checkstyle/checkstyle/issues/17988. -->
+      -Xep:EqualsGetClass:WARN
+      -Xep:InlineFormatString:WARN
+      -Xep:JdkObsolete:WARN
+      -Xep:StatementSwitchToExpressionSwitch:WARN
+      -Xep:StringSplitter:WARN
+      -Xep:EffectivelyPrivate:WARN
       <!-- Reason at https://github.com/checkstyle/checkstyle/issues/8252. -->
       -Xep:JUnitClassModifiers:OFF
       <!-- Reason at https://github.com/checkstyle/checkstyle/issues/8252. -->

--- a/src/test/java/com/puppycrawl/tools/checkstyle/utils/ModuleReflectionUtilTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/utils/ModuleReflectionUtilTest.java
@@ -106,6 +106,9 @@ public class ModuleReflectionUtilTest {
         assertWithMessage("Should return false when invalid class is passed")
                 .that(ModuleReflectionUtil.isCheckstyleModule(AbstractInvalidClass.class))
                 .isFalse();
+        assertWithMessage("Should return true when valid checkstyle class is passed")
+                .that(ModuleReflectionUtil.isCheckstyleModule(ValidClass.class))
+                .isTrue();
         assertWithMessage("Should return false when invalid class is passed")
                 .that(ModuleReflectionUtil
                     .isCheckstyleModule(InvalidNonDefaultConstructorClass.class))
@@ -217,14 +220,25 @@ public class ModuleReflectionUtilTest {
 
     /**
      * AbstractInvalidClass.
-     *
-     * @noinspection AbstractClassNeverImplemented
-     * @noinspectionreason AbstractClassNeverImplemented - class is only used in testing
      */
     private abstract static class AbstractInvalidClass extends AbstractAutomaticBean {
 
         public abstract void method();
 
+    }
+
+    private static final class ValidClass extends AbstractInvalidClass {
+
+        @Override
+        public void method() {
+            // dummy method
+        }
+
+        @Override
+        protected void finishLocalSetup() {
+            final AbstractInvalidClass ref = this;
+            ref.method();
+        }
     }
 
     private static final class CheckClass extends AbstractCheck {


### PR DESCRIPTION
Issue: #17845

Solved violations
```
[WARNING] /C:/Users/athar/OneDrive/Desktop/checkstyle/src/test/java/com/puppycrawl/tools/checkstyle/utils/ModuleReflectionUtilTest.java:[226,30] [UnusedMethod] Method 'method' is never used.
    (see https://errorprone.info/bugpattern/UnusedMethod)
  Did you mean to remove this line?
```
marked warn for violtions for checks

Created new issue #17988 for remaining violations in checks 