### PR TITLE
Issue #17778: Added JavadocMissingLeadingAsterisk and JavadocContentLocation Checks in google_checks.xml for Rule: 7.1.1 General Form

### DIFF
--- a/src/it/resources/com/google/checkstyle/test/chapter7javadoc/rule711generalform/InputCorrectJavadocLeadingAsteriskAlignment.java
+++ b/src/it/resources/com/google/checkstyle/test/chapter7javadoc/rule711generalform/InputCorrectJavadocLeadingAsteriskAlignment.java
@@ -20,13 +20,15 @@ public class InputCorrectJavadocLeadingAsteriskAlignment {
   /** */ // violation "Summary javadoc is missing."
   private String str1;
 
+  // violation 2 lines below "Javadoc line should start with leading asterisk."
   /**
-    No leading asterisk present. False negative until #17778, Subproblem 2.
+    No leading asterisk present.
    */
   public InputCorrectJavadocLeadingAsteriskAlignment() {}
 
-  // violation 2 lines below "Summary javadoc is missing."
-  // violation 2 lines below "Javadoc tag '@param' should be preceded with an empty line."
+  // violation 3 lines below "Summary javadoc is missing."
+  // violation 3 lines below "Javadoc tag '@param' should be preceded with an empty line."
+  // False negative for below javadoc, until #18271
   /***
    * @param a testing....
    */
@@ -35,7 +37,7 @@ public class InputCorrectJavadocLeadingAsteriskAlignment {
   /*************************************************
    *** @param str testing.....
    **********************************/
-  // False negative for above javadoc, until #17778, Subproblem 1 & 3.
+  // False negative for above javadoc, until #18271, #18273.
   public InputCorrectJavadocLeadingAsteriskAlignment(String str) {}
 
   /** * */ // violation "Summary javadoc is missing."
@@ -49,47 +51,51 @@ public class InputCorrectJavadocLeadingAsteriskAlignment {
    */
   private void foo() {}
 
-  /** Opening tag should be alone on line. // False negative until #17778, Subproblem 1.
+  // violation below "Javadoc content should start from the next line."
+  /** Opening tag should be alone on line.
    * This method does nothing.
    */
   private void foo2() {}
 
   /**
    * Javadoc for foo3.
-   Closing tag should be alone on line. */ // False negative until #17778, Subproblem 3.
+   Closing tag should be alone on line. */ // False negative until #18273.
+  // violation above "Javadoc line should start with leading asterisk."
   private void foo3() {
     // foo2 code goes here
   }
 
   /**
    * Javadoc for enum.
-   * */ // False negative until #17778, Subproblem 3.
+   * */ // False negative until #18273.
   private enum CorrectJavadocEnum {
     // violation 2 lines below "Summary javadoc is missing."
-    // False negative until #17778, Subproblem 2.
+    // violation 2 lines below "Javadoc line should start with leading asterisk."
     /**
 
      */
     ONE,
 
-    // False negative until #17778, Subproblem 2.
+    // violation 2 lines below "Javadoc line should start with leading asterisk."
     /**
      Not allowed. No leading asterisk present.
      */
     TWO,
 
-    // False negative until #17778, Subproblem 1 & 2.
+    // violation 2 lines below "Javadoc content should start from the next line."
+    // violation 2 lines below "Javadoc line should start with leading asterisk."
     /** Not allowed. Opening javadoc tag should be alone on line.
 
      */
     THREE,
 
-    // False negative until #17778, Subproblem 3.
+    // False negative until #18273.
     /**
      * Not allowed. Closing javadoc tag should be alone on line. */
     FOUR,
 
-    // violation below "Summary javadoc is missing."
+    // violation 2 lines below "Summary javadoc is missing."
+    // violation 2 lines below "Javadoc line should start with leading asterisk."
     /**
 
      */

--- a/src/it/resources/com/google/checkstyle/test/chapter7javadoc/rule711generalform/InputFormattedCorrectJavadocLeadingAsteriskAlignment.java
+++ b/src/it/resources/com/google/checkstyle/test/chapter7javadoc/rule711generalform/InputFormattedCorrectJavadocLeadingAsteriskAlignment.java
@@ -22,11 +22,12 @@ public class InputFormattedCorrectJavadocLeadingAsteriskAlignment {
   // violation above "Summary javadoc is missing."
   private String str1;
 
-  /** No leading asterisk present. False negative until #17778, Subproblem 2. */
+  /** No leading asterisk present. */
   public InputFormattedCorrectJavadocLeadingAsteriskAlignment() {}
 
-  // violation 2 lines below "Summary javadoc is missing."
-  // violation 2 lines below "Javadoc tag '@param' should be preceded with an empty line."
+  // violation 3 lines below "Summary javadoc is missing."
+  // violation 3 lines below "Javadoc tag '@param' should be preceded with an empty line."
+  // False negative for below javadoc, until #18271
   /***
    * @param a testing....
    */
@@ -35,7 +36,7 @@ public class InputFormattedCorrectJavadocLeadingAsteriskAlignment {
   /*************************************************
    *** @param str testing.....
    **********************************/
-  // False negative for above javadoc, until #17778, Subproblem 1 & 3.
+  // False negative for above javadoc, until #18271, #18273
   public InputFormattedCorrectJavadocLeadingAsteriskAlignment(String str) {}
 
   /** * */
@@ -49,35 +50,26 @@ public class InputFormattedCorrectJavadocLeadingAsteriskAlignment {
   /** This method does nothing. */
   private void foo() {}
 
-  /**
-   * Opening tag should be alone on line. // False negative until #17778, Subproblem 1. This method
-   * Does nothing.
-   */
+  /** Opening tag should be alone on line. This method does nothing. */
   private void foo2() {}
 
   /** Javadoc for foo3. Closing tag should be alone on line. */
-  // False negative until #17778, Subproblem 3.
   private void foo3() {
     // foo2 code goes here
   }
 
   /** Javadoc for enum. */
-  // False negative until #17778, Subproblem 3.
   private enum CorrectJavadocEnum {
-    // violation 2 lines below "Summary javadoc is missing."
-    // False negative until #17778, Subproblem 2.
+    // violation below "Summary javadoc is missing."
     /** */
     ONE,
 
-    // False negative until #17778, Subproblem 2.
     /** Not allowed. No leading asterisk present. */
     TWO,
 
-    // False negative until #17778, Subproblem 1 & 2.
     /** Not allowed. Opening javadoc tag should be alone on line. */
     THREE,
 
-    // False negative until #17778, Subproblem 3.
     /** Not allowed. Closing javadoc tag should be alone on line. */
     FOUR,
 

--- a/src/it/resources/com/google/checkstyle/test/chapter7javadoc/rule711generalform/InputFormattedIncorrectJavadocLeadingAsteriskAlignment.java
+++ b/src/it/resources/com/google/checkstyle/test/chapter7javadoc/rule711generalform/InputFormattedIncorrectJavadocLeadingAsteriskAlignment.java
@@ -29,7 +29,7 @@ public class InputFormattedIncorrectJavadocLeadingAsteriskAlignment {
 
   /** Misaligned leading asterisk. Inner Class. */
   private static class Inner {
-    // No leading asterisk present. False-negative until #17778, Subproblem 2
+
     // violation below "Summary javadoc is missing."
     /** */
     private Object obj;
@@ -47,7 +47,6 @@ public class InputFormattedIncorrectJavadocLeadingAsteriskAlignment {
     /** */
     ONE,
 
-    // Closing tag should be alone on line. False negative until #17778, subproblem 3
     /** Wrong Alignment. */
     TWO
   }

--- a/src/it/resources/com/google/checkstyle/test/chapter7javadoc/rule711generalform/InputIncorrectJavadocLeadingAsteriskAlignment.java
+++ b/src/it/resources/com/google/checkstyle/test/chapter7javadoc/rule711generalform/InputIncorrectJavadocLeadingAsteriskAlignment.java
@@ -59,8 +59,8 @@ public class InputIncorrectJavadocLeadingAsteriskAlignment {
     * Inner Class. */
   // violation above 'Leading asterisk has .* indentation .* 5, expected is 4.'
   private static class Inner {
-    // No leading asterisk present. False-negative until #17778, Subproblem 2
-    // violation below "Summary javadoc is missing."
+    // violation 2 lines below "Summary javadoc is missing."
+    // violation 2 lines below "Javadoc line should start with leading asterisk."
     /**
 
         */
@@ -86,7 +86,7 @@ public class InputIncorrectJavadocLeadingAsteriskAlignment {
     ONE,
 
 
-    // Closing tag should be alone on line. False negative until #17778, subproblem 3
+    // Closing tag should be alone on line. False negative until #18273
     /**
       * Wrong Alignment. */
     // violation above 'Leading asterisk has .* indentation .* 7, expected is 6'

--- a/src/it/resources/com/google/checkstyle/test/chapter7javadoc/rule712paragraphs/InputIncorrectJavadocParagraph.java
+++ b/src/it/resources/com/google/checkstyle/test/chapter7javadoc/rule712paragraphs/InputIncorrectJavadocParagraph.java
@@ -40,6 +40,7 @@ class InputIncorrectJavadocParagraph {
     return false;
   }
 
+  // violation 5 lines below "Javadoc content should start from the next line."
   // violation 4 lines below 'Redundant <p> tag.'
   // 2 violations 4 lines below:
   //  '<p> tag should be placed immediately before the first word'
@@ -70,7 +71,8 @@ class InputIncorrectJavadocParagraph {
      */
     public static final byte NUL = 0;
 
-    // 2 violations 5 lines below:
+    // 3 violations 6 lines below:
+    //  'Javadoc content should start from the next line.'
     //  '<p> tag should be placed immediately before the first word'
     //  'Redundant <p> tag.'
     // violation 5 lines below '<p> tag should be placed immediately before the first word'

--- a/src/it/resources/com/google/checkstyle/test/chapter7javadoc/rule734nonrequiredjavadoc/InputInvalidJavadocPositionRecord.java
+++ b/src/it/resources/com/google/checkstyle/test/chapter7javadoc/rule734nonrequiredjavadoc/InputInvalidJavadocPositionRecord.java
@@ -1,6 +1,7 @@
 package com.google.checkstyle.test.chapter7javadoc.rule734nonrequiredjavadoc;
 
-// violation below 'Javadoc comment is placed in the wrong location.'
+// violation 2 lines below 'Javadoc comment is placed in the wrong location.'
+// violation 2 lines below 'Javadoc content should start from the next line.'
 /** Odd javadoc */
 /** Valid javadoc.
  *

--- a/src/main/resources/google_checks.xml
+++ b/src/main/resources/google_checks.xml
@@ -196,6 +196,8 @@
     <module name="MultipleVariableDeclarations"/>
     <module name="ArrayTypeStyle"/>
     <module name="JavadocLeadingAsteriskAlign"/>
+    <module name="JavadocMissingLeadingAsterisk"/>
+    <module name="JavadocContentLocation"/>
     <module name="MissingSwitchDefault"/>
     <module name="FallThrough"/>
     <module name="UpperEll"/>

--- a/src/site/xdoc/checks/javadoc/javadoccontentlocation.xml
+++ b/src/site/xdoc/checks/javadoc/javadoccontentlocation.xml
@@ -173,6 +173,10 @@ class Example2 {
             <a href="https://github.com/search?q=path%3Aconfig%20path%3A**%2Fcheckstyle-checks.xml+repo%3Acheckstyle%2Fcheckstyle+JavadocContentLocation">
               Checkstyle Style</a>
           </li>
+          <li>
+            <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources%20path%3A**%2Fgoogle_checks.xml+repo%3Acheckstyle%2Fcheckstyle+JavadocContentLocation">
+              Google Style</a>
+          </li>
         </ul>
       </subsection>
 

--- a/src/site/xdoc/checks/javadoc/javadoccontentlocation.xml.template
+++ b/src/site/xdoc/checks/javadoc/javadoccontentlocation.xml.template
@@ -77,6 +77,10 @@
             <a href="https://github.com/search?q=path%3Aconfig%20path%3A**%2Fcheckstyle-checks.xml+repo%3Acheckstyle%2Fcheckstyle+JavadocContentLocation">
               Checkstyle Style</a>
           </li>
+          <li>
+            <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources%20path%3A**%2Fgoogle_checks.xml+repo%3Acheckstyle%2Fcheckstyle+JavadocContentLocation">
+              Google Style</a>
+          </li>
         </ul>
       </subsection>
 

--- a/src/site/xdoc/checks/javadoc/javadocmissingleadingasterisk.xml
+++ b/src/site/xdoc/checks/javadoc/javadocmissingleadingasterisk.xml
@@ -103,6 +103,10 @@ class Example1 {}
             <a href="https://github.com/search?q=path%3Aconfig%20path%3A**%2Fcheckstyle-checks.xml+repo%3Acheckstyle%2Fcheckstyle+JavadocMissingLeadingAsterisk">
               Checkstyle Style</a>
           </li>
+          <li>
+            <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources%20path%3A**%2Fgoogle_checks.xml+repo%3Acheckstyle%2Fcheckstyle+JavadocMissingLeadingAsterisk">
+              Google Style</a>
+          </li>
         </ul>
       </subsection>
 

--- a/src/site/xdoc/checks/javadoc/javadocmissingleadingasterisk.xml.template
+++ b/src/site/xdoc/checks/javadoc/javadocmissingleadingasterisk.xml.template
@@ -50,6 +50,10 @@
             <a href="https://github.com/search?q=path%3Aconfig%20path%3A**%2Fcheckstyle-checks.xml+repo%3Acheckstyle%2Fcheckstyle+JavadocMissingLeadingAsterisk">
               Checkstyle Style</a>
           </li>
+          <li>
+            <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources%20path%3A**%2Fgoogle_checks.xml+repo%3Acheckstyle%2Fcheckstyle+JavadocMissingLeadingAsterisk">
+              Google Style</a>
+          </li>
         </ul>
       </subsection>
 

--- a/src/site/xdoc/google_style.xml
+++ b/src/site/xdoc/google_style.xml
@@ -2374,6 +2374,28 @@
                   <br />
                   <span class="wrapper inline">
                     <img
+                            src="images/ok_green.png"
+                            alt="" />
+                  </span>
+                  <a href="checks/javadoc/javadocmissingleadingasterisk.html#JavadocMissingLeadingAsterisk">
+                    JavadocMissingLeadingAsterisk</a>
+                  (<a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources%20path%3A**%2Fgoogle_checks.xml+repo%3Acheckstyle%2Fcheckstyle+JavadocMissingLeadingAsterisk">
+                  config</a>)
+                  <br />
+                  <br />
+                  <span class="wrapper inline">
+                    <img
+                            src="images/ok_blue.png"
+                            alt="" />
+                  </span>
+                  <a href="checks/javadoc/javadoccontentlocation.html#JavadocContentLocation">
+                    JavadocContentLocation</a>
+                  (<a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources%20path%3A**%2Fgoogle_checks.xml+repo%3Acheckstyle%2Fcheckstyle+JavadocContentLocation">
+                  config</a>)
+                  <br />
+                  <br />
+                  <span class="wrapper inline">
+                    <img
                             src="images/ok_blue.png"
                             alt="" />
                   </span>
@@ -2381,6 +2403,23 @@
                     InvalidJavadocPosition</a>
                   (<a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources%20path%3A**%2Fgoogle_checks.xml+repo%3Acheckstyle%2Fcheckstyle+InvalidJavadocPosition">
                   config</a>)
+                  <br />
+                  <br />
+                  Non covered:
+                  <br />
+                  1. There is a false negative related to Javadoc content that begins
+                  with a leading asterisk. It is addressed at:
+                  <a href="https://github.com/checkstyle/checkstyle/issues/18271">
+                    #18271
+                  </a>
+                  <br />
+                  <br />
+                  2. There is a false negative concerning Javadoc blocks where the
+                  closing <code>*/</code> does not appear on its own line.
+                  It is addressed at:
+                  <a href="https://github.com/checkstyle/checkstyle/issues/18273">
+                    #18273
+                  </a>
                 </td>
                 <td>
                   <a href="https://github.com/checkstyle/checkstyle/tree/master/src/it/resources/com/google/checkstyle/test/chapter7javadoc/rule711generalform">


### PR DESCRIPTION
part of #17778
fixes #17696

Added [`JavadocMissingLeadingAsterisk`](https://checkstyle.org/checks/javadoc/javadocmissingleadingasterisk.html#JavadocMissingLeadingAsterisk) and [`JavadocContentLocation`](https://checkstyle.org/checks/javadoc/javadoccontentlocation.html) Check in google_checks.xml to fulfill the requirement of subprolem 1 and subproblem 2 described in the issue.

1. `JavadocMissingLeadingAsterisk` covers all the cases.
2. `JavadocContentLocation` covers almost cases except for below case.
```
/*************************************************
 *** @param str testing.....
 **********************************/
// False negative for above javadoc, until #17778, Subproblem 1 & 3.
public InputCorrectJavadocLeadingAsteriskAlignment(String str) {}
```
This behavior occurs because of the rule stating that `Any leading asterisks and spaces are not counted as the beginning of the content and are therefore ignored.` in the `JavadocContentLocation` check.

---
Diff Regression config: https://gist.githubusercontent.com/Praveen7294/e4a99e182dc0866275b165af90dfcde2/raw/91dc38b1e2ad2d78afa4b39c471e3677c831c9a7/base-config18255.xml
Diff Regression patch config: https://gist.githubusercontent.com/Praveen7294/772dca9b6e4c447f461fa0945116d3f7/raw/0a5d4e4b36b40185454c9faadc2edd9cb912a445/patch-config18255.xml
Diff Regression projects: https://gist.githubusercontent.com/Praveen7294/a1626a4272b4be9d7a0dc8a9fbae5ffa/raw/22fada1af5a2880572d3e91848996d50427c1616/list-of-projects.properties