### PR TITLE
Issue #11103: Fix Indentation check for lambda in enum constant argum…

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/indentation/LambdaHandler.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/indentation/LambdaHandler.java
@@ -19,6 +19,8 @@
 
 package com.puppycrawl.tools.checkstyle.checks.indentation;
 
+import javax.annotation.Nullable;
+
 import com.puppycrawl.tools.checkstyle.api.DetailAST;
 import com.puppycrawl.tools.checkstyle.api.TokenTypes;
 import com.puppycrawl.tools.checkstyle.utils.TokenUtil;
@@ -91,22 +93,30 @@ public class LambdaHandler extends AbstractExpressionHandler {
             return getParent().getSuggestedChildIndent(this);
         }
 
-        DetailAST parent = getMainAst().getParent();
-        if (getParent() instanceof NewHandler) {
-            parent = parent.getParent();
+        final IndentLevel result;
+        final DetailAST enumConstDef = findParentEnumConstantDef();
+        if (enumConstDef != null) {
+            result = getEnumConstantBasedIndent(enumConstDef);
+        }
+        else {
+            DetailAST parent = getMainAst().getParent();
+            if (getParent() instanceof NewHandler) {
+                parent = parent.getParent();
+            }
+
+            // Use the start of the parent's line as the reference indentation level.
+            IndentLevel level = new IndentLevel(getLineStart(parent));
+
+            // If the start of the lambda is the first element on the line;
+            // assume line wrapping with respect to its parent.
+            final DetailAST firstChild = getMainAst().getFirstChild();
+            if (getLineStart(firstChild) == expandedTabsColumnNo(firstChild)) {
+                level = new IndentLevel(level, getIndentCheck().getLineWrappingIndentation());
+            }
+            result = level;
         }
 
-        // Use the start of the parent's line as the reference indentation level.
-        IndentLevel level = new IndentLevel(getLineStart(parent));
-
-        // If the start of the lambda is the first element on the line;
-        // assume line wrapping with respect to its parent.
-        final DetailAST firstChild = getMainAst().getFirstChild();
-        if (getLineStart(firstChild) == expandedTabsColumnNo(firstChild)) {
-            level = new IndentLevel(level, getIndentCheck().getLineWrappingIndentation());
-        }
-
-        return level;
+        return result;
     }
 
     @Override
@@ -234,5 +244,37 @@ public class LambdaHandler extends AbstractExpressionHandler {
     private boolean isSameLineAsSwitch(DetailAST node) {
         return node.getType() == TokenTypes.LITERAL_SWITCH
             && TokenUtil.areOnSameLine(getMainAst(), node);
+    }
+
+    /**
+     * Finds the parent ENUM_CONSTANT_DEF node if this lambda is an argument of an enum constant.
+     *
+     * @return the ENUM_CONSTANT_DEF node if found, null otherwise
+     */
+    @Nullable
+    private DetailAST findParentEnumConstantDef() {
+        DetailAST result = null;
+        DetailAST parent = getMainAst().getParent();
+        while (parent != null) {
+            if (parent.getType() == TokenTypes.ENUM_CONSTANT_DEF) {
+                result = parent;
+                break;
+            }
+            parent = parent.getParent();
+        }
+        return result;
+    }
+
+    /**
+     * Calculates the expected indentation for a lambda inside enum constant arguments.
+     * The expected indent is the enum constant's indent plus line wrapping indentation.
+     *
+     * @param enumConstDef the ENUM_CONSTANT_DEF node
+     * @return the expected indentation level
+     */
+    private IndentLevel getEnumConstantBasedIndent(DetailAST enumConstDef) {
+        final int enumConstIndent = getLineStart(enumConstDef);
+        final IndentLevel baseLevel = new IndentLevel(enumConstIndent);
+        return new IndentLevel(baseLevel, getIndentCheck().getLineWrappingIndentation());
     }
 }

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/indentation/IndentationCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/indentation/IndentationCheckTest.java
@@ -4221,6 +4221,40 @@ public class IndentationCheckTest extends AbstractModuleTestSupport {
                 .hasSize(1);
     }
 
