### PR TITLE
Issue 19206 - Refactor gui package - extract duplicated listener logic and replace magic numbers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -50,3 +50,5 @@ replay_pid*
 # antlr4 grammar generates these
 **/gen
 **/JavaLanguageLexer.tokens
+
+designiteLog*.txt

--- a/config/jsoref-spellchecker/whitelist.words
+++ b/config/jsoref-spellchecker/whitelist.words
@@ -286,6 +286,7 @@ descendanttoken
 descr
 Deserializable
 designforextension
+designite
 destfile
 Destructuring
 detailast
@@ -853,7 +854,6 @@ mkordas
 mktemp
 MLINKCHECK
 MMMMMM
-MMMMMMMMMMMMMMMMMMMMMMMMMMMM
 moby
 mockit
 mockito

--- a/src/main/java/com/puppycrawl/tools/checkstyle/gui/BaseCellEditor.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/gui/BaseCellEditor.java
@@ -84,15 +84,7 @@ public class BaseCellEditor implements CellEditor {
      * @see EventListenerList
      */
     protected void fireEditingStopped() {
-        // Guaranteed to return a non-null array
-        final Object[] listeners = listenerList.getListenerList();
-        // Process the listeners last to first, notifying
-        // those that are interested in this event
-        for (int i = listeners.length - 2; i >= 0; i -= 2) {
-            if (listeners[i] == CellEditorListener.class) {
-                ((CellEditorListener) listeners[i + 1]).editingStopped(new ChangeEvent(this));
-            }
-        }
+        notifyListeners(true);
     }
 
     /**
@@ -102,13 +94,29 @@ public class BaseCellEditor implements CellEditor {
      * @see EventListenerList
      */
     protected void fireEditingCanceled() {
-        // Guaranteed to return a non-null array
+        notifyListeners(false);
+    }
+
+    /**
+     * Notifies all registered CellEditorListeners.
+     * Invokes editingStopped if stopped is true,
+     * editingCanceled otherwise.
+     *
+     * @param stopped true to notify listeners of editing stopped,
+     *                false to notify of editing canceled
+     */
+    private void notifyListeners(boolean stopped) {
         final Object[] listeners = listenerList.getListenerList();
-        // Process the listeners last to first, notifying
-        // those that are interested in this event
-        for (int i = listeners.length - 2; i >= 0; i -= 2) {
-            if (listeners[i] == CellEditorListener.class) {
-                ((CellEditorListener) listeners[i + 1]).editingCanceled(new ChangeEvent(this));
+        for (int idx = listeners.length - 2; idx >= 0; idx -= 2) {
+            if (listeners[idx] == CellEditorListener.class) {
+                final CellEditorListener listener =
+                        (CellEditorListener) listeners[idx + 1];
+                if (stopped) {
+                    listener.editingStopped(new ChangeEvent(this));
+                }
+                else {
+                    listener.editingCanceled(new ChangeEvent(this));
+                }
             }
         }
     }

--- a/src/main/java/com/puppycrawl/tools/checkstyle/gui/TreeTable.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/gui/TreeTable.java
@@ -70,6 +70,10 @@ public final class TreeTable extends JTable {
     private static final long serialVersionUID = -8493693409423365387L;
     /** The newline character. */
     private static final String NEWLINE = "\n";
+    /** The ratio of the total width allocated to the tree column. */
+    private static final double TREE_COLUMN_WIDTH_RATIO = 0.6;
+    /** The number of characters used to calculate the type column width. */
+    private static final int TYPE_COLUMN_CHAR_COUNT = 28;
     /** A subclass of JTree. */
     private final TreeTableCellRenderer tree;
     /** JTextArea editor. */
@@ -193,11 +197,12 @@ public final class TreeTable extends JTable {
         getColumn("Line").setMaxWidth(widthOfColumnContainingSixCharacterString);
         getColumn("Column").setMaxWidth(widthOfColumnContainingSixCharacterString);
         final int preferredTreeColumnWidth =
-                Math.toIntExact(Math.round(getPreferredSize().getWidth() * 0.6));
+                Math.toIntExact(Math.round(
+                        getPreferredSize().getWidth() * TREE_COLUMN_WIDTH_RATIO));
         getColumn("Tree").setPreferredWidth(preferredTreeColumnWidth);
         // Twenty-eight character string to contain "Type" column
         final int widthOfTwentyEightCharacterString =
-                fontMetrics.stringWidth("MMMMMMMMMMMMMMMMMMMMMMMMMMMM");
+                fontMetrics.stringWidth("M".repeat(TYPE_COLUMN_CHAR_COUNT));
         final int preferredTypeColumnWidth = widthOfTwentyEightCharacterString + padding;
         getColumn("Type").setPreferredWidth(preferredTypeColumnWidth);
     }
@@ -397,12 +402,12 @@ public final class TreeTable extends JTable {
         @Override
         public boolean isCellEditable(EventObject event) {
             if (event instanceof MouseEvent mouseEvent) {
-                for (int counter = getColumnCount() - 1; counter >= 0;
-                     counter--) {
-                    if (getColumnClass(counter) == ParseTreeTableModel.class) {
+                for (int columnIndex = getColumnCount() - 1; columnIndex >= 0;
+                     columnIndex--) {
+                    if (getColumnClass(columnIndex) == ParseTreeTableModel.class) {
                         final MouseEvent newMouseEvent = new MouseEvent(tree, mouseEvent.getID(),
                                 mouseEvent.getWhen(), mouseEvent.getModifiersEx(),
-                                mouseEvent.getX() - getCellRect(0, counter, true).x,
+                                mouseEvent.getX() - getCellRect(0, columnIndex, true).x,
                                 mouseEvent.getY(), mouseEvent.getClickCount(),
                                 mouseEvent.isPopupTrigger());
                         tree.dispatchEvent(newMouseEvent);


### PR DESCRIPTION
## Summary
Refactoring improvements in the `gui` package to improve readability and reduce code duplication.

## Changes Made

### BaseCellEditor.java - Extract Method
Extracted duplicated listener notification loop from 
`fireEditingStopped()` and `fireEditingCanceled()` into a 
private helper method `notifyListeners(boolean stopped)`.
No new imports required.

### TreeTable.java — Introduce Explaining Variables + Rename
- Replaced magic number `0.6` with named constant 
  `TREE_COLUMN_WIDTH_RATIO`
- Replaced 28 hardcoded M characters with named constant 
  `TYPE_COLUMN_CHAR_COUNT`
- Renamed loop variable `counter` to `columnIndex` in 
  `isCellEditable()`

## Testing
- `mvn clean verify` passes with zero errors
- All existing tests pass
- No functional changes - purely structural improvements