### PR TITLE
Issue #18621: Add OpenJDK Java Style Guidelines coverage infrastructure

### DIFF
--- a/config/import-control-test.xml
+++ b/config/import-control-test.xml
@@ -7,6 +7,7 @@
         pkg="(|
         |com\.puppycrawl\.tools\.checkstyle|
         |com\.google\.checkstyle\.test|
+        |com\.openjdk\.checkstyle\.test|
         |com\.sun\.checkstyle\.test|
         |org\.checkstyle.*)"
         regex="true">

--- a/config/jsoref-spellchecker/whitelist.words
+++ b/config/jsoref-spellchecker/whitelist.words
@@ -473,6 +473,7 @@ Fmetrics
 Fmodifier
 FModule
 Fnaming
+Fopenjdk
 forbiddenapis
 Foreach
 Fpuppycrawl
@@ -1529,6 +1530,7 @@ wontfix
 workaround
 workflow
 wq
+wrappinglines
 writetag
 writingchecks
 writingfilefilters

--- a/src/it/java/com/openjdk/checkstyle/test/base/AbstractOpenJdkModuleTestSupport.java
+++ b/src/it/java/com/openjdk/checkstyle/test/base/AbstractOpenJdkModuleTestSupport.java
@@ -1,0 +1,86 @@
+///////////////////////////////////////////////////////////////////////////////////////////////
+// checkstyle: Checks Java source code and other text files for adherence to a set of rules.
+// Copyright (C) 2001-2026 the original author or authors.
+//
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the GNU Lesser General Public
+// License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+//
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+// Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public
+// License along with this library; if not, write to the Free Software
+// Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+///////////////////////////////////////////////////////////////////////////////////////////////
+
+package com.openjdk.checkstyle.test.base;
+
+import java.io.IOException;
+import java.util.Set;
+
+import org.checkstyle.base.AbstractItModuleTestSupport;
+
+import com.puppycrawl.tools.checkstyle.ConfigurationLoader;
+import com.puppycrawl.tools.checkstyle.PropertiesExpander;
+import com.puppycrawl.tools.checkstyle.api.CheckstyleException;
+import com.puppycrawl.tools.checkstyle.api.Configuration;
+import com.puppycrawl.tools.checkstyle.internal.utils.CheckUtil;
+import com.puppycrawl.tools.checkstyle.utils.ModuleReflectionUtil;
+
+public abstract class AbstractOpenJdkModuleTestSupport extends AbstractItModuleTestSupport {
+
+    private static final String XML_NAME = "/openjdk_checks.xml";
+
+    private static final Configuration CONFIGURATION;
+
+    private static final Set<Class<?>> CHECKSTYLE_MODULES;
+
+    static {
+        try {
+            CONFIGURATION = ConfigurationLoader.loadConfiguration(XML_NAME,
+                    new PropertiesExpander(System.getProperties()));
+        }
+        catch (CheckstyleException exc) {
+            throw new IllegalStateException(exc);
+        }
+        try {
+            CHECKSTYLE_MODULES = CheckUtil.getCheckstyleModules();
+        }
+        catch (IOException exc) {
+            throw new IllegalStateException(exc);
+        }
+    }
+
+    @Override
+    protected ModuleCreationOption findModuleCreationOption(String moduleName) {
+        ModuleCreationOption moduleCreationOption = ModuleCreationOption.IN_CHECKER;
+
+        for (Class<?> moduleClass : CHECKSTYLE_MODULES) {
+            if (moduleClass.getSimpleName().equals(moduleName)
+                    || moduleClass.getSimpleName().equals(moduleName + "Check")) {
+                if (ModuleReflectionUtil.isCheckstyleTreeWalkerCheck(moduleClass)
+                        || ModuleReflectionUtil.isTreeWalkerFilterModule(moduleClass)) {
+                    moduleCreationOption = ModuleCreationOption.IN_TREEWALKER;
+                }
+                break;
+            }
+        }
+
+        return moduleCreationOption;
+    }
+
+    /**
+     * Performs verification of the file with the given file path against the whole config.
+     *
+     * @param filePath file path to verify.
+     * @throws Exception if exception occurs during verification process.
+     */
+    protected void verifyWithWholeConfig(String filePath) throws Exception {
+        verifyWithItConfig(CONFIGURATION, filePath);
+    }
+
+}

--- a/src/it/java/com/openjdk/checkstyle/test/chapter3formatting/rule38wrappinglines/OneStatementPerLineTest.java
+++ b/src/it/java/com/openjdk/checkstyle/test/chapter3formatting/rule38wrappinglines/OneStatementPerLineTest.java
@@ -1,0 +1,53 @@
+///////////////////////////////////////////////////////////////////////////////////////////////
+// checkstyle: Checks Java source code and other text files for adherence to a set of rules.
+// Copyright (C) 2001-2026 the original author or authors.
+//
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the GNU Lesser General Public
+// License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+//
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+// Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public
+// License along with this library; if not, write to the Free Software
+// Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+///////////////////////////////////////////////////////////////////////////////////////////////
+
+package com.openjdk.checkstyle.test.chapter3formatting.rule38wrappinglines;
+
+import org.junit.jupiter.api.Test;
+
+import com.openjdk.checkstyle.test.base.AbstractOpenJdkModuleTestSupport;
+
+public class OneStatementPerLineTest extends AbstractOpenJdkModuleTestSupport {
+
+    @Override
+    public String getPackageLocation() {
+        return "com/openjdk/checkstyle/test/chapter3formatting/rule38wrappinglines";
+    }
+
+    @Test
+    public void testOneStatementPerLineDefault() throws Exception {
+        verifyWithWholeConfig(getPath("InputOneStatementPerLineDefault.java"));
+    }
+
+    @Test
+    public void testOneStatementPerLineMultiple() throws Exception {
+        verifyWithWholeConfig(getPath("InputOneStatementPerLineMultiple.java"));
+    }
+
+    @Test
+    public void testOneStatementPerLineValid() throws Exception {
+        verifyWithWholeConfig(getPath("InputOneStatementPerLineValid.java"));
+    }
+
+    @Test
+    public void testOneStatementPerLineForLoop() throws Exception {
+        verifyWithWholeConfig(getPath("InputOneStatementPerLineForLoop.java"));
+    }
+
+}

