### PR TITLE
Issue #18926: Re-enable SystemGetProperty Qodana inspection

### DIFF
--- a/config/intellij-idea-inspections.xml
+++ b/config/intellij-idea-inspections.xml
@@ -4614,9 +4614,8 @@
   </inspection_tool>
   <inspection_tool class="SystemExit" enabled="true" level="ERROR" enabled_by_default="true"/>
   <inspection_tool class="SystemGC" enabled="true" level="WARNING" enabled_by_default="true"/>
-  <!-- temporary disabled until https://github.com/checkstyle/checkstyle/issues/18926 -->
-  <inspection_tool class="SystemGetProperty" enabled="false" level="WARNING"
-                   enabled_by_default="false" />
+  <inspection_tool class="SystemGetProperty" enabled="true" level="WARNING"
+                   enabled_by_default="true" />
   <inspection_tool class="SystemGetenv" enabled="true" level="ERROR" enabled_by_default="true"/>
   <inspection_tool class="SystemOutErr" enabled="true" level="ERROR" enabled_by_default="true"/>
   <!-- we do not use system variables for any security relates reasons

--- a/src/main/java/com/puppycrawl/tools/checkstyle/DetailNodeTreeStringPrinter.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/DetailNodeTreeStringPrinter.java
@@ -38,7 +38,7 @@ import com.puppycrawl.tools.checkstyle.utils.ParserUtil;
 public final class DetailNodeTreeStringPrinter {
 
     /** OS specific line separator. */
-    private static final String LINE_SEPARATOR = System.getProperty("line.separator");
+    private static final String LINE_SEPARATOR = System.lineSeparator();
 
     /** Prevent instances. */
     private DetailNodeTreeStringPrinter() {

--- a/src/main/java/com/puppycrawl/tools/checkstyle/SuppressionsStringPrinter.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/SuppressionsStringPrinter.java
@@ -21,6 +21,7 @@ package com.puppycrawl.tools.checkstyle;
 
 import java.io.File;
 import java.io.IOException;
+import java.nio.charset.Charset;
 import java.util.List;
 import java.util.Locale;
 import java.util.regex.Matcher;
@@ -43,7 +44,7 @@ public final class SuppressionsStringPrinter {
             Pattern.compile("^(\\d+):(\\d+)$");
 
     /** OS specific line separator. */
-    private static final String LINE_SEPARATOR = System.getProperty("line.separator");
+    private static final String LINE_SEPARATOR = System.lineSeparator();
 
     /** Prevent instances. */
     private SuppressionsStringPrinter() {
@@ -72,7 +73,7 @@ public final class SuppressionsStringPrinter {
             throw new IllegalStateException(exceptionMsg);
         }
 
-        final FileText fileText = new FileText(file, System.getProperty("file.encoding"));
+        final FileText fileText = new FileText(file, Charset.defaultCharset().name());
         final DetailAST detailAST =
                 JavaParser.parseFileText(fileText, JavaParser.Options.WITH_COMMENTS);
         final int lineNumber = Integer.parseInt(matcher.group(1));

--- a/src/test/java/com/puppycrawl/tools/checkstyle/ChecksAndFilesSuppressionFileGeneratorAuditListenerTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/ChecksAndFilesSuppressionFileGeneratorAuditListenerTest.java
@@ -41,7 +41,7 @@ import com.puppycrawl.tools.checkstyle.internal.utils.TestUtil;
 public class ChecksAndFilesSuppressionFileGeneratorAuditListenerTest {
 
     /** OS specific line separator. */
-    private static final String EOL = System.getProperty("line.separator");
+    private static final String EOL = System.lineSeparator();
 
     private static final String SUPPRESSION_XML_HEADER =
                 "<?xml version=\"1.0\" encoding=\"UTF-8\"?>" + EOL

--- a/src/test/java/com/puppycrawl/tools/checkstyle/SuppressionsStringPrinterTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/SuppressionsStringPrinterTest.java
@@ -30,7 +30,7 @@ import com.puppycrawl.tools.checkstyle.api.CheckstyleException;
 
 public class SuppressionsStringPrinterTest extends AbstractTreeTestSupport {
 
-    private static final String EOL = System.getProperty("line.separator");
+    private static final String EOL = System.lineSeparator();
 
     @Override
     public String getPackageLocation() {

--- a/src/test/java/com/puppycrawl/tools/checkstyle/XpathFileGeneratorAuditListenerTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/XpathFileGeneratorAuditListenerTest.java
@@ -46,7 +46,7 @@ import com.puppycrawl.tools.checkstyle.internal.utils.TestUtil;
 public class XpathFileGeneratorAuditListenerTest {
 
     /** OS specific line separator. */
-    private static final String EOL = System.getProperty("line.separator");
+    private static final String EOL = System.lineSeparator();
 
     private static final Violation FIRST_MESSAGE = createViolation(3, 51,
             TokenTypes.LCURLY, null, LeftCurlyCheck.class);

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/blocks/EmptyCatchBlockCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/blocks/EmptyCatchBlockCheckTest.java
@@ -81,7 +81,7 @@ public class EmptyCatchBlockCheckTest extends AbstractModuleTestSupport {
             "220:33: " + getCheckMessage(MSG_KEY_CATCH_BLOCK_EMPTY),
             "229:33: " + getCheckMessage(MSG_KEY_CATCH_BLOCK_EMPTY),
         };
-        final String originalLineSeparator = System.getProperty("line.separator");
+        final String originalLineSeparator = System.lineSeparator();
         try {
             System.setProperty("line.separator", "\r\n");
             verifyWithInlineConfigParser(

--- a/src/test/java/com/puppycrawl/tools/checkstyle/grammar/GeneratedJava14LexerTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/grammar/GeneratedJava14LexerTest.java
@@ -40,7 +40,7 @@ public class GeneratedJava14LexerTest
     /**
      * Is {@code true} if current default encoding is UTF-8.
      */
-    private static final boolean IS_UTF8 = Charset.forName(System.getProperty("file.encoding"))
+    private static final boolean IS_UTF8 = Charset.defaultCharset()
             .equals(StandardCharsets.UTF_8);
 
     @Override


### PR DESCRIPTION
Issue: #18926

Re-enabled the `SystemGetProperty` Qodana inspection by replacing `System.getProperty()` calls with their dedicated modern Java API equivalents.

**Main source fixes:**
- `System.getProperty("line.separator")` → `System.lineSeparator()` in `DetailNodeTreeStringPrinter.java` and `SuppressionsStringPrinter.java`
- `System.getProperty("file.encoding")` → `Charset.defaultCharset().name()` in `SuppressionsStringPrinter.java`

**Test file fixes:**
- `System.getProperty("line.separator")` → `System.lineSeparator()` in `XpathFileGeneratorAuditListenerTest.java`, `ChecksAndFilesSuppressionFileGeneratorAuditListenerTest.java`, `SuppressionsStringPrinterTest.java`, `EmptyCatchBlockCheckTest.java`
- `System.getProperty("file.encoding")` → `Charset.defaultCharset()` in `GeneratedJava14LexerTest.java`

**Config change:**
- Re-enabled `SystemGetProperty` inspection in `config/intellij-idea-inspections.xml`