### PR TITLE
Issue #18486: Refractor JavadocParagraph Check

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocParagraphCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocParagraphCheck.java
@@ -57,7 +57,8 @@ import com.puppycrawl.tools.checkstyle.utils.JavadocUtil;
  * <p>This Check ignores HTML comments.</p>
  *
  * <p>The Check ignores all the nested paragraph tags,
- * it will not give any kind of violation if the paragraph tag is nested.</p>
+ * it will not give any kind of violation if the paragraph tag is nested.
+ * It also ignores paragraph tags inside block tags.</p>
  *
  * @since 6.0
  */
@@ -165,7 +166,7 @@ public class JavadocParagraphCheck extends AbstractJavadocCheck {
      * @param tag html tag.
      */
     private void checkParagraphTag(DetailNode tag) {
-        if (!isNestedParagraph(tag)) {
+        if (!isNestedParagraph(tag) && !isInsideBlockTag(tag)) {
             final DetailNode newLine = getNearestEmptyLine(tag);
             if (isFirstParagraph(tag)) {
                 log(tag.getLineNumber(), tag.getColumnNumber(), MSG_REDUNDANT_PARAGRAPH);
@@ -208,6 +209,27 @@ public class JavadocParagraphCheck extends AbstractJavadocCheck {
         }
 
         return nested;
+    }
+
+    /**
+     * Determines whether the paragraph tag is inside javadoc block tag.
+     *
+     * @param tag html tag.
+     * @return true, if the paragraph tag is inside javadoc block tag.
+     */
+    private static boolean isInsideBlockTag(DetailNode tag) {
+        boolean result = false;
+        DetailNode parent = tag;
+
+        while (parent != null) {
+            if (parent.getType() == JavadocCommentsTokenTypes.JAVADOC_BLOCK_TAG) {
+                result = true;
+                break;
+            }
+            parent = parent.getParent();
+        }
+
+        return result;
     }
 
     /**

--- a/src/main/resources/com/puppycrawl/tools/checkstyle/meta/checks/javadoc/JavadocParagraphCheck.xml
+++ b/src/main/resources/com/puppycrawl/tools/checkstyle/meta/checks/javadoc/JavadocParagraphCheck.xml
@@ -31,7 +31,8 @@
  &lt;p&gt;This Check ignores HTML comments.&lt;/p&gt;
 
  &lt;p&gt;The Check ignores all the nested paragraph tags,
- it will not give any kind of violation if the paragraph tag is nested.&lt;/p&gt;</description>
+ it will not give any kind of violation if the paragraph tag is nested.
+ It also ignores paragraph tags inside block tags.&lt;/p&gt;</description>
          <properties>
             <property default-value="true" name="allowNewlineParagraph" type="boolean">
                <description>Control whether the &amp;lt;p&amp;gt; tag should be placed

--- a/src/site/xdoc/checks/javadoc/javadocparagraph.xml
+++ b/src/site/xdoc/checks/javadoc/javadocparagraph.xml
@@ -36,7 +36,8 @@
         <p>This Check ignores HTML comments.</p>
 
         <p>The Check ignores all the nested paragraph tags,
-          it will not give any kind of violation if the paragraph tag is nested.</p>
+          it will not give any kind of violation if the paragraph tag is nested.
+          It also ignores paragraph tags inside block tags.</p>
       </subsection>
 
       <subsection name="Properties" id="JavadocParagraph_Properties">

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocParagraphCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocParagraphCheckTest.java
@@ -262,4 +262,12 @@ public class JavadocParagraphCheckTest extends AbstractModuleTestSupport {
         verifyWithInlineConfigParser(
                 getPath("InputJavadocParagraphNested.java"), expected);
     }
+
+    @Test
+    public void testJavadocParagraphBlockTag() throws Exception {
+        final String[] expected = CommonUtil.EMPTY_STRING_ARRAY;
+
+        verifyWithInlineConfigParser(
+                getPath("InputJavadocParagraphBlockTag.java"), expected);
+    }
 }

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadocparagraph/InputJavadocParagraphBlockTag.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadocparagraph/InputJavadocParagraphBlockTag.java
@@ -1,0 +1,93 @@
+/*
+JavadocParagraph
+violateExecutionOnNonTightHtml = (default)false
+allowNewlineParagraph = (default)true
+
+
+*/
+
+package com.puppycrawl.tools.checkstyle.checks.javadoc.javadocparagraph;
+
+public class InputJavadocParagraphBlockTag {
+    /**
+     * Test method.
+     *
+     * @return some result
+     *
+     * <p>Indide Block Tag</p>
+     */
+    public void method() {
+    }
+
+    /**
+     * Test method.
+     *
+     * @return some result
+     *           <p>Indide Block Tag</p>
+     */
+    public void method2() {
+    }
+
+    /**
+     * Test method.
+     *
+     * @return some result <p>Indide Block Tag</p>
+     */
+    public void method3() {
+    }
+
+    /**
+     * Test method.
+     *
+     * @deprecated All instance methods have
+     *       their equivalent on the result of {@code Traverser.forTree(tree)} where {@code tree}
+     *       implements {@code SuccessorsFunction}, which has a similar API as {@link #children}
+     *       or can be the same lambda function as passed.
+     *       <p>This class is scheduled to be removed in October 2019.
+     */
+    public void method4() {
+    }
+
+    /**
+     * Test method.
+     *
+     * @param ast
+     *            Root node of subtree to traverse.
+     *            <p>
+     *            Note that the AST passed in is not visited itself. Visitation
+     *            starts with its children.
+     *            </p>
+     */
+    public void method5() {
+    }
+
+    /**
+     * Test method.
+     *
+     * @implNote This is for test purpose.
+     *  <p>This encoding is a classic space-time trade-off: we save space by encoding the values as
+     *  deltas, but pay in time because reading, writing and calculating encoded size requires long
+     *  addition/subtraction and array lookbehind. We assume that this is easily optimized by any
+     *  and that the space savings are worth the trade-off.
+     */
+    public void method6() {
+    }
+
+    /**
+     * Test method.
+     *
+     * @deprecated This is not useful, not adapted to the problem, and
+     *     does not scale to changes in the Java language. The only use
+     *     of this is to get a name.
+     *
+     *     <p>Besides, the real problem is that
+     *     <ul>
+     *         <li>enums are also classes
+     *         <li>annotations are also interfaces
+     *         <li>there are also anonymous classes in PMD 7.0, so this
+     *         cannot even be used to downcast safely
+     *     </ul>
+     */
+    public void method7() {
+    }
+}


### PR DESCRIPTION
Issue: #18486 

what this pr does ?

-> without this pr the check gives false positive for p tags inside block tags now in this pr i added a method to skip the p tags inside the javadoc block tags.

Diff Regression config: https://gist.githubusercontent.com/Aman-Baliyan/c46f95fd657e0ac11ebb04328e11377e/raw/ed493cc08347dcfe016af8e288aade0a8592b86d/JavadocParagraph.xml