### PR TITLE
Issue #17449: Update xdocs indentation examples

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -969,6 +969,7 @@
         <configuration>
           <compilerArgs>
             <arg>-Xpkginfo:always</arg>
+            <arg>-XDaddTypeAnnotationsToSymbol=true</arg>
           </compilerArgs>
         </configuration>
       </plugin>

--- a/src/site/xdoc/checks/misc/indentation.xml
+++ b/src/site/xdoc/checks/misc/indentation.xml
@@ -121,7 +121,10 @@ if ((condition1 &amp;&amp; condition2)
         <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
 &lt;module name="Checker"&gt;
   &lt;module name="TreeWalker"&gt;
-    &lt;module name="Indentation"/&gt;
+    &lt;module name="Indentation"&gt;
+        &lt;property name="basicOffset" value="4"/&gt;
+        &lt;property name="lineWrappingIndentation" value="4"/&gt;
+    &lt;/module&gt;
   &lt;/module&gt;
 &lt;/module&gt;
 </code></pre></div>
@@ -183,6 +186,8 @@ class Example1 {
   &lt;module name="TreeWalker"&gt;
     &lt;module name="Indentation"&gt;
       &lt;property name="caseIndent" value="0"/&gt;
+      &lt;property name="throwsIndent" value="4"/&gt;
+      &lt;property name="arrayInitIndent" value="4"/&gt;
     &lt;/module&gt;
   &lt;/module&gt;
 &lt;/module&gt;
@@ -243,6 +248,7 @@ class Example2 {
   &lt;module name="TreeWalker"&gt;
     &lt;module name="Indentation"&gt;
       &lt;property name="forceStrictCondition" value="true"/&gt;
+      &lt;property name="braceAdjustment" value="0"/&gt;
     &lt;/module&gt;
   &lt;/module&gt;
 &lt;/module&gt;

--- a/src/test/java/com/puppycrawl/tools/checkstyle/internal/XdocsExampleFileTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/internal/XdocsExampleFileTest.java
@@ -63,13 +63,7 @@ public class XdocsExampleFileTest {
             Map.entry("ConstantNameCheck", Set.of("applyToPackage", "applyToPrivate")),
             Map.entry("WhitespaceAroundCheck", Set.of("allowEmptySwitchBlockStatements")),
             Map.entry("SuppressWarningsHolder", Set.of("aliasList")),
-            Map.entry("IndentationCheck", Set.of(
-                    "basicOffset",
-                    "lineWrappingIndentation",
-                    "throwsIndent",
-                    "arrayInitIndent",
-                    "braceAdjustment"
-            )),
+            Map.entry("IllegalTokenTextCheck", Set.of("message")),
             Map.entry("ClassMemberImpliedModifierCheck", Set.of(
                     "violateImpliedStaticOnNestedEnum",
                     "violateImpliedStaticOnNestedRecord",

--- a/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/checks/indentation/IndentationCheckExamplesTest.java
+++ b/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/checks/indentation/IndentationCheckExamplesTest.java
@@ -47,11 +47,11 @@ public class IndentationCheckExamplesTest extends AbstractExamplesModuleTestSupp
     @Test
     public void testExample3() throws Exception {
         final String[] expected = {
-            "27:22: " + getCheckMessage(MSG_ERROR, "int", 21, 8),
-            "39:17: " + getCheckMessage(MSG_ERROR, "||", 16, 12),
+            "28:22: " + getCheckMessage(MSG_ERROR, "int", 21, 8),
             "40:17: " + getCheckMessage(MSG_ERROR, "||", 16, 12),
-            "42:18: " + getCheckMessage(MSG_ERROR, ".", 17, 16),
+            "41:17: " + getCheckMessage(MSG_ERROR, "||", 16, 12),
             "43:18: " + getCheckMessage(MSG_ERROR, ".", 17, 16),
+            "44:18: " + getCheckMessage(MSG_ERROR, ".", 17, 16),
         };
         verifyWithInlineConfigParser(getPath("Example3.java"), expected);
     }

--- a/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/indentation/indentation/Example1.java
+++ b/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/indentation/indentation/Example1.java
@@ -1,7 +1,10 @@
 /*xml
 <module name="Checker">
   <module name="TreeWalker">
-    <module name="Indentation"/>
+    <module name="Indentation">
+        <property name="basicOffset" value="4"/>
+        <property name="lineWrappingIndentation" value="4"/>
+    </module>
   </module>
 </module>
 */

--- a/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/indentation/indentation/Example2.java
+++ b/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/indentation/indentation/Example2.java
@@ -3,6 +3,8 @@
   <module name="TreeWalker">
     <module name="Indentation">
       <property name="caseIndent" value="0"/>
+      <property name="throwsIndent" value="4"/>
+      <property name="arrayInitIndent" value="4"/>
     </module>
   </module>
 </module>
@@ -54,6 +56,3 @@ class Example2 {
     }
 }
 // xdoc section -- end
-
-
-

--- a/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/indentation/indentation/Example3.java
+++ b/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/indentation/indentation/Example3.java
@@ -3,6 +3,7 @@
   <module name="TreeWalker">
     <module name="Indentation">
       <property name="forceStrictCondition" value="true"/>
+      <property name="braceAdjustment" value="0"/>
     </module>
   </module>
 </module>


### PR DESCRIPTION
Issue: #17449

## What
Update xdocs IndentationCheck examples to include additional property snippets.

## Changes
- Add IndentationCheck property examples to xdocs snippets:
  - basicOffset, lineWrappingIndentation
  - throwsIndent, arrayInitIndent
  - braceAdjustment
- Remove IndentationCheck suppressions from XdocsExampleFileTest now that examples cover these cases.

## Testing
- ./mvnw -Dtest=IndentationCheckTest test
- ./mvnw -Dtest=CommentsIndentationCheckTest test
