### PR TITLE
Issue #18926: Re-enable 'PropertiesAsHashtable' inspection

### DIFF
--- a/config/intellij-idea-inspections.xml
+++ b/config/intellij-idea-inspections.xml
@@ -5109,9 +5109,8 @@
                    enabled_by_default="true"/>
   <inspection_tool class="UseOfProcessBuilder" enabled="true" level="ERROR"
                    enabled_by_default="true"/>
-  <!-- temporary disabled until https://github.com/checkstyle/checkstyle/issues/18926 -->
-  <inspection_tool class="UseOfPropertiesAsHashtable" enabled="false" level="ERROR"
-                   enabled_by_default="false"/>
+  <inspection_tool class="UseOfPropertiesAsHashtable" enabled="true" level="ERROR"
+                   enabled_by_default="true"/>
   <inspection_tool class="UseOfSunClasses" enabled="true" level="ERROR"
                    enabled_by_default="true"/>
   <inspection_tool class="UsePrimitiveTypes" enabled="false" level="WARNING"

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/UniquePropertiesCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/UniquePropertiesCheck.java
@@ -168,6 +168,9 @@ public class UniquePropertiesCheck extends AbstractFileSetCheck {
 
         /**
          * Puts the value into properties by the key specified.
+         *
+         * @noinspection UseOfPropertiesAsHashtable
+         * @noinspectionreason We must override put to intercept properties loading.
          */
         @Override
         public synchronized Object put(Object key, Object value) {


### PR DESCRIPTION
Resolves part of #18926.
This PR re-enables the `PropertiesAsHashtable` inspection

Note to reviewers: I am opening this pr as a draft initially to trigger the qodana ci pipeline and identify the exact list of files violating the PropertiesAsHashtable inspection. I will push the fixes and suppressions shortly once the CI provides the report.