### PR TITLE
Issue #18599: Resolve error-prone violations

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/LineSeparatorOption.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/LineSeparatorOption.java
@@ -48,7 +48,7 @@ public enum LineSeparatorOption {
     SYSTEM(System.lineSeparator());
 
     /** The line separator representation. */
-    private final byte[] lineSeparator;
+    private final String lineSeparator;
 
     /**
      * Creates a new {@code LineSeparatorOption} instance.
@@ -56,7 +56,7 @@ public enum LineSeparatorOption {
      * @param sep the line separator, e.g. "\r\n"
      */
     LineSeparatorOption(String sep) {
-        lineSeparator = sep.getBytes(StandardCharsets.US_ASCII);
+        lineSeparator = sep;
     }
 
     /**
@@ -74,7 +74,10 @@ public enum LineSeparatorOption {
             result = LF.matches(bytes) || CR.matches(bytes);
         }
         else {
-            result = Arrays.equals(bytes, lineSeparator);
+            result = Arrays.equals(
+                    bytes,
+                    lineSeparator.getBytes(StandardCharsets.US_ASCII)
+            );
         }
         return result;
     }
@@ -86,7 +89,7 @@ public enum LineSeparatorOption {
      *     e.g. 1 for CR, 2 for CRLF, ...
      */
     public int length() {
-        return lineSeparator.length;
+        return lineSeparator.length();
     }
 
 }


### PR DESCRIPTION
Issue #18599

https://errorprone.info/bugpattern/ImmutableEnumChecker

`[WARNING] /C:/Users/brije/checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/checks/LineSeparatorOption.java:[51,26] [ImmutableEnumChecker] enums should be immutable: 'LineSeparatorOption' has field 'lineSeparator' of type 'byte[]', arrays are mutable
    (see https://errorprone.info/bugpattern/ImmutableEnumChecker)
`

The enum stored a mutable ```byte[]``` field, which violates deep immutability guarantees expected from enums. Even though the field was ```private final```, array contents remain mutable.

This change replaces the stored ```byte[]``` with an immutable ```String``` and performs byte conversion on demand. Behavior remains unchanged, but the enum is now fully immutable and compliant with Error Prone’s ```ImmutableEnumChecker```.

<img width="1919" height="967" alt="image" src="https://github.com/user-attachments/assets/fe02bf0d-ec8c-48d7-8ee9-b2fec3a23d9d" />
