### PR TITLE
Issue #18171: Add support for module imports in RedundantImport

### DIFF
--- a/src/main/resources/com/puppycrawl/tools/checkstyle/meta/checks/imports/RedundantImportCheck.xml
+++ b/src/main/resources/com/puppycrawl/tools/checkstyle/meta/checks/imports/RedundantImportCheck.xml
@@ -9,8 +9,8 @@
  considered redundant if:
  &lt;/div&gt;
  &lt;ul&gt;
-   &lt;li&gt;It is a duplicate of another import. This is, when a class is imported
-   more than once.&lt;/li&gt;
+   &lt;li&gt;It is a duplicate of another import. This is, when a class or a module
+   is imported more than once.&lt;/li&gt;
    &lt;li&gt;The class non-statically imported is from the &lt;code&gt;java.lang&lt;/code&gt;
    package, e.g. importing &lt;code&gt;java.lang.String&lt;/code&gt;.&lt;/li&gt;
    &lt;li&gt;The class non-statically imported is from the same package as the

--- a/src/site/xdoc/checks/imports/redundantimport.xml
+++ b/src/site/xdoc/checks/imports/redundantimport.xml
@@ -14,8 +14,8 @@
           considered redundant if:
         </div>
         <ul>
-        <li>It is a duplicate of another import. This is, when a class is imported
-          more than once.</li>
+        <li>It is a duplicate of another import. This is, when a class or a module
+          is imported more than once.</li>
         <li>The class non-statically imported is from the <code>java.lang</code>
           package, e.g. importing <code>java.lang.String</code>.</li>
         <li>The class non-statically imported is from the same package as the
@@ -48,6 +48,17 @@ import java.util.Scanner;
 import java.util.Scanner; // violation 'Duplicate import to line 18 - java.util.Scanner'
 
 public class Example1{ }
+</code></pre></div>
+        <hr class="example-separator"/>
+        <p id="Example2-code">
+            Example:
+        </p>
+        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+import module java.base;
+import module java.logging;
+import module java.base; // violation 'Duplicate import to line 14 - java.base'
+
+public class Example2{ }
 </code></pre></div>
       </subsection>
 

--- a/src/site/xdoc/checks/imports/redundantimport.xml.template
+++ b/src/site/xdoc/checks/imports/redundantimport.xml.template
@@ -32,6 +32,15 @@
                  value="resources/com/puppycrawl/tools/checkstyle/checks/imports/redundantimport/Example1.java"/>
           <param name="type" value="code"/>
         </macro>
+        <hr class="example-separator"/>
+        <p id="Example2-code">
+            Example:
+        </p>
+        <macro name="example">
+          <param name="path"
+                 value="resources-noncompilable/com/puppycrawl/tools/checkstyle/checks/imports/redundantimport/Example2.java"/>
+          <param name="type" value="code"/>
+        </macro>
       </subsection>
 
       <subsection name="Example of Usage" id="RedundantImport_Example_of_Usage">

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/imports/RedundantImportCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/imports/RedundantImportCheckTest.java
@@ -51,6 +51,7 @@ public class RedundantImportCheckTest
             TokenTypes.IMPORT,
             TokenTypes.STATIC_IMPORT,
             TokenTypes.PACKAGE_DEF,
+            TokenTypes.MODULE_IMPORT,
         };
         assertWithMessage("Default required tokens are invalid")
             .that(checkObj.getRequiredTokens())
@@ -114,6 +115,7 @@ public class RedundantImportCheckTest
             TokenTypes.IMPORT,
             TokenTypes.STATIC_IMPORT,
             TokenTypes.PACKAGE_DEF,
+            TokenTypes.MODULE_IMPORT,
         };
 
         assertWithMessage("Default acceptable tokens are invalid")
@@ -134,5 +136,25 @@ public class RedundantImportCheckTest
             "10:1: " + getCheckMessage(MSG_LANG, "java.lang.String")
         );
         verifyWithInlineConfigParser(file1, file2, expectedFirstInput, expectedSecondInput);
