### PR TITLE
Add missing Javadoc for WhitespaceAroundOption enum

### DIFF
--- a/WhitespaceAroundOption.java
+++ b/WhitespaceAroundOption.java
@@ -1,0 +1,22 @@
+package com.puppycrawl.tools.checkstyle.checks.whitespace;
+
+/**
+ * Represents the different whitespace handling options used by the
+ * {@link WhitespaceAroundCheck}. Each option determines how whitespace
+ * should be validated around various Java tokens such as operators,
+ * keywords, and punctuation symbols.
+ *
+ * <p>This enum is used internally by Checkstyle to configure how the
+ * WhitespaceAroundCheck enforces spacing rules in Java source code.</p>
+ */
+public enum WhitespaceAroundOption {
+    /**
+     * Require whitespace around the token.
+     */
+    REQUIRE,
+
+    /**
+     * Do not require whitespace around the token.
+     */
+    IGNORE
+}


### PR DESCRIPTION
This PR adds missing Javadoc to the WhitespaceAroundOption enum.
The added documentation explains the purpose of the enum and its
role in configuring WhitespaceAroundCheck spacing behavior.

This improves code readability and aligns the file with Checkstyle’s
documentation standards.
