### PR TITLE
[NO_LINE_WRAP] Remove non-line-wrapped statement examples from documentation

### DIFF
--- a/src/site/xdoc/checks/whitespace/nolinewrap.xml
+++ b/src/site/xdoc/checks/whitespace/nolinewrap.xml
@@ -181,13 +181,6 @@ class // violation 'should not be line-wrapped'
     }
   }
 }
-</code></pre></div>
-        <p>
-          Examples of not line-wrapped statements (good case):
-        </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
-import com.puppycrawl.tools.checkstyle.api.AbstractCheck;
-import static java.math.BigInteger.ZERO;
         </code></pre></div>
       </subsection>
 

--- a/src/site/xdoc/checks/whitespace/nolinewrap.xml.template
+++ b/src/site/xdoc/checks/whitespace/nolinewrap.xml.template
@@ -93,13 +93,6 @@
                  value="resources/com/puppycrawl/tools/checkstyle/checks/whitespace/nolinewrap/Example5.java"/>
           <param name="type" value="code"/>
         </macro>
-        <p>
-          Examples of not line-wrapped statements (good case):
-        </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
-import com.puppycrawl.tools.checkstyle.api.AbstractCheck;
-import static java.math.BigInteger.ZERO;
-        </code></pre></div>
       </subsection>
 
       <subsection name="Example of Usage" id="NoLineWrap_Example_of_Usage">


### PR DESCRIPTION
Fixes : #18282

Removed non-line-wrapped statements from `nolinewrap` documentation.