### PR TITLE
Issue #19064: Add third test to XpathRegressionOuterTypeFilenameTest

### DIFF
--- a/config/checkstyle-non-main-files-suppressions.xml
+++ b/config/checkstyle-non-main-files-suppressions.xml
@@ -414,7 +414,7 @@
   <suppress id="numberOfTestCasesInXpath" files="[\\/]src[\\/]it[\\/]java[\\/]org[\\/]checkstyle[\\/]suppressionxpathfilter[\\/]XpathRegressionUncommentedMainTest.java" />
   <suppress id="numberOfTestCasesInXpath" files="[\\/]src[\\/]it[\\/]java[\\/]org[\\/]checkstyle[\\/]suppressionxpathfilter[\\/]XpathRegressionUpperEllTest.java" />
   <suppress id="numberOfTestCasesInXpath" files="[\\/]src[\\/]it[\\/]java[\\/]org[\\/]checkstyle[\\/]suppressionxpathfilter[\\/]XpathRegressionArrayTypeStyleTest.java" />
-  <suppress id="numberOfTestCasesInXpath" files="[\\/]src[\\/]it[\\/]java[\\/]org[\\/]checkstyle[\\/]suppressionxpathfilter[\\/]XpathRegressionOuterTypeFilenameTest.java" />
+ 
   <suppress id="numberOfTestCasesInXpath" files="[\\/]src[\\/]it[\\/]java[\\/]org[\\/]checkstyle[\\/]suppressionxpathfilter[\\/]XpathRegressionTodoCommentTest.java" />
   <suppress id="numberOfTestCasesInXpath" files="[\\/]src[\\/]it[\\/]java[\\/]org[\\/]checkstyle[\\/]suppressionxpathfilter[\\/]XpathRegressionTrailingCommentTest.java" />
   <suppress id="numberOfTestCasesInXpath" files="[\\/]src[\\/]it[\\/]java[\\/]org[\\/]checkstyle[\\/]suppressionxpathfilter[\\/]annotation[\\/]XpathRegressionPackageAnnotationTest.java" />

--- a/src/it/java/org/checkstyle/suppressionxpathfilter/XpathRegressionOuterTypeFilenameTest.java
+++ b/src/it/java/org/checkstyle/suppressionxpathfilter/XpathRegressionOuterTypeFilenameTest.java
@@ -83,4 +83,29 @@ public class XpathRegressionOuterTypeFilenameTest extends AbstractXpathTestSuppo
                 expectedXpathQueries);
     }
 
+    @Test
+    public void testInterface() throws Exception {
+        final File fileToProcess = new File(getPath(
+                "InputXpathOuterTypeFilenameThree.java"));
+
+        final DefaultConfiguration moduleConfig =
+                createModuleConfig(OuterTypeFilenameCheck.class);
+
+        final String[] expectedViolation = {
+            "3:1: " + getCheckMessage(OuterTypeFilenameCheck.class,
+                    OuterTypeFilenameCheck.MSG_KEY),
+        };
+
+        final List<String> expectedXpathQueries = Arrays.asList(
+                "/COMPILATION_UNIT/INTERFACE_DEF[./IDENT[@text='MyInterface']]",
+                "/COMPILATION_UNIT/INTERFACE_DEF[./IDENT[@text='MyInterface']]"
+                    + "/MODIFIERS",
+                "/COMPILATION_UNIT/INTERFACE_DEF[./IDENT[@text='MyInterface']]"
+                    + "/LITERAL_INTERFACE"
+        );
+
+        runVerifications(moduleConfig, fileToProcess, expectedViolation,
+                expectedXpathQueries);
+    }
+
 }

--- a/src/it/resources/org/checkstyle/suppressionxpathfilter/outertypefilename/InputXpathOuterTypeFilenameThree.java
+++ b/src/it/resources/org/checkstyle/suppressionxpathfilter/outertypefilename/InputXpathOuterTypeFilenameThree.java
@@ -1,0 +1,4 @@
+package org.checkstyle.suppressionxpathfilter.outertypefilename;
+
+interface MyInterface { // warn
+}


### PR DESCRIPTION
Issue: #19064

Added a third test method to `XpathRegressionOuterTypeFilenameTest` using an `INTERFACE_DEF` node structure, which differs from the existing two tests that both use `CLASS_DEF`.

Removed `XpathRegressionOuterTypeFilenameTest` from the `numberOfTestCasesInXpath` suppression list.
