### PR TITLE
Issue #17882: Update GT of JavadocCommentsTokenTypes to new AST format

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/api/JavadocCommentsTokenTypes.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/api/JavadocCommentsTokenTypes.java
@@ -1133,7 +1133,31 @@ public final class JavadocCommentsTokenTypes {
 
     /**
      * Greater-than symbol {@code > }.
+     *
+     * <p><b>Example:</b></p>
+     * <pre>{@code * @see List<String>}</pre>
+     *
+     * <b>Tree:</b>
+     * <pre>{@code
+     * |--LEADING_ASTERISK ->  *
+     * |--TEXT ->
+     * |--JAVADOC_BLOCK_TAG -> JAVADOC_BLOCK_TAG
+     * |   `--SEE_BLOCK_TAG -> SEE_BLOCK_TAG
+     * |       |--AT_SIGN -> @
+     * |       |--TAG_NAME -> see
+     * |       |--TEXT ->
+     * |       `--REFERENCE -> REFERENCE
+     * |           |--IDENTIFIER -> List
+     * |           `--TYPE_ARGUMENTS -> TYPE_ARGUMENTS
+     * |               |--LT -> <
+     * |               |--TYPE_ARGUMENT -> TYPE_ARGUMENT
+     * |               |   `--IDENTIFIER -> String
+     * |               `--GT -> >
+     * |--NEWLINE -> \n
+     * `--Text ->
+     * }</pre>
      */
+
     public static final int GT = JavadocCommentsLexer.GT;
 
     /**


### PR DESCRIPTION
Issue: #17882

**Command used.**
java -jar checkstyle-13.1.0-SNAPSHOT-all.jar -j src/Test.java | sed "s/\[[0-9]\+:[0-9]\+\]//g"

**Test file**

`* @see List<String>`

AST output

```
JAVADOC_CONTENT -> JAVADOC_CONTENT
|--LEADING_ASTERISK -> *
|--TEXT ->
`--JAVADOC_BLOCK_TAG -> JAVADOC_BLOCK_TAG
    `--SEE_BLOCK_TAG -> SEE_BLOCK_TAG
        |--AT_SIGN -> @
        |--TAG_NAME -> see
        |--TEXT ->
        `--REFERENCE -> REFERENCE
            |--IDENTIFIER -> List
            `--TYPE_ARGUMENTS -> TYPE_ARGUMENTS
                |--LT -> <
                |--TYPE_ARGUMENT -> TYPE_ARGUMENT
                |   `--IDENTIFIER -> String
                `--GT -> >

```
