### PR TITLE
Issue #18653: Update HexLiteralCaseCheck add hex float literals

### DIFF
--- a/config/jsoref-spellchecker/whitelist.words
+++ b/config/jsoref-spellchecker/whitelist.words
@@ -427,6 +427,8 @@ Fdesign
 FDF
 FEF
 fenum
+ffc
+ffcp
 ffd
 fff
 FFFA

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/HexLiteralCaseCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/HexLiteralCaseCheck.java
@@ -44,10 +44,10 @@ public class HexLiteralCaseCheck extends AbstractCheck {
     public static final String MSG_KEY = "hex.literal";
 
     /** ASCII value for lowercase 'a'. */
-    private static final int A_ASCII = 97;
+    private static final int A_LOWER_ASCII = 97;
 
     /** ASCII value for lowercase 'f'. */
-    private static final int F_ASCII = 102;
+    private static final int F_LOWER_ASCII = 102;
 
     @Override
     public int[] getDefaultTokens() {
@@ -61,15 +61,26 @@ public class HexLiteralCaseCheck extends AbstractCheck {
 
     @Override
     public int[] getRequiredTokens() {
-        return new int[] {TokenTypes.NUM_LONG, TokenTypes.NUM_INT};
+        return new int[] {TokenTypes.NUM_LONG, TokenTypes.NUM_INT, TokenTypes.NUM_FLOAT,
+            TokenTypes.NUM_DOUBLE,
+        };
     }
 
     @Override
     public void visitToken(DetailAST ast) {
         final String text = ast.getText();
-        if ((text.startsWith("0x") || text.startsWith("0X"))
-                && containsLowerLetter(text)) {
-            log(ast, MSG_KEY);
+        if (text.startsWith("0x") || text.startsWith("0X")) {
+            final int type = ast.getType();
+            if (type == TokenTypes.NUM_FLOAT || type == TokenTypes.NUM_DOUBLE) {
+                if (containsLowerLetterInHexFloatLiteral(text)) {
+                    log(ast, MSG_KEY);
+                }
+            }
+            else {
+                if (containsLowerLetter(text)) {
+                    log(ast, MSG_KEY);
+                }
+            }
         }
     }
 
@@ -83,7 +94,7 @@ public class HexLiteralCaseCheck extends AbstractCheck {
         boolean result = false;
         final char[] characterList = text.toCharArray();
         for (char character : characterList) {
-            if (character >= A_ASCII && character <= F_ASCII) {
+            if (character >= A_LOWER_ASCII && character <= F_LOWER_ASCII) {
                 result = true;
                 break;
             }
@@ -91,4 +102,24 @@ public class HexLiteralCaseCheck extends AbstractCheck {
         return result;
     }
 
+    /**
+     * Checks if the given text contains any lowercase hexadecimal letter in
+     * Hex Float Literal (a–f).
+     *
+     * @param text the literal text to check
+     * @return true if the literal contains lowercase hex digits; false otherwise
+     */
+    public static boolean containsLowerLetterInHexFloatLiteral(final String text) {
+        boolean result = false;
+
+        final int index = text.length() - 1;
+        for (char character : text.substring(0, index).toCharArray()) {
+            if (character >= A_LOWER_ASCII && character <= F_LOWER_ASCII) {
+                result = true;
+                break;
+            }
+        }
+
+        return result;
+    }
 }

--- a/src/site/xdoc/checks/misc/hexliteralcase.xml
+++ b/src/site/xdoc/checks/misc/hexliteralcase.xml
@@ -48,8 +48,27 @@ class Example1 {
   long l2 = 0x7FFF_FFFF_FFFF_FFFFL;
 
   long l3 = 0x7FFF_AAA_bBB_DDDL;
-  // violation  above 'Should use uppercase hexadecimal letters.'
+  // violation above 'Should use uppercase hexadecimal letters.'
   long l4 = 0x7FFF_AAA_BBB_DDDL;
+
+  float c = 0x1ap1f; // violation  'Should use uppercase hexadecimal letters.'
+  float c2 = 0x1Ap1f;
+  double e = 0x1AbC.p1d; // violation  'Should use uppercase hexadecimal letters.'
+  double e2 = 0x1ABC.p1d;
+  double f = 0x1AbC.P1D; // violation  'Should use uppercase hexadecimal letters.'
+  double f2 = 0x1ABC.P1D;
+  float g = 0x1b.p1f; // violation  'Should use uppercase hexadecimal letters.'
+  float g2 = 0x1B.p1f;
+  float h = 0x1b.P1F; // violation  'Should use uppercase hexadecimal letters.'
+  float h2 = 0x1B.P1F;
+  float i = 0x1B.p1f;
+  double j = 0x1B.p1d;
+  float p = 0x7f_ff_ff_ff; // violation  'Should use uppercase hexadecimal letters.'
+  float p2 = 0x7F_FF_FF_FF;
+  float q = 0x1.ffcp15f; // violation  'Should use uppercase hexadecimal letters.'
+  float q2 = 0x1.FFCP15f;
+  float r = -0x1.ffcP+15f; // violation  'Should use uppercase hexadecimal letters.'
+  float r2 = -0x1.FFCP+15f;
 
 }
 </code></pre></div>

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/HexLiteralCaseCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/HexLiteralCaseCheckTest.java
@@ -38,7 +38,9 @@ public class HexLiteralCaseCheckTest
     @Test
     public void testGetRequiredTokens() {
         final HexLiteralCaseCheck check = new HexLiteralCaseCheck();
-        final int[] expectedTokens = {TokenTypes.NUM_LONG, TokenTypes.NUM_INT};
+        final int[] expectedTokens = {TokenTypes.NUM_LONG, TokenTypes.NUM_INT,
+            TokenTypes.NUM_FLOAT, TokenTypes.NUM_DOUBLE,
+        };
         assertWithMessage("Default required tokens are valid")
             .that(check.getRequiredTokens())
             .isEqualTo(expectedTokens);
@@ -46,12 +48,14 @@ public class HexLiteralCaseCheckTest
 
     @Test
     public void testAcceptableTokens() {
-        final int[] expected = {TokenTypes.NUM_LONG, TokenTypes.NUM_INT};
+        final int[] expected = {TokenTypes.NUM_LONG, TokenTypes.NUM_INT,
+            TokenTypes.NUM_FLOAT, TokenTypes.NUM_DOUBLE,
+        };
         final HexLiteralCaseCheck check = new HexLiteralCaseCheck();
         final int[] actual = check.getAcceptableTokens();
         assertWithMessage("Invalid size of tokens")
                 .that(actual.length)
-                .isEqualTo(2);
+                .isEqualTo(4);
         assertWithMessage("Default acceptable tokens are invalid")
                 .that(actual)
                 .isEqualTo(expected);
@@ -76,6 +80,26 @@ public class HexLiteralCaseCheckTest
         };
         verifyWithInlineConfigParser(
                 getPath("InputHexLiteralCaseCheck.java"), expected
+        );
+    }
+
+    @Test
+    public void testCheck2()
+            throws Exception {
+        final String[] expected = {
+            "10:16: " + getCheckMessage(MSG_KEY),
+            "11:16: " + getCheckMessage(MSG_KEY),
+            "12:16: " + getCheckMessage(MSG_KEY),
+            "13:16: " + getCheckMessage(MSG_KEY),
+            "14:15: " + getCheckMessage(MSG_KEY),
+            "15:15: " + getCheckMessage(MSG_KEY),
+            "17:15: " + getCheckMessage(MSG_KEY),
+            "19:15: " + getCheckMessage(MSG_KEY),
+            "20:15: " + getCheckMessage(MSG_KEY),
+            "21:16: " + getCheckMessage(MSG_KEY),
+        };
+        verifyWithInlineConfigParser(
+                getPath("InputHexLiteralCaseCheck2.java"), expected
         );
     }
 

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/hexliteralcase/InputHexLiteralCaseCheck2.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/hexliteralcase/InputHexLiteralCaseCheck2.java
@@ -1,0 +1,22 @@
+/*
+HexLiteralCase
+
+
+*/
+
+package com.puppycrawl.tools.checkstyle.checks.hexliteralcase;
+
+public class InputHexLiteralCaseCheck2 {
+    double c = 0x1ap1; // violation  'Should use uppercase hexadecimal letters.'
+    double d = 0x1aP1d; // violation  'Should use uppercase hexadecimal letters.'
+    double e = 0x1AbC.p1d; // violation  'Should use uppercase hexadecimal letters.'
+    double f = 0x1AbC.P1D; // violation  'Should use uppercase hexadecimal letters.'
+    float g = 0x1b.p1f; // violation  'Should use uppercase hexadecimal letters.'
+    float h = 0x1b.P1F; // violation  'Should use uppercase hexadecimal letters.'
+    float i = 0x1B.p1f;
+    float k = 0x1f.P1F; // violation  'Should use uppercase hexadecimal letters.'
+    double j = 0x1B.p1d;
+    float p = 0x7f_ff_ff_ff; // violation  'Should use uppercase hexadecimal letters.'
+    float q = 0x1.ffcp15f; // violation  'Should use uppercase hexadecimal letters.'
+    float r = -0x1.ffcP+15f; // violation  'Should use uppercase hexadecimal letters.'
+}

--- a/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/checks/HexLiteralCaseCheckExamplesTest.java
+++ b/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/checks/HexLiteralCaseCheckExamplesTest.java
@@ -1,0 +1,57 @@
+///////////////////////////////////////////////////////////////////////////////////////////////
+// checkstyle: Checks Java source code and other text files for adherence to a set of rules.
+// Copyright (C) 2001-2026 the original author or authors.
+//
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the GNU Lesser General Public
+// License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+//
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+// Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public
+// License along with this library; if not, write to the Free Software
+// Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+///////////////////////////////////////////////////////////////////////////////////////////////
+
+package com.puppycrawl.tools.checkstyle.checks;
+
+import static com.puppycrawl.tools.checkstyle.checks.HexLiteralCaseCheck.MSG_KEY;
+
+import org.junit.jupiter.api.Test;
+
+import com.puppycrawl.tools.checkstyle.AbstractExamplesModuleTestSupport;
+
+public class HexLiteralCaseCheckExamplesTest extends AbstractExamplesModuleTestSupport {
+
+    @Override
+    public String getPackageLocation() {
+        return "com/puppycrawl/tools/checkstyle/checks/hexliteralcase";
+    }
+
+    @Test
+    public void testExample1() throws Exception {
+        final String[] expected = {
+            "12:14: " + getCheckMessage(MSG_KEY, "Should use uppercase hexadecimal letters."),
+            "15:14: " + getCheckMessage(MSG_KEY, "Should use uppercase hexadecimal letters."),
+            "18:19: " + getCheckMessage(MSG_KEY, "Should use uppercase hexadecimal letters."),
+            "20:20: " + getCheckMessage(MSG_KEY, "Should use uppercase hexadecimal letters."),
+            "22:12: " + getCheckMessage(MSG_KEY, "Should use uppercase hexadecimal letters."),
+            "25:13: " + getCheckMessage(MSG_KEY, "Should use uppercase hexadecimal letters."),
+            "29:13: " + getCheckMessage(MSG_KEY, "Should use uppercase hexadecimal letters."),
+            "33:13: " + getCheckMessage(MSG_KEY, "Should use uppercase hexadecimal letters."),
+            "35:14: " + getCheckMessage(MSG_KEY, "Should use uppercase hexadecimal letters."),
+            "37:14: " + getCheckMessage(MSG_KEY, "Should use uppercase hexadecimal letters."),
+            "39:13: " + getCheckMessage(MSG_KEY, "Should use uppercase hexadecimal letters."),
+            "41:13: " + getCheckMessage(MSG_KEY, "Should use uppercase hexadecimal letters."),
+            "45:13: " + getCheckMessage(MSG_KEY, "Should use uppercase hexadecimal letters."),
+            "47:13: " + getCheckMessage(MSG_KEY, "Should use uppercase hexadecimal letters."),
+            "49:14: " + getCheckMessage(MSG_KEY, "Should use uppercase hexadecimal letters."),
+        };
+
+        verifyWithInlineConfigParser(getPath("Example1.java"), expected);
+    }
+}

--- a/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/hexliteralcase/Example1.java
+++ b/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/hexliteralcase/Example1.java
@@ -27,8 +27,27 @@ class Example1 {
   long l2 = 0x7FFF_FFFF_FFFF_FFFFL;
 
   long l3 = 0x7FFF_AAA_bBB_DDDL;
-  // violation  above 'Should use uppercase hexadecimal letters.'
+  // violation above 'Should use uppercase hexadecimal letters.'
   long l4 = 0x7FFF_AAA_BBB_DDDL;
+
+  float c = 0x1ap1f; // violation  'Should use uppercase hexadecimal letters.'
+  float c2 = 0x1Ap1f;
+  double e = 0x1AbC.p1d; // violation  'Should use uppercase hexadecimal letters.'
+  double e2 = 0x1ABC.p1d;
+  double f = 0x1AbC.P1D; // violation  'Should use uppercase hexadecimal letters.'
+  double f2 = 0x1ABC.P1D;
+  float g = 0x1b.p1f; // violation  'Should use uppercase hexadecimal letters.'
+  float g2 = 0x1B.p1f;
+  float h = 0x1b.P1F; // violation  'Should use uppercase hexadecimal letters.'
+  float h2 = 0x1B.P1F;
+  float i = 0x1B.p1f;
+  double j = 0x1B.p1d;
+  float p = 0x7f_ff_ff_ff; // violation  'Should use uppercase hexadecimal letters.'
+  float p2 = 0x7F_FF_FF_FF;
+  float q = 0x1.ffcp15f; // violation  'Should use uppercase hexadecimal letters.'
+  float q2 = 0x1.FFCP15f;
+  float r = -0x1.ffcP+15f; // violation  'Should use uppercase hexadecimal letters.'
+  float r2 = -0x1.FFCP+15f;
 
 }
 // xdoc section -- end


### PR DESCRIPTION
Issue : #18653 

What this pr does ? 

first the check does not support float hex literals now this pr add code to also check hex float literals.

Strange but there is no Examples test file present for `hexliteralcasecheck ` so i also added that

Diff Regression config: https://gist.githubusercontent.com/Aman-Baliyan/6116eec5f52041d7264c0b02bdc39039/raw/6e58d25b5b5ab0e224ee7c96f7b320e6ebc6fe87/HexLiteralCase.config