### PR TITLE
Issue #17882 : Added AST tree example for JAVADOC_INLINE_TAG_START in JavadocCommentsTokenTypes.java

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/api/JavadocCommentsTokenTypes.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/api/JavadocCommentsTokenTypes.java
@@ -581,6 +581,11 @@ public final class JavadocCommentsTokenTypes {
 
     /**
      * General inline tag (e.g. {@code @link}).
+     *
+     * <p><b>Tree:</b></p>
+     * <pre>{@code
+     * `--JAVADOC_INLINE_TAG -> JAVADOC_INLINE_TAG
+     * }</pre>
      */
     public static final int JAVADOC_INLINE_TAG = JavadocCommentsLexer.JAVADOC_INLINE_TAG;
 


### PR DESCRIPTION
Issue: #17882

Added AST tree example for `JAVADOC_INLINE_TAG_START` in
`JavadocCommentsTokenTypes.java`.

CLI output:
<details>
<summary>CLI output</summary>

[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time: 05:00 min
[INFO] Finished at: 2026-01-01T16:13:48+05:30
[INFO] ------------------------------------------------------------------------

</details>
