### PR TITLE
Issue #17882: Update JAVADOC_INLINE_TAG_END of JavadocCommentsTokenTypes to new AST format

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/api/JavadocCommentsTokenTypes.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/api/JavadocCommentsTokenTypes.java
@@ -738,6 +738,39 @@ public final class JavadocCommentsTokenTypes {
 
     /**
      * End of an inline tag <code>}</code>.
+     *
+     * <p>This node represents the closing brace of a Javadoc inline tag like
+     * {@code @code} or {@code @link}.</p>
+     *
+     * <p><b>Example:</b></p>
+     * <pre>{@code
+     * /**
+     * * {@code code}
+     * &#42;/
+     * }</pre>
+     *
+     * <b>Tree:</b>
+     * <pre>{@code
+     * JAVADOC_CONTENT -> JAVADOC_CONTENT
+     * |--TEXT -> /**
+     * |--NEWLINE -> \n
+     * |--LEADING_ASTERISK ->   *
+     * |--TEXT ->
+     * |--JAVADOC_INLINE_TAG -> JAVADOC_INLINE_TAG
+     * |   `--CODE_INLINE_TAG -> CODE_INLINE_TAG
+     * |       |--JAVADOC_INLINE_TAG_START -> { @
+     * |       |--TAG_NAME -> code
+     * |       |--TEXT ->   code
+     * |       `--JAVADOC_INLINE_TAG_END -> }
+     * |--NEWLINE -> \n
+     * |--LEADING_ASTERISK ->   *
+     * |--TEXT -> /
+     * |--NEWLINE -> \n
+     * |--TEXT -> public class Test {}
+     * `--NEWLINE -> \n
+     * }</pre>
+     *
+     * @see #JAVADOC_INLINE_TAG
      */
     public static final int JAVADOC_INLINE_TAG_END = JavadocCommentsLexer.JAVADOC_INLINE_TAG_END;
 


### PR DESCRIPTION
## Purpose

Update the Javadoc for `JAVADOC_INLINE_TAG_END` token to include an example input and the new AST print format.

## Issue

Continuation of #17882

## Description of Changes

Added documentation to `JAVADOC_INLINE_TAG_END` token in `JavadocCommentsTokenTypes.java` including:
- A description paragraph explaining what the token represents (the closing brace of inline Javadoc tags)
- An example showing the token in context using `{@code code}`
- The AST tree structure in the new format
- A `@see` reference to `#JAVADOC_INLINE_TAG`

## CLI Output (AST print for the example)

JAVADOC_CONTENT -> JAVADOC_CONTENT
|--TEXT -> /**
|--NEWLINE -> \n
|--LEADING_ASTERISK ->   *
|--TEXT ->
|--JAVADOC_INLINE_TAG -> JAVADOC_INLINE_TAG
|   `--CODE_INLINE_TAG -> CODE_INLINE_TAG
|       |--JAVADOC_INLINE_TAG_START -> { @
|       |--TAG_NAME -> code
|       |--TEXT ->   code
|       `--JAVADOC_INLINE_TAG_END -> }
|--NEWLINE -> \n
|--LEADING_ASTERISK ->   *
|--TEXT -> /
|--NEWLINE -> \n
|--TEXT -> public class Test {}
`--NEWLINE -> \n

## Verification
-  Build passes (`mvn compile` successful)
-  Follows the pattern established by `JAVADOC_INLINE_TAG_START` documentation
-  Single commit with correct message format