### PR TITLE
update COMMA symbol of JavadocCommentsTokenTypes to new AST format

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/api/JavadocCommentsTokenTypes.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/api/JavadocCommentsTokenTypes.java
@@ -1113,6 +1113,31 @@ public final class JavadocCommentsTokenTypes {
 
     /**
      * Comma symbol {@code , }.
+     *
+     * <p><b>Example:</b></p>
+     * <pre>{@code * @see #method(int, int)}</pre>
+     *
+     * <p><b>Tree:</b></p>
+     * <pre>{@code
+     * |--LEADING_ASTERISK ->  *
+     * |--TEXT ->
+     * `--JAVADOC_BLOCK_TAG -> JAVADOC_BLOCK_TAG
+     *     `--SEE_BLOCK_TAG -> SEE_BLOCK_TAG
+     *         |--AT_SIGN -> @
+     *         |--TAG_NAME -> see
+     *         |--TEXT ->
+     *         |--REFERENCE -> REFERENCE
+     *         |   |--HASH -> #
+     *         |   `--MEMBER_REFERENCE -> MEMBER_REFERENCE
+     *         |       |--IDENTIFIER -> method
+     *         |       |--LPAREN -> (
+     *         |       |--PARAMETER_TYPE_LIST -> PARAMETER_TYPE_LIST
+     *         |       |   |--PARAMETER_TYPE -> int
+     *         |       |   |--COMMA -> ,
+     *         |       |   |--TEXT ->
+     *         |       |   `--PARAMETER_TYPE -> int
+     *         |       `--RPAREN -> )
+     * }</pre>
      */
     public static final int COMMA = JavadocCommentsLexer.COMMA;
 


### PR DESCRIPTION
Part of [#17882]( https://github.com/checkstyle/checkstyle/issues/17882)

Test.java
```
/**
 * @see #method(int, int)
 */
class Test{
}
```

Full AST:
```
|--TEXT -> /** 
|--NEWLINE -> \n 
|--LEADING_ASTERISK ->  * 
|--TEXT ->   
`--JAVADOC_BLOCK_TAG -> JAVADOC_BLOCK_TAG 
    `--SEE_BLOCK_TAG -> SEE_BLOCK_TAG 
        |--AT_SIGN -> @ 
        |--TAG_NAME -> see 
        |--TEXT ->   
        |--REFERENCE -> REFERENCE 
        |   |--HASH -> # 
        |   `--MEMBER_REFERENCE -> MEMBER_REFERENCE 
        |       |--IDENTIFIER -> method 
        |       |--LPAREN -> ( 
        |       |--PARAMETER_TYPE_LIST -> PARAMETER_TYPE_LIST 
        |       |   |--PARAMETER_TYPE -> int 
        |       |   |--COMMA -> , 
        |       |   |--TEXT ->   
        |       |   `--PARAMETER_TYPE -> int 
        |       `--RPAREN -> ) 
        |--NEWLINE -> \n 
        |--LEADING_ASTERISK ->  * 
        `--DESCRIPTION -> DESCRIPTION 
            |--TEXT -> / 
            |--NEWLINE -> \n 
            |--TEXT -> class Test{ 
            |--NEWLINE -> \n 
            |--NEWLINE -> \n 
            `--TEXT -> } 
```
