### PR TITLE
Issue #16243: Make date/version breadcrumb more compact

### DIFF
--- a/src/site/resources/css/site.css
+++ b/src/site/resources/css/site.css
@@ -227,6 +227,7 @@ pre {
   align-items: center;
   justify-content: flex-end;
   margin-bottom: 5px !important;
+  padding: 0 15px;
 }
 
 #bodyColumn h2, h2 {


### PR DESCRIPTION
Issue
- #16243

This PR addresses the following point from https://github.com/checkstyle/checkstyle/issues/16243#issuecomment-2676918065
> we need to make panel that shows version and last datetime of release to be compact.
it has not big spacing on top and bottom:
> <img width="480" height="102" alt="image" src="https://github.com/user-attachments/assets/ef3030f8-3578-4dbc-bf58-c4e5ac38b4b4" />
