### PR TITLE
Issue #19064: Add third XPath test case for EmptyCatchBlockCheck" 

### DIFF
--- a/config/checkstyle-non-main-files-suppressions.xml
+++ b/config/checkstyle-non-main-files-suppressions.xml
@@ -417,8 +417,6 @@
   <suppress id="numberOfTestCasesInXpath" files="[\\/]src[\\/]it[\\/]java[\\/]org[\\/]checkstyle[\\/]suppressionxpathfilter[\\/]XpathRegressionTodoCommentTest.java" />
 
   <suppress id="numberOfTestCasesInXpath" files="[\\/]src[\\/]it[\\/]java[\\/]org[\\/]checkstyle[\\/]suppressionxpathfilter[\\/]annotation[\\/]XpathRegressionPackageAnnotationTest.java" />
-  <suppress id="numberOfTestCasesInXpath" files="[\\/]src[\\/]it[\\/]java[\\/]org[\\/]checkstyle[\\/]suppressionxpathfilter[\\/]blocks[\\/]XpathRegressionEmptyBlockTest.java" />
-  <suppress id="numberOfTestCasesInXpath" files="[\\/]src[\\/]it[\\/]java[\\/]org[\\/]checkstyle[\\/]suppressionxpathfilter[\\/]blocks[\\/]XpathRegressionEmptyCatchBlockTest.java" />
   <suppress id="numberOfTestCasesInXpath" files="[\\/]src[\\/]it[\\/]java[\\/]org[\\/]checkstyle[\\/]suppressionxpathfilter[\\/]coding[\\/]XpathRegressionArrayTrailingCommaTest.java" />
   <suppress id="numberOfTestCasesInXpath" files="[\\/]src[\\/]it[\\/]java[\\/]org[\\/]checkstyle[\\/]suppressionxpathfilter[\\/]coding[\\/]XpathRegressionAvoidDoubleBraceInitializationTest.java" />
   <suppress id="numberOfTestCasesInXpath" files="[\\/]src[\\/]it[\\/]java[\\/]org[\\/]checkstyle[\\/]suppressionxpathfilter[\\/]coding[\\/]XpathRegressionAvoidNoArgumentSuperConstructorCallTest.java" />

--- a/src/it/java/org/checkstyle/suppressionxpathfilter/blocks/XpathRegressionEmptyBlockTest.java
+++ b/src/it/java/org/checkstyle/suppressionxpathfilter/blocks/XpathRegressionEmptyBlockTest.java
@@ -84,4 +84,24 @@ public class XpathRegressionEmptyBlockTest extends AbstractXpathTestSupport {
                 expectedXpathQueries);
     }
 
+    @Test
+    public void testEmptyForLoopWithTokenProperty() throws Exception {
+        final File fileToProcess =
+                new File(getPath("InputXpathEmptyBlockEmpty.java"));
+        final DefaultConfiguration moduleConfig =
+                createModuleConfig(EmptyBlockCheck.class);
+        moduleConfig.addProperty("tokens", "LITERAL_FOR");
+        final String[] expectedViolation = {
+            "5:38: " + getCheckMessage(EmptyBlockCheck.class,
+                EmptyBlockCheck.MSG_KEY_BLOCK_NO_STATEMENT),
+        };
+        final List<String> expectedXpathQueries = Collections.singletonList(
+                "/COMPILATION_UNIT"
+                        + "/CLASS_DEF[./IDENT[@text='InputXpathEmptyBlockEmpty']]"
+                        + "/OBJBLOCK/METHOD_DEF[./IDENT[@text='emptyLoop']]"
+                        + "/SLIST/LITERAL_FOR/SLIST"
+        );
+        runVerifications(moduleConfig, fileToProcess, expectedViolation,
+                expectedXpathQueries);
+    }
 }

--- a/src/it/java/org/checkstyle/suppressionxpathfilter/blocks/XpathRegressionEmptyCatchBlockTest.java
+++ b/src/it/java/org/checkstyle/suppressionxpathfilter/blocks/XpathRegressionEmptyCatchBlockTest.java
@@ -85,4 +85,24 @@ public class XpathRegressionEmptyCatchBlockTest extends AbstractXpathTestSupport
         runVerifications(moduleConfig, fileToProcess, expectedViolation, expectedXpathQueries);
     }
 
+    @Test
+    public void testThree() throws Exception {
+        final File fileToProcess = new File(
+            getPath("InputXpathEmptyCatchBlockThree.java"));
+
+        final DefaultConfiguration moduleConfig = createModuleConfig(CLAZZ);
+
+        final String[] expectedViolation = {
+            "9:43: " + getCheckMessage(CLAZZ, EmptyCatchBlockCheck.MSG_KEY_CATCH_BLOCK_EMPTY),
+        };
+
+        final List<String> expectedXpathQueries = Collections.singletonList(
+            "/COMPILATION_UNIT/CLASS_DEF"
+                + "[./IDENT[@text='InputXpathEmptyCatchBlockThree']]"
+                + "/OBJBLOCK/METHOD_DEF[./IDENT[@text='process']]"
+                + "/SLIST/LITERAL_TRY/LITERAL_CATCH/SLIST"
+        );
+
+        runVerifications(moduleConfig, fileToProcess, expectedViolation, expectedXpathQueries);
+    }
 }

--- a/src/it/resources/org/checkstyle/suppressionxpathfilter/blocks/emptycatchblock/InputXpathEmptyCatchBlockThree.java
+++ b/src/it/resources/org/checkstyle/suppressionxpathfilter/blocks/emptycatchblock/InputXpathEmptyCatchBlockThree.java
@@ -1,0 +1,11 @@
+package org.checkstyle.suppressionxpathfilter.blocks.emptycatchblock;
+
+public class InputXpathEmptyCatchBlockThree {
+
+    public void process() {
+        String value = "test";
+        try {
+            Integer.parseInt(value);
+        } catch (NumberFormatException e) {} //warn
+    }
+}


### PR DESCRIPTION
### Summary
Adds a third XPath regression test to `XpathRegressionEmptyCatchBlockTest` for `EmptyCatchBlockCheck`.

### Changes
Added `testThree()` test method
Added new input file `InputXpathEmptyCatchBlockThree.java` with an empty catch block inside the `process()` method
Verifies the correct XPath query and violation location for the empty catch block.

Refs #19064