### PR TITLE
Issue #17882: Update LEADING_ASTERISK of Javadoc CommentTokenTypes in…

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/api/JavadocCommentsTokenTypes.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/api/JavadocCommentsTokenTypes.java
@@ -48,6 +48,26 @@ public final class JavadocCommentsTokenTypes {
 
     /**
      * Leading asterisk used to format Javadoc lines.
+     *
+     * <p><b>Example:</b></p>
+     * <pre>{@code
+     * /**
+     *  * This is a Javadoc line.
+     *  * /
+     * }</pre>
+     *
+     * <p><b>Tree:</b></p>
+     * <pre>{@code
+     * --BLOCK_COMMENT_BEGIN -> /**
+     *    |--COMMENT_CONTENT -> *\r\n * This is a Javadoc line.\r\n
+     *    |   `--JAVADOC_CONTENT -> JAVADOC_CONTENT
+     *    |       |--NEWLINE -> \r\n
+     *    |       |--LEADING_ASTERISK ->  *
+     *    |       |--TEXT ->  This is a Javadoc line.
+     *    |       |--NEWLINE -> \r\n
+     *    |       `--TEXT ->
+     * `   --BLOCK_COMMENT_END -> *
+     * }</pre>
      */
     public static final int LEADING_ASTERISK = JavadocCommentsLexer.LEADING_ASTERISK;
 


### PR DESCRIPTION
Issue #17882:

### Command Used
``` bash
java -jar checkstyle-12.1.2-all.jar -j Test.java
```

---


### Test File
``` java
/**
 * This is a Javadoc line.
 * Additional example line.
 */
public class Test {}
 ```

---


### Output
``` java
COMPILATION_UNIT -> COMPILATION_UNIT [4:0]
`--CLASS_DEF -> CLASS_DEF [4:0]
    |--MODIFIERS -> MODIFIERS [4:0]
    |   |--BLOCK_COMMENT_BEGIN -> /* [1:0]
    |   |   |--COMMENT_CONTENT -> *\r\n * This is a Javadoc line.\r\n  [1:2]
    |   |   |   `--JAVADOC_CONTENT -> JAVADOC_CONTENT [1:3]
    |   |   |       |--NEWLINE -> \r\n [1:3]
    |   |   |       |--LEADING_ASTERISK ->  * [2:0]
    |   |   |       |--TEXT ->  This is a Javadoc line. [2:2]
    |   |   |       |--NEWLINE -> \r\n [2:26]
    |   |   |       `--TEXT ->   [3:0]
    |   |   `--BLOCK_COMMENT_END -> */ [3:1]
    |   `--LITERAL_PUBLIC -> public [4:0]
    |--LITERAL_CLASS -> class [4:7]
    |--IDENT -> Test [4:13]
    `--OBJBLOCK -> OBJBLOCK [4:18]
        |--LCURLY -> { [4:18]
        `--RCURLY -> } [4:19]
```