### PR TITLE
Issue #18559: Add missing checks to sun_checks.xml

### DIFF
--- a/config/jsoref-spellchecker/whitelist.words
+++ b/config/jsoref-spellchecker/whitelist.words
@@ -183,6 +183,7 @@ circleci
 cirrusci
 classannotations
 classdataabstractioncoupling
+classdeclarations
 classfanoutcomplexity
 classloader
 classmemberimpliedmodifier
@@ -443,6 +444,7 @@ filebasic
 filechooser
 filefilter
 filelength
+fileorganization
 filepath
 fileset
 filesetcheck
@@ -1248,6 +1250,7 @@ shellcheck
 shengchen
 Shiell
 sickboy
+simplestatements
 Simplifiable
 simplifybooleanexpression
 simplifybooleanreturn
@@ -1348,6 +1351,7 @@ suppresswithnearbytextfilter
 suppresswithplaintextcommentfilter
 suse
 svg
+switchstatements
 sxpath
 syntastic
 Sys

--- a/src/it/java/com/sun/checkstyle/test/base/AbstractSunModuleTestSupport.java
+++ b/src/it/java/com/sun/checkstyle/test/base/AbstractSunModuleTestSupport.java
@@ -97,4 +97,14 @@ public abstract class AbstractSunModuleTestSupport extends AbstractItModuleTestS
         return getModuleConfig(CONFIGURATION, moduleName, moduleId);
     }
 
+    /**
+     * Performs verification of the file with the given file path against the whole config.
+     *
+     * @param filePath file path to verify.
+     * @throws Exception if exception occurs during verification process.
+     */
+    protected void verifyWithWholeConfig(String filePath) throws Exception {
+        verifyWithItConfig(CONFIGURATION, filePath);
+    }
+
 }

--- a/src/it/java/com/sun/checkstyle/test/chapter3fileorganization/rule313classdeclarations/DeclarationOrderTest.java
+++ b/src/it/java/com/sun/checkstyle/test/chapter3fileorganization/rule313classdeclarations/DeclarationOrderTest.java
@@ -1,0 +1,73 @@
+///////////////////////////////////////////////////////////////////////////////////////////////
+// checkstyle: Checks Java source code and other text files for adherence to a set of rules.
+// Copyright (C) 2001-2026 the original author or authors.
+//
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the GNU Lesser General Public
+// License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+//
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+// Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public
+// License along with this library; if not, write to the Free Software
+// Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+///////////////////////////////////////////////////////////////////////////////////////////////
+
+package com.sun.checkstyle.test.chapter3fileorganization.rule313classdeclarations;
+
+import org.junit.jupiter.api.Test;
+
+import com.sun.checkstyle.test.base.AbstractSunModuleTestSupport;
+
+public class DeclarationOrderTest extends AbstractSunModuleTestSupport {
+
+    @Override
+    public String getPackageLocation() {
+        return "com/sun/checkstyle/test/chapter3fileorganization/rule313classdeclarations";
+    }
+
+    @Test
+    public void testDeclarationOrderDefault() throws Exception {
+        verifyWithWholeConfig(getPath("InputDeclarationOrderDefault.java"));
+    }
+
+    @Test
+    public void testDeclarationOrderAccessModifiers() throws Exception {
+        verifyWithWholeConfig(getPath("InputDeclarationOrderAccessModifiers.java"));
+    }
+
+    @Test
+    public void testDeclarationOrderStaticMembers() throws Exception {
+        verifyWithWholeConfig(getPath("InputDeclarationOrderStaticMembers.java"));
+    }
+
+    @Test
+    public void testDeclarationOrderConstructor() throws Exception {
+        verifyWithWholeConfig(getPath("InputDeclarationOrderConstructor.java"));
+    }
+
+    @Test
+    public void testDeclarationOrderInstance() throws Exception {
+        verifyWithWholeConfig(getPath("InputDeclarationOrderInstance.java"));
+    }
+
+    @Test
+    public void testDeclarationOrderMultipleViolations() throws Exception {
+        verifyWithWholeConfig(getPath("InputDeclarationOrderMultipleViolations.java"));
+    }
+
+    @Test
+    public void testDeclarationOrderValid() throws Exception {
+        verifyWithWholeConfig(getPath("InputDeclarationOrderValid.java"));
+    }
+
+    @Test
+    public void testDeclarationOrderValidInnerClass() throws Exception {
+        verifyWithWholeConfig(getPath("InputDeclarationOrderValidInnerClass.java"));
+    }
+
+}

