### PR TITLE
Issue #14542: show beginning_development to Github

### DIFF
--- a/docs/BEGINNING_DEVELOPMENT.md
+++ b/docs/BEGINNING_DEVELOPMENT.md
@@ -7,6 +7,127 @@
 **This guide is for developers who want to contribute to Checkstyle. It will guide you through
 everything you need to do to complete your first pull request.**
 
+## Contents
+
+- [Before Development](#before-development)
+- [Starting Development](#starting-development)
+
+## Before Development
+
+- Ensure that Git and Java JDK >= 21 are installed.
+
+You can find information about development environment preparation here:
+[Prepare development environment in Ubuntu](https://github.com/sevntu-checkstyle/sevntu.checkstyle/wiki/Prepare-Development-Environment-in-Ubuntu-12.04)
+
+Note: JDK 25 is currently not supported.
+Some test dependencies (cacio-tta, Mockito/ByteBuddy)
+are incompatible with JDK 25. Please use JDK 21 (LTS)
+for development until this issue is resolved.
+See [issue #18361](https://github.com/checkstyle/checkstyle/issues/18361)
+for more details.
+
+- Fork Checkstyle upstream project. As it is described [here](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/fork-a-repo).
+
+- Clone your forked repository to your computer:
+
+```bash
+git clone git@github.com:your_user_name/checkstyle.git
+```
+
+- Before opening project in IDE, build the project in your terminal to download
+
+all needed artifacts. From the repository root folder, run:
+
+```bash
+./mvnw install
+```
+
+## Starting Development
+
+Here you can find instructions about importing and debugging the project for IDEs:
+[Eclipse IDE](https://checkstyle.sourceforge.io/eclipse.html),
+[NetBeans IDE](https://checkstyle.sourceforge.io/netbeans.html),
+[IntelliJ IDEA IDE](https://checkstyle.sourceforge.io/idea.html)
+
+Community video walk throughs of these instructions are available in SteLeo1602's
+[playlist on YouTube](https://www.youtube.com/playlist?list=PLHM9s_lN4X0hzOQ0sUmGdroxW0HfREAqj)
+
+Follow these instructions of Git usage and creating a Pull Request:
+1) Configure remotes by pointing to the official checkstyle repository,
+   naming it "upstream":
+
+```bash
+git remote add upstream https://github.com/checkstyle/checkstyle
+```
+
+2) Create a branch for a new check:
+
+```bash
+git checkout -b my-new-check
+```
+
+3) Commit changes to my-new-check branch:
+
+```bash
+git add .
+git commit -m "commit message"
+```
+
+4) Push branch to GitHub, to allow your mentor to review your code:
+
+```bash
+git push origin my-new-check
+```
+
+5) Repeat steps 3-4 till development is complete
+All additional commits, please [squash to first](https://davidwalsh.name/squash-commits-git)
+Please read all rules for PullRequest at our
+[wiki](https://github.com/checkstyle/checkstyle/wiki/PR-rules).
+
+```bash
+git rebase -i master
+git push --force origin my-new-check
+```
+
+6) Update current branch and local master by pulling changes that were done
+by other contributors:
+
+```bash
+git checkout master
+git pull upstream master
+git push origin master
+```
+
+7) Rebase your branch on your updated master:
+
+```bash
+git checkout my-new-check
+git rebase master
+```
+
+8) In the process of the rebase, it may discover conflicts.
+In that case it will stop and allow you to fix the conflicts.
+After fixing conflicts, use
+
+```bash
+git add .
+```
+
+to update the index with those contents, and then just run:
+
+```bash
+git rebase --continue
+```
+
+9) Push branch to GitHub (with all your final changes and actual code of Checkstyle):
+
+```bash
+git push --force origin my-new-check
+```
+
+10) Only after all content is finished and testing is done - send a
+[Pull Request](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/about-pull-requests)
+
 ## Prerequisites
 
 This guide assumes that you have some basic knowledge of

