### PR TITLE
Issue #18265: Added allowMultipleEmptyLinesInsideClassMembers property inside EmptyLineSeparator check in google_checks.xml

### DIFF
--- a/config/google-java-format/excluded/compilable-input-paths.txt
+++ b/config/google-java-format/excluded/compilable-input-paths.txt
@@ -97,3 +97,5 @@ src/it/resources/com/google/checkstyle/test/chapter4formatting/rule4841indentati
 src/it/resources/com/google/checkstyle/test/chapter4formatting/rule4841indentation/InputSwitchWrappingIndentation.java
 src/it/resources/com/google/checkstyle/test/chapter5naming/rule526parameternames/InputRecordComponentNameTwo.java
 src/it/resources/com/google/checkstyle/test/chapter5naming/rule527localvariablenames/InputPatternVariableNameEnhancedInstanceofTestDefault.java
+src/it/resources/com/google/checkstyle/test/chapter4formatting/rule461verticalwhitespace/InputMultipleEmptyLineInsideClassMembers.java
+src/it/resources/com/google/checkstyle/test/chapter4formatting/rule461verticalwhitespace/InputMultipleEmptyLineInsideClassMembers1.java

--- a/src/it/java/com/google/checkstyle/test/chapter4formatting/rule461verticalwhitespace/VerticalWhitespaceTest.java
+++ b/src/it/java/com/google/checkstyle/test/chapter4formatting/rule461verticalwhitespace/VerticalWhitespaceTest.java
@@ -40,4 +40,38 @@ public class VerticalWhitespaceTest extends AbstractGoogleModuleTestSupport {
         verifyWithWholeConfig(getPath("InputFormattedVerticalWhitespace.java"));
     }
 
+    @Test
+    public void testEmptyLineSeparatorBetweenClassMembers() throws Exception {
+        verifyWithWholeConfig(getPath("InputEmptyLineSeparator3.java"));
+    }
+
+    @Test
+    public void testFormattedEmptyLineSeparatorBetweenClassMembers() throws Exception {
+        verifyWithWholeConfig(getPath("InputFormattedEmptyLineSeparator3.java"));
+    }
+
+    @Test
+    public void testFormattedMultipleEmptyLineSeparatorInsideClassMembers() throws Exception {
+        verifyWithWholeConfig(
+                getPath("InputFormattedMultipleEmptyLineInsideClassMembers.java"));
+    }
+
+    @Test
+    public void testMultipleEmptyLineSeparatorInsideClassMembers() throws Exception {
+        verifyWithWholeConfig(
+                getPath("InputMultipleEmptyLineInsideClassMembers.java"));
+    }
+
+    @Test
+    public void testMultipleEmptyLineSeparatorInsideClassMembers1() throws Exception {
+        verifyWithWholeConfig(
+                getPath("InputMultipleEmptyLineInsideClassMembers1.java"));
+    }
+
+    @Test
+    public void testFormattedMultipleEmptyLineSeparatorInsideClassMembers1() throws Exception {
+        verifyWithWholeConfig(
+                getPath("InputFormattedMultipleEmptyLineInsideClassMembers1.java"));
+    }
+
 }

--- a/src/it/resources/com/google/checkstyle/test/chapter4formatting/rule461verticalwhitespace/InputEmptyLineSeparator3.java
+++ b/src/it/resources/com/google/checkstyle/test/chapter4formatting/rule461verticalwhitespace/InputEmptyLineSeparator3.java
@@ -13,15 +13,20 @@ tokens = (default)PACKAGE_DEF, IMPORT, STATIC_IMPORT, CLASS_DEF, INTERFACE_DEF, 
 
 
 
