### PR TITLE
Issue #9806: Extract summary from nested HTML tags in SummaryJavadocC…

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/SummaryJavadocCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/SummaryJavadocCheck.java
@@ -463,6 +463,11 @@ public class SummaryJavadocCheck extends AbstractJavadocCheck {
                 if (tempNode.getType() == JavadocCommentsTokenTypes.TEXT) {
                     contents.append(tempNode.getText());
                 }
+                else {
+                    final DetailNode htmlContentToken = JavadocUtil.findFirstToken(
+                            tempNode, JavadocCommentsTokenTypes.HTML_CONTENT);
+                    contents.append(getStringInsideHtmlTag("", htmlContentToken));
+                }
                 tempNode = tempNode.getNextSibling();
             }
         }

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/javadoc/SummaryJavadocCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/javadoc/SummaryJavadocCheckTest.java
@@ -201,11 +201,10 @@ public class SummaryJavadocCheckTest extends AbstractModuleTestSupport {
             "58:8: " + getCheckMessage(MSG_SUMMARY_MISSING_PERIOD),
             "64:8: " + getCheckMessage(MSG_SUMMARY_FIRST_SENTENCE),
             "75:8: " + getCheckMessage(MSG_SUMMARY_MISSING_PERIOD),
-            // Until https://github.com/checkstyle/checkstyle/issues/11425
-            "82:8: " + getCheckMessage(MSG_SUMMARY_JAVADOC_MISSING),
-            "94:8: " + getCheckMessage(MSG_SUMMARY_MISSING_PERIOD),
-            "104:8: " + getCheckMessage(MSG_SUMMARY_MISSING_PERIOD),
-            "110:8: " + getCheckMessage(MSG_SUMMARY_JAVADOC_MISSING),
+            "81:8: " + getCheckMessage(MSG_SUMMARY_FIRST_SENTENCE),
+            "93:8: " + getCheckMessage(MSG_SUMMARY_MISSING_PERIOD),
+            "103:8: " + getCheckMessage(MSG_SUMMARY_MISSING_PERIOD),
+            "109:8: " + getCheckMessage(MSG_SUMMARY_JAVADOC_MISSING),
         };
 
         verifyWithInlineConfigParser(
@@ -409,10 +408,9 @@ public class SummaryJavadocCheckTest extends AbstractModuleTestSupport {
     @Test
     public void testSummaryJavadocLargeJavaDoc() throws Exception {
         final String[] expected = {
-            "13:4: " + getCheckMessage(MSG_SUMMARY_JAVADOC_MISSING),
-            "27:8: " + getCheckMessage(MSG_SUMMARY_FIRST_SENTENCE),
-            "41:8: " + getCheckMessage(MSG_SUMMARY_JAVADOC_MISSING),
-            "61:8: " + getCheckMessage(MSG_SUMMARY_JAVADOC_MISSING),
+            "26:8: " + getCheckMessage(MSG_SUMMARY_FIRST_SENTENCE),
+            "40:8: " + getCheckMessage(MSG_SUMMARY_JAVADOC_MISSING),
+            "60:8: " + getCheckMessage(MSG_SUMMARY_JAVADOC_MISSING),
         };
 
         verifyWithInlineConfigParser(
@@ -427,5 +425,27 @@ public class SummaryJavadocCheckTest extends AbstractModuleTestSupport {
 
         verifyWithInlineConfigParser(
                 getPath("InputSummaryJavadocForbiddenFragmentsTabFormatted.java"), expected);
+    }
+
+    @Test
+    public void testNestedHtmlSummary() throws Exception {
+        final String[] expected = {
+            "38:8: " + getCheckMessage(MSG_SUMMARY_FIRST_SENTENCE),
+            "44:8: " + getCheckMessage(MSG_SUMMARY_JAVADOC_MISSING),
+            "50:8: " + getCheckMessage(MSG_SUMMARY_JAVADOC_MISSING),
+            "56:8: " + getCheckMessage(MSG_SUMMARY_JAVADOC_MISSING),
+            "94:8: " + getCheckMessage(MSG_SUMMARY_FIRST_SENTENCE),
+        };
+
+        verifyWithInlineConfigParser(
+                getPath("InputSummaryJavadocNestedHtml.java"), expected);
+    }
+
+    @Test
+    public void testFirstSentenceSpansHtmlTags() throws Exception {
+        final String[] expected = CommonUtil.EMPTY_STRING_ARRAY;
+
+        verifyWithInlineConfigParser(
+                getPath("InputSummaryJavadocFirstSentenceSpansHtmlTags.java"), expected);
     }
 }

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/summaryjavadoc/InputSummaryJavadocFirstSentenceSpansHtmlTags.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/summaryjavadoc/InputSummaryJavadocFirstSentenceSpansHtmlTags.java
@@ -1,0 +1,32 @@
+/*
+SummaryJavadoc
+violateExecutionOnNonTightHtml = (default)false
+forbiddenSummaryFragments = (default)^$
+period = (default).
+
+
+*/
+
+package com.puppycrawl.tools.checkstyle.checks.javadoc.summaryjavadoc;
+
+/**
+ * Input for testing summary whose first sentence starts in one HTML block tag
+ * and ends with a period inside another, as rendered by the javadoc tool.
+ */
+public class InputSummaryJavadocFirstSentenceSpansHtmlTags {
+
+    /**
+     * <p>
+     * Defines how to configure a new named cache produced by this <code>FactoryBean</code>:
+     * <ul>
+     * <li>
+     * <code>NONE</code>: Configuration starts with a new <code>Configuration</code> instance.
+     * Note that this mode may only be used if no named configuration already exists.</li>
+     * <li>
+     * <code>DEFAULT</code>: Configuration starts with the <code>EmbeddedCacheManager</code>'s
+     * <em>default</em> <code>Configuration</code> instance.</li>
+     * </ul>
+     * </p>
+     */
+    public void foo1() {}
+}

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/summaryjavadoc/InputSummaryJavadocIncorrect3.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/summaryjavadoc/InputSummaryJavadocIncorrect3.java
@@ -77,8 +77,7 @@ public class InputSummaryJavadocIncorrect3 {
     public void testBreakTag() {
     }
 
-    // Until https://github.com/checkstyle/checkstyle/issues/11425
-    // violation below 'Summary javadoc is missing'
+    // violation below 'First sentence of Javadoc is missing an ending period.'
     /**
      * <ul>
      *   <li><i>This is the summary</i></li>

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/summaryjavadoc/InputSummaryJavadocLargeJavadoc.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/summaryjavadoc/InputSummaryJavadocLargeJavadoc.java
@@ -9,7 +9,6 @@ period = (default).
 
 package com.puppycrawl.tools.checkstyle.checks.javadoc.summaryjavadoc;
 
-// violation below 'Summary javadoc is missing.'
 /**
  * <body>
  * <p> This class is only meant for testing. </p>

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/summaryjavadoc/InputSummaryJavadocNestedHtml.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/summaryjavadoc/InputSummaryJavadocNestedHtml.java
@@ -1,0 +1,107 @@
+/*
+SummaryJavadoc
+violateExecutionOnNonTightHtml = (default)false
+forbiddenSummaryFragments = (default)^$
+period = (default).
+
+
+*/
+
+package com.puppycrawl.tools.checkstyle.checks.javadoc.summaryjavadoc;
+
+/**
+ * Input for testing summary javadoc inside nested HTML tags.
+ */
+public class InputSummaryJavadocNestedHtml {
+
+    /**
+     * <p><b>Summary Normal Javadoc.</b></p>
+     */
+    public void foo1() {}
+
+    /**
+     * <p><b><i>Deeply nested summary.</i></b></p>
+     */
+    public void foo2() {}
+
+    /**
+     * <b>Bold summary text.</b>
+     */
+    public void foo3() {}
+
+    /**
+     * <p><em>Emphasized summary.</em></p>
+     */
+    public void foo4() {}
+
+    // violation below 'First sentence of Javadoc is missing an ending period.'
+    /**
+     * <p><b>Summary without period</b></p>
+     */
+    public void foo5() {}
+
+    // violation below 'Summary javadoc is missing.'
+    /**
+     * <p><b></b></p>
+     */
+    public void foo6() {}
+
+    // violation below 'Summary javadoc is missing.'
+    /**
+     * <p></p>
+     */
+    public void foo7() {}
+
+    // violation below 'Summary javadoc is missing.'
+    /**
+     * <p><b><i></i></b></p>
+     */
+    public void foo8() {}
+
+    /**
+     * <ul>
+     *   <li>This is the summary.</li>
+     * </ul>
+     */
+    public void foo11() {}
+
+    /**
+     * <div><span>Summary inside div and span.</span></div>
+     */
+    public void foo9() {}
+
+    /**
+     * <p>First sentence with period. More text.</p>
+     */
+    public void foo10() {}
+
+    /**
+     * <p>Summary with <br> void element.</p>
+     */
+    public void foo12() {}
+
+    /**
+     * <p><div>Block tag nested inside inline tag.</div></p>
+     */
+    public void foo13() {}
+
+    /**
+     * <p>Summary with {@code inline} javadoc tag.</p>
+     */
+    public void foo14() {}
+
+    // violation below 'First sentence of Javadoc is missing an ending period.'
+    /**
+     * <pre><code>
+     *     int x = 1;
+     * </code></pre>
+     */
+    public void foo15() {}
+
+    /**
+     * <pre>
+     *     Preformatted text only.
+     * </pre>
+     */
+    public void foo16() {}
+}


### PR DESCRIPTION
Fixes #9806, #11425

getStringInsideHtmlTag now recursively descends into nested HTML elements to extract summary text. Previously, only direct children of the first HTML tag were checked, causing false positives for summaries wrapped in tags like `<p><b>text</b></p>`.