### PR TITLE
Issue #19176: migrate api tests to getExpectedThrowable

### DIFF
--- a/src/test/java/com/puppycrawl/tools/checkstyle/api/ScopeTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/api/ScopeTest.java
@@ -20,6 +20,7 @@
 package com.puppycrawl.tools.checkstyle.api;
 
 import static com.google.common.truth.Truth.assertWithMessage;
+import static com.puppycrawl.tools.checkstyle.internal.utils.TestUtil.getExpectedThrowable;
 
 import org.junit.jupiter.api.Test;
 import org.junitpioneer.jupiter.DefaultLocale;
@@ -54,15 +55,13 @@ public class ScopeTest {
             .that(scope.getName())
             .isEqualTo("public");
 
-        try {
-            Scope.getInstance("unknown");
-            assertWithMessage("exception expected").fail();
-        }
-        catch (IllegalArgumentException exc) {
-            assertWithMessage("Invalid error message")
+        final IllegalArgumentException exc =
+                getExpectedThrowable(IllegalArgumentException.class, () -> {
+                    Scope.getInstance("unknown");
+                }, "exception expected");
+        assertWithMessage("Invalid error message")
                 .that(exc.getMessage())
                 .isEqualTo("No enum constant com.puppycrawl.tools.checkstyle.api.Scope.UNKNOWN");
-        }
     }
 
     @Test

--- a/src/test/java/com/puppycrawl/tools/checkstyle/api/SeverityLevelCounterTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/api/SeverityLevelCounterTest.java
@@ -20,6 +20,7 @@
 package com.puppycrawl.tools.checkstyle.api;
 
 import static com.google.common.truth.Truth.assertWithMessage;
+import static com.puppycrawl.tools.checkstyle.internal.utils.TestUtil.getExpectedThrowable;
 
 import org.junit.jupiter.api.Test;
 
@@ -27,17 +28,14 @@ public class SeverityLevelCounterTest {
 
     @Test
     public void testCtorException() {
-        try {
-            final Object test = new SeverityLevelCounter(null);
-            assertWithMessage("exception expected but got %s", test)
-                    .fail();
-        }
-        catch (IllegalArgumentException exc) {
-            assertWithMessage("Invalid exception message")
-                    .that(exc)
-                    .hasMessageThat()
-                    .isEqualTo("'level' cannot be null");
-        }
+        final IllegalArgumentException exc =
+                getExpectedThrowable(IllegalArgumentException.class,
+                        () -> new SeverityLevelCounter(null));
+
+        assertWithMessage("Invalid exception message")
+                .that(exc)
+                .hasMessageThat()
+                .isEqualTo("'level' cannot be null");
     }
 
     @Test

--- a/src/test/java/com/puppycrawl/tools/checkstyle/api/SeverityLevelTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/api/SeverityLevelTest.java
@@ -20,6 +20,7 @@
 package com.puppycrawl.tools.checkstyle.api;
 
 import static com.google.common.truth.Truth.assertWithMessage;
+import static com.puppycrawl.tools.checkstyle.internal.utils.TestUtil.getExpectedThrowable;
 
 import org.junit.jupiter.api.Test;
 import org.junitpioneer.jupiter.DefaultLocale;
@@ -54,16 +55,14 @@ public class SeverityLevelTest {
             .that(severityLevel.getName())
             .isEqualTo("info");
 
-        try {
-            SeverityLevel.getInstance("unknown");
-            assertWithMessage("exception expected").fail();
-        }
-        catch (IllegalArgumentException exc) {
-            assertWithMessage("Invalid exception message")
-                .that(exc.getMessage())
-                .isEqualTo("No enum constant "
-                    + "com.puppycrawl.tools.checkstyle.api.SeverityLevel.UNKNOWN");
-        }
+        final IllegalArgumentException exc =
+                getExpectedThrowable(IllegalArgumentException.class, () -> {
+                    SeverityLevel.getInstance("unknown");
+                }, "exception expected");
+        assertWithMessage("Invalid exception message")
+            .that(exc.getMessage())
+            .isEqualTo("No enum constant "
+                + "com.puppycrawl.tools.checkstyle.api.SeverityLevel.UNKNOWN");
     }
 
     @Test


### PR DESCRIPTION
Issue: #19176

Migrated tests in the `api` package to replace the deprecated `assertWithMessage(...).fail()` pattern with the `getExpectedThrowable` utility as described in the issue.

Initially selected the following files from the `api` package:
- ScopeTest.java
- SeverityLevelTest.java
- SeverityLevelCounterTest.java
- TokenTypesTest.java [already updated]
- LineColumnTest.java [already updated]

During inspection, `TokenTypesTest.java` and `LineColumnTest.java` already contained the updated pattern and did not require changes.

Changes were applied to:
- ScopeTest.java
- SeverityLevelTest.java
- SeverityLevelCounterTest.java

Verification:
- Project builds successfully
- Related tests pass locally

<img width="2575" height="1049" alt="Screenshot 2026-03-11 at 6 43 24 PM" src="https://github.com/user-attachments/assets/e719563d-ad68-4ff2-b830-17dbc95d0998" />