### PR TITLE
Issue #17951: Improve exception message for basedir path mismatch

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/Checker.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/Checker.java
@@ -376,7 +376,7 @@ public class Checker extends AbstractAutomaticBean implements MessageDispatcher,
      * @return {@code true} if the file is accepted.
      */
     private boolean acceptFileStarted(String fileName) {
-        final String stripped = CommonUtil.relativizePath(basedir, fileName);
+        final String stripped = relativizePathWithCatch(fileName);
         return beforeExecutionFileFilters.accept(stripped);
     }
 
@@ -388,7 +388,7 @@ public class Checker extends AbstractAutomaticBean implements MessageDispatcher,
      */
     @Override
     public void fireFileStarted(String fileName) {
-        final String stripped = CommonUtil.relativizePath(basedir, fileName);
+        final String stripped = relativizePathWithCatch(fileName);
         final AuditEvent event = new AuditEvent(this, stripped);
         for (final AuditListener listener : listeners) {
             listener.fileStarted(event);
@@ -403,7 +403,7 @@ public class Checker extends AbstractAutomaticBean implements MessageDispatcher,
      */
     @Override
     public void fireErrors(String fileName, SortedSet<Violation> errors) {
-        final String stripped = CommonUtil.relativizePath(basedir, fileName);
+        final String stripped = relativizePathWithCatch(fileName);
         boolean hasNonFilteredViolations = false;
         for (final Violation element : errors) {
             final AuditEvent event = new AuditEvent(this, stripped, element);
@@ -427,7 +427,7 @@ public class Checker extends AbstractAutomaticBean implements MessageDispatcher,
      */
     @Override
     public void fireFileFinished(String fileName) {
-        final String stripped = CommonUtil.relativizePath(basedir, fileName);
+        final String stripped = relativizePathWithCatch(fileName);
         final AuditEvent event = new AuditEvent(this, stripped);
         for (final AuditListener listener : listeners) {
             listener.fileFinished(event);
@@ -662,6 +662,25 @@ public class Checker extends AbstractAutomaticBean implements MessageDispatcher,
                     messageKey, args);
 
         return localizedMessage.getMessage();
+    }
+
+    /**
+     * Relativizes a path and wraps any exception with a user-friendly localized message.
+     *
+     * @param fileName the file path to relativize
+     * @return the relativized path
+     * @throws IllegalStateException if any exception occurs during relativization
+     */
+    private String relativizePathWithCatch(String fileName) {
+        try {
+            return CommonUtil.relativizePath(basedir, fileName);
+        }
+        // -@cs[IllegalCatch] Catching generic Exception to include fileName and basedir context
+        catch (Exception exception) {
+            throw new IllegalStateException(
+                getLocalizedMessage("general.relativizePath",
+                        fileName, basedir), exception);
+        }
     }
 
 }

--- a/src/main/resources/com/puppycrawl/tools/checkstyle/messages.properties
+++ b/src/main/resources/com/puppycrawl/tools/checkstyle/messages.properties
@@ -16,6 +16,7 @@ DefaultLogger.errorStreamException=Parameter errorStreamOptions can not be null
 DefaultLogger.infoStreamException=Parameter infoStreamOptions can not be null
 general.exception=Got an exception - {0}
 general.fileNotFound=File not found!
+general.relativizePath=Failed to relativize path ''{0}'' against base directory ''{1}'' (configured via ''basedir'' property). Please ensure the base directory path matches the current OS/path type.
 Main.createListener=Invalid output format. Found ''{0}'' but expected ''{1}'' or ''{2}''.
 Main.errorCounter=Checkstyle ends with {0} errors.
 Main.loadProperties=Unable to load properties from file ''{0}''.

--- a/src/main/resources/com/puppycrawl/tools/checkstyle/messages_de.properties
+++ b/src/main/resources/com/puppycrawl/tools/checkstyle/messages_de.properties
@@ -17,6 +17,7 @@ DefaultLogger.errorStreamException=Der Parameter errorStreamOptions darf nicht n
 DefaultLogger.infoStreamException=Der Parameter infoStreamOptions darf nicht null sein
 general.exception=Ein Fehler ist aufgetreten - {0}
 general.fileNotFound=Datei nicht gefunden!
+general.relativizePath=Der Pfad ''{0}'' konnte nicht relativ zum Basisverzeichnis ''{1}'' (konfiguriert über ''basedir''-Eigenschaft) aufgelöst werden. Bitte stellen Sie sicher, dass der Basisverzeichnispfad zum aktuellen Betriebssystem/Pfadtyp passt.
 Main.createListener=Ungültiges Ausgabeformat. Gefunden ''{0}'', aber ''{1}'' oder ''{2}'' erwartet.
 Main.errorCounter=Checkstyle endet mit {0} Fehlern.
 Main.loadProperties=Die Eigenschaften von Datei ''{0}'' können nicht geladen werden.

--- a/src/main/resources/com/puppycrawl/tools/checkstyle/messages_es.properties
+++ b/src/main/resources/com/puppycrawl/tools/checkstyle/messages_es.properties
@@ -17,6 +17,7 @@ DefaultLogger.errorStreamException=El parámetro errorStreamOptions no puede ser
 DefaultLogger.infoStreamException=El parámetro infoStreamOptions no puede ser nulos
 general.exception=Ocurrió una excepción - {0}
 general.fileNotFound=¡Fichero no encontrado!
+general.relativizePath=No se pudo relativizar la ruta ''{0}'' respecto al directorio base ''{1}'' (configurado mediante la propiedad ''basedir''). Asegúrese de que la ruta del directorio base coincida con el sistema operativo/tipo de ruta actual.
 Main.createListener=Formato de salida no válido. Encontrado ''{0}'' pero esperado ''{1}'' o ''{2}''.
 Main.errorCounter=Checkstyle termina con {0} errores.
 Main.loadProperties=No se pueden cargar las propiedades del archivo ''{0}''.

--- a/src/main/resources/com/puppycrawl/tools/checkstyle/messages_fi.properties
+++ b/src/main/resources/com/puppycrawl/tools/checkstyle/messages_fi.properties
@@ -17,6 +17,7 @@ DefaultLogger.errorStreamException=Parametri errorStreamOptions ei voi olla null
 DefaultLogger.infoStreamException=Parametri infoStreamOptions ei voi olla null
 general.exception=Poikkeus - {0}
 general.fileNotFound=Tiedostoa ei löydy!
+general.relativizePath=Polkua ''{0}'' ei voitu suhteuttaa kansioon ''{1}'' (määritetty ''basedir''-ominaisuudella). Varmista, että kansion polku vastaa nykyistä käyttöjärjestelmää/polkutyyppiä.
 Main.createListener=Virheellinen tulostusmuoto. Löytyi ''{0}'' mutta odotti ''{1}'' tai ''{2}''.
 Main.errorCounter=Checkstyle päättyy {0} virheellä.
 Main.loadProperties=Ominaisuuksia ei voi ladata tiedostosta ''{0}''.

--- a/src/main/resources/com/puppycrawl/tools/checkstyle/messages_fr.properties
+++ b/src/main/resources/com/puppycrawl/tools/checkstyle/messages_fr.properties
@@ -17,6 +17,7 @@ DefaultLogger.errorStreamException=Le paramètre errorStreamOptions ne peut pas 
 DefaultLogger.infoStreamException=Le paramètre infoStreamOptions ne peut pas être nul
 general.exception=Exception levée : {0}
 general.fileNotFound=Fichier non trouvé !
+general.relativizePath=Impossible de relativiser le chemin ''{0}'' par rapport au répertoire de base ''{1}'' (configuré via la propriété ''basedir''). Veuillez vous assurer que le chemin du répertoire de base correspond au système d''exploitation/type de chemin actuel.
 Main.createListener=Format de sortie invalide. Trouvé ''{0}'' mais attendu ''{1}'' ou ''{2}''.
 Main.errorCounter=Checkstyle se termine par {0} erreurs.
 Main.loadProperties=Impossible de charger des propriétés à partir du fichier ''{0}''.

--- a/src/main/resources/com/puppycrawl/tools/checkstyle/messages_ja.properties
+++ b/src/main/resources/com/puppycrawl/tools/checkstyle/messages_ja.properties
@@ -17,6 +17,7 @@ DefaultLogger.errorStreamException=パラメータ errorStreamOptions を null �
 DefaultLogger.infoStreamException=パラメータ infoStreamOptions を null にすることはできません
 general.exception=例外が発生しました - {0}
 general.fileNotFound=ファイルが見つかりません！
+general.relativizePath=パス ''{0}'' をベースディレクトリ ''{1}'' (''basedir'' プロパティで設定) に対して相対化できませんでした。ベースディレクトリのパスが現在のOS/パスタイプと一致していることを確認してください。
 Main.createListener=無効な出力形式です。''{0}'' 名が見つかりましたが、''{1}'' 名か ''{2}'' 名です。
 Main.errorCounter=Checkstyleは {0} 個のエラーで終了します。
 Main.loadProperties=ファイル ''{0}'' からプロパティを読み込めません。

--- a/src/main/resources/com/puppycrawl/tools/checkstyle/messages_pt.properties
+++ b/src/main/resources/com/puppycrawl/tools/checkstyle/messages_pt.properties
@@ -17,6 +17,7 @@ DefaultLogger.errorStreamException=O parâmetro errorStreamOptions não pode ser
 DefaultLogger.infoStreamException=O parâmetro infoStreamOptions não pode ser nulo
 general.exception=Foi capturada uma exceção - {0}
 general.fileNotFound=Arquivo não encontrado!
+general.relativizePath=Falha ao relativizar o caminho ''{0}'' em relação ao diretório base ''{1}'' (configurado pela propriedade ''basedir''). Certifique-se de que o caminho do diretório base corresponda ao sistema operacional/tipo de caminho atual.
 Main.createListener=O formato de saída é inválido. Foi encontrado ''{0}'', mas esperava ''{1}'' ou ''{2}''.
 Main.errorCounter=O Checkstyle terminou com {0} erros.
 Main.loadProperties=Não foi possível carregar propriedades do arquivo ''{0}''.

--- a/src/main/resources/com/puppycrawl/tools/checkstyle/messages_ru.properties
+++ b/src/main/resources/com/puppycrawl/tools/checkstyle/messages_ru.properties
@@ -17,6 +17,7 @@ DefaultLogger.errorStreamException=Параметр errorStreamOptions не мо
 DefaultLogger.infoStreamException=Параметр infoStreamOptions не может быть равен null
 general.exception=Поймано исключение {0}
 general.fileNotFound=Файл не найден!
+general.relativizePath=Не удалось преобразовать путь ''{0}'' относительно базового каталога ''{1}'' (настроено через свойство ''basedir''). Убедитесь, что путь базового каталога соответствует текущей ОС/типу пути.
 Main.createListener=Недопустимый формат вывода. Найдено ''{0}'', но ожидалось ''{1}'' или ''{2}''.
 Main.errorCounter=Checkstyle заканчивается с количеством ошибок {0}.
 Main.loadProperties=Не удалось загрузить свойства из файла ''{0}''.

--- a/src/main/resources/com/puppycrawl/tools/checkstyle/messages_tr.properties
+++ b/src/main/resources/com/puppycrawl/tools/checkstyle/messages_tr.properties
@@ -16,6 +16,7 @@ DefaultLogger.errorStreamException=Parametre errorStreamOptions null olamaz
 DefaultLogger.infoStreamException=Parametre infoStreamOptions null olamaz
 general.exception=Bir istisna yakalandı - {0}
 general.fileNotFound=Dosya bulunamadı!
+general.relativizePath=''{0}'' yolu, ''{1}'' temel dizinine (''basedir'' özelliği ile yapılandırılmış) göre göreceli hale getirilemedi. Lütfen temel dizin yolunun mevcut işletim sistemi/yol türüyle eşleştiğinden emin olun.
 Main.createListener=Geçersiz çıktı biçimi. ''{0}'' ancak beklenen ''{1}'' veya ''{2}'' bulundu.
 Main.errorCounter=Checkstyle {0} hatayla bitiyor.
 Main.loadProperties=''{0}'' dosyasından özellik yüklenemiyor.

--- a/src/main/resources/com/puppycrawl/tools/checkstyle/messages_zh.properties
+++ b/src/main/resources/com/puppycrawl/tools/checkstyle/messages_zh.properties
@@ -16,6 +16,7 @@ DefaultLogger.errorStreamException=参数 errorStreamOptions 不能为空
 DefaultLogger.infoStreamException=参数 infoStreamOptions 不能为空
 general.exception=异常 - {0}
 general.fileNotFound=找不到文件！
+general.relativizePath=无法将路径 ''{0}'' 相对于基目录 ''{1}''（通过 ''basedir'' 属性配置）进行相对化。请确保基目录路径与当前操作系统/路径类型匹配。
 Main.createListener=非法的输出格式。预期为 ''{1}'' 或 ''{2}''，但实际为 ''{0}''。
 Main.errorCounter=Checkstyle以 {0} 个错误结束。
 Main.loadProperties=无法从文件 ''{0}'' 中加载属性。

--- a/src/test/java/com/puppycrawl/tools/checkstyle/CheckerTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/CheckerTest.java
@@ -25,6 +25,7 @@ import static com.puppycrawl.tools.checkstyle.DefaultLogger.AUDIT_FINISHED_MESSA
 import static com.puppycrawl.tools.checkstyle.DefaultLogger.AUDIT_STARTED_MESSAGE;
 import static com.puppycrawl.tools.checkstyle.checks.NewlineAtEndOfFileCheck.MSG_KEY_NO_NEWLINE_EOF;
 import static com.puppycrawl.tools.checkstyle.checks.sizes.LineLengthCheck.MSG_KEY;
+import static com.puppycrawl.tools.checkstyle.internal.utils.TestUtil.getExpectedThrowable;
 
 import java.io.BufferedReader;
 import java.io.BufferedWriter;
@@ -54,10 +55,13 @@ import java.util.SortedSet;
 import java.util.TreeSet;
 import java.util.UUID;
 
+import org.apache.tools.ant.BuildException;
+import org.apache.tools.ant.Project;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 
 import com.puppycrawl.tools.checkstyle.AbstractAutomaticBean.OutputStreamOptions;
+import com.puppycrawl.tools.checkstyle.ant.CheckstyleAntTask;
 import com.puppycrawl.tools.checkstyle.api.AbstractCheck;
 import com.puppycrawl.tools.checkstyle.api.AbstractFileSetCheck;
 import com.puppycrawl.tools.checkstyle.api.AuditEvent;
@@ -1760,6 +1764,52 @@ public class CheckerTest extends AbstractModuleTestSupport {
 
         verify(createChecker(checkerConfig), processedFiles,
                 tempFile.getName(), expected);
+    }
+
+    @Test
+    public void testBasedirPathMismatchExceptionMessage() throws IOException {
+        final CheckstyleAntTask antTask = new CheckstyleAntTask();
+        antTask.setProject(new Project());
+        antTask.setConfig(getPath("InputCheckerTestConfigBasedirMismatch.xml"));
+
+        final File testFile = Files.createFile(
+            temporaryFolder.toPath().resolve("TestBasedirMismatch.java"))
+            .toFile();
+
+        antTask.setFile(testFile);
+
+        final BuildException ex = getExpectedThrowable(
+            BuildException.class,
+            antTask::execute,
+            "BuildException is expected");
+
+        final IllegalStateException relativizeException = findRelativizePathException(ex);
+        final String message = relativizeException.getMessage();
+
+        assertWithMessage("Exception message should mention failed relativization")
+            .that(message)
+            .contains("Failed to relativize path");
+
+        assertWithMessage("Exception message should mention base directory")
+            .that(message)
+            .contains("base directory");
+
+        assertWithMessage("Exception message should contain the file path")
+            .that(message)
+            .contains(testFile.getAbsolutePath());
+    }
+
+    private static IllegalStateException findRelativizePathException(Throwable throwable) {
+        Throwable current = throwable;
+        while (current != null) {
+            if (current instanceof IllegalStateException exception
+                    && current.getCause() instanceof IllegalArgumentException) {
+                return exception;
+            }
+            current = current.getCause();
+        }
+        throw new AssertionError(
+            "IllegalStateException from CommonUtil.relativizePath not found in cause chain");
     }
 
     public static class DefaultLoggerWithCounter extends DefaultLogger {

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checker/InputCheckerTestConfigBasedirMismatch.xml
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checker/InputCheckerTestConfigBasedirMismatch.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0"?>
+<!DOCTYPE module PUBLIC
+    "-//Checkstyle//DTD Checkstyle Configuration 1.3//EN"
+    "https://checkstyle.org/dtds/configuration_1_3.dtd">
+<module name="Checker">
+    <property name="basedir" value="relative/definitely/invalid/basedir"/>
+</module>


### PR DESCRIPTION
Issue #17951:

### Problem
When the `basedir` property uses a different path type than the files being processed (for example, a Unix path like `/mnt/...` on Windows), users encounter an unclear error:

`IllegalArgumentException: 'other' is different type of Path`

This message does not clearly indicate that the root cause is a mismatch in the `basedir` configuration, making troubleshooting difficult.

### Solution
Wrapped the `IllegalArgumentException` thrown by `Path.relativize()` inside `CommonUtil.relativizePath()` with a clearer, more informative error message that:

- Displays both the file path and base directory values involved
- Guides users to check and align their `basedir` configuration with the current OS/path format

**Improved error message example:**

```
Failed to relativize path 'C:...' against base directory '/mnt/...'.
"(configured via 'basedir' property). "
Please ensure the base directory path matches the current OS/path type.
```

### Changes
- **CommonUtil.java:** Added try-catch around `Path.relativize()` to throw the new informative exception
- **CommonUtilTest.java:** Added a unit test with Mockito to verify that the improved exception message is thrown correctly