### PR TITLE
Issue #18092: Add `-i` flag to compilation jobs in CircleCI

### DIFF
--- a/.ci/validation.sh
+++ b/.ci/validation.sh
@@ -553,7 +553,7 @@ javac17_standard)
   # InputCustomImportOrderNoPackage2 - nothing is required in front of first import
   # InputIllegalTypePackageClassName - bad import for testing
   # InputVisibilityModifierPackageClassName - bad import for testing
-  files=($(grep -REL --include='*.java' \
+  files=($(grep -RELi --include='*.java' \
         --exclude='InputCustomImportOrderNoPackage2.java' \
         --exclude='InputIllegalTypePackageClassName.java' \
         --exclude='InputVisibilityModifierPackageClassName.java' \
@@ -570,7 +570,7 @@ javac17_standard)
   ;;
 
 javac17)
-  files=($(grep -Rl --include='*.java' ': Compilable with Java17' \
+  files=($(grep -Rli --include='*.java' ': Compilable with Java17' \
         src/test/resources-noncompilable \
         src/it/resources-noncompilable \
         src/xdocs-examples/resources-noncompilable \
@@ -587,7 +587,7 @@ javac17)
   ;;
 
 javac19)
-  files=($(grep -Rl --include='*.java' ': Compilable with Java19' \
+  files=($(grep -Rli --include='*.java' ': Compilable with Java19' \
         src/test/resources-noncompilable \
         src/it/resources-noncompilable \
         src/xdocs-examples/resources-noncompilable || true))
@@ -603,7 +603,7 @@ javac19)
   ;;
 
 javac20)
-  files=($(grep -Rl --include='*.java' ': Compilable with Java20' \
+  files=($(grep -Rli --include='*.java' ': Compilable with Java20' \
         src/test/resources-noncompilable \
         src/it/resources-noncompilable \
         src/xdocs-examples/resources-noncompilable || true))
@@ -619,7 +619,7 @@ javac20)
   ;;
 
 javac21)
-  files=($(grep -Rl --include='*.java' ': Compilable with Java21' \
+  files=($(grep -Rli --include='*.java' ': Compilable with Java21' \
         src/test/resources-noncompilable \
         src/it/resources-noncompilable \
         src/xdocs-examples/resources-noncompilable || true))
@@ -635,7 +635,7 @@ javac21)
   ;;
 
 javac22)
-  files=($(grep -Rl --include='*.java' ': Compilable with Java22' \
+  files=($(grep -Rli --include='*.java' ': Compilable with Java22' \
         src/test/resources-noncompilable \
         src/it/resources-noncompilable \
         src/xdocs-examples/resources-noncompilable || true))

--- a/config/jsoref-spellchecker/whitelist.words
+++ b/config/jsoref-spellchecker/whitelist.words
@@ -1173,6 +1173,7 @@ regexpsingleline
 regexpsinglelinejava
 relativized
 releasenotes
+RELi
 remkop
 reportyml
 REPOURL

--- a/src/test/resources-noncompilable/com/puppycrawl/tools/checkstyle/checks/coding/missingswitchdefault/InputMissingSwitchDefaultCaseLabelElements.java
+++ b/src/test/resources-noncompilable/com/puppycrawl/tools/checkstyle/checks/coding/missingswitchdefault/InputMissingSwitchDefaultCaseLabelElements.java
@@ -4,7 +4,7 @@ MissingSwitchDefault
 
 */
 
-// non-compiled with javac: compilable with Java22
+// non-compiled with javac: until https://github.com/checkstyle/checkstyle/issues/18097
 package com.puppycrawl.tools.checkstyle.checks.coding.missingswitchdefault;
 
 public class InputMissingSwitchDefaultCaseLabelElements {

--- a/src/test/resources-noncompilable/com/puppycrawl/tools/checkstyle/grammar/antlr4/InputAntlr4AstRegressionCaseDefault.java
+++ b/src/test/resources-noncompilable/com/puppycrawl/tools/checkstyle/grammar/antlr4/InputAntlr4AstRegressionCaseDefault.java
@@ -1,4 +1,4 @@
-// non-compiled with javac: compilable with Java22
+// non-compiled with javac: until https://github.com/checkstyle/checkstyle/issues/18097
 package com.puppycrawl.tools.checkstyle.grammar.antlr4;
 
 

--- a/src/test/resources-noncompilable/com/puppycrawl/tools/checkstyle/grammar/antlr4/InputAntlr4AstRegressionPatternMatchingInSwitch.java
+++ b/src/test/resources-noncompilable/com/puppycrawl/tools/checkstyle/grammar/antlr4/InputAntlr4AstRegressionPatternMatchingInSwitch.java
@@ -1,4 +1,4 @@
-// non-compiled with javac: compilable with Java22
+// non-compiled with javac: until https://github.com/checkstyle/checkstyle/issues/18097
 package com.puppycrawl.tools.checkstyle.grammar.antlr4;
 
 public class InputAntlr4AstRegressionPatternMatchingInSwitch {

--- a/src/test/resources-noncompilable/com/puppycrawl/tools/checkstyle/grammar/antlr4/InputAntlr4AstRegressionPatternsInFor.java
+++ b/src/test/resources-noncompilable/com/puppycrawl/tools/checkstyle/grammar/antlr4/InputAntlr4AstRegressionPatternsInFor.java
@@ -1,4 +1,4 @@
-// non-compiled with javac: compilable with Java22
+// non-compiled with javac: until https://github.com/checkstyle/checkstyle/issues/18097
 package com.puppycrawl.tools.checkstyle.grammar.antlr4;
 
 public class InputAntlr4AstRegressionPatternsInFor {

--- a/src/test/resources-noncompilable/com/puppycrawl/tools/checkstyle/grammar/antlr4/InputAntlr4AstRegressionPatternsInIfStatement.java
+++ b/src/test/resources-noncompilable/com/puppycrawl/tools/checkstyle/grammar/antlr4/InputAntlr4AstRegressionPatternsInIfStatement.java
@@ -1,4 +1,4 @@
-// non-compiled with javac: compilable with Java22
+// non-compiled with javac: until https://github.com/checkstyle/checkstyle/issues/18097
 package com.puppycrawl.tools.checkstyle.grammar.antlr4;
 
 public class InputAntlr4AstRegressionPatternsInIfStatement {

--- a/src/test/resources-noncompilable/com/puppycrawl/tools/checkstyle/grammar/antlr4/InputAntlr4AstRegressionPatternsInSwitch.java
+++ b/src/test/resources-noncompilable/com/puppycrawl/tools/checkstyle/grammar/antlr4/InputAntlr4AstRegressionPatternsInSwitch.java
@@ -1,4 +1,4 @@
-// non-compiled with javac: compilable with Java22
+// non-compiled with javac: until https://github.com/checkstyle/checkstyle/issues/18097
 package com.puppycrawl.tools.checkstyle.grammar.antlr4;
 
 public class InputAntlr4AstRegressionPatternsInSwitch {

--- a/src/test/resources-noncompilable/com/puppycrawl/tools/checkstyle/grammar/antlr4/InputAntlr4AstRegressionPatternsInTernary.java
+++ b/src/test/resources-noncompilable/com/puppycrawl/tools/checkstyle/grammar/antlr4/InputAntlr4AstRegressionPatternsInTernary.java
@@ -1,4 +1,4 @@
-// non-compiled with javac: compilable with Java22
+// non-compiled with javac: until https://github.com/checkstyle/checkstyle/issues/18097
 package com.puppycrawl.tools.checkstyle.grammar.antlr4;
 
 public class InputAntlr4AstRegressionPatternsInTernary {

--- a/src/test/resources-noncompilable/com/puppycrawl/tools/checkstyle/grammar/antlr4/InputAntlr4AstRegressionPatternsInWhile.java
+++ b/src/test/resources-noncompilable/com/puppycrawl/tools/checkstyle/grammar/antlr4/InputAntlr4AstRegressionPatternsInWhile.java
@@ -1,4 +1,4 @@
-// non-compiled with javac: compilable with Java22
+// non-compiled with javac: until https://github.com/checkstyle/checkstyle/issues/18097
 package com.puppycrawl.tools.checkstyle.grammar.antlr4;
 
 public class InputAntlr4AstRegressionPatternsInWhile {


### PR DESCRIPTION
Resolves issue
- #18092 

Added `-i` grep flag to all `javacX` jobs. 
