### PR TITLE
Issue #18660: fix crash in EmptyLineSeparatorCheck

### DIFF
--- a/config/checkstyle-resources-suppressions.xml
+++ b/config/checkstyle-resources-suppressions.xml
@@ -7,6 +7,16 @@
 <suppressions>
 
   <!-- intentional problem for testing -->
+  <suppress checks="PackageDeclaration" files="InputEmptyLineSeparatorCrash18660\.java"/>
+
+  <!-- intentional problem for testing -->
+  <suppress checks="PackageDeclaration" files="InputEmptyLineSeparatorIssue18660e\.java"/>
+
+  <!-- intentional problem for testing -->
+  <suppress checks="PackageDeclaration"
+            files="emptylineseparator[\\/]InputEmptyLineSeparatorMutationTest\.java"/>
+
+  <!-- intentional problem for testing -->
   <suppress checks="PackageDeclaration"
             files="src[\\/]test[\\/]resources-noncompilable[\\/]com[\\/]puppycrawl[\\/]tools[\\/]checkstyle[\\/]checks[\\/]whitespace[\\/]emptylineseparator[\\/]InputEmptyLineSeparatorCompactNoPackage.java"/>
   <!-- intentional problem for testing -->

--- a/config/jsoref-spellchecker/whitelist.words
+++ b/config/jsoref-spellchecker/whitelist.words
@@ -870,6 +870,7 @@ multiplevariabledeclarations
 Multiset
 multithreading
 mutableexception
+mutationtest
 MVC
 mvn
 mvnrepository

