### PR TITLE
Issue #17449: Add missing examples for Indentation

### DIFF
--- a/src/site/xdoc/checks/misc/indentation.xml
+++ b/src/site/xdoc/checks/misc/indentation.xml
@@ -341,7 +341,303 @@ class Example4 {
         }
     }
 }
+</code></pre></div><hr class="example-separator"/>
+        <p id="Example5-config">
+          To configure the Check with arrayInitIndent:.
+        </p>
+        <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
+&lt;module name="Checker"&gt;
+  &lt;module name="TreeWalker"&gt;
+    &lt;module name="Indentation"&gt;
+      &lt;property name="arrayInitIndent" value="2"/&gt;
+    &lt;/module&gt;
+  &lt;/module&gt;
+&lt;/module&gt;
 </code></pre></div>
+        <p id="Example5-code">
+           Example of compliant code with arrayInitIndent
+        </p>
+        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+class Example5 {
+    String field = "example";                  // basicOffset
+    int[] values = {                           // basicOffset
+        10,
+        20,
+        30
+    };
+
+    void processValues() throws Exception {
+        handleValue("Test String", 42);          // basicOffset
+    }
+
+    void handleValue(String aFooString,
+                     int aFooInt) {             // indent:8 ; expected: &gt; 4;
+
+        boolean cond1,cond2,cond3,cond4,cond5,cond6;
+        cond1=cond2=cond3=cond4=cond5=cond6=false;
+
+        if (cond1
+                || cond2) {
+            field = field.toUpperCase()
+                    .concat(" TASK");
+        }
+
+        if ((cond1 &amp;&amp; cond2)
+                || (cond3 &amp;&amp; cond4)          // ok, lineWrappingIndentation
+                || !(cond5 &amp;&amp; cond6)) {      // ok, lineWrappingIndentation
+            field.toUpperCase()
+                    .concat(" TASK")             // ok, lineWrappingIndentation
+                    .chars().forEach(c -&gt; {      // ok, lineWrappingIndentation
+                        System.out.println((char) c);
+                    });
+        }
+    }
+
+    void demonstrateSwitch() throws Exception {
+        switch (field) {
+            case "EXAMPLE": processValues();                        // caseIndent
+            case "COMPLETED": handleValue("Completed Case", 456);   // caseIndent
+        }
+    }
+}
+</code></pre></div><hr class="example-separator"/>
+         <p id="Example6-config">
+            To configure the Check with basicOffset:
+         </p>
+         <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
+&lt;module name="Checker"&gt;
+  &lt;module name="TreeWalker"&gt;
+    &lt;module name="Indentation"&gt;
+      &lt;property name="basicOffset" value="2"/&gt;
+    &lt;/module&gt;
+  &lt;/module&gt;
+&lt;/module&gt;
+</code></pre></div>
+         <p id="Example6-code">
+            Example of compliant code with basicOffset
+         </p>
+         <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+class Example6 {
+  String field = "example";                  // basicOffset
+  int[] values = {                           // basicOffset
+      10,
+      20,
+      30
+  };
+
+  void processValues() throws Exception {
+    handleValue("Test String", 42);          // basicOffset
+  }
+
+  void handleValue(String aFooString,
+                   int aFooInt) {             // indent:8 ; expected: &gt; 4;
+
+    boolean cond1,cond2,cond3,cond4,cond5,cond6;
+    cond1=cond2=cond3=cond4=cond5=cond6=false;
+
+    if (cond1
+            || cond2) {
+      field = field.toUpperCase()
+              .concat(" TASK");
+    }
+
+    if ((cond1 &amp;&amp; cond2)
+            || (cond3 &amp;&amp; cond4)          // ok, lineWrappingIndentation
+            || !(cond5 &amp;&amp; cond6)) {      // ok, lineWrappingIndentation
+      field.toUpperCase()
+              .concat(" TASK")             // ok, lineWrappingIndentation
+              .chars().forEach(c -&gt; {      // ok, lineWrappingIndentation
+                System.out.println((char) c);
+              });
+    }
+  }
+
+    void demonstrateSwitch() throws Exception {
+        switch (field) {
+            case "EXAMPLE": processValues();                        // caseIndent
+            case "COMPLETED": handleValue("Completed Case", 456);   // caseIndent
+    }
+  }
+}
+</code></pre></div><hr class="example-separator"/>
+         <p id="Example7-config">
+           To configure the Check with braceAdjustment:
+         </p>
+         <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
+&lt;module name="Checker"&gt;
+  &lt;module name="TreeWalker"&gt;
+    &lt;module name="Indentation"&gt;
+      &lt;property name="braceAdjustment" value="2"/&gt;
+    &lt;/module&gt;
+  &lt;/module&gt;
+&lt;/module&gt;
+</code></pre></div>
+         <p id="Example7-code">
+            Example of compliant code with braceAdjustment
+         </p>
+         <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+class Example7 {
+    String field = "example";                  // basicOffset
+    int[] values = {                           // basicOffset
+        10,
+        20,
+        30
+    };
+
+    void processValues() throws Exception {
+        handleValue("Test String", 42);          // basicOffset
+    }
+
+    void handleValue(String aFooString,
+                     int aFooInt) {
+
+        boolean cond1,cond2,cond3,cond4,cond5,cond6;
+        cond1=cond2=cond3=cond4=cond5=cond6=false;
+
+        if (cond1
+                || cond2) {
+            field = field.toUpperCase()
+                    .concat(" TASK");
+        }
+
+        if ((cond1 &amp;&amp; cond2)
+                || (cond3 &amp;&amp; cond4)           // ok, lineWrappingIndentation
+                || !(cond5 &amp;&amp; cond6)) {       // ok, lineWrappingIndentation
+            field.toUpperCase()
+                    .concat(" TASK")             // ok, lineWrappingIndentation
+                    .chars().forEach(c -&gt; {      // ok, lineWrappingIndentation
+                        System.out.println((char) c);
+                    });
+        }
+    }
+
+    void demonstrateSwitch() throws Exception {
+        switch (field) {
+            case "EXAMPLE": processValues();                            // caseIndent
+            case "COMPLETED": handleValue("Completed Case", 456);       // caseIndent
+        }
+    }
+}
+</code></pre></div><hr class="example-separator"/>
+         <p id="Example8-config">
+            To configure the Check with throwsIndent:
+         </p>
+         <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
+&lt;module name="Checker"&gt;
+  &lt;module name="TreeWalker"&gt;
+    &lt;module name="Indentation"&gt;
+      &lt;property name="throwsIndent" value="6"/&gt;
+    &lt;/module&gt;
+  &lt;/module&gt;
+&lt;/module&gt;
+</code></pre></div>
+         <p id="Example8-code">
+            Example of compliant code with throwsIndent
+         </p>
+         <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+class Example8 {
+    String field = "example";                  // basicOffset
+    int[] values = {                           // basicOffset
+        10,
+        20,
+        30
+    };
+
+    void processValues() throws Exception {
+        handleValue("Test String", 42);          // basicOffset
+    }
+
+    void handleValue(String aFooString,
+                     int aFooInt) {             // indent:8 ; expected: &gt; 4;
+
+        boolean cond1,cond2,cond3,cond4,cond5,cond6;
+        cond1=cond2=cond3=cond4=cond5=cond6=false;
+
+        if (cond1
+                || cond2) {
+            field = field.toUpperCase()
+                    .concat(" TASK");
+        }
+
+        if ((cond1 &amp;&amp; cond2)
+                || (cond3 &amp;&amp; cond4)          // ok, lineWrappingIndentation
+                || !(cond5 &amp;&amp; cond6)) {      // ok, lineWrappingIndentation
+            field.toUpperCase()
+                    .concat(" TASK")             // ok, lineWrappingIndentation
+                    .chars().forEach(c -&gt; {      // ok, lineWrappingIndentation
+                        System.out.println((char) c);
+                    });
+        }
+    }
+
+    void demonstrateSwitch() throws Exception {
+        switch (field) {
+            case "EXAMPLE": processValues();                        // caseIndent
+            case "COMPLETED": handleValue("Completed Case", 456);   // caseIndent
+        }
+    }
+}
+</code></pre></div><hr class="example-separator"/>
+          <p id="Example9-config">
+             To configure the Check with lineWrappingIndentation:
+          </p>
+          <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
+&lt;module name="Checker"&gt;
+  &lt;module name="TreeWalker"&gt;
+    &lt;module name="Indentation"&gt;
+      &lt;property name="lineWrappingIndentation" value="4"/&gt;
+    &lt;/module&gt;
+  &lt;/module&gt;
+&lt;/module&gt;
+</code></pre></div>
+          <p id="Example9-code">
+             Example of compliant code with lineWrappingIndentation
+          </p>
+          <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+class Example9 {
+    String field = "example";                  // basicOffset
+    int[] values = {                           // basicOffset
+        10,
+        20,
+        30
+    };
+
+    void processValues() throws Exception {
+        handleValue("Test String", 42);          // basicOffset
+    }
+
+    void handleValue(String aFooString,
+                     int aFooInt) {             // indent:8 ; expected: &gt; 4;
+
+        boolean cond1,cond2,cond3,cond4,cond5,cond6;
+        cond1=cond2=cond3=cond4=cond5=cond6=false;
+
+        if (cond1
+                || cond2) {
+            field = field.toUpperCase()
+                    .concat(" TASK");
+        }
+
+        if ((cond1 &amp;&amp; cond2)
+                || (cond3 &amp;&amp; cond4)          // ok, lineWrappingIndentation
+                || !(cond5 &amp;&amp; cond6)) {      // ok, lineWrappingIndentation
+            field.toUpperCase()
+                    .concat(" TASK")             // ok, lineWrappingIndentation
+                    .chars().forEach(c -&gt; {      // ok, lineWrappingIndentation
+                        System.out.println((char) c);
+                    });
+        }
+    }
+
+    void demonstrateSwitch() throws Exception {
+        switch (field) {
+            case "EXAMPLE": processValues();                        // caseIndent
+            case "COMPLETED": handleValue("Completed Case", 456);   // caseIndent
+        }
+    }
+}
+</code></pre></div>
+
       </subsection>
 
       <subsection name="Example of Usage" id="Indentation_Example_of_Usage">

