### PR TITLE
Issue #19055: dependency pump fix error

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -233,7 +233,7 @@
     <forbiddenapis.version>3.10</forbiddenapis.version>
     <json-schema-validator.version>1.2.0</json-schema-validator.version>
     <checkerframework.version>3.54.0</checkerframework.version>
-    <error-prone.version>2.46.0</error-prone.version>
+    <error-prone.version>2.48.0</error-prone.version>
     <error-prone-support.version>0.28.0</error-prone-support.version>
     <doxia.version>1.12.0</doxia.version>
     <error-prone.configuration-args>

--- a/src/test/java/com/puppycrawl/tools/checkstyle/meta/XmlMetaReaderTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/meta/XmlMetaReaderTest.java
@@ -22,6 +22,7 @@ package com.puppycrawl.tools.checkstyle.meta;
 import static com.google.common.truth.Truth.assertThat;
 
 import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.List;
@@ -145,7 +146,7 @@ public class XmlMetaReaderTest extends AbstractPathTestSupport {
 
     @Test
     public void testReadXmlMetaModuleTypeNull() throws Exception {
-        try (InputStream is = IOUtils.toInputStream("", "UTF-8")) {
+        try (InputStream is = IOUtils.toInputStream("", StandardCharsets.UTF_8)) {
             assertThat(XmlMetaReader.read(is, null)).isNull();
         }
     }


### PR DESCRIPTION
dependency: #19055

Update `error_prone_core from 2.46.0 to 2.48.0`
Remove: `Use IOUtils.toInputStream(String, Charset) instead.`
Use : `import java.nio.charset.StandardCharsets`


