### PR TITLE
Issue #18836: Enable EXPERIMENTAL_MEMBER_VARIABLE mutator after Pitest fix

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5035,8 +5035,7 @@
                 <mutator>EXPERIMENTAL_ARGUMENT_PROPAGATION</mutator>
                 <mutator>EXPERIMENTAL_BIG_DECIMAL</mutator>
                 <mutator>EXPERIMENTAL_BIG_INTEGER</mutator>
-                <!-- Disabled until issue in pitest is resolved at https://github.com/hcoles/pitest/issues/1440 -->
-                <!-- <mutator>EXPERIMENTAL_MEMBER_VARIABLE</mutator> -->
+                <mutator>EXPERIMENTAL_MEMBER_VARIABLE</mutator>
                 <mutator>EXPERIMENTAL_NAKED_RECEIVER</mutator>
                 <mutator>REMOVE_INCREMENTS</mutator>
                 <mutator>EXPERIMENTAL_SWITCH</mutator>

--- a/src/test/java/com/puppycrawl/tools/checkstyle/api/AbstractViolationReporterTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/api/AbstractViolationReporterTest.java
@@ -134,6 +134,21 @@ public class AbstractViolationReporterTest {
         }
     }
 
+    @Test
+    public void testSetSeverity() throws Exception {
+        final DefaultConfiguration config = createModuleConfig(EmptyCheck.class);
+        final String severity = "warning";
+        config.addProperty("severity", severity);
+        emptyCheck.configure(config);
+
+        assertWithMessage("Invalid severity level")
+                .that(emptyCheck.getSeverityLevel())
+                .isEqualTo(SeverityLevel.WARNING);
+        assertWithMessage("Invalid severity")
+                .that(emptyCheck.getSeverity())
+                .isEqualTo(severity);
+    }
+
     public static class EmptyCheck extends AbstractCheck {
 
         @Override


### PR DESCRIPTION
Related  to #18836
Re-enables the EXPERIMENTAL_MEMBER_VARIABLE mutator in the api pitest profile.