### PR TITLE
Issue #18303: Added missing examples

### DIFF
--- a/src/site/xdoc/checks/coding/illegaltype.xml
+++ b/src/site/xdoc/checks/coding/illegaltype.xml
@@ -807,10 +807,10 @@ public class Example8 extends TreeSet {
 
   class B extends Gitter {}
   class C extends Github {}
-  // violation below 'Usage of type 'Optional' is not allowed'
+
   public Optional&lt;String&gt; field2;
   protected String field3;
-  Optional&lt;String&gt; field4; // violation, 'Usage of type 'Optional' is not allowed'
+  Optional&lt;String&gt; field4;
 
   private void method(List&lt;Foo&gt; list, Boolean value) {}
 
@@ -823,7 +823,7 @@ public class Example8 extends TreeSet {
   public void var() {
     var message = "Hello, World!";
   } // violation above 'Usage of type 'var' is not allowed'
-  // violation below 'Usage of type 'AbstractSet' is not allowed'
+
   public AbstractSet&lt;String&gt; function4() {
     return null;
   }

--- a/src/site/xdoc/checks/design/onetoplevelclass.xml
+++ b/src/site/xdoc/checks/design/onetoplevelclass.xml
@@ -62,7 +62,7 @@ class ViolationExample2 { // violation, "has to reside in its own source file."
           An example of code without violations:
         </p>
         <div class="wrapper"><pre class="prettyprint"><code class="language-java">
-public class Example3 { // OK, only one top-level class
+public class Example3 { // ok, only one top-level class
   // methods
 }
 </code></pre></div>

--- a/src/site/xdoc/checks/sizes/linelength.xml
+++ b/src/site/xdoc/checks/sizes/linelength.xml
@@ -254,9 +254,9 @@ class Example5 {
         <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
 &lt;module name="Checker"&gt;
   &lt;module name="LineLength"&gt;
-    &lt;property name="max" value="70"/&gt;
+    &lt;property name="max" value="100"/&gt;
   &lt;/module&gt;
-  &lt;module name="SuppressWithPlainTextCommentFilter"&gt;
+  &lt;module name="com.puppycrawl.tools.checkstyle.filters.SuppressWithPlainTextCommentFilter"&gt;
     &lt;property name="checkFormat" value="LineLength"/&gt;
     &lt;property name="offCommentFormat" value='^.*"""$'/&gt;
     &lt;property name="onCommentFormat" value='^\s*"""\s*(?:[,;]|.+)$'/&gt;

--- a/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/checks/coding/IllegalTypeCheckExamplesTest.java
+++ b/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/checks/coding/IllegalTypeCheckExamplesTest.java
@@ -121,6 +121,25 @@ public class IllegalTypeCheckExamplesTest extends AbstractExamplesModuleTestSupp
     }
 
     @Test
+    public void testExample7() throws Exception {
+        final String[] expected = {
+            "73:10: " + getCheckMessage(IllegalTypeCheck.MSG_KEY, "Optional"),
+            "75:3: " + getCheckMessage(IllegalTypeCheck.MSG_KEY, "Optional"),
+        };
+
+        verifyWithInlineConfigParser(getPath("Example7.java"), expected);
+    }
+
+    @Test
+    public void testExample8() throws Exception {
+        final String[] expected = {
+            "74:5: " + getCheckMessage(IllegalTypeCheck.MSG_KEY, "var"),
+        };
+
+        verifyWithInlineConfigParser(getPath("Example8.java"), expected);
+    }
+
+    @Test
     public void testExample9() throws Exception {
         final String[] expected = {
             "20:31: " + getCheckMessage(IllegalTypeCheck.MSG_KEY, "TreeSet"),

--- a/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/checks/coding/UnnecessaryParenthesesCheckExamplesTest.java
+++ b/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/checks/coding/UnnecessaryParenthesesCheckExamplesTest.java
@@ -61,4 +61,13 @@ public class UnnecessaryParenthesesCheckExamplesTest extends AbstractExamplesMod
         };
         verifyWithInlineConfigParser(getPath("Example2.java"), expected);
     }
+
+    @Test
+    public void testExample3() throws Exception {
+        final String[] expected = {
+            "17:13: " + getCheckMessage(MSG_EXPR),
+            "19:22: " + getCheckMessage(MSG_EXPR),
+        };
+        verifyWithInlineConfigParser(getPath("Example3.java"), expected);
+    }
 }

--- a/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/checks/design/OneTopLevelClassCheckExamplesTest.java
+++ b/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/checks/design/OneTopLevelClassCheckExamplesTest.java
@@ -24,6 +24,7 @@ import static com.puppycrawl.tools.checkstyle.checks.design.OneTopLevelClassChec
 import org.junit.jupiter.api.Test;
 
 import com.puppycrawl.tools.checkstyle.AbstractExamplesModuleTestSupport;
+import com.puppycrawl.tools.checkstyle.utils.CommonUtil;
 
 public class OneTopLevelClassCheckExamplesTest extends AbstractExamplesModuleTestSupport {
     @Override
@@ -47,6 +48,12 @@ public class OneTopLevelClassCheckExamplesTest extends AbstractExamplesModuleTes
         };
 
         verifyWithInlineConfigParser(getPath("Example2.java"), expected);
+    }
+
+    @Test
+    public void testExample3() throws Exception {
+        final String[] expected = CommonUtil.EMPTY_STRING_ARRAY;
+        verifyWithInlineConfigParser(getPath("Example3.java"), expected);
     }
 
 }

--- a/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocMethodCheckExamplesTest.java
+++ b/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocMethodCheckExamplesTest.java
@@ -104,4 +104,10 @@ public class JavadocMethodCheckExamplesTest extends AbstractExamplesModuleTestSu
 
         verifyWithInlineConfigParser(getPath("Example7.java"), expected);
     }
