### PR TITLE
Issue #18614: Fix tab-based indentation validation in getIndentImpl

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/indentation/NewHandler.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/indentation/NewHandler.java
@@ -121,7 +121,7 @@ public class NewHandler extends AbstractExpressionHandler {
         IndentLevel result;
         // if our expression isn't first on the line, just use the start
         // of the line
-        if (getLineStart(mainAst) == mainAst.getColumnNo()) {
+        if (isNewOnStartOfLine()) {
             result = super.getIndentImpl();
 
             final boolean isLineWrappedNew = TokenUtil.isOfType(mainAst.getParent().getParent(),
@@ -144,6 +144,17 @@ public class NewHandler extends AbstractExpressionHandler {
         }
 
         return result;
+    }
+
+    /**
+     * Checks if the new keyword is at the start of its line,
+     * using consistent visual column logic to handle both
+     * space and tab indented files.
+     *
+     * @return true if new is the first token on the line
+     */
+    private boolean isNewOnStartOfLine() {
+        return getLineStart(mainAst) == expandedTabsColumnNo(mainAst);
     }
 
     /**

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/indentation/IndentationCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/indentation/IndentationCheckTest.java
@@ -4286,6 +4286,50 @@ public class IndentationCheckTest extends AbstractModuleTestSupport {
         verifyWarns(checkConfig, fileName, expected);
     }
 
+    @Test
+    public void testTabIndentationNewInTryBlockValid() throws Exception {
+        final DefaultConfiguration checkConfig = createModuleConfig(IndentationCheck.class);
+        checkConfig.addProperty("basicOffset", "4");
+        checkConfig.addProperty("braceAdjustment", "0");
+        checkConfig.addProperty("caseIndent", "4");
+        checkConfig.addProperty("lineWrappingIndentation", "4");
+        checkConfig.addProperty("tabWidth", "4");
+
+        final String fileName = getPath("InputIndentationTryCtorParamsTabsValid.java");
+        final String[] expected = CommonUtil.EMPTY_STRING_ARRAY;
+        verifyWarns(checkConfig, fileName, expected);
+    }
+
+    @Test
+    public void testTabIndentationNewInTryBlockInvalid() throws Exception {
+        final DefaultConfiguration checkConfig = createModuleConfig(IndentationCheck.class);
+        checkConfig.addProperty("basicOffset", "4");
+        checkConfig.addProperty("braceAdjustment", "0");
+        checkConfig.addProperty("caseIndent", "4");
+        checkConfig.addProperty("lineWrappingIndentation", "4");
+        checkConfig.addProperty("tabWidth", "4");
+
+        final String fileName = getPath("InputIndentationTryCtorParamsTabsWrong.java");
+        final String[] expected = {
+            "20:13: " + getCheckMessage(MSG_ERROR, "new", 12, 16),
+        };
+        verifyWarns(checkConfig, fileName, expected);
+    }
+
+    @Test
+    public void testTabIndentationNewInTryBlockSameLine() throws Exception {
+        final DefaultConfiguration checkConfig = createModuleConfig(IndentationCheck.class);
+        checkConfig.addProperty("basicOffset", "4");
+        checkConfig.addProperty("braceAdjustment", "0");
+        checkConfig.addProperty("caseIndent", "4");
+        checkConfig.addProperty("lineWrappingIndentation", "4");
+        checkConfig.addProperty("tabWidth", "4");
+
+        final String fileName = getPath("InputIndentationTryCtorParamsTabsSameLine.java");
+        final String[] expected = CommonUtil.EMPTY_STRING_ARRAY;
+        verifyWarns(checkConfig, fileName, expected);
+    }
+
     private static final class IndentAudit implements AuditListener {
 
         private final IndentComment[] comments;

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/indentation/indentation/InputIndentationTryCtorParamsTabsSameLine.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/indentation/indentation/InputIndentationTryCtorParamsTabsSameLine.java
@@ -1,0 +1,24 @@
+/**                                                                          //indent:0 exp:0
+ * This test-input is intended to be checked using following configuration:  //indent:1 exp:1
+ *                                                                           //indent:1 exp:1
+ * basicOffset = 4                                                           //indent:1 exp:1
+ * braceAdjustment = 0                                                       //indent:1 exp:1
+ * caseIndent = 4                                                            //indent:1 exp:1
+ * lineWrappingIndentation = 4                                               //indent:1 exp:1
+ * tabWidth = 4                                                              //indent:1 exp:1
+ */                                                                          //indent:1 exp:1
+
+package com.puppycrawl.tools.checkstyle.checks.indentation.indentation;      //indent:0 exp:0
+
+public class InputIndentationTryCtorParamsTabsSameLine {                     //indent:0 exp:0
+	private InputIndentationTryCtorParamsTabsSameLine client;                //indent:4 exp:4
+	private InputIndentationTryCtorParamsTabsSameLine(String string) {       //indent:4 exp:4
+	}                                                                        //indent:4 exp:4
+	private void test() {                                                    //indent:4 exp:4
+		try {                                                                //indent:8 exp:8
+			client = new InputIndentationTryCtorParamsTabsSameLine(null);    //indent:12 exp:12
+		}                                                                    //indent:8 exp:8
+		catch (Exception e) {                                                //indent:8 exp:8
+		}                                                                    //indent:8 exp:8
+	}                                                                        //indent:4 exp:4
+}                                                                            //indent:0 exp:0

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/indentation/indentation/InputIndentationTryCtorParamsTabsValid.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/indentation/indentation/InputIndentationTryCtorParamsTabsValid.java
@@ -1,0 +1,25 @@
+/**                                                                          //indent:0 exp:0
+ * This test-input is intended to be checked using following configuration:  //indent:1 exp:1
+ *                                                                           //indent:1 exp:1
+ * basicOffset = 4                                                           //indent:1 exp:1
+ * braceAdjustment = 0                                                       //indent:1 exp:1
+ * caseIndent = 4                                                            //indent:1 exp:1
+ * lineWrappingIndentation = 4                                               //indent:1 exp:1
+ * tabWidth = 4                                                              //indent:1 exp:1
+ */                                                                          //indent:1 exp:1
+
+package com.puppycrawl.tools.checkstyle.checks.indentation.indentation;      //indent:0 exp:0
+
+public class InputIndentationTryCtorParamsTabsValid {                        //indent:0 exp:0
+	private InputIndentationTryCtorParamsTabsValid client;                   //indent:4 exp:4
+	private InputIndentationTryCtorParamsTabsValid(String string) {          //indent:4 exp:4
+	}                                                                        //indent:4 exp:4
+	private void test() {                                                    //indent:4 exp:4
+		try {                                                                //indent:8 exp:8
+			client =                                                         //indent:12 exp:12
+				new InputIndentationTryCtorParamsTabsValid(null);            //indent:16 exp:16
+		}                                                                    //indent:8 exp:8
+		catch (Exception e) {                                                //indent:8 exp:8
+		}                                                                    //indent:8 exp:8
+	}                                                                        //indent:4 exp:4
+}                                                                            //indent:0 exp:0

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/indentation/indentation/InputIndentationTryCtorParamsTabsWrong.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/indentation/indentation/InputIndentationTryCtorParamsTabsWrong.java
@@ -1,0 +1,25 @@
+/**                                                                          //indent:0 exp:0
+ * This test-input is intended to be checked using following configuration:  //indent:1 exp:1
+ *                                                                           //indent:1 exp:1
+ * basicOffset = 4                                                           //indent:1 exp:1
+ * braceAdjustment = 0                                                       //indent:1 exp:1
+ * caseIndent = 4                                                            //indent:1 exp:1
+ * lineWrappingIndentation = 4                                               //indent:1 exp:1
+ * tabWidth = 4                                                              //indent:1 exp:1
+ */                                                                          //indent:1 exp:1
+
+package com.puppycrawl.tools.checkstyle.checks.indentation.indentation;      //indent:0 exp:0
+
+public class InputIndentationTryCtorParamsTabsWrong {                        //indent:0 exp:0
+	private InputIndentationTryCtorParamsTabsWrong client;                   //indent:4 exp:4
+	private InputIndentationTryCtorParamsTabsWrong(String string) {          //indent:4 exp:4
+	}                                                                        //indent:4 exp:4
+	private void test() {                                                    //indent:4 exp:4
+		try {                                                                //indent:8 exp:8
+			client =                                                         //indent:12 exp:12
+			new InputIndentationTryCtorParamsTabsWrong(null);                //indent:12 exp:16 warn
+		}                                                                    //indent:8 exp:8
+		catch (Exception e) {                                                //indent:8 exp:8
+		}                                                                    //indent:8 exp:8
+	}                                                                        //indent:4 exp:4
+}                                                                            //indent:0 exp:0


### PR DESCRIPTION
###  Description

Fixes #18614 - incorrect indentation validation for tab-indented files in `IndentationCheck.getIndentImpl()`

**Root Cause:**
The previous implementation compared:

`getLineStart(mainAst)` → visual column (tab-expanded)

`mainAst.getColumnNo()` → raw character column (tab counts as 1)

For tab-indented files, these values never matched, causing the branch responsible for computing expected indentation to become unreachable. As a result, incorrect indentation for the `new` keyword inside a `try` block was not reported (false negative).

**Fix:**
Replaced the inconsistent visual vs raw column comparison with `isOnStartOfLine(mainAst)`, which uses consistent visual column logic and properly handles tab expansion.

This ensures:
Correct tab-indented code is validated properly
Incorrect tab indentation now reports violations
Space-indented behavior remains unchanged