### PR TITLE
Fixed issue #19162

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/blocks/LeftCurlyCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/blocks/LeftCurlyCheck.java
@@ -341,7 +341,10 @@ public class LeftCurlyCheck
      */
     private boolean hasLineBreakAfter(DetailAST leftCurly) {
         DetailAST nextToken = null;
-        if (leftCurly.getType() == TokenTypes.SLIST) {
+
+        final int leftCurlyType = leftCurly.getType();
+        if (leftCurlyType == TokenTypes.SLIST
+                || leftCurlyType == TokenTypes.OBJBLOCK) {
             nextToken = leftCurly.getFirstChild();
         }
         else {

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/blocks/LeftCurlyCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/blocks/LeftCurlyCheckTest.java
@@ -32,7 +32,6 @@ import com.puppycrawl.tools.checkstyle.api.TokenTypes;
 import com.puppycrawl.tools.checkstyle.utils.CommonUtil;
 
 public class LeftCurlyCheckTest extends AbstractModuleTestSupport {
-
     @Override
     public String getPackageLocation() {
         return "com/puppycrawl/tools/checkstyle/checks/blocks/leftcurly";
@@ -667,4 +666,12 @@ public class LeftCurlyCheckTest extends AbstractModuleTestSupport {
                 getPath("InputLeftCurlySwitchMutation.java"), expected);
     }
 
+    @Test
+    public void testMultipleBlocksOnSameLine() throws Exception {
+        final String[] expected = {
+            "18:24: " + getCheckMessage(MSG_KEY_LINE_BREAK_AFTER, "{", 24),
+        };
+        verifyWithInlineConfigParser(
+                getPath("InputLeftCurlyMultipleBlocksOnASingleLine.java"), expected);
+    }
 }

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/blocks/leftcurly/InputLeftCurlyMultipleBlocksOnASingleLine.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/blocks/leftcurly/InputLeftCurlyMultipleBlocksOnASingleLine.java
@@ -1,0 +1,21 @@
+/*
+LeftCurly
+option = (default)eol
+ignoreEnums = (default)true
+tokens = (default)ANNOTATION_DEF, CLASS_DEF, CTOR_DEF, ENUM_CONSTANT_DEF, \
+         ENUM_DEF, INTERFACE_DEF, LAMBDA, LITERAL_CASE, LITERAL_CATCH, \
+         LITERAL_DEFAULT, LITERAL_DO, LITERAL_ELSE, LITERAL_FINALLY, LITERAL_FOR, \
+         LITERAL_IF, LITERAL_SWITCH, LITERAL_SYNCHRONIZED, LITERAL_TRY, LITERAL_WHILE, \
+         METHOD_DEF, OBJBLOCK, STATIC_INIT, RECORD_DEF, COMPACT_CTOR_DEF
+
+
+*/
+
+package com.puppycrawl.tools.checkstyle.checks.blocks.leftcurly;
+
+class InputLeftCurlyMultipleBlocksOnASingleLine {
+    // violation below ''{' at column 24 should have a line break after'
+    public class Inner { public Inner() {
+        System.out.println("Violation should be reported for the first brace");
+    } }
+}


### PR DESCRIPTION
```java
class InputLeftCurlyMultipleBlocksOnASingleLine {
    // violation below ''{' at column 24 should have a line break after'
    public class Inner { public Inner() {
        System.out.println("Violation should be reported for the first brace");
    } }
}
```

The { at the start should now, hopefully, be flagged

While running tests, I couldn't fully, only `$ ./mvnw clean -Dtest=LeftCurlyCheckTest#testMultipleBlocksOnSameLine test` worked. It showed an error on 16 unexpected (the "class InputLeftCurlyMultipleBlocksOnASingleLine {" one), I don't know why. But it said [16, 18], so it was indeed showing the line break violation.