### PR TITLE
Issue #17663: Fix missing indentation violations for '->' and ',' in return statement continuations

### DIFF
--- a/config/checker-framework-suppressions/checker-nullness-optional-interning-suppressions.xml
+++ b/config/checker-framework-suppressions/checker-nullness-optional-interning-suppressions.xml
@@ -4962,14 +4962,42 @@
     <fileName>src/main/java/com/puppycrawl/tools/checkstyle/checks/indentation/BlockParentHandler.java</fileName>
     <specifier>not.interned</specifier>
     <message>attempting to use a non-@Interned comparison operand</message>
-    <lineContent>if (nonList != nonListStartAst) {</lineContent>
+    <lineContent>&amp;&amp; lastNode != returnExpr</lineContent>
   </checkerFrameworkError>
 
   <checkerFrameworkError unstable="false">
     <fileName>src/main/java/com/puppycrawl/tools/checkstyle/checks/indentation/BlockParentHandler.java</fileName>
     <specifier>not.interned</specifier>
     <message>attempting to use a non-@Interned comparison operand</message>
-    <lineContent>if (nonList != nonListStartAst) {</lineContent>
+    <lineContent>&amp;&amp; lastNode != returnExpr</lineContent>
+  </checkerFrameworkError>
+
+  <checkerFrameworkError unstable="false">
+    <fileName>src/main/java/com/puppycrawl/tools/checkstyle/checks/indentation/BlockParentHandler.java</fileName>
+    <specifier>not.interned</specifier>
+    <message>attempting to use a non-@Interned comparison operand</message>
+    <lineContent>if (current == source) {</lineContent>
+  </checkerFrameworkError>
+
+  <checkerFrameworkError unstable="false">
+    <fileName>src/main/java/com/puppycrawl/tools/checkstyle/checks/indentation/BlockParentHandler.java</fileName>
+    <specifier>not.interned</specifier>
+    <message>attempting to use a non-@Interned comparison operand</message>
+    <lineContent>if (current == source) {</lineContent>
+  </checkerFrameworkError>
+
+  <checkerFrameworkError unstable="false">
+    <fileName>src/main/java/com/puppycrawl/tools/checkstyle/checks/indentation/BlockParentHandler.java</fileName>
+    <specifier>not.interned</specifier>
+    <message>attempting to use a non-@Interned comparison operand</message>
+    <lineContent>if (source != null &amp;&amp; target != null &amp;&amp; source != target) {</lineContent>
+  </checkerFrameworkError>
+
+  <checkerFrameworkError unstable="false">
+    <fileName>src/main/java/com/puppycrawl/tools/checkstyle/checks/indentation/BlockParentHandler.java</fileName>
+    <specifier>not.interned</specifier>
+    <message>attempting to use a non-@Interned comparison operand</message>
+    <lineContent>if (source != null &amp;&amp; target != null &amp;&amp; source != target) {</lineContent>
   </checkerFrameworkError>
 
   <checkerFrameworkError unstable="false">

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/indentation/IndentationCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/indentation/IndentationCheckTest.java
@@ -369,6 +369,28 @@ public class IndentationCheckTest extends AbstractModuleTestSupport {
     }
 
     @Test
+    public void testReturnLambdaComma() throws Exception {
+        final DefaultConfiguration checkConfig = createModuleConfig(IndentationCheck.class);
+        checkConfig.addProperty("arrayInitIndent", "2");
+        checkConfig.addProperty("basicOffset", "2");
+        checkConfig.addProperty("braceAdjustment", "2");
+        checkConfig.addProperty("caseIndent", "2");
+        checkConfig.addProperty("forceStrictCondition", "false");
+        checkConfig.addProperty("lineWrappingIndentation", "4");
+        checkConfig.addProperty("tabWidth", "4");
+        checkConfig.addProperty("throwsIndent", "4");
+        final String[] expected = {
+            "6:5: " + getCheckMessage(MSG_CHILD_ERROR, "method def", 4, 8),
+            "7:5: " + getCheckMessage(MSG_CHILD_ERROR, "method def", 4, 8),
+            "12:5: " + getCheckMessage(MSG_ERROR, "s", 4, 8),
+            "17:5: " + getCheckMessage(MSG_ERROR, "1", 4, 8),
+            "18:5: " + getCheckMessage(MSG_ERROR, "2", 4, 8),
+            "19:5: " + getCheckMessage(MSG_ERROR, "3", 4, 8),
+        };
+        verifyWarns(checkConfig, getPath("InputIndentationReturnLambdaComma.java"), expected);
+    }
+
+    @Test
     public void testDifficultAnnotations() throws Exception {
         final DefaultConfiguration checkConfig = createModuleConfig(IndentationCheck.class);
 

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/indentation/indentation/InputIndentationReturnLambdaComma.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/indentation/indentation/InputIndentationReturnLambdaComma.java
@@ -1,0 +1,23 @@
+package com.puppycrawl.tools.checkstyle.checks.indentation.indentation;      //indent:0 exp:0
+
+public class InputIndentationReturnLambdaComma {                            //indent:0 exp:0
+  int sum(int a, int b, int c) {                                            //indent:2 exp:2
+    return a                                                                 //indent:4 exp:4
+    + b                                                                     //indent:4 exp:8 warn
+    + c;                                                                    //indent:4 exp:8 warn
+  }                                                                         //indent:2 exp:2
+
+  java.util.function.Function<String, Integer> test_arrow() {               //indent:2 exp:2
+    return (String s) ->                                                    //indent:4 exp:4
+    s.length();                                                             //indent:4 exp:8 warn
+  }                                                                         //indent:2 exp:2
+
+  int test_comma() {                                                        //indent:2 exp:2
+    return sum(                                                             //indent:4 exp:4
+    1,                                                                      //indent:4 exp:8 warn
+    2,                                                                      //indent:4 exp:8 warn
+    3                                                                       //indent:4 exp:8 warn
+    );                                                                      //indent:4 exp:4
+  }                                                                         //indent:2 exp:2
+}                                                                            //indent:0 exp:0
+


### PR DESCRIPTION
Issue: #17663

The indentation check does not catch indentation problems for lambda arrows (->) and commas (,) in return statement continuations. This results in false negatives. Return statements with incorrectly indented lambda arrow continuations or comma-separated arguments go unmarked as violations. In contrast, operators like + in similar situations are correctly identified.

For example:
- `return a + b + c;` - violations for `+` operators are correctly reported 
- `return (String s) -> s.length();` - violation for lambda arrow continuation is ignored 
- `return sum(1, 2, 3);` - violations for comma-separated arguments are ignored 

This inconsistency makes the indentation checking behavior incomplete and breaks the rule that all continuation elements in return statements should be checked in the same way. 

I added the `checkReturnStatementLineWrapping()` method to the `BlockParentHandler` class. This method checks the line wrapping indentation for return statements that span multiple lines. It ensures that lambda arrows (`->`) and commas (`,`) in return statement continuations are properly checked for indentation violations. This makes the behavior consistent with operators like `+`, which were already being checked.