### PR TITLE
Issue #19064: Add third test to XpathRegressionIllegalCatchTest

### DIFF
--- a/config/checkstyle-non-main-files-suppressions.xml
+++ b/config/checkstyle-non-main-files-suppressions.xml
@@ -428,7 +428,6 @@
   <suppress id="numberOfTestCasesInXpath" files="[\\/]src[\\/]it[\\/]java[\\/]org[\\/]checkstyle[\\/]suppressionxpathfilter[\\/]coding[\\/]XpathRegressionExplicitInitializationTest.java" />
   <suppress id="numberOfTestCasesInXpath" files="[\\/]src[\\/]it[\\/]java[\\/]org[\\/]checkstyle[\\/]suppressionxpathfilter[\\/]coding[\\/]XpathRegressionFallThroughTest.java" />
   <suppress id="numberOfTestCasesInXpath" files="[\\/]src[\\/]it[\\/]java[\\/]org[\\/]checkstyle[\\/]suppressionxpathfilter[\\/]coding[\\/]XpathRegressionHiddenFieldTest.java" />
-  <suppress id="numberOfTestCasesInXpath" files="[\\/]src[\\/]it[\\/]java[\\/]org[\\/]checkstyle[\\/]suppressionxpathfilter[\\/]coding[\\/]XpathRegressionIllegalCatchTest.java" />
   <suppress id="numberOfTestCasesInXpath" files="[\\/]src[\\/]it[\\/]java[\\/]org[\\/]checkstyle[\\/]suppressionxpathfilter[\\/]coding[\\/]XpathRegressionIllegalThrowsTest.java" />
   <suppress id="numberOfTestCasesInXpath" files="[\\/]src[\\/]it[\\/]java[\\/]org[\\/]checkstyle[\\/]suppressionxpathfilter[\\/]coding[\\/]XpathRegressionIllegalTokenTest.java" />
   <suppress id="numberOfTestCasesInXpath" files="[\\/]src[\\/]it[\\/]java[\\/]org[\\/]checkstyle[\\/]suppressionxpathfilter[\\/]coding[\\/]XpathRegressionIllegalTypeTest.java" />

--- a/src/it/java/org/checkstyle/suppressionxpathfilter/coding/XpathRegressionIllegalCatchTest.java
+++ b/src/it/java/org/checkstyle/suppressionxpathfilter/coding/XpathRegressionIllegalCatchTest.java
@@ -90,4 +90,27 @@ public class XpathRegressionIllegalCatchTest extends AbstractXpathTestSupport {
         runVerifications(moduleConfig, fileToProcess, expectedViolation,
                 expectedXpathQueries);
     }
+
+    @Test
+    public void testThree() throws Exception {
+        final File fileToProcess =
+                new File(getPath("InputXpathIllegalCatchThree.java"));
+
+        final DefaultConfiguration moduleConfig =
+                createModuleConfig(IllegalCatchCheck.class);
+
+        final String[] expectedViolation = {
+            "8:11: " + getCheckMessage(IllegalCatchCheck.class,
+                IllegalCatchCheck.MSG_KEY, "Throwable"),
+        };
+
+        final List<String> expectedXpathQueries = Collections.singletonList(
+            "/COMPILATION_UNIT/CLASS_DEF"
+                + "[./IDENT[@text='InputXpathIllegalCatchThree']]/OBJBLOCK"
+                + "/STATIC_INIT/SLIST/LITERAL_TRY/LITERAL_CATCH"
+        );
+
+        runVerifications(moduleConfig, fileToProcess, expectedViolation,
+                expectedXpathQueries);
+    }
 }

--- a/src/it/resources/org/checkstyle/suppressionxpathfilter/coding/illegalcatch/InputXpathIllegalCatchThree.java
+++ b/src/it/resources/org/checkstyle/suppressionxpathfilter/coding/illegalcatch/InputXpathIllegalCatchThree.java
@@ -1,0 +1,11 @@
+package org.checkstyle.suppressionxpathfilter.coding.illegalcatch;
+
+public class InputXpathIllegalCatchThree {
+
+    static {
+        try {
+            int x = 0;
+        } catch (Throwable e ) { // warn
+        }
+    }
+}


### PR DESCRIPTION
Issue: #19064

Adding third test in `XpathRegressionIllegalCatchTest`.
Remove `XpathRegressionIllegalCatchTest` from suppression `checkstyle-non-main-files-suppressions.xml`