### PR TITLE
Issue #17865: new xdoc xml page to share with users how to download xsd

### DIFF
--- a/src/site/site.xml
+++ b/src/site/site.xml
@@ -79,6 +79,7 @@
       <item name="Running" href="running.html">
         <item name="Ant Task" href="anttask.html"/>
         <item name="Command Line" href="cmdline.html"/>
+        <item name="Result Reports" href="result_reports.html"/>
       </item>
 
       <item name="Checks" href="checks.html">

--- a/src/site/xdoc/result_reports.xml
+++ b/src/site/xdoc/result_reports.xml
@@ -1,0 +1,56 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<document xmlns="http://maven.apache.org/XDOC/2.0"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/XDOC/2.0 https://maven.apache.org/xsd/xdoc-2.0.xsd">
+
+  <head>
+    <title>Result Reports</title>
+  </head>
+
+  <body>
+    <section name="Content">
+      <macro name="toc">
+        <param name="fromDepth" value="1"/>
+        <param name="toDepth" value="1"/>
+      </macro>
+    </section>
+
+    <section name="Overview">
+      <p>
+        Checkstyle can generate XML, SARIF and plain text reports of its findings.
+      </p>
+    </section>
+
+    <section name="Xml report">
+      <p>
+        The XML report schema is available at:
+        <a href="/xsds/checkstyle-report-1.0.0.xsd">
+          checkstyle-report-1.0.0.xsd
+        </a>
+      </p>
+      <p>
+        Use this schema to validate XML output from Checkstyle's report
+        generation.
+      </p>
+      <p>
+        Below is an example of a Checkstyle XML report:
+      </p>
+      <div class="wrapper">
+        <pre class="prettyprint">
+<code class="language-xml">
+&lt;?xml version="1.0" encoding="UTF-8"?&gt;
+&lt;checkstyle version="10.0"&gt;
+  &lt;file name="com/puppycrawl/tools/checkstyle/Main.java"&gt;
+    &lt;error line="1" column="1" severity="error"
+      message="Missing package-info.java file."
+      source="com.puppycrawl.tools.checkstyle.checks.coding.MissingPackageInfoCheck"/&gt;
+  &lt;/file&gt;
+&lt;/checkstyle&gt;
+</code>
+        </pre>
+      </div>
+    </section>
+  </body>
+</document>
+

--- a/src/test/java/com/puppycrawl/tools/checkstyle/internal/XdocsPagesTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/internal/XdocsPagesTest.java
@@ -262,7 +262,8 @@ public class XdocsPagesTest {
         "beginning_development.xml",
         "writingchecks.xml",
         "config.xml",
-        "report_issue.xml"
+        "report_issue.xml",
+        "result_reports.xml"
     );
 
     private static final String NAMES_MUST_BE_IN_ALPHABETICAL_ORDER_SITE_PATH =


### PR DESCRIPTION
Part of Issue #17867 , Comment https://github.com/checkstyle/checkstyle/issues/17865#issuecomment-3481538333

This change adds a new page to the Checkstyle website where users can find and download the XSD files for validating configuration files and report outputs.

What I Did

Made a new file ```src/site/xdoc/xsds.xml``` that lists the XSDs with links to download them.
Added "XSD Schemas" to the menu under "Configuration" in ```src/site/site.xml.```

Why

Users need a way to get the XSDs easily, just like the DTDs.
The XSDs are already set to be copied to the site by the build process.
This page explains how to use them in XML files.

The new page shows up at ```target/site/xsds.html``` with working links to the XSD files.