### PR TITLE
Issue #18030: Kill mutations in UnusedLocalVariableCheck for lambda and anon inner class detection

### DIFF
--- a/config/pitest-suppressions/pitest-coding-2-suppressions.xml
+++ b/config/pitest-suppressions/pitest-coding-2-suppressions.xml
@@ -1,38 +1,3 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <suppressedMutations>
-  <mutation unstable="false">
-    <sourceFile>UnusedLocalVariableCheck.java</sourceFile>
-    <mutatedClass>com.puppycrawl.tools.checkstyle.checks.coding.UnusedLocalVariableCheck</mutatedClass>
-    <mutatedMethod>getBlockContainingLocalAnonInnerClass</mutatedMethod>
-    <mutator>org.pitest.mutationtest.engine.gregor.mutators.NegateConditionalsMutator</mutator>
-    <description>negated conditional</description>
-    <lineContent>if (currentAst.getType() == TokenTypes.LAMBDA) {</lineContent>
-  </mutation>
-
-  <mutation unstable="false">
-    <sourceFile>UnusedLocalVariableCheck.java</sourceFile>
-    <mutatedClass>com.puppycrawl.tools.checkstyle.checks.coding.UnusedLocalVariableCheck</mutatedClass>
-    <mutatedMethod>getBlockContainingLocalAnonInnerClass</mutatedMethod>
-    <mutator>org.pitest.mutationtest.engine.gregor.mutators.RemoveConditionalMutator_EQUAL_IF</mutator>
-    <description>removed conditional - replaced equality check with true</description>
-    <lineContent>if (currentAst.getType() == TokenTypes.LAMBDA) {</lineContent>
-  </mutation>
-
-  <mutation unstable="false">
-    <sourceFile>UnusedLocalVariableCheck.java</sourceFile>
-    <mutatedClass>com.puppycrawl.tools.checkstyle.checks.coding.UnusedLocalVariableCheck</mutatedClass>
-    <mutatedMethod>isInsideLocalAnonInnerClass</mutatedMethod>
-    <mutator>org.pitest.mutationtest.engine.gregor.mutators.NegateConditionalsMutator</mutator>
-    <description>negated conditional</description>
-    <lineContent>if (currentAst.getType() == TokenTypes.SLIST) {</lineContent>
-  </mutation>
-
-  <mutation unstable="false">
-    <sourceFile>UnusedLocalVariableCheck.java</sourceFile>
-    <mutatedClass>com.puppycrawl.tools.checkstyle.checks.coding.UnusedLocalVariableCheck</mutatedClass>
-    <mutatedMethod>isInsideLocalAnonInnerClass</mutatedMethod>
-    <mutator>org.pitest.mutationtest.engine.gregor.mutators.RemoveConditionalMutator_EQUAL_IF</mutator>
-    <description>removed conditional - replaced equality check with true</description>
-    <lineContent>if (currentAst.getType() == TokenTypes.SLIST) {</lineContent>
-  </mutation>
 </suppressedMutations>

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/coding/UnusedLocalVariableCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/coding/UnusedLocalVariableCheckTest.java
@@ -581,4 +581,78 @@ public class UnusedLocalVariableCheckTest extends AbstractModuleTestSupport {
                 getPath("InputUnusedLocalVariableAnonInnerClasses3.java"),
                 expected);
     }
+
+    @Test
+    public void testGetBlockContainingLocalAnonInnerClass() throws Exception {
+        final DetailAST root = JavaParser.parseFile(
+                new File(getPath("InputUnusedLocalVariableLambdaAnonInner.java")),
+                JavaParser.Options.WITHOUT_COMMENTS);
+        final DetailAST fieldR = TestUtil.findTokenInAstByPredicate(root,
+                        ast -> {
+                            return ast.getType() == TokenTypes.VARIABLE_DEF
+                                    && "r".equals(ast.findFirstToken(TokenTypes.IDENT)
+                                    .getText());
+                        })
+                .orElseThrow();
+        final DetailAST literalNew = TestUtil.findTokenInAstByPredicate(fieldR,
+                        ast -> ast.getType() == TokenTypes.LITERAL_NEW)
+                .orElseThrow();
+        final DetailAST expectedLambda = fieldR.findFirstToken(TokenTypes.ASSIGN)
+                .getFirstChild();
+
+        final java.lang.reflect.Method method = UnusedLocalVariableCheck.class
+                .getDeclaredMethod("getBlockContainingLocalAnonInnerClass", DetailAST.class);
+        method.setAccessible(true);
+
+        final DetailAST actualResult = (DetailAST) method.invoke(null, literalNew);
+
+        assertWithMessage("Should return the LAMBDA")
+                .that(actualResult)
+                .isSameInstanceAs(expectedLambda);
+    }
+
+    @Test
+    public void testIsInsideLocalAnonInnerClass() throws Exception {
+        final DetailAST root = JavaParser.parseFile(
+                new File(getPath("InputUnusedLocalVariableLambdaAnonInner.java")),
+                JavaParser.Options.WITHOUT_COMMENTS);
+
+        final java.lang.reflect.Method insideMethodCheck = UnusedLocalVariableCheck.class
+                .getDeclaredMethod("isInsideLocalAnonInnerClass", DetailAST.class);
+        insideMethodCheck.setAccessible(true);
+
+        final DetailAST fieldObj = TestUtil.findTokenInAstByPredicate(root,
+                        ast -> {
+                            return ast.getType() == TokenTypes.VARIABLE_DEF
+                                    && "fieldObj".equals(ast.findFirstToken(TokenTypes.IDENT)
+                                    .getText());
+                        })
+                .orElseThrow();
+        final DetailAST literalNewField = fieldObj.findFirstToken(TokenTypes.ASSIGN)
+                .findFirstToken(TokenTypes.EXPR)
+                .findFirstToken(TokenTypes.LITERAL_NEW);
+
+        final boolean resultFalse = (boolean) insideMethodCheck.invoke(null, literalNewField);
+
+        assertWithMessage("Should be false for field initialization (no SLIST in ancestry)")
+                .that(resultFalse)
+                .isFalse();
+
+        final DetailAST localObj = TestUtil.findTokenInAstByPredicate(root,
+                        ast -> {
+                            return ast.getType() == TokenTypes.VARIABLE_DEF
+                                    && "localObj".equals(ast.findFirstToken(TokenTypes.IDENT)
+                                    .getText());
+                        })
+                .orElseThrow();
+        final DetailAST literalNewLocal = localObj.findFirstToken(TokenTypes.ASSIGN)
+                .findFirstToken(TokenTypes.EXPR)
+                .findFirstToken(TokenTypes.LITERAL_NEW);
+
+        final boolean resultTrue = (boolean) insideMethodCheck.invoke(null, literalNewLocal);
+
+        assertWithMessage("Should be true for local variable initialization")
+                .that(resultTrue)
+                .isTrue();
+    }
 }

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/unusedlocalvariable/InputUnusedLocalVariableLambdaAnonInner.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/unusedlocalvariable/InputUnusedLocalVariableLambdaAnonInner.java
@@ -1,0 +1,32 @@
+/*
+UnusedLocalVariable
+allowUnnamedVariables = false
+
+*/
+
+package com.puppycrawl.tools.checkstyle.checks.coding.unusedlocalvariable;
+
+public class InputUnusedLocalVariableLambdaAnonInner {
+
+    Runnable r = () -> {
+        new Object() {
+            void m() {
+                int x = 10; // violation 'Unused local variable 'x''
+            }
+        };
+    };
+
+    Object fieldObj = new Object() {
+        void m() {
+            int x = 10; // violation 'Unused local variable 'x''
+        }
+    };
+
+    void test() {
+        Object localObj = new Object() {
+            void m() {
+                int y = 5; // violation 'Unused local variable 'y''
+            }
+        };
+    }
+}


### PR DESCRIPTION
issue #18030

### Changes Made

**Added test input file:** `InputUnusedLocalVariableLambdaAnonInner.java`

Tests unused variables within nested lambda expressions and anonymous inner classes
Covers the scenario where a lambda contains an anonymous inner class

**Added test methods**: `testGetBlockContainingLocalAnonInnerClass()` and `testIsInsideLocalAnonInnerClass()` in `UnusedLocalVariableCheckTest.java`

**Verifies detection of unused variables in**:

**Removed suppressions**: Deleted 4 mutation suppressions from `pitest-coding-2-suppressions.xml`

getBlockContainingLocalAnonInnerClass - NegateConditionalsMutator
getBlockContainingLocalAnonInnerClass - RemoveConditionalMutator_EQUAL_IF
isInsideLocalAnonInnerClass - NegateConditionalsMutator
isInsideLocalAnonInnerClass - RemoveConditionalMutator_EQUAL_IF

### Mutations Killed
**The new tests exercises both conditional branches in**:

`if (currentAst.getType() == TokenTypes.LAMBDA)` in `getBlockContainingLocalAnonInnerClass`
`if (currentAst.getType() == TokenTypes.SLIST)` in `isInsideLocalAnonInnerClass`

