### PR TITLE
Issue #17882: Update TYPE_ARGUMENTS of JavadocCommentsTokenTypes to new AST format

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/api/JavadocCommentsTokenTypes.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/api/JavadocCommentsTokenTypes.java
@@ -1011,7 +1011,31 @@ public final class JavadocCommentsTokenTypes {
     public static final int PARAMETER_TYPE_LIST = JavadocCommentsLexer.PARAMETER_TYPE_LIST;
 
     /**
-     * Type arguments in generics.
+     * {@code TYPE_ARGUMENTS} Type arguments in generics.
+     *
+     * <p>Represents the type arguments inside a generic type reference.</p>
+     *
+     * <p><b>Example:</b></p>
+     * <pre>{@code {@link java.util.List<String>}}</pre>
+     *
+     * <p><b>Tree:</b></p>
+     * <pre>{@code
+     * JAVADOC_INLINE_TAG -> JAVADOC_INLINE_TAG
+     * `--LINK_INLINE_TAG -> LINK_INLINE_TAG
+     *     |--JAVADOC_INLINE_TAG_START -> &#123;@
+     *     |--TAG_NAME -> link
+     *     |--TEXT ->
+     *     |--REFERENCE -> REFERENCE
+     *     |   |--IDENTIFIER -> java.util.List
+     *     |   `--TYPE_ARGUMENTS -> TYPE_ARGUMENTS
+     *     |       |--LT -> <
+     *     |       |--TYPE_ARGUMENT -> TYPE_ARGUMENT
+     *     |       |   `--IDENTIFIER -> String
+     *     |       `--GT -> >
+     *     `--JAVADOC_INLINE_TAG_END -> }
+     * }</pre>
+     *
+     * @see #TYPE_ARGUMENT
      */
     public static final int TYPE_ARGUMENTS = JavadocCommentsLexer.TYPE_ARGUMENTS;
 


### PR DESCRIPTION
Issue #17882

Input file
```
package temp.temp1;

public class Temp {

    /**
     * Example for TYPE_ARGUMENTS: {@link java.util.List<String>}
     */
    public void example() { }
}

```

CLI output

```
JAVADOC_CONTENT -> JAVADOC_CONTENT 
|--TEXT -> package temp.temp1; 
|--NEWLINE -> \n 
|--NEWLINE -> \n 
|--TEXT -> public class Temp { 
|--NEWLINE -> \n 
|--NEWLINE -> \n 
|--TEXT ->     /** 
|--NEWLINE -> \n 
|--LEADING_ASTERISK ->      * 
|--TEXT ->  Example for TYPE_ARGUMENTS:  
|--JAVADOC_INLINE_TAG -> JAVADOC_INLINE_TAG 
|   `--LINK_INLINE_TAG -> LINK_INLINE_TAG 
|       |--JAVADOC_INLINE_TAG_START -> {@ 
|       |--TAG_NAME -> link 
|       |--TEXT ->   
|       |--REFERENCE -> REFERENCE 
|       |   |--IDENTIFIER -> java.util.List 
|       |   `--TYPE_ARGUMENTS -> TYPE_ARGUMENTS 
|       |       |--LT -> < 
|       |       |--TYPE_ARGUMENT -> TYPE_ARGUMENT 
|       |       |   `--IDENTIFIER -> String 
|       |       `--GT -> > 
|       `--JAVADOC_INLINE_TAG_END -> } 
|--NEWLINE -> \n 
|--LEADING_ASTERISK ->      * 
|--TEXT -> / 
|--NEWLINE -> \n 
|--TEXT ->     public void example() { } 
|--NEWLINE -> \n 
|--TEXT -> } 
`--NEWLINE -> \n
```