### PR TITLE
Grammar: support Java 25 statements before super() in constructors

### DIFF
--- a/src/main/resources/com/puppycrawl/tools/checkstyle/grammar/java/JavaLanguageParser.g4
+++ b/src/main/resources/com/puppycrawl/tools/checkstyle/grammar/java/JavaLanguageParser.g4
@@ -492,6 +492,7 @@ defaultValue
 // STATEMENTS / BLOCKS
 constructorBlock
     : LCURLY
+      blockStatement*
       explicitConstructorInvocation?
       blockStatement*
       RCURLY

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/grammar/java/InputJava25ConstructorBeforeSuper.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/grammar/java/InputJava25ConstructorBeforeSuper.java
@@ -1,0 +1,6 @@
+class InputJava25ConstructorBeforeSuper extends Base {
+    InputJava25ConstructorBeforeSuper() {
+        int x = 1;
+        super();
+    }
+}


### PR DESCRIPTION
Issue: #18913

### What
Updates Checkstyle Java grammar to support Java 25, which allows executable
statements before the explicit constructor invocation (`super()` / `this()`).

### Why
With Java 25, valid constructor bodies that contain statements before
`super()` cause Checkstyle to fail during parsing with:

`mismatched input '(' expecting ';'`

This results in Checkstyle crashing on valid Java source code.

### How
The grammar rule `constructorBlock` is updated to allow `blockStatement*`
both before and after `explicitConstructorInvocation`.

### Java version
Tested with Java 25.
