### PR TITLE
Issue #18110: Improve wrapping in web site for Command mentioned in …

### DIFF
--- a/src/site/resources/css/site.css
+++ b/src/site/resources/css/site.css
@@ -102,6 +102,16 @@ h1:hover:has(> a > img:first-child) .anchor {
   word-wrap: break-word !important;
 }
 
+.wrap-content .prettyprint code {
+  white-space: pre-wrap;
+  word-break: break-word;
+  text-wrap: wrap;
+}
+
+pre.block-command {
+  white-space: normal !important;
+}
+
 section {
   position: relative;
 }

--- a/src/site/xdoc/cmdline.xml.vm
+++ b/src/site/xdoc/cmdline.xml.vm
@@ -2091,27 +2091,27 @@ Checkstyle ends with 2 errors.
       </p>
       <div class="wrap-content">
         <div class="wrapper"><pre class="prettyprint"><code class="language-bash">
-          git clone https://github.com/checkstyle/checkstyle.git
-          cd checkstyle
-          ./mvnw clean compile
+git clone https://github.com/checkstyle/checkstyle.git
+cd checkstyle
+./mvnw clean compile
         </code></pre></div>
       </div>
       <p>
         Run validation with arguments:
       </p>
-      <div class="wrap-content">
-        <div class="wrapper"><pre class="prettyprint"><code class="language-bash">
-          ./mvnw exec:java -Dexec.mainClass="com.puppycrawl.tools.checkstyle.Main" \
-          &#xa0;&#xa0;&#xa0;&#xa0;-Dexec.args="-c /sun_checks.xml src/main/java"
-        </code></pre></div>
-      </div>
+        <div class="wrap-content">
+          <div class="wrapper"><pre class="prettyprint block-command"><code class="language-bash">
+           ./mvnw exec:java -Dexec.mainClass="com.puppycrawl.tools.checkstyle.Main"
+           -Dexec.args="-c /sun_checks.xml src/main/java"
+            </code></pre></div>
+        </div>
       <p>
         Run UI application for file :
       </p>
       <div class="wrap-content">
-        <div class="wrapper"><pre class="prettyprint"><code class="language-bash">
-          ./mvnw exec:java -Dexec.mainClass="com.puppycrawl.tools.checkstyle.gui.Main" -Dexec.args=\
-          &#xa0;&#xa0;&#xa0;&#xa0;"src/main/java/com/puppycrawl/tools/checkstyle/Checker.java"
+        <div class="wrapper"><pre class="prettyprint block-command"><code class="language-bash">
+          ./mvnw exec:java -Dexec.mainClass="com.puppycrawl.tools.checkstyle.gui.Main"
+          -Dexec.args="src/main/java/com/puppycrawl/tools/checkstyle/Checker.java"
         </code></pre></div>
       </div>
       <p>
@@ -2119,8 +2119,8 @@ Checkstyle ends with 2 errors.
       </p>
       <div class="wrap-content">
         <div class="wrapper"><pre class="prettyprint"><code class="language-bash">
-          ./mvnw clean package -Passembly,no-validations
-          java -jar target/checkstyle-X.X-SNAPSHOT-all.jar -c /sun_checks.xml MyClass.java
+./mvnw clean package -Passembly,no-validations
+java -jar target/checkstyle-X.X-SNAPSHOT-all.jar -c /sun_checks.xml MyClass.java
         </code></pre></div>
       </div>
     </section>
@@ -2174,9 +2174,9 @@ Checkstyle ends with 2 errors.
         </b>
       </p>
       <div class="wrap-content">
-        <div class="wrapper"><pre class="prettyprint"><code class="language-bash">
-          java -Dcheckstyle.cache.file=target/cachefile com.puppycrawl.tools.checkstyle.Main \
-          &#xa0;&#xa0;&#xa0;&#xa0;-c /sun_checks.xml Check.java
+        <div class="wrapper"><pre class="prettyprint block-command"><code class="language-bash">
+          java -Dcheckstyle.cache.file=target/cachefile com.puppycrawl.tools.checkstyle.Main
+          -c /sun_checks.xml Check.java
         </code></pre></div>
       </div>
 
@@ -2188,9 +2188,9 @@ Checkstyle ends with 2 errors.
         </b>
       </p>
       <div class="wrap-content">
-        <div class="wrapper"><pre class="prettyprint"><code class="language-bash">
-          java com.puppycrawl.tools.checkstyle.Main -c /sun_checks.xml \
-          &#xa0;&#xa0;&#xa0;&#xa0;-p myCheckstyle.properties Check.java
+        <div class="wrapper"><pre class="prettyprint block-command"><code class="language-bash">
+          java com.puppycrawl.tools.checkstyle.Main -c /sun_checks.xml
+          -p myCheckstyle.properties Check.java
         </code></pre></div>
       </div>
 
@@ -2202,9 +2202,9 @@ Checkstyle ends with 2 errors.
         </b>
       </p>
       <div class="wrap-content">
-        <div class="wrapper"><pre class="prettyprint"><code class="language-bash">
-          java com.puppycrawl.tools.checkstyle.Main -c /sun_checks.xml -f xml \
-          &#xa0;&#xa0;&#xa0;&#xa0;-o build/checkstyle_errors.xml Check.java
+        <div class="wrapper"><pre class="prettyprint block-command"><code class="language-bash">
+          java com.puppycrawl.tools.checkstyle.Main -c /sun_checks.xml -f xml
+          -o build/checkstyle_errors.xml Check.java
         </code></pre></div>
       </div>
 
@@ -2215,9 +2215,9 @@ Checkstyle ends with 2 errors.
         </b>
       </p>
       <div class="wrap-content">
-        <div class="wrapper"><pre class="prettyprint"><code class="language-bash">
-          java -classpath MyCustom.jar;checkstyle-${projectVersion}-all.jar \
-          &#xa0;&#xa0;&#xa0;&#xa0;com.puppycrawl.tools.checkstyle.Main -c config.xml Check.java
+        <div class="wrapper"><pre class="prettyprint block-command"><code class="language-bash">
+          java -classpath MyCustom.jar;checkstyle-${projectVersion}-all.jar
+          com.puppycrawl.tools.checkstyle.Main -c config.xml Check.java
         </code></pre></div>
       </div>
       <p>


### PR DESCRIPTION
Issue #18110:

Fixed wrapping issue by removing Unix \ line-wrap symbols and converting all commands to single lines. Browser/CSS now handles wrapping via  .wrap-content .prettyprint code styling. Added lineLength suppressions for cmdline.xml  to allow long single-line commands needed for proper browser wrapping.
