### PR TITLE
Issue #17449: Add XDocs examples for MethodCountCheck max* properties

### DIFF
--- a/src/site/xdoc/checks/sizes/methodcount.xml
+++ b/src/site/xdoc/checks/sizes/methodcount.xml
@@ -242,7 +242,112 @@ class Example3 { // violation, 'Number of public methods is 3 (max allowed is 2)
     public void innerMethod2() {} // NOT counted towards Example3
   }
 }
-</code></pre></div>
+</code></pre></div><hr class="example-separator"/>
+        <p id="Example4-config">
+          To configure the check to use separate maximums for private methods:
+        </p>
+        <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
+&lt;module name="Checker"&gt;
+  &lt;module name="TreeWalker"&gt;
+    &lt;module name="MethodCount"&gt;
+      &lt;property name="maxPrivate" value="1"/&gt;
+    &lt;/module&gt;
+  &lt;/module&gt;
+&lt;/module&gt;
+</code></pre></div><hr class="example-separator"/>
+        <p id="Example4-code">Example:</p>
+        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+class Example4 { // violation, 'Number of private methods is 2 (max allowed is 1)'
+
+  public void outerMethod1(int i) {}
+  public void outerMethod2() {}
+  public void outerMethod3(String str) {}
+
+  private void outerMethod4() {
+    Runnable r = (new Runnable() {
+      public void run() {} // NOT counted towards Example1
+    });
+  }
+
+  private void outerMethod5(int i) {}
+  void outerMethod6(int i, int j) {}
+
+  public static class InnerExample{
+    public void innerMethod1() {} // NOT counted towards Example1
+    public void innerMethod2() {} // NOT counted towards Example1
+  }
+}
+</code></pre></div><hr class="example-separator"/>
+        <p id="Example5-config">
+          To configure the check to use separate maximums for package-private methods:
+        </p>
+        <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
+&lt;module name="Checker"&gt;
+  &lt;module name="TreeWalker"&gt;
+    &lt;module name="MethodCount"&gt;
+      &lt;property name="maxPackage" value="0"/&gt;
+    &lt;/module&gt;
+  &lt;/module&gt;
+&lt;/module&gt;
+</code></pre></div><hr class="example-separator"/>
+        <p id="Example5-code">Example:</p>
+        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+class Example5 { // violation, 'Number of package methods is 1 (max allowed is 0)'
+
+  public void outerMethod1(int i) {}
+  public void outerMethod2() {}
+  public void outerMethod3(String str) {}
+
+  private void outerMethod4() {
+    Runnable r = (new Runnable() {
+      public void run() {} // NOT counted towards Example1
+    });
+  }
+
+  private void outerMethod5(int i) {}
+  void outerMethod6(int i, int j) {}
+
+  public static class InnerExample{
+    public void innerMethod1() {} // NOT counted towards Example1
+    public void innerMethod2() {} // NOT counted towards Example1
+  }
+}
+</code></pre></div><hr class="example-separator"/>
+        <p id="Example6-config">
+          To configure the check to use separate maximums for protected methods:
+        </p>
+        <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
+&lt;module name="Checker"&gt;
+  &lt;module name="TreeWalker"&gt;
+    &lt;module name="MethodCount"&gt;
+      &lt;property name="maxProtected" value="1"/&gt;
+    &lt;/module&gt;
+  &lt;/module&gt;
+&lt;/module&gt;
+</code></pre></div><hr class="example-separator"/>
+        <p id="Example6-code">Example:</p>
+        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+class Example6 { // no violations: there are no protected methods in this class
+
+  public void outerMethod1(int i) {}
+  public void outerMethod2() {}
+  public void outerMethod3(String str) {}
+
+  private void outerMethod4() {
+    Runnable r = (new Runnable() {
+      public void run() {} // NOT counted towards Example1
+    });
+  }
+
+  private void outerMethod5(int i) {}
+  void outerMethod6(int i, int j) {}
+
+  public static class InnerExample{
+    public void innerMethod1() {} // NOT counted towards Example1
+    public void innerMethod2() {} // NOT counted towards Example1
+  }
+}
+</code></pre></div><hr class="example-separator"/>
       </subsection>
 
       <subsection name="Example of Usage" id="MethodCount_Example_of_Usage">

