### PR TITLE
minor: align code with Javadoc

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/FinalLocalVariableCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/FinalLocalVariableCheck.java
@@ -511,7 +511,7 @@ public class FinalLocalVariableCheck extends AbstractCheck {
         // for-each variables are implicitly assigned
         candidate.assigned = ast.getParent().getType() == TokenTypes.FOR_EACH_CLAUSE;
         scope.put(astNode.getText(), candidate);
-        if (!isInitialized(astNode)) {
+        if (!isInitialized(ast)) {
             scopeStack.peek().uninitializedVariables.add(astNode);
         }
     }
@@ -523,7 +523,7 @@ public class FinalLocalVariableCheck extends AbstractCheck {
      * @return true if initialized
      */
     private static boolean isInitialized(DetailAST ast) {
-        return ast.getParent().getLastChild().getType() == TokenTypes.ASSIGN;
+        return ast.getLastChild().getType() == TokenTypes.ASSIGN;
     }
 
     /**


### PR DESCRIPTION
minor:

```
    /**
     * Check if VARIABLE_DEF is initialized or not.
     *
     * @param ast VARIABLE_DEF to be checked
     * @return true if initialized
     */
    private static boolean isInitialized(DetailAST ast) {
        return ast.getParent().getLastChild().getType() == TokenTypes.ASSIGN;
    }
```
according to method `isIntialized(DetailAst ast)` Javadoc DetailAst passed should be VARIABLE_DEF, but we were passing IDENT
```
    private void insertVariable(DetailAST ast) {
        final Map<String, FinalVariableCandidate> scope = scopeStack.peek().scope;
        final DetailAST astNode = ast.findFirstToken(TokenTypes.IDENT);
        final FinalVariableCandidate candidate = new FinalVariableCandidate(astNode);
        // for-each variables are implicitly assigned
        candidate.assigned = ast.getParent().getType() == TokenTypes.FOR_EACH_CLAUSE;
        scope.put(astNode.getText(), candidate);
        if (!isInitialized(astNode)) {
            scopeStack.peek().uninitializedVariables.add(astNode);
        }
    }

Here ast is VARIABLE_DEF and astNode is IDENT
```