### PR TITLE
Issue #19064: Add third test to XpathRegressionArrayTrailingCommaTest

### DIFF
--- a/config/checkstyle-non-main-files-suppressions.xml
+++ b/config/checkstyle-non-main-files-suppressions.xml
@@ -414,7 +414,6 @@
 
   <suppress id="numberOfTestCasesInXpath" files="[\\/]src[\\/]it[\\/]java[\\/]org[\\/]checkstyle[\\/]suppressionxpathfilter[\\/]XpathRegressionOuterTypeFilenameTest.java" />
   <suppress id="numberOfTestCasesInXpath" files="[\\/]src[\\/]it[\\/]java[\\/]org[\\/]checkstyle[\\/]suppressionxpathfilter[\\/]XpathRegressionTodoCommentTest.java" />
-  <suppress id="numberOfTestCasesInXpath" files="[\\/]src[\\/]it[\\/]java[\\/]org[\\/]checkstyle[\\/]suppressionxpathfilter[\\/]coding[\\/]XpathRegressionArrayTrailingCommaTest.java" />
   <suppress id="numberOfTestCasesInXpath" files="[\\/]src[\\/]it[\\/]java[\\/]org[\\/]checkstyle[\\/]suppressionxpathfilter[\\/]coding[\\/]XpathRegressionAvoidDoubleBraceInitializationTest.java" />
   <suppress id="numberOfTestCasesInXpath" files="[\\/]src[\\/]it[\\/]java[\\/]org[\\/]checkstyle[\\/]suppressionxpathfilter[\\/]coding[\\/]XpathRegressionAvoidNoArgumentSuperConstructorCallTest.java" />
   <suppress id="numberOfTestCasesInXpath" files="[\\/]src[\\/]it[\\/]java[\\/]org[\\/]checkstyle[\\/]suppressionxpathfilter[\\/]coding[\\/]XpathRegressionDefaultComesLastTest.java" />

--- a/src/it/java/org/checkstyle/suppressionxpathfilter/coding/XpathRegressionArrayTrailingCommaTest.java
+++ b/src/it/java/org/checkstyle/suppressionxpathfilter/coding/XpathRegressionArrayTrailingCommaTest.java
@@ -96,4 +96,34 @@ public class XpathRegressionArrayTrailingCommaTest extends AbstractXpathTestSupp
                 expectedXpathQueries);
     }
 
+    @Test
+    public void testInsideMethod() throws Exception {
+        final File fileToProcess =
+                new File(getPath("InputXpathArrayTrailingCommaInsideMethod.java"));
+
+        final DefaultConfiguration moduleConfig =
+                createModuleConfig(ArrayTrailingCommaCheck.class);
+
+        final String[] expectedViolation = {
+            "9:17: " + getCheckMessage(ArrayTrailingCommaCheck.class,
+                ArrayTrailingCommaCheck.MSG_KEY),
+        };
+
+        final List<String> expectedXpathQueries = Arrays.asList(
+                "/COMPILATION_UNIT/CLASS_DEF"
+                        + "[./IDENT[@text='InputXpathArrayTrailingCommaInsideMethod']]"
+                        + "/OBJBLOCK/METHOD_DEF[./IDENT[@text='method']]/SLIST"
+                        + "/VARIABLE_DEF[./IDENT[@text='a']]/ASSIGN/EXPR/LITERAL_NEW"
+                        + "/ARRAY_INIT/EXPR[./NUM_INT[@text='3']]",
+                "/COMPILATION_UNIT/CLASS_DEF"
+                        + "[./IDENT[@text='InputXpathArrayTrailingCommaInsideMethod']]"
+                        + "/OBJBLOCK/METHOD_DEF[./IDENT[@text='method']]/SLIST"
+                        + "/VARIABLE_DEF[./IDENT[@text='a']]/ASSIGN/EXPR/LITERAL_NEW"
+                        + "/ARRAY_INIT/EXPR/NUM_INT[@text='3']"
+        );
+
+        runVerifications(moduleConfig, fileToProcess, expectedViolation,
+                expectedXpathQueries);
+    }
+
 }

--- a/src/it/resources/org/checkstyle/suppressionxpathfilter/coding/arraytrailingcomma/InputXpathArrayTrailingCommaInsideMethod.java
+++ b/src/it/resources/org/checkstyle/suppressionxpathfilter/coding/arraytrailingcomma/InputXpathArrayTrailingCommaInsideMethod.java
@@ -1,0 +1,12 @@
+package org.checkstyle.suppressionxpathfilter.coding.arraytrailingcomma;
+
+public class InputXpathArrayTrailingCommaInsideMethod {
+
+    void method() {
+        int[] a = new int[] {
+                1,
+                2,
+                3 // warn
+        };
+    }
+}


### PR DESCRIPTION
Issue: #19064

This PR adds a third required test case to
XpathRegressionArrayTrailingCommaTest for an array initializer inside a method.

Changes:
- added testInsideMethod to XpathRegressionArrayTrailingCommaTest
- added InputXpathArrayTrailingCommaInsideMethod.java
- removed the temporary suppression entry for
  `XpathRegressionArrayTrailingCommaTest` from
  config/checkstyle-non-main-files-suppressions.xml