### PR TITLE
Issue #17882: Update JAVADOC_INLINE_TAG Javadoc with AST example

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/api/JavadocCommentsTokenTypes.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/api/JavadocCommentsTokenTypes.java
@@ -606,6 +606,43 @@ public final class JavadocCommentsTokenTypes {
 
     /**
      * General inline tag (e.g. {@code @link}).
+     *
+     * <p>Such Javadoc tag can have these children:</p>
+     * <ol>
+     * <li>{@link #CODE_INLINE_TAG}</li>
+     * <li>{@link #LINK_INLINE_TAG}</li>
+     * <li>{@link #VALUE_INLINE_TAG}</li>
+     * </ol>
+     *
+     * <p><b>Example:</b></p>
+     * <pre>{@code
+     * /**
+     * * {@code code}
+     * &#42;/
+     * }</pre>
+     *
+     * <b>Tree:</b>
+     * <pre>{@code
+     * JAVADOC_CONTENT -> JAVADOC_CONTENT
+     * |--TEXT -> /**
+     * |--NEWLINE -> \n
+     * |--LEADING_ASTERISK ->   *
+     * |--TEXT ->
+     * |--JAVADOC_INLINE_TAG -> JAVADOC_INLINE_TAG
+     * |   `--CODE_INLINE_TAG -> CODE_INLINE_TAG
+     * |       |--JAVADOC_INLINE_TAG_START -> { @
+     * |       |--TAG_NAME -> code
+     * |       |--TEXT ->   code
+     * |       `--JAVADOC_INLINE_TAG_END -> }
+     * |--NEWLINE -> \n
+     * |--LEADING_ASTERISK ->   *
+     * |--TEXT -> /
+     * |--NEWLINE -> \n
+     * |--TEXT -> public class Test {}
+     * `--NEWLINE -> \n
+     * }</pre>
+     *
+     * @see #JAVADOC_INLINE_TAG
      */
     public static final int JAVADOC_INLINE_TAG = JavadocCommentsLexer.JAVADOC_INLINE_TAG;
 


### PR DESCRIPTION
Issue #17882

## Description
Updated `JAVADOC_INLINE_TAG` token in `JavadocCommentsTokenTypes.java` to include the new AST print format examples.

## Example
**Input Code (src/Test.java):**
```java
/**
 * Test class.
 * {@code code}
 */
public class Test {}

Command: 
java -jar checkstyle-13.0.1-SNAPSHOT-all.jar -j src/Test.java | sed "s/\[[0-9]\+:[0-9]\+\]//g"

JAVADOC_CONTENT -> JAVADOC_CONTENT
|--TEXT -> /**
|--NEWLINE -> \n
|--LEADING_ASTERISK ->   *
|--TEXT ->   Test class.
|--NEWLINE -> \n
|--LEADING_ASTERISK ->   *
|--TEXT ->
|--JAVADOC_INLINE_TAG -> JAVADOC_INLINE_TAG
|   `--CODE_INLINE_TAG -> CODE_INLINE_TAG
|       |--JAVADOC_INLINE_TAG_START -> { @
|       |--TAG_NAME -> code
|       |--TEXT ->   code
|       `--JAVADOC_INLINE_TAG_END -> }
|--NEWLINE -> \n
|--LEADING_ASTERISK ->   *
|--TEXT -> /
|--NEWLINE -> \n
|--TEXT -> public class Test {}
`--NEWLINE -> \n