### PR TITLE
Issue #14782: Add LITERAL_DEFAULT token support in RightCurlyCheck

### DIFF
--- a/config/checkstyle-checks.xml
+++ b/config/checkstyle-checks.xml
@@ -371,6 +371,7 @@
       <property name="tokens" value="RECORD_DEF"/>
       <property name="tokens" value="COMPACT_CTOR_DEF"/>
       <property name="tokens" value="LITERAL_CASE"/>
+      <property name="tokens" value="LITERAL_DEFAULT"/>
       <property name="option" value="alone"/>
     </module>
     <module name="RightCurly">

--- a/src/it/resources/com/google/checkstyle/test/chapter4formatting/rule412nonemptyblocks/InputRightCurlySwitchCasesBlocks.java
+++ b/src/it/resources/com/google/checkstyle/test/chapter4formatting/rule412nonemptyblocks/InputRightCurlySwitchCasesBlocks.java
@@ -84,7 +84,7 @@ public class InputRightCurlySwitchCasesBlocks {
         }
       default:
         {
-          int x = 2; } // false-negative until #14782
+          int x = 2; } // violation ''}' at column 22 should be alone on a line.'
     }
   }
 
@@ -142,7 +142,7 @@ public class InputRightCurlySwitchCasesBlocks {
             break; // violation '.* incorrect indentation .* 12, expected .* following: 8, 10.'
         }
       default: { // violation ''{' at column 16 should be on a new line.'
-        int x = 2; } // false-negative until #14782
+        int x = 2; } // violation ''}' at column 20 should be alone on a line.'
     }
   }
 }

--- a/src/it/resources/com/google/checkstyle/test/chapter4formatting/rule4841indentation/InputLineBreakAfterLeftCurlyOfBlockInSwitch.java
+++ b/src/it/resources/com/google/checkstyle/test/chapter4formatting/rule4841indentation/InputLineBreakAfterLeftCurlyOfBlockInSwitch.java
@@ -25,6 +25,7 @@ public class InputLineBreakAfterLeftCurlyOfBlockInSwitch {
           handleTwoWithAnExtremelyLongMethodCallThatWouldNotFitOnTheSameLine();
       // violation below ''{' at column 18 should have line break after'
       default -> { handleSurprisingNumber(number); }
+      // violation above ''}' at column 52 should be alone on a line.'
     }
   }
 

--- a/src/main/resources/com/puppycrawl/tools/checkstyle/meta/checks/blocks/RightCurlyCheck.xml
+++ b/src/main/resources/com/puppycrawl/tools/checkstyle/meta/checks/blocks/RightCurlyCheck.xml
@@ -6,8 +6,8 @@
              parent="com.puppycrawl.tools.checkstyle.TreeWalker">
          <description>&lt;div&gt;
  Checks the placement of right curly braces (&lt;code&gt;'}'&lt;/code&gt;) for code blocks. This check
- supports if-else, try-catch-finally blocks, switch statements, switch cases, while-loops,
-  for-loops, method definitions, class definitions, constructor definitions,
+ supports if-else, try-catch-finally blocks, switch statements, switch cases, switch default,
+ while-loops, for-loops, method definitions, class definitions, constructor definitions,
  instance, static initialization blocks, annotation definitions and enum definitions.
  For right curly brace of expression blocks of arrays, lambdas and class instances
  please follow issue

--- a/src/main/resources/google_checks.xml
+++ b/src/main/resources/google_checks.xml
@@ -137,8 +137,8 @@
       <property name="tokens"
                value="CLASS_DEF, METHOD_DEF, CTOR_DEF, LITERAL_FOR, LITERAL_WHILE, STATIC_INIT,
                     INSTANCE_INIT, ANNOTATION_DEF, ENUM_DEF, INTERFACE_DEF, RECORD_DEF,
-                    COMPACT_CTOR_DEF, LITERAL_SWITCH, LITERAL_CASE, LITERAL_FINALLY,
-                    LITERAL_CATCH"/>
+                    COMPACT_CTOR_DEF, LITERAL_SWITCH, LITERAL_CASE, LITERAL_DEFAULT,
+                    LITERAL_FINALLY, LITERAL_CATCH"/>
     </module>
     <module name="SuppressionXpathSingleFilter">
       <!-- suppression is required till https://github.com/checkstyle/checkstyle/issues/7541 -->

--- a/src/site/xdoc/checks/blocks/rightcurly.xml
+++ b/src/site/xdoc/checks/blocks/rightcurly.xml
@@ -11,8 +11,8 @@
       <subsection name="Description" id="RightCurly_Description">
         <div>
           Checks the placement of right curly braces (<code>'}'</code>) for code blocks. This check
-          supports if-else, try-catch-finally blocks, switch statements, switch cases, while-loops,
-          for-loops, method definitions, class definitions, constructor definitions,
+          supports if-else, try-catch-finally blocks, switch statements, switch cases, switch default,
+          while-loops, for-loops, method definitions, class definitions, constructor definitions,
           instance, static initialization blocks, annotation definitions and enum definitions.
           For right curly brace of expression blocks of arrays, lambdas and class instances
           please follow issue
@@ -83,6 +83,8 @@
                     LITERAL_SWITCH</a>
                 , <a href="../../apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#LITERAL_CASE">
                     LITERAL_CASE</a>
+                , <a href="../../apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#LITERAL_DEFAULT">
+                    LITERAL_DEFAULT</a>
                   .
               </td>
               <td>
