### PR TITLE
Issue #17887: No space in command line checkstyle commands

### DIFF
--- a/src/site/resources/js/checkstyle.js
+++ b/src/site/resources/js/checkstyle.js
@@ -150,43 +150,12 @@ window.addEventListener("load", function () {
 });
 
 function trimCodeBlock(codeBlock) {
-    const walker = document.createTreeWalker(
-      codeBlock,
-      NodeFilter.SHOW_TEXT,
-      null,
-      false
-    );
-    const textNodes = [];
-    let node;
-    while ((node = walker.nextNode())) {
-      textNodes.push(node);
-    }
-
-    for (let i = 0; i < textNodes.length; i++) {
-      const txt = textNodes[i].textContent;
-      const trimmed = txt.trim();
-      if (trimmed.length === 0) {
-        // If whole node is whitespace remove it.
-        if (textNodes[i].parentNode) {
-          textNodes[i].parentNode.removeChild(textNodes[i]);
-        }
-      } else {
-        textNodes[i].textContent = trimmed;
-        break;
-      }
-    }
-
-    for (let i = textNodes.length - 1; i >= 0; i--) {
-      const txt = textNodes[i].textContent;
-      const trimmed = txt.trim();
-      if (trimmed.length === 0) {
-        if (textNodes[i].parentNode) {
-          textNodes[i].parentNode.removeChild(textNodes[i]);
-        }
-      } else {
-        textNodes[i].textContent = trimmed;
-        break;
-      }
+    const textNodes = codeBlock.children;
+    if (textNodes.length > 0) {
+        const firstNodeIdx = 0;
+        const lastNodeIdx = textNodes.length - 1;
+        textNodes[firstNodeIdx].textContent = textNodes[firstNodeIdx].textContent.trimStart();
+        textNodes[lastNodeIdx].textContent = textNodes[lastNodeIdx].textContent.trimEnd();
     }
 }
 


### PR DESCRIPTION
## Depends on
- #18016 to be merged first

## Issue
- #17887

## PR Description
Comment https://github.com/checkstyle/checkstyle/issues/17887#issuecomment-3458153401 first explained the problem and the solution.

Long story short, each `<code>` block is split into `<span>` tokens. The following method was trimming all `<span>` tokens, and as a consequence, whitespaces were missing.

https://github.com/checkstyle/checkstyle/blob/cb5af6edfffcd9a4b74dd05f3a896750ca859ea6/src/site/resources/js/checkstyle.js#L152-L191

When trimming a `<code>` block, we just want to ensure that there are no hidden whitespaces at the beginning and at the end (of the `<code>` block). The rest inbetween must remain untouched.

The solution is to simply _only trim the beginning of the first and the ending of the last `<span>` token for each `<code>` block_.

## Rendered HTML Diff Report
[Checkstyle Website Rendered HTML Diff Report](https://stoyank7.github.io/18010-17887/)

Only the files that have `Characters diff` different than `0`  are relevant. The others seem like some false positives. 

I compared this branch against branch `18010`, because we also made some JS changes there. Therefore, #18016 must be merged before this.