### PR TITLE
Issue #17882: Update HTML_COMMENT_END of JavadocCommentsTokenTypes to…

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/api/JavadocCommentsTokenTypes.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/api/JavadocCommentsTokenTypes.java
@@ -1004,7 +1004,27 @@ public final class JavadocCommentsTokenTypes {
 
     /**
      * Closing part of an HTML comment.
+     *
+     * <p>This node represents the closing delimiter of an HTML comment in
+     * Javadoc (for example {@code -->}).</p>
+     *
+     * <p><b>Example:</b></p>
+     * <pre>{@code * <!-- hidden comment -->}</pre>
+     *
+     * <b>Tree:</b>
+     * <pre>{@code
+     * |--LEADING_ASTERISK -> *
+     * |--TEXT ->
+     * |--HTML_COMMENT -> HTML_COMMENT
+     * |   |--HTML_COMMENT_START -> <!--
+     * |   |--HTML_COMMENT_CONTENT -> HTML_COMMENT_CONTENT
+     * |   |   `--TEXT ->  hidden comment
+     * |   `--HTML_COMMENT_END -> -->
+     * }</pre>
+     *
+     * @see #HTML_COMMENT
      */
+
     public static final int HTML_COMMENT_END = JavadocCommentsLexer.HTML_COMMENT_END;
 
     /**


### PR DESCRIPTION
Issue #17882:

**Command Used:**
`java -jar ./src/checkstyle-12.1.2-all.jar -j src/Test.java | sed "s/\[[0-9]\+:[0-9]\+\]//g"`

**Test.java:**

```
/**
 * Test class to demonstrate HTML comment end in Javadoc.
 */
public class Test {
    /**
     * Example with an HTML comment inside Javadoc.
     *
     * <!-- hidden comment -->
     */
    public void m() {}
}
```
**Ast Output:**

```
vivek@Viveks-MacBook-Air javadocUpdateHTML_COMMENT_END % java -jar ./src/checkstyle-12.1.2-all.jar -j src/Test.java | sed "s/\[[0-9]\+:[0-9]\+\]//g"
JAVADOC_CONTENT -> JAVADOC_CONTENT 
|--TEXT -> /** 
|--NEWLINE -> \n 
|--LEADING_ASTERISK ->  * 
|--TEXT ->  Test class to demonstrate HTML comment end in Javadoc. 
|--NEWLINE -> \n 
|--LEADING_ASTERISK ->  * 
|--TEXT -> / 
|--NEWLINE -> \n 
|--TEXT -> public class Test { 
|--NEWLINE -> \n 
|--TEXT ->     /** 
|--NEWLINE -> \n 
|--LEADING_ASTERISK ->      * 
|--TEXT ->  Example with an HTML comment inside Javadoc. 
|--NEWLINE -> \n 
|--LEADING_ASTERISK ->      * 
|--NEWLINE -> \n [6:6]
|--LEADING_ASTERISK ->      * 
|--TEXT ->   
|--HTML_COMMENT -> HTML_COMMENT 
|   |--HTML_COMMENT_START -> <!-- 
|   |--HTML_COMMENT_CONTENT -> HTML_COMMENT_CONTENT 
|   |   `--TEXT ->  hidden comment  
|   `--HTML_COMMENT_END -> --> 
|--NEWLINE -> \n 
|--LEADING_ASTERISK ->      * 
|--TEXT -> / 
|--NEWLINE -> \n 
|--TEXT ->     public void m() {} 
|--NEWLINE -> \n 
|--TEXT -> } 
`--NEWLINE -> \n 
```




