### PR TITLE
Issue #16243: Wrap inline code text

### DIFF
--- a/src/site/resources/css/site.css
+++ b/src/site/resources/css/site.css
@@ -421,6 +421,10 @@ section#Properties .wrapper table td a {
     word-break: break-word;
   }
 
+  code {
+    white-space: pre-wrap;
+  }
+
   table tr {
     display: block;
     margin-bottom: 1rem;


### PR DESCRIPTION
Part of issue
- #16243 

Resolves task:
> - [ ] Non-formatted text are not wrapped. [Details](https://github.com/checkstyle/checkstyle/issues/16243#issuecomment-2788105183). Here is example https://checkstyle.org/checks/annotation/suppresswarningsholder.html#Example2-config

> Non-formatted text are not wrapped in mobile mode

---
Before: https://checkstyle.org/checks/annotation/suppresswarningsholder.html#Example2-config
<img width="710" height="677" alt="image" src="https://github.com/user-attachments/assets/ac343a8d-bf09-4612-bf54-981043a36314" />


After: https://checkstyle-diff-reports.s3.us-east-2.amazonaws.com/fab13e7_20251115111912/checks/annotation/suppresswarningsholder.html#Example2-config
<img width="701" height="674" alt="image" src="https://github.com/user-attachments/assets/e211a254-be30-42ba-8cb5-04213ba0f443" />