### PR TITLE
Website: copy heading anchor link to clipboard fixes #18558

### DIFF
--- a/config/jsoref-spellchecker/whitelist.words
+++ b/config/jsoref-spellchecker/whitelist.words
@@ -764,6 +764,7 @@ kazgroup
 kbd
 kclee
 KDoc
+keyframes
 keyname
 keyscan
 konstantinos

--- a/src/site/resources/css/site.css
+++ b/src/site/resources/css/site.css
@@ -33,6 +33,41 @@ h4 {
   border: ridge;
 }
 
+.anchor-feedback {
+    position: fixed;
+    top: 20px;
+    right: 20px;
+    background-color: #007bff;
+    color: white;
+    padding: 10px 20px;
+    border-radius: 4px;
+    font-size: 14px;
+    font-weight: 500;
+    box-shadow: 0 4px 6px rgba(0, 0, 0, 0.1);
+    z-index: 9999;
+    opacity: 0;
+    animation: fadeInOut 2s ease-in-out;
+}
+
+@keyframes fadeInOut {
+    0% {
+        opacity: 0;
+        transform: translateY(-10px);
+    }
+    15% {
+        opacity: 1;
+        transform: translateY(0);
+    }
+    85% {
+        opacity: 1;
+        transform: translateY(0);
+    }
+    100% {
+        opacity: 0;
+        transform: translateY(-10px);
+    }
+}
+
 .container-fluid {
   padding-left: 15px;
   padding-right: 15px;

--- a/src/site/resources/js/anchors.js
+++ b/src/site/resources/js/anchors.js
@@ -1,10 +1,57 @@
 /*jslint browser: true*/
+/*jslint es6: true */
+/*jshint esversion: 6 */
 /*global window */
 (function () {
     "use strict";
+
+    function showCopiedFeedback(element) {
+        const feedback = document.createElement("div");
+        feedback.textContent = "Copied!";
+        feedback.className = "anchor-feedback";
+
+        document.body.appendChild(feedback);
+
+        setTimeout(function () {
+            feedback.remove();
+        }, 2000);
+    }
+
+    function createAnchor(parentElement, link, name, relativePath, feedbackTarget) {
+        const a = document.createElement("a");
+        a.setAttribute("href", link);
+
+        a.addEventListener("click", function (event) {
+            event.preventDefault();
+
+            if (navigator.clipboard) {
+                navigator.clipboard.writeText(link).then(function () {
+                    showCopiedFeedback(feedbackTarget);
+                }).catch(function (err) {
+                    console.warn("Failed to copy link to clipboard:", err);
+                });
+            } else {
+                console.warn("Clipboard API not available");
+            }
+
+            // Update URL without page jump
+            history.replaceState(null, "", "#" + name);
+        });
+
+        const image = document.createElement("img");
+        image.setAttribute("src", relativePath + "/images/anchor.png");
+
+        const anchor = document.createElement("div");
+        anchor.className = "anchor";
+
+        a.appendChild(image);
+        anchor.appendChild(a);
+        parentElement.appendChild(anchor);
+    }
+
     window.addEventListener("load", function () {
-        var url = window.location.href;
-        var position = url.indexOf("#");
+        let url = window.location.href;
+        const position = url.indexOf("#");
 
         if (position !== -1) {
             url = url.substring(0, position);
@@ -12,73 +59,44 @@
 
         const scriptElement = document.querySelector('script[src*="anchors.js"]');
         const scriptElementSrc = scriptElement.attributes.src.textContent;
-        const relativePath = scriptElementSrc.replace(/\/js\/anchors.js/, '');
+        const relativePath = scriptElementSrc.replace(/\/js\/anchors.js/, "");
 
-        var anchors = document.querySelectorAll("h1, h2");
+        // h1 / h2
+        const anchors = document.querySelectorAll("h1, h2");
         [].forEach.call(anchors, function (anchorItem) {
 
             if (anchorItem.closest("#bannerRight") || anchorItem.closest("#bannerLeft")) {
                 return;
             }
 
-            var name = anchorItem.previousSibling.previousElementSibling.id;
-            var link = "" + url + "#" + name + "";
+            const name = anchorItem.previousSibling.previousElementSibling.id;
+            const link = url + "#" + name;
 
-            var a = document.createElement("a");
-            a.setAttribute("href", link);
-
-            var image = document.createElement("img");
-            image.setAttribute("src", `${relativePath}/images/anchor.png`);
-
-            var anchor = document.createElement("div");
-            anchor.className = "anchor";
-
-            a.appendChild(image);
-            anchor.appendChild(a);
-            anchorItem.appendChild(anchor);
+            createAnchor(anchorItem, link, name, relativePath, anchorItem);
         });
 
-        var anchorsSubSection = document.getElementsByTagName("h3");
+        // h3
+        const anchorsSubSection = document.getElementsByTagName("h3");
         [].forEach.call(anchorsSubSection, function (anchorItem) {
-            var name;
+            let name;
             if (anchorItem.parentNode.id) {
                 name = anchorItem.parentNode.id;
             } else {
                 name = anchorItem.childNodes[0].name;
             }
-            var link = "" + url + "#" + name + "";
 
-            var a = document.createElement("a");
-            a.setAttribute("href", link);
-
-            var image = document.createElement("img");
-            image.setAttribute("src", `${relativePath}/images/anchor.png`);
-
-            var anchor = document.createElement("div");
-            anchor.className = "anchor";
-
-            a.appendChild(image);
-            anchor.appendChild(a);
-            anchorItem.appendChild(anchor);
+            const link = url + "#" + name;
+            createAnchor(anchorItem, link, name, relativePath, anchorItem);
         });
 
+        // Example sections
         const exampleDivs = document.querySelectorAll('p[id^="Example"]');
         [].forEach.call(exampleDivs, function (exampleDiv) {
             const name = exampleDiv.id;
-            const link = "" + url + "#" + name + "";
+            const link = url + "#" + name;
 
-            const a = document.createElement("a");
-            a.setAttribute("href", link);
-
-            const image = document.createElement("img");
-            image.setAttribute("src", `${relativePath}/images/anchor.png`);
-
-            const anchor = document.createElement("div");
-            anchor.className = "anchor";
-
-            a.appendChild(image);
-            anchor.appendChild(a);
-            exampleDiv.appendChild(anchor);
+            createAnchor(exampleDiv, link, name, relativePath, exampleDiv);
         });
     });
+
 }());


### PR DESCRIPTION
Issue #18558 
On the Checkstyle website, headings display an anchor icon that links to the corresponding section. Currently, clicking this icon does not copy the section URL, making it inconvenient to share direct links to specific documentation sections.

This change enhances the existing anchor behavior so that clicking the anchor icon copies the full section URL (including the fragment identifier) to the clipboard. 

This behavior aligns Checkstyle’s documentation UX with common documentation sites such as GitHub Docs and MDN, improving usability when referencing specific rules or configuration sections.

Reference video:

https://github.com/user-attachments/assets/478c7e00-1c25-4a25-aa5b-e41fd4ff795f


@romani please review this PR
fixes #18558 