### PR TITLE
Issue #11315: Add MatchXpath rule to forbid try-catch-fail and refactor utils/xpath packages

### DIFF
--- a/config/checkstyle-checks.xml
+++ b/config/checkstyle-checks.xml
@@ -265,6 +265,13 @@
 
   <module name="TreeWalker">
     <property name="tabWidth" value="4"/>
+    <module name="MatchXpath">
+      <property name="id" value="MatchXpathForbidTryCatchFail"/>
+      <property name="query" value="//METHOD_CALL[./IDENT[@text='assertWithMessage']
+        and (./following-sibling::IDENT[@text='fail'])]"/>
+      <message key="matchxpath.match"
+               value="Exceptions should be validated by `getExpectedThrowable`."/>
+    </module>
 
     <!-- Annotations -->
     <module name="AnnotationLocation">

--- a/config/suppressions.xml
+++ b/config/suppressions.xml
@@ -172,4 +172,10 @@
   <!-- Uses non-ascii symbols intentionally -->
   <suppress id="checkASCII"
             files="[\\/]src[\\/]test[\\/]java[\\/]com[\\/]puppycrawl[\\/]tools[\\/]checkstyle[\\/]ConfigurationLoaderTest.java"/>
+
+  <!-- Remove suppression once all violations are fixed, tracked in #19176 -->
+  <suppress checks="MatchXpath"
+            id="MatchXpathForbidTryCatchFail"
+            files=".*[\\/]src[\\/]test[\\/]java[\\/]com[\\/]puppycrawl[\\/]tools[\\/]checkstyle[\\/](?!utils|xpath).*"/>
+
 </suppressions>

--- a/src/test/java/com/puppycrawl/tools/checkstyle/utils/AnnotationUtilTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/utils/AnnotationUtilTest.java
@@ -21,6 +21,7 @@ package com.puppycrawl.tools.checkstyle.utils;
 
 import static com.google.common.truth.Truth.assertWithMessage;
 import static com.puppycrawl.tools.checkstyle.checks.annotation.SuppressWarningsCheck.MSG_KEY_SUPPRESSED_WARNING_NOT_ALLOWED;
+import static com.puppycrawl.tools.checkstyle.internal.utils.TestUtil.getExpectedThrowable;
 import static com.puppycrawl.tools.checkstyle.internal.utils.TestUtil.instantiate;
 
 import java.util.Set;
