### PR TITLE
Issue #14019: Kill surviving mutation in AbstractHeaderCheck

### DIFF
--- a/config/pitest-suppressions/pitest-header-suppressions.xml
+++ b/config/pitest-suppressions/pitest-header-suppressions.xml
@@ -1,11 +1,4 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <suppressedMutations>
-  <mutation unstable="false">
-    <sourceFile>AbstractHeaderCheck.java</sourceFile>
-    <mutatedClass>com.puppycrawl.tools.checkstyle.checks.header.AbstractHeaderCheck</mutatedClass>
-    <mutatedMethod>loadHeaderFile</mutatedMethod>
-    <mutator>org.pitest.mutationtest.engine.gregor.mutators.NonVoidMethodCallMutator</mutator>
-    <description>removed call to java/lang/String::valueOf</description>
-    <lineContent>throw new CheckstyleException(</lineContent>
-  </mutation>
+  
 </suppressedMutations>

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/header/HeaderCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/header/HeaderCheckTest.java
@@ -206,7 +206,8 @@ public class HeaderCheckTest extends AbstractModuleTestSupport {
     @Test
     public void testIoExceptionWhenLoadingHeaderFile() throws Exception {
         final HeaderCheck check = new HeaderCheck();
-        check.setHeaderFile(new URI("test://bad"));
+        final String uri = "test://bad";
+        check.setHeaderFile(new URI(uri));
 
         final ReflectiveOperationException ex =
                 getExpectedThrowable(ReflectiveOperationException.class,
@@ -215,7 +216,7 @@ public class HeaderCheckTest extends AbstractModuleTestSupport {
             .that(ex)
                 .hasCauseThat()
                     .hasMessageThat()
-                    .startsWith("unable to load header file ");
+                    .isEqualTo("unable to load header file " + uri);
     }
 
     @Test


### PR DESCRIPTION
Issue #14019

Before this change, PIT reported one surviving mutation in `AbstractHeaderCheck`. The mutator (`NonVoidMethodCallMutator`) removed the implicit `String.valueOf(headerFile)` call inside `throw new CheckstyleException("unable to load header file " + headerFile, exc);` replacing it with a null value.

Because the existing test `testIoExceptionWhenLoadingHeaderFile()` only checked the first part of the exception's message, the mutated code ("unable to load header file null") still passed.

This PR updates the test to assert that the exception message contains the entire text, including the headerFile. The test now fails for the mutated version.

Screenshots show the PIT report before and after the fix.
<img width="831" height="326" alt="Screenshot 2025-10-28 at 21 51 35" src="https://github.com/user-attachments/assets/cd791e9c-7418-468b-9ee9-e7ecccf5e413" />
<img width="1312" height="119" alt="Screenshot 2025-10-28 at 21 52 12" src="https://github.com/user-attachments/assets/a2305e4c-4e25-4058-8de0-c301adda7d06" />


<img width="845" height="324" alt="Screenshot 2025-10-28 at 22 23 52" src="https://github.com/user-attachments/assets/feb7acfe-6d64-4dad-8c24-37516b8ab312" />
<img width="945" height="40" alt="Screenshot 2025-10-28 at 22 23 11" src="https://github.com/user-attachments/assets/ca992c7a-dc83-4248-af93-f34bae89ee61" />
