### PR TITLE
Issue #17882: Update LPAREN and RPAREN to new AST Format

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/api/JavadocCommentsTokenTypes.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/api/JavadocCommentsTokenTypes.java
@@ -1176,12 +1176,64 @@ public final class JavadocCommentsTokenTypes {
     public static final int HASH = JavadocCommentsLexer.HASH;
 
     /**
-     * Left parenthesis {@code ( }.
+     * Left parenthesis {@code (} used in references within Javadoc.
+     *
+     * <p><b>Example:</b></p>
+     * <pre>{@code
+     * * &#123;@link String#length()}
+     * }</pre>
+     *
+     * <b>Tree:</b>
+     * <pre>{@code
+     * |--LEADING_ASTERISK ->  *
+     * |--TEXT ->
+     * |--JAVADOC_INLINE_TAG -> JAVADOC_INLINE_TAG
+     *     `--LINK_INLINE_TAG -> LINK_INLINE_TAG
+     *         |--JAVADOC_INLINE_TAG_START -> &#123;@
+     *         |--TAG_NAME -> link
+     *         |--TEXT ->
+     *         |--REFERENCE -> REFERENCE
+     *             |--IDENTIFIER -> String
+     *             |--HASH -> #
+     *             `--MEMBER_REFERENCE -> MEMBER_REFERENCE
+     *                 |--IDENTIFIER -> length
+     *                 |--LPAREN -> (
+     *                 `--RPAREN -> )
+     *         `--JAVADOC_INLINE_TAG_END -> }
+     * }</pre>
+     *
+     * @see #REFERENCE
      */
     public static final int LPAREN = JavadocCommentsLexer.LPAREN;
 
     /**
-     * Right parenthesis {@code ) }.
+     * Right parenthesis {@code (} used in references within Javadoc.
+     *
+     * <p><b>Example:</b></p>
+     * <pre>{@code
+     * * &#123;@link String#length()}
+     * }</pre>
+     *
+     * <b>Tree:</b>
+     * <pre>{@code
+     * |--LEADING_ASTERISK ->  *
+     * |--TEXT ->
+     * |--JAVADOC_INLINE_TAG -> JAVADOC_INLINE_TAG
+     *     `--LINK_INLINE_TAG -> LINK_INLINE_TAG
+     *         |--JAVADOC_INLINE_TAG_START -> &#123;@
+     *         |--TAG_NAME -> link
+     *         |--TEXT ->
+     *         |--REFERENCE -> REFERENCE
+     *             |--IDENTIFIER -> String
+     *             |--HASH -> #
+     *             `--MEMBER_REFERENCE -> MEMBER_REFERENCE
+     *                 |--IDENTIFIER -> length
+     *                 |--LPAREN -> (
+     *                 `--RPAREN -> )
+     *         `--JAVADOC_INLINE_TAG_END -> }
+     * }</pre>
+     *
+     * @see #REFERENCE
      */
     public static final int RPAREN = JavadocCommentsLexer.RPAREN;
 


### PR DESCRIPTION
Issue #17882

Command:
`java -jar checkstyle-13.1.0-all.jar -j src/Test.java | sed "s/\[[0-9]\+:[0-9]\+\]//g"`

**Test.java**
```
/**
 * {@link String#length()}
 */
class Test {}
```
Output:
```
bvidy@Vid MINGW64 /e/workspace/temp
$ java -jar checkstyle-13.1.0-all.jar -j src/Test.java | sed "s/\[[0-9]\+:[0-9]\+\]//g"
JAVADOC_CONTENT -> JAVADOC_CONTENT
|--TEXT -> /**
|--NEWLINE -> \r\n
|--LEADING_ASTERISK ->  *
|--TEXT ->
|--JAVADOC_INLINE_TAG -> JAVADOC_INLINE_TAG
|   `--LINK_INLINE_TAG -> LINK_INLINE_TAG
|       |--JAVADOC_INLINE_TAG_START -> {@
|       |--TAG_NAME -> link
|       |--TEXT ->
|       |--REFERENCE -> REFERENCE
|       |   |--IDENTIFIER -> String
|       |   |--HASH -> #
|       |   `--MEMBER_REFERENCE -> MEMBER_REFERENCE
|       |       |--IDENTIFIER -> length
|       |       |--LPAREN -> (
|       |       `--RPAREN -> )
|       `--JAVADOC_INLINE_TAG_END -> }
|--NEWLINE -> \r\n
|--LEADING_ASTERISK ->  *
|--TEXT -> /
|--NEWLINE -> \r\n
|--TEXT -> class Test {}
`--NEWLINE -> \r\n
```

