### PR TITLE
Issue #15456: Define violation messages for NestedTryDepthCheck

### DIFF
--- a/src/test/java/com/puppycrawl/tools/checkstyle/bdd/InlineConfigParser.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/bdd/InlineConfigParser.java
@@ -240,7 +240,6 @@ public final class InlineConfigParser {
             "com.puppycrawl.tools.checkstyle.checks.coding.MatchXpathCheck",
             "com.puppycrawl.tools.checkstyle.checks.coding.ModifiedControlVariableCheck",
             "com.puppycrawl.tools.checkstyle.checks.coding.MultipleStringLiteralsCheck",
-            "com.puppycrawl.tools.checkstyle.checks.coding.NestedTryDepthCheck",
             "com.puppycrawl.tools.checkstyle.checks.coding.StringLiteralEqualityCheck",
             "com.puppycrawl.tools.checkstyle.checks.coding.SuperFinalizeCheck",
             "com.puppycrawl.tools.checkstyle.checks.coding"

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/nestedtrydepth/InputNestedTryDepth.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/nestedtrydepth/InputNestedTryDepth.java
@@ -26,7 +26,7 @@ public class InputNestedTryDepth
         // nesting == 2
         try {
             try {
-                try { // violation
+                try { // violation, 'Nested try depth is 2 (max allowed is 1).'
                 } catch (Exception e) {
                 }
             } catch (Exception e) {
@@ -37,8 +37,8 @@ public class InputNestedTryDepth
         // nesting == 3
         try {
             try {
-                try { // violation
-                    try { // violation
+                try { // violation, 'Nested try depth is 2 (max allowed is 1).'
+                    try { // violation, 'Nested try depth is 3 (max allowed is 1).'
                     } catch (Exception e) {
                     }
                 } catch (Exception e) {

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/nestedtrydepth/InputNestedTryDepthMax.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/nestedtrydepth/InputNestedTryDepthMax.java
@@ -38,7 +38,7 @@ public class InputNestedTryDepthMax
         try {
             try {
                 try {
-                    try { // violation
+                    try { // violation, 'Nested try depth is 3 (max allowed is 2).'
                     } catch (Exception e) {
                     }
                 } catch (Exception e) {


### PR DESCRIPTION
Issue: #15456

## Summary
Define explicit violation messages for NestedTryDepthCheck test input files.

## Changes
- Added violation messages to `InputNestedTryDepth.java` (3 violations)
- Added violation messages to `InputNestedTryDepthMax.java` (1 violation)  
- Removed `NestedTryDepthCheck` from SUPPRESSED_CHECKS in InlineConfigParser.java

## Message Format
`'Nested try depth is X (max allowed is Y).'`