### PR TITLE
Issue #17449: add missing XDocs examples for InterfaceMemberImpliedMo…

### DIFF
--- a/src/site/xdoc/checks/modifier/interfacememberimpliedmodifier.xml
+++ b/src/site/xdoc/checks/modifier/interfacememberimpliedmodifier.xml
@@ -238,6 +238,93 @@ public interface Example2 {
     //    'Implied modifier 'public' should be explicit'
   }
 }
+</code></pre></div><hr class="example-separator"/>
+        <p>
+          This example checks that all implicit modifiers on methods and nested types are
+          explicitly specified, but fields do not need to be.
+        </p>
+        <p id="Example3-config">
+          Configuration:
+        </p>
+        <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
+&lt;module name="Checker"&gt;
+  &lt;module name="TreeWalker"&gt;
+    &lt;module name="InterfaceMemberImpliedModifier"&gt;
+      &lt;property name="violateImpliedPublicField" value="false"/&gt;
+      &lt;property name="violateImpliedStaticField" value="false"/&gt;
+      &lt;property name="violateImpliedFinalField" value="false"/&gt;
+    &lt;/module&gt;
+  &lt;/module&gt;
+&lt;/module&gt;
+</code></pre></div>
+        <p id="Example3-code">
+          Code:
+        </p>
+        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+public interface Example3 {
+
+  public static final String UNKNOWN = "Unknown";
+  String OTHER = "Other";
+
+  public static Example3 instance() { return null; }
+
+  public abstract Address createAddress(String addressLine, String city);
+  List&lt;Address&gt; findAddresses(String city);
+  // 2 violations above:
+  //    'Implied modifier 'abstract' should be explicit'
+  //    'Implied modifier 'public' should be explicit'
+  interface Address {
+    // 2 violations above:
+    //    'Implied modifier 'public' should be explicit'
+    //    'Implied modifier 'static' should be explicit'
+    String getCity();
+    // 2 violations above:
+    //    'Implied modifier 'abstract' should be explicit'
+    //    'Implied modifier 'public' should be explicit'
+  }
+}
+</code></pre></div><hr class="example-separator"/>
+        <p>
+          This example checks that all implicit modifiers on fields and nested types are
+          explicitly specified, but methods do not need to be.
+        </p>
+        <p id="Example4-config">
+          Configuration:
+        </p>
+        <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
+&lt;module name="Checker"&gt;
+  &lt;module name="TreeWalker"&gt;
+    &lt;module name="InterfaceMemberImpliedModifier"&gt;
+      &lt;property name="violateImpliedPublicMethod" value="false"/&gt;
+      &lt;property name="violateImpliedAbstractMethod" value="false"/&gt;
+    &lt;/module&gt;
+  &lt;/module&gt;
+&lt;/module&gt;
+</code></pre></div>
+        <p id="Example4-code">
+          Code:
+        </p>
+        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+public interface Example4 {
+
+  public static final String UNKNOWN = "Unknown";
+  String OTHER = "Other";
+  // 3 violations above:
+  //    'Implied modifier 'final' should be explicit'
+  //    'Implied modifier 'public' should be explicit'
+  //    'Implied modifier 'static' should be explicit'
+  public static Example4 instance() { return null; }
+
+  public abstract Address createAddress(String addressLine, String city);
+  List&lt;Address&gt; findAddresses(String city);
+
+  interface Address {
+    // 2 violations above:
+    //    'Implied modifier 'public' should be explicit'
+    //    'Implied modifier 'static' should be explicit'
+    String getCity();
+  }
+}
 </code></pre></div>
       </subsection>
 

--- a/src/site/xdoc/checks/modifier/interfacememberimpliedmodifier.xml.template
+++ b/src/site/xdoc/checks/modifier/interfacememberimpliedmodifier.xml.template
@@ -67,6 +67,46 @@
           <param name="path"
                  value="resources/com/puppycrawl/tools/checkstyle/checks/modifier/interfacememberimpliedmodifier/Example2.java"/>
           <param name="type" value="code"/>
+        </macro><hr class="example-separator"/>
+        <p>
+          This example checks that all implicit modifiers on methods and nested types are
+          explicitly specified, but fields do not need to be.
+        </p>
+        <p id="Example3-config">
+          Configuration:
+        </p>
+        <macro name="example">
+          <param name="path"
+                 value="resources/com/puppycrawl/tools/checkstyle/checks/modifier/interfacememberimpliedmodifier/Example3.java"/>
+          <param name="type" value="config"/>
+        </macro>
+        <p id="Example3-code">
+          Code:
+        </p>
+        <macro name="example">
+          <param name="path"
+                 value="resources/com/puppycrawl/tools/checkstyle/checks/modifier/interfacememberimpliedmodifier/Example3.java"/>
+          <param name="type" value="code"/>
+        </macro><hr class="example-separator"/>
+        <p>
+          This example checks that all implicit modifiers on fields and nested types are
+          explicitly specified, but methods do not need to be.
+        </p>
+        <p id="Example4-config">
+          Configuration:
+        </p>
+        <macro name="example">
+          <param name="path"
+                 value="resources/com/puppycrawl/tools/checkstyle/checks/modifier/interfacememberimpliedmodifier/Example4.java"/>
+          <param name="type" value="config"/>
+        </macro>
+        <p id="Example4-code">
+          Code:
+        </p>
+        <macro name="example">
+          <param name="path"
+                 value="resources/com/puppycrawl/tools/checkstyle/checks/modifier/interfacememberimpliedmodifier/Example4.java"/>
+          <param name="type" value="code"/>
         </macro>
       </subsection>
 

