### PR TITLE
Issue #17449 : Add XDocs examples for ClassMemberImpliedModifierCheck properties

### DIFF
--- a/src/site/xdoc/checks/modifier/classmemberimpliedmodifier.xml
+++ b/src/site/xdoc/checks/modifier/classmemberimpliedmodifier.xml
@@ -122,6 +122,146 @@ public final class Example1 {
   }
 }
 </code></pre></div>
+
+        <hr class="example-separator"/>
+
+        <p id="Example2-config">
+          Configuration:
+        </p>
+        <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
+&lt;module name="Checker"&gt;
+  &lt;module name="TreeWalker"&gt;
+    &lt;module name="ClassMemberImpliedModifier"&gt;
+      &lt;property name="violateImpliedStaticOnNestedInterface" value="false"/&gt;
+    &lt;/module&gt;
+  &lt;/module&gt;
+&lt;/module&gt;
+</code></pre></div>
+        <p id="Example2-code">
+          Code:
+        </p>
+        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+public final class Example2 {
+  static interface Address1 {
+  }
+
+  interface Address2 {  // ok, implied static is not enforced for nested interfaces
+  }
+
+  static enum Age1 {
+    CHILD, ADULT
+  }
+
+  enum Age2 {  // violation, 'Implied modifier 'static' should be explicit'
+    CHILD, ADULT
+  }
+
+  public static record GoodRecord() {}
+  // violation below, 'Implied modifier 'static' should be explicit'
+  public record BadRecord() {}
+
+  public static record OuterRecord() {
+    static record InnerRecord1(){}
+    // violation below, 'Implied modifier 'static' should be explicit'
+    record InnerRecord2(){}
+  }
+}
+</code></pre></div>
+
+        <hr class="example-separator"/>
+
+        <p id="Example3-config">
+          Configuration:
+        </p>
+        <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
+&lt;module name="Checker"&gt;
+  &lt;module name="TreeWalker"&gt;
+    &lt;module name="ClassMemberImpliedModifier"&gt;
+      &lt;property name="violateImpliedStaticOnNestedEnum" value="false"/&gt;
+    &lt;/module&gt;
+  &lt;/module&gt;
+&lt;/module&gt;
+</code></pre></div>
+        <p id="Example3-code">
+          Code:
+        </p>
+        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+public final class Example3 {
+
+  static interface Address1 {
+  }
+
+  interface Address2 {  // violation, 'Implied modifier 'static' should be explicit'
+  }
+
+  static enum Age1 {
+    CHILD, ADULT
+  }
+
+  enum Age2 {  // ok, implied static is not enforced for nested enums
+    CHILD, ADULT
+  }
+
+  public static record GoodRecord() {}
+
+  // violation below, 'Implied modifier 'static' should be explicit'
+  public record BadRecord() {}
+
+  public static record OuterRecord() {
+    static record InnerRecord1(){}
+    // violation below, 'Implied modifier 'static' should be explicit'
+    record InnerRecord2(){}
+  }
+}
+</code></pre></div>
+
+        <hr class="example-separator"/>
+
+        <p id="Example4-config">
+          Configuration:
+        </p>
+        <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
+&lt;module name="Checker"&gt;
+  &lt;module name="TreeWalker"&gt;
+    &lt;module name="ClassMemberImpliedModifier"&gt;
+      &lt;property name="violateImpliedStaticOnNestedRecord" value="false"/&gt;
+    &lt;/module&gt;
+  &lt;/module&gt;
+&lt;/module&gt;
+</code></pre></div>
+        <p id="Example4-code">
+          Code:
+        </p>
+        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+public final class Example4 {
+
+  static interface Address1 {
+  }
+
+  interface Address2 {  // violation, 'Implied modifier 'static' should be explicit'
+  }
+
+  static enum Age1 {
+    CHILD, ADULT
+  }
+
+  enum Age2 {  // violation, 'Implied modifier 'static' should be explicit'
+    CHILD, ADULT
+  }
+
+  public static record GoodRecord() {}
+
+  // ok, static modifier is not required due to configuration
+  public record BadRecord() {}
+
+  public static record OuterRecord() {
+    static record InnerRecord1(){}
+
+    // ok, static modifier is not required due to configuration
+    record InnerRecord2(){}
+  }
+}
+</code></pre></div>
       </subsection>
 
       <subsection name="Example of Usage" id="ClassMemberImpliedModifier_Example_of_Usage">

--- a/src/site/xdoc/checks/modifier/classmemberimpliedmodifier.xml.template
+++ b/src/site/xdoc/checks/modifier/classmemberimpliedmodifier.xml.template
@@ -48,6 +48,63 @@
                  value="resources/com/puppycrawl/tools/checkstyle/checks/modifier/classmemberimpliedmodifier/Example1.java"/>
           <param name="type" value="code"/>
         </macro>
