### PR TITLE
Issue #16807: update default properties in input files for filters

### DIFF
--- a/src/test/java/com/puppycrawl/tools/checkstyle/bdd/InlineConfigParser.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/bdd/InlineConfigParser.java
@@ -308,7 +308,6 @@ public final class InlineConfigParser {
      */
     private static final Set<String> SUPPRESSED_MODULES = Set.of(
             "com.puppycrawl.tools.checkstyle.checks.coding.IllegalTypeCheck",
-            "com.puppycrawl.tools.checkstyle.checks.coding.MagicNumberCheck",
             "com.puppycrawl.tools.checkstyle.checks.coding.MatchXpathCheck",
             "com.puppycrawl.tools.checkstyle.checks.coding.RequireThisCheck",
             "com.puppycrawl.tools.checkstyle.checks.coding.UnusedLocalVariableCheck",

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/coding/MagicNumberCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/coding/MagicNumberCheckTest.java
@@ -530,14 +530,14 @@ public class MagicNumberCheckTest
     public void testIgnoreFieldDeclaration4()
             throws Exception {
         final String[] expected = {
-            "29:27: " + getCheckMessage(MSG_KEY, "5"),
-            "36:26: " + getCheckMessage(MSG_KEY, "86400_000"),
-            "45:31: " + getCheckMessage(MSG_KEY, "5"),
-            "46:32: " + getCheckMessage(MSG_KEY, "69"),
-            "55:27: " + getCheckMessage(MSG_KEY, "5"),
-            "62:26: " + getCheckMessage(MSG_KEY, "86400_000"),
-            "71:31: " + getCheckMessage(MSG_KEY, "5"),
-            "72:32: " + getCheckMessage(MSG_KEY, "69"),
+            "32:27: " + getCheckMessage(MSG_KEY, "5"),
+            "39:26: " + getCheckMessage(MSG_KEY, "86400_000"),
+            "48:31: " + getCheckMessage(MSG_KEY, "5"),
+            "49:32: " + getCheckMessage(MSG_KEY, "69"),
+            "58:27: " + getCheckMessage(MSG_KEY, "5"),
+            "65:26: " + getCheckMessage(MSG_KEY, "86400_000"),
+            "74:31: " + getCheckMessage(MSG_KEY, "5"),
+            "75:32: " + getCheckMessage(MSG_KEY, "69"),
         };
         verifyWithInlineConfigParser(
                 getPath("InputMagicNumberIgnoreFieldDeclaration4.java"), expected);
@@ -547,24 +547,24 @@ public class MagicNumberCheckTest
     public void testIgnoreFieldDeclaration5()
             throws Exception {
         final String[] expected = {
-            "17:32: " + getCheckMessage(MSG_KEY, "22"),
-            "17:37: " + getCheckMessage(MSG_KEY, "7.0"),
-            "23:20: " + getCheckMessage(MSG_KEY, "10"),
-            "24:20: " + getCheckMessage(MSG_KEY, "10"),
-            "24:25: " + getCheckMessage(MSG_KEY, "20"),
-            "28:30: " + getCheckMessage(MSG_KEY, "4"),
-            "28:33: " + getCheckMessage(MSG_KEY, "5"),
-            "28:36: " + getCheckMessage(MSG_KEY, "6"),
-            "28:39: " + getCheckMessage(MSG_KEY, "7"),
-            "35:26: " + getCheckMessage(MSG_KEY, "2023"),
-            "35:32: " + getCheckMessage(MSG_KEY, "11"),
-            "35:36: " + getCheckMessage(MSG_KEY, "11"),
-            "35:40: " + getCheckMessage(MSG_KEY, "11"),
-            "42:16: " + getCheckMessage(MSG_KEY, "11"),
-            "42:20: " + getCheckMessage(MSG_KEY, "11"),
-            "42:24: " + getCheckMessage(MSG_KEY, "11"),
-            "48:41: " + getCheckMessage(MSG_KEY, "3"),
-            "49:61: " + getCheckMessage(MSG_KEY, "4"),
+            "20:32: " + getCheckMessage(MSG_KEY, "22"),
+            "20:37: " + getCheckMessage(MSG_KEY, "7.0"),
+            "26:20: " + getCheckMessage(MSG_KEY, "10"),
+            "27:20: " + getCheckMessage(MSG_KEY, "10"),
+            "27:25: " + getCheckMessage(MSG_KEY, "20"),
+            "31:30: " + getCheckMessage(MSG_KEY, "4"),
+            "31:33: " + getCheckMessage(MSG_KEY, "5"),
+            "31:36: " + getCheckMessage(MSG_KEY, "6"),
+            "31:39: " + getCheckMessage(MSG_KEY, "7"),
+            "38:26: " + getCheckMessage(MSG_KEY, "2023"),
+            "38:32: " + getCheckMessage(MSG_KEY, "11"),
+            "38:36: " + getCheckMessage(MSG_KEY, "11"),
+            "38:40: " + getCheckMessage(MSG_KEY, "11"),
+            "45:16: " + getCheckMessage(MSG_KEY, "11"),
+            "45:20: " + getCheckMessage(MSG_KEY, "11"),
+            "45:24: " + getCheckMessage(MSG_KEY, "11"),
+            "51:41: " + getCheckMessage(MSG_KEY, "3"),
+            "52:61: " + getCheckMessage(MSG_KEY, "4"),
         };
         verifyWithInlineConfigParser(
                 getPath("InputMagicNumberIgnoreFieldDeclaration5.java"), expected);
@@ -574,8 +574,8 @@ public class MagicNumberCheckTest
     public void testIgnoreFieldDeclaration6()
             throws Exception {
         final String[] expected = {
-            "16:38: " + getCheckMessage(MSG_KEY, "10"),
-            "17:46: " + getCheckMessage(MSG_KEY, "15"),
+            "19:38: " + getCheckMessage(MSG_KEY, "10"),
+            "20:46: " + getCheckMessage(MSG_KEY, "15"),
         };
         verifyWithInlineConfigParser(
                 getPath("InputMagicNumberIgnoreFieldDeclaration6.java"), expected);

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/magicnumber/InputMagicNumberIgnoreFieldDeclaration4.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/magicnumber/InputMagicNumberIgnoreFieldDeclaration4.java
@@ -4,6 +4,9 @@ ignoreNumbers = -2, -1, 0, 1, 2, 100
 ignoreHashCodeMethod = true
 ignoreFieldDeclaration = true
 constantWaiverParentToken = ARRAY_INIT, ASSIGN, ELIST, EXPR
+ignoreAnnotation = (default)false
+ignoreAnnotationElementDefaults = (default)true
+tokens = (default)NUM_DOUBLE, NUM_FLOAT, NUM_INT, NUM_LONG
 
 */
 

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/magicnumber/InputMagicNumberIgnoreFieldDeclaration5.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/magicnumber/InputMagicNumberIgnoreFieldDeclaration5.java
@@ -4,6 +4,9 @@ ignoreNumbers = -2, -1, 0, 1, 2, 100
 ignoreHashCodeMethod = true
 ignoreFieldDeclaration = (default)false
 constantWaiverParentToken = ARRAY_INIT, ASSIGN, ELIST, EXPR
+ignoreAnnotation = (default)false
+ignoreAnnotationElementDefaults = (default)true
+tokens = (default)NUM_DOUBLE, NUM_FLOAT, NUM_INT, NUM_LONG
 
 */
 

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/magicnumber/InputMagicNumberIgnoreFieldDeclaration6.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/magicnumber/InputMagicNumberIgnoreFieldDeclaration6.java
@@ -1,9 +1,12 @@
 /*
 MagicNumber
 ignoreNumbers = -2, -1, 0, 1, 2, 100
-ignoreAnnotation = false
+ignoreAnnotation = (default)false
 ignoreFieldDeclaration = true
 constantWaiverParentToken = ARRAY_INIT, ASSIGN, ELIST
+ignoreHashCodeMethod = (default)false
+ignoreAnnotationElementDefaults = (default)true
+tokens = (default)NUM_DOUBLE, NUM_FLOAT, NUM_INT, NUM_LONG
 
 */
 package com.puppycrawl.tools.checkstyle.checks.coding.magicnumber;


### PR DESCRIPTION
Issue: #16807

### Description
This PR unsuppresses `MagicNumberCheck` in `InlineConfigParser` and updates the remaining test input files to explicitly declare all default properties.

### Approach
1. **The Trigger:** Removed `com.puppycrawl...MagicNumberCheck` from the `SUPPRESSED_MODULES` list in `InlineConfigParser.java` to enforce explicit default property declarations in test inputs.
2. **Updating Inputs:** Added the missing default properties (using the `(default)` tag) to the headers of `InputMagicNumberIgnoreFieldDeclaration4.java`, `InputMagicNumberIgnoreFieldDeclaration5.java`, and `InputMagicNumberIgnoreFieldDeclaration6.java`.
3. **Updating Tests:** Updated the expected violation line numbers in `MagicNumberCheckTest.java` to account for the expanded configuration blocks pushing the Java code down.
