### PR TITLE
Issue #18435: Fix AST consistency across MethodNameCheck xdocs examples

### DIFF
--- a/src/site/xdoc/checks/naming/methodname.xml
+++ b/src/site/xdoc/checks/naming/methodname.xml
@@ -93,9 +93,10 @@
         <div class="wrapper"><pre class="prettyprint"><code class="language-java">
 class Example1 {
   public void method1() {}
-  protected void method2() {}
+  protected void Method2() {} // violation 'Name 'Method2' must match pattern'
   private void Method3() {} // violation 'Name 'Method3' must match pattern'
   public void Method4() {} // violation 'Name 'Method4' must match pattern'
+  void Method5() {} // violation 'Name 'Method5' must match pattern'
 }
 </code></pre></div><hr class="example-separator"/>
         <p id="Example2-config">
@@ -115,7 +116,10 @@ class Example1 {
         <div class="wrapper"><pre class="prettyprint"><code class="language-java">
 class Example2 {
   public void method1() {}
-  public void Method2() {} // violation 'Name 'Method2' must match pattern'
+  protected void Method2() {} // violation 'Name 'Method2' must match pattern'
+  private void Method3() {} // violation 'Name 'Method3' must match pattern'
+  public void Method4() {} // violation 'Name 'Method4' must match pattern'
+  void Method5() {} // violation 'Name 'Method5' must match pattern'
 }
 </code></pre></div><hr class="example-separator"/>
         <p id="Example3-config">
@@ -178,10 +182,11 @@ class Example4 {
         <p id="Example5-code">Code Example:</p>
         <div class="wrapper"><pre class="prettyprint"><code class="language-java">
 class Example5 {
-  public void Method1() {}
-  protected void Method2() {}
+  public void method1() {}
+  protected void Method2() {} // ok because, 'Property 'applyToProtected' is false'
   private void Method3() {} // violation 'Name 'Method3' must match pattern'
-  void Method4() {} // violation 'Name 'Method4' must match pattern'
+  public void Method4() {} // ok because, 'Property 'applyToPublic' is false'
+  void Method5() {} // violation 'Name 'Method5' must match pattern'
 }
 </code></pre></div>
       <hr class="example-separator"/>
@@ -201,10 +206,11 @@ class Example5 {
       <p id="Example6-code">Code Example:</p>
       <div class="wrapper"><pre class="prettyprint"><code class="language-java">
 class Example6 {
-  public void Method1() {} // violation 'Name 'Method1' must match pattern'
+  public void method1() {}
   protected void Method2() {} // violation 'Name 'Method2' must match pattern'
   private void Method3() {}
-  void Method4() {} // violation 'Name 'Method4' must match pattern'
+  public void Method4() {} // violation 'Name 'Method4' must match pattern'
+  void Method5() {} // violation 'Name 'Method5' must match pattern'
 }
 </code></pre></div><hr class="example-separator"/>
       <p id="Example7-config">
@@ -223,10 +229,11 @@ class Example6 {
       <p id="Example7-code">Code Example:</p>
       <div class="wrapper"><pre class="prettyprint"><code class="language-java">
 class Example7 {
-  public void Method1() {} // violation 'Name 'Method1' must match pattern'
+  public void method1() {}
   protected void Method2() {} // violation 'Name 'Method2' must match pattern'
   private void Method3() {} // violation 'Name 'Method3' must match pattern'
-  void Method4() {}
+  public void Method4() {} // violation 'Name 'Method4' must match pattern'
+  void Method5() {}  // ok because , 'Property 'applyToPackage' is set to false'
 }
 </code></pre></div>
       </subsection>

--- a/src/test/java/com/puppycrawl/tools/checkstyle/internal/XdocsExamplesAstConsistencyTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/internal/XdocsExamplesAstConsistencyTest.java
@@ -207,12 +207,6 @@ public class XdocsExamplesAstConsistencyTest {
             "checks/naming/localvariablename/Example5",
             "checks/naming/membername/Example2",
             "checks/naming/membername/Example3",
-            "checks/naming/methodname/Example2",
-            "checks/naming/methodname/Example3",
-            "checks/naming/methodname/Example4",
-            "checks/naming/methodname/Example5",
-            "checks/naming/methodname/Example6",
-            "checks/naming/methodname/Example7",
             "checks/naming/parametername/Example2",
             "checks/naming/parametername/Example3",
             "checks/naming/parametername/Example4",
@@ -319,8 +313,11 @@ public class XdocsExamplesAstConsistencyTest {
             "filters/suppresswithplaintextcommentfilter/Example5",
             "filters/suppresswithplaintextcommentfilter/Example9",
             // No properties in module, multiple very different examples to ease reading
-            "checks/annotation/missingoverrideonrecordaccessor/Example2"
-    );
+            "checks/annotation/missingoverrideonrecordaccessor/Example2",
+            // contains ExampleX constructors
+            "checks/naming/methodname/Example3",
+            "checks/naming/methodname/Example4"
+            );
 
     /**
      * Tests that examples with the same code structure maintain consistency.

--- a/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/checks/naming/MethodNameCheckExamplesTest.java
+++ b/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/checks/naming/MethodNameCheckExamplesTest.java
@@ -35,8 +35,10 @@ public class MethodNameCheckExamplesTest extends AbstractExamplesModuleTestSuppo
     @Test
     public void testExample1() throws Exception {
         final String[] expected = {
-            "15:16: " + getCheckMessage(MSG_INVALID_PATTERN, "Method3", "^[a-z][a-zA-Z0-9]*$"),
-            "16:15: " + getCheckMessage(MSG_INVALID_PATTERN, "Method4", "^[a-z][a-zA-Z0-9]*$"),
+            "18:18: " + getCheckMessage(MSG_INVALID_PATTERN, "Method2", "^[a-z][a-zA-Z0-9]*$"),
+            "19:16: " + getCheckMessage(MSG_INVALID_PATTERN, "Method3", "^[a-z][a-zA-Z0-9]*$"),
+            "20:15: " + getCheckMessage(MSG_INVALID_PATTERN, "Method4", "^[a-z][a-zA-Z0-9]*$"),
+            "21:8: " + getCheckMessage(MSG_INVALID_PATTERN, "Method5", "^[a-z][a-zA-Z0-9]*$"),
         };
 
         verifyWithInlineConfigParser(getPath("Example1.java"), expected);
@@ -45,7 +47,10 @@ public class MethodNameCheckExamplesTest extends AbstractExamplesModuleTestSuppo
     @Test
     public void testExample2() throws Exception {
         final String[] expected = {
-            "16:15: " + getCheckMessage(MSG_INVALID_PATTERN, "Method2", "^[a-z](_?[a-zA-Z0-9]+)*$"),
+            "18:18: " + getCheckMessage(MSG_INVALID_PATTERN, "Method2", "^[a-z](_?[a-zA-Z0-9]+)*$"),
+            "19:16: " + getCheckMessage(MSG_INVALID_PATTERN, "Method3", "^[a-z](_?[a-zA-Z0-9]+)*$"),
+            "20:15: " + getCheckMessage(MSG_INVALID_PATTERN, "Method4", "^[a-z](_?[a-zA-Z0-9]+)*$"),
+            "21:8: " + getCheckMessage(MSG_INVALID_PATTERN, "Method5", "^[a-z](_?[a-zA-Z0-9]+)*$"),
         };
 
         verifyWithInlineConfigParser(getPath("Example2.java"), expected);
@@ -73,7 +78,7 @@ public class MethodNameCheckExamplesTest extends AbstractExamplesModuleTestSuppo
     public void testExample5() throws Exception {
         final String[] expected = {
             "19:16: " + getCheckMessage(MSG_INVALID_PATTERN, "Method3", "^[a-z](_?[a-zA-Z0-9]+)*$"),
-            "20:8: " + getCheckMessage(MSG_INVALID_PATTERN, "Method4", "^[a-z](_?[a-zA-Z0-9]+)*$"),
+            "21:8: " + getCheckMessage(MSG_INVALID_PATTERN, "Method5", "^[a-z](_?[a-zA-Z0-9]+)*$"),
         };
 
         verifyWithInlineConfigParser(getPath("Example5.java"), expected);
@@ -82,9 +87,9 @@ public class MethodNameCheckExamplesTest extends AbstractExamplesModuleTestSuppo
     @Test
     public void testExample6() throws Exception {
         final String[] expected = {
-            "16:15: " + getCheckMessage(MSG_INVALID_PATTERN, "Method1", "^[a-z](_?[a-zA-Z0-9]+)*$"),
-            "17:18: " + getCheckMessage(MSG_INVALID_PATTERN, "Method2", "^[a-z](_?[a-zA-Z0-9]+)*$"),
-            "19:8: " + getCheckMessage(MSG_INVALID_PATTERN, "Method4", "^[a-z](_?[a-zA-Z0-9]+)*$"),
+            "18:18: " + getCheckMessage(MSG_INVALID_PATTERN, "Method2", "^[a-z](_?[a-zA-Z0-9]+)*$"),
+            "20:15: " + getCheckMessage(MSG_INVALID_PATTERN, "Method4", "^[a-z](_?[a-zA-Z0-9]+)*$"),
+            "21:8: " + getCheckMessage(MSG_INVALID_PATTERN, "Method5", "^[a-z](_?[a-zA-Z0-9]+)*$"),
         };
 
         verifyWithInlineConfigParser(getPath("Example6.java"), expected);
@@ -93,9 +98,9 @@ public class MethodNameCheckExamplesTest extends AbstractExamplesModuleTestSuppo
     @Test
     public void testExample7() throws Exception {
         final String[] expected = {
-            "16:15: " + getCheckMessage(MSG_INVALID_PATTERN, "Method1", "^[a-z](_?[a-zA-Z0-9]+)*$"),
-            "17:18: " + getCheckMessage(MSG_INVALID_PATTERN, "Method2", "^[a-z](_?[a-zA-Z0-9]+)*$"),
-            "18:16: " + getCheckMessage(MSG_INVALID_PATTERN, "Method3", "^[a-z](_?[a-zA-Z0-9]+)*$"),
+            "18:18: " + getCheckMessage(MSG_INVALID_PATTERN, "Method2", "^[a-z](_?[a-zA-Z0-9]+)*$"),
+            "19:16: " + getCheckMessage(MSG_INVALID_PATTERN, "Method3", "^[a-z](_?[a-zA-Z0-9]+)*$"),
+            "20:15: " + getCheckMessage(MSG_INVALID_PATTERN, "Method4", "^[a-z](_?[a-zA-Z0-9]+)*$"),
         };
 
         verifyWithInlineConfigParser(getPath("Example7.java"), expected);

--- a/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/naming/methodname/Example1.java
+++ b/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/naming/methodname/Example1.java
@@ -6,13 +6,18 @@
 </module>
 */
 
+
+
+
+
 package com.puppycrawl.tools.checkstyle.checks.naming.methodname;
 
 // xdoc section -- start
 class Example1 {
   public void method1() {}
-  protected void method2() {}
+  protected void Method2() {} // violation 'Name 'Method2' must match pattern'
   private void Method3() {} // violation 'Name 'Method3' must match pattern'
   public void Method4() {} // violation 'Name 'Method4' must match pattern'
+  void Method5() {} // violation 'Name 'Method5' must match pattern'
 }
 // xdoc section -- end

--- a/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/naming/methodname/Example2.java
+++ b/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/naming/methodname/Example2.java
@@ -8,11 +8,16 @@
 </module>
 */
 
+
+
 package com.puppycrawl.tools.checkstyle.checks.naming.methodname;
 
 // xdoc section -- start
 class Example2 {
   public void method1() {}
-  public void Method2() {} // violation 'Name 'Method2' must match pattern'
+  protected void Method2() {} // violation 'Name 'Method2' must match pattern'
+  private void Method3() {} // violation 'Name 'Method3' must match pattern'
+  public void Method4() {} // violation 'Name 'Method4' must match pattern'
+  void Method5() {} // violation 'Name 'Method5' must match pattern'
 }
 // xdoc section -- end

--- a/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/naming/methodname/Example5.java
+++ b/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/naming/methodname/Example5.java
@@ -14,9 +14,10 @@ package com.puppycrawl.tools.checkstyle.checks.naming.methodname;
 
 // xdoc section -- start
 class Example5 {
-  public void Method1() {}
-  protected void Method2() {}
+  public void method1() {}
+  protected void Method2() {} // ok because, 'Property 'applyToProtected' is false'
   private void Method3() {} // violation 'Name 'Method3' must match pattern'
-  void Method4() {} // violation 'Name 'Method4' must match pattern'
+  public void Method4() {} // ok because, 'Property 'applyToPublic' is false'
+  void Method5() {} // violation 'Name 'Method5' must match pattern'
 }
 // xdoc section -- end

--- a/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/naming/methodname/Example6.java
+++ b/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/naming/methodname/Example6.java
@@ -9,13 +9,15 @@
 </module>
 */
 
+
 package com.puppycrawl.tools.checkstyle.checks.naming.methodname;
 
 // xdoc section -- start
 class Example6 {
-  public void Method1() {} // violation 'Name 'Method1' must match pattern'
+  public void method1() {}
   protected void Method2() {} // violation 'Name 'Method2' must match pattern'
   private void Method3() {}
-  void Method4() {} // violation 'Name 'Method4' must match pattern'
+  public void Method4() {} // violation 'Name 'Method4' must match pattern'
+  void Method5() {} // violation 'Name 'Method5' must match pattern'
 }
 // xdoc section -- end

--- a/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/naming/methodname/Example7.java
+++ b/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/naming/methodname/Example7.java
@@ -9,13 +9,15 @@
 </module>
 */
 
+
 package com.puppycrawl.tools.checkstyle.checks.naming.methodname;
 
 // xdoc section -- start
 class Example7 {
-  public void Method1() {} // violation 'Name 'Method1' must match pattern'
+  public void method1() {}
   protected void Method2() {} // violation 'Name 'Method2' must match pattern'
   private void Method3() {} // violation 'Name 'Method3' must match pattern'
-  void Method4() {}
+  public void Method4() {} // violation 'Name 'Method4' must match pattern'
+  void Method5() {}  // ok because , 'Property 'applyToPackage' is set to false'
 }
 // xdoc section -- end


### PR DESCRIPTION
Issue: #18435 

This PR improves AST consistency across MethodNameCheck xdocs examples by aligning examples with equivalent semantic intent. 

- Example 1 , 2 , 5 ,6 and 7 are normalized to share a consistent AST structure while preserving their original configurational behaviour. 
- Example 3 , 4 are still remain suppressed, as they demonstrate constructor-specific behaviour and should not be normalized with method-only examples.