### PR TITLE
Issue #17882: Add STRING_LITERAL token Javadoc with AST example

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/api/JavadocCommentsTokenTypes.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/api/JavadocCommentsTokenTypes.java
@@ -1934,6 +1934,23 @@ public final class JavadocCommentsTokenTypes {
 
     /**
      * String literal inside Javadoc.
+     *
+     * <p>Example in Javadoc:</p>
+     *
+     * <pre>{@code
+     * {@see "foo"}
+     * }</pre>
+     *
+     * <p>Tree:</p>
+     *
+     * <pre>{@code
+     * JAVADOC_BLOCK_TAG -> JAVADOC_BLOCK_TAG
+     * `--SEE_BLOCK_TAG -> SEE_BLOCK_TAG
+     *     |--AT_SIGN -> @
+     *     |--TAG_NAME -> see
+     *     |--TEXT ->
+     *     `--STRING_LITERAL -> "foo"
+     * }</pre>
      */
     public static final int STRING_LITERAL = JavadocCommentsLexer.STRING_LITERAL;
 


### PR DESCRIPTION
**Issue:** #17882
Replaces: #18839 (Closed accidentally during rebase)

**Description:**
Updated the `STRING_LITERAL` token in `JavadocCommentsTokenTypes.java` to include the AST structure example.

This PR restores the work from PR #18839, which was already reviewed and approved by @romani. The previous PR was automatically closed due to a git rebase error, but the changes in this PR are identical to the approved version.

**Example Input Code (src/Test.java):**
/** @see "foo" */

**Command:**
`java -jar target/checkstyle-13.1.1-SNAPSHOT-all.jar -j src/Test.java | sed "s/\[[0-9]\+:[0-9]\+\]//g"`

**AST Output:**
```
JAVADOC_CONTENT -> JAVADOC_CONTENT
|--JAVADOC_TAG -> JAVADOC_TAG
|   |--SEE_LITERAL -> @see
|   |--WS ->  
|   `--STRING_LITERAL -> "foo"
`--EOF -> <EOF>
```
