### PR TITLE
Issue: #17882 Adding VOID_ELEMENT token javadoc with AST example 

### DIFF
--- a/src/Test.java
+++ b/src/Test.java
@@ -1,7 +1,0 @@
-
-public class Test {
-    /**
-     * Example with HTML anchor tag.
-     * <br>
-     */
-}


### PR DESCRIPTION
Test.java for this token:

```
public class Test {
    /**
     * Example with HTML anchor tag.
     * <br>
     */
}
```


```
full AST example:
JAVADOC_CONTENT -> JAVADOC_CONTENT 
|--NEWLINE -> \r\n
|--TEXT -> public class Test {
|--NEWLINE -> \r\n
|--TEXT ->     /**
|--NEWLINE -> \r\n
|--LEADING_ASTERISK ->      *
|--TEXT ->  Example with HTML anchor tag.
|--NEWLINE -> \r\n
|--LEADING_ASTERISK ->      *
|--TEXT ->
|--HTML_ELEMENT -> HTML_ELEMENT
|   `--VOID_ELEMENT -> VOID_ELEMENT
|       `--HTML_TAG_START -> HTML_TAG_START
|           |--TAG_OPEN -> <
|           |--TAG_NAME -> br
|           `--TAG_CLOSE -> >
|--NEWLINE -> \r\n
|--LEADING_ASTERISK ->      *
|--TEXT -> /
|--NEWLINE -> \r\n
|--TEXT -> }
`--NEWLINE -> \r\n
```
