### PR TITLE
Issue #10970: False negative fixed for pattern variables

### DIFF
--- a/config/checker-framework-suppressions/checker-nullness-optional-interning-suppressions.xml
+++ b/config/checker-framework-suppressions/checker-nullness-optional-interning-suppressions.xml
@@ -2442,6 +2442,20 @@
   <checkerFrameworkError unstable="false">
     <fileName>src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/FinalLocalVariableCheck.java</fileName>
     <specifier>dereference.of.nullable</specifier>
+    <message>dereference of possibly-null reference ast.findFirstToken(TokenTypes.MODIFIERS)</message>
+    <lineContent>&amp;&amp; ast.findFirstToken(TokenTypes.MODIFIERS)</lineContent>
+  </checkerFrameworkError>
+
+  <checkerFrameworkError unstable="false">
+    <fileName>src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/FinalLocalVariableCheck.java</fileName>
+    <specifier>dereference.of.nullable</specifier>
+    <message>dereference of possibly-null reference astNode</message>
+    <lineContent>final FinalVariableCandidate previousCandidate = scope.get(astNode.getText());</lineContent>
+  </checkerFrameworkError>
+
+  <checkerFrameworkError unstable="false">
+    <fileName>src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/FinalLocalVariableCheck.java</fileName>
+    <specifier>dereference.of.nullable</specifier>
     <message>dereference of possibly-null reference astNode</message>
     <lineContent>scope.put(astNode.getText(), candidate);</lineContent>
   </checkerFrameworkError>
@@ -2493,6 +2507,13 @@
     <specifier>dereference.of.nullable</specifier>
     <message>dereference of possibly-null reference scopeStack.peek()</message>
     <lineContent>containsBreak = scopeStack.peek().containsBreak;</lineContent>
+  </checkerFrameworkError>
+
+  <checkerFrameworkError unstable="false">
+    <fileName>src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/FinalLocalVariableCheck.java</fileName>
+    <specifier>dereference.of.nullable</specifier>
+    <message>dereference of possibly-null reference scopeStack.peek()</message>
+    <lineContent>final Map&lt;String, FinalVariableCandidate&gt; scope = scopeStack.peek().scope;</lineContent>
   </checkerFrameworkError>
 
   <checkerFrameworkError unstable="false">

--- a/config/suppressions.xml
+++ b/config/suppressions.xml
@@ -168,6 +168,8 @@
   <!-- Apart from a complex logic there is a lot of small methods for a better readability. -->
   <suppress checks="MethodCount"
             files="src[\\/]main[\\/]java[\\/]com[\\/]puppycrawl[\\/]tools[\\/]checkstyle[\\/]checks[\\/]whitespace[\\/]EmptyLineSeparatorCheck.java"/>
+  <suppress checks="MethodCount"
+            files="src[\\/]main[\\/]java[\\/]com[\\/]puppycrawl[\\/]tools[\\/]checkstyle[\\/]checks[\\/]coding[\\/]FinalLocalVariableCheck.java"/>
 
   <!-- Uses non-ascii symbols intentionally -->
   <suppress id="checkASCII"

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/FinalLocalVariableCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/FinalLocalVariableCheck.java
@@ -111,6 +111,13 @@ public class FinalLocalVariableCheck extends AbstractCheck {
     private boolean validateUnnamedVariables;
 
     /**
+     * Control whether to check
+     * <a href="https://openjdk.org/jeps/394">
+     * pattern variables</a>.
+     */
+    private boolean validatePatternVariables;
+
+    /**
      * Setter to control whether to check
      * <a href="https://docs.oracle.com/javase/specs/jls/se11/html/jls-14.html#jls-14.14.2">
      * enhanced for-loop</a> variable.
@@ -134,6 +141,18 @@ public class FinalLocalVariableCheck extends AbstractCheck {
         this.validateUnnamedVariables = validateUnnamedVariables;
     }
 
+    /**
+     * Setter to control whether to check
+     * <a href="https://openjdk.org/jeps/394">
+     * pattern variables></a>.
+     *
+     * @param validatePatternVariables whether to check pattern variables
+     * @since 13.4.0
+     */
+    public final void setValidatePatternVariables(boolean validatePatternVariables) {
+        this.validatePatternVariables = validatePatternVariables;
+    }
+
     @Override
     public int[] getRequiredTokens() {
         return new int[] {
@@ -145,6 +164,7 @@ public class FinalLocalVariableCheck extends AbstractCheck {
             TokenTypes.LITERAL_BREAK,
             TokenTypes.LITERAL_FOR,
             TokenTypes.EXPR,
+            TokenTypes.PATTERN_VARIABLE_DEF,
         };
     }
 
@@ -160,6 +180,7 @@ public class FinalLocalVariableCheck extends AbstractCheck {
             TokenTypes.LITERAL_FOR,
             TokenTypes.VARIABLE_DEF,
             TokenTypes.EXPR,
+            TokenTypes.PATTERN_VARIABLE_DEF,
         };
     }
 
@@ -176,6 +197,7 @@ public class FinalLocalVariableCheck extends AbstractCheck {
             TokenTypes.VARIABLE_DEF,
             TokenTypes.PARAMETER_DEF,
             TokenTypes.EXPR,
+            TokenTypes.PATTERN_VARIABLE_DEF,
         };
     }
 
@@ -238,6 +260,14 @@ public class FinalLocalVariableCheck extends AbstractCheck {
                 // Switch labeled expression has no slist
                 if (ast.getParent().getType() == TokenTypes.SWITCH_RULE) {
                     storePrevScopeUninitializedVariableData();
+                }
+            }
+
+            case TokenTypes.PATTERN_VARIABLE_DEF -> {
+                if (validatePatternVariables && isNotChildOfAssign(ast)
+                        && ast.findFirstToken(TokenTypes.MODIFIERS)
+                        .findFirstToken(TokenTypes.FINAL) == null) {
+                    insertPatternVariable(ast);
                 }
             }
 
