### PR TITLE
Issue #13999: Resolve Pitest Suppression in Pitest-Javadoc Profile

### DIFF
--- a/config/pitest-suppressions/pitest-javadoc-suppressions.xml
+++ b/config/pitest-suppressions/pitest-javadoc-suppressions.xml
@@ -1,20 +1,3 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <suppressedMutations>
-  <mutation unstable="false">
-    <sourceFile>JavadocTagInfo.java</sourceFile>
-    <mutatedClass>com.puppycrawl.tools.checkstyle.checks.javadoc.JavadocTagInfo$15</mutatedClass>
-    <mutatedMethod>isValidOn</mutatedMethod>
-    <mutator>org.pitest.mutationtest.engine.gregor.mutators.RemoveConditionalMutator_EQUAL_IF</mutator>
-    <description>removed conditional - replaced equality check with true</description>
-    <lineContent>&amp;&amp; varType.getFirstChild().getType() == TokenTypes.ARRAY_DECLARATOR</lineContent>
-  </mutation>
-
-  <mutation unstable="false">
-    <sourceFile>JavadocTagInfo.java</sourceFile>
-    <mutatedClass>com.puppycrawl.tools.checkstyle.checks.javadoc.JavadocTagInfo$15</mutatedClass>
-    <mutatedMethod>isValidOn</mutatedMethod>
-    <mutator>org.pitest.mutationtest.engine.gregor.mutators.RemoveConditionalMutator_EQUAL_IF</mutator>
-    <description>removed conditional - replaced equality check with true</description>
-    <lineContent>return astType == TokenTypes.VARIABLE_DEF</lineContent>
-  </mutation>
 </suppressedMutations>

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocTagInfoTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocTagInfoTest.java
@@ -354,6 +354,19 @@ public class JavadocTagInfoTest {
                     .isTrue();
         }
 
+        final int[] invalidTypes = {
+            TokenTypes.METHOD_DEF,
+            TokenTypes.CLASS_DEF,
+            TokenTypes.INTERFACE_DEF,
+            TokenTypes.ENUM_DEF,
+        };
+        for (int type: invalidTypes) {
+            ast.setType(type);
+            assertWithMessage("@serialField should only be valid on VARIABLE_DEF, not on others")
+                .that(JavadocTagInfo.SERIAL_FIELD.isValidOn(ast))
+                .isFalse();
+        }
+
         astChild2.setText("1111");
         assertWithMessage("Should return false when ast type is invalid for current tag")
                 .that(JavadocTagInfo.SERIAL_FIELD.isValidOn(ast))
@@ -366,6 +379,20 @@ public class JavadocTagInfoTest {
 
         ast.setType(TokenTypes.LAMBDA);
         assertWithMessage("Should return false when ast type is invalid for current tag")
+                .that(JavadocTagInfo.SERIAL_FIELD.isValidOn(ast))
+                .isFalse();
+
+        ast.setType(TokenTypes.VARIABLE_DEF);
+        astChild2.setType(TokenTypes.IDENT);
+        astChild2.setText("ObjectStreamField");
+        assertWithMessage("Should return false when type is not ARRAY_DECLARATOR ")
+                .that(JavadocTagInfo.SERIAL_FIELD.isValidOn(ast))
+                .isFalse();
+
+        ast.setType(TokenTypes.VARIABLE_DEF);
+        astChild2.setType(TokenTypes.ARRAY_DECLARATOR);
+        astChild2.setText("WrongField");
+        assertWithMessage("Should return false when text is not ObjectStreamField")
                 .that(JavadocTagInfo.SERIAL_FIELD.isValidOn(ast))
                 .isFalse();
     }


### PR DESCRIPTION
#13999 
Suppressions removed:
```
<mutation unstable="false">
    <sourceFile>JavadocTagInfo.java</sourceFile>
    <mutatedClass>com.puppycrawl.tools.checkstyle.checks.javadoc.JavadocTagInfo$15</mutatedClass>
    <mutatedMethod>isValidOn</mutatedMethod>
    <mutator>org.pitest.mutationtest.engine.gregor.mutators.RemoveConditionalMutator_EQUAL_IF</mutator>
    <description>removed conditional - replaced equality check with true</description>
    <lineContent>&amp;&amp; varType.getFirstChild().getType() == TokenTypes.ARRAY_DECLARATOR</lineContent>
  </mutation>
```
 ```
<mutation unstable="false">
    <sourceFile>JavadocTagInfo.java</sourceFile>
    <mutatedClass>com.puppycrawl.tools.checkstyle.checks.javadoc.JavadocTagInfo$15</mutatedClass>
    <mutatedMethod>isValidOn</mutatedMethod>
    <mutator>org.pitest.mutationtest.engine.gregor.mutators.RemoveConditionalMutator_EQUAL_IF</mutator>
    <description>removed conditional - replaced equality check with true</description>
    <lineContent>return astType == TokenTypes.VARIABLE_DEF</lineContent>
  </mutation>
```
Mutation -killed:

<img width="1920" height="1080" alt="Screenshot 2025-11-01 005235" src="https://github.com/user-attachments/assets/4b4cd1ef-0464-4f04-898d-43f0b5cee9ab" />
<img width="1818" height="942" alt="Screenshot 2025-11-01 005319" src="https://github.com/user-attachments/assets/70259123-5628-4250-beed-4fceb3f5e174" />

Report Analyzed
<img width="1919" height="226" alt="Screenshot 2025-11-01 023208" src="https://github.com/user-attachments/assets/77c1c0e2-54f5-48c9-9b29-7854b04a7c88" />