--- a/src/it/java/com/sun/checkstyle/test/chapter7statements/rule71simplestatements/OneStatementPerLineTest.java
+++ b/src/it/java/com/sun/checkstyle/test/chapter7statements/rule71simplestatements/OneStatementPerLineTest.java
@@ -1,0 +1,53 @@
+///////////////////////////////////////////////////////////////////////////////////////////////
+// checkstyle: Checks Java source code and other text files for adherence to a set of rules.
+// Copyright (C) 2001-2026 the original author or authors.
+//
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the GNU Lesser General Public
+// License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+//
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+// Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public
+// License along with this library; if not, write to the Free Software
+// Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+///////////////////////////////////////////////////////////////////////////////////////////////
+
+package com.sun.checkstyle.test.chapter7statements.rule71simplestatements;
+
+import org.junit.jupiter.api.Test;
+
+import com.sun.checkstyle.test.base.AbstractSunModuleTestSupport;
+
+public class OneStatementPerLineTest extends AbstractSunModuleTestSupport {
+
+    @Override
+    public String getPackageLocation() {
+        return "com/sun/checkstyle/test/chapter7statements/rule71simplestatements";
+    }
+
+    @Test
+    public void testOneStatementPerLineDefault() throws Exception {
+        verifyWithWholeConfig(getPath("InputOneStatementPerLineDefault.java"));
+    }
+
+    @Test
+    public void testOneStatementPerLineMultiple() throws Exception {
+        verifyWithWholeConfig(getPath("InputOneStatementPerLineMultiple.java"));
+    }
+
+    @Test
+    public void testOneStatementPerLineValid() throws Exception {
+        verifyWithWholeConfig(getPath("InputOneStatementPerLineValid.java"));
+    }
+
+    @Test
+    public void testOneStatementPerLineForLoop() throws Exception {
+        verifyWithWholeConfig(getPath("InputOneStatementPerLineForLoop.java"));
+    }
+
+}

--- a/src/it/java/com/sun/checkstyle/test/chapter7statements/rule78switchstatements/FallThroughTest.java
+++ b/src/it/java/com/sun/checkstyle/test/chapter7statements/rule78switchstatements/FallThroughTest.java
@@ -1,0 +1,53 @@
+///////////////////////////////////////////////////////////////////////////////////////////////
+// checkstyle: Checks Java source code and other text files for adherence to a set of rules.
+// Copyright (C) 2001-2026 the original author or authors.
+//
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the GNU Lesser General Public
+// License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+//
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+// Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public
+// License along with this library; if not, write to the Free Software
+// Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+///////////////////////////////////////////////////////////////////////////////////////////////
+
+package com.sun.checkstyle.test.chapter7statements.rule78switchstatements;
+
+import org.junit.jupiter.api.Test;
+
+import com.sun.checkstyle.test.base.AbstractSunModuleTestSupport;
+
+public class FallThroughTest extends AbstractSunModuleTestSupport {
+
+    @Override
+    public String getPackageLocation() {
+        return "com/sun/checkstyle/test/chapter7statements/rule78switchstatements";
+    }
+
+    @Test
+    public void testFallThroughDefault() throws Exception {
+        verifyWithWholeConfig(getPath("InputFallThroughDefault.java"));
+    }
+
+    @Test
+    public void testFallThroughWithBreak() throws Exception {
+        verifyWithWholeConfig(getPath("InputFallThroughWithBreak.java"));
+    }
+
+    @Test
+    public void testFallThroughWithComment() throws Exception {
+        verifyWithWholeConfig(getPath("InputFallThroughWithComment.java"));
+    }
+
+    @Test
+    public void testFallThroughValid() throws Exception {
+        verifyWithWholeConfig(getPath("InputFallThroughValid.java"));
+    }
+
+}

--- a/src/it/resources/com/sun/checkstyle/test/chapter3fileorganization/rule313classdeclarations/InputDeclarationOrderAccessModifiers.java
+++ b/src/it/resources/com/sun/checkstyle/test/chapter3fileorganization/rule313classdeclarations/InputDeclarationOrderAccessModifiers.java
@@ -1,0 +1,30 @@
+package com.sun.checkstyle.test.chapter3fileorganization.rule313classdeclarations;
+
+/**
+ * Test input for declaration order with access modifier violations.
+ */
+public final class InputDeclarationOrderAccessModifiers {
+
+    /** Package-private constant. */
+    static final int PACKAGE_VAR = 1;
+
+    /** Public after package. */
+    // violation below 'Variable access definition in wrong order.'
+    public static final int PUBLIC_VAR = 2;
+
+    /** Private constant. */
+    private static final int PRIVATE_VAR = 3;
+
+    /** Protected after private. */
+    // violation below 'Variable access definition in wrong order.'
+    protected static final int PROTECTED_VAR = 4;
+
+    /**
+     * Gets value.
+     *
+     * @return constant value
+     */
+    public int getValue() {
+        return PACKAGE_VAR + PUBLIC_VAR + PRIVATE_VAR + PROTECTED_VAR;
+    }
+}

