### PR TITLE
Issue #17988: error-prone violation ModuleReflectionUtilTest

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -245,6 +245,7 @@
       -Xep:ConstantNaming:ERROR
       -Xep:DefaultCharset:ERROR
       -Xep:DirectReturn:ERROR
+      -Xep:EffectivelyPrivate:ERROR
       -Xep:EmptyMethod:ERROR
       -Xep:EnumOrdinal:ERROR
       -Xep:ExplicitArgumentEnumeration:ERROR
@@ -279,7 +280,6 @@
       -Xep:JdkObsolete:WARN
       -Xep:StatementSwitchToExpressionSwitch:WARN
       -Xep:StringSplitter:WARN
-      -Xep:EffectivelyPrivate:WARN
       <!-- Reason at https://github.com/checkstyle/checkstyle/issues/8252. -->
       -Xep:JUnitClassModifiers:OFF
       <!-- Reason at https://github.com/checkstyle/checkstyle/issues/8252. -->

--- a/src/main/java/com/puppycrawl/tools/checkstyle/JavadocCommentsAstVisitor.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/JavadocCommentsAstVisitor.java
@@ -742,7 +742,7 @@ public class JavadocCommentsAstVisitor extends JavadocCommentsParserBaseVisitor<
          *
          * @param token the token to accumulate
          */
