### PR TITLE
Issue #19176: migrate coding tests to getExpectedThrowable

### DIFF
--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/coding/FinalLocalVariableCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/coding/FinalLocalVariableCheckTest.java
@@ -19,8 +19,8 @@
 
 package com.puppycrawl.tools.checkstyle.checks.coding;
 
-import static com.google.common.truth.Truth.assertWithMessage;
 import static com.puppycrawl.tools.checkstyle.checks.coding.FinalLocalVariableCheck.MSG_KEY;
+import static com.puppycrawl.tools.checkstyle.internal.utils.TestUtil.getExpectedThrowable;
 
 import org.junit.jupiter.api.Test;
 
@@ -251,13 +251,7 @@ public class FinalLocalVariableCheckTest
         final DetailAstImpl lambdaAst = new DetailAstImpl();
         lambdaAst.setType(TokenTypes.LAMBDA);
 
-        try {
-            check.visitToken(lambdaAst);
-            assertWithMessage("IllegalStateException is expected").fail();
-        }
-        catch (IllegalStateException exc) {
-            // it is OK
-        }
+        getExpectedThrowable(IllegalStateException.class, () -> check.visitToken(lambdaAst));
     }
 
     @Test

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/coding/IllegalInstantiationCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/coding/IllegalInstantiationCheckTest.java
@@ -21,6 +21,7 @@ package com.puppycrawl.tools.checkstyle.checks.coding;
 
 import static com.google.common.truth.Truth.assertWithMessage;
 import static com.puppycrawl.tools.checkstyle.checks.coding.IllegalInstantiationCheck.MSG_KEY;
+import static com.puppycrawl.tools.checkstyle.internal.utils.TestUtil.getExpectedThrowable;
 
 import java.io.File;
 import java.util.Collection;
@@ -152,15 +153,12 @@ public class IllegalInstantiationCheckTest
         lambdaAst.setType(TokenTypes.LAMBDA);
         lambdaAst.setText("LAMBDA");
 
