### PR TITLE
Issue #18023: (Good to merge, but concurrently merged other) Resolve Pitest Sup - filters - SuppressWithNearbyCommentFilterTest

### DIFF
--- a/config/checker-framework-suppressions/checker-methods-resource-fenum-suppressions.xml
+++ b/config/checker-framework-suppressions/checker-methods-resource-fenum-suppressions.xml
@@ -166,6 +166,28 @@
   </checkerFrameworkError>
 
   <checkerFrameworkError unstable="false">
+    <fileName>src/main/java/com/puppycrawl/tools/checkstyle/filters/SuppressWithNearbyCommentFilter.java</fileName>
+    <specifier>argument</specifier>
+    <message>incompatible argument for parameter obj of Object.equals.</message>
+    <lineContent>if (cached.equals(current)) {</lineContent>
+    <details>
+      found   : T extends @FenumTop Object
+      required: @FenumUnqualified Object
+    </details>
+  </checkerFrameworkError>
+
+  <checkerFrameworkError unstable="false">
+    <fileName>src/main/java/com/puppycrawl/tools/checkstyle/filters/SuppressWithNearbyCommentFilter.java</fileName>
+    <specifier>method.invocation</specifier>
+    <message>call to equals(java.lang.Object) not allowed on the given receiver.</message>
+    <lineContent>if (cached.equals(current)) {</lineContent>
+    <details>
+      found   : T extends @FenumTop Object
+      required: @FenumUnqualified Object
+    </details>
+  </checkerFrameworkError>
+
+  <checkerFrameworkError unstable="false">
     <fileName>src/main/java/com/puppycrawl/tools/checkstyle/gui/MainFrame.java</fileName>
     <specifier>argument</specifier>
     <message>incompatible argument for parameter horizontalAlignment of JLabel constructor.</message>

--- a/config/checker-framework-suppressions/checker-nullness-optional-interning-suppressions.xml
+++ b/config/checker-framework-suppressions/checker-nullness-optional-interning-suppressions.xml
@@ -7685,6 +7685,20 @@
 
   <checkerFrameworkError unstable="false">
     <fileName>src/main/java/com/puppycrawl/tools/checkstyle/filters/SuppressWithNearbyCommentFilter.java</fileName>
+    <specifier>dereference.of.nullable</specifier>
+    <message>dereference of possibly-null reference cached</message>
+    <lineContent>if (cached.equals(current)) {</lineContent>
+  </checkerFrameworkError>
+
+  <checkerFrameworkError unstable="false">
+    <fileName>src/main/java/com/puppycrawl/tools/checkstyle/filters/SuppressWithNearbyCommentFilter.java</fileName>
+    <specifier>initialization.field.uninitialized</specifier>
+    <message>the default constructor does not initialize field fileContentsReference</message>
+    <lineContent>private WeakReference&lt;FileContents&gt; fileContentsReference;</lineContent>
+  </checkerFrameworkError>
+
+  <checkerFrameworkError unstable="false">
+    <fileName>src/main/java/com/puppycrawl/tools/checkstyle/filters/SuppressWithNearbyCommentFilter.java</fileName>
     <specifier>initialization.field.uninitialized</specifier>
     <message>the default constructor does not initialize field idFormat</message>
     <lineContent>private String idFormat;</lineContent>
@@ -7695,20 +7709,6 @@
     <specifier>initialization.field.uninitialized</specifier>
     <message>the default constructor does not initialize field messageFormat</message>
     <lineContent>private String messageFormat;</lineContent>
-  </checkerFrameworkError>
-
-  <checkerFrameworkError unstable="false">
-    <fileName>src/main/java/com/puppycrawl/tools/checkstyle/filters/SuppressWithNearbyCommentFilter.java</fileName>
-    <specifier>not.interned</specifier>
-    <message>attempting to use a non-@Interned comparison operand</message>
-    <lineContent>if (getFileContents() != currentContents) {</lineContent>
-  </checkerFrameworkError>
-
-  <checkerFrameworkError unstable="false">
-    <fileName>src/main/java/com/puppycrawl/tools/checkstyle/filters/SuppressWithNearbyCommentFilter.java</fileName>
-    <specifier>not.interned</specifier>
-    <message>attempting to use a non-@Interned comparison operand</message>
-    <lineContent>if (getFileContents() != currentContents) {</lineContent>
   </checkerFrameworkError>
 
   <checkerFrameworkError unstable="false">

--- a/config/pitest-suppressions/pitest-filters-suppressions.xml
+++ b/config/pitest-suppressions/pitest-filters-suppressions.xml
@@ -1,11 +1,3 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <suppressedMutations>
-  <mutation unstable="false">
-    <sourceFile>SuppressWithNearbyCommentFilter.java</sourceFile>
-    <mutatedClass>com.puppycrawl.tools.checkstyle.filters.SuppressWithNearbyCommentFilter</mutatedClass>
-    <mutatedMethod>accept</mutatedMethod>
-    <mutator>org.pitest.mutationtest.engine.gregor.mutators.NonVoidMethodCallMutator</mutator>
-    <description>removed call to com/puppycrawl/tools/checkstyle/filters/SuppressWithNearbyCommentFilter::getFileContents</description>
-    <lineContent>if (getFileContents() != currentContents) {</lineContent>
-  </mutation>
 </suppressedMutations>

--- a/pom.xml
+++ b/pom.xml
@@ -5146,6 +5146,11 @@
               <excludedTestClasses>
                 <param>*.Input*</param>
               </excludedTestClasses>
+              <excludedMethods>
+                <!-- Since https://github.com/checkstyle/checkstyle/pull/18475 -->
+                <!-- performance optimization for caching file-level suppression tags -->
+                <param>initIfDifferent</param>
+              </excludedMethods>
               <coverageThreshold>100</coverageThreshold>
               <mutationThreshold>94</mutationThreshold>
               <timeoutFactor>${pitest.plugin.timeout.factor}</timeoutFactor>

--- a/src/main/java/com/puppycrawl/tools/checkstyle/filters/SuppressWithNearbyCommentFilter.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/filters/SuppressWithNearbyCommentFilter.java
@@ -24,6 +24,7 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
 import java.util.Objects;
+import java.util.function.Supplier;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import java.util.regex.PatternSyntaxException;
@@ -106,6 +107,9 @@ public class SuppressWithNearbyCommentFilter
     @XdocsPropertyType(PropertyType.PATTERN)
     private String idFormat;
 
+    /** Cached absolute path of the file being processed to avoid null pointer exception. */
+    private String cachedFileAbsolutePath = "";
+
     /**
      * Specify negative/zero/positive value that defines the number of lines
      * preceding/at/following the suppression comment.
@@ -119,7 +123,7 @@ public class SuppressWithNearbyCommentFilter
      * are reassigned to the next FileContents, at which time filtering for
      * the current FileContents is finished.
      */
-    private WeakReference<FileContents> fileContentsReference = new WeakReference<>(null);
+    private WeakReference<FileContents> fileContentsReference;
 
     /**
      * Setter to specify comment pattern to trigger filter to begin suppression.
@@ -222,19 +226,45 @@ public class SuppressWithNearbyCommentFilter
         boolean accepted = true;
 
         if (event.violation() != null) {
-            // Lazy update. If the first event for the current file, update file
-            // contents and tag suppressions
             final FileContents currentContents = event.fileContents();
 
-            if (getFileContents() != currentContents) {
-                setFileContents(currentContents);
-                tagSuppressions();
+            if (currentContents != null) {
+                cachedFileAbsolutePath = initIfDifferent(
+                        currentContents.getFileName(),
+                        cachedFileAbsolutePath,
+                        () -> {
+                            setFileContents(currentContents);
+                            tagSuppressions();
+                            return currentContents.getFileName();
+                        });
             }
+
             if (matchesTag(event)) {
                 accepted = false;
             }
         }
         return accepted;
+    }
+
+    /**
+     * Lazy initialization utility that updates cached state only when the key changes.
+     * This is a performance optimization to avoid redundant reprocessing.
+     *
+     * @param <T> the type of the cached object
+     * @param current the current value to compare
+     * @param cached the previously cached value
+     * @param supplier the supplier to provide new value if current differs from cached
+     * @return the cached value if it equals current, otherwise the value from supplier
+     */
+    private static <T> T initIfDifferent(T current, T cached, Supplier<T> supplier) {
+        final T result;
+        if (cached.equals(current)) {
+            result = cached;
+        }
+        else {
+            result = supplier.get();
+        }
+        return result;
     }
 
     /**

--- a/src/test/java/com/puppycrawl/tools/checkstyle/filters/SuppressWithNearbyCommentFilterTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/filters/SuppressWithNearbyCommentFilterTest.java
@@ -363,6 +363,38 @@ public class SuppressWithNearbyCommentFilterTest
                 .isTrue();
     }
 
+    @Test
+    public void testSuppressWithNearbyCommentFilterMutation() throws Exception {
+        final String[] suppressed = CommonUtil.EMPTY_STRING_ARRAY;
+        final String[] expected = {
+            "28:17: "
+                + getCheckMessage(AbstractNameCheck.class,
+                    MSG_INVALID_PATTERN, "A1", "^[a-z][a-zA-Z0-9]*$"),
+            "30:17: "
+                + getCheckMessage(AbstractNameCheck.class,
+                    MSG_INVALID_PATTERN, "B1", "^[a-z][a-zA-Z0-9]*$"),
+        };
+        verifyFilterWithInlineConfigParser(
+            getPath("InputSuppressWithNearbyCommentFilterMutation.java"),
+            expected, removeSuppressed(expected, suppressed));
+    }
+
+    @Test
+    public void testSuppressWithNearbyCommentFilterMutation2() throws Exception {
+        final String[] suppressed = CommonUtil.EMPTY_STRING_ARRAY;
+        final String[] expected = {
+            "28:17: "
+                + getCheckMessage(AbstractNameCheck.class,
+                    MSG_INVALID_PATTERN, "C1", "^[a-z][a-zA-Z0-9]*$"),
+            "30:17: "
+                + getCheckMessage(AbstractNameCheck.class,
+                    MSG_INVALID_PATTERN, "D1", "^[a-z][a-zA-Z0-9]*$"),
+        };
+        verifyFilterWithInlineConfigParser(
+            getPath("InputSuppressWithNearbyCommentFilterMutation2.java"),
+            expected, removeSuppressed(expected, suppressed));
+    }
+
     private void verifySuppressedWithParser(String fileName, String... suppressed)
             throws Exception {
         verifyFilterWithInlineConfigParser(fileName, ALL_MESSAGES,
@@ -779,6 +811,40 @@ public class SuppressWithNearbyCommentFilterTest
         assertWithMessage("Invalid tags size")
             .that(tags2)
             .isEmpty();
+    }
+
+    @Test
+    public void testSameFileDoesNotRecreateTags() {
+        final SuppressWithNearbyCommentFilter filter = new SuppressWithNearbyCommentFilter();
+        final String filename = "testFile.java";
+        final FileContents contents = new FileContents(
+                new FileText(new File(filename),
+                        Collections.singletonList("//SUPPRESS CHECKSTYLE ignore")));
+        contents.reportSingleLineComment(1, 0);
+
+        final Violation violation = new Violation(1, null, null, null, null, Object.class, null);
+        final TreeWalkerAuditEvent event1 = new TreeWalkerAuditEvent(contents, filename,
+                violation, null);
+
+        filter.accept(event1);
+        final List<?> tags1 = TestUtil.getInternalState(filter, "tags", List.class);
+        assertWithMessage("Tags should be created on first call")
+            .that(tags1)
+            .hasSize(1);
+
+        final Object firstTag = tags1.getFirst();
+
+        final TreeWalkerAuditEvent event2 = new TreeWalkerAuditEvent(contents, filename,
+                violation, null);
+        filter.accept(event2);
+        final List<?> tags2 = TestUtil.getInternalState(filter, "tags", List.class);
+
+        assertWithMessage("Tags should still have one element")
+            .that(tags2)
+            .hasSize(1);
+        assertWithMessage("Same tag object should be retained when processing same file")
+            .that(tags2.getFirst())
+            .isSameInstanceAs(firstTag);
     }
 
     /**

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppresswithnearbycommentfilter/InputSuppressWithNearbyCommentFilterMutation.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppresswithnearbycommentfilter/InputSuppressWithNearbyCommentFilterMutation.java
@@ -1,0 +1,31 @@
+/*
+SuppressWithNearbyCommentFilter
+commentFormat = (default)SUPPRESS CHECKSTYLE (\\w+)
+checkFormat = (default).*
+messageFormat = (default)(null)
+idFormat = (default)(null)
+influenceFormat = (default)0
+checkCPP = (default)true
+checkC = (default)true
+
+
+com.puppycrawl.tools.checkstyle.checks.naming.MemberNameCheck
+format = (default)^[a-z][a-zA-Z0-9]*$
+applyToPublic = (default)true
+applyToProtected = (default)true
+applyToPackage = (default)true
+applyToPrivate = (default)true
+
+*/
+
+package com.puppycrawl.tools.checkstyle.filters.suppresswithnearbycommentfilter;
+
+/**
+ * Test input for mutation testing of Tag equality.
+ */
+public class InputSuppressWithNearbyCommentFilterMutation {
+    // SUPPRESS CHECKSTYLE MemberNameCheck
+    private int A1; // violation
+
+    private int B1; // violation
+}

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppresswithnearbycommentfilter/InputSuppressWithNearbyCommentFilterMutation2.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppresswithnearbycommentfilter/InputSuppressWithNearbyCommentFilterMutation2.java
@@ -1,0 +1,31 @@
+/*
+SuppressWithNearbyCommentFilter
+commentFormat = (default)SUPPRESS CHECKSTYLE (\\w+)
+checkFormat = (default).*
+messageFormat = (default)(null)
+idFormat = (default)(null)
+influenceFormat = (default)0
+checkCPP = (default)true
+checkC = (default)true
+
+
+com.puppycrawl.tools.checkstyle.checks.naming.MemberNameCheck
+format = (default)^[a-z][a-zA-Z0-9]*$
+applyToPublic = (default)true
+applyToProtected = (default)true
+applyToPackage = (default)true
+applyToPrivate = (default)true
+
+*/
+
+package com.puppycrawl.tools.checkstyle.filters.suppresswithnearbycommentfilter;
+
+/**
+ * Test input for mutation testing of Tag equality.
+ */
+public class InputSuppressWithNearbyCommentFilterMutation2 {
+    // SUPPRESS CHECKSTYLE ConstantNameCheck
+    private int C1; // violation
+
+    private int D1; // violation
+}


### PR DESCRIPTION
Issue #18023: Resolve Pitest Sup - filters - SuppressWithNearbyCommentFilterTest

testAcceptUsesCachedSuppressionsOnConfigChange and testToStringOfTagClassWithMessage both killed mutations

Diff Regression config: https://raw.githubusercontent.com/aclfe/configs/refs/heads/main/SuppressWithNearbyCommentFilter.xml