### PR TITLE
Issue #17449: Added examples for legalAbstractClassNames property in …

### DIFF
--- a/src/site/xdoc/checks/coding/illegaltype.xml
+++ b/src/site/xdoc/checks/coding/illegaltype.xml
@@ -247,6 +247,14 @@ public class Example1 extends TreeSet {
   public void var() {
     var message = "Hello, World!";
   }
+
+  public AbstractSet&lt;String&gt; function4() {
+    return null;
+  }
+
+  private AbstractList&lt;String&gt; function5() {
+    return null;
+  }
 }
 </code></pre></div><hr class="example-separator"/>
         <p id="Example2-config">
@@ -318,6 +326,14 @@ public class Example2 extends TreeSet {
 
   public void var() {
     var message = "Hello, World!";
+  }
+
+  public AbstractSet&lt;String&gt; function4() {
+    return null;
+  }
+
+  private AbstractList&lt;String&gt; function5() {
+    return null;
   }
 }
 </code></pre></div><hr class="example-separator"/>
@@ -392,6 +408,14 @@ public class Example3 extends TreeSet {
   public void var() {
     var message = "Hello, World!";
   }
+
+  public AbstractSet&lt;String&gt; function4() {
+    return null;
+  }
+
+  private AbstractList&lt;String&gt; function5() {
+    return null;
+  }
 }
 </code></pre></div><hr class="example-separator"/>
         <p id="Example4-config">
@@ -465,6 +489,14 @@ public class Example4 extends TreeSet {
 
   public void var() {
     var message = "Hello, World!";
+  }
+
+  public AbstractSet&lt;String&gt; function4() {
+    return null;
+  }
+
+  private AbstractList&lt;String&gt; function5() {
+    return null;
   }
 }
 </code></pre></div><hr class="example-separator"/>
@@ -541,6 +573,14 @@ public class Example5 extends TreeSet {
   public void var() {
     var message = "Hello, World!";
   }
+
+  public AbstractSet&lt;String&gt; function4() {
+    return null;
+  }
+
+  private AbstractList&lt;String&gt; function5() {
+    return null;
+  }
 }
 </code></pre></div><hr class="example-separator"/>
         <p id="Example6-config">
@@ -614,6 +654,14 @@ public class Example6 extends TreeSet {
 
   public void var() {
     var message = "Hello, World!";
+  }
+
+  public AbstractSet&lt;String&gt; function4() {
+    return null;
+  }
+
+  private AbstractList&lt;String&gt; function5() {
+    return null;
   }
 }
 </code></pre></div><hr class="example-separator"/>
@@ -693,6 +741,14 @@ public class Example7 extends TreeSet {
   public void var() {
     var message = "Hello, World!";
   }
+
+  public AbstractSet&lt;String&gt; function4() {
+    return null;
+  }
+
+  private AbstractList&lt;String&gt; function5() {
+    return null;
+  }
 }
 </code></pre></div><hr class="example-separator"/>
         <p id="Example8-config">
