### PR TITLE
Issue #11166: Remove usage of getFileContents() from AvoidEscapedUnicodeCharactersChecks

### DIFF
--- a/config/checker-framework-suppressions/checker-index-suppressions.xml
+++ b/config/checker-framework-suppressions/checker-index-suppressions.xml
@@ -399,19 +399,8 @@
   <checkerFrameworkError unstable="false">
     <fileName>src/main/java/com/puppycrawl/tools/checkstyle/checks/AvoidEscapedUnicodeCharactersCheck.java</fileName>
     <specifier>argument</specifier>
-    <message>incompatible argument for parameter arg1 of Arrays.copyOfRange.</message>
-    <lineContent>comment.getEndColNo() + 1, codePoints.length));</lineContent>
-    <details>
-      found   : int
-      required: @LTEqLengthOf(&quot;codePoints&quot;) int
-    </details>
-  </checkerFrameworkError>
-
-  <checkerFrameworkError unstable="false">
-    <fileName>src/main/java/com/puppycrawl/tools/checkstyle/checks/AvoidEscapedUnicodeCharactersCheck.java</fileName>
-    <specifier>argument</specifier>
-    <message>incompatible argument for parameter arg1 of Arrays.copyOfRange.</message>
-    <lineContent>comment.getEndColNo() + 1, codePoints.length));</lineContent>
+    <message>incompatible argument for parameter arg1 of String.codePointCount.</message>
+    <lineContent>return line.codePointCount(0, safeCharIndex);</lineContent>
     <details>
       found   : int
       required: @NonNegative int

--- a/config/checker-framework-suppressions/checker-nullness-optional-interning-suppressions.xml
+++ b/config/checker-framework-suppressions/checker-nullness-optional-interning-suppressions.xml
@@ -1410,20 +1410,6 @@
   </checkerFrameworkError>
 
   <checkerFrameworkError unstable="false">
-    <fileName>src/main/java/com/puppycrawl/tools/checkstyle/checks/AvoidEscapedUnicodeCharactersCheck.java</fileName>
-    <specifier>initialization.field.uninitialized</specifier>
-    <message>the default constructor does not initialize field blockComments</message>
-    <lineContent>private Map&lt;Integer, List&lt;TextBlock&gt;&gt; blockComments;</lineContent>
-  </checkerFrameworkError>
-
-  <checkerFrameworkError unstable="false">
-    <fileName>src/main/java/com/puppycrawl/tools/checkstyle/checks/AvoidEscapedUnicodeCharactersCheck.java</fileName>
-    <specifier>initialization.field.uninitialized</specifier>
-    <message>the default constructor does not initialize field singlelineComments</message>
-    <lineContent>private Map&lt;Integer, TextBlock&gt; singlelineComments;</lineContent>
-  </checkerFrameworkError>
-
-  <checkerFrameworkError unstable="false">
     <fileName>src/main/java/com/puppycrawl/tools/checkstyle/checks/DescendantTokenCheck.java</fileName>
     <specifier>initialization.field.uninitialized</specifier>
     <message>the default constructor does not initialize field maximumMessage</message>

--- a/config/jsoref-spellchecker/whitelist.words
+++ b/config/jsoref-spellchecker/whitelist.words
@@ -370,7 +370,7 @@ elif
 elist
 Ellipsize
 emacs
-Emoji
+emoji
 emptyblock
 emptycatchblock
 emptyforinitializerpad

