### PR TITLE
Issue #19064: Add third test to XpathRegressionUnusedImportsTest

### DIFF
--- a/config/checkstyle-non-main-files-suppressions.xml
+++ b/config/checkstyle-non-main-files-suppressions.xml
@@ -470,7 +470,6 @@
   <suppress id="numberOfTestCasesInXpath" files="[\\/]src[\\/]it[\\/]java[\\/]org[\\/]checkstyle[\\/]suppressionxpathfilter[\\/]imports[\\/]XpathRegressionAvoidStarImportTest.java" />
   <suppress id="numberOfTestCasesInXpath" files="[\\/]src[\\/]it[\\/]java[\\/]org[\\/]checkstyle[\\/]suppressionxpathfilter[\\/]imports[\\/]XpathRegressionAvoidStaticImportTest.java" />
   <suppress id="numberOfTestCasesInXpath" files="[\\/]src[\\/]it[\\/]java[\\/]org[\\/]checkstyle[\\/]suppressionxpathfilter[\\/]imports[\\/]XpathRegressionIllegalImportTest.java" />
-  <suppress id="numberOfTestCasesInXpath" files="[\\/]src[\\/]it[\\/]java[\\/]org[\\/]checkstyle[\\/]suppressionxpathfilter[\\/]imports[\\/]XpathRegressionUnusedImportsTest.java" />
   <suppress id="numberOfTestCasesInXpath" files="[\\/]src[\\/]it[\\/]java[\\/]org[\\/]checkstyle[\\/]suppressionxpathfilter[\\/]javadoc[\\/]XpathRegressionJavadocContentLocationTest.java" />
   <suppress id="numberOfTestCasesInXpath" files="[\\/]src[\\/]it[\\/]java[\\/]org[\\/]checkstyle[\\/]suppressionxpathfilter[\\/]javadoc[\\/]XpathRegressionJavadocVariableTest.java" />
   <suppress id="numberOfTestCasesInXpath" files="[\\/]src[\\/]it[\\/]java[\\/]org[\\/]checkstyle[\\/]suppressionxpathfilter[\\/]javadoc[\\/]XpathRegressionMissingJavadocMethodTest.java" />

--- a/src/it/java/org/checkstyle/suppressionxpathfilter/imports/XpathRegressionUnusedImportsTest.java
+++ b/src/it/java/org/checkstyle/suppressionxpathfilter/imports/XpathRegressionUnusedImportsTest.java
@@ -85,4 +85,26 @@ public class XpathRegressionUnusedImportsTest extends AbstractXpathTestSupport {
                 expectedXpathQueries);
     }
 
+    @Test
+    public void testImportBreak() throws Exception {
+        final File fileToProcess =
+                new File(getPath("InputXpathUnusedImportsBreak.java"));
+
+        final DefaultConfiguration moduleConfig =
+                createModuleConfig(UnusedImportsCheck.class);
+
+        final String[] expectedViolation = {
+            "3:8: " + getCheckMessage(UnusedImportsCheck.class,
+                    UnusedImportsCheck.MSG_KEY, "java.util.List"),
+        };
+
+        final List<String> expectedXpathQueries = Collections.singletonList(
+                "/COMPILATION_UNIT/IMPORT/DOT"
+                        + "[./IDENT[@text='List']]/DOT/IDENT[@text='java']"
+        );
+
+        runVerifications(moduleConfig, fileToProcess, expectedViolation,
+                expectedXpathQueries);
+    }
+
 }

--- a/src/it/resources/org/checkstyle/suppressionxpathfilter/imports/unusedimports/InputXpathUnusedImportsBreak.java
+++ b/src/it/resources/org/checkstyle/suppressionxpathfilter/imports/unusedimports/InputXpathUnusedImportsBreak.java
@@ -1,0 +1,8 @@
+package org.checkstyle.suppressionxpathfilter.imports.unusedimports;
+
+import java.util // warn
+        .List;
+
+public class InputXpathUnusedImportsBreak {
+
+}


### PR DESCRIPTION
Issue : https://github.com/checkstyle/checkstyle/issues/19064

Removing XpathRegressionUnusedImportsTest from supression checkstyle-non-main-files-suppressions.xml.
Adding third test in XpathRegressionUnusedImportsTest