### PR TITLE
docs: Add DESCRIPTION token example with AST tree

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/api/JavadocCommentsTokenTypes.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/api/JavadocCommentsTokenTypes.java
@@ -1642,6 +1642,20 @@ public final class JavadocCommentsTokenTypes {
 
     /**
      * Description part of a Javadoc tag.
+     *
+     * <p><b>Example:</b></p>
+     * <pre>{@code * @param value The parameter description goes here.}</pre>
+     *
+     * <p><b>Tree:</b></p>
+     * <pre>{@code
+     * `--PARAM_BLOCK_TAG -> PARAM_BLOCK_TAG
+     *     |--AT_SIGN -> @
+     *     |--TAG_NAME -> param
+     *     |--TEXT ->
+     *     |--PARAMETER_NAME -> value
+     *     `--DESCRIPTION -> DESCRIPTION
+     *         `--TEXT ->  The parameter description goes here.
+     * }</pre>
      */
     public static final int DESCRIPTION = JavadocCommentsLexer.DESCRIPTION;
 


### PR DESCRIPTION
Issue: #17882 

**Command used**
```
java -jar checkstyle-13.2.0-all.jar -j src/Test.java | sed "s/\[[0-9]\+:[0-9]\+\]//g"
```

**Test.java**
```
:Test % cat src/Test.java 

/**
 * @param value The parameter description goes here.
 */
  public void Test(String value) {

  }
```

**AST**
```
Test % java -jar checkstyle-13.2.0-all.jar -j src/Test.java | sed "s/\[[0-9]\+:[0-9]\+\]//g"
JAVADOC_CONTENT -> JAVADOC_CONTENT [0:1]
|--TEXT -> /** [0:1]
|--NEWLINE -> \n [0:4]
|--LEADING_ASTERISK ->  * [1:1]
|--TEXT ->   [1:3]
`--JAVADOC_BLOCK_TAG -> JAVADOC_BLOCK_TAG [1:4]
    `--PARAM_BLOCK_TAG -> PARAM_BLOCK_TAG [1:4]
        |--AT_SIGN -> @ [1:4]
        |--TAG_NAME -> param [1:5]
        |--TEXT ->   [1:10]
        |--PARAMETER_NAME -> value [1:11]
        `--DESCRIPTION -> DESCRIPTION [1:16]
            |--TEXT ->  The parameter description goes here. [1:16]
            |--NEWLINE -> \n [1:53]
            |--LEADING_ASTERISK ->  * [2:1]
            |--TEXT -> / [2:3]
            |--NEWLINE -> \n [2:4]
            |--TEXT -> public void Test(String value) { [3:1]
            |--NEWLINE -> \n [3:33]
            |--NEWLINE -> \n [4:1]
            `--TEXT -> } [5:1]
```