### PR TITLE
Issue #18789: Activate Java 21 migration recipes in `OpenRewrite` CI

### DIFF
--- a/config/rewrite.yml
+++ b/config/rewrite.yml
@@ -30,7 +30,6 @@ recipeList:
   - tech.picnic.errorprone.refasterrules.BigDecimalRulesRecipes
   - tech.picnic.errorprone.refasterrules.CharSequenceRulesRecipes
   - tech.picnic.errorprone.refasterrules.ClassRulesRecipes
-  - tech.picnic.errorprone.refasterrules.CollectionRulesRecipes
   - tech.picnic.errorprone.refasterrules.ComparatorRulesRecipes
   - tech.picnic.errorprone.refasterrules.FileRulesRecipes
 ---
@@ -61,12 +60,11 @@ recipeList:
   - org.openrewrite.java.format.NormalizeLineBreaks
   - org.openrewrite.java.format.PadEmptyForLoopComponents
   - org.openrewrite.java.format.RemoveTrailingWhitespace
-  # until https://github.com/checkstyle/checkstyle/issues/18789
-  # - org.openrewrite.java.migrate.UpgradeToJava21
+  - org.openrewrite.java.migrate.UpgradeToJava21
   - org.openrewrite.java.migrate.lang.StringRulesRecipes
   - org.openrewrite.java.migrate.util.MigrateInflaterDeflaterToClose
   - org.openrewrite.java.migrate.util.ReplaceStreamCollectWithToList
-  # - org.openrewrite.java.migrate.util.SequencedCollection
+  - org.openrewrite.java.migrate.util.SequencedCollection
   - org.openrewrite.java.recipes.JavaRecipeBestPractices
   - org.openrewrite.java.recipes.RecipeTestingBestPractices
   - org.openrewrite.maven.BestPractices

--- a/src/test/java/com/puppycrawl/tools/checkstyle/api/AbstractCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/api/AbstractCheckTest.java
@@ -377,7 +377,7 @@ public class AbstractCheckTest extends AbstractModuleTestSupport {
                 .that(internalViolations)
                 .hasSize(1);
 
-        final Violation firstViolation = internalViolations.first();
+        final Violation firstViolation = internalViolations.getFirst();
         assertWithMessage("expected line")
                 .that(firstViolation.getLineNo())
                 .isEqualTo(1);

--- a/src/test/java/com/puppycrawl/tools/checkstyle/api/AbstractFileSetCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/api/AbstractFileSetCheckTest.java
@@ -72,7 +72,7 @@ public class AbstractFileSetCheckTest extends AbstractModuleTestSupport {
             check.process(firstFile, new FileText(firstFile, Collections.emptyList()));
 
         assertWithMessage("Invalid message")
-                .that(firstFileMessages.first().getViolation())
+                .that(firstFileMessages.getFirst().getViolation())
                 .isEqualTo("File should not be empty.");
 
         final SortedSet<Violation> internalMessages =
@@ -196,7 +196,7 @@ public class AbstractFileSetCheckTest extends AbstractModuleTestSupport {
                 .that(internalViolations)
                 .hasSize(1);
 
-        final Violation violation = internalViolations.first();
+        final Violation violation = internalViolations.getFirst();
         assertWithMessage("expected line")
                 .that(violation.getLineNo())
                 .isEqualTo(1);
@@ -244,7 +244,7 @@ public class AbstractFileSetCheckTest extends AbstractModuleTestSupport {
                 .that(dispatcher.errorList)
                 .hasSize(1);
 
-        final Violation violation = dispatcher.errorList.first();
+        final Violation violation = dispatcher.errorList.getFirst();
         assertWithMessage("expected line")
                 .that(violation.getLineNo())
                 .isEqualTo(1);

--- a/src/test/java/com/puppycrawl/tools/checkstyle/api/AbstractViolationReporterTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/api/AbstractViolationReporterTest.java
@@ -94,7 +94,7 @@ public class AbstractViolationReporterTest {
                 .that(messages)
                 .hasSize(1);
         assertWithMessage("violation differs from expected")
-                .that(messages.first().getViolation())
+                .that(messages.getFirst().getViolation())
                 .isEqualTo("This is a custom violation.");
     }
 
@@ -112,7 +112,7 @@ public class AbstractViolationReporterTest {
                 .hasSize(1);
 
         assertWithMessage("violation differs from expected")
-                .that(messages.first().getViolation())
+                .that(messages.getFirst().getViolation())
                 .isEqualTo("This is a custom violation with TestParam.");
     }
 

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/OrderedPropertiesCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/OrderedPropertiesCheckTest.java
@@ -134,8 +134,8 @@ public class OrderedPropertiesCheckTest extends AbstractModuleTestSupport {
         assertWithMessage("Wrong violations count")
                 .that(violations)
                 .hasSize(1);
-        final Violation violation = violations.first();
-        final String retrievedMessage = violations.first().getKey();
+        final Violation violation = violations.getFirst();
+        final String retrievedMessage = violations.getFirst().getKey();
         assertWithMessage("violation key is not valid")
                 .that(retrievedMessage)
                 .isEqualTo("unable.open.cause");

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/UniquePropertiesCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/UniquePropertiesCheckTest.java
@@ -138,8 +138,8 @@ public class UniquePropertiesCheckTest extends AbstractModuleTestSupport {
         assertWithMessage("Wrong messages count: %s", violations.size())
             .that(violations)
             .hasSize(1);
-        final Violation violation = violations.first();
-        final String retrievedMessage = violations.first().getKey();
+        final Violation violation = violations.getFirst();
+        final String retrievedMessage = violations.getFirst().getKey();
         assertWithMessage("violation key '%s' is not valid", retrievedMessage)
             .that(retrievedMessage)
             .isEqualTo("unable.open.cause");


### PR DESCRIPTION
### Issue #18789: Activate Java 21 migration recipes in `OpenRewrite` CI


```
 # collision to: UpgradeToJava21 first <-> getFirstExpand
 # tech.picnic.errorprone.refasterrules.CollectionRulesRecipes
```