### PR TITLE
Issue #18599: Resolve error-prone violations for ObjectEqualsForPrimi…

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -279,6 +279,7 @@
       -Xep:NestedOptionals:ERROR
       -Xep:NullArgumentForNonNullParameter:ERROR
       -Xep:NullableOptional:ERROR
+      -Xep:ObjectEqualsForPrimitives:ERROR
       <!-- We prefer UnnecessaryParenthesesCheck over error-prone's OperatorPrecedence. -->
       -Xep:OperatorPrecedence:OFF
       -Xep:OptionalOrElseGet:ERROR

--- a/src/main/java/com/puppycrawl/tools/checkstyle/api/LineColumn.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/api/LineColumn.java
@@ -76,6 +76,12 @@ public class LineColumn implements Comparable<LineColumn> {
         return result;
     }
 
+    /**
+     * Generated equals implementation.
+     *
+     * @noinspection ObjectEqualsForPrimitives
+     * @noinspectionreason ObjectEqualsForPrimitives - this code is generated
+     */
     @Override
     public boolean equals(Object other) {
         if (this == other) {
@@ -85,8 +91,8 @@ public class LineColumn implements Comparable<LineColumn> {
             return false;
         }
         final LineColumn lineColumn = (LineColumn) other;
-        return Objects.equals(line, lineColumn.line)
-                && Objects.equals(column, lineColumn.column);
+        return line == lineColumn.line
+            && column == lineColumn.column;
     }
 
     @Override

--- a/src/main/java/com/puppycrawl/tools/checkstyle/api/Violation.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/api/Violation.java
@@ -353,6 +353,8 @@ public final class Violation
      * @noinspection EqualsCalledOnEnumConstant
      * @noinspectionreason EqualsCalledOnEnumConstant - enumeration is needed to keep
      *      code consistent
+     * @noinspection ObjectEqualsForPrimitives
+     * @noinspectionreason ObjectEqualsForPrimitives - this code is generated
      */
     // -@cs[CyclomaticComplexity] equals - a lot of fields to check.
     @Override

--- a/src/main/java/com/puppycrawl/tools/checkstyle/filters/SuppressWithNearbyCommentFilter.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/filters/SuppressWithNearbyCommentFilter.java
@@ -385,6 +385,12 @@ public class SuppressWithNearbyCommentFilter
             }
         }
 
+        /**
+         * Generated equals implementation.
+         *
+         * @noinspection ObjectEqualsForPrimitives
+         * @noinspectionreason ObjectEqualsForPrimitives - this code is generated
+         */
         @Override
         public boolean equals(Object other) {
             if (this == other) {
@@ -394,12 +400,12 @@ public class SuppressWithNearbyCommentFilter
                 return false;
             }
             final Tag tag = (Tag) other;
-            return Objects.equals(firstLine, tag.firstLine)
-                    && Objects.equals(lastLine, tag.lastLine)
-                    && Objects.equals(text, tag.text)
-                    && Objects.equals(tagCheckRegexp, tag.tagCheckRegexp)
-                    && Objects.equals(tagMessageRegexp, tag.tagMessageRegexp)
-                    && Objects.equals(tagIdRegexp, tag.tagIdRegexp);
+            return firstLine == tag.firstLine
+                && lastLine == tag.lastLine
+                && Objects.equals(text, tag.text)
+                && Objects.equals(tagCheckRegexp, tag.tagCheckRegexp)
+                && Objects.equals(tagMessageRegexp, tag.tagMessageRegexp)
+                && Objects.equals(tagIdRegexp, tag.tagIdRegexp);
         }
 
         @Override

--- a/src/main/java/com/puppycrawl/tools/checkstyle/filters/SuppressWithPlainTextCommentFilter.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/filters/SuppressWithPlainTextCommentFilter.java
@@ -362,6 +362,8 @@ public class SuppressWithPlainTextCommentFilter extends AbstractAutomaticBean im
          * @noinspection EqualsCalledOnEnumConstant
          * @noinspectionreason EqualsCalledOnEnumConstant - enumeration is needed to keep
          *      code consistent
+         * @noinspection ObjectEqualsForPrimitives
+         * @noinspectionreason ObjectEqualsForPrimitives - this code is generated
          */
         @Override
         public boolean equals(Object other) {
@@ -372,7 +374,7 @@ public class SuppressWithPlainTextCommentFilter extends AbstractAutomaticBean im
                 return false;
             }
             final Suppression suppression = (Suppression) other;
-            return Objects.equals(lineNo, suppression.lineNo)
+            return lineNo == suppression.lineNo
                     && Objects.equals(suppressionType, suppression.suppressionType)
                     && Objects.equals(eventSourceRegexp, suppression.eventSourceRegexp)
                     && Objects.equals(eventMessageRegexp, suppression.eventMessageRegexp)

--- a/src/main/java/com/puppycrawl/tools/checkstyle/filters/SuppressionCommentFilter.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/filters/SuppressionCommentFilter.java
@@ -474,6 +474,8 @@ public class SuppressionCommentFilter
          * @noinspection EqualsCalledOnEnumConstant
          * @noinspectionreason EqualsCalledOnEnumConstant - enumeration is needed to keep
          *      code consistent
+         * @noinspection ObjectEqualsForPrimitives
+         * @noinspectionreason ObjectEqualsForPrimitives - this code is generated
          */
         @Override
         public boolean equals(Object other) {
@@ -484,8 +486,8 @@ public class SuppressionCommentFilter
                 return false;
             }
             final Tag tag = (Tag) other;
-            return Objects.equals(line, tag.line)
-                    && Objects.equals(column, tag.column)
+            return line == tag.line
+                    && column == tag.column
                     && Objects.equals(tagType, tag.tagType)
                     && Objects.equals(text, tag.text)
                     && Objects.equals(tagCheckRegexp, tag.tagCheckRegexp)


### PR DESCRIPTION
Issue : #18599 

https://errorprone.info/bugpattern/ObjectEqualsForPrimitives


This PR handles the violations related to `ObjectEqualsForPrimitives` for the given files:

`LineColumn.java`

`Violation.java`

`SuppressWithNearbyCommentFilter.java`

`SuppressWithPlainTextCommentFilter.java`

`SuppressionCommentFilter.java`