### PR TITLE
Issue #18993: Handle {@literal} and fix {@code} XML escaping in metad…

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/regexp/RegexpCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/regexp/RegexpCheck.java
@@ -87,7 +87,7 @@ import com.puppycrawl.tools.checkstyle.utils.CommonUtil;
  * <p>
  * <b>Note:</b> When entering a regular expression as a parameter in
  * the XML config file you must also take into account the XML rules. e.g.
- * if you want to match a &lt; symbol you need to enter &amp;lt;.
+ * if you want to match a {@literal <} symbol you need to enter &amp;lt;.
  * The regular expression should be entered on one line.
  * </p>
  *
@@ -99,7 +99,7 @@ import com.puppycrawl.tools.checkstyle.utils.CommonUtil;
  *
  * <p>
  * <b>Note:</b> To search for things that mean something in XML, like
- * &lt; you need to escape them like &amp;lt;. This is required so the
+ * {@literal <} you need to escape them like &amp;lt;. This is required so the
  * XML parser does not act on them, but instead passes the correct
  * character to the regexp engine.
  * </p>

--- a/src/main/resources/com/puppycrawl/tools/checkstyle/meta/checks/coding/SimplifyBooleanExpressionCheck.xml
+++ b/src/main/resources/com/puppycrawl/tools/checkstyle/meta/checks/coding/SimplifyBooleanExpressionCheck.xml
@@ -7,7 +7,7 @@
          <description>&lt;div&gt;
  Checks for over-complicated boolean expressions. Currently, it finds code like
  &lt;code&gt;if (b == true)&lt;/code&gt;, &lt;code&gt;b || true&lt;/code&gt;, &lt;code&gt;!false&lt;/code&gt;,
- &lt;code&gt;boolean a = q &gt; 12 ? true : false&lt;/code&gt;,
+ &lt;code&gt;boolean a = q &amp;gt; 12 ? true : false&lt;/code&gt;,
  etc.
  &lt;/div&gt;
 

--- a/src/main/resources/com/puppycrawl/tools/checkstyle/meta/filters/SuppressWithNearbyCommentFilter.xml
+++ b/src/main/resources/com/puppycrawl/tools/checkstyle/meta/filters/SuppressWithNearbyCommentFilter.xml
@@ -17,7 +17,7 @@
 
  &lt;p&gt;
  Attention: This filter may only be specified within the TreeWalker module
- (&lt;code&gt;&lt;module name="TreeWalker"/&gt;&lt;/code&gt;) and only applies to checks which are also
+ (&lt;code&gt;&amp;lt;module name="TreeWalker"/&amp;gt;&lt;/code&gt;) and only applies to checks which are also
  defined within this module. To filter non-TreeWalker checks like &lt;code&gt;RegexpSingleline&lt;/code&gt;,
  a
  &lt;a href="https://checkstyle.org/filters/suppresswithplaintextcommentfilter.html"&gt;

--- a/src/main/resources/com/puppycrawl/tools/checkstyle/meta/filters/SuppressionCommentFilter.xml
+++ b/src/main/resources/com/puppycrawl/tools/checkstyle/meta/filters/SuppressionCommentFilter.xml
@@ -25,7 +25,7 @@
 
  &lt;p&gt;
  Attention: This filter may only be specified within the TreeWalker module
- (&lt;code&gt;&lt;module name="TreeWalker"/&gt;&lt;/code&gt;) and only applies to checks which are also
+ (&lt;code&gt;&amp;lt;module name="TreeWalker"/&amp;gt;&lt;/code&gt;) and only applies to checks which are also
  defined within this module. To filter non-TreeWalker checks like &lt;code&gt;RegexpSingleline&lt;/code&gt;, a
  &lt;a href="https://checkstyle.org/filters/suppresswithplaintextcommentfilter.html"&gt;
  SuppressWithPlainTextCommentFilter&lt;/a&gt; or similar filter must be used.

--- a/src/site/xdoc/checks/coding/simplifybooleanexpression.xml
+++ b/src/site/xdoc/checks/coding/simplifybooleanexpression.xml
@@ -12,7 +12,7 @@
         <div>
           Checks for over-complicated boolean expressions. Currently, it finds code like
           <code>if (b == true)</code>, <code>b || true</code>, <code>!false</code>,
-          <code>boolean a = q > 12 ? true : false</code>,
+          <code>boolean a = q &gt; 12 ? true : false</code>,
           etc.
         </div>
 

--- a/src/site/xdoc/filters/suppressioncommentfilter.xml
+++ b/src/site/xdoc/filters/suppressioncommentfilter.xml
@@ -30,7 +30,7 @@
 
         <p>
           Attention: This filter may only be specified within the TreeWalker module
-          (<code><module name="TreeWalker"/></code>) and only applies to checks which are also
+          (<code>&lt;module name="TreeWalker"/&gt;</code>) and only applies to checks which are also
           defined within this module. To filter non-TreeWalker checks like <code>RegexpSingleline</code>, a
           <a href="https://checkstyle.org/filters/suppresswithplaintextcommentfilter.html">
           SuppressWithPlainTextCommentFilter</a> or similar filter must be used.

--- a/src/site/xdoc/filters/suppresswithnearbycommentfilter.xml
+++ b/src/site/xdoc/filters/suppresswithnearbycommentfilter.xml
@@ -22,7 +22,7 @@
 
         <p>
           Attention: This filter may only be specified within the TreeWalker module
-          (<code><module name="TreeWalker"/></code>) and only applies to checks which are also
+          (<code>&lt;module name="TreeWalker"/&gt;</code>) and only applies to checks which are also
           defined within this module. To filter non-TreeWalker checks like <code>RegexpSingleline</code>,
           a
           <a href="https://checkstyle.org/filters/suppresswithplaintextcommentfilter.html">


### PR DESCRIPTION
Issue #18993:

- Add {@literal} inline tag handling in `JavadocMetadataScraperUtil.constructSubTreeText()` and `SiteUtil.getDescriptionFromJavadocForXdoc()` so that structural tokens ({, @literal, }) are excluded and only the text content is passed
- Fix for  {@code} to escape < and > XML special characters in addition to &
- Replace `&lt;` with {@literal <} in RegexpCheck Javadoc to exercise the new code paths to statisfy jacoco coverage