--- a/config/pitest-suppressions/pitest-whitespace-suppressions.xml
+++ b/config/pitest-suppressions/pitest-whitespace-suppressions.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<suppressedMutations>
+  <mutation unstable="false">
+    <sourceFile>EmptyLineSeparatorCheck.java</sourceFile>
+    <mutatedClass>com.puppycrawl.tools.checkstyle.checks.whitespace.EmptyLineSeparatorCheck</mutatedClass>
+    <mutatedMethod>hasEmptyLineBefore</mutatedMethod>
+    <mutator>org.pitest.mutationtest.engine.gregor.mutators.NonVoidMethodCallMutator</mutator>
+    <description>removed call to com/puppycrawl/tools/checkstyle/checks/whitespace/EmptyLineSeparatorCheck::getLine</description>
+    <lineContent>getLine(typeChild.getLineNo() - 2);</lineContent>
+  </mutation>
+</suppressedMutations>

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/whitespace/EmptyLineSeparatorCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/whitespace/EmptyLineSeparatorCheck.java
@@ -569,7 +569,7 @@ public class EmptyLineSeparatorCheck extends AbstractCheck {
         for (DetailAST typeChild = token.findFirstToken(TokenTypes.TYPE).getLastChild();
              typeChild != null; typeChild = typeChild.getPreviousSibling()) {
 
-            if (isTokenNotOnPreviousSiblingLines(typeChild, token)) {
+            if (typeChild.getLineNo() > 2 && isTokenNotOnPreviousSiblingLines(typeChild, token)) {
 
                 final String commentBeginningPreviousLine =
                     getLine(typeChild.getLineNo() - 2);
@@ -683,13 +683,13 @@ public class EmptyLineSeparatorCheck extends AbstractCheck {
             }
             else if (token.findFirstToken(TokenTypes.TYPE) != null) {
                 for (DetailAST typeChild = token.findFirstToken(TokenTypes.TYPE).getLastChild();
-                     typeChild != null && !result && typeChild.getLineNo() > 1;
+                     typeChild != null && !result;
                      typeChild = typeChild.getPreviousSibling()) {
-
-                    final String commentBeginningPreviousLine =
-                        getLine(typeChild.getLineNo() - 2);
-                    result = CommonUtil.isBlank(commentBeginningPreviousLine);
-
+                    if (typeChild.getLineNo() > 1) {
+                        final String commentBeginningPreviousLine =
+                            getLine(typeChild.getLineNo() - 2);
+                        result = CommonUtil.isBlank(commentBeginningPreviousLine);
+                    }
                 }
             }
         }

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/whitespace/EmptyLineSeparatorCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/whitespace/EmptyLineSeparatorCheckTest.java
@@ -751,4 +751,133 @@ public class EmptyLineSeparatorCheckTest
         );
     }
 
+    /**
+     * This input file intentionally has no inline config header
+     * to reproduce the crash conditions (token at index 0 or 1),
+     * so {@code verifyWithInlineConfigParser} cannot be used here.
+     */
+    @Test
+    public void testIssue18660() throws Exception {
+        final DefaultConfiguration checkConfig =
+            createModuleConfig(EmptyLineSeparatorCheck.class);
+        checkConfig.addProperty("allowMultipleEmptyLines", "false");
+        final String[] expected = CommonUtil.EMPTY_STRING_ARRAY;
+        verify(checkConfig,
+            getNonCompilablePath("InputEmptyLineSeparatorCrash18660.java"),
+                expected);
+    }
+
+    /**
+     * This input file intentionally has no inline config header
+     * to reproduce the crash conditions (token at index 0 or 1),
+     * so {@code verifyWithInlineConfigParser} cannot be used here.
+     */
+    @Test
+    public void testIssue18660a() throws Exception {
+        final DefaultConfiguration checkConfig =
+                createModuleConfig(EmptyLineSeparatorCheck.class);
+        checkConfig.addProperty("allowMultipleEmptyLines", "false");
+        final String[] expected = CommonUtil.EMPTY_STRING_ARRAY;
+        verify(checkConfig,
+                getPath("InputEmptyLineSeparatorIssue18660a.java"), expected);
+    }
+
+    /**
+     * This input file intentionally has no inline config header
+     * to reproduce the crash conditions (token at index 0 or 1),
+     * so {@code verifyWithInlineConfigParser} cannot be used here.
+     */
+    @Test
+    public void testIssue18660b() throws Exception {
+        final DefaultConfiguration checkConfig =
+                createModuleConfig(EmptyLineSeparatorCheck.class);
+        checkConfig.addProperty("allowMultipleEmptyLines", "false");
+        final String[] expected = {
+            "6:24: " + getCheckMessage(MSG_SHOULD_BE_SEPARATED, "METHOD_DEF"),
+        };
+        verify(checkConfig,
+                getPath("InputEmptyLineSeparatorIssue18660b.java"), expected);
+    }
+
+    /**
+     * This input file intentionally has no inline config header
+     * to reproduce the crash conditions (token at index 0 or 1),
+     * so {@code verifyWithInlineConfigParser} cannot be used here.
+     */
+    @Test
+    public void testIssue18660c() throws Exception {
+        final DefaultConfiguration checkConfig =
+                createModuleConfig(EmptyLineSeparatorCheck.class);
+        checkConfig.addProperty("allowMultipleEmptyLines", "false");
+        final String[] expected = CommonUtil.EMPTY_STRING_ARRAY;
+        verify(checkConfig,
+                getPath("InputEmptyLineSeparatorIssue18660c.java"), expected);
+    }
+
+    /**
+     * This input file intentionally has no inline config header
+     * to reproduce the crash conditions (token at index 0 or 1),
+     * so {@code verifyWithInlineConfigParser} cannot be used here.
+     */
+    @Test
+    public void testIssue18660d() throws Exception {
+        final DefaultConfiguration checkConfig =
+                createModuleConfig(EmptyLineSeparatorCheck.class);
+        checkConfig.addProperty("allowMultipleEmptyLines", "false");
+        final String[] expected = {
+            "7:5: " + getCheckMessage(MSG_MULTIPLE_LINES, "METHOD_DEF"),
+        };
+        verify(checkConfig,
+                getPath("InputEmptyLineSeparatorIssue18660d.java"), expected);
+    }
+
+    /**
+     * This input file intentionally has no inline config header
+     * to reproduce the crash conditions (token at index 0 or 1),
+     * so {@code verifyWithInlineConfigParser} cannot be used here.
+     */
+    @Test
+    public void testIssue18660e() throws Exception {
+        final DefaultConfiguration checkConfig =
+                createModuleConfig(EmptyLineSeparatorCheck.class);
+        checkConfig.addProperty("allowMultipleEmptyLines", "false");
+        final String[] expected = CommonUtil.EMPTY_STRING_ARRAY;
+        verify(checkConfig,
+                getNonCompilablePath("InputEmptyLineSeparatorIssue18660e.java"),
+                expected);
+    }
+
+    /**
+     * This input file intentionally has no inline config header
+     * to reproduce the crash conditions (token at index 0 or 1),
+     * so {@code verifyWithInlineConfigParser} cannot be used here.
+     */
+    @Test
+    public void testMutationHasEmptyLineBefore() throws Exception {
+        final DefaultConfiguration checkConfig =
+                createModuleConfig(EmptyLineSeparatorCheck.class);
+        checkConfig.addProperty("allowMultipleEmptyLines", "false");
+        final String[] expected = {
+            "6:5: " + getCheckMessage(MSG_MULTIPLE_LINES, "VARIABLE_DEF"),
+            "9:5: " + getCheckMessage(MSG_SHOULD_BE_SEPARATED, "VARIABLE_DEF"),
+            "12:5: " + getCheckMessage(MSG_SHOULD_BE_SEPARATED, "VARIABLE_DEF"),
+        };
+        verify(checkConfig,
+                getNonCompilablePath("InputEmptyLineSeparatorMutationTest.java"), expected);
+    }
+
+    /**
+     * This input file intentionally has no inline config header
+     * to reproduce the crash conditions (token at index 0 or 1),
+     * so {@code verifyWithInlineConfigParser} cannot be used here.
+     */
+    @Test
+    public void testTopOfFileEdgeCase() throws Exception {
+        final DefaultConfiguration checkConfig =
+                createModuleConfig(EmptyLineSeparatorCheck.class);
+        final String[] expected = {};
+        verify(checkConfig,
+                getNonCompilablePath("InputEmptyLineSeparatorCrash18660.java"), expected);
+    }
+
 }

