### PR TITLE
Issue #17449: Add XDocs example for FinalLocalVariableCheck validateUnnamedVariables property

### DIFF
--- a/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/coding/finallocalvariable/Example5.java
+++ b/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/coding/finallocalvariable/Example5.java
@@ -3,6 +3,7 @@
   <module name="TreeWalker">
     <module name="FinalLocalVariable">
       <property name="tokens" value="VARIABLE_DEF,PARAMETER_DEF"/>
+      <property name="validateEnhancedForLoopVariable" value="false"/>
       <property name="validateUnnamedVariables" value="true"/>
     </module>
   </module>
@@ -22,13 +23,15 @@ class Example5
 
     return x+y;
   }
-  public static void main (String []args) {
+
+  public static void main(String[] args) {
     // violation above, 'Variable 'args' should be declared final'
-    // ok below, because validateEnhancedForLoopVariable is false by default
+    // ok below, because validateEnhancedForLoopVariable is false
     for (String i : args) {
       System.out.println(i);
     }
-    int result=foo(1,2); // violation, 'Variable 'result' should be declared final'
+    // violation, 'Variable 'result' should be declared final'
+    int result = foo(1, 2);
   }
 }
 // xdoc section -- end


### PR DESCRIPTION
Issue: #17449

This PR adds an XDocs example for the FinalLocalVariableCheck property:

- validateUnnamedVariables

Changes included:

- Added a new example configuration and code snippet (Example5) in the existing FinalLocalVariable XDocs example to demonstrate the behavior of validateUnnamedVariables.
- Added a corresponding XDocs example source file Example5.java under src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/coding/finallocalvariable.
- Updated FinalLocalVariableCheckExamplesTest to cover Example5.java and assert the expected violations when validateUnnamedVariables is enabled.
- Removed FinalLocalVariableCheck (validateUnnamedVariables) from the SUPPRESSED_PROPERTIES_BY_CHECK map in XdocsExampleFileTest, as this property is now covered by XDocs examples.

Testing:

- mvn -Pno-validations -DskipITs -DskipUTs=false test
- Verified that XdocsExampleFileTest now passes without a suppression entry for FinalLocalVariableCheck.
