### PR TITLE
Issue #16360: Added comment to testFileOpenTag

### DIFF
--- a/src/test/java/com/puppycrawl/tools/checkstyle/XMLLoggerTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/XMLLoggerTest.java
@@ -344,6 +344,12 @@ public class XMLLoggerTest extends AbstractXmlTestSupport {
         verifyWithInlineConfigParserAndXmlLogger(inputFile, expectedXmlReport);
     }
 
+    /**
+     * Cannot use verifyWithInlineConfigParserAndXmlLogger because this test
+     * requires a custom AuditEvent with a special character in the file
+     * name ("&") to verify XML escaping, without creating a physical file
+     * with special characters in the repository.
+     */
     @Test
     public void testFileOpenTag()
             throws Exception {


### PR DESCRIPTION
Issue #16360

The `testFileOpenTag` method in `XMLLoggerTest` cannot be updated to use the standard `verifyWithInlineConfigParserAndXmlLogger` approach.

Reason: The test requires creating an `AuditEvent` with a special character in the file name (`Test&.java`) to verify XML escaping. This cannot be represented by a standard input Java file without introducing physical files with special characters into the repository, which can cause cross-platform file system issues.

A comment has been added above the method to explain why this test deviates from the usual input/expected XML pattern.