### PR TITLE
Issue #17882 : Added tree example for JAVADOC_INLINE_TAG constant in JavadocCommentsTokenTypes

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/api/JavadocCommentsTokenTypes.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/api/JavadocCommentsTokenTypes.java
@@ -581,6 +581,11 @@ public final class JavadocCommentsTokenTypes {
 
     /**
      * General inline tag (e.g. {@code @link}).
+     *
+     * <p><b>Tree:</b></p>
+     * <pre>{@code
+     * `--JAVADOC_INLINE_TAG -> JAVADOC_INLINE_TAG
+     * }</pre>
      */
     public static final int JAVADOC_INLINE_TAG = JavadocCommentsLexer.JAVADOC_INLINE_TAG;
 


### PR DESCRIPTION
Issue: #17882

Added tree example for JAVADOC_INLINE_TAG constant in JavadocCommentsTokenTypes.java to match Checkstyle doc standards.