### PR TITLE
Issue #6294: Added test to kill mutation in AbstractExpressionHandler.getFirstToken

### DIFF
--- a/config/pitest-suppressions/pitest-indentation-suppressions.xml
+++ b/config/pitest-suppressions/pitest-indentation-suppressions.xml
@@ -10,15 +10,6 @@
   </mutation>
 
   <mutation unstable="false">
-    <sourceFile>AbstractExpressionHandler.java</sourceFile>
-    <mutatedClass>com.puppycrawl.tools.checkstyle.checks.indentation.AbstractExpressionHandler</mutatedClass>
-    <mutatedMethod>getFirstToken</mutatedMethod>
-    <mutator>org.pitest.mutationtest.engine.gregor.mutators.ConditionalsBoundaryMutator</mutator>
-    <description>changed conditional boundary</description>
-    <lineContent>if (toTest.getColumnNo() &lt; first.getColumnNo()) {</lineContent>
-  </mutation>
-
-  <mutation unstable="false">
     <sourceFile>CommentsIndentationCheck.java</sourceFile>
     <mutatedClass>com.puppycrawl.tools.checkstyle.checks.indentation.CommentsIndentationCheck</mutatedClass>
     <mutatedMethod>findPreviousStatement</mutatedMethod>

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/indentation/IndentationCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/indentation/IndentationCheckTest.java
@@ -4170,6 +4170,21 @@ public class IndentationCheckTest extends AbstractModuleTestSupport {
         verifyWarns(checkConfig, fileName, expected);
     }
 
+    @Test
+    public void testFirstTokenSelection() throws Exception {
+        final DefaultConfiguration checkConfig = createModuleConfig(IndentationCheck.class);
+        checkConfig.addProperty("basicOffset", "4");
+        checkConfig.addProperty("tabWidth", "4");
+
+        final String[] expected = {
+            "15:1: " + getCheckMessage(MSG_ERROR, "member def type", 0, 8),
+            "16:1: " + getCheckMessage(MSG_ERROR, "Integer", 0, 12),
+            "17:1: " + getCheckMessage(MSG_ERROR, ">", 0, 12),
+        };
+        verifyWarns(checkConfig,
+            getPath("InputIndentationFirstTokenSelection.java"), expected);
+    }
+
     private static final class IndentAudit implements AuditListener {
 
         private final IndentComment[] comments;

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/indentation/indentation/InputIndentationFirstTokenSelection.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/indentation/indentation/InputIndentationFirstTokenSelection.java
@@ -1,0 +1,19 @@
+package com.puppycrawl.tools.checkstyle.checks.indentation.indentation;       //indent:0 exp:0
+
+import java.util.ArrayList;                                                   //indent:0 exp:0
+import java.util.List;                                                        //indent:0 exp:0
+
+/**                                                                           //indent:0 exp:0
+ * This test-input is intended to be checked using following configuration:   //indent:1 exp:1
+ * basicOffset = 4                                                            //indent:1 exp:1
+ * tabWidth = 4                                                               //indent:1 exp:1
+ */                                                                           //indent:1 exp:1
+public class InputIndentationFirstTokenSelection {                            //indent:0 exp:0
+
+    public void beforeAndAfter() {                                            //indent:4 exp:4
+        List                                                                  //indent:8 exp:8
+<                                                                             //indent:0 exp:8 warn
+Integer> x = new ArrayList<Integer                                            //indent:0 exp:12 warn
+>();                                                                          //indent:0 exp:12 warn
+    }                                                                         //indent:4 exp:4
+}                                                                             //indent:0 exp:0


### PR DESCRIPTION
Issue #6294:

This PR adds a test case to kill the Pitest mutation in AbstractExpressionHandler.getFirstToken() method.
The mutation changes which token is selected when multiple tokens share the same column number. When a generic type is line-wrapped.
Both original and mutated code produce violations on the same line/column, but the error message token name differs, making the mutation killable.