### PR TITLE
Issue #18614: Fix false positive in IndentationCheck for new operator.

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/indentation/NewHandler.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/indentation/NewHandler.java
@@ -121,7 +121,7 @@ public class NewHandler extends AbstractExpressionHandler {
         IndentLevel result;
         // if our expression isn't first on the line, just use the start
         // of the line
-        if (getLineStart(mainAst) == mainAst.getColumnNo()) {
+        if (isOnStartOfLine(mainAst)) {
             result = super.getIndentImpl();
 
             final boolean isLineWrappedNew = TokenUtil.isOfType(mainAst.getParent().getParent(),

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/indentation/IndentationCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/indentation/IndentationCheckTest.java
@@ -4280,10 +4280,24 @@ public class IndentationCheckTest extends AbstractModuleTestSupport {
         checkConfig.addProperty("caseIndent", "4");
         checkConfig.addProperty("lineWrappingIndentation", "8");
         checkConfig.addProperty("tabWidth", "4");
-
-        final String fileName = getPath("InputIndentationTryCtorParams.java");
         final String[] expected = CommonUtil.EMPTY_STRING_ARRAY;
-        verifyWarns(checkConfig, fileName, expected);
+        verifyWarns(checkConfig, getPath("InputIndentationTryCtorParams.java"), expected);
+    }
+
+    @Test
+    public void testNewWithTabsIndentation() throws Exception {
+        final DefaultConfiguration checkConfig = createModuleConfig(IndentationCheck.class);
+        checkConfig.addProperty("basicOffset", "4");
+        checkConfig.addProperty("braceAdjustment", "0");
+        checkConfig.addProperty("caseIndent", "4");
+        checkConfig.addProperty("forceStrictCondition", "false");
+        checkConfig.addProperty("lineWrappingIndentation", "4");
+        checkConfig.addProperty("tabWidth", "4");
+        checkConfig.addProperty("throwsIndent", "4");
+        final String[] expected = {
+            "43:5: " + getCheckMessage(MSG_ERROR, "new", 4, 16),
+        };
+        verifyWarns(checkConfig, getPath("InputIndentationNewWithTabs.java"), expected);
     }
 
     private static final class IndentAudit implements AuditListener {

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/indentation/indentation/InputIndentationNewWithTabs.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/indentation/indentation/InputIndentationNewWithTabs.java
@@ -1,0 +1,47 @@
+package com.puppycrawl.tools.checkstyle.checks.indentation.indentation;        //indent:0 exp:0
+
+/**                                                                            //indent:0 exp:0
+ * This test-input is intended to be checked using following configuration:    //indent:1 exp:1
+ *                                                                             //indent:1 exp:1
+ * basicOffset = 4                                                             //indent:1 exp:1
+ * braceAdjustment = 0                                                         //indent:1 exp:1
+ * caseIndent = 4                                                              //indent:1 exp:1
+ * forceStrictCondition = false                                                //indent:1 exp:1
+ * lineWrappingIndentation = 4                                                 //indent:1 exp:1
+ * tabWidth = 4                                                                //indent:1 exp:1
+ * throwsIndent = 4                                                            //indent:1 exp:1
+ *                                                                             //indent:1 exp:1
+ */                                                                            //indent:1 exp:1
+public class InputIndentationNewWithTabs {                                     //indent:0 exp:0
+
+	static class Inner {                                                       //indent:4 exp:4
+		Inner(String s) {                                                      //indent:8 exp:8
+		}                                                                      //indent:8 exp:8
+	}                                                                          //indent:4 exp:4
+
+	private Inner client;                                                      //indent:4 exp:4
+
+	public void testCorrectNewInTryCatch() {                                   //indent:4 exp:4
+		try {                                                                  //indent:8 exp:8
+			client = new Inner(                                                //indent:12 exp:12
+				null                                                           //indent:16 exp:16
+			);                                                                 //indent:12 exp:12
+		} catch (Exception e) {                                                //indent:8 exp:8
+		}                                                                      //indent:8 exp:8
+	}                                                                          //indent:4 exp:4
+
+	public void testCorrectNewLineWrapped() {                                  //indent:4 exp:4
+		client =                                                               //indent:8 exp:8
+			new Inner(                                                         //indent:12 exp:12
+				null                                                           //indent:16 exp:16
+			);                                                                 //indent:12 exp:12
+	}                                                                          //indent:4 exp:4
+
+	public void testWrongNewIndent() {                                         //indent:4 exp:4
+		try {                                                                  //indent:8 exp:8
+			client =                                                           //indent:12 exp:12
+	new Inner(null);                                                           //indent:4 exp:16 warn
+		} catch (Exception e) {                                                //indent:8 exp:8
+		}                                                                      //indent:8 exp:8
+	}                                                                          //indent:4 exp:4
+}                                                                              //indent:0 exp:0


### PR DESCRIPTION
**Issue:** #18614

**Problem:**
IndentationCheck reported false positives for the `new` operator when using tab characters for indentation. The handler was comparing the visual line start position (tabs expanded) with the raw column number of the `new` token.

**Fix:**
Updated `NewHandler#getIndentImpl` to use `expandedTabsColumnNo` instead of `getColumnNo`. This ensures comparison uses visual column positions consistently.

**Testing:**
Added regression test `InputIndentationTryBlockNewIssue.java` reproducing the issue with tabs and verified `IndentationCheckTest` passes.