### PR TITLE
Issue #17882: added javadoc comments for parameter_name token

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/api/JavadocCommentsTokenTypes.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/api/JavadocCommentsTokenTypes.java
@@ -1538,7 +1538,27 @@ public final class JavadocCommentsTokenTypes {
     public static final int FIELD_TYPE = JavadocCommentsLexer.FIELD_TYPE;
 
     /**
-     * Parameter name reference.
+     * Parameter name reference in a Javadoc {@code @param} block tag.
+     *
+     * <p><b>Example:</b></p>
+     * <pre>{@code * @param value The parameter of method.}</pre>
+     *
+     * <b>Tree:</b>
+     * <pre>{@code
+     * JAVADOC_CONTENT -> JAVADOC_CONTENT
+     * |--LEADING_ASTERISK -> *
+     * |--TEXT ->
+     * `--JAVADOC_BLOCK_TAG -> JAVADOC_BLOCK_TAG
+     *     `--PARAM_BLOCK_TAG -> PARAM_BLOCK_TAG
+     *         |--AT_SIGN -> @
+     *         |--TAG_NAME -> param
+     *         |--TEXT ->
+     *         |--PARAMETER_NAME -> value
+     *         `--DESCRIPTION -> DESCRIPTION
+     *             `--TEXT ->  The parameter of method.
+     * }</pre>
+     *
+     * @see #PARAM_BLOCK_TAG
      */
     public static final int PARAMETER_NAME = JavadocCommentsLexer.PARAMETER_NAME;
 


### PR DESCRIPTION
Issue #17882 

Here is the full CLI output (AST print) for the example input:

```bash
JAVADOC_CONTENT -> JAVADOC_CONTENT [0:0]
|--TEXT -> public class Test { [0:0]
|--NEWLINE -> \n [0:19]
|--TEXT ->     /** [1:0]
|--NEWLINE -> \n [1:7]
|--LEADING_ASTERISK ->      * [2:0]
|--TEXT ->   [2:6]
|--JAVADOC_BLOCK_TAG -> JAVADOC_BLOCK_TAG [2:7]
|   `--PARAM_BLOCK_TAG -> PARAM_BLOCK_TAG [2:7]
|       |--AT_SIGN -> @ [2:7]
|       |--TAG_NAME -> param [2:8]
|       |--TEXT ->   [2:13]
|       |--PARAMETER_NAME -> value [2:14]
|       `--DESCRIPTION -> DESCRIPTION [2:19]
|           |--TEXT ->  The parameter of method. [2:19]
|           |--NEWLINE -> \n [2:44]
|           |--LEADING_ASTERISK ->      * [3:0]
|           |--TEXT -> / [3:6]
|           |--NEWLINE -> \n [3:7]
|           |--TEXT ->     public void foo(int value) {} [4:0]
|           |--NEWLINE -> \n [4:33]
|           `--TEXT -> } [5:0]
`--NEWLINE -> \n [5:1]
```

@romani please review