### PR TITLE
Issue #18599: Resolve error-prone violations

### DIFF
--- a/config/checker-framework-suppressions/checker-nullness-optional-interning-suppressions.xml
+++ b/config/checker-framework-suppressions/checker-nullness-optional-interning-suppressions.xml
@@ -8868,13 +8868,6 @@
 
   <checkerFrameworkError unstable="false">
     <fileName>src/main/java/com/puppycrawl/tools/checkstyle/site/SiteUtil.java</fileName>
-    <specifier>annotations.on.use</specifier>
-    <message>invalid type: annotations [@Initialized, @Nullable] conflict with declaration of type java.util.Optional</message>
-    <lineContent>private static Optional&lt;String&gt; getPropertyVersionFromItsJavadoc(DetailNode propertyJavadoc) {</lineContent>
-  </checkerFrameworkError>
-
-  <checkerFrameworkError unstable="false">
-    <fileName>src/main/java/com/puppycrawl/tools/checkstyle/site/SiteUtil.java</fileName>
     <specifier>argument</specifier>
     <message>incompatible argument for parameter classLoader of PackageNamesLoader.getPackageNames.</message>
     <lineContent>final Set&lt;String&gt; packageNames = PackageNamesLoader.getPackageNames(cl);</lineContent>
@@ -8911,13 +8904,6 @@
     <specifier>dereference.of.nullable</specifier>
     <message>dereference of possibly-null reference currentClass</message>
     <lineContent>result = currentClass.getDeclaredField(propertyName);</lineContent>
-  </checkerFrameworkError>
-
-  <checkerFrameworkError unstable="false">
-    <fileName>src/main/java/com/puppycrawl/tools/checkstyle/site/SiteUtil.java</fileName>
-    <specifier>dereference.of.nullable</specifier>
-    <message>dereference of possibly-null reference specifiedPropertyVersionInPropertyJavadoc</message>
-    <lineContent>if (specifiedPropertyVersionInPropertyJavadoc.isPresent()) {</lineContent>
   </checkerFrameworkError>
 
   <checkerFrameworkError unstable="false">

--- a/pom.xml
+++ b/pom.xml
@@ -262,6 +262,7 @@
       -Xep:MockitoMockClassReference:ERROR
       -Xep:MockitoStubbing:ERROR
       -Xep:NestedOptionals:ERROR
+      -Xep:NullableOptional:ERROR
       -Xep:OptionalOrElseGet:ERROR
       -Xep:PrimitiveComparison:ERROR
       -Xep:RedundantStringConversion:ERROR

--- a/src/main/java/com/puppycrawl/tools/checkstyle/site/SiteUtil.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/site/SiteUtil.java
@@ -770,7 +770,6 @@ public final class SiteUtil {
      * @param propertyJavadoc the property Javadoc to extract the since version from.
      * @return the Optional of property version specified in its javadoc.
      */
-    @Nullable
     private static Optional<String> getPropertyVersionFromItsJavadoc(DetailNode propertyJavadoc) {
         final Optional<DetailNode> propertyJavadocTag =
             getPropertySinceJavadocTag(propertyJavadoc);


### PR DESCRIPTION
Issue #18599: Resolve error-prone violations for NullableOptional
this was the warning before modification
[WARNING] /home/youssef/checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/site/SiteUtil.java:[774,37] [NullableOptional] Using an Optional variable which is expected to possibly be null is discouraged. It is best to indicate the absence of the value by assigning it an empty optional.
    (see https://errorprone.info/bugpattern/NullableOptional)