### PR TITLE
infra: Update Google Java Format version to 1.33.0

### DIFF
--- a/.github/workflows/google-java-format.yml
+++ b/.github/workflows/google-java-format.yml
@@ -20,7 +20,7 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  VERSION: 1.31.0
+  VERSION: 1.33.0
 
 jobs:
   test:


### PR DESCRIPTION
https://github.com/google/google-java-format/releases/tag/v1.33.0