### PR TITLE
Issue #11163: Enforce file size restriction on LeftCurlyCheck

### DIFF
--- a/config/checkstyle-resources-suppressions.xml
+++ b/config/checkstyle-resources-suppressions.xml
@@ -523,12 +523,6 @@
   <suppress checks="FileLength"
     files="[\\/]test[\\/]resources[\\/]com[\\/]puppycrawl[\\/]tools[\\/]checkstyle[\\/]checks[\\/]blocks[\\/]needbraces[\\/]InputNeedBracesLoopBodyTrue\.java"/>
   <suppress checks="FileLength"
-    files="[\\/]test[\\/]resources[\\/]com[\\/]puppycrawl[\\/]tools[\\/]checkstyle[\\/]checks[\\/]blocks[\\/]leftcurly[\\/]InputLeftCurlyTestMissingBraces\.java"/>
-  <suppress checks="FileLength"
-    files="[\\/]test[\\/]resources[\\/]com[\\/]puppycrawl[\\/]tools[\\/]checkstyle[\\/]checks[\\/]blocks[\\/]leftcurly[\\/]InputLeftCurlyTestDefault3\.java"/>
-  <suppress checks="FileLength"
-    files="[\\/]test[\\/]resources[\\/]com[\\/]puppycrawl[\\/]tools[\\/]checkstyle[\\/]checks[\\/]blocks[\\/]leftcurly[\\/]InputLeftCurlyTestNewLine3\.java"/>
-  <suppress checks="FileLength"
     files="[\\/]test[\\/]resources[\\/]com[\\/]puppycrawl[\\/]tools[\\/]checkstyle[\\/]checks[\\/]design[\\/]designforextension[\\/]InputDesignForExtensionIgnoredAnnotations\.java"/>
   <suppress checks="FileLength"
     files="[\\/]test[\\/]resources[\\/]com[\\/]puppycrawl[\\/]tools[\\/]checkstyle[\\/]checks[\\/]design[\\/]designforextension[\\/]InputDesignForExtension\.java"/>

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/blocks/LeftCurlyCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/blocks/LeftCurlyCheckTest.java
@@ -149,7 +149,7 @@ public class LeftCurlyCheckTest extends AbstractModuleTestSupport {
     }
 
     @Test
