### PR TITLE
docs(pitest): document equivalence for “Removed assignment to member variable columnFilter” in SuppressFilterElement

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/filters/SuppressFilterElement.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/filters/SuppressFilterElement.java
@@ -90,6 +90,11 @@ public class SuppressFilterElement
         }
         if (columns == null) {
             columnsCsv = null;
+            // PIT note: Removing this assignment produces an equivalent mutant because
+            // the field defaults to null and all usages guard with a null check
+            // (see isLineAndColumnMatching). This explicit assignment exists for
+            // readability/definite assignment; behavior is identical without it.
+            // See config/pitest-suppressions/pitest-filters-suppressions.xml.
             columnFilter = null;
         }
         else {


### PR DESCRIPTION
Issue: #18023  
Tracker: #12341

## Summary
- Document why the PIT mutant “Removed assignment to member variable columnFilter” for `com.puppycrawl.tools.checkstyle.filters.SuppressFilterElement::<init>` is equivalent and should remain suppressed.
- Add an inline comment in [SuppressFilterElement.java](cci:7://file:///home/jarvis/Documents/Github/contribute/checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/filters/SuppressFilterElement.java:0:0-0:0) with the rationale.

## Rationale
- The field `columnFilter` (reference type) defaults to `null`.
- In the constructor’s `columns == null` branch, the explicit assignment `columnFilter = null;` does not change runtime state versus the default `null`.
- All usages of `columnFilter` are guarded with null checks in [isLineAndColumnMatching(...)](cci:1://file:///home/jarvis/Documents/Github/contribute/checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/filters/SuppressFilterElement.java:172:4-182:5) located in:
  - [src/main/java/com/puppycrawl/tools/checkstyle/filters/SuppressFilterElement.java](cci:7://file:///home/jarvis/Documents/Github/contribute/checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/filters/SuppressFilterElement.java:0:0-0:0)
- Therefore, removing this write is unobservable and produces an equivalent mutant; it cannot be killed by tests without altering the class’s design/immutability guarantees.

## Changes
- [src/main/java/com/puppycrawl/tools/checkstyle/filters/SuppressFilterElement.java](cci:7://file:///home/jarvis/Documents/Github/contribute/checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/filters/SuppressFilterElement.java:0:0-0:0)
  - Add a clarifying comment above `columnFilter = null;` explaining equivalence and referencing suppressions.

## Validation
- Profile: `pitest-filters`
- Analyzer: No new surviving mutation(s) found.
- Latest PIT run summary:
  - Generated 1473 mutations; Killed 1458 (99%)
  - Mutations with no coverage: 0
  - BUILD SUCCESS

## Notes
- Suppression is intentionally retained due to equivalence to avoid churn and misleading action items.
- See Checkstyle wiki: “How to Generate and Analyze Pitest Reports”.

---

### Commit Message (one line)
Issue #18023: document equivalence for 'Removed assignment to member variable columnFilter' in SuppressFilterElement