### PR TITLE
Issue #16243: Set font-size to 12px for code blocks when on mobile

### DIFF
--- a/config/jsoref-spellchecker/whitelist.words
+++ b/config/jsoref-spellchecker/whitelist.words
@@ -1131,7 +1131,6 @@ puppycrawl
 pw
 pwd
 px
-pxx
 py
 qa
 qalab

--- a/src/site/resources/css/site.css
+++ b/src/site/resources/css/site.css
@@ -152,7 +152,7 @@ th {
 }
 
 .prettyprint code {
-  font-size: 12pxx;
+  font-size: inherit;
   text-wrap: nowrap;
   line-height: 1.625;
 }
@@ -447,6 +447,10 @@ section#Properties .wrapper table td a {
   section#Properties .wrapper table th,
   section#Properties .wrapper table td {
     width: auto !important;
+  }
+
+  .prettyprint code {
+    font-size: 12px;
   }
 }
 


### PR DESCRIPTION
**Issue**
- #16243

**Description**
This PR resolves the following point from the list:
> only in mobile mode, code block should be in 12px, in desktop mode, it should be same as other text. 

Requested at https://github.com/checkstyle/checkstyle/pull/16439#issuecomment-2707916386