### PR TITLE
Issue #18283: Allow _ as identifier in Google style for naming checks

### DIFF
--- a/src/main/resources/google_checks.xml
+++ b/src/main/resources/google_checks.xml
@@ -265,22 +265,22 @@
              value="Parameter name ''{0}'' must match pattern ''{1}''."/>
     </module>
     <module name="LambdaParameterName">
-      <property name="format" value="^[a-z]([a-z0-9][a-zA-Z0-9]*)?$"/>
+      <property name="format" value="^(_|[a-z]([a-z0-9][a-zA-Z0-9]*)?)$"/>
       <message key="name.invalidPattern"
              value="Lambda parameter name ''{0}'' must match pattern ''{1}''."/>
     </module>
     <module name="CatchParameterName">
-      <property name="format" value="^[a-z]([a-z0-9][a-zA-Z0-9]*)?$"/>
+      <property name="format" value="^(_|[a-z]([a-z0-9][a-zA-Z0-9]*)?)$"/>
       <message key="name.invalidPattern"
              value="Catch parameter name ''{0}'' must match pattern ''{1}''."/>
     </module>
     <module name="LocalVariableName">
-      <property name="format" value="^[a-z]([a-z0-9][a-zA-Z0-9]*)?$"/>
+      <property name="format" value="^(_|[a-z]([a-z0-9][a-zA-Z0-9]*)?)$"/>
       <message key="name.invalidPattern"
              value="Local variable name ''{0}'' must match pattern ''{1}''."/>
     </module>
     <module name="PatternVariableName">
-      <property name="format" value="^[a-z]([a-z0-9][a-zA-Z0-9]*)?$"/>
+      <property name="format" value="^(_|[a-z]([a-z0-9][a-zA-Z0-9]*)?)$"/>
       <message key="name.invalidPattern"
              value="Pattern variable name ''{0}'' must match pattern ''{1}''."/>
     </module>


### PR DESCRIPTION
Issue #18283 

Description
This pull request updates the Google style configuration (google_checks.xml) to allow the single underscore (_) as a valid identifier in naming checks where it is permitted by the Java language (Java 21 unnamed variables).
This brings Checkstyle’s Google config into alignment with modern Java language behavior and Common Style expectations.

What Was Changed
```
Upgrade regex patterns in `google_checks.xml`
Before: `^[a-z]([a-z0-9][a-zA-Z0-9]*)?$`
After: `^(_|[a-z]([a-z0-9][a-zA-Z0-9]*)?)$`
in-->
1. LambdaParameterName
2.CatchParameterName
3.LocalVariableName
4.PatternVariableName
```