### PR TITLE
Issue #18027: Resolve pitest for processFiles in CheckStyleAntTask

### DIFF
--- a/config/pitest-suppressions/pitest-ant-suppressions.xml
+++ b/config/pitest-suppressions/pitest-ant-suppressions.xml
@@ -66,15 +66,6 @@
   <mutation unstable="false">
     <sourceFile>CheckstyleAntTask.java</sourceFile>
     <mutatedClass>com.puppycrawl.tools.checkstyle.ant.CheckstyleAntTask</mutatedClass>
-    <mutatedMethod>processFiles</mutatedMethod>
-    <mutator>org.pitest.mutationtest.engine.gregor.mutators.NonVoidMethodCallMutator</mutator>
-    <description>removed call to java/lang/String::valueOf</description>
-    <lineContent>throw new BuildException(&quot;Unable to process files: &quot; + files, exc);</lineContent>
-  </mutation>
-
-  <mutation unstable="false">
-    <sourceFile>CheckstyleAntTask.java</sourceFile>
-    <mutatedClass>com.puppycrawl.tools.checkstyle.ant.CheckstyleAntTask</mutatedClass>
     <mutatedMethod>retrieveAllScannedFiles</mutatedMethod>
     <mutator>org.pitest.mutationtest.engine.gregor.mutators.NonVoidMethodCallMutator</mutator>
     <description>removed call to java/lang/Integer::valueOf</description>

--- a/src/test/java/com/puppycrawl/tools/checkstyle/ant/CheckstyleAntTaskTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/ant/CheckstyleAntTaskTest.java
@@ -1029,6 +1029,23 @@ public class CheckstyleAntTaskTest extends AbstractPathTestSupport {
                 .isGreaterThan(0L);
     }
 
+    @Test
+    public void testExceptionMessageContainsFileList() throws Exception {
+        final CheckstyleAntTask antTask = new CheckstyleAntTaskStub();
+        antTask.setConfig(getPath(CONFIG_FILE));
+        antTask.setProject(new Project());
+
+        final File file = new File(getPath(FLAWLESS_INPUT));
+        antTask.setFile(file);
+
+        final BuildException ex = getExpectedThrowable(
+                BuildException.class, antTask::execute, "BuildException is expected");
+
+        assertWithMessage("Exception message must contain the file name")
+                .that(ex.getMessage())
+                .contains(file.getName());
+    }
+
     private static CheckstyleAntTask.Formatter createPlainFormatter(File outputFile) {
         final CheckstyleAntTask.Formatter formatter = new CheckstyleAntTask.Formatter();
         formatter.setTofile(outputFile);


### PR DESCRIPTION
Issue #12341 

SubIssue #18027 

Added the test which kill the mutation of processFiles in CheckStyleAntTask

Error Message -> 

[ERROR]   Failures: 
[ERROR]   CheckstyleAntTaskTest.testExceptionMessageContainsFileList:1044 Exception message must contain the file name
value of           : getMessage()                                                                                                                                                   
expected to contain: InputCheckstyleAntTaskFlawless.java                                                                                                                            
but was            : Unable to process files: 
