### PR TITLE
Issue #11163: Enforce file size on JavadocVariable

### DIFF
--- a/config/checkstyle-resources-suppressions.xml
+++ b/config/checkstyle-resources-suppressions.xml
@@ -245,12 +245,6 @@
   <suppress checks="FileLength"
     files="[\\/]test[\\/]resources[\\/]com[\\/]puppycrawl[\\/]tools[\\/]checkstyle[\\/]checks[\\/]javadoc[\\/]javadoctagcontinuationindentation[\\/]InputJavadocTagContinuationIndentation\.java"/>
   <suppress checks="FileLength"
-    files="[\\/]test[\\/]resources[\\/]com[\\/]puppycrawl[\\/]tools[\\/]checkstyle[\\/]checks[\\/]javadoc[\\/]javadocvariable[\\/]InputJavadocVariableNoJavadoc5\.java"/>
-  <suppress checks="FileLength"
-    files="[\\/]test[\\/]resources[\\/]com[\\/]puppycrawl[\\/]tools[\\/]checkstyle[\\/]checks[\\/]javadoc[\\/]javadocvariable[\\/]InputJavadocVariableNoJavadoc2\.java"/>
-  <suppress checks="FileLength"
-    files="[\\/]test[\\/]resources[\\/]com[\\/]puppycrawl[\\/]tools[\\/]checkstyle[\\/]checks[\\/]javadoc[\\/]javadocvariable[\\/]InputJavadocVariableNoJavadoc3\.java"/>
-  <suppress checks="FileLength"
     files="[\\/]test[\\/]resources[\\/]com[\\/]puppycrawl[\\/]tools[\\/]checkstyle[\\/]checks[\\/]javadoc[\\/]javadoctype[\\/]InputJavadocTypeNoJavadoc\.java"/>
   <suppress checks="FileLength"
     files="[\\/]test[\\/]resources[\\/]com[\\/]puppycrawl[\\/]tools[\\/]checkstyle[\\/]checks[\\/]javadoc[\\/]javadoctype[\\/]InputJavadocTypeNoJavadoc_1\.java"/>

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocVariableCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocVariableCheckTest.java
@@ -206,7 +206,7 @@ public class JavadocVariableCheckTest
     }
 
     @Test
-    public void testAccessModifiersPublicProtected() throws Exception {
+    public void testAccessModifiersPublicProtectedPublic() throws Exception {
         final String[] expected = {
             "13:5: " + getCheckMessage(MSG_JAVADOC_MISSING),
             "14:5: " + getCheckMessage(MSG_JAVADOC_MISSING),
@@ -216,25 +216,32 @@ public class JavadocVariableCheckTest
             "37:9: " + getCheckMessage(MSG_JAVADOC_MISSING),
             "48:9: " + getCheckMessage(MSG_JAVADOC_MISSING),
             "49:9: " + getCheckMessage(MSG_JAVADOC_MISSING),
-            "61:5: " + getCheckMessage(MSG_JAVADOC_MISSING),
-            "62:5: " + getCheckMessage(MSG_JAVADOC_MISSING),
-            "72:9: " + getCheckMessage(MSG_JAVADOC_MISSING),
-            "73:9: " + getCheckMessage(MSG_JAVADOC_MISSING),
-            "84:9: " + getCheckMessage(MSG_JAVADOC_MISSING),
-            "85:9: " + getCheckMessage(MSG_JAVADOC_MISSING),
-            "96:9: " + getCheckMessage(MSG_JAVADOC_MISSING),
-            "97:9: " + getCheckMessage(MSG_JAVADOC_MISSING),
-            "108:9: " + getCheckMessage(MSG_JAVADOC_MISSING),
-            "109:9: " + getCheckMessage(MSG_JAVADOC_MISSING),
-            "130:9: " + getCheckMessage(MSG_JAVADOC_MISSING),
         };
         verifyWithInlineConfigParser(
-                getPath("InputJavadocVariableNoJavadoc2.java"),
-               expected);
+                getPath("InputJavadocVariableNoJavadoc2Public.java"), expected);
     }
 
     @Test
