### PR TITLE
Issue #18517: XdocsExamplesAstConsistencyTest should validate literal…

### DIFF
--- a/src/test/java/com/puppycrawl/tools/checkstyle/internal/XdocsExamplesAstConsistencyTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/internal/XdocsExamplesAstConsistencyTest.java
@@ -41,6 +41,7 @@ import com.puppycrawl.tools.checkstyle.api.DetailAST;
 import com.puppycrawl.tools.checkstyle.api.FileContents;
 import com.puppycrawl.tools.checkstyle.api.FileText;
 import com.puppycrawl.tools.checkstyle.api.TokenTypes;
+import com.puppycrawl.tools.checkstyle.utils.TokenUtil;
 
 /**
  * Ensures xdocs Java examples for the same check differ only by comments.
@@ -237,6 +238,7 @@ public class XdocsExamplesAstConsistencyTest {
             "checks/regexp/regexpsingleline/Example2",
             "checks/regexp/regexpsingleline/Example3",
             "checks/regexp/regexpsingleline/Example4",
+            "checks/regexp/regexpmultiline/Example5",
             "checks/sizes/lambdabodylength/Example2",
             "checks/sizes/linelength/Example6",
             "checks/trailingcomment/Example2",
@@ -305,10 +307,12 @@ public class XdocsExamplesAstConsistencyTest {
             "filters/suppresswithnearbycommentfilter/Example6",
             "filters/suppresswithnearbycommentfilter/Example7",
             "filters/suppresswithnearbycommentfilter/Example8",
+            "filters/suppresswithnearbytextfilter/Example2",
             "filters/suppresswithnearbytextfilter/Example3",
             "filters/suppresswithnearbytextfilter/Example4",
             "filters/suppresswithnearbytextfilter/Example5",
             "filters/suppresswithnearbytextfilter/Example6",
+            "filters/suppresswithnearbytextfilter/Example7",
             "filters/suppresswithnearbytextfilter/Example8",
             "filters/suppresswithnearbytextfilter/Example9",
             "filters/suppresswithplaintextcommentfilter/Example5",
@@ -347,7 +351,7 @@ public class XdocsExamplesAstConsistencyTest {
 
             builder.append("Found ")
                     .append(violations.size())
-                    .append("example files with AST mismatches.\n\n");
+                    .append(" example files with AST mismatches.\n\n");
 
             for (String violation : violations) {
                 builder.append(violation)
@@ -355,7 +359,7 @@ public class XdocsExamplesAstConsistencyTest {
             }
 
             builder.append("If these examples have different code intent, "
-                    + "add them to INDEPENDENT_EXAMPLES:\n");
+                    + "add them to SUPPRESSED_EXAMPLES:\n");
 
             for (String violation : violations) {
                 final String pattern = extractIndependentPattern(violation);
@@ -723,7 +727,7 @@ public class XdocsExamplesAstConsistencyTest {
             result = null;
         }
         else {
-            final StructuralAstNode node = new StructuralAstNode(ast.getType());
+            final StructuralAstNode node = new StructuralAstNode(ast.getType(), ast.getText());
 
             for (DetailAST child = ast.getFirstChild();
                  child != null;
@@ -755,13 +759,37 @@ public class XdocsExamplesAstConsistencyTest {
     /**
      * Represents a structural AST node without comments or source positions.
      * This allows for pure structural comparison between example files.
+     * Now includes literal text values for semantic comparison.
      */
     private static final class StructuralAstNode {
         private final int type;
+        private final String text;
         private final List<StructuralAstNode> children = new ArrayList<>();
 
-        private StructuralAstNode(int type) {
+        private StructuralAstNode(int type, String text) {
             this.type = type;
+            if (isLiteralToken(type)) {
+                this.text = text;
+            }
+            else {
+                this.text = null;
+            }
+        }
+
+        /**
+         * Checks if a token type represents a literal that should have its text compared.
+         *
+         * @param tokenType the token type
+         * @return true if the token represents a literal with semantic value
+         */
+        private static boolean isLiteralToken(int tokenType) {
+            return switch (tokenType) {
+                case TokenTypes.NUM_INT, TokenTypes.NUM_LONG, TokenTypes.NUM_FLOAT,
+                     TokenTypes.NUM_DOUBLE, TokenTypes.STRING_LITERAL,
+                     TokenTypes.CHAR_LITERAL, TokenTypes.LITERAL_TRUE,
+                     TokenTypes.LITERAL_FALSE, TokenTypes.LITERAL_NULL -> true;
+                default -> false;
+            };
         }
 
         private void addChild(StructuralAstNode child) {
@@ -772,8 +800,10 @@ public class XdocsExamplesAstConsistencyTest {
         public boolean equals(Object obj) {
             final boolean result;
             if (obj instanceof StructuralAstNode other) {
-                final boolean childrenEqual = children.equals(other.children);
-                result = type == other.type && childrenEqual;
+                final boolean typeMatch = type == other.type;
+                final boolean textMatch = Objects.equals(text, other.text);
+                final boolean childrenMatch = children.equals(other.children);
+                result = typeMatch && textMatch && childrenMatch;
             }
             else {
                 result = false;
@@ -783,7 +813,27 @@ public class XdocsExamplesAstConsistencyTest {
 
         @Override
         public int hashCode() {
-            return Objects.hash(type, children);
+            return Objects.hash(type, text, children);
+        }
+
+        @Override
+        public String toString() {
+            final StringBuilder sb = new StringBuilder(128);
+            sb.append("StructuralAstNode{type=");
+            try {
+                sb.append(TokenUtil.getTokenName(type));
+            }
+            catch (IllegalArgumentException exception) {
+                sb.append(type);
+            }
+            if (text != null) {
+                sb.append(", text='").append(text).append('\'');
+            }
+            if (!children.isEmpty()) {
+                sb.append(", children=").append(children.size());
+            }
+            sb.append('}');
+            return sb.toString();
         }
     }
 }


### PR DESCRIPTION
#18517 

Key Changes Summary:

`StructuralAstNode `constructor - Now accepts both type and text parameters
`isLiteralToken()` method - New method to identify tokens with semantic literal values 
`equals()` method - Enhanced to compare text values for literals =
`hashCode()` method - Includes text in hash calculation
`toString()` method - Added for better debugging output 
`toStructuralAst()` method - Modified to pass text to constructor (line 621)

What This Fixes:
The enhanced test will now catch cases like:

```
for ( ; i < 1; i++ ) vs for ( ; i < 2; i++ ) 
int x = 5 vs int x = 10 
String s = "hello" vs String s = "world" 
if (true) vs if (false)
``` 

The test remains flexible for:
Different variable names (identifiers are not compared)
Different whitespace/formatting
Different comments
Helper code outside xdoc markers


![Screenshot 2026-01-07 000226](https://github.com/user-attachments/assets/31e98780-deb6-4c64-b994-3d7395906846)
<img width="840" height="478" alt="image" src="https://github.com/user-attachments/assets/98d00d32-2975-4be8-9200-71c12ca1cecd" />