+
+        <hr class="example-separator"/>
+
+        <p id="Example2-config">
+          Configuration:
+        </p>
+        <macro name="example">
+          <param name="path"
+                 value="resources/com/puppycrawl/tools/checkstyle/checks/modifier/classmemberimpliedmodifier/Example2.java"/>
+          <param name="type" value="config"/>
+        </macro>
+        <p id="Example2-code">
+          Code:
+        </p>
+        <macro name="example">
+          <param name="path"
+                 value="resources/com/puppycrawl/tools/checkstyle/checks/modifier/classmemberimpliedmodifier/Example2.java"/>
+          <param name="type" value="code"/>
+        </macro>
+
+        <hr class="example-separator"/>
+
+        <p id="Example3-config">
+          Configuration:
+        </p>
+        <macro name="example">
+          <param name="path"
+                 value="resources/com/puppycrawl/tools/checkstyle/checks/modifier/classmemberimpliedmodifier/Example3.java"/>
+          <param name="type" value="config"/>
+        </macro>
+        <p id="Example3-code">
+          Code:
+        </p>
+        <macro name="example">
+          <param name="path"
+                 value="resources/com/puppycrawl/tools/checkstyle/checks/modifier/classmemberimpliedmodifier/Example3.java"/>
+          <param name="type" value="code"/>
+        </macro>
+
+        <hr class="example-separator"/>
+
+        <p id="Example4-config">
+          Configuration:
+        </p>
+        <macro name="example">
+          <param name="path"
+                 value="resources/com/puppycrawl/tools/checkstyle/checks/modifier/classmemberimpliedmodifier/Example4.java"/>
+          <param name="type" value="config"/>
+        </macro>
+        <p id="Example4-code">
+          Code:
+        </p>
+        <macro name="example">
+          <param name="path"
+                 value="resources/com/puppycrawl/tools/checkstyle/checks/modifier/classmemberimpliedmodifier/Example4.java"/>
+          <param name="type" value="code"/>
+        </macro>
       </subsection>
 
       <subsection name="Example of Usage" id="ClassMemberImpliedModifier_Example_of_Usage">

--- a/src/test/java/com/puppycrawl/tools/checkstyle/internal/XdocsExampleFileTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/internal/XdocsExampleFileTest.java
@@ -68,11 +68,14 @@ public class XdocsExampleFileTest {
                     "arrayInitIndent",
                     "braceAdjustment"
             )),
+
             Map.entry("ClassMemberImpliedModifierCheck", Set.of(
                     "violateImpliedStaticOnNestedEnum",
                     "violateImpliedStaticOnNestedRecord",
                     "violateImpliedStaticOnNestedInterface"
             )),
