### PR TITLE
Issue #17725: Detected multiple spaces around reserved words not dete…

### DIFF
--- a/config/google-java-format/excluded/compilable-input-paths.txt
+++ b/config/google-java-format/excluded/compilable-input-paths.txt
@@ -95,6 +95,7 @@ src/it/resources/com/google/checkstyle/test/chapter7javadoc/rule713atclauses/Inp
 src/it/resources/com/google/checkstyle/test/chapter7javadoc/rule734nonrequiredjavadoc/InputInvalidJavadocPosition.java
 src/it/resources/com/google/checkstyle/test/chapter7javadoc/rule734nonrequiredjavadoc/InputInvalidJavadocPositionRecord.java
 src/it/resources/com/google/checkstyle/test/chapter4formatting/rule462horizontalwhitespace/InputWhitespaceAroundWhen.java
+src/it/resources/com/google/checkstyle/test/chapter4formatting/rule462horizontalwhitespace/InputSingleSpaceSeparatorReservedWords.java
 src/it/resources/com/google/checkstyle/test/chapter4formatting/rule4841indentation/InputLambdaChild.java
 src/it/resources/com/google/checkstyle/test/chapter4formatting/rule4841indentation/InputSwitchOnStartOfTheLine.java
 src/it/resources/com/google/checkstyle/test/chapter4formatting/rule4841indentation/InputCatchParametersOnNewLine.java

--- a/src/it/java/com/google/checkstyle/test/chapter4formatting/rule462horizontalwhitespace/HorizontalWhitespaceTest.java
+++ b/src/it/java/com/google/checkstyle/test/chapter4formatting/rule462horizontalwhitespace/HorizontalWhitespaceTest.java
@@ -230,4 +230,9 @@ public class HorizontalWhitespaceTest extends AbstractGoogleModuleTestSupport {
         verifyWithWholeConfig(getPath("InputFormattedWhitespaceBeforeLeftCurlyOfEmptyBlock.java"));
     }
 
+    @Test
+    public void testSingleSpaceSeparatorReservedWords() throws Exception {
+        verifyWithWholeConfig(getPath("InputSingleSpaceSeparatorReservedWords.java"));
+    }
+
 }

--- a/src/it/resources/com/google/checkstyle/test/chapter4formatting/rule451wheretobreak/InputIllegalLineBreakAroundLambda.java
+++ b/src/it/resources/com/google/checkstyle/test/chapter4formatting/rule451wheretobreak/InputIllegalLineBreakAroundLambda.java
@@ -70,6 +70,7 @@ public class InputIllegalLineBreakAroundLambda {
       case ErrorInProcessingTryAgain
           ->  "Please try again after some time. you made a mistake or there is something wrong.";
       // violation above, ''->' should be on the previous line.'
+      // violation 2 lines above 'Use a single space to separate non-whitespace characters'
       default ->
           throw new IllegalArgumentException("");
     };

--- a/src/it/resources/com/google/checkstyle/test/chapter4formatting/rule462horizontalwhitespace/InputFormattedSingleSpaceSeparatorReservedWords.java
+++ b/src/it/resources/com/google/checkstyle/test/chapter4formatting/rule462horizontalwhitespace/InputFormattedSingleSpaceSeparatorReservedWords.java
@@ -1,0 +1,18 @@
+package com.google.checkstyle.test.chapter4formatting.rule462horizontalwhitespace;
+
+/** Test input for SingleSpaceSeparator check. */
+public class InputFormattedSingleSpaceSeparatorReservedWords {
+  void testIf(int x) {
+    if (x > 0) {
+      System.out.println("Positive");
+    } else {
+      return;
+    }
+  }
+
+  void testFor() {
+    for (int cur = 0; cur < 5; cur++) {
+      System.out.println(cur);
+    }
+  }
+}

--- a/src/it/resources/com/google/checkstyle/test/chapter4formatting/rule462horizontalwhitespace/InputGenericWhitespace.java
+++ b/src/it/resources/com/google/checkstyle/test/chapter4formatting/rule462horizontalwhitespace/InputGenericWhitespace.java
@@ -83,5 +83,6 @@ class InputGenericWhitespace implements Comparable<InputGenericWhitespace>, Seri
 
   public static class IntEnumValueType3<E extends Enum<E>  & IntEnum> {
     // violation above ''\>' is followed by whitespace.'
+    // violation 2 lines above 'Use a single space to separate non-whitespace characters'
   }
 }

