### PR TITLE
Issue #16243: Table headers text should be aligned to top of cell

### DIFF
--- a/src/site/resources/css/site.css
+++ b/src/site/resources/css/site.css
@@ -141,6 +141,7 @@ table {
 
 th {
   background-color: #ededed;
+  vertical-align: top !important;
 }
 
 .prettyprint {


### PR DESCRIPTION
## Resolves
Part of issue
- #16243 
    > -  tables headers text should aligned to top of cell, old website:
        <img width="533" height="314" alt="image" src="https://github.com/user-attachments/assets/6f867982-63c7-410e-8959-6496a0bc4a28" />

## Summary - What changed?
- Added a CSS rule to force all `<th>` elements to align their text to top.

Before this PR: [Google's Style – checkstyle](https://checkstyle.org/google_style.html#Coverage_table)
<img width="1421" height="365" alt="image" src="https://github.com/user-attachments/assets/61ad14f4-a4c9-4ff2-8899-2906aebcd6ed" />

After this PR: [Google's Style – checkstyle](https://checkstyle-diff-reports.s3.us-east-2.amazonaws.com/c9ac94d_20251102155816/google_style.html)
<img width="1421" height="365" alt="image" src="https://github.com/user-attachments/assets/e890da96-9a03-413e-a647-fdad5339334b" />

