### PR TITLE
Issue #18435:Remove javadoctagcontinuationindentation Example4 from(X…

### DIFF
--- a/src/site/xdoc/checks/javadoc/javadoctagcontinuationindentation.xml
+++ b/src/site/xdoc/checks/javadoc/javadoctagcontinuationindentation.xml
@@ -70,27 +70,48 @@
           Example:
         </p>
         <div class="wrapper"><pre class="prettyprint"><code class="language-java">
-/**
- * &lt;p&gt; 'p' tag is unclosed
- * &lt;p&gt; 'p' tag is closed&lt;/p&gt;
- */
 class Example1 {
 
   /**
-   * @tag comment
-   *     Indentation spacing is 4
+   * @param input comment with
+   *     indentation spacing for the tag
    */
-  public void testMethod1(String input) {
-    // ok, Default expected Indentation is 4
-  }
+  public void testIndentation4(String input) {}
+   // ok, Default expected Indentation is 4
 
   /**
-   * @tag comment
-   *   Indentation spacing is 2
+   * @param input comment with
+   *   indentation spacing for the tag
    */
-  public void testMethod2(String input) {
-    // violation 3 lines above 'Line continuation have incorrect indentation level'
-  }
+  public void testIndentation2(String input) {}
+   // violation 3 lines above 'Line continuation have incorrect indentation level'
+
+  /**
+   * &lt;pre&gt;
+   * this content, and not any error:
+   *   "JavadocTagContinuation do not validate lines contained in Pre tag,
+   *   No violation is expected here."&lt;/pre&gt;
+   */
+  public void testMethodPre(String input) {}
+
+  /**
+   * Writes the object using a
+   * &lt;a href="{@docRoot}/serialized-form.html#java.time.Ser"&gt;dedicated form&lt;/a&gt;.
+   * @serialData
+   * &lt;code&gt; // violation
+   * out.writeByte(1); // violation
+   * out.writeInt(nanos); // violation
+   * &lt;/code&gt; // violation
+   */
+  public void testMethodCode(String input) {}
+
+  /**
+   * Test class.
+   *
+   * @param input comment with
+   *          This is the predefined indentation applied by Eclipse formatter.
+   */
+  public void testIndentationEclipse(String input) {}
 }
 </code></pre></div><hr class="example-separator"/>
         <p id="Example2-config">
