### PR TITLE
Issue #17882: Add Tree example for HTML_ELEMENT token

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/api/JavadocCommentsTokenTypes.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/api/JavadocCommentsTokenTypes.java
@@ -1426,7 +1426,36 @@ public final class JavadocCommentsTokenTypes {
     // HTML
 
     /**
-     * General HTML element.
+     * General HTML element in a Javadoc comment.
+     *
+     * <p><b>Example:</b></p>
+     * <pre>{@code
+     * /**
+     *  * <p>Hello</p>
+     *  &#42;/
+     * }</pre>
+     *
+     * <b>Tree:</b>
+     * <pre>{@code
+     * JAVADOC_CONTENT -> JAVADOC_CONTENT
+     * |--LEADING_ASTERISK ->      *
+     * |--TEXT ->
+     * |--HTML_ELEMENT -> HTML_ELEMENT
+     * |   |--HTML_TAG_START -> HTML_TAG_START
+     * |   |   |--TAG_OPEN -> <
+     * |   |   |--TAG_NAME -> p
+     * |   |   `--TAG_CLOSE -> >
+     * |   |--HTML_CONTENT -> HTML_CONTENT
+     * |   |   `--TEXT -> Hello
+     * |   `--HTML_TAG_END -> HTML_TAG_END
+     * |       |--TAG_OPEN -> <
+     * |       |--TAG_SLASH -> /
+     * |       |--TAG_NAME -> p
+     * |       `--TAG_CLOSE -> >
+     * |--NEWLINE -> \n
+     * |--LEADING_ASTERISK ->      *
+     * |--TEXT -> /
+     * }</pre>
      */
     public static final int HTML_ELEMENT = JavadocCommentsLexer.HTML_ELEMENT;
 


### PR DESCRIPTION
## Issue Reference

#17882

## Description

This PR adds detailed Javadoc documentation for the **HTML_ELEMENT** token in
`JavadocCommentsTokenTypes.java`.

The documentation describes how HTML elements inside Javadoc comments are
represented in the Javadoc AST.

It includes:

- A short description of the token
- An example Javadoc snippet containing an HTML element
- The full AST tree output generated by the Checkstyle CLI

## CLI Output

Example input:
```
/**
 * <p>Hello</p>
 */
```

Command:
`java -jar checkstyle-13.1.0-SNAPSHOT-all.jar -j Test.java`

Output:
```
JAVADOC_CONTENT -> JAVADOC_CONTENT
|--LEADING_ASTERISK ->      *
|--TEXT ->
|--HTML_ELEMENT -> HTML_ELEMENT
|   |--HTML_TAG_START -> HTML_TAG_START
|   |   |--TAG_OPEN -> <
|   |   |--TAG_NAME -> p
|   |   `--TAG_CLOSE -> >
|   |--HTML_CONTENT -> HTML_CONTENT
|   |   `--TEXT -> Hello
|   `--HTML_TAG_END -> HTML_TAG_END
|       |--TAG_OPEN -> <
|       |--TAG_SLASH -> /
|       |--TAG_NAME -> p
|       `--TAG_CLOSE -> >
|--NEWLINE -> \n
|--LEADING_ASTERISK ->      *
|--TEXT -> /
```
