### PR TITLE
Issue #3073: links to old releases in web are damaged

### DIFF
--- a/src/site/resources/js/checkstyle.js
+++ b/src/site/resources/js/checkstyle.js
@@ -17,6 +17,34 @@ window.addEventListener("load", function () {
     });
 });
 
+document.addEventListener("DOMContentLoaded", () => {
+    const url = new URL(window.location.href);
+    if (!url.pathname.endsWith("/releasenotes.html")
+            || !url.hash.startsWith("#Release_")
+            || document.getElementById(url.hash.replace("#", ""))) {
+        return;
+    }
+
+    const version = url.hash.split('_')[1];
+    const versionParts = version.split(".");
+    if (!versionParts.length >= 2) {
+        return;
+    }
+
+    let major = parseInt(versionParts[0], 10);
+    let minor = parseInt(versionParts[1], 10);
+
+    if (major >= 1 && major < 6) {
+        window.location.replace(`./releasenotes_old_1-0_5-9.html${url.hash}`);
+    }
+    else if (major === 6 || major === 7) {
+        window.location.replace(`./releasenotes_old_6-0_7-8.html${url.hash}`);
+    }
+    else if (major === 8 && minor >= 0 && minor <= 34) {
+        window.location.replace(`./releasenotes_old_8-0_8-34.html${url.hash}`);
+    }
+});
+
 window.addEventListener("load", function () {
     const currentUrl = window.location.href;
 

--- a/src/test/java/com/puppycrawl/tools/checkstyle/internal/XdocsPagesTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/internal/XdocsPagesTest.java
@@ -97,6 +97,8 @@ import com.puppycrawl.tools.checkstyle.utils.TokenUtil;
  */
 public class XdocsPagesTest {
     private static final Path SITE_PATH = Path.of("src/site/site.xml");
+    private static final Path CHECKSTYLE_JS_PATH = Path.of(
+        "src/site/resources/js/checkstyle.js");
 
     private static final Path AVAILABLE_CHECKS_PATH = Path.of("src/site/xdoc/checks.xml");
     private static final Path AVAILABLE_FILE_FILTERS_PATH = Path.of(
@@ -2376,6 +2378,28 @@ public class XdocsPagesTest {
             result = id.substring(0, dash);
         }
         return result;
+    }
+
+    @Test
+    public void testAllOldReleaseNotesHaveRedirectInCheckstyleJs() throws Exception {
+        final String checkstyleJsContent = Files.readString(CHECKSTYLE_JS_PATH);
+        for (Path path : XdocUtil.getXdocsFilePaths()) {
+            if (!path.toString().contains("releasenotes_old_")) {
+                continue;
+            }
+            final String fileNameWithoutExtension =
+                    path.getFileName().toString().replace(".xml", "");
+            final String expectedRedirect = String.format(Locale.ROOT,
+                    "window.location.replace(`./%s.html", fileNameWithoutExtension);
+            assertWithMessage(String.format(
+                        Locale.ROOT,
+                        "Missing redirect for %s: expected '%s...' in %s",
+                        fileNameWithoutExtension,
+                        expectedRedirect,
+                        CHECKSTYLE_JS_PATH))
+                    .that(checkstyleJsContent)
+                    .contains(expectedRedirect);
+        }
     }
 
     @FunctionalInterface


### PR DESCRIPTION
## Issue
- #3073

## Description
This PR adds an extra JavaScript logic that redirects users if they are trying to access the release notes of an older release[^1].

## Proof that it works
See comment below https://github.com/checkstyle/checkstyle/pull/18037#issuecomment-3476576776

> New tests from
> 
> > https://checkstyle-diff-reports.s3.us-east-2.amazonaws.com/640642b_20251103191234/index.html
> 
> [`/releasenotes.html#Release_1.0`](https://checkstyle-diff-reports.s3.us-east-2.amazonaws.com/640642b_20251103191234/releasenotes.html#Release_1.0)  
> [`/releasenotes.html#Release_2.4`](https://checkstyle-diff-reports.s3.us-east-2.amazonaws.com/640642b_20251103191234/releasenotes.html#Release_2.4)  
> [`/releasenotes.html#Release_4.0`](https://checkstyle-diff-reports.s3.us-east-2.amazonaws.com/640642b_20251103191234/releasenotes.html#Release_4.0)  
> [`/releasenotes.html#Release_5.0_Beta_1`](https://checkstyle-diff-reports.s3.us-east-2.amazonaws.com/640642b_20251103191234/releasenotes.html#Release_5.0_Beta_1)  
> [`/releasenotes.html#Release_5.9`](https://checkstyle-diff-reports.s3.us-east-2.amazonaws.com/640642b_20251103191234/releasenotes.html#Release_5.9)  
> [`/releasenotes.html#Release_6.0`](https://checkstyle-diff-reports.s3.us-east-2.amazonaws.com/640642b_20251103191234/releasenotes.html#Release_6.0)  
> [`/releasenotes.html#Release_6.3`](https://checkstyle-diff-reports.s3.us-east-2.amazonaws.com/640642b_20251103191234/releasenotes.html#Release_6.3)  
> [`/releasenotes.html#Release_7.6.1`](https://checkstyle-diff-reports.s3.us-east-2.amazonaws.com/640642b_20251103191234/releasenotes.html#Release_7.6.1)  
> [`/releasenotes.html#Release_8.0`](https://checkstyle-diff-reports.s3.us-east-2.amazonaws.com/640642b_20251103191234/releasenotes.html#Release_8.0)  
> [`/releasenotes.html#Release_8.12`](https://checkstyle-diff-reports.s3.us-east-2.amazonaws.com/640642b_20251103191234/releasenotes.html#Release_8.12)  
> [`/releasenotes.html#Release_8.34`](https://checkstyle-diff-reports.s3.us-east-2.amazonaws.com/640642b_20251103191234/releasenotes.html#Release_8.34)  
> [`/releasenotes.html#Release_8.35`](https://checkstyle-diff-reports.s3.us-east-2.amazonaws.com/640642b_20251103191234/releasenotes.html#Release_8.35)  
> [`/releasenotes.html#Release_10.15.0`](https://checkstyle-diff-reports.s3.us-east-2.amazonaws.com/640642b_20251103191234/releasenotes.html#Release_10.15.0)  
> [`/releasenotes.html#Release_12.1.1`](https://checkstyle-diff-reports.s3.us-east-2.amazonaws.com/640642b_20251103191234/releasenotes.html#Release_12.1.1)



[^1]: By _older release_, I mean any release that is not in the current [`releasenotes.html`](https://checkstyle.sourceforge.io/releasenotes.html). These are stored in other files - [`releasenotes_old_8-0_8-34.html`](https://checkstyle.sourceforge.io/releasenotes_old_8-0_8-34.html), [`releasenotes_old_6-0_7-8.html`](https://checkstyle.sourceforge.io/releasenotes_old_6-0_7-8.html) and [`releasenotes_old_1-0_5-9.html`](https://checkstyle.sourceforge.io/releasenotes_old_1-0_5-9.html)