### PR TITLE
Issue #6456: Specify XPath version in SuppressionXpathFilter documentation

### DIFF
--- a/src/site/xdoc/checks/coding/matchxpath.xml
+++ b/src/site/xdoc/checks/coding/matchxpath.xml
@@ -32,6 +32,11 @@
           <a href="https://github.com/checkstyle/checkstyle/search?q=%22TOKEN_TYPES_WITH_TEXT_ATTRIBUTE+%3D+Arrays.asList%22">
           XpathUtil</a>.
         </p>
+        <p>
+          Checkstyle supports XPath 3.1 or higher, for exact version please find
+          &quot;Saxon-HE&quot; version in our <a href="../../project-info.html#Dependencies">dependency report</a>
+          and find related documentation at <a href="https://www.saxonica.com/">saxonica.com</a>.
+        </p>
       </subsection>
 
       <subsection name="Properties" id="MatchXpath_Properties">

--- a/src/site/xdoc/checks/coding/matchxpath.xml.template
+++ b/src/site/xdoc/checks/coding/matchxpath.xml.template
@@ -16,6 +16,11 @@
             <param name="modulePath"
                    value="src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/MatchXpathCheck.java"/>
         </macro>
+        <p>
+          Checkstyle supports XPath 3.1 or higher, for exact version please find
+          &quot;Saxon-HE&quot; version in our <a href="../../project-info.html#Dependencies">dependency report</a>
+          and find related documentation at <a href="https://www.saxonica.com/">saxonica.com</a>.
+        </p>
       </subsection>
 
       <subsection name="Properties" id="MatchXpath_Properties">

--- a/src/site/xdoc/filters/suppressionxpathfilter.xml
+++ b/src/site/xdoc/filters/suppressionxpathfilter.xml
@@ -137,6 +137,11 @@
           configuration file and input files. See <a href="https://checkstyle.org/cmdline.html">here</a>
           for more details.
         </p>
+        <p>
+          Checkstyle supports XPath 3.1 or higher, for exact version please find
+          &quot;Saxon-HE&quot; version in our <a href="../project-info.html#Dependencies">dependency report</a>
+          and find related documentation at <a href="https://www.saxonica.com/">saxonica.com</a>.
+        </p>
       </subsection>
       <subsection name="Notes" id="SuppressionXpathFilter_Notes">
         <p>

--- a/src/site/xdoc/filters/suppressionxpathfilter.xml.template
+++ b/src/site/xdoc/filters/suppressionxpathfilter.xml.template
@@ -16,6 +16,11 @@
             <param name="modulePath"
                    value="src/main/java/com/puppycrawl/tools/checkstyle/filters/SuppressionXpathFilter.java"/>
         </macro>
+        <p>
+          Checkstyle supports XPath 3.1 or higher, for exact version please find
+          &quot;Saxon-HE&quot; version in our <a href="../project-info.html#Dependencies">dependency report</a>
+          and find related documentation at <a href="https://www.saxonica.com/">saxonica.com</a>.
+        </p>
       </subsection>
       <subsection name="Notes" id="SuppressionXpathFilter_Notes">
         <macro name="notes">

--- a/src/site/xdoc/filters/suppressionxpathsinglefilter.xml
+++ b/src/site/xdoc/filters/suppressionxpathsinglefilter.xml
@@ -30,6 +30,11 @@
           Attention: This filter only supports single suppression, and will need multiple
           instances if users wants to suppress multiple violations.
         </p>
+        <p>
+          Checkstyle supports XPath 3.1 or higher, for exact version please find
+          &quot;Saxon-HE&quot; version in our <a href="../project-info.html#Dependencies">dependency report</a>
+          and find related documentation at <a href="https://www.saxonica.com/">saxonica.com</a>.
+        </p>
       </subsection>
       <subsection name="Notes" id="SuppressionXpathSingleFilter_Notes">
         <p>

--- a/src/site/xdoc/filters/suppressionxpathsinglefilter.xml.template
+++ b/src/site/xdoc/filters/suppressionxpathsinglefilter.xml.template
@@ -16,6 +16,11 @@
             <param name="modulePath"
                    value="src/main/java/com/puppycrawl/tools/checkstyle/filters/SuppressionXpathSingleFilter.java"/>
         </macro>
+        <p>
+          Checkstyle supports XPath 3.1 or higher, for exact version please find
+          &quot;Saxon-HE&quot; version in our <a href="../project-info.html#Dependencies">dependency report</a>
+          and find related documentation at <a href="https://www.saxonica.com/">saxonica.com</a>.
+        </p>
       </subsection>
       <subsection name="Notes" id="SuppressionXpathSingleFilter_Notes">
         <macro name="notes">


### PR DESCRIPTION
Issue #6456

Updated the documentation for SuppressionXpathFilter to state that checkstyle supports XPath 3.1.

https://www.saxonica.com/documentation12/index.html#!expressions

https://github.com/checkstyle/checkstyle/blob/8a63a3141b73f879d619bbc5c04659277b8eb2f3/pom.xml#L212

https://github.com/checkstyle/checkstyle/blob/8a63a3141b73f879d619bbc5c04659277b8eb2f3/pom.xml#L455-L458