### PR TITLE
Issue #17137: Fix the error for UnnecessaryNullCheckWithInstanceOf for complex cases

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/UnnecessaryNullCheckWithInstanceOfCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/UnnecessaryNullCheckWithInstanceOfCheck.java
@@ -74,13 +74,29 @@ public class UnnecessaryNullCheckWithInstanceOfCheck extends AbstractCheck {
      * @return the identifier if the check is redundant, otherwise {@code null}
      */
     private static Optional<DetailAST> findUnnecessaryNullCheck(DetailAST instanceOfNode) {
-        DetailAST currentParent = instanceOfNode;
+        final DetailAST topLevelExpr = findTopLevelLogicalExpression(instanceOfNode);
 
-        while (currentParent.getParent().getType() == TokenTypes.LAND) {
+        Optional<DetailAST> result = Optional.empty();
+        if (topLevelExpr.getType() == TokenTypes.LAND) {
+            result = findRedundantNullCheck(topLevelExpr, instanceOfNode)
+                    .map(DetailAST::getFirstChild);
+        }
+        return result;
+    }
+
+    /**
+     * Traverses up through LAND and LOR operators to find the top-level logical expression.
+     *
+     * @param node the starting node
+     * @return the top-level logical expression node
+     */
+    private static DetailAST findTopLevelLogicalExpression(DetailAST node) {
+        DetailAST currentParent = node;
+        while (currentParent.getParent().getType() == TokenTypes.LAND
+                || currentParent.getParent().getType() == TokenTypes.LOR) {
             currentParent = currentParent.getParent();
         }
-        return findRedundantNullCheck(currentParent, instanceOfNode)
-            .map(DetailAST::getFirstChild);
+        return currentParent;
     }
 
     /**
@@ -93,26 +109,121 @@ public class UnnecessaryNullCheckWithInstanceOfCheck extends AbstractCheck {
     private static Optional<DetailAST> findRedundantNullCheck(DetailAST logicalAndNode,
         DetailAST instanceOfNode) {
 
-        DetailAST nullCheckNode = null;
+        Optional<DetailAST> nullCheckNode = Optional.empty();
         final DetailAST instanceOfIdent = instanceOfNode.findFirstToken(TokenTypes.IDENT);
 
         if (instanceOfIdent != null
             && !containsVariableDereference(logicalAndNode, instanceOfIdent.getText())) {
 
-            DetailAST currentChild = logicalAndNode.getFirstChild();
-            while (currentChild != null) {
-                if (isNotEqual(currentChild)
-                        && isNullCheckRedundant(instanceOfIdent, currentChild)) {
-                    nullCheckNode = currentChild;
-                }
-                else if (nullCheckNode == null && currentChild.getType() == TokenTypes.LAND) {
-                    nullCheckNode = findRedundantNullCheck(currentChild, instanceOfNode)
-                            .orElse(null);
-                }
-                currentChild = currentChild.getNextSibling();
-            }
+            nullCheckNode = searchForNullCheck(logicalAndNode, instanceOfNode, instanceOfIdent);
         }
-        return Optional.ofNullable(nullCheckNode);
+        return nullCheckNode;
+    }
+
+    /**
+     * Searches for a redundant null check in the children of a logical AND node.
+     *
+     * @param logicalAndNode the LAND node to search
+     * @param instanceOfNode the instanceof expression node
+     * @param instanceOfIdent the identifier from the instanceof expression
+     * @return the null check node if found, null otherwise
+     */
+    private static Optional<DetailAST> searchForNullCheck(DetailAST logicalAndNode,
+        DetailAST instanceOfNode, DetailAST instanceOfIdent) {
+
+        Optional<DetailAST> nullCheckNode = Optional.empty();
+
+        final Optional<DetailAST> instanceOfSubtree =
+                findDirectChildContaining(logicalAndNode, instanceOfNode);
+
+        final DetailAST instanceOfSubtreeNode =
+                instanceOfSubtree.orElse(null);
+
+        final boolean instanceOfInLor =
+                instanceOfSubtreeNode != null
+                        && instanceOfSubtreeNode.getType() == TokenTypes.LOR;
+
+        DetailAST currentChild = logicalAndNode.getFirstChild();
+        while (currentChild != null) {
+            if (instanceOfInLor && currentChild.equals(instanceOfSubtreeNode)) {
+                break;
+            }
+
+            if (nullCheckNode.isEmpty()) {
+                nullCheckNode = checkChildForNullCheck(
+                        currentChild, instanceOfNode, instanceOfIdent);
+            }
+
+            currentChild = currentChild.getNextSibling();
+        }
+
+        return nullCheckNode;
+    }
+
+    /**
+     * Checks a child node for a redundant null check.
+     *
+     * @param currentChild the child node to check
+     * @param instanceOfNode the instanceof expression node
+     * @param instanceOfIdent the identifier from the instanceof expression
+     * @return the null check node if found, otherwise empty
+     */
+    private static Optional<DetailAST> checkChildForNullCheck(DetailAST currentChild,
+        DetailAST instanceOfNode, DetailAST instanceOfIdent) {
+
+        Optional<DetailAST> result = Optional.empty();
+
+        if (isNotEqual(currentChild)
+                && isNullCheckRedundant(instanceOfIdent, currentChild)) {
+            result = Optional.of(currentChild);
+        }
+        else if (currentChild.getType() == TokenTypes.LAND) {
+            result = findRedundantNullCheck(currentChild, instanceOfNode);
+        }
+
+        return result;
+    }
+
+    /**
+     * Finds the direct child of parent that contains the target node.
+     *
+     * @param parent the parent node
+     * @param target the target node to find
+     * @return the direct child containing target, or null if not found
+     */
+    private static Optional<DetailAST> findDirectChildContaining(DetailAST parent,
+        DetailAST target) {
+
+        DetailAST result = null;
+        DetailAST child = parent.getFirstChild();
+        while (child != null) {
+            if (isAncestorOf(child, target)) {
+                result = child;
+                break;
+            }
+            child = child.getNextSibling();
+        }
+        return Optional.ofNullable(result);
+    }
+
+    /**
+     * Checks if the given node is an ancestor of (or the same as) the target node.
+     *
+     * @param node the potential ancestor node
+     * @param target the target node to check
+     * @return true if node is an ancestor of target, false otherwise
+     */
+    private static boolean isAncestorOf(DetailAST node, DetailAST target) {
+        boolean found = false;
+        DetailAST current = target;
+        while (current != null) {
+            if (current.equals(node)) {
+                found = true;
+                break;
+            }
+            current = current.getParent();
+        }
+        return found;
     }
 
     /**
@@ -128,7 +239,9 @@ public class UnnecessaryNullCheckWithInstanceOfCheck extends AbstractCheck {
         boolean found = false;
 
         if (node.getType() == TokenTypes.DOT
-            || node.getType() == TokenTypes.METHOD_CALL || node.getType() == TokenTypes.LAND) {
+            || node.getType() == TokenTypes.METHOD_CALL
+            || node.getType() == TokenTypes.LAND
+            || node.getType() == TokenTypes.LOR) {
 
             DetailAST firstChild = node.getFirstChild();
 

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/coding/UnnecessaryNullCheckWithInstanceOfCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/coding/UnnecessaryNullCheckWithInstanceOfCheckTest.java
@@ -45,7 +45,9 @@ public class UnnecessaryNullCheckWithInstanceOfCheckTest extends AbstractModuleT
             "60:13: " + getCheckMessage(MSG_UNNECESSARY_NULLCHECK),
             "69:17: " + getCheckMessage(MSG_UNNECESSARY_NULLCHECK),
             "74:26: " + getCheckMessage(MSG_UNNECESSARY_NULLCHECK),
-            "85:19: " + getCheckMessage(MSG_UNNECESSARY_NULLCHECK),
+            "78:14: " + getCheckMessage(MSG_UNNECESSARY_NULLCHECK),
+            "80:30: " + getCheckMessage(MSG_UNNECESSARY_NULLCHECK),
+            "86:19: " + getCheckMessage(MSG_UNNECESSARY_NULLCHECK),
         };
         verifyWithInlineConfigParser(getPath(
             "InputUnnecessaryNullCheckWithInstanceOfOne.java"), expected);
@@ -193,4 +195,55 @@ public class UnnecessaryNullCheckWithInstanceOfCheckTest extends AbstractModuleT
             .that(check.getRequiredTokens())
             .isNotNull();
     }
+
+    @Test
+    public void testUnnecessaryNullCheckWithInstanceofComplexCases() throws Exception {
+
+        final String[] expected = {
+            "14:13: " + getCheckMessage(MSG_UNNECESSARY_NULLCHECK),
+            "19:27: " + getCheckMessage(MSG_UNNECESSARY_NULLCHECK),
+            "22:13: " + getCheckMessage(MSG_UNNECESSARY_NULLCHECK),
+            "27:13: " + getCheckMessage(MSG_UNNECESSARY_NULLCHECK),
+            "34:13: " + getCheckMessage(MSG_UNNECESSARY_NULLCHECK),
+            "39:13: " + getCheckMessage(MSG_UNNECESSARY_NULLCHECK),
+            "61:16: " + getCheckMessage(MSG_UNNECESSARY_NULLCHECK),
+            "66:25: " + getCheckMessage(MSG_UNNECESSARY_NULLCHECK),
+        };
+        verifyWithInlineConfigParser(getPath(
+                "InputUnnecessaryNullCheckWithInstanceOfComplexCases.java"), expected);
+    }
+
+    @Test
+    public void testUnnecessaryNullCheckWithInstanceofMutationKiller() throws Exception {
+
+        final String[] expected = {
+            "24:13: " + getCheckMessage(MSG_UNNECESSARY_NULLCHECK),
+            "28:29: " + getCheckMessage(MSG_UNNECESSARY_NULLCHECK),
+            "35:13: " + getCheckMessage(MSG_UNNECESSARY_NULLCHECK),
+            "39:13: " + getCheckMessage(MSG_UNNECESSARY_NULLCHECK),
+            "46:14: " + getCheckMessage(MSG_UNNECESSARY_NULLCHECK),
+            "56:13: " + getCheckMessage(MSG_UNNECESSARY_NULLCHECK),
+            "75:13: " + getCheckMessage(MSG_UNNECESSARY_NULLCHECK),
+            "79:13: " + getCheckMessage(MSG_UNNECESSARY_NULLCHECK),
+            "86:13: " + getCheckMessage(MSG_UNNECESSARY_NULLCHECK),
+            "90:13: " + getCheckMessage(MSG_UNNECESSARY_NULLCHECK),
+            "97:13: " + getCheckMessage(MSG_UNNECESSARY_NULLCHECK),
+        };
+        verifyWithInlineConfigParser(getPath(
+                "InputUnnecessaryNullCheckWithInstanceOfMutationKiller.java"), expected);
+    }
+
+    @Test
+    public void testUnnecessaryNullCheckWithInstanceofMutationKillerTwo() throws Exception {
+
+        final String[] expected = {
+            "12:39: " + getCheckMessage(MSG_UNNECESSARY_NULLCHECK),
+            "16:59: " + getCheckMessage(MSG_UNNECESSARY_NULLCHECK),
+            "23:39: " + getCheckMessage(MSG_UNNECESSARY_NULLCHECK),
+            "27:13: " + getCheckMessage(MSG_UNNECESSARY_NULLCHECK),
+        };
+        verifyWithInlineConfigParser(getPath(
+                "InputUnnecessaryNullCheckWithInstanceOfMutationKillerTwo.java"), expected);
+    }
+
 }

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/unnecessarynullcheckwithinstanceof/InputUnnecessaryNullCheckWithInstanceOfComplexCases.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/unnecessarynullcheckwithinstanceof/InputUnnecessaryNullCheckWithInstanceOfComplexCases.java
@@ -1,0 +1,70 @@
+/*
+UnnecessaryNullCheckWithInstanceOf
+
+*/
+
+package com.puppycrawl.tools.checkstyle.checks.coding.unnecessarynullcheckwithinstanceof;
+
+import java.util.Objects;
+
+public class InputUnnecessaryNullCheckWithInstanceOfComplexCases {
+
+    public void testOrWithInstanceOf(Object data, String s, String b) {
+        // violation below, 'Unnecessary nullity check'
+        if (data != null && (!Objects.equals(s, b) || data instanceof String)) {
+            System.out.println("data is a String");
+        }
+
+        // violation below, 'Unnecessary nullity check'
+        boolean isValid = b != null && (s != null || b instanceof String);
+
+        // violation below, 'Unnecessary nullity check'
+        if (data != null && (true || data instanceof String)) {
+            System.out.println("condition");
+        }
+
+        // violation below, 'Unnecessary nullity check'
+        if (data != null && (s.isEmpty() || b.isEmpty() || data instanceof String)) {
+            System.out.println("multiple or conditions");
+        }
+    }
+
+    public void testNestedOrWithInstanceOf(Object obj) {
+        // violation below, 'Unnecessary nullity check'
+        if (obj != null && ((true) || obj instanceof String)) {
+            System.out.println("nested parens");
+        }
+
+        // violation below, 'Unnecessary nullity check'
+        if (obj != null && (false || (true || obj instanceof String))) {
+            System.out.println("deeply nested");
+        }
+    }
+
+    public void testNoViolation(Object obj1, Object obj2) {
+
+        if (obj1 != null && (true || obj2 instanceof String)) {
+            System.out.println("different vars");
+        }
+
+        if (obj1 != null || obj1 instanceof String) {
+            System.out.println("only or");
+        }
+
+        if (obj1 != null && (obj1.toString().isEmpty() || obj1 instanceof String)) {
+            System.out.println("dereferenced");
+        }
+    }
+
+    public void testWhileAndFor(Object data) {
+        // violation below, 'Unnecessary nullity check'
+        while (data != null && (true || data instanceof String)) {
+            break;
+        }
+
+        // violation below, 'Unnecessary nullity check'
+        for (int i = 0; data != null && (true || data instanceof String); i++) {
+            break;
+        }
+    }
+}

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/unnecessarynullcheckwithinstanceof/InputUnnecessaryNullCheckWithInstanceOfMutationKiller.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/unnecessarynullcheckwithinstanceof/InputUnnecessaryNullCheckWithInstanceOfMutationKiller.java
@@ -1,0 +1,101 @@
+/*
+UnnecessaryNullCheckWithInstanceOf
+
+*/
+
+package com.puppycrawl.tools.checkstyle.checks.coding.unnecessarynullcheckwithinstanceof;
+
+public class InputUnnecessaryNullCheckWithInstanceOfMutationKiller {
+
+    public void testEqualOperatorNotViolation(Object obj) {
+        if (obj == null && obj instanceof String) {
+            System.out.println("Not flagged");
+        }
+        if (obj == null && true && obj instanceof String) {
+            System.out.println("Not flagged");
+        }
+        if (obj == null || obj instanceof String) {
+            System.out.println("LOR only");
+        }
+    }
+
+    public void testMultipleChildrenIteration(Object obj, Object data, String s) {
+        // violation below, 'Unnecessary nullity check'
+        if (obj != null && data != null && s != null && obj instanceof String) {
+            System.out.println("ok");
+        }
+        // violation below, 'Unnecessary nullity check'
+        if (data != null && obj != null && obj instanceof String && s != null) {
+            System.out.println("ok");
+        }
+    }
+
+    public void testDeepNesting(Object obj) {
+        // violation below, 'Unnecessary nullity check'
+        if (obj != null && ((obj instanceof String))) {
+            System.out.println("ok");
+        }
+        // violation below, 'Unnecessary nullity check'
+        if (obj != null && (true && (obj instanceof String))) {
+            System.out.println("ok");
+        }
+    }
+
+    public void testRecursiveLandProcessing(Object obj, Object data) {
+        // violation below, 'Unnecessary nullity check'
+        if ((obj != null && obj instanceof String) && data != null) {
+            System.out.println("ok");
+        }
+        if ((obj == null && obj instanceof String) && data != null) {
+            System.out.println("ok");
+        }
+    }
+
+    public void testMinimalCase(Object obj) {
+        // violation below, 'Unnecessary nullity check'
+        if (obj != null && obj instanceof String) {
+            System.out.println("ok");
+        }
+    }
+
+    public void testEqualVariousPositions(Object a, Object b, Object c) {
+        if (a == null && a instanceof String && b != null) {
+            System.out.println("ok");
+        }
+        if (b != null && a == null && a instanceof String) {
+            System.out.println("ok");
+        }
+        if (c instanceof String && c == null) {
+            System.out.println("ok");
+        }
+    }
+
+    public void testDeepAncestorSearch(Object obj, Object x, Object y, Object z) {
+        // violation below, 'Unnecessary nullity check'
+        if (obj != null && (((((obj instanceof String)))))) {
+            System.out.println("ok");
+        }
+        // violation below, 'Unnecessary nullity check'
+        if (obj != null && x != null && y != null && z != null && obj instanceof String) {
+            System.out.println("ok");
+        }
+    }
+
+    public void testFindDirectChildMultipleSiblings(Object a, Object b, Object c, Object d) {
+        // violation below, 'Unnecessary nullity check'
+        if (a != null && (a instanceof String || b != null) && c != null && d != null) {
+            System.out.println("ok");
+        }
+        // violation below, 'Unnecessary nullity check'
+        if (a != null && ((((b != null && (a instanceof String)))))) {
+            System.out.println("ok");
+        }
+    }
+
+    public void testAncestorTraversalBoundary(Object obj) {
+        // violation below, 'Unnecessary nullity check'
+        if (obj != null && obj instanceof String && true && true) {
+            System.out.println("ok");
+        }
+    }
+}

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/unnecessarynullcheckwithinstanceof/InputUnnecessaryNullCheckWithInstanceOfMutationKillerTwo.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/unnecessarynullcheckwithinstanceof/InputUnnecessaryNullCheckWithInstanceOfMutationKillerTwo.java
@@ -1,0 +1,31 @@
+/*
+UnnecessaryNullCheckWithInstanceOf
+
+*/
+
+package com.puppycrawl.tools.checkstyle.checks.coding.unnecessarynullcheckwithinstanceof;
+
+public class InputUnnecessaryNullCheckWithInstanceOfMutationKillerTwo {
+
+    public void testIsAncestorOfReturnsFalse(Object a, Object b, Object c) {
+        // violation below, 'Unnecessary nullity check'
+        if (b != null && c != null && a != null && a instanceof String) {
+            System.out.println("ok");
+        }
+        // violation below, 'Unnecessary nullity check'
+        if (b != null && c != null && c.hashCode() > 0 && a != null && a instanceof String) {
+            System.out.println("ok");
+        }
+    }
+
+    public void testDirectChildIterationExhaustsNonMatching(Object x, Object y, Object z) {
+        // violation below, 'Unnecessary nullity check'
+        if (y != null && z != null && x != null && x instanceof Integer) {
+            System.out.println("ok");
+        }
+        // violation below, 'Unnecessary nullity check'
+        if (x != null && (y != null && z != null && x instanceof Number)) {
+            System.out.println("ok");
+        }
+    }
+}

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/unnecessarynullcheckwithinstanceof/InputUnnecessaryNullCheckWithInstanceOfOne.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/unnecessarynullcheckwithinstanceof/InputUnnecessaryNullCheckWithInstanceOfOne.java
@@ -74,9 +74,10 @@ public class InputUnnecessaryNullCheckWithInstanceOfOne {
          for (int i = 0; getData!= null && getData instanceof String; i++) {
              return;
          }
-
-         if (data != null && (!Objects.equals(s, b) || data instanceof String)) { //ok, until #17137
-            boolean result = b != null && (s != null || b instanceof String); //ok, until #17137
+         // violation below, 'Unnecessary nullity check'
+         if (data != null && (!Objects.equals(s, b) || data instanceof String)) {
+             // violation below, 'Unnecessary nullity check'
+            boolean result = b != null && (s != null || b instanceof String);
             return;
         }
 


### PR DESCRIPTION
Issue #17137 

Changes:

- In previous code, it only climb through the LAND, so it incorrectly treated mixed expression as safe
but, i made changes so that now, it climb through LAND and also LOR

- It did not stop when the instanceof was inside a | | subtree


Current flow :

1. It moves to the top level logical expression by climbing through && and | |  and stops at top level
2. If top level logical expression is LOR, then it stops here, it only move further when the top level logical expression is LAND
3. THen , it finds the variable which is used in instanceof 
4. Created a method to prevent derefernce which checks whether there is any dot , method call, because if these are present then we need null check
5. Created a method determines the child the subtree contains the instanceof 


Method :

1. private static DetailAST findTopLevelLogicalExpression(DetailAST node)

- It walks up the AST from the instanceof node and returns the outermost logical expression ( && and | | ) that contains it

The previous code, only traverse through the &&, so i updated to check for | | also

2. private static Optional<DetailAST> findUnnecessaryNullCheck(DetailAST instanceOfNode)

- In the previous version, this method always finds the null check even when the top-level operator is | |

THe current behavior , only proceeds for && and blocks | | 
because instanceof make redundant only under AND 

3. private static Optional<DetailAST> findRedundantNullCheck(DetailAST logicalAndNode,DetailAST instanceOfNode)

- Extracts the identifier from instanceof and also avoid dereference 

4. private static DetailAST searchForNullCheck(DetailAST logicalAndNode,DetailAST instanceOfNode,DetailAST instanceOfIdent)

- Checks where the instaneof is present
- Check if instanceof is present under | |
- stop search when it is unsafe

5. private static DetailAST checkChildForNullCheck(DetailAST currentChild,DetailAST instanceOfNode, DetailAST instanceOfIdent, DetailAST currentNullCheck)

- It examines the child and check whether it is redundant null check or nested 

6. private static DetailAST findDirectChildContaining(DetailAST parent,DetailAST target)

- It returns which  immediate child of LAND node contain the instanceof

7. private static boolean isAncestorOf(DetailAST node, DetailAST target)

- Checks whether a node contains another node anywhere in its subtree

8. private static boolean containsVariableDereference(DetailAST node, String variableName)

- if (node.getType() == DOT || METHOD_CALL || LAND || LOR) Added LOR in this
this ensures that dereferance are detected even inside the OR brances

