### PR TITLE
Issue #9253: create CI test for limited call stack size and remove TestUtil workarounds

### DIFF
--- a/.github/workflows/limited-stack-test.yml
+++ b/.github/workflows/limited-stack-test.yml
@@ -1,0 +1,33 @@
+---
+name: Limited Stack Size Test
+
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+    branches:
+      - master
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  limited-stack-test:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Java
+        uses: actions/setup-java@v4
+        with:
+          java-version: '21'
+          distribution: 'temurin'
+          cache: 'maven'
+
+      - name: Run Maven tests with limited stack size
+        run: >
+          mvn -e --no-transfer-progress clean test
+          -DargLine="-Xss256k" -Dtest="!CommitValidationTest"

--- a/config/jsoref-spellchecker/whitelist.words
+++ b/config/jsoref-spellchecker/whitelist.words
@@ -880,6 +880,7 @@ multiplevariabledeclarations
 Multiset
 multithreading
 mutableexception
+mutationtest
 MVC
 mvn
 mvnd
@@ -1569,6 +1570,7 @@ xsl
 xslt
 xsltproc
 XSO
+Xss
 xwiki
 XXXX
 xxxxxx

--- a/config/pitest-suppressions/pitest-java-ast-visitor-suppressions.xml
+++ b/config/pitest-suppressions/pitest-java-ast-visitor-suppressions.xml
@@ -1,3 +1,38 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <suppressedMutations>
+  <mutation unstable="false">
+    <sourceFile>JavaAstVisitor.java</sourceFile>
+    <mutatedClass>com.puppycrawl.tools.checkstyle.JavaAstVisitor</mutatedClass>
+    <mutatedMethod>visitBinOp</mutatedMethod>
+    <mutator>org.pitest.mutationtest.engine.gregor.mutators.NonVoidMethodCallMutator</mutator>
+    <description>removed call to com/puppycrawl/tools/checkstyle/grammar/java/JavaLanguageParser$BinOpContext::expr</description>
+    <lineContent>ParseTree firstExpression = ctx.expr(0);</lineContent>
+  </mutation>
+
+  <mutation unstable="false">
+    <sourceFile>JavaAstVisitor.java</sourceFile>
+    <mutatedClass>com.puppycrawl.tools.checkstyle.JavaAstVisitor</mutatedClass>
+    <mutatedMethod>visitBinOp</mutatedMethod>
+    <mutator>org.pitest.mutationtest.engine.gregor.mutators.NonVoidMethodCallMutator</mutator>
+    <description>removed call to java/util/List::add</description>
+    <lineContent>binOpList.add((JavaLanguageParser.BinOpContext) firstExpression);</lineContent>
+  </mutation>
+
+  <mutation unstable="false">
+    <sourceFile>JavaAstVisitor.java</sourceFile>
+    <mutatedClass>com.puppycrawl.tools.checkstyle.JavaAstVisitor</mutatedClass>
+    <mutatedMethod>visitBinOp</mutatedMethod>
+    <mutator>org.pitest.mutationtest.engine.gregor.mutators.RemoveConditionalMutator_EQUAL_IF</mutator>
+    <description>removed conditional - replaced equality check with true</description>
+    <lineContent>if (binOpList.isEmpty()) {</lineContent>
+  </mutation>
+
+  <mutation unstable="false">
+    <sourceFile>JavaAstVisitor.java</sourceFile>
+    <mutatedClass>com.puppycrawl.tools.checkstyle.JavaAstVisitor</mutatedClass>
+    <mutatedMethod>visitBinOp</mutatedMethod>
+    <mutator>org.pitest.mutationtest.engine.gregor.mutators.RemoveConditionalMutator_EQUAL_ELSE</mutator>
+    <description>removed conditional - replaced equality check with false</description>
+    <lineContent>while (firstExpression instanceof JavaLanguageParser.BinOpContext) {</lineContent>
+  </mutation>
 </suppressedMutations>

--- a/src/test/java/com/puppycrawl/tools/checkstyle/AbstractModuleTestSupport.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/AbstractModuleTestSupport.java
@@ -50,7 +50,6 @@ import com.puppycrawl.tools.checkstyle.bdd.InlineConfigParser;
 import com.puppycrawl.tools.checkstyle.bdd.TestInputConfiguration;
 import com.puppycrawl.tools.checkstyle.bdd.TestInputViolation;
 import com.puppycrawl.tools.checkstyle.internal.utils.BriefUtLogger;
-import com.puppycrawl.tools.checkstyle.internal.utils.TestUtil;
 import com.puppycrawl.tools.checkstyle.utils.CommonUtil;
 import com.puppycrawl.tools.checkstyle.utils.ModuleReflectionUtil;
 import com.puppycrawl.tools.checkstyle.xpath.RootNode;
@@ -665,10 +664,7 @@ public abstract class AbstractModuleTestSupport extends AbstractPathTestSupport 
      */
     protected final void verifyWithLimitedResources(String fileName, String... expected)
             throws Exception {
-        TestUtil.getResultWithLimitedResources(() -> {
-            verifyWithInlineConfigParser(fileName, expected);
-            return null;
-        });
+        verifyWithInlineConfigParser(fileName, expected);
     }
 
     /**

--- a/src/test/java/com/puppycrawl/tools/checkstyle/JavaAstVisitorTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/JavaAstVisitorTest.java
@@ -291,9 +291,7 @@ public class JavaAstVisitorTest extends AbstractModuleTestSupport {
         // kill surviving pitest mutation from removal of nested binary operation
         // optimization in JavaAstVisitor#visitBinOp. Limited resources (small stack size)
         // ensure that we throw a StackOverflowError if optimization is removed.
-        final DetailAST root = TestUtil.getResultWithLimitedResources(
-                () -> new JavaAstVisitor(tokenStream).visit(compilationUnit)
-        );
+        final DetailAST root = new JavaAstVisitor(tokenStream).visit(compilationUnit);
 
         assertWithMessage("File parsing and AST building should complete successfully.")
                 .that(root)

--- a/src/test/java/com/puppycrawl/tools/checkstyle/internal/utils/TestUtil.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/internal/utils/TestUtil.java
@@ -35,9 +35,6 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
-import java.util.concurrent.Callable;
-import java.util.concurrent.FutureTask;
-import java.util.concurrent.TimeUnit;
 import java.util.function.Predicate;
 import java.util.function.Supplier;
 import java.util.regex.Pattern;
@@ -58,16 +55,6 @@ import com.puppycrawl.tools.checkstyle.api.DetailAST;
 import com.puppycrawl.tools.checkstyle.api.TextBlock;
 
 public final class TestUtil {
-
-    /**
-     * The stack size used in {@link TestUtil#getResultWithLimitedResources}.
-     * This value should be as small as possible. Some JVM requires this value to be
-     * at least 144k.
-     *
-     * @see <a href="https://www.baeldung.com/jvm-configure-stack-sizes">
-     *      Configuring Stack Sizes in the JVM</a>
-     */
-    private static final int MINIMAL_STACK_SIZE = 147456;
 
     private TestUtil() {
     }
@@ -271,25 +258,6 @@ public final class TestUtil {
             ++result;
         }
         return result;
-    }
-
-    /**
-     * Runs a given task with limited stack size and time duration, then
-     * returns the result. See AbstractModuleTestSupport#verifyWithLimitedResources
-     * for an example of how to use this method when task does not return a result, i.e.
-     * the given method's return type is {@code void}.
-     *
-     * @param callable the task to execute
-     * @param <V> return type of task - {@code Void} if task does not return result
-     * @return result
-     * @throws Exception if getting result fails
-     */
-    public static <V> V getResultWithLimitedResources(Callable<V> callable) throws Exception {
-        final FutureTask<V> futureTask = new FutureTask<>(callable);
-        final Thread thread = new Thread(null, futureTask,
-                "LimitedStackSizeThread", MINIMAL_STACK_SIZE);
-        thread.start();
-        return futureTask.get(10, TimeUnit.SECONDS);
     }
 
     /**


### PR DESCRIPTION
Fixes #9253

this transitions the limited stack size testing from Java workarounds to a continuous integration workflow, as requested in the issue. 