### PR TITLE
Issue #19176: migrate filters package tests to getExpectedThrowable

### DIFF
--- a/src/test/java/com/puppycrawl/tools/checkstyle/filters/SuppressWithNearbyCommentFilterTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/filters/SuppressWithNearbyCommentFilterTest.java
@@ -21,6 +21,7 @@ package com.puppycrawl.tools.checkstyle.filters;
 
 import static com.google.common.truth.Truth.assertWithMessage;
 import static com.puppycrawl.tools.checkstyle.checks.naming.AbstractNameCheck.MSG_INVALID_PATTERN;
+import static com.puppycrawl.tools.checkstyle.internal.utils.TestUtil.getExpectedThrowable;
 
 import java.io.File;
 import java.util.Arrays;
@@ -377,7 +378,7 @@ public class SuppressWithNearbyCommentFilterTest
     }
 
     @Test
-    public void testInvalidInfluenceFormat() throws Exception {
+    public void testInvalidInfluenceFormat() {
         final DefaultConfiguration treeWalkerConfig =
             createModuleConfig(TreeWalker.class);
         final DefaultConfiguration filterConfig =
@@ -388,19 +389,18 @@ public class SuppressWithNearbyCommentFilterTest
         treeWalkerConfig.addChild(filterConfig);
         treeWalkerConfig.addChild(checkConfig);
 
-        try {
-            execute(treeWalkerConfig,
-                    getPath("InputSuppressWithNearbyCommentFilterByCheckAndInfluence.java"));
-            assertWithMessage("Exception is expected").fail();
-        }
-        catch (CheckstyleException exc) {
-            assertWithMessage("Invalid exception message")
-                .that(exc)
-                .hasCauseThat()
-                .hasMessageThat()
-                .isEqualTo("unable to parse influence"
-                        + " from 'SUPPRESS CHECKSTYLE MemberNameCheck' using a");
-        }
+        final CheckstyleException exc =
+                getExpectedThrowable(CheckstyleException.class, () -> {
+                    execute(treeWalkerConfig,
+                            getPath("InputSuppressWithNearbyComment"
+                                    + "FilterByCheckAndInfluence.java"));
+                }, "Exception is expected");
+        assertWithMessage("Invalid exception message")
+            .that(exc)
+            .hasCauseThat()
+            .hasMessageThat()
+            .isEqualTo("unable to parse influence"
+                    + " from 'SUPPRESS CHECKSTYLE MemberNameCheck' using a");
     }
 
     @Test
@@ -437,7 +437,7 @@ public class SuppressWithNearbyCommentFilterTest
     }
 
     @Test
-    public void testInvalidCheckFormat() throws Exception {
+    public void testInvalidCheckFormat() {
         final DefaultConfiguration treeWalkerConfig =
             createModuleConfig(TreeWalker.class);
         final DefaultConfiguration filterConfig =
@@ -448,18 +448,17 @@ public class SuppressWithNearbyCommentFilterTest
         treeWalkerConfig.addChild(filterConfig);
         treeWalkerConfig.addChild(checkConfig);
 
-        try {
-            execute(treeWalkerConfig,
-                    getPath("InputSuppressWithNearbyCommentFilterByCheckAndInfluence.java"));
-            assertWithMessage("Exception is expected").fail();
-        }
-        catch (CheckstyleException exc) {
-            final IllegalArgumentException cause = (IllegalArgumentException) exc.getCause();
-            assertWithMessage("Invalid exception message")
-                .that(cause)
-                .hasMessageThat()
-                .isEqualTo("unable to parse expanded comment a[l");
-        }
+        final CheckstyleException exc =
+                getExpectedThrowable(CheckstyleException.class, () -> {
+                    execute(treeWalkerConfig,
+                            getPath("InputSuppressWithNearbyComment"
+                                    + "FilterByCheckAndInfluence.java"));
+                }, "Exception is expected");
+        final IllegalArgumentException cause = (IllegalArgumentException) exc.getCause();
+        assertWithMessage("Invalid exception message")
+            .that(cause)
+            .hasMessageThat()
+            .isEqualTo("unable to parse expanded comment a[l");
     }
 
     @Test

--- a/src/test/java/com/puppycrawl/tools/checkstyle/filters/SuppressWithNearbyTextFilterTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/filters/SuppressWithNearbyTextFilterTest.java
@@ -22,6 +22,7 @@ package com.puppycrawl.tools.checkstyle.filters;
 import static com.google.common.truth.Truth.assertWithMessage;
 import static com.puppycrawl.tools.checkstyle.checks.naming.AbstractNameCheck.MSG_INVALID_PATTERN;
 import static com.puppycrawl.tools.checkstyle.checks.sizes.LineLengthCheck.MSG_KEY;
+import static com.puppycrawl.tools.checkstyle.internal.utils.TestUtil.getExpectedThrowable;
 
 import java.io.File;
 import java.io.FileNotFoundException;
@@ -332,92 +333,84 @@ public class SuppressWithNearbyTextFilterTest extends AbstractModuleTestSupport 
     }
 
     @Test
