### PR TITLE
Issue #18435: Fix XdocsExamplesAstConsistencyTest(arraytrailingcomma …

### DIFF
--- a/src/site/xdoc/checks/coding/arraytrailingcomma.xml
+++ b/src/site/xdoc/checks/coding/arraytrailingcomma.xml
@@ -128,7 +128,7 @@ public class Example1 {
   double[][] decimals = {
     {0.5, 2.3, 1.1,},
     {1.7, 1.9, 0.6},
-    {0.8, 7.4, 6.5}  // violation 'Array should contain trailing comma.'
+    {0.8, 7.4, 6.5,}  // violation 'Array should contain trailing comma.'
   };
 
   char[] chars = {'a', 'b', 'c'
@@ -167,7 +167,7 @@ public class Example2 {
     true,
     true,
     false // violation 'Array should contain trailing comma.'
-  };
+    };
 
   String[][] text = {{},{},};
 
@@ -192,7 +192,7 @@ public class Example2 {
   int[] a2 = new int[]{
     1,
     2
-    ,};
+  ,};
 }
 </code></pre></div>
       </subsection>

--- a/src/test/java/com/puppycrawl/tools/checkstyle/internal/XdocsExamplesAstConsistencyTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/internal/XdocsExamplesAstConsistencyTest.java
@@ -97,7 +97,6 @@ public class XdocsExamplesAstConsistencyTest {
             "checks/blocks/rightcurly/Example3",
             "checks/blocks/rightcurly/Example4",
             "checks/blocks/rightcurly/Example5",
-            "checks/coding/arraytrailingcomma/Example2",
             "checks/coding/constructorsdeclarationgrouping/Example2",
             "checks/coding/covariantequals/Example2",
             "checks/coding/hiddenfield/Example7",

--- a/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/coding/arraytrailingcomma/Example1.java
+++ b/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/coding/arraytrailingcomma/Example1.java
@@ -22,7 +22,7 @@ public class Example1 {
   double[][] decimals = {
     {0.5, 2.3, 1.1,},
     {1.7, 1.9, 0.6},
-    {0.8, 7.4, 6.5}  // violation 'Array should contain trailing comma.'
+    {0.8, 7.4, 6.5,}  // violation 'Array should contain trailing comma.'
   };
 
   char[] chars = {'a', 'b', 'c'

--- a/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/coding/arraytrailingcomma/Example2.java
+++ b/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/coding/arraytrailingcomma/Example2.java
@@ -17,7 +17,7 @@ public class Example2 {
     true,
     true,
     false // violation 'Array should contain trailing comma.'
-  };
+    };
 
   String[][] text = {{},{},};
 
@@ -42,7 +42,7 @@ public class Example2 {
   int[] a2 = new int[]{
     1,
     2
-    ,};
+  ,};
 }
 // xdoc section -- end
 


### PR DESCRIPTION
Issue #18435 :
                   This PR removes `ArrayTrailingComma` Example 2 from the suppression list.

                  The example no longer violates the `ArrayTrailingComma` check, so the suppression is unnecessary.

compared at https://www.diffchecker.com/text-compare/ :
<img width="1773" height="1133" alt="image" src="https://github.com/user-attachments/assets/3ca6dc24-5924-41c6-bda5-5ef3183ec0b7" />

