### PR TITLE
Issue #11166: Remove usage of getFileContents() from AvoidEscapedUnicodeCharactersChecks

### DIFF
--- a/config/checker-framework-suppressions/checker-nullness-optional-interning-suppressions.xml
+++ b/config/checker-framework-suppressions/checker-nullness-optional-interning-suppressions.xml
@@ -1410,20 +1410,6 @@
   </checkerFrameworkError>
 
   <checkerFrameworkError unstable="false">
-    <fileName>src/main/java/com/puppycrawl/tools/checkstyle/checks/AvoidEscapedUnicodeCharactersCheck.java</fileName>
-    <specifier>initialization.field.uninitialized</specifier>
-    <message>the default constructor does not initialize field blockComments</message>
-    <lineContent>private Map&lt;Integer, List&lt;TextBlock&gt;&gt; blockComments;</lineContent>
-  </checkerFrameworkError>
-
-  <checkerFrameworkError unstable="false">
-    <fileName>src/main/java/com/puppycrawl/tools/checkstyle/checks/AvoidEscapedUnicodeCharactersCheck.java</fileName>
-    <specifier>initialization.field.uninitialized</specifier>
-    <message>the default constructor does not initialize field singlelineComments</message>
-    <lineContent>private Map&lt;Integer, TextBlock&gt; singlelineComments;</lineContent>
-  </checkerFrameworkError>
-
-  <checkerFrameworkError unstable="false">
     <fileName>src/main/java/com/puppycrawl/tools/checkstyle/checks/DescendantTokenCheck.java</fileName>
     <specifier>initialization.field.uninitialized</specifier>
     <message>the default constructor does not initialize field maximumMessage</message>

--- a/config/suppressions.xml
+++ b/config/suppressions.xml
@@ -127,7 +127,6 @@
   <suppress id="noUsageOfGetFileContentsMethod" files="MissingJavadocTypeCheck.java"/>
   <suppress id="noUsageOfGetFileContentsMethod" files="RegexpCheck.java"/>
   <suppress id="noUsageOfGetFileContentsMethod" files="RegexpSinglelineJavaCheck.java"/>
-  <suppress id="noUsageOfGetFileContentsMethod" files="AvoidEscapedUnicodeCharactersCheck.java"/>
 
   <!-- until https://github.com/checkstyle/checkstyle/issues/5234 -->
   <suppress id="MatchXPathBranchContains" files="[\\/]DetailAstImplTest.java"/>

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/AvoidEscapedUnicodeCharactersCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/AvoidEscapedUnicodeCharactersCheck.java
@@ -19,7 +19,8 @@
 
 package com.puppycrawl.tools.checkstyle.checks;
 
-import java.util.Arrays;
+import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.regex.Matcher;
@@ -28,10 +29,8 @@ import java.util.regex.Pattern;
 import com.puppycrawl.tools.checkstyle.FileStatefulCheck;
 import com.puppycrawl.tools.checkstyle.api.AbstractCheck;
 import com.puppycrawl.tools.checkstyle.api.DetailAST;
-import com.puppycrawl.tools.checkstyle.api.TextBlock;
 import com.puppycrawl.tools.checkstyle.api.TokenTypes;
 import com.puppycrawl.tools.checkstyle.utils.CheckUtil;
-import com.puppycrawl.tools.checkstyle.utils.CodePointUtil;
 
 /**
  * <div>
@@ -174,10 +173,12 @@ public class AvoidEscapedUnicodeCharactersCheck
             + "|\\\\u[fF]{3}[bB]"
             + "|\\\\u[fF]{4}");
 
-    /** Cpp style comments. */
-    private Map<Integer, TextBlock> singlelineComments;
-    /** C style comments. */
-    private Map<Integer, List<TextBlock>> blockComments;
+    /**
+     * Map of Pending Violations.
+     * Key: Line number of the violation.
+     * Value: List of literal AST nodes on that line pending validation.
+     */
+    private final Map<Integer, List<DetailAST>> pendingViolations = new HashMap<>();
 
     /** Allow use escapes for non-printable, control characters. */
     private boolean allowEscapesForControlCharacters;