-package com.google.checkstyle.test.chapter4formatting.rule461verticalwhitespace; //violation ''package' has more than 1 empty lines before'
+package com.google.checkstyle.test.chapter4formatting.rule461verticalwhitespace; // violation ''package' has more than 1 empty lines before.'
 
 
 
 
 public class InputEmptyLineSeparator3 {
-// violation above ''CLASS_DEF' has more than 1 empty lines before.'
+  // 2 violations above:
+  // 'Missing a Javadoc comment.'
+  // ''CLASS_DEF' has more than 1 empty lines before.'
 
 
-    String s = "Hello"; // violation ''VARIABLE_DEF' has more than 1 empty lines before.'
+  String str = "Hello"; // violation ''VARIABLE_DEF' has more than 1 empty lines before.'
+
+  /** Another method. */
+  public void bar() {}
 
 }

--- a/src/it/resources/com/google/checkstyle/test/chapter4formatting/rule461verticalwhitespace/InputFormattedEmptyLineSeparator3.java
+++ b/src/it/resources/com/google/checkstyle/test/chapter4formatting/rule461verticalwhitespace/InputFormattedEmptyLineSeparator3.java
@@ -12,10 +12,11 @@ tokens = (default)PACKAGE_DEF, IMPORT, STATIC_IMPORT, CLASS_DEF, INTERFACE_DEF, 
 
 package com.google.checkstyle.test.chapter4formatting.rule461verticalwhitespace;
 
-// violation above ''package' has more than 1 empty lines before.'
-
 public class InputFormattedEmptyLineSeparator3 {
-  // violation above ''CLASS_DEF' has more than 1 empty lines before.'
+  // violation above 'Missing a Javadoc comment.'
 
-  String s = "Hello"; // violation ''VARIABLE_DEF' has more than 1 empty lines before.'
+  String str = "Hello";
+
+  /** Another method. */
+  public void bar() {}
 }

--- a/src/it/resources/com/google/checkstyle/test/chapter4formatting/rule461verticalwhitespace/InputFormattedMultipleEmptyLineInsideClassMembers.java
+++ b/src/it/resources/com/google/checkstyle/test/chapter4formatting/rule461verticalwhitespace/InputFormattedMultipleEmptyLineInsideClassMembers.java
@@ -1,0 +1,52 @@
+package com.google.checkstyle.test.chapter4formatting.rule461verticalwhitespace;
+
+/**
+ * This file contains correct vertical whitespace inside class members and also between class
+ * members.
+ */
+public class InputFormattedMultipleEmptyLineInsideClassMembers {
+
+  static int count;
+  String str;
+  int value;
+
+  {
+    str = "Hello";
+  }
+
+  {
+    value = 10;
+  }
+
+  /** Constructor. */
+  InputFormattedMultipleEmptyLineInsideClassMembers() {
+    int a;
+
+    int b;
+  }
+
+  static {
+    count = 5;
+  }
+
+  static {
+    count++;
+  }
+
+  /** Method. */
+  public void foo() {
+    int x = 10;
+
+    int y = 20;
+  }
+
+  /** Another method. */
+  public void bar() {
+    int z = 30;
+  }
+
+  /** Main method. */
+  public static void main(String[] args) {
+    new InputFormattedMultipleEmptyLineInsideClassMembers();
+  }
+}

--- a/src/it/resources/com/google/checkstyle/test/chapter4formatting/rule461verticalwhitespace/InputFormattedMultipleEmptyLineInsideClassMembers1.java
+++ b/src/it/resources/com/google/checkstyle/test/chapter4formatting/rule461verticalwhitespace/InputFormattedMultipleEmptyLineInsideClassMembers1.java
@@ -1,0 +1,37 @@
+package com.google.checkstyle.test.chapter4formatting.rule461verticalwhitespace;
+
+/** This file contains correct vertical whitespace inside class members i.e enums and interface. */
+public class InputFormattedMultipleEmptyLineInsideClassMembers1 {
+
+  enum Status {
+    STARTED,
+
+    RUNNING,
+
+    FINISHED
+  }
+
+  interface Service {
+
+    void execute();
+
+    default void log() {
+
+      helper();
+    }
+
+    static void printInfo() {
+
+      System.out.println("Service info 1");
+
+      System.out.println("Service info 2");
+    }
+
+    private void helper() {
+
+      System.out.println("Helper logic 1");
+
+      System.out.println("Helper logic 2");
+    }
+  }
+}

