### PR TITLE
Issue #17882: Update NEWLINE token documentation in JavadocCommentsTokenTypes

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/api/JavadocCommentsTokenTypes.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/api/JavadocCommentsTokenTypes.java
@@ -73,6 +73,31 @@ public final class JavadocCommentsTokenTypes {
 
     /**
      * Newline character in a Javadoc comment.
+     *
+     * <p>This node represents a line break (CR, LF, or CRLF) within a Javadoc comment.</p>
+     *
+     * <p><b>Example:</b></p>
+     * <pre>{@code
+     * /**
+     *  * First line.
+     *  * Second line.
+     *  * /
+     * }</pre>
+     *
+     * <b>Tree:</b>
+     * <pre>{@code
+     * JAVADOC_CONTENT -> JAVADOC_CONTENT
+     *     |--NEWLINE -> \r\n
+     *     |--LEADING_ASTERISK ->  *
+     *     |--TEXT ->  First line.
+     *     |--NEWLINE -> \r\n
+     *     |--LEADING_ASTERISK ->  *
+     *     |--TEXT ->  Second line.
+     *     |--NEWLINE -> \r\n
+     *     `--TEXT ->
+     * }</pre>
+     *
+     * @see #JAVADOC_CONTENT
      */
     public static final int NEWLINE = JavadocCommentsLexer.NEWLINE;
 


### PR DESCRIPTION
## Description

This PR updates the NEWLINE token documentation in JavadocCommentsTokenTypes.java to follow the new AST print format.

### Changes:
- Added detailed description for NEWLINE token
- Added example Javadoc comment showing multiple lines
- Added AST tree representation

### Related Issue:
Closes part of #17882

### Testing:
- The example shows newline characters between Javadoc lines