### PR TITLE
Issue #13351: Resolve violations from spotbugs sb-contrib for ENMI_NU…

### DIFF
--- a/config/spotbugs-exclude.xml
+++ b/config/spotbugs-exclude.xml
@@ -246,7 +246,6 @@
   <Match>
     <!-- Till https://github.com/checkstyle/checkstyle/issues/13351 -->
     <Or>
-      <Class name="com.puppycrawl.tools.checkstyle.ConfigurationLoader$InternalLoader"/>
       <Class name="com.puppycrawl.tools.checkstyle.utils.CheckUtil"/>
       <Class name="com.puppycrawl.tools.checkstyle.utils.ScopeUtil"/>
     </Or>

--- a/src/main/java/com/puppycrawl/tools/checkstyle/ConfigurationLoader.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/ConfigurationLoader.java
@@ -551,11 +551,11 @@ public final class ConfigurationLoader {
                     configStack.pop();
 
                 // get severity attribute if it exists
-                SeverityLevel level = null;
+                Optional<SeverityLevel> level = Optional.empty();
                 if (containsAttribute(recentModule, SEVERITY)) {
                     try {
                         final String severity = recentModule.getProperty(SEVERITY);
-                        level = SeverityLevel.getInstance(severity);
+                        level = Optional.of(SeverityLevel.getInstance(severity));
                     }
                     catch (final CheckstyleException exc) {
                         // -@cs[IllegalInstantiation] SAXException is in the overridden
@@ -569,11 +569,10 @@ public final class ConfigurationLoader {
                 // omit this module if these should be omitted and the module
                 // has the severity 'ignore'
                 final boolean omitModule = omitIgnoredModules
-                    && level == SeverityLevel.IGNORE;
+                    && level.isPresent() && level.get() == SeverityLevel.IGNORE;
 
                 if (omitModule && !configStack.isEmpty()) {
-                    final DefaultConfiguration parentModule =
-                        configStack.peek();
+                    final DefaultConfiguration parentModule = configStack.peek();
                     parentModule.removeChild(recentModule);
                 }
             }


### PR DESCRIPTION
Issue #13351: Resolve violations from spotbugs sb-contrib for ENMI_NULL_ENUM_VALUE
removed one of the classes that was void function and the other 2 classes can not be changed because these are for public apis that we canot use optional in them as this will break the usage of external users