### PR TITLE
Issue #18033: Resolve PIT suppression removals and fix XPath iterator

### DIFF
--- a/config/pitest-suppressions/pitest-xpath-suppressions.xml
+++ b/config/pitest-suppressions/pitest-xpath-suppressions.xml
@@ -1,24 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <suppressedMutations>
   <mutation unstable="false">
-    <sourceFile>FollowingIterator.java</sourceFile>
-    <mutatedClass>com.puppycrawl.tools.checkstyle.xpath.iterators.FollowingIterator</mutatedClass>
-    <mutatedMethod>next</mutatedMethod>
-    <mutator>org.pitest.mutationtest.engine.gregor.mutators.experimental.MemberVariableMutator</mutator>
-    <description>Removed assignment to member variable siblingEnum</description>
-    <lineContent>siblingEnum = null;</lineContent>
-  </mutation>
-
-  <mutation unstable="false">
-    <sourceFile>PrecedingIterator.java</sourceFile>
-    <mutatedClass>com.puppycrawl.tools.checkstyle.xpath.iterators.PrecedingIterator</mutatedClass>
-    <mutatedMethod>next</mutatedMethod>
-    <mutator>org.pitest.mutationtest.engine.gregor.mutators.experimental.MemberVariableMutator</mutator>
-    <description>Removed assignment to member variable previousSiblingEnum</description>
-    <lineContent>previousSiblingEnum = null;</lineContent>
-  </mutation>
-
-  <mutation unstable="false">
     <sourceFile>ReverseListIterator.java</sourceFile>
     <mutatedClass>com.puppycrawl.tools.checkstyle.xpath.iterators.ReverseListIterator</mutatedClass>
     <mutatedMethod>&lt;init&gt;</mutatedMethod>

--- a/src/main/java/com/puppycrawl/tools/checkstyle/xpath/iterators/FollowingIterator.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/xpath/iterators/FollowingIterator.java
@@ -65,13 +65,15 @@ public class FollowingIterator implements AxisIterator {
             }
 
             if (result == null && siblingEnum != null) {
-                result = siblingEnum.next();
-                if (result == null) {
+                final NodeInfo nextSibling = siblingEnum.next();
+
+                if (nextSibling == null) {
                     siblingEnum = null;
+                    continue;
                 }
-                else {
-                    descendantEnum = result.iterateAxis(AxisInfo.DESCENDANT);
-                }
+
+                result = nextSibling;
+                descendantEnum = result.iterateAxis(AxisInfo.DESCENDANT);
             }
 
             if (result == null) {

--- a/src/main/java/com/puppycrawl/tools/checkstyle/xpath/iterators/PrecedingIterator.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/xpath/iterators/PrecedingIterator.java
@@ -65,13 +65,15 @@ public class PrecedingIterator implements AxisIterator {
             }
 
             if (result == null && previousSiblingEnum != null) {
-                result = previousSiblingEnum.next();
-                if (result == null) {
+                final NodeInfo nextSibling = previousSiblingEnum.next();
+
+                if (nextSibling == null) {
                     previousSiblingEnum = null;
+                    continue;
                 }
-                else {
-                    descendantEnum = new ReverseDescendantIterator(result);
-                }
+
+                result = nextSibling;
+                descendantEnum = new ReverseDescendantIterator(result);
             }
 
             if (result == null) {


### PR DESCRIPTION
Issue: #18033

- Updated PrecedingIterator and FollowingIterator so that sibling resets correctly trigger ancestor traversal, enabling PIT to detect mutations.
- Removed PrecedingIterator and FollowingIterator entries from the PIT suppression list.
- Left ReverseListIterator unchanged since its mutation is intentionally harmless.