### PR TITLE
Issue #18118: fix indentation calculation logic for chained method call

### DIFF
--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/indentation/IndentationCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/indentation/IndentationCheckTest.java
@@ -349,6 +349,7 @@ public class IndentationCheckTest extends AbstractModuleTestSupport {
             "53:19: " + getCheckMessage(MSG_CHILD_ERROR, "method call", 18, 20),
             "54:15: " + getCheckMessage(MSG_ERROR, "method call rparen", 14, 16),
             "75:13: " + getCheckMessage(MSG_ERROR, "lambda arguments", 12, 16),
+            "81:16: " + getCheckMessage(MSG_ERROR, "method call rparen", 15, 8),
         };
         verifyWarns(checkConfig, getPath("InputIndentationMethodCallLineWrap.java"), expected);
     }
@@ -1601,10 +1602,10 @@ public class IndentationCheckTest extends AbstractModuleTestSupport {
         checkConfig.addProperty("throwsIndent", "4");
         final String fileName = getPath("InputIndentationChainedMethodCalls.java");
         final String[] expected = {
-            "33:5: " + getCheckMessage(MSG_CHILD_ERROR, "method call", 4, 8),
-            "38:5: " + getCheckMessage(MSG_ERROR, ".", 4, 8),
-            "39:5: " + getCheckMessage(MSG_ERROR, ".", 4, 8),
-            "42:5: " + getCheckMessage(MSG_ERROR, "new", 4, 8),
+            "36:5: " + getCheckMessage(MSG_CHILD_ERROR, "method call", 4, 8),
+            "41:5: " + getCheckMessage(MSG_ERROR, ".", 4, 8),
+            "42:5: " + getCheckMessage(MSG_ERROR, ".", 4, 8),
+            "45:5: " + getCheckMessage(MSG_ERROR, "new", 4, 8),
         };
         verifyWarns(checkConfig, fileName, expected);
     }

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/indentation/indentation/InputIndentationChainedMethodCalls.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/indentation/indentation/InputIndentationChainedMethodCalls.java
@@ -14,6 +14,9 @@
 
 package com.puppycrawl.tools.checkstyle.checks.indentation.indentation;     //indent:0 exp:0
 
+import java.util.List;                                                      //indent:0 exp:0
+import java.util.stream.Stream;                                             //indent:0 exp:0
+
 class InputIndentationChainedMethodCalls {                                  //indent:0 exp:0
 
   public InputIndentationChainedMethodCalls(Object... params) {             //indent:2 exp:2
@@ -43,5 +46,37 @@ class InputIndentationChainedMethodCalls {                                  //in
         .getInstance()                                                      //indent:8 exp:8
         .doNothing("nothing")                                               //indent:8 exp:8
         .length();                                                          //indent:8 exp:8
+
+    new InputIndentationChainedMethodCalls("param1", "param2")              //indent:4 exp:4
+        .getInstance().doNothing(                                           //indent:8 exp:8
+            "nothing",                                                      //indent:12 exp:12
+            new InputIndentationChainedMethodCalls()                        //indent:12 exp:12
+                .getInstance()                                              //indent:16 exp:16
+                .doNothing("abc")                                           //indent:16 exp:16
+        );                                                                  //indent:8 exp:8
+  }                                                                         //indent:2 exp:2
+
+  public static void testListOfStreamPattern() {                            //indent:2 exp:2
+    List.of("foo").stream()                                                 //indent:4 exp:4
+        .findFirst()                                                        //indent:8 exp:8
+        .ifPresentOrElse(                                                   //indent:8 exp:8
+          System.out::println,                                              //indent:10 exp:10
+          () -> {                                                           //indent:10 exp:10
+            throw new IllegalStateException();                              //indent:12 exp:12
+          }                                                                 //indent:10 exp:10
+        );                                                                  //indent:8 exp:8
+
+    List.of("a", "b", "c").stream()                                         //indent:4 exp:4
+        .filter(s -> s.length() > 1)                                        //indent:8 exp:8
+        .forEach(System.out::println);                                      //indent:8 exp:8
+
+    Stream.of("foo")                                                        //indent:4 exp:4
+        .findFirst()                                                        //indent:8 exp:8
+        .ifPresentOrElse(                                                   //indent:8 exp:8
+          System.out::println,                                              //indent:10 exp:10
+          () -> {                                                           //indent:10 exp:10
+            throw new IllegalStateException();                              //indent:12 exp:12
+          }                                                                 //indent:10 exp:10
+        );                                                                  //indent:8 exp:8
   }                                                                         //indent:2 exp:2
 }                                                                           //indent:0 exp:0

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/indentation/indentation/InputIndentationMethodCallLineWrap.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/indentation/indentation/InputIndentationMethodCallLineWrap.java
@@ -74,4 +74,10 @@ public class InputIndentationMethodCallLineWrap {                            //i
             chainingWithLambda(                                              //indent:12 exp:12
             x -> x);                                                         //indent:12 exp:16 warn
     }                                                                        //indent:4 exp:4
+
+
+    void testLineWrap() {                                                    //indent:4 exp:4
+        toString(                                                            //indent:8 exp:8
+               );                                                            //indent:15 exp:8 warn
+    }                                                                        //indent:4 exp:4
 }                                                                            //indent:0 exp:0


### PR DESCRIPTION
Fixes #18118

Problem
The Indentation check incorrectly flagged the closing parenthesis in chained method calls like:

```java
List.of("foo").stream()
    .findFirst()
    .ifPresentOrElse(
        System.out::println,
        () -> { throw new IllegalStateException(); }
    );  // False positive: expected level 8, but 12 is correct
```
However, using Stream.of("foo") instead produced no error, creating inconsistent behavior.

Solution
Modified MethodCallHandler.getIndentImpl() to add the line start column as an acceptable+ indent level for chained method calls. This allows correctly indented closing parens to be accepted while still validating actually incorrect indentation.