### PR TITLE
Issue #17882: Update NEWLINE Javadoc with AST example

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/api/JavadocCommentsTokenTypes.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/api/JavadocCommentsTokenTypes.java
@@ -77,25 +77,24 @@ public final class JavadocCommentsTokenTypes {
      * <p><b>Example:</b></p>
      * <pre>{@code
      * /**
-     * * This is a Javadoc line.
-     * * /
+     *  * This is a Javadoc line.
+     *  * /
      * }</pre>
      *
      * <p><b>Tree:</b></p>
      * <pre>{@code
      * --BLOCK_COMMENT_BEGIN -> /**
-     * |--COMMENT_CONTENT -> *\r\n * This is a Javadoc line.\r\n
-     * |   `--JAVADOC_CONTENT -> JAVADOC_CONTENT
-     * |       |--NEWLINE -> \r\n
-     * |       |--LEADING_ASTERISK ->  *
-     * |       |--TEXT ->  This is a Javadoc line.
-     * |       |--NEWLINE -> \r\n
-     * |       `--TEXT ->
+     *    |--COMMENT_CONTENT -> *\r\n * This is a Javadoc line.\r\n
+     *    |   `--JAVADOC_CONTENT -> JAVADOC_CONTENT
+     *    |       |--NEWLINE -> \r\n
+     *    |       |--LEADING_ASTERISK ->  *
+     *    |       |--TEXT ->  This is a Javadoc line.
+     *    |       |--NEWLINE -> \r\n
+     *    |       `--TEXT ->
      * `   --BLOCK_COMMENT_END -> *
      * }</pre>
-     *
-     * @see #JAVADOC_CONTENT
      */
+
     public static final int NEWLINE = JavadocCommentsLexer.NEWLINE;
 
     /**


### PR DESCRIPTION
Issue: #17882

Updated `NEWLINE` token documentation with AST example.

**Input (Test.java):**
```java
/**
 * First line.
 * Second line.
 */
class MyClass {
}
 ```
 ## Command(Windows)
```
java -jar target/checkstyle-13.1.0-SNAPSHOT-all.jar -j Test.java | ForEach-Object { $_ -replace '\[[0-9]+:[0-9]+\]', '' }
```
## Generated AST Output:
```
JAVADOC_CONTENT -> JAVADOC_CONTENT
|--TEXT -> /**
|--NEWLINE -> \r\n
|--LEADING_ASTERISK ->  *
|--TEXT ->  First line.
|--NEWLINE -> \r\n
|--LEADING_ASTERISK ->  *
|--TEXT ->  Second line.
|--NEWLINE -> \r\n
|--LEADING_ASTERISK ->  *
|--TEXT -> /
|--NEWLINE -> \r\n
|--TEXT -> class MyClass {
|--NEWLINE -> \r\n
|--TEXT ->
|--NEWLINE -> \r\n
|--TEXT -> }
`--NEWLINE -> \r\n
```
