### PR TITLE
Issue #17449: Add XDocs example for TrailingCommentCheck legalComment…

### DIFF
--- a/src/site/xdoc/checks/misc/trailingcomment.xml.template
+++ b/src/site/xdoc/checks/misc/trailingcomment.xml.template
@@ -98,6 +98,24 @@
           <param name="path"
                  value="resources/com/puppycrawl/tools/checkstyle/checks/trailingcomment/Example4.java"/>
           <param name="type" value="code"/>
+        </macro><hr class="example-separator"/>
+
+        <p id="Example5-config">
+          To configure the check to allow certain trailing comments:
+        </p>
+        <macro name="example">
+          <param name="path"
+                 value="resources/com/puppycrawl/tools/checkstyle/checks/trailingcomment/Example5.java"/>
+          <param name="type" value="config"/>
+        </macro>
+
+        <p id="Example5-code">
+          Example:
+        </p>
+        <macro name="example">
+          <param name="path"
+                 value="resources/com/puppycrawl/tools/checkstyle/checks/trailingcomment/Example5.java"/>
+          <param name="type" value="code"/>
         </macro>
 
       </subsection>

--- a/src/test/java/com/puppycrawl/tools/checkstyle/internal/XdocsExampleFileTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/internal/XdocsExampleFileTest.java
@@ -52,7 +52,6 @@ public class XdocsExampleFileTest {
     // This list is temporarily suppressed.
     // Until: https://github.com/checkstyle/checkstyle/issues/17449
     private static final Map<String, Set<String>> SUPPRESSED_PROPERTIES_BY_CHECK = Map.ofEntries(
-            Map.entry("TrailingCommentCheck", Set.of("legalComment")),
             Map.entry("IllegalTypeCheck", Set.of("legalAbstractClassNames")),
             Map.entry("MissingJavadocTypeCheck", Set.of("skipAnnotations")),
             Map.entry("JavadocStyleCheck", Set.of("endOfSentenceFormat", "checkEmptyJavadoc")),

--- a/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/checks/TrailingCommentCheckExamplesTest.java
+++ b/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/checks/TrailingCommentCheckExamplesTest.java
@@ -67,4 +67,13 @@ public class TrailingCommentCheckExamplesTest extends AbstractExamplesModuleTest
 
         verifyWithInlineConfigParser(getPath("Example4.java"), expected);
     }
+
+    @Test
+    public void testExample5() throws Exception {
+        final String[] expected = {
+            "22:16: " + getCheckMessage(MSG_KEY),
+        };
+
+        verifyWithInlineConfigParser(getPath("Example5.java"), expected);
+    }
 }

--- a/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/trailingcomment/Example5.java
+++ b/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/trailingcomment/Example5.java
@@ -1,0 +1,32 @@
+/*xml
+<module name="Checker">
+  <module name="TreeWalker">
+    <module name="TrailingComment">
+      <property name="legalComment" value="^// (TODO|FIXME|NOSONAR)"/>
+    </module>
+  </module>
+</module>
+*/
+
+package com.puppycrawl.tools.checkstyle.checks.trailingcomment;
+
+// xdoc section -- start
+public class Example5 {
+  public static void main(String[] args) {
+    int x = 10;
+
+    if (x > 5) {}
+    int a = 5; // TODO: fix this logic later - ok, matches legalComment pattern
+    int b = 6; // FIXME: this should be calculated - ok, matches legalComment pattern
+    int c = 7; // NOSONAR - ok, matches legalComment pattern
+    int d = 8; // violation, doesn't match legalComment pattern
+    doSomething(
+            "param1"
+    ); // ok, by default such trailing of method/code-block ending is allowed
+
+  }
+
+  private static void doSomething(String param) {
+  }
+}
+// xdoc section -- end


### PR DESCRIPTION
## Issue #17449: Add XDocs example for TrailingCommentCheck legalComment property

->Changes:
- Added `Example5.java` demonstrating the `legalComment` property usage
- Removed `TrailingCommentCheck` from the suppression list in `XdocsExampleFileTest`

->What the example shows:
The `legalComment` property allows certain trailing comments that match a specific pattern. The example demonstrates:
- Comments matching the pattern (TODO, FIXME, NOSONAR) are allowed
- Comments not matching the pattern trigger violations
- Default behavior for method-ending comments is preserved

->Testing:
- All tests in `XdocsExampleFileTest` pass
-  The property is no longer in the suppression list