### PR TITLE
Issue #14019: Kill mutation in ModifiedControlVariableCheck

### DIFF
--- a/config/pitest-suppressions/pitest-coding-2-suppressions.xml
+++ b/config/pitest-suppressions/pitest-coding-2-suppressions.xml
@@ -1,24 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <suppressedMutations>
-
-  <mutation unstable="false">
-    <sourceFile>ModifiedControlVariableCheck.java</sourceFile>
-    <mutatedClass>com.puppycrawl.tools.checkstyle.checks.coding.ModifiedControlVariableCheck</mutatedClass>
-    <mutatedMethod>leaveToken</mutatedMethod>
-    <mutator>org.pitest.mutationtest.engine.gregor.mutators.NonVoidMethodCallMutator</mutator>
-    <description>removed call to java/lang/String::valueOf</description>
-    <lineContent>throw new IllegalStateException(ILLEGAL_TYPE_OF_TOKEN + ast);</lineContent>
-  </mutation>
-
-  <mutation unstable="false">
-    <sourceFile>ModifiedControlVariableCheck.java</sourceFile>
-    <mutatedClass>com.puppycrawl.tools.checkstyle.checks.coding.ModifiedControlVariableCheck</mutatedClass>
-    <mutatedMethod>visitToken</mutatedMethod>
-    <mutator>org.pitest.mutationtest.engine.gregor.mutators.NonVoidMethodCallMutator</mutator>
-    <description>removed call to java/lang/String::valueOf</description>
-    <lineContent>throw new IllegalStateException(ILLEGAL_TYPE_OF_TOKEN + ast);</lineContent>
-  </mutation>
-
   <mutation unstable="false">
     <sourceFile>UnusedLocalVariableCheck.java</sourceFile>
     <mutatedClass>com.puppycrawl.tools.checkstyle.checks.coding.UnusedLocalVariableCheck</mutatedClass>

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/coding/ModifiedControlVariableCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/coding/ModifiedControlVariableCheckTest.java
@@ -113,6 +113,7 @@ public class ModifiedControlVariableCheckTest
 
         final DetailAstImpl classDefAst = new DetailAstImpl();
         classDefAst.setType(TokenTypes.CLASS_DEF);
+        classDefAst.setText("CLASS_DEF");
 
         try {
             check.visitToken(classDefAst);
@@ -120,6 +121,9 @@ public class ModifiedControlVariableCheckTest
         }
         catch (IllegalStateException exc) {
             // it is OK
+            assertWithMessage("Error message must include token name")
+                    .that(exc.getMessage())
+                    .contains("CLASS_DEF");
         }
 
         try {
@@ -128,6 +132,9 @@ public class ModifiedControlVariableCheckTest
         }
         catch (IllegalStateException exc) {
             // it is OK
+            assertWithMessage("Error message must include token name")
+                    .that(exc.getMessage())
+                    .contains("CLASS_DEF");
         }
     }
 


### PR DESCRIPTION
Part of #14019: Suppressions for ModifiedControlVariableCheck.java removed from pitest-coding-2-suppressions.xml
After removing suppressions:
<img width="670" height="141" alt="Снимок экрана 2025-10-30 в 21 24 31" src="https://github.com/user-attachments/assets/40e62a16-2dea-412a-9cd3-25bbf1879fe5" />
After adding assertions:
<img width="656" height="138" alt="Снимок экрана 2025-10-30 в 21 42 30" src="https://github.com/user-attachments/assets/3ab6db28-ffbc-4cac-9d0b-83df56a72085" />