### PR TITLE
Issue #18556: updating multifileregexpheader and adding external xml …

### DIFF
--- a/src/site/xdoc/checks/header/multifileregexpheader.xml
+++ b/src/site/xdoc/checks/header/multifileregexpheader.xml
@@ -63,16 +63,19 @@ public class Example1 { }
 </code></pre></div>
         <hr class="example-separator"/>
 
-        <p id="Example2-config">
+        <p id="Example2-raw">
           To configure the check to use multiple header files:
         </p>
         <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
+&lt;?xml version="1.0"?&gt;
+&lt;!DOCTYPE module PUBLIC
+        "-//Puppy Crawl//DTD Check Configuration 1.3//EN"
+        "https://checkstyle.org/dtds/configuration_1_3.dtd"&gt;
 &lt;module name="Checker"&gt;
-  &lt;module name="MultiFileRegexpHeader"&gt;
-    &lt;property name="fileExtensions" value="java"/&gt;
-    &lt;property name="headerFiles" value="${config.folder}/java.header,
-    ${config.folder}/apache.header"/&gt;
-  &lt;/module&gt;
+    &lt;module name="MultiFileRegexpHeader"&gt;
+        &lt;property name="fileExtensions" value="java"/&gt;
+        &lt;property name="headerFiles" value="${config.folder}/java.header, ${config.folder}/apache.header"/&gt;
+    &lt;/module&gt;
 &lt;/module&gt;
 </code></pre></div>
 
@@ -99,17 +102,20 @@ public class Example2 { }
 </code></pre></div>
         <hr class="example-separator"/>
 
-        <p id="Example3-config">
+        <p id="Example3-raw">
           To configure the check to verify that each file starts with one of
           multiple headers.
         </p>
         <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
+&lt;?xml version="1.0"?&gt;
+&lt;!DOCTYPE module PUBLIC
+        "-//Checkstyle//DTD Checkstyle Configuration 1.3//EN"
+        "https://checkstyle.org/dtds/configuration_1_3.dtd"&gt;
 &lt;module name="Checker"&gt;
-  &lt;module name="MultiFileRegexpHeader"&gt;
-    &lt;property
-      name="headerFiles" value="${config.folder}/java.header,
-      ${config.folder}/apache.header"/&gt;
-  &lt;/module&gt;
+    &lt;module name="MultiFileRegexpHeader"&gt;
+        &lt;property name="headerFiles"
+                  value="${config.folder}/java.header, ${config.folder}/apache.header"/&gt;
+    &lt;/module&gt;
 &lt;/module&gt;
 </code></pre></div>
 
@@ -121,10 +127,14 @@ public class Example3 { }
 </code></pre></div>
         <hr class="example-separator"/>
 
-        <p id="Example4-config">
+        <p id="Example4-raw">
           For a configuration where any header is accepted:
         </p>
         <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
+&lt;?xml version="1.0"?&gt;
+&lt;!DOCTYPE module PUBLIC
+        "-//Puppy Crawl//DTD Check Configuration 1.3//EN"
+        "https://checkstyle.org/dtds/configuration_1_3.dtd"&gt;
 &lt;module name="Checker"&gt;
   &lt;module name="MultiFileRegexpHeader"&gt;
     &lt;property

--- a/src/site/xdoc/checks/header/multifileregexpheader.xml.template
+++ b/src/site/xdoc/checks/header/multifileregexpheader.xml.template
@@ -46,13 +46,13 @@
         </macro>
         <hr class="example-separator"/>
 
-        <p id="Example2-config">
+        <p id="Example2-raw">
           To configure the check to use multiple header files:
         </p>
         <macro name="example">
           <param name="path"
-                 value="resources/com/puppycrawl/tools/checkstyle/checks/header/multifileregexpheader/Example2.java"/>
-          <param name="type" value="config"/>
+                 value="resources/com/puppycrawl/tools/checkstyle/checks/header/multifileregexpheader/Example2.xml"/>
+          <param name="type" value="raw"/>
         </macro>
 
         <p id="java-raw">content of <code>java.header</code> file:</p>
@@ -77,14 +77,14 @@
         </macro>
         <hr class="example-separator"/>
 
-        <p id="Example3-config">
+        <p id="Example3-raw">
           To configure the check to verify that each file starts with one of
           multiple headers.
         </p>
         <macro name="example">
           <param name="path"
-                 value="resources/com/puppycrawl/tools/checkstyle/checks/header/multifileregexpheader/Example3.java"/>
-          <param name="type" value="config"/>
+                 value="resources/com/puppycrawl/tools/checkstyle/checks/header/multifileregexpheader/Example3.xml"/>
+          <param name="type" value="raw"/>
         </macro>
 
         <p id="Example3-code">Example3:</p>
