### PR TITLE
minor: reduce line-height for code blocks

### DIFF
--- a/src/site/resources/css/site.css
+++ b/src/site/resources/css/site.css
@@ -154,7 +154,7 @@ th {
 .prettyprint code {
   font-size: 15px;
   text-wrap: nowrap;
-  line-height: 1.625;
+  line-height: 1;
 }
 
 .inline-command code {


### PR DESCRIPTION
Comment https://github.com/checkstyle/checkstyle/pull/18063#issuecomment-3502390671
> [Old website (version/10.21.1)](https://checkstyle.sourceforge.io/version/10.21.1/checks/annotation/annotationlocation.html#Examples) used to have compact line spacing
> Spacing is now bigger. I don't know if it's intentional:
> We can reduce it like this:

> Please reduce spacing in separate PR.

---
[Before](https://checkstyle-diff-reports.s3.us-east-2.amazonaws.com/7db77fa_20251107084645/checks/annotation/annotationlocation.html#Examples)
<img width="693" height="268" alt="image" src="https://github.com/user-attachments/assets/fbf7c713-a3f1-4940-840d-b430238e9cd7" />


[After](https://checkstyle-diff-reports.s3.us-east-2.amazonaws.com/6530a7f_20251108080019/checks/annotation/annotationlocation.html#Examples)
<img width="689" height="223" alt="image" src="https://github.com/user-attachments/assets/ab8774f4-cb7b-4de9-aa1e-9b9f1f8df2f4" />
