### PR TITLE
Issue #16361: Update testAddErrorWithSpaceInPath to use verifyWithInlineConfigParserAndLogger

### DIFF
--- a/config/checkstyle-resources-suppressions.xml
+++ b/config/checkstyle-resources-suppressions.xml
@@ -646,5 +646,9 @@
     files="[\\/]test[\\/]resources[\\/]com[\\/]puppycrawl[\\/]tools[\\/]checkstyle[\\/]grammar[\\/]java14[\\/]InputJava14Records\.java"/>
   <suppress checks="FileLength"
     files="[\\/]test[\\/]resources-noncompilable[\\/]com[\\/]puppycrawl[\\/]tools[\\/]checkstyle[\\/]grammar[\\/]antlr4[\\/]InputAntlr4AstRegressionUncommon\.java"/>
+  <suppress checks="OuterTypeFilename"
+    files=".*[\\/]sariflogger[\\/]InputSarifLogger Space\.java"/>
+  <suppress id="resourceFileName"
+    files=".*[\\/]sariflogger[\\/]InputSarifLogger Space\.java"/>
 
 </suppressions>

--- a/config/jsoref-spellchecker/whitelist.words
+++ b/config/jsoref-spellchecker/whitelist.words
@@ -1281,7 +1281,6 @@ solr
 someinner
 somename
 someoneelse
-someuser
 sonarcloud
 sonarqube
 sonarsource

--- a/src/test/java/com/puppycrawl/tools/checkstyle/SarifLoggerTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/SarifLoggerTest.java
@@ -224,20 +224,14 @@ public class SarifLoggerTest extends AbstractModuleTestSupport {
     }
 
     @Test
-    public void testAddErrorWithSpaceInPath() throws IOException {
+    public void testAddErrorWithSpaceInPath() throws Exception {
+        final String inputFile = "InputSarifLogger Space.java";
+        final String expectedReportFile = "ExpectedSarifLoggerSpaceInPath.sarif";
         final SarifLogger logger = new SarifLogger(outStream,
                 OutputStreamOptions.CLOSE);
-        logger.auditStarted(null);
-        final Violation violation =
-                new Violation(1, 1,
-                        "messages.properties", "ruleId", null, SeverityLevel.ERROR, null,
-                        getClass(), "found an error");
-        final AuditEvent ev = new AuditEvent(this, "/home/someuser/Code/Test 2.java", violation);
-        logger.fileStarted(ev);
-        logger.addError(ev);
-        logger.fileFinished(ev);
-        logger.auditFinished(null);
-        verifyContent(getPath("ExpectedSarifLoggerSpaceInPath.sarif"), outStream);
+
+        verifyWithInlineConfigParserAndLogger(
+                getPath(inputFile), getPath(expectedReportFile), logger, outStream);
     }
 
     @Test

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/sariflogger/ExpectedSarifLoggerSpaceInPath.sarif
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/sariflogger/ExpectedSarifLoggerSpaceInPath.sarif
@@ -13,15 +13,20 @@
           "organization": "Checkstyle",
           "rules": [
             {
-              "id": "com.puppycrawl.tools.checkstyle.SarifLoggerTest",
+              "id": "com.puppycrawl.tools.checkstyle.checks.regexp.RegexpSinglelineCheck",
               "messageStrings": {
-
+                "regexp.exceeded": {
+                  "text": "Line matches the illegal pattern ''{0}''."
+                },
+                "regexp.minimum": {
+                  "text": "File does not contain at least {0} matches for pattern ''{1}''."
+                }
               },
               "shortDescription": {
-                "text": "SarifLoggerTest"
+                "text": "RegexpSingleline"
               },
               "fullDescription": {
-                "text": "No description available"
+                "text": "<div>\n Checks that a specified pattern matches a single-line in any file type.\n <\/div>\n\n <p>\n Rationale: This check can be used to prototype checks and to find common bad\n practice such as calling <code>ex.printStacktrace()<\/code>,\n <code>System.out.println()<\/code>, <code>System.exit()<\/code>, etc.\n <\/p>"
               }
             }
           ],
@@ -36,11 +41,10 @@
             {
               "physicalLocation": {
                 "artifactLocation": {
-                  "uri": "file:/home/someuser/Code/Test%202.java"
+                  "uri": "file:src/test/resources/com/puppycrawl/tools/checkstyle/sariflogger/InputSarifLogger%20Space.java"
                 },
                 "region": {
-                  "startColumn": 1,
-                  "startLine": 1
+                  "startLine": 4
                 }
               }
             }
@@ -48,7 +52,26 @@
           "message": {
             "text": "found an error"
           },
-          "ruleId": "com.puppycrawl.tools.checkstyle.SarifLoggerTest"
+          "ruleId": "com.puppycrawl.tools.checkstyle.checks.regexp.RegexpSinglelineCheck"
+        },
+        {
+          "level": "error",
+          "locations": [
+            {
+              "physicalLocation": {
+                "artifactLocation": {
+                  "uri": "file:src/test/resources/com/puppycrawl/tools/checkstyle/sariflogger/InputSarifLogger%20Space.java"
+                },
+                "region": {
+                  "startLine": 13
+                }
+              }
+            }
+          ],
+          "message": {
+            "text": "found an error"
+          },
+          "ruleId": "com.puppycrawl.tools.checkstyle.checks.regexp.RegexpSinglelineCheck"
         }
       ]
     }

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/sariflogger/InputSarifLogger Space.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/sariflogger/InputSarifLogger Space.java
@@ -1,0 +1,14 @@
+/*xml
+<module name="Checker">
+  <module name="RegexpSingleline">
+    <property name="format" value="Error here"/>
+    <property name="message" value="found an error"/>
+  </module>
+</module>
+*/
+
+package com.puppycrawl.tools.checkstyle.sariflogger;
+
+class InputSarifLoggerSpace {
+    // Error here
+}


### PR DESCRIPTION
Resolves #16361

Migrated `testAddErrorWithSpaceInPath` to use the `verifyWithInlineConfigParserAndLogger` framework.

**Modifications:**
* Replaced manual `Violation` and `AuditEvent` mocking in `SarifLoggerTest` with the inline configuration framework.
* Added `InputSarifLogger Space.java` to trigger violations via `RegexpSingleline`. 
* Updated `ExpectedSarifLoggerSpaceInPath.sarif` to match the newly generated JSON output.