### PR TITLE
Issue #18117: Make property links bold on mobile

### DIFF
--- a/src/site/resources/css/site.css
+++ b/src/site/resources/css/site.css
@@ -436,6 +436,10 @@ section#Properties .wrapper table td a {
     text-align: left;
   }
 
+  section[id$="_Properties"] table tr:nth-of-type(n+2) td:first-of-type a {
+    font-weight: bold;
+  }
+
   section#Properties .wrapper {
     overflow-x: hidden;
   }


### PR DESCRIPTION
Resolves issue 
- #18117 

Makes property links in table **bold** _only on mobile_.

<img width="576" height="768" alt="image" src="https://github.com/user-attachments/assets/045b842f-84d9-4239-be89-31a67075b574" />
