### PR TITLE
Issue #19176: migrate header tests to getExpectedThrowable

### DIFF
--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/header/MultiFileRegexpHeaderCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/header/MultiFileRegexpHeaderCheckTest.java
@@ -67,15 +67,12 @@ public class MultiFileRegexpHeaderCheckTest extends AbstractModuleTestSupport {
     @Test
     public void testSetHeaderUriNotSupport() {
         final MultiFileRegexpHeaderCheck instance = new MultiFileRegexpHeaderCheck();
-        try {
-            instance.setHeaderFiles(String.valueOf(URI.create("file://test")));
-            assertWithMessage("Expected exception for unsupported URI").fail();
-        }
-        catch (IllegalArgumentException exc) {
-            assertWithMessage("Invalid exception message")
-                    .that(exc.getMessage())
-                    .isEqualTo("unable to load header file file://test");
-        }
+        final IllegalArgumentException exc =
+                getExpectedThrowable(IllegalArgumentException.class,
+                        () -> instance.setHeaderFiles(String.valueOf(URI.create("file://test"))));
+        assertWithMessage("Invalid exception message")
+                .that(exc.getMessage())
+                .isEqualTo("unable to load header file file://test");
     }
 
     @Test
@@ -158,17 +155,12 @@ public class MultiFileRegexpHeaderCheckTest extends AbstractModuleTestSupport {
         Files.write(emptyFile.toPath(), new ArrayList<>(), StandardCharsets.UTF_8);
         final URI fileUri = emptyFile.toURI();
 
-        try {
-            MultiFileRegexpHeaderCheck.getLines("empty.header", fileUri);
-            assertWithMessage(
-                    "Expected IllegalArgumentException when reading from an empty header file")
-                .fail();
-        }
-        catch (IllegalArgumentException exc) {
-            assertWithMessage("Unexpected exception message")
-                    .that(exc.getMessage())
-                    .contains("Header file is empty: empty.header");
-        }
+        final IllegalArgumentException exc =
+                getExpectedThrowable(IllegalArgumentException.class,
+                        () -> MultiFileRegexpHeaderCheck.getLines("empty.header", fileUri));
+        assertWithMessage("Unexpected exception message")
+                .that(exc.getMessage())
+                .contains("Header file is empty: empty.header");
     }
 
     @Test
@@ -492,15 +484,12 @@ public class MultiFileRegexpHeaderCheckTest extends AbstractModuleTestSupport {
 
         final MultiFileRegexpHeaderCheck check = new MultiFileRegexpHeaderCheck();
 
-        try {
-            check.setHeaderFiles(corruptedHeaderFile.getPath());
-            assertWithMessage("Expected exception for corrupted header file").fail();
-        }
-        catch (IllegalArgumentException exc) {
-            assertWithMessage("Invalid exception message")
+        final IllegalArgumentException exc =
+                getExpectedThrowable(IllegalArgumentException.class,
+                        () -> check.setHeaderFiles(corruptedHeaderFile.getPath()));
+        assertWithMessage("Invalid exception message")
                 .that(exc.getMessage())
                 .isEqualTo("Invalid regex pattern: Invalid regex [a-z");
-        }
     }
 
     @Test
@@ -914,16 +903,11 @@ public class MultiFileRegexpHeaderCheckTest extends AbstractModuleTestSupport {
         final File nonExistentFile = new File(temporaryFolder, "nonexistent.header");
         final URI fileUri = nonExistentFile.toURI();
 
-        try {
-            MultiFileRegexpHeaderCheck.getLines("nonexistent.header", fileUri);
-            assertWithMessage(
-                    "Expected IllegalArgumentException when reading from a non-existent file")
-                .fail();
-        }
-        catch (IllegalArgumentException exc) {
-            assertWithMessage("Unexpected exception message")
-                    .that(exc.getMessage())
-                    .contains("unable to load header file nonexistent.header");
-        }
+        final IllegalArgumentException exc =
+                getExpectedThrowable(IllegalArgumentException.class,
+                        () -> MultiFileRegexpHeaderCheck.getLines("nonexistent.header", fileUri));
+        assertWithMessage("Unexpected exception message")
+                .that(exc.getMessage())
+                .contains("unable to load header file nonexistent.header");
     }
 }

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/header/RegexpHeaderCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/header/RegexpHeaderCheckTest.java
@@ -22,9 +22,9 @@ package com.puppycrawl.tools.checkstyle.checks.header;
 import static com.google.common.truth.Truth.assertWithMessage;
 import static com.puppycrawl.tools.checkstyle.checks.header.RegexpHeaderCheck.MSG_HEADER_MISMATCH;
 import static com.puppycrawl.tools.checkstyle.checks.header.RegexpHeaderCheck.MSG_HEADER_MISSING;
