### PR TITLE
Issue #16360: Migrate XMLLoggerTest.testNoCloseStream to use inlineCo…

### DIFF
--- a/src/test/java/com/puppycrawl/tools/checkstyle/XMLLoggerTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/XMLLoggerTest.java
@@ -140,6 +140,12 @@ public class XMLLoggerTest extends AbstractXmlTestSupport {
         verifyXml(getPath("ExpectedXMLLoggerEmpty.xml"), outStream);
     }
 
+    /**
+     * Cannot use verifyWithInlineConfigParserAndXmlLogger because it requires
+     * a custom stream to count close() calls.
+     *
+     * @throws Exception throws exception
+     */
     @Test
     public void testNoCloseStream()
             throws Exception {


### PR DESCRIPTION
Issue: #16360 

Change the XMLLoggerTest.testNoCloseStream method to use verifyWithInlineConfigParserAndXmlLogger