### PR TITLE
Issue #19147: Migrate JavadocVariableCheck to use AST rather than get…

### DIFF
--- a/config/checker-framework-suppressions/checker-nullness-optional-interning-suppressions.xml
+++ b/config/checker-framework-suppressions/checker-nullness-optional-interning-suppressions.xml
@@ -6326,8 +6326,29 @@
   <checkerFrameworkError unstable="false">
     <fileName>src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocVariableCheck.java</fileName>
     <specifier>dereference.of.nullable</specifier>
+    <message>dereference of possibly-null reference annotations</message>
+    <lineContent>result = hasJavadocCommentOnAnnotations(annotations)</lineContent>
+  </checkerFrameworkError>
+
+  <checkerFrameworkError unstable="false">
+    <fileName>src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocVariableCheck.java</fileName>
+    <specifier>dereference.of.nullable</specifier>
     <message>dereference of possibly-null reference ast.findFirstToken(TokenTypes.IDENT)</message>
     <lineContent>final String name = ast.findFirstToken(TokenTypes.IDENT).getText();</lineContent>
+  </checkerFrameworkError>
+
+  <checkerFrameworkError unstable="false">
+    <fileName>src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocVariableCheck.java</fileName>
+    <specifier>dereference.of.nullable</specifier>
+    <message>dereference of possibly-null reference modifiers</message>
+    <lineContent>boolean found = hasBlockCommentJavadoc(modifiers.getFirstChild());</lineContent>
+  </checkerFrameworkError>
+
+  <checkerFrameworkError unstable="false">
+    <fileName>src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocVariableCheck.java</fileName>
+    <specifier>dereference.of.nullable</specifier>
+    <message>dereference of possibly-null reference type</message>
+    <lineContent>DetailAST firstChild = type.getFirstChild();</lineContent>
   </checkerFrameworkError>
 
   <checkerFrameworkError unstable="false">

--- a/config/suppressions.xml
+++ b/config/suppressions.xml
@@ -134,7 +134,6 @@
   <suppress id="noUsageOfGetFileContentsMethod" files="JavadocMethodCheck.java"/>
   <suppress id="noUsageOfGetFileContentsMethod" files="JavadocStyleCheck.java"/>
   <suppress id="noUsageOfGetFileContentsMethod" files="JavadocTypeCheck.java"/>
-  <suppress id="noUsageOfGetFileContentsMethod" files="JavadocVariableCheck.java"/>
   <suppress id="noUsageOfGetFileContentsMethod" files="MissingJavadocMethodCheck.java"/>
   <suppress id="noUsageOfGetFileContentsMethod" files="MissingJavadocTypeCheck.java"/>
   <suppress id="noUsageOfGetFileContentsMethod" files="RegexpCheck.java"/>

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocVariableCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocVariableCheck.java
@@ -25,11 +25,10 @@ import java.util.regex.Pattern;
 import com.puppycrawl.tools.checkstyle.StatelessCheck;
 import com.puppycrawl.tools.checkstyle.api.AbstractCheck;
 import com.puppycrawl.tools.checkstyle.api.DetailAST;
-import com.puppycrawl.tools.checkstyle.api.FileContents;
-import com.puppycrawl.tools.checkstyle.api.TextBlock;
 import com.puppycrawl.tools.checkstyle.api.TokenTypes;
 import com.puppycrawl.tools.checkstyle.checks.naming.AccessModifierOption;
 import com.puppycrawl.tools.checkstyle.utils.CheckUtil;
+import com.puppycrawl.tools.checkstyle.utils.JavadocUtil;
 import com.puppycrawl.tools.checkstyle.utils.ScopeUtil;
 import com.puppycrawl.tools.checkstyle.utils.UnmodifiableCollectionUtil;
 
@@ -120,19 +119,16 @@ public class JavadocVariableCheck
         };
     }
 
-    // suppress deprecation until https://github.com/checkstyle/checkstyle/issues/11166
     @Override
