### PR TITLE
Issue #18023: Resolve Pitest Sup - filters - Supress - toString

### DIFF
--- a/config/pitest-suppressions/pitest-filters-suppressions.xml
+++ b/config/pitest-suppressions/pitest-filters-suppressions.xml
@@ -10,15 +10,6 @@
   </mutation>
 
   <mutation unstable="false">
-    <sourceFile>SuppressWithNearbyCommentFilter.java</sourceFile>
-    <mutatedClass>com.puppycrawl.tools.checkstyle.filters.SuppressWithNearbyCommentFilter$Tag</mutatedClass>
-    <mutatedMethod>toString</mutatedMethod>
-    <mutator>org.pitest.mutationtest.engine.gregor.mutators.NonVoidMethodCallMutator</mutator>
-    <description>removed call to java/lang/String::valueOf</description>
-    <lineContent>return &quot;Tag[text=&apos;&quot; + text + &apos;\&apos;&apos;</lineContent>
-  </mutation>
-
-  <mutation unstable="false">
     <sourceFile>XpathFilterElement.java</sourceFile>
     <mutatedClass>com.puppycrawl.tools.checkstyle.filters.XpathFilterElement</mutatedClass>
     <mutatedMethod>isXpathQueryMatching</mutatedMethod>

--- a/src/test/java/com/puppycrawl/tools/checkstyle/filters/SuppressWithNearbyCommentFilterTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/filters/SuppressWithNearbyCommentFilterTest.java
@@ -508,6 +508,23 @@ public class SuppressWithNearbyCommentFilterTest
                     + "tagCheckRegexp=.*, tagMessageRegexp=null, tagIdRegexp=.*]");
     }
 
+    /**
+     * {@link #verifySuppressedWithParser(String, String...)} does not invoke
+     * {@code Tag#toString()}. Direct assertion is required to kill the mutation
+     */
+    @Test
+    public void testToStringOfTagClassWithMessage() {
+        final SuppressWithNearbyCommentFilter filter = new SuppressWithNearbyCommentFilter();
+        filter.setMessageFormat("msg");
+        filter.setCheckFormat("IGNORE");
+        final Object tag =
+                getTagsAfterExecution(filter, "filename", "//SUPPRESS CHECKSTYLE ignore").get(0);
+        assertWithMessage("Invalid toString result")
+            .that(tag.toString())
+            .isEqualTo("Tag[text='SUPPRESS CHECKSTYLE ignore', firstLine=1, lastLine=1, "
+                    + "tagCheckRegexp=IGNORE, tagMessageRegexp=msg, tagIdRegexp=null]");
+    }
+
     @Test
     public void testUsingTagMessageRegexp() throws Exception {
         final String[] suppressed = CommonUtil.EMPTY_STRING_ARRAY;


### PR DESCRIPTION
Issue #18023: Resolve Pitest Sup - filters - Supress - toString

Part of #18475

Killing mutation for "call to java/lang/String::valueOf" and added comment explaining