@@ -517,6 +547,23 @@ public class FinalLocalVariableCheck extends AbstractCheck {
     }
 
     /**
+     * Insert a pattern variable at the topmost scope stack.
+     *
+     * @param ast the pattern variable to insert.
+     */
+    private void insertPatternVariable(DetailAST ast) {
+        final Map<String, FinalVariableCandidate> scope = scopeStack.peek().scope;
+        final DetailAST astNode = ast.findFirstToken(TokenTypes.IDENT);
+        final FinalVariableCandidate previousCandidate = scope.get(astNode.getText());
+        if (previousCandidate != null) {
+            final DetailAST ident = previousCandidate.variableIdent;
+            log(ident, MSG_KEY, ident.getText());
+        }
+        final FinalVariableCandidate candidate = new FinalVariableCandidate(astNode);
+        scope.put(astNode.getText(), candidate);
+    }
+
+    /**
      * Check if VARIABLE_DEF is initialized or not.
      *
      * @param ast VARIABLE_DEF to be checked
@@ -534,6 +581,17 @@ public class FinalLocalVariableCheck extends AbstractCheck {
      */
     private static boolean isFirstChild(DetailAST ast) {
         return ast.getPreviousSibling() == null;
+    }
+
+    /**
+     * Checks if pattern variable is not used for assign.
+     *
+     * @param ast PATTERN_VARIABLE_DEF.
+     * @return true if it's in conditional statement.
+     */
+    private static boolean isNotChildOfAssign(DetailAST ast) {
+        return ast.getParent().getParent()
+                .getParent().getType() != TokenTypes.ASSIGN;
     }
 
     /**

--- a/src/main/resources/com/puppycrawl/tools/checkstyle/meta/checks/coding/FinalLocalVariableCheck.xml
+++ b/src/main/resources/com/puppycrawl/tools/checkstyle/meta/checks/coding/FinalLocalVariableCheck.xml
@@ -28,6 +28,13 @@
  enhanced for-loop&lt;/a&gt; variable.</description>
             </property>
             <property default-value="false"
+                      name="validatePatternVariables"
+                      type="boolean">
+               <description>Control whether to check
+ &lt;a href="https://openjdk.org/jeps/394"&gt;
+ pattern variables&gt;&lt;/a&gt;.</description>
+            </property>
+            <property default-value="false"
                       name="validateUnnamedVariables"
                       type="boolean">
                <description>Control whether to check

--- a/src/site/xdoc/checks/coding/finallocalvariable.xml
+++ b/src/site/xdoc/checks/coding/finallocalvariable.xml
@@ -41,6 +41,14 @@
               <td>6.5</td>
             </tr>
             <tr>
+              <td><a id="validatePatternVariables"/><a href="#validatePatternVariables">validatePatternVariables</a></td>
+              <td>Control whether to check <a href="https://openjdk.org/jeps/394">
+ pattern variables></a>.</td>
+              <td><a href="../../property_types.html#boolean">boolean</a></td>
+              <td><code>false</code></td>
+              <td>13.4.0</td>
+            </tr>
+            <tr>
               <td><a id="validateUnnamedVariables"/><a href="#validateUnnamedVariables">validateUnnamedVariables</a></td>
               <td>Control whether to check <a href="https://docs.oracle.com/javase/specs/jls/se21/preview/specs/unnamed-jls.html">
  unnamed variables</a>.</td>
@@ -247,6 +255,37 @@ class Example5
       System.out.println(i);
     }
     int result=foo(1,2); // violation, 'Variable 'result' should be declared final'
+  }
+}
+</code></pre></div>
+        <hr class="example-separator"/>
+                <p id="Example6-config">
+                  An example of how to configure for pattern variables.
+                </p>
+                <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
+&lt;module name="Checker"&gt;
+  &lt;module name="TreeWalker"&gt;
+    &lt;module name="FinalLocalVariable"&gt;
+      &lt;property name="validatePatternVariables" value="true"/&gt;
+    &lt;/module&gt;
+  &lt;/module&gt;
+&lt;/module&gt;
+</code></pre></div>
+                <p id="Example6-code">Example:</p>
+                <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+class Example6 {
+  public void method() {
+    final Object o = 45;
+    // violation below, 'Variable 'p' should be declared final'
+    if (o instanceof String p) {
+      System.out.println(p);
+    }
+    if (o instanceof String p) { // ok
+      p = "rewrite";
+      System.out.println(p);
+    }
+    final boolean value = o instanceof String p;
+    // ok above, because p can't be reassigned
   }
 }
 </code></pre></div>

--- a/src/site/xdoc/checks/coding/finallocalvariable.xml.template
+++ b/src/site/xdoc/checks/coding/finallocalvariable.xml.template
@@ -118,6 +118,21 @@
                  value="resources/com/puppycrawl/tools/checkstyle/checks/coding/finallocalvariable/Example5.java"/>
           <param name="type" value="code"/>
         </macro>
+        <hr class="example-separator"/>
+                <p id="Example6-config">
+                  An example of how to configure for pattern variables.
+                </p>
+                <macro name="example">
+                  <param name="path"
+                         value="resources/com/puppycrawl/tools/checkstyle/checks/coding/finallocalvariable/Example6.java"/>
+                  <param name="type" value="config"/>
+                </macro>
+                <p id="Example6-code">Example:</p>
+                <macro name="example">
+                  <param name="path"
+                         value="resources/com/puppycrawl/tools/checkstyle/checks/coding/finallocalvariable/Example6.java"/>
+                  <param name="type" value="code"/>
+                </macro>
       </subsection>
 
       <subsection name="Example of Usage" id="FinalLocalVariable_Example_of_Usage">

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/coding/FinalLocalVariableCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/coding/FinalLocalVariableCheckTest.java
@@ -41,21 +41,21 @@ public class FinalLocalVariableCheckTest
     public void testInputFinalLocalVariableOne() throws Exception {
 
         final String[] expected = {
-            "17:13: " + getCheckMessage(MSG_KEY, "i"),
-            "17:16: " + getCheckMessage(MSG_KEY, "j"),
-            "19:18: " + getCheckMessage(MSG_KEY, "runnable"),
-            "29:13: " + getCheckMessage(MSG_KEY, "i"),
-            "33:13: " + getCheckMessage(MSG_KEY, "z"),
-            "35:16: " + getCheckMessage(MSG_KEY, "obj"),
-            "39:16: " + getCheckMessage(MSG_KEY, "x"),
-            "45:18: " + getCheckMessage(MSG_KEY, "runnable"),
-            "49:21: " + getCheckMessage(MSG_KEY, "q"),
-            "65:13: " + getCheckMessage(MSG_KEY, "i"),
-            "69:13: " + getCheckMessage(MSG_KEY, "z"),
-            "71:16: " + getCheckMessage(MSG_KEY, "obj"),
-            "75:16: " + getCheckMessage(MSG_KEY, "x"),
-            "83:21: " + getCheckMessage(MSG_KEY, "w"),
-            "85:26: " + getCheckMessage(MSG_KEY, "runnable"),
+            "18:13: " + getCheckMessage(MSG_KEY, "i"),
+            "18:16: " + getCheckMessage(MSG_KEY, "j"),
+            "20:18: " + getCheckMessage(MSG_KEY, "runnable"),
+            "30:13: " + getCheckMessage(MSG_KEY, "i"),
+            "34:13: " + getCheckMessage(MSG_KEY, "z"),
+            "36:16: " + getCheckMessage(MSG_KEY, "obj"),
+            "40:16: " + getCheckMessage(MSG_KEY, "x"),
+            "46:18: " + getCheckMessage(MSG_KEY, "runnable"),
+            "50:21: " + getCheckMessage(MSG_KEY, "q"),
+            "66:13: " + getCheckMessage(MSG_KEY, "i"),
+            "70:13: " + getCheckMessage(MSG_KEY, "z"),
+            "72:16: " + getCheckMessage(MSG_KEY, "obj"),
+            "76:16: " + getCheckMessage(MSG_KEY, "x"),
+            "84:21: " + getCheckMessage(MSG_KEY, "w"),
+            "86:26: " + getCheckMessage(MSG_KEY, "runnable"),
         };
         verifyWithInlineConfigParser(
                 getPath("InputFinalLocalVariableOne.java"), expected);
@@ -64,9 +64,9 @@ public class FinalLocalVariableCheckTest
     @Test
     public void testInputFinalLocalVariableTwo() throws Exception {
         final String[] expected = {
-            "24:17: " + getCheckMessage(MSG_KEY, "weird"),
-            "25:17: " + getCheckMessage(MSG_KEY, "j"),
-            "26:17: " + getCheckMessage(MSG_KEY, "k"),
+            "25:17: " + getCheckMessage(MSG_KEY, "weird"),
+            "26:17: " + getCheckMessage(MSG_KEY, "j"),
+            "27:17: " + getCheckMessage(MSG_KEY, "k"),
         };
         verifyWithInlineConfigParser(
                 getPath("InputFinalLocalVariableTwo.java"), expected);
@@ -75,16 +75,16 @@ public class FinalLocalVariableCheckTest
     @Test
     public void testInputFinalLocalVariableThree() throws Exception {
         final String[] expected = {
-            "14:17: " + getCheckMessage(MSG_KEY, "x"),
-            "20:21: " + getCheckMessage(MSG_KEY, "x"),
-            "41:21: " + getCheckMessage(MSG_KEY, "n"),
-            "47:17: " + getCheckMessage(MSG_KEY, "q"),
-            "48:17: " + getCheckMessage(MSG_KEY, "w"),
-            "57:25: " + getCheckMessage(MSG_KEY, "w"),
-            "58:25: " + getCheckMessage(MSG_KEY, "e"),
-            "79:21: " + getCheckMessage(MSG_KEY, "n"),
-            "92:21: " + getCheckMessage(MSG_KEY, "t"),
-            "102:25: " + getCheckMessage(MSG_KEY, "foo"),
+            "15:17: " + getCheckMessage(MSG_KEY, "x"),
+            "21:21: " + getCheckMessage(MSG_KEY, "x"),
+            "42:21: " + getCheckMessage(MSG_KEY, "n"),
+            "48:17: " + getCheckMessage(MSG_KEY, "q"),
+            "49:17: " + getCheckMessage(MSG_KEY, "w"),
+            "58:25: " + getCheckMessage(MSG_KEY, "w"),
+            "59:25: " + getCheckMessage(MSG_KEY, "e"),
+            "80:21: " + getCheckMessage(MSG_KEY, "n"),
+            "93:21: " + getCheckMessage(MSG_KEY, "t"),
+            "103:25: " + getCheckMessage(MSG_KEY, "foo"),
         };
         verifyWithInlineConfigParser(
                 getPath("InputFinalLocalVariableThree.java"), expected);
@@ -93,11 +93,11 @@ public class FinalLocalVariableCheckTest
     @Test
     public void testInputFinalLocalVariableFour() throws Exception {
         final String[] expected = {
-            "16:17: " + getCheckMessage(MSG_KEY, "shouldBeFinal"),
-            "28:17: " + getCheckMessage(MSG_KEY, "shouldBeFinal"),
-            "72:17: " + getCheckMessage(MSG_KEY, "shouldBeFinal"),
-            "85:17: " + getCheckMessage(MSG_KEY, "shouldBeFinal"),
-            "89:25: " + getCheckMessage(MSG_KEY, "shouldBeFinal"),
+            "17:17: " + getCheckMessage(MSG_KEY, "shouldBeFinal"),
+            "29:17: " + getCheckMessage(MSG_KEY, "shouldBeFinal"),
+            "73:17: " + getCheckMessage(MSG_KEY, "shouldBeFinal"),
+            "86:17: " + getCheckMessage(MSG_KEY, "shouldBeFinal"),
+            "90:25: " + getCheckMessage(MSG_KEY, "shouldBeFinal"),
         };
         verifyWithInlineConfigParser(
                 getPath("InputFinalLocalVariableFour.java"), expected);
@@ -106,11 +106,11 @@ public class FinalLocalVariableCheckTest
     @Test
     public void testFinalLocalVariableFive() throws Exception {
         final String[] expected = {
-            "15:17: " + getCheckMessage(MSG_KEY, "shouldBeFinal"),
-            "26:17: " + getCheckMessage(MSG_KEY, "shouldBeFinal"),
-            "58:17: " + getCheckMessage(MSG_KEY, "shouldBeFinal"),
-            "62:25: " + getCheckMessage(MSG_KEY, "shouldBeFinal"),
-            "83:41: " + getCheckMessage(MSG_KEY, "table"),
+            "16:17: " + getCheckMessage(MSG_KEY, "shouldBeFinal"),
+            "27:17: " + getCheckMessage(MSG_KEY, "shouldBeFinal"),
+            "59:17: " + getCheckMessage(MSG_KEY, "shouldBeFinal"),
+            "63:25: " + getCheckMessage(MSG_KEY, "shouldBeFinal"),
+            "84:41: " + getCheckMessage(MSG_KEY, "table"),
         };
         verifyWithInlineConfigParser(
                 getPath("InputFinalLocalVariableFive.java"), expected);
@@ -119,7 +119,7 @@ public class FinalLocalVariableCheckTest
     @Test
     public void testRecordsInput() throws Exception {
         final String[] expected = {
-            "20:17: " + getCheckMessage(MSG_KEY, "b"),
+            "21:17: " + getCheckMessage(MSG_KEY, "b"),
         };
         verifyWithInlineConfigParser(
                 getPath("InputFinalLocalVariableCheckRecords.java"), expected);
@@ -129,7 +129,7 @@ public class FinalLocalVariableCheckTest
     public void testInputFinalLocalVariable2One() throws Exception {
 
         final String[] expected = {
-            "53:28: " + getCheckMessage(MSG_KEY, "aArg"),
+            "54:28: " + getCheckMessage(MSG_KEY, "aArg"),
         };
         verifyWithInlineConfigParser(
                 getPath("InputFinalLocalVariable2One.java"), expected);
@@ -139,8 +139,8 @@ public class FinalLocalVariableCheckTest
     public void testInputFinalLocalVariable2Two() throws Exception {
 
         final String[] excepted = {
-            "78:36: " + getCheckMessage(MSG_KEY, "_o"),
-            "83:37: " + getCheckMessage(MSG_KEY, "_o1"),
+            "79:36: " + getCheckMessage(MSG_KEY, "_o"),
+            "84:37: " + getCheckMessage(MSG_KEY, "_o1"),
         };
         verifyWithInlineConfigParser(
                 getPath("InputFinalLocalVariable2Two.java"), excepted);
@@ -195,13 +195,13 @@ public class FinalLocalVariableCheckTest
     @Test
     public void testEnhancedForLoopVariableTrue() throws Exception {
         final String[] expected = {
-            "16:20: " + getCheckMessage(MSG_KEY, "a"),
-            "23:13: " + getCheckMessage(MSG_KEY, "x"),
-            "29:66: " + getCheckMessage(MSG_KEY, "snippets"),
-            "31:32: " + getCheckMessage(MSG_KEY, "filteredSnippets"),
-            "33:21: " + getCheckMessage(MSG_KEY, "snippet"),
-            "48:20: " + getCheckMessage(MSG_KEY, "a"),
-            "51:16: " + getCheckMessage(MSG_KEY, "a"),
+            "17:20: " + getCheckMessage(MSG_KEY, "a"),
+            "24:13: " + getCheckMessage(MSG_KEY, "x"),
+            "30:66: " + getCheckMessage(MSG_KEY, "snippets"),
+            "32:32: " + getCheckMessage(MSG_KEY, "filteredSnippets"),
+            "34:21: " + getCheckMessage(MSG_KEY, "snippet"),
+            "49:20: " + getCheckMessage(MSG_KEY, "a"),
+            "52:16: " + getCheckMessage(MSG_KEY, "a"),
         };
         verifyWithInlineConfigParser(
                 getPath("InputFinalLocalVariableEnhancedForLoopVariable.java"),
@@ -211,10 +211,10 @@ public class FinalLocalVariableCheckTest
     @Test
     public void testEnhancedForLoopVariableFalse() throws Exception {
         final String[] expected = {
-            "23:13: " + getCheckMessage(MSG_KEY, "x"),
-            "29:66: " + getCheckMessage(MSG_KEY, "snippets"),
-            "31:32: " + getCheckMessage(MSG_KEY, "filteredSnippets"),
-            "50:16: " + getCheckMessage(MSG_KEY, "a"),
+            "24:13: " + getCheckMessage(MSG_KEY, "x"),
+            "30:66: " + getCheckMessage(MSG_KEY, "snippets"),
+            "32:32: " + getCheckMessage(MSG_KEY, "filteredSnippets"),
+            "51:16: " + getCheckMessage(MSG_KEY, "a"),
         };
         verifyWithInlineConfigParser(
                 getPath("InputFinalLocalVariableEnhancedForLoopVariable2.java"),
@@ -225,7 +225,7 @@ public class FinalLocalVariableCheckTest
     public void testLambda()
             throws Exception {
         final String[] expected = {
-            "43:16: " + getCheckMessage(MSG_KEY, "result"),
+            "44:16: " + getCheckMessage(MSG_KEY, "result"),
         };
         verifyWithInlineConfigParser(
                 getPath("InputFinalLocalVariableNameLambda.java"),
@@ -237,8 +237,8 @@ public class FinalLocalVariableCheckTest
             throws Exception {
 
         final String[] expected = {
-            "12:28: " + getCheckMessage(MSG_KEY, "text"),
-            "25:13: " + getCheckMessage(MSG_KEY, "x"),
+            "13:28: " + getCheckMessage(MSG_KEY, "text"),
+            "26:13: " + getCheckMessage(MSG_KEY, "x"),
         };
         verifyWithInlineConfigParser(
                 getPath("InputFinalLocalVariableNameShadowing.java"), expected);
@@ -264,12 +264,12 @@ public class FinalLocalVariableCheckTest
     public void testVariableWhichIsAssignedMultipleTimes() throws Exception {
 
         final String[] expected = {
-            "57:13: " + getCheckMessage(MSG_KEY, "i"),
-            "130:16: " + getCheckMessage(MSG_KEY, "path"),
-            "135:20: " + getCheckMessage(MSG_KEY, "relativePath"),
-            "211:17: " + getCheckMessage(MSG_KEY, "kind"),
-            "216:24: " + getCheckMessage(MSG_KEY, "m"),
-            "418:17: " + getCheckMessage(MSG_KEY, "increment"),
+            "58:13: " + getCheckMessage(MSG_KEY, "i"),
+            "131:16: " + getCheckMessage(MSG_KEY, "path"),
+            "136:20: " + getCheckMessage(MSG_KEY, "relativePath"),
+            "212:17: " + getCheckMessage(MSG_KEY, "kind"),
+            "217:24: " + getCheckMessage(MSG_KEY, "m"),
+            "419:17: " + getCheckMessage(MSG_KEY, "increment"),
         };
         verifyWithInlineConfigParser(
                 getPath("InputFinalLocalVariableAssignedMultipleTimes.java"), expected);
@@ -278,7 +278,7 @@ public class FinalLocalVariableCheckTest
     @Test
     public void testVariableIsAssignedInsideAndOutsideSwitchBlock() throws Exception {
         final String[] expected = {
-            "39:13: " + getCheckMessage(MSG_KEY, "b"),
+            "40:13: " + getCheckMessage(MSG_KEY, "b"),
         };
         verifyWithInlineConfigParser(
                 getPath("InputFinalLocalVariableAssignedInsideAndOutsideSwitch.java"),
@@ -288,8 +288,8 @@ public class FinalLocalVariableCheckTest
     @Test
     public void testFinalLocalVariableFalsePositives() throws Exception {
         final String[] expected = {
-            "352:16: " + getCheckMessage(MSG_KEY, "c2"),
-            "2195:16: " + getCheckMessage(MSG_KEY, "b"),
+            "353:16: " + getCheckMessage(MSG_KEY, "c2"),
+            "2196:16: " + getCheckMessage(MSG_KEY, "b"),
         };
         verifyWithInlineConfigParser(
                 getPath("InputFinalLocalVariableFalsePositives.java"), expected);
@@ -321,7 +321,7 @@ public class FinalLocalVariableCheckTest
     @Test
     public void testBreakOrReturn() throws Exception {
         final String[] expected = {
-            "15:19: " + getCheckMessage(MSG_KEY, "e"),
+            "16:19: " + getCheckMessage(MSG_KEY, "e"),
         };
         verifyWithInlineConfigParser(
                 getPath("InputFinalLocalVariableBreak.java"), expected);
@@ -330,7 +330,7 @@ public class FinalLocalVariableCheckTest
     @Test
     public void testAnonymousClass() throws Exception {
         final String[] expected = {
-            "14:16: " + getCheckMessage(MSG_KEY, "testSupport"),
+            "15:16: " + getCheckMessage(MSG_KEY, "testSupport"),
         };
         verifyWithInlineConfigParser(
                 getPath("InputFinalLocalVariableAnonymousClass.java"), expected);
@@ -346,10 +346,10 @@ public class FinalLocalVariableCheckTest
     @Test
     public void testFinalLocalVariableSwitchExpressions() throws Exception {
         final String[] expected = {
-            "15:19: " + getCheckMessage(MSG_KEY, "e"),
-            "53:19: " + getCheckMessage(MSG_KEY, "e"),
-            "91:19: " + getCheckMessage(MSG_KEY, "e"),
-            "125:19: " + getCheckMessage(MSG_KEY, "e"),
+            "16:19: " + getCheckMessage(MSG_KEY, "e"),
+            "54:19: " + getCheckMessage(MSG_KEY, "e"),
+            "92:19: " + getCheckMessage(MSG_KEY, "e"),
+            "126:19: " + getCheckMessage(MSG_KEY, "e"),
         };
         verifyWithInlineConfigParser(
                 getNonCompilablePath("InputFinalLocalVariableCheckSwitchExpressions.java"),
@@ -359,11 +359,11 @@ public class FinalLocalVariableCheckTest
     @Test
     public void testFinalLocalVariableSwitchAssignment() throws Exception {
         final String[] expected = {
-            "21:13: " + getCheckMessage(MSG_KEY, "a"),
-            "44:13: " + getCheckMessage(MSG_KEY, "b"),
-            "46:21: " + getCheckMessage(MSG_KEY, "x"),
-            "72:16: " + getCheckMessage(MSG_KEY, "res"),
-            "92:16: " + getCheckMessage(MSG_KEY, "res"),
+            "22:13: " + getCheckMessage(MSG_KEY, "a"),
+            "45:13: " + getCheckMessage(MSG_KEY, "b"),
+            "47:21: " + getCheckMessage(MSG_KEY, "x"),
+            "73:16: " + getCheckMessage(MSG_KEY, "res"),
+            "93:16: " + getCheckMessage(MSG_KEY, "res"),
         };
         verifyWithInlineConfigParser(
                 getPath("InputFinalLocalVariableCheckSwitchAssignment.java"),
@@ -381,11 +381,11 @@ public class FinalLocalVariableCheckTest
     @Test
     public void testConstructor() throws Exception {
         final String[] expected = {
-            "14:44: " + getCheckMessage(MSG_KEY, "a"),
-            "18:44: " + getCheckMessage(MSG_KEY, "a"),
-            "19:43: " + getCheckMessage(MSG_KEY, "b"),
-            "22:47: " + getCheckMessage(MSG_KEY, "str"),
-            "35:21: " + getCheckMessage(MSG_KEY, "str"),
+            "15:44: " + getCheckMessage(MSG_KEY, "a"),
+            "19:44: " + getCheckMessage(MSG_KEY, "a"),
+            "20:43: " + getCheckMessage(MSG_KEY, "b"),
+            "23:47: " + getCheckMessage(MSG_KEY, "str"),
+            "36:21: " + getCheckMessage(MSG_KEY, "str"),
         };
         verifyWithInlineConfigParser(
             getPath("InputFinalLocalVariableConstructor.java"),
@@ -395,11 +395,11 @@ public class FinalLocalVariableCheckTest
     @Test
     public void test() throws Exception {
         final String[] expected = {
-            "22:17: " + getCheckMessage(MSG_KEY, "start"),
-            "24:17: " + getCheckMessage(MSG_KEY, "end"),
-            "42:38: " + getCheckMessage(MSG_KEY, "list"),
-            "45:38: " + getCheckMessage(MSG_KEY, "forEach"),
-            "47:38: " + getCheckMessage(MSG_KEY, "body"),
+            "23:17: " + getCheckMessage(MSG_KEY, "start"),
+            "25:17: " + getCheckMessage(MSG_KEY, "end"),
+            "43:38: " + getCheckMessage(MSG_KEY, "list"),
+            "46:38: " + getCheckMessage(MSG_KEY, "forEach"),
+            "48:38: " + getCheckMessage(MSG_KEY, "body"),
         };
         verifyWithInlineConfigParser(
             getPath("InputFinalLocalVariable3.java"),
@@ -409,14 +409,14 @@ public class FinalLocalVariableCheckTest
     @Test
     public void testValidateUnnamedVariablesTrue() throws Exception {
         final String[] expected = {
-            "21:22: " + getCheckMessage(MSG_KEY, "i"),
-            "22:17: " + getCheckMessage(MSG_KEY, "_"),
-            "23:17: " + getCheckMessage(MSG_KEY, "__"),
-            "26:13: " + getCheckMessage(MSG_KEY, "_"),
-            "27:13: " + getCheckMessage(MSG_KEY, "_result"),
-            "32:18: " + getCheckMessage(MSG_KEY, "_"),
-            "44:18: " + getCheckMessage(MSG_KEY, "_"),
-            "50:18: " + getCheckMessage(MSG_KEY, "__"),
+            "22:22: " + getCheckMessage(MSG_KEY, "i"),
+            "23:17: " + getCheckMessage(MSG_KEY, "_"),
+            "24:17: " + getCheckMessage(MSG_KEY, "__"),
+            "27:13: " + getCheckMessage(MSG_KEY, "_"),
+            "28:13: " + getCheckMessage(MSG_KEY, "_result"),
+            "33:18: " + getCheckMessage(MSG_KEY, "_"),
+            "45:18: " + getCheckMessage(MSG_KEY, "_"),
+            "51:18: " + getCheckMessage(MSG_KEY, "__"),
         };
         verifyWithInlineConfigParser(
                 getPath("InputFinalLocalVariableValidateUnnamedVariablesTrue.java"),
@@ -426,10 +426,10 @@ public class FinalLocalVariableCheckTest
     @Test
     public void testValidateUnnamedVariablesFalse() throws Exception {
         final String[] expected = {
-            "21:22: " + getCheckMessage(MSG_KEY, "i"),
-            "23:17: " + getCheckMessage(MSG_KEY, "__"),
-            "27:13: " + getCheckMessage(MSG_KEY, "_result"),
-            "50:18: " + getCheckMessage(MSG_KEY, "__"),
+            "22:22: " + getCheckMessage(MSG_KEY, "i"),
+            "24:17: " + getCheckMessage(MSG_KEY, "__"),
+            "28:13: " + getCheckMessage(MSG_KEY, "_result"),
+            "51:18: " + getCheckMessage(MSG_KEY, "__"),
         };
         verifyWithInlineConfigParser(
                 getPath("InputFinalLocalVariableValidateUnnamedVariablesFalse.java"),
@@ -439,14 +439,41 @@ public class FinalLocalVariableCheckTest
     @Test
     public void test1() throws Exception {
         final String[] expected = {
-            "13:34: " + getCheckMessage(MSG_KEY, "param"),
-            "14:20: " + getCheckMessage(MSG_KEY, "local"),
-            "20:32: " + getCheckMessage(MSG_KEY, "aParam"),
-            "23:40: " + getCheckMessage(MSG_KEY, "num"),
-            "28:42: " + getCheckMessage(MSG_KEY, "e"),
+            "14:34: " + getCheckMessage(MSG_KEY, "param"),
+            "15:20: " + getCheckMessage(MSG_KEY, "local"),
+            "21:32: " + getCheckMessage(MSG_KEY, "aParam"),
+            "24:40: " + getCheckMessage(MSG_KEY, "num"),
+            "29:42: " + getCheckMessage(MSG_KEY, "e"),
         };
         verifyWithInlineConfigParser(
             getPath("InputFinalLocalVariableInterface.java"),
             expected);
     }
+
+    @Test
+    public void testPatternVariables() throws Exception {
+        final String[] expected = {
+            "15:33: " + getCheckMessage(MSG_KEY, "p"),
+        };
+        verifyWithInlineConfigParser(
+            getPath("InputFinalLocalVariablePatternVariables.java"),
+            expected);
+    }
+
+    @Test
+    public void testPatternVariablesScope() throws Exception {
+        final String[] expected = CommonUtil.EMPTY_STRING_ARRAY;
+        verifyWithInlineConfigParser(
+                getPath("InputFinalLocalVariablePatternVariablesScope.java"),
+                expected);
+    }
+
+    @Test
+    public void testPatternVariables2() throws Exception {
+        final String[] expected = CommonUtil.EMPTY_STRING_ARRAY;
+        verifyWithInlineConfigParser(
+                getPath("InputFinalLocalVariablePatternVariables2.java"),
+                expected);
+    }
+
 }

--- a/src/test/java/com/puppycrawl/tools/checkstyle/filefilters/BeforeExecutionExclusionFileFilterTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/filefilters/BeforeExecutionExclusionFileFilterTest.java
@@ -75,7 +75,7 @@ public class BeforeExecutionExclusionFileFilterTest extends AbstractModuleTestSu
         final String[] filteredViolations = CommonUtil.EMPTY_STRING_ARRAY;
 
         final String[] unfilteredViolations = {
-            "17:13: " + getCheckMessage(FinalLocalVariableCheck.class, MSG_KEY, "i"),
+            "18:13: " + getCheckMessage(FinalLocalVariableCheck.class, MSG_KEY, "i"),
         };
 
         verifyFilterWithInlineConfigParser(

--- a/src/test/java/com/puppycrawl/tools/checkstyle/internal/XdocsExamplesAstConsistencyTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/internal/XdocsExamplesAstConsistencyTest.java
@@ -96,6 +96,7 @@ public class XdocsExamplesAstConsistencyTest {
             "checks/blocks/needbraces/Example6",
             "checks/coding/constructorsdeclarationgrouping/Example2",
             "checks/coding/covariantequals/Example2",
+            "checks/coding/finallocalvariable/Example6",
             "checks/coding/illegaltoken/Example2",
             "checks/coding/illegaltokentext/Example3",
             "checks/coding/illegaltokentext/Example4",

--- a/src/test/resources-noncompilable/com/puppycrawl/tools/checkstyle/checks/coding/finallocalvariable/InputFinalLocalVariableCheckSwitchExpressions.java
+++ b/src/test/resources-noncompilable/com/puppycrawl/tools/checkstyle/checks/coding/finallocalvariable/InputFinalLocalVariableCheckSwitchExpressions.java
@@ -2,6 +2,7 @@
 FinalLocalVariable
 validateEnhancedForLoopVariable = (default)false
 validateUnnamedVariables = (default)false
+validatePatternVariables = (default)false
 tokens = (default)VARIABLE_DEF
 
 */

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/finallocalvariable/InputFinalLocalVariable2Five.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/finallocalvariable/InputFinalLocalVariable2Five.java
@@ -2,6 +2,7 @@
 FinalLocalVariable
 validateEnhancedForLoopVariable = (default)false
 validateUnnamedVariables = (default)false
