### PR TITLE
Issue #18025: Resolve pitest Suppression Tree walker

### DIFF
--- a/config/ant-phase-verify.xml
+++ b/config/ant-phase-verify.xml
@@ -178,6 +178,7 @@
           <exclude name="**/InputTreeWalkerSkipParsingExceptionConfigSeverityDefault.java"/>
           <exclude name="**/InputTreeWalkerSkipParsingExceptionConfigSeverityIgnore.java"/>
           <exclude name="**/InputDefaultLoggerTestException.java"/>
+          <exclude name="**/InputTreeWalkerSkipParsingExceptionSeverityError.java"/>
         </fileset>
       </path>
       <formatter type="plain"/>

--- a/config/pitest-suppressions/pitest-tree-walker-suppressions.xml
+++ b/config/pitest-suppressions/pitest-tree-walker-suppressions.xml
@@ -1,11 +1,3 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <suppressedMutations>
-  <mutation unstable="false">
-    <sourceFile>TreeWalker.java</sourceFile>
-    <mutatedClass>com.puppycrawl.tools.checkstyle.TreeWalker</mutatedClass>
-    <mutatedMethod>&lt;init&gt;</mutatedMethod>
-    <mutator>org.pitest.mutationtest.engine.gregor.mutators.experimental.MemberVariableMutator</mutator>
-    <description>Removed assignment to member variable javaParseExceptionSeverity</description>
-    <lineContent>private SeverityLevel javaParseExceptionSeverity = SeverityLevel.ERROR;</lineContent>
-  </mutation>
 </suppressedMutations>

--- a/src/test/java/com/puppycrawl/tools/checkstyle/TreeWalkerTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/TreeWalkerTest.java
@@ -835,6 +835,18 @@ public class TreeWalkerTest extends AbstractModuleTestSupport {
         verify(checker, files, expectedViolation);
     }
 
+    @Test
+    public void testJavaParseExceptionSeverityCustom() throws Exception {
+        final String path =
+                getNonCompilablePath(
+                        "InputTreeWalkerSkipParsingExceptionSeverityError.java");
+        final String[] expected = {
+            "1: " + getCheckMessage(TreeWalker.PARSE_EXCEPTION_MSG, "IllegalStateException")
+                  + " occurred while parsing file " + path + ".",
+        };
+        verifyWithInlineXmlConfig(path, expected);
+    }
+
     public static class BadJavaDocCheck extends AbstractCheck {
 
         @Override

--- a/src/test/resources-noncompilable/com/puppycrawl/tools/checkstyle/treewalker/InputTreeWalkerSkipParsingExceptionSeverityError.java
+++ b/src/test/resources-noncompilable/com/puppycrawl/tools/checkstyle/treewalker/InputTreeWalkerSkipParsingExceptionSeverityError.java
@@ -1,0 +1,13 @@
+/*xml
+<module name="Checker">
+  <module name="TreeWalker">
+    <property name="skipFileOnJavaParseException" value="true"/>
+    <property name="javaParseExceptionSeverity" value="error"/>
+    <module name="ConstantName"/>
+  </module>
+</module>
+*/
+
+// violation 10 lines above
+// non-compiled syntax: bad file for testing
+public clazz InputTreeWalkerSkipParsingExceptionSeverityError { }


### PR DESCRIPTION
Issue: #18025 

Added test to kills mutation for testJavaParseExceptionSeverity
what this test do-

This test asserts that TreeWalker parsing exceptions always produce an AuditEvent with a non-null default severity of ERROR.
It is added to kill a PIT mutation that sets the default severity to null, ensuring parsing errors are consistently reported with a valid severity.