### PR TITLE
Issue #6294: Kill Pitest mutation for IndexHandler registration

### DIFF
--- a/config/pitest-suppressions/pitest-indentation-suppressions.xml
+++ b/config/pitest-suppressions/pitest-indentation-suppressions.xml
@@ -75,15 +75,6 @@
   <mutation unstable="false">
     <sourceFile>HandlerFactory.java</sourceFile>
     <mutatedClass>com.puppycrawl.tools.checkstyle.checks.indentation.HandlerFactory</mutatedClass>
-    <mutatedMethod>&lt;init&gt;</mutatedMethod>
-    <mutator>org.pitest.mutationtest.engine.gregor.mutators.VoidMethodCallMutator</mutator>
-    <description>removed call to com/puppycrawl/tools/checkstyle/checks/indentation/HandlerFactory::register</description>
-    <lineContent>register(TokenTypes.INDEX_OP, IndexHandler.class);</lineContent>
-  </mutation>
-
-  <mutation unstable="false">
-    <sourceFile>HandlerFactory.java</sourceFile>
-    <mutatedClass>com.puppycrawl.tools.checkstyle.checks.indentation.HandlerFactory</mutatedClass>
     <mutatedMethod>clearCreatedHandlers</mutatedMethod>
     <mutator>org.pitest.mutationtest.engine.gregor.mutators.VoidMethodCallMutator</mutator>
     <description>removed call to java/util/Map::clear</description>

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/indentation/IndentationCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/indentation/IndentationCheckTest.java
@@ -4154,6 +4154,22 @@ public class IndentationCheckTest extends AbstractModuleTestSupport {
             .isNotNull();
     }
 
+    @Test
+    public void testIndexOpWithInvalidChildIndentation() throws Exception {
+        final DefaultConfiguration checkConfig = createModuleConfig(IndentationCheck.class);
+        checkConfig.addProperty("arrayInitIndent", "4");
+        checkConfig.addProperty("basicOffset", "4");
+        checkConfig.addProperty("braceAdjustment", "0");
+        checkConfig.addProperty("caseIndent", "4");
+        checkConfig.addProperty("forceStrictCondition", "false");
+        checkConfig.addProperty("lineWrappingIndentation", "4");
+        checkConfig.addProperty("tabWidth", "4");
+        checkConfig.addProperty("throwsIndent", "4");
+        final String fileName = getPath("InputIndentationInvalidArrayIndexIndent.java");
+        final String[] expected = CommonUtil.EMPTY_STRING_ARRAY;
+        verifyWarns(checkConfig, fileName, expected);
+    }
+
     private static final class IndentAudit implements AuditListener {
 
         private final IndentComment[] comments;

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/indentation/indentation/InputIndentationInvalidArrayIndexIndent.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/indentation/indentation/InputIndentationInvalidArrayIndexIndent.java
@@ -1,0 +1,23 @@
+package com.puppycrawl.tools.checkstyle.checks.indentation.indentation;    //indent:0 exp:0
+
+/**                                                                        //indent:0 exp:0
+ * This test-input is intended to be checked using following configuration //indent:1 exp:1
+ *                                                                         //indent:1 exp:1
+ * arrayInitIndent = 4                                                     //indent:1 exp:1
+ * basicOffset = 4                                                         //indent:1 exp:1
+ * braceAdjustment = 0                                                     //indent:1 exp:1
+ * caseIndent = 4                                                          //indent:1 exp:1
+ * forceStrictCondition = false                                            //indent:1 exp:1
+ * lineWrappingIndentation = 4                                             //indent:1 exp:1
+ * tabWidth = 4                                                            //indent:1 exp:1
+ * throwsIndent = 4                                                        //indent:1 exp:1
+ *                                                                         //indent:1 exp:1
+ */                                                                        //indent:1 exp:1
+public class InputIndentationInvalidArrayIndexIndent {                     //indent:0 exp:0
+    void test() {                                                          //indent:4 exp:4
+        int[] array = new int[10];                                         //indent:8 exp:8
+        array[                                                             //indent:8 exp:8
+          1                                                                //indent:10 exp:10
+        ] = 0;                                                             //indent:8 exp:8
+    }                                                                      //indent:4 exp:4
+}                                                                          //indent:0 exp:0


### PR DESCRIPTION
Issue #6294: Kill Pitest mutation for IndexHandler registration

The IndexHandler prevents IndentationCheck from descending into array index expressions. To verify this, a new test case was added with intentionally invalid indentation inside an array index.

*   **Behavior with IndexHandler (Current)**: The check stops at `INDEX_OP`, ignoring the invalid child indentation (Pass).
*   **Behavior without IndexHandler (Mutation)**: The check descends into the subtree, detects the invalid indentation, and fails .
