### PR TITLE
Issue #17882: Update DEPRECATED_BLOCK_TAG of JavadocCommentsTokenTypes to new AST format

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/api/JavadocCommentsTokenTypes.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/api/JavadocCommentsTokenTypes.java
@@ -139,7 +139,7 @@ public final class JavadocCommentsTokenTypes {
      *
      * <p>Such Javadoc tag can have one child:</p>
      * <ol>
-     *  <li>{@link #DESCRIPTION}</li>
+     *   <li>{@link #DESCRIPTION}</li>
      * </ol>
      *
      * <p><b>Example:</b></p>
@@ -147,12 +147,15 @@ public final class JavadocCommentsTokenTypes {
      *
      * <b>Tree:</b>
      * <pre>{@code
-     * JAVADOC_BLOCK_TAG -> JAVADOC_BLOCK_TAG
-     * `--DEPRECATED_BLOCK_TAG -> DEPRECATED_BLOCK_TAG
-     *     |--AT_SIGN -> @
-     *     |--TAG_NAME -> deprecated
-     *     `--DESCRIPTION -> DESCRIPTION
-     *         `--TEXT ->  deprecated text.
+     * JAVADOC_CONTENT -> JAVADOC_CONTENT
+     * |--LEADING_ASTERISK -> *
+     * |--TEXT ->
+     * `--JAVADOC_BLOCK_TAG -> JAVADOC_BLOCK_TAG
+     *     `--DEPRECATED_BLOCK_TAG -> DEPRECATED_BLOCK_TAG
+     *         |--AT_SIGN -> @
+     *         |--TAG_NAME -> deprecated
+     *         `--DESCRIPTION -> DESCRIPTION
+     *             `--TEXT ->  deprecated text.
      * }</pre>
      *
      * @see #JAVADOC_BLOCK_TAG


### PR DESCRIPTION
Part of #17882 - Updated the Javadoc for DEPRECATED_BLOCK_TAG to include JAVADOC_CONTENT and LEADING_ASTERISK in the AST tree example.