@@ -148,7 +150,7 @@ public class Example1 {
       case 1: int y = 1; break;
       case 2: {x = 1;}
       case 3: int z = 0; {break;}
-      default: x = 0;
+      default: {x = 0;}
     }
     switch (mode) {
       case 1: x = 1; break;
@@ -209,7 +211,7 @@ public class Example2 {
       case 1: int y = 1; break;
       case 2: {x = 1;}
       case 3: int z = 0; {break;}
-      default: x = 0;
+      default: {x = 0;}
     }
     switch (mode) {
       case 1: x = 1; break;
@@ -221,14 +223,14 @@ public class Example2 {
           To configure the check with policy <code>alone</code> for
           <a href="https://docs.oracle.com/javase/tutorial/java/nutsandbolts/switch.html">
           Switch</a>
-          Statements and Switch Cases:
+          Statements, Switch Cases and Switch Default:
         </p>
         <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
 &lt;module name="Checker"&gt;
   &lt;module name="TreeWalker"&gt;
     &lt;module name="RightCurly"&gt;
       &lt;property name="option" value="alone"/&gt;
-      &lt;property name="tokens" value="LITERAL_SWITCH, LITERAL_CASE"/&gt;
+      &lt;property name="tokens" value="LITERAL_SWITCH, LITERAL_CASE, LITERAL_DEFAULT"/&gt;
     &lt;/module&gt;
   &lt;/module&gt;
 &lt;/module&gt;
@@ -268,7 +270,7 @@ public class Example3 {
       case 1: int y = 1; break;
       case 2: {x = 1;} // violation, 'should be alone on a line.'
       case 3: int z = 0; {break;}
-      default: x = 0;
+      default: {x = 0;} // violation, 'should be alone on a line.'
     }
     switch (mode) {
       case 1: x = 1; break;
@@ -328,7 +330,7 @@ public class Example4 {
       case 1: int y = 1; break;
       case 2: {x = 1;}
       case 3: int z = 0; {break;}
-      default: x = 0;
+      default: {x = 0;}
     }
     switch (mode) {
       case 1: x = 1; break;
@@ -340,14 +342,14 @@ public class Example4 {
           To configure the check with policy <code>alone_or_singleline</code> for
           <a href="https://docs.oracle.com/javase/tutorial/java/nutsandbolts/switch.html">
           Switch</a>
-          Statements and Switch Cases:
+          Statements, Switch Cases and Switch Default:
         </p>
         <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
 &lt;module name="Checker"&gt;
   &lt;module name="TreeWalker"&gt;
     &lt;module name="RightCurly"&gt;
       &lt;property name="option" value="alone_or_singleline"/&gt;
-      &lt;property name="tokens" value="LITERAL_SWITCH, LITERAL_CASE"/&gt;
+      &lt;property name="tokens" value="LITERAL_SWITCH, LITERAL_CASE, LITERAL_DEFAULT"/&gt;
     &lt;/module&gt;
   &lt;/module&gt;
 &lt;/module&gt;
@@ -387,7 +389,7 @@ public class Example5 {
       case 1: int y = 1; break;
       case 2: {x = 1;}
       case 3: int z = 0; {break;}
-      default: x = 0;
+      default: {x = 0;}
     }
     switch (mode) {
       case 1: x = 1; break;

--- a/src/site/xdoc/checks/blocks/rightcurly.xml.template
+++ b/src/site/xdoc/checks/blocks/rightcurly.xml.template
@@ -61,7 +61,7 @@
           To configure the check with policy <code>alone</code> for
           <a href="https://docs.oracle.com/javase/tutorial/java/nutsandbolts/switch.html">
           Switch</a>
-          Statements and Switch Cases:
+          Statements, Switch Cases and Switch Default:
         </p>
         <macro name="example">
             <param name="path"
@@ -96,7 +96,7 @@
           To configure the check with policy <code>alone_or_singleline</code> for
           <a href="https://docs.oracle.com/javase/tutorial/java/nutsandbolts/switch.html">
           Switch</a>
-          Statements and Switch Cases:
+          Statements, Switch Cases and Switch Default:
         </p>
         <macro name="example">
             <param name="path"

--- a/src/site/xdoc/google_style.xml
+++ b/src/site/xdoc/google_style.xml
@@ -732,12 +732,10 @@
                   <br/>
                   <br/>
                   There are some false-negatives regarding <code>ELSE</code>
-                  and <code>DEFAULT</code> blocks, they will be addressed at:
+                  blocks, they will be addressed at:
                   <a href="https://github.com/checkstyle/checkstyle/issues/15791">
                     #15791
                   </a>
-                  and
-                  <a href="https://github.com/checkstyle/checkstyle/issues/14782">#14782</a>
                 </td>
                 <td>
                   <a href="https://github.com/checkstyle/checkstyle/tree/master/src/it/resources/com/google/checkstyle/test/chapter4formatting/rule412nonemptyblocks">

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/blocks/RightCurlyCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/blocks/RightCurlyCheckTest.java
@@ -991,4 +991,134 @@ public class RightCurlyCheckTest extends AbstractModuleTestSupport {
         final String fileName = "InputRightCurlySwitchWhen.java";
         verifyWithInlineConfigParser(getNonCompilablePath(fileName), expected);
     }
+
+    @Test
+    public void testDefaultBlocksInSwitchStatementAlone() throws Exception {
+        final String[] expected = {
+            "33:13: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}", 13),
+            "44:13: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}", 13),
+            "73:13: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}", 13),
+            "78:68: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}", 68),
+            "90:40: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}", 40),
+            "97:43: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}", 43),
+            "107:36: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}", 36),
+        };
+        verifyWithInlineConfigParser(
+                getPath("InputRightCurlyDefaultBlocksInSwitchStatementAlone.java"), expected);
+    }
+
+    @Test
+    public void testDefaultBlocksInSwitchStatementAlone2() throws Exception {
+        final String[] expected = {
+            "17:15: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}", 15),
+            "29:13: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}", 13),
+            "41:24: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}", 24),
+            "53:13: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}", 13),
+            "64:25: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}", 25),
+            "71:35: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}", 35),
+        };
+        verifyWithInlineConfigParser(
+                getPath("InputRightCurlyDefaultBlocksInSwitchStatementAlone2.java"), expected);
+    }
+
+    @Test
+    public void testDefaultBlocksInSwitchStatementAloneOrSingleline() throws Exception {
+        final String[] expected = {
+            "33:13: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}", 13),
+            "44:13: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}", 13),
+            "73:13: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}", 13),
+            "78:74: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}", 74),
+        };
+        verifyWithInlineConfigParser(
+                getPath("InputRightCurlyDefaultBlocksInSwitchStatementAloneOrSingleline.java"),
+                expected);
+    }
+
+    @Test
+    public void testDefaultBlocksInSwitchStatementAloneOrSingleline2() throws Exception {
+        final String[] expected = {
+            "18:15: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}", 15),
+            "30:13: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}", 13),
+            "43:15: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}", 15),
+            "117:13: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}", 13),
+        };
+        verifyWithInlineConfigParser(
+                getPath("InputRightCurlyDefaultBlocksInSwitchStatementAloneOrSingleline2.java"),
+                expected);
+    }
+
+    @Test
+    public void testDefaultBlocksInSwitchStatementSame() throws Exception {
+        final String[] expected = {
+            "35:16: " + getCheckMessage(MSG_KEY_LINE_BREAK_BEFORE, "}", 16),
+            "46:13: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}", 13),
+            "75:13: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}", 13),
+            "80:74: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}", 74),
+            "110:13: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}", 13),
+        };
+        verifyWithInlineConfigParser(
+                getPath("InputRightCurlyDefaultBlocksInSwitchStatementSame.java"), expected);
+    }
+
+    @Test
+    public void testDefaultBlocksInSwitchStatementSame2() throws Exception {
+        final String[] expected = {
+            "18:13: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}", 13),
+            "30:13: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}", 13),
+            "42:13: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}", 13),
+            "54:13: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}", 13),
+            "84:35: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}", 35),
+        };
+        verifyWithInlineConfigParser(
+                getPath("InputRightCurlyDefaultBlocksInSwitchStatementSame2.java"), expected);
+    }
+
+    @Test
+    public void testDefaultBlocksWithSwitchRuleAlone() throws Exception {
+        final String[] expected = {
+            "63:13: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}", 13),
+            "68:82: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}", 82),
+            "78:35: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}", 35),
+            "88:32: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}", 32),
+        };
+        verifyWithInlineConfigParser(
+                getPath("InputRightCurlyDefaultBlocksWithSwitchRuleAlone.java"),
+                expected);
+    }
+
+    @Test
+    public void testDefaultBlocksWithSwitchRuleAloneOrSingleline() throws Exception {
+        final String[] expected = {
+            "55:27: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}", 27),
+            "68:13: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}", 13),
+            "79:13: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}", 13),
+            "84:70: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}", 70),
+        };
+        final String fileName =
+                "InputRightCurlyDefaultBlocksWithSwitchRuleAloneOrSingleline.java";
+        verifyWithInlineConfigParser(getPath(fileName), expected);
+    }
+
+    @Test
+    public void testDefaultBlocksWithSwitchExpressionAlone() throws Exception {
+        final String[] expected = {
+            "62:31: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}", 31),
+            "86:42: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}", 42),
+            "112:34: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}", 34),
+        };
+        final String fileName =
+                "InputRightCurlyDefaultBlocksWithSwitchExpressionAlone.java";
+        verifyWithInlineConfigParser(getPath(fileName), expected);
+    }
+
+    @Test
+    public void testDefaultBlocksWithSwitchExpressionAloneOrSingleline() throws Exception {
+        final String[] expected = {
+            "62:31: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}", 31),
+            "113:34: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}", 34),
+        };
+        final String fileName =
+                "InputRightCurlyDefaultBlocksWithSwitchExpressionAloneOrSingleline.java";
+        verifyWithInlineConfigParser(getPath(fileName), expected);
+    }
 }

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/blocks/rightcurly/InputRightCurlyDefaultBlocksInSwitchStatementAlone.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/blocks/rightcurly/InputRightCurlyDefaultBlocksInSwitchStatementAlone.java
@@ -1,0 +1,110 @@
+/*
+RightCurly
+option = ALONE
+tokens = LITERAL_DEFAULT
+
+*/
+package com.puppycrawl.tools.checkstyle.checks.blocks.rightcurly;
+
+public class InputRightCurlyDefaultBlocksInSwitchStatementAlone {
+    public static void test0() {
+        int mode = 0;
+        switch (mode) {
+            case 1: {
+                int x = 1;
+                break;
+            }
+            default: {
+                int x = 0;
+                break;
+            }
+        }
+    }
+
+    public static void test1() {
+        int mode = 0;
+        switch (mode) {
+            case 1:{
+                int x = 1;
+                break;
+            }
+            default:{
+                int x = 0;
+            } case 2 :          // violation '}' at column 13 should be alone on a line'
+                int x = 0;
+        }
+    }
+
+    public static void test2() {
+        int k = 0;
+        switch (k) {
+            default:{
+                 int x = 2;
+                 break;
+            } case 1:        // violation '}' at column 13 should be alone on a line'
+                 int x = 2;
+                 break;
+        }
+    }
+
+    public static void test3() {
+         int k = 0;
+         switch (k) {
+            default:{
+                 int x = 1;
+                 break;
+            }
+            case 1:
+                 int x = 2;
+                 break;
+         }
+    }
+
+    public static void test4() {
+         int k = 0;
+         switch (k) {
+            case 1:{
+                 int x = 1;
+                 break;
+            }
+            default:{
+                    int x = 2;
+                    break;
+            } }      // violation '}' at column 13 should be alone on a line'
+    }
+
+    public static void test5() {
+        int mode = 0;
+        switch (mode) { case 0: int x = 1; break; default : {x = 5;} }
+        // violation above '}' at column 68 should be alone on a line'
+    }
+
+    public static void test6() {
+        int mode = 0;
+        switch (mode) { default: }
+    }
+
+    public static void test7() {
+        int mode = 0;
+        switch (mode) {
+            default: {int x = 1; break;}  // violation '}' at column 40 should be alone on a line'
+            case 0 : break;
+        }
+    }
+
+    public static void test8() {
+        int mode = 0;
+        switch (mode) {default:{int x = 1;} // violation '}' at column 43 should be alone on a line'
+            break; case 0 : break; }
+    }
+
+    public static void test9() {
+        int mode = 0;
+        int x = 0;
+        switch (mode) {
+            case 0:
+            case 1: x = 1; break;
+            default: {x = 1; break;} // violation '}' at column 36 should be alone on a line'
+        }
+    }
+}

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/blocks/rightcurly/InputRightCurlyDefaultBlocksInSwitchStatementAlone2.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/blocks/rightcurly/InputRightCurlyDefaultBlocksInSwitchStatementAlone2.java
@@ -1,0 +1,113 @@
+/*
+RightCurly
+option = ALONE
+tokens = LITERAL_DEFAULT
+
+*/
+package com.puppycrawl.tools.checkstyle.checks.blocks.rightcurly;
+
+public class InputRightCurlyDefaultBlocksInSwitchStatementAlone2 {
+     public static void test10() {
+        int mode = 0;
+        switch (mode) {
+            case 0: int x = 1;
+            case 1: x = 1; break;
+            default: {
+                x =
+            1;} case 2 : x = 5;         // violation '}' at column 15 should be alone on a line'
+        }
+    }
+
+    public static void test11() {
+        int mode = 0;
+        switch (mode) {
+            case 0: {
+                int x = 0;
+            }
+            default: {
+
+            } case 1: int x = 1; break;    // violation '}' at column 13 should be alone on a line'
+        }
+    }
+
+    public static void test12() {
+        int mode = 0;
+        switch (mode) {
+            case 0: {
+                int x = 0;
+            }
+            default: {
+
+            int x = 1; } case 1: break;  // violation '}' at column 24 should be alone on a line'
+        }
+    }
+
+    public static void test13() {
+        int mode = 0;
+        switch (mode) {
+            case 0: { int x = 1;
+
+            }
+            default: {
+
+            } case 1:  // violation '}' at column 13 should be alone on a line'
+                break;
+        }
+    }
+
+    public static void test14() {
+        int mode = 0;
+        switch (mode) {
+            case 0: {
+
+            }
+            default: {  }         // violation '}' at column 25 should be alone on a line'
+            case 1: {break;}
+        }
+    }
+
+    public static void test15() {
+        int mode = 0; // violation below, '}' at column 35 should be alone on a line'
+        switch (mode) {default: { } case 1: {  } }
+    }
+
+    public static void test16() {
+        int mode = 0;
+        switch (mode) {
+            default: int x = 1; { } break;
+            case 1: { } int y = 1; break;
+        }
+    }
+
+    public static void test17() {
+        int mode = 0;
+        switch (mode) {
+            case 0:
+            int x = 1;
+            {  }
+            default:
+            mode++;
+            {
+
+            } int y;
+            case 3:
+            {
+
+            } int z = 1;
+        }
+    }
+
+    public static void test18() {
+        int mode = 0;
+        switch (mode) {
+            default: {
+            }
+            int x;
+            case 1:
+            int z;
+            {
+
+            }break; case 2: break;
+        }
+    }
+}

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/blocks/rightcurly/InputRightCurlyDefaultBlocksInSwitchStatementAloneOrSingleline.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/blocks/rightcurly/InputRightCurlyDefaultBlocksInSwitchStatementAloneOrSingleline.java
@@ -1,0 +1,110 @@
+/*
+RightCurly
+option = ALONE_OR_SINGLELINE
+tokens = LITERAL_DEFAULT
+
+*/
+package com.puppycrawl.tools.checkstyle.checks.blocks.rightcurly;
+
+public class InputRightCurlyDefaultBlocksInSwitchStatementAloneOrSingleline {
+    public static void test0() {
+        int mode = 0;
+        switch (mode) {
+            case 1: {
+                int x = 1;
+                break;
+            }
+            default: {
+                int x = 0;
+                break;
+            }
+        }
+    }
+
+    public static void test1() {
+        int mode = 0;
+        switch (mode) {
+            case 1:{
+                int x = 1;
+                break;
+            }
+            default:{
+                int x = 0;
+            } case 2 :          // violation '}' at column 13 should be alone on a line'
+                int x = 0;
+        }
+    }
+
+    public static void test2() {
+        int k = 0;
+        switch (k) {
+            default:{
+                 int x = 2;
+                 break;
+            } case 1:        // violation '}' at column 13 should be alone on a line'
+                 int x = 2;
+                 break;
+        }
+    }
+
+    public static void test3() {
+         int k = 0;
+         switch (k) {
+            default:{
+                 int x = 1;
+                 break;
+            }
+            case 1:
+                 int x = 2;
+                 break;
+         }
+    }
+
+    public static void test4() {
+         int k = 0;
+         switch (k) {
+            case 1:{
+                 int x = 1;
+                 break;
+            }
+            default:{
+                    int x = 2;
+                    break;
+            } }      // violation '}' at column 13 should be alone on a line'
+    }
+
+    public static void test5() {
+        int mode = 0;
+        switch (mode) { case 0: int x = 1; break; default: {x = 5; break;} }
+        // violation above '}' at column 74 should be alone on a line'
+    }
+
+    public static void test6() {
+        int mode = 0;
+        switch (mode) { default: int x = 1; }
+    }
+
+    public static void test7() {
+        int mode = 0;
+        switch (mode) {
+            default: {int x = 1; break;}
+            case 0 : break;
+        }
+    }
+
+    public static void test8() {
+        int mode = 0;
+        switch (mode) {default:{int x = 1;}
+            break; case 0 : break; }
+    }
+
+    public static void test9() {
+        int mode = 0;
+        int x = 0;
+        switch (mode) {
+            case 0:
+            case 1: x = 1; break;
+            default: {x = 1; break;}
+        }
+    }
+}

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/blocks/rightcurly/InputRightCurlyDefaultBlocksInSwitchStatementAloneOrSingleline2.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/blocks/rightcurly/InputRightCurlyDefaultBlocksInSwitchStatementAloneOrSingleline2.java
@@ -1,0 +1,120 @@
+/*
+RightCurly
+option = ALONE_OR_SINGLELINE
+tokens = LITERAL_DEFAULT
+
+*/
+package com.puppycrawl.tools.checkstyle.checks.blocks.rightcurly;
+
+public class InputRightCurlyDefaultBlocksInSwitchStatementAloneOrSingleline2 {
+
+    public static void test10() {
+        int mode = 0;
+        switch (mode) {
+            case 0: int x = 1;
+            case 1: x = 1; break;
+            default: {
+                x =
+            1;} case 2 : x = 5;         // violation '}' at column 15 should be alone on a line'
+        }
+    }
+
+    public static void test11() {
+        int mode = 0;
+        switch (mode) {
+            case 0: {
+                int x = 0;
+            }
+            default: {
+
+            } case 1: int x = 1; break;    // violation '}' at column 13 should be alone on a line'
+        }
+    }
+
+     public static void test12() {
+        int mode = 0;
+        switch (mode) {
+            case 0: {
+
+            }
+            default: {
+
+            int
+            y;} case 1: int x = 1; break;  // violation '}' at column 15 should be alone on a line'
+        }
+    }
+
+    public static void test13() {
+        int mode = 0;
+        switch (mode) {
+            case 0: {
+
+            }
+            default: {
+
+            }
+            case 1: break;
+        }
+    }
+
+    public static void test14() {
+        int mode = 0;
+        switch (mode) {
+            case 0: { int x = 1;
+
+            }
+            default: {  }
+            case 1: {break;}
+        }
+    }
+
+    public static void test15() {
+        int mode = 0;
+        switch (mode) {
+            default: int x = 1; { } break;
+            case 1: { } int y = 1; break;
+        }
+    }
+
+    public static void test16() {
+        int mode = 0;
+        switch (mode) {
+            case 0:
+            int x = 1;
+            {  }
+            default:
+            mode++;
+            {
+
+            } int y;
+            case 3:
+            {
+
+            } int z = 1;
+        }
+    }
+
+    public static void test17() {
+        int mode = 0;
+        switch (mode) {
+            default: {
+
+            }
+            case 1:
+            int z;
+            {
+
+            } break; case 2: break;
+        }
+    }
+
+    public static void test18() {
+        int mode = 0;
+        switch (mode) {
+            case 1:
+            default: {
+                int x = 0;
+            } break;    // violation '}' at column 13 should be alone on a line'
+        }
+    }
+}

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/blocks/rightcurly/InputRightCurlyDefaultBlocksInSwitchStatementSame.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/blocks/rightcurly/InputRightCurlyDefaultBlocksInSwitchStatementSame.java
@@ -1,0 +1,114 @@
+/*
+RightCurly
+option = SAME
+tokens = LITERAL_DEFAULT
+
+*/
+package com.puppycrawl.tools.checkstyle.checks.blocks.rightcurly;
+
+public class InputRightCurlyDefaultBlocksInSwitchStatementSame {
+    public static void test0() {
+        int mode = 0;
+        switch (mode) {
+            case 1: {
+                int x = 1;
+                break;
+            }
+            default: {
+                int x = 0;
+                break;
+            }
+        }
+    }
+
+    public static void test1() {
+        int mode = 0;
+        switch (mode) {
+            case 1:{
+                int x
+                    = 1;
+                break;
+            }
+            default:{
+                int x
+
+            =0;} case 2 :          // violation '}' at column 16 should have line break before'
+                int x = 0;
+        }
+    }
+
+    public static void test2() {
+        int k = 0;
+        switch (k) {
+            default:{
+                 int x = 1;
+                 break;
+            } case 1:        // violation '}' at column 13 should be alone on a line'
+                 int x = 2;
+                 break;
+        }
+    }
+
+    public static void test3() {
+         int k = 0;
+         switch (k) {
+            default:{
+                 int x = 1;
+                 break;
+            }
+            case 1:
+                 int x = 2;
+                 break;
+         }
+    }
+
+    public static void test4() {
+         int k = 0;
+         switch (k) {
+            case 1:{
+                 int x = 1;
+                 break;
+            }
+            default:{
+                    int x = 2;
+                    break;
+            } }      // violation '}' at column 13 should be alone on a line'
+    }
+
+    public static void test5() {
+        int mode = 0;
+        switch (mode) { case 0: int x = 1; break; default: {x = 5; break;} }
+        // violation above '}' at column 74 should be alone on a line'
+    }
+
+    public static void test6() {
+        int mode = 0;
+        switch (mode) { default: int x = 1;}
+    }
+
+    public static void test7() {
+        int mode = 0;
+        switch (mode) {
+            default: {int x = 1; break;}
+            case 0 : break;
+        }
+    }
+
+    public static void test8() {
+        int mode = 0;
+        switch (mode) {default:{int x = 1;}
+            break; case 0 : break; }
+    }
+
+    public static void test9() {
+        int mode = 0;
+        int x = 0;
+        switch (mode) {
+            case 0:{
+            int y = 1;}
+            default: {x = 1;
+            } case 1:  // violation '}' at column 13 should be alone on a line'
+                x = 5;
+        }
+    }
+}

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/blocks/rightcurly/InputRightCurlyDefaultBlocksInSwitchStatementSame2.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/blocks/rightcurly/InputRightCurlyDefaultBlocksInSwitchStatementSame2.java
@@ -1,0 +1,111 @@
+/*
+RightCurly
+option = SAME
+tokens = LITERAL_DEFAULT
+
+*/
+package com.puppycrawl.tools.checkstyle.checks.blocks.rightcurly;
+
+public class InputRightCurlyDefaultBlocksInSwitchStatementSame2 {
+
+     public static void test11() {
+        int mode = 0;
+        switch (mode) {
+            case 0: int x = 1;
+            case 1: x = 1; break;
+            default: {
+                x = 1; break;
+            } case 2 : x = 5;         // violation '}' at column 13 should be alone on a line'
+        }
+    }
+
+    public static void test12() {
+        int mode = 0;
+        switch (mode) {
+            case 0: {
+
+            }
+            default: {
+
+            } case 1: int x = 1; break;    // violation '}' at column 13 should be alone on a line'
+        }
+    }
+
+    public static void test13() {
+        int mode = 0;
+        switch (mode) {
+            case 0: {
+
+            }
+            default: {
+
+            } case 1: int x = 1; break;   // violation '}' at column 13 should be alone on a line'
+        }
+    }
+
+    public static void test14() {
+        int mode = 0;
+        switch (mode) {
+            case 0: {
+
+            }
+            default: {
+
+            } case 1: {int x = 1; break;} // violation '}' at column 13 should be alone on a line'
+        }
+    }
+
+    public static void test15() {
+        int mode = 0;
+        switch (mode) {
+            case 0: {
+
+            }
+            default: {
+
+            }
+            case 1: break;
+        }
+    }
+
+    public static void test16() {
+        int mode = 0;
+        switch (mode) {
+            case 0: {
+
+            }
+            default: {  }
+            case 1: {break;}
+        }
+    }
+
+    public static void test17() {
+        int mode = 0; // violation below, '}' at column 35 should be alone on a line'
+        switch (mode) {default: { } case 1: {  } }
+    }
+
+    public static void test18() {
+        int mode = 0;
+        switch (mode) {
+            default: int x = 1; { } break;
+            case 1: { } int y = 1; break;
+        }
+    }
+
+    public static void test19() {
+        int mode = 0;
+        switch (mode) {
+            case 0:
+            int x = 1;
+            {  }
+            default:
+            mode++;
+            {
+            } int y;
+            case 3:
+            {
+
+            } int z = 1;
+        }
+    }
+}

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/blocks/rightcurly/InputRightCurlyDefaultBlocksWithSwitchExpressionAlone.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/blocks/rightcurly/InputRightCurlyDefaultBlocksWithSwitchExpressionAlone.java
@@ -1,0 +1,117 @@
+/*
+RightCurly
+option = ALONE
+tokens = LITERAL_DEFAULT, LITERAL_IF
+
+*/
+
+package com.puppycrawl.tools.checkstyle.checks.blocks.rightcurly;
+
+public class InputRightCurlyDefaultBlocksWithSwitchExpressionAlone {
+
+    int foo(int yield) {
+        return switch (yield) {
+            case 1 -> 2;
+            case 2 -> 3;
+            case 3 -> 4;
+            default -> 5;
+        };
+    }
+
+    void test() {
+        int x = 1;
+        String s = switch (x) {
+            case 1 -> {
+
+                yield "and that's it";
+            }  case 2 -> "x is 2";
+            default -> "x is neither 1 nor 2";
+        };
+    }
+
+    void test2() {
+        int x = 1;
+        String s = switch (x) {
+            case 1 -> {
+
+                yield "and that's it";
+            }  case 2 -> { yield "x is 2";}
+            default -> "x is neither 1 nor 2";
+        };
+    }
+
+    void test3() {
+        int x = 1;
+         String s = switch (x) {
+            case 1 -> {
+
+                String s1 = "and that's it";
+                yield s1;
+            } case 2 -> { yield "x is 2";}
+            default -> "x is neither 1 nor 2";
+        };
+    }
+
+    void test4() throws Exception {
+           int a = 0;
+           int b = switch (a) {
+                case 0 -> {
+                    int x = 5;
+                    int y = 6;
+                    if (a == 2) {
+                        y = 7;}   // violation '}' at column 31 should be alone on a line'
+                    throw new Exception();
+                }
+                default -> 2;
+            };
+    }
+
+    void test5() throws Exception {
+        int a = 0;
+        int b = switch (a) {
+            case 0 -> {throw new Exception();}
+            default -> 2;
+        };
+    }
+
+    void test6() throws Exception {
+         int y = 0;
+         int x = 0;
+         final boolean a = switch (y) {
+             case 1 -> {x = 1; yield true;}
+             case 2 -> {
+                 x = 1;
+                 yield true;} case 3 -> {
+                 x = 1;
+                 if (x == 1) {yield true;} // violation '}' at column 42 should be alone on a line'
+                 yield false;}
+             default -> throw new RuntimeException();
+         };
+    }
+
+    void test7() throws Exception {
+         int y = 0;
+         int x = 0;
+         final boolean a = switch (y) {
+             case 1 -> {x = 1; yield true;}
+             default -> {
+                 x = 1;
+                 yield true;
+             }
+         };
+    }
+
+    void test8() throws Exception {
+         int y = 0;
+         int x = 0;
+         final String a = switch (y) {
+             case 1 -> "one";
+             default -> {
+                 x = 1;
+                 if (x == 1) {
+                     yield "yes";}  // violation '}' at column 34 should be alone on a line'
+                 yield "no";
+             }
+         };
+    }
+}

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/blocks/rightcurly/InputRightCurlyDefaultBlocksWithSwitchExpressionAloneOrSingleline.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/blocks/rightcurly/InputRightCurlyDefaultBlocksWithSwitchExpressionAloneOrSingleline.java
@@ -1,0 +1,118 @@
+/*
+RightCurly
+option = ALONE_OR_SINGLELINE
+tokens = LITERAL_DEFAULT, LITERAL_IF
+
+*/
+
+package com.puppycrawl.tools.checkstyle.checks.blocks.rightcurly;
+
+public class InputRightCurlyDefaultBlocksWithSwitchExpressionAloneOrSingleline {
+
+    int foo(int yield) {
+        return switch (yield) {
+            case 1 -> 2;
+            case 2 -> 3;
+            case 3 -> 4;
+            default -> 5;
+        };
+    }
+
+    void test() {
+        int x = 1;
+        String s = switch (x) {
+            case 1 -> {
+
+                yield "and that's it";
+            }  case 2 -> "x is 2";
+            default -> "x is neither 1 nor 2";
+        };
+    }
+
+    void test2() {
+        int x = 1;
+        String s = switch (x) {
+            case 1 -> {
+
+                yield "and that's it";
+            }  case 2 -> { yield "x is 2";}
+            default -> "x is neither 1 nor 2";
+        };
+    }
+
+    void test3() {
+        int x = 1;
+         String s = switch (x) {
+            case 1 -> {
+
+                String s1 = "and that's it";
+                yield s1;
+            } case 2 -> { yield "x is 2";}
+            default -> "x is neither 1 nor 2";
+        };
+    }
+
+    void test4() throws Exception {
+           int a = 0;
+           int b = switch (a) {
+                case 0 -> {
+                    int x = 5;
+                    int y = 6;
+                    if (a == 2) {
+                        y = 7;}   // violation '}' at column 31 should be alone on a line'
+                    throw new Exception();
+                }
+                default -> 2;
+            };
+    }
+
+    void test5() throws Exception {
+        int a = 0;
+        int b = switch (a) {
+            case 0 -> {throw new Exception();}
+            default -> 2;
+        };
+    }
+
+    void test6() {
+         int y = 0;
+         int x = 0;
+         final boolean a = switch (y) {
+             case 1 -> {x = 1; yield true;
+             }case 2 -> {
+                 x = 1;
+                 yield true;} case 3 -> {
+                 x = 1;
+                 if (x == 1) {yield true;}
+                 yield false;
+             }
+             default -> throw new RuntimeException();
+         };
+    }
+
+    void test7() throws Exception {
+         int y = 0;
+         int x = 0;
+         final boolean a = switch (y) {
+             case 1 -> {x = 1; yield true;}
+             default -> {
+                 x = 1;
+                 yield true;
+             }
+         };
+    }
+
+    void test8() throws Exception {
+         int y = 0;
+         int x = 0;
+         final String a = switch (y) {
+             case 1 -> "one";
+             default -> {
+                 x = 1;
+                 if (x == 1) {
+                     yield "yes";}  // violation '}' at column 34 should be alone on a line'
+                 yield "no";
+             }
+         };
+    }
+}

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/blocks/rightcurly/InputRightCurlyDefaultBlocksWithSwitchRuleAlone.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/blocks/rightcurly/InputRightCurlyDefaultBlocksWithSwitchRuleAlone.java
@@ -1,0 +1,112 @@
+/*
+RightCurly
+option = ALONE
+tokens = LITERAL_DEFAULT
+
+*/
+
+package com.puppycrawl.tools.checkstyle.checks.blocks.rightcurly;
+
+public class InputRightCurlyDefaultBlocksWithSwitchRuleAlone {
+
+    public static void test0() {
+        int mode = 0;
+        switch (mode) {
+            case 1 -> {
+                int x = 1;
+            }
+            case 2 -> {
+                int x = 0;
+            }
+            default -> {
+                System.out.println("default");
+            }
+        }
+    }
+
+    public static void test1() {
+        int mode = 0;
+        switch (mode) {
+            case 1 -> {
+                int x = 1;
+
+            }
+            default -> {
+                int x = 0;
+            }
+        }
+    }
+
+    public static void test2() {
+        int k = 0;
+        switch (k) {
+            case 1 -> {
+                 int x = 1;
+
+            }
+            case 2 -> {
+                int x = 2;}
+            default -> {
+                int x = 3;
+            }
+        }
+    }
+
+    public static void test3() {
+         int k = 0;
+         switch (k) {
+            case 1 -> {
+                 int x = 1;
+            }
+            default -> {
+                    int x = 2;
+            } }      // violation '}' at column 13 should be alone on a line'
+    }
+
+    public static void test4() {
+        int mode = 0;
+        switch (mode) { case 0 -> System.out.println("0"); default -> {int x = 1;} }
+        // violation above '}' at column 82 should be alone on a line'
+    }
+
+    public static void test5() {
+        int mode = 0;
+        switch (mode) {
+            case 0 -> {
+                int x = 1;
+            }
+            default -> {int x = 2;}  // violation '}' at column 35 should be alone on a line'
+        }
+    }
+
+    public static void test6() {
+        int mode = 0;
+        int x = 0;
+        switch (mode) {
+            case 0 -> throw new RuntimeException();
+            case 1 -> x = 1;
+            default -> {x = 1; }      // violation '}' at column 32 should be alone on a line'
+        }
+    }
+
+    public static void test7() {
+        int mode = 0;
+        switch (mode) {
+            case 1 -> {
+                int x = 1;
+
+            } default -> {
+                int x = 0;
+            }
+        }
+    }
+
+    public static void test8() {
+        int mode = 0;
+        switch (mode) {
+            case 1 -> {int x = 1;
+
+            }default -> throw new RuntimeException();
+        }
+    }
+}

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/blocks/rightcurly/InputRightCurlyDefaultBlocksWithSwitchRuleAloneOrSingleline.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/blocks/rightcurly/InputRightCurlyDefaultBlocksWithSwitchRuleAloneOrSingleline.java
@@ -1,0 +1,119 @@
+/*
+RightCurly
+option = ALONE_OR_SINGLELINE
+tokens = LITERAL_DEFAULT
+
+*/
+
+package com.puppycrawl.tools.checkstyle.checks.blocks.rightcurly;
+
+public class InputRightCurlyDefaultBlocksWithSwitchRuleAloneOrSingleline {
+
+    public void test0() {
+        int mode = 0;
+        switch (mode) {
+            case 1 -> {int x = 1;}
+            case 2 -> {int x = 0;}
+            default -> {System.out.println("default");}
+        }
+    }
+
+    public static void test1() {
+        int mode = 0;
+        switch (mode) {
+            case 1 -> {
+                int
+            x = 1;}
+            default -> {
+                int x = 0;
+            }
+            case 3 -> System.out.println("x is 3");
+        }
+    }
+
+    public static void test2() {
+        int mode = 0;
+        switch (mode) {
+            case 1 -> {
+                int x = 1;
+
+            }
+            default -> {
+                int x = 0;
+            }
+        }
+    }
+
+    public static void test3() {
+        int k = 0;
+        switch (k) {
+            case 1 -> {
+
+
+           int x = 1; }
+            default -> {
+                int x = 2;}     // violation '}' at column 27 should be alone on a line'
+
+        }
+    }
+
+    public static void test4() {
+         int k = 0;
+         switch (k) {
+            case 1 -> {int x = 1;
+
+            }
+            default -> {
+                int x = 2;
+            } }      // violation '}' at column 13 should be alone on a line'
+    }
+
+    public static void test5() {
+        int mode = 0;
+        switch (mode) {
+            case 1 -> {
+                 int x = 1;
+            }
+            default -> {
+                    int x = 2;
+            } }      // violation '}' at column 13 should be alone on a line'
+    }
+
+    public static void test6() {
+        int mode = 0;
+        switch (mode) { case 0 -> {int x = 1;} default -> {int x = 0;} }
+        // violation above '}' at column 70 should be alone on a line'
+    }
+
+    public static void test7() {
+        int mode = 0;
+        switch (mode) {
+            case 0 -> {
+                int x = 1;
+            }
+            default -> {int x = 2;}
+        }
+    }
+
+    public static void test8() {
+        int mode = 0;
+        int x = 0;
+        switch (mode) {
+            case 0 -> throw new RuntimeException();
+            case 1 -> x = 1;
+            default -> {x = 1; }
+        }
+    }
+
+    public static void test9() {
+        int mode = 0;
+        switch (mode) {
+            case 1 -> {
+                int x = 1;
+
+            } default -> {
+                int x = 0;
+            }
+        }
+    }
+}

