### PR TITLE
Issue #6294: Kill pitest mutation in TryHandler.checkTryResParen

### DIFF
--- a/config/pitest-suppressions/pitest-indentation-suppressions.xml
+++ b/config/pitest-suppressions/pitest-indentation-suppressions.xml
@@ -161,13 +161,4 @@
     <description>removed call to com/puppycrawl/tools/checkstyle/checks/indentation/SynchronizedHandler::checkExpressionSubtree</description>
     <lineContent>checkExpressionSubtree(syncAst, expected, false, false);</lineContent>
   </mutation>
-
-  <mutation unstable="false">
-    <sourceFile>TryHandler.java</sourceFile>
-    <mutatedClass>com.puppycrawl.tools.checkstyle.checks.indentation.TryHandler</mutatedClass>
-    <mutatedMethod>checkIndentation</mutatedMethod>
-    <mutator>org.pitest.mutationtest.engine.gregor.mutators.VoidMethodCallMutator</mutator>
-    <description>removed call to com/puppycrawl/tools/checkstyle/checks/indentation/TryHandler::checkTryResParen</description>
-    <lineContent>checkTryResParen(getTryResLparen(), &quot;lparen&quot;);</lineContent>
-  </mutation>
 </suppressedMutations>

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/indentation/IndentationCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/indentation/IndentationCheckTest.java
@@ -4070,6 +4070,23 @@ public class IndentationCheckTest extends AbstractModuleTestSupport {
     }
 
     @Test
+    public void testTryResourcesLparenViolation() throws Exception {
+        final DefaultConfiguration checkConfig = createModuleConfig(IndentationCheck.class);
+        checkConfig.addProperty("basicOffset", "4");
+        checkConfig.addProperty("braceAdjustment", "0");
+        checkConfig.addProperty("caseIndent", "4");
+        checkConfig.addProperty("lineWrappingIndentation", "4");
+        checkConfig.addProperty("throwsIndent", "4");
+        checkConfig.addProperty("forceStrictCondition", "false");
+        checkConfig.addProperty("tabWidth", "4");
+        final String fileName = getPath("InputIndentationTryResourcesLparenViolation.java");
+        final String[] expected = {
+            "22:1: " + getCheckMessage(MSG_ERROR_MULTI, "try lparen", 0, "8, 12"),
+        };
+        verifyWarns(checkConfig, fileName, expected);
+    }
+
+    @Test
     public void testSynchronizedWrapping() throws Exception {
         final DefaultConfiguration checkConfig = createModuleConfig(IndentationCheck.class);
         checkConfig.addProperty("arrayInitIndent", "4");

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/indentation/indentation/InputIndentationTryResourcesLparenViolation.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/indentation/indentation/InputIndentationTryResourcesLparenViolation.java
@@ -1,0 +1,29 @@
+package com.puppycrawl.tools.checkstyle.checks.indentation.indentation;    //indent:0 exp:0
+
+import java.io.BufferedWriter;                                             //indent:0 exp:0
+import java.nio.charset.Charset;                                           //indent:0 exp:0
+import java.nio.file.Files;                                                //indent:0 exp:0
+import java.nio.file.Path;                                                 //indent:0 exp:0
+
+/**                                                                        //indent:0 exp:0
+ * Test input for checkLeftParen lparen violation in TryHandler.           //indent:1 exp:1
+ * basicOffset = 4                                                         //indent:1 exp:1
+ * braceAdjustment = 0                                                     //indent:1 exp:1
+ * caseIndent = 4                                                          //indent:1 exp:1
+ * forceStrictCondition = false                                            //indent:1 exp:1
+ * lineWrappingIndentation = 4                                             //indent:1 exp:1
+ * tabWidth = 4                                                            //indent:1 exp:1
+ * throwsIndent = 4                                                        //indent:1 exp:1
+ */                                                                        //indent:1 exp:1
+public class InputIndentationTryResourcesLparenViolation {                 //indent:0 exp:0
+    void method(Path filePath, Charset charset) throws Exception {         //indent:4 exp:4
+
+        try                                                                //indent:8 exp:8
+(                                                                          //indent:0 exp:8,12 warn
+            BufferedWriter writer =                                        //indent:12 exp:12
+                    Files.newBufferedWriter(filePath, charset)             //indent:20 exp:20
+        ) {                                                                //indent:8 exp:8
+            writer.flush();                                                //indent:12 exp:12
+        }                                                                  //indent:8 exp:8
+    }                                                                      //indent:4 exp:4
+}                                                                          //indent:0 exp:0


### PR DESCRIPTION
Issue #6294:
Kill pitest mutation in TryHandler.checkTryResParen

### Changes
- Added InputIndentationTryResourcesLparenViolation.java with try-with-resources lparen at wrong indentation
- Added testTryResourcesLparenViolation() test in IndentationCheckTest.java
- Removed corresponding mutation suppression from pitest-indentation-suppressions.xml