### PR TITLE
Issue #19176: migrate tests to use getExpectedThrowable CheckStyle, Gui, Imports

### DIFF
--- a/src/test/java/com/puppycrawl/tools/checkstyle/CheckerTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/CheckerTest.java
@@ -450,15 +450,13 @@ public class CheckerTest extends AbstractModuleTestSupport {
         checker.setFileExtensions((String[]) null);
         checker.setFileExtensions(".java", "xml");
 
-        try {
-            checker.setCharset("UNKNOWN-CHARSET");
-            assertWithMessage("Exception is expected").fail();
-        }
-        catch (UnsupportedEncodingException exc) {
-            assertWithMessage("Error message is not expected")
-                .that(exc.getMessage())
-                .isEqualTo("unsupported charset: 'UNKNOWN-CHARSET'");
-        }
+        final UnsupportedEncodingException exc =
+                getExpectedThrowable(UnsupportedEncodingException.class, () -> {
+                    checker.setCharset("UNKNOWN-CHARSET");
+                }, "Exception is expected");
+        assertWithMessage("Error message is not expected")
+            .that(exc.getMessage())
+            .isEqualTo("unsupported charset: 'UNKNOWN-CHARSET'");
     }
 
     @Test
@@ -472,16 +470,13 @@ public class CheckerTest extends AbstractModuleTestSupport {
     public void testNoClassLoaderNoModuleFactory() {
         final Checker checker = new Checker();
 
-        try {
-            checker.finishLocalSetup();
-            assertWithMessage("Exception is expected").fail();
-        }
-        catch (CheckstyleException exc) {
-            assertWithMessage("Error message is not expected")
-                .that(exc.getMessage())
-                .isEqualTo("if no custom moduleFactory is set,"
-                    + " moduleClassLoader must be specified");
-        }
+        final CheckstyleException exc =
+                getExpectedThrowable(CheckstyleException.class,
+                    checker::finishLocalSetup, "Exception is expected");
+        assertWithMessage("Error message is not expected")
+            .that(exc.getMessage())
+            .isEqualTo("if no custom moduleFactory is set,"
+                + " moduleClassLoader must be specified");
     }
 
     @Test
@@ -538,31 +533,27 @@ public class CheckerTest extends AbstractModuleTestSupport {
         checker.setModuleFactory(factory);
 
         final Configuration config = new DefaultConfiguration("java.lang.String");
-        try {
-            checker.setupChild(config);
-            assertWithMessage("Exception is expected").fail();
-        }
-        catch (CheckstyleException exc) {
-            assertWithMessage("Error message is not expected")
-                .that(exc.getMessage())
-                .isEqualTo("java.lang.String is not allowed as a child in Checker");
-        }
+        final CheckstyleException exc =
+                getExpectedThrowable(CheckstyleException.class, () -> {
+                    checker.setupChild(config);
+                }, "Exception is expected");
+        assertWithMessage("Error message is not expected")
+            .that(exc.getMessage())
+            .isEqualTo("java.lang.String is not allowed as a child in Checker");
     }
 
     @Test
-    public void testSetupChildInvalidProperty() throws Exception {
+    public void testSetupChildInvalidProperty() {
         final DefaultConfiguration checkConfig = createModuleConfig(HiddenFieldCheck.class);
         checkConfig.addProperty("$$No such property", null);
-        try {
-            createChecker(checkConfig);
-            assertWithMessage("Exception is expected").fail();
-        }
-        catch (CheckstyleException exc) {
-            assertWithMessage("Error message is not expected")
-                .that(exc.getMessage())
-                .isEqualTo("cannot initialize module com.puppycrawl.tools.checkstyle.TreeWalker"
-                        + " - cannot initialize module " + checkConfig.getName());
-        }
+        final CheckstyleException exc =
+                getExpectedThrowable(CheckstyleException.class, () -> {
+                    createChecker(checkConfig);
+                }, "Exception is expected");
+        assertWithMessage("Error message is not expected")
+            .that(exc.getMessage())
+            .isEqualTo("cannot initialize module com.puppycrawl.tools.checkstyle.TreeWalker"
+                    + " - cannot initialize module " + checkConfig.getName());
     }
 
     @Test
@@ -594,20 +585,16 @@ public class CheckerTest extends AbstractModuleTestSupport {
         // The maximum file name length which is allowed in most UNIX, Windows file systems is 255.
         // See https://en.wikipedia.org/wiki/Filename;
         checker.setCacheFile(String.format(Locale.ENGLISH, "%0300d", 0));
-        try {
-            checker.destroy();
-            assertWithMessage("Exception did not happen").fail();
-        }
-        catch (IllegalStateException exc) {
-            assertWithMessage("Cause of exception differs from IOException")
-                    .that(exc.getCause())
-                    .isInstanceOf(IOException.class);
-
-            assertWithMessage("Exception message differ")
-                    .that(exc.getMessage())
-                    .isEqualTo(getLocalizedMessage(
-                            "Checker.cacheFilesException"));
-        }
+        final IllegalStateException exc =
+                getExpectedThrowable(IllegalStateException.class,
+                    checker::destroy, "Exception did not happen");
+        assertWithMessage("Cause of exception differs from IOException")
+            .that(exc.getCause())
+            .isInstanceOf(IOException.class);
+        assertWithMessage("Exception message differ")
+            .that(exc.getMessage())
+            .isEqualTo(getLocalizedMessage(
+                    "Checker.cacheFilesException"));
     }
 
     /**
@@ -804,7 +791,7 @@ public class CheckerTest extends AbstractModuleTestSupport {
      *      for test does not require serialization
      */
     @Test
-    public void testCatchErrorInProcessFilesMethod() throws Exception {
+    public void testCatchErrorInProcessFilesMethod() {
         // Assume that I/O error is happened when we try to invoke 'lastModified()' method.
         final String errorMessage = "Java Virtual Machine is broken"
             + " or has run out of resources necessary for it to continue operating.";
@@ -830,30 +817,26 @@ public class CheckerTest extends AbstractModuleTestSupport {
         final Checker checker = new Checker();
         final List<File> filesToProcess = new ArrayList<>();
         filesToProcess.add(mock);
-        try {
-            checker.process(filesToProcess);
-            assertWithMessage("IOError is expected!").fail();
-        }
-        // -@cs[IllegalCatchExtended] Testing for catch Error is part of 100% coverage.
-        catch (Error error) {
-            assertWithMessage("Error cause differs from IOError")
-                    .that(error.getCause())
-                    .isInstanceOf(IOError.class);
-            assertWithMessage("Error cause is not InternalError")
-                    .that(error.getCause().getCause())
-                    .isInstanceOf(InternalError.class);
-            assertWithMessage("Error message is not expected")
-                    .that(error)
-                    .hasCauseThat()
-                    .hasCauseThat()
-                    .hasMessageThat()
-                    .isEqualTo(errorMessage);
-            assertWithMessage("Error message differs")
-                    .that(error.getMessage())
-                    .isEqualTo(getLocalizedMessage(
-                            "Checker.error", mock.getPath()));
-
-        }
+        final Error error =
+                getExpectedThrowable(Error.class, () -> {
+                    checker.process(filesToProcess);
+                }, "IOError is expected!");
+        assertWithMessage("Error cause differs from IOError")
+            .that(error.getCause())
+            .isInstanceOf(IOError.class);
+        assertWithMessage("Error cause is not InternalError")
+            .that(error.getCause().getCause())
+            .isInstanceOf(InternalError.class);
+        assertWithMessage("Error message is not expected")
+            .that(error)
+            .hasCauseThat()
+            .hasCauseThat()
+            .hasMessageThat()
+            .isEqualTo(errorMessage);
+        assertWithMessage("Error message differs")
+            .that(error.getMessage())
+            .isEqualTo(getLocalizedMessage(
+                    "Checker.error", mock.getPath()));
     }
 
     /**
@@ -864,7 +847,7 @@ public class CheckerTest extends AbstractModuleTestSupport {
      *      for test does not require serialization
      */
     @Test
-    public void testCatchErrorWithNoFileName() throws Exception {
+    public void testCatchErrorWithNoFileName() {
         // Assume that I/O error is happened when we try to invoke 'lastModified()' method.
         final String errorMessage = "Java Virtual Machine is broken"
             + " or has run out of resources necessary for it to continue operating.";
@@ -894,28 +877,25 @@ public class CheckerTest extends AbstractModuleTestSupport {
         final Checker checker = new Checker();
         final List<File> filesToProcess = new ArrayList<>();
         filesToProcess.add(mock);
-        try {
-            checker.process(filesToProcess);
-            assertWithMessage("IOError is expected!").fail();
-        }
-        // -@cs[IllegalCatchExtended] Testing for catch Error is part of 100% coverage.
-        catch (Error error) {
-            assertWithMessage("Error cause differs from IOError")
-                    .that(error)
-                    .hasCauseThat()
-                    .isInstanceOf(IOError.class);
-            assertWithMessage("Error cause is not InternalError")
-                    .that(error)
-                    .hasCauseThat()
-                    .hasCauseThat()
-                    .isInstanceOf(InternalError.class);
-            assertWithMessage("Error message is not expected")
-                    .that(error)
-                    .hasCauseThat()
-                    .hasCauseThat()
-                    .hasMessageThat()
-                    .isEqualTo(errorMessage);
-        }
+        final Error error =
+                getExpectedThrowable(Error.class, () -> {
+                    checker.process(filesToProcess);
+                }, "IOError is expected!");
+        assertWithMessage("Error cause differs from IOError")
+            .that(error)
+            .hasCauseThat()
+            .isInstanceOf(IOError.class);
+        assertWithMessage("Error cause is not InternalError")
+            .that(error)
+            .hasCauseThat()
+            .hasCauseThat()
+            .isInstanceOf(InternalError.class);
+        assertWithMessage("Error message is not expected")
+            .that(error)
+            .hasCauseThat()
+            .hasCauseThat()
+            .hasMessageThat()
+            .isEqualTo(errorMessage);
     }
 
     /**
@@ -1091,15 +1071,13 @@ public class CheckerTest extends AbstractModuleTestSupport {
         final DefaultConfiguration checkConfig =
             createModuleConfig(CheckWhichThrowsError.class);
         final String filePath = getPath("InputChecker.java");
-        try {
-            execute(checkConfig, filePath);
-            assertWithMessage("Exception is expected").fail();
-        }
-        catch (CheckstyleException exc) {
-            assertWithMessage("Error message is not expected")
-                .that(exc.getMessage())
-                .isEqualTo("Exception was thrown while processing " + filePath);
-        }
+        final CheckstyleException exc =
+                getExpectedThrowable(CheckstyleException.class, () -> {
+                    execute(checkConfig, filePath);
+                }, "Exception is expected");
+        assertWithMessage("Error message is not expected")
+            .that(exc.getMessage())
+            .isEqualTo("Exception was thrown while processing " + filePath);
     }
 
     @Test
@@ -1121,30 +1099,28 @@ public class CheckerTest extends AbstractModuleTestSupport {
         final Checker checker = createChecker(checkerConfig);
 
         final String filePath = getPath("InputChecker.java");
-        try {
-            checker.process(Collections.singletonList(new File(filePath)));
-            assertWithMessage("Exception is expected").fail();
+        final CheckstyleException exc =
+                getExpectedThrowable(CheckstyleException.class, () -> {
+                    checker.process(Collections.singletonList(new File(filePath)));
+                }, "Exception is expected");
+        assertWithMessage("Error message is not expected")
+            .that(exc.getMessage())
+            .isEqualTo("Exception was thrown while processing " + filePath);
+
+        // destroy is called by Main
+        checker.destroy();
+
+        final Properties cache = new Properties();
+        try (BufferedReader reader = Files.newBufferedReader(cacheFile.toPath())) {
+            cache.load(reader);
         }
-        catch (CheckstyleException exc) {
-            assertWithMessage("Error message is not expected")
-                .that(exc.getMessage())
-                .isEqualTo("Exception was thrown while processing " + filePath);
 
-            // destroy is called by Main
-            checker.destroy();
-
-            final Properties cache = new Properties();
-            try (BufferedReader reader = Files.newBufferedReader(cacheFile.toPath())) {
-                cache.load(reader);
-            }
-
-            assertWithMessage("Cache has unexpected size")
-                .that(cache)
-                .hasSize(1);
-            assertWithMessage("testFile is not in cache")
-                .that(cache.getProperty(filePath))
-                .isNull();
-        }
+        assertWithMessage("Cache has unexpected size")
+            .that(cache)
+            .hasSize(1);
+        assertWithMessage("testFile is not in cache")
+            .that(cache.getProperty(filePath))
+            .isNull();
     }
 
     /**
@@ -1192,37 +1168,34 @@ public class CheckerTest extends AbstractModuleTestSupport {
         checker.configure(checkerConfig);
         final List<File> filesToProcess = new ArrayList<>();
         filesToProcess.add(mock);
-        try {
-            checker.process(filesToProcess);
-            assertWithMessage("IOError is expected!").fail();
+        final Error error =
+                getExpectedThrowable(Error.class, () -> {
+                    checker.process(filesToProcess);
+                }, "IOError is expected!");
+        assertWithMessage("Error cause differs from IOError")
+            .that(error.getCause())
+            .isInstanceOf(IOError.class);
+        assertWithMessage("Error message is not expected")
+            .that(error)
+            .hasCauseThat()
+            .hasCauseThat()
+            .hasMessageThat()
+            .isEqualTo(errorMessage);
+
+        // destroy is called by Main
+        checker.destroy();
+
+        final Properties cache = new Properties();
+        try (BufferedReader reader = Files.newBufferedReader(cacheFile.toPath())) {
+            cache.load(reader);
         }
-        // -@cs[IllegalCatchExtended] Testing for catch Error is part of 100% coverage.
-        catch (Error error) {
-            assertWithMessage("Error cause differs from IOError")
-                    .that(error.getCause())
-                    .isInstanceOf(IOError.class);
-            assertWithMessage("Error message is not expected")
-                    .that(error)
-                    .hasCauseThat()
-                    .hasCauseThat()
-                    .hasMessageThat()
-                    .isEqualTo(errorMessage);
 
-            // destroy is called by Main
-            checker.destroy();
-
-            final Properties cache = new Properties();
-            try (BufferedReader reader = Files.newBufferedReader(cacheFile.toPath())) {
-                cache.load(reader);
-            }
-
-            assertWithMessage("Cache has unexpected size")
-                    .that(cache)
-                    .hasSize(1);
-            assertWithMessage("testFile is not in cache")
-                .that(cache.getProperty("testFile"))
-                .isNull();
-        }
+        assertWithMessage("Cache has unexpected size")
+            .that(cache)
+            .hasSize(1);
+        assertWithMessage("testFile is not in cache")
+            .that(cache.getProperty("testFile"))
+            .isNull();
     }
 
     /**
@@ -1266,35 +1239,32 @@ public class CheckerTest extends AbstractModuleTestSupport {
         checker.configure(checkerConfig);
         final List<File> filesToProcess = new ArrayList<>();
         filesToProcess.add(mock);
-        try {
-            checker.process(filesToProcess);
-            assertWithMessage("IOError is expected!").fail();
+        final Error error =
+                getExpectedThrowable(Error.class, () -> {
+                    checker.process(filesToProcess);
+                }, "IOError is expected!");
+        assertWithMessage("Error cause differs from IOError")
+            .that(error)
+            .hasCauseThat()
+            .isInstanceOf(IOError.class);
+        assertWithMessage("Error message is not expected")
+            .that(error)
+            .hasCauseThat()
+            .hasCauseThat()
+            .hasMessageThat()
+            .isEqualTo(errorMessage);
+
+        // destroy is called by Main
+        checker.destroy();
+
+        final Properties cache = new Properties();
+        try (BufferedReader reader = Files.newBufferedReader(cacheFile.toPath())) {
+            cache.load(reader);
         }
-        // -@cs[IllegalCatchExtended] Testing for catch Error is part of 100% coverage.
-        catch (Error error) {
-            assertWithMessage("Error cause differs from IOError")
-                    .that(error)
-                    .hasCauseThat()
-                    .isInstanceOf(IOError.class);
-            assertWithMessage("Error message is not expected")
-                    .that(error)
-                    .hasCauseThat()
-                    .hasCauseThat()
-                    .hasMessageThat()
-                    .isEqualTo(errorMessage);
 
-            // destroy is called by Main
-            checker.destroy();
-
-            final Properties cache = new Properties();
-            try (BufferedReader reader = Files.newBufferedReader(cacheFile.toPath())) {
-                cache.load(reader);
-            }
-
-            assertWithMessage("Cache has unexpected size")
-                    .that(cache)
-                    .hasSize(1);
-        }
+        assertWithMessage("Cache has unexpected size")
+            .that(cache)
+            .hasSize(1);
     }
 
     /**
@@ -1329,21 +1299,19 @@ public class CheckerTest extends AbstractModuleTestSupport {
         final Checker checker = new Checker();
         final List<File> filesToProcess = new ArrayList<>();
         filesToProcess.add(mock);
-        try {
-            checker.process(filesToProcess);
-            assertWithMessage("SecurityException is expected!").fail();
-        }
-        catch (CheckstyleException exc) {
-            assertWithMessage("Error cause differs from SecurityException")
-                    .that(exc)
-                    .hasCauseThat()
-                    .isInstanceOf(SecurityException.class);
-            assertWithMessage("Error message is not expected")
-                    .that(exc)
-                    .hasCauseThat()
-                    .hasMessageThat()
-                    .isEqualTo(errorMessage);
-        }
+        final CheckstyleException exc =
+                getExpectedThrowable(CheckstyleException.class, () -> {
+                    checker.process(filesToProcess);
+                }, "SecurityException is expected!");
+        assertWithMessage("Error cause differs from SecurityException")
+            .that(exc)
+            .hasCauseThat()
+            .isInstanceOf(SecurityException.class);
+        assertWithMessage("Error message is not expected")
+            .that(exc)
+            .hasCauseThat()
+            .hasMessageThat()
+            .isEqualTo(errorMessage);
     }
 
     /**
@@ -1386,33 +1354,31 @@ public class CheckerTest extends AbstractModuleTestSupport {
         checker.configure(checkerConfig);
         final List<File> filesToProcess = new ArrayList<>();
         filesToProcess.add(mock);
-        try {
-            checker.process(filesToProcess);
-            assertWithMessage("SecurityException is expected!").fail();
+        final CheckstyleException exc =
+                getExpectedThrowable(CheckstyleException.class, () -> {
+                    checker.process(filesToProcess);
+                }, "SecurityException is expected!");
+        assertWithMessage("Error cause differs from SecurityException")
+            .that(exc)
+            .hasCauseThat()
+            .isInstanceOf(SecurityException.class);
+        assertWithMessage("Error message is not expected")
+            .that(exc)
+            .hasCauseThat()
+            .hasMessageThat()
+            .isEqualTo(errorMessage);
+
+        // destroy is called by Main
+        checker.destroy();
+
+        final Properties cache = new Properties();
+        try (BufferedReader reader = Files.newBufferedReader(cacheFile.toPath())) {
+            cache.load(reader);
         }
-        catch (CheckstyleException exc) {
-            assertWithMessage("Error cause differs from SecurityException")
-                    .that(exc)
-                    .hasCauseThat()
-                    .isInstanceOf(SecurityException.class);
-            assertWithMessage("Error message is not expected")
-                    .that(exc)
-                    .hasCauseThat()
-                    .hasMessageThat()
-                    .isEqualTo(errorMessage);
 
-            // destroy is called by Main
-            checker.destroy();
-
-            final Properties cache = new Properties();
-            try (BufferedReader reader = Files.newBufferedReader(cacheFile.toPath())) {
-                cache.load(reader);
-            }
-
-            assertWithMessage("Cache has unexpected size")
-                    .that(cache)
-                    .hasSize(1);
-        }
+        assertWithMessage("Cache has unexpected size")
+            .that(cache)
+            .hasSize(1);
     }
 
     @Test

--- a/src/test/java/com/puppycrawl/tools/checkstyle/ConfigurationLoaderTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/ConfigurationLoaderTest.java
@@ -20,6 +20,7 @@
 package com.puppycrawl.tools.checkstyle;
 
 import static com.google.common.truth.Truth.assertWithMessage;
+import static com.puppycrawl.tools.checkstyle.internal.utils.TestUtil.getExpectedThrowable;
 import static org.mockito.Mockito.mockConstruction;
 import static org.mockito.Mockito.when;
 
@@ -109,18 +110,16 @@ public class ConfigurationLoaderTest extends AbstractPathTestSupport {
         final Properties props = initProperties();
         final Object internalLoader = getInternalLoaderInstance(new PropertiesExpander(props));
 
-        try {
-            final String value = invokeReplacePropertiesMethod(internalLoader, "${a", null);
-            assertWithMessage("expected to fail, instead got: %s", value).fail();
-        }
-        catch (ReflectiveOperationException exc) {
-            assertWithMessage("Invalid exception cause message")
-                .that(exc.getCause())
-                .isInstanceOf(CheckstyleException.class);
-            assertWithMessage("Invalid exception message")
-                .that(exc.getCause().getMessage())
-                .isEqualTo("Syntax error in property: ${a");
-        }
+        final ReflectiveOperationException exc =
+                getExpectedThrowable(ReflectiveOperationException.class, () -> {
+                    invokeReplacePropertiesMethod(internalLoader, "${a", null);
+                }, "expected to fail");
+        assertWithMessage("Invalid exception cause message")
+            .that(exc.getCause())
+            .isInstanceOf(CheckstyleException.class);
+        assertWithMessage("Invalid exception message")
+            .that(exc.getCause().getMessage())
+            .isEqualTo("Syntax error in property: ${a");
     }
 
     @Test
@@ -128,18 +127,16 @@ public class ConfigurationLoaderTest extends AbstractPathTestSupport {
         final Properties props = initProperties();
         final Object internalLoader = getInternalLoaderInstance(new PropertiesExpander(props));
 
-        try {
-            final String value = invokeReplacePropertiesMethod(internalLoader, "${c}", null);
-            assertWithMessage("expected to fail, instead got: %s", value).fail();
-        }
-        catch (ReflectiveOperationException exc) {
-            assertWithMessage("Invalid exception cause message")
-                .that(exc.getCause())
-                .isInstanceOf(CheckstyleException.class);
-            assertWithMessage("Invalid exception message")
-                .that(exc.getCause().getMessage())
-                .isEqualTo("Property ${c} has not been set");
-        }
+        final ReflectiveOperationException exc =
+                getExpectedThrowable(ReflectiveOperationException.class, () -> {
+                    invokeReplacePropertiesMethod(internalLoader, "${c}", null);
+                }, "expected to fail");
+        assertWithMessage("Invalid exception cause message")
+            .that(exc.getCause())
+            .isInstanceOf(CheckstyleException.class);
+        assertWithMessage("Invalid exception message")
+            .that(exc.getCause().getMessage())
+            .isEqualTo("Property ${c} has not been set");
     }
 
     @Test
@@ -232,16 +229,14 @@ public class ConfigurationLoaderTest extends AbstractPathTestSupport {
         final ThreadModeSettings multiThreadModeSettings =
             new ThreadModeSettings(4, 2);
 
-        try {
-            ConfigurationLoader.loadConfiguration(
-                configPath, propertiesExpander, multiThreadModeSettings);
-            assertWithMessage("An exception is expected").fail();
-        }
-        catch (IllegalArgumentException exc) {
-            assertWithMessage("Invalid exception message")
-                .that(exc.getMessage())
-                .isEqualTo("Multi thread mode for Checker module is not implemented");
-        }
+        final IllegalArgumentException exc =
+                getExpectedThrowable(IllegalArgumentException.class, () -> {
+                    ConfigurationLoader.loadConfiguration(
+                        configPath, propertiesExpander, multiThreadModeSettings);
+                }, "An exception is expected");
+        assertWithMessage("Invalid exception message")
+            .that(exc.getMessage())
+            .isEqualTo("Multi thread mode for Checker module is not implemented");
     }
 
     @Test
@@ -280,101 +275,91 @@ public class ConfigurationLoaderTest extends AbstractPathTestSupport {
     }
 
     @Test
-    public void testMissingPropertyName() throws Exception {
-        try {
-            loadConfiguration("InputConfigurationLoaderMissingPropertyName.xml");
-            assertWithMessage("missing property name").fail();
-        }
-        catch (CheckstyleException exc) {
-            assertWithMessage("Invalid exception message: %s", exc.getMessage())
-                    .that(exc.getMessage())
-                    .contains("\"name\"");
-            assertWithMessage("Invalid exception message: %s", exc.getMessage())
-                    .that(exc.getMessage())
-                    .contains("\"property\"");
-            assertWithMessage("Invalid exception message: %s", exc.getMessage())
-                    .that(exc.getMessage())
-                    .endsWith(":8:41");
-        }
+    public void testMissingPropertyName() {
+        final CheckstyleException exc =
+                getExpectedThrowable(CheckstyleException.class, () -> {
+                    loadConfiguration("InputConfigurationLoaderMissingPropertyName.xml");
+                }, "missing property name");
+        assertWithMessage("Invalid exception message: %s", exc.getMessage())
+            .that(exc.getMessage())
+            .contains("\"name\"");
+        assertWithMessage("Invalid exception message: %s", exc.getMessage())
+            .that(exc.getMessage())
+            .contains("\"property\"");
+        assertWithMessage("Invalid exception message: %s", exc.getMessage())
+            .that(exc.getMessage())
+            .endsWith(":8:41");
     }
 
     @Test
     public void testMissingPropertyNameInMethodWithBooleanParameter() throws Exception {
-        try {
-            final String fName = getPath("InputConfigurationLoaderMissingPropertyName.xml");
-            ConfigurationLoader.loadConfiguration(fName, new PropertiesExpander(new Properties()),
-                    IgnoredModulesOptions.EXECUTE);
-
-            assertWithMessage("missing property name").fail();
-        }
-        catch (CheckstyleException exc) {
-            assertWithMessage("Invalid exception message: %s", exc.getMessage())
-                    .that(exc.getMessage())
-                    .contains("\"name\"");
-            assertWithMessage("Invalid exception message: %s", exc.getMessage())
-                    .that(exc.getMessage())
-                    .contains("\"property\"");
-            assertWithMessage("Invalid exception message: %s", exc.getMessage())
-                    .that(exc.getMessage())
-                    .endsWith(":8:41");
-        }
+        final String fName = getPath("InputConfigurationLoaderMissingPropertyName.xml");
+        final CheckstyleException exc =
+                getExpectedThrowable(CheckstyleException.class, () -> {
+                    ConfigurationLoader.loadConfiguration(fName,
+                            new PropertiesExpander(new Properties()),
+                            IgnoredModulesOptions.EXECUTE);
+                }, "missing property name");
+        assertWithMessage("Invalid exception message: %s", exc.getMessage())
+            .that(exc.getMessage())
+            .contains("\"name\"");
+        assertWithMessage("Invalid exception message: %s", exc.getMessage())
+            .that(exc.getMessage())
+            .contains("\"property\"");
+        assertWithMessage("Invalid exception message: %s", exc.getMessage())
+            .that(exc.getMessage())
+            .endsWith(":8:41");
     }
 
     @Test
-    public void testMissingPropertyValue() throws Exception {
-        try {
-            loadConfiguration("InputConfigurationLoaderMissingPropertyValue.xml");
-            assertWithMessage("missing property value").fail();
-        }
-        catch (CheckstyleException exc) {
-            assertWithMessage("Invalid exception message: %s", exc.getMessage())
-                    .that(exc.getMessage())
-                    .contains("\"value\"");
-            assertWithMessage("Invalid exception message: %s", exc.getMessage())
-                    .that(exc.getMessage())
-                    .contains("\"property\"");
-            assertWithMessage("Invalid exception message: %s", exc.getMessage())
-                    .that(exc.getMessage())
-                    .endsWith(":8:43");
-        }
+    public void testMissingPropertyValue() {
+        final CheckstyleException exc =
+                getExpectedThrowable(CheckstyleException.class, () -> {
+                    loadConfiguration("InputConfigurationLoaderMissingPropertyValue.xml");
+                }, "missing property value");
+        assertWithMessage("Invalid exception message: %s", exc.getMessage())
+            .that(exc.getMessage())
+            .contains("\"value\"");
+        assertWithMessage("Invalid exception message: %s", exc.getMessage())
+            .that(exc.getMessage())
+            .contains("\"property\"");
+        assertWithMessage("Invalid exception message: %s", exc.getMessage())
+            .that(exc.getMessage())
+            .endsWith(":8:43");
     }
 
     @Test
-    public void testMissingConfigName() throws Exception {
-        try {
-            loadConfiguration("InputConfigurationLoaderMissingConfigName.xml");
-            assertWithMessage("missing module name").fail();
-        }
-        catch (CheckstyleException exc) {
-            assertWithMessage("Invalid exception message: %s", exc.getMessage())
-                    .that(exc.getMessage())
-                    .contains("\"name\"");
-            assertWithMessage("Invalid exception message: %s", exc.getMessage())
-                    .that(exc.getMessage())
-                    .contains("\"module\"");
-            assertWithMessage("Invalid exception message: %s", exc.getMessage())
-                    .that(exc.getMessage())
-                    .endsWith(":7:23");
-        }
+    public void testMissingConfigName() {
+        final CheckstyleException exc =
+                getExpectedThrowable(CheckstyleException.class, () -> {
+                    loadConfiguration("InputConfigurationLoaderMissingConfigName.xml");
+                }, "missing module name");
+        assertWithMessage("Invalid exception message: %s", exc.getMessage())
+            .that(exc.getMessage())
+            .contains("\"name\"");
+        assertWithMessage("Invalid exception message: %s", exc.getMessage())
+            .that(exc.getMessage())
+            .contains("\"module\"");
+        assertWithMessage("Invalid exception message: %s", exc.getMessage())
+            .that(exc.getMessage())
+            .endsWith(":7:23");
     }
 
     @Test
-    public void testMissingConfigParent() throws Exception {
-        try {
-            loadConfiguration("InputConfigurationLoaderMissingConfigParent.xml");
-            assertWithMessage("missing module parent").fail();
-        }
-        catch (CheckstyleException exc) {
-            assertWithMessage("Invalid exception message: %s", exc.getMessage())
-                    .that(exc.getMessage())
-                    .contains("\"property\"");
-            assertWithMessage("Invalid exception message: %s", exc.getMessage())
-                    .that(exc.getMessage())
-                    .contains("\"module\"");
-            assertWithMessage("Invalid exception message: %s", exc.getMessage())
-                    .that(exc.getMessage())
-                    .endsWith(":8:38");
-        }
+    public void testMissingConfigParent() {
+        final CheckstyleException exc =
+                getExpectedThrowable(CheckstyleException.class, () -> {
+                    loadConfiguration("InputConfigurationLoaderMissingConfigParent.xml");
+                }, "missing module parent");
+        assertWithMessage("Invalid exception message: %s", exc.getMessage())
+            .that(exc.getMessage())
+            .contains("\"property\"");
+        assertWithMessage("Invalid exception message: %s", exc.getMessage())
+            .that(exc.getMessage())
+            .contains("\"module\"");
+        assertWithMessage("Invalid exception message: %s", exc.getMessage())
+            .that(exc.getMessage())
+            .endsWith(":8:38");
     }
 
     @Test
@@ -556,43 +541,38 @@ public class ConfigurationLoaderTest extends AbstractPathTestSupport {
                 + "ConfigurationLoader$InternalLoader");
         final Object obj = TestUtil.instantiate(aClass, objParent);
 
-        try {
-            TestUtil.invokeVoidMethod(obj, "startElement", "", "", "hello", null);
-
-            assertWithMessage("InvocationTargetException is expected").fail();
-        }
-        catch (ReflectiveOperationException exc) {
-            assertWithMessage("Invalid exception cause message")
-                .that(exc)
-                    .hasCauseThat()
-                        .hasMessageThat()
-                        .isEqualTo("Unknown name:" + "hello" + ".");
-        }
+        final ReflectiveOperationException exc =
+                getExpectedThrowable(ReflectiveOperationException.class, () -> {
+                    TestUtil.invokeVoidMethod(obj, "startElement", "", "", "hello", null);
+                }, "InvocationTargetException is expected");
+        assertWithMessage("Invalid exception cause message")
+            .that(exc)
+            .hasCauseThat()
+            .hasMessageThat()
+            .isEqualTo("Unknown name:" + "hello" + ".");
     }
 
     @Test
-    public void testNonExistentPropertyName() throws Exception {
-        try {
-            loadConfiguration("InputConfigurationLoaderNonexistentProperty.xml");
-            assertWithMessage("exception in expected").fail();
-        }
-        catch (CheckstyleException exc) {
-            assertWithMessage("Invalid exception message")
-                .that(exc.getMessage())
-                .isEqualTo("unable to parse configuration stream");
-            assertWithMessage("Expected cause of type SAXException")
-                .that(exc.getCause())
-                .isInstanceOf(SAXException.class);
-            assertWithMessage("Expected cause of type CheckstyleException")
-                .that(exc.getCause().getCause())
-                .isInstanceOf(CheckstyleException.class);
-            assertWithMessage("Invalid exception cause message")
-                .that(exc)
-                .hasCauseThat()
-                .hasCauseThat()
-                .hasMessageThat()
-                .isEqualTo("Property ${nonexistent} has not been set");
-        }
+    public void testNonExistentPropertyName() {
+        final CheckstyleException exc =
+                getExpectedThrowable(CheckstyleException.class, () -> {
+                    loadConfiguration("InputConfigurationLoaderNonexistentProperty.xml");
+                }, "exception in expected");
+        assertWithMessage("Invalid exception message")
+            .that(exc.getMessage())
+            .isEqualTo("unable to parse configuration stream");
+        assertWithMessage("Expected cause of type SAXException")
+            .that(exc.getCause())
+            .isInstanceOf(SAXException.class);
+        assertWithMessage("Expected cause of type CheckstyleException")
+            .that(exc.getCause().getCause())
+            .isInstanceOf(CheckstyleException.class);
+        assertWithMessage("Invalid exception cause message")
+            .that(exc)
+            .hasCauseThat()
+            .hasCauseThat()
+            .hasMessageThat()
+            .isEqualTo("Property ${nonexistent} has not been set");
     }
 
     @Test
@@ -639,18 +619,16 @@ public class ConfigurationLoaderTest extends AbstractPathTestSupport {
 
     @Test
     public void testLoadConfigurationWrongUrl() {
-        try {
-            ConfigurationLoader.loadConfiguration(
-                    ";InputConfigurationLoaderModuleIgnoreSeverity.xml",
-                    new PropertiesExpander(new Properties()), IgnoredModulesOptions.OMIT);
-
-            assertWithMessage("Exception is expected").fail();
-        }
-        catch (CheckstyleException exc) {
-            assertWithMessage("Invalid exception message")
-                .that(exc.getMessage())
-                .isEqualTo("Unable to find: ;InputConfigurationLoaderModuleIgnoreSeverity.xml");
-        }
+        final CheckstyleException exc =
+                getExpectedThrowable(CheckstyleException.class, () -> {
+                    ConfigurationLoader.loadConfiguration(
+                            ";InputConfigurationLoaderModuleIgnoreSeverity.xml",
+                            new PropertiesExpander(new Properties()),
+                            IgnoredModulesOptions.OMIT);
+                }, "Exception is expected");
+        assertWithMessage("Invalid exception message")
+            .that(exc.getMessage())
+            .isEqualTo("Unable to find: ;InputConfigurationLoaderModuleIgnoreSeverity.xml");
     }
 
     @Test
@@ -732,7 +710,7 @@ public class ConfigurationLoaderTest extends AbstractPathTestSupport {
                     when(mock.getProperty("severity")).thenThrow(CheckstyleException.class);
                 })) {
             final CheckstyleException ex =
-                    TestUtil.getExpectedThrowable(CheckstyleException.class, () -> {
+                    getExpectedThrowable(CheckstyleException.class, () -> {
                         ConfigurationLoader.loadConfiguration(
                                 getPath("InputConfigurationLoaderModuleIgnoreSeverity.xml"),
                                 new PropertiesExpander(

--- a/src/test/java/com/puppycrawl/tools/checkstyle/JavadocPropertiesGeneratorTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/JavadocPropertiesGeneratorTest.java
@@ -20,6 +20,7 @@
 package com.puppycrawl.tools.checkstyle;
 
 import static com.google.common.truth.Truth.assertWithMessage;
+import static com.puppycrawl.tools.checkstyle.internal.utils.TestUtil.getExpectedThrowable;
 
 import java.io.File;
 import java.io.FileNotFoundException;
@@ -164,26 +165,23 @@ public class JavadocPropertiesGeneratorTest extends AbstractPathTestSupport {
     @Test
     public void testNotExistentInputSpecified(@SysErr Capturable systemErr,
             @SysOut Capturable systemOut) {
-        try {
-            JavadocPropertiesGenerator.main(
-                "--destfile", DESTFILE_ABSOLUTE_PATH, "NotExistent.java");
-            assertWithMessage("Exception was expected").fail();
-        }
-        catch (CheckstyleException exc) {
-            assertWithMessage("Invalid error message")
-                .that(exc.getMessage())
-                .isEqualTo("Failed to write javadoc properties of 'NotExistent.java' to '"
-                    + DESTFILE_ABSOLUTE_PATH + "'");
-
-            final Throwable cause = exc.getCause();
-            assertWithMessage("Invalid error message")
-                    .that(cause)
-                    .isInstanceOf(FileNotFoundException.class);
-            assertWithMessage("Invalid error message")
-                    .that(cause)
-                    .hasMessageThat()
-                    .contains("NotExistent.java");
-        }
+        final CheckstyleException exc =
+                getExpectedThrowable(CheckstyleException.class, () -> {
+                    JavadocPropertiesGenerator.main(
+                        "--destfile", DESTFILE_ABSOLUTE_PATH, "NotExistent.java");
+                }, "Exception was expected");
+        assertWithMessage("Invalid error message")
+            .that(exc.getMessage())
+            .isEqualTo("Failed to write javadoc properties of 'NotExistent.java' to '"
+                + DESTFILE_ABSOLUTE_PATH + "'");
+        final Throwable cause = exc.getCause();
+        assertWithMessage("Invalid error message")
+            .that(cause)
+            .isInstanceOf(FileNotFoundException.class);
+        assertWithMessage("Invalid error message")
+            .that(cause)
+            .hasMessageThat()
+            .contains("NotExistent.java");
         assertWithMessage("Unexpected error log")
             .that(systemErr.getCapturedData())
             .isEqualTo("");
@@ -195,28 +193,25 @@ public class JavadocPropertiesGeneratorTest extends AbstractPathTestSupport {
     @Test
     public void testInvalidDestinationSpecified(@SysErr Capturable systemErr,
             @SysOut Capturable systemOut) throws Exception {
-        try {
-            // Passing a folder name will cause the FileNotFoundException.
-            JavadocPropertiesGenerator.main("--destfile", "..",
-                getPath("InputJavadocPropertiesGeneratorCorrect.java"));
-            assertWithMessage("Exception was expected").fail();
-        }
-        catch (CheckstyleException exc) {
-            final String expectedError = "Failed to write javadoc properties of '"
-                + getPath("InputJavadocPropertiesGeneratorCorrect.java") + "' to '..'";
-            assertWithMessage("Invalid error message")
-                .that(exc.getMessage())
-                .isEqualTo(expectedError);
-
-            final Throwable cause = exc.getCause();
-            assertWithMessage("Invalid error message")
-                    .that(cause)
-                    .isInstanceOf(FileNotFoundException.class);
-            assertWithMessage("Invalid error message")
-                    .that(cause)
-                    .hasMessageThat()
-                    .contains("..");
-        }
+        // Passing a folder name will cause the FileNotFoundException.
+        final CheckstyleException exc =
+                getExpectedThrowable(CheckstyleException.class, () -> {
+                    JavadocPropertiesGenerator.main("--destfile", "..",
+                        getPath("InputJavadocPropertiesGeneratorCorrect.java"));
+                }, "Exception was expected");
+        final String expectedError = "Failed to write javadoc properties of '"
+            + getPath("InputJavadocPropertiesGeneratorCorrect.java") + "' to '..'";
+        assertWithMessage("Invalid error message")
+            .that(exc.getMessage())
+            .isEqualTo(expectedError);
+        final Throwable cause = exc.getCause();
+        assertWithMessage("Invalid error message")
+            .that(cause)
+            .isInstanceOf(FileNotFoundException.class);
+        assertWithMessage("Invalid error message")
+            .that(cause)
+            .hasMessageThat()
+            .contains("..");
         assertWithMessage("Unexpected error log")
             .that(systemErr.getCapturedData())
             .isEqualTo("");
@@ -300,15 +295,13 @@ public class JavadocPropertiesGeneratorTest extends AbstractPathTestSupport {
     @Test
     public void testJavadocParseError() throws Exception {
         final String path = getPath("InputJavadocPropertiesGeneratorJavadocParseError.java");
-        try {
-            JavadocPropertiesGenerator.main(path, "--destfile", DESTFILE_ABSOLUTE_PATH);
-            assertWithMessage("Exception was expected").fail();
-        }
-        catch (IllegalArgumentException exc) {
-            assertWithMessage("Invalid error message")
-                    .that(exc.getMessage())
-                    .contains("mismatched input '<EOF>' expecting JAVADOC_INLINE_TAG_END");
-        }
+        final IllegalArgumentException exc =
+                getExpectedThrowable(IllegalArgumentException.class, () -> {
+                    JavadocPropertiesGenerator.main(path, "--destfile", DESTFILE_ABSOLUTE_PATH);
+                }, "Exception was expected");
+        assertWithMessage("Invalid error message")
+            .that(exc.getMessage())
+            .contains("mismatched input '<EOF>' expecting JAVADOC_INLINE_TAG_END");
         final long size = FileUtils.sizeOf(DESTFILE);
         assertWithMessage("File '%s' must be empty", DESTFILE)
             .that(size)
@@ -318,15 +311,13 @@ public class JavadocPropertiesGeneratorTest extends AbstractPathTestSupport {
     @Test
     public void testNotImplementedTag() throws Exception {
         final String path = getPath("InputJavadocPropertiesGeneratorNotImplementedTag.java");
-        try {
-            JavadocPropertiesGenerator.main(path, "--destfile", DESTFILE_ABSOLUTE_PATH);
-            assertWithMessage("Exception was expected").fail();
-        }
-        catch (CheckstyleException exc) {
-            assertWithMessage("Invalid error message")
-                .that(exc.getMessage())
-                .isEqualTo("Unsupported inline tag LINK_INLINE_TAG");
-        }
+        final CheckstyleException exc =
+                getExpectedThrowable(CheckstyleException.class, () -> {
+                    JavadocPropertiesGenerator.main(path, "--destfile", DESTFILE_ABSOLUTE_PATH);
+                }, "Exception was expected");
+        assertWithMessage("Invalid error message")
+            .that(exc.getMessage())
+            .isEqualTo("Unsupported inline tag LINK_INLINE_TAG");
         final long size = FileUtils.sizeOf(DESTFILE);
         assertWithMessage("File '%s' must be empty", DESTFILE)
             .that(size)
@@ -336,15 +327,13 @@ public class JavadocPropertiesGeneratorTest extends AbstractPathTestSupport {
     @Test
     public void testInvalidTokensInsideTag() throws Exception {
         final String path = getPath("InputJavadocPropertiesGeneratorInvalidTokensInsideTag.java");
-        try {
-            JavadocPropertiesGenerator.main(path, "--destfile", DESTFILE_ABSOLUTE_PATH);
-            assertWithMessage("Exception was expected").fail();
-        }
-        catch (CheckstyleException exc) {
-            assertWithMessage("Invalid error message")
-                .that(exc.getMessage())
-                .isEqualTo("Unsupported child in the inline tag NEWLINE");
-        }
+        final CheckstyleException exc =
+                getExpectedThrowable(CheckstyleException.class, () -> {
+                    JavadocPropertiesGenerator.main(path, "--destfile", DESTFILE_ABSOLUTE_PATH);
+                }, "Exception was expected");
+        assertWithMessage("Invalid error message")
+            .that(exc.getMessage())
+            .isEqualTo("Unsupported child in the inline tag NEWLINE");
         final long size = FileUtils.sizeOf(DESTFILE);
         assertWithMessage("File '%s' must be empty", DESTFILE)
             .that(size)
@@ -354,24 +343,21 @@ public class JavadocPropertiesGeneratorTest extends AbstractPathTestSupport {
     @Test
     public void testParseError() throws Exception {
         final String path = getNonCompilablePath("InputJavadocPropertiesGeneratorParseError.java");
-        try {
-            JavadocPropertiesGenerator.main(path, "--destfile", DESTFILE_ABSOLUTE_PATH);
-            assertWithMessage("Exception was expected").fail();
-        }
-        catch (CheckstyleException exc) {
-            assertWithMessage("Invalid error message")
-                    .that(exc.getMessage())
-                    .contains("InputJavadocPropertiesGeneratorParseError.java");
-
-            final Throwable cause = exc.getCause();
-            assertWithMessage("Invalid error message")
-                    .that(cause)
-                    .isInstanceOf(IllegalStateException.class);
-            assertWithMessage("Invalid error message")
-                    .that(cause)
-                    .hasMessageThat()
-                    .contains("9:0: mismatched input '!' expecting '}'");
-        }
+        final CheckstyleException exc =
+                getExpectedThrowable(CheckstyleException.class, () -> {
+                    JavadocPropertiesGenerator.main(path, "--destfile", DESTFILE_ABSOLUTE_PATH);
+                }, "Exception was expected");
+        assertWithMessage("Invalid error message")
+            .that(exc.getMessage())
+            .contains("InputJavadocPropertiesGeneratorParseError.java");
+        final Throwable cause = exc.getCause();
+        assertWithMessage("Invalid error message")
+            .that(cause)
+            .isInstanceOf(IllegalStateException.class);
+        assertWithMessage("Invalid error message")
+            .that(cause)
+            .hasMessageThat()
+            .contains("9:0: mismatched input '!' expecting '}'");
     }
 
     @Test

--- a/src/test/java/com/puppycrawl/tools/checkstyle/PackageObjectFactoryTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/PackageObjectFactoryTest.java
@@ -30,6 +30,7 @@ import static com.puppycrawl.tools.checkstyle.PackageObjectFactory.NULL_PACKAGE_
 import static com.puppycrawl.tools.checkstyle.PackageObjectFactory.PACKAGE_SEPARATOR;
 import static com.puppycrawl.tools.checkstyle.PackageObjectFactory.STRING_SEPARATOR;
 import static com.puppycrawl.tools.checkstyle.PackageObjectFactory.UNABLE_TO_INSTANTIATE_EXCEPTION_MESSAGE;
+import static com.puppycrawl.tools.checkstyle.internal.utils.TestUtil.getExpectedThrowable;
 import static org.mockito.Mockito.mockStatic;
 
 import java.io.File;
@@ -82,71 +83,70 @@ public class PackageObjectFactoryTest {
 
     @Test
     public void testCtorNullLoaderException1() {
-        try {
-            final Object test = new PackageObjectFactory(new HashSet<>(), null);
-            assertWithMessage("Exception is expected but got %s", test).fail();
-        }
-        catch (IllegalArgumentException exc) {
-            assertWithMessage("Invalid exception message")
-                .that(exc.getMessage())
-                .isEqualTo(NULL_LOADER_MESSAGE);
-        }
+        final IllegalArgumentException exc =
+                getExpectedThrowable(IllegalArgumentException.class, () -> {
+                    final Object test =
+                            new PackageObjectFactory(new HashSet<>(), null);
+                    assertWithMessage("Exception is expected but got %s", test).fail();
+                });
+        assertWithMessage("Invalid exception message")
+            .that(exc.getMessage())
+            .isEqualTo(NULL_LOADER_MESSAGE);
     }
 
     @Test
     public void testCtorNullLoaderException2() {
-        try {
-            final Object test = new PackageObjectFactory("test", null);
-            assertWithMessage("Exception is expected but got %s", test).fail();
-        }
-        catch (IllegalArgumentException exc) {
-            assertWithMessage("Invalid exception message")
-                .that(exc.getMessage())
-                .isEqualTo(NULL_LOADER_MESSAGE);
-        }
+        final IllegalArgumentException exc =
+                getExpectedThrowable(IllegalArgumentException.class, () -> {
+                    final Object test = new PackageObjectFactory("test", null);
+                    assertWithMessage("Exception is expected but got %s", test).fail();
+                });
+        assertWithMessage("Invalid exception message")
+            .that(exc.getMessage())
+            .isEqualTo(NULL_LOADER_MESSAGE);
     }
 
     @Test
     public void testCtorNullPackageException1() {
         final ClassLoader classLoader = Thread.currentThread().getContextClassLoader();
-        try {
-            final Object test = new PackageObjectFactory(Collections.singleton(null), classLoader);
-            assertWithMessage("Exception is expected but got %s", test).fail();
-        }
-        catch (IllegalArgumentException exc) {
-            assertWithMessage("Invalid exception message")
-                .that(exc.getMessage())
-                .isEqualTo(NULL_PACKAGE_MESSAGE);
-        }
+        final IllegalArgumentException exc =
+                getExpectedThrowable(IllegalArgumentException.class, () -> {
+                    final Object test =
+                            new PackageObjectFactory(Collections.singleton(null), classLoader);
+                    assertWithMessage("Exception is expected but got %s", test).fail();
+                });
+        assertWithMessage("Invalid exception message")
+            .that(exc.getMessage())
+            .isEqualTo(NULL_PACKAGE_MESSAGE);
     }
 
     @Test
     public void testCtorNullPackageException2() {
         final ClassLoader classLoader = Thread.currentThread().getContextClassLoader();
-        try {
-            final Object test = new PackageObjectFactory((String) null, classLoader);
-            assertWithMessage("Exception is expected but got %s", test).fail();
-        }
-        catch (IllegalArgumentException exc) {
-            assertWithMessage("Invalid exception message")
-                .that(exc.getMessage())
-                .isEqualTo(NULL_PACKAGE_MESSAGE);
-        }
+        final IllegalArgumentException exc =
+                getExpectedThrowable(IllegalArgumentException.class, () -> {
+                    final Object test =
+                            new PackageObjectFactory((String) null, classLoader);
+                    assertWithMessage("Exception is expected but got %s", test).fail();
+                });
+        assertWithMessage("Invalid exception message")
+            .that(exc.getMessage())
+            .isEqualTo(NULL_PACKAGE_MESSAGE);
     }
 
     @Test
     public void testCtorNullPackageException3() {
         final ClassLoader classLoader = Thread.currentThread().getContextClassLoader();
-        try {
-            final Object test = new PackageObjectFactory(Collections.singleton(null), classLoader,
-                    TRY_IN_ALL_REGISTERED_PACKAGES);
-            assertWithMessage("Exception is expected but got %s", test).fail();
-        }
-        catch (IllegalArgumentException exc) {
-            assertWithMessage("Invalid exception message")
-                .that(exc.getMessage())
-                .isEqualTo(NULL_PACKAGE_MESSAGE);
-        }
+        final IllegalArgumentException exc =
+                getExpectedThrowable(IllegalArgumentException.class, () -> {
+                    final Object test =
+                            new PackageObjectFactory(Collections.singleton(null), classLoader,
+                                    TRY_IN_ALL_REGISTERED_PACKAGES);
+                    assertWithMessage("Exception is expected but got %s", test).fail();
+                });
+        assertWithMessage("Invalid exception message")
+            .that(exc.getMessage())
+            .isEqualTo(NULL_PACKAGE_MESSAGE);
     }
 
     @Test
@@ -163,39 +163,35 @@ public class PackageObjectFactoryTest {
     @Test
     public void testMakeCheckFromName() {
         final String name = "com.puppycrawl.tools.checkstyle.checks.naming.ConstantName";
-        try {
-            factory.createModule(name);
-            assertWithMessage("Exception is expected").fail();
-        }
-        catch (CheckstyleException exc) {
-            final LocalizedMessage exceptionMessage = new LocalizedMessage(
-                    Definitions.CHECKSTYLE_BUNDLE, factory.getClass(),
-                    UNABLE_TO_INSTANTIATE_EXCEPTION_MESSAGE, name, null);
-            assertWithMessage("Invalid exception message")
-                .that(exc.getMessage())
-                .isEqualTo(exceptionMessage.getMessage());
-        }
+        final CheckstyleException exc =
+                getExpectedThrowable(CheckstyleException.class, () -> {
+                    factory.createModule(name);
+                }, "Exception is expected");
+        final LocalizedMessage exceptionMessage = new LocalizedMessage(
+                Definitions.CHECKSTYLE_BUNDLE, factory.getClass(),
+                UNABLE_TO_INSTANTIATE_EXCEPTION_MESSAGE, name, null);
+        assertWithMessage("Invalid exception message")
+            .that(exc.getMessage())
+            .isEqualTo(exceptionMessage.getMessage());
     }
 
     @Test
     public void testCreateModuleWithNonExistName() {
         final String[] names = {"NonExistClassOne", "NonExistClassTwo", };
         for (String name : names) {
-            try {
-                factory.createModule(name);
-                assertWithMessage("Exception is expected").fail();
-            }
-            catch (CheckstyleException exc) {
-                final String attemptedNames = BASE_PACKAGE + PACKAGE_SEPARATOR + name
-                    + STRING_SEPARATOR + name + CHECK_SUFFIX + STRING_SEPARATOR
-                    + BASE_PACKAGE + PACKAGE_SEPARATOR + name + CHECK_SUFFIX;
-                final LocalizedMessage exceptionMessage = new LocalizedMessage(
-                    Definitions.CHECKSTYLE_BUNDLE, factory.getClass(),
-                    UNABLE_TO_INSTANTIATE_EXCEPTION_MESSAGE, name, attemptedNames);
-                assertWithMessage("Invalid exception message")
-                    .that(exc.getMessage())
-                    .isEqualTo(exceptionMessage.getMessage());
-            }
+            final CheckstyleException exc =
+                    getExpectedThrowable(CheckstyleException.class, () -> {
+                        factory.createModule(name);
+                    }, "Exception is expected");
+            final String attemptedNames = BASE_PACKAGE + PACKAGE_SEPARATOR + name
+                + STRING_SEPARATOR + name + CHECK_SUFFIX + STRING_SEPARATOR
+                + BASE_PACKAGE + PACKAGE_SEPARATOR + name + CHECK_SUFFIX;
+            final LocalizedMessage exceptionMessage = new LocalizedMessage(
+                Definitions.CHECKSTYLE_BUNDLE, factory.getClass(),
+                UNABLE_TO_INSTANTIATE_EXCEPTION_MESSAGE, name, attemptedNames);
+            assertWithMessage("Invalid exception message")
+                .that(exc.getMessage())
+                .isEqualTo(exceptionMessage.getMessage());
         }
     }
 
@@ -255,20 +251,18 @@ public class PackageObjectFactoryTest {
         final PackageObjectFactory objectFactory = new PackageObjectFactory(
                 new LinkedHashSet<>(Arrays.asList(barPackage, fooPackage)), classLoader);
         final String name = "FooCheck";
-        try {
-            objectFactory.createModule(name);
-            assertWithMessage("Exception is expected").fail();
-        }
-        catch (CheckstyleException exc) {
-            final String optionalNames = barPackage + PACKAGE_SEPARATOR + name
-                    + STRING_SEPARATOR + fooPackage + PACKAGE_SEPARATOR + name;
-            final LocalizedMessage exceptionMessage = new LocalizedMessage(
-                    Definitions.CHECKSTYLE_BUNDLE, getClass(),
-                    AMBIGUOUS_MODULE_NAME_EXCEPTION_MESSAGE, name, optionalNames);
-            assertWithMessage("Invalid exception message")
-                .that(exc.getMessage())
-                .isEqualTo(exceptionMessage.getMessage());
-        }
+        final CheckstyleException exc =
+                getExpectedThrowable(CheckstyleException.class, () -> {
+                    objectFactory.createModule(name);
+                }, "Exception is expected");
+        final String optionalNames = barPackage + PACKAGE_SEPARATOR + name
+                + STRING_SEPARATOR + fooPackage + PACKAGE_SEPARATOR + name;
+        final LocalizedMessage exceptionMessage = new LocalizedMessage(
+                Definitions.CHECKSTYLE_BUNDLE, getClass(),
+                AMBIGUOUS_MODULE_NAME_EXCEPTION_MESSAGE, name, optionalNames);
+        assertWithMessage("Invalid exception message")
+            .that(exc.getMessage())
+            .isEqualTo(exceptionMessage.getMessage());
     }
 
     @Test
@@ -280,23 +274,21 @@ public class PackageObjectFactoryTest {
                 new LinkedHashSet<>(Arrays.asList(package1, package2)), classLoader);
         final String name = "FooCheck";
         final String checkName = name + CHECK_SUFFIX;
-        try {
-            objectFactory.createModule(name);
-            assertWithMessage("Exception is expected").fail();
-        }
-        catch (CheckstyleException exc) {
-            final String attemptedNames = package1 + PACKAGE_SEPARATOR + name + STRING_SEPARATOR
-                    + package2 + PACKAGE_SEPARATOR + name + STRING_SEPARATOR
-                    + checkName + STRING_SEPARATOR
-                    + package1 + PACKAGE_SEPARATOR + checkName + STRING_SEPARATOR
-                    + package2 + PACKAGE_SEPARATOR + checkName;
-            final LocalizedMessage exceptionMessage = new LocalizedMessage(
-                    Definitions.CHECKSTYLE_BUNDLE, getClass(),
-                    UNABLE_TO_INSTANTIATE_EXCEPTION_MESSAGE, name, attemptedNames);
-            assertWithMessage("Invalid exception message")
-                .that(exc.getMessage())
-                .isEqualTo(exceptionMessage.getMessage());
-        }
+        final CheckstyleException exc =
+                getExpectedThrowable(CheckstyleException.class, () -> {
+                    objectFactory.createModule(name);
+                }, "Exception is expected");
+        final String attemptedNames = package1 + PACKAGE_SEPARATOR + name + STRING_SEPARATOR
+                + package2 + PACKAGE_SEPARATOR + name + STRING_SEPARATOR
+                + checkName + STRING_SEPARATOR
+                + package1 + PACKAGE_SEPARATOR + checkName + STRING_SEPARATOR
+                + package2 + PACKAGE_SEPARATOR + checkName;
+        final LocalizedMessage exceptionMessage = new LocalizedMessage(
+                Definitions.CHECKSTYLE_BUNDLE, getClass(),
+                UNABLE_TO_INSTANTIATE_EXCEPTION_MESSAGE, name, attemptedNames);
+        assertWithMessage("Invalid exception message")
+            .that(exc.getMessage())
+            .isEqualTo(exceptionMessage.getMessage());
     }
 
     @Test
@@ -309,23 +301,21 @@ public class PackageObjectFactoryTest {
                 TRY_IN_ALL_REGISTERED_PACKAGES);
         final String name = "FooCheck";
         final String checkName = name + CHECK_SUFFIX;
-        try {
-            objectFactory.createModule(name);
-            assertWithMessage("Exception is expected").fail();
-        }
-        catch (CheckstyleException exc) {
-            final String attemptedNames = package1 + PACKAGE_SEPARATOR + name + STRING_SEPARATOR
-                    + package2 + PACKAGE_SEPARATOR + name + STRING_SEPARATOR
-                    + checkName + STRING_SEPARATOR
-                    + package1 + PACKAGE_SEPARATOR + checkName + STRING_SEPARATOR
-                    + package2 + PACKAGE_SEPARATOR + checkName;
-            final Violation exceptionMessage = new Violation(1,
-                    Definitions.CHECKSTYLE_BUNDLE, UNABLE_TO_INSTANTIATE_EXCEPTION_MESSAGE,
-                    new String[] {name, attemptedNames}, null, getClass(), null);
-            assertWithMessage("Invalid exception message")
-                .that(exc.getMessage())
-                .isEqualTo(exceptionMessage.getViolation());
-        }
+        final CheckstyleException exc =
+                getExpectedThrowable(CheckstyleException.class, () -> {
+                    objectFactory.createModule(name);
+                }, "Exception is expected");
+        final String attemptedNames = package1 + PACKAGE_SEPARATOR + name + STRING_SEPARATOR
+                + package2 + PACKAGE_SEPARATOR + name + STRING_SEPARATOR
+                + checkName + STRING_SEPARATOR
+                + package1 + PACKAGE_SEPARATOR + checkName + STRING_SEPARATOR
+                + package2 + PACKAGE_SEPARATOR + checkName;
+        final Violation exceptionMessage = new Violation(1,
+                Definitions.CHECKSTYLE_BUNDLE, UNABLE_TO_INSTANTIATE_EXCEPTION_MESSAGE,
+                new String[] {name, attemptedNames}, null, getClass(), null);
+        assertWithMessage("Invalid exception message")
+            .that(exc.getMessage())
+            .isEqualTo(exceptionMessage.getViolation());
     }
 
     @Test
@@ -405,19 +395,17 @@ public class PackageObjectFactoryTest {
 
     @Test
     public void testConstructorFailure() {
-        try {
-            factory.createModule(FailConstructorFileSet.class.getName());
-            assertWithMessage("Exception is expected").fail();
-        }
-        catch (CheckstyleException exc) {
-            assertWithMessage("Invalid exception message")
-                .that(exc.getMessage())
-                .isEqualTo("Unable to instantiate com.puppycrawl.tools.checkstyle."
-                    + "PackageObjectFactoryTest$FailConstructorFileSet");
-            assertWithMessage("Invalid exception cause class")
-                .that(exc.getCause().getClass().getSimpleName())
-                .isEqualTo("IllegalAccessException");
-        }
+        final CheckstyleException exc =
+                getExpectedThrowable(CheckstyleException.class, () -> {
+                    factory.createModule(FailConstructorFileSet.class.getName());
+                }, "Exception is expected");
+        assertWithMessage("Invalid exception message")
+            .that(exc.getMessage())
+            .isEqualTo("Unable to instantiate com.puppycrawl.tools.checkstyle."
+                + "PackageObjectFactoryTest$FailConstructorFileSet");
+        assertWithMessage("Invalid exception cause class")
+            .that(exc.getCause().getClass().getSimpleName())
+            .isEqualTo("IllegalAccessException");
     }
 
     @Test
@@ -534,7 +522,7 @@ public class PackageObjectFactoryTest {
         final PackageObjectFactory objectFactory =
             new PackageObjectFactory(packages, classLoader, SEARCH_REGISTERED_PACKAGES);
         final CheckstyleException ex =
-                TestUtil.getExpectedThrowable(CheckstyleException.class, () -> {
+                getExpectedThrowable(CheckstyleException.class, () -> {
                     objectFactory.createModule("PackageObjectFactoryTest$MockClass");
                 });
 
@@ -561,22 +549,20 @@ public class PackageObjectFactoryTest {
                 new HashSet<>(Arrays.asList(abcPackage, barPackage,
                         fooPackage, zooPackage)), classLoader);
         final String name = "FooCheck";
-        try {
-            objectFactory.createModule(name);
-            assertWithMessage("Exception is expected").fail();
-        }
-        catch (CheckstyleException exc) {
-            final String optionalNames = abcPackage + PACKAGE_SEPARATOR + name
-                    + STRING_SEPARATOR + barPackage + PACKAGE_SEPARATOR + name
-                    + STRING_SEPARATOR + fooPackage + PACKAGE_SEPARATOR + name
-                    + STRING_SEPARATOR + zooPackage + PACKAGE_SEPARATOR + name;
-            final LocalizedMessage exceptionMessage = new LocalizedMessage(
-                    Definitions.CHECKSTYLE_BUNDLE, getClass(),
-                    AMBIGUOUS_MODULE_NAME_EXCEPTION_MESSAGE, name, optionalNames);
-            assertWithMessage("Invalid exception message")
-                .that(exc.getMessage())
-                .isEqualTo(exceptionMessage.getMessage());
-        }
+        final CheckstyleException exc =
+                getExpectedThrowable(CheckstyleException.class, () -> {
+                    objectFactory.createModule(name);
+                }, "Exception is expected");
+        final String optionalNames = abcPackage + PACKAGE_SEPARATOR + name
+                + STRING_SEPARATOR + barPackage + PACKAGE_SEPARATOR + name
+                + STRING_SEPARATOR + fooPackage + PACKAGE_SEPARATOR + name
+                + STRING_SEPARATOR + zooPackage + PACKAGE_SEPARATOR + name;
+        final LocalizedMessage exceptionMessage = new LocalizedMessage(
+                Definitions.CHECKSTYLE_BUNDLE, getClass(),
+                AMBIGUOUS_MODULE_NAME_EXCEPTION_MESSAGE, name, optionalNames);
+        assertWithMessage("Invalid exception message")
+            .that(exc.getMessage())
+            .isEqualTo(exceptionMessage.getMessage());
     }
 
     private static final class FailConstructorFileSet extends AbstractFileSetCheck {

--- a/src/test/java/com/puppycrawl/tools/checkstyle/TreeWalkerTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/TreeWalkerTest.java
@@ -21,6 +21,7 @@ package com.puppycrawl.tools.checkstyle;
 
 import static com.google.common.truth.Truth.assertWithMessage;
 import static com.puppycrawl.tools.checkstyle.checks.naming.AbstractNameCheck.MSG_INVALID_PATTERN;
+import static com.puppycrawl.tools.checkstyle.internal.utils.TestUtil.getExpectedThrowable;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.CALLS_REAL_METHODS;
 import static org.mockito.Mockito.doThrow;
@@ -199,29 +200,25 @@ public class TreeWalkerTest extends AbstractModuleTestSupport {
     }
 
     @Test
-    public void testAcceptableTokens()
-            throws Exception {
+    public void testAcceptableTokens() {
         final DefaultConfiguration checkConfig =
             createModuleConfig(HiddenFieldCheck.class);
         checkConfig.addProperty("tokens", "VARIABLE_DEF, ENUM_DEF, CLASS_DEF, METHOD_DEF,"
                 + "IMPORT");
-        try {
-            execute(checkConfig, getPath("InputTreeWalker.java"));
-            assertWithMessage("CheckstyleException is expected").fail();
-        }
-        catch (CheckstyleException exc) {
-            final String errorMsg = exc.getMessage();
-            final Pattern expected = Pattern.compile(Pattern.quote("cannot initialize module"
-                    + " com.puppycrawl.tools.checkstyle.TreeWalker - Token ")
-                    + "\"(ENUM_DEF|CLASS_DEF|METHOD_DEF|IMPORT)\""
-                    + Pattern.quote(" was not found in Acceptable tokens list in check"
-                    + " com.puppycrawl.tools.checkstyle.checks.coding.HiddenFieldCheck"));
-
-            final Matcher errorMsgMatcher = expected.matcher(errorMsg);
-            assertWithMessage("Failure for: %s", errorMsg)
-                    .that(errorMsgMatcher.matches())
-                    .isTrue();
-        }
+        final CheckstyleException exc =
+                getExpectedThrowable(CheckstyleException.class, () -> {
+                    execute(checkConfig, getPath("InputTreeWalker.java"));
+                }, "CheckstyleException is expected");
+        final String errorMsg = exc.getMessage();
+        final Pattern expected = Pattern.compile(Pattern.quote("cannot initialize module"
+                + " com.puppycrawl.tools.checkstyle.TreeWalker - Token ")
+                + "\"(ENUM_DEF|CLASS_DEF|METHOD_DEF|IMPORT)\""
+                + Pattern.quote(" was not found in Acceptable tokens list in check"
+                + " com.puppycrawl.tools.checkstyle.checks.coding.HiddenFieldCheck"));
+        final Matcher errorMsgMatcher = expected.matcher(errorMsg);
+        assertWithMessage("Failure for: %s", errorMsg)
+            .that(errorMsgMatcher.matches())
+            .isTrue();
     }
 
     @Test
@@ -238,20 +235,18 @@ public class TreeWalkerTest extends AbstractModuleTestSupport {
     }
 
     @Test
-    public void testWithCheckNotHavingTreeWalkerAsParent() throws Exception {
+    public void testWithCheckNotHavingTreeWalkerAsParent() {
         final DefaultConfiguration checkConfig = createModuleConfig(JavadocPackageCheck.class);
 
-        try {
-            final String uniqueFileName = "junit_" + UUID.randomUUID() + ".java";
-            final File filePath = new File(temporaryFolder, uniqueFileName);
-            execute(createTreeWalkerConfig(checkConfig), filePath.toString());
-            assertWithMessage("CheckstyleException is expected").fail();
-        }
-        catch (CheckstyleException exception) {
-            assertWithMessage("Error message is unexpected")
-                    .that(exception.getMessage())
-                    .contains("TreeWalker is not allowed as a parent of");
-        }
+        final String uniqueFileName = "junit_" + UUID.randomUUID() + ".java";
+        final File filePath = new File(temporaryFolder, uniqueFileName);
+        final CheckstyleException exception =
+                getExpectedThrowable(CheckstyleException.class, () -> {
+                    execute(createTreeWalkerConfig(checkConfig), filePath.toString());
+                }, "CheckstyleException is expected");
+        assertWithMessage("Error message is unexpected")
+            .that(exception.getMessage())
+            .contains("TreeWalker is not allowed as a parent of");
     }
 
     @Test
@@ -262,17 +257,15 @@ public class TreeWalkerTest extends AbstractModuleTestSupport {
         treeWalker.setModuleFactory(factory);
 
         final Configuration config = new DefaultConfiguration("java.lang.String");
-        try {
-            treeWalker.setupChild(config);
-            assertWithMessage("Exception is expected").fail();
-        }
-        catch (CheckstyleException exc) {
-            assertWithMessage("Error message is not expected")
-                .that(exc.getMessage())
-                .isEqualTo("TreeWalker is not allowed as a parent of java.lang.String "
-                    + "Please review 'Parent Module' section for this Check in "
-                    + "web documentation if Check is standard.");
-        }
+        final CheckstyleException exc =
+                getExpectedThrowable(CheckstyleException.class, () -> {
+                    treeWalker.setupChild(config);
+                }, "Exception is expected");
+        assertWithMessage("Error message is not expected")
+            .that(exc.getMessage())
+            .isEqualTo("TreeWalker is not allowed as a parent of java.lang.String "
+                + "Please review 'Parent Module' section for this Check in "
+                + "web documentation if Check is standard.");
     }
 
     @Test
@@ -294,27 +287,25 @@ public class TreeWalkerTest extends AbstractModuleTestSupport {
     }
 
     @Test
-    public void testForInvalidCheckImplementation() throws Exception {
+    public void testForInvalidCheckImplementation() {
         final DefaultConfiguration checkConfig = createModuleConfig(BadJavaDocCheck.class);
         final String uniqueFileName = "file_" + UUID.randomUUID() + ".java";
         final File pathToEmptyFile = new File(temporaryFolder, uniqueFileName);
 
-        try {
-            execute(checkConfig, pathToEmptyFile.toString());
-            assertWithMessage("Exception is expected").fail();
-        }
-        catch (CheckstyleException exc) {
-            assertWithMessage("Error message is unexpected")
-                    .that(exc.getMessage())
-                    .isEqualTo("cannot initialize module com.puppycrawl.tools.checkstyle."
-                            + "TreeWalker - Check 'com.puppycrawl.tools.checkstyle."
-                            + "TreeWalkerTest$BadJavaDocCheck' waits for comment type token "
-                            + "('SINGLE_LINE_COMMENT') and should override "
-                            + "'isCommentNodesRequired()' method to return 'true'");
-            assertWithMessage("Error message is unexpected")
-                    .that(exc.getMessage())
-                    .contains("isCommentNodesRequired");
-        }
+        final CheckstyleException exc =
+                getExpectedThrowable(CheckstyleException.class, () -> {
+                    execute(checkConfig, pathToEmptyFile.toString());
+                }, "Exception is expected");
+        assertWithMessage("Error message is unexpected")
+            .that(exc.getMessage())
+            .isEqualTo("cannot initialize module com.puppycrawl.tools.checkstyle."
+                    + "TreeWalker - Check 'com.puppycrawl.tools.checkstyle."
+                    + "TreeWalkerTest$BadJavaDocCheck' waits for comment type token "
+                    + "('SINGLE_LINE_COMMENT') and should override "
+                    + "'isCommentNodesRequired()' method to return 'true'");
+        assertWithMessage("Error message is unexpected")
+            .that(exc.getMessage())
+            .contains("isCommentNodesRequired");
     }
 
     @Test
@@ -332,15 +323,13 @@ public class TreeWalkerTest extends AbstractModuleTestSupport {
                 "error public class InputTreeWalkerFileWithViolation {}"));
         final FileText fileText = new FileText(file, lines);
         treeWalker.setFileContents(new FileContents(fileText));
-        try {
-            treeWalker.processFiltered(file, fileText);
-            assertWithMessage("Exception expected").fail();
-        }
-        catch (CheckstyleException exc) {
-            assertWithMessage("Invalid exception message")
-                .that(exc.getMessage())
-                .isEqualTo("IllegalStateException occurred while parsing file input.java.");
-        }
+        final CheckstyleException exc =
+                getExpectedThrowable(CheckstyleException.class, () -> {
+                    treeWalker.processFiltered(file, fileText);
+                }, "Exception expected");
+        assertWithMessage("Invalid exception message")
+            .that(exc.getMessage())
+            .isEqualTo("IllegalStateException occurred while parsing file input.java.");
     }
 
     @Test
@@ -378,15 +367,13 @@ public class TreeWalkerTest extends AbstractModuleTestSupport {
         lines.add(" classD a {} ");
         final FileText fileText = new FileText(file, lines);
         treeWalker.setFileContents(new FileContents(fileText));
-        try {
-            treeWalker.processFiltered(file, fileText);
-            assertWithMessage("Exception is expected").fail();
-        }
-        catch (CheckstyleException exception) {
-            assertWithMessage("Error message is unexpected")
-                    .that(exception.getMessage())
-                    .contains("occurred while parsing file");
-        }
+        final CheckstyleException exception =
+                getExpectedThrowable(CheckstyleException.class, () -> {
+                    treeWalker.processFiltered(file, fileText);
+                }, "Exception is expected");
+        assertWithMessage("Error message is unexpected")
+            .that(exception.getMessage())
+            .contains("occurred while parsing file");
     }
 
     @Test
@@ -402,15 +389,13 @@ public class TreeWalkerTest extends AbstractModuleTestSupport {
         lines.add(" class a%$# {} ");
         final FileText fileText = new FileText(file, lines);
         treeWalker.setFileContents(new FileContents(fileText));
-        try {
-            treeWalker.processFiltered(file, fileText);
-            assertWithMessage("Exception is expected").fail();
-        }
-        catch (CheckstyleException exception) {
-            assertWithMessage("Error message is unexpected")
-                    .that(exception.getMessage())
-                    .contains("IllegalStateException occurred while parsing file");
-        }
+        final CheckstyleException exception =
+                getExpectedThrowable(CheckstyleException.class, () -> {
+                    treeWalker.processFiltered(file, fileText);
+                }, "Exception is expected");
+        assertWithMessage("Error message is unexpected")
+            .that(exception.getMessage())
+            .contains("IllegalStateException occurred while parsing file");
     }
 
     @Test
@@ -465,16 +450,14 @@ public class TreeWalkerTest extends AbstractModuleTestSupport {
         final FileText fileText = new FileText(file, lines);
         treeWalker.setFileContents(new FileContents(fileText));
 
-        try {
-            treeWalker.processFiltered(file, fileText);
-            assertWithMessage("file is not compilable, exception is expected").fail();
-        }
-        catch (CheckstyleException exception) {
-            final String message = "IllegalStateException occurred while parsing file";
-            assertWithMessage("Error message is unexpected")
-                    .that(exception.getMessage())
-                    .contains(message);
-        }
+        final CheckstyleException exception =
+                getExpectedThrowable(CheckstyleException.class, () -> {
+                    treeWalker.processFiltered(file, fileText);
+                }, "file is not compilable, exception is expected");
+        final String message = "IllegalStateException occurred while parsing file";
+        assertWithMessage("Error message is unexpected")
+            .that(exception.getMessage())
+            .contains(message);
     }
 
     @Test
@@ -678,15 +661,13 @@ public class TreeWalkerTest extends AbstractModuleTestSupport {
                 Collections.singletonList(new File(getPath("InputTreeWalker2.java")));
         final Checker checker = createChecker(treeWalkerConfig);
 
-        try {
-            checker.process(files);
-            assertWithMessage("exception is expected").fail();
-        }
-        catch (CheckstyleException exception) {
-            assertWithMessage("wrong order of Check executions")
-                    .that(exception.getCause().getMessage())
-                    .isEqualTo(AaCheck.class.toString());
-        }
+        final CheckstyleException exception =
+                getExpectedThrowable(CheckstyleException.class, () -> {
+                    checker.process(files);
+                }, "exception is expected");
+        assertWithMessage("wrong order of Check executions")
+            .that(exception.getCause().getMessage())
+            .isEqualTo(AaCheck.class.toString());
     }
 
     @Test
@@ -762,7 +743,7 @@ public class TreeWalkerTest extends AbstractModuleTestSupport {
             getPath("InputTreeWalkerProperFileExtension.java"),
             getNonCompilablePath("InputTreeWalkerSkipParsingException.java"),
         };
-        final Exception ex = TestUtil.getExpectedThrowable(CheckstyleException.class,
+        final Exception ex = getExpectedThrowable(CheckstyleException.class,
                 () -> execute(config, files),
                 "Exception is expected");
         assertWithMessage("Error message is unexpected")

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/imports/CustomImportOrderCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/imports/CustomImportOrderCheckTest.java
@@ -26,6 +26,7 @@ import static com.puppycrawl.tools.checkstyle.checks.imports.CustomImportOrderCh
 import static com.puppycrawl.tools.checkstyle.checks.imports.CustomImportOrderCheck.MSG_NONGROUP_IMPORT;
 import static com.puppycrawl.tools.checkstyle.checks.imports.CustomImportOrderCheck.MSG_ORDER;
 import static com.puppycrawl.tools.checkstyle.checks.imports.CustomImportOrderCheck.MSG_SEPARATED_IN_GROUP;
+import static com.puppycrawl.tools.checkstyle.internal.utils.TestUtil.getExpectedThrowable;
 
 import java.io.File;
 
@@ -479,91 +480,79 @@ public class CustomImportOrderCheckTest extends AbstractModuleTestSupport {
     }
 
     @Test
-    public void testSamePackageDepthNegative() throws Exception {
+    public void testSamePackageDepthNegative() {
 
-        try {
-            final String[] expected = CommonUtil.EMPTY_STRING_ARRAY;
-
-            verifyWithInlineConfigParser(
-                    getPath("InputCustomImportOrderDefault5.java"), expected);
-            assertWithMessage("exception expected").fail();
-        }
-        catch (CheckstyleException exc) {
-            assertWithMessage("Invalid exception message")
-                .that(exc)
-                .hasMessageThat()
-                .isEqualTo("cannot initialize module com.puppycrawl.tools.checkstyle.TreeWalker - "
-                        + "cannot initialize module com.puppycrawl.tools.checkstyle.checks"
-                        + ".imports.CustomImportOrderCheck");
-            assertWithMessage("Invalid exception message")
-                .that(exc.getCause().getCause().getCause().getCause().getMessage())
-                .isEqualTo("SAME_PACKAGE rule parameter should be positive integer: "
-                        + "SAME_PACKAGE(-1)");
-        }
+        final CheckstyleException exc =
+                getExpectedThrowable(CheckstyleException.class, () -> {
+                    final String[] expected = CommonUtil.EMPTY_STRING_ARRAY;
+                    verifyWithInlineConfigParser(
+                            getPath("InputCustomImportOrderDefault5.java"), expected);
+                }, "exception expected");
+        assertWithMessage("Invalid exception message")
+            .that(exc)
+            .hasMessageThat()
+            .isEqualTo("cannot initialize module com.puppycrawl.tools.checkstyle.TreeWalker - "
+                    + "cannot initialize module com.puppycrawl.tools.checkstyle.checks"
+                    + ".imports.CustomImportOrderCheck");
+        assertWithMessage("Invalid exception message")
+            .that(exc.getCause().getCause().getCause().getCause().getMessage())
+            .isEqualTo("SAME_PACKAGE rule parameter should be positive integer: "
+                    + "SAME_PACKAGE(-1)");
     }
 
     @Test
-    public void testSamePackageDepthZero() throws Exception {
-        try {
-            final String[] expected = CommonUtil.EMPTY_STRING_ARRAY;
-
-            verifyWithInlineConfigParser(
-                    getPath("InputCustomImportOrderDefault6.java"), expected);
-            assertWithMessage("exception expected").fail();
-        }
-        catch (CheckstyleException exc) {
-            assertWithMessage("Invalid exception message")
-                .that(exc.getMessage())
-                .isEqualTo("cannot initialize module com.puppycrawl.tools.checkstyle.TreeWalker - "
-                        + "cannot initialize module com.puppycrawl.tools.checkstyle.checks"
-                        + ".imports.CustomImportOrderCheck");
-            assertWithMessage("Invalid exception message")
-                .that(exc.getCause().getCause().getCause().getCause().getMessage())
-                .isEqualTo("SAME_PACKAGE rule parameter should be positive integer: "
-                        + "SAME_PACKAGE(0)");
-        }
+    public void testSamePackageDepthZero() {
+        final CheckstyleException exc =
+                getExpectedThrowable(CheckstyleException.class, () -> {
+                    final String[] expected = CommonUtil.EMPTY_STRING_ARRAY;
+                    verifyWithInlineConfigParser(
+                            getPath("InputCustomImportOrderDefault6.java"), expected);
+                }, "exception expected");
+        assertWithMessage("Invalid exception message")
+            .that(exc.getMessage())
+            .isEqualTo("cannot initialize module com.puppycrawl.tools.checkstyle.TreeWalker - "
+                    + "cannot initialize module com.puppycrawl.tools.checkstyle.checks"
+                    + ".imports.CustomImportOrderCheck");
+        assertWithMessage("Invalid exception message")
+            .that(exc.getCause().getCause().getCause().getCause().getMessage())
+            .isEqualTo("SAME_PACKAGE rule parameter should be positive integer: "
+                    + "SAME_PACKAGE(0)");
     }
 
     @Test
-    public void testUnsupportedRule() throws Exception {
-        try {
-            final String[] expected = CommonUtil.EMPTY_STRING_ARRAY;
-
-            verifyWithInlineConfigParser(
-                    getPath("InputCustomImportOrderDefault7.java"), expected);
-            assertWithMessage("exception expected").fail();
-        }
-        catch (CheckstyleException exc) {
-            assertWithMessage("Invalid exception message")
-                .that(exc.getMessage())
-                .isEqualTo("cannot initialize module com.puppycrawl.tools.checkstyle.TreeWalker - "
-                        + "cannot initialize module com.puppycrawl.tools.checkstyle.checks"
-                        + ".imports.CustomImportOrderCheck");
-            assertWithMessage("Invalid exception message")
-                .that(exc.getCause().getCause().getCause().getCause().getMessage())
-                .isEqualTo("Unexpected rule: UNSUPPORTED_RULE");
-        }
+    public void testUnsupportedRule() {
+        final CheckstyleException exc =
+                getExpectedThrowable(CheckstyleException.class, () -> {
+                    final String[] expected = CommonUtil.EMPTY_STRING_ARRAY;
+                    verifyWithInlineConfigParser(
+                            getPath("InputCustomImportOrderDefault7.java"), expected);
+                }, "exception expected");
+        assertWithMessage("Invalid exception message")
+            .that(exc.getMessage())
+            .isEqualTo("cannot initialize module com.puppycrawl.tools.checkstyle.TreeWalker - "
+                    + "cannot initialize module com.puppycrawl.tools.checkstyle.checks"
+                    + ".imports.CustomImportOrderCheck");
+        assertWithMessage("Invalid exception message")
+            .that(exc.getCause().getCause().getCause().getCause().getMessage())
+            .isEqualTo("Unexpected rule: UNSUPPORTED_RULE");
     }
 
     @Test
-    public void testSamePackageDepthNotInt() throws Exception {
-        try {
-            final String[] expected = CommonUtil.EMPTY_STRING_ARRAY;
-
-            verifyWithInlineConfigParser(
-                    getPath("InputCustomImportOrderDefault8.java"), expected);
-            assertWithMessage("exception expected").fail();
-        }
-        catch (CheckstyleException exc) {
-            assertWithMessage("Invalid exception message")
-                .that(exc.getMessage())
-                .isEqualTo("cannot initialize module com.puppycrawl.tools.checkstyle.TreeWalker - "
-                        + "cannot initialize module com.puppycrawl.tools.checkstyle.checks"
-                        + ".imports.CustomImportOrderCheck");
-            assertWithMessage("Invalid exception message")
-                .that(exc.getCause().getCause().getCause().getCause().getMessage())
-                .isEqualTo("For input string: \"INT_IS_REQUIRED_HERE\"");
-        }
+    public void testSamePackageDepthNotInt() {
+        final CheckstyleException exc =
+                getExpectedThrowable(CheckstyleException.class, () -> {
+                    final String[] expected = CommonUtil.EMPTY_STRING_ARRAY;
+                    verifyWithInlineConfigParser(
+                            getPath("InputCustomImportOrderDefault8.java"), expected);
+                }, "exception expected");
+        assertWithMessage("Invalid exception message")
+            .that(exc.getMessage())
+            .isEqualTo("cannot initialize module com.puppycrawl.tools.checkstyle.TreeWalker - "
+                    + "cannot initialize module com.puppycrawl.tools.checkstyle.checks"
+                    + ".imports.CustomImportOrderCheck");
+        assertWithMessage("Invalid exception message")
+            .that(exc.getCause().getCause().getCause().getCause().getMessage())
+            .isEqualTo("For input string: \"INT_IS_REQUIRED_HERE\"");
     }
 
     @Test

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/imports/ImportControlCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/imports/ImportControlCheckTest.java
@@ -116,38 +116,34 @@ public class ImportControlCheckTest extends AbstractModuleTestSupport {
     }
 
     @Test
-    public void testUnknown() throws Exception {
-        try {
-            final String[] expected = CommonUtil.EMPTY_STRING_ARRAY;
-            verifyWithInlineConfigParser(
-                    getPath("InputImportControl7.java"), expected);
-            assertWithMessage("Test should fail if exception was not thrown").fail();
-        }
-        catch (CheckstyleException exc) {
-            final String message = getCheckstyleExceptionMessage(exc);
-            final String messageStart = "Unable to find: ";
+    public void testUnknown() {
+        final CheckstyleException exc =
+                getExpectedThrowable(CheckstyleException.class, () -> {
+                    final String[] expected = CommonUtil.EMPTY_STRING_ARRAY;
+                    verifyWithInlineConfigParser(
+                            getPath("InputImportControl7.java"), expected);
+                }, "Test should fail if exception was not thrown");
+        final String message = getCheckstyleExceptionMessage(exc);
+        final String messageStart = "Unable to find: ";
 
-            assertWithMessage("Invalid message, should start with: %s", messageStart)
-                    .that(message)
-                    .startsWith(messageStart);
-        }
+        assertWithMessage("Invalid message, should start with: %s", messageStart)
+                .that(message)
+                .startsWith(messageStart);
     }
 
     @Test
-    public void testBroken() throws Exception {
-        try {
-            final String[] expected = CommonUtil.EMPTY_STRING_ARRAY;
-            verifyWithInlineConfigParser(getPath("InputImportControl8.java"), expected);
-            assertWithMessage("Test should fail if exception was not thrown").fail();
-        }
-        catch (CheckstyleException exc) {
-            final String message = getCheckstyleExceptionMessage(exc);
-            final String messageStart = "Unable to load ";
+    public void testBroken() {
+        final CheckstyleException exc =
+                getExpectedThrowable(CheckstyleException.class, () -> {
+                    final String[] expected = CommonUtil.EMPTY_STRING_ARRAY;
+                    verifyWithInlineConfigParser(getPath("InputImportControl8.java"), expected);
+                }, "Test should fail if exception was not thrown");
+        final String message = getCheckstyleExceptionMessage(exc);
+        final String messageStart = "Unable to load ";
 
-            assertWithMessage("Invalid message, should start with: %s", messageStart)
-                    .that(message)
-                    .startsWith(messageStart);
-        }
+        assertWithMessage("Invalid message, should start with: %s", messageStart)
+                .that(message)
+                .startsWith(messageStart);
     }
 
     @Test
@@ -313,20 +309,18 @@ public class ImportControlCheckTest extends AbstractModuleTestSupport {
     }
 
     @Test
-    public void testResourceUnableToLoad() throws Exception {
-        try {
-            final String[] expected = CommonUtil.EMPTY_STRING_ARRAY;
-            verifyWithInlineConfigParser(getPath("InputImportControl18.java"), expected);
-            assertWithMessage("Test should fail if exception was not thrown").fail();
-        }
-        catch (CheckstyleException exc) {
-            final String message = getCheckstyleExceptionMessage(exc);
-            final String messageStart = "Unable to find: ";
+    public void testResourceUnableToLoad() {
+        final CheckstyleException exc =
+                getExpectedThrowable(CheckstyleException.class, () -> {
+                    final String[] expected = CommonUtil.EMPTY_STRING_ARRAY;
+                    verifyWithInlineConfigParser(getPath("InputImportControl18.java"), expected);
+                }, "Test should fail if exception was not thrown");
+        final String message = getCheckstyleExceptionMessage(exc);
+        final String messageStart = "Unable to find: ";
 
-            assertWithMessage("Invalid message, should start with: %s", messageStart)
-                    .that(message)
-                    .startsWith(messageStart);
-        }
+        assertWithMessage("Invalid message, should start with: %s", messageStart)
+                .that(message)
+                .startsWith(messageStart);
     }
 
     @Test
@@ -338,22 +332,20 @@ public class ImportControlCheckTest extends AbstractModuleTestSupport {
     }
 
     @Test
-    public void testUrlInFilePropertyUnableToLoad() throws Exception {
+    public void testUrlInFilePropertyUnableToLoad() {
 
-        try {
-            final String[] expected = CommonUtil.EMPTY_STRING_ARRAY;
-            verifyWithInlineConfigParser(
-                    getPath("InputImportControl20.java"), expected);
-            assertWithMessage("Test should fail if exception was not thrown").fail();
-        }
-        catch (CheckstyleException exc) {
-            final String message = getCheckstyleExceptionMessage(exc);
-            final String messageStart = "Unable to load ";
+        final CheckstyleException exc =
+                getExpectedThrowable(CheckstyleException.class, () -> {
+                    final String[] expected = CommonUtil.EMPTY_STRING_ARRAY;
+                    verifyWithInlineConfigParser(
+                            getPath("InputImportControl20.java"), expected);
+                }, "Test should fail if exception was not thrown");
+        final String message = getCheckstyleExceptionMessage(exc);
+        final String messageStart = "Unable to load ";
 
-            assertWithMessage("Invalid message, should start with: %s", messageStart)
-                    .that(message)
-                    .startsWith(messageStart);
-        }
+        assertWithMessage("Invalid message, should start with: %s", messageStart)
+                .that(message)
+                .startsWith(messageStart);
     }
 
     @Test

--- a/src/test/java/com/puppycrawl/tools/checkstyle/gui/ParseTreeTablePresentationTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/gui/ParseTreeTablePresentationTest.java
@@ -20,6 +20,7 @@
 package com.puppycrawl.tools.checkstyle.gui;
 
 import static com.google.common.truth.Truth.assertWithMessage;
+import static com.puppycrawl.tools.checkstyle.internal.utils.TestUtil.getExpectedThrowable;
 
 import java.io.File;
 
@@ -293,15 +294,13 @@ public class ParseTreeTablePresentationTest extends AbstractPathTestSupport {
             .that(treeModel)
             .isNull();
 
-        try {
-            parseTree.getValueAt(node, parseTree.getColumnCount());
-            assertWithMessage("IllegalStateException expected").fail();
-        }
-        catch (IllegalStateException exc) {
-            assertWithMessage("Invalid error message")
-                .that(exc.getMessage())
-                .isEqualTo("Unknown column");
-        }
+        final IllegalStateException exc =
+                getExpectedThrowable(IllegalStateException.class, () -> {
+                    parseTree.getValueAt(node, parseTree.getColumnCount());
+                }, "IllegalStateException expected");
+        assertWithMessage("Invalid error message")
+            .that(exc.getMessage())
+            .isEqualTo("Unknown column");
     }
 
     @Test
@@ -351,15 +350,13 @@ public class ParseTreeTablePresentationTest extends AbstractPathTestSupport {
             .that(text)
             .isEqualTo(expectedText);
 
-        try {
-            parseTree.getValueAt(child, parseTree.getColumnCount());
-            assertWithMessage("IllegalStateException expected").fail();
-        }
-        catch (IllegalStateException exc) {
-            assertWithMessage("Invalid error message")
-                .that(exc.getMessage())
-                .isEqualTo("Unknown column");
-        }
+        final IllegalStateException exc =
+                getExpectedThrowable(IllegalStateException.class, () -> {
+                    parseTree.getValueAt(child, parseTree.getColumnCount());
+                }, "IllegalStateException expected");
+        assertWithMessage("Invalid error message")
+            .that(exc.getMessage())
+            .isEqualTo("Unknown column");
     }
 
     @Test
@@ -381,15 +378,13 @@ public class ParseTreeTablePresentationTest extends AbstractPathTestSupport {
             .that(parseTree.getColumnClass(4))
             .isEqualTo(String.class);
 
-        try {
-            parseTree.getColumnClass(parseTree.getColumnCount());
-            assertWithMessage("IllegalStateException expected").fail();
-        }
-        catch (IllegalStateException exc) {
-            assertWithMessage("Invalid error message")
-                .that(exc.getMessage())
-                .isEqualTo("Unknown column");
-        }
+        final IllegalStateException exc =
+                getExpectedThrowable(IllegalStateException.class, () -> {
+                    parseTree.getColumnClass(parseTree.getColumnCount());
+                }, "IllegalStateException expected");
+        assertWithMessage("Invalid error message")
+            .that(exc.getMessage())
+            .isEqualTo("Unknown column");
 
         assertWithMessage("Invalid cell editable status")
                 .that(parseTree.isCellEditable(1))


### PR DESCRIPTION
Resolves #19176

Migrated test files to replace the deprecated `assertWithMessage(...).fail()` try-catch pattern with `TestUtil.getExpectedThrowable`, as required by the rule introduced in #19168.

### Changes

* Replaced `try { ... assertWithMessage(...).fail(); } catch (...) { ... }` blocks with `getExpectedThrowable(...)`.
* Preserved existing `assertWithMessage` assertions to validate exception messages.
* Added static imports for `getExpectedThrowable` where required.

### Updated files

* SuppressWarningsFilterTest.java
* SeverityMatchFilterTest.java
* CSVFilterTest.java
* IntMatchFilterTest.java
* SuppressionFilterTest.java
* SuppressionXpathFilterTest.java
* SuppressionXpathSingleFilterTest.java
* SuppressionCommentFilterTest.java
* SuppressionSingleFilterTest.java
* BeforeExecutionExclusionFileFilterTest.java

All tests were executed locally and the build passed successfully.
