### PR TITLE
Issue #16360: Migrate XMLLoggerTest.testAddException to use inlineConfigParser

### DIFF
--- a/src/test/java/com/puppycrawl/tools/checkstyle/XMLLoggerTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/XMLLoggerTest.java
@@ -247,20 +247,9 @@ public class XMLLoggerTest extends AbstractXmlTestSupport {
     }
 
     @Test
-    public void testAddException()
-            throws Exception {
-        final XMLLogger logger = new XMLLogger(outStream, OutputStreamOptions.CLOSE);
-        logger.auditStarted(null);
-        final Violation violation =
-            new Violation(1, 1,
-                "messages.properties", null, null, null, getClass(), null);
-        final AuditEvent ev = new AuditEvent(this, "Test.java", violation);
-        logger.addException(ev, new TestException("msg", new RuntimeException("msg")));
-        logger.auditFinished(null);
-        verifyXml(getPath("ExpectedXMLLoggerException.xml"), outStream);
-        assertWithMessage("Invalid close count")
-            .that(outStream.getCloseCount())
-            .isEqualTo(1);
+    public void testAddException() throws Exception {
+        verifyWithInlineConfigParserAndXmlLogger("InputXMLLoggerException.java",
+                "ExpectedXMLLoggerExceptionInput.xml");
     }
 
     /**

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/xmllogger/ExpectedXMLLoggerException.xml
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/xmllogger/ExpectedXMLLoggerException.xml
@@ -1,8 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<checkstyle version="">
-<exception>
-<![CDATA[
-stackTrace&#10;example
-]]>
-</exception>
-</checkstyle>

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/xmllogger/ExpectedXMLLoggerExceptionInput.xml
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/xmllogger/ExpectedXMLLoggerExceptionInput.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<checkstyle version="">
+<file name="InputXMLLoggerException.java">
+<error line="11" column="17" severity="error" message="Name 'BadMemberName' must match pattern '^[a-z][a-zA-Z0-9]*$'." source="com.puppycrawl.tools.checkstyle.checks.naming.MemberNameCheck"/>
+</file>
+</checkstyle>

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/xmllogger/InputXMLLoggerException.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/xmllogger/InputXMLLoggerException.java
@@ -1,0 +1,12 @@
+/*xml
+<module name="Checker">
+  <module name="TreeWalker">
+    <module name="MemberName"/>
+  </module>
+</module>
+*/
+package com.puppycrawl.tools.checkstyle.xmllogger;
+
+public class InputXMLLoggerException {
+    private int BadMemberName;
+}


### PR DESCRIPTION
Relates to https://github.com/checkstyle/checkstyle/issues/16360

the test method testAddException in XMLLoggerTest.java was migrated to use the verifyWithInlineConfigParserAndXmlLogger.

Changes:
-> refactored testAddException to use the inline config verifier.
-> created src/test/resources/com/puppycrawl/tools/checkstyle/xmllogger/InputXMLLoggerException.java with an inline configuration and a MemberName violation.
-> Renamed src/test/resources/com/puppycrawl/tools/checkstyle/xmllogger/ExpectedXMLLoggerException.xml to ExpectedXMLLoggerExceptionInput.xml to avoid modifying original expected file.