### PR TITLE
Issue #18033: Hardcoded mutation for ReverseListIterator

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/xpath/iterators/ReverseListIterator.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/xpath/iterators/ReverseListIterator.java
@@ -63,12 +63,12 @@ public class ReverseListIterator implements AxisIterator {
     @Override
     public NodeInfo next() {
         final NodeInfo result;
+        //MUTATION: incorrect condition (to kill pitest mutation)
         if (index == -1) {
-            result = null;
-        }
-        else {
             result = items.get(index);
             index--;
+        } else {
+            result = null;
         }
         return result;
     }


### PR DESCRIPTION
Issue #18033

Added hardcoded mutation for killing pitest mutation of ReverseListIterator

Changes made:
```
public NodeInfo next() {
        final NodeInfo result;
        //MUTATION: incorrect condition (to kill pitest mutation)
        if (index == -1) {
            result = items.get(index);
            index--;
        } else {
            result = null;
        }
        return result;
}
```

To see if it fails CI test...