### PR TITLE
Issue #15456: Define violation messages for IllegalTokenTextCheck

### DIFF
--- a/src/site/xdoc/checks/coding/illegaltokentext.xml
+++ b/src/site/xdoc/checks/coding/illegaltokentext.xml
@@ -96,7 +96,8 @@
         <div class="wrapper"><pre class="prettyprint"><code class="language-java">
 public class Example1 {
   public void myTest() {
-    String test  = "a href"; // violation
+    // violation below 'Token text matches the illegal pattern 'a href'.'
+    String test  = "a href";
     String test2 = "A href"; // ok, case is sensitive
   }
 }
@@ -120,8 +121,10 @@ public class Example1 {
         <div class="wrapper"><pre class="prettyprint"><code class="language-java">
 public class Example2 {
   public void myTest() {
-    String test  = "a href"; // violation
-    String test2 = "A href"; // violation
+    // violation below 'Token text matches the illegal pattern 'a href'.'
+    String test  = "a href";
+    // violation below 'Token text matches the illegal pattern 'a href'.'
+    String test2 = "A href";
   }
 }
 </code></pre></div><hr class="example-separator"/>
@@ -144,7 +147,7 @@ public class Example2 {
 public class Example3 {
   public void myTest() {
     final String quote = """
-            \""""; // violation above
+            \""""; // violation above 'Token text matches the illegal pattern '"'.'
   }
 }
 </code></pre></div><hr class="example-separator"/>
@@ -170,9 +173,11 @@ public class Example4 {
     int test1 = 0;
     int test2 = 0x111;
     int test3 = 0X111; // ok, case is ignored
-    int test4 = 010; // violation
+    // violation below 'Token text matches the illegal pattern'
+    int test4 = 010;
     long test5 = 0L;
-    long test6 = 010L; // violation
+    // violation below 'Token text matches the illegal pattern'
+    long test6 = 010L;
   }
 }
 </code></pre></div><hr class="example-separator"/>
@@ -195,7 +200,7 @@ public class Example4 {
         <div class="wrapper"><pre class="prettyprint"><code class="language-java">
 public class Example5 {
   public void test() {
-    String link  = "href"; // violation, Custom illegal text found
+    String link  = "href"; // violation 'Custom illegal text found'
   }
 }
 </code></pre></div>

--- a/src/test/java/com/puppycrawl/tools/checkstyle/bdd/InlineConfigParser.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/bdd/InlineConfigParser.java
@@ -236,7 +236,6 @@ public final class InlineConfigParser {
      *  Until <a href="https://github.com/checkstyle/checkstyle/issues/15456">#15456</a>.
      */
     private static final Set<String> SUPPRESSED_CHECKS = Set.of(
-            "com.puppycrawl.tools.checkstyle.checks.coding.IllegalTokenTextCheck",
             "com.puppycrawl.tools.checkstyle.checks.coding.MatchXpathCheck",
             "com.puppycrawl.tools.checkstyle.checks.coding.ModifiedControlVariableCheck",
             "com.puppycrawl.tools.checkstyle.checks.coding.MultipleStringLiteralsCheck",

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/coding/IllegalTokenTextCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/coding/IllegalTokenTextCheckTest.java
@@ -55,8 +55,8 @@ public class IllegalTokenTextCheckTest
     public void testIllegalTokenTextCheckCaseInSensitive()
             throws Exception {
         final String[] expected = {
-            "34:28: " + getCheckMessage(MSG_KEY, "a href"),
-            "35:32: " + getCheckMessage(MSG_KEY, "a href"),
+            "35:28: " + getCheckMessage(MSG_KEY, "a href"),
+            "37:32: " + getCheckMessage(MSG_KEY, "a href"),
         };
         verifyWithInlineConfigParser(
                 getPath("InputIllegalTokenTextCheckCaseInSensitive.java"), expected);
@@ -92,7 +92,7 @@ public class IllegalTokenTextCheckTest
             "19:32: " + getCheckMessage(MSG_KEY, "a href"),
             "31:37: " + getCheckMessage(MSG_KEY, "a href"),
             "36:37: " + getCheckMessage(MSG_KEY, "a href"),
-            "42:54: " + getCheckMessage(MSG_KEY, "a href"),
+            "43:54: " + getCheckMessage(MSG_KEY, "a href"),
         };
         verifyWithInlineConfigParser(
                 getPath("InputIllegalTokenTextTextBlocks.java"), expected);
@@ -103,12 +103,12 @@ public class IllegalTokenTextCheckTest
 
         final String[] expected = {
             "16:28: " + getCheckMessage(MSG_KEY, "\""),
-            "17:33: " + getCheckMessage(MSG_KEY, "\""),
-            "19:32: " + getCheckMessage(MSG_KEY, "\""),
-            "21:36: " + getCheckMessage(MSG_KEY, "\""),
-            "31:37: " + getCheckMessage(MSG_KEY, "\""),
-            "36:37: " + getCheckMessage(MSG_KEY, "\""),
-            "42:42: " + getCheckMessage(MSG_KEY, "\""),
+            "18:33: " + getCheckMessage(MSG_KEY, "\""),
+            "20:32: " + getCheckMessage(MSG_KEY, "\""),
+            "22:36: " + getCheckMessage(MSG_KEY, "\""),
+            "32:37: " + getCheckMessage(MSG_KEY, "\""),
+            "37:37: " + getCheckMessage(MSG_KEY, "\""),
+            "44:42: " + getCheckMessage(MSG_KEY, "\""),
         };
         verifyWithInlineConfigParser(
                 getPath("InputIllegalTokenTextTextBlocksQuotes.java"), expected);

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/illegaltokentext/InputIllegalTokenTextCheckCaseInSensitive.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/illegaltokentext/InputIllegalTokenTextCheckCaseInSensitive.java
@@ -31,8 +31,10 @@ public class InputIllegalTokenTextCheckCaseInSensitive
 
     public void methodWithLiterals()
     {
-        final String ref = "<a href=\""; // violation
-        final String refCase = "<A hReF=\""; // violation
+        // violation below 'Token text matches the illegal pattern 'a href'.'
+        final String ref = "<a href=\"";
+        // violation below 'Token text matches the illegal pattern 'a href'.'
+        final String refCase = "<A hReF=\"";
     }
 
     public void methodWithLabels() {

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/illegaltokentext/InputIllegalTokenTextCheckCommentToken.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/illegaltokentext/InputIllegalTokenTextCheckCommentToken.java
@@ -1,4 +1,4 @@
-/* // violation
+/* // violation 'Token text matches the illegal pattern 'a href'.'
 IllegalTokenText
 format = a href
 ignoreCase = (default)false
@@ -41,8 +41,8 @@ public class InputIllegalTokenTextCheckCommentToken
             anotherLabel: // some comment href
             do {
                 continue anotherLabel;
-            } while (false); // violation below
-            break label; // a href
+            } while (false);
+            break label; // violation 'Token text matches the illegal pattern 'a href'.'
         }
     }
 }

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/illegaltokentext/InputIllegalTokenTextCheckCustomMessageInStringLiteral.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/illegaltokentext/InputIllegalTokenTextCheckCustomMessageInStringLiteral.java
@@ -31,7 +31,7 @@ public class InputIllegalTokenTextCheckCustomMessageInStringLiteral
 
     public void methodWithLiterals()
     {
-        final String ref = "<a href=\""; // violation
+        final String ref = "<a href=\""; // violation 'My custom message'
         final String refCase = "<A hReF=\"";
     }
 

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/illegaltokentext/InputIllegalTokenTextCheckDefaultCaseSensitive.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/illegaltokentext/InputIllegalTokenTextCheckDefaultCaseSensitive.java
@@ -31,7 +31,7 @@ public class InputIllegalTokenTextCheckDefaultCaseSensitive
 
     public void methodWithLiterals()
     {
-        final String ref = "<a href=\""; // violation
+        final String ref = "<a href=\""; // violation 'Token text matches the illegal pattern 'a href'.'
         final String refCase = "<A hReF=\"";
     }
 

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/illegaltokentext/InputIllegalTokenTextCheckNullMessageInStringLiteral.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/illegaltokentext/InputIllegalTokenTextCheckNullMessageInStringLiteral.java
@@ -31,7 +31,7 @@ public class InputIllegalTokenTextCheckNullMessageInStringLiteral
 
     public void methodWithLiterals()
     {
-        final String ref = "<a href=\""; // violation
+        final String ref = "<a href=\""; // violation 'Token text matches the illegal pattern 'a href'.'
         final String refCase = "<A hReF=\"";
     }
 

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/illegaltokentext/InputIllegalTokenTextTextBlocks.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/illegaltokentext/InputIllegalTokenTextTextBlocks.java
@@ -13,11 +13,11 @@ package com.puppycrawl.tools.checkstyle.checks.coding.illegaltokentext;
 
 public class InputIllegalTokenTextTextBlocks {
     public void methodWithLiterals() {
-        final String ref = "<a href=\""; // violation
+        final String ref = "<a href=\""; // violation 'Token text matches the illegal pattern 'a href'.'
         final String refCase1 = "<A hReF=\"";
 
         final String ref2 = """
-                <a href=\""""; // violation above
+                <a href=\""""; // violation above 'Token text matches the illegal pattern 'a href'.'
         final String refCase2 = """
                 <A hReF=\"""";
 
@@ -27,20 +27,21 @@ public class InputIllegalTokenTextTextBlocks {
                         <p>Hello, world</p>\u000D\u000A\n
                     </body>\u000D\u000A\n
                 </html>\u000D\u000A
-                """; // violation below
+                """; // violation below 'Token text matches the illegal pattern 'a href'.'
         String testMoreEscapes = """
                 fun with a href\n
                 whitespace\t\r
                 and other escapes \"""
-                """; // violation below
+                """; // violation below 'Token text matches the illegal pattern 'a href'.'
         String evenMoreEscapes = """
                 \b \f \\ \0 \1 \2 \r \r\n \\r\\n \\''
                 \\11 \\57 \n\\n\n\\\n\n \\ ""a "a
                 \\uffffa href \\' \\\' \'
                 """;
+        // violation 2 lines below 'Token text matches the illegal pattern 'a href'.'
         String concat = """
                 The quick brown fox""" + "  \n" + """
-                jumps over the lazy dog a href // violation above
+                jumps over the lazy dog a href
                 """;
     }
 }

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/illegaltokentext/InputIllegalTokenTextTextBlocksQuotes.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/illegaltokentext/InputIllegalTokenTextTextBlocksQuotes.java
@@ -13,13 +13,14 @@ package com.puppycrawl.tools.checkstyle.checks.coding.illegaltokentext;
 
 public class InputIllegalTokenTextTextBlocksQuotes {
     public void methodWithLiterals() {
-        final String ref = "<a href=\""; // violation
-        final String refCase1 = "<A hReF=\""; // violation
+        final String ref = "<a href=\""; // violation 'Token text matches the illegal pattern '"''
+        // violation below 'Token text matches the illegal pattern '"'.'
+        final String refCase1 = "<A hReF=\"";
 
         final String ref2 = """
-                <a href=\""""; // violation above
+                <a href=\""""; // violation above 'Token text matches the illegal pattern '"''
         final String refCase2 = """
-                <A hReF=\""""; // violation above
+                <A hReF=\""""; // violation above 'Token text matches the illegal pattern '"''
 
         String escape = """
                 <html>\u000D\u000A\n
@@ -27,20 +28,21 @@ public class InputIllegalTokenTextTextBlocksQuotes {
                         <p>Hello, world</p>\u000D\u000A\n
                     </body>\u000D\u000A\n
                 </html>\u000D\u000A
-                """; // violation below
+                """; // violation below 'Token text matches the illegal pattern '"''
         String testMoreEscapes = """
                 fun with\n
                 whitespace\t\r
                 and other escapes \"""
-                """; // violation below
+                """; // violation below 'Token text matches the illegal pattern '"''
         String evenMoreEscapes = """
                 \b \f \\ \0 \1 \2 \r \r\n \\r\\n \\''
                 \\11 \\57 \n\\n\n\\\n\n \\ ""a "a
                 \\uffff \\' \\\' \'
                 """;
+        // violation 2 lines below 'Token text matches the illegal pattern '"''
         String concat = """
                 The quick brown fox""" + "  \n" + """
-                jumps over the lazy dog // violation above
+                jumps over the lazy dog
                 """;
     }
 }

--- a/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/checks/coding/IllegalTokenTextCheckExamplesTest.java
+++ b/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/checks/coding/IllegalTokenTextCheckExamplesTest.java
@@ -34,7 +34,7 @@ public class IllegalTokenTextCheckExamplesTest extends AbstractExamplesModuleTes
     @Test
     public void testExample1() throws Exception {
         final String[] expected = {
-            "17:20: " + getCheckMessage(MSG_KEY, "a href"),
+            "18:20: " + getCheckMessage(MSG_KEY, "a href"),
         };
 
         verifyWithInlineConfigParser(getPath("Example1.java"), expected);
@@ -43,8 +43,8 @@ public class IllegalTokenTextCheckExamplesTest extends AbstractExamplesModuleTes
     @Test
     public void testExample2() throws Exception {
         final String[] expected = {
-            "18:20: " + getCheckMessage(MSG_KEY, "a href"),
             "19:20: " + getCheckMessage(MSG_KEY, "a href"),
+            "21:20: " + getCheckMessage(MSG_KEY, "a href"),
         };
 
         verifyWithInlineConfigParser(getPath("Example2.java"), expected);
@@ -62,8 +62,8 @@ public class IllegalTokenTextCheckExamplesTest extends AbstractExamplesModuleTes
     @Test
     public void testExample4() throws Exception {
         final String[] expected = {
-            "21:17: " + getCheckMessage(MSG_KEY, "^0[^lx]"),
-            "23:18: " + getCheckMessage(MSG_KEY, "^0[^lx]"),
+            "22:17: " + getCheckMessage(MSG_KEY, "^0[^lx]"),
+            "25:18: " + getCheckMessage(MSG_KEY, "^0[^lx]"),
         };
 
         verifyWithInlineConfigParser(getPath("Example4.java"), expected);

--- a/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/coding/illegaltokentext/Example1.java
+++ b/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/coding/illegaltokentext/Example1.java
@@ -14,7 +14,8 @@ package com.puppycrawl.tools.checkstyle.checks.coding.illegaltokentext;
 // xdoc section -- start
 public class Example1 {
   public void myTest() {
-    String test  = "a href"; // violation
+    // violation below 'Token text matches the illegal pattern 'a href'.'
+    String test  = "a href";
     String test2 = "A href"; // ok, case is sensitive
   }
 }

--- a/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/coding/illegaltokentext/Example2.java
+++ b/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/coding/illegaltokentext/Example2.java
@@ -15,8 +15,10 @@ package com.puppycrawl.tools.checkstyle.checks.coding.illegaltokentext;
 // xdoc section -- start
 public class Example2 {
   public void myTest() {
-    String test  = "a href"; // violation
-    String test2 = "A href"; // violation
+    // violation below 'Token text matches the illegal pattern 'a href'.'
+    String test  = "a href";
+    // violation below 'Token text matches the illegal pattern 'a href'.'
+    String test2 = "A href";
   }
 }
 // xdoc section -- end

--- a/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/coding/illegaltokentext/Example3.java
+++ b/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/coding/illegaltokentext/Example3.java
@@ -15,7 +15,7 @@ package com.puppycrawl.tools.checkstyle.checks.coding.illegaltokentext;
 public class Example3 {
   public void myTest() {
     final String quote = """
-            \""""; // violation above
+            \""""; // violation above 'Token text matches the illegal pattern '"'.'
   }
 }
 // xdoc section -- end

--- a/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/coding/illegaltokentext/Example4.java
+++ b/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/coding/illegaltokentext/Example4.java
@@ -18,9 +18,11 @@ public class Example4 {
     int test1 = 0;
     int test2 = 0x111;
     int test3 = 0X111; // ok, case is ignored
-    int test4 = 010; // violation
+    // violation below 'Token text matches the illegal pattern'
+    int test4 = 010;
     long test5 = 0L;
-    long test6 = 010L; // violation
+    // violation below 'Token text matches the illegal pattern'
+    long test6 = 010L;
   }
 }
 // xdoc section -- end

--- a/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/coding/illegaltokentext/Example5.java
+++ b/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/coding/illegaltokentext/Example5.java
@@ -15,7 +15,7 @@ package com.puppycrawl.tools.checkstyle.checks.coding.illegaltokentext;
 // xdoc section -- start
 public class Example5 {
   public void test() {
-    String link  = "href"; // violation, Custom illegal text found
+    String link  = "href"; // violation 'Custom illegal text found'
   }
 }
 // xdoc section -- end


### PR DESCRIPTION
Issue #15456

Define violation messages for IllegalTokenTextCheck

I have successfully migrated all other input files to use inline violations. However, I am blocked on the final file: InputIllegalTokenTextTextBlocksQuotes.java.

The Problem: This file tests for illegal double quotes (") inside Text Blocks ("""). To add the required violation comment, I need to insert // violation '... pattern '"'.' inside the text block.


Example: When I attempt to add the violation like this:

```
String concat = """
        The quick brown fox""" + "  \n" + """
        jumps over the lazy dog // violation above 'Token text matches the illegal pattern '"'.'
        """;
```

It results in a double violation (one real, one caused by the comment):

<img width="1228" height="191" alt="image" src="https://github.com/user-attachments/assets/b6ef5479-5f79-43d1-90b0-3684b4ba2ed7" />

Is there a preferred approach for handling inline violations inside Text Blocks?
Thanks in advance
