### PR TITLE
Pull #18820: Consolidate `CI` config #18819

### DIFF
--- a/.ci/validation.sh
+++ b/.ci/validation.sh
@@ -1246,6 +1246,18 @@ git-no-merge-commits)
   fi
   ;;
 
+git-check-squash-commit)
+  # Check if there are multiple commits that should be squashed into one
+  COMMIT_COUNT=$(git rev-list --count master.."$PR_HEAD_SHA")
+  if [ "$COMMIT_COUNT" -gt 1 ]; then
+    echo "Multiple commits found in PR. Please squash them into a single commit."
+    echo "Commit count: $COMMIT_COUNT"
+    echo "To learn how to clean up your commit history, visit:"
+    echo "https://www.reddit.com/r/git/comments/14msx5x/git_reset_soft_instead_of_git_rebase_i_headn/"
+    exit 1
+  fi
+  ;;
+
 git-check-pull-number)
   PR_NUMBER=${CIRCLE_PULL_REQUEST##*/}
   echo "PR_NUMBER=${PR_NUMBER}"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,21 +1,19 @@
+name: CI
 version: 2.1
-
 jobs:
-
   run-inspections:
     docker:
       - image: amitkumardeoghoria/idea-image:jdk21-idea2022.3.3-v1
-
     steps:
       - checkout
       - run:
           name: Print versions
           command: |
-            echo "Maven version:"
+            echo Maven version:
             ./mvnw --version
-            echo "Java version:"
+            echo Java version:
             java --version
-            echo "IDEA version:"
+            echo IDEA version:
             echo $IDEA_VERSION
       - run:
           name: Run inspections
@@ -27,16 +25,15 @@ jobs:
           working_directory: ~/project
       - store_artifacts:
           path: /home/circleci/project/target/inspection-results
-
   validate-with-maven-script:
-    description: "Runs a maven script using the job name as the argument."
+    description: Runs a maven script using the job name as the argument.
     parameters: &script_parameters
       image-name:
         type: string
-        default: "cimg/openjdk:21.0.6"
-        description: "docker image to use"
+        default: cimg/openjdk:21.0.6
+        description: docker image to use
       command:
-        description: "command to run"
+        description: command to run
         type: string
       no_output_timeout:
         type: string
@@ -62,9 +59,8 @@ jobs:
           paths:
             - .m2
             - .mvn/wrapper
-
   validate-with-script:
-    description: "Runs a non-maven script using the job name as the argument."
+    description: Runs a non-maven script using the job name as the argument.
     parameters: *script_parameters
     docker:
       - image: << parameters.image-name >>
@@ -79,11 +75,9 @@ jobs:
             export PR_HEAD_SHA=$CIRCLE_SHA1
             export PR_NUMBER=$CIRCLE_PR_NUMBER
             << parameters.command >>
-
   sonarqube:
     docker:
       - image: amitkumardeoghoria/jdk-21-groovy-git-mvn-ant-jq:v1
-
     steps:
       - checkout
       - run:
@@ -93,11 +87,9 @@ jobs:
             export PR_BRANCH_NAME=$CIRCLE_BRANCH
             export SONAR_API_TOKEN=$SONAR_TOKEN
             ./.ci/validation.sh sonarqube
-
   yamllint:
     docker:
       - image: cimg/base:2022.11
-
     steps:
       - checkout
       - run:
@@ -108,225 +100,206 @@ jobs:
       - run:
           name: Run yamllint
           command: yamllint -f parsable -c config/yamllint.yaml .
-
 workflows:
-  #  sonarqube:
-  #    jobs:
-  #      - sonarqube:
-  #          context:
-  #            - sonarqube
-
-  test:
-    jobs:
-      # no-exception-test script
-      - validate-with-maven-script:
-          name: "no-exception-lucene-and-others-javadoc"
-          image-name: &cs_img "amitkumardeoghoria/jdk-21-groovy-git-mvn-ant-jq:v1"
-          command: "./.ci/no-exception-test.sh no-exception-lucene-and-others-javadoc"
-      - validate-with-maven-script:
-          name: "no-exception-cassandra-storm-tapestry-javadoc"
-          image-name: *cs_img
-          command: "./.ci/no-exception-test.sh no-exception-cassandra-storm-tapestry-javadoc"
-      - validate-with-maven-script:
-          name: "no-exception-hadoop-apache-groovy-scouter-javadoc"
-          image-name: *cs_img
-          command: "./.ci/no-exception-test.sh no-exception-hadoop-apache-groovy-scouter-javadoc"
-      - validate-with-maven-script:
-          name: "no-exception-only-javadoc"
-          image-name: *cs_img
-          command: "./.ci/no-exception-test.sh no-exception-only-javadoc"
-
-      # validation script
-      - validate-with-maven-script:
-          name: "no-error-xwiki"
-          image-name: "cimg/openjdk:21.0.6"
-          command: "./.ci/validation.sh no-error-xwiki"
-      - validate-with-maven-script:
-          name: "no-error-pmd"
-          image-name: *cs_img
-          command: "./.ci/validation.sh no-error-pmd"
-      - validate-with-maven-script:
-          name: "no-exception-struts"
-          image-name: *cs_img
-          command: "./.ci/validation.sh no-exception-struts"
-      - validate-with-maven-script:
-          name: "no-exception-checkstyle-sevntu"
-          image-name: *cs_img
-          command: "./.ci/validation.sh no-exception-checkstyle-sevntu"
-      - validate-with-maven-script:
-          name: "no-exception-checkstyle-sevntu-javadoc"
-          image-name: *cs_img
-          command: "./.ci/validation.sh no-exception-checkstyle-sevntu-javadoc"
-      - validate-with-maven-script:
-          name: "no-exception-guava"
-          image-name: *cs_img
-          command: "./.ci/validation.sh no-exception-guava"
-      - validate-with-maven-script:
-          name: "no-exception-hibernate-orm"
-          image-name: *cs_img
-          command: "./.ci/validation.sh no-exception-hibernate-orm"
-      - validate-with-maven-script:
-          name: "no-exception-spotbugs"
-          image-name: *cs_img
-          command: "./.ci/validation.sh no-exception-spotbugs"
-      - validate-with-maven-script:
-          name: "no-exception-spoon"
-          image-name: *cs_img
-          command: "./.ci/validation.sh no-exception-spoon"
-      - validate-with-maven-script:
-          name: "no-exception-spring-framework"
-          image-name: *cs_img
-          command: "./.ci/validation.sh no-exception-spring-framework"
-      - validate-with-maven-script:
-          name: "no-exception-hbase"
-          image-name: *cs_img
-          command: "./.ci/validation.sh no-exception-hbase"
-      - validate-with-maven-script:
-          name: "no-exception-Pmd-elasticsearch-lombok-ast"
-          image-name: *cs_img
-          command: "./.ci/validation.sh no-exception-Pmd-elasticsearch-lombok-ast"
-      - validate-with-maven-script:
-          name: "no-exception-alot-of-projects"
-          image-name: *cs_img
-          command: "./.ci/validation.sh no-exception-alot-of-projects"
-      - validate-with-maven-script:
-          name: "no-warning-imports-guava"
-          image-name: *cs_img
-          command: "./.ci/validation.sh no-warning-imports-guava"
-      - validate-with-maven-script:
-          name: "no-warning-imports-java-design-patterns"
-          image-name: *cs_img
-          command: "./.ci/validation.sh no-warning-imports-java-design-patterns"
-      - validate-with-maven-script:
-          name: "checkstyle-and-sevntu"
-          image-name: *cs_img
-          command: "./.ci/validation.sh checkstyle-and-sevntu"
-      # https://github.com/spotbugs/spotbugs-maven-plugin/issues/806 explains
-      # why we need execution of spotbugs without any other maven plugins which can change binaries
-      - validate-with-maven-script:
-          name: "spotbugs-and-pmd"
-          image-name: *cs_img
-          command: "./.ci/validation.sh spotbugs-and-pmd"
-      - validate-with-maven-script:
-          name: "site"
-          image-name: *cs_img
-          command: "./.ci/validation.sh site"
-      - validate-with-maven-script:
-          name: "release-dry-run"
-          image-name: *cs_img
-          command: "./.ci/validation.sh release-dry-run"
-      - validate-with-maven-script:
-          name: "assembly-run-all-jar"
-          image-name: *cs_img
-          command: "./.ci/validation.sh assembly-run-all-jar"
-      - validate-with-maven-script:
-          name: "no-error-test-sbe"
-          image-name: "cimg/openjdk:21.0.6"
-          command: "./.ci/validation.sh no-error-test-sbe"
-      - validate-with-maven-script:
-          name: "no-error-spotbugs"
-          image-name: *cs_img
-          command: "./.ci/validation.sh no-error-spotbugs"
-      - validate-with-maven-script:
-          name: "no-error-pgjdbc"
-          image-name: "cimg/openjdk:21.0"
-          command: "./.ci/validation.sh no-error-pgjdbc"
-      - validate-with-maven-script:
-          name: "linkcheck-plugin"
-          image-name: "cimg/openjdk:21.0.6"
-          command: "./.ci/run-link-check-plugin.sh --skip-external"
-      - validate-with-maven-script:
-          name: "no-exception-samples-gradle"
-          image-name: "cimg/openjdk:21.0.6"
-          command: "./.ci/no-exception-test.sh no-exception-samples-gradle"
-      - validate-with-maven-script:
-          name: "no-exception-samples-maven"
-          image-name: "cimg/openjdk:21.0.6"
-          command: "./.ci/no-exception-test.sh no-exception-samples-maven"
-
-      - validate-with-maven-script:
-          name: "no-exception-samples-ant"
-          image-name: *cs_img
-          command: "./.ci/no-exception-test.sh no-exception-samples-ant"
-      - validate-with-maven-script:
-          name: "no-error-hazelcast"
-          image-name: *cs_img
-          command: "./.ci/validation.sh no-error-hazelcast"
-
   idea:
     jobs:
       - run-inspections
-
-  git-validation:
+  git:
     jobs:
       - validate-with-script:
-          name: "git-no-merge-commits"
-          command: "./.ci/validation.sh git-no-merge-commits"
+          name: git-no-merge-commits
+          command: ./.ci/validation.sh git-no-merge-commits
       - validate-with-script:
-          name: "git-check-pull-number"
-          command: "./.ci/validation.sh git-check-pull-number"
-
-  cli-validation:
+          name: git-check-pull-number
+          command: ./.ci/validation.sh git-check-pull-number
+      - validate-with-script:
+          name: git-check-squash-commit
+          command: ./.ci/validation.sh git-check-squash-commit
+  cli:
     jobs:
       - yamllint
       - validate-with-script:
-          name: "checkchmod"
-          command: "./.ci/checkchmod.sh"
+          name: checkchmod
+          command: ./.ci/checkchmod.sh
       - validate-with-script:
-          name: "check-github-workflows-concurrency"
-          command: "./.ci/validation.sh check-github-workflows-concurrency"
+          name: check-github-workflows-concurrency
+          command: ./.ci/validation.sh check-github-workflows-concurrency
       - validate-with-script:
-          name: "check-wildcards-on-pitest-target-classes"
-          image-name: "cimg/base:2022.11"
-          command: "./.ci/validation.sh check-wildcards-on-pitest-target-classes"
-
-  javac-validation:
+          name: check-wildcards-on-pitest-target-classes
+          image-name: cimg/base:2022.11
+          command: ./.ci/validation.sh check-wildcards-on-pitest-target-classes
+  javac:
     jobs:
       - validate-with-script:
-          name: "check-since-version"
-          command: "./.ci/validation.sh check-since-version"
+          name: check-since-version
+          command: ./.ci/validation.sh check-since-version
       - validate-with-script:
-          name: "javac21"
-          image-name: "cimg/openjdk:21.0.6"
-          command: "./.ci/validation.sh javac21"
+          name: javac21
+          image-name: cimg/openjdk:21.0.6
+          command: ./.ci/validation.sh javac21
       - validate-with-script:
-          name: "java 21 test resources compile"
-          image-name: "cimg/openjdk:21.0.8"
-          command: "./.ci/validation.sh compile-test-resources"
+          name: java 21 test resources compile
+          image-name: cimg/openjdk:21.0.8
+          command: ./.ci/validation.sh compile-test-resources
       - validate-with-script:
-          name: "javac22"
-          image-name: "cimg/openjdk:22.0.2"
-          command: "./.ci/validation.sh javac22"
+          name: javac22
+          image-name: cimg/openjdk:22.0.2
+          command: ./.ci/validation.sh javac22
       - validate-with-script:
-          name: "javac25"
-          image-name: "cimg/openjdk:25.0"
-          command: "./.ci/validation.sh javac25"
-
-  site-validation:
-    jobs:
-      - validate-with-maven-script:
-          name: "jdk21-package-site"
-          image-name: *cs_img
-          command: "./.ci/validation.sh package-site"
-
+          name: javac25
+          image-name: cimg/openjdk:25.0
+          command: ./.ci/validation.sh javac25
   openrewrite:
     jobs:
       - validate-with-maven-script:
-          name: "openrewrite-checkstyle-auto-fix"
-          image-name: "cimg/openjdk:21.0"
-          command: "./.ci/validation.sh openrewrite-checkstyle-auto-fix"
+          name: openrewrite-checkstyle-auto-fix
+          image-name: &cs_img amitkumardeoghoria/jdk-21-groovy-git-mvn-ant-jq:v1
+          command: ./.ci/validation.sh openrewrite-checkstyle-auto-fix
       - validate-with-maven-script:
-          name: "openrewrite-refaster-rules"
-          image-name: "cimg/openjdk:21.0"
-          command: "./.ci/validation.sh openrewrite-refaster-rules"
+          name: openrewrite-refaster-rules
+          image-name: *cs_img
+          command: ./.ci/validation.sh openrewrite-refaster-rules
       - validate-with-maven-script:
-          name: "openrewrite-static-analysis"
-          image-name: "cimg/openjdk:21.0"
-          command: "./.ci/validation.sh openrewrite-static-analysis"
-
-  spotless:
+          name: openrewrite-static-analysis
+          image-name: *cs_img
+          command: ./.ci/validation.sh openrewrite-static-analysis
+  no-tests:
     jobs:
       - validate-with-maven-script:
+          name: no-exception-lucene-and-others-javadoc
+          image-name: *cs_img
+          command: ./.ci/no-exception-test.sh no-exception-lucene-and-others-javadoc
+      - validate-with-maven-script:
+          name: no-exception-cassandra-storm-tapestry-javadoc
+          image-name: *cs_img
+          command: ./.ci/no-exception-test.sh no-exception-cassandra-storm-tapestry-javadoc
+      - validate-with-maven-script:
+          name: no-exception-hadoop-apache-groovy-scouter-javadoc
+          image-name: *cs_img
+          command: ./.ci/no-exception-test.sh no-exception-hadoop-apache-groovy-scouter-javadoc
+      - validate-with-maven-script:
+          name: no-exception-only-javadoc
+          image-name: *cs_img
+          command: ./.ci/no-exception-test.sh no-exception-only-javadoc
+      - validate-with-maven-script:
+          name: no-error-xwiki
+          image-name: *cs_img
+          command: ./.ci/validation.sh no-error-xwiki
+      - validate-with-maven-script:
+          name: no-error-pmd
+          image-name: *cs_img
+          command: ./.ci/validation.sh no-error-pmd
+      - validate-with-maven-script:
+          name: no-exception-struts
+          image-name: *cs_img
+          command: ./.ci/validation.sh no-exception-struts
+      - validate-with-maven-script:
+          name: no-exception-checkstyle-sevntu
+          image-name: *cs_img
+          command: ./.ci/validation.sh no-exception-checkstyle-sevntu
+      - validate-with-maven-script:
+          name: no-exception-checkstyle-sevntu-javadoc
+          image-name: *cs_img
+          command: ./.ci/validation.sh no-exception-checkstyle-sevntu-javadoc
+      - validate-with-maven-script:
+          name: no-exception-guava
+          image-name: *cs_img
+          command: ./.ci/validation.sh no-exception-guava
+      - validate-with-maven-script:
+          name: no-exception-hibernate-orm
+          image-name: *cs_img
+          command: ./.ci/validation.sh no-exception-hibernate-orm
+      - validate-with-maven-script:
+          name: no-exception-spotbugs
+          image-name: *cs_img
+          command: ./.ci/validation.sh no-exception-spotbugs
+      - validate-with-maven-script:
+          name: no-exception-spoon
+          image-name: *cs_img
+          command: ./.ci/validation.sh no-exception-spoon
+      - validate-with-maven-script:
+          name: no-exception-spring-framework
+          image-name: *cs_img
+          command: ./.ci/validation.sh no-exception-spring-framework
+      - validate-with-maven-script:
+          name: no-exception-hbase
+          image-name: *cs_img
+          command: ./.ci/validation.sh no-exception-hbase
+      - validate-with-maven-script:
+          name: no-exception-Pmd-elasticsearch-lombok-ast
+          image-name: *cs_img
+          command: ./.ci/validation.sh no-exception-Pmd-elasticsearch-lombok-ast
+      - validate-with-maven-script:
+          name: no-exception-alot-of-projects
+          image-name: *cs_img
+          command: ./.ci/validation.sh no-exception-alot-of-projects
+      - validate-with-maven-script:
+          name: no-error-test-sbe
+          image-name: *cs_img
+          command: ./.ci/validation.sh no-error-test-sbe
+      - validate-with-maven-script:
+          name: no-error-spotbugs
+          image-name: *cs_img
+          command: ./.ci/validation.sh no-error-spotbugs
+      - validate-with-maven-script:
+          name: no-error-pgjdbc
+          image-name: *cs_img
+          command: ./.ci/validation.sh no-error-pgjdbc
+      - validate-with-maven-script:
+          name: no-error-hazelcast
+          image-name: *cs_img
+          command: ./.ci/validation.sh no-error-hazelcast
+      - validate-with-maven-script:
+          name: no-warning-imports-guava
+          image-name: *cs_img
+          command: ./.ci/validation.sh no-warning-imports-guava
+      - validate-with-maven-script:
+          name: no-warning-imports-java-design-patterns
+          image-name: *cs_img
+          command: ./.ci/validation.sh no-warning-imports-java-design-patterns
+      - validate-with-maven-script:
+          name: no-exception-samples-gradle
+          image-name: *cs_img
+          command: ./.ci/no-exception-test.sh no-exception-samples-gradle
+      - validate-with-maven-script:
+          name: no-exception-samples-maven
+          image-name: *cs_img
+          command: ./.ci/no-exception-test.sh no-exception-samples-maven
+      - validate-with-maven-script:
+          name: no-exception-samples-ant
+          image-name: *cs_img
+          command: ./.ci/no-exception-test.sh no-exception-samples-ant
+  quality-assurance:
+    jobs:
+      - validate-with-maven-script:
+          name: checkstyle-and-sevntu
+          image-name: *cs_img
+          command: ./.ci/validation.sh checkstyle-and-sevntu
+      - validate-with-maven-script:
+          name: spotbugs-and-pmd
+          image-name: *cs_img
+          command: ./.ci/validation.sh spotbugs-and-pmd
+      - validate-with-maven-script:
+          name: site
+          image-name: *cs_img
+          command: ./.ci/validation.sh site
+      - validate-with-maven-script:
+          name: release-dry-run
+          image-name: *cs_img
+          command: ./.ci/validation.sh release-dry-run
+      - validate-with-maven-script:
+          name: assembly-run-all-jar
+          image-name: *cs_img
+          command: ./.ci/validation.sh assembly-run-all-jar
+      - validate-with-maven-script:
+          name: linkcheck-plugin
+          image-name: *cs_img
+          command: ./.ci/run-link-check-plugin.sh --skip-external
+      - validate-with-maven-script:
           name: spotless
-          image-name: "cimg/openjdk:21.0"
-          command: "./.ci/validation.sh spotless"
+          image-name: *cs_img
+          command: ./.ci/validation.sh spotless
+      - validate-with-maven-script:
+          name: jdk21-package-site
+          image-name: *cs_img
+          command: ./.ci/validation.sh package-site

--- a/config/jsoref-spellchecker/whitelist.words
+++ b/config/jsoref-spellchecker/whitelist.words
@@ -550,6 +550,7 @@ hazelcast
 hbase
 hcoles
 Headerjava
+headn
 Hejl
 HEXCHARS
 hexliteralcase
@@ -880,6 +881,7 @@ moradan
 mozilla
 MRELEASE
 mstudman
+msx
 MTAGLIST
 multicharacter
 multifileregexpheader
@@ -1163,6 +1165,7 @@ rebasing
 recordcomponentname
 recordcomponentnumber
 recordtypeparametername
+reddit
 redundantimport
 redundantmodifier
 refactor


### PR DESCRIPTION
### Pull #18820: Consolidate `CI` config #18819


items:
we missing:
- using same `image-name: *cs_img`
- grouping of same items like `validate-with-maven-script`


ordered root trunk:

<img width="226" height="272" alt="image" src="https://github.com/user-attachments/assets/5034b79f-862a-4983-be33-e1f78724ffce" />

<img width="291" height="414" alt="image" src="https://github.com/user-attachments/assets/681b6214-f318-4b82-b967-9484854a0994" />

