### PR TITLE
Issue #17253: Enforce no line break before '->' in google style

### DIFF
--- a/config/checkstyle-checks.xml
+++ b/config/checkstyle-checks.xml
@@ -1003,6 +1003,7 @@
       <property name="tokens" value="BXOR_ASSIGN"/>
       <property name="tokens" value="BOR_ASSIGN"/>
       <property name="tokens" value="BAND_ASSIGN"/>
+      <property name="tokens" value="LAMBDA"/>
       <property name="option" value="eol"/>
     </module>
     <module name="ParenPad"/>

--- a/src/it/resources/com/google/checkstyle/test/chapter4formatting/rule451wheretobreak/InputIllegalLineBreakAroundLambda.java
+++ b/src/it/resources/com/google/checkstyle/test/chapter4formatting/rule451wheretobreak/InputIllegalLineBreakAroundLambda.java
@@ -10,8 +10,9 @@ public class InputIllegalLineBreakAroundLambda {
   }
 
   void test() {
+    // violation 2 lines below ''->' should be on the previous line.'
     MyLambdaInterface div = (a, b)
-        -> { // illegal line break before lambda, ok until #17253
+        -> {
           if (b != 0) {
             return a / b;
           }
@@ -37,15 +38,18 @@ public class InputIllegalLineBreakAroundLambda {
 
   void test2(int day) {
     ArrayList<String> list = new ArrayList<>();
+    // violation 3 lines below ''->' should be on the previous line.'
     list.stream()
         .map(x
-            -> x.toString()); // illegal line break before lambda, ok until #17253
+            -> x.toString());
 
     String dayString = switch (day) {
+      // violation 2 lines below ''->' should be on the previous line.'
       case 1
-          -> "one day of the week";  // illegal line break before lambda, ok until #17253
+          -> "one day of the week";
+      // violation 2 lines below ''->' should be on the previous line.'
       case 2
-          -> // illegal line break before lambda, ok until #17253
+          ->
               "two day of the week";
       case 3 -> // ok because text following '->' is unbraced.
           "third day of the week";
@@ -57,14 +61,15 @@ public class InputIllegalLineBreakAroundLambda {
   void test3(TransactionStatus transaction) {
     String status = switch (transaction) {
       case TransactionIsComplete -> "ok done";
+      // violation 2 lines below ''->' should be on the previous line.'
       case NotValidTryAgain
-          -> // illegal line break before lambda, ok until #17253
+          ->
               "Please Enter the valid value. Try again this time with valid value";
       case CouldNotBeginTheProcess ->
           "Please try again after some time. Downtime.";
       case ErrorInProcessingTryAgain
           ->  "Please try again after some time. you made a mistake or there is something wrong.";
-      // illegal line break before lambda above, ok until #17253
+      // violation above, ''->' should be on the previous line.'
       default ->
           throw new IllegalArgumentException("");
     };

--- a/src/it/resources/com/google/checkstyle/test/chapter4formatting/rule451wheretobreak/InputLambdaBodyWrap.java
+++ b/src/it/resources/com/google/checkstyle/test/chapter4formatting/rule451wheretobreak/InputLambdaBodyWrap.java
@@ -23,6 +23,7 @@ public class InputLambdaBodyWrap {
   }
 
   private void runTask() {
+    // violation 2 lines below ''->' should be on the previous line.'
     Runnable runTask = ()
         -> {
           System.out.println("Starting task");
@@ -67,6 +68,7 @@ public class InputLambdaBodyWrap {
           return value;
         };
 
+    // violation 3 lines below ''->' should be on the previous line.'
     // violation 3 lines below ''{' at column 11 should be on the previous line.'
     java.util.function.Predicate<String> predicate = str
         ->

--- a/src/it/resources/com/google/checkstyle/test/chapter4formatting/rule4841indentation/InputSingleSwitchStatementWithoutCurly.java
+++ b/src/it/resources/com/google/checkstyle/test/chapter4formatting/rule4841indentation/InputSingleSwitchStatementWithoutCurly.java
@@ -6,6 +6,7 @@ package com.google.checkstyle.test.chapter4formatting.rule4841indentation;
 public class InputSingleSwitchStatementWithoutCurly {
   void testCorrectIndentation(int obj) {
     switch (obj) {
+      // violation 2 lines below ''->' should be on the previous line.'
       case 0
           ->
               System.out.println("Test");
@@ -21,7 +22,10 @@ public class InputSingleSwitchStatementWithoutCurly {
   void testIncorrectIndentation(int obj) {
     switch (obj) {
       case 1
-      ->                            // violation '.* incorrect indentation level 6, expected .* 10.'
+      ->
+      // 2 violations above:
+      //  '.* incorrect indentation level 6, expected .* 10.'
+      //  ''->' should be on the previous line.'
       System.out.println("Test");
       // violation above '.* incorrect indentation level 6, expected .* 14.'
     case 2 ->                      // violation '.* incorrect indentation level 4, expected .* 6.'
@@ -33,6 +37,7 @@ System.out.println("Test");        // violation '.* incorrect indentation level 
   void testMixedCases(int obj) {
     switch (obj) {
       case 1 -> System.out.println("TEST");
+      // violation 2 lines below ''->' should be on the previous line.'
       case 2
           -> System.out.println("Test");
       case 3 ->

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/whitespace/OperatorWrapCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/whitespace/OperatorWrapCheck.java
@@ -141,6 +141,7 @@ public class OperatorWrapCheck
             TokenTypes.BOR_ASSIGN,        // "|="
             TokenTypes.BAND_ASSIGN,       // "&="
             TokenTypes.METHOD_REF,        // "::"
+            TokenTypes.LAMBDA,            // "->"
         };
     }
 

--- a/src/main/resources/google_checks.xml
+++ b/src/main/resources/google_checks.xml
@@ -371,11 +371,17 @@
                     RECORD_DEF, RECORD_PATTERN_DEF"/>
     </module>
     <module name="OperatorWrap">
+      <property name="id" value="OperatorWrapNL"/>
       <property name="option" value="NL"/>
       <property name="tokens"
                value="BAND, BOR, BSR, BXOR, DIV, EQUAL, GE, GT, LAND, LE, LITERAL_INSTANCEOF, LOR,
                     LT, MINUS, MOD, NOT_EQUAL, PLUS, QUESTION, SL, SR, STAR, METHOD_REF,
                     TYPE_EXTENSION_AND "/>
+    </module>
+    <module name="OperatorWrap">
+      <property name="id" value="OperatorWrapEOL"/>
+      <property name="option" value="EOL"/>
+      <property name="tokens" value="LAMBDA"/>
     </module>
     <module name="AnnotationLocation">
       <property name="id" value="AnnotationLocationTypeAndPackage"/>

--- a/src/site/xdoc/checks/whitespace/operatorwrap.xml
+++ b/src/site/xdoc/checks/whitespace/operatorwrap.xml
@@ -114,6 +114,8 @@
                     BAND_ASSIGN</a>
                 , <a href="../../apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#METHOD_REF">
                     METHOD_REF</a>
+                , <a href="../../apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#LAMBDA">
+                    LAMBDA</a>
                   .
               </td>
               <td>

--- a/src/site/xdoc/google_style.xml
+++ b/src/site/xdoc/google_style.xml
@@ -909,7 +909,7 @@
                   <br />
                   <br />
                   <span class="wrapper inline">
-                    <img src="images/ok_blue.png" alt="" />
+                    <img src="images/ok_green.png" alt="" />
                   </span>
                   <a href="checks/whitespace/separatorwrap.html#SeparatorWrap">SeparatorWrap</a>
                   (<a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources%20path%3A**%2Fgoogle_checks.xml+repo%3Acheckstyle%2Fcheckstyle+SeparatorWrap">
@@ -922,13 +922,6 @@
                   <a href="checks/whitespace/methodparampad.html#MethodParamPad">MethodParamPad</a>
                   (<a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources%20path%3A**%2Fgoogle_checks.xml+repo%3Acheckstyle%2Fcheckstyle+MethodParamPad">
                   config</a>)
-                  <br />
-                  <br />
-                  Line break before and after the lambda(<code>-></code>) is not covered.
-                  It will be addressed at:
-                  <a href="https://github.com/checkstyle/checkstyle/issues/17253">
-                    #17253
-                  </a>
                 </td>
                 <td>
                   <a href="https://github.com/checkstyle/checkstyle/tree/master/src/it/resources/com/google/checkstyle/test/chapter4formatting/rule451wheretobreak">

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/whitespace/OperatorWrapCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/whitespace/OperatorWrapCheckTest.java
@@ -217,4 +217,19 @@ public class OperatorWrapCheckTest
                         "InputOperatorWrapInstanceOfOperatorEndOfLine.java"), expected);
     }
 
+    @Test
+    public void testLambdaEol() throws Exception {
+        final String[] expected = {
+            "20:9: " + getCheckMessage(MSG_LINE_PREVIOUS, "->"),
+            "29:9: " + getCheckMessage(MSG_LINE_PREVIOUS, "->"),
+            "38:17: " + getCheckMessage(MSG_LINE_PREVIOUS, "->"),
+            "47:13: " + getCheckMessage(MSG_LINE_PREVIOUS, "->"),
+            "60:17: " + getCheckMessage(MSG_LINE_PREVIOUS, "->"),
+            "70:17: " + getCheckMessage(MSG_LINE_PREVIOUS, "->"),
+            "81:17: " + getCheckMessage(MSG_LINE_PREVIOUS, "->"),
+        };
+        verifyWithInlineConfigParser(
+                getPath("InputOperatorWrapLambda.java"), expected);
+    }
+
 }

--- a/src/test/java/com/puppycrawl/tools/checkstyle/internal/XpathRegressionTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/internal/XpathRegressionTest.java
@@ -102,8 +102,8 @@ public class XpathRegressionTest extends AbstractModuleTestSupport {
         getAllowedDirectoryAndChecks();
 
     private static final Set<String> INTERNAL_MODULES = getInternalModules();
-    private static final DirectoryStream.Filter<Path> IS_DIRECTORY = path
-            -> path.toFile().isDirectory();
+    private static final DirectoryStream.Filter<Path> IS_DIRECTORY =
+        path -> path.toFile().isDirectory();
 
     private Path javaDir;
     private Path inputDir;

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/whitespace/operatorwrap/InputOperatorWrapLambda.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/whitespace/operatorwrap/InputOperatorWrapLambda.java
@@ -1,0 +1,86 @@
+/*
+OperatorWrap
+option = EOL
+tokens = LAMBDA
+
+
+*/
+
+package com.puppycrawl.tools.checkstyle.checks.whitespace.operatorwrap;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.function.Function;
+import java.util.function.Supplier;
+
+public class InputOperatorWrapLambda {
+
+    // violation 2 lines below ''->' should be on the previous line.'
+    Runnable r1 = ()
+        -> {};
+
+    Runnable r2 = () -> {};
+
+    Supplier<String> s1 = () ->
+            "hello";
+
+    // violation 2 lines below ''->' should be on the previous line.'
+    Function<String, String> f1 = x
+        -> x.toUpperCase();
+
+    Function<String, String> f2 = x -> x.toUpperCase();
+
+    void testStreamLambda() {
+        List<String> list = Arrays.asList("a", "b");
+        // violation 3 lines below ''->' should be on the previous line.'
+        list.stream()
+            .map(x
+                -> x.toString());
+
+        list.stream()
+            .map(x -> x.toString());
+    }
+
+    void testLambdaWithBlock() {
+        // violation 2 lines below ''->' should be on the previous line.'
+        Runnable r = ()
+            -> {
+              System.out.println("hello");
+            };
+
+        Runnable r2 = () -> {
+            System.out.println("hello");
+        };
+    }
+
+    String testSwitchRule(int day) {
+        return switch (day) {
+            // violation 2 lines below ''->' should be on the previous line.'
+            case 1
+                -> "Monday";
+
+            case 2 ->
+                "Tuesday";
+            case 3 -> "Wednesday";
+            case 4 -> {
+                yield "Thursday";
+            }
+            // violation 2 lines below ''->' should be on the previous line.'
+            case 5
+                -> {
+                yield "Friday";
+            }
+            default -> throw new IllegalArgumentException();
+        };
+    }
+
+    int testSwitchMultipleLabels(int val) {
+        return switch (val) {
+            // violation 2 lines below ''->' should be on the previous line.'
+            case 1, 2, 3
+                -> val * 2;
+            case 4, 5 -> val * 3;
+            default -> 0;
+        };
+    }
+}


### PR DESCRIPTION
Issue #17253:
Enforces Google Java Style Guide rule 4.5.1 for lambda arrows and switch rules:
> "A line is never broken adjacent to the arrow in a lambda or a switch rule,  except that a break may come immediately after the arrow if the text following it consists of a single unbraced expression."

This is implemented by adding `LAMBDA` token support to `OperatorWrap` check with `EOL` option in `google_checks.xml`. The `LAMBDA` token type in checkstyle's AST represents the `->` operator in both lambda expressions and switch rules, so a single configuration handles both cases.

The `EOL` option ensures `->` appears on the same line as what precedes it(no line break before `->`). Line breaks *after* `->` are permitted, which aligns with the style guide allowing a break after `->` when followed by a single unbraced expression.

Diff Regression config: https://gist.githubusercontent.com/vivek-0509/3e9b04adbe8a31bc23ebf33bb3f9acb6/raw/dc8a1f97334ef830ab58cc392171513edd1822c5/base_config.xml

Diff Regression patch config: https://gist.githubusercontent.com/vivek-0509/c7c2b896a7c103f04a4aef390a17e639/raw/e4ab16a1c0363daadfc0cba7ddbd92ad5b1fff85/patch_config.xml