+validatePatternVariables = (default)false
 tokens = PARAMETER_DEF
 
 */

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/finallocalvariable/InputFinalLocalVariable2Four.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/finallocalvariable/InputFinalLocalVariable2Four.java
@@ -2,6 +2,7 @@
 FinalLocalVariable
 validateEnhancedForLoopVariable = (default)false
 validateUnnamedVariables = (default)false
+validatePatternVariables = (default)false
 tokens = PARAMETER_DEF
 
 */

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/finallocalvariable/InputFinalLocalVariable2One.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/finallocalvariable/InputFinalLocalVariable2One.java
@@ -2,6 +2,7 @@
 FinalLocalVariable
 validateEnhancedForLoopVariable = (default)false
 validateUnnamedVariables = (default)false
+validatePatternVariables = (default)false
 tokens = PARAMETER_DEF
 
 */

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/finallocalvariable/InputFinalLocalVariable2Three.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/finallocalvariable/InputFinalLocalVariable2Three.java
@@ -2,6 +2,7 @@
 FinalLocalVariable
 validateEnhancedForLoopVariable = (default)false
 validateUnnamedVariables = (default)false
+validatePatternVariables = (default)false
 tokens = PARAMETER_DEF
 
 */

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/finallocalvariable/InputFinalLocalVariable2Two.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/finallocalvariable/InputFinalLocalVariable2Two.java
@@ -2,6 +2,7 @@
 FinalLocalVariable
 validateEnhancedForLoopVariable = (default)false
 validateUnnamedVariables = (default)false