@@ -109,27 +130,48 @@ class Example1 {
           Example:
         </p>
         <div class="wrapper"><pre class="prettyprint"><code class="language-java">
-/**
- * &lt;p&gt; 'p' tag is unclosed
- * &lt;p&gt; 'p' tag is closed&lt;/p&gt;
- */
 class Example2 {
 
   /**
-   * @tag comment
-   *     Indentation spacing is 4
+   * @param input comment with
+   *     indentation spacing for the tag
    */
-  public void testMethod1(String input) {
-    // ok, Indentation above 1 is fine as offset value is 2
-  }
+  public void testIndentation4(String input) {}
+   // ok, Indentation above 1 is fine as offset value is 2
 
   /**
-   * @tag comment
-   *   Indentation spacing is 2
+   * @param input comment with
+   *   indentation spacing for the tag
    */
-  public void testMethod2(String input) {
-    // ok, Indentation above 1 is fine as offset value is 2
-  }
+  public void testIndentation2(String input) {}
+   // ok, Indentation above 1 is fine as offset value is 2
+
+  /**
+   * &lt;pre&gt;
+   * this content, and not any error:
+   *   "JavadocTagContinuation do not validate lines contained in Pre tag,
+   *   No violation is expected here."&lt;/pre&gt;
+   */
+  public void testMethodPre(String input) {}
+
+  /**
+   * Writes the object using a
+   * &lt;a href="{@docRoot}/serialized-form.html#java.time.Ser"&gt;dedicated form&lt;/a&gt;.
+   * @serialData
+   * &lt;code&gt; // violation
+   * out.writeByte(1); // violation
+   * out.writeInt(nanos); // violation
+   * &lt;/code&gt; // violation
+   */
+  public void testMethodCode(String input) {}
+
+  /**
+   * Test class.
+   *
+   * @param input comment with
+   *          This is the predefined indentation applied by Eclipse formatter.
+   */
+  public void testIndentationEclipse(String input) {}
 }
 </code></pre></div><hr class="example-separator"/>
         <p id="Example3-config">
@@ -148,46 +190,29 @@ class Example2 {
           Example:
         </p>
         <div class="wrapper"><pre class="prettyprint"><code class="language-java">
-/**
- * &lt;p&gt; 'p' tag is unclosed
- * &lt;p&gt; 'p' tag is closed&lt;/p&gt;
- */
 class Example3 {
-  // violation 4 lines above 'Unclosed HTML tag found: p'
-  /**
-   * @tag comment
-   *     Indentation spacing is 4
-   */
-  public void testMethod1(String input) {
-    // ok, Default expected Indentation is 4
-  }
 
   /**
-   * @tag comment
-   *  Indentation spacing is 1
+   * @param input comment with
+   *     indentation spacing for the tag
    */
-  public void testMethod2(String input) {
-    // violation 3 lines above 'Line continuation have incorrect indentation level'
-  }
-}
-</code></pre></div><hr class="example-separator"/>
-        <p id="Example4-code">
-         Check does not validate the indentation of lines inside <code>pre</code> tags.
-         Example:
-        </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
-class Example4 {
+  public void testIndentation4(String input) {}
+   // ok, Default expected Indentation is 4
 
-   /**
-   * Writes the object using a
-   * &lt;a href="{@docRoot}/serialized-form.html#java.time.Ser"&gt;dedicated form&lt;/a&gt;.
-   * @serialData
+  /**
+   * @param input comment with
+   *   indentation spacing for the tag
+   */
+  public void testIndentation2(String input) {}
+   // violation 3 lines above 'Line continuation have incorrect indentation level'
+
+  /**
    * &lt;pre&gt;
-   * out.writeByte(1);
-   * out.writeInt(nanos);
-   * &lt;/pre&gt;
+   * this content, and not any error:
+   *   "JavadocTagContinuation do not validate lines contained in Pre tag,
+   *   No violation is expected here."&lt;/pre&gt;
    */
-  public void testMethod1(String input) {}
+  public void testMethodPre(String input) {}
 
   /**
    * Writes the object using a
@@ -198,20 +223,64 @@ class Example4 {
    * out.writeInt(nanos); // violation
    * &lt;/code&gt; // violation
    */
-  public void testMethod2(String input) {}
+  public void testMethodCode(String input) {}
 
   /**
    * Test class.
    *
-   * @apiNote
+   * @param input comment with
    *          This is the predefined indentation applied by Eclipse formatter.
-   *          &lt;pre&gt;
+   */
+  public void testIndentationEclipse(String input) {}
+}
+</code></pre></div><hr class="example-separator"/>
+        <p id="Example4-code">
+         Check does not validate the indentation of lines inside <code>pre</code> tags.
+         Example:
+        </p>
+        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+class Example4 {
+
+  /**
+   * @param input comment with
+   *     indentation spacing for the tag
+   */
+  public void testIndentation4(String input) {}
+   // ok, Default expected Indentation is 4
+
+  /**
+   * @param input comment with
+   *   indentation spacing for the tag
+   */
+  public void testIndentation2(String input) {}
+   // violation 3 lines above 'Line continuation have incorrect indentation level'
+
+  /**
+   * &lt;pre&gt;
    * this content, and not any error:
    *   "JavadocTagContinuation do not validate lines contained in Pre tag,
    *   No violation is expected here."&lt;/pre&gt;
    */
-  public void testMethod3(String input) {}
+  public void testMethodPre(String input) {}
 
+  /**
+   * Writes the object using a
+   * &lt;a href="{@docRoot}/serialized-form.html#java.time.Ser"&gt;dedicated form&lt;/a&gt;.
+   * @serialData
+   * &lt;code&gt; // violation
+   * out.writeByte(1); // violation
+   * out.writeInt(nanos); // violation
+   * &lt;/code&gt; // violation
+   */
+  public void testMethodCode(String input) {}
+
+  /**
+   * Test class.
+   *
+   * @param input comment with
+   *          This is the predefined indentation applied by Eclipse formatter.
+   */
+  public void testIndentationEclipse(String input) {}
 }
 </code></pre></div>
       </subsection>

--- a/src/test/java/com/puppycrawl/tools/checkstyle/internal/XdocsExamplesAstConsistencyTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/internal/XdocsExamplesAstConsistencyTest.java
@@ -182,7 +182,6 @@ public class XdocsExamplesAstConsistencyTest {
             "checks/javadoc/javadocleadingasteriskalign/Example3",
             "checks/javadoc/javadocmethod/Example7",
             "checks/javadoc/javadocmethod/Example8",
-            "checks/javadoc/javadoctagcontinuationindentation/Example4",
             "checks/javadoc/javadocvariable/Example5",
             "checks/metrics/classdataabstractioncoupling/Example11",
             "checks/metrics/classdataabstractioncoupling/Example2",

--- a/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocTagContinuationIndentationCheckExamplesTest.java
+++ b/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocTagContinuationIndentationCheckExamplesTest.java
@@ -19,13 +19,11 @@
 
 package com.puppycrawl.tools.checkstyle.checks.javadoc;
 
-import static com.puppycrawl.tools.checkstyle.checks.javadoc.AbstractJavadocCheck.MSG_KEY_UNCLOSED_HTML_TAG;
 import static com.puppycrawl.tools.checkstyle.checks.javadoc.JavadocTagContinuationIndentationCheck.MSG_KEY;
 
 import org.junit.jupiter.api.Test;
 
 import com.puppycrawl.tools.checkstyle.AbstractExamplesModuleTestSupport;
-import com.puppycrawl.tools.checkstyle.utils.CommonUtil;
 
 public class JavadocTagContinuationIndentationCheckExamplesTest
         extends AbstractExamplesModuleTestSupport {
@@ -37,7 +35,11 @@ public class JavadocTagContinuationIndentationCheckExamplesTest
     @Test
     public void testExample1() throws Exception {
         final String[] expected = {
-            "27: " + getCheckMessage(MSG_KEY, 4),
+            "22: " + getCheckMessage(MSG_KEY, 4),
+            "39: " + getCheckMessage(MSG_KEY, 4),
+            "40: " + getCheckMessage(MSG_KEY, 4),
+            "41: " + getCheckMessage(MSG_KEY, 4),
+            "42: " + getCheckMessage(MSG_KEY, 4),
         };
 
         verifyWithInlineConfigParser(getPath("Example1.java"), expected);
@@ -45,29 +47,36 @@ public class JavadocTagContinuationIndentationCheckExamplesTest
 
     @Test
     public void testExample2() throws Exception {
-        final String[] expected = CommonUtil.EMPTY_STRING_ARRAY;
+        final String[] expected = {
+            "41: " + getCheckMessage(MSG_KEY, 2),
+            "42: " + getCheckMessage(MSG_KEY, 2),
+            "43: " + getCheckMessage(MSG_KEY, 2),
+            "44: " + getCheckMessage(MSG_KEY, 2),
+        };
         verifyWithInlineConfigParser(getPath("Example2.java"), expected);
     }
 
     @Test
     public void testExample3() throws Exception {
         final String[] expected = {
-            "14: " + getCheckMessage(MSG_KEY_UNCLOSED_HTML_TAG, "p"),
-            "29: " + getCheckMessage(MSG_KEY, 4),
+            "24: " + getCheckMessage(MSG_KEY, 4),
+            "41: " + getCheckMessage(MSG_KEY, 4),
+            "42: " + getCheckMessage(MSG_KEY, 4),
+            "43: " + getCheckMessage(MSG_KEY, 4),
+            "44: " + getCheckMessage(MSG_KEY, 4),
         };
-
         verifyWithInlineConfigParser(getPath("Example3.java"), expected);
     }
 
     @Test
     public void testExample4() throws Exception {
         final String[] expected = {
-            "29: " + getCheckMessage(MSG_KEY, 4),
-            "30: " + getCheckMessage(MSG_KEY, 4),
-            "31: " + getCheckMessage(MSG_KEY, 4),
-            "32: " + getCheckMessage(MSG_KEY, 4),
+            "22: " + getCheckMessage(MSG_KEY, 4),
+            "39: " + getCheckMessage(MSG_KEY, 4),
+            "40: " + getCheckMessage(MSG_KEY, 4),
+            "41: " + getCheckMessage(MSG_KEY, 4),
+            "42: " + getCheckMessage(MSG_KEY, 4),
         };
-
         verifyWithInlineConfigParser(getPath("Example4.java"), expected);
     }
 }

--- a/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadoctagcontinuationindentation/Example1.java
+++ b/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadoctagcontinuationindentation/Example1.java
@@ -8,26 +8,47 @@
 package com.puppycrawl.tools.checkstyle.checks.javadoc.javadoctagcontinuationindentation;
 
 // xdoc section -- start
-/**
- * <p> 'p' tag is unclosed
- * <p> 'p' tag is closed</p>
- */
 class Example1 {
 
   /**
-   * @tag comment
-   *     Indentation spacing is 4
+   * @param input comment with
+   *     indentation spacing for the tag
    */
-  public void testMethod1(String input) {
-    // ok, Default expected Indentation is 4
-  }
+  public void testIndentation4(String input) {}
+   // ok, Default expected Indentation is 4
 
   /**
-   * @tag comment
-   *   Indentation spacing is 2
+   * @param input comment with
+   *   indentation spacing for the tag
    */
-  public void testMethod2(String input) {
-    // violation 3 lines above 'Line continuation have incorrect indentation level'
-  }
+  public void testIndentation2(String input) {}
+   // violation 3 lines above 'Line continuation have incorrect indentation level'
+
+  /**
+   * <pre>
+   * this content, and not any error:
+   *   "JavadocTagContinuation do not validate lines contained in Pre tag,
+   *   No violation is expected here."</pre>
+   */
+  public void testMethodPre(String input) {}
+
+  /**
+   * Writes the object using a
+   * <a href="{@docRoot}/serialized-form.html#java.time.Ser">dedicated form</a>.
+   * @serialData
+   * <code> // violation
+   * out.writeByte(1); // violation
+   * out.writeInt(nanos); // violation
+   * </code> // violation
+   */
+  public void testMethodCode(String input) {}
+
+  /**
+   * Test class.
+   *
+   * @param input comment with
+   *          This is the predefined indentation applied by Eclipse formatter.
+   */
+  public void testIndentationEclipse(String input) {}
 }
 // xdoc section -- end

--- a/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadoctagcontinuationindentation/Example2.java
+++ b/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadoctagcontinuationindentation/Example2.java
@@ -10,26 +10,47 @@
 package com.puppycrawl.tools.checkstyle.checks.javadoc.javadoctagcontinuationindentation;
 
 // xdoc section -- start
-/**
- * <p> 'p' tag is unclosed
- * <p> 'p' tag is closed</p>
- */
 class Example2 {
 
   /**
-   * @tag comment
-   *     Indentation spacing is 4
+   * @param input comment with
+   *     indentation spacing for the tag
    */
-  public void testMethod1(String input) {
-    // ok, Indentation above 1 is fine as offset value is 2
-  }
+  public void testIndentation4(String input) {}
+   // ok, Indentation above 1 is fine as offset value is 2
 
   /**
-   * @tag comment
-   *   Indentation spacing is 2
+   * @param input comment with
+   *   indentation spacing for the tag
    */
-  public void testMethod2(String input) {
-    // ok, Indentation above 1 is fine as offset value is 2
-  }
+  public void testIndentation2(String input) {}
+   // ok, Indentation above 1 is fine as offset value is 2
+
+  /**
+   * <pre>
+   * this content, and not any error:
+   *   "JavadocTagContinuation do not validate lines contained in Pre tag,
+   *   No violation is expected here."</pre>
+   */
+  public void testMethodPre(String input) {}
+
+  /**
+   * Writes the object using a
+   * <a href="{@docRoot}/serialized-form.html#java.time.Ser">dedicated form</a>.
+   * @serialData
+   * <code> // violation
+   * out.writeByte(1); // violation
+   * out.writeInt(nanos); // violation
+   * </code> // violation
+   */
+  public void testMethodCode(String input) {}
+
+  /**
+   * Test class.
+   *
+   * @param input comment with
+   *          This is the predefined indentation applied by Eclipse formatter.
+   */
+  public void testIndentationEclipse(String input) {}
 }
 // xdoc section -- end

--- a/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadoctagcontinuationindentation/Example3.java
+++ b/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadoctagcontinuationindentation/Example3.java
@@ -10,26 +10,47 @@
 package com.puppycrawl.tools.checkstyle.checks.javadoc.javadoctagcontinuationindentation;
 
 // xdoc section -- start
-/**
- * <p> 'p' tag is unclosed
- * <p> 'p' tag is closed</p>
- */
 class Example3 {
-  // violation 4 lines above 'Unclosed HTML tag found: p'
-  /**
-   * @tag comment
-   *     Indentation spacing is 4
-   */
-  public void testMethod1(String input) {
-    // ok, Default expected Indentation is 4
-  }
 
   /**
-   * @tag comment
-   *  Indentation spacing is 1
+   * @param input comment with
+   *     indentation spacing for the tag
    */
-  public void testMethod2(String input) {
-    // violation 3 lines above 'Line continuation have incorrect indentation level'
-  }
+  public void testIndentation4(String input) {}
+   // ok, Default expected Indentation is 4
+
+  /**
+   * @param input comment with
+   *   indentation spacing for the tag
+   */
+  public void testIndentation2(String input) {}
+   // violation 3 lines above 'Line continuation have incorrect indentation level'
+
+  /**
+   * <pre>
+   * this content, and not any error:
+   *   "JavadocTagContinuation do not validate lines contained in Pre tag,
+   *   No violation is expected here."</pre>
+   */
+  public void testMethodPre(String input) {}
+
+  /**
+   * Writes the object using a
+   * <a href="{@docRoot}/serialized-form.html#java.time.Ser">dedicated form</a>.
+   * @serialData
+   * <code> // violation
+   * out.writeByte(1); // violation
+   * out.writeInt(nanos); // violation
+   * </code> // violation
+   */
+  public void testMethodCode(String input) {}
+
+  /**
+   * Test class.
+   *
+   * @param input comment with
+   *          This is the predefined indentation applied by Eclipse formatter.
+   */
+  public void testIndentationEclipse(String input) {}
 }
 // xdoc section -- end

--- a/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadoctagcontinuationindentation/Example4.java
+++ b/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadoctagcontinuationindentation/Example4.java
@@ -8,19 +8,29 @@
 package com.puppycrawl.tools.checkstyle.checks.javadoc.javadoctagcontinuationindentation;
 
 // xdoc section -- start
-
 class Example4 {
 
-   /**
-   * Writes the object using a
-   * <a href="{@docRoot}/serialized-form.html#java.time.Ser">dedicated form</a>.
-   * @serialData
-   * <pre>
-   * out.writeByte(1);
-   * out.writeInt(nanos);
-   * </pre>
+  /**
+   * @param input comment with
+   *     indentation spacing for the tag
    */
-  public void testMethod1(String input) {}
+  public void testIndentation4(String input) {}
+   // ok, Default expected Indentation is 4
+
+  /**
+   * @param input comment with
+   *   indentation spacing for the tag
+   */
+  public void testIndentation2(String input) {}
+   // violation 3 lines above 'Line continuation have incorrect indentation level'
+
+  /**
+   * <pre>
+   * this content, and not any error:
+   *   "JavadocTagContinuation do not validate lines contained in Pre tag,
+   *   No violation is expected here."</pre>
+   */
+  public void testMethodPre(String input) {}
 
   /**
    * Writes the object using a
@@ -31,20 +41,14 @@ class Example4 {
    * out.writeInt(nanos); // violation
    * </code> // violation
    */
-  public void testMethod2(String input) {}
+  public void testMethodCode(String input) {}
 
   /**
    * Test class.
    *
-   * @apiNote
+   * @param input comment with
    *          This is the predefined indentation applied by Eclipse formatter.
-   *          <pre>
-   * this content, and not any error:
-   *   "JavadocTagContinuation do not validate lines contained in Pre tag,
-   *   No violation is expected here."</pre>
    */
-  public void testMethod3(String input) {}
-
+  public void testIndentationEclipse(String input) {}
 }
-
 // xdoc section -- end


### PR DESCRIPTION
Issue : #18435

Remove javadoctagcontinuationindentation Example4 from XdocsExamplesAstconsistencyTest.
Updated Example1–Example4 so they now have the same AST structure.