-    public void testDefault3() throws Exception {
+    public void testDefault3Basic() throws Exception {
         final String[] expected = {
             "17:1: " + getCheckMessage(MSG_KEY_LINE_PREVIOUS, "{", 1),
             "20:5: " + getCheckMessage(MSG_KEY_LINE_PREVIOUS, "{", 5),
@@ -163,52 +163,137 @@ public class LeftCurlyCheckTest extends AbstractModuleTestSupport {
             "57:9: " + getCheckMessage(MSG_KEY_LINE_PREVIOUS, "{", 9),
             "59:13: " + getCheckMessage(MSG_KEY_LINE_PREVIOUS, "{", 13),
             "68:9: " + getCheckMessage(MSG_KEY_LINE_PREVIOUS, "{", 9),
-            "81:5: " + getCheckMessage(MSG_KEY_LINE_PREVIOUS, "{", 5),
-            "88:5: " + getCheckMessage(MSG_KEY_LINE_PREVIOUS, "{", 5),
-            "94:5: " + getCheckMessage(MSG_KEY_LINE_PREVIOUS, "{", 5),
-            "102:19: " + getCheckMessage(MSG_KEY_LINE_BREAK_AFTER, "{", 19),
-            "111:1: " + getCheckMessage(MSG_KEY_LINE_PREVIOUS, "{", 1),
-            "114:5: " + getCheckMessage(MSG_KEY_LINE_PREVIOUS, "{", 5),
-            "123:1: " + getCheckMessage(MSG_KEY_LINE_PREVIOUS, "{", 1),
-            "125:5: " + getCheckMessage(MSG_KEY_LINE_PREVIOUS, "{", 5),
-            "134:1: " + getCheckMessage(MSG_KEY_LINE_PREVIOUS, "{", 1),
-            "136:5: " + getCheckMessage(MSG_KEY_LINE_PREVIOUS, "{", 5),
-            "138:9: " + getCheckMessage(MSG_KEY_LINE_PREVIOUS, "{", 9),
-            "153:1: " + getCheckMessage(MSG_KEY_LINE_PREVIOUS, "{", 1),
-            "162:1: " + getCheckMessage(MSG_KEY_LINE_PREVIOUS, "{", 1),
-            "169:5: " + getCheckMessage(MSG_KEY_LINE_PREVIOUS, "{", 5),
+            "80:5: " + getCheckMessage(MSG_KEY_LINE_PREVIOUS, "{", 5),
+            "88:19: " + getCheckMessage(MSG_KEY_LINE_BREAK_AFTER, "{", 19),
         };
         verifyWithInlineConfigParser(
-                getPath("InputLeftCurlyTestDefault3.java"), expected);
+                getPath("InputLeftCurlyTestDefault3Basic.java"), expected);
     }
 
     @Test
-    public void testNewline3() throws Exception {
+    public void testDefault3Empty() throws Exception {
+        final String[] expected = {
+            "17:1: " + getCheckMessage(MSG_KEY_LINE_PREVIOUS, "{", 1),
+            "30:1: " + getCheckMessage(MSG_KEY_LINE_PREVIOUS, "{", 1),
+        };
+        verifyWithInlineConfigParser(
+                getPath("InputLeftCurlyTestDefault3Empty.java"), expected);
+    }
+
+    @Test
+    public void testDefault3Enum() throws Exception {
+        final String[] expected = {
+            "17:1: " + getCheckMessage(MSG_KEY_LINE_PREVIOUS, "{", 1),
+            "19:5: " + getCheckMessage(MSG_KEY_LINE_PREVIOUS, "{", 5),
+        };
+        verifyWithInlineConfigParser(
+                getPath("InputLeftCurlyTestDefault3Enum.java"), expected);
+    }
+
+    @Test
+    public void testDefault3Initializer() throws Exception {
+        final String[] expected = {
+            "17:1: " + getCheckMessage(MSG_KEY_LINE_PREVIOUS, "{", 1),
+            "20:5: " + getCheckMessage(MSG_KEY_LINE_PREVIOUS, "{", 5),
+            "26:1: " + getCheckMessage(MSG_KEY_LINE_PREVIOUS, "{", 1),
+            "33:5: " + getCheckMessage(MSG_KEY_LINE_PREVIOUS, "{", 5),
+        };
+        verifyWithInlineConfigParser(
+                getPath("InputLeftCurlyTestDefault3Initializer.java"), expected);
+    }
+
+    @Test
+    public void testDefault3Misc() throws Exception {
+        final String[] expected = {
+            "17:1: " + getCheckMessage(MSG_KEY_LINE_PREVIOUS, "{", 1),
+            "25:1: " + getCheckMessage(MSG_KEY_LINE_PREVIOUS, "{", 1),
+            "28:5: " + getCheckMessage(MSG_KEY_LINE_PREVIOUS, "{", 5),
+            "37:1: " + getCheckMessage(MSG_KEY_LINE_PREVIOUS, "{", 1),
+            "39:5: " + getCheckMessage(MSG_KEY_LINE_PREVIOUS, "{", 5),
+            "48:1: " + getCheckMessage(MSG_KEY_LINE_PREVIOUS, "{", 1),
+            "50:5: " + getCheckMessage(MSG_KEY_LINE_PREVIOUS, "{", 5),
+            "52:9: " + getCheckMessage(MSG_KEY_LINE_PREVIOUS, "{", 9),
+        };
+        verifyWithInlineConfigParser(
+                getPath("InputLeftCurlyTestDefault3Misc.java"), expected);
+    }
+
+    @Test
+    public void testNewline3Basic() throws Exception {
         final String[] expected = {
             "31:33: " + getCheckMessage(MSG_KEY_LINE_NEW, "{", 33),
-            "96:19: " + getCheckMessage(MSG_KEY_LINE_NEW, "{", 19),
-            "102:19: " + getCheckMessage(MSG_KEY_LINE_NEW, "{", 19),
-            "147:49: " + getCheckMessage(MSG_KEY_LINE_NEW, "{", 49),
-            "163:12: " + getCheckMessage(MSG_KEY_LINE_NEW, "{", 12),
-            "170:16: " + getCheckMessage(MSG_KEY_LINE_NEW, "{", 16),
+            "82:19: " + getCheckMessage(MSG_KEY_LINE_NEW, "{", 19),
+            "88:19: " + getCheckMessage(MSG_KEY_LINE_NEW, "{", 19),
         };
         verifyWithInlineConfigParser(
-                getPath("InputLeftCurlyTestNewLine3.java"), expected);
+                getPath("InputLeftCurlyTestNewLine3Basic.java"), expected);
     }
 
     @Test
-    public void testMissingBraces() throws Exception {
+    public void testNewline3Empty() throws Exception {
+        final String[] expected = {
+            "24:49: " + getCheckMessage(MSG_KEY_LINE_NEW, "{", 49),
+        };
+        verifyWithInlineConfigParser(
+                getPath("InputLeftCurlyTestNewLine3Empty.java"), expected);
+    }
+
+    @Test
+    public void testNewline3Enum() throws Exception {
+        final String[] expected = CommonUtil.EMPTY_STRING_ARRAY;
+        verifyWithInlineConfigParser(
+                getPath("InputLeftCurlyTestNewLine3Enum.java"), expected);
+    }
+
+    @Test
+    public void testNewline3Initializer() throws Exception {
+        final String[] expected = {
+            "27:12: " + getCheckMessage(MSG_KEY_LINE_NEW, "{", 12),
+            "34:16: " + getCheckMessage(MSG_KEY_LINE_NEW, "{", 16),
+        };
+        verifyWithInlineConfigParser(
+                getPath("InputLeftCurlyTestNewLine3Initializer.java"), expected);
+    }
+
+    @Test
+    public void testNewline3Misc() throws Exception {
+        final String[] expected = CommonUtil.EMPTY_STRING_ARRAY;
+        verifyWithInlineConfigParser(
+                getPath("InputLeftCurlyTestNewLine3Misc.java"), expected);
+    }
+
+    @Test
+    public void testMissingBracesConditional() throws Exception {
+        final String[] expected = {
+            "17:1: " + getCheckMessage(MSG_KEY_LINE_PREVIOUS, "{", 1),
+            "20:5: " + getCheckMessage(MSG_KEY_LINE_PREVIOUS, "{", 5),
+            "26:5: " + getCheckMessage(MSG_KEY_LINE_PREVIOUS, "{", 5),
+        };
+        verifyWithInlineConfigParser(
+                getPath("InputLeftCurlyTestMissingBracesConditional.java"), expected);
+    }
+
+    @Test
+    public void testMissingBracesLoop() throws Exception {
         final String[] expected = {
             "17:1: " + getCheckMessage(MSG_KEY_LINE_PREVIOUS, "{", 1),
             "20:5: " + getCheckMessage(MSG_KEY_LINE_PREVIOUS, "{", 5),
             "26:5: " + getCheckMessage(MSG_KEY_LINE_PREVIOUS, "{", 5),
             "39:5: " + getCheckMessage(MSG_KEY_LINE_PREVIOUS, "{", 5),
             "56:5: " + getCheckMessage(MSG_KEY_LINE_PREVIOUS, "{", 5),
-            "74:5: " + getCheckMessage(MSG_KEY_LINE_PREVIOUS, "{", 5),
-            "110:5: " + getCheckMessage(MSG_KEY_LINE_PREVIOUS, "{", 5),
         };
         verifyWithInlineConfigParser(
-                getPath("InputLeftCurlyTestMissingBraces.java"), expected);
+                getPath("InputLeftCurlyTestMissingBracesLoop.java"), expected);
+    }
+
+    @Test
+    public void testMissingBracesMisc() throws Exception {
+        final String[] expected = {
+            "17:1: " + getCheckMessage(MSG_KEY_LINE_PREVIOUS, "{", 1),
+            "20:5: " + getCheckMessage(MSG_KEY_LINE_PREVIOUS, "{", 5),
+        };
+        verifyWithInlineConfigParser(
+                getPath("InputLeftCurlyTestMissingBracesMisc.java"), expected);
     }
 
     @Test

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/blocks/leftcurly/InputLeftCurlyTestDefault3Basic.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/blocks/leftcurly/InputLeftCurlyTestDefault3Basic.java
@@ -13,7 +13,7 @@ tokens = (default)ANNOTATION_DEF, CLASS_DEF, CTOR_DEF, ENUM_CONSTANT_DEF, \
 
 package com.puppycrawl.tools.checkstyle.checks.blocks.leftcurly;
 
-class InputLeftCurlyTestDefault3
+class InputLeftCurlyTestDefault3Basic
 { // violation ''{' at column 1 should be on the previous line'
     /** @see test method **/
     int foo() throws InterruptedException
@@ -76,20 +76,6 @@ class InputLeftCurlyTestDefault3
             return 2;
     }
 
-    // Test static initialiser
-    static
-    { // violation ''{' at column 5 should be on the previous line'
-        int x = 1; // should not require any javadoc
-    }
-
-
-
-    public enum GreetingsEnum
-    { // violation ''{' at column 5 should be on the previous line'
-        HELLO,
-        GOODBYE
-    };
-
     void method2()
     { // violation ''{' at column 5 should be on the previous line'
         boolean flag = true;
@@ -101,75 +87,4 @@ class InputLeftCurlyTestDefault3
         // violation below ''{' at column 19 should have line break after'
         if (flag) { String.CASE_INSENSITIVE_ORDER.equals("it is ok."); }
     }
-}
-
-/**
- * Test input for closing brace if that brace terminates
- * a statement or the body of a constructor.
- */
-class FooCtor
-{ // violation ''{' at column 1 should be on the previous line'
-        int i;
-        public FooCtor()
-    { // violation ''{' at column 5 should be on the previous line'
-                i = 1;
-    }}
-
-/**
-* Test input for closing brace if that brace terminates
-* a statement or the body of a method.
-*/
-class FooMethod
-{ // violation ''{' at column 1 should be on the previous line'
-        public void fooMethod()
-    { // violation ''{' at column 5 should be on the previous line'
-                int i = 1;
-    }}
-
-/**
-* Test input for closing brace if that brace terminates
-* a statement or the body of a named class.
-*/
-class FooInner
-{ // violation ''{' at column 1 should be on the previous line'
-        class InnerFoo
-    { // violation ''{' at column 5 should be on the previous line'
-                public void fooInnerMethod ()
-        { // violation ''{' at column 9 should be on the previous line'
-
-                }
-    }}
-
-/**
- * False positive
- *
- */
-class Absent_CustomFieldSerializer3 {
-
-    public static void serialize() {} // Expected nothing but was "'}' should be alone on a line."
-}
-
-class Absent_CustomFieldSerializer4
-{ // violation ''{' at column 1 should be on the previous line'
-    public Absent_CustomFieldSerializer4() {}
-}
-
-class EmptyClass2 {}
-
-interface EmptyInterface3 {}
-
-class ClassWithStaticInitializers
-{ // violation ''{' at column 1 should be on the previous line'
-    static {
-    }
-    static
-    {}
-
-    static class Inner
-    { // violation ''{' at column 5 should be on the previous line'
-        static {
-            int i = 1;
-        }
-    }
-
 }

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/blocks/leftcurly/InputLeftCurlyTestDefault3Empty.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/blocks/leftcurly/InputLeftCurlyTestDefault3Empty.java
@@ -1,0 +1,36 @@
+/*
+LeftCurly
+option = (default)eol
+ignoreEnums = (default)true
+tokens = (default)ANNOTATION_DEF, CLASS_DEF, CTOR_DEF, ENUM_CONSTANT_DEF, \
+         ENUM_DEF, INTERFACE_DEF, LAMBDA, LITERAL_CASE, LITERAL_CATCH, \
+         LITERAL_DEFAULT, LITERAL_DO, LITERAL_ELSE, LITERAL_FINALLY, LITERAL_FOR, \
+         LITERAL_IF, LITERAL_SWITCH, LITERAL_SYNCHRONIZED, LITERAL_TRY, LITERAL_WHILE, \
+         METHOD_DEF, OBJBLOCK, STATIC_INIT, RECORD_DEF, COMPACT_CTOR_DEF
+
+
+*/
+
+package com.puppycrawl.tools.checkstyle.checks.blocks.leftcurly;
+
+class InputLeftCurlyTestDefault3Empty
+{ // violation ''{' at column 1 should be on the previous line'
+}
+
+/**
+ * False positive
+ *
+ */
+class Absent_CustomFieldSerializer3 {
+
+    public static void serialize() {} // Expected nothing but was "'}' should be alone on a line."
+}
+
+class Absent_CustomFieldSerializer4
+{ // violation ''{' at column 1 should be on the previous line'
+    public Absent_CustomFieldSerializer4() {}
+}
+
+class EmptyClass2 {}
+
+interface EmptyInterface3 {}

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/blocks/leftcurly/InputLeftCurlyTestDefault3Enum.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/blocks/leftcurly/InputLeftCurlyTestDefault3Enum.java
@@ -1,0 +1,23 @@
+/*
+LeftCurly
+option = (default)eol
+ignoreEnums = (default)true
+tokens = (default)ANNOTATION_DEF, CLASS_DEF, CTOR_DEF, ENUM_CONSTANT_DEF, \
+         ENUM_DEF, INTERFACE_DEF, LAMBDA, LITERAL_CASE, LITERAL_CATCH, \
+         LITERAL_DEFAULT, LITERAL_DO, LITERAL_ELSE, LITERAL_FINALLY, LITERAL_FOR, \
+         LITERAL_IF, LITERAL_SWITCH, LITERAL_SYNCHRONIZED, LITERAL_TRY, LITERAL_WHILE, \
+         METHOD_DEF, OBJBLOCK, STATIC_INIT, RECORD_DEF, COMPACT_CTOR_DEF
+
+
+*/
+
+package com.puppycrawl.tools.checkstyle.checks.blocks.leftcurly;
+
+class InputLeftCurlyTestDefault3Enum
+{ // violation ''{' at column 1 should be on the previous line'
+    public enum GreetingsEnum
+    { // violation ''{' at column 5 should be on the previous line'
+        HELLO,
+        GOODBYE
+    };
+}

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/blocks/leftcurly/InputLeftCurlyTestDefault3Initializer.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/blocks/leftcurly/InputLeftCurlyTestDefault3Initializer.java
@@ -1,0 +1,38 @@
+/*
+LeftCurly
+option = (default)eol
+ignoreEnums = (default)true
+tokens = (default)ANNOTATION_DEF, CLASS_DEF, CTOR_DEF, ENUM_CONSTANT_DEF, \
+         ENUM_DEF, INTERFACE_DEF, LAMBDA, LITERAL_CASE, LITERAL_CATCH, \
+         LITERAL_DEFAULT, LITERAL_DO, LITERAL_ELSE, LITERAL_FINALLY, LITERAL_FOR, \
+         LITERAL_IF, LITERAL_SWITCH, LITERAL_SYNCHRONIZED, LITERAL_TRY, LITERAL_WHILE, \
+         METHOD_DEF, OBJBLOCK, STATIC_INIT, RECORD_DEF, COMPACT_CTOR_DEF
+
+
+*/
+
+package com.puppycrawl.tools.checkstyle.checks.blocks.leftcurly;
+
+class InputLeftCurlyTestDefault3Initializer
+{ // violation ''{' at column 1 should be on the previous line'
+    // Test static initialiser
+    static
+    { // violation ''{' at column 5 should be on the previous line'
+        int x = 1; // should not require any javadoc
+    }
+}
+
+class ClassWithStaticInitializers
+{ // violation ''{' at column 1 should be on the previous line'
+    static {
+    }
+    static
+    {}
+
+    static class Inner
+    { // violation ''{' at column 5 should be on the previous line'
+        static {
+            int i = 1;
+        }
+    }
+}

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/blocks/leftcurly/InputLeftCurlyTestDefault3Misc.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/blocks/leftcurly/InputLeftCurlyTestDefault3Misc.java
@@ -1,0 +1,55 @@
+/*
+LeftCurly
+option = (default)eol
+ignoreEnums = (default)true
+tokens = (default)ANNOTATION_DEF, CLASS_DEF, CTOR_DEF, ENUM_CONSTANT_DEF, \
+         ENUM_DEF, INTERFACE_DEF, LAMBDA, LITERAL_CASE, LITERAL_CATCH, \
+         LITERAL_DEFAULT, LITERAL_DO, LITERAL_ELSE, LITERAL_FINALLY, LITERAL_FOR, \
+         LITERAL_IF, LITERAL_SWITCH, LITERAL_SYNCHRONIZED, LITERAL_TRY, LITERAL_WHILE, \
+         METHOD_DEF, OBJBLOCK, STATIC_INIT, RECORD_DEF, COMPACT_CTOR_DEF
+
+
+*/
+
+package com.puppycrawl.tools.checkstyle.checks.blocks.leftcurly;
+
+class InputLeftCurlyTestDefault3Misc
+{ // violation ''{' at column 1 should be on the previous line'
+}
+
+/**
+ * Test input for closing brace if that brace terminates
+ * a statement or the body of a constructor.
+ */
+class FooCtor
+{ // violation ''{' at column 1 should be on the previous line'
+        int i;
+        public FooCtor()
+    { // violation ''{' at column 5 should be on the previous line'
+                i = 1;
+    }}
+
+/**
+* Test input for closing brace if that brace terminates
+* a statement or the body of a method.
+*/
+class FooMethod
+{ // violation ''{' at column 1 should be on the previous line'
+        public void fooMethod()
+    { // violation ''{' at column 5 should be on the previous line'
+                int i = 1;
+    }}
+
+/**
+* Test input for closing brace if that brace terminates
+* a statement or the body of a named class.
+*/
+class FooInner
+{ // violation ''{' at column 1 should be on the previous line'
+        class InnerFoo
+    { // violation ''{' at column 5 should be on the previous line'
+                public void fooInnerMethod ()
+        { // violation ''{' at column 9 should be on the previous line'
+
+                }
+    }}

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/blocks/leftcurly/InputLeftCurlyTestMissingBracesConditional.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/blocks/leftcurly/InputLeftCurlyTestMissingBracesConditional.java
@@ -1,0 +1,60 @@
+/*
+LeftCurly
+option = (default)eol
+ignoreEnums = (default)true
+tokens = (default)ANNOTATION_DEF, CLASS_DEF, CTOR_DEF, ENUM_CONSTANT_DEF, \
+         ENUM_DEF, INTERFACE_DEF, LAMBDA, LITERAL_CASE, LITERAL_CATCH, \
+         LITERAL_DEFAULT, LITERAL_DO, LITERAL_ELSE, LITERAL_FINALLY, LITERAL_FOR, \
+         LITERAL_IF, LITERAL_SWITCH, LITERAL_SYNCHRONIZED, LITERAL_TRY, LITERAL_WHILE, \
+         METHOD_DEF, OBJBLOCK, STATIC_INIT, RECORD_DEF, COMPACT_CTOR_DEF
+
+
+*/
+
+package com.puppycrawl.tools.checkstyle.checks.blocks.leftcurly;
+
+class InputLeftCurlyTestMissingBracesConditional
+{ // violation ''{' at column 1 should be on the previous line'
+    /** @return helper func **/
+    boolean condition()
+    { // violation ''{' at column 5 should be on the previous line'
+        return false;
+    }
+
+    /** Test if constructs **/
+    public void testIf()
+    { // violation ''{' at column 5 should be on the previous line'
+        // Valid
+        if (condition()) {
+            testIf();
+        }
+        else if (condition()) {
+            testIf();
+        }
+        else {
+            testIf();
+        }
+
+        // Invalid
+        if (condition());
+        if (condition())
+            testIf();
+        if (condition())
+            testIf();
+        else
+            testIf();
+        if (condition())
+            testIf();
+        else {
+            testIf();
+        }
+        if (condition()) {
+            testIf();
+        }
+        else
+            testIf();
+        if (condition())
+            if (condition())
+                testIf();
+    }
+}

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/blocks/leftcurly/InputLeftCurlyTestMissingBracesLoop.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/blocks/leftcurly/InputLeftCurlyTestMissingBracesLoop.java
@@ -13,7 +13,7 @@ tokens = (default)ANNOTATION_DEF, CLASS_DEF, CTOR_DEF, ENUM_CONSTANT_DEF, \
 
 package com.puppycrawl.tools.checkstyle.checks.blocks.leftcurly;
 
