### PR TITLE
Issue #6294: Resolve pitest mutation in Indentation Check

### DIFF
--- a/config/pitest-suppressions/pitest-indentation-suppressions.xml
+++ b/config/pitest-suppressions/pitest-indentation-suppressions.xml
@@ -109,15 +109,6 @@
   </mutation>
 
   <mutation unstable="false">
-    <sourceFile>IndentationCheck.java</sourceFile>
-    <mutatedClass>com.puppycrawl.tools.checkstyle.checks.indentation.IndentationCheck</mutatedClass>
-    <mutatedMethod>beginTree</mutatedMethod>
-    <mutator>org.pitest.mutationtest.engine.gregor.mutators.VoidMethodCallMutator</mutator>
-    <description>removed call to com/puppycrawl/tools/checkstyle/checks/indentation/PrimordialHandler::checkIndentation</description>
-    <lineContent>primordialHandler.checkIndentation();</lineContent>
-  </mutation>
-
-  <mutation unstable="false">
     <sourceFile>MethodDefHandler.java</sourceFile>
     <mutatedClass>com.puppycrawl.tools.checkstyle.checks.indentation.MethodDefHandler</mutatedClass>
     <mutatedMethod>getMethodDefLineStart</mutatedMethod>

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/indentation/IndentationCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/indentation/IndentationCheck.java
@@ -355,7 +355,6 @@ public class IndentationCheck extends AbstractCheck {
         handlers.clear();
         final PrimordialHandler primordialHandler = new PrimordialHandler(this);
         handlers.push(primordialHandler);
-        primordialHandler.checkIndentation();
         incorrectIndentationLines = new HashSet<>();
     }
 

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/indentation/IndentationCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/indentation/IndentationCheckTest.java
@@ -4087,6 +4087,22 @@ public class IndentationCheckTest extends AbstractModuleTestSupport {
         verifyWarns(checkConfig, fileName, expected);
     }
 
+    /**
+     * Pure unit test to satisfy line coverage for {@link PrimordialHandler#checkIndentation()}.
+     * The method has an empty implementation required by the abstract contract of
+     * {@link AbstractExpressionHandler}. A unit test is required as this method is not
+     * reachable through any integration test.
+     */
+    @Test
+    public void testPrimordialHandlerCheckIndentation() {
+        final IndentationCheck check = new IndentationCheck();
+        final PrimordialHandler handler = new PrimordialHandler(check);
+        handler.checkIndentation();
+        assertWithMessage("Method should complete without exception")
+            .that(handler)
+            .isNotNull();
+    }
+
     private static final class IndentAudit implements AuditListener {
 
         private final IndentComment[] comments;


### PR DESCRIPTION
Issue #6294:

Removed no operation call `primordialHandler.checkIndentation()` from `IndentationCheck.beginTree()` since the method body is empty. Added unit test for line coverage as the method is required by abstract contract but unreachable via integration tests.