-        try {
-            check.visitToken(lambdaAst);
-            assertWithMessage("IllegalArgumentException is expected").fail();
-        }
-        catch (IllegalArgumentException exc) {
-            assertWithMessage("Message must include token name")
+        final IllegalArgumentException exc =
+                getExpectedThrowable(IllegalArgumentException.class,
+                        () -> check.visitToken(lambdaAst));
+        assertWithMessage("Message must include token name")
                 .that(exc.getMessage())
                 .contains("LAMBDA");
-        }
     }
 
     /**

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/coding/IllegalTypeCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/coding/IllegalTypeCheckTest.java
@@ -419,13 +419,7 @@ public class IllegalTypeCheckTest extends AbstractModuleTestSupport {
         final DetailAstImpl classDefAst = new DetailAstImpl();
         classDefAst.setType(TokenTypes.DOT);
 
-        try {
-            check.visitToken(classDefAst);
-            assertWithMessage("IllegalStateException is expected").fail();
-        }
-        catch (IllegalStateException exc) {
-            // it is OK
-        }
+        getExpectedThrowable(IllegalStateException.class, () -> check.visitToken(classDefAst));
     }
 
     /**

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/coding/MatchXpathCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/coding/MatchXpathCheckTest.java
@@ -181,13 +181,8 @@ public class MatchXpathCheckTest
     public void testInvalidQuery() {
         final MatchXpathCheck matchXpathCheck = new MatchXpathCheck();
 
-        try {
-            matchXpathCheck.setQuery("!@#%^");
-            assertWithMessage("Exception was expected").fail();
-        }
-        catch (IllegalStateException ignored) {
-            // it is OK
-        }
+        getExpectedThrowable(IllegalStateException.class,
+                () -> matchXpathCheck.setQuery("!@#%^"));
     }
 
     @Test
@@ -201,13 +196,8 @@ public class MatchXpathCheckTest
         detailAST.setLineNo(0);
         detailAST.setColumnNo(0);
 
-        try {
-            matchXpathCheck.beginTree(detailAST);
-            assertWithMessage("Exception was expected").fail();
-        }
-        catch (IllegalStateException ignored) {
-            // it is OK
-        }
+        getExpectedThrowable(IllegalStateException.class,
+                () -> matchXpathCheck.beginTree(detailAST));
     }
 
     @Test

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/coding/ModifiedControlVariableCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/coding/ModifiedControlVariableCheckTest.java
@@ -21,6 +21,7 @@ package com.puppycrawl.tools.checkstyle.checks.coding;
 
 import static com.google.common.truth.Truth.assertWithMessage;
 import static com.puppycrawl.tools.checkstyle.checks.coding.ModifiedControlVariableCheck.MSG_KEY;
+import static com.puppycrawl.tools.checkstyle.internal.utils.TestUtil.getExpectedThrowable;
 
 import java.io.File;
 import java.util.Collection;
@@ -115,27 +116,19 @@ public class ModifiedControlVariableCheckTest
         classDefAst.setType(TokenTypes.CLASS_DEF);
         classDefAst.setText("CLASS_DEF");
 
-        try {
-            check.visitToken(classDefAst);
-            assertWithMessage("IllegalStateException is expected").fail();
-        }
-        catch (IllegalStateException exc) {
-            // it is OK
-            assertWithMessage("Error message must include token name")
-                    .that(exc.getMessage())
-                    .contains("CLASS_DEF");
-        }
+        final IllegalStateException visitTokenException =
+                getExpectedThrowable(IllegalStateException.class,
+                        () -> check.visitToken(classDefAst));
+        assertWithMessage("Error message must include token name")
+                .that(visitTokenException.getMessage())
+                .contains("CLASS_DEF");
 
-        try {
-            check.leaveToken(classDefAst);
-            assertWithMessage("IllegalStateException is expected").fail();
-        }
-        catch (IllegalStateException exc) {
-            // it is OK
-            assertWithMessage("Error message must include token name")
-                    .that(exc.getMessage())
-                    .contains("CLASS_DEF");
-        }
+        final IllegalStateException leaveTokenException =
+                getExpectedThrowable(IllegalStateException.class,
+                        () -> check.leaveToken(classDefAst));
+        assertWithMessage("Error message must include token name")
+                .that(leaveTokenException.getMessage())
+                .contains("CLASS_DEF");
     }
 
     @Test

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/coding/ReturnCountCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/coding/ReturnCountCheckTest.java
@@ -119,21 +119,9 @@ public class ReturnCountCheckTest extends AbstractModuleTestSupport {
         final DetailAstImpl classDefAst = new DetailAstImpl();
         classDefAst.setType(TokenTypes.CLASS_DEF);
 
-        try {
-            check.visitToken(classDefAst);
-            assertWithMessage("IllegalStateException is expected").fail();
-        }
-        catch (IllegalStateException exc) {
-            // it is OK
-        }
+        getExpectedThrowable(IllegalStateException.class, () -> check.visitToken(classDefAst));
 
-        try {
-            check.leaveToken(classDefAst);
-            assertWithMessage("IllegalStateException is expected").fail();
-        }
-        catch (IllegalStateException exc) {
-            // it is OK
-        }
+        getExpectedThrowable(IllegalStateException.class, () -> check.leaveToken(classDefAst));
     }
 
     @Test


### PR DESCRIPTION
Issue: #19176

This PR migrates the remaining manual exception assertions in a small `checks/coding` batch to `getExpectedThrowable(...)`.

Validation:
- `./mvnw -e --no-transfer-progress clean test -Dtest='ModifiedControlVariableCheckTest,ReturnCountCheckTest,FinalLocalVariableCheckTest,IllegalInstantiationCheckTest,IllegalTypeCheckTest,MatchXpathCheckTest'`