--- a/src/test/java/com/puppycrawl/tools/checkstyle/internal/XdocsExampleFileTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/internal/XdocsExampleFileTest.java
@@ -71,13 +71,6 @@ public class XdocsExampleFileTest {
                     "violateImpliedStaticOnNestedEnum",
                     "violateImpliedStaticOnNestedRecord",
                     "violateImpliedStaticOnNestedInterface"
-            )),
-            Map.entry("InterfaceMemberImpliedModifierCheck", Set.of(
-                    "violateImpliedFinalField",
-                    "violateImpliedPublicField",
-                    "violateImpliedStaticField",
-                    "violateImpliedPublicMethod",
-                    "violateImpliedAbstractMethod"
             ))
     );
 

--- a/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/checks/modifier/InterfaceMemberImpliedModifierCheckExamplesTest.java
+++ b/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/checks/modifier/InterfaceMemberImpliedModifierCheckExamplesTest.java
@@ -63,4 +63,29 @@ public class InterfaceMemberImpliedModifierCheckExamplesTest
 
         verifyWithInlineConfigParser(getPath("Example2.java"), expected);
     }
+
+    @Test
+    public void testExample3() throws Exception {
+        final String[] expected = {
+            "25:3: " + getCheckMessage(MSG_KEY, "abstract"),
+            "25:3: " + getCheckMessage(MSG_KEY, "public"),
+            "29:3: " + getCheckMessage(MSG_KEY, "public"),
+            "29:3: " + getCheckMessage(MSG_KEY, "static"),
+            "33:5: " + getCheckMessage(MSG_KEY, "abstract"),
+            "33:5: " + getCheckMessage(MSG_KEY, "public"),
+        };
+        verifyWithInlineConfigParser(getPath("Example3.java"), expected);
+    }
+
+    @Test
+    public void testExample4() throws Exception {
+        final String[] expected = {
+            "19:3: " + getCheckMessage(MSG_KEY, "final"),
+            "19:3: " + getCheckMessage(MSG_KEY, "public"),
+            "19:3: " + getCheckMessage(MSG_KEY, "static"),
+            "29:3: " + getCheckMessage(MSG_KEY, "public"),
+            "29:3: " + getCheckMessage(MSG_KEY, "static"),
+        };
+        verifyWithInlineConfigParser(getPath("Example4.java"), expected);
+    }
 }

--- a/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/modifier/interfacememberimpliedmodifier/Example3.java
+++ b/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/modifier/interfacememberimpliedmodifier/Example3.java
@@ -1,0 +1,39 @@
+/*xml
+<module name="Checker">
+  <module name="TreeWalker">
+    <module name="InterfaceMemberImpliedModifier">
+      <property name="violateImpliedPublicField" value="false"/>
+      <property name="violateImpliedStaticField" value="false"/>
+      <property name="violateImpliedFinalField" value="false"/>
+    </module>
+  </module>
+</module>
+*/
+package com.puppycrawl.tools.checkstyle.checks.modifier.interfacememberimpliedmodifier;
+
+import java.util.List;
+
+// xdoc section -- start
+public interface Example3 {
+
+  public static final String UNKNOWN = "Unknown";
+  String OTHER = "Other";
+
+  public static Example3 instance() { return null; }
+
+  public abstract Address createAddress(String addressLine, String city);
+  List<Address> findAddresses(String city);
+  // 2 violations above:
+  //    'Implied modifier 'abstract' should be explicit'
+  //    'Implied modifier 'public' should be explicit'
+  interface Address {
+    // 2 violations above:
+    //    'Implied modifier 'public' should be explicit'
+    //    'Implied modifier 'static' should be explicit'
+    String getCity();
+    // 2 violations above:
+    //    'Implied modifier 'abstract' should be explicit'
+    //    'Implied modifier 'public' should be explicit'
+  }
+}
+// xdoc section -- end

--- a/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/modifier/interfacememberimpliedmodifier/Example4.java
+++ b/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/modifier/interfacememberimpliedmodifier/Example4.java
@@ -1,0 +1,36 @@
+/*xml
+<module name="Checker">
+  <module name="TreeWalker">
+    <module name="InterfaceMemberImpliedModifier">
+      <property name="violateImpliedPublicMethod" value="false"/>
+      <property name="violateImpliedAbstractMethod" value="false"/>
+    </module>
+  </module>
+</module>
+*/
+package com.puppycrawl.tools.checkstyle.checks.modifier.interfacememberimpliedmodifier;
+
+import java.util.List;
+
+// xdoc section -- start
+public interface Example4 {
+
+  public static final String UNKNOWN = "Unknown";
+  String OTHER = "Other";
+  // 3 violations above:
+  //    'Implied modifier 'final' should be explicit'
+  //    'Implied modifier 'public' should be explicit'
+  //    'Implied modifier 'static' should be explicit'
+  public static Example4 instance() { return null; }
+
+  public abstract Address createAddress(String addressLine, String city);
+  List<Address> findAddresses(String city);
+
+  interface Address {
+    // 2 violations above:
+    //    'Implied modifier 'public' should be explicit'
+    //    'Implied modifier 'static' should be explicit'
+    String getCity();
+  }
+}
+// xdoc section -- end


### PR DESCRIPTION
Issue #17449

Added missing XDocs examples for `InterfaceMemberImpliedModifierCheck` properties:
- `violateImpliedPublicField`
- `violateImpliedStaticField`
- `violateImpliedFinalField`
- `violateImpliedPublicMethod`
- `violateImpliedAbstractMethod`

Cleaned up the suppression list by removing the check from `SUPPRESSED_PROPERTIES_BY_CHECK` in `XdocsExampleFileTest.java`.

### Diff Proofs
To ensure examples differ only by trailing comments and configurations per

https://www.diffchecker.com/wEvUxaXk/ --  For exaple 2 And 3
https://www.diffchecker.com/X8rxlYYS/ -- For exaple 2 And 4