+validatePatternVariables = (default)false
 tokens = PARAMETER_DEF
 
 */

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/finallocalvariable/InputFinalLocalVariable3.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/finallocalvariable/InputFinalLocalVariable3.java
@@ -2,6 +2,7 @@
 FinalLocalVariable
 validateEnhancedForLoopVariable = (default)false
 validateUnnamedVariables = (default)false
+validatePatternVariables = (default)false
 tokens = (default)VARIABLE_DEF
 
 */

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/finallocalvariable/InputFinalLocalVariableAnonymousClass.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/finallocalvariable/InputFinalLocalVariableAnonymousClass.java
@@ -2,6 +2,7 @@
 FinalLocalVariable
 validateEnhancedForLoopVariable = (default)false
 validateUnnamedVariables = (default)false
+validatePatternVariables = (default)false
 tokens = (default)VARIABLE_DEF
 
 */

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/finallocalvariable/InputFinalLocalVariableAssignedInsideAndOutsideSwitch.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/finallocalvariable/InputFinalLocalVariableAssignedInsideAndOutsideSwitch.java
@@ -2,6 +2,7 @@
 FinalLocalVariable
 validateEnhancedForLoopVariable = (default)false
 validateUnnamedVariables = (default)false
+validatePatternVariables = (default)false
 tokens = (default)VARIABLE_DEF
 
 */

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/finallocalvariable/InputFinalLocalVariableAssignedMultipleTimes.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/finallocalvariable/InputFinalLocalVariableAssignedMultipleTimes.java
@@ -2,6 +2,7 @@
 FinalLocalVariable
 validateEnhancedForLoopVariable = (default)false
 validateUnnamedVariables = (default)false
