### PR TITLE
Issue #18026: Resolve Pitest suppression for runCheckstyle in main.java

### DIFF
--- a/config/pitest-suppressions/pitest-main-suppressions.xml
+++ b/config/pitest-suppressions/pitest-main-suppressions.xml
@@ -1,11 +1,3 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <suppressedMutations>
-  <mutation unstable="false">
-    <sourceFile>Main.java</sourceFile>
-    <mutatedClass>com.puppycrawl.tools.checkstyle.Main</mutatedClass>
-    <mutatedMethod>runCheckstyle</mutatedMethod>
-    <mutator>org.pitest.mutationtest.engine.gregor.mutators.NonVoidMethodCallMutator</mutator>
-    <description>removed call to com/puppycrawl/tools/checkstyle/Main::getOutputStreamOptions</description>
-    <lineContent>getOutputStreamOptions(options.outputPath));</lineContent>
-  </mutation>
 </suppressedMutations>

--- a/config/spotbugs-exclude.xml
+++ b/config/spotbugs-exclude.xml
@@ -309,6 +309,9 @@
       <Class name="com.puppycrawl.tools.checkstyle.Checker"/>
       <Class name="com.puppycrawl.tools.checkstyle.checks.TranslationCheck"/>
       <Class name="com.puppycrawl.tools.checkstyle.filters.CsvFilterElement"/>
+      <Class name="com.puppycrawl.tools.checkstyle.XpathFileGeneratorAuditListener" />
+      <Class name=
+           "com.puppycrawl.tools.checkstyle.ChecksAndFilesSuppressionFileGeneratorAuditListener" />
     </Or>
     <Bug pattern="CT_CONSTRUCTOR_THROW"/>
   </Match>

--- a/src/main/java/com/puppycrawl/tools/checkstyle/ChecksAndFilesSuppressionFileGeneratorAuditListener.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/ChecksAndFilesSuppressionFileGeneratorAuditListener.java
@@ -70,9 +70,14 @@ public class ChecksAndFilesSuppressionFileGeneratorAuditListener
      *
      * @param out the output stream
      * @param outputStreamOptions if {@code CLOSE} stream should be closed in auditFinished()
+     * @throws IllegalArgumentException if outputStreamOptions is null.
      */
     public ChecksAndFilesSuppressionFileGeneratorAuditListener(OutputStream out,
                                            OutputStreamOptions outputStreamOptions) {
+        if (outputStreamOptions == null) {
+            throw new IllegalArgumentException("Parameter outputStreamOptions can not be null");
+        }
+
         writer = new PrintWriter(new OutputStreamWriter(out, StandardCharsets.UTF_8));
         closeStream = outputStreamOptions == OutputStreamOptions.CLOSE;
     }

--- a/src/main/java/com/puppycrawl/tools/checkstyle/XpathFileGeneratorAuditListener.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/XpathFileGeneratorAuditListener.java
@@ -56,9 +56,14 @@ public class XpathFileGeneratorAuditListener
      *
      * @param out the output stream
      * @param outputStreamOptions if {@code CLOSE} stream should be closed in auditFinished()
+     * @throws IllegalArgumentException if outputStreamOptions is null
      */
     public XpathFileGeneratorAuditListener(OutputStream out,
                                            OutputStreamOptions outputStreamOptions) {
+        if (outputStreamOptions == null) {
+            throw new IllegalArgumentException("Parameter outputStreamOptions can not be null");
+        }
+
         writer = new PrintWriter(new OutputStreamWriter(out, StandardCharsets.UTF_8));
         closeStream = outputStreamOptions == OutputStreamOptions.CLOSE;
     }

--- a/src/test/java/com/puppycrawl/tools/checkstyle/ChecksAndFilesSuppressionFileGeneratorAuditListenerTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/ChecksAndFilesSuppressionFileGeneratorAuditListenerTest.java
@@ -252,6 +252,26 @@ public class ChecksAndFilesSuppressionFileGeneratorAuditListenerTest {
             .isEmpty();
     }
 
+    @Test
+    public void testNullOutputStreamOptions() {
+        final OutputStream out = new ByteArrayOutputStream();
+        try {
+            final ChecksAndFilesSuppressionFileGeneratorAuditListener listener =
+                    new ChecksAndFilesSuppressionFileGeneratorAuditListener(out,
+                            null);
+            // assert required to calm down eclipse's 'The allocated object is never used' violation
+            assertWithMessage("Null instance")
+                    .that(listener)
+                    .isNotNull();
+            assertWithMessage("Exception was expected").fail();
+        }
+        catch (IllegalArgumentException exception) {
+            assertWithMessage("Invalid error message")
+                    .that(exception.getMessage())
+                    .isEqualTo("Parameter outputStreamOptions can not be null");
+        }
+    }
+
     private AuditEvent createAuditEvent(String fileName, int lineNumber, int columnNumber,
                                         Class<?> sourceClass) {
         final Violation violation =

--- a/src/test/java/com/puppycrawl/tools/checkstyle/XpathFileGeneratorAuditListenerTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/XpathFileGeneratorAuditListenerTest.java
@@ -269,6 +269,25 @@ public class XpathFileGeneratorAuditListenerTest {
             .isEqualTo(0);
     }
 
+    @Test
+    public void testNullOutputStreamOptions() {
+        final OutputStream out = new ByteArrayOutputStream();
+        try {
+            final XpathFileGeneratorAuditListener listener = new XpathFileGeneratorAuditListener(
+                    out, null);
+            // assert required to calm down eclipse's 'The allocated object is never used' violation
+            assertWithMessage("Null instance")
+                    .that(listener)
+                    .isNotNull();
+            assertWithMessage("Exception was expected").fail();
+        }
+        catch (IllegalArgumentException exception) {
+            assertWithMessage("Invalid error message")
+                    .that(exception.getMessage())
+                    .isEqualTo("Parameter outputStreamOptions can not be null");
+        }
+    }
+
     private AuditEvent createAuditEvent(String fileName, int lineNumber, int columnNumber,
                                         Class<?> sourceClass) {
         final Violation violation =


### PR DESCRIPTION
Issue #18026:

Kill Mutant: Removed call to `getOutputStreamOptions` in `Main.runCheckstyle()`

### Solution
Added null parameter validation in listener constructors:
- **`XpathFileGeneratorAuditListener`**: Throws `IllegalArgumentException` if `outputStreamOptions` is null
- **`ChecksAndFilesSuppressionFileGeneratorAuditListener`**: Throws `IllegalArgumentException` if `outputStreamOptions` is null

If ⁠ getOutputStreamOptions() ⁠ is removed, ⁠ null ⁠ is passed → ⁠ IllegalArgumentException ⁠ with clear message → test fails with expected exception and mutant is killed.

### Additional Changes
- Added SpotBugs suppression for `CT_CONSTRUCTOR_THROW` in listener constructors (null checks are intentional for mutation testing)
- Added tests `testNullOutputStreamOptions()` in both listener test classes to achieve 100% coverage

