### PR TITLE
Issue #6294: Kill pitest mutation in Synchronized Handler checkWrappi…

### DIFF
--- a/config/pitest-suppressions/pitest-indentation-suppressions.xml
+++ b/config/pitest-suppressions/pitest-indentation-suppressions.xml
@@ -156,15 +156,6 @@
   <mutation unstable="false">
     <sourceFile>SynchronizedHandler.java</sourceFile>
     <mutatedClass>com.puppycrawl.tools.checkstyle.checks.indentation.SynchronizedHandler</mutatedClass>
-    <mutatedMethod>checkIndentation</mutatedMethod>
-    <mutator>org.pitest.mutationtest.engine.gregor.mutators.VoidMethodCallMutator</mutator>
-    <description>removed call to com/puppycrawl/tools/checkstyle/checks/indentation/SynchronizedHandler::checkWrappingIndentation</description>
-    <lineContent>checkWrappingIndentation(getMainAst(),</lineContent>
-  </mutation>
-
-  <mutation unstable="false">
-    <sourceFile>SynchronizedHandler.java</sourceFile>
-    <mutatedClass>com.puppycrawl.tools.checkstyle.checks.indentation.SynchronizedHandler</mutatedClass>
     <mutatedMethod>checkSynchronizedExpr</mutatedMethod>
     <mutator>org.pitest.mutationtest.engine.gregor.mutators.VoidMethodCallMutator</mutator>
     <description>removed call to com/puppycrawl/tools/checkstyle/checks/indentation/SynchronizedHandler::checkExpressionSubtree</description>

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/indentation/IndentationCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/indentation/IndentationCheckTest.java
@@ -4069,6 +4069,24 @@ public class IndentationCheckTest extends AbstractModuleTestSupport {
         verifyWarns(checkConfig, fileName, expected);
     }
 
+    @Test
+    public void testSynchronizedWrapping() throws Exception {
+        final DefaultConfiguration checkConfig = createModuleConfig(IndentationCheck.class);
+        checkConfig.addProperty("arrayInitIndent", "4");
+        checkConfig.addProperty("basicOffset", "4");
+        checkConfig.addProperty("braceAdjustment", "0");
+        checkConfig.addProperty("caseIndent", "4");
+        checkConfig.addProperty("forceStrictCondition", "false");
+        checkConfig.addProperty("lineWrappingIndentation", "8");
+        checkConfig.addProperty("tabWidth", "4");
+        checkConfig.addProperty("throwsIndent", "4");
+        final String fileName = getPath("InputIndentationSynchronizedWrapping.java");
+        final String[] expected = {
+            "22:13: " + getCheckMessage(MSG_ERROR, ".", 12, 16),
+        };
+        verifyWarns(checkConfig, fileName, expected);
+    }
+
     private static final class IndentAudit implements AuditListener {
 
         private final IndentComment[] comments;

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/indentation/indentation/InputIndentationSynchronizedWrapping.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/indentation/indentation/InputIndentationSynchronizedWrapping.java
@@ -1,0 +1,26 @@
+package com.puppycrawl.tools.checkstyle.checks.indentation.indentation;    //indent:0 exp:0
+
+/**                                                                         //indent:0 exp:0
+ * Test for checkWrappingIndentation in SynchronizedHandler.                //indent:1 exp:1
+ * arrayInitIndent = 4                                                      //indent:1 exp:1
+ * basicOffset = 4                                                          //indent:1 exp:1
+ * braceAdjustment = 0                                                      //indent:1 exp:1
+ * caseIndent = 4                                                           //indent:1 exp:1
+ * forceStrictCondition = false                                             //indent:1 exp:1
+ * lineWrappingIndentation = 8                                              //indent:1 exp:1
+ * tabWidth = 4                                                             //indent:1 exp:1
+ * throwsIndent = 4                                                         //indent:1 exp:1
+ */                                                                         //indent:1 exp:1
+public class InputIndentationSynchronizedWrapping {                         //indent:0 exp:0
+    Object lock = new Object();                                             //indent:4 exp:4
+
+    void method() {                                                         //indent:4 exp:4
+        synchronized (lock) {                                               //indent:8 exp:8
+            System.out.println("valid");                                    //indent:12 exp:12
+        }                                                                   //indent:8 exp:8
+        synchronized (lock                                                  //indent:8 exp:8
+            .getClass()) {                                                  //indent:12 exp:16 warn
+            System.out.println("invalid wrapping");                         //indent:12 exp:12
+        }                                                                   //indent:8 exp:8
+    }                                                                       //indent:4 exp:4
+}                                                                           //indent:0 exp:0


### PR DESCRIPTION
Issue #6294:

Add test to kill checkWrappingIndentation pitest mutation in SynchronizedHandler.

**Changes:**
- Add testSynchronizedWrapping in IndentationCheckTest
- Add InputIndentationSynchronizedWrapping.java test input
- Remove pitest suppression for checkWrappingIndentation mutation

**How it works:**
Uses `basicOffset=4` and `lineWrappingIndentation=8` so checkWrappingIndentation expects indent at 16, while checkSynchronizedExpr expects 12. This creates a unique violation only caught by checkWrappingIndentation.