### PR TITLE
Issue #13796: clarify AnnotationLocation same-line annotation precedence

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/annotation/AnnotationLocationCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/annotation/AnnotationLocationCheck.java
@@ -70,6 +70,12 @@ import com.puppycrawl.tools.checkstyle.utils.TokenUtil;
  * InvalidJavadocPosition</a>.
  * </p>
  *
+ * <p>
+ * The property {@code allowSamelineMultipleAnnotations} has the
+ * dominant effect and allows both single and multiple annotations on
+ * the same line, regardless of whether they are parameterized or parameterless.
+ * </p>
+ *
  * @since 6.0
  */
 @StatelessCheck

--- a/src/main/resources/com/puppycrawl/tools/checkstyle/meta/checks/annotation/AnnotationLocationCheck.xml
+++ b/src/main/resources/com/puppycrawl/tools/checkstyle/meta/checks/annotation/AnnotationLocationCheck.xml
@@ -44,6 +44,12 @@
  immediately after the documentation block. If that behavior is desired, consider also using
  &lt;a href="https://checkstyle.org/checks/javadoc/invalidjavadocposition.html#InvalidJavadocPosition"&gt;
  InvalidJavadocPosition&lt;/a&gt;.
+ &lt;/p&gt;
+
+ &lt;p&gt;
+ The property &lt;code&gt;allowSamelineMultipleAnnotations&lt;/code&gt; has the
+ dominant effect and allows both single and multiple annotations on
+ the same line, regardless of whether they are parameterized or parameterless.
  &lt;/p&gt;</description>
          <properties>
             <property default-value="false"

--- a/src/site/xdoc/checks/annotation/annotationlocation.xml
+++ b/src/site/xdoc/checks/annotation/annotationlocation.xml
@@ -53,6 +53,12 @@ public String getNameIfPresent() { ... }
           <a href="https://checkstyle.org/checks/javadoc/invalidjavadocposition.html#InvalidJavadocPosition">
           InvalidJavadocPosition</a>.
         </p>
+
+        <p>
+          The property <code>allowSamelineMultipleAnnotations</code> has the
+          dominant effect and allows both single and multiple annotations on
+          the same line, regardless of whether they are parameterized or parameterless.
+        </p>
       </subsection>
 
       <subsection name="Properties" id="AnnotationLocation_Properties">


### PR DESCRIPTION
Fixes #13796

This PR clarifies the AnnotationLocation documentation by explaining that
allowSamelineMultipleAnnotations has a dominant effect over other same line
annotation properties.

Documentation only change. No logic changes.