### PR TITLE
Issue #17449: add missing XDocs examples for ConstantNameCheck

### DIFF
--- a/src/site/xdoc/checks/naming/constantname.xml
+++ b/src/site/xdoc/checks/naming/constantname.xml
@@ -148,6 +148,60 @@ class Example3 {
   final static int MYSELF = 100;
   protected final static int myselfConstant = 1;
 }
+</code></pre></div><hr class="example-separator"/>
+        <p id="Example4-config">
+          The following configuration skip validation on private constant field.
+        </p>
+
+        <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
+&lt;module name="Checker"&gt;
+  &lt;module name="TreeWalker"&gt;
+    &lt;module name="ConstantName"&gt;
+      &lt;property name="applyToPrivate" value="false"/&gt;
+    &lt;/module&gt;
+  &lt;/module&gt;
+&lt;/module&gt;
+</code></pre></div>
+        <p id="Example4-code">Code Example:</p>
+        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+class Example4 {
+  public final static int FIRST_CONSTANT1 = 10;
+  protected final static int SECOND_CONSTANT2 = 100;
+  final static int third_Constant3 = 1000; // violation 'must match pattern'
+  private final static int fourth_Const4 = 50;
+  public final static int log = 10; // violation 'must match pattern'
+  protected final static int logger = 50; // violation 'must match pattern'
+  final static int loggerMYSELF = 5; // violation 'must match pattern'
+  final static int MYSELF = 100;
+  protected final static int myselfConstant = 1; // violation 'must match pattern'
+}
+</code></pre></div><hr class="example-separator"/>
+        <p id="Example5-config">
+          The following configuration skip validation on package-private constant field.
+        </p>
+
+        <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
+&lt;module name="Checker"&gt;
+  &lt;module name="TreeWalker"&gt;
+    &lt;module name="ConstantName"&gt;
+      &lt;property name="applyToPackage" value="false"/&gt;
+    &lt;/module&gt;
+  &lt;/module&gt;
+&lt;/module&gt;
+</code></pre></div>
+        <p id="Example5-code">Code Example:</p>
+        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+class Example5 {
+  public final static int FIRST_CONSTANT1 = 10;
+  protected final static int SECOND_CONSTANT2 = 100;
+  final static int third_Constant3 = 1000;
+  private final static int fourth_Const4 = 50; // violation 'must match pattern'
+  public final static int log = 10; // violation 'must match pattern'
+  protected final static int logger = 50; // violation 'must match pattern'
+  final static int loggerMYSELF = 5;
+  final static int MYSELF = 100;
+  protected final static int myselfConstant = 1; // violation 'must match pattern'
+}
 </code></pre></div>
       </subsection>
 

--- a/src/site/xdoc/checks/naming/constantname.xml.template
+++ b/src/site/xdoc/checks/naming/constantname.xml.template
@@ -72,6 +72,36 @@
           <param name="path"
                  value="resources/com/puppycrawl/tools/checkstyle/checks/naming/constantname/Example3.java"/>
           <param name="type" value="code"/>
+        </macro><hr class="example-separator"/>
+        <p id="Example4-config">
+          The following configuration skip validation on private constant field.
+        </p>
+
+        <macro name="example">
+          <param name="path"
+                 value="resources/com/puppycrawl/tools/checkstyle/checks/naming/constantname/Example4.java"/>
+          <param name="type" value="config"/>
+        </macro>
+        <p id="Example4-code">Code Example:</p>
+        <macro name="example">
+          <param name="path"
+                 value="resources/com/puppycrawl/tools/checkstyle/checks/naming/constantname/Example4.java"/>
+          <param name="type" value="code"/>
+        </macro><hr class="example-separator"/>
+        <p id="Example5-config">
+          The following configuration skip validation on package-private constant field.
+        </p>
+
+        <macro name="example">
+          <param name="path"
+                 value="resources/com/puppycrawl/tools/checkstyle/checks/naming/constantname/Example5.java"/>
+          <param name="type" value="config"/>
+        </macro>
+        <p id="Example5-code">Code Example:</p>
+        <macro name="example">
+          <param name="path"
+                 value="resources/com/puppycrawl/tools/checkstyle/checks/naming/constantname/Example5.java"/>
+          <param name="type" value="code"/>
         </macro>
       </subsection>
 

