### PR TITLE
Issue #18939: Top comment should 'Compilable with Java22'

### DIFF
--- a/src/it/resources/org/checkstyle/suppressionxpathfilter/coding/missingnullcaseinswitch/InputXpathMissingNullCaseInSwitchNested.java
+++ b/src/it/resources/org/checkstyle/suppressionxpathfilter/coding/missingnullcaseinswitch/InputXpathMissingNullCaseInSwitchNested.java
@@ -1,4 +1,4 @@
-// Java21
+// non-compiled with javac: Compilable with Java22
 package org.checkstyle.suppressionxpathfilter.coding.missingnullcaseinswitch;
 
 public class InputXpathMissingNullCaseInSwitchNested {

--- a/src/it/resources/org/checkstyle/suppressionxpathfilter/coding/missingnullcaseinswitch/InputXpathMissingNullCaseInSwitchSimple.java
+++ b/src/it/resources/org/checkstyle/suppressionxpathfilter/coding/missingnullcaseinswitch/InputXpathMissingNullCaseInSwitchSimple.java
@@ -1,4 +1,4 @@
-// Java21
+// non-compiled with javac: Compilable with Java22
 package org.checkstyle.suppressionxpathfilter.coding.missingnullcaseinswitch;
 
 public class InputXpathMissingNullCaseInSwitchSimple {


### PR DESCRIPTION
Fixes #18939

### Description
Updated the top comments in the `missingnullcaseinswitch` test input files from `// Java21` to `// non-compiled with javac: Compilable with Java22`. 