### PR TITLE
Issue #18033: Resolve Pitest Suppressions - xpath

### DIFF
--- a/config/checker-framework-suppressions/checker-nullness-optional-interning-suppressions.xml
+++ b/config/checker-framework-suppressions/checker-nullness-optional-interning-suppressions.xml
@@ -9830,17 +9830,6 @@
 
   <checkerFrameworkError unstable="false">
     <fileName>src/main/java/com/puppycrawl/tools/checkstyle/xpath/iterators/ReverseListIterator.java</fileName>
-    <specifier>assignment</specifier>
-    <message>incompatible types in assignment.</message>
-    <lineContent>this.items = null;</lineContent>
-    <details>
-      found   : null (NullType)
-      required: @Initialized @NonNull List&lt;? extends @Initialized @NonNull NodeInfo&gt;
-    </details>
-  </checkerFrameworkError>
-
-  <checkerFrameworkError unstable="false">
-    <fileName>src/main/java/com/puppycrawl/tools/checkstyle/xpath/iterators/ReverseListIterator.java</fileName>
     <specifier>return</specifier>
     <message>incompatible types in return.</message>
     <lineContent>return result;</lineContent>

--- a/config/import-control.xml
+++ b/config/import-control.xml
@@ -323,6 +323,9 @@
     <subpackage name="iterators">
       <!-- These are more saxon utilities, and should not have anything checkstyle specific -->
       <disallow pkg="com\.puppycrawl.*" regex="true"/>
+      <file name="ReverseListIterator">
+        <allow class="com.puppycrawl.tools.checkstyle.utils.UnmodifiableCollectionUtil"/>
+      </file>
     </subpackage>
   </subpackage>
 

--- a/config/pitest-suppressions/pitest-xpath-suppressions.xml
+++ b/config/pitest-suppressions/pitest-xpath-suppressions.xml
@@ -17,13 +17,4 @@
     <description>Removed assignment to member variable previousSiblingEnum</description>
     <lineContent>previousSiblingEnum = null;</lineContent>
   </mutation>
-
-  <mutation unstable="false">
-    <sourceFile>ReverseListIterator.java</sourceFile>
-    <mutatedClass>com.puppycrawl.tools.checkstyle.xpath.iterators.ReverseListIterator</mutatedClass>
-    <mutatedMethod>&lt;init&gt;</mutatedMethod>
-    <mutator>org.pitest.mutationtest.engine.gregor.mutators.experimental.MemberVariableMutator</mutator>
-    <description>Removed assignment to member variable items</description>
-    <lineContent>this.items = null;</lineContent>
-  </mutation>
 </suppressedMutations>

--- a/src/main/java/com/puppycrawl/tools/checkstyle/utils/UnmodifiableCollectionUtil.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/utils/UnmodifiableCollectionUtil.java
@@ -54,6 +54,26 @@ public final class UnmodifiableCollectionUtil {
     }
 
     /**
+     * Creates an unmodifiable list from the provided collection.
+     * If the collection is null, returns an empty unmodifiable list.
+     *
+     * @param collection the collection to create an unmodifiable list from
+     * @param <T> the type of elements in the list
+     * @return an unmodifiable list containing the elements from the provided collection,
+     *         or an empty list if the collection is null
+     */
+    public static <T> List<T> unmodifiableList(Collection<? extends T> collection) {
+        final List<T> result;
+        if (collection == null) {
+            result = Collections.emptyList();
+        }
+        else {
+            result = List.copyOf(collection);
+        }
+        return result;
+    }
+
+    /**
      * Returns an unmodifiable view of a List containing elements of a specific type.
      *
      * @param items The List of items to make unmodifiable.

--- a/src/main/java/com/puppycrawl/tools/checkstyle/xpath/iterators/ReverseListIterator.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/xpath/iterators/ReverseListIterator.java
@@ -19,10 +19,10 @@
 
 package com.puppycrawl.tools.checkstyle.xpath.iterators;
 
-import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
 
+import com.puppycrawl.tools.checkstyle.utils.UnmodifiableCollectionUtil;
 import net.sf.saxon.om.NodeInfo;
 import net.sf.saxon.tree.iter.AxisIterator;
 
@@ -45,14 +45,8 @@ public class ReverseListIterator implements AxisIterator {
      * @param items the collection of nodes.
      */
     public ReverseListIterator(Collection<? extends NodeInfo> items) {
-        if (items == null) {
-            this.items = null;
-            index = -1;
-        }
-        else {
-            this.items = new ArrayList<>(items);
-            index = items.size() - 1;
-        }
+        this.items = UnmodifiableCollectionUtil.unmodifiableList(items);
+        index = this.items.size() - 1;
     }
 
     /**


### PR DESCRIPTION
Issue #18033: Removed the suppression of the mutation in Pitest Suppressions - xpath by removing the assignment in the constructor to null as it is redundant because unassigning it in java is the same as assigning it to null