### PR TITLE
Issue #19064: Add third test to XpathRegressionFinalClassTest

### DIFF
--- a/config/checkstyle-non-main-files-suppressions.xml
+++ b/config/checkstyle-non-main-files-suppressions.xml
@@ -449,7 +449,6 @@
   <suppress id="numberOfTestCasesInXpath" files="[\\/]src[\\/]it[\\/]java[\\/]org[\\/]checkstyle[\\/]suppressionxpathfilter[\\/]coding[\\/]XpathRegressionVariableDeclarationUsageDistanceTest.java" />
   <suppress id="numberOfTestCasesInXpath" files="[\\/]src[\\/]it[\\/]java[\\/]org[\\/]checkstyle[\\/]suppressionxpathfilter[\\/]coding[\\/]XpathRegressionWhenShouldBeUsedTest.java" />
   <suppress id="numberOfTestCasesInXpath" files="[\\/]src[\\/]it[\\/]java[\\/]org[\\/]checkstyle[\\/]suppressionxpathfilter[\\/]design[\\/]XpathRegressionDesignForExtensionTest.java" />
-  <suppress id="numberOfTestCasesInXpath" files="[\\/]src[\\/]it[\\/]java[\\/]org[\\/]checkstyle[\\/]suppressionxpathfilter[\\/]design[\\/]XpathRegressionFinalClassTest.java" />
   <suppress id="numberOfTestCasesInXpath" files="[\\/]src[\\/]it[\\/]java[\\/]org[\\/]checkstyle[\\/]suppressionxpathfilter[\\/]design[\\/]XpathRegressionHideUtilityClassConstructorTest.java" />
   <suppress id="numberOfTestCasesInXpath" files="[\\/]src[\\/]it[\\/]java[\\/]org[\\/]checkstyle[\\/]suppressionxpathfilter[\\/]design[\\/]XpathRegressionInterfaceIsTypeTest.java" />
   <suppress id="numberOfTestCasesInXpath" files="[\\/]src[\\/]it[\\/]java[\\/]org[\\/]checkstyle[\\/]suppressionxpathfilter[\\/]design[\\/]XpathRegressionSealedShouldHavePermitsListTest.java" />

--- a/src/it/java/org/checkstyle/suppressionxpathfilter/design/XpathRegressionFinalClassTest.java
+++ b/src/it/java/org/checkstyle/suppressionxpathfilter/design/XpathRegressionFinalClassTest.java
@@ -96,4 +96,34 @@ public class XpathRegressionFinalClassTest extends AbstractXpathTestSupport {
         runVerifications(moduleConfig, fileToProcess, expectedViolation,
                 expectedXpathQueries);
     }
+
+    @Test
+    public void testStaticNestedClass() throws Exception {
+        final File fileToProcess = new File(getPath(
+                "InputXpathFinalClassStaticNestedClass.java"));
+
+        final DefaultConfiguration moduleConfig =
+                createModuleConfig(FinalClassCheck.class);
+
+        final String[] expectedViolation = {
+            "5:5: " + getCheckMessage(FinalClassCheck.class,
+                    FinalClassCheck.MSG_KEY, "StaticNestedClass"),
+        };
+
+        final List<String> expectedXpathQueries = Arrays.asList(
+                "/COMPILATION_UNIT/CLASS_DEF[./IDENT["
+                        + "@text='InputXpathFinalClassStaticNestedClass']]"
+                        + "/OBJBLOCK/CLASS_DEF[./IDENT[@text='StaticNestedClass']]",
+                "/COMPILATION_UNIT/CLASS_DEF[./IDENT["
+                        + "@text='InputXpathFinalClassStaticNestedClass']]"
+                        + "/OBJBLOCK/CLASS_DEF[./IDENT[@text='StaticNestedClass']]/MODIFIERS",
+                "/COMPILATION_UNIT/CLASS_DEF[./IDENT["
+                        + "@text='InputXpathFinalClassStaticNestedClass']]"
+                        + "/OBJBLOCK/CLASS_DEF[./IDENT[@text='StaticNestedClass']]"
+                        + "/MODIFIERS/LITERAL_STATIC"
+        );
+
+        runVerifications(moduleConfig, fileToProcess, expectedViolation,
+                expectedXpathQueries);
+    }
 }

--- a/src/it/resources/org/checkstyle/suppressionxpathfilter/design/finalclass/InputXpathFinalClassStaticNestedClass.java
+++ b/src/it/resources/org/checkstyle/suppressionxpathfilter/design/finalclass/InputXpathFinalClassStaticNestedClass.java
@@ -1,0 +1,8 @@
+package org.checkstyle.suppressionxpathfilter.design.finalclass;
+
+public class InputXpathFinalClassStaticNestedClass {
+
+    static class StaticNestedClass { // warn
+        private StaticNestedClass() {}
+    }
+}


### PR DESCRIPTION
Issue : #19064
Removing `XpathRegressionFinalClassTest` from suppression `checkstyle-non-main-files-suppressions.xml`. Adding third test in `XpathRegressionFinalClassTest`