### PR TITLE
Issue #17449: Add XDocs example for WhitespaceAroundCheck

### DIFF
--- a/src/site/xdoc/checks/whitespace/whitespacearound.xml
+++ b/src/site/xdoc/checks/whitespace/whitespacearound.xml
@@ -629,6 +629,35 @@ class Example10 {
   }
 }
 </code></pre></div>
+        <hr class="example-separator"/>
+        <p id="Example11-config">
+          To configure the check to allow empty switch block statements:
+        </p>
+        <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
+&lt;module name="Checker"&gt;
+  &lt;module name="TreeWalker"&gt;
+    &lt;module name="WhitespaceAround"&gt;
+      &lt;property name="allowEmptySwitchBlockStatements" value="true"/&gt;
+    &lt;/module&gt;
+  &lt;/module&gt;
+&lt;/module&gt;
+</code></pre></div>
+        <p id="Example11-code">Example:</p>
+        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+class Example11 {
+  void example() {
+    int i = 0;
+    switch (i) {
+      case 1: {}
+    }
+
+    int a=4; // 2 violations
+    // ''=' is not preceded with whitespace.'
+    // ''=' is not followed by whitespace.'
+  }
+}
+</code></pre></div>
+
       </subsection>
 
       <subsection name="Example of Usage" id="WhitespaceAround_Example_of_Usage">

--- a/src/site/xdoc/checks/whitespace/whitespacearound.xml.template
+++ b/src/site/xdoc/checks/whitespace/whitespacearound.xml.template
@@ -173,6 +173,22 @@
                  value="resources/com/puppycrawl/tools/checkstyle/checks/whitespace/whitespacearound/Example10.java"/>
           <param name="type" value="code"/>
         </macro>
+        <hr class="example-separator"/>
+        <p id="Example11-config">
+          To configure the check to allow empty switch block statements:
+        </p>
+        <macro name="example">
+          <param name="path"
+                 value="resources/com/puppycrawl/tools/checkstyle/checks/whitespace/whitespacearound/Example11.java"/>
+          <param name="type" value="config"/>
+        </macro>
+        <p id="Example11-code">Example:</p>
+        <macro name="example">
+          <param name="path"
+                 value="resources/com/puppycrawl/tools/checkstyle/checks/whitespace/whitespacearound/Example11.java"/>
+          <param name="type" value="code"/>
+        </macro>
+
       </subsection>
 
       <subsection name="Example of Usage" id="WhitespaceAround_Example_of_Usage">

--- a/src/test/java/com/puppycrawl/tools/checkstyle/internal/XdocsExampleFileTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/internal/XdocsExampleFileTest.java
@@ -61,7 +61,6 @@ public class XdocsExampleFileTest {
             Map.entry("MissingJavadocTypeCheck", Set.of("skipAnnotations")),
             Map.entry("JavadocStyleCheck", Set.of("endOfSentenceFormat")),
             Map.entry("ConstantNameCheck", Set.of("applyToPackage", "applyToPrivate")),
-            Map.entry("WhitespaceAroundCheck", Set.of("allowEmptySwitchBlockStatements")),
             Map.entry("SuppressWarningsHolder", Set.of("aliasList")),
             Map.entry("IndentationCheck", Set.of(
                     "basicOffset",

--- a/src/test/java/com/puppycrawl/tools/checkstyle/internal/XdocsExamplesAstConsistencyTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/internal/XdocsExamplesAstConsistencyTest.java
@@ -266,6 +266,7 @@ public class XdocsExamplesAstConsistencyTest {
             "checks/whitespace/whitespacearound/Example7",
             "checks/whitespace/whitespacearound/Example8",
             "checks/whitespace/whitespacearound/Example9",
+            "checks/whitespace/whitespacearound/Example11",
             "filters/suppressionfilter/Example2",
             "filters/suppressionfilter/Example3",
             "filters/suppressionfilter/Example4",

--- a/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/checks/whitespace/WhitespaceAroundExamplesTest.java
+++ b/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/checks/whitespace/WhitespaceAroundExamplesTest.java
@@ -157,4 +157,15 @@ public class WhitespaceAroundExamplesTest extends AbstractExamplesModuleTestSupp
 
         verifyWithInlineConfigParser(getPath("Example10.java"), expected);
     }
+
+    @Test
+    public void testExample11() throws Exception {
+        final String[] expected = {
+            "21:10: " + getCheckMessage(MSG_WS_NOT_PRECEDED, "="),
+            "21:10: " + getCheckMessage(MSG_WS_NOT_FOLLOWED, "="),
+        };
+
+        verifyWithInlineConfigParser(getPath("Example11.java"), expected);
+    }
+
 }

--- a/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/whitespace/whitespacearound/Example11.java
+++ b/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/whitespace/whitespacearound/Example11.java
@@ -1,0 +1,26 @@
+/*xml
+<module name="Checker">
+  <module name="TreeWalker">
+    <module name="WhitespaceAround">
+      <property name="allowEmptySwitchBlockStatements" value="true"/>
+    </module>
+  </module>
+</module>
+*/
+
+package com.puppycrawl.tools.checkstyle.checks.whitespace.whitespacearound;
+
+// xdoc section -- start
+class Example11 {
+  void example() {
+    int i = 0;
+    switch (i) {
+      case 1: {}
+    }
+
+    int a=4; // 2 violations
+    // ''=' is not preceded with whitespace.'
+    // ''=' is not followed by whitespace.'
+  }
+}
+// xdoc section -- end


### PR DESCRIPTION
Issue #17449

**Description:**
Added missing XDocs example for WhitespaceAroundCheck property: `allowEmptySwitchBlockStatements`.

**Changes:**

- Created `Example11.java` demonstrating the property usage.
- Added test case `testExample11()` in `WhitespaceAroundExamplesTest.java`.
- Added  `Example11.java`  in `XdocsExamplesAstConsistencyTest.java`.
- Updated `whitespacearound.xml` to include the new example.
- Updated `whitespacearound.xml.template` to include the new example macro.
