### PR TITLE
Issue #19064:  Added 3rd test to XpathRegressionIllegalThrowsTest

### DIFF
--- a/config/checkstyle-non-main-files-suppressions.xml
+++ b/config/checkstyle-non-main-files-suppressions.xml
@@ -421,7 +421,6 @@
   <suppress id="numberOfTestCasesInXpath" files="[\\/]src[\\/]it[\\/]java[\\/]org[\\/]checkstyle[\\/]suppressionxpathfilter[\\/]coding[\\/]XpathRegressionDeclarationOrderTest.java" />
   <suppress id="numberOfTestCasesInXpath" files="[\\/]src[\\/]it[\\/]java[\\/]org[\\/]checkstyle[\\/]suppressionxpathfilter[\\/]coding[\\/]XpathRegressionFallThroughTest.java" />
   <suppress id="numberOfTestCasesInXpath" files="[\\/]src[\\/]it[\\/]java[\\/]org[\\/]checkstyle[\\/]suppressionxpathfilter[\\/]coding[\\/]XpathRegressionHiddenFieldTest.java" />
-  <suppress id="numberOfTestCasesInXpath" files="[\\/]src[\\/]it[\\/]java[\\/]org[\\/]checkstyle[\\/]suppressionxpathfilter[\\/]coding[\\/]XpathRegressionIllegalThrowsTest.java" />
   <suppress id="numberOfTestCasesInXpath" files="[\\/]src[\\/]it[\\/]java[\\/]org[\\/]checkstyle[\\/]suppressionxpathfilter[\\/]coding[\\/]XpathRegressionIllegalTypeTest.java" />
   <suppress id="numberOfTestCasesInXpath" files="[\\/]src[\\/]it[\\/]java[\\/]org[\\/]checkstyle[\\/]suppressionxpathfilter[\\/]coding[\\/]XpathRegressionInnerAssignmentTest.java" />
   <suppress id="numberOfTestCasesInXpath" files="[\\/]src[\\/]it[\\/]java[\\/]org[\\/]checkstyle[\\/]suppressionxpathfilter[\\/]coding[\\/]XpathRegressionMissingNullCaseInSwitchTest.java" />

--- a/src/it/java/org/checkstyle/suppressionxpathfilter/coding/XpathRegressionIllegalThrowsTest.java
+++ b/src/it/java/org/checkstyle/suppressionxpathfilter/coding/XpathRegressionIllegalThrowsTest.java
@@ -90,4 +90,31 @@ public class XpathRegressionIllegalThrowsTest extends AbstractXpathTestSupport {
         runVerifications(moduleConfig, fileToProcess, expectedViolation,
                 expectedXpathQueries);
     }
+
+    @Test
+    public void testThrowable() throws Exception {
+        final File fileToProcess =
+                new File(getPath("InputXpathIllegalThrowsThrowable.java"));
+
+        final DefaultConfiguration moduleConfig =
+                createModuleConfig(IllegalThrowsCheck.class);
+
+        final String[] expectedViolation = {
+            "6:35: " + getCheckMessage(IllegalThrowsCheck.class,
+                IllegalThrowsCheck.MSG_KEY, "Throwable"),
+        };
+
+        final List<String> expectedXpathQueries = Collections.singletonList(
+            "/COMPILATION_UNIT/CLASS_DEF"
+               + "[./IDENT[@text='InputXpathIllegalThrowsThrowable']]/OBJBLOCK"
+               + "/VARIABLE_DEF[./IDENT[@text='obj']]"
+               + "/ASSIGN/EXPR/LITERAL_NEW[./IDENT[@text='Object']]"
+               + "/OBJBLOCK/METHOD_DEF[./IDENT[@text='test']]"
+               + "/LITERAL_THROWS/IDENT[@text='Throwable']"
+        );
+
+        runVerifications(moduleConfig, fileToProcess,
+                expectedViolation, expectedXpathQueries);
+    }
+
 }

--- a/src/it/resources/org/checkstyle/suppressionxpathfilter/coding/illegalthrows/InputXpathIllegalThrowsThrowable.java
+++ b/src/it/resources/org/checkstyle/suppressionxpathfilter/coding/illegalthrows/InputXpathIllegalThrowsThrowable.java
@@ -1,0 +1,10 @@
+package org.checkstyle.suppressionxpathfilter.coding.illegalthrows;
+
+public class InputXpathIllegalThrowsThrowable {
+
+    Object obj=new Object() {
+        public void test() throws Throwable //warn
+        {
+        }
+    };
+}


### PR DESCRIPTION
Issue :#19064 
Removing `XpathRegressionIllegalThrowsTest` from suppression `checkstyle-non-main-files-suppressions.xml`. Adding third test in `XpathRegressionIllegalThrowsTest`