-    @SuppressWarnings("deprecation")
     public void visitToken(DetailAST ast) {
-        if (shouldCheck(ast)) {
-            final FileContents contents = getFileContents();
-            final TextBlock textBlock =
-                contents.getJavadocBefore(ast.getLineNo());
-
-            if (textBlock == null) {
-                log(ast, MSG_JAVADOC_MISSING);
-            }
+        if (shouldCheck(ast) && !hasJavadocComment(ast)) {
+            log(ast, MSG_JAVADOC_MISSING);
         }
+    }
+
+    @Override
+    public boolean isCommentNodesRequired() {
+        return true;
     }
 
     /**
@@ -201,5 +197,111 @@ public class JavadocVariableCheck
         }
 
         return CheckUtil.getAccessModifierFromModifiersToken(selectedAst);
+    }
+
+    /**
+     * Checks whether the variable definition has a Javadoc comment.
+     * For {@code VARIABLE_DEF}, Javadoc is searched among children of
+     * the {@code MODIFIERS} node and the {@code TYPE} node.
+     * For {@code ENUM_CONSTANT_DEF}, Javadoc is searched among direct
+     * children of the constant definition.
+     *
+     * @param variableDefAst the AST of the variable definition to check.
+     * @return true if a Javadoc comment is found, false otherwise.
+     */
+    private static boolean hasJavadocComment(DetailAST variableDefAst) {
+        final boolean result;
+        if (variableDefAst.getType() == TokenTypes.VARIABLE_DEF) {
+            result = hasJavadocCommentOnVariable(variableDefAst);
+        }
+        else {
+            // For enum constants, Javadoc can be attached to the constant definition itself, or to its annotations if they exist.
+            final DetailAST annotations = variableDefAst.findFirstToken(TokenTypes.ANNOTATIONS);
+            result = hasJavadocCommentOnAnnotations(annotations) || hasBlockCommentJavadoc(variableDefAst.getFirstChild());
+        }
+        return result;
+    }
+
+    /**
+     * Checks whether a {@code VARIABLE_DEF} has a Javadoc comment
+     * attached to its modifiers, annotations, or type.
+     * For a {@code VARIABLE_DEF}, Javadoc can be attached to the modifiers,
+     * annotations, or type.
+     * This method checks for Javadoc comments in all of these locations
+     * to ensure that the variable definition is properly documented.
+     *
+     * @param variableDefAst the AST of the variable definition to check.
+     * @return true if a Javadoc comment is found, false otherwise.
+     */
+    private static boolean hasJavadocCommentOnVariable(
+        DetailAST variableDefAst) {
+        final DetailAST modifiers =
+            variableDefAst.findFirstToken(TokenTypes.MODIFIERS);
+
+        boolean found = hasBlockCommentJavadoc(modifiers.getFirstChild());
+
+        if (!found) {
+            found = hasJavadocCommentOnAnnotations(modifiers);
+        }
+
+        if (!found) {
+            final DetailAST type =
+                variableDefAst.findFirstToken(TokenTypes.TYPE);
+            DetailAST firstChild = type.getFirstChild();
+            found = hasBlockCommentJavadoc(firstChild);
+
+            while (!found) {
+                if (firstChild.getType() != TokenTypes.DOT) {
+                    break;
+                }
+
+                firstChild = firstChild.getFirstChild();
+                found = hasBlockCommentJavadoc(firstChild);
+            }
+        }
+
+        return found;
+    }
+
+    /**
+     * Checks whether any annotation within the modifiers has a
+     * Javadoc comment as a child node.
+     *
+     * @param modifiers the MODIFIERS node.
+     * @return true if a Javadoc comment exists inside any annotation.
+     */
+    private static boolean hasJavadocCommentOnAnnotations(
+            DetailAST modifiers) {
+        boolean found = false;
+        for (DetailAST child = modifiers.getFirstChild();
+                child != null; child = child.getNextSibling()) {
+            if (hasBlockCommentJavadoc(child.getFirstChild())) {
+                found = true;
+                break;
+            }
+        }
+        return found;
+    }
+
+    /**
+     * Checks whether the given AST node or any of its siblings is a
+     * block comment that is a Javadoc comment.
+     *
+     * @param firstChild the first child of the node to check.
+     * @return true if a Javadoc block comment is found among the
+     *     siblings, false otherwise.
+     */
+    private static boolean hasBlockCommentJavadoc(DetailAST firstChild) {
+        boolean found = false;
+        for (DetailAST child = firstChild; child != null;
+                child = child.getNextSibling()) {
+            if (child.getType() == TokenTypes.BLOCK_COMMENT_BEGIN
+                    && JavadocUtil.isJavadocComment(
+                        JavadocUtil.getBlockCommentContent(child))) {
+                found = true;
+                break;
+            }
+        }
+        return found;
     }
 }

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocVariableCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocVariableCheckTest.java
@@ -428,4 +428,74 @@ public class JavadocVariableCheckTest
             getPath("InputJavadocVariableAboveComment.java"),
             expected);
     }
