### PR TITLE
minor: Consolidate CI jobs like `validate-with-maven-script`

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,13 +1,12 @@
+name: CI
 version: 2.1
-
 jobs:
-
   validate-with-maven-script:
     description: Runs a maven script using the job name as the argument.
     parameters: &script_parameters
       image-name:
         type: string
-        default: cimg/openjdk:21.0.6
+        default: cimg/openjdk:21.0.8
         description: docker image to use
       command:
         description: command to run
@@ -36,7 +35,6 @@ jobs:
           paths:
             - .m2
             - .mvn/wrapper
-
   validate-with-script:
     description: Runs a non-maven script using the job name as the argument.
     parameters: *script_parameters
@@ -53,11 +51,9 @@ jobs:
             export PR_HEAD_SHA=$CIRCLE_SHA1
             export PR_NUMBER=$CIRCLE_PR_NUMBER
             << parameters.command >>
-
   sonarqube:
     docker:
-      - image: amitkumardeoghoria/jdk-21-groovy-git-mvn-ant-jq:v1
-
+      - image: &cs_img amitkumardeoghoria/jdk-21-groovy-git-mvn-ant-jq:v1
     steps:
       - checkout
       - run:
@@ -67,11 +63,9 @@ jobs:
             export PR_BRANCH_NAME=$CIRCLE_BRANCH
             export SONAR_API_TOKEN=$SONAR_TOKEN
             ./.ci/validation.sh sonarqube
-
   yamllint:
     docker:
       - image: cimg/base:2022.11
-
     steps:
       - checkout
       - run:
@@ -82,20 +76,13 @@ jobs:
       - run:
           name: Run yamllint
           command: yamllint -f parsable -c config/yamllint.yaml .
-
 workflows:
-  #  sonarqube:
-  #    jobs:
-  #      - sonarqube:
-  #          context:
-  #            - sonarqube
-
   test:
     jobs:
-      # no-exception-test script
+      # no-exception-test.sh jobs
       - validate-with-maven-script:
           name: no-exception-lucene-and-others-javadoc
-          image-name: &cs_img amitkumardeoghoria/jdk-21-groovy-git-mvn-ant-jq:v1
+          image-name: *cs_img
           command: ./.ci/no-exception-test.sh no-exception-lucene-and-others-javadoc
       - validate-with-maven-script:
           name: no-exception-cassandra-storm-tapestry-javadoc
@@ -109,16 +96,19 @@ workflows:
           name: no-exception-only-javadoc
           image-name: *cs_img
           command: ./.ci/no-exception-test.sh no-exception-only-javadoc
-
-      # validation script
       - validate-with-maven-script:
-          name: no-error-xwiki
-          image-name: cimg/openjdk:21.0.6
-          command: ./.ci/validation.sh no-error-xwiki
-      - validate-with-maven-script:
-          name: no-error-pmd
+          name: no-exception-samples-gradle
           image-name: *cs_img
-          command: ./.ci/validation.sh no-error-pmd
+          command: ./.ci/no-exception-test.sh no-exception-samples-gradle
+      - validate-with-maven-script:
+          name: no-exception-samples-maven
+          image-name: *cs_img
+          command: ./.ci/no-exception-test.sh no-exception-samples-maven
+      - validate-with-maven-script:
+          name: no-exception-samples-ant
+          image-name: *cs_img
+          command: ./.ci/no-exception-test.sh no-exception-samples-ant
+      # validation.sh no-exception jobs
       - validate-with-maven-script:
           name: no-exception-struts
           image-name: *cs_img
@@ -163,6 +153,32 @@ workflows:
           name: no-exception-alot-of-projects
           image-name: *cs_img
           command: ./.ci/validation.sh no-exception-alot-of-projects
