### PR TITLE
Issue #17882: Update Javadoc token documentation (28 tokens)

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/api/JavadocCommentsTokenTypes.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/api/JavadocCommentsTokenTypes.java
@@ -110,6 +110,35 @@ public final class JavadocCommentsTokenTypes {
 
     /**
      * General block tag (e.g. {@code @param}, {@code @return}).
+     *
+     * <p>Such Javadoc tag can have these children:</p>
+     * <ol>
+     * <li>{@link #PARAM_BLOCK_TAG}</li>
+     * <li>{@link #RETURN_BLOCK_TAG}</li>
+     * <li>{@link #THROWS_BLOCK_TAG}</li>
+     * </ol>
+     *
+     * <p><b>Example:</b></p>
+     * <pre>{@code * @param value The parameter of method.}</pre>
+     *
+     * <b>Tree:</b>
+     * <pre>{@code
+     * JAVADOC_CONTENT -> JAVADOC_CONTENT
+     * |--LEADING_ASTERISK -> *
+     * |--TEXT ->
+     * `--JAVADOC_BLOCK_TAG -> JAVADOC_BLOCK_TAG
+     *     `--PARAM_BLOCK_TAG -> PARAM_BLOCK_TAG
+     *         |--AT_SIGN -> @
+     *         |--TAG_NAME -> param
+     *         |--TEXT ->
+     *         |--PARAMETER_NAME -> value
+     *         `--DESCRIPTION -> DESCRIPTION
+     *             `--TEXT ->  The parameter of method.
+     * }</pre>
+     *
+     * @see #PARAM_BLOCK_TAG
+     * @see #RETURN_BLOCK_TAG
+     * @see #THROWS_BLOCK_TAG
      */
     public static final int JAVADOC_BLOCK_TAG = JavadocCommentsLexer.JAVADOC_BLOCK_TAG;
 


### PR DESCRIPTION
## Issue Reference

Closes #17882

## Description

This PR adds detailed Javadoc documentation for **JAVADOC_BLOCK_TAG** token in JavadocCommentsTokenTypes.java.

The documentation includes:
- Description of the token's purpose
- List of possible children tokens
- Example Javadoc snippet
- AST tree representation
- @see references to related tokens

## CLI Output

Example input:
```java
* @param value The parameter of method.
```

Command:
```bash
java -jar checkstyle-13.1.0-SNAPSHOT-all.jar -j src/Test.java | sed "s/\[[0-9]\+:[0-9]\+\]//g"
```

Output:
```
JAVADOC_CONTENT -> JAVADOC_CONTENT
|--LEADING_ASTERISK -> *
|--TEXT ->
`--JAVADOC_BLOCK_TAG -> JAVADOC_BLOCK_TAG
    `--PARAM_BLOCK_TAG -> PARAM_BLOCK_TAG
        |--AT_SIGN -> @
        |--TAG_NAME -> param
        |--TEXT ->
        |--PARAMETER_NAME -> value
        `--DESCRIPTION -> DESCRIPTION
            `--TEXT ->  The parameter of method.
```

## Testing

- Local compilation passed
- All CI checks passed (119/119)
