### PR TITLE
Issue #19064: Add third test to XpathRegressionEmptyStatementTest

### DIFF
--- a/config/checkstyle-non-main-files-suppressions.xml
+++ b/config/checkstyle-non-main-files-suppressions.xml
@@ -425,7 +425,7 @@
   <suppress id="numberOfTestCasesInXpath" files="[\\/]src[\\/]it[\\/]java[\\/]org[\\/]checkstyle[\\/]suppressionxpathfilter[\\/]coding[\\/]XpathRegressionAvoidNoArgumentSuperConstructorCallTest.java" />
   <suppress id="numberOfTestCasesInXpath" files="[\\/]src[\\/]it[\\/]java[\\/]org[\\/]checkstyle[\\/]suppressionxpathfilter[\\/]coding[\\/]XpathRegressionDeclarationOrderTest.java" />
   <suppress id="numberOfTestCasesInXpath" files="[\\/]src[\\/]it[\\/]java[\\/]org[\\/]checkstyle[\\/]suppressionxpathfilter[\\/]coding[\\/]XpathRegressionDefaultComesLastTest.java" />
-  <suppress id="numberOfTestCasesInXpath" files="[\\/]src[\\/]it[\\/]java[\\/]org[\\/]checkstyle[\\/]suppressionxpathfilter[\\/]coding[\\/]XpathRegressionEmptyStatementTest.java" />
+ 
   <suppress id="numberOfTestCasesInXpath" files="[\\/]src[\\/]it[\\/]java[\\/]org[\\/]checkstyle[\\/]suppressionxpathfilter[\\/]coding[\\/]XpathRegressionEqualsAvoidNullTest.java" />
   <suppress id="numberOfTestCasesInXpath" files="[\\/]src[\\/]it[\\/]java[\\/]org[\\/]checkstyle[\\/]suppressionxpathfilter[\\/]coding[\\/]XpathRegressionExplicitInitializationTest.java" />
   <suppress id="numberOfTestCasesInXpath" files="[\\/]src[\\/]it[\\/]java[\\/]org[\\/]checkstyle[\\/]suppressionxpathfilter[\\/]coding[\\/]XpathRegressionFallThroughTest.java" />

--- a/src/it/java/org/checkstyle/suppressionxpathfilter/coding/XpathRegressionEmptyStatementTest.java
+++ b/src/it/java/org/checkstyle/suppressionxpathfilter/coding/XpathRegressionEmptyStatementTest.java
@@ -80,4 +80,23 @@ public class XpathRegressionEmptyStatementTest extends AbstractXpathTestSupport 
         runVerifications(moduleConfig, fileToProcess, expectedViolation,
                 expectedXpathQueries);
     }
+
+    @Test
+    public void testWhileLoopEmptyStatement() throws Exception {
+        final File fileToProcess =
+                new File(getPath("InputXpathEmptyStatementWhile.java"));
+        final DefaultConfiguration moduleConfig =
+                createModuleConfig(EmptyStatementCheck.class);
+        final String[] expectedViolation = {
+            "5:21: " + getCheckMessage(EmptyStatementCheck.class, EmptyStatementCheck.MSG_KEY),
+        };
+        final List<String> expectedXpathQueries = Collections.singletonList(
+                "/COMPILATION_UNIT"
+                        + "/CLASS_DEF[./IDENT[@text='InputXpathEmptyStatementWhile']]"
+                        + "/OBJBLOCK/METHOD_DEF[./IDENT[@text='foo']]"
+                        + "/SLIST/LITERAL_WHILE/EMPTY_STAT"
+        );
+        runVerifications(moduleConfig, fileToProcess, expectedViolation,
+                expectedXpathQueries);
+    }
 }

--- a/src/it/resources/org/checkstyle/suppressionxpathfilter/coding/emptystatement/InputXpathEmptyStatementWhile.java
+++ b/src/it/resources/org/checkstyle/suppressionxpathfilter/coding/emptystatement/InputXpathEmptyStatementWhile.java
@@ -1,0 +1,7 @@
+package org.checkstyle.suppressionxpathfilter.coding.emptystatement;
+
+public class InputXpathEmptyStatementWhile {
+    public void foo() {
+        while (true); // warn
+    }
+}


### PR DESCRIPTION
Issue: #19064

Added a third test method to `XpathRegressionEmptyStatementTest` using a `LITERAL_WHILE/EMPTY_STAT` node structure, which differs from the existing `LITERAL_FOR/EMPTY_STAT` (test one) and `LITERAL_IF/EMPTY_STAT` (test two) structures.

Removed `XpathRegressionEmptyStatementTest` from the `numberOfTestCasesInXpath` suppression list.
