### PR TITLE
Issue #17988: error-prone violation ModuleReflectionUtilTest

### DIFF
--- a/src/test/java/com/puppycrawl/tools/checkstyle/utils/ModuleReflectionUtilTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/utils/ModuleReflectionUtilTest.java
@@ -223,7 +223,7 @@ public class ModuleReflectionUtilTest {
      */
     private abstract static class AbstractInvalidClass extends AbstractAutomaticBean {
 
-        public abstract void method();
+        abstract void method();
 
     }
 


### PR DESCRIPTION
Issue #17988: error-prone violation ModuleReflectionUtilTest

Ran `./mvnw -e --no-transfer-progress clean test-compile -Perror-prone-test-compile` as mentioned in #17988 and saw this warning:

```
[WARNING] /home/kairav/Desktop/checkstyle/checkstyle/src/test/java/com/puppycrawl/tools/checkstyle/utils/ModuleReflectionUtilTest.java:[226,30] [EffectivelyPrivate] This declaration has public or protected modifiers, but is effectively private.
    (see https://errorprone.info/bugpattern/EffectivelyPrivate)
  Did you mean 'abstract void method();'?
```

Fix: Just removing private as the error said