### PR TITLE
Issue #18228: supressed indentation check

### DIFF
--- a/src/it/resources/com/google/checkstyle/test/chapter4formatting/rule489textblocks/InputFormattedTextBlocksIndentation.java
+++ b/src/it/resources/com/google/checkstyle/test/chapter4formatting/rule489textblocks/InputFormattedTextBlocksIndentation.java
@@ -35,12 +35,10 @@ public class InputFormattedTextBlocksIndentation {
 
   /** Somejavadoc. */
   public void textFuncIndenation2() {
-    // violation 2 lines below '.* incorrect indentation level 0, expected .* 8.'
     String e2 =
 """
 content of the block e2
 """;
-    // violation above '.* incorrect indentation level 0, expected .* 8.'
 
     getData(
         """

--- a/src/it/resources/com/google/checkstyle/test/chapter4formatting/rule489textblocks/InputTextBlocksIndentation.java
+++ b/src/it/resources/com/google/checkstyle/test/chapter4formatting/rule489textblocks/InputTextBlocksIndentation.java
@@ -36,12 +36,10 @@ public class InputTextBlocksIndentation {
 
   /** Somejavadoc. */
   public void textFuncIndenation2() {
-    // violation 2 lines below '.* incorrect indentation level 0, expected .* 8.'
-    String e2 = // false-positive, ok until #18228
+    String e2 = // zero indentation is allowed
 """
 content of the block e2
-"""; // false-positive, ok until #18228
-    // violation above '.* incorrect indentation level 0, expected .* 8.'
+""";
 
     // violation 2 lines below '.* incorrect indentation level 4, expected .* 6.'
     getData(

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/indentation/IndentationCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/indentation/IndentationCheck.java
@@ -172,6 +172,9 @@ public class IndentationCheck extends AbstractCheck {
      */
     private boolean forceStrictCondition;
 
+    /** Allow text block opening/closing quotes to start on left margin. */
+    private boolean allowTextBlockQuotesOnLeftMargin;
+
     /**
      * Getter to query strict indent level in line wrapping case. If value is true, line wrap indent
      * have to be same as lineWrappingIndentation parameter. If value is false, line wrap indent
@@ -193,6 +196,25 @@ public class IndentationCheck extends AbstractCheck {
      */
     public void setForceStrictCondition(boolean value) {
         forceStrictCondition = value;
+    }
+
+    /**
+     * Getter to query whether text block opening and closing quotes are allowed on left margin.
+     *
+     * @return {@code true} if text block quotes may start at column 0.
+     */
+    public boolean isAllowTextBlockQuotesOnLeftMargin() {
+        return allowTextBlockQuotesOnLeftMargin;
+    }
+
+    /**
+     * Setter to allow text block opening and closing quotes on left margin.
+     *
+     * @param value user's value of allowTextBlockQuotesOnLeftMargin.
+     * @since 13.3.0
+     */
+    public void setAllowTextBlockQuotesOnLeftMargin(boolean value) {
+        allowTextBlockQuotesOnLeftMargin = value;
     }
 
     /**

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/indentation/LineWrappingHandler.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/indentation/LineWrappingHandler.java
@@ -282,8 +282,17 @@ public class LineWrappingHandler {
      * @return true if node is line-starting node.
      */
     private boolean shouldProcessTextBlockLiteral(DetailAST node) {
-        return node.getType() != TokenTypes.TEXT_BLOCK_LITERAL_END
-                || expandedTabsColumnNo(node) == getLineStart(node);
+        final int nodeType = node.getType();
+        final boolean isTextBlockQuote = TokenUtil.isOfType(nodeType,
+                TokenTypes.TEXT_BLOCK_LITERAL_BEGIN,
+                TokenTypes.TEXT_BLOCK_LITERAL_END);
+        final boolean isZeroIndentedTextBlockQuote = isTextBlockQuote
+            && expandedTabsColumnNo(node) == 0
+            && indentCheck.isAllowTextBlockQuotesOnLeftMargin();
+
+        return !isZeroIndentedTextBlockQuote
+                && (nodeType != TokenTypes.TEXT_BLOCK_LITERAL_END
+                || expandedTabsColumnNo(node) == getLineStart(node));
     }
 
     /**

--- a/src/main/resources/com/puppycrawl/tools/checkstyle/meta/checks/indentation/IndentationCheck.xml
+++ b/src/main/resources/com/puppycrawl/tools/checkstyle/meta/checks/indentation/IndentationCheck.xml
@@ -45,6 +45,11 @@
  }
  &lt;/code&gt;&lt;/pre&gt;&lt;/div&gt;</description>
          <properties>
+            <property default-value="false"
+                      name="allowTextBlockQuotesOnLeftMargin"
+                      type="boolean">
+               <description>Allow text block opening and closing quotes on left margin.</description>
+            </property>
             <property default-value="4" name="arrayInitIndent" type="int">
                <description>Specify how far an array initialization should be indented when on next line.</description>
             </property>

--- a/src/main/resources/google_checks.xml
+++ b/src/main/resources/google_checks.xml
@@ -325,6 +325,7 @@
       <property name="caseIndent" value="2"/>
       <property name="throwsIndent" value="4"/>
       <property name="lineWrappingIndentation" value="4"/>
+      <property name="allowTextBlockQuotesOnLeftMargin" value="true"/>
       <property name="arrayInitIndent" value="2"/>
     </module>
 

--- a/src/site/xdoc/checks/misc/indentation.xml
+++ b/src/site/xdoc/checks/misc/indentation.xml
@@ -62,6 +62,13 @@ if ((condition1 &amp;&amp; condition2)
               <th>since</th>
             </tr>
             <tr>
+              <td><a id="allowTextBlockQuotesOnLeftMargin"/><a href="#allowTextBlockQuotesOnLeftMargin">allowTextBlockQuotesOnLeftMargin</a></td>
+              <td>Allow text block opening and closing quotes on left margin.</td>
+              <td><a href="../../property_types.html#boolean">boolean</a></td>
+              <td><code>false</code></td>
+              <td>13.3.0</td>
+            </tr>
+            <tr>
               <td><a id="arrayInitIndent"/><a href="#arrayInitIndent">arrayInitIndent</a></td>
               <td>Specify how far an array initialization should be indented when on next line.</td>
               <td><a href="../../property_types.html#int">int</a></td>
@@ -243,6 +250,7 @@ class Example2 {
   &lt;module name="TreeWalker"&gt;
     &lt;module name="Indentation"&gt;
       &lt;property name="forceStrictCondition" value="true"/&gt;
+            &lt;property name="allowTextBlockQuotesOnLeftMargin" value="true"/&gt;
     &lt;/module&gt;
   &lt;/module&gt;
 &lt;/module&gt;

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/indentation/IndentationCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/indentation/IndentationCheckTest.java
@@ -1398,6 +1398,24 @@ public class IndentationCheckTest extends AbstractModuleTestSupport {
             expected);
     }
 
+    // we can not use verifyWarns() due to usage of multi line string syntax in input
+    @Test
+    public void testTextBlockLiteralWithLeftMarginQuotesAllowed() throws Exception {
+        final DefaultConfiguration checkConfig = createModuleConfig(IndentationCheck.class);
+
+        checkConfig.addProperty("lineWrappingIndentation", "4");
+        checkConfig.addProperty("forceStrictCondition", "true");
+        checkConfig.addProperty("allowTextBlockQuotesOnLeftMargin", "true");
+        checkConfig.addProperty("tabWidth", "4");
+        final String[] expected = {
+            "29:17: " + getCheckMessage(MSG_ERROR, "\"\"\"", 16, 12),
+            "59:9: " + getCheckMessage(MSG_ERROR, "\"\"\"", 8, 12),
+            "78:15: " + getCheckMessage(MSG_ERROR, "\"\"\"", 14, 12),
+        };
+        verifyWarns(checkConfig, getPath("InputIndentationTextBlockWithLeftMarginQuotes.java"),
+            expected);
+    }
+
     @Test
     public void testValidNewKeywordWithForceStrictCondition() throws Exception {
         final DefaultConfiguration checkConfig = createModuleConfig(IndentationCheck.class);

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/indentation/indentation/InputIndentationTextBlockWithLeftMarginQuotes.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/indentation/indentation/InputIndentationTextBlockWithLeftMarginQuotes.java
@@ -1,0 +1,119 @@
+// Java17                                                                   //indent:0 exp:0
+package com.puppycrawl.tools.checkstyle.checks.indentation.indentation;     //indent:0 exp:0
+
+/* Config:                                                                  //indent:0 exp:0
+ * This test-input is intended to be checked using following configuration: //indent:1 exp:1
+ * tabWidth = 4                                                             //indent:1 exp:1
+ * lineWrappingIndentation = 4                                              //indent:1 exp:1
+ * forceStrictCondition = true                                              //indent:1 exp:1
+ */                                                                         //indent:1 exp:1
+
+public class InputIndentationTextBlockWithLeftMarginQuotes {                //indent:0 exp:0
+//below indent:4 exp:4
+    private static final String EXAMPLE = """
+        Example string""";                                                  //indent:8 exp:8
+//below indent:4 exp:4
+    private static final String GO1 = """
+    GO                                                                      //indent:4 exp:4
+""";                                                                        //indent:0 exp:0
+//below indent:4 exp:4
+    private static final String GO2 = """
+    GO                                                                      //indent:4 exp:4
+        """;                                                                //indent:8 exp:8
+
+    public void textBlockNoIndent() {                                       //indent:4 exp:4
+//below indent:8 exp:8
+        String contentW = ("""
+                -----1234--                                                 //indent:16 exp:16
+                -----1234--h-hh                                             //indent:16 exp:16
+                """);                                                       //indent:16 exp:12 warn
+//below indent:8 exp:8
+        String contentR = ("""
+                -----1234--                                                 //indent:16 exp:16
+                -----1234----                                               //indent:16 exp:16
+            """);                                                           //indent:12 exp:12
+//below indent:8 exp:8
+        if ("""
+              one more string""".equals(contentR)) {                        //indent:14 exp:14
+            System.out.println("This is string");                           //indent:12 exp:12
+        }                                                                   //indent:8 exp:8
+//below indent:8 exp:8
+        if (contentR.equals("""
+          stuff""")) {                                                      //indent:10 exp:10
+        }                                                                   //indent:8 exp:8
+        String a =                                                          //indent:8 exp:8
+//below indent:0 exp:0
+"""
+          3                                                                 //indent:10 exp:10
+          4                                                                 //indent:10 exp:10
+          5                                                                 //indent:10 exp:10
+          6                                                                 //indent:10 exp:10
+          7                                                                 //indent:10 exp:10
+"""                                                                         //indent:0 exp:0
+              ;                                                             //indent:14 exp:14
+    }                                                                       //indent:4 exp:4
+
+    private static void fooBlockAsArgument() {                              //indent:4 exp:4
+        String main =                                                       //indent:8 exp:8
+//below indent:8 exp:12 warn
+        """
+        public class Main {                                                 //indent:8 exp:8
+          public void kit(String args) {                                    //indent:10 exp:10
+            System.out.println("hello, world!");                            //indent:12 exp:12
+            if (args.length > 0) {                                          //indent:12 exp:12
+              long pid = ProcessHandle.current().pid();                     //indent:14 exp:14
+              System.exit(process.exitValue());                             //indent:14 exp:14
+            }                                                               //indent:12 exp:12
+          }                                                                 //indent:10 exp:10
+        }                                                                   //indent:8 exp:8
+            """;                                                            //indent:12 exp:12
+//below indent:8 exp:8
+        LOG.warn("""
+                    The following settings                                  //indent:20 exp:20
+                    {}                                                      //indent:20 exp:20
+                    Therefore returning error result.""",                   //indent:20 exp:20
+            GO2);                                                           //indent:12 exp:12
+        LOG.warn(                                                           //indent:8 exp:8
+//below indent:14 exp:12 warn
+              """
+              Failed to lidation; will ignore for now,                      //indent:14 exp:14
+              but it may fail later during runtime""",                      //indent:14 exp:14
+            GO1);                                                           //indent:12 exp:12
+    }                                                                       //indent:4 exp:4
+
+    public void fooBlockAsCondition() {                                     //indent:4 exp:4
+//below indent:8 exp:8
+        if (GO1.equalsIgnoreCase("""
+//below indent:14 exp:14
+              my other string""" + """
+//below indent:14 exp:14
+              plus this string""" + """
+              and also this one.""")) {                                     //indent:14 exp:14
+            System.out.println("this is my other string");}                 //indent:12 exp:12
+//below indent:8 exp:8
+        if ("""
+              one more string""".equals(GO2)) {                             //indent:14 exp:14
+            System.out.println("This is one more string");}                 //indent:12 exp:12
+//below indent:8 exp:8
+        if ("""
+//below indent:18 exp:18
+                  a""" + """
+                  bc""" == GO2) {                                           //indent:18 exp:18
+        }                                                                   //indent:8 exp:8
+        else {                                                              //indent:8 exp:8
+//below indent:12 exp:12
+            System.out.printf("""
+          day of the week                                                   //indent:10 exp:10
+              successfully got: "%s"},                                      //indent:14 exp:14
+                """, LOG.getNumberOfErrors());                              //indent:16 exp:16
+        }                                                                   //indent:8 exp:8
+    }                                                                       //indent:4 exp:4
+
+    public class LOG {                                                      //indent:4 exp:4
+        public static void warn(String block, String example){              //indent:8 exp:8
+        }                                                                   //indent:8 exp:8
+        static String getNumberOfErrors() {                                 //indent:8 exp:8
+            return "Example";                                               //indent:12 exp:12
+        }                                                                   //indent:8 exp:8
+    }                                                                       //indent:4 exp:4
+}                                                                           //indent:0 exp:0

--- a/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/checks/indentation/IndentationCheckExamplesTest.java
+++ b/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/checks/indentation/IndentationCheckExamplesTest.java
@@ -47,11 +47,11 @@ public class IndentationCheckExamplesTest extends AbstractExamplesModuleTestSupp
     @Test
     public void testExample3() throws Exception {
         final String[] expected = {
-            "27:22: " + getCheckMessage(MSG_ERROR, "int", 21, 8),
-            "39:17: " + getCheckMessage(MSG_ERROR, "||", 16, 12),
+            "28:22: " + getCheckMessage(MSG_ERROR, "int", 21, 8),
             "40:17: " + getCheckMessage(MSG_ERROR, "||", 16, 12),
-            "42:18: " + getCheckMessage(MSG_ERROR, ".", 17, 16),
+            "41:17: " + getCheckMessage(MSG_ERROR, "||", 16, 12),
             "43:18: " + getCheckMessage(MSG_ERROR, ".", 17, 16),
+            "44:18: " + getCheckMessage(MSG_ERROR, ".", 17, 16),
         };
         verifyWithInlineConfigParser(getPath("Example3.java"), expected);
     }

--- a/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/indentation/indentation/Example3.java
+++ b/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/indentation/indentation/Example3.java
@@ -3,6 +3,7 @@
   <module name="TreeWalker">
     <module name="Indentation">
       <property name="forceStrictCondition" value="true"/>
+            <property name="allowTextBlockQuotesOnLeftMargin" value="true"/>
     </module>
   </module>
 </module>


### PR DESCRIPTION
fixes #18228 
Root Cause: The [IndentationCheck] was checking line-wrapping indentation for all text block quotes, even when they legitimately appear at column 0 per Google style.

Solution: Modified the indentation check to suppress violations for text block quotes at column 0.