-    public void testAccessModifiersPackagePrivate() throws Exception {
+    public void testAccessModifiersPublicProtectedPackage() throws Exception {
+        final String[] expected = {
+            "13:5: " + getCheckMessage(MSG_JAVADOC_MISSING),
+            "14:5: " + getCheckMessage(MSG_JAVADOC_MISSING),
+            "24:9: " + getCheckMessage(MSG_JAVADOC_MISSING),
+            "25:9: " + getCheckMessage(MSG_JAVADOC_MISSING),
+            "36:9: " + getCheckMessage(MSG_JAVADOC_MISSING),
+            "37:9: " + getCheckMessage(MSG_JAVADOC_MISSING),
+            "48:9: " + getCheckMessage(MSG_JAVADOC_MISSING),
+            "49:9: " + getCheckMessage(MSG_JAVADOC_MISSING),
+            "60:9: " + getCheckMessage(MSG_JAVADOC_MISSING),
+            "61:9: " + getCheckMessage(MSG_JAVADOC_MISSING),
+            "82:9: " + getCheckMessage(MSG_JAVADOC_MISSING),
+        };
+        verifyWithInlineConfigParser(
+                getPath("InputJavadocVariableNoJavadoc2Package.java"), expected);
+    }
+
+    @Test
+    public void testAccessModifiersPackagePrivatePublic() throws Exception {
         final String[] expected = {
             "15:5: " + getCheckMessage(MSG_JAVADOC_MISSING),
             "16:5: " + getCheckMessage(MSG_JAVADOC_MISSING),
@@ -244,21 +251,28 @@ public class JavadocVariableCheckTest
             "39:9: " + getCheckMessage(MSG_JAVADOC_MISSING),
             "50:9: " + getCheckMessage(MSG_JAVADOC_MISSING),
             "51:9: " + getCheckMessage(MSG_JAVADOC_MISSING),
-            "63:5: " + getCheckMessage(MSG_JAVADOC_MISSING),
-            "64:5: " + getCheckMessage(MSG_JAVADOC_MISSING),
-            "74:9: " + getCheckMessage(MSG_JAVADOC_MISSING),
-            "75:9: " + getCheckMessage(MSG_JAVADOC_MISSING),
-            "86:9: " + getCheckMessage(MSG_JAVADOC_MISSING),
-            "87:9: " + getCheckMessage(MSG_JAVADOC_MISSING),
-            "98:9: " + getCheckMessage(MSG_JAVADOC_MISSING),
-            "99:9: " + getCheckMessage(MSG_JAVADOC_MISSING),
-            "110:9: " + getCheckMessage(MSG_JAVADOC_MISSING),
-            "111:9: " + getCheckMessage(MSG_JAVADOC_MISSING),
-            "121:9: " + getCheckMessage(MSG_JAVADOC_MISSING),
         };
         verifyWithInlineConfigParser(
-                getPath("InputJavadocVariableNoJavadoc3.java"),
-               expected);
+                getPath("InputJavadocVariableNoJavadoc3Public.java"), expected);
+    }
+
+    @Test
+    public void testAccessModifiersPackagePrivatePackage() throws Exception {
+        final String[] expected = {
+            "15:5: " + getCheckMessage(MSG_JAVADOC_MISSING),
+            "16:5: " + getCheckMessage(MSG_JAVADOC_MISSING),
+            "26:9: " + getCheckMessage(MSG_JAVADOC_MISSING),
+            "27:9: " + getCheckMessage(MSG_JAVADOC_MISSING),
+            "38:9: " + getCheckMessage(MSG_JAVADOC_MISSING),
+            "39:9: " + getCheckMessage(MSG_JAVADOC_MISSING),
+            "50:9: " + getCheckMessage(MSG_JAVADOC_MISSING),
+            "51:9: " + getCheckMessage(MSG_JAVADOC_MISSING),
+            "62:9: " + getCheckMessage(MSG_JAVADOC_MISSING),
+            "63:9: " + getCheckMessage(MSG_JAVADOC_MISSING),
+            "73:9: " + getCheckMessage(MSG_JAVADOC_MISSING),
+        };
+        verifyWithInlineConfigParser(
+                getPath("InputJavadocVariableNoJavadoc3Package.java"), expected);
     }
 
     @Test
@@ -318,8 +332,7 @@ public class JavadocVariableCheckTest
     }
 
     @Test
