### PR TITLE
Issue #17128: shorten InputIndentationStrictCondition.java

### DIFF
--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/indentation/indentation/InputIndentationStrictCondition.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/indentation/indentation/InputIndentationStrictCondition.java
@@ -1,14 +1,14 @@
-package com.puppycrawl.tools.checkstyle.checks.indentation.indentation;    //indent:0 exp:0
+package com.puppycrawl.tools.checkstyle.checks.indentation.indentation;//indent:0 exp:0
 
-import java.lang.Thread;                                                   //indent:0 exp:0
+import java.lang.Thread;                                              //indent:0 exp:0
 
-public class InputIndentationStrictCondition {                             //indent:0 exp:0
-    void method(Thread foo) {                                              //indent:4 exp:4
-        method(                                                            //indent:8 exp:8
-                new Thread() {                                             //indent:16 exp:16
-                        public void run() {                                //indent:24 exp:24
-                            }                                              //indent:28 exp:16,20,24 warn
-                    }                                                      //indent:20 exp:20
-        );                                                                 //indent:8 exp:8
-        }                                                                  //indent:8 exp:4 warn
-    }                                                                      //indent:4 exp:0 warn
+public class InputIndentationStrictCondition {                        //indent:0 exp:0
+    void method(Thread foo) {                                         //indent:4 exp:4
+        method(                                                       //indent:8 exp:8
+                new Thread() {                                        //indent:16 exp:16
+                        public void run() {                           //indent:24 exp:24
+                            }                                         //indent:28 exp:16,20,24 warn
+                    }                                                 //indent:20 exp:20
+        );                                                            //indent:8 exp:8
+        }                                                             //indent:8 exp:4 warn
+    }                                                                 //indent:4 exp:0 warn


### PR DESCRIPTION
Hi @romani ,

I am starting to tackle Issue #17128 by working on `InputIndentationStrictCondition.java`.

## My understanding of the task:
- I should **not** move or modify the code itself, or change the `indent:`/`exp:` values in the trailing comments.
- The only allowed change is adjusting the **padding (spaces)** between code and each `//indent:` trailing comment, so that:
    - All such comments (except for `package` and `import` lines) start at the same column (vertical alignment) within the file
    - Every line is ≤100 characters
    - The `package` and `import` comment alignment does not matter, as those are ignored by the test

I just want to confirm that this approach is correct before I continue with more files and PRs.

Thank you for your guidance!

---

**Please let me know if this understanding is correct 🙏**
