### PR TITLE
Issue #16969: Reduce width of side panel

### DIFF
--- a/src/site/resources/css/site.css
+++ b/src/site/resources/css/site.css
@@ -167,7 +167,9 @@ div, p, td, table td, th, table th, li, pre, #breadcrumbs span,
 }
 
 .sidebar-nav {
-  padding: 8px 4px 0 12px;
+  width: 240px;
+  padding: 8px 6px 0 10px;
+  box-sizing: border-box;
 }
 
 .nav-list {
@@ -511,3 +513,23 @@ section#Properties .wrapper table td a {
 html {
   scroll-behavior: smooth;
 }
+
+@media (max-width: 767px) {
+  .sidebar-nav {
+    width: 270px;
+    padding-left: 6px;
+    padding-right: 4px;
+    box-sizing: border-box;
+  }
+  .well.sidebar-nav {
+    padding-right: 0px;
+    padding-left: 6px;
+  }
+  .nav-list > li > a {
+    padding-right: 6px;
+  }
+  .nav-list > li > a::after {
+    right: 6px;
+  }
+}
+


### PR DESCRIPTION
Issue #16969 

# What was problem
The website sidebar occupies more horizontal space than required, which reduces
the available reading area for the main content.
This makes documentation pages feel compressed, especially on smaller screens.

---

# Solution
Adjusted the sidebar layout using CSS to reduce its effective width and spacing.
The change improves readability while keeping the existing structure and
navigation behavior unchanged.
Update sidebar rules in site.CSS.

Note-->This change is purely a UI/CSS enhancement.
Local mvn site execution may show a known JaCoCo/JXR issue unrelated to this
change, but CI site generation should not be affected.