### PR TITLE
Issue #18283: allow unnamed variables (_) in naming patterns

### DIFF
--- a/src/it/java/com/google/checkstyle/test/chapter5naming/rule527localvariablenames/LocalVariableNamesTest.java
+++ b/src/it/java/com/google/checkstyle/test/chapter5naming/rule527localvariablenames/LocalVariableNamesTest.java
@@ -52,4 +52,14 @@ public class LocalVariableNamesTest extends AbstractGoogleModuleTestSupport {
         verifyWithWholeConfig(getPath("InputLocalVariableNameOneCharVarName.java"));
     }
 
+    @Test
+    public void testUnnamedVariables() throws Exception {
+        verifyWithWholeConfig(getPath("InputUnnamedVariables.java"));
+    }
+
+    @Test
+    public void testPatternVariableNameUnnamed() throws Exception {
+        verifyWithWholeConfig(getPath("InputPatternVariableNameUnnamed.java"));
+    }
+
 }

--- a/src/it/resources/com/google/checkstyle/test/chapter5naming/rule526parameternames/InputCatchParameterName.java
+++ b/src/it/resources/com/google/checkstyle/test/chapter5naming/rule526parameternames/InputCatchParameterName.java
@@ -94,5 +94,26 @@ public class InputCatchParameterName {
       /* foo */
     } catch (Exception Ex) { // violation 'Catch parameter name 'Ex' must match pattern'
     }
+
+    try {
+      /* foo */
+    } catch (Exception _) {
+      // handle
+    }
+
+    try {
+      /* foo */
+    } catch (Exception _ex) { // violation 'Catch parameter name '_ex' must match pattern'
+    }
+
+    try {
+      /* foo */
+    } catch (Exception e_x) { // violation 'Catch parameter name 'e_x' must match pattern'
+    }
+
+    try {
+      /* foo */
+    } catch (Exception ex_) { // violation 'Catch parameter name 'ex_' must match pattern'
+    }
   }
 }

--- a/src/it/resources/com/google/checkstyle/test/chapter5naming/rule526parameternames/InputLambdaParameterName.java
+++ b/src/it/resources/com/google/checkstyle/test/chapter5naming/rule526parameternames/InputLambdaParameterName.java
@@ -28,4 +28,15 @@ public class InputLambdaParameterName {
 
   BiFunction<String, String, Integer> goodNamedParameters =
       (first, second) -> (first + second).length();
+
+  BiFunction<String, String, String> unnamedParam = (first, _) -> first;
+
+  BiFunction<String, String, String> underscoreStart =
+      (first, _second) -> first; // violation 'Lambda parameter name '_second' must match pattern'
+
+  BiFunction<String, String, String> underscoreMiddle =
+      (first, sec_ond) -> first; // violation 'Lambda parameter name 'sec_ond' must match pattern'
+
+  BiFunction<String, String, String> underscoreEnd =
+      (first, second_) -> first; // violation 'Lambda parameter name 'second_' must match pattern'
 }

--- a/src/it/resources/com/google/checkstyle/test/chapter5naming/rule527localvariablenames/InputPatternVariableNameUnnamed.java
+++ b/src/it/resources/com/google/checkstyle/test/chapter5naming/rule527localvariablenames/InputPatternVariableNameUnnamed.java
@@ -1,0 +1,28 @@
+// Java22
+
+package com.google.checkstyle.test.chapter5naming.rule527localvariablenames;
+
+/** Tests unnamed pattern variables. */
+public class InputPatternVariableNameUnnamed {
+
+  void test(Object o1) {
+    if (o1 instanceof String _) {
+      System.out.println("ok");
+    }
+
+    // violation below 'Pattern variable name '_s' must match pattern'
+    if (o1 instanceof String _s) {
+      System.out.println(_s);
+    }
+
+    // violation below 'Pattern variable name 's_t' must match pattern'
+    if (o1 instanceof String s_t) {
+      System.out.println(s_t);
+    }
+
+    // violation below 'Pattern variable name 'st_' must match pattern'
+    if (o1 instanceof String st_) {
+      System.out.println(st_);
+    }
+  }
+}

