### PR TITLE
Issue #17656: Cirrus should be used wisely to avoid credit limits

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -1,4 +1,14 @@
-only_if: $CIRRUS_BRANCH == $CIRRUS_DEFAULT_BRANCH || $CIRRUS_BRANCH !=~ 'pull/.*'
+only_if: |
+  (
+    $CIRRUS_BRANCH == $CIRRUS_DEFAULT_BRANCH ||
+    $CIRRUS_BRANCH !=~ 'pull/.*'
+  ) &&
+  changesInclude(
+    'src/**',
+    'config/**',
+    'pom.xml',
+    '.ci/**'
+  )
 task:
   name: Windows build
   windows_container:


### PR DESCRIPTION
#17656 

Skip Windows CI for docs-only PRs to reduce Cirrus credit usage

**Description**:
This PR optimizes Cirrus CI usage by preventing heavy Windows builds from running on PRs that only modify documentation or non-code files.

The Windows task now uses Cirrus-native changesInclude() to run only when:
- The default branch is built, or
- A PR modifies source code, build files, or CI logic

This allows Cirrus to decide before VM scheduling, avoiding unnecessary Windows VM allocation and reducing credit consumption, while preserving full validation for all code changes.