### PR TITLE
Issue #11166: remove getFileContents from UnusedImportCheck

### DIFF
--- a/config/pitest-suppressions/pitest-api-suppressions.xml
+++ b/config/pitest-suppressions/pitest-api-suppressions.xml
@@ -1,3 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<suppressedMutations>
-</suppressedMutations>

--- a/config/pitest-suppressions/pitest-imports-suppressions.xml
+++ b/config/pitest-suppressions/pitest-imports-suppressions.xml
@@ -1,3 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<suppressedMutations>
-</suppressedMutations>

--- a/src/main/java/com/puppycrawl/tools/checkstyle/api/FullIdent.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/api/FullIdent.java
@@ -101,13 +101,34 @@ public final class FullIdent {
                 pushToIdentStack(identStack, firstChild);
             }
             else if (typeOfAst == TokenTypes.DOT) {
-                pushToIdentStack(identStack, firstChild.getNextSibling());
+                final DetailAST next = firstChild.getNextSibling();
+                processDot(identStack, next);
                 pushToIdentStack(identStack, firstChild);
                 dotCounter++;
             }
             else {
                 dotCounter = appendToFull(full, currentAst, dotCounter,
                         bracketsExist, isArrayTypeDeclarationStart);
+            }
+        }
+    }
+
+    /**
+     * Check a node is comment node or not then push to stack.
+     *
+     * @param identStack the Deque to add to
+     * @param ast the node
+     */
+    public static void processDot(Deque<DetailAST> identStack, DetailAST ast) {
+        if (ast != null) {
+            final int astType = ast.getType();
+
+            if (astType == TokenTypes.SINGLE_LINE_COMMENT
+                    || astType == TokenTypes.BLOCK_COMMENT_BEGIN) {
+                pushToIdentStack(identStack, ast.getNextSibling());
+            }
+            else {
+                pushToIdentStack(identStack, ast);
             }
         }
     }

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/imports/UnusedImportsCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/imports/UnusedImportsCheck.java
@@ -28,10 +28,12 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import java.util.stream.Stream;
 
+import javax.annotation.Nullable;
+
 import com.puppycrawl.tools.checkstyle.FileStatefulCheck;
 import com.puppycrawl.tools.checkstyle.api.AbstractCheck;
+import com.puppycrawl.tools.checkstyle.api.Comment;
 import com.puppycrawl.tools.checkstyle.api.DetailAST;
-import com.puppycrawl.tools.checkstyle.api.FileContents;
 import com.puppycrawl.tools.checkstyle.api.FullIdent;
 import com.puppycrawl.tools.checkstyle.api.TextBlock;
 import com.puppycrawl.tools.checkstyle.api.TokenTypes;
@@ -129,6 +131,9 @@ public class UnusedImportsCheck extends AbstractCheck {
             Pattern.CASE_INSENSITIVE
     );
 
+    /** Line split pattern. */
+    private static final Pattern LINE_SPLIT_PATTERN = Pattern.compile("\\R");
+
     /** Suffix for the star import. */
     private static final String STAR_IMPORT_SUFFIX = ".*";
 