-class InputLeftCurlyTestMissingBraces
+class InputLeftCurlyTestMissingBracesLoop
 { // violation ''{' at column 1 should be on the previous line'
     /** @return helper func **/
     boolean condition()
@@ -68,57 +68,4 @@ class InputLeftCurlyTestMissingBraces
             if (i > 2)
                 testFor();
     }
-
-    /** Test if constructs **/
-    public void testIf()
-    { // violation ''{' at column 5 should be on the previous line'
-        // Valid
-        if (condition()) {
-            testIf();
-        }
-        else if (condition()) {
-            testIf();
-        }
-        else {
-            testIf();
-        }
-
-        // Invalid
-        if (condition());
-        if (condition())
-            testIf();
-        if (condition())
-            testIf();
-        else
-            testIf();
-        if (condition())
-            testIf();
-        else {
-            testIf();
-        }
-        if (condition()) {
-            testIf();
-        }
-        else
-            testIf();
-        if (condition())
-            if (condition())
-                testIf();
-    }
-
-    void whitespaceAfterSemi()
-    { // violation ''{' at column 5 should be on the previous line'
-        //reject
-        int i = 1;int j = 2;
-
-        //accept
-        for (;;) {
-        }
-    }
-
-    /** Empty constructor block. **/
-    public InputLeftCurlyTestMissingBraces() {}
-
-    /** Empty method block. **/
-    public void emptyImplementation() {}
 }

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/blocks/leftcurly/InputLeftCurlyTestMissingBracesMisc.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/blocks/leftcurly/InputLeftCurlyTestMissingBracesMisc.java
@@ -1,0 +1,34 @@
+/*
+LeftCurly
+option = (default)eol
+ignoreEnums = (default)true
+tokens = (default)ANNOTATION_DEF, CLASS_DEF, CTOR_DEF, ENUM_CONSTANT_DEF, \
+         ENUM_DEF, INTERFACE_DEF, LAMBDA, LITERAL_CASE, LITERAL_CATCH, \
+         LITERAL_DEFAULT, LITERAL_DO, LITERAL_ELSE, LITERAL_FINALLY, LITERAL_FOR, \
+         LITERAL_IF, LITERAL_SWITCH, LITERAL_SYNCHRONIZED, LITERAL_TRY, LITERAL_WHILE, \
+         METHOD_DEF, OBJBLOCK, STATIC_INIT, RECORD_DEF, COMPACT_CTOR_DEF
+
+
+*/
+
+package com.puppycrawl.tools.checkstyle.checks.blocks.leftcurly;
+
+class InputLeftCurlyTestMissingBracesMisc
+{ // violation ''{' at column 1 should be on the previous line'
+
+    void whitespaceAfterSemi()
+    { // violation ''{' at column 5 should be on the previous line'
+        //reject
+        int i = 1;int j = 2;
+
+        //accept
+        for (;;) {
+        }
+    }
+
+    /** Empty constructor block. **/
+    public InputLeftCurlyTestMissingBracesMisc() {}
+
+    /** Empty method block. **/
+    public void emptyImplementation() {}
+}

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/blocks/leftcurly/InputLeftCurlyTestNewLine3Basic.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/blocks/leftcurly/InputLeftCurlyTestNewLine3Basic.java
@@ -13,7 +13,7 @@ tokens = (default)ANNOTATION_DEF, CLASS_DEF, CTOR_DEF, ENUM_CONSTANT_DEF, \
 
 package com.puppycrawl.tools.checkstyle.checks.blocks.leftcurly;
 