-        public void append(Token token) {
+        /* package */ void append(Token token) {
             if (buffer.isEmpty()) {
                 startToken = token;
             }
@@ -755,7 +755,7 @@ public class JavadocCommentsAstVisitor extends JavadocCommentsParserBaseVisitor<
          *
          * @param parent the parent node to add the new node to
          */
-        public void flushTo(JavadocNodeImpl parent) {
+        /* package */ void flushTo(JavadocNodeImpl parent) {
             if (!buffer.isEmpty()) {
                 final JavadocNodeImpl startNode = create(startToken);
                 startNode.setText(buffer.toString());

--- a/src/main/java/com/puppycrawl/tools/checkstyle/JavadocDetailNodeParser.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/JavadocDetailNodeParser.java
@@ -170,7 +170,7 @@ public class JavadocDetailNodeParser {
          * @param offset
          *        offset line number
          */
-        public void setOffset(int offset) {
+        /* package */ void setOffset(int offset) {
             this.offset = offset;
         }
 

--- a/src/main/java/com/puppycrawl/tools/checkstyle/XMLLogger.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/XMLLogger.java
@@ -362,7 +362,7 @@ public final class XMLLogger
          *
          * @return the file error events.
          */
-        public List<AuditEvent> getErrors() {
+        /* package */ List<AuditEvent> getErrors() {
             return Collections.unmodifiableList(errors);
         }
 
@@ -371,7 +371,7 @@ public final class XMLLogger
          *
          * @param event the error event.
          */
-        public void addError(AuditEvent event) {
+        /* package */ void addError(AuditEvent event) {
             errors.add(event);
         }
 
@@ -380,7 +380,7 @@ public final class XMLLogger
          *
          * @return the file exceptions.
          */
-        public List<Throwable> getExceptions() {
+        /* package */ List<Throwable> getExceptions() {
             return Collections.unmodifiableList(exceptions);
         }
 
@@ -389,7 +389,7 @@ public final class XMLLogger
          *
          * @param throwable the file exception
          */
-        public void addException(Throwable throwable) {
+        /* package */ void addException(Throwable throwable) {
             exceptions.add(throwable);
         }
 

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/TranslationCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/TranslationCheck.java
@@ -567,7 +567,7 @@ public final class TranslationCheck extends AbstractFileSetCheck {
          *
          * @return the bundle base name
          */
-        public String getBaseName() {
+        /* package */ String getBaseName() {
             return baseName;
         }
 
@@ -576,7 +576,7 @@ public final class TranslationCheck extends AbstractFileSetCheck {
          *
          * @return the common path of files
          */
-        public String getPath() {
+        /* package */ String getPath() {
             return path;
         }
 
@@ -585,7 +585,7 @@ public final class TranslationCheck extends AbstractFileSetCheck {
          *
          * @return the common extension of files
          */
-        public String getExtension() {
+        /* package */ String getExtension() {
             return extension;
         }
 
@@ -594,7 +594,7 @@ public final class TranslationCheck extends AbstractFileSetCheck {
          *
          * @return the set of files
          */
-        public Set<File> getFiles() {
+        /* package */ Set<File> getFiles() {
             return Collections.unmodifiableSet(files);
         }
 
@@ -603,7 +603,7 @@ public final class TranslationCheck extends AbstractFileSetCheck {
          *
          * @param file file which should be added into resource bundle.
          */
-        public void addFile(File file) {
+        /* package */ void addFile(File file) {
             files.add(file);
         }
 
@@ -613,7 +613,7 @@ public final class TranslationCheck extends AbstractFileSetCheck {
          * @param fileNameRegexp file name regexp.
          * @return true if a resource bundle contains a file which name matches file name regexp.
          */
-        public boolean containsFile(String fileNameRegexp) {
+        /* package */ boolean containsFile(String fileNameRegexp) {
             boolean containsFile = false;
             for (File currentFile : files) {
                 if (Pattern.matches(fileNameRegexp, currentFile.getName())) {

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/UniquePropertiesCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/UniquePropertiesCheck.java
@@ -185,7 +185,7 @@ public class UniquePropertiesCheck extends AbstractFileSetCheck {
          *
          * @return A collection of duplicated keys.
          */
-        public Map<String, Integer> getDuplicatedKeys() {
+        /* package */ Map<String, Integer> getDuplicatedKeys() {
             return new HashMap<>(duplicatedKeys);
         }
 

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/AbstractSuperCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/AbstractSuperCheck.java
@@ -219,7 +219,7 @@ public abstract class AbstractSuperCheck
         /**
          * Records that the overriding method has a call to the super method.
          */
-        public void setCallingSuper() {
+        /* package */ void setCallingSuper() {
             callingSuper = true;
         }
 
@@ -229,7 +229,7 @@ public abstract class AbstractSuperCheck
          *
          * @return true if the overriding method has a call to the super method.
          */
-        public boolean isCallingSuper() {
+        /* package */ boolean isCallingSuper() {
             return callingSuper;
         }
 
@@ -238,7 +238,7 @@ public abstract class AbstractSuperCheck
          *
          * @return the overriding method definition AST.
          */
-        public DetailAST getMethod() {
+        /* package */ DetailAST getMethod() {
             return method;
         }
 

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/EqualsAvoidNullCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/EqualsAvoidNullCheck.java
@@ -526,7 +526,7 @@ public class EqualsAvoidNullCheck extends AbstractCheck {
          *
          * @param frameName value to set.
          */
-        public void setFrameName(String frameName) {
+        /* package */ void setFrameName(String frameName) {
             this.frameName = frameName;
         }
 
@@ -535,7 +535,7 @@ public class EqualsAvoidNullCheck extends AbstractCheck {
          *
          * @return frame name.
          */
-        public String getFrameName() {
+        /* package */ String getFrameName() {
             return frameName;
         }
 
@@ -544,7 +544,7 @@ public class EqualsAvoidNullCheck extends AbstractCheck {
          *
          * @return parent frame.
          */
-        public FieldFrame getParent() {
+        /* package */ FieldFrame getParent() {
             return parent;
         }
 
@@ -553,7 +553,7 @@ public class EqualsAvoidNullCheck extends AbstractCheck {
          *
          * @return children of this frame.
          */
-        public Set<FieldFrame> getChildren() {
+        /* package */ Set<FieldFrame> getChildren() {
             return Collections.unmodifiableSet(children);
         }
 
@@ -562,7 +562,7 @@ public class EqualsAvoidNullCheck extends AbstractCheck {
          *
          * @param child frame to add.
          */
-        public void addChild(FieldFrame child) {
+        /* package */ void addChild(FieldFrame child) {
             children.add(child);
         }
 
@@ -571,7 +571,7 @@ public class EqualsAvoidNullCheck extends AbstractCheck {
          *
          * @param field the ast of the field.
          */
-        public void addField(DetailAST field) {
+        /* package */ void addField(DetailAST field) {
             if (field.findFirstToken(TokenTypes.IDENT) != null) {
                 fieldNameToAst.put(getFieldName(field), field);
             }
@@ -582,7 +582,7 @@ public class EqualsAvoidNullCheck extends AbstractCheck {
          *
          * @param value value to set.
          */
-        public void setClassOrEnumOrRecordDef(boolean value) {
+        /* package */ void setClassOrEnumOrRecordDef(boolean value) {
             classOrEnumOrRecordDef = value;
         }
 
@@ -591,7 +591,7 @@ public class EqualsAvoidNullCheck extends AbstractCheck {
          *
          * @return classOrEnumOrRecordDef.
          */
-        public boolean isClassOrEnumOrRecordDef() {
+        /* package */ boolean isClassOrEnumOrRecordDef() {
             return classOrEnumOrRecordDef;
         }
 
@@ -600,7 +600,7 @@ public class EqualsAvoidNullCheck extends AbstractCheck {
          *
          * @param methodCall METHOD_CALL ast.
          */
-        public void addMethodCall(DetailAST methodCall) {
+        /* package */ void addMethodCall(DetailAST methodCall) {
             methodCalls.add(methodCall);
         }
 
@@ -610,7 +610,7 @@ public class EqualsAvoidNullCheck extends AbstractCheck {
          * @param name name of the field to check.
          * @return DetailAST if this FieldFrame contains instance field.
          */
-        public DetailAST findField(String name) {
+        /* package */ DetailAST findField(String name) {
             return fieldNameToAst.get(name);
         }
 
@@ -619,7 +619,7 @@ public class EqualsAvoidNullCheck extends AbstractCheck {
          *
          * @return method calls of this frame.
          */
-        public Set<DetailAST> getMethodCalls() {
+        /* package */ Set<DetailAST> getMethodCalls() {
             return Collections.unmodifiableSet(methodCalls);
         }
 

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/FinalLocalVariableCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/FinalLocalVariableCheck.java
@@ -729,7 +729,8 @@ public class FinalLocalVariableCheck extends AbstractCheck {
          * @param ast ast.
          * @return Optional of {@link FinalVariableCandidate}.
          */
-        public Optional<FinalVariableCandidate> findFinalVariableCandidateForAst(DetailAST ast) {
+        /* package */ Optional<FinalVariableCandidate>
+            findFinalVariableCandidateForAst(DetailAST ast) {
             Optional<FinalVariableCandidate> result = Optional.empty();
             DetailAST storedVariable = null;
             final Optional<FinalVariableCandidate> candidate =

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/HiddenFieldCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/HiddenFieldCheck.java
@@ -575,7 +575,7 @@ public class HiddenFieldCheck
          *
          * @param field  the name of the instance field.
          */
-        public void addInstanceField(String field) {
+        /* package */ void addInstanceField(String field) {
             instanceFields.add(field);
         }
 
@@ -584,7 +584,7 @@ public class HiddenFieldCheck
          *
          * @param field  the name of the instance field.
          */
-        public void addStaticField(String field) {
+        /* package */ void addStaticField(String field) {
             staticFields.add(field);
         }
 
@@ -594,7 +594,7 @@ public class HiddenFieldCheck
          * @param field the field to check
          * @return true if this FieldFrame contains instance field
          */
-        public boolean containsInstanceField(String field) {
+        /* package */ boolean containsInstanceField(String field) {
             FieldFrame currentParent = parent;
             boolean contains = instanceFields.contains(field);
             boolean isStaticType = staticType;
@@ -612,7 +612,7 @@ public class HiddenFieldCheck
          * @param field the field to check
          * @return true if this FieldFrame contains static field
          */
-        public boolean containsStaticField(String field) {
+        /* package */ boolean containsStaticField(String field) {
             FieldFrame currentParent = parent;
             boolean contains = staticFields.contains(field);
             while (currentParent != null && !contains) {
@@ -627,7 +627,7 @@ public class HiddenFieldCheck
          *
          * @return parent frame.
          */
-        public FieldFrame getParent() {
+        /* package */ FieldFrame getParent() {
             return parent;
         }
 

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/RequireThisCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/RequireThisCheck.java
@@ -1090,7 +1090,7 @@ public class RequireThisCheck extends AbstractCheck {
          * @param parent parent frame.
          * @param ident frame name ident.
          */
-        protected AbstractFrame(AbstractFrame parent, DetailAST ident) {
+        /* package */ AbstractFrame(AbstractFrame parent, DetailAST ident) {
             this.parent = parent;
             frameNameIdent = ident;
             varIdents = new HashSet<>();
@@ -1101,7 +1101,7 @@ public class RequireThisCheck extends AbstractCheck {
          *
          * @return a FrameType.
          */
-        protected abstract FrameType getType();
+        /* package */ abstract FrameType getType();
 
         /**
          * Add a name to the frame.
@@ -1117,7 +1117,7 @@ public class RequireThisCheck extends AbstractCheck {
          *
          * @return the parent frame
          */
-        protected AbstractFrame getParent() {
+        /* package */ AbstractFrame getParent() {
             return parent;
         }
 
@@ -1126,7 +1126,7 @@ public class RequireThisCheck extends AbstractCheck {
          *
          * @return the name identifier text
          */
-        protected String getFrameName() {
+        /* package */ String getFrameName() {
             return frameNameIdent.getText();
         }
 
@@ -1135,7 +1135,7 @@ public class RequireThisCheck extends AbstractCheck {
          *
          * @return the name identifier token
          */
-        public DetailAST getFrameNameIdent() {
+        /* package */ DetailAST getFrameNameIdent() {
             return frameNameIdent;
         }
 
@@ -1145,7 +1145,7 @@ public class RequireThisCheck extends AbstractCheck {
          * @param identToFind the IDENT ast of the name we're looking for.
          * @return whether it was found.
          */
-        protected boolean containsFieldOrVariable(DetailAST identToFind) {
+        /* package */ boolean containsFieldOrVariable(DetailAST identToFind) {
             return containsFieldOrVariableDef(varIdents, identToFind);
         }
 
@@ -1156,7 +1156,7 @@ public class RequireThisCheck extends AbstractCheck {
          * @param lookForMethod whether we are looking for a method name.
          * @return whether it was found.
          */
-        protected AbstractFrame getIfContains(DetailAST identToFind, boolean lookForMethod) {
+        /* package */ AbstractFrame getIfContains(DetailAST identToFind, boolean lookForMethod) {
             final AbstractFrame frame;
 
             if (!lookForMethod
@@ -1178,7 +1178,7 @@ public class RequireThisCheck extends AbstractCheck {
          * @return true if the set contains a declaration with the text of the specified
          *         IDENT ast and it is declared in a proper position.
          */
-        protected boolean containsFieldOrVariableDef(Set<DetailAST> set, DetailAST ident) {
+        /* package */ boolean containsFieldOrVariableDef(Set<DetailAST> set, DetailAST ident) {
             boolean result = false;
             for (DetailAST ast: set) {
                 if (isProperDefinition(ident, ast)) {
@@ -1196,7 +1196,7 @@ public class RequireThisCheck extends AbstractCheck {
          * @param ast the IDENT ast of the definition to check.
          * @return true if ast is correspondent to ident.
          */
-        protected boolean isProperDefinition(DetailAST ident, DetailAST ast) {
+        /* package */ boolean isProperDefinition(DetailAST ident, DetailAST ast) {
             final String identToFind = ident.getText();
             return identToFind.equals(ast.getText())
                 && CheckUtil.isBeforeInSource(ast, ident);
@@ -1214,7 +1214,7 @@ public class RequireThisCheck extends AbstractCheck {
          * @param parent parent frame.
          * @param ident method name identifier token.
          */
-        protected MethodFrame(AbstractFrame parent, DetailAST ident) {
+        /* package */ MethodFrame(AbstractFrame parent, DetailAST ident) {
             super(parent, ident);
         }
 
@@ -1236,7 +1236,7 @@ public class RequireThisCheck extends AbstractCheck {
          * @param parent parent frame.
          * @param ident frame name ident.
          */
-        protected ConstructorFrame(AbstractFrame parent, DetailAST ident) {
+        /* package */ ConstructorFrame(AbstractFrame parent, DetailAST ident) {
             super(parent, ident);
         }
 
@@ -1285,7 +1285,7 @@ public class RequireThisCheck extends AbstractCheck {
          *
          * @param ident an ident of static member of the class.
          */
-        public void addStaticMember(final DetailAST ident) {
+        /* package */ void addStaticMember(final DetailAST ident) {
             staticMembers.add(ident);
         }
 
@@ -1294,7 +1294,7 @@ public class RequireThisCheck extends AbstractCheck {
          *
          * @param ident an ident of static method of the class.
          */
-        public void addStaticMethod(final DetailAST ident) {
+        /* package */ void addStaticMethod(final DetailAST ident) {
             staticMethods.add(ident);
         }
 
@@ -1303,7 +1303,7 @@ public class RequireThisCheck extends AbstractCheck {
          *
          * @param ident an ident of instance member of the class.
          */
-        public void addInstanceMember(final DetailAST ident) {
+        /* package */ void addInstanceMember(final DetailAST ident) {
             instanceMembers.add(ident);
         }
 
@@ -1312,7 +1312,7 @@ public class RequireThisCheck extends AbstractCheck {
          *
          * @param ident an ident of instance method of the class.
          */
-        public void addInstanceMethod(final DetailAST ident) {
+        /* package */ void addInstanceMethod(final DetailAST ident) {
             instanceMethods.add(ident);
         }
 
@@ -1323,7 +1323,7 @@ public class RequireThisCheck extends AbstractCheck {
          * @return true is the given name is a name of a known
          *         instance member of the class.
          */
-        public boolean hasInstanceMember(final DetailAST ident) {
+        /* package */ boolean hasInstanceMember(final DetailAST ident) {
             return containsFieldOrVariableDef(instanceMembers, ident);
         }
 
@@ -1334,7 +1334,7 @@ public class RequireThisCheck extends AbstractCheck {
          * @return true if the given ast is correspondent to a known
          *         instance method of the class.
          */
-        public boolean hasInstanceMethod(final DetailAST ident) {
+        /* package */ boolean hasInstanceMethod(final DetailAST ident) {
             return containsMethodDef(instanceMethods, ident);
         }
 
@@ -1345,7 +1345,7 @@ public class RequireThisCheck extends AbstractCheck {
          * @return true is the given ast is correspondent to a known
          *         instance method of the class.
          */
-        public boolean hasStaticMethod(final DetailAST ident) {
+        /* package */ boolean hasStaticMethod(final DetailAST ident) {
             return containsMethodDef(staticMethods, ident);
         }
 
@@ -1355,7 +1355,7 @@ public class RequireThisCheck extends AbstractCheck {
          * @param instanceMember an instance member of a class.
          * @return true if given instance member has final modifier.
          */
-        public boolean hasFinalField(final DetailAST instanceMember) {
+        /* package */ boolean hasFinalField(final DetailAST instanceMember) {
             boolean result = false;
             for (DetailAST member : instanceMembers) {
                 final DetailAST parent = member.getParent();
@@ -1466,7 +1466,7 @@ public class RequireThisCheck extends AbstractCheck {
          * @param parent parent frame.
          * @param frameName name of the frame.
          */
-        protected AnonymousClassFrame(AbstractFrame parent, String frameName) {
+        /* package */ AnonymousClassFrame(AbstractFrame parent, String frameName) {
             super(parent, null);
             this.frameName = frameName;
         }
@@ -1489,7 +1489,7 @@ public class RequireThisCheck extends AbstractCheck {
          * @param parent parent frame.
          * @param ident ident frame name ident.
          */
-        protected BlockFrame(AbstractFrame parent, DetailAST ident) {
+        /* package */ BlockFrame(AbstractFrame parent, DetailAST ident) {
             super(parent, ident);
         }
 
@@ -1511,7 +1511,7 @@ public class RequireThisCheck extends AbstractCheck {
          * @param parent parent frame.
          * @param ident ident frame name ident.
          */
-        protected CatchFrame(AbstractFrame parent, DetailAST ident) {
+        /* package */ CatchFrame(AbstractFrame parent, DetailAST ident) {
             super(parent, ident);
         }
 
@@ -1551,7 +1551,7 @@ public class RequireThisCheck extends AbstractCheck {
          * @param parent parent frame.
          * @param ident ident frame name ident.
          */
-        protected ForFrame(AbstractFrame parent, DetailAST ident) {
+        /* package */ ForFrame(AbstractFrame parent, DetailAST ident) {
             super(parent, ident);
         }
 
@@ -1574,7 +1574,7 @@ public class RequireThisCheck extends AbstractCheck {
          * @param parent parent frame.
          * @param ident ident frame name ident.
          */
-        protected TryWithResourcesFrame(AbstractFrame parent, DetailAST ident) {
+        /* package */ TryWithResourcesFrame(AbstractFrame parent, DetailAST ident) {
             super(parent, ident);
         }
 

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/ReturnCountCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/ReturnCountCheck.java
@@ -247,7 +247,7 @@ public final class ReturnCountCheck extends AbstractCheck {
          * @param maxAssigned Maximum allowed number of return statements.
          * @param voidReturn Identifies if context is void.
          */
-        public void visitLiteralReturn(int maxAssigned, Boolean voidReturn) {
+        /* package */ void visitLiteralReturn(int maxAssigned, Boolean voidReturn) {
             isVoidContext = voidReturn;
             maxAllowed = maxAssigned;
 
@@ -260,7 +260,7 @@ public final class ReturnCountCheck extends AbstractCheck {
          *
          * @param ast method def associated with this context.
          */
-        public void checkCount(DetailAST ast) {
+        /* package */ void checkCount(DetailAST ast) {
             if (checking && maxAllowed != null && count > maxAllowed) {
                 if (isVoidContext) {
                     log(ast, MSG_KEY_VOID, count, maxAllowed);

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/UnusedLocalVariableCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/UnusedLocalVariableCheck.java
@@ -921,7 +921,7 @@ public class UnusedLocalVariableCheck extends AbstractCheck {
          *
          * @return name of variable
          */
-        public String getName() {
+        /* package */ String getName() {
             return name;
         }
 
@@ -930,7 +930,7 @@ public class UnusedLocalVariableCheck extends AbstractCheck {
          *
          * @return the associated ast node of type {@link TokenTypes#TYPE}
          */
-        public DetailAST getTypeAst() {
+        /* package */ DetailAST getTypeAst() {
             return typeAst;
         }
 
@@ -941,14 +941,14 @@ public class UnusedLocalVariableCheck extends AbstractCheck {
          *
          * @return the scope associated with the variable
          */
-        public DetailAST getScope() {
+        /* package */ DetailAST getScope() {
             return scope;
         }
 
         /**
          * Register the variable as used.
          */
-        public void registerAsUsed() {
+        /* package */ void registerAsUsed() {
             used = true;
         }
 
@@ -956,7 +956,7 @@ public class UnusedLocalVariableCheck extends AbstractCheck {
          * Register the variable as an instance variable or
          * class variable.
          */
-        public void registerAsInstOrClassVar() {
+        /* package */ void registerAsInstOrClassVar() {
             instVarOrClassVar = true;
         }
 
@@ -965,7 +965,7 @@ public class UnusedLocalVariableCheck extends AbstractCheck {
          *
          * @return true if variable is used
          */
-        public boolean isUsed() {
+        /* package */ boolean isUsed() {
             return used;
         }
 
@@ -974,7 +974,7 @@ public class UnusedLocalVariableCheck extends AbstractCheck {
          *
          * @return true if is an instance variable or a class variable
          */
-        public boolean isInstVarOrClassVar() {
+        /* package */ boolean isInstVarOrClassVar() {
             return instVarOrClassVar;
         }
     }
@@ -1028,7 +1028,7 @@ public class UnusedLocalVariableCheck extends AbstractCheck {
          *
          * @return qualified class name
          */
-        public String getQualifiedName() {
+        /* package */ String getQualifiedName() {
             return qualifiedName;
         }
 
@@ -1037,7 +1037,7 @@ public class UnusedLocalVariableCheck extends AbstractCheck {
          *
          * @return the depth of nesting of type declaration
          */
-        public int getDepth() {
+        /* package */ int getDepth() {
             return depth;
         }
 
@@ -1046,7 +1046,7 @@ public class UnusedLocalVariableCheck extends AbstractCheck {
          *
          * @return ast node of the type declaration
          */
-        public DetailAST getTypeDeclAst() {
+        /* package */ DetailAST getTypeDeclAst() {
             return typeDeclAst;
         }
 
@@ -1056,7 +1056,7 @@ public class UnusedLocalVariableCheck extends AbstractCheck {
          * @param literalNewAst ast node of type {@link TokenTypes#LITERAL_NEW}
          * @return copy of variables in instanceAndClassVar stack with updated scope.
          */
-        public Deque<VariableDesc> getUpdatedCopyOfVarStack(DetailAST literalNewAst) {
+        /* package */ Deque<VariableDesc> getUpdatedCopyOfVarStack(DetailAST literalNewAst) {
             final DetailAST updatedScope = literalNewAst;
             final Deque<VariableDesc> instAndClassVarDeque = new ArrayDeque<>();
             instanceAndClassVarStack.forEach(instVar -> {
@@ -1073,7 +1073,7 @@ public class UnusedLocalVariableCheck extends AbstractCheck {
          *
          * @param variableDesc variable to be added
          */
-        public void addInstOrClassVar(VariableDesc variableDesc) {
+        /* package */ void addInstOrClassVar(VariableDesc variableDesc) {
             instanceAndClassVarStack.push(variableDesc);
         }
     }

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/design/FinalClassCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/design/FinalClassCheck.java
@@ -444,7 +444,7 @@ public class FinalClassCheck
          *
          * @return qualified class name
          */
-        protected String getQualifiedName() {
+        /* package */ String getQualifiedName() {
             return qualifiedName;
         }
 
@@ -453,7 +453,7 @@ public class FinalClassCheck
          *
          * @return the depth of nesting of type declaration
          */
-        protected int getDepth() {
+        /* package */ int getDepth() {
             return depth;
         }
 
@@ -462,7 +462,8 @@ public class FinalClassCheck
          *
          * @return ast node of the type declaration
          */
-        protected DetailAST getTypeDeclarationAst() {
+
+        /* package */ DetailAST getTypeDeclarationAst() {
             return typeDeclarationAst;
         }
     }

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/design/HideUtilityClassConstructorCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/design/HideUtilityClassConstructorCheck.java
@@ -204,7 +204,7 @@ public class HideUtilityClassConstructorCheck extends AbstractCheck {
          *
          * @return boolean
          */
-        public boolean isHasNonStaticMethodOrField() {
+        /* package */ boolean isHasNonStaticMethodOrField() {
             return hasNonStaticMethodOrField;
         }
 
@@ -213,7 +213,7 @@ public class HideUtilityClassConstructorCheck extends AbstractCheck {
          *
          * @return boolean
          */
-        public boolean isHasNonPrivateStaticMethodOrField() {
+        /* package */ boolean isHasNonPrivateStaticMethodOrField() {
             return hasNonPrivateStaticMethodOrField;
         }
 
@@ -222,7 +222,7 @@ public class HideUtilityClassConstructorCheck extends AbstractCheck {
          *
          * @return boolean
          */
-        public boolean isHasDefaultCtor() {
+        /* package */ boolean isHasDefaultCtor() {
             return hasDefaultCtor;
         }
 
@@ -231,14 +231,14 @@ public class HideUtilityClassConstructorCheck extends AbstractCheck {
          *
          * @return boolean
          */
-        public boolean isHasPublicCtor() {
+        /* package */ boolean isHasPublicCtor() {
             return hasPublicCtor;
         }
 
         /**
          * Main method to gather statistics.
          */
-        public void invoke() {
+        /* package */ void invoke() {
             final DetailAST objBlock = ast.findFirstToken(TokenTypes.OBJBLOCK);
             hasDefaultCtor = true;
             DetailAST child = objBlock.getFirstChild();

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/header/MultiFileRegexpHeaderCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/header/MultiFileRegexpHeaderCheck.java
@@ -280,7 +280,7 @@ public class MultiFileRegexpHeaderCheck
          * @return HeaderFileMetadata instance
          * @throws IllegalArgumentException if the header file is invalid or cannot be read
          */
-        public static HeaderFileMetadata createFromFile(String headerPath) {
+        /* package */ static HeaderFileMetadata createFromFile(String headerPath) {
             if (CommonUtil.isBlank(headerPath)) {
                 throw new IllegalArgumentException("Header file is not set");
             }
@@ -375,7 +375,7 @@ public class MultiFileRegexpHeaderCheck
          *
          * @return a matching result
          */
-        public static MatchResult matching() {
+        /* package */ static MatchResult matching() {
             return new MatchResult(true, 0, null, null);
         }
 
@@ -387,7 +387,7 @@ public class MultiFileRegexpHeaderCheck
          * @param messageArg the argument for the message
          * @return a mismatch result
          */
-        public static MatchResult mismatch(int lineNumber, String messageKey,
+        /* package */ static MatchResult mismatch(int lineNumber, String messageKey,
                                            String messageArg) {
             return new MatchResult(false, lineNumber, messageKey, messageArg);
         }

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/imports/CustomImportOrderCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/imports/CustomImportOrderCheck.java
@@ -793,7 +793,7 @@ public class CustomImportOrderCheck extends AbstractCheck {
          *
          * @return import start line from ast.
          */
-        public int getStartLineNumber() {
+        /* package */ int getStartLineNumber() {
             return importAST.getLineNo();
         }
 
@@ -807,7 +807,7 @@ public class CustomImportOrderCheck extends AbstractCheck {
          *
          * @return import end line from ast.
          */
-        public int getEndLineNumber() {
+        /* package */ int getEndLineNumber() {
             return importAST.getLastChild().getLineNo();
         }
     }

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/imports/UnusedImportsCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/imports/UnusedImportsCheck.java
@@ -545,7 +545,7 @@ public class UnusedImportsCheck extends AbstractCheck {
          *
          * @param type the type name
          */
-        public void addDeclaredType(String type) {
+        /* package */ void addDeclaredType(String type) {
             declaredTypes.add(type);
         }
 
@@ -554,7 +554,7 @@ public class UnusedImportsCheck extends AbstractCheck {
          *
          * @param type the type name
          */
-        public void addReferencedType(String type) {
+        /* package */ void addReferencedType(String type) {
             referencedTypes.add(type);
         }
 
@@ -563,7 +563,7 @@ public class UnusedImportsCheck extends AbstractCheck {
          *
          * @param types the type names
          */
-        public void addReferencedTypes(Collection<String> types) {
+        /* package */ void addReferencedTypes(Collection<String> types) {
             referencedTypes.addAll(types);
         }
 
@@ -571,7 +571,7 @@ public class UnusedImportsCheck extends AbstractCheck {
          * Filters out all references to locally defined types.
          *
          */
-        public void finish() {
+        /* package */ void finish() {
             referencedTypes.removeAll(declaredTypes);
         }
 
@@ -580,7 +580,7 @@ public class UnusedImportsCheck extends AbstractCheck {
          *
          * @return a new frame.
          */
-        public Frame push() {
+        /* package */ Frame push() {
             return new Frame(this);
         }
 
@@ -589,7 +589,7 @@ public class UnusedImportsCheck extends AbstractCheck {
          *
          * @return the parent frame
          */
-        public Frame pop() {
+        /* package */ Frame pop() {
             finish();
             parent.addReferencedTypes(referencedTypes);
             return parent;
@@ -601,7 +601,7 @@ public class UnusedImportsCheck extends AbstractCheck {
          * @param type the type name
          * @return {@code true} if the type is used
          */
-        public boolean isReferencedType(String type) {
+        /* package */ boolean isReferencedType(String type) {
             return referencedTypes.contains(type);
         }
 
@@ -610,7 +610,7 @@ public class UnusedImportsCheck extends AbstractCheck {
          *
          * @return a new frame.
          */
-        public static Frame compilationUnit() {
+        /* package */ static Frame compilationUnit() {
             return new Frame(null);
         }
 

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocMethodCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocMethodCheck.java
@@ -1002,7 +1002,7 @@ public class JavadocMethodCheck extends AbstractCheck {
          * @param className token which represents class name.
          * @throws IllegalArgumentException when className is nulls
          */
-        protected ClassInfo(final Token className) {
+        /* package */ ClassInfo(final Token className) {
             name = className;
         }
 
@@ -1011,7 +1011,7 @@ public class JavadocMethodCheck extends AbstractCheck {
          *
          * @return class name
          */
-        public final Token getName() {
+        /* package */ final Token getName() {
             return name;
         }
 
@@ -1039,7 +1039,7 @@ public class JavadocMethodCheck extends AbstractCheck {
          *
          * @return text of the token
          */
-        public String getText() {
+        /* package */ String getText() {
             return text;
         }
 

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/metrics/AbstractClassCouplingCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/metrics/AbstractClassCouplingCheck.java
@@ -336,7 +336,7 @@ public abstract class AbstractClassCouplingCheck extends AbstractCheck {
          *
          * @param literalThrows throws to process.
          */
-        public void visitLiteralThrows(DetailAST literalThrows) {
+        /* package */ void visitLiteralThrows(DetailAST literalThrows) {
             for (DetailAST childAST = literalThrows.getFirstChild();
                  childAST != null;
                  childAST = childAST.getNextSibling()) {
@@ -351,7 +351,7 @@ public abstract class AbstractClassCouplingCheck extends AbstractCheck {
          *
          * @param ast type to process.
          */
-        public void visitType(DetailAST ast) {
+        /* package */ void visitType(DetailAST ast) {
             DetailAST child = ast.getFirstChild();
             while (child != null) {
                 if (TokenUtil.isOfType(child, TokenTypes.IDENT, TokenTypes.DOT)) {
@@ -369,7 +369,7 @@ public abstract class AbstractClassCouplingCheck extends AbstractCheck {
          *
          * @param ast NEW to process.
          */
-        public void visitLiteralNew(DetailAST ast) {
+        /* package */ void visitLiteralNew(DetailAST ast) {
 
             if (ast.getParent().getType() == TokenTypes.METHOD_REF) {
                 addReferencedClassName(ast.getParent().getFirstChild());
@@ -403,7 +403,7 @@ public abstract class AbstractClassCouplingCheck extends AbstractCheck {
         }
 
         /** Checks if coupling less than allowed or not. */
-        public void checkCoupling() {
+        /* package */ void checkCoupling() {
             referencedClassNames.remove(className);
             referencedClassNames.remove(packageName + DOT + className);
 

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/metrics/BooleanExpressionComplexityCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/metrics/BooleanExpressionComplexityCheck.java
@@ -255,12 +255,12 @@ public final class BooleanExpressionComplexityCheck extends AbstractCheck {
          *
          * @return should we check in current context or not.
          */
-        public boolean isChecking() {
+        /* package */ boolean isChecking() {
             return checking;
         }
 
         /** Increases operator counter. */
-        public void visitBooleanOperator() {
+        /* package */ void visitBooleanOperator() {
             ++count;
         }
 
@@ -269,7 +269,7 @@ public final class BooleanExpressionComplexityCheck extends AbstractCheck {
          *
          * @param ast a node we check now.
          */
-        public void checkCount(DetailAST ast) {
+        /* package */ void checkCount(DetailAST ast) {
             if (checking && count > max) {
                 final DetailAST parentAST = ast.getParent();
 

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/metrics/JavaNCSSCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/metrics/JavaNCSSCheck.java
@@ -381,7 +381,7 @@ public class JavaNCSSCheck extends AbstractCheck {
         /**
          * Increments the counter.
          */
-        public void increment() {
+        /* package */ void increment() {
             count++;
         }
 
@@ -390,7 +390,7 @@ public class JavaNCSSCheck extends AbstractCheck {
          *
          * @return the counter
          */
-        public int getCount() {
+        /* package */ int getCount() {
             return count;
         }
 

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/metrics/NPathComplexityCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/metrics/NPathComplexityCheck.java
@@ -551,7 +551,7 @@ public final class NPathComplexityCheck extends AbstractCheck {
          *
          * @param endToken token.
          */
-        public void setToken(DetailAST endToken) {
+        /* package */ void setToken(DetailAST endToken) {
             if (!isAfter(endToken)) {
                 endLineNo = endToken.getLineNo();
                 endColumnNo = endToken.getColumnNo();
@@ -559,7 +559,7 @@ public final class NPathComplexityCheck extends AbstractCheck {
         }
 
         /** Sets end token coordinates to the start of the file. */
-        public void reset() {
+        /* package */ void reset() {
             endLineNo = 0;
             endColumnNo = 0;
         }
@@ -570,7 +570,7 @@ public final class NPathComplexityCheck extends AbstractCheck {
          * @param ast given token.
          * @return true, if saved coordinates located after given token.
          */
-        public boolean isAfter(DetailAST ast) {
+        /* package */ boolean isAfter(DetailAST ast) {
             final int lineNo = ast.getLineNo();
             final int columnNo = ast.getColumnNo();
             return lineNo <= endLineNo
@@ -607,7 +607,7 @@ public final class NPathComplexityCheck extends AbstractCheck {
          *
          * @return NP value for range
          */
-        public BigInteger getRangeValue() {
+        /* package */ BigInteger getRangeValue() {
             return rangeValue;
         }
 
@@ -616,7 +616,7 @@ public final class NPathComplexityCheck extends AbstractCheck {
          *
          * @return NP value for expression
          */
-        public BigInteger getExpressionValue() {
+        /* package */ BigInteger getExpressionValue() {
             return expressionValue;
         }
 

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/sizes/ExecutableStatementCountCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/sizes/ExecutableStatementCountCheck.java
@@ -209,7 +209,7 @@ public final class ExecutableStatementCountCheck
          *
          * @param addition the count increment.
          */
-        public void addCount(int addition) {
+        /* package */ void addCount(int addition) {
             count += addition;
         }
 
@@ -218,7 +218,7 @@ public final class ExecutableStatementCountCheck
          *
          * @return the member AST node.
          */
-        public DetailAST getAST() {
+        /* package */ DetailAST getAST() {
             return ast;
         }
 
@@ -227,7 +227,7 @@ public final class ExecutableStatementCountCheck
          *
          * @return the count.
          */
-        public int getCount() {
+        /* package */ int getCount() {
             return count;
         }
 

--- a/src/main/java/com/puppycrawl/tools/checkstyle/filters/SuppressWithNearbyCommentFilter.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/filters/SuppressWithNearbyCommentFilter.java
@@ -439,7 +439,7 @@ public class SuppressWithNearbyCommentFilter
          * @param event the {@code TreeWalkerAuditEvent} to check.
          * @return true if the source of event matches the text of this tag.
          */
-        public boolean isMatch(TreeWalkerAuditEvent event) {
+        /* package */ boolean isMatch(TreeWalkerAuditEvent event) {
             return isInScopeOfSuppression(event)
                     && isCheckMatch(event)
                     && isIdMatch(event)

--- a/src/main/java/com/puppycrawl/tools/checkstyle/filters/SuppressionCommentFilter.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/filters/SuppressionCommentFilter.java
@@ -442,7 +442,7 @@ public class SuppressionCommentFilter
          *
          * @return the line number of the tag in the source file.
          */
-        public int getLine() {
+        /* package */ int getLine() {
             return line;
         }
 
@@ -453,7 +453,7 @@ public class SuppressionCommentFilter
          *
          * @return the column number of the tag in the source file.
          */
-        public int getColumn() {
+        /* package */ int getColumn() {
             return column;
         }
 
@@ -463,7 +463,7 @@ public class SuppressionCommentFilter
          *
          * @return {@code ON} if the suppression turns reporting on.
          */
-        public TagType getTagType() {
+        /* package */ TagType getTagType() {
             return tagType;
         }
 
@@ -527,7 +527,7 @@ public class SuppressionCommentFilter
          * @param event the {@code TreeWalkerAuditEvent} to check.
          * @return true if the source of event matches the text of this tag.
          */
-        public boolean isMatch(TreeWalkerAuditEvent event) {
+        /* package */ boolean isMatch(TreeWalkerAuditEvent event) {
             return isCheckMatch(event) && isIdMatch(event) && isMessageMatch(event);
         }
 

--- a/src/test/java/com/puppycrawl/tools/checkstyle/PackageNamesLoaderTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/PackageNamesLoaderTest.java
@@ -303,7 +303,7 @@ public class PackageNamesLoaderTest extends AbstractPathTestSupport {
      */
     private static class NoOperationUrlConnection extends URLConnection {
 
-        protected NoOperationUrlConnection(URL url) {
+        /* package */ NoOperationUrlConnection(URL url) {
             super(url);
         }
 

--- a/src/test/java/com/puppycrawl/tools/checkstyle/internal/XdocsJavaDocsTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/internal/XdocsJavaDocsTest.java
@@ -364,7 +364,8 @@ public class XdocsJavaDocsTest extends AbstractModuleTestSupport {
             DetailAST result = node.getParent();
             int type = result.getType();
 
-            while (type == TokenTypes.MODIFIERS || type == TokenTypes.ANNOTATION) {
+            while (type == TokenTypes.MODIFIERS || type == TokenTypes.ANNOTATION
+                    || type == TokenTypes.TYPE) {
                 result = result.getParent();
                 type = result.getType();
             }

--- a/src/test/java/com/puppycrawl/tools/checkstyle/utils/ModuleReflectionUtilTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/utils/ModuleReflectionUtilTest.java
@@ -223,7 +223,7 @@ public class ModuleReflectionUtilTest {
      */
     private abstract static class AbstractInvalidClass extends AbstractAutomaticBean {
 
-        public abstract void method();
+        /* package */ abstract void method();
 
     }
 


### PR DESCRIPTION
Issue #17988: error-prone violation ModuleReflectionUtilTest

Original Error:
```

[WARNING] /home/xxxx/Desktop/checkstyle/checkstyle/src/test/java/com/puppycrawl/tools/checkstyle/utils/ModuleReflectionUtilTest.java:[226,30] [EffectivelyPrivate] This declaration has public or protected modifiers, but is effectively private.
    (see https://errorprone.info/bugpattern/EffectivelyPrivate)
  Did you mean 'abstract void method();'?
```

Upon removing, we get **PMD error**. 

To resolve both:

I added the /* package */ comment to `ModuleReflectionUtilTest.java` to resolve the `CommentDefaultAccessModifier` PMD error.
follows the previous convention in Issue #5665 and PR #6562

