### PR TITLE
Issue #17882: Update FORMAT_SPECIFIER of JavadocCommentsTokenTypes to…

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/api/JavadocCommentsTokenTypes.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/api/JavadocCommentsTokenTypes.java
@@ -1663,7 +1663,35 @@ public final class JavadocCommentsTokenTypes {
     public static final int DESCRIPTION = JavadocCommentsLexer.DESCRIPTION;
 
     /**
-     * Format specifier inside Javadoc content.
+     * Format specifier inside a {@code {@value}} inline tag.
+     * The {@value} tag is used to display the value of a constant directly
+     * within the Javadoc documentation. In newer Java versions (20+), there
+     * is ability include a format string inside the tag.
+     *
+     * <p>In this example, the format specifier {@code 0x%04x} is used to format the integer
+     * {@code Modifier#MANDATED} as a hexadecimal value, padded with zeros to a width of four characters.</p>
+     * <pre>{@code
+     * {@value %04x Modifier#MANDATED}
+     * }</pre>
+     *
+     * <p><b>Tree:</b></p>
+     * <pre>{@code
+     * JAVADOC_INLINE_TAG -> JAVADOC_INLINE_TAG
+     * `--VALUE_INLINE_TAG -> VALUE_INLINE_TAG
+     *     |--JAVADOC_INLINE_TAG_START -> {@
+     *     |--TAG_NAME -> value
+     *     |--TEXT ->
+     *     |--FORMAT_SPECIFIER -> %04x
+     *     |--TEXT ->
+     *     |--REFERENCE -> REFERENCE
+     *     |   |--IDENTIFIER -> Modifier
+     *     |   |--HASH -> #
+     *     |   `--MEMBER_REFERENCE -> MEMBER_REFERENCE
+     *     |       `--IDENTIFIER -> MANDATED
+     *     `--JAVADOC_INLINE_TAG_END -> }
+     * }</pre>
+     *
+     * @see #VALUE_INLINE_TAG
      */
     public static final int FORMAT_SPECIFIER = JavadocCommentsLexer.FORMAT_SPECIFIER;
 


### PR DESCRIPTION
Issue: #17882

```
**Input (`src/Test.java`):**

/** 
 * {@value %s #MY_CONSTANT}
 */
public class Test {}


**Command:**
java -jar target/checkstyle-13.3.0-SNAPSHOT-all.jar -j src/Test.java | sed "s/\[[0-9]\+:[0-9]\+\]//g"

JAVADOC_CONTENT -> JAVADOC_CONTENT [0:1]
|--TEXT -> /**  [0:1]
|--NEWLINE -> \n [0:5]
|--LEADING_ASTERISK ->  * [1:1]
|--TEXT ->   [1:3]
|--JAVADOC_INLINE_TAG -> JAVADOC_INLINE_TAG [1:4]
|   `--VALUE_INLINE_TAG -> VALUE_INLINE_TAG [1:4]
|       |--JAVADOC_INLINE_TAG_START -> {@ [1:4]
|       |--TAG_NAME -> value [1:6]
|       |--TEXT ->   [1:11]
|       |--FORMAT_SPECIFIER -> %s [1:12]
|       |--TEXT ->   [1:14]
|       |--REFERENCE -> REFERENCE [1:15]
|       |   |--HASH -> # [1:15]
|       |   `--MEMBER_REFERENCE -> MEMBER_REFERENCE [1:16]
|       |       `--IDENTIFIER -> MY_CONSTANT [1:16]
|       `--JAVADOC_INLINE_TAG_END -> } [1:27]
|--NEWLINE -> \n [1:28]
|--LEADING_ASTERISK ->  * [2:1]
|--TEXT -> / [2:3]
|--NEWLINE -> \n [2:4]
|--TEXT -> public class Test {} [3:1]
`--NEWLINE -> \n [3:21]
```