### PR TITLE
doc: add non-default basicOffset example for IndentationCheck

### DIFF
--- a/src/test/java/com/puppycrawl/tools/checkstyle/internal/XdocsExampleFileTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/internal/XdocsExampleFileTest.java
@@ -61,7 +61,6 @@ public class XdocsExampleFileTest {
             Map.entry("JavadocStyleCheck", Set.of("endOfSentenceFormat")),
             Map.entry("SuppressWarningsHolder", Set.of("aliasList")),
             Map.entry("IndentationCheck", Set.of(
-                    "basicOffset",
                     "lineWrappingIndentation",
                     "throwsIndent",
                     "arrayInitIndent",

--- a/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/checks/indentation/IndentationCheckExamplesTest.java
+++ b/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/checks/indentation/IndentationCheckExamplesTest.java
@@ -61,4 +61,10 @@ public class IndentationCheckExamplesTest extends AbstractExamplesModuleTestSupp
         final String[] expected = {};
         verifyWithInlineConfigParser(getPath("Example4.java"), expected);
     }
+
+    @Test
+    public void testExample5() throws Exception {
+        final String[] expected = {};
+        verifyWithInlineConfigParser(getPath("Example5.java"), expected);
+    }
 }

--- a/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/indentation/indentation/Example5.java
+++ b/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/indentation/indentation/Example5.java
@@ -1,0 +1,57 @@
+/*xml
+<module name="Checker">
+  <module name="TreeWalker">
+    <module name="Indentation">
+      <property name="basicOffset" value="2"/>
+    </module>
+  </module>
+</module>
+*/
+
+package com.puppycrawl.tools.checkstyle.checks.indentation.indentation;
+
+// xdoc section -- start
+class Example5 {
+    String field = "example";                  // basicOffset
+    int[] values = {                           // basicOffset
+        10,
+        20,
+        30
+    };
+
+    void processValues() throws Exception {
+        handleValue("Test String", 42);          // basicOffset
+    }
+
+    void handleValue(String aFooString,
+                     int aFooInt) {             // indent:8 ; expected: > 4;
+
+        boolean cond1,cond2,cond3,cond4,cond5,cond6;
+        cond1=cond2=cond3=cond4=cond5=cond6=false;
+
+        if (cond1
+            || cond2) {
+            field = field.toUpperCase()
+                .concat(" TASK");
+        }
+
+        if ((cond1 && cond2)
+                || (cond3 && cond4)          // ok, lineWrappingIndentation
+                || !(cond5 && cond6)) {      // ok, lineWrappingIndentation
+            field.toUpperCase()
+                 .concat(" TASK")             // ok, lineWrappingIndentation
+                 .chars().forEach(c -> {      // ok, lineWrappingIndentation
+                     System.out.println((char) c);
+                 });
+        }
+    }
+
+    void demonstrateSwitch() throws Exception {
+        switch (field) {
+            case "EXAMPLE": processValues();                        // caseIndent
+            case "COMPLETED": handleValue("Completed Case", 456);   // caseIndent
+        }
+    }
+}
+// xdoc section -- end
+


### PR DESCRIPTION
Added a new example (Example5.java) demonstrating the use of the
basicOffset property in IndentationCheck with a non-default value.

Removed basicOffset from the SUPPRESSED_PROPERTIES_BY_CHECK list
in XdocsExampleFileTest since the example now exists.

Issue: #17449