### PR TITLE
Issue #14122: Recfactored DefaultLogger class to avoid CT_CONSTRUCTOR…

### DIFF
--- a/config/spotbugs-exclude.xml
+++ b/config/spotbugs-exclude.xml
@@ -300,11 +300,15 @@
   <Match>
     <!-- until https://github.com/checkstyle/checkstyle/issues/14122 -->
     <Or>
-      <Class name="com.puppycrawl.tools.checkstyle.DefaultLogger"/>
       <Class name="com.puppycrawl.tools.checkstyle.PackageObjectFactory"/>
       <Class name="com.puppycrawl.tools.checkstyle.XmlLoader"/>
       <Class name="com.puppycrawl.tools.checkstyle.Checker"/>
     </Or>
+    <Bug pattern="CT_CONSTRUCTOR_THROW"/>
+  </Match>
+  <Match>
+    <!-- external projects inherits from it so it should not be changed  -->
+    <Class name="com.puppycrawl.tools.checkstyle.DefaultLogger"/>
     <Bug pattern="CT_CONSTRUCTOR_THROW"/>
   </Match>
   <Match>


### PR DESCRIPTION
Issue #14122: Recfactored DefaultLogger class to avoid CT_CONSTRUCTOR_THROW violation
made DefaultLogger final class and removed inheritance form DefaultLoggerWithCounter and BriefUtLogger