+
+    @Test
+    public void testJavadocOnAnnotatedField() throws Exception {
+        final String[] expected = {
+            "17:5: " + getCheckMessage(MSG_JAVADOC_MISSING),
+            "24:5: " + getCheckMessage(MSG_JAVADOC_MISSING),
+            "30:5: " + getCheckMessage(MSG_JAVADOC_MISSING),
+        };
+        verifyWithInlineConfigParser(
+            getPath("InputJavadocVariableOnAnnotatedField.java"),
+            expected);
+    }
+
+    @Test
+    public void testJavadocOnPrivateEnumConstants() throws Exception {
+        final String[] expected = {
+            "21:9: " + getCheckMessage(MSG_JAVADOC_MISSING),
+        };
+        verifyWithInlineConfigParser(
+            getPath("InputJavadocVariableOnPrivateEnumConstants.java"),
+            expected);
+    }
+
+    @Test
+    public void testJavadocOnType() throws Exception {
+        final String[] expected = {
+            "16:5: " + getCheckMessage(MSG_JAVADOC_MISSING),
+            "17:5: " + getCheckMessage(MSG_JAVADOC_MISSING),
+        };
+        verifyWithInlineConfigParser(
+            getPath("InputJavadocVariableJavadocOnType.java"),
+            expected);
+    }
+
+    @Test
+    public void testMultipleAnnotations() throws Exception {
+        final String[] expected = {
+            "18:5: " + getCheckMessage(MSG_JAVADOC_MISSING),
+            "30:5: " + getCheckMessage(MSG_JAVADOC_MISSING),
+        };
+        verifyWithInlineConfigParser(
+            getPath("InputJavadocVariableMultipleAnnotations.java"),
+            expected);
+    }
+
+    @Test
+    public void testEnumsWithAnnotations() throws Exception {
+        final String[] expected = {
+            "25:9: " + getCheckMessage(MSG_JAVADOC_MISSING),
+            "27:9: " + getCheckMessage(MSG_JAVADOC_MISSING),
+        };
+        verifyWithInlineConfigParser(
+            getPath("InputJavadocVariableEnumsWithAnnotations.java"),
+            expected);
+    }
+
+    @Test
+    public void testJavadocOnPackagePrivate() throws Exception {
+        final String[] expected = {
+            "16:5: " + getCheckMessage(MSG_JAVADOC_MISSING),
+            "21:5: " + getCheckMessage(MSG_JAVADOC_MISSING),
+            "32:14: " + getCheckMessage(MSG_JAVADOC_MISSING),
+            "34:14: " + getCheckMessage(MSG_JAVADOC_MISSING),
+            "39:14: " + getCheckMessage(MSG_JAVADOC_MISSING),
+            "43:5: " + getCheckMessage(MSG_JAVADOC_MISSING),
+            "48:18: " + getCheckMessage(MSG_JAVADOC_MISSING),
+        };
+        verifyWithInlineConfigParser(
+                getPath("InputJavadocVariablePackagePrivate.java"), expected);
+    }
 }

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadocvariable/InputJavadocVariableEnumsWithAnnotations.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadocvariable/InputJavadocVariableEnumsWithAnnotations.java
@@ -1,0 +1,29 @@
+/*
+JavadocVariable
+accessModifiers = (default)public,protected,package,private
+ignoreNamePattern = (default)null
+tokens = (default)ENUM_CONSTANT_DEF
+
+*/
+package com.puppycrawl.tools.checkstyle.checks.javadoc.javadocvariable;
+
+public class InputJavadocVariableEnumsWithAnnotations {
+    public enum EnumWithAnnotations {
+        /** Enum constant. */
+        ENUM_CONSTANT1,
+        /** Enum constant. */
+        @Deprecated
+        ENUM_CONSTANT2,
+        /** Enum constant. */
+        @Deprecated(since = "1.5", forRemoval = true)
+        ENUM_CONSTANT3
+    }
+
+    private enum EnumWithAnnotationsAndNoJavadoc {
+        /** Enum constant. */
+        ENUM_CONSTANT1,
+        @Deprecated // violation, 'Missing a Javadoc comment'
+        ENUM_CONSTANT2,
+        ENUM_CONSTANT3 // violation, 'Missing a Javadoc comment'
+    }
+}

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadocvariable/InputJavadocVariableJavadocOnType.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadocvariable/InputJavadocVariableJavadocOnType.java
@@ -1,0 +1,19 @@
+/*
+JavadocVariable
+accessModifiers = (default)public,protected,package,private
+ignoreNamePattern = (default)null
+tokens = ENUM_CONSTANT_DEF, VARIABLE_DEF
+
+*/
+
+package com.puppycrawl.tools.checkstyle.checks.javadoc.javadocvariable;
+
+public class InputJavadocVariableJavadocOnType {
+
+    // Javadoc placed between modifier and type
+    public /** some javadoc */ int fieldWithJavadocOnType;
+
+    public int fieldWithoutJavadoc; // violation, 'Missing a Javadoc comment.'
+    public /* not javadoc */ int fieldWithRegularComment; // violation, 'Missing a Javadoc comment.'
+}
+

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadocvariable/InputJavadocVariableMultipleAnnotations.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadocvariable/InputJavadocVariableMultipleAnnotations.java
@@ -1,0 +1,37 @@
+/*
+JavadocVariable
+accessModifiers = (default)public,protected,package,private
+ignoreNamePattern = (default)null
+tokens = ENUM_CONSTANT_DEF, VARIABLE_DEF
+
+*/
+
+package com.puppycrawl.tools.checkstyle.checks.javadoc.javadocvariable;
+
+public class InputJavadocVariableMultipleAnnotations {
+
+    @Deprecated
+    /** Javadoc between annotations. */
+    @SuppressWarnings("unused")
+    private int fieldWithJavadocBetweenAnnotations;
+
+    @Deprecated // violation, 'Missing a Javadoc comment.'
+    @SuppressWarnings("unused")
+    private int fieldWithMultipleAnnotationsNoJavadoc;
+
+    /** Javadoc on field with annotation. */
+    @Deprecated
+    private int fieldWithJavadocOnFirstAnnotation;
+
+    /** Javadoc with public modifier and annotation. */
+    public @Deprecated
+    int fieldWithPublicAndAnnotation;
+
+    @SuppressWarnings("unused") // violation, 'Missing a Javadoc comment.
+    public /* not a javadoc comment */ int fieldWithAnnotationAndBlockComment;
+
+    @Deprecated
+    @SuppressWarnings("unused")
+    /** Javadoc after both annotations. */
+    private int fieldWithJavadocAfterAnnotations;
+}

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadocvariable/InputJavadocVariableOnAnnotatedField.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadocvariable/InputJavadocVariableOnAnnotatedField.java
@@ -1,0 +1,31 @@
+/*
+JavadocVariable
+accessModifiers = (default)public,protected,package,private
+ignoreNamePattern = (default)null
+tokens = ENUM_CONSTANT_DEF, VARIABLE_DEF
+
+*/
+
+package com.puppycrawl.tools.checkstyle.checks.javadoc.javadocvariable;
+
+public class InputJavadocVariableOnAnnotatedField {
+
+    /** Javadoc above annotation. */
+    @SuppressWarnings("unused")
+    private int annotatedFieldWithJavadoc;
+
+    @SuppressWarnings("unused") // violation, 'Missing a Javadoc comment.'
+    private int annotatedFieldWithoutJavadoc;
+
+    /** Javadoc with public modifier and annotation. */
+    public @Deprecated
+    int fieldWithPublicAndAnnotation;
+
+    public static final int fieldWithModifiersOnly = 1; // violation, 'Missing a Javadoc comment.'
+
+    /** Javadoc on field with annotation. */
+    @SuppressWarnings("unused")
+    public static final int fieldWithAnnotationAndJavadoc = 2;
+
+    private static int fieldWithModifiersNoAnnotation = 3; // violation, 'Missing'
+}

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadocvariable/InputJavadocVariableOnPrivateEnumConstants.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadocvariable/InputJavadocVariableOnPrivateEnumConstants.java
@@ -1,0 +1,24 @@
+/*
+JavadocVariable
+accessModifiers = (default)public,protected,package,private
+ignoreNamePattern = (default)null
+tokens = ENUM_CONSTANT_DEF, VARIABLE_DEF
+
+*/
+
+package com.puppycrawl.tools.checkstyle.checks.javadoc.javadocvariable;
+
+public class InputJavadocVariableOnPrivateEnumConstants {
+
+    private enum PrivateEnum {
+
+        /** Documented private constant. */
+        PRIVATE_DOCUMENTED,
+
+        /** Another documented constant. */
+        ANOTHER_DOCUMENTED,
+
+        PRIVATE_UNDOCUMENTED, // violation, 'Missing a Javadoc comment.'
+    }
+}
+

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadocvariable/InputJavadocVariablePackagePrivate.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadocvariable/InputJavadocVariablePackagePrivate.java
@@ -1,0 +1,54 @@
+/*
+JavadocVariable
+accessModifiers = (default)public,protected,package,private
+ignoreNamePattern = (default)null
+tokens = ENUM_CONSTANT_DEF, VARIABLE_DEF
+
+*/
+
+package com.puppycrawl.tools.checkstyle.checks.javadoc.javadocvariable;
+
+public class InputJavadocVariablePackagePrivate {
+
+    /** Some javadoc */
+    String packagePrivateVar = "test";
+
+    public String publicVar = "test"; // violation, 'Missing a Javadoc comment'
+
+    /** Some javadoc */
+    public  static final String PUBLIC_STATIC_FINAL_VAR = "test";
+
+    protected String protectedVar2 = "test"; // violation, 'Missing a Javadoc comment'
+
+    /** Some javadoc */
+    private String privateVar = "test";
+
+    /** Some javadoc */
+    protected String protectedVar = "test";
+
+    /** Some javadoc */
+    java.lang.String state = "test";
+
+    java.lang.String state2 = "test"; // violation, 'Missing a Javadoc comment'
+
+    java.util.List<String> state3 = null; // violation, 'Missing a Javadoc comment'
+
+    /** Some javadoc */
+    java.util.List<String> state4;
+
+    java.util.List<String> state5; // violation, 'Missing a Javadoc comment'
+
+    public /** some javadoc */ java.lang.String fieldWithJavadocOnType2;
+
+    public java.lang.String fieldWithoutJavadoc2; // violation, 'Missing a Javadoc comment.'
+
+    /** Some javadoc */
+    java.util.Map.Entry<String, String> deepDotField1;
+
+    java.util.Map.Entry<String, String> deepDotField2; // violation, 'Missing a Javadoc comment'
+
+    /** Some javadoc - To kill pitest mutations */
+    java.util.Map./** javadoc on middle dot */ Entry<String, String> deepDotJavadocOnMiddle;
+
+    public /** javadoc at outermost */ java.util.Map.Entry<String, String> deepDotJavadocOnType;
+}


