### PR TITLE
Issue #18028: Resolve Pitest Supressions - api - abstractfileset

### DIFF
--- a/config/pitest-suppressions/pitest-api-suppressions.xml
+++ b/config/pitest-suppressions/pitest-api-suppressions.xml
@@ -8,13 +8,4 @@
     <description>removed call to com/puppycrawl/tools/checkstyle/api/AbstractCheck::getSeverityLevel</description>
     <lineContent>getSeverityLevel(),</lineContent>
   </mutation>
-
-  <mutation unstable="false">
-    <sourceFile>AbstractFileSetCheck.java</sourceFile>
-    <mutatedClass>com.puppycrawl.tools.checkstyle.api.AbstractFileSetCheck</mutatedClass>
-    <mutatedMethod>log</mutatedMethod>
-    <mutator>org.pitest.mutationtest.engine.gregor.mutators.NonVoidMethodCallMutator</mutator>
-    <description>removed call to com/puppycrawl/tools/checkstyle/api/AbstractFileSetCheck::getSeverityLevel</description>
-    <lineContent>getSeverityLevel(),</lineContent>
-  </mutation>
 </suppressedMutations>

--- a/src/test/java/com/puppycrawl/tools/checkstyle/api/AbstractFileSetCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/api/AbstractFileSetCheckTest.java
@@ -203,6 +203,9 @@ public class AbstractFileSetCheckTest extends AbstractModuleTestSupport {
         assertWithMessage("expected column")
                 .that(violation.getColumnNo())
                 .isEqualTo(1);
+        assertWithMessage("expected severity")
+                .that(violation.getSeverityLevel())
+                .isEqualTo(SeverityLevel.ERROR);
     }
 
     @Test
@@ -248,6 +251,9 @@ public class AbstractFileSetCheckTest extends AbstractModuleTestSupport {
         assertWithMessage("expected column")
                 .that(violation.getColumnNo())
                 .isEqualTo(0);
+        assertWithMessage("expected severity")
+                .that(violation.getSeverityLevel())
+                .isEqualTo(SeverityLevel.ERROR);
 
         // re-running erases previous errors
 


### PR DESCRIPTION
Issue #18028: Resolve Pitest Supressions - api - abstractfileset

Updated testLineColumnLog: We added a check to ensure the severity level is ERROR.
Updated testMultiFileFireErrors: We added the exact same check there.

shows "KILLED" 

<img width="1058" height="29" alt="image" src="https://github.com/user-attachments/assets/64a7369e-190a-4f19-9ea2-2a5892f6e832" />

<img width="1062" height="22" alt="image" src="https://github.com/user-attachments/assets/e3367f50-51bf-4163-b105-6f061425faa4" />

Please let me know if this approach is accepted or if any changes are needed, thank you.