### PR TITLE
Issue #18409: Remove duplicate violations in sun_checks.xml

### DIFF
--- a/src/main/resources/sun_checks.xml
+++ b/src/main/resources/sun_checks.xml
@@ -142,7 +142,12 @@
     <module name="OperatorWrap"/>
     <module name="ParenPad"/>
     <module name="TypecastParenPad"/>
-    <module name="WhitespaceAfter"/>
+    <module name="WhitespaceAfter">
+      <!-- Explicit token list to avoid duplication with WhitespaceAround.
+       All other default tokens are covered by WhitespaceAround. -->
+      <property name="tokens"
+                value="COMMA, SEMI, TYPECAST, LITERAL_YIELD, ELLIPSIS, LITERAL_CASE"/>
+    </module>
     <module name="WhitespaceAround"/>
 
     <!-- Modifier Checks                                    -->


### PR DESCRIPTION
Issue #18409: 

Added explicit tokens to WhitespaceAfter check to remove overlap with 
WhitespaceAround. Kept only tokens not covered by WhitespaceAround:
COMMA, SEMI, TYPECAST, LITERAL_YIELD, ELLIPSIS, LITERAL_CASE.