### PR TITLE
Issue #17299: Convert ImportDetails, MatchResult, HeaderFileMetadata …

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/header/MultiFileRegexpHeaderCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/header/MultiFileRegexpHeaderCheck.java
@@ -130,14 +130,14 @@ public class MultiFileRegexpHeaderCheck
      */
     public String getConfiguredHeaderPaths() {
         return headerFilesMetadata.stream()
-                .map(HeaderFileMetadata::getHeaderFilePath)
+                .map(HeaderFileMetadata::headerFilePath)
                 .collect(Collectors.joining(", "));
     }
 
     @Override
     public Set<String> getExternalResourceLocations() {
         return headerFilesMetadata.stream()
-                .map(HeaderFileMetadata::getHeaderFileUri)
+                .map(HeaderFileMetadata::headerFileUri)
                 .map(URI::toASCIIString)
                 .collect(Collectors.toUnmodifiableSet());
     }
@@ -149,11 +149,11 @@ public class MultiFileRegexpHeaderCheck
                     .map(headerFile -> matchHeader(fileText, headerFile))
                     .toList();
 
-            if (matchResult.stream().noneMatch(match -> match.isMatching)) {
+            if (matchResult.stream().noneMatch(MatchResult::isMatching)) {
                 final MatchResult mismatch = matchResult.get(0);
                 final String allConfiguredHeaderPaths = getConfiguredHeaderPaths();
-                log(mismatch.lineNumber, mismatch.messageKey,
-                        mismatch.messageArg, allConfiguredHeaderPaths);
+                log(mismatch.lineNumber(), mismatch.messageKey(),
+                        mismatch.messageArg(), allConfiguredHeaderPaths);
             }
         }
     }