+validatePatternVariables = (default)false
 tokens = (default)VARIABLE_DEF
 
 */

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/finallocalvariable/InputFinalLocalVariableBreak.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/finallocalvariable/InputFinalLocalVariableBreak.java
@@ -2,6 +2,7 @@
 FinalLocalVariable
 validateEnhancedForLoopVariable = (default)false
 validateUnnamedVariables = (default)false
+validatePatternVariables = (default)false
 tokens = (default)VARIABLE_DEF
 
 */

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/finallocalvariable/InputFinalLocalVariableCheckRecords.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/finallocalvariable/InputFinalLocalVariableCheckRecords.java
@@ -2,6 +2,7 @@
 FinalLocalVariable
 validateEnhancedForLoopVariable = (default)false
 validateUnnamedVariables = (default)false
+validatePatternVariables = (default)false
 tokens = (default)VARIABLE_DEF
 
 */

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/finallocalvariable/InputFinalLocalVariableCheckSwitchAssignment.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/finallocalvariable/InputFinalLocalVariableCheckSwitchAssignment.java
@@ -2,6 +2,7 @@
 FinalLocalVariable
 validateEnhancedForLoopVariable = (default)false
 validateUnnamedVariables = (default)false
+validatePatternVariables = (default)false
 tokens = (default)VARIABLE_DEF
 
 */

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/finallocalvariable/InputFinalLocalVariableConstructor.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/finallocalvariable/InputFinalLocalVariableConstructor.java
@@ -2,6 +2,7 @@
 FinalLocalVariable
 validateEnhancedForLoopVariable = (default)false
 validateUnnamedVariables = (default)false
