### PR TITLE
Issue #18026: Resolve Pitest suppression for getExclusions

### DIFF
--- a/config/pitest-suppressions/pitest-main-suppressions.xml
+++ b/config/pitest-suppressions/pitest-main-suppressions.xml
@@ -8,13 +8,4 @@
     <description>removed call to com/puppycrawl/tools/checkstyle/Main::getOutputStreamOptions</description>
     <lineContent>getOutputStreamOptions(options.outputPath));</lineContent>
   </mutation>
-
-  <mutation unstable="false">
-    <sourceFile>Main.java</sourceFile>
-    <mutatedClass>com.puppycrawl.tools.checkstyle.Main$CliOptions</mutatedClass>
-    <mutatedMethod>getExclusions</mutatedMethod>
-    <mutator>org.pitest.mutationtest.engine.gregor.mutators.experimental.NakedReceiverMutator</mutator>
-    <description>replaced call to java/util/stream/Stream::map with receiver</description>
-    <lineContent>.map(Pattern::quote)</lineContent>
-  </mutation>
 </suppressedMutations>

--- a/src/test/java/com/puppycrawl/tools/checkstyle/MainTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/MainTest.java
@@ -1978,6 +1978,34 @@ public class MainTest {
                 .isInstanceOf(DefaultLogger.class);
     }
 
+    @Test
+    public void testExcludeOptionDirectoryWithPlusInName(@SysErr Capturable systemErr,
+                                                         @SysOut Capturable systemOut)
+            throws IOException {
+
+        final File specialDir = new File(temporaryFolder, "dir+name");
+        assertWithMessage("Directory must be created")
+                .that(specialDir.mkdirs())
+                .isTrue();
+
+        final File inputFile = new File(specialDir, "InputMainExclude.java");
+        Files.writeString(inputFile.toPath(),
+                "public class InputMainExclude { }" + System.lineSeparator());
+
+        final String dirPath = specialDir.getCanonicalPath();
+
+        assertMainReturnCode(-1, "-c", "/google_checks.xml", dirPath,
+                "-e", dirPath);
+
+        assertWithMessage("Unexpected output log")
+                .that(systemOut.getCapturedData())
+                .isEqualTo("Files to process must be specified, found 0."
+                        + System.lineSeparator());
+        assertWithMessage("Unexpected system error log")
+                .that(systemErr.getCapturedData())
+                .isEqualTo("");
+    }
+
     /**
      * Helper method to run {@link Main#main(String...)} and verify the exit code.
      * Uses {@link Mockito#mockStatic(Class)} to mock method {@link Runtime#exit(int)}


### PR DESCRIPTION
Issue: #18026

This PR kills a surviving Pitest mutation in `Main$CliOptions#getExclusions`.

### Problem

A surviving mutation (produced by `NakedReceiverMutator`) replaced the call to
`Stream::map`, effectively skipping `Pattern::quote` when building exclusion
patterns. This caused paths containing regex meta-characters to be handled
incorrectly.

### Solution

Added an input-based test that:

- creates a real directory containing a `+` character in its name
- runs Checkstyle through the CLI with the `-e` (exclude) option
- verifies that the directory is correctly excluded

### Result

Before this change, the mutation survived.  
After this change, Pitest reports the mutation as **KILLED**.
