### PR TITLE
Issue #11602: Convert no-error-equalsverifier regression to CLI

### DIFF
--- a/.ci/validation.sh
+++ b/.ci/validation.sh
@@ -882,12 +882,15 @@ no-error-methods-distance)
 no-error-equalsverifier)
   CS_POM_VERSION="$(getCheckstylePomVersion)"
   echo CS_version: "${CS_POM_VERSION}"
-  ./mvnw -e --no-transfer-progress clean install -Pno-validations
+  ./mvnw -e --no-transfer-progress clean package -Passembly,no-validations
   echo "Checkout target sources ..."
   checkout_from https://github.com/jqno/equalsverifier.git
   cd .ci-temp/equalsverifier
-  mvn -e --no-transfer-progress -Pstatic-analysis-checkstyle -DdisableStaticAnalysis compile \
-    checkstyle:check -Dversion.checkstyle="${CS_POM_VERSION}"
+  readarray -t files < <(find . \( -path '*/src/main/java/*.java' \
+    -o -path '*/src/test/java/*.java' \))
+  java -jar "../../target/checkstyle-${CS_POM_VERSION}-all.jar" \
+    -c build/checkstyle-config.xml \
+    "${files[@]}"
   cd ../
   removeFolderWithProtectedFiles equalsverifier
   ;;

--- a/config/jsoref-spellchecker/whitelist.words
+++ b/config/jsoref-spellchecker/whitelist.words
@@ -274,7 +274,6 @@ Dconfig
 Dconnection
 ddd
 DDDL
-Ddisable
 Ddry
 DEADBEEF
 DECCHARS
@@ -1130,7 +1129,6 @@ protonpack
 Psevntu
 PSHOME
 PSMODULEP
-Pstatic
 pubconstr
 pubifc
 PUBLI
@@ -1158,6 +1156,7 @@ rcurly
 rdiachenko
 RDz
 reactivex
+readarray
 README
 Readonly
 rebased


### PR DESCRIPTION
Issue #11602:

Converts the no-error-equalsverifier regression test from using maven-checkstyle-plugin to direct Checkstyle CLI usage.