### PR TITLE
Issue #16360: Migrate XMLLoggerTest.testAuditFinishedWithoutFileFinis…

### DIFF
--- a/src/test/java/com/puppycrawl/tools/checkstyle/XMLLoggerTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/XMLLoggerTest.java
@@ -350,21 +350,9 @@ public class XMLLoggerTest extends AbstractXmlTestSupport {
 
     @Test
     public void testAuditFinishedWithoutFileFinished() throws Exception {
-        final XMLLogger logger = new XMLLogger(outStream, OutputStreamOptions.CLOSE);
-        logger.auditStarted(null);
-        final AuditEvent fileStartedEvent = new AuditEvent(this, "Test.java");
-        logger.fileStarted(fileStartedEvent);
-
-        final Violation violation =
-                new Violation(1, 1,
-                        "messages.properties", "key", null, SeverityLevel.ERROR, null,
-                        getClass(), null);
-        final AuditEvent errorEvent = new AuditEvent(this, "Test.java", violation);
-        logger.addError(errorEvent);
-
-        logger.fileFinished(errorEvent);
-        logger.auditFinished(null);
-        verifyXml(getPath("ExpectedXMLLoggerError.xml"), outStream, violation.getViolation());
+        final String inputFile = "InputXMLLoggerAuditFinishedWithoutFileFinished.java";
+        final String expectedXmlReport = "ExpectedXMLLoggerAuditFinishedWithoutFileFinished.xml";
+        verifyWithInlineConfigParserAndXmlLogger(inputFile, expectedXmlReport);
     }
 
     @Test

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/xmllogger/ExpectedXMLLoggerAuditFinishedWithoutFileFinished.xml
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/xmllogger/ExpectedXMLLoggerAuditFinishedWithoutFileFinished.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<checkstyle version="">
+<file name="InputXMLLoggerAuditFinishedWithoutFileFinished.java">
+<error line="13" column="17" severity="error" message="Name &apos;Bad_Name&apos; must match pattern &apos;^[a-z][a-zA-Z0-9]*$&apos;." source="com.puppycrawl.tools.checkstyle.checks.naming.MemberNameCheck"/>
+</file>
+</checkstyle>

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/xmllogger/InputXMLLoggerAuditFinishedWithoutFileFinished.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/xmllogger/InputXMLLoggerAuditFinishedWithoutFileFinished.java
@@ -1,0 +1,14 @@
+/*xml
+<module name="Checker">
+    <module name="TreeWalker">
+        <module name="MemberName">
+            <property name="format" value="^[a-z][a-zA-Z0-9]*$"/>
+        </module>
+    </module>
+</module>
+*/
+package com.puppycrawl.tools.checkstyle.xmllogger;
+
+public class InputXMLLoggerAuditFinishedWithoutFileFinished {
+    private int Bad_Name;
+}


### PR DESCRIPTION
Issue #16360: Change the XMLLoggerTest.testAuditFinishedWithoutFileFinished method to use verifyWithInlineConfigParserAndXmlLogger.