### PR TITLE
Issue #19176: migrate coding tests to getExpectedThrowable

### DIFF
--- a/config/pmd-test.xml
+++ b/config/pmd-test.xml
@@ -96,7 +96,10 @@
            In ArchUnitTest, ArchUnitSuperClassTest, ImmutabilityTest, ArchUnitCyclesCheckTest
            assertion calls are not required as they are called by the library.
            In MainTest PMD does not find asserts in lambdas called in the method
-             invokeAndWait. -->
+             invokeAndWait.
+           In FinalLocalVariableCheckTest, IllegalTypeCheckTest, MatchXpathCheckTest,
+             ReturnCountCheckTest PMD does not find asserts in getExpectedThrowable
+             utility method called from the test method. -->
       <!-- For AllCheckTest.testAllModulesAreReferencedInConfigFile,
            testAllCheckTokensAreReferencedInCheckstyleConfigFile,
            testAllCheckTokensAreReferencedInGoogleConfigFile,
@@ -130,7 +133,16 @@
                    | //ClassDeclaration[@SimpleName='SuppressionFilterTest']
                        //MethodDeclaration[starts-with(@Name, 'testUseCache')]
                    | //ClassDeclaration[@SimpleName='MainTest']
-                       //MethodDeclaration[starts-with(@Name, 'testMain')]"/>
+                       //MethodDeclaration[starts-with(@Name, 'testMain')]
+                   | //ClassDeclaration[@SimpleName='FinalLocalVariableCheckTest']
+                       //MethodDeclaration[@Name='testImproperToken']
+                   | //ClassDeclaration[@SimpleName='IllegalTypeCheckTest']
+                       //MethodDeclaration[@Name='testImproperToken']
+                   | //ClassDeclaration[@SimpleName='MatchXpathCheckTest']
+                       //MethodDeclaration[@Name='testInvalidQuery'
+                        or @Name='testEvaluationException']
+                   | //ClassDeclaration[@SimpleName='ReturnCountCheckTest']
+                       //MethodDeclaration[@Name='testImproperToken']"/>
     </properties>
   </rule>
 

--- a/config/suppressions.xml
+++ b/config/suppressions.xml
@@ -176,6 +176,6 @@
   <!-- Remove suppression once all violations are fixed, tracked in #19176 -->
   <suppress checks="MatchXpath"
             id="MatchXpathForbidTryCatchFail"
-            files=".*[\\/]src[\\/]test[\\/]java[\\/]com[\\/]puppycrawl[\\/]tools[\\/]checkstyle[\\/](?!utils|xpath).*"/>
+            files=".*[\\/]src[\\/]test[\\/]java[\\/]com[\\/]puppycrawl[\\/]tools[\\/]checkstyle[\\/](?!utils|xpath|checks[\\/]coding).*"/>
 
 </suppressions>

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/coding/FinalLocalVariableCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/coding/FinalLocalVariableCheckTest.java
@@ -19,8 +19,8 @@
 
 package com.puppycrawl.tools.checkstyle.checks.coding;
 
-import static com.google.common.truth.Truth.assertWithMessage;
 import static com.puppycrawl.tools.checkstyle.checks.coding.FinalLocalVariableCheck.MSG_KEY;
+import static com.puppycrawl.tools.checkstyle.internal.utils.TestUtil.getExpectedThrowable;
 
 import org.junit.jupiter.api.Test;
 
@@ -251,13 +251,8 @@ public class FinalLocalVariableCheckTest
         final DetailAstImpl lambdaAst = new DetailAstImpl();
         lambdaAst.setType(TokenTypes.LAMBDA);
 
-        try {
-            check.visitToken(lambdaAst);
-            assertWithMessage("IllegalStateException is expected").fail();
-        }
-        catch (IllegalStateException exc) {
-            // it is OK
-        }
+        getExpectedThrowable(IllegalStateException.class,
+                () -> check.visitToken(lambdaAst));
     }
 
     @Test

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/coding/IllegalInstantiationCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/coding/IllegalInstantiationCheckTest.java
@@ -21,6 +21,7 @@ package com.puppycrawl.tools.checkstyle.checks.coding;
 
 import static com.google.common.truth.Truth.assertWithMessage;
 import static com.puppycrawl.tools.checkstyle.checks.coding.IllegalInstantiationCheck.MSG_KEY;
+import static com.puppycrawl.tools.checkstyle.internal.utils.TestUtil.getExpectedThrowable;
 
 import java.io.File;
 import java.util.Collection;
@@ -152,15 +153,12 @@ public class IllegalInstantiationCheckTest
         lambdaAst.setType(TokenTypes.LAMBDA);
         lambdaAst.setText("LAMBDA");
 
