### PR TITLE
Issue #17449: Add XDocs examples for ConstantNameCheck applyToPackage and applyToPrivate

### DIFF
--- a/src/test/java/com/puppycrawl/tools/checkstyle/internal/XdocsExampleFileTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/internal/XdocsExampleFileTest.java
@@ -60,7 +60,6 @@ public class XdocsExampleFileTest {
     private static final Map<String, Set<String>> SUPPRESSED_PROPERTIES_BY_CHECK = Map.ofEntries(
             Map.entry("MissingJavadocTypeCheck", Set.of("skipAnnotations")),
             Map.entry("JavadocStyleCheck", Set.of("endOfSentenceFormat", "checkEmptyJavadoc")),
-            Map.entry("ConstantNameCheck", Set.of("applyToPackage", "applyToPrivate")),
             Map.entry("WhitespaceAroundCheck", Set.of("allowEmptySwitchBlockStatements")),
             Map.entry("SuppressWarningsHolder", Set.of("aliasList")),
             Map.entry("IllegalTokenTextCheck", Set.of("message")),

--- a/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/checks/naming/ConstantNameCheckExamplesTest.java
+++ b/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/checks/naming/ConstantNameCheckExamplesTest.java
@@ -71,4 +71,16 @@ public class ConstantNameCheckExamplesTest extends AbstractExamplesModuleTestSup
 
         verifyWithInlineConfigParser(getPath("Example3.java"), expected);
     }
+
+    @Test
+    public void testExample4() throws Exception {
+        final String[] expected = {
+            "22:20: " + getCheckMessage(MSG_INVALID_PATTERN, "log", DEFAULT_PATTERN),
+            "24:20: " + getCheckMessage(MSG_INVALID_PATTERN, "logger", DEFAULT_PATTERN),
+            "29:30: " + getCheckMessage(MSG_INVALID_PATTERN, "myselfConstant", DEFAULT_PATTERN),
+        };
+
+        verifyWithInlineConfigParser(getPath("Example4.java"), expected);
+    }
+
 }

--- a/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/naming/constantname/Example4.java
+++ b/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/naming/constantname/Example4.java
@@ -1,0 +1,31 @@
+/*xml
+<module name="Checker">
+  <module name="TreeWalker">
+    <module name="ConstantName">
+      <property name="applyToPackage" value="false"/>
+      <property name="applyToPrivate" value="false"/>
+    </module>
+  </module>
+</module>
+*/
+package com.puppycrawl.tools.checkstyle.checks.naming.constantname;
+
+// xdoc section -- start
+class Example4 {
+  public final static int FIRST_CONSTANT1 = 10;
+  protected final static int SECOND_CONSTANT2 = 100;
+  // ignored, package-private and applyToPackage = false
+  final static int third_Constant3 = 1000;
+  // ignored, private and applyToPrivate = false
+  private final static int fourth_Const4 = 50;
+  // violation, 'must match pattern'
+  public final static int log = 10;
+  // violation, 'must match pattern'
+  protected final static int logger = 50;
+  // ignored, package-private and applyToPackage = false
+  final static int loggerMYSELF = 5;
+  final static int MYSELF = 100;
+  // violation, 'must match pattern'
+  protected final static int myselfConstant = 1;
+}
+// xdoc section -- end


### PR DESCRIPTION
Issue: #17449

This PR adds missing XDoc examples for the ConstantNameCheck properties applyToPackage and applyToPrivate, and wires them into the XDocs examples test infrastructure.

Summary of changes

- XDoc updates for ConstantNameCheck
- Documented the applyToPackage and applyToPrivate properties in the Properties table in
- src/site/xdoc/config_naming.xml → ConstantName section. 
- Added a new example configuration (Example3-config) demonstrating:
- applyToPublic and applyToProtected set to false.
- Added a new Java example (Example4) showing how:
- applyToPrivate = false and applyToPackage = false cause private and package-private constants with non-conforming names to be ignored.

- New example source

- Added Example4.java under src/xdocs-examples/resources-noncompilable/com/puppycrawl/tools/checkstyle/checks/naming/constantname/ with the matching /*xml configuration block for ConstantName using applyToPackage and applyToPrivate.

- New examples test
Added ConstantNameCheckExamplesTest in src/test/java/com/puppycrawl/tools/checkstyle/checks/naming/ to verify:
- Example1 violations with the default format pattern.
- Example2 violations with the custom format that allows log / logger.
- Example3 violations when only non-public constants are validated.
- Example4 produces no violations when applyToPrivate and applyToPackage are disabled.
- Used CommonUtil.EMPTY_STRING_ARRAY for testExample4, since the configuration is intended to be clean.


Testing

- Ran mvn -Pno-validations test -Dtest=ConstantNameCheckExamplesTest locally.
- Verified XdocsExampleFileTest passes without suppressions for ConstantNameCheck.