--- a/src/it/resources/com/openjdk/checkstyle/test/chapter3formatting/rule38wrappinglines/InputOneStatementPerLineDefault.java
+++ b/src/it/resources/com/openjdk/checkstyle/test/chapter3formatting/rule38wrappinglines/InputOneStatementPerLineDefault.java
@@ -1,0 +1,39 @@
+package com.openjdk.checkstyle.test.chapter3formatting.rule38wrappinglines;
+
+/**
+ * Test input for one statement per line with default violations.
+ */
+public final class InputOneStatementPerLineDefault {
+
+    /** Dummy variable. */
+    private int one = 0;
+
+    /** Dummy variable. */
+    private int two = 0;
+
+    /**
+     * Simple legal method.
+     */
+    public void doLegal() {
+        one = 1;
+        two = 2;
+    }
+
+    /**
+     * Simplest form of illegal layouts.
+     */
+    public void doIllegal() {
+        one = 1; two = 2; // violation 'Only one statement per line allowed.'
+        if (one == 1) {
+            one++; two++; // violation 'Only one statement per line allowed.'
+        }
+        doLegal(); doLegal(); // violation 'Only one statement'
+    }
+
+    /**
+     * Two statements distributed over two lines.
+     */
+    public void doIllegalTwo() {
+        one = 1; two = 2; // violation 'Only one statement per line allowed.'
+    }
+}

--- a/src/it/resources/com/openjdk/checkstyle/test/chapter3formatting/rule38wrappinglines/InputOneStatementPerLineForLoop.java
+++ b/src/it/resources/com/openjdk/checkstyle/test/chapter3formatting/rule38wrappinglines/InputOneStatementPerLineForLoop.java
@@ -1,0 +1,53 @@
+package com.openjdk.checkstyle.test.chapter3formatting.rule38wrappinglines;
+
+/**
+ * Test input for one statement per line in for loop.
+ */
+public final class InputOneStatementPerLineForLoop {
+
+    /**
+     * Method with for loop - multiple statements in header are allowed.
+     */
+    public void method() {
+        int sum = 0;
+        for (int i = 0, j = 0; i < 2; i++, j++) {
+            sum += i + j;
+        }
+    }
+
+    /**
+     * Multiline for loop is legal.
+     */
+    public void multilineFor() {
+        int sum = 0;
+        for (int i = 0,
+             j = 1;
+             i < 2;
+             i++, j--) {
+            sum += i;
+        }
+    }
+
+    /**
+     * Forever loop is legal.
+     */
+    public void foreverLoop() {
+        int count = 0;
+        for (;;) {
+            count++;
+            if (count > 1) {
+                break;
+            }
+        }
+    }
+
+    /**
+     * One statement inside for block is legal.
+     */
+    public void singleStatementFor() {
+        int one = 0;
+        for (int i = 0; i < 2; i++) {
+            one = i;
+        }
+    }
+}

--- a/src/it/resources/com/openjdk/checkstyle/test/chapter3formatting/rule38wrappinglines/InputOneStatementPerLineMultiple.java
+++ b/src/it/resources/com/openjdk/checkstyle/test/chapter3formatting/rule38wrappinglines/InputOneStatementPerLineMultiple.java
@@ -1,0 +1,46 @@
+package com.openjdk.checkstyle.test.chapter3formatting.rule38wrappinglines;
+
+/**
+ * Test input for multiple statements per line.
+ */
+public final class InputOneStatementPerLineMultiple {
+    /** Dummy variable. */
+    private int one = 0;
+
+    /** Dummy variable. */
+    private int two = 0;
+
+    /**
+     * Method with multiple violations.
+     */
+    public void method() {
+        int num = 0;
+        int count = 1; count++; // violation 'Only one statement'
+        num++; count++; // violation 'Only one statement per line allowed.'
+    }
+
+    /**
+     * Method with while loop violation.
+     */
+    public void whileMethod() {
+        while (one < 2) {
+            one++; two--; // violation 'Only one statement per line allowed.'
+        }
+    }
+
+    /**
+     * Method with if statement violation.
+     */
+    public void ifMethod() {
+        if (one == 1) {
+            one++; two++; // violation 'Only one statement per line allowed.'
+        }
+    }
+
+    /**
+     * Method with method call violations.
+     */
+    public void callMethod() {
+        toString(); toString(); // violation 'Only one statement'
+    }
+}

--- a/src/it/resources/com/openjdk/checkstyle/test/chapter3formatting/rule38wrappinglines/InputOneStatementPerLineValid.java
+++ b/src/it/resources/com/openjdk/checkstyle/test/chapter3formatting/rule38wrappinglines/InputOneStatementPerLineValid.java
@@ -1,0 +1,62 @@
+package com.openjdk.checkstyle.test.chapter3formatting.rule38wrappinglines;
+
+/**
+ * Test input for valid one statement per line.
+ */
+public final class InputOneStatementPerLineValid {
+
+    /** Dummy variable. */
+    private int one = 0;
+
+    /** Dummy variable. */
+    private int two = 0;
+
+    /**
+     * Method with proper one statement per line.
+     */
+    public void method() {
+        int num = 0;
+        int count = 1;
+        num++;
+        count++;
+    }
+
+    /**
+     * Legal method with separate lines.
+     */
+    public void doLegal() {
+        one = 1;
+        two = 2;
+    }
+
+    /**
+     * String with format inside is legal.
+     */
+    public void doLegalString() {
+        one = 1;
+        two = 2;
+        System.identityHashCode("one = 1; two = 2");
+    }
+
+    /**
+     * Break and continue statements.
+     */
+    public void loopMethod() {
+        int sum = 0;
+        for (int i = 0; i < 2; i++) {
+            sum += i;
+            if (sum > 1) {
+                break;
+            }
+        }
+
+        while (one < 2) {
+            one++;
+        }
+
+        do {
+            two++;
+        }
+        while (two < 2);
+    }
+}

