### PR TITLE
supplemental: Better violation when checks are not in alphabetical order

### DIFF
--- a/src/site/xdoc/checks.xml
+++ b/src/site/xdoc/checks.xml
@@ -1616,6 +1616,14 @@
           </tr>
           <tr>
             <td>
+              <a href="checks/design/throwscount.html#ThrowsCount">ThrowsCount</a>
+            </td>
+            <td>
+              Restricts throws statements to a specified count.
+            </td>
+          </tr>
+          <tr>
+            <td>
               <a href="checks/whitespace/singlespaceseparator.html#SingleSpaceSeparator">
                 SingleSpaceSeparator
               </a>
@@ -1682,14 +1690,6 @@
             <td>
               Allows to specify what warnings that <code>@SuppressWarnings</code> is
               not allowed to suppress.
-            </td>
-          </tr>
-          <tr>
-            <td>
-              <a href="checks/design/throwscount.html#ThrowsCount">ThrowsCount</a>
-            </td>
-            <td>
-              Restricts throws statements to a specified count.
             </td>
           </tr>
           <tr>

--- a/src/site/xdoc/checks.xml.template
+++ b/src/site/xdoc/checks.xml.template
@@ -2017,6 +2017,17 @@
           </tr>
           <tr>
             <td>
+              <a href="checks/design/throwscount.html#ThrowsCount">ThrowsCount</a>
+            </td>
+            <td>
+              <macro name="checks">
+                <param name="modulePath"
+  value="src/main/java/com/puppycrawl/tools/checkstyle/checks/design/ThrowsCountCheck.java" />
+              </macro>
+            </td>
+          </tr>
+          <tr>
+            <td>
               <a href="checks/whitespace/singlespaceseparator.html#SingleSpaceSeparator">
                 SingleSpaceSeparator
               </a>
@@ -2096,17 +2107,6 @@
               <macro name="checks">
                 <param name="modulePath"
   value="src/main/java/com/puppycrawl/tools/checkstyle/checks/annotation/SuppressWarningsCheck.java" />
-              </macro>
-            </td>
-          </tr>
-          <tr>
-            <td>
-              <a href="checks/design/throwscount.html#ThrowsCount">ThrowsCount</a>
-            </td>
-            <td>
-              <macro name="checks">
-                <param name="modulePath"
-  value="src/main/java/com/puppycrawl/tools/checkstyle/checks/design/ThrowsCountCheck.java" />
               </macro>
             </td>
           </tr>

--- a/src/test/java/com/puppycrawl/tools/checkstyle/internal/XdocsPagesTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/internal/XdocsPagesTest.java
@@ -571,10 +571,17 @@ public class XdocsPagesTest {
                     .sorted()
                     .toList();
 
-            assertWithMessage(name + NAMES_MUST_BE_IN_ALPHABETICAL_ORDER_SITE_PATH + path)
-                    .that(names)
-                    .containsExactlyElementsIn(namesSorted)
-                    .inOrder();
+            String previousCheck = namesSorted.get(0);
+            for (int i = 0; i < names.size(); i++) {
+                String actual = names.get(i);
+                String expected = namesSorted.get(i);
+
+                assertWithMessage(actual + "Check is not in alphabetical order at " +
+                        SITE_PATH + ". it must come after " + previousCheck + "Check.")
+                        .that(actual)
+                        .isEqualTo(expected);
+                previousCheck = namesSorted.get(i);
+            }
         }
     }
 


