### PR TITLE
Issue #18435: Fix AST inconsistency in OneTopLevelClass examples

### DIFF
--- a/src/site/xdoc/checks/design/onetoplevelclass.xml
+++ b/src/site/xdoc/checks/design/onetoplevelclass.xml
@@ -50,7 +50,7 @@ class ViolationExample1 { // violation, "has to reside in its own source file."
           An example of code without public top-level type:
         </p>
         <div class="wrapper"><pre class="prettyprint"><code class="language-java">
-class Example2 { // ok, first top-level class
+public class Example2 { // ok, first top-level class
   // methods
 }
 

--- a/src/test/java/com/puppycrawl/tools/checkstyle/internal/XdocsExamplesAstConsistencyTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/internal/XdocsExamplesAstConsistencyTest.java
@@ -135,7 +135,6 @@ public class XdocsExamplesAstConsistencyTest {
             "checks/descendanttoken/Example7",
             "checks/descendanttoken/Example8",
             "checks/descendanttoken/Example9",
-            "checks/design/onetoplevelclass/Example2",
             "checks/design/onetoplevelclass/Example3",
             "checks/design/visibilitymodifier/Example11",
             "checks/design/visibilitymodifier/Example12",

--- a/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/design/onetoplevelclass/Example2.java
+++ b/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/design/onetoplevelclass/Example2.java
@@ -9,7 +9,7 @@
 package com.puppycrawl.tools.checkstyle.checks.design.onetoplevelclass;
 
 // xdoc section -- start
-class Example2 { // ok, first top-level class
+public class Example2 { // ok, first top-level class
   // methods
 }
 


### PR DESCRIPTION
Example1 and Example2 both demonstrate the OneTopLevelClass violation but had different ASTs due to a missing `public` modifier in Example2.
This change makes Example2 AST-identical to Example1 and removes it from the suppression list. Example3 remains suppressed as it represents a different, non-violation use case.
Fixes #18435 