--- a/src/it/resources/com/google/checkstyle/test/chapter4formatting/rule462horizontalwhitespace/InputNoWhitespaceBeforeEllipsis.java
+++ b/src/it/resources/com/google/checkstyle/test/chapter4formatting/rule462horizontalwhitespace/InputNoWhitespaceBeforeEllipsis.java
@@ -61,9 +61,13 @@ public class InputNoWhitespaceBeforeEllipsis {
 
   void test12(@NonNull String @C []    ... arg) {}
   // violation above ''...' is preceded with whitespace'
+  // violation 2 lines above 'Use a single space to separate non-whitespace characters'
 
+  // violation below 'Use a single space to separate non-whitespace characters'
   void test13(@NonNull String    [] @B ... arg) {}
 
   void test14(   String    [] @B ... arg) {}
   // violation above ''(' is followed by whitespace'
+  // violation 2 lines above 'Use a single space to separate non-whitespace characters'
+  // violation 3 lines above 'Use a single space to separate non-whitespace characters'
 }

--- a/src/it/resources/com/google/checkstyle/test/chapter4formatting/rule462horizontalwhitespace/InputSingleSpaceSeparatorReservedWords.java
+++ b/src/it/resources/com/google/checkstyle/test/chapter4formatting/rule462horizontalwhitespace/InputSingleSpaceSeparatorReservedWords.java
@@ -1,0 +1,25 @@
+package com.google.checkstyle.test.chapter4formatting.rule462horizontalwhitespace;
+
+/**
+ * Test input for SingleSpaceSeparator check.
+ */
+public class InputSingleSpaceSeparatorReservedWords {
+  void testIf(int x) {
+    // violation below 'Use a single space to separate non-whitespace characters.'
+    if   (x > 0) {
+      System.out.println("Positive");
+    }       else       {
+      // violation above 'Use a single space to separate non-whitespace characters.'
+      // violation 2 lines above 'Use a single space to separate non-whitespace characters.'
+      return;
+    }
+  }
+
+  void testFor() {
+    // violation below 'Use a single space to separate non-whitespace characters.'
+    for    (int cur = 0; cur < 5; cur++) {
+      System.out.println(cur);
+    }
+  }
+}
+

