### PR TITLE
Issue #13351: Resolve violations from spotbugs sb-contrib for ENMI_ON…

### DIFF
--- a/config/spotbugs-exclude.xml
+++ b/config/spotbugs-exclude.xml
@@ -257,14 +257,7 @@
     <Bug pattern="ENMI_NULL_ENUM_VALUE"/>
   </Match>
   <Match>
-    <!-- Till https://github.com/checkstyle/checkstyle/issues/13351 -->
-    <Or>
-      <Class name="com.puppycrawl.tools.checkstyle.checks.javadoc.JavadocTagInfo"/>
-    </Or>
-    <Bug pattern="ENMI_ONE_ENUM_VALUE"/>
-  </Match>
-  <Match>
-    <!-- Till https://github.com/checkstyle/checkstyle/issues/13351 -->
+    <!-- Swing TreeModel API requires passing 'this' as event source -->
     <Or>
       <Class name="com.puppycrawl.tools.checkstyle.gui.ParseTreeTableModel"/>
     </Or>


### PR DESCRIPTION
Issue #13351: Resolve violations from spotbugs sb-contrib for ENMI_ONE_ENUM_VALUE and SPP_PASSING_THIS_AS_PARM.
ENMI_ONE_ENUM_VALUE was not suppressing any bug
SPP_PASSING_THIS_AS_PARM explained the reason why can not be removed