### PR TITLE
Issue #14084: Resolve CheckerFramework violations

### DIFF
--- a/config/checker-framework-suppressions/checker-nullness-optional-interning-suppressions.xml
+++ b/config/checker-framework-suppressions/checker-nullness-optional-interning-suppressions.xml
@@ -6469,7 +6469,6 @@
     </details>
   </checkerFrameworkError>
 
-
   <checkerFrameworkError unstable="false">
     <fileName>src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocTypeCheck.java</fileName>
     <specifier>dereference.of.nullable</specifier>
@@ -7619,17 +7618,6 @@
     <details>
       type of expression: @Initialized @Nullable Pattern
       method return type: @Initialized @NonNull Pattern
-    </details>
-  </checkerFrameworkError>
-
-  <checkerFrameworkError unstable="false">
-    <fileName>src/main/java/com/puppycrawl/tools/checkstyle/filters/SuppressFilterElement.java</fileName>
-    <specifier>return</specifier>
-    <message>incompatible types in return.</message>
-    <lineContent>return result;</lineContent>
-    <details>
-      type of expression: @Initialized @Nullable String
-      method return type: @Initialized @NonNull String
     </details>
   </checkerFrameworkError>
 

--- a/src/main/java/com/puppycrawl/tools/checkstyle/filters/SuppressFilterElement.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/filters/SuppressFilterElement.java
@@ -22,6 +22,8 @@ package com.puppycrawl.tools.checkstyle.filters;
 import java.util.Objects;
 import java.util.regex.Pattern;
 
+import javax.annotation.Nullable;
+
 import com.puppycrawl.tools.checkstyle.api.AuditEvent;
 import com.puppycrawl.tools.checkstyle.api.Filter;
 
@@ -210,6 +212,7 @@ public class SuppressFilterElement
      * @param pattern pattern object
      * @return value of pattern or null
      */
+    @Nullable
     private static String getPatternSafely(Pattern pattern) {
         String result = null;
         if (pattern != null) {


### PR DESCRIPTION
Issue:
#14084

In that case, @PolyNull means the nullness of the return value is the same as the nullness of Pattern.
https://checkerframework.org/manual/#qualifier-polymorphism-examples