### PR TITLE
Issue #18660: fix crash in EmptyLineSeparatorCheck

### DIFF
--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/whitespace/EmptyLineSeparatorCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/whitespace/EmptyLineSeparatorCheckTest.java
@@ -84,6 +84,18 @@ public class EmptyLineSeparatorCheckTest
     }
 
     @Test
+    public void testCrash18660Coverage() throws Exception {
+        final DefaultConfiguration checkConfig =
+                createModuleConfig(EmptyLineSeparatorCheck.class);
+
+        final String[] expected = CommonUtil.EMPTY_STRING_ARRAY;
+
+        verify(checkConfig,
+                getPath("InputEmptyLineSeparatorCrash18660.java"),
+                expected);
+    }
+
+    @Test
     public void testSeparationOfClassAndPackageWithComment() throws Exception {
 
         final String[] expected = {

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/whitespace/emptylineseparator/InputEmptyLineSeparatorCrash18660.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/whitespace/emptylineseparator/InputEmptyLineSeparatorCrash18660.java
@@ -1,0 +1,11 @@
+package com.puppycrawl.tools.checkstyle.checks.whitespace.emptylineseparator;
+
+public class InputEmptyLineSeparatorCrash18660 {
+    // This comment is at the start of the class body and used to crash EmptyLineSeparatorCheck
+
+    void display(boolean ifYes) {
+        if (true) {
+            System.out.println("Hello world");
+        }
+    }
+}


### PR DESCRIPTION
Fixes #18660.
EmptyLineSeparatorCheck could throw ArrayIndexOutOfBoundsException when a comment
appears at the beginning of a class body and pre-previous line checks access
negative indices. Added regression test and boundary fix.