### PR TITLE
Issue #17842: Activate GoogleNonConstantFieldName in google_checks.xml

### DIFF
--- a/src/it/resources/com/google/checkstyle/test/chapter5naming/rule525nonconstantfieldnames/InputNonConstantNamesBasic.java
+++ b/src/it/resources/com/google/checkstyle/test/chapter5naming/rule525nonconstantfieldnames/InputNonConstantNamesBasic.java
@@ -2,28 +2,37 @@ package com.google.checkstyle.test.chapter5naming.rule525nonconstantfieldnames;
 
 /** Some javadoc. */
 public class InputNonConstantNamesBasic {
-  public int mPublic; // violation 'Member name 'mPublic' must match pattern'
-  protected int mProtected; // violation 'Member name 'mProtected' must match pattern'
-  int mPackage; // violation 'Member name 'mPackage' must match pattern'
-  private int mPrivate; // violation 'Member name 'mPrivate' must match pattern'
+  // violation below, ''mPublic' must .* avoid single lowercase letter followed by uppercase'
+  public int mPublic;
+  // violation below, ''mProtected' must .* avoid single lowercase letter followed by uppercase'
+  protected int mProtected;
+  // violation below, ''mPackage' must .* avoid single lowercase letter followed by uppercase'
+  int mPackage;
+  // violation below, ''mPrivate' must .* avoid single lowercase letter followed by uppercase'
+  private int mPrivate;
 
-  public int _public; // violation 'Member name '_public' must match pattern'
-  protected int prot_ected; // violation 'Member name 'prot_ected' must match pattern'
-  int package_; // violation 'Member name 'package_' must match pattern'
-  private int priva$te; // violation 'Member name 'priva\$te' must match pattern'
+  public int _public; // violation ''_public' .* underscores allowed only between adjacent digits.'
+  // violation below, ''prot_ected' .* underscores allowed only between adjacent digits.'
+  protected int prot_ected;
+  int package_; // violation ''package_' .* underscores allowed only between adjacent digits.'
+  // violation below, ''priva\$te' must .* contain only letters, digits or underscores'
+  private int priva$te;
 
   public int ppublic;
   protected int pprotected;
   int ppackage;
   private int pprivate;
 
-  int ABC = 0;
-  // 2 violations above:
+  // 2 violations 3 lines below:
   //  'Abbreviation in name 'ABC' must contain no more than '1' consecutive capital letters.'
-  //  'Member name 'ABC' must match pattern'
-  final int C_D_E = 0; // violation 'Member name 'C_D_E' must match pattern'
+  //  'Non-constant field name 'ABC' must start lowercase, be at least 2 chars'
+  int ABC = 0;
+  final int C_D_E = 0; // violation ''C_D_E' .* underscores allowed only between adjacent digits.'
 
-  public int $mPublic; // violation 'Member name '\$mPublic' must match pattern'
-  protected int mPro$tected; // violation 'Member name 'mPro\$tected' must match pattern'
-  int mPackage$; // violation 'Member name 'mPackage\$' must match pattern'
+  // violation below, ''\$mPublic' must .* contain only letters, digits or underscores'
+  public int $mPublic;
+  // violation below, ''mPro\$tected' must .* contain only letters, digits or underscores'
+  protected int mPro$tected;
+  // violation below, ''mPackage\$' must .* contain only letters, digits or underscores'
+  int mPackage$;
 }

