### PR TITLE
Issue #18303: Added a method to catch the ExampleX not refered in XdocsExampleFileTest

### DIFF
--- a/src/test/java/com/puppycrawl/tools/checkstyle/internal/XdocsExampleFileTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/internal/XdocsExampleFileTest.java
@@ -118,4 +118,40 @@ public class XdocsExampleFileTest {
                     .fail();
         }
     }
+
+    @Test
+    public void testAllXdocsExamplesAreTestedInXdocsExamplesTests() throws Exception {
+        final Map<String, Set<String>> allExamplesByCheckDir =
+                XdocUtil.getAllXdocsExampleFilesByCheckDirectory();
+
+        final Map<String, Set<String>> testedExamplesByCheckDir =
+                XdocUtil.getTestedXdocsExampleFilesByCheckDirectory();
+
+        final List<String> failures = new ArrayList<>();
+
+        for (Map.Entry<String, Set<String>> entry : allExamplesByCheckDir.entrySet()) {
+            final String checkDir = entry.getKey();
+            final Set<String> allExamples = entry.getValue();
+            final Set<String> testedExamples =
+                    testedExamplesByCheckDir.getOrDefault(checkDir, Collections.emptySet());
+
+            for (String exampleFile : allExamples) {
+                if (!testedExamples.contains(exampleFile)) {
+                    failures.add(
+                            "Xdoc example file '" + exampleFile
+                                    + "' in check directory '" + checkDir
+                                    + "' is not tested in xdocs-examples/java"
+                    );
+                }
+            }
+        }
+
+        if (!failures.isEmpty()) {
+            assertWithMessage(
+                    "The following xdoc example files are not referenced in any test:\n"
+                            + String.join("\n", failures)
+            ).fail();
+        }
+    }
+
 }

--- a/src/test/java/com/puppycrawl/tools/checkstyle/internal/utils/XdocUtil.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/internal/utils/XdocUtil.java
@@ -25,6 +25,7 @@ import java.nio.file.Path;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Set;
 import java.util.regex.Matcher;
