### PR TITLE
infra: use depth of 1 when cloning git repositories

### DIFF
--- a/.ci/util.sh
+++ b/.ci/util.sh
@@ -53,7 +53,7 @@ function checkout_from {
     git clean -f -d
     cd ../
   else
-    for i in 1 2 3 4 5; do git clone "$CLONE_URL" && break || sleep 15s; done
+    for i in 1 2 3 4 5; do git clone --depth 1 "$CLONE_URL" && break || sleep 15s; done
   fi
   cd ../
 }

--- a/.ci/validation.sh
+++ b/.ci/validation.sh
@@ -755,6 +755,7 @@ no-error-orekit)
   cd .ci-temp/hipparchus
   # checkout to version that Orekit expects
   SHA_HIPPARCHUS="1492f06848f57e46bef911a""ad16203a242080028"
+  git fetch --depth 1 origin "$SHA_HIPPARCHUS"
   git checkout $SHA_HIPPARCHUS
   mvn -e --no-transfer-progress install -DskipTests
   cd -
@@ -763,6 +764,7 @@ no-error-orekit)
   # no CI is enforced in project, so to make our build stable we should
   # checkout to latest release/development (annotated tag or hash) or sha that have fix we need
   # git checkout $(git describe --abbrev=0 --tags)
+  git fetch --depth 1 origin "9b121e504771f3ddd303ab""cc""c74ac9db64541ea1"
   git checkout "9b121e504771f3ddd303ab""cc""c74ac9db64541ea1"
   mvn -e --no-transfer-progress compile checkstyle:check \
     -Dorekit.checkstyle.version="${CS_POM_VERSION}"


### PR DESCRIPTION
## Summary - What changed?
Use `--depth 1` in the git clone command within `checkout_from` to create a shallow clone.

### Documentation on the `--depth` option
https://git-scm.com/docs/git-clone#Documentation/git-clone.txt---depthdepth
> Create a shallow clone with a history truncated to the specified number of commits.

## Motivation - Why change?
This `checkout_from` function is used in 48 places to clone repositories. When cloning, we care about the code's latest state from the cloned project. We do not care about the project’s git history. By default, `git clone` also pulls the full git history. Setting the depth to `1` ensures that we only pull the minimum git history - the latest commit.

This will speed up all CI jobs that use it.

## Benchmarks with `trino` and `spring-integration` repositories
The _Time_ for each benchmark is an average of 3 runs:

| Command                                                                         | Time (real `time`) | Folder Size (`du`) |
|---------------------------------------------------------------------------------|--------------------|------------------|
| `git clone https://github.com/trinodb/trino.git`                                | 44.47s             | 510.73 MB        |
| `git clone --depth 1 https://github.com/trinodb/trino.git`                      | 9.92s              | 247.36 MB        |
|                                                                                 |                    |                  |
| `git clone https://github.com/spring-projects/spring-integration.git`<br>       | 12.21s             | 128.81 MB        |
| `git clone --depth 1 https://github.com/spring-projects/spring-integration.git` | 02.97s             | 45.74 MB         |