--- a/src/site/xdoc/beginning_development.xml
+++ b/src/site/xdoc/beginning_development.xml
@@ -1,162 +1,20 @@
 <?xml version="1.0" encoding="UTF-8"?>
-
-<document xmlns="http://maven.apache.org/XDOC/2.0"
-  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-  xsi:schemaLocation="http://maven.apache.org/XDOC/2.0 https://maven.apache.org/xsd/xdoc-2.0.xsd">
-
-  <head>
-    <title>Beginning Development</title>
-  </head>
-
-  <body>
-    <section name="Content">
-      <macro name="toc">
-        <param name="fromDepth" value="1"/>
-        <param name="toDepth" value="1"/>
-      </macro>
-    </section>
-    <section name="Before Development">
-      <p>
-        1. Ensure that Git and Java JDK >= 21 are installed.<br/>
-        You can find information about development environment preparation here:
-        <a href="https://github.com/sevntu-checkstyle/sevntu.checkstyle/wiki/Prepare-Development-Environment-in-Ubuntu-12.04">
-        Prepare development environment in Ubuntu</a>.<br/>
-      </p>
-      <p>
-        <b>Note:</b> JDK 25 is currently not supported. Some test dependencies
-        (cacio-tta, Mockito/ByteBuddy) are incompatible with JDK 25.
-        Please use JDK 21 (LTS) for development until this issue is resolved.
-        See <a href="https://github.com/checkstyle/checkstyle/issues/18361">issue #18361</a>
-        for more details.
-      </p>
-      <p>
-        2. Fork Checkstyle upstream project. As it is described
-        <a href="https://help.github.com/articles/fork-a-repo/"> here</a><br/>
-        3. Clone your forked repository to your computer:
-      </p>
-      <div class="wrap-content">
-        <div class="wrapper"><pre class="prettyprint"><code class="language-bash">
-git clone git@github.com:your_user_name/checkstyle.git
-        </code></pre></div>
-      </div>
-      <p>
-        4. Before opening project in IDE, build the project in your terminal to download<br/>
-        all needed artifacts. From the repository root folder, run:
-      </p>
-      <div class="wrap-content">
-        <div class="wrapper"><pre class="prettyprint"><code class="language-bash">
-./mvnw install
-        </code></pre></div>
-      </div>
-    </section>
-
-    <section name="Starting Development">
-      <p>
-        Here you can find instructions about importing and debugging the project for IDEs:<br/>
-        <a href="eclipse.html">Eclipse IDE</a><br/>
-        <a href="netbeans.html">NetBeans IDE</a><br/>
-        <a href="idea.html">IntelliJ IDEA IDE</a><br/>
-      </p>
-
-      <p>
-        Community video walk throughs of these instructions are available in SteLeo1602's
-        <a href="https://www.youtube.com/playlist?list=PLHM9s_lN4X0hzOQ0sUmGdroxW0HfREAqj">
-           playlist on YouTube.</a>
-      </p>
-
-      <p>
-        Follow these instructions of Git usage and creating a Pull Request:<br/>
-           1) Configure remotes by pointing to the official checkstyle repository,<br/>
-        naming it "upstream":
-      </p>
-      <div class="wrap-content">
-        <div class="wrapper"><pre class="prettyprint"><code class="language-text">
-git remote add upstream https://github.com/checkstyle/checkstyle
-        </code></pre></div>
-      </div>
-      <p>
-           2) Create a branch for a new check:
-      </p>
-      <div class="wrap-content">
-        <div class="wrapper"><pre class="prettyprint"><code class="language-text">
-git checkout -b my-new-check
-        </code></pre></div>
-      </div>
-      <p>
-           3) Commit changes to my-new-check branch:
-      </p>
-      <div class="wrap-content">
-        <div class="wrapper"><pre class="prettyprint"><code class="language-text">
-git add .
-git commit -m "commit message"
-        </code></pre></div>
-      </div>
-      <p>
-           4) Push branch to GitHub, to allow your mentor to review your code:
-      </p>
-      <div class="wrap-content">
-        <div class="wrapper"><pre class="prettyprint"><code class="language-text">
-git push origin my-new-check
-        </code></pre></div>
-      </div>
-      <p>
-           5) Repeat steps 3-4 till development is complete<br/>
-           All additional commits, please <a href="https://davidwalsh.name/squash-commits-git">
-           squash to first</a>. Please read all rules for PullRequest at
-           our <a href="https://github.com/checkstyle/checkstyle/wiki/PR-rules">wiki</a>.
-      </p>
-      <div class="wrap-content">
-        <div class="wrapper"><pre class="prettyprint"><code class="language-text">
-git rebase -i master
-git push --force origin my-new-check
-        </code></pre></div>
-      </div>
-      <p>
-           6) Update current branch and local master by pulling changes that were done<br/>
-           by other contributors:
-      </p>
-      <div class="wrap-content">
-        <div class="wrapper"><pre class="prettyprint"><code class="language-text">
-git checkout master
-git pull upstream master
-git push origin master
-        </code></pre></div>
-      </div>
-      <p>
-           7) Rebase your branch on your updated master:
-      </p>
-      <div class="wrap-content">
-        <div class="wrapper"><pre class="prettyprint"><code class="language-text">
-git checkout my-new-check
-git rebase master
-        </code></pre></div>
-      </div>
-      <p>
-           8) In the process of the rebase, it may discover conflicts.<br/>
-           In that case it will stop and allow you to fix the conflicts.<br/>
-           After fixing conflicts, use
-      </p>
-      <div class="wrapper"><pre class="prettyprint"><code class="language-text">
-git add .
-      </code></pre></div>
-      <p> to update the index with those contents, and then just run:</p>
-      <div class="wrap-content">
-        <div class="wrapper"><pre class="prettyprint"><code class="language-text">
-git rebase --continue
-        </code></pre></div>
-      </div>
-      <p>
-           9) Push branch to GitHub (with all your final changes and actual code of Checkstyle):
-      </p>
-      <div class="wrap-content">
-        <div class="wrapper"><pre class="prettyprint"><code class="language-text">
-git push --force origin my-new-check
-        </code></pre></div>
-      </div>
-      <p>
-         10) Only after all content is finished and testing is done - send a
-        <a href="https://help.github.com/articles/using-pull-requests/">Pull Request</a>
-      </p>
-    </section>
-  </body>
+<document>
+    <properties>
+        <title>Beginning_Development</title>
+    </properties>
+    <body>
+        <section name="beginning_development">
+            <p>
+                The beginning_development guidelines have moved to GitHub.
+            </p>
+            <p>
+                Please see
+                <a href="https://github.com/checkstyle/checkstyle/blob/master/docs/BEGINNING_DEVELOPMENT.md">
+                    BEGINNING_DEVELOPMENT.md
+                </a>
+                for the complete and up-to-date documentation.
+            </p>
+        </section>
+    </body>
 </document>


### PR DESCRIPTION
#14542 

# What was Problem
beginning_development.html didn't live onto Github, the problem was, in future if in case some rules have to change or code then changes will done on two places which is complex and user will confuse to seeing two different beginning_development guidelines one on url another on Github(report-issue.md) so, we will live beginning_development.xml onto Github.

---

# Approach
on beginning_development.xml I show url of github of BEGINNING_DEVELOPMENT.md --> whenever user will come and click on beginning_development section then that contributor will see that page has moved onto Github please click on given url .
<img width="1893" height="1032" alt="image" src="https://github.com/user-attachments/assets/0ad281ea-be48-48ed-a474-a38eb194e635" />


---

# Solution
<img width="1183" height="549" alt="image" src="https://github.com/user-attachments/assets/126ed928-39ec-4308-b344-b0d218c29bdf" />
