### PR TITLE
Issue #19176: migrate ant tests to getExpectedThrowable

### DIFF
--- a/src/test/java/com/puppycrawl/tools/checkstyle/ant/CheckstyleAntTaskTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/ant/CheckstyleAntTaskTest.java
@@ -367,21 +367,17 @@ public class CheckstyleAntTaskTest extends AbstractPathTestSupport {
         antTask.setConfig(getPath("InputCheckstyleAntTaskPackagePrefix.xml"));
         antTask.setFile(new File(getPath(FLAWLESS_INPUT)));
 
-        try {
-            antTask.execute();
-            assertWithMessage("Should throw BuildException for non-existent module.")
-                    .fail();
-        }
-        catch (final BuildException exception) {
-            final Throwable cause = exception.getCause();
+        final BuildException exception = getExpectedThrowable(BuildException.class,
+                antTask::execute,
+                "Should throw BuildException for non-existent module.");
+        final Throwable cause = exception.getCause();
 
-            assertWithMessage("BuildException should have a cause")
-                    .that(cause)
-                    .isNotNull();
-            assertWithMessage("Error message should contain the correct package prefix")
-                    .that(cause.getMessage())
-                    .contains("com.puppycrawl.tools.checkstyle");
-        }
+        assertWithMessage("BuildException should have a cause")
+                .that(cause)
+                .isNotNull();
+        assertWithMessage("Error message should contain the correct package prefix")
+                .that(cause.getMessage())
+                .contains("com.puppycrawl.tools.checkstyle");
     }
 
     @Test


### PR DESCRIPTION
Issue: #19176

This PR migrates the remaining manual exception assertion in `CheckstyleAntTaskTest` to `getExpectedThrowable(...)` and keeps the existing cause/message checks.

Validation:
- `./mvnw -e --no-transfer-progress clean test -Dtest=CheckstyleAntTaskTest`