### PR TITLE
Issue #19176: migrate metrics tests to getExpectedThrowable

### DIFF
--- a/config/suppressions.xml
+++ b/config/suppressions.xml
@@ -176,6 +176,6 @@
   <!-- Remove suppression once all violations are fixed, tracked in #19176 -->
   <suppress checks="MatchXpath"
             id="MatchXpathForbidTryCatchFail"
-            files=".*[\\/]src[\\/]test[\\/]java[\\/]com[\\/]puppycrawl[\\/]tools[\\/]checkstyle[\\/](?!utils|xpath|checks[\\/]coding|checks[\\/]design|checks[\\/]modifier|checks[\\/]naming|checks[\\/]annotation|checks[\\/]indentation).*"/>
+            files=".*[\\/]src[\\/]test[\\/]java[\\/]com[\\/]puppycrawl[\\/]tools[\\/]checkstyle[\\/](?!utils|xpath|checks[\\/]coding|checks[\\/]design|checks[\\/]modifier|checks[\\/]naming|checks[\\/]annotation|checks[\\/]indentation|checks[\\/]metrics).*"/>
 
 </suppressions>

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/metrics/BooleanExpressionComplexityCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/metrics/BooleanExpressionComplexityCheckTest.java
@@ -21,6 +21,7 @@ package com.puppycrawl.tools.checkstyle.checks.metrics;
 
 import static com.google.common.truth.Truth.assertWithMessage;
 import static com.puppycrawl.tools.checkstyle.checks.metrics.BooleanExpressionComplexityCheck.MSG_KEY;
+import static com.puppycrawl.tools.checkstyle.internal.utils.TestUtil.getExpectedThrowable;
 
 import org.antlr.v4.runtime.CommonToken;
 import org.junit.jupiter.api.Test;
@@ -76,15 +77,12 @@ public class BooleanExpressionComplexityCheckTest extends AbstractModuleTestSupp
             new BooleanExpressionComplexityCheck();
         final DetailAstImpl ast = new DetailAstImpl();
         ast.initialize(new CommonToken(TokenTypes.INTERFACE_DEF, "interface"));
-        try {
-            booleanExpressionComplexityCheckObj.visitToken(ast);
-            assertWithMessage("exception expected").fail();
-        }
-        catch (IllegalArgumentException exc) {
-            assertWithMessage("Invalid exception message")
-                .that(exc.getMessage())
-                .isEqualTo("Unknown type: interface[0x-1]");
-        }
+        final IllegalArgumentException exc =
+                getExpectedThrowable(IllegalArgumentException.class,
+                        () -> booleanExpressionComplexityCheckObj.visitToken(ast));
+        assertWithMessage("Invalid exception message")
+            .that(exc.getMessage())
+            .isEqualTo("Unknown type: interface[0x-1]");
     }
 
     @Test

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/metrics/ClassDataAbstractionCouplingCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/metrics/ClassDataAbstractionCouplingCheckTest.java
@@ -21,6 +21,7 @@ package com.puppycrawl.tools.checkstyle.checks.metrics;
 
 import static com.google.common.truth.Truth.assertWithMessage;
 import static com.puppycrawl.tools.checkstyle.checks.metrics.ClassDataAbstractionCouplingCheck.MSG_KEY;
+import static com.puppycrawl.tools.checkstyle.internal.utils.TestUtil.getExpectedThrowable;
 
 import org.antlr.v4.runtime.CommonToken;
 import org.junit.jupiter.api.Test;
@@ -96,7 +97,7 @@ public class ClassDataAbstractionCouplingCheckTest extends AbstractModuleTestSup
     }
 
     @Test