--- a/src/it/resources/com/google/checkstyle/test/chapter4formatting/rule4853methodsandconstructorsannotations/InputMethodsAndConstructorsAnnotations.java
+++ b/src/it/resources/com/google/checkstyle/test/chapter4formatting/rule4853methodsandconstructorsannotations/InputMethodsAndConstructorsAnnotations.java
@@ -67,6 +67,7 @@ public class InputMethodsAndConstructorsAnnotations {
   // violation below 'Annotation 'SomeAnnotation2' should be alone on line.'
   @SomeAnnotation1 @SomeAnnotation2  InputMethodsAndConstructorsAnnotations(String a,
                                                                             String b) {}
+  // violation 2 lines above 'Use a single space to separate non-whitespace characters'
 
   // violation below 'Annotation 'SuppressWarnings' should be alone on line.'
   @SuppressWarnings("blah") InputMethodsAndConstructorsAnnotations(int x, int y) {}

--- a/src/main/resources/google_checks.xml
+++ b/src/main/resources/google_checks.xml
@@ -202,6 +202,7 @@
                                    may only be represented as '{}' when not part of a
                                    multi-block statement (4.1.3)"/>
     </module>
+    <module name="SingleSpaceSeparator"/>
     <module name="OneStatementPerLine"/>
     <module name="MultipleVariableDeclarations"/>
     <module name="ArrayTypeStyle"/>

--- a/src/site/xdoc/checks/whitespace/singlespaceseparator.xml
+++ b/src/site/xdoc/checks/whitespace/singlespaceseparator.xml
@@ -140,6 +140,10 @@ class Example2 {
             OpenJDK Style</a>
           </li>
           <li>
+            <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources%20path%3A**%2Fgoogle_checks.xml+repo%3Acheckstyle%2Fcheckstyle+SingleSpaceSeparator">
+            Google Style</a>
+          </li>
+          <li>
             <a href="https://github.com/search?q=path%3Aconfig%20path%3A**%2Fcheckstyle-checks.xml+repo%3Acheckstyle%2Fcheckstyle+SingleSpaceSeparator">
             Checkstyle Style</a>
           </li>

--- a/src/site/xdoc/checks/whitespace/singlespaceseparator.xml.template
+++ b/src/site/xdoc/checks/whitespace/singlespaceseparator.xml.template
@@ -67,6 +67,10 @@
             OpenJDK Style</a>
           </li>
           <li>
+            <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources%20path%3A**%2Fgoogle_checks.xml+repo%3Acheckstyle%2Fcheckstyle+SingleSpaceSeparator">
+            Google Style</a>
+          </li>
+          <li>
             <a href="https://github.com/search?q=path%3Aconfig%20path%3A**%2Fcheckstyle-checks.xml+repo%3Acheckstyle%2Fcheckstyle+SingleSpaceSeparator">
             Checkstyle Style</a>
           </li>

--- a/src/site/xdoc/google_style.xml
+++ b/src/site/xdoc/google_style.xml
@@ -1062,6 +1062,15 @@
                   <span class="wrapper inline">
                     <img src="images/ok_green.png" alt="" />
                   </span>
+                  <a href="checks/whitespace/singlespaceseparator.html#SingleSpaceSeparator">
+                    SingleSpaceSeparator</a>
+                  (<a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources%20path%3A**%2Fgoogle_checks.xml+repo%3Acheckstyle%2Fcheckstyle+SingleSpaceSeparator">
+                  config</a>)
+                  <br />
+                  <br />
+                  <span class="wrapper inline">
+                    <img src="images/ok_green.png" alt="" />
+                  </span>
                   <a href="checks/whitespace/nowhitespacebeforecasedefaultcolon.html#NoWhitespaceBeforeCaseDefaultColon">
                     NoWhitespaceBeforeCaseDefaultColon</a>
                   (<a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources%20path%3A**%2Fgoogle_checks.xml+repo%3Acheckstyle%2Fcheckstyle+NoWhitespaceBeforeCaseDefaultColon">

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/whitespace/SingleSpaceSeparatorCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/whitespace/SingleSpaceSeparatorCheckTest.java
@@ -196,4 +196,16 @@ public class SingleSpaceSeparatorCheckTest extends AbstractModuleTestSupport {
             getPath("InputSingleSpaceSeparatorCommentsWithEmoji.java"), expected);
     }
 
+    @Test
+    public void testSpaceErrorsAroundForElse() throws Exception {
+        final String[] expected = {
+            "13:14: " + getCheckMessage(MSG_KEY),
+            "17:17: " + getCheckMessage(MSG_KEY),
+            "17:28: " + getCheckMessage(MSG_KEY),
+            "24:16: " + getCheckMessage(MSG_KEY),
+        };
+        verifyWithInlineConfigParser(
+            getPath("InputSingleSpaceSeparatorReservedWords.java"), expected);
+    }
+
 }

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/whitespace/singlespaceseparator/InputSingleSpaceSeparatorReservedWords.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/whitespace/singlespaceseparator/InputSingleSpaceSeparatorReservedWords.java
@@ -1,0 +1,28 @@
+/*
+SingleSpaceSeparator
+validateComments = (default)false
+
+
+*/
+
+package com.puppycrawl.tools.checkstyle.checks.whitespace.singlespaceseparator;
+
+public class InputSingleSpaceSeparatorReservedWords {
+      void testIf(int x) {
+        // violation below 'Use a single space to separate non-whitespace characters'
+        if   (x > 0) {
+          System.out.println("Positive");
+          // violation 2 lines below 'Use a single space to separate non-whitespace characters'
+          // violation below 'Use a single space to separate non-whitespace characters'
+        }       else       {
+          return;
+        }
+      }
+
+      void testFor() {
+        // violation below 'Use a single space to separate non-whitespace characters'
+        for    (int i = 0; i < 5; i++) {
+          System.out.println(i);
+        }
+      }
+}


### PR DESCRIPTION
Issue #17725: multiple spaces around reserved words not detected

added SingleSpaceSeparatorCheck to google-checks so now it detects the extra spaces


cat Test.java
```

class Test {
  void testIf(int x) {
    if   (x > 0) { // Expected 1 Violation for multiple spaces
      System.out.println("Positive");
    }       else       { // Expected 2 Violations for multiple spaces
      return;
    }
  }

  void testFor() {
    for    (int i = 0; i < 5; i++) { // Expected 1 Violation for multiple spaces
      System.out.println(i);
    }
  }
}
```

java -jar target/checkstyle-13.3.0-SNAPSHOT-all.jar -c /google_checks.xml Test.java
Starting audit...
[WARN] /home/youssef/checkstyle/Test.java:3:10: Use a single space to separate non-whitespace characters. [SingleSpaceSeparator]
[WARN] /home/youssef/checkstyle/Test.java:5:13: Use a single space to separate non-whitespace characters. [SingleSpaceSeparator]
[WARN] /home/youssef/checkstyle/Test.java:5:24: Use a single space to separate non-whitespace characters. [SingleSpaceSeparator]
[WARN] /home/youssef/checkstyle/Test.java:11:12: Use a single space to separate non-whitespace characters. [SingleSpaceSeparator]
Audit done.


Diff Regression config: https://gist.githubusercontent.com/Youssefalaa7/8929ccde6109c60ff9815d4e1fba40fd/raw/8da8745daecebf07a634b5bafff5c0325bf8b9e0/google_checks_base.xml

Diff Regression patch config: https://gist.githubusercontent.com/Youssefalaa7/7ff433cde8ce6b336063d9bea3aba2c8/raw/003509bcab5d2e588dca82dbb7612521db839d8b/patch_config.xml