### PR TITLE
Issue #17882: Updated HTML_COMMENT of JavadocCommentsTokenTypes to new AST format

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/api/JavadocCommentsTokenTypes.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/api/JavadocCommentsTokenTypes.java
@@ -993,7 +993,38 @@ public final class JavadocCommentsTokenTypes {
     public static final int TAG_ATTR_NAME = JavadocCommentsLexer.TAG_ATTR_NAME;
 
     /**
-     * Full HTML comment.
+     * Start of an HTML comment node.
+     *
+     * <p>This node represents a full HTML comment inside Javadoc.</p>
+     *
+     * <p>This node has three children:</p>
+     * <ol>
+     *   <li>{@link #HTML_COMMENT_START}</li>
+     *   <li>{@link #HTML_COMMENT_CONTENT}</li>
+     *   <li>{@link #HTML_COMMENT_END}</li>
+     * </ol>
+     *
+     * <p><b>Example:</b></p>
+     * <pre>{@code * <!-- Hello World! -->}</pre>
+     *
+     * <b>Tree:</b>
+     * <pre>{@code
+     * JAVADOC_CONTENT -> JAVADOC_CONTENT
+     * |--TEXT -> /**
+     * |--NEWLINE -> \r\n
+     * |--LEADING_ASTERISK ->  *
+     * |--TEXT ->
+     * |--HTML_COMMENT -> HTML_COMMENT
+     *     |--HTML_COMMENT_START -> <!--
+     *     |--HTML_COMMENT_CONTENT -> HTML_COMMENT_CONTENT
+     *     |   `--TEXT ->  Hello World!
+     *     `--HTML_COMMENT_END -> -->
+     * |--NEWLINE -> \r\n
+     * |--LEADING_ASTERISK ->  *
+     * |--TEXT -> /
+     * }</pre>
+     *
+     * @see #HTML_COMMENT
      */
     public static final int HTML_COMMENT = JavadocCommentsLexer.HTML_COMMENT;
 


### PR DESCRIPTION
Issue: #17882 

**Command Used:**
`java -jar checkstyle-12.1.3-SNAPSHOT-all.jar -j src/Test.java | sed "s/\[[0-9]\+:[0-9]\+\]//g"`

**Test.java**
```
/**
 * <!-- Hello World! -->
 */
public class Test {
}
```

```
HP@DESKTOP-IF47D4L MINGW64 ~/JAVADOC
$ java -jar checkstyle-12.1.3-SNAPSHOT-all.jar -j src/Test.java | sed "s/\[[0-9]\+:[0-9]\+\]//g"
JAVADOC_CONTENT -> JAVADOC_CONTENT
|--TEXT -> /**
|--NEWLINE -> \r\n
|--LEADING_ASTERISK ->  *
|--TEXT ->
|--HTML_COMMENT -> HTML_COMMENT
|   |--HTML_COMMENT_START -> <!--
|   |--HTML_COMMENT_CONTENT -> HTML_COMMENT_CONTENT
|   |   `--TEXT ->  Hello World!
|   `--HTML_COMMENT_END -> -->
|--NEWLINE -> \r\n
|--LEADING_ASTERISK ->  *
|--TEXT -> /
|--NEWLINE -> \r\n
|--TEXT -> public class Test {
|--NEWLINE -> \r\n
`--TEXT -> }
```
