### PR TITLE
Issue #19156: Fix VariableDeclarationUsageDistanceCheck for inner class

### DIFF
--- a/config/checker-framework-suppressions/checker-nullness-optional-interning-suppressions.xml
+++ b/config/checker-framework-suppressions/checker-nullness-optional-interning-suppressions.xml
@@ -3672,6 +3672,17 @@
 
   <checkerFrameworkError unstable="false">
     <fileName>src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/VariableDeclarationUsageDistanceCheck.java</fileName>
+    <specifier>argument</specifier>
+    <message>incompatible argument for parameter parent of VariableDeclarationUsageDistanceCheck.isChild.</message>
+    <lineContent>if (isChild(catchOrFinallyBlock, variable)) {</lineContent>
+    <details>
+      found   : @Initialized @Nullable DetailAST
+      required: @Initialized @NonNull DetailAST
+    </details>
+  </checkerFrameworkError>
+
+  <checkerFrameworkError unstable="false">
+    <fileName>src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/VariableDeclarationUsageDistanceCheck.java</fileName>
     <specifier>dereference.of.nullable</specifier>
     <message>dereference of possibly-null reference ast</message>
     <lineContent>while (ast.getType() != TokenTypes.RPAREN) {</lineContent>
@@ -3687,8 +3698,8 @@
   <checkerFrameworkError unstable="false">
     <fileName>src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/VariableDeclarationUsageDistanceCheck.java</fileName>
     <specifier>dereference.of.nullable</specifier>
-    <message>dereference of possibly-null reference currentSiblingAst.findFirstToken(TokenTypes.IDENT)</message>
-    <lineContent>currentSiblingAst.findFirstToken(TokenTypes.IDENT).getText();</lineContent>
+    <message>dereference of possibly-null reference currentAst.findFirstToken(TokenTypes.IDENT)</message>
+    <lineContent>currentAst.findFirstToken(TokenTypes.IDENT).getText();</lineContent>
   </checkerFrameworkError>
 
   <checkerFrameworkError unstable="false">

--- a/config/checker-framework-suppressions/checker-nullness-optional-interning-suppressions.xml
+++ b/config/checker-framework-suppressions/checker-nullness-optional-interning-suppressions.xml
@@ -3802,6 +3802,17 @@
 
   <checkerFrameworkError unstable="false">
     <fileName>src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/VariableDeclarationUsageDistanceCheck.java</fileName>
+    <specifier>argument</specifier>
+    <message>incompatible argument for parameter parent of VariableDeclarationUsageDistanceCheck.isChild.</message>
+    <lineContent>if (isChild(catchOrFinallyBlock, variable)) {</lineContent>
+    <details>
+      found   : @Initialized @Nullable DetailAST
+      required: @Initialized @NonNull DetailAST
+    </details>
+  </checkerFrameworkError>
+
+  <checkerFrameworkError unstable="false">
+    <fileName>src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/VariableDeclarationUsageDistanceCheck.java</fileName>
     <specifier>dereference.of.nullable</specifier>
     <message>dereference of possibly-null reference ast</message>
     <lineContent>while (ast.getType() != TokenTypes.RPAREN) {</lineContent>
@@ -3817,8 +3828,8 @@
   <checkerFrameworkError unstable="false">
     <fileName>src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/VariableDeclarationUsageDistanceCheck.java</fileName>
     <specifier>dereference.of.nullable</specifier>
-    <message>dereference of possibly-null reference currentSiblingAst.findFirstToken(TokenTypes.IDENT)</message>
-    <lineContent>currentSiblingAst.findFirstToken(TokenTypes.IDENT).getText();</lineContent>
+    <message>dereference of possibly-null reference currentAst.findFirstToken(TokenTypes.IDENT)</message>
+    <lineContent>currentAst.findFirstToken(TokenTypes.IDENT).getText();</lineContent>
   </checkerFrameworkError>
 
   <checkerFrameworkError unstable="false">

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/VariableDeclarationUsageDistanceCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/VariableDeclarationUsageDistanceCheck.java
@@ -230,15 +230,15 @@ public class VariableDeclarationUsageDistanceCheck extends AbstractCheck {
      */
     private static boolean isInitializationSequence(
             DetailAST variableUsageAst, String variableName) {
+        DetailAST currentAst = variableUsageAst;
+
         boolean result = true;
         boolean isUsedVariableDeclarationFound = false;
-        DetailAST currentSiblingAst = variableUsageAst;
         String initInstanceName = "";
-
-        while (result && !isUsedVariableDeclarationFound && currentSiblingAst != null) {
-            if (currentSiblingAst.getType() == TokenTypes.EXPR
-                    && currentSiblingAst.getFirstChild().getType() == TokenTypes.METHOD_CALL) {
-                final DetailAST methodCallAst = currentSiblingAst.getFirstChild();
+        while (result && !isUsedVariableDeclarationFound && currentAst != null) {
+            if (currentAst.getType() == TokenTypes.EXPR
+                    && currentAst.getFirstChild().getType() == TokenTypes.METHOD_CALL) {
+                final DetailAST methodCallAst = currentAst.getFirstChild();
                 final String instanceName = getInstanceName(methodCallAst);
                 if (instanceName.isEmpty()) {
                     result = false;
@@ -253,17 +253,91 @@ public class VariableDeclarationUsageDistanceCheck extends AbstractCheck {
                 }
 
             }
-            else if (currentSiblingAst.getType() == TokenTypes.VARIABLE_DEF) {
+            else if (currentAst.getType() == TokenTypes.VARIABLE_DEF) {
                 final String currentVariableName =
-                        currentSiblingAst.findFirstToken(TokenTypes.IDENT).getText();
+                        currentAst.findFirstToken(TokenTypes.IDENT).getText();
                 isUsedVariableDeclarationFound = variableName.equals(currentVariableName);
             }
             else {
-                result = currentSiblingAst.getType() == TokenTypes.SEMI;
+                result = Set.of(
+                    TokenTypes.SEMI,
+                    TokenTypes.LCURLY
+                ).contains(currentAst.getType());
             }
-            currentSiblingAst = currentSiblingAst.getPreviousSibling();
+
+            currentAst = getNextNodeToCheck(currentAst);
         }
         return result;
+    }
+
+    /**
+     * Returns the next node to check for initialization sequence.
+     *
+     * @param currentAst The current node.
+     * @return The next node to check for initialization sequence.
+     */
+    private static DetailAST getNextNodeToCheck(DetailAST currentAst) {
+        final DetailAST nextAst;
+
+        if (currentAst.getPreviousSibling() != null) {
+            nextAst = currentAst.getPreviousSibling();
+        }
+        else {
+            // go up the tree
+            final DetailAST predecessor = getFirstPredecessorOfTypes(
+                Set.of(
+                    TokenTypes.SLIST,
+                    TokenTypes.OBJBLOCK
+                ), currentAst);
+
+            if (predecessor.getType() == TokenTypes.SLIST) {
+                nextAst = getNextNodeToCheckBetweenScopesSlist(predecessor);
+            }
+            else {
+                nextAst = predecessor.getParent().getPreviousSibling();
+            }
+        }
+        return nextAst;
+    }
+
+    /**
+     * Returns the next node to check for initialization sequence when the
+     * current node is a direct child of SLIST.
+     *
+     * @param ast The SLIST node which is the parent of the current node.
+     * @return The next node to check for initialization sequence.
+     */
+    private static DetailAST getNextNodeToCheckBetweenScopesSlist(DetailAST ast) {
+        return switch (ast.getParent().getType()) {
+            case TokenTypes.LITERAL_ELSE, TokenTypes.LITERAL_CATCH,
+                 TokenTypes.LITERAL_FINALLY, TokenTypes.CASE_GROUP ->
+                ast.getParent().getParent().getPreviousSibling();
+            case TokenTypes.LITERAL_TRY, TokenTypes.LITERAL_FOR, TokenTypes.LITERAL_WHILE,
+                 TokenTypes.LITERAL_DO, TokenTypes.LITERAL_IF,
+                 TokenTypes.LITERAL_SYNCHRONIZED ->
+                ast.getParent().getPreviousSibling();
+            case TokenTypes.METHOD_DEF, TokenTypes.INSTANCE_INIT ->
+                getFirstPredecessorOfTypes(
+                Set.of(TokenTypes.CLASS_DEF), ast).getPreviousSibling();
+            default -> ast.getPreviousSibling();
+        };
+    }
+
+    /**
+     * Returns the AST node of the specified types that is the closest predecessor
+     * of the specified node.
+     *
+     * @param types The set of types of the predecessor to search for.
+     * @param ast The AST node for which predecessor is searched.
+     * @return The closest predecessor of one of the specified types;
+     *         null if no such node exists.
+     */
+    private static DetailAST getFirstPredecessorOfTypes(Set<Integer> types, DetailAST ast) {
+        DetailAST current = ast;
+        while (!types.contains(current.getType())) {
+            current = current.getParent();
+        }
+        return current;
     }
 
     /**
@@ -378,6 +452,7 @@ public class VariableDeclarationUsageDistanceCheck extends AbstractCheck {
             // If there's no any variable usage, then distance = 0.
             else if (variableUsageExpressions.isEmpty()) {
                 variableUsageAst = null;
+                dist = 0;
             }
             // If variable usage exists in different scopes, then distance =
             // distance until variable first usage.
@@ -581,46 +656,42 @@ public class VariableDeclarationUsageDistanceCheck extends AbstractCheck {
      */
     private static DetailAST getFirstNodeInsideTryCatchFinallyBlocks(
             DetailAST block, DetailAST variable) {
-        DetailAST currentNode = block.getFirstChild();
-        final List<DetailAST> variableUsageExpressions =
-                new ArrayList<>();
-
-        // Checking variable usage inside TRY block.
-        if (isChild(currentNode, variable)) {
-            variableUsageExpressions.add(currentNode);
-        }
-
-        // Switch on CATCH block.
-        currentNode = currentNode.getNextSibling();
-
-        // Checking variable usage inside all CATCH blocks.
-        while (currentNode != null
-                && currentNode.getType() == TokenTypes.LITERAL_CATCH) {
-            final DetailAST catchBlock = currentNode.getLastChild();
-
-            if (isChild(catchBlock, variable)) {
-                variableUsageExpressions.add(catchBlock);
-            }
-            currentNode = currentNode.getNextSibling();
-        }
-
-        // Checking variable usage inside FINALLY block.
-        if (currentNode != null) {
-            final DetailAST finalBlock = currentNode.getLastChild();
-
-            if (isChild(finalBlock, variable)) {
-                variableUsageExpressions.add(finalBlock);
-            }
-        }
-
         DetailAST variableUsageNode = null;
 
-        // If variable usage exists in several related blocks, then
-        // firstNodeInsideBlock = null, otherwise if variable usage exists
-        // only inside one block, then get node from
-        // variableUsageExpressions.
-        if (variableUsageExpressions.size() == 1) {
-            variableUsageNode = variableUsageExpressions.getFirst().getFirstChild();
+        final DetailAST resourceSpec = block.findFirstToken(TokenTypes.RESOURCE_SPECIFICATION);
+        if (resourceSpec == null || !isVariableInOperatorExpr(resourceSpec, variable)) {
+            DetailAST currentNode = block.getFirstChild();
+            // Skip resource specification if exists.
+            if (currentNode.getType() == TokenTypes.RESOURCE_SPECIFICATION) {
+                currentNode = currentNode.getNextSibling();
+            }
+
+            final List<DetailAST> variableUsageExpressions = new ArrayList<>();
+            // Checking variable usage inside TRY block.
+            if (isChild(currentNode, variable)) {
+                variableUsageExpressions.add(currentNode);
+            }
+
+            // Switch on CATCH block.
+            currentNode = currentNode.getNextSibling();
+
+            // Checking variable usage inside all CATCH and FINALLY blocks.
+            while (currentNode != null) {
+                final DetailAST catchOrFinallyBlock = currentNode.findFirstToken(TokenTypes.SLIST);
+
+                if (isChild(catchOrFinallyBlock, variable)) {
+                    variableUsageExpressions.add(catchOrFinallyBlock);
+                }
+                currentNode = currentNode.getNextSibling();
+            }
+
+            // If variable usage exists in several related blocks, then
+            // firstNodeInsideBlock = null, otherwise if variable usage exists
+            // only inside one block, then get node from
+            // variableUsageExpressions.
+            if (variableUsageExpressions.size() == 1) {
+                variableUsageNode = variableUsageExpressions.getFirst();
+            }
         }
 
         return variableUsageNode;

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/coding/VariableDeclarationUsageDistanceCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/coding/VariableDeclarationUsageDistanceCheckTest.java
@@ -85,6 +85,7 @@ public class VariableDeclarationUsageDistanceCheckTest extends
         final String[] expected = {
             "17:9: " + getCheckMessage(MSG_KEY, "first", 5, 1),
             "29:9: " + getCheckMessage(MSG_KEY, "allInvariants", 2, 1),
+            "58:9: " + getCheckMessage(MSG_KEY, "b", 3, 1),
         };
         verifyWithInlineConfigParser(
                 getPath("InputVariableDeclarationUsageDistanceGeneral2.java"), expected);
@@ -344,6 +345,7 @@ public class VariableDeclarationUsageDistanceCheckTest extends
     public void testGeneralClass3() throws Exception {
         final String[] expected = {
             "46:9: " + getCheckMessage(MSG_KEY, "a", 2, 1),
+            "92:9: " + getCheckMessage(MSG_KEY, "t", 3, 1),
         };
 
         verifyWithInlineConfigParser(
@@ -362,10 +364,7 @@ public class VariableDeclarationUsageDistanceCheckTest extends
 
     @Test
     public void testVariableDeclarationUsageDistanceTryResources() throws Exception {
-        final String[] expected = {
-            "19:9: " + getCheckMessage(MSG_KEY, "a", 2, 1),
-            "20:9: " + getCheckMessage(MSG_KEY, "b", 2, 1),
-        };
+        final String[] expected = CommonUtil.EMPTY_STRING_ARRAY;
 
         verifyWithInlineConfigParser(
                 getPath("InputVariableDeclarationUsageDistanceTryResources.java"), expected);
@@ -438,6 +437,119 @@ public class VariableDeclarationUsageDistanceCheckTest extends
         final String[] expected = CommonUtil.EMPTY_STRING_ARRAY;
         verifyWithInlineConfigParser(
                 getPath("InputVariableDeclarationUsageDistanceMethodDef.java"), expected);
+    }
+
+    @Test
+    public void testInitializationSequence1() throws Exception {
+        final String[] expected = {
+            "25:9: " + getCheckMessage(MSG_KEY, "list2", 2, 1),
+            "40:9: " + getCheckMessage(MSG_KEY, "list2", 2, 1),
+            "49:9: " + getCheckMessage(MSG_KEY, "list", 2, 1),
+            "55:9: " + getCheckMessage(MSG_KEY, "list2", 2, 1),
+            "69:9: " + getCheckMessage(MSG_KEY, "list2", 2, 1),
+            "83:9: " + getCheckMessage(MSG_KEY, "list2", 2, 1),
+            "91:9: " + getCheckMessage(MSG_KEY, "list", 2, 1),
+            "97:9: " + getCheckMessage(MSG_KEY, "list2", 2, 1),
+        };
+
+        verifyWithInlineConfigParser(
+            getPath(
+                "InputVariableDeclarationUsageDistanceInitializationSequence1.java"),
+            expected);
+    }
+
+    @Test
+    public void testInitializationSequence2() throws Exception {
+        final String[] expected = {
+            "25:9: " + getCheckMessage(MSG_KEY, "list2", 2, 1),
+            "33:9: " + getCheckMessage(MSG_KEY, "list", 2, 1),
+            "40:9: " + getCheckMessage(MSG_KEY, "list2", 2, 1),
+            "53:9: " + getCheckMessage(MSG_KEY, "list2", 2, 1),
+            "61:9: " + getCheckMessage(MSG_KEY, "list", 2, 1),
+            "68:9: " + getCheckMessage(MSG_KEY, "list2", 2, 1),
+            "82:9: " + getCheckMessage(MSG_KEY, "list2", 2, 1),
+            "90:9: " + getCheckMessage(MSG_KEY, "list", 2, 1),
+            "94:9: " + getCheckMessage(MSG_KEY, "list2", 2, 1),
+            "101:9: " + getCheckMessage(MSG_KEY, "list", 2, 1),
+            "105:9: " + getCheckMessage(MSG_KEY, "list2", 2, 1),
+        };
+
+        verifyWithInlineConfigParser(
+            getPath(
+                "InputVariableDeclarationUsageDistanceInitializationSequence2.java"),
+            expected);
+    }
+
+    @Test
+    public void testInitializationSequence3() throws Exception {
+        final String[] expected = {
+            "24:9: " + getCheckMessage(MSG_KEY, "list2", 2, 1),
+            "38:9: " + getCheckMessage(MSG_KEY, "list2", 3, 1),
+            "51:9: " + getCheckMessage(MSG_KEY, "list2", 2, 1),
+            "70:9: " + getCheckMessage(MSG_KEY, "list", 2, 1),
+        };
+
+        verifyWithInlineConfigParser(
+            getPath(
+                "InputVariableDeclarationUsageDistanceInitializationSequence3.java"),
+            expected);
+    }
+
+    @Test
+    public void testInitializationSequence4() throws Exception {
+        final String[] expected = {
+            "25:9: " + getCheckMessage(MSG_KEY, "list2", 2, 1),
+            "40:9: " + getCheckMessage(MSG_KEY, "list2", 2, 1),
+            "57:9: " + getCheckMessage(MSG_KEY, "list2", 2, 1),
+            "67:9: " + getCheckMessage(MSG_KEY, "list", 2, 1),
+            "74:9: " + getCheckMessage(MSG_KEY, "list2", 2, 1),
+            "93:9: " + getCheckMessage(MSG_KEY, "list2", 2, 1),
+        };
+
+        verifyWithInlineConfigParser(
+            getPath(
+                "InputVariableDeclarationUsageDistanceInitializationSequence4.java"),
+            expected);
+    }
+
+    @Test
+    public void testInitializationSequence5() throws Exception {
+        final String[] expected = {
+            "27:9: " + getCheckMessage(MSG_KEY, "list2", 2, 1),
+            "44:9: " + getCheckMessage(MSG_KEY, "list2", 2, 1),
+            "60:9: " + getCheckMessage(MSG_KEY, "list2", 3, 1),
+            "80:9: " + getCheckMessage(MSG_KEY, "list2", 2, 1),
+        };
+
+        verifyWithInlineConfigParser(
+            getPath(
+                "InputVariableDeclarationUsageDistanceInitializationSequence5.java"),
+            expected);
+    }
+
+    @Test
+    public void testFalsePositive1() throws Exception {
+        final String[] expected = {
+            "33:17: " + getCheckMessage(MSG_KEY, "localMap", 5, 3),
+            "35:17: " + getCheckMessage(MSG_KEY, "nl", 5, 3),
+        };
+
+        verifyWithInlineConfigParser(
+            getPath(
+                "InputVariableDeclarationUsageDistanceInitializationFalsePositive1.java"),
+            expected);
+    }
+
+    @Test
+    public void testReturn() throws Exception {
+        final String[] expected = {
+            "47:9: " + getCheckMessage(MSG_KEY, "function", 5, 3),
+        };
+
+        verifyWithInlineConfigParser(
+            getPath(
+                "InputVariableDeclarationUsageDistanceInitializationReturn.java"),
+            expected);
     }
 
 }

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/variabledeclarationusagedistance/InputVariableDeclarationUsageDistanceGeneral2.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/variabledeclarationusagedistance/InputVariableDeclarationUsageDistanceGeneral2.java
@@ -55,8 +55,12 @@ public class InputVariableDeclarationUsageDistanceGeneral2 {
     }
 
     void method() throws Exception {
+        String b = "x"; // violation 'Distance .* is 3.'
+        System.out.println();
         String a = "";
+        System.out.println();
         try (AutoCloseable i = new java.io.StringReader(a)) {
+            b.length();
         }
         finally {
             a.equals("");

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/variabledeclarationusagedistance/InputVariableDeclarationUsageDistanceGeneral3.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/variabledeclarationusagedistance/InputVariableDeclarationUsageDistanceGeneral3.java
@@ -88,8 +88,7 @@ public class InputVariableDeclarationUsageDistanceGeneral3 {
     }
 
     public void method7() {
-        // the below distance is 1 (expected 3),
-        // until https://github.com/checkstyle/checkstyle/issues/19156
+        // violation below 'Distance .* is 3.'
         Integer t = 5;
         nothing();
         System.out.println();

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/variabledeclarationusagedistance/InputVariableDeclarationUsageDistanceInitializationFalsePositive1.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/variabledeclarationusagedistance/InputVariableDeclarationUsageDistanceInitializationFalsePositive1.java
@@ -1,0 +1,118 @@
+/*
+VariableDeclarationUsageDistance
+allowedDistance = (default)3
+ignoreVariablePattern = (default)
+validateBetweenScopes = true
+ignoreFinal = false
+
+
+*/
+
+package com.puppycrawl.tools.checkstyle.checks.coding.variabledeclarationusagedistance;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.concurrent.atomic.AtomicLongFieldUpdater;
+
+public class InputVariableDeclarationUsageDistanceInitializationFalsePositive1 {
+
+    static class RequestHandler<T> {
+        final State<T> state = new State<>();
+        final NotificationLite<T> notifier = NotificationLite.instance();
+        volatile long wip;
+        static final AtomicLongFieldUpdater<RequestHandler> WIP =
+            AtomicLongFieldUpdater.newUpdater(RequestHandler.class, "wip");
+
+        void requestMoreAfterEmission(int emitted) {}
+
+        public void drainQueue(OriginSubscriber<T> originSubscriber) {
+            if (WIP.getAndIncrement(this) == 0) {
+                State<T> localState = state;
+                // violation below, false positive, 'Distance .* is 5.'
+                Map<Subscriber<? super T>, AtomicLong> localMap = localState.ss;
+                RxRingBuffer localBuffer = originSubscriber.buffer;
+                NotificationLite<T> nl = notifier;  // violation 'Distance .* is 5.'
+
+                int emitted = 0;
+                do {
+                    WIP.set(this, 1);
+                    while (true) {
+                        if (localState.hasNoSubscriber()) {
+                            if (localBuffer.poll() == null) {
+                                break;
+                            } else {
+                                continue;
+                            }
+                        }
+
+                        boolean shouldEmit = localState.canEmitWithDecrement();
+                        if (!shouldEmit) {
+                            break;
+                        }
+                        Object o = localBuffer.poll();
+                        if (o == null) {
+                            localState.incrementOutstandingAfterFailedEmit();
+                            break;
+                        }
+
+                        for (Subscriber<? super T> s : localState.getSubscribers()) {
+                            AtomicLong req = localMap.get(s);
+                            if (req != null) {
+                                nl.accept(s, o);
+                                req.decrementAndGet();
+                            }
+                        }
+                        emitted++;
+                    }
+                } while (WIP.decrementAndGet(this) > 0);
+                requestMoreAfterEmission(emitted);
+            }
+        }
+    }
+
+    static class Subscriber<T> { }
+
+    static class NotificationLite<T> {
+        static <T> NotificationLite<T> instance() {
+            return new NotificationLite<>();
+        }
+        void accept(Subscriber<? super T> s, Object o) {}
+    }
+
+    static class RxRingBuffer {
+        static final int SIZE = 256;
+        Object poll() {
+            return null;
+        }
+        static RxRingBuffer getSpmcInstance() {
+            return new RxRingBuffer();
+        }
+    }
+
+    static class State<T> {
+        final Map<Subscriber<? super T>, AtomicLong> ss = new LinkedHashMap<>();
+        boolean hasNoSubscriber() {
+            return ss.isEmpty();
+        }
+        boolean canEmitWithDecrement() {
+            return false;
+        }
+        void incrementOutstandingAfterFailedEmit() {}
+        Subscriber<? super T>[] getSubscribers() {
+            @SuppressWarnings("unchecked")
+            Subscriber<? super T>[] arr = new Subscriber[0];
+            return arr;
+        }
+    }
+
+    static class OriginSubscriber<T> {
+        final RxRingBuffer buffer = RxRingBuffer.getSpmcInstance();
+    }
+
+    public void rxJavaCase() {
+        OriginSubscriber<Object> originSubscriber = new OriginSubscriber<>();
+        RequestHandler<Object> handler = new RequestHandler<>();
+        handler.drainQueue(originSubscriber);
+    }
+}

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/variabledeclarationusagedistance/InputVariableDeclarationUsageDistanceInitializationReturn.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/variabledeclarationusagedistance/InputVariableDeclarationUsageDistanceInitializationReturn.java
@@ -1,0 +1,58 @@
+/*
+VariableDeclarationUsageDistance
+allowedDistance = (default)3
+ignoreVariablePattern = (default)
+validateBetweenScopes = true
+ignoreFinal = false
+
+
+*/
+
+package com.puppycrawl.tools.checkstyle.checks.coding.variabledeclarationusagedistance;
+
+import java.lang.reflect.Method;
+import java.util.ArrayList;
+import java.util.List;
+
+public class InputVariableDeclarationUsageDistanceInitializationReturn {
+
+    static class MyNode {
+    }
+
+    static class MatchesFunction {
+        Object call(Context c, List<Object> list) {
+            return null;
+        }
+    }
+
+    static class Attribute {
+        Attribute(MyNode node, String name, Method method) {
+        }
+    }
+
+    static class Context {
+        Context(Object ignored) {
+        }
+
+        void setNodeSet(List<?> list) {
+        }
+    }
+
+    static class FunctionCallException extends Exception {
+    }
+
+    private Object tryRegexp(MyNode myNode, String exp)
+        throws FunctionCallException, NoSuchMethodException {
+         // violation below 'Distance .* is 5.'
+        MatchesFunction function = new MatchesFunction();
+        List<Object> list = new ArrayList<>();
+        List<Attribute> attrs = new ArrayList<>();
+        attrs.add(new Attribute(myNode, "matches",
+            myNode.getClass().getMethod("getClassName", new Class[0])));
+        list.add(attrs);
+        list.add(exp);
+        Context c = new Context(null);
+        c.setNodeSet(new ArrayList<>());
+        return function.call(c, list);
+    }
+}

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/variabledeclarationusagedistance/InputVariableDeclarationUsageDistanceInitializationSequence1.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/variabledeclarationusagedistance/InputVariableDeclarationUsageDistanceInitializationSequence1.java
@@ -1,0 +1,111 @@
+/*
+VariableDeclarationUsageDistance
+allowedDistance = 1
+ignoreVariablePattern = (default)
+validateBetweenScopes = true
+ignoreFinal = false
+
+
+*/
+
+package com.puppycrawl.tools.checkstyle.checks.coding.variabledeclarationusagedistance;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class InputVariableDeclarationUsageDistanceInitializationSequence1 {
+
+    public void ifBlock() {
+        List<Integer> list = new ArrayList<>();
+        System.out.println(0);
+        if (check()) {
+            System.out.println(list.size());
+        }
+
+        List<Integer> list2 = new ArrayList<>();  // violation 'Distance .* is 2'
+        nothing();
+        if (check()) {
+            System.out.println(list2.size());
+        }
+    }
+
+    public void elseBlock() {
+        List<Integer> list = new ArrayList<>();
+        System.out.println(0);
+        if (check()) {
+        } else {
+            System.out.println(list.size());
+        }
+
+        List<Integer> list2 = new ArrayList<>();  // violation 'Distance .* is 2'
+        nothing();
+        if (check()) {
+        } else {
+            System.out.println(list2.size());
+        }
+    }
+
+    public void ifCondition() {
+        List<Integer> list = new ArrayList<>();  // violation 'Distance .* is 2'
+        System.out.println(0);
+        System.out.println(0);
+        if (System.out.equals(list)) {
+        }
+
+        List<Integer> list2 = new ArrayList<>();  // violation 'Distance .* is 2'
+        nothing();
+        System.out.println(0);
+        if (System.out.equals(list2)) {
+        }
+    }
+
+    public void switchCase() {
+        List<Integer> list = new ArrayList<>();
+        System.out.println(0);
+        switch (1 + 1) {
+        case 2: nothing(); break;
+        case 3: System.out.println(list.size()); break;
+        }
+        List<Integer> list2 = new ArrayList<>();  // violation 'Distance .* is 2'
+        nothing();
+        switch (1 + 1) {
+        case 2: System.out.println(list2.size()); break;
+        }
+    }
+
+    public void switchDefault() {
+        List<Integer> list = new ArrayList<>();
+        System.out.println(0);
+        switch (1 + 1) {
+        case 2: nothing(); break;
+        default: System.out.println(list.size()); break;
+        }
+        List<Integer> list2 = new ArrayList<>();  // violation 'Distance .* is 2'
+        nothing();
+        switch (1 + 1) {
+        default: System.out.println(list2.size()); break;
+        }
+    }
+
+    public void switchCondition() {
+        List<Integer> list = new ArrayList<>();  // violation 'Distance .* is 2'
+        System.out.println(0);
+        System.out.println(0);
+        switch (list.size()) {
+        default: break;
+        }
+        List<Integer> list2 = new ArrayList<>();  // violation 'Distance .* is 2'
+        nothing();
+        System.out.println(0);
+        switch (list2.size()) {
+        default: break;
+        }
+    }
+
+    private void nothing() {
+    }
+
+    private boolean check() {
+        return true;
+    }
+}

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/variabledeclarationusagedistance/InputVariableDeclarationUsageDistanceInitializationSequence2.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/variabledeclarationusagedistance/InputVariableDeclarationUsageDistanceInitializationSequence2.java
@@ -1,0 +1,117 @@
+/*
+VariableDeclarationUsageDistance
+allowedDistance = 1
+ignoreVariablePattern = (default)
+validateBetweenScopes = true
+ignoreFinal = false
+
+
+*/
+
+package com.puppycrawl.tools.checkstyle.checks.coding.variabledeclarationusagedistance;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class InputVariableDeclarationUsageDistanceInitializationSequence2 {
+
+    public void whileBlock() {
+        List<Integer> list = new ArrayList<>();
+        System.out.println(0);
+        while (check()) {
+            System.out.println(list.size());
+        }
+
+        List<Integer> list2 = new ArrayList<>();  // violation 'Distance .* is 2'
+        nothing();
+        while (check()) {
+            System.out.println(list2.size());
+        }
+    }
+
+    public void whileCondition() {
+        List<Integer> list = new ArrayList<>();  // violation 'Distance .* is 2'
+        System.out.println(0);
+        System.out.println(0);
+        while (list.isEmpty()) {
+            nothing();
+        }
+
+        List<Integer> list2 = new ArrayList<>();  // violation 'Distance .* is 2'
+        nothing();
+        System.out.println(0);
+        while (list2.isEmpty()) {}
+    }
+
+    public void doWhileBlock() {
+        List<Integer> list = new ArrayList<>();
+        System.out.println(0);
+        do {
+            System.out.println(list.size());
+        } while (check());
+
+        List<Integer> list2 = new ArrayList<>();  // violation 'Distance .* is 2'
+        nothing();
+        do {
+            System.out.println(list2.size());
+        } while (check());
+    }
+
+    public void doWhileCondition() {
+        List<Integer> list = new ArrayList<>();  // violation 'Distance .* is 2'
+        System.out.println(0);
+        System.out.println(0);
+        do {
+            nothing();
+        } while (list.isEmpty());
+
+        List<Integer> list2 = new ArrayList<>();  // violation 'Distance .* is 2'
+        nothing();
+        System.out.println(0);
+        do {
+        } while (list2.isEmpty());
+    }
+
+    public void forBlock() {
+        List<Integer> list = new ArrayList<>();
+        System.out.println(0);
+        for (; check(); ) {
+            System.out.println(list.size());
+        }
+
+        List<Integer> list2 = new ArrayList<>();  // violation 'Distance .* is 2'
+        nothing();
+        for (; check(); ) {
+            System.out.println(list2.size());
+        }
+    }
+
+    public void forInitAndIterator() {
+        List<Integer> list = new ArrayList<>();  // violation 'Distance .* is 2'
+        System.out.println(0);
+        System.out.println(0);
+        for (list.add(1); check(); list.add(1)) {}
+        List<Integer> list2 = new ArrayList<>();  // violation 'Distance .* is 2'
+        nothing();
+        System.out.println(1);
+        for (System.out.println(list2.size()); check(); System.out.println(list2.size())) {}
+    }
+
+    public void forEnhanced() {
+        List<Integer> list = new ArrayList<>();  // violation 'Distance .* is 2'
+        System.out.println(0);
+        System.out.println(0);
+        for (Integer i : list) {}
+        List<Integer> list2 = new ArrayList<>();  // violation 'Distance .* is 2'
+        nothing();
+        System.out.println(1);
+        for (Integer i : list2.subList(0, 1)) {}
+    }
+
+    private void nothing() {
+    }
+
+    private boolean check() {
+        return true;
+    }
+}

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/variabledeclarationusagedistance/InputVariableDeclarationUsageDistanceInitializationSequence3.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/variabledeclarationusagedistance/InputVariableDeclarationUsageDistanceInitializationSequence3.java
@@ -1,0 +1,108 @@
+/*
+VariableDeclarationUsageDistance
+allowedDistance = 1
+ignoreVariablePattern = (default)
+validateBetweenScopes = true
+ignoreFinal = false
+
+
+*/
+
+package com.puppycrawl.tools.checkstyle.checks.coding.variabledeclarationusagedistance;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class InputVariableDeclarationUsageDistanceInitializationSequence3 {
+    public void codeBlock() {
+        List<Integer> list = new ArrayList<>();
+        System.out.println(0);
+        {
+            System.out.println(list.size());
+        }
+
+        List<Integer> list2 = new ArrayList<>();  // violation 'Distance .* is 2'
+        nothing();
+        {
+            System.out.println(list2.size());
+        }
+    }
+
+    public void synchronizedBlock() {
+        List<Integer> list = new ArrayList<>();
+        System.out.println(0);
+        synchronized (this) {
+            System.out.println(list.size());
+        }
+
+        List<Integer> list2 = new ArrayList<>();  // violation 'Distance .* is 3'
+        nothing();
+        synchronized (this) {
+            System.out.println(list2.size());
+        }
+    }
+
+    public void synchronizedObject() {
+        List<Integer> list = new ArrayList<>();
+        int i = 0;
+        synchronized (list.subList(i, 1)) {
+        }
+
+        List<Integer> list2 = new ArrayList<>();  // violation 'Distance .* is 2'
+        nothing();
+        synchronized (list2.subList(0, 1)) {
+        }
+    }
+
+    public void mixedNested1() {
+        List<Integer> list = new ArrayList<>();
+        class AClass extends Parent {
+            @Override
+            void method() {
+                if (true) {
+                    list.add(0);
+                }
+            }
+        }
+    }
+
+    private void mixedNested2() {
+        List<Integer> list = new ArrayList<>(); // violation 'Distance .* is 2'
+
+        if (true) {
+            int a = 3;
+            while (check()) {
+                int b = 2;
+                nothing();
+                {
+                    list.add(2);
+                }
+            }
+        }
+    }
+
+    private class Parent {
+        void method() {
+        }
+    }
+
+    private void nothing() {
+    }
+
+    private class Close implements AutoCloseable {
+        public Close(int i) {
+        }
+
+        @Override
+        public void close() throws Exception {
+        }
+    }
+
+    private boolean check() {
+        return true;
+    }
+
+    private AutoCloseable getAutoCloseable(int i) {
+        return new Close(i);
+    }
+}

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/variabledeclarationusagedistance/InputVariableDeclarationUsageDistanceInitializationSequence4.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/variabledeclarationusagedistance/InputVariableDeclarationUsageDistanceInitializationSequence4.java
@@ -1,0 +1,119 @@
+/*
+VariableDeclarationUsageDistance
+allowedDistance = 1
+ignoreVariablePattern = (default)
+validateBetweenScopes = true
+ignoreFinal = false
+
+
+*/
+
+package com.puppycrawl.tools.checkstyle.checks.coding.variabledeclarationusagedistance;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class InputVariableDeclarationUsageDistanceInitializationSequence4 {
+    public void tryBlock() {
+        List<Integer> list = new ArrayList<>();
+        System.out.println(0);
+        try {
+            System.out.println(list.size());
+        } catch (Exception e) {
+        }
+
+        List<Integer> list2 = new ArrayList<>();  // violation 'Distance .* is 2'
+        nothing();
+        try {
+            System.out.println(list2.size());
+        } catch (Exception e) {
+        }
+    }
+
+    public void catchBlock() {
+        List<Integer> list = new ArrayList<>();
+        System.out.println(0);
+        try {
+        } catch (Exception e) {
+            System.out.println(list.size());
+        }
+        List<Integer> list2 = new ArrayList<>();  // violation 'Distance .* is 2'
+        nothing();
+        try {
+        } catch (Exception e) {
+            System.out.println(list2.size());
+        }
+    }
+
+    public void finallyBlock() {
+        List<Integer> list = new ArrayList<>();
+        System.out.println(0);
+        try {
+        } catch (Exception e) {
+        } finally {
+            System.out.println(list.size());
+        }
+
+        List<Integer> list2 = new ArrayList<>();  // violation 'Distance .* is 2'
+        nothing();
+        try {
+        } catch (Exception e) {
+        } finally {
+            System.out.println(list2.size());
+        }
+    }
+
+    public void tryResource() {
+        List<Integer> list = new ArrayList<>();   // violation 'Distance .* is 2'
+        this.getAutoCloseable(0);
+        this.getAutoCloseable(0);
+        try (AutoCloseable a = this.getAutoCloseable(list.size())) {
+        } catch (Exception e) {
+        }
+
+        List<Integer> list2 = new ArrayList<>();  // violation 'Distance .* is 2'
+        nothing();
+        System.out.println(0);
+        try (AutoCloseable a = new Close(list2.size())) {
+        } catch (Exception e) {
+        }
+    }
+
+    public void multipleBlocks() {
+        List<Integer> list = new ArrayList<>();
+        nothing();
+        try {
+            nothing();
+            int x = list.size();
+        } catch (Exception e) {
+        } finally {
+            System.out.println(list.size());
+        }
+
+        List<Integer> list2 = new ArrayList<>();  // violation 'Distance .* is 2'
+        nothing();
+        list2.add(1);
+        try {
+            int x = list2.size();
+        } catch (Exception e) {
+        } finally {
+            System.out.println(list2.size());
+        }
+    }
+
+    private void nothing() {
+    }
+
+    private class Close implements AutoCloseable {
+        public Close(int i) {
+        }
+
+        @Override
+        public void close() throws Exception {
+        }
+    }
+
+    private AutoCloseable getAutoCloseable(int i) {
+        return new Close(i);
+    }
+}

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/variabledeclarationusagedistance/InputVariableDeclarationUsageDistanceInitializationSequence5.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/variabledeclarationusagedistance/InputVariableDeclarationUsageDistanceInitializationSequence5.java
@@ -1,0 +1,97 @@
+/*
+VariableDeclarationUsageDistance
+allowedDistance = 1
+ignoreVariablePattern = (default)
+validateBetweenScopes = true
+ignoreFinal = false
+
+
+*/
+
+package com.puppycrawl.tools.checkstyle.checks.coding.variabledeclarationusagedistance;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class InputVariableDeclarationUsageDistanceInitializationSequence5 {
+    public void innerClassMethod() {
+        List<Integer> list = new ArrayList<>();
+        System.out.println(0);
+        class AClass extends Parent {
+            @Override
+            void method() {
+                System.out.println(list.size());
+            }
+        }
+
+        List<Integer> list2 = new ArrayList<>(); // violation 'Distance .* is 2'
+        nothing();
+        class BClass extends Parent {
+            @Override
+            void method() {
+                System.out.println(list2.size());
+            }
+        }
+    }
+
+    public void innerClassField() {
+        List<Integer> list = new ArrayList<>();
+        Integer.valueOf(0);
+        class AClass extends Parent {
+            private int i = Integer.valueOf(list.size());
+        }
+
+        List<Integer> list2 = new ArrayList<>(); // violation 'Distance .* is 2'
+        nothing();
+        class BClass extends Parent {
+            private int i = list2.size();
+        }
+    }
+
+    public void innerClassInitializer() {
+        List<Integer> list = new ArrayList<>();
+        System.out.println(0);
+        class AClass extends Parent {
+            {
+                System.out.println(list.size());
+            }
+        }
+
+        List<Integer> list2 = new ArrayList<>(); // violation 'Distance .* is 3'
+        nothing();
+        System.out.println(1);
+        class BClass extends Parent {
+            {
+                System.out.println(list2.size());
+            }
+        }
+    }
+
+    public void anonymousClassMethod() {
+        List<Integer> list = new ArrayList<>();
+        System.out.println(0);
+        Parent aClass = new Parent() {
+            @Override
+            void method() {
+                System.out.println(list.size());
+            }
+        };
+
+        List<Integer> list2 = new ArrayList<>();  // violation 'Distance .* is 2'
+        nothing();
+        Parent bClass = new Parent() {
+            @Override
+            void method() {
+               System.out.println(list2.size());
+            }
+        };
+    }
+
+    private class Parent {
+        void method() {
+        }
+    }
+
+    private void nothing() {
+    }
+}

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/variabledeclarationusagedistance/InputVariableDeclarationUsageDistanceTryResources.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/variabledeclarationusagedistance/InputVariableDeclarationUsageDistanceTryResources.java
@@ -16,8 +16,8 @@ import java.util.*;
 
 public class InputVariableDeclarationUsageDistanceTryResources {
     public int methodTry() {
-        String a = ""; // violation 'Distance .* is 2.'
-        String b = "abc"; // violation 'Distance .* is 2.'
+        String a = "";
+        String b = "abc";
         System.out.println();
         try (AutoCloseable j = new java.io.StringReader(b);
              final AutoCloseable i = new java.io.StringReader(a);
@@ -34,7 +34,7 @@ public class InputVariableDeclarationUsageDistanceTryResources {
         String b = "";
         FileReader fr = new FileReader(b);
         BufferedReader br = new BufferedReader(fr);
-        try {
+        try (AutoCloseable j = new java.io.StringReader("");){
             return br.readLine();
         } finally {
             br.close();


### PR DESCRIPTION
Issue: #19156

Fixed false negative of VariableDeclarationUsageDistanceCheck not reporting violation when
- The check's property `validateBetweenScopes` is set to `true`;
- The variable definition and its first usage exceeds the maximum allowed distance; and
- The first usage is inside an inner class.

Root Cause
---
The method `isInitializationSequence()` fails to check for method calls in outer scopes. 

This method is used to detect initialization sequences from variable first usage up to variable definition. If detected, it exempts the variable from distance check.

If variable definition is in an outer scope, the method is supposed to check inside outer scope as well. However, the current implementation only checks within the inner scope.

Example
---
```java
  Integer t = 5;  // violation, 'Distance .* is 3.
  nothing();                                (1)
  list.add(5);                              (2)
  class BClass extends Parent {
      @Override
      void mm() {
          list.add(t);                      (3)
      }
  }
```
The current implementation only checks (3) and concludes yes, it is an initialization sequence; therefore does not report a violation.

After the fix, (2) and (1) will also be checked and violation is reported since `nothing();` is not an initialization.

Fix
---
When we reach the first sibling, we continue to check previous siblings of the parent node (or grandparent or great-grandparent, based on the type of current scope). 

I also added an additional set of tests to ensure correct behavior in various nested blocks.