### PR TITLE
Issue #19064: Add third test to XpathRegressionTodoCommentTest

### DIFF
--- a/config/checkstyle-non-main-files-suppressions.xml
+++ b/config/checkstyle-non-main-files-suppressions.xml
@@ -414,7 +414,7 @@
   <suppress id="numberOfTestCasesInXpath" files="[\\/]src[\\/]it[\\/]java[\\/]org[\\/]checkstyle[\\/]suppressionxpathfilter[\\/]XpathRegressionUncommentedMainTest.java" />
 
   <suppress id="numberOfTestCasesInXpath" files="[\\/]src[\\/]it[\\/]java[\\/]org[\\/]checkstyle[\\/]suppressionxpathfilter[\\/]XpathRegressionOuterTypeFilenameTest.java" />
-  <suppress id="numberOfTestCasesInXpath" files="[\\/]src[\\/]it[\\/]java[\\/]org[\\/]checkstyle[\\/]suppressionxpathfilter[\\/]XpathRegressionTodoCommentTest.java" />
+
   <suppress id="numberOfTestCasesInXpath" files="[\\/]src[\\/]it[\\/]java[\\/]org[\\/]checkstyle[\\/]suppressionxpathfilter[\\/]XpathRegressionTrailingCommentTest.java" />
   <suppress id="numberOfTestCasesInXpath" files="[\\/]src[\\/]it[\\/]java[\\/]org[\\/]checkstyle[\\/]suppressionxpathfilter[\\/]annotation[\\/]XpathRegressionPackageAnnotationTest.java" />
   <suppress id="numberOfTestCasesInXpath" files="[\\/]src[\\/]it[\\/]java[\\/]org[\\/]checkstyle[\\/]suppressionxpathfilter[\\/]blocks[\\/]XpathRegressionEmptyBlockTest.java" />

--- a/src/it/java/org/checkstyle/suppressionxpathfilter/XpathRegressionTodoCommentTest.java
+++ b/src/it/java/org/checkstyle/suppressionxpathfilter/XpathRegressionTodoCommentTest.java
@@ -83,4 +83,28 @@ public class XpathRegressionTodoCommentTest extends AbstractXpathTestSupport {
         runVerifications(moduleConfig, fileToProcess, expectedViolation,
                 expectedXpathQueries);
     }
+
+    @Test
+    public void testInsideMethod() throws Exception {
+        final File fileToProcess =
+                new File(getPath("InputXpathTodoCommentInsideMethod.java"));
+
+        final DefaultConfiguration moduleConfig =
+                createModuleConfig(TodoCommentCheck.class);
+        moduleConfig.addProperty("format", "FIXME:");
+
+        final String[] expectedViolation = {
+            "5:11: " + getCheckMessage(TodoCommentCheck.class, MSG_KEY, "FIXME:"),
+        };
+
+        final List<String> expectedXpathQueries = Collections.singletonList(
+                "/COMPILATION_UNIT/CLASS_DEF[./IDENT[@text="
+                        + "'InputXpathTodoCommentInsideMethod']]/OBJBLOCK/"
+                        + "METHOD_DEF[./IDENT[@text='method']]/SLIST/"
+                        + "SINGLE_LINE_COMMENT/COMMENT_CONTENT[@text=' FIXME: //warn\\n']"
+        );
+
+        runVerifications(moduleConfig, fileToProcess, expectedViolation,
+                expectedXpathQueries);
+    }
 }

--- a/src/it/resources/org/checkstyle/suppressionxpathfilter/todocomment/InputXpathTodoCommentInsideMethod.java
+++ b/src/it/resources/org/checkstyle/suppressionxpathfilter/todocomment/InputXpathTodoCommentInsideMethod.java
@@ -1,0 +1,7 @@
+package org.checkstyle.suppressionxpathfilter.todocomment;
+
+public class InputXpathTodoCommentInsideMethod {
+    void method() {
+        // FIXME: //warn
+    }
+}


### PR DESCRIPTION
Issue: #19064

Added a third test method to `XpathRegressionTodoCommentTest` with a FIXME comment inside a `METHOD_DEF/SLIST`, which differs from the existing tests that place comments directly inside `CLASS_DEF/OBJBLOCK` (single-line in test one, block comment in test two).

Removed `XpathRegressionTodoCommentTest` from the `numberOfTestCasesInXpath` suppression list.
