### PR TITLE
Issue #17882: Update EXCEPTION_BLOCK_TAG of JavadocCommentsTokenTypes to new AST format

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/api/JavadocCommentsTokenTypes.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/api/JavadocCommentsTokenTypes.java
@@ -242,22 +242,26 @@ public final class JavadocCommentsTokenTypes {
      *
      * <p>Such Javadoc tag can have two children:</p>
      * <ol>
-     *  <li>{@link #IDENTIFIER}</li>
-     *  <li>{@link #DESCRIPTION}</li>
+     *   <li>{@link #IDENTIFIER}</li>
+     *   <li>{@link #DESCRIPTION}</li>
      * </ol>
      *
      * <p><b>Example:</b></p>
      * <pre>{@code * @exception FileNotFoundException when file is not found.}</pre>
+     *
      * <b>Tree:</b>
      * <pre>{@code
-     * JAVADOC_BLOCK_TAG -> JAVADOC_BLOCK_TAG
-     * `--EXCEPTION_BLOCK_TAG -> EXCEPTION_BLOCK_TAG
-     *    |--AT_SIGN -> @
-     *    |--TAG_NAME -> exception
-     *    |--TEXT ->
-     *    |--IDENTIFIER -> FileNotFoundException
-     *    `--DESCRIPTION -> DESCRIPTION
-     *        `--TEXT -> when file is not found.
+     * JAVADOC_CONTENT -> JAVADOC_CONTENT
+     * |--LEADING_ASTERISK -> *
+     * |--TEXT ->
+     * `--JAVADOC_BLOCK_TAG -> JAVADOC_BLOCK_TAG
+     *     `--EXCEPTION_BLOCK_TAG -> EXCEPTION_BLOCK_TAG
+     *         |--AT_SIGN -> @
+     *         |--TAG_NAME -> exception
+     *         |--TEXT ->
+     *         |--IDENTIFIER -> FileNotFoundException
+     *         `--DESCRIPTION -> DESCRIPTION
+     *             `--TEXT ->  when file is not found.
      * }</pre>
      *
      * @see #JAVADOC_BLOCK_TAG


### PR DESCRIPTION
Part of #17882 - Updated the Javadoc for EXCEPTION_BLOCK_TAG to include JAVADOC_CONTENT and LEADING_ASTERISK in the AST tree example.