### PR TITLE
Issue #18435: Fix OneTopLevelClass Example2 AST consistency

### DIFF
--- a/src/test/java/com/puppycrawl/tools/checkstyle/internal/XdocsExamplesAstConsistencyTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/internal/XdocsExamplesAstConsistencyTest.java
@@ -135,7 +135,6 @@ public class XdocsExamplesAstConsistencyTest {
             "checks/descendanttoken/Example7",
             "checks/descendanttoken/Example8",
             "checks/descendanttoken/Example9",
-            "checks/design/onetoplevelclass/Example2",
             "checks/design/onetoplevelclass/Example3",
             "checks/design/visibilitymodifier/Example11",
             "checks/design/visibilitymodifier/Example12",

--- a/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/design/onetoplevelclass/Example2.java
+++ b/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/design/onetoplevelclass/Example2.java
@@ -9,7 +9,7 @@
 package com.puppycrawl.tools.checkstyle.checks.design.onetoplevelclass;
 
 // xdoc section -- start
-class Example2 { // ok, first top-level class
+public class Example2 { // ok, first top-level class
   // methods
 }
 


### PR DESCRIPTION
Issue #18435 

Remove OneTopLevelClass Example2 from XdocsExamplesAstconsistencyTest.
Example 1 vs 2 : https://www.diffchecker.com/lZJMTCc7/