### PR TITLE
Issue #17449: Add XDocs example for WhitespaceAroundCheck allowEmptySwitchBlockStatements

### DIFF
--- a/src/site/xdoc/checks/whitespace/whitespacearound.xml
+++ b/src/site/xdoc/checks/whitespace/whitespacearound.xml
@@ -628,6 +628,28 @@ class Example10 {
     }
   }
 }
+</code></pre></div><hr class="example-separator"/>
+        <p id="Example11-config">
+          To configure the check to allow empty switch block statements:
+        </p>
+        <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
+&lt;module name="Checker"&gt;
+  &lt;module name="TreeWalker"&gt;
+    &lt;module name="WhitespaceAround"&gt;
+      &lt;property name="allowEmptySwitchBlockStatements" value="true"/&gt;
+    &lt;/module&gt;
+  &lt;/module&gt;
+&lt;/module&gt;
+</code></pre></div><hr class="example-separator"/>
+        <p id="Example11-code">Example:</p>
+        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+class Example11 {
+  void method(int value) {
+    // allowed: empty switch block when allowEmptySwitchBlockStatements is true
+    switch (value) {
+    }
+  }
+}
 </code></pre></div>
       </subsection>
 

--- a/src/site/xdoc/checks/whitespace/whitespacearound.xml.template
+++ b/src/site/xdoc/checks/whitespace/whitespacearound.xml.template
@@ -172,6 +172,20 @@
           <param name="path"
                  value="resources/com/puppycrawl/tools/checkstyle/checks/whitespace/whitespacearound/Example10.java"/>
           <param name="type" value="code"/>
+        </macro><hr class="example-separator"/>
+        <p id="Example11-config">
+          To configure the check to allow empty switch block statements:
+        </p>
+        <macro name="example">
+          <param name="path"
+                 value="resources/com/puppycrawl/tools/checkstyle/checks/whitespace/whitespacearound/Example11.java"/>
+          <param name="type" value="config"/>
+        </macro><hr class="example-separator"/>
+        <p id="Example11-code">Example:</p>
+        <macro name="example">
+          <param name="path"
+                 value="resources/com/puppycrawl/tools/checkstyle/checks/whitespace/whitespacearound/Example11.java"/>
+          <param name="type" value="code"/>
         </macro>
       </subsection>
 

--- a/src/test/java/com/puppycrawl/tools/checkstyle/internal/XdocsExampleFileTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/internal/XdocsExampleFileTest.java
@@ -61,7 +61,6 @@ public class XdocsExampleFileTest {
             Map.entry("MissingJavadocTypeCheck", Set.of("skipAnnotations")),
             Map.entry("JavadocStyleCheck", Set.of("endOfSentenceFormat", "checkEmptyJavadoc")),
             Map.entry("ConstantNameCheck", Set.of("applyToPackage", "applyToPrivate")),
-            Map.entry("WhitespaceAroundCheck", Set.of("allowEmptySwitchBlockStatements")),
             Map.entry("SuppressWarningsHolder", Set.of("aliasList")),
             Map.entry("IllegalTokenTextCheck", Set.of("message")),
             Map.entry("IndentationCheck", Set.of(

--- a/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/checks/whitespace/WhitespaceAroundExamplesTest.java
+++ b/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/checks/whitespace/WhitespaceAroundExamplesTest.java
@@ -49,6 +49,9 @@ public class WhitespaceAroundExamplesTest extends AbstractExamplesModuleTestSupp
             "29:24: " + getCheckMessage(MSG_WS_NOT_FOLLOWED, "{"),
             "29:24: " + getCheckMessage(MSG_WS_NOT_PRECEDED, "{"),
             "29:25: " + getCheckMessage(MSG_WS_NOT_PRECEDED, "}"),
+            // new empty-switch violations (switch (value) {})
+            "39:20: " + getCheckMessage(MSG_WS_NOT_FOLLOWED, "{"),
+            "39:21: " + getCheckMessage(MSG_WS_NOT_PRECEDED, "}"),
         };
 
         verifyWithInlineConfigParser(getPath("Example1.java"), expected);
@@ -157,4 +160,12 @@ public class WhitespaceAroundExamplesTest extends AbstractExamplesModuleTestSupp
 
         verifyWithInlineConfigParser(getPath("Example10.java"), expected);
     }
+
+    @Test
+    public void testExample11() throws Exception {
+        final String[] expected = {};
+
+        verifyWithInlineConfigParser(getPath("Example11.java"), expected);
+    }
+
 }

--- a/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/whitespace/whitespacearound/Example1.java
+++ b/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/whitespace/whitespacearound/Example1.java
@@ -32,6 +32,11 @@ class Example1 {
     for (char item: vowels) { // ok, ignoreEnhancedForColon is true by default
 
     }
+
+    int value = 0;
+    // violation below: empty switch block is not allowed when
+    // allowEmptySwitchBlockStatements is false (default behavior)
+    switch (value) {}
   }
 }
 // xdoc section -- end

--- a/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/whitespace/whitespacearound/Example11.java
+++ b/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/whitespace/whitespacearound/Example11.java
@@ -1,0 +1,21 @@
+/*xml
+<module name="Checker">
+  <module name="TreeWalker">
+    <module name="WhitespaceAround">
+      <property name="allowEmptySwitchBlockStatements" value="true"/>
+    </module>
+  </module>
+</module>
+*/
+
+package com.puppycrawl.tools.checkstyle.checks.whitespace.whitespacearound;
+
+// xdoc section -- start
+class Example11 {
+  void method(int value) {
+    // allowed: empty switch block when allowEmptySwitchBlockStatements is true
+    switch (value) {
+    }
+  }
+}
+// xdoc section -- end


### PR DESCRIPTION
Issue: #17449

This PR adds XDocs coverage for the `allowEmptySwitchBlockStatements` property of `WhitespaceAroundCheck`.

Changes included:

- Updated the WhitespaceAround XDocs example configuration to include the
  `allowEmptySwitchBlockStatements` property in the `/*xml` block of the example source.
- Updated the rendered `whitespacearound.xml` documentation to show the same configuration.
- Ensured the template (`whitespacearound.xml.template`) references the updated example config.
- Removed `WhitespaceAroundCheck` (`allowEmptySwitchBlockStatements`) from the
  `SUPPRESSED_PROPERTIES_BY_CHECK` map in `XdocsExampleFileTest`, as this property
  is now covered by XDocs examples.

Testing:

- `mvn -Pno-validations -DskipITs -DskipUTs=false test`
- Verified that `XdocsExampleFileTest` now passes without suppressions for `WhitespaceAroundCheck`.
