### PR TITLE
Issue #10969: Fix false positives for pattern variables in RequireThisCheck

### DIFF
--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/coding/RequireThisCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/coding/RequireThisCheckTest.java
@@ -347,6 +347,16 @@ public class RequireThisCheckTest extends AbstractModuleTestSupport {
     }
 
     @Test
+    public void testPatternVariables() throws Exception {
+
+        final String[] expected = {
+            "28:9: " + getCheckMessage(MSG_VARIABLE, "s", ""),
+        };
+        verifyWithInlineConfigParser(
+                getPath("InputRequireThisPatternVariables.java"), expected);
+    }
+
+    @Test
     public void testTryWithResources() throws Exception {
         final String[] expected = CommonUtil.EMPTY_STRING_ARRAY;
         verifyWithInlineConfigParser(

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/requirethis/InputRequireThisPatternVariables.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/requirethis/InputRequireThisPatternVariables.java
@@ -1,0 +1,30 @@
+/*
+RequireThis
+checkFields = (default)true
+checkMethods = false
+validateOnlyOverlapping = false
+*/
+
+package com.puppycrawl.tools.checkstyle.checks.coding.requirethis;
+
+class InputRequireThisPatternVariables {
+
+    private String s = "field";
+
+    void usePatternVariable(Object o) {
+        
+        if (o instanceof String s) {
+            s.length(); 
+        }
+    }
+
+    void usePatternVariableInCondition(Object o) {
+        if (o instanceof String s && s.length() > 0) { 
+            s.isEmpty(); 
+        }
+    }
+
+    void fieldStillRequiresThis() {
+        s = "other"; 
+    }
+}


### PR DESCRIPTION
Hi

I've updated the RequireThisCheck logic to handle pattern variables correctly. Previously, the check was failing to recognize pattern variables as local declarations, causing false positive violations for the this. qualifier even when a pattern variable was shadowing a field.

I have added PATTERN_VARIABLE_DEF to the identified local variables list. I also added a regression test in RequireThisCheckTest.java to confirm the fix.

Issue: #10969