### PR TITLE
Issue #17882: Updated EXTENDS of JavadocCommentsTokenTypes to new AST format

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/api/JavadocCommentsTokenTypes.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/api/JavadocCommentsTokenTypes.java
@@ -726,7 +726,31 @@ public final class JavadocCommentsTokenTypes {
     public static final int GT = JavadocCommentsLexer.GT;
 
     /**
-     * Keyword {@code extends} in type parameters.
+     * {@code extends} keyword in type parameters.
+     *
+     * <p>Such Javadoc inline tag has one child:</p>
+     * <ol>
+     *   <li>{@link #CODE_INLINE_TAG}</li>
+     * </ol>
+     *
+     * <p><b>Example:</b></p>
+     * <pre>{@code * Keyword {@code extends} in type parameters.}</pre>
+     *
+     * <b>Tree:</b>
+     * <pre>{@code
+     * JAVADOC_CONTENT -> JAVADOC_CONTENT
+     * |--LEADING_ASTERISK -> *
+     * |--TEXT -> Keyword
+     * `--JAVADOC_INLINE_TAG -> JAVADOC_INLINE_TAG
+     *     `--CODE_INLINE_TAG -> CODE_INLINE_TAG
+     *         |--JAVADOC_INLINE_TAG_START -> { @
+     *         |--TAG_NAME -> code
+     *         |--TEXT -> extends
+     *         `--JAVADOC_INLINE_TAG_END -> }
+     * |--TEXT ->  in type parameters.
+     * }</pre>
+     *
+     * @see #JAVADOC_INLINE_TAG
      */
     public static final int EXTENDS = JavadocCommentsLexer.EXTENDS;
 


### PR DESCRIPTION
Issue #17882

**Command Used:**
`java -jar checkstyle-12.1.3-SNAPSHOT-all.jar -j src/Test.java | sed "s/\[[0-9]\+:[0-9]\+\]//g"`

**Test.java**
```
public class Test {

    /**
     * Keyword {@code extends} in type parameters.
     */
    public void example() {

    }
}
```

```
HP@DESKTOP-IF47D4L MINGW64 /c/users/hp/JAVADOC
$ java -jar checkstyle-12.1.3-SNAPSHOT-all.jar -j src/Test.java | sed "s/\[[0-9]\+:[0-9]\+\]//g"
JAVADOC_CONTENT -> JAVADOC_CONTENT
|--TEXT -> public class Test {
|--NEWLINE -> \r\n
|--NEWLINE -> \r\n
|--TEXT ->     /**
|--NEWLINE -> \r\n
|--LEADING_ASTERISK ->      *
|--TEXT ->  Keyword
|--JAVADOC_INLINE_TAG -> JAVADOC_INLINE_TAG
|   `--CODE_INLINE_TAG -> CODE_INLINE_TAG
|       |--JAVADOC_INLINE_TAG_START -> {@
|       |--TAG_NAME -> code
|       |--TEXT ->  extends
|       `--JAVADOC_INLINE_TAG_END -> }
|--TEXT ->  in type parameters.
|--NEWLINE -> \r\n
|--LEADING_ASTERISK ->      *
|--TEXT -> /
|--NEWLINE -> \r\n
|--TEXT ->     public void example() {
|--NEWLINE -> \r\n
|--NEWLINE -> \r\n
|--TEXT ->     }
|--NEWLINE -> \r\n
|--TEXT -> }
`--NEWLINE -> \r\n
```