-    public void testDoNotIgnoreAnythingWhenIgnoreNamePatternIsEmpty()
-            throws Exception {
+    public void testDoNotIgnoreAnythingWhenIgnoreNamePatternIsEmptyPublic() throws Exception {
         final String[] expected = {
             "13:5: " + getCheckMessage(MSG_JAVADOC_MISSING),
             "14:5: " + getCheckMessage(MSG_JAVADOC_MISSING),
@@ -337,31 +350,38 @@ public class JavadocVariableCheckTest
             "49:9: " + getCheckMessage(MSG_JAVADOC_MISSING),
             "50:9: " + getCheckMessage(MSG_JAVADOC_MISSING),
             "51:9: " + getCheckMessage(MSG_JAVADOC_MISSING),
-            "61:5: " + getCheckMessage(MSG_JAVADOC_MISSING),
-            "62:5: " + getCheckMessage(MSG_JAVADOC_MISSING),
-            "63:5: " + getCheckMessage(MSG_JAVADOC_MISSING),
-            "64:5: " + getCheckMessage(MSG_JAVADOC_MISSING),
-            "72:9: " + getCheckMessage(MSG_JAVADOC_MISSING),
-            "73:9: " + getCheckMessage(MSG_JAVADOC_MISSING),
-            "74:9: " + getCheckMessage(MSG_JAVADOC_MISSING),
-            "75:9: " + getCheckMessage(MSG_JAVADOC_MISSING),
-            "84:9: " + getCheckMessage(MSG_JAVADOC_MISSING),
-            "85:9: " + getCheckMessage(MSG_JAVADOC_MISSING),
-            "86:9: " + getCheckMessage(MSG_JAVADOC_MISSING),
-            "87:9: " + getCheckMessage(MSG_JAVADOC_MISSING),
-            "96:9: " + getCheckMessage(MSG_JAVADOC_MISSING),
-            "97:9: " + getCheckMessage(MSG_JAVADOC_MISSING),
-            "98:9: " + getCheckMessage(MSG_JAVADOC_MISSING),
-            "99:9: " + getCheckMessage(MSG_JAVADOC_MISSING),
-            "108:9: " + getCheckMessage(MSG_JAVADOC_MISSING),
-            "109:9: " + getCheckMessage(MSG_JAVADOC_MISSING),
-            "110:9: " + getCheckMessage(MSG_JAVADOC_MISSING),
-            "111:9: " + getCheckMessage(MSG_JAVADOC_MISSING),
-            "121:9: " + getCheckMessage(MSG_JAVADOC_MISSING),
         };
         verifyWithInlineConfigParser(
-                getPath("InputJavadocVariableNoJavadoc5.java"),
-                expected);
+                getPath("InputJavadocVariableNoJavadoc5Public.java"), expected);
+    }
+
+    @Test
+    public void testDoNotIgnoreAnythingWhenIgnoreNamePatternIsEmptyPackage() throws Exception {
+        final String[] expected = {
+            "13:5: " + getCheckMessage(MSG_JAVADOC_MISSING),
+            "14:5: " + getCheckMessage(MSG_JAVADOC_MISSING),
+            "15:5: " + getCheckMessage(MSG_JAVADOC_MISSING),
+            "16:5: " + getCheckMessage(MSG_JAVADOC_MISSING),
+            "24:9: " + getCheckMessage(MSG_JAVADOC_MISSING),
+            "25:9: " + getCheckMessage(MSG_JAVADOC_MISSING),
+            "26:9: " + getCheckMessage(MSG_JAVADOC_MISSING),
+            "27:9: " + getCheckMessage(MSG_JAVADOC_MISSING),
+            "36:9: " + getCheckMessage(MSG_JAVADOC_MISSING),
+            "37:9: " + getCheckMessage(MSG_JAVADOC_MISSING),
+            "38:9: " + getCheckMessage(MSG_JAVADOC_MISSING),
+            "39:9: " + getCheckMessage(MSG_JAVADOC_MISSING),
+            "48:9: " + getCheckMessage(MSG_JAVADOC_MISSING),
+            "49:9: " + getCheckMessage(MSG_JAVADOC_MISSING),
+            "50:9: " + getCheckMessage(MSG_JAVADOC_MISSING),
+            "51:9: " + getCheckMessage(MSG_JAVADOC_MISSING),
+            "60:9: " + getCheckMessage(MSG_JAVADOC_MISSING),
+            "61:9: " + getCheckMessage(MSG_JAVADOC_MISSING),
+            "62:9: " + getCheckMessage(MSG_JAVADOC_MISSING),
+            "63:9: " + getCheckMessage(MSG_JAVADOC_MISSING),
+            "73:9: " + getCheckMessage(MSG_JAVADOC_MISSING),
+        };
+        verifyWithInlineConfigParser(
+                getPath("InputJavadocVariableNoJavadoc5Package.java"), expected);
     }
 
     @Test

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadocvariable/InputJavadocVariableNoJavadoc2Package.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadocvariable/InputJavadocVariableNoJavadoc2Package.java
@@ -8,56 +8,8 @@ tokens = (default)ENUM_CONSTANT_DEF
 
 package com.puppycrawl.tools.checkstyle.checks.javadoc.javadocvariable;
 
