### PR TITLE
Issue #17882: Update JAVADOC_INLINE_TAG_END token documentation

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/api/JavadocCommentsTokenTypes.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/api/JavadocCommentsTokenTypes.java
@@ -771,6 +771,7 @@ public final class JavadocCommentsTokenTypes {
      * }</pre>
      *
      * @see #JAVADOC_INLINE_TAG
+     * @see #JAVADOC_INLINE_TAG_START
      */
     public static final int JAVADOC_INLINE_TAG_END = JavadocCommentsLexer.JAVADOC_INLINE_TAG_END;
 


### PR DESCRIPTION
This PR recreates #18628 on a clean branch without merge commits to satisfy ci/circleci: git-no-merge-commits.

Changes:
- Update JAVADOC_INLINE_TAG_END token documentation with AST example.

Notes:
- The previous PR had a merge commit (Merge branch 'master' into issue-17882-javadoc-inline-tag-end) which causes CircleCI git-no-merge-commits to fail.