--- a/src/test/resources-noncompilable/com/puppycrawl/tools/checkstyle/checks/whitespace/emptylineseparator/InputEmptyLineSeparatorCrash18660.java
+++ b/src/test/resources-noncompilable/com/puppycrawl/tools/checkstyle/checks/whitespace/emptylineseparator/InputEmptyLineSeparatorCrash18660.java
@@ -1,0 +1,9 @@
+public class InputEmptyLineSeparatorCrash18660 {
+    // This comment is at the start of the class body and used to crash EmptyLineSeparatorCheck
+
+    void display(boolean ifYes) {
+        if (true) {
+            System.out.println("Hello world");
+        }
+    }
+}

--- a/src/test/resources-noncompilable/com/puppycrawl/tools/checkstyle/checks/whitespace/emptylineseparator/InputEmptyLineSeparatorIssue18660e.java
+++ b/src/test/resources-noncompilable/com/puppycrawl/tools/checkstyle/checks/whitespace/emptylineseparator/InputEmptyLineSeparatorIssue18660e.java
@@ -1,0 +1,4 @@
+class InputEmptyLineSeparatorIssue18660e {
+    java.util.List
+            <String> field;
+}

--- a/src/test/resources-noncompilable/com/puppycrawl/tools/checkstyle/checks/whitespace/emptylineseparator/InputEmptyLineSeparatorMutationTest.java
+++ b/src/test/resources-noncompilable/com/puppycrawl/tools/checkstyle/checks/whitespace/emptylineseparator/InputEmptyLineSeparatorMutationTest.java
@@ -1,0 +1,15 @@
+public class InputEmptyLineSeparatorMutationTest {
+
+    int a;
+
+
+    int b; // should be OK (has empty line before)
+
+    int c; // violation (no empty line before)
+    List<String> d; // no empty line before, generic type forces loop exhaustion
+
+    List<String> e; // no empty line before, generic type forces loop exhaustion
+    List<
+
+            String> f; // blank line inside, no violation expected
+}

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/whitespace/emptylineseparator/InputEmptyLineSeparatorIssue18660a.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/whitespace/emptylineseparator/InputEmptyLineSeparatorIssue18660a.java
@@ -1,0 +1,6 @@
+package com.puppycrawl.tools.checkstyle.checks.whitespace.emptylineseparator;
+
+public class InputEmptyLineSeparatorIssue18660a {
+
+    void display() { }
+}

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/whitespace/emptylineseparator/InputEmptyLineSeparatorIssue18660b.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/whitespace/emptylineseparator/InputEmptyLineSeparatorIssue18660b.java
@@ -1,0 +1,7 @@
+package com.puppycrawl.tools.checkstyle.checks.whitespace.emptylineseparator;
+
+public class InputEmptyLineSeparatorIssue18660b {
+    int x = 1;
+
+    void method1() { } void display() { }
+}

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/whitespace/emptylineseparator/InputEmptyLineSeparatorIssue18660c.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/whitespace/emptylineseparator/InputEmptyLineSeparatorIssue18660c.java
@@ -1,0 +1,6 @@
+package com.puppycrawl.tools.checkstyle.checks.whitespace.emptylineseparator;
+
+public class InputEmptyLineSeparatorIssue18660c {
+
+    void display() { }
+}

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/whitespace/emptylineseparator/InputEmptyLineSeparatorIssue18660d.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/whitespace/emptylineseparator/InputEmptyLineSeparatorIssue18660d.java
@@ -1,0 +1,8 @@
+package com.puppycrawl.tools.checkstyle.checks.whitespace.emptylineseparator;
+
+public class InputEmptyLineSeparatorIssue18660d {
+
+
+    // comment
+    void display() { }
+}


### PR DESCRIPTION
Fixes #18660.

This PR provides the functional fix for the crash in `EmptyLineSeparatorCheck` when a token is at the top of the file (indices 0 or 1).

Supersedes #18671 as requested by @romani.