--- a/src/site/xdoc/checks/misc/indentation.xml.template
+++ b/src/site/xdoc/checks/misc/indentation.xml.template
@@ -88,7 +88,88 @@
           <param name="path"
                  value="resources/com/puppycrawl/tools/checkstyle/checks/indentation/indentation/Example4.java"/>
           <param name="type" value="code"/>
+        </macro><hr class="example-separator"/>
+        <p id="Example5-config">
+          To configure the Check with arrayInitIndent:.
+        </p>
+        <macro name="example">
+          <param name="path"
+                 value="resources/com/puppycrawl/tools/checkstyle/checks/indentation/indentation/Example5.java"/>
+          <param name="type" value="config"/>
         </macro>
+        <p id="Example5-code">
+           Example of compliant code with arrayInitIndent
+        </p>
+        <macro name="example">
+          <param name="path"
+                 value="resources/com/puppycrawl/tools/checkstyle/checks/indentation/indentation/Example5.java"/>
+          <param name="type" value="code"/>
+        </macro><hr class="example-separator"/>
+         <p id="Example6-config">
+            To configure the Check with basicOffset:
+         </p>
+         <macro name="example">
+            <param name="path"
+                    value="resources/com/puppycrawl/tools/checkstyle/checks/indentation/indentation/Example6.java"/>
+            <param name="type" value="config"/>
+         </macro>
+         <p id="Example6-code">
+            Example of compliant code with basicOffset
+         </p>
+         <macro name="example">
+           <param name="path"
+                   value="resources/com/puppycrawl/tools/checkstyle/checks/indentation/indentation/Example6.java"/>
+           <param name="type" value="code"/>
+         </macro><hr class="example-separator"/>
+         <p id="Example7-config">
+           To configure the Check with braceAdjustment:
+         </p>
+         <macro name="example">
+            <param name="path"
+                    value="resources/com/puppycrawl/tools/checkstyle/checks/indentation/indentation/Example7.java"/>
+            <param name="type" value="config"/>
+         </macro>
+         <p id="Example7-code">
+            Example of compliant code with braceAdjustment
+         </p>
+         <macro name="example">
+          <param name="path"
+                 value="resources/com/puppycrawl/tools/checkstyle/checks/indentation/indentation/Example7.java"/>
+          <param name="type" value="code"/>
+         </macro><hr class="example-separator"/>
+         <p id="Example8-config">
+            To configure the Check with throwsIndent:
+         </p>
+         <macro name="example">
+            <param name="path"
+                     value="resources/com/puppycrawl/tools/checkstyle/checks/indentation/indentation/Example8.java"/>
+            <param name="type" value="config"/>
+         </macro>
+         <p id="Example8-code">
+            Example of compliant code with throwsIndent
+         </p>
+         <macro name="example">
+           <param name="path"
+                  value="resources/com/puppycrawl/tools/checkstyle/checks/indentation/indentation/Example8.java"/>
+           <param name="type" value="code"/>
+         </macro><hr class="example-separator"/>
+          <p id="Example9-config">
+             To configure the Check with lineWrappingIndentation:
+          </p>
+          <macro name="example">
+            <param name="path"
+                      value="resources/com/puppycrawl/tools/checkstyle/checks/indentation/indentation/Example9.java"/>
+            <param name="type" value="config"/>
+          </macro>
+          <p id="Example9-code">
+             Example of compliant code with lineWrappingIndentation
+          </p>
+          <macro name="example">
+            <param name="path"
+                     value="resources/com/puppycrawl/tools/checkstyle/checks/indentation/indentation/Example9.java"/>
+            <param name="type" value="code"/>
+          </macro>
+
       </subsection>
 
       <subsection name="Example of Usage" id="Indentation_Example_of_Usage">