-        try {
-            check.visitToken(lambdaAst);
-            assertWithMessage("IllegalArgumentException is expected").fail();
-        }
-        catch (IllegalArgumentException exc) {
-            assertWithMessage("Message must include token name")
-                .that(exc.getMessage())
-                .contains("LAMBDA");
-        }
+        final IllegalArgumentException exc =
+                getExpectedThrowable(IllegalArgumentException.class,
+                        () -> check.visitToken(lambdaAst));
+        assertWithMessage("Message must include token name")
+            .that(exc.getMessage())
+            .contains("LAMBDA");
     }
 
     /**

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/coding/IllegalTypeCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/coding/IllegalTypeCheckTest.java
@@ -419,13 +419,8 @@ public class IllegalTypeCheckTest extends AbstractModuleTestSupport {
         final DetailAstImpl classDefAst = new DetailAstImpl();
         classDefAst.setType(TokenTypes.DOT);
 
-        try {
-            check.visitToken(classDefAst);
-            assertWithMessage("IllegalStateException is expected").fail();
-        }
-        catch (IllegalStateException exc) {
-            // it is OK
-        }
+        getExpectedThrowable(IllegalStateException.class,
+                () -> check.visitToken(classDefAst));
     }
 
     /**

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/coding/MatchXpathCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/coding/MatchXpathCheckTest.java
@@ -181,13 +181,8 @@ public class MatchXpathCheckTest
     public void testInvalidQuery() {
         final MatchXpathCheck matchXpathCheck = new MatchXpathCheck();
 
-        try {
-            matchXpathCheck.setQuery("!@#%^");
-            assertWithMessage("Exception was expected").fail();
-        }
-        catch (IllegalStateException ignored) {
-            // it is OK
-        }
+        getExpectedThrowable(IllegalStateException.class,
+                () -> matchXpathCheck.setQuery("!@#%^"));
     }
 
     @Test
@@ -201,13 +196,8 @@ public class MatchXpathCheckTest
         detailAST.setLineNo(0);
         detailAST.setColumnNo(0);
 
-        try {
-            matchXpathCheck.beginTree(detailAST);
-            assertWithMessage("Exception was expected").fail();
-        }
-        catch (IllegalStateException ignored) {
-            // it is OK
-        }
+        getExpectedThrowable(IllegalStateException.class,
+                () -> matchXpathCheck.beginTree(detailAST));
     }
 
     @Test

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/coding/ModifiedControlVariableCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/coding/ModifiedControlVariableCheckTest.java
@@ -21,6 +21,7 @@ package com.puppycrawl.tools.checkstyle.checks.coding;
 
 import static com.google.common.truth.Truth.assertWithMessage;
 import static com.puppycrawl.tools.checkstyle.checks.coding.ModifiedControlVariableCheck.MSG_KEY;
+import static com.puppycrawl.tools.checkstyle.internal.utils.TestUtil.getExpectedThrowable;
 
 import java.io.File;
 import java.util.Collection;
@@ -115,27 +116,19 @@ public class ModifiedControlVariableCheckTest
         classDefAst.setType(TokenTypes.CLASS_DEF);
         classDefAst.setText("CLASS_DEF");
 
-        try {
-            check.visitToken(classDefAst);
-            assertWithMessage("IllegalStateException is expected").fail();
-        }
-        catch (IllegalStateException exc) {
-            // it is OK
-            assertWithMessage("Error message must include token name")
-                    .that(exc.getMessage())
-                    .contains("CLASS_DEF");
-        }
+        final IllegalStateException visitExc =
+                getExpectedThrowable(IllegalStateException.class,
+                        () -> check.visitToken(classDefAst));
+        assertWithMessage("Error message must include token name")
+                .that(visitExc.getMessage())
+                .contains("CLASS_DEF");
 
-        try {
-            check.leaveToken(classDefAst);
-            assertWithMessage("IllegalStateException is expected").fail();
-        }
-        catch (IllegalStateException exc) {
-            // it is OK
-            assertWithMessage("Error message must include token name")
-                    .that(exc.getMessage())
-                    .contains("CLASS_DEF");
-        }
+        final IllegalStateException leaveExc =
+                getExpectedThrowable(IllegalStateException.class,
+                        () -> check.leaveToken(classDefAst));
+        assertWithMessage("Error message must include token name")
+                .that(leaveExc.getMessage())
+                .contains("CLASS_DEF");
     }
 
     @Test

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/coding/ReturnCountCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/coding/ReturnCountCheckTest.java
@@ -119,21 +119,11 @@ public class ReturnCountCheckTest extends AbstractModuleTestSupport {
         final DetailAstImpl classDefAst = new DetailAstImpl();
         classDefAst.setType(TokenTypes.CLASS_DEF);
 
-        try {
-            check.visitToken(classDefAst);
-            assertWithMessage("IllegalStateException is expected").fail();
-        }
-        catch (IllegalStateException exc) {
-            // it is OK
-        }
+        getExpectedThrowable(IllegalStateException.class,
+                () -> check.visitToken(classDefAst));
 
-        try {
-            check.leaveToken(classDefAst);
-            assertWithMessage("IllegalStateException is expected").fail();
-        }
-        catch (IllegalStateException exc) {
-            // it is OK
-        }
+        getExpectedThrowable(IllegalStateException.class,
+                () -> check.leaveToken(classDefAst));
     }
 
     @Test


### PR DESCRIPTION
Issue #19176: migrate coding tests to getExpectedThrowable

Migrated 6 test files in the checks/coding package from the old
assertWithMessage(...).fail() try-catch pattern to the new
getExpectedThrowable utility method.

Files migrated:
- FinalLocalVariableCheckTest.java (1 try-catch)
- IllegalInstantiationCheckTest.java (1 try-catch)
- IllegalTypeCheckTest.java (1 try-catch)
- MatchXpathCheckTest.java (2 try-catches)
- ModifiedControlVariableCheckTest.java (2 try-catches)
- ReturnCountCheckTest.java (2 try-catches)

Also updated config/suppressions.xml to add checks/coding to the
MatchXpathForbidTryCatchFail exclusion regex, and removed the
now-unused assertWithMessage import from FinalLocalVariableCheckTest.