### PR TITLE
Issue #17882: Update JAVADOC_INLINE_TAG_START token documentation

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/api/JavadocCommentsTokenTypes.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/api/JavadocCommentsTokenTypes.java
@@ -676,13 +676,44 @@ public final class JavadocCommentsTokenTypes {
     public static final int JAVADOC_INLINE_TAG = JavadocCommentsLexer.JAVADOC_INLINE_TAG;
 
     /**
-     * Start of an inline tag  <code>{</code>.
+     * Start of an inline tag {@code &#123;@}.
+     *
+     * <p><b>Example:</b></p>
+     * <pre>{@code
+     * /**
+     * * {@code code}
+     * &#42;/
+     * }</pre>
+     *
+     * <b>Tree:</b>
+     * <pre>{@code
+     * JAVADOC_CONTENT -> JAVADOC_CONTENT
+     * |--TEXT -> /**
+     * |--NEWLINE -> \n
+     * |--LEADING_ASTERISK ->   *
+     * |--TEXT ->
+     * |--JAVADOC_INLINE_TAG -> JAVADOC_INLINE_TAG
+     * |   `--CODE_INLINE_TAG -> CODE_INLINE_TAG
+     * |       |--JAVADOC_INLINE_TAG_START -> { @
+     * |       |--TAG_NAME -> code
+     * |       |--TEXT ->   code
+     * |       `--JAVADOC_INLINE_TAG_END -> }
+     * |--NEWLINE -> \n
+     * |--LEADING_ASTERISK ->   *
+     * |--TEXT -> /
+     * |--NEWLINE -> \n
+     * |--TEXT -> public class Test {}
+     * `--NEWLINE -> \n
+     * }</pre>
+     *
+     * @see #JAVADOC_INLINE_TAG
+     * @see #JAVADOC_INLINE_TAG_END
      */
     public static final int JAVADOC_INLINE_TAG_START =
             JavadocCommentsLexer.JAVADOC_INLINE_TAG_START;
 
     /**
-     * End of an inline tag <code>}</code>.
+     * End of an inline tag {@code }}.
      */
     public static final int JAVADOC_INLINE_TAG_END = JavadocCommentsLexer.JAVADOC_INLINE_TAG_END;
 


### PR DESCRIPTION
## Issue Reference

Closes #17882

## Description

This PR adds detailed Javadoc documentation for **JAVADOC_INLINE_TAG_START** token in JavadocCommentsTokenTypes.java.

The documentation includes:
- Description of the token's purpose
- Example Javadoc snippet
- AST tree representation
- @see references to related tokens

## CLI Output

Example input:
```java
* {@code text}
```

Command:
```bash
java -jar checkstyle-13.1.0-SNAPSHOT-all.jar -j src/Test.java | sed "s/\[[0-9]\+:[0-9]\+\]//g"
```

Output:
```
JAVADOC_INLINE_TAG -> JAVADOC_INLINE_TAG
`--CODE_INLINE_TAG -> CODE_INLINE_TAG
    |--JAVADOC_INLINE_TAG_START -> {@
    |--TAG_NAME -> code
    |--TEXT ->  text
    `--JAVADOC_INLINE_TAG_END -> }
```

## Testing

- Local compilation passed
