### PR TITLE
Issue #17882: Update DEPRECATED_BLOCK_TAG Javadoc to new AST format

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/api/JavadocCommentsTokenTypes.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/api/JavadocCommentsTokenTypes.java
@@ -20,6 +20,7 @@
 package com.puppycrawl.tools.checkstyle.api;
 
 import com.puppycrawl.tools.checkstyle.grammar.javadoc.JavadocCommentsLexer;
+import org.antlr.v4.runtime.tree.Tree;
 
 /**
  * Contains the constants for all the tokens contained in the Abstract
@@ -223,24 +224,46 @@ public final class JavadocCommentsTokenTypes {
      * </ol>
      *
      * <p><b>Example:</b></p>
-     * <pre>{@code * @deprecated deprecated text.}</pre>
+     * <pre>{@code
+     * /**
+     *  * @deprecated Use newMethod() instead.
+     *  */
+     * }</pre>
      *
      * <b>Tree:</b>
      * <pre>{@code
      * JAVADOC_CONTENT -> JAVADOC_CONTENT
-     * |--LEADING_ASTERISK -> *
+     * |--TEXT -> public class Test {
+     * |--NEWLINE -> \n
+     * |--NEWLINE -> \n
+     * |--TEXT ->     /**
+     * |--NEWLINE -> \n
+     * |--LEADING_ASTERISK ->      *
      * |--TEXT ->
-     * `--JAVADOC_BLOCK_TAG -> JAVADOC_BLOCK_TAG
-     *     `--DEPRECATED_BLOCK_TAG -> DEPRECATED_BLOCK_TAG
-     *         |--AT_SIGN -> @
-     *         |--TAG_NAME -> deprecated
-     *         `--DESCRIPTION -> DESCRIPTION
-     *             `--TEXT ->  deprecated text.
+     * |--JAVADOC_BLOCK_TAG -> JAVADOC_BLOCK_TAG
+     * |   `--DEPRECATED_BLOCK_TAG -> DEPRECATED_BLOCK_TAG
+     * |       |--AT_SIGN -> @
+     * |       |--TAG_NAME -> deprecated
+     * |       `--DESCRIPTION -> DESCRIPTION
+     * |           |--TEXT ->  Use newMethod() instead.
+     * |           |--NEWLINE -> \n
+     * |           |--LEADING_ASTERISK ->      *
+     * |           |--TEXT -> /
+     * |           |--NEWLINE -> \n
+     * |           |--TEXT ->     public void oldMethod() {
+     * |           |--NEWLINE -> \n
+     * |           |--TEXT ->     }
+     * |           |--NEWLINE -> \n
+     * |           `--TEXT -> }
+     * `--NEWLINE -> \n
      * }</pre>
      *
      * @see #JAVADOC_BLOCK_TAG
      */
-    public static final int DEPRECATED_BLOCK_TAG = JavadocCommentsLexer.DEPRECATED_BLOCK_TAG;
+
+
+
+        public static final int DEPRECATED_BLOCK_TAG = JavadocCommentsLexer.DEPRECATED_BLOCK_TAG;
 
     /**
      * {@code @param} Javadoc block tag.


### PR DESCRIPTION
# PLEASE READ BEFORE REMOVING

**Rules:**

- **Issue Requirement**
   - The issue you are trying to fix/resolve **must** have the `"approved"` label.
   - If an issue exists, reference it in the Pull Request description:
     Example: `"Issue: #XXXXXX"`
- **Commit message** should adhere to the following rules:
   - MUST match any one of the following patterns:

     ```
     ^Issue #\d+: .*$
     ^Pull #\d+: .*$
     ^(minor|config|infra|doc|spelling|dependency): .*$
     ```

   - MUST contain only one line of text
   - MUST NOT end with a period, space, or tab
   - MUST be less than or equal to 200 characters

To avoid multiple iterations of fixes and CI failures, please read
[Contribution Guide](https://checkstyle.org/contributing.html).

**ATTENTION:** Pull Requests that do not pass our CI checks will not be merged,
but we will help to resolve issues.

---
Thanks for reading, feel free to remove this whole message and type what you need.


Issue: #17882

Updated JavadocCommentsTokenTypes DEPRECATED_BLOCK_TAG
to include example and AST tree from the latest Checkstyle snapshot.

AST output used for update:

JAVADOC_CONTENT -> JAVADOC_CONTENT
|--TEXT -> public class Test {
|--NEWLINE -> \n
|--NEWLINE -> \n
|--TEXT ->     /**
|--NEWLINE -> \n
|--LEADING_ASTERISK ->      *
|--TEXT ->
|--JAVADOC_BLOCK_TAG -> JAVADOC_BLOCK_TAG
|   `--DEPRECATED_BLOCK_TAG -> DEPRECATED_BLOCK_TAG
|       |--AT_SIGN -> @
|       |--TAG_NAME -> deprecated
|       `--DESCRIPTION -> DESCRIPTION
|           |--TEXT ->  Use newMethod() instead.
|           |--NEWLINE -> \n
|           |--LEADING_ASTERISK ->      *
|           |--TEXT -> /
|           |--NEWLINE -> \n
|           |--TEXT ->     public void oldMethod() {
|           |--NEWLINE -> \n
|           |--TEXT ->     }
|           |--NEWLINE -> \n
|           `--TEXT -> }
`--NEWLINE -> \n

