### PR TITLE
Issue #18027: Resolve pitest for formatter count in CheckstyleAntTask

### DIFF
--- a/config/pitest-suppressions/pitest-ant-suppressions.xml
+++ b/config/pitest-suppressions/pitest-ant-suppressions.xml
@@ -66,15 +66,6 @@
   <mutation unstable="false">
     <sourceFile>CheckstyleAntTask.java</sourceFile>
     <mutatedClass>com.puppycrawl.tools.checkstyle.ant.CheckstyleAntTask</mutatedClass>
-    <mutatedMethod>getListeners</mutatedMethod>
-    <mutator>org.pitest.mutationtest.engine.gregor.mutators.NonVoidMethodCallMutator</mutator>
-    <description>removed call to java/util/List::size</description>
-    <lineContent>final int formatterCount = Math.max(1, formatters.size());</lineContent>
-  </mutation>
-
-  <mutation unstable="false">
-    <sourceFile>CheckstyleAntTask.java</sourceFile>
-    <mutatedClass>com.puppycrawl.tools.checkstyle.ant.CheckstyleAntTask</mutatedClass>
     <mutatedMethod>processFiles</mutatedMethod>
     <mutator>org.pitest.mutationtest.engine.gregor.mutators.NonVoidMethodCallMutator</mutator>
     <description>removed call to java/lang/String::valueOf</description>


### PR DESCRIPTION
Issue #18027:

Added test to kill mutant in CheckstyleAntTask.getListeners()

This PR adds a test case to kill a mutant that removes the call to formatters.size() in CheckstyleAntTask.getListeners() method.

**Test Implementation:**
- Added testMultipleFormattersProduceOutputs() method
- Creates two formatters with separate output files
- Verifies both formatters produce non-empty output files
- If the mutant is present (formatters.size() removed), formatterCount would be 1 instead of 2, causing only the first formatter to be processed and the second file to be missing/empty, causing the test to fail

**Helper Method:**
- Added createPlainFormatter() helper method for reusability