### PR TITLE
Issue #16807: update properties in input files for JavadocPackage

### DIFF
--- a/src/test/java/com/puppycrawl/tools/checkstyle/bdd/InlineConfigParser.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/bdd/InlineConfigParser.java
@@ -317,7 +317,6 @@ public final class InlineConfigParser {
             "com.puppycrawl.tools.checkstyle.checks.imports.ImportControlCheck",
             "com.puppycrawl.tools.checkstyle.checks.imports.ImportOrderCheck",
             "com.puppycrawl.tools.checkstyle.checks.javadoc.JavadocContentLocationCheck",
-            "com.puppycrawl.tools.checkstyle.checks.javadoc.JavadocPackageCheck",
             "com.puppycrawl.tools.checkstyle.checks.javadoc.JavadocParagraphCheck",
             "com.puppycrawl.tools.checkstyle.checks.javadoc.JavadocStyleCheck",
             "com.puppycrawl.tools.checkstyle.checks.javadoc.JavadocTypeCheck",

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadocpackage/InputJavadocPackageBadCls.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadocpackage/InputJavadocPackageBadCls.java
@@ -1,7 +1,7 @@
 /*
 JavadocPackage
-allowLegacy = false
-fileExtensions = java
+allowLegacy = (default)false
+fileExtensions = (default).java
 
 
 */

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadocpackage/InputJavadocPackageBadCls2.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadocpackage/InputJavadocPackageBadCls2.java
@@ -1,7 +1,7 @@
 /*
 JavadocPackage
 allowLegacy = true
-fileExtensions = java
+fileExtensions = (default).java
 
 
 */

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadocpackage/InputJavadocPackageBadTag.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadocpackage/InputJavadocPackageBadTag.java
@@ -1,7 +1,7 @@
 /*
 JavadocPackage
-allowLegacy = false
-fileExtensions = java
+allowLegacy = (default)false
+fileExtensions = (default).java
 
 
 */

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadocpackage/InputJavadocPackageClass.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadocpackage/InputJavadocPackageClass.java
@@ -1,7 +1,7 @@
 /*
 JavadocPackage
-allowLegacy = false
-fileExtensions = java
+allowLegacy = (default)false
+fileExtensions = (default).java
 
 
 */

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadocpackage/InputJavadocPackageNoJavadoc.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadocpackage/InputJavadocPackageNoJavadoc.java
@@ -1,7 +1,7 @@
 /*
 JavadocPackage
-allowLegacy = false
-fileExtensions = java
+allowLegacy = (default)false
+fileExtensions = (default).java
 
 
 */

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadocpackage/InputJavadocPackageNotJava.txt
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadocpackage/InputJavadocPackageNotJava.txt
@@ -1,5 +1,8 @@
 /*
 JavadocPackage
+allowLegacy = (default)false
+fileExtensions = (default).java
+
 
 */
 

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadocpackage/annotation/package-info.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadocpackage/annotation/package-info.java
@@ -1,5 +1,8 @@
 /*
 JavadocPackage
+allowLegacy = (default)false
+fileExtensions = (default).java
+
 
 */
 

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadocpackage/bothfiles/InputJavadocPackageBothIgnored.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadocpackage/bothfiles/InputJavadocPackageBothIgnored.java
@@ -1,7 +1,7 @@
 /*
 JavadocPackage
-allowLegacy = false
-fileExtensions = java
+allowLegacy = (default)false
+fileExtensions = (default).java
 
 
 */

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadocpackage/noparentfile/package-info.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadocpackage/noparentfile/package-info.java
@@ -1,5 +1,8 @@
 /*
 JavadocPackage
+allowLegacy = (default)false
+fileExtensions = (default).java
+
 
 */
 

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadocpackage/pkghtml/InputJavadocPackageHtmlIgnored.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadocpackage/pkghtml/InputJavadocPackageHtmlIgnored.java
@@ -1,7 +1,7 @@
 /*
 JavadocPackage
-allowLegacy = false
-fileExtensions = java
+allowLegacy = (default)false
+fileExtensions = (default).java
 
 
 */

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadocpackage/pkghtml/InputJavadocPackageHtmlIgnored2.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadocpackage/pkghtml/InputJavadocPackageHtmlIgnored2.java
@@ -1,7 +1,7 @@
 /*
 JavadocPackage
 allowLegacy = true
-fileExtensions = java
+fileExtensions = (default).java
 
 
 */


### PR DESCRIPTION
Issue [#16807](https://github.com/checkstyle/checkstyle/issues/16807)
This PR updates all input files for `JavadocPackageCheck` to explicitly specify all default properties using the `(default)` tag format.