+
+    @Test
+    public void testExample8() throws Exception {
+        final String[] expected = CommonUtil.EMPTY_STRING_ARRAY;
+        verifyWithInlineConfigParser(getPath("Example8.java"), expected);
+    }
 }

--- a/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocTagContinuationIndentationCheckExamplesTest.java
+++ b/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocTagContinuationIndentationCheckExamplesTest.java
@@ -58,4 +58,16 @@ public class JavadocTagContinuationIndentationCheckExamplesTest
 
         verifyWithInlineConfigParser(getPath("Example3.java"), expected);
     }
+
+    @Test
+    public void testExample4() throws Exception {
+        final String[] expected = {
+            "29: " + getCheckMessage(MSG_KEY, 4),
+            "30: " + getCheckMessage(MSG_KEY, 4),
+            "31: " + getCheckMessage(MSG_KEY, 4),
+            "32: " + getCheckMessage(MSG_KEY, 4),
+        };
+
+        verifyWithInlineConfigParser(getPath("Example4.java"), expected);
+    }
 }

--- a/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/checks/sizes/LineLengthCheckExamplesTest.java
+++ b/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/checks/sizes/LineLengthCheckExamplesTest.java
@@ -74,4 +74,10 @@ public class LineLengthCheckExamplesTest extends AbstractExamplesModuleTestSuppo
 
         verifyWithInlineConfigParser(getPath("Example5.java"), expected);
     }
+
+    @Test
+    public void testExample6() throws Exception {
+        final String[] expected = CommonUtil.EMPTY_STRING_ARRAY;
+        verifyWithInlineConfigParser(getPath("Example6.java"), expected);
+    }
 }

--- a/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/coding/illegaltype/Example7.java
+++ b/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/coding/illegaltype/Example7.java
@@ -17,7 +17,15 @@
 package com.puppycrawl.tools.checkstyle.checks.coding.illegaltype;
 
 import java.io.Serializable;
-import java.util.*;
+import java.util.Optional;
+import java.util.HashMap;
+import java.util.LinkedHashMap;
+import java.util.TreeMap;
+import java.util.TreeSet;
+import java.util.List;
+import java.util.Set;
+import java.util.AbstractSet;
+import java.util.AbstractList;
 import java.util.function.Consumer;
 
 // xdoc section -- start

--- a/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/coding/illegaltype/Example8.java
+++ b/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/coding/illegaltype/Example8.java
@@ -57,10 +57,10 @@ public class Example8 extends TreeSet {
 
   class B extends Gitter {}
   class C extends Github {}
-  // violation below 'Usage of type 'Optional' is not allowed'
+
   public Optional<String> field2;
   protected String field3;
-  Optional<String> field4; // violation, 'Usage of type 'Optional' is not allowed'
+  Optional<String> field4;
 
   private void method(List<Foo> list, Boolean value) {}
 
@@ -73,7 +73,7 @@ public class Example8 extends TreeSet {
   public void var() {
     var message = "Hello, World!";
   } // violation above 'Usage of type 'var' is not allowed'
-  // violation below 'Usage of type 'AbstractSet' is not allowed'
+
   public AbstractSet<String> function4() {
     return null;
   }

--- a/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/design/onetoplevelclass/Example3.java
+++ b/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/design/onetoplevelclass/Example3.java
@@ -9,7 +9,7 @@
 package com.puppycrawl.tools.checkstyle.checks.design.onetoplevelclass;
 
 // xdoc section -- start
-public class Example3 { // OK, only one top-level class
+public class Example3 { // ok, only one top-level class
   // methods
 }
 // xdoc section -- end

--- a/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/sizes/linelength/Example6.java
+++ b/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/sizes/linelength/Example6.java
@@ -1,9 +1,9 @@
 /*xml
 <module name="Checker">
   <module name="LineLength">
-    <property name="max" value="70"/>
+    <property name="max" value="100"/>
   </module>
-  <module name="SuppressWithPlainTextCommentFilter">
+  <module name="com.puppycrawl.tools.checkstyle.filters.SuppressWithPlainTextCommentFilter">
     <property name="checkFormat" value="LineLength"/>
     <property name="offCommentFormat" value='^.*"""$'/>
     <property name="onCommentFormat" value='^\s*"""\s*(?:[,;]|.+)$'/>


### PR DESCRIPTION
Issue : #18303 

Added missing examples which are not added in their ExampleTest file as discussed . The files changes are-

 ```
  1. src/site/xdoc/checks/coding/illegaltype.xml
  2.src/site/xdoc/checks/design/onetoplevelclass.xml
  3.src/site/xdoc/checks/sizes/linelength.xml
  4.src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/checks/coding/IllegalTypeCheckExamplesTest.java
  5.src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/checks/coding/UnnecessaryParenthesesCheckExamplesTest.java
  6.src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/checks/design/OneTopLevelClassCheckExamplesTest.java
  7.src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocMethodCheckExamplesTest.java   
  8.src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocTagContinuationIndentationCheckExamplesTest.java
  9.src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/checks/sizes/LineLengthCheckExamplesTest.java        
 10.src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/coding/illegaltype/Example7.java
 11.src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/coding/illegaltype/Example8.java
 12.src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/design/onetoplevelclass/Example3.java    
 13.src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/sizes/linelength/Example6.java
```

I also updated some Examples because some of them are wrong-

```
1.src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/coding/illegaltype/Example7.java - > does not contain proper header files

2.src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/coding/illegaltype/Example8.java -> only violates var first it has included optional violations but did not throw them

3.src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/design/onetoplevelclass/Example3.java -> spell mistake (changes "OK" to "ok") otherwise the test throws errors

4.src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/sizes/linelength/Example6.java -> changes suppression path added correct path
```