### PR TITLE
Issue #17882: Added AST tree example for JAVADOC_INLINE_TAG_START

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/api/JavadocCommentsTokenTypes.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/api/JavadocCommentsTokenTypes.java
@@ -697,7 +697,40 @@ public final class JavadocCommentsTokenTypes {
     public static final int JAVADOC_INLINE_TAG = JavadocCommentsLexer.JAVADOC_INLINE_TAG;
 
     /**
-     * Start of an inline tag  <code>{</code>.
+     * Start of an inline tag <code>{</code>.
+     *
+     * <p>This node represents the start of a Javadoc inline tag like
+     * {@code @code} or {@code @link}.</p>
+     *
+     * <p><b>Example:</b></p>
+     * <pre>{@code
+     * /**
+     * * {@code code}
+     * &#42;/
+     * }</pre>
+     *
+     * <b>Tree:</b>
+     * <pre>{@code
+     * JAVADOC_CONTENT -> JAVADOC_CONTENT
+     * |--TEXT -> /**
+     * |--NEWLINE -> \n
+     * |--LEADING_ASTERISK ->   *
+     * |--TEXT ->
+     * |--JAVADOC_INLINE_TAG -> JAVADOC_INLINE_TAG
+     * |   `--CODE_INLINE_TAG -> CODE_INLINE_TAG
+     * |       |--JAVADOC_INLINE_TAG_START -> { @
+     * |       |--TAG_NAME -> code
+     * |       |--TEXT ->   code
+     * |       `--JAVADOC_INLINE_TAG_END -> }
+     * |--NEWLINE -> \n
+     * |--LEADING_ASTERISK ->   *
+     * |--TEXT -> /
+     * |--NEWLINE -> \n
+     * |--TEXT -> public class Test {}
+     * `--NEWLINE -> \n
+     * }</pre>
+     *
+     * @see #JAVADOC_INLINE_TAG
      */
     public static final int JAVADOC_INLINE_TAG_START =
             JavadocCommentsLexer.JAVADOC_INLINE_TAG_START;


### PR DESCRIPTION
Issue: #17882

### **Description**
Updated JAVADOC_INLINE_TAG_START token in JavadocCommentsTokenTypes.java to include the new AST print format examples.
### Example
**Input Code (src/Test.java):**

public class Test {
    /**
     * {@code exampleCode}
     */
}

**Command:** 
java -jar checkstyle-13.0.1-SNAPSHOT-all.jar -j src/Test.java | sed "s/\[[0-9]\+:[0-9]\+\]//g"

```
JAVADOC_CONTENT -> JAVADOC_CONTENT [0:0]
|--TEXT -> public class Test { [0:0]
|--NEWLINE -> \n [0:19]
|--TEXT ->     /** [1:0]
|--NEWLINE -> \n [1:7]
|--LEADING_ASTERISK ->      * [2:0]
|--TEXT ->   [2:6]
|--JAVADOC_INLINE_TAG -> JAVADOC_INLINE_TAG [2:7]
|   `--CODE_INLINE_TAG -> CODE_INLINE_TAG [2:7]
|       |--JAVADOC_INLINE_TAG_START -> {@ [2:7]
|       |--TAG_NAME -> code [2:9]
|       |--TEXT ->  exampleCode [2:13]
|       `--JAVADOC_INLINE_TAG_END -> } [2:25]
|--NEWLINE -> \n [2:26]
|--LEADING_ASTERISK ->      * [3:0]
|--TEXT -> / [3:6]
|--NEWLINE -> \n [3:7]
|--TEXT -> } [4:0]
`--NEWLINE -> \n [4:1]
```