@@ -767,6 +823,96 @@ public class Example8 extends TreeSet {
   public void var() {
     var message = "Hello, World!";
   } // violation above 'Usage of type 'var' is not allowed'
+  // violation below 'Usage of type 'AbstractSet' is not allowed'
+  public AbstractSet&lt;String&gt; function4() {
+    return null;
+  }
+
+  private AbstractList&lt;String&gt; function5() {
+    return null;
+  }
+}
+</code></pre></div><hr class="example-separator"/>
+        <p id="Example9-config">
+          To configure the check so that it violates Abstract Types which are illegal:
+        </p>
+        <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
+&lt;module name="Checker"&gt;
+  &lt;module name="TreeWalker"&gt;
+    &lt;module name="IllegalType"&gt;
+      &lt;property name="validateAbstractClassNames" value="true"/&gt;
+      &lt;property name="legalAbstractClassNames" value="AbstractList"/&gt;
+    &lt;/module&gt;
+  &lt;/module&gt;
+&lt;/module&gt;
+</code></pre></div>
+        <p id="Example9-code">Example:</p>
+        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+// violation below 'Usage of type 'TreeSet' is not allowed'
+public class Example9 extends TreeSet {
+  // violation below 'Usage of type 'java.util.HashSet' is not allowed'
+  public &lt;T extends java.util.HashSet&gt; void method() {
+    // violation below 'Usage of type 'LinkedHashMap' is not allowed'
+    LinkedHashMap&lt;Integer, String&gt; lhmap = new LinkedHashMap&lt;Integer, String&gt;();
+    // violation below 'Usage of type 'TreeMap' is not allowed'
+    TreeMap&lt;Integer, String&gt; treemap = new TreeMap&lt;Integer, String&gt;();
+    java.lang.IllegalArgumentException illegalex;
+    // violation below 'Usage of type 'java.util.TreeSet' is not allowed'
+    java.util.TreeSet treeset;
+  }
+  // violation below 'Usage of type 'java.util.HashSet' is not allowed'
+  public &lt;T extends java.util.HashSet&gt; void typeParam(T t) {}
+  // violation below 'Usage of type 'HashMap' is not allowed'
+  public HashMap&lt;String, String&gt; function1() {
+    return null;
+  }
+  // violation below 'Usage of type 'HashMap' is not allowed'
+  private HashMap&lt;String, String&gt; function2() {
+    return null;
+  }
+  // violation below 'Usage of type 'HashMap' is not allowed'
+  protected HashMap&lt;Integer, String&gt; function3() {
+    return null;
+  }
+
+  public &lt;T extends Boolean, U extends Serializable&gt; void typeParam(T a) {}
+
+  public &lt;T extends java.util.Optional&gt; void method(T t) {
+    Optional&lt;T&gt; i;
+  }
+
+  abstract class A {
+
+    public abstract Set&lt;Boolean&gt; shortName(Set&lt;? super Boolean&gt; a);
+
+  }
+
+  class B extends Gitter {}
+  class C extends Github {}
+
+  public Optional&lt;String&gt; field2;
+  protected String field3;
+  Optional&lt;String&gt; field4;
+
+  private void method(List&lt;Foo&gt; list, Boolean value) {}
+
+  void foo() {
+    Optional&lt;String&gt; i;
+  }
+
+  final Consumer&lt;Foo&gt; consumer = Foo&lt;Boolean&gt;::foo;
+
+  public void var() {
+    var message = "Hello, World!";
+  }
+  // violation below 'Usage of type 'AbstractSet' is not allowed'
+  public AbstractSet&lt;String&gt; function4() {
+    return null;
+  }
+
+  private AbstractList&lt;String&gt; function5() {
+    return null;
+  }
 }
 </code></pre></div>
       </subsection>

--- a/src/site/xdoc/checks/coding/illegaltype.xml.template
+++ b/src/site/xdoc/checks/coding/illegaltype.xml.template
@@ -145,6 +145,20 @@
           <param name="path"
                  value="resources/com/puppycrawl/tools/checkstyle/checks/coding/illegaltype/Example8.java"/>
           <param name="type" value="code"/>
+        </macro><hr class="example-separator"/>
+        <p id="Example9-config">
+          To configure the check so that it violates Abstract Types which are illegal:
+        </p>
+        <macro name="example">
+          <param name="path"
+                 value="resources/com/puppycrawl/tools/checkstyle/checks/coding/illegaltype/Example9.java"/>
+          <param name="type" value="config"/>
+        </macro>
+        <p id="Example9-code">Example:</p>
+        <macro name="example">
+          <param name="path"
+                 value="resources/com/puppycrawl/tools/checkstyle/checks/coding/illegaltype/Example9.java"/>
+          <param name="type" value="code"/>
         </macro>
       </subsection>
 

