### PR TITLE
Issue #17882: Update TAG_SLASH of JavadocCommentsTokenTypes to new AST format

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/api/JavadocCommentsTokenTypes.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/api/JavadocCommentsTokenTypes.java
@@ -1219,7 +1219,33 @@ public final class JavadocCommentsTokenTypes {
     public static final int TAG_SLASH_CLOSE = JavadocCommentsLexer.TAG_SLASH_CLOSE;
 
     /**
-     * Slash symbol inside a closing tag.
+     * {@code TAG_SLASH} represents the slash {@literal "/"} used
+     * inside an HTML closing tag.
+     *
+     * <p>Appears in Javadoc comments when closing HTML elements.</p>
+     *
+     * <p><b>Example:</b></p>
+     * <pre>{@code
+     * <p>Paragraph text</p>
+     * }</pre>
+     *
+     * <b>Tree:</b>
+     * <pre>{@code
+     * HTML_ELEMENT -> HTML_ELEMENT
+     * |--HTML_TAG_START -> HTML_TAG_START
+     * |   |--TAG_OPEN -> <
+     * |   |--TAG_NAME -> p
+     * |   `--TAG_CLOSE -> >
+     * |--HTML_CONTENT -> HTML_CONTENT
+     * |   `--TEXT -> Paragraph text
+     * `--HTML_TAG_END -> HTML_TAG_END
+     *     |--TAG_OPEN -> <
+     *     |--TAG_SLASH -> /
+     *     |--TAG_NAME -> p
+     *     `--TAG_CLOSE -> >
+     * }</pre>
+     *
+     * @see #HTML_TAG_END
      */
     public static final int TAG_SLASH = JavadocCommentsLexer.TAG_SLASH;
 


### PR DESCRIPTION
Issue #17882

Input file 
```
package temp.temp1;

public class Temp {

    /**
     * Example for TAG_SLASH.
     * <p>Paragraph text</p>
     */
    public void example() { }

}
```

CLI output

``` 
JAVADOC_CONTENT -> JAVADOC_CONTENT 
|--TEXT -> package temp.temp1; 
|--NEWLINE -> \r\n 
|--NEWLINE -> \r\n 
|--TEXT -> public class Temp { 
|--NEWLINE -> \r\n 
|--NEWLINE -> \r\n 
|--TEXT ->     /** 
|--NEWLINE -> \r\n 
|--LEADING_ASTERISK ->      * 
|--TEXT ->  Example for TAG_SLASH. 
|--NEWLINE -> \r\n 
|--LEADING_ASTERISK ->      * 
|--TEXT ->   
|--HTML_ELEMENT -> HTML_ELEMENT 
|   |--HTML_TAG_START -> HTML_TAG_START 
|   |   |--TAG_OPEN -> < 
|   |   |--TAG_NAME -> p 
|   |   `--TAG_CLOSE -> > 
|   |--HTML_CONTENT -> HTML_CONTENT 
|   |   `--TEXT -> Paragraph text 
|   `--HTML_TAG_END -> HTML_TAG_END 
|       |--TAG_OPEN -> < 
|       |--TAG_SLASH -> / 
|       |--TAG_NAME -> p 
|       `--TAG_CLOSE -> > 
|--NEWLINE -> \r\n 
|--LEADING_ASTERISK ->      * 
|--TEXT -> / 
|--NEWLINE -> \r\n 
|--TEXT ->     public void example() { } 
|--NEWLINE -> \r\n 
|--NEWLINE -> \r\n 
|--TEXT -> } 
|--NEWLINE -> \r\n 
`--NEWLINE -> \r\n
```