+    }
+
+    @Test
+    public void testModuleImportBuiltInModules() throws Exception {
+        final String[] expected = {
+            "11:1: " + getCheckMessage(MSG_DUPLICATE, 10, "java.base"),
+            "13:1: " + getCheckMessage(MSG_DUPLICATE, 12, "java.logging"),
+        };
+        verifyWithInlineConfigParser(
+                getNonCompilablePath("InputRedundantImportBuiltInModules.java"), expected);
+    }
+
+    @Test
+    public void testModuleImportCustomModules() throws Exception {
+        final String[] expected = {
+            "11:1: " + getCheckMessage(MSG_DUPLICATE, 10, "moduleA"),
+            "13:1: " + getCheckMessage(MSG_DUPLICATE, 12, "moduleB"),
+        };
+        verifyWithInlineConfigParser(
+                getNonCompilablePath("InputRedundantImportCustomModules.java"), expected);
     }
 }

--- a/src/test/resources-noncompilable/com/puppycrawl/tools/checkstyle/checks/imports/redundantimport/InputRedundantImportBuiltInModules.java
+++ b/src/test/resources-noncompilable/com/puppycrawl/tools/checkstyle/checks/imports/redundantimport/InputRedundantImportBuiltInModules.java
@@ -1,0 +1,16 @@
+/*
+RedundantImport
+
+
+*/
+
+// non-compiled with javac: Compilable with Java25
+package com.puppycrawl.tools.checkstyle.checks.imports.redundantimport;
+
+import module java.base;
+import module java.base; // violation 'Duplicate import to line 10'
+import module java.logging;
+import module java.logging; // violation 'Duplicate import to line 12'
+
+class InputRedundantImportBuiltInModules {
+}

--- a/src/test/resources-noncompilable/com/puppycrawl/tools/checkstyle/checks/imports/redundantimport/InputRedundantImportCustomModules.java
+++ b/src/test/resources-noncompilable/com/puppycrawl/tools/checkstyle/checks/imports/redundantimport/InputRedundantImportCustomModules.java
@@ -1,0 +1,16 @@
+/*
+RedundantImport
+
+
+*/
+
+// non-compiled with javac: reference to non-existent modules moduleA and moduleB
+package com.puppycrawl.tools.checkstyle.checks.imports.redundantimport;
+
+import module moduleA;
+import module moduleA; // violation 'Duplicate import to line 10'
+import module moduleB;
+import module moduleB; // violation 'Duplicate import to line 12'
+
+class InputRedundantImportCustomModules {
+}

--- a/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/checks/imports/RedundantImportCheckExamplesTest.java
+++ b/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/checks/imports/RedundantImportCheckExamplesTest.java
@@ -44,4 +44,13 @@ public class RedundantImportCheckExamplesTest extends AbstractExamplesModuleTest
 
         verifyWithInlineConfigParser(getPath("Example1.java"), expected);
     }
+
+    @Test
+    public void testExample2() throws Exception {
+        final String[] expected = {
+            "16:1: " + getCheckMessage(MSG_DUPLICATE, 14, "java.base"),
+        };
+
+        verifyWithInlineConfigParser(getNonCompilablePath("Example2.java"), expected);
+    }
 }

--- a/src/xdocs-examples/resources-noncompilable/com/puppycrawl/tools/checkstyle/checks/imports/redundantimport/Example2.java
+++ b/src/xdocs-examples/resources-noncompilable/com/puppycrawl/tools/checkstyle/checks/imports/redundantimport/Example2.java
@@ -1,0 +1,20 @@
+/*xml
+<module name="Checker">
+  <module name="TreeWalker">
+    <module name="RedundantImport"/>
+  </module>
+</module>
+*/
+
+// non-compiled with javac: Compilable with Java25
+
+package com.puppycrawl.tools.checkstyle.checks.imports.redundantimport;
+
+// xdoc section -- start
+import module java.base;
+import module java.logging;
+import module java.base; // violation 'Duplicate import to line 14 - java.base'
+
+public class Example2{ }
+// xdoc section -- end
+


### PR DESCRIPTION
Resolves issue
- #18171

---

- Updated `RedundantImport` so that it finds redundant module imports (`import module ...`)
- Added 2 tests
- Updated documentation
- Added an example on the check website page