### PR TITLE
Issue #17882: Update PARAMETER_TYPE of JavadocCommentsTokenTypes to new AST format

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/api/JavadocCommentsTokenTypes.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/api/JavadocCommentsTokenTypes.java
@@ -869,7 +869,32 @@ public final class JavadocCommentsTokenTypes {
     public static final int SUPER = JavadocCommentsLexer.SUPER;
 
     /**
-     * Parameter type reference.
+     * {@code PARAMETER_TYPE} Parameter type reference.
+     *
+     * <p>Represents a type used in a method parameter.</p>
+     *
+     * <p><b>Example:</b></p>
+     * <pre>{@code {@link java.util.List#add(Object)}} </pre>
+     *
+     * <b>Tree:</b>
+     * <pre>{@code
+     * JAVADOC_INLINE_TAG -> JAVADOC_INLINE_TAG
+     * `--LINK_INLINE_TAG -> LINK_INLINE_TAG
+     *     |--JAVADOC_INLINE_TAG_START -> &#123;@
+     *     |--TAG_NAME -> link
+     *     |--REFERENCE -> REFERENCE
+     *     |   |--IDENTIFIER -> List
+     *     |   |--HASH -> #
+     *     |   `--MEMBER_REFERENCE -> MEMBER_REFERENCE
+     *     |       |--IDENTIFIER -> add
+     *     |       |--LPAREN -> (
+     *     |       |--PARAMETER_TYPE_LIST -> PARAMETER_TYPE_LIST
+     *     |       |   `--PARAMETER_TYPE -> Object
+     *     |       `--RPAREN -> )
+     *     `--JAVADOC_INLINE_TAG_END -> }
+     * }</pre>
+     *
+     * @see #TYPE_NAME
      */
     public static final int PARAMETER_TYPE = JavadocCommentsLexer.PARAMETER_TYPE;
 


### PR DESCRIPTION
Issue #17882

Input file
```
package temp.temp1;

public class Temp {

    /**
     * Example for PARAMETER_TYPE: {@link List#add(Object)}
     */
    public void example() { }
}


```

CLI 
```
JAVADOC_CONTENT -> JAVADOC_CONTENT 
|--TEXT -> package temp.temp1; 
|--NEWLINE -> \n 
|--NEWLINE -> \n 
|--TEXT -> public class Temp { 
|--NEWLINE -> \n 
|--NEWLINE -> \n 
|--TEXT ->     /** 
|--NEWLINE -> \n 
|--LEADING_ASTERISK ->      * 
|--TEXT ->  Example for PARAMETER_TYPE:  
|--JAVADOC_INLINE_TAG -> JAVADOC_INLINE_TAG 
|   `--LINK_INLINE_TAG -> LINK_INLINE_TAG 
|       |--JAVADOC_INLINE_TAG_START -> {@ 
|       |--TAG_NAME -> link 
|       |--TEXT ->   
|       |--REFERENCE -> REFERENCE 
|       |   |--IDENTIFIER -> List 
|       |   |--HASH -> # 
|       |   `--MEMBER_REFERENCE -> MEMBER_REFERENCE 
|       |       |--IDENTIFIER -> add 
|       |       |--LPAREN -> ( 
|       |       |--PARAMETER_TYPE_LIST -> PARAMETER_TYPE_LIST 
|       |       |   `--PARAMETER_TYPE -> Object 
|       |       `--RPAREN -> ) 
|       `--JAVADOC_INLINE_TAG_END -> } 
|--NEWLINE -> \n 
|--LEADING_ASTERISK ->      * 
|--TEXT -> / 
|--NEWLINE -> \n 
|--TEXT ->     public void example() { } 
|--NEWLINE -> \n 
|--TEXT -> } 
`--NEWLINE -> \n
```