### PR TITLE
Issue 14542

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -15,10 +15,12 @@ maintainers alike.**
 
 - [Code of Conduct](#code-of-conduct)
 - [Getting Started](#getting-started)
+- [Build](#build)
+- [Submitting Pull Requests](#submitting-pull-requests)
+- [Quality Matters](#quality-matters)
+- [Code Review](#code-review)
 - [Opening an Issue](#opening-an-issue)
 - [Reporting Security Issues](#reporting-security-issues)
-- [Submitting Pull Requests](#submitting-pull-requests)
-- [Code Review](#code-review)
 - [Google Summer of Code](#google-summer-of-code)
 - [Asking Questions](#asking-questions)
 - [Credits](#credits)
@@ -53,8 +55,57 @@ This project and everyone participating in it is governed by the
   If you see such comment created long time ago but issue is still open and no Pull created, please
   feel free to make a comment that you will try to do it.
 
+### Build
+
+The project follows a general maven layout and phases for its build.
+Generated jars will be in folder `target`.
+
+- Generate maven standard jar:
+
+```bash
+./mvnw clean install
+```
+
+- Generate maven standard jar and skip all validations/verifications:
+
+```bash
+./mvnw -P no-validations clean install
+```
+
+- Generate uber jar (checkstyle-all-X.XX.jar) to use our command line:
+
+```bash
+./mvnw -P assembly clean package
+```
+
 ## Submitting Pull Requests
 
+- The commit message must adhere to a certain format. It should be "Issue #Number:
+   Brief single-line message", where NUMBER is the issue number at GitHub
+   (see [an example](https://github.com/checkstyle/checkstyle/commit/9303fd9d971eb55cdfd62686ba2f5698edb2c83e)).
+    Small changes of configuration files, documentation fixes, etc.
+    can be contributed by starting the commit message with one of
+    "minor:", "config:", "infra:", "doc:", "dependency:" or "spelling:",
+    followed by a space and a brief single-line message.
+    "supplemental:" is used for PRs/commits that will support other,
+    more significant changes with format as
+    "supplemental: .... for Issue #XXXX" where "XXXX"
+    refers to the issue that requires this supplemental commit.
+    After submitting a Pull Request, it will be
+    automatically checked by our continuous integration (CI) systems,
+    including GitHub Workflows, CircleCI, and Azure Pipelines.
+    Therefore, please recheck after some minutes
+    that the CIs didn't find any issues with your changes.
+    If there are issues, please fix them by amending commit
+    (not by separate commit) and provide an
+    updated version of the same Pull Request.
+    At times we are busy with our day jobs. This means
+    that you might not always get an immediate answer.
+    You are not being ignored, and we value your work -
+    we might just be too busy to review your code,
+    especially if it is a bit complex.
+    If you don't get a response within two weeks,
+    feel free to send a reminder email about your tracker item.
 - **Read our pull request rules.** See [PR Rules](https://github.com/checkstyle/checkstyle/wiki/PR-rules).
 - **Comment on the issue.** When you decide which issue you would like to take up,
   please comment on the issue to let others know that you are working on it ("I am on it.").
@@ -63,13 +114,58 @@ This project and everyone participating in it is governed by the
   activity, feel free to ask if the issue is still being worked on.
 - **Read the Github docs.** Visit GitHub's [Pull Request Guide](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests)
   for information on how to submit a pull request.
-- **Follow the template.** Please follow the [CheckStyle Pull Request Template](https://github.com/checkstyle/checkstyle/blob/master/.github/PULL_REQUEST_TEMPLATE.md)
-  that is provided in the pull request description when submitting a pull request.
 - **Run maven build locally.** `mvn clean verify` should pass on your local before
   submitting a pull request.
+- Please create a
+  [Pull Request](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/about-pull-requests)
+  for your contribution.
+  In the Pull Request description, add any
+  explanations of the implementation nuances.
+- ATTENTION:
+   Please verify that the Pull Request contains ONLY
+   your intended changes and is based on the
+   most recent HEAD of our master branch.
+   Please read the Pull Request template for more requirements.
+- **Follow the template.** Please follow the [CheckStyle Pull Request Template](https://github.com/checkstyle/checkstyle/blob/master/.github/PULL_REQUEST_TEMPLATE.md)
+  that is provided in the pull request description when submitting a pull request.
 - **Keep the PR small.** If you are working on a large feature, consider breaking it up into
   smaller PRs that can be reviewed and merged independently. This makes it easier for
   reviewers to understand the changes and for maintainers to merge the PR.
+
+## Quality Matters
+
+We use a set of development tools to ensure that
+the quality of our code is kept at a high level.
+Like most projects today, we use JUnit to test our code.
+However, we do take this one step further and measure
+the coverage of our unit tests using [JaCoCo](https://www.eclemma.org/jacoco/).
+This means it is not sufficient to pass all tests,
+but the tests should ideally execute each line in the code,
+code coverage should be 100%.
+To generate the JaCoCo report, run the Maven command:
+
+```bash
+
+./mvnw clean test jacoco:restore-instrumented-classes jacoco:report@default-report .
+
+```
+
+Check the results of the report in
+target/site/jacoco/index.html in the project's root folder.
+Besides using unit testing, we obviously
+also use checkstyle to check its own code.
+The Maven command `./mvnw clean verify` must pass without any errors.
+
+If you add new end user features (Check, Filter, ....), remember
+to document them in JavaDoc of java classes and xdoc files
+that are used to generate that site.
+Please recheck the site and all bundles generated by `./mvnw clean site`
+
+We require regression testing for most functional changes,
+especially for check modules.
+See our
+[regression testing tool documentation](https://github.com/checkstyle/contribution/tree/master/checkstyle-tester#checkstyle-tester)
+for details.
 
 ## Code Review
 
@@ -111,6 +207,13 @@ Some points to consider when opening an issue:
   Provide as much information as you can, including steps to reproduce, stack traces, etc.
 - **Use [GitHub-flavored Markdown](https://help.github.com/en/github/writing-on-github/basic-writing-and-formatting-syntax).**
   Especially put code blocks and console outputs in backticks (```). This improves readability.
+- To report an issue please follow our practices page -
+  [How to report an bug and new module request?](https://checkstyle.sourceforge.io/report_issue.html)
+- As soon as one of admins of our project approved your idea you are good
+  to start implementation and you will be welcome with final code contribution.
+  Please do not expect that we will accept any code that you send to us.
+  Example of ideal [issue description](https://github.com/checkstyle/checkstyle/issues/258),
+  and how it is commented on fix [Pull Request](https://github.com/checkstyle/checkstyle/pull/601).
 
 ## Reporting Security Issues
 

--- a/config/jsoref-spellchecker/whitelist.words
+++ b/config/jsoref-spellchecker/whitelist.words
@@ -133,7 +133,6 @@ BTest
 btnfrs
 buf
 bugdatabase
-bugfixes
 Bunsubscribe
 bw
 BXOR

--- a/src/site/xdoc/contributing.xml
+++ b/src/site/xdoc/contributing.xml
@@ -1,188 +1,20 @@
 <?xml version="1.0" encoding="UTF-8"?>
-
-<document xmlns="http://maven.apache.org/XDOC/2.0"
-  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-  xsi:schemaLocation="http://maven.apache.org/XDOC/2.0 https://maven.apache.org/xsd/xdoc-2.0.xsd">
-
-  <head>
+<document>
+  <properties>
     <title>Contributing</title>
-  </head>
-
+  </properties>
   <body>
-    <section name="Content">
-      <macro name="toc">
-        <param name="fromDepth" value="1"/>
-        <param name="toDepth" value="1"/>
-      </macro>
-    </section>
-
-    <section name="Introduction">
-
+    <section name="Contributing">
       <p>
-        Hey, good to see you on this page. It means that you are
-        considering a contribution of your own work to the Checkstyle
-        project. We welcome anything: bugfixes, new check modules, unit
-        tests, documentation improvements, build process simplification,
-        etc.
-      </p>
-
-      <p>
-        This document assumes you are working with the GIT version of
-        checkstyle and that you are familiar with some standard
-        development tools (
-
-        <a href="https://git-scm.com">GIT</a>,
-        <a href="https://maven.apache.org">Maven</a>,
-        <a href="https://junit.org">JUnit</a>).
+        The contributing guidelines have moved to GitHub.
       </p>
       <p>
-        To start the development - visit our
-        <a href="beginning_development.html">Beginning Development</a> page.
-      </p>
-      <p>
-        <b>ATTENTION:</b> if you have idea how to improve Checkstyle please create issue on
-        our <a href="https://github.com/checkstyle/checkstyle/issues">tracking system</a>.
-        As soon as one of admins of our project approved your idea you are good to start
-        implementation and you will be welcome with final code contribution.
-        Please do not expect that we will accept any code that you send to us.
-        Example of ideal <a href="https://github.com/checkstyle/checkstyle/issues/258">
-        issue description</a>,
-        and how it is commented on fix <a href="https://github.com/checkstyle/checkstyle/pull/601">
-        Pull Request</a>.
+        Please see
+        <a href="https://github.com/checkstyle/checkstyle/blob/master/.github/CONTRIBUTING.md">
+          CONTRIBUTING.md
+        </a>
+        for the complete and up-to-date documentation.
       </p>
     </section>
-
-    <section name="Report An Issue">
-
-      <p>
-        All functional changes in the project must be linked to an approved issue.
-        The Issue number has to be referenced in the git commit message, see format below.
-      </p>
-
-      <p>
-        To report an issue please follow our practices page - <a href="report_issue.html">
-        How to report an issue?</a> (<a href="report_issue.html#How_to_report_a_bug.3F">
-        How to report a bug?</a>)
-      </p>
-    </section>
-
-    <section name="Build">
-      <p>
-        The project follows a general maven layout and phases for its build.
-        Generated jars will be in folder <code>target</code>.
-      </p>
-
-      <p>
-        Generate maven standard jar: <code>./mvnw clean install</code>
-        <br/>
-        Generate maven standard jar and skip all validations/verifications:
-        <code>./mvnw -P no-validations clean install</code>
-        <br/>
-        Generate uber jar (checkstyle-all-X.XX.jar) to use our
-        <a href="/cmdline.html">command line</a>:
-        <code>./mvnw -P assembly clean package</code>
-      </p>
-    </section>
-
-    <section name="Quality Matters">
-
-      <p>
-        We use a set of development tools to ensure that
-        the quality of our code is kept at a high level. Like
-        most projects today, we use JUnit to test our code. However, we
-        do take this one step further and measure the coverage of our
-        unit tests using
-
-        <a href="https://www.eclemma.org/jacoco/">JaCoCo</a>.
-
-        This means it is not sufficient to pass all tests, but the tests
-        should ideally execute each line in the code, code coverage should be 100%. To generate the
-        JaCoCo report, run the Maven command:
-        <br/>
-        <code>
-          ./mvnw clean test jacoco:restore-instrumented-classes
-          jacoco:report@default-report
-        </code>
-        .
-        <br/>
-        Check the results of the report in target/site/jacoco/index.html in the project's root
-        folder.
-      </p>
-
-      <p>
-        Besides using unit testing, we obviously also use checkstyle to
-        check its own code.
-      </p>
-
-      <p>
-        The Maven command <code>./mvnw clean verify</code> must pass
-        without any errors.
-      </p>
-
-      <p>
-        If you add new end user features (Check, Filter, ....), remember to document
-        them in JavaDoc of java classes and xdoc files that are used to generate that site.
-        Please recheck the site and all bundles generated by <code>./mvnw clean site</code>
-      </p>
-
-      <p>
-        We require regression testing for most functional changes, especially for check modules.
-        See our <a href=
-        "https://github.com/checkstyle/contribution/tree/master/checkstyle-tester#checkstyle-tester">
-        regression testing tool documentation</a> for details.
-      </p>
-    </section>
-
-    <section name="Submitting Your Contribution">
-
-      <p>
-        Once you have made sure that your changes pass the Maven command
-        <code>./mvnw clean verify</code>, the code coverage is of high
-        standard and everything is documented, then you are ready to
-        submit your work.
-      </p>
-
-      <p>
-        Please create a
-        <a href="https://help.github.com/articles/using-pull-requests/">Pull Request</a>
-        for your contribution. In the Pull Request description, add any explanations of the
-        implementation nuances. Please read the Pull Request template for more requirements.
-        <b>ATTENTION:</b> Please verify that the Pull Request contains ONLY your intended changes
-        and is based on the most recent HEAD of our master branch.
-      </p>
-
-      <p>
-        <b>ATTENTION:</b>The commit message must adhere to a certain format.
-        It should be "Issue #Number: Brief single-line message", where NUMBER is the issue number
-        at GitHub
-        (see
-        <a href="https://github.com/checkstyle/checkstyle/commit/9303fd9d971eb55cdfd62686ba2f5698edb2c83e">
-        an example</a>).
-        Small changes of configuration files, documentation fixes, etc. can be contributed by
-        starting the commit message with one of "minor:", "config:", "infra:", "doc:",
-        "dependency:" or "spelling:", followed by a space and a brief single-line message.
-        <br/>
-        "supplemental:" is used for PRs/commits that will support other, more significant
-        changes with format as "supplemental: .... for Issue #XXXX" where "XXXX" refers to the
-        issue that requires this supplemental commit.
-      </p>
-
-      <p>
-        After submitting a Pull Request, it will be automatically checked by our continuous
-        integration (CI) systems, including GitHub Workflows, CircleCI, and Azure Pipelines.
-        Therefore, please recheck after some minutes that the CIs didn't
-        find any issues with your changes. If there are issues, please fix them by amending
-        commit (not by separate commit) and provide an updated version of the same Pull Request.
-      </p>
-
-      <p>
-        At times we are busy with our day jobs. This means that
-        you might not always get an immediate answer. You are not being ignored,
-        and we value your work - we might just be too busy to review your code,
-        especially if it is a bit complex. If you don't get a response within two weeks,
-        feel free to send a reminder email about your tracker item.
-      </p>
-    </section>
-
   </body>
 </document>


### PR DESCRIPTION
#14542 

# What was problem
Contributing.xml didn't live onto Github, the problem was, in future if in case `some rules have to change or code then changes will done on two places which is complex `and `user will confuse to seeing two different contributing guidelines one on url another on Github(contributing.md)` so, we will live `contributing.xml` onto Github.

---

# Approach
on contributing.xml I show url of github of `contributing.md` --> whenever user will come and click on contributing section then that contributor will see that page has moved onto Github please click on given url .

---
 # Solution
I removed content of contributing.xml and show only contributing.md link
<img width="969" height="504" alt="image" src="https://github.com/user-attachments/assets/fc19213b-646a-4aaa-b9de-d0195765574e" />
