### PR TITLE
Issue #18317: update doc example to show method without inheritDoc

### DIFF
--- a/src/site/xdoc/checks/annotation/missingoverride.xml
+++ b/src/site/xdoc/checks/annotation/missingoverride.xml
@@ -99,6 +99,19 @@ class Example1 extends ParentClass1 {
   public static void test4() {
 
   }
+
+  // No javadoc, no @Override needed
+  public void test5() {
+
+  }
+
+  // Javadoc present but no {@inheritDoc}, no @Override needed
+  /**
+   * This is a sample javadoc.
+   */
+  public void test6() {
+
+  }
 }
 </code></pre></div><hr class="example-separator"/>
         <p id="Example2-config">

--- a/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/annotation/missingoverride/Example1.java
+++ b/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/annotation/missingoverride/Example1.java
@@ -39,5 +39,18 @@ class Example1 extends ParentClass1 {
   public static void test4() {
 
   }
+
+  // No javadoc, no @Override needed
+  public void test5() {
+
+  }
+
+  // Javadoc present but no {@inheritDoc}, no @Override needed
+  /**
+   * This is a sample javadoc.
+   */
+  public void test6() {
+
+  }
 }
 // xdoc section -- end


### PR DESCRIPTION
Issue: #18317

Extend the MissingOverride documentation with a third example that clarifies when the `@Override` annotation is required. The new example shows:

1. Methods without javadoc do not need `@Override` annotation
2. Methods with javadoc but without {`@inheritDoc`} tag do not need `@Override`  
3. Only methods with {`@inheritDoc`} tag require `@Override` annotation

This resolves confusion reported in issue #17561 where developers were unsure about the relationship between javadoc and the `@Override` requirement