### PR TITLE
Issue #18317: update doc example to show method without inheritDoc

### DIFF
--- a/src/site/xdoc/checks/annotation/missingoverride.xml
+++ b/src/site/xdoc/checks/annotation/missingoverride.xml
@@ -99,6 +99,15 @@ class Example1 extends ParentClass1 {
   public static void test4() {
 
   }
+
+  // No javadoc, no @Override needed
+  public void test5() {}
+
+  // Javadoc present but no {@inheritDoc}, no @Override needed
+  /**
+   * This is a sample javadoc.
+   */
+  public void test6() {}
 }
 </code></pre></div><hr class="example-separator"/>
         <p id="Example2-config">

--- a/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/checks/annotation/MissingOverrideCheckExamplesTest.java
+++ b/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/checks/annotation/MissingOverrideCheckExamplesTest.java
@@ -36,9 +36,9 @@ public class MissingOverrideCheckExamplesTest extends AbstractExamplesModuleTest
     @Test
     public void testExample1() throws Exception {
         final String[] expected = {
-            "27:3: " + getCheckMessage(MSG_KEY_ANNOTATION_MISSING_OVERRIDE, "test2"),
-            "33:3: " + getCheckMessage(MSG_KEY_TAG_NOT_VALID_ON, "{@inheritDoc}"),
-            "39:3: " + getCheckMessage(MSG_KEY_TAG_NOT_VALID_ON, "{@inheritDoc}"),
+            "31:3: " + getCheckMessage(MSG_KEY_ANNOTATION_MISSING_OVERRIDE, "test2"),
+            "37:3: " + getCheckMessage(MSG_KEY_TAG_NOT_VALID_ON, "{@inheritDoc}"),
+            "43:3: " + getCheckMessage(MSG_KEY_TAG_NOT_VALID_ON, "{@inheritDoc}"),
         };
         verifyWithInlineConfigParser(getPath("Example1.java"), expected);
     }

--- a/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/annotation/missingoverride/Example1.java
+++ b/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/annotation/missingoverride/Example1.java
@@ -13,6 +13,10 @@ class ParentClass1{
 
   public void test2(){}
 
+  public void test5(){}
+
+  public void test6(){}
+
 }
 // xdoc section -- start
 class Example1 extends ParentClass1 {
@@ -39,5 +43,14 @@ class Example1 extends ParentClass1 {
   public static void test4() {
 
   }
+
+  // No javadoc, no @Override needed
+  public void test5() {}
+
+  // Javadoc present but no {@inheritDoc}, no @Override needed
+  /**
+   * This is a sample javadoc.
+   */
+  public void test6() {}
 }
 // xdoc section -- end


### PR DESCRIPTION
Issue: #18317

Extend the MissingOverride documentation with a 5 and 6 examples that clarifies when the `@Override` annotation is required. The new example shows:

1. No javadoc, no `@Override` needed
2. Javadoc present but no {`@inheritDoc`}, no `@Override` needed

This resolves confusion reported in issue #17561 where developers were unsure about the relationship between javadoc and the `@Override` requirement