### PR TITLE
minor: change code block font size to 15px

### DIFF
--- a/src/site/resources/css/site.css
+++ b/src/site/resources/css/site.css
@@ -152,7 +152,7 @@ th {
 }
 
 .prettyprint code {
-  font-size: inherit;
+  font-size: 15px;
   text-wrap: nowrap;
   line-height: 1.625;
 }


### PR DESCRIPTION
Comment https://github.com/checkstyle/checkstyle/pull/18055#issuecomment-3499550704

> please send PR for 15 , it makes sense

---
Before: https://checkstyle-diff-reports.s3.us-east-2.amazonaws.com/0b2ba18_20251105081749/checks/annotation/annotationlocation.html#Examples (taken from #18055)
<img width="785" height="340" alt="image" src="https://github.com/user-attachments/assets/1da4183e-20e9-4d74-8918-4471445f4a0a" />



After: https://checkstyle-diff-reports.s3.us-east-2.amazonaws.com/7db77fa_20251107084645/checks/annotation/annotationlocation.html#Examples (this PR)
<img width="691" height="310" alt="image" src="https://github.com/user-attachments/assets/75960bb6-1ade-45c5-8255-ab503baafdf5" />

