### PR TITLE
Issue #19176: migrate xpath tests to getExpectedThrowable

### DIFF
--- a/src/test/java/com/puppycrawl/tools/checkstyle/ChecksAndFilesSuppressionFileGeneratorAuditListenerTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/ChecksAndFilesSuppressionFileGeneratorAuditListenerTest.java
@@ -20,6 +20,7 @@
 package com.puppycrawl.tools.checkstyle;
 
 import static com.google.common.truth.Truth.assertWithMessage;
+import static com.puppycrawl.tools.checkstyle.internal.utils.TestUtil.getExpectedThrowable;
 
 import java.io.ByteArrayOutputStream;
 import java.io.OutputStream;
@@ -126,15 +127,12 @@ public class ChecksAndFilesSuppressionFileGeneratorAuditListenerTest {
                         "messages.properties", null, null, null, getClass(), null);
         final AuditEvent ev = new AuditEvent(this, "Test.java", violation);
 
-        try {
-            logger.addException(ev, null);
-            assertWithMessage("Exception is excepted").fail();
-        }
-        catch (UnsupportedOperationException exc) {
-            assertWithMessage("Invalid exception message")
-                .that(exc.getMessage())
-                .isEqualTo("Operation is not supported");
-        }
+        final UnsupportedOperationException exception =
+            getExpectedThrowable(UnsupportedOperationException.class,
+                () -> logger.addException(ev, null));
+        assertWithMessage("Invalid exception message")
+            .that(exception.getMessage())
+            .isEqualTo("Operation is not supported");
     }
 
     /**
@@ -255,21 +253,12 @@ public class ChecksAndFilesSuppressionFileGeneratorAuditListenerTest {
     @Test
     public void testNullOutputStreamOptions() {
         final OutputStream out = new ByteArrayOutputStream();
-        try {
-            final ChecksAndFilesSuppressionFileGeneratorAuditListener listener =
-                    new ChecksAndFilesSuppressionFileGeneratorAuditListener(out,
-                            null);
-            // assert required to calm down eclipse's 'The allocated object is never used' violation
-            assertWithMessage("Null instance")
-                    .that(listener)
-                    .isNotNull();
-            assertWithMessage("Exception was expected").fail();
-        }
-        catch (IllegalArgumentException exception) {
-            assertWithMessage("Invalid error message")
-                    .that(exception.getMessage())
-                    .isEqualTo("Parameter outputStreamOptions can not be null");
-        }
+        final IllegalArgumentException exception =
+            getExpectedThrowable(IllegalArgumentException.class,
+                () -> new ChecksAndFilesSuppressionFileGeneratorAuditListener(out, null));
+        assertWithMessage("Invalid error message")
+                .that(exception.getMessage())
+                .isEqualTo("Parameter outputStreamOptions can not be null");
     }
 
     private AuditEvent createAuditEvent(String fileName, int lineNumber, int columnNumber,

--- a/src/test/java/com/puppycrawl/tools/checkstyle/XpathFileGeneratorAuditListenerTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/XpathFileGeneratorAuditListenerTest.java
@@ -20,6 +20,7 @@
 package com.puppycrawl.tools.checkstyle;
 
 import static com.google.common.truth.Truth.assertWithMessage;
+import static com.puppycrawl.tools.checkstyle.internal.utils.TestUtil.getExpectedThrowable;
 
 import java.io.ByteArrayOutputStream;
 import java.io.File;
@@ -146,15 +147,12 @@ public class XpathFileGeneratorAuditListenerTest {
                         "messages.properties", null, null, null, getClass(), null);
         final AuditEvent ev = new AuditEvent(this, "Test.java", violation);
 
-        try {
-            logger.addException(ev, null);
-            assertWithMessage("Exception is excepted").fail();
-        }
-        catch (UnsupportedOperationException exc) {
-            assertWithMessage("Invalid exception message")
-                .that(exc.getMessage())
-                .isEqualTo("Operation is not supported");
-        }
+        final UnsupportedOperationException exception =
+            getExpectedThrowable(UnsupportedOperationException.class,
+                () -> logger.addException(ev, null));
+        assertWithMessage("Invalid exception message")
+            .that(exception.getMessage())
+            .isEqualTo("Operation is not supported");
     }
 
     @Test
@@ -272,20 +270,12 @@ public class XpathFileGeneratorAuditListenerTest {
     @Test
     public void testNullOutputStreamOptions() {
         final OutputStream out = new ByteArrayOutputStream();
-        try {
-            final XpathFileGeneratorAuditListener listener = new XpathFileGeneratorAuditListener(
-                    out, null);
-            // assert required to calm down eclipse's 'The allocated object is never used' violation
-            assertWithMessage("Null instance")
-                    .that(listener)
-                    .isNotNull();
-            assertWithMessage("Exception was expected").fail();
-        }
-        catch (IllegalArgumentException exception) {
-            assertWithMessage("Invalid error message")
-                    .that(exception.getMessage())
-                    .isEqualTo("Parameter outputStreamOptions can not be null");
-        }
+        final IllegalArgumentException exception =
+            getExpectedThrowable(IllegalArgumentException.class,
+                () -> new XpathFileGeneratorAuditListener(out, null));
+        assertWithMessage("Invalid error message")
+                .that(exception.getMessage())
+                .isEqualTo("Parameter outputStreamOptions can not be null");
     }
 
     private AuditEvent createAuditEvent(String fileName, int lineNumber, int columnNumber,


### PR DESCRIPTION
Issue: #19176

This PR migrates the remaining xpath-related test cases in this batch from `assertWithMessage(...).fail()` to `getExpectedThrowable(...)`.
It covers the xpath node tests, xpath mapper tests, and the xpath-based suppression file generator listener tests.

Tests:
- ./mvnw -e --no-transfer-progress clean test -Dtest='AttributeNodeTest,RootNodeTest,XpathMapperTest,XpathFileGeneratorAuditListenerTest,ChecksAndFilesSuppressionFileGeneratorAuditListenerTest'