### PR TITLE
Issue #17882: Update HTML_ATTRIBUTES of JavadocCommentsTokenTypes to …

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/api/JavadocCommentsTokenTypes.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/api/JavadocCommentsTokenTypes.java
@@ -1097,7 +1097,38 @@ public final class JavadocCommentsTokenTypes {
     public static final int HTML_ATTRIBUTE = JavadocCommentsLexer.HTML_ATTRIBUTE;
 
     /**
-     * List of HTML attributes.
+     * {@code HTML_ATTRIBUTES} represents a collection of HTML attributes
+     * inside an HTML tag.
+     *
+     * <p>Appears in Javadoc comments when documenting HTML elements that contain
+     * multiple attributes.</p>
+     *
+     * <p><b>Example:</b></p>
+     * <pre>{@code
+     * <div lang="en" custom-attr="value"></div>
+     * }</pre>
+     *
+     * <p><b>Tree:</b></p>
+     * <pre>{@code
+     * HTML_ELEMENT -> HTML_ELEMENT
+     * |--HTML_TAG_START -> HTML_TAG_START
+     * |   |--TAG_OPEN -> <
+     * |   |--TAG_NAME -> div
+     * |   |--HTML_ATTRIBUTES -> HTML_ATTRIBUTES
+     * |   |   |--HTML_ATTRIBUTE -> HTML_ATTRIBUTE
+     * |   |   |   |--TEXT ->
+     * |   |   |   |--TAG_ATTR_NAME -> lang
+     * |   |   |   |--EQUALS -> =
+     * |   |   |   `--ATTRIBUTE_VALUE -> "en"
+     * |   |   `--HTML_ATTRIBUTE -> HTML_ATTRIBUTE
+     * |   |       |--TEXT ->
+     * |   |       |--TAG_ATTR_NAME -> custom-attr
+     * |   |       |--EQUALS -> =
+     * |   |       `--ATTRIBUTE_VALUE -> "value"
+     * |   `--TAG_CLOSE -> >
+     * }</pre>
+     *
+     * @see #HTML_ATTRIBUTE
      */
     public static final int HTML_ATTRIBUTES = JavadocCommentsLexer.HTML_ATTRIBUTES;
 


### PR DESCRIPTION
Issue #17882

Input file 
```
package temp.temp1;

public class Temp {
    /**
     * Example for HTML_ATTRIBUTES.
     *
     * <div lang="en" custom-attr="value">
     */
    public void example() {}
}

```
CLI output

```
JAVADOC_CONTENT -> JAVADOC_CONTENT 
|--TEXT -> package temp.temp1; 
|--NEWLINE -> \n 
|--NEWLINE -> \n 
|--TEXT -> public class Temp { 
|--NEWLINE -> \n 
|--TEXT ->     /** 
|--NEWLINE -> \n 
|--LEADING_ASTERISK ->      * 
|--TEXT ->  Example for HTML_ATTRIBUTES. 
|--NEWLINE -> \n 
|--LEADING_ASTERISK ->      * 
|--NEWLINE -> \n 
|--LEADING_ASTERISK ->      * 
|--TEXT ->   
|--HTML_ELEMENT -> HTML_ELEMENT 
|   |--HTML_TAG_START -> HTML_TAG_START 
|   |   |--TAG_OPEN -> < 
|   |   |--TAG_NAME -> div 
|   |   |--HTML_ATTRIBUTES -> HTML_ATTRIBUTES 
|   |   |   |--HTML_ATTRIBUTE -> HTML_ATTRIBUTE 
|   |   |   |   |--TEXT ->   
|   |   |   |   |--TAG_ATTR_NAME -> lang 
|   |   |   |   |--EQUALS -> = 
|   |   |   |   `--ATTRIBUTE_VALUE -> "en" 
|   |   |   `--HTML_ATTRIBUTE -> HTML_ATTRIBUTE 
|   |   |       |--TEXT ->   
|   |   |       |--TAG_ATTR_NAME -> custom-attr 
|   |   |       |--EQUALS -> = 
|   |   |       `--ATTRIBUTE_VALUE -> "value" 
|   |   `--TAG_CLOSE -> > 
|   |--NEWLINE -> \n 
|   |--LEADING_ASTERISK ->      * 
|   `--HTML_CONTENT -> HTML_CONTENT 
|       |--TEXT -> / 
|       |--NEWLINE -> \n 
|       |--TEXT ->     public void example() {} 
|       |--NEWLINE -> \n 
|       `--TEXT -> } 
`--NEWLINE -> \n 
```