### PR DESCRIPTION
Before:
```
Check names must be in alphabetical order at src/site/site.xmlsrc/site/xdoc/checks.xml
contents match, but order was wrong
expected: [AbbreviationAsWordInName, AbstractClassName, AnnotationLocation, AnnotationOnSameLine, AnnotationUseStyle, AnonInnerLength, ArrayTrailingComma, ArrayTypeStyle, AtclauseOrder, AvoidDoubleBraceInitialization, AvoidEscapedUnicodeCharacters, AvoidInlineConditionals, AvoidNestedBlocks, AvoidNoArgumentSuperConstructorCall, AvoidStarImport, AvoidStaticImport, BooleanExpressionComplexity, CatchParameterName, ClassDataAbstractionCoupling, ClassFanOutComplexity, ClassMemberImpliedModifier, ClassTypeParameterName, CommentsIndentation, ConstantName, ConstructorsDeclarationGrouping, CovariantEquals, CustomImportOrder, CyclomaticComplexity, DeclarationOrder, DefaultComesLast, DescendantToken, DesignForExtension, EmptyBlock, EmptyCatchBlock, EmptyForInitializerPad, EmptyForIteratorPad, EmptyLineSeparator, EmptyStatement, EqualsAvoidNull, EqualsHashCode, ExecutableStatementCount, ExplicitInitialization, FallThrough, FileLength, FileTabCharacter, FinalClass, FinalLocalVariable, FinalParameters, GenericWhitespace, Header, HexLiteralCase, HiddenField, HideUtilityClassConstructor, IllegalCatch, IllegalIdentifierName, IllegalImport, IllegalInstantiation, IllegalThrows, IllegalToken, IllegalTokenText, IllegalType, ImportControl, ImportOrder, Indentation, InnerAssignment, InnerTypeLast, InterfaceIsType, InterfaceMemberImpliedModifier, InterfaceTypeParameterName, InvalidJavadocPosition, JavaNCSS, JavadocBlockTagLocation, JavadocContentLocation, JavadocLeadingAsteriskAlign, JavadocMethod, JavadocMissingLeadingAsterisk, JavadocMissingWhitespaceAfterAsterisk, JavadocPackage, JavadocParagraph, JavadocStyle, JavadocTagContinuationIndentation, JavadocType, JavadocVariable, LambdaBodyLength, LambdaParameterName, LeftCurly, LineLength, LocalFinalVariableName, LocalVariableName, MagicNumber, MatchXpath, MemberName, MethodCount, MethodLength, MethodName, MethodParamPad, MethodTypeParameterName, MissingCtor, MissingDeprecated, MissingJavadocMethod, MissingJavadocPackage, MissingJavadocType, MissingNullCaseInSwitch, MissingOverride, MissingSwitchDefault, ModifiedControlVariable, ModifierOrder, MultiFileRegexpHeader, MultipleStringLiterals, MultipleVariableDeclarations, MutableException, NPathComplexity, NeedBraces, NestedForDepth, NestedIfDepth, NestedTryDepth, NewlineAtEndOfFile, NoArrayTrailingComma, NoClone, NoCodeInFile, NoEnumTrailingComma, NoFinalizer, NoLineWrap, NoWhitespaceAfter, NoWhitespaceBefore, NoWhitespaceBeforeCaseDefaultColon, NonEmptyAtclauseDescription, OneStatementPerLine, OneTopLevelClass, OperatorWrap, OrderedProperties, OuterTypeFilename, OuterTypeNumber, OverloadMethodsDeclarationOrder, PackageAnnotation, PackageDeclaration, PackageName, ParameterAssignment, ParameterName, ParameterNumber, ParenPad, PatternVariableAssignment, PatternVariableName, RecordComponentName, RecordComponentNumber, RecordTypeParameterName, RedundantImport, RedundantModifier, Regexp, RegexpHeader, RegexpMultiline, RegexpOnFilename, RegexpSingleline, RegexpSinglelineJava, RequireEmptyLineBeforeBlockTagGroup, RequireThis, ReturnCount, RightCurly, SealedShouldHavePermitsList, SeparatorWrap, SimplifyBooleanExpression, SimplifyBooleanReturn, SingleLineJavadoc, SingleSpaceSeparator, StaticVariableName, StringLiteralEquality, SummaryJavadoc, SuperClone, SuperFinalize, SuppressWarnings, ThrowsCount, TodoComment, TrailingComment, Translation, TypeName, TypecastParenPad, UncommentedMain, UniqueProperties, UnnecessaryNullCheckWithInstanceOf, UnnecessaryParentheses, UnnecessarySemicolonAfterOuterTypeDeclaration, UnnecessarySemicolonAfterTypeMemberDeclaration, UnnecessarySemicolonInEnumeration, UnnecessarySemicolonInTryWithResources, UnusedCatchParameterShouldBeUnnamed, UnusedImports, UnusedLambdaParameterShouldBeUnnamed, UnusedLocalVariable, UpperEll, VariableDeclarationUsageDistance, VisibilityModifier, WhenShouldBeUsed, WhitespaceAfter, WhitespaceAround, WriteTag]
but was : [AbbreviationAsWordInName, AbstractClassName, AnnotationLocation, AnnotationOnSameLine, AnnotationUseStyle, AnonInnerLength, ArrayTrailingComma, ArrayTypeStyle, AtclauseOrder, AvoidDoubleBraceInitialization, AvoidEscapedUnicodeCharacters, AvoidInlineConditionals, AvoidNestedBlocks, AvoidNoArgumentSuperConstructorCall, AvoidStarImport, AvoidStaticImport, BooleanExpressionComplexity, CatchParameterName, ClassDataAbstractionCoupling, ClassFanOutComplexity, ClassMemberImpliedModifier, ClassTypeParameterName, CommentsIndentation, ConstantName, ConstructorsDeclarationGrouping, CovariantEquals, CustomImportOrder, CyclomaticComplexity, DeclarationOrder, DefaultComesLast, DescendantToken, DesignForExtension, EmptyBlock, EmptyCatchBlock, EmptyForInitializerPad, EmptyForIteratorPad, EmptyLineSeparator, EmptyStatement, EqualsAvoidNull, EqualsHashCode, ExecutableStatementCount, ExplicitInitialization, FallThrough, FileLength, FileTabCharacter, FinalClass, FinalLocalVariable, FinalParameters, GenericWhitespace, Header, HexLiteralCase, HiddenField, HideUtilityClassConstructor, IllegalCatch, IllegalIdentifierName, IllegalImport, IllegalInstantiation, IllegalThrows, IllegalToken, IllegalTokenText, IllegalType, ImportControl, ImportOrder, Indentation, InnerAssignment, InnerTypeLast, InterfaceIsType, InterfaceMemberImpliedModifier, InterfaceTypeParameterName, InvalidJavadocPosition, JavaNCSS, JavadocBlockTagLocation, JavadocContentLocation, JavadocLeadingAsteriskAlign, JavadocMethod, JavadocMissingLeadingAsterisk, JavadocMissingWhitespaceAfterAsterisk, JavadocPackage, JavadocParagraph, JavadocStyle, JavadocTagContinuationIndentation, JavadocType, JavadocVariable, LambdaBodyLength, LambdaParameterName, LeftCurly, LineLength, LocalFinalVariableName, LocalVariableName, MagicNumber, MatchXpath, MemberName, MethodCount, MethodLength, MethodName, MethodParamPad, MethodTypeParameterName, MissingCtor, MissingDeprecated, MissingJavadocMethod, MissingJavadocPackage, MissingJavadocType, MissingNullCaseInSwitch, MissingOverride, MissingSwitchDefault, ModifiedControlVariable, ModifierOrder, MultiFileRegexpHeader, MultipleStringLiterals, MultipleVariableDeclarations, MutableException, NPathComplexity, NeedBraces, NestedForDepth, NestedIfDepth, NestedTryDepth, NewlineAtEndOfFile, NoArrayTrailingComma, NoClone, NoCodeInFile, NoEnumTrailingComma, NoFinalizer, NoLineWrap, NoWhitespaceAfter, NoWhitespaceBefore, NoWhitespaceBeforeCaseDefaultColon, NonEmptyAtclauseDescription, OneStatementPerLine, OneTopLevelClass, OperatorWrap, OrderedProperties, OuterTypeFilename, OuterTypeNumber, OverloadMethodsDeclarationOrder, PackageAnnotation, PackageDeclaration, PackageName, ParameterAssignment, ParameterName, ParameterNumber, ParenPad, PatternVariableAssignment, PatternVariableName, RecordComponentName, RecordComponentNumber, RecordTypeParameterName, RedundantImport, RedundantModifier, Regexp, RegexpHeader, RegexpMultiline, RegexpOnFilename, RegexpSingleline, RegexpSinglelineJava, RequireEmptyLineBeforeBlockTagGroup, RequireThis, ReturnCount, RightCurly, SealedShouldHavePermitsList, SeparatorWrap, SimplifyBooleanExpression, SimplifyBooleanReturn, SingleLineJavadoc, ThrowsCount, SingleSpaceSeparator, StaticVariableName, StringLiteralEquality, SummaryJavadoc, SuperClone, SuperFinalize, SuppressWarnings, TodoComment, TrailingComment, Translation, TypeName, TypecastParenPad, UncommentedMain, UniqueProperties, UnnecessaryNullCheckWithInstanceOf, UnnecessaryParentheses, UnnecessarySemicolonAfterOuterTypeDeclaration, UnnecessarySemicolonAfterTypeMemberDeclaration, UnnecessarySemicolonInEnumeration, UnnecessarySemicolonInTryWithResources, UnusedCatchParameterShouldBeUnnamed, UnusedImports, UnusedLambdaParameterShouldBeUnnamed, UnusedLocalVariable, UpperEll, VariableDeclarationUsageDistance, VisibilityModifier, WhenShouldBeUsed, WhitespaceAfter, WhitespaceAround, WriteTag]
```

Now:
```
ThrowsCountCheck is not in alphabetical order at src/site/site.xml. it must come after SingleLineJavadocCheck.
expected: SingleSpaceSeparator
but was : ThrowsCount
Expected :SingleSpaceSeparator
Actual   :ThrowsCount
```

if changes get approved, I'll do the same with Filters in this same PR