### PR TITLE
Update TAG_OPEN of JavadocCommentsTokenTypes to new AST format.

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/api/JavadocCommentsTokenTypes.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/api/JavadocCommentsTokenTypes.java
@@ -1096,7 +1096,37 @@ public final class JavadocCommentsTokenTypes {
     public static final int HTML_TAG_END = JavadocCommentsLexer.HTML_TAG_END;
 
     /**
-     * Opening tag delimiter {@code < }.
+     * Represents the opening {@literal "<"} symbol of an HTML start tag.
+     *
+     * <p><b>Example:</b></p>
+     * <pre>{@code
+     * <div class="container" lang="en"></div>
+     * }</pre>
+     *
+     * <b>Tree:</b>
+     * <pre>{@code
+     * HTML_ELEMENT -> HTML_ELEMENT
+     * |--HTML_TAG_START -> HTML_TAG_START
+     * |   |--TAG_OPEN -> <
+     * |   |--TAG_NAME -> div
+     * |   |--HTML_ATTRIBUTES -> HTML_ATTRIBUTES
+     * |   |   |--HTML_ATTRIBUTE -> HTML_ATTRIBUTE
+     * |   |   |   |--TAG_ATTR_NAME -> class
+     * |   |   |   |--EQUALS -> =
+     * |   |   |   `--ATTRIBUTE_VALUE -> "container"
+     * |   |   `--HTML_ATTRIBUTE -> HTML_ATTRIBUTE
+     * |   |       |--TAG_ATTR_NAME -> lang
+     * |   |       |--EQUALS -> =
+     * |   |       `--ATTRIBUTE_VALUE -> "en"
+     * |   `--TAG_CLOSE -> >
+     * `--HTML_TAG_END -> HTML_TAG_END
+     *     |--TAG_OPEN -> <
+     *     |--TAG_SLASH -> /
+     *     |--TAG_NAME -> div
+     *     `--TAG_CLOSE -> >
+     * }</pre>
+     *
+     * @see #HTML_TAG_START
      */
     public static final int TAG_OPEN = JavadocCommentsLexer.TAG_OPEN;
 


### PR DESCRIPTION
Issue #17882

Input  file 
```
package temp.temp1;

public class Temp {
    /**
     * Example description.
     *
     * <div class="container" lang="en"></div>
     */
    public void example() { }
}
``


Full CLI output:
JAVADOC_CONTENT -> JAVADOC_CONTENT 
|--TEXT -> package temp.temp1; 
|--NEWLINE -> \n 
|--NEWLINE -> \n 
|--TEXT -> public class Temp { 
|--NEWLINE -> \n 
|--TEXT ->     /** 
|--NEWLINE -> \n 
|--LEADING_ASTERISK ->      * 
|--TEXT ->  Example description. 
|--NEWLINE -> \n 
|--LEADING_ASTERISK ->      * 
|--NEWLINE -> \n 
|--LEADING_ASTERISK ->      * 
|--TEXT ->   
|--HTML_ELEMENT -> HTML_ELEMENT 
|   |--HTML_TAG_START -> HTML_TAG_START 
|   |   |--TAG_OPEN -> < 
|   |   |--TAG_NAME -> div 
|   |   |--HTML_ATTRIBUTES -> HTML_ATTRIBUTES 
|   |   |   |--HTML_ATTRIBUTE -> HTML_ATTRIBUTE 
|   |   |   |   |--TEXT ->   
|   |   |   |   |--TAG_ATTR_NAME -> class 
|   |   |   |   |--EQUALS -> = 
|   |   |   |   `--ATTRIBUTE_VALUE -> "container" 
|   |   |   `--HTML_ATTRIBUTE -> HTML_ATTRIBUTE 
|   |   |       |--TEXT ->   
|   |   |       |--TAG_ATTR_NAME -> lang 
|   |   |       |--EQUALS -> = 
|   |   |       `--ATTRIBUTE_VALUE -> "en" 
|   |   `--TAG_CLOSE -> > 
|   `--HTML_TAG_END -> HTML_TAG_END 
|       |--TAG_OPEN -> < 
|       |--TAG_SLASH -> / 
|       |--TAG_NAME -> div 
|       `--TAG_CLOSE -> > 
|--NEWLINE -> \n 
|--LEADING_ASTERISK ->      * 
|--TEXT -> / 
|--NEWLINE -> \n 
|--TEXT ->     public void example() { } 
|--NEWLINE -> \n 
|--TEXT -> } 
|--NEWLINE -> \n 
`--NEWLINE -> \n 