### PR TITLE
Issue #16807: remove MemberNameCheck from SUPPRESSED_MODULES

### DIFF
--- a/src/test/java/com/puppycrawl/tools/checkstyle/TreeWalkerTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/TreeWalkerTest.java
@@ -505,9 +505,9 @@ public class TreeWalkerTest extends AbstractModuleTestSupport {
     public void testBehaviourWithChecksAndFilters() throws Exception {
 
         final String[] expected = {
-            "17:17: " + getCheckMessage(MemberNameCheck.class, "name.invalidPattern", "P",
+            "22:17: " + getCheckMessage(MemberNameCheck.class, "name.invalidPattern", "P",
                     "^[a-z][a-zA-Z0-9]*$"),
-            "12:17: " + getCheckMessage(MemberNameCheck.class, "name.invalidPattern", "I",
+            "17:17: " + getCheckMessage(MemberNameCheck.class, "name.invalidPattern", "I",
                     "^[a-z][a-zA-Z0-9]*$"),
         };
 

--- a/src/test/java/com/puppycrawl/tools/checkstyle/bdd/InlineConfigParser.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/bdd/InlineConfigParser.java
@@ -333,7 +333,6 @@ public final class InlineConfigParser {
             "com.puppycrawl.tools.checkstyle.checks.naming.ConstantNameCheck",
             "com.puppycrawl.tools.checkstyle.checks.naming.LocalFinalVariableNameCheck",
             "com.puppycrawl.tools.checkstyle.checks.naming.LocalVariableNameCheck",
-            "com.puppycrawl.tools.checkstyle.checks.naming.MemberNameCheck",
             "com.puppycrawl.tools.checkstyle.checks.naming.ParameterNameCheck",
             "com.puppycrawl.tools.checkstyle.checks.regexp.RegexpCheck",
             "com.puppycrawl.tools.checkstyle.checks.regexp.RegexpSinglelineCheck",

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/SuppressWarningsHolderTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/SuppressWarningsHolderTest.java
@@ -610,7 +610,7 @@ public class SuppressWarningsHolderTest extends AbstractModuleTestSupport {
         final String pattern = "^[a-z][a-zA-Z0-9]*$";
 
         final String[] expected = {
-            "18:16: " + getCheckMessage(MemberNameCheck.class,
+            "22:16: " + getCheckMessage(MemberNameCheck.class,
                     AbstractNameCheck.MSG_INVALID_PATTERN, "K", pattern),
         };
         verifyWithInlineConfigParser(

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/suppresswarningsholder/InputSuppressWarningsHolder8.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/suppresswarningsholder/InputSuppressWarningsHolder8.java
@@ -5,7 +5,11 @@ aliasList = (default)
 com.puppycrawl.tools.checkstyle.filters.SuppressWarningsFilter
 
 com.puppycrawl.tools.checkstyle.checks.naming.MemberNameCheck
-format = ^[a-z][a-zA-Z0-9]*$
+format = (default)^[a-z][a-zA-Z0-9]*$
+applyToPublic = (default)true
+applyToProtected = (default)true
+applyToPackage = (default)true
+applyToPrivate = (default)true
 
 
 */

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/treewalker/InputTreeWalkerSuppressionCommentFilter.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/treewalker/InputTreeWalkerSuppressionCommentFilter.java
@@ -1,5 +1,10 @@
 /*
 com.puppycrawl.tools.checkstyle.checks.naming.MemberNameCheck
+format = (default)^[a-z][a-zA-Z0-9]*$
+applyToPublic = (default)true
+applyToProtected = (default)true
+applyToPackage = (default)true
+applyToPrivate = (default)true
 
 
 com.puppycrawl.tools.checkstyle.filters.SuppressionCommentFilter


### PR DESCRIPTION
issue #16807.
 ---                                                                  
  PR Summary — Issue #16807: Remove MemberNameCheck from 
  SUPPRESSED_MODULES                                                   
                  
  **What This PR Does**

  All input test files that reference MemberNameCheck now have every default property explicitly listed with the (default) tag. Because the files are already compliant (According to the issue#16807), the suppression is no longer needed.

  The changes fall into 3 categories:

  ---
  1. Remove the suppression (InlineConfigParser.java)

  MemberNameCheck is removed from SUPPRESSED_MODULES, enabling validateDefaultProperties() to run on all input files that use this module.

  ---
  2. Update two non-compliant input files to satisfy the validation

  InputSuppressWarningsHolder8.java — was missing the (default) tag on format and missing all 4 applyTo* properties entirely.

  InputTreeWalkerSuppressionCommentFilter.java — was missing all 4 applyTo* properties entirely.

  Both files now declare all 5 default properties for MemberNameCheck:
```java
  format           = (default)^[a-z][a-zA-Z0-9]*$
  applyToPublic    = (default)true
  applyToProtected = (default)true
  applyToPackage   = (default)true
  applyToPrivate   = (default)true
```
  ---
  3. Update hardcoded line numbers in two test files

  Adding those properties to the file headers shifted the Java code inside each input file to new line numbers. The corresponding tests have hardcoded violation line numbers that must match:

  - SuppressWarningsHolderTest.java: "18:16" → "22:16" (header grew by
  4 lines)
  - TreeWalkerTest.java: "12:17" → "17:17" and "17:17" → "22:17"
  (header grew by 5 lines)

  ---