### PR TITLE
Issue #18062: Remove broken link to Maven Snapshot repository in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,9 +28,6 @@ The latest release version can be found at
 [GitHub releases](https://github.com/checkstyle/checkstyle/releases/)
 or at [Maven repo](https://repo1.maven.org/maven2/com/puppycrawl/tools/checkstyle/).
 
-Each-commit builds of maven artifacts can be found at
-[Maven Snapshot repository](https://oss.sonatype.org/content/repositories/snapshots/com/puppycrawl/tools/checkstyle/).
-
 Documentation is available in HTML format, see https://checkstyle.org/checks.html .
 
 ## Table of Contents


### PR DESCRIPTION
Resolves issue
- #18062 
