### PR TITLE
Issue #17697: Add check for box comments

### DIFF
--- a/src/it/java/com/google/checkstyle/test/chapter4formatting/rule4861blockcommentstyle/BlockCommentStyleTest.java
+++ b/src/it/java/com/google/checkstyle/test/chapter4formatting/rule4861blockcommentstyle/BlockCommentStyleTest.java
@@ -71,4 +71,8 @@ public class BlockCommentStyleTest extends AbstractGoogleModuleTestSupport {
         verifyWithWholeConfig(getPath("InputFormattedCommentsIndentationSurroundingCode.java"));
     }
 
+    @Test
+    public void testBoxComments() throws Exception {
+        verifyWithWholeConfig(getPath("InputBoxComments.java"));
+    }
 }

--- a/src/it/resources/com/google/checkstyle/test/chapter4formatting/rule4861blockcommentstyle/InputBoxComments.java
+++ b/src/it/resources/com/google/checkstyle/test/chapter4formatting/rule4861blockcommentstyle/InputBoxComments.java
@@ -1,0 +1,94 @@
+package com.google.checkstyle.test.chapter4formatting.rule4861blockcommentstyle;
+
+// violation below 'Comment uses box-like repetitive character pattern.'
+// =========================================
+// Box with slashes
+// =========================================
+// violation above 'Comment uses box-like repetitive character pattern.'
+
+// violation below 'Comment uses box-like repetitive character pattern.'
+// #########################################
+// Box with hashes
+// #########################################
+// violation above 'Comment uses box-like repetitive character pattern.'
+
+// violation below 'Comment uses box-like repetitive character pattern.'
+// *****************************************
+// Box with asterisks
+// *****************************************
+// violation above 'Comment uses box-like repetitive character pattern.'
+
+/** Some javadoc. */
+public class InputBoxComments {
+
+  // violation below 'Comment uses box-like repetitive character pattern.'
+  // =========================================
+  // Methods with separators
+  // =========================================
+  // violation above 'Comment uses box-like repetitive character pattern.'
+
+  // box with only 9 chars triggers violation
+  void myFunc2() {
+    // violation below 'Comment uses box-like repetitive character pattern.'
+    // =========
+    int y = 2;
+  }
+
+  // box with only 9 chars triggers violation
+  // violation below 'Comment uses box-like repetitive character pattern.'
+  // *********
+  void myFunc3() {
+    int z = 3;
+  }
+
+  // box with only 9 chars triggers violation
+  void myFunc4() {
+    // violation below 'Comment uses box-like repetitive character pattern.'
+    // #########
+    int a = 4;
+  }
+
+  // mixed text with separators is fine
+  // ========= Section separator =========
+  void myFunc5() {
+    int b = 5;
+  }
+
+  // only 6 chars (below 9-char threshold)
+  void myFunc6() {
+    // ######
+    int c = 6;
+  }
+
+  // only 7 chars (below 9-char threshold)
+  void myFunc7() {
+    // *******
+    int d = 7;
+  }
+
+  // only 8 chars (below 9-char threshold)
+  void myFunc8() {
+    // ========
+    int e = 8;
+  }
+
+  // normal block comment
+  void myFunc9() {
+    /* normal block comment */
+    int f = 9;
+  }
+
+  // normal Javadoc comment
+  /*
+   * normal Javadoc comment.
+   */
+  void myFunc10() {
+    int g = 10;
+  }
+
+  // has text after separators, not a pure box line
+  void myFunc11() {
+    // ========= this is fine =========
+    int h = 11;
+  }
+}

