### PR TITLE
Issue #17882: Update Javadoc for ATTRIBUTE_VALUE token

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/api/JavadocCommentsTokenTypes.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/api/JavadocCommentsTokenTypes.java
@@ -1079,7 +1079,35 @@ public final class JavadocCommentsTokenTypes {
     public static final int EQUALS = JavadocCommentsLexer.EQUALS;
 
     /**
-     * Value assigned to an attribute.
+     * {@code ATTRIBUTE_VALUE} Value assigned to an attribute.
+     *
+     * <p><b>Example:</b></p>
+     * <pre>{@code <a href="example">text</a>}</pre>
+     *
+     * <p><b>Tree:</b></p>
+     * <pre>{@code
+     * HTML_ELEMENT -> HTML_ELEMENT
+     * |--HTML_TAG_START -> HTML_TAG_START
+     * |   |--TAG_OPEN -> <
+     * |   |--TAG_NAME -> a
+     * |   |--HTML_ATTRIBUTES -> HTML_ATTRIBUTES
+     * |   |   `--HTML_ATTRIBUTE -> HTML_ATTRIBUTE
+     * |   |       |--TEXT ->
+     * |   |       |--TAG_ATTR_NAME -> href
+     * |   |       |--EQUALS -> =
+     * |   |       `--ATTRIBUTE_VALUE -> "example"
+     * |   `--TAG_CLOSE -> >
+     * |--HTML_CONTENT -> HTML_CONTENT
+     * |   `--TEXT -> text
+     * `--HTML_TAG_END -> HTML_TAG_END
+     * |--TAG_OPEN -> <
+     * |--TAG_SLASH -> /
+     * |--TAG_NAME -> a
+     * `--TAG_CLOSE -> >
+     * }</pre>
+     *
+     * @see #HTML_ATTRIBUTE
+     * @see #TAG_ATTR_NAME
      */
     public static final int ATTRIBUTE_VALUE = JavadocCommentsLexer.ATTRIBUTE_VALUE;
 


### PR DESCRIPTION
Issue: #17882

## Description
Updated the Javadoc for `ATTRIBUTE_VALUE` token inside `JavadocCommentsTokenTypes.java` to match the new AST printing format.

## Verification
I verified the AST structure using the CLI and the generated jar.

**Command:**
`java -jar target/checkstyle-12.3.0-SNAPSHOT-all.jar -j Test.java`

**Input (Test.java):**
```java
/**
 * <a href="example">text</a>
 */
class Test {}
```

**Output:**
```
JAVADOC_CONTENT -> JAVADOC_CONTENT
|--TEXT -> /**
|--NEWLINE -> \r\n
|--LEADING_ASTERISK ->  *
|--TEXT ->
|--HTML_ELEMENT -> HTML_ELEMENT
|   |--HTML_TAG_START -> HTML_TAG_START
|   |   |--TAG_OPEN -> <
|   |   |--TAG_NAME -> a
|   |   |--HTML_ATTRIBUTES -> HTML_ATTRIBUTES
|   |   |   `--HTML_ATTRIBUTE -> HTML_ATTRIBUTE
|   |   |       |--TEXT ->
|   |   |       |--TAG_ATTR_NAME -> href
|   |   |       |--EQUALS -> =
|   |   |       `--ATTRIBUTE_VALUE -> "example"
|   |   `--TAG_CLOSE -> >
|   |--HTML_CONTENT -> HTML_CONTENT
|   |   `--TEXT -> text
|   `--HTML_TAG_END -> HTML_TAG_END
|       |--TAG_OPEN -> <
|       |--TAG_SLASH -> /
|       |--TAG_NAME -> a
|       `--TAG_CLOSE -> >
|--NEWLINE -> \r\n
|--LEADING_ASTERISK ->  *
|--TEXT -> /
|--NEWLINE -> \r\n
|--NEWLINE -> \r\n
`--TEXT -> class Test {}
```
