### PR TITLE
Issue #18032: Resolve Pitest Suppression - packagenamesloader

### DIFF
--- a/config/pitest-suppressions/pitest-packagenamesloader-suppressions.xml
+++ b/config/pitest-suppressions/pitest-packagenamesloader-suppressions.xml
@@ -1,11 +1,3 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <suppressedMutations>
-  <mutation unstable="false">
-    <sourceFile>PackageNamesLoader.java</sourceFile>
-    <mutatedClass>com.puppycrawl.tools.checkstyle.PackageNamesLoader</mutatedClass>
-    <mutatedMethod>processFile</mutatedMethod>
-    <mutator>org.pitest.mutationtest.engine.gregor.mutators.NonVoidMethodCallMutator</mutator>
-    <description>removed call to java/lang/String::valueOf</description>
-    <lineContent>throw new CheckstyleException(&quot;unable to open &quot; + packageFile, exc);</lineContent>
-  </mutation>
 </suppressedMutations>

--- a/src/test/java/com/puppycrawl/tools/checkstyle/PackageNamesLoaderTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/PackageNamesLoaderTest.java
@@ -209,6 +209,9 @@ public class PackageNamesLoaderTest extends AbstractPathTestSupport {
                     .that(exc)
                     .hasMessageThat()
                     .isNotEqualTo("unable to get package file resources");
+            assertWithMessage("Exception message must contain URL")
+                    .that(exc.getMessage())
+                    .contains(url.toString());
         }
     }
 


### PR DESCRIPTION
Issue #18032: Resolve Pitest Suppression - packagenamesloader

Removed suppression from `config/pitest-supressions/pitest-packagenamesloader-suppressions.xml`
```
<mutation unstable="false">
    <sourceFile>PackageNamesLoader.java</sourceFile>
    <mutatedClass>com.puppycrawl.tools.checkstyle.PackageNamesLoader</mutatedClass>
    <mutatedMethod>processFile</mutatedMethod>
    <mutator>org.pitest.mutationtest.engine.gregor.mutators.NonVoidMethodCallMutator</mutator>
    <description>removed call to java/lang/String::valueOf</description>
    <lineContent>throw new CheckstyleException(&quot;unable to open &quot; + packageFile, exc);</lineContent>
  </mutation>
```
