### PR TITLE
Issue #18028: Resolve Pitest Supressions - api - abstractcheck

### DIFF
--- a/config/pitest-suppressions/pitest-api-suppressions.xml
+++ b/config/pitest-suppressions/pitest-api-suppressions.xml
@@ -1,11 +1,3 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <suppressedMutations>
-  <mutation unstable="false">
-    <sourceFile>AbstractCheck.java</sourceFile>
-    <mutatedClass>com.puppycrawl.tools.checkstyle.api.AbstractCheck</mutatedClass>
-    <mutatedMethod>log</mutatedMethod>
-    <mutator>org.pitest.mutationtest.engine.gregor.mutators.NonVoidMethodCallMutator</mutator>
-    <description>removed call to com/puppycrawl/tools/checkstyle/api/AbstractCheck::getSeverityLevel</description>
-    <lineContent>getSeverityLevel(),</lineContent>
-  </mutation>
 </suppressedMutations>

--- a/src/test/java/com/puppycrawl/tools/checkstyle/api/AbstractCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/api/AbstractCheckTest.java
@@ -340,6 +340,9 @@ public class AbstractCheckTest extends AbstractModuleTestSupport {
         assertWithMessage("expected column")
                 .that(firstViolation.getColumnNo())
                 .isEqualTo(0);
+        assertWithMessage("expected severity level")
+                .that(firstViolation.getSeverityLevel())
+                .isEqualTo(SeverityLevel.ERROR);
 
         final Violation secondViolation = iterator.next();
         assertWithMessage("expected line")
@@ -348,6 +351,9 @@ public class AbstractCheckTest extends AbstractModuleTestSupport {
         assertWithMessage("expected column")
                 .that(secondViolation.getColumnNo())
                 .isEqualTo(6);
+        assertWithMessage("expected severity level")
+                .that(secondViolation.getSeverityLevel())
+                .isEqualTo(SeverityLevel.ERROR);
     }
 
     @Test
@@ -378,6 +384,9 @@ public class AbstractCheckTest extends AbstractModuleTestSupport {
         assertWithMessage("expected column")
                 .that(firstViolation.getColumnNo())
                 .isEqualTo(5);
+        assertWithMessage("expected severity level")
+                .that(firstViolation.getSeverityLevel())
+                .isEqualTo(SeverityLevel.ERROR);
     }
 
     @Test


### PR DESCRIPTION
Issue #18028: Resolve Pitest Supressions - api - abstractcheck

Added assertions to testLineColumnLog and testAstLog. 

All 3 have been "KILLED"

<img width="990" height="21" alt="image" src="https://github.com/user-attachments/assets/83fd71c1-3612-454a-afe1-fe74370236d8" />
<img width="980" height="24" alt="image" src="https://github.com/user-attachments/assets/8b6c8f97-1634-4448-b5bf-733b7013521b" />
<img width="996" height="17" alt="image" src="https://github.com/user-attachments/assets/3ff844c8-969d-49cc-869e-59eb04389b36" />
