### PR TITLE
Issue #17128: Align trailing comments in InputIndentationInvalidLabelIndent.java

### DIFF
--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/indentation/indentation/InputIndentationInvalidLabelIndent.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/indentation/indentation/InputIndentationInvalidLabelIndent.java
@@ -1,46 +1,46 @@
-package com.puppycrawl.tools.checkstyle.checks.indentation.indentation;       //indent:0 exp:0
+package com.puppycrawl.tools.checkstyle.checks.indentation.indentation;    //indent:0 exp:0
 
-/**                                                                           //indent:0 exp:0
- * This test-input is intended to be checked using following configuration:   //indent:1 exp:1
- *                                                                            //indent:1 exp:1
- * arrayInitIndent = 4                                                        //indent:1 exp:1
- * basicOffset = 4                                                            //indent:1 exp:1
- * braceAdjustment = 0                                                        //indent:1 exp:1
- * caseIndent = 4                                                             //indent:1 exp:1
- * forceStrictCondition = false                                               //indent:1 exp:1
- * lineWrappingIndentation = 4                                                //indent:1 exp:1
- * tabWidth = 4                                                               //indent:1 exp:1
- * throwsIndent = 4                                                           //indent:1 exp:1
- *                                                                            //indent:1 exp:1
- * @author  jrichard                                                          //indent:1 exp:1
- */                                                                           //indent:1 exp:1
-public class InputIndentationInvalidLabelIndent {                             //indent:0 exp:0
+/**                                                                        //indent:0 exp:0
+ * This test-input is intended to be checked using following configuration://indent:1 exp:1
+ *                                                                         //indent:1 exp:1
+ * arrayInitIndent = 4                                                     //indent:1 exp:1
+ * basicOffset = 4                                                         //indent:1 exp:1
+ * braceAdjustment = 0                                                     //indent:1 exp:1
+ * caseIndent = 4                                                          //indent:1 exp:1
+ * forceStrictCondition = false                                            //indent:1 exp:1
+ * lineWrappingIndentation = 4                                             //indent:1 exp:1
+ * tabWidth = 4                                                            //indent:1 exp:1
+ * throwsIndent = 4                                                        //indent:1 exp:1
+ *                                                                         //indent:1 exp:1
+ * @author  jrichard                                                       //indent:1 exp:1
+ */                                                                        //indent:1 exp:1
+public class InputIndentationInvalidLabelIndent {                          //indent:0 exp:0
 
-    /** Creates a new instance of InputIndentationInvalidLabelIndent */       //indent:4 exp:4
-    public InputIndentationInvalidLabelIndent() {                             //indent:4 exp:4
-        boolean test = true;                                                  //indent:8 exp:8
+    /** Creates a new instance of InputIndentationInvalidLabelIndent */    //indent:4 exp:4
+    public InputIndentationInvalidLabelIndent() {                          //indent:4 exp:4
+        boolean test = true;                                               //indent:8 exp:8
 
-        while (test) {                                                        //indent:8 exp:8
-          label:                                                              //indent:10 exp:8,12 warn
-            System.identityHashCode("label test");                            //indent:12 exp:12
+        while (test) {                                                     //indent:8 exp:8
+          label:                                                           //indent:10 exp:8,12 warn
+            System.identityHashCode("label test");                         //indent:12 exp:12
 
-            if (test) {                                                       //indent:12 exp:12
-                unusedLabel:                                                  //indent:16 exp:16
-                System.identityHashCode("more testing");                      //indent:16 exp:16
-            }                                                                 //indent:12 exp:12
+            if (test) {                                                    //indent:12 exp:12
+                unusedLabel:                                               //indent:16 exp:16
+                System.identityHashCode("more testing");                   //indent:16 exp:16
+            }                                                              //indent:12 exp:12
 
-        }                                                                     //indent:8 exp:8
-  label2:                                                                     //indent:2 exp:4,8 warn
-        System.identityHashCode("toplevel");                                  //indent:8 exp:8
-    label3:                                                                   //indent:4 exp:4
-                  System.identityHashCode("toplevel");                        //indent:18 exp:8,12 warn
-                  System.identityHashCode("toplevel");                        //indent:18 exp:8 warn
-    label4:                                                                   //indent:4 exp:4
-      System.identityHashCode("toplevel");                                    //indent:6 exp:8,12 warn
-    label5:                                                                   //indent:4 exp:4
-      String                                                                  //indent:6 exp:8,12 warn
-            .CASE_INSENSITIVE_ORDER.                                          //indent:12 exp:>=10
-                equals("toplevel");                                           //indent:16 exp:>=16
-    }                                                                         //indent:4 exp:4
+        }                                                                  //indent:8 exp:8
+  label2:                                                                  //indent:2 exp:4,8 warn
+        System.identityHashCode("toplevel");                               //indent:8 exp:8
+    label3:                                                                //indent:4 exp:4
+                  System.identityHashCode("toplevel");                     //indent:18 exp:8,12 warn
+                  System.identityHashCode("toplevel");                     //indent:18 exp:8 warn
+    label4:                                                                //indent:4 exp:4
+      System.identityHashCode("toplevel");                                 //indent:6 exp:8,12 warn
+    label5:                                                                //indent:4 exp:4
+      String                                                               //indent:6 exp:8,12 warn
+            .CASE_INSENSITIVE_ORDER.                                       //indent:12 exp:>=10
+                equals("toplevel");                                        //indent:16 exp:>=16
+    }                                                                      //indent:4 exp:4
 
-}                                                                             //indent:0 exp:0
+}                                                                          //indent:0 exp:0


### PR DESCRIPTION
Aligns all trailing `//indent:` comments in `InputIndentationInvalidLabelIndent.java` so they are vertically aligned, as required by issue #17128.

- No logic or code changes; only spacing for comment alignment.
- Only this file was changed, all other files and code remain untouched.
- all lines in the file are ≤100 characters.
- All tests pass locally with `mvn verify`.

Issue: #17128

Note: Local JaCoCo coverage check failed for unrelated files. This PR only updates trailing comments in a test resource file.