### PR TITLE
Issue #16360: Add comment explaining why XMLLogger testCloseStream an…

### DIFF
--- a/src/test/java/com/puppycrawl/tools/checkstyle/XMLLoggerTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/XMLLoggerTest.java
@@ -126,6 +126,10 @@ public class XMLLoggerTest extends AbstractXmlTestSupport {
         outStream.close();
     }
 
+    /**
+     * Cannot use verifyWithInlineConfigParserAndXmlLogger because this test
+     * relies on a custom OutputStream to assert close() call behavior.
+     */
     @Test
     public void testCloseStream()
             throws Exception {
@@ -259,6 +263,11 @@ public class XMLLoggerTest extends AbstractXmlTestSupport {
             .isEqualTo(1);
     }
 
+    /**
+     * Cannot use verifyWithInlineConfigParserAndXmlLogger because this test
+     * requires an AuditEvent with a null file name and a custom OutputStream
+     * to verify close() behavior.
+     */
     @Test
     public void testAddExceptionWithNullFileName()
             throws Exception {


### PR DESCRIPTION
Issue #16360: 


Adds documentation explaining why certain tests in `XMLLoggerTest` cannot be updated to use `verifyWithInlineConfigParserAndXmlLogger`.

## Details

This PR adds explanatory comments to the following tests:

- **`testCloseStream`**  
  This test relies on a custom `OutputStream` (`CloseAndFlushTestByteArrayOutputStream`) to verify `close()` call behavior using `getCloseCount()`.  
  The inline verifier internally manages its own stream and does not expose it, so this behavior cannot be validated through the helper.

- **`testAddExceptionWithNullFileName`**  
  This test requires an `AuditEvent` with a `null` file name and uses a custom exception with a controlled stack trace.  
  These scenarios cannot be reproduced through a normal `Checker` execution driven by the inline verifier.
