### PR TITLE
Issue #17882: Update SEE_BLOCK_TAG to new format of AST print

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/api/JavadocCommentsTokenTypes.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/api/JavadocCommentsTokenTypes.java
@@ -274,7 +274,33 @@ public final class JavadocCommentsTokenTypes {
     public static final int VERSION_BLOCK_TAG = JavadocCommentsLexer.VERSION_BLOCK_TAG;
 
     /**
-     * {@code @see} block tag.
+     * {@code @see} Javadoc block tag.
+     *
+     * <p>Such Javadoc tag can have three children:</p>
+     * <ol>
+     *  <li>{@link #REFERENCE}</li>
+     *  <li>{@link #DESCRIPTION}</li>
+     *  <li>{@link #HTML_ELEMENT}</li>
+     * </ol>
+     *
+     * <p><b>Example:</b></p>
+     * <pre>{@code * @see SomeClass#Field}</pre>
+     *
+     * <b>Tree:</b>
+     * <pre>{@code
+     * JAVADOC_BLOCK_TAG -> JAVADOC_BLOCK_TAG
+     * `--SEE_BLOCK_TAG -> SEE_BLOCK_TAG
+     *     |--AT_SIGN -> @
+     *     |--TAG_NAME -> see
+     *     |--TEXT ->
+     *     `--REFERENCE -> REFERENCE
+     *         |--IDENTIFIER -> SomeClass
+     *         |--HASH -> #
+     *         `--MEMBER_REFERENCE -> MEMBER_REFERENCE
+     *             `--IDENTIFIER -> Field
+     * }</pre>
+     *
+     * @see #JAVADOC_BLOCK_TAG
      */
     public static final int SEE_BLOCK_TAG = JavadocCommentsLexer.SEE_BLOCK_TAG;
 


### PR DESCRIPTION
Issue #17882
## Test file
```java
 * @see SomeClass#Field
```
## AST output
```text
JAVADOC_CONTENT -> JAVADOC_CONTENT 
|--LEADING_ASTERISK ->  * 
|--TEXT ->   
`--JAVADOC_BLOCK_TAG -> JAVADOC_BLOCK_TAG 
    `--SEE_BLOCK_TAG -> SEE_BLOCK_TAG 
        |--AT_SIGN -> @ 
        |--TAG_NAME -> see 
        |--TEXT ->   
        `--REFERENCE -> REFERENCE 
            |--IDENTIFIER -> SomeClass 
            |--HASH -> # 
            `--MEMBER_REFERENCE -> MEMBER_REFERENCE 
                `--IDENTIFIER -> Field 
```
## Screenshot from local JavaDoc
<img width="435" height="629" alt="image" src="https://github.com/user-attachments/assets/bd57e020-cb8a-42b0-8ec3-fe405f7f5cc0" />