### PR TITLE
Issue #17882: Update TYPE_NAME of JavadocCommentsTokenTypes to new AST format

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/api/JavadocCommentsTokenTypes.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/api/JavadocCommentsTokenTypes.java
@@ -940,7 +940,23 @@ public final class JavadocCommentsTokenTypes {
     public static final int REFERENCE = JavadocCommentsLexer.REFERENCE;
 
     /**
-     * Type name reference.
+     * {@code TYPE_NAME} Type name reference.
+     *
+     * <p>Name of a type in Javadoc references.</p>
+     *
+     * <p><b>Example:</b></p>
+     * <pre>{@code @see java.io.IOException}</pre>
+     *
+     * <b>Tree:</b>
+     * <pre>{@code
+     * SEE_BLOCK_TAG -> SEE_BLOCK_TAG
+     * |--AT_SIGN -> @
+     * |--TAG_NAME -> see
+     * |--REFERENCE -> REFERENCE
+     * |   `--IDENTIFIER -> java.io.IOException
+     * }</pre>
+     *
+     * @see #REFERENCE
      */
     public static final int TYPE_NAME = JavadocCommentsLexer.TYPE_NAME;
 


### PR DESCRIPTION
Issue #17882

Input file 
```
package temp.temp1;

public class Temp {

    /**
     * @see java.io.IOException
     */
    public void example() { }
}

```

CLI output 

```
JAVADOC_CONTENT -> JAVADOC_CONTENT 
|--TEXT -> package temp.temp1; 
|--NEWLINE -> \r\n 
|--NEWLINE -> \r\n 
|--TEXT -> public class Temp { 
|--NEWLINE -> \r\n 
|--NEWLINE -> \r\n 
|--TEXT ->     /** 
|--NEWLINE -> \r\n 
|--LEADING_ASTERISK ->      * 
|--TEXT ->   
`--JAVADOC_BLOCK_TAG -> JAVADOC_BLOCK_TAG 
    `--SEE_BLOCK_TAG -> SEE_BLOCK_TAG 
        |--AT_SIGN -> @ 
        |--TAG_NAME -> see 
        |--TEXT ->   
        |--REFERENCE -> REFERENCE 
        |   `--IDENTIFIER -> java.io.IOException 
        |--NEWLINE -> \r\n 
        |--LEADING_ASTERISK ->      * 
        `--DESCRIPTION -> DESCRIPTION 
            |--TEXT -> / 
            |--NEWLINE -> \r\n 
            |--TEXT ->     public void example() { } 
            |--NEWLINE -> \r\n 
            `--TEXT -> } 
 ```