### PR TITLE
Issue #11166: resolved AvoidEscapedUnicodeCharactersCheck

### DIFF
--- a/config/checkstyle-non-main-files-suppressions.xml
+++ b/config/checkstyle-non-main-files-suppressions.xml
@@ -9,6 +9,10 @@
   <!-- don't validate generated files -->
   <suppress id="lineLength" files="releasenotes.xml"/>
 
+  <!-- exclude java-upgrade logs from line length checks -->
+  <suppress id="lineLength"
+         files="\.github[\\/]java-upgrade[\\/].*[\\/]logs[\\/].*\.log"/>
+
   <!-- full path is required for logic of script google-java-format.sh -->
   <suppress id="lineLength" files="compilable-input-paths.txt"/>
   <suppress id="lineLength" files="noncompilable-input-paths.txt"/>

--- a/config/suppressions.xml
+++ b/config/suppressions.xml
@@ -127,7 +127,6 @@
   <suppress id="noUsageOfGetFileContentsMethod" files="MissingJavadocTypeCheck.java"/>
   <suppress id="noUsageOfGetFileContentsMethod" files="RegexpCheck.java"/>
   <suppress id="noUsageOfGetFileContentsMethod" files="RegexpSinglelineJavaCheck.java"/>
-  <suppress id="noUsageOfGetFileContentsMethod" files="AvoidEscapedUnicodeCharactersCheck.java"/>
 
   <!-- until https://github.com/checkstyle/checkstyle/issues/5234 -->
   <suppress id="MatchXPathBranchContains" files="[\\/]DetailAstImplTest.java"/>

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/AvoidEscapedUnicodeCharactersCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/AvoidEscapedUnicodeCharactersCheck.java
@@ -19,19 +19,22 @@
 
 package com.puppycrawl.tools.checkstyle.checks;
 
-import java.util.Arrays;
+import java.util.ArrayDeque;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.IdentityHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Deque;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 import com.puppycrawl.tools.checkstyle.FileStatefulCheck;
 import com.puppycrawl.tools.checkstyle.api.AbstractCheck;
 import com.puppycrawl.tools.checkstyle.api.DetailAST;
-import com.puppycrawl.tools.checkstyle.api.TextBlock;
 import com.puppycrawl.tools.checkstyle.api.TokenTypes;
 import com.puppycrawl.tools.checkstyle.utils.CheckUtil;
-import com.puppycrawl.tools.checkstyle.utils.CodePointUtil;
+import com.puppycrawl.tools.checkstyle.utils.TokenUtil;
 
 /**
  * <div>
@@ -174,10 +177,17 @@ public class AvoidEscapedUnicodeCharactersCheck
             + "|\\\\u[fF]{3}[bB]"
             + "|\\\\u[fF]{4}");
 
-    /** Cpp style comments. */
-    private Map<Integer, TextBlock> singlelineComments;
-    /** C style comments. */
-    private Map<Integer, List<TextBlock>> blockComments;
+    /** Comment nodes grouped by starting line number. */
+    private final Map<Integer, List<CommentInfo>> commentsByLine = new HashMap<>();
+
+    /** Literal token start columns grouped by line number. */
+    private final Map<Integer, List<Integer>> literalStartColumnsByLine = new HashMap<>();
+
+    /** Max column of non-comment tokens per line. */
+    private final Map<Integer, Integer> maxNonCommentColumnByLine = new HashMap<>();
+
+    /** Tracks visited nodes to prevent circular recursion using identity comparison. */
+    private final Map<DetailAST, Boolean> visitedNodes = new IdentityHashMap<>();
 
     /** Allow use escapes for non-printable, control characters. */
     private boolean allowEscapesForControlCharacters;
@@ -250,12 +260,18 @@ public class AvoidEscapedUnicodeCharactersCheck
         };
     }
 
-    // suppress deprecation until https://github.com/checkstyle/checkstyle/issues/11166
     @Override
-    @SuppressWarnings("deprecation")
     public void beginTree(DetailAST rootAST) {
-        singlelineComments = getFileContents().getSingleLineComments();
-        blockComments = getFileContents().getBlockComments();
+        commentsByLine.clear();
+        literalStartColumnsByLine.clear();
+        maxNonCommentColumnByLine.clear();
+        visitedNodes.clear();
+        collectNodes(rootAST);
+    }
+
+    @Override
+    public boolean isCommentNodesRequired() {
+        return true;
     }
 
     @Override