-    public void testExcludedPackageWithEndingDot() throws Exception {
+    public void testExcludedPackageWithEndingDot() {
         final DefaultConfiguration checkConfig =
             createModuleConfig(ClassDataAbstractionCouplingCheck.class);
 
@@ -104,21 +105,18 @@ public class ClassDataAbstractionCouplingCheckTest extends AbstractModuleTestSup
         checkConfig.addProperty("excludedPackages",
             "com.puppycrawl.tools.checkstyle.checks.metrics.inputs.a.");
 
-        try {
-            createChecker(checkConfig);
-            assertWithMessage("exception expected").fail();
-        }
-        catch (CheckstyleException exc) {
-            assertWithMessage("Invalid exception message")
-                .that(exc.getMessage())
-                .isEqualTo("cannot initialize module com.puppycrawl.tools.checkstyle.TreeWalker - "
-                    + "cannot initialize module com.puppycrawl.tools.checkstyle.checks."
-                    + "metrics.ClassDataAbstractionCouplingCheck");
-            assertWithMessage("Invalid exception message,")
-                .that(exc.getCause().getCause().getCause().getCause().getMessage())
-                .isEqualTo("the following values are not valid identifiers: ["
-                    + "com.puppycrawl.tools.checkstyle.checks.metrics.inputs.a.]");
-        }
+        final CheckstyleException exc =
+                getExpectedThrowable(CheckstyleException.class,
+                        () -> createChecker(checkConfig));
+        assertWithMessage("Invalid exception message")
+            .that(exc.getMessage())
+            .isEqualTo("cannot initialize module com.puppycrawl.tools.checkstyle.TreeWalker - "
+                + "cannot initialize module com.puppycrawl.tools.checkstyle.checks."
+                + "metrics.ClassDataAbstractionCouplingCheck");
+        assertWithMessage("Invalid exception message,")
+            .that(exc.getCause().getCause().getCause().getCause().getMessage())
+            .isEqualTo("the following values are not valid identifiers: ["
+                + "com.puppycrawl.tools.checkstyle.checks.metrics.inputs.a.]");
     }
 
     @Test
@@ -147,15 +145,12 @@ public class ClassDataAbstractionCouplingCheckTest extends AbstractModuleTestSup
             new ClassDataAbstractionCouplingCheck();
         final DetailAstImpl ast = new DetailAstImpl();
         ast.initialize(new CommonToken(TokenTypes.CTOR_DEF, "ctor"));
-        try {
-            classDataAbstractionCouplingCheckObj.visitToken(ast);
-            assertWithMessage("exception expected").fail();
-        }
-        catch (IllegalArgumentException exc) {
-            assertWithMessage("Invalid exception message")
-                .that(exc.getMessage())
-                .isEqualTo("Unknown type: ctor[0x-1]");
-        }
+        final IllegalArgumentException exc =
+                getExpectedThrowable(IllegalArgumentException.class,
+                        () -> classDataAbstractionCouplingCheckObj.visitToken(ast));
+        assertWithMessage("Invalid exception message")
+            .that(exc.getMessage())
+            .isEqualTo("Unknown type: ctor[0x-1]");
     }
 
     @Test

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/metrics/ClassFanOutComplexityCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/metrics/ClassFanOutComplexityCheckTest.java
@@ -21,6 +21,7 @@ package com.puppycrawl.tools.checkstyle.checks.metrics;
 
 import static com.google.common.truth.Truth.assertWithMessage;
 import static com.puppycrawl.tools.checkstyle.checks.metrics.ClassFanOutComplexityCheck.MSG_KEY;
+import static com.puppycrawl.tools.checkstyle.internal.utils.TestUtil.getExpectedThrowable;
 
 import java.io.File;
 import java.util.Collection;
@@ -79,7 +80,7 @@ public class ClassFanOutComplexityCheckTest extends AbstractModuleTestSupport {
     }
 
     @Test
-    public void testExcludedPackagesCommonPackagesWithEndingDot() throws Exception {
+    public void testExcludedPackagesCommonPackagesWithEndingDot() {
         final DefaultConfiguration checkConfig =
             createModuleConfig(ClassFanOutComplexityCheck.class);
 
@@ -87,21 +88,18 @@ public class ClassFanOutComplexityCheckTest extends AbstractModuleTestSupport {
         checkConfig.addProperty("excludedPackages",
             "com.puppycrawl.tools.checkstyle.checks.metrics.inputs.a.");
 
-        try {
-            createChecker(checkConfig);
-            assertWithMessage("exception expected").fail();
-        }
-        catch (CheckstyleException exc) {
-            assertWithMessage("Invalid exception message")
-                .that(exc.getMessage())
-                .isEqualTo("cannot initialize module com.puppycrawl.tools.checkstyle.TreeWalker - "
-                    + "cannot initialize module com.puppycrawl.tools.checkstyle.checks."
-                    + "metrics.ClassFanOutComplexityCheck");
-            assertWithMessage("Invalid exception message,")
-                .that(exc.getCause().getCause().getCause().getCause().getMessage())
-                .isEqualTo("the following values are not valid identifiers: ["
-                            + "com.puppycrawl.tools.checkstyle.checks.metrics.inputs.a.]");
-        }
+        final CheckstyleException exc =
+                getExpectedThrowable(CheckstyleException.class,
+                        () -> createChecker(checkConfig));
+        assertWithMessage("Invalid exception message")
+            .that(exc.getMessage())
+            .isEqualTo("cannot initialize module com.puppycrawl.tools.checkstyle.TreeWalker - "
+                + "cannot initialize module com.puppycrawl.tools.checkstyle.checks."
+                + "metrics.ClassFanOutComplexityCheck");
+        assertWithMessage("Invalid exception message,")
+            .that(exc.getCause().getCause().getCause().getCause().getMessage())
+            .isEqualTo("the following values are not valid identifiers: ["
+                        + "com.puppycrawl.tools.checkstyle.checks.metrics.inputs.a.]");
     }
 
     @Test


### PR DESCRIPTION
Issue #19176: migrate coding tests to getExpectedThrowable

Migrated 3 test files in the checks/metrics package from the old
assertWithMessage(...).fail() try-catch pattern to the new
getExpectedThrowable utility method.

Files migrated:
- BooleanExpressionComplexityCheckTest.java (1 try-catch)
- ClassFanOutComplexityCheckTest.java (1 try-catch)
- ClassDataAbstractionCouplingCheckTest.java (2 try-catches)

Also updated config/suppressions.xml to add checks/metrics to the
MatchXpathForbidTryCatchFail exclusion regex, and removed redundant
throws Exception from methods that no longer throw checked exceptions.

Resolves #19176
<img width="849" height="921" alt="Screenshot 2026-03-13 at 3 24 23 AM" src="https://github.com/user-attachments/assets/a1950050-c8b3-4c90-b08f-79e8149486ee" />

