### PR TITLE
Issue #18010: Code syntax highlighting javascript (code-prettify) is executed twice

### DIFF
--- a/src/site/resources/js/checkstyle.js
+++ b/src/site/resources/js/checkstyle.js
@@ -55,7 +55,6 @@ window.addEventListener("load", function () {
     externalLinks.forEach((link) => {
         link.setAttribute("target", "_blank");
     });
-    prettyPrint();
 });
 
 window.addEventListener("scroll", function () {


### PR DESCRIPTION
## Issue
- #18010 

## PR Description
See the related issue. It explains everything.

## Rendered HTML Diff Report
I made a small custom tool that produces a diff report on the rendered[^1] HTML. This helps us see what difference the changed JavaScript makes.

The tool compares `master` and `18010` (this branch). Keep in mind it is not very mobile-friendly

[Checkstyle Website Rendered HTML Diff Report: Comparison between 'master' and '18010'](https://stoyank7.github.io/master-18010/)

- The only anomaly on the report is `checks/index.html, but this one is a bug. I checked it manually.

[^1]: rendered HTML - HTML after applying JavaScript. In other words, what the user's browser sees.