--- a/config/pitest-suppressions/pitest-misc-suppressions.xml
+++ b/config/pitest-suppressions/pitest-misc-suppressions.xml
@@ -1,0 +1,110 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<suppressedMutations>
+  <mutation unstable="false">
+    <sourceFile>AvoidEscapedUnicodeCharactersCheck.java</sourceFile>
+    <mutatedClass>com.puppycrawl.tools.checkstyle.checks.AvoidEscapedUnicodeCharactersCheck</mutatedClass>
+    <mutatedMethod>beginTree</mutatedMethod>
+    <mutator>org.pitest.mutationtest.engine.gregor.mutators.VoidMethodCallMutator</mutator>
+    <description>removed call to java/util/Map::clear</description>
+    <lineContent>blockComments.clear();</lineContent>
+  </mutation>
+
+  <mutation unstable="false">
+    <sourceFile>AvoidEscapedUnicodeCharactersCheck.java</sourceFile>
+    <mutatedClass>com.puppycrawl.tools.checkstyle.checks.AvoidEscapedUnicodeCharactersCheck</mutatedClass>
+    <mutatedMethod>beginTree</mutatedMethod>
+    <mutator>org.pitest.mutationtest.engine.gregor.mutators.VoidMethodCallMutator</mutator>
+    <description>removed call to java/util/Map::clear</description>
+    <lineContent>singlelineComments.clear();</lineContent>
+  </mutation>
+
+  <mutation unstable="false">
+    <sourceFile>AvoidEscapedUnicodeCharactersCheck.java</sourceFile>
+    <mutatedClass>com.puppycrawl.tools.checkstyle.checks.AvoidEscapedUnicodeCharactersCheck</mutatedClass>
+    <mutatedMethod>charIndexToCodePointIndex</mutatedMethod>
+    <mutator>org.pitest.mutationtest.engine.gregor.mutators.experimental.ArgumentPropagationMutator</mutator>
+    <description>replaced call to java/lang/String::codePointCount with argument</description>
+    <lineContent>return line.codePointCount(0, safeCharIndex);</lineContent>
+  </mutation>
+
+  <mutation unstable="false">
+    <sourceFile>AvoidEscapedUnicodeCharactersCheck.java</sourceFile>
+    <mutatedClass>com.puppycrawl.tools.checkstyle.checks.AvoidEscapedUnicodeCharactersCheck</mutatedClass>
+    <mutatedMethod>convertToTextBlock</mutatedMethod>
+    <mutator>org.pitest.mutationtest.engine.gregor.mutators.experimental.ArgumentPropagationMutator</mutator>
+    <description>replaced call to com/puppycrawl/tools/checkstyle/checks/AvoidEscapedUnicodeCharactersCheck::charIndexToCodePointIndex with argument</description>
+    <lineContent>codePointEndCol = charIndexToCodePointIndex(line, charPosAfterComment + 2);</lineContent>
+  </mutation>
+
+  <mutation unstable="false">
+    <sourceFile>AvoidEscapedUnicodeCharactersCheck.java</sourceFile>
+    <mutatedClass>com.puppycrawl.tools.checkstyle.checks.AvoidEscapedUnicodeCharactersCheck</mutatedClass>
+    <mutatedMethod>convertToTextBlock</mutatedMethod>
+    <mutator>org.pitest.mutationtest.engine.gregor.mutators.NonVoidMethodCallMutator</mutator>
+    <description>removed call to com/puppycrawl/tools/checkstyle/checks/AvoidEscapedUnicodeCharactersCheck::charIndexToCodePointIndex</description>
+    <lineContent>codePointEndCol = charIndexToCodePointIndex(line, charPosAfterComment);</lineContent>
+  </mutation>
+
+  <mutation unstable="false">
+    <sourceFile>AvoidEscapedUnicodeCharactersCheck.java</sourceFile>
+    <mutatedClass>com.puppycrawl.tools.checkstyle.checks.AvoidEscapedUnicodeCharactersCheck</mutatedClass>
+    <mutatedMethod>convertToTextBlock</mutatedMethod>
+    <mutator>org.pitest.mutationtest.engine.gregor.mutators.experimental.ArgumentPropagationMutator</mutator>
+    <description>replaced call to com/puppycrawl/tools/checkstyle/checks/AvoidEscapedUnicodeCharactersCheck::charIndexToCodePointIndex with argument</description>
+    <lineContent>codePointEndCol = charIndexToCodePointIndex(line, charPosAfterComment);</lineContent>
+  </mutation>
+
+  <mutation unstable="false">
+    <sourceFile>AvoidEscapedUnicodeCharactersCheck.java</sourceFile>
+    <mutatedClass>com.puppycrawl.tools.checkstyle.checks.AvoidEscapedUnicodeCharactersCheck</mutatedClass>
+    <mutatedMethod>convertToTextBlock</mutatedMethod>
+    <mutator>org.pitest.mutationtest.engine.gregor.mutators.experimental.NakedReceiverMutator</mutator>
+    <description>replaced call to com/puppycrawl/tools/checkstyle/api/DetailAST::getLastChild with receiver</description>
+    <lineContent>final DetailAST blockCommentEnd = commentAst.getLastChild();</lineContent>
+  </mutation>
+
+  <mutation unstable="false">
+    <sourceFile>AvoidEscapedUnicodeCharactersCheck.java</sourceFile>
+    <mutatedClass>com.puppycrawl.tools.checkstyle.checks.AvoidEscapedUnicodeCharactersCheck</mutatedClass>
+    <mutatedMethod>convertToTextBlock</mutatedMethod>
+    <mutator>org.pitest.mutationtest.engine.gregor.mutators.MathMutator</mutator>
+    <description>Replaced integer addition with subtraction</description>
+    <lineContent>final int charPosAfterComment = blockCommentEnd.getColumnNo() + 2;</lineContent>
+  </mutation>
+
+  <mutation unstable="false">
+    <sourceFile>AvoidEscapedUnicodeCharactersCheck.java</sourceFile>
+    <mutatedClass>com.puppycrawl.tools.checkstyle.checks.AvoidEscapedUnicodeCharactersCheck</mutatedClass>
+    <mutatedMethod>convertToTextBlock</mutatedMethod>
+    <mutator>org.pitest.mutationtest.engine.gregor.mutators.NonVoidMethodCallMutator</mutator>
+    <description>removed call to com/puppycrawl/tools/checkstyle/api/DetailAST::getColumnNo</description>
+    <lineContent>final int charPosAfterComment = blockCommentEnd.getColumnNo() + 2;</lineContent>
+  </mutation>
+
+  <mutation unstable="false">
+    <sourceFile>AvoidEscapedUnicodeCharactersCheck.java</sourceFile>
+    <mutatedClass>com.puppycrawl.tools.checkstyle.checks.AvoidEscapedUnicodeCharactersCheck</mutatedClass>
+    <mutatedMethod>convertToTextBlock</mutatedMethod>
+    <mutator>org.pitest.mutationtest.engine.gregor.mutators.NonVoidMethodCallMutator</mutator>
+    <description>removed call to com/puppycrawl/tools/checkstyle/api/DetailAST::getColumnNo</description>
+    <lineContent>final int startCol = commentAst.getColumnNo();</lineContent>
+  </mutation>
+
+  <mutation unstable="false">
+    <sourceFile>AvoidEscapedUnicodeCharactersCheck.java</sourceFile>
+    <mutatedClass>com.puppycrawl.tools.checkstyle.checks.AvoidEscapedUnicodeCharactersCheck</mutatedClass>
+    <mutatedMethod>hasTrailComment</mutatedMethod>
+    <mutator>org.pitest.mutationtest.engine.gregor.mutators.experimental.ArgumentPropagationMutator</mutator>
+    <description>replaced call to com/puppycrawl/tools/checkstyle/checks/AvoidEscapedUnicodeCharactersCheck::charIndexToCodePointIndex with argument</description>
+    <lineContent>final int codePointEndCol = charIndexToCodePointIndex(</lineContent>
+  </mutation>
+
+  <mutation unstable="false">
+    <sourceFile>AvoidEscapedUnicodeCharactersCheck.java</sourceFile>
+    <mutatedClass>com.puppycrawl.tools.checkstyle.checks.AvoidEscapedUnicodeCharactersCheck</mutatedClass>
+    <mutatedMethod>hasTrailComment</mutatedMethod>
+    <mutator>org.pitest.mutationtest.engine.gregor.mutators.RemoveConditionalMutator_EQUAL_IF</mutator>
+    <description>removed conditional - replaced equality check with true</description>
+    <lineContent>if (!result) {</lineContent>
+  </mutation>
+</suppressedMutations>

--- a/config/suppressions.xml
+++ b/config/suppressions.xml
@@ -127,7 +127,6 @@
   <suppress id="noUsageOfGetFileContentsMethod" files="MissingJavadocTypeCheck.java"/>
   <suppress id="noUsageOfGetFileContentsMethod" files="RegexpCheck.java"/>
   <suppress id="noUsageOfGetFileContentsMethod" files="RegexpSinglelineJavaCheck.java"/>
-  <suppress id="noUsageOfGetFileContentsMethod" files="AvoidEscapedUnicodeCharactersCheck.java"/>
 
   <!-- until https://github.com/checkstyle/checkstyle/issues/5234 -->
   <suppress id="MatchXPathBranchContains" files="[\\/]DetailAstImplTest.java"/>

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/AvoidEscapedUnicodeCharactersCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/AvoidEscapedUnicodeCharactersCheckTest.java
@@ -21,6 +21,7 @@ package com.puppycrawl.tools.checkstyle.checks;
 
 import static com.google.common.truth.Truth.assertWithMessage;
 import static com.puppycrawl.tools.checkstyle.checks.AvoidEscapedUnicodeCharactersCheck.MSG_KEY;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 
 import java.util.Arrays;
 import java.util.List;
@@ -158,6 +159,8 @@ public class AvoidEscapedUnicodeCharactersCheckTest extends AbstractModuleTestSu
             TokenTypes.STRING_LITERAL,
             TokenTypes.CHAR_LITERAL,
             TokenTypes.TEXT_BLOCK_CONTENT,
+            TokenTypes.SINGLE_LINE_COMMENT,
+            TokenTypes.BLOCK_COMMENT_BEGIN,
         };
         assertWithMessage("Required tokens differ from expected")
             .that(checkObj.getRequiredTokens())
@@ -457,6 +460,50 @@ public class AvoidEscapedUnicodeCharactersCheckTest extends AbstractModuleTestSu
     }
 
     @Test
