### PR TITLE
Issue #6294: Refactor CommentsIndentationCheck to use single method f…

### DIFF
--- a/config/checker-framework-suppressions/checker-nullness-optional-interning-suppressions.xml
+++ b/config/checker-framework-suppressions/checker-nullness-optional-interning-suppressions.xml
@@ -5191,17 +5191,6 @@
   </checkerFrameworkError>
 
   <checkerFrameworkError unstable="false">
-    <fileName>src/main/java/com/puppycrawl/tools/checkstyle/checks/indentation/CommentsIndentationCheck.java</fileName>
-    <specifier>return</specifier>
-    <message>incompatible types in return.</message>
-    <lineContent>return tokenWhichBeginsTheLine;</lineContent>
-    <details>
-      type of expression: @Initialized @Nullable DetailAST
-      method return type: @Initialized @NonNull DetailAST
-    </details>
-  </checkerFrameworkError>
-
-  <checkerFrameworkError unstable="false">
     <fileName>src/main/java/com/puppycrawl/tools/checkstyle/checks/indentation/DetailAstSet.java</fileName>
     <specifier>return</specifier>
     <message>incompatible types in return.</message>

--- a/config/pitest-suppressions/pitest-indentation-suppressions.xml
+++ b/config/pitest-suppressions/pitest-indentation-suppressions.xml
@@ -28,42 +28,6 @@
   </mutation>
 
   <mutation unstable="false">
