### PR TITLE
Issue #19064: add testMemberNameEnum to XpathRegressionMemberNameTest

### DIFF
--- a/src/it/java/org/checkstyle/suppressionxpathfilter/naming/XpathRegressionMemberNameTest.java
+++ b/src/it/java/org/checkstyle/suppressionxpathfilter/naming/XpathRegressionMemberNameTest.java
@@ -96,4 +96,27 @@ public class XpathRegressionMemberNameTest extends AbstractXpathTestSupport {
                 expectedXpathQueries);
     }
 
+    @Test
+    public void testMemberNameEnum() throws Exception {
+        final File fileToProcess =
+                new File(getPath("InputXpathMemberNameEnum.java"));
+
+        final String pattern = "^[a-z][a-zA-Z0-9]*$";
+        final DefaultConfiguration moduleConfig =
+                createModuleConfig(MemberNameCheck.class);
+
+        final String[] expectedViolation = {
+            "5:16: " + getCheckMessage(MemberNameCheck.class,
+                        AbstractNameCheck.MSG_INVALID_PATTERN, "NUM3", pattern),
+        };
+
+        final List<String> expectedXpathQueries = Collections.singletonList(
+                "/COMPILATION_UNIT"
+                        + "/ENUM_DEF[./IDENT[@text='InputXpathMemberNameEnum']]"
+                        + "/OBJBLOCK/VARIABLE_DEF/IDENT[@text='NUM3']"
+        );
+        runVerifications(moduleConfig, fileToProcess, expectedViolation,
+                expectedXpathQueries);
+    }
+
 }

--- a/src/it/resources/org/checkstyle/suppressionxpathfilter/naming/membername/InputXpathMemberNameEnum.java
+++ b/src/it/resources/org/checkstyle/suppressionxpathfilter/naming/membername/InputXpathMemberNameEnum.java
@@ -1,0 +1,6 @@
+package org.checkstyle.suppressionxpathfilter.naming.membername;
+
+public enum InputXpathMemberNameEnum {
+    INSTANCE;
+    public int NUM3; // warn
+}


### PR DESCRIPTION
  XpathRegressionMemberNameTest

# Part of issue#19064

Update XpathRegressionMemberNameTest  3rd test case with different Xpath node structure

src/it/resources/org/checkstyle/suppressionxpathfilter/naming/membername/InputXpathMemberNameEnum.java 
