### PR TITLE
Issue #17988: Escalate FormatStringShouldUsePlaceholders to error in error-prone test-compile

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -273,6 +273,7 @@
       -Xep:TypeParameterUnusedInFormals:ERROR
       -Xep:UnusedMethod:ERROR
       -Xep:VoidUsed:ERROR
+      -Xep:FormatStringShouldUsePlaceholders:ERROR
       <!-- Reason at https://github.com/checkstyle/checkstyle/issues/17988. -->
       -Xep:EqualsGetClass:WARN
       -Xep:InlineFormatString:WARN


### PR DESCRIPTION
Escalate `FormatStringShouldUsePlaceholders` from warning to error during the error-prone test-compile phase. Running the following command to check result
```shell
./mvnw -e --no-transfer-progress clean test-compile -Perror-prone-test-compile
````

Since all FormatStringShouldUsePlaceholders issues were cleaned up in the test-compile phase in #18274, enforcing this rule as an error helps prevent regressions.

Issues: #17988