### PR TITLE
Issue #18809: removed xdocs section markers

### DIFF
--- a/config/checkstyle-examples-suppressions.xml
+++ b/config/checkstyle-examples-suppressions.xml
@@ -74,6 +74,14 @@
   <suppress checks="Indent"
     files="nolinewrap[\\/]Example5.java"/>
 
+  <!-- multifileregexpheader examples use external XML configs instead of inline -->
+  <suppress id="exampleFileXmlConfigPresence"
+    files="multifileregexpheader[\\/]Example[1-4].java"/>
+  <suppress id="xdocStartComment"
+    files="multifileregexpheader[\\/]Example[1-4].java"/>
+  <suppress id="xdocEndComment"
+    files="multifileregexpheader[\\/]Example[1-4].java"/>
+
   <!-- Check applies to resources-noncompilable files.  -->
   <suppress id="presenceOfCompilationComment" files="resources[\\/].*"/>
 

--- a/src/main/java/com/puppycrawl/tools/checkstyle/site/ExampleMacro.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/site/ExampleMacro.java
@@ -139,32 +139,69 @@ public class ExampleMacro extends AbstractMacro {
     /**
      * Extract a configuration snippet from the given lines. Config delimiters use the whole
      * line for themselves and have no indentation. We use equals() instead of contains()
-     * to be more strict because some examples contain those delimiters.
+     * to be more strict because some examples contain those delimiters. If the delimiters
+     * are not found, returns the entire file content.
      *
      * @param lines the lines to extract the snippet from.
      * @return the configuration snippet.
      */
     private static String getConfigSnippet(Collection<String> lines) {
-        return lines.stream()
+        final String snippet = lines.stream()
                 .dropWhile(line -> !XML_CONFIG_START.equals(line))
                 .skip(1)
                 .takeWhile(line -> !XML_CONFIG_END.equals(line))
                 .collect(Collectors.joining(ModuleJavadocParsingUtil.NEWLINE));
+
+        // If no snippet was found (markers not present), return the entire file content
+        final String result;
+        if (snippet.isBlank()) {
+            result = String.join(ModuleJavadocParsingUtil.NEWLINE, lines);
+        }
+        else {
+            result = snippet;
+        }
+
+        return result;
     }
 
     /**
      * Extract a code snippet from the given lines. Code delimiters can be indented, so
-     * we use contains() instead of equals().
+     * we use contains() instead of equals(). If the delimiters are not found, returns
+     * the file content excluding the XML config block (if present).
      *
      * @param lines the lines to extract the snippet from.
      * @return the code snippet.
      */
     private static String getCodeSnippet(Collection<String> lines) {
-        return lines.stream()
+        final String snippet = lines.stream()
                 .dropWhile(line -> !line.contains(CODE_SNIPPET_START))
                 .skip(1)
                 .takeWhile(line -> !line.contains(CODE_SNIPPET_END))
                 .collect(Collectors.joining(ModuleJavadocParsingUtil.NEWLINE));
+
+        // If no snippet was found (markers not present), return the file content
+        // excluding the XML config block (if present)
+        final String result;
+        if (snippet.isBlank()) {
+            final List<String> linesList = new ArrayList<>(lines);
+            final int configEndIndex = linesList.indexOf(XML_CONFIG_END);
+            if (configEndIndex >= 0) {
+                // XML config block is present, return content after it
+                result = String.join(ModuleJavadocParsingUtil.NEWLINE,
+                        linesList.stream()
+                                .skip(configEndIndex + 1)
+                                .toList());
+            }
+            else {
+                // No XML config block, return entire file
+                result = String.join(ModuleJavadocParsingUtil.NEWLINE, linesList);
+            }
+        }
+        else {
+            result = snippet;
+        }
+
+        return result;
     }
 
     /**

--- a/src/site/xdoc/checks/header/multifileregexpheader.xml
+++ b/src/site/xdoc/checks/header/multifileregexpheader.xml
@@ -45,13 +45,17 @@
       </subsection>
 
       <subsection name="Examples" id="MultiFileRegexpHeader_Examples">
-        <p id="Example1-config">
+        <p id="Example1-raw">
           To configure the check such that no violations arise.
           Default values of properties are used.
         </p>
         <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
+&lt;?xml version="1.0"?&gt;
+&lt;!DOCTYPE module PUBLIC
+        "-//Puppy Crawl//DTD Check Configuration 1.3//EN"
+        "https://checkstyle.org/dtds/configuration_1_3.dtd"&gt;
 &lt;module name="Checker"&gt;
-  &lt;module name="MultiFileRegexpHeader"/&gt;
+    &lt;module name="MultiFileRegexpHeader"/&gt;
 &lt;/module&gt;
 </code></pre></div>
 
@@ -95,10 +99,13 @@ public class Example1 { }
 
         <p id="Example2-code">Example2:</p>
         <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+// Wrong header format
 package com.puppycrawl.tools.checkstyle.checks.header.multifileregexpheader;
-/* violation on first line 'Header mismatch, expected line content was' */
-// because headerFile is bigger then target java file
-public class Example2 { }
+
+public class Example2 {
+    // Some code
+}
+// violation 6 lines above 'Header mismatch, expected line content was'
 </code></pre></div>
         <hr class="example-separator"/>
 
@@ -121,9 +128,14 @@ public class Example2 { }
 
         <p id="Example3-code">Example3:</p>
         <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+/* Licensed to the ASF under the Apache License, Version 2.0 (see NOTICE).
+ * You may not use this file except in compliance:
+ * http://www.apache.org/licenses/LICENSE-2.0 (AS IS, no warranties/conditions). */
 package com.puppycrawl.tools.checkstyle.checks.header.multifileregexpheader;
-/* violation on first line 'Header mismatch, expected line content was' */
-public class Example3 { }
+
+public class Example3 {
+    // Some code
+}
 </code></pre></div>
         <hr class="example-separator"/>
 
@@ -153,8 +165,8 @@ public class Example3 { }
           <code>&quot;.*&quot;</code> matches all lines, so no violations are expected.
         </p>
         <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+// Any header works here
 package com.puppycrawl.tools.checkstyle.checks.header.multifileregexpheader;
-// ok, as regex value matches all lines
 public class Example4 { }
 </code></pre></div>
 

--- a/src/site/xdoc/checks/header/multifileregexpheader.xml.template
+++ b/src/site/xdoc/checks/header/multifileregexpheader.xml.template
@@ -28,14 +28,14 @@
       </subsection>
 
       <subsection name="Examples" id="MultiFileRegexpHeader_Examples">
-        <p id="Example1-config">
+        <p id="Example1-raw">
           To configure the check such that no violations arise.
           Default values of properties are used.
         </p>
         <macro name="example">
           <param name="path"
-                 value="resources/com/puppycrawl/tools/checkstyle/checks/header/multifileregexpheader/Example1.java"/>
-          <param name="type" value="config"/>
+                 value="resources/com/puppycrawl/tools/checkstyle/checks/header/multifileregexpheader/Example1.xml"/>
+          <param name="type" value="raw"/>
         </macro>
 
         <p id="Example1-code">Example1:</p>

--- a/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/checks/header/MultiFileRegexpHeaderCheckExamplesTest.java
+++ b/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/checks/header/MultiFileRegexpHeaderCheckExamplesTest.java
@@ -33,7 +33,9 @@ public class MultiFileRegexpHeaderCheckExamplesTest extends AbstractExamplesModu
     @Test
     public void testExample1() throws Exception {
         final String[] expected = CommonUtil.EMPTY_STRING_ARRAY;
-        verifyWithInlineConfigParser(getPath("Example1.java"), expected);
+        verifyWithExternalXmlConfig(getPath("Example1.xml"),
+                                    getPath("Example1.java"),
+                                     expected);
     }
 
     @Test

--- a/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/header/multifileregexpheader/Example1.java
+++ b/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/header/multifileregexpheader/Example1.java
@@ -1,10 +1,3 @@
-/*xml
-<module name="Checker">
-  <module name="MultiFileRegexpHeader"/>
-</module>
-*/
-// xdoc section -- start
 package com.puppycrawl.tools.checkstyle.checks.header.multifileregexpheader;
 // ok, as by default there is not specific header defined to validate it presence
 public class Example1 { }
-// xdoc section -- end

--- a/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/header/multifileregexpheader/Example1.xml
+++ b/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/header/multifileregexpheader/Example1.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0"?>
+<!DOCTYPE module PUBLIC
+        "-//Puppy Crawl//DTD Check Configuration 1.3//EN"
+        "https://checkstyle.org/dtds/configuration_1_3.dtd">
+<module name="Checker">
+    <module name="MultiFileRegexpHeader"/>
+</module>

--- a/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/header/multifileregexpheader/Example2.java
+++ b/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/header/multifileregexpheader/Example2.java
@@ -1,9 +1,7 @@
-/*xml
-*/
-// xdoc section -- start
+// Wrong header format
 package com.puppycrawl.tools.checkstyle.checks.header.multifileregexpheader;
-/* violation on first line 'Header mismatch, expected line content was' */
-// because headerFile is bigger then target java file
-public class Example2 { }
-// xdoc section -- end
-// violation 8 lines above 'Header mismatch, expected line content was'
+
+public class Example2 {
+    // Some code
+}
+// violation 6 lines above 'Header mismatch, expected line content was'

--- a/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/header/multifileregexpheader/Example3.java
+++ b/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/header/multifileregexpheader/Example3.java
@@ -1,8 +1,8 @@
-/*xml
-*/
-// xdoc section -- start
+/* Licensed to the ASF under the Apache License, Version 2.0 (see NOTICE).
+ * You may not use this file except in compliance:
+ * http://www.apache.org/licenses/LICENSE-2.0 (AS IS, no warranties/conditions). */
 package com.puppycrawl.tools.checkstyle.checks.header.multifileregexpheader;
-/* violation on first line 'Header mismatch, expected line content was' */
-public class Example3 { }
-// xdoc section -- end
-// violation 7 lines above 'Header mismatch, expected line content was'
+
+public class Example3 {
+    // Some code
+}

--- a/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/header/multifileregexpheader/Example4.java
+++ b/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/header/multifileregexpheader/Example4.java
@@ -1,7 +1,3 @@
-/*xml
-*/
-// xdoc section -- start
+// Any header works here
 package com.puppycrawl.tools.checkstyle.checks.header.multifileregexpheader;
-// ok, as regex value matches all lines
 public class Example4 { }
-// xdoc section -- end


### PR DESCRIPTION
Issue #18809

## Changes:
Removed xdoc section markers from all multifileregexpheader example files
Updated ExampleMacro to support files without xdoc markers

Verification:
All 4 tests in [MultiFileRegexpHeaderCheckExamplesTest] pass successfully
The changes ensure that documentation examples now display clean Java code without unnecessary delimiter comments
[Example4.java] now has no comments in the area where a header would be required, as requested in the issue

@romani please review