### PR TITLE
Issue #18842: google_checks.xml incorrectly marks /** {@return the customer ID} */ as violation

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/SummaryJavadocCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/SummaryJavadocCheck.java
@@ -91,10 +91,22 @@ public class SummaryJavadocCheck extends AbstractJavadocCheck {
     /** Default period literal. */
     private static final String DEFAULT_PERIOD = ".";
 
+    /** Default empty regexp. */
+    private static final String DEFAULT_EMPTY_REGEXP = "^$";
+
+    /** Single whitespace string. */
+    private static final String SINGLE_SPACE = " ";
+
     /**
      * Specify the regexp for forbidden summary fragments.
      */
-    private Pattern forbiddenSummaryFragments = CommonUtil.createPattern("^$");
+    private Pattern forbiddenSummaryFragments = CommonUtil.createPattern(DEFAULT_EMPTY_REGEXP);
+
+    /**
+     * Specify the regexp for forbidden fragments in inline return tags.
+     */
+    private Pattern forbiddenInlineReturnFragments =
+            CommonUtil.createPattern(DEFAULT_EMPTY_REGEXP);
 
     /**
      * Specify the period symbol. Used to check the first sentence ends with a period. Periods that
@@ -117,6 +129,16 @@ public class SummaryJavadocCheck extends AbstractJavadocCheck {
      */
     public void setForbiddenSummaryFragments(Pattern pattern) {
         forbiddenSummaryFragments = pattern;
+    }
+
+    /**
+     * Setter to specify the regexp for forbidden fragments in inline return tags.
+     *
+     * @param pattern a pattern.
+     * @since 13.4.0
+     */
+    public void setForbiddenInlineReturnFragments(Pattern pattern) {
+        forbiddenInlineReturnFragments = pattern;
     }
 
     /**
@@ -307,7 +329,7 @@ public class SummaryJavadocCheck extends AbstractJavadocCheck {
             log(inlineReturnTag.getLineNumber(), inlineReturnTag.getColumnNumber(),
                     MSG_SUMMARY_JAVADOC_MISSING);
         }
-        else if (containsForbiddenFragment(inlineReturn)) {
+        else if (containsForbiddenInlineReturnFragment(inlineReturn)) {
             log(inlineReturnTag.getLineNumber(), inlineReturnTag.getColumnNumber(),
                     MSG_SUMMARY_JAVADOC);
         }
@@ -358,8 +380,20 @@ public class SummaryJavadocCheck extends AbstractJavadocCheck {
      */
     private boolean containsForbiddenFragment(String firstSentence) {
         final String javadocText = JAVADOC_MULTILINE_TO_SINGLELINE_PATTERN
-                .matcher(firstSentence).replaceAll(" ");
+                .matcher(firstSentence).replaceAll(SINGLE_SPACE);
         return forbiddenSummaryFragments.matcher(trimExcessWhitespaces(javadocText)).find();
+    }
+
+    /**
+     * Tests if inline return contains forbidden fragment.
+     *
+     * @param inlineReturn string with inline return content.
+     * @return {@code true} if inline return contains forbidden fragment.
+     */
+    private boolean containsForbiddenInlineReturnFragment(String inlineReturn) {
+        final String javadocText = JAVADOC_MULTILINE_TO_SINGLELINE_PATTERN
+                .matcher(inlineReturn).replaceAll(SINGLE_SPACE);
+        return forbiddenInlineReturnFragments.matcher(trimExcessWhitespaces(javadocText)).find();
     }
 
     /**

--- a/src/main/resources/com/puppycrawl/tools/checkstyle/meta/checks/javadoc/SummaryJavadocCheck.xml
+++ b/src/main/resources/com/puppycrawl/tools/checkstyle/meta/checks/javadoc/SummaryJavadocCheck.xml
@@ -20,6 +20,11 @@
  &lt;/p&gt;</description>
          <properties>
             <property default-value="^$"
+                      name="forbiddenInlineReturnFragments"
+                      type="java.util.regex.Pattern">
+               <description>Specify the regexp for forbidden fragments in inline return tags.</description>
+            </property>
+            <property default-value="^$"
                       name="forbiddenSummaryFragments"
                       type="java.util.regex.Pattern">
                <description>Specify the regexp for forbidden summary fragments.</description>

--- a/src/main/resources/google_checks.xml
+++ b/src/main/resources/google_checks.xml
@@ -395,6 +395,8 @@
     <module name="SummaryJavadoc">
       <property name="forbiddenSummaryFragments"
         value="^@return the *|^This method returns |^A [{]@code [a-zA-Z0-9]+[}]( is a )|^[a-z]"/>
+      <property name="forbiddenInlineReturnFragments"
+        value="^@return the *|^This method returns |^A [{]@code [a-zA-Z0-9]+[}]( is a )"/>
     </module>
     <module name="JavadocParagraph">
       <property name="allowNewlineParagraph" value="false"/>

--- a/src/site/xdoc/checks/javadoc/summaryjavadoc.xml
+++ b/src/site/xdoc/checks/javadoc/summaryjavadoc.xml
@@ -37,6 +37,13 @@
               <th>since</th>
             </tr>
             <tr>
+              <td><a id="forbiddenInlineReturnFragments"/><a href="#forbiddenInlineReturnFragments">forbiddenInlineReturnFragments</a></td>
+              <td>Specify the regexp for forbidden fragments in inline return tags.</td>
+              <td><a href="../../property_types.html#Pattern">Pattern</a></td>
+              <td><code>^$</code></td>
+              <td>13.4.0</td>
+            </tr>
+            <tr>
               <td><a id="forbiddenSummaryFragments"/><a href="#forbiddenSummaryFragments">forbiddenSummaryFragments</a></td>
               <td>Specify the regexp for forbidden summary fragments.</td>
               <td><a href="../../property_types.html#Pattern">Pattern</a></td>
@@ -133,6 +140,8 @@ class Example1 {
     &lt;module name="SummaryJavadoc"&gt;
       &lt;property name="forbiddenSummaryFragments"
         value="^This method returns.*"/&gt;
+      &lt;property name="forbiddenInlineReturnFragments"
+        value="^@return the .*|^This method returns.*|^A [{]@code \\w+[}]( is a )"/&gt;
     &lt;/module&gt;
   &lt;/module&gt;
 &lt;/module&gt;

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/javadoc/SummaryJavadocCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/javadoc/SummaryJavadocCheckTest.java
@@ -268,13 +268,50 @@ public class SummaryJavadocCheckTest extends AbstractModuleTestSupport {
     @Test
     public void testInlineReturnForbidden() throws Exception {
         final String[] expected = {
-            "14:8: " + getCheckMessage(MSG_SUMMARY_JAVADOC),
-            "21:8: " + getCheckMessage(MSG_SUMMARY_JAVADOC),
-            "28:8: " + getCheckMessage(MSG_SUMMARY_JAVADOC),
+            "15:8: " + getCheckMessage(MSG_SUMMARY_JAVADOC),
+            "22:8: " + getCheckMessage(MSG_SUMMARY_JAVADOC),
+            "29:8: " + getCheckMessage(MSG_SUMMARY_JAVADOC),
         };
 
         verifyWithInlineConfigParser(
                 getPath("InputSummaryJavadocInlineReturnForbidden.java"), expected);
+    }
+
+    @Test
+    public void testInlineReturnGoogle() throws Exception {
+        final String[] expected = {
+            "25:9: " + getCheckMessage(MSG_SUMMARY_JAVADOC),
+            "35:8: " + getCheckMessage(MSG_SUMMARY_JAVADOC),
+        };
+
+        verifyWithInlineConfigParser(
+                getPath("InputSummaryJavadocInlineReturnGoogle.java"), expected);
+    }
+
+    @Test
+    public void testInlineReturnGoogleAltPattern() throws Exception {
+        final String[] expected = {
+            "23:9: " + getCheckMessage(MSG_SUMMARY_JAVADOC),
+        };
+
+        verifyWithInlineConfigParser(
+                getPath("InputSummaryJavadocInlineReturnGoogleAltPattern.java"), expected);
+    }
+
+    @Test
+    public void testInlineReturnOnlyLowercase() throws Exception {
+        final String[] expected = {
+            "22:8: " + getCheckMessage(MSG_SUMMARY_JAVADOC),
+        };
+
+        verifyWithInlineConfigParser(
+                getPath("InputSummaryJavadocInlineReturnOnlyLowercase.java"), expected);
+    }
+
+    @Test
+    public void testInlineReturnDefault() throws Exception {
+        verifyWithInlineConfigParser(
+                getPath("InputSummaryJavadocInlineReturnDefault.java"));
     }
 
     @Test

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/summaryjavadoc/InputSummaryJavadocInlineReturnDefault.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/summaryjavadoc/InputSummaryJavadocInlineReturnDefault.java
@@ -1,0 +1,18 @@
+/*
+SummaryJavadoc
+
+*/
+
+package com.puppycrawl.tools.checkstyle.checks.javadoc.summaryjavadoc;
+
+public class InputSummaryJavadocInlineReturnDefault {
+    /** {@return the customer ID} */
+    int customerId() {
+        return 0;
+    }
+
+    /** {@return a customer object} */
+    Object getCustomer() {
+        return null;
+    }
+}

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/summaryjavadoc/InputSummaryJavadocInlineReturnForbidden.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/summaryjavadoc/InputSummaryJavadocInlineReturnForbidden.java
@@ -2,6 +2,7 @@
 SummaryJavadoc
 violateExecutionOnNonTightHtml = (default)false
 forbiddenSummaryFragments = the .*|This method returns
+forbiddenInlineReturnFragments = the .*|This method returns
 period = (default).
 
 */

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/summaryjavadoc/InputSummaryJavadocInlineReturnGoogle.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/summaryjavadoc/InputSummaryJavadocInlineReturnGoogle.java
@@ -1,0 +1,38 @@
+/*
+SummaryJavadoc
+violateExecutionOnNonTightHtml = (default)false
+forbiddenSummaryFragments = ^@return the *|^This method returns |^A \
+                            [{]@code [a-zA-Z0-9]+[}]( is a )|^[a-z]
+forbiddenInlineReturnFragments = ^@return the *|^This method returns |^A \
+                                  [{]@code [a-zA-Z0-9]+[}]( is a )
+period = (default).
+
+*/
+
+package com.puppycrawl.tools.checkstyle.checks.javadoc.summaryjavadoc;
+
+public class InputSummaryJavadocInlineReturnGoogle {
+    /** {@return the customer ID} */
+    int customerId() {
+        return 0;
+    }
+
+    /** {@return the nothing} */
+    int returnNothing() {
+        return 0;
+    }
+
+    /** {@return This method returns something} */ // violation 'Forbidden summary fragment.'
+    int returnSomething() {
+        return 0;
+    }
+
+    /** {@return a customer object} */
+    Object getCustomer() {
+        return null;
+    }
+
+    /** some javadoc. */ // violation 'Forbidden summary fragment.'
+    void someMethod() {
+    }
+}

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/summaryjavadoc/InputSummaryJavadocInlineReturnGoogleAltPattern.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/summaryjavadoc/InputSummaryJavadocInlineReturnGoogleAltPattern.java
@@ -1,0 +1,27 @@
+/*
+SummaryJavadoc
+violateExecutionOnNonTightHtml = (default)false
+forbiddenSummaryFragments = ^@return the *|^[a-z]|^This method returns
+forbiddenInlineReturnFragments = ^@return the *|^This method returns
+period = (default).
+
+*/
+
+package com.puppycrawl.tools.checkstyle.checks.javadoc.summaryjavadoc;
+
+public class InputSummaryJavadocInlineReturnGoogleAltPattern {
+    /** {@return the customer ID} */
+    int customerId() {
+        return 0;
+    }
+
+    /** {@return a customer object} */
+    Object getCustomer() {
+        return null;
+    }
+
+    /** {@return This method returns something} */ // violation 'Forbidden summary fragment.'
+    int returnSomething() {
+        return 0;
+    }
+}

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/summaryjavadoc/InputSummaryJavadocInlineReturnOnlyLowercase.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/summaryjavadoc/InputSummaryJavadocInlineReturnOnlyLowercase.java
@@ -1,0 +1,25 @@
+/*
+SummaryJavadoc
+violateExecutionOnNonTightHtml = (default)false
+forbiddenSummaryFragments = ^[a-z]
+period = (default).
+
+*/
+
+package com.puppycrawl.tools.checkstyle.checks.javadoc.summaryjavadoc;
+
+public class InputSummaryJavadocInlineReturnOnlyLowercase {
+    /** {@return the customer ID} */
+    int customerId() {
+        return 0;
+    }
+
+    /** {@return a customer object} */
+    Object getCustomer() {
+        return null;
+    }
+
+    /** some javadoc. */ // violation 'Forbidden summary fragment.'
+    void someMethod() {
+    }
+}

--- a/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/checks/javadoc/SummaryJavadocCheckExamplesTest.java
+++ b/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/checks/javadoc/SummaryJavadocCheckExamplesTest.java
@@ -49,11 +49,11 @@ public class SummaryJavadocCheckExamplesTest extends AbstractExamplesModuleTestS
     @Test
     public void testExample2() throws Exception {
         final String[] expected = {
-            "21:6: " + getCheckMessage(MSG_SUMMARY_JAVADOC_MISSING),
-            "25:6: " + getCheckMessage(MSG_SUMMARY_JAVADOC_MISSING),
-            "30:6: " + getCheckMessage(MSG_SUMMARY_JAVADOC_MISSING),
-            "39:6: " + getCheckMessage(MSG_SUMMARY_JAVADOC),
-            "45:5: " + getCheckMessage(MSG_SUMMARY_MISSING_PERIOD),
+            "23:6: " + getCheckMessage(MSG_SUMMARY_JAVADOC_MISSING),
+            "27:6: " + getCheckMessage(MSG_SUMMARY_JAVADOC_MISSING),
+            "32:6: " + getCheckMessage(MSG_SUMMARY_JAVADOC_MISSING),
+            "41:6: " + getCheckMessage(MSG_SUMMARY_JAVADOC),
+            "47:5: " + getCheckMessage(MSG_SUMMARY_MISSING_PERIOD),
         };
 
         verifyWithInlineConfigParser(getPath("Example2.java"), expected);

--- a/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/summaryjavadoc/Example2.java
+++ b/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/summaryjavadoc/Example2.java
@@ -4,6 +4,8 @@
     <module name="SummaryJavadoc">
       <property name="forbiddenSummaryFragments"
         value="^This method returns.*"/>
+      <property name="forbiddenInlineReturnFragments"
+        value="^@return the .*|^This method returns.*|^A [{]@code \\w+[}]( is a )"/>
     </module>
   </module>
 </module>


### PR DESCRIPTION
Issue #18842

## Summary:
- The check now uses the AST to identify inline return tags ({@return ...}) in Javadoc comments.
- When an inline return tag is found, the code only checks if its content is empty.
- It does NOT apply the forbidden summary fragments pattern (such as checking for lowercase starts or specific phrases) to inline return tags.
- This means constructs like /** {@return the customer ID} */ are allowed, matching the Google Java Style Guide and fixing the false positive reported in the issue.