### PR TITLE
Issue #17449: Added XDocs example for TrailingCommentCheck legalComme…

### DIFF
--- a/src/site/xdoc/checks/misc/trailingcomment.xml
+++ b/src/site/xdoc/checks/misc/trailingcomment.xml
@@ -222,6 +222,43 @@ public class Example4 {
   int c; // NOSONAR - OK, comment starts with " NOSONAR"
   int d; // violation, not suppressed
 }
+</code></pre></div><hr class="example-separator"/>
+
+        <p id="Example5-config">
+          To configure the check to allow certain trailing comments:
+        </p>
+        <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
+&lt;module name="Checker"&gt;
+  &lt;module name="TreeWalker"&gt;
+    &lt;module name="TrailingComment"&gt;
+      &lt;property name="legalComment" value="^ (TODO|FIXME|NOSONAR)"/&gt;
+    &lt;/module&gt;
+  &lt;/module&gt;
+&lt;/module&gt;
+</code></pre></div>
+
+        <p id="Example5-code">
+          Example:
+        </p>
+        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+public class Example5 {
+  public static void main(String[] args) {
+    int x = 10;
+
+    if (x &gt; 5) {}
+    int a = 5; // TODO: fix this logic later - ok, matches legalComment pattern
+    int b = 6; // FIXME: this should be calculated - ok, matches legalComment pattern
+    int c = 7; // NOSONAR - ok, matches legalComment pattern
+    int d = 8; // violation, doesn't match legalComment pattern
+    doSomething(
+            "param1"
+    ); // ok, by default such trailing of method/code-block ending is allowed
+
+  }
+
+  private static void doSomething(String param) {
+  }
+}
 </code></pre></div>
 
       </subsection>

--- a/src/site/xdoc/checks/misc/trailingcomment.xml.template
+++ b/src/site/xdoc/checks/misc/trailingcomment.xml.template
@@ -98,6 +98,24 @@
           <param name="path"
                  value="resources/com/puppycrawl/tools/checkstyle/checks/trailingcomment/Example4.java"/>
           <param name="type" value="code"/>
+        </macro><hr class="example-separator"/>
+
+        <p id="Example5-config">
+          To configure the check to allow certain trailing comments:
+        </p>
+        <macro name="example">
+          <param name="path"
+                 value="resources/com/puppycrawl/tools/checkstyle/checks/trailingcomment/Example5.java"/>
+          <param name="type" value="config"/>
+        </macro>
+
+        <p id="Example5-code">
+          Example:
+        </p>
+        <macro name="example">
+          <param name="path"
+                 value="resources/com/puppycrawl/tools/checkstyle/checks/trailingcomment/Example5.java"/>
+          <param name="type" value="code"/>
         </macro>
 
       </subsection>

--- a/src/test/java/com/puppycrawl/tools/checkstyle/internal/XdocsExampleFileTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/internal/XdocsExampleFileTest.java
@@ -52,7 +52,6 @@ public class XdocsExampleFileTest {
     // This list is temporarily suppressed.
     // Until: https://github.com/checkstyle/checkstyle/issues/17449
     private static final Map<String, Set<String>> SUPPRESSED_PROPERTIES_BY_CHECK = Map.ofEntries(
-            Map.entry("TrailingCommentCheck", Set.of("legalComment")),
             Map.entry("IllegalTypeCheck", Set.of("legalAbstractClassNames")),
             Map.entry("MissingJavadocTypeCheck", Set.of("skipAnnotations")),
             Map.entry("JavadocStyleCheck", Set.of("endOfSentenceFormat", "checkEmptyJavadoc")),

--- a/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/checks/TrailingCommentCheckExamplesTest.java
+++ b/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/checks/TrailingCommentCheckExamplesTest.java
@@ -67,4 +67,13 @@ public class TrailingCommentCheckExamplesTest extends AbstractExamplesModuleTest
 
         verifyWithInlineConfigParser(getPath("Example4.java"), expected);
     }
+
+    @Test
+    public void testExample5() throws Exception {
+        final String[] expected = {
+            "22:16: " + getCheckMessage(MSG_KEY),
+        };
+
+        verifyWithInlineConfigParser(getPath("Example5.java"), expected);
+    }
 }

--- a/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/trailingcomment/Example5.java
+++ b/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/trailingcomment/Example5.java
@@ -1,0 +1,32 @@
+/*xml
+<module name="Checker">
+  <module name="TreeWalker">
+    <module name="TrailingComment">
+      <property name="legalComment" value="^ (TODO|FIXME|NOSONAR)"/>
+    </module>
+  </module>
+</module>
+*/
+
+package com.puppycrawl.tools.checkstyle.checks.trailingcomment;
+
+// xdoc section -- start
+public class Example5 {
+  public static void main(String[] args) {
+    int x = 10;
+
+    if (x > 5) {}
+    int a = 5; // TODO: fix this logic later - ok, matches legalComment pattern
+    int b = 6; // FIXME: this should be calculated - ok, matches legalComment pattern
+    int c = 7; // NOSONAR - ok, matches legalComment pattern
+    int d = 8; // violation, doesn't match legalComment pattern
+    doSomething(
+            "param1"
+    ); // ok, by default such trailing of method/code-block ending is allowed
+
+  }
+
+  private static void doSomething(String param) {
+  }
+}
+// xdoc section -- end


### PR DESCRIPTION
Resolves #17449
Added Example5 to demonstrate the `legalComment` property of TrailingCommentCheck.

Changes:
- Added `Example5.java` showing how `legalComment` pattern allows specific trailing comments (TODO, FIXME, NOSONAR)
- Added `testExample5()` in `TrailingCommentCheckExamplesTest.java`
- Removed `TrailingCommentCheck` from suppression list in `XdocsExampleFileTest.java`
- Updated `trailingcomment.xml.template` with Example5 section