### PR TITLE
Issue #17882 Update Literal-inline-tag of JavadocCommentsTokenTypes to new Ast print format

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/api/JavadocCommentsTokenTypes.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/api/JavadocCommentsTokenTypes.java
@@ -713,6 +713,23 @@ public final class JavadocCommentsTokenTypes {
 
     /**
      * {@code {@literal}} inline tag.
+     *
+     * <p><b>Example:</b></p>
+     * <pre>{@code * {@literal @Override}}</pre>
+     *
+     * <b>Tree:</b>
+     * <pre>{@code
+     * |--LEADING_ASTERISK -> *
+     * |--TEXT ->
+     * `--JAVADOC_INLINE_TAG -> JAVADOC_INLINE_TAG
+     *     `--LITERAL_INLINE_TAG -> LITERAL_INLINE_TAG
+     *         |--JAVADOC_INLINE_TAG_START -> { @
+     *         |--TAG_NAME -> literal
+     *         |--TEXT ->  @Override
+     *         `--JAVADOC_INLINE_TAG_END -> }
+     * }</pre>
+     *
+     * @see #JAVADOC_INLINE_TAG
      */
     public static final int LITERAL_INLINE_TAG = JavadocCommentsLexer.LITERAL_INLINE_TAG;
 


### PR DESCRIPTION
Fixes: #17882 

```
Command used - 
java -jar checkstyle-12.2.0-all.jar  -j src/Test.java | sed "s/\[[0-9]\+:[0-9]\+\]//g"
```

```
Test.java

/**
 * {@literal @Override}
 */
public class Test {}
```

```
Real Ast-

JAVADOC_CONTENT -> JAVADOC_CONTENT 
|--TEXT -> /**
|--NEWLINE -> \r\n
|--LEADING_ASTERISK ->  *
|--TEXT ->
|--JAVADOC_INLINE_TAG -> JAVADOC_INLINE_TAG
|   `--LITERAL_INLINE_TAG -> LITERAL_INLINE_TAG
|       |--JAVADOC_INLINE_TAG_START -> {@
|       |--TAG_NAME -> literal
|       |--TEXT ->  @Override
|       `--JAVADOC_INLINE_TAG_END -> }
|--NEWLINE -> \r\n
|--LEADING_ASTERISK ->  *
|--TEXT -> /
|--NEWLINE -> \r\n
`--TEXT -> public class Test {}
```




