### PR TITLE
Issue #6294: Kill pitest mutation in Switch Handler

### DIFF
--- a/config/pitest-suppressions/pitest-indentation-suppressions.xml
+++ b/config/pitest-suppressions/pitest-indentation-suppressions.xml
@@ -127,24 +127,6 @@
   </mutation>
 
   <mutation unstable="false">
-    <sourceFile>SwitchHandler.java</sourceFile>
-    <mutatedClass>com.puppycrawl.tools.checkstyle.checks.indentation.SwitchHandler</mutatedClass>
-    <mutatedMethod>checkIndentation</mutatedMethod>
-    <mutator>org.pitest.mutationtest.engine.gregor.mutators.VoidMethodCallMutator</mutator>
-    <description>removed call to com/puppycrawl/tools/checkstyle/checks/indentation/SwitchHandler::checkSwitchExpr</description>
-    <lineContent>checkSwitchExpr();</lineContent>
-  </mutation>
-
-  <mutation unstable="false">
-    <sourceFile>SwitchHandler.java</sourceFile>
-    <mutatedClass>com.puppycrawl.tools.checkstyle.checks.indentation.SwitchHandler</mutatedClass>
-    <mutatedMethod>checkSwitchExpr</mutatedMethod>
-    <mutator>org.pitest.mutationtest.engine.gregor.mutators.VoidMethodCallMutator</mutator>
-    <description>removed call to com/puppycrawl/tools/checkstyle/checks/indentation/SwitchHandler::checkExpressionSubtree</description>
-    <lineContent>checkExpressionSubtree(</lineContent>
-  </mutation>
-
-  <mutation unstable="false">
     <sourceFile>SynchronizedHandler.java</sourceFile>
     <mutatedClass>com.puppycrawl.tools.checkstyle.checks.indentation.SynchronizedHandler</mutatedClass>
     <mutatedMethod>checkIndentation</mutatedMethod>

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/indentation/IndentationCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/indentation/IndentationCheckTest.java
@@ -4037,6 +4037,23 @@ public class IndentationCheckTest extends AbstractModuleTestSupport {
     }
 
     @Test
+    public void testSwitchExprViolation() throws Exception {
+        final DefaultConfiguration checkConfig = createModuleConfig(IndentationCheck.class);
+        checkConfig.addProperty("basicOffset", "4");
+        checkConfig.addProperty("braceAdjustment", "0");
+        checkConfig.addProperty("caseIndent", "4");
+        checkConfig.addProperty("lineWrappingIndentation", "4");
+        checkConfig.addProperty("throwsIndent", "4");
+        checkConfig.addProperty("forceStrictCondition", "false");
+        checkConfig.addProperty("tabWidth", "4");
+        final String fileName = getPath("InputIndentationSwitchExprViolation.java");
+        final String[] expected = {
+            "18:1: " + getCheckMessage(MSG_CHILD_ERROR, "switch", 0, 8),
+        };
+        verifyWarns(checkConfig, fileName, expected);
+    }
+
+    @Test
     public void testIndentationSealedClasses()
             throws Exception {
         final DefaultConfiguration checkConfig = createModuleConfig(IndentationCheck.class);

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/indentation/indentation/InputIndentationSwitchExprViolation.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/indentation/indentation/InputIndentationSwitchExprViolation.java
@@ -1,0 +1,24 @@
+package com.puppycrawl.tools.checkstyle.checks.indentation.indentation;    //indent:0 exp:0
+
+/**                                                                        //indent:0 exp:0
+ * This test input is intended to be checked using following configuration //indent:1 exp:1
+ *                                                                         //indent:1 exp:1
+ * basicOffset = 4                                                         //indent:1 exp:1
+ * braceAdjustment = 0                                                     //indent:1 exp:1
+ * caseIndent = 4                                                          //indent:1 exp:1
+ * forceStrictCondition = false                                            //indent:1 exp:1
+ * lineWrappingIndentation = 4                                             //indent:1 exp:1
+ * tabWidth = 4                                                            //indent:1 exp:1
+ * throwsIndent = 4                                                        //indent:1 exp:1
+ */                                                                        //indent:1 exp:1
+public class InputIndentationSwitchExprViolation {                         //indent:0 exp:0
+    void method() {                                                        //indent:4 exp:4
+        int x = 1;                                                         //indent:8 exp:8
+        switch (                                                           //indent:8 exp:8
+x                                                                          //indent:0 exp:8 warn
+        ) {                                                                //indent:8 exp:8
+            case 1:                                                        //indent:12 exp:12
+                break;                                                     //indent:16 exp:16
+        }                                                                  //indent:8 exp:8
+    }                                                                      //indent:4 exp:4
+}                                                                          //indent:0 exp:0


### PR DESCRIPTION
 Issue #6294:

### Summary
Added test to kill surviving pitest mutations in [SwitchHandler.java](cci:7://file:///Users/vivek/checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/checks/indentation/SwitchHandler.java:0:0-0:0).

### Changes
- Added InputIndentationSwitchExprViolation.java  - test input with switch expression on its own line at wrong indentation (column 0)
- Added testSwitchExprViolation()  test method in IndentationCheckTest.java
- Removed 2 mutation suppressions from pitest-indentation-suppressions.xml
  - `SwitchHandler.checkIndentation` → checkSwitchExpr()) call
  - `SwitchHandler.checkSwitchExpr` → `checkExpressionSubtree()` call