### PR TITLE
Issue #18070: resolve PMD warning during execution

### DIFF
--- a/config/pmd-main.xml
+++ b/config/pmd-main.xml
@@ -50,7 +50,7 @@
          value="//ClassDeclaration[@SimpleName='AutomaticBean']"/>
     </properties>
   </rule>
-  <rule ref="category/java/design.xml/AvoidCatchingGenericException">
+  <rule ref="category/java/errorprone.xml/AvoidCatchingGenericException">
     <properties>
       <!-- we allow catching Exception in certain cases to provide more details in wrapper -->
       <property name="violationSuppressXPath"

--- a/config/pmd.xml
+++ b/config/pmd.xml
@@ -312,7 +312,7 @@
     <!-- We use our ImportControl to control imports in packages and classes. -->
     <exclude name="LoosePackageCoupling"/>
   </rule>
-  <rule ref="category/java/design.xml/AvoidCatchingGenericException">
+  <rule ref="category/java/errorprone.xml/AvoidCatchingGenericException">
     <properties>
       <!-- Checker: There is no other way to deliver the filename that was under processing.
            See https://github.com/checkstyle/checkstyle/issues/2285


### PR DESCRIPTION
part of : #18070

targeting:
```
[WARNING] Warning at C:\projects\checkstyle\target\pmd\rulesets\001-pmd-main.xml:53:3
 51|     </properties>
 52|   </rule>
 53|   <rule ref="category/java/design.xml/AvoidCatchingGenericException">
       ^^^^^ Use Rule name category/java/errorprone.xml/AvoidCatchingGenericException instead of the deprecated Rule name category/java/design.xml/AvoidCatchingGenericException. PMD 8.0.0 will remove support for this deprecated Rule name usage.
 54|     <properties>
 55|       <!-- we allow catching Exception in certain cases to provide more details in wrapper -->
[WARNING] Warning at C:\projects\checkstyle\target\pmd\rulesets\001-pmd-main.xml:53:3
 51|     </properties>
 52|   </rule>
 53|   <rule ref="category/java/design.xml/AvoidCatchingGenericException">
       ^^^^^ Use Rule name category/java/errorprone.xml/AvoidCatchingGenericException instead of the deprecated Rule name category/java/design.xml/AvoidCatchingGenericException. PMD 8.0.0 will remove support for this deprecated Rule name usage.
 54|     <properties>
 55|       <!-- we allow catching Exception in certain cases to provide more details in wrapper -->

```