### PR TITLE
Issue #14870: Fix PMD violations UnnecessaryVarargsArrayCreation, Con…

### DIFF
--- a/config/pmd.xml
+++ b/config/pmd.xml
@@ -97,15 +97,6 @@
                     //MethodDeclaration[@Name='testUtilClassesImmutability']"/>
     </properties>
   </rule>
-  <rule ref="category/java/bestpractices.xml/UnnecessaryVarargsArrayCreation">
-    <properties>
-      <!-- until https://github.com/checkstyle/checkstyle/issues/14870 -->
-      <property name="violationSuppressXPath"
-                value="//ClassDeclaration[@SimpleName='CustomImportOrderCheckTest']
-                    //MethodDeclaration[@Name='testGetFullImportIdent']"/>
-    </properties>
-  </rule>
-
 
   <rule ref="category/java/documentation.xml">
     <!-- too much false positives -->
@@ -506,21 +497,6 @@
     <exclude name="UseStringBufferForStringAppends"/>
   </rule>
 
-  <rule ref="category/java/performance.xml/ConsecutiveAppendsShouldReuse">
-    <properties>
-      <!-- until https://github.com/checkstyle/checkstyle/issues/14870 -->
-      <property name="violationSuppressXPath"
-                value="//ClassDeclaration[@SimpleName='XMLLogger']
-                        //MethodDeclaration[@Name='encode']
-                | //ClassDeclaration[@SimpleName='InlineTagUtil']
-                      //MethodDeclaration[@Name='convertLinesToString']
-                | //ClassDeclaration[@SimpleName='XdocsPagesTest']
-                      //MethodDeclaration[@Name='validateViolationSection']
-                | //ClassDeclaration[@SimpleName='XdocsJavaDocsTest']
-                     //MethodDeclaration[@Name='createPropertiesText'
-                        or @Name='appendNodeText' or @Name='getAttributeText']"/>
-    </properties>
-  </rule>
   <rule ref="category/java/performance.xml/UseArraysAsList">
     <properties>
       <!-- until https://github.com/checkstyle/checkstyle/issues/14870 -->

--- a/src/main/java/com/puppycrawl/tools/checkstyle/XMLLogger.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/XMLLogger.java
@@ -280,9 +280,9 @@ public final class XMLLogger
                     if (Character.isISOControl(chr)) {
                         // true escape characters need '&' before, but it also requires XML 1.1
                         // until https://github.com/checkstyle/checkstyle/issues/5168
-                        sb.append("#x");
-                        sb.append(Integer.toHexString(chr));
-                        sb.append(';');
+                        sb.append("#x")
+                                .append(Integer.toHexString(chr))
+                                .append(';');
                     }
                     else {
                         sb.append(chr);

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/utils/InlineTagUtil.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/utils/InlineTagUtil.java
@@ -108,8 +108,8 @@ public final class InlineTagUtil {
     private static String convertLinesToString(String... lines) {
         final StringBuilder builder = new StringBuilder(1024);
         for (String line : lines) {
-            builder.append(line);
-            builder.append(LINE_FEED);
+            builder.append(line)
+                    .append(LINE_FEED);
         }
         return builder.toString();
     }

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/imports/CustomImportOrderCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/imports/CustomImportOrderCheckTest.java
@@ -414,7 +414,7 @@ public class CustomImportOrderCheckTest extends AbstractModuleTestSupport {
         final Class<?> clazz = CustomImportOrderCheck.class;
         final Object t = TestUtil.instantiate(clazz);
         final Object actual = TestUtil.invokeMethod(t, "getFullImportIdent",
-                Object.class, new Object[] {null});
+                Object.class, (Object) null);
 
         final String expected = "";
         assertWithMessage("Invalid getFullImportIdent result")

--- a/src/test/java/com/puppycrawl/tools/checkstyle/internal/XdocsJavaDocsTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/internal/XdocsJavaDocsTest.java
@@ -185,15 +185,15 @@ public class XdocsJavaDocsTest extends AbstractModuleTestSupport {
         }
 
         if (changeToTag) {
-            result.append("{@");
-            result.append(name);
-            result.append(' ');
+            result.append("{@")
+                    .append(name)
+                    .append(' ');
         }
         else {
-            result.append('<');
-            result.append(name);
-            result.append(getAttributeText(name, node.getAttributes()));
-            result.append('>');
+            result.append('<')
+                    .append(name)
+                    .append(getAttributeText(name, node.getAttributes()))
+                    .append('>');
         }
 
         if (newLineOpenAfter) {
@@ -215,9 +215,9 @@ public class XdocsJavaDocsTest extends AbstractModuleTestSupport {
             result.append('}');
         }
         else {
-            result.append("</");
-            result.append(name);
-            result.append('>');
+            result.append("</")
+                    .append(name)
+                    .append('>');
         }
     }
 
@@ -279,10 +279,10 @@ public class XdocsJavaDocsTest extends AbstractModuleTestSupport {
                 attrValue = attribute.getNodeValue();
             }
 
-            result.append(attrName);
-            result.append("=\"");
-            result.append(attrValue);
-            result.append('"');
+            result.append(attrName)
+                    .append("=\"")
+                    .append(attrValue)
+                    .append('"');
         }
 
         return result.toString();

--- a/src/test/java/com/puppycrawl/tools/checkstyle/internal/XdocsPagesTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/internal/XdocsPagesTest.java
@@ -1691,8 +1691,8 @@ public class XdocsPagesTest {
         final StringBuilder expectedText = new StringBuilder(120);
 
         for (String s : list) {
-            expectedText.append(s);
-            expectedText.append('\n');
+            expectedText.append(s)
+                    .append('\n');
         }
 
         if (!expectedText.isEmpty()) {


### PR DESCRIPTION
Issue #14870:

- Fix PMD `ConsecutiveAppendsShouldReuse` violations by chaining `.append()` calls in `XMLLogger`, `InlineTagUtil`, `XdocsJavaDocsTest`, and `XdocsPagesTest`
- Fix PMD `UnnecessaryVarargsArrayCreation` violation in `CustomImportOrderCheckTest`
- Remove corresponding PMD suppressions from `config/pmd.xml`
