### PR TITLE
Issue #18361: add JDK 25 not supported warning to beginning_developme…

### DIFF
--- a/src/site/xdoc/beginning_development.xml
+++ b/src/site/xdoc/beginning_development.xml
@@ -21,6 +21,15 @@
         You can find information about development environment preparation here:
         <a href="https://github.com/sevntu-checkstyle/sevntu.checkstyle/wiki/Prepare-Development-Environment-in-Ubuntu-12.04">
         Prepare development environment in Ubuntu</a>.<br/>
+      </p>
+      <p>
+        <b>Note:</b> JDK 25 is currently not supported. Some test dependencies
+        (cacio-tta, Mockito/ByteBuddy) are incompatible with JDK 25.
+        Please use JDK 21 (LTS) for development until this issue is resolved.
+        See <a href="https://github.com/checkstyle/checkstyle/issues/18361">issue #18361</a>
+        for more details.
+      </p>
+      <p>
         2. Fork Checkstyle upstream project. As it is described
         <a href="https://help.github.com/articles/fork-a-repo/"> here</a><br/>
         3. Clone your forked repository to your computer:


### PR DESCRIPTION
Issue #18361:
doc update: add JDK 25 compatibility warning to beginning_development.xml

JDK 25 is not yet supported due to dependency issues:
- cacio-tta 1.18 fails with NoClassDefFoundError for sun.java2d.SurfaceManagerFactory
- Mockito/ByteBuddy requires version 1.17.0+ for JDK 25 support

Added note recommending JDK 21 (LTS) for development until issue #18361 is resolved.

<img width="1277" height="185" alt="image" src="https://github.com/user-attachments/assets/f4bb8755-8af4-44dd-9c6c-d785f8578ad4" />
