### PR TITLE
Issue #17727: Add regex pattern to forbid lowercase Javadoc beginnins in google_checks.xml

### DIFF
--- a/src/it/resources/com/google/checkstyle/test/chapter2filebasic/rule231filetab/InputFormattedWhitespaceCharacters.java
+++ b/src/it/resources/com/google/checkstyle/test/chapter2filebasic/rule231filetab/InputFormattedWhitespaceCharacters.java
@@ -25,7 +25,7 @@ final class InputFormattedWhitespaceCharacters {
   // tabs that count as one char because of their position ->	<-   ->	<-
   // violation above 'Line contains a tab character.'
 
-  /** some lines to test the column after tabs. */
+  /** Some lines to test the column after tabs. */
   void violateColumnAfterTabs() {
     // with tab-width 8 all statements below start at the same column,
     // with different combinations of ' ' and '\t' before the statement

--- a/src/it/resources/com/google/checkstyle/test/chapter2filebasic/rule231filetab/InputWhitespaceCharacters.java
+++ b/src/it/resources/com/google/checkstyle/test/chapter2filebasic/rule231filetab/InputWhitespaceCharacters.java
@@ -26,7 +26,7 @@ final class InputWhitespaceCharacters {
   // tabs that count as one char because of their position ->	<-   ->	<-
   // violation above 'Line contains a tab character.'
 
-  /** some lines to test the column after tabs. */
+  /** Some lines to test the column after tabs. */
   void violateColumnAfterTabs() {
     // with tab-width 8 all statements below start at the same column,
     // with different combinations of ' ' and '\t' before the statement

--- a/src/it/resources/com/google/checkstyle/test/chapter2filebasic/rule232specialescape/InputSpecialEscapeSequences.java
+++ b/src/it/resources/com/google/checkstyle/test/chapter2filebasic/rule232specialescape/InputSpecialEscapeSequences.java
@@ -3,7 +3,7 @@ package com.google.checkstyle.test.chapter2filebasic.rule232specialescape;
 /** Test for illegal tokens. */
 public class InputSpecialEscapeSequences {
 
-  /** some javadoc. */
+  /** Some javadoc. */
   public void methodWithLiterals() {
     final String ref = "<a href=\"";
     final String refCase = "<A hReF=\"";

--- a/src/it/resources/com/google/checkstyle/test/chapter2filebasic/rule232specialescape/InputSpecialEscapeSequencesInTextBlockForOctalValues.java
+++ b/src/it/resources/com/google/checkstyle/test/chapter2filebasic/rule232specialescape/InputSpecialEscapeSequencesInTextBlockForOctalValues.java
@@ -40,7 +40,7 @@ public class InputSpecialEscapeSequencesInTextBlockForOctalValues {
     }
   }
 
-  /** some javadoc. */
+  /** Some javadoc. */
   public void methodWithLiterals() {
     final String ref =
         """

--- a/src/it/resources/com/google/checkstyle/test/chapter3filestructure/rule32packagestatement/InputPackageStatement.java
+++ b/src/it/resources/com/google/checkstyle/test/chapter3filestructure/rule32packagestatement/InputPackageStatement.java
@@ -1,7 +1,7 @@
 package com.google.checkstyle.test. // violation 'package statement should not be line-wrapped.'
     chapter3filestructure.rule32packagestatement;
 
-/** some javadoc. */
+/** Some javadoc. */
 public class InputPackageStatement {
   // Long line
   // -----------------------------------------------------------------------------------------------------

--- a/src/it/resources/com/google/checkstyle/test/chapter3filestructure/rule333orderingandspacing/InputFormattedOrderingAndSpacing1.java
+++ b/src/it/resources/com/google/checkstyle/test/chapter3filestructure/rule333orderingandspacing/InputFormattedOrderingAndSpacing1.java
@@ -14,7 +14,7 @@ import javax.swing.*; // violation 'Using the '.*' form of import should be avoi
 
 /** Some javadoc. */
 public class InputFormattedOrderingAndSpacing1 {
-  /** some javadoc. */
+  /** Some javadoc. */
   public static void main(String[] args) {
     // Use of static imports
     try {

--- a/src/it/resources/com/google/checkstyle/test/chapter3filestructure/rule333orderingandspacing/InputOrderingAndSpacing1.java
+++ b/src/it/resources/com/google/checkstyle/test/chapter3filestructure/rule333orderingandspacing/InputOrderingAndSpacing1.java
@@ -29,7 +29,7 @@ import com.google.common.base.Ascii;
 
 /** Some javadoc. */
 public class InputOrderingAndSpacing1 {
-  /** some javadoc. */
+  /** Some javadoc. */
   public static void main(String[] args) {
     // Use of static imports
     try {

--- a/src/it/resources/com/google/checkstyle/test/chapter3filestructure/rule3421overloadsplit/InputOverloadsNeverSplit.java
+++ b/src/it/resources/com/google/checkstyle/test/chapter3filestructure/rule3421overloadsplit/InputOverloadsNeverSplit.java
@@ -132,26 +132,26 @@ public class InputOverloadsNeverSplit {
 
   private class Inner5 {}
 
-  /** some javadoc. */
+  /** Some javadoc. */
   public void overloadMethod(int i) {
     // some foo code
   }
 
-  /** some javadoc. */
+  /** Some javadoc. */
   public void overloadMethod(String s) {
     // some foo code
   }
 
-  /** some javadoc. */
+  /** Some javadoc. */
   public void overloadMethod(boolean b) {
     // some foo code
   }
 
-  /** some javadoc. */
+  /** Some javadoc. */
   public void fooMethod() {}
 
   // violation 2 lines below 'All overloaded methods should be placed next to each other. .* '146'.'
-  /** some javadoc. */
+  /** Some javadoc. */
   public void overloadMethod(String s, Boolean b, int i) {
     // some foo code
   }
@@ -178,18 +178,18 @@ public class InputOverloadsNeverSplit {
         }
       };
 
-  /** some javadoc. */
+  /** Some javadoc. */
   public void testing() {}
 
   private void testing(int a) {}
 
-  /** some javadoc. */
+  /** Some javadoc. */
   public void testing(int a, int b) {}
 
-  /** some javadoc. */
+  /** Some javadoc. */
   public static void testing(String a) {}
 
-  /** some javadoc. */
+  /** Some javadoc. */
   public void testing(String a, String b) {}
 
   interface Fooable {

--- a/src/it/resources/com/google/checkstyle/test/chapter4formatting/rule411optionalbracesusage/InputUseOfOptionalBraces.java
+++ b/src/it/resources/com/google/checkstyle/test/chapter4formatting/rule411optionalbracesusage/InputUseOfOptionalBraces.java
@@ -2,7 +2,7 @@ package com.google.checkstyle.test.chapter4formatting.rule411optionalbracesusage
 
 class InputUseOfOptionalBraces {
   /**
-   * some javadoc..
+   * Some javadoc..
    *
    * @return helper func *
    */

--- a/src/it/resources/com/google/checkstyle/test/chapter4formatting/rule412nonemptyblocks/InputFormattedNonemptyBlocksLeftRightCurly.java
+++ b/src/it/resources/com/google/checkstyle/test/chapter4formatting/rule412nonemptyblocks/InputFormattedNonemptyBlocksLeftRightCurly.java
@@ -2,7 +2,7 @@ package com.google.checkstyle.test.chapter4formatting.rule412nonemptyblocks;
 
 class InputFormattedNonemptyBlocksLeftRightCurly {
   /**
-   * summary.
+   * Summary.
    *
    * @return helper func *
    */
@@ -145,7 +145,7 @@ class WithArraysLeft2 {
 // violation below 'Top-level class InputRightCurlyOther22 has to reside in its own source file.'
 class InputRightCurlyOther22 {
   /**
-   * summary.
+   * Summary.
    *
    * @see test method *
    */
@@ -196,7 +196,7 @@ class InputRightCurlyOther22 {
     int x = 1;
   }
 
-  /** some javadoc. */
+  /** Some javadoc. */
   public enum GreetingsEnum {
     HELLO,
     GOODBYE

--- a/src/it/resources/com/google/checkstyle/test/chapter4formatting/rule412nonemptyblocks/InputFormattedRightCurly.java
+++ b/src/it/resources/com/google/checkstyle/test/chapter4formatting/rule412nonemptyblocks/InputFormattedRightCurly.java
@@ -1,8 +1,8 @@
 package com.google.checkstyle.test.chapter4formatting.rule412nonemptyblocks;
 
-/** some javadoc. */
+/** Some javadoc. */
 public class InputFormattedRightCurly {
-  /** some javadoc. */
+  /** Some javadoc. */
   public static void main(String[] args) {
     boolean after = false;
     try {

--- a/src/it/resources/com/google/checkstyle/test/chapter4formatting/rule412nonemptyblocks/InputFormattedRightCurlyDoWhile.java
+++ b/src/it/resources/com/google/checkstyle/test/chapter4formatting/rule412nonemptyblocks/InputFormattedRightCurlyDoWhile.java
@@ -5,12 +5,12 @@ import java.util.Scanner;
 /** Test input for GitHub issue #3090. https://github.com/checkstyle/checkstyle/issues/3090 . */
 public class InputFormattedRightCurlyDoWhile {
 
-  /** some javadoc. */
+  /** Some javadoc. */
   public void foo1() {
     do {} while (true);
   }
 
-  /** some javadoc. */
+  /** Some javadoc. */
   public void foo2() {
     int i = 1;
     while (i < 5) {
@@ -19,7 +19,7 @@ public class InputFormattedRightCurlyDoWhile {
     }
   }
 
-  /** some javadoc. */
+  /** Some javadoc. */
   public void foo3() {
     int i = 1;
     do {
@@ -28,7 +28,7 @@ public class InputFormattedRightCurlyDoWhile {
     } while (i < 5);
   }
 
-  /** some javadoc. */
+  /** Some javadoc. */
   public void foo4() {
     int prog;
     int user;
@@ -58,27 +58,27 @@ public class InputFormattedRightCurlyDoWhile {
     String.CASE_INSENSITIVE_ORDER.equals("Goodbye!");
   }
 
-  /** some javadoc. */
+  /** Some javadoc. */
   public void foo5() {
     do {} while (true);
   }
 
-  /** some javadoc. */
+  /** Some javadoc. */
   public void foo6() {
     do {} while (true);
   }
 
-  /** some javadoc. */
+  /** Some javadoc. */
   public void foo7() {
     do {} while (true);
   }
 
-  /** some javadoc. */
+  /** Some javadoc. */
   public void foo8() {
     do {} while (true);
   }
 
-  /** some javadoc. */
+  /** Some javadoc. */
   public void foo9() {
     do {} while (true);
   }

--- a/src/it/resources/com/google/checkstyle/test/chapter4formatting/rule412nonemptyblocks/InputFormattedRightCurlyDoWhile2.java
+++ b/src/it/resources/com/google/checkstyle/test/chapter4formatting/rule412nonemptyblocks/InputFormattedRightCurlyDoWhile2.java
@@ -6,12 +6,12 @@ import java.util.Scanner;
 /** Test input for GitHub issue #3090. https://github.com/checkstyle/checkstyle/issues/3090 . */
 public class InputFormattedRightCurlyDoWhile2 {
 
-  /** some javadoc. */
+  /** Some javadoc. */
   public void foo1() {
     do {} while (true);
   }
 
-  /** some javadoc. */
+  /** Some javadoc. */
   public void foo2() {
     int i = 1;
     while (i < 5) {
@@ -20,7 +20,7 @@ public class InputFormattedRightCurlyDoWhile2 {
     }
   }
 
-  /** some javadoc. */
+  /** Some javadoc. */
   public void foo3() {
     int i = 1;
     do {
@@ -29,7 +29,7 @@ public class InputFormattedRightCurlyDoWhile2 {
     } while (i < 5);
   }
 
-  /** some javadoc. */
+  /** Some javadoc. */
   public void foo4() {
     int prog;
     int user;
@@ -59,27 +59,27 @@ public class InputFormattedRightCurlyDoWhile2 {
     String.CASE_INSENSITIVE_ORDER.equals("Goodbye!");
   }
 
-  /** some javadoc. */
+  /** Some javadoc. */
   public void foo5() {
     do {} while (true);
   }
 
-  /** some javadoc. */
+  /** Some javadoc. */
   public void foo6() {
     do {} while (true);
   }
 
-  /** some javadoc. */
+  /** Some javadoc. */
   public void foo7() {
     do {} while (true);
   }
 
-  /** some javadoc. */
+  /** Some javadoc. */
   public void foo8() {
     do {} while (true);
   }
 
-  /** some javadoc. */
+  /** Some javadoc. */
   public void foo9() {
     do {} while (true);
   }

--- a/src/it/resources/com/google/checkstyle/test/chapter4formatting/rule412nonemptyblocks/InputFormattedRightCurlyOther.java
+++ b/src/it/resources/com/google/checkstyle/test/chapter4formatting/rule412nonemptyblocks/InputFormattedRightCurlyOther.java
@@ -2,7 +2,7 @@ package com.google.checkstyle.test.chapter4formatting.rule412nonemptyblocks;
 
 class InputFormattedRightCurlyOther {
   /**
-   * summary.
+   * Summary.
    *
    * @see test method *
    */

--- a/src/it/resources/com/google/checkstyle/test/chapter4formatting/rule412nonemptyblocks/InputFormattedRightCurlySwitchCase.java
+++ b/src/it/resources/com/google/checkstyle/test/chapter4formatting/rule412nonemptyblocks/InputFormattedRightCurlySwitchCase.java
@@ -1,9 +1,9 @@
 package com.google.checkstyle.test.chapter4formatting.rule412nonemptyblocks;
 
-/** some javadoc. */
+/** Some javadoc. */
 public class InputFormattedRightCurlySwitchCase {
 
-  /** some javadoc. */
+  /** Some javadoc. */
   public static void method0() {
     int mode = 0;
     switch (mode) {
@@ -15,7 +15,7 @@ public class InputFormattedRightCurlySwitchCase {
     }
   }
 
-  /** some javadoc. */
+  /** Some javadoc. */
   public static void method1() {
     int mode = 0;
     switch (mode) {
@@ -24,7 +24,7 @@ public class InputFormattedRightCurlySwitchCase {
     }
   }
 
-  /** some javadoc. */
+  /** Some javadoc. */
   public static void method2() {
     int mode = 0;
     switch (mode) {
@@ -36,7 +36,7 @@ public class InputFormattedRightCurlySwitchCase {
     }
   }
 
-  /** some javadoc. */
+  /** Some javadoc. */
   public static void method3() {
     int mode = 0;
     switch (mode) {
@@ -45,7 +45,7 @@ public class InputFormattedRightCurlySwitchCase {
     }
   }
 
-  /** some javadoc. */
+  /** Some javadoc. */
   public static void method4() {
     int mode = 0;
     switch (mode) {

--- a/src/it/resources/com/google/checkstyle/test/chapter4formatting/rule412nonemptyblocks/InputFormattedRightCurlySwitchCasesBlocks.java
+++ b/src/it/resources/com/google/checkstyle/test/chapter4formatting/rule412nonemptyblocks/InputFormattedRightCurlySwitchCasesBlocks.java
@@ -1,9 +1,9 @@
 package com.google.checkstyle.test.chapter4formatting.rule412nonemptyblocks;
 
-/** some javadoc. */
+/** Some javadoc. */
 public class InputFormattedRightCurlySwitchCasesBlocks {
 
-  /** some javadoc. */
+  /** Some javadoc. */
   public static void test0() {
     int mode = 0;
     switch (mode) {
@@ -24,7 +24,7 @@ public class InputFormattedRightCurlySwitchCasesBlocks {
     }
   }
 
-  /** some javadoc. */
+  /** Some javadoc. */
   public static void test() {
     int mode = 0;
     switch (mode) {
@@ -38,7 +38,7 @@ public class InputFormattedRightCurlySwitchCasesBlocks {
     }
   }
 
-  /** some javadoc. */
+  /** Some javadoc. */
   public static void test1() {
     int k = 0;
     switch (k) {
@@ -54,7 +54,7 @@ public class InputFormattedRightCurlySwitchCasesBlocks {
     }
   }
 
-  /** some javadoc. */
+  /** Some javadoc. */
   public static void test2() {
     int mode = 0;
     switch (mode) {
@@ -72,7 +72,7 @@ public class InputFormattedRightCurlySwitchCasesBlocks {
     }
   }
 
-  /** some javadoc. */
+  /** Some javadoc. */
   public static void test3() {
     int k = 0;
     switch (k) {
@@ -93,7 +93,7 @@ public class InputFormattedRightCurlySwitchCasesBlocks {
     }
   }
 
-  /** some javadoc. */
+  /** Some javadoc. */
   public static void test4() {
     int mode = 0;
     switch (mode) {
@@ -109,7 +109,7 @@ public class InputFormattedRightCurlySwitchCasesBlocks {
     }
   }
 
-  /** some javadoc. */
+  /** Some javadoc. */
   public static void test5() {
     int k = 0;
     switch (k) {
@@ -125,7 +125,7 @@ public class InputFormattedRightCurlySwitchCasesBlocks {
     }
   }
 
-  /** some javadoc. */
+  /** Some javadoc. */
   public static void test6() {
     int mode = 0;
     switch (mode) {
@@ -140,7 +140,7 @@ public class InputFormattedRightCurlySwitchCasesBlocks {
     }
   }
 
-  /** some javadoc. */
+  /** Some javadoc. */
   public static void test7() {
     int k = 0;
     switch (k) {

--- a/src/it/resources/com/google/checkstyle/test/chapter4formatting/rule412nonemptyblocks/InputFormattedTryCatchIfElse.java
+++ b/src/it/resources/com/google/checkstyle/test/chapter4formatting/rule412nonemptyblocks/InputFormattedTryCatchIfElse.java
@@ -1,6 +1,6 @@
 package com.google.checkstyle.test.chapter4formatting.rule412nonemptyblocks;
 
-/** some javadoc. */
+/** Some javadoc. */
 public class InputFormattedTryCatchIfElse {
 
   @interface TesterAnnotation {}
@@ -94,9 +94,9 @@ public class InputFormattedTryCatchIfElse {
     }
   }
 
-  /** some javadoc. */
+  /** Some javadoc. */
   public class MyResource implements AutoCloseable {
-    /** some javadoc. */
+    /** Some javadoc. */
     @Override
     public void close() throws Exception {
       System.out.println("Closed MyResource");

--- a/src/it/resources/com/google/checkstyle/test/chapter4formatting/rule412nonemptyblocks/InputFormattedTryCatchIfElse2.java
+++ b/src/it/resources/com/google/checkstyle/test/chapter4formatting/rule412nonemptyblocks/InputFormattedTryCatchIfElse2.java
@@ -1,8 +1,8 @@
 package com.google.checkstyle.test.chapter4formatting.rule412nonemptyblocks;
 
-/** some javadoc. */
+/** Some javadoc. */
 public class InputFormattedTryCatchIfElse2 {
-  /** some javadoc. */
+  /** Some javadoc. */
   public static void main(String[] args) {
     boolean after = false;
     try {

--- a/src/it/resources/com/google/checkstyle/test/chapter4formatting/rule412nonemptyblocks/InputNonemptyBlocksLeftRightCurly.java
+++ b/src/it/resources/com/google/checkstyle/test/chapter4formatting/rule412nonemptyblocks/InputNonemptyBlocksLeftRightCurly.java
@@ -3,7 +3,7 @@ package com.google.checkstyle.test.chapter4formatting.rule412nonemptyblocks;
 class InputNonemptyBlocksLeftRightCurly
   { // violation ''{' at column 3 should be on the previous line.'
     /**
-     * summary.
+     * Summary.
      *
      * @return helper func *
      */
@@ -155,7 +155,7 @@ class WithArraysLeft { // ok
 class InputRightCurlyOther2
   { // violation ''{' at column 3 should be on the previous line.'
     /**
-     * summary.
+     * Summary.
      *
      * @see test method *
      */
@@ -220,7 +220,7 @@ class InputRightCurlyOther2
       int x = 1;
     } // ok
 
-    /** some javadoc. */
+    /** Some javadoc. */
     public enum GreetingsEnum
     { // violation ''{' at column 5 should be on the previous line.'
       HELLO,

--- a/src/it/resources/com/google/checkstyle/test/chapter4formatting/rule412nonemptyblocks/InputRightCurly.java
+++ b/src/it/resources/com/google/checkstyle/test/chapter4formatting/rule412nonemptyblocks/InputRightCurly.java
@@ -1,8 +1,8 @@
 package com.google.checkstyle.test.chapter4formatting.rule412nonemptyblocks;
 
-/** some javadoc. */
+/** Some javadoc. */
 public class InputRightCurly {
-  /** some javadoc. */
+  /** Some javadoc. */
   public static void main(String[] args) {
     boolean after = false;
     try {

--- a/src/it/resources/com/google/checkstyle/test/chapter4formatting/rule412nonemptyblocks/InputRightCurlyDoWhile.java
+++ b/src/it/resources/com/google/checkstyle/test/chapter4formatting/rule412nonemptyblocks/InputRightCurlyDoWhile.java
@@ -5,12 +5,12 @@ import java.util.Scanner;
 /** Test input for GitHub issue #3090. https://github.com/checkstyle/checkstyle/issues/3090 . */
 public class InputRightCurlyDoWhile {
 
-  /** some javadoc. */
+  /** Some javadoc. */
   public void foo1() {
     do {} while (true);
   }
 
-  /** some javadoc. */
+  /** Some javadoc. */
   public void foo2() {
     int i = 1;
     while (i < 5) {
@@ -19,7 +19,7 @@ public class InputRightCurlyDoWhile {
     }
   }
 
-  /** some javadoc. */
+  /** Some javadoc. */
   public void foo3() {
     int i = 1;
     do {
@@ -28,7 +28,7 @@ public class InputRightCurlyDoWhile {
     } while (i < 5);
   }
 
-  /** some javadoc. */
+  /** Some javadoc. */
   public void foo4() {
     int prog;
     int user;
@@ -58,30 +58,30 @@ public class InputRightCurlyDoWhile {
     String.CASE_INSENSITIVE_ORDER.equals("Goodbye!");
   }
 
-  /** some javadoc. */
+  /** Some javadoc. */
   public void foo5() {
     do {} // violation ''}' at column 9 should be on the same line as the next part of .*'
     while (true);
   }
 
-  /** some javadoc. */
+  /** Some javadoc. */
   public void foo6() {
     do {} // violation ''}' at column 9 should be on the same line as the next part of .*'
     while (true);
   }
 
-  /** some javadoc. */
+  /** Some javadoc. */
   public void foo7() {
     do {} while (true);
   }
 
-  /** some javadoc. */
+  /** Some javadoc. */
   public void foo8() {
     do {} // violation ''}' at column 9 should be on the same line as the next part of .*'
     while (true);
   }
 
-  /** some javadoc. */
+  /** Some javadoc. */
   public void foo9() {
     do {} while (true);
   }

--- a/src/it/resources/com/google/checkstyle/test/chapter4formatting/rule412nonemptyblocks/InputRightCurlyDoWhile2.java
+++ b/src/it/resources/com/google/checkstyle/test/chapter4formatting/rule412nonemptyblocks/InputRightCurlyDoWhile2.java
@@ -6,12 +6,12 @@ import java.util.Scanner;
 /** Test input for GitHub issue #3090. https://github.com/checkstyle/checkstyle/issues/3090 . */
 public class InputRightCurlyDoWhile2 {
 
-  /** some javadoc. */
+  /** Some javadoc. */
   public void foo1() {
     do {} while (true);
   }
 
-  /** some javadoc. */
+  /** Some javadoc. */
   public void foo2() {
     int i = 1;
     while (i < 5) {
@@ -20,7 +20,7 @@ public class InputRightCurlyDoWhile2 {
     }
   }
 
-  /** some javadoc. */
+  /** Some javadoc. */
   public void foo3() {
     int i = 1;
     do {
@@ -29,7 +29,7 @@ public class InputRightCurlyDoWhile2 {
     } while (i < 5);
   }
 
-  /** some javadoc. */
+  /** Some javadoc. */
   public void foo4() {
     int prog;
     int user;
@@ -59,30 +59,30 @@ public class InputRightCurlyDoWhile2 {
     String.CASE_INSENSITIVE_ORDER.equals("Goodbye!");
   }
 
-  /** some javadoc. */
+  /** Some javadoc. */
   public void foo5() {
     do {} // violation ''}' at column 9 should be on the same line as the next part of .*'
     while (true);
   }
 
-  /** some javadoc. */
+  /** Some javadoc. */
   public void foo6() {
     do {} // violation ''}' at column 9 should be on the same line as the next part of .*'
     while (true);
   }
 
-  /** some javadoc. */
+  /** Some javadoc. */
   public void foo7() {
     do {} while (true);
   }
 
-  /** some javadoc. */
+  /** Some javadoc. */
   public void foo8() {
     do {} // violation ''}' at column 9 should be on the same line as the next part of .*'
     while (true);
   }
 
-  /** some javadoc. */
+  /** Some javadoc. */
   public void foo9() {
     do {} while (true);
   }

--- a/src/it/resources/com/google/checkstyle/test/chapter4formatting/rule412nonemptyblocks/InputRightCurlyOther.java
+++ b/src/it/resources/com/google/checkstyle/test/chapter4formatting/rule412nonemptyblocks/InputRightCurlyOther.java
@@ -2,7 +2,7 @@ package com.google.checkstyle.test.chapter4formatting.rule412nonemptyblocks;
 
 class InputRightCurlyOther {
   /**
-   * summary.
+   * Summary.
    *
    * @see test method *
    */

--- a/src/it/resources/com/google/checkstyle/test/chapter4formatting/rule412nonemptyblocks/InputRightCurlySwitchCase.java
+++ b/src/it/resources/com/google/checkstyle/test/chapter4formatting/rule412nonemptyblocks/InputRightCurlySwitchCase.java
@@ -1,9 +1,9 @@
 package com.google.checkstyle.test.chapter4formatting.rule412nonemptyblocks;
 
-/** some javadoc. */
+/** Some javadoc. */
 public class InputRightCurlySwitchCase {
 
-  /** some javadoc. */
+  /** Some javadoc. */
   public static void method0() {
     int mode = 0;
     switch (mode) {
@@ -14,7 +14,7 @@ public class InputRightCurlySwitchCase {
         x = 0; } // violation ''}' at column 16 should be alone on a line.'
   }
 
-  /** some javadoc. */
+  /** Some javadoc. */
   public static void method1() {
     int mode = 0;
     switch (mode) {
@@ -22,7 +22,7 @@ public class InputRightCurlySwitchCase {
         int x = 0; } // violation ''}' at column 20 should be alone on a line.'
   }
 
-  /** some javadoc. */
+  /** Some javadoc. */
   public static void method2() {
     int mode = 0;
     switch (mode) {
@@ -34,7 +34,7 @@ public class InputRightCurlySwitchCase {
     }
   }
 
-  /** some javadoc. */
+  /** Some javadoc. */
   public static void method3() {
     int mode = 0;
     switch (mode) {
@@ -43,7 +43,7 @@ public class InputRightCurlySwitchCase {
     }
   }
 
-  /** some javadoc. */
+  /** Some javadoc. */
   public static void method4() {
     int mode = 0;
     switch (mode) {

--- a/src/it/resources/com/google/checkstyle/test/chapter4formatting/rule412nonemptyblocks/InputRightCurlySwitchCasesBlocks.java
+++ b/src/it/resources/com/google/checkstyle/test/chapter4formatting/rule412nonemptyblocks/InputRightCurlySwitchCasesBlocks.java
@@ -1,9 +1,9 @@
 package com.google.checkstyle.test.chapter4formatting.rule412nonemptyblocks;
 
-/** some javadoc. */
+/** Some javadoc. */
 public class InputRightCurlySwitchCasesBlocks {
 
-  /** some javadoc. */
+  /** Some javadoc. */
   public static void test0() {
     int mode = 0;
     switch (mode) {
@@ -24,7 +24,7 @@ public class InputRightCurlySwitchCasesBlocks {
     }
   }
 
-  /** some javadoc. */
+  /** Some javadoc. */
   public static void test() {
     int mode = 0;
     switch (mode) {
@@ -40,7 +40,7 @@ public class InputRightCurlySwitchCasesBlocks {
     }
   }
 
-  /** some javadoc. */
+  /** Some javadoc. */
   public static void test1() {
     int k = 0;
     switch (k) {
@@ -55,7 +55,7 @@ public class InputRightCurlySwitchCasesBlocks {
     }
   }
 
-  /** some javadoc. */
+  /** Some javadoc. */
   public static void test2() {
     int mode = 0;
     switch (mode) {
@@ -73,7 +73,7 @@ public class InputRightCurlySwitchCasesBlocks {
     }
   }
 
-  /** some javadoc. */
+  /** Some javadoc. */
   public static void test3() {
     int k = 0;
     switch (k) {
@@ -88,7 +88,7 @@ public class InputRightCurlySwitchCasesBlocks {
     }
   }
 
-  /** some javadoc. */
+  /** Some javadoc. */
   public static void test4() {
     int mode = 0;
     switch (mode) {
@@ -105,7 +105,7 @@ public class InputRightCurlySwitchCasesBlocks {
     }
   }
 
-  /** some javadoc. */
+  /** Some javadoc. */
   public static void test5() {
     int k = 0;
     switch (k) {
@@ -118,7 +118,7 @@ public class InputRightCurlySwitchCasesBlocks {
     }
   }
 
-  /** some javadoc. */
+  /** Some javadoc. */
   public static void test6() {
     int mode = 0;
     switch (mode) {
@@ -132,7 +132,7 @@ public class InputRightCurlySwitchCasesBlocks {
     }
   }
 
-  /** some javadoc. */
+  /** Some javadoc. */
   public static void test7() {
     int k = 0;
     switch (k) {

--- a/src/it/resources/com/google/checkstyle/test/chapter4formatting/rule412nonemptyblocks/InputTryCatchIfElse.java
+++ b/src/it/resources/com/google/checkstyle/test/chapter4formatting/rule412nonemptyblocks/InputTryCatchIfElse.java
@@ -1,6 +1,6 @@
 package com.google.checkstyle.test.chapter4formatting.rule412nonemptyblocks;
 
-/** some javadoc. */
+/** Some javadoc. */
 public class InputTryCatchIfElse {
 
   @interface TesterAnnotation {} // ok
@@ -122,9 +122,9 @@ public class InputTryCatchIfElse {
     }
   }
 
-  /** some javadoc. */
+  /** Some javadoc. */
   public class MyResource implements AutoCloseable {
-    /** some javadoc. */
+    /** Some javadoc. */
     @Override
     public void close() throws Exception {
       System.out.println("Closed MyResource");

--- a/src/it/resources/com/google/checkstyle/test/chapter4formatting/rule412nonemptyblocks/InputTryCatchIfElse2.java
+++ b/src/it/resources/com/google/checkstyle/test/chapter4formatting/rule412nonemptyblocks/InputTryCatchIfElse2.java
@@ -1,8 +1,8 @@
 package com.google.checkstyle.test.chapter4formatting.rule412nonemptyblocks;
 
-/** some javadoc. */
+/** Some javadoc. */
 public class InputTryCatchIfElse2 {
-  /** some javadoc. */
+  /** Some javadoc. */
   public static void main(String[] args) {
     boolean after = false;
 

--- a/src/it/resources/com/google/checkstyle/test/chapter4formatting/rule413emptyblocks/InputEmptyBlocksAndCatchBlocks.java
+++ b/src/it/resources/com/google/checkstyle/test/chapter4formatting/rule413emptyblocks/InputEmptyBlocksAndCatchBlocks.java
@@ -84,9 +84,9 @@ class InputEmptyBlocksAndCatchBlocks {
     //  'WhitespaceAround: '}' is not preceded with whitespace.'
   }
 
-  /** some. */
+  /** Some. */
   public class MyResource implements AutoCloseable {
-    /** some. */
+    /** Some. */
     @Override
     public void close() throws Exception {
       System.out.println("Closed MyResource");

--- a/src/it/resources/com/google/checkstyle/test/chapter4formatting/rule413emptyblocks/InputEmptyBlocksAndCatchBlocksNoViolations.java
+++ b/src/it/resources/com/google/checkstyle/test/chapter4formatting/rule413emptyblocks/InputEmptyBlocksAndCatchBlocksNoViolations.java
@@ -6,7 +6,7 @@ package com.google.checkstyle.test.chapter4formatting.rule413emptyblocks;
 
 import java.io.IOException;
 
-/** some javadoc. */
+/** Some javadoc. */
 public class InputEmptyBlocksAndCatchBlocksNoViolations {
   private void foo6() {
     try {
@@ -16,7 +16,7 @@ public class InputEmptyBlocksAndCatchBlocksNoViolations {
     }
   }
 
-  /** some javadoc. */
+  /** Some javadoc. */
   public void testTryCatch() {
     try {
       int y = 0;
@@ -31,7 +31,7 @@ public class InputEmptyBlocksAndCatchBlocksNoViolations {
     }
   }
 
-  /** some javadoc. */
+  /** Some javadoc. */
   public void testTryCatch3() {
     try {
       int y = 0;
@@ -46,7 +46,7 @@ public class InputEmptyBlocksAndCatchBlocksNoViolations {
     }
   }
 
-  /** some javadoc. */
+  /** Some javadoc. */
   public void testTryCatch4() {
     int y = 0;
     int u = 8;
@@ -58,7 +58,7 @@ public class InputEmptyBlocksAndCatchBlocksNoViolations {
     }
   }
 
-  /** some javadoc. */
+  /** Some javadoc. */
   public void setFormats() {
     try {
       int k = 4;
@@ -72,7 +72,7 @@ public class InputEmptyBlocksAndCatchBlocksNoViolations {
     }
   }
 
-  /** some javadoc. */
+  /** Some javadoc. */
   public void testIfElse() {
     if (true) {
       return;
@@ -81,7 +81,7 @@ public class InputEmptyBlocksAndCatchBlocksNoViolations {
     }
   }
 
-  /** some javadoc. */
+  /** Some javadoc. */
   public void testIfElseIfLadder() {
     if (true) {
       return;
@@ -92,7 +92,7 @@ public class InputEmptyBlocksAndCatchBlocksNoViolations {
     }
   }
 
-  /** some javadoc. */
+  /** Some javadoc. */
   public void testSwtichCase() {
     switch (1) {
       case 1:

--- a/src/it/resources/com/google/checkstyle/test/chapter4formatting/rule413emptyblocks/InputEmptyCatchBlockViolationsByComment.java
+++ b/src/it/resources/com/google/checkstyle/test/chapter4formatting/rule413emptyblocks/InputEmptyCatchBlockViolationsByComment.java
@@ -2,7 +2,7 @@ package com.google.checkstyle.test.chapter4formatting.rule413emptyblocks;
 
 import java.io.IOException;
 
-/** some javadoc. */
+/** Some javadoc. */
 public class InputEmptyCatchBlockViolationsByComment {
   private void foo() {
     try {

--- a/src/it/resources/com/google/checkstyle/test/chapter4formatting/rule413emptyblocks/InputEmptyCatchBlockViolationsByVariableName.java
+++ b/src/it/resources/com/google/checkstyle/test/chapter4formatting/rule413emptyblocks/InputEmptyCatchBlockViolationsByVariableName.java
@@ -2,7 +2,7 @@ package com.google.checkstyle.test.chapter4formatting.rule413emptyblocks;
 
 import java.io.IOException;
 
-/** some javadoc. */
+/** Some javadoc. */
 public class InputEmptyCatchBlockViolationsByVariableName {
   private void foo() {
     try {

--- a/src/it/resources/com/google/checkstyle/test/chapter4formatting/rule413emptyblocks/InputEmptyCatchEmptyComment.java
+++ b/src/it/resources/com/google/checkstyle/test/chapter4formatting/rule413emptyblocks/InputEmptyCatchEmptyComment.java
@@ -2,7 +2,7 @@ package com.google.checkstyle.test.chapter4formatting.rule413emptyblocks;
 
 import java.io.IOException;
 
-/** some javadoc. */
+/** Some javadoc. */
 public class InputEmptyCatchEmptyComment {
   private void foo() {
     try {

--- a/src/it/resources/com/google/checkstyle/test/chapter4formatting/rule413emptyblocks/InputFormattedEmptyBlocksAndCatchBlocks.java
+++ b/src/it/resources/com/google/checkstyle/test/chapter4formatting/rule413emptyblocks/InputFormattedEmptyBlocksAndCatchBlocks.java
@@ -71,9 +71,9 @@ class InputFormattedEmptyBlocksAndCatchBlocks {
     }
   }
 
-  /** some. */
+  /** Some. */
   public class MyResource implements AutoCloseable {
-    /** some. */
+    /** Some. */
     @Override
     public void close() throws Exception {
       System.out.println("Closed MyResource");

--- a/src/it/resources/com/google/checkstyle/test/chapter4formatting/rule413emptyblocks/InputFormattedEmptyCatchEmptyComment.java
+++ b/src/it/resources/com/google/checkstyle/test/chapter4formatting/rule413emptyblocks/InputFormattedEmptyCatchEmptyComment.java
@@ -2,7 +2,7 @@ package com.google.checkstyle.test.chapter4formatting.rule413emptyblocks;
 
 import java.io.IOException;
 
-/** some javadoc. */
+/** Some javadoc. */
 public class InputFormattedEmptyCatchEmptyComment {
   private void foo() {
     try {

--- a/src/it/resources/com/google/checkstyle/test/chapter4formatting/rule42blockindentation/InputClassWithChainedMethods3.java
+++ b/src/it/resources/com/google/checkstyle/test/chapter4formatting/rule42blockindentation/InputClassWithChainedMethods3.java
@@ -1,12 +1,12 @@
 package com.google.checkstyle.test.chapter4formatting.rule42blockindentation;
 
-/** some javadoc. */
+/** Some javadoc. */
 public class InputClassWithChainedMethods3 {
 
-  /** some javadoc. */
+  /** Some javadoc. */
   public InputClassWithChainedMethods3(Object... params) {}
 
-  /** some javadoc. */
+  /** Some javadoc. */
   public static void main(String[] args) {
     new InputClassWithChainedMethods3()
         .getInstance("string_one")
@@ -24,12 +24,12 @@ public class InputClassWithChainedMethods3 {
     // violation 2 lines above ''new' has incorrect indentation level 4, expected .* 8.'
   }
 
-  /** some javadoc. */
+  /** Some javadoc. */
   public String doNothing(String something, String... uselessParams) {
     return something;
   }
 
-  /** some javadoc. */
+  /** Some javadoc. */
   public InputClassWithChainedMethods3 getInstance(String... uselessParams) {
     return this;
   }

--- a/src/it/resources/com/google/checkstyle/test/chapter4formatting/rule42blockindentation/InputFastMatcher.java
+++ b/src/it/resources/com/google/checkstyle/test/chapter4formatting/rule42blockindentation/InputFastMatcher.java
@@ -1,39 +1,39 @@
 package com.google.checkstyle.test.chapter4formatting.rule42blockindentation;
 
-/** some javadoc. */
+/** Some javadoc. */
 public class InputFastMatcher {
 
-  /** some javadoc. */
+  /** Some javadoc. */
   public boolean matches(char c) {
     // OOOO Auto-generated method stub
     return false;
   }
 
-  /** some javadoc. */
+  /** Some javadoc. */
   public String replaceFrom(CharSequence sequence, CharSequence replacement) {
     // OOOO Auto-generated method stub
     return null;
   }
 
-  /** some javadoc. */
+  /** Some javadoc. */
   public String collapseFrom(CharSequence sequence, char replacement) {
     // OOOO Auto-generated method stub
     return null;
   }
 
-  /** some javadoc. */
+  /** Some javadoc. */
   public String trimFrom(CharSequence s) {
     // OOOO Auto-generated method stub
     return null;
   }
 
-  /** some javadoc. */
+  /** Some javadoc. */
   public String trimLeadingFrom(CharSequence sequence) {
     // OOOO Auto-generated method stub
     return null;
   }
 
-  /** some javadoc. */
+  /** Some javadoc. */
   public String trimTrailingFrom(CharSequence sequence) {
     // OOOO Auto-generated method stub
     return null;

--- a/src/it/resources/com/google/checkstyle/test/chapter4formatting/rule42blockindentation/InputFormattedClassWithChainedMethods3.java
+++ b/src/it/resources/com/google/checkstyle/test/chapter4formatting/rule42blockindentation/InputFormattedClassWithChainedMethods3.java
@@ -1,8 +1,8 @@
 package com.google.checkstyle.test.chapter4formatting.rule42blockindentation;
 
-/** some javadoc. */
+/** Some javadoc. */
 public class InputFormattedClassWithChainedMethods3 {
-  /** some javadoc. */
+  /** Some javadoc. */
   public InputFormattedClassWithChainedMethods3() {
 
     String someString = "";
@@ -12,13 +12,13 @@ public class InputFormattedClassWithChainedMethods3 {
     doNothing(someString.concat("zyx").concat("255, 254, 253"));
   }
 
-  /** some javadoc. */
+  /** Some javadoc. */
   public static void main(String[] args) {
     InputFormattedClassWithChainedMethods3 classWithChainedMethodsCorrect =
         new InputFormattedClassWithChainedMethods3();
   }
 
-  /** some javadoc. */
+  /** Some javadoc. */
   public String doNothing(String something) {
     return something;
   }

--- a/src/it/resources/com/google/checkstyle/test/chapter4formatting/rule42blockindentation/InputIndentationCorrect.java
+++ b/src/it/resources/com/google/checkstyle/test/chapter4formatting/rule42blockindentation/InputIndentationCorrect.java
@@ -1,6 +1,6 @@
 package com.google.checkstyle.test.chapter4formatting.rule42blockindentation;
 
-/** some javadoc. */
+/** Some javadoc. */
 public abstract class InputIndentationCorrect {
 
   static int i;
@@ -19,12 +19,12 @@ public abstract class InputIndentationCorrect {
     abc = 2;
   }
 
-  /** some javadoc. */
+  /** Some javadoc. */
   public boolean matches(char c) {
     return false;
   }
 
-  /** some javadoc. */
+  /** Some javadoc. */
   public void foo() {
     int i = 0;
     for (; i < 9; i++) {
@@ -43,26 +43,26 @@ public abstract class InputIndentationCorrect {
     }
   }
 
-  /** some javadoc. */
+  /** Some javadoc. */
   public boolean veryLongLongLongCondition() {
     return veryLongLongLongCondition2();
   }
 
-  /** some javadoc. */
+  /** Some javadoc. */
   public boolean veryLongLongLongCondition2() {
     return false;
   }
 
-  /** some javadoc. */
+  /** Some javadoc. */
   public void someFooMethod(
       String longString, String superLongString, String exraSuperLongString) {}
 
-  /** some javadoc. */
+  /** Some javadoc. */
   public void fooThrowMethod() throws Exception {
     /* Some code*/
   }
 
-  /** some javadoc. */
+  /** Some javadoc. */
   public void doSmth() {
     for (int h : pqr) {
       someFooMethod("longString", "veryLongString", "superVeryExtraLongString");

--- a/src/it/resources/com/google/checkstyle/test/chapter4formatting/rule42blockindentation/InputIndentationCorrectAnnotationArrayInit.java
+++ b/src/it/resources/com/google/checkstyle/test/chapter4formatting/rule42blockindentation/InputIndentationCorrectAnnotationArrayInit.java
@@ -1,6 +1,6 @@
 package com.google.checkstyle.test.chapter4formatting.rule42blockindentation;
 
-/** some javadoc. */
+/** Some javadoc. */
 public class InputIndentationCorrectAnnotationArrayInit {
   interface MyInterface {
     @AnAnnotation(values = {"Hello"})

--- a/src/it/resources/com/google/checkstyle/test/chapter4formatting/rule42blockindentation/InputIndentationCorrectClass.java
+++ b/src/it/resources/com/google/checkstyle/test/chapter4formatting/rule42blockindentation/InputIndentationCorrectClass.java
@@ -2,10 +2,10 @@ package com.google.checkstyle.test.chapter4formatting.rule42blockindentation;
 
 import java.util.Iterator;
 
-/** some javadoc. */
+/** Some javadoc. */
 public class InputIndentationCorrectClass implements Runnable, Cloneable {
 
-  /** some javadoc. */
+  /** Some javadoc. */
   @Override
   public void run() {
     SecondClassWithLongLongLongLongName anon = new SecondClassWithLongLongLongLongName() {};

--- a/src/it/resources/com/google/checkstyle/test/chapter4formatting/rule42blockindentation/InputIndentationCorrectNewChildren.java
+++ b/src/it/resources/com/google/checkstyle/test/chapter4formatting/rule42blockindentation/InputIndentationCorrectNewChildren.java
@@ -1,6 +1,6 @@
 package com.google.checkstyle.test.chapter4formatting.rule42blockindentation;
 
-/** some javadoc. */
+/** Some javadoc. */
 public class InputIndentationCorrectNewChildren {
 
   private final StringBuffer filter =

--- a/src/it/resources/com/google/checkstyle/test/chapter4formatting/rule44columnlimit/InputColumnLimitEdgeCase.java
+++ b/src/it/resources/com/google/checkstyle/test/chapter4formatting/rule44columnlimit/InputColumnLimitEdgeCase.java
@@ -1,6 +1,6 @@
 package com.google.checkstyle.test.chapter4formatting.rule44columnlimit;
 
-/** some javadoc. */
+/** Some javadoc. */
 public class InputColumnLimitEdgeCase {
   void testMethod1() {
     String s3 =
@@ -19,7 +19,7 @@ public class InputColumnLimitEdgeCase {
         """;
   }
 
-  /** some javadoc. */
+  /** Some javadoc. */
   String getSampleTest() {
     return "String";
   }

--- a/src/it/resources/com/google/checkstyle/test/chapter4formatting/rule44columnlimit/InputFormattedColumnLimitEdgeCase.java
+++ b/src/it/resources/com/google/checkstyle/test/chapter4formatting/rule44columnlimit/InputFormattedColumnLimitEdgeCase.java
@@ -1,6 +1,6 @@
 package com.google.checkstyle.test.chapter4formatting.rule44columnlimit;
 
-/** some javadoc. */
+/** Some javadoc. */
 public class InputFormattedColumnLimitEdgeCase {
   void testMethod1() {
     String s3 =
@@ -19,7 +19,7 @@ public class InputFormattedColumnLimitEdgeCase {
         """;
   }
 
-  /** some javadoc. */
+  /** Some javadoc. */
   String getSampleTest() {
     return "String";
   }

--- a/src/it/resources/com/google/checkstyle/test/chapter4formatting/rule44columnlimit/InputFormattedTextBlockColumnLimit.java
+++ b/src/it/resources/com/google/checkstyle/test/chapter4formatting/rule44columnlimit/InputFormattedTextBlockColumnLimit.java
@@ -1,6 +1,6 @@
 package com.google.checkstyle.test.chapter4formatting.rule44columnlimit;
 
-/** somejavadoc. */
+/** Somejavadoc. */
 public class InputFormattedTextBlockColumnLimit {
   static final String SAMPLE =
       """
@@ -9,7 +9,7 @@ public class InputFormattedTextBlockColumnLimit {
       ST002,Station 002,ZONE2,,CP2,,668 Street,Unit 23,San Jose,CA,95191,US,37.35102477242508,-121.9209934020318
       """;
 
-  /** somejavadoc. */
+  /** Somejavadoc. */
   public static void main(String[] args) {
     String textBlock =
         """

--- a/src/it/resources/com/google/checkstyle/test/chapter4formatting/rule44columnlimit/InputTextBlockColumnLimit.java
+++ b/src/it/resources/com/google/checkstyle/test/chapter4formatting/rule44columnlimit/InputTextBlockColumnLimit.java
@@ -1,6 +1,6 @@
 package com.google.checkstyle.test.chapter4formatting.rule44columnlimit;
 
-/** somejavadoc. */
+/** Somejavadoc. */
 public class InputTextBlockColumnLimit {
   // violation below 'Opening quotes (""") of text-block must be on the new line'
   static final String SAMPLE = """
@@ -10,7 +10,7 @@ public class InputTextBlockColumnLimit {
       """;
   // violation above 'Text-block quotes are not vertically aligned'
 
-  /** somejavadoc. */
+  /** Somejavadoc. */
   public static void main(String[] args) {
     // violation below 'Opening quotes (""") of text-block must be on the new line'
     String textBlock = """

--- a/src/it/resources/com/google/checkstyle/test/chapter4formatting/rule451wheretobreak/InputFormattedIllegalLineBreakAroundLambda.java
+++ b/src/it/resources/com/google/checkstyle/test/chapter4formatting/rule451wheretobreak/InputFormattedIllegalLineBreakAroundLambda.java
@@ -2,7 +2,7 @@ package com.google.checkstyle.test.chapter4formatting.rule451wheretobreak;
 
 import java.util.ArrayList;
 
-/** some javadoc. */
+/** Some javadoc. */
 public class InputFormattedIllegalLineBreakAroundLambda {
 
   private interface MyLambdaInterface {
@@ -61,7 +61,7 @@ public class InputFormattedIllegalLineBreakAroundLambda {
         };
   }
 
-  /** some javadoc. */
+  /** Some javadoc. */
   public enum TransactionStatus {
     NotValidTryAgain,
     ErrorInProcessingTryAgain,

--- a/src/it/resources/com/google/checkstyle/test/chapter4formatting/rule451wheretobreak/InputIllegalLineBreakAroundLambda.java
+++ b/src/it/resources/com/google/checkstyle/test/chapter4formatting/rule451wheretobreak/InputIllegalLineBreakAroundLambda.java
@@ -2,7 +2,7 @@ package com.google.checkstyle.test.chapter4formatting.rule451wheretobreak;
 
 import java.util.ArrayList;
 
-/** some javadoc. */
+/** Some javadoc. */
 public class InputIllegalLineBreakAroundLambda {
 
   private interface MyLambdaInterface {
@@ -70,7 +70,7 @@ public class InputIllegalLineBreakAroundLambda {
     };
   }
 
-  /** some javadoc. */
+  /** Some javadoc. */
   public enum TransactionStatus {
     NotValidTryAgain,
     ErrorInProcessingTryAgain,

--- a/src/it/resources/com/google/checkstyle/test/chapter4formatting/rule452indentcontinuationlines/InputClassWithChainedMethods2.java
+++ b/src/it/resources/com/google/checkstyle/test/chapter4formatting/rule452indentcontinuationlines/InputClassWithChainedMethods2.java
@@ -1,12 +1,12 @@
 package com.google.checkstyle.test.chapter4formatting.rule452indentcontinuationlines;
 
-/** some javadoc. */
+/** Some javadoc. */
 public class InputClassWithChainedMethods2 {
 
-  /** some javadoc. */
+  /** Some javadoc. */
   public InputClassWithChainedMethods2(Object... params) {}
 
-  /** some javadoc. */
+  /** Some javadoc. */
   public static void main(String[] args) {
     new InputClassWithChainedMethods2()
         .getInstance("string_one")
@@ -24,12 +24,12 @@ public class InputClassWithChainedMethods2 {
     // violation 2 lines above ''new' has incorrect indentation level 4, expected .* 8.'
   }
 
-  /** some javadoc. */
+  /** Some javadoc. */
   public String doNothing(String something, String... uselessParams) {
     return something;
   }
 
-  /** some javadoc. */
+  /** Some javadoc. */
   public InputClassWithChainedMethods2 getInstance(String... uselessParams) {
     return this;
   }

--- a/src/it/resources/com/google/checkstyle/test/chapter4formatting/rule452indentcontinuationlines/InputFastMatcher.java
+++ b/src/it/resources/com/google/checkstyle/test/chapter4formatting/rule452indentcontinuationlines/InputFastMatcher.java
@@ -1,39 +1,39 @@
 package com.google.checkstyle.test.chapter4formatting.rule452indentcontinuationlines;
 
-/** some javadoc. */
+/** Some javadoc. */
 public class InputFastMatcher {
 
-  /** some javadoc. */
+  /** Some javadoc. */
   public boolean matches(char c) {
     // OOOO Auto-generated method stub
     return false;
   }
 
-  /** some javadoc. */
+  /** Some javadoc. */
   public String replaceFrom(CharSequence sequence, CharSequence replacement) {
     // OOOO Auto-generated method stub
     return null;
   }
 
-  /** some javadoc. */
+  /** Some javadoc. */
   public String collapseFrom(CharSequence sequence, char replacement) {
     // OOOO Auto-generated method stub
     return null;
   }
 
-  /** some javadoc. */
+  /** Some javadoc. */
   public String trimFrom(CharSequence s) {
     // OOOO Auto-generated method stub
     return null;
   }
 
-  /** some javadoc. */
+  /** Some javadoc. */
   public String trimLeadingFrom(CharSequence sequence) {
     // OOOO Auto-generated method stub
     return null;
   }
 
-  /** some javadoc. */
+  /** Some javadoc. */
   public String trimTrailingFrom(CharSequence sequence) {
     // OOOO Auto-generated method stub
     return null;

--- a/src/it/resources/com/google/checkstyle/test/chapter4formatting/rule452indentcontinuationlines/InputFormattedClassWithChainedMethods2.java
+++ b/src/it/resources/com/google/checkstyle/test/chapter4formatting/rule452indentcontinuationlines/InputFormattedClassWithChainedMethods2.java
@@ -1,8 +1,8 @@
 package com.google.checkstyle.test.chapter4formatting.rule452indentcontinuationlines;
 
-/** some javadoc. */
+/** Some javadoc. */
 public class InputFormattedClassWithChainedMethods2 {
-  /** some javadoc. */
+  /** Some javadoc. */
   public InputFormattedClassWithChainedMethods2() {
 
     String someString = "";
@@ -12,13 +12,13 @@ public class InputFormattedClassWithChainedMethods2 {
     doNothing(someString.concat("zyx").concat("255, 254, 253"));
   }
 
-  /** some javadoc. */
+  /** Some javadoc. */
   public static void main(String[] args) {
     InputFormattedClassWithChainedMethods2 classWithChainedMethodsCorrect =
         new InputFormattedClassWithChainedMethods2();
   }
 
-  /** some javadoc. */
+  /** Some javadoc. */
   public String doNothing(String something) {
     return something;
   }

--- a/src/it/resources/com/google/checkstyle/test/chapter4formatting/rule452indentcontinuationlines/InputIndentationCorrect.java
+++ b/src/it/resources/com/google/checkstyle/test/chapter4formatting/rule452indentcontinuationlines/InputIndentationCorrect.java
@@ -1,6 +1,6 @@
 package com.google.checkstyle.test.chapter4formatting.rule452indentcontinuationlines;
 
-/** some javadoc. */
+/** Some javadoc. */
 public abstract class InputIndentationCorrect {
 
   static int i;
@@ -19,12 +19,12 @@ public abstract class InputIndentationCorrect {
     abc = 2;
   }
 
-  /** some javadoc. */
+  /** Some javadoc. */
   public boolean matches(char c) {
     return false;
   }
 
-  /** some javadoc. */
+  /** Some javadoc. */
   public void foo() {
     int i = 0;
     for (; i < 9; i++) {
@@ -43,26 +43,26 @@ public abstract class InputIndentationCorrect {
     }
   }
 
-  /** some javadoc. */
+  /** Some javadoc. */
   public boolean veryLongLongLongCondition() {
     return veryLongLongLongCondition2();
   }
 
-  /** some javadoc. */
+  /** Some javadoc. */
   public boolean veryLongLongLongCondition2() {
     return false;
   }
 
-  /** some javadoc. */
+  /** Some javadoc. */
   public void someFooMethod(
       String longString, String superLongString, String exraSuperLongString) {}
 
-  /** some javadoc. */
+  /** Some javadoc. */
   public void fooThrowMethod() throws Exception {
     /* Some code*/
   }
 
-  /** some javadoc. */
+  /** Some javadoc. */
   public void doSmth() {
     for (int h : pqr) {
       someFooMethod("longString", "veryLongString", "superVeryExtraLongString");

--- a/src/it/resources/com/google/checkstyle/test/chapter4formatting/rule452indentcontinuationlines/InputIndentationCorrectAnnotationArrayInit.java
+++ b/src/it/resources/com/google/checkstyle/test/chapter4formatting/rule452indentcontinuationlines/InputIndentationCorrectAnnotationArrayInit.java
@@ -1,6 +1,6 @@
 package com.google.checkstyle.test.chapter4formatting.rule452indentcontinuationlines;
 
-/** some javadoc. */
+/** Some javadoc. */
 public class InputIndentationCorrectAnnotationArrayInit {
   interface MyInterface {
     @AnAnnotation(values = {"Hello"})

--- a/src/it/resources/com/google/checkstyle/test/chapter4formatting/rule452indentcontinuationlines/InputIndentationCorrectClass.java
+++ b/src/it/resources/com/google/checkstyle/test/chapter4formatting/rule452indentcontinuationlines/InputIndentationCorrectClass.java
@@ -2,10 +2,10 @@ package com.google.checkstyle.test.chapter4formatting.rule452indentcontinuationl
 
 import java.util.Iterator;
 
-/** some javadoc. */
+/** Some javadoc. */
 public class InputIndentationCorrectClass implements Runnable, Cloneable {
 
-  /** some javadoc. */
+  /** Some javadoc. */
   @Override
   public void run() {
     SecondClassWithLongLongLongLongName anon = new SecondClassWithLongLongLongLongName() {};

--- a/src/it/resources/com/google/checkstyle/test/chapter4formatting/rule452indentcontinuationlines/InputIndentationCorrectNewChildren.java
+++ b/src/it/resources/com/google/checkstyle/test/chapter4formatting/rule452indentcontinuationlines/InputIndentationCorrectNewChildren.java
@@ -1,6 +1,6 @@
 package com.google.checkstyle.test.chapter4formatting.rule452indentcontinuationlines;
 
-/** some javadoc. */
+/** Some javadoc. */
 public class InputIndentationCorrectNewChildren {
 
   private final StringBuffer filter =

--- a/src/it/resources/com/google/checkstyle/test/chapter4formatting/rule462horizontalwhitespace/InputFormattedGenericWhitespaceEndsTheLine.java
+++ b/src/it/resources/com/google/checkstyle/test/chapter4formatting/rule462horizontalwhitespace/InputFormattedGenericWhitespaceEndsTheLine.java
@@ -1,8 +1,8 @@
 package com.google.checkstyle.test.chapter4formatting.rule462horizontalwhitespace;
 
-/** some javadoc. */
+/** Some javadoc. */
 public class InputFormattedGenericWhitespaceEndsTheLine {
-  /** some javadoc. */
+  /** Some javadoc. */
   public boolean returnsGenericObjectAtEndOfLine(Object otherObject) {
     return otherObject instanceof Enum<?>;
   }

--- a/src/it/resources/com/google/checkstyle/test/chapter4formatting/rule462horizontalwhitespace/InputFormattedMethodParamPad2.java
+++ b/src/it/resources/com/google/checkstyle/test/chapter4formatting/rule462horizontalwhitespace/InputFormattedMethodParamPad2.java
@@ -4,23 +4,23 @@ import java.util.Vector;
 
 /** Test input for MethodDefPadCheck. */
 public class InputFormattedMethodParamPad2 {
-  /** some javadoc. */
+  /** Some javadoc. */
   public InputFormattedMethodParamPad2() {
     super();
   }
 
-  /** some javadoc. */
+  /** Some javadoc. */
   public InputFormattedMethodParamPad2(int param) {
     super();
   }
 
-  /** some javadoc. */
+  /** Some javadoc. */
   public void method() {}
 
-  /** some javadoc. */
+  /** Some javadoc. */
   public void method(int param) {}
 
-  /** some javadoc. */
+  /** Some javadoc. */
   public void method(double param) {
     // invoke constructor
     InputFormattedMethodParamPad2 pad = new InputFormattedMethodParamPad2();
@@ -32,7 +32,7 @@ public class InputFormattedMethodParamPad2 {
     method();
   }
 
-  /** some javadoc. */
+  /** Some javadoc. */
   public void dottedCalls() {
     this.method();
     this.method();
@@ -48,7 +48,7 @@ public class InputFormattedMethodParamPad2 {
     Integer.parseInt("0");
   }
 
-  /** some javadoc. */
+  /** Some javadoc. */
   public void newArray() {
     int[] a = new int[] {0, 1};
     Vector<String> v = new Vector<String>();

--- a/src/it/resources/com/google/checkstyle/test/chapter4formatting/rule462horizontalwhitespace/InputFormattedNoWhitespaceBeforeAnnotations.java
+++ b/src/it/resources/com/google/checkstyle/test/chapter4formatting/rule462horizontalwhitespace/InputFormattedNoWhitespaceBeforeAnnotations.java
@@ -3,7 +3,7 @@ package com.google.checkstyle.test.chapter4formatting.rule462horizontalwhitespac
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Target;
 
-/** some javadoc. */
+/** Some javadoc. */
 public class InputFormattedNoWhitespaceBeforeAnnotations {
 
   @Target(ElementType.TYPE_USE)
@@ -18,22 +18,22 @@ public class InputFormattedNoWhitespaceBeforeAnnotations {
   @NonNull int @AnnoType [] @NonNull2 [] fiel1;
   @NonNull int @AnnoType [] @NonNull2 [] field2;
 
-  /** some javadoc. */
+  /** Some javadoc. */
   public void foo(final char @NonNull [] param) {}
 
   // @NonNull int @NonNull ... field3; // non-compilable
   // @NonNull int @NonNull... field4; // non-compilable
 
-  /** some javadoc. */
+  /** Some javadoc. */
   public void foo1(final char[] param) {}
 
-  /** some javadoc. */
+  /** Some javadoc. */
   public void foo2(final char[] param) {}
 
-  /** some javadoc. */
+  /** Some javadoc. */
   public void foo3(final char @NonNull [] param) {}
 
-  /** some javadoc. */
+  /** Some javadoc. */
   public void foo4(final char @NonNull [] param) {}
 
   void test1(String... param) {}

--- a/src/it/resources/com/google/checkstyle/test/chapter4formatting/rule462horizontalwhitespace/InputFormattedNoWhitespaceBeforeCaseDefaultColon.java
+++ b/src/it/resources/com/google/checkstyle/test/chapter4formatting/rule462horizontalwhitespace/InputFormattedNoWhitespaceBeforeCaseDefaultColon.java
@@ -1,6 +1,6 @@
 package com.google.checkstyle.test.chapter4formatting.rule462horizontalwhitespace;
 
-/** some javadoc. */
+/** Some javadoc. */
 public class InputFormattedNoWhitespaceBeforeCaseDefaultColon {
   {
     switch (1) {

--- a/src/it/resources/com/google/checkstyle/test/chapter4formatting/rule462horizontalwhitespace/InputFormattedNoWhitespaceBeforeColonOfLabel.java
+++ b/src/it/resources/com/google/checkstyle/test/chapter4formatting/rule462horizontalwhitespace/InputFormattedNoWhitespaceBeforeColonOfLabel.java
@@ -1,6 +1,6 @@
 package com.google.checkstyle.test.chapter4formatting.rule462horizontalwhitespace;
 
-/** some javadoc. */
+/** Some javadoc. */
 public class InputFormattedNoWhitespaceBeforeColonOfLabel {
 
   {
@@ -8,7 +8,7 @@ public class InputFormattedNoWhitespaceBeforeColonOfLabel {
     for (int i = 0; i < 10; i++) {}
   }
 
-  /** some javadoc. */
+  /** Some javadoc. */
   public void foo() {
     label2:
     while (true) {}

--- a/src/it/resources/com/google/checkstyle/test/chapter4formatting/rule462horizontalwhitespace/InputFormattedNoWhitespaceBeforeEllipsis.java
+++ b/src/it/resources/com/google/checkstyle/test/chapter4formatting/rule462horizontalwhitespace/InputFormattedNoWhitespaceBeforeEllipsis.java
@@ -3,7 +3,7 @@ package com.google.checkstyle.test.chapter4formatting.rule462horizontalwhitespac
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Target;
 
-/** some javadoc. */
+/** Some javadoc. */
 public class InputFormattedNoWhitespaceBeforeEllipsis {
 
   @Target(ElementType.TYPE_USE)
@@ -23,28 +23,28 @@ public class InputFormattedNoWhitespaceBeforeEllipsis {
   // @NonNull int @NonNull ... field3; // non-compilable
   // @NonNull int @NonNull... field4; // non-compilable
 
-  /** some javadoc. */
+  /** Some javadoc. */
   void test1(String... param) {}
 
-  /** some javadoc. */
+  /** Some javadoc. */
   void test2(String... param) {}
 
-  /** some javadoc. */
+  /** Some javadoc. */
   void test3(String @NonNull ... param) {}
 
-  /** some javadoc. */
+  /** Some javadoc. */
   void test4(String @NonNull ... param) {}
 
-  /** some javadoc. */
+  /** Some javadoc. */
   void test5(String[]... param) {}
 
-  /** some javadoc. */
+  /** Some javadoc. */
   void test6(String[]... param) {}
 
-  /** some javadoc. */
+  /** Some javadoc. */
   void test7(String @NonNull []... param) {}
 
-  /** some javadoc. */
+  /** Some javadoc. */
   void test8(String @NonNull []... param) {}
 
   void test9(String @Size(max = 10) ... names) {}

--- a/src/it/resources/com/google/checkstyle/test/chapter4formatting/rule462horizontalwhitespace/InputFormattedNoWhitespaceBeforeEmptyForLoop.java
+++ b/src/it/resources/com/google/checkstyle/test/chapter4formatting/rule462horizontalwhitespace/InputFormattedNoWhitespaceBeforeEmptyForLoop.java
@@ -1,9 +1,9 @@
 package com.google.checkstyle.test.chapter4formatting.rule462horizontalwhitespace;
 
-/** some javadoc. */
+/** Some javadoc. */
 public class InputFormattedNoWhitespaceBeforeEmptyForLoop {
 
-  /** some javadoc. */
+  /** Some javadoc. */
   public static void foo() {
     for (; ; ) { // ok
       break;

--- a/src/it/resources/com/google/checkstyle/test/chapter4formatting/rule462horizontalwhitespace/InputFormattedParenPad.java
+++ b/src/it/resources/com/google/checkstyle/test/chapter4formatting/rule462horizontalwhitespace/InputFormattedParenPad.java
@@ -4,7 +4,7 @@ import java.io.IOException;
 import java.io.StringWriter;
 import java.io.Writer;
 
-/** some javadoc. */
+/** Some javadoc. */
 public class InputFormattedParenPad {
   boolean fooo = this.bar((true && false) && true);
 
@@ -13,7 +13,7 @@ public class InputFormattedParenPad {
         .toString();
   }
 
-  /** some javadoc. */
+  /** Some javadoc. */
   @MyAnnotation
   public boolean bar(boolean a) {
     assert (true);
@@ -140,7 +140,7 @@ public class InputFormattedParenPad {
       }
     }
 
-    /** some javadoc. */
+    /** Some javadoc. */
     public void myMethod() {
       String s = "test";
       Object o = s;
@@ -148,7 +148,7 @@ public class InputFormattedParenPad {
       ((String) o).length();
     }
 
-    /** some javadoc. */
+    /** Some javadoc. */
     public void crisRon() {
       Object leo = "messi";
       Object ibra = leo;
@@ -156,7 +156,7 @@ public class InputFormattedParenPad {
       Math.random();
     }
 
-    /** some javadoc. */
+    /** Some javadoc. */
     public void intStringConv() {
       Object a = 5;
       Object b = "string";
@@ -167,7 +167,7 @@ public class InputFormattedParenPad {
       String d = ((String) b);
     }
 
-    /** some javadoc. */
+    /** Some javadoc. */
     public int something(Object o) {
       if (o == null || !(o instanceof Float)) {
         return -1;
@@ -180,7 +180,7 @@ public class InputFormattedParenPad {
       boolean result = number == 123;
     }
 
-    /** some javadoc. */
+    /** Some javadoc. */
     public String testing() {
       return (this.exam != null) ? ((Enum) this.exam).name() : null;
     }

--- a/src/it/resources/com/google/checkstyle/test/chapter4formatting/rule462horizontalwhitespace/InputFormattedWhitespaceAfterBad.java
+++ b/src/it/resources/com/google/checkstyle/test/chapter4formatting/rule462horizontalwhitespace/InputFormattedWhitespaceAfterBad.java
@@ -1,8 +1,8 @@
 package com.google.checkstyle.test.chapter4formatting.rule462horizontalwhitespace;
 
-/** some javadoc. */
+/** Some javadoc. */
 public class InputFormattedWhitespaceAfterBad {
-  /** some javadoc. */
+  /** Some javadoc. */
   public void check1(int x, int y) {
     // violation below ''for' construct must use '{}'s.'
     for (int a = 1, b = 2; a < 5; a++, b--)
@@ -16,7 +16,7 @@ public class InputFormattedWhitespaceAfterBad {
     } while (x == 0 || y == 2);
   }
 
-  /** some javadoc. */
+  /** Some javadoc. */
   public void check2(final int a, final int b) {
     if ((float) a == 0.0) {
       System.out.println("true");
@@ -25,7 +25,7 @@ public class InputFormattedWhitespaceAfterBad {
     }
   }
 
-  /** some javadoc. */
+  /** Some javadoc. */
   public void check3(int... a) {
     Runnable r2 = () -> String.valueOf("Hello world two!");
     switch (a[0]) {
@@ -34,14 +34,14 @@ public class InputFormattedWhitespaceAfterBad {
     }
   }
 
-  /** some javadoc. */
+  /** Some javadoc. */
   public void check4() throws java.io.IOException {
     try (java.io.InputStream ignored = System.in; ) {
       /* foo */
     }
   }
 
-  /** some javadoc. */
+  /** Some javadoc. */
   public void check5() {
     try {
       /* foo */
@@ -57,7 +57,7 @@ public class InputFormattedWhitespaceAfterBad {
     }
   }
 
-  /** some javadoc. */
+  /** Some javadoc. */
   public void check6() {
     try {
       /* foo */
@@ -66,7 +66,7 @@ public class InputFormattedWhitespaceAfterBad {
     }
   }
 
-  /** some javadoc. */
+  /** Some javadoc. */
   public void check7() {
     synchronized (this) {
     }
@@ -75,7 +75,7 @@ public class InputFormattedWhitespaceAfterBad {
     }
   }
 
-  /** some javadoc. */
+  /** Some javadoc. */
   public String check8() {
     return ("a" + "b");
   }

--- a/src/it/resources/com/google/checkstyle/test/chapter4formatting/rule462horizontalwhitespace/InputFormattedWhitespaceAfterDoubleSlashes.java
+++ b/src/it/resources/com/google/checkstyle/test/chapter4formatting/rule462horizontalwhitespace/InputFormattedWhitespaceAfterDoubleSlashes.java
@@ -6,11 +6,11 @@
 
 package com.google.checkstyle.test.chapter4formatting.rule462horizontalwhitespace;
 
-/** some javadoc. */
+/** Some javadoc. */
 public class InputFormattedWhitespaceAfterDoubleSlashes {
   String googleCheck = "Google"; // google
 
-  /** somejavadoc. */
+  /** Somejavadoc. */
   public void foo1() {
     int pro1 = 0; // the main variable
 

--- a/src/it/resources/com/google/checkstyle/test/chapter4formatting/rule462horizontalwhitespace/InputFormattedWhitespaceAfterGood.java
+++ b/src/it/resources/com/google/checkstyle/test/chapter4formatting/rule462horizontalwhitespace/InputFormattedWhitespaceAfterGood.java
@@ -1,13 +1,13 @@
 package com.google.checkstyle.test.chapter4formatting.rule462horizontalwhitespace;
 
-/** some javadoc. */
+/** Some javadoc. */
 public class InputFormattedWhitespaceAfterGood {
 
   int xyz; // multiple space between content and double slash.
   int abc; //       multiple space between double slash and comment's text.
   int pqr; //     testing both.
 
-  /** some javadoc. */
+  /** Some javadoc. */
   public void check1(int x, int y) {
     // violation below ''for' construct must use '{}'s.'
     for (int a = 1, b = 2; a < 5; a++, b--)
@@ -21,7 +21,7 @@ public class InputFormattedWhitespaceAfterGood {
     } while (x == 0 || y == 2);
   }
 
-  /** some javadoc. */
+  /** Some javadoc. */
   public void check2(final int a, final int b) {
     if ((float) a == 0.0) {
       System.out.println("true");
@@ -30,7 +30,7 @@ public class InputFormattedWhitespaceAfterGood {
     }
   }
 
-  /** some javadoc. */
+  /** Some javadoc. */
   public void check3(int... a) {
     Runnable r2 = () -> String.valueOf("Hello world two!");
     switch (a[0]) {
@@ -39,7 +39,7 @@ public class InputFormattedWhitespaceAfterGood {
     }
   }
 
-  /** some javadoc. */
+  /** Some javadoc. */
   public void check4() throws java.io.IOException {
     try (java.io.InputStream ignored = System.in) {
       /* foo */
@@ -51,7 +51,7 @@ public class InputFormattedWhitespaceAfterGood {
     }
   }
 
-  /** some javadoc. */
+  /** Some javadoc. */
   public void check5() {
 
     try {
@@ -61,7 +61,7 @@ public class InputFormattedWhitespaceAfterGood {
     }
   }
 
-  /** some javadoc. */
+  /** Some javadoc. */
   public void check6() {
     try {
       /* foo. */
@@ -70,13 +70,13 @@ public class InputFormattedWhitespaceAfterGood {
     }
   }
 
-  /** some javadoc. */
+  /** Some javadoc. */
   public void check7() {
     synchronized (this) {
     }
   }
 
-  /** some javadoc. */
+  /** Some javadoc. */
   public String check8() {
     return ("a" + "b");
   }

--- a/src/it/resources/com/google/checkstyle/test/chapter4formatting/rule462horizontalwhitespace/InputFormattedWhitespaceAroundArrow.java
+++ b/src/it/resources/com/google/checkstyle/test/chapter4formatting/rule462horizontalwhitespace/InputFormattedWhitespaceAroundArrow.java
@@ -10,7 +10,7 @@ import java.util.List;
 import java.util.stream.Collectors;
 import javax.swing.JCheckBox;
 
-/** some javadoc. */
+/** Some javadoc. */
 public class InputFormattedWhitespaceAroundArrow {
   static {
     new JCheckBox()
@@ -28,7 +28,7 @@ public class InputFormattedWhitespaceAroundArrow {
     }
   }
 
-  /** method. */
+  /** Method. */
   void test(Object o, Object o2, int y) {
     switch (o) {
       case String s when (s.equals("a")) -> {}
@@ -88,18 +88,18 @@ public class InputFormattedWhitespaceAroundArrow {
             .orElseThrow(() -> new IllegalStateException("big problem"));
   }
 
-  /** some javadoc. */
+  /** Some javadoc. */
   record Point(int x, int y) {}
 
-  /** some javadoc. */
+  /** Some javadoc. */
   public interface Predicate {
-    /** some javadoc. */
+    /** Some javadoc. */
     boolean test(Object value);
   }
 
-  /** some javadoc. */
+  /** Some javadoc. */
   public interface VoidPredicate {
-    /** some javadoc. */
+    /** Some javadoc. */
     public boolean get();
   }
 }

--- a/src/it/resources/com/google/checkstyle/test/chapter4formatting/rule462horizontalwhitespace/InputFormattedWhitespaceAroundBasic.java
+++ b/src/it/resources/com/google/checkstyle/test/chapter4formatting/rule462horizontalwhitespace/InputFormattedWhitespaceAroundBasic.java
@@ -15,21 +15,21 @@ class InputFormattedWhitespaceAroundBasic {
   /** Should be ok. */
   private final int var3 = 1;
 
-  /** skip blank lines between comment and code, should be ok. */
+  /** Skip blank lines between comment and code, should be ok. */
   private final int var4 = 1;
 
   int xyz; // multiple space between content and double slash.
   int abc; //       multiple space between double slash and comment's text.
   int pqr; //     testing both.
 
-  /** bug 806243 (NoWhitespaceBeforeCheck violation for anonymous inner class). */
+  /** Bug 806243 (NoWhitespaceBeforeCheck violation for anonymous inner class). */
   private int test;
 
   private int i4;
   private int i5;
   private int i6;
 
-  /** method. */
+  /** Method. */
   void method1() {
     final int a = 1;
     int b = 1;
@@ -40,7 +40,7 @@ class InputFormattedWhitespaceAroundBasic {
     b = ++b - --b;
   }
 
-  /** method. */
+  /** Method. */
   void method2() {
     synchronized (this) {
     }
@@ -51,7 +51,7 @@ class InputFormattedWhitespaceAroundBasic {
     }
   }
 
-  /** test WS after void return. */
+  /** Test WS after void return. */
   private void fastExit() {
     boolean complicatedStuffNeeded = true;
     if (!complicatedStuffNeeded) {
@@ -62,7 +62,7 @@ class InputFormattedWhitespaceAroundBasic {
   }
 
   /**
-   * test WS after non void return.
+   * Test WS after non void return.
    *
    * @return 2
    */
@@ -74,7 +74,7 @@ class InputFormattedWhitespaceAroundBasic {
     }
   }
 
-  /** test casts. */
+  /** Test casts. */
   private void testCasts() {
     Object o = (Object) new Object();
     o = (Object) o;
@@ -82,25 +82,25 @@ class InputFormattedWhitespaceAroundBasic {
     o = (Object) o;
   }
 
-  /** test questions. */
+  /** Test questions. */
   private void testQuestions() {
 
     boolean b = (1 == 2) ? false : true;
   }
 
-  /** star test. */
+  /** Star test. */
   private void starTest() {
     int x = 2 * 3 * 4;
   }
 
-  /** boolean test. */
+  /** Boolean test. */
   private void boolTest() {
     boolean a = true;
     boolean x = !a;
     int z = ~1 + ~2;
   }
 
-  /** division test. */
+  /** Division test. */
   private void divTest() {
     int a = 4 % 2;
     int b = 4 % 2;
@@ -112,7 +112,7 @@ class InputFormattedWhitespaceAroundBasic {
   }
 
   /**
-   * summary.
+   * Summary.
    *
    * @return dot test *
    */
@@ -124,7 +124,7 @@ class InputFormattedWhitespaceAroundBasic {
     return o.toString();
   }
 
-  /** assert statement test. */
+  /** Assert statement test. */
   public void assertTest() {
 
     assert true;
@@ -141,7 +141,7 @@ class InputFormattedWhitespaceAroundBasic {
     assert true : "Whups";
   }
 
-  /** another check. */
+  /** Another check. */
   void donBradman(Runnable run) {
     donBradman(
         new Runnable() {
@@ -154,13 +154,13 @@ class InputFormattedWhitespaceAroundBasic {
         };
   }
 
-  /** rfe 521323, detect whitespace before ';'. */
+  /** Rfe 521323, detect whitespace before ';'. */
   void rfe521323() {
     doStuff();
     for (int i = 0; i < 5; i++) {}
   }
 
-  /** bug 806243 (NoWhitespaceBeforeCheck violation for anonymous inner class). */
+  /** Bug 806243 (NoWhitespaceBeforeCheck violation for anonymous inner class). */
   void bug806243() {
     Object o =
         new InputFormattedWhitespaceAroundBasic() {

--- a/src/it/resources/com/google/checkstyle/test/chapter4formatting/rule462horizontalwhitespace/InputFormattedWhitespaceAroundGenerics.java
+++ b/src/it/resources/com/google/checkstyle/test/chapter4formatting/rule462horizontalwhitespace/InputFormattedWhitespaceAroundGenerics.java
@@ -10,7 +10,7 @@ interface Foo3 {}
 // violation below 'Top-level class Foo22 has to reside in its own source file.'
 interface Foo22 {}
 
-/** some javadoc. */
+/** Some javadoc. */
 public class InputFormattedWhitespaceAroundGenerics {}
 
 // No whitespace after commas

--- a/src/it/resources/com/google/checkstyle/test/chapter4formatting/rule462horizontalwhitespace/InputFormattedWhitespaceAroundWhen.java
+++ b/src/it/resources/com/google/checkstyle/test/chapter4formatting/rule462horizontalwhitespace/InputFormattedWhitespaceAroundWhen.java
@@ -4,7 +4,7 @@ package com.google.checkstyle.test.chapter4formatting.rule462horizontalwhitespac
 
 class InputFormattedWhitespaceAroundWhen {
 
-  /** method. */
+  /** Method. */
   void test(Object o) {
     switch (o) {
       case Integer i when (i == 0) -> {}
@@ -21,7 +21,7 @@ class InputFormattedWhitespaceAroundWhen {
     }
   }
 
-  /** method. */
+  /** Method. */
   void test2(Object o) {
 
     switch (o) {

--- a/src/it/resources/com/google/checkstyle/test/chapter4formatting/rule462horizontalwhitespace/InputFormattedWhitespaceBeforeLeftCurlyOfEmptyBlock.java
+++ b/src/it/resources/com/google/checkstyle/test/chapter4formatting/rule462horizontalwhitespace/InputFormattedWhitespaceBeforeLeftCurlyOfEmptyBlock.java
@@ -1,6 +1,6 @@
 package com.google.checkstyle.test.chapter4formatting.rule462horizontalwhitespace;
 
-/** some javadoc. */
+/** Some javadoc. */
 public class InputFormattedWhitespaceBeforeLeftCurlyOfEmptyBlock {
 
   InputFormattedWhitespaceBeforeLeftCurlyOfEmptyBlock instance =
@@ -20,7 +20,7 @@ public class InputFormattedWhitespaceBeforeLeftCurlyOfEmptyBlock {
 
   record Record() {}
 
-  /** some javadoc. */
+  /** Some javadoc. */
   public static void main(String... args) {
 
     boolean b = System.currentTimeMillis() < 0;

--- a/src/it/resources/com/google/checkstyle/test/chapter4formatting/rule462horizontalwhitespace/InputGenericWhitespaceEndsTheLine.java
+++ b/src/it/resources/com/google/checkstyle/test/chapter4formatting/rule462horizontalwhitespace/InputGenericWhitespaceEndsTheLine.java
@@ -1,8 +1,8 @@
 package com.google.checkstyle.test.chapter4formatting.rule462horizontalwhitespace;
 
-/** some javadoc. */
+/** Some javadoc. */
 public class InputGenericWhitespaceEndsTheLine {
-  /** some javadoc. */
+  /** Some javadoc. */
   public boolean returnsGenericObjectAtEndOfLine(Object otherObject) {
     return otherObject instanceof Enum<?>;
   }

--- a/src/it/resources/com/google/checkstyle/test/chapter4formatting/rule462horizontalwhitespace/InputMethodParamPad2.java
+++ b/src/it/resources/com/google/checkstyle/test/chapter4formatting/rule462horizontalwhitespace/InputMethodParamPad2.java
@@ -4,23 +4,23 @@ import java.util.Vector;
 
 /** Test input for MethodDefPadCheck. */
 public class InputMethodParamPad2 {
-  /** some javadoc. */
+  /** Some javadoc. */
   public InputMethodParamPad2() {
     super();
   }
 
-  /** some javadoc. */
+  /** Some javadoc. */
   public InputMethodParamPad2 (int param) { // violation ''(' is preceded with whitespace.'
     super (); // violation ''(' is preceded with whitespace.'
   }
 
-  /** some javadoc. */
+  /** Some javadoc. */
   public void method() {}
 
-  /** some javadoc. */
+  /** Some javadoc. */
   public void method (int param) {} // violation ''(' is preceded with whitespace.'
 
-  /** some javadoc. */
+  /** Some javadoc. */
   public void method(double param) {
     // invoke constructor
     InputMethodParamPad2 pad = new InputMethodParamPad2();
@@ -33,7 +33,7 @@ public class InputMethodParamPad2 {
     method (); // violation ''(' is preceded with whitespace.'
   }
 
-  /** some javadoc. */
+  /** Some javadoc. */
   public void dottedCalls() {
     this.method();
     this.method (); // violation ''(' is preceded with whitespace.'
@@ -52,7 +52,7 @@ public class InputMethodParamPad2 {
        .parseInt("0");
   }
 
-  /** some javadoc. */
+  /** Some javadoc. */
   public void newArray() {
     int[] a = new int[]{0, 1};
     java.util.Vector<String> v = new java.util.Vector<String>();

--- a/src/it/resources/com/google/checkstyle/test/chapter4formatting/rule462horizontalwhitespace/InputNoWhitespaceBeforeAnnotations.java
+++ b/src/it/resources/com/google/checkstyle/test/chapter4formatting/rule462horizontalwhitespace/InputNoWhitespaceBeforeAnnotations.java
@@ -3,7 +3,7 @@ package com.google.checkstyle.test.chapter4formatting.rule462horizontalwhitespac
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Target;
 
-/** some javadoc. */
+/** Some javadoc. */
 public class InputNoWhitespaceBeforeAnnotations {
 
   @Target(ElementType.TYPE_USE)
@@ -28,20 +28,20 @@ public class InputNoWhitespaceBeforeAnnotations {
   // @NonNull int @NonNull ... field3; // non-compilable
   // @NonNull int @NonNull... field4; // non-compilable
 
-  /** some javadoc. */
+  /** Some javadoc. */
   public void foo(final char @NonNull [] param) {}
 
-  /** some javadoc. */
+  /** Some javadoc. */
   public void foo1(final char[] param) {}
 
-  /** some javadoc. */
+  /** Some javadoc. */
   public void foo2(final char[] param) {}
 
-  /** some javadoc. */
+  /** Some javadoc. */
   public void foo3(final char @NonNull[] param) {}
   // violation above ''NonNull' is not followed by whitespace'
 
-  /** some javadoc. */
+  /** Some javadoc. */
   public void foo4(final char @NonNull [] param) {}
 
   void test1(String... param) {}

--- a/src/it/resources/com/google/checkstyle/test/chapter4formatting/rule462horizontalwhitespace/InputNoWhitespaceBeforeCaseDefaultColon.java
+++ b/src/it/resources/com/google/checkstyle/test/chapter4formatting/rule462horizontalwhitespace/InputNoWhitespaceBeforeCaseDefaultColon.java
@@ -1,6 +1,6 @@
 package com.google.checkstyle.test.chapter4formatting.rule462horizontalwhitespace;
 
-/** some javadoc. */
+/** Some javadoc. */
 public class InputNoWhitespaceBeforeCaseDefaultColon {
   {
     switch (1) {

--- a/src/it/resources/com/google/checkstyle/test/chapter4formatting/rule462horizontalwhitespace/InputNoWhitespaceBeforeColonOfLabel.java
+++ b/src/it/resources/com/google/checkstyle/test/chapter4formatting/rule462horizontalwhitespace/InputNoWhitespaceBeforeColonOfLabel.java
@@ -1,6 +1,6 @@
 package com.google.checkstyle.test.chapter4formatting.rule462horizontalwhitespace;
 
-/** some javadoc. */
+/** Some javadoc. */
 public class InputNoWhitespaceBeforeColonOfLabel {
 
   {
@@ -9,7 +9,7 @@ public class InputNoWhitespaceBeforeColonOfLabel {
     }
   }
 
-  /** some javadoc. */
+  /** Some javadoc. */
   public void foo() {
     label2:
     while (true) {

--- a/src/it/resources/com/google/checkstyle/test/chapter4formatting/rule462horizontalwhitespace/InputNoWhitespaceBeforeEllipsis.java
+++ b/src/it/resources/com/google/checkstyle/test/chapter4formatting/rule462horizontalwhitespace/InputNoWhitespaceBeforeEllipsis.java
@@ -4,7 +4,7 @@ import java.lang.annotation.ElementType;
 import java.lang.annotation.Target;
 
 //
-/** some javadoc. */
+/** Some javadoc. */
 public class InputNoWhitespaceBeforeEllipsis {
 
   @Target(ElementType.TYPE_USE)
@@ -23,30 +23,30 @@ public class InputNoWhitespaceBeforeEllipsis {
   // @NonNull int @NonNull ... field3; // non-compilable
   // @NonNull int @NonNull... field4; // non-compilable
 
-  /** some javadoc. */
+  /** Some javadoc. */
   void test1(String... param) {}
 
-  /** some javadoc. */
+  /** Some javadoc. */
   void test2(String ... param) {} // violation ''...' is preceded with whitespace.'
 
-  /** some javadoc. */
+  /** Some javadoc. */
   void test3(String @NonNull ... param) {}
 
-  /** some javadoc. */
+  /** Some javadoc. */
   void test4(String @NonNull... param) {}
   // violation above ''NonNull' is not followed by whitespace'
 
-  /** some javadoc. */
+  /** Some javadoc. */
   void test5(String[]... param) {}
 
-  /** some javadoc. */
+  /** Some javadoc. */
   void test6(String[] ... param) {} // violation ''...' is preceded with whitespace.'
 
-  /** some javadoc. */
+  /** Some javadoc. */
   void test7(String @NonNull[]... param) {}
   // violation above ''NonNull' is not followed by whitespace'
 
-  /** some javadoc. */
+  /** Some javadoc. */
   void test8(String @NonNull[] ... param) {}
   // 2 violations above:
   //   ''NonNull' is not followed by whitespace'

--- a/src/it/resources/com/google/checkstyle/test/chapter4formatting/rule462horizontalwhitespace/InputNoWhitespaceBeforeEmptyForLoop.java
+++ b/src/it/resources/com/google/checkstyle/test/chapter4formatting/rule462horizontalwhitespace/InputNoWhitespaceBeforeEmptyForLoop.java
@@ -1,9 +1,9 @@
 package com.google.checkstyle.test.chapter4formatting.rule462horizontalwhitespace;
 
-/** some javadoc. */
+/** Some javadoc. */
 public class InputNoWhitespaceBeforeEmptyForLoop {
 
-  /** some javadoc. */
+  /** Some javadoc. */
   public static void foo() {
     for (; ; ) { // ok
       break;

--- a/src/it/resources/com/google/checkstyle/test/chapter4formatting/rule462horizontalwhitespace/InputParenPad.java
+++ b/src/it/resources/com/google/checkstyle/test/chapter4formatting/rule462horizontalwhitespace/InputParenPad.java
@@ -4,7 +4,7 @@ import java.io.IOException;
 import java.io.StringWriter;
 import java.io.Writer;
 
-/** some javadoc. */
+/** Some javadoc. */
 public class InputParenPad {
   boolean fooo = this.bar(( true && false ) && true);
   // 2 violations above:
@@ -35,7 +35,7 @@ public class InputParenPad {
                     //  '')' is preceded with whitespace.'
   }
 
-  /** some javadoc. */
+  /** Some javadoc. */
   @MyAnnotation
   public boolean bar(boolean a) {
     assert ( true );
@@ -199,7 +199,7 @@ public class InputParenPad {
       }
     }
 
-    /** some javadoc. */
+    /** Some javadoc. */
     public void myMethod() {
       String s = "test";
       Object o = s;
@@ -210,7 +210,7 @@ public class InputParenPad {
       //  '')' is preceded with whitespace.'
     }
 
-    /** some javadoc. */
+    /** Some javadoc. */
     public void crisRon() {
       Object leo = "messi";
       Object ibra = leo;
@@ -221,7 +221,7 @@ public class InputParenPad {
       Math.random();
     }
 
-    /** some javadoc. */
+    /** Some javadoc. */
     public void intStringConv() {
       Object a = 5;
       Object b = "string";
@@ -235,7 +235,7 @@ public class InputParenPad {
       String d = ((String) b);
     }
 
-    /** some javadoc. */
+    /** Some javadoc. */
     public int something( Object o ) {
       // 2 violations above:
       //  ''(' is followed by whitespace.'
@@ -264,7 +264,7 @@ public class InputParenPad {
       boolean result = number == 123;
     }
 
-    /** some javadoc. */
+    /** Some javadoc. */
     public String testing() {
       return ( this.exam != null )
               // 2 violations above:

--- a/src/it/resources/com/google/checkstyle/test/chapter4formatting/rule462horizontalwhitespace/InputWhitespaceAfterBad.java
+++ b/src/it/resources/com/google/checkstyle/test/chapter4formatting/rule462horizontalwhitespace/InputWhitespaceAfterBad.java
@@ -1,8 +1,8 @@
 package com.google.checkstyle.test.chapter4formatting.rule462horizontalwhitespace;
 
-/** some javadoc. */
+/** Some javadoc. */
 public class InputWhitespaceAfterBad {
-  /** some javadoc. */
+  /** Some javadoc. */
   public void check1(int x,int y) { // violation '',' is not followed by whitespace.'
     for(int a = 1,b = 2;a < 5;a++,b--)
       ;
@@ -35,7 +35,7 @@ public class InputWhitespaceAfterBad {
     //  ''while' is not followed by whitespace.'
   }
 
-  /** some javadoc. */
+  /** Some javadoc. */
   public void check2(final int a,final int b) { // violation '',' is not followed by whitespace.'
     if((float)a == 0.0) {
       // 3 violations above:
@@ -52,7 +52,7 @@ public class InputWhitespaceAfterBad {
     }
   }
 
-  /** some javadoc. */
+  /** Some javadoc. */
   public void check3(int...a) { // violation ''...' is not followed by whitespace.'
     Runnable r2 = () ->String.valueOf("Hello world two!");
     // 2 violations above:
@@ -67,7 +67,7 @@ public class InputWhitespaceAfterBad {
     }
   }
 
-  /** some javadoc. */
+  /** Some javadoc. */
   public void check4() throws java.io.IOException {
     try(java.io.InputStream ignored = System.in;) {}
     // 2 violations above:
@@ -75,7 +75,7 @@ public class InputWhitespaceAfterBad {
     //  ''try' is not followed by whitespace.'
   }
 
-  /** some javadoc. */
+  /** Some javadoc. */
   public void check5() {
     try {
       /* foo */
@@ -97,7 +97,7 @@ public class InputWhitespaceAfterBad {
     }
   }
 
-  /** some javadoc. */
+  /** Some javadoc. */
   public void check6() {
     try {
       /* foo */
@@ -108,7 +108,7 @@ public class InputWhitespaceAfterBad {
     }
   }
 
-  /** some javadoc. */
+  /** Some javadoc. */
   public void check7() {
     synchronized(this) {
       // 2 violations above:
@@ -120,7 +120,7 @@ public class InputWhitespaceAfterBad {
     }
   }
 
-  /** some javadoc. */
+  /** Some javadoc. */
   public String check8() {
     return("a" + "b");
     // 2 violations above:

--- a/src/it/resources/com/google/checkstyle/test/chapter4formatting/rule462horizontalwhitespace/InputWhitespaceAfterDoubleSlashes.java
+++ b/src/it/resources/com/google/checkstyle/test/chapter4formatting/rule462horizontalwhitespace/InputWhitespaceAfterDoubleSlashes.java
@@ -6,12 +6,12 @@
 
 package com.google.checkstyle.test.chapter4formatting.rule462horizontalwhitespace;
 
-/** some javadoc. */
+/** Some javadoc. */
 public class InputWhitespaceAfterDoubleSlashes {
   String googleCheck = "Google"; //google
   // violation above ''//' must be followed by a whitespace.'
 
-  /** somejavadoc. */
+  /** Somejavadoc. */
   public void foo1() {
     int pro1 = 0; //the main variable
     // violation above ''//' must be followed by a whitespace.'

--- a/src/it/resources/com/google/checkstyle/test/chapter4formatting/rule462horizontalwhitespace/InputWhitespaceAfterDoubleSlashesCorrect.java
+++ b/src/it/resources/com/google/checkstyle/test/chapter4formatting/rule462horizontalwhitespace/InputWhitespaceAfterDoubleSlashesCorrect.java
@@ -4,11 +4,11 @@
 
 package com.google.checkstyle.test.chapter4formatting.rule462horizontalwhitespace;
 
-/** some javadoc. */
+/** Some javadoc. */
 public class InputWhitespaceAfterDoubleSlashesCorrect {
   String googleCheck = "Google"; // google
 
-  /** somejavadoc. */
+  /** Somejavadoc. */
   public void foo1() {
     int pro1 = 0; // the main variable
 

--- a/src/it/resources/com/google/checkstyle/test/chapter4formatting/rule462horizontalwhitespace/InputWhitespaceAfterGood.java
+++ b/src/it/resources/com/google/checkstyle/test/chapter4formatting/rule462horizontalwhitespace/InputWhitespaceAfterGood.java
@@ -1,13 +1,13 @@
 package com.google.checkstyle.test.chapter4formatting.rule462horizontalwhitespace;
 
-/** some javadoc. */
+/** Some javadoc. */
 public class InputWhitespaceAfterGood {
 
   int xyz;       // multiple space between content and double slash.
   int abc; //       multiple space between double slash and comment's text.
   int pqr;       //     testing both.
 
-  /** some javadoc. */
+  /** Some javadoc. */
   public void check1(int x, int y) {
     // violation below ''for' construct must use '{}'s.'
     for (int a = 1, b = 2; a < 5; a++, b--)
@@ -20,7 +20,7 @@ public class InputWhitespaceAfterGood {
     } while (x == 0 || y == 2);
   }
 
-  /** some javadoc. */
+  /** Some javadoc. */
   public void check2(final int a, final int b) {
     if ((float) a == 0.0) {
       System.out.println("true");
@@ -29,7 +29,7 @@ public class InputWhitespaceAfterGood {
     }
   }
 
-  /** some javadoc. */
+  /** Some javadoc. */
   public void check3(int... a) {
     Runnable r2 = () -> String.valueOf("Hello world two!");
     switch (a[0]) {
@@ -38,7 +38,7 @@ public class InputWhitespaceAfterGood {
     }
   }
 
-  /** some javadoc. */
+  /** Some javadoc. */
   public void check4() throws java.io.IOException {
     try (java.io.InputStream ignored = System.in) {}
     try {
@@ -48,7 +48,7 @@ public class InputWhitespaceAfterGood {
     }
   }
 
-  /** some javadoc. */
+  /** Some javadoc. */
   public void check5() {
 
     try {
@@ -58,7 +58,7 @@ public class InputWhitespaceAfterGood {
     }
   }
 
-  /** some javadoc. */
+  /** Some javadoc. */
   public void check6() {
     try {
       /* foo. */
@@ -67,13 +67,13 @@ public class InputWhitespaceAfterGood {
     }
   }
 
-  /** some javadoc. */
+  /** Some javadoc. */
   public void check7() {
     synchronized (this) {
     }
   }
 
-  /** some javadoc. */
+  /** Some javadoc. */
   public String check8() {
     return ("a" + "b");
   }

--- a/src/it/resources/com/google/checkstyle/test/chapter4formatting/rule462horizontalwhitespace/InputWhitespaceAroundArrow.java
+++ b/src/it/resources/com/google/checkstyle/test/chapter4formatting/rule462horizontalwhitespace/InputWhitespaceAroundArrow.java
@@ -10,7 +10,7 @@ import java.util.List;
 import java.util.stream.Collectors;
 import javax.swing.JCheckBox;
 
-/** some javadoc. */
+/** Some javadoc. */
 public class InputWhitespaceAroundArrow {
   static {
     // violation below ''->' is not preceded with whitespace.'
@@ -28,7 +28,7 @@ public class InputWhitespaceAroundArrow {
     }
   }
 
-  /** method. */
+  /** Method. */
   void test(Object o, Object o2, int y) {
     switch (o) {
       case String s when (
@@ -102,18 +102,18 @@ public class InputWhitespaceAroundArrow {
     //     'WhitespaceAround: '->' is not followed by whitespace. .*'
   }
 
-  /** some javadoc. */
+  /** Some javadoc. */
   record Point(int x, int y) {}
 
-  /** some javadoc. */
+  /** Some javadoc. */
   public interface Predicate {
-    /** some javadoc. */
+    /** Some javadoc. */
     boolean test(Object value);
   }
 
-  /** some javadoc. */
+  /** Some javadoc. */
   public interface VoidPredicate {
-    /** some javadoc. */
+    /** Some javadoc. */
     public boolean get();
   }
 }

--- a/src/it/resources/com/google/checkstyle/test/chapter4formatting/rule462horizontalwhitespace/InputWhitespaceAroundArrowCorrect.java
+++ b/src/it/resources/com/google/checkstyle/test/chapter4formatting/rule462horizontalwhitespace/InputWhitespaceAroundArrowCorrect.java
@@ -10,7 +10,7 @@ import java.util.List;
 import java.util.stream.Collectors;
 import javax.swing.JCheckBox;
 
-/** some javadoc. */
+/** Some javadoc. */
 public class InputWhitespaceAroundArrowCorrect {
   static {
     new JCheckBox()
@@ -20,7 +20,7 @@ public class InputWhitespaceAroundArrowCorrect {
             });
   }
 
-  /** some javadoc. */
+  /** Some javadoc. */
   void foo1(Object o) {
     switch (o) {
       case String s when (s.equals("a")) -> {}
@@ -29,7 +29,7 @@ public class InputWhitespaceAroundArrowCorrect {
     }
   }
 
-  /** method. */
+  /** Method. */
   void test(Object o, Object o2, int y) {
     switch (o) {
       case String s when (s.equals("a")) -> {}
@@ -54,7 +54,7 @@ public class InputWhitespaceAroundArrowCorrect {
         };
   }
 
-  /** some javadoc. */
+  /** Some javadoc. */
   int test2(int k, Object o1) {
     Predicate predicate = value -> (value != null);
 
@@ -74,7 +74,7 @@ public class InputWhitespaceAroundArrowCorrect {
     return k * 2;
   }
 
-  /** some javadoc. */
+  /** Some javadoc. */
   static void test3() {
     ArrayList<Boolean> boolList = new ArrayList<Boolean>(Arrays.asList(false, true, false, false));
 
@@ -97,19 +97,19 @@ public class InputWhitespaceAroundArrowCorrect {
             .orElseThrow(() -> new IllegalStateException("big problem"));
   }
 
-  /** some javadoc. */
+  /** Some javadoc. */
   record Point(int x, int y) {}
 
-  /** some javadoc. */
+  /** Some javadoc. */
   public interface Predicate {
 
-    /** some javadoc. */
+    /** Some javadoc. */
     boolean test(Object value);
   }
 
-  /** some javadoc. */
+  /** Some javadoc. */
   public interface VoidPredicate {
-    /** some javadoc. */
+    /** Some javadoc. */
     public boolean get();
   }
 }

--- a/src/it/resources/com/google/checkstyle/test/chapter4formatting/rule462horizontalwhitespace/InputWhitespaceAroundBasic.java
+++ b/src/it/resources/com/google/checkstyle/test/chapter4formatting/rule462horizontalwhitespace/InputWhitespaceAroundBasic.java
@@ -15,20 +15,20 @@ class InputWhitespaceAroundBasic {
   /** Should be ok. */
   private final int var3 = 1;
 
-  /** skip blank lines between comment and code, should be ok. */
+  /** Skip blank lines between comment and code, should be ok. */
   private final int var4 = 1;
 
   int xyz;       // multiple space between content and double slash.
   int abc; //       multiple space between double slash and comment's text.
   int pqr;       //     testing both.
 
-  /** bug 806243 (NoWhitespaceBeforeCheck violation for anonymous inner class). */
+  /** Bug 806243 (NoWhitespaceBeforeCheck violation for anonymous inner class). */
   private int test;
 
   private int i4, i5, i6;
   // violation above 'Each variable declaration must be in its own statement.'
 
-  /** method. */
+  /** Method. */
   void method1() {
     final int a = 1;
     int b= 1; // violation ''=' is not preceded with whitespace.'
@@ -39,7 +39,7 @@ class InputWhitespaceAroundBasic {
     b = ++ b - -- b;
   }
 
-  /** method. */
+  /** Method. */
   void method2() {
     synchronized(this) {
       // 2 violations above:
@@ -55,7 +55,7 @@ class InputWhitespaceAroundBasic {
     }
   }
 
-  /** test WS after void return. */
+  /** Test WS after void return. */
   private void fastExit() {
     boolean complicatedStuffNeeded = true;
     // 2 violations 3 lines below:
@@ -69,7 +69,7 @@ class InputWhitespaceAroundBasic {
   }
 
   /**
-   * test WS after non void return.
+   * Test WS after non void return.
    *
    * @return 2
    */
@@ -84,7 +84,7 @@ class InputWhitespaceAroundBasic {
     }
   }
 
-  /** test casts. */
+  /** Test casts. */
   private void testCasts() {
     Object o = (Object) new Object();
     o = (Object) o;
@@ -93,25 +93,25 @@ class InputWhitespaceAroundBasic {
             o;
   }
 
-  /** test questions. */
+  /** Test questions. */
   private void testQuestions() {
 
     boolean b = (1 ==2) ? false : true; // violation ''==' is not followed by whitespace.'
   }
 
-  /** star test. */
+  /** Star test. */
   private void starTest() {
     int x = 2 * 3* 4; // violation ''*' is not preceded with whitespace.'
   }
 
-  /** boolean test. */
+  /** Boolean test. */
   private void boolTest() {
     boolean a = true;
     boolean x = !a;
     int z = ~1 + ~2;
   }
 
-  /** division test. */
+  /** Division test. */
   private void divTest() {
     int a = 4 % 2;
     int b = 4% 2; // violation ''%' is not preceded with whitespace.'
@@ -123,7 +123,7 @@ class InputWhitespaceAroundBasic {
   }
 
   /**
-   * summary.
+   * Summary.
    *
    * @return dot test *
    */
@@ -135,7 +135,7 @@ class InputWhitespaceAroundBasic {
     return o.toString();
   }
 
-  /** assert statement test. */
+  /** Assert statement test. */
   public void assertTest() {
 
     assert true;
@@ -153,7 +153,7 @@ class InputWhitespaceAroundBasic {
     assert true: "Whups"; // violation '':' is not preceded with whitespace.'
   }
 
-  /** another check. */
+  /** Another check. */
   void donBradman(Runnable run) {
     donBradman(
         new Runnable() {
@@ -166,13 +166,13 @@ class InputWhitespaceAroundBasic {
         };
   }
 
-  /** rfe 521323, detect whitespace before ';'. */
+  /** Rfe 521323, detect whitespace before ';'. */
   void rfe521323() {
     doStuff();
     for (int i = 0; i < 5; i++) {}
   }
 
-  /** bug 806243 (NoWhitespaceBeforeCheck violation for anonymous inner class). */
+  /** Bug 806243 (NoWhitespaceBeforeCheck violation for anonymous inner class). */
   void bug806243() {
     Object o =
         new InputWhitespaceAroundBasic() {

--- a/src/it/resources/com/google/checkstyle/test/chapter4formatting/rule462horizontalwhitespace/InputWhitespaceAroundGenerics.java
+++ b/src/it/resources/com/google/checkstyle/test/chapter4formatting/rule462horizontalwhitespace/InputWhitespaceAroundGenerics.java
@@ -10,7 +10,7 @@ interface Foo {}
 // violation below 'Top-level class Foo2 has to reside in its own source file.'
 interface Foo2 {}
 
-/** some javadoc. */
+/** Some javadoc. */
 public class InputWhitespaceAroundGenerics {}
 
 // No whitespace after commas

--- a/src/it/resources/com/google/checkstyle/test/chapter4formatting/rule462horizontalwhitespace/InputWhitespaceAroundWhen.java
+++ b/src/it/resources/com/google/checkstyle/test/chapter4formatting/rule462horizontalwhitespace/InputWhitespaceAroundWhen.java
@@ -4,7 +4,7 @@ package com.google.checkstyle.test.chapter4formatting.rule462horizontalwhitespac
 
 class InputWhitespaceAroundWhen {
 
-  /** method. */
+  /** Method. */
   void test(Object o) {
     switch (o) {
       case Integer i when(i == 0) ->
@@ -55,7 +55,7 @@ class InputWhitespaceAroundWhen {
     }
   }
 
-  /** method. */
+  /** Method. */
   void test2(Object o) {
 
     switch (o) {

--- a/src/it/resources/com/google/checkstyle/test/chapter4formatting/rule462horizontalwhitespace/InputWhitespaceBeforeLeftCurlyOfEmptyBlock.java
+++ b/src/it/resources/com/google/checkstyle/test/chapter4formatting/rule462horizontalwhitespace/InputWhitespaceBeforeLeftCurlyOfEmptyBlock.java
@@ -1,6 +1,6 @@
 package com.google.checkstyle.test.chapter4formatting.rule462horizontalwhitespace;
 
-/** some javadoc. */
+/** Some javadoc. */
 public class InputWhitespaceBeforeLeftCurlyOfEmptyBlock {
 
   InputWhitespaceBeforeLeftCurlyOfEmptyBlock instance =
@@ -21,7 +21,7 @@ public class InputWhitespaceBeforeLeftCurlyOfEmptyBlock {
 
   record Record(){} // ok until #17715
 
-  /** some javadoc. */
+  /** Some javadoc. */
   public static void main(String... args) {
 
     boolean b = System.currentTimeMillis() < 0;

--- a/src/it/resources/com/google/checkstyle/test/chapter4formatting/rule4832nocstylearray/InputNoCstyleArrays.java
+++ b/src/it/resources/com/google/checkstyle/test/chapter4formatting/rule4832nocstylearray/InputNoCstyleArrays.java
@@ -5,10 +5,10 @@ public class InputNoCstyleArrays {
   private int[] javastyle = new int[0];
   private int cstyle[] = new int[0]; // violation 'Array brackets at illegal position.'
 
-  /** some javadoc. */
+  /** Some javadoc. */
   public static void mainJava(String[] javastyle) {}
 
-  /** some javadoc. */
+  /** Some javadoc. */
   public static void mainC(String cstyle[]) { // violation 'Array brackets at illegal position.'
     final int[] blah = new int[0];
     final boolean isok1 = cstyle instanceof String[];
@@ -22,7 +22,7 @@ public class InputNoCstyleArrays {
     //                    'Array brackets at illegal position.'
   }
 
-  /** some javadoc. */
+  /** Some javadoc. */
   public class Test {
     public Test[] variable;
 

--- a/src/it/resources/com/google/checkstyle/test/chapter4formatting/rule4841indentation/InputAnnotationArrayInitMultiline.java
+++ b/src/it/resources/com/google/checkstyle/test/chapter4formatting/rule4841indentation/InputAnnotationArrayInitMultiline.java
@@ -3,7 +3,7 @@ package com.google.checkstyle.test.chapter4formatting.rule4841indentation;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 
-/** some annotation. */
+/** Some annotation. */
 @InputAnnotationArrayInitMultiline.AnnotList({
   @InputAnnotationArrayInitMultiline.Annot(
       "hello-Goodbye world in one very long and lengthy string in annoation array"),

--- a/src/it/resources/com/google/checkstyle/test/chapter4formatting/rule4841indentation/InputAnnotationArrayInitMultiline2.java
+++ b/src/it/resources/com/google/checkstyle/test/chapter4formatting/rule4841indentation/InputAnnotationArrayInitMultiline2.java
@@ -76,7 +76,7 @@ class CustomResponseDto {}
 // violation below 'Top-level class ErrorDto has to reside in its own source file.'
 class ErrorDto {}
 
-/** some javadoc. */
+/** Some javadoc. */
 @TagNameAndDescriptionNew(
     name = "${something1.something2.something3}",
     description = "Endpoint for blah blah blah activities",
@@ -87,7 +87,7 @@ class ErrorDto {}
 )
 public interface InputAnnotationArrayInitMultiline2 {
 
-  /** some javadoc. */
+  /** Some javadoc. */
   @OperationFinal(summary = "Retrieves something for verifying something")
   @ResponseStatus(HttpStatus.OK)
   @ApiResponses(value = {

--- a/src/it/resources/com/google/checkstyle/test/chapter4formatting/rule4841indentation/InputAnnotationArrayInitMultilineCorrect.java
+++ b/src/it/resources/com/google/checkstyle/test/chapter4formatting/rule4841indentation/InputAnnotationArrayInitMultilineCorrect.java
@@ -1,6 +1,6 @@
 package com.google.checkstyle.test.chapter4formatting.rule4841indentation;
 
-/** some annotation. */
+/** Some annotation. */
 @InputAnnotationArrayInitMultilineCorrect.AnnotList({
   @InputAnnotationArrayInitMultilineCorrect.Annot(
       "hello-Goodbye world in one very long and lengthy string in annoation array"),

--- a/src/it/resources/com/google/checkstyle/test/chapter4formatting/rule4841indentation/InputCatchParametersOnNewLine.java
+++ b/src/it/resources/com/google/checkstyle/test/chapter4formatting/rule4841indentation/InputCatchParametersOnNewLine.java
@@ -2,10 +2,10 @@
 
 package com.google.checkstyle.test.chapter4formatting.rule4841indentation;
 
-/** some javadoc. */
+/** Some javadoc. */
 public class InputCatchParametersOnNewLine {
 
-  /** some test Method. */
+  /** Some test Method. */
   public void test1() {
     try {
       System.out.println("try0");

--- a/src/it/resources/com/google/checkstyle/test/chapter4formatting/rule4841indentation/InputClassWithChainedMethods.java
+++ b/src/it/resources/com/google/checkstyle/test/chapter4formatting/rule4841indentation/InputClassWithChainedMethods.java
@@ -1,12 +1,12 @@
 package com.google.checkstyle.test.chapter4formatting.rule4841indentation;
 
-/** some javadoc. */
+/** Some javadoc. */
 public class InputClassWithChainedMethods {
 
-  /** some javadoc. */
+  /** Some javadoc. */
   public InputClassWithChainedMethods(Object... params) {}
 
-  /** some javadoc. */
+  /** Some javadoc. */
   public static void main(String[] args) {
     new InputClassWithChainedMethods()
         .getInstance("string_one")
@@ -22,12 +22,12 @@ public class InputClassWithChainedMethods {
     // violation above ''new' has incorrect indentation level 4, expected .* 8.'
   }
 
-  /** some javadoc. */
+  /** Some javadoc. */
   public String doNothing(String something, String... uselessParams) {
     return something;
   }
 
-  /** some javadoc. */
+  /** Some javadoc. */
   public InputClassWithChainedMethods getInstance(String... uselessParams) {
     return this;
   }

--- a/src/it/resources/com/google/checkstyle/test/chapter4formatting/rule4841indentation/InputClassWithChainedMethodsCorrect.java
+++ b/src/it/resources/com/google/checkstyle/test/chapter4formatting/rule4841indentation/InputClassWithChainedMethodsCorrect.java
@@ -1,8 +1,8 @@
 package com.google.checkstyle.test.chapter4formatting.rule4841indentation;
 
-/** some javadoc. */
+/** Some javadoc. */
 public class InputClassWithChainedMethodsCorrect {
-  /** some javadoc. */
+  /** Some javadoc. */
   public InputClassWithChainedMethodsCorrect() {
 
     String someString = "";
@@ -12,13 +12,13 @@ public class InputClassWithChainedMethodsCorrect {
     doNothing(someString.concat("zyx").concat("255, 254, 253"));
   }
 
-  /** some javadoc. */
+  /** Some javadoc. */
   public static void main(String[] args) {
     InputClassWithChainedMethodsCorrect classWithChainedMethodsCorrect =
         new InputClassWithChainedMethodsCorrect();
   }
 
-  /** some javadoc. */
+  /** Some javadoc. */
   public String doNothing(String something) {
     return something;
   }

--- a/src/it/resources/com/google/checkstyle/test/chapter4formatting/rule4841indentation/InputFastMatcher.java
+++ b/src/it/resources/com/google/checkstyle/test/chapter4formatting/rule4841indentation/InputFastMatcher.java
@@ -1,39 +1,39 @@
 package com.google.checkstyle.test.chapter4formatting.rule4841indentation;
 
-/** some javadoc. */
+/** Some javadoc. */
 public class InputFastMatcher {
 
-  /** some javadoc. */
+  /** Some javadoc. */
   public boolean matches(char c) {
     // OOOO Auto-generated method stub
     return false;
   }
 
-  /** some javadoc. */
+  /** Some javadoc. */
   public String replaceFrom(CharSequence sequence, CharSequence replacement) {
     // OOOO Auto-generated method stub
     return null;
   }
 
-  /** some javadoc. */
+  /** Some javadoc. */
   public String collapseFrom(CharSequence sequence, char replacement) {
     // OOOO Auto-generated method stub
     return null;
   }
 
-  /** some javadoc. */
+  /** Some javadoc. */
   public String trimFrom(CharSequence s) {
     // OOOO Auto-generated method stub
     return null;
   }
 
-  /** some javadoc. */
+  /** Some javadoc. */
   public String trimLeadingFrom(CharSequence sequence) {
     // OOOO Auto-generated method stub
     return null;
   }
 
-  /** some javadoc. */
+  /** Some javadoc. */
   public String trimTrailingFrom(CharSequence sequence) {
     // OOOO Auto-generated method stub
     return null;

--- a/src/it/resources/com/google/checkstyle/test/chapter4formatting/rule4841indentation/InputFormattedAnnotationArrayInitMultiline.java
+++ b/src/it/resources/com/google/checkstyle/test/chapter4formatting/rule4841indentation/InputFormattedAnnotationArrayInitMultiline.java
@@ -3,7 +3,7 @@ package com.google.checkstyle.test.chapter4formatting.rule4841indentation;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 
-/** some annotation. */
+/** Some annotation. */
 @InputAnnotationArrayInitMultiline.AnnotList({
   @InputAnnotationArrayInitMultiline.Annot(
       "hello-Goodbye world in one very long and lengthy string in annoation array"),

--- a/src/it/resources/com/google/checkstyle/test/chapter4formatting/rule4841indentation/InputFormattedAnnotationArrayInitMultiline2.java
+++ b/src/it/resources/com/google/checkstyle/test/chapter4formatting/rule4841indentation/InputFormattedAnnotationArrayInitMultiline2.java
@@ -76,7 +76,7 @@ class ResponseDot {}
 // violation below 'Top-level class ErrorDot has to reside in its own source file.'
 class ErrorDot {}
 
-/** some javadoc. */
+/** Some javadoc. */
 @TagNameAndDescription(
     name = "${something1.something2.something3}",
     description = "Endpoint for blah blah blah activities",
@@ -86,7 +86,7 @@ class ErrorDot {}
             url = "https://google.com"))
 public interface InputFormattedAnnotationArrayInitMultiline2 {
 
-  /** some javadoc. */
+  /** Some javadoc. */
   @Operation(summary = "Retrieves something for verifying something")
   @ResponseValueShow(DummyHttp.OK)
   @ApiResponsesOne(

--- a/src/it/resources/com/google/checkstyle/test/chapter4formatting/rule4841indentation/InputFormattedCatchParametersOnNewLine.java
+++ b/src/it/resources/com/google/checkstyle/test/chapter4formatting/rule4841indentation/InputFormattedCatchParametersOnNewLine.java
@@ -2,10 +2,10 @@
 
 package com.google.checkstyle.test.chapter4formatting.rule4841indentation;
 
-/** some javadoc. */
+/** Some javadoc. */
 public class InputFormattedCatchParametersOnNewLine {
 
-  /** some test Method. */
+  /** Some test Method. */
   public void test1() {
     try {
       System.out.println("try0");

--- a/src/it/resources/com/google/checkstyle/test/chapter4formatting/rule4841indentation/InputFormattedClassWithChainedMethods.java
+++ b/src/it/resources/com/google/checkstyle/test/chapter4formatting/rule4841indentation/InputFormattedClassWithChainedMethods.java
@@ -1,12 +1,12 @@
 package com.google.checkstyle.test.chapter4formatting.rule4841indentation;
 
-/** some javadoc. */
+/** Some javadoc. */
 public class InputFormattedClassWithChainedMethods {
 
-  /** some javadoc. */
+  /** Some javadoc. */
   public InputFormattedClassWithChainedMethods(Object... params) {}
 
-  /** some javadoc. */
+  /** Some javadoc. */
   public static void main(String[] args) {
     new InputFormattedClassWithChainedMethods()
         .getInstance("string_one")
@@ -23,12 +23,12 @@ public class InputFormattedClassWithChainedMethods {
             .doNothing("nothing");
   }
 
-  /** some javadoc. */
+  /** Some javadoc. */
   public String doNothing(String something, String... uselessParams) {
     return something;
   }
 
-  /** some javadoc. */
+  /** Some javadoc. */
   public InputFormattedClassWithChainedMethods getInstance(String... uselessParams) {
     return this;
   }

--- a/src/it/resources/com/google/checkstyle/test/chapter4formatting/rule4841indentation/InputFormattedLambdaAndChildOnTheSameLine.java
+++ b/src/it/resources/com/google/checkstyle/test/chapter4formatting/rule4841indentation/InputFormattedLambdaAndChildOnTheSameLine.java
@@ -4,7 +4,7 @@ package com.google.checkstyle.test.chapter4formatting.rule4841indentation;
 
 import java.lang.reflect.Proxy;
 
-/** some javadoc. */
+/** Some javadoc. */
 public class InputFormattedLambdaAndChildOnTheSameLine {
 
   enum A {

--- a/src/it/resources/com/google/checkstyle/test/chapter4formatting/rule4841indentation/InputFormattedLambdaChild.java
+++ b/src/it/resources/com/google/checkstyle/test/chapter4formatting/rule4841indentation/InputFormattedLambdaChild.java
@@ -6,7 +6,7 @@ import java.util.List;
 import java.util.function.Function;
 import java.util.function.Predicate;
 
-/** some javadoc. */
+/** Some javadoc. */
 public class InputFormattedLambdaChild {
   String testMethod1(List<Integer> operations) {
     return operations.stream()

--- a/src/it/resources/com/google/checkstyle/test/chapter4formatting/rule4841indentation/InputFormattedLineBreakAfterLeftCurlyOfBlockInSwitch.java
+++ b/src/it/resources/com/google/checkstyle/test/chapter4formatting/rule4841indentation/InputFormattedLineBreakAfterLeftCurlyOfBlockInSwitch.java
@@ -1,6 +1,6 @@
 package com.google.checkstyle.test.chapter4formatting.rule4841indentation;
 
-/** some javadoc. */
+/** Some javadoc. */
 public class InputFormattedLineBreakAfterLeftCurlyOfBlockInSwitch {
 
   void testMethod1(int month) {

--- a/src/it/resources/com/google/checkstyle/test/chapter4formatting/rule4841indentation/InputFormattedNewKeywordChildren.java
+++ b/src/it/resources/com/google/checkstyle/test/chapter4formatting/rule4841indentation/InputFormattedNewKeywordChildren.java
@@ -5,7 +5,7 @@ import java.io.IOException;
 import java.io.InputStreamReader;
 import java.util.Optional;
 
-/** some data. */
+/** Some data. */
 public class InputFormattedNewKeywordChildren {
 
   static {
@@ -26,7 +26,7 @@ public class InputFormattedNewKeywordChildren {
     }
   }
 
-  /** some data. */
+  /** Some data. */
   public Object foo() {
     return Optional.empty()
         .orElseThrow(
@@ -35,7 +35,7 @@ public class InputFormattedNewKeywordChildren {
                     "Something wrong 1, something wrong 2, something wrong 3"));
   }
 
-  /** some data. */
+  /** Some data. */
   public void foo2() throws IOException {
     BufferedReader bf =
         new BufferedReader(
@@ -44,7 +44,7 @@ public class InputFormattedNewKeywordChildren {
             });
   }
 
-  /** some data. */
+  /** Some data. */
   public Object foo4(int data) {
     return Optional.empty()
         .orElseThrow(
@@ -53,7 +53,7 @@ public class InputFormattedNewKeywordChildren {
                     "something wrong 1, something wrong 2, something wrong 3"));
   }
 
-  /** some data. */
+  /** Some data. */
   public Object foo5(int data) {
     return Optional.empty()
         .orElseThrow(
@@ -62,7 +62,7 @@ public class InputFormattedNewKeywordChildren {
                     "something wrong 1, something wrong 2, something wrong 3"));
   }
 
-  /** some data. */
+  /** Some data. */
   public void createExpressionIssue(Object invocation, String toBeRemovedExpression) {
     throw new IllegalArgumentException(
         "The expression "

--- a/src/it/resources/com/google/checkstyle/test/chapter4formatting/rule4841indentation/InputFormattedSingleSwitchStatementWithoutCurly.java
+++ b/src/it/resources/com/google/checkstyle/test/chapter4formatting/rule4841indentation/InputFormattedSingleSwitchStatementWithoutCurly.java
@@ -1,6 +1,6 @@
 package com.google.checkstyle.test.chapter4formatting.rule4841indentation;
 
-/** some javadoc. */
+/** Some javadoc. */
 public class InputFormattedSingleSwitchStatementWithoutCurly {
   void testCorrectIndentation(int obj) {
     switch (obj) {

--- a/src/it/resources/com/google/checkstyle/test/chapter4formatting/rule4841indentation/InputFormattedSwitchOnStartOfTheLine.java
+++ b/src/it/resources/com/google/checkstyle/test/chapter4formatting/rule4841indentation/InputFormattedSwitchOnStartOfTheLine.java
@@ -2,7 +2,7 @@
 
 package com.google.checkstyle.test.chapter4formatting.rule4841indentation;
 
-/** some javadoc. */
+/** Some javadoc. */
 public class InputFormattedSwitchOnStartOfTheLine {
   String testMethod1(int i) {
     String s =

--- a/src/it/resources/com/google/checkstyle/test/chapter4formatting/rule4841indentation/InputFormattedSwitchWrappingIndentation.java
+++ b/src/it/resources/com/google/checkstyle/test/chapter4formatting/rule4841indentation/InputFormattedSwitchWrappingIndentation.java
@@ -2,7 +2,7 @@ package com.google.checkstyle.test.chapter4formatting.rule4841indentation;
 
 import java.util.List;
 
-/** some javadoc. */
+/** Some javadoc. */
 public class InputFormattedSwitchWrappingIndentation {
   String testMethod1(int i) {
     String name = "";

--- a/src/it/resources/com/google/checkstyle/test/chapter4formatting/rule4841indentation/InputIndentationCorrect.java
+++ b/src/it/resources/com/google/checkstyle/test/chapter4formatting/rule4841indentation/InputIndentationCorrect.java
@@ -1,6 +1,6 @@
 package com.google.checkstyle.test.chapter4formatting.rule4841indentation;
 
-/** some javadoc. */
+/** Some javadoc. */
 public abstract class InputIndentationCorrect {
 
   static int i;
@@ -19,12 +19,12 @@ public abstract class InputIndentationCorrect {
     abc = 2;
   }
 
-  /** some javadoc. */
+  /** Some javadoc. */
   public boolean matches(char c) {
     return false;
   }
 
-  /** some javadoc. */
+  /** Some javadoc. */
   public void foo() {
     int i = 0;
     for (; i < 9; i++) {
@@ -43,26 +43,26 @@ public abstract class InputIndentationCorrect {
     }
   }
 
-  /** some javadoc. */
+  /** Some javadoc. */
   public boolean veryLongLongLongCondition() {
     return veryLongLongLongCondition2();
   }
 
-  /** some javadoc. */
+  /** Some javadoc. */
   public boolean veryLongLongLongCondition2() {
     return false;
   }
 
-  /** some javadoc. */
+  /** Some javadoc. */
   public void someFooMethod(
       String longString, String superLongString, String exraSuperLongString) {}
 
-  /** some javadoc. */
+  /** Some javadoc. */
   public void fooThrowMethod() throws Exception {
     /* Some code*/
   }
 
-  /** some javadoc. */
+  /** Some javadoc. */
   public void doSmth() {
     for (int h : pqr) {
       someFooMethod("longString", "veryLongString", "superVeryExtraLongString");

--- a/src/it/resources/com/google/checkstyle/test/chapter4formatting/rule4841indentation/InputIndentationCorrectAnnotationArrayInit.java
+++ b/src/it/resources/com/google/checkstyle/test/chapter4formatting/rule4841indentation/InputIndentationCorrectAnnotationArrayInit.java
@@ -1,6 +1,6 @@
 package com.google.checkstyle.test.chapter4formatting.rule4841indentation;
 
-/** some javadoc. */
+/** Some javadoc. */
 public class InputIndentationCorrectAnnotationArrayInit {
   interface MyInterface {
     @AnAnnotation(values = {"Hello"})

--- a/src/it/resources/com/google/checkstyle/test/chapter4formatting/rule4841indentation/InputIndentationCorrectClass.java
+++ b/src/it/resources/com/google/checkstyle/test/chapter4formatting/rule4841indentation/InputIndentationCorrectClass.java
@@ -2,10 +2,10 @@ package com.google.checkstyle.test.chapter4formatting.rule4841indentation;
 
 import java.util.Iterator;
 
-/** some javadoc. */
+/** Some javadoc. */
 public class InputIndentationCorrectClass implements Runnable, Cloneable {
 
-  /** some javadoc. */
+  /** Some javadoc. */
   @Override
   public void run() {
     SecondClassWithLongLongLongLongName anon = new SecondClassWithLongLongLongLongName() {};

--- a/src/it/resources/com/google/checkstyle/test/chapter4formatting/rule4841indentation/InputIndentationCorrectNewChildren.java
+++ b/src/it/resources/com/google/checkstyle/test/chapter4formatting/rule4841indentation/InputIndentationCorrectNewChildren.java
@@ -1,6 +1,6 @@
 package com.google.checkstyle.test.chapter4formatting.rule4841indentation;
 
-/** some javadoc. */
+/** Some javadoc. */
 public class InputIndentationCorrectNewChildren {
 
   private final StringBuffer filter =

--- a/src/it/resources/com/google/checkstyle/test/chapter4formatting/rule4841indentation/InputLambdaAndChildOnTheSameLine.java
+++ b/src/it/resources/com/google/checkstyle/test/chapter4formatting/rule4841indentation/InputLambdaAndChildOnTheSameLine.java
@@ -4,7 +4,7 @@ package com.google.checkstyle.test.chapter4formatting.rule4841indentation;
 
 import java.lang.reflect.Proxy;
 
-/** some javadoc. */
+/** Some javadoc. */
 public class InputLambdaAndChildOnTheSameLine {
 
   enum A { A1, A2, A3, A4, A5 }

--- a/src/it/resources/com/google/checkstyle/test/chapter4formatting/rule4841indentation/InputLambdaChild.java
+++ b/src/it/resources/com/google/checkstyle/test/chapter4formatting/rule4841indentation/InputLambdaChild.java
@@ -6,7 +6,7 @@ import java.util.List;
 import java.util.function.Function;
 import java.util.function.Predicate;
 
-/**some javadoc.*/
+/**Some javadoc.*/
 public class InputLambdaChild {
   String testMethod1(List<Integer> operations) {
     return operations.stream()

--- a/src/it/resources/com/google/checkstyle/test/chapter4formatting/rule4841indentation/InputLambdaChildCorrect.java
+++ b/src/it/resources/com/google/checkstyle/test/chapter4formatting/rule4841indentation/InputLambdaChildCorrect.java
@@ -6,7 +6,7 @@ import java.util.List;
 import java.util.function.Function;
 import java.util.function.Predicate;
 
-/** some javadoc. */
+/** Some javadoc. */
 public class InputLambdaChildCorrect {
   String testMethod1(List<Integer> operations) {
     return operations.stream()

--- a/src/it/resources/com/google/checkstyle/test/chapter4formatting/rule4841indentation/InputLineBreakAfterLeftCurlyOfBlockInSwitch.java
+++ b/src/it/resources/com/google/checkstyle/test/chapter4formatting/rule4841indentation/InputLineBreakAfterLeftCurlyOfBlockInSwitch.java
@@ -1,6 +1,6 @@
 package com.google.checkstyle.test.chapter4formatting.rule4841indentation;
 
-/** some javadoc. */
+/** Some javadoc. */
 public class InputLineBreakAfterLeftCurlyOfBlockInSwitch {
 
   void testMethod1(int month) {

--- a/src/it/resources/com/google/checkstyle/test/chapter4formatting/rule4841indentation/InputMultilineStatementsCorrect.java
+++ b/src/it/resources/com/google/checkstyle/test/chapter4formatting/rule4841indentation/InputMultilineStatementsCorrect.java
@@ -2,10 +2,10 @@
 
 package com.google.checkstyle.test.chapter4formatting.rule4841indentation;
 
-/** some class. */
+/** Some class. */
 public class InputMultilineStatementsCorrect {
 
-  /** some test method. */
+  /** Some test method. */
   public void test1() {
     try {
       System.out.println("try0");

--- a/src/it/resources/com/google/checkstyle/test/chapter4formatting/rule4841indentation/InputNewKeywordChildren.java
+++ b/src/it/resources/com/google/checkstyle/test/chapter4formatting/rule4841indentation/InputNewKeywordChildren.java
@@ -5,7 +5,7 @@ import java.io.IOException;
 import java.io.InputStreamReader;
 import java.util.Optional;
 
-/** some data. */
+/** Some data. */
 public class InputNewKeywordChildren {
 
   static {
@@ -28,7 +28,7 @@ public class InputNewKeywordChildren {
     }
   }
 
-  /** some data. */
+  /** Some data. */
   public Object foo() {
     return Optional.empty()
         .orElseThrow(
@@ -39,7 +39,7 @@ new IllegalArgumentException(
     // violation above '.* incorrect indentation level 0, expected level should be one .* 18, 20'
   }
 
-  /** some data. */
+  /** Some data. */
   public Object foo1() {
     return Optional.empty()
         .orElseThrow(
@@ -49,7 +49,7 @@ new IllegalArgumentException(
     // violation above '.* incorrect indentation level 0, expected .* 18, 20.'
   }
 
-  /** some data. */
+  /** Some data. */
   public void foo2() throws IOException {
     BufferedReader bf =
         new BufferedReader(
@@ -58,7 +58,7 @@ new IllegalArgumentException(
             });
   }
 
-  /** some data. */
+  /** Some data. */
   public Object foo4(int data) {
     return Optional.empty()
         .orElseThrow(
@@ -66,7 +66,7 @@ new IllegalArgumentException(
                 "something wrong 1, something wrong 2, something wrong 3"));
   }
 
-  /** some data. */
+  /** Some data. */
   public Object foo5(int data) {
     return Optional.empty()
         .orElseThrow(
@@ -75,7 +75,7 @@ new IllegalArgumentException(
     // violation above '.* incorrect indentation level 8, expected .* 16.'
   }
 
-  /** some data. */
+  /** Some data. */
   public void createExpressionIssue(Object invocation, String toBeRemovedExpression) {
     throw new IllegalArgumentException("The expression " + toBeRemovedExpression
         + ", which creates argument of the invocation " + invocation + " cannot be removed."

--- a/src/it/resources/com/google/checkstyle/test/chapter4formatting/rule4841indentation/InputNewKeywordChildrenCorrect.java
+++ b/src/it/resources/com/google/checkstyle/test/chapter4formatting/rule4841indentation/InputNewKeywordChildrenCorrect.java
@@ -5,10 +5,10 @@ import java.io.IOException;
 import java.io.InputStreamReader;
 import java.util.Optional;
 
-/** some data. */
+/** Some data. */
 public class InputNewKeywordChildrenCorrect {
 
-  /** some data. */
+  /** Some data. */
   public Object foo() {
     return Optional.empty()
         .orElseThrow(
@@ -17,7 +17,7 @@ public class InputNewKeywordChildrenCorrect {
                     "Something wrong 1, something wrong 2, something wrong 3"));
   }
 
-  /** some data. */
+  /** Some data. */
   public void foo2() throws IOException {
     BufferedReader bf =
         new BufferedReader(

--- a/src/it/resources/com/google/checkstyle/test/chapter4formatting/rule4841indentation/InputSingleSwitchStatementWithoutCurly.java
+++ b/src/it/resources/com/google/checkstyle/test/chapter4formatting/rule4841indentation/InputSingleSwitchStatementWithoutCurly.java
@@ -2,7 +2,7 @@
 
 package com.google.checkstyle.test.chapter4formatting.rule4841indentation;
 
-/**some javadoc.*/
+/**Some javadoc.*/
 public class InputSingleSwitchStatementWithoutCurly {
   void testCorrectIndentation(int obj) {
     switch (obj) {

--- a/src/it/resources/com/google/checkstyle/test/chapter4formatting/rule4841indentation/InputSingleSwitchStatementWithoutCurlyCorrect.java
+++ b/src/it/resources/com/google/checkstyle/test/chapter4formatting/rule4841indentation/InputSingleSwitchStatementWithoutCurlyCorrect.java
@@ -2,7 +2,7 @@
 
 package com.google.checkstyle.test.chapter4formatting.rule4841indentation;
 
-/** some javadoc. */
+/** Some javadoc. */
 public class InputSingleSwitchStatementWithoutCurlyCorrect {
   void testCorrectIndentation(int obj) {
     switch (obj) {

--- a/src/it/resources/com/google/checkstyle/test/chapter4formatting/rule4841indentation/InputSwitchOnStartOfTheLine.java
+++ b/src/it/resources/com/google/checkstyle/test/chapter4formatting/rule4841indentation/InputSwitchOnStartOfTheLine.java
@@ -2,7 +2,7 @@
 
 package com.google.checkstyle.test.chapter4formatting.rule4841indentation;
 
-/**some javadoc.*/
+/**Some javadoc.*/
 public class InputSwitchOnStartOfTheLine {
   String testMethod1(int i) {
     String s =

--- a/src/it/resources/com/google/checkstyle/test/chapter4formatting/rule4841indentation/InputSwitchOnStartOfTheLineCorrect.java
+++ b/src/it/resources/com/google/checkstyle/test/chapter4formatting/rule4841indentation/InputSwitchOnStartOfTheLineCorrect.java
@@ -2,7 +2,7 @@
 
 package com.google.checkstyle.test.chapter4formatting.rule4841indentation;
 
-/** some javadoc. */
+/** Some javadoc. */
 public class InputSwitchOnStartOfTheLineCorrect {
   String testMethod1(int i) {
     String s =

--- a/src/it/resources/com/google/checkstyle/test/chapter4formatting/rule4841indentation/InputSwitchWrappingIndentation.java
+++ b/src/it/resources/com/google/checkstyle/test/chapter4formatting/rule4841indentation/InputSwitchWrappingIndentation.java
@@ -4,7 +4,7 @@ package com.google.checkstyle.test.chapter4formatting.rule4841indentation;
 
 import java.util.List;
 
-/**some javadoc.*/
+/**Some javadoc.*/
 public class InputSwitchWrappingIndentation {
   String testMethod1(int i) {
     String name = "";

--- a/src/it/resources/com/google/checkstyle/test/chapter4formatting/rule4841indentation/InputSwitchWrappingIndentationCorrect.java
+++ b/src/it/resources/com/google/checkstyle/test/chapter4formatting/rule4841indentation/InputSwitchWrappingIndentationCorrect.java
@@ -4,7 +4,7 @@ package com.google.checkstyle.test.chapter4formatting.rule4841indentation;
 
 import java.util.List;
 
-/** some javadoc. */
+/** Some javadoc. */
 public class InputSwitchWrappingIndentationCorrect {
   String testMethod1(int i) {
     String name = "";

--- a/src/it/resources/com/google/checkstyle/test/chapter4formatting/rule4852classannotations/InputClassAnnotation2.java
+++ b/src/it/resources/com/google/checkstyle/test/chapter4formatting/rule4852classannotations/InputClassAnnotation2.java
@@ -2,13 +2,13 @@ package com.google.checkstyle.test.chapter4formatting.rule4852classannotations;
 
 import javax.annotation.CheckReturnValue;
 
-/** somejavadoc data. */
+/** Somejavadoc data. */
 @Deprecated
 @CheckReturnValue
 public final class InputClassAnnotation2 {
   void test1() {}
 
-  /** somejavadoc data. */
+  /** Somejavadoc data. */
   @Deprecated @CheckReturnValue
   public class Inner {
     // violation 2 lines above 'Annotation 'CheckReturnValue' should be alone on line'
@@ -17,7 +17,7 @@ public final class InputClassAnnotation2 {
 }
 
 // violation 2 lines below 'Top-level class InputClassAnnotation3 has to reside'
-/** somejavadoc data. */
+/** Somejavadoc data. */
 @Deprecated @CheckReturnValue
 final class InputClassAnnotation3 {
   // violation 2 lines above 'Annotation 'CheckReturnValue' should be alone on line'
@@ -25,7 +25,7 @@ final class InputClassAnnotation3 {
 }
 
 // violation 2 lines below 'Top-level class InputClassAnnotation5 has to reside'
-/** some javadoc. */
+/** Some javadoc. */
 @Deprecated
 // testing
 @CheckReturnValue

--- a/src/it/resources/com/google/checkstyle/test/chapter4formatting/rule4852classannotations/InputFormattedClassAnnotation2.java
+++ b/src/it/resources/com/google/checkstyle/test/chapter4formatting/rule4852classannotations/InputFormattedClassAnnotation2.java
@@ -2,13 +2,13 @@ package com.google.checkstyle.test.chapter4formatting.rule4852classannotations;
 
 import javax.annotation.CheckReturnValue;
 
-/** somejavadoc data. */
+/** Somejavadoc data. */
 @Deprecated
 @CheckReturnValue
 public final class InputFormattedClassAnnotation2 {
   void test1() {}
 
-  /** somejavadoc data. */
+  /** Somejavadoc data. */
   @Deprecated
   @CheckReturnValue
   public class Inner {
@@ -17,7 +17,7 @@ public final class InputFormattedClassAnnotation2 {
 }
 
 // violation 2 lines below 'Top-level class InputClassAnnotation4 has to reside'
-/** somejavadoc data. */
+/** Somejavadoc data. */
 @Deprecated
 @CheckReturnValue
 final class InputClassAnnotation4 {
@@ -25,7 +25,7 @@ final class InputClassAnnotation4 {
 }
 
 // violation 2 lines below 'Top-level class InputClassAnnotation6 has to reside'
-/** some javadoc. */
+/** Some javadoc. */
 @Deprecated
 // testing
 @CheckReturnValue

--- a/src/it/resources/com/google/checkstyle/test/chapter4formatting/rule4853methodsandconstructorsannotations/InputFormattedMethodsAndConstructorsAnnotations.java
+++ b/src/it/resources/com/google/checkstyle/test/chapter4formatting/rule4853methodsandconstructorsannotations/InputFormattedMethodsAndConstructorsAnnotations.java
@@ -10,16 +10,16 @@ public class InputFormattedMethodsAndConstructorsAnnotations {
 
   // ********testing methods.***********
 
-  /** testing. */
+  /** Testing. */
   @SomeAnnotation1
   @SomeAnnotation2
   void test1() {}
 
-  /** testing. */
+  /** Testing. */
   @SomeAnnotation1
   void test2() {}
 
-  /** testing. */
+  /** Testing. */
   @SomeAnnotation1
   @SomeAnnotation2
   void test3() {}
@@ -33,16 +33,16 @@ public class InputFormattedMethodsAndConstructorsAnnotations {
 
   // ********testing constructors.*********
 
-  /** testing. */
+  /** Testing. */
   @SomeAnnotation1
   @SomeAnnotation2
   InputFormattedMethodsAndConstructorsAnnotations() {}
 
-  /** testing. */
+  /** Testing. */
   @SomeAnnotation1
   InputFormattedMethodsAndConstructorsAnnotations(float f) {}
 
-  /** testing. */
+  /** Testing. */
   @SomeAnnotation1
   @SomeAnnotation2
   InputFormattedMethodsAndConstructorsAnnotations(int x) {}

--- a/src/it/resources/com/google/checkstyle/test/chapter4formatting/rule4853methodsandconstructorsannotations/InputMethodsAndConstructorsAnnotations.java
+++ b/src/it/resources/com/google/checkstyle/test/chapter4formatting/rule4853methodsandconstructorsannotations/InputMethodsAndConstructorsAnnotations.java
@@ -10,27 +10,27 @@ public class InputMethodsAndConstructorsAnnotations {
 
   // ********testing methods.***********
 
-  /** testing. */
+  /** Testing. */
   @SomeAnnotation1
   @SomeAnnotation2
   void test1() {}
 
-  /** testing. */
+  /** Testing. */
   @SomeAnnotation1 void test2() {}
 
-  /** testing. */
+  /** Testing. */
   @SomeAnnotation1 @SomeAnnotation2
   // violation above 'Annotation 'SomeAnnotation2' should be alone on line.'
   void test3() {}
 
   @SomeAnnotation1
   @SomeAnnotation2
-  /** testing. */ // violation 'Javadoc comment is placed in the wrong location.'
+  /** Testing. */ // violation 'Javadoc comment is placed in the wrong location.'
   void test4() {}
 
   @SomeAnnotation1 @SomeAnnotation2
   // violation above 'Annotation 'SomeAnnotation2' should be alone on line.'
-  /** testing. */ // violation 'Javadoc comment is placed in the wrong location.'
+  /** Testing. */ // violation 'Javadoc comment is placed in the wrong location.'
   void test5() {}
 
   @SomeAnnotation1 @SomeAnnotation2 void test6() {}
@@ -41,27 +41,27 @@ public class InputMethodsAndConstructorsAnnotations {
 
   // ********testing constructors.*********
 
-  /** testing. */
+  /** Testing. */
   @SomeAnnotation1
   @SomeAnnotation2
   InputMethodsAndConstructorsAnnotations() {}
 
-  /** testing. */
+  /** Testing. */
   @SomeAnnotation1 InputMethodsAndConstructorsAnnotations(float f) {}
 
-  /** testing. */
+  /** Testing. */
   @SomeAnnotation1 @SomeAnnotation2
   // violation above 'Annotation 'SomeAnnotation2' should be alone on line.'
   InputMethodsAndConstructorsAnnotations(int x) {}
 
   @SomeAnnotation1
   @SomeAnnotation2
-  /** testing. */ // violation 'Javadoc comment is placed in the wrong location.'
+  /** Testing. */ // violation 'Javadoc comment is placed in the wrong location.'
   InputMethodsAndConstructorsAnnotations(String str) {}
 
   @SomeAnnotation1 @SomeAnnotation2
   // violation above 'Annotation 'SomeAnnotation2' should be alone on line.'
-  /** testing. */ // violation 'Javadoc comment is placed in the wrong location.'
+  /** Testing. */ // violation 'Javadoc comment is placed in the wrong location.'
   InputMethodsAndConstructorsAnnotations(double d) {}
 
   // violation below 'Annotation 'SomeAnnotation2' should be alone on line.'

--- a/src/it/resources/com/google/checkstyle/test/chapter4formatting/rule4854fieldannotations/InputFieldAnnotations.java
+++ b/src/it/resources/com/google/checkstyle/test/chapter4formatting/rule4854fieldannotations/InputFieldAnnotations.java
@@ -17,20 +17,20 @@ public class InputFieldAnnotations {
     int x();
   }
 
-  /** testing. */
+  /** Testing. */
   @SomeAnnotation1
   @SomeAnnotation2
   String name = "Zops";
 
-  /** testing. */
+  /** Testing. */
   @SomeAnnotation1 @SomeAnnotation2
   int age = 19;
 
-  /** testing. */
+  /** Testing. */
   @SomeAnnotation1
   @SomeAnnotation2 String favLanguage = "Java";
 
-  /** testing. */
+  /** Testing. */
   @SomeAnnotation1
   @SomeAnnotation3(x = 90) String favPet = "Dog";
 
@@ -39,15 +39,15 @@ public class InputFieldAnnotations {
   @SuppressWarnings("bla") @SomeAnnotation3(x = 0) float pi = 3.14f;
 
   @SomeAnnotation1 @SomeAnnotation3(x = 14)
-  /** testing. */ // violation 'Javadoc comment is placed in the wrong location.'
+  /** Testing. */ // violation 'Javadoc comment is placed in the wrong location.'
   List<String> list = new ArrayList<>();
 
   @SuppressWarnings("bla")
   @SomeAnnotation1
-  /** testing. */ // violation 'Javadoc comment is placed in the wrong location.'
+  /** Testing. */ // violation 'Javadoc comment is placed in the wrong location.'
   InputFieldAnnotations obj = new InputFieldAnnotations();
 
-  /** testing. */
+  /** Testing. */
   @SomeAnnotation1 @SomeAnnotation2
   // violation above 'Annotation 'SomeAnnotation2' should be alone on line.'
   void test1() {}

--- a/src/it/resources/com/google/checkstyle/test/chapter4formatting/rule4854fieldannotations/InputFormattedFieldAnnotations.java
+++ b/src/it/resources/com/google/checkstyle/test/chapter4formatting/rule4854fieldannotations/InputFormattedFieldAnnotations.java
@@ -17,16 +17,16 @@ public class InputFormattedFieldAnnotations {
     int x();
   }
 
-  /** testing. */
+  /** Testing. */
   @SomeAnnotation1 @SomeAnnotation2 String name = "Zops";
 
-  /** testing. */
+  /** Testing. */
   @SomeAnnotation1 @SomeAnnotation2 int age = 19;
 
-  /** testing. */
+  /** Testing. */
   @SomeAnnotation1 @SomeAnnotation2 String favLanguage = "Java";
 
-  /** testing. */
+  /** Testing. */
   @SomeAnnotation1
   @SomeAnnotation3(x = 90)
   String favPet = "Dog";
@@ -37,16 +37,16 @@ public class InputFormattedFieldAnnotations {
   @SomeAnnotation3(x = 0)
   float pi = 3.14f;
 
-  /** testing. */
+  /** Testing. */
   @SomeAnnotation1
   @SomeAnnotation3(x = 14)
   List<String> list = new ArrayList<>();
 
-  /** testing. */
+  /** Testing. */
   @SuppressWarnings("bla")
   InputFormattedFieldAnnotations obj = new InputFormattedFieldAnnotations();
 
-  /** testing. */
+  /** Testing. */
   @SomeAnnotation1
   @SomeAnnotation2
   void test1() {}

--- a/src/it/resources/com/google/checkstyle/test/chapter4formatting/rule4861blockcommentstyle/InputCommentsIndentationCommentIsAtTheEndOfBlock.java
+++ b/src/it/resources/com/google/checkstyle/test/chapter4formatting/rule4861blockcommentstyle/InputCommentsIndentationCommentIsAtTheEndOfBlock.java
@@ -3,38 +3,38 @@ package com.google.checkstyle.test.chapter4formatting.rule4861blockcommentstyle;
 /** Contains examples of using comments at the end of the block. */
 public class InputCommentsIndentationCommentIsAtTheEndOfBlock {
 
-  /** some javadoc. */
+  /** Some javadoc. */
   public void foo1() {
     foo2();
     // OOOO: missing functionality
   }
 
-  /** some javadoc. */
+  /** Some javadoc. */
   public void foo2() {
     // violation 2 lines below '.* indentation should be the same level as line 15.'
     foo3();
                        // odd indentation comment
   }
 
-  /** some javadoc. */
+  /** Some javadoc. */
   public void foo3() {
     foo2();
     // refreshDisplay();
   }
 
-  /** some javadoc. */
+  /** Some javadoc. */
   public void foo4() {
     foooooooooooooooooooooooooooooooooooooooooo();
     // ^-- some hint
   }
 
-  /** some javadoc. */
+  /** Some javadoc. */
   public void foooooooooooooooooooooooooooooooooooooooooo() {}
 
      /////////////////////////////// odd indentation comment
   // violation above '.* indentation should be the same level as line 38.'
 
-  /** some javadoc. */
+  /** Some javadoc. */
   public void foo7() {
     // violation 2 lines below'.* indentation should be the same level as line 40.'
     int a = 0;
@@ -43,12 +43,12 @@ public class InputCommentsIndentationCommentIsAtTheEndOfBlock {
 
   /////////////////////////////// (a single-line border to separate a group of methods)
 
-  /** some javadoc. */
+  /** Some javadoc. */
   public void foo8() {}
 
-  /** some javadoc. */
+  /** Some javadoc. */
   public class TestClass {
-    /** some javadoc. */
+    /** Some javadoc. */
     public void test() {
       // violation 3 lines below '.* indentation should be the same level as line 55.'
       // violation 4 lines below'.* indentation should be the same level as line 52.'
@@ -58,7 +58,7 @@ public class InputCommentsIndentationCommentIsAtTheEndOfBlock {
       // odd indentation comment
   }
 
-  /** some javadoc. */
+  /** Some javadoc. */
   public void foo9() {
     // violation 2 lines below '.* indentation should be the same level as line 64.'
     this.foo1();
@@ -69,13 +69,13 @@ public class InputCommentsIndentationCommentIsAtTheEndOfBlock {
   //
   //    }
 
-  /** some javadoc. */
+  /** Some javadoc. */
   public void foo11() {
     String.valueOf(new Integer(0)).trim().length();
     // comment
   }
 
-  /** some javadoc. */
+  /** Some javadoc. */
   public void foo12() {
     // violation 5 lines below '.* indentation should be the same level as line 81.'
     String
@@ -85,13 +85,13 @@ public class InputCommentsIndentationCommentIsAtTheEndOfBlock {
               // odd indentation comment
   }
 
-  /** some javadoc. */
+  /** Some javadoc. */
   public void foo13() {
     String.valueOf(new Integer(0)).trim().length();
     // comment
   }
 
-  /** some javadoc. */
+  /** Some javadoc. */
   public void foo14() {
     // violation 4 lines below '.* indentation should be the same level as line 97.'
     String.valueOf(new Integer(0))
@@ -100,13 +100,13 @@ public class InputCommentsIndentationCommentIsAtTheEndOfBlock {
                            // odd indentation comment
   }
 
-  /** some javadoc. */
+  /** Some javadoc. */
   public void foo15() {
     String.valueOf(new Integer(0));
     // comment
   }
 
-  /** some javadoc. */
+  /** Some javadoc. */
   public void foo16() {
     // violation 3 lines below '.* indentation should be the same level as line 112.'
     String
@@ -114,7 +114,7 @@ public class InputCommentsIndentationCommentIsAtTheEndOfBlock {
                  // odd indentation comment
   }
 
-  /** some javadoc. */
+  /** Some javadoc. */
   public void foo17() {
     String.valueOf(new Integer(0))
             .trim()
@@ -122,7 +122,7 @@ public class InputCommentsIndentationCommentIsAtTheEndOfBlock {
             .length();
   }
 
-  /** some javadoc. */
+  /** Some javadoc. */
   public void foo18() {
     // violation 4 lines below '.* indentation should be the same level as line 132.'
     String
@@ -132,7 +132,7 @@ public class InputCommentsIndentationCommentIsAtTheEndOfBlock {
         .length();
   }
 
-  /** some javadoc. */
+  /** Some javadoc. */
   public void foo19() {
     (new Thread(
             new Runnable() {
@@ -143,7 +143,7 @@ public class InputCommentsIndentationCommentIsAtTheEndOfBlock {
     // comment
   }
 
-  /** some javadoc. */
+  /** Some javadoc. */
   public void foo20() {
     // violation 8 lines below '.* indentation should be the same level as line 149.'
     (new Thread(new Runnable() {
@@ -156,7 +156,7 @@ public class InputCommentsIndentationCommentIsAtTheEndOfBlock {
                       // odd indentation comment
   }
 
-  /** some javadoc. */
+  /** Some javadoc. */
   public void foo21() {
     int[] array = new int[5];
 
@@ -173,7 +173,7 @@ public class InputCommentsIndentationCommentIsAtTheEndOfBlock {
     // the above example was taken from hibernate-orm and was modified a bit
   }
 
-  /** some javadoc. */
+  /** Some javadoc. */
   public void foo22() {
     int[] array = new int[5];
 
@@ -188,26 +188,26 @@ public class InputCommentsIndentationCommentIsAtTheEndOfBlock {
                              // odd indentation comment
   }
 
-  /** some javadoc. */
+  /** Some javadoc. */
   public void foo23() {
     new Object();
     // comment
   }
 
-  /** some javadoc. */
+  /** Some javadoc. */
   public void foo24() {
     // violation 2 lines below '.* indentation should be the same level as line 200.'
     new Object();
                  // odd indentation comment
   }
 
-  /** some javadoc. */
+  /** Some javadoc. */
   public String foo25() {
     return String.format(java.util.Locale.ENGLISH, "%d", 1);
     // comment
   }
 
-  /** some javadoc. */
+  /** Some javadoc. */
   public String foo26() {
     // violation 3 lines below '.* indentation should be the same level as line 213.'
     return String.format(java.util.Locale.ENGLISH, "%d",
@@ -215,7 +215,7 @@ public class InputCommentsIndentationCommentIsAtTheEndOfBlock {
                               // odd indentation comment
   }
 
-  /** some javadoc. */
+  /** Some javadoc. */
   public void foo27() {
     // comment
     // block
@@ -224,14 +224,14 @@ public class InputCommentsIndentationCommentIsAtTheEndOfBlock {
     // OOOO
   }
 
-  /** some javadoc. */
+  /** Some javadoc. */
   public String foo28() {
     int a = 5;
     return String.format(java.util.Locale.ENGLISH, "%d", 1);
     // comment
   }
 
-  /** some javadoc. */
+  /** Some javadoc. */
   public String foo29() {
     int a = 5;
     // violation 3 lines below '.* indentation should be the same level as line 238.'
@@ -240,7 +240,7 @@ public class InputCommentsIndentationCommentIsAtTheEndOfBlock {
                       // odd indentation comment
   }
 
-  /** some javadoc. */
+  /** Some javadoc. */
   public void foo30() {
     // comment
     // violation 2 lines below '.* indentation should be the same level as line 247.'
@@ -248,13 +248,13 @@ public class InputCommentsIndentationCommentIsAtTheEndOfBlock {
 // odd indentation comment
   }
 
-  /** some javadoc. */
+  /** Some javadoc. */
   public void foo31() {
     String s = new String("A" + "B" + "C");
     // comment
   }
 
-  /** some javadoc. */
+  /** Some javadoc. */
   public void foo32() {
     // violation 4 lines below '.* indentation should be the same level as line 260.'
     String s = new String("A"
@@ -263,7 +263,7 @@ public class InputCommentsIndentationCommentIsAtTheEndOfBlock {
         // odd indentation comment
   }
 
-  /** some javadoc. */
+  /** Some javadoc. */
   public void foo33() {
     // comment
     // violation 2 lines below '.* indentation should be the same level as line 270.'
@@ -271,13 +271,13 @@ public class InputCommentsIndentationCommentIsAtTheEndOfBlock {
 // odd indentation comment
   }
 
-  /** some javadoc. */
+  /** Some javadoc. */
   public void foo34() throws Exception {
     throw new Exception("", new Exception());
     // comment
   }
 
-  /** some javadoc. */
+  /** Some javadoc. */
   public void foo35() throws Exception {
     // violation 4 lines below '.* indentation should be the same level as line 283.'
     throw new Exception("",
@@ -286,7 +286,7 @@ public class InputCommentsIndentationCommentIsAtTheEndOfBlock {
         // odd indentation comment
   }
 
-  /** some javadoc. */
+  /** Some javadoc. */
   public void foo36() throws Exception {
     // violation 4 lines below '.* indentation should be the same level as line 292.'
     throw new Exception("",
@@ -295,20 +295,20 @@ public class InputCommentsIndentationCommentIsAtTheEndOfBlock {
 // odd indentation comment
   }
 
-  /** some javadoc. */
+  /** Some javadoc. */
   public void foo37() throws Exception {
     throw new Exception("", new Exception());
     // comment
   }
 
-  /** some javadoc. */
+  /** Some javadoc. */
   public void foo38() throws Exception {
     // violation 2 lines below '.* indentation should be the same level as line 307.'
     throw new Exception("", new Exception());
           // odd indentation comment
   }
 
-  /** some javadoc. */
+  /** Some javadoc. */
   public void foo39() throws Exception {
     // violation 3 lines below'.* indentation should be the same level as line 314.'
     throw new Exception("",
@@ -316,7 +316,7 @@ public class InputCommentsIndentationCommentIsAtTheEndOfBlock {
      // odd indentation comment
   }
 
-  /** some javadoc. */
+  /** Some javadoc. */
   public void foo40() throws Exception {
     int a = 88;
     // violation 2 lines below '.* indentation should be the same level as line 323.'
@@ -324,14 +324,14 @@ public class InputCommentsIndentationCommentIsAtTheEndOfBlock {
      // odd indentation comment
   }
 
-  /** some javadoc. */
+  /** Some javadoc. */
   public void foo41() throws Exception {
     int a = 88;
     throw new Exception("", new Exception());
     // comment
   }
 
-  /** some javadoc. */
+  /** Some javadoc. */
   public void foo42() {
     int a = 5;
     if (a == 5) {
@@ -342,7 +342,7 @@ public class InputCommentsIndentationCommentIsAtTheEndOfBlock {
     }
   }
 
-  /** some javadoc. */
+  /** Some javadoc. */
   public void foo43() {
     try {
       int a;
@@ -352,7 +352,7 @@ public class InputCommentsIndentationCommentIsAtTheEndOfBlock {
     }
   }
 
-  /** some javadoc. */
+  /** Some javadoc. */
   public void foo44() {
     int ar = 5;
     // comment
@@ -360,7 +360,7 @@ public class InputCommentsIndentationCommentIsAtTheEndOfBlock {
     // comment
   }
 
-  /** some javadoc. */
+  /** Some javadoc. */
   public void foo45() {
     int ar = 5;
     // comment
@@ -369,7 +369,7 @@ public class InputCommentsIndentationCommentIsAtTheEndOfBlock {
      // odd indentation comment
   }
 
-  /** some javadoc. */
+  /** Some javadoc. */
   public void foo46() {
     // violation 3 lines below '.* indentation should be the same level as line 378.'
 // comment
@@ -377,7 +377,7 @@ public class InputCommentsIndentationCommentIsAtTheEndOfBlock {
 // odd indentation comment
   }
 
-  /** some javadoc. */
+  /** Some javadoc. */
   public void foo47() {
     int a = 5;
     // comment
@@ -385,7 +385,7 @@ public class InputCommentsIndentationCommentIsAtTheEndOfBlock {
     // comment
   }
 
-  /** some javadoc. */
+  /** Some javadoc. */
   public void foo48() {
     // violation 4 lines below '.* indentation should be the same level as line 391.'
     int a = 5;
@@ -394,21 +394,21 @@ public class InputCommentsIndentationCommentIsAtTheEndOfBlock {
 // odd indentation comment
   }
 
-  /** some javadoc. */
+  /** Some javadoc. */
   public void foo49() {
     // comment
     // block
     // ok
   }
 
-  /** some javadoc. */
+  /** Some javadoc. */
   public void foo50() {
     return;
 
     // No NPE here!
   }
 
-  /** some javadoc. */
+  /** Some javadoc. */
   public String foo51() {
     // violation 4 lines below '.* indentation should be the same level as line 414.'
     return String
@@ -417,7 +417,7 @@ public class InputCommentsIndentationCommentIsAtTheEndOfBlock {
      // odd indentation comment
   }
 
-  /** some javadoc. */
+  /** Some javadoc. */
   public String foo52() {
     return String.valueOf("11");
     // comment

--- a/src/it/resources/com/google/checkstyle/test/chapter4formatting/rule4861blockcommentstyle/InputCommentsIndentationInEmptyBlock.java
+++ b/src/it/resources/com/google/checkstyle/test/chapter4formatting/rule4861blockcommentstyle/InputCommentsIndentationInEmptyBlock.java
@@ -1,6 +1,6 @@
 package com.google.checkstyle.test.chapter4formatting.rule4861blockcommentstyle;
 
-/** some javadoc. */
+/** Some javadoc. */
 public class InputCommentsIndentationInEmptyBlock {
 
   private void foo1() {
@@ -61,7 +61,7 @@ public class InputCommentsIndentationInEmptyBlock {
     }
   }
 
-  /** some javadoc. */
+  /** Some javadoc. */
   public void foo6() {
     try {
       /* foo */
@@ -71,7 +71,7 @@ public class InputCommentsIndentationInEmptyBlock {
     // violation 2 lines above '.* indentation should be the same level as line 70.'
   }
 
-  /** some javadoc. */
+  /** Some javadoc. */
   public void foo7() {
     try {
       /* foo */

--- a/src/it/resources/com/google/checkstyle/test/chapter4formatting/rule4861blockcommentstyle/InputCommentsIndentationInSwitchBlock.java
+++ b/src/it/resources/com/google/checkstyle/test/chapter4formatting/rule4861blockcommentstyle/InputCommentsIndentationInSwitchBlock.java
@@ -1,6 +1,6 @@
 package com.google.checkstyle.test.chapter4formatting.rule4861blockcommentstyle;
 
-/** some javadoc. */
+/** Some javadoc. */
 public class InputCommentsIndentationInSwitchBlock {
 
   private static void fooSwitch() {
@@ -123,7 +123,7 @@ public class InputCommentsIndentationInSwitchBlock {
     }
   }
 
-  /** some javadoc. */
+  /** Some javadoc. */
   public void fooDotInCaseBlock() {
     int i = 0;
     String s = "";
@@ -165,7 +165,7 @@ public class InputCommentsIndentationInSwitchBlock {
             ;
   }
 
-  /** some javadoc. */
+  /** Some javadoc. */
   public void foo2() {
     int a = 1;
     switch (a) {
@@ -176,7 +176,7 @@ public class InputCommentsIndentationInSwitchBlock {
     // violation 2 lines above'.* indentation should be the same level as line 175.'
   }
 
-  /** some javadoc. */
+  /** Some javadoc. */
   public void foo3() {
     int a = 1;
     switch (a) {
@@ -187,7 +187,7 @@ public class InputCommentsIndentationInSwitchBlock {
     }
   }
 
-  /** some javadoc. */
+  /** Some javadoc. */
   public void foo4() {
     int a = 1;
     switch (a) {
@@ -200,7 +200,7 @@ public class InputCommentsIndentationInSwitchBlock {
     }
   }
 
-  /** some javadoc. */
+  /** Some javadoc. */
   public void foo5() {
     int a = 1;
     switch (a) {
@@ -212,7 +212,7 @@ public class InputCommentsIndentationInSwitchBlock {
     }
   }
 
-  /** some javadoc. */
+  /** Some javadoc. */
   public void foo6() {
     int a = 1;
     switch (a) {
@@ -224,7 +224,7 @@ public class InputCommentsIndentationInSwitchBlock {
     }
   }
 
-  /** some javadoc. */
+  /** Some javadoc. */
   public void foo7() {
     int a = 2;
     String s = "";
@@ -259,7 +259,7 @@ public class InputCommentsIndentationInSwitchBlock {
     }
   }
 
-  /** some javadoc. */
+  /** Some javadoc. */
   public void foo8() {
     int a = 2;
     String s = "";
@@ -287,7 +287,7 @@ public class InputCommentsIndentationInSwitchBlock {
     }
   }
 
-  /** some javadoc. */
+  /** Some javadoc. */
   public void foo9() {
     int a = 5;
     switch (a) {
@@ -298,7 +298,7 @@ public class InputCommentsIndentationInSwitchBlock {
     }
   }
 
-  /** some javadoc. */
+  /** Some javadoc. */
   public void foo10() {
     int a = 5;
     switch (a) {
@@ -308,7 +308,7 @@ public class InputCommentsIndentationInSwitchBlock {
     }
   }
 
-  /** some javadoc. */
+  /** Some javadoc. */
   public void foo11() {
     int a = 5;
     switch (a) {
@@ -319,7 +319,7 @@ public class InputCommentsIndentationInSwitchBlock {
     }
   }
 
-  /** some javadoc. */
+  /** Some javadoc. */
   public void foo12() {
     int a = 5;
     switch (a) {

--- a/src/it/resources/com/google/checkstyle/test/chapter4formatting/rule4861blockcommentstyle/InputCommentsIndentationSurroundingCode.java
+++ b/src/it/resources/com/google/checkstyle/test/chapter4formatting/rule4861blockcommentstyle/InputCommentsIndentationSurroundingCode.java
@@ -5,7 +5,7 @@ package com.google.checkstyle.test.chapter4formatting.rule4861blockcommentstyle;
 import java.util.Arrays;
 
 // some
-/** some javadoc. */
+/** Some javadoc. */
 public class InputCommentsIndentationSurroundingCode {
   private void foo1() {
     if (true) {
@@ -84,17 +84,17 @@ public class InputCommentsIndentationSurroundingCode {
     if (!Arrays.equals(new String[] {""}, new String[] {""})/* wierd comment */) { /* foo */ }
   }
 
-  /** some javadoc. */
+  /** Some javadoc. */
   private static void testing() {}
 
-  /** some javadoc. */
+  /** Some javadoc. */
   public void foid5() {
     String s = "";
     s.toString().toString().toString();
     // comment
   }
 
-  /** some javadoc. */
+  /** Some javadoc. */
   public void foo6() {
     // comment
     // ...
@@ -105,7 +105,7 @@ public class InputCommentsIndentationSurroundingCode {
     String someStr = new String();
   }
 
-  /** some javadoc. */
+  /** Some javadoc. */
   public void foo7() {
     // comment
     // ...
@@ -116,7 +116,7 @@ public class InputCommentsIndentationSurroundingCode {
     String someStr = new String();
   }
 
-  /** some javadoc. */
+  /** Some javadoc. */
   public void foo8() {
     String s = new String(); // comment
     // ...
@@ -127,12 +127,12 @@ public class InputCommentsIndentationSurroundingCode {
     String someStr = new String();
   }
 
-  /** some javadoc. */
+  /** Some javadoc. */
   public String foo9(String s1, String s2, String s3) {
     return "";
   }
 
-  /** some javadoc. */
+  /** Some javadoc. */
   public void foo10() throws Exception {
 
     final String pattern = "^foo$";

--- a/src/it/resources/com/google/checkstyle/test/chapter4formatting/rule4861blockcommentstyle/InputFormattedCommentsIndentationCommentIsAtTheEndOfBlock.java
+++ b/src/it/resources/com/google/checkstyle/test/chapter4formatting/rule4861blockcommentstyle/InputFormattedCommentsIndentationCommentIsAtTheEndOfBlock.java
@@ -3,37 +3,37 @@ package com.google.checkstyle.test.chapter4formatting.rule4861blockcommentstyle;
 /** Contains examples of using comments at the end of the block. */
 public class InputFormattedCommentsIndentationCommentIsAtTheEndOfBlock {
 
-  /** some javadoc. */
+  /** Some javadoc. */
   public void foo1() {
     foo2();
     // OOOO: missing functionality
   }
 
-  /** some javadoc. */
+  /** Some javadoc. */
   public void foo2() {
 
     foo3();
     // odd indentation comment
   }
 
-  /** some javadoc. */
+  /** Some javadoc. */
   public void foo3() {
     foo2();
     // refreshDisplay();
   }
 
-  /** some javadoc. */
+  /** Some javadoc. */
   public void foo4() {
     foooooooooooooooooooooooooooooooooooooooooo();
     // ^-- some hint
   }
 
-  /** some javadoc. */
+  /** Some javadoc. */
   public void foooooooooooooooooooooooooooooooooooooooooo() {}
 
   /////////////////////////////// odd indentation comment
 
-  /** some javadoc. */
+  /** Some javadoc. */
   public void foo7() {
 
     int a = 0;
@@ -42,12 +42,12 @@ public class InputFormattedCommentsIndentationCommentIsAtTheEndOfBlock {
 
   /////////////////////////////// (a single-line border to separate a group of methods)
 
-  /** some javadoc. */
+  /** Some javadoc. */
   public void foo8() {}
 
-  /** some javadoc. */
+  /** Some javadoc. */
   public class TestClass {
-    /** some javadoc. */
+    /** Some javadoc. */
     public void test() {
 
       int a = 0;
@@ -56,7 +56,7 @@ public class InputFormattedCommentsIndentationCommentIsAtTheEndOfBlock {
     // odd indentation comment
   }
 
-  /** some javadoc. */
+  /** Some javadoc. */
   public void foo9() {
 
     this.foo1();
@@ -67,46 +67,46 @@ public class InputFormattedCommentsIndentationCommentIsAtTheEndOfBlock {
   //
   //    }
 
-  /** some javadoc. */
+  /** Some javadoc. */
   public void foo11() {
     String.valueOf(new Integer(0)).trim().length();
     // comment
   }
 
-  /** some javadoc. */
+  /** Some javadoc. */
   public void foo12() {
 
     String.valueOf(new Integer(0)).trim().length();
     // odd indentation comment
   }
 
-  /** some javadoc. */
+  /** Some javadoc. */
   public void foo13() {
     String.valueOf(new Integer(0)).trim().length();
     // comment
   }
 
-  /** some javadoc. */
+  /** Some javadoc. */
   public void foo14() {
 
     String.valueOf(new Integer(0)).trim().length();
     // odd indentation comment
   }
 
-  /** some javadoc. */
+  /** Some javadoc. */
   public void foo15() {
     String.valueOf(new Integer(0));
     // comment
   }
 
-  /** some javadoc. */
+  /** Some javadoc. */
   public void foo16() {
 
     String.valueOf(new Integer(0));
     // odd indentation comment
   }
 
-  /** some javadoc. */
+  /** Some javadoc. */
   public void foo17() {
     String.valueOf(new Integer(0))
         .trim()
@@ -114,7 +114,7 @@ public class InputFormattedCommentsIndentationCommentIsAtTheEndOfBlock {
         .length();
   }
 
-  /** some javadoc. */
+  /** Some javadoc. */
   public void foo18() {
 
     String.valueOf(new Integer(0))
@@ -123,7 +123,7 @@ public class InputFormattedCommentsIndentationCommentIsAtTheEndOfBlock {
         .length();
   }
 
-  /** some javadoc. */
+  /** Some javadoc. */
   public void foo19() {
     (new Thread(
             new Runnable() {
@@ -134,7 +134,7 @@ public class InputFormattedCommentsIndentationCommentIsAtTheEndOfBlock {
     // comment
   }
 
-  /** some javadoc. */
+  /** Some javadoc. */
   public void foo20() {
 
     (new Thread(
@@ -146,7 +146,7 @@ public class InputFormattedCommentsIndentationCommentIsAtTheEndOfBlock {
     // odd indentation comment
   }
 
-  /** some javadoc. */
+  /** Some javadoc. */
   public void foo21() {
     int[] array = new int[5];
 
@@ -163,7 +163,7 @@ public class InputFormattedCommentsIndentationCommentIsAtTheEndOfBlock {
     // the above example was taken from hibernate-orm and was modified a bit
   }
 
-  /** some javadoc. */
+  /** Some javadoc. */
   public void foo22() {
     int[] array = new int[5];
 
@@ -181,33 +181,33 @@ public class InputFormattedCommentsIndentationCommentIsAtTheEndOfBlock {
     // odd indentation comment
   }
 
-  /** some javadoc. */
+  /** Some javadoc. */
   public void foo23() {
     new Object();
     // comment
   }
 
-  /** some javadoc. */
+  /** Some javadoc. */
   public void foo24() {
 
     new Object();
     // odd indentation comment
   }
 
-  /** some javadoc. */
+  /** Some javadoc. */
   public String foo25() {
     return String.format(java.util.Locale.ENGLISH, "%d", 1);
     // comment
   }
 
-  /** some javadoc. */
+  /** Some javadoc. */
   public String foo26() {
 
     return String.format(java.util.Locale.ENGLISH, "%d", 1);
     // odd indentation comment
   }
 
-  /** some javadoc. */
+  /** Some javadoc. */
   public void foo27() {
     // comment
     // block
@@ -216,14 +216,14 @@ public class InputFormattedCommentsIndentationCommentIsAtTheEndOfBlock {
     // OOOO
   }
 
-  /** some javadoc. */
+  /** Some javadoc. */
   public String foo28() {
     int a = 5;
     return String.format(java.util.Locale.ENGLISH, "%d", 1);
     // comment
   }
 
-  /** some javadoc. */
+  /** Some javadoc. */
   public String foo29() {
     int a = 5;
 
@@ -231,7 +231,7 @@ public class InputFormattedCommentsIndentationCommentIsAtTheEndOfBlock {
     // odd indentation comment
   }
 
-  /** some javadoc. */
+  /** Some javadoc. */
   public void foo30() {
     // comment
 
@@ -239,20 +239,20 @@ public class InputFormattedCommentsIndentationCommentIsAtTheEndOfBlock {
     // odd indentation comment
   }
 
-  /** some javadoc. */
+  /** Some javadoc. */
   public void foo31() {
     String s = new String("A" + "B" + "C");
     // comment
   }
 
-  /** some javadoc. */
+  /** Some javadoc. */
   public void foo32() {
 
     String s = new String("A" + "B" + "C");
     // odd indentation comment
   }
 
-  /** some javadoc. */
+  /** Some javadoc. */
   public void foo33() {
     // comment
 
@@ -260,47 +260,47 @@ public class InputFormattedCommentsIndentationCommentIsAtTheEndOfBlock {
     // odd indentation comment
   }
 
-  /** some javadoc. */
+  /** Some javadoc. */
   public void foo34() throws Exception {
     throw new Exception("", new Exception());
     // comment
   }
 
-  /** some javadoc. */
+  /** Some javadoc. */
   public void foo35() throws Exception {
 
     throw new Exception("", new Exception());
     // odd indentation comment
   }
 
-  /** some javadoc. */
+  /** Some javadoc. */
   public void foo36() throws Exception {
 
     throw new Exception("", new Exception());
     // odd indentation comment
   }
 
-  /** some javadoc. */
+  /** Some javadoc. */
   public void foo37() throws Exception {
     throw new Exception("", new Exception());
     // comment
   }
 
-  /** some javadoc. */
+  /** Some javadoc. */
   public void foo38() throws Exception {
 
     throw new Exception("", new Exception());
     // odd indentation comment
   }
 
-  /** some javadoc. */
+  /** Some javadoc. */
   public void foo39() throws Exception {
 
     throw new Exception("", new Exception());
     // odd indentation comment
   }
 
-  /** some javadoc. */
+  /** Some javadoc. */
   public void foo40() throws Exception {
     int a = 88;
 
@@ -308,14 +308,14 @@ public class InputFormattedCommentsIndentationCommentIsAtTheEndOfBlock {
     // odd indentation comment
   }
 
-  /** some javadoc. */
+  /** Some javadoc. */
   public void foo41() throws Exception {
     int a = 88;
     throw new Exception("", new Exception());
     // comment
   }
 
-  /** some javadoc. */
+  /** Some javadoc. */
   public void foo42() {
     int a = 5;
     if (a == 5) {
@@ -326,7 +326,7 @@ public class InputFormattedCommentsIndentationCommentIsAtTheEndOfBlock {
     }
   }
 
-  /** some javadoc. */
+  /** Some javadoc. */
   public void foo43() {
     try {
       int a;
@@ -336,7 +336,7 @@ public class InputFormattedCommentsIndentationCommentIsAtTheEndOfBlock {
     }
   }
 
-  /** some javadoc. */
+  /** Some javadoc. */
   public void foo44() {
     int ar = 5;
     // comment
@@ -344,7 +344,7 @@ public class InputFormattedCommentsIndentationCommentIsAtTheEndOfBlock {
     // comment
   }
 
-  /** some javadoc. */
+  /** Some javadoc. */
   public void foo45() {
     int ar = 5;
     // comment
@@ -353,7 +353,7 @@ public class InputFormattedCommentsIndentationCommentIsAtTheEndOfBlock {
     // odd indentation comment
   }
 
-  /** some javadoc. */
+  /** Some javadoc. */
   public void foo46() {
 
     // comment
@@ -361,7 +361,7 @@ public class InputFormattedCommentsIndentationCommentIsAtTheEndOfBlock {
     // odd indentation comment
   }
 
-  /** some javadoc. */
+  /** Some javadoc. */
   public void foo47() {
     int a = 5;
     // comment
@@ -369,7 +369,7 @@ public class InputFormattedCommentsIndentationCommentIsAtTheEndOfBlock {
     // comment
   }
 
-  /** some javadoc. */
+  /** Some javadoc. */
   public void foo48() {
 
     int a = 5;
@@ -378,28 +378,28 @@ public class InputFormattedCommentsIndentationCommentIsAtTheEndOfBlock {
     // odd indentation comment
   }
 
-  /** some javadoc. */
+  /** Some javadoc. */
   public void foo49() {
     // comment
     // block
     // ok
   }
 
-  /** some javadoc. */
+  /** Some javadoc. */
   public void foo50() {
     return;
 
     // No NPE here!
   }
 
-  /** some javadoc. */
+  /** Some javadoc. */
   public String foo51() {
 
     return String.valueOf("11");
     // odd indentation comment
   }
 
-  /** some javadoc. */
+  /** Some javadoc. */
   public String foo52() {
     return String.valueOf("11");
     // comment

--- a/src/it/resources/com/google/checkstyle/test/chapter4formatting/rule4861blockcommentstyle/InputFormattedCommentsIndentationInEmptyBlock.java
+++ b/src/it/resources/com/google/checkstyle/test/chapter4formatting/rule4861blockcommentstyle/InputFormattedCommentsIndentationInEmptyBlock.java
@@ -1,6 +1,6 @@
 package com.google.checkstyle.test.chapter4formatting.rule4861blockcommentstyle;
 
-/** some javadoc. */
+/** Some javadoc. */
 public class InputFormattedCommentsIndentationInEmptyBlock {
 
   private void foo1() {
@@ -59,7 +59,7 @@ public class InputFormattedCommentsIndentationInEmptyBlock {
     }
   }
 
-  /** some javadoc. */
+  /** Some javadoc. */
   public void foo6() {
     try {
       /* foo */
@@ -68,7 +68,7 @@ public class InputFormattedCommentsIndentationInEmptyBlock {
     }
   }
 
-  /** some javadoc. */
+  /** Some javadoc. */
   public void foo7() {
     try {
       /* foo */

--- a/src/it/resources/com/google/checkstyle/test/chapter4formatting/rule4861blockcommentstyle/InputFormattedCommentsIndentationInSwitchBlock.java
+++ b/src/it/resources/com/google/checkstyle/test/chapter4formatting/rule4861blockcommentstyle/InputFormattedCommentsIndentationInSwitchBlock.java
@@ -1,6 +1,6 @@
 package com.google.checkstyle.test.chapter4formatting.rule4861blockcommentstyle;
 
-/** some javadoc. */
+/** Some javadoc. */
 public class InputFormattedCommentsIndentationInSwitchBlock {
 
   private static void fooSwitch() {
@@ -124,7 +124,7 @@ public class InputFormattedCommentsIndentationInSwitchBlock {
     }
   }
 
-  /** some javadoc. */
+  /** Some javadoc. */
   public void fooDotInCaseBlock() {
     int i = 0;
     String s = "";
@@ -166,7 +166,7 @@ public class InputFormattedCommentsIndentationInSwitchBlock {
         ;
   }
 
-  /** some javadoc. */
+  /** Some javadoc. */
   public void foo2() {
     int a = 1;
     switch (a) {
@@ -176,7 +176,7 @@ public class InputFormattedCommentsIndentationInSwitchBlock {
     }
   }
 
-  /** some javadoc. */
+  /** Some javadoc. */
   public void foo3() {
     int a = 1;
     switch (a) {
@@ -187,7 +187,7 @@ public class InputFormattedCommentsIndentationInSwitchBlock {
     }
   }
 
-  /** some javadoc. */
+  /** Some javadoc. */
   public void foo4() {
     int a = 1;
     switch (a) {
@@ -199,7 +199,7 @@ public class InputFormattedCommentsIndentationInSwitchBlock {
     }
   }
 
-  /** some javadoc. */
+  /** Some javadoc. */
   public void foo5() {
     int a = 1;
     switch (a) {
@@ -211,7 +211,7 @@ public class InputFormattedCommentsIndentationInSwitchBlock {
     }
   }
 
-  /** some javadoc. */
+  /** Some javadoc. */
   public void foo6() {
     int a = 1;
     switch (a) {
@@ -223,7 +223,7 @@ public class InputFormattedCommentsIndentationInSwitchBlock {
     }
   }
 
-  /** some javadoc. */
+  /** Some javadoc. */
   public void foo7() {
     int a = 2;
     String s = "";
@@ -255,7 +255,7 @@ public class InputFormattedCommentsIndentationInSwitchBlock {
     }
   }
 
-  /** some javadoc. */
+  /** Some javadoc. */
   public void foo8() {
     int a = 2;
     String s = "";
@@ -283,7 +283,7 @@ public class InputFormattedCommentsIndentationInSwitchBlock {
     }
   }
 
-  /** some javadoc. */
+  /** Some javadoc. */
   public void foo9() {
     int a = 5;
     switch (a) {
@@ -294,7 +294,7 @@ public class InputFormattedCommentsIndentationInSwitchBlock {
     }
   }
 
-  /** some javadoc. */
+  /** Some javadoc. */
   public void foo10() {
     int a = 5;
     switch (a) {
@@ -304,7 +304,7 @@ public class InputFormattedCommentsIndentationInSwitchBlock {
     }
   }
 
-  /** some javadoc. */
+  /** Some javadoc. */
   public void foo11() {
     int a = 5;
     switch (a) {
@@ -315,7 +315,7 @@ public class InputFormattedCommentsIndentationInSwitchBlock {
     }
   }
 
-  /** some javadoc. */
+  /** Some javadoc. */
   public void foo12() {
     int a = 5;
     switch (a) {

--- a/src/it/resources/com/google/checkstyle/test/chapter4formatting/rule4861blockcommentstyle/InputFormattedCommentsIndentationSurroundingCode.java
+++ b/src/it/resources/com/google/checkstyle/test/chapter4formatting/rule4861blockcommentstyle/InputFormattedCommentsIndentationSurroundingCode.java
@@ -6,7 +6,7 @@ import java.util.Arrays;
 
 // some
 
-/** some javadoc. */
+/** Some javadoc. */
 public class InputFormattedCommentsIndentationSurroundingCode {
   private void foo1() {
     if (true) {
@@ -88,17 +88,17 @@ public class InputFormattedCommentsIndentationSurroundingCode {
     }
   }
 
-  /** some javadoc. */
+  /** Some javadoc. */
   private static void testing() {}
 
-  /** some javadoc. */
+  /** Some javadoc. */
   public void foid5() {
     String s = "";
     s.toString().toString().toString();
     // comment
   }
 
-  /** some javadoc. */
+  /** Some javadoc. */
   public void foo6() {
     // comment
     // ...
@@ -109,7 +109,7 @@ public class InputFormattedCommentsIndentationSurroundingCode {
     String someStr = new String();
   }
 
-  /** some javadoc. */
+  /** Some javadoc. */
   public void foo7() {
     // comment
     // ...
@@ -120,7 +120,7 @@ public class InputFormattedCommentsIndentationSurroundingCode {
     String someStr = new String();
   }
 
-  /** some javadoc. */
+  /** Some javadoc. */
   public void foo8() {
     String s = new String(); // comment
     // ...
@@ -131,12 +131,12 @@ public class InputFormattedCommentsIndentationSurroundingCode {
     String someStr = new String();
   }
 
-  /** some javadoc. */
+  /** Some javadoc. */
   public String foo9(String s1, String s2, String s3) {
     return "";
   }
 
-  /** some javadoc. */
+  /** Some javadoc. */
   public void foo10() throws Exception {
 
     final String pattern = "^foo$";

--- a/src/it/resources/com/google/checkstyle/test/chapter4formatting/rule4862todocomments/InputTodoCommentAllVariants.java
+++ b/src/it/resources/com/google/checkstyle/test/chapter4formatting/rule4862todocomments/InputTodoCommentAllVariants.java
@@ -1,6 +1,6 @@
 package com.google.checkstyle.test.chapter4formatting.rule4862todocomments;
 
-/** some javadoc. */
+/** Some javadoc. */
 public class InputTodoCommentAllVariants {
 
   void myFunc1(int i) {

--- a/src/it/resources/com/google/checkstyle/test/chapter4formatting/rule487modifiers/InputFormattedModifierOrder.java
+++ b/src/it/resources/com/google/checkstyle/test/chapter4formatting/rule487modifiers/InputFormattedModifierOrder.java
@@ -72,7 +72,7 @@ abstract strictfp class InputFormattedModifierOrder {
 
   // violation 2 lines above '.* annotation modifier does not precede non-annotation modifiers.'
 
-  /** holder for redundant 'public' modifier check. */
+  /** Holder for redundant 'public' modifier check. */
   public static interface InputRedundantPublicModifier {
     public void abc1();
 
@@ -84,7 +84,7 @@ abstract strictfp class InputFormattedModifierOrder {
 
     final float PI_FINAL = (float) 3.14;
 
-    /** all OK. */
+    /** All OK. */
     float PI_OK = (float) 3.14;
   }
 
@@ -133,7 +133,7 @@ final class RedundantFinalClass2 {
 interface InnerImplementation2 {
   InnerImplementation2 inner =
       new InnerImplementation2() {
-        /** compiler requires 'public' modifier. */
+        /** Compiler requires 'public' modifier. */
         public void method() {}
       };
 

--- a/src/it/resources/com/google/checkstyle/test/chapter4formatting/rule487modifiers/InputFormattedModifierOrderNonSealed.java
+++ b/src/it/resources/com/google/checkstyle/test/chapter4formatting/rule487modifiers/InputFormattedModifierOrderNonSealed.java
@@ -1,6 +1,6 @@
 package com.google.checkstyle.test.chapter4formatting.rule487modifiers;
 
-/** some javadoc. */
+/** Some javadoc. */
 public sealed class InputFormattedModifierOrderNonSealed
     permits InputFormattedModifierOrderNonSealed.CircleOne,
         InputFormattedModifierOrderNonSealed.RectangleOne,

--- a/src/it/resources/com/google/checkstyle/test/chapter4formatting/rule487modifiers/InputFormattedModifierOrderSealed.java
+++ b/src/it/resources/com/google/checkstyle/test/chapter4formatting/rule487modifiers/InputFormattedModifierOrderSealed.java
@@ -1,6 +1,6 @@
 package com.google.checkstyle.test.chapter4formatting.rule487modifiers;
 
-/** some javadoc. */
+/** Some javadoc. */
 public sealed class InputFormattedModifierOrderSealed
     permits InputFormattedModifierOrderSealed.Four1,
         InputFormattedModifierOrderSealed.Three1,
@@ -16,7 +16,7 @@ public sealed class InputFormattedModifierOrderSealed
     private final class OtherSquare4 extends OtherSquare3 {}
   }
 
-  /** some javadoc. */
+  /** Some javadoc. */
   public final class FilledFour1 extends Four1 {}
 
   abstract sealed interface Five1 permits Two1, Three1 {}

--- a/src/it/resources/com/google/checkstyle/test/chapter4formatting/rule487modifiers/InputModifierOrder.java
+++ b/src/it/resources/com/google/checkstyle/test/chapter4formatting/rule487modifiers/InputModifierOrder.java
@@ -64,7 +64,7 @@ strictfp abstract class InputModifierOrder {
   // violation below ''@MyAnnotation2' .* does not precede non-annotation modifiers.'
   abstract @MyAnnotation2 public void fooMet1();
 
-  /** holder for redundant 'public' modifier check. */
+  /** Holder for redundant 'public' modifier check. */
   public static interface InputRedundantPublicModifier {
     public void abc1();
 
@@ -76,7 +76,7 @@ strictfp abstract class InputModifierOrder {
 
     final float PI_FINAL = (float) 3.14;
 
-    /** all OK. */
+    /** All OK. */
     float PI_OK = (float) 3.14;
   }
 
@@ -119,7 +119,7 @@ final class RedundantFinalClass {
 interface InnerImplementation {
   InnerImplementation inner =
           new InnerImplementation() {
-            /** compiler requires 'public' modifier. */
+            /** Compiler requires 'public' modifier. */
             public void method() {}
           };
 

--- a/src/it/resources/com/google/checkstyle/test/chapter4formatting/rule487modifiers/InputModifierOrderNonSealed.java
+++ b/src/it/resources/com/google/checkstyle/test/chapter4formatting/rule487modifiers/InputModifierOrderNonSealed.java
@@ -1,7 +1,7 @@
 package com.google.checkstyle.test.chapter4formatting.rule487modifiers;
 
 // violation 2 lines below ''public' modifier out of order with the JLS suggestions.'
-/** some javadoc. */
+/** Some javadoc. */
 sealed public class InputModifierOrderNonSealed
     permits InputModifierOrderNonSealed.CircleOne1, InputModifierOrderNonSealed.RectangleOne1,
         InputModifierOrderNonSealed.SquareOne1 {

--- a/src/it/resources/com/google/checkstyle/test/chapter4formatting/rule487modifiers/InputModifierOrderSealed.java
+++ b/src/it/resources/com/google/checkstyle/test/chapter4formatting/rule487modifiers/InputModifierOrderSealed.java
@@ -1,13 +1,13 @@
 package com.google.checkstyle.test.chapter4formatting.rule487modifiers;
 
 // violation 2 lines below ''public' modifier out of order with the JLS suggestions'
-/** some javadoc. */
+/** Some javadoc. */
 sealed public class InputModifierOrderSealed permits
         InputModifierOrderSealed.Four,
         InputModifierOrderSealed.Three,
         InputModifierOrderSealed.Two {
 
-  /** some javadoc. */
+  /** Some javadoc. */
   public final class Two extends InputModifierOrderSealed implements Five {}
 
   sealed class Four extends InputModifierOrderSealed {}
@@ -20,7 +20,7 @@ sealed public class InputModifierOrderSealed permits
     private final class OtherSquare2 extends OtherSquare {}
   }
 
-  /** some javadoc. */
+  /** Some javadoc. */
   public final class FilledFour extends Four {}
 
   // violation below ''abstract' modifier out of order with the JLS suggestions'

--- a/src/it/resources/com/google/checkstyle/test/chapter4formatting/rule488numericliterals/InputNumericLiterals.java
+++ b/src/it/resources/com/google/checkstyle/test/chapter4formatting/rule488numericliterals/InputNumericLiterals.java
@@ -1,7 +1,7 @@
 package com.google.checkstyle.test.chapter4formatting.rule488numericliterals;
 
 class InputNumericLiterals {
-  /** test. * */
+  /** Test. * */
   private final long ignore = 666l + 666L; // violation 'Should use uppercase 'L'.'
 
   private String notWarn = "666l"; // ok
@@ -29,7 +29,7 @@ class InputNumericLiterals {
   private void processUpperEll(String s, long l) {}
 
   class Inner {
-    /** test. * */
+    /** Test. * */
     private static final long IGNORE = 666l + 666L; // violation 'Should use uppercase 'L'.'
 
     private static final String notWarn = "666l"; // ok
@@ -60,7 +60,7 @@ class InputNumericLiterals {
     void fooMethod() {
       Foo foo =
           new Foo() {
-            /** test. * */
+            /** Test. * */
             private final long ignore = 666l + 666L; // violation 'Should use uppercase 'L'.'
 
             private String notWarn = "666l"; // ok

--- a/src/it/resources/com/google/checkstyle/test/chapter4formatting/rule489textblocks/InputFormattedTextBlocksGeneralForm.java
+++ b/src/it/resources/com/google/checkstyle/test/chapter4formatting/rule489textblocks/InputFormattedTextBlocksGeneralForm.java
@@ -1,9 +1,9 @@
 package com.google.checkstyle.test.chapter4formatting.rule489textblocks;
 
-/** somejavadoc. */
+/** Somejavadoc. */
 public class InputFormattedTextBlocksGeneralForm {
 
-  /** some javadoc. */
+  /** Some javadoc. */
   public static String textFun() {
 
     final String simpleScript =
@@ -29,7 +29,7 @@ public class InputFormattedTextBlocksGeneralForm {
     // violation above 'incorrect indentation level 4, expected level should be 8.'
   }
 
-  /** somejavadoc. */
+  /** Somejavadoc. */
   public String textFun2() {
 
     final String simpleScript2 =
@@ -50,7 +50,7 @@ public class InputFormattedTextBlocksGeneralForm {
     // violation above 'incorrect indentation level 4, expected level should be 8.'
   }
 
-  /** somejavadoc. */
+  /** Somejavadoc. */
   public String textFun3() {
 
     String s =
@@ -74,14 +74,14 @@ public class InputFormattedTextBlocksGeneralForm {
         + getName();
   }
 
-  /** somejavadoc. */
+  /** Somejavadoc. */
   public String getName() {
     return "name";
   }
 
-  /** somejavadoc. */
+  /** Somejavadoc. */
   public static void getData(String data) {}
 
-  /** somejavadoc. */
+  /** Somejavadoc. */
   public static void getData(String data, int length) {}
 }

--- a/src/it/resources/com/google/checkstyle/test/chapter4formatting/rule489textblocks/InputFormattedTextBlocksIndentation.java
+++ b/src/it/resources/com/google/checkstyle/test/chapter4formatting/rule489textblocks/InputFormattedTextBlocksIndentation.java
@@ -1,9 +1,9 @@
 package com.google.checkstyle.test.chapter4formatting.rule489textblocks;
 
-/** somejavadoc. */
+/** Somejavadoc. */
 public class InputFormattedTextBlocksIndentation {
 
-  /** somejavadoc. */
+  /** Somejavadoc. */
   public void textIndentation1() {
     String e1 =
         """
@@ -33,7 +33,7 @@ public class InputFormattedTextBlocksIndentation {
         5);
   }
 
-  /** somejavadoc. */
+  /** Somejavadoc. */
   public void textFuncIndenation2() {
     // violation 2 lines below '.* incorrect indentation level 0, expected .* 8.'
     String e2 =
@@ -49,6 +49,6 @@ content of the block e2
         5);
   }
 
-  /** somejavadoc. */
+  /** Somejavadoc. */
   public static void getData(String data, int length) {}
 }

--- a/src/it/resources/com/google/checkstyle/test/chapter4formatting/rule489textblocks/InputTextBlocksGeneralForm.java
+++ b/src/it/resources/com/google/checkstyle/test/chapter4formatting/rule489textblocks/InputTextBlocksGeneralForm.java
@@ -1,9 +1,9 @@
 package com.google.checkstyle.test.chapter4formatting.rule489textblocks;
 
-/** somejavadoc. */
+/** Somejavadoc. */
 public class InputTextBlocksGeneralForm {
 
-  /** some javadoc. */
+  /** Some javadoc. */
   public static String textFun() {
 
     // violation below 'Opening quotes (""") of text-block must be on the new line'
@@ -28,7 +28,7 @@ public class InputTextBlocksGeneralForm {
         """; // violation 'Text-block quotes are not vertically aligned'
   }
 
-  /** somejavadoc. */
+  /** Somejavadoc. */
   public String textFun2() {
 
     final String simpleScript2 =
@@ -54,7 +54,7 @@ public class InputTextBlocksGeneralForm {
     // 'Text-block quotes are not vertically aligned'
   }
 
-  /** somejavadoc. */
+  /** Somejavadoc. */
   public String textFun3() {
 
     String s =
@@ -74,15 +74,15 @@ public class InputTextBlocksGeneralForm {
         """.charAt(0) + getName();
   }
 
-  /** somejavadoc. */
+  /** Somejavadoc. */
   public String getName() {
     return "name";
   }
 
-  /** somejavadoc. */
+  /** Somejavadoc. */
   public static void getData(String data) {}
 
-  /** somejavadoc. */
+  /** Somejavadoc. */
   public static void getData(String data, int length) {}
 
 }

--- a/src/it/resources/com/google/checkstyle/test/chapter4formatting/rule489textblocks/InputTextBlocksIndentation.java
+++ b/src/it/resources/com/google/checkstyle/test/chapter4formatting/rule489textblocks/InputTextBlocksIndentation.java
@@ -1,9 +1,9 @@
 package com.google.checkstyle.test.chapter4formatting.rule489textblocks;
 
-/** somejavadoc. */
+/** Somejavadoc. */
 public class InputTextBlocksIndentation {
 
-  /** somejavadoc. */
+  /** Somejavadoc. */
   public void textIndentation1() {
     String e1 =
         """
@@ -34,7 +34,7 @@ public class InputTextBlocksIndentation {
     );
   }
 
-  /** somejavadoc. */
+  /** Somejavadoc. */
   public void textFuncIndenation2() {
     // violation 2 lines below '.* incorrect indentation level 0, expected .* 8.'
     String e2 = // false-positive, ok until #18228
@@ -52,6 +52,6 @@ content of the block e2
     );
   }
 
-  /** somejavadoc. */
+  /** Somejavadoc. */
   public static void getData(String data, int length) {}
 }

--- a/src/it/resources/com/google/checkstyle/test/chapter5naming/rule51identifiernames/InputCatchParameterName.java
+++ b/src/it/resources/com/google/checkstyle/test/chapter5naming/rule51identifiernames/InputCatchParameterName.java
@@ -1,6 +1,6 @@
 package com.google.checkstyle.test.chapter5naming.rule51identifiernames;
 
-/** some javadoc. */
+/** Some javadoc. */
 public class InputCatchParameterName {
   {
     try {

--- a/src/it/resources/com/google/checkstyle/test/chapter5naming/rule523methodnames/InputMethodName2.java
+++ b/src/it/resources/com/google/checkstyle/test/chapter5naming/rule523methodnames/InputMethodName2.java
@@ -2,7 +2,7 @@ package com.google.checkstyle.test.chapter5naming.rule523methodnames;
 
 import org.junit.jupiter.api.Test;
 
-/** some data. */
+/** Some data. */
 public class InputMethodName2 {
 
   @Test

--- a/src/it/resources/com/google/checkstyle/test/chapter5naming/rule525nonconstantfieldnames/InputNonConstantNamesBasic.java
+++ b/src/it/resources/com/google/checkstyle/test/chapter5naming/rule525nonconstantfieldnames/InputNonConstantNamesBasic.java
@@ -1,6 +1,6 @@
 package com.google.checkstyle.test.chapter5naming.rule525nonconstantfieldnames;
 
-/** some javadoc. */
+/** Some javadoc. */
 public class InputNonConstantNamesBasic {
   public int mPublic; // violation 'Member name 'mPublic' must match pattern'
   protected int mProtected; // violation 'Member name 'mProtected' must match pattern'

--- a/src/it/resources/com/google/checkstyle/test/chapter5naming/rule526parameternames/InputCatchParameterName.java
+++ b/src/it/resources/com/google/checkstyle/test/chapter5naming/rule526parameternames/InputCatchParameterName.java
@@ -1,6 +1,6 @@
 package com.google.checkstyle.test.chapter5naming.rule526parameternames;
 
-/** some javadoc. */
+/** Some javadoc. */
 public class InputCatchParameterName {
   {
     try {

--- a/src/it/resources/com/google/checkstyle/test/chapter5naming/rule526parameternames/InputFormattedRecordComponentNameTwo.java
+++ b/src/it/resources/com/google/checkstyle/test/chapter5naming/rule526parameternames/InputFormattedRecordComponentNameTwo.java
@@ -2,7 +2,7 @@
 
 package com.google.checkstyle.test.chapter5naming.rule526parameternames;
 
-/** some javadoc. Config: format = "^[a-z]([a-z0-9][a-zA-Z0-9]*)?$" */
+/** Some javadoc. Config: format = "^[a-z]([a-z0-9][a-zA-Z0-9]*)?$" */
 public record InputFormattedRecordComponentNameTwo<E>(int _componentName, String componentName2) {}
 
 // violation 2 lines above 'Record component name '_componentName' must match pattern'

--- a/src/it/resources/com/google/checkstyle/test/chapter5naming/rule526parameternames/InputLambdaParameterName.java
+++ b/src/it/resources/com/google/checkstyle/test/chapter5naming/rule526parameternames/InputLambdaParameterName.java
@@ -3,7 +3,7 @@ package com.google.checkstyle.test.chapter5naming.rule526parameternames;
 import java.util.function.BiFunction;
 import java.util.function.Function;
 
-/** some javadoc. */
+/** Some javadoc. */
 public class InputLambdaParameterName {
 
   Function<String, String> badNamedParameterWithoutParenthesis =

--- a/src/it/resources/com/google/checkstyle/test/chapter5naming/rule526parameternames/InputRecordComponentNameTwo.java
+++ b/src/it/resources/com/google/checkstyle/test/chapter5naming/rule526parameternames/InputRecordComponentNameTwo.java
@@ -3,7 +3,7 @@
 package com.google.checkstyle.test.chapter5naming.rule526parameternames;
 
 /**
- * some javadoc.
+ * Some javadoc.
  * Config:
  * format = "^[a-z]([a-z0-9][a-zA-Z0-9]*)?$"
  *

--- a/src/it/resources/com/google/checkstyle/test/chapter5naming/rule527localvariablenames/InputFormattedPatternVariableNameEnhancedInstanceofTestDefault.java
+++ b/src/it/resources/com/google/checkstyle/test/chapter5naming/rule527localvariablenames/InputFormattedPatternVariableNameEnhancedInstanceofTestDefault.java
@@ -6,7 +6,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Locale;
 
-/** some javadoc. */
+/** Some javadoc. */
 public class InputFormattedPatternVariableNameEnhancedInstanceofTestDefault {
   private Object obj;
 
@@ -37,7 +37,7 @@ public class InputFormattedPatternVariableNameEnhancedInstanceofTestDefault {
     public boolean get();
   }
 
-  /** some javadoc. */
+  /** Some javadoc. */
   public void testing(Object o1, Object o2) {
     Object b;
     Object c;

--- a/src/it/resources/com/google/checkstyle/test/chapter5naming/rule527localvariablenames/InputLocalVariableNameOneCharVarName.java
+++ b/src/it/resources/com/google/checkstyle/test/chapter5naming/rule527localvariablenames/InputLocalVariableNameOneCharVarName.java
@@ -4,7 +4,7 @@ import java.util.HashMap;
 import java.util.Map;
 
 class InputLocalVariableNameOneCharVarName {
-  /** some javadoc. */
+  /** Some javadoc. */
   public void fooMethod() {
     for (int i = 1; i < 10; i++) {
       // some code

--- a/src/it/resources/com/google/checkstyle/test/chapter5naming/rule527localvariablenames/InputLocalVariableNameSimple.java
+++ b/src/it/resources/com/google/checkstyle/test/chapter5naming/rule527localvariablenames/InputLocalVariableNameSimple.java
@@ -17,7 +17,7 @@ final class InputLocalVariableNameSimple {
 
   private int[] ints = new int[] {1, 2, 3, 4};
 
-  /** test local variables. */
+  /** Test local variables. */
   private void localVariables() {
     // bad examples
     int a;

--- a/src/it/resources/com/google/checkstyle/test/chapter5naming/rule527localvariablenames/InputPatternVariableNameEnhancedInstanceofTestDefault.java
+++ b/src/it/resources/com/google/checkstyle/test/chapter5naming/rule527localvariablenames/InputPatternVariableNameEnhancedInstanceofTestDefault.java
@@ -6,7 +6,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Locale;
 
-/** some javadoc. */
+/** Some javadoc. */
 public class InputPatternVariableNameEnhancedInstanceofTestDefault {
   private Object obj;
 
@@ -37,7 +37,7 @@ public class InputPatternVariableNameEnhancedInstanceofTestDefault {
     public boolean get();
   }
 
-  /** some javadoc. */
+  /** Some javadoc. */
   public void testing(Object o1, Object o2) {
     Object b;
     Object c;

--- a/src/it/resources/com/google/checkstyle/test/chapter5naming/rule528typevariablenames/InputInterfaceTypeParameterName.java
+++ b/src/it/resources/com/google/checkstyle/test/chapter5naming/rule528typevariablenames/InputInterfaceTypeParameterName.java
@@ -2,9 +2,9 @@ package com.google.checkstyle.test.chapter5naming.rule528typevariablenames;
 
 import java.io.Serializable;
 
-/** some javadoc. */
+/** Some javadoc. */
 public class InputInterfaceTypeParameterName<T> {
-  /** some javadoc. */
+  /** Some javadoc. */
   public <TT> void foo() {}
 
   <T> void foo(int i) {}

--- a/src/it/resources/com/google/checkstyle/test/chapter5naming/rule528typevariablenames/InputRecordTypeParameterNameOne.java
+++ b/src/it/resources/com/google/checkstyle/test/chapter5naming/rule528typevariablenames/InputRecordTypeParameterNameOne.java
@@ -5,10 +5,10 @@ package com.google.checkstyle.test.chapter5naming.rule528typevariablenames;
 import java.io.Serializable;
 import java.util.LinkedHashMap;
 
-/** some javadoc. Config: pattern = "(^[A-Z][0-9]?)$|([A-Z][a-zA-Z0-9]*[T]$)" */
+/** Some javadoc. Config: pattern = "(^[A-Z][0-9]?)$|([A-Z][a-zA-Z0-9]*[T]$)" */
 public record InputRecordTypeParameterNameOne<t>(Integer x, String str) {
   // violation above 'Record type name 't' must match pattern'
-  /** some javadoc. */
+  /** Some javadoc. */
   public <TT> void foo() {}
 
   <T> void foo(int i) {}

--- a/src/it/resources/com/google/checkstyle/test/chapter5naming/rule53camelcase/InputUnderscoreUsedInNames.java
+++ b/src/it/resources/com/google/checkstyle/test/chapter5naming/rule53camelcase/InputUnderscoreUsedInNames.java
@@ -2,7 +2,7 @@ package com.google.checkstyle.test.chapter5naming.rule53camelcase;
 
 import org.junit.jupiter.api.Test;
 
-/** some javadoc. */
+/** Some javadoc. */
 public class InputUnderscoreUsedInNames {
 
   private String guava33_4_6;

--- a/src/it/resources/com/google/checkstyle/test/chapter6programpractice/rule61overridealwaysused/InputOverrideAlwaysUsedForRecord.java
+++ b/src/it/resources/com/google/checkstyle/test/chapter6programpractice/rule61overridealwaysused/InputOverrideAlwaysUsedForRecord.java
@@ -2,10 +2,10 @@ package com.google.checkstyle.test.chapter6programpractice.rule61overridealwaysu
 
 import java.util.Locale;
 
-/** some javadoc. */
+/** Some javadoc. */
 public record InputOverrideAlwaysUsedForRecord(String name, int age) {
 
-  /** some javadoc. */
+  /** Some javadoc. */
   public String name() { // false-negative, ok until #17561
     return name.toUpperCase(Locale.ROOT);
   }

--- a/src/it/resources/com/google/checkstyle/test/chapter6programpractice/rule64finalizers/InputNoFinalizer.java
+++ b/src/it/resources/com/google/checkstyle/test/chapter6programpractice/rule64finalizers/InputNoFinalizer.java
@@ -20,6 +20,6 @@ public class InputNoFinalizer {
     runnable.run();
   }
 
-  /** should not be reported by NoFinalizer check. */
+  /** Should not be reported by NoFinalizer check. */
   public void finalize(String x) {}
 }

--- a/src/it/resources/com/google/checkstyle/test/chapter7javadoc/rule711generalform/InputCorrectJavadocLeadingAsteriskAlignment.java
+++ b/src/it/resources/com/google/checkstyle/test/chapter7javadoc/rule711generalform/InputCorrectJavadocLeadingAsteriskAlignment.java
@@ -8,7 +8,7 @@ package com.google.checkstyle.test.chapter7javadoc.rule711generalform;
  */
 public class InputCorrectJavadocLeadingAsteriskAlignment {
 
-  /** javadoc for instance variable. */
+  /** Javadoc for instance variable. */
   private int int1;
 
   /** */ // violation "Summary javadoc is missing."

--- a/src/it/resources/com/google/checkstyle/test/chapter7javadoc/rule711generalform/InputFormattedCorrectJavadocLeadingAsteriskAlignment.java
+++ b/src/it/resources/com/google/checkstyle/test/chapter7javadoc/rule711generalform/InputFormattedCorrectJavadocLeadingAsteriskAlignment.java
@@ -7,7 +7,7 @@ package com.google.checkstyle.test.chapter7javadoc.rule711generalform;
  */
 public class InputFormattedCorrectJavadocLeadingAsteriskAlignment {
 
-  /** javadoc for instance variable. */
+  /** Javadoc for instance variable. */
   private int int1;
 
   /** */
@@ -51,7 +51,7 @@ public class InputFormattedCorrectJavadocLeadingAsteriskAlignment {
 
   /**
    * Opening tag should be alone on line. // False negative until #17778, Subproblem 1. This method
-   * does nothing.
+   * Does nothing.
    */
   private void foo2() {}
 

--- a/src/it/resources/com/google/checkstyle/test/chapter7javadoc/rule711generalform/InputFormattedJavadocPositionOnCanonicalConstructorsWithAnnotation.java
+++ b/src/it/resources/com/google/checkstyle/test/chapter7javadoc/rule711generalform/InputFormattedJavadocPositionOnCanonicalConstructorsWithAnnotation.java
@@ -1,6 +1,6 @@
 package com.google.checkstyle.test.chapter7javadoc.rule711generalform;
 
-/** some javadoc. */
+/** Some javadoc. */
 public class InputFormattedJavadocPositionOnCanonicalConstructorsWithAnnotation {
   @interface SizeType {
     int max();

--- a/src/it/resources/com/google/checkstyle/test/chapter7javadoc/rule711generalform/InputFormattedJavadocPositionOnConstructorInRecord.java
+++ b/src/it/resources/com/google/checkstyle/test/chapter7javadoc/rule711generalform/InputFormattedJavadocPositionOnConstructorInRecord.java
@@ -29,9 +29,9 @@ public class InputFormattedJavadocPositionOnConstructorInRecord {
   public record MyRecord(String text) {
 
     // violation 3 lines below 'Javadoc comment is placed in the wrong location.'
-    /** invalid comment. */
+    /** Invalid comment. */
     public MyRecord {}
-    /** invalid comment. */
+    /** Invalid comment. */
   }
 
   /**
@@ -43,7 +43,7 @@ public class InputFormattedJavadocPositionOnConstructorInRecord {
   record Mapping(String from, String to) {
 
     // violation below 'Javadoc comment is placed in the wrong location.'
-    /** some javadoc. */
+    /** Some javadoc. */
     /**
      * The constructor for Mapping.
      *

--- a/src/it/resources/com/google/checkstyle/test/chapter7javadoc/rule711generalform/InputFormattedSingleLineJavadocAndInvalidJavadocPosition.java
+++ b/src/it/resources/com/google/checkstyle/test/chapter7javadoc/rule711generalform/InputFormattedSingleLineJavadocAndInvalidJavadocPosition.java
@@ -1,13 +1,13 @@
 package // violation 'package statement should not be line-wrapped.'
     // violation below 'Javadoc comment is placed in the wrong location.'
-    /** invalid javadoc. */
+    /** Invalid javadoc. */
     com.google.checkstyle.test.chapter7javadoc.rule711generalform;
 
 // violation below 'Javadoc comment is placed in the wrong location.'
-/** invalid javadoc. */
+/** Invalid javadoc. */
 import javax.swing.JFrame;
 
-/** some javadoc. */
+/** Some javadoc. */
 public class InputFormattedSingleLineJavadocAndInvalidJavadocPosition {
 
   /** As of JDK 1.1, replaced by {@link #setBounds(int,int,int,int)}. */
@@ -23,7 +23,7 @@ public class InputFormattedSingleLineJavadocAndInvalidJavadocPosition {
   void foo3() {}
 
   /**
-   * summary.
+   * Summary.
    *
    * @throws CheckstyleException if a problem occurs
    */
@@ -51,7 +51,7 @@ public class InputFormattedSingleLineJavadocAndInvalidJavadocPosition {
   void bar() {}
 
   /**
-   * summary.
+   * Summary.
    *
    * <h1>Some header </h1>
    *
@@ -77,7 +77,7 @@ public class InputFormattedSingleLineJavadocAndInvalidJavadocPosition {
   }
 
   /**
-   * summary.
+   * Summary.
    *
    * @return in multi line javadoc
    */
@@ -87,76 +87,76 @@ public class InputFormattedSingleLineJavadocAndInvalidJavadocPosition {
 }
 
 // violation below 'Javadoc comment is placed in the wrong location.'
-/** invalid javadoc. */
-/** valid javadoc. */
+/** Invalid javadoc. */
+/** Valid javadoc. */
 class ExtraInputInvalidJavadocPosition {
   // violation above '.* ExtraInputInvalidJavadocPosition has to reside in its own source file.'
   // violation below 'Javadoc comment is placed in the wrong location.'
-  /** invalid javadoc. */
+  /** Invalid javadoc. */
 }
 
-/** valid javadoc. */
+/** Valid javadoc. */
 /* ignore */
 class ExtraInputInvalidJavadocPosition2 {
   // violation above '.* ExtraInputInvalidJavadocPosition2 has to reside in its own source file.'
   // violation below 'Javadoc comment is placed in the wrong location.'
-  /** invalid javadoc. */
+  /** Invalid javadoc. */
   static {
     /* ignore */
   }
 
   // violation below 'Javadoc comment is placed in the wrong location.'
-  /** invalid javadoc. */
-  /** valid javadoc. */
+  /** Invalid javadoc. */
+  /** Valid javadoc. */
   int field1;
 
-  /** valid javadoc. */
+  /** Valid javadoc. */
   int[] field2;
 
-  /** valid javadoc. */
+  /** Valid javadoc. */
   public int[] field3;
 
-  /** valid javadoc. */
+  /** Valid javadoc. */
   @Deprecated int field4;
 
   // violation 2 lines below 'Javadoc comment is placed in the wrong location.'
   int
-      /** invalid javadoc. */
+      /** Invalid javadoc. */
       field20;
 
   // violation 2 lines below 'Javadoc comment is placed in the wrong location.'
   int field21
-      /** invalid javadoc. */
+      /** Invalid javadoc. */
       ;
 
   // violation 2 lines below 'Javadoc comment is placed in the wrong location.'
   @Deprecated
-  /** invalid javadoc. */
+  /** Invalid javadoc. */
   JFrame frame = new JFrame();
 
   void method1() {}
 
-  /** valid javadoc. */
+  /** Valid javadoc. */
   void method2() {}
 
-  /** valid javadoc. */
+  /** Valid javadoc. */
   <T> T method3() {
     return null;
   }
 
-  /** valid javadoc. */
+  /** Valid javadoc. */
   String[] method4() {
     return null;
   }
 
   // violation 2 lines below 'Javadoc comment is placed in the wrong location.'
   void
-      /** invalid javadoc. */
+      /** Invalid javadoc. */
       method20() {}
 
   // violation 2 lines below 'Javadoc comment is placed in the wrong location.'
   void method21
-      /** invalid javadoc. */
+      /** Invalid javadoc. */
       () {}
 
   // 2 violations 2 lines above:
@@ -165,7 +165,7 @@ class ExtraInputInvalidJavadocPosition2 {
 
   // violation 2 lines below 'Javadoc comment is placed in the wrong location.'
   void method22(
-      /** invalid javadoc. */
+      /** Invalid javadoc. */
       ) {}
 
   // violation 2 lines above ''method def rparen' has incorrect indentation level 6, expected .* 2.'
@@ -174,19 +174,19 @@ class ExtraInputInvalidJavadocPosition2 {
   //  '.* indentation should be the same level as line 178.'
   //  'Javadoc comment is placed in the wrong location.'
   void method23()
-        /** invalid javadoc. */
+        /** Invalid javadoc. */
       {}
 
   // violation 2 lines above ''method def lcurly' has incorrect indentation level 6, expected .* 4.'
 
   // violation 2 lines below 'Javadoc comment is placed in the wrong location.'
   void method24() {
-    /** invalid javadoc. */
+    /** Invalid javadoc. */
   }
 
   // violation 2 lines below 'Javadoc comment is placed in the wrong location.'
   void method25() {
-    /** invalid javadoc. */
+    /** Invalid javadoc. */
     int variable;
   }
 }
@@ -194,18 +194,18 @@ class ExtraInputInvalidJavadocPosition2 {
 // violation 2 lines below '.* has to reside in its own source file.'
 // violation 2 lines below 'Javadoc comment is placed in the wrong location.'
 @Deprecated
-/** invalid javadoc. */
+/** Invalid javadoc. */
 class ExtraInputInvalidJavadocPosition3 {}
 
 // violation 2 lines below '.* has to reside in its own source file.'
-/** valid javadoc. */
+/** Valid javadoc. */
 @Deprecated
 class ExtraInputInvalidJavadocPosition4 {}
 
 // violation 2 lines below '.* has to reside in its own source file.'
 // violation 2 lines below 'Javadoc comment is placed in the wrong location.'
 class
-/** invalid javadoc. */
+/** Invalid javadoc. */
 ExtraInputInvalidJavadocPosition5 {}
 
 // violation 2 lines above '.* has incorrect indentation .* 0, expected .* 4.'
@@ -213,9 +213,9 @@ ExtraInputInvalidJavadocPosition5 {}
 // violation 2 lines below '.* has to reside in its own source file.'
 // violation 2 lines below 'Javadoc comment is placed in the wrong location.'
 class ExtraInputInvalidJavadocPosition6
-/** invalid javadoc. */
+/** Invalid javadoc. */
 {}
-/** invalid javadoc. */
+/** Invalid javadoc. */
 // 2 violations 2 lines above:
 //  ''class def lcurly' has incorrect indentation level 0, expected level should be 2.'
 //  ''}' at column 2 should be alone on a line.'

--- a/src/it/resources/com/google/checkstyle/test/chapter7javadoc/rule711generalform/InputJavadocPositionOnCanonicalConstructorsWithAnnotation.java
+++ b/src/it/resources/com/google/checkstyle/test/chapter7javadoc/rule711generalform/InputJavadocPositionOnCanonicalConstructorsWithAnnotation.java
@@ -1,6 +1,6 @@
 package com.google.checkstyle.test.chapter7javadoc.rule711generalform;
 
-/** some javadoc. */
+/** Some javadoc. */
 public class InputJavadocPositionOnCanonicalConstructorsWithAnnotation {
 
   @interface SizeType {
@@ -54,7 +54,7 @@ public class InputJavadocPositionOnCanonicalConstructorsWithAnnotation {
   record BindCtor(String from, String to) {
 
     // violation below 'Javadoc comment is placed in the wrong location.'
-    /** some javadoc. */
+    /** Some javadoc. */
     /**
      * The constructor for Mapping.
      *

--- a/src/it/resources/com/google/checkstyle/test/chapter7javadoc/rule711generalform/InputJavadocPositionOnCompactConstructorsWithAnnotation.java
+++ b/src/it/resources/com/google/checkstyle/test/chapter7javadoc/rule711generalform/InputJavadocPositionOnCompactConstructorsWithAnnotation.java
@@ -54,7 +54,7 @@ public class InputJavadocPositionOnCompactConstructorsWithAnnotation {
      */
     @SizeType(max = 2)
     public MyRecord {}
-    /** invalid javadoc.*/
+    /** Invalid javadoc.*/
     // violation above 'Javadoc comment is placed in the wrong location.'
   }
 }

--- a/src/it/resources/com/google/checkstyle/test/chapter7javadoc/rule711generalform/InputJavadocPositionOnConstructorInRecord.java
+++ b/src/it/resources/com/google/checkstyle/test/chapter7javadoc/rule711generalform/InputJavadocPositionOnConstructorInRecord.java
@@ -32,9 +32,9 @@ public class InputJavadocPositionOnConstructorInRecord {
   public record MyRecord(String text) {
 
     // violation 3 lines below 'Javadoc comment is placed in the wrong location.'
-    /** invalid comment. */
+    /** Invalid comment. */
     public MyRecord {}
-    /** invalid comment. */
+    /** Invalid comment. */
   }
 
   /**
@@ -46,7 +46,7 @@ public class InputJavadocPositionOnConstructorInRecord {
   record Mapping(String from, String to) {
 
     // violation below 'Javadoc comment is placed in the wrong location.'
-    /** some javadoc. */
+    /** Some javadoc. */
     /**
      * The constructor for Mapping.
      *

--- a/src/it/resources/com/google/checkstyle/test/chapter7javadoc/rule711generalform/InputSingleLineJavadocAndInvalidJavadocPosition.java
+++ b/src/it/resources/com/google/checkstyle/test/chapter7javadoc/rule711generalform/InputSingleLineJavadocAndInvalidJavadocPosition.java
@@ -1,13 +1,13 @@
 package // violation 'package statement should not be line-wrapped.'
     // violation below 'Javadoc comment is placed in the wrong location.'
-    /** invalid javadoc. */
+    /** Invalid javadoc. */
     com.google.checkstyle.test.chapter7javadoc.rule711generalform;
 
 // violation below 'Javadoc comment is placed in the wrong location.'
-/** invalid javadoc. */
+/** Invalid javadoc. */
 import javax.swing.JFrame;
 
-/** some javadoc. */
+/** Some javadoc. */
 public class InputSingleLineJavadocAndInvalidJavadocPosition {
 
   /** As of JDK 1.1, replaced by {@link #setBounds(int,int,int,int)}. */
@@ -24,7 +24,7 @@ public class InputSingleLineJavadocAndInvalidJavadocPosition {
   void foo3() {}
 
   /**
-   * summary.
+   * Summary.
    *
    * @throws CheckstyleException if a problem occurs
    */
@@ -54,7 +54,7 @@ public class InputSingleLineJavadocAndInvalidJavadocPosition {
   void bar() {}
 
   /**
-   * summary.
+   * Summary.
    *
    * <h1>Some header </h1>
    *
@@ -82,7 +82,7 @@ public class InputSingleLineJavadocAndInvalidJavadocPosition {
   }
 
   /**
-   * summary.
+   * Summary.
    *
    * @return in multi line javadoc
    */
@@ -92,96 +92,96 @@ public class InputSingleLineJavadocAndInvalidJavadocPosition {
 }
 
 // violation below 'Javadoc comment is placed in the wrong location.'
-/** invalid javadoc. */
-/** valid javadoc. */
+/** Invalid javadoc. */
+/** Valid javadoc. */
 class InputInvalidJavadocPosition {
   // violation above '.* InputInvalidJavadocPosition has to reside in its own source file.'
   // violation below 'Javadoc comment is placed in the wrong location.'
-  /** invalid javadoc. */
+  /** Invalid javadoc. */
 }
 
-/** valid javadoc. */
+/** Valid javadoc. */
 /* ignore */
 class InputInvalidJavadocPosition2 {
   // violation above '.* InputInvalidJavadocPosition2 has to reside in its own source file.'
   // violation below 'Javadoc comment is placed in the wrong location.'
-  /** invalid javadoc. */
+  /** Invalid javadoc. */
   static {
     /* ignore */
   }
 
   // violation below 'Javadoc comment is placed in the wrong location.'
-  /** invalid javadoc. */
-  /** valid javadoc. */
+  /** Invalid javadoc. */
+  /** Valid javadoc. */
   int field1;
 
-  /** valid javadoc. */
+  /** Valid javadoc. */
   int[] field2;
 
-  /** valid javadoc. */
+  /** Valid javadoc. */
   public int[] field3;
 
-  /** valid javadoc. */
+  /** Valid javadoc. */
   @Deprecated int field4;
 
   // violation 2 lines below 'Javadoc comment is placed in the wrong location.'
   int
-      /** invalid javadoc. */
+      /** Invalid javadoc. */
       field20;
 
   // violation 2 lines below 'Javadoc comment is placed in the wrong location.'
   int field21
-      /** invalid javadoc. */
+      /** Invalid javadoc. */
       ;
 
   // violation 2 lines below 'Javadoc comment is placed in the wrong location.'
   @Deprecated
-  /** invalid javadoc. */
+  /** Invalid javadoc. */
   JFrame frame = new JFrame();
 
   void method1() {}
 
-  /** valid javadoc. */
+  /** Valid javadoc. */
   void method2() {}
 
-  /** valid javadoc. */
+  /** Valid javadoc. */
   <T> T method3() {
     return null;
   }
 
-  /** valid javadoc. */
+  /** Valid javadoc. */
   String[] method4() {
     return null;
   }
 
   // violation 2 lines below 'Javadoc comment is placed in the wrong location.'
   void
-      /** invalid javadoc. */
+      /** Invalid javadoc. */
       method20() {}
 
   // violation 2 lines below 'Javadoc comment is placed in the wrong location.'
   void method21
-  /** invalid javadoc. */
+  /** Invalid javadoc. */
   () {} // violation ''(' should be on the previous line.'
 
   // violation 2 lines below 'Javadoc comment is placed in the wrong location.'
   void method22(
-  /** invalid javadoc. */
+  /** Invalid javadoc. */
   ) {}
 
   // violation 2 lines below 'Javadoc comment is placed in the wrong location.'
   void method23()
-    /** invalid javadoc. */
+    /** Invalid javadoc. */
     {}
 
   // violation 2 lines below 'Javadoc comment is placed in the wrong location.'
   void method24() {
-    /** invalid javadoc. */
+    /** Invalid javadoc. */
   }
 
   // violation 2 lines below 'Javadoc comment is placed in the wrong location.'
   void method25() {
-    /** invalid javadoc. */
+    /** Invalid javadoc. */
     int variable;
   }
 }
@@ -189,26 +189,26 @@ class InputInvalidJavadocPosition2 {
 // violation 2 lines below '.* InputInvalidJavadocPosition3 has to reside in its own source file.'
 // violation 2 lines below 'Javadoc comment is placed in the wrong location.'
 @Deprecated
-/** invalid javadoc. */
+/** Invalid javadoc. */
 class InputInvalidJavadocPosition3 {}
 
 // violation 2 lines below '.* InputInvalidJavadocPosition4 has to reside in its own source file.'
-/** valid javadoc. */
+/** Valid javadoc. */
 @Deprecated
 class InputInvalidJavadocPosition4 {}
 
 // violation 2 lines below '.* InputInvalidJavadocPosition5 has to reside in its own source file.'
 // violation 2 lines below 'Javadoc comment is placed in the wrong location.'
 class
-/** invalid javadoc. */
+/** Invalid javadoc. */
 InputInvalidJavadocPosition5 {}
 // violation above ''InputInvalidJavadocPosition5' has incorrect indentation .* 0, expected .* 4.'
 
 // violation 2 lines below '.* InputInvalidJavadocPosition6 has to reside in its own source file.'
 // violation 2 lines below 'Javadoc comment is placed in the wrong location.'
 class InputInvalidJavadocPosition6
-  /** invalid javadoc. */
+  /** Invalid javadoc. */
   {}
-/** invalid javadoc. */
+/** Invalid javadoc. */
 // violation 2 lines above''}' at column 4 should be alone on a line.'
 // violation 2 lines above 'Javadoc comment is placed in the wrong location.'

--- a/src/it/resources/com/google/checkstyle/test/chapter7javadoc/rule712paragraphs/InputCorrectRequireEmptyLineBeforeBlockTagGroup.java
+++ b/src/it/resources/com/google/checkstyle/test/chapter7javadoc/rule712paragraphs/InputCorrectRequireEmptyLineBeforeBlockTagGroup.java
@@ -28,7 +28,7 @@ class InputCorrectRequireEmptyLineBeforeBlockTagGroup {
   }
 
   /**
-   * summary.
+   * Summary.
    *
    * @return this only has a tag.
    */

--- a/src/it/resources/com/google/checkstyle/test/chapter7javadoc/rule712paragraphs/InputFormattedCorrectRequireEmptyLineBeforeBlockTagGroup.java
+++ b/src/it/resources/com/google/checkstyle/test/chapter7javadoc/rule712paragraphs/InputFormattedCorrectRequireEmptyLineBeforeBlockTagGroup.java
@@ -28,7 +28,7 @@ class InputFormattedCorrectRequireEmptyLineBeforeBlockTagGroup {
   }
 
   /**
-   * summary.
+   * Summary.
    *
    * @return this only has a tag.
    */

--- a/src/it/resources/com/google/checkstyle/test/chapter7javadoc/rule713atclauses/InputCorrectAtClauseOrderCheck1.java
+++ b/src/it/resources/com/google/checkstyle/test/chapter7javadoc/rule713atclauses/InputCorrectAtClauseOrderCheck1.java
@@ -60,7 +60,7 @@ class InputCorrectAtClauseOrderCheck1 implements Serializable {
   }
 
   /**
-   * summary.
+   * Summary.
    *
    * @author max
    * @version 1.0

--- a/src/it/resources/com/google/checkstyle/test/chapter7javadoc/rule713atclauses/InputCorrectAtClauseOrderCheck2.java
+++ b/src/it/resources/com/google/checkstyle/test/chapter7javadoc/rule713atclauses/InputCorrectAtClauseOrderCheck2.java
@@ -39,7 +39,7 @@ class InputCorrectAtClauseOrderCheck2 implements Serializable {
   }
 
   /**
-   * summary.
+   * Summary.
    *
    * @author max
    * @version 1.0

--- a/src/it/resources/com/google/checkstyle/test/chapter7javadoc/rule713atclauses/InputCorrectAtClauseOrderCheck3.java
+++ b/src/it/resources/com/google/checkstyle/test/chapter7javadoc/rule713atclauses/InputCorrectAtClauseOrderCheck3.java
@@ -39,7 +39,7 @@ class InputCorrectAtClauseOrderCheck3 implements Serializable {
   }
 
   /**
-   * summary.
+   * Summary.
    *
    * @author max
    * @version 1.0

--- a/src/it/resources/com/google/checkstyle/test/chapter7javadoc/rule713atclauses/InputNonEmptyAtclauseDescription.java
+++ b/src/it/resources/com/google/checkstyle/test/chapter7javadoc/rule713atclauses/InputNonEmptyAtclauseDescription.java
@@ -35,7 +35,7 @@ class InputNonEmptyAtclauseDescription {
   // violation 9 lines below 'At-clause should have a non-empty description.'
   // violation 9 lines below 'At-clause should have a non-empty description.'
   /**
-   * some javadoc.
+   * Some javadoc.
    *
    * @param a
    * @param b
@@ -54,7 +54,7 @@ class InputNonEmptyAtclauseDescription {
   // violation 8 lines below 'At-clause should have a non-empty description.'
   // violation 8 lines below 'At-clause should have a non-empty description.'
   /**
-   * some javadoc.
+   * Some javadoc.
    *
    * @param a
    * @param b

--- a/src/it/resources/com/google/checkstyle/test/chapter7javadoc/rule72thesummaryfragment/InputCorrectSummaryFragment.java
+++ b/src/it/resources/com/google/checkstyle/test/chapter7javadoc/rule72thesummaryfragment/InputCorrectSummaryFragment.java
@@ -25,7 +25,7 @@ class InputCorrectSummaryFragment {
   /** This is valid. <a href="mailto:vlad@htmlbook.ru"/> */
   class InnerInputCorrectJavaDocParagraphCheck {
 
-    /** foooo@foooo. */
+    /** Foooo@foooo. */
     public static final byte NUL = 0;
 
     /** Some java@doc. This method returns. */

--- a/src/it/resources/com/google/checkstyle/test/chapter7javadoc/rule72thesummaryfragment/InputIncorrectSummaryFragment.java
+++ b/src/it/resources/com/google/checkstyle/test/chapter7javadoc/rule72thesummaryfragment/InputIncorrectSummaryFragment.java
@@ -27,7 +27,7 @@ class InputIncorrectSummaryFragment {
   class InnerInputCorrectJavaDocParagraphCheck {
 
     // violation below 'First sentence of Javadoc is missing an ending period.'
-    /** foooo@foooo */
+    /** Foooo@foooo */
     public static final byte NUL = 0;
 
     /** Some java@doc. */
@@ -65,6 +65,10 @@ class InputIncorrectSummaryFragment {
 
     /** An especially short bit of Javadoc. */
     void foo6() {}
+
+    // violation below 'Forbidden summary fragment.'
+    /** adds an element to the list. */
+    void add(String element) {}
   }
 
   // violation below 'Forbidden summary fragment.'

--- a/src/it/resources/com/google/checkstyle/test/chapter7javadoc/rule731selfexplanatory/InputJavadocMethodAndMissingJavadocMethod.java
+++ b/src/it/resources/com/google/checkstyle/test/chapter7javadoc/rule731selfexplanatory/InputJavadocMethodAndMissingJavadocMethod.java
@@ -57,12 +57,12 @@ public class InputJavadocMethodAndMissingJavadocMethod extends OverrideClasss {
     return "Fooooooooooooooo" + "ooooo" + "ooo" + x;
   }
 
-  /** some javadoc. */
+  /** Some javadoc. */
   public void smallMethod1() {
     foo2();
   }
 
-  /** some javadoc. */
+  /** Some javadoc. */
   protected void smallMethod2() {
     foo2();
   }
@@ -101,7 +101,7 @@ public class InputJavadocMethodAndMissingJavadocMethod extends OverrideClasss {
     foo3();
   }
 
-  /** some javadoc. */
+  /** Some javadoc. */
   public InputJavadocMethodAndMissingJavadocMethod(int a, int b) {
     foo2();
   }

--- a/src/it/resources/com/google/checkstyle/test/chapter7javadoc/rule731selfexplanatory/InputSelfExplanatoryMembersRecord.java
+++ b/src/it/resources/com/google/checkstyle/test/chapter7javadoc/rule731selfexplanatory/InputSelfExplanatoryMembersRecord.java
@@ -1,14 +1,14 @@
 package com.google.checkstyle.test.chapter7javadoc.rule731selfexplanatory;
 
-/** some javadoc. */
+/** Some javadoc. */
 public record InputSelfExplanatoryMembersRecord(int scoreBoard) {
 
   public static int score = 0;
 
-  /** some javadoc. */
+  /** Some javadoc. */
   public InputSelfExplanatoryMembersRecord {}
 
-  /** some javadoc. */
+  /** Some javadoc. */
   public void myScore() {}
 
   public void setScoreBoard(int score) {
@@ -19,12 +19,12 @@ public record InputSelfExplanatoryMembersRecord(int scoreBoard) {
     return score;
   }
 
-  /** some javadoc. */
+  /** Some javadoc. */
   public int getFoo() {
     return scoreBoard * 2;
   }
 
-  /** some javadoc. */
+  /** Some javadoc. */
   @Override
   public String toString() {
     return "failed to get score";
@@ -58,17 +58,17 @@ public record InputSelfExplanatoryMembersRecord(int scoreBoard) {
     return "Fooooooooooooooo" + "ooooo" + "ooo" + x;
   }
 
-  /** some javadoc. */
+  /** Some javadoc. */
   public void smallMethod1() {
     foo2();
   }
 
-  /** some javadoc. */
+  /** Some javadoc. */
   protected void smallMethod2() {
     foo2();
   }
 
-  /** some javadoc. */
+  /** Some javadoc. */
   public String testingParams(String param1, String param2) {
     return "Fooooooooooooooo" + "ooooo" + "ooo" + param1 + param2;
   }

--- a/src/it/resources/com/google/checkstyle/test/chapter7javadoc/rule731selfexplanatory/InputSelfExplanatoryMembersRecord2.java
+++ b/src/it/resources/com/google/checkstyle/test/chapter7javadoc/rule731selfexplanatory/InputSelfExplanatoryMembersRecord2.java
@@ -1,6 +1,6 @@
 package com.google.checkstyle.test.chapter7javadoc.rule731selfexplanatory;
 
-/** some javadoc. */
+/** Some javadoc. */
 public record InputSelfExplanatoryMembersRecord2(int card1, int card2, int card3) {
 
   // violation below 'Missing a Javadoc comment.'
@@ -28,12 +28,12 @@ public record InputSelfExplanatoryMembersRecord2(int card1, int card2, int card3
     return card3;
   }
 
-  /** some javadoc. */
+  /** Some javadoc. */
   public int getFoo() {
     return card1 * 2;
   }
 
-  /** some javadoc. */
+  /** Some javadoc. */
   @Override
   public String toString() {
     return "failed to get score";
@@ -67,17 +67,17 @@ public record InputSelfExplanatoryMembersRecord2(int card1, int card2, int card3
     return "Fooooooooooooooo" + "ooooo" + "ooo" + x;
   }
 
-  /** some javadoc. */
+  /** Some javadoc. */
   public void smallMethod1() {
     foo2();
   }
 
-  /** some javadoc. */
+  /** Some javadoc. */
   protected void smallMethod2() {
     foo2();
   }
 
-  /** some javadoc. */
+  /** Some javadoc. */
   public String testingParams(String param1, String param2) {
     return "Fooooooooooooooo" + "ooooo" + "ooo" + param1 + param2;
   }

--- a/src/it/resources/com/google/checkstyle/test/chapter7javadoc/rule732exceptionoverrides/InputJavadocMethodAndMissingJavadocMethod.java
+++ b/src/it/resources/com/google/checkstyle/test/chapter7javadoc/rule732exceptionoverrides/InputJavadocMethodAndMissingJavadocMethod.java
@@ -57,12 +57,12 @@ public class InputJavadocMethodAndMissingJavadocMethod extends OverrideClass {
     return "Fooooooooooooooo" + "ooooo" + "ooo" + x;
   }
 
-  /** some javadoc. */
+  /** Some javadoc. */
   public void smallMethod1() {
     foo2();
   }
 
-  /** some javadoc. */
+  /** Some javadoc. */
   protected void smallMethod2() {
     foo2();
   }
@@ -101,7 +101,7 @@ public class InputJavadocMethodAndMissingJavadocMethod extends OverrideClass {
     foo3();
   }
 
-  /** some javadoc. */
+  /** Some javadoc. */
   public InputJavadocMethodAndMissingJavadocMethod(int a, int b) {
     foo2();
   }

--- a/src/it/resources/com/google/checkstyle/test/chapter7javadoc/rule734nonrequiredjavadoc/InputFormattedInvalidJavadocPosition.java
+++ b/src/it/resources/com/google/checkstyle/test/chapter7javadoc/rule734nonrequiredjavadoc/InputFormattedInvalidJavadocPosition.java
@@ -1,83 +1,83 @@
 package // violation 'package statement should not be line-wrapped.'
-    /** odd javadoc */
+    /** Odd javadoc */
     // violation above 'Javadoc comment is placed in the wrong location.'
     com.google.checkstyle.test.chapter7javadoc.rule734nonrequiredjavadoc;
 
 // violation below 'Javadoc comment is placed in the wrong location.'
-/** odd javadoc */
+/** Odd javadoc */
 import javax.swing.JFrame;
 
 // violation below 'Javadoc comment is placed in the wrong location.'
-/** odd javadoc */
-/** valid javadoc. */
+/** Odd javadoc */
+/** Valid javadoc. */
 class InputFormattedInvalidJavadocPosition {
-  /** odd javadoc */
+  /** Odd javadoc */
   // violation above 'Javadoc comment is placed in the wrong location.'
 }
 
-/** valid javadoc. */
+/** Valid javadoc. */
 /* ignore */
 class ExtraInputInvalidJavadocPosition2 {
   // violation above '.* ExtraInputInvalidJavadocPosition2 has to reside in its own source file.'
 
-  /** odd javadoc */
+  /** Odd javadoc */
   // violation above 'Javadoc comment is placed in the wrong location.'
   static {
     /* ignore */
   }
 
   // violation below 'Javadoc comment is placed in the wrong location.'
-  /** odd javadoc */
-  /** valid javadoc. */
+  /** Odd javadoc */
+  /** Valid javadoc. */
   int field1;
 
-  /** valid javadoc. */
+  /** Valid javadoc. */
   JFrame frame = new JFrame();
 
-  /** valid javadoc. */
+  /** Valid javadoc. */
   public int[] field3;
 
-  /** valid javadoc. */
+  /** Valid javadoc. */
   @Deprecated int field4;
 
   // violation 2 lines below 'Javadoc comment is placed in the wrong location.'
   int
-      /** odd javadoc */
+      /** Odd javadoc */
       field20;
 
   // violation 2 lines below 'Javadoc comment is placed in the wrong location.'
   int field21
-      /** odd javadoc */
+      /** Odd javadoc */
       ;
 
   // violation 2 lines below 'Javadoc comment is placed in the wrong location.'
   @Deprecated
-  /** odd javadoc */
+  /** Odd javadoc */
   int field22;
 
   void method1() {}
 
-  /** valid javadoc. */
+  /** Valid javadoc. */
   void method2() {}
 
-  /** valid javadoc. */
+  /** Valid javadoc. */
   <T> T method3() {
     return null;
   }
 
-  /** valid javadoc. */
+  /** Valid javadoc. */
   String[] method4() {
     return null;
   }
 
   // violation 2 lines below 'Javadoc comment is placed in the wrong location.'
   void
-      /** odd javadoc */
+      /** Odd javadoc */
       method20() {}
 
   // violation 2 lines below 'Javadoc comment is placed in the wrong location.'
   void method21
-      /** odd javadoc */
+      /** Odd javadoc */
       () {}
 
   // 2 violations 2 lines above:
@@ -86,39 +86,39 @@ class ExtraInputInvalidJavadocPosition2 {
 
   // violation 2 lines below 'Javadoc comment is placed in the wrong location.'
   void method22(
-      /** odd javadoc */
+      /** Odd javadoc */
       ) {} // violation '.* incorrect indentation level 6, expected level should be 2.'
 
   // 2 violations 4 lines below:
   //  '.* indentation should be the same level as line 97.'
   //  'Javadoc comment is placed in the wrong location.'
   void method23()
-        /** odd javadoc */
+        /** Odd javadoc */
       {} // violation '.* has incorrect indentation level 6, expected level should be 4.'
 
   // violation 2 lines below 'Javadoc comment is placed in the wrong location.'
   void method24() {
-    /** odd javadoc */
+    /** Odd javadoc */
   }
 
   // violation 2 lines below 'Javadoc comment is placed in the wrong location.'
   void method25() {
-    /** odd javadoc */
+    /** Odd javadoc */
     int variable;
   }
 
   @Deprecated
-  /** odd javadoc */
+  /** Odd javadoc */
   // violation above 'Javadoc comment is placed in the wrong location.'
   class InputInvalidJavadocPosition3 {}
 
-  /** valid javadoc. */
+  /** Valid javadoc. */
   @Deprecated
   class InputInvalidJavadocPosition4 {}
 
   // violation 2 lines below 'Javadoc comment is placed in the wrong location.'
   class
-  /** odd javadoc */
+  /** Odd javadoc */
   InputInvalidJavadocPosition5 {}
 
   // violation 2 lines above '.* incorrect indentation .* 2, expected .* 6.'
@@ -126,11 +126,11 @@ class ExtraInputInvalidJavadocPosition2 {
   /* extra violation 4 line below until https://github.com/google/google-java-format/issues/1126 */
   // violation 2 lines below 'Javadoc comment is placed in the wrong location.'
   class InputInvalidJavadocPosition6
-  /** odd javadoc */
+  /** Odd javadoc */
   {}
   // 2 violations above:
   //  ''class def lcurly' has incorrect indentation level 2, expected level should be 4.'
   //  ''}' at column 4 should be alone on a line.'
-  /** odd javadoc */
+  /** Odd javadoc */
   // violation above 'Javadoc comment is placed in the wrong location.'
 }

--- a/src/it/resources/com/google/checkstyle/test/chapter7javadoc/rule734nonrequiredjavadoc/InputFormattedInvalidJavadocPositionRecord.java
+++ b/src/it/resources/com/google/checkstyle/test/chapter7javadoc/rule734nonrequiredjavadoc/InputFormattedInvalidJavadocPositionRecord.java
@@ -1,15 +1,15 @@
 package com.google.checkstyle.test.chapter7javadoc.rule734nonrequiredjavadoc;
 
 // violation below 'Javadoc comment is placed in the wrong location.'
-/** odd javadoc */
+/** Odd javadoc */
 /**
- * valid javadoc.
+ * Valid javadoc.
  *
  * @param containerPath options
  * @param options path
  */
 public record InputFormattedInvalidJavadocPositionRecord(String containerPath, String... options) {
-  /** odd javadoc */
+  /** Odd javadoc */
   // violation above 'Javadoc comment is placed in the wrong location.'
 
   /**
@@ -20,37 +20,37 @@ public record InputFormattedInvalidJavadocPositionRecord(String containerPath, S
    * @throws NullPointerException if any of the arguments are null
    */
   public InputFormattedInvalidJavadocPositionRecord {
-    /** some javadoc. */
+    /** Some javadoc. */
     // violation above 'Javadoc comment is placed in the wrong location'
   }
 
-  /** some javadoc. * */
+  /** Some javadoc. * */
   record Example1(int num, String data) {
 
-    /** some javadoc. */
+    /** Some javadoc. */
     Example1 {}
 
     @Override
-    /** some javadoc. * */
+    /** Some javadoc. * */
     public String toString() {
       // violation 2 lines above 'Javadoc comment is placed in the wrong location.'
       return "Example" + data;
     }
 
-    /** some javadoc. */
+    /** Some javadoc. */
     @Override
-    /** some javadoc. * */
+    /** Some javadoc. * */
     public int hashCode() {
       // violation 2 lines above 'Javadoc comment is placed in the wrong location.'
       return 5 + num;
     }
 
-    /** some javadoc. * */
+    /** Some javadoc. * */
     @Override
-    /** some javadoc. * */
+    /** Some javadoc. * */
     public boolean equals(Object obj) {
       // violation 2 lines above 'Javadoc comment is placed in the wrong location.'
-      /** some javadoc. * */
+      /** Some javadoc. * */
       // violation above 'Javadoc comment is placed in the wrong location.'
       return false;
     }
@@ -58,7 +58,7 @@ public record InputFormattedInvalidJavadocPositionRecord(String containerPath, S
 }
 
 // violation below 'Javadoc comment is placed in the wrong location.'
-/** invalid comment. */
+/** Invalid comment. */
 /**
  * The configuration.
  *
@@ -67,22 +67,22 @@ public record InputFormattedInvalidJavadocPositionRecord(String containerPath, S
 record MyRecord1(String text) {
   // violation above 'Top-level class MyRecord1 has to reside in its own source file'
 
-  /** some javadoc. */
+  /** Some javadoc. */
   MyRecord1 {}
-  /** invalid comment. */
+  /** Invalid comment. */
   // violation above 'Javadoc comment is placed in the wrong location.'
 }
 
-/** some javadoc. */
+/** Some javadoc. */
 // violation above 'Javadoc comment is placed in the wrong location.'
 /**
- * some javadoc.
+ * Some javadoc.
  *
  * @param from the from
  */
 record Mapping1(String from) { // violation 'Top-level class Mapping1 has to reside in its own'
 
-  /** some javadoc. */
+  /** Some javadoc. */
   // violation above 'Javadoc comment is placed in the wrong location.'
   /**
    * The constructor for Mapping.
@@ -91,7 +91,7 @@ record Mapping1(String from) { // violation 'Top-level class Mapping1 has to res
    */
   Mapping1(String from) {
     this.from = from;
-    /** some javadoc. */
+    /** Some javadoc. */
     // violation above 'Javadoc comment is placed in the wrong location.'
   }
 }

--- a/src/it/resources/com/google/checkstyle/test/chapter7javadoc/rule734nonrequiredjavadoc/InputInvalidJavadocPosition.java
+++ b/src/it/resources/com/google/checkstyle/test/chapter7javadoc/rule734nonrequiredjavadoc/InputInvalidJavadocPosition.java
@@ -1,122 +1,122 @@
 package // violation 'package statement should not be line-wrapped.'
-    /** odd javadoc */ // violation 'Javadoc comment is placed in the wrong location.'
+    /** Odd javadoc */ // violation 'Javadoc comment is placed in the wrong location.'
     com.google.checkstyle.test.chapter7javadoc.rule734nonrequiredjavadoc;
 
 // violation below 'Javadoc comment is placed in the wrong location.'
-/** odd javadoc */
+/** Odd javadoc */
 import javax.swing.JFrame;
 
 // violation below 'Javadoc comment is placed in the wrong location.'
-/** odd javadoc */
-/** valid javadoc. */
+/** Odd javadoc */
+/** Valid javadoc. */
 class InputInvalidJavadocPosition {
-  /** odd javadoc */
+  /** Odd javadoc */
   // violation above 'Javadoc comment is placed in the wrong location.'
 }
 
-/** valid javadoc. */
+/** Valid javadoc. */
 /* ignore */
 class InputInvalidJavadocPosition2 {
   // violation above '.* InputInvalidJavadocPosition2 has to reside in its own source file.'
 
-  /** odd javadoc */ // violation 'Javadoc comment is placed in the wrong location.'
+  /** Odd javadoc */ // violation 'Javadoc comment is placed in the wrong location.'
   static {
     /* ignore */
   }
 
   // violation below 'Javadoc comment is placed in the wrong location.'
-  /** odd javadoc */
-  /** valid javadoc. */
+  /** Odd javadoc */
+  /** Valid javadoc. */
   int field1;
 
-  /** valid javadoc. */
+  /** Valid javadoc. */
   JFrame frame = new JFrame();
 
-  /** valid javadoc. */
+  /** Valid javadoc. */
   public int[] field3;
 
-  /** valid javadoc. */
+  /** Valid javadoc. */
   @Deprecated int field4;
 
   // violation 2 lines below 'Javadoc comment is placed in the wrong location.'
   int
-      /** odd javadoc */
+      /** Odd javadoc */
       field20;
 
   // violation 2 lines below 'Javadoc comment is placed in the wrong location.'
   int field21
-      /** odd javadoc */;
+      /** Odd javadoc */;
 
   // violation 2 lines below 'Javadoc comment is placed in the wrong location.'
   @Deprecated
-  /** odd javadoc */
+  /** Odd javadoc */
   int field22;
 
   void method1() {}
 
-  /** valid javadoc. */
+  /** Valid javadoc. */
   void method2() {}
 
-  /** valid javadoc. */
+  /** Valid javadoc. */
   <T> T method3() {
     return null;
   }
 
-  /** valid javadoc. */
+  /** Valid javadoc. */
   String[] method4() {
     return null;
   }
 
   // violation 2 lines below 'Javadoc comment is placed in the wrong location.'
   void
-      /** odd javadoc */
+      /** Odd javadoc */
       method20() {}
 
   // violation 2 lines below 'Javadoc comment is placed in the wrong location.'
   void method21
-  /** odd javadoc */
+  /** Odd javadoc */
   () {} // violation ''(' should be on the previous line.'
 
   // violation 2 lines below 'Javadoc comment is placed in the wrong location.'
   void method22(
-  /** odd javadoc */
+  /** Odd javadoc */
   ) {}
 
   // violation 2 lines below 'Javadoc comment is placed in the wrong location.'
   void method23()
-    /** odd javadoc */
+    /** Odd javadoc */
     {}
 
   // violation 2 lines below 'Javadoc comment is placed in the wrong location.'
   void method24() {
-    /** odd javadoc */
+    /** Odd javadoc */
   }
 
   // violation 2 lines below 'Javadoc comment is placed in the wrong location.'
   void method25() {
-    /** odd javadoc */
+    /** Odd javadoc */
     int variable;
   }
 
   @Deprecated
-  /** odd javadoc */
+  /** Odd javadoc */
   // violation above 'Javadoc comment is placed in the wrong location.'
   class InputInvalidJavadocPosition3 {}
 
-  /** valid javadoc. */
+  /** Valid javadoc. */
   @Deprecated
   class InputInvalidJavadocPosition4 {}
 
   // violation 2 lines below 'Javadoc comment is placed in the wrong location.'
   class
-  /** odd javadoc */
+  /** Odd javadoc */
   InputInvalidJavadocPosition5 {}
   // violation above ''InputInvalidJavadocPosition5' has incorrect indentation .* 2, expected .* 6.'
 
   // violation 2 lines below 'Javadoc comment is placed in the wrong location.'
   class InputInvalidJavadocPosition6
-    /** odd javadoc */
+    /** Odd javadoc */
     {} // violation ''}' at column 6 should be alone on a line.'
-  /** odd javadoc */
+  /** Odd javadoc */
   // violation above 'Javadoc comment is placed in the wrong location.'
 }

--- a/src/it/resources/com/google/checkstyle/test/chapter7javadoc/rule734nonrequiredjavadoc/InputInvalidJavadocPositionRecord.java
+++ b/src/it/resources/com/google/checkstyle/test/chapter7javadoc/rule734nonrequiredjavadoc/InputInvalidJavadocPositionRecord.java
@@ -1,15 +1,15 @@
 package com.google.checkstyle.test.chapter7javadoc.rule734nonrequiredjavadoc;
 
 // violation below 'Javadoc comment is placed in the wrong location.'
-/** odd javadoc */
-/** valid javadoc.
+/** Odd javadoc */
+/** Valid javadoc.
  *
  * @param containerPath options
  * @param options path
  *
  */
 public record InputInvalidJavadocPositionRecord(String containerPath, String... options) {
-  /** odd javadoc */ // violation 'Javadoc comment is placed in the wrong location.'
+  /** Odd javadoc */ // violation 'Javadoc comment is placed in the wrong location.'
 
   /**
    * Creates a mount.
@@ -19,40 +19,40 @@ public record InputInvalidJavadocPositionRecord(String containerPath, String... 
    * @throws NullPointerException     if any of the arguments are null
    */
   public InputInvalidJavadocPositionRecord {
-    /** some javadoc. */ // violation 'Javadoc comment is placed in the wrong location'
+    /** Some javadoc. */ // violation 'Javadoc comment is placed in the wrong location'
   }
 
-  /** some javadoc. **/
+  /** Some javadoc. **/
   record Example(int num, String data) {
 
     /**
-     * some javadoc.
+     * Some javadoc.
      **/
     Example {}
 
     @Override
-    /** some javadoc. **/
+    /** Some javadoc. **/
     public String toString() {
       // violation 2 lines above 'Javadoc comment is placed in the wrong location.'
       return "Example" + data;
     }
 
     /**
-     * some javadoc.
+     * Some javadoc.
      **/
     @Override
-    /** some javadoc. **/
+    /** Some javadoc. **/
     public int hashCode() {
       // violation 2 lines above 'Javadoc comment is placed in the wrong location.'
       return 5 + num;
     }
 
-    /** some javadoc. **/
+    /** Some javadoc. **/
     @Override
-    /** some javadoc. **/
+    /** Some javadoc. **/
     public boolean equals(Object obj) {
       // violation 2 lines above 'Javadoc comment is placed in the wrong location.'
-      /** some javadoc. **/
+      /** Some javadoc. **/
       // violation above 'Javadoc comment is placed in the wrong location.'
       return false;
     }
@@ -60,7 +60,7 @@ public record InputInvalidJavadocPositionRecord(String containerPath, String... 
 }
 
 // violation below 'Javadoc comment is placed in the wrong location.'
-/** invalid comment. */
+/** Invalid comment. */
 /**
  * The configuration.
  *
@@ -69,20 +69,20 @@ public record InputInvalidJavadocPositionRecord(String containerPath, String... 
 record MyRecord(String text) {
   // violation above 'Top-level class MyRecord has to reside in its own source file'
 
-  /** some javadoc.*/
+  /** Some javadoc.*/
   MyRecord {}
-  /** invalid comment. */ // violation 'Javadoc comment is placed in the wrong location.'
+  /** Invalid comment. */ // violation 'Javadoc comment is placed in the wrong location.'
 }
 
-/** some javadoc. */ // violation 'Javadoc comment is placed in the wrong location.'
+/** Some javadoc. */ // violation 'Javadoc comment is placed in the wrong location.'
 /**
- * some javadoc.
+ * Some javadoc.
  *
  * @param from the from
  */
 record Mapping(String from) { // violation 'Top-level class Mapping has to reside in its own'
 
-  /** some javadoc. */ // violation 'Javadoc comment is placed in the wrong location.'
+  /** Some javadoc. */ // violation 'Javadoc comment is placed in the wrong location.'
   /**
    * The constructor for Mapping.
    *
@@ -90,7 +90,7 @@ record Mapping(String from) { // violation 'Top-level class Mapping has to resid
    */
   Mapping(String from) {
     this.from = from;
-    /** some javadoc. */
+    /** Some javadoc. */
     // violation above 'Javadoc comment is placed in the wrong location.'
   }
 }

--- a/src/it/resources/com/google/checkstyle/test/chapter7javadoc/rule73wherejavadocrequired/InputJavadocMethodAndMissingJavadocMethod.java
+++ b/src/it/resources/com/google/checkstyle/test/chapter7javadoc/rule73wherejavadocrequired/InputJavadocMethodAndMissingJavadocMethod.java
@@ -62,7 +62,7 @@ public class InputJavadocMethodAndMissingJavadocMethod extends OverrideClass {
     foo2();
   }
 
-  /** some javadoc. */
+  /** Some javadoc. */
   protected void smallMethod2() {
     foo2();
   }

--- a/src/it/resources/com/google/checkstyle/test/chapter7javadoc/rule73wherejavadocrequired/InputMissingJavadocTypeCorrect.java
+++ b/src/it/resources/com/google/checkstyle/test/chapter7javadoc/rule73wherejavadocrequired/InputMissingJavadocTypeCorrect.java
@@ -48,47 +48,47 @@ public class InputMissingJavadocTypeCorrect {
 
   private @interface MyAnnotationPrivate {}
 
-  /** some javadoc. */
+  /** Some javadoc. */
   public void myMethod() {
     class MyMethodClass {}
   }
 
-  /** some javadoc. */
+  /** Some javadoc. */
   protected int testProtectedMethod1() {
     return 0;
   }
 
-  /** some javadoc. */
+  /** Some javadoc. */
   protected void testProtectedMethod2() {}
 
-  /** some javadoc. */
+  /** Some javadoc. */
   public void testPublicMethod() {}
 
   private void testPrivateMethod() {}
 
   void testPackagePrivateMethod() {}
 
-  /** some javadoc. */
+  /** Some javadoc. */
   protected InputMissingJavadocTypeCorrect() {}
 
-  /** some javadoc. */
+  /** Some javadoc. */
   public InputMissingJavadocTypeCorrect(String arg) {}
 
   private InputMissingJavadocTypeCorrect(int arg) {}
 
   InputMissingJavadocTypeCorrect(double arg) {}
 
-  /** some javadoc. */
+  /** Some javadoc. */
   protected @interface ProtectedAnnotation {}
 
-  /** some javadoc. */
+  /** Some javadoc. */
   public @interface PublicAnnotation {}
 
   private @interface PrivateAnnotation {}
 
   @interface PackagePrivateAnnotation {}
 
-  /** some javadoc. */
+  /** Some javadoc. */
   protected class InnerProtected {
     protected void testProtectedInnerMethod() {}
 
@@ -105,14 +105,14 @@ public class InputMissingJavadocTypeCorrect {
     private InnerProtected(double arg) {}
   }
 
-  /** some javadoc. */
+  /** Some javadoc. */
   public enum MyEnumPublic2 {
     TEST;
 
-    /** some javadoc. */
+    /** Some javadoc. */
     public void testPublicEnumMethod() {}
 
-    /** some javadoc. */
+    /** Some javadoc. */
     protected void testProtectedEnumMethod() {}
 
     private void testPrivateEnumMethod() {}
@@ -124,7 +124,7 @@ public class InputMissingJavadocTypeCorrect {
     MyEnumPublic2(String arg) {}
   }
 
-  /** some javadoc. */
+  /** Some javadoc. */
   protected enum MyEnumProtected {
     TEST;
 
@@ -141,7 +141,7 @@ public class InputMissingJavadocTypeCorrect {
     MyEnumProtected(String arg) {}
   }
 
-  /** some javadoc. */
+  /** Some javadoc. */
   protected interface MyInterfaceProtected {
     public void testPublicInterfaceMethod();
 
@@ -150,14 +150,14 @@ public class InputMissingJavadocTypeCorrect {
     void testPackagePrivateInterfaceMethod();
   }
 
-  /** some javadoc. */
+  /** Some javadoc. */
   public interface MyInterfacePublic2 {
-    /** some javadoc. */
+    /** Some javadoc. */
     public void testPublicInterfaceMethod();
 
     private void testPrivateInterfaceMethod() {}
 
-    /** some javadoc. */
+    /** Some javadoc. */
     void testPackagePrivateInterfaceMethod();
   }
 }

--- a/src/it/resources/com/google/checkstyle/test/chapter7javadoc/rule73wherejavadocrequired/InputMissingJavadocTypeIncorrect.java
+++ b/src/it/resources/com/google/checkstyle/test/chapter7javadoc/rule73wherejavadocrequired/InputMissingJavadocTypeIncorrect.java
@@ -27,7 +27,7 @@ public class InputMissingJavadocTypeIncorrect {
   // violation below 'Missing a Javadoc comment.'
   protected @interface MyAnnotationProtected {}
 
-  /** some javadoc. */
+  /** Some javadoc. */
   public void myMethod() {
     class MyMethodClass {}
   }

--- a/src/main/resources/google_checks.xml
+++ b/src/main/resources/google_checks.xml
@@ -395,7 +395,7 @@
     <module name="JavadocTagContinuationIndentation"/>
     <module name="SummaryJavadoc">
       <property name="forbiddenSummaryFragments"
-               value="^@return the *|^This method returns |^A [{]@code [a-zA-Z0-9]+[}]( is a )"/>
+        value="^@return the *|^This method returns |^A [{]@code [a-zA-Z0-9]+[}]( is a )|^[a-z]"/>
     </module>
     <module name="JavadocParagraph">
       <property name="allowNewlineParagraph" value="false"/>


### PR DESCRIPTION
Issue: #17727

The default `google_checks.xml` configuration does not enforce the Google Style Guide rule that Javadoc summary fragments must start with a capital letter. This leads to false negatives where Javadoc summaries beginning with lowercase letters (for example, "adds an element to the list.") are not marked as violations, even though the Google Style Guide states that summaries should be "capitalized and punctuated as if it were a complete sentence."

I added the regex pattern `|^\s*[a-z]` to the `forbiddenSummaryFragments` property in the `SummaryJavadoc` check configuration. This pattern detects Javadoc summaries that start with optional whitespace followed by a lowercase letter, ensuring that lowercase beginnings in Javadoc are marked as violations according to the Google Style Guide.