@@ -307,39 +323,218 @@ public class AvoidEscapedUnicodeCharactersCheck
      * @return true if trail comment is present after ast token.
      */
     private boolean hasTrailComment(DetailAST ast) {
+        final LiteralPosition position = resolveLiteralPosition(ast);
+        return hasTrailingCommentOnLine(position);
+    }
+
+    /**
+     * Resolves the line and end-column for a literal, accounting for text blocks.
+     *
+     * @param ast literal token
+     * @return resolved line and end-column position
+     */
+    private static LiteralPosition resolveLiteralPosition(DetailAST ast) {
         int lineNo = ast.getLineNo();
+        int literalEndColumn = getLiteralEndColumn(ast);
 
         // Since the trailing comment in the case of text blocks must follow the """ delimiter,
         // we need to look for it after TEXT_BLOCK_LITERAL_END.
         if (ast.getType() == TokenTypes.TEXT_BLOCK_CONTENT) {
-            lineNo = ast.getNextSibling().getLineNo();
+            final DetailAST endToken = ast.getNextSibling();
+            if (endToken != null) {
+                lineNo = endToken.getLineNo();
+                literalEndColumn = getLiteralEndColumn(endToken);
+            }
         }
+        return new LiteralPosition(lineNo, literalEndColumn);
+    }
+
+    /**
+     * Checks if a trailing comment exists on the resolved line for the literal.
+     *
+     * @param position literal position
+     * @return true if a trailing comment applies
+     */
+    private boolean hasTrailingCommentOnLine(LiteralPosition position) {
+        final List<CommentInfo> comments = commentsByLine.get(position.lineNo);
         boolean result = false;
-        if (singlelineComments.containsKey(lineNo)) {
-            result = true;
-        }
-        else {
-            final List<TextBlock> commentList = blockComments.get(lineNo);
-            if (commentList != null) {
-                final TextBlock comment = commentList.getLast();
-                final int[] codePoints = getLineCodePoints(lineNo - 1);
-                result = isTrailingBlockComment(comment, codePoints);
+        if (comments != null) {
+            final int maxNonCommentColumn =
+                    maxNonCommentColumnByLine.getOrDefault(position.lineNo, -1);
+            for (CommentInfo comment : comments) {
+                if (isTrailingCommentCandidate(position, comment.startColumn,
+                        maxNonCommentColumn)) {
+                    result = true;
+                    break;
+                }
             }
         }
         return result;
     }
 
     /**
-     * Whether the C style comment is trailing.
+     * Determines if a comment should be treated as trailing for the given literal.
      *
-     * @param comment the comment to check.
-     * @param codePoints the first line of the comment, in unicode code points
-     * @return true if the comment is trailing.
+     * @param position literal position
+     * @param commentStartColumn comment start column
+     * @param maxNonCommentColumn max non-comment column on the line
+     * @return true if the comment is a valid trailing comment
      */
-    private static boolean isTrailingBlockComment(TextBlock comment, int... codePoints) {
-        return comment.getText().length != 1
-            || CodePointUtil.isBlank(Arrays.copyOfRange(codePoints,
-                comment.getEndColNo() + 1, codePoints.length));
+    private boolean isTrailingCommentCandidate(LiteralPosition position,
+            int commentStartColumn, int maxNonCommentColumn) {
+        boolean result = true;
+        if (commentStartColumn <= position.literalEndColumn) {
+            result = false;
+        }
+        else if (maxNonCommentColumn > commentStartColumn) {
+            result = false;
+        }
+        else if (hasAnotherLiteralAfter(position.lineNo, position.literalEndColumn,
+                commentStartColumn)) {
+            result = false;
+        }
+        return result;
+    }
+
+    /**
+     * Collects comment nodes and tracks max non-comment token column per line.
+     *
+     * @param ast root node to traverse
+     */
+    private void collectNodes(DetailAST ast) {
+        if (ast != null) {
+            final Deque<DetailAST> stack = new ArrayDeque<>();
+            stack.push(ast);
+            while (!stack.isEmpty()) {
+                final DetailAST current = stack.pop();
+                if (visitedNodes.put(current, Boolean.TRUE) == null) {
+                    recordNode(current);
+                    pushChildren(current, stack);
+                }
+            }
+        }
+    }
+
+    /**
+     * Records comment, literal, and non-comment token positions for this node.
+     *
+     * @param ast node to record
+     */
+    private void recordNode(DetailAST ast) {
+        final int lineNo = ast.getLineNo();
+        if (lineNo > 0) {
+            if (isCommentStart(ast)) {
+                commentsByLine
+                    .computeIfAbsent(lineNo, key -> new ArrayList<>())
+                    .add(new CommentInfo(ast.getColumnNo()));
+            }
+            else {
+                if (isLiteralToken(ast)) {
+                    literalStartColumnsByLine
+                        .computeIfAbsent(lineNo, key -> new ArrayList<>())
+                        .add(ast.getColumnNo());
+                }
+                if (!TokenUtil.isCommentType(ast.getType())) {
+                    recordMaxNonCommentColumn(lineNo, ast.getColumnNo());
+                }
+            }
+        }
+    }
+
+    /**
+     * Records the maximum non-comment column for the given line.
+     *
+     * @param lineNo line number
+     * @param columnNo column number
+     */
+    private void recordMaxNonCommentColumn(int lineNo, int columnNo) {
+        if (columnNo >= 0) {
+            maxNonCommentColumnByLine.merge(lineNo, columnNo, Math::max);
+        }
+    }
+
+    /**
+     * Pushes child nodes onto the traversal stack while guarding against malformed AST cycles.
+     *
+     * @param ast node whose children are traversed
+     * @param stack traversal stack
+     */
+    private void pushChildren(DetailAST ast, Deque<DetailAST> stack) {
+        // Traverse children; guard against malformed ASTs with cyclic links.
+        DetailAST child = ast.getFirstChild();
+        while (child != null) {
+            if (!visitedNodes.containsKey(child)) {
+                stack.push(child);
+            }
+            final DetailAST nextSibling = child.getNextSibling();
+            if (nextSibling == child || visitedNodes.containsKey(nextSibling)) {
+                break;
+            }
+            child = nextSibling;
+        }
+    }
+
+    /**
+     * Determines if the given node starts a comment.
+     *
+     * @param ast node to check
+     * @return true if the node is a comment start
+     */
+    private static boolean isCommentStart(DetailAST ast) {
+        return ast.getType() == TokenTypes.SINGLE_LINE_COMMENT
+                || ast.getType() == TokenTypes.BLOCK_COMMENT_BEGIN;
+    }
+
+    /**
+     * Checks if the node represents a literal token we track on the same line.
+     *
+     * @param ast node to check
+     * @return true if the node is a literal token
+     */
+    private static boolean isLiteralToken(DetailAST ast) {
+        return ast.getType() == TokenTypes.STRING_LITERAL
+                || ast.getType() == TokenTypes.CHAR_LITERAL
+                || ast.getType() == TokenTypes.TEXT_BLOCK_CONTENT;
+    }
+
+    /**
+     * Checks if another literal starts between the current literal end and comment.
+     *
+     * @param lineNo line number to inspect
+     * @param literalEndColumn end column of the current literal
+     * @param commentStartColumn start column of the trailing comment
+     * @return true if another literal starts after the current literal before the comment
+     */
+    private boolean hasAnotherLiteralAfter(int lineNo, int literalEndColumn,
+            int commentStartColumn) {
+        final List<Integer> columns = literalStartColumnsByLine.get(lineNo);
+        boolean result = false;
+        if (columns != null) {
+            for (Integer startColumn : columns) {
+                if (startColumn != null
+                        && startColumn > literalEndColumn
+                        && startColumn < commentStartColumn) {
+                    result = true;
+                    break;
+                }
+            }
+        }
+        return result;
+    }
+
+    /**
+     * Calculates the ending column of a literal token.
+     *
+     * @param ast literal token
+     * @return ending column number
+     */
+    private static int getLiteralEndColumn(DetailAST ast) {
+        final String text = ast.getText();
+        int endColumn = ast.getColumnNo();
+        if (text != null) {
+            endColumn += text.length() - 1;
+        }
+        return endColumn;
     }
 
     /**
@@ -367,6 +562,23 @@ public class AvoidEscapedUnicodeCharactersCheck
     private boolean isAllCharactersEscaped(String literal) {
         return allowIfAllCharactersEscaped
                 && ALL_ESCAPED_CHARS.matcher(literal).find();
+    }
+
+    /**
+     * Simple comment info.
+     *
+     * @param startColumn the starting column of the comment
+     */
+    private record CommentInfo(int startColumn) {
+    }
+
+    /**
+     * Literal position info.
+     *
+     * @param lineNo line number
+     * @param literalEndColumn literal end column
+     */
+    private record LiteralPosition(int lineNo, int literalEndColumn) {
     }
 
 }

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/avoidescapedunicodecharacters/InputAvoidEscapedUnicodeCharacters2.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/avoidescapedunicodecharacters/InputAvoidEscapedUnicodeCharacters2.java
@@ -153,4 +153,7 @@ public class InputAvoidEscapedUnicodeCharacters2 {
                 // violation below, 'Unicode escape(s) usage should be avoided.'
         private String validEscapeWithManyUs = "t\uuuuuuuuu1234";
         private String validEscapeWithManyUsCommented = "t\uuuuuuuuu1234"; // comment
+
+        private String concatenated = "\u03bcs" + "x"; // Greek letter mu
+                // violation above, 'Unicode escape(s) usage should be avoided.'
 }

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/avoidescapedunicodecharacters/InputAvoidEscapedUnicodeCharactersComments.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/avoidescapedunicodecharacters/InputAvoidEscapedUnicodeCharactersComments.java
@@ -1,0 +1,38 @@
+/*
+AvoidEscapedUnicodeCharacters
+allowEscapesForControlCharacters = (default)false
+allowByTailComment = true
+allowIfAllCharactersEscaped = (default)false
+allowNonPrintableEscapes = (default)false
+
+
+*/
+
+// Test cases for comment handling
+package com.puppycrawl.tools.checkstyle.checks.avoidescapedunicodecharacters;
+
+public class InputAvoidEscapedUnicodeCharactersComments {
+
+    public void test1() {
+        // Just a comment, no tokens
+    }
+
+    public void test2() {
+        // violation below, 'Unicode escape(s) usage should be avoided.'
+        String s = "\u03bc"; // comment after
+    }
+
+    public void test3() {
+        // violation below, 'Unicode escape(s) usage should be avoided.'
+        String s = "\u03bc";
+        // comment on its own line
+    }
+
+    /* multi-line comment
+       spanning lines
+     */
+    public void test4() {
+        // violation below, 'Unicode escape(s) usage should be avoided.'
+        String s = "\u03bc";
+    }
+}

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/avoidescapedunicodecharacters/InputAvoidEscapedUnicodeCharactersEdgeCases.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/avoidescapedunicodecharacters/InputAvoidEscapedUnicodeCharactersEdgeCases.java
@@ -1,0 +1,30 @@
+/*
+AvoidEscapedUnicodeCharacters
+allowEscapesForControlCharacters = (default)false
+allowByTailComment = (default)false
+allowIfAllCharactersEscaped = (default)false
+allowNonPrintableEscapes = (default)false
+
+
+*/
+
+// Edge case testing
+package com.puppycrawl.tools.checkstyle.checks.avoidescapedunicodecharacters;
+
+public class InputAvoidEscapedUnicodeCharactersEdgeCases {
+
+    // violation below, 'Unicode escape(s) usage should be avoided.'
+    char charWithUnicode = '\u03bc';
+
+    // violation below, 'Unicode escape(s) usage should be avoided.'
+    String stringWithUnicode = "test\u03bc";
+
+    public void method() {
+        // violation below, 'Unicode escape(s) usage should be avoided.'
+        String s = "\u03bc";
+
+        /* Block comment with \u03bc */
+        // violation below, 'Unicode escape(s) usage should be avoided.'
+        String s2 = "\u03bc";
+    }
+}

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/avoidescapedunicodecharacters/InputAvoidEscapedUnicodeCharactersTextBlockWithTrailingComment.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/avoidescapedunicodecharacters/InputAvoidEscapedUnicodeCharactersTextBlockWithTrailingComment.java
@@ -1,0 +1,25 @@
+/*
+AvoidEscapedUnicodeCharacters
+allowEscapesForControlCharacters = (default)false
+allowByTailComment = true
+allowIfAllCharactersEscaped = (default)false
+allowNonPrintableEscapes = (default)false
+
+
+*/
+
+// Java17
+package com.puppycrawl.tools.checkstyle.checks.avoidescapedunicodecharacters;
+
+public class InputAvoidEscapedUnicodeCharactersTextBlockWithTrailingComment {
+
+    public void testTextBlockWithTrailingComment() {
+        // violation below, 'Unicode escape(s) usage should be avoided.'
+        String unitAbbrev1 = """
+            asd\u03bcsasd""";
+        String unitAbbrev2 = """
+            asd\u03bcsasd"""; // Greek letter mu
+        // violation below, 'Unicode escape(s) usage should be avoided.'
+        String normal = "\u03bc";
+    }
+}


### PR DESCRIPTION
Issue #11166 

## Summary:
- Reworked AvoidEscapedUnicodeCharactersCheck to detect trailing comments via comment nodes and token positions, removing direct file-contents access.
- Removed the suppression entry for this check.