### PR TITLE
Issue #16361: update testAddErrorModuleId to use verifyWithInlineconf…

### DIFF
--- a/src/test/java/com/puppycrawl/tools/checkstyle/DefaultLoggerTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/DefaultLoggerTest.java
@@ -37,7 +37,6 @@ import org.junit.jupiter.api.Test;
 import com.puppycrawl.tools.checkstyle.AbstractAutomaticBean.OutputStreamOptions;
 import com.puppycrawl.tools.checkstyle.api.AuditEvent;
 import com.puppycrawl.tools.checkstyle.api.AutomaticBean;
-import com.puppycrawl.tools.checkstyle.api.Violation;
 import com.puppycrawl.tools.checkstyle.internal.utils.TestUtil;
 
 public class DefaultLoggerTest extends AbstractModuleTestSupport {
@@ -216,28 +215,21 @@ public class DefaultLoggerTest extends AbstractModuleTestSupport {
     }
 
     @Test
-    public void testAddErrorModuleId() {
-        final OutputStream infoStream = new ByteArrayOutputStream();
-        final OutputStream errorStream = new ByteArrayOutputStream();
-        final String auditFinishMessage = getAuditFinishMessage();
-        final String auditStartMessage = getAuditStartMessage();
+    public void testAddErrorModuleId() throws Exception {
+        final String inputFile = "InputDefaultLoggerTestAddErrorModuleId.java";
+        final String expectedInfoFile = "ExpectedDefaultLoggerInfoDefaultOutput.txt";
+        final String expectedErrorFile = "ExpectedDefaultLoggerErrorsTestAddErrorModuleId.txt";
+
+        final ByteArrayOutputStream infoStream = new ByteArrayOutputStream();
+        final ByteArrayOutputStream errorStream = new ByteArrayOutputStream();
         final DefaultLogger dl = new DefaultLogger(infoStream, OutputStreamOptions.CLOSE,
                 errorStream, OutputStreamOptions.CLOSE);
-        dl.finishLocalSetup();
-        dl.auditStarted(null);
-        dl.addError(new AuditEvent(this, "fileName", new Violation(1, 2, "bundle", "key",
-                null, "moduleId", getClass(), "customViolation")));
-        dl.auditFinished(null);
-        assertWithMessage("expected output")
-            .that(infoStream.toString())
-            .isEqualTo(auditStartMessage
-                        + System.lineSeparator()
-                        + auditFinishMessage
-                        + System.lineSeparator());
-        assertWithMessage("expected output")
-            .that(errorStream.toString())
-            .isEqualTo("[ERROR] fileName:1:2: customViolation [moduleId]"
-                + System.lineSeparator());
+
+        verifyWithInlineConfigParserAndDefaultLogger(
+                getPath(inputFile),
+                getPath(expectedInfoFile),
+                getPath(expectedErrorFile),
+                dl, infoStream, errorStream);
     }
 
     @Test
@@ -356,26 +348,6 @@ public class DefaultLoggerTest extends AbstractModuleTestSupport {
                 .that(errorStream.closedCount)
                 .isEqualTo(0);
         }
-    }
-
-    private static LocalizedMessage getAuditStartMessageClass() {
-        return new LocalizedMessage(Definitions.CHECKSTYLE_BUNDLE,
-                DefaultLogger.class, "DefaultLogger.auditStarted");
-    }
-
-    private static LocalizedMessage getAuditFinishMessageClass() {
-        return new LocalizedMessage(Definitions.CHECKSTYLE_BUNDLE,
-                DefaultLogger.class, "DefaultLogger.auditFinished");
-    }
-
-    private static String getAuditStartMessage() {
-        final LocalizedMessage auditStartMessage = getAuditStartMessageClass();
-        return auditStartMessage.getMessage();
-    }
-
-    private static String getAuditFinishMessage() {
-        final LocalizedMessage auditFinishMessage = getAuditFinishMessageClass();
-        return auditFinishMessage.getMessage();
     }
 
     private static final class MockByteArrayOutputStream extends ByteArrayOutputStream {

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/defaultlogger/ExpectedDefaultLoggerErrorsTestAddErrorModuleId.txt
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/defaultlogger/ExpectedDefaultLoggerErrorsTestAddErrorModuleId.txt
@@ -1,0 +1,1 @@
+[ERROR] src/test/resources/com/puppycrawl/tools/checkstyle/defaultlogger/InputDefaultLoggerTestAddErrorModuleId.java:13:8: Unused import - java.util.List. [moduleId]

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/defaultlogger/InputDefaultLoggerTestAddErrorModuleId.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/defaultlogger/InputDefaultLoggerTestAddErrorModuleId.java
@@ -1,0 +1,16 @@
+/*xml
+<module name="Checker">
+  <module name="TreeWalker">
+    <module name="com.puppycrawl.tools.checkstyle.checks.imports.UnusedImportsCheck">
+        <property name="id" value="moduleId" />
+    </module>
+  </module>
+</module>
+*/
+
+package com.puppycrawl.tools.checkstyle.defaultlogger;
+
+import java.util.List; // violation 'Unused import - java.util.List.'
+
+public class InputDefaultLoggerTestAddErrorModuleId {
+}


### PR DESCRIPTION
Issue #16361

### Changes
- Refactored `testAddErrorModuleId` to use `verifyWithInlineConfigParserAndDefaultLogger`.
- Added a new input file with inline XML configuration:
  - Uses `<module name="com.puppycrawl.tools.checkstyle.checks.imports.UnusedImportsCheck">` with `id="moduleId"`.
  - Contains a single unused import to trigger the error.
- Added an expected error output file that contains the expected logger output for the module ID test.
