### PR TITLE
Issue #18926: Re-enable ClassEscapesItsScope Qodana inspection

### DIFF
--- a/config/intellij-idea-inspections.xml
+++ b/config/intellij-idea-inspections.xml
@@ -1088,9 +1088,8 @@
     <option name="m_includeLibraryClasses" value="false"/>
     <option name="m_limit" value="15"/>
   </inspection_tool>
-  <!-- temporary disabled until https://github.com/checkstyle/checkstyle/issues/18926 -->
-  <inspection_tool class="ClassEscapesItsScope" enabled="false" level="WARNING"
-                   enabled_by_default="false" />
+  <inspection_tool class="ClassEscapesItsScope" enabled="true" level="WARNING"
+                   enabled_by_default="true" />
   <!-- we do not need that -->
   <inspection_tool class="ClassHasNoToStringMethod" enabled="false" level="ERROR"
                    enabled_by_default="false">

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/imports/AccessResult.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/imports/AccessResult.java
@@ -23,7 +23,7 @@ package com.puppycrawl.tools.checkstyle.checks.imports;
  * Represents the result of an access check.
  *
  */
-enum AccessResult {
+public enum AccessResult {
 
     /** Represents that access is allowed. */
     ALLOWED,

--- a/src/test/java/com/puppycrawl/tools/checkstyle/AbstractModuleTestSupport.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/AbstractModuleTestSupport.java
@@ -75,7 +75,7 @@ public abstract class AbstractModuleTestSupport extends AbstractPathTestSupport 
      *
      * @return logger for tests
      */
-    protected final BriefUtLogger getBriefUtLogger() {
+    protected final DefaultLogger getBriefUtLogger() {
         return new BriefUtLogger(stream);
     }
 


### PR DESCRIPTION
Issue: #18926

Re-enables the `ClassEscapesItsScope` Qodana inspection by fixing violations where class types were not exported from their module.

**Code fixes:**
- Made `AccessResult` enum `public` in `AccessResult.java` — it was package-private but used in `public`/`protected` methods of `AbstractImportRule` and `AbstractImportControl`
- Changed return type of `getBriefUtLogger()` in `AbstractModuleTestSupport` from `BriefUtLogger` (internal utility) to `DefaultLogger` (public class)

**Config change:**
- Re-enabled `ClassEscapesItsScope` inspection in `config/intellij-idea-inspections.xml`