### PR TITLE
Issue #16003: Add Kafka to no-error testing

### DIFF
--- a/.ci/validation.sh
+++ b/.ci/validation.sh
@@ -210,6 +210,30 @@ markdownlint)
   mdl -g . && echo "All .md files verified"
   ;;
 
+no-error-kafka)
+  CS_POM_VERSION="$(getCheckstylePomVersion)"
+  echo "CS_version: ${CS_POM_VERSION}"
+  ./mvnw -e --no-transfer-progress clean install -Pno-validations
+  echo "Checkout target sources ..."
+  # until https://github.com/checkstyle/checkstyle/issues/18272
+  checkout_from "https://github.com/dejan2609/kafka.git"
+  cd .ci-temp/kafka/
+  git fetch --depth 1 origin KAFKA-19809:KAFKA-19809
+  git checkout KAFKA-19809
+  cat >> customConfig.gradle<< EOF
+allprojects {
+    repositories {
+        mavenLocal()
+    }
+}
+EOF
+  ./gradlew checkstyleMain checkstyleTest \
+    -I customConfig.gradle \
+    -PcheckstyleVersion="${CS_POM_VERSION}"
+  cd ..
+  removeFolderWithProtectedFiles kafka
+  ;;
+
 no-error-pmd)
   CS_POM_VERSION="$(getCheckstylePomVersion)"
   echo "CS_version: ${CS_POM_VERSION}"

--- a/.github/workflows/no-error-workflow.yml
+++ b/.github/workflows/no-error-workflow.yml
@@ -1,0 +1,27 @@
+name: 'no-error testing'
+
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+    branches: '*'
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  no-error-kafka:
+    if: github.repository == 'checkstyle/checkstyle'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: actions/setup-java@v5
+        with:
+          distribution: temurin
+          java-version: 25
+
+      - name: Run Checkstyle on Apache Kafka
+        run: ./.ci/validation.sh no-error-kafka

--- a/config/jsoref-spellchecker/whitelist.words
+++ b/config/jsoref-spellchecker/whitelist.words
@@ -22,6 +22,7 @@ aggregators
 allchecks
 allclasses
 allowlegacy
+allprojects
 alot
 alundblad
 amazonaws
@@ -282,6 +283,7 @@ defau
 defaultcomeslast
 defaultlabelpresence
 defaultlogger
+dejan
 delims
 DENORMALIZER
 Depedency


### PR DESCRIPTION
Resolves issue
- #16003 

Based on the work of:
- @romani #16032
- @dejan2609 #16395

---

Added GitHub Actions Workflow for regression testing with Apache Kafka: `no-error-kafka`. The job is identical to the other `no-error-*` jobs. For instance:
https://github.com/checkstyle/checkstyle/blob/57df2a717bf7850b3afb43c2438dde542fad05e5/.ci/validation.sh#L236-L247

Usually, such jobs use Semaphore and CircleCI, but this one must use GitHub Actions due to high memory usage.