--- a/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/checks/blocks/RightCurlyCheckExamplesTest.java
+++ b/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/checks/blocks/RightCurlyCheckExamplesTest.java
@@ -55,6 +55,7 @@ public class RightCurlyCheckExamplesTest extends AbstractExamplesModuleTestSuppo
     public void testExample3() throws Exception {
         final String[] expected = {
             "46:22: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}", 22),
+            "48:23: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}", 23),
             "52:23: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}", 23),
         };
         verifyWithInlineConfigParser(getPath("Example3.java"), expected);

--- a/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/blocks/rightcurly/Example1.java
+++ b/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/blocks/rightcurly/Example1.java
@@ -42,7 +42,7 @@ public class Example1 {
       case 1: int y = 1; break;
       case 2: {x = 1;}
       case 3: int z = 0; {break;}
-      default: x = 0;
+      default: {x = 0;}
     }
     switch (mode) {
       case 1: x = 1; break;

--- a/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/blocks/rightcurly/Example2.java
+++ b/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/blocks/rightcurly/Example2.java
@@ -47,7 +47,7 @@ public class Example2 {
       case 1: int y = 1; break;
       case 2: {x = 1;}
       case 3: int z = 0; {break;}
-      default: x = 0;
+      default: {x = 0;}
     }
     switch (mode) {
       case 1: x = 1; break;

--- a/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/blocks/rightcurly/Example3.java
+++ b/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/blocks/rightcurly/Example3.java
@@ -3,7 +3,7 @@
   <module name="TreeWalker">
     <module name="RightCurly">
       <property name="option" value="alone"/>
-      <property name="tokens" value="LITERAL_SWITCH, LITERAL_CASE"/>
+      <property name="tokens" value="LITERAL_SWITCH, LITERAL_CASE, LITERAL_DEFAULT"/>
     </module>
   </module>
 </module>
@@ -45,7 +45,7 @@ public class Example3 {
       case 1: int y = 1; break;
       case 2: {x = 1;} // violation, 'should be alone on a line.'
       case 3: int z = 0; {break;}
-      default: x = 0;
+      default: {x = 0;} // violation, 'should be alone on a line.'
     }
     switch (mode) {
       case 1: x = 1; break;

--- a/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/blocks/rightcurly/Example4.java
+++ b/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/blocks/rightcurly/Example4.java
@@ -45,7 +45,7 @@ public class Example4 {
       case 1: int y = 1; break;
       case 2: {x = 1;}
       case 3: int z = 0; {break;}
-      default: x = 0;
+      default: {x = 0;}
     }
     switch (mode) {
       case 1: x = 1; break;

--- a/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/blocks/rightcurly/Example5.java
+++ b/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/blocks/rightcurly/Example5.java
@@ -3,7 +3,7 @@
   <module name="TreeWalker">
     <module name="RightCurly">
       <property name="option" value="alone_or_singleline"/>
-      <property name="tokens" value="LITERAL_SWITCH, LITERAL_CASE"/>
+      <property name="tokens" value="LITERAL_SWITCH, LITERAL_CASE, LITERAL_DEFAULT"/>
     </module>
   </module>
 </module>
@@ -45,7 +45,7 @@ public class Example5 {
       case 1: int y = 1; break;
       case 2: {x = 1;}
       case 3: int z = 0; {break;}
-      default: x = 0;
+      default: {x = 0;}
     }
     switch (mode) {
       case 1: x = 1; break;


### PR DESCRIPTION
Fix false-negative for LITERAL_DEFAULT token in RightCurlyCheck

Issue #14782:

- Add `LITERAL_DEFAULT` token support in `RightCurlyCheck`
- Add `LITERAL_DEFAULT` to Google style configuration (`google_checks.xml`)
- Update documentation, examples, and xdoc templates to include `LITERAL_DEFAULT`
- Remove `#14782` false-negative reference from `google_style.xml` coverage page

Diff Regression config: https://gist.githubusercontent.com/vivek-0509/de0e36db6f5b68a6a617acbe7e5312ea/raw/ffbe0df1852c6a3038a056c0134c108a7e431611/base_config.xml

Diff Regression patch config: https://gist.githubusercontent.com/vivek-0509/d0238b505bbd2e8c3eaf35291cb96ca8/raw/1e96218808d7e4166f1fcb77eb7364cd5a29f726/patch_config.xml