--- a/src/it/resources/com/sun/checkstyle/test/chapter3fileorganization/rule313classdeclarations/InputDeclarationOrderConstructor.java
+++ b/src/it/resources/com/sun/checkstyle/test/chapter3fileorganization/rule313classdeclarations/InputDeclarationOrderConstructor.java
@@ -1,0 +1,29 @@
+package com.sun.checkstyle.test.chapter3fileorganization.rule313classdeclarations;
+
+/**
+ * Test input for declaration order with constructor order violation.
+ */
+public final class InputDeclarationOrderConstructor {
+
+    /** Static constant. */
+    public static final int CONST = 1;
+
+    /** Instance variable. */
+    private int instanceVar;
+
+    /**
+     * Gets value.
+     *
+     * @return instance variable value
+     */
+    public int getValue() {
+        return instanceVar;
+    }
+
+    /**
+     * Constructor after method.
+     */ // violation below 'Constructor definition in wrong order.'
+    public InputDeclarationOrderConstructor() {
+        instanceVar = 0;
+    }
+}

--- a/src/it/resources/com/sun/checkstyle/test/chapter3fileorganization/rule313classdeclarations/InputDeclarationOrderDefault.java
+++ b/src/it/resources/com/sun/checkstyle/test/chapter3fileorganization/rule313classdeclarations/InputDeclarationOrderDefault.java
@@ -1,0 +1,36 @@
+package com.sun.checkstyle.test.chapter3fileorganization.rule313classdeclarations;
+
+/**
+ * Test input for declaration order with default scenarios.
+ */
+public final class InputDeclarationOrderDefault {
+
+    /** Static constant. */
+    public static final int FOO = 1;
+
+    /** Private constant. */
+    private static final int BAR = 2;
+
+    /** Public before private. */
+    // violation below 'Variable access definition in wrong order.'
+    public static final int BAZ = 3;
+
+    /** Instance variable. */
+    private int instanceVar;
+
+    /**
+     * Constructor.
+     */
+    public InputDeclarationOrderDefault() {
+        instanceVar = 0;
+    }
+
+    /**
+     * Gets instance variable.
+     *
+     * @return instance variable value
+     */
+    public int getInstanceVar() {
+        return instanceVar;
+    }
+}

--- a/src/it/resources/com/sun/checkstyle/test/chapter3fileorganization/rule313classdeclarations/InputDeclarationOrderInstance.java
+++ b/src/it/resources/com/sun/checkstyle/test/chapter3fileorganization/rule313classdeclarations/InputDeclarationOrderInstance.java
@@ -1,0 +1,31 @@
+package com.sun.checkstyle.test.chapter3fileorganization.rule313classdeclarations;
+
+/**
+ * Test input for declaration order with instance variable order violation.
+ */
+public final class InputDeclarationOrderInstance {
+
+    /** Static constant. */
+    public static final int CONST = 1;
+
+    /**
+     * Constructor.
+     */
+    public InputDeclarationOrderInstance() {
+        instanceVar = 0;
+    }
+
+    /**
+     * Gets value.
+     *
+     * @return instance variable value
+     */
+    public int getValue() {
+        return instanceVar;
+    }
+
+
+    /** Instance variable after method. */
+    private int instanceVar;
+    // violation above 'Instance variable definition in wrong order.'
+}

--- a/src/it/resources/com/sun/checkstyle/test/chapter3fileorganization/rule313classdeclarations/InputDeclarationOrderMultipleViolations.java
+++ b/src/it/resources/com/sun/checkstyle/test/chapter3fileorganization/rule313classdeclarations/InputDeclarationOrderMultipleViolations.java
@@ -1,0 +1,42 @@
+package com.sun.checkstyle.test.chapter3fileorganization.rule313classdeclarations;
+
+/**
+ * Test input for declaration order with multiple violations.
+ */
+public final class InputDeclarationOrderMultipleViolations {
+
+    /** Package-private static constant. */
+    static final int PACKAGE_CONST = 1;
+
+    /** Private static constant. */
+    private static final int PRIVATE_CONST = 2;
+
+    /** Public after private. */
+    // violation below 'Variable access definition in wrong order.'
+    public static final int PUBLIC_CONST = 3;
+
+    /** Instance variable. */
+    private int instanceVar;
+
+    /**
+     * Gets value.
+     *
+     * @return calculated value
+     */
+    public int getValue() {
+        return PACKAGE_CONST + PRIVATE_CONST + PUBLIC_CONST + instanceVar
+                + staticVar;
+    }
+
+    /**
+     * Constructor.
+     */ // violation below 'Constructor definition in wrong order.'
+    public InputDeclarationOrderMultipleViolations() {
+        instanceVar = 0;
+    }
+
+
+    /** Static variable after method. */
+    private static int staticVar = 0;
+    // violation above 'Static variable definition in wrong order.'
+}

