### PR TITLE
Issue #19150: Update WriteTagCheck to use AST of Javadoc

### DIFF
--- a/config/checker-framework-suppressions/checker-nullness-optional-interning-suppressions.xml
+++ b/config/checker-framework-suppressions/checker-nullness-optional-interning-suppressions.xml
@@ -6079,15 +6079,8 @@
 
   <checkerFrameworkError unstable="false">
     <fileName>src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/WriteTagCheck.java</fileName>
-    <specifier>dereference.of.nullable</specifier>
-    <message>dereference of possibly-null reference modifiers</message>
-    <lineContent>cmt = modifiers.findFirstToken(TokenTypes.BLOCK_COMMENT_BEGIN);</lineContent>
-  </checkerFrameworkError>
-
-  <checkerFrameworkError unstable="false">
-    <fileName>src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/WriteTagCheck.java</fileName>
     <specifier>initialization.fields.uninitialized</specifier>
-    <message>the constructor does not initialize fields: tagRegExp, tagFormat, tag</message>
+    <message>the constructor does not initialize fields: tagFormat, tag</message>
     <lineContent>public WriteTagCheck() {</lineContent>
   </checkerFrameworkError>
 

--- a/config/checkstyle-non-main-files-suppressions.xml
+++ b/config/checkstyle-non-main-files-suppressions.xml
@@ -13,6 +13,10 @@
   <suppress id="lineLength" files="compilable-input-paths.txt"/>
   <suppress id="lineLength" files="noncompilable-input-paths.txt"/>
 
+  <!-- Expected report file for WriteTagCheckTest, contains full paths -->
+  <suppress id="lineLength"
+            files="/writetag/ExpectedWriteTagResetSeverity\.txt"/>
+
   <!-- Input files for NewlineAtEndOfFileCheckTest, intentional no new line at the end. -->
   <suppress checks="NewlineAtEndOfFile"
              files="/test/.*/InputNewlineAtEndOfFile.*\.(java|txt)"/>

--- a/config/jsoref-spellchecker/whitelist.words
+++ b/config/jsoref-spellchecker/whitelist.words
@@ -862,7 +862,6 @@ mockito
 Modello
 modifiedcontrolvariable
 modifierorder
-Mohanad
 Mohnen
 mojohaus
 moks

--- a/config/pmd.xml
+++ b/config/pmd.xml
@@ -559,6 +559,9 @@
                       //MethodDeclaration[@Name='setViolateExecutionOnNonTightHtml'
                                             or @Name='setJavadocTokens']
                       | //ClassDeclaration[@SimpleName='JavadocMethodCheck']
+                      //MethodDeclaration[@Name='setViolateExecutionOnNonTightHtml'
+                                            or @Name='setJavadocTokens']
+                      | //ClassDeclaration[@SimpleName='WriteTagCheck']
                       //MethodDeclaration[@Name='setViolateExecutionOnNonTightHtml']"/>
     </properties>
   </rule>

--- a/pom.xml
+++ b/pom.xml
@@ -4210,6 +4210,7 @@
                 <param>com.puppycrawl.tools.checkstyle.checks.javadoc.*</param>
               </targetTests>
               <avoidCallsTo>
+                <avoidCallsTo>com.puppycrawl.tools.checkstyle.utils.NullUtil</avoidCallsTo>
                 <avoidCallsTo>com.puppycrawl.tools.checkstyle.utils.UnmodifiableCollectionUtil</avoidCallsTo>
               </avoidCallsTo>
               <excludedTestClasses>

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/WriteTagCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/WriteTagCheck.java
@@ -19,18 +19,21 @@
 
 package com.puppycrawl.tools.checkstyle.checks.javadoc;
 
-import java.util.regex.Matcher;
+import java.util.ArrayDeque;
+import java.util.Deque;
 import java.util.regex.Pattern;
 
 import javax.annotation.Nullable;
 
-import com.puppycrawl.tools.checkstyle.StatelessCheck;
-import com.puppycrawl.tools.checkstyle.api.AbstractCheck;
+import com.puppycrawl.tools.checkstyle.FileStatefulCheck;
 import com.puppycrawl.tools.checkstyle.api.DetailAST;
+import com.puppycrawl.tools.checkstyle.api.DetailNode;
+import com.puppycrawl.tools.checkstyle.api.JavadocCommentsTokenTypes;
 import com.puppycrawl.tools.checkstyle.api.SeverityLevel;
 import com.puppycrawl.tools.checkstyle.api.TokenTypes;
 import com.puppycrawl.tools.checkstyle.utils.CommonUtil;
 import com.puppycrawl.tools.checkstyle.utils.JavadocUtil;
+import com.puppycrawl.tools.checkstyle.utils.NullUtil;
 
 /**
  * <div>
@@ -42,9 +45,8 @@ import com.puppycrawl.tools.checkstyle.utils.JavadocUtil;
  *
  * @since 4.2
  */
