### PR TITLE
Issue #17882: Update CUSTOM_BLOCK_TAG of JavadocCommentsTokenTypes to new AST format

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/api/JavadocCommentsTokenTypes.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/api/JavadocCommentsTokenTypes.java
@@ -508,15 +508,18 @@ public final class JavadocCommentsTokenTypes {
      *
      * <p><b>Example:</b></p>
      * <pre>{@code * @mycustomtag This is a custom block tag.}</pre>
+     *
      * <b>Tree:</b>
      * <pre>{@code
-     * JAVADOC_BLOCK_TAG -> JAVADOC_BLOCK_TAG
-     * `--CUSTOM_BLOCK_TAG -> CUSTOM_BLOCK_TAG
-     *     |--AT_SIGN -> @
-     *     |--TAG_NAME -> customBlock
-     *     |--TEXT ->
-     *     `--DESCRIPTION -> DESCRIPTION
-     *         `--TEXT ->  This is a custom block tag.
+     * JAVADOC_CONTENT -> JAVADOC_CONTENT
+     * |--LEADING_ASTERISK -> *
+     * |--TEXT ->
+     * `--JAVADOC_BLOCK_TAG -> JAVADOC_BLOCK_TAG
+     *     `--CUSTOM_BLOCK_TAG -> CUSTOM_BLOCK_TAG
+     *         |--AT_SIGN -> @
+     *         |--TAG_NAME -> mycustomtag
+     *         `--DESCRIPTION -> DESCRIPTION
+     *             `--TEXT ->  This is a custom block tag.
      * }</pre>
      *
      * @see #JAVADOC_BLOCK_TAG


### PR DESCRIPTION
Part of #17882 - Updated the Javadoc for CUSTOM_BLOCK_TAG to include JAVADOC_CONTENT and LEADING_ASTERISK in the AST tree example.