@@ -247,30 +248,90 @@ public class AvoidEscapedUnicodeCharactersCheck
             TokenTypes.STRING_LITERAL,
             TokenTypes.CHAR_LITERAL,
             TokenTypes.TEXT_BLOCK_CONTENT,
+            TokenTypes.SINGLE_LINE_COMMENT,
+            TokenTypes.BLOCK_COMMENT_BEGIN,
         };
     }
 
-    // suppress deprecation until https://github.com/checkstyle/checkstyle/issues/11166
     @Override
-    @SuppressWarnings("deprecation")
+    public boolean isCommentNodesRequired() {
+        return true;
+    }
+
+    @Override
     public void beginTree(DetailAST rootAST) {
-        singlelineComments = getFileContents().getSingleLineComments();
-        blockComments = getFileContents().getBlockComments();
+        pendingViolations.clear();
     }
 
     @Override
     public void visitToken(DetailAST ast) {
+        if (ast.getType() == TokenTypes.SINGLE_LINE_COMMENT
+                || ast.getType() == TokenTypes.BLOCK_COMMENT_BEGIN) {
+            checkComment(ast);
+        }
+        else {
+            checkLiteral(ast);
+        }
+    }
+
+    @Override
+    public void finishTree(DetailAST rootAST) {
+        for (List<DetailAST> asts : pendingViolations.values()) {
+            for (DetailAST ast : asts) {
+                log(ast, MSG_KEY);
+            }
+        }
+    }
+
+    /**
+     * Checks if the literal has Unicode char and should be reported.
+     * If violation is found, it is added to pendingViolations.
+     *
+     * @param ast literal token.
+     */
+    private void checkLiteral(DetailAST ast) {
         final String literal =
             CheckUtil.stripIndentAndInitialNewLineFromTextBlock(ast.getText());
 
-        if (hasUnicodeChar(literal) && !(allowByTailComment && hasTrailComment(ast)
-                || isAllCharactersEscaped(literal)
+        if (hasUnicodeChar(literal) && !(isAllCharactersEscaped(literal)
                 || allowEscapesForControlCharacters
                         && isOnlyUnicodeValidChars(literal, UNICODE_CONTROL)
                 || allowNonPrintableEscapes
                         && isOnlyUnicodeValidChars(literal, NON_PRINTABLE_CHARS))) {
-            log(ast, MSG_KEY);
+
+            if (allowByTailComment) {
+                int lineNo = ast.getLineNo();
+                if (ast.getType() == TokenTypes.TEXT_BLOCK_CONTENT) {
+                    lineNo = ast.getNextSibling().getLineNo();
+                }
+                pendingViolations.computeIfAbsent(lineNo, key -> new ArrayList<>()).add(ast);
+            }
+            else {
+                log(ast, MSG_KEY);
+            }
         }
+    }
+
+    /**
+     * Checks if a comment clears any pending violations on the same line.
+     *
+     * @param comment comment token.
+     */
+    private void checkComment(DetailAST comment) {
+        if (isTrailingComment(comment)) {
+            pendingViolations.remove(comment.getLineNo());
+        }
+    }
+
+    /**
+     * Checks if a comment is trailing (has no code after it on the same line).
+     *
+     * @param commentNode the comment AST node
+     * @return true if it is trailing
+     */
+    private static boolean isTrailingComment(DetailAST commentNode) {
+        final DetailAST nextSibling = commentNode.getNextSibling();
+        return nextSibling == null || nextSibling.getLineNo() != commentNode.getLineNo();
     }
 
     /**
@@ -301,48 +362,6 @@ public class AvoidEscapedUnicodeCharactersCheck
     }
 
     /**
-     * Check if trail comment is present after ast token.
-     *
-     * @param ast current token.
-     * @return true if trail comment is present after ast token.
-     */
-    private boolean hasTrailComment(DetailAST ast) {
-        int lineNo = ast.getLineNo();
-
-        // Since the trailing comment in the case of text blocks must follow the """ delimiter,
-        // we need to look for it after TEXT_BLOCK_LITERAL_END.
-        if (ast.getType() == TokenTypes.TEXT_BLOCK_CONTENT) {
-            lineNo = ast.getNextSibling().getLineNo();
-        }
-        boolean result = false;
-        if (singlelineComments.containsKey(lineNo)) {
-            result = true;
-        }
-        else {
-            final List<TextBlock> commentList = blockComments.get(lineNo);
-            if (commentList != null) {
-                final TextBlock comment = commentList.getLast();
-                final int[] codePoints = getLineCodePoints(lineNo - 1);
-                result = isTrailingBlockComment(comment, codePoints);
-            }
-        }
-        return result;
-    }
-
-    /**
-     * Whether the C style comment is trailing.
-     *
-     * @param comment the comment to check.
-     * @param codePoints the first line of the comment, in unicode code points
-     * @return true if the comment is trailing.
-     */
-    private static boolean isTrailingBlockComment(TextBlock comment, int... codePoints) {
-        return comment.getText().length != 1
-            || CodePointUtil.isBlank(Arrays.copyOfRange(codePoints,
-                comment.getEndColNo() + 1, codePoints.length));
-    }
-
-    /**
      * Count regexp matches into String literal.
      *
      * @param pattern pattern.
@@ -368,5 +387,4 @@ public class AvoidEscapedUnicodeCharactersCheck
         return allowIfAllCharactersEscaped
                 && ALL_ESCAPED_CHARS.matcher(literal).find();
     }
-
 }

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/AvoidEscapedUnicodeCharactersCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/AvoidEscapedUnicodeCharactersCheckTest.java
@@ -34,6 +34,7 @@ import com.google.common.base.Splitter;
 import com.puppycrawl.tools.checkstyle.AbstractModuleTestSupport;
 import com.puppycrawl.tools.checkstyle.api.TokenTypes;
 import com.puppycrawl.tools.checkstyle.internal.utils.TestUtil;
+import com.puppycrawl.tools.checkstyle.utils.CommonUtil;
 
 public class AvoidEscapedUnicodeCharactersCheckTest extends AbstractModuleTestSupport {
 
@@ -158,6 +159,8 @@ public class AvoidEscapedUnicodeCharactersCheckTest extends AbstractModuleTestSu
             TokenTypes.STRING_LITERAL,
             TokenTypes.CHAR_LITERAL,
             TokenTypes.TEXT_BLOCK_CONTENT,
+            TokenTypes.SINGLE_LINE_COMMENT,
+            TokenTypes.BLOCK_COMMENT_BEGIN,
         };
         assertWithMessage("Required tokens differ from expected")
             .that(checkObj.getRequiredTokens())
@@ -457,6 +460,26 @@ public class AvoidEscapedUnicodeCharactersCheckTest extends AbstractModuleTestSu
     }
 
     @Test
+    public void testBlockCommentAtAbsoluteEndOfFile() throws Exception {
+        final String[] expected = CommonUtil.EMPTY_STRING_ARRAY;
+        verifyWithInlineConfigParser(
+            getPath("InputAvoidEscapedUnicodeCharactersCommentEnd.java"),
+            expected);
+    }
+
+    @Test
+    public void testBeginTreeClearsPendingViolations() throws Exception {
+        final String file1 = getPath("InputAvoidEscapedUnicodeCharactersBeginTree1.java");
+        final String file2 = getPath("InputAvoidEscapedUnicodeCharactersBeginTree2.java");
+
+        final List<String> expected1 = List.of(
+                "15:17: " + getCheckMessage(MSG_KEY));
+        final List<String> expected2 = Arrays.asList(CommonUtil.EMPTY_STRING_ARRAY);
+
+        verifyWithInlineConfigParser(file1, file2, expected1, expected2);
+    }
+
+    @Test
     public void testGetAcceptableTokens() {
         final AvoidEscapedUnicodeCharactersCheck check = new AvoidEscapedUnicodeCharactersCheck();
         final int[] actual = check.getAcceptableTokens();
@@ -464,6 +487,8 @@ public class AvoidEscapedUnicodeCharactersCheckTest extends AbstractModuleTestSu
             TokenTypes.STRING_LITERAL,
             TokenTypes.CHAR_LITERAL,
             TokenTypes.TEXT_BLOCK_CONTENT,
+            TokenTypes.SINGLE_LINE_COMMENT,
+            TokenTypes.BLOCK_COMMENT_BEGIN,
         };
         assertWithMessage("Acceptable tokens differ from expected")
             .that(actual)

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/avoidescapedunicodecharacters/InputAvoidEscapedUnicodeCharactersBeginTree1.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/avoidescapedunicodecharacters/InputAvoidEscapedUnicodeCharactersBeginTree1.java
@@ -1,0 +1,17 @@
+/*
+AvoidEscapedUnicodeCharacters
+allowEscapesForControlCharacters = (default)false
+allowByTailComment = true
+allowIfAllCharactersEscaped = (default)false
+allowNonPrintableEscapes = (default)false
+
+
+*/
+
+package com.puppycrawl.tools.checkstyle.checks.avoidescapedunicodecharacters;
+
+public class InputAvoidEscapedUnicodeCharactersBeginTree1 {
+
+     String s = "\u0001";
+     // violation above, 'Unicode escape(s) usage should be avoided.'
+}

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/avoidescapedunicodecharacters/InputAvoidEscapedUnicodeCharactersBeginTree2.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/avoidescapedunicodecharacters/InputAvoidEscapedUnicodeCharactersBeginTree2.java
@@ -1,0 +1,15 @@
+/*
+AvoidEscapedUnicodeCharacters
+allowEscapesForControlCharacters = (default)false
+allowByTailComment = true
+allowIfAllCharactersEscaped = (default)false
+allowNonPrintableEscapes = (default)false
+
+
+*/
+
+package com.puppycrawl.tools.checkstyle.checks.avoidescapedunicodecharacters;
+
+public class InputAvoidEscapedUnicodeCharactersBeginTree2 {
+    //EMPTY
+}

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/avoidescapedunicodecharacters/InputAvoidEscapedUnicodeCharactersCommentEnd.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/avoidescapedunicodecharacters/InputAvoidEscapedUnicodeCharactersCommentEnd.java
@@ -1,0 +1,27 @@
+/*
+AvoidEscapedUnicodeCharacters
+allowEscapesForControlCharacters = (default)false
+allowByTailComment = true
+allowIfAllCharactersEscaped = (default)false
+allowNonPrintableEscapes = (default)false
+
+
+*/
+
+package com.puppycrawl.tools.checkstyle.checks.avoidescapedunicodecharacters;
+
+public class InputAvoidEscapedUnicodeCharactersCommentEnd {
+/** JavaDoc for field */
+    String s1 = "\u221e"; /* trailing comment */
+
+    /** JavaDoc for method */
+    public void method() {
+        String s2 = "\u221e"; /* trailing in method */
+    }
+
+    String s3 = "\u221e"; /* trailing after method */
+}
+
+/* Block comment after class */
+
+/** JavaDoc comment at end of file */


### PR DESCRIPTION
#11166 

Report label: AvoidEscapedUnicodeCharacters/Example1
Diff Regression config: https://raw.githubusercontent.com/checkstyle/test-configs/main/AvoidEscapedUnicodeCharacters/Example1/config.xml
Diff Regression projects: https://raw.githubusercontent.com/checkstyle/test-configs/main/AvoidEscapedUnicodeCharacters/Example1/list-of-projects.properties