### PR TITLE
minor: remove duplicate test

### DIFF
--- a/src/test/java/com/puppycrawl/tools/checkstyle/DefaultLoggerTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/DefaultLoggerTest.java
@@ -216,32 +216,6 @@ public class DefaultLoggerTest extends AbstractModuleTestSupport {
     }
 
     @Test
-    public void testAddError() {
-        final OutputStream infoStream = new ByteArrayOutputStream();
-        final OutputStream errorStream = new ByteArrayOutputStream();
-        final String auditStartMessage = getAuditStartMessage();
-        final String auditFinishMessage = getAuditFinishMessage();
-        final DefaultLogger dl = new DefaultLogger(infoStream,
-                OutputStreamOptions.CLOSE, errorStream,
-                OutputStreamOptions.CLOSE);
-        dl.finishLocalSetup();
-        dl.auditStarted(null);
-        dl.addError(new AuditEvent(this, "fileName", new Violation(1, 2, "bundle", "key",
-                null, null, getClass(), "customViolation")));
-        dl.auditFinished(null);
-        assertWithMessage("expected output")
-            .that(infoStream.toString())
-            .isEqualTo(auditStartMessage
-                        + System.lineSeparator()
-                        + auditFinishMessage
-                        + System.lineSeparator());
-        assertWithMessage("expected output")
-            .that(errorStream.toString())
-            .isEqualTo("[ERROR] fileName:1:2: customViolation [DefaultLoggerTest]"
-                + System.lineSeparator());
-    }
-
-    @Test
     public void testAddErrorModuleId() {
         final OutputStream infoStream = new ByteArrayOutputStream();
         final OutputStream errorStream = new ByteArrayOutputStream();


### PR DESCRIPTION
**Refer to:** #16361 and [this comment](https://github.com/checkstyle/checkstyle/issues/16361#issuecomment-3955485179)

## Why?
While migrating `testAddError`, I noticed that updating it to use `verifyWithInlineConfigParserAndDefaultLogger` would make it functionally identical to [testSingleError](https://github.com/checkstyle/checkstyle/blob/e6a0703eb38acf2cb064e30990cc7c0aa2d7f029/src/test/java/com/puppycrawl/tools/checkstyle/DefaultLoggerTest.java#L77).

To avoid duplicate tests, I’m proposing to remove `testAddError`. If this affects test coverage, we could instead keep it but change the error type it tests to ensure unique coverage.

I’m happy to adjust this approach if it is prefered keeping the test or making other changes.