### PR TITLE
Issue #18435:  Fix AST consistency in IllegalToken Example1

### DIFF
--- a/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/coding/illegaltoken/Example1.java
+++ b/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/coding/illegaltoken/Example1.java
@@ -9,15 +9,15 @@ package com.puppycrawl.tools.checkstyle.checks.coding.illegaltoken;
 
 // xdoc section -- start
 class Example1 {
-  native void InvalidExample();
+    native void InvalidExample(); // violation, 'Using 'native' is not allowed'
 
-  void anotherMethod() {
-    outer: // violation, 'Using 'outer:' is not allowed'
-    for (int i = 0; i < 5; i++) {
-      if (i == 1) {
-        break outer;
-      }
+    void anotherMethod() {
+        outer:
+        for (int i = 0; i < 5; i++) {
+            if (i == 1) {
+                break outer;
+            }
+        }
     }
-  }
 }
 // xdoc section -- end


### PR DESCRIPTION
Fixes #18435

Updated the violation comment placement in Example1.java to ensure AST
documentation consistency in IllegalToken examples.
