### PR TITLE
Issue #18790: Fix IllegalTokenText false positives for escape sequences

### DIFF
--- a/src/it/resources/com/google/checkstyle/test/chapter2filebasic/rule232specialescape/InputSpecialEscapeSequences.java
+++ b/src/it/resources/com/google/checkstyle/test/chapter2filebasic/rule232specialescape/InputSpecialEscapeSequences.java
@@ -11,7 +11,7 @@ public class InputSpecialEscapeSequences {
 
   /** Some javadoc. */
   public String wrongEscapeSequences() {
-    final String r1 = "\u0008";
+    final String r1 = "\u0008"; // violation 'Consider using special escape sequence'
     final String r2 = "\u0009"; // violation 'Consider using special escape sequence .*'
     final String r3 = "\u000csssdfsd"; // violation 'Consider using special escape sequence .*'
     final char r5 = '\012'; // violation 'Consider using special escape sequence .*'
@@ -35,14 +35,15 @@ public class InputSpecialEscapeSequences {
 
   /** Some javadoc. */
   public void specialCharsWithWarn() {
-    String r1 = "\\u0008";
+    String r1 = "\\u0008"; // violation 'Consider using special escape sequence'
     String r2 = "\\u0009"; // violation 'Consider using special escape sequence .*'
     String r3 = "\\u000a"; // violation 'Consider using special escape sequence .*'
     String r4 = "\\u000c"; // violation 'Consider using special escape sequence .*'
     String r5 = "\\u000d"; // violation 'Consider using special escape sequence .*'
-    String r6 = "\\u0022"; // violation 'Consider using special escape sequence .*'
-    String r7 = "\\u0027"; // violation 'Consider using special escape sequence .*'
-    String r8 = "\\u005c"; // violation 'Consider using special escape sequence .*'
+    String r6 = "\\u0020"; // violation 'Consider using special escape sequence'
+    String r7 = "\\u0022"; // violation 'Consider using special escape sequence'
+    String r8 = "\\u0027"; // violation 'Consider using special escape sequence'
+    String r9 = "\\u005c"; // violation 'Consider using special escape sequence'
   }
 
   /** Some javadoc. */
@@ -60,7 +61,7 @@ public class InputSpecialEscapeSequences {
 
   class Inner {
     public String wrongEscapeSequences() {
-      final String r1 = "\u0008";
+      final String r1 = "\u0008"; // violation 'Consider using special escape sequence'
       final String r2 = "\u0009"; // violation 'Consider using special escape sequence .*'
       final String r3 = "\u000csssdfsd";
       // violation above 'Consider using special escape sequence .*'
@@ -83,14 +84,15 @@ public class InputSpecialEscapeSequences {
     }
 
     public void specialCharsWithWarn() {
-      String r1 = "\\u0008";
+      String r1 = "\\u0008"; // violation 'Consider using special escape sequence'
       String r2 = "\\u0009"; // violation 'Consider using special escape sequence .*'
       String r3 = "\\u000a"; // violation 'Consider using special escape sequence .*'
       String r4 = "\\u000c"; // violation 'Consider using special escape sequence .*'
       String r5 = "\\u000d"; // violation 'Consider using special escape sequence .*'
-      String r6 = "\\u0022"; // violation 'Consider using special escape sequence .*'
-      String r7 = "\\u0027"; // violation 'Consider using special escape sequence .*'
-      String r8 = "\\u005c"; // violation 'Consider using special escape sequence .*'
+      String r6 = "\\u0020"; // violation 'Consider using special escape sequence .*'
+      String r7 = "\\u0022"; // violation 'Consider using special escape sequence'
+      String r8 = "\\u0027"; // violation 'Consider using special escape sequence .*'
+      String r9 = "\\u005c"; // violation 'Consider using special escape sequence .*'
     }
 
     public void specialCharsWithWarn2() {
@@ -108,7 +110,7 @@ public class InputSpecialEscapeSequences {
     Inner anoInner =
         new Inner() {
           public String wrongEscapeSequences() {
-            final String r1 = "\u0008";
+            final String r1 = "\u0008"; // violation 'Consider using special escape sequence'
             final String r2 = "\u0009"; // violation 'Consider using special escape sequence .*'
             final String r3 = "\u000csssdfsd";
             // violation above 'Consider using special escape sequence .*'
@@ -131,14 +133,15 @@ public class InputSpecialEscapeSequences {
           }
 
           public void specialCharsWithWarn() {
-            String r1 = "\\u0008";
+            String r1 = "\\u0008"; // violation 'Consider using special escape sequence'
             String r2 = "\\u0009"; // violation 'Consider using special escape sequence .*'
             String r3 = "\\u000a"; // violation 'Consider using special escape sequence .*'
             String r4 = "\\u000c"; // violation 'Consider using special escape sequence .*'
             String r5 = "\\u000d"; // violation 'Consider using special escape sequence .*'
-            String r6 = "\\u0022"; // violation 'Consider using special escape sequence .*'
-            String r7 = "\\u0027"; // violation 'Consider using special escape sequence .*'
-            String r8 = "\\u005c"; // violation 'Consider using special escape sequence .*'
+            String r6 = "\\u0020"; // violation 'Consider using special escape sequence'
+            String r7 = "\\u0022"; // violation 'Consider using special escape sequence .*'
+            String r8 = "\\u0027"; // violation 'Consider using special escape sequence .*'
+            String r9 = "\\u005c"; // violation 'Consider using special escape sequence .*'
           }
 
           public void specialCharsWithWarn2() {

--- a/src/it/resources/com/google/checkstyle/test/chapter2filebasic/rule232specialescape/InputSpecialEscapeSequencesForEscapedS.java
+++ b/src/it/resources/com/google/checkstyle/test/chapter2filebasic/rule232specialescape/InputSpecialEscapeSequencesForEscapedS.java
@@ -4,25 +4,28 @@ class InputSpecialEscapeSequencesForEscapedS {
 
   void unicode() {
     final String r0 = "\s";
-    final String r1 = "\u000b"; // violation 'Consider using special escape sequence'
-    final String r2 = "\u000c"; // violation 'Consider using special escape sequence'
-    final String r3 = "\u001c"; // violation 'Consider using special escape sequence'
-    final String r4 = "\u001D"; // violation 'Consider using special escape sequence'
-    final String r5 = "\u001E"; // violation 'Consider using special escape sequence'
-    final String r6 = "\u001F"; // violation 'Consider using special escape sequence'
-    final String r7 = "\u1680"; // violation 'Consider using special escape sequence'
-    final String r8 = "\u2000"; // violation 'Consider using special escape sequence'
-    final String r9 = "\u200A"; // violation 'Consider using special escape sequence'
-    final String r10 = "\u2028"; // violation 'Consider using special escape sequence'
-    final String r12 = "\u2029"; // violation 'Consider using special escape sequence'
-    final String r13 = "\u202F"; // violation 'Consider using special escape sequence'
-    final String r14 = "\u205F"; // violation 'Consider using special escape sequence'
-    final String r15 = "\u3000"; // violation 'Consider using special escape sequence'
+    final String r1 = "\u0020"; // violation 'Consider using special escape sequence'
+    final String r2 = "\u0008"; // violation 'Consider using special escape sequence'
+    // These have no escape sequences, should not cause violations
+    final String r3 = "\u000b";
+    final String r4 = "\u001c";
+    final String r5 = "\u001D";
+    final String r6 = "\u001E";
+    final String r7 = "\u001F";
+    final String r8 = "\u1680";
+    final String r9 = "\u2000";
+    final String r10 = "\u200A";
+    final String r11 = "\u2028";
+    final String r12 = "\u2029";
+    final String r13 = "\u202F";
+    final String r14 = "\u205F";
+    final String r15 = "\u3000";
   }
 
   void octal() {
     final String r1 = "\040"; // violation 'Consider using special escape sequence'
     final String r2 = "\011"; // violation 'Consider using special escape sequence'
     final String r3 = "\012"; // violation 'Consider using special escape sequence'
+    final String r4 = "\010"; // violation 'Consider using special escape sequence'
   }
 }

--- a/src/it/resources/com/google/checkstyle/test/chapter2filebasic/rule232specialescape/InputSpecialEscapeSequencesInTextBlockForUnicodeValues.java
+++ b/src/it/resources/com/google/checkstyle/test/chapter2filebasic/rule232specialescape/InputSpecialEscapeSequencesInTextBlockForUnicodeValues.java
@@ -5,7 +5,7 @@ public class InputSpecialEscapeSequencesInTextBlockForUnicodeValues {
 
   class Inner {
     public void wrongEscapeSequences() {
-      final String r1 =
+      final String r1 = // violation below 'Consider using special escape sequence'
           """
           \u0008
           """;
@@ -37,59 +37,56 @@ public class InputSpecialEscapeSequencesInTextBlockForUnicodeValues {
           """
           \\u005c
           """;
-      final String r9 = // violation below 'Consider using special escape sequence'
+      // The following have no escape sequences, should not cause violations
+      final String r9 =
           """
           \\u000b
           """;
-      final String r10 = // violation below 'Consider using special escape sequence'
+      final String r10 =
           """
           \\u001c
           """;
-      final String r11 = // violation below 'Consider using special escape sequence'
+      final String r11 =
           """
           \\u001D
           """;
-      final String r12 = // violation below 'Consider using special escape sequence'
+      final String r12 =
           """
           \\u001E
           """;
-      final String r13 = // violation below 'Consider using special escape sequence'
+      final String r13 =
           """
           \\u001F
           """;
-      final String r14 = // violation below 'Consider using special escape sequence'
-          """
-          \\u005c
-          """;
-      final String r15 = // violation below 'Consider using special escape sequence'
+      final String r14 =
           """
           \\u1680
           """;
-      final String r16 = // violation below 'Consider using special escape sequence'
+      final String r15 =
           """
           \\u2000
           """;
-      final String r17 = // violation below 'Consider using special escape sequence'
+      final String r16 =
           """
           \\u200A
           """;
-      final String r18 = // violation below 'Consider using special escape sequence'
+      final String r17 =
           """
           \\u2028
           """;
-      final String r19 = // violation below 'Consider using special escape sequence'
+      final String r18 =
           """
           \\u2029
           """;
-      final String r20 = // violation below 'Consider using special escape sequence'
+      final String r19 =
           """
           \\u202F
           """;
-      final String r21 = // violation below 'Consider using special escape sequence'
+      final String r20 =
           """
           \\u205F
           """;
-      final String r22 = // violation below 'Consider using special escape sequence'
+      final String r21 =
           """
           \\u3000
           """;
@@ -98,7 +95,7 @@ public class InputSpecialEscapeSequencesInTextBlockForUnicodeValues {
 
   /** Some javadoc. */
   public void specialCharsWithWarnUnicode() {
-    String r1 =
+    String r1 = // violation below 'Consider using special escape sequence'
         """
         \\u0008
         """;
@@ -120,76 +117,45 @@ public class InputSpecialEscapeSequencesInTextBlockForUnicodeValues {
         """;
     String r6 = // violation below 'Consider using special escape sequence'
         """
-        \\u0022
+        \\u0020
         """;
     String r7 = // violation below 'Consider using special escape sequence'
         """
-        \\u0027
+        \\u0022
         """;
     String r8 = // violation below 'Consider using special escape sequence'
         """
-        \\u005c
+        \\u0027
         """;
     String r9 = // violation below 'Consider using special escape sequence'
         """
+        \\u005c
+        """;
+    // The following have no escape sequences, should not cause violations
+    String r10 =
+        """
         \\u000b
         """;
-    String r10 = // violation below 'Consider using special escape sequence'
+    String r11 =
         """
         \\u001c
         """;
-    String r11 = // violation below 'Consider using special escape sequence'
-        """
-        \\u001D
-        """;
-    String r12 = // violation below 'Consider using special escape sequence'
-        """
-        \\u001E
-        """;
-    String r13 = // violation below 'Consider using special escape sequence'
-        """
-        \\u001F
-        """;
-    String r14 = // violation below 'Consider using special escape sequence'
-        """
-        \\u005c
-        """;
-    String r15 = // violation below 'Consider using special escape sequence'
+    String r12 =
         """
         \\u1680
         """;
-    String r16 = // violation below 'Consider using special escape sequence'
+    String r13 =
         """
         \\u2000
         """;
-    String r17 = // violation below 'Consider using special escape sequence'
-        """
-        \\u200A
-        """;
-    String r18 = // violation below 'Consider using special escape sequence'
-        """
-        \\u2028
-        """;
-    String r19 = // violation below 'Consider using special escape sequence'
-        """
-        \\u2029
-        """;
-    String r20 = // violation below 'Consider using special escape sequence'
-        """
-        \\u202F
-        """;
-    String r21 = // violation below 'Consider using special escape sequence'
-        """
-        \\u205F
-        """;
-    String r22 = // violation below 'Consider using special escape sequence'
+    String r14 =
         """
         \\u3000
         """;
   }
 
   private static void wrongEscapeSequences() {
-    final String r1 =
+    final String r1 = // violation below 'Consider using special escape sequence'
         """
         \u0008
         """;
@@ -209,67 +175,31 @@ public class InputSpecialEscapeSequencesInTextBlockForUnicodeValues {
         """
         \u000csssdfsd
         """; // violation 2 lines above 'Unicode escape(s) usage should be avoided.
-    final String r9 = // violation below 'Consider using special escape sequence'
+    // The following have no escape sequences, should not cause violations
+    final String r6 =
         """
         \u000b
         """;
-    final String r10 = // violation below 'Consider using special escape sequence'
+    final String r7 =
         """
         \u001c
         """;
-    final String r11 = // violation below 'Consider using special escape sequence'
-        """
-        \u001D
-        """;
-    final String r12 = // violation below 'Consider using special escape sequence'
-        """
-        \u001E
-        """;
-    final String r13 = // violation below 'Consider using special escape sequence'
-        """
-        \u001F
-        """;
-    // violation 2 lines below 'Unicode escape(s) usage should be avoided'
-    final String r14 = // violation below 'Consider using special escape sequence'
-        """
-        \u005c
-        """;
-    final String r15 = // violation below 'Consider using special escape sequence'
+    final String r8 =
         """
         \u1680
         """;
-    final String r16 = // violation below 'Consider using special escape sequence'
+    final String r9 =
         """
         \u2000
         """;
-    final String r17 = // violation below 'Consider using special escape sequence'
-        """
-        \u200A
-        """;
-    final String r18 = // violation below 'Consider using special escape sequence'
-        """
-        \u2028
-        """;
-    final String r19 = // violation below 'Consider using special escape sequence'
-        """
-        \u2029
-        """;
-    final String r20 = // violation below 'Consider using special escape sequence'
-        """
-        \u202F
-        """;
-    final String r21 = // violation below 'Consider using special escape sequence'
-        """
-        \u205F
-        """;
-    final String r22 = // violation below 'Consider using special escape sequence'
+    final String r10 =
         """
         \u3000
         """;
   }
 
   private static void specialCharsWithWarn() {
-    String r1 =
+    String r1 = // violation below 'Consider using special escape sequence'
         """
         \\u0008
         """;
@@ -291,13 +221,17 @@ public class InputSpecialEscapeSequencesInTextBlockForUnicodeValues {
         """;
     String r6 = // violation below 'Consider using special escape sequence'
         """
-        \\u0022
+        \\u0020
         """;
     String r7 = // violation below 'Consider using special escape sequence'
         """
-        \\u0027
+        \\u0022
         """;
     String r8 = // violation below 'Consider using special escape sequence'
+        """
+        \\u0027
+        """;
+    String r9 = // violation below 'Consider using special escape sequence'
         """
         \\u005c
         """;
@@ -306,7 +240,7 @@ public class InputSpecialEscapeSequencesInTextBlockForUnicodeValues {
   Inner anoInner =
       new Inner() {
         public void wrongEscapeSequences1() {
-          final String r1 =
+          final String r1 = // violation below 'Consider using special escape sequence'
               """
               \u0008
               """;
@@ -320,12 +254,12 @@ public class InputSpecialEscapeSequencesInTextBlockForUnicodeValues {
               """;
           final String r4 = // violation below 'Consider using special escape sequence'
               """
-              \u000csssdfsd
+              \u0020
               """;
         }
 
         public void specialCharsWithWarn() {
-          String r1 =
+          String r1 = // violation below 'Consider using special escape sequence'
               """
               \\u0008
               """;
@@ -347,69 +281,38 @@ public class InputSpecialEscapeSequencesInTextBlockForUnicodeValues {
               """;
           String r6 = // violation below 'Consider using special escape sequence'
               """
-              \\u0022
+              \\u0020
               """;
           String r7 = // violation below 'Consider using special escape sequence'
               """
-              \\u0027
+              \\u0022
               """;
           String r8 = // violation below 'Consider using special escape sequence'
               """
-              \\u005c
+              \\u0027
               """;
           String r9 = // violation below 'Consider using special escape sequence'
               """
+              \\u005c
+              """;
+          // The following have no escape sequences, should not cause violations
+          String r10 =
+              """
               \\u000b
               """;
-          String r10 = // violation below 'Consider using special escape sequence'
+          String r11 =
               """
               \\u001c
               """;
-          String r11 = // violation below 'Consider using special escape sequence'
-              """
-              \\u001D
-              """;
-          String r12 = // violation below 'Consider using special escape sequence'
-              """
-              \\u001E
-              """;
-          String r13 = // violation below 'Consider using special escape sequence'
-              """
-              \\u001F
-              """;
-          String r14 = // violation below 'Consider using special escape sequence'
-              """
-              \\u005c
-              """;
-          String r15 = // violation below 'Consider using special escape sequence'
+          String r12 =
               """
               \\u1680
               """;
-          String r16 = // violation below 'Consider using special escape sequence'
+          String r13 =
               """
               \\u2000
               """;
-          String r17 = // violation below 'Consider using special escape sequence'
-              """
-              \\u200A
-              """;
-          String r18 = // violation below 'Consider using special escape sequence'
-              """
-              \\u2028
-              """;
-          String r19 = // violation below 'Consider using special escape sequence'
-              """
-              \\u2029
-              """;
-          String r20 = // violation below 'Consider using special escape sequence'
-              """
-              \\u202F
-              """;
-          String r21 = // violation below 'Consider using special escape sequence'
-              """
-              \\u205F
-              """;
-          String r22 = // violation below 'Consider using special escape sequence'
+          String r14 =
               """
               \\u3000
               """;

--- a/src/main/resources/google_checks.xml
+++ b/src/main/resources/google_checks.xml
@@ -77,7 +77,7 @@
     <module name="IllegalTokenText">
       <property name="tokens" value="STRING_LITERAL, CHAR_LITERAL, TEXT_BLOCK_CONTENT"/>
       <property name="format"
-          value="\\u00(09|0(a|A)|0(b|B)|(0|1)(c|C)|(0|1)(d|D)|1(d|D)|1(e|E)|1(f|F)|22|27|5(C|c))|\\u1680|\\u3000|\\u20(00|0(a|A)|28|29|(2|5)(f|F))|\\(0(10|11|12|14|15|40|42|47)|134)"/>
+          value="\\u00(08|09|0(a|A)|0(c|C)|0(d|D)|20|22|27|5(C|c))|\\(0(10|11|12|14|15|40|42|47)|134)"/>
       <property name="message"
                value="Consider using special escape sequence instead of octal value or Unicode escaped value."/>
     </module>


### PR DESCRIPTION
Issue #18790:

PR in issue #17551 incorrectly added Unicode whitespace patterns (`\u000b` etc) to the IllegalTokenText check, assuming they should use `\s`. Per [JLS §3.10.7](https://docs.oracle.com/javase/specs/jls/se21/html/jls-3.html#jls-3.10.7 ), `\s` only represents `\u0020` (space).

from "JLS §3.10.7":
```
EscapeSequence:
\ b (backspace BS, Unicode \u0008)
\ s (space SP, Unicode \u0020)
\ t (horizontal tab HT, Unicode \u0009)
\ n (linefeed LF, Unicode \u000a)
\ f (form feed FF, Unicode \u000c)
\ r (carriage return CR, Unicode \u000d)
\ [LineTerminator](https://docs.oracle.com/javase/specs/jls/se21/html/jls-3.html#jls-LineTerminator) (line continuation, no Unicode representation)
\ " (double quote ", Unicode \u0022)
\ ' (single quote ', Unicode \u0027)
\ \ (backslash \, Unicode \u005c)
[OctalEscape](https://docs.oracle.com/javase/specs/jls/se21/html/jls-3.html#jls-OctalEscape) (octal value, Unicode \u0000 to \u00ff)
OctalEscape:
\ [OctalDigit](https://docs.oracle.com/javase/specs/jls/se21/html/jls-3.html#jls-OctalDigit)
\ [OctalDigit](https://docs.oracle.com/javase/specs/jls/se21/html/jls-3.html#jls-OctalDigit) [OctalDigit](https://docs.oracle.com/javase/specs/jls/se21/html/jls-3.html#jls-OctalDigit)
\ [ZeroToThree](https://docs.oracle.com/javase/specs/jls/se21/html/jls-3.html#jls-ZeroToThree) [OctalDigit](https://docs.oracle.com/javase/specs/jls/se21/html/jls-3.html#jls-OctalDigit) [OctalDigit](https://docs.oracle.com/javase/specs/jls/se21/html/jls-3.html#jls-OctalDigit)
OctalDigit:
(one of)
0 1 2 3 4 5 6 7
ZeroToThree:
(one of)
0 1 2 3
```


Changes:
- Fixed regex pattern in [google_checks.xml](cci:7://file:///Users/vivek/checkstyle/src/main/resources/google_checks.xml:0:0-0:0) to only flag characters with  valid escape sequences
- Added missing `\u0008` (`\b`) and `\u0020` (`\s`) detection
- Removed false positive patterns for Unicode whitespace without escapes
- Updated IT test files to reflect correct behavior

Diff Regression config: https://gist.githubusercontent.com/vivek-0509/92bf07546fa328ac048a8d06be68953a/raw/ca48cb714b2ed4976a2741de8c64026e85ee781d/base_config.xml

Diff Regression patch config: https://gist.githubusercontent.com/vivek-0509/181751a6b6938040781fbafa73725ec5/raw/34b10bec5c0c7debf1079b4690ad6031659c8393/patch_config.xml