### PR TITLE
Issue #17882: Update TYPE_ARGUMENT token to new AST format

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/api/JavadocCommentsTokenTypes.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/api/JavadocCommentsTokenTypes.java
@@ -1559,6 +1559,33 @@ public final class JavadocCommentsTokenTypes {
 
     /**
      * Single type argument in generics.
+     *
+     * <p>This node represents one individual type inside a generic type
+     * argument list.</p>
+     *
+     * <p><b>Example:</b></p>
+     * <pre>{@code
+     * {@link java.util.List<String>}
+     * }</pre>
+     *
+     * <p><b>Tree:</b></p>
+     * <pre>{@code
+     * JAVADOC_INLINE_TAG -> JAVADOC_INLINE_TAG
+     * `--LINK_INLINE_TAG -> LINK_INLINE_TAG
+     *     |--JAVADOC_INLINE_TAG_START -> &#123;@
+     *     |--TAG_NAME -> link
+     *     |--TEXT ->
+     *     |--REFERENCE -> REFERENCE
+     *         |--IDENTIFIER -> java.util.List
+     *         `--TYPE_ARGUMENTS -> TYPE_ARGUMENTS
+     *             |--LT -> <
+     *             |--TYPE_ARGUMENT -> TYPE_ARGUMENT
+     *             |   `--IDENTIFIER -> String
+     *             `--GT -> >
+     *     `--JAVADOC_INLINE_TAG_END -> }
+     * }</pre>
+     *
+     * @see #TYPE_ARGUMENTS
      */
     public static final int TYPE_ARGUMENT = JavadocCommentsLexer.TYPE_ARGUMENT;
 


### PR DESCRIPTION
Issue #17882 

**Command**
`java -jar checkstyle-13.1.0-all.jar -j src/Test.java | sed "s/\[[0-9]\+:[0-9]\+\]//g"`

**Test.java**
```
/**
 * {@link java.util.List<String>}
 */
class Test {
}
```

**Output**
```
bvidy@Vid MINGW64 /e/workspace/temp
$ java -jar checkstyle-13.1.0-all.jar -j src/Test.java | sed "s/\[[0-9]\+:[0-9]\+\]//g"
JAVADOC_CONTENT -> JAVADOC_CONTENT
|--TEXT -> /**
|--NEWLINE -> \r\n
|--LEADING_ASTERISK ->  *
|--TEXT ->
|--JAVADOC_INLINE_TAG -> JAVADOC_INLINE_TAG
|   `--LINK_INLINE_TAG -> LINK_INLINE_TAG
|       |--JAVADOC_INLINE_TAG_START -> {@
|       |--TAG_NAME -> link
|       |--TEXT ->
|       |--REFERENCE -> REFERENCE
|       |   |--IDENTIFIER -> java.util.List
|       |   `--TYPE_ARGUMENTS -> TYPE_ARGUMENTS
|       |       |--LT -> <
|       |       |--TYPE_ARGUMENT -> TYPE_ARGUMENT
|       |       |   `--IDENTIFIER -> String
|       |       `--GT -> >
|       `--JAVADOC_INLINE_TAG_END -> }
|--NEWLINE -> \r\n
|--LEADING_ASTERISK ->  *
|--TEXT -> /
|--NEWLINE -> \r\n
|--TEXT -> class Test {
|--NEWLINE -> \r\n
|--TEXT -> }
`--NEWLINE -> \r\n

```