### PR TITLE
Issue #17882: added comments for SNIPPET_* tokens

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/api/JavadocCommentsTokenTypes.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/api/JavadocCommentsTokenTypes.java
@@ -1072,7 +1072,7 @@ public final class JavadocCommentsTokenTypes {
      * code snippets directly inside a Javadoc sentence.</p>
      *
      * <p><b>Example:</b></p>
-     * <pre>{ @code * Example showing { @snippet :java |
+     * <pre>{ @code * Example showing { @snippet :java
      * System.out.println("hello");
      * }}</pre>
      *
@@ -1085,7 +1085,7 @@ public final class JavadocCommentsTokenTypes {
      *         |--JAVADOC_INLINE_TAG_START -> { @
      *         |--COLON -> :
      *         |--SNIPPET_BODY -> SNIPPET_BODY
-     *         |   |--TEXT -> java |
+     *         |   |--TEXT -> java
      *         |   |--NEWLINE -> \n
      *         |   |--LEADING_ASTERISK -> *
      *         |   |--TEXT -> System.out.println("hello");
@@ -1521,7 +1521,35 @@ public final class JavadocCommentsTokenTypes {
     public static final int FORMAT_SPECIFIER = JavadocCommentsLexer.FORMAT_SPECIFIER;
 
     /**
-     * Attribute name in a {@code @snippet}.
+     * Attribute name in a {@code @snippet} tag.
+     *
+     * <p>
+     * <b>Note:</b> In the current Checkstyle AST, all snippet attributes (such as
+     * {@code lang=java}) appear as plain text under the {@code DESCRIPTION} node.
+     * There is <b>no</b> {@code SNIPPET_ATTR_NAME} node in the AST tree.
+     * All attribute content is represented as {@code TEXT}.</p>
+     *
+     * <p>
+     * <b>Example:</b>
+     * </p>
+     * <pre>{@code * @snippet lang=java}</pre>
+     *
+     * <p>
+     * <b>Tree:</b>
+     * </p>
+     * <pre>{@code
+     * JAVADOC_CONTENT -> JAVADOC_CONTENT
+     * |--LEADING_ASTERISK ->  *
+     * |--TEXT ->
+     * `--JAVADOC_BLOCK_TAG -> JAVADOC_BLOCK_TAG
+     *    `--CUSTOM_BLOCK_TAG -> CUSTOM_BLOCK_TAG
+     *        |--AT_SIGN -> @
+     *        |--TAG_NAME -> snippet
+     *        `--DESCRIPTION -> DESCRIPTION
+     *            `--TEXT ->  lang=java
+     * }</pre>
+     *
+     * @see #SNIPPET_ATTRIBUTE
      */
     public static final int SNIPPET_ATTR_NAME = JavadocCommentsLexer.SNIPPET_ATTR_NAME;
 
@@ -1597,17 +1625,88 @@ public final class JavadocCommentsTokenTypes {
     public static final int INDEX_TERM = JavadocCommentsLexer.INDEX_TERM;
 
     /**
-     * Single snippet attribute.
+     * Single attribute in a {@code @snippet} tag.
+     *
+     * <p>
+     * Represents a single attribute (e.g., {@code lang=java})
+     * in a {@code @snippet} tag.</p>
+     *
+     * <p><b>Note:</b> In the current Checkstyle AST, all snippet
+     * attributes appear as plain text under the {@code DESCRIPTION} node,
+     * not as a separate {@code SNIPPET_ATTRIBUTE} node.</p>
+     *
+     * <p><b>Example:</b></p>
+     * <pre>{@code * @snippet lang=java}</pre>
+     *
+     * <p><b>Tree:</b></p>
+     * <pre>{@code
+     * JAVADOC_CONTENT -> JAVADOC_CONTENT
+     * |--LEADING_ASTERISK ->  *
+     * |--TEXT ->
+     * `--JAVADOC_BLOCK_TAG -> JAVADOC_BLOCK_TAG
+     *    `--CUSTOM_BLOCK_TAG -> CUSTOM_BLOCK_TAG
+     *        |--AT_SIGN -> @
+     *        |--TAG_NAME -> snippet
+     *        `--DESCRIPTION -> DESCRIPTION
+     *            `--TEXT ->  lang=java
+     * }</pre>
      */
     public static final int SNIPPET_ATTRIBUTE = JavadocCommentsLexer.SNIPPET_ATTRIBUTE;
 
     /**
-     * Collection of snippet attributes.
+     * Collection of attributes in a {@code @snippet} tag.
+     *
+     * <p>
+     * Represents all attributes (e.g., {@code lang=java region=main}) in a {@code @snippet} tag.
+     * </p>
+     *
+     * <p><b>Note:</b> In the current Checkstyle AST, all snippet attributes appear as
+     * plain text under the {@code DESCRIPTION} node, not as a separate
+     * {@code SNIPPET_ATTRIBUTES} node.</p>
+     *
+     * <p><b>Example:</b></p>
+     * <pre>{@code * @snippet lang=java region=main}</pre>
+     *
+     * <p><b>Tree:</b></p>
+     * <pre>{@code
+     * JAVADOC_CONTENT -> JAVADOC_CONTENT
+     * |--LEADING_ASTERISK ->  *
+     * |--TEXT ->
+     * `--JAVADOC_BLOCK_TAG -> JAVADOC_BLOCK_TAG
+     *    `--CUSTOM_BLOCK_TAG -> CUSTOM_BLOCK_TAG
+     *        |--AT_SIGN -> @
+     *        |--TAG_NAME -> snippet
+     *        `--DESCRIPTION -> DESCRIPTION
+     *            `--TEXT ->  lang=java region=main
+     * }</pre>
      */
     public static final int SNIPPET_ATTRIBUTES = JavadocCommentsLexer.SNIPPET_ATTRIBUTES;
 
     /**
-     * Body content of a {@code @snippet}.
+     * Body content of a {@code @snippet} tag.
+     *
+     * <p>
+     * Represents the code or text content inside a {@code @snippet} tag in Javadoc.
+     * </p>
+     *
+     * <b>Example:</b>
+     * <pre>{@code * @snippet lang=java * System.out.println("hello");}</pre>
+     *
+     * <b>Tree:</b>
+     * <pre>{@code
+     * JAVADOC_CONTENT -> JAVADOC_CONTENT
+     * |--LEADING_ASTERISK ->  *
+     * |--TEXT ->
+     * `--JAVADOC_BLOCK_TAG -> JAVADOC_BLOCK_TAG
+     *    `--CUSTOM_BLOCK_TAG -> CUSTOM_BLOCK_TAG
+     *        |--AT_SIGN -> @
+     *        |--TAG_NAME -> snippet
+     *        `--DESCRIPTION -> DESCRIPTION
+     *            |--TEXT ->  lang=java
+     *            |--NEWLINE -> \n
+     *            |--LEADING_ASTERISK ->  *
+     *            `--TEXT -> System.out.println("hello");
+     * }</pre>
      */
     public static final int SNIPPET_BODY = JavadocCommentsLexer.SNIPPET_BODY;
 


### PR DESCRIPTION
Issue #17882 
added javadoc comments for SNIPPET_ATTR_NAME token

Here is the full CLI output:
```
  JAVADOC_CONTENT -> JAVADOC_CONTENT [0:0]
|--TEXT -> public class Test { [0:0]
|--NEWLINE -> \n [0:19]
|--TEXT ->     /** [1:0]
|--NEWLINE -> \n [1:7]
|--LEADING_ASTERISK ->      * [2:0]
|--TEXT ->   [2:6]
|--JAVADOC_BLOCK_TAG -> JAVADOC_BLOCK_TAG [2:7]
|   `--CUSTOM_BLOCK_TAG -> CUSTOM_BLOCK_TAG [2:7]
|       |--AT_SIGN -> @ [2:7]
|       |--TAG_NAME -> snippet [2:8]
|       `--DESCRIPTION -> DESCRIPTION [2:15]
|           |--TEXT ->  lang=java [2:15]
|           |--NEWLINE -> \n [2:25]
|           |--LEADING_ASTERISK ->      * [3:0]
|           |--TEXT -> / [3:6]
|           |--NEWLINE -> \n [3:7]
|           |--TEXT ->     void example() {} [4:0]
|           |--NEWLINE -> \n [4:21]
|           `--TEXT -> } [5:0]
```


