### PR TITLE
Issue #16361: Updated testAddException in SarifLoggerTest exception test to use verifyWithInlineConfigParserAndLogger

### DIFF
--- a/src/test/java/com/puppycrawl/tools/checkstyle/SarifLoggerTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/SarifLoggerTest.java
@@ -158,20 +158,17 @@ public class SarifLoggerTest extends AbstractModuleTestSupport {
     }
 
     @Test
-    public void testAddException() throws IOException {
+    public void testAddException() throws Exception {
+        final String inputFile = "InputSarifLoggerSingleException.java";
+        final String expectedReportFile = "ExpectedSarifLoggerSingleException.sarif";
         final SarifLogger logger = new SarifLogger(outStream,
                 OutputStreamOptions.CLOSE);
-        logger.auditStarted(null);
-        final Violation message =
-                new Violation(1, 1,
-                        "messages.properties", "null", null, null,
-                        getClass(), "found an error");
-        final AuditEvent ev = new AuditEvent(this, null, message);
-        logger.fileStarted(ev);
-        logger.addException(ev, new TestException("msg", new RuntimeException("msg")));
-        logger.fileFinished(ev);
-        logger.auditFinished(null);
-        verifyContent(getPath("ExpectedSarifLoggerSingleException.sarif"), outStream);
+
+        verifyWithInlineConfigParserAndLogger(
+                getPath(inputFile),
+                getPath(expectedReportFile),
+                logger,
+                outStream);
     }
 
     @Test

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/sariflogger/InputSarifLoggerSingleException.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/sariflogger/InputSarifLoggerSingleException.java
@@ -1,0 +1,13 @@
+/*xml
+<module name="Checker">
+  <module name="TreeWalker">
+    <!-- This check does NOT exist and will cause ClassNotFoundException -->
+    <module name="com.puppycrawl.tools.checkstyle.checks.fake.NonExistentCheck"/>
+  </module>
+</module>
+*/
+package com.puppycrawl.tools.checkstyle.sariflogger;
+
+public class InputSarifLoggerSingleException {
+    int x = 1;
+}


### PR DESCRIPTION
Issue #16361

Refactored SarifLoggerTest#testAddException to use verifyWithInlineConfigParserAndLogger, aligning the test with real Checkstyle execution and existing logger tests.

Added InputSarifLoggerSingleException.java with inline XML configuration to reliably trigger an exception during analysis without manual logger invocation.