+import static com.puppycrawl.tools.checkstyle.internal.utils.TestUtil.getExpectedThrowable;
 
 import java.util.List;
-import java.util.Locale;
 import java.util.regex.Pattern;
 
 import org.junit.jupiter.api.Test;
@@ -108,18 +108,14 @@ public class RegexpHeaderCheckTest extends AbstractModuleTestSupport {
     public void testSetHeader() {
         // check invalid header passes
         final RegexpHeaderCheck instance = new RegexpHeaderCheck();
-        try {
-            final String header = "^/**\\n * Licensed to the Apache Software Foundation (ASF)";
-            instance.setHeader(header);
-            assertWithMessage(String.format(Locale.ROOT, "%s should have been thrown",
-                    IllegalArgumentException.class)).fail();
-        }
-        catch (IllegalArgumentException exc) {
-            assertWithMessage("Invalid exception message")
+        final String header = "^/**\\n * Licensed to the Apache Software Foundation (ASF)";
+        final IllegalArgumentException exc =
+                getExpectedThrowable(IllegalArgumentException.class,
+                        () -> instance.setHeader(header));
+        assertWithMessage("Invalid exception message")
                 .that(exc.getMessage())
                 .isEqualTo("Unable to parse format: ^/**\\n *"
                     + " Licensed to the Apache Software Foundation (ASF)");
-        }
     }
 
     @Test
@@ -132,20 +128,16 @@ public class RegexpHeaderCheckTest extends AbstractModuleTestSupport {
     }
 
     @Test
-    public void testEmptyFilename() throws Exception {
+    public void testEmptyFilename() {
         final DefaultConfiguration checkConfig = createModuleConfig(RegexpHeaderCheck.class);
         checkConfig.addProperty("headerFile", "");
-        try {
-            createChecker(checkConfig);
-            assertWithMessage("Checker creation should not succeed with invalid headerFile").fail();
-        }
-        catch (CheckstyleException exc) {
-            assertWithMessage("Invalid exception message")
+        final CheckstyleException exc =
+                getExpectedThrowable(CheckstyleException.class, () -> createChecker(checkConfig));
+        assertWithMessage("Invalid exception message")
                 .that(exc.getMessage())
                 .isEqualTo("cannot initialize module"
                     + " com.puppycrawl.tools.checkstyle.checks.header.RegexpHeaderCheck"
                     + " - Cannot set property 'headerFile' to ''");
-        }
     }
 
     @Test
@@ -199,22 +191,17 @@ public class RegexpHeaderCheckTest extends AbstractModuleTestSupport {
     }
 
     @Test
-    public void testFailureForMultilineRegexp() throws Exception {
+    public void testFailureForMultilineRegexp() {
         final DefaultConfiguration checkConfig =
                 createModuleConfig(RegexpHeaderCheck.class);
         checkConfig.addProperty("header", "^(.*\\n.*)");
-        try {
-            createChecker(checkConfig);
-            assertWithMessage(
-                    "Checker creation should not succeed when regexp spans multiple lines").fail();
-        }
-        catch (CheckstyleException exc) {
-            assertWithMessage("Invalid exception message")
+        final CheckstyleException exc =
+                getExpectedThrowable(CheckstyleException.class, () -> createChecker(checkConfig));
+        assertWithMessage("Invalid exception message")
                 .that(exc.getMessage())
                 .isEqualTo("cannot initialize module"
                     + " com.puppycrawl.tools.checkstyle.checks.header.RegexpHeaderCheck"
                     + " - Cannot set property 'header' to '^(.*\\n.*)'");
-        }
     }
 
     @Test
@@ -372,16 +359,12 @@ public class RegexpHeaderCheckTest extends AbstractModuleTestSupport {
         checkConfig.addProperty("headerFile", getPath("InputRegexpHeader.invalid.header"));
         final String[] expected = CommonUtil.EMPTY_STRING_ARRAY;
         final String path = getPath("InputRegexpHeaderMulti52.java");
-        try {
-            // Content header is conflicting with Input inline header
-            verify(checkConfig, path, expected);
-            assertWithMessage("IllegalArgumentException is expected").fail();
-        }
-        catch (IllegalArgumentException exc) {
-            assertWithMessage("Invalid exception message")
+        final IllegalArgumentException exc =
+                getExpectedThrowable(IllegalArgumentException.class,
+                        () -> verify(checkConfig, path, expected));
+        assertWithMessage("Invalid exception message")
                 .that(exc.getMessage())
                 .isEqualTo("line 3 in header specification is not a regular expression");
-        }
     }
 
     @Test


### PR DESCRIPTION
Issue: #19176

This PR migrates the remaining manual exception assertions in the header package to `getExpectedThrowable(...)`.

Validation:
- `./mvnw -e --no-transfer-progress test -Dtest='RegexpHeaderCheckTest,MultiFileRegexpHeaderCheckTest'`