### PR TITLE
Issue #18327: Replacing the clone link sponspowered

### DIFF
--- a/.ci/validation.sh
+++ b/.ci/validation.sh
@@ -323,8 +323,7 @@ no-error-configurate)
   echo "CS_version: ${CS_POM_VERSION}"
   ./mvnw -e --no-transfer-progress clean install -Pno-validations
   echo "Checkout target sources ..."
-  # until https://github.com/checkstyle/checkstyle/issues/18327
-  checkout_from "https://github.com/stoyanK7/Configurate.git"
+  checkout_from "https://github.com/SpongePowered/Configurate.git"
   cd .ci-temp/Configurate
   git fetch --depth 1 origin major-checkstyle-12:major-checkstyle-12
   git checkout major-checkstyle-12

--- a/config/jsoref-spellchecker/whitelist.words
+++ b/config/jsoref-spellchecker/whitelist.words
@@ -1318,7 +1318,6 @@ stemp
 stext
 sthref
 stmt
-stoyan
 streamapi
 strictfp
 stringliteralequality


### PR DESCRIPTION
Issue : #18327

Replacing the clone link from `https://github.com/stoyanK7/Configurate.git` in .ci/validation.ch
 To,
`https://github.com/SpongePowered/Configurate.git`