### PR TITLE
Issue #17882: Update IDENTIFIER Javadoc with AST to new AST format

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/api/JavadocCommentsTokenTypes.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/api/JavadocCommentsTokenTypes.java
@@ -1059,6 +1059,24 @@ public final class JavadocCommentsTokenTypes {
 
     /**
      * Identifier token.
+     *
+     * <p><b>Example:</b></p>
+     * <pre>{@code * @throws Exception if error.}</pre>
+     *
+     * <p><b>Tree:</b></p>
+     * <pre>{@code
+     * JAVADOC_CONTENT -> JAVADOC_CONTENT
+     * |--LEADING_ASTERISK -> *
+     * |--TEXT ->
+     * `--JAVADOC_BLOCK_TAG -> JAVADOC_BLOCK_TAG
+     *     `--THROWS_BLOCK_TAG -> THROWS_BLOCK_TAG
+     *         |--AT_SIGN -> @
+     *         |--TAG_NAME -> throws
+     *         |--TEXT ->
+     *         |--IDENTIFIER -> Exception
+     *         `--DESCRIPTION -> DESCRIPTION
+     *             `--TEXT ->  if error.
+     * }</pre>
      */
     public static final int IDENTIFIER = JavadocCommentsLexer.IDENTIFIER;
 


### PR DESCRIPTION
issue:#17882

## command
```
java -jar target/checkstyle-*-SNAPSHOT-all.jar -j tmp/Test.java \
  | sed -E "s/\[[0-9]+:[0-9]+\]//g"
```
## Test.java
```
/**
 * @throws Exception if error.
 */
public class Test {
}
```

## AST
```
JAVADOC_CONTENT -> JAVADOC_CONTENT 
|--TEXT -> /** 
|--NEWLINE -> \n 
|--LEADING_ASTERISK ->  * 
|--TEXT ->   
|--JAVADOC_BLOCK_TAG -> JAVADOC_BLOCK_TAG 
|   `--THROWS_BLOCK_TAG -> THROWS_BLOCK_TAG 
|       |--AT_SIGN -> @ 
|       |--TAG_NAME -> throws 
|       |--TEXT ->   
|       |--IDENTIFIER -> Exception 
|       `--DESCRIPTION -> DESCRIPTION 
|           |--TEXT ->  if error. 
|           |--NEWLINE -> \n 
|           |--LEADING_ASTERISK ->  * 
|           |--TEXT -> / 
|           |--NEWLINE -> \n 
|           |--TEXT -> public class Test { 
|           |--NEWLINE -> \n 
|           `--TEXT -> } 
`--NEWLINE -> \n 
```