+validatePatternVariables = (default)false
 tokens = PARAMETER_DEF
 
 */

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/finallocalvariable/InputFinalLocalVariableEnhancedForLoopVariable.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/finallocalvariable/InputFinalLocalVariableEnhancedForLoopVariable.java
@@ -2,6 +2,7 @@
 FinalLocalVariable
 validateEnhancedForLoopVariable = true
 validateUnnamedVariables = (default)false
+validatePatternVariables = (default)false
 tokens = VARIABLE_DEF, PARAMETER_DEF
 
 */

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/finallocalvariable/InputFinalLocalVariableEnhancedForLoopVariable2.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/finallocalvariable/InputFinalLocalVariableEnhancedForLoopVariable2.java
@@ -2,6 +2,7 @@
 FinalLocalVariable
 validateEnhancedForLoopVariable = (default)false
 validateUnnamedVariables = (default)false
+validatePatternVariables = (default)false
 tokens = VARIABLE_DEF, PARAMETER_DEF
 
 */

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/finallocalvariable/InputFinalLocalVariableFalsePositive.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/finallocalvariable/InputFinalLocalVariableFalsePositive.java
@@ -2,6 +2,7 @@
 FinalLocalVariable
 validateEnhancedForLoopVariable = (default)false
 validateUnnamedVariables = (default)false
