### PR TITLE
Pull #18672: Add `JavaLangAPIs`

### DIFF
--- a/config/rewrite.yml
+++ b/config/rewrite.yml
@@ -17,7 +17,9 @@ recipeList:
   - org.openrewrite.java.format.PadEmptyForLoopComponents
   - org.openrewrite.java.format.RemoveTrailingWhitespace
   - org.openrewrite.java.migrate.UpgradeToJava21
+  - org.openrewrite.java.migrate.lang.JavaLangAPIs
   - org.openrewrite.java.migrate.lang.StringRulesRecipes
+  - org.openrewrite.java.migrate.util.JavaUtilAPIs
   - org.openrewrite.java.migrate.util.MigrateInflaterDeflaterToClose
   - org.openrewrite.java.migrate.util.ReplaceStreamCollectWithToList
   - org.openrewrite.java.migrate.util.SequencedCollection

--- a/src/it/java/org/checkstyle/base/AbstractItModuleTestSupport.java
+++ b/src/it/java/org/checkstyle/base/AbstractItModuleTestSupport.java
@@ -482,7 +482,7 @@ public abstract class AbstractItModuleTestSupport extends AbstractPathTestSuppor
           String file) throws Exception {
         stream.flush();
         stream.reset();
-        final List<File> files = Collections.singletonList(new File(file));
+        final List<File> files = List.of(new File(file));
         final Checker checker = createChecker(config);
         final Map<String, List<String>> actualViolations =
                 getActualViolations(checker.process(files));

--- a/src/it/java/org/checkstyle/suppressionxpathfilter/XpathRegressionArrayTypeStyleTest.java
+++ b/src/it/java/org/checkstyle/suppressionxpathfilter/XpathRegressionArrayTypeStyleTest.java
@@ -20,7 +20,6 @@
 package org.checkstyle.suppressionxpathfilter;
 
 import java.io.File;
-import java.util.Collections;
 import java.util.List;
 
 import org.junit.jupiter.api.Test;
@@ -47,7 +46,7 @@ public class XpathRegressionArrayTypeStyleTest extends AbstractXpathTestSupport 
             "4:19: " + getCheckMessage(ArrayTypeStyleCheck.class, ArrayTypeStyleCheck.MSG_KEY),
         };
 