-    public void testInvalidCheckPattern() throws Exception {
+    public void testInvalidCheckPattern() {
         final String[] violationAndSuppressedMessages = {
             "18: " + getLineLengthCheckMessage(80, 93),
         };
 
-        try {
-            verifyFilterWithInlineConfigParser(
-                getPath("InputSuppressWithNearbyTextFilterInvalidCheckPattern.txt"),
-                violationAndSuppressedMessages
-            );
-            assertWithMessage("CheckstyleException is expected").fail();
-        }
-        catch (CheckstyleException exc) {
-            final IllegalArgumentException cause = (IllegalArgumentException) exc.getCause();
-            assertWithMessage("Invalid exception message")
+        final CheckstyleException exc =
+                getExpectedThrowable(CheckstyleException.class, () -> {
+                    verifyFilterWithInlineConfigParser(
+                        getPath("InputSuppressWithNearbyTextFilterInvalidCheckPattern.txt"),
+                        violationAndSuppressedMessages
+                    );
+                }, "CheckstyleException is expected");
+        final IllegalArgumentException cause = (IllegalArgumentException) exc.getCause();
+        assertWithMessage("Invalid exception message")
                 .that(cause)
                 .hasMessageThat()
                 .isEqualTo("unable to parse expanded comment a![b");
-        }
     }
 
     @Test
-    public void testInvalidIdPattern() throws Exception {
+    public void testInvalidIdPattern() {
         final String[] violationAndSuppressedMessages = {
             "18: " + getLineLengthCheckMessage(80, 93),
         };
 
-        try {
-            verifyFilterWithInlineConfigParser(
-                getPath("InputSuppressWithNearbyTextFilterInvalidIdPattern.txt"),
-                violationAndSuppressedMessages
-            );
-            assertWithMessage("CheckstyleException is expected").fail();
-        }
-        catch (CheckstyleException exc) {
-            final IllegalArgumentException cause = (IllegalArgumentException) exc.getCause();
-            assertWithMessage("Invalid exception message")
+        final CheckstyleException exc =
+                getExpectedThrowable(CheckstyleException.class, () -> {
+                    verifyFilterWithInlineConfigParser(
+                        getPath("InputSuppressWithNearbyTextFilterInvalidIdPattern.txt"),
+                        violationAndSuppressedMessages
+                    );
+                }, "CheckstyleException is expected");
+        final IllegalArgumentException cause = (IllegalArgumentException) exc.getCause();
+        assertWithMessage("Invalid exception message")
                 .that(cause)
                 .hasMessageThat()
                 .isEqualTo("unable to parse expanded comment a![b");
-        }
     }
 
     @Test
-    public void testInvalidMessagePattern() throws Exception {
+    public void testInvalidMessagePattern() {
         final String[] violationAndSuppressedMessages = {
             "18: " + getLineLengthCheckMessage(80, 93),
         };
 
-        try {
-            verifyFilterWithInlineConfigParser(
-                getPath("InputSuppressWithNearbyTextFilterInvalidMessagePattern.txt"),
-                violationAndSuppressedMessages
-            );
-            assertWithMessage("CheckstyleException is expected").fail();
-        }
-        catch (CheckstyleException exc) {
-            final IllegalArgumentException cause = (IllegalArgumentException) exc.getCause();
-            assertWithMessage("Invalid exception message")
+        final CheckstyleException exc =
+                getExpectedThrowable(CheckstyleException.class, () -> {
+                    verifyFilterWithInlineConfigParser(
+                        getPath("InputSuppressWithNearbyTextFilterInvalidMessagePattern.txt"),
+                        violationAndSuppressedMessages
+                    );
+                }, "CheckstyleException is expected");
+        final IllegalArgumentException cause = (IllegalArgumentException) exc.getCause();
+        assertWithMessage("Invalid exception message")
                 .that(cause)
                 .hasMessageThat()
                 .isEqualTo("unable to parse expanded comment a![b");
-        }
     }
 
     @Test
-    public void testInvalidLineRange() throws Exception {
+    public void testInvalidLineRange() {
         final String[] violationAndSuppressedMessages = {
             "18: " + getLineLengthCheckMessage(80, 93),
         };
 
-        try {
-            verifyFilterWithInlineConfigParser(
-                getPath("InputSuppressWithNearbyTextFilterInvalidLineRange.txt"),
-                violationAndSuppressedMessages
-            );
-            assertWithMessage("CheckstyleException is expected").fail();
-        }
-        catch (CheckstyleException exc) {
-            assertWithMessage("Invalid exception message")
+        final CheckstyleException exc =
+                getExpectedThrowable(CheckstyleException.class, () -> {
+                    verifyFilterWithInlineConfigParser(
+                        getPath("InputSuppressWithNearbyTextFilterInvalidLineRange.txt"),
+                        violationAndSuppressedMessages
+                    );
+                }, "CheckstyleException is expected");
+        assertWithMessage("Invalid exception message")
                 .that(exc)
                 .hasCauseThat()
                 .hasMessageThat()
                 .isEqualTo("unable to parse line range"
                         + " from 'SUPPRESS CHECKSTYLE LineLengthCheck' using a!b");
-        }
     }
 
     /**
@@ -488,24 +481,22 @@ public class SuppressWithNearbyTextFilterTest extends AbstractModuleTestSupport 
         final AuditEvent auditEvent = new AuditEvent(this, fileName, message);
         final SuppressWithNearbyTextFilter filter = new SuppressWithNearbyTextFilter();
 
-        try {
-            filter.accept(auditEvent);
-            assertWithMessage("%s is expected", IllegalStateException.class.getSimpleName()).fail();
-        }
-        catch (IllegalStateException exc) {
-            assertWithMessage("Invalid exception message")
+        final IllegalStateException exc =
+                getExpectedThrowable(IllegalStateException.class, () -> {
+                    filter.accept(auditEvent);
+                }, "IllegalStateException is expected");
+        assertWithMessage("Invalid exception message")
                 .that(exc.getMessage())
                 .isEqualTo("Cannot read source file: " + fileName);
 
-            final Throwable cause = exc.getCause();
-            assertWithMessage("Exception cause has invalid type")
-                    .that(cause)
-                    .isInstanceOf(FileNotFoundException.class);
-            assertWithMessage("Invalid exception message")
+        final Throwable cause = exc.getCause();
+        assertWithMessage("Exception cause has invalid type")
+                .that(cause)
+                .isInstanceOf(FileNotFoundException.class);
+        assertWithMessage("Invalid exception message")
                 .that(cause)
                 .hasMessageThat()
                 .isEqualTo(fileName + " (No such file or directory)");
-        }
     }
 
     /**

--- a/src/test/java/com/puppycrawl/tools/checkstyle/filters/SuppressWithPlainTextCommentFilterTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/filters/SuppressWithPlainTextCommentFilterTest.java
@@ -25,6 +25,7 @@ import static com.puppycrawl.tools.checkstyle.checks.javadoc.JavadocMethodCheck.
 import static com.puppycrawl.tools.checkstyle.checks.javadoc.JavadocMethodCheck.MSG_UNUSED_TAG;
 import static com.puppycrawl.tools.checkstyle.checks.whitespace.FileTabCharacterCheck.MSG_CONTAINS_TAB;
 import static com.puppycrawl.tools.checkstyle.checks.whitespace.FileTabCharacterCheck.MSG_FILE_CONTAINS_TAB;
+import static com.puppycrawl.tools.checkstyle.internal.utils.TestUtil.getExpectedThrowable;
 
 import java.io.File;
 import java.io.FileNotFoundException;
@@ -205,7 +206,7 @@ public class SuppressWithPlainTextCommentFilterTest extends AbstractModuleTestSu
     }
 
     @Test
-    public void testInvalidCheckFormat() throws Exception {
+    public void testInvalidCheckFormat() {
         final DefaultConfiguration filterCfg =
             createModuleConfig(SuppressWithPlainTextCommentFilter.class);
         filterCfg.addProperty("checkFormat", "e[l");
@@ -223,25 +224,23 @@ public class SuppressWithPlainTextCommentFilterTest extends AbstractModuleTestSu
             "10:1: " + getCheckMessage(FileTabCharacterCheck.class, MSG_CONTAINS_TAB),
         };
 
-        try {
-            verifySuppressed(
-                "InputSuppressWithPlainTextCommentFilterWithCustomOnAndOffComments.java",
-                removeSuppressed(violationMessages, suppressed),
-                filterCfg, checkCfg
-            );
-            assertWithMessage("CheckstyleException is expected").fail();
-        }
-        catch (CheckstyleException exc) {
-            final IllegalArgumentException cause = (IllegalArgumentException) exc.getCause();
-            assertWithMessage("Invalid exception message")
+        final CheckstyleException exc =
+                getExpectedThrowable(CheckstyleException.class, () -> {
+                    verifySuppressed(
+                        "InputSuppressWithPlainTextCommentFilterWithCustomOnAndOffComments.java",
+                        removeSuppressed(violationMessages, suppressed),
+                        filterCfg, checkCfg
+                    );
+                }, "CheckstyleException is expected");
+        final IllegalArgumentException cause = (IllegalArgumentException) exc.getCause();
+        assertWithMessage("Invalid exception message")
                 .that(cause)
                 .hasMessageThat()
                 .isEqualTo("unable to parse expanded comment e[l");
-        }
     }
 
     @Test
-    public void testInvalidIdFormat() throws Exception {
+    public void testInvalidIdFormat() {
         final DefaultConfiguration filterCfg =
             createModuleConfig(SuppressWithPlainTextCommentFilter.class);
         filterCfg.addProperty("idFormat", "e[l");
@@ -251,24 +250,22 @@ public class SuppressWithPlainTextCommentFilterTest extends AbstractModuleTestSu
         final DefaultConfiguration checkCfg = createModuleConfig(FileTabCharacterCheck.class);
         checkCfg.addProperty("eachLine", "true");
 
-        try {
-            verifySuppressed(
-                "InputSuppressWithPlainTextCommentFilterWithCustomOnAndOffComments.java",
-                CommonUtil.EMPTY_STRING_ARRAY, filterCfg, checkCfg
-            );
-            assertWithMessage("CheckstyleException is expected").fail();
-        }
-        catch (CheckstyleException exc) {
-            final IllegalArgumentException cause = (IllegalArgumentException) exc.getCause();
-            assertWithMessage("Invalid exception message")
+        final CheckstyleException exc =
+                getExpectedThrowable(CheckstyleException.class, () -> {
+                    verifySuppressed(
+                        "InputSuppressWithPlainTextCommentFilterWithCustomOnAndOffComments.java",
+                        CommonUtil.EMPTY_STRING_ARRAY, filterCfg, checkCfg
+                    );
+                }, "CheckstyleException is expected");
+        final IllegalArgumentException cause = (IllegalArgumentException) exc.getCause();
+        assertWithMessage("Invalid exception message")
                 .that(cause)
                 .hasMessageThat()
                 .isEqualTo("unable to parse expanded comment e[l");
-        }
     }
 
     @Test
-    public void testInvalidMessageFormat() throws Exception {
+    public void testInvalidMessageFormat() {
         final DefaultConfiguration filterCfg =
             createModuleConfig(SuppressWithPlainTextCommentFilter.class);
         filterCfg.addProperty("messageFormat", "e[l");
@@ -286,25 +283,23 @@ public class SuppressWithPlainTextCommentFilterTest extends AbstractModuleTestSu
             "10:1: " + getCheckMessage(FileTabCharacterCheck.class, MSG_CONTAINS_TAB),
         };
 
-        try {
-            verifySuppressed(
-                "InputSuppressWithPlainTextCommentFilterWithCustomOnAndOffComments.java",
-                removeSuppressed(violationMessages, suppressed),
-                filterCfg, checkCfg
-            );
-            assertWithMessage("CheckstyleException is expected").fail();
-        }
-        catch (CheckstyleException exc) {
-            final IllegalArgumentException cause = (IllegalArgumentException) exc.getCause();
-            assertWithMessage("Invalid exception message")
+        final CheckstyleException exc =
+                getExpectedThrowable(CheckstyleException.class, () -> {
+                    verifySuppressed(
+                        "InputSuppressWithPlainTextCommentFilterWithCustomOnAndOffComments.java",
+                        removeSuppressed(violationMessages, suppressed),
+                        filterCfg, checkCfg
+                    );
+                }, "CheckstyleException is expected");
+        final IllegalArgumentException cause = (IllegalArgumentException) exc.getCause();
+        assertWithMessage("Invalid exception message")
                 .that(cause)
                 .hasMessageThat()
                 .isEqualTo("unable to parse expanded comment e[l");
-        }
     }
 
     @Test
-    public void testInvalidMessageFormatInSqlFile() throws Exception {
+    public void testInvalidMessageFormatInSqlFile() {
         final DefaultConfiguration filterCfg =
             createModuleConfig(SuppressWithPlainTextCommentFilter.class);
         filterCfg.addProperty("onCommentFormat", "CSON (\\w+)");
@@ -320,21 +315,19 @@ public class SuppressWithPlainTextCommentFilterTest extends AbstractModuleTestSu
                     "^.*COUNT\\(\\*\\).*$"),
         };
 
-        try {
-            verifySuppressed(
-                "InputSuppressWithPlainTextCommentFilterWithCustomOnComment.sql",
-                removeSuppressed(violationMessages, suppressed),
-                filterCfg, checkCfg
-            );
-            assertWithMessage("CheckstyleException is expected").fail();
-        }
-        catch (CheckstyleException exc) {
-            final IllegalArgumentException cause = (IllegalArgumentException) exc.getCause();
-            assertWithMessage("Invalid exception message")
+        final CheckstyleException exc =
+                getExpectedThrowable(CheckstyleException.class, () -> {
+                    verifySuppressed(
+                        "InputSuppressWithPlainTextCommentFilterWithCustomOnComment.sql",
+                        removeSuppressed(violationMessages, suppressed),
+                        filterCfg, checkCfg
+                    );
+                }, "CheckstyleException is expected");
+        final IllegalArgumentException cause = (IllegalArgumentException) exc.getCause();
+        assertWithMessage("Invalid exception message")
                 .that(cause)
                 .hasMessageThat()
                 .isEqualTo("unable to parse expanded comment e[l");
-        }
     }
 
     @Test
@@ -613,24 +606,22 @@ public class SuppressWithPlainTextCommentFilterTest extends AbstractModuleTestSu
 
         final SuppressWithPlainTextCommentFilter filter = new SuppressWithPlainTextCommentFilter();
 
-        try {
-            filter.accept(auditEvent);
-            assertWithMessage("%s is expected", IllegalStateException.class.getSimpleName()).fail();
-        }
-        catch (IllegalStateException exc) {
-            assertWithMessage("Invalid exception message")
+        final IllegalStateException exc =
+                getExpectedThrowable(IllegalStateException.class, () -> {
+                    filter.accept(auditEvent);
+                }, "IllegalStateException is expected");
+        assertWithMessage("Invalid exception message")
                 .that(exc.getMessage())
                 .isEqualTo("Cannot read source file: " + fileName);
 
-            final Throwable cause = exc.getCause();
-            assertWithMessage("Exception cause has invalid type")
-                    .that(cause)
-                    .isInstanceOf(FileNotFoundException.class);
-            assertWithMessage("Invalid exception message")
+        final Throwable cause = exc.getCause();
+        assertWithMessage("Exception cause has invalid type")
+                .that(cause)
+                .isInstanceOf(FileNotFoundException.class);
+        assertWithMessage("Invalid exception message")
                 .that(cause)
                 .hasMessageThat()
                 .isEqualTo(fileName + " (No such file or directory)");
-        }
     }
 
     @Test

--- a/src/test/java/com/puppycrawl/tools/checkstyle/filters/SuppressionCommentFilterTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/filters/SuppressionCommentFilterTest.java
@@ -21,6 +21,7 @@ package com.puppycrawl.tools.checkstyle.filters;
 
 import static com.google.common.truth.Truth.assertWithMessage;
 import static com.puppycrawl.tools.checkstyle.checks.naming.AbstractNameCheck.MSG_INVALID_PATTERN;
+import static com.puppycrawl.tools.checkstyle.internal.utils.TestUtil.getExpectedThrowable;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -367,7 +368,7 @@ public class SuppressionCommentFilterTest
     }
 
     @Test
-    public void testInvalidCheckFormat() throws Exception {
+    public void testInvalidCheckFormat() {
         final DefaultConfiguration treeWalkerConfig =
             createModuleConfig(TreeWalker.class);
         final DefaultConfiguration filterConfig =
@@ -378,21 +379,19 @@ public class SuppressionCommentFilterTest
         treeWalkerConfig.addChild(filterConfig);
         treeWalkerConfig.addChild(checkConfig);
 
-        try {
-            execute(treeWalkerConfig, getPath("InputSuppressionCommentFilter10.java"));
-            assertWithMessage("Exception is expected").fail();
-        }
-        catch (CheckstyleException exc) {
-            final IllegalArgumentException cause = (IllegalArgumentException) exc.getCause();
-            assertWithMessage("Invalid exception message")
-                .that(cause)
-                .hasMessageThat()
-                .isEqualTo("unable to parse expanded comment e[l");
-        }
+        final CheckstyleException exc =
+                getExpectedThrowable(CheckstyleException.class, () -> {
+                    execute(treeWalkerConfig, getPath("InputSuppressionCommentFilter10.java"));
+                }, "Exception is expected");
+        final IllegalArgumentException cause = (IllegalArgumentException) exc.getCause();
+        assertWithMessage("Invalid exception message")
+            .that(cause)
+            .hasMessageThat()
+            .isEqualTo("unable to parse expanded comment e[l");
     }
 
     @Test
-    public void testInvalidMessageFormat() throws Exception {
+    public void testInvalidMessageFormat() {
         final DefaultConfiguration treeWalkerConfig =
             createModuleConfig(TreeWalker.class);
         final DefaultConfiguration filterConfig =
@@ -403,17 +402,15 @@ public class SuppressionCommentFilterTest
         treeWalkerConfig.addChild(filterConfig);
         treeWalkerConfig.addChild(checkConfig);
 
-        try {
-            execute(treeWalkerConfig, getPath("InputSuppressionCommentFilter11.java"));
-            assertWithMessage("Exception is expected").fail();
-        }
-        catch (CheckstyleException exc) {
-            final IllegalArgumentException cause = (IllegalArgumentException) exc.getCause();
-            assertWithMessage("Invalid exception message")
-                .that(cause)
-                .hasMessageThat()
-                .isEqualTo("unable to parse expanded comment e[l");
-        }
+        final CheckstyleException exc =
+                getExpectedThrowable(CheckstyleException.class, () -> {
+                    execute(treeWalkerConfig, getPath("InputSuppressionCommentFilter11.java"));
+                }, "Exception is expected");
+        final IllegalArgumentException cause = (IllegalArgumentException) exc.getCause();
+        assertWithMessage("Invalid exception message")
+            .that(cause)
+            .hasMessageThat()
+            .isEqualTo("unable to parse expanded comment e[l");
     }
 
     @Test

--- a/src/test/java/com/puppycrawl/tools/checkstyle/filters/SuppressionFilterTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/filters/SuppressionFilterTest.java
@@ -21,6 +21,7 @@ package com.puppycrawl.tools.checkstyle.filters;
 
 import static com.google.common.truth.Truth.assertWithMessage;
 import static com.puppycrawl.tools.checkstyle.checks.naming.AbstractNameCheck.MSG_INVALID_PATTERN;
+import static com.puppycrawl.tools.checkstyle.internal.utils.TestUtil.getExpectedThrowable;
 import static org.junit.jupiter.api.Assumptions.assumeTrue;
 
 import java.io.File;
@@ -96,32 +97,28 @@ public class SuppressionFilterTest extends AbstractModuleTestSupport {
     @Test
     public void testNonExistentSuppressionFileWithFalseOptional() {
         final String fileName = "non_existent_suppression_file.xml";
-        try {
-            final boolean optional = false;
-            createSuppressionFilter(fileName, optional);
-            assertWithMessage("Exception is expected").fail();
-        }
-        catch (CheckstyleException exc) {
-            assertWithMessage("Invalid error message")
-                .that(exc.getMessage())
-                .isEqualTo("Unable to find: " + fileName);
-        }
+        final CheckstyleException exc =
+                getExpectedThrowable(CheckstyleException.class, () -> {
+                    final boolean optional = false;
+                    createSuppressionFilter(fileName, optional);
+                }, "Exception is expected");
+        assertWithMessage("Invalid error message")
+            .that(exc.getMessage())
+            .isEqualTo("Unable to find: " + fileName);
     }
 
     @Test
     public void testExistingInvalidSuppressionFileWithTrueOptional() throws IOException {
         final String fileName = getPath("InputSuppressionFilterInvalidFile.xml");
-        try {
-            final boolean optional = true;
-            createSuppressionFilter(fileName, optional);
-            assertWithMessage("Exception is expected").fail();
-        }
-        catch (CheckstyleException exc) {
-            assertWithMessage("Invalid error message")
-                .that(exc.getMessage())
-                .isEqualTo("Unable to parse " + fileName
-                        + " - invalid files or checks or message format");
-        }
+        final CheckstyleException exc =
+                getExpectedThrowable(CheckstyleException.class, () -> {
+                    final boolean optional = true;
+                    createSuppressionFilter(fileName, optional);
+                }, "Exception is expected");
+        assertWithMessage("Invalid error message")
+            .that(exc.getMessage())
+            .isEqualTo("Unable to parse " + fileName
+                    + " - invalid files or checks or message format");
     }
 
     @Test

--- a/src/test/java/com/puppycrawl/tools/checkstyle/filters/SuppressionXpathFilterTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/filters/SuppressionXpathFilterTest.java
@@ -22,6 +22,7 @@ package com.puppycrawl.tools.checkstyle.filters;
 import static com.google.common.truth.Truth.assertWithMessage;
 import static com.puppycrawl.tools.checkstyle.checks.coding.IllegalTokenTextCheck.MSG_KEY;
 import static com.puppycrawl.tools.checkstyle.checks.naming.AbstractNameCheck.MSG_INVALID_PATTERN;
+import static com.puppycrawl.tools.checkstyle.internal.utils.TestUtil.getExpectedThrowable;
 
 import java.util.Collections;
 import java.util.Set;
@@ -81,32 +82,28 @@ public class SuppressionXpathFilterTest extends AbstractModuleTestSupport {
     @Test
     public void testNonExistentSuppressionFileWithFalseOptional() throws Exception {
         final String fileName = getPath("non_existent_suppression_file.xml");
-        try {
-            final boolean optional = false;
-            createSuppressionXpathFilter(fileName, optional);
-            assertWithMessage("Exception is expected").fail();
-        }
-        catch (CheckstyleException exc) {
-            assertWithMessage("Invalid error message")
-                .that(exc.getMessage())
-                .isEqualTo("Unable to find: " + fileName);
-        }
+        final CheckstyleException exc =
+                getExpectedThrowable(CheckstyleException.class, () -> {
+                    final boolean optional = false;
+                    createSuppressionXpathFilter(fileName, optional);
+                }, "Exception is expected");
+        assertWithMessage("Invalid error message")
+            .that(exc.getMessage())
+            .isEqualTo("Unable to find: " + fileName);
     }
 
     @Test
     public void testExistingInvalidSuppressionFileWithTrueOptional() throws Exception {
         final String fileName = getPath("InputSuppressionXpathFilterInvalidFile.xml");
-        try {
-            final boolean optional = true;
-            createSuppressionXpathFilter(fileName, optional);
-            assertWithMessage("Exception is expected").fail();
-        }
-        catch (CheckstyleException exc) {
-            assertWithMessage("Invalid error message")
-                .that(exc.getMessage())
-                .isEqualTo("Unable to parse " + fileName
-                    + " - invalid files or checks or message format for suppress-xpath");
-        }
+        final CheckstyleException exc =
+                getExpectedThrowable(CheckstyleException.class, () -> {
+                    final boolean optional = true;
+                    createSuppressionXpathFilter(fileName, optional);
+                }, "Exception is expected");
+        assertWithMessage("Invalid error message")
+            .that(exc.getMessage())
+            .isEqualTo("Unable to parse " + fileName
+                + " - invalid files or checks or message format for suppress-xpath");
     }
 
     @Test

--- a/src/test/java/com/puppycrawl/tools/checkstyle/filters/SuppressionXpathSingleFilterTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/filters/SuppressionXpathSingleFilterTest.java
@@ -23,6 +23,7 @@ import static com.google.common.truth.Truth.assertWithMessage;
 import static com.puppycrawl.tools.checkstyle.checks.coding.MagicNumberCheck.MSG_KEY;
 import static com.puppycrawl.tools.checkstyle.checks.javadoc.MissingJavadocMethodCheck.MSG_JAVADOC_MISSING;
 import static com.puppycrawl.tools.checkstyle.checks.naming.AbstractNameCheck.MSG_INVALID_PATTERN;
+import static com.puppycrawl.tools.checkstyle.internal.utils.TestUtil.getExpectedThrowable;
 
 import java.io.File;
 import java.nio.charset.StandardCharsets;
@@ -128,17 +129,15 @@ public class SuppressionXpathSingleFilterTest
     @Test
     public void testIncorrectQuery() {
         final String xpath = "1@#";
-        try {
-            final Object test = createSuppressionXpathSingleFilter(
-                    "InputSuppressionXpathSingleFilterComplexQuery", "Test",
-                    null, null, xpath);
-            assertWithMessage("Exception was expected but got %s", test).fail();
-        }
-        catch (IllegalArgumentException exc) {
-            assertWithMessage("Message should be: Unexpected xpath query")
-                    .that(exc.getMessage())
-                    .contains("Incorrect xpath query");
-        }
+        final IllegalArgumentException exc =
+                getExpectedThrowable(IllegalArgumentException.class, () -> {
+                    createSuppressionXpathSingleFilter(
+                            "InputSuppressionXpathSingleFilterComplexQuery", "Test",
+                            null, null, xpath);
+                }, "Exception was expected");
+        assertWithMessage("Message should be: Unexpected xpath query")
+                .that(exc.getMessage())
+                .contains("Incorrect xpath query");
     }
 
     @Test
@@ -185,29 +184,25 @@ public class SuppressionXpathSingleFilterTest
     @Test
     public void testInvalidFileRegexp() {
         final SuppressionXpathSingleFilter filter = new SuppressionXpathSingleFilter();
-        try {
-            filter.setFiles("e[l");
-            assertWithMessage("PatternSyntaxException is expected").fail();
-        }
-        catch (PatternSyntaxException exc) {
-            assertWithMessage("Message should be: Unclosed character class")
-                    .that(exc.getMessage())
-                    .contains("Unclosed character class");
-        }
+        final PatternSyntaxException exc =
+                getExpectedThrowable(PatternSyntaxException.class, () -> {
+                    filter.setFiles("e[l");
+                }, "PatternSyntaxException is expected");
+        assertWithMessage("Message should be: Unclosed character class")
+                .that(exc.getMessage())
+                .contains("Unclosed character class");
     }
 
     @Test
     public void testInvalidCheckRegexp() {
         final SuppressionXpathSingleFilter filter = new SuppressionXpathSingleFilter();
-        try {
-            filter.setChecks("e[l");
-            assertWithMessage("PatternSyntaxException is expected").fail();
-        }
-        catch (PatternSyntaxException exc) {
-            assertWithMessage("Message should be: Unclosed character class")
-                    .that(exc.getMessage())
-                    .contains("Unclosed character class");
-        }
+        final PatternSyntaxException exc =
+                getExpectedThrowable(PatternSyntaxException.class, () -> {
+                    filter.setChecks("e[l");
+                }, "PatternSyntaxException is expected");
+        assertWithMessage("Message should be: Unclosed character class")
+                .that(exc.getMessage())
+                .contains("Unclosed character class");
     }
 
     @Test
@@ -318,15 +313,13 @@ public class SuppressionXpathSingleFilterTest
             StandardCharsets.UTF_8.name()));
         final TreeWalkerAuditEvent ev = new TreeWalkerAuditEvent(fileContents,
                 "InputSuppressionXpathSingleFilterComplexQuery.java", message, null);
-        try {
-            filter.accept(ev);
-            assertWithMessage("Exception is expected").fail();
-        }
-        catch (IllegalStateException exc) {
-            assertWithMessage("Exception message does not match expected one")
-                    .that(exc.getMessage())
-                    .contains("Cannot initialize context and evaluate query");
-        }
+        final IllegalStateException exc =
+                getExpectedThrowable(IllegalStateException.class, () -> {
+                    filter.accept(ev);
+                }, "Exception is expected");
+        assertWithMessage("Exception message does not match expected one")
+                .that(exc.getMessage())
+                .contains("Cannot initialize context and evaluate query");
     }
 
     @Test

--- a/src/test/java/com/puppycrawl/tools/checkstyle/filters/SuppressionsLoaderTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/filters/SuppressionsLoaderTest.java
@@ -20,6 +20,7 @@
 package com.puppycrawl.tools.checkstyle.filters;
 
 import static com.google.common.truth.Truth.assertWithMessage;
+import static com.puppycrawl.tools.checkstyle.internal.utils.TestUtil.getExpectedThrowable;
 import static org.junit.jupiter.api.Assumptions.assumeTrue;
 
 import java.io.IOException;
@@ -84,28 +85,24 @@ public class SuppressionsLoaderTest extends AbstractPathTestSupport {
 
     @Test
     public void testLoadFromMalformedUrl() {
-        try {
-            SuppressionsLoader.loadSuppressions("http");
-            assertWithMessage("exception expected").fail();
-        }
-        catch (CheckstyleException exc) {
-            assertWithMessage("Invalid error message")
+        final CheckstyleException exc =
+                getExpectedThrowable(CheckstyleException.class, () -> {
+                    SuppressionsLoader.loadSuppressions("http");
+                }, "exception expected");
+        assertWithMessage("Invalid error message")
                 .that(exc.getMessage())
                 .isEqualTo("Unable to find: http");
-        }
     }
 
     @Test
     public void testLoadFromNonExistentUrl() {
-        try {
-            SuppressionsLoader.loadSuppressions("/non/existent/file.xml");
-            assertWithMessage("exception expected").fail();
-        }
-        catch (CheckstyleException exc) {
-            assertWithMessage("Invalid error message")
+        final CheckstyleException exc =
+                getExpectedThrowable(CheckstyleException.class, () -> {
+                    SuppressionsLoader.loadSuppressions("/non/existent/file.xml");
+                }, "exception expected");
+        assertWithMessage("Invalid error message")
                 .that(exc.getMessage())
                 .isEqualTo("Unable to find: /non/existent/file.xml");
-        }
     }
 
     @Test
@@ -137,57 +134,51 @@ public class SuppressionsLoaderTest extends AbstractPathTestSupport {
     @Test
     public void testNoFile() throws IOException {
         final String fn = getPath("InputSuppressionsLoaderNoFile.xml");
-        try {
-            SuppressionsLoader.loadSuppressions(fn);
-            assertWithMessage("Exception is expected").fail();
-        }
-        catch (CheckstyleException exc) {
-            final String messageStart = "Unable to parse " + fn;
-            assertWithMessage("Exception message should start with: %s", messageStart)
-                    .that(exc.getMessage())
-                    .startsWith("Unable to parse " + fn);
-            assertWithMessage("Exception message should contain \"files\"")
-                    .that(exc.getMessage())
-                    .contains("\"files\"");
-            assertWithMessage("Exception message should contain \"suppress\"")
-                    .that(exc.getMessage())
-                    .contains("\"suppress\"");
-        }
+        final CheckstyleException exc =
+                getExpectedThrowable(CheckstyleException.class, () -> {
+                    SuppressionsLoader.loadSuppressions(fn);
+                }, "Exception is expected");
+        final String messageStart = "Unable to parse " + fn;
+        assertWithMessage("Exception message should start with: %s", messageStart)
+                .that(exc.getMessage())
+                .startsWith("Unable to parse " + fn);
+        assertWithMessage("Exception message should contain \"files\"")
+                .that(exc.getMessage())
+                .contains("\"files\"");
+        assertWithMessage("Exception message should contain \"suppress\"")
+                .that(exc.getMessage())
+                .contains("\"suppress\"");
     }
 
     @Test
     public void testNoCheck() throws IOException {
         final String fn = getPath("InputSuppressionsLoaderNoCheck.xml");
-        try {
-            SuppressionsLoader.loadSuppressions(fn);
-            assertWithMessage("Exception is expected").fail();
-        }
-        catch (CheckstyleException exc) {
-            final String messageStart = "Unable to parse " + fn;
-            assertWithMessage("Exception message should start with: %s", messageStart)
-                    .that(exc.getMessage())
-                    .startsWith(messageStart);
-            assertWithMessage("Exception message should contain \"checks\"")
-                    .that(exc.getMessage())
-                    .contains("\"checks\"");
-            assertWithMessage("Exception message should contain \"suppress\"")
-                    .that(exc.getMessage())
-                    .contains("\"suppress\"");
-        }
+        final CheckstyleException exc =
+                getExpectedThrowable(CheckstyleException.class, () -> {
+                    SuppressionsLoader.loadSuppressions(fn);
+                }, "Exception is expected");
+        final String messageStart = "Unable to parse " + fn;
+        assertWithMessage("Exception message should start with: %s", messageStart)
+                .that(exc.getMessage())
+                .startsWith(messageStart);
+        assertWithMessage("Exception message should contain \"checks\"")
+                .that(exc.getMessage())
+                .contains("\"checks\"");
+        assertWithMessage("Exception message should contain \"suppress\"")
+                .that(exc.getMessage())
+                .contains("\"suppress\"");
     }
 
     @Test
     public void testBadInt() throws IOException {
         final String fn = getPath("InputSuppressionsLoaderBadInt.xml");
-        try {
-            SuppressionsLoader.loadSuppressions(fn);
-            assertWithMessage("Exception is expected").fail();
-        }
-        catch (CheckstyleException exc) {
-            assertWithMessage(exc.getMessage())
+        final CheckstyleException exc =
+                getExpectedThrowable(CheckstyleException.class, () -> {
+                    SuppressionsLoader.loadSuppressions(fn);
+                }, "Exception is expected");
+        assertWithMessage(exc.getMessage())
                 .that(exc.getMessage())
                 .startsWith("Number format exception " + fn + " - For input string: \"a\"");
-        }
     }
 
     private static FilterSet loadFilterSet(String url) throws Exception {
@@ -235,52 +226,46 @@ public class SuppressionsLoaderTest extends AbstractPathTestSupport {
     @Test
     public void testUnableToFindSuppressions() {
         final String sourceName = "InputSuppressionsLoaderNone.xml";
-
-        try {
-            TestUtil.invokeVoidStaticMethod(SuppressionsLoader.class, "loadSuppressions",
-                    new InputSource(sourceName), sourceName);
-            assertWithMessage("InvocationTargetException is expected").fail();
-        }
-        catch (ReflectiveOperationException exc) {
-            assertWithMessage("Invalid exception cause message")
+        final ReflectiveOperationException exc =
+                getExpectedThrowable(ReflectiveOperationException.class, () -> {
+                    TestUtil.invokeVoidStaticMethod(SuppressionsLoader.class,
+                            "loadSuppressions",
+                            new InputSource(sourceName), sourceName);
+                }, "InvocationTargetException is expected");
+        assertWithMessage("Invalid exception cause message")
                 .that(exc)
-                    .hasCauseThat()
-                        .hasMessageThat()
-                        .isEqualTo("Unable to find: " + sourceName);
-        }
+                .hasCauseThat()
+                .hasMessageThat()
+                .isEqualTo("Unable to find: " + sourceName);
     }
 
     @Test
     public void testUnableToReadSuppressions() {
         final String sourceName = "InputSuppressionsLoaderNone.xml";
-
-        try {
-            TestUtil.invokeVoidStaticMethod(SuppressionsLoader.class, "loadSuppressions",
-                    new InputSource(), sourceName);
-            assertWithMessage("InvocationTargetException is expected").fail();
-        }
-        catch (ReflectiveOperationException exc) {
-            assertWithMessage("Invalid exception cause message")
+        final ReflectiveOperationException exc =
+                getExpectedThrowable(ReflectiveOperationException.class, () -> {
+                    TestUtil.invokeVoidStaticMethod(SuppressionsLoader.class,
+                            "loadSuppressions",
+                            new InputSource(), sourceName);
+                }, "InvocationTargetException is expected");
+        assertWithMessage("Invalid exception cause message")
                 .that(exc)
-                    .hasCauseThat()
-                        .hasMessageThat()
-                        .isEqualTo("Unable to read " + sourceName);
-        }
+                .hasCauseThat()
+                .hasMessageThat()
+                .isEqualTo("Unable to read " + sourceName);
     }
 
     @Test
     public void testNoCheckNoId() throws IOException {
         final String fn = getPath("InputSuppressionsLoaderNoCheckAndId.xml");
-        try {
-            SuppressionsLoader.loadSuppressions(fn);
-            assertWithMessage("Exception is expected").fail();
-        }
-        catch (CheckstyleException exc) {
-            assertWithMessage("Invalid error message")
+        final CheckstyleException exc =
+                getExpectedThrowable(CheckstyleException.class, () -> {
+                    SuppressionsLoader.loadSuppressions(fn);
+                }, "Exception is expected");
+        assertWithMessage("Invalid error message")
                 .that(exc.getMessage())
                 .isEqualTo("Unable to parse " + fn
                         + " - missing checks or id or message attribute");
-        }
     }
 
     @Test
@@ -296,16 +281,14 @@ public class SuppressionsLoaderTest extends AbstractPathTestSupport {
     @Test
     public void testInvalidFileFormat() throws IOException {
         final String fn = getPath("InputSuppressionsLoaderInvalidFile.xml");
-        try {
-            SuppressionsLoader.loadSuppressions(fn);
-            assertWithMessage("Exception is expected").fail();
-        }
-        catch (CheckstyleException exc) {
-            assertWithMessage("Invalid error message")
+        final CheckstyleException exc =
+                getExpectedThrowable(CheckstyleException.class, () -> {
+                    SuppressionsLoader.loadSuppressions(fn);
+                }, "Exception is expected");
+        assertWithMessage("Invalid error message")
                 .that(exc.getMessage())
                 .isEqualTo("Unable to parse " + fn
                         + " - invalid files or checks or message format");
-        }
     }
 
     @Test
@@ -351,32 +334,28 @@ public class SuppressionsLoaderTest extends AbstractPathTestSupport {
     @Test
     public void testXpathInvalidFileFormat() throws IOException {
         final String fn = getPath("InputSuppressionsLoaderXpathInvalidFile.xml");
-        try {
-            SuppressionsLoader.loadXpathSuppressions(fn);
-            assertWithMessage("Exception should be thrown").fail();
-        }
-        catch (CheckstyleException exc) {
-            assertWithMessage("Invalid error message")
+        final CheckstyleException exc =
+                getExpectedThrowable(CheckstyleException.class, () -> {
+                    SuppressionsLoader.loadXpathSuppressions(fn);
+                }, "Exception should be thrown");
+        assertWithMessage("Invalid error message")
                 .that(exc.getMessage())
                 .isEqualTo("Unable to parse " + fn
                         + " - invalid files or checks or message format for suppress-xpath");
-        }
     }
 
     @Test
     public void testXpathNoCheckNoId() throws IOException {
         final String fn =
                 getPath("InputSuppressionsLoaderXpathNoCheckAndId.xml");
-        try {
-            SuppressionsLoader.loadXpathSuppressions(fn);
-            assertWithMessage("Exception should be thrown").fail();
-        }
-        catch (CheckstyleException exc) {
-            assertWithMessage("Invalid error message")
+        final CheckstyleException exc =
+                getExpectedThrowable(CheckstyleException.class, () -> {
+                    SuppressionsLoader.loadXpathSuppressions(fn);
+                }, "Exception should be thrown");
+        assertWithMessage("Invalid error message")
                 .that(exc.getMessage())
                 .isEqualTo("Unable to parse " + fn
                         + " - missing checks or id or message attribute for suppress-xpath");
-        }
     }
 
     @Test

--- a/src/test/java/com/puppycrawl/tools/checkstyle/filters/XpathFilterElementTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/filters/XpathFilterElementTest.java
@@ -20,6 +20,7 @@
 package com.puppycrawl.tools.checkstyle.filters;
 
 import static com.google.common.truth.Truth.assertWithMessage;
+import static com.puppycrawl.tools.checkstyle.internal.utils.TestUtil.getExpectedThrowable;
 
 import java.io.File;
 import java.nio.charset.StandardCharsets;
@@ -132,31 +133,27 @@ public class XpathFilterElementTest extends AbstractModuleTestSupport {
 
     @Test
     public void testInvalidCheckRegexp() {
-        try {
-            final Object test = new XpathFilterElement(
-                    ".*", "e[l", ".*", "moduleId", "query");
-            assertWithMessage("Exception is expected but got %s", test).fail();
-        }
-        catch (IllegalArgumentException exc) {
-            assertWithMessage("Message should be: Failed to initialise regular expression")
-                    .that(exc.getMessage())
-                    .contains("Failed to initialise regular expression");
-        }
+        final IllegalArgumentException exc =
+                getExpectedThrowable(IllegalArgumentException.class, () -> {
+                    new XpathFilterElement(
+                            ".*", "e[l", ".*", "moduleId", "query").getClass();
+                }, "Exception is expected");
+        assertWithMessage("Message should be: Failed to initialise regular expression")
+                .that(exc.getMessage())
+                .contains("Failed to initialise regular expression");
     }
 
     @Test
     public void testIncorrectQuery() {
         final String xpath = "1@#";
-        try {
-            final Object test = new XpathFilterElement("InputXpathFilterElementSuppressByXpath",
-                    "Test", null, null, xpath);
-            assertWithMessage("Exception is expected but got %s", test).fail();
-        }
-        catch (IllegalArgumentException exc) {
-            assertWithMessage("Message should be: Incorrect xpath query")
-                    .that(exc.getMessage())
-                    .contains("Incorrect xpath query");
-        }
+        final IllegalArgumentException exc =
+                getExpectedThrowable(IllegalArgumentException.class, () -> {
+                    new XpathFilterElement("InputXpathFilterElementSuppressByXpath",
+                            "Test", null, null, xpath).getClass();
+                }, "Exception is expected");
+        assertWithMessage("Message should be: Incorrect xpath query")
+                .that(exc.getMessage())
+                .contains("Incorrect xpath query");
     }
 
     @Test
@@ -321,15 +318,13 @@ public class XpathFilterElementTest extends AbstractModuleTestSupport {
                         getClass(), null);
         final TreeWalkerAuditEvent ev = new TreeWalkerAuditEvent(fileContents,
                 file.getName(), message, null);
-        try {
-            filter.accept(ev);
-            assertWithMessage("Exception is expected").fail();
-        }
-        catch (IllegalStateException exc) {
-            assertWithMessage("Exception message does not match expected one")
-                    .that(exc.getMessage())
-                    .contains("Cannot initialize context and evaluate query");
-        }
+        final IllegalStateException exc =
+                getExpectedThrowable(IllegalStateException.class, () -> {
+                    filter.accept(ev);
+                }, "Exception is expected");
+        assertWithMessage("Exception message does not match expected one")
+                .that(exc.getMessage())
+                .contains("Cannot initialize context and evaluate query");
     }
 
     @Test


### PR DESCRIPTION
This PR migrates test files in the `filters` package to use `getExpectedThrowable` instead of the deprecated `assertWithMessage(...).fail()` pattern as required by Issue #19176.

Files updated:

* SuppressionsLoaderTest.java
* SuppressWithNearbyTextFilterTest.java
* SuppressWithPlainTextCommentFilterTest.java
* SuppressionXpathSingleFilterTest.java
* XpathFilterElementTest.java
* SuppressionXpathFilterTest.java
* SuppressWithNearbyCommentFilterTest.java
* SuppressionFilterTest.java
* SuppressionCommentFilterTest.java

All occurrences of `assertWithMessage(...).fail()` in the `filters` package have been migrated.
Tests were executed locally and passed successfully.

<img width="2557" height="1037" alt="Screenshot 2026-03-12 at 12 06 39 AM" src="https://github.com/user-attachments/assets/5d893419-310d-413c-8594-586dee7fe740" />