--- a/src/it/resources/com/google/checkstyle/test/chapter4formatting/rule461verticalwhitespace/InputMultipleEmptyLineInsideClassMembers.java
+++ b/src/it/resources/com/google/checkstyle/test/chapter4formatting/rule461verticalwhitespace/InputMultipleEmptyLineInsideClassMembers.java
@@ -1,0 +1,99 @@
+package com.google.checkstyle.test.chapter4formatting.rule461verticalwhitespace;
+
+/**
+ * This file contains incorrect vertical whitespace inside class
+ * members and also between class members.
+ */
+public class InputMultipleEmptyLineInsideClassMembers {
+
+
+  static int count; // violation ''VARIABLE_DEF' has more than 1 empty lines before.'
+
+
+  // violation below ''VARIABLE_DEF' has more than 1 empty lines before.'
+  String str;
+
+
+  // violation below ''VARIABLE_DEF' has more than 1 empty lines before.'
+  int value;
+
+
+  { // violation ''INSTANCE_INIT' has more than 1 empty lines before.'
+    str = "Hello"; // violation 'There is more than 1 empty line after this line.'
+
+
+  }
+
+
+  { // violation ''INSTANCE_INIT' has more than 1 empty lines before.'
+    value = 10; // violation 'There is more than 1 empty line after this line.'
+
+
+  }
+
+
+  InputMultipleEmptyLineInsideClassMembers() {
+    // violation above ''CTOR_DEF' has more than 1 empty lines before.'
+    int a; // violation 'There is more than 1 empty line after this line.'
+
+
+    int b; // violation 'There is more than 1 empty line after this line.'
+
+
+  }
+
+
+  static { // violation ''STATIC_INIT' has more than 1 empty lines before.'
+    // violation above 'There is more than 1 empty line after this line.'
+
+
+    count = 5; // violation 'There is more than 1 empty line after this line.'
+
+
+  }
+
+
+  static { // violation ''STATIC_INIT' has more than 1 empty lines before.'
+    // violation above 'There is more than 1 empty line after this line.'
+
+
+    count++; // violation 'There is more than 1 empty line after this line.'
+
+
+  }
+
+  /** Method. */
+  public void foo() {
+
+    int x = 10;
+    // violation above 'There is more than 1 empty line after this line.'
+
+
+    // violation below 'There is more than 1 empty line after this line.'
+    int y = 20;
+
+
+  }
+
+  /** Another method. */
+  public void bar() {
+    // violation above 'There is more than 1 empty line after this line.'
+
+
+    // violation below 'There is more than 1 empty line after this line.'
+    int z = 30;
+
+
+  }
+
+  /** Main method. */
+  public static void main(String[] args) {
+    // violation above 'There is more than 1 empty line after this line.'
+
+
+    // violation below 'There is more than 1 empty line after this line.'
+    new InputMultipleEmptyLineInsideClassMembers();
+
+
+  }
+}

--- a/src/it/resources/com/google/checkstyle/test/chapter4formatting/rule461verticalwhitespace/InputMultipleEmptyLineInsideClassMembers1.java
+++ b/src/it/resources/com/google/checkstyle/test/chapter4formatting/rule461verticalwhitespace/InputMultipleEmptyLineInsideClassMembers1.java
@@ -1,0 +1,75 @@
+package com.google.checkstyle.test.chapter4formatting.rule461verticalwhitespace;
+
+/**
+ * This file contains incorrect vertical whitespace inside class
+ * members i.e enums and interface.
+ */
+public class InputMultipleEmptyLineInsideClassMembers1 {
+
+  enum Status { // false negative until #18437
+
+
+    STARTED, // false negative until #18437
+
+
+    RUNNING, // false negative until #18437
+
+
+    FINISHED // false negative until #18437
+
+
+  }
+
+  interface Service {
+
+    void execute();
+
+
+    default void log() {
+      // 2 violations above:
+      // ''METHOD_DEF' has more than 1 empty lines before.'
+      // 'There is more than 1 empty line after this line.'
+
+
+      helper(); // violation 'There is more than 1 empty line after this line.'
+
+
+    }
+
+
+    static void printInfo() {
+      // 2 violations above:
+      // ''METHOD_DEF' has more than 1 empty lines before.'
+      // 'There is more than 1 empty line after this line.'
+
+
+      System.out.println("Service info 1");
+
+
+      System.out.println("Service info 2"); // false positive until #18438
+      // violation above 'There is more than 1 empty line after this line.'
+
+      // violation 'There is more than 1 empty line after this line.'
+
+
+    }
+
+
+    private void helper() {
+      // 2 violations above:
+      // ''METHOD_DEF' has more than 1 empty lines before.'
+      // 'There is more than 1 empty line after this line.'
+
+
+      System.out.println("Helper logic 1");
+
+
+      System.out.println("Helper logic 2"); // false positive until #18438
+      // violation above 'There is more than 1 empty line after this line.'
+
+      // violation 'There is more than 1 empty line after this line.'
+
+
+    }
+  }
+}

