### PR TITLE
Issue #18599: Resolve error-prone for ObjectEqualsForPrimitives

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -261,6 +261,7 @@
       -Xep:MockitoMockClassReference:ERROR
       -Xep:MockitoStubbing:ERROR
       -Xep:NestedOptionals:ERROR
+      -Xep:ObjectEqualsForPrimitives:ERROR
       -Xep:OptionalOrElseGet:ERROR
       -Xep:PrimitiveComparison:ERROR
       -Xep:RedundantStringConversion:ERROR

--- a/src/main/java/com/puppycrawl/tools/checkstyle/api/Violation.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/api/Violation.java
@@ -364,10 +364,10 @@ public final class Violation
             return false;
         }
         final Violation violation = (Violation) object;
-        return Objects.equals(lineNo, violation.lineNo)
-                && Objects.equals(columnNo, violation.columnNo)
-                && Objects.equals(columnCharIndex, violation.columnCharIndex)
-                && Objects.equals(tokenType, violation.tokenType)
+        return lineNo == violation.lineNo
+                && columnNo == violation.columnNo
+                && columnCharIndex == violation.columnCharIndex
+                && tokenType == violation.tokenType
                 && Objects.equals(severityLevel, violation.severityLevel)
                 && Objects.equals(moduleId, violation.moduleId)
                 && Objects.equals(key, violation.key)


### PR DESCRIPTION
Issue #18599 
Fixed -> 
```
[WARNING] /C:/Users/brije/checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/api/Violation.java:[367,30] [ObjectEqualsForPrimitives] Avoid unnecessary boxing by using plain == for primitive types.
    (see https://errorprone.info/bugpattern/ObjectEqualsForPrimitives)
  Did you mean 'return (lineNo == violation.lineNo)'?
[WARNING] /C:/Users/brije/checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/api/Violation.java:[368,34] [ObjectEqualsForPrimitives] Avoid unnecessary boxing by using plain == for primitive types.
    (see https://errorprone.info/bugpattern/ObjectEqualsForPrimitives)
  Did you mean '&& (columnNo == violation.columnNo)'?
[WARNING] /C:/Users/brije/checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/api/Violation.java:[369,34] [ObjectEqualsForPrimitives] Avoid unnecessary boxing by using plain == for primitive types.
    (see https://errorprone.info/bugpattern/ObjectEqualsForPrimitives)
  Did you mean '&& (columnCharIndex == violation.columnCharIndex)'?
[WARNING] /C:/Users/brije/checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/api/Violation.java:[370,34] [ObjectEqualsForPrimitives] Avoid unnecessary boxing by using plain == for primitive types.
    (see https://errorprone.info/bugpattern/ObjectEqualsForPrimitives)
  Did you mean '&& (tokenType == violation.tokenType)'?
```