### PR TITLE
Issue #11199: Update doc for SuppressWithPlainTextCommentFilter

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/filters/SuppressWithPlainTextCommentFilter.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/filters/SuppressWithPlainTextCommentFilter.java
@@ -42,18 +42,14 @@ import com.puppycrawl.tools.checkstyle.utils.CommonUtil;
 /**
  * <div>
  * Filter {@code SuppressWithPlainTextCommentFilter} uses plain text to suppress
- * audit events. The filter can be used only to suppress audit events received
- * from the checks which implement FileSetCheck interface. In other words, the
- * checks which have Checker as a parent module. The filter knows nothing about
- * AST, it treats only plain text comments and extracts the information required
- * for suppression from the plain text comments. Currently, the filter supports
- * only single-line comments.
+ * audit events. The filter knows nothing about AST, it treats only plain text
+ * comments and extracts the information required for suppression from the plain
+ * text comments. Currently, the filter supports only single-line comments.
  * </div>
  *
  * <p>
  * Please, be aware of the fact that, it is not recommended to use the filter
- * for Java code anymore, however you still are able to use it to suppress audit
- * events received from the checks which implement FileSetCheck interface.
+ * for Java code anymore.
  * </p>
  *
  * <p>
@@ -78,7 +74,7 @@ import com.puppycrawl.tools.checkstyle.utils.CommonUtil;
  * </p>
  *
  * <p>
- * SuppressionWithPlainTextCommentFilter can suppress Checks that have Treewalker or
+ * SuppressWithPlainTextCommentFilter can suppress Checks that have Treewalker or
  * Checker as parent module.
  * </p>
  *

--- a/src/main/resources/com/puppycrawl/tools/checkstyle/meta/filters/SuppressWithPlainTextCommentFilter.xml
+++ b/src/main/resources/com/puppycrawl/tools/checkstyle/meta/filters/SuppressWithPlainTextCommentFilter.xml
@@ -6,18 +6,14 @@
               parent="com.puppycrawl.tools.checkstyle.Checker">
          <description>&lt;div&gt;
  Filter &lt;code&gt;SuppressWithPlainTextCommentFilter&lt;/code&gt; uses plain text to suppress
- audit events. The filter can be used only to suppress audit events received
- from the checks which implement FileSetCheck interface. In other words, the
- checks which have Checker as a parent module. The filter knows nothing about
- AST, it treats only plain text comments and extracts the information required
- for suppression from the plain text comments. Currently, the filter supports
- only single-line comments.
+ audit events. The filter knows nothing about AST, it treats only plain text
+ comments and extracts the information required for suppression from the plain
+ text comments. Currently, the filter supports only single-line comments.
  &lt;/div&gt;
 
  &lt;p&gt;
  Please, be aware of the fact that, it is not recommended to use the filter
- for Java code anymore, however you still are able to use it to suppress audit
- events received from the checks which implement FileSetCheck interface.
+ for Java code anymore.
  &lt;/p&gt;
 
  &lt;p&gt;
@@ -41,7 +37,7 @@
  &lt;/p&gt;
 
  &lt;p&gt;
- SuppressionWithPlainTextCommentFilter can suppress Checks that have Treewalker or
+ SuppressWithPlainTextCommentFilter can suppress Checks that have Treewalker or
  Checker as parent module.
  &lt;/p&gt;</description>
          <properties>

--- a/src/site/xdoc/filters/suppresswithplaintextcommentfilter.xml
+++ b/src/site/xdoc/filters/suppresswithplaintextcommentfilter.xml
@@ -11,18 +11,14 @@
       <subsection name="Description" id="SuppressWithPlainTextCommentFilter_Description">
         <div>
           Filter <code>SuppressWithPlainTextCommentFilter</code> uses plain text to suppress
-          audit events. The filter can be used only to suppress audit events received
-          from the checks which implement FileSetCheck interface. In other words, the
-          checks which have Checker as a parent module. The filter knows nothing about
-          AST, it treats only plain text comments and extracts the information required
-          for suppression from the plain text comments. Currently, the filter supports
-          only single-line comments.
+          audit events. The filter knows nothing about AST, it treats only plain text
+          comments and extracts the information required for suppression from the plain
+          text comments. Currently, the filter supports only single-line comments.
         </div>
 
         <p>
           Please, be aware of the fact that, it is not recommended to use the filter
-          for Java code anymore, however you still are able to use it to suppress audit
-          events received from the checks which implement FileSetCheck interface.
+          for Java code anymore.
         </p>
 
         <p>
@@ -47,7 +43,7 @@
         </p>
 
         <p>
-          SuppressionWithPlainTextCommentFilter can suppress Checks that have Treewalker or
+          SuppressWithPlainTextCommentFilter can suppress Checks that have Treewalker or
           Checker as parent module.
         </p>
       </subsection>


### PR DESCRIPTION
Resolves #11199 
removed contradictory documentation in `SuppressWithPlainTextCommentFilter.java` and `suppresswithplaintextcommentfilter.xml` that incorrectly stated the filter could only be used for checks implementing `FileSetCheck`
fixed a typo in the documentation that incorrectly referred to the class as `SuppressionWithPlainTextCommentFilter` instead of `SuppressWithPlainTextCommentFilter`.
also request in the original issue about ordering of  notes and properties in the xmlfile was already resolved