### PR TITLE
Issue #18559: Add DeclarationOrder, FallThrough, OneStatementPerLine to sun_checks.xml

### DIFF
--- a/src/main/resources/sun_checks.xml
+++ b/src/main/resources/sun_checks.xml
@@ -165,14 +165,17 @@
 
     <!-- Checks for common coding problems               -->
     <!-- See https://checkstyle.org/checks/coding/index.html -->
+    <module name="DeclarationOrder"/>
     <module name="EmptyStatement"/>
     <module name="EqualsHashCode"/>
     <module name="HiddenField"/>
     <module name="IllegalInstantiation"/>
     <module name="InnerAssignment"/>
     <module name="MagicNumber"/>
+    <module name="FallThrough"/>
     <module name="MissingSwitchDefault"/>
     <module name="MultipleVariableDeclarations"/>
+    <module name="OneStatementPerLine"/>
     <module name="SimplifyBooleanExpression"/>
     <module name="SimplifyBooleanReturn"/>
 


### PR DESCRIPTION
## Issue Reference

Closes #18559

## Description

This PR adds three missing checks to sun_checks.xml that are required by the Code Conventions for the Java TM Programming Language.

### Added checks:

1. **DeclarationOrder** - Section 3.1.3
   - Enforces the order of class/interface declarations: static variables, instance variables, constructors, methods

2. **FallThrough** - Section 7.8
   - Checks for fall-through in switch statements without proper comments

3. **OneStatementPerLine** - Section 7.1
   - Ensures each line contains at most one statement

## Changes

- Added DeclarationOrder to coding checks section
- Added FallThrough to coding checks section
- Added OneStatementPerLine to coding checks section