-public class InputJavadocVariableNoJavadoc2 //comment test
+class InputJavadocVariableNoJavadoc2Package
 {
-    public int i1; // violation, 'Missing a Javadoc comment'
-    protected int i2; // violation, 'Missing a Javadoc comment'
-    int i3;
-    private int i4;
-
-    public void foo1() {}
-    protected void foo2() {}
-    void foo3() {}
-    private void foo4() {}
-
-    protected class ProtectedInner {
-        public int i1; // violation, 'Missing a Javadoc comment'
-        protected int i2; // violation, 'Missing a Javadoc comment'
-        int i3;
-        private int i4;
-
-        public void foo1() {}
-        protected void foo2() {}
-        void foo3() {}
-        private void foo4() {}
-    }
-
-    class PackageInner {
-        public int i1; // violation, 'Missing a Javadoc comment'
-        protected int i2; // violation, 'Missing a Javadoc comment'
-        int i3;
-        private int i4;
-
-        public void foo1() {}
-        protected void foo2() {}
-        void foo3() {}
-        private void foo4() {}
-    }
-
-    private class PrivateInner {
-        public int i1; // violation, 'Missing a Javadoc comment'
-        protected int i2; // violation, 'Missing a Javadoc comment'
-        int i3;
-        private int i4;
-
-        public void foo1() {}
-        protected void foo2() {}
-        void foo3() {}
-        private void foo4() {}
-    }
-}
-
-class  PackageClass2 {
     public int i1; // violation, 'Missing a Javadoc comment'
     protected int i2; // violation, 'Missing a Javadoc comment'
     int i3;

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadocvariable/InputJavadocVariableNoJavadoc2Public.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadocvariable/InputJavadocVariableNoJavadoc2Public.java
@@ -1,0 +1,58 @@
+/*
+JavadocVariable
+accessModifiers = public, protected
+ignoreNamePattern = (default)null
+tokens = (default)ENUM_CONSTANT_DEF
+
+*/
+
+package com.puppycrawl.tools.checkstyle.checks.javadoc.javadocvariable;
+
+public class InputJavadocVariableNoJavadoc2Public //comment test
+{
+    public int i1; // violation, 'Missing a Javadoc comment'
+    protected int i2; // violation, 'Missing a Javadoc comment'
+    int i3;
+    private int i4;
+
+    public void foo1() {}
+    protected void foo2() {}
+    void foo3() {}
+    private void foo4() {}
+
+    protected class ProtectedInner {
+        public int i1; // violation, 'Missing a Javadoc comment'
+        protected int i2; // violation, 'Missing a Javadoc comment'
+        int i3;
+        private int i4;
+
+        public void foo1() {}
+        protected void foo2() {}
+        void foo3() {}
+        private void foo4() {}
+    }
+
+    class PackageInner {
+        public int i1; // violation, 'Missing a Javadoc comment'
+        protected int i2; // violation, 'Missing a Javadoc comment'
+        int i3;
+        private int i4;
+
+        public void foo1() {}
+        protected void foo2() {}
+        void foo3() {}
+        private void foo4() {}
+    }
+
+    private class PrivateInner {
+        public int i1; // violation, 'Missing a Javadoc comment'
+        protected int i2; // violation, 'Missing a Javadoc comment'
+        int i3;
+        private int i4;
+
+        public void foo1() {}
+        protected void foo2() {}
+        void foo3() {}
+        private void foo4() {}
+    }
+}

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadocvariable/InputJavadocVariableNoJavadoc3Package.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadocvariable/InputJavadocVariableNoJavadoc3Package.java
@@ -8,56 +8,8 @@ tokens = (default)ENUM_CONSTANT_DEF
 
 package com.puppycrawl.tools.checkstyle.checks.javadoc.javadocvariable;
 
-public class InputJavadocVariableNoJavadoc3 //comment test
+class InputJavadocVariableNoJavadoc3Package
 {
-    public int i1;
-    protected int i2;
-    int i3; // violation, 'Missing a Javadoc comment'
-    private int i4;// violation, 'Missing a Javadoc comment'
-
-    public void foo1() {}
-    protected void foo2() {}
-    void foo3() {}
-    private void foo4() {}
-
-    protected class ProtectedInner {
-        public int i1;
-        protected int i2;
-        int i3; // violation, 'Missing a Javadoc comment'
-        private int i4;// violation, 'Missing a Javadoc comment'
-
-        public void foo1() {}
-        protected void foo2() {}
-        void foo3() {}
-        private void foo4() {}
-    }
-
-    class PackageInner {
-        public int i1;
-        protected int i2;
-        int i3; // violation, 'Missing a Javadoc comment'
-        private int i4; // violation, 'Missing a Javadoc comment'
-
-        public void foo1() {}
-        protected void foo2() {}
-        void foo3() {}
-        private void foo4() {}
-    }
-
-    private class PrivateInner {
-        public int i1;
-        protected int i2;
-        int i3; // violation, 'Missing a Javadoc comment'
-        private int i4; // violation, 'Missing a Javadoc comment'
-
-        public void foo1() {}
-        protected void foo2() {}
-        void foo3() {}
-        private void foo4() {}
-    }
-}
-
-class PackageClass3 {
     public int i1;
     protected int i2;
     int i3; // violation, 'Missing a Javadoc comment'

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadocvariable/InputJavadocVariableNoJavadoc3Public.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadocvariable/InputJavadocVariableNoJavadoc3Public.java
@@ -1,0 +1,58 @@
+/*
+JavadocVariable
+accessModifiers = package, private
+ignoreNamePattern = (default)null
+tokens = (default)ENUM_CONSTANT_DEF
+
+*/
+
+package com.puppycrawl.tools.checkstyle.checks.javadoc.javadocvariable;
+
+public class InputJavadocVariableNoJavadoc3Public
+{
+    public int i1;
+    protected int i2;
+    int i3; // violation, 'Missing a Javadoc comment'
+    private int i4;// violation, 'Missing a Javadoc comment'
+
+    public void foo1() {}
+    protected void foo2() {}
+    void foo3() {}
+    private void foo4() {}
+
+    protected class ProtectedInner {
+        public int i1;
+        protected int i2;
+        int i3; // violation, 'Missing a Javadoc comment'
+        private int i4;// violation, 'Missing a Javadoc comment'
+
+        public void foo1() {}
+        protected void foo2() {}
+        void foo3() {}
+        private void foo4() {}
+    }
+
+    class PackageInner {
+        public int i1;
+        protected int i2;
+        int i3; // violation, 'Missing a Javadoc comment'
+        private int i4; // violation, 'Missing a Javadoc comment'
+
+        public void foo1() {}
+        protected void foo2() {}
+        void foo3() {}
+        private void foo4() {}
+    }
+
+    private class PrivateInner {
+        public int i1;
+        protected int i2;
+        int i3; // violation, 'Missing a Javadoc comment'
+        private int i4; // violation, 'Missing a Javadoc comment'
+
+        public void foo1() {}
+        protected void foo2() {}
+        void foo3() {}
+        private void foo4() {}
+    }
+}

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadocvariable/InputJavadocVariableNoJavadoc5Package.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadocvariable/InputJavadocVariableNoJavadoc5Package.java
@@ -8,56 +8,8 @@ tokens = (default)ENUM_CONSTANT_DEF
 
 package com.puppycrawl.tools.checkstyle.checks.javadoc.javadocvariable;
 
-public class InputJavadocVariableNoJavadoc5 //comment test
+class InputJavadocVariableNoJavadoc5Package
 {
-    public int i1; // violation, 'Missing a Javadoc comment'
-    protected int i2; // violation, 'Missing a Javadoc comment'
-    int i3; // violation, 'Missing a Javadoc comment'
-    private int i4; // violation, 'Missing a Javadoc comment'
-
-    public void foo1() {}
-    protected void foo2() {}
-    void foo3() {}
-    private void foo4() {}
-
-    protected class ProtectedInner {
-        public int i1; // violation, 'Missing a Javadoc comment'
-        protected int i2; // violation, 'Missing a Javadoc comment'
-        int i3; // violation, 'Missing a Javadoc comment'
-        private int i4; // violation, 'Missing a Javadoc comment'
-
-        public void foo1() {}
-        protected void foo2() {}
-        void foo3() {}
-        private void foo4() {}
-    }
-
-    class PackageInner {
-        public int i1; // violation, 'Missing a Javadoc comment'
-        protected int i2; // violation, 'Missing a Javadoc comment'
-        int i3; // violation, 'Missing a Javadoc comment'
-        private int i4; // violation, 'Missing a Javadoc comment'
-
-        public void foo1() {}
-        protected void foo2() {}
-        void foo3() {}
-        private void foo4() {}
-    }
-
-    private class PrivateInner {
-        public int i1; // violation, 'Missing a Javadoc comment'
-        protected int i2; // violation, 'Missing a Javadoc comment'
-        int i3; // violation, 'Missing a Javadoc comment'
-        private int i4; // violation, 'Missing a Javadoc comment'
-
-        public void foo1() {}
-        protected void foo2() {}
-        void foo3() {}
-        private void foo4() {}
-    }
-}
-
-class PackageClass5 {
     public int i1; // violation, 'Missing a Javadoc comment'
     protected int i2; // violation, 'Missing a Javadoc comment'
     int i3; // violation, 'Missing a Javadoc comment'

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadocvariable/InputJavadocVariableNoJavadoc5Public.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadocvariable/InputJavadocVariableNoJavadoc5Public.java
@@ -1,0 +1,58 @@
+/*
+JavadocVariable
+accessModifiers = (default)public,protected,package,private
+ignoreNamePattern =
+tokens = (default)ENUM_CONSTANT_DEF
+
+*/
+
+package com.puppycrawl.tools.checkstyle.checks.javadoc.javadocvariable;
+
+public class InputJavadocVariableNoJavadoc5Public //comment test
+{
+    public int i1; // violation, 'Missing a Javadoc comment'
+    protected int i2; // violation, 'Missing a Javadoc comment'
+    int i3; // violation, 'Missing a Javadoc comment'
+    private int i4; // violation, 'Missing a Javadoc comment'
+
+    public void foo1() {}
+    protected void foo2() {}
+    void foo3() {}
+    private void foo4() {}
+
+    protected class ProtectedInner {
+        public int i1; // violation, 'Missing a Javadoc comment'
+        protected int i2; // violation, 'Missing a Javadoc comment'
+        int i3; // violation, 'Missing a Javadoc comment'
+        private int i4; // violation, 'Missing a Javadoc comment'
+
+        public void foo1() {}
+        protected void foo2() {}
+        void foo3() {}
+        private void foo4() {}
+    }
+
+    class PackageInner {
+        public int i1; // violation, 'Missing a Javadoc comment'
+        protected int i2; // violation, 'Missing a Javadoc comment'
+        int i3; // violation, 'Missing a Javadoc comment'
+        private int i4; // violation, 'Missing a Javadoc comment'
+
+        public void foo1() {}
+        protected void foo2() {}
+        void foo3() {}
+        private void foo4() {}
+    }
+
+    private class PrivateInner {
+        public int i1; // violation, 'Missing a Javadoc comment'
+        protected int i2; // violation, 'Missing a Javadoc comment'
+        int i3; // violation, 'Missing a Javadoc comment'
+        private int i4; // violation, 'Missing a Javadoc comment'
+
+        public void foo1() {}
+        protected void foo2() {}
+        void foo3() {}
+        private void foo4() {}
+    }
+}


### PR DESCRIPTION
Issue #11163

**Description:**
Split the remaining `javadocvariable` input files to enforce the 120-line limit and improve readability and maintainability of `JavadocVariableCheck` tests.

The original test inputs covered multiple class access modifiers and inner classes in single large files. This change separates them into:
* `InputJavadocVariableNoJavadoc2.java` split into:
  * `InputJavadocVariableNoJavadoc2Public`
  * `InputJavadocVariableNoJavadoc2Package`
* `InputJavadocVariableNoJavadoc3.java` split into:
  * `InputJavadocVariableNoJavadoc3Public`
  * `InputJavadocVariableNoJavadoc3Package`
* `InputJavadocVariableNoJavadoc5.java` split into:
  * `InputJavadocVariableNoJavadoc5Public`
  * `InputJavadocVariableNoJavadoc5Package`

Removed the old giant files and deleted their corresponding suppression entries in `checkstyle_resources_suppressions.xml`.