+validatePatternVariables = (default)false
 tokens = VARIABLE_DEF, PARAMETER_DEF
 
 */

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/finallocalvariable/InputFinalLocalVariableFalsePositives.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/finallocalvariable/InputFinalLocalVariableFalsePositives.java
@@ -2,6 +2,7 @@
 FinalLocalVariable
 validateEnhancedForLoopVariable = (default)false
 validateUnnamedVariables = (default)false
+validatePatternVariables = (default)false
 tokens = (default)VARIABLE_DEF
 
 */

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/finallocalvariable/InputFinalLocalVariableFive.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/finallocalvariable/InputFinalLocalVariableFive.java
@@ -2,6 +2,7 @@
 FinalLocalVariable
 validateEnhancedForLoopVariable = (default)false
 validateUnnamedVariables = (default)false
+validatePatternVariables = (default)false
 tokens = (default)VARIABLE_DEF
 
 */

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/finallocalvariable/InputFinalLocalVariableFour.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/finallocalvariable/InputFinalLocalVariableFour.java
@@ -2,6 +2,7 @@
 FinalLocalVariable
 validateEnhancedForLoopVariable = (default)false
 validateUnnamedVariables = (default)false
+validatePatternVariables = (default)false
 tokens = (default)VARIABLE_DEF
 
 */

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/finallocalvariable/InputFinalLocalVariableInterface.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/finallocalvariable/InputFinalLocalVariableInterface.java
@@ -2,6 +2,7 @@
 FinalLocalVariable
 validateEnhancedForLoopVariable = (default)false
 validateUnnamedVariables = (default)false
+validatePatternVariables = (default)false
 tokens = VARIABLE_DEF, PARAMETER_DEF
 
 */

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/finallocalvariable/InputFinalLocalVariableLeavingSlistToken.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/finallocalvariable/InputFinalLocalVariableLeavingSlistToken.java
@@ -2,6 +2,7 @@
 FinalLocalVariable
 validateEnhancedForLoopVariable = (default)false
 validateUnnamedVariables = (default)false
+validatePatternVariables = (default)false
 tokens = (default)VARIABLE_DEF
 
 */

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/finallocalvariable/InputFinalLocalVariableMultiCatch.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/finallocalvariable/InputFinalLocalVariableMultiCatch.java
@@ -2,6 +2,7 @@
 FinalLocalVariable
 validateEnhancedForLoopVariable = (default)false
 validateUnnamedVariables = (default)false
+validatePatternVariables = (default)false
 tokens = PARAMETER_DEF,VARIABLE_DEF
 
 */

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/finallocalvariable/InputFinalLocalVariableMultipleAndNestedConditions.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/finallocalvariable/InputFinalLocalVariableMultipleAndNestedConditions.java
@@ -2,6 +2,7 @@
 FinalLocalVariable
 validateEnhancedForLoopVariable = (default)false
 validateUnnamedVariables = (default)false
+validatePatternVariables = (default)false
 tokens = (default)VARIABLE_DEF
 
 */

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/finallocalvariable/InputFinalLocalVariableNameLambda.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/finallocalvariable/InputFinalLocalVariableNameLambda.java
@@ -2,6 +2,7 @@
 FinalLocalVariable
 validateEnhancedForLoopVariable = (default)false
 validateUnnamedVariables = (default)false
+validatePatternVariables = (default)false
 tokens = PARAMETER_DEF,VARIABLE_DEF
 
 */

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/finallocalvariable/InputFinalLocalVariableNameShadowing.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/finallocalvariable/InputFinalLocalVariableNameShadowing.java
@@ -2,6 +2,7 @@
 FinalLocalVariable
 validateEnhancedForLoopVariable = (default)false
 validateUnnamedVariables = (default)false
+validatePatternVariables = (default)false
 tokens = PARAMETER_DEF,VARIABLE_DEF
 
 */

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/finallocalvariable/InputFinalLocalVariableNativeMethods.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/finallocalvariable/InputFinalLocalVariableNativeMethods.java
@@ -2,6 +2,7 @@
 FinalLocalVariable
 validateEnhancedForLoopVariable = (default)false
 validateUnnamedVariables = (default)false
+validatePatternVariables = (default)false
 tokens = PARAMETER_DEF
 
 */

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/finallocalvariable/InputFinalLocalVariableOne.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/finallocalvariable/InputFinalLocalVariableOne.java
@@ -2,6 +2,7 @@
 FinalLocalVariable
 validateEnhancedForLoopVariable = (default)false
 validateUnnamedVariables = (default)false
