### PR TITLE
Issue #18435: Fix javadocleadingasteriskalign example AST consistency

### DIFF
--- a/src/site/xdoc/checks/javadoc/javadocleadingasteriskalign.xml
+++ b/src/site/xdoc/checks/javadoc/javadocleadingasteriskalign.xml
@@ -113,7 +113,12 @@ public class Example2 {
   /**
     *  Javadoc for instance variable. // violation
     */ // violation
-  private String name;
+  private int ball;
+
+  /**
+    *  Javadoc for instance variable. // violation
+    */ // violation
+  private int age;
 
   /**
   *  Javadoc for method. // violation
@@ -123,7 +128,7 @@ public class Example2 {
   /**
    Javadoc for Constructor.
 */ // violation
-  private Example2() {}
+  public Example2() {}
 
   /**
     * Javadoc for enum. // violation
@@ -137,12 +142,7 @@ public class Example2 {
 
     /**
         * Incorrect indentation for leading asterisk. */ // violation
-    TWO,
-
-    /**
- *    // violation
-     */
-    THREE
+    TWO
   }
 }
 </code></pre></div><hr class="example-separator"/>
@@ -170,7 +170,12 @@ public class Example3 {
   /** &lt;- Preceded with Tabs.
    * &lt;- Preceded with Tabs &amp; Spaces.
    */ // &lt;- Preceded with Tabs &amp; Spaces.
-  private String name;
+  private int ball;
+
+  /** &lt;- Preceded with Tabs.
+   * &lt;- Preceded with Tabs &amp; Spaces.
+   */ // &lt;- Preceded with Tabs &amp; Spaces.
+  private int age;
 
   /** &lt;- Preceded with Spaces.
    * &lt;- Preceded with Tabs.
@@ -180,7 +185,7 @@ public class Example3 {
   /**
     * // violation
   */ // violation
-  private Example3() {}
+  public Example3() {}
 
   private enum tabsExample {
     /**

--- a/src/test/java/com/puppycrawl/tools/checkstyle/internal/XdocsExamplesAstConsistencyTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/internal/XdocsExamplesAstConsistencyTest.java
@@ -178,8 +178,6 @@ public class XdocsExamplesAstConsistencyTest {
             "checks/indentation/commentsindentation/Example6",
             "checks/indentation/commentsindentation/Example7",
             "checks/indentation/commentsindentation/Example8",
-            "checks/javadoc/javadocleadingasteriskalign/Example2",
-            "checks/javadoc/javadocleadingasteriskalign/Example3",
             "checks/javadoc/javadocmethod/Example7",
             "checks/javadoc/javadocmethod/Example8",
             "checks/javadoc/javadocstyle/Example7",

--- a/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadocleadingasteriskalign/Example2.java
+++ b/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadocleadingasteriskalign/Example2.java
@@ -16,7 +16,12 @@ public class Example2 {
   /**
     *  Javadoc for instance variable. // violation
     */ // violation
-  private String name;
+  private int ball;
+
+  /**
+    *  Javadoc for instance variable. // violation
+    */ // violation
+  private int age;
 
   /**
   *  Javadoc for method. // violation
@@ -26,7 +31,7 @@ public class Example2 {
   /**
    Javadoc for Constructor.
 */ // violation
-  private Example2() {}
+  public Example2() {}
 
   /**
     * Javadoc for enum. // violation
@@ -40,12 +45,7 @@ public class Example2 {
 
     /**
         * Incorrect indentation for leading asterisk. */ // violation
-    TWO,
-
-    /**
- *    // violation
-     */
-    THREE
+    TWO
   }
 }
 // xdoc section -- end

--- a/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadocleadingasteriskalign/Example3.java
+++ b/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadocleadingasteriskalign/Example3.java
@@ -19,7 +19,12 @@ public class Example3 {
   /** <- Preceded with Tabs.
    * <- Preceded with Tabs & Spaces.
    */ // <- Preceded with Tabs & Spaces.
-  private String name;
+  private int ball;
+
+  /** <- Preceded with Tabs.
+   * <- Preceded with Tabs & Spaces.
+   */ // <- Preceded with Tabs & Spaces.
+  private int age;
 
   /** <- Preceded with Spaces.
    * <- Preceded with Tabs.
@@ -29,7 +34,7 @@ public class Example3 {
   /**
     * // violation
   */ // violation
-  private Example3() {}
+  public Example3() {}
 
   private enum tabsExample {
     /**


### PR DESCRIPTION
Issue #18435

https://checkstyle.org/checks/javadoc/javadocleadingasteriskalign.html#Examples

Aligned Java AST structure across Example1, Example2, and Example3 for the JavadocLeadingAsteriskAlign check.

All examples now share the same class structure (fields, methods, constructor visibility, and enum shape). Differences are limited to Javadoc content and indentation, which is the intended focus of this check.