### PR TITLE
Issue #18599: Resolve error-prone violations for UnsynchronizedOverri…

### DIFF
--- a/config/checker-framework-suppressions/checker-nullness-optional-interning-suppressions.xml
+++ b/config/checker-framework-suppressions/checker-nullness-optional-interning-suppressions.xml
@@ -1517,7 +1517,7 @@
     <fileName>src/main/java/com/puppycrawl/tools/checkstyle/checks/OrderedPropertiesCheck.java</fileName>
     <specifier>override.return</specifier>
     <message>Incompatible return type.</message>
-    <lineContent>public Enumeration&lt;Object&gt; keys() {</lineContent>
+    <lineContent>public synchronized Enumeration&lt;Object&gt; keys() {</lineContent>
     <details>
       found   : Enumeration&lt;Object&gt;
       required: Enumeration&lt;@KeyFor(&quot;this&quot;) Object&gt;

--- a/pom.xml
+++ b/pom.xml
@@ -274,6 +274,7 @@
       -Xep:TimeZoneUsage:ERROR
       -Xep:TruthAssertExpected:ERROR
       -Xep:TypeParameterUnusedInFormals:ERROR
+      -Xep:UnsynchronizedOverridesSynchronized:ERROR
       -Xep:UnusedMethod:ERROR
       -Xep:VoidUsed:ERROR
       -Xep:FormatStringShouldUsePlaceholders:ERROR

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/OrderedPropertiesCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/OrderedPropertiesCheck.java
@@ -207,9 +207,14 @@ public class OrderedPropertiesCheck extends AbstractFileSetCheck {
 
         /**
          * Returns a copy of the keys.
+         *
+         * @noinspection SynchronizedMethod
+         * @noinspectionreason SynchronizedMethod - synchronized keyword is required
+         *      to override the synchronized keys() method from Hashtable parent class,
+         *      maintaining thread-safety contract
          */
         @Override
-        public Enumeration<Object> keys() {
+        public synchronized Enumeration<Object> keys() {
             return Collections.enumeration(keyList);
         }
 


### PR DESCRIPTION
Issue #18599: Resolve error-prone violations for UnsynchronizedOverridesSynchronized
this was the warning before modification
[WARNING] /home/youssef/checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/checks/[OrderedPropertiesCheck.java](http://orderedpropertiescheck.java/):[212,36] [UnsynchronizedOverridesSynchronized] Unsynchronized method keys overrides synchronized method in Hashtable     (see https://errorprone.info/bugpattern/UnsynchronizedOverridesSynchronized)