-        final List<String> expectedXpathQueries = Collections.singletonList(
+        final List<String> expectedXpathQueries = List.of(
                 "/COMPILATION_UNIT/CLASS_DEF"
                         + "[./IDENT[@text='InputXpathArrayTypeStyleVariable']]"
                         + "/OBJBLOCK/VARIABLE_DEF[./IDENT[@text='strings']]/TYPE["
@@ -70,7 +69,7 @@ public class XpathRegressionArrayTypeStyleTest extends AbstractXpathTestSupport 
             "4:19: " + getCheckMessage(ArrayTypeStyleCheck.class, ArrayTypeStyleCheck.MSG_KEY),
         };
 
-        final List<String> expectedXpathQueries = Collections.singletonList(
+        final List<String> expectedXpathQueries = List.of(
             "/COMPILATION_UNIT/CLASS_DEF"
                     + "[./IDENT[@text='InputXpathArrayTypeStyleMethodDef']]"
                     + "/OBJBLOCK/METHOD_DEF[./IDENT[@text='getData']]/TYPE/ARRAY_DECLARATOR"

--- a/src/it/java/org/checkstyle/suppressionxpathfilter/XpathRegressionTodoCommentTest.java
+++ b/src/it/java/org/checkstyle/suppressionxpathfilter/XpathRegressionTodoCommentTest.java
@@ -22,7 +22,6 @@ package org.checkstyle.suppressionxpathfilter;
 import static com.puppycrawl.tools.checkstyle.checks.TodoCommentCheck.MSG_KEY;
 
 import java.io.File;
-import java.util.Collections;
 import java.util.List;
 
 import org.junit.jupiter.api.Test;
@@ -51,7 +50,7 @@ public class XpathRegressionTodoCommentTest extends AbstractXpathTestSupport {
             "4:7: " + getCheckMessage(TodoCommentCheck.class, MSG_KEY, "FIXME:"),
         };
 
-        final List<String> expectedXpathQueries = Collections.singletonList(
+        final List<String> expectedXpathQueries = List.of(
                 "/COMPILATION_UNIT/CLASS_DEF[./IDENT[@text="
                         + "'InputXpathTodoCommentSingleLine']]/OBJBLOCK/"
                         + "SINGLE_LINE_COMMENT/COMMENT_CONTENT[@text=' warn FIXME:\\n']");
@@ -73,7 +72,7 @@ public class XpathRegressionTodoCommentTest extends AbstractXpathTestSupport {
             "4:7: " + getCheckMessage(TodoCommentCheck.class, MSG_KEY, "FIXME:"),
         };
 
-        final List<String> expectedXpathQueries = Collections.singletonList(
+        final List<String> expectedXpathQueries = List.of(
                 "/COMPILATION_UNIT/CLASS_DEF[./IDENT[@text="
                         + "'InputXpathTodoCommentBlock']]/"
                         + "OBJBLOCK/BLOCK_COMMENT_BEGIN/COMMENT_CONTENT"

--- a/src/it/java/org/checkstyle/suppressionxpathfilter/XpathRegressionTrailingCommentTest.java
+++ b/src/it/java/org/checkstyle/suppressionxpathfilter/XpathRegressionTrailingCommentTest.java
@@ -20,7 +20,6 @@
 package org.checkstyle.suppressionxpathfilter;
 
 import java.io.File;
-import java.util.Collections;
 import java.util.List;
 
 import org.junit.jupiter.api.Test;
@@ -49,7 +48,7 @@ public class XpathRegressionTrailingCommentTest extends AbstractXpathTestSupport
                         TrailingCommentCheck.MSG_KEY),
         };
 
-        final List<String> expectedXpathQueries = Collections.singletonList(
+        final List<String> expectedXpathQueries = List.of(
                 "/COMPILATION_UNIT/CLASS_DEF"
                         + "[./IDENT[@text='InputXpathTrailingCommentSingleLine']]/"
                         + "OBJBLOCK/SINGLE_LINE_COMMENT[./COMMENT_CONTENT[@text=' don&apos;"
@@ -73,7 +72,7 @@ public class XpathRegressionTrailingCommentTest extends AbstractXpathTestSupport
                         TrailingCommentCheck.MSG_KEY),
         };
 
-        final List<String> expectedXpathQueries = Collections.singletonList(
+        final List<String> expectedXpathQueries = List.of(
                 "/COMPILATION_UNIT/CLASS_DEF"
                         + "[./IDENT[@text='InputXpathTrailingCommentBlock']]"
                         + "/OBJBLOCK/SINGLE_LINE_COMMENT[./COMMENT_CONTENT[@text=' warn\\n']]"

--- a/src/it/java/org/checkstyle/suppressionxpathfilter/annotation/XpathRegressionAnnotationUseStyleTest.java
+++ b/src/it/java/org/checkstyle/suppressionxpathfilter/annotation/XpathRegressionAnnotationUseStyleTest.java
@@ -21,7 +21,6 @@ package org.checkstyle.suppressionxpathfilter.annotation;
 
 import java.io.File;
 import java.util.Arrays;
-import java.util.Collections;
 import java.util.List;
 
 import org.checkstyle.suppressionxpathfilter.AbstractXpathTestSupport;
@@ -160,7 +159,7 @@ public class XpathRegressionAnnotationUseStyleTest extends AbstractXpathTestSupp
                     AnnotationUseStyleCheck.MSG_KEY_ANNOTATION_TRAILING_COMMA_MISSING),
         };
 
-        final List<String> expectedXpathQueries = Collections.singletonList(
+        final List<String> expectedXpathQueries = List.of(
                 "/COMPILATION_UNIT/CLASS_DEF"
                         + "[./IDENT[@text='InputXpathAnnotationUseStyleFour']]"
                         + "/MODIFIERS/ANNOTATION[./IDENT[@text='SuppressWarnings']]"
@@ -287,7 +286,7 @@ public class XpathRegressionAnnotationUseStyleTest extends AbstractXpathTestSupp
                     AnnotationUseStyleCheck.MSG_KEY_ANNOTATION_TRAILING_COMMA_PRESENT),
         };
 
-        final List<String> expectedXpathQueries = Collections.singletonList(
+        final List<String> expectedXpathQueries = List.of(
                 "/COMPILATION_UNIT/CLASS_DEF"
                         + "[./IDENT[@text='InputXpathAnnotationUseStyleEight']]"
                         + "/MODIFIERS/ANNOTATION[./IDENT[@text='SuppressWarnings']]"

--- a/src/it/java/org/checkstyle/suppressionxpathfilter/blocks/XpathRegressionAvoidNestedBlocksTest.java
+++ b/src/it/java/org/checkstyle/suppressionxpathfilter/blocks/XpathRegressionAvoidNestedBlocksTest.java
@@ -21,7 +21,6 @@ package org.checkstyle.suppressionxpathfilter.blocks;
 
 import java.io.File;
 import java.util.Arrays;
-import java.util.Collections;
 import java.util.List;
 
 import org.checkstyle.suppressionxpathfilter.AbstractXpathTestSupport;
@@ -55,7 +54,7 @@ public class XpathRegressionAvoidNestedBlocksTest extends AbstractXpathTestSuppo
                     AvoidNestedBlocksCheck.MSG_KEY_BLOCK_NESTED),
         };
 
-        final List<String> expectedXpathQueries = Collections.singletonList(
+        final List<String> expectedXpathQueries = List.of(
                 "/COMPILATION_UNIT/CLASS_DEF"
                         + "[./IDENT[@text='InputXpathAvoidNestedBlocksEmpty']]"
                         + "/OBJBLOCK/METHOD_DEF[./IDENT[@text='empty']]/SLIST/SLIST"
@@ -78,7 +77,7 @@ public class XpathRegressionAvoidNestedBlocksTest extends AbstractXpathTestSuppo
                     AvoidNestedBlocksCheck.MSG_KEY_BLOCK_NESTED),
         };
 
-        final List<String> expectedXpathQueries = Collections.singletonList(
+        final List<String> expectedXpathQueries = List.of(
                 "/COMPILATION_UNIT/CLASS_DEF"
                         + "[./IDENT[@text='InputXpathAvoidNestedBlocksVariable']]"
                         + "/OBJBLOCK/METHOD_DEF[./IDENT[@text='varAssign']]/SLIST/SLIST"
@@ -130,7 +129,7 @@ public class XpathRegressionAvoidNestedBlocksTest extends AbstractXpathTestSuppo
                     AvoidNestedBlocksCheck.MSG_KEY_BLOCK_NESTED),
         };
 
-        final List<String> expectedXpathQueries = Collections.singletonList(
+        final List<String> expectedXpathQueries = List.of(
                 "/COMPILATION_UNIT/CLASS_DEF[./IDENT"
                         + "[@text='InputXpathAvoidNestedBlocksAllowedInSwitchCase"
                         + "']]/OBJBLOCK/METHOD_DEF[./IDENT[@text='s']]"

--- a/src/it/java/org/checkstyle/suppressionxpathfilter/blocks/XpathRegressionEmptyBlockTest.java
+++ b/src/it/java/org/checkstyle/suppressionxpathfilter/blocks/XpathRegressionEmptyBlockTest.java
@@ -20,7 +20,6 @@
 package org.checkstyle.suppressionxpathfilter.blocks;
 
 import java.io.File;
-import java.util.Collections;
 import java.util.List;
 
 import org.checkstyle.suppressionxpathfilter.AbstractXpathTestSupport;
@@ -54,7 +53,7 @@ public class XpathRegressionEmptyBlockTest extends AbstractXpathTestSupport {
             "5:38: " + getCheckMessage(EmptyBlockCheck.class,
                 EmptyBlockCheck.MSG_KEY_BLOCK_EMPTY, "for"),
         };
-        final List<String> expectedXpathQueries = Collections.singletonList(
+        final List<String> expectedXpathQueries = List.of(
                 "/COMPILATION_UNIT"
                     + "/CLASS_DEF[./IDENT[@text='InputXpathEmptyBlockEmpty']]"
                     + "/OBJBLOCK/METHOD_DEF[./IDENT[@text='emptyLoop']]"
@@ -74,7 +73,7 @@ public class XpathRegressionEmptyBlockTest extends AbstractXpathTestSupport {
             "5:38: " + getCheckMessage(EmptyBlockCheck.class,
                 EmptyBlockCheck.MSG_KEY_BLOCK_NO_STATEMENT),
         };
-        final List<String> expectedXpathQueries = Collections.singletonList(
+        final List<String> expectedXpathQueries = List.of(
                 "/COMPILATION_UNIT"
                         + "/CLASS_DEF[./IDENT[@text='InputXpathEmptyBlockEmpty']]"
                         + "/OBJBLOCK/METHOD_DEF[./IDENT[@text='emptyLoop']]"

--- a/src/it/java/org/checkstyle/suppressionxpathfilter/blocks/XpathRegressionEmptyCatchBlockTest.java
+++ b/src/it/java/org/checkstyle/suppressionxpathfilter/blocks/XpathRegressionEmptyCatchBlockTest.java
@@ -20,7 +20,6 @@
 package org.checkstyle.suppressionxpathfilter.blocks;
 
 import java.io.File;
-import java.util.Collections;
 import java.util.List;
 
 import org.checkstyle.suppressionxpathfilter.AbstractXpathTestSupport;
@@ -54,7 +53,7 @@ public class XpathRegressionEmptyCatchBlockTest extends AbstractXpathTestSupport
             "8:38: " + getCheckMessage(CLAZZ, EmptyCatchBlockCheck.MSG_KEY_CATCH_BLOCK_EMPTY),
         };
 
-        final List<String> expectedXpathQueries = Collections.singletonList(
+        final List<String> expectedXpathQueries = List.of(
             "/COMPILATION_UNIT/CLASS_DEF"
                 + "[./IDENT[@text='InputXpathEmptyCatchBlockOne']]"
                 + "/OBJBLOCK/METHOD_DEF[./IDENT[@text='main']]"
@@ -75,7 +74,7 @@ public class XpathRegressionEmptyCatchBlockTest extends AbstractXpathTestSupport
             "8:47: " + getCheckMessage(CLAZZ, EmptyCatchBlockCheck.MSG_KEY_CATCH_BLOCK_EMPTY),
         };
 
-        final List<String> expectedXpathQueries = Collections.singletonList(
+        final List<String> expectedXpathQueries = List.of(
             "/COMPILATION_UNIT/CLASS_DEF"
                 + "[./IDENT[@text='InputXpathEmptyCatchBlockTwo']]"
                 + "/OBJBLOCK/METHOD_DEF[./IDENT[@text='main']]"

--- a/src/it/java/org/checkstyle/suppressionxpathfilter/blocks/XpathRegressionLeftCurlyTest.java
+++ b/src/it/java/org/checkstyle/suppressionxpathfilter/blocks/XpathRegressionLeftCurlyTest.java
@@ -21,7 +21,6 @@ package org.checkstyle.suppressionxpathfilter.blocks;
 
 import java.io.File;
 import java.util.Arrays;
-import java.util.Collections;
 import java.util.List;
 
 import org.checkstyle.suppressionxpathfilter.AbstractXpathTestSupport;
@@ -107,7 +106,7 @@ public class XpathRegressionLeftCurlyTest extends AbstractXpathTestSupport {
                 LeftCurlyCheck.MSG_KEY_LINE_BREAK_AFTER, "{", 19),
         };
 
-        final List<String> expectedXpathQueries = Collections.singletonList(
+        final List<String> expectedXpathQueries = List.of(
             "/COMPILATION_UNIT/CLASS_DEF"
                 + "[./IDENT[@text='InputXpathLeftCurlyThree']]/OBJBLOCK"
                 + "/METHOD_DEF[./IDENT[@text='sample']]/SLIST/LITERAL_IF/SLIST"

--- a/src/it/java/org/checkstyle/suppressionxpathfilter/blocks/XpathRegressionNeedBracesTest.java
+++ b/src/it/java/org/checkstyle/suppressionxpathfilter/blocks/XpathRegressionNeedBracesTest.java
@@ -22,7 +22,6 @@ package org.checkstyle.suppressionxpathfilter.blocks;
 import static com.puppycrawl.tools.checkstyle.checks.blocks.NeedBracesCheck.MSG_KEY_NEED_BRACES;
 
 import java.io.File;
-import java.util.Collections;
 import java.util.List;
 
 import org.checkstyle.suppressionxpathfilter.AbstractXpathTestSupport;
@@ -57,7 +56,7 @@ public class XpathRegressionNeedBracesTest extends AbstractXpathTestSupport {
             "13:9: " + getCheckMessage(NeedBracesCheck.class, MSG_KEY_NEED_BRACES, "do"),
         };
 
-        final List<String> expectedXpathQueries = Collections.singletonList(
+        final List<String> expectedXpathQueries = List.of(
                 "/COMPILATION_UNIT/CLASS_DEF"
                         + "[./IDENT[@text='InputXpathNeedBracesDo']]"
                         + "/OBJBLOCK/METHOD_DEF[./IDENT[@text='test']]/SLIST/LITERAL_DO"
@@ -80,7 +79,7 @@ public class XpathRegressionNeedBracesTest extends AbstractXpathTestSupport {
             "16:9: " + getCheckMessage(NeedBracesCheck.class, MSG_KEY_NEED_BRACES, "if"),
         };
 
-        final List<String> expectedXpathQueries = Collections.singletonList(
+        final List<String> expectedXpathQueries = List.of(
             "/COMPILATION_UNIT/CLASS_DEF"
                 + "[./IDENT[@text='InputXpathNeedBracesSingleLine']]"
                 + "/OBJBLOCK/METHOD_DEF[./IDENT[@text='test']]/SLIST/LITERAL_IF"
@@ -104,7 +103,7 @@ public class XpathRegressionNeedBracesTest extends AbstractXpathTestSupport {
             "4:29: " + getCheckMessage(NeedBracesCheck.class, MSG_KEY_NEED_BRACES, "->"),
         };
 
-        final List<String> expectedXpathQueries = Collections.singletonList(
+        final List<String> expectedXpathQueries = List.of(
             "/COMPILATION_UNIT/CLASS_DEF"
                 + "[./IDENT[@text='InputXpathNeedBracesSingleLineLambda']]"
                 + "/OBJBLOCK/VARIABLE_DEF[./IDENT[@text='r3']]/ASSIGN/LAMBDA"
@@ -126,7 +125,7 @@ public class XpathRegressionNeedBracesTest extends AbstractXpathTestSupport {
             "9:9: " + getCheckMessage(NeedBracesCheck.class, MSG_KEY_NEED_BRACES, "while"),
         };
 
-        final List<String> expectedXpathQueries = Collections.singletonList(
+        final List<String> expectedXpathQueries = List.of(
             "/COMPILATION_UNIT/CLASS_DEF"
                 + "[./IDENT[@text='InputXpathNeedBracesEmptyLoopBody']]"
                 + "/OBJBLOCK/METHOD_DEF[./IDENT[@text='test']]/SLIST/LITERAL_WHILE"

--- a/src/it/java/org/checkstyle/suppressionxpathfilter/blocks/XpathRegressionRightCurlyTest.java
+++ b/src/it/java/org/checkstyle/suppressionxpathfilter/blocks/XpathRegressionRightCurlyTest.java
@@ -20,7 +20,6 @@
 package org.checkstyle.suppressionxpathfilter.blocks;
 
 import java.io.File;
-import java.util.Collections;
 import java.util.List;
 
 import org.checkstyle.suppressionxpathfilter.AbstractXpathTestSupport;
@@ -57,7 +56,7 @@ public class XpathRegressionRightCurlyTest extends AbstractXpathTestSupport {
                 RightCurlyCheck.MSG_KEY_LINE_SAME, "}", 9),
         };
 
-        final List<String> expectedXpathQueries = Collections.singletonList(
+        final List<String> expectedXpathQueries = List.of(
             "/COMPILATION_UNIT/CLASS_DEF"
                 + "[./IDENT[@text='InputXpathRightCurlyOne']]/OBJBLOCK"
                 + "/METHOD_DEF[./IDENT[@text='test']]/SLIST/LITERAL_IF/SLIST/RCURLY"
@@ -81,7 +80,7 @@ public class XpathRegressionRightCurlyTest extends AbstractXpathTestSupport {
                 RightCurlyCheck.MSG_KEY_LINE_ALONE, "}", 15),
         };
 
-        final List<String> expectedXpathQueries = Collections.singletonList(
+        final List<String> expectedXpathQueries = List.of(
             "/COMPILATION_UNIT/CLASS_DEF"
                 + "[./IDENT[@text='InputXpathRightCurlyTwo']]/OBJBLOCK"
                 + "/METHOD_DEF[./IDENT[@text='fooMethod']]/SLIST/LITERAL_TRY/SLIST/RCURLY"
@@ -105,7 +104,7 @@ public class XpathRegressionRightCurlyTest extends AbstractXpathTestSupport {
                 RightCurlyCheck.MSG_KEY_LINE_ALONE, "}", 72),
         };
 
-        final List<String> expectedXpathQueries = Collections.singletonList(
+        final List<String> expectedXpathQueries = List.of(
             "/COMPILATION_UNIT/CLASS_DEF"
                 + "[./IDENT[@text='InputXpathRightCurlyThree']]/OBJBLOCK"
                 + "/METHOD_DEF[./IDENT[@text='sample']]/SLIST/LITERAL_IF/SLIST/RCURLY"
@@ -129,7 +128,7 @@ public class XpathRegressionRightCurlyTest extends AbstractXpathTestSupport {
                 RightCurlyCheck.MSG_KEY_LINE_BREAK_BEFORE, "}", 27),
         };
 
-        final List<String> expectedXpathQueries = Collections.singletonList(
+        final List<String> expectedXpathQueries = List.of(
             "/COMPILATION_UNIT/CLASS_DEF"
                 + "[./IDENT[@text='InputXpathRightCurlyFour']]/OBJBLOCK"
                 + "/METHOD_DEF[./IDENT[@text='sample']]/SLIST/LITERAL_IF/SLIST/RCURLY"

--- a/src/it/java/org/checkstyle/suppressionxpathfilter/coding/XpathRegressionArrayTrailingCommaTest.java
+++ b/src/it/java/org/checkstyle/suppressionxpathfilter/coding/XpathRegressionArrayTrailingCommaTest.java
@@ -21,7 +21,6 @@ package org.checkstyle.suppressionxpathfilter.coding;
 
 import java.io.File;
 import java.util.Arrays;
-import java.util.Collections;
 import java.util.List;
 
 import org.checkstyle.suppressionxpathfilter.AbstractXpathTestSupport;
@@ -85,7 +84,7 @@ public class XpathRegressionArrayTrailingCommaTest extends AbstractXpathTestSupp
                 ArrayTrailingCommaCheck.MSG_KEY),
         };
 
-        final List<String> expectedXpathQueries = Collections.singletonList(
+        final List<String> expectedXpathQueries = List.of(
             "/COMPILATION_UNIT/CLASS_DEF"
                 + "[./IDENT[@text='InputXpathArrayTrailingCommaMatrix']]"
                 + "/OBJBLOCK/VARIABLE_DEF[./IDENT[@text='d2']]/ASSIGN/EXPR/LITERAL_NEW"

--- a/src/it/java/org/checkstyle/suppressionxpathfilter/coding/XpathRegressionAvoidInlineConditionalsTest.java
+++ b/src/it/java/org/checkstyle/suppressionxpathfilter/coding/XpathRegressionAvoidInlineConditionalsTest.java
@@ -21,7 +21,6 @@ package org.checkstyle.suppressionxpathfilter.coding;
 
 import java.io.File;
 import java.util.Arrays;
-import java.util.Collections;
 import java.util.List;
 
 import org.checkstyle.suppressionxpathfilter.AbstractXpathTestSupport;
@@ -83,7 +82,7 @@ public class XpathRegressionAvoidInlineConditionalsTest extends AbstractXpathTes
                 AvoidInlineConditionalsCheck.MSG_KEY),
         };
 
-        final List<String> expectedXpathQueries = Collections.singletonList(
+        final List<String> expectedXpathQueries = List.of(
                 "/COMPILATION_UNIT/CLASS_DEF[./IDENT[@text='"
                         + "InputXpathAvoidInlineConditionalsAssign']]"
                         + "/OBJBLOCK/METHOD_DEF[./IDENT[@text='setB']]/SLIST"

--- a/src/it/java/org/checkstyle/suppressionxpathfilter/coding/XpathRegressionAvoidNoArgumentSuperConstructorCallTest.java
+++ b/src/it/java/org/checkstyle/suppressionxpathfilter/coding/XpathRegressionAvoidNoArgumentSuperConstructorCallTest.java
@@ -20,7 +20,6 @@
 package org.checkstyle.suppressionxpathfilter.coding;
 
 import java.io.File;
-import java.util.Collections;
 import java.util.List;
 
 import org.checkstyle.suppressionxpathfilter.AbstractXpathTestSupport;
@@ -58,7 +57,7 @@ public class XpathRegressionAvoidNoArgumentSuperConstructorCallTest
                 AvoidNoArgumentSuperConstructorCallCheck.MSG_CTOR),
         };
 
-        final List<String> expectedXpathQueries = Collections.singletonList(
+        final List<String> expectedXpathQueries = List.of(
                 "/COMPILATION_UNIT/CLASS_DEF[./IDENT"
                     + "[@text='InputXpathAvoidNoArgumentSuperConstructorCallDefault']]"
                     + "/OBJBLOCK/CTOR_DEF[./IDENT["
@@ -83,7 +82,7 @@ public class XpathRegressionAvoidNoArgumentSuperConstructorCallTest
                 AvoidNoArgumentSuperConstructorCallCheck.MSG_CTOR),
         };
 
-        final List<String> expectedXpathQueries = Collections.singletonList(
+        final List<String> expectedXpathQueries = List.of(
             "/COMPILATION_UNIT/CLASS_DEF[./IDENT[@text="
                 + "'InputXpathAvoidNoArgumentSuperConstructorCallInnerClass']]"
                 + "/OBJBLOCK/METHOD_DEF[./IDENT[@text='test']]"

--- a/src/it/java/org/checkstyle/suppressionxpathfilter/coding/XpathRegressionCovariantEqualsTest.java
+++ b/src/it/java/org/checkstyle/suppressionxpathfilter/coding/XpathRegressionCovariantEqualsTest.java
@@ -20,7 +20,6 @@
 package org.checkstyle.suppressionxpathfilter.coding;
 
 import java.io.File;
-import java.util.Collections;
 import java.util.List;
 
 import org.checkstyle.suppressionxpathfilter.AbstractXpathTestSupport;
@@ -56,7 +55,7 @@ public class XpathRegressionCovariantEqualsTest extends AbstractXpathTestSupport
                         CovariantEqualsCheck.MSG_KEY),
         };
 
-        final List<String> expectedXpathQueries = Collections.singletonList(
+        final List<String> expectedXpathQueries = List.of(
             "/COMPILATION_UNIT/CLASS_DEF"
                 + "[./IDENT[@text='InputXpathCovariantEqualsInClass']]"
                 + "/OBJBLOCK/METHOD_DEF/IDENT[@text='equals']"
@@ -79,7 +78,7 @@ public class XpathRegressionCovariantEqualsTest extends AbstractXpathTestSupport
                         CovariantEqualsCheck.MSG_KEY),
         };
 
-        final List<String> expectedXpathQueries = Collections.singletonList(
+        final List<String> expectedXpathQueries = List.of(
                 "/COMPILATION_UNIT/ENUM_DEF"
                 + "[./IDENT[@text='InputXpathCovariantEqualsInEnum']]"
                         + "/OBJBLOCK/METHOD_DEF/IDENT[@text='equals']");
@@ -102,7 +101,7 @@ public class XpathRegressionCovariantEqualsTest extends AbstractXpathTestSupport
                         CovariantEqualsCheck.MSG_KEY),
         };
 
-        final List<String> expectedXpathQueries = Collections.singletonList(
+        final List<String> expectedXpathQueries = List.of(
                 "/COMPILATION_UNIT/RECORD_DEF"
                 + "[./IDENT[@text='InputXpathCovariantEqualsInRecord']]"
                         + "/OBJBLOCK/METHOD_DEF/IDENT[@text='equals']");

--- a/src/it/java/org/checkstyle/suppressionxpathfilter/coding/XpathRegressionDefaultComesLastTest.java
+++ b/src/it/java/org/checkstyle/suppressionxpathfilter/coding/XpathRegressionDefaultComesLastTest.java
@@ -21,7 +21,6 @@ package org.checkstyle.suppressionxpathfilter.coding;
 
 import java.io.File;
 import java.util.Arrays;
-import java.util.Collections;
 import java.util.List;
 
 import org.checkstyle.suppressionxpathfilter.AbstractXpathTestSupport;
@@ -86,7 +85,7 @@ public class XpathRegressionDefaultComesLastTest extends AbstractXpathTestSuppor
                 DefaultComesLastCheck.MSG_KEY_SKIP_IF_LAST_AND_SHARED_WITH_CASE),
         };
 
-        final List<String> expectedXpathQueries = Collections.singletonList(
+        final List<String> expectedXpathQueries = List.of(
             "/COMPILATION_UNIT/CLASS_DEF[./IDENT"
                 + "[@text='InputXpathDefaultComesLastEmptyCase']]/OBJBLOCK"
                 + "/METHOD_DEF[./IDENT[@text='test']]/SLIST/LITERAL_SWITCH/CASE_GROUP"

--- a/src/it/java/org/checkstyle/suppressionxpathfilter/coding/XpathRegressionEmptyStatementTest.java
+++ b/src/it/java/org/checkstyle/suppressionxpathfilter/coding/XpathRegressionEmptyStatementTest.java
@@ -20,7 +20,6 @@
 package org.checkstyle.suppressionxpathfilter.coding;
 
 import java.io.File;
-import java.util.Collections;
 import java.util.List;
 
 import org.checkstyle.suppressionxpathfilter.AbstractXpathTestSupport;
@@ -52,7 +51,7 @@ public class XpathRegressionEmptyStatementTest extends AbstractXpathTestSupport 
         final String[] expectedViolation = {
             "5:36: " + getCheckMessage(EmptyStatementCheck.class, EmptyStatementCheck.MSG_KEY),
         };
-        final List<String> expectedXpathQueries = Collections.singletonList(
+        final List<String> expectedXpathQueries = List.of(
                 "/COMPILATION_UNIT"
                         + "/CLASS_DEF[./IDENT[@text='InputXpathEmptyStatementLoops']]"
                         + "/OBJBLOCK/METHOD_DEF[./IDENT[@text='foo']]"
@@ -71,7 +70,7 @@ public class XpathRegressionEmptyStatementTest extends AbstractXpathTestSupport 
         final String[] expectedViolation = {
             "6:19: " + getCheckMessage(EmptyStatementCheck.class, EmptyStatementCheck.MSG_KEY),
         };
-        final List<String> expectedXpathQueries = Collections.singletonList(
+        final List<String> expectedXpathQueries = List.of(
                 "/COMPILATION_UNIT"
                         + "/CLASS_DEF[./IDENT[@text='InputXpathEmptyStatementConditionals']]"
                         + "/OBJBLOCK/METHOD_DEF[./IDENT[@text='foo']]"

--- a/src/it/java/org/checkstyle/suppressionxpathfilter/coding/XpathRegressionExplicitInitializationTest.java
+++ b/src/it/java/org/checkstyle/suppressionxpathfilter/coding/XpathRegressionExplicitInitializationTest.java
@@ -20,7 +20,6 @@
 package org.checkstyle.suppressionxpathfilter.coding;
 
 import java.io.File;
-import java.util.Collections;
 import java.util.List;
 
 import org.checkstyle.suppressionxpathfilter.AbstractXpathTestSupport;
@@ -56,7 +55,7 @@ public class XpathRegressionExplicitInitializationTest extends AbstractXpathTest
                 ExplicitInitializationCheck.MSG_KEY, "a", 0),
         };
 
-        final List<String> expectedXpathQueries = Collections.singletonList(
+        final List<String> expectedXpathQueries = List.of(
                 "/COMPILATION_UNIT/CLASS_DEF"
                         + "[./IDENT[@text='InputXpathExplicitInitializationPrimitiveType']]"
                         + "/OBJBLOCK/VARIABLE_DEF/IDENT[@text='a']"
@@ -79,7 +78,7 @@ public class XpathRegressionExplicitInitializationTest extends AbstractXpathTest
                 ExplicitInitializationCheck.MSG_KEY, "bar", "null"),
         };
 
-        final List<String> expectedXpathQueries = Collections.singletonList(
+        final List<String> expectedXpathQueries = List.of(
                 "/COMPILATION_UNIT/CLASS_DEF"
                         + "[./IDENT[@text='InputXpathExplicitInitializationObjectType']]"
                         + "/OBJBLOCK/VARIABLE_DEF/IDENT[@text='bar']"

--- a/src/it/java/org/checkstyle/suppressionxpathfilter/coding/XpathRegressionHiddenFieldTest.java
+++ b/src/it/java/org/checkstyle/suppressionxpathfilter/coding/XpathRegressionHiddenFieldTest.java
@@ -20,7 +20,6 @@
 package org.checkstyle.suppressionxpathfilter.coding;
 
 import java.io.File;
-import java.util.Collections;
 import java.util.List;
 
 import org.checkstyle.suppressionxpathfilter.AbstractXpathTestSupport;
@@ -56,7 +55,7 @@ public class XpathRegressionHiddenFieldTest extends AbstractXpathTestSupport {
                 HiddenFieldCheck.MSG_KEY, "value"),
         };
 
-        final List<String> expectedXpathQueries = Collections.singletonList(
+        final List<String> expectedXpathQueries = List.of(
             "/COMPILATION_UNIT/CLASS_DEF"
                 + "[./IDENT[@text='InputXpathHiddenFieldLambdaExpInMethodCall']]/OBJBLOCK"
                 + "/INSTANCE_INIT/SLIST/EXPR/METHOD_CALL/ELIST/LAMBDA/PARAMETERS"
@@ -80,7 +79,7 @@ public class XpathRegressionHiddenFieldTest extends AbstractXpathTestSupport {
                 HiddenFieldCheck.MSG_KEY, "other"),
         };
 
-        final List<String> expectedXpathQueries = Collections.singletonList(
+        final List<String> expectedXpathQueries = List.of(
             "/COMPILATION_UNIT/CLASS_DEF"
                 + "[./IDENT[@text='InputXpathHiddenFieldMethodParam']]/OBJBLOCK"
                 + "/METHOD_DEF[./IDENT[@text='method']]/PARAMETERS/PARAMETER_DEF"

--- a/src/it/java/org/checkstyle/suppressionxpathfilter/coding/XpathRegressionIllegalCatchTest.java
+++ b/src/it/java/org/checkstyle/suppressionxpathfilter/coding/XpathRegressionIllegalCatchTest.java
@@ -20,7 +20,6 @@
 package org.checkstyle.suppressionxpathfilter.coding;
 
 import java.io.File;
-import java.util.Collections;
 import java.util.List;
 
 import org.checkstyle.suppressionxpathfilter.AbstractXpathTestSupport;
@@ -56,7 +55,7 @@ public class XpathRegressionIllegalCatchTest extends AbstractXpathTestSupport {
                 IllegalCatchCheck.MSG_KEY, "RuntimeException"),
         };
 
-        final List<String> expectedXpathQueries = Collections.singletonList(
+        final List<String> expectedXpathQueries = List.of(
             "/COMPILATION_UNIT/CLASS_DEF"
                 + "[./IDENT[@text='InputXpathIllegalCatchOne']]/OBJBLOCK"
                 + "/METHOD_DEF[./IDENT[@text='fun']]/SLIST"
@@ -80,7 +79,7 @@ public class XpathRegressionIllegalCatchTest extends AbstractXpathTestSupport {
                 IllegalCatchCheck.MSG_KEY, "java.lang.RuntimeException"),
         };
 
-        final List<String> expectedXpathQueries = Collections.singletonList(
+        final List<String> expectedXpathQueries = List.of(
             "/COMPILATION_UNIT/CLASS_DEF"
                 + "[./IDENT[@text='InputXpathIllegalCatchTwo']]/OBJBLOCK"
                 + "/METHOD_DEF[./IDENT[@text='methodTwo']]/SLIST"

--- a/src/it/java/org/checkstyle/suppressionxpathfilter/coding/XpathRegressionIllegalThrowsTest.java
+++ b/src/it/java/org/checkstyle/suppressionxpathfilter/coding/XpathRegressionIllegalThrowsTest.java
@@ -20,7 +20,6 @@
 package org.checkstyle.suppressionxpathfilter.coding;
 
 import java.io.File;
-import java.util.Collections;
 import java.util.List;
 
 import org.checkstyle.suppressionxpathfilter.AbstractXpathTestSupport;
@@ -56,7 +55,7 @@ public class XpathRegressionIllegalThrowsTest extends AbstractXpathTestSupport {
                 IllegalThrowsCheck.MSG_KEY, "RuntimeException"),
         };
 
-        final List<String> expectedXpathQueries = Collections.singletonList(
+        final List<String> expectedXpathQueries = List.of(
             "/COMPILATION_UNIT/CLASS_DEF"
                 + "[./IDENT[@text='InputXpathIllegalThrowsRuntimeException']]/OBJBLOCK"
                 + "/METHOD_DEF[./IDENT[@text='sayHello']]/LITERAL_THROWS"
@@ -80,7 +79,7 @@ public class XpathRegressionIllegalThrowsTest extends AbstractXpathTestSupport {
                 IllegalThrowsCheck.MSG_KEY, "java.lang.Error"),
         };
 
-        final List<String> expectedXpathQueries = Collections.singletonList(
+        final List<String> expectedXpathQueries = List.of(
             "/COMPILATION_UNIT/CLASS_DEF"
                 + "[./IDENT[@text='InputXpathIllegalThrowsError']]/OBJBLOCK"
                 + "/METHOD_DEF[./IDENT[@text='methodTwo']]/LITERAL_THROWS"

--- a/src/it/java/org/checkstyle/suppressionxpathfilter/coding/XpathRegressionIllegalTokenTest.java
+++ b/src/it/java/org/checkstyle/suppressionxpathfilter/coding/XpathRegressionIllegalTokenTest.java
@@ -20,7 +20,6 @@
 package org.checkstyle.suppressionxpathfilter.coding;
 
 import java.io.File;
-import java.util.Collections;
 import java.util.List;
 
 import org.checkstyle.suppressionxpathfilter.AbstractXpathTestSupport;
@@ -53,7 +52,7 @@ public class XpathRegressionIllegalTokenTest extends AbstractXpathTestSupport {
             "5:10: " + getCheckMessage(IllegalTokenCheck.class,
                         IllegalTokenCheck.MSG_KEY, "outer:"),
         };
-        final List<String> expectedXpathQueries = Collections.singletonList(
+        final List<String> expectedXpathQueries = List.of(
                 "/COMPILATION_UNIT"
                     + "/CLASS_DEF[./IDENT[@text='InputXpathIllegalTokenLabel']]"
                     + "/OBJBLOCK/METHOD_DEF[./IDENT[@text='myTest']]"
@@ -77,7 +76,7 @@ public class XpathRegressionIllegalTokenTest extends AbstractXpathTestSupport {
             "4:10: " + getCheckMessage(IllegalTokenCheck.class,
                         IllegalTokenCheck.MSG_KEY, "native"),
         };
-        final List<String> expectedXpathQueries = Collections.singletonList(
+        final List<String> expectedXpathQueries = List.of(
                 "/COMPILATION_UNIT"
                         + "/CLASS_DEF[./IDENT[@text='InputXpathIllegalTokenNative']]"
                         + "/OBJBLOCK/METHOD_DEF[./IDENT[@text='myTest']]"

--- a/src/it/java/org/checkstyle/suppressionxpathfilter/coding/XpathRegressionIllegalTokenTextTest.java
+++ b/src/it/java/org/checkstyle/suppressionxpathfilter/coding/XpathRegressionIllegalTokenTextTest.java
@@ -21,7 +21,6 @@ package org.checkstyle.suppressionxpathfilter.coding;
 
 import java.io.File;
 import java.util.Arrays;
-import java.util.Collections;
 import java.util.List;
 
 import org.checkstyle.suppressionxpathfilter.AbstractXpathTestSupport;
@@ -112,7 +111,7 @@ public class XpathRegressionIllegalTokenTextTest extends AbstractXpathTestSuppor
             "4:10: " + getCheckMessage(IllegalTokenTextCheck.class,
                         IllegalTokenTextCheck.MSG_KEY, "invalidIdentifier"),
         };
-        final List<String> expectedXpathQueries = Collections.singletonList(
+        final List<String> expectedXpathQueries = List.of(
                 "/COMPILATION_UNIT"
                     + "/INTERFACE_DEF[./IDENT[@text='InputXpathIllegalTokenTextInterface']]"
                     + "/OBJBLOCK/METHOD_DEF/IDENT[@text='invalidIdentifier']"

--- a/src/it/java/org/checkstyle/suppressionxpathfilter/coding/XpathRegressionIllegalTypeTest.java
+++ b/src/it/java/org/checkstyle/suppressionxpathfilter/coding/XpathRegressionIllegalTypeTest.java
@@ -20,7 +20,6 @@
 package org.checkstyle.suppressionxpathfilter.coding;
 
 import java.io.File;
-import java.util.Collections;
 import java.util.List;
 
 import org.checkstyle.suppressionxpathfilter.AbstractXpathTestSupport;
@@ -54,7 +53,7 @@ public class XpathRegressionIllegalTypeTest extends AbstractXpathTestSupport {
             "4:23: " + getCheckMessage(IllegalTypeCheck.class,
                                       IllegalTypeCheck.MSG_KEY, "java.util.HashSet"),
         };
-        final List<String> expectedXpathQueries = Collections.singletonList(
+        final List<String> expectedXpathQueries = List.of(
             "/COMPILATION_UNIT"
                 + "/CLASS_DEF[./IDENT[@text='InputXpathIllegalTypeOne']]"
                 + "/OBJBLOCK/METHOD_DEF[./IDENT[@text='typeParam']]/TYPE_PARAMETERS/TYPE_PARAMETER"
@@ -79,7 +78,7 @@ public class XpathRegressionIllegalTypeTest extends AbstractXpathTestSupport {
             "6:20: " + getCheckMessage(IllegalTypeCheck.class,
                                       IllegalTypeCheck.MSG_KEY, "Boolean"),
         };
-        final List<String> expectedXpathQueries = Collections.singletonList(
+        final List<String> expectedXpathQueries = List.of(
             "/COMPILATION_UNIT/CLASS_DEF[./IDENT[@text='InputXpathIllegalTypeTwo']"
                 + "]/OBJBLOCK/METHOD_DEF[./IDENT[@text='typeParam']]/TYPE_PARAMETERS/"
                 + "TYPE_PARAMETER[./IDENT[@text='T']]/TYPE_UPPER_BOUNDS/IDENT[@text='Boolean']"

--- a/src/it/java/org/checkstyle/suppressionxpathfilter/coding/XpathRegressionMatchXpathTest.java
+++ b/src/it/java/org/checkstyle/suppressionxpathfilter/coding/XpathRegressionMatchXpathTest.java
@@ -21,7 +21,6 @@ package org.checkstyle.suppressionxpathfilter.coding;
 
 import java.io.File;
 import java.util.Arrays;
-import java.util.Collections;
 import java.util.List;
 
 import org.checkstyle.suppressionxpathfilter.AbstractXpathTestSupport;
@@ -85,7 +84,7 @@ public class XpathRegressionMatchXpathTest extends AbstractXpathTestSupport {
             "4:25: " + getCheckMessage(MatchXpathCheck.class, MatchXpathCheck.MSG_KEY),
         };
 
-        final List<String> expectedXpathQueries = Collections.singletonList(
+        final List<String> expectedXpathQueries = List.of(
                 "/COMPILATION_UNIT/CLASS_DEF"
                         + "[./IDENT[@text='InputXpathMatchXpathTwo']]"
                         + "/OBJBLOCK/METHOD_DEF[./IDENT[@text='func1']]"
@@ -460,7 +459,7 @@ public class XpathRegressionMatchXpathTest extends AbstractXpathTestSupport {
             "5:1: " + getCheckMessage(MatchXpathCheck.class, MatchXpathCheck.MSG_KEY),
         };
 
-        final List<String> expectedXpathQueries = Collections.singletonList(
+        final List<String> expectedXpathQueries = List.of(
                 "/COMPILATION_UNIT"
                         + "/CLASS_DEF[./IDENT[@text='InputXpathMatchXpathThree']]"
                         + "/OBJBLOCK/RCURLY"

--- a/src/it/java/org/checkstyle/suppressionxpathfilter/coding/XpathRegressionMissingNullCaseInSwitchTest.java
+++ b/src/it/java/org/checkstyle/suppressionxpathfilter/coding/XpathRegressionMissingNullCaseInSwitchTest.java
@@ -21,7 +21,6 @@ package org.checkstyle.suppressionxpathfilter.coding;
 
 import java.io.File;
 import java.util.Arrays;
-import java.util.Collections;
 import java.util.List;
 
 import org.checkstyle.suppressionxpathfilter.AbstractXpathTestSupport;
@@ -56,7 +55,7 @@ public class XpathRegressionMissingNullCaseInSwitchTest
                     MissingNullCaseInSwitchCheck.MSG_KEY),
         };
 
-        final List<String> expectedXpathQueries = Collections.singletonList(
+        final List<String> expectedXpathQueries = List.of(
                 "/COMPILATION_UNIT/CLASS_DEF[./IDENT"
                         + "[@text='InputXpathMissingNullCaseInSwitchSimple']]"
                         + "/OBJBLOCK/METHOD_DEF[./IDENT[@text='test']]/SLIST/LITERAL_SWITCH"

--- a/src/it/java/org/checkstyle/suppressionxpathfilter/coding/XpathRegressionMissingSwitchDefaultTest.java
+++ b/src/it/java/org/checkstyle/suppressionxpathfilter/coding/XpathRegressionMissingSwitchDefaultTest.java
@@ -21,7 +21,6 @@ package org.checkstyle.suppressionxpathfilter.coding;
 
 import java.io.File;
 import java.util.Arrays;
-import java.util.Collections;
 import java.util.List;
 
 import org.checkstyle.suppressionxpathfilter.AbstractXpathTestSupport;
@@ -54,7 +53,7 @@ public class XpathRegressionMissingSwitchDefaultTest extends AbstractXpathTestSu
             "6:9: " + getCheckMessage(CLAZZ, MissingSwitchDefaultCheck.MSG_KEY),
         };
 
-        final List<String> expectedXpathQueries = Collections.singletonList(
+        final List<String> expectedXpathQueries = List.of(
                 "/COMPILATION_UNIT/CLASS_DEF"
                         + "[./IDENT[@text='InputXpathMissingSwitchDefaultSimple']]"
                         + "/OBJBLOCK/METHOD_DEF[./IDENT[@text='test1']]"

--- a/src/it/java/org/checkstyle/suppressionxpathfilter/coding/XpathRegressionMultipleStringLiteralsTest.java
+++ b/src/it/java/org/checkstyle/suppressionxpathfilter/coding/XpathRegressionMultipleStringLiteralsTest.java
@@ -23,7 +23,6 @@ import static com.puppycrawl.tools.checkstyle.checks.coding.MultipleStringLitera
 
 import java.io.File;
 import java.util.Arrays;
-import java.util.Collections;
 import java.util.List;
 
 import org.checkstyle.suppressionxpathfilter.AbstractXpathTestSupport;
@@ -86,7 +85,7 @@ public class XpathRegressionMultipleStringLiteralsTest extends AbstractXpathTest
                     MSG_KEY, "\", \"", 3),
         };
 
-        final List<String> expectedXpathQueries = Collections.singletonList(
+        final List<String> expectedXpathQueries = List.of(
                 "/COMPILATION_UNIT/CLASS_DEF[./IDENT"
                 + "[@text='InputXpathMultipleStringLiteralsAllowDuplicates']]"
                 + "/OBJBLOCK/METHOD_DEF[./IDENT[@text='myTest']]/SLIST/VARIABLE_DEF"
@@ -111,7 +110,7 @@ public class XpathRegressionMultipleStringLiteralsTest extends AbstractXpathTest
                     MSG_KEY, "\"DoubleString\"", 2),
         };
 
-        final List<String> expectedXpathQueries = Collections.singletonList(
+        final List<String> expectedXpathQueries = List.of(
                 "/COMPILATION_UNIT/CLASS_DEF[./IDENT"
                 + "[@text='InputXpathMultipleStringLiteralsIgnoreRegexp']]"
                 + "/OBJBLOCK/METHOD_DEF[./IDENT[@text='myTest']]/SLIST/VARIABLE_DEF"

--- a/src/it/java/org/checkstyle/suppressionxpathfilter/coding/XpathRegressionNestedForDepthTest.java
+++ b/src/it/java/org/checkstyle/suppressionxpathfilter/coding/XpathRegressionNestedForDepthTest.java
@@ -20,7 +20,6 @@
 package org.checkstyle.suppressionxpathfilter.coding;
 
 import java.io.File;
-import java.util.Collections;
 import java.util.List;
 
 import org.checkstyle.suppressionxpathfilter.AbstractXpathTestSupport;
@@ -56,7 +55,7 @@ public class XpathRegressionNestedForDepthTest extends AbstractXpathTestSupport 
                 NestedForDepthCheck.MSG_KEY, 2, 1),
         };
 
-        final List<String> expectedXpathQueries = Collections.singletonList(
+        final List<String> expectedXpathQueries = List.of(
             "/COMPILATION_UNIT/CLASS_DEF"
                 + "[./IDENT[@text='InputXpathNestedForDepth']]/OBJBLOCK"
                 + "/METHOD_DEF[./IDENT[@text='test']]/SLIST/LITERAL_FOR"
@@ -81,7 +80,7 @@ public class XpathRegressionNestedForDepthTest extends AbstractXpathTestSupport 
                 NestedForDepthCheck.MSG_KEY, 3, 2),
         };
 
-        final List<String> expectedXpathQueries = Collections.singletonList(
+        final List<String> expectedXpathQueries = List.of(
             "/COMPILATION_UNIT/CLASS_DEF"
                 + "[./IDENT[@text='InputXpathNestedForDepthMax']]"
                 + "/OBJBLOCK/METHOD_DEF[./IDENT[@text='test']]"

--- a/src/it/java/org/checkstyle/suppressionxpathfilter/coding/XpathRegressionNestedIfDepthTest.java
+++ b/src/it/java/org/checkstyle/suppressionxpathfilter/coding/XpathRegressionNestedIfDepthTest.java
@@ -20,7 +20,6 @@
 package org.checkstyle.suppressionxpathfilter.coding;
 
 import java.io.File;
-import java.util.Collections;
 import java.util.List;
 
 import org.checkstyle.suppressionxpathfilter.AbstractXpathTestSupport;
@@ -56,7 +55,7 @@ public class XpathRegressionNestedIfDepthTest extends AbstractXpathTestSupport {
                  NestedIfDepthCheck.MSG_KEY, 2, 1),
         };
 
-        final List<String> expectedXpathQueries = Collections.singletonList(
+        final List<String> expectedXpathQueries = List.of(
             "/COMPILATION_UNIT/CLASS_DEF"
                 + "[./IDENT[@text='InputXpathNestedIfDepth']]/OBJBLOCK"
                 + "/METHOD_DEF[./IDENT[@text='test']]/SLIST/LITERAL_IF"
@@ -81,7 +80,7 @@ public class XpathRegressionNestedIfDepthTest extends AbstractXpathTestSupport {
                 NestedIfDepthCheck.MSG_KEY, 4, 3),
         };
 
-        final List<String> expectedXpathQueries = Collections.singletonList(
+        final List<String> expectedXpathQueries = List.of(
             "/COMPILATION_UNIT/CLASS_DEF"
                 + "[./IDENT[@text='InputXpathNestedIfDepthMax']]"
                 + "/OBJBLOCK/METHOD_DEF[./IDENT[@text='test']]"

--- a/src/it/java/org/checkstyle/suppressionxpathfilter/coding/XpathRegressionNestedTryDepthTest.java
+++ b/src/it/java/org/checkstyle/suppressionxpathfilter/coding/XpathRegressionNestedTryDepthTest.java
@@ -20,7 +20,6 @@
 package org.checkstyle.suppressionxpathfilter.coding;
 
 import java.io.File;
-import java.util.Collections;
 import java.util.List;
 
 import org.checkstyle.suppressionxpathfilter.AbstractXpathTestSupport;
@@ -56,7 +55,7 @@ public class XpathRegressionNestedTryDepthTest extends AbstractXpathTestSupport 
                 NestedTryDepthCheck.MSG_KEY, 2, 1),
         };
 
-        final List<String> expectedXpathQueries = Collections.singletonList(
+        final List<String> expectedXpathQueries = List.of(
             "/COMPILATION_UNIT/CLASS_DEF"
                 + "[./IDENT[@text='InputXpathNestedTryDepth']]/OBJBLOCK"
                 + "/METHOD_DEF[./IDENT[@text='test']]/SLIST/LITERAL_TRY/SLIST"
@@ -81,7 +80,7 @@ public class XpathRegressionNestedTryDepthTest extends AbstractXpathTestSupport 
                 NestedTryDepthCheck.MSG_KEY, 4, 3),
         };
 
-        final List<String> expectedXpathQueries = Collections.singletonList(
+        final List<String> expectedXpathQueries = List.of(
             "/COMPILATION_UNIT/CLASS_DEF"
                 + "[./IDENT[@text='InputXpathNestedTryDepthMax']]"
                 + "/OBJBLOCK/METHOD_DEF[./IDENT[@text='test']]"

--- a/src/it/java/org/checkstyle/suppressionxpathfilter/coding/XpathRegressionNoArrayTrailingCommaTest.java
+++ b/src/it/java/org/checkstyle/suppressionxpathfilter/coding/XpathRegressionNoArrayTrailingCommaTest.java
@@ -20,7 +20,6 @@
 package org.checkstyle.suppressionxpathfilter.coding;
 
 import java.io.File;
-import java.util.Collections;
 import java.util.List;
 
 import org.checkstyle.suppressionxpathfilter.AbstractXpathTestSupport;
@@ -56,7 +55,7 @@ public class XpathRegressionNoArrayTrailingCommaTest extends AbstractXpathTestSu
                 NoArrayTrailingCommaCheck.MSG_KEY),
         };
 
-        final List<String> expectedXpathQueries = Collections.singletonList(
+        final List<String> expectedXpathQueries = List.of(
             "/COMPILATION_UNIT/CLASS_DEF[./IDENT"
                     + "[@text='InputXpathNoArrayTrailingCommaOne']]"
                     + "/OBJBLOCK/VARIABLE_DEF[./IDENT[@text='t1']]/ASSIGN/EXPR"
@@ -80,7 +79,7 @@ public class XpathRegressionNoArrayTrailingCommaTest extends AbstractXpathTestSu
                 NoArrayTrailingCommaCheck.MSG_KEY),
         };
 
-        final List<String> expectedXpathQueries = Collections.singletonList(
+        final List<String> expectedXpathQueries = List.of(
             "/COMPILATION_UNIT/CLASS_DEF"
                     + "[./IDENT[@text='InputXpathNoArrayTrailingCommaTwo']]"
                     + "/OBJBLOCK/VARIABLE_DEF[./IDENT[@text='t4']]"

--- a/src/it/java/org/checkstyle/suppressionxpathfilter/coding/XpathRegressionNoEnumTrailingCommaTest.java
+++ b/src/it/java/org/checkstyle/suppressionxpathfilter/coding/XpathRegressionNoEnumTrailingCommaTest.java
@@ -20,7 +20,6 @@
 package org.checkstyle.suppressionxpathfilter.coding;
 
 import java.io.File;
-import java.util.Collections;
 import java.util.List;
 
 import org.checkstyle.suppressionxpathfilter.AbstractXpathTestSupport;
@@ -56,7 +55,7 @@ public class XpathRegressionNoEnumTrailingCommaTest extends AbstractXpathTestSup
                     NoEnumTrailingCommaCheck.MSG_KEY),
         };
 
-        final List<String> expectedXpathQueries = Collections.singletonList(
+        final List<String> expectedXpathQueries = List.of(
             "/COMPILATION_UNIT/CLASS_DEF"
                     + "[./IDENT[@text='InputXpathNoEnumTrailingCommaOne']]"
                     + "/OBJBLOCK/ENUM_DEF[./IDENT[@text='Foo3']]/OBJBLOCK/COMMA[2]"
@@ -78,7 +77,7 @@ public class XpathRegressionNoEnumTrailingCommaTest extends AbstractXpathTestSup
                     NoEnumTrailingCommaCheck.MSG_KEY),
         };
 
-        final List<String> expectedXpathQueries = Collections.singletonList(
+        final List<String> expectedXpathQueries = List.of(
             "/COMPILATION_UNIT/CLASS_DEF"
                     + "[./IDENT[@text='InputXpathNoEnumTrailingCommaTwo']]"
                     + "/OBJBLOCK/ENUM_DEF[./IDENT[@text='Foo6']]/OBJBLOCK/COMMA[2]"

--- a/src/it/java/org/checkstyle/suppressionxpathfilter/coding/XpathRegressionOneStatementPerLineTest.java
+++ b/src/it/java/org/checkstyle/suppressionxpathfilter/coding/XpathRegressionOneStatementPerLineTest.java
@@ -20,7 +20,6 @@
 package org.checkstyle.suppressionxpathfilter.coding;
 
 import java.io.File;
-import java.util.Collections;
 import java.util.List;
 
 import org.checkstyle.suppressionxpathfilter.AbstractXpathTestSupport;
@@ -56,7 +55,7 @@ public class XpathRegressionOneStatementPerLineTest extends AbstractXpathTestSup
                 OneStatementPerLineCheck.MSG_KEY),
         };
 
-        final List<String> expectedXpathQueries = Collections.singletonList(
+        final List<String> expectedXpathQueries = List.of(
             "/COMPILATION_UNIT/CLASS_DEF"
                 + "[./IDENT[@text='InputXpathOneStatementPerLineClassFields']]/OBJBLOCK"
                 + "/VARIABLE_DEF[./IDENT[@text='j']]/SEMI"
@@ -79,7 +78,7 @@ public class XpathRegressionOneStatementPerLineTest extends AbstractXpathTestSup
                 OneStatementPerLineCheck.MSG_KEY),
         };
 
-        final List<String> expectedXpathQueries = Collections.singletonList(
+        final List<String> expectedXpathQueries = List.of(
             "/COMPILATION_UNIT/CLASS_DEF"
                 + "[./IDENT[@text='InputXpathOneStatementPerLineForLoopBlock']]/OBJBLOCK"
                 + "/METHOD_DEF[./IDENT[@text='foo5']]/SLIST/LITERAL_FOR/SLIST/SEMI[2]"

--- a/src/it/java/org/checkstyle/suppressionxpathfilter/coding/XpathRegressionRequireThisTest.java
+++ b/src/it/java/org/checkstyle/suppressionxpathfilter/coding/XpathRegressionRequireThisTest.java
@@ -20,7 +20,6 @@
 package org.checkstyle.suppressionxpathfilter.coding;
 
 import java.io.File;
-import java.util.Collections;
 import java.util.List;
 
 import org.checkstyle.suppressionxpathfilter.AbstractXpathTestSupport;
@@ -57,7 +56,7 @@ public class XpathRegressionRequireThisTest extends AbstractXpathTestSupport {
                 RequireThisCheck.MSG_VARIABLE, "age", ""),
         };
 
-        final List<String> expectedXpathQueries = Collections.singletonList(
+        final List<String> expectedXpathQueries = List.of(
             "/COMPILATION_UNIT/CLASS_DEF"
                 + "[./IDENT[@text='InputXpathRequireThisOne']]/OBJBLOCK"
                 + "/METHOD_DEF[./IDENT[@text='changeAge']]/SLIST/EXPR/ASSIGN"
@@ -82,7 +81,7 @@ public class XpathRegressionRequireThisTest extends AbstractXpathTestSupport {
                 RequireThisCheck.MSG_METHOD, "method1", ""),
         };
 
-        final List<String> expectedXpathQueries = Collections.singletonList(
+        final List<String> expectedXpathQueries = List.of(
             "/COMPILATION_UNIT/CLASS_DEF"
                 + "[./IDENT[@text='InputXpathRequireThisTwo']]/OBJBLOCK"
                 + "/METHOD_DEF[./IDENT[@text='method2']]/SLIST/EXPR"

--- a/src/it/java/org/checkstyle/suppressionxpathfilter/coding/XpathRegressionSimplifyBooleanExpressionTest.java
+++ b/src/it/java/org/checkstyle/suppressionxpathfilter/coding/XpathRegressionSimplifyBooleanExpressionTest.java
@@ -23,7 +23,6 @@ import static com.puppycrawl.tools.checkstyle.checks.coding.SimplifyBooleanExpre
 
 import java.io.File;
 import java.util.Arrays;
-import java.util.Collections;
 import java.util.List;
 
 import org.checkstyle.suppressionxpathfilter.AbstractXpathTestSupport;
@@ -108,7 +107,7 @@ public class XpathRegressionSimplifyBooleanExpressionTest extends AbstractXpathT
             "7:20: " + getCheckMessage(SimplifyBooleanExpressionCheck.class, MSG_KEY),
         };
 
-        final List<String> expectedXpathQuery = Collections.singletonList(
+        final List<String> expectedXpathQuery = List.of(
                 "/COMPILATION_UNIT/CLASS_DEF[./IDENT"
                 + "[@text='InputXpathSimplifyBooleanExpressionInterface']]"
                 + "/OBJBLOCK/INTERFACE_DEF[./IDENT[@text='Inner']]/OBJBLOCK/METHOD_DEF[./IDENT"

--- a/src/it/java/org/checkstyle/suppressionxpathfilter/coding/XpathRegressionSimplifyBooleanReturnTest.java
+++ b/src/it/java/org/checkstyle/suppressionxpathfilter/coding/XpathRegressionSimplifyBooleanReturnTest.java
@@ -22,7 +22,6 @@ package org.checkstyle.suppressionxpathfilter.coding;
 import static com.puppycrawl.tools.checkstyle.checks.coding.SimplifyBooleanReturnCheck.MSG_KEY;
 
 import java.io.File;
-import java.util.Collections;
 import java.util.List;
 
 import org.checkstyle.suppressionxpathfilter.AbstractXpathTestSupport;
@@ -58,7 +57,7 @@ public class XpathRegressionSimplifyBooleanReturnTest extends AbstractXpathTestS
             "6:9: " + getCheckMessage(CLASS, MSG_KEY),
         };
 
-        final List<String> expectedXpathQueries = Collections.singletonList(
+        final List<String> expectedXpathQueries = List.of(
             "/COMPILATION_UNIT/CLASS_DEF[./IDENT[@text="
                 + "'InputXpathSimplifyBooleanReturnIfBooleanEqualsBoolean']]"
                 + "/OBJBLOCK/METHOD_DEF[./IDENT[@text='toTest']]/SLIST/LITERAL_IF"
@@ -81,7 +80,7 @@ public class XpathRegressionSimplifyBooleanReturnTest extends AbstractXpathTestS
             "11:13: " + getCheckMessage(CLASS, MSG_KEY),
         };
 
-        final List<String> expectedXpathQueries = Collections.singletonList(
+        final List<String> expectedXpathQueries = List.of(
             "/COMPILATION_UNIT/CLASS_DEF[./IDENT[@text="
                 + "'InputXpathSimplifyBooleanReturnIfBooleanReturnBoolean']]"
                 + "/OBJBLOCK/METHOD_DEF[./IDENT[@text='toTest']]/SLIST/EXPR/METHOD_CALL/ELIST"

--- a/src/it/java/org/checkstyle/suppressionxpathfilter/coding/XpathRegressionStringLiteralEqualityTest.java
+++ b/src/it/java/org/checkstyle/suppressionxpathfilter/coding/XpathRegressionStringLiteralEqualityTest.java
@@ -21,7 +21,6 @@ package org.checkstyle.suppressionxpathfilter.coding;
 
 import java.io.File;
 import java.util.Arrays;
-import java.util.Collections;
 import java.util.List;
 
 import org.checkstyle.suppressionxpathfilter.AbstractXpathTestSupport;
@@ -106,7 +105,7 @@ public class XpathRegressionStringLiteralEqualityTest extends AbstractXpathTestS
             "6:29: " + getCheckMessage(StringLiteralEqualityCheck.class,
                     StringLiteralEqualityCheck.MSG_KEY, "=="),
         };
-        final List<String> expectedXpathQueries = Collections.singletonList(
+        final List<String> expectedXpathQueries = List.of(
             "/COMPILATION_UNIT"
                 + "/CLASS_DEF[./IDENT[@text='InputXpathStringLiteralEqualityExp']]"
                 + "/OBJBLOCK/METHOD_DEF[./IDENT[@text='myFunction']]"

--- a/src/it/java/org/checkstyle/suppressionxpathfilter/coding/XpathRegressionSuperCloneTest.java
+++ b/src/it/java/org/checkstyle/suppressionxpathfilter/coding/XpathRegressionSuperCloneTest.java
@@ -20,7 +20,6 @@
 package org.checkstyle.suppressionxpathfilter.coding;
 
 import java.io.File;
-import java.util.Collections;
 import java.util.List;
 
 import org.checkstyle.suppressionxpathfilter.AbstractXpathTestSupport;
@@ -54,7 +53,7 @@ public class XpathRegressionSuperCloneTest extends AbstractXpathTestSupport {
             "6:23: " + getCheckMessage(SuperCloneCheck.class, AbstractSuperCheck.MSG_KEY, "clone"),
         };
 
-        final List<String> expectedXpathQueries = Collections.singletonList(
+        final List<String> expectedXpathQueries = List.of(
                 "/COMPILATION_UNIT/CLASS_DEF"
                         + "[./IDENT[@text='InputXpathSuperCloneInnerClone']]"
                         + "/OBJBLOCK/CLASS_DEF[./IDENT[@text='InnerClone']]"
@@ -77,7 +76,7 @@ public class XpathRegressionSuperCloneTest extends AbstractXpathTestSupport {
             "6:23: " + getCheckMessage(SuperCloneCheck.class, AbstractSuperCheck.MSG_KEY, "clone"),
         };
 
-        final List<String> expectedXpathQueries = Collections.singletonList(
+        final List<String> expectedXpathQueries = List.of(
                 "/COMPILATION_UNIT/CLASS_DEF"
                         + "[./IDENT[@text='InputXpathSuperCloneNoSuperClone']]"
                         + "/OBJBLOCK/CLASS_DEF[./IDENT[@text='NoSuperClone']]"
@@ -100,7 +99,7 @@ public class XpathRegressionSuperCloneTest extends AbstractXpathTestSupport {
             "4:19: " + getCheckMessage(SuperCloneCheck.class, AbstractSuperCheck.MSG_KEY, "clone"),
         };
 
-        final List<String> expectedXpathQueries = Collections.singletonList(
+        final List<String> expectedXpathQueries = List.of(
                 "/COMPILATION_UNIT/CLASS_DEF"
                         + "[./IDENT[@text='InputXpathSuperClonePlainAndSubclasses']]"
                         + "/OBJBLOCK/METHOD_DEF/IDENT[@text='clone']"

--- a/src/it/java/org/checkstyle/suppressionxpathfilter/coding/XpathRegressionSuperFinalizeTest.java
+++ b/src/it/java/org/checkstyle/suppressionxpathfilter/coding/XpathRegressionSuperFinalizeTest.java
@@ -20,7 +20,6 @@
 package org.checkstyle.suppressionxpathfilter.coding;
 
 import java.io.File;
-import java.util.Collections;
 import java.util.List;
 
 import org.checkstyle.suppressionxpathfilter.AbstractXpathTestSupport;
@@ -54,7 +53,7 @@ public class XpathRegressionSuperFinalizeTest extends AbstractXpathTestSupport {
                                         AbstractSuperCheck.MSG_KEY, "finalize"),
         };
 
-        final List<String> expectedXpathQueries = Collections.singletonList(
+        final List<String> expectedXpathQueries = List.of(
             "/COMPILATION_UNIT/CLASS_DEF"
                 + "[./IDENT[@text='InputXpathSuperFinalizeNoFinalize']]"
                 + "/OBJBLOCK/METHOD_DEF/IDENT[@text='finalize']"
@@ -73,7 +72,7 @@ public class XpathRegressionSuperFinalizeTest extends AbstractXpathTestSupport {
                                         AbstractSuperCheck.MSG_KEY, "finalize"),
         };
 
-        final List<String> expectedXpathQueries = Collections.singletonList(
+        final List<String> expectedXpathQueries = List.of(
             "/COMPILATION_UNIT/CLASS_DEF"
                 + "[./IDENT[@text='InputXpathSuperFinalizeInnerClass']]"
                 + "/OBJBLOCK/METHOD_DEF/IDENT[@text='finalize']"
@@ -92,7 +91,7 @@ public class XpathRegressionSuperFinalizeTest extends AbstractXpathTestSupport {
                                         AbstractSuperCheck.MSG_KEY, "finalize"),
         };
 
-        final List<String> expectedXpathQueries = Collections.singletonList(
+        final List<String> expectedXpathQueries = List.of(
             "/COMPILATION_UNIT/CLASS_DEF"
                 + "[./IDENT[@text='InputXpathSuperFinalizeAnonymousClass']]"
                 + "/OBJBLOCK/METHOD_DEF[./IDENT[@text='createAnonymousClass']]"

--- a/src/it/java/org/checkstyle/suppressionxpathfilter/coding/XpathRegressionUnnecessaryParenthesesTest.java
+++ b/src/it/java/org/checkstyle/suppressionxpathfilter/coding/XpathRegressionUnnecessaryParenthesesTest.java
@@ -21,7 +21,6 @@ package org.checkstyle.suppressionxpathfilter.coding;
 
 import java.io.File;
 import java.util.Arrays;
-import java.util.Collections;
 import java.util.List;
 
 import org.checkstyle.suppressionxpathfilter.AbstractXpathTestSupport;
@@ -114,7 +113,7 @@ public class XpathRegressionUnnecessaryParenthesesTest extends AbstractXpathTest
                 UnnecessaryParenthesesCheck.MSG_LAMBDA),
         };
 
-        final List<String> expectedXpathQueries = Collections.singletonList(
+        final List<String> expectedXpathQueries = List.of(
             "/COMPILATION_UNIT/CLASS_DEF"
                 + "[./IDENT[@text='InputXpathUnnecessaryParenthesesLambdas']]"
                 + "/OBJBLOCK/VARIABLE_DEF[./IDENT[@text='predicate']]"
@@ -138,7 +137,7 @@ public class XpathRegressionUnnecessaryParenthesesTest extends AbstractXpathTest
                 UnnecessaryParenthesesCheck.MSG_IDENT, "a"),
         };
 
-        final List<String> expectedXpathQueries = Collections.singletonList(
+        final List<String> expectedXpathQueries = List.of(
             "/COMPILATION_UNIT/CLASS_DEF"
                 + "[./IDENT[@text='InputXpathUnnecessaryParenthesesLocalVariables']]"
                 + "/OBJBLOCK/METHOD_DEF[./IDENT[@text='foo']]"
@@ -163,7 +162,7 @@ public class XpathRegressionUnnecessaryParenthesesTest extends AbstractXpathTest
                 UnnecessaryParenthesesCheck.MSG_STRING, "\"Checkstyle\""),
         };
 
-        final List<String> expectedXpathQueries = Collections.singletonList(
+        final List<String> expectedXpathQueries = List.of(
             "/COMPILATION_UNIT/CLASS_DEF"
                 + "[./IDENT[@text='InputXpathUnnecessaryParenthesesStringLiteral']]"
                 + "/OBJBLOCK/METHOD_DEF[./IDENT[@text='foo']]"
@@ -188,7 +187,7 @@ public class XpathRegressionUnnecessaryParenthesesTest extends AbstractXpathTest
                 UnnecessaryParenthesesCheck.MSG_LITERAL, "10"),
         };
 
-        final List<String> expectedXpathQueries = Collections.singletonList(
+        final List<String> expectedXpathQueries = List.of(
             "/COMPILATION_UNIT/CLASS_DEF"
                 + "[./IDENT[@text='InputXpathUnnecessaryParenthesesMethodDef']]"
                 + "/OBJBLOCK/METHOD_DEF[./IDENT[@text='foo']]"

--- a/src/it/java/org/checkstyle/suppressionxpathfilter/coding/XpathRegressionUnnecessarySemicolonAfterOuterTypeDeclarationTest.java
+++ b/src/it/java/org/checkstyle/suppressionxpathfilter/coding/XpathRegressionUnnecessarySemicolonAfterOuterTypeDeclarationTest.java
@@ -20,7 +20,6 @@
 package org.checkstyle.suppressionxpathfilter.coding;
 
 import java.io.File;
-import java.util.Collections;
 import java.util.List;
 
 import org.checkstyle.suppressionxpathfilter.AbstractXpathTestSupport;
@@ -57,7 +56,7 @@ public class XpathRegressionUnnecessarySemicolonAfterOuterTypeDeclarationTest
         };
 
         final List<String> expectedXpathQueries =
-                Collections.singletonList("/COMPILATION_UNIT/SEMI");
+                List.of("/COMPILATION_UNIT/SEMI");
 
         runVerifications(moduleConfig, fileToProcess, expectedViolation, expectedXpathQueries);
     }
@@ -74,7 +73,7 @@ public class XpathRegressionUnnecessarySemicolonAfterOuterTypeDeclarationTest
         };
 
         final List<String> expectedXpathQueries =
-                Collections.singletonList("/COMPILATION_UNIT/SEMI");
+                List.of("/COMPILATION_UNIT/SEMI");
 
         runVerifications(moduleConfig, fileToProcess, expectedViolation, expectedXpathQueries);
     }

--- a/src/it/java/org/checkstyle/suppressionxpathfilter/coding/XpathRegressionUnnecessarySemicolonAfterTypeMemberDeclarationTest.java
+++ b/src/it/java/org/checkstyle/suppressionxpathfilter/coding/XpathRegressionUnnecessarySemicolonAfterTypeMemberDeclarationTest.java
@@ -20,7 +20,6 @@
 package org.checkstyle.suppressionxpathfilter.coding;
 
 import java.io.File;
-import java.util.Collections;
 import java.util.List;
 
 import org.checkstyle.suppressionxpathfilter.AbstractXpathTestSupport;
@@ -56,7 +55,7 @@ public class XpathRegressionUnnecessarySemicolonAfterTypeMemberDeclarationTest
                 UnnecessarySemicolonAfterTypeMemberDeclarationCheck.MSG_SEMI),
         };
 
-        final List<String> expectedXpathQueries = Collections.singletonList(
+        final List<String> expectedXpathQueries = List.of(
             "/COMPILATION_UNIT/CLASS_DEF[./IDENT"
                 + "[@text="
                 + "'InputXpathUnnecessarySemicolonAfterTypeMemberDeclarationDefault']]"
@@ -79,7 +78,7 @@ public class XpathRegressionUnnecessarySemicolonAfterTypeMemberDeclarationTest
                 UnnecessarySemicolonAfterTypeMemberDeclarationCheck.MSG_SEMI),
         };
 
-        final List<String> expectedXpathQueries = Collections.singletonList(
+        final List<String> expectedXpathQueries = List.of(
             "/COMPILATION_UNIT/CLASS_DEF[."
                 + "/IDENT[@text='InputXpathUnnecessarySemicolonAfterTypeMember"
                     + "DeclarationTokens']]"

--- a/src/it/java/org/checkstyle/suppressionxpathfilter/coding/XpathRegressionUnnecessarySemicolonInEnumerationTest.java
+++ b/src/it/java/org/checkstyle/suppressionxpathfilter/coding/XpathRegressionUnnecessarySemicolonInEnumerationTest.java
@@ -20,7 +20,6 @@
 package org.checkstyle.suppressionxpathfilter.coding;
 
 import java.io.File;
-import java.util.Collections;
 import java.util.List;
 
 import org.checkstyle.suppressionxpathfilter.AbstractXpathTestSupport;
@@ -58,7 +57,7 @@ public class XpathRegressionUnnecessarySemicolonInEnumerationTest
                 UnnecessarySemicolonInEnumerationCheck.MSG_SEMI),
         };
 
-        final List<String> expectedXpathQueries = Collections.singletonList(
+        final List<String> expectedXpathQueries = List.of(
                 "/COMPILATION_UNIT/ENUM_DEF[./IDENT[@text='Bad']]/OBJBLOCK/SEMI"
         );
 
@@ -79,7 +78,7 @@ public class XpathRegressionUnnecessarySemicolonInEnumerationTest
                 UnnecessarySemicolonInEnumerationCheck.MSG_SEMI),
         };
 
-        final List<String> expectedXpathQueries = Collections.singletonList(
+        final List<String> expectedXpathQueries = List.of(
             "/COMPILATION_UNIT/ENUM_DEF[./IDENT[@text="
                 + "'InputXpathUnnecessarySemicolonInEnumerationAll']]"
                 + "/OBJBLOCK/SEMI"

--- a/src/it/java/org/checkstyle/suppressionxpathfilter/coding/XpathRegressionUnnecessarySemicolonInTryWithResourcesTest.java
+++ b/src/it/java/org/checkstyle/suppressionxpathfilter/coding/XpathRegressionUnnecessarySemicolonInTryWithResourcesTest.java
@@ -20,7 +20,6 @@
 package org.checkstyle.suppressionxpathfilter.coding;
 
 import java.io.File;
-import java.util.Collections;
 import java.util.List;
 
 import org.checkstyle.suppressionxpathfilter.AbstractXpathTestSupport;
@@ -56,7 +55,7 @@ public class XpathRegressionUnnecessarySemicolonInTryWithResourcesTest
             "11:76: " + getCheckMessage(UnnecessarySemicolonInTryWithResourcesCheck.class,
                 UnnecessarySemicolonInTryWithResourcesCheck.MSG_SEMI),
         };
-        final List<String> expectedXpathQueries = Collections.singletonList(
+        final List<String> expectedXpathQueries = List.of(
                 "/COMPILATION_UNIT/CLASS_DEF[./IDENT[@text="
                         + "'InputXpathUnnecessarySemicolonInTryWithResourcesDefault']]"
                         + "/OBJBLOCK/METHOD_DEF[./IDENT[@text='m']]/SLIST/LITERAL_TRY"
@@ -80,7 +79,7 @@ public class XpathRegressionUnnecessarySemicolonInTryWithResourcesTest
                 UnnecessarySemicolonInTryWithResourcesCheck.MSG_SEMI),
         };
 
-        final List<String> expectedXpathQueries = Collections.singletonList(
+        final List<String> expectedXpathQueries = List.of(
             "/COMPILATION_UNIT/CLASS_DEF[./IDENT[@text="
                     + "'InputXpathUnnecessarySemicolonInTryWithResourcesNoBrace']]"
                 + "/OBJBLOCK/METHOD_DEF[./IDENT[@text='test']]"

--- a/src/it/java/org/checkstyle/suppressionxpathfilter/design/XpathRegressionThrowsCountTest.java
+++ b/src/it/java/org/checkstyle/suppressionxpathfilter/design/XpathRegressionThrowsCountTest.java
@@ -20,7 +20,6 @@
 package org.checkstyle.suppressionxpathfilter.design;
 
 import java.io.File;
-import java.util.Collections;
 import java.util.List;
 
 import org.checkstyle.suppressionxpathfilter.AbstractXpathTestSupport;
@@ -53,7 +52,7 @@ public class XpathRegressionThrowsCountTest extends AbstractXpathTestSupport {
             "4:30: " + getCheckMessage(ThrowsCountCheck.class,
                         ThrowsCountCheck.MSG_KEY, 5, 4),
         };
-        final List<String> expectedXpathQueries = Collections.singletonList(
+        final List<String> expectedXpathQueries = List.of(
                 "/COMPILATION_UNIT"
                     + "/CLASS_DEF[./IDENT[@text='InputXpathThrowsCountDefault']]"
                     + "/OBJBLOCK/METHOD_DEF[./IDENT[@text='myFunction']]"
@@ -78,7 +77,7 @@ public class XpathRegressionThrowsCountTest extends AbstractXpathTestSupport {
             "4:30: " + getCheckMessage(ThrowsCountCheck.class,
                         ThrowsCountCheck.MSG_KEY, 3, 2),
         };
-        final List<String> expectedXpathQueries = Collections.singletonList(
+        final List<String> expectedXpathQueries = List.of(
                 "/COMPILATION_UNIT"
                     + "/INTERFACE_DEF[./IDENT[@text='InputXpathThrowsCountCustomMax']]"
                     + "/OBJBLOCK/METHOD_DEF[./IDENT[@text='myFunction']]"
@@ -103,7 +102,7 @@ public class XpathRegressionThrowsCountTest extends AbstractXpathTestSupport {
             "9:40: " + getCheckMessage(ThrowsCountCheck.class,
                         ThrowsCountCheck.MSG_KEY, 5, 4),
         };
-        final List<String> expectedXpathQueries = Collections.singletonList(
+        final List<String> expectedXpathQueries = List.of(
                 "/COMPILATION_UNIT"
                     + "/CLASS_DEF[./IDENT[@text='InputXpathThrowsCountPrivateMethods']]"
                     + "/OBJBLOCK/METHOD_DEF[./IDENT[@text='myFunc']]"

--- a/src/it/java/org/checkstyle/suppressionxpathfilter/design/XpathRegressionVisibilityModifierTest.java
+++ b/src/it/java/org/checkstyle/suppressionxpathfilter/design/XpathRegressionVisibilityModifierTest.java
@@ -22,7 +22,6 @@ package org.checkstyle.suppressionxpathfilter.design;
 import static com.puppycrawl.tools.checkstyle.checks.design.VisibilityModifierCheck.MSG_KEY;
 
 import java.io.File;
-import java.util.Collections;
 import java.util.List;
 
 import org.checkstyle.suppressionxpathfilter.AbstractXpathTestSupport;
@@ -57,7 +56,7 @@ public class XpathRegressionVisibilityModifierTest extends AbstractXpathTestSupp
             "6:9: " + getCheckMessage(VisibilityModifierCheck.class, MSG_KEY, "field"),
         };
 
-        final List<String> expectedXpathQueries = Collections.singletonList(
+        final List<String> expectedXpathQueries = List.of(
                 "/COMPILATION_UNIT/CLASS_DEF[./IDENT["
                         + "@text='InputXpathVisibilityModifierDefault']]"
                         + "/OBJBLOCK/VARIABLE_DEF/IDENT[@text='field']"
@@ -80,7 +79,7 @@ public class XpathRegressionVisibilityModifierTest extends AbstractXpathTestSupp
                     "annotatedString"),
         };
 
-        final List<String> expectedXpathQueries = Collections.singletonList(
+        final List<String> expectedXpathQueries = List.of(
                 "/COMPILATION_UNIT/CLASS_DEF[./IDENT["
                         + "@text='InputXpathVisibilityModifierAnnotation']]"
                         + "/OBJBLOCK/VARIABLE_DEF/IDENT[@text='annotatedString']"
@@ -101,7 +100,7 @@ public class XpathRegressionVisibilityModifierTest extends AbstractXpathTestSupp
             "6:23: " + getCheckMessage(VisibilityModifierCheck.class, MSG_KEY, "field1"),
         };
 
-        final List<String> expectedXpathQueries = Collections.singletonList(
+        final List<String> expectedXpathQueries = List.of(
                 "/COMPILATION_UNIT/CLASS_DEF[./IDENT["
                         + "@text='InputXpathVisibilityModifierAnonymous']]"
                         + "/OBJBLOCK/VARIABLE_DEF[./IDENT[@text='runnable']]"
@@ -124,7 +123,7 @@ public class XpathRegressionVisibilityModifierTest extends AbstractXpathTestSupp
             "7:20: " + getCheckMessage(VisibilityModifierCheck.class, MSG_KEY, "field2"),
         };
 
-        final List<String> expectedXpathQueries = Collections.singletonList(
+        final List<String> expectedXpathQueries = List.of(
                 "/COMPILATION_UNIT/CLASS_DEF[./IDENT["
                         + "@text='InputXpathVisibilityModifierInner']]"
                         + "/OBJBLOCK/CLASS_DEF[./IDENT[@text='InnerClass']]/OBJBLOCK/"

--- a/src/it/java/org/checkstyle/suppressionxpathfilter/imports/XpathRegressionAvoidStarImportTest.java
+++ b/src/it/java/org/checkstyle/suppressionxpathfilter/imports/XpathRegressionAvoidStarImportTest.java
@@ -20,7 +20,6 @@
 package org.checkstyle.suppressionxpathfilter.imports;
 
 import java.io.File;
-import java.util.Collections;
 import java.util.List;
 
 import org.checkstyle.suppressionxpathfilter.AbstractXpathTestSupport;
@@ -58,7 +57,7 @@ public class XpathRegressionAvoidStarImportTest
                 AvoidStarImportCheck.MSG_KEY, "javax.swing.WindowConstants.*"),
         };
 
-        final List<String> expectedXpathQueries = Collections.singletonList(
+        final List<String> expectedXpathQueries = List.of(
                 "/COMPILATION_UNIT/STATIC_IMPORT/DOT"
         );
 
@@ -78,7 +77,7 @@ public class XpathRegressionAvoidStarImportTest
                 AvoidStarImportCheck.MSG_KEY, "java.io.*"),
         };
 
-        final List<String> expectedXpathQueries = Collections.singletonList(
+        final List<String> expectedXpathQueries = List.of(
                 "/COMPILATION_UNIT/IMPORT/DOT"
         );
 

--- a/src/it/java/org/checkstyle/suppressionxpathfilter/imports/XpathRegressionAvoidStaticImportTest.java
+++ b/src/it/java/org/checkstyle/suppressionxpathfilter/imports/XpathRegressionAvoidStaticImportTest.java
@@ -20,7 +20,6 @@
 package org.checkstyle.suppressionxpathfilter.imports;
 
 import java.io.File;
-import java.util.Collections;
 import java.util.List;
 
 import org.checkstyle.suppressionxpathfilter.AbstractXpathTestSupport;
@@ -58,7 +57,7 @@ public class XpathRegressionAvoidStaticImportTest
                 AvoidStaticImportCheck.MSG_KEY, "javax.swing.WindowConstants.*"),
         };
 
-        final List<String> expectedXpathQueries = Collections.singletonList(
+        final List<String> expectedXpathQueries = List.of(
                 "/COMPILATION_UNIT/STATIC_IMPORT/DOT"
         );
 
@@ -78,7 +77,7 @@ public class XpathRegressionAvoidStaticImportTest
                 AvoidStaticImportCheck.MSG_KEY, "java.io.File.createTempFile"),
         };
 
-        final List<String> expectedXpathQueries = Collections.singletonList(
+        final List<String> expectedXpathQueries = List.of(
                 "/COMPILATION_UNIT/STATIC_IMPORT/DOT[./IDENT[@text='createTempFile']]"
         );
 

--- a/src/it/java/org/checkstyle/suppressionxpathfilter/imports/XpathRegressionCustomImportOrderTest.java
+++ b/src/it/java/org/checkstyle/suppressionxpathfilter/imports/XpathRegressionCustomImportOrderTest.java
@@ -20,7 +20,6 @@
 package org.checkstyle.suppressionxpathfilter.imports;
 
 import java.io.File;
-import java.util.Collections;
 import java.util.List;
 
 import org.checkstyle.suppressionxpathfilter.AbstractXpathTestSupport;
@@ -59,7 +58,7 @@ public class XpathRegressionCustomImportOrderTest extends AbstractXpathTestSuppo
                         "java.util.Arrays.sort"),
         };
 
-        final List<String> expectedXpathQueries = Collections.singletonList(
+        final List<String> expectedXpathQueries = List.of(
                 "/COMPILATION_UNIT/STATIC_IMPORT[./DOT/IDENT[@text='PI']]"
         );
 
@@ -81,7 +80,7 @@ public class XpathRegressionCustomImportOrderTest extends AbstractXpathTestSuppo
                         CustomImportOrderCheck.MSG_LINE_SEPARATOR, "java.io.File"),
         };
 
-        final List<String> expectedXpathQueries = Collections.singletonList(
+        final List<String> expectedXpathQueries = List.of(
                 "/COMPILATION_UNIT/IMPORT[./DOT/IDENT[@text='File']]"
         );
 
@@ -103,7 +102,7 @@ public class XpathRegressionCustomImportOrderTest extends AbstractXpathTestSuppo
                         CustomImportOrderCheck.MSG_SEPARATED_IN_GROUP, "java.lang.Math.PI"),
         };
 
-        final List<String> expectedXpathQueries = Collections.singletonList(
+        final List<String> expectedXpathQueries = List.of(
                 "/COMPILATION_UNIT/STATIC_IMPORT[./DOT/IDENT[@text='PI']]"
         );
 
@@ -126,7 +125,7 @@ public class XpathRegressionCustomImportOrderTest extends AbstractXpathTestSuppo
                         "com.puppycrawl.tools.checkstyle.api.DetailAST"),
         };
 
-        final List<String> expectedXpathQueries = Collections.singletonList(
+        final List<String> expectedXpathQueries = List.of(
                 "/COMPILATION_UNIT/IMPORT[./DOT/IDENT[@text='DetailAST']]"
         );
 
@@ -149,7 +148,7 @@ public class XpathRegressionCustomImportOrderTest extends AbstractXpathTestSuppo
                         "java.lang.Math.PI"),
         };
 
-        final List<String> expectedXpathQueries = Collections.singletonList(
+        final List<String> expectedXpathQueries = List.of(
                 "/COMPILATION_UNIT/STATIC_IMPORT[./DOT/IDENT[@text='PI']]"
         );
 
@@ -174,7 +173,7 @@ public class XpathRegressionCustomImportOrderTest extends AbstractXpathTestSuppo
                         "com.puppycrawl.tools.checkstyle.api.DetailAST"),
         };
 
-        final List<String> expectedXpathQueries = Collections.singletonList(
+        final List<String> expectedXpathQueries = List.of(
                 "/COMPILATION_UNIT/IMPORT[./DOT/IDENT[@text='DetailAST']]"
         );
 

--- a/src/it/java/org/checkstyle/suppressionxpathfilter/imports/XpathRegressionIllegalImportTest.java
+++ b/src/it/java/org/checkstyle/suppressionxpathfilter/imports/XpathRegressionIllegalImportTest.java
@@ -20,7 +20,6 @@
 package org.checkstyle.suppressionxpathfilter.imports;
 
 import java.io.File;
-import java.util.Collections;
 import java.util.List;
 
 import org.checkstyle.suppressionxpathfilter.AbstractXpathTestSupport;
@@ -54,7 +53,7 @@ public class XpathRegressionIllegalImportTest extends AbstractXpathTestSupport {
             "3:1: " + getCheckMessage(IllegalImportCheck.class,
                         IllegalImportCheck.MSG_KEY, "java.util.List"),
         };
-        final List<String> expectedXpathQueries = Collections.singletonList(
+        final List<String> expectedXpathQueries = List.of(
             "/COMPILATION_UNIT/IMPORT"
         );
 
@@ -75,7 +74,7 @@ public class XpathRegressionIllegalImportTest extends AbstractXpathTestSupport {
             "3:1: " + getCheckMessage(IllegalImportCheck.class,
                         IllegalImportCheck.MSG_KEY, "java.lang.Math.pow"),
         };
-        final List<String> expectedXpathQueries = Collections.singletonList(
+        final List<String> expectedXpathQueries = List.of(
             "/COMPILATION_UNIT/STATIC_IMPORT"
 
         );

--- a/src/it/java/org/checkstyle/suppressionxpathfilter/imports/XpathRegressionImportControlTest.java
+++ b/src/it/java/org/checkstyle/suppressionxpathfilter/imports/XpathRegressionImportControlTest.java
@@ -21,7 +21,6 @@ package org.checkstyle.suppressionxpathfilter.imports;
 
 import java.io.File;
 import java.util.Arrays;
-import java.util.Collections;
 import java.util.List;
 
 import org.checkstyle.suppressionxpathfilter.AbstractXpathTestSupport;
@@ -59,7 +58,7 @@ public class XpathRegressionImportControlTest extends AbstractXpathTestSupport {
                 ImportControlCheck.MSG_DISALLOWED, "java.util.Scanner"),
         };
 
-        final List<String> expectedXpathQueries = Collections.singletonList(
+        final List<String> expectedXpathQueries = List.of(
             "/COMPILATION_UNIT/IMPORT"
         );
 
@@ -126,7 +125,7 @@ public class XpathRegressionImportControlTest extends AbstractXpathTestSupport {
                 ImportControlCheck.MSG_DISALLOWED, "java.util.Scanner"),
         };
 
-        final List<String> expectedXpathQueries = Collections.singletonList(
+        final List<String> expectedXpathQueries = List.of(
             "/COMPILATION_UNIT/IMPORT[./DOT/IDENT[@text='Scanner']]"
         );
 

--- a/src/it/java/org/checkstyle/suppressionxpathfilter/imports/XpathRegressionImportOrderTest.java
+++ b/src/it/java/org/checkstyle/suppressionxpathfilter/imports/XpathRegressionImportOrderTest.java
@@ -20,7 +20,6 @@
 package org.checkstyle.suppressionxpathfilter.imports;
 
 import java.io.File;
-import java.util.Collections;
 import java.util.List;
 
 import org.checkstyle.suppressionxpathfilter.AbstractXpathTestSupport;
@@ -56,7 +55,7 @@ public class XpathRegressionImportOrderTest extends AbstractXpathTestSupport {
                         ImportOrderCheck.MSG_ORDERING, "java.util.Set"),
         };
 
-        final List<String> expectedXpathQueries = Collections.singletonList(
+        final List<String> expectedXpathQueries = List.of(
                 "/COMPILATION_UNIT/IMPORT"
         );
 
@@ -77,7 +76,7 @@ public class XpathRegressionImportOrderTest extends AbstractXpathTestSupport {
                         ImportOrderCheck.MSG_SEPARATED_IN_GROUP, "java.util.Set"),
         };
 
-        final List<String> expectedXpathQueries = Collections.singletonList(
+        final List<String> expectedXpathQueries = List.of(
                 "/COMPILATION_UNIT/IMPORT[./DOT/IDENT[@text='Set']]"
         );
 
@@ -100,7 +99,7 @@ public class XpathRegressionImportOrderTest extends AbstractXpathTestSupport {
                         ImportOrderCheck.MSG_SEPARATION, "org.junit.*"),
         };
 
-        final List<String> expectedXpathQueries = Collections.singletonList(
+        final List<String> expectedXpathQueries = List.of(
                 "/COMPILATION_UNIT/IMPORT[./DOT/DOT/IDENT[@text='org']]"
         );
 
@@ -122,7 +121,7 @@ public class XpathRegressionImportOrderTest extends AbstractXpathTestSupport {
                         ImportOrderCheck.MSG_ORDERING, "java.lang.Math.PI"),
         };
 
-        final List<String> expectedXpathQueries = Collections.singletonList(
+        final List<String> expectedXpathQueries = List.of(
                 "/COMPILATION_UNIT/STATIC_IMPORT"
         );
 
@@ -144,7 +143,7 @@ public class XpathRegressionImportOrderTest extends AbstractXpathTestSupport {
                         ImportOrderCheck.MSG_ORDERING, "java.util.Date"),
         };
 
-        final List<String> expectedXpathQueries = Collections.singletonList(
+        final List<String> expectedXpathQueries = List.of(
                 "/COMPILATION_UNIT/IMPORT[./DOT/IDENT[@text='Date']]"
         );
 

--- a/src/it/java/org/checkstyle/suppressionxpathfilter/imports/XpathRegressionRedundantImportTest.java
+++ b/src/it/java/org/checkstyle/suppressionxpathfilter/imports/XpathRegressionRedundantImportTest.java
@@ -20,7 +20,6 @@
 package org.checkstyle.suppressionxpathfilter.imports;
 
 import java.io.File;
-import java.util.Collections;
 import java.util.List;
 
 import org.checkstyle.suppressionxpathfilter.AbstractXpathTestSupport;
@@ -54,7 +53,7 @@ public class XpathRegressionRedundantImportTest extends AbstractXpathTestSupport
                         RedundantImportCheck.MSG_SAME, "org.checkstyle.suppressionxpathfilter"
                                 + ".imports.redundantimport.InputXpathRedundantImportInternal"),
         };
-        final List<String> expectedXpathQueries = Collections.singletonList(
+        final List<String> expectedXpathQueries = List.of(
                 "/COMPILATION_UNIT/IMPORT");
 
         runVerifications(moduleConfig, fileToProcess, expectedViolation,
@@ -71,7 +70,7 @@ public class XpathRegressionRedundantImportTest extends AbstractXpathTestSupport
             "3:1: " + getCheckMessage(RedundantImportCheck.class,
                         RedundantImportCheck.MSG_LANG, "java.lang.String"),
         };
-        final List<String> expectedXpathQueries = Collections.singletonList(
+        final List<String> expectedXpathQueries = List.of(
                 "/COMPILATION_UNIT/IMPORT");
 
         runVerifications(moduleConfig, fileToProcess, expectedViolation,
@@ -88,7 +87,7 @@ public class XpathRegressionRedundantImportTest extends AbstractXpathTestSupport
             "4:1: " + getCheckMessage(RedundantImportCheck.class,
                         RedundantImportCheck.MSG_DUPLICATE, 3, "java.util.Scanner"),
         };
-        final List<String> expectedXpathQueries = Collections.singletonList(
+        final List<String> expectedXpathQueries = List.of(
                 "/COMPILATION_UNIT/IMPORT[./DOT/IDENT[@text='Scanner']]");
 
         runVerifications(moduleConfig, fileToProcess, expectedViolation,

--- a/src/it/java/org/checkstyle/suppressionxpathfilter/imports/XpathRegressionUnusedImportsTest.java
+++ b/src/it/java/org/checkstyle/suppressionxpathfilter/imports/XpathRegressionUnusedImportsTest.java
@@ -20,7 +20,6 @@
 package org.checkstyle.suppressionxpathfilter.imports;
 
 import java.io.File;
-import java.util.Collections;
 import java.util.List;
 
 import org.checkstyle.suppressionxpathfilter.AbstractXpathTestSupport;
@@ -56,7 +55,7 @@ public class XpathRegressionUnusedImportsTest extends AbstractXpathTestSupport {
                     UnusedImportsCheck.MSG_KEY, "java.util.List"),
         };
 
-        final List<String> expectedXpathQueries = Collections.singletonList(
+        final List<String> expectedXpathQueries = List.of(
                 "/COMPILATION_UNIT/IMPORT/DOT[./IDENT[@text='List']]/DOT/IDENT[@text='java']");
 
         runVerifications(moduleConfig, fileToProcess, expectedViolation,
@@ -76,7 +75,7 @@ public class XpathRegressionUnusedImportsTest extends AbstractXpathTestSupport {
                     UnusedImportsCheck.MSG_KEY, "java.util.Map.Entry"),
         };
 
-        final List<String> expectedXpathQueries = Collections.singletonList(
+        final List<String> expectedXpathQueries = List.of(
                 "/COMPILATION_UNIT/STATIC_IMPORT/DOT"
                         + "[./IDENT[@text='Entry']]/DOT[./IDENT[@text='Map']]"
                         + "/DOT/IDENT[@text='java']");

--- a/src/it/java/org/checkstyle/suppressionxpathfilter/indentation/XpathRegressionCommentsIndentationTest.java
+++ b/src/it/java/org/checkstyle/suppressionxpathfilter/indentation/XpathRegressionCommentsIndentationTest.java
@@ -20,7 +20,6 @@
 package org.checkstyle.suppressionxpathfilter.indentation;
 
 import java.io.File;
-import java.util.Collections;
 import java.util.List;
 
 import org.checkstyle.suppressionxpathfilter.AbstractXpathTestSupport;
@@ -56,7 +55,7 @@ public class XpathRegressionCommentsIndentationTest extends AbstractXpathTestSup
                 "comments.indentation.single", 4, 8, 4),
         };
 
-        final List<String> expectedXpathQueries = Collections.singletonList(
+        final List<String> expectedXpathQueries = List.of(
             "/COMPILATION_UNIT/CLASS_DEF[./IDENT"
                 + "[@text='InputXpathCommentsIndentationSingleLine']]"
                 + "/OBJBLOCK/SINGLE_LINE_COMMENT[./COMMENT_CONTENT[@text=' Comment // warn\\n']]"
@@ -79,7 +78,7 @@ public class XpathRegressionCommentsIndentationTest extends AbstractXpathTestSup
                 "comments.indentation.block", 7, 10, 4),
         };
 
-        final List<String> expectedXpathQueries = Collections.singletonList(
+        final List<String> expectedXpathQueries = List.of(
             "/COMPILATION_UNIT/CLASS_DEF[./IDENT"
                 + "[@text='InputXpathCommentsIndentationBlock']]/OBJBLOCK/"
                 + "VARIABLE_DEF[./IDENT[@text='f']]/TYPE/BLOCK_COMMENT_BEGIN[./COMMENT_CONTENT"
@@ -103,7 +102,7 @@ public class XpathRegressionCommentsIndentationTest extends AbstractXpathTestSup
                 "comments.indentation.single", 10, 12, 4),
         };
 
-        final List<String> expectedXpathQueries = Collections.singletonList(
+        final List<String> expectedXpathQueries = List.of(
             "/COMPILATION_UNIT/CLASS_DEF[./IDENT"
                 + "[@text='InputXpathCommentsIndentationSeparator']]"
                 + "/OBJBLOCK/METHOD_DEF[./IDENT[@text='foo']]/MODIFIERS/SINGLE_LINE_COMMENT"
@@ -127,7 +126,7 @@ public class XpathRegressionCommentsIndentationTest extends AbstractXpathTestSup
                 "comments.indentation.single", 8, 24, 8),
         };
 
-        final List<String> expectedXpathQueries = Collections.singletonList(
+        final List<String> expectedXpathQueries = List.of(
             "/COMPILATION_UNIT/CLASS_DEF[./IDENT"
                 + "[@text='InputXpathCommentsIndentationDistributedStatement']]"
                 + "/OBJBLOCK/METHOD_DEF[./IDENT[@text='foo']]/SLIST/SINGLE_LINE_COMMENT"
@@ -151,7 +150,7 @@ public class XpathRegressionCommentsIndentationTest extends AbstractXpathTestSup
                 "comments.indentation.single", 7, 0, 4),
         };
 
-        final List<String> expectedXpathQueries = Collections.singletonList(
+        final List<String> expectedXpathQueries = List.of(
             "/COMPILATION_UNIT/CLASS_DEF[./IDENT"
                 + "[@text='InputXpathCommentsIndentationSingleLineBlock']]"
                 + "/OBJBLOCK/METHOD_DEF[./IDENT[@text='foo']]/SLIST/SINGLE_LINE_COMMENT"
@@ -175,7 +174,7 @@ public class XpathRegressionCommentsIndentationTest extends AbstractXpathTestSup
                 "comments.indentation.single", "9, 11", 19, "16, 12"),
         };
 
-        final List<String> expectedXpathQueries = Collections.singletonList(
+        final List<String> expectedXpathQueries = List.of(
             "/COMPILATION_UNIT/CLASS_DEF[./IDENT"
                 + "[@text='InputXpathCommentsIndentationNonEmptyCase']]"
                 + "/OBJBLOCK/METHOD_DEF[./IDENT[@text='foo']]/SLIST/LITERAL_SWITCH/"
@@ -199,7 +198,7 @@ public class XpathRegressionCommentsIndentationTest extends AbstractXpathTestSup
                 "comments.indentation.single", "8, 10", 0, "12, 12"),
         };
 
-        final List<String> expectedXpathQueries = Collections.singletonList(
+        final List<String> expectedXpathQueries = List.of(
             "/COMPILATION_UNIT/CLASS_DEF[./IDENT"
                 + "[@text='InputXpathCommentsIndentationEmptyCase']]"
                 + "/OBJBLOCK/METHOD_DEF[./IDENT[@text='foo']]/SLIST/LITERAL_SWITCH/"
@@ -223,7 +222,7 @@ public class XpathRegressionCommentsIndentationTest extends AbstractXpathTestSup
                 "comments.indentation.single", 7, 8, 12),
         };
 
-        final List<String> expectedXpathQueries = Collections.singletonList(
+        final List<String> expectedXpathQueries = List.of(
             "/COMPILATION_UNIT/CLASS_DEF[./IDENT"
                 + "[@text='InputXpathCommentsIndentationWithinBlockStatement']]"
                 + "/OBJBLOCK/METHOD_DEF[./IDENT[@text='foo']]/SLIST/VARIABLE_DEF"

--- a/src/it/java/org/checkstyle/suppressionxpathfilter/indentation/XpathRegressionIndentationTest.java
+++ b/src/it/java/org/checkstyle/suppressionxpathfilter/indentation/XpathRegressionIndentationTest.java
@@ -21,7 +21,6 @@ package org.checkstyle.suppressionxpathfilter.indentation;
 
 import java.io.File;
 import java.util.Arrays;
-import java.util.Collections;
 import java.util.List;
 
 import org.checkstyle.suppressionxpathfilter.AbstractXpathTestSupport;
@@ -179,7 +178,7 @@ public class XpathRegressionIndentationTest extends AbstractXpathTestSupport {
                     IndentationCheck.MSG_ERROR, "(", 8, 12),
         };
 
-        final List<String> expectedXpathQueries = Collections.singletonList(
+        final List<String> expectedXpathQueries = List.of(
             "/COMPILATION_UNIT/CLASS_DEF"
                     + "[./IDENT[@text='InputXpathIndentationLambdaOne"
                     + "']]/OBJBLOCK/METHOD_DEF[./IDENT[@text='test']]/SLIST/VARIABLE_DEF"
@@ -211,7 +210,7 @@ public class XpathRegressionIndentationTest extends AbstractXpathTestSupport {
                     IndentationCheck.MSG_CHILD_ERROR_MULTI, "block", 14, "12, 16"),
         };
 
-        final List<String> expectedXpathQueries = Collections.singletonList(
+        final List<String> expectedXpathQueries = List.of(
             "/COMPILATION_UNIT/CLASS_DEF"
                     + "[./IDENT[@text='InputXpathIndentationLambdaTwo']]"
                     + "/OBJBLOCK/METHOD_DEF[./IDENT[@text='test']]/SLIST/VARIABLE_DEF["
@@ -244,7 +243,7 @@ public class XpathRegressionIndentationTest extends AbstractXpathTestSupport {
                 IndentationCheck.MSG_CHILD_ERROR, "if", 8, 12),
         };
 
-        final List<String> expectedXpathQueries = Collections.singletonList(
+        final List<String> expectedXpathQueries = List.of(
             "/COMPILATION_UNIT/CLASS_DEF"
                     + "[./IDENT[@text='InputXpathIndentationIfWithoutCurly']]"
                     + "/OBJBLOCK/METHOD_DEF[./IDENT[@text='test']]/SLIST/LITERAL_IF/EXPR/"
@@ -277,7 +276,7 @@ public class XpathRegressionIndentationTest extends AbstractXpathTestSupport {
                 IndentationCheck.MSG_CHILD_ERROR, "else", 8, 12),
         };
 
-        final List<String> expectedXpathQueries = Collections.singletonList(
+        final List<String> expectedXpathQueries = List.of(
             "/COMPILATION_UNIT/CLASS_DEF"
                     + "[./IDENT[@text='InputXpathIndentationElseWithoutCurly']]"
                     + "/OBJBLOCK/METHOD_DEF[./IDENT[@text='test']]/SLIST/LITERAL_IF/LITERAL_ELSE"

--- a/src/it/java/org/checkstyle/suppressionxpathfilter/javadoc/XpathRegressionInvalidJavadocPositionTest.java
+++ b/src/it/java/org/checkstyle/suppressionxpathfilter/javadoc/XpathRegressionInvalidJavadocPositionTest.java
@@ -20,7 +20,6 @@
 package org.checkstyle.suppressionxpathfilter.javadoc;
 
 import java.io.File;
-import java.util.Collections;
 import java.util.List;
 
 import org.checkstyle.suppressionxpathfilter.AbstractXpathTestSupport;
@@ -56,7 +55,7 @@ public class XpathRegressionInvalidJavadocPositionTest extends AbstractXpathTest
                 InvalidJavadocPositionCheck.MSG_KEY),
         };
 
-        final List<String> expectedXpathQueries = Collections.singletonList(
+        final List<String> expectedXpathQueries = List.of(
             "/COMPILATION_UNIT/CLASS_DEF"
                     + "[./IDENT[@text='InputXpathInvalidJavadocPositionOne']]"
                     + "/MODIFIERS/BLOCK_COMMENT_BEGIN[./COMMENT_CONTENT"
@@ -80,7 +79,7 @@ public class XpathRegressionInvalidJavadocPositionTest extends AbstractXpathTest
                 InvalidJavadocPositionCheck.MSG_KEY),
         };
 
-        final List<String> expectedXpathQueries = Collections.singletonList(
+        final List<String> expectedXpathQueries = List.of(
             "/COMPILATION_UNIT/CLASS_DEF[./IDENT"
                     + "[@text='InputXpathInvalidJavadocPositionTwo']]"
                     + "/OBJBLOCK/BLOCK_COMMENT_BEGIN[./COMMENT_CONTENT"
@@ -104,7 +103,7 @@ public class XpathRegressionInvalidJavadocPositionTest extends AbstractXpathTest
                 InvalidJavadocPositionCheck.MSG_KEY),
         };
 
-        final List<String> expectedXpathQueries = Collections.singletonList(
+        final List<String> expectedXpathQueries = List.of(
             "/COMPILATION_UNIT/CLASS_DEF"
                     + "[./IDENT[@text='InputXpathInvalidJavadocPositionThree']]/"
                     + "OBJBLOCK/BLOCK_COMMENT_BEGIN[./COMMENT_CONTENT"
@@ -128,7 +127,7 @@ public class XpathRegressionInvalidJavadocPositionTest extends AbstractXpathTest
                 InvalidJavadocPositionCheck.MSG_KEY),
         };
 
-        final List<String> expectedXpathQueries = Collections.singletonList(
+        final List<String> expectedXpathQueries = List.of(
             "/COMPILATION_UNIT/CLASS_DEF"
                 + "[./IDENT[@text='InputXpathInvalidJavadocPositionFour']]"
                 + "/OBJBLOCK/BLOCK_COMMENT_BEGIN[./COMMENT_CONTENT"
@@ -152,7 +151,7 @@ public class XpathRegressionInvalidJavadocPositionTest extends AbstractXpathTest
                 InvalidJavadocPositionCheck.MSG_KEY),
         };
 
-        final List<String> expectedXpathQueries = Collections.singletonList(
+        final List<String> expectedXpathQueries = List.of(
             "/COMPILATION_UNIT/CLASS_DEF"
                 + "[./IDENT[@text='InputXpathInvalidJavadocPositionFive']]"
                 + "/OBJBLOCK/METHOD_DEF[./IDENT[@text='foo']]"
@@ -177,7 +176,7 @@ public class XpathRegressionInvalidJavadocPositionTest extends AbstractXpathTest
                 InvalidJavadocPositionCheck.MSG_KEY),
         };
 
-        final List<String> expectedXpathQueries = Collections.singletonList(
+        final List<String> expectedXpathQueries = List.of(
             "/COMPILATION_UNIT/CLASS_DEF"
                 + "[./IDENT[@text='InputXpathInvalidJavadocPositionSix']]"
                 + "/OBJBLOCK/BLOCK_COMMENT_BEGIN[./COMMENT_CONTENT"

--- a/src/it/java/org/checkstyle/suppressionxpathfilter/javadoc/XpathRegressionJavadocContentLocationTest.java
+++ b/src/it/java/org/checkstyle/suppressionxpathfilter/javadoc/XpathRegressionJavadocContentLocationTest.java
@@ -20,7 +20,6 @@
 package org.checkstyle.suppressionxpathfilter.javadoc;
 
 import java.io.File;
-import java.util.Collections;
 import java.util.List;
 
 import org.checkstyle.suppressionxpathfilter.AbstractXpathTestSupport;
@@ -56,7 +55,7 @@ public class XpathRegressionJavadocContentLocationTest extends AbstractXpathTest
                     JavadocContentLocationCheck.MSG_JAVADOC_CONTENT_SECOND_LINE),
         };
 
-        final List<String> expectedXpathQueries = Collections.singletonList(
+        final List<String> expectedXpathQueries = List.of(
             "/COMPILATION_UNIT/INTERFACE_DEF"
                 + "[./IDENT[@text='InputXpathJavadocContentLocationOne']]"
                 + "/OBJBLOCK/METHOD_DEF[./IDENT[@text='test']]/TYPE/BLOCK_COMMENT_BEGIN"
@@ -82,7 +81,7 @@ public class XpathRegressionJavadocContentLocationTest extends AbstractXpathTest
                     JavadocContentLocationCheck.MSG_JAVADOC_CONTENT_FIRST_LINE),
         };
 
-        final List<String> expectedXpathQueries = Collections.singletonList(
+        final List<String> expectedXpathQueries = List.of(
             "/COMPILATION_UNIT/INTERFACE_DEF[./IDENT"
                     + "[@text='InputXpathJavadocContentLocationTwo']]"
                     + "/OBJBLOCK/METHOD_DEF[./IDENT[@text='test']]/TYPE/BLOCK_COMMENT_BEGIN"

--- a/src/it/java/org/checkstyle/suppressionxpathfilter/javadoc/XpathRegressionJavadocMethodTest.java
+++ b/src/it/java/org/checkstyle/suppressionxpathfilter/javadoc/XpathRegressionJavadocMethodTest.java
@@ -24,7 +24,6 @@ import static com.puppycrawl.tools.checkstyle.checks.javadoc.JavadocMethodCheck.
 
 import java.io.File;
 import java.util.Arrays;
-import java.util.Collections;
 import java.util.List;
 
 import org.checkstyle.suppressionxpathfilter.AbstractXpathTestSupport;
@@ -88,7 +87,7 @@ public class XpathRegressionJavadocMethodTest extends AbstractXpathTestSupport {
                     "@param", "x"),
         };
 
-        final List<String> expectedXpathQueries = Collections.singletonList(
+        final List<String> expectedXpathQueries = List.of(
                 "/COMPILATION_UNIT/CLASS_DEF"
                         + "[./IDENT[@text='InputXpathJavadocMethodTwo']]"
                         + "/OBJBLOCK/METHOD_DEF[./IDENT[@text='checkParam']]/PARAMETERS"
@@ -140,7 +139,7 @@ public class XpathRegressionJavadocMethodTest extends AbstractXpathTestSupport {
                     "@throws", "Exception"),
         };
 
-        final List<String> expectedXpathQueries = Collections.singletonList(
+        final List<String> expectedXpathQueries = List.of(
                 "/COMPILATION_UNIT/CLASS_DEF"
                         + "[./IDENT[@text='InputXpathJavadocMethodFour']]"
                         + "/OBJBLOCK/METHOD_DEF[./IDENT[@text='foo']]"
@@ -165,7 +164,7 @@ public class XpathRegressionJavadocMethodTest extends AbstractXpathTestSupport {
                     "@throws", "org.apache.tools.ant.BuildException"),
         };
 
-        final List<String> expectedXpathQueries = Collections.singletonList(
+        final List<String> expectedXpathQueries = List.of(
                 "/COMPILATION_UNIT/CLASS_DEF"
                         + "[./IDENT[@text='InputXpathJavadocMethodFive']]"
                         + "/OBJBLOCK/METHOD_DEF[./IDENT[@text='bar']]/SLIST"

--- a/src/it/java/org/checkstyle/suppressionxpathfilter/metrics/XpathRegressionBooleanExpressionComplexityTest.java
+++ b/src/it/java/org/checkstyle/suppressionxpathfilter/metrics/XpathRegressionBooleanExpressionComplexityTest.java
@@ -20,7 +20,6 @@
 package org.checkstyle.suppressionxpathfilter.metrics;
 
 import java.io.File;
-import java.util.Collections;
 import java.util.List;
 
 import org.checkstyle.suppressionxpathfilter.AbstractXpathTestSupport;
@@ -55,7 +54,7 @@ public class XpathRegressionBooleanExpressionComplexityTest
                     BooleanExpressionComplexityCheck.MSG_KEY, 11, 3),
         };
 
-        final List<String> expectedXpathQueries = Collections.singletonList(
+        final List<String> expectedXpathQueries = List.of(
                 "/COMPILATION_UNIT/CLASS_DEF[./IDENT"
                         + "[@text='InputXpathBooleanExpressionComplexityCatchBlock']]"
                         + "/OBJBLOCK/METHOD_DEF[./IDENT[@text='methodOne']]/SLIST"
@@ -80,7 +79,7 @@ public class XpathRegressionBooleanExpressionComplexityTest
                     BooleanExpressionComplexityCheck.MSG_KEY, 11, 3),
         };
 
-        final List<String> expectedXpathQueries = Collections.singletonList(
+        final List<String> expectedXpathQueries = List.of(
                 "/COMPILATION_UNIT/CLASS_DEF[./IDENT["
                         + "@text='InputXpathBooleanExpressionComplexityClassFields']]"
                         + "/OBJBLOCK/METHOD_DEF[./IDENT[@text='methodTwo']]/SLIST/VARIABLE_DEF"
@@ -104,7 +103,7 @@ public class XpathRegressionBooleanExpressionComplexityTest
                     BooleanExpressionComplexityCheck.MSG_KEY, 4, 3),
         };
 
-        final List<String> expectedXpathQueries = Collections.singletonList(
+        final List<String> expectedXpathQueries = List.of(
                 "/COMPILATION_UNIT/CLASS_DEF[./IDENT["
                         + "@text='InputXpathBooleanExpressionComplexityConditionals']]"
                         + "/OBJBLOCK/METHOD_DEF[./IDENT[@text='methodThree']]/SLIST/LITERAL_IF"

--- a/src/it/java/org/checkstyle/suppressionxpathfilter/metrics/XpathRegressionNPathComplexityTest.java
+++ b/src/it/java/org/checkstyle/suppressionxpathfilter/metrics/XpathRegressionNPathComplexityTest.java
@@ -21,7 +21,6 @@ package org.checkstyle.suppressionxpathfilter.metrics;
 
 import java.io.File;
 import java.util.Arrays;
-import java.util.Collections;
 import java.util.List;
 
 import org.checkstyle.suppressionxpathfilter.AbstractXpathTestSupport;
@@ -89,7 +88,7 @@ public class XpathRegressionNPathComplexityTest extends AbstractXpathTestSupport
                 NPathComplexityCheck.MSG_KEY, 3, 0),
         };
 
-        final List<String> expectedXpathQueries = Collections.singletonList(
+        final List<String> expectedXpathQueries = List.of(
             "/COMPILATION_UNIT/CLASS_DEF"
                 + "[./IDENT[@text='InputXpathNPathComplexityStaticBlock']]"
                 + "/OBJBLOCK/STATIC_INIT"

--- a/src/it/java/org/checkstyle/suppressionxpathfilter/modifier/XpathRegressionModifierOrderTest.java
+++ b/src/it/java/org/checkstyle/suppressionxpathfilter/modifier/XpathRegressionModifierOrderTest.java
@@ -21,7 +21,6 @@ package org.checkstyle.suppressionxpathfilter.modifier;
 
 import java.io.File;
 import java.util.Arrays;
-import java.util.Collections;
 import java.util.List;
 
 import org.checkstyle.suppressionxpathfilter.AbstractXpathTestSupport;
@@ -81,7 +80,7 @@ public class XpathRegressionModifierOrderTest extends AbstractXpathTestSupport {
                     ModifierOrderCheck.MSG_MODIFIER_ORDER, "private"),
         };
 
-        final List<String> expectedXpathQueries = Collections.singletonList(
+        final List<String> expectedXpathQueries = List.of(
                 "/COMPILATION_UNIT/CLASS_DEF[./IDENT"
                         + "[@text='InputXpathModifierOrderVariable']]"
                         + "/OBJBLOCK/VARIABLE_DEF[./IDENT[@text='var']]/MODIFIERS/LITERAL_PRIVATE");

--- a/src/it/java/org/checkstyle/suppressionxpathfilter/naming/XpathRegressionAbbreviationAsWordInNameTest.java
+++ b/src/it/java/org/checkstyle/suppressionxpathfilter/naming/XpathRegressionAbbreviationAsWordInNameTest.java
@@ -20,7 +20,6 @@
 package org.checkstyle.suppressionxpathfilter.naming;
 
 import java.io.File;
-import java.util.Collections;
 import java.util.List;
 
 import org.checkstyle.suppressionxpathfilter.AbstractXpathTestSupport;
@@ -56,7 +55,7 @@ public class XpathRegressionAbbreviationAsWordInNameTest extends AbstractXpathTe
                 AbbreviationAsWordInNameCheck.MSG_KEY, "ANNOTATION", 4),
         };
 
-        final List<String> expectedXpathQueries = Collections.singletonList(
+        final List<String> expectedXpathQueries = List.of(
                 "/COMPILATION_UNIT/CLASS_DEF[./IDENT["
                     + "@text='InputXpathAbbreviationAsWordInNameAnnotation']]"
                     + "/OBJBLOCK/ANNOTATION_DEF/IDENT[@text='ANNOTATION']"
@@ -79,7 +78,7 @@ public class XpathRegressionAbbreviationAsWordInNameTest extends AbstractXpathTe
                 AbbreviationAsWordInNameCheck.MSG_KEY, "ANNOTATION_FIELD", 4),
         };
 
-        final List<String> expectedXpathQueries = Collections.singletonList(
+        final List<String> expectedXpathQueries = List.of(
                 "/COMPILATION_UNIT/ANNOTATION_DEF[./IDENT["
                     + "@text='InputXpathAbbreviationAsWordInNameAnnotationField']]"
                     + "/OBJBLOCK/ANNOTATION_FIELD_DEF/IDENT[@text='ANNOTATION_FIELD']"
@@ -102,7 +101,7 @@ public class XpathRegressionAbbreviationAsWordInNameTest extends AbstractXpathTe
                 AbbreviationAsWordInNameCheck.MSG_KEY, "CLASS", 4),
         };
 
-        final List<String> expectedXpathQueries = Collections.singletonList(
+        final List<String> expectedXpathQueries = List.of(
                 "/COMPILATION_UNIT/CLASS_DEF[./IDENT["
                     + "@text='InputXpathAbbreviationAsWordInNameClass']]"
                     + "/OBJBLOCK/CLASS_DEF/IDENT[@text='CLASS']"
@@ -125,7 +124,7 @@ public class XpathRegressionAbbreviationAsWordInNameTest extends AbstractXpathTe
                 AbbreviationAsWordInNameCheck.MSG_KEY, "ENUMERATION", 4),
         };
 
-        final List<String> expectedXpathQueries = Collections.singletonList(
+        final List<String> expectedXpathQueries = List.of(
                 "/COMPILATION_UNIT/CLASS_DEF[./IDENT["
                     + "@text='InputXpathAbbreviationAsWordInNameEnum']]"
                     + "/OBJBLOCK/ENUM_DEF/IDENT[@text='ENUMERATION']"
@@ -148,7 +147,7 @@ public class XpathRegressionAbbreviationAsWordInNameTest extends AbstractXpathTe
                 AbbreviationAsWordInNameCheck.MSG_KEY, "FIELD", 4),
         };
 
-        final List<String> expectedXpathQueries = Collections.singletonList(
+        final List<String> expectedXpathQueries = List.of(
                 "/COMPILATION_UNIT/CLASS_DEF[./IDENT["
                     + "@text='InputXpathAbbreviationAsWordInNameField']]"
                     + "/OBJBLOCK/VARIABLE_DEF/IDENT[@text='FIELD']"
@@ -171,7 +170,7 @@ public class XpathRegressionAbbreviationAsWordInNameTest extends AbstractXpathTe
                 AbbreviationAsWordInNameCheck.MSG_KEY, "INTERFACE", 4),
         };
 
-        final List<String> expectedXpathQueries = Collections.singletonList(
+        final List<String> expectedXpathQueries = List.of(
                 "/COMPILATION_UNIT/CLASS_DEF[./IDENT["
                     + "@text='InputXpathAbbreviationAsWordInNameInterface']]"
                     + "/OBJBLOCK/INTERFACE_DEF/IDENT[@text='INTERFACE']"
@@ -194,7 +193,7 @@ public class XpathRegressionAbbreviationAsWordInNameTest extends AbstractXpathTe
                 AbbreviationAsWordInNameCheck.MSG_KEY, "METHOD", 4),
         };
 
-        final List<String> expectedXpathQueries = Collections.singletonList(
+        final List<String> expectedXpathQueries = List.of(
                 "/COMPILATION_UNIT/INTERFACE_DEF[./IDENT["
                     + "@text='InputXpathAbbreviationAsWordInNameMethod']]"
                     + "/OBJBLOCK/METHOD_DEF/IDENT[@text='METHOD']"
@@ -217,7 +216,7 @@ public class XpathRegressionAbbreviationAsWordInNameTest extends AbstractXpathTe
                 AbbreviationAsWordInNameCheck.MSG_KEY, "PARAMETER", 4),
         };
 
-        final List<String> expectedXpathQueries = Collections.singletonList(
+        final List<String> expectedXpathQueries = List.of(
                 "/COMPILATION_UNIT/INTERFACE_DEF[./IDENT["
                     + "@text='InputXpathAbbreviationAsWordInNameParameter']]"
                     + "/OBJBLOCK/METHOD_DEF[./IDENT[@text='method']]"
@@ -241,7 +240,7 @@ public class XpathRegressionAbbreviationAsWordInNameTest extends AbstractXpathTe
                 AbbreviationAsWordInNameCheck.MSG_KEY, "VARIABLE", 4),
         };
 
-        final List<String> expectedXpathQueries = Collections.singletonList(
+        final List<String> expectedXpathQueries = List.of(
                 "/COMPILATION_UNIT/CLASS_DEF[./IDENT["
                     + "@text='InputXpathAbbreviationAsWordInNameVariable']]"
                     + "/OBJBLOCK/METHOD_DEF[./IDENT[@text='method']]"

--- a/src/it/java/org/checkstyle/suppressionxpathfilter/naming/XpathRegressionCatchParameterNameTest.java
+++ b/src/it/java/org/checkstyle/suppressionxpathfilter/naming/XpathRegressionCatchParameterNameTest.java
@@ -22,7 +22,6 @@ package org.checkstyle.suppressionxpathfilter.naming;
 import static com.puppycrawl.tools.checkstyle.checks.naming.AbstractNameCheck.MSG_INVALID_PATTERN;
 
 import java.io.File;
-import java.util.Collections;
 import java.util.List;
 
 import org.checkstyle.suppressionxpathfilter.AbstractXpathTestSupport;
@@ -59,7 +58,7 @@ public class XpathRegressionCatchParameterNameTest extends AbstractXpathTestSupp
                     MSG_INVALID_PATTERN, "e1", pattern),
         };
 
-        final List<String> expectedXpathQueries = Collections.singletonList(
+        final List<String> expectedXpathQueries = List.of(
                 "/COMPILATION_UNIT/CLASS_DEF"
                 + "[./IDENT[@text='InputXpathCatchParameterNameSimple']]"
                 + "/OBJBLOCK/METHOD_DEF[./IDENT[@text='method']]"
@@ -84,7 +83,7 @@ public class XpathRegressionCatchParameterNameTest extends AbstractXpathTestSupp
                     MSG_INVALID_PATTERN, "i", pattern),
         };
 
-        final List<String> expectedXpathQueries = Collections.singletonList(
+        final List<String> expectedXpathQueries = List.of(
                 "/COMPILATION_UNIT/CLASS_DEF"
                 + "[./IDENT[@text='InputXpathCatchParameterNameNested']]"
                 + "/OBJBLOCK/CLASS_DEF[./IDENT[@text='NestedClass']]"
@@ -112,7 +111,7 @@ public class XpathRegressionCatchParameterNameTest extends AbstractXpathTestSupp
                     MSG_INVALID_PATTERN, "Ex", pattern),
         };
 
-        final List<String> expectedXpathQueries = Collections.singletonList(
+        final List<String> expectedXpathQueries = List.of(
                 "/COMPILATION_UNIT/CLASS_DEF"
                 + "[./IDENT[@text='InputXpathCatchParameterNameStaticInit']]"
                 + "/OBJBLOCK/STATIC_INIT/SLIST"
@@ -138,7 +137,7 @@ public class XpathRegressionCatchParameterNameTest extends AbstractXpathTestSupp
                     MSG_INVALID_PATTERN, "E1", pattern),
         };
 
-        final List<String> expectedXpathQueries = Collections.singletonList(
+        final List<String> expectedXpathQueries = List.of(
                 "/COMPILATION_UNIT/CLASS_DEF"
                 + "[./IDENT[@text='InputXpathCatchParameterNameAnonymous']]"
                 + "/OBJBLOCK/CLASS_DEF[./IDENT[@text='InnerClass']]"
@@ -167,7 +166,7 @@ public class XpathRegressionCatchParameterNameTest extends AbstractXpathTestSupp
                     MSG_INVALID_PATTERN, "e", pattern),
         };
 
-        final List<String> expectedXpathQueries = Collections.singletonList(
+        final List<String> expectedXpathQueries = List.of(
                 "/COMPILATION_UNIT/CLASS_DEF"
                 + "[./IDENT[@text='InputXpathCatchParameterNameLambda']]"
                 + "/OBJBLOCK/VARIABLE_DEF[./IDENT[@text='lambdaFunction']]"
@@ -195,7 +194,7 @@ public class XpathRegressionCatchParameterNameTest extends AbstractXpathTestSupp
                     MSG_INVALID_PATTERN, "eX", pattern),
         };
 
-        final List<String> expectedXpathQueries = Collections.singletonList(
+        final List<String> expectedXpathQueries = List.of(
                 "/COMPILATION_UNIT/ENUM_DEF"
                 + "[./IDENT[@text='InputXpathCatchParameterNameEnum']]"
                 + "/OBJBLOCK/ENUM_CONSTANT_DEF[./IDENT[@text='VALUE']]"
@@ -223,7 +222,7 @@ public class XpathRegressionCatchParameterNameTest extends AbstractXpathTestSupp
                     MSG_INVALID_PATTERN, "EX", pattern),
         };
 
-        final List<String> expectedXpathQueries = Collections.singletonList(
+        final List<String> expectedXpathQueries = List.of(
                 "/COMPILATION_UNIT/INTERFACE_DEF"
                 + "[./IDENT[@text='InputXpathCatchParameterNameInterface']]"
                 + "/OBJBLOCK/INTERFACE_DEF[./IDENT[@text='InnerInterface']]"

--- a/src/it/java/org/checkstyle/suppressionxpathfilter/naming/XpathRegressionConstantNameTest.java
+++ b/src/it/java/org/checkstyle/suppressionxpathfilter/naming/XpathRegressionConstantNameTest.java
@@ -22,7 +22,6 @@ package org.checkstyle.suppressionxpathfilter.naming;
 import static com.puppycrawl.tools.checkstyle.checks.naming.AbstractNameCheck.MSG_INVALID_PATTERN;
 
 import java.io.File;
-import java.util.Collections;
 import java.util.List;
 
 import org.checkstyle.suppressionxpathfilter.AbstractXpathTestSupport;
@@ -58,7 +57,7 @@ public class XpathRegressionConstantNameTest extends AbstractXpathTestSupport {
             "4:29: " + getCheckMessage(CLASS, MSG_INVALID_PATTERN, "number", PATTERN),
         };
 
-        final List<String> expectedXpathQueries = Collections.singletonList(
+        final List<String> expectedXpathQueries = List.of(
             "/COMPILATION_UNIT/CLASS_DEF[./IDENT"
                 + "[@text='InputXpathConstantNameLowercase']]"
                 + "/OBJBLOCK/VARIABLE_DEF/IDENT[@text='number']"
@@ -80,7 +79,7 @@ public class XpathRegressionConstantNameTest extends AbstractXpathTestSupport {
                 MSG_INVALID_PATTERN, "badConstant", PATTERN),
         };
 
-        final List<String> expectedXpathQueries = Collections.singletonList(
+        final List<String> expectedXpathQueries = List.of(
             "/COMPILATION_UNIT/CLASS_DEF"
                 + "[./IDENT[@text='InputXpathConstantNameCamelCase']]"
                 + "/OBJBLOCK/VARIABLE_DEF/IDENT[@text='badConstant']"
@@ -101,7 +100,7 @@ public class XpathRegressionConstantNameTest extends AbstractXpathTestSupport {
             "4:33: " + getCheckMessage(CLASS, MSG_INVALID_PATTERN, "_CONSTANT", PATTERN),
         };
 
-        final List<String> expectedXpathQueries = Collections.singletonList(
+        final List<String> expectedXpathQueries = List.of(
             "/COMPILATION_UNIT/CLASS_DEF[./IDENT"
                 + "[@text='InputXpathConstantNameWithBeginningUnderscore']]"
                 + "/OBJBLOCK/VARIABLE_DEF/IDENT[@text='_CONSTANT']"
@@ -122,7 +121,7 @@ public class XpathRegressionConstantNameTest extends AbstractXpathTestSupport {
             "4:30: " + getCheckMessage(CLASS, MSG_INVALID_PATTERN, "BAD__NAME", PATTERN),
         };
 
-        final List<String> expectedXpathQueries = Collections.singletonList(
+        final List<String> expectedXpathQueries = List.of(
             "/COMPILATION_UNIT/CLASS_DEF[./IDENT"
                 + "[@text='InputXpathConstantNameWithTwoUnderscores']]"
                 + "/OBJBLOCK/VARIABLE_DEF/IDENT[@text='BAD__NAME']"

--- a/src/it/java/org/checkstyle/suppressionxpathfilter/naming/XpathRegressionIllegalIdentifierNameTest.java
+++ b/src/it/java/org/checkstyle/suppressionxpathfilter/naming/XpathRegressionIllegalIdentifierNameTest.java
@@ -20,7 +20,6 @@
 package org.checkstyle.suppressionxpathfilter.naming;
 
 import java.io.File;
-import java.util.Collections;
 import java.util.List;
 
 import org.checkstyle.suppressionxpathfilter.AbstractXpathTestSupport;
@@ -59,7 +58,7 @@ public class XpathRegressionIllegalIdentifierNameTest extends AbstractXpathTestS
                 AbstractNameCheck.MSG_INVALID_PATTERN, "var", format),
             };
 
-        final List<String> expectedXpathQueries = Collections.singletonList(
+        final List<String> expectedXpathQueries = List.of(
             "/COMPILATION_UNIT/RECORD_DEF"
                 + "[./IDENT[@text='InputXpathIllegalIdentifierNameOne'"
                 + "]]/RECORD_COMPONENTS/RECORD_COMPONENT_DEF/IDENT[@text='var']"
@@ -84,7 +83,7 @@ public class XpathRegressionIllegalIdentifierNameTest extends AbstractXpathTestS
                 AbstractNameCheck.MSG_INVALID_PATTERN, "te$t", format),
             };
 
-        final List<String> expectedXpathQueries = Collections.singletonList(
+        final List<String> expectedXpathQueries = List.of(
             "/COMPILATION_UNIT/CLASS_DEF"
                 + "[./IDENT[@text='InputXpathIllegalIdentifierNameTwo']"
                 + "]/OBJBLOCK/METHOD_DEF[./IDENT[@text='foo']]/PARAMETERS/PARAMETER_DEF"

--- a/src/it/java/org/checkstyle/suppressionxpathfilter/naming/XpathRegressionLambdaParameterNameTest.java
+++ b/src/it/java/org/checkstyle/suppressionxpathfilter/naming/XpathRegressionLambdaParameterNameTest.java
@@ -21,7 +21,6 @@ package org.checkstyle.suppressionxpathfilter.naming;
 
 import java.io.File;
 import java.util.Arrays;
-import java.util.Collections;
 import java.util.List;
 
 import org.checkstyle.suppressionxpathfilter.AbstractXpathTestSupport;
@@ -59,7 +58,7 @@ public class XpathRegressionLambdaParameterNameTest extends AbstractXpathTestSup
                     AbstractNameCheck.MSG_INVALID_PATTERN, "S", defaultPattern),
         };
 
-        final List<String> expectedXpathQueries = Collections.singletonList(
+        final List<String> expectedXpathQueries = List.of(
                "/COMPILATION_UNIT/CLASS_DEF"
                        + "[./IDENT[@text='InputXpathLambdaParameterNameDefault']]"
                        + "/OBJBLOCK/METHOD_DEF[./IDENT[@text='test']]/SLIST/VARIABLE_DEF["

--- a/src/it/java/org/checkstyle/suppressionxpathfilter/naming/XpathRegressionLocalFinalVariableNameTest.java
+++ b/src/it/java/org/checkstyle/suppressionxpathfilter/naming/XpathRegressionLocalFinalVariableNameTest.java
@@ -22,7 +22,6 @@ package org.checkstyle.suppressionxpathfilter.naming;
 import static com.puppycrawl.tools.checkstyle.checks.naming.LocalFinalVariableNameCheck.MSG_INVALID_PATTERN;
 
 import java.io.File;
-import java.util.Collections;
 import java.util.List;
 
 import org.checkstyle.suppressionxpathfilter.AbstractXpathTestSupport;
@@ -60,7 +59,7 @@ public class XpathRegressionLocalFinalVariableNameTest extends AbstractXpathTest
                     MSG_INVALID_PATTERN, "scanner", "^[A-Z][A-Z0-9]*$"),
         };
 
-        final List<String> expectedXpathQueries = Collections.singletonList(
+        final List<String> expectedXpathQueries = List.of(
                 "/COMPILATION_UNIT/CLASS_DEF[./IDENT["
                         + "@text='InputXpathLocalFinalVariableNameResource']]"
                         + "/OBJBLOCK/METHOD_DEF[./IDENT[@text='MyMethod']]/SLIST/LITERAL_TRY"
@@ -84,7 +83,7 @@ public class XpathRegressionLocalFinalVariableNameTest extends AbstractXpathTest
                     MSG_INVALID_PATTERN, "VAR1", "^[A-Z][a-z0-9]*$"),
         };
 
-        final List<String> expectedXpathQueries = Collections.singletonList(
+        final List<String> expectedXpathQueries = List.of(
                 "/COMPILATION_UNIT/CLASS_DEF[./IDENT["
                         + "@text='InputXpathLocalFinalVariableNameVar']]"
                         + "/OBJBLOCK/METHOD_DEF[./IDENT[@text='MyMethod']]/SLIST/VARIABLE_DEF"
@@ -108,7 +107,7 @@ public class XpathRegressionLocalFinalVariableNameTest extends AbstractXpathTest
                         MSG_INVALID_PATTERN, "VAR1", "^[A-Z][a-z0-9]*$"),
         };
 
-        final List<String> expectedXpathQueries = Collections.singletonList(
+        final List<String> expectedXpathQueries = List.of(
                 "/COMPILATION_UNIT/CLASS_DEF[./IDENT["
                         + "@text='InputXpathLocalFinalVariableNameInner']]"
                         + "/OBJBLOCK/CLASS_DEF[./IDENT[@text='InnerClass']]/OBJBLOCK"

--- a/src/it/java/org/checkstyle/suppressionxpathfilter/naming/XpathRegressionLocalVariableNameTest.java
+++ b/src/it/java/org/checkstyle/suppressionxpathfilter/naming/XpathRegressionLocalVariableNameTest.java
@@ -22,7 +22,6 @@ package org.checkstyle.suppressionxpathfilter.naming;
 import static com.puppycrawl.tools.checkstyle.checks.naming.AbstractNameCheck.MSG_INVALID_PATTERN;
 
 import java.io.File;
-import java.util.Collections;
 import java.util.List;
 
 import org.checkstyle.suppressionxpathfilter.AbstractXpathTestSupport;
@@ -56,7 +55,7 @@ public class XpathRegressionLocalVariableNameTest extends AbstractXpathTestSuppo
                 "VAR", pattern),
         };
 
-        final List<String> expectedXpathQueries = Collections.singletonList(
+        final List<String> expectedXpathQueries = List.of(
             "/COMPILATION_UNIT/CLASS_DEF[./IDENT["
               + "@text='InputXpathLocalVariableNameMethod']]"
               + "/OBJBLOCK/METHOD_DEF[./IDENT[@text='MyMethod']]"
@@ -79,7 +78,7 @@ public class XpathRegressionLocalVariableNameTest extends AbstractXpathTestSuppo
                 "var_1", pattern),
         };
 
-        final List<String> expectedXpathQueries = Collections.singletonList(
+        final List<String> expectedXpathQueries = List.of(
             "/COMPILATION_UNIT/CLASS_DEF[./IDENT["
               + "@text='InputXpathLocalVariableNameIteration']]"
               + "/OBJBLOCK/METHOD_DEF[./IDENT[@text='MyMethod']]/"
@@ -102,7 +101,7 @@ public class XpathRegressionLocalVariableNameTest extends AbstractXpathTestSuppo
                 "VAR", pattern),
         };
 
-        final List<String> expectedXpathQueries = Collections.singletonList(
+        final List<String> expectedXpathQueries = List.of(
             "/COMPILATION_UNIT/CLASS_DEF[./IDENT["
               + "@text='InputXpathLocalVariableNameInnerClass']]"
               + "/OBJBLOCK/CLASS_DEF[./IDENT[@text='InnerClass']]/OBJBLOCK/"

--- a/src/it/java/org/checkstyle/suppressionxpathfilter/naming/XpathRegressionMemberNameTest.java
+++ b/src/it/java/org/checkstyle/suppressionxpathfilter/naming/XpathRegressionMemberNameTest.java
@@ -20,7 +20,6 @@
 package org.checkstyle.suppressionxpathfilter.naming;
 
 import java.io.File;
-import java.util.Collections;
 import java.util.List;
 
 import org.checkstyle.suppressionxpathfilter.AbstractXpathTestSupport;
@@ -58,7 +57,7 @@ public class XpathRegressionMemberNameTest extends AbstractXpathTestSupport {
                         AbstractNameCheck.MSG_INVALID_PATTERN, "NUM2", pattern),
         };
 
-        final List<String> expectedXpathQueries = Collections.singletonList(
+        final List<String> expectedXpathQueries = List.of(
                 "/COMPILATION_UNIT"
                         + "/CLASS_DEF[./IDENT[@text"
                         + "='InputXpathMemberNameDefault']]"
@@ -85,7 +84,7 @@ public class XpathRegressionMemberNameTest extends AbstractXpathTestSupport {
                         AbstractNameCheck.MSG_INVALID_PATTERN, "NUM1", pattern),
         };
 
-        final List<String> expectedXpathQueries = Collections.singletonList(
+        final List<String> expectedXpathQueries = List.of(
                 "/COMPILATION_UNIT"
                         + "/CLASS_DEF[./IDENT[@text"
                         + "='InputXpathMemberNameIgnoreProtected']]"

--- a/src/it/java/org/checkstyle/suppressionxpathfilter/naming/XpathRegressionMethodNameTest.java
+++ b/src/it/java/org/checkstyle/suppressionxpathfilter/naming/XpathRegressionMethodNameTest.java
@@ -20,7 +20,6 @@
 package org.checkstyle.suppressionxpathfilter.naming;
 
 import java.io.File;
-import java.util.Collections;
 import java.util.List;
 
 import org.checkstyle.suppressionxpathfilter.AbstractXpathTestSupport;
@@ -58,7 +57,7 @@ public class XpathRegressionMethodNameTest extends AbstractXpathTestSupport {
                         AbstractNameCheck.MSG_INVALID_PATTERN, "SecondMethod", pattern),
         };
 
-        final List<String> expectedXpathQueries = Collections.singletonList(
+        final List<String> expectedXpathQueries = List.of(
                 "/COMPILATION_UNIT"
                         + "/CLASS_DEF[./IDENT[@text"
                         + "='InputXpathMethodNameDefault']]"
@@ -83,7 +82,7 @@ public class XpathRegressionMethodNameTest extends AbstractXpathTestSupport {
                         AbstractNameCheck.MSG_INVALID_PATTERN, "MyMethod2", pattern),
         };
 
-        final List<String> expectedXpathQueries = Collections.singletonList(
+        final List<String> expectedXpathQueries = List.of(
                 "/COMPILATION_UNIT"
                         + "/CLASS_DEF[./IDENT[@text"
                         + "='InputXpathMethodNameInner']]"
@@ -112,7 +111,7 @@ public class XpathRegressionMethodNameTest extends AbstractXpathTestSupport {
                         "ThirdMethod", pattern),
         };
 
-        final List<String> expectedXpathQueries = Collections.singletonList(
+        final List<String> expectedXpathQueries = List.of(
                 "/COMPILATION_UNIT"
                         + "/INTERFACE_DEF[./IDENT[@text='Check']]"
                         + "/OBJBLOCK/METHOD_DEF/IDENT[@text='ThirdMethod']"

--- a/src/it/java/org/checkstyle/suppressionxpathfilter/naming/XpathRegressionPackageNameTest.java
+++ b/src/it/java/org/checkstyle/suppressionxpathfilter/naming/XpathRegressionPackageNameTest.java
@@ -22,7 +22,6 @@ package org.checkstyle.suppressionxpathfilter.naming;
 import static com.puppycrawl.tools.checkstyle.checks.naming.PackageNameCheck.MSG_KEY;
 
 import java.io.File;
-import java.util.Collections;
 import java.util.List;
 
 import org.checkstyle.suppressionxpathfilter.AbstractXpathTestSupport;
@@ -62,7 +61,7 @@ public class XpathRegressionPackageNameTest extends AbstractXpathTestSupport {
                     pattern),
         };
 
-        final List<String> expectedXpathQueries = Collections.singletonList(
+        final List<String> expectedXpathQueries = List.of(
                 "/COMPILATION_UNIT/PACKAGE_DEF/DOT"
                         + "[./IDENT[@text='packagename']]/DOT"
                         + "[./IDENT[@text='naming']]/DOT"
@@ -90,7 +89,7 @@ public class XpathRegressionPackageNameTest extends AbstractXpathTestSupport {
                     pattern),
         };
 
-        final List<String> expectedXpathQueries = Collections.singletonList(
+        final List<String> expectedXpathQueries = List.of(
                 "/COMPILATION_UNIT/PACKAGE_DEF/DOT[./IDENT"
                         + "[@text='PACKAGENAME']]/DOT[./IDENT"
                         + "[@text='suppressionxpathfilter']]"
@@ -118,7 +117,7 @@ public class XpathRegressionPackageNameTest extends AbstractXpathTestSupport {
                     pattern),
         };
 
-        final List<String> expectedXpathQueries = Collections.singletonList(
+        final List<String> expectedXpathQueries = List.of(
                 "/COMPILATION_UNIT/PACKAGE_DEF/DOT"
                         + "[./IDENT[@text='packagename']]/DOT"
                         + "[./IDENT[@text='naming']]/DOT"

--- a/src/it/java/org/checkstyle/suppressionxpathfilter/naming/XpathRegressionParameterNameTest.java
+++ b/src/it/java/org/checkstyle/suppressionxpathfilter/naming/XpathRegressionParameterNameTest.java
@@ -20,7 +20,6 @@
 package org.checkstyle.suppressionxpathfilter.naming;
 
 import java.io.File;
-import java.util.Collections;
 import java.util.List;
 
 import org.checkstyle.suppressionxpathfilter.AbstractXpathTestSupport;
@@ -58,7 +57,7 @@ public class XpathRegressionParameterNameTest extends AbstractXpathTestSupport {
                         AbstractNameCheck.MSG_INVALID_PATTERN, "v_1", pattern),
         };
 
-        final List<String> expectedXpathQueries = Collections.singletonList(
+        final List<String> expectedXpathQueries = List.of(
                 "/COMPILATION_UNIT"
                         + "/CLASS_DEF[./IDENT[@text"
                         + "='InputXpathParameterNameDefaultPattern']]"
@@ -84,7 +83,7 @@ public class XpathRegressionParameterNameTest extends AbstractXpathTestSupport {
                         AbstractNameCheck.MSG_INVALID_PATTERN, "V2", pattern),
         };
 
-        final List<String> expectedXpathQueries = Collections.singletonList(
+        final List<String> expectedXpathQueries = List.of(
                 "/COMPILATION_UNIT"
                         + "/CLASS_DEF[./IDENT[@text"
                         + "='InputXpathParameterNameDifferentPattern']]"
@@ -110,7 +109,7 @@ public class XpathRegressionParameterNameTest extends AbstractXpathTestSupport {
                         AbstractNameCheck.MSG_INVALID_PATTERN, "V2", pattern),
         };
 
-        final List<String> expectedXpathQueries = Collections.singletonList(
+        final List<String> expectedXpathQueries = List.of(
                 "/COMPILATION_UNIT"
                         + "/CLASS_DEF[./IDENT[@text"
                         + "='InputXpathParameterNameIgnoreOverridden']]"
@@ -137,7 +136,7 @@ public class XpathRegressionParameterNameTest extends AbstractXpathTestSupport {
                         AbstractNameCheck.MSG_INVALID_PATTERN, "b", pattern),
         };
 
-        final List<String> expectedXpathQueries = Collections.singletonList(
+        final List<String> expectedXpathQueries = List.of(
                 "/COMPILATION_UNIT"
                         + "/CLASS_DEF[./IDENT[@text"
                         + "='InputXpathParameterNameAccessModifier']]"

--- a/src/it/java/org/checkstyle/suppressionxpathfilter/naming/XpathRegressionPatternVariableNameTest.java
+++ b/src/it/java/org/checkstyle/suppressionxpathfilter/naming/XpathRegressionPatternVariableNameTest.java
@@ -20,7 +20,6 @@
 package org.checkstyle.suppressionxpathfilter.naming;
 
 import java.io.File;
-import java.util.Collections;
 import java.util.List;
 
 import org.checkstyle.suppressionxpathfilter.AbstractXpathTestSupport;
@@ -60,7 +59,7 @@ public class XpathRegressionPatternVariableNameTest extends AbstractXpathTestSup
                     "STRING1", defaultPattern),
         };
 
-        final List<String> expectedXpathQueries = Collections.singletonList(
+        final List<String> expectedXpathQueries = List.of(
             "/COMPILATION_UNIT/CLASS_DEF"
                 + "[./IDENT[@text='InputXpathPatternVariableNameOne']]"
                 + "/OBJBLOCK/METHOD_DEF[./IDENT[@text='MyClass']]/SLIST/LITERAL_IF/EXPR/"
@@ -89,7 +88,7 @@ public class XpathRegressionPatternVariableNameTest extends AbstractXpathTestSup
                     AbstractNameCheck.MSG_INVALID_PATTERN, "s", nonDefaultPattern),
         };
 
-        final List<String> expectedXpathQueries = Collections.singletonList(
+        final List<String> expectedXpathQueries = List.of(
             "/COMPILATION_UNIT/CLASS_DEF"
                 + "[./IDENT[@text='InputXpathPatternVariableNameTwo']]"
                 + "/OBJBLOCK/METHOD_DEF[./IDENT[@text='MyClass']]/SLIST/LITERAL_IF/EXPR/"
@@ -118,7 +117,7 @@ public class XpathRegressionPatternVariableNameTest extends AbstractXpathTestSup
                 AbstractNameCheck.MSG_INVALID_PATTERN, "STR", nonDefaultPattern),
         };
 
-        final List<String> expectedXpathQueries = Collections.singletonList(
+        final List<String> expectedXpathQueries = List.of(
                 "/COMPILATION_UNIT/CLASS_DEF"
                     + "[./IDENT[@text='InputXpathPatternVariableNameThree']]"
                     + "/OBJBLOCK/METHOD_DEF[./IDENT[@text='MyClass']]/SLIST/LITERAL_IF/"
@@ -147,7 +146,7 @@ public class XpathRegressionPatternVariableNameTest extends AbstractXpathTestSup
                 AbstractNameCheck.MSG_INVALID_PATTERN, "st", nonDefaultPattern),
         };
 
-        final List<String> expectedXpathQueries = Collections.singletonList(
+        final List<String> expectedXpathQueries = List.of(
                 "/COMPILATION_UNIT/CLASS_DEF"
                     + "[./IDENT[@text='InputXpathPatternVariableNameFour']]"
                     + "/OBJBLOCK/METHOD_DEF[./IDENT[@text='MyClass']]/SLIST/LITERAL_IF/EXPR/"

--- a/src/it/java/org/checkstyle/suppressionxpathfilter/naming/XpathRegressionRecordComponentNameTest.java
+++ b/src/it/java/org/checkstyle/suppressionxpathfilter/naming/XpathRegressionRecordComponentNameTest.java
@@ -20,7 +20,6 @@
 package org.checkstyle.suppressionxpathfilter.naming;
 
 import java.io.File;
-import java.util.Collections;
 import java.util.List;
 
 import org.checkstyle.suppressionxpathfilter.AbstractXpathTestSupport;
@@ -58,7 +57,7 @@ public class XpathRegressionRecordComponentNameTest extends AbstractXpathTestSup
                     "_value", "^[a-z][a-zA-Z0-9]*$"),
         };
 
-        final List<String> expectedXpathQueries = Collections.singletonList(
+        final List<String> expectedXpathQueries = List.of(
             "/COMPILATION_UNIT/RECORD_DEF[./IDENT[@text='InputXpathRecordComponentNameDefault']]"
                 + "/RECORD_COMPONENTS/RECORD_COMPONENT_DEF/IDENT[@text='_value']"
         );
@@ -82,7 +81,7 @@ public class XpathRegressionRecordComponentNameTest extends AbstractXpathTestSup
                     "otherValue", "^_[a-z][a-zA-Z0-9]*$"),
         };
 
-        final List<String> expectedXpathQueries = Collections.singletonList(
+        final List<String> expectedXpathQueries = List.of(
             "/COMPILATION_UNIT/CLASS_DEF"
                 + "[./IDENT[@text='InputXpathRecordComponentNameFormat']]/OBJBLOCK"
                 + "/RECORD_DEF[./IDENT[@text='MyRecord']]"

--- a/src/it/java/org/checkstyle/suppressionxpathfilter/naming/XpathRegressionStaticVariableNameTest.java
+++ b/src/it/java/org/checkstyle/suppressionxpathfilter/naming/XpathRegressionStaticVariableNameTest.java
@@ -20,7 +20,6 @@
 package org.checkstyle.suppressionxpathfilter.naming;
 
 import java.io.File;
-import java.util.Collections;
 import java.util.List;
 
 import org.checkstyle.suppressionxpathfilter.AbstractXpathTestSupport;
@@ -58,7 +57,7 @@ public class XpathRegressionStaticVariableNameTest extends AbstractXpathTestSupp
                         AbstractNameCheck.MSG_INVALID_PATTERN, "NUM2", pattern),
         };
 
-        final List<String> expectedXpathQueries = Collections.singletonList(
+        final List<String> expectedXpathQueries = List.of(
                 "/COMPILATION_UNIT"
                         + "/CLASS_DEF[./IDENT[@text"
                         + "='InputXpathStaticVariableName']]"
@@ -84,7 +83,7 @@ public class XpathRegressionStaticVariableNameTest extends AbstractXpathTestSupp
                         AbstractNameCheck.MSG_INVALID_PATTERN, "NUM3", pattern),
         };
 
-        final List<String> expectedXpathQueries = Collections.singletonList(
+        final List<String> expectedXpathQueries = List.of(
                 "/COMPILATION_UNIT"
                         + "/CLASS_DEF[./IDENT[@text"
                         + "='InputXpathStaticVariableNameInnerClassField']]"
@@ -111,7 +110,7 @@ public class XpathRegressionStaticVariableNameTest extends AbstractXpathTestSupp
                         AbstractNameCheck.MSG_INVALID_PATTERN, "NUM3", pattern),
         };
 
-        final List<String> expectedXpathQueries = Collections.singletonList(
+        final List<String> expectedXpathQueries = List.of(
                 "/COMPILATION_UNIT"
                         + "/CLASS_DEF[./IDENT[@text"
                         + "='InputXpathStaticVariableNameNoAccessModifier']]"

--- a/src/it/java/org/checkstyle/suppressionxpathfilter/naming/XpathRegressionTypeNameTest.java
+++ b/src/it/java/org/checkstyle/suppressionxpathfilter/naming/XpathRegressionTypeNameTest.java
@@ -20,7 +20,6 @@
 package org.checkstyle.suppressionxpathfilter.naming;
 
 import java.io.File;
-import java.util.Collections;
 import java.util.List;
 
 import org.checkstyle.suppressionxpathfilter.AbstractXpathTestSupport;
@@ -58,7 +57,7 @@ public class XpathRegressionTypeNameTest extends AbstractXpathTestSupport {
                         AbstractNameCheck.MSG_INVALID_PATTERN, "SecondName_", pattern),
         };
 
-        final List<String> expectedXpathQueries = Collections.singletonList(
+        final List<String> expectedXpathQueries = List.of(
                 "/COMPILATION_UNIT"
                         + "/CLASS_DEF[./IDENT[@text"
                         + "='InputXpathTypeNameDefault']]"
@@ -84,7 +83,7 @@ public class XpathRegressionTypeNameTest extends AbstractXpathTestSupport {
                         AbstractNameCheck.MSG_INVALID_PATTERN, "SecondName", pattern),
         };
 
-        final List<String> expectedXpathQueries = Collections.singletonList(
+        final List<String> expectedXpathQueries = List.of(
                 "/COMPILATION_UNIT"
                         + "/CLASS_DEF[./IDENT[@text"
                         + "='InputXpathTypeNameInterfaceDef']]"

--- a/src/it/java/org/checkstyle/suppressionxpathfilter/sizes/XpathRegressionLambdaBodyLengthTest.java
+++ b/src/it/java/org/checkstyle/suppressionxpathfilter/sizes/XpathRegressionLambdaBodyLengthTest.java
@@ -20,7 +20,6 @@
 package org.checkstyle.suppressionxpathfilter.sizes;
 
 import java.io.File;
-import java.util.Collections;
 import java.util.List;
 
 import org.checkstyle.suppressionxpathfilter.AbstractXpathTestSupport;
@@ -54,7 +53,7 @@ public class XpathRegressionLambdaBodyLengthTest
             "7:48: " + getCheckMessage(CLASS, LambdaBodyLengthCheck.MSG_KEY, 11, 10),
         };
 
-        final List<String> expectedXpathQueries = Collections.singletonList(
+        final List<String> expectedXpathQueries = List.of(
             "/COMPILATION_UNIT/CLASS_DEF"
                 + "[./IDENT[@text='InputXpathLambdaBodyLengthDefaultMax']]"
                 + "/OBJBLOCK/METHOD_DEF[./IDENT[@text='test']]/SLIST"
@@ -73,7 +72,7 @@ public class XpathRegressionLambdaBodyLengthTest
             "7:25: " + getCheckMessage(CLASS, LambdaBodyLengthCheck.MSG_KEY, 6, 5),
         };
 
-        final List<String> expectedXpathQueries = Collections.singletonList(
+        final List<String> expectedXpathQueries = List.of(
             "/COMPILATION_UNIT/CLASS_DEF"
                 + "[./IDENT[@text='InputXpathLambdaBodyLengthCustomMax']]"
                 + "/OBJBLOCK/METHOD_DEF[./IDENT[@text='test']]/SLIST"

--- a/src/it/java/org/checkstyle/suppressionxpathfilter/sizes/XpathRegressionParameterNumberTest.java
+++ b/src/it/java/org/checkstyle/suppressionxpathfilter/sizes/XpathRegressionParameterNumberTest.java
@@ -22,7 +22,6 @@ package org.checkstyle.suppressionxpathfilter.sizes;
 import static com.puppycrawl.tools.checkstyle.checks.sizes.ParameterNumberCheck.MSG_KEY;
 
 import java.io.File;
-import java.util.Collections;
 import java.util.List;
 
 import org.checkstyle.suppressionxpathfilter.AbstractXpathTestSupport;
@@ -54,7 +53,7 @@ public class XpathRegressionParameterNumberTest extends AbstractXpathTestSupport
             "5:10: " + getCheckMessage(ParameterNumberCheck.class, MSG_KEY, 7, 11),
         };
 
-        final List<String> expectedXpathQueries = Collections.singletonList(
+        final List<String> expectedXpathQueries = List.of(
                 "/COMPILATION_UNIT/CLASS_DEF"
                 + "[./IDENT[@text='InputXpathParameterNumberDefault']]"
                 + "/OBJBLOCK/METHOD_DEF/IDENT[@text='myMethod']"
@@ -77,7 +76,7 @@ public class XpathRegressionParameterNumberTest extends AbstractXpathTestSupport
             "7:10: " + getCheckMessage(ParameterNumberCheck.class, MSG_KEY, 10, 11),
         };
 
-        final List<String> expectedXpathQueries = Collections.singletonList(
+        final List<String> expectedXpathQueries = List.of(
                "/COMPILATION_UNIT/CLASS_DEF"
                + "[./IDENT[@text='InputXpathParameterNumberMethods']]"
                + "/OBJBLOCK/METHOD_DEF/IDENT[@text='myMethod']"
@@ -99,7 +98,7 @@ public class XpathRegressionParameterNumberTest extends AbstractXpathTestSupport
             "6:13: " + getCheckMessage(ParameterNumberCheck.class, MSG_KEY, 7, 8),
         };
 
-        final List<String> expectedXpathQueries = Collections.singletonList(
+        final List<String> expectedXpathQueries = List.of(
                 "/COMPILATION_UNIT/CLASS_DEF[./IDENT"
                 + "[@text='InputXpathParameterNumberIgnoreOverriddenMethods']]"
                 + "/OBJBLOCK/CTOR_DEF/IDENT"
@@ -123,7 +122,7 @@ public class XpathRegressionParameterNumberTest extends AbstractXpathTestSupport
             "15:34: " + getCheckMessage(ParameterNumberCheck.class, MSG_KEY, 2, 3),
         };
 
-        final List<String> expectedXpathQueries = Collections.singletonList(
+        final List<String> expectedXpathQueries = List.of(
                 "/COMPILATION_UNIT/CLASS_DEF"
                 + "[./IDENT[@text='InputXpathParameterNumberIgnoreAnnotatedBy']]"
                 + "/OBJBLOCK/CLASS_DEF[./IDENT[@text='InnerClass']]"

--- a/src/it/java/org/checkstyle/suppressionxpathfilter/whitespace/XpathRegressionEmptyLineSeparatorTest.java
+++ b/src/it/java/org/checkstyle/suppressionxpathfilter/whitespace/XpathRegressionEmptyLineSeparatorTest.java
@@ -21,7 +21,6 @@ package org.checkstyle.suppressionxpathfilter.whitespace;
 
 import java.io.File;
 import java.util.Arrays;
-import java.util.Collections;
 import java.util.List;
 
 import org.checkstyle.suppressionxpathfilter.AbstractXpathTestSupport;
@@ -135,7 +134,7 @@ public class XpathRegressionEmptyLineSeparatorTest extends AbstractXpathTestSupp
                     EmptyLineSeparatorCheck.MSG_MULTIPLE_LINES_AFTER, "}"),
         };
 
-        final List<String> expectedXpathQueries = Collections.singletonList(
+        final List<String> expectedXpathQueries = List.of(
                 "/COMPILATION_UNIT/CLASS_DEF"
                         + "[./IDENT[@text='InputXpathEmptyLineSeparatorFour']]"
                         + "/OBJBLOCK/METHOD_DEF[./IDENT[@text='foo1']]/SLIST/RCURLY"
@@ -160,7 +159,7 @@ public class XpathRegressionEmptyLineSeparatorTest extends AbstractXpathTestSupp
                     EmptyLineSeparatorCheck.MSG_MULTIPLE_LINES_INSIDE),
         };
 
-        final List<String> expectedXpathQueries = Collections.singletonList(
+        final List<String> expectedXpathQueries = List.of(
                 "/COMPILATION_UNIT/CLASS_DEF"
                         + "[./IDENT[@text='InputXpathEmptyLineSeparatorFive']]"
                         + "/OBJBLOCK/METHOD_DEF[./IDENT[@text='foo1']]/SLIST/LITERAL_TRY/SLIST"

--- a/src/it/java/org/checkstyle/suppressionxpathfilter/whitespace/XpathRegressionGenericWhitespaceTest.java
+++ b/src/it/java/org/checkstyle/suppressionxpathfilter/whitespace/XpathRegressionGenericWhitespaceTest.java
@@ -21,7 +21,6 @@ package org.checkstyle.suppressionxpathfilter.whitespace;
 
 import java.io.File;
 import java.util.Arrays;
-import java.util.Collections;
 import java.util.List;
 
 import org.checkstyle.suppressionxpathfilter.AbstractXpathTestSupport;
@@ -57,7 +56,7 @@ public class XpathRegressionGenericWhitespaceTest extends AbstractXpathTestSuppo
                     GenericWhitespaceCheck.MSG_WS_PRECEDED, ">"),
         };
 
-        final List<String> expectedXpathQueries = Collections.singletonList(
+        final List<String> expectedXpathQueries = List.of(
             "/COMPILATION_UNIT/CLASS_DEF"
                 + "[./IDENT[@text='InputXpathGenericWhitespaceEnd']]/OBJBLOCK"
                 + "/METHOD_DEF[./IDENT[@text='bad']]"
@@ -82,7 +81,7 @@ public class XpathRegressionGenericWhitespaceTest extends AbstractXpathTestSuppo
                     GenericWhitespaceCheck.MSG_WS_NOT_PRECEDED, "&"),
         };
 
-        final List<String> expectedXpathQueries = Collections.singletonList(
+        final List<String> expectedXpathQueries = List.of(
             "/COMPILATION_UNIT/CLASS_DEF[./IDENT["
                 + "@text='InputXpathGenericWhitespaceNestedOne']]"
                 + "/OBJBLOCK/METHOD_DEF[./IDENT[@text='bad']]/TYPE_PARAMETERS"
@@ -107,7 +106,7 @@ public class XpathRegressionGenericWhitespaceTest extends AbstractXpathTestSuppo
                     GenericWhitespaceCheck.MSG_WS_FOLLOWED, ">"),
         };
 
-        final List<String> expectedXpathQueries = Collections.singletonList(
+        final List<String> expectedXpathQueries = List.of(
             "/COMPILATION_UNIT/CLASS_DEF[./IDENT["
                 + "@text='InputXpathGenericWhitespaceNestedTwo']]"
                 + "/OBJBLOCK/METHOD_DEF[./IDENT[@text='bad']]/TYPE_PARAMETERS"
@@ -132,7 +131,7 @@ public class XpathRegressionGenericWhitespaceTest extends AbstractXpathTestSuppo
                     GenericWhitespaceCheck.MSG_WS_FOLLOWED, ">"),
         };
 
-        final List<String> expectedXpathQueries = Collections.singletonList(
+        final List<String> expectedXpathQueries = List.of(
             "/COMPILATION_UNIT/CLASS_DEF[./IDENT["
                 + "@text='InputXpathGenericWhitespaceNestedThree']]"
                 + "/OBJBLOCK/METHOD_DEF[./IDENT[@text='bad']]/TYPE_PARAMETERS"
@@ -157,7 +156,7 @@ public class XpathRegressionGenericWhitespaceTest extends AbstractXpathTestSuppo
                     GenericWhitespaceCheck.MSG_WS_FOLLOWED, ">"),
         };
 
-        final List<String> expectedXpathQueries = Collections.singletonList(
+        final List<String> expectedXpathQueries = List.of(
             "/COMPILATION_UNIT/CLASS_DEF[./IDENT["
                 + "@text='InputXpathGenericWhitespaceSingleOne']]"
                 + "/OBJBLOCK/VARIABLE_DEF[./IDENT[@text='bad']]/ASSIGN/EXPR/METHOD_CALL"
@@ -182,7 +181,7 @@ public class XpathRegressionGenericWhitespaceTest extends AbstractXpathTestSuppo
                     GenericWhitespaceCheck.MSG_WS_ILLEGAL_FOLLOW, ">"),
         };
 
-        final List<String> expectedXpathQueries = Collections.singletonList(
+        final List<String> expectedXpathQueries = List.of(
             "/COMPILATION_UNIT/CLASS_DEF[./IDENT["
                 + "@text='InputXpathGenericWhitespaceSingleTwo']]"
                 + "/OBJBLOCK/METHOD_DEF[./IDENT[@text='bad']]/TYPE_PARAMETERS/GENERIC_END"

--- a/src/it/java/org/checkstyle/suppressionxpathfilter/whitespace/XpathRegressionMethodParamPadTest.java
+++ b/src/it/java/org/checkstyle/suppressionxpathfilter/whitespace/XpathRegressionMethodParamPadTest.java
@@ -20,7 +20,6 @@
 package org.checkstyle.suppressionxpathfilter.whitespace;
 
 import java.io.File;
-import java.util.Collections;
 import java.util.List;
 
 import org.checkstyle.suppressionxpathfilter.AbstractXpathTestSupport;
@@ -56,7 +55,7 @@ public class XpathRegressionMethodParamPadTest extends AbstractXpathTestSupport 
                 MethodParamPadCheck.MSG_WS_PRECEDED, "("),
         };
 
-        final List<String> expectedXpathQueries = Collections.singletonList(
+        final List<String> expectedXpathQueries = List.of(
             "/COMPILATION_UNIT/CLASS_DEF[./IDENT"
                 + "[@text='InputXpathMethodParamPadOne']]/OBJBLOCK"
                 + "/METHOD_DEF[./IDENT[@text='InputMethodParamPad']]/LPAREN"
@@ -79,7 +78,7 @@ public class XpathRegressionMethodParamPadTest extends AbstractXpathTestSupport 
                 MethodParamPadCheck.MSG_LINE_PREVIOUS, "("),
         };
 
-        final List<String> expectedXpathQueries = Collections.singletonList(
+        final List<String> expectedXpathQueries = List.of(
             "/COMPILATION_UNIT/CLASS_DEF[./IDENT"
                 + "[@text='InputXpathMethodParamPadTwo']]/OBJBLOCK"
                 + "/METHOD_DEF[./IDENT[@text='sayHello']]/LPAREN"
@@ -103,7 +102,7 @@ public class XpathRegressionMethodParamPadTest extends AbstractXpathTestSupport 
                 MethodParamPadCheck.MSG_WS_NOT_PRECEDED, "("),
         };
 
-        final List<String> expectedXpathQueries = Collections.singletonList(
+        final List<String> expectedXpathQueries = List.of(
             "/COMPILATION_UNIT/CLASS_DEF[./IDENT"
                 + "[@text='InputXpathMethodParamPadThree']]/OBJBLOCK"
                 + "/METHOD_DEF[./IDENT[@text='sayHello']]/LPAREN"

--- a/src/it/java/org/checkstyle/suppressionxpathfilter/whitespace/XpathRegressionNoWhitespaceAfterTest.java
+++ b/src/it/java/org/checkstyle/suppressionxpathfilter/whitespace/XpathRegressionNoWhitespaceAfterTest.java
@@ -21,7 +21,6 @@ package org.checkstyle.suppressionxpathfilter.whitespace;
 
 import java.io.File;
 import java.util.Arrays;
-import java.util.Collections;
 import java.util.List;
 
 import org.checkstyle.suppressionxpathfilter.AbstractXpathTestSupport;
@@ -85,7 +84,7 @@ public class XpathRegressionNoWhitespaceAfterTest extends AbstractXpathTestSuppo
                     NoWhitespaceAfterCheck.MSG_KEY, "."),
         };
 
-        final List<String> expectedXpathQueries = Collections.singletonList(
+        final List<String> expectedXpathQueries = List.of(
             "/COMPILATION_UNIT/CLASS_DEF"
                 + "[./IDENT[@text='InputXpathNoWhitespaceAfterTokens']]"
                 + "/OBJBLOCK/METHOD_DEF[./IDENT[@text='test']]"

--- a/src/it/java/org/checkstyle/suppressionxpathfilter/whitespace/XpathRegressionNoWhitespaceBeforeCaseDefaultColonTest.java
+++ b/src/it/java/org/checkstyle/suppressionxpathfilter/whitespace/XpathRegressionNoWhitespaceBeforeCaseDefaultColonTest.java
@@ -20,7 +20,6 @@
 package org.checkstyle.suppressionxpathfilter.whitespace;
 
 import java.io.File;
-import java.util.Collections;
 import java.util.List;
 
 import org.checkstyle.suppressionxpathfilter.AbstractXpathTestSupport;
@@ -59,7 +58,7 @@ public class XpathRegressionNoWhitespaceBeforeCaseDefaultColonTest
                     NoWhitespaceBeforeCaseDefaultColonCheck.MSG_KEY, ":"),
         };
 
-        final List<String> expectedXpathQueries = Collections.singletonList(
+        final List<String> expectedXpathQueries = List.of(
             "/COMPILATION_UNIT/CLASS_DEF[./IDENT[@text="
                     + "'InputXpathNoWhitespaceBeforeCaseDefaultColonOne']]"
                     + "/OBJBLOCK/INSTANCE_INIT/SLIST/LITERAL_SWITCH/CASE_GROUP/LITERAL_CASE/COLON"
@@ -83,7 +82,7 @@ public class XpathRegressionNoWhitespaceBeforeCaseDefaultColonTest
                     NoWhitespaceBeforeCaseDefaultColonCheck.MSG_KEY, ":"),
         };
 
-        final List<String> expectedXpathQueries = Collections.singletonList(
+        final List<String> expectedXpathQueries = List.of(
             "/COMPILATION_UNIT/CLASS_DEF[./IDENT[@text="
                     + "'InputXpathNoWhitespaceBeforeCaseDefaultColonTwo']]"
                     + "/OBJBLOCK/INSTANCE_INIT/SLIST/LITERAL_SWITCH/CASE_GROUP"
@@ -108,7 +107,7 @@ public class XpathRegressionNoWhitespaceBeforeCaseDefaultColonTest
                         NoWhitespaceBeforeCaseDefaultColonCheck.MSG_KEY, ":"),
         };
 
-        final List<String> expectedXpathQueries = Collections.singletonList(
+        final List<String> expectedXpathQueries = List.of(
             "/COMPILATION_UNIT/CLASS_DEF[./IDENT[@text="
                     + "'InputXpathNoWhitespaceBeforeCaseDefaultColonThree']]"
                     + "/OBJBLOCK/INSTANCE_INIT/SLIST/LITERAL_SWITCH/CASE_GROUP"
@@ -133,7 +132,7 @@ public class XpathRegressionNoWhitespaceBeforeCaseDefaultColonTest
                         NoWhitespaceBeforeCaseDefaultColonCheck.MSG_KEY, ":"),
         };
 
-        final List<String> expectedXpathQueries = Collections.singletonList(
+        final List<String> expectedXpathQueries = List.of(
             "/COMPILATION_UNIT/CLASS_DEF[./IDENT[@text="
                     + "'InputXpathNoWhitespaceBeforeCaseDefaultColonFour']]"
                     + "/OBJBLOCK/INSTANCE_INIT/SLIST/LITERAL_SWITCH/CASE_GROUP"

--- a/src/it/java/org/checkstyle/suppressionxpathfilter/whitespace/XpathRegressionNoWhitespaceBeforeTest.java
+++ b/src/it/java/org/checkstyle/suppressionxpathfilter/whitespace/XpathRegressionNoWhitespaceBeforeTest.java
@@ -20,7 +20,6 @@
 package org.checkstyle.suppressionxpathfilter.whitespace;
 
 import java.io.File;
-import java.util.Collections;
 import java.util.List;
 
 import org.checkstyle.suppressionxpathfilter.AbstractXpathTestSupport;
@@ -56,7 +55,7 @@ public class XpathRegressionNoWhitespaceBeforeTest extends AbstractXpathTestSupp
                     NoWhitespaceBeforeCheck.MSG_KEY, ";"),
         };
 
-        final List<String> expectedXpathQueries = Collections.singletonList(
+        final List<String> expectedXpathQueries = List.of(
             "/COMPILATION_UNIT/CLASS_DEF"
                 + "[./IDENT[@text='InputXpathNoWhitespaceBefore']]/OBJBLOCK"
                 + "/VARIABLE_DEF[./IDENT[@text='bad']]/SEMI"
@@ -80,7 +79,7 @@ public class XpathRegressionNoWhitespaceBeforeTest extends AbstractXpathTestSupp
                 NoWhitespaceBeforeCheck.MSG_KEY, "."),
         };
 
-        final List<String> expectedXpathQueries = Collections.singletonList(
+        final List<String> expectedXpathQueries = List.of(
             "/COMPILATION_UNIT/CLASS_DEF"
                 + "[./IDENT[@text='InputXpathNoWhitespaceBeforeTokens']]"
                 + "/OBJBLOCK/METHOD_DEF[./IDENT[@text='test']]"
@@ -106,7 +105,7 @@ public class XpathRegressionNoWhitespaceBeforeTest extends AbstractXpathTestSupp
                 NoWhitespaceBeforeCheck.MSG_KEY, ","),
         };
 
-        final List<String> expectedXpathQueries = Collections.singletonList(
+        final List<String> expectedXpathQueries = List.of(
             "/COMPILATION_UNIT/CLASS_DEF"
                 + "[./IDENT[@text='InputXpathNoWhitespaceBeforeLineBreaks']]"
                 + "/OBJBLOCK/METHOD_DEF[./IDENT[@text='test']]"

--- a/src/it/java/org/checkstyle/suppressionxpathfilter/whitespace/XpathRegressionOperatorWrapTest.java
+++ b/src/it/java/org/checkstyle/suppressionxpathfilter/whitespace/XpathRegressionOperatorWrapTest.java
@@ -20,7 +20,6 @@
 package org.checkstyle.suppressionxpathfilter.whitespace;
 
 import java.io.File;
-import java.util.Collections;
 import java.util.List;
 
 import org.checkstyle.suppressionxpathfilter.AbstractXpathTestSupport;
@@ -56,7 +55,7 @@ public class XpathRegressionOperatorWrapTest extends AbstractXpathTestSupport {
                         OperatorWrapCheck.MSG_LINE_NEW, "+"),
         };
 
-        final List<String> expectedXpathQueries = Collections.singletonList(
+        final List<String> expectedXpathQueries = List.of(
                 "/COMPILATION_UNIT"
                         + "/CLASS_DEF[./IDENT[@text"
                         + "='InputXpathOperatorWrapNewLine']]"
@@ -85,7 +84,7 @@ public class XpathRegressionOperatorWrapTest extends AbstractXpathTestSupport {
                         OperatorWrapCheck.MSG_LINE_PREVIOUS, "="),
         };
 
-        final List<String> expectedXpathQueries = Collections.singletonList(
+        final List<String> expectedXpathQueries = List.of(
              "/COMPILATION_UNIT"
                 + "/CLASS_DEF[./IDENT[@text='InputXpathOperatorWrapPreviousLine']]"
                 + "/OBJBLOCK/VARIABLE_DEF[./IDENT[@text='b']]"

--- a/src/it/java/org/checkstyle/suppressionxpathfilter/whitespace/XpathRegressionParenPadTest.java
+++ b/src/it/java/org/checkstyle/suppressionxpathfilter/whitespace/XpathRegressionParenPadTest.java
@@ -20,7 +20,6 @@
 package org.checkstyle.suppressionxpathfilter.whitespace;
 
 import java.io.File;
-import java.util.Collections;
 import java.util.List;
 
 import org.checkstyle.suppressionxpathfilter.AbstractXpathTestSupport;
@@ -58,7 +57,7 @@ public class XpathRegressionParenPadTest extends AbstractXpathTestSupport {
                     AbstractParenPadCheck.MSG_WS_FOLLOWED, "("),
         };
 
-        final List<String> expectedXpathQueries = Collections.singletonList(
+        final List<String> expectedXpathQueries = List.of(
             "/COMPILATION_UNIT/CLASS_DEF"
                 + "[./IDENT[@text='InputXpathParenPadLeftFollowed']]"
                 + "/OBJBLOCK/METHOD_DEF[./IDENT[@text='method']]/SLIST/LITERAL_IF/LPAREN"
@@ -82,7 +81,7 @@ public class XpathRegressionParenPadTest extends AbstractXpathTestSupport {
                     AbstractParenPadCheck.MSG_WS_NOT_FOLLOWED, "("),
         };
 
-        final List<String> expectedXpathQueries = Collections.singletonList(
+        final List<String> expectedXpathQueries = List.of(
             "/COMPILATION_UNIT/CLASS_DEF"
                 + "[./IDENT[@text='InputXpathParenPadLeftNotFollowed']]"
                 + "/OBJBLOCK/METHOD_DEF[./IDENT[@text='method']]/SLIST/LITERAL_IF/LPAREN"
@@ -105,7 +104,7 @@ public class XpathRegressionParenPadTest extends AbstractXpathTestSupport {
                     AbstractParenPadCheck.MSG_WS_PRECEDED, ")"),
         };
 
-        final List<String> expectedXpathQueries = Collections.singletonList(
+        final List<String> expectedXpathQueries = List.of(
             "/COMPILATION_UNIT/CLASS_DEF"
                 + "[./IDENT[@text='InputXpathParenPadRightPreceded']]"
                 + "/OBJBLOCK/METHOD_DEF[./IDENT[@text='method']]/SLIST/LITERAL_IF/RPAREN"
@@ -129,7 +128,7 @@ public class XpathRegressionParenPadTest extends AbstractXpathTestSupport {
                     AbstractParenPadCheck.MSG_WS_NOT_PRECEDED, ")"),
         };
 
-        final List<String> expectedXpathQueries = Collections.singletonList(
+        final List<String> expectedXpathQueries = List.of(
             "/COMPILATION_UNIT/CLASS_DEF"
                 + "[./IDENT[@text='InputXpathParenPadRightNotPreceded']]"
                 + "/OBJBLOCK/METHOD_DEF[./IDENT[@text='method']]/SLIST/LITERAL_IF/RPAREN"

--- a/src/it/java/org/checkstyle/suppressionxpathfilter/whitespace/XpathRegressionSeparatorWrapTest.java
+++ b/src/it/java/org/checkstyle/suppressionxpathfilter/whitespace/XpathRegressionSeparatorWrapTest.java
@@ -21,7 +21,6 @@ package org.checkstyle.suppressionxpathfilter.whitespace;
 
 import java.io.File;
 import java.util.Arrays;
-import java.util.Collections;
 import java.util.List;
 
 import org.checkstyle.suppressionxpathfilter.AbstractXpathTestSupport;
@@ -56,7 +55,7 @@ public class XpathRegressionSeparatorWrapTest extends AbstractXpathTestSupport {
                         SeparatorWrapCheck.MSG_LINE_PREVIOUS, ","),
         };
 
-        final List<String> expectedXpathQueries = Collections.singletonList(
+        final List<String> expectedXpathQueries = List.of(
                 "/COMPILATION_UNIT/CLASS_DEF"
                         + "[./IDENT[@text='InputXpathSeparatorWrapClass']]"
                         + "/OBJBLOCK/METHOD_DEF[./IDENT[@text='testMethod']]"
@@ -80,7 +79,7 @@ public class XpathRegressionSeparatorWrapTest extends AbstractXpathTestSupport {
                         SeparatorWrapCheck.MSG_LINE_PREVIOUS, "..."),
         };
 
-        final List<String> expectedXpathQueries = Collections.singletonList(
+        final List<String> expectedXpathQueries = List.of(
                 "/COMPILATION_UNIT/INTERFACE_DEF"
                         + "[./IDENT[@text='InputXpathSeparatorWrapInterface']]"
                         + "/OBJBLOCK/METHOD_DEF[./IDENT[@text='testMethod2']]"

--- a/src/it/java/org/checkstyle/suppressionxpathfilter/whitespace/XpathRegressionSingleSpaceSeparatorTest.java
+++ b/src/it/java/org/checkstyle/suppressionxpathfilter/whitespace/XpathRegressionSingleSpaceSeparatorTest.java
@@ -20,7 +20,6 @@
 package org.checkstyle.suppressionxpathfilter.whitespace;
 
 import java.io.File;
-import java.util.Collections;
 import java.util.List;
 
 import org.checkstyle.suppressionxpathfilter.AbstractXpathTestSupport;
@@ -56,7 +55,7 @@ public class XpathRegressionSingleSpaceSeparatorTest extends AbstractXpathTestSu
                     SingleSpaceSeparatorCheck.MSG_KEY),
         };
 
-        final List<String> expectedXpathQueries = Collections.singletonList(
+        final List<String> expectedXpathQueries = List.of(
             "/COMPILATION_UNIT/CLASS_DEF"
                 + "[./IDENT[@text='InputXpathSingleSpaceSeparator']]/OBJBLOCK"
                 + "/VARIABLE_DEF/IDENT[@text='bad']"
@@ -81,7 +80,7 @@ public class XpathRegressionSingleSpaceSeparatorTest extends AbstractXpathTestSu
                     SingleSpaceSeparatorCheck.MSG_KEY),
         };
 
-        final List<String> expectedXpathQueries = Collections.singletonList(
+        final List<String> expectedXpathQueries = List.of(
             "/COMPILATION_UNIT/CLASS_DEF[."
                 + "/IDENT[@text='InputXpathSingleSpaceSeparatorValidateComments']]"
                 + "/OBJBLOCK/SINGLE_LINE_COMMENT[./COMMENT_CONTENT"

--- a/src/it/java/org/checkstyle/suppressionxpathfilter/whitespace/XpathRegressionTypecastParenPadTest.java
+++ b/src/it/java/org/checkstyle/suppressionxpathfilter/whitespace/XpathRegressionTypecastParenPadTest.java
@@ -21,7 +21,6 @@ package org.checkstyle.suppressionxpathfilter.whitespace;
 
 import java.io.File;
 import java.util.Arrays;
-import java.util.Collections;
 import java.util.List;
 
 import org.checkstyle.suppressionxpathfilter.AbstractXpathTestSupport;
@@ -112,7 +111,7 @@ public class XpathRegressionTypecastParenPadTest extends AbstractXpathTestSuppor
                     AbstractParenPadCheck.MSG_WS_PRECEDED, ")"),
         };
 
-        final List<String> expectedXpathQueries = Collections.singletonList(
+        final List<String> expectedXpathQueries = List.of(
             "/COMPILATION_UNIT/CLASS_DEF"
                 + "[./IDENT[@text='InputXpathTypecastParenPadRightPreceded']]"
                 + "/OBJBLOCK/VARIABLE_DEF[./IDENT[@text='bad']]/ASSIGN/EXPR/TYPECAST/RPAREN"
@@ -136,7 +135,7 @@ public class XpathRegressionTypecastParenPadTest extends AbstractXpathTestSuppor
                     AbstractParenPadCheck.MSG_WS_NOT_PRECEDED, ")"),
         };
 
-        final List<String> expectedXpathQueries = Collections.singletonList(
+        final List<String> expectedXpathQueries = List.of(
             "/COMPILATION_UNIT/CLASS_DEF[./IDENT["
                 + "@text='InputXpathTypecastParenPadRightNotPreceded']]"
                 + "/OBJBLOCK/VARIABLE_DEF[./IDENT[@text='bad']]/ASSIGN/EXPR/TYPECAST/RPAREN"

--- a/src/it/java/org/checkstyle/suppressionxpathfilter/whitespace/XpathRegressionWhitespaceAfterTest.java
+++ b/src/it/java/org/checkstyle/suppressionxpathfilter/whitespace/XpathRegressionWhitespaceAfterTest.java
@@ -20,7 +20,6 @@
 package org.checkstyle.suppressionxpathfilter.whitespace;
 
 import java.io.File;
-import java.util.Collections;
 import java.util.List;
 
 import org.checkstyle.suppressionxpathfilter.AbstractXpathTestSupport;
@@ -56,7 +55,7 @@ public class XpathRegressionWhitespaceAfterTest extends AbstractXpathTestSupport
                     WhitespaceAfterCheck.MSG_WS_TYPECAST, "-"),
         };
 
-        final List<String> expectedXpathQueries = Collections.singletonList(
+        final List<String> expectedXpathQueries = List.of(
             "/COMPILATION_UNIT/CLASS_DEF[./IDENT["
                 + "@text='InputXpathWhitespaceAfterTypecast']]/OBJBLOCK"
                 + "/VARIABLE_DEF[./IDENT[@text='bad']]/ASSIGN/EXPR/TYPECAST/RPAREN"
@@ -79,7 +78,7 @@ public class XpathRegressionWhitespaceAfterTest extends AbstractXpathTestSupport
                     WhitespaceAfterCheck.MSG_WS_NOT_FOLLOWED, ","),
         };
 
-        final List<String> expectedXpathQueries = Collections.singletonList(
+        final List<String> expectedXpathQueries = List.of(
             "/COMPILATION_UNIT/CLASS_DEF[./IDENT["
                 + "@text='InputXpathWhitespaceAfterNotFollowed']]/OBJBLOCK"
                 + "/VARIABLE_DEF[./IDENT[@text='bad']]/ASSIGN/ARRAY_INIT/COMMA"

--- a/src/it/java/org/checkstyle/suppressionxpathfilter/whitespace/XpathRegressionWhitespaceAroundTest.java
+++ b/src/it/java/org/checkstyle/suppressionxpathfilter/whitespace/XpathRegressionWhitespaceAroundTest.java
@@ -20,7 +20,6 @@
 package org.checkstyle.suppressionxpathfilter.whitespace;
 
 import java.io.File;
-import java.util.Collections;
 import java.util.List;
 
 import org.checkstyle.suppressionxpathfilter.AbstractXpathTestSupport;
@@ -56,7 +55,7 @@ public class XpathRegressionWhitespaceAroundTest extends AbstractXpathTestSuppor
                     WhitespaceAroundCheck.MSG_WS_NOT_PRECEDED, "="),
         };
 
-        final List<String> expectedXpathQueries = Collections.singletonList(
+        final List<String> expectedXpathQueries = List.of(
             "/COMPILATION_UNIT/CLASS_DEF[./IDENT["
                 + "@text='InputXpathWhitespaceAroundNotPreceded']]/OBJBLOCK"
                 + "/VARIABLE_DEF[./IDENT[@text='bad']]/ASSIGN"
@@ -79,7 +78,7 @@ public class XpathRegressionWhitespaceAroundTest extends AbstractXpathTestSuppor
                     WhitespaceAroundCheck.MSG_WS_NOT_FOLLOWED, "="),
         };
 
-        final List<String> expectedXpathQueries = Collections.singletonList(
+        final List<String> expectedXpathQueries = List.of(
             "/COMPILATION_UNIT/CLASS_DEF[./IDENT["
                 + "@text='InputXpathWhitespaceAroundNotFollowed']]/OBJBLOCK"
                 + "/VARIABLE_DEF[./IDENT[@text='bad']]/ASSIGN"

--- a/src/main/java/com/puppycrawl/tools/checkstyle/JavaAstVisitor.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/JavaAstVisitor.java
@@ -21,7 +21,6 @@ package com.puppycrawl.tools.checkstyle;
 
 import java.util.ArrayDeque;
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Optional;
@@ -820,7 +819,7 @@ public final class JavaAstVisitor extends JavaLanguageParserBaseVisitor<DetailAs
         final DetailAstImpl dummyNode = new DetailAstImpl();
         // Since the TYPE AST is built by visitAnnotationMethodOrConstantRest(), we skip it
         // here (child [0])
-        processChildren(dummyNode, Collections.singletonList(ctx.children.get(1)));
+        processChildren(dummyNode, List.of(ctx.children.get(1)));
         // We also append the SEMI token to the first child [size() - 1],
         // until https://github.com/checkstyle/checkstyle/issues/3151
         dummyNode.getFirstChild().addChild(create(ctx.SEMI()));

--- a/src/main/java/com/puppycrawl/tools/checkstyle/PackageObjectFactory.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/PackageObjectFactory.java
@@ -165,7 +165,7 @@ public class PackageObjectFactory implements ModuleFactory {
             throw new IllegalArgumentException(NULL_PACKAGE_MESSAGE);
         }
 
-        packages = Collections.singleton(packageName);
+        packages = Set.of(packageName);
         this.moduleClassLoader = moduleClassLoader;
     }
 

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/SuppressWarningsHolder.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/SuppressWarningsHolder.java
@@ -465,7 +465,7 @@ public class SuppressWarningsHolder
      */
     private static List<String> getAnnotationValues(DetailAST ast) {
         return switch (ast.getType()) {
-            case TokenTypes.EXPR -> Collections.singletonList(getStringExpr(ast));
+            case TokenTypes.EXPR -> List.of(getStringExpr(ast));
             case TokenTypes.ANNOTATION_ARRAY_INIT -> findAllExpressionsInChildren(ast);
             default -> throw new IllegalArgumentException(
                     "Expression or annotation array initializer AST expected: " + ast);

--- a/src/main/java/com/puppycrawl/tools/checkstyle/filters/SuppressionXpathFilter.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/filters/SuppressionXpathFilter.java
@@ -19,7 +19,6 @@
 
 package com.puppycrawl.tools.checkstyle.filters;
 
-import java.util.Collections;
 import java.util.HashSet;
 import java.util.Objects;
 import java.util.Set;
@@ -305,7 +304,7 @@ public class SuppressionXpathFilter extends AbstractAutomaticBean implements
 
     @Override
     public Set<String> getExternalResourceLocations() {
-        return Collections.singleton(file);
+        return Set.of(file);
     }
 
     @Override

--- a/src/main/java/com/puppycrawl/tools/checkstyle/utils/UnmodifiableCollectionUtil.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/utils/UnmodifiableCollectionUtil.java
@@ -120,6 +120,6 @@ public final class UnmodifiableCollectionUtil {
      * @return immutable set
      */
     public static <T> Set<T> singleton(T obj) {
-        return Collections.singleton(obj);
+        return Set.of(obj);
     }
 }

--- a/src/test/java/com/puppycrawl/tools/checkstyle/AbstractModuleTestSupport.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/AbstractModuleTestSupport.java
@@ -440,7 +440,7 @@ public abstract class AbstractModuleTestSupport extends AbstractPathTestSupport 
                 InlineConfigParser.parse(inputFile);
         final DefaultConfiguration parsedConfig =
                 testInputConfiguration.createConfiguration();
-        final List<File> filesToCheck = Collections.singletonList(new File(inputFile));
+        final List<File> filesToCheck = List.of(new File(inputFile));
         final String basePath = Path.of("").toAbsolutePath().toString();
 
         final Checker checker = createChecker(parsedConfig);
@@ -471,7 +471,7 @@ public abstract class AbstractModuleTestSupport extends AbstractPathTestSupport 
                 InlineConfigParser.parseWithXmlHeader(inputFile);
         final Configuration parsedConfig =
                 testInputConfiguration.getXmlConfiguration();
-        final List<File> filesToCheck = Collections.singletonList(new File(inputFile));
+        final List<File> filesToCheck = List.of(new File(inputFile));
         final String basePath = Path.of("").toAbsolutePath().toString();
 
         final Checker checker = createChecker(parsedConfig);
@@ -510,7 +510,7 @@ public abstract class AbstractModuleTestSupport extends AbstractPathTestSupport 
                 InlineConfigParser.parseWithXmlHeader(inputFile);
         final Configuration parsedConfig =
                 testInputConfiguration.getXmlConfiguration();
-        final List<File> filesToCheck = Collections.singletonList(new File(inputFile));
+        final List<File> filesToCheck = List.of(new File(inputFile));
         final String basePath = Path.of("").toAbsolutePath().toString();
 
         final Checker checker = createChecker(parsedConfig);
@@ -812,7 +812,7 @@ public abstract class AbstractModuleTestSupport extends AbstractPathTestSupport 
                                                     String file) throws Exception {
         stream.flush();
         stream.reset();
-        final List<File> files = Collections.singletonList(new File(file));
+        final List<File> files = List.of(new File(file));
         final Checker checker = createChecker(config);
         checker.process(files);
         final Map<String, List<String>> actualViolations =

--- a/src/test/java/com/puppycrawl/tools/checkstyle/AbstractXmlTestSupport.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/AbstractXmlTestSupport.java
@@ -26,7 +26,6 @@ import java.io.ByteArrayOutputStream;
 import java.io.File;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.List;
 import java.util.Set;
 import java.util.function.BiPredicate;
@@ -290,7 +289,7 @@ public abstract class AbstractXmlTestSupport extends AbstractModuleTestSupport {
         final XMLLogger logger = new XMLLogger(actualXmlOutput,
                 AbstractAutomaticBean.OutputStreamOptions.CLOSE);
         checker.addListener(logger);
-        final List<File> filesToCheck = Collections.singletonList(new File(configFilePath));
+        final List<File> filesToCheck = List.of(new File(configFilePath));
         checker.process(filesToCheck);
 
         verifyXml(getPath(expectedXmlReportPath), actualXmlOutput);

--- a/src/test/java/com/puppycrawl/tools/checkstyle/CheckerTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/CheckerTest.java
@@ -155,7 +155,7 @@ public class CheckerTest extends AbstractModuleTestSupport {
         checker.destroy();
 
         final File tempFile = createTempFile("junit");
-        checker.process(Collections.singletonList(tempFile));
+        checker.process(List.of(tempFile));
         final SortedSet<Violation> violations = new TreeSet<>();
         violations.add(new Violation(1, 0, "a Bundle", "message.key",
                 new Object[] {"arg"}, null, getClass(), null));
@@ -296,7 +296,7 @@ public class CheckerTest extends AbstractModuleTestSupport {
         checker.addBeforeExecutionFileFilter(filter);
 
         filter.resetFilter();
-        checker.process(Collections.singletonList(new File("dummy.java")));
+        checker.process(List.of(new File("dummy.java")));
         assertWithMessage("Checker.acceptFileStarted() doesn't call filter")
                 .that(filter.wasCalled())
                 .isTrue();
@@ -312,7 +312,7 @@ public class CheckerTest extends AbstractModuleTestSupport {
         checker.removeBeforeExecutionFileFilter(filter);
 
         f2.resetFilter();
-        checker.process(Collections.singletonList(new File("dummy.java")));
+        checker.process(List.of(new File("dummy.java")));
         assertWithMessage("Checker.acceptFileStarted() doesn't call filter")
                 .that(f2.wasCalled())
                 .isTrue();
@@ -757,7 +757,7 @@ public class CheckerTest extends AbstractModuleTestSupport {
         checker.configure(checkerConfig);
         checker.addListener(getBriefUtLogger());
 
-        checker.process(Collections.singletonList(new File("dummy.java")));
+        checker.process(List.of(new File("dummy.java")));
         checker.clearCache();
         // invoke destroy to persist cache
         final PropertyCacheFile cache = TestUtil.getInternalState(checker,
@@ -1124,7 +1124,7 @@ public class CheckerTest extends AbstractModuleTestSupport {
 
         final String filePath = getPath("InputChecker.java");
         try {
-            checker.process(Collections.singletonList(new File(filePath)));
+            checker.process(List.of(new File(filePath)));
             assertWithMessage("Exception is expected").fail();
         }
         catch (CheckstyleException exc) {
@@ -1452,7 +1452,7 @@ public class CheckerTest extends AbstractModuleTestSupport {
         final DummyFileSet fileSet = new DummyFileSet();
         final Checker checker = new Checker();
         checker.addFileSetCheck(fileSet);
-        checker.process(Collections.singletonList(new File("dummy.java")));
+        checker.process(List.of(new File("dummy.java")));
         final List<String> expected =
             Arrays.asList("beginProcessing", "finishProcessing", "destroy");
         assertWithMessage("Method calls were not expected")
@@ -1488,7 +1488,7 @@ public class CheckerTest extends AbstractModuleTestSupport {
         checker.setModuleFactory(factory);
         checker.setupChild(createModuleConfig(DebugAuditAdapter.class));
         // Let's try fire some events
-        checker.process(Collections.singletonList(new File("dummy.java")));
+        checker.process(List.of(new File("dummy.java")));
         assertWithMessage("Checker.fireAuditStarted() doesn't call listener")
                 .that(auditAdapter.wasCalled())
                 .isTrue();
@@ -1511,7 +1511,7 @@ public class CheckerTest extends AbstractModuleTestSupport {
         };
         checker.setModuleFactory(factory);
         checker.setupChild(createModuleConfig(TestBeforeExecutionFileFilter.class));
-        checker.process(Collections.singletonList(new File("dummy.java")));
+        checker.process(List.of(new File("dummy.java")));
         assertWithMessage("Checker.acceptFileStarted() doesn't call listener")
                 .that(fileFilter.wasCalled())
                 .isTrue();
@@ -1629,7 +1629,7 @@ public class CheckerTest extends AbstractModuleTestSupport {
 
         // super.verify does not work here, for we change the logger
         out.flush();
-        final int errs = checker.process(Collections.singletonList(new File(path)));
+        final int errs = checker.process(List.of(new File(path)));
         try (ByteArrayInputStream inputStream =
                 new ByteArrayInputStream(out.toByteArray());
             LineNumberReader lnr = new LineNumberReader(

--- a/src/test/java/com/puppycrawl/tools/checkstyle/ConfigurationLoaderTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/ConfigurationLoaderTest.java
@@ -28,7 +28,6 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Collection;
-import java.util.Collections;
 import java.util.List;
 import java.util.Properties;
 
@@ -443,8 +442,8 @@ public class ConfigurationLoaderTest extends AbstractPathTestSupport {
         final Configuration[] grandchildren = children[0].getChildren();
         final List<String> messages = new ArrayList<>(grandchildren[0].getMessages().values());
         final String expectedKey = "name.invalidPattern";
-        final List<String> expectedMessages = Collections
-                .singletonList("Member ''{0}'' must start with ''m'' (checked pattern ''{1}'').");
+        final List<String> expectedMessages = List
+                .of("Member ''{0}'' must start with ''m'' (checked pattern ''{1}'').");
         assertWithMessage("Messages should contain key: %s", expectedKey)
                 .that(grandchildren[0].getMessages())
                 .containsKey(expectedKey);

--- a/src/test/java/com/puppycrawl/tools/checkstyle/PackageNamesLoaderTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/PackageNamesLoaderTest.java
@@ -79,8 +79,8 @@ public class PackageNamesLoaderTest extends AbstractPathTestSupport {
 
     @Test
     public void testPackagesFile() throws Exception {
-        final Enumeration<URL> enumeration = Collections.enumeration(Collections.singleton(
-                new File(getPath("InputPackageNamesLoaderFile.xml")).toURI().toURL()));
+        final Enumeration<URL> enumeration = Collections.enumeration(
+                Set.of(new File(getPath("InputPackageNamesLoaderFile.xml")).toURI().toURL()));
 
         final Set<String> actualPackageNames = PackageNamesLoader
                 .getPackageNames(new TestUrlsClassLoader(enumeration));
@@ -117,8 +117,8 @@ public class PackageNamesLoaderTest extends AbstractPathTestSupport {
 
     @Test
     public void testPackagesWithDots() throws Exception {
-        final Enumeration<URL> enumeration = Collections.enumeration(Collections.singleton(
-                new File(getPath("InputPackageNamesLoaderWithDots.xml")).toURI().toURL()));
+        final Enumeration<URL> enumeration = Collections.enumeration(
+                Set.of(new File(getPath("InputPackageNamesLoaderWithDots.xml")).toURI().toURL()));
 
         final Set<String> actualPackageNames = PackageNamesLoader
                 .getPackageNames(new TestUrlsClassLoader(enumeration));
@@ -138,8 +138,8 @@ public class PackageNamesLoaderTest extends AbstractPathTestSupport {
 
     @Test
     public void testPackagesWithDotsEx() throws Exception {
-        final Enumeration<URL> enumeration = Collections.enumeration(Collections.singleton(
-                new File(getPath("InputPackageNamesLoaderWithDotsEx.xml")).toURI().toURL()));
+        final Enumeration<URL> enumeration = Collections.enumeration(
+                Set.of(new File(getPath("InputPackageNamesLoaderWithDotsEx.xml")).toURI().toURL()));
 
         final Set<String> actualPackageNames = PackageNamesLoader
                 .getPackageNames(new TestUrlsClassLoader(enumeration));
@@ -160,8 +160,8 @@ public class PackageNamesLoaderTest extends AbstractPathTestSupport {
 
     @Test
     public void testPackagesWithSaxException() throws Exception {
-        final Enumeration<URL> enumeration = Collections.enumeration(Collections.singleton(
-                new File(getPath("InputPackageNamesLoaderNotXml.java")).toURI().toURL()));
+        final Enumeration<URL> enumeration = Collections.enumeration(
+                Set.of(new File(getPath("InputPackageNamesLoaderNotXml.java")).toURI().toURL()));
 
         try {
             PackageNamesLoader.getPackageNames(new TestUrlsClassLoader(enumeration));
@@ -186,7 +186,8 @@ public class PackageNamesLoaderTest extends AbstractPathTestSupport {
 
         final URL url = URL.of(URI.create("test://dummy"), handler);
 
-        final Enumeration<URL> enumeration = Collections.enumeration(Collections.singleton(url));
+        final Enumeration<URL> enumeration = Collections.enumeration(
+                Set.of(url));
 
         try {
             PackageNamesLoader.getPackageNames(new TestUrlsClassLoader(enumeration));
@@ -239,8 +240,8 @@ public class PackageNamesLoaderTest extends AbstractPathTestSupport {
 
     @Test
     public void testMapping() throws Exception {
-        final Enumeration<URL> enumeration = Collections.enumeration(Collections.singleton(
-                new File(getPath("InputPackageNamesLoader1.xml")).toURI().toURL()));
+        final Enumeration<URL> enumeration = Collections.enumeration(
+                Set.of(new File(getPath("InputPackageNamesLoader1.xml")).toURI().toURL()));
 
         final Set<String> actualPackageNames = PackageNamesLoader
                 .getPackageNames(new TestUrlsClassLoader(enumeration));
@@ -252,8 +253,8 @@ public class PackageNamesLoaderTest extends AbstractPathTestSupport {
 
     @Test
     public void testMapping2() throws Exception {
-        final Enumeration<URL> enumeration = Collections.enumeration(Collections.singleton(
-                new File(getPath("InputPackageNamesLoader2.xml")).toURI().toURL()));
+        final Enumeration<URL> enumeration = Collections.enumeration(
+                Set.of(new File(getPath("InputPackageNamesLoader2.xml")).toURI().toURL()));
 
         final Set<String> actualPackageNames = PackageNamesLoader
                 .getPackageNames(new TestUrlsClassLoader(enumeration));

--- a/src/test/java/com/puppycrawl/tools/checkstyle/PackageObjectFactoryTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/PackageObjectFactoryTest.java
@@ -39,6 +39,7 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.LinkedHashSet;
+import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Optional;
@@ -357,7 +358,7 @@ public class PackageObjectFactoryTest {
     public void testCreateCheckWithPartialPackageNameByBruteForce() throws Exception {
         final String checkName = "checks.annotation.AnnotationLocation";
         final PackageObjectFactory packageObjectFactory = new PackageObjectFactory(
-            new HashSet<>(Collections.singletonList(BASE_PACKAGE)),
+            new HashSet<>(List.of(BASE_PACKAGE)),
             Thread.currentThread().getContextClassLoader(), TRY_IN_ALL_REGISTERED_PACKAGES);
         final AnnotationLocationCheck check = (AnnotationLocationCheck) packageObjectFactory
                 .createModule(checkName);
@@ -368,7 +369,7 @@ public class PackageObjectFactoryTest {
 
     @Test
     public void testJoinPackageNamesWithClassName() throws Exception {
-        final Set<String> packages = Collections.singleton("test");
+        final Set<String> packages = Set.of("test");
         final String className = "SomeClass";
         final String actual = TestUtil.invokeStaticMethod(
                 PackageObjectFactory.class, "joinPackageNamesWithClassName", String.class,
@@ -456,7 +457,7 @@ public class PackageObjectFactoryTest {
         final String name = "String";
         final String packageName = "java.lang";
         final ClassLoader classLoader = Thread.currentThread().getContextClassLoader();
-        final Set<String> packages = Collections.singleton(packageName);
+        final Set<String> packages = Set.of(packageName);
         final PackageObjectFactory objectFactory = new PackageObjectFactory(packages, classLoader,
                 TRY_IN_ALL_REGISTERED_PACKAGES);
 
@@ -488,7 +489,7 @@ public class PackageObjectFactoryTest {
     @Test
     public void testCreateObjectWithNameContainingPackageSeparator() throws Exception {
         final ClassLoader classLoader = ClassLoader.getSystemClassLoader();
-        final Set<String> packages = Collections.singleton(BASE_PACKAGE);
+        final Set<String> packages = Set.of(BASE_PACKAGE);
         final PackageObjectFactory objectFactory =
             new PackageObjectFactory(packages, classLoader, TRY_IN_ALL_REGISTERED_PACKAGES);
 
@@ -507,7 +508,7 @@ public class PackageObjectFactoryTest {
     @Test
     public void testCreateObjectWithNameContainingPackageSeparatorWithoutSearch() throws Exception {
         final ClassLoader classLoader = ClassLoader.getSystemClassLoader();
-        final Set<String> packages = Collections.singleton(BASE_PACKAGE);
+        final Set<String> packages = Set.of(BASE_PACKAGE);
         final PackageObjectFactory objectFactory =
             new PackageObjectFactory(packages, classLoader, TRY_IN_ALL_REGISTERED_PACKAGES);
 
@@ -530,7 +531,7 @@ public class PackageObjectFactoryTest {
     @Test
     public void testCreateModuleWithTryInAllRegisteredPackages() {
         final ClassLoader classLoader = ClassLoader.getSystemClassLoader();
-        final Set<String> packages = Collections.singleton(BASE_PACKAGE);
+        final Set<String> packages = Set.of(BASE_PACKAGE);
         final PackageObjectFactory objectFactory =
             new PackageObjectFactory(packages, classLoader, SEARCH_REGISTERED_PACKAGES);
         final CheckstyleException ex =

--- a/src/test/java/com/puppycrawl/tools/checkstyle/TreeWalkerTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/TreeWalkerTest.java
@@ -35,7 +35,6 @@ import java.nio.file.StandardCopyOption;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
@@ -674,7 +673,7 @@ public class TreeWalkerTest extends AbstractModuleTestSupport {
         treeWalkerConfig.addChild(configuration1);
 
         final List<File> files =
-                Collections.singletonList(new File(getPath("InputTreeWalker2.java")));
+                List.of(new File(getPath("InputTreeWalker2.java")));
         final Checker checker = createChecker(treeWalkerConfig);
 
         try {
@@ -735,7 +734,7 @@ public class TreeWalkerTest extends AbstractModuleTestSupport {
         final Checker checker = createChecker(config);
         final Map<String, List<String>> expectedViolation = new HashMap<>();
         expectedViolation.put(getPath("InputTreeWalkerProperFileExtension.java"),
-                Collections.singletonList(
+                List.of(
                         "10:27: " + getCheckMessage(ConstantNameCheck.class,
                         MSG_INVALID_PATTERN, "k", "^[A-Z][A-Z0-9]*(_[A-Z0-9]+)*$")));
         verify(checker, files, expectedViolation);

--- a/src/test/java/com/puppycrawl/tools/checkstyle/api/AbstractCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/api/AbstractCheckTest.java
@@ -25,9 +25,9 @@ import static com.puppycrawl.tools.checkstyle.internal.utils.TestUtil.getExpecte
 import java.io.File;
 import java.nio.charset.Charset;
 import java.util.Arrays;
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.Iterator;
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.SortedSet;
@@ -319,7 +319,7 @@ public class AbstractCheckTest extends AbstractModuleTestSupport {
         final ViolationCheck check = new ViolationCheck();
         check.configure(new DefaultConfiguration("check"));
         final File file = new File("fileName");
-        final FileText theText = new FileText(file, Collections.singletonList("test123"));
+        final FileText theText = new FileText(file, List.of("test123"));
 
         check.setFileContents(new FileContents(theText));
         check.clearViolations();
@@ -361,7 +361,7 @@ public class AbstractCheckTest extends AbstractModuleTestSupport {
         final ViolationAstCheck check = new ViolationAstCheck();
         check.configure(new DefaultConfiguration("check"));
         final File file = new File("fileName");
-        final FileText theText = new FileText(file, Collections.singletonList("test123"));
+        final FileText theText = new FileText(file, List.of("test123"));
 
         check.setFileContents(new FileContents(theText));
         check.clearViolations();

--- a/src/test/java/com/puppycrawl/tools/checkstyle/api/FileContentsTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/api/FileContentsTest.java
@@ -55,12 +55,12 @@ public class FileContentsTest {
     public void testIsLineBlank() {
         assertWithMessage("Invalid result")
                 .that(new FileContents(
-                        new FileText(new File("filename"), Collections.singletonList("123")))
+                        new FileText(new File("filename"), List.of("123")))
                                 .lineIsBlank(0))
                 .isFalse();
         assertWithMessage("Invalid result")
                 .that(new FileContents(new FileText(new File("filename"),
-                        Collections.singletonList("")))
+                        List.of("")))
                         .lineIsBlank(0))
                 .isTrue();
     }
@@ -69,12 +69,12 @@ public class FileContentsTest {
     public void testLineIsComment() {
         assertWithMessage("Invalid result")
                 .that(new FileContents(
-                        new FileText(new File("filename"), Collections.singletonList("123")))
+                        new FileText(new File("filename"), List.of("123")))
                                 .lineIsComment(0))
                 .isFalse();
         assertWithMessage("Invalid result")
                 .that(new FileContents(
-                        new FileText(new File("filename"), Collections.singletonList(" // abc")))
+                        new FileText(new File("filename"), List.of(" // abc")))
                                 .lineIsComment(0))
                 .isTrue();
     }
@@ -103,7 +103,7 @@ public class FileContentsTest {
     public void testSinglelineCommentNotIntersect() {
         // just to make UT coverage 100%
         final FileContents fileContents = new FileContents(
-                new FileText(new File("filename"), Collections.singletonList("  //  ")));
+                new FileText(new File("filename"), List.of("  //  ")));
         fileContents.reportSingleLineComment(1, 2);
         assertWithMessage("Should return false when there is no intersection")
                 .that(fileContents.hasIntersectionWithComment(1, 0, 1, 1))
@@ -114,7 +114,7 @@ public class FileContentsTest {
     public void testSinglelineCommentIntersect() {
         // just to make UT coverage 100%
         final FileContents fileContents = new FileContents(
-                new FileText(new File("filename"), Collections.singletonList("  //   ")));
+                new FileText(new File("filename"), List.of("  //   ")));
         fileContents.reportSingleLineComment("type", 1, 2);
         assertWithMessage("Should return true when comments intersect")
                 .that(fileContents.hasIntersectionWithComment(1, 5, 1, 6))
@@ -124,7 +124,7 @@ public class FileContentsTest {
     @Test
     public void testReportCppComment() {
         final FileContents fileContents = new FileContents(
-                new FileText(new File("filename"), Collections.singletonList("   //  ")));
+                new FileText(new File("filename"), List.of("   //  ")));
         fileContents.reportSingleLineComment(1, 2);
         final Map<Integer, TextBlock> cppComments = fileContents.getSingleLineComments();
 
@@ -148,7 +148,7 @@ public class FileContentsTest {
     @Test
     public void testReportComment() {
         final FileContents fileContents = new FileContents(
-                new FileText(new File("filename"), Collections.singletonList("  //   ")));
+                new FileText(new File("filename"), List.of("  //   ")));
         fileContents.reportBlockComment("type", 1, 2, 1, 2);
         final Map<Integer, List<TextBlock>> comments = fileContents.getBlockComments();
 
@@ -160,7 +160,7 @@ public class FileContentsTest {
     @Test
     public void testReportBlockCommentSameLine() {
         final FileContents fileContents = new FileContents(
-                new FileText(new File("filename"), Collections.singletonList("/* a */ /* b */ ")));
+                new FileText(new File("filename"), List.of("/* a */ /* b */ ")));
         fileContents.reportBlockComment("type", 1, 0, 1, 6);
         fileContents.reportBlockComment("type", 1, 8, 1, 14);
         final Map<Integer, List<TextBlock>> comments = fileContents.getBlockComments();
@@ -182,7 +182,7 @@ public class FileContentsTest {
 
         assertWithMessage("Invalid comment")
                 .that(comments.get(1).toString())
-                .isEqualTo(Collections.singletonList(
+                .isEqualTo(List.of(
                     new Comment(new String[] {"/*", "c", "*/"}, 0, 3, 1)).toString()
             );
     }
@@ -235,7 +235,7 @@ public class FileContentsTest {
     @Test
     public void testReportJavadocComment() {
         final FileContents fileContents = new FileContents(
-                new FileText(new File("filename"), Collections.singletonList("  /** */   ")));
+                new FileText(new File("filename"), List.of("  /** */   ")));
         fileContents.reportBlockComment(1, 2, 1, 6);
         final TextBlock comment = fileContents.getJavadocBefore(2);
 
@@ -247,7 +247,7 @@ public class FileContentsTest {
     @Test
     public void testReportJavadocComment2() {
         final FileContents fileContents = new FileContents(
-                new FileText(new File("filename"), Collections.singletonList("  /** */   ")));
+                new FileText(new File("filename"), List.of("  /** */   ")));
         fileContents.reportBlockComment(1, 2, 1, 6);
         final TextBlock comment = fileContents.getJavadocBefore(2);
 
@@ -265,7 +265,7 @@ public class FileContentsTest {
     public void testInPackageInfo() {
         final FileContents fileContents = new FileContents(new FileText(
                 new File("package-info.java"),
-                Collections.singletonList("  //   ")));
+                List.of("  //   ")));
 
         assertWithMessage("Should return true when in package info")
                 .that(fileContents.inPackageInfo())
@@ -281,7 +281,7 @@ public class FileContentsTest {
     public void testNotInPackageInfo() {
         final FileContents fileContents = new FileContents(new FileText(
                 new File("some-package-info.java"),
-                Collections.singletonList("  //   ")));
+                List.of("  //   ")));
 
         assertWithMessage("Should return false when not in package info")
                 .that(fileContents.inPackageInfo())
@@ -291,7 +291,7 @@ public class FileContentsTest {
     @Test
     public void testGetJavadocBefore() {
         final FileContents fileContents = new FileContents(
-                new FileText(new File("filename"), Collections.singletonList("    ")));
+                new FileText(new File("filename"), List.of("    ")));
         final Map<Integer, TextBlock> javadoc = new HashMap<>();
         javadoc.put(0, new Comment(new String[] {"// "}, 2, 1, 2));
         TestUtil.setInternalState(fileContents, "javadocComments", javadoc);
@@ -324,7 +324,7 @@ public class FileContentsTest {
         final Map<Integer, List<TextBlock>> clangComments = TestUtil.getInternalStateMapIntegerList(
                 fileContents, "clangComments");
         final TextBlock textBlock = new Comment(new String[] {""}, 1, 1, 1);
-        clangComments.put(1, Collections.singletonList(textBlock));
+        clangComments.put(1, List.of(textBlock));
         clangComments.put(2, Collections.emptyList());
 
         assertWithMessage("Invalid results")

--- a/src/test/java/com/puppycrawl/tools/checkstyle/api/FileTextTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/api/FileTextTest.java
@@ -146,7 +146,7 @@ public class FileTextTest extends AbstractPathTestSupport {
 
     @Test
     public void testLines() throws IOException {
-        final List<String> lines = Collections.singletonList("abc");
+        final List<String> lines = List.of("abc");
         final FileText fileText = new FileText(new File(getPath("InputFileTextImportControl.xml")),
                 lines);
         assertWithMessage("Invalid line")

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/TranslationCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/TranslationCheckTest.java
@@ -29,7 +29,7 @@ import java.io.IOException;
 import java.io.Writer;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
-import java.util.Collections;
+import java.util.List;
 import java.util.Set;
 import java.util.SortedSet;
 import java.util.TreeSet;
@@ -185,9 +185,9 @@ public class TranslationCheckTest extends AbstractXmlTestSupport {
         final String secondErrorMessage = getCheckMessage(MSG_KEY, "anotherKey");
 
         verify(checker, propertyFiles, ImmutableMap.of(
-            ":1", Collections.singletonList(" " + firstErrorMessage),
+            ":1", List.of(" " + firstErrorMessage),
             "InputTranslationCheckFireErrors_de.properties",
-                Collections.singletonList(line + secondErrorMessage)));
+                List.of(line + secondErrorMessage)));
 
         verifyXml(getPath("ExpectedTranslationLog.xml"), out,
             TranslationCheckTest::isFilenamesEqual,

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/coding/EqualsHashCodeCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/coding/EqualsHashCodeCheckTest.java
@@ -25,7 +25,6 @@ import static com.puppycrawl.tools.checkstyle.checks.coding.EqualsHashCodeCheck.
 
 import java.io.File;
 import java.util.Arrays;
-import java.util.Collections;
 import java.util.List;
 
 import org.junit.jupiter.api.Test;
@@ -73,10 +72,10 @@ public class EqualsHashCodeCheckTest
         final DefaultConfiguration checkConfig =
             createModuleConfig(EqualsHashCodeCheck.class);
 
-        final List<String> expectedFirstInputErrors = Collections.singletonList(
+        final List<String> expectedFirstInputErrors = List.of(
             "10:5: " + getCheckMessage(MSG_KEY_EQUALS)
         );
-        final List<String> expectedSecondInputErrors = Collections.singletonList(
+        final List<String> expectedSecondInputErrors = List.of(
             "37:13: " + getCheckMessage(MSG_KEY_HASHCODE)
         );
         final List<String> expectedThirdInputErrors =

--- a/src/test/java/com/puppycrawl/tools/checkstyle/filters/SuppressWithNearbyCommentFilterTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/filters/SuppressWithNearbyCommentFilterTest.java
@@ -24,7 +24,6 @@ import static com.puppycrawl.tools.checkstyle.checks.naming.AbstractNameCheck.MS
 
 import java.io.File;
 import java.util.Arrays;
-import java.util.Collections;
 import java.util.List;
 
 import org.junit.jupiter.api.Test;
@@ -466,7 +465,7 @@ public class SuppressWithNearbyCommentFilterTest
     public void testAcceptNullViolation() {
         final SuppressWithNearbyCommentFilter filter = new SuppressWithNearbyCommentFilter();
         final FileContents contents = new FileContents(new FileText(new File("filename"),
-                Collections.singletonList("//SUPPRESS CHECKSTYLE ignore")));
+                List.of("//SUPPRESS CHECKSTYLE ignore")));
         contents.reportSingleLineComment(1, 0);
         final TreeWalkerAuditEvent auditEvent =
                 new TreeWalkerAuditEvent(contents, null, null, null);

--- a/src/test/java/com/puppycrawl/tools/checkstyle/filters/SuppressionXpathFilterTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/filters/SuppressionXpathFilterTest.java
@@ -23,7 +23,6 @@ import static com.google.common.truth.Truth.assertWithMessage;
 import static com.puppycrawl.tools.checkstyle.checks.coding.IllegalTokenTextCheck.MSG_KEY;
 import static com.puppycrawl.tools.checkstyle.checks.naming.AbstractNameCheck.MSG_INVALID_PATTERN;
 
-import java.util.Collections;
 import java.util.Set;
 
 import org.junit.jupiter.api.Test;
@@ -152,7 +151,7 @@ public class SuppressionXpathFilterTest extends AbstractModuleTestSupport {
         final boolean optional = false;
         final String fileName = getPath("InputSuppressionXpathFilterIdAndQuery.xml");
         final SuppressionXpathFilter filter = createSuppressionXpathFilter(fileName, optional);
-        final Set<String> expected = Collections.singleton(fileName);
+        final Set<String> expected = Set.of(fileName);
         final Set<String> actual = filter.getExternalResourceLocations();
         assertWithMessage("Invalid external resource")
             .that(actual)

--- a/src/test/java/com/puppycrawl/tools/checkstyle/internal/CommitValidationTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/internal/CommitValidationTest.java
@@ -69,7 +69,7 @@ import org.junit.jupiter.api.Test;
 public class CommitValidationTest {
 
     private static final List<String> USERS_EXCLUDED_FROM_VALIDATION =
-            Collections.singletonList("dependabot[bot]");
+            List.of("dependabot[bot]");
 
     private static final String ISSUE_COMMIT_MESSAGE_REGEX_PATTERN = "^Issue #\\d+: .*$";
     private static final String PR_COMMIT_MESSAGE_REGEX_PATTERN = "^Pull #\\d+: .*$";

--- a/src/test/java/com/puppycrawl/tools/checkstyle/internal/testmodules/CheckstyleAntTaskStub.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/internal/testmodules/CheckstyleAntTaskStub.java
@@ -21,7 +21,6 @@ package com.puppycrawl.tools.checkstyle.internal.testmodules;
 
 import java.io.File;
 import java.io.Serial;
-import java.util.Collections;
 import java.util.List;
 
 import com.puppycrawl.tools.checkstyle.ant.CheckstyleAntTask;
@@ -30,7 +29,7 @@ public class CheckstyleAntTaskStub extends CheckstyleAntTask {
 
     @Override
     protected List<File> scanFileSets() {
-        return Collections.singletonList(new MockFile());
+        return List.of(new MockFile());
     }
 
     private static final class MockFile extends File {

--- a/src/test/java/com/puppycrawl/tools/checkstyle/utils/ModuleReflectionUtilTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/utils/ModuleReflectionUtilTest.java
@@ -25,7 +25,6 @@ import static com.puppycrawl.tools.checkstyle.internal.utils.TestUtil.isUtilsCla
 
 import java.io.File;
 import java.io.IOException;
-import java.util.Collections;
 import java.util.List;
 import java.util.Set;
 
@@ -87,7 +86,7 @@ public class ModuleReflectionUtilTest {
     @Test
     public void testGetCheckStyleModules() throws IOException {
         final ClassLoader classLoader = ClassLoader.getSystemClassLoader();
-        final Set<String> packages = Collections.singleton(BASE_PACKAGE + ".checks.javadoc.utils");
+        final Set<String> packages = Set.of(BASE_PACKAGE + ".checks.javadoc.utils");
 
         assertWithMessage("specified package has no checkstyle modules")
                 .that(ModuleReflectionUtil.getCheckstyleModules(packages, classLoader))

--- a/src/test/java/com/puppycrawl/tools/checkstyle/xpath/XpathQueryGeneratorTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/xpath/XpathQueryGeneratorTest.java
@@ -24,7 +24,6 @@ import static com.google.common.truth.Truth.assertWithMessage;
 import java.io.File;
 import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
-import java.util.Collections;
 import java.util.List;
 
 import org.junit.jupiter.api.BeforeEach;
@@ -132,7 +131,7 @@ public class XpathQueryGeneratorTest extends AbstractModuleTestSupport {
         final XpathQueryGenerator queryGenerator = new XpathQueryGenerator(rootAst, lineNumber,
                 columnNumber, fileText, DEFAULT_TAB_WIDTH);
         final List<String> actual = queryGenerator.generate();
-        final List<String> expected = Collections.singletonList(
+        final List<String> expected = List.of(
             "/COMPILATION_UNIT/CLASS_DEF[./IDENT[@text='InputXpathQueryGenerator']]"
                     + "/OBJBLOCK/METHOD_DEF[./IDENT[@text='Label']]/SLIST/LITERAL_SWITCH/LCURLY");
         assertWithMessage("Generated queries do not match expected ones")
@@ -147,7 +146,7 @@ public class XpathQueryGeneratorTest extends AbstractModuleTestSupport {
         final XpathQueryGenerator queryGenerator = new XpathQueryGenerator(rootAst, lineNumber,
                 columnNumber, fileText, DEFAULT_TAB_WIDTH);
         final List<String> actual = queryGenerator.generate();
-        final List<String> expected = Collections.singletonList(
+        final List<String> expected = List.of(
             "/COMPILATION_UNIT/CLASS_DEF[./IDENT[@text='InputXpathQueryGenerator']]/OBJBLOCK"
                 + "/INSTANCE_INIT/SLIST/RCURLY");
         assertWithMessage("Generated queries do not match expected ones")
@@ -179,7 +178,7 @@ public class XpathQueryGeneratorTest extends AbstractModuleTestSupport {
         final XpathQueryGenerator queryGenerator = new XpathQueryGenerator(rootAst, lineNumber,
                 columnNumber, fileText, DEFAULT_TAB_WIDTH);
         final List<String> actual = queryGenerator.generate();
-        final List<String> expected = Collections.singletonList(
+        final List<String> expected = List.of(
             "/COMPILATION_UNIT/CLASS_DEF[./IDENT[@text='InputXpathQueryGenerator']]/OBJBLOCK"
                 + "/METHOD_DEF[./IDENT[@text='callSomeMethod']]/LPAREN");
         assertWithMessage("Generated queries do not match expected ones")
@@ -221,7 +220,7 @@ public class XpathQueryGeneratorTest extends AbstractModuleTestSupport {
         final XpathQueryGenerator queryGenerator = new XpathQueryGenerator(rootAst, lineNumber,
                 columnNumber, fileText, DEFAULT_TAB_WIDTH);
         final List<String> actual = queryGenerator.generate();
-        final List<String> expected = Collections.singletonList(
+        final List<String> expected = List.of(
             "/COMPILATION_UNIT/IMPORT[./DOT/IDENT[@text='File']]");
         assertWithMessage("Generated queries do not match expected ones")
             .that(actual)
@@ -266,7 +265,7 @@ public class XpathQueryGeneratorTest extends AbstractModuleTestSupport {
         final XpathQueryGenerator queryGenerator = new XpathQueryGenerator(rootAst, lineNumber,
                 columnNumber, fileText, DEFAULT_TAB_WIDTH);
         final List<String> actual = queryGenerator.generate();
-        final List<String> expected = Collections.singletonList(
+        final List<String> expected = List.of(
             "/COMPILATION_UNIT/CLASS_DEF[./IDENT[@text='InputXpathQueryGenerator']]"
                     + "/OBJBLOCK/METHOD_DEF[./IDENT[@text='Label']]/SLIST/LITERAL_SWITCH");
         assertWithMessage("Generated queries do not match expected ones")
@@ -321,7 +320,7 @@ public class XpathQueryGeneratorTest extends AbstractModuleTestSupport {
         final XpathQueryGenerator queryGenerator = new XpathQueryGenerator(rootAst, lineNumber,
                 columnNumber, fileText, DEFAULT_TAB_WIDTH);
         final List<String> actual = queryGenerator.generate();
-        final List<String> expected = Collections.singletonList(
+        final List<String> expected = List.of(
             "/COMPILATION_UNIT/CLASS_DEF"
                 + "[./IDENT[@text='InputXpathQueryGenerator']]/OBJBLOCK/METHOD_DEF["
                 + "./IDENT[@text='foo']]/SLIST/LITERAL_FOR/FOR_ITERATOR/ELIST/COMMA");
@@ -354,7 +353,7 @@ public class XpathQueryGeneratorTest extends AbstractModuleTestSupport {
         final XpathQueryGenerator queryGenerator = new XpathQueryGenerator(rootAst, lineNumber,
                 columnNumber, fileText, DEFAULT_TAB_WIDTH);
         final List<String> actual = queryGenerator.generate();
-        final List<String> expected = Collections.singletonList(
+        final List<String> expected = List.of(
                 "/COMPILATION_UNIT/IMPORT[./DOT/IDENT[@text='JToolBar']]");
         assertWithMessage("Generated queries do not match expected ones")
             .that(actual)
@@ -368,7 +367,7 @@ public class XpathQueryGeneratorTest extends AbstractModuleTestSupport {
         final XpathQueryGenerator queryGenerator = new XpathQueryGenerator(rootAst, lineNumber,
                 columnNumber, fileText, DEFAULT_TAB_WIDTH);
         final List<String> actual = queryGenerator.generate();
-        final List<String> expected = Collections.singletonList(
+        final List<String> expected = List.of(
                 "/COMPILATION_UNIT/IMPORT[./DOT/IDENT[@text='Iterator']]");
         assertWithMessage("Generated queries do not match expected ones")
             .that(actual)
@@ -382,7 +381,7 @@ public class XpathQueryGeneratorTest extends AbstractModuleTestSupport {
         final XpathQueryGenerator queryGenerator = new XpathQueryGenerator(rootAst, lineNumber,
                 columnNumber, fileText, DEFAULT_TAB_WIDTH);
         final List<String> actual = queryGenerator.generate();
-        final List<String> expected = Collections.singletonList(
+        final List<String> expected = List.of(
                 "/COMPILATION_UNIT/IMPORT/DOT[./IDENT[@text='JToolBar']]/DOT/IDENT[@text='javax']");
         assertWithMessage("Generated queries do not match expected ones")
             .that(actual)
@@ -396,7 +395,7 @@ public class XpathQueryGeneratorTest extends AbstractModuleTestSupport {
         final XpathQueryGenerator queryGenerator = new XpathQueryGenerator(rootAst, lineNumber,
                 columnNumber, fileText, DEFAULT_TAB_WIDTH);
         final List<String> actual = queryGenerator.generate();
-        final List<String> expected = Collections.singletonList(
+        final List<String> expected = List.of(
             "/COMPILATION_UNIT/CLASS_DEF/IDENT[@text='InputXpathQueryGenerator']");
         assertWithMessage("Generated queries do not match expected ones")
             .that(actual)
@@ -471,7 +470,7 @@ public class XpathQueryGeneratorTest extends AbstractModuleTestSupport {
         final XpathQueryGenerator queryGenerator = new XpathQueryGenerator(detailAst, lineNumber,
                 columnNumber, testFileText, tabWidth);
         final List<String> actual = queryGenerator.generate();
-        final List<String> expected = Collections.singletonList(
+        final List<String> expected = List.of(
                 "/COMPILATION_UNIT/CLASS_DEF"
                     + "[./IDENT[@text='InputXpathQueryGeneratorTabWidth']]/OBJBLOCK"
                     + "/METHOD_DEF[./IDENT[@text='tabAfterMe']]/SLIST");
@@ -493,7 +492,7 @@ public class XpathQueryGeneratorTest extends AbstractModuleTestSupport {
         final XpathQueryGenerator queryGenerator = new XpathQueryGenerator(detailAst, lineNumber,
                 columnNumber, testFileText, tabWidth);
         final List<String> actual = queryGenerator.generate();
-        final List<String> expected = Collections.singletonList(
+        final List<String> expected = List.of(
                 "/COMPILATION_UNIT/CLASS_DEF[./IDENT[@text='InputXpathQueryGeneratorTabWidth']]"
                     + "/OBJBLOCK/VARIABLE_DEF[./IDENT[@text='endLineTab']]/SEMI");
         assertWithMessage("Generated queries do not match expected ones")
@@ -508,7 +507,7 @@ public class XpathQueryGeneratorTest extends AbstractModuleTestSupport {
         final XpathQueryGenerator queryGenerator = new XpathQueryGenerator(rootAst, lineNumber,
                 columnNumber, TokenTypes.CLASS_DEF, fileText, DEFAULT_TAB_WIDTH);
         final List<String> actual = queryGenerator.generate();
-        final List<String> expected = Collections.singletonList(
+        final List<String> expected = List.of(
                 "/COMPILATION_UNIT/CLASS_DEF[./IDENT[@text='InputXpathQueryGenerator']]");
         assertWithMessage("Generated queries do not match expected ones")
             .that(actual)
@@ -599,7 +598,7 @@ public class XpathQueryGeneratorTest extends AbstractModuleTestSupport {
         final XpathQueryGenerator queryGenerator = new XpathQueryGenerator(detailAst,
                 lineNumber, columnNumber, testFileText, tabWidth);
         final List<String> actual = queryGenerator.generate();
-        final List<String> expected = Collections.singletonList(
+        final List<String> expected = List.of(
             "/COMPILATION_UNIT/CLASS_DEF"
                     + "[./IDENT[@text='InputXpathQueryGeneratorTextBlock']]/OBJBLOCK/"
                     + "VARIABLE_DEF[./IDENT[@text='testOne']]/ASSIGN/EXPR/"
@@ -626,7 +625,7 @@ public class XpathQueryGeneratorTest extends AbstractModuleTestSupport {
         final XpathQueryGenerator queryGenerator = new XpathQueryGenerator(detailAst,
                 lineNumber, columnNumber, testFileText, tabWidth);
         final List<String> actual = queryGenerator.generate();
-        final List<String> expected = Collections.singletonList(
+        final List<String> expected = List.of(
                 "/COMPILATION_UNIT/CLASS_DEF"
                         + "[./IDENT[@text='InputXpathQueryGeneratorTextBlockNewLine']]/OBJBLOCK/"
                         + "VARIABLE_DEF[./IDENT[@text='testOne']]/ASSIGN/EXPR/"
@@ -653,7 +652,7 @@ public class XpathQueryGeneratorTest extends AbstractModuleTestSupport {
         final XpathQueryGenerator queryGenerator = new XpathQueryGenerator(detailAst,
                 lineNumber, columnNumber, testFileText, tabWidth);
         final List<String> actual = queryGenerator.generate();
-        final List<String> expected = Collections.singletonList(
+        final List<String> expected = List.of(
                 "/COMPILATION_UNIT/CLASS_DEF"
                         + "[./IDENT[@text='InputXpathQueryGeneratorTextBlockCrlf']]/OBJBLOCK/"
                         + "VARIABLE_DEF[./IDENT[@text='testOne']]/ASSIGN/EXPR/"


### PR DESCRIPTION
### Pull #18672: Add `JavaLangAPIs`

- https://docs.openrewrite.org/recipes/java/migrate/util/migratecollectionssingletonlist

```
src/main/java/com/puppycrawl/tools/checkstyle/checks/SuppressWarningsHolder.java by:
[WARNING]     org.openrewrite.java.migrate.util.JavaUtilAPIs
[WARNING]         org.openrewrite.java.migrate.util.MigrateCollectionsSingletonList
[WARNING] Changes have been made to src/main/java/com/puppycrawl/tools/checkstyle/utils/UnmodifiableCollectionUtil.java by:
[WARNING]     org.openrewrite.java.migrate.util.JavaUtilAPIs
[WARNING]         org.openrewrite.java.migrate.util.MigrateCollectionsSingletonSet
```