### PR TITLE
Issue #18028: Hardcoded mutation removed assignment to member variable args

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/api/Violation.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/api/Violation.java
@@ -111,12 +111,8 @@ public final class Violation
         this.tokenType = tokenType;
         this.key = key;
 
-        if (args == null) {
-            this.args = null;
-        }
-        else {
-            this.args = UnmodifiableCollectionUtil.copyOfArray(args, args.length);
-        }
+        //Hardcoded mutation
+        this.args=null;
         this.bundle = bundle;
         this.severityLevel = severityLevel;
         this.moduleId = moduleId;


### PR DESCRIPTION
Issue: #18028 

Mutation:
```
<mutation unstable="false">
    <sourceFile>Violation.java</sourceFile>
    <mutatedClass>com.puppycrawl.tools.checkstyle.api.Violation</mutatedClass>
    <mutatedMethod>&lt;init&gt;</mutatedMethod>
    <mutator>org.pitest.mutationtest.engine.gregor.mutators.experimental.MemberVariableMutator</mutator>
    <description>Removed assignment to member variable args</description>
    <lineContent>this.args = null;</lineContent>
  </mutation>
```

Hardcoded mutation:
```
public Violation(int lineNo,
                            int columnNo,
                            int columnCharIndex,
                            int tokenType,
                            String bundle,
                            String key,
                            Object[] args,
                            SeverityLevel severityLevel,
                            String moduleId,
                            Class<?> sourceClass,
                            @Nullable String customMessage) {
        this.lineNo = lineNo;
        this.columnNo = columnNo;
        this.columnCharIndex = columnCharIndex;
        this.tokenType = tokenType;
        this.key = key;

        //Hardcoded mutation
        this.args=null;
        this.bundle = bundle;
        this.severityLevel = severityLevel;
        this.moduleId = moduleId;
        this.sourceClass = sourceClass;
        this.customMessage = customMessage;
    }
```