### PR TITLE
Issue #18931: Add MatchXpath example for large array initialization

### DIFF
--- a/src/site/xdoc/checks/coding/matchxpath.xml
+++ b/src/site/xdoc/checks/coding/matchxpath.xml
@@ -236,6 +236,31 @@ public class Example5 {
     public Inner() { }
   }
 }
+</code></pre></div><hr class="example-separator"/>
+        <p id="Example6-config">
+          Reports a violation if an array initialization has more than <b>10</b> elements.
+        </p>
+        <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
+&lt;module name="Checker"&gt;
+  &lt;module name="TreeWalker"&gt;
+    &lt;module name="MatchXpath"&gt;
+      &lt;property name="id" value="largeConstantCollection"/&gt;
+      &lt;property name="query"
+           value="//ARRAY_INIT[count(./EXPR) &gt; 10]"/&gt;
+      &lt;message key="matchxpath.match"
+           value="Array initialization should contain at most 10 elements"/&gt;
+    &lt;/module&gt;
+  &lt;/module&gt;
+&lt;/module&gt;
+</code></pre></div>
+        <p id="Example6-code">Example:</p>
+        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+public class Example6 {
+  // violation below 'Array initialization should contain at most 10 elements'
+  int[] array = {1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12};
+
+  int[] small = {1, 2, 3};
+}
 </code></pre></div>
       </subsection>
 

--- a/src/site/xdoc/checks/coding/matchxpath.xml.template
+++ b/src/site/xdoc/checks/coding/matchxpath.xml.template
@@ -146,6 +146,20 @@ CLASS_DEF -&gt; CLASS_DEF [1:0]
           <param name="path"
                  value="resources/com/puppycrawl/tools/checkstyle/checks/coding/matchxpath/Example5.java"/>
           <param name="type" value="code"/>
+        </macro><hr class="example-separator"/>
+        <p id="Example6-config">
+          Reports a violation if an array initialization has more than <b>10</b> elements.
+        </p>
+        <macro name="example">
+          <param name="path"
+                 value="resources/com/puppycrawl/tools/checkstyle/checks/coding/matchxpath/Example6.java"/>
+          <param name="type" value="config"/>
+        </macro>
+        <p id="Example6-code">Example:</p>
+        <macro name="example">
+          <param name="path"
+                 value="resources/com/puppycrawl/tools/checkstyle/checks/coding/matchxpath/Example6.java"/>
+          <param name="type" value="code"/>
         </macro>
       </subsection>
 

--- a/src/test/java/com/puppycrawl/tools/checkstyle/internal/XdocsExamplesAstConsistencyTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/internal/XdocsExamplesAstConsistencyTest.java
@@ -101,6 +101,7 @@ public class XdocsExamplesAstConsistencyTest {
             "checks/coding/matchxpath/Example3",
             "checks/coding/matchxpath/Example4",
             "checks/coding/matchxpath/Example5",
+            "checks/coding/matchxpath/Example6",
             "checks/coding/packagedeclaration/Example2",
             "checks/coding/requirethis/Example5",
             "checks/coding/requirethis/Example6",

--- a/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/checks/coding/MatchXpathCheckExamplesTest.java
+++ b/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/checks/coding/MatchXpathCheckExamplesTest.java
@@ -76,4 +76,13 @@ public class MatchXpathCheckExamplesTest extends AbstractExamplesModuleTestSuppo
 
         verifyWithInlineConfigParser(getPath("Example5.java"), expected);
     }
+
+    @Test
+    public void testExample6() throws Exception {
+        final String[] expected = {
+            "19:17: " + "Array initialization should contain at most 10 elements",
+        };
+
+        verifyWithInlineConfigParser(getPath("Example6.java"), expected);
+    }
 }

--- a/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/coding/matchxpath/Example6.java
+++ b/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/coding/matchxpath/Example6.java
@@ -1,0 +1,23 @@
+/*xml
+<module name="Checker">
+  <module name="TreeWalker">
+    <module name="MatchXpath">
+      <property name="id" value="largeConstantCollection"/>
+      <property name="query"
+           value="//ARRAY_INIT[count(./EXPR) > 10]"/>
+      <message key="matchxpath.match"
+           value="Array initialization should contain at most 10 elements"/>
+    </module>
+  </module>
+</module>
+*/
+package com.puppycrawl.tools.checkstyle.checks.coding.matchxpath;
+
+// xdoc section -- start
+public class Example6 {
+  // violation below 'Array initialization should contain at most 10 elements'
+  int[] array = {1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12};
+
+  int[] small = {1, 2, 3};
+}
+// xdoc section -- end


### PR DESCRIPTION
Resolves #18931

I have made the changes as per your suggestion and added the id="largeConstantCollection" in the example. The documentation example, test, and example file have been updated accordingly and the build is passing locally.

Could you please review it and let me know if any further changes are needed? Thank you!