### PR TITLE
Issue #17265: Remove duplicate violations in WhitespaceAfter and Whit…

### DIFF
--- a/src/it/resources/com/google/checkstyle/test/chapter4formatting/rule462horizontalwhitespace/InputWhitespaceAfterBad.java
+++ b/src/it/resources/com/google/checkstyle/test/chapter4formatting/rule462horizontalwhitespace/InputWhitespaceAfterBad.java
@@ -6,46 +6,36 @@ public class InputWhitespaceAfterBad {
   public void check1(int x,int y) { // violation '',' is not followed by whitespace.'
     for(int a = 1,b = 2;a < 5;a++,b--)
       ;
-    // 7 violations 2 lines above:
+    // 6 violations 2 lines above:
     //  ''for' construct must use '{}'s.'
     //  ''for' is not followed by whitespace.'
-    //  ''for' is not followed by whitespace.'
     //  '',' is not followed by whitespace.'
     //  '';' is not followed by whitespace.'
     //  '';' is not followed by whitespace.'
     //  '',' is not followed by whitespace.'
-    while(x == 0) {
-      // 2 violations above:
-      //  ''while' is not followed by whitespace.'
-      //  ''while' is not followed by whitespace.'
+    while(x == 0) { // violation ''while' is not followed by whitespace.'
       int a = 0,b = 1;
       // 2 violations above:
       //  'Each variable declaration must be in its own statement.'
       //  '',' is not followed by whitespace.'
     }
     do{
-      // 3 violations above:
-      //  ''do' is not followed by whitespace.'
+      // 2 violations above:
       //  ''do' is not followed by whitespace.'
       //  ''{' is not preceded with whitespace.'
       System.out.println("Testing");
-    } while(x == 0 || y == 2);
-    // 2 violations above:
-    //  ''while' is not followed by whitespace.'
-    //  ''while' is not followed by whitespace.'
+    } while(x == 0 || y == 2); // violation ''while' is not followed by whitespace.'
   }
 
   /** Some javadoc. */
   public void check2(final int a,final int b) { // violation '',' is not followed by whitespace.'
     if((float)a == 0.0) {
-      // 3 violations above:
-      //  ''if' is not followed by whitespace.'
+      // 2 violations above:
       //  ''if' is not followed by whitespace.'
       //  ''typecast' is not followed by whitespace.'
       System.out.println("true");
     } else{
-      // 3 violations above:
-      //  ''else' is not followed by whitespace.'
+      // 2 violations above:
       //  ''else' is not followed by whitespace.'
       //  ''{' is not preceded with whitespace.'
       System.out.println("false");
@@ -54,14 +44,10 @@ public class InputWhitespaceAfterBad {
 
   /** Some javadoc. */
   public void check3(int...a) { // violation ''...' is not followed by whitespace.'
+    // violation below, ''->' is not followed by whitespace.'
     Runnable r2 = () ->String.valueOf("Hello world two!");
-    // 2 violations above:
-    //  ''->' is not followed by whitespace.'
-    //  ''->' is not followed by whitespace.'
+    // violation below, ''switch' is not followed by whitespace.'
     switch(a[0]) {
-      // 2 violations above:
-      //  ''switch' is not followed by whitespace.'
-      //  ''switch' is not followed by whitespace.'
       default:
         break;
     }
@@ -69,10 +55,8 @@ public class InputWhitespaceAfterBad {
 
   /** Some javadoc. */
   public void check4() throws java.io.IOException {
+    // violation below, ''try' is not followed by whitespace.'
     try(java.io.InputStream ignored = System.in;) {}
-    // 2 violations above:
-    //  ''try' is not followed by whitespace.'
-    //  ''try' is not followed by whitespace.'
   }
 
   /** Some javadoc. */
@@ -80,8 +64,7 @@ public class InputWhitespaceAfterBad {
     try {
       /* foo */
     } finally{
-      // 3 violations above:
-      //  ''finally' is not followed by whitespace.'
+      // 2 violations above:
       //  ''finally' is not followed by whitespace.'
       //  ''{' is not preceded with whitespace.'
     }
@@ -90,8 +73,7 @@ public class InputWhitespaceAfterBad {
     } catch (Exception e) {
       /* foo */
     } finally{
-      // 3 violations above:
-      //  ''finally' is not followed by whitespace.'
+      // 2 violations above:
       //  ''finally' is not followed by whitespace.'
       //  ''{' is not preceded with whitespace.'
     }
@@ -101,19 +83,13 @@ public class InputWhitespaceAfterBad {
   public void check6() {
     try {
       /* foo */
-    } catch(Exception e) {
-      // 2 violations above:
-      //  ''catch' is not followed by whitespace.'
-      //  ''catch' is not followed by whitespace.'
+    } catch(Exception e) { // violation ''catch' is not followed by whitespace.'
     }
   }
 
   /** Some javadoc. */
   public void check7() {
-    synchronized(this) {
-      // 2 violations above:
-      //  ''synchronized' is not followed by whitespace.'
-      //  ''synchronized' is not followed by whitespace.'
+    synchronized(this) { // violation ''synchronized' is not followed by whitespace.'
     }
 
     synchronized (this) {
@@ -122,9 +98,6 @@ public class InputWhitespaceAfterBad {
 
   /** Some javadoc. */
   public String check8() {
-    return("a" + "b");
-    // 2 violations above:
-    //  ''return' is not followed by whitespace.'
-    //  ''return' is not followed by whitespace.'
+    return("a" + "b"); // violation ''return' is not followed by whitespace.'
   }
 }

--- a/src/it/resources/com/google/checkstyle/test/chapter4formatting/rule462horizontalwhitespace/InputWhitespaceAroundArrow.java
+++ b/src/it/resources/com/google/checkstyle/test/chapter4formatting/rule462horizontalwhitespace/InputWhitespaceAroundArrow.java
@@ -57,17 +57,14 @@ public class InputWhitespaceAroundArrow {
   }
 
   int test2(int k, Object o1) {
+    // violation below, 'WhitespaceAround: '->' is not followed by whitespace. .*'
     Predicate predicate = value ->(value != null);
-    // 2 violations above:
-    //     ''->' is not followed by whitespace.'
-    //     'WhitespaceAround: '->' is not followed by whitespace. .*'
+
     Object b = ((VoidPredicate) ()->o1 instanceof String s).get();
-    // 3 violations above:
-    //     ''->' is not followed by whitespace.'
+    // 2 violations above:
     //     'WhitespaceAround: '->' is not followed by whitespace. .*'
     //     'WhitespaceAround: '->' is not preceded with whitespace.'
-    // 3 violations 5 lines below:
-    //     ''->' is not followed by whitespace.'
+    // 2 violations 4 lines below:
     //     ''->' is not followed by whitespace. .*'
     //     ''{' is not preceded with whitespace.'
     new LinkedList<Integer>().stream()
@@ -96,10 +93,8 @@ public class InputWhitespaceAroundArrow {
     Object result = boolList.stream().filter(
         // violation below 'WhitespaceAround: '->' is not preceded with whitespace.'
         statement-> false).findFirst()
+        // violation below, 'WhitespaceAround: '->' is not followed by whitespace. .*'
         .orElseThrow(() ->new IllegalStateException("big problem"));
-    // 2 violations above:
-    //     ''->' is not followed by whitespace.'
-    //     'WhitespaceAround: '->' is not followed by whitespace. .*'
   }
 
   /** Some javadoc. */

--- a/src/it/resources/com/google/checkstyle/test/chapter4formatting/rule462horizontalwhitespace/InputWhitespaceAroundBasic.java
+++ b/src/it/resources/com/google/checkstyle/test/chapter4formatting/rule462horizontalwhitespace/InputWhitespaceAroundBasic.java
@@ -41,14 +41,10 @@ class InputWhitespaceAroundBasic {
 
   /** Method. */
   void method2() {
-    synchronized(this) {
-      // 2 violations above:
-      //  ''synchronized' is not followed by whitespace.'
-      //  ''synchronized' is not followed by whitespace.'
+    synchronized(this) { // violation ''synchronized' is not followed by whitespace.'
     }
     try{
-      // 3 violations above:
-      //  ''try' is not followed by whitespace.'
+      // 2 violations above:
       //  ''try' is not followed by whitespace.'
       //  ''{' is not preceded with whitespace.'
     } catch (RuntimeException e) {// violation ''{' is not followed by whitespace.'
@@ -58,10 +54,8 @@ class InputWhitespaceAroundBasic {
   /** Test WS after void return. */
   private void fastExit() {
     boolean complicatedStuffNeeded = true;
-    // 2 violations 3 lines below:
-    //  ''if' is not followed by whitespace.'
-    //  ''if' is not followed by whitespace.'
-    if(!complicatedStuffNeeded) {
+
+    if(!complicatedStuffNeeded) { // violation ''if' is not followed by whitespace.'
       // should not complain about missing WS after return
     } else {
       // do complicated stuff
@@ -75,10 +69,7 @@ class InputWhitespaceAroundBasic {
    */
   private int nonVoid() {
     if (true) {
-      return(2);
-      // 2 violations above:
-      //  ''return' is not followed by whitespace.'
-      //  ''return' is not followed by whitespace.'
+      return(2); // violation ''return' is not followed by whitespace.'
     } else {
       return 2; // this is ok
     }
@@ -233,10 +224,7 @@ class InputWhitespaceAroundBasic {
       Runnable l;
 
       l = ()-> {}; // violation ''->' is not preceded with whitespace.'
-      l = () ->{};
-      // 2 violations above:
-      //  ''->' is not followed by whitespace.'
-      //  ''->' is not followed by whitespace.'
+      l = () ->{}; // violation ''->' is not followed by whitespace.'
       l = () -> {};
       l = () -> {};
 

--- a/src/it/resources/com/google/checkstyle/test/chapter4formatting/rule462horizontalwhitespace/InputWhitespaceAroundWhen.java
+++ b/src/it/resources/com/google/checkstyle/test/chapter4formatting/rule462horizontalwhitespace/InputWhitespaceAroundWhen.java
@@ -7,25 +7,20 @@ class InputWhitespaceAroundWhen {
   /** Method. */
   void test(Object o) {
     switch (o) {
-      case Integer i when(i == 0) ->
+      case Integer i when(i == 0) -> // violation ''when' is not followed by whitespace.'
         {
         }
-      // 2 violations 3 lines above:
-      //              ''when' is not followed by whitespace.'
-      //              ''when' is not followed by whitespace.'
+      // violation below, ''when' is not followed by whitespace.'
       case String s when(
-              // 2 violations above:
-              //              ''when' is not followed by whitespace'
-              //              ''when' is not followed by whitespace'
               s.equals("a")) ->
         {
         }
+
+      // violation below, ''when' is not followed by whitespace.'
       case Point(int x, int y) when!(x >= 0 && y >= 0) ->
         {
         }
-      // 2 violations 3 lines above:
-      //              ''when' is not followed by whitespace.'
-      //              ''when' is not followed by whitespace.'
+
       default ->
         {
         }
@@ -38,15 +33,13 @@ class InputWhitespaceAroundWhen {
       case Point(int x, int y)when(x >= 0 && y >= 0) ->
         {
         }
-      // 3 violations 3 lines above:
-      //              ''when' is not followed by whitespace.'
+      // 2 violations 3 lines above:
       //              ''when' is not followed by whitespace.'
       //              ''when' is not preceded with whitespace.'
       case Point(int x, int y)when!(x >= 0 && y >= 0) ->
         {
         }
-      // 3 violations 3 lines above:
-      //              ''when' is not followed by whitespace.'
+      // 2 violations 3 lines above:
       //              ''when' is not followed by whitespace.'
       //              ''when' is not preceded with whitespace.'
       default ->

--- a/src/it/resources/com/google/checkstyle/test/chapter4formatting/rule462horizontalwhitespace/InputWhitespaceBeforeLeftCurlyOfEmptyBlock.java
+++ b/src/it/resources/com/google/checkstyle/test/chapter4formatting/rule462horizontalwhitespace/InputWhitespaceBeforeLeftCurlyOfEmptyBlock.java
@@ -30,15 +30,9 @@ public class InputWhitespaceBeforeLeftCurlyOfEmptyBlock {
 
     for (int i = 1; i > 1; i++){} // ok until #17715
 
-    do{} while (b);
-    // 2 violations above:
-    //   ''do' is not followed by whitespace.'
-    //   'WhitespaceAround: 'do' is not followed by whitespace. *'
+    do{} while (b); // violation 'WhitespaceAround: 'do' is not followed by whitespace. *'
 
-    Runnable noop = () ->{};
-    // 2 violations above:
-    //   ''->' is not followed by whitespace.'
-    //   'WhitespaceAround: '->' is not followed by whitespace. *'
+    Runnable noop = () ->{}; // violation 'WhitespaceAround: '->' is not followed by whitespace. *'
   }
 
   static{} // ok until #17715

--- a/src/main/resources/google_checks.xml
+++ b/src/main/resources/google_checks.xml
@@ -147,10 +147,7 @@
     </module>
     <module name="WhitespaceAfter">
       <property name="tokens"
-               value="COMMA, SEMI, TYPECAST, LITERAL_IF, LITERAL_ELSE, LITERAL_RETURN,
-                    LITERAL_WHILE, LITERAL_DO, LITERAL_FOR, LITERAL_FINALLY, DO_WHILE, ELLIPSIS,
-                    LITERAL_SWITCH, LITERAL_SYNCHRONIZED, LITERAL_TRY, LITERAL_CATCH, LAMBDA,
-                    LITERAL_YIELD, LITERAL_CASE, LITERAL_WHEN, ANNOTATIONS"/>
+               value="COMMA, SEMI, TYPECAST, ELLIPSIS, LITERAL_YIELD, LITERAL_CASE, ANNOTATIONS"/>
     </module>
     <module name="WhitespaceAround">
       <property name="allowEmptyConstructors" value="true"/>

--- a/src/test/java/com/puppycrawl/tools/checkstyle/internal/AllChecksTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/internal/AllChecksTest.java
@@ -235,6 +235,14 @@ public class AllChecksTest extends AbstractModuleTestSupport {
                 // google prefers no spaces on one side or both for these tokens
                 "GENERIC_START", "GENERIC_END", "WILDCARD_TYPE")
                 .collect(Collectors.toUnmodifiableSet()));
+        GOOGLE_TOKENS_IN_CONFIG_TO_IGNORE.put("WhitespaceAfter", Stream.of(
+                // these tokens are already validated by WhitespaceAround, having them
+                // in both checks causes duplicate violations
+                "LITERAL_IF", "LITERAL_ELSE", "LITERAL_RETURN", "LITERAL_WHILE",
+                "LITERAL_DO", "LITERAL_FOR", "LITERAL_FINALLY", "DO_WHILE",
+                "LITERAL_SWITCH", "LITERAL_SYNCHRONIZED", "LITERAL_TRY", "LITERAL_CATCH",
+                "LAMBDA", "LITERAL_WHEN")
+                .collect(Collectors.toUnmodifiableSet()));
         GOOGLE_TOKENS_IN_CONFIG_TO_IGNORE.put("IllegalTokenText", Stream.of(
                 // numerical types should not be included
                 "NUM_DOUBLE", "NUM_FLOAT", "NUM_INT", "NUM_LONG",


### PR DESCRIPTION
Issue #17265:

Removed overlapping tokens from WhitespaceAfter in google_checks.xml to eliminate duplicate violations. These tokens are already covered by WhitespaceAround

**Tokens removed from WhitespaceAfter:**
`LITERAL_IF`, `LITERAL_ELSE`, `LITERAL_RETURN`, `LITERAL_WHILE`, `LITERAL_DO`, `LITERAL_FOR`, `LITERAL_FINALLY`, `DO_WHILE`, `LITERAL_SWITCH`, `LITERAL_SYNCHRONIZED`, `LITERAL_TRY`, `LITERAL_CATCH`, `LAMBDA`, `LITERAL_WHEN`

### Test on the example mentioned in the Issue:  

```
 cat > /tmp/DuplicateError.java << 'EOF'
/** some data. */
class DuplicateError {

  /** method. */
  void test(Object o) {
    switch (o) {
      case String s when (
          s.equals("a"))->{
      }
      default -> {}
    }
  }
}
EOF

java -jar target/checkstyle-*-all.jar -c src/main/resources/google_checks.xml /tmp/DuplicateError.java

Starting audit...
[WARN] /tmp/DuplicateError.java:7:25: WhitespaceAround: '->' is not followed by whitespace. Empty blocks                may only be represented as {} when not part of a multi-block statement (4.1.3) [WhitespaceAround]
[WARN] /tmp/DuplicateError.java:7:25: WhitespaceAround: '->' is not preceded with whitespace. [WhitespaceAround]
Audit done.
```

Diff Regression config: https://gist.githubusercontent.com/vivek-0509/08529f51aeb4b954a15dfed0ebf4d7b7/raw/a24f19b012cc9220c33c94e837a68e81dd140d81/base_config.xml

Diff Regression patch config: https://gist.githubusercontent.com/vivek-0509/648b48d07ff54889f063a5f463574f6b/raw/8f207881dacc15162e916b46fc4f7fb6f7a20942/patch_config.xml