--- a/src/it/resources/com/google/checkstyle/test/chapter4formatting/rule462horizontalwhitespace/InputWhitespaceAroundBasic.java
+++ b/src/it/resources/com/google/checkstyle/test/chapter4formatting/rule462horizontalwhitespace/InputWhitespaceAroundBasic.java
@@ -138,6 +138,7 @@ class InputWhitespaceAroundBasic {
   /** Assert statement test. */
   public void assertTest() {
 
+    // violation below 'There is more than 1 empty line after this line.'
     assert true;
 
 

--- a/src/main/resources/google_checks.xml
+++ b/src/main/resources/google_checks.xml
@@ -210,6 +210,7 @@
                     COMPACT_CTOR_DEF"/>
       <property name="allowNoEmptyLineBetweenFields" value="true"/>
       <property name="allowMultipleEmptyLines" value="false"/>
+      <property name="allowMultipleEmptyLinesInsideClassMembers" value="false"/>
     </module>
     <module name="SeparatorWrap">
       <property name="id" value="SeparatorWrapDot"/>


### PR DESCRIPTION
Issue: #18265

From: https://google.github.io/styleguide/javaguide.html#s4.6.1-vertical-whitespace

- Added a [allowMultipleEmptyLinesInsideClassMembers](https://checkstyle.org/checks/whitespace/emptylineseparator.html#allowMultipleEmptyLinesInsideClassMembers) property inside EmptyLineSeparator check.
- Added test cases `testCorrectEmptyLineSeparatorInsideClassMembers()` and `testIncorrectEmptyLineSeparatorInsideClassMembers()` in `VerticalWhitespaceTest.java`.
- Added input files `InputCorrectEmptyLineInsideClassMembers.java` and `InputIncorrectEmptyLineInsideClassMembers.java` to rule461verticalwhitespace directory.

- From this PR #17950 , `InputEmptyLineSeparator3.java` and `InputFormattedEmptyLineSeparator3.java` were added to the `rule461verticalwhitespace` directory but but they were not covered by any test cases. Therefore, added test cases `testEmptyLineSeparatorBetweenClassMembers()` and `testFormattedEmptyLineSeparatorBetweenClassMembers()` to `VerticalWhitespaceTest.java`.

---
Diff Regression config: https://gist.githubusercontent.com/Praveen7294/605a30d7c12d5fcc633316127e4db0be/raw/c0f9602b094f75a806a296569b5f70a6c3d5e471/base-config-emptyline.xml
Diff Regression patch config: https://gist.githubusercontent.com/Praveen7294/0c2bffd20db9d6c9696c2fce03de4407/raw/f89ddb1333c8bfe4b26e62ba9f3e4327567bfc4e/patch-config-emptyline.xml
Diff Regression projects: https://gist.githubusercontent.com/Praveen7294/a1626a4272b4be9d7a0dc8a9fbae5ffa/raw/22fada1af5a2880572d3e91848996d50427c1616/list-of-projects.properties