### PR TITLE
Issue #7531: doc: added warning about AST changes with comment-aware checks

### DIFF
--- a/src/site/xdoc/cmdline.xml.vm
+++ b/src/site/xdoc/cmdline.xml.vm
@@ -1009,6 +1009,15 @@ class Test {
   </p>
 </div>
 
+<p>
+  Note: The generated XPath query is specific to the configuration used during generation.
+  If you later add "comment-aware" checks (like <code>TodoComment</code>) to your
+  configuration, Checkstyle will insert comment nodes into the AST. This changes the
+  tree structure and may cause strict XPath queries (like those relying on child counts
+  or specific indices) to fail. It is recommended to regenerate the suppression XML
+  if you significantly change the active checks in your configuration.
+</p>
+
 <h4 id="Generating_Checks_And_Files_Suppressions_XML"><span>
 7. Generating Checks And Files Suppressions XML
 (<span class="no-transform">-G, --generate-checks-and-files-suppression</span>)

--- a/src/site/xdoc/filters/suppressionxpathfilter.xml
+++ b/src/site/xdoc/filters/suppressionxpathfilter.xml
@@ -209,6 +209,15 @@
           ATTENTION: filtering by message is dependent on runtime locale. If project is running
           in different languages it is better to avoid filtering by message.
         </p>
+
+        <p>
+          <b>Attention:</b> The structure of the Abstract Syntax Tree (AST) can change
+          depending on the enabled checks. If &quot;comment-aware&quot; checks (such as
+          <code>TodoComment</code>) are enabled, comment nodes are added to the AST.
+          XPath queries should be written robustly to handle the potential presence
+          of comment nodes. For example, relying on strict <code>count(*)</code>
+          checks might fail if comments are present in the code block.
+        </p>
       </subsection>
       <subsection name="Properties" id="SuppressionXpathFilter_Properties">
         <div class="wrapper">

--- a/src/site/xdoc/filters/suppressionxpathfilter.xml.template
+++ b/src/site/xdoc/filters/suppressionxpathfilter.xml.template
@@ -22,6 +22,15 @@
             <param name="modulePath"
                    value="src/main/java/com/puppycrawl/tools/checkstyle/filters/SuppressionXpathFilter.java"/>
         </macro>
+
+        <p>
+          <b>Attention:</b> The structure of the Abstract Syntax Tree (AST) can change
+          depending on the enabled checks. If "comment-aware" checks (such as
+          <code>TodoComment</code>) are enabled, comment nodes are added to the AST.
+          XPath queries should be written robustly to handle the potential presence
+          of comment nodes. For example, relying on strict <code>count(*)</code>
+          checks might fail if comments are present in the code block.
+        </p>
       </subsection>
       <subsection name="Properties" id="SuppressionXpathFilter_Properties">
         <div class="wrapper">


### PR DESCRIPTION
fixes #7531
this PR updates the documentation to warn users that enabling "comment-aware" checks (like TodoComment) changes the structure of the abstract syntax tree (AST) by inserting comment nodes.

Changes:
1 ) Command Line Usage (cmdline.xml.vm): Added a note in the "Generating XPath Suppressions XML" section.
2) Filters (suppressionxpathfilter.xml): Added an "Attention" note in the SuppressionXpathFilter documentation.