### PR TITLE
Issue #18435: Remove emptyforinitializerpad Example2 from XdocsExampl…

### DIFF
--- a/src/site/xdoc/checks/whitespace/emptyforinitializerpad.xml
+++ b/src/site/xdoc/checks/whitespace/emptyforinitializerpad.xml
@@ -59,7 +59,7 @@ for (
 class Example1 {
   int i = 0;
   void example() {
-    for ( ; i &lt; 1; i++ );  // violation '';' is preceded with whitespace'
+    for ( ; i &lt; 2; i++ );  // violation '';' is preceded with whitespace'
     for (; i &lt; 2; i++ );
     for (;i&lt;2;i++);
     for ( ;i&lt;2;i++);       // violation '';' is preceded with whitespace'
@@ -89,10 +89,10 @@ class Example1 {
 class Example2 {
   int i = 0;
   void example() {
-    for ( ; i &lt; 2; i++ ) { };
-    for (; i &lt; 2; i++ ) { };    // violation '';' is not preceded with whitespace'
-    for (;i&lt;2;i++) { };         // violation '';' is not preceded with whitespace'
-    for ( ;i&lt;2;i++) { };
+    for ( ; i &lt; 2; i++ );
+    for (; i &lt; 2; i++ );    // violation '';' is not preceded with whitespace'
+    for (;i&lt;2;i++);         // violation '';' is not preceded with whitespace'
+    for ( ;i&lt;2;i++);
     for (
           ; i &lt; 2; i++ );
   }

--- a/src/test/java/com/puppycrawl/tools/checkstyle/internal/XdocsExamplesAstConsistencyTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/internal/XdocsExamplesAstConsistencyTest.java
@@ -244,7 +244,6 @@ public class XdocsExamplesAstConsistencyTest {
             "checks/trailingcomment/Example4",
             "checks/trailingcomment/Example5",
             "checks/trailingcomment/Example6",
-            "checks/whitespace/emptyforinitializerpad/Example2",
             "checks/whitespace/nolinewrap/Example2",
             "checks/whitespace/nolinewrap/Example3",
             "checks/whitespace/nolinewrap/Example4",

--- a/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/whitespace/emptyforinitializerpad/Example1.java
+++ b/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/whitespace/emptyforinitializerpad/Example1.java
@@ -14,7 +14,7 @@ package com.puppycrawl.tools.checkstyle.checks.whitespace.emptyforinitializerpad
 class Example1 {
   int i = 0;
   void example() {
-    for ( ; i < 1; i++ );  // violation '';' is preceded with whitespace'
+    for ( ; i < 2; i++ );  // violation '';' is preceded with whitespace'
     for (; i < 2; i++ );
     for (;i<2;i++);
     for ( ;i<2;i++);       // violation '';' is preceded with whitespace'

--- a/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/whitespace/emptyforinitializerpad/Example2.java
+++ b/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/whitespace/emptyforinitializerpad/Example2.java
@@ -16,10 +16,10 @@ package com.puppycrawl.tools.checkstyle.checks.whitespace.emptyforinitializerpad
 class Example2 {
   int i = 0;
   void example() {
-    for ( ; i < 2; i++ ) { };
-    for (; i < 2; i++ ) { };    // violation '';' is not preceded with whitespace'
-    for (;i<2;i++) { };         // violation '';' is not preceded with whitespace'
-    for ( ;i<2;i++) { };
+    for ( ; i < 2; i++ );
+    for (; i < 2; i++ );    // violation '';' is not preceded with whitespace'
+    for (;i<2;i++);         // violation '';' is not preceded with whitespace'
+    for ( ;i<2;i++);
     for (
           ; i < 2; i++ );
   }


### PR DESCRIPTION
Issue #18435:
Remove emptyforinitializerpad Example2 from XdocsExamplesAstConsistencyTest.
Update Example 2 to match Example 1 Ast.

https://www.diffchecker.com/kS03ZKeN/
<img width="733" height="738" alt="Comparison of Example1 and  Example2" src="https://github.com/user-attachments/assets/8c1b88ba-6606-4951-bde6-d9bff52dcab3" />
Both Example2 and Example1 have same numbers and spacing.
