### PR TITLE
Issue #17882: Update REFERENCE of JavadocCommentsTokenTypes to new AST format

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/api/JavadocCommentsTokenTypes.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/api/JavadocCommentsTokenTypes.java
@@ -874,7 +874,26 @@ public final class JavadocCommentsTokenTypes {
     public static final int PARAMETER_TYPE = JavadocCommentsLexer.PARAMETER_TYPE;
 
     /**
-     * General reference within Javadoc.
+     * {@code REFERENCE} General reference within Javadoc.
+     *
+     * <p>Represents the target of an inline reference tag such as
+     * {@code {@link String#length()}}.</p>
+     *
+     * <p><b>Example:</b></p>
+     * <pre>{@code
+     * {@link String#length()}
+     * }</pre>
+     *
+     * <b>Tree:</b>
+     * <pre>{@code
+     * JAVADOC_INLINE_TAG -> JAVADOC_INLINE_TAG
+     * |--LINK_INLINE_TAG -> LINK_INLINE_TAG
+     * |   |--JAVADOC_INLINE_TAG_START -> &#123;@
+     * |   |--TAG_NAME -> link
+     * |   `--REFERENCE -> String#length()
+     * }</pre>
+     *
+     * @see #JAVADOC_INLINE_TAG
      */
     public static final int REFERENCE = JavadocCommentsLexer.REFERENCE;
 


### PR DESCRIPTION
Issue #17882

Input file

```
package temp.temp1;

public class Temp {
    /**
     * Example for REFERENCE.
     *
     * {@link java.lang.String#length()}
     */
    public void example() { }
}

```

CLI output

```
JAVADOC_CONTENT -> JAVADOC_CONTENT 
|--TEXT -> package temp.temp1; 
|--NEWLINE -> \n 
|--NEWLINE -> \n 
|--TEXT -> public class Temp { 
|--NEWLINE -> \n 
|--TEXT ->     /** 
|--NEWLINE -> \n 
|--LEADING_ASTERISK ->      * 
|--TEXT ->  Example for REFERENCE. 
|--NEWLINE -> \n 
|--LEADING_ASTERISK ->      * 
|--NEWLINE -> \n 
|--LEADING_ASTERISK ->      * 
|--TEXT ->   
|--JAVADOC_INLINE_TAG -> JAVADOC_INLINE_TAG 
|   `--LINK_INLINE_TAG -> LINK_INLINE_TAG 
|       |--JAVADOC_INLINE_TAG_START -> {@ 
|       |--TAG_NAME -> link 
|       |--TEXT ->   
|       |--REFERENCE -> REFERENCE 
|       |   |--IDENTIFIER -> java.lang.String 
|       |   |--HASH -> # 
|       |   `--MEMBER_REFERENCE -> MEMBER_REFERENCE 
|       |       |--IDENTIFIER -> length 
|       |       |--LPAREN -> ( 
|       |       `--RPAREN -> ) 
|       `--JAVADOC_INLINE_TAG_END -> } 
|--NEWLINE -> \n 
|--LEADING_ASTERISK ->      * 
|--TEXT -> / 
|--NEWLINE -> \n 
|--TEXT ->     public void example() { } 
|--NEWLINE -> \n 
|--TEXT -> } 
`--NEWLINE -> \n 

```