### PR TITLE
Issue #18614: Add regression test for indentation of constructor parameters inside try block

### DIFF
--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/indentation/IndentationCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/indentation/IndentationCheckTest.java
@@ -4256,6 +4256,20 @@ public class IndentationCheckTest extends AbstractModuleTestSupport {
         verifyWarns(checkConfig, fileName, expected);
     }
 
+    @Test
+    public void testTryBlockConstructorParameters() throws Exception {
+        final DefaultConfiguration checkConfig = createModuleConfig(IndentationCheck.class);
+        checkConfig.addProperty("basicOffset", "4");
+        checkConfig.addProperty("braceAdjustment", "0");
+        checkConfig.addProperty("caseIndent", "4");
+        checkConfig.addProperty("lineWrappingIndentation", "8");
+        checkConfig.addProperty("tabWidth", "4");
+
+        final String fileName = getPath("InputIndentationTryCtorParams.java");
+        final String[] expected = CommonUtil.EMPTY_STRING_ARRAY;
+        verifyWarns(checkConfig, fileName, expected);
+    }
+
     private static final class IndentAudit implements AuditListener {
 
         private final IndentComment[] comments;

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/indentation/indentation/InputIndentationTryCtorParams.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/indentation/indentation/InputIndentationTryCtorParams.java
@@ -1,0 +1,29 @@
+/**                                                                          //indent:0 exp:0
+ * This test-input is intended to be checked using following configuration:  //indent:1 exp:1
+ *                                                                           //indent:1 exp:1
+ * basicOffset = 4                                                           //indent:1 exp:1
+ * braceAdjustment = 0                                                       //indent:1 exp:1
+ * caseIndent = 4                                                            //indent:1 exp:1
+ * lineWrappingIndentation = 8                                               //indent:1 exp:1
+ * tabWidth = 4                                                              //indent:1 exp:1
+ */                                                                          //indent:1 exp:1
+
+package com.puppycrawl.tools.checkstyle.checks.indentation.indentation;      //indent:0 exp:0
+
+public class InputIndentationTryCtorParams {                                 //indent:0 exp:0
+
+    private InputIndentationTryCtorParams client;                            //indent:4 exp:4
+
+    private InputIndentationTryCtorParams(String string) {                   //indent:4 exp:4
+    }                                                                        //indent:4 exp:4
+
+    private void test() {                                                    //indent:4 exp:4
+        try {                                                                //indent:8 exp:8
+            client = new InputIndentationTryCtorParams(                      //indent:12 exp:12
+                    null                                                     //indent:20 exp:20
+            );                                                               //indent:12 exp:12
+        }                                                                    //indent:8 exp:8
+        catch (Exception e) {                                                //indent:8 exp:8
+        }                                                                    //indent:8 exp:8
+    }                                                                        //indent:4 exp:4
+}                                                                            //indent:0 exp:0


### PR DESCRIPTION
Closes #18614

The issue reported a false positive indentation violation
for constructor parameters inside a try block.

The issue is no longer reproducible in the current version of `checkstyle-13.3.0-all.jar`.
This PR adds a regression test to ensure the behavior
does not reappear in the future.

The test verifies that no indentation violations are
reported for properly indented constructor parameters
inside a try block.