--- a/src/it/resources/com/sun/checkstyle/test/chapter3fileorganization/rule313classdeclarations/InputDeclarationOrderStaticMembers.java
+++ b/src/it/resources/com/sun/checkstyle/test/chapter3fileorganization/rule313classdeclarations/InputDeclarationOrderStaticMembers.java
@@ -1,0 +1,30 @@
+package com.sun.checkstyle.test.chapter3fileorganization.rule313classdeclarations;
+
+/**
+ * Test input for declaration order with static member violations.
+ */
+public final class InputDeclarationOrderStaticMembers {
+
+    /** Instance variable first. */
+    private int instanceVar = 1;
+
+    /** Static after instance. */
+    // violation below 'Static variable definition in wrong order.'
+    public static final int STATIC_VAR = 2;
+
+    /**
+     * Constructor.
+     */
+    public InputDeclarationOrderStaticMembers() {
+        instanceVar = 0;
+    }
+
+    /**
+     * Gets value.
+     *
+     * @return instance variable value
+     */
+    public int getValue() {
+        return instanceVar + STATIC_VAR;
+    }
+}

--- a/src/it/resources/com/sun/checkstyle/test/chapter3fileorganization/rule313classdeclarations/InputDeclarationOrderValid.java
+++ b/src/it/resources/com/sun/checkstyle/test/chapter3fileorganization/rule313classdeclarations/InputDeclarationOrderValid.java
@@ -1,0 +1,39 @@
+package com.sun.checkstyle.test.chapter3fileorganization.rule313classdeclarations;
+
+/**
+ * Test input for declaration order with valid order (no violations).
+ */
+public final class InputDeclarationOrderValid {
+
+    /** Public static constant. */
+    public static final int PUBLIC_CONST = 1;
+
+    /** Protected static constant. */
+    protected static final int PROTECTED_CONST = 2;
+
+    /** Package-private static constant. */
+    static final int PACKAGE_CONST = 3;
+
+    /** Private static constant. */
+    private static final int PRIVATE_CONST = 4;
+
+    /** Instance variable. */
+    private int instanceVar;
+
+    /**
+     * Constructor.
+     */
+    public InputDeclarationOrderValid() {
+        instanceVar = 0;
+    }
+
+    /**
+     * Gets value.
+     *
+     * @return calculated value
+     */
+    public int getValue() {
+        return PUBLIC_CONST + PROTECTED_CONST + PACKAGE_CONST + PRIVATE_CONST
+                + instanceVar;
+    }
+}

--- a/src/it/resources/com/sun/checkstyle/test/chapter3fileorganization/rule313classdeclarations/InputDeclarationOrderValidInnerClass.java
+++ b/src/it/resources/com/sun/checkstyle/test/chapter3fileorganization/rule313classdeclarations/InputDeclarationOrderValidInnerClass.java
@@ -1,0 +1,63 @@
+package com.sun.checkstyle.test.chapter3fileorganization.rule313classdeclarations;
+
+/**
+ * Test input for valid declaration order with inner class.
+ */
+public final class InputDeclarationOrderValidInnerClass {
+
+    /** Public static constant. */
+    public static final int PUBLIC_CONST = 1;
+
+    /** Protected static constant. */
+    protected static final int PROTECTED_CONST = 2;
+
+    /** Private static constant. */
+    private static final int PRIVATE_CONST = 3;
+
+    /** Instance variable. */
+    private int instanceVar;
+
+    /**
+     * Constructor.
+     */
+    public InputDeclarationOrderValidInnerClass() {
+        instanceVar = 0;
+    }
+
+    /**
+     * Gets value.
+     *
+     * @return calculated value
+     */
+    public int getValue() {
+        return PUBLIC_CONST + PROTECTED_CONST + PRIVATE_CONST + instanceVar;
+    }
+
+    /**
+     * Valid inner class with proper declaration order.
+     */
+    private static final class InnerClass {
+
+        /** Inner static constant. */
+        private static final int INNER_CONST = 1;
+
+        /** Inner instance variable. */
+        private int innerVar;
+
+        /**
+         * Inner constructor.
+         */
+        InnerClass() {
+            innerVar = 0;
+        }
+
+        /**
+         * Gets inner value.
+         *
+         * @return inner value
+         */
+        int getInnerVar() {
+            return innerVar + INNER_CONST;
+        }
+    }
+}

--- a/src/it/resources/com/sun/checkstyle/test/chapter3fileorganization/rule313classdeclarations/package-info.java
+++ b/src/it/resources/com/sun/checkstyle/test/chapter3fileorganization/rule313classdeclarations/package-info.java
@@ -1,0 +1,4 @@
+/**
+ * Test inputs for declaration order check in Sun style.
+ */
+package com.sun.checkstyle.test.chapter3fileorganization.rule313classdeclarations;

