### PR TITLE
Issue #18518: Fix grammar and punctuation in TestingTechniques.md Issue #18518: Fix grammar and punctuation in TestingTechniques.md

### DIFF
--- a/docs/TestingTechniques.md
+++ b/docs/TestingTechniques.md
@@ -7,7 +7,7 @@
 
 **TDD** is one of the encouraged ways to efficiently make new implementations for Checkstyle.
 
-With **TDD**, you create the test prior the implementation that it will test. Created test then
+With **TDD**, you create the test prior to the implementation that it will test. Created test then
 serves as a door to the module's source code, which we can access by using the debug tool and
 reproduce its execution piece by piece.
 
@@ -16,18 +16,18 @@ allowing to develop with respect to that test's results.
 
 ## Where Checkstyle's tests are located
 
-The directory with tests that we need are located in
+The directory with tests that we need is located in
 `src/test/java/com/puppycrawl/tools/checkstyle/,,,`. What follows after is the
 relative path of the module that the needed tests belong to.
 
 - Tests are organized into module data collection files. Each such collection file stores all
-  of the tests for certain module
+  of the tests for a certain module
 - Name format for such collection files is: `[ModuleClassName]Test` where `[...]` indicates you
   paste your own option inside
 
 ## Test structure
 
-Each method with `test` prefix in module data collection files represents distinct test. Such test
+Each method with `test` prefix in module data collection files represents a distinct test. Such test
 methods come in the following common structure:
 
 ```text
@@ -48,7 +48,7 @@ public void test[NameOfTest]() throws Exception {
 Input files are files that are being tested by the test.
 
 All input files are located in same `src/test`
-directory, but in `resources` or`resources-noncompilable` folders.
+directory, but in `resources` or `resources-noncompilable` folders.
 
 - At this moment, Checkstyle uses jdk 17 as its operating version, and all input files that can
   be compiled at jdk 17 or older go to `resources`, while those input files that require newer
@@ -66,7 +66,7 @@ Input files are named in the following format: `Input[ModuleName][FileNickname].
 - The String array, `String[] expected`, contains the violation messages that we *expect* to
   receive from the test.
 - These are not always the violation messages that are guaranteed
-  to come out of test, but rather the violation messages that test *should* give if we assume
+  to come out of the test, but rather the violation messages that the test *should* give if we assume
   that all necessary implementation for that test's module is correctly in effect.
 - The format for expected violation message element in `expected` array is:\
   `"lineNumber:columnNumber: " + <rest of violation message that can be generated using
@@ -76,7 +76,7 @@ Input files are named in the following format: `Input[ModuleName][FileNickname].
 
 Once input file and expected violations are properly connected to the test, it's time for the
 verify method (usually `verifyWithInlineConfigParser()`) to attempt to use Checkstyle to analyze
-input file, get *actual* violations that it detects with current implementation, and at the end
+input file, get *actual* violations that it detects with the current implementation, and at the end
 compare actual results with the expected. If actual results differ from the expected, the test
 fails, and explains where exactly was the inconsistency.
 
@@ -111,7 +111,7 @@ execution.
 
 #### Config (Before)
 
-Enclosed in block comments `/* ... */` at beginning of file, config represents the **before**
+Enclosed in block comments `/* ... */` at the beginning of file, config represents the **before**
 state of the input file as it shows the settings used for the module to run on the code.
 
 There are various types/formats of configs such as `property`, `XML`, and `java`. However, in
@@ -121,7 +121,7 @@ property to be defined), then `XML` format is used. `Java` config format is the 
 others don't help, being defined outside the input file in the test method and thus violating the
 BDD.
 
-The `property`config format has the following layout:
+The `property` config format has the following layout:
 
 ```text
 /*
@@ -147,7 +147,7 @@ scope.
 #### Violation marking (After)
 
 The final part represents the **after** state of input file by showing the intended results of the
-test using specific `// violation` comment marking on same lines of code that intend to cause the
+test using specific `// violation` comment marking on the same lines of code that intend to cause the
 violation.
 
 The format of violation comment is: `// violation, 'violation message'` where violation message
@@ -156,16 +156,16 @@ be entirely written out between the quotes but at least just some part.
 
 ## Conclusion
 
-Once you have the test set up properly, you now have the handy tool for accurately analyzing
+Once you have the test set up properly, you now have a handy tool for accurately analyzing
 the module by using test to access the module's source in real time.
 
-- To do so, place breakpoint anywhere in the module's source and run test method with debug.
+- To do so, place a breakpoint anywhere in the module's source and run the test method with debug.
   This will get you to that point of module's source in debug mode.
 
-This **Test Driven Development** technique with collaboration of debug fits well for solving
+This **Test Driven Development** technique with the collaboration of debug fits well for solving
 various module problems from corresponding issues that give you already prepared information for
 creating the input file and the test to solve that problem.
 
-To watch the live moment on applying TDD to solve module's problem, you can take a look at the
+To watch the live moment on applying TDD to solve a module's problem, you can take a look at the
 [2nd part of video tutorial](https://youtu.be/VnenZbbh1WU?si=wjNjKpMm9WyqQX1C) mentioned at the
 beginning of this page.


### PR DESCRIPTION
Fixes #18518

### Changes made:
- Added missing preposition "to" in line 10: "prior to the implementation"
- Fixed subject-verb agreement in line 19: "directory...is located"
- Added missing article "a" in line 24: "for a certain module"
- Added missing article "a" in line 30: "represents a distinct test"
- Added missing article "the" in line 65: "come out of the test"
- Added missing article "the" in line 66: "that the test should give"
- Added missing article "the" in line 77: "with the current implementation"
- Added missing article "the" in line 111: "at the beginning of file"
- Fixed spacing in line 123: "`property` config format"
- Added missing article "the" in line 152: "on the same lines of code"
- Added missing article "a" in line 161: "have a handy tool"
- Added missing article "a" in line 164: "place a breakpoint"
- Added missing article "the" in line 164: "run the test method"
- Added missing article "the" in line 167: "with the collaboration of debug"
- Added missing article "a" in line 170: "solve a module's problem"

All grammar and punctuation issues have been addressed to improve document readability.