### PR TITLE
Issue #19064: Add third test to XpathRegressionUpperEllTest

### DIFF
--- a/config/checkstyle-non-main-files-suppressions.xml
+++ b/config/checkstyle-non-main-files-suppressions.xml
@@ -412,7 +412,7 @@
 
 <!-- until https://github.com/checkstyle/checkstyle/issues/19064 -->
   <suppress id="numberOfTestCasesInXpath" files="[\\/]src[\\/]it[\\/]java[\\/]org[\\/]checkstyle[\\/]suppressionxpathfilter[\\/]XpathRegressionUncommentedMainTest.java" />
-  <suppress id="numberOfTestCasesInXpath" files="[\\/]src[\\/]it[\\/]java[\\/]org[\\/]checkstyle[\\/]suppressionxpathfilter[\\/]XpathRegressionUpperEllTest.java" />
+ 
   <suppress id="numberOfTestCasesInXpath" files="[\\/]src[\\/]it[\\/]java[\\/]org[\\/]checkstyle[\\/]suppressionxpathfilter[\\/]XpathRegressionArrayTypeStyleTest.java" />
   <suppress id="numberOfTestCasesInXpath" files="[\\/]src[\\/]it[\\/]java[\\/]org[\\/]checkstyle[\\/]suppressionxpathfilter[\\/]XpathRegressionOuterTypeFilenameTest.java" />
   <suppress id="numberOfTestCasesInXpath" files="[\\/]src[\\/]it[\\/]java[\\/]org[\\/]checkstyle[\\/]suppressionxpathfilter[\\/]XpathRegressionTodoCommentTest.java" />

--- a/src/it/java/org/checkstyle/suppressionxpathfilter/XpathRegressionUpperEllTest.java
+++ b/src/it/java/org/checkstyle/suppressionxpathfilter/XpathRegressionUpperEllTest.java
@@ -91,4 +91,32 @@ public class XpathRegressionUpperEllTest extends AbstractXpathTestSupport {
         runVerifications(moduleConfig, fileToProcess, expectedViolation,
                          expectedXpathQueries);
     }
+
+    @Test
+    public void testUpperEllThree() throws Exception {
+        final File fileToProcess =
+            new File(getPath("InputXpathUpperEllThree.java"));
+
+        final DefaultConfiguration moduleConfig =
+            createModuleConfig(UpperEllCheck.class);
+
+        final String[] expectedViolation = {
+            "5:18: " + getCheckMessage(UpperEllCheck.class,
+                                       UpperEllCheck.MSG_KEY),
+        };
+
+        final List<String> expectedXpathQueries = Arrays.asList(
+            "/COMPILATION_UNIT/ENUM_DEF"
+                + "[./IDENT[@text='InputXpathUpperEllThree']]/OBJBLOCK"
+                + "/VARIABLE_DEF[./IDENT[@text='field']]/ASSIGN/EXPR"
+                + "[./NUM_LONG[@text='123l']]",
+            "/COMPILATION_UNIT/ENUM_DEF"
+                + "[./IDENT[@text='InputXpathUpperEllThree']]/OBJBLOCK"
+                + "/VARIABLE_DEF[./IDENT[@text='field']]/ASSIGN/EXPR"
+                + "/NUM_LONG[@text='123l']"
+        );
+
+        runVerifications(moduleConfig, fileToProcess, expectedViolation,
+                         expectedXpathQueries);
+    }
 }

--- a/src/it/resources/org/checkstyle/suppressionxpathfilter/upperell/InputXpathUpperEllThree.java
+++ b/src/it/resources/org/checkstyle/suppressionxpathfilter/upperell/InputXpathUpperEllThree.java
@@ -1,0 +1,6 @@
+package org.checkstyle.suppressionxpathfilter.upperell;
+
+public enum InputXpathUpperEllThree {
+    VALUE;
+    long field = 123l; //warn
+}


### PR DESCRIPTION
Issue: #19064

Added a third test method to `XpathRegressionUpperEllTest` using an `ENUM_DEF` node structure, which differs from the existing `CLASS_DEF` (test one) and `INTERFACE_DEF` (test two) structures.

Removed `XpathRegressionUpperEllTest` from the `numberOfTestCasesInXpath` suppression list.