+      # no-error jobs
+      - validate-with-maven-script:
+          name: no-error-xwiki
+          image-name: *cs_img
+          command: ./.ci/validation.sh no-error-xwiki
+      - validate-with-maven-script:
+          name: no-error-pmd
+          image-name: *cs_img
+          command: ./.ci/validation.sh no-error-pmd
+      - validate-with-maven-script:
+          name: no-error-test-sbe
+          image-name: *cs_img
+          command: ./.ci/validation.sh no-error-test-sbe
+      - validate-with-maven-script:
+          name: no-error-spotbugs
+          image-name: *cs_img
+          command: ./.ci/validation.sh no-error-spotbugs
+      - validate-with-maven-script:
+          name: no-error-pgjdbc
+          image-name: *cs_img
+          command: ./.ci/validation.sh no-error-pgjdbc
+      - validate-with-maven-script:
+          name: no-error-hazelcast
+          image-name: *cs_img
+          command: ./.ci/validation.sh no-error-hazelcast
+      # no-warning jobs
       - validate-with-maven-script:
           name: no-warning-imports-guava
           image-name: *cs_img
@@ -171,12 +187,11 @@ workflows:
           name: no-warning-imports-java-design-patterns
           image-name: *cs_img
           command: ./.ci/validation.sh no-warning-imports-java-design-patterns
+      # other validation jobs
       - validate-with-maven-script:
           name: checkstyle-and-sevntu
           image-name: *cs_img
           command: ./.ci/validation.sh checkstyle-and-sevntu
-      # https://github.com/spotbugs/spotbugs-maven-plugin/issues/806 explains
-      # why we need execution of spotbugs without any other maven plugins which can change binaries
       - validate-with-maven-script:
           name: spotbugs-and-pmd
           image-name: *cs_img
@@ -194,52 +209,48 @@ workflows:
           image-name: *cs_img
           command: ./.ci/validation.sh assembly-run-all-jar
       - validate-with-maven-script:
-          name: no-error-test-sbe
-          image-name: cimg/openjdk:21.0.6
-          command: ./.ci/validation.sh no-error-test-sbe
-      - validate-with-maven-script:
-          name: no-error-spotbugs
-          image-name: *cs_img
-          command: ./.ci/validation.sh no-error-spotbugs
-      - validate-with-maven-script:
-          name: no-error-pgjdbc
-          image-name: cimg/openjdk:21.0
-          command: ./.ci/validation.sh no-error-pgjdbc
-      - validate-with-maven-script:
           name: linkcheck-plugin
-          image-name: cimg/openjdk:21.0.6
+          image-name: *cs_img
           command: ./.ci/run-link-check-plugin.sh --skip-external
       - validate-with-maven-script:
-          name: no-exception-samples-gradle
-          image-name: cimg/openjdk:21.0.6
-          command: ./.ci/no-exception-test.sh no-exception-samples-gradle
-      - validate-with-maven-script:
-          name: no-exception-samples-maven
-          image-name: cimg/openjdk:21.0.6
-          command: ./.ci/no-exception-test.sh no-exception-samples-maven
-
-      - validate-with-maven-script:
-          name: no-exception-samples-ant
+          name: jdk21-package-site
           image-name: *cs_img
-          command: ./.ci/no-exception-test.sh no-exception-samples-ant
+          command: ./.ci/validation.sh package-site
       - validate-with-maven-script:
-          name: no-error-hazelcast
+          name: openrewrite-checkstyle-auto-fix
           image-name: *cs_img
-          command: ./.ci/validation.sh no-error-hazelcast
-
-  git-validation:
+          command: ./.ci/validation.sh openrewrite-checkstyle-auto-fix
+      - validate-with-maven-script:
+          name: openrewrite-refaster-rules-1
+          image-name: *cs_img
+          command: ./.ci/validation.sh openrewrite-refaster-rules-1
+      - validate-with-maven-script:
+          name: openrewrite-refaster-rules-2
+          image-name: *cs_img
+          command: ./.ci/validation.sh openrewrite-refaster-rules-2
+      - validate-with-maven-script:
+          name: openrewrite-static-analysis
+          image-name: *cs_img
+          command: ./.ci/validation.sh openrewrite-static-analysis
+      - validate-with-maven-script:
+          name: spotless
+          image-name: *cs_img
+          command: ./.ci/validation.sh spotless
+  git:
     jobs:
       - validate-with-script:
           name: git-no-merge-commits
