### PR TITLE
minor: escape '>' in UseEnhancedSwitch xml documentation

### DIFF
--- a/src/main/resources/com/puppycrawl/tools/checkstyle/meta/checks/coding/UseEnhancedSwitchCheck.xml
+++ b/src/main/resources/com/puppycrawl/tools/checkstyle/meta/checks/coding/UseEnhancedSwitchCheck.xml
@@ -5,20 +5,20 @@
              name="UseEnhancedSwitch"
              parent="com.puppycrawl.tools.checkstyle.TreeWalker">
          <description>&lt;div&gt;
- Ensures that the enhanced switch (using &lt;code&gt;-&gt;&lt;/code&gt; for case labels) is used
+ Ensures that the enhanced switch (using &lt;code&gt;-&amp;gt;&lt;/code&gt; for case labels) is used
  instead of the traditional switch (using &lt;code&gt;:&lt;/code&gt; for case labels) where possible.
  &lt;/div&gt;
 
  &lt;p&gt;
  Rationale: Java 14 has introduced enhancements for switch statements and expressions
- that disallow fall-through behavior. The enhanced switch syntax using &lt;code&gt;-&gt;&lt;/code&gt;
+ that disallow fall-through behavior. The enhanced switch syntax using &lt;code&gt;-&amp;gt;&lt;/code&gt;
  for case labels typically leads to more concise and readable code, reducing the likelihood
  of errors associated with fall-through cases.
  &lt;/p&gt;
 
  &lt;p&gt;
  See the &lt;a href="https://docs.oracle.com/javase/specs/jls/se22/html/jls-14.html#jls-14.11.1-200"&gt;
- Java Language Specification&lt;/a&gt; for more information about &lt;code&gt;-&gt;&lt;/code&gt; case labels, also known as
+ Java Language Specification&lt;/a&gt; for more information about &lt;code&gt;-&amp;gt;&lt;/code&gt; case labels, also known as
  "switch rules".
  &lt;/p&gt;</description>
          <message-keys>

--- a/src/site/xdoc/checks.xml
+++ b/src/site/xdoc/checks.xml
@@ -2047,7 +2047,7 @@
               </a>
             </td>
             <td>
-              Ensures that the enhanced switch (using <code>-></code> for case labels) is used
+              Ensures that the enhanced switch (using <code>-&gt;</code> for case labels) is used
               instead of the traditional switch (using <code>:</code> for case labels) where
               possible.
             </td>

--- a/src/site/xdoc/checks/coding/index.xml
+++ b/src/site/xdoc/checks/coding/index.xml
@@ -628,7 +628,7 @@
               </a>
             </td>
             <td>
-              Ensures that the enhanced switch (using <code>-></code> for case labels) is used
+              Ensures that the enhanced switch (using <code>-&gt;</code> for case labels) is used
               instead of the traditional switch (using <code>:</code> for case labels) where
               possible.
             </td>

--- a/src/site/xdoc/checks/coding/useenhancedswitch.xml
+++ b/src/site/xdoc/checks/coding/useenhancedswitch.xml
@@ -10,20 +10,20 @@
       <p>Since Checkstyle 13.3.0</p>
       <subsection name="Description" id="UseEnhancedSwitch_Description">
         <div>
-          Ensures that the enhanced switch (using <code>-></code> for case labels) is used
+          Ensures that the enhanced switch (using <code>-&gt;</code> for case labels) is used
           instead of the traditional switch (using <code>:</code> for case labels) where possible.
         </div>
 
         <p>
           Rationale: Java 14 has introduced enhancements for switch statements and expressions
-          that disallow fall-through behavior. The enhanced switch syntax using <code>-></code>
+          that disallow fall-through behavior. The enhanced switch syntax using <code>-&gt;</code>
           for case labels typically leads to more concise and readable code, reducing the likelihood
           of errors associated with fall-through cases.
         </p>
 
         <p>
           See the <a href="https://docs.oracle.com/javase/specs/jls/se22/html/jls-14.html#jls-14.11.1-200">
-          Java Language Specification</a> for more information about <code>-></code> case labels, also known as
+          Java Language Specification</a> for more information about <code>-&gt;</code> case labels, also known as
           "switch rules".
         </p>
       </subsection>


### PR DESCRIPTION
Escape > as `&gt;` in UseEnhancedSwitch XML documentation, missed due to merge ordering with #19010