--- a/src/it/resources/com/google/checkstyle/test/chapter5naming/rule527localvariablenames/InputUnnamedVariables.java
+++ b/src/it/resources/com/google/checkstyle/test/chapter5naming/rule527localvariablenames/InputUnnamedVariables.java
@@ -1,0 +1,40 @@
+// Java22
+
+package com.google.checkstyle.test.chapter5naming.rule527localvariablenames;
+
+import java.util.HashMap;
+
+/** Tests that unnamed variables (_) are allowed per Google Style. */
+public class InputUnnamedVariables {
+
+  record Point(int x, int y) {}
+
+  void testUnnamedVariables() {
+    for (var _ : new String[] {"foo"}) {
+      System.out.println("iteration");
+    }
+
+    var _ = new Thread();
+
+    switch ("foo") {
+      case String _ -> System.out.println("bar");
+    }
+
+    switch (new Point(0, 0)) {
+      case Point(int _, _) -> System.out.println("point");
+    }
+
+    try {
+      // something
+    } catch (Error _) {
+      // error handling
+    }
+
+    var map = new HashMap<String, Integer>();
+    map.computeIfAbsent("foo", _ -> 23);
+
+    var _name = "test"; // violation 'Local variable name '_name' must match pattern'
+    var na_me = "test"; // violation 'Local variable name 'na_me' must match pattern'
+    var name_ = "test"; // violation 'Local variable name 'name_' must match pattern'
+  }
+}

--- a/src/main/resources/google_checks.xml
+++ b/src/main/resources/google_checks.xml
@@ -265,22 +265,22 @@
              value="Parameter name ''{0}'' must match pattern ''{1}''."/>
     </module>
     <module name="LambdaParameterName">
-      <property name="format" value="^[a-z]([a-z0-9][a-zA-Z0-9]*)?$"/>
+      <property name="format" value="^(_|[a-z]([a-z0-9][a-zA-Z0-9]*)?)$"/>
       <message key="name.invalidPattern"
              value="Lambda parameter name ''{0}'' must match pattern ''{1}''."/>
     </module>
     <module name="CatchParameterName">
-      <property name="format" value="^[a-z]([a-z0-9][a-zA-Z0-9]*)?$"/>
+      <property name="format" value="^(_|[a-z]([a-z0-9][a-zA-Z0-9]*)?)$"/>
       <message key="name.invalidPattern"
              value="Catch parameter name ''{0}'' must match pattern ''{1}''."/>
     </module>
     <module name="LocalVariableName">
-      <property name="format" value="^[a-z]([a-z0-9][a-zA-Z0-9]*)?$"/>
+      <property name="format" value="^(_|[a-z]([a-z0-9][a-zA-Z0-9]*)?)$"/>
       <message key="name.invalidPattern"
              value="Local variable name ''{0}'' must match pattern ''{1}''."/>
     </module>
     <module name="PatternVariableName">
-      <property name="format" value="^[a-z]([a-z0-9][a-zA-Z0-9]*)?$"/>
+      <property name="format" value="^(_|[a-z]([a-z0-9][a-zA-Z0-9]*)?)$"/>
       <message key="name.invalidPattern"
              value="Pattern variable name ''{0}'' must match pattern ''{1}''."/>
     </module>


### PR DESCRIPTION
Issue #18283: 

## Problem
Java 22+ introduced unnamed variables (`_`). The current Google Checks regex flags `_` as a violation in:
- LambdaParameterName
- CatchParameterName
- LocalVariableName
- PatternVariableName

## Solution
Update regex patterns in Google Checks config:
- Before: `^[a-z]([a-z0-9][a-zA-Z0-9]*)?$`
- After: `^(_|[a-z]([a-z0-9][a-zA-Z0-9]*)?)$`

## Changes
- Modified regex for the four checks
- Added `InputUnnamedVariables.java` testing all contexts
- Updated `LocalVariableNamesTest.java` with new test
- Included tests for unnamed lambda and catch parameters
