### PR TITLE
Issue #19064: Added third test to XpathRegressionUnusedLocalVariableTest

### DIFF
--- a/config/checkstyle-non-main-files-suppressions.xml
+++ b/config/checkstyle-non-main-files-suppressions.xml
@@ -441,7 +441,6 @@
   <suppress id="numberOfTestCasesInXpath" files="[\\/]src[\\/]it[\\/]java[\\/]org[\\/]checkstyle[\\/]suppressionxpathfilter[\\/]coding[\\/]XpathRegressionUnnecessarySemicolonInTryWithResourcesTest.java" />
   <suppress id="numberOfTestCasesInXpath" files="[\\/]src[\\/]it[\\/]java[\\/]org[\\/]checkstyle[\\/]suppressionxpathfilter[\\/]coding[\\/]XpathRegressionUnusedCatchParameterShouldBeUnnamedTest.java" />
   <suppress id="numberOfTestCasesInXpath" files="[\\/]src[\\/]it[\\/]java[\\/]org[\\/]checkstyle[\\/]suppressionxpathfilter[\\/]coding[\\/]XpathRegressionUnusedLambdaParameterShouldBeUnnamedTest.java" />
-  <suppress id="numberOfTestCasesInXpath" files="[\\/]src[\\/]it[\\/]java[\\/]org[\\/]checkstyle[\\/]suppressionxpathfilter[\\/]coding[\\/]XpathRegressionUnusedLocalVariableTest.java" />
   <suppress id="numberOfTestCasesInXpath" files="[\\/]src[\\/]it[\\/]java[\\/]org[\\/]checkstyle[\\/]suppressionxpathfilter[\\/]coding[\\/]XpathRegressionVariableDeclarationUsageDistanceTest.java" />
   <suppress id="numberOfTestCasesInXpath" files="[\\/]src[\\/]it[\\/]java[\\/]org[\\/]checkstyle[\\/]suppressionxpathfilter[\\/]coding[\\/]XpathRegressionWhenShouldBeUsedTest.java" />
   <suppress id="numberOfTestCasesInXpath" files="[\\/]src[\\/]it[\\/]java[\\/]org[\\/]checkstyle[\\/]suppressionxpathfilter[\\/]design[\\/]XpathRegressionDesignForExtensionTest.java" />

--- a/src/it/java/org/checkstyle/suppressionxpathfilter/coding/XpathRegressionUnusedLocalVariableTest.java
+++ b/src/it/java/org/checkstyle/suppressionxpathfilter/coding/XpathRegressionUnusedLocalVariableTest.java
@@ -112,4 +112,42 @@ public class XpathRegressionUnusedLocalVariableTest extends AbstractXpathTestSup
                 expectedXpathQueries);
 
     }
+
+    @Test
+    public void testThree() throws Exception {
+        final File fileToProcess = new File(getPath(
+                "InputXpathUnusedLocalVariableThree.java"));
+
+        final DefaultConfiguration moduleConfig =
+            createModuleConfig(UnusedLocalVariableCheck.class);
+
+        final String[] expectedViolation = {
+            "8:9: " + getCheckMessage(UnusedLocalVariableCheck.class,
+                   UnusedLocalVariableCheck.MSG_UNUSED_NAMED_LOCAL_VARIABLE, "c"),
+        };
+
+        final List<String> expectedXpathQueries = Arrays.asList(
+                "/COMPILATION_UNIT/CLASS_DEF[./IDENT["
+                        + "@text='InputXpathUnusedLocalVariableThree']]/OBJBLOCK/"
+                        + "METHOD_DEF[./IDENT[@text='foo']]/SLIST/LITERAL_DO/SLIST/"
+                        + "VARIABLE_DEF[./IDENT[@text='c']]",
+                "/COMPILATION_UNIT/CLASS_DEF[./IDENT["
+                        + "@text='InputXpathUnusedLocalVariableThree']]/OBJBLOCK/"
+                        + "METHOD_DEF[./IDENT[@text='foo']]/SLIST/LITERAL_DO/SLIST/"
+                        + "VARIABLE_DEF[./IDENT[@text='c']]/MODIFIERS",
+                "/COMPILATION_UNIT/CLASS_DEF[./IDENT["
+                        + "@text='InputXpathUnusedLocalVariableThree']]/OBJBLOCK/"
+                        + "METHOD_DEF[./IDENT[@text='foo']]/SLIST/LITERAL_DO/SLIST/"
+                        + "VARIABLE_DEF[./IDENT[@text='c']]/TYPE",
+                "/COMPILATION_UNIT/CLASS_DEF[./IDENT["
+                        + "@text='InputXpathUnusedLocalVariableThree']]/OBJBLOCK/"
+                        + "METHOD_DEF[./IDENT[@text='foo']]/SLIST/LITERAL_DO/SLIST/"
+                        + "VARIABLE_DEF[./IDENT[@text='c']]/TYPE/LITERAL_INT"
+        );
+
+        runVerifications(moduleConfig, fileToProcess, expectedViolation,
+                expectedXpathQueries);
+
+    }
+
 }

--- a/src/it/resources/org/checkstyle/suppressionxpathfilter/coding/unusedlocalvariable/InputXpathUnusedLocalVariableThree.java
+++ b/src/it/resources/org/checkstyle/suppressionxpathfilter/coding/unusedlocalvariable/InputXpathUnusedLocalVariableThree.java
@@ -1,0 +1,12 @@
+package org.checkstyle.suppressionxpathfilter.coding.unusedlocalvariable;
+
+public class InputXpathUnusedLocalVariableThree {
+
+    public void foo(){
+       int i = 0;
+       do{
+        int c = 15; //warn
+        i++;
+       }while(i<5);
+    }
+}


### PR DESCRIPTION
Issue : #19064
Removing `XpathRegressionUnusedLocalVariableTest` from `suppression checkstyle-non-main-files-suppressions.xml`. Adding third test in `XpathRegressionUnusedLocalVariableTest`