### PR TITLE
Issue #18074: Align SLF4J version to the version reflections uses, and mark it as a runtime dependency

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -208,7 +208,7 @@
     <pmd.version>7.18.0</pmd.version>
     <maven.jacoco.plugin.version>0.8.14</maven.jacoco.plugin.version>
     <mockito.version>5.2.0</mockito.version>
-    <slf4j.version>2.0.17</slf4j.version>
+    <slf4j.version>1.7.32</slf4j.version> <!-- Aligned with the version reflections depends on -->
     <saxon.version>12.9</saxon.version>
     <maven.checkstyle.plugin.version>3.6.0</maven.checkstyle.plugin.version>
     <maven.sevntu.checkstyle.plugin.version>1.44.1</maven.sevntu.checkstyle.plugin.version>
@@ -426,13 +426,13 @@
       <groupId>org.slf4j</groupId>
       <artifactId>slf4j-api</artifactId>
       <version>${slf4j.version}</version>
-      <scope>test</scope>
+      <scope>runtime</scope>
     </dependency>
     <dependency>
       <groupId>org.slf4j</groupId>
       <artifactId>slf4j-simple</artifactId>
       <version>${slf4j.version}</version>
-      <scope>test</scope>
+      <scope>runtime</scope>
     </dependency>
     <dependency>
       <groupId>org.jacoco</groupId>


### PR DESCRIPTION
This PR handles a regression introduced by #17958:
As long as `org.slf4j:slf4j-api` was not explicilty stated in the `pom.xml`, the assembly plugin would pick up the transitive dependency.
With #17958, this dependency was explicitly marked as a test dependency, making the assembly plugin skip it. To fix this regression, the dependency was aligned to the version used by `org.reflections:reflections` and marked as a runtime dependency, making it availale for both the tests that use it and the checkstyle-all uberjar.

Fixes #18074 