--- a/src/test/java/com/puppycrawl/tools/checkstyle/internal/XdocsExampleFileTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/internal/XdocsExampleFileTest.java
@@ -60,13 +60,6 @@ public class XdocsExampleFileTest {
     private static final Map<String, Set<String>> SUPPRESSED_PROPERTIES_BY_CHECK = Map.ofEntries(
             Map.entry("JavadocStyleCheck", Set.of("endOfSentenceFormat")),
             Map.entry("SuppressWarningsHolder", Set.of("aliasList")),
-            Map.entry("IndentationCheck", Set.of(
-                    "basicOffset",
-                    "lineWrappingIndentation",
-                    "throwsIndent",
-                    "arrayInitIndent",
-                    "braceAdjustment"
-            )),
             Map.entry("ClassMemberImpliedModifierCheck", Set.of(
                     "violateImpliedStaticOnNestedEnum",
                     "violateImpliedStaticOnNestedRecord",

--- a/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/checks/indentation/IndentationCheckExamplesTest.java
+++ b/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/checks/indentation/IndentationCheckExamplesTest.java
@@ -61,4 +61,34 @@ public class IndentationCheckExamplesTest extends AbstractExamplesModuleTestSupp
         final String[] expected = {};
         verifyWithInlineConfigParser(getPath("Example4.java"), expected);
     }
+
+    @Test
+    public void testExample5() throws Exception {
+        final String[] expected ={};
+        verifyWithInlineConfigParser(getPath("Example5.java"), expected);
+    }
+
+    @Test
+    public void testExample6() throws Exception {
+        final String[] expected ={};
+        verifyWithInlineConfigParser(getPath("Example6.java"), expected);
+    }
+
+    @Test
+    public void testExample7() throws Exception {
+        final String[] expected ={};
+        verifyWithInlineConfigParser(getPath("Example7.java"), expected);
+    }
+
+    @Test
+    public void testExample8() throws Exception {
+        final String[] expected ={};
+        verifyWithInlineConfigParser(getPath("Example8.java"), expected);
+    }
+
+    @Test
+    public void testExample9() throws Exception {
+        final String[] expected ={};
+        verifyWithInlineConfigParser(getPath("Example9.java"), expected);
+    }
 }

--- a/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/indentation/indentation/Example5.java
+++ b/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/indentation/indentation/Example5.java
@@ -1,0 +1,57 @@
+/*xml
+<module name="Checker">
+  <module name="TreeWalker">
+    <module name="Indentation">
+      <property name="arrayInitIndent" value="2"/>
+    </module>
+  </module>
+</module>
+*/
+
+package com.puppycrawl.tools.checkstyle.checks.indentation.indentation;
+
+// xdoc section -- start
+class Example5 {
+    String field = "example";                  // basicOffset
+    int[] values = {                           // basicOffset
+        10,
+        20,
+        30
+    };
+
+    void processValues() throws Exception {
+        handleValue("Test String", 42);          // basicOffset
+    }
+
+    void handleValue(String aFooString,
+                     int aFooInt) {             // indent:8 ; expected: > 4;
+
+        boolean cond1,cond2,cond3,cond4,cond5,cond6;
+        cond1=cond2=cond3=cond4=cond5=cond6=false;
+
+        if (cond1
+                || cond2) {
+            field = field.toUpperCase()
+                    .concat(" TASK");
+        }
+
+        if ((cond1 && cond2)
+                || (cond3 && cond4)          // ok, lineWrappingIndentation
+                || !(cond5 && cond6)) {      // ok, lineWrappingIndentation
+            field.toUpperCase()
+                    .concat(" TASK")             // ok, lineWrappingIndentation
+                    .chars().forEach(c -> {      // ok, lineWrappingIndentation
+                        System.out.println((char) c);
+                    });
+        }
+    }
+
+    void demonstrateSwitch() throws Exception {
+        switch (field) {
+            case "EXAMPLE": processValues();                        // caseIndent
+            case "COMPLETED": handleValue("Completed Case", 456);   // caseIndent
+        }
+    }
+}
+// xdoc section -- end
+

--- a/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/indentation/indentation/Example6.java
+++ b/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/indentation/indentation/Example6.java
@@ -1,0 +1,57 @@
+/*xml
+<module name="Checker">
+  <module name="TreeWalker">
+    <module name="Indentation">
+      <property name="basicOffset" value="2"/>
+    </module>
+  </module>
+</module>
+*/
+
+package com.puppycrawl.tools.checkstyle.checks.indentation.indentation;
+
+// xdoc section -- start
+class Example6 {
+  String field = "example";                  // basicOffset
+  int[] values = {                           // basicOffset
+      10,
+      20,
+      30
+  };
+
+  void processValues() throws Exception {
+    handleValue("Test String", 42);          // basicOffset
+  }
+
+  void handleValue(String aFooString,
+                   int aFooInt) {             // indent:8 ; expected: > 4;
+
+    boolean cond1,cond2,cond3,cond4,cond5,cond6;
+    cond1=cond2=cond3=cond4=cond5=cond6=false;
+
+    if (cond1
+            || cond2) {
+      field = field.toUpperCase()
+              .concat(" TASK");
+    }
+
+    if ((cond1 && cond2)
+            || (cond3 && cond4)          // ok, lineWrappingIndentation
+            || !(cond5 && cond6)) {      // ok, lineWrappingIndentation
+      field.toUpperCase()
+              .concat(" TASK")             // ok, lineWrappingIndentation
+              .chars().forEach(c -> {      // ok, lineWrappingIndentation
+                System.out.println((char) c);
+              });
+    }
+  }
+
+    void demonstrateSwitch() throws Exception {
+        switch (field) {
+            case "EXAMPLE": processValues();                        // caseIndent
+            case "COMPLETED": handleValue("Completed Case", 456);   // caseIndent
+    }
+  }
+}
+// xdoc section -- end
+

--- a/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/indentation/indentation/Example7.java
+++ b/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/indentation/indentation/Example7.java
@@ -1,0 +1,59 @@
+/*xml
+<module name="Checker">
+  <module name="TreeWalker">
+    <module name="Indentation">
+      <property name="braceAdjustment" value="2"/>
+    </module>
+  </module>
+</module>
+*/
+
+package com.puppycrawl.tools.checkstyle.checks.indentation.indentation;
+
+// xdoc section -- start
+class Example7 {
+    String field = "example";                  // basicOffset
+    int[] values = {                           // basicOffset
+        10,
+        20,
+        30
+    };
+
+    void processValues() throws Exception {
+        handleValue("Test String", 42);          // basicOffset
+    }
+
+    void handleValue(String aFooString,
+                     int aFooInt) {
+
+        boolean cond1,cond2,cond3,cond4,cond5,cond6;
+        cond1=cond2=cond3=cond4=cond5=cond6=false;
+
+        if (cond1
+                || cond2) {
+            field = field.toUpperCase()
+                    .concat(" TASK");
+        }
+
+        if ((cond1 && cond2)
+                || (cond3 && cond4)           // ok, lineWrappingIndentation
+                || !(cond5 && cond6)) {       // ok, lineWrappingIndentation
+            field.toUpperCase()
+                    .concat(" TASK")             // ok, lineWrappingIndentation
+                    .chars().forEach(c -> {      // ok, lineWrappingIndentation
+                        System.out.println((char) c);
+                    });
+        }
+    }
+
+    void demonstrateSwitch() throws Exception {
+        switch (field) {
+            case "EXAMPLE": processValues();                            // caseIndent
+            case "COMPLETED": handleValue("Completed Case", 456);       // caseIndent
+        }
+    }
+}
+// xdoc section -- end
+
+
+

--- a/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/indentation/indentation/Example8.java
+++ b/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/indentation/indentation/Example8.java
@@ -1,0 +1,57 @@
+/*xml
+<module name="Checker">
+  <module name="TreeWalker">
+    <module name="Indentation">
+      <property name="throwsIndent" value="6"/>
+    </module>
+  </module>
+</module>
+*/
+
+package com.puppycrawl.tools.checkstyle.checks.indentation.indentation;
+
+// xdoc section -- start
+class Example8 {
+    String field = "example";                  // basicOffset
+    int[] values = {                           // basicOffset
+        10,
+        20,
+        30
+    };
+
+    void processValues() throws Exception {
+        handleValue("Test String", 42);          // basicOffset
+    }
+
+    void handleValue(String aFooString,
+                     int aFooInt) {             // indent:8 ; expected: > 4;
+
+        boolean cond1,cond2,cond3,cond4,cond5,cond6;
+        cond1=cond2=cond3=cond4=cond5=cond6=false;
+
+        if (cond1
+                || cond2) {
+            field = field.toUpperCase()
+                    .concat(" TASK");
+        }
+
+        if ((cond1 && cond2)
+                || (cond3 && cond4)          // ok, lineWrappingIndentation
+                || !(cond5 && cond6)) {      // ok, lineWrappingIndentation
+            field.toUpperCase()
+                    .concat(" TASK")             // ok, lineWrappingIndentation
+                    .chars().forEach(c -> {      // ok, lineWrappingIndentation
+                        System.out.println((char) c);
+                    });
+        }
+    }
+
+    void demonstrateSwitch() throws Exception {
+        switch (field) {
+            case "EXAMPLE": processValues();                        // caseIndent
+            case "COMPLETED": handleValue("Completed Case", 456);   // caseIndent
+        }
+    }
+}
+// xdoc section -- end
+

--- a/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/indentation/indentation/Example9.java
+++ b/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/indentation/indentation/Example9.java
@@ -1,0 +1,57 @@
+/*xml
+<module name="Checker">
+  <module name="TreeWalker">
+    <module name="Indentation">
+      <property name="lineWrappingIndentation" value="4"/>
+    </module>
+  </module>
+</module>
+*/
+
+package com.puppycrawl.tools.checkstyle.checks.indentation.indentation;
+
+// xdoc section -- start
+class Example9 {
+    String field = "example";                  // basicOffset
+    int[] values = {                           // basicOffset
+        10,
+        20,
+        30
+    };
+
+    void processValues() throws Exception {
+        handleValue("Test String", 42);          // basicOffset
+    }
+
+    void handleValue(String aFooString,
+                     int aFooInt) {             // indent:8 ; expected: > 4;
+
+        boolean cond1,cond2,cond3,cond4,cond5,cond6;
+        cond1=cond2=cond3=cond4=cond5=cond6=false;
+
+        if (cond1
+                || cond2) {
+            field = field.toUpperCase()
+                    .concat(" TASK");
+        }
+
+        if ((cond1 && cond2)
+                || (cond3 && cond4)          // ok, lineWrappingIndentation
+                || !(cond5 && cond6)) {      // ok, lineWrappingIndentation
+            field.toUpperCase()
+                    .concat(" TASK")             // ok, lineWrappingIndentation
+                    .chars().forEach(c -> {      // ok, lineWrappingIndentation
+                        System.out.println((char) c);
+                    });
+        }
+    }
+
+    void demonstrateSwitch() throws Exception {
+        switch (field) {
+            case "EXAMPLE": processValues();                        // caseIndent
+            case "COMPLETED": handleValue("Completed Case", 456);   // caseIndent
+        }
+    }
+}
+// xdoc section -- end
+


### PR DESCRIPTION
#17449 

Added missing XDoc examples for IndentationCheck

Example5: arrayInitIndent
Example6: basicOffset
Example7: braceAdjustment
Example8: throwsIndent
Example9: lineWrappingIndentation
Updated the XDoc template file to include references to these examples.
Added IndentationCheckExamplesTest to verify the examples.

