### PR TITLE
doc: clarify behavior of NewlineAtEndOfFileCheck regarding extra blan…

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/NewlineAtEndOfFileCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/NewlineAtEndOfFileCheck.java
@@ -76,6 +76,11 @@ import com.puppycrawl.tools.checkstyle.api.FileText;
  * This will check against the platform-specific default line separator.
  * </p>
  *
+ * <p>This check verifies only the presence of a single line separator at the end of the file.
+ * It does not report violations for multiple trailing blank lines
+ * or additional newline characters beyond the final separator.
+ * </p>
+ *
  * <p>
  * It is also possible to enforce the use of a specific line-separator across
  * platforms, with the {@code lineSeparator} property.

--- a/src/main/resources/com/puppycrawl/tools/checkstyle/meta/checks/NewlineAtEndOfFileCheck.xml
+++ b/src/main/resources/com/puppycrawl/tools/checkstyle/meta/checks/NewlineAtEndOfFileCheck.xml
@@ -50,6 +50,11 @@
  This will check against the platform-specific default line separator.
  &lt;/p&gt;
 
+ &lt;p&gt;This check verifies only the presence of a single line separator at the end of the file.
+ It does not report violations for multiple trailing blank lines
+ or additional newline characters beyond the final separator.
+ &lt;/p&gt;
+
  &lt;p&gt;
  It is also possible to enforce the use of a specific line-separator across
  platforms, with the &lt;code&gt;lineSeparator&lt;/code&gt; property.

--- a/src/site/xdoc/checks/misc/newlineatendoffile.xml
+++ b/src/site/xdoc/checks/misc/newlineatendoffile.xml
@@ -57,6 +57,11 @@ StaticMethodCandidateCheck.name = Static Method Candidate
           This will check against the platform-specific default line separator.
         </p>
 
+        <p>This check verifies only the presence of a single line separator at the end of the file.
+          It does not report violations for multiple trailing blank lines
+          or additional newline characters beyond the final separator.
+        </p>
+
         <p>
           It is also possible to enforce the use of a specific line-separator across
           platforms, with the <code>lineSeparator</code> property.


### PR DESCRIPTION
Issue : #18159 

This PR updates the documentation for NewlineAtEndOfFileCheck to clarify that the check requires only a single newline at the end of the file and does not report violations for multiple trailing blank lines.