### PR TITLE
Issue #19064: Adding third Test in XpathRegressionWhitespaceAround

### DIFF
--- a/config/checkstyle-non-main-files-suppressions.xml
+++ b/config/checkstyle-non-main-files-suppressions.xml
@@ -469,5 +469,4 @@
   <suppress id="numberOfTestCasesInXpath" files="[\\/]src[\\/]it[\\/]java[\\/]org[\\/]checkstyle[\\/]suppressionxpathfilter[\\/]whitespace[\\/]XpathRegressionEmptyForIteratorPadTest.java" />
   <suppress id="numberOfTestCasesInXpath" files="[\\/]src[\\/]it[\\/]java[\\/]org[\\/]checkstyle[\\/]suppressionxpathfilter[\\/]whitespace[\\/]XpathRegressionOperatorWrapTest.java" />
   <suppress id="numberOfTestCasesInXpath" files="[\\/]src[\\/]it[\\/]java[\\/]org[\\/]checkstyle[\\/]suppressionxpathfilter[\\/]whitespace[\\/]XpathRegressionSingleSpaceSeparatorTest.java" />
-  <suppress id="numberOfTestCasesInXpath" files="[\\/]src[\\/]it[\\/]java[\\/]org[\\/]checkstyle[\\/]suppressionxpathfilter[\\/]whitespace[\\/]XpathRegressionWhitespaceAroundTest.java" />
 </suppressions>

--- a/src/it/java/org/checkstyle/suppressionxpathfilter/whitespace/XpathRegressionWhitespaceAroundTest.java
+++ b/src/it/java/org/checkstyle/suppressionxpathfilter/whitespace/XpathRegressionWhitespaceAroundTest.java
@@ -89,4 +89,27 @@ public class XpathRegressionWhitespaceAroundTest extends AbstractXpathTestSuppor
                 expectedXpathQueries);
     }
 
+    @Test
+    public void testWhitespaceAroundLambda() throws Exception {
+        final File fileToProcess =
+                new File(getPath("InputXpathWhitespaceAroundLambda.java"));
+
+        final DefaultConfiguration moduleConfig =
+                createModuleConfig(WhitespaceAroundCheck.class);
+
+        final String[] expectedViolation = {
+            "7:48: " + getCheckMessage(WhitespaceAroundCheck.class,
+                    WhitespaceAroundCheck.MSG_WS_NOT_PRECEDED, "->"),
+        };
+
+        final List<String> expectedXpathQueries = Collections.singletonList(
+            "/COMPILATION_UNIT/CLASS_DEF[./IDENT["
+                + "@text='InputXpathWhitespaceAroundLambda']]/OBJBLOCK/METHOD_DEF"
+                + "[./IDENT[@text='foo']]/SLIST/VARIABLE_DEF[./IDENT"
+                + "[@text='function']]/ASSIGN/LAMBDA"
+        );
+
+        runVerifications(moduleConfig, fileToProcess, expectedViolation,
+                expectedXpathQueries);
+    }
 }

--- a/src/it/resources/org/checkstyle/suppressionxpathfilter/whitespace/whitespacearound/InputXpathWhitespaceAroundLambda.java
+++ b/src/it/resources/org/checkstyle/suppressionxpathfilter/whitespace/whitespacearound/InputXpathWhitespaceAroundLambda.java
@@ -1,0 +1,9 @@
+package org.checkstyle.suppressionxpathfilter.whitespace.whitespacearound;
+
+import java.util.function.Function;
+
+public class InputXpathWhitespaceAroundLambda {
+    public void foo() {
+        Function<Object, String> function = (o)-> o.toString(); //warn
+    }
+}


### PR DESCRIPTION
Issue: #19064
Adding Third test in `XpathRegressionWhitespaceAroundTest`.
Removing `XpathRegressionWhitespaceAroundTest` from `checkstyle-non-main-files-suppressions.xml`
