### PR TITLE
Issue #18926: Re-enable Java9ReflectionClassVisibility Qodana inspection

### DIFF
--- a/config/intellij-idea-inspections.xml
+++ b/config/intellij-idea-inspections.xml
@@ -2785,9 +2785,8 @@
          When this problem is resolved we could reconsider disablement. -->
   <inspection_tool class="Java8MapApi" enabled="false" level="WARNING"
                    enabled_by_default="false"/>
-  <!-- temporary disabled until https://github.com/checkstyle/checkstyle/issues/18926 -->
-  <inspection_tool class="Java9ReflectionClassVisibility" enabled="false" level="WARNING"
-                   enabled_by_default="false" />
+  <inspection_tool class="Java9ReflectionClassVisibility" enabled="true" level="WARNING"
+                   enabled_by_default="true" />
   <inspection_tool class="JavaCollectionsStaticMethod" enabled="false" level="WEAK WARNING"
                    enabled_by_default="false"/>
   <inspection_tool class="JavaDoc" enabled="true" level="ERROR" enabled_by_default="true">

--- a/src/test/java/com/puppycrawl/tools/checkstyle/internal/utils/CheckUtil.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/internal/utils/CheckUtil.java
@@ -45,9 +45,11 @@ import com.puppycrawl.tools.checkstyle.api.FileText;
 import com.puppycrawl.tools.checkstyle.checks.coding.AbstractSuperCheck;
 import com.puppycrawl.tools.checkstyle.checks.naming.AbstractAccessControlNameCheck;
 import com.puppycrawl.tools.checkstyle.checks.naming.AbstractNameCheck;
+import com.puppycrawl.tools.checkstyle.checks.regexp.MultilineDetector;
 import com.puppycrawl.tools.checkstyle.checks.regexp.RegexpMultilineCheck;
 import com.puppycrawl.tools.checkstyle.checks.regexp.RegexpSinglelineCheck;
 import com.puppycrawl.tools.checkstyle.checks.regexp.RegexpSinglelineJavaCheck;
+import com.puppycrawl.tools.checkstyle.checks.regexp.SinglelineDetector;
 import com.puppycrawl.tools.checkstyle.checks.whitespace.AbstractParenPadCheck;
 import com.puppycrawl.tools.checkstyle.utils.JavadocUtil;
 import com.puppycrawl.tools.checkstyle.utils.ModuleReflectionUtil;
@@ -210,12 +212,10 @@ public final class CheckUtil {
      * @param module class to examine.
      * @param deepScan scan subclasses.
      * @return a set of checkstyle's module message fields.
-     * @throws ClassNotFoundException if the attempt to read a protected class fails.
      * @noinspection BooleanParameter
      * @noinspectionreason BooleanParameter - boolean parameter eases testing
      */
-    public static Set<Field> getCheckMessages(Class<?> module, boolean deepScan)
-            throws ClassNotFoundException {
+    public static Set<Field> getCheckMessages(Class<?> module, boolean deepScan) {
         final Set<Field> checkstyleMessages = new HashSet<>();
 
         // get all fields from current class
@@ -236,15 +236,11 @@ public final class CheckUtil {
 
         // special cases that require additional classes
         if (module == RegexpMultilineCheck.class) {
-            checkstyleMessages.addAll(getCheckMessages(Class
-                    .forName("com.puppycrawl.tools.checkstyle.checks.regexp.MultilineDetector"),
-                    deepScan));
+            checkstyleMessages.addAll(getCheckMessages(MultilineDetector.class, deepScan));
         }
         else if (module == RegexpSinglelineCheck.class
                 || module == RegexpSinglelineJavaCheck.class) {
-            checkstyleMessages.addAll(getCheckMessages(Class
-                    .forName("com.puppycrawl.tools.checkstyle.checks.regexp.SinglelineDetector"),
-                    deepScan));
+            checkstyleMessages.addAll(getCheckMessages(SinglelineDetector.class, deepScan));
         }
 
         return checkstyleMessages;


### PR DESCRIPTION
Issue: #18926

Re-enables the `Java9ReflectionClassVisibility` Qodana inspection that was temporarily disabled.

This inspection detects cases where reflection on classes in Java 9+ modules may fail due to visibility restrictions.