### PR TITLE
Update AT_SIGN of JavadocCommentsTokenTypes to new AST format

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/api/JavadocCommentsTokenTypes.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/api/JavadocCommentsTokenTypes.java
@@ -70,6 +70,32 @@ public final class JavadocCommentsTokenTypes {
 
     /**
      * At-sign {@code @} that starts a block tag.
+     *
+     * <p><b>Example:</b></p>
+     * <pre>{@code * @param value The parameter of method.}</pre>
+     *
+     * <b>Tree:</b>
+     * <pre>{@code
+     * JAVADOC_BLOCK_TAG -> JAVADOC_BLOCK_TAG 
+     * `--PARAM_BLOCK_TAG -> PARAM_BLOCK_TAG 
+     *     |--AT_SIGN -> @ 
+     *     |--TAG_NAME -> param 
+     *     |--TEXT ->   
+     *     |--PARAMETER_NAME -> value 
+     *     `--DESCRIPTION -> DESCRIPTION 
+     *         |--TEXT ->  The parameter of method. 
+     *         |--NEWLINE -> \n 
+     *         |--LEADING_ASTERISK ->  * 
+     *         |--TEXT -> / 
+     *         |--NEWLINE -> \n 
+     *         |--TEXT -> public class Test { 
+     *         |--NEWLINE -> \n 
+     *         |--TEXT ->     public void m(int value) {} 
+     *         |--NEWLINE -> \n 
+     *         `--TEXT -> } 
+     * }</pre>
+     *
+     * @see #JAVADOC_BLOCK_TAG
      */
     public static final int AT_SIGN = JavadocCommentsLexer.AT_SIGN;
 


### PR DESCRIPTION
Fixes: #17882

This PR updates the Javadoc comment for the `AT_SIGN` token in
`JavadocCommentsTokenTypes.java` to match the new AST print format
generated by the latest Checkstyle snapshot.