@@ -95,13 +95,13 @@
         </macro>
         <hr class="example-separator"/>
 
-        <p id="Example4-config">
+        <p id="Example4-raw">
           For a configuration where any header is accepted:
         </p>
         <macro name="example">
           <param name="path"
-                 value="resources/com/puppycrawl/tools/checkstyle/checks/header/multifileregexpheader/Example4.java"/>
-          <param name="type" value="config"/>
+                 value="resources/com/puppycrawl/tools/checkstyle/checks/header/multifileregexpheader/Example4.xml"/>
+          <param name="type" value="raw"/>
         </macro>
 
         <p id="universal-raw">content of <code>universal.header</code> file:</p>

--- a/src/test/java/com/puppycrawl/tools/checkstyle/AbstractModuleTestSupport.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/AbstractModuleTestSupport.java
@@ -257,6 +257,28 @@ public abstract class AbstractModuleTestSupport extends AbstractPathTestSupport 
     }
 
     /**
+     * Performs verification of the file with the given file path using configuration,
+     * loaded from an external XML resource and the array of expected messages.
+     *
+     * @param configPath path to the XML configuration resource.
+     * @param filePath file path to verify.
+     * @param expected an array of expected messages.
+     * @throws Exception if exception occurs during verification process.
+     */
+    protected void verifyWithExternalXmlConfig(
+            String configPath,
+            String filePath,
+            String... expected)
+            throws Exception {
+        final Configuration config =
+                ConfigurationLoader.loadConfiguration(
+                        configPath,
+                        new PropertiesExpander(System.getProperties()),
+                        ConfigurationLoader.IgnoredModulesOptions.EXECUTE);
+        verify(config, filePath, expected);
+    }
+
+    /**
      * Performs verification of the file with the given file path using specified configuration
      * and the array expected messages. Also performs verification of the config specified in
      * input file.

--- a/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/checks/header/MultiFileRegexpHeaderCheckExamplesTest.java
+++ b/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/checks/header/MultiFileRegexpHeaderCheckExamplesTest.java
@@ -38,42 +38,47 @@ public class MultiFileRegexpHeaderCheckExamplesTest extends AbstractExamplesModu
 
     @Test
     public void testExample2() throws Exception {
-        final String[] expected = {
-            "1: " + getCheckMessage(MultiFileRegexpHeaderCheck.MSG_HEADER_MISMATCH,
-                    "// Checkstyle - Java code style checker."
-                   + " Copyright (C) 20XX-20XX the authors.",
+        final String path =
                      "src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/header/"
                       + "multifileregexpheader/java.header, "
                     + "src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/header/"
-                      + "multifileregexpheader/apache.header"),
+                       + "multifileregexpheader/apache.header";
+        final String[] expected = {
+            "1: " + getCheckMessage(MultiFileRegexpHeaderCheck.MSG_HEADER_MISMATCH,
+                    "// Checkstyle - Java code style checker."
+                   + " Copyright (C) 20XX-20XX the authors.", path),
         };
-
         System.setProperty("config.folder", "src/xdocs-examples/resources/" + getPackageLocation());
-        verifyWithInlineConfigParser(getPath("Example2.java"), expected);
-
+        verifyWithExternalXmlConfig(getPath("Example2.xml"),
+                                    getPath("Example2.java"),
+                                     expected);
     }
 
     @Test
     public void testExample3() throws Exception {
-        final String[] expected = {
-            "1: " + getCheckMessage(MultiFileRegexpHeaderCheck.MSG_HEADER_MISMATCH,
-                    "// Checkstyle - Java code style checker."
-                   + " Copyright (C) 20XX-20XX the authors.",
+        final String path =
                      "src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/header/"
                       + "multifileregexpheader/java.header, "
                     + "src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/header/"
-                       + "multifileregexpheader/apache.header"),
+                       + "multifileregexpheader/apache.header";
+        final String[] expected = {
+            "1: " + getCheckMessage(MultiFileRegexpHeaderCheck.MSG_HEADER_MISMATCH,
+                       "// Checkstyle - Java code style checker."
+                   + " Copyright (C) 20XX-20XX the authors.", path),
         };
-
         System.setProperty("config.folder", "src/xdocs-examples/resources/" + getPackageLocation());
-        verifyWithInlineConfigParser(getPath("Example3.java"), expected);
+        verifyWithExternalXmlConfig(getPath("Example3.xml"),
+                                    getPath("Example3.java"),
+                                     expected);
     }
 
     @Test
     public void testExample4() throws Exception {
         final String[] expected = CommonUtil.EMPTY_STRING_ARRAY;
         System.setProperty("config.folder", "src/xdocs-examples/resources/" + getPackageLocation());
-        verifyWithInlineConfigParser(getPath("Example4.java"), expected);
+        verifyWithExternalXmlConfig(getPath("Example4.xml"),
+                                    getPath("Example4.java"),
+                                     expected);
     }
 }
 

--- a/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/header/multifileregexpheader/Example2.java
+++ b/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/header/multifileregexpheader/Example2.java
@@ -1,11 +1,4 @@
 /*xml
-<module name="Checker">
-  <module name="MultiFileRegexpHeader">
-    <property name="fileExtensions" value="java"/>
-    <property name="headerFiles" value="${config.folder}/java.header,
-    ${config.folder}/apache.header"/>
-  </module>
-</module>
 */
 // xdoc section -- start
 package com.puppycrawl.tools.checkstyle.checks.header.multifileregexpheader;
