### PR TITLE
Issue #16360: Add comment explaining why some Xmllogger test cannot b…

### DIFF
--- a/src/test/java/com/puppycrawl/tools/checkstyle/XMLLoggerTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/XMLLoggerTest.java
@@ -399,6 +399,11 @@ public class XMLLoggerTest extends AbstractXmlTestSupport {
                 List.of(inputFileWithConfig, inputFileWithConfig));
     }
 
+    /**
+     * Cannot use verifyWithInlineConfigParserAndXmlLogger because this is a
+     * pure unit test that validates constructor error handling and exception
+     * messaging, which cannot be exercised through Checker execution.
+     */
     @Test
     public void testNullOutputStreamOptions() {
         try {
@@ -417,6 +422,11 @@ public class XMLLoggerTest extends AbstractXmlTestSupport {
         }
     }
 
+    /**
+     * Cannot use verifyWithInlineConfigParserAndXmlLogger because this test
+     * directly exercises XMLLogger lifecycle behavior (finishLocalSetup) and
+     * does not depend on Checker execution or XML output.
+     */
     @Test
     public void testFinishLocalSetup() {
         final XMLLogger logger = new XMLLogger(outStream, OutputStreamOptions.CLOSE);
@@ -429,6 +439,9 @@ public class XMLLoggerTest extends AbstractXmlTestSupport {
     }
 
     /**
+     * Cannot use verifyWithInlineConfigParserAndXmlLogger because this test
+     * verifies constructor wiring and internal state (closeStream flag),
+     * which are not exposed through the inline verifier.
      * We keep this test for 100% coverage. Until #12873.
      */
     @Test
@@ -442,6 +455,9 @@ public class XMLLoggerTest extends AbstractXmlTestSupport {
     }
 
     /**
+     * Cannot use verifyWithInlineConfigParserAndXmlLogger because this test
+     * verifies constructor wiring and internal state (closeStream flag),
+     * which are not exposed through the inline verifier.
      * We keep this test for 100% coverage. Until #12873.
      */
     @Test


### PR DESCRIPTION
Issue #16360:

Added comment explaining why some Xmllogger test cannot be updated to use verifyWithInlineConfigParserAndXmlLogger
