### PR TITLE
minor: add check to enforce presence of 'since' macro

### DIFF
--- a/config/checkstyle-non-main-files-checks.xml
+++ b/config/checkstyle-non-main-files-checks.xml
@@ -171,5 +171,13 @@
     <property name="maximum" value="1"/>
     <property name="message" value="Description macro usage is required in template files."/>
   </module>
+  <module name="RegexpSingleline">
+    <property name="id" value="sinceMacroMustExist"/>
+    <property name="format" value="&lt;macro name=&quot;since&quot;&gt;"/>
+    <property name="fileExtensions" value="xml.template"/>
+    <property name="minimum" value="1"/>
+    <property name="maximum" value="1"/>
+    <property name="message" value="Since macro usage is required in template files."/>
+  </module>
 
 </module>

--- a/config/checkstyle-non-main-files-suppressions.xml
+++ b/config/checkstyle-non-main-files-suppressions.xml
@@ -323,6 +323,9 @@
   <suppress id="propertiesMacroMustExist"
             files="src[\\/]site[\\/]xdoc[\\/]checks\.xml\.template"/>
 
+  <!-- no since in module by design -->
+  <suppress id="sinceMacroMustExist"
+            files="src[\\/]site[\\/]xdoc[\\/]checks\.xml\.template"/>
   <!-- no description in module by design -->
   <suppress id="descriptionMacroMustExist"
             files="src[\\/]site[\\/]xdoc[\\/]checks\.xml\.template"/>


### PR DESCRIPTION
Related to
- https://github.com/checkstyle/checkstyle/pull/18229

---

In that PR I added a test in `XdocsPagesTest` to enforce presence of `<macro name="since">` in all `.xml.template` files. However, I later learned that there are checkstyle `RegexpSingleline` checks that enforce this - presence, of `description`, `properties`, `parentModule`,...  This PR adds such check for `since` macro _for consistency_.

I believe, the test in `XdocsPagesTest` can remain because it also enforces that the `since` macro is the first element of the page.