### PR TITLE
Issue #19064: Add missing test case for PackageAnnotationCheck XPath regression

### DIFF
--- a/config/checkstyle-non-main-files-suppressions.xml
+++ b/config/checkstyle-non-main-files-suppressions.xml
@@ -414,7 +414,6 @@
 
   <suppress id="numberOfTestCasesInXpath" files="[\\/]src[\\/]it[\\/]java[\\/]org[\\/]checkstyle[\\/]suppressionxpathfilter[\\/]XpathRegressionOuterTypeFilenameTest.java" />
   <suppress id="numberOfTestCasesInXpath" files="[\\/]src[\\/]it[\\/]java[\\/]org[\\/]checkstyle[\\/]suppressionxpathfilter[\\/]XpathRegressionTodoCommentTest.java" />
-  <suppress id="numberOfTestCasesInXpath" files="[\\/]src[\\/]it[\\/]java[\\/]org[\\/]checkstyle[\\/]suppressionxpathfilter[\\/]annotation[\\/]XpathRegressionPackageAnnotationTest.java" />
   <suppress id="numberOfTestCasesInXpath" files="[\\/]src[\\/]it[\\/]java[\\/]org[\\/]checkstyle[\\/]suppressionxpathfilter[\\/]blocks[\\/]XpathRegressionEmptyBlockTest.java" />
   <suppress id="numberOfTestCasesInXpath" files="[\\/]src[\\/]it[\\/]java[\\/]org[\\/]checkstyle[\\/]suppressionxpathfilter[\\/]blocks[\\/]XpathRegressionEmptyCatchBlockTest.java" />
   <suppress id="numberOfTestCasesInXpath" files="[\\/]src[\\/]it[\\/]java[\\/]org[\\/]checkstyle[\\/]suppressionxpathfilter[\\/]coding[\\/]XpathRegressionArrayTrailingCommaTest.java" />

--- a/src/it/java/org/checkstyle/suppressionxpathfilter/annotation/XpathRegressionPackageAnnotationTest.java
+++ b/src/it/java/org/checkstyle/suppressionxpathfilter/annotation/XpathRegressionPackageAnnotationTest.java
@@ -84,4 +84,25 @@ public class XpathRegressionPackageAnnotationTest extends AbstractXpathTestSuppo
         runVerifications(moduleConfig, fileToProcess, expectedViolation,
                 expectedXpathQueries);
     }
+
+    @Test
+    public void testThree() throws Exception {
+        final File fileToProcess =
+                new File(getNonCompilablePath(
+                        "InputXpathPackageAnnotationThree.java"));
+
+        final DefaultConfiguration moduleConfig =
+                createModuleConfig(PackageAnnotationCheck.class);
+
+        final String[] expectedViolation = {
+            "5:1: " + getCheckMessage(PackageAnnotationCheck.class,
+                PackageAnnotationCheck.MSG_KEY),
+        };
+
+        final List<String> expectedXpathQueries =
+                Arrays.asList("/COMPILATION_UNIT", "/COMPILATION_UNIT/PACKAGE_DEF");
+
+        runVerifications(moduleConfig, fileToProcess, expectedViolation,
+                expectedXpathQueries);
+    }
 }

--- a/src/it/resources-noncompilable/org/checkstyle/suppressionxpathfilter/annotation/packageannotation/InputXpathPackageAnnotationThree.java
+++ b/src/it/resources-noncompilable/org/checkstyle/suppressionxpathfilter/annotation/packageannotation/InputXpathPackageAnnotationThree.java
@@ -1,0 +1,9 @@
+// non-compiled with javac: compiling on jdk before 8
+//more details at https://github.com/checkstyle/checkstyle/issues/7846
+@SuppressWarnings("unused")
+@Deprecated
+package com.puppycrawl.tools.checkstyle.checks.annotation.packageannotation; // warn
+
+public class InputXpathPackageAnnotationThree {
+
+}


### PR DESCRIPTION
Adds a third test case (`testThree`) to `XpathRegressionPackageAnnotationTest` to improve test coverage for the PackageAnnotationCheck XPath suppression filtering.

The new test case validates XPath query generation when a package declaration has multiple annotations (`@SuppressWarnings` and `@Deprecated`), ensuring proper XPath node identification in this scenario.

**Changes:**
- Added `testThree()` method to `XpathRegressionPackageAnnotationTest`
- Created `InputXpathPackageAnnotationThree.java` with multiple package annotations

Refs #19064