### PR TITLE
Issue checkstyle#18453: exclude mvnw files and rewrite.yml from spell…

### DIFF
--- a/config/jsoref-spellchecker/exclude.pl
+++ b/config/jsoref-spellchecker/exclude.pl
@@ -24,6 +24,9 @@ my @excludes=qw(
   ^config/checker-framework-suppressions/
   ^config/archunit-store/
   ^config/sarif-schema-2.1.0.json$
+  ^mvnw$
+  ^mvnw\.cmd$
+  ^config/rewrite\.yml$
 );
 my $exclude = join "|", @excludes;
 while (<>) {

--- a/config/jsoref-spellchecker/whitelist.words
+++ b/config/jsoref-spellchecker/whitelist.words
@@ -49,7 +49,6 @@ APPLET
 appveyor
 APRV
 Aqj
-ARCHITEW
 archunit
 args
 Arial
@@ -78,7 +77,6 @@ autobuild
 autocomplete
 autoconfiguration
 autocrlf
-autofix
 Autoproxy
 Autowire
 Autowired
@@ -146,7 +144,6 @@ caciocavallosilano
 calledmethods
 camelcase
 casegroup
-casesensitive
 catchparametername
 cba
 cbeaff
@@ -240,13 +237,10 @@ csv
 ctc
 ctor
 ctx
-CTYPE
 customimportorder
 CVS
 cyclomatic
 cyclomaticcomplexity
-cygpath
-cygwin
 cz
 dalvik
 Daniil
@@ -390,7 +384,6 @@ Eslint
 esslingen
 esversion
 etsy
-euf
 ev
 Evt
 exceptionoverrides
@@ -492,7 +485,7 @@ gav
 Gdrox
 generalform
 genericwhitespace
-getenv
+Getenv
 gg
 gh
 Ghj
@@ -569,7 +562,6 @@ HXKS
 hyperlink
 hz
 iae
-icm
 ico
 icu
 identifiernames
@@ -629,7 +621,6 @@ isindex
 isset
 issuecomment
 issuehunt
-Itemtype
 itemvalue
 ith
 itr
@@ -643,8 +634,6 @@ Jakub
 jarchitect
 javaastvisitor
 javac
-JAVACCMD
-JAVACMD
 javadoc
 javadocblocktaglocation
 javadoccontentlocation
@@ -831,7 +820,6 @@ mfussenegger
 MHTML
 Micha
 microsoft
-mingw
 minimalistic
 Mipmap
 misconfigured
@@ -850,7 +838,6 @@ mixin
 mkdir
 MKo
 mkordas
-mktemp
 MLINKCHECK
 MMMMMM
 MMMMMMMMMMMMMMMMMMMMMMMMMMMM
@@ -881,10 +868,8 @@ multithreading
 mutableexception
 MVC
 mvn
-mvnd
 mvnrepository
 mvnw
-MWRAPPER
 Mycheckstyle
 mycompany
 mycompanychecks
@@ -957,7 +942,6 @@ nonrequiredjavadoc
 nonvalidating
 noparentfile
 NOPMD
-noprofile
 noreply
 noscript
 NOSONAR
@@ -987,7 +971,6 @@ numericliterals
 nutsandbolts
 nvim
 nvuillam
-nx
 OAuth
 objblock
 oburn
@@ -1094,7 +1077,6 @@ Pointcut
 POJO
 Popup
 Postgresql
-powershell
 prebuilts
 prefs
 PRESIZE
@@ -1110,8 +1092,6 @@ propertycachefile
 propkey
 protonpack
 Psevntu
-PSHOME
-PSMODULEP
 pullrequest
 puppycrawl
 pw
@@ -1148,7 +1128,6 @@ redundantmodifier
 refactor
 refactoring
 refaster
-refasterrules
 refid
 refreshenv
 regex
@@ -1163,7 +1142,6 @@ releasenotes
 RELi
 remkop
 reportyml
-REPOURL
 requireemptylinebeforeblocktaggroup
 requirethis
 resourceleak
@@ -1212,7 +1190,6 @@ Schneeberger
 scm
 scp
 screenshot
-Scriptblock
 Scss
 sdk
 sdkman
@@ -1227,7 +1204,6 @@ SERIALVERSIONUID
 servlet
 severitymatchfilter
 sevntu
-shasum
 shellcheck
 shengchen
 Shiell
@@ -1282,7 +1258,6 @@ stackoverflow
 stackoverflowerror
 stacktrace
 standalone
-staticanalysis
 staticvariablename
 stdin
 Stdlib
@@ -1370,7 +1345,6 @@ tidelift
 timeline
 timezone
 TKN
-Tls
 tmp
 tmpdir
 tngtech
@@ -1441,7 +1415,6 @@ upperell
 urandom
 uri
 url
-usebackq
 useenhancedswitch
 userguide
 username
@@ -1480,7 +1453,6 @@ Wakelock
 walkthrough
 Warni
 Weakento
-webclient
 Webflow
 webjar
 Weblogic
@@ -1570,7 +1542,6 @@ xwiki
 XXXX
 xxxxxx
 xy
-xzf
 xzvf
 yaml
 yamllint


### PR DESCRIPTION
Issue #18453: Exclude mvnw, mvnw.cmd, config/rewrite.yml from spellchecker

Added exclusion patterns to `config/jsoref-spellchecker/exclude.pl` for
the 3 files mentioned in issue #18453:

- `mvnw` — Maven wrapper shell script (external/generated)
- `mvnw.cmd` — Maven wrapper batch script (external/generated)
- `config/rewrite.yml` — OpenRewrite config (third-party/generated)

These files are not authored or maintained by the Checkstyle project,
so spell checking them provides no value and causes unnecessary CI failures.