### PR TITLE
Issue #19064: Add third test to XpathRegressionNoFinalizerTest

### DIFF
--- a/config/checkstyle-non-main-files-suppressions.xml
+++ b/config/checkstyle-non-main-files-suppressions.xml
@@ -445,7 +445,7 @@
   <suppress id="numberOfTestCasesInXpath" files="[\\/]src[\\/]it[\\/]java[\\/]org[\\/]checkstyle[\\/]suppressionxpathfilter[\\/]coding[\\/]XpathRegressionNoArrayTrailingCommaTest.java" />
   <suppress id="numberOfTestCasesInXpath" files="[\\/]src[\\/]it[\\/]java[\\/]org[\\/]checkstyle[\\/]suppressionxpathfilter[\\/]coding[\\/]XpathRegressionNoCloneTest.java" />
   <suppress id="numberOfTestCasesInXpath" files="[\\/]src[\\/]it[\\/]java[\\/]org[\\/]checkstyle[\\/]suppressionxpathfilter[\\/]coding[\\/]XpathRegressionNoEnumTrailingCommaTest.java" />
-  <suppress id="numberOfTestCasesInXpath" files="[\\/]src[\\/]it[\\/]java[\\/]org[\\/]checkstyle[\\/]suppressionxpathfilter[\\/]coding[\\/]XpathRegressionNoFinalizerTest.java" />
+ 
   <suppress id="numberOfTestCasesInXpath" files="[\\/]src[\\/]it[\\/]java[\\/]org[\\/]checkstyle[\\/]suppressionxpathfilter[\\/]coding[\\/]XpathRegressionOneStatementPerLineTest.java" />
   <suppress id="numberOfTestCasesInXpath" files="[\\/]src[\\/]it[\\/]java[\\/]org[\\/]checkstyle[\\/]suppressionxpathfilter[\\/]coding[\\/]XpathRegressionOverloadMethodsDeclarationOrderTest.java" />
   <suppress id="numberOfTestCasesInXpath" files="[\\/]src[\\/]it[\\/]java[\\/]org[\\/]checkstyle[\\/]suppressionxpathfilter[\\/]coding[\\/]XpathRegressionPackageDeclarationTest.java" />

--- a/src/it/java/org/checkstyle/suppressionxpathfilter/coding/XpathRegressionNoFinalizerTest.java
+++ b/src/it/java/org/checkstyle/suppressionxpathfilter/coding/XpathRegressionNoFinalizerTest.java
@@ -108,4 +108,36 @@ public class XpathRegressionNoFinalizerTest extends AbstractXpathTestSupport {
                 expectedXpathQueries);
     }
 
+    @Test
+    public void testInEnum() throws Exception {
+        final File fileToProcess = new File(
+                getPath("InputXpathNoFinalizerInEnum.java"));
+
+        final DefaultConfiguration moduleConfig =
+                createModuleConfig(NoFinalizerCheck.class);
+
+        final String[] expectedViolation = {
+            "5:9: " + getCheckMessage(NoFinalizerCheck.class,
+                    NoFinalizerCheck.MSG_KEY),
+        };
+
+        final List<String> expectedXpathQueries = Arrays.asList(
+                "/COMPILATION_UNIT/INTERFACE_DEF"
+                + "[./IDENT[@text='InputXpathNoFinalizerInEnum']]"
+                + "/OBJBLOCK/CLASS_DEF[./IDENT[@text='InnerClass']]/OBJBLOCK"
+                + "/METHOD_DEF[./IDENT[@text='finalize']]",
+                "/COMPILATION_UNIT/INTERFACE_DEF"
+                + "[./IDENT[@text='InputXpathNoFinalizerInEnum']]"
+                + "/OBJBLOCK/CLASS_DEF[./IDENT[@text='InnerClass']]/OBJBLOCK"
+                + "/METHOD_DEF[./IDENT[@text='finalize']]/MODIFIERS",
+                "/COMPILATION_UNIT/INTERFACE_DEF"
+                + "[./IDENT[@text='InputXpathNoFinalizerInEnum']]"
+                + "/OBJBLOCK/CLASS_DEF[./IDENT[@text='InnerClass']]/OBJBLOCK"
+                + "/METHOD_DEF[./IDENT[@text='finalize']]/MODIFIERS/LITERAL_PROTECTED"
+        );
+
+        runVerifications(moduleConfig, fileToProcess, expectedViolation,
+                expectedXpathQueries);
+    }
+
 }

--- a/src/it/resources/org/checkstyle/suppressionxpathfilter/coding/nofinalizer/InputXpathNoFinalizerInEnum.java
+++ b/src/it/resources/org/checkstyle/suppressionxpathfilter/coding/nofinalizer/InputXpathNoFinalizerInEnum.java
@@ -1,0 +1,8 @@
+package org.checkstyle.suppressionxpathfilter.coding.nofinalizer;
+
+public interface InputXpathNoFinalizerInEnum {
+    class InnerClass {
+        protected void finalize() throws Throwable { // warn
+        }
+    }
+}


### PR DESCRIPTION
Issue: #19064

Added a third test method to `XpathRegressionNoFinalizerTest` using an `ENUM_DEF` node structure, which differs from the existing `CLASS_DEF` (test one) and nested `CLASS_DEF` (test two) structures.

Removed `XpathRegressionNoFinalizerTest` from the `numberOfTestCasesInXpath` suppression list.
