### PR TITLE
Issue #19176: migrate api tests to getExpectedThrowable (batch 2)

### DIFF
--- a/src/test/java/com/puppycrawl/tools/checkstyle/api/AbstractFileSetCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/api/AbstractFileSetCheckTest.java
@@ -20,6 +20,7 @@
 package com.puppycrawl.tools.checkstyle.api;
 
 import static com.google.common.truth.Truth.assertWithMessage;
+import static com.puppycrawl.tools.checkstyle.internal.utils.TestUtil.getExpectedThrowable;
 
 import java.io.File;
 import java.nio.charset.StandardCharsets;
@@ -114,17 +115,13 @@ public class AbstractFileSetCheckTest extends AbstractModuleTestSupport {
         final File firstFile = new File("inputAbstractFileSetCheck.tmp");
 
         final FileText fileText = new FileText(firstFile, Collections.emptyList());
-        try {
-            check.process(firstFile, fileText);
-            assertWithMessage("Exception is expected")
-                    .fail();
-        }
-        catch (IllegalArgumentException exc) {
-            // exception is expected
-            assertWithMessage("Invalid exception message")
-                    .that(exc.getMessage())
-                    .isEqualTo("Test");
-        }
+        final IllegalArgumentException exc =
+                getExpectedThrowable(IllegalArgumentException.class, () -> {
+                    check.process(firstFile, fileText);
+                }, "Exception is expected");
+        assertWithMessage("Invalid exception message")
+                .that(exc.getMessage())
+                .isEqualTo("Test");
 
         final SortedSet<Violation> internalViolations =
                 check.getViolations();
@@ -135,17 +132,13 @@ public class AbstractFileSetCheckTest extends AbstractModuleTestSupport {
         // again to prove only 1 violation exists
         final File secondFile = new File("inputAbstractFileSetCheck.tmp");
         final FileText fileText2 = new FileText(secondFile, Collections.emptyList());
-        try {
-            check.process(secondFile, fileText2);
-            assertWithMessage("Exception is expected")
-                .fail();
-        }
-        catch (IllegalArgumentException exc) {
-            // exception is expected
-            assertWithMessage("Invalid exception message")
-                    .that(exc.getMessage())
-                    .isEqualTo("Test");
-        }
+        final IllegalArgumentException exc2 =
+                getExpectedThrowable(IllegalArgumentException.class, () -> {
+                    check.process(secondFile, fileText2);
+                }, "Exception is expected");
+        assertWithMessage("Invalid exception message")
+                .that(exc2.getMessage())
+                .isEqualTo("Test");
 
         final SortedSet<Violation> internalViolations2 =
             check.getViolations();
@@ -171,16 +164,13 @@ public class AbstractFileSetCheckTest extends AbstractModuleTestSupport {
     @Test
     public void testSetExtensionThrowsExceptionWhenTheyAreNull() {
         final DummyFileSetCheck check = new DummyFileSetCheck();
-        try {
-            check.setFileExtensions((String[]) null);
-            assertWithMessage("Expected exception.")
-                .fail();
-        }
-        catch (IllegalArgumentException exception) {
-            assertWithMessage("Invalid exception message")
-                    .that(exception.getMessage())
-                    .isEqualTo("Extensions array can not be null");
-        }
+        final IllegalArgumentException exception =
+                getExpectedThrowable(IllegalArgumentException.class, () -> {
+                    check.setFileExtensions((String[]) null);
+                }, "Expected exception.");
+        assertWithMessage("Invalid exception message")
+                .that(exception.getMessage())
+                .isEqualTo("Extensions array can not be null");
     }
 
     @Test

--- a/src/test/java/com/puppycrawl/tools/checkstyle/api/AbstractViolationReporterTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/api/AbstractViolationReporterTest.java
@@ -20,6 +20,7 @@
 package com.puppycrawl.tools.checkstyle.api;
 
 import static com.google.common.truth.Truth.assertWithMessage;
+import static com.puppycrawl.tools.checkstyle.internal.utils.TestUtil.getExpectedThrowable;
 
 import java.util.SortedSet;
 
@@ -122,16 +123,13 @@ public class AbstractViolationReporterTest {
         config.addMessage("msgKey", "This is a custom violation {0.");
         emptyCheck.configure(config);
 
-        try {
-            emptyCheck.log(1, "msgKey", "TestParam");
-            assertWithMessage("exception expected")
-                    .fail();
-        }
-        catch (IllegalArgumentException exc) {
-            assertWithMessage("Error violation is unexpected")
-                    .that(exc.getMessage())
-                    .isEqualTo("Unmatched braces in the pattern.");
-        }
+        final IllegalArgumentException exc =
+                getExpectedThrowable(IllegalArgumentException.class, () -> {
+                    emptyCheck.log(1, "msgKey", "TestParam");
+                }, "exception expected");
+        assertWithMessage("Error violation is unexpected")
+                .that(exc.getMessage())
+                .isEqualTo("Unmatched braces in the pattern.");
     }
 
     @Test


### PR DESCRIPTION
Migrated tests in the `api` package to use `getExpectedThrowable` instead of the old
`assertWithMessage(...).fail()` pattern as required by the new Checkstyle rule introduced in #19168.

Updated files in this batch:
- AbstractFileSetCheckTest
- AbstractViolationReporterTest

The remaining test files in the `api` package were already migrated previously.

- AbstractCheckTest.java
- AuditEventTest.java
- BeforeExecutionFileFilterSetTest.java

All tests were executed locally and the build passed successfully.

Next, I plan to continue migrating other test files that still use the
`assertWithMessage(...).fail()` pattern in other packages.

<img width="2557" height="1043" alt="Screenshot 2026-03-11 at 7 27 23 PM" src="https://github.com/user-attachments/assets/55feda74-924b-4c82-8155-8619fac5e040" />