### PR TITLE
Issue #18599: Resolve error-prone violations

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -253,6 +253,7 @@
       -Xep:FormatStringConcatenation:ERROR
       -Xep:IdentityConversion:ERROR
       -Xep:ImmutablesSortedSetComparator:ERROR
+      -Xep:InvalidParam:ERROR
       -Xep:IsInstanceLambdaUsage:ERROR
       -Xep:LexicographicalAnnotationAttributeListing:ERROR
       -Xep:LexicographicalAnnotationListing:ERROR

--- a/src/main/java/com/puppycrawl/tools/checkstyle/PackageObjectFactory.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/PackageObjectFactory.java
@@ -267,14 +267,14 @@ public class PackageObjectFactory implements ModuleFactory {
 
     /**
      * Create Object from optional full module names.
-     * In most case, there should be only one element in {@code fullModuleName}, otherwise
+     * In most case, there should be only one element in {@code fullModuleNames}, otherwise
      * an exception would be thrown.
      *
      * @param name name of module
      * @param fullModuleNames the supplied full module names set
-     * @return instance of module if there is only one element in {@code fullModuleName}
+     * @return instance of module if there is only one element in {@code fullModuleNames}
      * @throws CheckstyleException if the class fails to instantiate or there are more than one
-     *      element in {@code fullModuleName}
+     *      element in {@code fullModuleNames}
      */
     private Object createObjectFromFullModuleNames(String name, Set<String> fullModuleNames)
             throws CheckstyleException {


### PR DESCRIPTION
Issue #18599

Fixed ->
```
  Did you mean '* In most case, there should be only one element in {@code fullModuleNames}, otherwise'?
Warning:  /home/runner/work/checkstyle/checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/PackageObjectFactory.java:[275,67] [InvalidParam] `fullModuleName` is very close to the parameter `fullModuleNames`. Did you mean to reference the parameter?
    (see https://errorprone.info/bugpattern/InvalidParam)
  Did you mean '* @return instance of module if there is only one element in {@code fullModuleNames}'?
Warning:  /home/runner/work/checkstyle/checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/PackageObjectFactory.java:[277,24] [InvalidParam] `fullModuleName` is very close to the parameter `fullModuleNames`. Did you mean to reference the parameter?
    (see https://errorprone.info/bugpattern/InvalidParam)
  Did you mean '*      element in {@code fullModuleNames}'?
```