--- a/src/it/resources/com/sun/checkstyle/test/chapter7statements/rule71simplestatements/InputOneStatementPerLineDefault.java
+++ b/src/it/resources/com/sun/checkstyle/test/chapter7statements/rule71simplestatements/InputOneStatementPerLineDefault.java
@@ -1,0 +1,39 @@
+package com.sun.checkstyle.test.chapter7statements.rule71simplestatements;
+
+/**
+ * Test input for one statement per line with default violations.
+ */
+public final class InputOneStatementPerLineDefault {
+
+    /** Dummy variable. */
+    private int one = 0;
+
+    /** Dummy variable. */
+    private int two = 0;
+
+    /**
+     * Simple legal method.
+     */
+    public void doLegal() {
+        one = 1;
+        two = 2;
+    }
+
+    /**
+     * Simplest form of illegal layouts.
+     */
+    public void doIllegal() {
+        one = 1; two = 2; // violation 'Only one statement per line allowed.'
+        if (one == 1) {
+            one++; two++; // violation 'Only one statement per line allowed.'
+        }
+        doLegal(); doLegal(); // violation 'Only one statement'
+    }
+
+    /**
+     * Two statements distributed over two lines.
+     */
+    public void doIllegalTwo() {
+        one = 1; two = 2; // violation 'Only one statement per line allowed.'
+    }
+}

--- a/src/it/resources/com/sun/checkstyle/test/chapter7statements/rule71simplestatements/InputOneStatementPerLineForLoop.java
+++ b/src/it/resources/com/sun/checkstyle/test/chapter7statements/rule71simplestatements/InputOneStatementPerLineForLoop.java
@@ -1,0 +1,53 @@
+package com.sun.checkstyle.test.chapter7statements.rule71simplestatements;
+
+/**
+ * Test input for one statement per line in for loop.
+ */
+public final class InputOneStatementPerLineForLoop {
+
+    /**
+     * Method with for loop - multiple statements in header are allowed.
+     */
+    public void method() {
+        int sum = 0;
+        for (int i = 0, j = 0; i < 2; i++, j++) {
+            sum += i + j;
+        }
+    }
+
+    /**
+     * Multiline for loop is legal.
+     */
+    public void multilineFor() {
+        int sum = 0;
+        for (int i = 0,
+             j = 1;
+             i < 2;
+             i++, j--) {
+            sum += i;
+        }
+    }
+
+    /**
+     * Forever loop is legal.
+     */
+    public void foreverLoop() {
+        int count = 0;
+        for (;;) {
+            count++;
+            if (count > 1) {
+                break;
+            }
+        }
+    }
+
+    /**
+     * One statement inside for block is legal.
+     */
+    public void singleStatementFor() {
+        int one = 0;
+        for (int i = 0; i < 2; i++) {
+            one = i;
+        }
+    }
+}

--- a/src/it/resources/com/sun/checkstyle/test/chapter7statements/rule71simplestatements/InputOneStatementPerLineMultiple.java
+++ b/src/it/resources/com/sun/checkstyle/test/chapter7statements/rule71simplestatements/InputOneStatementPerLineMultiple.java
@@ -1,0 +1,46 @@
+package com.sun.checkstyle.test.chapter7statements.rule71simplestatements;
+
+/**
+ * Test input for multiple statements per line.
+ */
+public final class InputOneStatementPerLineMultiple {
+    /** Dummy variable. */
+    private int one = 0;
+
+    /** Dummy variable. */
+    private int two = 0;
+
+    /**
+     * Method with multiple violations.
+     */
+    public void method() {
+        int num = 0;
+        int count = 1; count++; // violation 'Only one statement'
+        num++; count++; // violation 'Only one statement per line allowed.'
+    }
+
+    /**
+     * Method with while loop violation.
+     */
+    public void whileMethod() {
+        while (one < 2) {
+            one++; two--; // violation 'Only one statement per line allowed.'
+        }
+    }
+
+    /**
+     * Method with if statement violation.
+     */
+    public void ifMethod() {
+        if (one == 1) {
+            one++; two++; // violation 'Only one statement per line allowed.'
+        }
+    }
+
+    /**
+     * Method with method call violations.
+     */
+    public void callMethod() {
+        toString(); toString(); // violation 'Only one statement'
+    }
+}

