### PR TITLE
Issue #17449: Add XDocs example for TrailingCommentCheck legalComment…

### DIFF
--- a/src/test/java/com/puppycrawl/tools/checkstyle/internal/XdocsExampleFileTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/internal/XdocsExampleFileTest.java
@@ -39,21 +39,19 @@ import com.puppycrawl.tools.checkstyle.internal.utils.XdocUtil;
 public class XdocsExampleFileTest {
 
     private static final Set<String> COMMON_PROPERTIES = Set.of(
-        "severity",
-        "id",
-        "fileExtensions",
-        "tabWidth",
-        "fileContents",
-        "tokens",
-        "javadocTokens",
-        "violateExecutionOnNonTightHtml"
-    );
+            "severity",
+            "id",
+            "fileExtensions",
+            "tabWidth",
+            "fileContents",
+            "tokens",
+            "javadocTokens",
+            "violateExecutionOnNonTightHtml");
 
     // This list is temporarily suppressed.
     // Until: https://github.com/checkstyle/checkstyle/issues/17449
     private static final Map<String, Set<String>> SUPPRESSED_PROPERTIES_BY_CHECK = Map.ofEntries(
             Map.entry("MissingJavadocMethodCheck", Set.of("minLineCount")),
-            Map.entry("TrailingCommentCheck", Set.of("legalComment")),
             Map.entry("IllegalTypeCheck", Set.of("legalAbstractClassNames")),
             Map.entry("MissingJavadocTypeCheck", Set.of("skipAnnotations")),
             Map.entry("JavadocStyleCheck", Set.of("endOfSentenceFormat", "checkEmptyJavadoc")),
@@ -68,28 +66,23 @@ public class XdocsExampleFileTest {
                     "lineWrappingIndentation",
                     "throwsIndent",
                     "arrayInitIndent",
-                    "braceAdjustment"
-            )),
+                    "braceAdjustment")),
             Map.entry("MethodCountCheck", Set.of("maxPrivate", "maxPackage", "maxProtected")),
             Map.entry("ClassMemberImpliedModifierCheck", Set.of(
                     "violateImpliedStaticOnNestedEnum",
                     "violateImpliedStaticOnNestedRecord",
-                    "violateImpliedStaticOnNestedInterface"
-            )),
+                    "violateImpliedStaticOnNestedInterface")),
             Map.entry("DescendantTokenCheck", Set.of("minimumMessage")),
             Map.entry("InterfaceMemberImpliedModifierCheck", Set.of(
                     "violateImpliedFinalField",
                     "violateImpliedPublicField",
                     "violateImpliedStaticField",
                     "violateImpliedPublicMethod",
-                    "violateImpliedAbstractMethod"
-            ))
-    );
+                    "violateImpliedAbstractMethod")));
 
     @Test
     public void testAllCheckPropertiesAreUsedInXdocsExamples() throws Exception {
-        final Map<String, Set<String>> usedPropertiesByCheck =
-            XdocUtil.extractUsedPropertiesFromXdocsExamples();
+        final Map<String, Set<String>> usedPropertiesByCheck = XdocUtil.extractUsedPropertiesFromXdocsExamples();
         final List<String> failures = new ArrayList<>();
 
         for (Class<?> checkClass : CheckUtil.getCheckstyleChecks()) {
@@ -97,16 +90,15 @@ public class XdocsExampleFileTest {
 
             final Set<String> definedProperties = Arrays.stream(
                     PropertyUtils.getPropertyDescriptors(checkClass))
-                .filter(descriptor -> descriptor.getWriteMethod() != null)
-                .map(PropertyDescriptor::getName)
-                .filter(property -> !COMMON_PROPERTIES.contains(property))
-                .collect(Collectors.toUnmodifiableSet());
+                    .filter(descriptor -> descriptor.getWriteMethod() != null)
+                    .map(PropertyDescriptor::getName)
+                    .filter(property -> !COMMON_PROPERTIES.contains(property))
+                    .collect(Collectors.toUnmodifiableSet());
 
-            final Set<String> usedProperties =
-                usedPropertiesByCheck.getOrDefault(checkSimpleName, Collections.emptySet());
+            final Set<String> usedProperties = usedPropertiesByCheck.getOrDefault(checkSimpleName,
+                    Collections.emptySet());
 
-            final Set<String> suppressedProps =
-                SUPPRESSED_PROPERTIES_BY_CHECK.getOrDefault(
+            final Set<String> suppressedProps = SUPPRESSED_PROPERTIES_BY_CHECK.getOrDefault(
                     checkSimpleName, Collections.emptySet());
 
             for (String property : definedProperties) {

--- a/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/trailingcomment/Example5.java
+++ b/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/trailingcomment/Example5.java
@@ -1,0 +1,32 @@
+/*xml
+<module name="Checker">
+  <module name="TreeWalker">
+    <module name="TrailingComment">
+      <property name="legalComment" value="^// (TODO|FIXME|NOSONAR)"/>
+    </module>
+  </module>
+</module>
+*/
+
+package com.puppycrawl.tools.checkstyle.checks.trailingcomment;
+
+// xdoc section -- start
+public class Example5 {
+    public static void main(String[] args) {
+        int x = 10;
+
+        if (x > 5) {
+        }
+        int a = 5; // TODO: fix this logic later - ok, matches legalComment pattern
+        int b = 6; // FIXME: this should be calculated - ok, matches legalComment pattern
+        int c = 7; // NOSONAR - ok, matches legalComment pattern
+        int d = 8; // violation, doesn't match legalComment pattern
+        doSomething(
+                "param1"); // ok, by default such trailing of method/code-block ending is allowed
+
+    }
+
+    private static void doSomething(String param) {
+    }
+}
+// xdoc section -- end


### PR DESCRIPTION
## Issue #17449: Add XDocs example for TrailingCommentCheck legalComment property

-> Changes:
- Added `Example5.java` demonstrating the `legalComment` property usage
- Removed `TrailingCommentCheck` from the suppression list in `XdocsExampleFileTest`

->What the example shows:
The `legalComment` property allows certain trailing comments that match a specific pattern. The example demonstrates:
- Comments matching the pattern (TODO, FIXME, NOSONAR) are allowed
- Comments not matching the pattern trigger violations
- Default behavior for method-ending comments is preserved

->Testing:
- All tests in `XdocsExampleFileTest` pass
- The property is no longer in the suppression list