### PR TITLE
Issue #17299: Convert eligible classes to records

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/TreeWalkerAuditEvent.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/TreeWalkerAuditEvent.java
@@ -26,61 +26,16 @@ import com.puppycrawl.tools.checkstyle.api.Violation;
 /**
  * Raw {@code TreeWalker} event for audit.
  *
+ * @param fileContents contents of the file associated with the event
+ * @param fileName file associated with the event
+ * @param violation the actual violation
+ * @param rootAst root AST element {@link DetailAST} of the file
  */
-public class TreeWalkerAuditEvent {
-
-    /** Filename event associated with. **/
-    private final String fileName;
-    /** The file contents. */
-    private final FileContents fileContents;
-    /** Violation associated with the event. **/
-    private final Violation violation;
-    /** Root ast element. **/
-    private final DetailAST rootAst;
-
-    /**
-     * Creates a new {@code TreeWalkerAuditEvent} instance.
-     *
-     * @param fileContents contents of the file associated with the event
-     * @param fileName file associated with the event
-     * @param violation the actual violation
-     * @param rootAst root AST element {@link DetailAST} of the file
-     */
-    public TreeWalkerAuditEvent(FileContents fileContents, String fileName,
-                                Violation violation, DetailAST rootAst) {
-        this.fileContents = fileContents;
-        this.fileName = fileName;
-        this.violation = violation;
-        this.rootAst = rootAst;
-    }
-
-    /**
-     * Returns name of file being audited.
-     *
-     * @return the file name currently being audited or null if there is
-     *     no relation to a file.
-     */
-    public String getFileName() {
-        return fileName;
-    }
-
-    /**
-     * Returns contents of the file.
-     *
-     * @return contents of the file.
-     */
-    public FileContents getFileContents() {
-        return fileContents;
-    }
-
-    /**
-     * Gets the violation.
-     *
-     * @return the violation
-     */
-    public Violation getViolation() {
-        return violation;
-    }
+public record TreeWalkerAuditEvent(
+        FileContents fileContents,
+        String fileName,
+        Violation violation,
+        DetailAST rootAst) {
 
     /**
      * Return the line number on the source file where the event occurred.
@@ -145,15 +100,6 @@ public class TreeWalkerAuditEvent {
      */
     public int getTokenType() {
         return violation.getTokenType();
-    }
-
-    /**
-     * Gets the root element of the AST tree.
-     *
-     * @return the root element of the AST tree
-     */
-    public DetailAST getRootAst() {
-        return rootAst;
     }
 
 }

--- a/src/main/java/com/puppycrawl/tools/checkstyle/XpathFileGeneratorAstFilter.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/XpathFileGeneratorAstFilter.java
@@ -78,7 +78,7 @@ public class XpathFileGeneratorAstFilter extends AbstractAutomaticBean implement
             final List<String> xpathQueries = xpathQueryGenerator.generate();
             if (!xpathQueries.isEmpty()) {
                 final String query = String.join(DELIMITER, xpathQueries);
-                MESSAGE_QUERY_MAP.put(event.getViolation(), query);
+                MESSAGE_QUERY_MAP.put(event.violation(), query);
             }
         }
         return true;

