### PR TITLE
Issue #8396: Fix multiline method call indentation issue with array components

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/indentation/MethodCallHandler.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/indentation/MethodCallHandler.java
@@ -112,19 +112,19 @@ public class MethodCallHandler extends AbstractExpressionHandler {
      * @return true if chained class are wrapped
      */
     private boolean isChainedMethodCallWrapped() {
-        boolean result = false;
         final DetailAST main = getMainAst();
         final DetailAST dot = main.getFirstChild();
         final DetailAST target = dot.getFirstChild();
 
         final DetailAST dot1 = target.getFirstChild();
-        final DetailAST target1 = dot1.getFirstChild();
-
-        if (dot1.getType() == TokenTypes.DOT
-            && target1.getType() == TokenTypes.METHOD_CALL) {
-            result = true;
+        DetailAST target1 = dot1;
+        while (target1.getFirstChild() != null
+                && target1.getType() != TokenTypes.METHOD_CALL) {
+            target1 = target1.getFirstChild();
         }
-        return result;
+
+        return dot1.getType() == TokenTypes.DOT
+                && target1.getType() == TokenTypes.METHOD_CALL;
     }
 
     /**

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/indentation/IndentationCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/indentation/IndentationCheckTest.java
@@ -352,6 +352,23 @@ public class IndentationCheckTest extends AbstractModuleTestSupport {
     }
 
     @Test
+    public void testMethodCallLineWrap1() throws Exception {
+        final DefaultConfiguration checkConfig = createModuleConfig(IndentationCheck.class);
+
+        checkConfig.addProperty("arrayInitIndent", "4");
+        checkConfig.addProperty("basicOffset", "4");
+        checkConfig.addProperty("braceAdjustment", "0");
+        checkConfig.addProperty("caseIndent", "4");
+        checkConfig.addProperty("forceStrictCondition", "false");
+        checkConfig.addProperty("lineWrappingIndentation", "4");
+        checkConfig.addProperty("tabWidth", "4");
+        checkConfig.addProperty("throwsIndent", "4");
+        final String[] expected = CommonUtil.EMPTY_STRING_ARRAY;
+        verifyWarns(checkConfig, getPath("InputIndentationMethodCallLineWrap1.java"),
+                expected);
+    }
+
+    @Test
     public void testDifficultAnnotations() throws Exception {
         final DefaultConfiguration checkConfig = createModuleConfig(IndentationCheck.class);
 

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/indentation/indentation/InputIndentationMethodCallLineWrap1.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/indentation/indentation/InputIndentationMethodCallLineWrap1.java
@@ -1,0 +1,76 @@
+package com.puppycrawl.tools.checkstyle.checks.indentation.indentation;      //indent:0 exp:0
+
+/**                                                                          //indent:0 exp:0
+ * This test-input is intended to be checked using following configuration:  //indent:1 exp:1
+ *                                                                           //indent:1 exp:1
+ * arrayInitIndent = 4                                                       //indent:1 exp:1
+ * basicOffset = 4                                                           //indent:1 exp:1
+ * braceAdjustment = 0                                                       //indent:1 exp:1
+ * caseIndent = 4                                                            //indent:1 exp:1
+ * forceStrictCondition = false                                              //indent:1 exp:1
+ * lineWrappingIndentation = 4                                               //indent:1 exp:1
+ * tabWidth = 4                                                              //indent:1 exp:1
+ * throwsIndent = 4                                                          //indent:1 exp:1
+ *                                                                           //indent:1 exp:1
+ *                                                                           //indent:1 exp:1
+ */                                                                          //indent:1 exp:1
+public class InputIndentationMethodCallLineWrap1 {                           //indent:0 exp:0
+
+    InputIndentationMethodCallLineWrap1[] arr = {this};                      //indent:4 exp:4
+
+    InputIndentationMethodCallLineWrap1[][] arr1 = {{this}};                 //indent:4 exp:4
+
+    InputIndentationMethodCallLineWrap1 getCurr() {                          //indent:4 exp:4
+        return this;                                                         //indent:8 exp:8
+    }                                                                        //indent:4 exp:4
+
+    InputIndentationMethodCallLineWrap1[] getCurrArr() {                     //indent:4 exp:4
+        return arr;                                                          //indent:8 exp:8
+    }                                                                        //indent:4 exp:4
+
+    InputIndentationMethodCallLineWrap1[][] getCurrArr1() {                  //indent:4 exp:4
+        return arr1;                                                         //indent:8 exp:8
+    }                                                                        //indent:4 exp:4
+
+    void method() {                                                          //indent:4 exp:4
+        InputIndentationMethodCallLineWrap1 obj =                            //indent:8 exp:8
+                new InputIndentationMethodCallLineWrap1();                   //indent:16 exp:16
+
+        obj                                                                  //indent:8 exp:8
+            .getCurrArr()[0]                                                 //indent:12 exp:12
+            .getCurr()                                                       //indent:12 exp:12
+            .getCurr();                                                      //indent:12 exp:12
+
+        obj.getCurrArr()[0]                                                  //indent:8 exp:8
+            .getCurr()                                                       //indent:12 exp:12
+            .getCurr();                                                      //indent:12 exp:12
+
+        obj.getCurrArr()[0].getCurr()                                        //indent:8 exp:8
+            .getCurr();                                                      //indent:12 exp:12
+
+        obj                                                                  //indent:8 exp:8
+            .getCurrArr1()[0][0]                                             //indent:12 exp:12
+            .getCurr()                                                       //indent:12 exp:12
+            .getCurr();                                                      //indent:12 exp:12
+
+        obj.getCurrArr1()[0][0]                                              //indent:8 exp:8
+            .getCurr()                                                       //indent:12 exp:12
+            .getCurr();                                                      //indent:12 exp:12
+
+        obj.getCurrArr1()[0][0].getCurr()                                    //indent:8 exp:8
+            .getCurr();                                                      //indent:12 exp:12
+
+        obj                                                                  //indent:8 exp:8
+            .getCurr()                                                       //indent:12 exp:12
+            .getCurr()                                                       //indent:12 exp:12
+            .getCurr();                                                      //indent:12 exp:12
+
+        obj.getCurr()                                                        //indent:8 exp:8
+            .getCurr()                                                       //indent:12 exp:12
+            .getCurr();                                                      //indent:12 exp:12
+
+        obj.getCurr().getCurr()                                              //indent:8 exp:8
+            .getCurr();                                                      //indent:12 exp:12
+
+    }                                                                        //indent:4 exp:4
+}                                                                            //indent:0 exp:0


### PR DESCRIPTION
Issue #8396 

- Fixed `isChainedMethodCallWrapped()`
- Added a test method `testMethodCallLineWrap1()`
- Added a input file `InputIndentationMethodCallLineWrap1.java`