### PR TITLE
infra: constant-values.html violation on run-link-check-plugin.sh on master branch

### DIFF
--- a/.ci/run-link-check-plugin.sh
+++ b/.ci/run-link-check-plugin.sh
@@ -27,7 +27,8 @@ if [[ $OPTION == "--skip-external" ]]; then
 else
   echo "Checking internal (checkstyle website) and external links."
   echo "$LINKCHECK_ERRORS" | sort > .ci-temp/linkcheck-errors-sorted.txt
-  sort config/linkcheck-suppressions.txt > .ci-temp/linkcheck-suppressions-sorted.txt
+  sort config/linkcheck-suppressions.txt | grep -v 'apidocs/constant-values.html' \
+      > .ci-temp/linkcheck-suppressions-sorted.txt
 fi
 
 # Suppressions exist until https://github.com/checkstyle/checkstyle/issues/11572


### PR DESCRIPTION
https://github.com/checkstyle/checkstyle/actions/runs/20693986292/job/59406305419

```
Checking internal (checkstyle website) and external links.
--- .ci-temp/linkcheck-suppressions-sorted.txt	2026-01-04 14:02:37.605417117 +0000
+++ .ci-temp/linkcheck-errors-sorted.txt	2026-01-04 14:02:37.603417127 +0000
@@ -845,7 +845,6 @@
 <a href="apidocs/com/puppycrawl/tools/checkstyle/xpath/iterators/PrecedingIterator.html#%3Cinit%3E(net.sf.saxon.om.NodeInfo)">#%3Cinit%3E(net.sf.saxon.om.NodeInfo)</a>: doesn't exist.
 <a href="apidocs/com/puppycrawl/tools/checkstyle/xpath/iterators/ReverseDescendantIterator.html#%3Cinit%3E(net.sf.saxon.om.NodeInfo)">#%3Cinit%3E(net.sf.saxon.om.NodeInfo)</a>: doesn't exist.
 <a href="apidocs/com/puppycrawl/tools/checkstyle/xpath/iterators/ReverseListIterator.html#%3Cinit%3E(java.util.Collection)">#%3Cinit%3E(java.util.Collection)</a>: doesn't exist.
-<a href="apidocs/constant-values.html#com.puppycrawl">#com.puppycrawl</a>: doesn't exist.
 <a href="com/puppycrawl/tools/checkstyle/AbstractAutomaticBean.OutputStreamOptions.html#%3Cinit%3E()">com/puppycrawl/tools/checkstyle/AbstractAutomaticBean.OutputStreamOptions.html#%3Cinit%3E()</a>: doesn't exist.
 <a href="com/puppycrawl/tools/checkstyle/AbstractAutomaticBean.PatternArrayConverter.html#%3Cinit%3E()">com/puppycrawl/tools/checkstyle/AbstractAutomaticBean.PatternArrayConverter.html#%3Cinit%3E()</a>: doesn't exist.
 <a href="com/puppycrawl/tools/checkstyle/AbstractAutomaticBean.PatternConverter.html#%3Cinit%3E()">com/puppycrawl/tools/checkstyle/AbstractAutomaticBean.PatternConverter.html#%3Cinit%3E()</a>: doesn't exist.
------------ grep of linkcheck.html--END
Exit code:1
```