+    @Test
+    public void testLambdaInEnumConstant() throws Exception {
+        final DefaultConfiguration checkConfig = createModuleConfig(IndentationCheck.class);
+        checkConfig.addProperty("basicOffset", "4");
+        checkConfig.addProperty("braceAdjustment", "0");
+        checkConfig.addProperty("caseIndent", "4");
+        checkConfig.addProperty("throwsIndent", "4");
+        checkConfig.addProperty("arrayInitIndent", "4");
+        checkConfig.addProperty("lineWrappingIndentation", "4");
+        checkConfig.addProperty("forceStrictCondition", "false");
+        checkConfig.addProperty("tabWidth", "8");
+
+        final String fileName = getPath("InputIndentationLambdaInEnum.java");
+        final String[] expected = CommonUtil.EMPTY_STRING_ARRAY;
+        verifyWarns(checkConfig, fileName, expected);
+    }
+
+    @Test
+    public void testLambdaInEnumConstantWithMultipleArgs() throws Exception {
+        final DefaultConfiguration checkConfig = createModuleConfig(IndentationCheck.class);
+        checkConfig.addProperty("basicOffset", "4");
+        checkConfig.addProperty("braceAdjustment", "0");
+        checkConfig.addProperty("caseIndent", "4");
+        checkConfig.addProperty("throwsIndent", "4");
+        checkConfig.addProperty("arrayInitIndent", "4");
+        checkConfig.addProperty("lineWrappingIndentation", "4");
+        checkConfig.addProperty("forceStrictCondition", "false");
+        checkConfig.addProperty("tabWidth", "8");
+
+        final String fileName = getPath("InputIndentationLambdaInEnumMultipleArgs.java");
+        final String[] expected = CommonUtil.EMPTY_STRING_ARRAY;
+        verifyWarns(checkConfig, fileName, expected);
+    }
+
     private static final class IndentAudit implements AuditListener {
 
         private final IndentComment[] comments;

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/indentation/indentation/InputIndentationLambdaInEnum.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/indentation/indentation/InputIndentationLambdaInEnum.java
@@ -1,0 +1,38 @@
+/*                                                                      //indent:0 exp:0
+ * Config:                                                              //indent:1 exp:1
+ * This test-input is intended to be checked using following            //indent:1 exp:1
+ * configuration:                                                       //indent:1 exp:1
+ *                                                                      //indent:1 exp:1
+ * basicOffset = 4                                                      //indent:1 exp:1
+ * braceAdjustment = 0                                                  //indent:1 exp:1
+ * caseIndent = 4                                                       //indent:1 exp:1
+ * throwsIndent = 4                                                     //indent:1 exp:1
+ * arrayInitIndent = 4                                                  //indent:1 exp:1
+ * lineWrappingIndentation = 4                                          //indent:1 exp:1
+ * forceStrictCondition = false                                         //indent:1 exp:1
+ * tabWidth = 8                                                         //indent:1 exp:1
+ */                                                                     //indent:1 exp:1
+
+package com.puppycrawl.tools.checkstyle.checks.indentation.indentation; //indent:0 exp:0
+
+import java.util.function.Function;                                     //indent:0 exp:0
+
+/**                                                                     //indent:0 exp:0
+ * Test Lambda indentation in enum constant argument.                   //indent:1 exp:1
+ */                                                                     //indent:1 exp:1
+public enum InputIndentationLambdaInEnum {                              //indent:0 exp:0
+
+    ENUM_VALUE(                                                         //indent:4 exp:4
+            v -> v,                                                     //indent:12 exp:12
+            new Object()                                                //indent:12 exp:12
+    );                                                                  //indent:4 exp:4
+
+    private final Function<Object, Object> function;                    //indent:4 exp:4
+    private final Object object;                                        //indent:4 exp:4
+
+    InputIndentationLambdaInEnum(Function<Object, Object> function,     //indent:4 exp:4
+                                  Object object) {                      //indent:34 exp:34
+        this.function = function;                                       //indent:8 exp:8
+        this.object = object;                                           //indent:8 exp:8
+    }                                                                   //indent:4 exp:4
+}                                                                       //indent:0 exp:0

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/indentation/indentation/InputIndentationLambdaInEnumMultipleArgs.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/indentation/indentation/InputIndentationLambdaInEnumMultipleArgs.java
@@ -1,0 +1,34 @@
+/*                                                                              //indent:0 exp:0
+ * Config:                                                                      //indent:1 exp:1
+ * This test-input is intended to be checked using following configuration:     //indent:1 exp:1
+ *                                                                              //indent:1 exp:1
+ * basicOffset = 4                                                              //indent:1 exp:1
+ * braceAdjustment = 0                                                          //indent:1 exp:1
+ * caseIndent = 4                                                               //indent:1 exp:1
+ * throwsIndent = 4                                                             //indent:1 exp:1
+ * arrayInitIndent = 4                                                          //indent:1 exp:1
+ * lineWrappingIndentation = 4                                                  //indent:1 exp:1
+ * forceStrictCondition = false                                                 //indent:1 exp:1
+ * tabWidth = 8                                                                 //indent:1 exp:1
+ */                                                                             //indent:1 exp:1
+
+package com.puppycrawl.tools.checkstyle.checks.indentation.indentation;         //indent:0 exp:0
+
+import java.util.function.Consumer;                                             //indent:0 exp:0
+import java.util.function.Function;                                             //indent:0 exp:0
+
+/**                                                                             //indent:0 exp:0
+ * Test Lambda in Enum constant with multiple arguments.                        //indent:1 exp:1
+ */                                                                             //indent:1 exp:1
+public enum InputIndentationLambdaInEnumMultipleArgs {                          //indent:0 exp:0
+
+    NAME(                                                                       //indent:4 exp:4
+        String::getClass,                                                       //indent:8 exp:8
+        any -> {}                                                               //indent:8 exp:8
+    );                                                                          //indent:4 exp:4
+
+    InputIndentationLambdaInEnumMultipleArgs(                                   //indent:4 exp:4
+            Function<String, Class<?>> function,                                //indent:12 exp:12
+            Consumer<String> consumer) {                                        //indent:12 exp:12
+    }                                                                           //indent:4 exp:4
+}                                                                               //indent:0 exp:0


### PR DESCRIPTION
fixes #11103
fixes #13539

Added  handling in `LambdaHandler.getIndentImpl()` to detect  lambdas inside enum constant arguments and calculate their expected indentation based on the enum constant's position.
