### PR TITLE
Issue #18027: Resolve pitest for createOverridingProperties in CheckStyleAntTask

### DIFF
--- a/config/pitest-suppressions/pitest-ant-suppressions.xml
+++ b/config/pitest-suppressions/pitest-ant-suppressions.xml
@@ -14,24 +14,6 @@
     <mutatedClass>com.puppycrawl.tools.checkstyle.ant.CheckstyleAntTask</mutatedClass>
     <mutatedMethod>createOverridingProperties</mutatedMethod>
     <mutator>org.pitest.mutationtest.engine.gregor.mutators.NonVoidMethodCallMutator</mutator>
-    <description>removed call to java/util/Map$Entry::getValue</description>
-    <lineContent>final String value = String.valueOf(entry.getValue());</lineContent>
-  </mutation>
-
-  <mutation unstable="false">
-    <sourceFile>CheckstyleAntTask.java</sourceFile>
-    <mutatedClass>com.puppycrawl.tools.checkstyle.ant.CheckstyleAntTask</mutatedClass>
-    <mutatedMethod>createOverridingProperties</mutatedMethod>
-    <mutator>org.pitest.mutationtest.engine.gregor.mutators.NonVoidMethodCallMutator</mutator>
-    <description>removed call to java/util/Properties::setProperty</description>
-    <lineContent>returnValue.setProperty(entry.getKey(), value);</lineContent>
-  </mutation>
-
-  <mutation unstable="false">
-    <sourceFile>CheckstyleAntTask.java</sourceFile>
-    <mutatedClass>com.puppycrawl.tools.checkstyle.ant.CheckstyleAntTask</mutatedClass>
-    <mutatedMethod>createOverridingProperties</mutatedMethod>
-    <mutator>org.pitest.mutationtest.engine.gregor.mutators.NonVoidMethodCallMutator</mutator>
     <description>removed call to java/lang/String::valueOf</description>
     <lineContent>throw new BuildException(&quot;Error loading Properties file &apos;&quot;</lineContent>
   </mutation>

--- a/src/test/java/com/puppycrawl/tools/checkstyle/ant/CheckstyleAntTaskTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/ant/CheckstyleAntTaskTest.java
@@ -1046,6 +1046,25 @@ public class CheckstyleAntTaskTest extends AbstractPathTestSupport {
                 .contains(file.getName());
     }
 
+    @Test
+    public void testAntProjectPropertyValueIsCopiedCorrectly() throws IOException {
+        TestRootModuleChecker.reset();
+
+        final CheckstyleAntTask antTask = getCheckstyleAntTask(CUSTOM_ROOT_CONFIG_FILE);
+
+        final Project project = new Project();
+        project.setProperty("lineLength.severity", "ignore");
+        antTask.setProject(project);
+
+        antTask.setFile(new File(getPath(VIOLATED_INPUT)));
+
+        antTask.execute();
+
+        assertWithMessage("Failed to propagate Ant project property value correctly")
+                .that(TestRootModuleChecker.getProperty())
+                .isEqualTo("ignore");
+    }
+
     private static CheckstyleAntTask.Formatter createPlainFormatter(File outputFile) {
         final CheckstyleAntTask.Formatter formatter = new CheckstyleAntTask.Formatter();
         formatter.setTofile(outputFile);


### PR DESCRIPTION
Issue #12341 

SubIssue #18027 

Added the test which kill the mutation of createOverridingProperties in CheckStyleAntTask
This test removes two mutations 
1. removed call to java/util/Map$Entry::getValue
2. removed call to java/util/Properties::setProperty

Error Message ->

[ERROR] Failures: 
[ERROR]   CheckstyleAntTaskTest.testAntProjectPropertyValueIsCopiedCorrectly:1065 Failed to propagate Ant project property value correctly
value of: getProperty()                                                                                                                                                             
expected: ignore                                                                                                                                                                    
but was an empty string