--- a/src/it/resources/com/sun/checkstyle/test/chapter7statements/rule71simplestatements/InputOneStatementPerLineValid.java
+++ b/src/it/resources/com/sun/checkstyle/test/chapter7statements/rule71simplestatements/InputOneStatementPerLineValid.java
@@ -1,0 +1,62 @@
+package com.sun.checkstyle.test.chapter7statements.rule71simplestatements;
+
+/**
+ * Test input for valid one statement per line.
+ */
+public final class InputOneStatementPerLineValid {
+
+    /** Dummy variable. */
+    private int one = 0;
+
+    /** Dummy variable. */
+    private int two = 0;
+
+    /**
+     * Method with proper one statement per line.
+     */
+    public void method() {
+        int num = 0;
+        int count = 1;
+        num++;
+        count++;
+    }
+
+    /**
+     * Legal method with separate lines.
+     */
+    public void doLegal() {
+        one = 1;
+        two = 2;
+    }
+
+    /**
+     * String with format inside is legal.
+     */
+    public void doLegalString() {
+        one = 1;
+        two = 2;
+        System.identityHashCode("one = 1; two = 2");
+    }
+
+    /**
+     * Break and continue statements.
+     */
+    public void loopMethod() {
+        int sum = 0;
+        for (int i = 0; i < 2; i++) {
+            sum += i;
+            if (sum > 1) {
+                break;
+            }
+        }
+
+        while (one < 2) {
+            one++;
+        }
+
+        do {
+            two++;
+        }
+        while (two < 2);
+    }
+}

--- a/src/it/resources/com/sun/checkstyle/test/chapter7statements/rule71simplestatements/package-info.java
+++ b/src/it/resources/com/sun/checkstyle/test/chapter7statements/rule71simplestatements/package-info.java
@@ -1,0 +1,4 @@
+/**
+ * Test inputs for one statement per line check in Sun style.
+ */
+package com.sun.checkstyle.test.chapter7statements.rule71simplestatements;

--- a/src/it/resources/com/sun/checkstyle/test/chapter7statements/rule78switchstatements/InputFallThroughDefault.java
+++ b/src/it/resources/com/sun/checkstyle/test/chapter7statements/rule78switchstatements/InputFallThroughDefault.java
@@ -1,0 +1,28 @@
+package com.sun.checkstyle.test.chapter7statements.rule78switchstatements;
+
+/**
+ * Test input for fall through with default violations.
+ */
+public final class InputFallThroughDefault {
+
+    /**
+     * Method with switch fall through violations.
+     *
+     * @param value input value
+     * @return result
+     */
+    public int method(final int value) {
+        int result = 0;
+        switch (value) {
+            case 0:
+                result = 1;
+                // violation below 'Fall through from previous branch'
+            case 1:
+                result = 2;
+                break;
+            default:
+                result = 0;
+        }
+        return result;
+    }
+}

--- a/src/it/resources/com/sun/checkstyle/test/chapter7statements/rule78switchstatements/InputFallThroughValid.java
+++ b/src/it/resources/com/sun/checkstyle/test/chapter7statements/rule78switchstatements/InputFallThroughValid.java
@@ -1,0 +1,52 @@
+package com.sun.checkstyle.test.chapter7statements.rule78switchstatements;
+
+/**
+ * Test input for valid switch statements (no fall through violations).
+ */
+public final class InputFallThroughValid {
+
+    /**
+     * Method with properly terminated switch cases.
+     *
+     * @param value input value
+     * @return result
+     */
+    public int method(final int value) {
+        int result = 0;
+        switch (value) {
+            case 0:
+                result = 1;
+                break;
+            case 1:
+                result = 2;
+                break;
+            case 2:
+                result = 0;
+                break;
+            default:
+                result = 0;
+                break;
+        }
+        return result;
+    }
+
+    /**
+     * Method with empty cases (allowed to fall through).
+     *
+     * @param value input value
+     * @return result
+     */
+    public int emptyCase(final int value) {
+        int result = 0;
+        switch (value) {
+            case 0:
+            case 1:
+            case 2:
+                result = 1;
+                break;
+            default:
+                result = 0;
+        }
+        return result;
+    }
+}

--- a/src/it/resources/com/sun/checkstyle/test/chapter7statements/rule78switchstatements/InputFallThroughWithBreak.java
+++ b/src/it/resources/com/sun/checkstyle/test/chapter7statements/rule78switchstatements/InputFallThroughWithBreak.java
@@ -1,0 +1,31 @@
+package com.sun.checkstyle.test.chapter7statements.rule78switchstatements;
+
+/**
+ * Test input for fall through with break statements.
+ */
+public final class InputFallThroughWithBreak {
+
+    /**
+     * Method with switch and missing breaks.
+     *
+     * @param value input value
+     * @return result
+     */
+    public int method(final int value) {
+        int result = 0;
+        switch (value) {
+            case 0:
+                result = 1;
+                break;
+            case 1:
+                result = 2;
+                // violation below 'Fall through from previous branch'
+            case 2:
+                result = 0;
+                break;
+            default:
+                result = 0;
+        }
+        return result;
+    }
+}

