### PR TITLE
Issue #17882: Update EQUALS of JavadocCommentsTokenTypes to new AST f…

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/api/JavadocCommentsTokenTypes.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/api/JavadocCommentsTokenTypes.java
@@ -1554,7 +1554,38 @@ public final class JavadocCommentsTokenTypes {
     public static final int SNIPPET_ATTR_NAME = JavadocCommentsLexer.SNIPPET_ATTR_NAME;
 
     /**
-     * Equals sign {@code = }.
+     * Equals sign {@code =}.
+     *
+     * <p>Used within snippet attributes to assign values.</p>
+     *
+     * <p><b>Example:</b></p>
+     * <pre>{@code
+     * &#123;@snippet lang="java" :
+     *   int x = 1;
+     * }
+     * }</pre>
+     *
+     * <p><b>Tree:</b></p>
+     * <pre>{@code
+     * JAVADOC_INLINE_TAG -> JAVADOC_INLINE_TAG
+     * `--SNIPPET_INLINE_TAG -> SNIPPET_INLINE_TAG
+     *     |--JAVADOC_INLINE_TAG_START -> &#123;@
+     *     |--SNIPPET_ATTRIBUTES -> SNIPPET_ATTRIBUTES
+     *     |   `--SNIPPET_ATTRIBUTE -> SNIPPET_ATTRIBUTE
+     *     |       |--TEXT ->
+     *     |       |--SNIPPET_ATTR_NAME -> lang
+     *     |       |--EQUALS -> =
+     *     |       `--ATTRIBUTE_VALUE -> "java"
+     *     |--COLON -> :
+     *     |--SNIPPET_BODY -> SNIPPET_BODY
+     *     |   |--NEWLINE -> \n
+     *     |   |--TEXT ->   int x = 1;
+     *     |   |--NEWLINE -> \r\n
+     *     `--JAVADOC_INLINE_TAG_END -> }
+     * }</pre>
+     *
+     * @see #SNIPPET_ATTRIBUTE
+     * @see #SNIPPET_ATTRIBUTES
      */
     public static final int EQUALS = JavadocCommentsLexer.EQUALS;
 


### PR DESCRIPTION
## Description
Updates the Javadoc documentation for the `EQUALS` token to include the new AST print format generated by the latest Checkstyle snapshot.

## Related Issue
Fixes #17882

## Example Input
```java
public class Test {

    /**
     * {@snippet lang="java" :
     *   int x = 1;
     * }
     */
    void m() {}
}
```
Command:

``` 
java -jar checkstyle-13.1.0-SNAPSHOT-all.jar -j src/Test.java | sed "s/\[[0-9]\+:[0-9]\+\]//g 

```
## Here is the full CLI output:
```
JAVADOC_CONTENT -> JAVADOC_CONTENT
|--TEXT -> public class Test {
|--NEWLINE -> \r\n
|--NEWLINE -> \r\n
|--TEXT ->     /**
|--NEWLINE -> \r\n
|--LEADING_ASTERISK ->      *
|--TEXT ->
|--JAVADOC_INLINE_TAG -> JAVADOC_INLINE_TAG
|   `--SNIPPET_INLINE_TAG -> SNIPPET_INLINE_TAG
|       |--JAVADOC_INLINE_TAG_START -> {@
|       |--SNIPPET_ATTRIBUTES -> SNIPPET_ATTRIBUTES
|       |   `--SNIPPET_ATTRIBUTE -> SNIPPET_ATTRIBUTE
|       |       |--TEXT ->
|       |       |--SNIPPET_ATTR_NAME -> lang
|       |       |--EQUALS -> =
|       |       `--ATTRIBUTE_VALUE -> "java"
|       |--COLON -> :
|       |--SNIPPET_BODY -> SNIPPET_BODY
|       |   |--NEWLINE -> \r\n
|       |   |--LEADING_ASTERISK ->      *
|       |   |--TEXT ->    int x = 1;
|       |   |--NEWLINE -> \r\n
|       |   |--LEADING_ASTERISK ->      *
|       |   `--TEXT ->
|       `--JAVADOC_INLINE_TAG_END -> }
|--NEWLINE -> \r\n
|--LEADING_ASTERISK ->      *
|--TEXT -> /
|--NEWLINE -> \r\n
|--TEXT ->     void m() {}
|--NEWLINE -> \r\n
|--TEXT -> }
`--NEWLINE -> \r\n
```

## Testing
- [x] `./mvnw clean verify` passes