### PR TITLE
doc: Add extra section about 'Performance Regressions'

### DIFF
--- a/docs/GRAMMAR_UPDATES.md
+++ b/docs/GRAMMAR_UPDATES.md
@@ -228,3 +228,13 @@ AST because it provides a more structured representation of the source code that
 analyze. The AST is designed specifically for static analysis and provides a more convenient
 interface for writing checks; it abstracts away the details of the parse tree and provides a
 simplified view of the source code.
+
+### Performance Regressions
+
+When updating the grammar, we should be mindful of the performance impact of our changes. For that,
+we have a CI job that compares the performance of the changes against a baseline. Make sure to
+check the results of the performance regression tests after making changes to the grammar. You can
+find the tests
+[here](https://github.com/checkstyle/checkstyle/blob/master/.ci/check-performance-regression.sh) and
+the CI job
+[here](https://github.com/checkstyle/checkstyle/blob/master/.github/workflows/check-performance-regression.yml).


### PR DESCRIPTION
Resolves comment https://github.com/checkstyle/checkstyle/pull/18079#issuecomment-3518316481
> Can somebody tell me how to [run those performance benchmark reports](https://github.com/checkstyle/checkstyle/pull/17982#issuecomment-3441805908)?
>>    ===================== BENCHMARK SUMMARY ====================
    Execution Time Baseline: 390.7 s
    Average Execution Time: 527.54 s
    ============================================================
    Execution Time Difference: 35.0200%
>>    Difference exceeds the maximum allowed difference (35.0200% > 10%)!

> Wouldn't be a bad idea to mention that in [docs/GRAMMAR_UPDATES.md](https://github.com/checkstyle/checkstyle/blob/master/docs/GRAMMAR_UPDATES.md).

> Please send separate PR