### PR TITLE
Issue #17882: Update HTML_COMMENT_CONTENT of JavadocCommentsTokenTypes to new AST format

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/api/JavadocCommentsTokenTypes.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/api/JavadocCommentsTokenTypes.java
@@ -1350,7 +1350,22 @@ public final class JavadocCommentsTokenTypes {
     public static final int HTML_COMMENT_END = JavadocCommentsLexer.HTML_COMMENT_END;
 
     /**
-     * Content inside an HTML comment.
+     * {@code HTML_COMMENT_CONTENT} Content inside an HTML comment.
+     *
+     * <p>Text within an HTML comment.</p>
+     *
+     * <p><b>Example:</b> {@code <!-- This is a comment -->}</p>
+     *
+     * <p><b>Tree:</b></p>
+     * <pre>{@code
+     * HTML_COMMENT -> HTML_COMMENT
+     * |--HTML_COMMENT_START -> <!--
+     * |--HTML_COMMENT_CONTENT -> HTML_COMMENT_CONTENT
+     * |   `--TEXT ->  This is a comment
+     * `--HTML_COMMENT_END -> -->
+     * }</pre>
+     *
+     * @see #HTML_COMMENT
      */
     public static final int HTML_COMMENT_CONTENT = JavadocCommentsLexer.HTML_COMMENT_CONTENT;
 


### PR DESCRIPTION
Issue #17882

Input file
```
package temp.temp1;

public class Temp {
    /**
     * Example for HTML_COMMENT_CONTENT.
     *
     * <!-- This is a comment -->
     */
    public void example() { }
}

```
Full CLI outout

```
JAVADOC_CONTENT -> JAVADOC_CONTENT 
|--TEXT -> package temp.temp1; 
|--NEWLINE -> \n 
|--NEWLINE -> \n 
|--TEXT -> public class Temp { 
|--NEWLINE -> \n 
|--TEXT ->     /** 
|--NEWLINE -> \n 
|--LEADING_ASTERISK ->      * 
|--TEXT ->  Example for HTML_COMMENT_CONTENT. 
|--NEWLINE -> \n 
|--LEADING_ASTERISK ->      * 
|--NEWLINE -> \n 
|--LEADING_ASTERISK ->      * 
|--TEXT ->   
|--HTML_COMMENT -> HTML_COMMENT 
|   |--HTML_COMMENT_START -> <!-- 
|   |--HTML_COMMENT_CONTENT -> HTML_COMMENT_CONTENT 
|   |   `--TEXT ->  This is a comment  
|   `--HTML_COMMENT_END -> --> 
|--NEWLINE -> \n 
|--LEADING_ASTERISK ->      * 
|--TEXT -> / 
|--NEWLINE -> \n 
|--TEXT ->     public void example() { } 
|--NEWLINE -> \n 
|--TEXT -> } 
`--NEWLINE -> \n
```