--- a/src/site/xdoc/checks/sizes/methodcount.xml.template
+++ b/src/site/xdoc/checks/sizes/methodcount.xml.template
@@ -70,7 +70,49 @@
           <param name="path"
                  value="resources/com/puppycrawl/tools/checkstyle/checks/sizes/methodcount/Example3.java"/>
           <param name="type" value="code"/>
-        </macro>
+        </macro><hr class="example-separator"/>
+        <p id="Example4-config">
+          To configure the check to use separate maximums for private methods:
+        </p>
+        <macro name="example">
+          <param name="path"
+                 value="resources/com/puppycrawl/tools/checkstyle/checks/sizes/methodcount/Example4.java"/>
+          <param name="type" value="config"/>
+        </macro><hr class="example-separator"/>
+        <p id="Example4-code">Example:</p>
+        <macro name="example">
+          <param name="path"
+                 value="resources/com/puppycrawl/tools/checkstyle/checks/sizes/methodcount/Example4.java"/>
+          <param name="type" value="code"/>
+        </macro><hr class="example-separator"/>
+        <p id="Example5-config">
+          To configure the check to use separate maximums for package-private methods:
+        </p>
+        <macro name="example">
+          <param name="path"
+                 value="resources/com/puppycrawl/tools/checkstyle/checks/sizes/methodcount/Example5.java"/>
+          <param name="type" value="config"/>
+        </macro><hr class="example-separator"/>
+        <p id="Example5-code">Example:</p>
+        <macro name="example">
+          <param name="path"
+                 value="resources/com/puppycrawl/tools/checkstyle/checks/sizes/methodcount/Example5.java"/>
+          <param name="type" value="code"/>
+        </macro><hr class="example-separator"/>
+        <p id="Example6-config">
+          To configure the check to use separate maximums for protected methods:
+        </p>
+        <macro name="example">
+          <param name="path"
+                 value="resources/com/puppycrawl/tools/checkstyle/checks/sizes/methodcount/Example6.java"/>
+          <param name="type" value="config"/>
+        </macro><hr class="example-separator"/>
+        <p id="Example6-code">Example:</p>
+        <macro name="example">
+          <param name="path"
+                 value="resources/com/puppycrawl/tools/checkstyle/checks/sizes/methodcount/Example6.java"/>
+          <param name="type" value="code"/>
+        </macro><hr class="example-separator"/>
       </subsection>
 
       <subsection name="Example of Usage" id="MethodCount_Example_of_Usage">

--- a/src/test/java/com/puppycrawl/tools/checkstyle/internal/XdocsExampleFileTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/internal/XdocsExampleFileTest.java
@@ -72,7 +72,6 @@ public class XdocsExampleFileTest {
                     "arrayInitIndent",
                     "braceAdjustment"
             )),
-            Map.entry("MethodCountCheck", Set.of("maxPrivate", "maxPackage", "maxProtected")),
             Map.entry("ClassMemberImpliedModifierCheck", Set.of(
                     "violateImpliedStaticOnNestedEnum",
                     "violateImpliedStaticOnNestedRecord",

--- a/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/checks/sizes/MethodCountCheckExamplesTest.java
+++ b/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/checks/sizes/MethodCountCheckExamplesTest.java
@@ -53,4 +53,29 @@ public class MethodCountCheckExamplesTest extends AbstractExamplesModuleTestSupp
 
         verifyWithInlineConfigParser(getPath("Example3.java"), expected);
     }
+
+    @Test
+    public void testExample4() throws Exception {
+        final String[] expected = {
+            "13:1: " + getCheckMessage(MethodCountCheck.MSG_PRIVATE_METHODS, 2, 1),
+        };
+
+        verifyWithInlineConfigParser(getPath("Example4.java"), expected);
+    }
+
+    @Test
+    public void testExample5() throws Exception {
+        final String[] expected = {
+            "13:1: " + getCheckMessage(MethodCountCheck.MSG_PACKAGE_METHODS, 1, 0),
+        };
+
+        verifyWithInlineConfigParser(getPath("Example5.java"), expected);
+    }
+
+    @Test
+    public void testExample6() throws Exception {
+        final String[] expected = {};
+
+        verifyWithInlineConfigParser(getPath("Example6.java"), expected);
+    }
 }

