### PR TITLE
Issue #18843: Indentation Check Handlers should not have reference to…

### DIFF
--- a/config/checker-framework-suppressions/checker-nullness-optional-interning-suppressions.xml
+++ b/config/checker-framework-suppressions/checker-nullness-optional-interning-suppressions.xml
@@ -5763,13 +5763,6 @@
   </checkerFrameworkError>
 
   <checkerFrameworkError unstable="false">
-    <fileName>src/main/java/com/puppycrawl/tools/checkstyle/checks/indentation/IndentationCheck.java</fileName>
-    <specifier>initialization.field.uninitialized</specifier>
-    <message>the default constructor does not initialize field incorrectIndentationLines</message>
-    <lineContent>private Set&lt;Integer&gt; incorrectIndentationLines;</lineContent>
-  </checkerFrameworkError>
-
-  <checkerFrameworkError unstable="false">
     <fileName>src/main/java/com/puppycrawl/tools/checkstyle/checks/indentation/LineWrappingHandler.java</fileName>
     <specifier>not.interned</specifier>
     <message>attempting to use a non-@Interned comparison operand</message>

--- a/config/spotbugs-exclude.xml
+++ b/config/spotbugs-exclude.xml
@@ -266,12 +266,6 @@
     <Bug pattern="UWF_FIELD_NOT_INITIALIZED_IN_CONSTRUCTOR"/>
   </Match>
   <Match>
-    <!-- until https://github.com/checkstyle/checkstyle/issues/14121 -->
-    <Class name="com.puppycrawl.tools.checkstyle.checks.indentation.IndentationCheck"/>
-    <Method name="indentationLog"/>
-    <Bug pattern="UWF_FIELD_NOT_INITIALIZED_IN_CONSTRUCTOR"/>
-  </Match>
-  <Match>
     <!-- there is strict order of method executions, call in misorder will result in failure -->
     <Class name="com.puppycrawl.tools.checkstyle.AbstractAutomaticBean"/>
     <Method name="setupChild"/>

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/indentation/IndentationCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/indentation/IndentationCheck.java
@@ -145,7 +145,7 @@ public class IndentationCheck extends AbstractCheck {
     private final HandlerFactory handlerFactory = new HandlerFactory();
 
     /** Lines logged as having incorrect indentation. */
-    private Set<Integer> incorrectIndentationLines;
+    private final Set<Integer> incorrectIndentationLines = new HashSet<>();
 
     /** Specify how far new indentation level should be indented when on the next line. */
     private int basicOffset = DEFAULT_INDENTATION;
@@ -354,7 +354,6 @@ public class IndentationCheck extends AbstractCheck {
         clearState();
         final PrimordialHandler primordialHandler = new PrimordialHandler(this);
         handlers.push(primordialHandler);
-        incorrectIndentationLines = new HashSet<>();
     }
 
     @Override
@@ -376,6 +375,7 @@ public class IndentationCheck extends AbstractCheck {
     private void clearState() {
         handlerFactory.clearCreatedHandlers();
         handlers.clear();
+        incorrectIndentationLines.clear();
     }
 
     /**


### PR DESCRIPTION
Fixes #18843 
Part of #14121

Changes

- Initialize incorrectIndentationLines eagerly to fix SpotBugs `UWF_FIELD_NOT_INITIALIZED_IN_CONSTRUCTOR` warning
- Changed to `private final Set<Integer> incorrectIndentationLines = new HashSet<>()`
- Updated `beginTree() `to use clear() instead of reassignment
- Remove SpotBugs suppression for this violation