### PR TITLE
Issue #17882: added comments for hash token

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/api/JavadocCommentsTokenTypes.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/api/JavadocCommentsTokenTypes.java
@@ -1148,7 +1148,29 @@ public final class JavadocCommentsTokenTypes {
     public static final int IDENTIFIER = JavadocCommentsLexer.IDENTIFIER;
 
     /**
-     * Hash symbol {@code #} used in references.
+     * Hash symbol {@code #} used in references within Javadoc.
+     *
+     * <p><b>Example:</b></p>
+     * <pre>{@code * @see MyClass#myMethod()}</pre>
+     *
+     * <b>Tree:</b>
+     * <pre>{@code
+     * |--LEADING_ASTERISK -> *
+     * |--TEXT ->
+     * |--JAVADOC_BLOCK_TAG -> JAVADOC_BLOCK_TAG
+     * |   `--SEE_BLOCK_TAG -> SEE_BLOCK_TAG
+     * |       |--AT_SIGN -> @
+     * |       |--TAG_NAME -> see
+     * |       |--TEXT ->
+     * |       `--REFERENCE -> REFERENCE
+     * |           |--IDENTIFIER -> MyClass
+     * |           |--HASH -> #
+     * |           |--IDENTIFIER -> myMethod
+     * |           |--LPAREN -> (
+     * |           `--RPAREN -> )
+     * }</pre>
+     *
+     * @see #REFERENCE
      */
     public static final int HASH = JavadocCommentsLexer.HASH;
 


### PR DESCRIPTION
Issue #17882 
updated javadoc comments for hash token

here is the full CLI output:
```
    JAVADOC_CONTENT -> JAVADOC_CONTENT [0:0]
|--TEXT -> /** [0:0]
|--NEWLINE -> \n [0:3]
|--LEADING_ASTERISK ->  * [1:0]
|--TEXT ->   [1:2]
|--JAVADOC_BLOCK_TAG -> JAVADOC_BLOCK_TAG [1:3]
|   `--SEE_BLOCK_TAG -> SEE_BLOCK_TAG [1:3]
|       |--AT_SIGN -> @ [1:3]
|       |--TAG_NAME -> see [1:4]
|       |--TEXT ->   [1:7]
|       |--REFERENCE -> REFERENCE [1:8]
|       |   |--IDENTIFIER -> MyClass [1:8]
|       |   |--HASH -> # [1:15]
|       |   `--MEMBER_REFERENCE -> MEMBER_REFERENCE [1:16]
|       |       |--IDENTIFIER -> myMethod [1:16]
|       |       |--LPAREN -> ( [1:24]
|       |       `--RPAREN -> ) [1:25]
|       |--NEWLINE -> \n [1:26]
|       |--LEADING_ASTERISK ->  * [2:0]
|       `--DESCRIPTION -> DESCRIPTION [2:2]
|           |--TEXT -> / [2:2]
|           |--NEWLINE -> \n [2:3]
|           |--TEXT -> public class Test { [3:0]
|           |--NEWLINE -> \n [3:19]
|           `--TEXT -> } [4:0]
`--NEWLINE -> \n [4:1]
```
