### PR TITLE
Issue #18027: Resolve Pitest Suppressions - ant for retrieveAllScanne…

### DIFF
--- a/config/checker-framework-suppressions/checker-nullness-optional-interning-suppressions.xml
+++ b/config/checker-framework-suppressions/checker-nullness-optional-interning-suppressions.xml
@@ -922,17 +922,6 @@
   </checkerFrameworkError>
 
   <checkerFrameworkError unstable="false">
-    <fileName>src/main/java/com/puppycrawl/tools/checkstyle/SarifLogger.java</fileName>
-    <specifier>return</specifier>
-    <message>incompatible types in return.</message>
-    <lineContent>return SEVERITY_LEVEL_MAP.get(severityLevel);</lineContent>
-    <details>
-      type of expression: @Initialized @Nullable String
-      method return type: @Initialized @NonNull String
-    </details>
-  </checkerFrameworkError>
-
-  <checkerFrameworkError unstable="false">
     <fileName>src/main/java/com/puppycrawl/tools/checkstyle/SuppressionsStringPrinter.java</fileName>
     <specifier>argument</specifier>
     <message>incompatible argument for parameter s of Integer.parseInt.</message>

--- a/config/pitest-suppressions/pitest-ant-suppressions.xml
+++ b/config/pitest-suppressions/pitest-ant-suppressions.xml
@@ -17,13 +17,4 @@
     <description>replaced call to java/util/Objects::toString with argument</description>
     <lineContent>final String version = Objects.toString(</lineContent>
   </mutation>
-
-  <mutation unstable="false">
-    <sourceFile>CheckstyleAntTask.java</sourceFile>
-    <mutatedClass>com.puppycrawl.tools.checkstyle.ant.CheckstyleAntTask</mutatedClass>
-    <mutatedMethod>retrieveAllScannedFiles</mutatedMethod>
-    <mutator>org.pitest.mutationtest.engine.gregor.mutators.NonVoidMethodCallMutator</mutator>
-    <description>removed call to java/lang/Integer::valueOf</description>
-    <lineContent>logIndex, fileNames.length, scanner.getBasedir()), Project.MSG_VERBOSE);</lineContent>
-  </mutation>
 </suppressedMutations>

--- a/pom.xml
+++ b/pom.xml
@@ -4698,6 +4698,10 @@
                 <param>replaceVersionString</param>
                 <!-- this method in XMLLogger.java works properly only when execution is from jar -->
                 <param>printVersionString</param>
+                <!-- Switch expressions with enum cases produce equivalent mutations
+                that cannot be killed since all branches are already covered.
+                See https://github.com/checkstyle/checkstyle/issues/18024 -->
+                <param>renderSeverityLevel</param>
               </excludedMethods>
               <features>
                 <feature>+funmodifiablecollection</feature>

--- a/src/main/java/com/puppycrawl/tools/checkstyle/SarifLogger.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/SarifLogger.java
@@ -111,14 +111,6 @@ public final class SarifLogger extends AbstractAutomaticBean implements AuditLis
     /** Comma and line separator. */
     private static final String COMMA_LINE_SEPARATOR = ",\n";
 
-    /** Map of severity levels to SARIF level strings. */
-    private static final Map<SeverityLevel, String> SEVERITY_LEVEL_MAP = Map.of(
-        SeverityLevel.IGNORE, "none",
-        SeverityLevel.INFO, "note",
-        SeverityLevel.WARNING, "warning",
-        SeverityLevel.ERROR, "error"
-    );
-
     /** Helper writer that allows easy encoding and printing. */
     private final PrintWriter writer;
 
@@ -459,7 +451,12 @@ public final class SarifLogger extends AbstractAutomaticBean implements AuditLis
      * @return the rendered severity level in string.
      */
     private static String renderSeverityLevel(SeverityLevel severityLevel) {
-        return SEVERITY_LEVEL_MAP.get(severityLevel);
+        return switch (severityLevel) {
+            case IGNORE -> "none";
+            case INFO -> "note";
+            case WARNING -> "warning";
+            case ERROR -> "error";
+        };
     }
 
     /**

--- a/src/test/java/com/puppycrawl/tools/checkstyle/ant/CheckstyleAntTaskTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/ant/CheckstyleAntTaskTest.java
@@ -1102,6 +1102,31 @@ public class CheckstyleAntTaskTest extends AbstractPathTestSupport {
                 .isEqualTo("ignore");
     }
 
+    @Test
+    public final void testFileSetWithLogIndexVerification() throws IOException {
+        // given
+        TestRootModuleChecker.reset();
+
+        final CheckstyleAntTaskLogStub antTask = new CheckstyleAntTaskLogStub();
+        antTask.setConfig(getPath(CUSTOM_ROOT_CONFIG_FILE));
+        antTask.setProject(new Project());
+
+        final FileSet fileSet = new FileSet();
+        fileSet.setFile(new File(getPath(FLAWLESS_INPUT)));
+        antTask.addFileset(fileSet);
+
+        // when
+        antTask.scanFileSets();
+
+        // then
+        final List<MessageLevelPair> loggedMessages = antTask.getLoggedMessages();
+
+        assertWithMessage("Log message with correct index was not found")
+                .that(loggedMessages.stream().filter(
+                        msg -> msg.getMsg().startsWith("0) Adding 1 files from directory")).count())
+                .isEqualTo(1);
+    }
+
     private static CheckstyleAntTask.Formatter createPlainFormatter(File outputFile) {
         final CheckstyleAntTask.Formatter formatter = new CheckstyleAntTask.Formatter();
         formatter.setTofile(outputFile);


### PR DESCRIPTION
Issue #18027:
Resolve Pitest Suppressions - ant for retrieveAllScannedFiles method
restored the switch statement again discussed at https://github.com/checkstyle/checkstyle/pull/18580 and excluded the function renderSeverityLevel from the pom.xml