+            Map.entry("DescendantTokenCheck", Set.of("minimumMessage")),
+
             Map.entry("InterfaceMemberImpliedModifierCheck", Set.of(
                     "violateImpliedFinalField",
                     "violateImpliedPublicField",

--- a/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/checks/modifier/ClassMemberImpliedModifierCheckExamplesTest.java
+++ b/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/checks/modifier/ClassMemberImpliedModifierCheckExamplesTest.java
@@ -26,6 +26,7 @@ import org.junit.jupiter.api.Test;
 import com.puppycrawl.tools.checkstyle.AbstractExamplesModuleTestSupport;
 
 public class ClassMemberImpliedModifierCheckExamplesTest extends AbstractExamplesModuleTestSupport {
+
     @Override
     public String getPackageLocation() {
         return "com/puppycrawl/tools/checkstyle/checks/modifier/classmemberimpliedmodifier";
@@ -43,4 +44,41 @@ public class ClassMemberImpliedModifierCheckExamplesTest extends AbstractExample
         verifyWithInlineConfigParser(
                 getPath("Example1.java"), expected);
     }
+
+    @Test
+    public void testExample2() throws Exception {
+        final String[] expected = {
+            "25:3: " + getCheckMessage(MSG_KEY, "static"),
+            "31:3: " + getCheckMessage(MSG_KEY, "static"),
+            "36:5: " + getCheckMessage(MSG_KEY, "static"),
+        };
+
+        verifyWithInlineConfigParser(
+                getPath("Example2.java"), expected);
+    }
+
+    @Test
+    public void testExample3() throws Exception {
+        final String[] expected = {
+            "19:3: " + getCheckMessage(MSG_KEY, "static"),
+            "33:3: " + getCheckMessage(MSG_KEY, "static"),
+            "38:5: " + getCheckMessage(MSG_KEY, "static"),
+        };
+
+        verifyWithInlineConfigParser(
+                getPath("Example3.java"), expected);
+    }
+
+    @Test
+    public void testExample4() throws Exception {
+        final String[] expected = {
+            "19:3: " + getCheckMessage(MSG_KEY, "static"),
+            "26:3: " + getCheckMessage(MSG_KEY, "static"),
+        };
+
+        verifyWithInlineConfigParser(
+                getPath("Example4.java"), expected);
+    }
+
 }
+

--- a/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/modifier/classmemberimpliedmodifier/Example2.java
+++ b/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/modifier/classmemberimpliedmodifier/Example2.java
@@ -1,0 +1,39 @@
+/*xml
+<module name="Checker">
+  <module name="TreeWalker">
+    <module name="ClassMemberImpliedModifier">
+      <property name="violateImpliedStaticOnNestedInterface" value="false"/>
+    </module>
+  </module>
+</module>
+*/
+// Java17
+package com.puppycrawl.tools.checkstyle.checks.modifier.classmemberimpliedmodifier;
+
+// xdoc section -- start
+public final class Example2 {
+  static interface Address1 {
+  }
+
+  interface Address2 {  // ok, implied static is not enforced for nested interfaces
+  }
+
+  static enum Age1 {
+    CHILD, ADULT
+  }
+
+  enum Age2 {  // violation, 'Implied modifier 'static' should be explicit'
+    CHILD, ADULT
+  }
+
+  public static record GoodRecord() {}
+  // violation below, 'Implied modifier 'static' should be explicit'
+  public record BadRecord() {}
+
+  public static record OuterRecord() {
+    static record InnerRecord1(){}
+    // violation below, 'Implied modifier 'static' should be explicit'
+    record InnerRecord2(){}
+  }
+}
+// xdoc section -- end

--- a/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/modifier/classmemberimpliedmodifier/Example3.java
+++ b/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/modifier/classmemberimpliedmodifier/Example3.java
@@ -1,0 +1,42 @@
+/*xml
+<module name="Checker">
+  <module name="TreeWalker">
+    <module name="ClassMemberImpliedModifier">
+      <property name="violateImpliedStaticOnNestedEnum" value="false"/>
+    </module>
+  </module>
+</module>
+*/
+// Java17
+package com.puppycrawl.tools.checkstyle.checks.modifier.classmemberimpliedmodifier;
+
+// xdoc section -- start
+public final class Example3 {
+
+  static interface Address1 {
+  }
+
+  interface Address2 {  // violation, 'Implied modifier 'static' should be explicit'
+  }
+
+  static enum Age1 {
+    CHILD, ADULT
+  }
+
+  enum Age2 {  // ok, implied static is not enforced for nested enums
+    CHILD, ADULT
+  }
+
+  public static record GoodRecord() {}
+
+  // violation below, 'Implied modifier 'static' should be explicit'
+  public record BadRecord() {}
+
+  public static record OuterRecord() {
+    static record InnerRecord1(){}
+    // violation below, 'Implied modifier 'static' should be explicit'
+    record InnerRecord2(){}
+  }
+}
+// xdoc section -- end
+

--- a/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/modifier/classmemberimpliedmodifier/Example4.java
+++ b/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/modifier/classmemberimpliedmodifier/Example4.java
@@ -1,0 +1,43 @@
+/*xml
+<module name="Checker">
+  <module name="TreeWalker">
+    <module name="ClassMemberImpliedModifier">
+      <property name="violateImpliedStaticOnNestedRecord" value="false"/>
+    </module>
+  </module>
+</module>
+*/
+// Java17
+package com.puppycrawl.tools.checkstyle.checks.modifier.classmemberimpliedmodifier;
+
+// xdoc section -- start
+public final class Example4 {
+
+  static interface Address1 {
+  }
+
+  interface Address2 {  // violation, 'Implied modifier 'static' should be explicit'
+  }
+
+  static enum Age1 {
+    CHILD, ADULT
+  }
+
+  enum Age2 {  // violation, 'Implied modifier 'static' should be explicit'
+    CHILD, ADULT
+  }
+
+  public static record GoodRecord() {}
+
+  // ok, static modifier is not required due to configuration
+  public record BadRecord() {}
+
+  public static record OuterRecord() {
+    static record InnerRecord1(){}
+
+    // ok, static modifier is not required due to configuration
+    record InnerRecord2(){}
+  }
+}
+// xdoc section -- end
+


### PR DESCRIPTION
Issue: #17449

### Description
Added missing XDocs example coverage for ClassMemberImpliedModifierCheck properties so that all configurable options are demonstrated in documentation examples.

### Changes
Added ClassMemberImpliedModifierCheck property examples to XDocs snippets:

- violateImpliedStaticOnNestedEnum
- violateImpliedStaticOnNestedRecord
- violateImpliedStaticOnNestedInterface

Added corresponding examples tests to validate the new snippets.

Removed ClassMemberImpliedModifierCheck property suppressions from XdocsExampleFileTest now that examples fully cover these cases.

### Testing
`./mvnw -Dtest=ClassMemberImpliedModifierCheckExamplesTest test`