### PR TITLE
Issue #6294: Kill pitest mutation in SynchronizedHandler

### DIFF
--- a/config/pitest-suppressions/pitest-indentation-suppressions.xml
+++ b/config/pitest-suppressions/pitest-indentation-suppressions.xml
@@ -125,22 +125,4 @@
     <description>changed conditional boundary</description>
     <lineContent>if (node.getLineNo() &lt; lineStart) {</lineContent>
   </mutation>
-
-  <mutation unstable="false">
-    <sourceFile>SynchronizedHandler.java</sourceFile>
-    <mutatedClass>com.puppycrawl.tools.checkstyle.checks.indentation.SynchronizedHandler</mutatedClass>
-    <mutatedMethod>checkIndentation</mutatedMethod>
-    <mutator>org.pitest.mutationtest.engine.gregor.mutators.VoidMethodCallMutator</mutator>
-    <description>removed call to com/puppycrawl/tools/checkstyle/checks/indentation/SynchronizedHandler::checkSynchronizedExpr</description>
-    <lineContent>checkSynchronizedExpr();</lineContent>
-  </mutation>
-
-  <mutation unstable="false">
-    <sourceFile>SynchronizedHandler.java</sourceFile>
-    <mutatedClass>com.puppycrawl.tools.checkstyle.checks.indentation.SynchronizedHandler</mutatedClass>
-    <mutatedMethod>checkSynchronizedExpr</mutatedMethod>
-    <mutator>org.pitest.mutationtest.engine.gregor.mutators.VoidMethodCallMutator</mutator>
-    <description>removed call to com/puppycrawl/tools/checkstyle/checks/indentation/SynchronizedHandler::checkExpressionSubtree</description>
-    <lineContent>checkExpressionSubtree(syncAst, expected, false, false);</lineContent>
-  </mutation>
 </suppressedMutations>

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/indentation/IndentationCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/indentation/IndentationCheckTest.java
@@ -4020,6 +4020,23 @@ public class IndentationCheckTest extends AbstractModuleTestSupport {
     }
 
     @Test
+    public void testSynchronizedExprViolation() throws Exception {
+        final DefaultConfiguration checkConfig = createModuleConfig(IndentationCheck.class);
+        checkConfig.addProperty("basicOffset", "4");
+        checkConfig.addProperty("braceAdjustment", "0");
+        checkConfig.addProperty("caseIndent", "4");
+        checkConfig.addProperty("lineWrappingIndentation", "4");
+        checkConfig.addProperty("throwsIndent", "4");
+        checkConfig.addProperty("forceStrictCondition", "false");
+        checkConfig.addProperty("tabWidth", "4");
+        final String fileName = getPath("InputIndentationSynchronizedExprViolation.java");
+        final String[] expected = {
+            "18:1: " + getCheckMessage(MSG_CHILD_ERROR, "synchronized", 0, 12),
+        };
+        verifyWarns(checkConfig, fileName, expected);
+    }
+
+    @Test
     public void testIndentationAnnotationArray() throws Exception {
         final DefaultConfiguration checkConfig = createModuleConfig(IndentationCheck.class);
         checkConfig.addProperty("tabWidth", "4");

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/indentation/indentation/InputIndentationSynchronizedExprViolation.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/indentation/indentation/InputIndentationSynchronizedExprViolation.java
@@ -1,0 +1,23 @@
+package com.puppycrawl.tools.checkstyle.checks.indentation.indentation;    //indent:0 exp:0
+
+/**                                                                        //indent:0 exp:0
+ * This test input is intended to be checked using following configuration //indent:1 exp:1
+ *                                                                         //indent:1 exp:1
+ * basicOffset = 4                                                         //indent:1 exp:1
+ * braceAdjustment = 0                                                     //indent:1 exp:1
+ * caseIndent = 4                                                          //indent:1 exp:1
+ * forceStrictCondition = false                                            //indent:1 exp:1
+ * lineWrappingIndentation = 4                                             //indent:1 exp:1
+ * tabWidth = 4                                                            //indent:1 exp:1
+ * throwsIndent = 4                                                        //indent:1 exp:1
+ */                                                                        //indent:1 exp:1
+public class InputIndentationSynchronizedExprViolation {                   //indent:0 exp:0
+    private final Object lock = new Object();                              //indent:4 exp:4
+    void method() {                                                        //indent:4 exp:4
+        synchronized (                                                     //indent:8 exp:8
+lock                                                                       //indent:0 exp:12 warn
+        ) {                                                                //indent:8 exp:8
+            System.out.println("test");                                    //indent:12 exp:12
+        }                                                                  //indent:8 exp:8
+    }                                                                      //indent:4 exp:4
+}                                                                          //indent:0 exp:0


### PR DESCRIPTION
 Issue #6294: 

### Summary
Added test to kill surviving pitest mutations in SynchronizedHandler.java

### Changes
- Added `InputIndentationSynchronizedExprViolation.java`  test input with synchronized expression on its own line at wrong indentation (column 0)
- Added testSynchronizedExprViolation() test method in IndentationCheckTest.java
- Removed 2 mutation suppressions from pitest-indentation-suppressions.xml
  - `SynchronizedHandler.checkIndentation` → checkSynchronizedExpr() call
  - `SynchronizedHandler.checkSynchronizedExpr` → checkExpressionSubtree() call