### PR TITLE
Issue #16146: Webpage is blank of JDEPEND section

### DIFF
--- a/.ci/generate-website.sh
+++ b/.ci/generate-website.sh
@@ -16,6 +16,7 @@ echo TARGET_VERSION="$TARGET_VERSION"
 git checkout "checkstyle-$TARGET_VERSION"
 
 echo "Generating web site"
-./mvnw -e --no-transfer-progress site -Pno-validations -Dmaven.javadoc.skip=false
+./mvnw -e --no-transfer-progress site -Pno-validations \
+  -Dmaven.javadoc.skip=false -Djdepend.skip=false
 
 git checkout origin/master

--- a/.github/workflows/site.yml
+++ b/.github/workflows/site.yml
@@ -96,7 +96,8 @@ jobs:
         run: |
           bash
           cd .ci-temp/checkstyle
-          mvn -e --no-transfer-progress clean site -Pno-validations -Dmaven.javadoc.skip=false
+          mvn -e --no-transfer-progress clean site -Pno-validations \
+            -Dmaven.javadoc.skip=false -Djdepend.skip=false
 
       - name: Setup local maven cache
         uses: actions/cache/save@v4

--- a/config/jsoref-spellchecker/whitelist.words
+++ b/config/jsoref-spellchecker/whitelist.words
@@ -310,6 +310,7 @@ diffplug
 DIFFTOOL
 dirname
 Djacoco
+Djdepend
 Dlinkcheck
 DMail
 Dmaven


### PR DESCRIPTION
## Resolves
Issue
- #16146 

## Summary - What changed?
Added `-Djdepend.skip=false` to:
- job that generates website via `GitHub, generate website` comment
- job that generates website and uploads it to checkstyle.github.io

## What was the problem?
Looking back at the history of `jdepend-report.html` in [checkstyle/checkstyle.github.io/](https://github.com/checkstyle/checkstyle.github.io/), the report's contents got deleted in https://github.com/checkstyle/checkstyle.github.io/commit/2c6cfb6b5ff0fb8bd758ec254832094ced38d29b (checkstyle release 10.3.4).

The issue and PR that caused this change are:
- #12115
- #12118

The issue states that
> this is exact place where we want to skip all tools/test - you can add -Pno-validations to skip execution of tests and all tools.

so the PR above added `-Pno-validations` to the site deployment job.
Problem is that `no-validations` profile skips JDepend (and a bunch of other things):
https://github.com/checkstyle/checkstyle/blob/b2412ead07d76ae9391f847d048dc7c9e86674df/pom.xml#L2414-L2430