@@ -13,4 +6,4 @@ package com.puppycrawl.tools.checkstyle.checks.header.multifileregexpheader;
 // because headerFile is bigger then target java file
 public class Example2 { }
 // xdoc section -- end
-// violation 15 lines above 'Header mismatch, expected line content was'
+// violation 8 lines above 'Header mismatch, expected line content was'

--- a/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/header/multifileregexpheader/Example2.xml
+++ b/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/header/multifileregexpheader/Example2.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0"?>
+<!DOCTYPE module PUBLIC
+        "-//Puppy Crawl//DTD Check Configuration 1.3//EN"
+        "https://checkstyle.org/dtds/configuration_1_3.dtd">
+<module name="Checker">
+    <module name="MultiFileRegexpHeader">
+        <property name="fileExtensions" value="java"/>
+        <property name="headerFiles" value="${config.folder}/java.header, ${config.folder}/apache.header"/>
+    </module>
+</module>
+

--- a/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/header/multifileregexpheader/Example3.java
+++ b/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/header/multifileregexpheader/Example3.java
@@ -1,15 +1,8 @@
 /*xml
-<module name="Checker">
-  <module name="MultiFileRegexpHeader">
-    <property
-      name="headerFiles" value="${config.folder}/java.header,
-      ${config.folder}/apache.header"/>
-  </module>
-</module>
 */
 // xdoc section -- start
 package com.puppycrawl.tools.checkstyle.checks.header.multifileregexpheader;
 /* violation on first line 'Header mismatch, expected line content was' */
 public class Example3 { }
 // xdoc section -- end
-// violation 14 lines above 'Header mismatch, expected line content was'
+// violation 7 lines above 'Header mismatch, expected line content was'

--- a/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/header/multifileregexpheader/Example3.xml
+++ b/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/header/multifileregexpheader/Example3.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0"?>
+<!DOCTYPE module PUBLIC
+        "-//Checkstyle//DTD Checkstyle Configuration 1.3//EN"
+        "https://checkstyle.org/dtds/configuration_1_3.dtd">
+<module name="Checker">
+    <module name="MultiFileRegexpHeader">
+        <property name="headerFiles"
+                  value="${config.folder}/java.header, ${config.folder}/apache.header"/>
+    </module>
+</module>

--- a/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/header/multifileregexpheader/Example4.java
+++ b/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/header/multifileregexpheader/Example4.java
@@ -1,11 +1,4 @@
 /*xml
-<module name="Checker">
-  <module name="MultiFileRegexpHeader">
-    <property
-      name="headerFiles"
-      value="${config.folder}/universal.header"/>
-  </module>
-</module>
 */
 // xdoc section -- start
 package com.puppycrawl.tools.checkstyle.checks.header.multifileregexpheader;

--- a/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/header/multifileregexpheader/Example4.xml
+++ b/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/header/multifileregexpheader/Example4.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0"?>
+<!DOCTYPE module PUBLIC
+        "-//Puppy Crawl//DTD Check Configuration 1.3//EN"
+        "https://checkstyle.org/dtds/configuration_1_3.dtd">
+<module name="Checker">
+  <module name="MultiFileRegexpHeader">
+    <property
+      name="headerFiles"
+      value="${config.folder}/universal.header"/>
+  </module>
+</module>


### PR DESCRIPTION
Issue: #18556

Added a method in AbstractModuleTestSupport to check external xml for example also.
Now new method verifyWithExternalXmlConfig get three args... `xml, javafile, expected`.
only template file point to inline xml for documentation so user can see the confiq.
