### PR TITLE
Issue #18612: Remove redundant tokens property from CustomImportOrder in google_checks.xml

### DIFF
--- a/src/main/resources/google_checks.xml
+++ b/src/main/resources/google_checks.xml
@@ -344,7 +344,6 @@
       <property name="sortImportsInGroupAlphabetically" value="true"/>
       <property name="separateLineBetweenGroups" value="true"/>
       <property name="customImportOrderRules" value="STATIC###THIRD_PARTY_PACKAGE"/>
-      <property name="tokens" value="IMPORT, STATIC_IMPORT, PACKAGE_DEF"/>
     </module>
     <module name="MethodParamPad">
       <property name="tokens"


### PR DESCRIPTION
Fixes #18612

## Summary

The `tokens` property was dropped from `CustomImportOrder` in #12145. Since `getAcceptableTokens()` returns `getRequiredTokens()`, the tokens cannot be customized - they are fixed to `IMPORT`, `STATIC_IMPORT`, and `PACKAGE_DEF`.

The `tokens` property in `google_checks.xml` has no effect and should be removed.

## Changes

Removed the redundant line:
```xml
<property name="tokens" value="IMPORT, STATIC_IMPORT, PACKAGE_DEF"/>
```