### PR TITLE
Issue #19176: migrate utils tests to use getExpectedThrowable

### DIFF
--- a/src/test/java/com/puppycrawl/tools/checkstyle/utils/AnnotationUtilTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/utils/AnnotationUtilTest.java
@@ -21,6 +21,7 @@ package com.puppycrawl.tools.checkstyle.utils;
 
 import static com.google.common.truth.Truth.assertWithMessage;
 import static com.puppycrawl.tools.checkstyle.checks.annotation.SuppressWarningsCheck.MSG_KEY_SUPPRESSED_WARNING_NOT_ALLOWED;
+import static com.puppycrawl.tools.checkstyle.internal.utils.TestUtil.getExpectedThrowable;
 import static com.puppycrawl.tools.checkstyle.internal.utils.TestUtil.instantiate;
 
 import java.util.Set;
@@ -42,43 +43,37 @@ public class AnnotationUtilTest extends AbstractModuleTestSupport {
 
     @Test
     public void testIsProperUtilsClass() {
-        try {
-            instantiate(AnnotationUtil.class);
-            assertWithMessage("Exception is expected").fail();
-        }
-        catch (ReflectiveOperationException exc) {
-            assertWithMessage("Invalid exception message")
-                .that(exc)
-                .hasCauseThat()
-                .hasMessageThat()
-                .isEqualTo("do not instantiate.");
-        }
+        final ReflectiveOperationException exc =
+                getExpectedThrowable(ReflectiveOperationException.class, () -> {
+                    instantiate(AnnotationUtil.class);
+                }, "Exception is expected");
+        assertWithMessage("Invalid exception message")
+            .that(exc)
+            .hasCauseThat()
+            .hasMessageThat()
+            .isEqualTo("do not instantiate.");
     }
 
     @Test
     public void testContainsAnnotationNull() {
-        try {
-            AnnotationUtil.containsAnnotation(null);
-            assertWithMessage("IllegalArgumentException is expected").fail();
-        }
-        catch (IllegalArgumentException exc) {
-            assertWithMessage("Invalid exception message")
-                .that(exc.getMessage())
-                .isEqualTo("the ast is null");
-        }
+        final IllegalArgumentException exc =
+                getExpectedThrowable(IllegalArgumentException.class, () -> {
+                    AnnotationUtil.containsAnnotation(null);
+                }, "IllegalArgumentException is expected");
+        assertWithMessage("Invalid exception message")
+            .that(exc.getMessage())
+            .isEqualTo("the ast is null");
     }
 
     @Test
     public void testContainsAnnotationNull2() {
-        try {
-            AnnotationUtil.containsAnnotation(null, "");
-            assertWithMessage("IllegalArgumentException is expected").fail();
-        }
-        catch (IllegalArgumentException exc) {
-            assertWithMessage("Invalid exception message")
-                .that(exc.getMessage())
-                .isEqualTo("the ast is null");
-        }
+        final IllegalArgumentException exc =
+                getExpectedThrowable(IllegalArgumentException.class, () -> {
+                    AnnotationUtil.containsAnnotation(null, "");
+                }, "IllegalArgumentException is expected");
+        assertWithMessage("Invalid exception message")
+            .that(exc.getMessage())
+            .isEqualTo("the ast is null");
     }
 
     @Test
@@ -119,95 +114,81 @@ public class AnnotationUtilTest extends AbstractModuleTestSupport {
 
     @Test
     public void testAnnotationHolderNull() {
-        try {
-            AnnotationUtil.getAnnotationHolder(null);
-            assertWithMessage("IllegalArgumentException is expected").fail();
-        }
-        catch (IllegalArgumentException exc) {
-            assertWithMessage("Invalid exception message")
-                .that(exc.getMessage())
-                .isEqualTo("the ast is null");
-        }
+        final IllegalArgumentException exc =
+                getExpectedThrowable(IllegalArgumentException.class, () -> {
+                    AnnotationUtil.getAnnotationHolder(null);
+                }, "IllegalArgumentException is expected");
+        assertWithMessage("Invalid exception message")
+            .that(exc.getMessage())
+            .isEqualTo("the ast is null");
     }
 
     @Test
     public void testAnnotationNull() {
-        try {
-            AnnotationUtil.getAnnotation(null, null);
-            assertWithMessage("IllegalArgumentException is expected").fail();
-        }
-        catch (IllegalArgumentException exc) {
-            assertWithMessage("Invalid exception message")
-                .that(exc.getMessage())
-                .isEqualTo("the ast is null");
-        }
+        final IllegalArgumentException exc =
+                getExpectedThrowable(IllegalArgumentException.class, () -> {
+                    AnnotationUtil.getAnnotation(null, null);
+                }, "IllegalArgumentException is expected");
+        assertWithMessage("Invalid exception message")
+            .that(exc.getMessage())
+            .isEqualTo("the ast is null");
     }
 
     @Test
     public void testAnnotationNull2() {
-        try {
-            AnnotationUtil.getAnnotation(new DetailAstImpl(), null);
-            assertWithMessage("IllegalArgumentException is expected").fail();
-        }
-        catch (IllegalArgumentException exc) {
-            assertWithMessage("Invalid exception message")
-                .that(exc.getMessage())
-                .isEqualTo("the annotation is null");
-        }
+        final IllegalArgumentException exc =
+                getExpectedThrowable(IllegalArgumentException.class, () -> {
+                    AnnotationUtil.getAnnotation(new DetailAstImpl(), null);
+                }, "IllegalArgumentException is expected");
+        assertWithMessage("Invalid exception message")
+            .that(exc.getMessage())
+            .isEqualTo("the annotation is null");
     }
 
     @Test
     public void testAnnotationEmpty() {
-        try {
-            AnnotationUtil.getAnnotation(new DetailAstImpl(), "");
-            assertWithMessage("IllegalArgumentException is expected").fail();
-        }
-        catch (IllegalArgumentException exc) {
-            assertWithMessage("Invalid exception message")
-                .that(exc.getMessage())
-                .isEqualTo("the annotation is empty or spaces");
-        }
+        final IllegalArgumentException exc =
+                getExpectedThrowable(IllegalArgumentException.class, () -> {
+                    AnnotationUtil.getAnnotation(new DetailAstImpl(), "");
+                }, "IllegalArgumentException is expected");
+        assertWithMessage("Invalid exception message")
+            .that(exc.getMessage())
+            .isEqualTo("the annotation is empty or spaces");
     }
 
     @Test
     public void testContainsAnnotationWithNull() {
-        try {
-            AnnotationUtil.getAnnotation(null, "");
-            assertWithMessage("IllegalArgumentException is expected").fail();
-        }
-        catch (IllegalArgumentException exc) {
-            assertWithMessage("Invalid exception message")
-                .that(exc.getMessage())
-                .isEqualTo("the ast is null");
-        }
+        final IllegalArgumentException exc =
+                getExpectedThrowable(IllegalArgumentException.class, () -> {
+                    AnnotationUtil.getAnnotation(null, "");
+                }, "IllegalArgumentException is expected");
+        assertWithMessage("Invalid exception message")
+            .that(exc.getMessage())
+            .isEqualTo("the ast is null");
     }
 
     @Test
     public void testContainsAnnotationListWithNullAst() {
-        try {
-            AnnotationUtil.containsAnnotation(null, Set.of("Override"));
-            assertWithMessage("IllegalArgumentException is expected").fail();
-        }
-        catch (IllegalArgumentException exc) {
-            assertWithMessage("Invalid exception message")
-                .that(exc.getMessage())
-                .isEqualTo("the ast is null");
-        }
+        final IllegalArgumentException exc =
+                getExpectedThrowable(IllegalArgumentException.class, () -> {
+                    AnnotationUtil.containsAnnotation(null, Set.of("Override"));
+                }, "IllegalArgumentException is expected");
+        assertWithMessage("Invalid exception message")
+            .that(exc.getMessage())
+            .isEqualTo("the ast is null");
     }
 
     @Test
     public void testContainsAnnotationListWithNullList() {
         final DetailAST ast = new DetailAstImpl();
         final Set<String> annotations = null;
-        try {
-            AnnotationUtil.containsAnnotation(ast, annotations);
-            assertWithMessage("IllegalArgumentException is expected").fail();
-        }
-        catch (IllegalArgumentException exc) {
-            assertWithMessage("Invalid exception message")
-                .that(exc.getMessage())
-                .isEqualTo("annotations cannot be null");
-        }
+        final IllegalArgumentException exc =
+                getExpectedThrowable(IllegalArgumentException.class, () -> {
+                    AnnotationUtil.containsAnnotation(ast, annotations);
+                }, "IllegalArgumentException is expected");
+        assertWithMessage("Invalid exception message")
+            .that(exc.getMessage())
+            .isEqualTo("annotations cannot be null");
     }
 
     @Test

--- a/src/test/java/com/puppycrawl/tools/checkstyle/utils/JavadocUtilTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/utils/JavadocUtilTest.java
@@ -20,6 +20,7 @@
 package com.puppycrawl.tools.checkstyle.utils;
 
 import static com.google.common.truth.Truth.assertWithMessage;
+import static com.puppycrawl.tools.checkstyle.internal.utils.TestUtil.getExpectedThrowable;
 import static com.puppycrawl.tools.checkstyle.internal.utils.TestUtil.isUtilsClassHasPrivateConstructor;
 
 import java.util.List;
@@ -278,54 +279,46 @@ public class JavadocUtilTest {
 
     @Test
     public void testGetTokenNameForLargeId() {
-        try {
-            JavadocUtil.getTokenName(30073);
-            assertWithMessage("exception expected").fail();
-        }
-        catch (IllegalArgumentException exc) {
-            assertWithMessage("Invalid exception message")
-                .that(exc.getMessage())
-                .isEqualTo("Unknown javadoc token id. Given id: 30073");
-        }
+        final IllegalArgumentException exc =
+                getExpectedThrowable(IllegalArgumentException.class, () -> {
+                    JavadocUtil.getTokenName(30073);
+                }, "exception expected");
+        assertWithMessage("Invalid exception message")
+            .that(exc.getMessage())
+            .isEqualTo("Unknown javadoc token id. Given id: 30073");
     }
 
     @Test
     public void testGetTokenNameForInvalidId() {
-        try {
-            JavadocUtil.getTokenName(110);
-            assertWithMessage("exception expected").fail();
-        }
-        catch (IllegalArgumentException exc) {
-            assertWithMessage("Invalid exception message")
-                .that(exc.getMessage())
-                .isEqualTo("Unknown javadoc token id. Given id: 110");
-        }
+        final IllegalArgumentException exc =
+                getExpectedThrowable(IllegalArgumentException.class, () -> {
+                    JavadocUtil.getTokenName(110);
+                }, "exception expected");
+        assertWithMessage("Invalid exception message")
+            .that(exc.getMessage())
+            .isEqualTo("Unknown javadoc token id. Given id: 110");
     }
 
     @Test
     public void testGetTokenNameForLowerBoundInvalidId() {
-        try {
-            JavadocUtil.getTokenName(10095);
-            assertWithMessage("exception expected").fail();
-        }
-        catch (IllegalArgumentException exc) {
-            assertWithMessage("Invalid exception message")
-                .that(exc.getMessage())
-                .isEqualTo("Unknown javadoc token id. Given id: 10095");
-        }
+        final IllegalArgumentException exc =
+                getExpectedThrowable(IllegalArgumentException.class, () -> {
+                    JavadocUtil.getTokenName(10095);
+                }, "exception expected");
+        assertWithMessage("Invalid exception message")
+            .that(exc.getMessage())
+            .isEqualTo("Unknown javadoc token id. Given id: 10095");
     }
 
     @Test
     public void testGetTokenIdThatIsUnknown() {
-        try {
-            JavadocUtil.getTokenId("");
-            assertWithMessage("exception expected").fail();
-        }
-        catch (IllegalArgumentException exc) {
-            assertWithMessage("Invalid exception message")
-                .that(exc.getMessage())
-                .isEqualTo("Unknown javadoc token name. Given name ");
-        }
+        final IllegalArgumentException exc =
+                getExpectedThrowable(IllegalArgumentException.class, () -> {
+                    JavadocUtil.getTokenId("");
+                }, "exception expected");
+        assertWithMessage("Invalid exception message")
+            .that(exc.getMessage())
+            .isEqualTo("Unknown javadoc token name. Given name ");
     }
 
     @Test

--- a/src/test/java/com/puppycrawl/tools/checkstyle/utils/TokenUtilTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/utils/TokenUtilTest.java
@@ -20,6 +20,7 @@
 package com.puppycrawl.tools.checkstyle.utils;
 
 import static com.google.common.truth.Truth.assertWithMessage;
+import static com.puppycrawl.tools.checkstyle.internal.utils.TestUtil.getExpectedThrowable;
 import static com.puppycrawl.tools.checkstyle.internal.utils.TestUtil.isUtilsClassHasPrivateConstructor;
 
 import java.lang.reflect.Field;
@@ -59,20 +60,18 @@ public class TokenUtilTest {
     public void testGetIntFromInaccessibleField() throws NoSuchFieldException {
         final Field field = Integer.class.getDeclaredField("value");
 
-        try {
-            TokenUtil.getIntFromField(field, 0);
-            assertWithMessage("IllegalStateException is expected").fail();
-        }
-        catch (IllegalStateException expected) {
-            // The exception message may vary depending on the version of the JDK.
-            // It will definitely contain the TokenUtil class name and the Integer class name.
-            final String message = expected.getMessage();
-            assertWithMessage("Invalid exception message: %s", message)
-                    .that(message.startsWith("java.lang.IllegalAccessException: ")
-                            && message.contains("com.puppycrawl.tools.checkstyle.utils.TokenUtil")
-                            && message.contains("access a member of class java.lang.Integer"))
-                    .isTrue();
-        }
+        final IllegalStateException expected =
+                getExpectedThrowable(IllegalStateException.class, () -> {
+                    TokenUtil.getIntFromField(field, 0);
+                }, "IllegalStateException is expected");
+        // The exception message may vary depending on the version of the JDK.
+        // It will definitely contain the TokenUtil class name and the Integer class name.
+        final String message = expected.getMessage();
+        assertWithMessage("Invalid exception message: %s", message)
+                .that(message.startsWith("java.lang.IllegalAccessException: ")
+                        && message.contains("com.puppycrawl.tools.checkstyle.utils.TokenUtil")
+                        && message.contains("access a member of class java.lang.Integer"))
+                .isTrue();
     }
 
     @Test
@@ -126,15 +125,13 @@ public class TokenUtilTest {
         }
 
         final int nextAfterMaxId = maxId + 1;
-        try {
-            TokenUtil.getTokenName(nextAfterMaxId);
-            assertWithMessage("IllegalArgumentException is expected").fail();
-        }
-        catch (IllegalArgumentException expectedException) {
-            assertWithMessage("Invalid exception message")
-                .that(expectedException.getMessage())
-                .isEqualTo("unknown TokenTypes id '" + nextAfterMaxId + "'");
-        }
+        final IllegalArgumentException expectedException =
+                getExpectedThrowable(IllegalArgumentException.class, () -> {
+                    TokenUtil.getTokenName(nextAfterMaxId);
+                }, "IllegalArgumentException is expected");
+        assertWithMessage("Invalid exception message")
+            .that(expectedException.getMessage())
+            .isEqualTo("unknown TokenTypes id '" + nextAfterMaxId + "'");
     }
 
     @Test
@@ -158,43 +155,37 @@ public class TokenUtilTest {
     @Test
     public void testTokenValueIncorrect2() {
         final int id = 0;
-        try {
-            TokenUtil.getTokenName(id);
-            assertWithMessage("IllegalArgumentException is expected").fail();
-        }
-        catch (IllegalArgumentException expected) {
-            assertWithMessage("Invalid exception message")
-                .that(expected.getMessage())
-                .isEqualTo("unknown TokenTypes id '" + id + "'");
-        }
+        final IllegalArgumentException expected =
+                getExpectedThrowable(IllegalArgumentException.class, () -> {
+                    TokenUtil.getTokenName(id);
+                }, "IllegalArgumentException is expected");
+        assertWithMessage("Invalid exception message")
+            .that(expected.getMessage())
+            .isEqualTo("unknown TokenTypes id '" + id + "'");
     }
 
     @Test
     public void testTokenIdIncorrect() {
         final String id = "NON_EXISTENT_VALUE";
-        try {
-            TokenUtil.getTokenId(id);
-            assertWithMessage("IllegalArgumentException is expected").fail();
-        }
-        catch (IllegalArgumentException expected) {
-            assertWithMessage("Invalid exception message")
-                .that(expected.getMessage())
-                .isEqualTo("unknown TokenTypes value '" + id + "'");
-        }
+        final IllegalArgumentException expected =
+                getExpectedThrowable(IllegalArgumentException.class, () -> {
+                    TokenUtil.getTokenId(id);
+                }, "IllegalArgumentException is expected");
+        assertWithMessage("Invalid exception message")
+            .that(expected.getMessage())
+            .isEqualTo("unknown TokenTypes value '" + id + "'");
     }
 
     @Test
     public void testShortDescriptionIncorrect() {
         final String id = "NON_EXISTENT_VALUE";
-        try {
-            TokenUtil.getShortDescription(id);
-            assertWithMessage("IllegalArgumentException is expected").fail();
-        }
-        catch (IllegalArgumentException expected) {
-            assertWithMessage("Invalid exception message")
-                .that(expected.getMessage())
-                .isEqualTo("unknown TokenTypes value '" + id + "'");
-        }
+        final IllegalArgumentException expected =
+                getExpectedThrowable(IllegalArgumentException.class, () -> {
+                    TokenUtil.getShortDescription(id);
+                }, "IllegalArgumentException is expected");
+        assertWithMessage("Invalid exception message")
+            .that(expected.getMessage())
+            .isEqualTo("unknown TokenTypes value '" + id + "'");
     }
 
     @Test

--- a/src/test/java/com/puppycrawl/tools/checkstyle/utils/XpathUtilTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/utils/XpathUtilTest.java
@@ -21,6 +21,7 @@ package com.puppycrawl.tools.checkstyle.utils;
 
 import static com.google.common.truth.Truth.assertWithMessage;
 import static com.puppycrawl.tools.checkstyle.AbstractPathTestSupport.addEndOfLine;
+import static com.puppycrawl.tools.checkstyle.internal.utils.TestUtil.getExpectedThrowable;
 import static com.puppycrawl.tools.checkstyle.internal.utils.TestUtil.isUtilsClassHasPrivateConstructor;
 import static com.puppycrawl.tools.checkstyle.utils.XpathUtil.getTextAttributeValue;
 
@@ -174,18 +175,16 @@ public class XpathUtilTest {
         Files.writeString(file.toPath(), fileContent, StandardCharsets.UTF_8);
         final String invalidXpath = "\\//CLASS_DEF"
                 + "//METHOD_DEF//VARIABLE_DEF//IDENT";
-        try {
-            XpathUtil.printXpathBranch(invalidXpath, file);
-            assertWithMessage("Should end with exception").fail();
-        }
-        catch (CheckstyleException exc) {
-            final String expectedMessage =
-                "Error during evaluation for xpath: " + invalidXpath
-                    + ", file: " + file.getCanonicalPath();
-            assertWithMessage("Exception message is different")
-                .that(exc.getMessage())
-                .isEqualTo(expectedMessage);
-        }
+        final CheckstyleException exc =
+                getExpectedThrowable(CheckstyleException.class, () -> {
+                    XpathUtil.printXpathBranch(invalidXpath, file);
+                }, "Should end with exception");
+        final String expectedMessage =
+            "Error during evaluation for xpath: " + invalidXpath
+                + ", file: " + file.getCanonicalPath();
+        assertWithMessage("Exception message is different")
+            .that(exc.getMessage())
+            .isEqualTo(expectedMessage);
     }
 
     @Test


### PR DESCRIPTION
Migrated remaining test files in the `utils` package to replace the deprecated `assertWithMessage(...).fail()` pattern with `getExpectedThrowable`.

Updated files:

* AnnotationUtilTest.java
* JavadocUtilTest.java
* TokenUtilTest.java
* XpathUtilTest.java

The rest of the test files in the `utils` package already use the `getExpectedThrowable` pattern and did not require migration.

Verified that no occurrences of `assertWithMessage(...).fail()` remain in the `utils` directory.
