### PR TITLE
Issue #14019: kill surviving mutation in CheckstyleAntTask.addProperty

### DIFF
--- a/config/pitest-suppressions/pitest-ant-suppressions.xml
+++ b/config/pitest-suppressions/pitest-ant-suppressions.xml
@@ -3,15 +3,6 @@
   <mutation unstable="false">
     <sourceFile>CheckstyleAntTask.java</sourceFile>
     <mutatedClass>com.puppycrawl.tools.checkstyle.ant.CheckstyleAntTask</mutatedClass>
-    <mutatedMethod>addProperty</mutatedMethod>
-    <mutator>org.pitest.mutationtest.engine.gregor.mutators.NonVoidMethodCallMutator</mutator>
-    <description>removed call to java/util/List::add</description>
-    <lineContent>overrideProps.add(property);</lineContent>
-  </mutation>
-
-  <mutation unstable="false">
-    <sourceFile>CheckstyleAntTask.java</sourceFile>
-    <mutatedClass>com.puppycrawl.tools.checkstyle.ant.CheckstyleAntTask</mutatedClass>
     <mutatedMethod>createOverridingProperties</mutatedMethod>
     <mutator>org.pitest.mutationtest.engine.gregor.mutators.NonVoidMethodCallMutator</mutator>
     <description>removed call to com/puppycrawl/tools/checkstyle/ant/CheckstyleAntTask::getLocation</description>
@@ -34,15 +25,6 @@
     <mutator>org.pitest.mutationtest.engine.gregor.mutators.NonVoidMethodCallMutator</mutator>
     <description>removed call to java/util/Properties::setProperty</description>
     <lineContent>returnValue.setProperty(entry.getKey(), value);</lineContent>
-  </mutation>
-
-  <mutation unstable="false">
-    <sourceFile>CheckstyleAntTask.java</sourceFile>
-    <mutatedClass>com.puppycrawl.tools.checkstyle.ant.CheckstyleAntTask</mutatedClass>
-    <mutatedMethod>createOverridingProperties</mutatedMethod>
-    <mutator>org.pitest.mutationtest.engine.gregor.mutators.NonVoidMethodCallMutator</mutator>
-    <description>removed call to java/util/Properties::setProperty</description>
-    <lineContent>returnValue.setProperty(p.getKey(), p.getValue());</lineContent>
   </mutation>
 
   <mutation unstable="false">

--- a/src/test/java/com/puppycrawl/tools/checkstyle/ant/CheckstyleAntTaskTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/ant/CheckstyleAntTaskTest.java
@@ -446,6 +446,10 @@ public class CheckstyleAntTaskTest extends AbstractPathTestSupport {
         assertWithMessage("Checker is not processed")
                 .that(TestRootModuleChecker.isProcessed())
                 .isTrue();
+        assertWithMessage("Property should be passed to checker with correct value")
+            .that(TestRootModuleChecker.getProperty())
+            .isEqualTo("ignore");
+
     }
 
     @Test


### PR DESCRIPTION
#14019 
Removed suppression from:
`checkstyle/config/pitest-suppressions/pitest-ant-suppressions.xml
`
```
<mutation unstable="false">
    <sourceFile>CheckstyleAntTask.java</sourceFile>
    <mutatedClass>com.puppycrawl.tools.checkstyle.ant.CheckstyleAntTask</mutatedClass>
    <mutatedMethod>addProperty</mutatedMethod>
    <mutator>org.pitest.mutationtest.engine.gregor.mutators.NonVoidMethodCallMutator</mutator>
    <description>removed call to java/util/List::add</description>
    <lineContent>overrideProps.add(property);</lineContent>
  </mutation>
```

- Generated report locally using : mvn -e --no-transfer-progress -P"$PITEST_PROFILE" clean test-compile org.pitest:pitest-maven:mutationCoverage (Added profile)

<img width="1589" height="249" alt="Screenshot 2025-10-29 191650" src="https://github.com/user-attachments/assets/dfbaf3b2-babe-48dd-972a-56aa39f52dcc" />

Mutations:

<img width="1571" height="157" alt="Screenshot 2025-10-29 191813" src="https://github.com/user-attachments/assets/772d9480-b899-4d08-9b64-e3e5c0a155b8" />

- Updated testOverrideProperty 

- Again generated pitest-report:

<img width="1569" height="217" alt="Screenshot 2025-10-30 004023" src="https://github.com/user-attachments/assets/0ebaa46a-34df-4998-abdb-2e77140be728" />

Killed mutation:

<img width="1888" height="375" alt="Screenshot 2025-10-30 004105" src="https://github.com/user-attachments/assets/15c12f4e-ab2e-4966-920a-82361a14f36f" />

- Remove suppression from:
`checkstyle/config/pitest-suppressions/pitest-ant-suppressions.xml
` 
```
<mutation unstable="false">                                                                                                                                                      
    <sourceFile>CheckstyleAntTask.java</sourceFile>                                                                                                                                
    <mutatedClass>com.puppycrawl.tools.checkstyle.ant.CheckstyleAntTask</mutatedClass>                                                                                             
    <mutatedMethod>createOverridingProperties</mutatedMethod>                                                                                                                      
    <mutator>org.pitest.mutationtest.engine.gregor.mutators.NonVoidMethodCallMutator</mutator>                                                                                     
   <description>removed call to java/util/Properties::setProperty</description>                                                                                                   
   <lineContent>returnValue.setProperty(p.getKey(), p.getValue());</lineContent>                                                                                                    </mutation>    
```
pitest-report

<img width="1853" height="727" alt="Screenshot 2025-10-30 124949" src="https://github.com/user-attachments/assets/54ffcdc3-d364-413f-835b-04368814e092" />

Already mutation is killed

<img width="1625" height="269" alt="Screenshot 2025-10-30 125050" src="https://github.com/user-attachments/assets/b8437f1c-602d-4d1a-8af3-81fa225d0f3a" />

Pitest-analyze:
groovy .ci/pitest-survival-check-xml.groovy "$PITEST_PROFILE"

<img width="1820" height="227" alt="Screenshot 2025-10-30 125643" src="https://github.com/user-attachments/assets/9dd0e3ff-d89c-459f-b71a-2dd8e1c4ba53" />


