### PR TITLE
Issue #17882: Add VOID_ELEMENT token Javadoc with AST example

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/api/JavadocCommentsTokenTypes.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/api/JavadocCommentsTokenTypes.java
@@ -1814,6 +1814,21 @@ public final class JavadocCommentsTokenTypes {
 
     /**
      * Void HTML element (self-closing).
+     *
+     * <p>Example in Javadoc:</p>
+     * <pre>
+     * &lt;br&gt;
+     * </pre>
+     *
+     * <p>Tree:</p>
+     * <pre>
+     * HTML_ELEMENT -> HTML_ELEMENT
+     * `--VOID_ELEMENT -> VOID_ELEMENT
+     *     `--HTML_TAG_START -> HTML_TAG_START
+     *         |--TAG_OPEN -> &lt;
+     *         |--TAG_NAME -> br
+     *         `--TAG_CLOSE -> &gt;
+     * </pre>
      */
     public static final int VOID_ELEMENT = JavadocCommentsLexer.VOID_ELEMENT;
 


### PR DESCRIPTION
**Issue:** #17882

**Description:** 
Updated the VOID_ELEMENT token in JavadocCommentsTokenTypes.java to include the new AST print format example.

**Example Input Code (src/Test.java):**

```
/**
 * <br>
 */
```

**Command:**

`java -jar target/checkstyle-13.1.1-SNAPSHOT-all.jar -j src/Test.java | sed "s/\[[0-9]\+:[0-9]\+\]//g"`

**AST Output:**

```
JAVADOC_CONTENT -> JAVADOC_CONTENT
|--TEXT -> /**
|--NEWLINE -> \n
|--LEADING_ASTERISK ->  *
|--TEXT ->   
|--HTML_ELEMENT -> HTML_ELEMENT
|   `--VOID_ELEMENT -> VOID_ELEMENT
|       `--HTML_TAG_START -> HTML_TAG_START
|           |--TAG_OPEN -> <
|           |--TAG_NAME -> br
|           `--TAG_CLOSE -> >
|--NEWLINE -> \n
|--LEADING_ASTERISK ->  *
`--TEXT -> /
```