### PR TITLE
Issue #17882: Update TEXT token documentation in JavadocCommentsTokenTypes

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/api/JavadocCommentsTokenTypes.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/api/JavadocCommentsTokenTypes.java
@@ -78,6 +78,31 @@ public final class JavadocCommentsTokenTypes {
 
     /**
      * Plain text content within a Javadoc comment.
+     *
+     * <p>This node represents any plain text that appears in a Javadoc comment,
+     * including spaces and punctuation.</p>
+     *
+     * <p><b>Example:</b></p>
+     * <pre>{@code
+     * /**
+     *  * This is plain text content.
+     *  * /
+     * }</pre>
+     *
+     * <p><b>Tree:</b></p>
+     * <pre>{@code
+     * --BLOCK_COMMENT_BEGIN -> /**
+     *    |--COMMENT_CONTENT -> *\r\n * This is plain text content.\r\n
+     *    |   `--JAVADOC_CONTENT -> JAVADOC_CONTENT
+     *    |       |--NEWLINE -> \r\n
+     *    |       |--LEADING_ASTERISK ->  *
+     *    |       |--TEXT ->  This is plain text content.
+     *    |       |--NEWLINE -> \r\n
+     *    |       `--TEXT ->
+     *    `--BLOCK_COMMENT_END -> * /
+     * }</pre>
+     *
+     * @see #JAVADOC_CONTENT
      */
     public static final int TEXT = JavadocCommentsLexer.TEXT;
 


### PR DESCRIPTION
## Description

This PR updates the TEXT token documentation in JavadocCommentsTokenTypes.java to follow the new AST print format.

### Changes:
- Added detailed description for TEXT token
- Added example Javadoc comment
- Added AST tree representation

### Related Issue:
Closes part of #17882

### Testing:
- Generated AST using checkstyle CLI to verify the tree structure
- The example shows plain text content in a Javadoc comment