### PR TITLE
Issue #18437: Added 'ENUM_CONSTANT_DEF' in EmptyLineSeparator Check

### DIFF
--- a/config/checker-framework-suppressions/checker-nullness-optional-interning-suppressions.xml
+++ b/config/checker-framework-suppressions/checker-nullness-optional-interning-suppressions.xml
@@ -7091,6 +7091,13 @@
   <checkerFrameworkError unstable="false">
     <fileName>src/main/java/com/puppycrawl/tools/checkstyle/checks/whitespace/EmptyLineSeparatorCheck.java</fileName>
     <specifier>dereference.of.nullable</specifier>
+    <message>dereference of possibly-null reference firstConstant</message>
+    <lineContent>if (firstConstant.getLineNo() == ast.getLineNo()</lineContent>
+  </checkerFrameworkError>
+
+  <checkerFrameworkError unstable="false">
+    <fileName>src/main/java/com/puppycrawl/tools/checkstyle/checks/whitespace/EmptyLineSeparatorCheck.java</fileName>
+    <specifier>dereference.of.nullable</specifier>
     <message>dereference of possibly-null reference token.findFirstToken(TokenTypes.TYPE)</message>
     <lineContent>for (DetailAST typeChild = token.findFirstToken(TokenTypes.TYPE).getLastChild();</lineContent>
   </checkerFrameworkError>

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/whitespace/EmptyLineSeparatorCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/whitespace/EmptyLineSeparatorCheck.java
@@ -149,6 +149,7 @@ public class EmptyLineSeparatorCheck extends AbstractCheck {
             TokenTypes.CLASS_DEF,
             TokenTypes.INTERFACE_DEF,
             TokenTypes.ENUM_DEF,
+            TokenTypes.ENUM_CONSTANT_DEF,
             TokenTypes.STATIC_INIT,
             TokenTypes.INSTANCE_INIT,
             TokenTypes.METHOD_DEF,
@@ -166,7 +167,11 @@ public class EmptyLineSeparatorCheck extends AbstractCheck {
 
     @Override
     public void visitToken(DetailAST ast) {
-        checkComments(ast);
+
+        if (ast.getType() != TokenTypes.ENUM_CONSTANT_DEF) {
+            checkComments(ast);
+        }
+
         if (hasMultipleLinesBefore(ast)) {
             log(ast, MSG_MULTIPLE_LINES, ast.getText());
         }
@@ -201,6 +206,8 @@ public class EmptyLineSeparatorCheck extends AbstractCheck {
             case TokenTypes.VARIABLE_DEF -> processVariableDef(ast, nextToken);
 
             case TokenTypes.IMPORT, TokenTypes.STATIC_IMPORT -> processImport(ast, nextToken);
+
+            case TokenTypes.ENUM_CONSTANT_DEF -> processEnumConstant(ast);
 
             default -> {
                 if (nextToken.getType() == TokenTypes.RCURLY) {
@@ -380,7 +387,8 @@ public class EmptyLineSeparatorCheck extends AbstractCheck {
      */
     private boolean hasMultipleLinesBefore(DetailAST ast) {
         return (ast.getType() != TokenTypes.VARIABLE_DEF || isTypeField(ast))
-                && hasNotAllowedTwoEmptyLinesBefore(ast);
+                && hasNotAllowedTwoEmptyLinesBefore(ast)
+                && ast.getType() != TokenTypes.ENUM_CONSTANT_DEF;
     }
 
     /**
@@ -465,6 +473,110 @@ public class EmptyLineSeparatorCheck extends AbstractCheck {
             log(nextToken, MSG_SHOULD_BE_SEPARATED,
                     nextToken.getText());
         }
+    }
+
+    /**
+     * Process Enum Constant.
+     *
+     * @param ast token
+     */
+    public void processEnumConstant(DetailAST ast) {
+
+        // Check empty line before enum Constant (comment skipped)
+        final DetailAST secondLastChild = ast.getLastChild().getPreviousSibling();
+
+        final boolean hasMultipleEmptyLinesBeforeConstant =
+                !isEnumConstantOnSharedLine(ast)
+                && hasNotAllowedTwoEmptyLinesBefore(ast);
+
+        final boolean hasMultipleEmptyLinesBeforeConstantComment =
+                secondLastChild.getLineNo() > ast.getPreviousSibling().getLineNo()
+                && hasMultipleLinesBefore(secondLastChild);
+
+        if (hasMultipleEmptyLinesBeforeConstant
+                || hasMultipleEmptyLinesBeforeConstantComment) {
+            log(ast, MSG_MULTIPLE_LINES, ast.getText());
+        }
+
+        if (!allowMultipleEmptyLines) {
+            checkMultipleEmptyLinesAfterLastEnumConstant(ast);
+        }
+    }
+
+    /**
+     * Checks whether the enum constant is placed on a line that also contains
+     * another enum constant.
+     *
+     * @param ast the ast to check.
+     * @return true if the enum constant shares its line with another enum constant
+     */
+    private static boolean isEnumConstantOnSharedLine(DetailAST ast) {
+        boolean result = false;
+        final DetailAST objectBlock = ast.getParent();
+        // true if token is placed in single line enum
+        if (objectBlock.getParent().getLineNo() == ast.getLineNo()) {
+            result = true;
+        }
+        else {
+            // For multiline enum, true if token is placed in group of single line
+            // except first enum constant
+            final DetailAST firstConstant =
+                    objectBlock.findFirstToken(TokenTypes.ENUM_CONSTANT_DEF);
+            if (firstConstant.getLineNo() == ast.getLineNo()
+                    && firstConstant.getColumnNo() < ast.getColumnNo()) {
+                result = true;
+            }
+        }
+
+        return result;
+    }
+
+    /**
+     * Checks whether there are more than one empty lines after the last enum
+     * constant before the closing brace.
+     *
+     * @param ast token
+     */
+    private void checkMultipleEmptyLinesAfterLastEnumConstant(DetailAST ast) {
+        // skip next token is comma or comment
+        DetailAST nextToken = ast.getNextSibling();
+        while (nextToken.getType() == TokenTypes.COMMA
+                || TokenUtil.isCommentType(nextToken.getType())) {
+            nextToken = nextToken.getNextSibling();
+        }
+
+        // Check consecutive empty line after last
+        // enum constant (skipped comment after token)
+        if (nextToken.getType() == TokenTypes.RCURLY
+                && hasConsecutiveEmptyLines(ast.getLineNo(), nextToken.getLineNo())) {
+            log(ast, MSG_MULTIPLE_LINES_AFTER, ast.getText());
+        }
+    }
+
+    /**
+     * Checks, whether there is a consecutive empty lines within the specified line range.
+     *
+     * @param startLine first line in the range
+     * @param endLine second line in the range
+     * @return true, if found any consecutive empty lines within the range
+     */
+    private boolean hasConsecutiveEmptyLines(int startLine, int endLine) {
+        int emptyLines = 0;
+        boolean hasConsecutiveEmptyLines = false;
+        for (int lineNo = startLine; lineNo <= endLine - 2; ++lineNo) {
+            if (CommonUtil.isBlank(getLine(lineNo))) {
+                emptyLines++;
+                if (emptyLines > 1) {
+                    hasConsecutiveEmptyLines = true;
+                    break;
+                }
+            }
+            else {
+                emptyLines = 0;
+            }
+        }
+
+        return hasConsecutiveEmptyLines;
     }
 
     /**

--- a/src/main/resources/com/puppycrawl/tools/checkstyle/meta/checks/whitespace/EmptyLineSeparatorCheck.xml
+++ b/src/main/resources/com/puppycrawl/tools/checkstyle/meta/checks/whitespace/EmptyLineSeparatorCheck.xml
@@ -42,7 +42,7 @@
                       type="boolean">
                <description>Allow no empty line between fields.</description>
             </property>
-            <property default-value="PACKAGE_DEF,IMPORT,STATIC_IMPORT,CLASS_DEF,INTERFACE_DEF,ENUM_DEF,STATIC_INIT,INSTANCE_INIT,METHOD_DEF,CTOR_DEF,VARIABLE_DEF,RECORD_DEF,COMPACT_CTOR_DEF"
+            <property default-value="PACKAGE_DEF,IMPORT,STATIC_IMPORT,CLASS_DEF,INTERFACE_DEF,ENUM_DEF,ENUM_CONSTANT_DEF,STATIC_INIT,INSTANCE_INIT,METHOD_DEF,CTOR_DEF,VARIABLE_DEF,RECORD_DEF,COMPACT_CTOR_DEF"
                       name="tokens"
                       type="java.lang.String[]"
                       validation-type="tokenSet">

--- a/src/site/xdoc/checks/whitespace/emptylineseparator.xml
+++ b/src/site/xdoc/checks/whitespace/emptylineseparator.xml
@@ -82,6 +82,8 @@
                     INTERFACE_DEF</a>
                 , <a href="../../apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#ENUM_DEF">
                     ENUM_DEF</a>
+                , <a href="../../apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#ENUM_CONSTANT_DEF">
+                    ENUM_CONSTANT_DEF</a>
                 , <a href="../../apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#STATIC_INIT">
                     STATIC_INIT</a>
                 , <a href="../../apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#INSTANCE_INIT">
@@ -111,6 +113,8 @@
                     INTERFACE_DEF</a>
                 , <a href="../../apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#ENUM_DEF">
                     ENUM_DEF</a>
+                , <a href="../../apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#ENUM_CONSTANT_DEF">
+                    ENUM_CONSTANT_DEF</a>
                 , <a href="../../apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#STATIC_INIT">
                     STATIC_INIT</a>
                 , <a href="../../apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#INSTANCE_INIT">

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/whitespace/EmptyLineSeparatorCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/whitespace/EmptyLineSeparatorCheckTest.java
@@ -371,6 +371,54 @@ public class EmptyLineSeparatorCheckTest
     }
 
     @Test
+    public void testEmptyLineWithEnumConstant() throws Exception {
+        final String[] expected = {
+            "20:9: " + getCheckMessage(MSG_MULTIPLE_LINES, "ENUM_CONSTANT_DEF"),
+            "24:9: " + getCheckMessage(MSG_MULTIPLE_LINES, "ENUM_CONSTANT_DEF"),
+            "28:9: " + getCheckMessage(MSG_MULTIPLE_LINES, "ENUM_CONSTANT_DEF"),
+            "32:9: " + getCheckMessage(MSG_MULTIPLE_LINES, "ENUM_CONSTANT_DEF"),
+            "41:9: " + getCheckMessage(MSG_MULTIPLE_LINES, "ENUM_CONSTANT_DEF"),
+            "50:9: " + getCheckMessage(MSG_MULTIPLE_LINES, "VARIABLE_DEF"),
+            "68:7: " + getCheckMessage(MSG_MULTIPLE_LINES, "ENUM_CONSTANT_DEF"),
+        };
+
+        verifyWithInlineConfigParser(
+                getPath("InputEmptyLineSeparatorEnumConstant.java"), expected
+        );
+    }
+
+    @Test
+    public void testEmptyLineWithEnumConstantWithDefaultProperties() throws Exception {
+        final String[] expected = CommonUtil.EMPTY_STRING_ARRAY;
+
+        verifyWithInlineConfigParser(
+                getPath("InputEmptyLineSeparatorEnumConstantDefault.java"), expected
+        );
+    }
+
+    @Test
+    public void testEmptyLineWithEnum() throws Exception {
+        final String[] expected = {
+            "18:5: " + getCheckMessage(MSG_MULTIPLE_LINES, "ENUM_DEF"),
+            "23:5: " + getCheckMessage(MSG_MULTIPLE_LINES, "ENUM_DEF"),
+            "27:9: " + getCheckMessage(MSG_MULTIPLE_LINES, "ENUM_CONSTANT_DEF"),
+            "27:23: " + getCheckMessage(MSG_MULTIPLE_LINES_AFTER, "ENUM_CONSTANT_DEF"),
+            "39:9: " + getCheckMessage(MSG_MULTIPLE_LINES, "ENUM_CONSTANT_DEF"),
+            "42:9: " + getCheckMessage(MSG_MULTIPLE_LINES_AFTER, "ENUM_CONSTANT_DEF"),
+            "42:9: " + getCheckMessage(MSG_MULTIPLE_LINES, "ENUM_CONSTANT_DEF"),
+            "55:9: " + getCheckMessage(MSG_MULTIPLE_LINES, "ENUM_CONSTANT_DEF"),
+            "76:9: " + getCheckMessage(MSG_MULTIPLE_LINES_AFTER, "ENUM_CONSTANT_DEF"),
+            "91:9: " + getCheckMessage(MSG_MULTIPLE_LINES, "ENUM_CONSTANT_DEF"),
+            "94:13: " + getCheckMessage(MSG_MULTIPLE_LINES, "ENUM_CONSTANT_DEF"),
+            "97:21: " + getCheckMessage(MSG_MULTIPLE_LINES, "ENUM_CONSTANT_DEF"),
+            "113:9: " + getCheckMessage(MSG_MULTIPLE_LINES_AFTER, "ENUM_CONSTANT_DEF"),
+        };
+
+        verifyWithInlineConfigParser(
+                getPath("InputEmptyLineSeparatorEnum.java"), expected);
+    }
+
+    @Test
     public void testInterfaceFields() throws Exception {
         final String[] expected = {
             "21:5: " + getCheckMessage(MSG_MULTIPLE_LINES, "VARIABLE_DEF"),
@@ -395,6 +443,7 @@ public class EmptyLineSeparatorCheckTest
             TokenTypes.CLASS_DEF,
             TokenTypes.INTERFACE_DEF,
             TokenTypes.ENUM_DEF,
+            TokenTypes.ENUM_CONSTANT_DEF,
             TokenTypes.STATIC_INIT,
             TokenTypes.INSTANCE_INIT,
             TokenTypes.METHOD_DEF,

--- a/src/test/java/com/puppycrawl/tools/checkstyle/internal/AllChecksTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/internal/AllChecksTest.java
@@ -268,6 +268,9 @@ public class AllChecksTest extends AbstractModuleTestSupport {
                 // whitespace is necessary between a type annotation and ellipsis
                 // according '4.6.2 Horizontal whitespace point 9'
                 "ELLIPSIS").collect(Collectors.toUnmodifiableSet()));
+        GOOGLE_TOKENS_IN_CONFIG_TO_IGNORE.put("EmptyLineSeparator", Stream.of(
+                "ENUM_CONSTANT_DEF"
+        ).collect(Collectors.toUnmodifiableSet()));
         INTERNAL_MODULES = Definitions.INTERNAL_MODULES.stream()
                 .map(moduleName -> {
                     final List<String> packageTokens = Splitter

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/whitespace/emptylineseparator/InputEmptyLineSeparatorEnum.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/whitespace/emptylineseparator/InputEmptyLineSeparatorEnum.java
@@ -1,0 +1,117 @@
+/*
+EmptyLineSeparator
+allowNoEmptyLineBetweenFields = (default)false
+allowMultipleEmptyLines = false
+allowMultipleEmptyLinesInsideClassMembers = (default)true
+tokens = PACKAGE_DEF, IMPORT, STATIC_IMPORT, CLASS_DEF, INTERFACE_DEF, ENUM_DEF, \
+         STATIC_INIT, INSTANCE_INIT, METHOD_DEF, CTOR_DEF, VARIABLE_DEF, RECORD_DEF, \
+         COMPACT_CTOR_DEF, ENUM_CONSTANT_DEF,
+
+
+*/
+
+package com.puppycrawl.tools.checkstyle.checks.whitespace.emptylineseparator;
+
+public class InputEmptyLineSeparatorEnum {
+
+
+    private enum State {NEW, SUCCESS, FAILURE}
+    // violation above ''ENUM_DEF' has more than 1 empty lines before.'
+
+
+
+    private enum State1 {
+        // violation above ''ENUM_DEF' has more than 1 empty lines before.'
+
+
+        NEW, SUCCESS, FAILURE,
+        // 2 violations above:
+        // ''ENUM_CONSTANT_DEF' has more than 1 empty lines before.'
+        // ''ENUM_CONSTANT_DEF' has more than 1 empty lines after.'
+
+
+
+    }
+
+    private enum State2 {
+
+
+        NEW, SUCCESS, // violation ''ENUM_CONSTANT_DEF' has more than 1 empty lines before.'
+
+
+        FAILURE, // violation ''ENUM_CONSTANT_DEF' has more than 1 empty lines after.'
+        // violation above ''ENUM_CONSTANT_DEF' has more than 1 empty lines before.'
+
+
+
+    }
+
+    private enum State3 {
+
+
+        /**
+         * For testing.
+         */
+        NEW, // violation ''ENUM_CONSTANT_DEF' has more than 1 empty lines before.'
+
+        /**
+         * For testing.
+         */
+        SUCCESS,
+
+        FAILURE
+        // single line comment
+
+        // testing comment 1
+
+        // testing comment 2
+
+        // testing comment 3
+
+    }
+
+    private enum State4 {
+        NEW,
+        SUCCESS,
+        FAILURE, // violation ''ENUM_CONSTANT_DEF' has more than 1 empty lines after.'
+        // testing comment
+        // testing comment
+
+        // testing comment
+
+
+        // testing comment
+        // testing comment
+    }
+
+    private enum State5
+    {
+
+
+        NEW, // violation ''ENUM_CONSTANT_DEF' has more than 1 empty lines before.'
+
+
+            SUCCESS, // violation ''ENUM_CONSTANT_DEF' has more than 1 empty lines before.'
+
+
+                    FAILURE // violation ''ENUM_CONSTANT_DEF' has more than 1 empty lines before.'
+    }
+
+    private enum State6
+    {
+        NEW }
+
+    private enum State7
+    { NEW }
+
+    private enum State8 {
+        NEW,
+
+    }
+
+    private enum State9 {
+        NEW, // violation ''ENUM_CONSTANT_DEF' has more than 1 empty lines after.'
+
+
+    }
+}

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/whitespace/emptylineseparator/InputEmptyLineSeparatorEnumConstant.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/whitespace/emptylineseparator/InputEmptyLineSeparatorEnumConstant.java
@@ -1,0 +1,70 @@
+/*
+EmptyLineSeparator
+allowNoEmptyLineBetweenFields = (default)false
+allowMultipleEmptyLines = false
+allowMultipleEmptyLinesInsideClassMembers = (default)true
+tokens = PACKAGE_DEF, IMPORT, STATIC_IMPORT, CLASS_DEF, INTERFACE_DEF, ENUM_DEF, \
+         STATIC_INIT, INSTANCE_INIT, METHOD_DEF, CTOR_DEF, VARIABLE_DEF, RECORD_DEF, \
+         COMPACT_CTOR_DEF, ENUM_CONSTANT_DEF,
+
+
+*/
+
+package com.puppycrawl.tools.checkstyle.checks.whitespace.emptylineseparator;
+
+public class InputEmptyLineSeparatorEnumConstant {
+
+    public enum Check {
+
+
+        FIRST, // violation ''ENUM_CONSTANT_DEF' has more than 1 empty lines before.'
+        SECOND,
+
+
+        THIRD, // violation ''ENUM_CONSTANT_DEF' has more than 1 empty lines before.'
+
+
+
+        FOURTH, // violation ''ENUM_CONSTANT_DEF' has more than 1 empty lines before.'
+
+
+
+        SPECIAL(100) { // violation ''ENUM_CONSTANT_DEF' has more than 1 empty lines before.'
+            @Override
+            public String describe() {
+                return "Special enum constant";
+            }
+        },
+
+
+
+        NORMAL(200) { // violation ''ENUM_CONSTANT_DEF' has more than 1 empty lines before.'
+            @Override
+            public String describe() {
+                return "Normal enum constant";
+            }
+        };
+
+
+
+        private final int code; // violation ''VARIABLE_DEF' has more than 1 empty lines before.'
+
+        Check() {
+            this.code = 0;
+        }
+
+        Check(int code) {
+            this.code = code;
+        }
+
+        public String describe() {
+            return "Default enum constant";
+        }
+    }
+
+    private enum State9
+
+
+    { NEW // violation ''ENUM_CONSTANT_DEF' has more than 1 empty lines before.'
+    }
+}

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/whitespace/emptylineseparator/InputEmptyLineSeparatorEnumConstantDefault.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/whitespace/emptylineseparator/InputEmptyLineSeparatorEnumConstantDefault.java
@@ -1,0 +1,105 @@
+/*
+EmptyLineSeparator
+allowNoEmptyLineBetweenFields = (default)false
+allowMultipleEmptyLines = (default)true
+allowMultipleEmptyLinesInsideClassMembers = (default)true
+tokens = (default)PACKAGE_DEF, IMPORT, STATIC_IMPORT, CLASS_DEF, INTERFACE_DEF, ENUM_DEF, \
+         STATIC_INIT, INSTANCE_INIT, METHOD_DEF, CTOR_DEF, VARIABLE_DEF, RECORD_DEF, \
+         COMPACT_CTOR_DEF, ENUM_CONSTANT_DEF,
+
+
+*/
+
+package com.puppycrawl.tools.checkstyle.checks.whitespace.emptylineseparator;
+
+public class InputEmptyLineSeparatorEnumConstantDefault {
+
+    public enum Check {
+
+
+        FIRST,
+        SECOND,
+
+
+        THIRD,
+
+
+
+        FOURTH,
+
+
+
+        SPECIAL(100) {
+            @Override
+            public String describe() {
+                return "Special enum constant";
+            }
+        },
+
+
+        NORMAL(200) {
+            @Override
+            public String describe() {
+                return "Normal enum constant";
+            }
+        };
+
+
+
+        private final int code;
+
+        Check() {
+            this.code = 0;
+        }
+
+        Check(int code) {
+            this.code = code;
+        }
+
+        public String describe() {
+            return "Default enum constant";
+        }
+    }
+
+    private enum State {NEW, SUCCESS, FAILURE}
+
+
+
+    private enum State1 {
+
+
+        NEW, SUCCESS, FAILURE,
+
+
+
+    }
+
+    private enum State2 {
+
+
+        NEW, SUCCESS,
+
+
+        FAILURE,
+
+
+
+    }
+
+    private enum State3 {
+
+        /**
+         * For testing.
+         */
+        NEW,
+
+        /**
+         * For testing.
+         */
+        SUCCESS,
+
+        FAILURE
+        // single line comment
+
+    }
+}


### PR DESCRIPTION
Issue #18437 

- Added `ENUM_CONSTANT_DEF` token in `EmptyLineSeparatorCheck.java`.
- Added two test cases to check empty before and after `ENUM_CONSTANT_DEF` token, one with default properties `testEmptyLineWithEnumConstantWithDefaultProperties()` and other with `allowMultipleEmptyLines = false` i.e `testEmptyLineWithEnumConstant()`.
- For both test cases created input files: `InputEmptyLineSeparatorEnumConstantDefault.java` and `InputEmptyLineSeparatorEnumConstant.java`