### PR TITLE
infra: restore inspection scope file for local IDEA setup

### DIFF
--- a/config/intellij-idea-inspection-scope.xml
+++ b/config/intellij-idea-inspection-scope.xml
@@ -1,0 +1,8 @@
+<!-- This file is used to set inspection scope
+     for local IntelliJ IDEA code analysis.
+     ATTENTION: this file is not used by TeamCity,
+     all excludes should be specified in build configuration -->
+<component name="DependencyValidationManager">
+  <scope name="Checkstyle Inspection Scope"
+         pattern="!file[checkstyle]:target//*&amp;&amp;!file:src/test/resources*//**&amp;&amp;!file:src/it/resources*//**&amp;&amp;!file:src/site/resources/js/google-analytics.js&amp;&amp;!file:src/site/resources/styleguides*//**&amp;&amp;!file:config/intellij-idea-inspections.properties&amp;&amp;!file:config/site-2.0.0.xsd&amp;&amp;!file[checkstyle]:.ci-temp//*&amp;&amp;!file[checkstyle]:bin//*&amp;&amp;!file[checkstyle]:.settings//*&amp;&amp;!file:.classpath&amp;&amp;!file:.project&amp;&amp;!file:.circleci/config.yml&amp;&amp;!file:config/projects-to-test/openjdk-projects-to-test-on.config&amp;&amp;!file:config/projects-for-no-exception-javadoc.config&amp;&amp;!file:.ci/pitest-survival-check-xml.groovy"/>
+</component>


### PR DESCRIPTION
infra:
This file was deleted in https://github.com/checkstyle/checkstyle/pull/18898, but its still used while setting up local development environment for the project