### PR TITLE
Issue #15456: Define violation messages for IllegalTypeCheck

### DIFF
--- a/src/test/java/com/puppycrawl/tools/checkstyle/bdd/InlineConfigParser.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/bdd/InlineConfigParser.java
@@ -239,7 +239,6 @@ public final class InlineConfigParser {
             "com.puppycrawl.tools.checkstyle.checks.coding.ExplicitInitializationCheck",
             "com.puppycrawl.tools.checkstyle.checks.coding.IllegalInstantiationCheck",
             "com.puppycrawl.tools.checkstyle.checks.coding.IllegalTokenTextCheck",
-            "com.puppycrawl.tools.checkstyle.checks.coding.IllegalTypeCheck",
             "com.puppycrawl.tools.checkstyle.checks.coding.MatchXpathCheck",
             "com.puppycrawl.tools.checkstyle.checks.coding.ModifiedControlVariableCheck",
             "com.puppycrawl.tools.checkstyle.checks.coding.MultipleStringLiteralsCheck",


### PR DESCRIPTION
Issue #15456

Just removing the IllegalTypeCheck from InlineConfigParser.java

## **Why such a small change:**
I was initially confused as to why it's still passing checks after removing IllegalTypeCheck from InlineConfigParser.java.
I tried running `./mvnw clean test -Dtest=IllegalTypeCheckTest` and other relevant commands (as shown in the picture), it passed all the tests.  

<img width="1259" height="377" alt="Screenshot From 2025-12-05 06-19-15 (Copy)" src="https://github.com/user-attachments/assets/4026c418-d969-4173-9cf7-0a74ade850b8" />

After a while, I assumed maybe the tests must be fixed already that's why they're passing. As shown here in the commit: https://github.com/checkstyle/checkstyle/commit/90158f09926eb1f7d89edd55720747e68112f603 (not in this specific commit, but we see that appropriate violation messages are already in place when clicking on a ExampleX.java)

The changes have already been done by someone else.

Thus I'm only removing the line from InlineConfigParser.java as merely a cleanup act. I suspect there might be more such cases, thus I'll keep making PRs and keep checking. Cheers