### PR TITLE
doc: add Example5 for IllegalTokenText custom message

### DIFF
--- a/src/site/xdoc/checks/coding/illegaltokentext.xml
+++ b/src/site/xdoc/checks/coding/illegaltokentext.xml
@@ -175,6 +175,29 @@ public class Example4 {
     long test6 = 010L; // violation
   }
 }
+</code></pre></div><hr class="example-separator"/>
+        <p id="Example5-config">
+          To configure the check with a custom violation message using the
+          <code>message</code> property:
+        </p>
+        <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
+&lt;module name="Checker"&gt;
+  &lt;module name="TreeWalker"&gt;
+    &lt;module name="IllegalTokenText"&gt;
+      &lt;property name="tokens" value="STRING_LITERAL"/&gt;
+      &lt;property name="format" value="href"/&gt;
+      &lt;property name="message" value="Custom illegal text found"/&gt;
+    &lt;/module&gt;
+  &lt;/module&gt;
+&lt;/module&gt;
+</code></pre></div>
+        <p id="Example5-code">Example:</p>
+        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+public class Example5 {
+  public void test() {
+    String link  = "href"; // violation, Custom illegal text found
+  }
+}
 </code></pre></div>
       </subsection>
 

--- a/src/site/xdoc/checks/coding/illegaltokentext.xml.template
+++ b/src/site/xdoc/checks/coding/illegaltokentext.xml.template
@@ -87,6 +87,21 @@
           <param name="path"
                  value="resources/com/puppycrawl/tools/checkstyle/checks/coding/illegaltokentext/Example4.java"/>
           <param name="type" value="code"/>
+        </macro><hr class="example-separator"/>
+        <p id="Example5-config">
+          To configure the check with a custom violation message using the
+          <code>message</code> property:
+        </p>
+        <macro name="example">
+          <param name="path"
+                 value="resources/com/puppycrawl/tools/checkstyle/checks/coding/illegaltokentext/Example5.java"/>
+          <param name="type" value="config"/>
+        </macro>
+        <p id="Example5-code">Example:</p>
+        <macro name="example">
+          <param name="path"
+                 value="resources/com/puppycrawl/tools/checkstyle/checks/coding/illegaltokentext/Example5.java"/>
+          <param name="type" value="code"/>
         </macro>
       </subsection>
 

--- a/src/test/java/com/puppycrawl/tools/checkstyle/internal/XdocsExampleFileTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/internal/XdocsExampleFileTest.java
@@ -63,7 +63,6 @@ public class XdocsExampleFileTest {
             Map.entry("ConstantNameCheck", Set.of("applyToPackage", "applyToPrivate")),
             Map.entry("WhitespaceAroundCheck", Set.of("allowEmptySwitchBlockStatements")),
             Map.entry("SuppressWarningsHolder", Set.of("aliasList")),
-            Map.entry("IllegalTokenTextCheck", Set.of("message")),
             Map.entry("IndentationCheck", Set.of(
                     "basicOffset",
                     "lineWrappingIndentation",

--- a/src/test/java/com/puppycrawl/tools/checkstyle/internal/XdocsExamplesAstConsistencyTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/internal/XdocsExamplesAstConsistencyTest.java
@@ -104,6 +104,7 @@ public class XdocsExamplesAstConsistencyTest {
             "checks/coding/illegaltoken/Example2",
             "checks/coding/illegaltokentext/Example3",
             "checks/coding/illegaltokentext/Example4",
+            "checks/coding/illegaltokentext/Example5",
             "checks/coding/innerassignment/Example2",
             "checks/coding/matchxpath/Example2",
             "checks/coding/matchxpath/Example3",

--- a/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/checks/coding/IllegalTokenTextCheckExamplesTest.java
+++ b/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/checks/coding/IllegalTokenTextCheckExamplesTest.java
@@ -68,4 +68,13 @@ public class IllegalTokenTextCheckExamplesTest extends AbstractExamplesModuleTes
 
         verifyWithInlineConfigParser(getPath("Example4.java"), expected);
     }
+
+    @Test
+    public void testExample5() throws Exception {
+        final String[] expected = {
+            "18:20: Custom illegal text found",
+        };
+
+        verifyWithInlineConfigParser(getPath("Example5.java"), expected);
+    }
 }

--- a/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/coding/illegaltokentext/Example5.java
+++ b/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/coding/illegaltokentext/Example5.java
@@ -1,0 +1,21 @@
+/*xml
+<module name="Checker">
+  <module name="TreeWalker">
+    <module name="IllegalTokenText">
+      <property name="tokens" value="STRING_LITERAL"/>
+      <property name="format" value="href"/>
+      <property name="message" value="Custom illegal text found"/>
+    </module>
+  </module>
+</module>
+*/
+
+package com.puppycrawl.tools.checkstyle.checks.coding.illegaltokentext;
+
+// xdoc section -- start
+public class Example5 {
+  public void test() {
+    String link  = "href"; // violation, Custom illegal text found
+  }
+}
+// xdoc section -- end


### PR DESCRIPTION
Issue: #17449

This change adds a new Example5 to demonstrate usage of the IllegalTokenText
check with a custom violation message via the message property.

Updates include:
- New Example5 source under xdocs-examples resources
- Corresponding example test coverage
- Documentation updates to include the new example
- Suppression added for AST consistency where example intent differs

All changes are documentation/example-only and do not affect check logic.