--- a/src/test/java/com/puppycrawl/tools/checkstyle/internal/XdocsExampleFileTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/internal/XdocsExampleFileTest.java
@@ -52,7 +52,6 @@ public class XdocsExampleFileTest {
     // This list is temporarily suppressed.
     // Until: https://github.com/checkstyle/checkstyle/issues/17449
     private static final Map<String, Set<String>> SUPPRESSED_PROPERTIES_BY_CHECK = Map.ofEntries(
-            Map.entry("IllegalTypeCheck", Set.of("legalAbstractClassNames")),
             Map.entry("MissingJavadocTypeCheck", Set.of("skipAnnotations")),
             Map.entry("JavadocStyleCheck", Set.of("endOfSentenceFormat", "checkEmptyJavadoc")),
             Map.entry("ConstantNameCheck", Set.of("applyToPackage", "applyToPrivate")),

--- a/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/checks/coding/IllegalTypeCheckExamplesTest.java
+++ b/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/checks/coding/IllegalTypeCheckExamplesTest.java
@@ -32,15 +32,15 @@ public class IllegalTypeCheckExamplesTest extends AbstractExamplesModuleTestSupp
     @Test
     public void testExample1() throws Exception {
         final String[] expected = {
-            "22:31: " + getCheckMessage(IllegalTypeCheck.MSG_KEY, "TreeSet"),
-            "24:21: " + getCheckMessage(IllegalTypeCheck.MSG_KEY, "java.util.HashSet"),
-            "26:5: " + getCheckMessage(IllegalTypeCheck.MSG_KEY, "LinkedHashMap"),
-            "28:5: " + getCheckMessage(IllegalTypeCheck.MSG_KEY, "TreeMap"),
-            "31:5: " + getCheckMessage(IllegalTypeCheck.MSG_KEY, "java.util.TreeSet"),
-            "34:21: " + getCheckMessage(IllegalTypeCheck.MSG_KEY, "java.util.HashSet"),
-            "36:10: " + getCheckMessage(IllegalTypeCheck.MSG_KEY, "HashMap"),
-            "40:11: " + getCheckMessage(IllegalTypeCheck.MSG_KEY, "HashMap"),
-            "44:13: " + getCheckMessage(IllegalTypeCheck.MSG_KEY, "HashMap"),
+            "16:31: " + getCheckMessage(IllegalTypeCheck.MSG_KEY, "TreeSet"),
+            "18:21: " + getCheckMessage(IllegalTypeCheck.MSG_KEY, "java.util.HashSet"),
+            "20:5: " + getCheckMessage(IllegalTypeCheck.MSG_KEY, "LinkedHashMap"),
+            "22:5: " + getCheckMessage(IllegalTypeCheck.MSG_KEY, "TreeMap"),
+            "25:5: " + getCheckMessage(IllegalTypeCheck.MSG_KEY, "java.util.TreeSet"),
+            "28:21: " + getCheckMessage(IllegalTypeCheck.MSG_KEY, "java.util.HashSet"),
+            "30:10: " + getCheckMessage(IllegalTypeCheck.MSG_KEY, "HashMap"),
+            "34:11: " + getCheckMessage(IllegalTypeCheck.MSG_KEY, "HashMap"),
+            "38:13: " + getCheckMessage(IllegalTypeCheck.MSG_KEY, "HashMap"),
         };
 
         verifyWithInlineConfigParser(getPath("Example1.java"), expected);
@@ -49,11 +49,11 @@ public class IllegalTypeCheckExamplesTest extends AbstractExamplesModuleTestSupp
     @Test
     public void testExample2() throws Exception {
         final String[] expected = {
-            "25:21: " + getCheckMessage(IllegalTypeCheck.MSG_KEY, "java.util.HashSet"),
-            "35:21: " + getCheckMessage(IllegalTypeCheck.MSG_KEY, "java.util.HashSet"),
-            "37:10: " + getCheckMessage(IllegalTypeCheck.MSG_KEY, "HashMap"),
-            "41:11: " + getCheckMessage(IllegalTypeCheck.MSG_KEY, "HashMap"),
-            "45:13: " + getCheckMessage(IllegalTypeCheck.MSG_KEY, "HashMap"),
+            "20:21: " + getCheckMessage(IllegalTypeCheck.MSG_KEY, "java.util.HashSet"),
+            "30:21: " + getCheckMessage(IllegalTypeCheck.MSG_KEY, "java.util.HashSet"),
+            "32:10: " + getCheckMessage(IllegalTypeCheck.MSG_KEY, "HashMap"),
+            "36:11: " + getCheckMessage(IllegalTypeCheck.MSG_KEY, "HashMap"),
+            "40:13: " + getCheckMessage(IllegalTypeCheck.MSG_KEY, "HashMap"),
         };
 
         verifyWithInlineConfigParser(getPath("Example2.java"), expected);
@@ -62,13 +62,13 @@ public class IllegalTypeCheckExamplesTest extends AbstractExamplesModuleTestSupp
     @Test
     public void testExample3() throws Exception {
         final String[] expected = {
-            "23:31: " + getCheckMessage(IllegalTypeCheck.MSG_KEY, "TreeSet"),
-            "25:21: " + getCheckMessage(IllegalTypeCheck.MSG_KEY, "java.util.HashSet"),
-            "27:5: " + getCheckMessage(IllegalTypeCheck.MSG_KEY, "LinkedHashMap"),
-            "29:5: " + getCheckMessage(IllegalTypeCheck.MSG_KEY, "TreeMap"),
-            "32:5: " + getCheckMessage(IllegalTypeCheck.MSG_KEY, "java.util.TreeSet"),
-            "35:21: " + getCheckMessage(IllegalTypeCheck.MSG_KEY, "java.util.HashSet"),
-            "45:13: " + getCheckMessage(IllegalTypeCheck.MSG_KEY, "HashMap"),
+            "17:31: " + getCheckMessage(IllegalTypeCheck.MSG_KEY, "TreeSet"),
+            "19:21: " + getCheckMessage(IllegalTypeCheck.MSG_KEY, "java.util.HashSet"),
+            "21:5: " + getCheckMessage(IllegalTypeCheck.MSG_KEY, "LinkedHashMap"),
+            "23:5: " + getCheckMessage(IllegalTypeCheck.MSG_KEY, "TreeMap"),
+            "26:5: " + getCheckMessage(IllegalTypeCheck.MSG_KEY, "java.util.TreeSet"),
+            "29:21: " + getCheckMessage(IllegalTypeCheck.MSG_KEY, "java.util.HashSet"),
+            "39:13: " + getCheckMessage(IllegalTypeCheck.MSG_KEY, "HashMap"),
         };
 
         verifyWithInlineConfigParser(getPath("Example3.java"), expected);
@@ -77,16 +77,16 @@ public class IllegalTypeCheckExamplesTest extends AbstractExamplesModuleTestSupp
     @Test
     public void testExample4() throws Exception {
         final String[] expected = {
-            "24:31: " + getCheckMessage(IllegalTypeCheck.MSG_KEY, "TreeSet"),
-            "26:21: " + getCheckMessage(IllegalTypeCheck.MSG_KEY, "java.util.HashSet"),
-            "28:5: " + getCheckMessage(IllegalTypeCheck.MSG_KEY, "LinkedHashMap"),
-            "30:5: " + getCheckMessage(IllegalTypeCheck.MSG_KEY, "TreeMap"),
-            "33:5: " + getCheckMessage(IllegalTypeCheck.MSG_KEY, "java.util.TreeSet"),
-            "36:21: " + getCheckMessage(IllegalTypeCheck.MSG_KEY, "java.util.HashSet"),
-            "38:10: " + getCheckMessage(IllegalTypeCheck.MSG_KEY, "HashMap"),
-            "42:11: " + getCheckMessage(IllegalTypeCheck.MSG_KEY, "HashMap"),
-            "46:13: " + getCheckMessage(IllegalTypeCheck.MSG_KEY, "HashMap"),
-            "62:19: " + getCheckMessage(IllegalTypeCheck.MSG_KEY, "Gitter"),
+            "18:31: " + getCheckMessage(IllegalTypeCheck.MSG_KEY, "TreeSet"),
+            "20:21: " + getCheckMessage(IllegalTypeCheck.MSG_KEY, "java.util.HashSet"),
+            "22:5: " + getCheckMessage(IllegalTypeCheck.MSG_KEY, "LinkedHashMap"),
+            "24:5: " + getCheckMessage(IllegalTypeCheck.MSG_KEY, "TreeMap"),
+            "27:5: " + getCheckMessage(IllegalTypeCheck.MSG_KEY, "java.util.TreeSet"),
+            "30:21: " + getCheckMessage(IllegalTypeCheck.MSG_KEY, "java.util.HashSet"),
+            "32:10: " + getCheckMessage(IllegalTypeCheck.MSG_KEY, "HashMap"),
+            "36:11: " + getCheckMessage(IllegalTypeCheck.MSG_KEY, "HashMap"),
+            "40:13: " + getCheckMessage(IllegalTypeCheck.MSG_KEY, "HashMap"),
+            "56:19: " + getCheckMessage(IllegalTypeCheck.MSG_KEY, "Gitter"),
         };
 
         verifyWithInlineConfigParser(getPath("Example4.java"), expected);
@@ -95,11 +95,11 @@ public class IllegalTypeCheckExamplesTest extends AbstractExamplesModuleTestSupp
     @Test
     public void testExample5() throws Exception {
         final String[] expected = {
-            "24:31: " + getCheckMessage(IllegalTypeCheck.MSG_KEY, "TreeSet"),
-            "26:21: " + getCheckMessage(IllegalTypeCheck.MSG_KEY, "java.util.HashSet"),
-            "36:21: " + getCheckMessage(IllegalTypeCheck.MSG_KEY, "java.util.HashSet"),
-            "38:10: " + getCheckMessage(IllegalTypeCheck.MSG_KEY, "HashMap"),
-            "46:13: " + getCheckMessage(IllegalTypeCheck.MSG_KEY, "HashMap"),
+            "18:31: " + getCheckMessage(IllegalTypeCheck.MSG_KEY, "TreeSet"),
+            "20:21: " + getCheckMessage(IllegalTypeCheck.MSG_KEY, "java.util.HashSet"),
+            "30:21: " + getCheckMessage(IllegalTypeCheck.MSG_KEY, "java.util.HashSet"),
+            "32:10: " + getCheckMessage(IllegalTypeCheck.MSG_KEY, "HashMap"),
+            "40:13: " + getCheckMessage(IllegalTypeCheck.MSG_KEY, "HashMap"),
         };
 
         verifyWithInlineConfigParser(getPath("Example5.java"), expected);
@@ -108,25 +108,33 @@ public class IllegalTypeCheckExamplesTest extends AbstractExamplesModuleTestSupp
     @Test
     public void testExample6() throws Exception {
         final String[] expected = {
-            "48:21: " + getCheckMessage(IllegalTypeCheck.MSG_KEY, "Boolean"),
-            "56:25: " + getCheckMessage(IllegalTypeCheck.MSG_KEY, "Boolean"),
-            "56:56: " + getCheckMessage(IllegalTypeCheck.MSG_KEY, "Boolean"),
-            "67:28: " + getCheckMessage(IllegalTypeCheck.MSG_KEY, "Foo"),
-            "67:39: " + getCheckMessage(IllegalTypeCheck.MSG_KEY, "Boolean"),
-            "73:18: " + getCheckMessage(IllegalTypeCheck.MSG_KEY, "Foo"),
-            "73:38: " + getCheckMessage(IllegalTypeCheck.MSG_KEY, "Boolean"),
+            "42:21: " + getCheckMessage(IllegalTypeCheck.MSG_KEY, "Boolean"),
+            "50:25: " + getCheckMessage(IllegalTypeCheck.MSG_KEY, "Boolean"),
+            "50:56: " + getCheckMessage(IllegalTypeCheck.MSG_KEY, "Boolean"),
+            "61:28: " + getCheckMessage(IllegalTypeCheck.MSG_KEY, "Foo"),
+            "61:39: " + getCheckMessage(IllegalTypeCheck.MSG_KEY, "Boolean"),
+            "67:18: " + getCheckMessage(IllegalTypeCheck.MSG_KEY, "Foo"),
+            "67:38: " + getCheckMessage(IllegalTypeCheck.MSG_KEY, "Boolean"),
         };
 
         verifyWithInlineConfigParser(getPath("Example6.java"), expected);
     }
 
     @Test
-    public void testExample7() throws Exception {
+    public void testExample9() throws Exception {
         final String[] expected = {
-            "71:10: " + getCheckMessage(IllegalTypeCheck.MSG_KEY, "Optional"),
-            "73:3: " + getCheckMessage(IllegalTypeCheck.MSG_KEY, "Optional"),
+            "20:31: " + getCheckMessage(IllegalTypeCheck.MSG_KEY, "TreeSet"),
+            "22:21: " + getCheckMessage(IllegalTypeCheck.MSG_KEY, "java.util.HashSet"),
+            "24:5: " + getCheckMessage(IllegalTypeCheck.MSG_KEY, "LinkedHashMap"),
+            "26:5: " + getCheckMessage(IllegalTypeCheck.MSG_KEY, "TreeMap"),
+            "29:5: " + getCheckMessage(IllegalTypeCheck.MSG_KEY, "java.util.TreeSet"),
+            "32:21: " + getCheckMessage(IllegalTypeCheck.MSG_KEY, "java.util.HashSet"),
+            "34:10: " + getCheckMessage(IllegalTypeCheck.MSG_KEY, "HashMap"),
+            "38:11: " + getCheckMessage(IllegalTypeCheck.MSG_KEY, "HashMap"),
+            "42:13: " + getCheckMessage(IllegalTypeCheck.MSG_KEY, "HashMap"),
+            "77:10: " + getCheckMessage(IllegalTypeCheck.MSG_KEY, "AbstractSet"),
         };
 
-        verifyWithInlineConfigParser(getPath("Example7.java"), expected);
+        verifyWithInlineConfigParser(getPath("Example9.java"), expected);
     }
 }

--- a/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/coding/illegaltype/Example1.java
+++ b/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/coding/illegaltype/Example1.java
@@ -8,14 +8,8 @@
 package com.puppycrawl.tools.checkstyle.checks.coding.illegaltype;
 
 import java.io.Serializable;
-import java.util.LinkedHashMap;
-import java.util.TreeSet;
-import java.util.TreeMap;
-import java.util.HashMap;
-import java.util.Set;
-import java.util.Optional;
+import java.util.*;
 import java.util.function.Consumer;
-import java.util.List;
 
 // xdoc section -- start
 // violation below 'Usage of type 'TreeSet' is not allowed'
@@ -74,6 +68,14 @@ public class Example1 extends TreeSet {
 
   public void var() {
     var message = "Hello, World!";
+  }
+
+  public AbstractSet<String> function4() {
+    return null;
+  }
+
+  private AbstractList<String> function5() {
+    return null;
   }
 }
 // xdoc section -- end

--- a/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/coding/illegaltype/Example2.java
+++ b/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/coding/illegaltype/Example2.java
@@ -11,14 +11,9 @@
 package com.puppycrawl.tools.checkstyle.checks.coding.illegaltype;
 
 import java.io.Serializable;
-import java.util.LinkedHashMap;
-import java.util.TreeSet;
-import java.util.TreeMap;
-import java.util.HashMap;
-import java.util.Set;
-import java.util.Optional;
+import java.util.*;
 import java.util.function.Consumer;
-import java.util.List;
+
 // xdoc section -- start
 public class Example2 extends TreeSet {
   // violation below 'Usage of type 'java.util.HashSet' is not allowed'
@@ -75,6 +70,14 @@ public class Example2 extends TreeSet {
 
   public void var() {
     var message = "Hello, World!";
+  }
+
+  public AbstractSet<String> function4() {
+    return null;
+  }
+
+  private AbstractList<String> function5() {
+    return null;
   }
 }
 // xdoc section -- end

--- a/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/coding/illegaltype/Example3.java
+++ b/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/coding/illegaltype/Example3.java
@@ -9,14 +9,8 @@
 */
 package com.puppycrawl.tools.checkstyle.checks.coding.illegaltype;
 import java.io.Serializable;
-import java.util.LinkedHashMap;
-import java.util.TreeSet;
-import java.util.TreeMap;
-import java.util.HashMap;
-import java.util.Set;
-import java.util.Optional;
+import java.util.*;
 import java.util.function.Consumer;
-import java.util.List;
 
 // xdoc section -- start
 // violation below 'Usage of type 'TreeSet' is not allowed'
@@ -75,6 +69,14 @@ public class Example3 extends TreeSet {
 
   public void var() {
     var message = "Hello, World!";
+  }
+
+  public AbstractSet<String> function4() {
+    return null;
+  }
+
+  private AbstractList<String> function5() {
+    return null;
   }
 }
 // xdoc section -- end

--- a/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/coding/illegaltype/Example4.java
+++ b/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/coding/illegaltype/Example4.java
@@ -10,14 +10,8 @@
 */
 package com.puppycrawl.tools.checkstyle.checks.coding.illegaltype;
 import java.io.Serializable;
-import java.util.LinkedHashMap;
-import java.util.TreeSet;
-import java.util.TreeMap;
-import java.util.HashMap;
-import java.util.Set;
-import java.util.Optional;
+import java.util.*;
 import java.util.function.Consumer;
-import java.util.List;
 
 // xdoc section -- start
 // violation below 'Usage of type 'TreeSet' is not allowed'
@@ -76,6 +70,14 @@ public class Example4 extends TreeSet {
 
   public void var() {
     var message = "Hello, World!";
+  }
+
+  public AbstractSet<String> function4() {
+    return null;
+  }
+
+  private AbstractList<String> function5() {
+    return null;
   }
 }
 // xdoc section -- end

--- a/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/coding/illegaltype/Example5.java
+++ b/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/coding/illegaltype/Example5.java
@@ -10,14 +10,8 @@
 */
 package com.puppycrawl.tools.checkstyle.checks.coding.illegaltype;
 import java.io.Serializable;
-import java.util.LinkedHashMap;
-import java.util.TreeSet;
-import java.util.TreeMap;
-import java.util.HashMap;
-import java.util.Set;
-import java.util.Optional;
+import java.util.*;
 import java.util.function.Consumer;
-import java.util.List;
 
 // xdoc section -- start
 // violation below 'Usage of type 'TreeSet' is not allowed'
@@ -76,6 +70,14 @@ public class Example5 extends TreeSet {
 
   public void var() {
     var message = "Hello, World!";
+  }
+
+  public AbstractSet<String> function4() {
+    return null;
+  }
+
+  private AbstractList<String> function5() {
+    return null;
   }
 }
 // xdoc section -- end

--- a/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/coding/illegaltype/Example7.java
+++ b/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/coding/illegaltype/Example7.java
@@ -17,14 +17,8 @@
 package com.puppycrawl.tools.checkstyle.checks.coding.illegaltype;
 
 import java.io.Serializable;
-import java.util.LinkedHashMap;
-import java.util.TreeSet;
-import java.util.TreeMap;
-import java.util.HashMap;
-import java.util.Set;
-import java.util.Optional;
+import java.util.*;
 import java.util.function.Consumer;
-import java.util.List;
 
 // xdoc section -- start
 public class Example7 extends TreeSet {
@@ -82,6 +76,14 @@ public class Example7 extends TreeSet {
 
   public void var() {
     var message = "Hello, World!";
+  }
+
+  public AbstractSet<String> function4() {
+    return null;
+  }
+
+  private AbstractList<String> function5() {
+    return null;
   }
 }
 // xdoc section -- end

--- a/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/coding/illegaltype/Example8.java
+++ b/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/coding/illegaltype/Example8.java
@@ -13,14 +13,8 @@
 package com.puppycrawl.tools.checkstyle.checks.coding.illegaltype;
 
 import java.io.Serializable;
-import java.util.LinkedHashMap;
-import java.util.TreeSet;
-import java.util.TreeMap;
-import java.util.HashMap;
-import java.util.Set;
-import java.util.Optional;
+import java.util.*;
 import java.util.function.Consumer;
-import java.util.List;
 
 // xdoc section -- start
 public class Example8 extends TreeSet {
@@ -79,5 +73,13 @@ public class Example8 extends TreeSet {
   public void var() {
     var message = "Hello, World!";
   } // violation above 'Usage of type 'var' is not allowed'
+  // violation below 'Usage of type 'AbstractSet' is not allowed'
+  public AbstractSet<String> function4() {
+    return null;
+  }
+
+  private AbstractList<String> function5() {
+    return null;
+  }
 }
 // xdoc section -- end

--- a/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/coding/illegaltype/Example9.java
+++ b/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/coding/illegaltype/Example9.java
@@ -2,43 +2,47 @@
 <module name="Checker">
   <module name="TreeWalker">
     <module name="IllegalType">
-      <property name="illegalClassNames" value="Boolean, Foo"/>
+      <property name="validateAbstractClassNames" value="true"/>
+      <property name="legalAbstractClassNames" value="AbstractList"/>
     </module>
   </module>
 </module>
 */
+
 package com.puppycrawl.tools.checkstyle.checks.coding.illegaltype;
+
 import java.io.Serializable;
 import java.util.*;
 import java.util.function.Consumer;
 
 // xdoc section -- start
-public class Example6 extends TreeSet {
-
+// violation below 'Usage of type 'TreeSet' is not allowed'
+public class Example9 extends TreeSet {
+  // violation below 'Usage of type 'java.util.HashSet' is not allowed'
   public <T extends java.util.HashSet> void method() {
-
+    // violation below 'Usage of type 'LinkedHashMap' is not allowed'
     LinkedHashMap<Integer, String> lhmap = new LinkedHashMap<Integer, String>();
-
+    // violation below 'Usage of type 'TreeMap' is not allowed'
     TreeMap<Integer, String> treemap = new TreeMap<Integer, String>();
     java.lang.IllegalArgumentException illegalex;
-
+    // violation below 'Usage of type 'java.util.TreeSet' is not allowed'
     java.util.TreeSet treeset;
   }
-
+  // violation below 'Usage of type 'java.util.HashSet' is not allowed'
   public <T extends java.util.HashSet> void typeParam(T t) {}
-
+  // violation below 'Usage of type 'HashMap' is not allowed'
   public HashMap<String, String> function1() {
     return null;
   }
-
+  // violation below 'Usage of type 'HashMap' is not allowed'
   private HashMap<String, String> function2() {
     return null;
   }
-
+  // violation below 'Usage of type 'HashMap' is not allowed'
   protected HashMap<Integer, String> function3() {
     return null;
   }
-  // violation below 'Usage of type 'Boolean' is not allowed'
+
   public <T extends Boolean, U extends Serializable> void typeParam(T a) {}
 
   public <T extends java.util.Optional> void method(T t) {
@@ -46,9 +50,9 @@ public class Example6 extends TreeSet {
   }
 
   abstract class A {
-    // violation below 'Usage of type 'Boolean' is not allowed'
+
     public abstract Set<Boolean> shortName(Set<? super Boolean> a);
-    // violation above 'Usage of type 'Boolean' is not allowed'
+
   }
 
   class B extends Gitter {}
@@ -57,20 +61,19 @@ public class Example6 extends TreeSet {
   public Optional<String> field2;
   protected String field3;
   Optional<String> field4;
-  // violation below 'Usage of type 'Foo' is not allowed'
+
   private void method(List<Foo> list, Boolean value) {}
-  // violation above 'Usage of type 'Boolean' is not allowed'
+
   void foo() {
     Optional<String> i;
   }
-  // violation below 'Usage of type 'Foo' is not allowed'
+
   final Consumer<Foo> consumer = Foo<Boolean>::foo;
-  // violation above 'Usage of type 'Boolean' is not allowed'
 
   public void var() {
     var message = "Hello, World!";
   }
-
+  // violation below 'Usage of type 'AbstractSet' is not allowed'
   public AbstractSet<String> function4() {
     return null;
   }
@@ -80,4 +83,3 @@ public class Example6 extends TreeSet {
   }
 }
 // xdoc section -- end
-


### PR DESCRIPTION
Issue: #17449 

Changes made:

-Added examples for legalAbstractClassNames property in illegalTypeCheck (inside the appropriate /*xml block).
-Updated the XDoc template/resource file to reference the new example.
-Removed legalAbstractClassNames from the suppression list in XdocsExampleFileTest.
-Verified that XdocsExampleFileTest passes without relying on suppression.
