### PR TITLE
Issue #17565: Fix LeftCurlyCheck to correctly validate line break after '{'

### DIFF
--- a/src/it/resources/com/google/checkstyle/test/chapter4formatting/rule462horizontalwhitespace/InputWhitespaceAroundArrow.java
+++ b/src/it/resources/com/google/checkstyle/test/chapter4formatting/rule462horizontalwhitespace/InputWhitespaceAroundArrow.java
@@ -32,18 +32,22 @@ public class InputWhitespaceAroundArrow {
   void test(Object o, Object o2, int y) {
     switch (o) {
       case String s when (
-          s.equals("a"))-> // violation ''->' is not preceded with whitespace.'
+          // violation 2 lines below ''->' is not preceded with whitespace.'
+          // violation 2 lines below ''{' at column 9 should be on the previous line.'
+          s.equals("a"))->
         {
         }
       case Point(int x, int xy) when !(x >= 0 && y >= 0) -> {}
-      default-> // violation ''->' is not preceded with whitespace.'
+      // violation below ''->' is not preceded with whitespace.'
+      default->
         {}
     }
 
     int x = switch (o) {
       case String s -> {
         switch (o2) {
-          case Integer i when i == 0-> { // violation ''->' is not preceded with whitespace.'
+          // violation below ''->' is not preceded with whitespace.'
+          case Integer i when i == 0-> {
             if (y == 0) {
               System.out.println(0);
             }

--- a/src/it/resources/com/google/checkstyle/test/chapter4formatting/rule462horizontalwhitespace/InputWhitespaceAroundWhen.java
+++ b/src/it/resources/com/google/checkstyle/test/chapter4formatting/rule462horizontalwhitespace/InputWhitespaceAroundWhen.java
@@ -7,41 +7,50 @@ class InputWhitespaceAroundWhen {
   /** Method. */
   void test(Object o) {
     switch (o) {
-      case Integer i when(i == 0) -> // violation ''when' is not followed by whitespace.'
+      // violation 2 lines below ''when' is not followed by whitespace.'
+      // violation 2 lines below ''{' at column 9 should be on the previous line.'
+      case Integer i when(i == 0) ->
         {
         }
-      // violation below, ''when' is not followed by whitespace.'
+      // violation 2 lines below ''when' is not followed by whitespace.'
+      // violation 3 lines below ''{' at column 9 should be on the previous line.'
       case String s when(
               s.equals("a")) ->
         {
         }
 
-      // violation below, ''when' is not followed by whitespace.'
+      // violation 2 lines below ''when' is not followed by whitespace.'
+      // violation 2 lines below ''{' at column 9 should be on the previous line.'
       case Point(int x, int y) when!(x >= 0 && y >= 0) ->
         {
         }
-
+      // violation 2 lines below ''{' at column 9 should be on the previous line.'
       default ->
         {
         }
     }
 
     switch (o) {
+      // violation 2 lines below ''when' is not preceded with whitespace.'
+      // violation 2 lines below ''{' at column 9 should be on the previous line.'
       case Point(int x, int y)when (x < 9 && y >= 0) ->
         {
-        }  // violation 2 lines above ''when' is not preceded with whitespace.'
+        }
+      // 2 violations 4 lines below:
+      //              ''when' is not followed by whitespace.'
+      //              ''when' is not preceded with whitespace.'
+      // violation 2 lines below ''{' at column 9 should be on the previous line.'
       case Point(int x, int y)when(x >= 0 && y >= 0) ->
         {
         }
-      // 2 violations 3 lines above:
+      // 2 violations 4 lines below:
       //              ''when' is not followed by whitespace.'
       //              ''when' is not preceded with whitespace.'
+      // violation 2 lines below ''{' at column 9 should be on the previous line.'
       case Point(int x, int y)when!(x >= 0 && y >= 0) ->
         {
         }
-      // 2 violations 3 lines above:
-      //              ''when' is not followed by whitespace.'
-      //              ''when' is not preceded with whitespace.'
+      // violation 2 lines below ''{' at column 9 should be on the previous line.'
       default ->
         {
         }
@@ -52,30 +61,38 @@ class InputWhitespaceAroundWhen {
   void test2(Object o) {
 
     switch (o) {
+      // violation 2 lines below ''{' at column 9 should be on the previous line.'
       case Integer i when (i == 0) ->
         {
         }
+      // violation 2 lines below ''{' at column 9 should be on the previous line.'
       case String s when (s.equals("a")) ->
         {
         }
+      // violation 2 lines below ''{' at column 9 should be on the previous line.'
       case Point(int x, int y) when (x >= 0 && y >= 0) ->
         {
         }
+      // violation 2 lines below ''{' at column 9 should be on the previous line.'
       default ->
         {
         }
     }
 
     switch (o) {
+      // violation 2 lines below ''{' at column 9 should be on the previous line.'
       case Integer i when i == 0 ->
         {
         }
+      // violation 2 lines below ''{' at column 9 should be on the previous line.'
       case String s when s.equals("a") ->
         {
         }
+      // violation 2 lines below ''{' at column 9 should be on the previous line.'
       case Point(int x, int y) when x >= 0 && y >= 0 ->
         {
         }
+      // violation 2 lines below ''{' at column 9 should be on the previous line.'
       default ->
         {
         }
@@ -107,6 +124,7 @@ class InputWhitespaceAroundWhen {
       case 'p' -> {
         System.out.println("o");
       }
+      // violation 2 lines below ''{' at column 9 should be on the previous line.'
       default ->
         {
           System.out.println("default");

--- a/src/it/resources/com/google/checkstyle/test/chapter4formatting/rule4841indentation/InputLineBreakAfterLeftCurlyOfBlockInSwitch.java
+++ b/src/it/resources/com/google/checkstyle/test/chapter4formatting/rule4841indentation/InputLineBreakAfterLeftCurlyOfBlockInSwitch.java
@@ -10,8 +10,10 @@ public class InputLineBreakAfterLeftCurlyOfBlockInSwitch {
             System.out.println("try");
             yield 1;
           }
-          case 2, 9, 10, 11, 12 -> { yield 2; } // false-negative, ok until #17565
-          case 3, 5, 4, 8 -> { yield month << 2; } // false-negative, ok until #17565
+          // violation below ''{' at column 36 should have line break after'
+          case 2, 9, 10, 11, 12 -> { yield 2; }
+          // violation below ''{' at column 30 should have line break after'
+          case 3, 5, 4, 8 -> { yield month << 2; }
           default -> 0;
         };
   }
@@ -21,7 +23,8 @@ public class InputLineBreakAfterLeftCurlyOfBlockInSwitch {
       case 0, 1 -> System.out.println("0");
       case 2 ->
           handleTwoWithAnExtremelyLongMethodCallThatWouldNotFitOnTheSameLine();
-      default -> { handleSurprisingNumber(number); } // false-negative, ok until #17565
+      // violation below ''{' at column 18 should have line break after'
+      default -> { handleSurprisingNumber(number); }
     }
   }
 

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/blocks/LeftCurlyCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/blocks/LeftCurlyCheck.java
@@ -123,6 +123,7 @@ public class LeftCurlyCheck
             TokenTypes.STATIC_INIT,
             TokenTypes.RECORD_DEF,
             TokenTypes.COMPACT_CTOR_DEF,
+            TokenTypes.SWITCH_RULE,
         };
     }
 
@@ -156,7 +157,8 @@ public class LeftCurlyCheck
             case TokenTypes.LITERAL_WHILE, TokenTypes.LITERAL_CATCH,
                  TokenTypes.LITERAL_SYNCHRONIZED, TokenTypes.LITERAL_FOR, TokenTypes.LITERAL_TRY,
                  TokenTypes.LITERAL_FINALLY, TokenTypes.LITERAL_DO,
-                 TokenTypes.LITERAL_IF, TokenTypes.STATIC_INIT, TokenTypes.LAMBDA -> {
+                 TokenTypes.LITERAL_IF, TokenTypes.STATIC_INIT, TokenTypes.LAMBDA,
+                 TokenTypes.SWITCH_RULE -> {
                 startToken = ast;
                 yield ast.findFirstToken(TokenTypes.SLIST);
             }
@@ -352,5 +354,4 @@ public class LeftCurlyCheck
                 || nextToken.getType() == TokenTypes.RCURLY
                 || !TokenUtil.areOnSameLine(leftCurly, nextToken);
     }
-
 }

--- a/src/main/resources/com/puppycrawl/tools/checkstyle/meta/checks/blocks/LeftCurlyCheck.xml
+++ b/src/main/resources/com/puppycrawl/tools/checkstyle/meta/checks/blocks/LeftCurlyCheck.xml
@@ -16,7 +16,7 @@
                       type="com.puppycrawl.tools.checkstyle.checks.blocks.LeftCurlyOption">
                <description>Specify the policy on placement of a left curly brace (&lt;code&gt;'{'&lt;/code&gt;).</description>
             </property>
-            <property default-value="ANNOTATION_DEF,CLASS_DEF,CTOR_DEF,ENUM_CONSTANT_DEF,ENUM_DEF,INTERFACE_DEF,LAMBDA,LITERAL_CASE,LITERAL_CATCH,LITERAL_DEFAULT,LITERAL_DO,LITERAL_ELSE,LITERAL_FINALLY,LITERAL_FOR,LITERAL_IF,LITERAL_SWITCH,LITERAL_SYNCHRONIZED,LITERAL_TRY,LITERAL_WHILE,METHOD_DEF,OBJBLOCK,STATIC_INIT,RECORD_DEF,COMPACT_CTOR_DEF"
+            <property default-value="ANNOTATION_DEF,CLASS_DEF,CTOR_DEF,ENUM_CONSTANT_DEF,ENUM_DEF,INTERFACE_DEF,LAMBDA,LITERAL_CASE,LITERAL_CATCH,LITERAL_DEFAULT,LITERAL_DO,LITERAL_ELSE,LITERAL_FINALLY,LITERAL_FOR,LITERAL_IF,LITERAL_SWITCH,LITERAL_SYNCHRONIZED,LITERAL_TRY,LITERAL_WHILE,METHOD_DEF,OBJBLOCK,STATIC_INIT,RECORD_DEF,COMPACT_CTOR_DEF,SWITCH_RULE"
                       name="tokens"
                       type="java.lang.String[]"
                       validation-type="tokenSet">

--- a/src/main/resources/google_checks.xml
+++ b/src/main/resources/google_checks.xml
@@ -102,7 +102,7 @@
                     INTERFACE_DEF, LAMBDA, LITERAL_CATCH,
                     LITERAL_DO, LITERAL_ELSE, LITERAL_FINALLY, LITERAL_FOR, LITERAL_IF,
                     LITERAL_SWITCH, LITERAL_SYNCHRONIZED, LITERAL_TRY, LITERAL_WHILE, METHOD_DEF,
-                    OBJBLOCK, STATIC_INIT, RECORD_DEF, COMPACT_CTOR_DEF"/>
+                    OBJBLOCK, STATIC_INIT, RECORD_DEF, COMPACT_CTOR_DEF, SWITCH_RULE"/>
     </module>
     <module name="LeftCurly">
       <property name="id" value="LeftCurlyNl"/>

--- a/src/site/xdoc/checks/blocks/leftcurly.xml
+++ b/src/site/xdoc/checks/blocks/leftcurly.xml
@@ -90,6 +90,8 @@
                     RECORD_DEF</a>
                 , <a href="../../apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#COMPACT_CTOR_DEF">
                     COMPACT_CTOR_DEF</a>
+                , <a href="../../apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#SWITCH_RULE">
+                    SWITCH_RULE</a>
                   .
               </td>
               <td>
@@ -141,6 +143,8 @@
                     RECORD_DEF</a>
                 , <a href="../../apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#COMPACT_CTOR_DEF">
                     COMPACT_CTOR_DEF</a>
+                , <a href="../../apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#SWITCH_RULE">
+                    SWITCH_RULE</a>
                   .
               </td>
               <td>3.0</td>

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/blocks/LeftCurlyCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/blocks/LeftCurlyCheckTest.java
@@ -410,6 +410,7 @@ public class LeftCurlyCheckTest extends AbstractModuleTestSupport {
             TokenTypes.STATIC_INIT,
             TokenTypes.RECORD_DEF,
             TokenTypes.COMPACT_CTOR_DEF,
+            TokenTypes.SWITCH_RULE,
         };
         assertWithMessage("Default acceptable tokens are invalid")
             .that(actual)
@@ -549,4 +550,36 @@ public class LeftCurlyCheckTest extends AbstractModuleTestSupport {
         verifyWithInlineConfigParser(
                 getPath("InputLeftCurlyCommentBeforeLeftCurly2.java"), expected);
     }
+
+    @Test
+    public void testSwitchRuleLineBreakAfter() throws Exception {
+        final String[] expected = {
+            "27:31: " + getCheckMessage(MSG_KEY_LINE_BREAK_AFTER, "{", 31),
+            "29:31: " + getCheckMessage(MSG_KEY_LINE_BREAK_AFTER, "{", 31),
+            "43:24: " + getCheckMessage(MSG_KEY_LINE_BREAK_AFTER, "{", 24),
+            "93:7: " + getCheckMessage(MSG_KEY_LINE_PREVIOUS, "{", 7),
+        };
+        verifyWithInlineConfigParser(
+                getPath("InputLeftCurlySwitchRuleLineBreakAfter.java"), expected);
+    }
+
+    @Test
+    public void testSwitchRuleWithBlock() throws Exception {
+        final String[] expected = {
+            "17:23: " + getCheckMessage(MSG_KEY_LINE_BREAK_AFTER, "{", 23),
+        };
+        verifyWithInlineConfigParser(
+                getPath("InputLeftCurlySwitchRuleWithBlock.java"), expected);
+    }
+
+    @Test
+    public void testSwitchMutation() throws Exception {
+        final String[] expected = {
+            "17:23: " + getCheckMessage(MSG_KEY_LINE_BREAK_AFTER, "{", 23),
+            "19:24: " + getCheckMessage(MSG_KEY_LINE_BREAK_AFTER, "{", 24),
+        };
+        verifyWithInlineConfigParser(
+                getPath("InputLeftCurlySwitchMutation.java"), expected);
+    }
+
 }

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/blocks/leftcurly/InputLeftCurlySwitchMutation.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/blocks/leftcurly/InputLeftCurlySwitchMutation.java
@@ -1,0 +1,23 @@
+/*
+LeftCurly
+option = (default)eol
+ignoreEnums = false
+tokens = SWITCH_RULE
+
+
+*/
+
+package com.puppycrawl.tools.checkstyle.checks.blocks.leftcurly;
+
+public class InputLeftCurlySwitchMutation {
+
+    void test(int x) {
+        int result = switch (x) {
+            // violation below ''{' at column 23 should have line break after'
+            case 1 -> { yield 1; }
+            // violation below ''{' at column 24 should have line break after'
+            default -> { yield 0; }
+        };
+    }
+
+}

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/blocks/leftcurly/InputLeftCurlySwitchRuleLineBreakAfter.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/blocks/leftcurly/InputLeftCurlySwitchRuleLineBreakAfter.java
@@ -1,0 +1,96 @@
+/*
+LeftCurly
+option = (default)eol
+ignoreEnums = false
+tokens = (default)ANNOTATION_DEF, CLASS_DEF, CTOR_DEF, ENUM_CONSTANT_DEF, \
+         ENUM_DEF, INTERFACE_DEF, LAMBDA, LITERAL_CASE, LITERAL_CATCH, \
+         LITERAL_DEFAULT, LITERAL_DO, LITERAL_ELSE, LITERAL_FINALLY, LITERAL_FOR, \
+         LITERAL_IF, LITERAL_SWITCH, LITERAL_SYNCHRONIZED, LITERAL_TRY, LITERAL_WHILE, \
+         METHOD_DEF, OBJBLOCK, STATIC_INIT, RECORD_DEF, COMPACT_CTOR_DEF, SWITCH_RULE
+
+
+*/
+
+package com.puppycrawl.tools.checkstyle.checks.blocks.leftcurly;
+
+/** Some javadoc. */
+public class InputLeftCurlySwitchRuleLineBreakAfter {
+
+    void testMethod1(int val) {
+        int result =
+                switch (val) {
+                    case 1, 6, 7 -> {
+                        System.out.println("try");
+                        yield val*2;
+                    }
+                    // violation below ''{' at column 31 should have line break after'
+                    case 2 -> { yield 2; }
+                    // violation below ''{' at column 31 should have line break after'
+                    case 3 -> { yield 4;
+                    }case 4 -> { // false negative
+                        yield 5;
+                    }
+                    default -> 0;
+                };
+    }
+
+    void testMethod2(int number) {
+        switch (number) {
+            case 0, 1 -> System.out.println("0");
+            case 2 ->
+                    handleTwoWithAnExtromelyLongMethodCallThatWouldNotFitOnTheSameLine();
+            // violation below ''{' at column 24 should have line break after'
+            default -> { handleSurprisingNumber(number); }
+        }
+    }
+
+    void testValidCases(int x) {
+        switch (x) {
+            case 1 -> {
+                System.out.println("one");
+            }
+            case 2 -> System.out.println("two");
+            case 3 -> { }
+            default -> {
+                System.out.println("default");
+            }
+        }
+    }
+
+    private void handleSurprisingNumber(int number) {
+        // do nothing
+    }
+
+    private int handleTwoWithAnExtromelyLongMethodCallThatWouldNotFitOnTheSameLine() {
+        return 0;
+    }
+
+    static {
+        int x = 1;
+    }
+
+    void testValidEolNoViolation(int x) {
+        switch (x) {
+            case 9 -> {
+                System.out.println("valid");
+            }
+        }
+    }
+
+    void testOldStyleSwitch(int x) {
+        switch (x) {
+            case 10: {
+                System.out.println("old style");
+            }
+            break;
+        }
+    }
+
+}
+
+enum TestEnumCoverage {
+    A
+      { // violation ''{' at column 7 should be on the previous line'
+        void method() { }
+      };
+}

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/blocks/leftcurly/InputLeftCurlySwitchRuleWithBlock.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/blocks/leftcurly/InputLeftCurlySwitchRuleWithBlock.java
@@ -1,0 +1,21 @@
+/*
+LeftCurly
+option = (default)eol
+ignoreEnums = false
+tokens = LITERAL_CASE, LITERAL_DEFAULT
+
+
+*/
+
+package com.puppycrawl.tools.checkstyle.checks.blocks.leftcurly;
+
+public class InputLeftCurlySwitchRuleWithBlock {
+
+    void test(int x) {
+        int result = switch (x) {
+            // violation below ''{' at column 23 should have line break after'
+            case 1 -> { yield 1; }
+            default -> 0;
+        };
+    }
+}


### PR DESCRIPTION
Issue #17565 

In this PR, I updated the LeftCurlyCheck logic and its corresponding tests to correctly validate line-break behavior 

Diff Regression config: https://gist.githubusercontent.com/MonuChaudhary14/0f6c4c3e4845e24ed9b75552b764f5d1/raw/0c26c30c16bdcf876e51ecdcab07b4c9b13b5fdf/google_checks.xml

Diff Regression patch config: https://gist.githubusercontent.com/MonuChaudhary14/db1380d15620df0e3fab53887651da22/raw/848c6ef0ac27539a0577f8f5b98e0c232208db95/patch_config.xml