--- a/src/main/resources/openjdk_checks.xml
+++ b/src/main/resources/openjdk_checks.xml
@@ -1,0 +1,51 @@
+<?xml version="1.0"?>
+<!DOCTYPE module PUBLIC
+          "-//Checkstyle//DTD Checkstyle Configuration 1.3//EN"
+          "https://checkstyle.org/dtds/configuration_1_3.dtd">
+
+<!--
+  Checkstyle configuration that checks the OpenJDK coding conventions from the
+  OpenJDK Java Style Guidelines at https://cr.openjdk.org/~alundblad/styleguide/index-v6.html
+
+  Checkstyle is very configurable. Be sure to read the documentation at
+  https://checkstyle.org (or in your downloaded distribution).
+
+  To completely disable a check, just comment it out or delete it from the file.
+  To suppress certain violations please review suppression filters.
+
+-->
+
+<module name="Checker">
+  <property name="severity" value="error"/>
+
+  <property name="fileExtensions" value="java, properties, xml"/>
+
+  <!-- Excludes all 'module-info.java' files              -->
+  <!-- See https://checkstyle.org/filefilters/index.html -->
+  <module name="BeforeExecutionExclusionFileFilter">
+    <property name="fileNamePattern" value="module\-info\.java$"/>
+  </module>
+
+  <!-- https://checkstyle.org/filters/suppressionfilter.html -->
+  <module name="SuppressionFilter">
+    <property name="file" value="${org.checkstyle.openjdk.suppressionfilter.config}"
+              default="checkstyle-suppressions.xml" />
+    <property name="optional" value="true"/>
+  </module>
+
+  <!-- Add OpenJDK-specific checks here based on the style guide -->
+
+  <module name="TreeWalker">
+    <!-- Add TreeWalker checks based on OpenJDK style guide -->
+    <module name="OneStatementPerLine"/>
+
+    <!-- https://checkstyle.org/filters/suppressionxpathfilter.html -->
+    <module name="SuppressionXpathFilter">
+      <property name="file" value="${org.checkstyle.openjdk.suppressionxpathfilter.config}"
+                default="checkstyle-xpath-suppressions.xml" />
+      <property name="optional" value="true"/>
+    </module>
+
+  </module>
+
+</module>

--- a/src/site/site.xml
+++ b/src/site/site.xml
@@ -373,6 +373,7 @@
 
       <item name="Style Configurations" href="style_configs.html">
         <item name="Google's Style" href="google_style.html"/>
+        <item name="OpenJDK's Style" href="openjdk_style.html"/>
         <item name="Sun's Style" href="sun_style.html"/>
       </item>
     </menu>

