### PR TITLE
Issue #16807: update properties for BooleanExpressionComplexity

### DIFF
--- a/src/test/java/com/puppycrawl/tools/checkstyle/bdd/InlineConfigParser.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/bdd/InlineConfigParser.java
@@ -326,7 +326,6 @@ public final class InlineConfigParser {
             "com.puppycrawl.tools.checkstyle.checks.javadoc.MissingJavadocTypeCheck",
             "com.puppycrawl.tools.checkstyle.checks.javadoc.SummaryJavadocCheck",
             "com.puppycrawl.tools.checkstyle.checks.javadoc.WriteTagCheck",
-            "com.puppycrawl.tools.checkstyle.checks.metrics.BooleanExpressionComplexityCheck",
             "com.puppycrawl.tools.checkstyle.checks.metrics.ClassFanOutComplexityCheck",
             "com.puppycrawl.tools.checkstyle.checks.metrics.CyclomaticComplexityCheck",
             "com.puppycrawl.tools.checkstyle.checks.modifier.RedundantModifierCheck",

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/metrics/booleanexpressioncomplexity/InputBooleanExpressionComplexityLeaves.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/metrics/booleanexpressioncomplexity/InputBooleanExpressionComplexityLeaves.java
@@ -1,5 +1,7 @@
 /*
 BooleanExpressionComplexity
+max = (default)3
+tokens = (default)LAND, BAND, LOR, BOR, BXOR
 
 
 */

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/metrics/booleanexpressioncomplexity/InputBooleanExpressionComplexityRecordLeaves.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/metrics/booleanexpressioncomplexity/InputBooleanExpressionComplexityRecordLeaves.java
@@ -1,5 +1,7 @@
 /*
 BooleanExpressionComplexity
+max = (default)3
+tokens = (default)LAND, BAND, LOR, BOR, BXOR
 
 
 */


### PR DESCRIPTION
Issue [#16807](https://github.com/checkstyle/checkstyle/issues/16807)
This PR updates all input files for `BooleanExpressionComplexity` to explicitly specify all default properties using the `(default)` tag format.