### PR TITLE
Issue #17882: Add COLON token Javadoc with AST example

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/api/JavadocCommentsTokenTypes.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/api/JavadocCommentsTokenTypes.java
@@ -1753,7 +1753,24 @@ public final class JavadocCommentsTokenTypes {
     public static final int ATTRIBUTE_VALUE = JavadocCommentsLexer.ATTRIBUTE_VALUE;
 
     /**
-     * Colon symbol {@code : }.
+     * Colon symbol {@code :}.
+     *
+     * <p><b>Example:</b></p>
+     * <pre>{@code * {@snippet : body}}</pre>
+     *
+     * <b>Tree:</b>
+     * <pre>{@code
+     * JAVADOC_INLINE_TAG -> JAVADOC_INLINE_TAG
+     * `--SNIPPET_INLINE_TAG -> SNIPPET_INLINE_TAG
+     * |--JAVADOC_INLINE_TAG_START -> {@
+     * |--COLON -> :
+     * |--SNIPPET_BODY -> SNIPPET_BODY
+     * |   `--TEXT ->  body
+     * `--JAVADOC_INLINE_TAG_END -> }
+     * }</pre>
+     *
+     * @see #JAVADOC_INLINE_TAG
+     * @see #SNIPPET_INLINE_TAG
      */
     public static final int COLON = JavadocCommentsLexer.COLON;
 


### PR DESCRIPTION
Issue: #17882

**Description:**
Updated the COLON token in JavadocCommentsTokenTypes.java to include the new AST print format example.

**Example Input Code (src/Test.java):**

```
/**
 * {@snippet : body}
 */
class Test {}

```
**Command:**
`java -jar target/checkstyle-13.2.0-SNAPSHOT-all.jar -j src/Test.java`

**AST Output:**

```
JAVADOC_CONTENT -> JAVADOC_CONTENT [0:1]
|--TEXT -> /** [0:1]
|--NEWLINE -> \n [0:4]
|--LEADING_ASTERISK ->  * [1:1]
|--TEXT ->   [1:3]
|--JAVADOC_INLINE_TAG -> JAVADOC_INLINE_TAG [1:4]
|   `--SNIPPET_INLINE_TAG -> SNIPPET_INLINE_TAG [1:4]
|       |--JAVADOC_INLINE_TAG_START -> {@ [1:4]
|       |--COLON -> : [1:14]
|       |--SNIPPET_BODY -> SNIPPET_BODY [1:15]
|       |   `--TEXT ->  body [1:15]
|       `--JAVADOC_INLINE_TAG_END -> } [1:20]
|--NEWLINE -> \n [1:21]
|--LEADING_ASTERISK ->  * [2:1]
|--TEXT -> / [2:3]
|--NEWLINE -> \n [2:4]
`--TEXT -> class Test {} [3:1]
```