### PR TITLE
Issue #18926: Re-enable 'EmptyClass' inspection

### DIFF
--- a/config/intellij-idea-inspections.xml
+++ b/config/intellij-idea-inspections.xml
@@ -1681,8 +1681,7 @@
   </inspection_tool>
   <inspection_tool class="EmptyCatchBlockJS" enabled="true" level="ERROR"
                    enabled_by_default="true"/>
-  <!-- temporary disabled until https://github.com/checkstyle/checkstyle/issues/18926 -->
-  <inspection_tool class="EmptyClass" enabled="false" level="WARNING" enabled_by_default="false">
+  <inspection_tool class="EmptyClass" enabled="true" level="WARNING" enabled_by_default="true">
     <option name="ignorableAnnotations">
       <value/>
     </option>
@@ -4510,6 +4509,8 @@
         <option value="JUnitTestClassNamingConvention"/>
         <!-- usage of picocli library in Main.java case we won't fix -->
         <option value="CanBeFinal"/>
+        <!-- false positive from Language Injection in snippet block -->
+        <option value="EmptyClass"/>
       </list>
     </option>
   </inspection_tool>

--- a/src/main/java/com/puppycrawl/tools/checkstyle/api/JavadocCommentsTokenTypes.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/api/JavadocCommentsTokenTypes.java
@@ -27,8 +27,9 @@ import com.puppycrawl.tools.checkstyle.grammar.javadoc.JavadocCommentsLexer;
  *
  * @see <a href="https://docs.oracle.com/javase/8/docs/technotes/tools/unix/javadoc.html">
  *     javadoc - The Java API Documentation Generator</a>
- * @noinspection JavadocDeclaration
+ * @noinspection JavadocDeclaration ,EmptyClass
  * @noinspectionreason JavadocDeclaration - Javadoc is intentional
+ * @noinspectionreason EmptyClass - false positive from Language Injection in snippet block
  */
 @SuppressWarnings({"InvalidInlineTag", "UnrecognisedJavadocTag"})
 public final class JavadocCommentsTokenTypes {


### PR DESCRIPTION
Fixes #18926

This PR re-enables the `EmptyClass` inspection in Qodana.

**Note to reviewers:** I am opening this PR as a draft initially to trigger the Qodana CI pipeline and filter the exact list of files violating this specific inspection. I will push the code fixes shortly once the CI provides the targeted report.