### PR TITLE
Issue #17426: activate SealedShouldHavePermitsList for checkstyle pro…

### DIFF
--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/design/SealedShouldHavePermitsListCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/design/SealedShouldHavePermitsListCheckTest.java
@@ -93,10 +93,7 @@ public class SealedShouldHavePermitsListCheckTest extends AbstractModuleTestSupp
 
     @Test
     public void testJepExample() throws Exception {
-        final String[] expected = {
-            "10:1: " + getCheckMessage(MSG_KEY),
-            "24:1: " + getCheckMessage(MSG_KEY),
-        };
+        final String[] expected = {};
         verifyWithInlineConfigParser(
                 getPath(
                         "InputSealedShouldHavePermitsListJepExample.java"),

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/design/sealedshouldhavepermitslist/InputSealedShouldHavePermitsListJepExample.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/design/sealedshouldhavepermitslist/InputSealedShouldHavePermitsListJepExample.java
@@ -6,12 +6,7 @@ SealedShouldHavePermitsList
 // Java17
 package com.puppycrawl.tools.checkstyle.checks.design.sealedshouldhavepermitslist;
 
-// violation below 'Sealed classes or interfaces should explicitly declare permitted subclasses'
-public sealed class InputSealedShouldHavePermitsListJepExample
-        // The permits clause has been omitted
-        // as its permitted classes have been
-        // defined in the same file.
-{ }
+public sealed class InputSealedShouldHavePermitsListJepExample permits Circle, Square, Rectangle { }
 
 final class Circle extends InputSealedShouldHavePermitsListJepExample {
     float radius;
@@ -20,8 +15,7 @@ non-sealed class Square extends InputSealedShouldHavePermitsListJepExample {
     float side;
 }
 
-// violation below 'Sealed classes or interfaces should explicitly declare permitted subclasses'
-sealed class Rectangle extends InputSealedShouldHavePermitsListJepExample {
+sealed class Rectangle extends InputSealedShouldHavePermitsListJepExample permits FilledRectangle {
     float length, width;
 }
 final class FilledRectangle extends Rectangle {


### PR DESCRIPTION
Issue #17426: activate SealedShouldHavePermitsList for checkstyle project

all the rest violations have one with violation and other corrected to appear in tests the difference as this example have InputSealedShouldHavePermitsListInnerClass and InputSealedShouldHavePermitsListInnerClassCorrected

```
/*
SealedShouldHavePermitsList

*/
// Java17
package com.puppycrawl.tools.checkstyle.checks.design.sealedshouldhavepermitslist;

public class InputSealedShouldHavePermitsListInnerClass {
   // violation below 'Sealed classes or interfaces should explicitly declare permitted subclasses'
    sealed class A {}
    final class B extends A {}
    final class C extends A {}
    final class D { } // this can extend A, so as any other class in the compilation unit
    non-sealed class F extends A {}
    sealed class G extends A {}
    // violation above 'Sealed classes or interfaces should explicitly declare permitted subclasses'
    final class I extends G {}
    enum E {}
    record R(int x) {}
}

class InputSealedShouldHavePermitsListInnerClassCorrected {
    sealed class A permits B, C, F, G { } // ok, explicitly declared the permitted subclasses
    final class B extends A { }
    final class C extends A { }
    final class D { }    // this can't extend A
    non-sealed class F extends A {}
    sealed class G extends A permits I {}
    final class I extends G {}
    enum E {}
    record R(int x) {}
}

```