@@ -42,43 +43,37 @@ public class AnnotationUtilTest extends AbstractModuleTestSupport {
 
     @Test
     public void testIsProperUtilsClass() {
-        try {
-            instantiate(AnnotationUtil.class);
-            assertWithMessage("Exception is expected").fail();
-        }
-        catch (ReflectiveOperationException exc) {
-            assertWithMessage("Invalid exception message")
-                .that(exc)
-                .hasCauseThat()
-                .hasMessageThat()
-                .isEqualTo("do not instantiate.");
-        }
+        final ReflectiveOperationException exc =
+                getExpectedThrowable(ReflectiveOperationException.class, () -> {
+                    instantiate(AnnotationUtil.class);
+                });
+        assertWithMessage("Invalid exception message")
+            .that(exc)
+            .hasCauseThat()
+            .hasMessageThat()
+            .isEqualTo("do not instantiate.");
     }
 
     @Test
     public void testContainsAnnotationNull() {
-        try {
-            AnnotationUtil.containsAnnotation(null);
-            assertWithMessage("IllegalArgumentException is expected").fail();
-        }
-        catch (IllegalArgumentException exc) {
-            assertWithMessage("Invalid exception message")
-                .that(exc.getMessage())
-                .isEqualTo("the ast is null");
-        }
+        final IllegalArgumentException exc =
+                getExpectedThrowable(IllegalArgumentException.class, () -> {
+                    AnnotationUtil.containsAnnotation(null);
+                });
+        assertWithMessage("Invalid exception message")
+            .that(exc.getMessage())
+            .isEqualTo("the ast is null");
     }
 
     @Test
     public void testContainsAnnotationNull2() {
-        try {
-            AnnotationUtil.containsAnnotation(null, "");
-            assertWithMessage("IllegalArgumentException is expected").fail();
-        }
-        catch (IllegalArgumentException exc) {
-            assertWithMessage("Invalid exception message")
-                .that(exc.getMessage())
-                .isEqualTo("the ast is null");
-        }
+        final IllegalArgumentException exc =
+                getExpectedThrowable(IllegalArgumentException.class, () -> {
+                    AnnotationUtil.containsAnnotation(null, "");
+                });
+        assertWithMessage("Invalid exception message")
+            .that(exc.getMessage())
+            .isEqualTo("the ast is null");
     }
 
     @Test
@@ -119,95 +114,81 @@ public class AnnotationUtilTest extends AbstractModuleTestSupport {
 
     @Test
     public void testAnnotationHolderNull() {
-        try {
-            AnnotationUtil.getAnnotationHolder(null);
-            assertWithMessage("IllegalArgumentException is expected").fail();
-        }
-        catch (IllegalArgumentException exc) {
-            assertWithMessage("Invalid exception message")
-                .that(exc.getMessage())
-                .isEqualTo("the ast is null");
-        }
+        final IllegalArgumentException exc =
+                getExpectedThrowable(IllegalArgumentException.class, () -> {
+                    AnnotationUtil.getAnnotationHolder(null);
+                });
+        assertWithMessage("Invalid exception message")
+            .that(exc.getMessage())
+            .isEqualTo("the ast is null");
     }
 
     @Test
     public void testAnnotationNull() {
-        try {
-            AnnotationUtil.getAnnotation(null, null);
-            assertWithMessage("IllegalArgumentException is expected").fail();
-        }
-        catch (IllegalArgumentException exc) {
-            assertWithMessage("Invalid exception message")
-                .that(exc.getMessage())
-                .isEqualTo("the ast is null");
-        }
+        final IllegalArgumentException exc =
+                getExpectedThrowable(IllegalArgumentException.class, () -> {
+                    AnnotationUtil.getAnnotation(null, null);
+                });
+        assertWithMessage("Invalid exception message")
+            .that(exc.getMessage())
+            .isEqualTo("the ast is null");
     }
 
     @Test
     public void testAnnotationNull2() {
-        try {
-            AnnotationUtil.getAnnotation(new DetailAstImpl(), null);
-            assertWithMessage("IllegalArgumentException is expected").fail();
-        }
-        catch (IllegalArgumentException exc) {
-            assertWithMessage("Invalid exception message")
-                .that(exc.getMessage())
-                .isEqualTo("the annotation is null");
-        }
+        final IllegalArgumentException exc =
+                getExpectedThrowable(IllegalArgumentException.class, () -> {
+                    AnnotationUtil.getAnnotation(new DetailAstImpl(), null);
+                });
+        assertWithMessage("Invalid exception message")
+            .that(exc.getMessage())
+            .isEqualTo("the annotation is null");
     }
 
     @Test
     public void testAnnotationEmpty() {
-        try {
-            AnnotationUtil.getAnnotation(new DetailAstImpl(), "");
-            assertWithMessage("IllegalArgumentException is expected").fail();
-        }
-        catch (IllegalArgumentException exc) {
-            assertWithMessage("Invalid exception message")
-                .that(exc.getMessage())
-                .isEqualTo("the annotation is empty or spaces");
-        }
+        final IllegalArgumentException exc =
+                getExpectedThrowable(IllegalArgumentException.class, () -> {
+                    AnnotationUtil.getAnnotation(new DetailAstImpl(), "");
+                });
+        assertWithMessage("Invalid exception message")
+            .that(exc.getMessage())
+            .isEqualTo("the annotation is empty or spaces");
     }
 
     @Test
     public void testContainsAnnotationWithNull() {
-        try {
-            AnnotationUtil.getAnnotation(null, "");
-            assertWithMessage("IllegalArgumentException is expected").fail();
-        }
-        catch (IllegalArgumentException exc) {
-            assertWithMessage("Invalid exception message")
-                .that(exc.getMessage())
-                .isEqualTo("the ast is null");
-        }
+        final IllegalArgumentException exc =
+                getExpectedThrowable(IllegalArgumentException.class, () -> {
+                    AnnotationUtil.getAnnotation(null, "");
+                });
+        assertWithMessage("Invalid exception message")
+            .that(exc.getMessage())
+            .isEqualTo("the ast is null");
     }
 
     @Test
     public void testContainsAnnotationListWithNullAst() {
-        try {
-            AnnotationUtil.containsAnnotation(null, Set.of("Override"));
-            assertWithMessage("IllegalArgumentException is expected").fail();
-        }
-        catch (IllegalArgumentException exc) {
-            assertWithMessage("Invalid exception message")
-                .that(exc.getMessage())
-                .isEqualTo("the ast is null");
-        }
+        final IllegalArgumentException exc =
+                getExpectedThrowable(IllegalArgumentException.class, () -> {
+                    AnnotationUtil.containsAnnotation(null, Set.of("Override"));
+                });
+        assertWithMessage("Invalid exception message")
+            .that(exc.getMessage())
+            .isEqualTo("the ast is null");
     }
 
     @Test
     public void testContainsAnnotationListWithNullList() {
         final DetailAST ast = new DetailAstImpl();
         final Set<String> annotations = null;
-        try {
-            AnnotationUtil.containsAnnotation(ast, annotations);
-            assertWithMessage("IllegalArgumentException is expected").fail();
-        }
-        catch (IllegalArgumentException exc) {
-            assertWithMessage("Invalid exception message")
-                .that(exc.getMessage())
-                .isEqualTo("annotations cannot be null");
-        }
+        final IllegalArgumentException exc =
+                getExpectedThrowable(IllegalArgumentException.class, () -> {
+                    AnnotationUtil.containsAnnotation(ast, annotations);
+                });
+        assertWithMessage("Invalid exception message")
+            .that(exc.getMessage())
+            .isEqualTo("annotations cannot be null");
     }
 
     @Test

--- a/src/test/java/com/puppycrawl/tools/checkstyle/utils/CheckUtilTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/utils/CheckUtilTest.java
@@ -25,6 +25,7 @@ import static com.puppycrawl.tools.checkstyle.checks.coding.MultipleVariableDecl
 import static com.puppycrawl.tools.checkstyle.checks.coding.NestedIfDepthCheck.MSG_KEY;
 import static com.puppycrawl.tools.checkstyle.checks.javadoc.JavadocMethodCheck.MSG_EXPECTED_TAG;
 import static com.puppycrawl.tools.checkstyle.internal.utils.TestUtil.findTokenInAstByPredicate;
+import static com.puppycrawl.tools.checkstyle.internal.utils.TestUtil.getExpectedThrowable;
 import static com.puppycrawl.tools.checkstyle.internal.utils.TestUtil.isUtilsClassHasPrivateConstructor;
 
 import java.nio.file.Path;
@@ -118,18 +119,16 @@ public class CheckUtilTest extends AbstractModuleTestSupport {
         final DetailAstImpl modifiers = new DetailAstImpl();
         modifiers.setType(TokenTypes.METHOD_DEF);
 
-        try {
-            CheckUtil.getAccessModifierFromModifiersToken(modifiers);
-            assertWithMessage("%s was expected.", IllegalArgumentException.class.getSimpleName())
-                .fail();
-        }
-        catch (IllegalArgumentException exc) {
-            final String expectedExceptionMsg = "expected non-null AST-token with type 'MODIFIERS'";
-            final String actualExceptionMsg = exc.getMessage();
-            assertWithMessage("Invalid exception message")
-                .that(actualExceptionMsg)
-                .isEqualTo(expectedExceptionMsg);
-        }
+        final IllegalArgumentException exc =
+            getExpectedThrowable(IllegalArgumentException.class, () -> {
+                CheckUtil.getAccessModifierFromModifiersToken(modifiers);
+            });
+
+        final String expectedExceptionMsg = "expected non-null AST-token with type 'MODIFIERS'";
+        final String actualExceptionMsg = exc.getMessage();
+        assertWithMessage("Invalid exception message")
+            .that(actualExceptionMsg)
+            .isEqualTo(expectedExceptionMsg);
     }
 
     @Test

--- a/src/test/java/com/puppycrawl/tools/checkstyle/utils/JavadocUtilTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/utils/JavadocUtilTest.java
@@ -20,6 +20,7 @@
 package com.puppycrawl.tools.checkstyle.utils;
 
 import static com.google.common.truth.Truth.assertWithMessage;
+import static com.puppycrawl.tools.checkstyle.internal.utils.TestUtil.getExpectedThrowable;
 import static com.puppycrawl.tools.checkstyle.internal.utils.TestUtil.isUtilsClassHasPrivateConstructor;
 
 import java.util.List;
@@ -278,54 +279,46 @@ public class JavadocUtilTest {
 
     @Test
     public void testGetTokenNameForLargeId() {
-        try {
-            JavadocUtil.getTokenName(30073);
-            assertWithMessage("exception expected").fail();
-        }
-        catch (IllegalArgumentException exc) {
-            assertWithMessage("Invalid exception message")
-                .that(exc.getMessage())
-                .isEqualTo("Unknown javadoc token id. Given id: 30073");
-        }
+        final IllegalArgumentException exc =
+                getExpectedThrowable(IllegalArgumentException.class, () -> {
+                    JavadocUtil.getTokenName(30073);
+                });
+        assertWithMessage("Invalid exception message")
+            .that(exc.getMessage())
+            .isEqualTo("Unknown javadoc token id. Given id: 30073");
     }
 
     @Test
     public void testGetTokenNameForInvalidId() {
-        try {
-            JavadocUtil.getTokenName(110);
-            assertWithMessage("exception expected").fail();
-        }
-        catch (IllegalArgumentException exc) {
-            assertWithMessage("Invalid exception message")
-                .that(exc.getMessage())
-                .isEqualTo("Unknown javadoc token id. Given id: 110");
-        }
+        final IllegalArgumentException exc =
+                getExpectedThrowable(IllegalArgumentException.class, () -> {
+                    JavadocUtil.getTokenName(110);
+                });
+        assertWithMessage("Invalid exception message")
+            .that(exc.getMessage())
+            .isEqualTo("Unknown javadoc token id. Given id: 110");
     }
 
     @Test
     public void testGetTokenNameForLowerBoundInvalidId() {
-        try {
-            JavadocUtil.getTokenName(10095);
-            assertWithMessage("exception expected").fail();
-        }
-        catch (IllegalArgumentException exc) {
-            assertWithMessage("Invalid exception message")
-                .that(exc.getMessage())
-                .isEqualTo("Unknown javadoc token id. Given id: 10095");
-        }
+        final IllegalArgumentException exc =
+                getExpectedThrowable(IllegalArgumentException.class, () -> {
+                    JavadocUtil.getTokenName(10095);
+                });
+        assertWithMessage("Invalid exception message")
+            .that(exc.getMessage())
+            .isEqualTo("Unknown javadoc token id. Given id: 10095");
     }
 
     @Test
     public void testGetTokenIdThatIsUnknown() {
-        try {
-            JavadocUtil.getTokenId("");
-            assertWithMessage("exception expected").fail();
-        }
-        catch (IllegalArgumentException exc) {
-            assertWithMessage("Invalid exception message")
-                .that(exc.getMessage())
-                .isEqualTo("Unknown javadoc token name. Given name ");
-        }
+        final IllegalArgumentException exc =
+                getExpectedThrowable(IllegalArgumentException.class, () -> {
+                    JavadocUtil.getTokenId("");
+                });
+        assertWithMessage("Invalid exception message")
+            .that(exc.getMessage())
+            .isEqualTo("Unknown javadoc token name. Given name ");
     }
 
     @Test

--- a/src/test/java/com/puppycrawl/tools/checkstyle/utils/TokenUtilTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/utils/TokenUtilTest.java
@@ -20,6 +20,7 @@
 package com.puppycrawl.tools.checkstyle.utils;
 
 import static com.google.common.truth.Truth.assertWithMessage;
+import static com.puppycrawl.tools.checkstyle.internal.utils.TestUtil.getExpectedThrowable;
 import static com.puppycrawl.tools.checkstyle.internal.utils.TestUtil.isUtilsClassHasPrivateConstructor;
 
 import java.lang.reflect.Field;
@@ -59,20 +60,19 @@ public class TokenUtilTest {
     public void testGetIntFromInaccessibleField() throws NoSuchFieldException {
         final Field field = Integer.class.getDeclaredField("value");
 
-        try {
-            TokenUtil.getIntFromField(field, 0);
-            assertWithMessage("IllegalStateException is expected").fail();
-        }
-        catch (IllegalStateException expected) {
-            // The exception message may vary depending on the version of the JDK.
-            // It will definitely contain the TokenUtil class name and the Integer class name.
-            final String message = expected.getMessage();
-            assertWithMessage("Invalid exception message: %s", message)
-                    .that(message.startsWith("java.lang.IllegalAccessException: ")
-                            && message.contains("com.puppycrawl.tools.checkstyle.utils.TokenUtil")
-                            && message.contains("access a member of class java.lang.Integer"))
-                    .isTrue();
-        }
+        final IllegalStateException expected =
+            getExpectedThrowable(IllegalStateException.class, () -> {
+                TokenUtil.getIntFromField(field, 0);
+            });
+
+        // The exception message may vary depending on the version of the JDK.
+        // It will definitely contain the TokenUtil class name and the Integer class name.
+        final String message = expected.getMessage();
+        assertWithMessage("Invalid exception message: %s", message)
+                .that(message.startsWith("java.lang.IllegalAccessException: ")
+                        && message.contains("com.puppycrawl.tools.checkstyle.utils.TokenUtil")
+                        && message.contains("access a member of class java.lang.Integer"))
+                .isTrue();
     }
 
     @Test
@@ -113,7 +113,6 @@ public class TokenUtilTest {
         int maxId = 0;
         final Field[] fields = TokenTypes.class.getDeclaredFields();
         for (final Field field : fields) {
-            // Only process the int declarations.
             if (field.getType() != Integer.TYPE) {
                 continue;
             }
@@ -126,15 +125,14 @@ public class TokenUtilTest {
         }
 
         final int nextAfterMaxId = maxId + 1;
-        try {
-            TokenUtil.getTokenName(nextAfterMaxId);
-            assertWithMessage("IllegalArgumentException is expected").fail();
-        }
-        catch (IllegalArgumentException expectedException) {
-            assertWithMessage("Invalid exception message")
-                .that(expectedException.getMessage())
-                .isEqualTo("unknown TokenTypes id '" + nextAfterMaxId + "'");
-        }
+        final IllegalArgumentException expectedException =
+            getExpectedThrowable(IllegalArgumentException.class, () -> {
+                TokenUtil.getTokenName(nextAfterMaxId);
+            });
+
+        assertWithMessage("Invalid exception message")
+            .that(expectedException.getMessage())
+            .isEqualTo("unknown TokenTypes id '" + nextAfterMaxId + "'");
     }
 
     @Test
@@ -158,43 +156,40 @@ public class TokenUtilTest {
     @Test
     public void testTokenValueIncorrect2() {
         final int id = 0;
-        try {
-            TokenUtil.getTokenName(id);
-            assertWithMessage("IllegalArgumentException is expected").fail();
-        }
-        catch (IllegalArgumentException expected) {
-            assertWithMessage("Invalid exception message")
-                .that(expected.getMessage())
-                .isEqualTo("unknown TokenTypes id '" + id + "'");
-        }
+        final IllegalArgumentException expected =
+            getExpectedThrowable(IllegalArgumentException.class, () -> {
+                TokenUtil.getTokenName(id);
+            });
+
+        assertWithMessage("Invalid exception message")
+            .that(expected.getMessage())
+            .isEqualTo("unknown TokenTypes id '" + id + "'");
     }
 
     @Test
     public void testTokenIdIncorrect() {
         final String id = "NON_EXISTENT_VALUE";
-        try {
-            TokenUtil.getTokenId(id);
-            assertWithMessage("IllegalArgumentException is expected").fail();
-        }
-        catch (IllegalArgumentException expected) {
-            assertWithMessage("Invalid exception message")
-                .that(expected.getMessage())
-                .isEqualTo("unknown TokenTypes value '" + id + "'");
-        }
+        final IllegalArgumentException expected =
+            getExpectedThrowable(IllegalArgumentException.class, () -> {
+                TokenUtil.getTokenId(id);
+            });
+
+        assertWithMessage("Invalid exception message")
+            .that(expected.getMessage())
+            .isEqualTo("unknown TokenTypes value '" + id + "'");
     }
 
     @Test
     public void testShortDescriptionIncorrect() {
         final String id = "NON_EXISTENT_VALUE";
-        try {
-            TokenUtil.getShortDescription(id);
-            assertWithMessage("IllegalArgumentException is expected").fail();
-        }
-        catch (IllegalArgumentException expected) {
-            assertWithMessage("Invalid exception message")
-                .that(expected.getMessage())
-                .isEqualTo("unknown TokenTypes value '" + id + "'");
-        }
+        final IllegalArgumentException expected =
+            getExpectedThrowable(IllegalArgumentException.class, () -> {
+                TokenUtil.getShortDescription(id);
+            });
+
+        assertWithMessage("Invalid exception message")
+            .that(expected.getMessage())
+            .isEqualTo("unknown TokenTypes value '" + id + "'");
     }
 
     @Test

--- a/src/test/java/com/puppycrawl/tools/checkstyle/utils/XpathUtilTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/utils/XpathUtilTest.java
@@ -21,6 +21,7 @@ package com.puppycrawl.tools.checkstyle.utils;
 
 import static com.google.common.truth.Truth.assertWithMessage;
 import static com.puppycrawl.tools.checkstyle.AbstractPathTestSupport.addEndOfLine;
+import static com.puppycrawl.tools.checkstyle.internal.utils.TestUtil.getExpectedThrowable;
 import static com.puppycrawl.tools.checkstyle.internal.utils.TestUtil.isUtilsClassHasPrivateConstructor;
 import static com.puppycrawl.tools.checkstyle.utils.XpathUtil.getTextAttributeValue;
 
@@ -174,18 +175,16 @@ public class XpathUtilTest {
         Files.writeString(file.toPath(), fileContent, StandardCharsets.UTF_8);
         final String invalidXpath = "\\//CLASS_DEF"
                 + "//METHOD_DEF//VARIABLE_DEF//IDENT";
-        try {
+        final CheckstyleException exc = getExpectedThrowable(CheckstyleException.class, () -> {
             XpathUtil.printXpathBranch(invalidXpath, file);
-            assertWithMessage("Should end with exception").fail();
-        }
-        catch (CheckstyleException exc) {
-            final String expectedMessage =
-                "Error during evaluation for xpath: " + invalidXpath
-                    + ", file: " + file.getCanonicalPath();
-            assertWithMessage("Exception message is different")
-                .that(exc.getMessage())
-                .isEqualTo(expectedMessage);
-        }
+        });
+
+        final String expectedMessage =
+            "Error during evaluation for xpath: " + invalidXpath
+                + ", file: " + file.getCanonicalPath();
+        assertWithMessage("Exception message is different")
+            .that(exc.getMessage())
+            .isEqualTo(expectedMessage);
     }
 
     @Test

--- a/src/test/java/com/puppycrawl/tools/checkstyle/xpath/AttributeNodeTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/xpath/AttributeNodeTest.java
@@ -54,15 +54,13 @@ public class AttributeNodeTest {
 
     @Test
     public void testCompareOrder() {
-        try {
-            attributeNode.compareOrder(null);
-            assertWithMessage("Exception is excepted").fail();
-        }
-        catch (UnsupportedOperationException exc) {
-            assertWithMessage("Invalid exception message")
-                .that(exc.getMessage())
-                .isEqualTo("Operation is not supported");
-        }
+        final UnsupportedOperationException exc =
+                getExpectedThrowable(UnsupportedOperationException.class, () -> {
+                    attributeNode.compareOrder(null);
+                });
+        assertWithMessage("Invalid exception message")
+            .that(exc.getMessage())
+            .isEqualTo("Operation is not supported");
     }
 
     @Test
@@ -84,15 +82,13 @@ public class AttributeNodeTest {
 
     @Test
     public void testGetAttributeValue() {
-        try {
-            attributeNode.getAttributeValue("", "");
-            assertWithMessage("Exception is excepted").fail();
-        }
-        catch (UnsupportedOperationException exc) {
-            assertWithMessage("Invalid exception message")
-                .that(exc.getMessage())
-                .isEqualTo("Operation is not supported");
-        }
+        final UnsupportedOperationException exc =
+                getExpectedThrowable(UnsupportedOperationException.class, () -> {
+                    attributeNode.getAttributeValue("", "");
+                });
+        assertWithMessage("Invalid exception message")
+            .that(exc.getMessage())
+            .isEqualTo("Operation is not supported");
     }
 
     @Test
@@ -107,28 +103,20 @@ public class AttributeNodeTest {
 
     @Test
     public void testGetParent() {
-        try {
-            attributeNode.getParent();
-            assertWithMessage("Exception is excepted").fail();
-        }
-        catch (UnsupportedOperationException exc) {
-            assertWithMessage("Invalid exception message")
-                .that(exc.getMessage())
-                .isEqualTo("Operation is not supported");
-        }
+        final UnsupportedOperationException exc =
+                getExpectedThrowable(UnsupportedOperationException.class, attributeNode::getParent);
+        assertWithMessage("Invalid exception message")
+            .that(exc.getMessage())
+            .isEqualTo("Operation is not supported");
     }
 
     @Test
     public void testGetRoot() {
-        try {
-            attributeNode.getRoot();
-            assertWithMessage("Exception is excepted").fail();
-        }
-        catch (UnsupportedOperationException exc) {
-            assertWithMessage("Invalid exception message")
-                .that(exc.getMessage())
-                .isEqualTo("Operation is not supported");
-        }
+        final UnsupportedOperationException exc =
+                getExpectedThrowable(UnsupportedOperationException.class, attributeNode::getRoot);
+        assertWithMessage("Invalid exception message")
+            .that(exc.getMessage())
+            .isEqualTo("Operation is not supported");
     }
 
     @Test
@@ -140,78 +128,69 @@ public class AttributeNodeTest {
 
     @Test
     public void testIterate() {
-        try (AxisIterator ignored = attributeNode.iterateAxis(AxisInfo.SELF)) {
-            assertWithMessage("Exception is excepted").fail();
-        }
-        catch (UnsupportedOperationException exc) {
-            assertWithMessage("Invalid exception message")
-                .that(exc.getMessage())
-                .isEqualTo("Operation is not supported");
+        final UnsupportedOperationException exc =
+                getExpectedThrowable(UnsupportedOperationException.class,
+                        () -> callIterateAxis(attributeNode));
+        assertWithMessage("Invalid exception message")
+            .that(exc.getMessage())
+            .isEqualTo("Operation is not supported");
+    }
+
+    private static void callIterateAxis(AttributeNode node) {
+        try (AxisIterator ignored = node.iterateAxis(AxisInfo.SELF)) {
+            assertWithMessage("Exception is expected")
+                    .that(ignored)
+                    .isNotNull();
         }
     }
 
     @Test
     public void testGetLineNumber() {
-        try {
-            attributeNode.getLineNumber();
-            assertWithMessage("Exception is excepted").fail();
-        }
-        catch (UnsupportedOperationException exc) {
-            assertWithMessage("Invalid exception message")
-                .that(exc.getMessage())
-                .isEqualTo("Operation is not supported");
-        }
+        final UnsupportedOperationException exc =
+                getExpectedThrowable(UnsupportedOperationException.class,
+                        attributeNode::getLineNumber);
+        assertWithMessage("Invalid exception message")
+            .that(exc.getMessage())
+            .isEqualTo("Operation is not supported");
     }
 
     @Test
     public void testGetColumnNumber() {
-        try {
-            attributeNode.getColumnNumber();
-            assertWithMessage("Exception is excepted").fail();
-        }
-        catch (UnsupportedOperationException exc) {
-            assertWithMessage("Invalid exception message")
-                .that(exc.getMessage())
-                .isEqualTo("Operation is not supported");
-        }
+        final UnsupportedOperationException exc =
+                getExpectedThrowable(UnsupportedOperationException.class,
+                        attributeNode::getColumnNumber);
+        assertWithMessage("Invalid exception message")
+            .that(exc.getMessage())
+            .isEqualTo("Operation is not supported");
     }
 
     @Test
     public void testGetTokenType() {
-        try {
-            attributeNode.getTokenType();
-            assertWithMessage("Exception is excepted").fail();
-        }
-        catch (UnsupportedOperationException exc) {
-            assertWithMessage("Invalid exception message")
-                .that(exc.getMessage())
-                .isEqualTo("Operation is not supported");
-        }
+        final UnsupportedOperationException exc =
+                getExpectedThrowable(UnsupportedOperationException.class,
+                        attributeNode::getTokenType);
+        assertWithMessage("Invalid exception message")
+            .that(exc.getMessage())
+            .isEqualTo("Operation is not supported");
     }
 
     @Test
     public void testGetUnderlyingNode() {
-        try {
-            attributeNode.getUnderlyingNode();
-            assertWithMessage("Exception is excepted").fail();
-        }
-        catch (UnsupportedOperationException exc) {
-            assertWithMessage("Invalid exception message")
-                .that(exc.getMessage())
-                .isEqualTo("Operation is not supported");
-        }
+        final UnsupportedOperationException exc =
+                getExpectedThrowable(UnsupportedOperationException.class,
+                        attributeNode::getUnderlyingNode);
+        assertWithMessage("Invalid exception message")
+            .that(exc.getMessage())
+            .isEqualTo("Operation is not supported");
     }
 
     @Test
     public void testGetAllNamespaces() {
-        try {
-            attributeNode.getAllNamespaces();
-            assertWithMessage("Exception is excepted").fail();
-        }
-        catch (UnsupportedOperationException exc) {
-            assertWithMessage("Invalid exception message")
-                .that(exc.getMessage())
-                .isEqualTo("Operation is not supported");
-        }
+        final UnsupportedOperationException exc =
+                getExpectedThrowable(UnsupportedOperationException.class,
+                        attributeNode::getAllNamespaces);
+        assertWithMessage("Invalid exception message")
+            .that(exc.getMessage())
+            .isEqualTo("Operation is not supported");
     }
 }

--- a/src/test/java/com/puppycrawl/tools/checkstyle/xpath/RootNodeTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/xpath/RootNodeTest.java
@@ -20,6 +20,7 @@
 package com.puppycrawl.tools.checkstyle.xpath;
 
 import static com.google.common.truth.Truth.assertWithMessage;
+import static com.puppycrawl.tools.checkstyle.internal.utils.TestUtil.getExpectedThrowable;
 import static com.puppycrawl.tools.checkstyle.utils.XpathUtil.getXpathItems;
 
 import java.io.File;
@@ -56,15 +57,13 @@ public class RootNodeTest extends AbstractPathTestSupport {
 
     @Test
     public void testCompareOrder() {
-        try {
-            rootNode.compareOrder(null);
-            assertWithMessage("Exception is excepted").fail();
-        }
-        catch (UnsupportedOperationException exc) {
-            assertWithMessage("Invalid exception message")
-                .that(exc.getMessage())
-                .isEqualTo("Operation is not supported");
-        }
+        final UnsupportedOperationException exc =
+                getExpectedThrowable(UnsupportedOperationException.class, () -> {
+                    rootNode.compareOrder(null);
+                });
+        assertWithMessage("Invalid exception message")
+            .that(exc.getMessage())
+            .isEqualTo("Operation is not supported");
     }
 
     @Test
@@ -191,288 +190,213 @@ public class RootNodeTest extends AbstractPathTestSupport {
 
     @Test
     public void testGetStringValue() {
-        try {
-            rootNode.getStringValue();
-            assertWithMessage("Exception is excepted").fail();
-        }
-        catch (UnsupportedOperationException exc) {
-            assertWithMessage("Invalid exception message")
-                .that(exc.getMessage())
-                .isEqualTo("Operation is not supported");
-        }
+        final UnsupportedOperationException exc =
+                getExpectedThrowable(UnsupportedOperationException.class, rootNode::getStringValue);
+        assertWithMessage("Invalid exception message")
+            .that(exc.getMessage())
+            .isEqualTo("Operation is not supported");
     }
 
     @Test
     public void testGetAttributeValue() {
-        try {
-            rootNode.getAttributeValue("", "");
-            assertWithMessage("Exception is excepted").fail();
-        }
-        catch (UnsupportedOperationException exc) {
-            assertWithMessage("Invalid exception message")
-                .that(exc.getMessage())
-                .isEqualTo("Operation is not supported");
-        }
+        final UnsupportedOperationException exc =
+                getExpectedThrowable(UnsupportedOperationException.class, () -> {
+                    rootNode.getAttributeValue("", "");
+                });
+        assertWithMessage("Invalid exception message")
+            .that(exc.getMessage())
+            .isEqualTo("Operation is not supported");
     }
 
     @Test
     public void testGetDeclaredNamespaces() {
-        try {
-            rootNode.getDeclaredNamespaces(null);
-            assertWithMessage("Exception is excepted").fail();
-        }
-        catch (UnsupportedOperationException exc) {
-            assertWithMessage("Invalid exception message")
-                .that(exc.getMessage())
-                .isEqualTo("Operation is not supported");
-        }
+        final UnsupportedOperationException exc =
+                getExpectedThrowable(UnsupportedOperationException.class, () -> {
+                    rootNode.getDeclaredNamespaces(null);
+                });
+        assertWithMessage("Invalid exception message")
+            .that(exc.getMessage())
+            .isEqualTo("Operation is not supported");
     }
 
     @Test
     public void testIsId() {
-        try {
-            rootNode.isId();
-            assertWithMessage("Exception is excepted").fail();
-        }
-        catch (UnsupportedOperationException exc) {
-            assertWithMessage("Invalid exception message")
-                .that(exc.getMessage())
-                .isEqualTo("Operation is not supported");
-        }
+        final UnsupportedOperationException exc =
+                getExpectedThrowable(UnsupportedOperationException.class, rootNode::isId);
+        assertWithMessage("Invalid exception message")
+            .that(exc.getMessage())
+            .isEqualTo("Operation is not supported");
     }
 
     @Test
     public void testIsIdref() {
-        try {
-            rootNode.isIdref();
-            assertWithMessage("Exception is excepted").fail();
-        }
-        catch (UnsupportedOperationException exc) {
-            assertWithMessage("Invalid exception message")
-                .that(exc.getMessage())
-                .isEqualTo("Operation is not supported");
-        }
+        final UnsupportedOperationException exc =
+                getExpectedThrowable(UnsupportedOperationException.class, rootNode::isIdref);
+        assertWithMessage("Invalid exception message")
+            .that(exc.getMessage())
+            .isEqualTo("Operation is not supported");
     }
 
     @Test
     public void testIsNilled() {
-        try {
-            rootNode.isNilled();
-            assertWithMessage("Exception is excepted").fail();
-        }
-        catch (UnsupportedOperationException exc) {
-            assertWithMessage("Invalid exception message")
-                .that(exc.getMessage())
-                .isEqualTo("Operation is not supported");
-        }
+        final UnsupportedOperationException exc =
+                getExpectedThrowable(UnsupportedOperationException.class, rootNode::isNilled);
+        assertWithMessage("Invalid exception message")
+            .that(exc.getMessage())
+            .isEqualTo("Operation is not supported");
     }
 
     @Test
     public void testIsStreamed() {
-        try {
-            rootNode.isStreamed();
-            assertWithMessage("Exception is excepted").fail();
-        }
-        catch (UnsupportedOperationException exc) {
-            assertWithMessage("Invalid exception message")
-                .that(exc.getMessage())
-                .isEqualTo("Operation is not supported");
-        }
+        final UnsupportedOperationException exc =
+                getExpectedThrowable(UnsupportedOperationException.class, rootNode::isStreamed);
+        assertWithMessage("Invalid exception message")
+            .that(exc.getMessage())
+            .isEqualTo("Operation is not supported");
     }
 
     @Test
     public void testGetConfiguration() {
-        try {
-            rootNode.getConfiguration();
-            assertWithMessage("Exception is excepted").fail();
-        }
-        catch (UnsupportedOperationException exc) {
-            assertWithMessage("Invalid exception message")
-                .that(exc.getMessage())
-                .isEqualTo("Operation is not supported");
-        }
+        final UnsupportedOperationException exc =
+                getExpectedThrowable(UnsupportedOperationException.class,
+                        rootNode::getConfiguration);
+        assertWithMessage("Invalid exception message")
+            .that(exc.getMessage())
+            .isEqualTo("Operation is not supported");
     }
 
     @Test
     public void testSetSystemId() {
-        try {
-            rootNode.setSystemId("1");
-            assertWithMessage("Exception is excepted").fail();
-        }
-        catch (UnsupportedOperationException exc) {
-            assertWithMessage("Invalid exception message")
-                .that(exc.getMessage())
-                .isEqualTo("Operation is not supported");
-        }
+        final UnsupportedOperationException exc =
+                getExpectedThrowable(UnsupportedOperationException.class, () -> {
+                    rootNode.setSystemId("1");
+                });
+        assertWithMessage("Invalid exception message")
+            .that(exc.getMessage())
+            .isEqualTo("Operation is not supported");
     }
 
     @Test
     public void testGetSystemId() {
-        try {
-            rootNode.getSystemId();
-            assertWithMessage("Exception is excepted").fail();
-        }
-        catch (UnsupportedOperationException exc) {
-            assertWithMessage("Invalid exception message")
-                .that(exc.getMessage())
-                .isEqualTo("Operation is not supported");
-        }
+        final UnsupportedOperationException exc =
+                getExpectedThrowable(UnsupportedOperationException.class, rootNode::getSystemId);
+        assertWithMessage("Invalid exception message")
+            .that(exc.getMessage())
+            .isEqualTo("Operation is not supported");
     }
 
     @Test
     public void testGetPublicId() {
-        try {
-            rootNode.getPublicId();
-            assertWithMessage("Exception is excepted").fail();
-        }
-        catch (UnsupportedOperationException exc) {
-            assertWithMessage("Invalid exception message")
-                .that(exc.getMessage())
-                .isEqualTo("Operation is not supported");
-        }
+        final UnsupportedOperationException exc =
+                getExpectedThrowable(UnsupportedOperationException.class, rootNode::getPublicId);
+        assertWithMessage("Invalid exception message")
+            .that(exc.getMessage())
+            .isEqualTo("Operation is not supported");
     }
 
     @Test
     public void testBaseUri() {
-        try {
-            rootNode.getBaseURI();
-            assertWithMessage("Exception is excepted").fail();
-        }
-        catch (UnsupportedOperationException exc) {
-            assertWithMessage("Invalid exception message")
-                .that(exc.getMessage())
-                .isEqualTo("Operation is not supported");
-        }
+        final UnsupportedOperationException exc =
+                getExpectedThrowable(UnsupportedOperationException.class, rootNode::getBaseURI);
+        assertWithMessage("Invalid exception message")
+            .that(exc.getMessage())
+            .isEqualTo("Operation is not supported");
     }
 
     @Test
     public void testSaveLocation() {
-        try {
-            rootNode.saveLocation();
-            assertWithMessage("Exception is excepted").fail();
-        }
-        catch (UnsupportedOperationException exc) {
-            assertWithMessage("Invalid exception message")
-                .that(exc.getMessage())
-                .isEqualTo("Operation is not supported");
-        }
+        final UnsupportedOperationException exc =
+                getExpectedThrowable(UnsupportedOperationException.class, rootNode::saveLocation);
+        assertWithMessage("Invalid exception message")
+            .that(exc.getMessage())
+            .isEqualTo("Operation is not supported");
     }
 
     @Test
     public void testGetStringValueCs() {
-        try {
-            rootNode.getUnicodeStringValue();
-            assertWithMessage("Exception is excepted").fail();
-        }
-        catch (UnsupportedOperationException exc) {
-            assertWithMessage("Invalid exception message")
-                .that(exc.getMessage())
-                .isEqualTo("Operation is not supported");
-        }
+        final UnsupportedOperationException exc =
+                getExpectedThrowable(UnsupportedOperationException.class,
+                        rootNode::getUnicodeStringValue);
+        assertWithMessage("Invalid exception message")
+            .that(exc.getMessage())
+            .isEqualTo("Operation is not supported");
     }
 
     @Test
     public void testFingerprint() {
-        try {
-            rootNode.getFingerprint();
-            assertWithMessage("Exception is excepted").fail();
-        }
-        catch (UnsupportedOperationException exc) {
-            assertWithMessage("Invalid exception message")
-                .that(exc.getMessage())
-                .isEqualTo("Operation is not supported");
-        }
+        final UnsupportedOperationException exc =
+                getExpectedThrowable(UnsupportedOperationException.class, rootNode::getFingerprint);
+        assertWithMessage("Invalid exception message")
+            .that(exc.getMessage())
+            .isEqualTo("Operation is not supported");
     }
 
     @Test
     public void testGetDisplayName() {
-        try {
-            rootNode.getDisplayName();
-            assertWithMessage("Exception is excepted").fail();
-        }
-        catch (UnsupportedOperationException exc) {
-            assertWithMessage("Invalid exception message")
-                .that(exc.getMessage())
-                .isEqualTo("Operation is not supported");
-        }
+        final UnsupportedOperationException exc =
+                getExpectedThrowable(UnsupportedOperationException.class, rootNode::getDisplayName);
+        assertWithMessage("Invalid exception message")
+            .that(exc.getMessage())
+            .isEqualTo("Operation is not supported");
     }
 
     @Test
     public void testGetPrefix() {
-        try {
-            rootNode.getPrefix();
-            assertWithMessage("Exception is excepted").fail();
-        }
-        catch (UnsupportedOperationException exc) {
-            assertWithMessage("Invalid exception message")
-                .that(exc.getMessage())
-                .isEqualTo("Operation is not supported");
-        }
+        final UnsupportedOperationException exc =
+                getExpectedThrowable(UnsupportedOperationException.class, rootNode::getPrefix);
+        assertWithMessage("Invalid exception message")
+            .that(exc.getMessage())
+            .isEqualTo("Operation is not supported");
     }
 
     @Test
     public void testGetSchemaType() {
-        try {
-            rootNode.getSchemaType();
-            assertWithMessage("Exception is excepted").fail();
-        }
-        catch (UnsupportedOperationException exc) {
-            assertWithMessage("Invalid exception message")
-                .that(exc.getMessage())
-                .isEqualTo("Operation is not supported");
-        }
+        final UnsupportedOperationException exc =
+                getExpectedThrowable(UnsupportedOperationException.class, rootNode::getSchemaType);
+        assertWithMessage("Invalid exception message")
+            .that(exc.getMessage())
+            .isEqualTo("Operation is not supported");
     }
 
     @Test
     public void testAtomize() {
-        try {
-            rootNode.atomize();
-            assertWithMessage("Exception is excepted").fail();
-        }
-        catch (UnsupportedOperationException exc) {
-            assertWithMessage("Invalid exception message")
-                .that(exc.getMessage())
-                .isEqualTo("Operation is not supported");
-        }
+        final UnsupportedOperationException exc =
+                getExpectedThrowable(UnsupportedOperationException.class, rootNode::atomize);
+        assertWithMessage("Invalid exception message")
+            .that(exc.getMessage())
+            .isEqualTo("Operation is not supported");
     }
 
     @Test
     public void testGenerateId() {
-        try {
-            rootNode.generateId(null);
-            assertWithMessage("Exception is excepted").fail();
-        }
-        catch (UnsupportedOperationException exc) {
-            assertWithMessage("Invalid exception message")
-                .that(exc.getMessage())
-                .isEqualTo("Operation is not supported");
-        }
+        final UnsupportedOperationException exc =
+                getExpectedThrowable(UnsupportedOperationException.class, () -> {
+                    rootNode.generateId(null);
+                });
+        assertWithMessage("Invalid exception message")
+            .that(exc.getMessage())
+            .isEqualTo("Operation is not supported");
     }
 
     @Test
     public void testCopy() {
-        try {
-            rootNode.copy(null, -1, null);
-            assertWithMessage("Exception is excepted").fail();
-        }
-        catch (UnsupportedOperationException exc) {
-            assertWithMessage("Invalid exception message")
-                .that(exc.getMessage())
-                .isEqualTo("Operation is not supported");
-        }
+        final UnsupportedOperationException exc =
+                getExpectedThrowable(UnsupportedOperationException.class, () -> {
+                    rootNode.copy(null, -1, null);
+                });
+        assertWithMessage("Invalid exception message")
+            .that(exc.getMessage())
+            .isEqualTo("Operation is not supported");
     }
 
     @Test
     public void testGetAllNamespaces() {
-        try {
-            rootNode.getAllNamespaces();
-            assertWithMessage("Exception is excepted").fail();
-        }
-        catch (UnsupportedOperationException exc) {
-            assertWithMessage("Invalid exception message")
-                .that(exc.getMessage())
-                .isEqualTo("Operation is not supported");
-        }
+        final UnsupportedOperationException exc =
+                getExpectedThrowable(UnsupportedOperationException.class,
+                        rootNode::getAllNamespaces);
+        assertWithMessage("Invalid exception message")
+            .that(exc.getMessage())
+            .isEqualTo("Operation is not supported");
     }
 
     @Test

--- a/src/test/java/com/puppycrawl/tools/checkstyle/xpath/XpathMapperTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/xpath/XpathMapperTest.java
@@ -20,6 +20,7 @@
 package com.puppycrawl.tools.checkstyle.xpath;
 
 import static com.google.common.truth.Truth.assertWithMessage;
+import static com.puppycrawl.tools.checkstyle.internal.utils.TestUtil.getExpectedThrowable;
 import static com.puppycrawl.tools.checkstyle.utils.XpathUtil.getXpathItems;
 
 import java.io.File;
@@ -530,30 +531,26 @@ public class XpathMapperTest extends AbstractModuleTestSupport {
     public void testQueryRootNotImplementedAxis() throws Exception {
         final String xpath = "//namespace::*";
         final RootNode rootNode = getRootNode("InputXpathMapperAst.java");
-        try {
-            getXpathItems(xpath, rootNode);
-            assertWithMessage("Exception is excepted").fail();
-        }
-        catch (UnsupportedOperationException exc) {
-            assertWithMessage("Invalid exception")
-                    .that(exc.getMessage())
-                    .isEqualTo("Operation is not supported");
-        }
+        final UnsupportedOperationException exc =
+                getExpectedThrowable(UnsupportedOperationException.class, () -> {
+                    getXpathItems(xpath, rootNode);
+                });
+        assertWithMessage("Invalid exception")
+                .that(exc.getMessage())
+                .isEqualTo("Operation is not supported");
     }
 
     @Test
     public void testQueryElementNotImplementedAxis() throws Exception {
         final String xpath = "/COMPILATION_UNIT/CLASS_DEF//namespace::*";
         final RootNode rootNode = getRootNode("InputXpathMapperAst.java");
-        try {
-            getXpathItems(xpath, rootNode);
-            assertWithMessage("Exception is excepted").fail();
-        }
-        catch (UnsupportedOperationException exc) {
-            assertWithMessage("Invalid exception")
-                    .that(exc.getMessage())
-                    .isEqualTo("Operation is not supported");
-        }
+        final UnsupportedOperationException exc =
+                getExpectedThrowable(UnsupportedOperationException.class, () -> {
+                    getXpathItems(xpath, rootNode);
+                });
+        assertWithMessage("Invalid exception")
+                .that(exc.getMessage())
+                .isEqualTo("Operation is not supported");
     }
 
     @Test


### PR DESCRIPTION
issue #11315 
this pr starts fixing the issue described in #11315 by replacing the old `assertWithMessage(...).fail()` pattern in try-catch blocks with the cleaner `getExpectedThrowable` approach. I have added a `MatchXpath` rule and fixed all violations in the utils and xpath test . a temporary suppression has been added to keep the build passing while the remaining files are still being migrated. as they all together are close to 240 files in number i plan to fix the rest in smaller follow-up prs and will remove the suppression in the final one