### PR TITLE
Issue #19064: Add third test to XpathRegressionMissingJavadocMethodTest

### DIFF
--- a/config/checkstyle-non-main-files-suppressions.xml
+++ b/config/checkstyle-non-main-files-suppressions.xml
@@ -459,7 +459,6 @@
   <suppress id="numberOfTestCasesInXpath" files="[\\/]src[\\/]it[\\/]java[\\/]org[\\/]checkstyle[\\/]suppressionxpathfilter[\\/]imports[\\/]XpathRegressionIllegalImportTest.java" />
   <suppress id="numberOfTestCasesInXpath" files="[\\/]src[\\/]it[\\/]java[\\/]org[\\/]checkstyle[\\/]suppressionxpathfilter[\\/]javadoc[\\/]XpathRegressionJavadocContentLocationTest.java" />
   <suppress id="numberOfTestCasesInXpath" files="[\\/]src[\\/]it[\\/]java[\\/]org[\\/]checkstyle[\\/]suppressionxpathfilter[\\/]javadoc[\\/]XpathRegressionJavadocVariableTest.java" />
-  <suppress id="numberOfTestCasesInXpath" files="[\\/]src[\\/]it[\\/]java[\\/]org[\\/]checkstyle[\\/]suppressionxpathfilter[\\/]javadoc[\\/]XpathRegressionMissingJavadocMethodTest.java" />
   <suppress id="numberOfTestCasesInXpath" files="[\\/]src[\\/]it[\\/]java[\\/]org[\\/]checkstyle[\\/]suppressionxpathfilter[\\/]metrics[\\/]XpathRegressionCyclomaticComplexityTest.java" />
   <suppress id="numberOfTestCasesInXpath" files="[\\/]src[\\/]it[\\/]java[\\/]org[\\/]checkstyle[\\/]suppressionxpathfilter[\\/]metrics[\\/]XpathRegressionNPathComplexityTest.java" />
   <suppress id="numberOfTestCasesInXpath" files="[\\/]src[\\/]it[\\/]java[\\/]org[\\/]checkstyle[\\/]suppressionxpathfilter[\\/]modifier[\\/]XpathRegressionClassMemberImpliedModifierTest.java" />

--- a/src/it/java/org/checkstyle/suppressionxpathfilter/javadoc/XpathRegressionMissingJavadocMethodTest.java
+++ b/src/it/java/org/checkstyle/suppressionxpathfilter/javadoc/XpathRegressionMissingJavadocMethodTest.java
@@ -111,4 +111,38 @@ public class XpathRegressionMissingJavadocMethodTest extends AbstractXpathTestSu
 
         runVerifications(moduleConfig, fileToProcess, expectedViolation, expectedXpathQueries);
     }
+
+    @Test
+    public void testMissingJavadocMethodInInterface() throws Exception {
+        final File fileToProcess = new File(
+            getPath("InputXpathMissingJavadocMethodInInterface.java")
+        );
+
+        final DefaultConfiguration moduleConfig =
+            createModuleConfig(MissingJavadocMethodCheck.class);
+        moduleConfig.addProperty("tokens", "METHOD_DEF");
+
+        final String[] expectedViolation = {
+            "4:5: " + getCheckMessage(MissingJavadocMethodCheck.class,
+                MissingJavadocMethodCheck.MSG_JAVADOC_MISSING),
+        };
+
+        final List<String> expectedXpathQueries = Arrays.asList(
+                "/COMPILATION_UNIT/INTERFACE_DEF"
+                    + "[./IDENT[@text='InputXpathMissingJavadocMethodInInterface']]"
+                    + "/OBJBLOCK/METHOD_DEF[./IDENT[@text='foo']]",
+
+                "/COMPILATION_UNIT/INTERFACE_DEF"
+                    + "[./IDENT[@text='InputXpathMissingJavadocMethodInInterface']]"
+                    + "/OBJBLOCK/METHOD_DEF[./IDENT[@text='foo']]"
+                    + "/MODIFIERS",
+
+                "/COMPILATION_UNIT/INTERFACE_DEF"
+                    + "[./IDENT[@text='InputXpathMissingJavadocMethodInInterface']]"
+                    + "/OBJBLOCK/METHOD_DEF[./IDENT[@text='foo']]"
+                    + "/MODIFIERS/LITERAL_PUBLIC"
+        );
+
+        runVerifications(moduleConfig, fileToProcess, expectedViolation, expectedXpathQueries);
+    }
 }

--- a/src/it/resources/org/checkstyle/suppressionxpathfilter/javadoc/missingjavadocmethod/InputXpathMissingJavadocMethodInInterface.java
+++ b/src/it/resources/org/checkstyle/suppressionxpathfilter/javadoc/missingjavadocmethod/InputXpathMissingJavadocMethodInInterface.java
@@ -1,0 +1,5 @@
+package org.checkstyle.suppressionxpathfilter.javadoc.missingjavadocmethod;
+
+public interface InputXpathMissingJavadocMethodInInterface {
+    public void foo(); // warn
+}


### PR DESCRIPTION
Adds third test method to `XpathRegressionMissingJavadocMethodTest` covering missing Javadoc in interface method to introduce structural AST variation and comply with issue #19064.