--- a/src/it/resources/com/sun/checkstyle/test/chapter7statements/rule78switchstatements/InputFallThroughWithComment.java
+++ b/src/it/resources/com/sun/checkstyle/test/chapter7statements/rule78switchstatements/InputFallThroughWithComment.java
@@ -1,0 +1,31 @@
+package com.sun.checkstyle.test.chapter7statements.rule78switchstatements;
+
+/**
+ * Test input for fall through with relief comment.
+ */
+public final class InputFallThroughWithComment {
+
+    /**
+     * Method with switch and fall through comments.
+     *
+     * @param value input value
+     * @return result
+     */
+    public int method(final int value) {
+        int result = 0;
+        switch (value) {
+            case 0:
+                result = 1;
+                // fall through
+            case 1:
+                result = 2;
+                /* falls through */
+            case 2:
+                result = 0;
+                break;
+            default:
+                result = 0;
+        }
+        return result;
+    }
+}

--- a/src/it/resources/com/sun/checkstyle/test/chapter7statements/rule78switchstatements/package-info.java
+++ b/src/it/resources/com/sun/checkstyle/test/chapter7statements/rule78switchstatements/package-info.java
@@ -1,0 +1,4 @@
+/**
+ * Test inputs for fall through check in Sun style.
+ */
+package com.sun.checkstyle.test.chapter7statements.rule78switchstatements;

--- a/src/main/resources/sun_checks.xml
+++ b/src/main/resources/sun_checks.xml
@@ -167,18 +167,21 @@
     <!-- See https://checkstyle.org/checks/coding/index.html -->
     <module name="EmptyStatement"/>
     <module name="EqualsHashCode"/>
+    <module name="FallThrough"/>
     <module name="HiddenField"/>
     <module name="IllegalInstantiation"/>
     <module name="InnerAssignment"/>
     <module name="MagicNumber"/>
     <module name="MissingSwitchDefault"/>
     <module name="MultipleVariableDeclarations"/>
+    <module name="OneStatementPerLine"/>
     <module name="SimplifyBooleanExpression"/>
     <module name="SimplifyBooleanReturn"/>
 
     <!-- Checks for class design                         -->
     <!-- See https://checkstyle.org/checks/design/index.html -->
     <module name="DesignForExtension"/>
+    <module name="DeclarationOrder"/>
     <module name="FinalClass"/>
     <module name="HideUtilityClassConstructor"/>
     <module name="InterfaceIsType"/>