--- a/src/main/java/com/puppycrawl/tools/checkstyle/api/LineColumn.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/api/LineColumn.java
@@ -24,6 +24,8 @@ import java.util.Objects;
 /**
  * Immutable line and column numbers.
  *
+ * @noinspection ClassCanBeRecord
+ * @noinspectionreason Public API class – converting to record would break binary compatibility.
  */
 public class LineColumn implements Comparable<LineColumn> {
 

--- a/src/main/java/com/puppycrawl/tools/checkstyle/filters/SuppressWithNearbyCommentFilter.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/filters/SuppressWithNearbyCommentFilter.java
@@ -221,10 +221,10 @@ public class SuppressWithNearbyCommentFilter
     public boolean accept(TreeWalkerAuditEvent event) {
         boolean accepted = true;
 
-        if (event.getViolation() != null) {
+        if (event.violation() != null) {
             // Lazy update. If the first event for the current file, update file
             // contents and tag suppressions
-            final FileContents currentContents = event.getFileContents();
+            final FileContents currentContents = event.fileContents();
 
             if (getFileContents() != currentContents) {
                 setFileContents(currentContents);

--- a/src/main/java/com/puppycrawl/tools/checkstyle/filters/SuppressionCommentFilter.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/filters/SuppressionCommentFilter.java
@@ -245,10 +245,10 @@ public class SuppressionCommentFilter
     public boolean accept(TreeWalkerAuditEvent event) {
         boolean accepted = true;
 
-        if (event.getViolation() != null) {
+        if (event.violation() != null) {
             // Lazy update. If the first event for the current file, update file
             // contents and tag suppressions
-            final FileContents currentContents = event.getFileContents();
+            final FileContents currentContents = event.fileContents();
 
             if (getFileContents() != currentContents) {
                 setFileContents(currentContents);

--- a/src/main/java/com/puppycrawl/tools/checkstyle/filters/XpathFilterElement.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/filters/XpathFilterElement.java
@@ -135,9 +135,9 @@ public final class XpathFilterElement implements TreeWalkerFilter {
      * @return true if it is matching
      */
     private boolean isFileNameAndModuleAndModuleNameMatching(TreeWalkerAuditEvent event) {
-        return event.getFileName() != null
-                && (fileRegexp == null || fileRegexp.matcher(event.getFileName()).find())
-                && event.getViolation() != null
+        return event.fileName() != null
+                && (fileRegexp == null || fileRegexp.matcher(event.fileName()).find())
+                && event.violation() != null
                 && (moduleId == null || moduleId.equals(event.getModuleId()))
                 && (checkRegexp == null || checkRegexp.matcher(event.getSourceName()).find());
     }
@@ -189,11 +189,11 @@ public final class XpathFilterElement implements TreeWalkerFilter {
      */
     private List<Item> getItems(TreeWalkerAuditEvent event) {
         final RootNode rootNode;
-        if (event.getRootAst() == null) {
+        if (event.rootAst() == null) {
             rootNode = null;
         }
         else {
-            rootNode = new RootNode(event.getRootAst());
+            rootNode = new RootNode(event.rootAst());
         }
         final List<Item> items;
         try {

--- a/src/main/java/com/puppycrawl/tools/checkstyle/site/AllCheckSummaries.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/site/AllCheckSummaries.java
@@ -349,7 +349,7 @@ public class AllCheckSummaries extends AbstractMacro {
                                        StringBuilder holderRows) {
         for (CheckInfo info : infos.values()) {
             final String row = buildTableRow(info);
-            if (isHolder(info.simpleName)) {
+            if (isHolder(info.simpleName())) {
                 holderRows.append(row);
             }
             else {
@@ -372,15 +372,15 @@ public class AllCheckSummaries extends AbstractMacro {
         final String ind14 = ModuleJavadocParsingUtil.INDENT_LEVEL_14;
         final String ind16 = ModuleJavadocParsingUtil.INDENT_LEVEL_16;
 
-        final String cleanSummary = sanitizeAnchorUrls(info.summary);
+        final String cleanSummary = sanitizeAnchorUrls(info.summary());
 
         return ind10 + "<tr>"
                 + ind12 + TD_TAG
                 + ind14
                 + "<a href=\""
-                + info.link
+                + info.link()
                 + "\">"
-                + ind16 + info.simpleName
+                + ind16 + info.simpleName()
                 + ind14 + CLOSING_ANCHOR_TAG
                 + ind12 + TD_CLOSE_TAG
                 + ind12 + TD_TAG
@@ -835,26 +835,11 @@ public class AllCheckSummaries extends AbstractMacro {
 
     /**
      * Data holder for each Check module entry.
+     *
+     * @param simpleName check simple name
+     * @param link documentation link
+     * @param summary module summary
      */
-    private static final class CheckInfo {
-        /** Simple name of the check. */
-        private final String simpleName;
-        /** Documentation link. */
-        private final String link;
-        /** Short summary text. */
-        private final String summary;
-
-        /**
-         * Constructs an info record.
-         *
-         * @param simpleName check simple name
-         * @param link documentation link
-         * @param summary module summary
-         */
-        private CheckInfo(String simpleName, String link, String summary) {
-            this.simpleName = simpleName;
-            this.link = link;
-            this.summary = summary;
-        }
+    private record CheckInfo(String simpleName, String link, String summary) {
     }
 }

--- a/src/main/java/com/puppycrawl/tools/checkstyle/xpath/XpathQueryGenerator.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/xpath/XpathQueryGenerator.java
@@ -96,8 +96,8 @@ public class XpathQueryGenerator {
      * @param tabWidth distance between tab stop position
      */
     public XpathQueryGenerator(TreeWalkerAuditEvent event, int tabWidth) {
-        this(event.getRootAst(), event.getLine(), event.getColumn(), event.getTokenType(),
-                event.getFileContents().getText(), tabWidth);
+        this(event.rootAst(), event.getLine(), event.getColumn(), event.getTokenType(),
+                event.fileContents().getText(), tabWidth);
     }
 
     /**

--- a/src/test/java/com/puppycrawl/tools/checkstyle/filters/SuppressionCommentFilterTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/filters/SuppressionCommentFilterTest.java
@@ -428,7 +428,7 @@ public class SuppressionCommentFilterTest
             .that(filter.accept(auditEvent))
                 .isTrue();
         assertWithMessage("File name should not be null")
-            .that(auditEvent.getFileName())
+            .that(auditEvent.fileName())
             .isNull();
     }
 


### PR DESCRIPTION
#17299 

1. TreeWalkerAuditEvent.java
Converted from class to record
Removed explicit fields, constructor, and basic getters
Kept all delegating methods (getLine, getMessage, etc.)
Updated Javadoc to record parameter format

2. LineColumn.java
Added suppression comment : This is part of the public API and must maintain backward compatibility
No other changes (maintains backward compatibility)

3. AllCheckSummaries.java
Converted `CheckInfo `nested class to a record (at the end of file)
Updated `buildTableRow `method to use record accessor methods:
```
info.simpleName → info.simpleName()
info.link → info.link()
info.summary → info.summary()
```