### PR TITLE
Issue #17882: Update HTML_COMMENT_START of JavadocCommentsTokenTypes new AST format

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/api/JavadocCommentsTokenTypes.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/api/JavadocCommentsTokenTypes.java
@@ -1394,7 +1394,23 @@ public final class JavadocCommentsTokenTypes {
     public static final int HTML_COMMENT = JavadocCommentsLexer.HTML_COMMENT;
 
     /**
-     * Opening part of an HTML comment.
+     * {@code HTML_COMMENT_START} represents the beginning of an HTML comment,
+     * i.e., the {@literal "<!--"} sequence inside a Javadoc comment.
+     *
+     * <p>HTML comments occasionally appear in Javadoc to add internal notes or
+     * explanations without affecting the rendered output.</p>
+     * Example: {@code <!-- Note: This method is for demonstration purposes only. -->}
+     *
+     * <p><b>Tree:</b></p>
+     * <pre>{@code
+     * HTML_COMMENT -> HTML_COMMENT
+     * |--HTML_COMMENT_START -> <!--
+     * |--HTML_COMMENT_CONTENT -> HTML_COMMENT_CONTENT
+     * |   `--TEXT ->  Note: This method is for demonstration purposes only.
+     * `--HTML_COMMENT_END -> -->
+     * }</pre>
+     *
+     * @see #HTML_COMMENT_END
      */
     public static final int HTML_COMMENT_START = JavadocCommentsLexer.HTML_COMMENT_START;
 


### PR DESCRIPTION
Issue #17882

Input file 
```
package temp.temp1;

public class Temp {

    /**
     * Demonstrates how HTML comments may appear in Javadoc.
     *
     * <!-- Note: This method is for demonstration purposes only. -->
     */
    public void example() { }
}

```

CLI output

```
JAVADOC_CONTENT -> JAVADOC_CONTENT 
|--TEXT -> package temp.temp1; 
|--NEWLINE -> \n 
|--NEWLINE -> \n 
|--TEXT -> public class Temp { 
|--NEWLINE -> \n 
|--NEWLINE -> \n 
|--TEXT ->     /** 
|--NEWLINE -> \n 
|--LEADING_ASTERISK ->      * 
|--TEXT ->  Demonstrates how HTML comments may appear in Javadoc. 
|--NEWLINE -> \n 
|--LEADING_ASTERISK ->      * 
|--NEWLINE -> \n 
|--LEADING_ASTERISK ->      * 
|--TEXT ->   
|--HTML_COMMENT -> HTML_COMMENT 
|   |--HTML_COMMENT_START -> <!-- 
|   |--HTML_COMMENT_CONTENT -> HTML_COMMENT_CONTENT 
|   |   `--TEXT ->  Note: This method is for demonstration purposes only.  
|   `--HTML_COMMENT_END -> --> 
|--NEWLINE -> \n 
|--LEADING_ASTERISK ->      * 
|--TEXT -> / 
|--NEWLINE -> \n 
|--TEXT ->     public void example() { } 
|--NEWLINE -> \n 
|--TEXT -> } 
`--NEWLINE -> \n 
```