### PR TITLE
Issue #16361: update testNoCloseStream to use verifyWithInlineConfigP…

### DIFF
--- a/src/test/java/com/puppycrawl/tools/checkstyle/SarifLoggerTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/SarifLoggerTest.java
@@ -359,11 +359,14 @@ public class SarifLoggerTest extends AbstractModuleTestSupport {
     }
 
     @Test
-    public void testNoCloseStream() throws IOException {
+    public void testNoCloseStream() throws Exception {
+        final String inputFile = "InputSarifLoggerEmpty.java";
+        final String expectedReportFile = "ExpectedSarifLoggerEmpty.sarif";
         final SarifLogger logger = new SarifLogger(outStream,
                 OutputStreamOptions.NONE);
-        logger.auditStarted(null);
-        logger.auditFinished(null);
+
+        verifyWithInlineConfigParserAndLogger(
+                getPath(inputFile), getPath(expectedReportFile), logger, outStream);
 
         assertWithMessage("Invalid close count")
             .that(outStream.getCloseCount())
@@ -371,9 +374,6 @@ public class SarifLoggerTest extends AbstractModuleTestSupport {
         assertWithMessage("Invalid flush count")
             .that(outStream.getFlushCount())
             .isEqualTo(1);
-
-        outStream.close();
-        verifyContent(getPath("ExpectedSarifLoggerEmpty.sarif"), outStream);
     }
 
     @Test


### PR DESCRIPTION
Issue #16361

Updated `testNoCloseStream` in `SarifLoggerTest.java` to use `verifyWithInlineConfigParserAndLogger`.

This migration reuses the existing `InputSarifLoggerEmpty.java` and `ExpectedSarifLoggerEmpty.sarif` files, replacing the manual `auditStarted`/`auditFinished` event injection while preserving the `outStream.getCloseCount()` and `getFlushCount()` assertions.