### PR TITLE
Issue #5460: Fix false positive in ImportOrder for separator between …

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/imports/ImportOrderCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/imports/ImportOrderCheck.java
@@ -139,9 +139,11 @@ public class ImportOrderCheck
 
     /**
      * Control whether static import groups should be separated by, at least, one blank
-     * line or comment and aren't separated internally. This property has effect only when the
-     * property {@code option} is set to {@code top} or {@code bottom} and when property
-     * {@code staticGroups} is enabled.
+     * line or comment and aren't separated internally. When the property {@code option}
+     * is set to {@code top} or {@code bottom}, this property requires {@code staticGroups}
+     * to be enabled. When the property {@code option} is set to {@code under} or
+     * {@code above}, this property allows blank lines between static and non-static
+     * imports within the same group.
      */
     private boolean separatedStaticGroups;
 
@@ -279,9 +281,11 @@ public class ImportOrderCheck
     /**
      * Setter to control whether static import groups should be separated by, at least,
      * one blank line or comment and aren't separated internally.
-     * This property has effect only when the property
-     * {@code option} is set to {@code top} or {@code bottom} and when property {@code staticGroups}
-     * is enabled.
+     * When the property {@code option} is set to {@code top} or {@code bottom},
+     * this property requires {@code staticGroups} to be enabled.
+     * When the property {@code option} is set to {@code under} or {@code above},
+     * this property allows blank lines between static and non-static imports
+     * within the same group.
      *
      * @param separatedStaticGroups
      *            whether groups should be separated by one blank line or comment.
@@ -410,6 +414,12 @@ public class ImportOrderCheck
         }
         else if (groupIdx == lastGroup) {
             doVisitTokenInSameGroup(isStatic, previous, name, ast);
+
+            if (separatedStaticGroups
+                    && isStatic != lastImportStatic
+                    && !isSeparatorBeforeImport(ast.getLineNo())) {
+                log(ast, MSG_SEPARATION, name);
+            }
         }
         else {
             handleLowerGroup(previous, ast, name);
@@ -489,7 +499,15 @@ public class ImportOrderCheck
      */
     private boolean isSeparatorInGroup(int groupIdx, boolean isStatic, int line) {
         final boolean inSameGroup = groupIdx == lastGroup;
-        return (inSameGroup || !needSeparator(isStatic)) && isSeparatorBeforeImport(line);
+        final boolean result;
+        if (inSameGroup) {
+            result = (isStatic == lastImportStatic || !separatedStaticGroups)
+                    && isSeparatorBeforeImport(line);
+        }
+        else {
+            result = !needSeparator(isStatic) && isSeparatorBeforeImport(line);
+        }
+        return result;
     }
 
     /**

--- a/src/main/resources/com/puppycrawl/tools/checkstyle/meta/checks/imports/ImportOrderCheck.xml
+++ b/src/main/resources/com/puppycrawl/tools/checkstyle/meta/checks/imports/ImportOrderCheck.xml
@@ -66,9 +66,11 @@
             <property default-value="false" name="separatedStaticGroups" type="boolean">
                <description>Control whether static import groups should be separated by, at least,
  one blank line or comment and aren't separated internally.
- This property has effect only when the property
- &lt;code&gt;option&lt;/code&gt; is set to &lt;code&gt;top&lt;/code&gt; or &lt;code&gt;bottom&lt;/code&gt; and when property &lt;code&gt;staticGroups&lt;/code&gt;
- is enabled.</description>
+ When the property &lt;code&gt;option&lt;/code&gt; is set to &lt;code&gt;top&lt;/code&gt; or &lt;code&gt;bottom&lt;/code&gt;,
+ this property requires &lt;code&gt;staticGroups&lt;/code&gt; to be enabled.
+ When the property &lt;code&gt;option&lt;/code&gt; is set to &lt;code&gt;under&lt;/code&gt; or &lt;code&gt;above&lt;/code&gt;,
+ this property allows blank lines between static and non-static imports
+ within the same group.</description>
             </property>
             <property default-value="false"
                       name="sortStaticImportsAlphabetically"

--- a/src/site/xdoc/checks/imports/importorder.xml
+++ b/src/site/xdoc/checks/imports/importorder.xml
@@ -87,7 +87,7 @@
             </tr>
             <tr>
               <td><a id="separatedStaticGroups"/><a href="#separatedStaticGroups">separatedStaticGroups</a></td>
-              <td>Control whether static import groups should be separated by, at least, one blank line or comment and aren't separated internally. This property has effect only when the property <code>option</code> is set to <code>top</code> or <code>bottom</code> and when property <code>staticGroups</code> is enabled.</td>
+              <td>Control whether static import groups should be separated by, at least, one blank line or comment and aren't separated internally. When the property <code>option</code> is set to <code>top</code> or <code>bottom</code>, this property requires <code>staticGroups</code> to be enabled. When the property <code>option</code> is set to <code>under</code> or <code>above</code>, this property allows blank lines between static and non-static imports within the same group.</td>
               <td><a href="../../property_types.html#boolean">boolean</a></td>
               <td><code>false</code></td>
               <td>8.12</td>

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/imports/ImportOrderCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/imports/ImportOrderCheckTest.java
@@ -896,4 +896,57 @@ public class ImportOrderCheckTest extends AbstractModuleTestSupport {
                 .isTrue();
 
     }
+
+    @Test
+    public void testUnderSeparatedStaticNonStaticBlankLine() throws Exception {
+        final String[] expected = CommonUtil.EMPTY_STRING_ARRAY;
+
+        verifyWithInlineConfigParser(
+                getPath("InputImportOrderUnderSeparatedStaticNonStaticBlankLine.java"), expected);
+    }
+
+    @Test
+    public void testUnderSeparatedSameTypeBlankLine() throws Exception {
+        final String[] expected = {
+            "21:1: " + getCheckMessage(MSG_SEPARATED_IN_GROUP,
+                    "java.util.List"),
+            "25:1: " + getCheckMessage(MSG_SEPARATED_IN_GROUP,
+                    "java.util.Collections.sort"),
+        };
+
+        verifyWithInlineConfigParser(
+                getPath("InputImportOrderUnderSeparatedSameTypeBlankLine.java"), expected);
+    }
+
+    @Test
+    public void testUnderSeparatedSameTypeBlankLineCorrect() throws Exception {
+        final String[] expected = CommonUtil.EMPTY_STRING_ARRAY;
+
+        verifyWithInlineConfigParser(
+            getPath("InputImportOrderUnderSeparatedSameTypeBlankLineCorrect.java"),
+                expected);
+    }
+
+    @Test
+    public void testUnderSeparatedStaticNonStaticBlankLineEclipseStyle() throws Exception {
+        final String[] expected = CommonUtil.EMPTY_STRING_ARRAY;
+
+        verifyWithInlineConfigParser(
+            getNonCompilablePath(
+                    "InputImportOrderUnderSeparatedStaticNonStaticBlankLineEclipseStyle.java"),
+                expected);
+    }
+
+    @Test
+    public void testUnderSeparatedStaticNonStaticMissingSeparator() throws Exception {
+        final String[] expected = {
+            "20:1: " + getCheckMessage(MSG_SEPARATION, "java.util.Collections.emptyList"),
+            "23:1: " + getCheckMessage(MSG_SEPARATION, "com.google.common.collect.Lists.asList"),
+        };
+
+        verifyWithInlineConfigParser(
+                getPath("InputImportOrderUnderSeparatedStaticNonStaticMissingSeparator.java"),
+                expected);
+    }
+
 }

--- a/src/test/resources-noncompilable/com/puppycrawl/tools/checkstyle/checks/imports/importorder/InputImportOrderUnderSeparatedStaticNonStaticBlankLineEclipseStyle.java
+++ b/src/test/resources-noncompilable/com/puppycrawl/tools/checkstyle/checks/imports/importorder/InputImportOrderUnderSeparatedStaticNonStaticBlankLineEclipseStyle.java
@@ -1,0 +1,28 @@
+/*
+ImportOrder
+option = (default)under
+groups = /^java\./,javax,org,com,net,edu,io
+ordered = (default)true
+separated = true
+separatedStaticGroups = true
+caseSensitive = (default)true
+staticGroups = (default)
+sortStaticImportsAlphabetically = (default)false
+useContainerOrderingForStatic = true
+tokens = (default)IMPORT, STATIC_IMPORT
+
+
+*/
+
+package com.puppycrawl.tools.checkstyle.checks.imports.importorder;
+
+import java.some.common.collect1.Lists1;
+
+import static java.some.common.collect1.Lists1.asList;
+
+import com.google.common.collect.Lists;
+
+import static com.google.common.collect.Lists.asList;
+
+public class InputImportOrderUnderSeparatedStaticNonStaticBlankLineEclipseStyle {
+}

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/imports/importorder/InputImportOrderUnderSeparatedSameTypeBlankLine.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/imports/importorder/InputImportOrderUnderSeparatedSameTypeBlankLine.java
@@ -1,0 +1,32 @@
+/*
+ImportOrder
+option = (default)under
+groups = /^java\./,javax,org,com,net,edu,io
+ordered = (default)true
+separated = true
+separatedStaticGroups = true
+caseSensitive = (default)true
+staticGroups = (default)
+sortStaticImportsAlphabetically = (default)false
+useContainerOrderingForStatic = true
+tokens = (default)IMPORT, STATIC_IMPORT
+
+
+*/
+
+package com.puppycrawl.tools.checkstyle.checks.imports.importorder;
+
+import java.util.Arrays;
+
+import java.util.List; // violation 'Extra separation in import group before 'java.util.List''
+
+import static java.util.Collections.emptyList;
+
+import static java.util.Collections.sort; // violation 'Extra separation in import group'
+
+import com.google.common.collect.Lists;
+
+import static com.google.common.collect.Lists.asList;
+
+public class InputImportOrderUnderSeparatedSameTypeBlankLine {
+}

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/imports/importorder/InputImportOrderUnderSeparatedSameTypeBlankLineCorrect.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/imports/importorder/InputImportOrderUnderSeparatedSameTypeBlankLineCorrect.java
@@ -1,0 +1,30 @@
+/*
+ImportOrder
+option = (default)under
+groups = /^java\./,javax,org,com,net,edu,io
+ordered = (default)true
+separated = true
+separatedStaticGroups = true
+caseSensitive = (default)true
+staticGroups = (default)
+sortStaticImportsAlphabetically = (default)false
+useContainerOrderingForStatic = true
+tokens = (default)IMPORT, STATIC_IMPORT
+
+
+*/
+
+package com.puppycrawl.tools.checkstyle.checks.imports.importorder;
+
+import java.util.Arrays;
+import java.util.List;
+
+import static java.util.Collections.emptyList;
+import static java.util.Collections.sort;
+
+import com.google.common.collect.Lists;
+
+import static com.google.common.collect.Lists.asList;
+
+public class InputImportOrderUnderSeparatedSameTypeBlankLineCorrect {
+}

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/imports/importorder/InputImportOrderUnderSeparatedStaticNonStaticBlankLine.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/imports/importorder/InputImportOrderUnderSeparatedStaticNonStaticBlankLine.java
@@ -1,0 +1,28 @@
+/*
+ImportOrder
+option = (default)under
+groups = /^java\./,javax,org,com,net,edu,io
+ordered = (default)true
+separated = true
+separatedStaticGroups = true
+caseSensitive = (default)true
+staticGroups = (default)
+sortStaticImportsAlphabetically = (default)false
+useContainerOrderingForStatic = true
+tokens = (default)IMPORT, STATIC_IMPORT
+
+
+*/
+
+package com.puppycrawl.tools.checkstyle.checks.imports.importorder;
+
+import java.util.Arrays;
+
+import static java.util.Collections.emptyList;
+
+import com.google.common.collect.Lists;
+
+import static com.google.common.collect.Lists.asList;
+
+public class InputImportOrderUnderSeparatedStaticNonStaticBlankLine {
+}

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/imports/importorder/InputImportOrderUnderSeparatedStaticNonStaticMissingSeparator.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/imports/importorder/InputImportOrderUnderSeparatedStaticNonStaticMissingSeparator.java
@@ -1,0 +1,26 @@
+/*
+ImportOrder
+option = (default)under
+groups = /^java\./,javax,org,com,net,edu,io
+ordered = (default)true
+separated = true
+separatedStaticGroups = true
+caseSensitive = (default)true
+staticGroups = (default)
+sortStaticImportsAlphabetically = (default)false
+useContainerOrderingForStatic = true
+tokens = (default)IMPORT, STATIC_IMPORT
+
+
+*/
+
+package com.puppycrawl.tools.checkstyle.checks.imports.importorder;
+
+import java.util.Arrays;
+import static java.util.Collections.emptyList; // violation '.* should be separated from previous'
+
+import com.google.common.collect.Lists;
+import static com.google.common.collect.Lists.asList; // violation '.* should be separated'
+
+public class InputImportOrderUnderSeparatedStaticNonStaticMissingSeparator {
+}


### PR DESCRIPTION
Issue #5460:

Fix false positive "Extra separation in import group" when blank line exists between static and non-static imports within the same group with `option=under/above` and `separated=true`. This aligns with Eclipse IDE default behavior which adds blank lines between static and non-static import blocks