### PR TITLE
Issue #17882: Add FIELD_TYPE token Javadoc with AST example

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/api/JavadocCommentsTokenTypes.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/api/JavadocCommentsTokenTypes.java
@@ -1742,7 +1742,38 @@ public final class JavadocCommentsTokenTypes {
     public static final int SNIPPET_BODY = JavadocCommentsLexer.SNIPPET_BODY;
 
     /**
-     * Field type reference.
+     * Field type reference in a Javadoc.
+     *
+     * <p>Example:</p>
+     * <pre>
+     * &#47;**
+     * * &#64;serialField counter int The counter.
+     * *&#47;
+     * </pre>
+     *
+     * <b>Tree:</b>
+     * <pre>
+     * JAVADOC_CONTENT -> JAVADOC_CONTENT
+     * |--TEXT -> /&#42;*
+     * |--NEWLINE -> \n
+     * |--LEADING_ASTERISK ->  *
+     * |--TEXT ->
+     * `--JAVADOC_BLOCK_TAG -> JAVADOC_BLOCK_TAG
+     * `--SERIAL_FIELD_BLOCK_TAG -> SERIAL_FIELD_BLOCK_TAG
+     * |--AT_SIGN -> @
+     * |--TAG_NAME -> serialField
+     * |--TEXT ->
+     * |--IDENTIFIER -> counter
+     * |--TEXT ->
+     * |--FIELD_TYPE -> int
+     * `--DESCRIPTION -> DESCRIPTION
+     * |--TEXT ->  The counter.
+     * |--NEWLINE -> \n
+     * |--LEADING_ASTERISK ->  *
+     * `--TEXT -> /
+     * </pre>
+     *
+     * @see #FIELD_TYPE
      */
     public static final int FIELD_TYPE = JavadocCommentsLexer.FIELD_TYPE;
 


### PR DESCRIPTION
Issue #17882 

**Description**

This PR updates the FIELD_TYPE token in JavadocCommentsTokenTypes.java to include:
A proper Javadoc description.
An example showing how to use the token with @serialField.
The corresponding AST tree produced by the latest Checkstyle snapshot.

**Example

```
/**
 * @serialField counter int The counter.
 */
private int counter;
```

**Command to generate AST:**

`java -jar target/checkstyle-13.1.1-SNAPSHOT-all.jar -j src/Test.java | sed "s/\[[0-9]\+:[0-9]\+\]//g"`

**AST Output:**

```
JAVADOC_CONTENT -> JAVADOC_CONTENT
|--TEXT -> /**
|--NEWLINE -> \n
|--LEADING_ASTERISK ->  *
|--TEXT ->   
`--JAVADOC_BLOCK_TAG -> JAVADOC_BLOCK_TAG
    `--SERIAL_FIELD_BLOCK_TAG -> SERIAL_FIELD_BLOCK_TAG
        |--AT_SIGN -> @
        |--TAG_NAME -> serialField
        |--TEXT ->  
        |--IDENTIFIER -> counter
        |--TEXT ->  
        |--FIELD_TYPE -> int
        `--DESCRIPTION -> DESCRIPTION
            |--TEXT ->  The counter.
            |--NEWLINE -> \n
            |--LEADING_ASTERISK ->  *
            `--TEXT -> /
```