-    <sourceFile>CommentsIndentationCheck.java</sourceFile>
-    <mutatedClass>com.puppycrawl.tools.checkstyle.checks.indentation.CommentsIndentationCheck</mutatedClass>
-    <mutatedMethod>findTokenWhichBeginsTheLine</mutatedMethod>
-    <mutator>org.pitest.mutationtest.engine.gregor.mutators.NegateConditionalsMutator</mutator>
-    <description>negated conditional</description>
-    <lineContent>if (isUsingOfObjectReferenceToInvokeMethod(root)) {</lineContent>
-  </mutation>
-
-  <mutation unstable="false">
-    <sourceFile>CommentsIndentationCheck.java</sourceFile>
-    <mutatedClass>com.puppycrawl.tools.checkstyle.checks.indentation.CommentsIndentationCheck</mutatedClass>
-    <mutatedMethod>getPrevStatementWhenCommentIsUnderCase</mutatedMethod>
-    <mutator>org.pitest.mutationtest.engine.gregor.mutators.NegateConditionalsMutator</mutator>
-    <description>negated conditional</description>
-    <lineContent>if (isUsingOfObjectReferenceToInvokeMethod(blockBody)) {</lineContent>
-  </mutation>
-
-  <mutation unstable="false">
-    <sourceFile>CommentsIndentationCheck.java</sourceFile>
-    <mutatedClass>com.puppycrawl.tools.checkstyle.checks.indentation.CommentsIndentationCheck</mutatedClass>
-    <mutatedMethod>isUsingOfObjectReferenceToInvokeMethod</mutatedMethod>
-    <mutator>org.pitest.mutationtest.engine.gregor.mutators.NegateConditionalsMutator</mutator>
-    <description>negated conditional</description>
-    <lineContent>&amp;&amp; root.getFirstChild().getFirstChild().getFirstChild().getNextSibling() != null;</lineContent>
-  </mutation>
-
-  <mutation unstable="false">
-    <sourceFile>CommentsIndentationCheck.java</sourceFile>
-    <mutatedClass>com.puppycrawl.tools.checkstyle.checks.indentation.CommentsIndentationCheck</mutatedClass>
-    <mutatedMethod>isUsingOfObjectReferenceToInvokeMethod</mutatedMethod>
-    <mutator>org.pitest.mutationtest.engine.gregor.mutators.returns.BooleanTrueReturnValsMutator</mutator>
-    <description>replaced boolean return with true for com/puppycrawl/tools/checkstyle/checks/indentation/CommentsIndentationCheck::isUsingOfObjectReferenceToInvokeMethod</description>
-    <lineContent>return root.getFirstChild().getFirstChild().getFirstChild() != null</lineContent>
-  </mutation>
-
-  <mutation unstable="false">
     <sourceFile>HandlerFactory.java</sourceFile>
     <mutatedClass>com.puppycrawl.tools.checkstyle.checks.indentation.HandlerFactory</mutatedClass>
     <mutatedMethod>clearCreatedHandlers</mutatedMethod>

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/indentation/CommentsIndentationCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/indentation/CommentsIndentationCheck.java
@@ -626,13 +626,12 @@ public class CommentsIndentationCheck extends AbstractCheck {
             previousStatement = getPrevStatementFromSwitchBlock(comment);
         }
         final DetailAST tokenWhichBeginsTheLine;
-        if (root.getType() == TokenTypes.EXPR
-                && root.getFirstChild().getFirstChild() != null) {
+        if (root.getType() == TokenTypes.EXPR) {
             if (root.getFirstChild().getType() == TokenTypes.LITERAL_NEW) {
                 tokenWhichBeginsTheLine = root.getFirstChild();
             }
             else {
-                tokenWhichBeginsTheLine = findTokenWhichBeginsTheLine(root);
+                tokenWhichBeginsTheLine = findStartTokenOfMethodCallChain(root);
             }
         }
         else if (root.getType() == TokenTypes.PLUS) {
@@ -647,34 +646,6 @@ public class CommentsIndentationCheck extends AbstractCheck {
             previousStatement = tokenWhichBeginsTheLine;
         }
         return previousStatement;
-    }
-
-    /**
-     * Finds a token which begins the line.
-     *
-     * @param root root token of the line.
-     * @return token which begins the line.
-     */
-    private static DetailAST findTokenWhichBeginsTheLine(DetailAST root) {
-        final DetailAST tokenWhichBeginsTheLine;
-        if (isUsingOfObjectReferenceToInvokeMethod(root)) {
-            tokenWhichBeginsTheLine = findStartTokenOfMethodCallChain(root);
-        }
-        else {
-            tokenWhichBeginsTheLine = root.getFirstChild().findFirstToken(TokenTypes.IDENT);
-        }
-        return tokenWhichBeginsTheLine;
-    }
-
-    /**
-     * Checks whether there is a use of an object reference to invoke an object's method on line.
-     *
-     * @param root root token of the line.
-     * @return true if there is a use of an object reference to invoke an object's method on line.
-     */
-    private static boolean isUsingOfObjectReferenceToInvokeMethod(DetailAST root) {
-        return root.getFirstChild().getFirstChild().getFirstChild() != null
-            && root.getFirstChild().getFirstChild().getFirstChild().getNextSibling() != null;
     }
 
     /**
@@ -830,12 +801,7 @@ public class CommentsIndentationCheck extends AbstractCheck {
                 blockBody = blockBody.getPreviousSibling();
             }
             if (blockBody.getType() == TokenTypes.EXPR) {
-                if (isUsingOfObjectReferenceToInvokeMethod(blockBody)) {
-                    prevStmt = findStartTokenOfMethodCallChain(blockBody);
-                }
-                else {
-                    prevStmt = blockBody.getFirstChild().getFirstChild();
-                }
+                prevStmt = findStartTokenOfMethodCallChain(blockBody);
             }
             else {
                 if (blockBody.getType() == TokenTypes.SLIST) {

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/indentation/CommentsIndentationCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/indentation/CommentsIndentationCheckTest.java
@@ -414,4 +414,10 @@ public class CommentsIndentationCheckTest extends AbstractModuleTestSupport {
             expected);
     }
 
+    @Test
+    public void testStartOfMethodCallChainNpe() throws Exception {
+        final String[] expected = CommonUtil.EMPTY_STRING_ARRAY;
+        verifyWithInlineConfigParser(
+                getPath("InputCommentsIndentationStartOfMethodCallChainNpe.java"), expected);
+    }
 }

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/indentation/commentsindentation/InputCommentsIndentationStartOfMethodCallChainNpe.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/indentation/commentsindentation/InputCommentsIndentationStartOfMethodCallChainNpe.java
@@ -1,0 +1,17 @@
+/*
+CommentsIndentation
+tokens = (default)SINGLE_LINE_COMMENT, BLOCK_COMMENT_BEGIN
+
+
+*/
+
+package com.puppycrawl.tools.checkstyle.checks.indentation.commentsindentation;
+
+public class InputCommentsIndentationStartOfMethodCallChainNpe {
+    void foo() {
+        int i = 0;
+        ++
+        i;
+        // Comment triggers check
+    }
+}


### PR DESCRIPTION
Issue #6294:

Removed isUsingOfObjectReferenceToInvokeMethod and findTokenWhichBeginsTheLine methods.
findStartTokenOfMethodCallChain handles all cases correctly, making conditional logic unnecessary.