### PR TITLE
Issue #18435: Remove HiddenField Example7 from XdocsExamplesAstConsis…

### DIFF
--- a/src/site/xdoc/checks/coding/hiddenfield.xml
+++ b/src/site/xdoc/checks/coding/hiddenfield.xml
@@ -375,8 +375,7 @@ class Example7 {
   private String field;
   private String testField;
 
-  Example7(int field) { // violation, ''field' hides a field'
-    this.field = Integer.toString(field);
+  Example7(String field) { // violation, ''field' hides a field'
   }
   void method(String param) {
     String field = param; // violation, ''field' hides a field'

--- a/src/test/java/com/puppycrawl/tools/checkstyle/internal/XdocsExamplesAstConsistencyTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/internal/XdocsExamplesAstConsistencyTest.java
@@ -100,7 +100,6 @@ public class XdocsExamplesAstConsistencyTest {
             "checks/blocks/rightcurly/Example5",
             "checks/coding/constructorsdeclarationgrouping/Example2",
             "checks/coding/covariantequals/Example2",
-            "checks/coding/hiddenfield/Example7",
             "checks/coding/illegaltoken/Example2",
             "checks/coding/illegaltokentext/Example3",
             "checks/coding/illegaltokentext/Example4",

--- a/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/checks/coding/HiddenFieldCheckExamplesTest.java
+++ b/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/checks/coding/HiddenFieldCheckExamplesTest.java
@@ -102,10 +102,10 @@ public class HiddenFieldCheckExamplesTest extends AbstractExamplesModuleTestSupp
     @Test
     public void testExample7() throws Exception {
         final String[] expected = {
-            "18:16: " + getCheckMessage(MSG_KEY, "field"),
-            "22:12: " + getCheckMessage(MSG_KEY, "field"),
-            "24:28: " + getCheckMessage(MSG_KEY, "testField"),
-            "27:28: " + getCheckMessage(MSG_KEY, "field"),
+            "18:19: " + getCheckMessage(MSG_KEY, "field"),
+            "21:12: " + getCheckMessage(MSG_KEY, "field"),
+            "23:28: " + getCheckMessage(MSG_KEY, "testField"),
+            "26:28: " + getCheckMessage(MSG_KEY, "field"),
         };
 
         verifyWithInlineConfigParser(getPath("Example7.java"), expected);

--- a/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/coding/hiddenfield/Example7.java
+++ b/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/coding/hiddenfield/Example7.java
@@ -15,8 +15,7 @@ class Example7 {
   private String field;
   private String testField;
 
-  Example7(int field) { // violation, ''field' hides a field'
-    this.field = Integer.toString(field);
+  Example7(String field) { // violation, ''field' hides a field'
   }
   void method(String param) {
     String field = param; // violation, ''field' hides a field'


### PR DESCRIPTION
Issue: #18435

Remove HiddenField Example7 from supression  XdocsExamplesAstConsistencyTest 
Example 1 and Example 7 code were same only configuration were different and violationcomment.
Diffchecker link  of Example 1 vs Example 7 : https://www.diffchecker.com/VMp0OFMs/
<img width="1442" height="407" alt="Screenshot 2026-01-27 113725" src="https://github.com/user-attachments/assets/fa541e46-935c-4ce4-9601-f9ee8be7f7b7" />
<img width="1416" height="243" alt="Screenshot 2026-01-27 113643" src="https://github.com/user-attachments/assets/2a5854e2-8e93-457f-bf74-b757006150ae" />
In Example7 it is showing ` <property name="ignoreAbstractMethods" value="true"/> `
By default it is false so in all Examples it show violation in Example7 it is not.