+          image-name: *cs_img
           command: ./.ci/validation.sh git-no-merge-commits
       - validate-with-script:
           name: git-check-pull-number
+          image-name: *cs_img
           command: ./.ci/validation.sh git-check-pull-number
       - validate-with-script:
           name: git-check-single-commit
+          image-name: *cs_img
           command: ./.ci/validation.sh git-check-single-commit
-
-  cli-validation:
+  cli:
     jobs:
       - yamllint
       - validate-with-script:
@@ -250,17 +261,17 @@ workflows:
           command: ./.ci/validation.sh check-github-workflows-concurrency
       - validate-with-script:
           name: check-wildcards-on-pitest-target-classes
-          image-name: cimg/base:2022.11
+          image-name: *cs_img
           command: ./.ci/validation.sh check-wildcards-on-pitest-target-classes
-
-  javac-validation:
-    jobs:
       - validate-with-script:
           name: check-since-version
+          image-name: *cs_img
           command: ./.ci/validation.sh check-since-version
+  javac:
+    jobs:
       - validate-with-script:
           name: javac21
-          image-name: cimg/openjdk:21.0.6
+          image-name: cimg/openjdk:21.0.8
           command: ./.ci/validation.sh javac21
       - validate-with-script:
           name: java 21 test resources compile
@@ -274,36 +285,3 @@ workflows:
           name: javac25
           image-name: cimg/openjdk:25.0
           command: ./.ci/validation.sh javac25
-
-  site-validation:
-    jobs:
-      - validate-with-maven-script:
-          name: jdk21-package-site
-          image-name: *cs_img
-          command: ./.ci/validation.sh package-site
-
-  openrewrite:
-    jobs:
-      - validate-with-maven-script:
-          name: openrewrite-checkstyle-auto-fix
-          image-name: cimg/openjdk:21.0
-          command: ./.ci/validation.sh openrewrite-checkstyle-auto-fix
-      - validate-with-maven-script:
-          name: openrewrite-refaster-rules-1
-          image-name: cimg/openjdk:21.0
-          command: ./.ci/validation.sh openrewrite-refaster-rules-1
-      - validate-with-maven-script:
-          name: openrewrite-refaster-rules-2
-          image-name: cimg/openjdk:21.0
-          command: ./.ci/validation.sh openrewrite-refaster-rules-2
-      - validate-with-maven-script:
-          name: openrewrite-static-analysis
-          image-name: cimg/openjdk:21.0
-          command: ./.ci/validation.sh openrewrite-static-analysis
-
-  spotless:
-    jobs:
-      - validate-with-maven-script:
-          name: spotless
-          image-name: cimg/openjdk:21.0
-          command: ./.ci/validation.sh spotless


### PR DESCRIPTION
### minor: Consolidate CI jobs like `validate-with-maven-script`



pre: (distributed all over)

<img width="1875" height="617" alt="image" src="https://github.com/user-attachments/assets/f1106f12-c627-40b9-aea9-84342c2cfa17" />


now: (grouped and centralized)


<img width="1860" height="474" alt="image" src="https://github.com/user-attachments/assets/3b8cb733-7563-472e-b29e-2be81b82030a" />



SSOT/SPOT



1 vs 2 

<img width="847" height="456" alt="Image" src="https://github.com/user-attachments/assets/8c40e301-2596-4ad0-882b-105ee2dfc266" />


<img width="880" height="483" alt="Image" src="https://github.com/user-attachments/assets/17aa8534-8b92-4325-9c74-3f9cb17462f2" />