### PR TITLE
Issue #18034: Resolve PIT Mutation Suppression for NonVoidMethodCallM…

### DIFF
--- a/config/pitest-suppressions/pitest-imports-suppressions.xml
+++ b/config/pitest-suppressions/pitest-imports-suppressions.xml
@@ -1,42 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <suppressedMutations>
   <mutation unstable="false">
-    <sourceFile>ImportControlCheck.java</sourceFile>
-    <mutatedClass>com.puppycrawl.tools.checkstyle.checks.imports.ImportControlCheck</mutatedClass>
-    <mutatedMethod>setFile</mutatedMethod>
-    <mutator>org.pitest.mutationtest.engine.gregor.mutators.NonVoidMethodCallMutator</mutator>
-    <description>removed call to java/lang/String::valueOf</description>
-    <lineContent>throw new IllegalArgumentException(UNABLE_TO_LOAD + uri, exc);</lineContent>
-  </mutation>
-
-  <mutation unstable="false">
-    <sourceFile>ImportControlLoader.java</sourceFile>
-    <mutatedClass>com.puppycrawl.tools.checkstyle.checks.imports.ImportControlLoader</mutatedClass>
-    <mutatedMethod>load</mutatedMethod>
-    <mutator>org.pitest.mutationtest.engine.gregor.mutators.NonVoidMethodCallMutator</mutator>
-    <description>removed call to java/lang/String::valueOf</description>
-    <lineContent>throw new CheckstyleException(&quot;unable to read &quot; + uri, exc);</lineContent>
-  </mutation>
-
-  <mutation unstable="false">
-    <sourceFile>ImportControlLoader.java</sourceFile>
-    <mutatedClass>com.puppycrawl.tools.checkstyle.checks.imports.ImportControlLoader</mutatedClass>
-    <mutatedMethod>loadUri</mutatedMethod>
-    <mutator>org.pitest.mutationtest.engine.gregor.mutators.NonVoidMethodCallMutator</mutator>
-    <description>removed call to java/lang/String::valueOf</description>
-    <lineContent>throw new CheckstyleException(&quot;syntax error in url &quot; + uri, exc);</lineContent>
-  </mutation>
-
-  <mutation unstable="false">
-    <sourceFile>ImportControlLoader.java</sourceFile>
-    <mutatedClass>com.puppycrawl.tools.checkstyle.checks.imports.ImportControlLoader</mutatedClass>
-    <mutatedMethod>loadUri</mutatedMethod>
-    <mutator>org.pitest.mutationtest.engine.gregor.mutators.NonVoidMethodCallMutator</mutator>
-    <description>removed call to java/lang/String::valueOf</description>
-    <lineContent>throw new CheckstyleException(&quot;unable to find &quot; + uri, exc);</lineContent>
-  </mutation>
-
-  <mutation unstable="false">
     <sourceFile>ImportOrderCheck.java</sourceFile>
     <mutatedClass>com.puppycrawl.tools.checkstyle.checks.imports.ImportOrderCheck</mutatedClass>
     <mutatedMethod>visitToken</mutatedMethod>

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/imports/ImportControlCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/imports/ImportControlCheckTest.java
@@ -27,6 +27,7 @@ import static com.puppycrawl.tools.checkstyle.checks.imports.ImportControlCheck.
 import static com.puppycrawl.tools.checkstyle.internal.utils.TestUtil.getExpectedThrowable;
 
 import java.io.File;
+import java.net.URI;
 import java.nio.file.Files;
 import java.util.Arrays;
 import java.util.List;
@@ -146,6 +147,26 @@ public class ImportControlCheckTest extends AbstractModuleTestSupport {
                     .that(message)
                     .startsWith(messageStart);
         }
+    }
+
+    @Test
+    public void testSetFileContainsUriInMessage() {
+        final ImportControlCheck check = new ImportControlCheck();
+        final File missingFile = new File(temporaryFolder, "missing-import-control.xml");
+        final URI uri = missingFile.toURI();
+
+        final IllegalArgumentException exception =
+                getExpectedThrowable(IllegalArgumentException.class, () -> check.setFile(uri));
+
+        assertWithMessage("Invalid exception message")
+                .that(exception.getMessage())
+                .isEqualTo("Unable to load " + uri);
+        assertWithMessage("Invalid exception cause")
+                .that(exception.getCause())
+                .isInstanceOf(CheckstyleException.class);
+        assertWithMessage("Cause message should contain uri")
+                .that(exception.getCause().getMessage())
+                .isEqualTo("unable to find " + uri);
     }
 
     @Test

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/imports/ImportControlLoaderTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/imports/ImportControlLoaderTest.java
@@ -60,15 +60,18 @@ public class ImportControlLoaderTest {
 
     @Test
     public void testWrongFormatUri() throws Exception {
+        final URI uri = new URI("aaa://" + getPath("InputImportControlLoaderComplete.xml"));
         try {
-            ImportControlLoader.load(new URI("aaa://"
-                    + getPath("InputImportControlLoaderComplete.xml")));
+            ImportControlLoader.load(uri);
             assertWithMessage("exception expected").fail();
         }
         catch (CheckstyleException exc) {
             assertWithMessage("Invalid exception class")
                 .that(exc.getCause())
                 .isInstanceOf(MalformedURLException.class);
+            assertWithMessage("Invalid exception message")
+                .that(exc.getMessage())
+                .isEqualTo("syntax error in url " + uri);
             assertWithMessage("Invalid exception message")
                 .that(exc)
                 .hasCauseThat()
@@ -119,10 +122,11 @@ public class ImportControlLoaderTest {
     // and is difficult to emulate
     public void testLoadThrowsException() {
         final InputSource source = new InputSource();
+        final URI uri = new File(getPath("InputImportControlLoaderComplete.xml")).toURI();
         try {
             final Class<?> clazz = ImportControlLoader.class;
             TestUtil.invokeVoidStaticMethod(clazz, "load", source,
-                    new File(getPath("InputImportControlLoaderComplete.xml")).toURI());
+                    uri);
             assertWithMessage("exception expected").fail();
         }
         catch (ReflectiveOperationException exc) {
@@ -133,7 +137,7 @@ public class ImportControlLoaderTest {
                     .that(exc)
                     .hasCauseThat()
                     .hasMessageThat()
-                    .startsWith("unable to read");
+                    .isEqualTo("unable to read " + uri);
         }
     }
 


### PR DESCRIPTION
Remove the three `NonVoidMethodCallMutator` suppressions from `pitest-imports-suppression.xml`, but keep the following one:
```xml
<mutation unstable="false">
  <sourceFile>ImportOrderCheck.java</sourceFile>
  <mutatedClass>com.puppycrawl.tools.checkstyle.checks.imports.ImportOrderCheck</mutatedClass>
  <mutatedMethod>visitToken</mutatedMethod>
  <mutator>org.pitest.mutationtest.engine.gregor.mutators.NonVoidMethodCallMutator</mutator>
  <description>removed call to java/lang/String::valueOf</description>
  <lineContent>throw new IllegalStateException(</lineContent>
</mutation>
```

This suppression is retained because it represents an equivalent mutation. Removing String.valueOf(option) does not change the resulting exception message: StringBuilder.append(null) still produces "null". Since there is no observable behavior difference, keeping this suppression is appropriate.

**Reference**: Issue #18034