### PR TITLE
Issue #19064: Add third test to XpathRegressionArrayTypeStyleTest

### DIFF
--- a/config/checkstyle-non-main-files-suppressions.xml
+++ b/config/checkstyle-non-main-files-suppressions.xml
@@ -412,9 +412,8 @@
 
 <!-- until https://github.com/checkstyle/checkstyle/issues/19064 -->
   <suppress id="numberOfTestCasesInXpath" files="[\\/]src[\\/]it[\\/]java[\\/]org[\\/]checkstyle[\\/]suppressionxpathfilter[\\/]XpathRegressionUncommentedMainTest.java" />
- 
-  <suppress id="numberOfTestCasesInXpath" files="[\\/]src[\\/]it[\\/]java[\\/]org[\\/]checkstyle[\\/]suppressionxpathfilter[\\/]XpathRegressionArrayTypeStyleTest.java" />
- 
+
+  <suppress id="numberOfTestCasesInXpath" files="[\\/]src[\\/]it[\\/]java[\\/]org[\\/]checkstyle[\\/]suppressionxpathfilter[\\/]XpathRegressionOuterTypeFilenameTest.java" />
   <suppress id="numberOfTestCasesInXpath" files="[\\/]src[\\/]it[\\/]java[\\/]org[\\/]checkstyle[\\/]suppressionxpathfilter[\\/]XpathRegressionTodoCommentTest.java" />
   <suppress id="numberOfTestCasesInXpath" files="[\\/]src[\\/]it[\\/]java[\\/]org[\\/]checkstyle[\\/]suppressionxpathfilter[\\/]XpathRegressionTrailingCommentTest.java" />
   <suppress id="numberOfTestCasesInXpath" files="[\\/]src[\\/]it[\\/]java[\\/]org[\\/]checkstyle[\\/]suppressionxpathfilter[\\/]annotation[\\/]XpathRegressionPackageAnnotationTest.java" />

--- a/src/it/java/org/checkstyle/suppressionxpathfilter/XpathRegressionArrayTypeStyleTest.java
+++ b/src/it/java/org/checkstyle/suppressionxpathfilter/XpathRegressionArrayTypeStyleTest.java
@@ -80,4 +80,28 @@ public class XpathRegressionArrayTypeStyleTest extends AbstractXpathTestSupport 
                 expectedXpathQueries);
     }
 
+    @Test
+    public void testParameter() throws Exception {
+        final File fileToProcess =
+                new File(getPath("InputXpathArrayTypeStyleParameter.java"));
+
+        final DefaultConfiguration moduleConfig =
+                createModuleConfig(ArrayTypeStyleCheck.class);
+
+        final String[] expectedViolation = {
+            "4:28: " + getCheckMessage(ArrayTypeStyleCheck.class, ArrayTypeStyleCheck.MSG_KEY),
+        };
+
+        final List<String> expectedXpathQueries = Collections.singletonList(
+            "/COMPILATION_UNIT/CLASS_DEF"
+                    + "[./IDENT[@text='InputXpathArrayTypeStyleParameter']]"
+                    + "/OBJBLOCK/METHOD_DEF[./IDENT[@text='method']]"
+                    + "/PARAMETERS/PARAMETER_DEF[./IDENT[@text='args']]"
+                    + "/TYPE[./IDENT[@text='String']]/ARRAY_DECLARATOR"
+        );
+
+        runVerifications(moduleConfig, fileToProcess, expectedViolation,
+                expectedXpathQueries);
+    }
+
 }

--- a/src/it/resources/org/checkstyle/suppressionxpathfilter/arraytypestyle/InputXpathArrayTypeStyleParameter.java
+++ b/src/it/resources/org/checkstyle/suppressionxpathfilter/arraytypestyle/InputXpathArrayTypeStyleParameter.java
@@ -1,0 +1,6 @@
+package org.checkstyle.suppressionxpathfilter.arraytypestyle;
+
+public class InputXpathArrayTypeStyleParameter {
+    void method(String args[]) { // warn
+    }
+}


### PR DESCRIPTION
Issue: #19064

Added a third test method to `XpathRegressionArrayTypeStyleTest` using a `PARAMETER_DEF` node structure, which differs from the existing `VARIABLE_DEF` (test one) and `METHOD_DEF` return type (test two) structures.

Removed `XpathRegressionArrayTypeStyleTest` from the `numberOfTestCasesInXpath` suppression list.
