### PR TITLE
Issue #14122: Refactor classes to prevent vulnerability to finalizer …

### DIFF
--- a/config/checker-framework-suppressions/checker-nullness-optional-interning-suppressions.xml
+++ b/config/checker-framework-suppressions/checker-nullness-optional-interning-suppressions.xml
@@ -1636,7 +1636,7 @@
     <lineContent>setFileExtensions(&quot;properties&quot;);</lineContent>
     <details>
       found   : @UnderInitialization(com.puppycrawl.tools.checkstyle.api.AbstractFileSetCheck.class) @NonNull TranslationCheck
-      required: @Initialized @NonNull TranslationCheck
+      required: @Initialized @NonNull AbstractFileSetCheck
     </details>
   </checkerFrameworkError>
 

--- a/config/spotbugs-exclude.xml
+++ b/config/spotbugs-exclude.xml
@@ -302,16 +302,9 @@
     <Or>
       <Class name="com.puppycrawl.tools.checkstyle.DefaultLogger"/>
       <Class name="com.puppycrawl.tools.checkstyle.PackageObjectFactory"/>
-      <Class name="com.puppycrawl.tools.checkstyle.SarifLogger"/>
-      <Class name="com.puppycrawl.tools.checkstyle.XMLLogger"/>
       <Class name="com.puppycrawl.tools.checkstyle.XmlLoader"/>
-      <Class name="com.puppycrawl.tools.checkstyle.filters.XpathFilterElement"/>
       <Class name="com.puppycrawl.tools.checkstyle.Checker"/>
-      <Class name="com.puppycrawl.tools.checkstyle.checks.TranslationCheck"/>
       <Class name="com.puppycrawl.tools.checkstyle.filters.CsvFilterElement"/>
-      <Class name="com.puppycrawl.tools.checkstyle.XpathFileGeneratorAuditListener" />
-      <Class name=
-           "com.puppycrawl.tools.checkstyle.ChecksAndFilesSuppressionFileGeneratorAuditListener" />
     </Or>
     <Bug pattern="CT_CONSTRUCTOR_THROW"/>
   </Match>

--- a/src/main/java/com/puppycrawl/tools/checkstyle/ChecksAndFilesSuppressionFileGeneratorAuditListener.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/ChecksAndFilesSuppressionFileGeneratorAuditListener.java
@@ -36,7 +36,7 @@ import com.puppycrawl.tools.checkstyle.api.AuditListener;
  * Generates <b>suppressions.xml</b> file, based on violations occurred.
  * See issue <a href="https://github.com/checkstyle/checkstyle/issues/5983">#5983</a>
  */
-public class ChecksAndFilesSuppressionFileGeneratorAuditListener
+public final class ChecksAndFilesSuppressionFileGeneratorAuditListener
         extends AbstractAutomaticBean
         implements AuditListener {
 

--- a/src/main/java/com/puppycrawl/tools/checkstyle/SarifLogger.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/SarifLogger.java
@@ -50,7 +50,7 @@ import com.puppycrawl.tools.checkstyle.utils.CommonUtil;
  * SARIF stands for the static analysis results interchange format.
  * See <a href="https://sarifweb.azurewebsites.net/">reference</a>
  */
-public class SarifLogger extends AbstractAutomaticBean implements AuditListener {
+public final class SarifLogger extends AbstractAutomaticBean implements AuditListener {
 
     /** The length of unicode placeholder. */
     private static final int UNICODE_LENGTH = 4;

--- a/src/main/java/com/puppycrawl/tools/checkstyle/XMLLogger.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/XMLLogger.java
@@ -43,7 +43,7 @@ import com.puppycrawl.tools.checkstyle.api.SeverityLevel;
  */
 // -@cs[AbbreviationAsWordInName] We can not change it as,
 // check's name is part of API (used in configurations).
-public class XMLLogger
+public final class XMLLogger
     extends AbstractAutomaticBean
     implements AuditListener {
 

--- a/src/main/java/com/puppycrawl/tools/checkstyle/XpathFileGeneratorAuditListener.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/XpathFileGeneratorAuditListener.java
@@ -32,7 +32,7 @@ import com.puppycrawl.tools.checkstyle.api.AuditListener;
  * Generates <b>suppressions.xml</b> file, based on violations occurred.
  * See issue <a href="https://github.com/checkstyle/checkstyle/issues/102">#102</a>
  */
-public class XpathFileGeneratorAuditListener
+public final class XpathFileGeneratorAuditListener
         extends AbstractAutomaticBean
         implements AuditListener {
 

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/TranslationCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/TranslationCheck.java
@@ -93,7 +93,7 @@ import com.puppycrawl.tools.checkstyle.utils.CommonUtil;
  * @since 3.0
  */
 @GlobalStatefulCheck
-public class TranslationCheck extends AbstractFileSetCheck {
+public final class TranslationCheck extends AbstractFileSetCheck {
 
     /**
      * A key is pointing to the warning message text for missing key
@@ -180,18 +180,6 @@ public class TranslationCheck extends AbstractFileSetCheck {
         setFileExtensions("properties");
         baseName = CommonUtil.createPattern("^messages.*$");
         log = LogFactory.getLog(TranslationCheck.class);
-    }
-
-    /**
-     * Setter to specify the file extensions of the files to process.
-     *
-     * @param extensions the set of file extensions. A missing
-     *         initial '.' character of an extension is automatically added.
-     * @throws IllegalArgumentException is argument is null
-     */
-    @Override
-    public final void setFileExtensions(String... extensions) {
-        super.setFileExtensions(extensions);
     }
 
     /**

--- a/src/main/java/com/puppycrawl/tools/checkstyle/filters/XpathFilterElement.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/filters/XpathFilterElement.java
@@ -41,7 +41,7 @@ import net.sf.saxon.trans.XPathException;
  * objects based on the criteria of file, check, module id, xpathQuery.
  *
  */
-public class XpathFilterElement implements TreeWalkerFilter {
+public final class XpathFilterElement implements TreeWalkerFilter {
 
     /** The regexp to match file names against. */
     private final Pattern fileRegexp;


### PR DESCRIPTION
Issue #14122

### Problem
Some concrete classes can throw exceptions inside their constructors, making them vulnerable to **Finalizer Attacks** . A malicious subclass could potentially override `finalize()` and access a partially initialized object.

### Fix
The following classes have been declared `final` to prevent subclassing:

* `SarifLogger`
* `XMLLogger`
* `XpathFilterElement`
* `TranslationCheck`
* `XpathFileGeneratorAuditListener`
* `ChecksAndFilesSuppressionFileGeneratorAuditListener`

### Reasoning
Making these classes `final` strictly prevents subclassing and fully eliminates the attack vector by ensuring no malicious subclass can override finalize().
The only tradeoff is that these classes can no longer be extended. After reviewing the codebase, none of these classes are subclassed, and they appear to be treated as leaf implementations, so this change should not cause any issues.