### PR TITLE
dependency: change checker-qual dependency scope to provided

### DIFF
--- a/config/import-control.xml
+++ b/config/import-control.xml
@@ -200,7 +200,6 @@
     </file>
     <subpackage name="imports">
       <allow class="com.puppycrawl.tools.checkstyle.XmlLoader" local-only="true"/>
-      <allow class="org.checkerframework.checker.index.qual.IndexOrLow"/>
     </subpackage>
     <subpackage name="indentation">
       <allow pkg="java.lang.reflect"/>

--- a/pom.xml
+++ b/pom.xml
@@ -471,6 +471,7 @@
       <groupId>org.checkerframework</groupId>
       <artifactId>checker-qual</artifactId>
       <version>${checkerframework.version}</version>
+      <scope>provided</scope>
     </dependency>
     <dependency>
       <groupId>org.apache.maven.doxia</groupId>

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/imports/UnusedImportsCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/imports/UnusedImportsCheck.java
@@ -28,8 +28,6 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import java.util.stream.Stream;
 
-import org.checkerframework.checker.index.qual.IndexOrLow;
-
 import com.puppycrawl.tools.checkstyle.FileStatefulCheck;
 import com.puppycrawl.tools.checkstyle.api.AbstractCheck;
 import com.puppycrawl.tools.checkstyle.api.DetailAST;
@@ -485,7 +483,7 @@ public class UnusedImportsCheck extends AbstractCheck {
      * @return -1 if parentheses are unbalanced, 0 if no method is found,
      *         or the index of the first space outside parentheses.
      */
-    private static @IndexOrLow("#1")int extractReferencePart(String input) {
+    private static int extractReferencePart(String input) {
         int parenthesesCount = 0;
         int firstSpaceOutsideParens = -1;
         for (int index = 0; index < input.length(); index++) {


### PR DESCRIPTION
Change checker-qual dependency scope to provided.

We should not have this library in our depencies, to avoid our user to resolve conflict of versions, especially as we are always using latest versions.

https://github.com/checkstyle/checkstyle/commit/c170d4a43be3d41f5ad900ecd64c33b6355298e0 introducing workaround to avoid dependency to checker artifacts.