### PR TITLE
Issue #18035: Kill pitest mutation in CommentsIndentation Check

### DIFF
--- a/config/pitest-suppressions/pitest-indentation-suppressions.xml
+++ b/config/pitest-suppressions/pitest-indentation-suppressions.xml
@@ -1,15 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <suppressedMutations>
   <mutation unstable="false">
-    <sourceFile>CommentsIndentationCheck.java</sourceFile>
-    <mutatedClass>com.puppycrawl.tools.checkstyle.checks.indentation.CommentsIndentationCheck</mutatedClass>
-    <mutatedMethod>findPreviousStatement</mutatedMethod>
-    <mutator>org.pitest.mutationtest.engine.gregor.mutators.NegateConditionalsMutator</mutator>
-    <description>negated conditional</description>
-    <lineContent>if (root.getFirstChild().getType() == TokenTypes.LITERAL_NEW) {</lineContent>
-  </mutation>
-
-  <mutation unstable="false">
     <sourceFile>HandlerFactory.java</sourceFile>
     <mutatedClass>com.puppycrawl.tools.checkstyle.checks.indentation.HandlerFactory</mutatedClass>
     <mutatedMethod>clearCreatedHandlers</mutatedMethod>

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/indentation/CommentsIndentationCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/indentation/CommentsIndentationCheck.java
@@ -627,12 +627,7 @@ public class CommentsIndentationCheck extends AbstractCheck {
         }
         final DetailAST tokenWhichBeginsTheLine;
         if (root.getType() == TokenTypes.EXPR) {
-            if (root.getFirstChild().getType() == TokenTypes.LITERAL_NEW) {
-                tokenWhichBeginsTheLine = root.getFirstChild();
-            }
-            else {
-                tokenWhichBeginsTheLine = findStartTokenOfMethodCallChain(root);
-            }
+            tokenWhichBeginsTheLine = findStartTokenOfMethodCallChain(root);
         }
         else if (root.getType() == TokenTypes.PLUS) {
             tokenWhichBeginsTheLine = root.getFirstChild();


### PR DESCRIPTION
Issue #18035:

The LITERAL_NEW special case in findPreviousStatement() method produces equivalent results to findTokenWhichBeginsTheLine(). Regression testing across multiple projects confirms no behavioral difference, making this dead code. This refactoring eliminates the  mutation that could not be killed due to equivalent behavior.