### PR TITLE
Issue #11602: Convert no-error-orekit regression to CLI

### DIFF
--- a/.ci/validation.sh
+++ b/.ci/validation.sh
@@ -777,7 +777,7 @@ no-error-pgjdbc)
 no-error-orekit)
   CS_POM_VERSION="$(getCheckstylePomVersion)"
   echo CS_version: "${CS_POM_VERSION}"
-  ./mvnw -e --no-transfer-progress clean install -Pno-validations
+  ./mvnw -e --no-transfer-progress clean package -Passembly,no-validations
   echo "Checkout target sources ..."
   checkout_from https://github.com/Hipparchus-Math/hipparchus.git
   cd .ci-temp/hipparchus
@@ -794,8 +794,12 @@ no-error-orekit)
   # git checkout $(git describe --abbrev=0 --tags)
   git fetch --depth 1 origin "9b121e504771f3ddd303ab""cc""c74ac9db64541ea1"
   git checkout "9b121e504771f3ddd303ab""cc""c74ac9db64541ea1"
-  mvn -e --no-transfer-progress compile checkstyle:check \
-    -Dorekit.checkstyle.version="${CS_POM_VERSION}"
+  echo "checkstyle.header.file=license-header.txt" > checkstyle.properties
+  readarray -t files < <(find src/main/java -name "*.java")
+  java -jar "../../target/checkstyle-${CS_POM_VERSION}-all.jar" \
+    -c checkstyle.xml \
+    -p checkstyle.properties \
+    "${files[@]}"
   cd ..
   removeFolderWithProtectedFiles Orekit
   removeFolderWithProtectedFiles hipparchus

--- a/config/jsoref-spellchecker/whitelist.words
+++ b/config/jsoref-spellchecker/whitelist.words
@@ -327,7 +327,6 @@ doclint
 doctype
 documentationcomments
 donotignoreexceptions
-Dorekit
 Dorg
 DOTALL
 doubletag
@@ -1158,6 +1157,7 @@ rcurly
 rdiachenko
 RDz
 reactivex
+readarray
 README
 Readonly
 rebased


### PR DESCRIPTION
Issue #11602: 

Converts the no-error-orekit regression test to use Checkstyle CLI directly, removing the dependency on maven-checkstyle-plugin.