### PR TITLE
Updated AT_SIGN Javadoc to new AST format

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/api/JavadocCommentsTokenTypes.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/api/JavadocCommentsTokenTypes.java
@@ -70,6 +70,23 @@ public final class JavadocCommentsTokenTypes {
 
     /**
      * At-sign {@code @} that starts a block tag.
+     *
+     * <p><b>Example:</b></p>
+     * <pre>{@code * @author name}</pre>
+     *
+     * <b>Tree:</b>
+     * <pre>{@code
+     * |--LEADING_ASTERISK -> *
+     * |--TEXT ->
+     * `--JAVADOC_BLOCK_TAG -> JAVADOC_BLOCK_TAG
+     *     `--AUTHOR_BLOCK_TAG -> AUTHOR_BLOCK_TAG
+     *         |--AT_SIGN -> @
+     *         |--TAG_NAME -> author
+     *         `--DESCRIPTION -> DESCRIPTION
+     *             `--TEXT ->  name
+     * }</pre>
+     *
+     * @see #JAVADOC_BLOCK_TAG
      */
     public static final int AT_SIGN = JavadocCommentsLexer.AT_SIGN;
 


### PR DESCRIPTION
Issue: #17882

This PR updates the Javadoc for the AT_SIGN token in `JavadocCommentsTokenTypes.java` to reflect the new Javadoc AST print format introduced in recent Checkstyle versions.

**src/Test.java**
```
/**
 * @author name
 */
public class Test {
}
```
**Command Used:**
```
java -jar checkstyle-12.2.0-SNAPSHOT-all.jar -j src/Test.java | ForEach-Object { $_ -replace '\[[0-9]+:[0-9]+\]', '' }
```

**Output:**
```
JAVADOC_CONTENT -> JAVADOC_CONTENT
|--TEXT -> /**
|--NEWLINE -> \r\n
|--LEADING_ASTERISK ->  *
|--TEXT ->
`--JAVADOC_BLOCK_TAG -> JAVADOC_BLOCK_TAG
    `--AUTHOR_BLOCK_TAG -> AUTHOR_BLOCK_TAG
        |--AT_SIGN -> @
        |--TAG_NAME -> author
        `--DESCRIPTION -> DESCRIPTION
            |--TEXT ->  name
            |--NEWLINE -> \r\n
            |--LEADING_ASTERISK ->  *
            |--TEXT -> /
            |--NEWLINE -> \r\n
            |--TEXT -> public class Test {
            |--NEWLINE -> \r\n
            `--TEXT -> }
```