### PR TITLE
Issue #19064: Add third test to XpathRegressionNoCloneTest

### DIFF
--- a/config/checkstyle-non-main-files-suppressions.xml
+++ b/config/checkstyle-non-main-files-suppressions.xml
@@ -442,7 +442,7 @@
   <suppress id="numberOfTestCasesInXpath" files="[\\/]src[\\/]it[\\/]java[\\/]org[\\/]checkstyle[\\/]suppressionxpathfilter[\\/]coding[\\/]XpathRegressionNestedIfDepthTest.java" />
   <suppress id="numberOfTestCasesInXpath" files="[\\/]src[\\/]it[\\/]java[\\/]org[\\/]checkstyle[\\/]suppressionxpathfilter[\\/]coding[\\/]XpathRegressionNestedTryDepthTest.java" />
   <suppress id="numberOfTestCasesInXpath" files="[\\/]src[\\/]it[\\/]java[\\/]org[\\/]checkstyle[\\/]suppressionxpathfilter[\\/]coding[\\/]XpathRegressionNoArrayTrailingCommaTest.java" />
-  <suppress id="numberOfTestCasesInXpath" files="[\\/]src[\\/]it[\\/]java[\\/]org[\\/]checkstyle[\\/]suppressionxpathfilter[\\/]coding[\\/]XpathRegressionNoCloneTest.java" />
+ 
   <suppress id="numberOfTestCasesInXpath" files="[\\/]src[\\/]it[\\/]java[\\/]org[\\/]checkstyle[\\/]suppressionxpathfilter[\\/]coding[\\/]XpathRegressionNoEnumTrailingCommaTest.java" />
  
   <suppress id="numberOfTestCasesInXpath" files="[\\/]src[\\/]it[\\/]java[\\/]org[\\/]checkstyle[\\/]suppressionxpathfilter[\\/]coding[\\/]XpathRegressionOneStatementPerLineTest.java" />

--- a/src/it/java/org/checkstyle/suppressionxpathfilter/coding/XpathRegressionNoCloneTest.java
+++ b/src/it/java/org/checkstyle/suppressionxpathfilter/coding/XpathRegressionNoCloneTest.java
@@ -101,4 +101,35 @@ public class XpathRegressionNoCloneTest extends AbstractXpathTestSupport {
         runVerifications(moduleConfig, fileToProcess, expectedViolation,
                 expectedXpathQueries);
     }
+
+    @Test
+    public void testInEnum() throws Exception {
+        final File fileToProcess =
+                new File(getPath("InputXpathNoCloneInEnum.java"));
+
+        final DefaultConfiguration moduleConfig =
+                createModuleConfig(NoCloneCheck.class);
+
+        final String[] expectedViolation = {
+            "8:9: " + getCheckMessage(NoCloneCheck.class, NoCloneCheck.MSG_KEY),
+        };
+
+        final List<String> expectedXpathQueries = Arrays.asList(
+                "/COMPILATION_UNIT/ENUM_DEF"
+                    + "[./IDENT[@text='InputXpathNoCloneInEnum']]/OBJBLOCK"
+                    + "/CLASS_DEF[./IDENT[@text='InnerClass']]/OBJBLOCK"
+                    + "/METHOD_DEF[./IDENT[@text='clone']]",
+                "/COMPILATION_UNIT/ENUM_DEF"
+                    + "[./IDENT[@text='InputXpathNoCloneInEnum']]/OBJBLOCK"
+                    + "/CLASS_DEF[./IDENT[@text='InnerClass']]/OBJBLOCK"
+                    + "/METHOD_DEF[./IDENT[@text='clone']]/MODIFIERS",
+                "/COMPILATION_UNIT/ENUM_DEF"
+                    + "[./IDENT[@text='InputXpathNoCloneInEnum']]/OBJBLOCK"
+                    + "/CLASS_DEF[./IDENT[@text='InnerClass']]/OBJBLOCK"
+                    + "/METHOD_DEF[./IDENT[@text='clone']]/MODIFIERS/LITERAL_PUBLIC"
+        );
+
+        runVerifications(moduleConfig, fileToProcess, expectedViolation,
+                expectedXpathQueries);
+    }
 }

--- a/src/it/resources/org/checkstyle/suppressionxpathfilter/coding/noclone/InputXpathNoCloneInEnum.java
+++ b/src/it/resources/org/checkstyle/suppressionxpathfilter/coding/noclone/InputXpathNoCloneInEnum.java
@@ -1,0 +1,11 @@
+package org.checkstyle.suppressionxpathfilter.coding.noclone;
+
+public enum InputXpathNoCloneInEnum {
+
+    INSTANCE;
+
+    class InnerClass {
+        public Object clone() { return null; } // warn
+    }
+
+}


### PR DESCRIPTION
Issue: #19064

Added a third test method to `XpathRegressionNoCloneTest` using an `ENUM_DEF` node structure, which differs from the existing `CLASS_DEF` (test one) and nested `CLASS_DEF` (test two) structures.

Removed `XpathRegressionNoCloneTest` from the `numberOfTestCasesInXpath` suppression list.
