### PR TITLE
minor: using method lineSeparator() instead of getProperty("line.separator")

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/LineSeparatorOption.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/LineSeparatorOption.java
@@ -45,7 +45,7 @@ public enum LineSeparatorOption {
     LF_CR_CRLF("#"),
 
     /** System default line separators. **/
-    SYSTEM(System.getProperty("line.separator"));
+    SYSTEM(System.lineSeparator());
 
     /** The line separator representation. */
     private final byte[] lineSeparator;


### PR DESCRIPTION
minor: using lineSeparator() 

System.lineSeparator() is the preferred, type-safe API for obtaining the platform line separator. It avoids string-based system property access, cannot return null, and is safer in restricted environments.

https://dzone.com/articles/prefer-systemlineseparator-for-writing-system-depe
https://bugs.openjdk.org/browse/JDK-8198645
https://hg.openjdk.org/jdk/jdk/rev/25aa8b9f1dae