@@ -51,6 +52,23 @@ import org.xml.sax.SAXException;
 public final class XdocUtil {
 
     public static final String DIRECTORY_PATH = "src/site/xdoc";
+
+    private static final Pattern PACKAGE_LOCATION_PATTERN = Pattern.compile(
+            "getPackageLocation\\(\\)\\s*\\{\\s*return\\s*\"([^\"]+)\""
+    );
+
+    private static final Pattern VERIFY_PATTERN = Pattern.compile(
+            "(?:verifyWithInlineXmlConfig"
+                    + "|verifyWithInlineConfigParser"
+                    + "|verifyWithInlineConfigParserSeparateConfigAndTarget)"
+                    + "\\s*\\(\\s*(?:getPath|getNonCompilablePath)"
+                    + "\\s*\\(\\s*\"([^\"]*(?:Example[^\"]+|package-info)\\.java)\"\\s*\\)"
+    );
+
+    private static final Pattern CONFIG_PATTERN = Pattern.compile(
+            "(?:getPath|getNonCompilablePath)"
+                    + "\\s*\\(\\s*\"([^\"]*(?:Example[^\"]+|package-info)\\.java)\"\\s*\\)"
+    );
 
     private XdocUtil() {
     }
@@ -262,4 +280,237 @@ public final class XdocUtil {
 
         return result;
     }
+
+    public static Map<String, Set<String>> getAllXdocsExampleFilesByCheckDirectory()
+            throws IOException {
+
+        final List<Path> roots = List.of(
+                Path.of("src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks"),
+                Path.of("src/xdocs-examples/resources-noncompilable"
+                        + "/com/puppycrawl/tools/checkstyle/checks")
+        );
+
+        final Set<String> excludedDirs = Set.of(
+                "deeper",
+                "javadocleadingasteriskalign",
+                "nonemptyatclausedescription",
+                "importcontrol",
+                "ignore",
+                "textblockgooglestyleformatting",
+                "missingjavadocpackage",
+                "javadocpackage",
+                "nowhitespacebeforecasedefaultcolon",
+                "unnecessarysemicolonaftertypememberdeclaration",
+                "unnecessarysemicolonafteroutertypedeclaration",
+                "unnecessarysemicolonintrywithresources",
+                "javadocmissingwhitespaceafterasterisk"
+        );
+
+        final Set<String> categoryDirs = Set.of(
+                "modifier",
+                "javadoc",
+                "coding",
+                "indentation",
+                "sizes",
+                "design",
+                "annotation",
+                "imports",
+                "blocks",
+                "naming",
+                "metrics",
+                "whitespace",
+                "regexp",
+                "header"
+        );
+
+        final Map<String, Set<String>> examplesByCheckDir = new HashMap<>();
+
+        for (Path root : roots) {
+            collectExampleFiles(root, excludedDirs, categoryDirs, examplesByCheckDir);
+        }
+
+        return examplesByCheckDir;
+    }
+
+    private static void collectExampleFiles(
+            Path root,
+            Set<String> excludedDirs,
+            Set<String> categoryDirs,
+            Map<String, Set<String>> examplesByCheckDir)
+            throws IOException {
+
+        if (Files.exists(root)) {
+            try (Stream<Path> paths = Files.walk(root)) {
+                paths.filter(XdocUtil::isExampleJavaFile)
+                        .forEach(path -> {
+                            addExampleFile(
+                                    path,
+                                    root,
+                                    excludedDirs,
+                                    categoryDirs,
+                                    examplesByCheckDir);
+                        });
+            }
+        }
+    }
+
+    private static boolean isExampleJavaFile(Path path) {
+        final String fileName = path.getFileName().toString();
+
+        return fileName.startsWith("Example") && fileName.endsWith(".java")
+                || "package-info.java".equals(fileName);
+    }
+
+    private static void addExampleFile(
+            Path path,
+            Path root,
+            Set<String> excludedDirs,
+            Set<String> categoryDirs,
+            Map<String, Set<String>> examplesByCheckDir) {
+
+        final Path relativePath = root.relativize(path);
+        final Path parentPath = relativePath.getParent();
+
+        if (parentPath != null
+                && parentPath.getNameCount() >= 2) {
+
+            final String categoryDir =
+                    parentPath.getName(0).toString().toLowerCase(Locale.ROOT);
+
+            if (categoryDirs.contains(categoryDir)) {
+
+                boolean isExcluded = false;
+
+                for (int index = 0; index < parentPath.getNameCount(); index++) {
+                    final String dirName =
+                            parentPath.getName(index)
+                                    .toString()
+                                    .toLowerCase(Locale.ROOT);
+
+                    if (excludedDirs.contains(dirName)) {
+                        isExcluded = true;
+                        break;
+                    }
+                }
+
+                if (!isExcluded) {
+                    final String checkDir =
+                            parentPath.getName(1).toString().toLowerCase(Locale.ROOT);
+                    final String fileName = path.getFileName().toString();
+
+                    examplesByCheckDir
+                            .computeIfAbsent(checkDir, key -> new HashSet<>())
+                            .add(fileName);
+                }
+            }
+        }
+    }
+
+    public static Map<String, Set<String>> getTestedXdocsExampleFilesByCheckDirectory()
+            throws IOException {
+
+        final Path testRoot =
+                Path.of("src/xdocs-examples/java/com/puppycrawl/tools/checkstyle");
+
+        final Map<String, Set<String>> testedExamplesByCheckDir = new HashMap<>();
+
+        if (Files.exists(testRoot)) {
+            try (Stream<Path> paths = Files.walk(testRoot)) {
+                for (Path path : paths.filter(XdocUtil::isExamplesTestFile)
+                        .toList()) {
+                    processExamplesTestFile(path, testedExamplesByCheckDir);
+                }
+            }
+        }
+
+        return testedExamplesByCheckDir;
+    }
+
+    private static boolean isExamplesTestFile(Path path) {
+        return path.getFileName().toString().endsWith("ExamplesTest.java");
+    }
+
+    private static void processExamplesTestFile(
+            Path path,
+            Map<String, Set<String>> testedExamplesByCheckDir)
+            throws IOException {
+
+        final String content = Files.readString(path);
+        final Set<String> testedFiles = extractTestedExampleFiles(content);
+
+        if (testedFiles.isEmpty()) {
+            throw new AssertionError(
+                    "No xdocs example files referenced in test file: " + path);
+        }
+
+        final String checkDir = extractCheckDirectory(path, content);
+        testedExamplesByCheckDir.put(checkDir, testedFiles);
+    }
+
+    private static String extractCheckDirectory(Path path, String content) {
+        String result = null;
+
+        final Matcher matcher = PACKAGE_LOCATION_PATTERN.matcher(content);
+        if (matcher.find()) {
+            final String packagePath = matcher.group(1);
+            final String[] parts = packagePath.split("/");
+            result = parts[parts.length - 1].toLowerCase(Locale.ROOT);
+        }
+
+        if (result == null) {
+            result = deriveCheckDirFromFileName(path);
+        }
+
+        return result;
+    }
+
+    private static String deriveCheckDirFromFileName(Path path) {
+        String checkDir =
+                path.getFileName().toString().replace("ExamplesTest.java", "");
+
+        if (checkDir.endsWith("Check")) {
+            checkDir = checkDir.substring(0, checkDir.length() - 5);
+        }
+
+        return checkDir.toLowerCase(Locale.ROOT);
+    }
+
+    private static Set<String> extractTestedExampleFiles(String content) {
+        final Set<String> testedFiles = new HashSet<>();
+
+        collectExampleFilesFromPattern(
+                content, VERIFY_PATTERN, testedFiles);
+        collectExampleFilesFromPattern(
+                content, CONFIG_PATTERN, testedFiles);
+
+        return testedFiles;
+    }
+
+    private static void collectExampleFilesFromPattern(
+            String content,
+            Pattern pattern,
+            Set<String> testedFiles) {
+
+        final Matcher matcher = pattern.matcher(content);
+
+        while (matcher.find()) {
+            final String filePath = matcher.group(1);
+            final String fileName = extractFileName(filePath);
+
+            if (fileName.startsWith("Example") || "package-info.java".equals(fileName)) {
+                testedFiles.add(fileName);
+            }
+        }
+    }
+
+    private static String extractFileName(String filePath) {
+        String result = filePath;
+
+        if (filePath.contains("/")) {
+            result = filePath.substring(filePath.lastIndexOf('/') + 1);
+        }
+
+        return result;
+    }
+
 }


### PR DESCRIPTION
Issue #18303 

Created a method which checks if any ExampleX is not refered in XdocsExampleFileTest

What the method does
1. Scan folder for all ExampleX.java files
2. Create a map by checkName
3. Read all the test files 
4. Create another map of tested examples
5. Compare them

Error Message -> 
 
```
[ERROR]   XdocsExampleFileTest.testAllXdocsExamplesAreTestedInXdocsExamplesTests:153 The following xdoc example files are not referenced in any test:
Xdoc example file 'Example1.java' in check directory 'packageannotation' is not tested in xdocs-examples/java                                                                       
Xdoc example file 'Example2.java' in check directory 'packageannotation' is not tested in xdocs-examples/java  
```

In this some files are suppressed for now