### PR TITLE
Issue #13038: Fix incorrect distance calculation for method definitions

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/VariableDeclarationUsageDistanceCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/VariableDeclarationUsageDistanceCheck.java
@@ -24,6 +24,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Map.Entry;
 import java.util.Optional;
+import java.util.Set;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -61,6 +62,19 @@ public class VariableDeclarationUsageDistanceCheck extends AbstractCheck {
      * usage.
      */
     private static final int DEFAULT_DISTANCE = 3;
+
+    /** Tokens that should be ignored when calculating usage distance. */
+    private static final Set<Integer> ZERO_DISTANCE_TOKENS = Set.of(
+            TokenTypes.VARIABLE_DEF,
+            TokenTypes.TYPE,
+            TokenTypes.MODIFIERS,
+            TokenTypes.RESOURCE,
+            TokenTypes.EXTENDS_CLAUSE,
+            TokenTypes.IMPLEMENTS_CLAUSE,
+            TokenTypes.TYPE_PARAMETERS,
+            TokenTypes.PARAMETERS,
+            TokenTypes.LITERAL_THROWS
+    );
 
     /**
      * Specify the maximum distance between a variable's declaration and its first usage.
@@ -710,12 +724,7 @@ public class VariableDeclarationUsageDistanceCheck extends AbstractCheck {
      * @return true if it should be ignored for distance counting, otherwise false.
      */
     private static boolean isZeroDistanceToken(int type) {
-        return type == TokenTypes.VARIABLE_DEF
-                || type == TokenTypes.TYPE
-                || type == TokenTypes.MODIFIERS
-                || type == TokenTypes.RESOURCE
-                || type == TokenTypes.EXTENDS_CLAUSE
-                || type == TokenTypes.IMPLEMENTS_CLAUSE;
+        return ZERO_DISTANCE_TOKENS.contains(type);
     }
 
 }

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/coding/VariableDeclarationUsageDistanceCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/coding/VariableDeclarationUsageDistanceCheckTest.java
@@ -353,7 +353,7 @@ public class VariableDeclarationUsageDistanceCheckTest extends
     @Test
     public void testGeneralClass4() throws Exception {
         final String[] expected = {
-            "26:9: " + getCheckMessage(MSG_KEY, "z", 3, 1),
+            "25:9: " + getCheckMessage(MSG_KEY, "z", 2, 1),
         };
 
         verifyWithInlineConfigParser(
@@ -417,5 +417,12 @@ public class VariableDeclarationUsageDistanceCheckTest extends
         verifyWithInlineConfigParser(
                 getPath("InputVariableDeclarationUsageDistancePatternVariables.java"),
                 expected);
+    }
+
+    @Test
+    public void testVariableDeclarationUsageDistanceMethodDef() throws Exception {
+        final String[] expected = CommonUtil.EMPTY_STRING_ARRAY;
+        verifyWithInlineConfigParser(
+                getPath("InputVariableDeclarationUsageDistanceMethodDef.java"), expected);
     }
 }

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/variabledeclarationusagedistance/InputVariableDeclarationUsageDistanceGeneral4.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/variabledeclarationusagedistance/InputVariableDeclarationUsageDistanceGeneral4.java
@@ -22,8 +22,7 @@ public class InputVariableDeclarationUsageDistanceGeneral4 {
         <T> void xx(List<T> m){}
     }
     public void method9() {
-        // until https://github.com/checkstyle/checkstyle/issues/13011
-        Integer z = 5; // violation 'Distance .* is 3.'
+        Integer z = 5; // violation 'Distance .* is 2.'
         Iterator<Integer> mn = new HashSet<Integer>().iterator();
         class BClass extends Parent {
             Boolean h = false;

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/variabledeclarationusagedistance/InputVariableDeclarationUsageDistanceMethodDef.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/variabledeclarationusagedistance/InputVariableDeclarationUsageDistanceMethodDef.java
@@ -1,0 +1,40 @@
+/*
+VariableDeclarationUsageDistance
+allowedDistance = 1
+ignoreFinal = false
+validateBetweenScopes = true
+ignoreVariablePattern = (default)
+
+
+*/
+
+package com.puppycrawl.tools.checkstyle.checks.coding.variabledeclarationusagedistance;
+
+import java.util.Iterator;
+
+/**
+ * Test case, method definition tokens should not count towards distance.
+ */
+public class InputVariableDeclarationUsageDistanceMethodDef {
+
+    public void testMethodWithGenericInnerClass() {
+        int a = 1;
+        class GeneralLogic {
+            public <T> Iterator<T> method(T[] b) throws Exception {
+                if (a > 0) {
+                    System.out.println(b.length);
+                }
+                return null;
+            }
+        }
+    }
+
+    public void testConstructorInInnerClass() {
+        String value = "test";
+        class Container {
+            Container(String param) throws IllegalArgumentException {
+                System.out.println(value + param);
+            }
+        }
+    }
+}


### PR DESCRIPTION
Issue #13038:

Added TYPE_PARAMETERS, PARAMETERS, and LITERAL_THROWS to the zero-distance tokens set in 
isZeroDistanceToken(). These method signature elements should not contribute to the distance calculation.
