### PR TITLE
Issue #17882: Update USES_BLOCK_TAG of JavadocCommentsTokenTypes to new AST format

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/api/JavadocCommentsTokenTypes.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/api/JavadocCommentsTokenTypes.java
@@ -379,12 +379,15 @@ public final class JavadocCommentsTokenTypes {
      *
      * <b>Tree:</b>
      * <pre>{@code
-     * JAVADOC_BLOCK_TAG -> JAVADOC_BLOCK_TAG
-     * `--USES_BLOCK_TAG -> USES_BLOCK_TAG
-     *    |--AT_SIGN -> @
-     *    |--TAG_NAME -> uses
-     *    |--TEXT ->
-     *    `--IDENTIFIER -> com.example.app.MyService
+     * JAVADOC_CONTENT -> JAVADOC_CONTENT
+     * |--LEADING_ASTERISK -> *
+     * |--TEXT ->
+     * `--JAVADOC_BLOCK_TAG -> JAVADOC_BLOCK_TAG
+     *     `--USES_BLOCK_TAG -> USES_BLOCK_TAG
+     *         |--AT_SIGN -> @
+     *         |--TAG_NAME -> uses
+     *         |--TEXT ->
+     *         `--IDENTIFIER -> com.example.app.MyService
      * }</pre>
      *
      * @see #JAVADOC_BLOCK_TAG


### PR DESCRIPTION
Part of #17882 - Updated the Javadoc for USES_BLOCK_TAG to include JAVADOC_CONTENT and LEADING_ASTERISK in the AST tree example.