### PR TITLE
Issue #19176: migrate suppressions printer tests to getExpectedThrowable

### DIFF
--- a/src/test/java/com/puppycrawl/tools/checkstyle/SuppressionsStringPrinterTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/SuppressionsStringPrinterTest.java
@@ -20,6 +20,7 @@
 package com.puppycrawl.tools.checkstyle;
 
 import static com.google.common.truth.Truth.assertWithMessage;
+import static com.puppycrawl.tools.checkstyle.internal.utils.TestUtil.getExpectedThrowable;
 import static com.puppycrawl.tools.checkstyle.internal.utils.TestUtil.isUtilsClassHasPrivateConstructor;
 
 import java.io.File;
@@ -104,16 +105,13 @@ public class SuppressionsStringPrinterTest extends AbstractTreeTestSupport {
         final File input = new File(getPath("InputSuppressionsStringPrinter.java"));
         final String invalidLineAndColumnNumber = "abc-432";
         final int tabWidth = 2;
-        try {
-            SuppressionsStringPrinter.printSuppressions(input,
-                    invalidLineAndColumnNumber, tabWidth);
-            assertWithMessage("exception expected").fail();
-        }
-        catch (IllegalStateException exc) {
-            assertWithMessage("Invalid exception message")
-                .that(exc.getMessage())
-                .isEqualTo("abc-432 does not match valid format 'line:column'.");
-        }
+        final IllegalStateException exc =
+                getExpectedThrowable(IllegalStateException.class,
+                        () -> SuppressionsStringPrinter.printSuppressions(input,
+                                invalidLineAndColumnNumber, tabWidth));
+        assertWithMessage("Invalid exception message")
+            .that(exc.getMessage())
+            .isEqualTo("abc-432 does not match valid format 'line:column'.");
     }
 
     @Test
@@ -121,20 +119,17 @@ public class SuppressionsStringPrinterTest extends AbstractTreeTestSupport {
         final File input = new File(getNonCompilablePath("InputSuppressionsStringPrinter.java"));
         final String lineAndColumnNumber = "2:3";
         final int tabWidth = 2;
-        try {
-            SuppressionsStringPrinter.printSuppressions(input,
-                    lineAndColumnNumber, tabWidth);
-            assertWithMessage("exception expected").fail();
-        }
-        catch (CheckstyleException exc) {
-            assertWithMessage("Invalid class")
-                .that(exc.getCause())
-                .isInstanceOf(IllegalStateException.class);
-            assertWithMessage("Invalid exception message")
-                .that(exc.getCause().toString())
-                .isEqualTo(IllegalStateException.class.getName()
-                            + ": 2:0: no viable alternative at input 'classD'");
-        }
+        final CheckstyleException exc =
+                getExpectedThrowable(CheckstyleException.class,
+                        () -> SuppressionsStringPrinter.printSuppressions(input,
+                                lineAndColumnNumber, tabWidth));
+        assertWithMessage("Invalid class")
+            .that(exc.getCause())
+            .isInstanceOf(IllegalStateException.class);
+        assertWithMessage("Invalid exception message")
+            .that(exc.getCause().toString())
+            .isEqualTo(IllegalStateException.class.getName()
+                        + ": 2:0: no viable alternative at input 'classD'");
     }
 
 }


### PR DESCRIPTION
Issue: #19176

This PR converts the remaining `SuppressionsStringPrinterTest` exception expectations to `getExpectedThrowable(...)` so the assertions and causes stay intact.

Validation:
- „./mvnw -e --no-transfer-progress clean test -Dtest=SuppressionsStringPrinterTest" (fails before the actual test runs because the exec plugin cannot load `org.jacoco.agent.rt.internal_29a6edd.Offline`, so the result is the same jacoco classpath issue reported earlier).