### PR TITLE
Issue #18882: Move Qodana config into config folder and update CI

### DIFF
--- a/.github/workflows/qodana.yml
+++ b/.github/workflows/qodana.yml
@@ -24,7 +24,10 @@ jobs:
         uses: JetBrains/qodana-action@v2025.3
         with:
           use-caches: false
-          args: --print-problems
+          args: >
+            --config,config/qodana.yml,
+            --profile-path,config/intellij-idea-inspections.xml,
+            --print-problems
 
       - name: Brief Report
         if: always()

--- a/config/qodana.yml
+++ b/config/qodana.yml
@@ -1,14 +1,12 @@
 version: 1.0
 
-linter: jetbrains/qodana-jvm-community:2025.3
+image: jetbrains/qodana-jvm-community:2025.3
 projectJDK: "21"
 
 failureConditions:
   severityThresholds:
     any: 0
 
-profile:
-  path: config/intellij-idea-inspections.xml
 
 exclude:
   - name: All

--- a/pom.xml
+++ b/pom.xml
@@ -1988,6 +1988,7 @@
                 <exclude>openrewrite-recipes-checkstyle.properties</exclude>
                 <exclude>org.eclipse.jdt.core.prefs</exclude>
                 <exclude>projects-to-test/**</exclude>
+                <exclude>qodana.yml</exclude>
                 <exclude>rewrite.yml</exclude>
                 <exclude>sarif-schema-2.1.0.json</exclude>
                 <exclude>signatures-test.txt</exclude>


### PR DESCRIPTION
Issue #18882

Moved `qodana.yml` into the `config/` directory and updated the Qodana GitHub Actions workflow to explicitly use `--config config/qodana.yml`.

Also excluded `qodana.yml` from `xml-maven-plugin` validation to prevent Maven from attempting to parse the YAML file as XML.

This keeps Qodana working as before while allowing the config to live under `config/` without breaking the Maven build.