### PR TITLE
ci: set Java heap size for Checkstyle execution to fix circleci executions

### DIFF
--- a/.ci/validation.sh
+++ b/.ci/validation.sh
@@ -288,7 +288,7 @@ EOF
   echo "Running Checkstyle on Apache-licensed modules..."
   readarray -t apache_files < <(find "${APACHE_SOURCES[@]}" \
     -name '*.java' ! -name 'module-info.java')
-  java -jar ../../target/checkstyle-"${CS_POM_VERSION}"-all.jar \
+  java -Xmx3g -jar ../../target/checkstyle-"${CS_POM_VERSION}"-all.jar \
     -c checkstyle/checkstyle.xml \
     -p checkstyle-apache.properties \
     "${apache_files[@]}"
@@ -309,7 +309,7 @@ EOF
   echo "Running Checkstyle on Community-licensed modules (hazelcast-sql)..."
   readarray -t community_files < <(find "${COMMUNITY_SOURCES[@]}" \
     -name '*.java' ! -name 'module-info.java')
-  java -jar ../../target/checkstyle-"${CS_POM_VERSION}"-all.jar \
+  java -Xmx3g -jar ../../target/checkstyle-"${CS_POM_VERSION}"-all.jar \
     -c checkstyle/checkstyle.xml \
     -p checkstyle-community.properties \
     "${community_files[@]}"


### PR DESCRIPTION
https://app.circleci.com/pipelines/github/checkstyle/checkstyle/43061/workflows/9f6f5ce8-db64-48c9-af4a-f39de76805ab/jobs/1385775/steps

```
Checkout Hazelcast sources...
Cloning into 'hazelcast'...
remote: Enumerating objects: 14011, done.        
remote: Counting objects: 100% (14011/14011), done.        
remote: Compressing objects: 100% (7315/7315), done.        
remote: Total 14011 (delta 6456), reused 13432 (delta 6230), pack-reused 0 (from 0)        
Receiving objects: 100% (14011/14011), 20.86 MiB | 28.95 MiB/s, done.
Resolving deltas: 100% (6456/6456), done.
Updating files: 100% (12177/12177), done.
Running Checkstyle on Apache-licensed modules...
Starting audit...
./.ci/validation.sh: line 26:   838 Killed                  java -jar ../../target/checkstyle-"${CS_POM_VERSION}"-all.jar -c checkstyle/checkstyle.xml -p checkstyle-apache.properties "${apache_files[@]}"

Exited with code exit status 137
```

<img width="1238" height="450" alt="image" src="https://github.com/user-attachments/assets/57b36b45-db92-4eee-a60a-5c2ef44f035a" />
