### PR TITLE
Issue #18207: IllegalImport: new property illegalModules to cover module imports

### DIFF
--- a/config/checker-framework-suppressions/checker-nullness-optional-interning-suppressions.xml
+++ b/config/checker-framework-suppressions/checker-nullness-optional-interning-suppressions.xml
@@ -4619,7 +4619,7 @@
   <checkerFrameworkError unstable="false">
     <fileName>src/main/java/com/puppycrawl/tools/checkstyle/checks/imports/IllegalImportCheck.java</fileName>
     <specifier>initialization.fields.uninitialized</specifier>
-    <message>the constructor does not initialize fields: illegalPkgs, illegalClasses</message>
+    <message>the constructor does not initialize fields: illegalPkgs, illegalClasses, illegalModules</message>
     <lineContent>public IllegalImportCheck() {</lineContent>
   </checkerFrameworkError>
 

--- a/src/main/resources/com/puppycrawl/tools/checkstyle/meta/checks/imports/IllegalImportCheck.xml
+++ b/src/main/resources/com/puppycrawl/tools/checkstyle/meta/checks/imports/IllegalImportCheck.xml
@@ -5,7 +5,7 @@
              name="IllegalImport"
              parent="com.puppycrawl.tools.checkstyle.TreeWalker">
          <description>&lt;div&gt;
- Checks for imports from a set of illegal packages.
+ Checks for imports from a set of illegal packages and modules.
  &lt;/div&gt;
 
  &lt;p&gt;
@@ -22,6 +22,12 @@
  then list of class names will be interpreted as regular expressions.
  Note, all properties for match will be used.</description>
             </property>
+            <property default-value="" name="illegalModules" type="java.lang.String[]">
+               <description>Specify module names to reject, if &lt;b&gt;regexp&lt;/b&gt; property is not
+ set, checks if import equals module name. If &lt;b&gt;regexp&lt;/b&gt; property is set,
+ then list of module names will be interpreted as regular expressions.
+ Note, all properties for match will be used.</description>
+            </property>
             <property default-value="sun" name="illegalPkgs" type="java.lang.String[]">
                <description>Specify packages to reject, if &lt;b&gt;regexp&lt;/b&gt; property is not set,
  checks if import is the part of package. If &lt;b&gt;regexp&lt;/b&gt; property is set,
@@ -29,8 +35,8 @@
  Note, all properties for match will be used.</description>
             </property>
             <property default-value="false" name="regexp" type="boolean">
-               <description>Control whether the &lt;code&gt;illegalPkgs&lt;/code&gt; and &lt;code&gt;illegalClasses&lt;/code&gt;
- should be interpreted as regular expressions.</description>
+               <description>Control whether the &lt;code&gt;illegalPkgs&lt;/code&gt;, &lt;code&gt;illegalClasses&lt;/code&gt; and
+ &lt;code&gt;illegalModules&lt;/code&gt; should be interpreted as regular expressions.</description>
             </property>
          </properties>
          <message-keys>

--- a/src/site/xdoc/checks.xml
+++ b/src/site/xdoc/checks.xml
@@ -604,7 +604,7 @@
               </a>
             </td>
             <td>
-              Checks for imports from a set of illegal packages.
+              Checks for imports from a set of illegal packages and modules.
             </td>
           </tr>
           <tr>

--- a/src/site/xdoc/checks/imports/illegalimport.xml
+++ b/src/site/xdoc/checks/imports/illegalimport.xml
@@ -10,7 +10,7 @@
       <p>Since Checkstyle 3.0</p>
       <subsection name="Description" id="IllegalImport_Description">
         <div>
-          Checks for imports from a set of illegal packages.
+          Checks for imports from a set of illegal packages and modules.
         </div>
       </subsection>
 
@@ -42,6 +42,13 @@
               <td>7.8</td>
             </tr>
             <tr>
+              <td><a id="illegalModules"/><a href="#illegalModules">illegalModules</a></td>
+              <td>Specify module names to reject, if <b>regexp</b> property is not set, checks if import equals module name. If <b>regexp</b> property is set, then list of module names will be interpreted as regular expressions. Note, all properties for match will be used.</td>
+              <td><a href="../../property_types.html#String.5B.5D">String[]</a></td>
+              <td><code>{}</code></td>
+              <td>12.3.0</td>
+            </tr>
+            <tr>
               <td><a id="illegalPkgs"/><a href="#illegalPkgs">illegalPkgs</a></td>
               <td>Specify packages to reject, if <b>regexp</b> property is not set, checks if import is the part of package. If <b>regexp</b> property is set, then list of packages will be interpreted as regular expressions. Note, all properties for match will be used.</td>
               <td><a href="../../property_types.html#String.5B.5D">String[]</a></td>
@@ -50,7 +57,7 @@
             </tr>
             <tr>
               <td><a id="regexp"/><a href="#regexp">regexp</a></td>
-              <td>Control whether the <code>illegalPkgs</code> and <code>illegalClasses</code> should be interpreted as regular expressions.</td>
+              <td>Control whether the <code>illegalPkgs</code>, <code>illegalClasses</code> and <code>illegalModules</code> should be interpreted as regular expressions.</td>
               <td><a href="../../property_types.html#boolean">boolean</a></td>
               <td><code>false</code></td>
               <td>7.8</td>
@@ -223,6 +230,36 @@ import java.util.Date;
 import sun.misc.*; // violation, 'Illegal import'
 
 public class Example5 {}
+</code></pre></div>
+        <hr class="example-separator"/>
+        <p id="Example6-config">
+          To configure the check so that it rejects modules <code>java.base</code> and
+          <code>java.logging</code>:
+        </p>
+        <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
+&lt;module name="Checker"&gt;
+  &lt;module name="TreeWalker"&gt;
+    &lt;module name="IllegalImport"&gt;
+      &lt;property name="illegalModules" value="java.base, java.logging"/&gt;
+    &lt;/module&gt;
+  &lt;/module&gt;
+&lt;/module&gt;
+</code></pre></div>
+        <p id="Example6-code">
+          The following example shows module with two illegal module imports:
+          <ul>
+            <li><b>java.base</b>, <code>illegalModules</code> property contains this module</li>
+            <li><b>java.logging</b>, <code>illegalModules</code> property contains this module</li>
+            </ul>
+        </p>
+        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+import module java.base; // violation, 'Illegal import'
+import module java.xml;
+import module java.sql;
+import module java.logging; // violation, 'Illegal import'
+import module java.naming;
+
+public class Example6 {}
 </code></pre></div>
       </subsection>
 

--- a/src/site/xdoc/checks/imports/illegalimport.xml.template
+++ b/src/site/xdoc/checks/imports/illegalimport.xml.template
@@ -139,6 +139,28 @@
                  value="resources/com/puppycrawl/tools/checkstyle/checks/imports/illegalimport/Example5.java"/>
           <param name="type" value="code"/>
         </macro>
+        <hr class="example-separator"/>
+        <p id="Example6-config">
+          To configure the check so that it rejects modules <code>java.base</code> and
+          <code>java.logging</code>:
+        </p>
+        <macro name="example">
+          <param name="path"
+                 value="resources-noncompilable/com/puppycrawl/tools/checkstyle/checks/imports/illegalimport/Example6.java"/>
+          <param name="type" value="config"/>
+        </macro>
+        <p id="Example6-code">
+          The following example shows module with two illegal module imports:
+          <ul>
+            <li><b>java.base</b>, <code>illegalModules</code> property contains this module</li>
+            <li><b>java.logging</b>, <code>illegalModules</code> property contains this module</li>
+            </ul>
+        </p>
+        <macro name="example">
+          <param name="path"
+                 value="resources-noncompilable/com/puppycrawl/tools/checkstyle/checks/imports/illegalimport/Example6.java"/>
+          <param name="type" value="code"/>
+        </macro>
       </subsection>
 
       <subsection name="Example of Usage" id="IllegalImport_Example_of_Usage">

--- a/src/site/xdoc/checks/imports/index.xml
+++ b/src/site/xdoc/checks/imports/index.xml
@@ -47,7 +47,7 @@
               </a>
             </td>
             <td>
-              Checks for imports from a set of illegal packages.
+              Checks for imports from a set of illegal packages and modules.
             </td>
           </tr>
           <tr>

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/imports/IllegalImportCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/imports/IllegalImportCheckTest.java
@@ -37,7 +37,11 @@ public class IllegalImportCheckTest extends AbstractModuleTestSupport {
     @Test
     public void testGetRequiredTokens() {
         final IllegalImportCheck checkObj = new IllegalImportCheck();
-        final int[] expected = {TokenTypes.IMPORT, TokenTypes.STATIC_IMPORT};
+        final int[] expected = {
+            TokenTypes.IMPORT,
+            TokenTypes.STATIC_IMPORT,
+            TokenTypes.MODULE_IMPORT,
+        };
         assertWithMessage("Default required tokens are invalid")
             .that(checkObj.getRequiredTokens())
             .isEqualTo(expected);
@@ -47,9 +51,9 @@ public class IllegalImportCheckTest extends AbstractModuleTestSupport {
     public void testWithSupplied()
             throws Exception {
         final String[] expected = {
-            "12:1: " + getCheckMessage(MSG_KEY, "java.io.*"),
-            "26:1: " + getCheckMessage(MSG_KEY, "java.io.File.listRoots"),
-            "30:1: " + getCheckMessage(MSG_KEY, "java.io.File.createTempFile"),
+            "13:1: " + getCheckMessage(MSG_KEY, "java.io.*"),
+            "27:1: " + getCheckMessage(MSG_KEY, "java.io.File.listRoots"),
+            "31:1: " + getCheckMessage(MSG_KEY, "java.io.File.createTempFile"),
         };
         verifyWithInlineConfigParser(
                 getPath("InputIllegalImportDefault1.java"), expected);
@@ -67,7 +71,7 @@ public class IllegalImportCheckTest extends AbstractModuleTestSupport {
     public void testCustomSunPackageWithRegexp()
             throws Exception {
         final String[] expected = {
-            "17:1: " + getCheckMessage(MSG_KEY, "sun.reflect.*"),
+            "18:1: " + getCheckMessage(MSG_KEY, "sun.reflect.*"),
         };
         verifyWithInlineConfigParser(
                 getNonCompilablePath("InputIllegalImportDefault.java"), expected);
@@ -78,7 +82,11 @@ public class IllegalImportCheckTest extends AbstractModuleTestSupport {
         final IllegalImportCheck testCheckObject =
                 new IllegalImportCheck();
         final int[] actual = testCheckObject.getAcceptableTokens();
-        final int[] expected = {TokenTypes.IMPORT, TokenTypes.STATIC_IMPORT};
+        final int[] expected = {
+            TokenTypes.IMPORT,
+            TokenTypes.STATIC_IMPORT,
+            TokenTypes.MODULE_IMPORT,
+        };
 
         assertWithMessage("Default acceptable tokens are invalid")
             .that(actual)
@@ -89,9 +97,9 @@ public class IllegalImportCheckTest extends AbstractModuleTestSupport {
     public void testIllegalClasses()
             throws Exception {
         final String[] expected = {
-            "14:1: " + getCheckMessage(MSG_KEY, "java.sql.Connection"),
-            "18:1: " + getCheckMessage(MSG_KEY, "org.junit.jupiter.api.*"),
-            "31:1: " + getCheckMessage(MSG_KEY, "org.junit.jupiter.api.*"),
+            "15:1: " + getCheckMessage(MSG_KEY, "java.sql.Connection"),
+            "19:1: " + getCheckMessage(MSG_KEY, "org.junit.jupiter.api.*"),
+            "32:1: " + getCheckMessage(MSG_KEY, "org.junit.jupiter.api.*"),
         };
         verifyWithInlineConfigParser(
                 getPath("InputIllegalImportDefault3.java"), expected);
@@ -101,9 +109,9 @@ public class IllegalImportCheckTest extends AbstractModuleTestSupport {
     public void testIllegalClassesStarImport()
             throws Exception {
         final String[] expected = {
-            "12:1: " + getCheckMessage(MSG_KEY, "java.io.*"),
-            "18:1: " + getCheckMessage(MSG_KEY, "org.junit.jupiter.api.*"),
-            "31:1: " + getCheckMessage(MSG_KEY, "org.junit.jupiter.api.*"),
+            "13:1: " + getCheckMessage(MSG_KEY, "java.io.*"),
+            "19:1: " + getCheckMessage(MSG_KEY, "org.junit.jupiter.api.*"),
+            "32:1: " + getCheckMessage(MSG_KEY, "org.junit.jupiter.api.*"),
         };
         verifyWithInlineConfigParser(
                 getPath("InputIllegalImportDefault4.java"), expected);
@@ -113,13 +121,13 @@ public class IllegalImportCheckTest extends AbstractModuleTestSupport {
     public void testIllegalPackagesRegularExpression()
             throws Exception {
         final String[] expected = {
-            "15:1: " + getCheckMessage(MSG_KEY, "java.util.List"),
             "16:1: " + getCheckMessage(MSG_KEY, "java.util.List"),
-            "19:1: " + getCheckMessage(MSG_KEY, "java.util.Enumeration"),
-            "20:1: " + getCheckMessage(MSG_KEY, "java.util.Arrays"),
-            "37:1: " + getCheckMessage(MSG_KEY, "java.util.Date"),
-            "38:1: " + getCheckMessage(MSG_KEY, "java.util.Calendar"),
-            "39:1: " + getCheckMessage(MSG_KEY, "java.util.BitSet"),
+            "17:1: " + getCheckMessage(MSG_KEY, "java.util.List"),
+            "20:1: " + getCheckMessage(MSG_KEY, "java.util.Enumeration"),
+            "21:1: " + getCheckMessage(MSG_KEY, "java.util.Arrays"),
+            "38:1: " + getCheckMessage(MSG_KEY, "java.util.Date"),
+            "39:1: " + getCheckMessage(MSG_KEY, "java.util.Calendar"),
+            "40:1: " + getCheckMessage(MSG_KEY, "java.util.BitSet"),
         };
         verifyWithInlineConfigParser(
                 getPath("InputIllegalImportDefault5.java"), expected);
@@ -129,9 +137,9 @@ public class IllegalImportCheckTest extends AbstractModuleTestSupport {
     public void testIllegalClassesRegularExpression()
             throws Exception {
         final String[] expected = {
-            "15:1: " + getCheckMessage(MSG_KEY, "java.util.List"),
             "16:1: " + getCheckMessage(MSG_KEY, "java.util.List"),
-            "20:1: " + getCheckMessage(MSG_KEY, "java.util.Arrays"),
+            "17:1: " + getCheckMessage(MSG_KEY, "java.util.List"),
+            "21:1: " + getCheckMessage(MSG_KEY, "java.util.Arrays"),
         };
         verifyWithInlineConfigParser(
                 getPath("InputIllegalImportDefault6.java"), expected);
@@ -141,20 +149,43 @@ public class IllegalImportCheckTest extends AbstractModuleTestSupport {
     public void testIllegalPackagesAndClassesRegularExpression()
             throws Exception {
         final String[] expected = {
-            "15:1: " + getCheckMessage(MSG_KEY, "java.util.List"),
             "16:1: " + getCheckMessage(MSG_KEY, "java.util.List"),
-            "19:1: " + getCheckMessage(MSG_KEY, "java.util.Enumeration"),
-            "20:1: " + getCheckMessage(MSG_KEY, "java.util.Arrays"),
-            "33:1: " + getCheckMessage(MSG_KEY, "java.awt.Component"),
-            "34:1: " + getCheckMessage(MSG_KEY, "java.awt.Graphics2D"),
-            "35:1: " + getCheckMessage(MSG_KEY, "java.awt.HeadlessException"),
-            "36:1: " + getCheckMessage(MSG_KEY, "java.awt.Label"),
-            "37:1: " + getCheckMessage(MSG_KEY, "java.util.Date"),
-            "38:1: " + getCheckMessage(MSG_KEY, "java.util.Calendar"),
-            "39:1: " + getCheckMessage(MSG_KEY, "java.util.BitSet"),
+            "17:1: " + getCheckMessage(MSG_KEY, "java.util.List"),
+            "20:1: " + getCheckMessage(MSG_KEY, "java.util.Enumeration"),
+            "21:1: " + getCheckMessage(MSG_KEY, "java.util.Arrays"),
+            "34:1: " + getCheckMessage(MSG_KEY, "java.awt.Component"),
+            "35:1: " + getCheckMessage(MSG_KEY, "java.awt.Graphics2D"),
+            "36:1: " + getCheckMessage(MSG_KEY, "java.awt.HeadlessException"),
+            "37:1: " + getCheckMessage(MSG_KEY, "java.awt.Label"),
+            "38:1: " + getCheckMessage(MSG_KEY, "java.util.Date"),
+            "39:1: " + getCheckMessage(MSG_KEY, "java.util.Calendar"),
+            "40:1: " + getCheckMessage(MSG_KEY, "java.util.BitSet"),
         };
         verifyWithInlineConfigParser(
                 getPath("InputIllegalImportDefault7.java"), expected);
+    }
+
+    @Test
+    public void testIllegalModulesNoRegex() throws Exception {
+        final String[] expected = {
+            "14:1: " + getCheckMessage(MSG_KEY, "java.base"),
+            "17:1: " + getCheckMessage(MSG_KEY, "java.logging"),
+            "20:1: " + getCheckMessage(MSG_KEY, "java.sql.Connection"),
+        };
+        verifyWithInlineConfigParser(
+                getNonCompilablePath("InputIllegalImportModuleNoRegex.java"), expected);
+    }
+
+    @Test
+    public void testIllegalModulesWithRegex() throws Exception {
+        final String[] expected = {
+            "14:1: " + getCheckMessage(MSG_KEY, "java.base"),
+            "17:1: " + getCheckMessage(MSG_KEY, "java.logging"),
+            "20:1: " + getCheckMessage(MSG_KEY, "java.sql.Connection"),
+            "21:1: " + getCheckMessage(MSG_KEY, "java.sql.Driver"),
+        };
+        verifyWithInlineConfigParser(
+                getNonCompilablePath("InputIllegalImportModuleWithRegex.java"), expected);
     }
 
 }

--- a/src/test/resources-noncompilable/com/puppycrawl/tools/checkstyle/checks/imports/illegalimport/InputIllegalImportDefault.java
+++ b/src/test/resources-noncompilable/com/puppycrawl/tools/checkstyle/checks/imports/illegalimport/InputIllegalImportDefault.java
@@ -2,6 +2,7 @@
 IllegalImport
 illegalPkgs = sun.reflect
 illegalClasses = (default)
+illegalModules = (default)
 regexp = true
 
 

--- a/src/test/resources-noncompilable/com/puppycrawl/tools/checkstyle/checks/imports/illegalimport/InputIllegalImportModuleNoRegex.java
+++ b/src/test/resources-noncompilable/com/puppycrawl/tools/checkstyle/checks/imports/illegalimport/InputIllegalImportModuleNoRegex.java
@@ -1,0 +1,25 @@
+/*
+IllegalImport
+illegalPkgs = (default)sun
+illegalClasses = java.sql.Connection
+illegalModules = java.base,java.logging
+regexp = (default)false
+
+
+*/
+
+// non-compiled with javac: Compilable with Java25
+package com.puppycrawl.tools.checkstyle.checks.imports.illegalimport;
+
+import module java.base; // violation 'Illegal import - java.base'
+import module java.xml;
+import module java.sql;
+import module java.logging; // violation 'Illegal import - java.logging'
+import module java.naming;
+
+import java.sql.Connection; // violation 'Illegal import - java.sql.Connection'
+import java.sql.Driver;
+import java.util.List;
+import java.lang.*;
+
+class InputIllegalImportModuleNoRegex {}

--- a/src/test/resources-noncompilable/com/puppycrawl/tools/checkstyle/checks/imports/illegalimport/InputIllegalImportModuleWithRegex.java
+++ b/src/test/resources-noncompilable/com/puppycrawl/tools/checkstyle/checks/imports/illegalimport/InputIllegalImportModuleWithRegex.java
@@ -1,0 +1,25 @@
+/*
+IllegalImport
+illegalPkgs = (default)sun
+illegalClasses = ^java\.sql\..*$
+illegalModules = ^java\.(base|logging)$
+regexp = true
+
+
+*/
+
+// non-compiled with javac: Compilable with Java25
+package com.puppycrawl.tools.checkstyle.checks.imports.illegalimport;
+
+import module java.base; // violation 'Illegal import - java.base'
+import module java.xml;
+import module java.sql;
+import module java.logging; // violation 'Illegal import - java.logging'
+import module java.naming;
+
+import java.sql.Connection; // violation 'Illegal import - java.sql.Connection'
+import java.sql.Driver; // violation 'Illegal import - java.sql.Driver'
+import java.util.List;
+import java.lang.*;
+
+class InputIllegalImportModuleWithRegex {}

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/imports/illegalimport/InputIllegalImportDefault1.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/imports/illegalimport/InputIllegalImportDefault1.java
@@ -2,6 +2,7 @@
 IllegalImport
 illegalPkgs = java.io
 illegalClasses = (default)
+illegalModules = (default)
 regexp = (default)false
 
 

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/imports/illegalimport/InputIllegalImportDefault2.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/imports/illegalimport/InputIllegalImportDefault2.java
@@ -2,6 +2,7 @@
 IllegalImport
 illegalPkgs = (default)sun
 illegalClasses = (default)
+illegalModules = (default)
 regexp = (default)false
 
 

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/imports/illegalimport/InputIllegalImportDefault3.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/imports/illegalimport/InputIllegalImportDefault3.java
@@ -2,6 +2,7 @@
 IllegalImport
 illegalPkgs = org.junit.jupiter.api
 illegalClasses = java.sql.Connection
+illegalModules = (default)
 regexp = (default)false
 
 

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/imports/illegalimport/InputIllegalImportDefault4.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/imports/illegalimport/InputIllegalImportDefault4.java
@@ -2,6 +2,7 @@
 IllegalImport
 illegalPkgs = org.junit.jupiter.api
 illegalClasses = java.io.*
+illegalModules = (default)
 regexp = (default)false
 
 

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/imports/illegalimport/InputIllegalImportDefault5.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/imports/illegalimport/InputIllegalImportDefault5.java
@@ -2,6 +2,7 @@
 IllegalImport
 illegalPkgs = java\\.util
 illegalClasses = (default)
+illegalModules = (default)
 regexp = true
 
 

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/imports/illegalimport/InputIllegalImportDefault6.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/imports/illegalimport/InputIllegalImportDefault6.java
@@ -2,6 +2,7 @@
 IllegalImport
 illegalPkgs = (default)sun
 illegalClasses = ^java\\.util\\.(List|Arrays)
+illegalModules = (default)
 regexp = true
 
 

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/imports/illegalimport/InputIllegalImportDefault7.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/imports/illegalimport/InputIllegalImportDefault7.java
@@ -2,6 +2,7 @@
 IllegalImport
 illegalPkgs = java\\.util
 illegalClasses = ^java\\.awt\\..*
+illegalModules = (default)
 regexp = true
 
 

--- a/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/checks/imports/IllegalImportCheckExamplesTest.java
+++ b/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/checks/imports/IllegalImportCheckExamplesTest.java
@@ -96,4 +96,14 @@ public class IllegalImportCheckExamplesTest extends AbstractExamplesModuleTestSu
 
         verifyWithInlineConfigParser(getPath("Example5.java"), expected);
     }
+
+    @Test
+    public void testExample6() throws Exception {
+        final String[] expected = {
+            "15:1: " + getCheckMessage(IllegalImportCheck.MSG_KEY, "java.base"),
+            "18:1: " + getCheckMessage(IllegalImportCheck.MSG_KEY, "java.logging"),
+        };
+
+        verifyWithInlineConfigParser(getNonCompilablePath("Example6.java"), expected);
+    }
 }

--- a/src/xdocs-examples/resources-noncompilable/com/puppycrawl/tools/checkstyle/checks/imports/illegalimport/Example6.java
+++ b/src/xdocs-examples/resources-noncompilable/com/puppycrawl/tools/checkstyle/checks/imports/illegalimport/Example6.java
@@ -1,0 +1,22 @@
+/*xml
+<module name="Checker">
+  <module name="TreeWalker">
+    <module name="IllegalImport">
+      <property name="illegalModules" value="java.base, java.logging"/>
+    </module>
+  </module>
+</module>
+*/
+
+// non-compiled with javac: Compilable with Java25
+package com.puppycrawl.tools.checkstyle.checks.imports.illegalimport;
+
+// xdoc section -- start
+import module java.base; // violation, 'Illegal import'
+import module java.xml;
+import module java.sql;
+import module java.logging; // violation, 'Illegal import'
+import module java.naming;
+
+public class Example6 {}
+// xdoc section -- end


### PR DESCRIPTION
Resolves issue
- #18207 

---
- Added new property `illegalModules` to `IllegalImport` check. The property behaves the same way as the already existing properties `illegalClasses` and `illegalPkgs`.
- Added 2 unit tests
- Added `illegalModules = (default)` to existing tests' configuration
   - Updated expected violation lines by adding `1`
- Added 1 website example
    - <img width="666" height="549" alt="image" src="https://github.com/user-attachments/assets/8c96de82-c224-464f-8485-8e29e80581d2" />

---

### Diff regression configuration
#### Base
```xml
<module name="IllegalImport"/>
```
Diff Regression config: https://raw.githubusercontent.com/checkstyle/test-configs/refs/heads/main/IllegalImport/Example1/config.xml
#### Patch
```xml
<module name="IllegalImport">
    <property name="illegalModules" value="java.base"/>
</module>
```
Diff Regression patch config: https://gist.githubusercontent.com/stoyanK7/0745bc19e0625706ed273c773a403d0e/raw/3120d03035ba196872db30a8330803c789244e86/config.xml