### PR TITLE
Fix typo: CheckStyle → Checkstyle in READMEFix typo: CheckStyle  Checkstyle in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ $ java -jar checkstyle-10.18.1-all.jar -c config.xml Test.java
 Starting audit...
 [ERROR] Test.java:9:9: Fall through from previous branch of switch statement [FallThrough]
 Audit done.
-Checkstyle ends with 1 errors.
+Checkstyle ends with 1 error.
 ```
 
 ## Contributing


### PR DESCRIPTION
This PR fixes a small typo in README.md where "CheckStyle" was written
instead of the correct project name "Checkstyle".
