### PR TITLE
Issue #18435: Fix AST consistency in TypecastParenPad examples

### DIFF
--- a/src/site/xdoc/checks/whitespace/typecastparenpad.xml
+++ b/src/site/xdoc/checks/whitespace/typecastparenpad.xml
@@ -84,17 +84,17 @@ class Example1 {
         </p>
         <div class="wrapper"><pre class="prettyprint"><code class="language-java">
 class Example2 {
-  double d1 = 3.14;
+  float f1 = 3.14f;
 
-  int n = ( int ) d1;
+  int n = ( int ) f1;
 
-  int m = (int ) d1; // violation 'not followed by whitespace'
+  double d = 1.234567;
 
-  double d2 = 9.8;
+  float f2 = (float ) d; // violation 'not followed by whitespace'
 
-  int x = (int) d2; // 2 violations
+  float f3 = (float) d; // 2 violations
 
-  int y = ( int) d2; // violation 'not preceded with whitespace'
+  float f4 = ( float) d; // violation 'not preceded with whitespace'
 }
 </code></pre></div>
       </subsection>

--- a/src/test/java/com/puppycrawl/tools/checkstyle/internal/XdocsExamplesAstConsistencyTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/internal/XdocsExamplesAstConsistencyTest.java
@@ -252,7 +252,6 @@ public class XdocsExamplesAstConsistencyTest {
             "checks/whitespace/separatorwrap/Example2",
             "checks/whitespace/separatorwrap/Example3",
             "checks/whitespace/singlespaceseparator/Example2",
-            "checks/whitespace/typecastparenpad/Example2",
             "checks/whitespace/whitespaceafter/Example2",
             "checks/whitespace/whitespacearound/Example10",
             "checks/whitespace/whitespacearound/Example2",

--- a/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/checks/whitespace/TypecastParenPadExamplesTest.java
+++ b/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/checks/whitespace/TypecastParenPadExamplesTest.java
@@ -49,10 +49,10 @@ public class TypecastParenPadExamplesTest extends AbstractExamplesModuleTestSupp
     @Test
     public void testExample2() throws Exception {
         final String[] expected = {
-            "21:11: " + getCheckMessage(MSG_WS_NOT_FOLLOWED, "("),
-            "25:11: " + getCheckMessage(MSG_WS_NOT_FOLLOWED, "("),
-            "25:15: " + getCheckMessage(MSG_WS_NOT_PRECEDED, ")"),
-            "27:16: " + getCheckMessage(MSG_WS_NOT_PRECEDED, ")"),
+            "23:14: " + getCheckMessage(MSG_WS_NOT_FOLLOWED, "("),
+            "25:14: " + getCheckMessage(MSG_WS_NOT_FOLLOWED, "("),
+            "25:20: " + getCheckMessage(MSG_WS_NOT_PRECEDED, ")"),
+            "27:21: " + getCheckMessage(MSG_WS_NOT_PRECEDED, ")"),
         };
 
         verifyWithInlineConfigParser(getPath("Example2.java"), expected);

--- a/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/whitespace/typecastparenpad/Example2.java
+++ b/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/whitespace/typecastparenpad/Example2.java
@@ -14,16 +14,16 @@ package com.puppycrawl.tools.checkstyle.checks.whitespace.typecastparenpad;
 
 // xdoc section -- start
 class Example2 {
-  double d1 = 3.14;
+  float f1 = 3.14f;
 
-  int n = ( int ) d1;
+  int n = ( int ) f1;
 
-  int m = (int ) d1; // violation 'not followed by whitespace'
+  double d = 1.234567;
 
-  double d2 = 9.8;
+  float f2 = (float ) d; // violation 'not followed by whitespace'
 
-  int x = (int) d2; // 2 violations
+  float f3 = (float) d; // 2 violations
 
-  int y = ( int) d2; // violation 'not preceded with whitespace'
+  float f4 = ( float) d; // violation 'not preceded with whitespace'
 }
 // xdoc section -- end


### PR DESCRIPTION
Issue: #18435

## Description

Fixed AST consistency for `TypecastParenPad` check examples by aligning `Example2.java` code structure with `Example1.java`.

## Technical Details

- Updated `Example2.java` to use the same variable types and cast patterns as `Example1.java`
  (`float`, `double` → `float` casts instead of `double` → `int`).
- Updated `TypecastParenPadExamplesTest.java` to reflect the correct violation line numbers for `Example2`.
- Updated `typecastparenpad.xml` xdoc to match the new `Example2` code.
- Removed `checks/whitespace/typecastparenpad/Example2` from the `SUPPRESSED_EXAMPLES` list in `XdocsExamplesAstConsistencyTest`.