### PR TITLE
Issue #17933: Remove obsolete SpotBugs RCN_REDUNDANT_NULLCHECK_OF_NON…

### DIFF
--- a/config/spotbugs-exclude.xml
+++ b/config/spotbugs-exclude.xml
@@ -11,48 +11,6 @@
   </Match>
   <Match>
     <!-- till https://github.com/checkstyle/checkstyle/issues/17933 fails on java11+ -->
-    <Class name="com.puppycrawl.tools.checkstyle.Main" />
-    <Method name="loadProperties" />
-    <Bug pattern="RCN_REDUNDANT_NULLCHECK_OF_NONNULL_VALUE" />
-  </Match>
-  <Match>
-    <!-- till https://github.com/checkstyle/checkstyle/issues/17933 fails on java11+ -->
-    <Class name="com.puppycrawl.tools.checkstyle.PropertyCacheFile" />
-    <Method name="load" />
-    <Bug pattern="RCN_REDUNDANT_NULLCHECK_OF_NONNULL_VALUE" />
-  </Match>
-  <Match>
-    <!-- till https://github.com/checkstyle/checkstyle/issues/17933 fails on java11+ -->
-    <Class name="com.puppycrawl.tools.checkstyle.PropertyCacheFile" />
-    <Method name="persist" />
-    <Bug pattern="RCN_REDUNDANT_NULLCHECK_OF_NONNULL_VALUE" />
-  </Match>
-  <Match>
-    <!-- till https://github.com/checkstyle/checkstyle/issues/17933 fails on java11+ -->
-    <Class name="com.puppycrawl.tools.checkstyle.ant.CheckstyleAntTask" />
-    <Method name="createOverridingProperties" />
-    <Bug pattern="RCN_REDUNDANT_NULLCHECK_OF_NONNULL_VALUE" />
-  </Match>
-  <Match>
-    <!-- till https://github.com/checkstyle/checkstyle/issues/17933 fails on java11+ -->
-    <Class name="com.puppycrawl.tools.checkstyle.checks.OrderedPropertiesCheck" />
-    <Method name="processFiltered" />
-    <Bug pattern="RCN_REDUNDANT_NULLCHECK_OF_NONNULL_VALUE" />
-  </Match>
-  <Match>
-    <!-- till https://github.com/checkstyle/checkstyle/issues/17933 fails on java11+ -->
-    <Class name="com.puppycrawl.tools.checkstyle.checks.TranslationCheck" />
-    <Method name="getTranslationKeys" />
-    <Bug pattern="RCN_REDUNDANT_NULLCHECK_OF_NONNULL_VALUE" />
-  </Match>
-  <Match>
-    <!-- till https://github.com/checkstyle/checkstyle/issues/17933 fails on java11+ -->
-    <Class name="com.puppycrawl.tools.checkstyle.checks.UniquePropertiesCheck" />
-    <Method name="processFiltered" />
-    <Bug pattern="RCN_REDUNDANT_NULLCHECK_OF_NONNULL_VALUE" />
-  </Match>
-  <Match>
-    <!-- till https://github.com/checkstyle/checkstyle/issues/17933 fails on java11+ -->
     <Class name="com.puppycrawl.tools.checkstyle.meta.MetadataGeneratorUtil" />
     <Method name="dumpMetadata" />
     <Bug pattern="RCN_REDUNDANT_NULLCHECK_WOULD_HAVE_BEEN_A_NPE" />


### PR DESCRIPTION
Issue #17933:

## Remove obsolete SpotBugs RCN suppressions

This PR removes outdated `RCN_REDUNDANT_NULLCHECK_OF_NONNULL_VALUE` suppressions that were previously added due to false positives on Java 11+. The affected methods no longer contain redundant null checks, so these exclusions are no longer needed.

After removing them, running: `mvn clean verify`
passed successfully with **0 SpotBugs violations**, confirming the cleanup is safe.


<img width="744" height="203" alt="Screenshot 2025-12-03 at 4 14 33 PM" src="https://github.com/user-attachments/assets/d1ff9476-43e4-4f76-bf6e-3c83d0b78681" />
