### PR TITLE
Issue #18091: Add Java 25 compilation to CircleCI

### DIFF
--- a/.ci/validation.sh
+++ b/.ci/validation.sh
@@ -650,6 +650,22 @@ javac22)
   fi
   ;;
 
+javac25)
+  files=($(grep -Rli --include='*.java' ': Compilable with Java25' \
+        src/test/resources-noncompilable \
+        src/it/resources-noncompilable \
+        src/xdocs-examples/resources-noncompilable || true))
+  if [[  ${#files[@]} -eq 0 ]]; then
+    echo "No Java25 files to process"
+  else
+    mkdir -p target
+    for file in "${files[@]}"
+    do
+      javac --release 25 --enable-preview -d target "${file}"
+    done
+  fi
+  ;;
+
 package-site)
   ./mvnw -e --no-transfer-progress package -Passembly,no-validations
   ./mvnw -e --no-transfer-progress site -Dlinkcheck.skip=true

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -310,6 +310,10 @@ workflows:
           name: "javac22"
           image-name: "cimg/openjdk:22.0.2"
           command: "./.ci/validation.sh javac22"
+      - validate-with-script:
+          name: "javac25"
+          image-name: "cimg/openjdk:25.0"
+          command: "./.ci/validation.sh javac25"
 
   site-validation:
     jobs:

--- a/config/jsoref-spellchecker/whitelist.words
+++ b/config/jsoref-spellchecker/whitelist.words
@@ -1192,6 +1192,7 @@ rhysd
 rickgiles
 rightcurly
 Rl
+Rli
 rnveach
 robinraju
 romani


### PR DESCRIPTION
Resolves issue
#18091 

Local runs of script:
```bash
$ javac --version
javac 25.0.1
```
```bash
# With no files
$ ./.ci/validation.sh javac25
No Java25 files to process
```

```bash
# With Java 25 feature
$ cat src/test/resources-noncompilable/com/puppycrawl/tools/checkstyle/main/InputShouldCompile.java
// non-compiled with javac: compilable with Java25

import module java.base;

class InputShouldCompile {
}

$ ./.ci/validation.sh javac25
# no output
```


```bash
# With a failing file
$ cat  src/test/resources-noncompilable/com/puppycrawl/tools/checkstyle/main/InputShouldNotCompile.java
// non-compiled with javac: compilable with Java25

asdasdasd

$ ./.ci/validation.sh javac25
src/test/resources-noncompilable/com/puppycrawl/tools/checkstyle/main/InputShouldNotCompile.java:3: error: reached end of file while parsing
asdasdasd
^
1 error
```
