### PR TITLE
Issue #16969: Reduce sidebar width to improve content readability

### DIFF
--- a/src/site/resources/js/checkstyle.js
+++ b/src/site/resources/js/checkstyle.js
@@ -105,8 +105,8 @@ function setBodyColumnMargin() {
       leftColumn.className = "span2";
       bodyColumn.className = "span10";
     } else if (window.innerWidth > 1280) {
-      leftColumn.className = "span3";
-      bodyColumn.className = "span9";
+      leftColumn.className = "span2";
+      bodyColumn.className = "span10";
     } else if  (window.innerWidth > 823) {
       leftColumn.className = "span4";
       bodyColumn.className = "span8";

--- a/src/site/site.xml
+++ b/src/site/site.xml
@@ -13,8 +13,8 @@
 
   <custom>
     <fluidoSkin>
-      <leftColumnClass>span4</leftColumnClass>
-      <bodyColumnClass>span8</bodyColumnClass>
+      <leftColumnClass>span2</leftColumnClass>
+      <bodyColumnClass>span10</bodyColumnClass>
     </fluidoSkin>
   </custom>
 


### PR DESCRIPTION
Fixes #16969

As reported, the side panel was previously too wide on laptop screens. Reducing the sidebar width allocates more screen space to the body content, making the documentation easier to read on standard desktop/laptop displays.

earlier ->
<img width="1912" height="965" alt="Screenshot 2026-02-05 122513" src="https://github.com/user-attachments/assets/1782612d-f78d-4c62-836b-f30cd0e29b3f" />

after the change->
<img width="1905" height="835" alt="Screenshot 2026-02-05 122525" src="https://github.com/user-attachments/assets/30dcd441-b8da-49a9-b1bb-7da3e9e49212" />

