### PR TITLE
Issue #11602: Convert no-error-htmlunit regression to CLI

### DIFF
--- a/.ci/validation.sh
+++ b/.ci/validation.sh
@@ -930,11 +930,16 @@ no-error-spring-integration)
 no-error-htmlunit)
   CS_POM_VERSION="$(getCheckstylePomVersion)"
   echo CS_version: "${CS_POM_VERSION}"
-  ./mvnw -e --no-transfer-progress clean install -Pno-validations
+  ./mvnw -e --no-transfer-progress clean package -Passembly,no-validations
   echo "Checkout target sources ..."
   checkout_from https://github.com/HtmlUnit/htmlunit
   cd .ci-temp/htmlunit
-  mvn -e --no-transfer-progress compile checkstyle:check -Dcheckstyle.version="${CS_POM_VERSION}"
+  echo "checkstyle.suppressions.file=checkstyle_suppressions.xml" > checkstyle.properties
+  readarray -t files < <(find src/main/java src/test/java -name "*.java")
+  java -jar "../../target/checkstyle-${CS_POM_VERSION}-all.jar" \
+    -c checkstyle.xml \
+    -p checkstyle.properties \
+    "${files[@]}"
   cd ../
   removeFolderWithProtectedFiles htmlunit
   ;;

--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -71,6 +71,7 @@ blocks:
                 - .ci/validation.sh no-error-methods-distance
                 - .ci/validation.sh no-error-equalsverifier
                 - .ci/validation.sh jacoco
+                - .ci/validation.sh no-error-htmlunit
 
           commands:
             - echo "eval of CMD is starting";

--- a/config/jsoref-spellchecker/whitelist.words
+++ b/config/jsoref-spellchecker/whitelist.words
@@ -1157,6 +1157,7 @@ rcurly
 rdiachenko
 RDz
 reactivex
+readarray
 README
 Readonly
 rebased


### PR DESCRIPTION
Issue #11602:

This PR converts the `no-error-htmlunit` regression test from using `maven-checkstyle-plugin` to using the Checkstyle CLI directly.