### PR TITLE
Issue #17177: Examples Validation content is same in all for single C…

### DIFF
--- a/src/site/xdoc/checks/annotation/suppresswarningsholder.xml
+++ b/src/site/xdoc/checks/annotation/suppresswarningsholder.xml
@@ -105,7 +105,7 @@ class Example1 {
 </code></pre></div>
         <p id="Example2-code">Example:</p>
         <div class="wrapper"><pre class="prettyprint"><code class="language-java">
-class Example2 {
+public class Example2 {
   // violation below, 'More than 7 parameters (found 8)'
   public void needsLotsOfParameters (int a,
     int b, int c, int d, int e, int f, int g, int h) {

--- a/src/test/java/com/puppycrawl/tools/checkstyle/internal/XdocsExamplesAstConsistencyTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/internal/XdocsExamplesAstConsistencyTest.java
@@ -77,9 +77,7 @@ public class XdocsExamplesAstConsistencyTest {
     private static final Set<String> SUPPRESSED_EXAMPLES = Set.of(
             "checks/annotation/annotationonsameline/Example2",
             "checks/annotation/missingoverride/Example2",
-            "checks/annotation/suppresswarningsholder/Example2",
-            "checks/annotation/suppresswarningsholder/Example3",
-            "checks/annotation/suppresswarningsholder/Example4",
+            "checks/annotation/suppresswarningsholder/Example1",
             "checks/blocks/emptyblock/Example3",
             "checks/blocks/emptycatchblock/Example4",
             "checks/blocks/emptycatchblock/Example5",

--- a/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/annotation/suppresswarningsholder/Example2.java
+++ b/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/annotation/suppresswarningsholder/Example2.java
@@ -14,7 +14,7 @@
 package com.puppycrawl.tools.checkstyle.checks.annotation.suppresswarningsholder;
 
 // xdoc section -- start
-class Example2 {
+public class Example2 {
   // violation below, 'More than 7 parameters (found 8)'
   public void needsLotsOfParameters (int a,
     int b, int c, int d, int e, int f, int g, int h) {


### PR DESCRIPTION
#17177 

Add AST Consistency Test for Xdocs Examples

**Description**

This PR adds a new test `XdocsExamplesAstConsistencyTest` that validates all xdocs Java examples for the same check have identical AST structure, differing only in comments. This ensures consistency across documentation examples as requested in issue #13345.

**Changes**

Added:
- `XdocsExamplesAstConsistencyTest.java`: New JUnit test class that:
  - Scans all directories under `src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle`
  - Compares AST structure of all `Example*.java` files within each directory
  - Ignores comment nodes (SINGLE_LINE_COMMENT, BLOCK_COMMENT_BEGIN, COMMENT_CONTENT) during comparison
  - Reports violations when examples have different code structures
  - Includes suppression list for existing violations (81 directories)

Current behavior:
- Test passes with suppressions in place
- Skips 81 suppressed directories
- Validates all non-suppressed directories

Example violation output (when suppression is removed):
```
Directory: checks/annotation/annotationlocation
Reference: Example1.java
Mismatch:  Example2.java
```

<img width="1286" height="722" alt="image" src="https://github.com/user-attachments/assets/061b68cb-c7f7-44d0-a9ea-0f7055671a47" />
