### PR TITLE
infra: add JDK 21 setup to site.yml and diff-report.yml, disable Error Prone in equalsverifier CI job

### DIFF
--- a/.ci/validation.sh
+++ b/.ci/validation.sh
@@ -885,7 +885,7 @@ no-error-equalsverifier)
   echo "Checkout target sources ..."
   checkout_from https://github.com/jqno/equalsverifier.git
   cd .ci-temp/equalsverifier
-  mvn -e --no-transfer-progress -Pstatic-analysis-checkstyle compile \
+  mvn -e --no-transfer-progress -Pstatic-analysis-checkstyle -DdisableStaticAnalysis compile \
     checkstyle:check -Dversion.checkstyle="${CS_POM_VERSION}"
   cd ../
   removeFolderWithProtectedFiles equalsverifier

--- a/.github/workflows/diff-report.yml
+++ b/.github/workflows/diff-report.yml
@@ -138,6 +138,12 @@ jobs:
           path: ~/.m2/repository
           key: checkstyle-maven-cache-${{ hashFiles('**/pom.xml') }}
 
+      - name: Set up JDK
+        uses: actions/setup-java@v5
+        with:
+          java-version: '21'
+          distribution: 'temurin'
+
       - name: Download contribution
         uses: actions/checkout@v6
         with:

--- a/.github/workflows/site.yml
+++ b/.github/workflows/site.yml
@@ -92,6 +92,12 @@ jobs:
           path: ~/.m2/repository
           key: checkstyle-maven-cache-${{ hashFiles('**/pom.xml') }}
 
+      - name: Set up JDK
+        uses: actions/setup-java@v5
+        with:
+          java-version: '21'
+          distribution: 'temurin'
+
       - name: Generate site
         run: |
           bash

--- a/config/jsoref-spellchecker/whitelist.words
+++ b/config/jsoref-spellchecker/whitelist.words
@@ -274,6 +274,7 @@ Dconfig
 Dconnection
 ddd
 DDDL
+Ddisable
 Ddry
 DEADBEEF
 DECCHARS


### PR DESCRIPTION
Fixes missing JDK 21 setup in workflow files that run Maven/Groovy commands and disable Error Prone in equalsverifier CI job for JDK 21 compatibility

### Changes

- **site.yml**: Added `actions/setup-java@v5` with JDK 21 to `generate_site` job
- **diff-report.yml**: Added `actions/setup-java@v5` with JDK 21 to `make_report` job
- **error-prone.yml**: disable Error Prone in equalsverifier CI job for JDK 21 compatibility