--- a/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/sizes/methodcount/Example4.java
+++ b/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/sizes/methodcount/Example4.java
@@ -1,0 +1,33 @@
+/*xml
+<module name="Checker">
+  <module name="TreeWalker">
+    <module name="MethodCount">
+      <property name="maxPrivate" value="1"/>
+    </module>
+  </module>
+</module>
+*/
+package com.puppycrawl.tools.checkstyle.checks.sizes.methodcount;
+
+// xdoc section -- start
+class Example4 { // violation, 'Number of private methods is 2 (max allowed is 1)'
+
+  public void outerMethod1(int i) {}
+  public void outerMethod2() {}
+  public void outerMethod3(String str) {}
+
+  private void outerMethod4() {
+    Runnable r = (new Runnable() {
+      public void run() {} // NOT counted towards Example1
+    });
+  }
+
+  private void outerMethod5(int i) {}
+  void outerMethod6(int i, int j) {}
+
+  public static class InnerExample{
+    public void innerMethod1() {} // NOT counted towards Example1
+    public void innerMethod2() {} // NOT counted towards Example1
+  }
+}
+// xdoc section -- end

--- a/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/sizes/methodcount/Example5.java
+++ b/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/sizes/methodcount/Example5.java
@@ -1,0 +1,33 @@
+/*xml
+<module name="Checker">
+  <module name="TreeWalker">
+    <module name="MethodCount">
+      <property name="maxPackage" value="0"/>
+    </module>
+  </module>
+</module>
+*/
+package com.puppycrawl.tools.checkstyle.checks.sizes.methodcount;
+
+// xdoc section -- start
+class Example5 { // violation, 'Number of package methods is 1 (max allowed is 0)'
+
+  public void outerMethod1(int i) {}
+  public void outerMethod2() {}
+  public void outerMethod3(String str) {}
+
+  private void outerMethod4() {
+    Runnable r = (new Runnable() {
+      public void run() {} // NOT counted towards Example1
+    });
+  }
+
+  private void outerMethod5(int i) {}
+  void outerMethod6(int i, int j) {}
+
+  public static class InnerExample{
+    public void innerMethod1() {} // NOT counted towards Example1
+    public void innerMethod2() {} // NOT counted towards Example1
+  }
+}
+// xdoc section -- end

--- a/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/sizes/methodcount/Example6.java
+++ b/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/sizes/methodcount/Example6.java
@@ -1,0 +1,33 @@
+/*xml
+<module name="Checker">
+  <module name="TreeWalker">
+    <module name="MethodCount">
+      <property name="maxProtected" value="1"/>
+    </module>
+  </module>
+</module>
+*/
+package com.puppycrawl.tools.checkstyle.checks.sizes.methodcount;
+
+// xdoc section -- start
+class Example6 { // no violations: there are no protected methods in this class
+
+  public void outerMethod1(int i) {}
+  public void outerMethod2() {}
+  public void outerMethod3(String str) {}
+
+  private void outerMethod4() {
+    Runnable r = (new Runnable() {
+      public void run() {} // NOT counted towards Example1
+    });
+  }
+
+  private void outerMethod5(int i) {}
+  void outerMethod6(int i, int j) {}
+
+  public static class InnerExample{
+    public void innerMethod1() {} // NOT counted towards Example1
+    public void innerMethod2() {} // NOT counted towards Example1
+  }
+}
+// xdoc section -- end


### PR DESCRIPTION
Issue: #17449

This PR adds XDocs examples for the following `MethodCountCheck` properties:

- `maxPrivate`
- `maxPackage`
- `maxProtected`

Changes included:

- Added a new example configuration and code snippet (`Example4`) in `methodcount.xml` to demonstrate using separate maximums for private, package-private, and protected methods.
- Added a corresponding XDocs example source file `Example4.java` under `src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/sizes/methodcount`.
- Updated `methodcount.xml.template` to wire in the new example using the standard `<macro name="example">` pattern.
- Removed `MethodCountCheck` (`maxPrivate`, `maxPackage`, `maxProtected`) from the `SUPPRESSED_PROPERTIES_BY_CHECK` map in `XdocsExampleFileTest`, as these properties are now covered by XDocs examples.

Testing:

- `mvn -Pno-validations -DskipITs -DskipUTs=false test`
- Verified that `XdocsExampleFileTest` now passes without suppressions for `MethodCountCheck`.
