### PR TITLE
Issue #18926: Re-enable 'WhileCanBeDoWhile' inspection

### DIFF
--- a/config/intellij-idea-inspections.xml
+++ b/config/intellij-idea-inspections.xml
@@ -5222,9 +5222,8 @@
   <inspection_tool class="Weblogic" enabled="false" level="ERROR" enabled_by_default="false"/>
   <inspection_tool class="WhenWithOnlyElse" enabled="false" level="WEAK WARNING"
                    enabled_by_default="false"/>
-  <!-- temporary disabled until https://github.com/checkstyle/checkstyle/issues/18926 -->
-  <inspection_tool class="WhileCanBeDoWhile" enabled="false" level="WARNING"
-                   enabled_by_default="false" />
+  <inspection_tool class="WhileCanBeDoWhile" enabled="true" level="WARNING"
+                   enabled_by_default="true"/>
   <inspection_tool class="WhileCanBeForeach" enabled="true" level="ERROR"
                    enabled_by_default="true"/>
   <inspection_tool class="WhileLoopSpinsOnField" enabled="true" level="WARNING"


### PR DESCRIPTION
Resolves part of #18926.

This PR re-enables the `WhileCanBeDoWhile` inspection in Qodana.

**Note to reviewers:** I am opening this PR as a draft initially to trigger the Qodana CI pipeline and filter the exact list of files violating this specific inspection. I will push the code fixes shortly once the CI provides the targeted report.