### PR TITLE
infra: improve wording of error on unsynsynchronized Inputs for google style

### DIFF
--- a/.ci/google-java-format.sh
+++ b/.ci/google-java-format.sh
@@ -50,17 +50,20 @@ for list_file_path in "${NONFORMATTED_LIST[@]}"; do
     fi
     if (( diff > 500 )); then
       if ! is_suppressed "$SUPPRESS_GT_500" "Input${name}.java"; then
-        echo -e "\033[1;31mError: Difference for Input${name}.java is more than 50 bytes (${diff})"
+        echo -e "\033[1;31mError: Input${name}.java and InputFormatted${name}.java might not be synchronized."
+        echo -e "\033[1;31mError: Difference is more than 500 bytes. Detected diff is ${diff} bytes."
         exit 1
       fi
     elif (( diff > 100 )); then
       if ! is_suppressed "$SUPPRESS_GT_100_LTE_500" "Input${name}.java"; then
-        echo -e "\033[1;31mError: Difference for Input${name}.java is more than 50 bytes (${diff})"
+        echo -e "\033[1;31mError: Input${name}.java and InputFormatted${name}.java might not be synchronized."
+        echo -e "\033[1;31mError: Difference is more than 100 bytes. Detected diff is ${diff} bytes."
         exit 1
       fi
     elif (( diff > 50 )); then
       if ! is_suppressed "$SUPPRESS_LTE_100" "Input${name}.java"; then
-        echo -e "\033[1;31mError: Difference for Input${name}.java is more than 50 bytes (${diff})"
+        echo -e "\033[1;31mError: Input${name}.java and InputFormatted${name}.java might not be synchronized."
+        echo -e "\033[1;31mError: Difference is more than 50 bytes. Detected diff is ${diff} bytes."
         exit 1
       fi
     fi


### PR DESCRIPTION
detected at https://github.com/checkstyle/checkstyle/pull/17329#discussion_r2530721518
https://github.com/checkstyle/checkstyle/actions/runs/19383295060/job/55465942981?pr=17329

very hard to understand error message:
```
Run ./.ci/google-java-format.sh .ci-temp/google-java-format-1.31.0-all-deps.jar
  ./.ci/google-java-format.sh .ci-temp/google-java-format-1.31.0-all-deps.jar
  ./.ci/validation.sh git-diff
  shell: /usr/bin/bash -e {0}
  env:
    VERSION: 1.31.0
    JAVA_HOME: /opt/hostedtoolcache/Java_Temurin-Hotspot_jdk/21.0.9-10/x64
    JAVA_HOME_21_X64: /opt/hostedtoolcache/Java_Temurin-Hotspot_jdk/21.0.9-10/x64
Checking that all excluded java files in this script have matching InputFormatted* file:
Excluded Input files matches to InputFormatted files.
Checking that all excluded java files have same size as matching InputFormatted* file:
Error: Difference for InputTextBlocksIndentation.java is more than 50 bytes (405)
Error: Process completed with exit code 1.
```