### PR TITLE
Issue #16963: fix Uncaught TypeError in resetStyling

### DIFF
--- a/src/site/resources/js/checkstyle.js
+++ b/src/site/resources/js/checkstyle.js
@@ -168,11 +168,27 @@ function setCollapsableMenuButton() {
 }
 
 function resetStyling() {
-    document.querySelector("#leftColumn").removeAttribute("style");
-    document.querySelector("body").removeAttribute("style");
-    document.querySelector("#bodyColumn").style.removeProperty("position");
-    document.querySelector("#hamburger").remove();
-    document.querySelector(".xright").lastChild.remove();
+    const leftColumn = document.querySelector("#leftColumn");
+    const body = document.querySelector("body");
+    const bodyColumn = document.querySelector("#bodyColumn");
+    const hamburger = document.querySelector("#hamburger");
+    const xright = document.querySelector(".xright");
+
+    if (leftColumn) {
+        leftColumn.removeAttribute("style");
+    }
+    if (body) {
+        body.removeAttribute("style");
+    }
+    if (bodyColumn) {
+        bodyColumn.style.removeProperty("position");
+    }
+    if (hamburger) {
+        hamburger.remove();
+    }
+    if (xright && xright.lastChild) {
+        xright.lastChild.remove();
+    }
 }
 
 window.addEventListener("load", function () {


### PR DESCRIPTION
Fixes #16963

Action: User clicked "Inspect" twice quickly (opened DevTools twice back-to-back).

This affects many left-side navigation links across the website, not just cmdline.html.

Solution: Refactored resetStyling() to include null guards for all DOM elements being manipulated. The function now safely checks for the existence of #leftColumn, body, #bodyColumn, #hamburger, and .xright before calling methods on them.

Testing: - 
before the changes - 
<img width="1915" height="1037" alt="Screenshot 2026-02-05 134510" src="https://github.com/user-attachments/assets/8ce50ac1-fb8f-451c-beb0-22e9052083a6" />

after the change - 
<img width="1908" height="1040" alt="Screenshot 2026-02-05 134548" src="https://github.com/user-attachments/assets/a49e7433-d672-4aec-acdb-c5bd139d81b7" />

