### PR TITLE
Issue #15456: Specify violation messages for NonEmptyAtclauseDescriptionCheck

### DIFF
--- a/src/test/java/com/puppycrawl/tools/checkstyle/bdd/InlineConfigParser.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/bdd/InlineConfigParser.java
@@ -254,7 +254,6 @@ public final class InlineConfigParser {
             "com.puppycrawl.tools.checkstyle.checks.javadoc.MissingJavadocMethodCheck",
             "com.puppycrawl.tools.checkstyle.checks.javadoc.MissingJavadocPackageCheck",
             "com.puppycrawl.tools.checkstyle.checks.javadoc.MissingJavadocTypeCheck",
-            "com.puppycrawl.tools.checkstyle.checks.javadoc.NonEmptyAtclauseDescriptionCheck",
             "com.puppycrawl.tools.checkstyle.checks.javadoc"
                     + ".RequireEmptyLineBeforeBlockTagGroupCheck",
             "com.puppycrawl.tools.checkstyle.checks.javadoc.SingleLineJavadocCheck",

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/nonemptyatclausedescription/InputNonEmptyAtclauseDescriptionOne.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/nonemptyatclausedescription/InputNonEmptyAtclauseDescriptionOne.java
@@ -31,27 +31,27 @@ class InputNonEmptyAtclauseDescriptionOne
 
         }
 
-        // violation 3 lines below
+        // violation 3 lines below 'At-clause should have a non-empty description'
         /**
          * Some javadoc.
          * @param a
          * @param b
          * @param c
-         */ // violation 2 lines above
-        // violation 2 lines above
+         */ // violation 2 lines above 'At-clause should have a non-empty description'
+        // violation 2 lines above 'At-clause should have a non-empty description'
         public InputNonEmptyAtclauseDescriptionOne(String a, int b, double c)
         {
 
         }
 
-        // violation 3 lines below
+        // violation 3 lines below 'At-clause should have a non-empty description'
         /**
          *
          * @param a
          * @param e
          * @deprecated       
-         */ // violation 2 lines above
-        // violation 2 lines above
+         */ // violation 2 lines above 'At-clause should have a non-empty description'
+        // violation 2 lines above 'At-clause should have a non-empty description'
         public InputNonEmptyAtclauseDescriptionOne(String a, boolean e)
         {
 
@@ -84,9 +84,9 @@ class InputNonEmptyAtclauseDescriptionOne
                 return 1;
         }
 
-        // violation 5 lines below
-        // violation 5 lines below
-        // violation 5 lines below
+        // violation 5 lines below 'At-clause should have a non-empty description'
+        // violation 5 lines below 'At-clause should have a non-empty description'
+        // violation 5 lines below 'At-clause should have a non-empty description'
         /**
          *
          * @param a
@@ -96,9 +96,9 @@ class InputNonEmptyAtclauseDescriptionOne
          * @throws Exception
          * @deprecated              
          * 
-         */ // violation 4 lines above
-        // violation 4 lines above
-        // violation 4 lines above
+         */ // violation 4 lines above 'At-clause should have a non-empty description'
+        // violation 4 lines above 'At-clause should have a non-empty description'
+        // violation 4 lines above 'At-clause should have a non-empty description'
         public int foo3(String a, int b, double c) throws Exception
         {
                 return 1;


### PR DESCRIPTION
Issue: #15456 

Specify violation messages for all input files for NonEmptyAtclauseDescriptionCheck.
Existing messages are reused to ensure consistency.