### PR TITLE
Issue #19064: Add third XPath test case for MissingJavadocPackage

### DIFF
--- a/config/checkstyle-non-main-files-suppressions.xml
+++ b/config/checkstyle-non-main-files-suppressions.xml
@@ -468,7 +468,6 @@
   <suppress id="numberOfTestCasesInXpath" files="[\\/]src[\\/]it[\\/]java[\\/]org[\\/]checkstyle[\\/]suppressionxpathfilter[\\/]javadoc[\\/]XpathRegressionJavadocContentLocationTest.java" />
   <suppress id="numberOfTestCasesInXpath" files="[\\/]src[\\/]it[\\/]java[\\/]org[\\/]checkstyle[\\/]suppressionxpathfilter[\\/]javadoc[\\/]XpathRegressionJavadocVariableTest.java" />
   <suppress id="numberOfTestCasesInXpath" files="[\\/]src[\\/]it[\\/]java[\\/]org[\\/]checkstyle[\\/]suppressionxpathfilter[\\/]javadoc[\\/]XpathRegressionMissingJavadocMethodTest.java" />
-  <suppress id="numberOfTestCasesInXpath" files="[\\/]src[\\/]it[\\/]java[\\/]org[\\/]checkstyle[\\/]suppressionxpathfilter[\\/]javadoc[\\/]XpathRegressionMissingJavadocPackageTest.java" />
   <suppress id="numberOfTestCasesInXpath" files="[\\/]src[\\/]it[\\/]java[\\/]org[\\/]checkstyle[\\/]suppressionxpathfilter[\\/]metrics[\\/]XpathRegressionCyclomaticComplexityTest.java" />
   <suppress id="numberOfTestCasesInXpath" files="[\\/]src[\\/]it[\\/]java[\\/]org[\\/]checkstyle[\\/]suppressionxpathfilter[\\/]metrics[\\/]XpathRegressionNPathComplexityTest.java" />
   <suppress id="numberOfTestCasesInXpath" files="[\\/]src[\\/]it[\\/]java[\\/]org[\\/]checkstyle[\\/]suppressionxpathfilter[\\/]modifier[\\/]XpathRegressionClassMemberImpliedModifierTest.java" />

--- a/config/jsoref-spellchecker/whitelist.words
+++ b/config/jsoref-spellchecker/whitelist.words
@@ -31,6 +31,7 @@ annotationlocation
 annotationonsameline
 annotationusestyle
 annotationutil
+annotationwithoutjavadoc
 anoninner
 anoninnerlength
 antfile

--- a/src/it/java/org/checkstyle/suppressionxpathfilter/javadoc/XpathRegressionMissingJavadocPackageTest.java
+++ b/src/it/java/org/checkstyle/suppressionxpathfilter/javadoc/XpathRegressionMissingJavadocPackageTest.java
@@ -84,4 +84,25 @@ public class XpathRegressionMissingJavadocPackageTest extends AbstractXpathTestS
                 expectedXpathQueries);
     }
 
+    @Test
+    public void testAnnotationWithoutJavadoc() throws Exception {
+        final File fileToProcess = new File(getPath(
+                "annotationwithoutjavadoc/package-info.java"));
+
+        final DefaultConfiguration moduleConfig =
+                createModuleConfig(MissingJavadocPackageCheck.class);
+
+        final String[] expectedViolation = {
+            "2:1: " + getCheckMessage(MissingJavadocPackageCheck.class,
+                MissingJavadocPackageCheck.MSG_PKG_JAVADOC_MISSING),
+        };
+
+        final List<String> expectedXpathQueries = Arrays.asList(
+            "/COMPILATION_UNIT", "/COMPILATION_UNIT/PACKAGE_DEF"
+        );
+
+        runVerifications(moduleConfig, fileToProcess, expectedViolation,
+                expectedXpathQueries);
+    }
+
 }

--- a/src/it/resources/org/checkstyle/suppressionxpathfilter/javadoc/missingjavadocpackage/annotationwithoutjavadoc/package-info.java
+++ b/src/it/resources/org/checkstyle/suppressionxpathfilter/javadoc/missingjavadocpackage/annotationwithoutjavadoc/package-info.java
@@ -1,0 +1,2 @@
+@Deprecated
+package org.checkstyle.suppressionxpathfilter.javadoc.missingjavadocpackage.annotationwithoutjavadoc; //warn


### PR DESCRIPTION
## Description
This PR addresses part of issue #19064 by adding a third test method to `XpathRegressionMissingJavadocPackageTest`.

The new test covers a case where `package-info.java` contains an annotation with no javadoc comment, ensuring structural AST variation while still triggering `MissingJavadocPackageCheck`.