### PR TITLE
Issue #18599: Fix MalformedInlineTag violation in AnnotationUseStyleCheck

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/annotation/AnnotationUseStyleCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/annotation/AnnotationUseStyleCheck.java
@@ -292,7 +292,7 @@ public final class AnnotationUseStyleCheck extends AbstractCheck {
     }
 
     /**
-     * Retrieves an {@link Enum Enum} type from a @{link String String}.
+     * Retrieves an {@link Enum Enum} type from a {@link String String}.
      *
      * @param <T> the enum type
      * @param enumClass the enum class


### PR DESCRIPTION
Ref: #18599

Fixes a `MalformedInlineTag` violation reported by Error in `AnnotationUseStyleCheck.java`.

The Javadoc tag was incorrectly written as `@{link String String}`.
This PR corrects the syntax to `{@link String String}`.