### PR TITLE
Issue #19064: Add third test to XpathRegressionIllegalTokenTest

### DIFF
--- a/config/checkstyle-non-main-files-suppressions.xml
+++ b/config/checkstyle-non-main-files-suppressions.xml
@@ -432,7 +432,7 @@
   <suppress id="numberOfTestCasesInXpath" files="[\\/]src[\\/]it[\\/]java[\\/]org[\\/]checkstyle[\\/]suppressionxpathfilter[\\/]coding[\\/]XpathRegressionHiddenFieldTest.java" />
   <suppress id="numberOfTestCasesInXpath" files="[\\/]src[\\/]it[\\/]java[\\/]org[\\/]checkstyle[\\/]suppressionxpathfilter[\\/]coding[\\/]XpathRegressionIllegalCatchTest.java" />
   <suppress id="numberOfTestCasesInXpath" files="[\\/]src[\\/]it[\\/]java[\\/]org[\\/]checkstyle[\\/]suppressionxpathfilter[\\/]coding[\\/]XpathRegressionIllegalThrowsTest.java" />
-  <suppress id="numberOfTestCasesInXpath" files="[\\/]src[\\/]it[\\/]java[\\/]org[\\/]checkstyle[\\/]suppressionxpathfilter[\\/]coding[\\/]XpathRegressionIllegalTokenTest.java" />
+ 
   <suppress id="numberOfTestCasesInXpath" files="[\\/]src[\\/]it[\\/]java[\\/]org[\\/]checkstyle[\\/]suppressionxpathfilter[\\/]coding[\\/]XpathRegressionIllegalTypeTest.java" />
   <suppress id="numberOfTestCasesInXpath" files="[\\/]src[\\/]it[\\/]java[\\/]org[\\/]checkstyle[\\/]suppressionxpathfilter[\\/]coding[\\/]XpathRegressionInnerAssignmentTest.java" />
   <suppress id="numberOfTestCasesInXpath" files="[\\/]src[\\/]it[\\/]java[\\/]org[\\/]checkstyle[\\/]suppressionxpathfilter[\\/]coding[\\/]XpathRegressionMissingCtorTest.java" />

--- a/src/it/java/org/checkstyle/suppressionxpathfilter/coding/XpathRegressionIllegalTokenTest.java
+++ b/src/it/java/org/checkstyle/suppressionxpathfilter/coding/XpathRegressionIllegalTokenTest.java
@@ -20,6 +20,7 @@
 package org.checkstyle.suppressionxpathfilter.coding;
 
 import java.io.File;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 
@@ -82,6 +83,34 @@ public class XpathRegressionIllegalTokenTest extends AbstractXpathTestSupport {
                         + "/CLASS_DEF[./IDENT[@text='InputXpathIllegalTokenNative']]"
                         + "/OBJBLOCK/METHOD_DEF[./IDENT[@text='myTest']]"
                         + "/MODIFIERS/LITERAL_NATIVE"
+        );
+
+        runVerifications(moduleConfig, fileToProcess, expectedViolation,
+                expectedXpathQueries);
+    }
+
+    @Test
+    public void testPostIncrement() throws Exception {
+        final File fileToProcess =
+                new File(getPath("InputXpathIllegalTokenPostIncrement.java"));
+        final DefaultConfiguration moduleConfig =
+                createModuleConfig(IllegalTokenCheck.class);
+
+        moduleConfig.addProperty("tokens", "POST_INC");
+
+        final String[] expectedViolation = {
+            "8:10: " + getCheckMessage(IllegalTokenCheck.class,
+                        IllegalTokenCheck.MSG_KEY, "++"),
+        };
+        final List<String> expectedXpathQueries = Arrays.asList(
+                "/COMPILATION_UNIT"
+                        + "/ENUM_DEF[./IDENT[@text='InputXpathIllegalTokenPostIncrement']]"
+                        + "/OBJBLOCK/METHOD_DEF[./IDENT[@text='method']]"
+                        + "/SLIST/EXPR",
+                "/COMPILATION_UNIT"
+                        + "/ENUM_DEF[./IDENT[@text='InputXpathIllegalTokenPostIncrement']]"
+                        + "/OBJBLOCK/METHOD_DEF[./IDENT[@text='method']]"
+                        + "/SLIST/EXPR/POST_INC[./IDENT[@text='i']]"
         );
 
         runVerifications(moduleConfig, fileToProcess, expectedViolation,

--- a/src/it/resources/org/checkstyle/suppressionxpathfilter/coding/illegaltoken/InputXpathIllegalTokenPostIncrement.java
+++ b/src/it/resources/org/checkstyle/suppressionxpathfilter/coding/illegaltoken/InputXpathIllegalTokenPostIncrement.java
@@ -1,0 +1,10 @@
+package org.checkstyle.suppressionxpathfilter.coding.illegaltoken;
+
+public enum InputXpathIllegalTokenPostIncrement {
+    VALUE;
+
+    void method() {
+        int i = 0;
+        i++; // warn
+    }
+}


### PR DESCRIPTION
Issue: #19064

Added a third test method to `XpathRegressionIllegalTokenTest` using an `ENUM_DEF` with a `POST_INC` token, which differs from the existing `LABELED_STAT` (test one) and `LITERAL_NATIVE` (test two) structures.

Removed `XpathRegressionIllegalTokenTest` from the `numberOfTestCasesInXpath` suppression list.