### PR DESCRIPTION
Issue: #19147

Diff Regression config: https://gist.githubusercontent.com/Tasneemmohammed0/7eab0e8ac4114af0cc7fb0ef4ba0b751/raw/3b94ba729a6c7c19ef9a13c325da77d04b7b2d80/my_check.xml
 
Migrate `JavadocVariableCheck` from the deprecated regexp-based `getFileConents()` to AST-based Javadoc detection.

> [!IMPORTANT]
> I know the issue description suggested extending `AbstractJavadocCheck`.  I tried implementing it that way, but it did not make much sense in this case.
>  I explored two possible approaches. I followed **Approach 1**, but here are more details (happy to discuss and change the implementation if needed :) ).

## Approach 1 (Current Implementation)
- Replaced the deprecated `getFileContents()` call with AST-based Javadoc detection using `BLOCK_COMMENT_BEGIN` nodes together with `JavadocUtil.isJavadocComment()`.
- Overrode `isCommentNodesRequired()` to return `true` so comment nodes are available in the AST.
- Added helper methods to walk the AST and locate Javadoc comments in valid positions around variables and enum constants.

With this approach, Javadoc presence is checked directly when visiting `VARIABLE_DEF` or `ENUM_CONSTANT_DEF` tokens.

## Approach 2
- Extend `AbstractJavadocCheck`.
- Collect all variables/enums first.
- While visiting Javadoc tokens, check the parent node to determine whether the Javadoc belongs to a variable or enum.

I think this approach is less efficient since it requires traversing the tree twice: once to collect variables/enums (traversed manually) and another time while processing Javadoc tokens.

By keeping `AbstractCheck` and enabling comment nodes, we can detect Javadoc presence in a **single pass** while visiting each `VARIABLE_DEF` / `ENUM_CONSTANT_DEF` token directly. This keeps the logic simpler and aligns with how the check already operates.