### PR TITLE
Issue #17045: UI Flickering on Checkstyle.org – Panel Resizes Erratically on Navigation

### DIFF
--- a/src/site/resources/js/checkstyle.js
+++ b/src/site/resources/js/checkstyle.js
@@ -158,5 +158,11 @@ function trimCodeBlock(codeBlock) {
     }
 }
 
-window.addEventListener("load", setBodyColumnMargin);
+if (document.readyState === "loading") {
+    document.addEventListener("DOMContentLoaded", setBodyColumnMargin);
+}
+else {
+    setBodyColumnMargin();
+}
+
 window.addEventListener("resize", setBodyColumnMargin);

--- a/src/site/site.xml
+++ b/src/site/site.xml
@@ -51,7 +51,7 @@
     <head>
       <!-- Will be added to every generated page -->
       <![CDATA[
-        <script type="text/javascript" src="$relativePath/js/checkstyle.js"></script>
+        <script type="text/javascript" src="$relativePath/js/checkstyle.js" defer async></script>
         <script type="text/javascript" src="$relativePath/js/anchors.js"></script>
         <script type="text/javascript" src="$relativePath/js/google-analytics.js"></script>
         <script type="text/javascript" src="$relativePath/js/copy-clipboard.js"></script>


### PR DESCRIPTION
## Issue
- #17045

## Summary - What changed?
- Changed the event that triggers `setBodyColumnMargin()` from `window ("load")` to `document ("DOMContentLoaded")`
	- The `load` event fires only after _the whole page has loaded_ - scripts, images, iframes, stylesheets,... [^1]. We could instead use the `DOMContentLoaded` event that fires earlier - _when the HTML document has been completely parsed, and all deferred scripts have downloaded and executed_[^2]. Even the docs suggest that using `load` is a common mistake[^2]:
		> A different event, [`load`](https://developer.mozilla.org/en-US/docs/Web/API/Window/load_event), should be used only to detect a fully-loaded page. It is a common mistake to use `load` where `DOMContentLoaded` would be more appropriate.

		We don't need a fully loaded page to set the `className` of `#leftColumn` and `#bodyColumn`, just the DOM. Therefore, using `DOMContentLoaded` is something we can do.
- Added `async` and `defer` attributes to the `checkstyle.js` script so that it's fetched in parallel to the HTML parser
	- Until now, that was done in sequence
	- The official HTML specification[^3] has a very good diagram explaining what each attribute does:
	    -  <img width="1112" height="291" alt="image" src="https://github.com/user-attachments/assets/ba03e15f-f052-4d9f-9c6b-21a732ba5d5e" />
	    - They also say that
	        > _"The [defer](https://html.spec.whatwg.org/multipage/scripting.html#attr-script-defer) attribute may be specified even if the [async](https://html.spec.whatwg.org/multipage/scripting.html#attr-script-async) attribute is specified, to cause legacy web browsers that only support [defer](https://html.spec.whatwg.org/multipage/scripting.html#attr-script-defer) (and not [async](https://html.spec.whatwg.org/multipage/scripting.html#attr-script-async)) to fall back to the [defer](https://html.spec.whatwg.org/multipage/scripting.html#attr-script-defer) behavior instead of the blocking behavior that is the default."_
	        
## Does this all work?
I see an improvement in 80% of cases. Though sometimes flickering still occurs (for instance, on the `Release Notes` page). You just have to test on your browser.

[^1]: [Window: load event - Web APIs | MDN](https://developer.mozilla.org/en-US/docs/Web/API/Window/load_event)
[^2]: [Document: DOMContentLoaded event - Web APIs | MDN](https://developer.mozilla.org/en-US/docs/Web/API/Document/DOMContentLoaded_event)
[^3]: [HTML Standard 4.12.1 The script element](https://html.spec.whatwg.org/multipage/scripting.html#the-script-element)