-class InputLeftCurlyTestNewLine3
+class InputLeftCurlyTestNewLine3Basic
 {
     /** @see test method **/
     int foo() throws InterruptedException
@@ -76,20 +76,6 @@ class InputLeftCurlyTestNewLine3
             return 2;
     }
 
-    // Test static initialiser
-    static
-    {
-        int x = 1; // should not require any javadoc
-    }
-
-
-
-    public enum GreetingsEnum
-    {
-        HELLO,
-        GOODBYE
-    };
-
     void method2()
     {
         boolean flag = true;
@@ -101,75 +87,4 @@ class InputLeftCurlyTestNewLine3
         // statement if lcurly on the same line.
         if (flag) { String.valueOf("ok"); } // violation ''{' at column 19 should be on a new line'
     }
-}
-
-/**
- * Test input for closing brace if that brace terminates
- * a statement or the body of a constructor.
- */
-class FooCtorTestNewLine3
-{
-        int i;
-        public void FooCtor()
-    {
-                i = 1;
-    }}
-
-/**
-* Test input for closing brace if that brace terminates
-* a statement or the body of a method.
-*/
-class FooMethodTestNewLine3
-{
-        public void fooMethod()
-    {
-                int i = 1;
-    }}
-
-/**
-* Test input for closing brace if that brace terminates
-* a statement or the body of a named class.
-*/
-class FooInnerTestNewLine3
-{
-        class InnerFoo
-    {
-                public void fooInnerMethod ()
-        {
-
-                }
-    }}
-
-/**
- * False positive
- *
- */
-class Absent_CustomFieldSerializer3TestNewLine3 {
-    // violation above ''{' at column 49 should be on a new line'
-    public static void serialize() {} // Expected nothing but was "'}' should be alone on a line."
-}
-
-class Absent_CustomFieldSerializer4TestNewLine3
-{
-    public void Absent_CustomFieldSerializer4() {}
-}
-
-class EmptyClass2TestNewLine3 {}
-
-interface EmptyInterface3TestNewLine3 {}
-
-class ClassWithStaticInitializersTestNewLine3
-{
-    static { // violation ''{' at column 12 should be on a new line'
-    }
-    static
-    {}
-
-    static class Inner
-    {
-        static { // violation ''{' at column 16 should be on a new line'
-            int i = 1;
-        }
-    }
-
 }

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/blocks/leftcurly/InputLeftCurlyTestNewLine3Empty.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/blocks/leftcurly/InputLeftCurlyTestNewLine3Empty.java
@@ -1,0 +1,36 @@
+/*
+LeftCurly
+option = nl
+ignoreEnums = (default)true
+tokens = (default)ANNOTATION_DEF, CLASS_DEF, CTOR_DEF, ENUM_CONSTANT_DEF, \
+         ENUM_DEF, INTERFACE_DEF, LAMBDA, LITERAL_CASE, LITERAL_CATCH, \
+         LITERAL_DEFAULT, LITERAL_DO, LITERAL_ELSE, LITERAL_FINALLY, LITERAL_FOR, \
+         LITERAL_IF, LITERAL_SWITCH, LITERAL_SYNCHRONIZED, LITERAL_TRY, LITERAL_WHILE, \
+         METHOD_DEF, OBJBLOCK, STATIC_INIT, RECORD_DEF, COMPACT_CTOR_DEF
+
+
+*/
+
+package com.puppycrawl.tools.checkstyle.checks.blocks.leftcurly;
+
+class InputLeftCurlyTestNewLine3Empty
+{
+}
+
+/**
+ * False positive
+ *
+ */
+class Absent_CustomFieldSerializer3TestNewLine3 {
+    // violation above ''{' at column 49 should be on a new line'
+    public static void serialize() {} // Expected nothing but was "'}' should be alone on a line."
+}
+
+class Absent_CustomFieldSerializer4TestNewLine3
+{
+    public void Absent_CustomFieldSerializer4() {}
+}
+
+class EmptyClass2TestNewLine3 {}
+
+interface EmptyInterface3TestNewLine3 {}

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/blocks/leftcurly/InputLeftCurlyTestNewLine3Enum.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/blocks/leftcurly/InputLeftCurlyTestNewLine3Enum.java
@@ -1,0 +1,23 @@
+/*
+LeftCurly
+option = nl
+ignoreEnums = (default)true
+tokens = (default)ANNOTATION_DEF, CLASS_DEF, CTOR_DEF, ENUM_CONSTANT_DEF, \
+         ENUM_DEF, INTERFACE_DEF, LAMBDA, LITERAL_CASE, LITERAL_CATCH, \
+         LITERAL_DEFAULT, LITERAL_DO, LITERAL_ELSE, LITERAL_FINALLY, LITERAL_FOR, \
+         LITERAL_IF, LITERAL_SWITCH, LITERAL_SYNCHRONIZED, LITERAL_TRY, LITERAL_WHILE, \
+         METHOD_DEF, OBJBLOCK, STATIC_INIT, RECORD_DEF, COMPACT_CTOR_DEF
+
+
+*/
+
+package com.puppycrawl.tools.checkstyle.checks.blocks.leftcurly;
+
+class InputLeftCurlyTestNewLine3Enum
+{
+    public enum GreetingsEnum
+    {
+        HELLO,
+        GOODBYE
+    };
+}

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/blocks/leftcurly/InputLeftCurlyTestNewLine3Initializer.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/blocks/leftcurly/InputLeftCurlyTestNewLine3Initializer.java
@@ -1,0 +1,38 @@
+/*
+LeftCurly
+option = nl
+ignoreEnums = (default)true
+tokens = (default)ANNOTATION_DEF, CLASS_DEF, CTOR_DEF, ENUM_CONSTANT_DEF, \
+         ENUM_DEF, INTERFACE_DEF, LAMBDA, LITERAL_CASE, LITERAL_CATCH, \
+         LITERAL_DEFAULT, LITERAL_DO, LITERAL_ELSE, LITERAL_FINALLY, LITERAL_FOR, \
+         LITERAL_IF, LITERAL_SWITCH, LITERAL_SYNCHRONIZED, LITERAL_TRY, LITERAL_WHILE, \
+         METHOD_DEF, OBJBLOCK, STATIC_INIT, RECORD_DEF, COMPACT_CTOR_DEF
+
+
+*/
+
+package com.puppycrawl.tools.checkstyle.checks.blocks.leftcurly;
+
+class InputLeftCurlyTestNewLine3Initializer
+{
+    // Test static initialiser
+    static
+    {
+        int x = 1; // should not require any javadoc
+    }
+}
+
+class ClassWithStaticInitializersTestNewLine3
+{
+    static { // violation ''{' at column 12 should be on a new line'
+    }
+    static
+    {}
+
+    static class Inner
+    {
+        static { // violation ''{' at column 16 should be on a new line'
+            int i = 1;
+        }
+    }
+}

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/blocks/leftcurly/InputLeftCurlyTestNewLine3Misc.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/blocks/leftcurly/InputLeftCurlyTestNewLine3Misc.java
@@ -1,0 +1,55 @@
+/*
+LeftCurly
+option = nl
+ignoreEnums = (default)true
+tokens = (default)ANNOTATION_DEF, CLASS_DEF, CTOR_DEF, ENUM_CONSTANT_DEF, \
+         ENUM_DEF, INTERFACE_DEF, LAMBDA, LITERAL_CASE, LITERAL_CATCH, \
+         LITERAL_DEFAULT, LITERAL_DO, LITERAL_ELSE, LITERAL_FINALLY, LITERAL_FOR, \
+         LITERAL_IF, LITERAL_SWITCH, LITERAL_SYNCHRONIZED, LITERAL_TRY, LITERAL_WHILE, \
+         METHOD_DEF, OBJBLOCK, STATIC_INIT, RECORD_DEF, COMPACT_CTOR_DEF
+
+
+*/
+
+package com.puppycrawl.tools.checkstyle.checks.blocks.leftcurly;
+
+class InputLeftCurlyTestNewLine3Misc
+{
+}
+
+/**
+ * Test input for closing brace if that brace terminates
+ * a statement or the body of a constructor.
+ */
+class FooCtorTestNewLine3
+{
+        int i;
+        public void FooCtor()
+    {
+                i = 1;
+    }}
+
+/**
+* Test input for closing brace if that brace terminates
+* a statement or the body of a method.
+*/
+class FooMethodTestNewLine3
+{
+        public void fooMethod()
+    {
+                int i = 1;
+    }}
+
+/**
+* Test input for closing brace if that brace terminates
+* a statement or the body of a named class.
+*/
+class FooInnerTestNewLine3
+{
+        class InnerFoo
+    {
+                public void fooInnerMethod ()
+        {
+
+                }
+    }}


### PR DESCRIPTION
Issue: #11163

Input files that exceed 120 lines and are splitted:
- InputLeftCurlyTestDefault3.java
- InputLeftCurlyTestNewLine3.java
- InputLeftCurlyTestMissingBraces.java