--- a/src/site/xdoc/checks/coding/declarationorder.xml
+++ b/src/site/xdoc/checks/coding/declarationorder.xml
@@ -193,6 +193,10 @@ public class Example3 {
             <a href="https://github.com/search?q=path%3Aconfig%20path%3A**%2Fcheckstyle-checks.xml+repo%3Acheckstyle%2Fcheckstyle+DeclarationOrder">
             Checkstyle Style</a>
           </li>
+          <li>
+            <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources%20path%3A**%2Fsun_checks.xml+repo%3Acheckstyle%2Fcheckstyle+DeclarationOrder">
+            Sun Style</a>
+          </li>
         </ul>
       </subsection>
 

--- a/src/site/xdoc/checks/coding/declarationorder.xml.template
+++ b/src/site/xdoc/checks/coding/declarationorder.xml.template
@@ -78,6 +78,10 @@
             <a href="https://github.com/search?q=path%3Aconfig%20path%3A**%2Fcheckstyle-checks.xml+repo%3Acheckstyle%2Fcheckstyle+DeclarationOrder">
             Checkstyle Style</a>
           </li>
+          <li>
+            <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources%20path%3A**%2Fsun_checks.xml+repo%3Acheckstyle%2Fcheckstyle+DeclarationOrder">
+            Sun Style</a>
+          </li>
         </ul>
       </subsection>
 

--- a/src/site/xdoc/checks/coding/fallthrough.xml
+++ b/src/site/xdoc/checks/coding/fallthrough.xml
@@ -205,6 +205,10 @@ class Example3 {
             <a href="https://github.com/search?q=path%3Aconfig%20path%3A**%2Fcheckstyle-checks.xml+repo%3Acheckstyle%2Fcheckstyle+FallThrough">
             Checkstyle Style</a>
           </li>
+          <li>
+            <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources%20path%3A**%2Fsun_checks.xml+repo%3Acheckstyle%2Fcheckstyle+FallThrough">
+            Sun Style</a>
+          </li>
         </ul>
       </subsection>
 

--- a/src/site/xdoc/checks/coding/fallthrough.xml.template
+++ b/src/site/xdoc/checks/coding/fallthrough.xml.template
@@ -86,6 +86,10 @@
             <a href="https://github.com/search?q=path%3Aconfig%20path%3A**%2Fcheckstyle-checks.xml+repo%3Acheckstyle%2Fcheckstyle+FallThrough">
             Checkstyle Style</a>
           </li>
+          <li>
+            <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources%20path%3A**%2Fsun_checks.xml+repo%3Acheckstyle%2Fcheckstyle+FallThrough">
+            Sun Style</a>
+          </li>
         </ul>
       </subsection>
 

--- a/src/site/xdoc/checks/coding/onestatementperline.xml
+++ b/src/site/xdoc/checks/coding/onestatementperline.xml
@@ -176,6 +176,10 @@ public class Example2 {
             <a href="https://github.com/search?q=path%3Aconfig%20path%3A**%2Fcheckstyle-checks.xml+repo%3Acheckstyle%2Fcheckstyle+OneStatementPerLine">
             Checkstyle Style</a>
           </li>
+          <li>
+            <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources%20path%3A**%2Fsun_checks.xml+repo%3Acheckstyle%2Fcheckstyle+OneStatementPerLine">
+            Sun Style</a>
+          </li>
         </ul>
       </subsection>
 

--- a/src/site/xdoc/checks/coding/onestatementperline.xml.template
+++ b/src/site/xdoc/checks/coding/onestatementperline.xml.template
@@ -80,6 +80,10 @@
             <a href="https://github.com/search?q=path%3Aconfig%20path%3A**%2Fcheckstyle-checks.xml+repo%3Acheckstyle%2Fcheckstyle+OneStatementPerLine">
             Checkstyle Style</a>
           </li>
+          <li>
+            <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources%20path%3A**%2Fsun_checks.xml+repo%3Acheckstyle%2Fcheckstyle+OneStatementPerLine">
+            Sun Style</a>
+          </li>
         </ul>
       </subsection>
 

--- a/src/site/xdoc/sun_style.xml
+++ b/src/site/xdoc/sun_style.xml
@@ -260,7 +260,23 @@
                     3.1.3 Class and Interface Declarations
                   </a>
                 </td>
-                <td>???</td>
+                <td>
+                  <span class="wrapper inline">
+                    <img src="images/ok_blue.png" alt=""/>
+                  </span>
+                  <a href="checks/coding/declarationorder.html#DeclarationOrder">
+                    DeclarationOrder
+                  </a>
+                </td>
+                <td>
+                  <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources%20path%3A**%2Fsun_checks.xml+repo%3Acheckstyle%2Fcheckstyle+DeclarationOrder">
+                    config
+                  </a>
+                  <br/>
+                  <a href="https://github.com/checkstyle/checkstyle/blob/master/src/it/java/com/sun/checkstyle/test/chapter3fileorganization/rule313classdeclarations/DeclarationOrderTest.java">
+                    test
+                  </a>
+                </td>
                 <td/>
               </tr>
               <tr>
@@ -579,7 +595,23 @@
                     7.1 Simple Statements
                   </a>
                 </td>
-                <td>???</td>
+                <td>
+                  <span class="wrapper inline">
+                    <img src="images/ok_green.png" alt=""/>
+                  </span>
+                  <a href="checks/coding/onestatementperline.html#OneStatementPerLine">
+                    OneStatementPerLine
+                  </a>
+                </td>
+                <td>
+                  <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources%20path%3A**%2Fsun_checks.xml+repo%3Acheckstyle%2Fcheckstyle+OneStatementPerLine">
+                    config
+                  </a>
+                  <br/>
+                  <a href="https://github.com/checkstyle/checkstyle/blob/master/src/it/java/com/sun/checkstyle/test/chapter7statements/rule71simplestatements/OneStatementPerLineTest.java">
+                    test
+                  </a>
+                </td>
                 <td/>
               </tr>
               <tr>
@@ -698,7 +730,23 @@
                     7.8 switch Statements
                   </a>
                 </td>
-                <td>???</td>
+                <td>
+                  <span class="wrapper inline">
+                    <img src="images/ok_green.png" alt=""/>
+                  </span>
+                  <a href="checks/coding/fallthrough.html#FallThrough">
+                    FallThrough
+                  </a>
+                </td>
+                <td>
+                  <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources%20path%3A**%2Fsun_checks.xml+repo%3Acheckstyle%2Fcheckstyle+FallThrough">
+                    config
+                  </a>
+                  <br/>
+                  <a href="https://github.com/checkstyle/checkstyle/blob/master/src/it/java/com/sun/checkstyle/test/chapter7statements/rule78switchstatements/FallThroughTest.java">
+                    test
+                  </a>
+                </td>
                 <td/>
               </tr>
               <tr>


### PR DESCRIPTION
Issue #18559:

### Description
Added missing DeclarationOrder, FallThrough, and OneStatementPerLine checks to sun_checks.xml .Also added integration tests and documentation for these checks.

### Changes
*   **Configuration**: Added DeclarationOrder, FallThrough, and OneStatementPerLine to sun_checks.xml.
*   **Test Support**: Updated AbstractSunModuleTestSupport to support verifyWithWholeConfig for full configuration testing.
*   **Integration Tests**: Added new IT tests and input resources for the added checks, ensuring compliance with Sun Code Conventions (including package-info.java files).
*   **Documentation**: Updated sun_style.xml to reflect coverage for:
    *   3.1.3 Class and Interface Declarations
    *   7.1 Simple Statements
    *   7.8 switch Statements