### PR TITLE
Issue #18023: Resolve Pitest Sup - filters - SupressionCommentFilter

### DIFF
--- a/config/pitest-suppressions/pitest-filters-suppressions.xml
+++ b/config/pitest-suppressions/pitest-filters-suppressions.xml
@@ -19,15 +19,6 @@
   </mutation>
 
   <mutation unstable="false">
-    <sourceFile>SuppressionCommentFilter.java</sourceFile>
-    <mutatedClass>com.puppycrawl.tools.checkstyle.filters.SuppressionCommentFilter$Tag</mutatedClass>
-    <mutatedMethod>toString</mutatedMethod>
-    <mutator>org.pitest.mutationtest.engine.gregor.mutators.NonVoidMethodCallMutator</mutator>
-    <description>removed call to java/lang/String::valueOf</description>
-    <lineContent>return &quot;Tag[text=&apos;&quot; + text + &apos;\&apos;&apos;</lineContent>
-  </mutation>
-
-  <mutation unstable="false">
     <sourceFile>XpathFilterElement.java</sourceFile>
     <mutatedClass>com.puppycrawl.tools.checkstyle.filters.XpathFilterElement</mutatedClass>
     <mutatedMethod>isXpathQueryMatching</mutatedMethod>

--- a/src/test/java/com/puppycrawl/tools/checkstyle/filters/SuppressionCommentFilterTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/filters/SuppressionCommentFilterTest.java
@@ -322,6 +322,18 @@ public class SuppressionCommentFilterTest
     }
 
     @Test
+    public void testToStringOfTagClassWithIdFormat() {
+        final SuppressionCommentFilter filter = new SuppressionCommentFilter();
+        filter.setIdFormat("id");
+        final Object tag =
+                getTagsAfterExecution(filter, "filename", "//CHECKSTYLE:OFF").get(0);
+        assertWithMessage("Invalid toString result")
+            .that(tag.toString())
+            .isEqualTo("Tag[text='CHECKSTYLE:OFF', line=1, column=0, type=OFF,"
+                    + " tagCheckRegexp=.*, tagMessageRegexp=null, tagIdRegexp=id]");
+    }
+
+    @Test
     public void testCompareToOfTagClass() {
         final List<Comparable<Object>> tags1 =
                 getTagsAfterExecutionOnDefaultFilter("//CHECKSTYLE:OFF", " //CHECKSTYLE:ON");


### PR DESCRIPTION

Issue #18023: Resolve Pitest Sup - filters - SupressionCommentFilter

a test case setting idFormat to "id" to ensure tagIdRegexp is non-null

shows "KILLED"
<img width="571" height="39" alt="image" src="https://github.com/user-attachments/assets/f8f2c69b-a29b-4fa9-a2e4-f801640df280" />
<img width="587" height="44" alt="image" src="https://github.com/user-attachments/assets/5ff2bdda-0d93-478c-8ee5-68d0b3212de5" />
 