@@ -154,6 +159,11 @@ public class UnusedImportsCheck extends AbstractCheck {
      */
     public void setProcessJavadoc(boolean value) {
         processJavadoc = value;
+    }
+
+    @Override
+    public boolean isCommentNodesRequired() {
+        return true;
     }
 
     @Override
@@ -311,18 +321,84 @@ public class UnusedImportsCheck extends AbstractCheck {
     }
 
     /**
+     * Retrieves the Javadoc comment associated with a given AST node.
+     *
+     * @param ast the AST node (e.g., class, method, constructor) to search above.
+     * @return the {@code DetailAST} representing the Javadoc comment if found and
+     *          valid; {@code null} otherwise.
+     */
+    @Nullable
+    private static DetailAST getJavadoc(DetailAST ast) {
+        // Prefer Javadoc directly above the node
+        DetailAST cmt = ast.findFirstToken(TokenTypes.BLOCK_COMMENT_BEGIN);
+        if (cmt == null) {
+            // Check MODIFIERS and TYPE block and TYPE_PARAMETERS for comments
+            cmt = getJavadocFromModifiers(ast);
+            final DetailAST type = ast.findFirstToken(TokenTypes.TYPE);
+            final DetailAST typeParam = ast.findFirstToken(TokenTypes.TYPE_PARAMETERS);
+
+            if (cmt == null && type != null) {
+                cmt = type.findFirstToken(TokenTypes.BLOCK_COMMENT_BEGIN);
+            }
+            if (cmt == null && typeParam != null) {
+                cmt = typeParam.findFirstToken(TokenTypes.BLOCK_COMMENT_BEGIN);
+            }
+        }
+
+        final DetailAST javadoc;
+        if (cmt != null && JavadocUtil.isJavadocComment(cmt)) {
+            javadoc = cmt;
+        }
+        else {
+            javadoc = null;
+        }
+
+        return javadoc;
+    }
+
+    /**
+     * Retrieves the Javadoc comment associated with modifiers in given AST node.
+     *
+     * @param ast the ast node to search above.
+     * @return the {@code DetailAST} representing the Javadoc comment if found and
+     *          valid; {@code null} otherwise.
+     */
+    @Nullable
+    private static DetailAST getJavadocFromModifiers(DetailAST ast) {
+        DetailAST cmt = null;
+        final DetailAST modifiers = ast.findFirstToken(TokenTypes.MODIFIERS);
+        if (modifiers != null) {
+            final DetailAST annotation = modifiers.findFirstToken(TokenTypes.ANNOTATION);
+            if (annotation != null) {
+                cmt = annotation.findFirstToken(TokenTypes.BLOCK_COMMENT_BEGIN);
+            }
+            if (cmt == null) {
+                cmt = modifiers.findFirstToken(TokenTypes.BLOCK_COMMENT_BEGIN);
+            }
+        }
+        return cmt;
+    }
+
+    /**
      * Collects references made in Javadoc comments.
      *
      * @param ast node to inspect for Javadoc
      */
-    // suppress deprecation until https://github.com/checkstyle/checkstyle/issues/11166
-    @SuppressWarnings("deprecation")
     private void collectReferencesFromJavadoc(DetailAST ast) {
-        final FileContents contents = getFileContents();
-        final int lineNo = ast.getLineNo();
-        final TextBlock textBlock = contents.getJavadocBefore(lineNo);
-        if (textBlock != null) {
-            currentFrame.addReferencedTypes(collectReferencesFromJavadoc(textBlock));
+        final DetailAST javadoc = getJavadoc(ast);
+        if (javadoc != null) {
+            final String content = JavadocUtil.getJavadocCommentContent(javadoc);
+            final String[] cmtLines;
+            if (LINE_SPLIT_PATTERN.matcher(content).find()) {
+                cmtLines = LINE_SPLIT_PATTERN.split(content);
+            }
+            else {
+                // added a start in start for single line javadoc
+                cmtLines = new String[] {"*", content};
+            }
+            // all other parameters are set to 1 as they are not used
+            final Comment comment = new Comment(cmtLines, 1, 1, 1);
+            currentFrame.addReferencedTypes(collectsReferencesFromJavadoc(comment));
         }
     }
 
@@ -333,7 +409,7 @@ public class UnusedImportsCheck extends AbstractCheck {
      * @param textBlock The javadoc block to parse
      * @return a set of classes referenced in the javadoc block
      */
-    private static Set<String> collectReferencesFromJavadoc(TextBlock textBlock) {
+    private static Set<String> collectsReferencesFromJavadoc(TextBlock textBlock) {
         // Process INLINE tags
         final List<JavadocTag> inlineTags = getTargetTags(textBlock,
                 JavadocUtil.JavadocTagType.INLINE);

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/imports/UnusedImportsCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/imports/UnusedImportsCheckTest.java
@@ -158,6 +158,15 @@ public class UnusedImportsCheckTest extends AbstractModuleTestSupport {
     }
 
     @Test
+    public void testDefaultFalse() throws Exception {
+        final String[] expected = {
+            "8:8: " + getCheckMessage(MSG_KEY, "java.util.List"),
+        };
+        verifyWithInlineConfigParser(
+                getPath("InputUnusedImportsMutation.java"), expected);
+    }
+
+    @Test
     public void testBug() throws Exception {
         final String[] expected = CommonUtil.EMPTY_STRING_ARRAY;
         verifyWithInlineConfigParser(
@@ -242,6 +251,13 @@ public class UnusedImportsCheckTest extends AbstractModuleTestSupport {
         verifyWithInlineConfigParser(
                 getNonCompilablePath("InputUnusedImportsFileInUnnamedPackage.java"),
             expected);
+    }
+
+    @Test
+    public void testAnnotation() throws Exception {
+        final String[] expected = CommonUtil.EMPTY_STRING_ARRAY;
+        verifyWithInlineConfigParser(
+                getPath("InputUnusedImportsAnnotation.java"), expected);
     }
 
     @Test

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/api/fullident/InputFullIdentUnusedImport.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/api/fullident/InputFullIdentUnusedImport.java
@@ -1,0 +1,15 @@
+/*
+com.puppycrawl.tools.checkstyle.checks.imports.UnusedImportsCheck
+processJavadoc = (default)true
+
+*/
+
+package com.puppycrawl.tools.checkstyle.api.fullident;
+
+import java.util. // violation 'Unused import - java.util.List.'
+List;
+import java.util. /* Block comment */
+Map; // violation above 'Unused import - java.util.Map.'
+
+public class InputFullIdentUnusedImport {
+}

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/imports/unusedimports/InputUnusedImportsAnnotation.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/imports/unusedimports/InputUnusedImportsAnnotation.java
@@ -1,0 +1,53 @@
+/*
+UnusedImports
+processJavadoc = (default)true
+
+
+*/
+
+package com.puppycrawl.tools.checkstyle.checks.imports.unusedimports;
+
+import java.util.List;
+import java.util.Map;
+import java.util.HashMap;
+import java.util.ArrayList;
+import java.util.HashSet;
+
+import javax.annotation.Nullable;
+
+public class InputUnusedImportsAnnotation {
+
+    /** @see List */
+    @Nullable
+    public boolean isTrue() {
+        return true;
+    }
+
+    /** @see Map */
+    <V> void foo(V v) {
+    }
+
+    @interface MyAnnotation {
+
+       /**
+        * @see HashMap
+        */
+       String value() default "";
+    }
+
+    /**
+     * @see ArrayList
+     */
+    @Nullable
+    /* @see List */
+    public String test() {
+        return "test";
+    }
+
+    /**
+     * @see HashSet
+     */
+    @Nullable
+    <V> void fooOne(V v) {
+    }
+}

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/imports/unusedimports/InputUnusedImportsMutation.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/imports/unusedimports/InputUnusedImportsMutation.java
@@ -1,0 +1,16 @@
+/*
+UnusedImports
+processJavadoc = (default)true
+
+*/
+package com.puppycrawl.tools.checkstyle.checks.imports.unusedimports;
+
+import java.util.List; // violation 'Unused import - java.util.List.'
+
+public class InputUnusedImportsMutation {
+
+    /* @see List */
+    public boolean isTrue() {
+        return true;
+    }
+}


### PR DESCRIPTION
Issue: #11166 

What this pr does?
- remove usage of getFileContents() from UnusedImportCheck.java and add a method which extract javadoc directly from ast.


Problems -

```
there is a issue in `createFullIdent()` of` FullIdent.java` when comment are enabled in the ast the example of the issue are -

Example1 - 

import java.util. // This is comment
List

FullIdent output - > import java.util. //

but it has to be- import java.util.List

Example 2-

import java.util. 
List // This is comment

FullIdent output - > import java.util.List

it works fine when the comments are in last line 
```

the fullIdent issue is also solved in this pr.




