### PR TITLE
Issue #12769: Fixed false negative for OneStatementPerLineCheck

### DIFF
--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/coding/OneStatementPerLineCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/coding/OneStatementPerLineCheckTest.java
@@ -190,4 +190,16 @@ public class OneStatementPerLineCheckTest extends AbstractModuleTestSupport {
         final List<String> expectedSecondInput = List.of(CommonUtil.EMPTY_STRING_ARRAY);
         verifyWithInlineConfigParser(file1, file2, expectedFirstInput, expectedSecondInput);
     }
+
+    @Test
+    public void testEmptyStatementWithAnnotation() throws Exception {
+        final String[] expected = {
+            "10:5: " + getCheckMessage(MSG_KEY),
+            "13:5: " + getCheckMessage(MSG_KEY),
+        };
+
+        verifyWithInlineConfigParser(
+                getPath("InputOneStatementPerLineEmptyStatementWithAnnotation.java"),
+                expected);
+    }
 }

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/onestatementperline/InputOneStatementPerLineEmptyStatementWithAnnotation.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/onestatementperline/InputOneStatementPerLineEmptyStatementWithAnnotation.java
@@ -1,0 +1,17 @@
+/*
+OneStatementPerLine
+
+*/
+
+package com.puppycrawl.tools.checkstyle.checks.coding.onestatementperline;
+
+public class InputOneStatementPerLineEmptyStatementWithAnnotation {
+    String str1 = "123";
+    ; // violation 'Only one statement per line allowed.'
+    @Deprecated
+    String str2 = "123";
+    ;  // violation 'Only one statement per line allowed.'
+
+    /** Valid javadoc. */
+    @Deprecated int field4;
+}


### PR DESCRIPTION
Issue: #12769

without annotation
```
public class Main {
    String str1 = "123";
}
```
```
COMPILATION_UNIT -> COMPILATION_UNIT [1:0]
`--CLASS_DEF -> CLASS_DEF [1:0]
    |--MODIFIERS -> MODIFIERS [1:0]
    |   `--LITERAL_PUBLIC -> public [1:0]
    |--LITERAL_CLASS -> class [1:7]
    |--IDENT -> Main [1:13]
    `--OBJBLOCK -> OBJBLOCK [1:18]
        |--LCURLY -> { [1:18]
        |--VARIABLE_DEF -> VARIABLE_DEF [2:4]
        |   |--MODIFIERS -> MODIFIERS [2:4]
        |   |--TYPE -> TYPE [2:4]
        |   |   `--IDENT -> String [2:4]
        |   |--IDENT -> str1 [2:11]
        |   |--ASSIGN -> = [2:16]
        |   |   `--EXPR -> EXPR [2:18]
        |   |       `--STRING_LITERAL -> "123" [2:18]
        |   `--SEMI -> ; [2:23]
        `--RCURLY -> } [3:0]
```

with annotation
```
public class Main {
    @MyAnnotation
    String str1 = "123";
}
```
```
`--CLASS_DEF -> CLASS_DEF [1:0]
    |--MODIFIERS -> MODIFIERS [1:0]
    |   `--LITERAL_PUBLIC -> public [1:0]
    |--LITERAL_CLASS -> class [1:7]
    |--IDENT -> Main [1:13]
    `--OBJBLOCK -> OBJBLOCK [1:18]
        |--LCURLY -> { [1:18]
        |--VARIABLE_DEF -> VARIABLE_DEF [2:4]
        |   |--MODIFIERS -> MODIFIERS [2:4]
        |   |   `--ANNOTATION -> ANNOTATION [2:4]
        |   |       |--AT -> @ [2:4]
        |   |       `--IDENT -> MyAnnotation [2:5]
        |   |--TYPE -> TYPE [3:4]
        |   |   `--IDENT -> String [3:4]
        |   |--IDENT -> str1 [3:11]
        |   |--ASSIGN -> = [3:16]
        |   |   `--EXPR -> EXPR [3:18]
        |   |       `--STRING_LITERAL -> "123" [3:18]
        |   `--SEMI -> ; [3:23]
        `--RCURLY -> } [4:0]
```

due annotation line number of VARIABLE_DEF is 1 less than normal