--- a/src/site/xdoc/checks/coding/onestatementperline.xml
+++ b/src/site/xdoc/checks/coding/onestatementperline.xml
@@ -180,6 +180,10 @@ public class Example2 {
             <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources%20path%3A**%2Fsun_checks.xml+repo%3Acheckstyle%2Fcheckstyle+OneStatementPerLine">
             Sun Style</a>
           </li>
+          <li>
+            <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources%20path%3A**%2Fopenjdk_checks.xml+repo%3Acheckstyle%2Fcheckstyle+OneStatementPerLine">
+            OpenJDK Style</a>
+          </li>
         </ul>
       </subsection>
 

--- a/src/site/xdoc/checks/coding/onestatementperline.xml.template
+++ b/src/site/xdoc/checks/coding/onestatementperline.xml.template
@@ -84,6 +84,10 @@
             <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources%20path%3A**%2Fsun_checks.xml+repo%3Acheckstyle%2Fcheckstyle+OneStatementPerLine">
             Sun Style</a>
           </li>
+          <li>
+            <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources%20path%3A**%2Fopenjdk_checks.xml+repo%3Acheckstyle%2Fcheckstyle+OneStatementPerLine">
+            OpenJDK Style</a>
+          </li>
         </ul>
       </subsection>
 

--- a/src/site/xdoc/config.xml
+++ b/src/site/xdoc/config.xml
@@ -501,6 +501,10 @@
             <a href="https://github.com/search?q=path%3Aconfig%20path%3A**%2Fcheckstyle-checks.xml+repo%3Acheckstyle%2Fcheckstyle+Checker">
             Checkstyle Style</a>
           </li>
+          <li>
+            <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources%20path%3A**%2Fopenjdk_checks.xml+repo%3Acheckstyle%2Fcheckstyle+Checker">
+            OpenJDK Style</a>
+          </li>
         </ul>
       </subsection>
 
@@ -664,6 +668,10 @@
           <li>
             <a href="https://github.com/search?q=path%3Aconfig%20path%3A**%2Fcheckstyle-checks.xml+repo%3Acheckstyle%2Fcheckstyle+TreeWalker">
             Checkstyle Style</a>
+          </li>
+          <li>
+            <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources%20path%3A**%2Fopenjdk_checks.xml+repo%3Acheckstyle%2Fcheckstyle+TreeWalker">
+            OpenJDK Style</a>
           </li>
         </ul>
       </subsection>

--- a/src/site/xdoc/filefilters/beforeexecutionexclusionfilefilter.xml
+++ b/src/site/xdoc/filefilters/beforeexecutionexclusionfilefilter.xml
@@ -190,6 +190,10 @@
             <a href="https://github.com/search?q=path%3Aconfig%20path%3A**%2Fcheckstyle-checks.xml+repo%3Acheckstyle%2Fcheckstyle+BeforeExecutionExclusionFileFilter">
             Checkstyle Style</a>
           </li>
+          <li>
+            <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources%20path%3A**%2Fopenjdk_checks.xml+repo%3Acheckstyle%2Fcheckstyle+BeforeExecutionExclusionFileFilter">
+            OpenJDK Style</a>
+          </li>
         </ul>
       </subsection>
       <subsection name="Package" id="BeforeExecutionExclusionFileFilter_Package">

--- a/src/site/xdoc/filefilters/beforeexecutionexclusionfilefilter.xml.template
+++ b/src/site/xdoc/filefilters/beforeexecutionexclusionfilefilter.xml.template
@@ -101,6 +101,10 @@
             <a href="https://github.com/search?q=path%3Aconfig%20path%3A**%2Fcheckstyle-checks.xml+repo%3Acheckstyle%2Fcheckstyle+BeforeExecutionExclusionFileFilter">
             Checkstyle Style</a>
           </li>
+          <li>
+            <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources%20path%3A**%2Fopenjdk_checks.xml+repo%3Acheckstyle%2Fcheckstyle+BeforeExecutionExclusionFileFilter">
+            OpenJDK Style</a>
+          </li>
         </ul>
       </subsection>
       <subsection name="Package" id="BeforeExecutionExclusionFileFilter_Package">

--- a/src/site/xdoc/filters/suppressionfilter.xml
+++ b/src/site/xdoc/filters/suppressionfilter.xml
@@ -395,6 +395,10 @@ files=&quot;com[\\/]mycompany[\\/]app[\\/].*IT.java&quot;/&gt;
             <a href="https://github.com/search?q=path%3Aconfig%20path%3A**%2Fcheckstyle-checks.xml+repo%3Acheckstyle%2Fcheckstyle+SuppressionFilter">
             Checkstyle Style</a>
           </li>
+          <li>
+            <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources%20path%3A**%2Fopenjdk_checks.xml+repo%3Acheckstyle%2Fcheckstyle+SuppressionFilter">
+            OpenJDK Style</a>
+          </li>
         </ul>
       </subsection>
       <subsection name="Package" id="SuppressionFilter_Package">

--- a/src/site/xdoc/filters/suppressionfilter.xml.template
+++ b/src/site/xdoc/filters/suppressionfilter.xml.template
@@ -195,6 +195,10 @@ files="com[\\/]mycompany[\\/]app[\\/].*IT.java"/&gt;
             <a href="https://github.com/search?q=path%3Aconfig%20path%3A**%2Fcheckstyle-checks.xml+repo%3Acheckstyle%2Fcheckstyle+SuppressionFilter">
             Checkstyle Style</a>
           </li>
+          <li>
+            <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources%20path%3A**%2Fopenjdk_checks.xml+repo%3Acheckstyle%2Fcheckstyle+SuppressionFilter">
+            OpenJDK Style</a>
+          </li>
         </ul>
       </subsection>
       <subsection name="Package" id="SuppressionFilter_Package">

--- a/src/site/xdoc/filters/suppressionxpathfilter.xml
+++ b/src/site/xdoc/filters/suppressionxpathfilter.xml
@@ -997,6 +997,10 @@ public class Example14 {
             <a href="https://github.com/search?q=path%3Aconfig%20path%3A**%2Fcheckstyle-checks.xml+repo%3Acheckstyle%2Fcheckstyle+SuppressionXpathFilter">
               Checkstyle Style</a>
           </li>
+          <li>
+            <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources%20path%3A**%2Fopenjdk_checks.xml+repo%3Acheckstyle%2Fcheckstyle+SuppressionXpathFilter">
+            OpenJDK Style</a>
+          </li>
         </ul>
       </subsection>
       <subsection name="Package" id="SuppressionXpathFilter_Package">

--- a/src/site/xdoc/filters/suppressionxpathfilter.xml.template
+++ b/src/site/xdoc/filters/suppressionxpathfilter.xml.template
@@ -549,6 +549,10 @@ CLASS_DEF -&gt; CLASS_DEF [1:0]
             <a href="https://github.com/search?q=path%3Aconfig%20path%3A**%2Fcheckstyle-checks.xml+repo%3Acheckstyle%2Fcheckstyle+SuppressionXpathFilter">
               Checkstyle Style</a>
           </li>
+          <li>
+            <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources%20path%3A**%2Fopenjdk_checks.xml+repo%3Acheckstyle%2Fcheckstyle+SuppressionXpathFilter">
+            OpenJDK Style</a>
+          </li>
         </ul>
       </subsection>
       <subsection name="Package" id="SuppressionXpathFilter_Package">

--- a/src/site/xdoc/openjdk_style.xml
+++ b/src/site/xdoc/openjdk_style.xml
@@ -1,0 +1,800 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<document xmlns="http://maven.apache.org/XDOC/2.0"
+          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+          xsi:schemaLocation="http://maven.apache.org/XDOC/2.0
+                              https://maven.apache.org/xsd/xdoc-2.0.xsd">
+
+  <head>
+    <title>OpenJDK's Style</title>
+  </head>
+
+  <body>
+    <section name="OpenJDK's Java Style Checkstyle Coverage">
+      <subsection name="Useful information" id="OpenJDK_Useful_information">
+        <p>
+          This coverage report was created for
+          <a href="https://cr.openjdk.org/~alundblad/styleguide/index-v6.html">
+            OpenJDK Java Style Guidelines</a> (Draft, v6).
+        </p>
+        <p>
+          <a href="https://github.com/checkstyle/checkstyle/blob/master/src/main/resources/openjdk_checks.xml">
+            Incomplete Checkstyle configuration for 'OpenJDK Java Style'</a>
+        </p>
+      </subsection>
+      <subsection name="Legend" id="OpenJDK_Legend">
+        <p>
+          "???" - Report is incomplete in this line.
+          <br />
+          "--" - There is no rule in this paragraph.
+          <br />
+          "↓" - This paragraph is the high-level point of some group.
+          <br />
+          <span class="wrapper inline">
+            <img src="images/ok_green.png" alt="" />
+          </span>
+          - Existing Check covers all requirements from OpenJDK.
+          <br />
+          <span class="wrapper inline">
+            <img src="images/ok_blue.png" alt="" />
+          </span>
+          - Existing Check covers some part of requirements from OpenJDK.
+          <br />
+          <span class="wrapper inline">
+            <img src="images/ban_red.png" alt="" />
+          </span>
+          - Requirements are not possible to check by Checkstyle at all.
+          <br />
+        </p>
+      </subsection>
+      <subsection name="Coverage table" id="OpenJDK_Coverage_table">
+        <p>
+          <b>ATTENTION:</b>
+          Links to config and test in following table reference to latest (not released yet) config.
+          Config might be slightly different from what we have in latest release.
+          Please always use config that is embedded to jar or use a custom version copied
+          from one that matches your checkstyle version.
+        </p>
+        <div class="wrapper">
+          <table>
+            <thead>
+              <tr>
+                <th/>
+                <th>OpenJDK's Java Style Rule</th>
+                <th>Checkstyle Check</th>
+                <th>Applied to config</th>
+              </tr>
+            </thead>
+            <tbody>
+              <!-- 1 Introduction -->
+              <tr>
+                <td>
+                  <a name="a1"/>
+                  <a href="#1">
+                    <span class="wrapper inline">
+                      <img src="images/anchor.png" alt=""/>
+                    </span>
+                  </a>
+                </td>
+                <td>
+                  <a href="https://cr.openjdk.org/~alundblad/styleguide/index-v6.html#toc-introduction">
+                    <strong>1 - Introduction</strong>
+                  </a>
+                </td>
+                <td>--</td>
+                <td/>
+              </tr>
+              <tr>
+                <td>
+                  <a name="a1.1"/>
+                  <a href="#1.1">
+                    <span class="wrapper inline">
+                      <img src="images/anchor.png" alt=""/>
+                    </span>
+                  </a>
+                </td>
+                <td>
+                  <a href="https://cr.openjdk.org/~alundblad/styleguide/index-v6.html#toc-motivation">
+                    1.1 Motivation
+                  </a>
+                </td>
+                <td>--</td>
+                <td/>
+              </tr>
+              <tr>
+                <td>
+                  <a name="a1.2"/>
+                  <a href="#1.2">
+                    <span class="wrapper inline">
+                      <img src="images/anchor.png" alt=""/>
+                    </span>
+                  </a>
+                </td>
+                <td>
+                  <a href="https://cr.openjdk.org/~alundblad/styleguide/index-v6.html#toc-guiding-principles">
+                    1.2 Guiding Principles
+                  </a>
+                </td>
+                <td>--</td>
+                <td/>
+              </tr>
+              <!-- 2 Java Source Files -->
+              <tr>
+                <td>
+                  <a name="a2"/>
+                  <a href="#2">
+                    <span class="wrapper inline">
+                      <img src="images/anchor.png" alt=""/>
+                    </span>
+                  </a>
+                </td>
+                <td>
+                  <a href="https://cr.openjdk.org/~alundblad/styleguide/index-v6.html#toc-java-source-files">
+                    <strong>2 - Java Source Files</strong>
+                  </a>
+                </td>
+                <td>???</td>
+                <td/>
+              </tr>
+              <tr>
+                <td>
+                  <a name="a2.1"/>
+                  <a href="#2.1">
+                    <span class="wrapper inline">
+                      <img src="images/anchor.png" alt=""/>
+                    </span>
+                  </a>
+                </td>
+                <td>
+                  <a href="https://cr.openjdk.org/~alundblad/styleguide/index-v6.html#toc-special-characters">
+                    2.1 Special Characters
+                  </a>
+                </td>
+                <td>???</td>
+                <td/>
+              </tr>
+              <!-- 3 Formatting -->
+              <tr>
+                <td>
+                  <a name="a3"/>
+                  <a href="#3">
+                    <span class="wrapper inline">
+                      <img src="images/anchor.png" alt=""/>
+                    </span>
+                  </a>
+                </td>
+                <td>
+                  <a href="https://cr.openjdk.org/~alundblad/styleguide/index-v6.html#toc-formatting">
+                    <strong>3 - Formatting</strong>
+                  </a>
+                </td>
+                <td>???</td>
+                <td/>
+              </tr>
+              <tr>
+                <td>
+                  <a name="a3.1"/>
+                  <a href="#3.1">
+                    <span class="wrapper inline">
+                      <img src="images/anchor.png" alt=""/>
+                    </span>
+                  </a>
+                </td>
+                <td>
+                  <a href="https://cr.openjdk.org/~alundblad/styleguide/index-v6.html#toc-copyright-notice">
+                    3.1 Copyright notice
+                  </a>
+                </td>
+                <td>???</td>
+                <td/>
+              </tr>
+              <tr>
+                <td>
+                  <a name="a3.2"/>
+                  <a href="#3.2">
+                    <span class="wrapper inline">
+                      <img src="images/anchor.png" alt=""/>
+                    </span>
+                  </a>
+                </td>
+                <td>
+                  <a href="https://cr.openjdk.org/~alundblad/styleguide/index-v6.html#toc-package-declaration">
+                    3.2 Package declaration
+                  </a>
+                </td>
+                <td>???</td>
+                <td/>
+              </tr>
+              <tr>
+                <td>
+                  <a name="a3.3"/>
+                  <a href="#3.3">
+                    <span class="wrapper inline">
+                      <img src="images/anchor.png" alt=""/>
+                    </span>
+                  </a>
+                </td>
+                <td>
+                  <a href="https://cr.openjdk.org/~alundblad/styleguide/index-v6.html#toc-import-statements">
+                    3.3 Import statements
+                  </a>
+                </td>
+                <td>???</td>
+                <td/>
+              </tr>
+              <tr>
+                <td>
+                  <a name="a3.3.1"/>
+                  <a href="#3.3.1">
+                    <span class="wrapper inline">
+                      <img src="images/anchor.png" alt=""/>
+                    </span>
+                  </a>
+                </td>
+                <td>
+                  <a href="https://cr.openjdk.org/~alundblad/styleguide/index-v6.html#toc-import-statements">
+                    3.3.1 Wildcard Imports
+                  </a>
+                </td>
+                <td>???</td>
+                <td/>
+              </tr>
+              <tr>
+                <td>
+                  <a name="a3.4"/>
+                  <a href="#3.4">
+                    <span class="wrapper inline">
+                      <img src="images/anchor.png" alt=""/>
+                    </span>
+                  </a>
+                </td>
+                <td>
+                  <a href="https://cr.openjdk.org/~alundblad/styleguide/index-v6.html#toc-class-structure">
+                    3.4 Class Structure
+                  </a>
+                </td>
+                <td>???</td>
+                <td/>
+              </tr>
+              <tr>
+                <td>
+                  <a name="a3.4.1"/>
+                  <a href="#3.4.1">
+                    <span class="wrapper inline">
+                      <img src="images/anchor.png" alt=""/>
+                    </span>
+                  </a>
+                </td>
+                <td>
+                  <a href="https://cr.openjdk.org/~alundblad/styleguide/index-v6.html#toc-class-structure">
+                    3.4.1 Order of Constructors and Overloaded Methods
+                  </a>
+                </td>
+                <td>???</td>
+                <td/>
+              </tr>
+              <tr>
+                <td>
+                  <a name="a3.5"/>
+                  <a href="#3.5">
+                    <span class="wrapper inline">
+                      <img src="images/anchor.png" alt=""/>
+                    </span>
+                  </a>
+                </td>
+                <td>
+                  <a href="https://cr.openjdk.org/~alundblad/styleguide/index-v6.html#toc-modifiers">
+                    3.5 Modifiers
+                  </a>
+                </td>
+                <td>???</td>
+                <td/>
+              </tr>
+              <tr>
+                <td>
+                  <a name="a3.6"/>
+                  <a href="#3.6">
+                    <span class="wrapper inline">
+                      <img src="images/anchor.png" alt=""/>
+                    </span>
+                  </a>
+                </td>
+                <td>
+                  <a href="https://cr.openjdk.org/~alundblad/styleguide/index-v6.html#toc-braces">
+                    3.6 Braces
+                  </a>
+                </td>
+                <td>???</td>
+                <td/>
+              </tr>
+              <tr>
+                <td>
+                  <a name="a3.6.1"/>
+                  <a href="#3.6.1">
+                    <span class="wrapper inline">
+                      <img src="images/anchor.png" alt=""/>
+                    </span>
+                  </a>
+                </td>
+                <td>
+                  <a href="https://cr.openjdk.org/~alundblad/styleguide/index-v6.html#toc-braces">
+                    3.6.1 Short Forms
+                  </a>
+                </td>
+                <td>???</td>
+                <td/>
+              </tr>
+              <tr>
+                <td>
+                  <a name="a3.7"/>
+                  <a href="#3.7">
+                    <span class="wrapper inline">
+                      <img src="images/anchor.png" alt=""/>
+                    </span>
+                  </a>
+                </td>
+                <td>
+                  <a href="https://cr.openjdk.org/~alundblad/styleguide/index-v6.html#toc-indentation">
+                    3.7 Indentation
+                  </a>
+                </td>
+                <td>???</td>
+                <td/>
+              </tr>
+              <tr>
+                <td>
+                  <a name="a3.8"/>
+                  <a href="#3.8">
+                    <span class="wrapper inline">
+                      <img src="images/anchor.png" alt=""/>
+                    </span>
+                  </a>
+                </td>
+                <td>
+                  <a href="https://cr.openjdk.org/~alundblad/styleguide/index-v6.html#toc-wrapping-lines">
+                    3.8 Wrapping Lines
+                  </a>
+                </td>
+                <td>
+                  <span class="wrapper inline">
+                    <img src="images/ok_blue.png" alt=""/>
+                  </span>
+                  <a href="checks/coding/onestatementperline.html#OneStatementPerLine">
+                    OneStatementPerLine</a>
+                </td>
+                <td>
+                  <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources%20path%3A**%2Fopenjdk_checks.xml+repo%3Acheckstyle%2Fcheckstyle+OneStatementPerLine">
+                    config
+                  </a>
+                  <br/>
+                  <a href="https://github.com/checkstyle/checkstyle/blob/master/src/it/java/com/openjdk/checkstyle/test/chapter3formatting/rule38wrappinglines/OneStatementPerLineTest.java">
+                    test
+                  </a>
+                </td>
+              </tr>
+              <tr>
+                <td>
+                  <a name="a3.8.1"/>
+                  <a href="#3.8.1">
+                    <span class="wrapper inline">
+                      <img src="images/anchor.png" alt=""/>
+                    </span>
+                  </a>
+                </td>
+                <td>
+                  <a href="https://cr.openjdk.org/~alundblad/styleguide/index-v6.html#toc-wrapping-lines">
+                    3.8.1 Wrapping Class Declarations
+                  </a>
+                </td>
+                <td>???</td>
+                <td/>
+              </tr>
+              <tr>
+                <td>
+                  <a name="a3.8.2"/>
+                  <a href="#3.8.2">
+                    <span class="wrapper inline">
+                      <img src="images/anchor.png" alt=""/>
+                    </span>
+                  </a>
+                </td>
+                <td>
+                  <a href="https://cr.openjdk.org/~alundblad/styleguide/index-v6.html#toc-wrapping-lines">
+                    3.8.2 Wrapping Method Declarations
+                  </a>
+                </td>
+                <td>???</td>
+                <td/>
+              </tr>
+              <tr>
+                <td>
+                  <a name="a3.8.3"/>
+                  <a href="#3.8.3">
+                    <span class="wrapper inline">
+                      <img src="images/anchor.png" alt=""/>
+                    </span>
+                  </a>
+                </td>
+                <td>
+                  <a href="https://cr.openjdk.org/~alundblad/styleguide/index-v6.html#toc-wrapping-lines">
+                    3.8.3 Wrapping Expressions
+                  </a>
+                </td>
+                <td>???</td>
+                <td/>
+              </tr>
+              <tr>
+                <td>
+                  <a name="a3.9"/>
+                  <a href="#3.9">
+                    <span class="wrapper inline">
+                      <img src="images/anchor.png" alt=""/>
+                    </span>
+                  </a>
+                </td>
+                <td>
+                  <a href="https://cr.openjdk.org/~alundblad/styleguide/index-v6.html#toc-whitespace">
+                    3.9 Whitespace
+                  </a>
+                </td>
+                <td>↓</td>
+                <td/>
+              </tr>
+              <tr>
+                <td>
+                  <a name="a3.9.1"/>
+                  <a href="#3.9.1">
+                    <span class="wrapper inline">
+                      <img src="images/anchor.png" alt=""/>
+                    </span>
+                  </a>
+                </td>
+                <td>
+                  <a href="https://cr.openjdk.org/~alundblad/styleguide/index-v6.html#toc-whitespace">
+                    3.9.1 Vertical Whitespace
+                  </a>
+                </td>
+                <td>???</td>
+                <td/>
+              </tr>
+              <tr>
+                <td>
+                  <a name="a3.9.2"/>
+                  <a href="#3.9.2">
+                    <span class="wrapper inline">
+                      <img src="images/anchor.png" alt=""/>
+                    </span>
+                  </a>
+                </td>
+                <td>
+                  <a href="https://cr.openjdk.org/~alundblad/styleguide/index-v6.html#toc-whitespace">
+                    3.9.2 Horizontal Whitespace
+                  </a>
+                </td>
+                <td>???</td>
+                <td/>
+              </tr>
+              <tr>
+                <td>
+                  <a name="a3.10"/>
+                  <a href="#3.10">
+                    <span class="wrapper inline">
+                      <img src="images/anchor.png" alt=""/>
+                    </span>
+                  </a>
+                </td>
+                <td>
+                  <a href="https://cr.openjdk.org/~alundblad/styleguide/index-v6.html#toc-variable-declarations">
+                    3.10 Variable Declarations
+                  </a>
+                </td>
+                <td>???</td>
+                <td/>
+              </tr>
+              <tr>
+                <td>
+                  <a name="a3.11"/>
+                  <a href="#3.11">
+                    <span class="wrapper inline">
+                      <img src="images/anchor.png" alt=""/>
+                    </span>
+                  </a>
+                </td>
+                <td>
+                  <a href="https://cr.openjdk.org/~alundblad/styleguide/index-v6.html#toc-annotations">
+                    3.11 Annotations
+                  </a>
+                </td>
+                <td>???</td>
+                <td/>
+              </tr>
+              <tr>
+                <td>
+                  <a name="a3.12"/>
+                  <a href="#3.12">
+                    <span class="wrapper inline">
+                      <img src="images/anchor.png" alt=""/>
+                    </span>
+                  </a>
+                </td>
+                <td>
+                  <a href="https://cr.openjdk.org/~alundblad/styleguide/index-v6.html#toc-lambda-expressions">
+                    3.12 Lambda Expressions
+                  </a>
+                </td>
+                <td>???</td>
+                <td/>
+              </tr>
+              <tr>
+                <td>
+                  <a name="a3.13"/>
+                  <a href="#3.13">
+                    <span class="wrapper inline">
+                      <img src="images/anchor.png" alt=""/>
+                    </span>
+                  </a>
+                </td>
+                <td>
+                  <a href="https://cr.openjdk.org/~alundblad/styleguide/index-v6.html#toc-redundant-parentheses">
+                    3.13 Redundant Parentheses
+                  </a>
+                </td>
+                <td>???</td>
+                <td/>
+              </tr>
+              <tr>
+                <td>
+                  <a name="a3.14"/>
+                  <a href="#3.14">
+                    <span class="wrapper inline">
+                      <img src="images/anchor.png" alt=""/>
+                    </span>
+                  </a>
+                </td>
+                <td>
+                  <a href="https://cr.openjdk.org/~alundblad/styleguide/index-v6.html#toc-literals">
+                    3.14 Literals
+                  </a>
+                </td>
+                <td>???</td>
+                <td/>
+              </tr>
+              <tr>
+                <td>
+                  <a name="a3.15"/>
+                  <a href="#3.15">
+                    <span class="wrapper inline">
+                      <img src="images/anchor.png" alt=""/>
+                    </span>
+                  </a>
+                </td>
+                <td>
+                  <a href="https://cr.openjdk.org/~alundblad/styleguide/index-v6.html#toc-javadoc">
+                    3.15 Javadoc
+                  </a>
+                </td>
+                <td>???</td>
+                <td/>
+              </tr>
+              <!-- 4 Naming -->
+              <tr>
+                <td>
+                  <a name="a4"/>
+                  <a href="#4">
+                    <span class="wrapper inline">
+                      <img src="images/anchor.png" alt=""/>
+                    </span>
+                  </a>
+                </td>
+                <td>
+                  <a href="https://cr.openjdk.org/~alundblad/styleguide/index-v6.html#toc-naming">
+                    <strong>4 - Naming</strong>
+                  </a>
+                </td>
+                <td>↓</td>
+                <td/>
+              </tr>
+              <tr>
+                <td>
+                  <a name="a4.1"/>
+                  <a href="#4.1">
+                    <span class="wrapper inline">
+                      <img src="images/anchor.png" alt=""/>
+                    </span>
+                  </a>
+                </td>
+                <td>
+                  <a href="https://cr.openjdk.org/~alundblad/styleguide/index-v6.html#toc-package-names">
+                    4.1 Package Names
+                  </a>
+                </td>
+                <td>???</td>
+                <td/>
+              </tr>
+              <tr>
+                <td>
+                  <a name="a4.2"/>
+                  <a href="#4.2">
+                    <span class="wrapper inline">
+                      <img src="images/anchor.png" alt=""/>
+                    </span>
+                  </a>
+                </td>
+                <td>
+                  <a href="https://cr.openjdk.org/~alundblad/styleguide/index-v6.html#toc-class-interface-and-enum-names">
+                    4.2 Class, Interface and Enum Names
+                  </a>
+                </td>
+                <td>???</td>
+                <td/>
+              </tr>
+              <tr>
+                <td>
+                  <a name="a4.3"/>
+                  <a href="#4.3">
+                    <span class="wrapper inline">
+                      <img src="images/anchor.png" alt=""/>
+                    </span>
+                  </a>
+                </td>
+                <td>
+                  <a href="https://cr.openjdk.org/~alundblad/styleguide/index-v6.html#toc-method-names">
+                    4.3 Method Names
+                  </a>
+                </td>
+                <td>???</td>
+                <td/>
+              </tr>
+              <tr>
+                <td>
+                  <a name="a4.4"/>
+                  <a href="#4.4">
+                    <span class="wrapper inline">
+                      <img src="images/anchor.png" alt=""/>
+                    </span>
+                  </a>
+                </td>
+                <td>
+                  <a href="https://cr.openjdk.org/~alundblad/styleguide/index-v6.html#toc-variables">
+                    4.4 Variables
+                  </a>
+                </td>
+                <td>???</td>
+                <td/>
+              </tr>
+              <tr>
+                <td>
+                  <a name="a4.5"/>
+                  <a href="#4.5">
+                    <span class="wrapper inline">
+                      <img src="images/anchor.png" alt=""/>
+                    </span>
+                  </a>
+                </td>
+                <td>
+                  <a href="https://cr.openjdk.org/~alundblad/styleguide/index-v6.html#toc-type-variables">
+                    4.5 Type Variables
+                  </a>
+                </td>
+                <td>???</td>
+                <td/>
+              </tr>
+              <tr>
+                <td>
+                  <a name="a4.6"/>
+                  <a href="#4.6">
+                    <span class="wrapper inline">
+                      <img src="images/anchor.png" alt=""/>
+                    </span>
+                  </a>
+                </td>
+                <td>
+                  <a href="https://cr.openjdk.org/~alundblad/styleguide/index-v6.html#toc-constants">
+                    4.6 Constants
+                  </a>
+                </td>
+                <td>???</td>
+                <td/>
+              </tr>
+              <!-- 5 Programming Practices -->
+              <tr>
+                <td>
+                  <a name="a5"/>
+                  <a href="#5">
+                    <span class="wrapper inline">
+                      <img src="images/anchor.png" alt=""/>
+                    </span>
+                  </a>
+                </td>
+                <td>
+                  <a href="https://cr.openjdk.org/~alundblad/styleguide/index-v6.html#toc-programming-practices">
+                    <strong>5 - Programming Practices</strong>
+                  </a>
+                </td>
+                <td>???</td>
+                <td/>
+              </tr>
+              <tr>
+                <td>
+                  <a name="a5.1"/>
+                  <a href="#5.1">
+                    <span class="wrapper inline">
+                      <img src="images/anchor.png" alt=""/>
+                    </span>
+                  </a>
+                </td>
+                <td>
+                  <a href="https://cr.openjdk.org/~alundblad/styleguide/index-v6.html#toc-commenting-code">
+                    5.1 Commenting Code
+                  </a>
+                </td>
+                <td>???</td>
+                <td/>
+              </tr>
+              <!-- 6 When to reformat code -->
+              <tr>
+                <td>
+                  <a name="a6"/>
+                  <a href="#6">
+                    <span class="wrapper inline">
+                      <img src="images/anchor.png" alt=""/>
+                    </span>
+                  </a>
+                </td>
+                <td>
+                  <a href="https://cr.openjdk.org/~alundblad/styleguide/index-v6.html#toc-when-to-reformat-code">
+                    <strong>6 - When to reformat code</strong>
+                  </a>
+                </td>
+                <td>--</td>
+                <td/>
+              </tr>
+              <!-- 7 Cases not covered -->
+              <tr>
+                <td>
+                  <a name="a7"/>
+                  <a href="#7">
+                    <span class="wrapper inline">
+                      <img src="images/anchor.png" alt=""/>
+                    </span>
+                  </a>
+                </td>
+                <td>
+                  <a href="https://cr.openjdk.org/~alundblad/styleguide/index-v6.html#toc-cases-not-covered">
+                    <strong>7 - Cases not covered</strong>
+                  </a>
+                </td>
+                <td>--</td>
+                <td/>
+              </tr>
+            </tbody>
+          </table>
+        </div>
+      </subsection>
+      <subsection name="Suppressions" id="OpenJDK_Suppressions">
+        <p>
+          It is possible to suppress some violations by embedded filters
+          <a href="filters/suppressionfilter.html#SuppressionFilter">
+            SuppressionFilter</a>
+          and
+          <a href="filters/suppressionxpathfilter.html#SuppressionXpathFilter">
+            SuppressionXpathFilter</a>.
+          Location of config file for <i>SuppressionFilter</i> can be defined by system property
+          <i>org.checkstyle.openjdk.suppressionfilter.config</i> (default value is
+          <i>checkstyle-suppressions.xml</i>).
+          Location of config file for <i>SuppressionXpathFilter</i>
+          can be defined by system property
+          <i>org.checkstyle.openjdk.suppressionxpathfilter.config</i> (default value is
+          <i>checkstyle-xpath-suppressions.xml</i>).
+        </p>
+        <p>
+          For more details please review exact configuration of Filters in openjdk_checks.xml:
+          <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources%20path%3A**%2Fopenjdk_checks.xml+repo%3Acheckstyle%2Fcheckstyle+SuppressionFilter">
+                    SuppressionFilter</a>,
+          <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources%20path%3A**%2Fopenjdk_checks.xml+repo%3Acheckstyle%2Fcheckstyle+SuppressionXpathFilter">
+                    SuppressionXpathFilter</a>.
+        </p>
+      </subsection>
+    </section>
+  </body>
+</document>

--- a/src/test/java/com/puppycrawl/tools/checkstyle/internal/XdocsPagesTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/internal/XdocsPagesTest.java
@@ -241,6 +241,9 @@ public class XdocsPagesTest {
     private static final Set<String> GOOGLE_MODULES = Collections.unmodifiableSet(
         CheckUtil.getConfigGoogleStyleModules());
 
+    private static final Set<String> OPENJDK_MODULES = Collections.unmodifiableSet(
+        CheckUtil.getConfigOpenJdkStyleModules());
+
     private static final Set<String> NON_MODULE_XDOC = Set.of(
         "config_system_properties.xml",
         "sponsoring.xml",
@@ -252,6 +255,7 @@ public class XdocsPagesTest {
         "checks.xml",
         "property_types.xml",
         "google_style.xml",
+        "openjdk_style.xml",
         "sun_style.xml",
         "style_configs.xml",
         "writingfilters.xml",
@@ -676,6 +680,10 @@ public class XdocsPagesTest {
                 }
                 else if ("sun_style.xml".equals(fileName)) {
                     sectionName = "Sun";
+                    expectedId = (sectionName + "_" + nameString).replace(' ', '_');
+                }
+                else if ("openjdk_style.xml".equals(fileName)) {
+                    sectionName = "OpenJDK";
                     expectedId = (sectionName + "_" + nameString).replace(' ', '_');
                 }
                 else if ((path.toString().contains("filters")
@@ -1739,6 +1747,7 @@ public class XdocsPagesTest {
             .replace("Checkstyle Style", "")
             .replace("Google Style", "")
             .replace("Sun Style", "")
+            .replace("OpenJDK Style", "")
             .replace("Checkstyle's Import Control Config", "")
             .trim();
 
@@ -1750,6 +1759,7 @@ public class XdocsPagesTest {
         boolean hasCheckstyle = false;
         boolean hasGoogle = false;
         boolean hasSun = false;
+        boolean hasOpenjdk = false;
 
         for (Node node : XmlUtil.findChildElementsByTag(subSection, "a")) {
             final String url = node.getAttributes().getNamedItem("href").getTextContent();
@@ -1789,6 +1799,19 @@ public class XdocsPagesTest {
                     .that(SUN_MODULES)
                     .contains(sectionName);
             }
+            else if ("OpenJDK Style".equals(linkText)) {
+                hasOpenjdk = true;
+                expectedUrl = "https://github.com/search?q="
+                        + "path%3Asrc%2Fmain%2Fresources%20path%3A**%2Fopenjdk_checks.xml+"
+                        + "repo%3Acheckstyle%2Fcheckstyle+"
+                        + sectionName;
+                assertWithMessage(
+                    "%s section '%s' should be in openjdk_checks.xml "
+                           + "or not reference 'OpenJDK Style'",
+                    fileName, sectionName)
+                    .that(OPENJDK_MODULES)
+                    .contains(sectionName);
+            }
             else if ("Checkstyle's Import Control Config".equals(linkText)) {
                 expectedUrl = "https://github.com/checkstyle/checkstyle/blob/master/config/"
                     + "import-control.xml";
@@ -1809,6 +1832,11 @@ public class XdocsPagesTest {
         assertWithMessage("%s section '%s' should have a sun section since it is in it's config",
             fileName, sectionName)
                 .that(hasSun || !SUN_MODULES.contains(sectionName))
+                .isTrue();
+        assertWithMessage("%s section '%s' should have an openjdk section since "
+                        + "it is in its config",
+            fileName, sectionName)
+                .that(hasOpenjdk || !OPENJDK_MODULES.contains(sectionName))
                 .isTrue();
     }
 
@@ -1871,6 +1899,7 @@ public class XdocsPagesTest {
 
             final Set<String> styleChecks = switch (styleName) {
                 case "google" -> new HashSet<>(GOOGLE_MODULES);
+                case "openjdk" -> new HashSet<>(OPENJDK_MODULES);
                 case "sun" -> {
                     final Set<String> checks = new HashSet<>(SUN_MODULES);
                     checks.removeAll(IGNORED_SUN_MODULES);

--- a/src/test/java/com/puppycrawl/tools/checkstyle/internal/utils/CheckUtil.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/internal/utils/CheckUtil.java
@@ -72,6 +72,10 @@ public final class CheckUtil {
         return getCheckStyleModulesReferencedInConfig("src/main/resources/google_checks.xml");
     }
 
+    public static Set<String> getConfigOpenJdkStyleModules() {
+        return getCheckStyleModulesReferencedInConfig("src/main/resources/openjdk_checks.xml");
+    }
+
     /**
      * Retrieves a set of class names, removing 'Check' from the end if the class is
      * a checkstyle check.


### PR DESCRIPTION
Issue #18621:
This PR adds the infrastructure for tracking Checkstyle coverage of OpenJDK Java Style Guidelines (v6).

**Changes:**
- Add openjdk_checks.xml - Checkstyle configuration skeleton
- Add openjdk_style.xml - Coverage documentation page
- Add AbstractOpenJdkModuleTestSupport.java - Integration test base class
- Update CheckUtil.java- Add getConfigOpenJdkStyleModules() method
- Update XdocsPagesTest.java - Add validation for OpenJDK style
- Update site.xml 
- Update import-control-test.xml 

The actual checks will be added in follow-up PRs as rules are mapped.