### PR TITLE
Issue #17663: Fixing False negatives (indentation)

### DIFF
--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/indentation/IndentationCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/indentation/IndentationCheckTest.java
@@ -3075,6 +3075,53 @@ public class IndentationCheckTest extends AbstractModuleTestSupport {
     }
 
     @Test
+    public void testIndentationContinuationLines() throws Exception {
+        final DefaultConfiguration checkConfig = createModuleConfig(IndentationCheck.class);
+        checkConfig.addProperty("basicOffset", "2");
+        checkConfig.addProperty("lineWrappingIndentation", "4");
+        checkConfig.addProperty("braceAdjustment", "2");
+        checkConfig.addProperty("caseIndent", "2");
+        checkConfig.addProperty("throwsIndent", "4");
+        checkConfig.addProperty("tabWidth", "4");
+
+        final String fileName = getPath("InputIndentationContinuationLines.java");
+
+        final String[] expected = {
+            "16:5: " + getCheckMessage(MSG_CHILD_ERROR, "method def", 4, 8),
+            "17:5: " + getCheckMessage(MSG_CHILD_ERROR, "method def", 4, 8),
+            "22:5: " + getCheckMessage(MSG_ERROR, "lambda arguments", 4, 8),
+            "27:5: " + getCheckMessage(MSG_CHILD_ERROR, "method call", 4, 8),
+            "28:5: " + getCheckMessage(MSG_CHILD_ERROR, "method call", 4, 8),
+            "29:5: " + getCheckMessage(MSG_CHILD_ERROR, "method call", 4, 8),
+            "35:7: " + getCheckMessage(MSG_CHILD_ERROR, "method def", 6, 8),
+            "40:7: " + getCheckMessage(MSG_ERROR, "lambda arguments", 6, 8),
+        };
+
+        verifyWarns(checkConfig, fileName, expected);
+    }
+
+    @Test
+    public void testIndentationLambdaCoverage() throws Exception {
+        final DefaultConfiguration checkConfig = createModuleConfig(IndentationCheck.class);
+        checkConfig.addProperty("basicOffset", "2");
+        checkConfig.addProperty("lineWrappingIndentation", "4");
+        checkConfig.addProperty("braceAdjustment", "2");
+        checkConfig.addProperty("caseIndent", "2");
+        checkConfig.addProperty("throwsIndent", "4");
+        checkConfig.addProperty("tabWidth", "4");
+
+        final String fileName = getPath("InputIndentationLambdaCoverage.java");
+
+        final String[] expected = {
+            "21:9: " + getCheckMessage(MSG_CHILD_ERROR, "block", 8, 6),
+            "43:5: " + getCheckMessage(MSG_ERROR, "42", 4, 8),
+            "57:3: " + getCheckMessage(MSG_ERROR, "42", 2, 8),
+        };
+
+        verifyWarns(checkConfig, fileName, expected);
+    }
+
+    @Test
     public void testSeparatedStatements() throws Exception {
         final DefaultConfiguration checkConfig = createModuleConfig(IndentationCheck.class);
         checkConfig.addProperty("tabWidth", "4");

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/indentation/indentation/InputIndentationContinuationLines.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/indentation/indentation/InputIndentationContinuationLines.java
@@ -1,0 +1,69 @@
+// Java17                                                                    //indent:0 exp:0
+
+package com.puppycrawl.tools.checkstyle.checks.indentation.indentation;      //indent:0 exp:0
+
+/* Config:                                                                   //indent:0 exp:0
+ * basicOffset = 2                                                           //indent:1 exp:1
+ * braceAdjustment = 2                                                       //indent:1 exp:1
+ * caseIndent = 2                                                            //indent:1 exp:1
+ * tabWidth = 4                                                              //indent:1 exp:1
+ * lineWrappingIndentation = 4                                               //indent:1 exp:1
+ */                                                                          //indent:1 exp:1
+
+public class InputIndentationContinuationLines {                             //indent:0 exp:0
+  int sum(int a, int b, int c) {                                             //indent:2 exp:2
+    return a                                                                 //indent:4 exp:4
+    + b                                                                      //indent:4 exp:8 warn
+    + c;                                                                     //indent:4 exp:8 warn
+  }                                                                          //indent:2 exp:2
+
+  java.util.function.Function<String, Integer> test_arrow() {                //indent:2 exp:2
+    return (String s) ->                                                     //indent:4 exp:4
+    s.length();                                                              //indent:4 exp:8 warn
+  }                                                                          //indent:2 exp:2
+
+  int test_comma() {                                                         //indent:2 exp:2
+    return sum(                                                              //indent:4 exp:4
+    1,                                                                       //indent:4 exp:8 warn
+    2,                                                                       //indent:4 exp:8 warn
+    3                                                                        //indent:4 exp:8 warn
+    );                                                                       //indent:4 exp:4
+  }                                                                          //indent:2 exp:2
+
+  int sum2(int a, int b, int c) {                                            //indent:2 exp:2
+    return a + b                                                             //indent:4 exp:4
+      + c;                                                                   //indent:6 exp:8 warn
+  }                                                                          //indent:2 exp:2
+
+  java.util.function.Function<String, Integer> testArrow() {                 //indent:2 exp:2
+    return (String s) ->                                                     //indent:4 exp:4
+      s.length();                                                            //indent:6 exp:8 warn
+  }                                                                          //indent:2 exp:2
+
+  java.util.function.Function<String, Integer> testArrowSameLine() {         //indent:2 exp:2
+    return (String s) -> s.length();                                         //indent:4 exp:4
+  }                                                                          //indent:2 exp:2
+
+  int testComma() {                                                          //indent:2 exp:2
+    return sum(                                                              //indent:4 exp:4
+        1,                                                                   //indent:8 exp:8
+        2,                                                                   //indent:8 exp:8
+        3                                                                    //indent:8 exp:8
+    );                                                                       //indent:4 exp:4
+  }                                                                          //indent:2 exp:2
+
+  int testCommaSameLine() {                                                  //indent:2 exp:2
+    return sum(1, 2, 3);                                                     //indent:4 exp:4
+  }                                                                          //indent:2 exp:2
+
+  void testLambdaWithExpression() {                                          //indent:2 exp:2
+    java.util.function.Supplier<Integer> supplier = () ->                    //indent:4 exp:4
+        42;                                                                  //indent:8 exp:8
+  }                                                                          //indent:2 exp:2
+
+  void testLambdaBlock() {                                                   //indent:2 exp:2
+    java.util.function.Supplier<Integer> supplier = () -> {                  //indent:4 exp:4
+      return 42;                                                             //indent:6 exp:6
+    };                                                                       //indent:4 exp:4
+  }                                                                          //indent:2 exp:2
+}                                                                            //indent:0 exp:0

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/indentation/indentation/InputIndentationLambdaCoverage.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/indentation/indentation/InputIndentationLambdaCoverage.java
@@ -1,0 +1,64 @@
+// Java17                                                                    //indent:0 exp:0
+
+package com.puppycrawl.tools.checkstyle.checks.indentation.indentation;      //indent:0 exp:0
+
+import java.util.Optional;                                                   //indent:0 exp:0
+import java.util.function.Function;                                          //indent:0 exp:0
+import java.util.function.Supplier;                                          //indent:0 exp:0
+
+/* Config:                                                                   //indent:0 exp:0
+ * basicOffset = 2                                                           //indent:1 exp:1
+ * braceAdjustment = 2                                                       //indent:1 exp:1
+ * caseIndent = 2                                                            //indent:1 exp:1
+ * tabWidth = 4                                                              //indent:1 exp:1
+ * lineWrappingIndentation = 4                                               //indent:1 exp:1
+ */                                                                          //indent:1 exp:1
+
+public class InputIndentationLambdaCoverage {                                //indent:0 exp:0
+
+  void testLambdaBlockWrongIndent() {                                        //indent:2 exp:2
+    Supplier<Integer> supplier = () -> {                                     //indent:4 exp:4
+        return 42;                                                           //indent:8 exp:6 warn
+    };                                                                       //indent:4 exp:4
+  }                                                                          //indent:2 exp:2
+
+  void testLambdaBlockCorrectIndentMultiLine() {                             //indent:2 exp:2
+    Supplier<Integer> supplier = () -> {                                     //indent:4 exp:4
+      int x = 10;                                                            //indent:6 exp:6
+      return x;                                                              //indent:6 exp:6
+    };                                                                       //indent:4 exp:4
+  }                                                                          //indent:2 exp:2
+
+  void testLambdaExpressionNoBlock() {                                       //indent:2 exp:2
+    Function<Integer, Integer> func = (Integer x) ->                         //indent:4 exp:4
+        x * 2;                                                               //indent:8 exp:8
+  }                                                                          //indent:2 exp:2
+
+  void testLambdaExpressionNoBlockSameLine() {                               //indent:2 exp:2
+    Function<Integer, Integer> func = (Integer x) -> x * 2;                  //indent:4 exp:4
+  }                                                                          //indent:2 exp:2
+
+  void testLambdaWrongIndent() {                                             //indent:2 exp:2
+    Supplier<Integer> supplier = () ->                                       //indent:4 exp:4
+    42;                                                                      //indent:4 exp:8 warn
+  }                                                                          //indent:2 exp:2
+
+  void testLambdaBlockSameLineAsArrow() {                                    //indent:2 exp:2
+    Supplier<Integer> supplier = () -> { return 42; };                       //indent:4 exp:4
+  }                                                                          //indent:2 exp:2
+
+  void testLambdaCorrectIndent() {                                           //indent:2 exp:2
+    Supplier<Integer> supplier = () ->                                       //indent:4 exp:4
+        42;                                                                  //indent:8 exp:8
+  }                                                                          //indent:2 exp:2
+
+  void testLambdaExpressionWrongColumn() {                                   //indent:2 exp:2
+    Supplier<Integer> supplier = () ->                                       //indent:4 exp:4
+  42;                                                                        //indent:2 exp:8 warn
+  }                                                                          //indent:2 exp:2
+
+  void testLambdaAsArgument() {                                              //indent:2 exp:2
+    Optional.of("test").map(s ->                                             //indent:4 exp:4
+        s.length());                                                         //indent:8 exp:8
+  }                                                                          //indent:2 exp:2
+}                                                                            //indent:0 exp:0


### PR DESCRIPTION
Issue #17663: Fixing False negatives (indentation)


In the original issue #17663, there were 2 false negatives. One was with arrow lambda expression as such
```
  java.util.function.Function<String, Integer> test_arrow() {
    return (String s) ->
    s.length(); // Expected Violation (but ignored)
  }
```

the other one was with MethodCallHandler:

```
  int test_comma() {
    return sum(
    1, // Expected Violation (but ignored)
    2, // Expected Violation (but ignored)
    3  // Expected Violation (but ignored)
    );
```

Both false negatives have been addressed in the changes