### PR TITLE
Issue #12556: Cleaning up deprecated createClassPath

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/ant/CheckstyleAntTask.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/ant/CheckstyleAntTask.java
@@ -195,20 +195,6 @@ public class CheckstyleAntTask extends Task {
     }
 
     /**
-     * Creates classpath.
-     *
-     * @return a created path for locating classes
-     * @deprecated left in implementation until #12556 only to allow users to migrate to new gradle
-     *     plugins. This method will be removed in Checkstyle 11.x.x .
-     * @noinspection DeprecatedIsStillUsed
-     * @noinspectionreason DeprecatedIsStillUsed - until #12556
-     */
-    @Deprecated(since = "10.7.0")
-    public org.apache.tools.ant.types.Path createClasspath() {
-        return new org.apache.tools.ant.types.Path(getProject());
-    }
-
-    /**
      * Sets file to be checked.
      *
      * @param file the file to be checked

--- a/src/test/java/com/puppycrawl/tools/checkstyle/ant/CheckstyleAntTaskTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/ant/CheckstyleAntTaskTest.java
@@ -838,24 +838,6 @@ public class CheckstyleAntTaskTest extends AbstractPathTestSupport {
                 .isInstanceOf(SarifLogger.class);
     }
 
-    /**
-     * Testing deprecated method.
-     */
-    @Test
-    public void testCreateClasspath() {
-        final CheckstyleAntTask antTask = new CheckstyleAntTask();
-        final Project mockProject = new Project();
-        antTask.setProject(mockProject);
-
-        assertWithMessage("Classpath should belong to the expected project")
-                .that(antTask.createClasspath().getProject())
-                .isEqualTo(mockProject);
-
-        assertWithMessage("Invalid classpath")
-                .that(antTask.createClasspath().toString())
-                .isEmpty();
-    }
-
     @Test
     public void testDestroyed() throws IOException {
         TestRootModuleChecker.reset();


### PR DESCRIPTION
Issue #12556: Cleaning up deprecated createClassPath

Issue #12556 had determined that deprecated method createClassPath() needs removal. 
The relevant test case and method have been removed. 