-@StatelessCheck
-public class WriteTagCheck
-    extends AbstractCheck {
+@FileStatefulCheck
+public class WriteTagCheck extends AbstractJavadocCheck {
 
     /**
      * A key is pointing to the warning message text in "messages.properties"
@@ -64,18 +66,20 @@ public class WriteTagCheck
      */
     public static final String MSG_TAG_FORMAT = "type.tagFormat";
 
-    /** Line split pattern. */
-    private static final Pattern LINE_SPLIT_PATTERN = Pattern.compile("\\R");
-
-    /** Compiled regexp to match tag. */
-    private Pattern tagRegExp;
     /** Specify the regexp to match tag content. */
     private Pattern tagFormat;
 
     /** Specify the name of tag. */
     private String tag;
+
     /** Specify the severity level when tag is found and printed. */
     private SeverityLevel tagSeverity = SeverityLevel.INFO;
+
+    /** Whether the target tag was found in the current Javadoc tree. */
+    private boolean tagFound;
+
+    /** Parent line number for the missing tag report in the current Javadoc tree. */
+    private int parentLineNo;
 
     /**
      * Creates a new {@code WriteTagCheck} instance.
@@ -92,7 +96,6 @@ public class WriteTagCheck
      */
     public void setTag(String tag) {
         this.tag = tag;
-        tagRegExp = CommonUtil.createPattern(tag + "\\s*(.*$)");
     }
 
     /**
@@ -114,6 +117,26 @@ public class WriteTagCheck
      */
     public final void setTagSeverity(SeverityLevel severity) {
         tagSeverity = severity;
+    }
+
+    /**
+     * Setter to control when to print violations if the Javadoc being examined by this check
+     * violates the tight html rules defined at
+     * <a href="https://checkstyle.org/writingjavadocchecks.html#Tight-HTML_rules">
+     *     Tight-HTML Rules</a>.
+     *
+     * @param shouldReportViolation value to which the field shall be set to
+     * @since 8.3
+     * @propertySince 13.9.0
+     */
+    @Override
+    public void setViolateExecutionOnNonTightHtml(boolean shouldReportViolation) {
+        super.setViolateExecutionOnNonTightHtml(shouldReportViolation);
+    }
+
+    @Override
+    public int[] getRequiredTokens() {
+        return CommonUtil.EMPTY_INT_ARRAY;
     }
 
     @Override
@@ -144,109 +167,126 @@ public class WriteTagCheck
     }
 
     @Override
-    public boolean isCommentNodesRequired() {
-        return true;
+    public int[] getDefaultJavadocTokens() {
+        return new int[] {
+            JavadocCommentsTokenTypes.JAVADOC_BLOCK_TAG,
+        };
     }
 
     @Override
-    public int[] getRequiredTokens() {
-        return CommonUtil.EMPTY_INT_ARRAY;
+    public int[] getRequiredJavadocTokens() {
+        return getAcceptableJavadocTokens();
     }
 
     @Override
     public void visitToken(DetailAST ast) {
-        final DetailAST javadoc = getJavadoc(ast);
+        final DetailAST javadocComment = findJavadoc(ast);
+        if (javadocComment != null) {
+            parentLineNo = ast.getLineNo();
+            super.visitToken(javadocComment);
+        }
+    }
 
-        if (javadoc != null) {
-            final String[] cmtLines = LINE_SPLIT_PATTERN
-                    .split(JavadocUtil.getJavadocCommentContent(javadoc));
+    @Override
+    public void beginJavadocTree(DetailNode rootAst) {
+        tagFound = false;
+    }
 
-            checkTag(javadoc.getLineNo(),
-                    javadoc.getLineNo() + countCommentLines(javadoc),
-                    cmtLines);
+    @Override
+    public void visitJavadocToken(DetailNode ast) {
+        final String tagName = "@" + JavadocUtil.getTagName(ast);
+        if (tagName.equals(tag)) {
+            tagFound = true;
+            final String content = getTagContent(ast);
+
+            if (tagFormat == null || tagFormat.matcher(content).find()) {
+                logTag(ast.getLineNumber(), tag, content);
+            }
+            else {
+                log(ast.getLineNumber(), MSG_TAG_FORMAT, tag, tagFormat.pattern());
+            }
+        }
+    }
+
+    @Override
+    public void finishJavadocTree(DetailNode rootAst) {
+        if (tag != null && !tagFound) {
+            log(parentLineNo, MSG_MISSING_TAG, tag);
         }
     }
 
     /**
-     * Retrieves the Javadoc comment associated with a given AST node.
+     * Returns the raw content of the tag.
      *
-     * @param ast the AST node (e.g., class, method, constructor) to search above.
-     * @return the {@code DetailAST} representing the Javadoc comment if found and
-     *          valid; {@code null} otherwise.
+     * @param javadocBlockTagNode The node representing a Javadoc block tag.
+     *       This node must be of type {@link JavadocCommentsTokenTypes#JAVADOC_BLOCK_TAG}
+     * @return The raw content of the tag.
+     */
+    private static String getTagContent(DetailNode javadocBlockTagNode) {
+        final DetailNode tagNodeNextSibling = JavadocUtil.findFirstToken(
+            javadocBlockTagNode.getFirstChild(),
+            JavadocCommentsTokenTypes.TAG_NAME).getNextSibling();
+
+        final int stringBuilderCapacity = 128;
+        final StringBuilder rawTextBuilder = new StringBuilder(stringBuilderCapacity);
+        if (tagNodeNextSibling != null) {
+            // DFS to extract texts of all leaf nodes
+            final Deque<DetailNode> stack = new ArrayDeque<>();
+            stack.push(tagNodeNextSibling);
+
+            while (!stack.isEmpty()) {
+                final DetailNode currentNode = stack.pop();
+
+                // append text if node is a leaf
+                if (currentNode.getFirstChild() == null) {
+                    rawTextBuilder.append(currentNode.getText());
+                }
+
+                final DetailNode nextSibling = currentNode.getNextSibling();
+                final DetailNode firstChild = currentNode.getFirstChild();
+
+                if (nextSibling != null) {
+                    stack.push(nextSibling);
+                }
+                if (firstChild != null) {
+                    stack.push(firstChild);
+                }
+            }
+        }
+
+        return rawTextBuilder.toString().stripLeading();
+    }
+
+    /**
+     * Finds the Javadoc comment associated with a structural AST node.
+     *
+     * @param ast the structural node (e.g., CLASS_DEF, METHOD_DEF)
+     * @return the Javadoc block comment if found, or null
      */
     @Nullable
-    private static DetailAST getJavadoc(DetailAST ast) {
-        // Prefer Javadoc directly above the node
+    private static DetailAST findJavadoc(DetailAST ast) {
         DetailAST cmt = ast.findFirstToken(TokenTypes.BLOCK_COMMENT_BEGIN);
         if (cmt == null) {
-            // Check MODIFIERS and TYPE block for comments
-            final DetailAST modifiers = ast.findFirstToken(TokenTypes.MODIFIERS);
+            final DetailAST modifiers = NullUtil.notNull(ast.findFirstToken(TokenTypes.MODIFIERS));
             final DetailAST type = ast.findFirstToken(TokenTypes.TYPE);
 
+            final DetailAST annotation = modifiers.findFirstToken(TokenTypes.ANNOTATION);
             cmt = modifiers.findFirstToken(TokenTypes.BLOCK_COMMENT_BEGIN);
+            if (annotation != null) {
+                cmt = annotation.findFirstToken(TokenTypes.BLOCK_COMMENT_BEGIN);
+            }
             if (cmt == null && type != null) {
                 cmt = type.findFirstToken(TokenTypes.BLOCK_COMMENT_BEGIN);
             }
         }
-
-        final DetailAST javadoc;
-        if (cmt != null && JavadocUtil.isJavadocComment(cmt)) {
-            javadoc = cmt;
-        }
-        else {
-            javadoc = null;
-        }
-
-        return javadoc;
-    }
-
-    /**
-     * Counts the number of lines in a block comment.
-     *
-     * @param blockComment the AST node representing the block comment.
-     * @return the number of lines in the comment.
-     */
-    private static int countCommentLines(DetailAST blockComment) {
-        final String content = JavadocUtil.getBlockCommentContent(blockComment);
-        return LINE_SPLIT_PATTERN.split(content).length;
-    }
-
-    /**
-     * Validates the Javadoc comment against the configured requirements.
-     *
-     * @param astLineNo the line number of the type definition.
-     * @param javadocLineNo the starting line number of the Javadoc comment block.
-     * @param comment the lines of the Javadoc comment block.
-     */
-    private void checkTag(int astLineNo, int javadocLineNo, String... comment) {
-        if (tagRegExp != null) {
-            boolean hasTag = false;
-            for (int i = 0; i < comment.length; i++) {
-                final String commentValue = comment[i];
-                final Matcher matcher = tagRegExp.matcher(commentValue);
-                if (matcher.find()) {
-                    hasTag = true;
-                    final int contentStart = matcher.start(1);
-                    final String content = commentValue.substring(contentStart);
-                    if (tagFormat == null || tagFormat.matcher(content).find()) {
-                        logTag(astLineNo + i, tag, content);
-                    }
-                    else {
-                        log(astLineNo + i, MSG_TAG_FORMAT, tag, tagFormat.pattern());
-                    }
-                }
-            }
-            if (!hasTag) {
-                log(javadocLineNo, MSG_MISSING_TAG, tag);
-            }
-        }
+        return cmt;
     }
 
     /**
      * Log a message.
      *
      * @param line the line number where the violation was found
-     * @param tagName the javadoc tag to be logged
+     * @param tagName the Javadoc tag to be logged
      * @param tagValue the contents of the tag
      *
      * @see java.text.MessageFormat

--- a/src/main/resources/com/puppycrawl/tools/checkstyle/meta/checks/javadoc/WriteTagCheck.xml
+++ b/src/main/resources/com/puppycrawl/tools/checkstyle/meta/checks/javadoc/WriteTagCheck.xml
@@ -28,8 +28,15 @@
                       validation-type="tokenSet">
                <description>tokens to check</description>
             </property>
+            <property default-value="false"
+                      name="violateExecutionOnNonTightHtml"
+                      type="boolean">
+               <description>Control when to print violations if the Javadoc being examined by this check violates the tight html rules defined at &lt;a href="https://checkstyle.org/writingjavadocchecks.html#Tight-HTML_rules"&gt;Tight-HTML Rules&lt;/a&gt;.</description>
+            </property>
          </properties>
          <message-keys>
+            <message-key key="javadoc.parse.rule.error"/>
+            <message-key key="javadoc.unclosedHtml"/>
             <message-key key="javadoc.writeTag"/>
             <message-key key="type.missingTag"/>
             <message-key key="type.tagFormat"/>

--- a/src/site/xdoc/checks/javadoc/writetag.xml
+++ b/src/site/xdoc/checks/javadoc/writetag.xml
@@ -49,6 +49,13 @@
               <td>4.2</td>
             </tr>
             <tr>
+              <td><a id="violateExecutionOnNonTightHtml"/><a href="#violateExecutionOnNonTightHtml">violateExecutionOnNonTightHtml</a></td>
+              <td>Control when to print violations if the Javadoc being examined by this check violates the tight html rules defined at <a href="https://checkstyle.org/writingjavadocchecks.html#Tight-HTML_rules">Tight-HTML Rules</a>.</td>
+              <td><a href="../../property_types.html#boolean">boolean</a></td>
+              <td><code>false</code></td>
+              <td>13.9.0</td>
+            </tr>
+            <tr>
               <td><a id="tokens"/><a href="#tokens">tokens</a></td>
               <td>tokens to check</td>
               <td>subset of tokens
@@ -332,6 +339,16 @@ public class UseCase1 {
 
       <subsection name="Violation Messages" id="WriteTag_Violation_Messages">
         <ul>
+          <li>
+            <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources%2Fcom%2Fpuppycrawl%2Ftools%2Fcheckstyle%2Fchecks%2Fjavadoc+path%3A**%2Fmessages*.properties+repo%3Acheckstyle%2Fcheckstyle+%22javadoc.parse.rule.error%22">
+              javadoc.parse.rule.error
+            </a>
+          </li>
+          <li>
+            <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources%2Fcom%2Fpuppycrawl%2Ftools%2Fcheckstyle%2Fchecks%2Fjavadoc+path%3A**%2Fmessages*.properties+repo%3Acheckstyle%2Fcheckstyle+%22javadoc.unclosedHtml%22">
+              javadoc.unclosedHtml
+            </a>
+          </li>
           <li>
             <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources%2Fcom%2Fpuppycrawl%2Ftools%2Fcheckstyle%2Fchecks%2Fjavadoc+path%3A**%2Fmessages*.properties+repo%3Acheckstyle%2Fcheckstyle+%22javadoc.writeTag%22">
               javadoc.writeTag

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/javadoc/WriteTagCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/javadoc/WriteTagCheckTest.java
@@ -20,6 +20,7 @@
 package com.puppycrawl.tools.checkstyle.checks.javadoc;
 
 import static com.google.common.truth.Truth.assertWithMessage;
+import static com.puppycrawl.tools.checkstyle.checks.javadoc.AbstractJavadocCheck.MSG_KEY_UNCLOSED_HTML_TAG;
 import static com.puppycrawl.tools.checkstyle.checks.javadoc.WriteTagCheck.MSG_MISSING_TAG;
 import static com.puppycrawl.tools.checkstyle.checks.javadoc.WriteTagCheck.MSG_TAG_FORMAT;
 import static com.puppycrawl.tools.checkstyle.checks.javadoc.WriteTagCheck.MSG_WRITE_TAG;
@@ -32,24 +33,15 @@ import java.io.LineNumberReader;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Collections;
-import java.util.HashSet;
 import java.util.List;
-import java.util.Locale;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
 
 import org.junit.jupiter.api.Test;
 
 import com.puppycrawl.tools.checkstyle.AbstractAutomaticBean;
 import com.puppycrawl.tools.checkstyle.AbstractModuleTestSupport;
 import com.puppycrawl.tools.checkstyle.Checker;
-import com.puppycrawl.tools.checkstyle.DefaultConfiguration;
 import com.puppycrawl.tools.checkstyle.DefaultLogger;
-import com.puppycrawl.tools.checkstyle.PackageObjectFactory;
-import com.puppycrawl.tools.checkstyle.TreeWalker;
-import com.puppycrawl.tools.checkstyle.internal.utils.TestUtil;
 import com.puppycrawl.tools.checkstyle.utils.CommonUtil;
-import de.thetaphi.forbiddenapis.SuppressForbidden;
 
 /**
  * Unit test for WriteTagCheck.
@@ -70,7 +62,7 @@ public class WriteTagCheckTest extends AbstractModuleTestSupport {
     @Test
     public void testTag() throws Exception {
         final String[] expected = {
-            "15: " + getCheckMessage(MSG_WRITE_TAG, "@author", "Daniel Grenner"),
+            "16: " + getCheckMessage(MSG_WRITE_TAG, "@author", "Daniel Grenner"),
         };
         verifyWithInlineConfigParserTwice(getPath("InputWriteTag.java"), expected);
     }
@@ -78,7 +70,7 @@ public class WriteTagCheckTest extends AbstractModuleTestSupport {
     @Test
     public void testMissingFormat() throws Exception {
         final String[] expected = {
-            "15: " + getCheckMessage(MSG_WRITE_TAG, "@author", "Daniel Grenner"),
+            "16: " + getCheckMessage(MSG_WRITE_TAG, "@author", "Daniel Grenner"),
         };
         verifyWithInlineConfigParserTwice(
                 getPath("InputWriteTagMissingFormat.java"), expected);
@@ -87,7 +79,7 @@ public class WriteTagCheckTest extends AbstractModuleTestSupport {
     @Test
     public void testTagIncomplete() throws Exception {
         final String[] expected = {
-            "16: " + getCheckMessage(MSG_WRITE_TAG, "@incomplete",
+            "17: " + getCheckMessage(MSG_WRITE_TAG, "@incomplete",
                 "This class needs more code..."),
         };
         verifyWithInlineConfigParserTwice(
@@ -97,8 +89,8 @@ public class WriteTagCheckTest extends AbstractModuleTestSupport {
     @Test
     public void testDoubleTag() throws Exception {
         final String[] expected = {
-            "18: " + getCheckMessage(MSG_WRITE_TAG, "@doubletag", "first text"),
-            "19: " + getCheckMessage(MSG_WRITE_TAG, "@doubletag", "second text"),
+            "19: " + getCheckMessage(MSG_WRITE_TAG, "@doubletag", "first text"),
+            "20: " + getCheckMessage(MSG_WRITE_TAG, "@doubletag", "second text"),
         };
         verifyWithInlineConfigParserTwice(
                 getPath("InputWriteTagDoubleTag.java"), expected);
@@ -107,7 +99,7 @@ public class WriteTagCheckTest extends AbstractModuleTestSupport {
     @Test
     public void testEmptyTag() throws Exception {
         final String[] expected = {
-            "20: " + getCheckMessage(MSG_WRITE_TAG, "@emptytag", ""),
+            "21: " + getCheckMessage(MSG_WRITE_TAG, "@emptytag", ""),
         };
         verifyWithInlineConfigParserTwice(
                 getPath("InputWriteTagEmptyTag.java"), expected);
@@ -116,7 +108,7 @@ public class WriteTagCheckTest extends AbstractModuleTestSupport {
     @Test
     public void testMissingTag() throws Exception {
         final String[] expected = {
-            "20: " + getCheckMessage(MSG_MISSING_TAG, "@missingtag"),
+            "21: " + getCheckMessage(MSG_MISSING_TAG, "@missingtag"),
         };
         verifyWithInlineConfigParserTwice(
                 getPath("InputWriteTagMissingTag.java"), expected);
@@ -125,7 +117,7 @@ public class WriteTagCheckTest extends AbstractModuleTestSupport {
     @Test
     public void testInterface() throws Exception {
         final String[] expected = {
-            "15: " + getCheckMessage(MSG_WRITE_TAG, "@author", "Daniel Grenner"),
+            "16: " + getCheckMessage(MSG_WRITE_TAG, "@author", "Daniel Grenner"),
         };
         verifyWithInlineConfigParserTwice(
                 getPath("InputWriteTagInterface.java"), expected
@@ -143,9 +135,9 @@ public class WriteTagCheckTest extends AbstractModuleTestSupport {
     @Test
     public void testMethod() throws Exception {
         final String[] expected = {
-            "25: " + getCheckMessage(MSG_WRITE_TAG, "@todo",
+            "27: " + getCheckMessage(MSG_WRITE_TAG, "@todo",
                     "Add a constructor comment"),
-            "37: " + getCheckMessage(MSG_WRITE_TAG, "@todo", "Add a comment"),
+            "39: " + getCheckMessage(MSG_WRITE_TAG, "@todo", "Add a comment"),
         };
         verifyWithInlineConfigParserTwice(
                 getPath("InputWriteTagMethod.java"), expected);
@@ -154,88 +146,22 @@ public class WriteTagCheckTest extends AbstractModuleTestSupport {
     @Test
     public void testSeverity() throws Exception {
         final String[] expected = {
-            "16: " + getCheckMessage(MSG_WRITE_TAG, "@author", "Daniel Grenner"),
+            "17: " + getCheckMessage(MSG_WRITE_TAG, "@author", "Daniel Grenner"),
         };
         verifyWithInlineConfigParserTwice(
                 getPath("InputWriteTagSeverity.java"), expected);
     }
 
-    /**
-     * Reason for low level testing:
-     * There is no direct way to fetch severity level directly.
-     * This is an exceptional case in which the logs are fetched indirectly using default
-     * logger listener in order to check for the severity level being reset by logging twice.
-     * First log should be the tag's severity level then it should reset the severity level back to
-     * error which is then checked upon using the log's severity level.
-     * This test needs to use a forbidden api {@code ByteArrayOutputStream#toString()}
-     * to get the logs as a string from the output stream
-     */
-    @SuppressForbidden
     @Test
     public void testResetSeverityLevel() throws Exception {
-
-        final Checker checker = new Checker();
-
-        final TreeWalker treeWalker = new TreeWalker();
-        final PackageObjectFactory factory = new PackageObjectFactory(
-                new HashSet<>(), Thread.currentThread().getContextClassLoader());
-
-        treeWalker.setModuleFactory(factory);
-        treeWalker.finishLocalSetup();
-
-        final DefaultConfiguration writeTagConfig = createModuleConfig(WriteTagCheck.class);
-        writeTagConfig.addProperty("tag", "@author");
-        writeTagConfig.addProperty("tagFormat", "Mohanad");
-        writeTagConfig.addProperty("tagSeverity", "warning");
-
-        treeWalker.setupChild(writeTagConfig);
-
-        checker.addFileSetCheck(treeWalker);
-
-        final ByteArrayOutputStream out = TestUtil.getInternalState(this, "stream",
-                ByteArrayOutputStream.class);
-        final DefaultLogger logger = new DefaultLogger(out,
+        final ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
+        final DefaultLogger logger = new DefaultLogger(outputStream,
                 AbstractAutomaticBean.OutputStreamOptions.CLOSE);
-        checker.addListener(logger);
-
-        execute(checker, getPath("InputWriteTagResetSeverity.java"));
-
-        final String output = out.toString(StandardCharsets.UTF_8);
-
-        // logs severity levels are between square brackets []
-        final Pattern severityPattern = Pattern.compile("\\[(ERROR|WARN|INFO|IGNORE)]");
-
-        final Matcher matcher = severityPattern.matcher(output);
-
-        // First log is just the normal tag one
-        final boolean firstMatchFound = matcher.find();
-        assertWithMessage("Severity level should be wrapped in a square bracket []")
-                .that(firstMatchFound)
-                .isTrue();
-
-        final String tagExpectedSeverityLevel = "warn";
-        final String firstSeverityLevel = matcher.group(1).toLowerCase(Locale.ENGLISH);
-
-        assertWithMessage("First log should have an error severity level")
-                .that(firstSeverityLevel)
-                .isEqualTo(tagExpectedSeverityLevel);
-
-        // Now we check for the second log which should log error  if
-        // the previous log did not have an issue while resetting the original severity level
-        final boolean secondMatchFound = matcher.find();
-        assertWithMessage("Severity level should be wrapped in a square bracket []")
-                .that(secondMatchFound)
-                .isTrue();
-
-        final String expectedSeverityLevelAfterReset = "error";
-
-        final String secondSeverityLevel = matcher.group(1).toLowerCase(Locale.ENGLISH);
-
-        assertWithMessage("Second violation's severity level"
-                + " should have been reset back to default (error)")
-                .that(secondSeverityLevel)
-                .isEqualTo(expectedSeverityLevelAfterReset);
-
+        verifyWithInlineConfigParserAndDefaultLogger(
+                getPath("InputWriteTagResetSeverity.java"),
+                getPath("ExpectedWriteTagResetSeverity.txt"),
+                logger,
+                outputStream);
     }
 
     @Test
@@ -247,7 +173,7 @@ public class WriteTagCheckTest extends AbstractModuleTestSupport {
     @Test
     public void testRegularEx() throws Exception {
         final String[] expected = {
-            "16: " + getCheckMessage(MSG_WRITE_TAG, "@author", "Daniel Grenner"),
+            "17: " + getCheckMessage(MSG_WRITE_TAG, "@author", "Daniel Grenner"),
         };
 
         verifyWithInlineConfigParserTwice(
@@ -257,7 +183,7 @@ public class WriteTagCheckTest extends AbstractModuleTestSupport {
     @Test
     public void testRegularExError() throws Exception {
         final String[] expected = {
-            "15: " + getCheckMessage(MSG_TAG_FORMAT, "@author", "ABC"),
+            "16: " + getCheckMessage(MSG_TAG_FORMAT, "@author", "ABC"),
         };
         verifyWithInlineConfigParserTwice(
                 getPath("InputWriteTagExpressionError.java"), expected);
@@ -266,13 +192,13 @@ public class WriteTagCheckTest extends AbstractModuleTestSupport {
     @Test
     public void testEnumsAndAnnotations() throws Exception {
         final String[] expected = {
-            "16: " + getCheckMessage(MSG_WRITE_TAG, "@incomplete",
+            "17: " + getCheckMessage(MSG_WRITE_TAG, "@incomplete",
                     "This enum needs more code..."),
-            "21: " + getCheckMessage(MSG_WRITE_TAG, "@incomplete",
+            "22: " + getCheckMessage(MSG_WRITE_TAG, "@incomplete",
                     "This enum constant needs more code..."),
-            "28: " + getCheckMessage(MSG_WRITE_TAG, "@incomplete",
+            "29: " + getCheckMessage(MSG_WRITE_TAG, "@incomplete",
                     "This annotation needs more code..."),
-            "33: " + getCheckMessage(MSG_WRITE_TAG, "@incomplete",
+            "34: " + getCheckMessage(MSG_WRITE_TAG, "@incomplete",
                     "This annotation field needs more code..."),
         };
         verifyWithInlineConfigParserTwice(
@@ -289,18 +215,182 @@ public class WriteTagCheckTest extends AbstractModuleTestSupport {
     @Test
     public void testWriteTagRecordsAndCompactCtors() throws Exception {
         final String[] expected = {
-            "19: " + getCheckMessage(MSG_TAG_FORMAT, "@incomplete", "\\S"),
-            "26: " + getCheckMessage(MSG_WRITE_TAG, "@incomplete",
+            "20: " + getCheckMessage(MSG_TAG_FORMAT, "@incomplete", "\\S"),
+            "27: " + getCheckMessage(MSG_WRITE_TAG, "@incomplete",
                     "Failed to recognize 'record' introduced in Java 14."),
-            "37: " + getCheckMessage(MSG_WRITE_TAG, "@incomplete",
+            "38: " + getCheckMessage(MSG_WRITE_TAG, "@incomplete",
                     "Failed to recognize 'record' introduced in Java 14."),
-            "48: " + getCheckMessage(MSG_WRITE_TAG, "@incomplete",
+            "49: " + getCheckMessage(MSG_WRITE_TAG, "@incomplete",
                     "Failed to recognize 'record' introduced in Java 14."),
-            "62: " + getCheckMessage(MSG_WRITE_TAG, "@incomplete",
+            "63: " + getCheckMessage(MSG_WRITE_TAG, "@incomplete",
                     "Failed to recognize 'record' introduced in Java 14."),
         };
         verifyWithInlineConfigParserTwice(
             getPath("InputWriteTagRecordsAndCompactCtors.java"), expected);
+    }
+
+    @Test
+    public void testTagTypeAuthor() throws Exception {
+        final String[] expected = {
+            "16: " + getCheckMessage(MSG_WRITE_TAG, "@author",
+                "<p>Jane Doe</p>     {@summary a concise summary}"),
+        };
+        verifyWithInlineConfigParserTwice(
+            getPath("InputWriteTagTypeAuthor.java"), expected);
+    }
+
+    @Test
+    public void testTagTypeCustom() throws Exception {
+        final String[] expected = {
+            "17: " + getCheckMessage(MSG_WRITE_TAG, "@customBlock",
+                "{@customInline {@nested <br>}}"),
+        };
+        verifyWithInlineConfigParserTwice(
+            getPath("InputWriteTagTypeCustom.java"), expected);
+    }
+
+    @Test
+    public void testTagTypeDeprecated() throws Exception {
+        final String[] expected = {
+            "16: " + getCheckMessage(MSG_WRITE_TAG, "@deprecated",
+                "{@systemProperty x}"),
+        };
+        verifyWithInlineConfigParserTwice(
+            getPath("InputWriteTagTypeDeprecated.java"), expected);
+    }
+
+    @Test
+    public void testTagTypeParam() throws Exception {
+        final String[] expected = {
+            "19: " + getCheckMessage(MSG_WRITE_TAG, "@param",
+                "<T> type {@index i}"),
+            "20: " + getCheckMessage(MSG_WRITE_TAG, "@param",
+                "<U> {@linkplain java.lang.String#trim() link}"),
+            "21: " + getCheckMessage(MSG_WRITE_TAG, "@param",
+                "var1 <p><i>html</i></p> <h2>title</h2>"),
+            "22: " + getCheckMessage(MSG_WRITE_TAG, "@param",
+                "var2 {@link java.lang.String#trim() variable}"),
+            "23: " + getCheckMessage(MSG_WRITE_TAG, "@param",
+                "var3 {@return {@code null} or {@literal \"x\"}}"),
+            "24: " + getCheckMessage(MSG_WRITE_TAG, "@param",
+                "var4     <!-- @@ -->"),
+        };
+        verifyWithInlineConfigParserTwice(
+            getPath("InputWriteTagTypeParam.java"), expected);
+    }
+
+    @Test
+    public void testTagTypeReturn() throws Exception {
+        final String[] expected = {
+            "17: " + getCheckMessage(MSG_WRITE_TAG, "@return",
+                "value of type {@code String}"),
+        };
+        verifyWithInlineConfigParserTwice(
+            getPath("InputWriteTagTypeReturn.java"), expected);
+    }
+
+    @Test
+    public void testTagTypeSee() throws Exception {
+        final String[] expected = {
+            "19: " + getCheckMessage(MSG_WRITE_TAG, "@see",
+                "java.io.Closeable#close()"),
+            "20: " + getCheckMessage(MSG_WRITE_TAG, "@see",
+                "<a href=\"https://docs.oracle.com/en/java/\">ref</a>"),
+            "21: " + getCheckMessage(MSG_WRITE_TAG, "@see",
+                "\"text\""),
+        };
+        verifyWithInlineConfigParserTwice(
+            getPath("InputWriteTagTypeSee.java"), expected);
+    }
+
+    @Test
+    public void testTagTypeSince() throws Exception {
+        final String[] expected = {
+            "19: " + getCheckMessage(MSG_WRITE_TAG, "@since",
+                "2.2.2 (2019-12-31)"),
+        };
+        verifyWithInlineConfigParserTwice(
+            getPath("InputWriteTagTypeSince.java"), expected);
+    }
+
+    @Test
+    public void testTagTypeThrows() throws Exception {
+        final String[] expected = {
+            "20: " + getCheckMessage(MSG_WRITE_TAG, "@throws",
+                "Exception when i is {@value Integer#MAX_VALUE}"),
+        };
+        verifyWithInlineConfigParserTwice(
+            getPath("InputWriteTagTypeThrows.java"), expected);
+    }
+
+    @Test
+    public void testNonTightHtml() throws Exception {
+        final String[] expected = {
+            "15: " + getCheckMessage(MSG_KEY_UNCLOSED_HTML_TAG, "p"),
+        };
+        verifyWithInlineConfigParserTwice(
+            getPath("InputWriteTagNonTightHtml.java"), expected);
+    }
+
+    @Test
+    public void testPackageInfo() throws Exception {
+        final String[] expected = CommonUtil.EMPTY_STRING_ARRAY;
+        verifyWithInlineConfigParserTwice(
+            getPath("package-info.java"), expected);
+    }
+
+    @Test
+    public void testTwoClasses() throws Exception {
+        final String[] expected = {
+            "16: " + getCheckMessage(MSG_WRITE_TAG, "@incomplete", "test"),
+            "25: " + getCheckMessage(MSG_MISSING_TAG, "@incomplete"),
+        };
+        verifyWithInlineConfigParserTwice(
+            getPath("InputWriteTagTwoClasses.java"), expected);
+    }
+
+    @Test
+    public void testAnnotationProcessing() throws Exception {
+        final String[] expected = {
+            "16: " + getCheckMessage(MSG_WRITE_TAG, "@incomplete", "test"),
+        };
+        verifyWithInlineConfigParserTwice(
+            getPath("InputWriteTagAnnotationProcessing.java"), expected);
+    }
+
+    @Test
+    public void testAnnotationValue() throws Exception {
+        final String[] expected = {
+            "16: " + getCheckMessage(MSG_WRITE_TAG, "@incomplete", "test"),
+        };
+        verifyWithInlineConfigParserTwice(
+            getPath("InputWriteTagAnnotationValue.java"), expected);
+    }
+
+    @Test
+    public void testMultipleAnnotations() throws Exception {
+        final String[] expected = CommonUtil.EMPTY_STRING_ARRAY;
+        verifyWithInlineConfigParserTwice(
+            getPath("InputWriteTagMultipleAnnotationsNoJavadoc.java"),
+            expected);
+    }
+
+    @Test
+    public void testBetweenAnnotations() throws Exception {
+        final String[] expected = {
+            "16: " + getCheckMessage(MSG_WRITE_TAG, "@incomplete", "test"),
+        };
+        verifyWithInlineConfigParserTwice(
+            getPath("InputWriteTagSingleAnnotation.java"), expected);
+    }
+
+    @Test
+    public void testIssue20875() throws Exception {
+        final String[] expected = {
+            "18: " + getCheckMessage(MSG_MISSING_TAG, "@since"),
+        };
+        verifyWithInlineConfigParserTwice(
+            getPath("InputWriteTagIssue20875.java"), expected);
     }
 
     @Override

--- a/src/test/java/com/puppycrawl/tools/checkstyle/internal/utils/CheckUtil.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/internal/utils/CheckUtil.java
@@ -57,18 +57,6 @@ import com.puppycrawl.tools.checkstyle.utils.TokenUtil;
 
 public final class CheckUtil {
 
-    /**
-     * Defines whether a class hierarchy should be scanned deeply for messages.
-     */
-    private enum ScanMode {
-
-        /** Scan the class hierarchy deeply. */
-        DEEP_SCAN,
-        /** Scan only the given class. */
-        NO_DEEP_SCAN
-
-    }
-
     public static final String CRLF = "\r\n";
 
     private CheckUtil() {
@@ -429,6 +417,18 @@ public final class CheckUtil {
             result = "\n";
         }
         return result;
+    }
+
+    /**
+     * Defines whether a class hierarchy should be scanned deeply for messages.
+     */
+    private enum ScanMode {
+
+        /** Scan the class hierarchy deeply. */
+        DEEP_SCAN,
+        /** Scan only the given class. */
+        NO_DEEP_SCAN
+
     }
 
 }

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/writetag/ExpectedWriteTagResetSeverity.txt
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/writetag/ExpectedWriteTagResetSeverity.txt
@@ -1,0 +1,4 @@
+Starting audit...
+[WARN] src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/writetag/InputWriteTagResetSeverity.java:16: Javadoc tag @author=Mohanad [WriteTag]
+[ERROR] src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/writetag/InputWriteTagResetSeverity.java:17: Type Javadoc tag @author must match pattern 'Mohanad'. [WriteTag]
+Audit done.

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/writetag/InputWriteTag.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/writetag/InputWriteTag.java
@@ -4,6 +4,7 @@ tag = @author
 tagFormat = \\S
 tagSeverity = error
 tokens = (default)INTERFACE_DEF, CLASS_DEF, ENUM_DEF, ANNOTATION_DEF, RECORD_DEF
+violateExecutionOnNonTightHtml = (default)false
 
 
 */

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/writetag/InputWriteTagAnnotationProcessing.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/writetag/InputWriteTagAnnotationProcessing.java
@@ -1,7 +1,7 @@
 /*
 WriteTag
-tag = (default)null
-tagFormat = (default)null
+tag = @incomplete
+tagFormat = \\S
 tagSeverity = (default)info
 tokens = (default)INTERFACE_DEF, CLASS_DEF, ENUM_DEF, ANNOTATION_DEF, RECORD_DEF
 violateExecutionOnNonTightHtml = (default)false
@@ -11,9 +11,11 @@ violateExecutionOnNonTightHtml = (default)false
 
 package com.puppycrawl.tools.checkstyle.checks.javadoc.writetag;
 
-class InputWriteTagNoJavadoc
-{
-    public void method()
-    {
-    }
+// violation 2 lines below 'Javadoc tag @incomplete=test'
+/**
+ * @incomplete test
+ */
+@Deprecated
+@SuppressWarnings("unchecked")
+class InputWriteTagAnnotationProcessing {
 }

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/writetag/InputWriteTagAnnotationValue.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/writetag/InputWriteTagAnnotationValue.java
@@ -1,7 +1,7 @@
 /*
 WriteTag
-tag = (default)null
-tagFormat = (default)null
+tag = @incomplete
+tagFormat = \\S
 tagSeverity = (default)info
 tokens = (default)INTERFACE_DEF, CLASS_DEF, ENUM_DEF, ANNOTATION_DEF, RECORD_DEF
 violateExecutionOnNonTightHtml = (default)false
@@ -11,9 +11,11 @@ violateExecutionOnNonTightHtml = (default)false
 
 package com.puppycrawl.tools.checkstyle.checks.javadoc.writetag;
 
-class InputWriteTagNoJavadoc
-{
-    public void method()
-    {
-    }
+// violation 2 lines below 'Javadoc tag @incomplete=test'
+/**
+ * @incomplete test
+ */
+@Deprecated
+@SuppressWarnings(value = "unchecked")
+class InputWriteTagAnnotationValue {
 }

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/writetag/InputWriteTagBlockComment.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/writetag/InputWriteTagBlockComment.java
@@ -4,6 +4,7 @@ tag = @author
 tagFormat = \\S
 tagSeverity = error
 tokens = ENUM_DEF, ENUM_CONSTANT_DEF
+violateExecutionOnNonTightHtml = (default)false
 
 
 */

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/writetag/InputWriteTagDefault.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/writetag/InputWriteTagDefault.java
@@ -4,6 +4,7 @@ tag = (default)null
 tagFormat = (default)null
 tagSeverity = (default)info
 tokens = (default)INTERFACE_DEF, CLASS_DEF, ENUM_DEF, ANNOTATION_DEF, RECORD_DEF
+violateExecutionOnNonTightHtml = (default)false
 
 
 */

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/writetag/InputWriteTagDoubleTag.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/writetag/InputWriteTagDoubleTag.java
@@ -4,6 +4,7 @@ tag = @doubletag
 tagFormat = \\S
 tagSeverity = error
 tokens = (default)INTERFACE_DEF, CLASS_DEF, ENUM_DEF, ANNOTATION_DEF, RECORD_DEF
+violateExecutionOnNonTightHtml = (default)false
 
 
 */

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/writetag/InputWriteTagEmptyTag.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/writetag/InputWriteTagEmptyTag.java
@@ -4,6 +4,7 @@ tag = @emptytag
 tagFormat =(default)(null)
 tagSeverity = (default)info
 tokens = (default)INTERFACE_DEF, CLASS_DEF, ENUM_DEF, ANNOTATION_DEF, RECORD_DEF
+violateExecutionOnNonTightHtml = (default)false
 
 
 */

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/writetag/InputWriteTagEnumsAndAnnotations.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/writetag/InputWriteTagEnumsAndAnnotations.java
@@ -4,6 +4,7 @@ tag = @incomplete
 tagFormat = .*
 tagSeverity = (default)info
 tokens = ANNOTATION_DEF, ENUM_DEF, ANNOTATION_FIELD_DEF, ENUM_CONSTANT_DEF
+violateExecutionOnNonTightHtml = (default)false
 
 
 */

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/writetag/InputWriteTagExpressionError.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/writetag/InputWriteTagExpressionError.java
@@ -4,6 +4,7 @@ tag = @author
 tagFormat = ABC
 tagSeverity = (default)info
 tokens = (default)INTERFACE_DEF, CLASS_DEF, ENUM_DEF, ANNOTATION_DEF, RECORD_DEF
+violateExecutionOnNonTightHtml = (default)false
 
 
 */

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/writetag/InputWriteTagIgnore.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/writetag/InputWriteTagIgnore.java
@@ -5,6 +5,7 @@ tagFormat = \\S
 tagSeverity = (default)info
 severity = ignore
 tokens = (default)INTERFACE_DEF, CLASS_DEF, ENUM_DEF, ANNOTATION_DEF, RECORD_DEF
+violateExecutionOnNonTightHtml = (default)false
 
 
 */

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/writetag/InputWriteTagIncomplete.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/writetag/InputWriteTagIncomplete.java
@@ -4,6 +4,7 @@ tag = @incomplete
 tagFormat = \\S
 tagSeverity = error
 tokens = (default)INTERFACE_DEF, CLASS_DEF, ENUM_DEF, ANNOTATION_DEF, RECORD_DEF
+violateExecutionOnNonTightHtml = (default)false
 
 
 */

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/writetag/InputWriteTagInterface.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/writetag/InputWriteTagInterface.java
@@ -4,6 +4,7 @@ tag = @author
 tagFormat = \\S
 tagSeverity = error
 tokens = (default)INTERFACE_DEF, CLASS_DEF, ENUM_DEF, ANNOTATION_DEF, RECORD_DEF
+violateExecutionOnNonTightHtml = (default)false
 
 
 */

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/writetag/InputWriteTagIssue20875.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/writetag/InputWriteTagIssue20875.java
@@ -1,8 +1,8 @@
 /*
 WriteTag
-tag = (default)null
-tagFormat = (default)null
-tagSeverity = (default)info
+tag = @since
+tagFormat = \d+
+tagSeverity = ignore
 tokens = (default)INTERFACE_DEF, CLASS_DEF, ENUM_DEF, ANNOTATION_DEF, RECORD_DEF
 violateExecutionOnNonTightHtml = (default)false
 
@@ -11,9 +11,10 @@ violateExecutionOnNonTightHtml = (default)false
 
 package com.puppycrawl.tools.checkstyle.checks.javadoc.writetag;
 
-class InputWriteTagNoJavadoc
-{
-    public void method()
-    {
-    }
+// violation 4 lines below 'missing @since tag.*'
+/**
+ * @version 1
+ */
+@Deprecated
+public class InputWriteTagIssue20875 {
 }

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/writetag/InputWriteTagMethod.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/writetag/InputWriteTagMethod.java
@@ -5,6 +5,8 @@ tagFormat = \\S
 tagSeverity = (default)info
 tokens = INTERFACE_DEF, CLASS_DEF, METHOD_DEF, CTOR_DEF
 severity = ignore
+violateExecutionOnNonTightHtml = true
+
 
 */
 

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/writetag/InputWriteTagMissingFormat.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/writetag/InputWriteTagMissingFormat.java
@@ -4,6 +4,7 @@ tag = @author
 tagFormat = (default)null
 tagSeverity = error
 tokens = (default)INTERFACE_DEF, CLASS_DEF, ENUM_DEF, ANNOTATION_DEF, RECORD_DEF
+violateExecutionOnNonTightHtml = (default)false
 
 
 */

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/writetag/InputWriteTagMissingTag.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/writetag/InputWriteTagMissingTag.java
@@ -4,6 +4,7 @@ tag = @missingtag
 tagFormat = (default)null
 tagSeverity = (default)info
 tokens = (default)INTERFACE_DEF, CLASS_DEF, ENUM_DEF, ANNOTATION_DEF, RECORD_DEF
+violateExecutionOnNonTightHtml = (default)false
 
 
 */

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/writetag/InputWriteTagMultipleAnnotationsNoJavadoc.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/writetag/InputWriteTagMultipleAnnotationsNoJavadoc.java
@@ -1,7 +1,7 @@
 /*
 WriteTag
-tag = (default)null
-tagFormat = (default)null
+tag = @incomplete
+tagFormat = \\S
 tagSeverity = (default)info
 tokens = (default)INTERFACE_DEF, CLASS_DEF, ENUM_DEF, ANNOTATION_DEF, RECORD_DEF
 violateExecutionOnNonTightHtml = (default)false
@@ -11,9 +11,7 @@ violateExecutionOnNonTightHtml = (default)false
 
 package com.puppycrawl.tools.checkstyle.checks.javadoc.writetag;
 
-class InputWriteTagNoJavadoc
-{
-    public void method()
-    {
-    }
+@Deprecated
+@SuppressWarnings("unchecked")
+class InputWriteTagMultipleAnnotationsNoJavadoc {
 }

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/writetag/InputWriteTagNonTightHtml.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/writetag/InputWriteTagNonTightHtml.java
@@ -4,16 +4,18 @@ tag = (default)null
 tagFormat = (default)null
 tagSeverity = (default)info
 tokens = (default)INTERFACE_DEF, CLASS_DEF, ENUM_DEF, ANNOTATION_DEF, RECORD_DEF
-violateExecutionOnNonTightHtml = (default)false
+violateExecutionOnNonTightHtml = true
 
 
 */
 
 package com.puppycrawl.tools.checkstyle.checks.javadoc.writetag;
+// violation 2 lines below 'Unclosed HTML tag found: p'
+/**
+ * <p>
+ */
+class InputWriteTagNonTightHtml {
 
-class InputWriteTagNoJavadoc
-{
-    public void method()
-    {
-    }
+    public static final int CONST = 12;
+
 }

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/writetag/InputWriteTagRecordsAndCompactCtors.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/writetag/InputWriteTagRecordsAndCompactCtors.java
@@ -4,6 +4,7 @@ tag = @incomplete
 tagSeverity = error
 tagFormat = \\S
 tokens = INTERFACE_DEF, CLASS_DEF, ENUM_DEF, ANNOTATION_DEF, RECORD_DEF, COMPACT_CTOR_DEF, CTOR_DEF
+violateExecutionOnNonTightHtml = (default)false
 
 
 */

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/writetag/InputWriteTagRegularExpression.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/writetag/InputWriteTagRegularExpression.java
@@ -4,6 +4,7 @@ tag = @author
 tagFormat = 0*
 tagSeverity = (default)info
 tokens = (default)INTERFACE_DEF, CLASS_DEF, ENUM_DEF, ANNOTATION_DEF, RECORD_DEF
+violateExecutionOnNonTightHtml = (default)false
 
 
 */

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/writetag/InputWriteTagResetSeverity.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/writetag/InputWriteTagResetSeverity.java
@@ -1,5 +1,16 @@
-package com.puppycrawl.tools.checkstyle.checks.javadoc.writetag;
+/*xml
+<module name="Checker">
+  <module name="TreeWalker">
+    <module name="WriteTag">
+      <property name="tag" value="@author"/>
+      <property name="tagFormat" value="Mohanad"/>
+      <property name="tagSeverity" value="warning"/>
+    </module>
+  </module>
+</module>
 
+*/
+package com.puppycrawl.tools.checkstyle.checks.javadoc.writetag;
 /**
  * Testing tag writing
  * @author Mohanad

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/writetag/InputWriteTagSeverity.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/writetag/InputWriteTagSeverity.java
@@ -4,6 +4,7 @@ tag = @author
 tagFormat = \\S
 tagSeverity = error
 tokens = (default)INTERFACE_DEF, CLASS_DEF, ENUM_DEF, ANNOTATION_DEF, RECORD_DEF
+violateExecutionOnNonTightHtml = (default)false
 
 
 */

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/writetag/InputWriteTagSingleAnnotation.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/writetag/InputWriteTagSingleAnnotation.java
@@ -1,7 +1,7 @@
 /*
 WriteTag
-tag = (default)null
-tagFormat = (default)null
+tag = @incomplete
+tagFormat = \\S
 tagSeverity = (default)info
 tokens = (default)INTERFACE_DEF, CLASS_DEF, ENUM_DEF, ANNOTATION_DEF, RECORD_DEF
 violateExecutionOnNonTightHtml = (default)false
@@ -11,9 +11,10 @@ violateExecutionOnNonTightHtml = (default)false
 
 package com.puppycrawl.tools.checkstyle.checks.javadoc.writetag;
 
-class InputWriteTagNoJavadoc
-{
-    public void method()
-    {
-    }
+// violation 2 lines below 'Javadoc tag @incomplete=test'
+/**
+ * @incomplete test
+ */
+@Deprecated
+class InputWriteTagSingleAnnotation {
 }

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/writetag/InputWriteTagTwoClasses.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/writetag/InputWriteTagTwoClasses.java
@@ -1,0 +1,26 @@
+/*
+WriteTag
+tag = @incomplete
+tagFormat = \\S
+tagSeverity = (default)info
+tokens = (default)INTERFACE_DEF, CLASS_DEF, ENUM_DEF, ANNOTATION_DEF, RECORD_DEF
+violateExecutionOnNonTightHtml = (default)false
+
+
+*/
+
+package com.puppycrawl.tools.checkstyle.checks.javadoc.writetag;
+
+// violation 2 lines below 'Javadoc tag @incomplete=test'
+/**
+ * @incomplete test
+ */
+class InputWriteTagTwoClasses {
+}
+
+// violation 4 lines below 'Type Javadoc comment is missing @incomplete tag.'
+/**
+ * No incomplete tag here.
+ */
+class InputWriteTagTwoClassesExtra {
+}

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/writetag/InputWriteTagTypeAuthor.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/writetag/InputWriteTagTypeAuthor.java
@@ -1,7 +1,7 @@
 /*
 WriteTag
-tag = (default)null
-tagFormat = (default)null
+tag = @author
+tagFormat = \\S
 tagSeverity = (default)info
 tokens = (default)INTERFACE_DEF, CLASS_DEF, ENUM_DEF, ANNOTATION_DEF, RECORD_DEF
 violateExecutionOnNonTightHtml = (default)false
@@ -11,9 +11,9 @@ violateExecutionOnNonTightHtml = (default)false
 
 package com.puppycrawl.tools.checkstyle.checks.javadoc.writetag;
 
-class InputWriteTagNoJavadoc
-{
-    public void method()
-    {
-    }
+// violation 2 lines below 'Javadoc tag @author=<p>Jane Doe</p>     {@summary a concise summary}'
+/**
+ * @author <p>Jane Doe</p>     {@summary a concise summary}
+ */
+class InputWriteTagTypeAuthor {
 }

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/writetag/InputWriteTagTypeCustom.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/writetag/InputWriteTagTypeCustom.java
@@ -1,0 +1,23 @@
+/*
+WriteTag
+tag = @customBlock
+tagFormat = \\S
+tagSeverity = (default)info
+tokens = INTERFACE_DEF, CLASS_DEF, ENUM_DEF, ANNOTATION_DEF, RECORD_DEF, METHOD_DEF
+violateExecutionOnNonTightHtml = (default)false
+
+
+*/
+
+package com.puppycrawl.tools.checkstyle.checks.javadoc.writetag;
+
+class InputWriteTagTypeCustom {
+    // violation 2 lines below 'Javadoc tag @customBlock={@customInline {@nested <br>}}'
+    /**
+     * @customBlock {@customInline {@nested <br>}}
+     * @return value of type {@code String}
+     */
+    private String method() {
+        return "";
+    }
+}

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/writetag/InputWriteTagTypeDeprecated.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/writetag/InputWriteTagTypeDeprecated.java
@@ -1,7 +1,7 @@
 /*
 WriteTag
-tag = (default)null
-tagFormat = (default)null
+tag = @deprecated
+tagFormat = \\S
 tagSeverity = (default)info
 tokens = (default)INTERFACE_DEF, CLASS_DEF, ENUM_DEF, ANNOTATION_DEF, RECORD_DEF
 violateExecutionOnNonTightHtml = (default)false
@@ -11,9 +11,10 @@ violateExecutionOnNonTightHtml = (default)false
 
 package com.puppycrawl.tools.checkstyle.checks.javadoc.writetag;
 
-class InputWriteTagNoJavadoc
-{
-    public void method()
-    {
-    }
+// violation 2 lines below 'Javadoc tag @deprecated={@systemProperty x}'
+/**
+ * @deprecated {@systemProperty x}
+ */
+@Deprecated
+class InputWriteTagTypeDeprecated {
 }

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/writetag/InputWriteTagTypeParam.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/writetag/InputWriteTagTypeParam.java
@@ -1,0 +1,32 @@
+/*
+WriteTag
+tag = @param
+tagFormat = \\S
+tagSeverity = (default)info
+tokens = INTERFACE_DEF, CLASS_DEF, ENUM_DEF, ANNOTATION_DEF, RECORD_DEF, METHOD_DEF
+violateExecutionOnNonTightHtml = (default)false
+
+
+*/
+
+package com.puppycrawl.tools.checkstyle.checks.javadoc.writetag;
+
+class InputWriteTagTypeParam {
+    // violation 4 lines below 'Javadoc tag @param=<T> type {@index i}'
+    // violation 4 lines below 'Javadoc tag @param=<U> {@linkplain java.lang.String#trim() link}'
+    // violation 4 lines below 'Javadoc tag @param=var1 <p><i>html</i></p> <h2>title</h2>'
+    /**
+     * @param <T> type {@index i}
+     * @param <U> {@linkplain java.lang.String#trim() link}
+     * @param var1 <p><i>html</i></p> <h2>title</h2>
+     * @param var2 {@link java.lang.String#trim() variable}
+     * @param var3 {@return {@code null} or {@literal "x"}}
+     * @param var4     <!-- @@ -->
+     */
+    public <T, U> void method(int var1, int var2, int var3, int var4) {
+    // violation 5 lines above 'Javadoc tag @param=var2 {@link java.lang.String#trim() variable}'
+    // violation 5 lines above 'Javadoc tag @param=var3 {@return {@code null} or {@literal "x"}}'
+    // violation 5 lines above 'Javadoc tag @param=var4     <!-- @@ -->'
+
+    }
+}

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/writetag/InputWriteTagTypeReturn.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/writetag/InputWriteTagTypeReturn.java
@@ -1,0 +1,22 @@
+/*
+WriteTag
+tag = @return
+tagFormat = \\S
+tagSeverity = (default)info
+tokens = INTERFACE_DEF, CLASS_DEF, ENUM_DEF, ANNOTATION_DEF, RECORD_DEF, METHOD_DEF
+violateExecutionOnNonTightHtml = (default)false
+
+
+*/
+
+package com.puppycrawl.tools.checkstyle.checks.javadoc.writetag;
+
+class InputWriteTagTypeReturn {
+    // violation 2 lines below 'Javadoc tag @return=value of type {@code String}'
+    /**
+     * @return value of type {@code String}
+     */
+    private String method() {
+        return "";
+    }
+}

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/writetag/InputWriteTagTypeSee.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/writetag/InputWriteTagTypeSee.java
@@ -1,0 +1,27 @@
+/*
+WriteTag
+tag = @see
+tagFormat = \\S
+tagSeverity = (default)info
+tokens = INTERFACE_DEF, CLASS_DEF, ENUM_DEF, ANNOTATION_DEF, RECORD_DEF, METHOD_DEF
+violateExecutionOnNonTightHtml = (default)false
+
+
+*/
+
+package com.puppycrawl.tools.checkstyle.checks.javadoc.writetag;
+
+class InputWriteTagTypeSee {
+    // violation 4 lines below 'Javadoc tag @see=java.io.Closeable#close()'
+    // violation 4 lines below 'Javadoc tag @see=<a href="https://docs.oracle.com/en/java/">ref</a>'
+    // violation 4 lines below 'Javadoc tag @see="text"'
+    /**
+     * @see java.io.Closeable#close()
+     * @see <a href="https://docs.oracle.com/en/java/">ref</a>
+     * @see "text"
+     * @return value of type {@code String}
+     */
+    private String method() {
+        return "";
+    }
+}

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/writetag/InputWriteTagTypeSince.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/writetag/InputWriteTagTypeSince.java
@@ -1,0 +1,29 @@
+/*
+WriteTag
+tag = @since
+tagFormat = \\S
+tagSeverity = (default)info
+tokens = INTERFACE_DEF, CLASS_DEF, ENUM_DEF, ANNOTATION_DEF, RECORD_DEF, METHOD_DEF
+violateExecutionOnNonTightHtml = (default)false
+
+
+*/
+
+package com.puppycrawl.tools.checkstyle.checks.javadoc.writetag;
+
+import java.io.IOException;
+
+class InputWriteTagTypeSince {
+    // violation 2 lines below 'Javadoc tag @since=2.2.2 (2019-12-31)'
+    /**
+     * @since      2.2.2 (2019-12-31)
+     * @return value of type {@code String}
+     * @throws IOException  when {@code i} is 0
+     */
+    String method(int i) throws IOException {
+        if (i == 0) {
+            throw new IOException("");
+        }
+        return "";
+    }
+}

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/writetag/InputWriteTagTypeThrows.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/writetag/InputWriteTagTypeThrows.java
@@ -1,0 +1,28 @@
+/*
+WriteTag
+tag = @throws
+tagFormat = \\S
+tagSeverity = (default)info
+tokens = INTERFACE_DEF, CLASS_DEF, ENUM_DEF, ANNOTATION_DEF, RECORD_DEF, METHOD_DEF
+violateExecutionOnNonTightHtml = (default)false
+
+
+*/
+
+package com.puppycrawl.tools.checkstyle.checks.javadoc.writetag;
+
+import java.io.IOException;
+
+class InputWriteTagTypeThrows {
+    // violation 3 lines below 'Javadoc tag @throws=Exception when i is {@value Integer#MAX_VALUE}'
+    /**
+     * @return value of type {@code String}
+     * @throws Exception when i is {@value Integer#MAX_VALUE}
+     */
+    String method(int i) throws Exception {
+        if (i == Integer.MAX_VALUE) {
+            throw new Exception("");
+        }
+        return "";
+    }
+}

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/writetag/package-info.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/writetag/package-info.java
@@ -9,11 +9,7 @@ violateExecutionOnNonTightHtml = (default)false
 
 */
 
+/**
+ * Test.
+ */
 package com.puppycrawl.tools.checkstyle.checks.javadoc.writetag;
-
-class InputWriteTagNoJavadoc
-{
-    public void method()
-    {
-    }
-}


### PR DESCRIPTION
fixes #19150

Changes
---

- `WriteTagCheck` now extends `AbstractJavadocCheck` instead of `AbstractCheck` to directly process Javadoc AST nodes 
- Replaced regex-based line matching (`LINE_SPLIT_PATTERN` and `tagRegExp`) with AST node traversal by overriding `visitJavadocToken(DetailNode)`.
- Implemented a Depth-First Search (DFS) approach to concatenate all leaf nodes. This successfully reconstructs the raw text after a block tag for tagFormat regex matching, overcoming the challenge of Javadoc AST splitting text into multiple node types (e.g., TEXT, HTML_ELEMENT).
- ~Added `TokenTypes.BLOCK_COMMENT_BEGIN` to `getDefaultTokens()` and `getAcceptableTokens()` to ensure the check processes Javadoc correctly.~
- Updated `WriteTagCheckTest` with comprehensive test cases and updated `writetag.xml` to reflect the new tokens property defaults.

---
Diff Regression config: https://gist.githubusercontent.com/lithops-zty/d48fadd689faa04a60283258549a9c89/raw/56e253f3efd810fff3d860c930d9c029fa345582/config.xml
Diff Regression projects: https://gist.githubusercontent.com/lithops-zty/1d287eceaed038cfd47e38f9e7d3a7b6/raw/e698bbeea7d65586c4c06538a4ce92796e28b6ab/projects.properties