### PR TITLE
Issue #17680: Clarify limitation in 5.2.5 Non-constant field names coverage

### DIFF
--- a/src/site/xdoc/google_style.xml
+++ b/src/site/xdoc/google_style.xml
@@ -1970,6 +1970,19 @@
                   <a href="https://github.com/checkstyle/checkstyle/issues/17842">
                     #17842
                   </a>
+                  <br/>
+                  <br/>
+                  <span class="wrapper inline">
+                    <img
+                        src="images/ban_red.png"
+                        alt="" />
+                  </span>
+                  As with section 5.2.4, due to
+                  <a href="writingchecks.html#Limitations">limitations</a>,
+                  Checkstyle cannot determine whether a static final field is semantically
+                  a constant or not. In other words, MemberName cannot verify that static
+                  final fields use lower case name when they are not constants (e.g.,
+                  static final List&lt;String&gt; names).
                 </td>
                 <td>
                   <a href="https://github.com/checkstyle/checkstyle/tree/master/src/it/resources/com/google/checkstyle/test/chapter5naming/rule525nonconstantfieldnames">


### PR DESCRIPTION
#17680 

The Google Style coverage documentation incorrectly indicated that section 5.2.5 (Non-constant field names) was fully covered by the MemberName check. However, Checkstyle cannot distinguish between true constants (UPPER_SNAKE_CASE) and non-constant static final fields (lowerCamelCase), such as static final List<String> names. I added a red icon and explanatory text clarifying this limitation, consistent with section 5.2.4.
