### PR TITLE
Issue #17882: Update DEPRECATED_BLOCK_TAG structure in JavadocCommentsTokenTypes

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/api/JavadocCommentsTokenTypes.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/api/JavadocCommentsTokenTypes.java
@@ -147,20 +147,26 @@ public final class JavadocCommentsTokenTypes {
      * </ol>
      *
      * <p><b>Example:</b></p>
-     * <pre>{@code * @deprecated deprecated text.}</pre>
+     * <pre>
+     * /**
+     *  * &#64;deprecated description
+     *  *&#47;
+     * </pre>
      *
-     * <b>Tree:</b>
-     * <pre>{@code
+     * <p><b>Tree:</b></p>
+     * <pre>
      * JAVADOC_CONTENT -> JAVADOC_CONTENT
-     * |--LEADING_ASTERISK -> *
-     * |--TEXT ->
-     * `--JAVADOC_BLOCK_TAG -> JAVADOC_BLOCK_TAG
-     *     `--DEPRECATED_BLOCK_TAG -> DEPRECATED_BLOCK_TAG
-     *         |--AT_SIGN -> @
-     *         |--TAG_NAME -> deprecated
-     *         `--DESCRIPTION -> DESCRIPTION
-     *             `--TEXT ->  deprecated text.
-     * }</pre>
+     * |-- TEXT -> /**
+     * |-- NEWLINE -> \n
+     * |-- LEADING_ASTERISK ->  *
+     * |-- TEXT ->
+     * `-- JAVADOC_BLOCK_TAG -> JAVADOC_BLOCK_TAG
+     *     `-- DEPRECATED_BLOCK_TAG -> DEPRECATED_BLOCK_TAG
+     *         |-- AT_SIGN -> &#64;
+     *         |-- TAG_NAME -> deprecated
+     *         `-- DESCRIPTION -> DESCRIPTION
+     *             `-- TEXT -> description
+     * </pre>
      *
      * @see #JAVADOC_BLOCK_TAG
      */


### PR DESCRIPTION
Issue: #17882

I updated the Javadoc documentation for DEPRECATED_BLOCK_TAG.
I generated the new AST tree using the Checkstyle CLI tool and updated the example code to match the new format.