### PR TITLE
Issue #17882: Update PARAMETER_TYPE_LIST of JavadocCommentsTokenTypes to new AST format

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/api/JavadocCommentsTokenTypes.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/api/JavadocCommentsTokenTypes.java
@@ -889,7 +889,37 @@ public final class JavadocCommentsTokenTypes {
     public static final int MEMBER_REFERENCE = JavadocCommentsLexer.MEMBER_REFERENCE;
 
     /**
-     * List of parameter types in a reference.
+     * {@code PARAMETER_TYPE_LIST} represents the list of parameter types inside a
+     * member reference within a Javadoc inline {@code @link} tag.
+     *
+     * <p><b>Example:</b></p>
+     * <pre>{@code
+     * {@link Math#max(int, int)}
+     * }</pre>
+     *
+     * <p><b>Tree:</b></p>
+     * <pre>{@code
+     * JAVADOC_INLINE_TAG -> JAVADOC_INLINE_TAG
+     * `--LINK_INLINE_TAG -> LINK_INLINE_TAG
+     *     |--JAVADOC_INLINE_TAG_START -> {\@
+     *     |--TAG_NAME -> link
+     *     |--TEXT ->
+     *     |--REFERENCE -> REFERENCE
+     *     |   |--IDENTIFIER -> Math
+     *     |   |--HASH -> #
+     *     |   `--MEMBER_REFERENCE -> MEMBER_REFERENCE
+     *     |       |--IDENTIFIER -> max
+     *     |       |--LPAREN -> (
+     *     |       |--PARAMETER_TYPE_LIST -> PARAMETER_TYPE_LIST
+     *     |       |   |--PARAMETER_TYPE -> int
+     *     |       |   |--COMMA -> ,
+     *     |       |   |--TEXT ->
+     *     |       |   `--PARAMETER_TYPE -> int
+     *     |       `--RPAREN -> )
+     *     `--JAVADOC_INLINE_TAG_END -> }
+     * }</pre>
+     *
+     * @see #PARAMETER_TYPE
      */
     public static final int PARAMETER_TYPE_LIST = JavadocCommentsLexer.PARAMETER_TYPE_LIST;
 


### PR DESCRIPTION
Issue #17882
Input file
```
package temp.temp1;

public class Temp {
    /**
     * Example for PARAMETER_TYPE_LIST.
     * {@link Math#max(int, int)}
     */
    public void example() { }
}


```

Full CLI output 

```
JAVADOC_CONTENT -> JAVADOC_CONTENT 
|--TEXT -> package temp.temp1; 
|--NEWLINE -> \n 
|--NEWLINE -> \n 
|--TEXT -> public class Temp { 
|--NEWLINE -> \n 
|--TEXT ->     /** 
|--NEWLINE -> \n 
|--LEADING_ASTERISK ->      * 
|--TEXT ->  Example for PARAMETER_TYPE_LIST. 
|--NEWLINE -> \n 
|--LEADING_ASTERISK ->      * 
|--TEXT ->   
|--JAVADOC_INLINE_TAG -> JAVADOC_INLINE_TAG 
|   `--LINK_INLINE_TAG -> LINK_INLINE_TAG 
|       |--JAVADOC_INLINE_TAG_START -> {@ 
|       |--TAG_NAME -> link 
|       |--TEXT ->   
|       |--REFERENCE -> REFERENCE 
|       |   |--IDENTIFIER -> Math 
|       |   |--HASH -> # 
|       |   `--MEMBER_REFERENCE -> MEMBER_REFERENCE 
|       |       |--IDENTIFIER -> max 
|       |       |--LPAREN -> ( 
|       |       |--PARAMETER_TYPE_LIST -> PARAMETER_TYPE_LIST 
|       |       |   |--PARAMETER_TYPE -> int 
|       |       |   |--COMMA -> , 
|       |       |   |--TEXT ->   
|       |       |   `--PARAMETER_TYPE -> int 
|       |       `--RPAREN -> ) 
|       `--JAVADOC_INLINE_TAG_END -> } 
|--NEWLINE -> \n 
|--LEADING_ASTERISK ->      * 
|--TEXT -> / 
|--NEWLINE -> \n 
|--TEXT ->     public void example() { } 
|--NEWLINE -> \n 
|--TEXT -> } 
`--NEWLINE -> \n
``