--- a/src/it/resources/com/google/checkstyle/test/chapter5naming/rule525nonconstantfieldnames/InputNonConstantNamesSimple.java
+++ b/src/it/resources/com/google/checkstyle/test/chapter5naming/rule525nonconstantfieldnames/InputNonConstantNamesSimple.java
@@ -6,17 +6,21 @@ final class InputNonConstantNamesSimple {
 
   public static final int MAX_ROWS = 2;
 
-  private int bad$Static = 2; // violation 'Member name 'bad\$Static' must match pattern'
+  // violation below, ''bad\$Static' must .* contain only letters, digits or underscores'
+  private int bad$Static = 2;
 
   private static int sum_Created = 0;
 
-  private int bad_Member = 2; // violation 'Member name 'bad_Member' must match pattern'
+  // violation below, ''bad_Member' .* underscores allowed only between adjacent digits.'
+  private int bad_Member = 2;
 
-  private int m = 0; // violation 'Member name 'm' must match pattern'
+  // violation below, 'Non-constant field name 'm' must start lowercase, be at least 2 chars'
+  private int m = 0;
 
-  protected int m_M = 0; // violation 'Member name 'm_M' must match pattern'
+  // violation below, ''m_M' .* underscores allowed only between adjacent digits.'
+  protected int m_M = 0;
 
-  private int[] m$nts = // violation 'Member name 'm\$nts' must match pattern'
+  private int[] m$nts = // violation ''m\$nts' must .* contain only letters, digits or underscores'
       new int[] {1, 2, 3, 4};
 
   public static int sTest1;
@@ -25,13 +29,17 @@ final class InputNonConstantNamesSimple {
 
   static int sTest2;
 
-  int mTest1; // violation 'Member name 'mTest1' must match pattern'
+  // violation below, ''mTest1' must .* avoid single lowercase letter followed by uppercase'
+  int mTest1;
 
-  public int mTest2; // violation 'Member name 'mTest2' must match pattern'
+  // violation below, ''mTest2' must .* avoid single lowercase letter followed by uppercase'
+  public int mTest2;
 
-  public int $mTest2; // violation 'Member name '\$mTest2' must match pattern'
+  // violation below, ''\$mTest2' must .* contain only letters, digits or underscores'
+  public int $mTest2;
 
-  public int mTes$t2; // violation 'Member name 'mTes\$t2' must match pattern'
+  // violation below, ''mTes\$t2' must .* contain only letters, digits or underscores'
+  public int mTes$t2;
 
   private void localVariables() {
     int a;
@@ -49,58 +57,75 @@ final class InputNonConstantNamesSimple {
 
     public static final int MAX_ROWS = 2;
 
-    private int bad$Static = 2; // violation 'Member name 'bad\$Static' must match pattern'
+    // violation below, ''bad\$Static' must .* contain only letters, digits or underscores'
+    private int bad$Static = 2;
 
+    // violation below, ''sum_Created' .* underscores allowed only between adjacent digits.'
     private int sum_Created = 0;
-    // violation above 'Member name 'sum_Created' must match pattern'
 
-    private int bad_Member = 2; // violation 'Member name 'bad_Member' must match pattern'
+    // violation below, ''bad_Member' .* underscores allowed only between adjacent digits.'
+    private int bad_Member = 2;
 
-    private int m = 0; // violation 'Member name 'm' must match pattern'
+    // violation below, 'Non-constant field name 'm' must start lowercase, be at least 2 chars'
+    private int m = 0;
 
-    protected int m_M = 0; // violation 'Member name 'm_M' must match pattern'
+    // violation below, ''m_M' .* underscores allowed only between adjacent digits.'
+    protected int m_M = 0;
 
+    // violation below, ''m\$nts' must .* contain only letters, digits or underscores'
     private int[] m$nts = new int[] {1, 2, 3, 4};
-    // violation above 'Member name 'm\$nts' must match pattern'
 
-    int mTest1; // violation 'Member name 'mTest1' must match pattern'
+    // violation below, ''mTest1' must .* avoid single lowercase letter followed by uppercase'
+    int mTest1;
 
-    public int mTest2; // violation 'Member name 'mTest2' must match pattern'
+    // violation below, ''mTest2' must .* avoid single lowercase letter followed by uppercase'
+    public int mTest2;
 
-    public int $mTest2; // violation 'Member name '\$mTest2' must match pattern'
+    // violation below, ''\$mTest2' must .* contain only letters, digits or underscores'
+    public int $mTest2;
 
-    public int mTes$t2; // violation 'Member name 'mTes\$t2' must match pattern'
+    // violation below, ''mTes\$t2' must .* contain only letters, digits or underscores'
+    public int mTes$t2;
 
-    public int mTest2$; // violation 'Member name 'mTest2\$' must match pattern'
+    // violation below, ''mTest2\$' must .* contain only letters, digits or underscores'
+    public int mTest2$;
 
     void fooMethod() {
       Foo foo =
           new Foo() {
 
-            int bad$Static = 2; // violation 'Member name 'bad\$Static' must match pattern'
+            // violation below, ''bad\$Static' must .* contain only letters, digits or underscores'
+            int bad$Static = 2;
 
+            // violation below, ''sum_Created' .* underscores allowed only between adjacent digits.'
             int sum_Created = 0;
-            // violation above 'Member name 'sum_Created' must match pattern'
 
+            // violation below, ''bad_Member' .* underscores allowed only between adjacent digits.'
             int bad_Member = 2;
-            // violation above 'Member name 'bad_Member' must match pattern'
 
-            int m = 0; // violation 'Member name 'm' must match pattern'
+            // violation below, 'Non-constant field name 'm' must start lowercase, be at least 2'
+            int m = 0;
 
-            int m_M = 0; // violation 'Member name 'm_M' must match pattern'
+            // violation below, ''m_M' .* underscores allowed only between adjacent digits.'
+            int m_M = 0;
 
+            // violation below, ''m\$nts' must .* contain only letters, digits or underscores'
             int[] m$nts = new int[] {1, 2, 3, 4};
-            // violation above 'Member name 'm\$nts' must match pattern'
 
-            int mTest1; // violation 'Member name 'mTest1' must match pattern'
+            // violation below, ''mTest1' .* avoid single lowercase letter followed by uppercase'
+            int mTest1;
 
-            int mTest2; // violation 'Member name 'mTest2' must match pattern'
+            // violation below, ''mTest2' .* avoid single lowercase letter followed by uppercase'
+            int mTest2;
 
-            int $mTest2; // violation 'Member name '\$mTest2' must match pattern'
+            // violation below, ''\$mTest2' must .* contain only letters, digits or underscores'
+            int $mTest2;
 
-            int mTes$t2; // violation 'Member name 'mTes\$t2' must match pattern'
+            // violation below, ''mTes\$t2' must .* contain only letters, digits or underscores'
+            int mTes$t2;
 
-            int mTest2$; // violation 'Member name 'mTest2\$' must match pattern'
+            // violation below, ''mTest2\$' must .* contain only letters, digits or underscores'
+            int mTest2$;
 
             public void greet() {}
           };

--- a/src/it/resources/com/google/checkstyle/test/chapter5naming/rule53camelcase/InputUnderscoreUsedInNames.java
+++ b/src/it/resources/com/google/checkstyle/test/chapter5naming/rule53camelcase/InputUnderscoreUsedInNames.java
@@ -22,27 +22,33 @@ public class InputUnderscoreUsedInNames {
   private String gradle851;
 
   class InnerBad {
-    int guava_33_4_7; // false-negative, _ between digit and letter
+    // violation below, ''guava_33_4_7' .* underscores allowed only between adjacent digits.'
+    int guava_33_4_7;
     int guava33_4_7;
 
-    int guava33_4_8_; // violation, _ at the end, 'must match pattern'
+    // violation below, ''guava33_4_8_' .* underscores allowed only between adjacent digits.'
+    int guava33_4_8_;
     int guava33_4_8;
 
-    int jdk_8_90; // false-negative, _ between digit and letter
+    // violation below, ''jdk_8_90' .* underscores allowed only between adjacent digits.'
+    int jdk_8_90;
     int jdk8_90;
 
-    int jdk8_91_; // violation, _ at the end, 'must match pattern'
+    // violation below, ''jdk8_91_' .* underscores allowed only between adjacent digits.'
+    int jdk8_91_;
     int jdk8_91;
 
-    int kotlin_1_9_24; // false-negative, _ between digit and letter
+    // violation below, ''kotlin_1_9_24' .* underscores allowed only between adjacent digits.'
+    int kotlin_1_9_24;
     int kotlin1_9_24;
 
-    // violation below, _ not allowed between lowercase character sequences, 'pattern'
+    // violation below, ''kotlin_version1_9_24'.* underscores allowed only between adjacent digits.'
     int kotlin_version1_9_24;
 
     int kotlinVersion1_9_24;
 
-    int kotlin1_9_25_; // violation, _ at the end, 'must match pattern'
+    // violation below, ''kotlin1_9_25_' .* underscores allowed only between adjacent digits.'
+    int kotlin1_9_25_;
     int kotlin1_9_25;
   }
 

--- a/src/main/resources/google_checks.xml
+++ b/src/main/resources/google_checks.xml
@@ -252,12 +252,7 @@
       <message key="name.invalidPattern"
              value="Type name ''{0}'' must match pattern ''{1}''."/>
     </module>
-    <module name="MemberName">
-      <property name="format"
-        value="^(?![a-z]$)(?![a-z][A-Z])[a-z][a-zA-Z0-9]*(?:_[0-9]+)*$"/>
-      <message key="name.invalidPattern"
-             value="Member name ''{0}'' must match pattern ''{1}''."/>
-    </module>
+    <module name="GoogleNonConstantFieldName"/>
     <module name="ParameterName">
       <property name="format" value="^[a-z]([a-z0-9][a-zA-Z0-9]*)?$"/>
       <message key="name.invalidPattern"

--- a/src/site/xdoc/checks/naming/googlenonconstantfieldname.xml
+++ b/src/site/xdoc/checks/naming/googlenonconstantfieldname.xml
@@ -100,6 +100,10 @@ class Example1 {
             <a href="https://github.com/search?q=path%3Aconfig%20path%3A**%2Fcheckstyle-checks.xml+repo%3Acheckstyle%2Fcheckstyle+GoogleNonConstantFieldName">
               Checkstyle Style</a>
           </li>
+          <li>
+            <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources%20path%3A**%2Fgoogle_checks.xml+repo%3Acheckstyle%2Fcheckstyle+GoogleNonConstantFieldName">
+            Google Style</a>
+          </li>
         </ul>
       </subsection>
 

--- a/src/site/xdoc/checks/naming/googlenonconstantfieldname.xml.template
+++ b/src/site/xdoc/checks/naming/googlenonconstantfieldname.xml.template
@@ -41,6 +41,10 @@
             <a href="https://github.com/search?q=path%3Aconfig%20path%3A**%2Fcheckstyle-checks.xml+repo%3Acheckstyle%2Fcheckstyle+GoogleNonConstantFieldName">
               Checkstyle Style</a>
           </li>
+          <li>
+            <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources%20path%3A**%2Fgoogle_checks.xml+repo%3Acheckstyle%2Fcheckstyle+GoogleNonConstantFieldName">
+            Google Style</a>
+          </li>
         </ul>
       </subsection>
 

--- a/src/site/xdoc/checks/naming/membername.xml
+++ b/src/site/xdoc/checks/naming/membername.xml
@@ -154,10 +154,6 @@ class Example3 {
       <subsection name="Example of Usage" id="MemberName_Example_of_Usage">
         <ul>
           <li>
-            <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources%20path%3A**%2Fgoogle_checks.xml+repo%3Acheckstyle%2Fcheckstyle+MemberName">
-            Google Style</a>
-          </li>
-          <li>
             <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources%20path%3A**%2Fsun_checks.xml+repo%3Acheckstyle%2Fcheckstyle+MemberName">
             Sun Style</a>
           </li>

--- a/src/site/xdoc/checks/naming/membername.xml.template
+++ b/src/site/xdoc/checks/naming/membername.xml.template
@@ -80,10 +80,6 @@
       <subsection name="Example of Usage" id="MemberName_Example_of_Usage">
         <ul>
           <li>
-            <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources%20path%3A**%2Fgoogle_checks.xml+repo%3Acheckstyle%2Fcheckstyle+MemberName">
-            Google Style</a>
-          </li>
-          <li>
             <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources%20path%3A**%2Fsun_checks.xml+repo%3Acheckstyle%2Fcheckstyle+MemberName">
             Sun Style</a>
           </li>

--- a/src/site/xdoc/google_style.xml
+++ b/src/site/xdoc/google_style.xml
@@ -1958,18 +1958,11 @@
                 </td>
                 <td>
                   <span class="wrapper inline">
-                    <img src="images/ok_blue.png" alt="" />
+                    <img src="images/ok_green.png" alt="" />
                   </span>
-                  <a href="checks/naming/membername.html#MemberName">MemberName</a>
-                  (<a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources%20path%3A**%2Fgoogle_checks.xml+repo%3Acheckstyle%2Fcheckstyle+MemberName">
+                  <a href="checks/naming/googlenonconstantfieldname.html#GoogleNonConstantFieldName">GoogleNonConstantFieldName</a>
+                  (<a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources%20path%3A**%2Fgoogle_checks.xml+repo%3Acheckstyle%2Fcheckstyle+GoogleNonConstantFieldName">
                   config</a>)
-                  <br/>
-                  <br/>
-                  There are some false-negatives regarding the use of underscore in
-                  the member names. They will be addressed at:
-                  <a href="https://github.com/checkstyle/checkstyle/issues/17842">
-                    #17842
-                  </a>
                   <br/>
                   <br/>
                   <span class="wrapper inline">
@@ -1980,8 +1973,8 @@
                   As with section 5.2.4, due to
                   <a href="writingchecks.html#Limitations">limitations</a>,
                   Checkstyle cannot determine whether a static final field is semantically
-                  a constant or not. In other words, MemberName cannot verify that static
-                  final fields use lower case name when they are not constants (e.g.,
+                  a constant or not. In other words, GoogleNonConstantFieldName cannot verify
+                  that static final fields use lower case name when they are not constants (e.g.,
                   static final List&lt;String&gt; names).
                 </td>
                 <td>

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/main/InputMainViolationsForGoogleSuppressions.xml
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/main/InputMainViolationsForGoogleSuppressions.xml
@@ -5,7 +5,7 @@
 <suppressions>
   <suppress
          files="InputMainViolationsForGoogle.java"
-         checks="MemberNameCheck"
+         checks="GoogleNonConstantFieldNameCheck"
          lines="7"
   />
   <suppress

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/main/InputMainViolationsForGoogleXpathSuppressions.xml
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/main/InputMainViolationsForGoogleXpathSuppressions.xml
@@ -5,7 +5,7 @@
 <suppressions>
   <suppress-xpath
          files="InputMainViolationsForGoogle.java"
-         checks="MemberNameCheck"
+         checks="GoogleNonConstantFieldNameCheck"
          query="//CLASS_DEF[./IDENT[@text='InputMainViolationsForGoogle']]/
                   OBJBLOCK/VARIABLE_DEF/IDENT[@text='m_field']"
   />


### PR DESCRIPTION
Issue #17842:

Replace MemberName with GoogleNonConstantFieldName in google_checks.xml to fix false-negatives for member names with underscores between letters and digits.

Diff Regression config: https://gist.githubusercontent.com/vivek-0509/94f9fb7d62cbbd713adc3d598c72ce4a/raw/5aadc7d27f7d60abc70d61570565695e512ed0ee/google_checks_base.xml

Diff Regression patch config: https://gist.githubusercontent.com/vivek-0509/4a80f1a7b830fab98b8e10ba020c3977/raw/58c81726f38afc71fc6161948d8469f87b3f77b2/patch_config.xml


