### PR TITLE
Issue #18025: Resolve pitest for javaParseExceptionSeverity in TreeWalker

### DIFF
--- a/config/pitest-suppressions/pitest-tree-walker-suppressions.xml
+++ b/config/pitest-suppressions/pitest-tree-walker-suppressions.xml
@@ -3,15 +3,6 @@
   <mutation unstable="false">
     <sourceFile>TreeWalker.java</sourceFile>
     <mutatedClass>com.puppycrawl.tools.checkstyle.TreeWalker</mutatedClass>
-    <mutatedMethod>&lt;init&gt;</mutatedMethod>
-    <mutator>org.pitest.mutationtest.engine.gregor.mutators.experimental.MemberVariableMutator</mutator>
-    <description>Removed assignment to member variable javaParseExceptionSeverity</description>
-    <lineContent>private SeverityLevel javaParseExceptionSeverity = SeverityLevel.ERROR;</lineContent>
-  </mutation>
-
-  <mutation unstable="false">
-    <sourceFile>TreeWalker.java</sourceFile>
-    <mutatedClass>com.puppycrawl.tools.checkstyle.TreeWalker</mutatedClass>
     <mutatedMethod>createNewCheckSortedSet</mutatedMethod>
     <mutator>org.pitest.mutationtest.engine.gregor.mutators.experimental.NakedReceiverMutator</mutator>
     <description>replaced call to java/util/Comparator::thenComparing with receiver</description>

--- a/src/test/java/com/puppycrawl/tools/checkstyle/TreeWalkerTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/TreeWalkerTest.java
@@ -186,6 +186,36 @@ public class TreeWalkerTest extends AbstractModuleTestSupport {
     }
 
     @Test
+    public void testJavaParseExceptionSeverityDefaultIsError() throws Exception {
+        final DefaultConfiguration treeWalkerConfig =
+                createModuleConfig(TreeWalker.class);
+        treeWalkerConfig.addProperty("skipFileOnJavaParseException", "true");
+
+        treeWalkerConfig.addChild(
+                createModuleConfig(NoCodeInFileCheck.class));
+
+        final Checker checker = createChecker(treeWalkerConfig);
+
+        final File[] files = {
+            new File(getNonCompilablePath(
+                    "InputTreeWalkerSkipParsingException.java")),
+        };
+
+        final Map<String, List<String>> expectedViolations = new HashMap<>();
+        expectedViolations.put(
+                getNonCompilablePath("InputTreeWalkerSkipParsingException.java"),
+                List.of(
+                    "1: Java specific (TreeWalker-based) modules are skipped due to an "
+                        + "exception during parsing - IllegalStateException "
+                        + "occurred while parsing file "
+                        + getNonCompilablePath("InputTreeWalkerSkipParsingException.java") + "."
+                )
+        );
+
+        verify(checker, files, expectedViolations);
+    }
+
+    @Test
     public void testImproperFileExtension() throws Exception {
         final String regularFilePath = getPath("InputTreeWalkerImproperFileExtension.java");
         final File originalFile = new File(regularFilePath);
@@ -964,5 +994,4 @@ public class TreeWalkerTest extends AbstractModuleTestSupport {
         }
 
     }
-
 }


### PR DESCRIPTION
Issue #12341 

SubIssue #18025 

Added the test which kill the mutation of javaParseExceptionSeverity in TreeWalker

Error Message ->

```
[ERROR] Failures: 
[ERROR]   TreeWalkerTest.testJavaParseExceptionSeverityDefaultAndSetter:195 Default javaParseExceptionSeverity must be ERROR
value of: getJavaParseExceptionSeverity()                                                                                                                                           
expected: error                                                                                                                                                                     
but was : null
```
