### PR TITLE
Issue #13351: Resolve violations from spotbugs sb-contrib for ScopeUtil

### DIFF
--- a/config/checker-framework-suppressions/checker-nullness-optional-interning-suppressions.xml
+++ b/config/checker-framework-suppressions/checker-nullness-optional-interning-suppressions.xml
@@ -9272,36 +9272,7 @@
     <fileName>src/main/java/com/puppycrawl/tools/checkstyle/utils/ScopeUtil.java</fileName>
     <specifier>introduce.eliminate</specifier>
     <message>It is bad style to create an Optional just to chain methods to get a non-optional value.</message>
-    <lineContent>.orElseGet(() -&gt; getDefaultScope(aMods));</lineContent>
-  </checkerFrameworkError>
-
-  <checkerFrameworkError unstable="false">
-    <fileName>src/main/java/com/puppycrawl/tools/checkstyle/utils/ScopeUtil.java</fileName>
-    <specifier>introduce.eliminate</specifier>
-    <message>It is bad style to create an Optional just to chain methods to get a non-optional value.</message>
     <lineContent>.orElseGet(() -&gt; getDefaultScope(ast));</lineContent>
-  </checkerFrameworkError>
-
-  <checkerFrameworkError unstable="false">
-    <fileName>src/main/java/com/puppycrawl/tools/checkstyle/utils/ScopeUtil.java</fileName>
-    <specifier>return</specifier>
-    <message>incompatible types in return.</message>
-    <lineContent>return result;</lineContent>
-    <details>
-      type of expression: @Initialized @Nullable Scope
-      method return type: @Initialized @NonNull Scope
-    </details>
-  </checkerFrameworkError>
-
-  <checkerFrameworkError unstable="false">
-    <fileName>src/main/java/com/puppycrawl/tools/checkstyle/utils/ScopeUtil.java</fileName>
-    <specifier>return</specifier>
-    <message>incompatible types in return.</message>
-    <lineContent>return returnValue;</lineContent>
-    <details>
-      type of expression: @Initialized @Nullable Scope
-      method return type: @Initialized @NonNull Scope
-    </details>
   </checkerFrameworkError>
 
   <checkerFrameworkError unstable="false">

--- a/config/checker-framework-suppressions/checker-purity-value-returns-suppressions.xml
+++ b/config/checker-framework-suppressions/checker-purity-value-returns-suppressions.xml
@@ -1,6 +1,61 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <suppressedErrors>
   <checkerFrameworkError unstable="false">
+    <fileName>src/main/java/com/puppycrawl/tools/checkstyle/checks/design/DesignForExtensionCheck.java</fileName>
+    <specifier>argument</specifier>
+    <message>incompatible argument for parameter other of Optional.orElse.</message>
+    <lineContent>.orElse(Boolean.FALSE);</lineContent>
+    <details>
+      found   : @BoolVal(false) Boolean
+      required: Boolean
+    </details>
+  </checkerFrameworkError>
+
+  <checkerFrameworkError unstable="false">
+    <fileName>src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocStyleCheck.java</fileName>
+    <specifier>argument</specifier>
+    <message>incompatible argument for parameter other of Optional.orElse.</message>
+    <lineContent>.orElse(Boolean.FALSE);</lineContent>
+    <details>
+      found   : @BoolVal(false) Boolean
+      required: Boolean
+    </details>
+  </checkerFrameworkError>
+
+  <checkerFrameworkError unstable="false">
+    <fileName>src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocTypeCheck.java</fileName>
+    <specifier>argument</specifier>
+    <message>incompatible argument for parameter other of Optional.orElse.</message>
+    <lineContent>.orElse(Boolean.FALSE);</lineContent>
+    <details>
+      found   : @BoolVal(false) Boolean
+      required: Boolean
+    </details>
+  </checkerFrameworkError>
+
+  <checkerFrameworkError unstable="false">
+    <fileName>src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/MissingJavadocMethodCheck.java</fileName>
+    <specifier>argument</specifier>
+    <message>incompatible argument for parameter other of Optional.orElse.</message>
+    <lineContent>.orElse(Boolean.FALSE);</lineContent>
+    <details>
+      found   : @BoolVal(false) Boolean
+      required: Boolean
+    </details>
+  </checkerFrameworkError>
+
+  <checkerFrameworkError unstable="false">
+    <fileName>src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/MissingJavadocTypeCheck.java</fileName>
+    <specifier>argument</specifier>
+    <message>incompatible argument for parameter other of Optional.orElse.</message>
+    <lineContent>.orElse(Boolean.FALSE);</lineContent>
+    <details>
+      found   : @BoolVal(false) Boolean
+      required: Boolean
+    </details>
+  </checkerFrameworkError>
+
+  <checkerFrameworkError unstable="false">
     <fileName>src/main/java/com/puppycrawl/tools/checkstyle/utils/CheckUtil.java</fileName>
     <specifier>argument</specifier>
     <message>incompatible argument for parameter radix of Integer.parseInt.</message>

