### PR TITLE
Issue #17882: Update CUSTOM_INLINE_TAG of JavadocCommentsTokenTypes to new AST format

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/api/JavadocCommentsTokenTypes.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/api/JavadocCommentsTokenTypes.java
@@ -920,7 +920,26 @@ public final class JavadocCommentsTokenTypes {
     public static final int SNIPPET_INLINE_TAG = JavadocCommentsLexer.SNIPPET_INLINE_TAG;
 
     /**
-     * Custom or unrecognized inline tag.
+     * {@code @custom} inline tag.
+     *
+     * <p><b>Example:</b></p>
+     * <pre>{@code * Example showing {@custom This is a Custom Inline Tag}.}</pre>
+     *
+     * <p><b>Tree:</b></p>
+     * <pre>{@code
+     * |--LEADING_ASTERISK ->      *
+     * |--TEXT ->  Example showing
+     * |--JAVADOC_INLINE_TAG -> JAVADOC_INLINE_TAG
+     * |   `--CUSTOM_INLINE_TAG -> CUSTOM_INLINE_TAG
+     * |       |--JAVADOC_INLINE_TAG_START -> { @
+     * |       |--TAG_NAME -> custom
+     * |       |--DESCRIPTION -> DESCRIPTION
+     * |       |   `--TEXT ->  This is a Custom Inline Tag
+     * |       `--JAVADOC_INLINE_TAG_END -> }
+     * |--TEXT -> .
+     * }</pre>
+     *
+     * @see #JAVADOC_INLINE_TAG
      */
     public static final int CUSTOM_INLINE_TAG = JavadocCommentsLexer.CUSTOM_INLINE_TAG;
 


### PR DESCRIPTION
Issue #17882

Input File: Test.java
```
package temp.temp1;

public class Test {
    /**
     * Example showing {@custom This is a Custom Inline Tag}.
     */

    public class example() {}
}
```

CLI Output:
```
PS D:\checkstyle> java -jar target/checkstyle-12.3.2-SNAPSHOT-all.jar -j src/Test.java | ForEach-Object { $_ -replace '\[[0-9]+:[0-9]+\]', '' }
JAVADOC_CONTENT -> JAVADOC_CONTENT 
|--TEXT -> package temp.temp1; 
|--NEWLINE -> \r\n 
|--NEWLINE -> \r\n 
|--TEXT -> public class Test { 
|--NEWLINE -> \r\n 
|--TEXT ->     /** 
|--NEWLINE -> \r\n 
|--LEADING_ASTERISK ->      * 
|--TEXT ->  Example showing  
|--JAVADOC_INLINE_TAG -> JAVADOC_INLINE_TAG 
|   `--CUSTOM_INLINE_TAG -> CUSTOM_INLINE_TAG 
|       |--JAVADOC_INLINE_TAG_START -> {@ 
|       |--TAG_NAME -> custom 
|       |--DESCRIPTION -> DESCRIPTION 
|       |   `--TEXT ->  This is a Custom Inline Tag 
|       `--JAVADOC_INLINE_TAG_END -> } 
|--TEXT -> . 
|--NEWLINE -> \r\n 
|--LEADING_ASTERISK ->      * 
|--TEXT -> / 
|--NEWLINE -> \r\n 
|--NEWLINE -> \r\n 
|--TEXT ->     public class example() {} 
|--NEWLINE -> \r\n 
`--TEXT -> } 

```