### PR TITLE
Issue #18644: Fix SummaryJavadoc forbiddenSummaryFragments for tab-formatted code

### DIFF
--- a/config/checkstyle-resources-suppressions.xml
+++ b/config/checkstyle-resources-suppressions.xml
@@ -225,6 +225,9 @@
     files="[\\/]InputCheckerTabCharacterCustomWidth\.java"/>
   <suppress checks="FileTabCharacter"
     files="src[\\/]test[\\/]resources[\\/]com[\\/]puppycrawl[\\/]tools[\\/]checkstyle[\\/]checks[\\/]coding[\\/]textblockgooglestyleformatting[\\/]InputTextBlockGoogleStyleFormattingWithTabs\.java"/>
+  <!-- intentional tabs for testing SummaryJavadocCheck with tab-formatted javadoc -->
+  <suppress checks="FileTabCharacter"
+    files="[\\/]InputSummaryJavadocForbiddenFragmentsTabFormatted\.java"/>
 
   <!-- This file must not have a package statement, for testing purposes -->
   <suppress checks="PackageDeclarationCheck"

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/SummaryJavadocCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/SummaryJavadocCheck.java
@@ -80,7 +80,7 @@ public class SummaryJavadocCheck extends AbstractJavadocCheck {
      * This regexp is used to convert multiline javadoc to single-line without stars.
      */
     private static final Pattern JAVADOC_MULTILINE_TO_SINGLELINE_PATTERN =
-            Pattern.compile("\n +(\\*)|^ +(\\*)");
+            Pattern.compile("\n[ \\t]+(\\*)|^[ \\t]+(\\*)");
 
     /**
      * This regexp is used to remove html tags, whitespace, and asterisks from a string.

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/javadoc/SummaryJavadocCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/javadoc/SummaryJavadocCheckTest.java
@@ -417,4 +417,14 @@ public class SummaryJavadocCheckTest extends AbstractModuleTestSupport {
         verifyWithInlineConfigParser(
                 getPath("InputSummaryJavadocLargeJavadoc.java"), expected);
     }
+
+    @Test
+    public void testForbiddenFragmentsTabFormatted() throws Exception {
+        final String[] expected = {
+            "15: " + getCheckMessage(MSG_SUMMARY_JAVADOC),
+        };
+
+        verifyWithInlineConfigParser(
+                getPath("InputSummaryJavadocForbiddenFragmentsTabFormatted.java"), expected);
+    }
 }

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/summaryjavadoc/InputSummaryJavadocForbiddenFragmentsTabFormatted.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/summaryjavadoc/InputSummaryJavadocForbiddenFragmentsTabFormatted.java
@@ -1,0 +1,28 @@
+/*
+SummaryJavadoc
+violateExecutionOnNonTightHtml = (default)false
+forbiddenSummaryFragments = ^[a-z]
+
+
+*/
+
+// Note: This file uses tab indentation. The Javadoc continuation lines
+// have tab characters before the asterisks (e.g., "\t *" not " *").
+package com.puppycrawl.tools.checkstyle.checks.javadoc.summaryjavadoc;
+
+public class InputSummaryJavadocForbiddenFragmentsTabFormatted {
+	// violation below, 'Forbidden summary fragment'
+	/**
+	 * adds an element to the list.
+	 *
+	 * @param element the element to add
+	 */
+	public void add(String element) {}
+
+	/**
+	 * Adds an element to the list.
+	 *
+	 * @param element the element to add
+	 */
+	public void addOk(String element) {}
+}


### PR DESCRIPTION
Fixes #18644

## Summary

The `JAVADOC_MULTILINE_TO_SINGLELINE_PATTERN` regex in `SummaryJavadocCheck` only matched spaces before asterisks (`\n +(\*)`), not tabs. When Javadoc continuation lines used tabs (e.g., `\t * text`), the pattern failed to match, leaving the asterisk in the processed string.

This caused `forbiddenSummaryFragments` patterns like `^[a-z]` to fail because the string started with `*` instead of the actual summary text.

## Changes

- Changed the pattern from `\n +(\*)` to `\n[ \t]+(\*)` to match both spaces and tabs before the asterisk
- Added test case with tab-formatted Javadoc to verify the fix

## Test

The new test `testForbiddenFragmentsTabFormatted` verifies that `forbiddenSummaryFragments = ^[a-z]` correctly detects a violation when the Javadoc summary starts with a lowercase letter in tab-formatted code.