### PR TITLE
Issue #19064: Add third test to XpathRegressionUncommentedMainTest

### DIFF
--- a/config/checkstyle-non-main-files-suppressions.xml
+++ b/config/checkstyle-non-main-files-suppressions.xml
@@ -411,7 +411,6 @@
             files="src[\\/]site[\\/]xdoc[\\/]checks[\\/][a-z]+\.xml"/>
 
 <!-- until https://github.com/checkstyle/checkstyle/issues/19064 -->
-  <suppress id="numberOfTestCasesInXpath" files="[\\/]src[\\/]it[\\/]java[\\/]org[\\/]checkstyle[\\/]suppressionxpathfilter[\\/]XpathRegressionUncommentedMainTest.java" />
 
   <suppress id="numberOfTestCasesInXpath" files="[\\/]src[\\/]it[\\/]java[\\/]org[\\/]checkstyle[\\/]suppressionxpathfilter[\\/]XpathRegressionOuterTypeFilenameTest.java" />
   <suppress id="numberOfTestCasesInXpath" files="[\\/]src[\\/]it[\\/]java[\\/]org[\\/]checkstyle[\\/]suppressionxpathfilter[\\/]XpathRegressionTodoCommentTest.java" />

--- a/src/it/java/org/checkstyle/suppressionxpathfilter/XpathRegressionUncommentedMainTest.java
+++ b/src/it/java/org/checkstyle/suppressionxpathfilter/XpathRegressionUncommentedMainTest.java
@@ -98,4 +98,33 @@ public class XpathRegressionUncommentedMainTest extends AbstractXpathTestSupport
         runVerifications(moduleConfig, fileToProcess, expectedViolation,
                 expectedXpathQueries);
     }
+
+    @Test
+    public void testInRecord() throws Exception {
+        final File fileToProcess =
+                new File(getPath("InputXpathUncommentedMainInRecord.java"));
+
+        final DefaultConfiguration moduleConfig =
+                createModuleConfig(UncommentedMainCheck.class);
+
+        final String[] expectedViolation = {
+            "4:5: " + getCheckMessage(UncommentedMainCheck.class,
+                        UncommentedMainCheck.MSG_KEY),
+        };
+
+        final List<String> expectedXpathQueries = Arrays.asList(
+                "/COMPILATION_UNIT/RECORD_DEF"
+                        + "[./IDENT[@text='InputXpathUncommentedMainInRecord']]"
+                        + "/OBJBLOCK/METHOD_DEF[./IDENT[@text='main']]",
+                "/COMPILATION_UNIT/RECORD_DEF"
+                        + "[./IDENT[@text='InputXpathUncommentedMainInRecord']]"
+                        + "/OBJBLOCK/METHOD_DEF[./IDENT[@text='main']]/MODIFIERS",
+                "/COMPILATION_UNIT/RECORD_DEF"
+                        + "[./IDENT[@text='InputXpathUncommentedMainInRecord']]"
+                        + "/OBJBLOCK/METHOD_DEF[./IDENT[@text='main']]/MODIFIERS/LITERAL_PUBLIC"
+        );
+
+        runVerifications(moduleConfig, fileToProcess, expectedViolation,
+                expectedXpathQueries);
+    }
 }

--- a/src/it/resources/org/checkstyle/suppressionxpathfilter/uncommentedmain/InputXpathUncommentedMainInRecord.java
+++ b/src/it/resources/org/checkstyle/suppressionxpathfilter/uncommentedmain/InputXpathUncommentedMainInRecord.java
@@ -1,0 +1,6 @@
+package org.checkstyle.suppressionxpathfilter.uncommentedmain;
+
+public record InputXpathUncommentedMainInRecord() {
+    public static void main(String[] args) { //warn
+    }
+}


### PR DESCRIPTION
Issue: #19064

Added a third test method to `XpathRegressionUncommentedMainTest` using a `RECORD_DEF` node structure, which differs from the existing `CLASS_DEF` (test one) and nested `CLASS_DEF` (test two) structures.

Removed `XpathRegressionUncommentedMainTest` from the `numberOfTestCasesInXpath` suppression list.
