### PR TITLE
Issue #6294: Refactor column comparison in getFirstAstNode in Abstrac…

### DIFF
--- a/config/pitest-suppressions/pitest-indentation-suppressions.xml
+++ b/config/pitest-suppressions/pitest-indentation-suppressions.xml
@@ -1,15 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <suppressedMutations>
   <mutation unstable="false">
-    <sourceFile>AbstractExpressionHandler.java</sourceFile>
-    <mutatedClass>com.puppycrawl.tools.checkstyle.checks.indentation.AbstractExpressionHandler</mutatedClass>
-    <mutatedMethod>getFirstAstNode</mutatedMethod>
-    <mutator>org.pitest.mutationtest.engine.gregor.mutators.ConditionalsBoundaryMutator</mutator>
-    <description>changed conditional boundary</description>
-    <lineContent>&amp;&amp; curNode.getColumnNo() &lt; realStart.getColumnNo()) {</lineContent>
-  </mutation>
-
-  <mutation unstable="false">
     <sourceFile>CommentsIndentationCheck.java</sourceFile>
     <mutatedClass>com.puppycrawl.tools.checkstyle.checks.indentation.CommentsIndentationCheck</mutatedClass>
     <mutatedMethod>findPreviousStatement</mutatedMethod>

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/indentation/AbstractExpressionHandler.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/indentation/AbstractExpressionHandler.java
@@ -460,7 +460,8 @@ public abstract class AbstractExpressionHandler {
         while (curNode != null) {
             if (curNode.getLineNo() < realStart.getLineNo()
                     || curNode.getLineNo() == realStart.getLineNo()
-                    && curNode.getColumnNo() < realStart.getColumnNo()) {
+                    && Math.min(curNode.getColumnNo(), realStart.getColumnNo())
+                    == curNode.getColumnNo()) {
                 realStart = curNode;
             }
             DetailAST toVisit = curNode.getFirstChild();


### PR DESCRIPTION
Issue #6294:

Replaced conditional boundary comparisons with Math.min() in getFirstAstNode() method. This refactoring eliminates equivalent ConditionalsBoundaryMutator mutations that could not be killed. Using Math.min() changes the mutation type to EqualityMutator which is killable.