### PR TITLE
Issue #17725: add regression test for whitespace around reserved words

### DIFF
--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/whitespace/WhitespaceAroundCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/whitespace/WhitespaceAroundCheckTest.java
@@ -712,4 +712,13 @@ public class WhitespaceAroundCheckTest
                 getPath(fileName),
                 expected);
     }
+
+    @Test
+    public void testWhitespaceAroundReservedWords() throws Exception {
+        final String[] expected = CommonUtil.EMPTY_STRING_ARRAY;
+
+        verifyWithInlineConfigParser(
+                getPath("InputWhitespaceAroundReservedWords.java"),
+                expected);
+    }
 }

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/whitespace/whitespacearound/InputWhitespaceAroundReservedWords.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/whitespace/whitespacearound/InputWhitespaceAroundReservedWords.java
@@ -1,0 +1,34 @@
+/*xml
+<module name="Checker">
+  <module name="TreeWalker">
+    <module name="WhitespaceAround">
+      <property name="tokens"
+        value="LITERAL_IF, LITERAL_ELSE, LITERAL_FOR, LITERAL_WHILE"/>
+    </module>
+  </module>
+</module>
+*/
+package com.puppycrawl.tools.checkstyle.checks.whitespace.whitespacearound;
+
+public class InputWhitespaceAroundReservedWords {
+
+    void testIf(int x) {
+        if    (x > 0) {
+            x++;
+        }       else       {
+            x--;
+        }
+    }
+
+    void testFor() {
+        for    (int i = 0; i < 1; i++) {
+            System.out.println(i);
+        }
+    }
+
+    void testWhile() {
+        while    (true) {
+            break;
+        }
+    }
+}

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/whitespace/whitespacearound/InputWhitespaceAroundReservedWordsFormatted.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/whitespace/whitespacearound/InputWhitespaceAroundReservedWordsFormatted.java
@@ -1,0 +1,34 @@
+/*xml
+<module name="Checker">
+  <module name="TreeWalker">
+    <module name="WhitespaceAround">
+      <property name="tokens"
+        value="LITERAL_IF, LITERAL_ELSE, LITERAL_FOR, LITERAL_WHILE"/>
+    </module>
+  </module>
+</module>
+*/
+package com.puppycrawl.tools.checkstyle.checks.whitespace.whitespacearound;
+
+public class InputWhitespaceAroundReservedWordsFormatted {
+
+    void testIf(int x) {
+        if (x > 0) {
+            x++;
+        } else {
+            x--;
+        }
+    }
+
+    void testFor() {
+        for (int i = 0; i < 1; i++) {
+            System.out.println(i);
+        }
+    }
+
+    void testWhile() {
+        while (true) {
+            break;
+        }
+    }
+}


### PR DESCRIPTION
Issue: #17725

This pull request adds a regression test for WhitespaceAroundCheck covering
reserved words (if, else, for, while) when excessive whitespace appears before
the opening parenthesis.

The test reproduces the scenario described in the issue using inline
configuration. No production code is modified in this PR

I can try working on the behavior change in a follow-up PR if needed.