### PR TITLE
Issue #19087: Add instruction to exclude non-compiled resource directories in IntelliJ IDEA

### DIFF
--- a/src/site/xdoc/idea.xml
+++ b/src/site/xdoc/idea.xml
@@ -41,6 +41,23 @@
       </p>
     </section>
 
+    <section name="Exclude Non-Compiled Resource Directories">
+      <p>
+        The following directories contain files that are not compilable and will cause build
+        errors if IntelliJ IDEA tries to compile them. Mark each as <b>Excluded</b> in the
+        Project Structure settings before running tests via IntelliJ's interface:
+        <ul>
+          <li><code>src/it/resources-noncompilable</code></li>
+          <li><code>src/test/resources-noncompilable</code></li>
+          <li><code>src/xdocs-examples/resources-noncompilable</code></li>
+        </ul>
+        Open <code>File | Project Structure</code> (or press <code>Ctrl+Alt+Shift+S</code>),
+        navigate to <code>Modules</code>, select the checkstyle module, then open the
+        <code>Sources</code> tab. Right-click each directory above and select
+        <code>Excluded</code>.
+      </p>
+    </section>
+
     <section name="Debug">
       <p>
         Open the Check's source file by double-click on it in a source tree as is shown:<br/><br/>


### PR DESCRIPTION
Issue: #19087

Added a new section **"Exclude Non-Compiled Resource Directories"** to the IntelliJ IDEA setup guide (`src/site/xdoc/idea.xml`), placed between the import and debug sections.

The section explains that the following directories must be marked as **Excluded** in IntelliJ's Project Structure settings to prevent build errors when running tests via IntelliJ's GUI:
- `src/it/resources`
- `src/test/resources`
- `src/test/resources-noncompilable`
- `src/xdocs-examples/resources`

These directories contain test input files that are intentionally not meant to be compiled (many contain purposeful violations). Without excluding them, IntelliJ attempts to compile them and throws errors that confuse newcomers.