### PR TITLE
Issue: #18221: infra: skip CommitValidationTest if .git directory is missing

### DIFF
--- a/src/test/java/com/puppycrawl/tools/checkstyle/internal/CommitValidationTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/internal/CommitValidationTest.java
@@ -21,6 +21,7 @@ package com.puppycrawl.tools.checkstyle.internal;
 
 import static com.google.common.truth.Truth.assertWithMessage;
 
+import java.io.File;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -39,6 +40,7 @@ import org.eclipse.jgit.lib.Repository;
 import org.eclipse.jgit.revwalk.RevCommit;
 import org.eclipse.jgit.revwalk.RevWalk;
 import org.eclipse.jgit.storage.file.FileRepositoryBuilder;
+import org.junit.jupiter.api.Assumptions;
 import org.junit.jupiter.api.Test;
 
 /**
@@ -254,6 +256,8 @@ public class CommitValidationTest {
     }
 
     private static List<RevCommit> getCommitsToCheck() throws Exception {
+        Assumptions.assumeTrue(new File(".git").exists(),
+            "Project is not a git repository (likely a zip download), skipping commit validation");
         final List<RevCommit> commits;
         try (Repository repo = new FileRepositoryBuilder().findGitDir().build()) {
             final RevCommitsPair revCommitsPair = resolveRevCommitsPair(repo);


### PR DESCRIPTION
Issue: #[18221](https://github.com/checkstyle/checkstyle/issues/18221)

## Description
Modified file `CommitValidationTest.java` to skip execution if the `.git` directory is not present.

## Rationale
Currently, the build fails with an `IllegalArgumentException` in `CommitValidationTest` when building from a source distribution (ZIP download, since it doesn't have the .git folder). The change done simply used JUnit's `Assumptions.assumeTrue` to check for the existence of the `.git` folder before attempting to access the repository, allowing the build to proceed by skipping this specific test when working with non-git environment 

<img width="1342" height="243" alt="Screenshot From 2025-12-02 09-34-38" src="https://github.com/user-attachments/assets/a1348842-30de-438c-891d-3fba0a193d7c" />