--- a/src/test/java/com/puppycrawl/tools/checkstyle/internal/XdocsExampleFileTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/internal/XdocsExampleFileTest.java
@@ -60,7 +60,6 @@ public class XdocsExampleFileTest {
     private static final Map<String, Set<String>> SUPPRESSED_PROPERTIES_BY_CHECK = Map.ofEntries(
             Map.entry("MissingJavadocTypeCheck", Set.of("skipAnnotations")),
             Map.entry("JavadocStyleCheck", Set.of("endOfSentenceFormat")),
-            Map.entry("ConstantNameCheck", Set.of("applyToPackage", "applyToPrivate")),
             Map.entry("SuppressWarningsHolder", Set.of("aliasList")),
             Map.entry("IndentationCheck", Set.of(
                     "basicOffset",

--- a/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/checks/naming/ConstantNameCheckExamplesTest.java
+++ b/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/checks/naming/ConstantNameCheckExamplesTest.java
@@ -71,4 +71,30 @@ public class ConstantNameCheckExamplesTest extends AbstractExamplesModuleTestSup
 
         verifyWithInlineConfigParser(getPath("Example3.java"), expected);
     }
+
+    @Test
+    public void testExample4() throws Exception {
+        final String[] expected = {
+            "17:20: " + getCheckMessage(MSG_INVALID_PATTERN, "third_Constant3", DEFAULT_PATTERN),
+            "19:27: " + getCheckMessage(MSG_INVALID_PATTERN, "log", DEFAULT_PATTERN),
+            "20:30: " + getCheckMessage(MSG_INVALID_PATTERN, "logger", DEFAULT_PATTERN),
+            "21:20: " + getCheckMessage(MSG_INVALID_PATTERN, "loggerMYSELF", DEFAULT_PATTERN),
+            "23:30: " + getCheckMessage(MSG_INVALID_PATTERN, "myselfConstant", DEFAULT_PATTERN),
+        };
+
+        verifyWithInlineConfigParser(getPath("Example4.java"), expected);
+    }
+
+    @Test
+    public void testExample5() throws Exception {
+        final String[] expected = {
+            "18:28: " + getCheckMessage(MSG_INVALID_PATTERN, "fourth_Const4", DEFAULT_PATTERN),
+            "19:27: " + getCheckMessage(MSG_INVALID_PATTERN, "log", DEFAULT_PATTERN),
+            "20:30: " + getCheckMessage(MSG_INVALID_PATTERN, "logger", DEFAULT_PATTERN),
+            "23:30: " + getCheckMessage(MSG_INVALID_PATTERN, "myselfConstant", DEFAULT_PATTERN),
+        };
+
+        verifyWithInlineConfigParser(getPath("Example5.java"), expected);
+    }
+
 }

--- a/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/naming/constantname/Example4.java
+++ b/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/naming/constantname/Example4.java
@@ -1,0 +1,25 @@
+/*xml
+<module name="Checker">
+  <module name="TreeWalker">
+    <module name="ConstantName">
+      <property name="applyToPrivate" value="false"/>
+    </module>
+  </module>
+</module>
+*/
+
+package com.puppycrawl.tools.checkstyle.checks.naming.constantname;
+
+// xdoc section -- start
+class Example4 {
+  public final static int FIRST_CONSTANT1 = 10;
+  protected final static int SECOND_CONSTANT2 = 100;
+  final static int third_Constant3 = 1000; // violation 'must match pattern'
+  private final static int fourth_Const4 = 50;
+  public final static int log = 10; // violation 'must match pattern'
+  protected final static int logger = 50; // violation 'must match pattern'
+  final static int loggerMYSELF = 5; // violation 'must match pattern'
+  final static int MYSELF = 100;
+  protected final static int myselfConstant = 1; // violation 'must match pattern'
+}
+// xdoc section -- end

--- a/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/naming/constantname/Example5.java
+++ b/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/naming/constantname/Example5.java
@@ -1,0 +1,25 @@
+/*xml
+<module name="Checker">
+  <module name="TreeWalker">
+    <module name="ConstantName">
+      <property name="applyToPackage" value="false"/>
+    </module>
+  </module>
+</module>
+*/
+
+package com.puppycrawl.tools.checkstyle.checks.naming.constantname;
+
+// xdoc section -- start
+class Example5 {
+  public final static int FIRST_CONSTANT1 = 10;
+  protected final static int SECOND_CONSTANT2 = 100;
+  final static int third_Constant3 = 1000;
+  private final static int fourth_Const4 = 50; // violation 'must match pattern'
+  public final static int log = 10; // violation 'must match pattern'
+  protected final static int logger = 50; // violation 'must match pattern'
+  final static int loggerMYSELF = 5;
+  final static int MYSELF = 100;
+  protected final static int myselfConstant = 1; // violation 'must match pattern'
+}
+// xdoc section -- end


### PR DESCRIPTION
Issue [#17449](https://github.com/checkstyle/checkstyle/issues/17449)

## Summary
This PR adds missing XDoc examples and corresponding tests for `ConstantNameCheck` properties `applyToPrivate` and `applyToPackage`. These examples demonstrate how the check behaves when certain constant fields are excluded from validation based on their access modifiers.

## Changes
- Added `Example4.java` demonstrating validation skipping for **private constant fields** (`applyToPrivate = false`).
- Added `Example5.java` demonstrating validation skipping for **package-private constant fields** (`applyToPackage = false`).
- Updated `constantname.xml.template` to include macros for `Example4` and `Example5`, and added both examples to the main XML documentation.
- Added tests in `ConstantNameCheckExamplesTest.java` to verify expected violations when private or package-private constants are excluded.

> [!NOTE]  
> The website has been generated locally to verify that the examples render correctly and match the required format.