### PR TITLE
Issue #18435: Fix xdocs Examples AST Consistency for Illegaltoken exa…

### DIFF
--- a/src/site/xdoc/checks/coding/illegaltoken.xml
+++ b/src/site/xdoc/checks/coding/illegaltoken.xml
@@ -63,7 +63,9 @@
         <p id="Example1-code">Example:</p>
         <div class="wrapper"><pre class="prettyprint"><code class="language-java">
 class Example1 {
-  void InvalidExample() {
+  native void InvalidExample();
+
+  void anotherMethod() {
     outer: // violation, 'Using 'outer:' is not allowed'
     for (int i = 0; i &lt; 5; i++) {
       if (i == 1) {
@@ -89,6 +91,15 @@ class Example1 {
         <div class="wrapper"><pre class="prettyprint"><code class="language-java">
 class Example2 {
   native void InvalidExample(); // violation, 'Using 'native' is not allowed'
+
+  void anotherMethod() {
+    outer:
+    for (int i = 0; i &lt; 5; i++) {
+      if (i == 1) {
+        break outer;
+      }
+    }
+  }
 }
 </code></pre></div>
       </subsection>

--- a/src/test/java/com/puppycrawl/tools/checkstyle/internal/XdocsExamplesAstConsistencyTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/internal/XdocsExamplesAstConsistencyTest.java
@@ -94,7 +94,6 @@ public class XdocsExamplesAstConsistencyTest {
             "checks/blocks/emptycatchblock/Example4",
             "checks/blocks/emptycatchblock/Example5",
             "checks/blocks/needbraces/Example6",
-            "checks/coding/illegaltoken/Example2",
             "checks/coding/illegaltokentext/Example3",
             "checks/coding/illegaltokentext/Example4",
             "checks/coding/illegaltokentext/Example5",

--- a/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/checks/coding/IllegalTokenCheckExamplesTest.java
+++ b/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/checks/coding/IllegalTokenCheckExamplesTest.java
@@ -32,7 +32,7 @@ public class IllegalTokenCheckExamplesTest extends AbstractExamplesModuleTestSup
     @Test
     public void testExample1() throws Exception {
         final String[] expected = {
-            "13:10: " + getCheckMessage(IllegalTokenCheck.MSG_KEY, "outer:"),
+            "15:10: " + getCheckMessage(IllegalTokenCheck.MSG_KEY, "outer:"),
         };
 
         verifyWithInlineConfigParser(getPath("Example1.java"), expected);

--- a/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/coding/illegaltoken/Example1.java
+++ b/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/coding/illegaltoken/Example1.java
@@ -9,7 +9,9 @@ package com.puppycrawl.tools.checkstyle.checks.coding.illegaltoken;
 
 // xdoc section -- start
 class Example1 {
-  void InvalidExample() {
+  native void InvalidExample();
+
+  void anotherMethod() {
     outer: // violation, 'Using 'outer:' is not allowed'
     for (int i = 0; i < 5; i++) {
       if (i == 1) {

--- a/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/coding/illegaltoken/Example2.java
+++ b/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/coding/illegaltoken/Example2.java
@@ -12,5 +12,14 @@ package com.puppycrawl.tools.checkstyle.checks.coding.illegaltoken;
 // xdoc section -- start
 class Example2 {
   native void InvalidExample(); // violation, 'Using 'native' is not allowed'
+
+  void anotherMethod() {
+    outer:
+    for (int i = 0; i < 5; i++) {
+      if (i == 1) {
+        break outer;
+      }
+    }
+  }
 }
 // xdoc section -- end


### PR DESCRIPTION
Issue: #18435 

**Description:**
Unified the code structure in `Example1.java` and `Example2.java` for the `IllegalToken` check to resolve the AST consistency test failure. Removed `Example2` from the suppression list.