--- a/config/jsoref-spellchecker/whitelist.words
+++ b/config/jsoref-spellchecker/whitelist.words
@@ -382,7 +382,6 @@ emptytag
 Emtpy
 endline
 enegger
-ENMI
 ent
 enum
 eol

--- a/config/spotbugs-exclude.xml
+++ b/config/spotbugs-exclude.xml
@@ -244,13 +244,6 @@
     <Bug pattern="ITC_INHERITANCE_TYPE_CHECKING"/>
   </Match>
   <Match>
-    <!-- Till https://github.com/checkstyle/checkstyle/issues/13351 -->
-    <Or>
-      <Class name="com.puppycrawl.tools.checkstyle.utils.ScopeUtil"/>
-    </Or>
-    <Bug pattern="ENMI_NULL_ENUM_VALUE"/>
-  </Match>
-  <Match>
     <!-- Swing TreeModel API requires passing 'this' as event source -->
     <Or>
       <Class name="com.puppycrawl.tools.checkstyle.gui.ParseTreeTableModel"/>

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/RequireThisCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/RequireThisCheck.java
@@ -318,7 +318,7 @@ public class RequireThisCheck extends AbstractCheck {
      *         'this' and null otherwise.
      */
     private AbstractFrame getFieldWithoutThis(DetailAST ast, int parentType) {
-        final boolean importOrPackage = ScopeUtil.getSurroundingScope(ast) == null;
+        final boolean importOrPackage = ScopeUtil.getSurroundingScope(ast).isEmpty();
         final boolean typeName = parentType == TokenTypes.TYPE
                 || parentType == TokenTypes.LITERAL_NEW;
         AbstractFrame frame = null;

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/design/DesignForExtensionCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/design/DesignForExtensionCheck.java
@@ -364,12 +364,16 @@ public class DesignForExtensionCheck extends AbstractCheck {
      */
     private static boolean canBeOverridden(DetailAST methodDef) {
         final DetailAST modifiers = methodDef.findFirstToken(TokenTypes.MODIFIERS);
-        return ScopeUtil.getSurroundingScope(methodDef).isIn(Scope.PROTECTED)
-            && !ScopeUtil.isInInterfaceOrAnnotationBlock(methodDef)
-            && modifiers.findFirstToken(TokenTypes.LITERAL_PRIVATE) == null
-            && modifiers.findFirstToken(TokenTypes.ABSTRACT) == null
-            && modifiers.findFirstToken(TokenTypes.FINAL) == null
-            && modifiers.findFirstToken(TokenTypes.LITERAL_STATIC) == null;
+        return ScopeUtil.getSurroundingScope(methodDef)
+            .map(surroundingScope -> {
+                return surroundingScope.isIn(Scope.PROTECTED)
+                    && !ScopeUtil.isInInterfaceOrAnnotationBlock(methodDef)
+                    && modifiers.findFirstToken(TokenTypes.LITERAL_PRIVATE) == null
+                    && modifiers.findFirstToken(TokenTypes.ABSTRACT) == null
+                    && modifiers.findFirstToken(TokenTypes.FINAL) == null
+                    && modifiers.findFirstToken(TokenTypes.LITERAL_STATIC) == null;
+            })
+            .orElse(Boolean.FALSE);
     }
 
     /**

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocStyleCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocStyleCheck.java
@@ -222,12 +222,14 @@ public class JavadocStyleCheck
         }
         else if (!ScopeUtil.isInCodeBlock(ast)) {
             final Scope customScope = ScopeUtil.getScope(ast);
-            final Scope surroundingScope = ScopeUtil.getSurroundingScope(ast);
-
-            check = customScope.isIn(scope)
-                    && surroundingScope.isIn(scope)
-                    && (excludeScope == null || !customScope.isIn(excludeScope)
-                            || !surroundingScope.isIn(excludeScope));
+            check = ScopeUtil.getSurroundingScope(ast)
+                    .map(surroundingScope -> {
+                        return customScope.isIn(scope)
+                                && surroundingScope.isIn(scope)
+                                && (excludeScope == null || !customScope.isIn(excludeScope)
+                                        || !surroundingScope.isIn(excludeScope));
+                    })
+                    .orElse(Boolean.FALSE);
         }
         return check;
     }

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocTypeCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocTypeCheck.java
@@ -283,11 +283,13 @@ public class JavadocTypeCheck
      * @return whether we should check a given node.
      */
     private boolean shouldCheck(DetailAST ast) {
-        final Scope surroundingScope = ScopeUtil.getSurroundingScope(ast);
-
-        return surroundingScope.isIn(scope)
-                && (excludeScope == null || !surroundingScope.isIn(excludeScope))
-                && !AnnotationUtil.containsAnnotation(ast, allowedAnnotations);
+        return ScopeUtil.getSurroundingScope(ast)
+            .map(surroundingScope -> {
+                return surroundingScope.isIn(scope)
+                    && (excludeScope == null || !surroundingScope.isIn(excludeScope))
+                    && !AnnotationUtil.containsAnnotation(ast, allowedAnnotations);
+            })
+            .orElse(Boolean.FALSE);
     }
 
     /**

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/MissingJavadocMethodCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/MissingJavadocMethodCheck.java
@@ -288,12 +288,14 @@ public class MissingJavadocMethodCheck extends AbstractCheck {
      * @return whether we should check a given node.
      */
     private boolean shouldCheck(final DetailAST ast, final Scope nodeScope) {
-        final Scope surroundingScope = ScopeUtil.getSurroundingScope(ast);
-
-        return nodeScope != excludeScope
-                && surroundingScope != excludeScope
-                && nodeScope.isIn(scope)
-                && surroundingScope.isIn(scope);
+        return ScopeUtil.getSurroundingScope(ast)
+            .map(surroundingScope -> {
+                return nodeScope != excludeScope
+                    && surroundingScope != excludeScope
+                    && nodeScope.isIn(scope)
+                    && surroundingScope.isIn(scope);
+            })
+            .orElse(Boolean.FALSE);
     }
 
     /**

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/MissingJavadocTypeCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/MissingJavadocTypeCheck.java
@@ -137,11 +137,13 @@ public class MissingJavadocTypeCheck extends AbstractCheck {
      * @return whether we should check a given node.
      */
     private boolean shouldCheck(final DetailAST ast) {
-        final Scope surroundingScope = ScopeUtil.getSurroundingScope(ast);
-
-        return surroundingScope.isIn(scope)
-                && (excludeScope == null || !surroundingScope.isIn(excludeScope))
-                && !AnnotationUtil.containsAnnotation(ast, skipAnnotations);
+        return ScopeUtil.getSurroundingScope(ast)
+            .map(surroundingScope -> {
+                return surroundingScope.isIn(scope)
+                    && (excludeScope == null || !surroundingScope.isIn(excludeScope))
+                    && !AnnotationUtil.containsAnnotation(ast, skipAnnotations);
+            })
+            .orElse(Boolean.FALSE);
     }
 
 }

--- a/src/main/java/com/puppycrawl/tools/checkstyle/utils/ScopeUtil.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/utils/ScopeUtil.java
@@ -42,14 +42,14 @@ public final class ScopeUtil {
      * @param aMods root node of a modifier set
      * @return a {@code Scope} value or {@code null}
      */
-    public static Scope getDeclaredScopeFromMods(DetailAST aMods) {
-        Scope result = null;
+    public static Optional<Scope> getDeclaredScopeFromMods(DetailAST aMods) {
+        Optional<Scope> result = Optional.empty();
         for (DetailAST token = aMods.getFirstChild(); token != null;
              token = token.getNextSibling()) {
             result = switch (token.getType()) {
-                case TokenTypes.LITERAL_PUBLIC -> Scope.PUBLIC;
-                case TokenTypes.LITERAL_PROTECTED -> Scope.PROTECTED;
-                case TokenTypes.LITERAL_PRIVATE -> Scope.PRIVATE;
+                case TokenTypes.LITERAL_PUBLIC -> Optional.of(Scope.PUBLIC);
+                case TokenTypes.LITERAL_PROTECTED -> Optional.of(Scope.PROTECTED);
+                case TokenTypes.LITERAL_PRIVATE -> Optional.of(Scope.PRIVATE);
                 default -> result;
             };
         }
@@ -64,7 +64,7 @@ public final class ScopeUtil {
      */
     public static Scope getScope(DetailAST ast) {
         return Optional.ofNullable(ast.findFirstToken(TokenTypes.MODIFIERS))
-                .map(ScopeUtil::getDeclaredScopeFromMods)
+                .flatMap(ScopeUtil::getDeclaredScopeFromMods)
                 .orElseGet(() -> getDefaultScope(ast));
     }
 
@@ -77,7 +77,7 @@ public final class ScopeUtil {
      * @see #getDefaultScope(DetailAST)
      */
     public static Scope getScopeFromMods(DetailAST aMods) {
-        return Optional.ofNullable(getDeclaredScopeFromMods(aMods))
+        return getDeclaredScopeFromMods(aMods)
                 .orElseGet(() -> getDefaultScope(aMods));
     }
 
@@ -123,20 +123,20 @@ public final class ScopeUtil {
      * @param node the node to return the scope for
      * @return the Scope of the surrounding block
      */
-    public static Scope getSurroundingScope(DetailAST node) {
-        Scope returnValue = null;
+    public static Optional<Scope> getSurroundingScope(DetailAST node) {
+        Optional<Scope> returnValue = Optional.empty();
         for (DetailAST token = node;
              token != null;
              token = token.getParent()) {
             final int type = token.getType();
             if (TokenUtil.isTypeDeclaration(type)) {
                 final Scope tokenScope = getScope(token);
-                if (returnValue == null || returnValue.isIn(tokenScope)) {
-                    returnValue = tokenScope;
+                if (returnValue.isEmpty() || returnValue.get().isIn(tokenScope)) {
+                    returnValue = Optional.of(tokenScope);
                 }
             }
             else if (type == TokenTypes.LITERAL_NEW) {
-                returnValue = Scope.ANONINNER;
+                returnValue = Optional.of(Scope.ANONINNER);
                 // because Scope.ANONINNER is not in any other Scope
                 break;
             }
@@ -348,8 +348,11 @@ public final class ScopeUtil {
      * @return true if the ast node is in the scope.
      */
     public static boolean isInScope(DetailAST ast, Scope scope) {
-        final Scope surroundingScopeOfAstToken = getSurroundingScope(ast);
-        return surroundingScopeOfAstToken == scope;
+        return getSurroundingScope(ast)
+                .map(surroundingScope -> {
+                    return surroundingScope == scope;
+                })
+                .orElse(Boolean.FALSE);
     }
 
 }

--- a/src/test/java/com/puppycrawl/tools/checkstyle/utils/ScopeUtilTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/utils/ScopeUtilTest.java
@@ -22,6 +22,8 @@ package com.puppycrawl.tools.checkstyle.utils;
 import static com.google.common.truth.Truth.assertWithMessage;
 import static com.puppycrawl.tools.checkstyle.internal.utils.TestUtil.isUtilsClassHasPrivateConstructor;
 
+import java.util.Optional;
+
 import org.junit.jupiter.api.Test;
 
 import com.puppycrawl.tools.checkstyle.DetailAstImpl;
@@ -282,26 +284,26 @@ public class ScopeUtilTest {
 
     @Test
     public void testSurroundingScope() {
-        final Scope publicScope = ScopeUtil.getSurroundingScope(getNodeWithParentScope(
+        final Optional<Scope> publicScope = ScopeUtil.getSurroundingScope(getNodeWithParentScope(
                 TokenTypes.LITERAL_PUBLIC, "public", TokenTypes.ANNOTATION_DEF));
         assertWithMessage("Invalid surrounding scope")
             .that(publicScope)
-            .isEqualTo(Scope.PUBLIC);
-        final Scope protectedScope = ScopeUtil.getSurroundingScope(getNodeWithParentScope(
+            .isEqualTo(Optional.of(Scope.PUBLIC));
+        final Optional<Scope> protectedScope = ScopeUtil.getSurroundingScope(getNodeWithParentScope(
                 TokenTypes.LITERAL_PROTECTED, "protected", TokenTypes.INTERFACE_DEF));
         assertWithMessage("Invalid surrounding scope")
             .that(protectedScope)
-            .isEqualTo(Scope.PROTECTED);
-        final Scope privateScope = ScopeUtil.getSurroundingScope(getNodeWithParentScope(
+            .isEqualTo(Optional.of(Scope.PROTECTED));
+        final Optional<Scope> privateScope = ScopeUtil.getSurroundingScope(getNodeWithParentScope(
                 TokenTypes.LITERAL_PRIVATE, "private", TokenTypes.ENUM_DEF));
         assertWithMessage("Invalid surrounding scope")
             .that(privateScope)
-            .isEqualTo(Scope.PRIVATE);
-        final Scope staticScope = ScopeUtil.getSurroundingScope(getNodeWithParentScope(
+            .isEqualTo(Optional.of(Scope.PRIVATE));
+        final Optional<Scope> staticScope = ScopeUtil.getSurroundingScope(getNodeWithParentScope(
                 TokenTypes.LITERAL_STATIC, "static", TokenTypes.CLASS_DEF));
         assertWithMessage("Invalid surrounding scope")
             .that(staticScope)
-            .isEqualTo(Scope.PACKAGE);
+            .isEqualTo(Optional.of(Scope.PACKAGE));
     }
 
     @Test
@@ -318,11 +320,11 @@ public class ScopeUtilTest {
 
     @Test
     public void testSurroundingScopeOfNodeChildOfLiteralNewIsAnoninner() {
-        final Scope scope =
+        final Optional<Scope> scope =
                 ScopeUtil.getSurroundingScope(getNode(TokenTypes.LITERAL_NEW, TokenTypes.IDENT));
         assertWithMessage("Invalid surrounding scope")
             .that(scope)
-            .isEqualTo(Scope.ANONINNER);
+            .isEqualTo(Optional.of(Scope.ANONINNER));
     }
 
     @Test


### PR DESCRIPTION
Issue #13351: Resolve violations from spotbugs sb-contrib for ScopeUtil


[ERROR] Medium: Method com.puppycrawl.tools.checkstyle.utils.ScopeUtil.getDeclaredScopeFromMods(DetailAST) sets an enum reference to null [com.puppycrawl.tools.checkstyle.utils.ScopeUtil] At ScopeUtil.java:[line 46] ENMI_NULL_ENUM_VALUE
[ERROR] Medium: Method com.puppycrawl.tools.checkstyle.utils.ScopeUtil.getSurroundingScope(DetailAST) sets an enum reference to null [com.puppycrawl.tools.checkstyle.utils.ScopeUtil] At ScopeUtil.java:[line 127] ENMI_NULL_ENUM_VALUE