### PR TITLE
Issue #17882: Update MEMBER_REFERENCE of JavadocCommentsTokenTypes to new AST format

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/api/JavadocCommentsTokenTypes.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/api/JavadocCommentsTokenTypes.java
@@ -903,7 +903,33 @@ public final class JavadocCommentsTokenTypes {
     public static final int TYPE_NAME = JavadocCommentsLexer.TYPE_NAME;
 
     /**
-     * Member reference (e.g. method or field).
+     * {@code MEMBER_REFERENCE} Member reference (method or field).
+     *
+     * <p>Represents a field or method in a type reference.</p>
+     *
+     * <p><b>Example:</b></p>
+     * <pre>{@code
+     * {@link String#length()}
+     * }</pre>
+     *
+     * <p><b>Tree:</b></p>
+     * <pre>{@code
+     * JAVADOC_INLINE_TAG -> JAVADOC_INLINE_TAG
+     * `--LINK_INLINE_TAG -> LINK_INLINE_TAG
+     *     |--JAVADOC_INLINE_TAG_START -> &#123;@
+     *     |--TAG_NAME -> link
+     *     |--TEXT ->
+     *     |--REFERENCE -> REFERENCE
+     *     |   |--IDENTIFIER -> String
+     *     |   |--HASH -> #
+     *     |   `--MEMBER_REFERENCE -> MEMBER_REFERENCE
+     *     |       |--IDENTIFIER -> length
+     *     |       |--LPAREN -> (
+     *     |       `--RPAREN -> )
+     *     `--JAVADOC_INLINE_TAG_END -> }
+     * }</pre>
+     *
+     * @see #REFERENCE
      */
     public static final int MEMBER_REFERENCE = JavadocCommentsLexer.MEMBER_REFERENCE;
 


### PR DESCRIPTION
Issue #17882

Input file
```
package temp.temp1;

public class Temp {

    /**
     *  Example for MEMBER_REFERENCE: {@link String#length()}
     */
    public void example() { }
}

```


CLI output

```
JAVADOC_CONTENT -> JAVADOC_CONTENT 
|--TEXT -> package temp.temp1; 
|--NEWLINE -> \n 
|--NEWLINE -> \n 
|--TEXT -> public class Temp { 
|--NEWLINE -> \n 
|--NEWLINE -> \n 
|--TEXT ->     /** 
|--NEWLINE -> \n 
|--LEADING_ASTERISK ->      * 
|--TEXT ->   Example for MEMBER_REFERENCE:  
|--JAVADOC_INLINE_TAG -> JAVADOC_INLINE_TAG 
|   `--LINK_INLINE_TAG -> LINK_INLINE_TAG 
|       |--JAVADOC_INLINE_TAG_START -> {@ 
|       |--TAG_NAME -> link 
|       |--TEXT ->   
|       |--REFERENCE -> REFERENCE 
|       |   |--IDENTIFIER -> String 
|       |   |--HASH -> # 
|       |   `--MEMBER_REFERENCE -> MEMBER_REFERENCE 
|       |       |--IDENTIFIER -> length 
|       |       |--LPAREN -> ( 
|       |       `--RPAREN -> ) 
|       `--JAVADOC_INLINE_TAG_END -> } 
|--NEWLINE -> \n 
|--LEADING_ASTERISK ->      * 
|--TEXT -> / 
|--NEWLINE -> \n 
|--TEXT ->     public void example() { } 
|--NEWLINE -> \n 
|--TEXT -> } 
`--NEWLINE -> \n 

```