--- a/src/it/resources/com/google/checkstyle/test/chapter7javadoc/rule711generalform/InputCorrectJavadocLeadingAsteriskAlignment.java
+++ b/src/it/resources/com/google/checkstyle/test/chapter7javadoc/rule711generalform/InputCorrectJavadocLeadingAsteriskAlignment.java
@@ -22,7 +22,7 @@ public class InputCorrectJavadocLeadingAsteriskAlignment {
 
   // violation 2 lines below "Javadoc line should start with leading asterisk."
   /**
-    No leading asterisk present.
+   No leading asterisk present.
    */
   public InputCorrectJavadocLeadingAsteriskAlignment() {}
 
@@ -34,10 +34,12 @@ public class InputCorrectJavadocLeadingAsteriskAlignment {
    */
   public InputCorrectJavadocLeadingAsteriskAlignment(int a) {}
 
+  // violation below "Comment uses box-like repetitive character pattern."
   /*************************************************
    *** @param str testing.....
    **********************************/
   // False negative for above javadoc, until #18271, #18273.
+
   public InputCorrectJavadocLeadingAsteriskAlignment(String str) {}
 
   /** * */ // violation "Summary javadoc is missing."

--- a/src/it/resources/com/google/checkstyle/test/chapter7javadoc/rule711generalform/InputFormattedCorrectJavadocLeadingAsteriskAlignment.java
+++ b/src/it/resources/com/google/checkstyle/test/chapter7javadoc/rule711generalform/InputFormattedCorrectJavadocLeadingAsteriskAlignment.java
@@ -33,10 +33,12 @@ public class InputFormattedCorrectJavadocLeadingAsteriskAlignment {
    */
   public InputFormattedCorrectJavadocLeadingAsteriskAlignment(int a) {}
 
+  // violation below "Comment uses box-like repetitive character pattern."
   /*************************************************
    *** @param str testing.....
    **********************************/
   // False negative for above javadoc, until #18271, #18273
+
   public InputFormattedCorrectJavadocLeadingAsteriskAlignment(String str) {}
 
   /** * */

--- a/src/main/resources/google_checks.xml
+++ b/src/main/resources/google_checks.xml
@@ -460,9 +460,16 @@
     </module>
     <module name="SingleLineJavadoc"/>
     <module name="TodoComment">
+      <property name="id" value="TodoFormat"/>
       <property name="format" value="^[ \t]*(?!TODO:)(?i:TODO)\b:?"/>
       <message key="todo.match"
                value="''TODO:'' must be written in all caps and followed by a colon."/>
+    </module>
+    <module name="TodoComment">
+      <property name="id" value="BoxComments"/>
+      <property name="format" value="^[ \t]*([*=#])\1{8,}[ \t]*$"/>
+      <message key="todo.match"
+               value="Comment uses box-like repetitive character pattern."/>
     </module>
     <module name="EmptyCatchBlock">
       <property name="commentFormat" value="\w+"/>

--- a/src/site/xdoc/checks/misc/todocomment.xml
+++ b/src/site/xdoc/checks/misc/todocomment.xml
@@ -103,6 +103,63 @@ public class Example2 {
   }
 }
 </code></pre></div>
+        <hr class="example-separator"/>
+        <p id="Example3-config">
+          To configure the check to detect box comments (Google Java Style Guide &#xa7;4.8.6.1):
+        </p>
+        <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
+&lt;module name="Checker"&gt;
+  &lt;module name="TreeWalker"&gt;
+    &lt;module name="TodoComment"&gt;
+      &lt;property name="id" value="BoxComments"/&gt;
+      &lt;property name="format" value="^\s*([*=#])\1{8,}\s*$"/&gt;
+      &lt;message key="todo.match"
+               value="Comment uses box-like repetitive character pattern."/&gt;
+    &lt;/module&gt;
+  &lt;/module&gt;
+&lt;/module&gt;
+</code></pre></div>
+        <p id="Example3-code">
+          Example:
+        </p>
+        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+/** // violation 'Comment uses box-like repetitive character pattern'
+ =========================================
+ Box comment with equals
+ =========================================
+ */
+
+public class Example3 {
+
+  // violation below 'Comment uses box-like repetitive character pattern'
+  // =========
+  void method1() {
+    int y = 2;
+  }
+
+  // violation below 'Comment uses box-like repetitive character pattern'
+  // *********
+  void method2() {
+    int z = 3;
+  }
+
+  // violation below 'Comment uses box-like repetitive character pattern'
+  // #########
+  void method3() {
+    int a = 4;
+  }
+
+  // normal comment
+  void method4() {
+    int b = 5;
+  }
+
+  // ###### (only 6 chars - below 9-char threshold)
+  void method5() {
+    int c = 6;
+  }
+}
+</code></pre></div>
       </subsection>
 
       <subsection name="Example of Usage" id="TodoComment_Example_of_Usage">

--- a/src/site/xdoc/checks/misc/todocomment.xml.template
+++ b/src/site/xdoc/checks/misc/todocomment.xml.template
@@ -68,6 +68,23 @@
                  value="resources/com/puppycrawl/tools/checkstyle/checks/todocomment/Example2.java"/>
           <param name="type" value="code"/>
         </macro>
+        <hr class="example-separator"/>
+        <p id="Example3-config">
+          To configure the check to detect box comments (Google Java Style Guide §4.8.6.1):
+        </p>
+        <macro name="example">
+          <param name="path"
+                 value="resources/com/puppycrawl/tools/checkstyle/checks/todocomment/Example3.java"/>
+          <param name="type" value="config"/>
+        </macro>
+        <p id="Example3-code">
+          Example:
+        </p>
+        <macro name="example">
+          <param name="path"
+                 value="resources/com/puppycrawl/tools/checkstyle/checks/todocomment/Example3.java"/>
+          <param name="type" value="code"/>
+        </macro>
       </subsection>
 
       <subsection name="Example of Usage" id="TodoComment_Example_of_Usage">

--- a/src/site/xdoc/google_style.xml
+++ b/src/site/xdoc/google_style.xml
@@ -1616,6 +1616,12 @@
                     CommentsIndentation</a>
                   (<a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources%20path%3A**%2Fgoogle_checks.xml+repo%3Acheckstyle%2Fcheckstyle+CommentsIndentation">
                   config</a>)
+                  <br/>
+                  <br/>
+                  <span class="wrapper inline">
+                    <img src="images/ok_green.png" alt="" />
+                  </span>
+                  BoxComments
                 </td>
                 <td>
                   <a href="https://github.com/checkstyle/checkstyle/tree/master/src/it/resources/com/google/checkstyle/test/chapter4formatting/rule4861blockcommentstyle">

--- a/src/test/java/com/puppycrawl/tools/checkstyle/internal/XdocsExamplesAstConsistencyTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/internal/XdocsExamplesAstConsistencyTest.java
@@ -217,6 +217,7 @@ public class XdocsExamplesAstConsistencyTest {
             "checks/regexp/regexpmultiline/Example5",
             "checks/sizes/lambdabodylength/Example2",
             "checks/sizes/linelength/Example6",
+            "checks/todocomment/Example3",
             "checks/trailingcomment/Example2",
             "checks/trailingcomment/Example3",
             "checks/trailingcomment/Example4",

--- a/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/checks/TodoCommentCheckExamplesTest.java
+++ b/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/checks/TodoCommentCheckExamplesTest.java
@@ -51,4 +51,16 @@ public class TodoCommentCheckExamplesTest extends AbstractExamplesModuleTestSupp
 
         verifyWithInlineConfigParser(getPath("Example2.java"), expected);
     }
+
+    @Test
+    public void testExample3() throws Exception {
+        final String[] expected = {
+            "17:3: Comment uses box-like repetitive character pattern.",
+            "26:5: Comment uses box-like repetitive character pattern.",
+            "32:5: Comment uses box-like repetitive character pattern.",
+            "38:5: Comment uses box-like repetitive character pattern.",
+        };
+
+        verifyWithInlineConfigParser(getPath("Example3.java"), expected);
+    }
 }

--- a/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/todocomment/Example3.java
+++ b/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/todocomment/Example3.java
@@ -1,0 +1,53 @@
+/*xml
+<module name="Checker">
+  <module name="TreeWalker">
+    <module name="TodoComment">
+      <property name="id" value="BoxComments"/>
+      <property name="format" value="^\s*([*=#])\1{8,}\s*$"/>
+      <message key="todo.match"
+               value="Comment uses box-like repetitive character pattern."/>
+    </module>
+  </module>
+</module>
+*/
+
+package com.puppycrawl.tools.checkstyle.checks.todocomment;
+
+// xdoc section -- start
+/** // violation 'Comment uses box-like repetitive character pattern'
+ =========================================
+ Box comment with equals
+ =========================================
+ */
+
+public class Example3 {
+
+  // violation below 'Comment uses box-like repetitive character pattern'
+  // =========
+  void method1() {
+    int y = 2;
+  }
+
+  // violation below 'Comment uses box-like repetitive character pattern'
+  // *********
+  void method2() {
+    int z = 3;
+  }
+
+  // violation below 'Comment uses box-like repetitive character pattern'
+  // #########
+  void method3() {
+    int a = 4;
+  }
+
+  // normal comment
+  void method4() {
+    int b = 5;
+  }
+
+  // ###### (only 6 chars - below 9-char threshold)
+  void method5() {
+    int c = 6;
+  }
+}
+// xdoc section -- end


### PR DESCRIPTION
#17697 

Adds detection for comments enclosed in boxes drawn with special characters, providing partial coverage for Google Java Style Guide §4.8.6: "Comments are not enclosed in boxes drawn with asterisks or other characters."

**Implementation**
Uses the existing `TodoComment `check with a custom configuration:
Check ID: `BoxComments`
Regex Pattern: `^[ \t]*([*=#-])\1{8,}[ \t]*$`
Detection: `Lines with 9+ consecutive repeated characters (*, =, #)`

**Changes**
Configuration
Modified: `src/main/resources/google_checks.xml`
Added `TodoComment `module with id="`BoxComments`"
Added suppressions for test files with intentional box-style comments

**Documentation**
Modified: **src/xdocs/google_style.xml**
Added row for §`4.8.6.3 `showing partial coverage
Modified: `src/xdocs/checks/misc/todocomment.xml`
Added `Example 3` demonstrating box comment detection

Created: `src/xdocs/resources/com/puppycrawl/tools/checkstyle/checks/todocomment/Example3.java`
Example configuration and test cases

**Tests**
Created: `src/it/java/com/google/checkstyle/test/chapter4formatting/rule4863boxcomments/BoxCommentsTest.java`

**Integration test for Google style**
Created: `src/it/resources/com/google/checkstyle/test/chapter4formatting/rule4863boxcomments/InputBoxComments.java`

**Test input with various box comment patterns**
Modified: `src/test/java/com/puppycrawl/tools/checkstyle/checks/TodoCommentCheckExamplesTest.java`
Added `testExample3()` for box comment examples

Diff Regression config: https://raw.githubusercontent.com/smita1078/checkstyle/BoxComments/src/main/resources/google_checks.xml
Diff Regression projects: https://gist.githubusercontent.com/smita1078/f26521cfc945a2c966396eabd09bc1e8/raw/8d1de4376f538633f1d9f394494ba7315b40d81f/projects-google-style.properties
Report label: BoxComments check on Google Style projects