### PR TITLE
Issue #17882: Update SUPER of JavadocCommentsTokenTypes to new AST format

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/api/JavadocCommentsTokenTypes.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/api/JavadocCommentsTokenTypes.java
@@ -1012,7 +1012,36 @@ public final class JavadocCommentsTokenTypes {
     public static final int EXTENDS = JavadocCommentsLexer.EXTENDS;
 
     /**
-     * Keyword {@code super} in type parameters.
+     * {@code SUPER} represents the {@code super} keyword inside a generic
+     * wildcard bound (e.g., {@code ? super Number}).
+     *
+     * <p><b>Example:</b> {@code {@link java.util.List <? super Integer> list}
+     * of any supertype of Integer}</p>
+     *
+     * <p><b>Tree:</b></p>
+     * <pre>{@code
+     * JAVADOC_INLINE_TAG -> JAVADOC_INLINE_TAG
+     * `--LINK_INLINE_TAG -> LINK_INLINE_TAG
+     *     |--JAVADOC_INLINE_TAG_START -> { @
+     *     |--TAG_NAME -> link
+     *     |--TEXT ->
+     *     |--REFERENCE -> REFERENCE
+     *     |   |--IDENTIFIER -> java.util.List
+     *     |   `--TYPE_ARGUMENTS -> TYPE_ARGUMENTS
+     *     |       |--LT -> <
+     *     |       |--TYPE_ARGUMENT -> TYPE_ARGUMENT
+     *     |       |   |--QUESTION -> ?
+     *     |       |   |--TEXT ->
+     *     |       |   |--SUPER -> super
+     *     |       |   |--TEXT ->
+     *     |       |   `--IDENTIFIER -> Integer
+     *     |       `--GT -> >
+     *     |--DESCRIPTION -> DESCRIPTION
+     *     |   `--TEXT ->  list of any supertype of Integer
+     *     `--JAVADOC_INLINE_TAG_END -> }
+     * }</pre>
+     *
+     * @see #PARAMETER_TYPE
      */
     public static final int SUPER = JavadocCommentsLexer.SUPER;
 


### PR DESCRIPTION
Issue #17882

Input file
```
package temp.temp1;

public class Temp {

    /**
     * {@link java.util.List<? super Integer> list of any supertype of Integer}
     */
    public void example() { }
}

```

CLI output 

```
JAVADOC_CONTENT -> JAVADOC_CONTENT 
|--TEXT -> package temp.temp1; 
|--NEWLINE -> \n 
|--NEWLINE -> \n 
|--TEXT -> public class Temp { 
|--NEWLINE -> \n 
|--NEWLINE -> \n 
|--TEXT ->     /** 
|--NEWLINE -> \n 
|--LEADING_ASTERISK ->      * 
|--TEXT ->   
|--JAVADOC_INLINE_TAG -> JAVADOC_INLINE_TAG 
|   `--LINK_INLINE_TAG -> LINK_INLINE_TAG 
|       |--JAVADOC_INLINE_TAG_START -> {@ 
|       |--TAG_NAME -> link 
|       |--TEXT ->   
|       |--REFERENCE -> REFERENCE 
|       |   |--IDENTIFIER -> java.util.List 
|       |   `--TYPE_ARGUMENTS -> TYPE_ARGUMENTS 
|       |       |--LT -> < 
|       |       |--TYPE_ARGUMENT -> TYPE_ARGUMENT 
|       |       |   |--QUESTION -> ? 
|       |       |   |--TEXT ->   
|       |       |   |--SUPER -> super 
|       |       |   |--TEXT ->   
|       |       |   `--IDENTIFIER -> Integer 
|       |       `--GT -> > 
|       |--DESCRIPTION -> DESCRIPTION 
|       |   `--TEXT ->  list of any supertype of Integer 
|       `--JAVADOC_INLINE_TAG_END -> } 
|--NEWLINE -> \n 
|--LEADING_ASTERISK ->      * 
|--TEXT -> / 
|--NEWLINE -> \n 
|--TEXT ->     public void example() { } 
|--NEWLINE -> \n 
|--TEXT -> } 
`--NEWLINE -> \n 
```
