### PR TITLE
Issue #14631: Update RETURN_BLOCK_TAG Javadoc to new AST format

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/api/JavadocCommentsTokenTypes.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/api/JavadocCommentsTokenTypes.java
@@ -187,7 +187,7 @@ public final class JavadocCommentsTokenTypes {
     public static final int AT_SIGN = JavadocCommentsLexer.AT_SIGN;
 
     /**
-     * {@code @author} Javadoc block tag.
+nano src/main/java/com/puppycrawl/tools/checkstyle/api/JavadocCommentsTokenTypes.java     * {@code @author} Javadoc block tag.
      *
      * <p>Such Javadoc tag can have one child:</p>
      * <ol>
@@ -299,6 +299,40 @@ public final class JavadocCommentsTokenTypes {
      *
      * @see #JAVADOC_BLOCK_TAG
      */
+
+/**
+ * {@code @return} Javadoc block tag.
+ *
+ * <p>Such Javadoc tag can have one child:</p>
+ * <ol>
+ *   <li>{@link #DESCRIPTION}</li>
+ * </ol>
+ *
+ * <p><b>Example:</b></p>
+ * <pre>{@code
+ * /**
+ *  * @return result of computation
+ *  *\/
+ * }</pre>
+ *
+ * <b>Tree:</b>
+ * <pre>{@code
+ * JAVADOC_CONTENT -> JAVADOC_CONTENT
+ * |--TEXT -> /**
+ * |--NEWLINE -> \n
+ * |--LEADING_ASTERISK ->  *
+ * |--TEXT ->
+ * |--JAVADOC_BLOCK_TAG -> JAVADOC_BLOCK_TAG
+ * |   `--RETURN_BLOCK_TAG -> RETURN_BLOCK_TAG
+ * |       |--AT_SIGN -> @
+ * |       |--TAG_NAME -> return
+ * |       `--DESCRIPTION -> DESCRIPTION
+ * |           `--TEXT ->  result of computation
+ * }</pre>
+ *
+ * @see #JAVADOC_BLOCK_TAG
+ */
+
     public static final int RETURN_BLOCK_TAG = JavadocCommentsLexer.RETURN_BLOCK_TAG;
 
     /**


### PR DESCRIPTION
Example input (src/Test.java):

/**
 * @return result of computation
 */

Command used to generate AST:

java -jar target/checkstyle-13.3.0-SNAPSHOT-all.jar -j temp/Test.java | sed "s/\[[0-9]\+:[0-9]\+\]//g"

Output:
JAVADOC_CONTENT -> JAVADOC_CONTENT
|--TEXT -> /**
|--NEWLINE -> \n
|--LEADING_ASTERISK ->  *
|--TEXT ->
|--JAVADOC_BLOCK_TAG -> JAVADOC_BLOCK_TAG
|   `--RETURN_BLOCK_TAG -> RETURN_BLOCK_TAG
|       |--AT_SIGN -> @
|       |--TAG_NAME -> return
|       `--DESCRIPTION -> DESCRIPTION
|           |--TEXT ->  result of computation
|           |--NEWLINE -> \n
|           |--LEADING_ASTERISK ->  *
|           `--TEXT -> /
`--NEWLINE -> \n
