### PR TITLE
Issue 17449

### DIFF
--- a/src/site/xdoc/checks/javadoc/javadocstyle.xml
+++ b/src/site/xdoc/checks/javadoc/javadocstyle.xml
@@ -621,7 +621,72 @@ public class Example7 {
   // violation 4 lines above 'Javadoc has empty description section'
 }
 </code></pre></div>
-      </subsection>
+
+        <hr class="example-separator"/>
+              <p id="Example8-config">
+                To configure the Check to use custom end of sentence format:
+              </p>
+              <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
+&lt;module name="Checker"&gt;
+  &lt;module name="TreeWalker"&gt;
+    &lt;module name="JavadocStyle"&gt;
+      &lt;property name="endOfSentenceFormat"
+        value="([.。][ \t\n\r\f&amp;lt;])|([.。]$)"/&gt;
+    &lt;/module&gt;
+  &lt;/module&gt;
+&lt;/module&gt;
+</code></pre></div>
+
+              <p id="Example8-code">Example8:</p>
+              <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+/**
+ * Some description here。
+ */
+public class Example8 {
+  Example8() {}
+  /**
+   * Some description here.
+   */
+  private void testMethod1() {}
+  /**
+   * Some description here。
+   */
+  private boolean testMethod2() {
+    return true;
+  }
+  /**
+   * Some description here?
+   */
+  private void testMethod3() {
+    // violation 4 lines above 'First sentence should end with a period'
+  }
+  /**
+   * Some description here!
+   */
+  public void testMethod4() {
+    // violation 4 lines above 'First sentence should end with a period'
+  }
+  /**
+   * Some description here
+   * Second line of description
+   */
+  private void testMethod5() {
+    // violation 5 lines above 'First sentence should end with a period'
+  }
+  /**
+   * Some description here
+   * &lt;p
+   */
+  private void testMethod6() { // violation 4 lines above 'should end with a period'
+    // violation 3 lines above 'Incomplete HTML tag found'
+  }
+  /**
+   *
+   */
+  private void testEmptyMethod() {}
+}
+</code></pre></div>
+              </subsection>
 
       <subsection name="Example of Usage" id="JavadocStyle_Example_of_Usage">
         <ul>

--- a/src/site/xdoc/checks/javadoc/javadocstyle.xml.template
+++ b/src/site/xdoc/checks/javadoc/javadocstyle.xml.template
@@ -134,7 +134,24 @@
                  value="resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadocstyle/Example7.java"/>
           <param name="type" value="code"/>
         </macro>
-      </subsection>
+
+        <hr class="example-separator"/>
+              <p id="Example8-config">
+                To configure the Check to use custom end of sentence format:
+              </p>
+              <macro name="example">
+                <param name="path"
+                       value="resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadocstyle/Example8.java"/>
+                <param name="type" value="config"/>
+              </macro>
+
+              <p id="Example8-code">Example8:</p>
+              <macro name="example">
+                <param name="path"
+                       value="resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadocstyle/Example8.java"/>
+                <param name="type" value="code"/>
+              </macro>
+              </subsection>
 
       <subsection name="Example of Usage" id="JavadocStyle_Example_of_Usage">
         <ul>

--- a/src/test/java/com/puppycrawl/tools/checkstyle/internal/XdocsExampleFileTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/internal/XdocsExampleFileTest.java
@@ -58,7 +58,6 @@ public class XdocsExampleFileTest {
     // This list is temporarily suppressed.
     // Until: https://github.com/checkstyle/checkstyle/issues/17449
     private static final Map<String, Set<String>> SUPPRESSED_PROPERTIES_BY_CHECK = Map.ofEntries(
-            Map.entry("JavadocStyleCheck", Set.of("endOfSentenceFormat")),
             Map.entry("SuppressWarningsHolder", Set.of("aliasList")),
             Map.entry("IndentationCheck", Set.of(
                     "basicOffset",

--- a/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocStyleCheckExamplesTest.java
+++ b/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocStyleCheckExamplesTest.java
@@ -107,4 +107,16 @@ public class JavadocStyleCheckExamplesTest extends AbstractExamplesModuleTestSup
         };
         verifyWithInlineConfigParser(getPath("Example7.java"), expected);
     }
+
+    @Test
+    public void testExample8() throws Exception {
+        final String[] expected = {
+            "28: " + getCheckMessage(MSG_NO_PERIOD),
+            "34: " + getCheckMessage(MSG_NO_PERIOD),
+            "40: " + getCheckMessage(MSG_NO_PERIOD),
+            "47: " + getCheckMessage(MSG_NO_PERIOD),
+            "49: " + getCheckMessage(MSG_INCOMPLETE_TAG, "   * <p"),
+        };
+        verifyWithInlineConfigParser(getPath("Example8.java"), expected);
+    }
 }

--- a/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadocstyle/Example8.java
+++ b/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadocstyle/Example8.java
@@ -1,0 +1,59 @@
+/*xml
+<module name="Checker">
+  <module name="TreeWalker">
+    <module name="JavadocStyle">
+      <property name="endOfSentenceFormat"
+        value="([.。][ \t\n\r\f&lt;])|([.。]$)"/>
+    </module>
+  </module>
+</module>
+*/
+package com.puppycrawl.tools.checkstyle.checks.javadoc.javadocstyle;
+// xdoc section -- start
+/**
+ * Some description here。
+ */
+public class Example8 {
+  Example8() {}
+  /**
+   * Some description here.
+   */
+  private void testMethod1() {}
+  /**
+   * Some description here。
+   */
+  private boolean testMethod2() {
+    return true;
+  }
+  /**
+   * Some description here?
+   */
+  private void testMethod3() {
+    // violation 4 lines above 'First sentence should end with a period'
+  }
+  /**
+   * Some description here!
+   */
+  public void testMethod4() {
+    // violation 4 lines above 'First sentence should end with a period'
+  }
+  /**
+   * Some description here
+   * Second line of description
+   */
+  private void testMethod5() {
+    // violation 5 lines above 'First sentence should end with a period'
+  }
+  /**
+   * Some description here
+   * <p
+   */
+  private void testMethod6() { // violation 4 lines above 'should end with a period'
+    // violation 3 lines above 'Incomplete HTML tag found'
+  }
+  /**
+   *
+   */
+  private void testEmptyMethod() {}
+}
+// xdoc section -- end


### PR DESCRIPTION
#17449 

Added missing XDoc examples for JavadocStyleCheck:

Example8: endofsentenceFormat
Updated the XDoc template file to include references to these examples.
Added JavadocStyleCheckExamplesTest to verify the examples.