### PR TITLE
Issue #17882: Update HTML_TAG_END of JavadocCommentsTokenTypes to new…

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/api/JavadocCommentsTokenTypes.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/api/JavadocCommentsTokenTypes.java
@@ -894,8 +894,40 @@ public final class JavadocCommentsTokenTypes {
     public static final int HTML_TAG_START = JavadocCommentsLexer.HTML_TAG_START;
 
     /**
-     * End of an HTML tag.
+     * End of an HTML tag (the closing tag node).
+     *
+     * <p>This node represents the closing part of an HTML element and contains the
+     * closing delimiter, optional slash, and the tag name.</p>
+     *
+     * <p><b>Example:</b></p>
+     * <pre>{@code * <a href="https://example.com">link</a>}</pre>
+     *
+     * <b>Tree:</b>
+     * <pre>{@code
+     * |--LEADING_ASTERISK -> *
+     * `--HTML_ELEMENT -> HTML_ELEMENT
+     *     |--HTML_TAG_START -> HTML_TAG_START
+     *     |   |--TAG_OPEN -> <
+     *     |   |--TAG_NAME -> a
+     *     |   |--HTML_ATTRIBUTES -> HTML_ATTRIBUTES
+     *     |   |   `--HTML_ATTRIBUTE -> HTML_ATTRIBUTE
+     *     |   |       |--TEXT ->   (whitespace)
+     *     |   |       |--TAG_ATTR_NAME -> href
+     *     |   |       |--EQUALS -> =
+     *     |   |       `--ATTRIBUTE_VALUE -> "https://example.com"
+     *     |   `--TAG_CLOSE -> >
+     *     |--HTML_CONTENT -> HTML_CONTENT
+     *     |   `--TEXT -> link
+     *     `--HTML_TAG_END -> HTML_TAG_END
+     *         |--TAG_OPEN -> <
+     *         |--TAG_SLASH -> /
+     *         |--TAG_NAME -> a
+     *         `--TAG_CLOSE -> >
+     * }</pre>
+     *
+     * @see #HTML_ELEMENT
      */
+
     public static final int HTML_TAG_END = JavadocCommentsLexer.HTML_TAG_END;
 
     /**


### PR DESCRIPTION
Issue #17882

**Command Used:**
`java -jar ./src/checkstyle-12.1.2-all.jar -j src/Test.java | sed "s/\[[0-9]\+:[0-9]\+\]//g"`

**Test.java**

```
/**
 * Test class to demonstrate HTML tag end in Javadoc.
 */
public class Test {
    /**
     * Example with HTML anchor tag.
     *
     * <a href="https://example.com">link</a>
     */
    public void m() {}
}
```

**Ast Output:**
```

vivek@Viveks-MacBook-Air javadocUpdateHTML_TAG_END % java -jar ./src/checkstyle-12.1.2-all.jar -j src/Test.java | sed "s/\[[0-9]\+:[0-9]\+\]//g"
JAVADOC_CONTENT -> JAVADOC_CONTENT 
|--TEXT -> /** 
|--NEWLINE -> \n 
|--LEADING_ASTERISK ->  * 
|--TEXT ->  Test class to demonstrate HTML tag end in Javadoc. 
|--NEWLINE -> \n 
|--LEADING_ASTERISK ->  * 
|--TEXT -> / 
|--NEWLINE -> \n 
|--TEXT -> public class Test { 
|--NEWLINE -> \n 
|--TEXT ->     /** 
|--NEWLINE -> \n 
|--LEADING_ASTERISK ->      * 
|--TEXT ->  Example with HTML anchor tag. 
|--NEWLINE -> \n 
|--LEADING_ASTERISK ->      * 
|--NEWLINE -> \n 
|--LEADING_ASTERISK ->      * 
|--TEXT ->   
|--HTML_ELEMENT -> HTML_ELEMENT 
|   |--HTML_TAG_START -> HTML_TAG_START 
|   |   |--TAG_OPEN -> < 
|   |   |--TAG_NAME -> a 
|   |   |--HTML_ATTRIBUTES -> HTML_ATTRIBUTES 
|   |   |   `--HTML_ATTRIBUTE -> HTML_ATTRIBUTE 
|   |   |       |--TEXT ->   
|   |   |       |--TAG_ATTR_NAME -> href 
|   |   |       |--EQUALS -> = 
|   |   |       `--ATTRIBUTE_VALUE -> "https://example.com" 
|   |   `--TAG_CLOSE -> > 
|   |--HTML_CONTENT -> HTML_CONTENT 
|   |   `--TEXT -> link 
|   `--HTML_TAG_END -> HTML_TAG_END 
|       |--TAG_OPEN -> < 
|       |--TAG_SLASH -> / 
|       |--TAG_NAME -> a 
|       `--TAG_CLOSE -> > 
|--NEWLINE -> \n 
|--LEADING_ASTERISK ->      * 
|--TEXT -> / 
|--NEWLINE -> \n 
|--TEXT ->     public void m() {} 
|--NEWLINE -> \n 
|--TEXT -> } 
`--NEWLINE -> \n 
```