@@ -167,7 +167,7 @@ public class MultiFileRegexpHeaderCheck
      */
     private static MatchResult matchHeader(FileText fileText, HeaderFileMetadata headerFile) {
         final int fileSize = fileText.size();
-        final List<Pattern> headerPatterns = headerFile.getHeaderPatterns();
+        final List<Pattern> headerPatterns = headerFile.headerPatterns();
         final int headerPatternSize = headerPatterns.size();
 
         int mismatchLine = MISMATCH_CODE;
@@ -206,15 +206,15 @@ public class MultiFileRegexpHeaderCheck
         final int lineToLog;
         final String messageArg;
 
-        if (headerFile.getHeaderPatterns().size() > fileText.size()) {
+        if (headerFile.headerPatterns().size() > fileText.size()) {
             messageKey = MSG_HEADER_MISSING;
             lineToLog = 1;
-            messageArg = headerFile.getHeaderFilePath();
+            messageArg = headerFile.headerFilePath();
         }
         else {
             messageKey = MSG_HEADER_MISMATCH;
             lineToLog = mismatchLine + 1;
-            final String lineContent = headerFile.getLineContents().get(mismatchLine);
+            final String lineContent = headerFile.lineContents().get(mismatchLine);
             if (lineContent.isEmpty()) {
                 messageArg = EMPTY_LINE_PATTERN;
             }
@@ -260,34 +260,17 @@ public class MultiFileRegexpHeaderCheck
 
     /**
      * Metadata holder for a header file, storing its URI, compiled patterns, and line contents.
+     *
+     * @param headerFileUri URI of the header file
+     * @param headerFilePath original path string of the header file
+     * @param headerPatterns compiled regex patterns for header lines
+     * @param lineContents raw lines from the header file
      */
-    private static final class HeaderFileMetadata {
-        /** URI of the header file. */
-        private final URI headerFileUri;
-        /** Original path string of the header file. */
-        private final String headerFilePath;
-        /** Compiled regex patterns for each line of the header. */
-        private final List<Pattern> headerPatterns;
-        /** Raw line contents of the header file. */
-        private final List<String> lineContents;
-
-        /**
-         * Initializes the metadata holder.
-         *
-         * @param headerFileUri URI of the header file
-         * @param headerFilePath original path string of the header file
-         * @param headerPatterns compiled regex patterns for header lines
-         * @param lineContents raw lines from the header file
-         */
-        private HeaderFileMetadata(
-                URI headerFileUri, String headerFilePath,
-                List<Pattern> headerPatterns, List<String> lineContents
-        ) {
-            this.headerFileUri = headerFileUri;
-            this.headerFilePath = headerFilePath;
-            this.headerPatterns = headerPatterns;
-            this.lineContents = lineContents;
-        }
+    private record HeaderFileMetadata(
+            URI headerFileUri,
+            String headerFilePath,
+            List<Pattern> headerPatterns,
+            List<String> lineContents) {
 
         /**
          * Creates a HeaderFileMetadata instance by reading and processing
@@ -333,29 +316,12 @@ public class MultiFileRegexpHeaderCheck
         }
 
         /**
-         * Returns the URI of the header file.
-         *
-         * @return header file URI
-         */
-        public URI getHeaderFileUri() {
-            return headerFileUri;
-        }
-
-        /**
-         * Returns the original path string of the header file.
-         *
-         * @return header file path string
-         */
-        public String getHeaderFilePath() {
-            return headerFilePath;
-        }
-
-        /**
          * Returns an unmodifiable list of compiled header patterns.
          *
          * @return header patterns
          */
-        public List<Pattern> getHeaderPatterns() {
+        @Override
+        public List<Pattern> headerPatterns() {
             return List.copyOf(headerPatterns);
         }
 
@@ -364,7 +330,8 @@ public class MultiFileRegexpHeaderCheck
          *
          * @return header lines
          */
-        public List<String> getLineContents() {
+        @Override
+        public List<String> lineContents() {
             return List.copyOf(lineContents);
         }
 
@@ -391,32 +358,17 @@ public class MultiFileRegexpHeaderCheck
 
     /**
      * Represents the result of a header match check, containing information about any mismatch.
+     *
+     * @param isMatching whether the header matched
+     * @param lineNumber line number of mismatch (1-based)
+     * @param messageKey message key for violation
+     * @param messageArg message argument
      */
-    private static final class MatchResult {
-        /** Whether the header matched the file. */
-        private final boolean isMatching;
-        /** Line number where the mismatch occurred (1-based). */
-        private final int lineNumber;
-        /** The message key for the violation. */
-        private final String messageKey;
-        /** The argument for the message. */
-        private final String messageArg;
-
-        /**
-         * Private constructor.
-         *
-         * @param isMatching whether the header matched
-         * @param lineNumber line number of mismatch (1-based)
-         * @param messageKey message key for violation
-         * @param messageArg message argument
-         */
-        private MatchResult(boolean isMatching, int lineNumber, String messageKey,
-                            String messageArg) {
-            this.isMatching = isMatching;
-            this.lineNumber = lineNumber;
-            this.messageKey = messageKey;
-            this.messageArg = messageArg;
-        }
+    private record MatchResult(
+            boolean isMatching,
+            int lineNumber,
+            String messageKey,
+            String messageArg) {
 
         /**
          * Creates a matching result.

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/imports/CustomImportOrderCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/imports/CustomImportOrderCheck.java
@@ -367,14 +367,14 @@ public class CustomImportOrderCheck extends AbstractCheck {
         String previousImportFromCurrentGroup = null;
 
         for (ImportDetails importObject : importToGroupList) {
-            final String importGroup = importObject.getImportGroup();
-            final String fullImportIdent = importObject.getImportFullPath();
+            final String importGroup = importObject.importGroup();
+            final String fullImportIdent = importObject.importFullPath();
 
             if (importGroup.equals(currentGroup)) {
                 validateExtraEmptyLine(previousImportObjectFromCurrentGroup,
                         importObject, fullImportIdent);
                 if (isAlphabeticalOrderBroken(previousImportFromCurrentGroup, fullImportIdent)) {
-                    log(importObject.getImportAST(), MSG_LEX,
+                    log(importObject.importAST(), MSG_LEX,
                             fullImportIdent, previousImportFromCurrentGroup);
                 }
                 else {
@@ -394,13 +394,13 @@ public class CustomImportOrderCheck extends AbstractCheck {
                         previousImportFromCurrentGroup = fullImportIdent;
                     }
                     else {
-                        logWrongImportGroupOrder(importObject.getImportAST(),
+                        logWrongImportGroupOrder(importObject.importAST(),
                                 importGroup, nextGroup, fullImportIdent);
                     }
                     previousImportObjectFromCurrentGroup = importObject;
                 }
                 else {
-                    logWrongImportGroupOrder(importObject.getImportAST(),
+                    logWrongImportGroupOrder(importObject.importAST(),
                             importGroup, currentGroup, fullImportIdent);
                 }
             }
@@ -417,7 +417,7 @@ public class CustomImportOrderCheck extends AbstractCheck {
     private void validateMissedEmptyLine(ImportDetails previousImport,
                                          ImportDetails importObject, String fullImportIdent) {
         if (isEmptyLineMissed(previousImport, importObject)) {
-            log(importObject.getImportAST(), MSG_LINE_SEPARATOR, fullImportIdent);
+            log(importObject.importAST(), MSG_LINE_SEPARATOR, fullImportIdent);
         }
     }
 
@@ -431,7 +431,7 @@ public class CustomImportOrderCheck extends AbstractCheck {
     private void validateExtraEmptyLine(ImportDetails previousImport,
                                         ImportDetails importObject, String fullImportIdent) {
         if (isSeparatedByExtraEmptyLine(previousImport, importObject)) {
-            log(importObject.getImportAST(), MSG_SEPARATED_IN_GROUP, fullImportIdent);
+            log(importObject.importAST(), MSG_SEPARATED_IN_GROUP, fullImportIdent);
         }
     }
 
@@ -443,8 +443,8 @@ public class CustomImportOrderCheck extends AbstractCheck {
      */
     private String getFirstGroup() {
         final ImportDetails firstImport = importToGroupList.get(0);
-        return getImportGroup(firstImport.isStaticImport(),
-                firstImport.getImportFullPath());
+        return getImportGroup(firstImport.staticImport(),
+                firstImport.importFullPath());
     }
 
     /**
@@ -556,7 +556,7 @@ public class CustomImportOrderCheck extends AbstractCheck {
     private boolean hasAnyImportInCurrentGroup(String currentGroup) {
         boolean result = false;
         for (ImportDetails currentImport : importToGroupList) {
-            if (currentGroup.equals(currentImport.getImportGroup())) {
+            if (currentGroup.equals(currentImport.importGroup())) {
                 result = true;
                 break;
             }
@@ -776,49 +776,17 @@ public class CustomImportOrderCheck extends AbstractCheck {
     /**
      * Contains import attributes as line number, import full path, import
      * group.
+     *
+     * @param importFullPath import full path
+     * @param importGroup import group
+     * @param staticImport if import is static
+     * @param importAST import AST
      */
-    private static final class ImportDetails {
-
-        /** Import full path. */
-        private final String importFullPath;
-
-        /** Import group. */
-        private final String importGroup;
-
-        /** Is static import. */
-        private final boolean staticImport;
-
-        /** Import AST. */
-        private final DetailAST importAST;
-
-        /**
-         * Initialise importFullPath, importGroup, staticImport, importAST.
-         *
-         * @param importFullPath
-         *        import full path.
-         * @param importGroup
-         *        import group.
-         * @param staticImport
-         *        if import is static.
-         * @param importAST
-         *        import ast
-         */
-        private ImportDetails(String importFullPath, String importGroup, boolean staticImport,
-                                    DetailAST importAST) {
-            this.importFullPath = importFullPath;
-            this.importGroup = importGroup;
-            this.staticImport = staticImport;
-            this.importAST = importAST;
-        }
-
-        /**
-         * Get import full path variable.
-         *
-         * @return import full path variable.
-         */
-        public String getImportFullPath() {
-            return importFullPath;
-        }
+    private record ImportDetails(
+            String importFullPath,
+            String importGroup,
+            boolean staticImport,
+            DetailAST importAST) {
 
         /**
          * Get import start line number from ast.
@@ -842,34 +810,6 @@ public class CustomImportOrderCheck extends AbstractCheck {
         public int getEndLineNumber() {
             return importAST.getLastChild().getLineNo();
         }
-
-        /**
-         * Get import group.
-         *
-         * @return import group.
-         */
-        public String getImportGroup() {
-            return importGroup;
-        }
-
-        /**
-         * Checks if import is static.
-         *
-         * @return true, if import is static.
-         */
-        public boolean isStaticImport() {
-            return staticImport;
-        }
-
-        /**
-         * Get import ast.
-         *
-         * @return import ast.
-         */
-        public DetailAST getImportAST() {
-            return importAST;
-        }
-
     }
 
     /**

--- a/src/test/java/com/puppycrawl/tools/checkstyle/internal/XdocsJavaDocsTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/internal/XdocsJavaDocsTest.java
@@ -347,7 +347,7 @@ public class XdocsJavaDocsTest extends AbstractModuleTestSupport {
 
                 switch (parentNode.getType()) {
                     case TokenTypes.CLASS_DEF, TokenTypes.CTOR_DEF, TokenTypes.ENUM_DEF,
-                         TokenTypes.ENUM_CONSTANT_DEF -> {
+                         TokenTypes.ENUM_CONSTANT_DEF, TokenTypes.RECORD_DEF -> {
                         // ignore
                     }
                     case TokenTypes.METHOD_DEF -> visitMethod(ast, parentNode);


### PR DESCRIPTION
Part of Issue #17299:

Converted the following classes to records:
- `CustomImportOrderCheck.ImportDetails`
- `MultiFileRegexpHeaderCheck.MatchResult`
- `MultiFileRegexpHeaderCheck.HeaderFileMetadata`
- Also updated `XdocsJavaDocsTest` to handle `RECORD_DEF` tokens.