### PR TITLE
Pull #18746: Add `failOnDryRunResults` to fix rewrite feature envy 

### DIFF
--- a/.ci/validation.sh
+++ b/.ci/validation.sh
@@ -1367,28 +1367,17 @@ spotless)
   ;;
 
 openrewrite-recipes)
-  echo "Cloning and building OpenRewrite recipes..."
-  PROJECT_ROOT="$(pwd)"
-  export MAVEN_OPTS="-Xmx4g -Xms2g"
-
-  cd /tmp
-  git clone https://github.com/checkstyle/checkstyle-openrewrite-recipes.git
-  cd checkstyle-openrewrite-recipes
-  ./mvnw -e --no-transfer-progress clean install -DskipTests
-
-  cd "$PROJECT_ROOT"
-
-  echo "Running Checkstyle validation to get report for openrewrite..."
-  set +e
-  ./mvnw -e --no-transfer-progress clean compile antrun:run@ant-phase-verify
-  set -e
-  echo "Running OpenRewrite recipes..."
-  ./mvnw -e --no-transfer-progress rewrite:run -Drewrite.recipeChangeLogLevel=INFO
-
-  echo "Checking for uncommitted changes..."
-  ./.ci/print-diff-as-patch.sh target/rewrite.patch
-
-  rm -rf /tmp/checkstyle-openrewrite-recipes
+  export MAVEN_OPTS="-Xmx6g"
+  echo Install OpenRewrite recipes...
+  git clone https://github.com/checkstyle/checkstyle-openrewrite-recipes.git /tmp/checkstyle-openrewrite-recipes
+  cd /tmp/checkstyle-openrewrite-recipes
+  ./mvnw -e --no-transfer-progress install -DskipTests
+  cd /home/circleci/project # Return to original directory
+  rm -rf /tmp/checkstyle-openrewrite-recipes # Cleanup
+  echo Run Checkstyle validation to get report for OpenRewrite...
+  echo DryRun OpenRewrite recipes...
+  ./mvnw -e --no-transfer-progress compile antrun:run@ant-phase-verify \
+    rewrite:dryRun -Drewrite.recipeChangeLogLevel=INFO
   ;;
 
 *)

--- a/pom.xml
+++ b/pom.xml
@@ -652,6 +652,7 @@
           <configuration>
             <configLocation>config/rewrite.yml</configLocation>
             <exportDatatables>true</exportDatatables>
+            <failOnDryRunResults>true</failOnDryRunResults>
             <skipMavenParsing>true</skipMavenParsing>
             <activeRecipes>
               <recipe>org.checkstyle.AllAutoFixes</recipe>


### PR DESCRIPTION
### Pull #18746: Add `failOnDryRunResults` to fix rewrite feature envy 


benefit;

- less featue envy
- better UX as logging tells how to fix:

```
[WARNING] Run 'mvn rewrite:run' to apply the recipes.
```


let user know what to do:



```
[INFO] Running recipe(s)...
[INFO] Printing available datatables to: target/rewrite/datatables/2026-01-24_13-58-46-018
[WARNING] The recipe produced 4 warning(s). Please report this to the recipe author.
[WARNING] These recipes would make changes to src/it/java/org/checkstyle/base/AbstractItModuleTestSupport.java:
[INFO]     org.openrewrite.java.migrate.UpgradeToJava21
[INFO]         org.openrewrite.java.migrate.util.SequencedCollection
[INFO]             org.openrewrite.java.migrate.util.ListFirstAndLast
[WARNING] Patch file available:
[WARNING]     /home/circleci/project/target/rewrite/rewrite.patch
[WARNING] Estimate time saved: 5m
[WARNING] Run 'mvn rewrite:run' to apply the recipes.
[INFO] ------------------------------------------------------------------------
[INFO] BUILD FAILURE
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  09:41 min
[INFO] Finished at: 2026-01-24T13:58:46Z
[INFO] ------------------------------------------------------------------------
```