### PR TITLE
Issue #18748: Split openrewrite-recipes CI job into two parallel jobs

### DIFF
--- a/.ci/validation.sh
+++ b/.ci/validation.sh
@@ -32,6 +32,7 @@ all-sevntu-checks)
     | grep -vE "Checker|TreeWalker|Filter|Holder" | grep -v "^$" \
     | sed "s/com\.github\.sevntu\.checkstyle\.checks\..*\.//" \
     | sort | uniq | sed "s/Check$//" > $working_dir/file.txt
+
   wget -q http://sevntu-checkstyle.github.io/sevntu.checkstyle/apidocs/allclasses-frame.html -O - \
     | grep "<li>" | cut -d '>' -f 3 | sed "s/<\/a//" \
     | grep -E "Check$" \
@@ -1378,8 +1379,8 @@ spotless)
   ./mvnw -e --no-transfer-progress spotless:check
   ;;
 
-openrewrite-recipes)
-  echo "Cloning and building OpenRewrite recipes..."
+openrewrite-recipes-1)
+  echo "Cloning and building OpenRewrite recipes (Part 1)..."
   PROJECT_ROOT="$(pwd)"
   export MAVEN_OPTS="-Xmx4g -Xms2g"
 
@@ -1394,8 +1395,37 @@ openrewrite-recipes)
   set +e
   ./mvnw -e --no-transfer-progress clean compile antrun:run@ant-phase-verify
   set -e
-  echo "Running OpenRewrite recipes..."
-  ./mvnw -e --no-transfer-progress rewrite:run -Drewrite.recipeChangeLogLevel=INFO
+  echo "Running OpenRewrite recipes Part 1..."
+  ./mvnw -e --no-transfer-progress rewrite:run \
+    -Drewrite.recipeChangeLogLevel=INFO \
+    -Drewrite.activeRecipes=org.checkstyle.AutoFixesPart1
+
+  echo "Checking for uncommitted changes..."
+  ./.ci/print-diff-as-patch.sh target/rewrite.patch
+
+  rm -rf /tmp/checkstyle-openrewrite-recipes
+  ;;
+
+openrewrite-recipes-2)
+  echo "Cloning and building OpenRewrite recipes (Part 2)..."
+  PROJECT_ROOT="$(pwd)"
+  export MAVEN_OPTS="-Xmx4g -Xms2g"
+
+  cd /tmp
+  git clone https://github.com/checkstyle/checkstyle-openrewrite-recipes.git
+  cd checkstyle-openrewrite-recipes
+  ./mvnw -e --no-transfer-progress clean install -DskipTests
+
+  cd "$PROJECT_ROOT"
+
+  echo "Running Checkstyle validation to get report for openrewrite..."
+  set +e
+  ./mvnw -e --no-transfer-progress clean compile antrun:run@ant-phase-verify
+  set -e
+  echo "Running OpenRewrite recipes Part 2..."
+  ./mvnw -e --no-transfer-progress rewrite:run \
+    -Drewrite.recipeChangeLogLevel=INFO \
+    -Drewrite.activeRecipes=org.checkstyle.AutoFixesPart2
 
   echo "Checking for uncommitted changes..."
   ./.ci/print-diff-as-patch.sh target/rewrite.patch

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -312,10 +312,13 @@ workflows:
   openrewrite:
     jobs:
       - validate-with-maven-script:
-          name: "openrewrite-recipes"
+          name: "openrewrite-recipes-1"
           image-name: "cimg/openjdk:21.0"
-          command: "./.ci/validation.sh openrewrite-recipes"
-          no_output_timeout: 15m
+          command: "./.ci/validation.sh openrewrite-recipes-1"
+      - validate-with-maven-script:
+          name: "openrewrite-recipes-2"
+          image-name: "cimg/openjdk:21.0"
+          command: "./.ci/validation.sh openrewrite-recipes-2"
 
   spotless:
     jobs:

--- a/config/jsoref-spellchecker/whitelist.words
+++ b/config/jsoref-spellchecker/whitelist.words
@@ -1167,6 +1167,7 @@ redundantimport
 redundantmodifier
 refactor
 refactoring
+Refaster
 refasterrules
 refid
 refreshenv

--- a/config/rewrite.yml
+++ b/config/rewrite.yml
@@ -2,7 +2,15 @@
 type: specs.openrewrite.org/v1beta/recipe
 name: org.checkstyle.AllAutoFixes
 displayName: Auto Fixes
-description: List of auto fixes from different providers.
+description: Master list of all auto fixes for local development.
+recipeList:
+  - org.checkstyle.AutoFixesPart1
+  - org.checkstyle.AutoFixesPart2
+---
+type: specs.openrewrite.org/v1beta/recipe
+name: org.checkstyle.AutoFixesPart1
+displayName: Auto Fixes Part 1
+description: OpenRewrite and Checkstyle standard fixes.
 recipeList:
   - org.checkstyle.autofix.CheckstyleAutoFix:
       violationReportPath: target/cs_errors.xml
@@ -16,11 +24,12 @@ recipeList:
   - org.openrewrite.java.format.NormalizeLineBreaks
   - org.openrewrite.java.format.PadEmptyForLoopComponents
   - org.openrewrite.java.format.RemoveTrailingWhitespace
-  - org.openrewrite.java.migrate.UpgradeToJava21
+  # until https://github.com/checkstyle/checkstyle/issues/18789
+  # - org.openrewrite.java.migrate.UpgradeToJava21
   - org.openrewrite.java.migrate.lang.StringRulesRecipes
   - org.openrewrite.java.migrate.util.MigrateInflaterDeflaterToClose
   - org.openrewrite.java.migrate.util.ReplaceStreamCollectWithToList
-  - org.openrewrite.java.migrate.util.SequencedCollection
+  # - org.openrewrite.java.migrate.util.SequencedCollection
   - org.openrewrite.java.recipes.JavaRecipeBestPractices
   - org.openrewrite.java.recipes.RecipeTestingBestPractices
   - org.openrewrite.maven.BestPractices
@@ -44,6 +53,12 @@ recipeList:
   - org.openrewrite.staticanalysis.UnnecessaryParentheses
   - org.openrewrite.staticanalysis.UnnecessaryReturnAsLastStatement
   - org.openrewrite.staticanalysis.UseLambdaForFunctionalInterface
+---
+type: specs.openrewrite.org/v1beta/recipe
+name: org.checkstyle.AutoFixesPart2
+displayName: Auto Fixes Part 2
+description: ErrorProne Refaster rules.
+recipeList:
   - tech.picnic.errorprone.refasterrules.BigDecimalRulesRecipes
   - tech.picnic.errorprone.refasterrules.CharSequenceRulesRecipes
   - tech.picnic.errorprone.refasterrules.ClassRulesRecipes
@@ -60,4 +75,3 @@ recipeList:
   - tech.picnic.errorprone.refasterrules.PrimitiveRulesRecipes
   - tech.picnic.errorprone.refasterrules.StreamRulesRecipes
   - tech.picnic.errorprone.refasterrules.TimeRulesRecipes
----


### PR DESCRIPTION
Fixes #18748.
this PR splits the recipes into two parallel CircleCI jobs to cut the execution time effectively in half
1) openrewrite-recipes-1: Runs 9 min
2) openrewrite-recipes-2: Runs 12 min