### PR TITLE
Issue #16360: Added comment to testAddExceptionBetweenFileStartedAndF…

### DIFF
--- a/src/test/java/com/puppycrawl/tools/checkstyle/AbstractXmlTestSupport.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/AbstractXmlTestSupport.java
@@ -33,6 +33,7 @@ import java.util.function.BiPredicate;
 
 import javax.xml.parsers.ParserConfigurationException;
 
+import com.puppycrawl.tools.checkstyle.api.CheckstyleException;
 import org.w3c.dom.Document;
 import org.w3c.dom.NamedNodeMap;
 import org.w3c.dom.Node;
@@ -328,5 +329,48 @@ public abstract class AbstractXmlTestSupport extends AbstractModuleTestSupport {
 
         checker.process(filesToCheck);
         verifyXml(getPath(expectedXmlReportPath), actualXmlOutput);
+    }
+
+    /**
+     * Verifies XML output using inline configuration parser and XML logger,
+     * using a provided OutputStream so tests can verify stream lifecycle behavior.
+     *
+     * @param filePath the path to the test file
+     * @param expectedXmlReportPath the path to the expected XML report
+     * @param outStream the output stream used by XMLLogger
+     * @throws Exception if an error occurs
+     */
+    protected final void verifyWithInlineConfigParserAndXmlLogger(
+        String filePath,
+        String expectedXmlReportPath,
+        ByteArrayOutputStream outStream) throws Exception {
+
+        final String configFilePath = getPath(filePath);
+        final TestInputConfiguration testInputConfiguration =
+                InlineConfigParser.parse(configFilePath);
+        final DefaultConfiguration parsedConfig =
+                testInputConfiguration.createConfiguration();
+        final String basePath = new File(getPath("")).getAbsolutePath();
+
+        final Checker checker = createChecker(parsedConfig);
+        checker.setBasedir(basePath);
+
+        final XMLLogger logger = new XMLLogger(
+                outStream,
+                AbstractAutomaticBean.OutputStreamOptions.CLOSE);
+        checker.addListener(logger);
+        final List<File> filesToCheck =
+                Collections.singletonList(new File(configFilePath));
+
+        try {
+            checker.process(filesToCheck);
+        }
+        catch (CheckstyleException ex) {
+            // expected for invalid Java input
+        }
+        finally {
+            checker.destroy();
+        }
+        verifyXml(getPath(expectedXmlReportPath), outStream);
     }
 }

--- a/src/test/java/com/puppycrawl/tools/checkstyle/XMLLoggerTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/XMLLoggerTest.java
@@ -291,13 +291,13 @@ public class XMLLoggerTest extends AbstractXmlTestSupport {
         final XMLLogger logger = new XMLLogger(outStream, OutputStreamOptions.CLOSE);
         logger.auditStarted(null);
 
-        final AuditEvent fileStartedEvent = new AuditEvent(this, "Test.java");
+        final AuditEvent fileStartedEvent = new AuditEvent(this, "InputXMLLoggerAddExceptionBetweenFileStartedAndFinished.java");
         logger.fileStarted(fileStartedEvent);
 
         final Violation violation =
                 new Violation(1, 1,
                         "messages.properties", null, null, null, getClass(), null);
-        final AuditEvent ev = new AuditEvent(this, "Test.java", violation);
+        final AuditEvent ev = new AuditEvent(this, "InputXMLLoggerAddExceptionBetweenFileStartedAndFinished.java", violation);
         logger.addException(ev, new TestException("msg", new RuntimeException("msg")));
 
         logger.fileFinished(ev);
@@ -328,24 +328,11 @@ public class XMLLoggerTest extends AbstractXmlTestSupport {
     }
 
     @Test
-    public void testAddExceptionBetweenFileStartedAndFinished()
-            throws Exception {
-        final XMLLogger logger = new XMLLogger(outStream, OutputStreamOptions.CLOSE);
-        logger.auditStarted(null);
-        final Violation violation =
-                new Violation(1, 1,
-                        "messages.properties", null, null, null, getClass(), null);
-        final AuditEvent fileStartedEvent = new AuditEvent(this, "Test.java");
-        logger.fileStarted(fileStartedEvent);
-        final AuditEvent ev = new AuditEvent(this, "Test.java", violation);
-        logger.addException(ev, new TestException("msg", new RuntimeException("msg")));
-        final AuditEvent fileFinishedEvent = new AuditEvent(this, "Test.java");
-        logger.fileFinished(fileFinishedEvent);
-        logger.auditFinished(null);
-        verifyXml(getPath("ExpectedXMLLoggerException2.xml"), outStream);
-        assertWithMessage("Invalid close count")
-            .that(outStream.getCloseCount())
-            .isEqualTo(1);
+    public void testAddExceptionBetweenFileStartedAndFinished() throws Exception {
+        final String inputFileWithConfig = "InputXMLLoggerAddExceptionBetweenFileStartedAndFinished.java";
+        final String expectedXmlReport = "ExpectedXMLLoggerException2.xml";
+        verifyWithInlineConfigParserAndXmlLogger(inputFileWithConfig, expectedXmlReport, outStream);
+
     }
 
     @Test

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/xmllogger/ExpectedXMLLoggerException2.xml
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/xmllogger/ExpectedXMLLoggerException2.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <checkstyle version="">
-<file name="Test.java">
+<file name="InputXMLLoggerAddExceptionBetweenFileStartedAndFinished.java">
 <exception>
 <![CDATA[
 stackTrace&#10;example

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/xmllogger/InputXMLLoggerAddExceptionBetweenFileStartedAndFinished.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/xmllogger/InputXMLLoggerAddExceptionBetweenFileStartedAndFinished.java
@@ -1,0 +1,14 @@
+/*xml
+<module name="Checker">
+    <module name="TreeWalker">
+        <module name="MemberName">
+        </module>
+    </module>
+</module>
+*/
+
+package com.puppycrawl.tools.checkstyle.xmllogger;
+
+public class InputXMLLoggerAddExceptionBetweenFileStartedAndFinished {
+    private int num
+}


### PR DESCRIPTION
Issue : #16360 
This test cannot use verifyWithInlineConfigParserAndXmlLogger because it injects a custom exception and verifies XMLLogger’s exception-handling and OutputStream lifecycle behavior, which cannot be reproduced through Checker execution.