### PR TITLE
Issue #17882: Update CUSTOM_INLINE_TAG of JavadocCommentsTokenTypes to new AST format

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/api/JavadocCommentsTokenTypes.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/api/JavadocCommentsTokenTypes.java
@@ -923,19 +923,21 @@ public final class JavadocCommentsTokenTypes {
      * {@code @custom} inline tag.
      *
      * <p><b>Example:</b></p>
-     * <pre>{@code * Example showing {@custom inline tag}}</pre>
+     * <pre>{@code * Example showing {@custom This is a Custom Inline Tag}.}</pre>
      *
      * <p><b>Tree:</b></p>
      * <pre>{@code
+     * JAVADOC_CONTENT -> JAVADOC_CONTENT
      * |--LEADING_ASTERISK -> *
-     * |--TEXT ->
-     * `--JAVADOC_INLINE_TAG -> JAVADOC_INLINE_TAG
-     *     `--CUSTOM_INLINE_TAG -> CUSTOM_INLINE_TAG
-     *         |--JAVADOC_INLINE_TAG_START -> { @
-     *         |--TAG_NAME -> custom
-     *         |--DESCRIPTION -> DESCRIPTION
-     *         |   `--TEXT ->  This is a Custom Inline Tag
-     *         `--JAVADOC_INLINE_TAG_END -> }
+     * |--TEXT ->  Example showing
+     * |--JAVADOC_INLINE_TAG -> JAVADOC_INLINE_TAG
+     * |   `--CUSTOM_INLINE_TAG -> CUSTOM_INLINE_TAG
+     * |       |--JAVADOC_INLINE_TAG_START -> { @
+     * |       |--TAG_NAME -> custom
+     * |       |--DESCRIPTION -> DESCRIPTION
+     * |       |   `--TEXT ->  This is a Custom Inline Tag
+     * |       `--JAVADOC_INLINE_TAG_END -> }
+     * `--TEXT -> .
      * }</pre>
      *
      * @see #JAVADOC_INLINE_TAG


### PR DESCRIPTION
Issue #17882 

Input file
```
* { @custom This is a Custom Inline Tag }
```

CLI Output
```
|--LEADING_ASTERISK -> *
|--TEXT ->
`--JAVADOC_INLINE_TAG -> JAVADOC_INLINE_TAG
    `--CUSTOM_INLINE_TAG -> CUSTOM_INLINE_TAG
        |--JAVADOC_INLINE_TAG_START -> { @
        |--TAG_NAME -> custom
        |--DESCRIPTION -> DESCRIPTION
        |   `--TEXT ->  This is a Custom Inline Tag
        `--JAVADOC_INLINE_TAG_END -> }
```
