### PR TITLE
Issue #17882: Updated EXTENDS of JavadocCommentsTokenTypes to new AST format

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/api/JavadocCommentsTokenTypes.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/api/JavadocCommentsTokenTypes.java
@@ -795,7 +795,42 @@ public final class JavadocCommentsTokenTypes {
     public static final int GT = JavadocCommentsLexer.GT;
 
     /**
-     * Keyword {@code extends} in type parameters.
+     * {@code extends} keyword inside type arguments of a Javadoc inline tag.
+     *
+     * <p>This node represents the {@code extends} bound used inside a
+     * parameterized type within an inline Javadoc tag.</p>
+     *
+     * <p><b>Example:</b></p>
+     * <pre>{@code
+     * * {@link java.util.List&lt;? extends Number&gt; list of any subtype of Number}
+     * }</pre>
+     *
+     * <b>Tree:</b>
+     * <pre>{@code
+     * |--LEADING_ASTERISK -> *
+     * |--TEXT ->
+     * |--JAVADOC_INLINE_TAG -> JAVADOC_INLINE_TAG
+     *     `--LINK_INLINE_TAG -> LINK_INLINE_TAG
+     *         |--JAVADOC_INLINE_TAG_START -> { @
+     *         |--TAG_NAME -> link
+     *         |--TEXT ->
+     *         |--REFERENCE -> REFERENCE
+     *         |   |--IDENTIFIER -> java.util.List
+     *         |   `--TYPE_ARGUMENTS -> TYPE_ARGUMENTS
+     *         |       |--LT -> <
+     *         |       |--TYPE_ARGUMENT -> TYPE_ARGUMENT
+     *         |       |   |--QUESTION -> ?
+     *         |       |   |--TEXT ->
+     *         |       |   |--EXTENDS -> extends
+     *         |       |   |--TEXT ->
+     *         |       |   `--IDENTIFIER -> Number
+     *         |       `--GT -> >
+     *         |--DESCRIPTION -> DESCRIPTION
+     *         |   `--TEXT ->  list of any subtype of Number
+     *         `--JAVADOC_INLINE_TAG_END -> }
+     * }</pre>
+     *
+     * @see #JAVADOC_INLINE_TAG
      */
     public static final int EXTENDS = JavadocCommentsLexer.EXTENDS;
 


### PR DESCRIPTION
Issue: #17882

**Command used:**
`java -jar checkstyle-12.1.3-SNAPSHOT-all.jar -j src/Test.java | sed "s/\[[0-9]\+:[0-9]\+\]//g"`

**Test.java**
```
Test.java
public class Test {
    /**
     * {@link java.util.List<? extends Number> list of any subtype of Number}
     */
    public void example(){
    }
}
```

```
HP@DESKTOP-IF47D4L MINGW64 ~/JAVADOC
$ java -jar checkstyle-12.1.3-SNAPSHOT-all.jar -j src/Test.java | sed "s/\[[0-9]\+:[0-9]\+\]//g"
JAVADOC_CONTENT -> JAVADOC_CONTENT
|--TEXT -> public class Test {
|--NEWLINE -> \r\n
|--TEXT ->     /**
|--NEWLINE -> \r\n
|--LEADING_ASTERISK ->      *
|--TEXT ->
|--JAVADOC_INLINE_TAG -> JAVADOC_INLINE_TAG
|   `--LINK_INLINE_TAG -> LINK_INLINE_TAG
|       |--JAVADOC_INLINE_TAG_START -> {@
|       |--TAG_NAME -> link
|       |--TEXT ->
|       |--REFERENCE -> REFERENCE
|       |   |--IDENTIFIER -> java.util.List
|       |   `--TYPE_ARGUMENTS -> TYPE_ARGUMENTS
|       |       |--LT -> <
|       |       |--TYPE_ARGUMENT -> TYPE_ARGUMENT
|       |       |   |--QUESTION -> ?
|       |       |   |--TEXT ->
|       |       |   |--EXTENDS -> extends
|       |       |   |--TEXT ->
|       |       |   `--IDENTIFIER -> Number
|       |       `--GT -> >
|       |--DESCRIPTION -> DESCRIPTION
|       |   `--TEXT ->  list of any subtype of Number
|       `--JAVADOC_INLINE_TAG_END -> }
|--NEWLINE -> \r\n
|--LEADING_ASTERISK ->      *
|--TEXT -> /
|--NEWLINE -> \r\n
|--TEXT ->     public void example(){
|--NEWLINE -> \r\n
|--TEXT ->     }
|--NEWLINE -> \r\n
`--TEXT -> }
```