### PR TITLE
Issue #15456: Define violation messages for ModifiedControlVariableCheck

### DIFF
--- a/src/test/java/com/puppycrawl/tools/checkstyle/bdd/InlineConfigParser.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/bdd/InlineConfigParser.java
@@ -236,7 +236,6 @@ public final class InlineConfigParser {
      *  Until <a href="https://github.com/checkstyle/checkstyle/issues/15456">#15456</a>.
      */
     private static final Set<String> SUPPRESSED_CHECKS = Set.of(
-            "com.puppycrawl.tools.checkstyle.checks.coding.ModifiedControlVariableCheck",
             "com.puppycrawl.tools.checkstyle.checks.coding.MultipleStringLiteralsCheck",
             "com.puppycrawl.tools.checkstyle.checks.coding.StringLiteralEqualityCheck",
             "com.puppycrawl.tools.checkstyle.checks.coding.SuperFinalizeCheck",

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/modifiedcontrolvariable/InputModifiedControlVariableBothForLoops.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/modifiedcontrolvariable/InputModifiedControlVariableBothForLoops.java
@@ -18,14 +18,14 @@ class InputModifiedControlVariableBothForLoops
     {
         // violation :
         for (int i = 0; i < 1; i++) {
-            i++; // violation
+            i++; // violation 'Control variable 'i' is modified.'
         }
         for (int i = 0; i < 1; i++) {
-            i = i + 1; // violation
+            i = i + 1; // violation 'Control variable 'i' is modified.'
         }
         for (int i = 0; i < 1; i++) {
-            for (int j = 0; j < 1; i++) { // violation
-                --i; // violation
+            for (int j = 0; j < 1; i++) { // violation 'Control variable 'i' is modified.'
+                --i; // violation 'Control variable 'i' is modified.'
             }
         }
         for (int i = 0, j = 0; i < 1; i++) {
@@ -53,14 +53,14 @@ class InputModifiedControlVariableBothForLoops
         String[] sa = {"a", "b"};
         for(String s:sa) {}
         for(String s:sa) {
-            s = "new string"; // violation
+            s = "new string"; // violation 'Control variable 's' is modified.'
         }
         for(int i=0;i < 10;) {
             i++;
         }
         for (int i = 0, l = 0,m=0; l < 10; i++,m=m+2) {
             l++;
-            m++; // violation
+            m++; // violation 'Control variable 'm' is modified.'
         }
         for (int i = 0; i < 10; ) {
             i = 11;
@@ -71,8 +71,8 @@ class InputModifiedControlVariableBothForLoops
             w++;
         }
         for (int i=0,k=0; i<10 && k < 10; ++i,++k) {
-            i = i + 3; // violation
-            k = k + 4; // violation
+            i = i + 3; // violation 'Control variable 'i' is modified.'
+            k = k + 4; // violation 'Control variable 'k' is modified.'
         }
         for (int i = 0,j = 0 ; i <10; i++) {
             j++;
@@ -82,7 +82,7 @@ class InputModifiedControlVariableBothForLoops
             new NestedClass() {
                 public void method() {}
             };
-            v = "bad"; // violation
+            v = "bad"; // violation 'Control variable 'v' is modified.'
         }
         for (int i = 0; i < 10; i += 1) {
             for (i = 7; i < 10; i += 1) {}

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/modifiedcontrolvariable/InputModifiedControlVariableEnhancedForLoopVariable2.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/modifiedcontrolvariable/InputModifiedControlVariableEnhancedForLoopVariable2.java
@@ -22,7 +22,7 @@ public class InputModifiedControlVariableEnhancedForLoopVariable2 {
     void m2(int[] a) {
         for (int i = 0, j = 1; ; i++, j++) {
             for (int k : a) {
-                i++; // violation
+                i++; // violation 'Control variable 'i' is modified.'
             }
         }
     }

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/modifiedcontrolvariable/InputModifiedControlVariableEnhancedForLoopVariable3.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/modifiedcontrolvariable/InputModifiedControlVariableEnhancedForLoopVariable3.java
@@ -17,7 +17,7 @@ public class InputModifiedControlVariableEnhancedForLoopVariable3 {
     {
         final String[] lines = {"line1", "line2", "line3"};
         for (String line: lines) {
-            line = line.trim(); // violation
+            line = line.trim(); // violation 'Control variable 'line' is modified.'
         }
     }
 }

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/modifiedcontrolvariable/InputModifiedControlVariableTestVariousAssignments.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/modifiedcontrolvariable/InputModifiedControlVariableTestVariousAssignments.java
@@ -15,77 +15,77 @@ public class InputModifiedControlVariableTestVariousAssignments {
 
     void method() {
         for (int i=0,k=0; i<10 && k < 10; ++i,++k) {
-            i -= 3; // violation 'Control variable 'i' is modified'
-            k -= 4; // violation 'Control variable 'k' is modified'
+            i -= 3; // violation 'Control variable 'i' is modified.'
+            k -= 4; // violation 'Control variable 'k' is modified.'
         }
     }
 
     void method1() {
         for (int i=0,k=0; i<10 && k < 10; ++i,++k) {
-            i *= 3; // violation 'Control variable 'i' is modified'
-            k *= 4; // violation 'Control variable 'k' is modified'
+            i *= 3; // violation 'Control variable 'i' is modified.'
+            k *= 4; // violation 'Control variable 'k' is modified.'
         }
     }
 
     void method2() {
         for (int i=0,k=0; i<10 && k < 10; ++i,++k) {
-            i /= 3; // violation 'Control variable 'i' is modified'
-            k /= 4; // violation 'Control variable 'k' is modified'
+            i /= 3; // violation 'Control variable 'i' is modified.'
+            k /= 4; // violation 'Control variable 'k' is modified.'
         }
     }
 
     void method3() {
         for (int i=0,k=0; i<10 && k < 10; ++i,++k) {
-            i %= 3; // violation 'Control variable 'i' is modified'
-            k %= 4; // violation 'Control variable 'k' is modified'
+            i %= 3; // violation 'Control variable 'i' is modified.'
+            k %= 4; // violation 'Control variable 'k' is modified.'
         }
     }
 
     void method4() {
         for (int i=0,k=0; i<10 && k < 10; ++i,++k) {
-            i >>= 3; // violation 'Control variable 'i' is modified'
-            k >>= 4; // violation 'Control variable 'k' is modified'
+            i >>= 3; // violation 'Control variable 'i' is modified.'
+            k >>= 4; // violation 'Control variable 'k' is modified.'
         }
     }
     void method5() {
         for (int i=0,k=0; i<10 && k < 10; ++i,++k) {
-            i >>>= 3; // violation 'Control variable 'i' is modified'
-            k >>>= 4; // violation 'Control variable 'k' is modified'
+            i >>>= 3; // violation 'Control variable 'i' is modified.'
+            k >>>= 4; // violation 'Control variable 'k' is modified.'
         }
     }
 
     void method6() {
         for (int i=0,k=0; i<10 && k < 10; ++i,++k) {
-            i <<= 3; // violation 'Control variable 'i' is modified'
-            k <<= 4; // violation 'Control variable 'k' is modified'
+            i <<= 3; // violation 'Control variable 'i' is modified.'
+            k <<= 4; // violation 'Control variable 'k' is modified.'
         }
     }
 
     void method7() {
         for (int i=0,k=0; i<10 && k < 10; ++i,++k) {
-            i &= 3; // violation 'Control variable 'i' is modified'
-            k &= 4; // violation 'Control variable 'k' is modified'
+            i &= 3; // violation 'Control variable 'i' is modified.'
+            k &= 4; // violation 'Control variable 'k' is modified.'
         }
     }
 
     void method8() {
         for (int i=0,k=0; i<10 && k < 10; ++i,++k) {
-            i ^= 3; // violation 'Control variable 'i' is modified'
-            k ^= 4; // violation 'Control variable 'k' is modified'
+            i ^= 3; // violation 'Control variable 'i' is modified.'
+            k ^= 4; // violation 'Control variable 'k' is modified.'
         }
     }
 
     void method9() {
         for (int i=0,k=0; i<10 && k < 10; ++i,++k) {
-            i |= 3; // violation 'Control variable 'i' is modified'
-            k |= 4; // violation 'Control variable 'k' is modified'
+            i |= 3; // violation 'Control variable 'i' is modified.'
+            k |= 4; // violation 'Control variable 'k' is modified.'
         }
     }
 
     void method10() {
         for (int i=0,k=0; i<10 && k < 10; ++i,++k) {
-            i--; // violation 'Control variable 'i' is modified'
-            k--; // violation 'Control variable 'k' is modified'
+            i--; // violation 'Control variable 'i' is modified.'
+            k--; // violation 'Control variable 'k' is modified.'
         }
     }
 }


### PR DESCRIPTION
Issue #15456: Define explicit violation messages for ModifiedControlVariableCheck test input files.

## Changes
- Added violation messages to all test input files
- Removed `ModifiedControlVariableCheck` from SUPPRESSED_CHECKS in `InlineConfigParser.java`

## Build
`./mvnw clean test -Dtest=ModifiedControlVariableCheckTest`
<img width="1819" height="585" alt="image" src="https://github.com/user-attachments/assets/2142d848-786b-491c-b710-208cd8a61f41" />
