### PR TITLE
Issue #17449: Add example for aliasList in SuppressWarningsHolder

### DIFF
--- a/src/site/xdoc/checks/annotation/suppresswarningsholder.xml
+++ b/src/site/xdoc/checks/annotation/suppresswarningsholder.xml
@@ -183,10 +183,32 @@ public class Example4 {
   }
 
 }
+</code></pre></div><hr class="example-separator"/>
+
+        <p id="Example5-config">
+          You can also define a custom alias for a check using the check name or simple
+          name with <code>aliasList</code> in format of <code>CheckName=alias</code>:
+    </p>
+    <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
+&lt;module name="Checker"&gt;
+  &lt;module name="TreeWalker"&gt;
+    &lt;module name="ConstantName"/&gt;
+    &lt;module name="SuppressWarningsHolder"&gt;
+      &lt;property name="aliasList" value="ConstantName=mycustom"/&gt;
+    &lt;/module&gt;
+  &lt;/module&gt;
+  &lt;module name="SuppressWarningsFilter"/&gt;
+&lt;/module&gt;
 </code></pre></div>
-
+    <p id="Example5-code">Example:</p>
+    <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+public class Example5 {
+  private static final int i = 0; // violation, 'Name 'i' must match pattern'
+  @SuppressWarnings("mycustom")
+  private static final int m = 0; // violation suppressed
+}
+</code></pre></div>
       </subsection>
-
       <subsection name="Example of Usage" id="SuppressWarningsHolder_Example_of_Usage">
         <ul>
           <li>

--- a/src/site/xdoc/checks/annotation/suppresswarningsholder.xml.template
+++ b/src/site/xdoc/checks/annotation/suppresswarningsholder.xml.template
@@ -91,10 +91,22 @@
           <param name="path"
                  value="resources/com/puppycrawl/tools/checkstyle/checks/annotation/suppresswarningsholder/Example4.java"/>
           <param name="type" value="code"/>
-        </macro>
+        </macro><hr class="example-separator"/>
 
+        <p id="Example5-config">
+          You can also define a custom alias for a check using the check name or simple
+          name with <code>aliasList</code> in format of <code>CheckName=alias</code>:
+    </p>
+    <macro name="example">
+      <param name="path" value="resources/com/puppycrawl/tools/checkstyle/checks/annotation/suppresswarningsholder/Example5.java"/>
+      <param name="type" value="config"/>
+    </macro>
+    <p id="Example5-code">Example:</p>
+    <macro name="example">
+      <param name="path" value="resources/com/puppycrawl/tools/checkstyle/checks/annotation/suppresswarningsholder/Example5.java"/>
+      <param name="type" value="code"/>
+    </macro>
       </subsection>
-
       <subsection name="Example of Usage" id="SuppressWarningsHolder_Example_of_Usage">
         <ul>
           <li>

--- a/src/test/java/com/puppycrawl/tools/checkstyle/internal/XdocsExamplesAstConsistencyTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/internal/XdocsExamplesAstConsistencyTest.java
@@ -90,6 +90,7 @@ public class XdocsExamplesAstConsistencyTest {
             "checks/annotation/annotationonsameline/Example2",
             "checks/annotation/missingoverride/Example2",
             "checks/annotation/suppresswarningsholder/Example1",
+            "checks/annotation/suppresswarningsholder/Example5",
             "checks/blocks/emptyblock/Example3",
             "checks/blocks/emptycatchblock/Example4",
             "checks/blocks/emptycatchblock/Example5",

--- a/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/checks/annotation/SuppressWarningsHolderExamplesTest.java
+++ b/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/checks/annotation/SuppressWarningsHolderExamplesTest.java
@@ -83,4 +83,15 @@ public class SuppressWarningsHolderExamplesTest extends AbstractExamplesModuleTe
 
         verifyWithInlineConfigParser(getPath("Example4.java"), expected);
     }
+
+    @Test
+    public void testExample5() throws Exception {
+        final String pattern = "^[A-Z][A-Z0-9]*(_[A-Z0-9]+)*$";
+        final String[] expected = {
+            "17:28: " + getCheckMessage(ConstantNameCheck.class,
+                        AbstractNameCheck.MSG_INVALID_PATTERN, "i", pattern),
+        };
+
+        verifyWithInlineConfigParser(getPath("Example5.java"), expected);
+    }
 }

--- a/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/annotation/suppresswarningsholder/Example5.java
+++ b/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/annotation/suppresswarningsholder/Example5.java
@@ -1,0 +1,21 @@
+/*xml
+<module name="Checker">
+  <module name="TreeWalker">
+    <module name="ConstantName"/>
+    <module name="SuppressWarningsHolder">
+      <property name="aliasList" value="ConstantName=mycustom"/>
+    </module>
+  </module>
+  <module name="SuppressWarningsFilter"/>
+</module>
+*/
+
+package com.puppycrawl.tools.checkstyle.checks.annotation.suppresswarningsholder;
+
+// xdoc section -- start
+public class Example5 {
+  private static final int i = 0; // violation, 'Name 'i' must match pattern'
+  @SuppressWarnings("mycustom")
+  private static final int m = 0; // violation suppressed
+}
+// xdoc section -- end


### PR DESCRIPTION
Issue: #17449

## Description
Added a new example class, `Example5.java`, to explain the `aliasList` property in the `suppresswarningsholder` check.

Changes included:
- Created `Example5.java` with the relevant code samples.
- Updated `XdocsExampleFileTest` to reflect the changes.
- Verified the build locally by running `.\mvnw.cmd clean verify`.