### PR TITLE
Issue #17882: Update Javadoc for COLON token

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/api/JavadocCommentsTokenTypes.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/api/JavadocCommentsTokenTypes.java
@@ -1768,6 +1768,32 @@ public final class JavadocCommentsTokenTypes {
 
     /**
      * Colon symbol {@code : }.
+     *
+     * <p><b>Example:</b></p>
+     * <pre>{@code * {@snippet :config}}</pre>
+     *
+     * <p><b>Tree:</b></p>
+     * <pre>{@code
+     * JAVADOC_CONTENT -> JAVADOC_CONTENT
+     * |--TEXT -> /**
+     * |--NEWLINE -> \n
+     * |--LEADING_ASTERISK ->  *
+     * |--TEXT ->
+     * |--JAVADOC_INLINE_TAG -> JAVADOC_INLINE_TAG
+     * |   `--SNIPPET_INLINE_TAG -> SNIPPET_INLINE_TAG
+     * |       |--JAVADOC_INLINE_TAG_START -> {@
+     * |       |--COLON -> :
+     * |       |--SNIPPET_BODY -> SNIPPET_BODY
+     * |       |   `--TEXT -> config
+     * |       `--JAVADOC_INLINE_TAG_END -> }
+     * |--NEWLINE -> \n
+     * |--LEADING_ASTERISK ->  *
+     * |--TEXT -> /
+     * |--NEWLINE -> \n
+     * `--TEXT -> class Test {}
+     * }</pre>
+     *
+     * @see #SNIPPET_INLINE_TAG
      */
     public static final int COLON = JavadocCommentsLexer.COLON;
 


### PR DESCRIPTION
Issue #17882 – COLON Token Javadoc Update

## Description
Updated the Javadoc for the `COLON` token in `JavadocCommentsTokenTypes.java` to include an example and the corresponding AST tree.

## Technical Details

The following Javadoc snippet demonstrates the `COLON` token used inside a `{@snippet}` inline tag:

```java
/**
 * {@snippet :config}
 */
class Test {}
```

## Command Used

The AST was generated using the Checkstyle CLI with Javadoc AST output enabled.

```bash
java -jar target/checkstyle-13.3.0-SNAPSHOT-all.jar -j Test.java | ForEach-Object { $_ -replace '\[[0-9]+:[0-9]+\]', '' }
```

Line and column numbers were removed from the output for improved readability.

## AST Output

```
JAVADOC_CONTENT -> JAVADOC_CONTENT
|--TEXT -> /**
|--NEWLINE -> \n
|--LEADING_ASTERISK ->  *
|--TEXT ->
|--JAVADOC_INLINE_TAG -> JAVADOC_INLINE_TAG
|   `--SNIPPET_INLINE_TAG -> SNIPPET_INLINE_TAG
|       |--JAVADOC_INLINE_TAG_START -> {@
|       |--COLON -> :
|       |--SNIPPET_BODY -> SNIPPET_BODY
|       |   `--TEXT -> config
|       `--JAVADOC_INLINE_TAG_END -> }
|--NEWLINE -> \n
|--LEADING_ASTERISK ->  *
|--TEXT -> /
|--NEWLINE -> \n
`--TEXT -> class Test {}
```
