### PR TITLE
Issue #17882: Update INHERIT_DOC_INLINE_TAG of JavadocCommentTokenTypes to new AST format

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/api/JavadocCommentsTokenTypes.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/api/JavadocCommentsTokenTypes.java
@@ -683,6 +683,25 @@ public final class JavadocCommentsTokenTypes {
 
     /**
      * {@code {@inheritDoc}} inline tag.
+     *
+     * <p>This node models the inline {@code {@inheritDoc}} tag that instructs Javadoc
+     * to inherit documentation from the corresponding element in a parent class or interface.</p>
+     *
+     * <p><b>Example:</b></p>
+     * <pre>{@code * {@inheritDoc}}</pre>
+     *
+     * <b>Tree:</b>
+     * <pre>{@code
+     * |--LEADING_ASTERISK ->      *
+     * |--TEXT ->
+     * `--JAVADOC_INLINE_TAG -> JAVADOC_INLINE_TAG
+     *     `--INHERIT_DOC_INLINE_TAG -> INHERIT_DOC_INLINE_TAG
+     *         |--JAVADOC_INLINE_TAG_START -> { @
+     *         |--TAG_NAME -> inheritDoc
+     *         `--JAVADOC_INLINE_TAG_END -> }
+     * }</pre>
+     *
+     * @see #JAVADOC_INLINE_TAG
      */
     public static final int INHERIT_DOC_INLINE_TAG = JavadocCommentsLexer.INHERIT_DOC_INLINE_TAG;
 


### PR DESCRIPTION
Issue: #17882

Input File
```
public class Test1 {

    /**
     * {@inheritDoc}
     */
    public void test(){
    }
}
```

CLI Output

```
JAVADOC_CONTENT -> JAVADOC_CONTENT 
|--TEXT -> public class Test1 { 
|--NEWLINE -> \r\n 
|--NEWLINE -> \r\n 
|--TEXT ->     /** 
|--NEWLINE -> \r\n 
|--LEADING_ASTERISK ->      * 
|--TEXT ->   
|--JAVADOC_INLINE_TAG -> JAVADOC_INLINE_TAG 
|   `--INHERIT_DOC_INLINE_TAG -> INHERIT_DOC_INLINE_TAG 
|       |--JAVADOC_INLINE_TAG_START -> {@
|       |--TAG_NAME -> inheritDoc
|       `--JAVADOC_INLINE_TAG_END -> }
|--NEWLINE -> \r\n
|--LEADING_ASTERISK ->      *
|--TEXT -> /
|--NEWLINE -> \r\n
|--TEXT ->     public void test(){
|--NEWLINE -> \r\n
|--TEXT ->     }
|--NEWLINE -> \r\n
|--TEXT -> }
`--NEWLINE -> \r\n
```