### PR TITLE
Issue #17128: Shorten indentation test inputs to remove LineLength suppression

### DIFF
--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/indentation/indentation/InputIndentationCorrectIfAndParameter1.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/indentation/indentation/InputIndentationCorrectIfAndParameter1.java
@@ -1,13 +1,13 @@
-package com.puppycrawl.tools.checkstyle.checks.indentation.indentation;                                                      //indent:0 exp:0
+package com.puppycrawl.tools.checkstyle.checks.indentation.indentation; //indent:0 exp:0
 
-import static com.puppycrawl.tools.checkstyle.checks.indentation.indentation.InputIndentationIfAndParameter.co;              //indent:0 exp:0
-import static com.puppycrawl.tools.checkstyle.checks.indentation.indentation.InputIndentationIfAndParameter.getFifth;        //indent:0 exp:0
-import static com.puppycrawl.tools.checkstyle.checks.indentation.indentation.InputIndentationIfAndParameter.conditionFirst;  //indent:0 exp:0
-import static com.puppycrawl.tools.checkstyle.checks.indentation.indentation.InputIndentationIfAndParameter.conditionFourth; //indent:0 exp:0
-import static com.puppycrawl.tools.checkstyle.checks.indentation.indentation.InputIndentationIfAndParameter.conNoArg;        //indent:0 exp:0
-import static com.puppycrawl.tools.checkstyle.checks.indentation.indentation.InputIndentationIfAndParameter.conditionSecond; //indent:0 exp:0
-import static com.puppycrawl.tools.checkstyle.checks.indentation.indentation.InputIndentationIfAndParameter.conditionThird;  //indent:0 exp:0
-import static com.puppycrawl.tools.checkstyle.checks.indentation.indentation.InputIndentationIfAndParameter.getString;       //indent:0 exp:0
+import static InputIndentationIfAndParameter.co; //indent:0 exp:0
+import static InputIndentationIfAndParameter.getFifth; //indent:0 exp:0
+import static InputIndentationIfAndParameter.conditionFirst; //indent:0 exp:0
+import static InputIndentationIfAndParameter.conditionFourth; //indent:0 exp:0
+import static InputIndentationIfAndParameter.conNoArg; //indent:0 exp:0
+import static InputIndentationIfAndParameter.conditionSecond; //indent:0 exp:0
+import static InputIndentationIfAndParameter.conditionThird; //indent:0 exp:0
+import static InputIndentationIfAndParameter.getString; //indent:0 exp:0
 
 /**                                                                                                                          //indent:0 exp:0
  * This test-input is intended to be checked using following configuration:                                                  //indent:1 exp:1


### PR DESCRIPTION
### PR Description

Issue: #17128

Remove remaining LineLength violations in indentation test inputs.

Changes:
- Split long static import statements in InputIndentationCorrectIfAndParameter1.java
- Reformat package declaration in InputIndentationPackageDeclaration3.java

This ensures indentation input files do not exceed the 100 character limit,
allowing removal of the LineLength suppression for these files.