+validatePatternVariables = (default)false
 tokens = (default)VARIABLE_DEF
 
 */

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/finallocalvariable/InputFinalLocalVariablePatternVariables.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/finallocalvariable/InputFinalLocalVariablePatternVariables.java
@@ -1,0 +1,30 @@
+/*
+FinalLocalVariable
+validateEnhancedForLoopVariable = (default)false
+validateUnnamedVariables = (default)false
+validatePatternVariables = true
+tokens = (default)VARIABLE_DEF
+
+*/
+
+package com.puppycrawl.tools.checkstyle.checks.coding.finallocalvariable;
+
+public class InputFinalLocalVariablePatternVariables {
+    public void run(String... arguments) {
+        final Object o = 45;
+        if (o instanceof String p) { // violation "Variable 'p' should be declared final"
+            System.out.println(p);
+        }
+        if (o instanceof final String p) {
+            System.out.println(p);
+        }
+        if (o instanceof String p) {
+            p = "rewrite";
+            System.out.println(p);
+        }
+        if (o instanceof String p) {
+            p = new String("p");
+        }
+        final boolean value = o instanceof String p;
+    }
+}

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/finallocalvariable/InputFinalLocalVariablePatternVariables2.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/finallocalvariable/InputFinalLocalVariablePatternVariables2.java
@@ -1,0 +1,27 @@
+/*
+FinalLocalVariable
+validateEnhancedForLoopVariable = (default)false
+validateUnnamedVariables = (default)false
+validatePatternVariables = (default)false
+tokens = (default)VARIABLE_DEF
+
+*/
+
+package com.puppycrawl.tools.checkstyle.checks.coding.finallocalvariable;
+
+public class InputFinalLocalVariablePatternVariables2 {
+    public void run(String... arguments) {
+        final Object o = 45;
+        if (o instanceof String p) {
+            System.out.println(p);
+        }
+        if (o instanceof final String p) {
+            System.out.println(p);
+        }
+        if (o instanceof String p) {
+            p = "rewrite";
+            System.out.println(p);
+        }
+        final boolean value = o instanceof String p;
+    }
+}

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/finallocalvariable/InputFinalLocalVariablePatternVariablesScope.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/finallocalvariable/InputFinalLocalVariablePatternVariablesScope.java
@@ -1,0 +1,20 @@
+/*
+FinalLocalVariable
+validateEnhancedForLoopVariable = (default)false
+validateUnnamedVariables = (default)false
+validatePatternVariables = true
+tokens = (default)VARIABLE_DEF
+
+*/
+
+package com.puppycrawl.tools.checkstyle.checks.coding.finallocalvariable;
+
+public class InputFinalLocalVariablePatternVariablesScope {
+    public static boolean bigEnoughRect(String s) {
+        if (!(s instanceof String r)) {
+            return false;
+        }
+        r = "hello";
+        return r.length() > 5;
+    }
+}

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/finallocalvariable/InputFinalLocalVariableReceiverParameter.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/finallocalvariable/InputFinalLocalVariableReceiverParameter.java
@@ -2,6 +2,7 @@
 FinalLocalVariable
 validateEnhancedForLoopVariable = (default)false
 validateUnnamedVariables = (default)false
+validatePatternVariables = (default)false
 tokens = PARAMETER_DEF,VARIABLE_DEF
 
 */

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/finallocalvariable/InputFinalLocalVariableSwitchStatement.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/finallocalvariable/InputFinalLocalVariableSwitchStatement.java
@@ -2,6 +2,7 @@
 FinalLocalVariable
 validateEnhancedForLoopVariable = (default)false
 validateUnnamedVariables = (default)false
+validatePatternVariables = (default)false
 tokens = (default)VARIABLE_DEF
 
 */

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/finallocalvariable/InputFinalLocalVariableThree.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/finallocalvariable/InputFinalLocalVariableThree.java
@@ -2,6 +2,7 @@
 FinalLocalVariable
 validateEnhancedForLoopVariable = (default)false
 validateUnnamedVariables = (default)false
+validatePatternVariables = (default)false
 tokens = (default)VARIABLE_DEF
 
 */

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/finallocalvariable/InputFinalLocalVariableTwo.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/finallocalvariable/InputFinalLocalVariableTwo.java
@@ -2,6 +2,7 @@
 FinalLocalVariable
 validateEnhancedForLoopVariable = (default)false
 validateUnnamedVariables = (default)false
+validatePatternVariables = (default)false
 tokens = (default)VARIABLE_DEF
 
 */

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/finallocalvariable/InputFinalLocalVariableValidateUnnamedVariablesFalse.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/finallocalvariable/InputFinalLocalVariableValidateUnnamedVariablesFalse.java
@@ -2,6 +2,7 @@
 FinalLocalVariable
 validateUnnamedVariables = (default)false
 validateEnhancedForLoopVariable = true
+validatePatternVariables = (default)false
 tokens = (default)VARIABLE_DEF
 
 */

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/finallocalvariable/InputFinalLocalVariableValidateUnnamedVariablesTrue.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/finallocalvariable/InputFinalLocalVariableValidateUnnamedVariablesTrue.java
@@ -2,6 +2,7 @@
 FinalLocalVariable
 validateUnnamedVariables = true
 validateEnhancedForLoopVariable = true
+validatePatternVariables = (default)false
 tokens = (default)VARIABLE_DEF
 
 */

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/filefilters/beforeexecutionexclusionfilefilter/InputBeforeExecutionExclusionFileFilter.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/filefilters/beforeexecutionexclusionfilefilter/InputBeforeExecutionExclusionFileFilter.java
@@ -6,6 +6,7 @@ fileNamePattern = FileFilter\\.java
 com.puppycrawl.tools.checkstyle.checks.coding.FinalLocalVariableCheck
 validateEnhancedForLoopVariable = (default)false
 validateUnnamedVariables = (default)false
+validatePatternVariables = (default)false
 tokens = (default)VARIABLE_DEF
 
 */

--- a/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/checks/coding/FinalLocalVariableCheckExamplesTest.java
+++ b/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/checks/coding/FinalLocalVariableCheckExamplesTest.java
@@ -87,4 +87,13 @@ public class FinalLocalVariableCheckExamplesTest extends AbstractExamplesModuleT
         verifyWithInlineConfigParser(getPath("Example5.java"), expected);
     }
 
+    @Test
+    public void testExample6() throws Exception {
+        final String[] expected = {
+            "19:29: " + getCheckMessage(MSG_KEY, "p"),
+        };
+
+        verifyWithInlineConfigParser(getPath("Example6.java"), expected);
+    }
+
 }

--- a/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/coding/finallocalvariable/Example6.java
+++ b/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/coding/finallocalvariable/Example6.java
@@ -1,0 +1,30 @@
+/*xml
+<module name="Checker">
+  <module name="TreeWalker">
+    <module name="FinalLocalVariable">
+      <property name="validatePatternVariables" value="true"/>
+    </module>
+  </module>
+</module>
+*/
+
+package com.puppycrawl.tools.checkstyle.checks.coding.finallocalvariable;
+
+// xdoc section -- start
+
+class Example6 {
+  public void method() {
+    final Object o = 45;
+    // violation below, 'Variable 'p' should be declared final'
+    if (o instanceof String p) {
+      System.out.println(p);
+    }
+    if (o instanceof String p) { // ok
+      p = "rewrite";
+      System.out.println(p);
+    }
+    final boolean value = o instanceof String p;
+    // ok above, because p can't be reassigned
+  }
+}
+// xdoc section -- end


### PR DESCRIPTION
Issue: #10970

Added support for pattern variables
https://docs.oracle.com/en/java/javase/18/language/pattern-matching-instanceof-operator.html 

```
    public static boolean bigEnoughRect(Shape s) {
        if (!(s instanceof Rectangle r)) {
            // You cannot use the pattern variable r here because
            // the predicate s instanceof Rectangle is false.
            return false;
        }
        // You can use r here.
        return r.length() > 5; 
    }
```
Beyond scope is supported

no violation will be reported if pattern variable is used for assign
e.g. `final boolean value = o instanceof String p; // ok as variable p can't be used`
