### PR TITLE
Issue #17437: Add new skipAnnotations property to NoLineWrapCheck

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/whitespace/NoLineWrapCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/whitespace/NoLineWrapCheck.java
@@ -23,6 +23,7 @@ import com.puppycrawl.tools.checkstyle.StatelessCheck;
 import com.puppycrawl.tools.checkstyle.api.AbstractCheck;
 import com.puppycrawl.tools.checkstyle.api.DetailAST;
 import com.puppycrawl.tools.checkstyle.api.TokenTypes;
+import com.puppycrawl.tools.checkstyle.utils.AnnotationUtil;
 import com.puppycrawl.tools.checkstyle.utils.CommonUtil;
 import com.puppycrawl.tools.checkstyle.utils.TokenUtil;
 
@@ -44,10 +45,26 @@ public class NoLineWrapCheck extends AbstractCheck {
     public static final String MSG_KEY = "no.line.wrap";
 
     /**
+     * Property that defines whether annotations on the previous line should be
+     * checked as violation.
+     */
+    private boolean skipAnnotations = true;
+
+    /**
      * Creates a new {@code NoLineWrapCheck} instance.
      */
     public NoLineWrapCheck() {
         // no code by default
+    }
+
+    /**
+     * Setter to specify whether to skip annotations to be part of target token.
+     *
+     * @param shouldSkipAnnotations whether to skip annotations to be part of target token.
+     * @since 13.9.0
+     */
+    public void setSkipAnnotations(boolean shouldSkipAnnotations) {
+        skipAnnotations = shouldSkipAnnotations;
     }
 
     @Override
@@ -84,7 +101,11 @@ public class NoLineWrapCheck extends AbstractCheck {
 
     @Override
     public void visitToken(DetailAST ast) {
-        if (!TokenUtil.areOnSameLine(ast, ast.getLastChild())) {
+        DetailAST detailAST = ast;
+        if (skipAnnotations && AnnotationUtil.containsAnnotation(ast)) {
+            detailAST = AnnotationUtil.getAnnotationHolder(ast).getNextSibling();
+        }
+        if (!TokenUtil.areOnSameLine(detailAST, ast.getLastChild())) {
             log(ast, MSG_KEY, ast.getText());
         }
     }

--- a/src/main/resources/com/puppycrawl/tools/checkstyle/meta/checks/whitespace/NoLineWrapCheck.xml
+++ b/src/main/resources/com/puppycrawl/tools/checkstyle/meta/checks/whitespace/NoLineWrapCheck.xml
@@ -9,6 +9,9 @@
  but it's possible to check any statement.
  &lt;/div&gt;</description>
          <properties>
+            <property default-value="true" name="skipAnnotations" type="boolean">
+               <description>Specify whether to skip annotations to be part of target token.</description>
+            </property>
             <property default-value="PACKAGE_DEF,IMPORT,STATIC_IMPORT,MODULE_IMPORT"
                       name="tokens"
                       type="java.lang.String[]"

--- a/src/site/xdoc/checks/whitespace/nolinewrap.xml
+++ b/src/site/xdoc/checks/whitespace/nolinewrap.xml
@@ -26,6 +26,13 @@
               <th>since</th>
             </tr>
             <tr>
+              <td><a id="skipAnnotations"/><a href="#skipAnnotations">skipAnnotations</a></td>
+              <td>Specify whether to skip annotations to be part of target token.</td>
+              <td><a href="../../property_types.html#boolean">boolean</a></td>
+              <td><code>true</code></td>
+              <td>13.9.0</td>
+            </tr>
+            <tr>
               <td><a id="tokens"/><a href="#tokens">tokens</a></td>
               <td>tokens to check</td>
               <td>subset of tokens
@@ -102,6 +109,8 @@ class
     Example1() {}
   public void
     doSomething() {}
+  @Deprecated
+  private void doNothing() {}
 }
 </code></pre></div><hr class="example-separator"/>
         <p id="Example2-config">
@@ -137,6 +146,8 @@ class
     Example2() {}
   public void
     doSomething() {}
+  @Deprecated
+  private void doNothing() {}
 }
 </code></pre></div><hr class="example-separator"/>
         <p id="Example3-config">
@@ -168,6 +179,44 @@ import module
 // violation below 'should not be line-wrapped'
 import static java.math.
   BigInteger.ZERO;
+</code></pre></div><hr class="example-separator"/>
+        <p id="Example4-config">
+          To configure the check to force no line-wrapping annotations:
+        </p>
+        <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
+&lt;module name="Checker"&gt;
+  &lt;module name="TreeWalker"&gt;
+    &lt;module name="NoLineWrap"&gt;
+      &lt;property name="tokens" value="IMPORT, STATIC_IMPORT,
+      PACKAGE_DEF, CLASS_DEF, METHOD_DEF, CTOR_DEF"/&gt;
+      &lt;property name="skipAnnotations" value="false"/&gt;
+    &lt;/module&gt;
+  &lt;/module&gt;
+&lt;/module&gt;
+</code></pre></div>
+        <p id="Example4-code">
+          Example:
+        </p>
+        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+package com.puppycrawl.      // violation 'should not be line-wrapped'
+  tools.checkstyle.checks.whitespace.nolinewrap;
+
+import com.puppycrawl.tools. // violation 'should not be line-wrapped'
+  checkstyle.api.AbstractCheck;
+
+import static java.math.     // violation 'should not be line-wrapped'
+  BigInteger.ZERO;
+
+class                        // violation 'should not be line-wrapped'
+  Example4 {
+
+  public                     // violation 'should not be line-wrapped'
+    Example4() {}
+  public void                // violation 'should not be line-wrapped'
+    doSomething() {}
+  @Deprecated                // violation 'should not be line-wrapped'
+  private void doNothing() {}
+}
 </code></pre></div><hr class="example-separator"/>
       </subsection>
 

--- a/src/site/xdoc/checks/whitespace/nolinewrap.xml.template
+++ b/src/site/xdoc/checks/whitespace/nolinewrap.xml.template
@@ -78,6 +78,22 @@
           value="resources-noncompilable/com/puppycrawl/tools/checkstyle/checks/whitespace/nolinewrap/Example3.java"/>
           <param name="type" value="code"/>
         </macro><hr class="example-separator"/>
+        <p id="Example4-config">
+          To configure the check to force no line-wrapping annotations:
+        </p>
+        <macro name="example">
+          <param name="path"
+                 value="resources/com/puppycrawl/tools/checkstyle/checks/whitespace/nolinewrap/Example4.java"/>
+          <param name="type" value="config"/>
+        </macro>
+        <p id="Example4-code">
+          Example:
+        </p>
+        <macro name="example">
+          <param name="path"
+                 value="resources/com/puppycrawl/tools/checkstyle/checks/whitespace/nolinewrap/Example4.java"/>
+          <param name="type" value="code"/>
+        </macro><hr class="example-separator"/>
       </subsection>
 
       <subsection name="Use Cases" id="NoLineWrap_Use_Cases">

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/whitespace/NoLineWrapCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/whitespace/NoLineWrapCheckTest.java
@@ -56,11 +56,11 @@ public class NoLineWrapCheckTest
     public void testCustomTokensLineWrapping()
             throws Exception {
         final String[] expected = {
-            "13:1: " + getCheckMessage(MSG_KEY, "import"),
-            "17:1: " + getCheckMessage(MSG_KEY, "import"),
-            "20:1: " + getCheckMessage(MSG_KEY, "CLASS_DEF"),
-            "23:9: " + getCheckMessage(MSG_KEY, "METHOD_DEF"),
-            "30:1: " + getCheckMessage(MSG_KEY, "ENUM_DEF"),
+            "14:1: " + getCheckMessage(MSG_KEY, "import"),
+            "18:1: " + getCheckMessage(MSG_KEY, "import"),
+            "21:1: " + getCheckMessage(MSG_KEY, "CLASS_DEF"),
+            "24:9: " + getCheckMessage(MSG_KEY, "METHOD_DEF"),
+            "31:1: " + getCheckMessage(MSG_KEY, "ENUM_DEF"),
         };
         verifyWithInlineConfigParser(
                 getPath("InputNoLineWrapBad2.java"), expected);
@@ -71,15 +71,15 @@ public class NoLineWrapCheckTest
             throws Exception {
 
         final String[] expected = {
-            "13:9: " + getCheckMessage(MSG_KEY, "CTOR_DEF"),
-            "19:5: " + getCheckMessage(MSG_KEY, "RECORD_DEF"),
-            "28:9: " + getCheckMessage(MSG_KEY, "CTOR_DEF"),
-            "34:5: " + getCheckMessage(MSG_KEY, "RECORD_DEF"),
-            "36:9: " + getCheckMessage(MSG_KEY, "COMPACT_CTOR_DEF"),
-            "41:5: " + getCheckMessage(MSG_KEY, "RECORD_DEF"),
-            "43:9: " + getCheckMessage(MSG_KEY, "COMPACT_CTOR_DEF"),
-            "48:9: " + getCheckMessage(MSG_KEY, "RECORD_DEF"),
-            "50:13: " + getCheckMessage(MSG_KEY, "COMPACT_CTOR_DEF"),
+            "14:9: " + getCheckMessage(MSG_KEY, "CTOR_DEF"),
+            "20:5: " + getCheckMessage(MSG_KEY, "RECORD_DEF"),
+            "29:9: " + getCheckMessage(MSG_KEY, "CTOR_DEF"),
+            "35:5: " + getCheckMessage(MSG_KEY, "RECORD_DEF"),
+            "37:9: " + getCheckMessage(MSG_KEY, "COMPACT_CTOR_DEF"),
+            "42:5: " + getCheckMessage(MSG_KEY, "RECORD_DEF"),
+            "44:9: " + getCheckMessage(MSG_KEY, "COMPACT_CTOR_DEF"),
+            "49:9: " + getCheckMessage(MSG_KEY, "RECORD_DEF"),
+            "51:13: " + getCheckMessage(MSG_KEY, "COMPACT_CTOR_DEF"),
         };
         verifyWithInlineConfigParser(
                 getPath("InputNoLineWrapRecordsAndCompactCtors.java"),
@@ -89,11 +89,34 @@ public class NoLineWrapCheckTest
     @Test
     public void testNoLineWrapModuleImport() throws Exception {
         final String[] expected = {
-            "14:1: " + getCheckMessage(MSG_KEY, "import"),
-            "21:1: " + getCheckMessage(MSG_KEY, "import"),
+            "15:1: " + getCheckMessage(MSG_KEY, "import"),
+            "22:1: " + getCheckMessage(MSG_KEY, "import"),
         };
         verifyWithInlineConfigParser(
                 getNonCompilablePath("InputNoLineWrapModuleImport.java"), expected);
+    }
+
+    @Test
+    public void testNoLineWrapWithSkipAnnotationsFalse() throws Exception {
+        final String[] expected = {
+            "10:1: " + getCheckMessage(MSG_KEY, "CLASS_DEF"),
+            "14:5: " + getCheckMessage(MSG_KEY, "CTOR_DEF"),
+            "19:5: " + getCheckMessage(MSG_KEY, "METHOD_DEF"),
+            "25:5: " + getCheckMessage(MSG_KEY, "ENUM_DEF"),
+            "31:5: " + getCheckMessage(MSG_KEY, "RECORD_DEF"),
+            "34:9: " + getCheckMessage(MSG_KEY, "COMPACT_CTOR_DEF"),
+        };
+        verifyWithInlineConfigParser(
+                getPath("InputNoLineWrapSkipAnnotationsFalse.java"), expected);
+    }
+
+    @Test
+    public void testNoLineWrapWithSkipAnnotationsTrue() throws Exception {
+        final String[] expected = {
+            "22:5: " + getCheckMessage(MSG_KEY, "METHOD_DEF"),
+        };
+        verifyWithInlineConfigParser(
+                getPath("InputNoLineWrapSkipAnnotationsTrue.java"), expected);
     }
 
 }

--- a/src/test/resources-noncompilable/com/puppycrawl/tools/checkstyle/checks/whitespace/nolinewrap/InputNoLineWrapModuleImport.java
+++ b/src/test/resources-noncompilable/com/puppycrawl/tools/checkstyle/checks/whitespace/nolinewrap/InputNoLineWrapModuleImport.java
@@ -1,6 +1,7 @@
 /*
 NoLineWrap
 tokens = (default)PACKAGE_DEF, IMPORT, STATIC_IMPORT, MODULE_IMPORT
+skipAnnotations = (default)true
 
 
 */
@@ -21,5 +22,6 @@ import java.util.List;
 import
     java.util.Map;
 
+@Deprecated
 public class InputNoLineWrapModuleImport {
 }

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/whitespace/nolinewrap/InputNoLineWrapBad.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/whitespace/nolinewrap/InputNoLineWrapBad.java
@@ -1,7 +1,7 @@
 /*
 NoLineWrap
 tokens = (default)PACKAGE_DEF, IMPORT, STATIC_IMPORT, MODULE_IMPORT
-
+skipAnnotations = (default)true
 
 */
 

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/whitespace/nolinewrap/InputNoLineWrapBad2.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/whitespace/nolinewrap/InputNoLineWrapBad2.java
@@ -1,6 +1,7 @@
 /*
 NoLineWrap
 tokens = IMPORT, STATIC_IMPORT, CLASS_DEF, METHOD_DEF, ENUM_DEF
+skipAnnotations = (default)true
 
 
 */

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/whitespace/nolinewrap/InputNoLineWrapGood.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/whitespace/nolinewrap/InputNoLineWrapGood.java
@@ -1,6 +1,7 @@
 /*
 NoLineWrap
 tokens = (default)PACKAGE_DEF, IMPORT, STATIC_IMPORT, MODULE_IMPORT
+skipAnnotations = (default)true
 
 
 */

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/whitespace/nolinewrap/InputNoLineWrapRecordsAndCompactCtors.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/whitespace/nolinewrap/InputNoLineWrapRecordsAndCompactCtors.java
@@ -1,6 +1,7 @@
 /*
 NoLineWrap
 tokens = RECORD_DEF, CLASS_DEF, CTOR_DEF, COMPACT_CTOR_DEF
+skipAnnotations = (default)true
 
 
 */

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/whitespace/nolinewrap/InputNoLineWrapSkipAnnotationsFalse.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/whitespace/nolinewrap/InputNoLineWrapSkipAnnotationsFalse.java
@@ -1,0 +1,38 @@
+/*
+NoLineWrap
+tokens = CLASS_DEF, METHOD_DEF, CTOR_DEF, ENUM_DEF, INTERFACE_DEF, RECORD_DEF, COMPACT_CTOR_DEF
+skipAnnotations = false
+
+*/
+
+package com.puppycrawl.tools.checkstyle.checks.whitespace.nolinewrap;
+// violation below 'CLASS_DEF statement should not be line-wrapped.'
+@SuppressWarnings("unused")
+public class InputNoLineWrapSkipAnnotationsFalse {
+
+    // violation below 'CTOR_DEF statement should not be line-wrapped.'
+    @Deprecated
+    public InputNoLineWrapSkipAnnotationsFalse() {
+    }
+
+    // violation below 'METHOD_DEF statement should not be line-wrapped.'
+    @SafeVarargs
+    public final <T> void foo(T... elements) {
+
+    }
+
+    // violation below 'ENUM_DEF statement should not be line-wrapped.'
+    @Deprecated
+    public enum InputNoLineWrapSkipAnnotationsFalseEnum {
+        FOO
+    }
+
+    // violation below 'RECORD_DEF statement should not be line-wrapped.'
+    @Deprecated
+    public record InputNoLineWrapSkipAnnotationsFalseRecord(String foo) {
+        // violation below 'COMPACT_CTOR_DEF statement should not be line-wrapped.'
+        @Deprecated
+        public InputNoLineWrapSkipAnnotationsFalseRecord {
+        }
+    }
+}

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/whitespace/nolinewrap/InputNoLineWrapSkipAnnotationsTrue.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/whitespace/nolinewrap/InputNoLineWrapSkipAnnotationsTrue.java
@@ -1,0 +1,39 @@
+/*
+NoLineWrap
+tokens = CLASS_DEF, METHOD_DEF, CTOR_DEF, ENUM_DEF, INTERFACE_DEF, RECORD_DEF, COMPACT_CTOR_DEF
+skipAnnotations = (default)true
+
+*/
+
+package com.puppycrawl.tools.checkstyle.checks.whitespace.nolinewrap;
+@SuppressWarnings("unused")
+public class InputNoLineWrapSkipAnnotationsTrue {
+
+    @Deprecated
+    public InputNoLineWrapSkipAnnotationsTrue() {
+    }
+
+    @SafeVarargs
+    public final <T> void foo(T... elements) {
+
+    }
+
+    // violation below 'METHOD_DEF statement should not be line-wrapped.'
+    @SafeVarargs
+    public final <T>
+      void bar(T... elements) {
+
+    }
+
+    @Deprecated
+    public enum InputNoLineWrapAnnotationsEnum {
+        FOO
+    }
+
+    @Deprecated
+    public record InputNoLineWrapAnnotationRecord(String foo) {
+        @Deprecated
+        public InputNoLineWrapAnnotationRecord {
+        }
+    }
+}

--- a/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/checks/whitespace/NoLineWrapExamplesTest.java
+++ b/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/checks/whitespace/NoLineWrapExamplesTest.java
@@ -64,6 +64,21 @@ public class NoLineWrapExamplesTest extends AbstractExamplesModuleTestSupport {
     }
 
     @Test
+    public void testExample4() throws Exception {
+        final String[] expected = {
+            "14:1: " + getCheckMessage(MSG_KEY, "package"),
+            "17:1: " + getCheckMessage(MSG_KEY, "import"),
+            "20:1: " + getCheckMessage(MSG_KEY, "import"),
+            "23:1: " + getCheckMessage(MSG_KEY, "CLASS_DEF"),
+            "26:3: " + getCheckMessage(MSG_KEY, "CTOR_DEF"),
+            "28:3: " + getCheckMessage(MSG_KEY, "METHOD_DEF"),
+            "30:3: " + getCheckMessage(MSG_KEY, "METHOD_DEF"),
+        };
+
+        verifyWithInlineConfigParser(getPath("Example4.java"), expected);
+    }
+
+    @Test
     public void testUseCase1() throws Exception {
         final String[] expected = {
             "21:1: " + getCheckMessage(MSG_KEY, "CLASS_DEF"),

--- a/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/whitespace/nolinewrap/Example1.java
+++ b/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/whitespace/nolinewrap/Example1.java
@@ -23,5 +23,7 @@ class
     Example1() {}
   public void
     doSomething() {}
+  @Deprecated
+  private void doNothing() {}
 }
 // xdoc section -- end

--- a/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/whitespace/nolinewrap/Example2.java
+++ b/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/whitespace/nolinewrap/Example2.java
@@ -25,5 +25,7 @@ class
     Example2() {}
   public void
     doSomething() {}
+  @Deprecated
+  private void doNothing() {}
 }
 // xdoc section -- end

--- a/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/whitespace/nolinewrap/Example4.java
+++ b/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/whitespace/nolinewrap/Example4.java
@@ -1,0 +1,33 @@
+/*xml
+<module name="Checker">
+  <module name="TreeWalker">
+    <module name="NoLineWrap">
+      <property name="tokens" value="IMPORT, STATIC_IMPORT,
+      PACKAGE_DEF, CLASS_DEF, METHOD_DEF, CTOR_DEF"/>
+      <property name="skipAnnotations" value="false"/>
+    </module>
+  </module>
+</module>
+*/
+
+// xdoc section -- start
+package com.puppycrawl.      // violation 'should not be line-wrapped'
+  tools.checkstyle.checks.whitespace.nolinewrap;
+
+import com.puppycrawl.tools. // violation 'should not be line-wrapped'
+  checkstyle.api.AbstractCheck;
+
+import static java.math.     // violation 'should not be line-wrapped'
+  BigInteger.ZERO;
+
+class                        // violation 'should not be line-wrapped'
+  Example4 {
+
+  public                     // violation 'should not be line-wrapped'
+    Example4() {}
+  public void                // violation 'should not be line-wrapped'
+    doSomething() {}
+  @Deprecated                // violation 'should not be line-wrapped'
+  private void doNothing() {}
+}
+// xdoc section -- end


### PR DESCRIPTION
Issue #17437: Add new property `skipAnnotations` with default value `true`

```plain
cat config.xml
<?xml version="1.0"?>
<!DOCTYPE module PUBLIC
  "-//Checkstyle//DTD Checkstyle Configuration 1.3//EN"
  "https://checkstyle.org/dtds/configuration_1_3.dtd">
<module name="Checker">
  <module name="TreeWalker">
        <module name="NoLineWrap">
      <property name="tokens" value="IMPORT, STATIC_IMPORT, PACKAGE_DEF, CLASS_DEF
   , METHOD_DEF, CTOR_DEF, ENUM_DEF, INTERFACE_DEF
   , RECORD_DEF, COMPACT_CTOR_DEF"/>
    </module>
  </module>
</module>

cat Test.java
@Deprecated
public class Test {
}

java -jar checkstyle-12.2.1-SNAPSHOT-all.jar -c config.xml Test.java
Starting audit...
Audit done.
```

Diff Regression config: https://gist.githubusercontent.com/ivamly/1d1a764194b49d0ca6d62bbe3b71d293/raw/995288d228057586a253a9c551e142370a95b5b7/my_checks.xml
Diff Regression patch config: https://gist.githubusercontent.com/mahfouz72/33967bf86e4a29cafa429771b0e95808/raw/3214b2640cd3f82b3bb2f5415e2873bf415c084f/check_patch.xml