### PR TITLE
Issue #18599: Disable InlineMeSuggester as Error Prone annotations are forbidden in main sources

### DIFF
--- a/config/checkstyle-checks.xml
+++ b/config/checkstyle-checks.xml
@@ -299,7 +299,7 @@
     <module name="MissingOverrideOnRecordAccessor"/>
     <module name="PackageAnnotation"/>
     <module name="SuppressWarnings">
-      <property name="format" value="^((?!unchecked|deprecation|rawtypes|resource|InvalidInlineTag|UnrecognisedJavadocTag).)*$"/>
+      <property name="format" value="^((?!unchecked|deprecation|rawtypes|resource|InvalidInlineTag|UnrecognisedJavadocTag|InlineMeSuggester).)*$"/>
       <message key="suppressed.warning.not.allowed"
            value="The warning ''{0}'' cannot be suppressed at this location.
            Only few javac warnings are allowed to suppress.

--- a/config/intellij-idea-inspections.xml
+++ b/config/intellij-idea-inspections.xml
@@ -4490,6 +4490,8 @@
         <option value="InvalidInlineTag"/>
         <!-- suppression for unrecognised javadoc tag -->
         <option value="UnrecognisedJavadocTag"/>
+        <!-- suppression for inline me suggester -->
+        <option value="InlineMeSuggester"/>
         <!-- false positives -->
         <option value="JUnitTestCaseWithNoTests"/>
         <!-- false positives -->

--- a/pom.xml
+++ b/pom.xml
@@ -256,6 +256,7 @@
       -Xep:FormatStringShouldUsePlaceholders:ERROR
       -Xep:IdentityConversion:ERROR
       -Xep:ImmutablesSortedSetComparator:ERROR
+      -Xep:InlineMeSuggester:ERROR
       -Xep:InconsistentCapitalization:ERROR
       <!-- Reason at https://github.com/checkstyle/checkstyle/issues/17988. -->
       -Xep:InlineFormatString:OFF

--- a/src/main/java/com/puppycrawl/tools/checkstyle/DefaultConfiguration.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/DefaultConfiguration.java
@@ -141,6 +141,7 @@ public final class DefaultConfiguration implements Configuration {
      *      {@code addProperty(String propertyName, String value)} instead.
      */
     @Deprecated(since = "8.45")
+    @SuppressWarnings("InlineMeSuggester")
     public void addAttribute(String attributeName, String value) {
         addProperty(attributeName, value);
     }


### PR DESCRIPTION
Issue #18599

## Disable InlineMeSuggester due to Checkstyle source restrictions

This PR disables the Error Prone `InlineMeSuggester` rule.

```
Warning:  /home/runner/work/checkstyle/checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/
DefaultConfiguration.java:[144,17] [InlineMeSuggester] This deprecated API looks inlineable. If you'd like the body of the API to be 
automatically inlined to its callers, please annotate it with @InlineMe. NOTE: the suggested fix makes the 
method final if it was not already.
    (see https://errorprone.info/bugpattern/InlineMeSuggester)
```

https://github.com/checkstyle/checkstyle/blob/4629a7a4007cb9558fe9cdf6e5d4e8ae42dbd4b1/src/main/java/com/puppycrawl/tools/checkstyle/DefaultConfiguration.java#L143-L146

While investigating the warning reported by Error Prone:

https://errorprone.info/bugpattern/InlineMeSuggester
https://errorprone.info/docs/inlineme

I attempted to apply the suggested fix by annotating the deprecated `addAttribute` method in `DefaultConfiguration` with `@InlineMe`. However, this change introduced new Checkstyle violations:

- `ImportControlMain` rejects `com.google.errorprone.annotations.InlineMe` in main sources
- `RedundantModifier` flags the required `final` modifier since `DefaultConfiguration` is already final

As a result, the original implementation of `addAttribute` has been restored, and `InlineMeSuggester` is explicitly turned OFF in the Error Prone configuration.