### PR TITLE
Issue #19176: migrate metric/size tests to getExpectedThrowable

### DIFF
--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/sizes/ExecutableStatementCountCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/sizes/ExecutableStatementCountCheckTest.java
@@ -21,6 +21,7 @@ package com.puppycrawl.tools.checkstyle.checks.sizes;
 
 import static com.google.common.truth.Truth.assertWithMessage;
 import static com.puppycrawl.tools.checkstyle.checks.sizes.ExecutableStatementCountCheck.MSG_KEY;
+import static com.puppycrawl.tools.checkstyle.internal.utils.TestUtil.getExpectedThrowable;
 
 import java.util.Collection;
 
@@ -132,15 +133,12 @@ public class ExecutableStatementCountCheckTest
         final DetailAstImpl ast = new DetailAstImpl();
         ast.initialize(
             new CommonToken(TokenTypes.ENUM, "ENUM"));
-        try {
-            checkObj.visitToken(ast);
-            assertWithMessage("exception expected").fail();
-        }
-        catch (IllegalStateException exc) {
-            assertWithMessage("Invalid exception message")
-                .that(exc.getMessage())
-                .isEqualTo("ENUM[0x-1]");
-        }
+        final IllegalStateException visit =
+                getExpectedThrowable(IllegalStateException.class,
+                        () -> checkObj.visitToken(ast));
+        assertWithMessage("Invalid exception message")
+            .that(visit.getMessage())
+            .isEqualTo("ENUM[0x-1]");
     }
 
     @Test
@@ -150,15 +148,12 @@ public class ExecutableStatementCountCheckTest
         final DetailAstImpl ast = new DetailAstImpl();
         ast.initialize(
             new CommonToken(TokenTypes.ENUM, "ENUM"));
-        try {
-            checkObj.leaveToken(ast);
-            assertWithMessage("exception expected").fail();
-        }
-        catch (IllegalStateException exc) {
-            assertWithMessage("Invalid exception message")
-                .that(exc.getMessage())
-                .isEqualTo("ENUM[0x-1]");
-        }
+        final IllegalStateException leave =
+                getExpectedThrowable(IllegalStateException.class,
+                        () -> checkObj.leaveToken(ast));
+        assertWithMessage("Invalid exception message")
+            .that(leave.getMessage())
+            .isEqualTo("ENUM[0x-1]");
     }
 
     @Test

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/sizes/FileLengthCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/sizes/FileLengthCheckTest.java
@@ -21,6 +21,7 @@ package com.puppycrawl.tools.checkstyle.checks.sizes;
 
 import static com.google.common.truth.Truth.assertWithMessage;
 import static com.puppycrawl.tools.checkstyle.checks.sizes.FileLengthCheck.MSG_KEY;
+import static com.puppycrawl.tools.checkstyle.internal.utils.TestUtil.getExpectedThrowable;
 
 import org.junit.jupiter.api.Test;
 
@@ -68,21 +69,19 @@ public class FileLengthCheckTest
     }
 
     @Test
-    public void testArgs() throws Exception {
+    public void testArgs() {
         final DefaultConfiguration checkConfig =
             createModuleConfig(FileLengthCheck.class);
-        try {
-            checkConfig.addProperty("max", "abc");
-            createChecker(checkConfig);
-            assertWithMessage("Should indicate illegal args").fail();
-        }
-        catch (CheckstyleException exc) {
-            assertWithMessage("Invalid exception message")
-                .that(exc.getMessage())
-                .isEqualTo("cannot initialize module com.puppycrawl.tools.checkstyle.checks."
-                    + "sizes.FileLengthCheck - "
-                    + "illegal value 'abc' for property 'max'");
-        }
+        final CheckstyleException exc = getExpectedThrowable(CheckstyleException.class,
+                () -> {
+                    checkConfig.addProperty("max", "abc");
+                    createChecker(checkConfig);
+                });
+        assertWithMessage("Invalid exception message")
+            .that(exc.getMessage())
+            .isEqualTo("cannot initialize module com.puppycrawl.tools.checkstyle.checks."
+                + "sizes.FileLengthCheck - "
+                + "illegal value 'abc' for property 'max'");
     }
 
     @Test
@@ -104,15 +103,11 @@ public class FileLengthCheckTest
         assertWithMessage("extension should be the same")
             .that(check.getFileExtensions()[0])
             .isEqualTo(".java");
-        try {
-            check.setFileExtensions((String[]) null);
-            assertWithMessage("IllegalArgumentException is expected").fail();
-        }
-        catch (IllegalArgumentException exc) {
-            assertWithMessage("Invalid exception message")
-                .that(exc.getMessage())
-                .isEqualTo("Extensions array can not be null");
-        }
+        final IllegalArgumentException exc = getExpectedThrowable(IllegalArgumentException.class,
+                () -> check.setFileExtensions((String[]) null));
+        assertWithMessage("Invalid exception message")
+            .that(exc.getMessage())
+            .isEqualTo("Extensions array can not be null");
     }
 
 }


### PR DESCRIPTION
Issue: #19176

This PR converts `FileLengthCheckTest` and `ExecutableStatementCountCheckTest` to `getExpectedThrowable(...)`, keeping existing message assertions.

Note: `BooleanExpressionComplexityCheckTest` was already migrated on master, so it is no longer part of this PR.

Validation:
- `./mvnw -e --no-transfer-progress verify -Dtest="ExecutableStatementCountCheckTest,FileLengthCheckTest"`