### PR TITLE
Issue #17882: add WS token description to fix JavadocCommentsTokenTypes errors

### DIFF
--- a/src/main/resources/com/puppycrawl/tools/checkstyle/api/tokentypes.properties
+++ b/src/main/resources/com/puppycrawl/tools/checkstyle/api/tokentypes.properties
@@ -1,0 +1,1 @@
+WS=Whitespace


### PR DESCRIPTION
Issue #17882: add WS token description to fix  JavadocCommentsTokenTypes errors. 

Added the missing WS token description in src/main/resources/com/puppycrawl/tools/checkstyle/api/tokentypes.properties
to fix TokenTypesTest and TokenUtilTest CI errors.