+    public void testCommentProcessing() throws Exception {
+        final String[] expected = {
+            "28:20: " + getCheckMessage(MSG_KEY),
+            "30:20: " + getCheckMessage(MSG_KEY),
+            "36:32: " + getCheckMessage(MSG_KEY),
+            "38:37: " + getCheckMessage(MSG_KEY),
+            "40:24: " + getCheckMessage(MSG_KEY),
+            "43:32: " + getCheckMessage(MSG_KEY),
+            "47:27: " + getCheckMessage(MSG_KEY),
+            "49:29: " + getCheckMessage(MSG_KEY),
+        };
+        verifyWithInlineConfigParser(
+                getPath("InputAvoidEscapedUnicodeCharactersComments.java"), expected);
+    }
+
+    @Test
+    public void testBeginTreeHandlesNullAndClearsComments() throws Exception {
+        final String[] expected = {
+            "28:20: " + getCheckMessage(MSG_KEY),
+            "30:20: " + getCheckMessage(MSG_KEY),
+            "36:32: " + getCheckMessage(MSG_KEY),
+            "38:37: " + getCheckMessage(MSG_KEY),
+            "40:24: " + getCheckMessage(MSG_KEY),
+            "43:32: " + getCheckMessage(MSG_KEY),
+            "47:27: " + getCheckMessage(MSG_KEY),
+            "49:29: " + getCheckMessage(MSG_KEY),
+        };
+        // First call - populates and checks
+        verifyWithInlineConfigParser(
+                    getPath("InputAvoidEscapedUnicodeCharactersComments.java"), expected);
+
+        // Second call - clears and repopulates
+        verifyWithInlineConfigParser(
+                    getPath("InputAvoidEscapedUnicodeCharactersComments.java"), expected);
+    }
+
+    @Test
+    public void testBeginTreeHandlesNullRoot() {
+        final AvoidEscapedUnicodeCharactersCheck check =
+            new AvoidEscapedUnicodeCharactersCheck();
+        assertDoesNotThrow(() -> check.beginTree(null));
+    }
+
+    @Test
     public void testGetAcceptableTokens() {
         final AvoidEscapedUnicodeCharactersCheck check = new AvoidEscapedUnicodeCharactersCheck();
         final int[] actual = check.getAcceptableTokens();
@@ -464,6 +511,8 @@ public class AvoidEscapedUnicodeCharactersCheckTest extends AbstractModuleTestSu
             TokenTypes.STRING_LITERAL,
             TokenTypes.CHAR_LITERAL,
             TokenTypes.TEXT_BLOCK_CONTENT,
+            TokenTypes.SINGLE_LINE_COMMENT,
+            TokenTypes.BLOCK_COMMENT_BEGIN,
         };
         assertWithMessage("Acceptable tokens differ from expected")
             .that(actual)

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/avoidescapedunicodecharacters/InputAvoidEscapedUnicodeCharactersComments.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/avoidescapedunicodecharacters/InputAvoidEscapedUnicodeCharactersComments.java
@@ -1,0 +1,51 @@
+/*
+AvoidEscapedUnicodeCharacters
+allowEscapesForControlCharacters = (default)false
+allowByTailComment = (default)false
+allowIfAllCharactersEscaped = (default)false
+allowNonPrintableEscapes = (default)false
+
+
+*/
+
+package com.puppycrawl.tools.checkstyle.checks.avoidescapedunicodecharacters;
+
+public class InputAvoidEscapedUnicodeCharactersComments {
+
+    // Test empty block comments
+    /* */
+    /**/
+    /*   */
+
+    String test1 = "hello";
+    String test2 = "world";
+
+    /* Regular block comment */
+    /** Javadoc comment */
+
+    String multiByteLine = "Text with 😊 emoji and 🌍 world"; /* trailing comment */
+
+    String test5 = "\u03bc"; // violation
+
+    String test6 = "😊\u03bc"; // violation
+
+    /* This comment
+       spans multiple
+       lines and should
+       test the span checking logic */
+    String multiLineSpanTest = "\u03bc"; // violation
+
+    String trailingWhitespaceTest = "\u03bc"; /* comment */    // violation
+
+    String shortLine = "\u03bc"; // violation
+
+    /* Comment ends above */
+    String noTrailingComment = "\u03bc"; // violation
+
+    /* Comment completely on different line */
+
+    String isolatedLine = "\u03bc"; // violation
+
+    String whitespaceTest = "\u03bc"; /* comment */                                    // violation
+
+ }


### PR DESCRIPTION
#11166 