### PR TITLE
Issue #17449: Add Missing Examples for ClassMemberImpliedModifierCheck

### DIFF
--- a/src/site/xdoc/checks/modifier/classmemberimpliedmodifier.xml
+++ b/src/site/xdoc/checks/modifier/classmemberimpliedmodifier.xml
@@ -122,6 +122,134 @@ public final class Example1 {
   }
 }
 </code></pre></div>
+        <hr class="example-separator"/>
+        <p id="Example2-config">
+          To configure the check to not require explicit <code>static</code> on nested enums:
+        </p>
+        <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
+&lt;module name="Checker"&gt;
+  &lt;module name="TreeWalker"&gt;
+    &lt;module name="ClassMemberImpliedModifier" /&gt;
+      &lt;property name="violateImpliedStaticOnNestedEnum" value="false"/&gt;
+  &lt;/module&gt;
+&lt;/module&gt;
+</code></pre></div>
+        <p id="Example2-code">
+          Code:
+        </p>
+        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+public final class Example2 {
+  static interface Address1 {
+  }
+
+  interface Address2 {  // violation, 'Implied modifier 'static' should be explicit'
+  }
+
+  static enum Age1 {
+    CHILD, ADULT
+  }
+
+  enum Age2 {  // violation, 'Implied modifier 'static' should be explicit'
+    CHILD, ADULT
+  }
+
+  public static record GoodRecord() {}
+  // violation below, 'Implied modifier 'static' should be explicit'
+  public record BadRecord() {}
+
+  public static record OuterRecord() {
+    static record InnerRecord1(){}
+    // violation below, 'Implied modifier 'static' should be explicit'
+    record InnerRecord2(){}
+  }
+}
+</code></pre></div>
+
+        <hr class="example-separator"/>
+        <p id="Example3-config">
+          To configure the check to not require explicit <code>static</code> on nested interfaces:
+        </p>
+        <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
+&lt;module name="Checker"&gt;
+  &lt;module name="TreeWalker"&gt;
+    &lt;module name="ClassMemberImpliedModifier" /&gt;
+      &lt;property name="violateImpliedStaticOnNestedInterface" value="false"/&gt;
+  &lt;/module&gt;
+&lt;/module&gt;
+</code></pre></div>
+        <p id="Example3-code">
+          Code:
+        </p>
+        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+public final class Example3 {
+  static interface Address1 {
+  }
+
+  interface Address2 {  // violation, 'Implied modifier 'static' should be explicit'
+  }
+
+  static enum Age1 {
+    CHILD, ADULT
+  }
+
+  enum Age2 {  // violation, 'Implied modifier 'static' should be explicit'
+    CHILD, ADULT
+  }
+
+  public static record GoodRecord() {}
+  // violation below, 'Implied modifier 'static' should be explicit'
+  public record BadRecord() {}
+
+  public static record OuterRecord() {
+    static record InnerRecord1(){}
+    // violation below, 'Implied modifier 'static' should be explicit'
+    record InnerRecord2(){}
+  }
+}
+</code></pre></div>
+
+        <hr class="example-separator"/>
+        <p id="Example4-config">
+          To configure the check to not require explicit <code>static</code> on nested records:
+        </p>
+        <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
+&lt;module name="Checker"&gt;
+  &lt;module name="TreeWalker"&gt;
+    &lt;module name="ClassMemberImpliedModifier" /&gt;
+      &lt;property name="violateImpliedStaticOnNestedRecord" value="false"/&gt;
+  &lt;/module&gt;
+&lt;/module&gt;
+</code></pre></div>
+        <p id="Example4-code">
+          Code:
+        </p>
+        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+public final class Example4 {
+  static interface Address1 {
+  }
+
+  interface Address2 {  // violation, 'Implied modifier 'static' should be explicit'
+  }
+
+  static enum Age1 {
+    CHILD, ADULT
+  }
+
+  enum Age2 {  // violation, 'Implied modifier 'static' should be explicit'
+    CHILD, ADULT
+  }
+
+  public static record GoodRecord() {}
+  // violation below, 'Implied modifier 'static' should be explicit'
+  public record BadRecord() {}
+
+  public static record OuterRecord() {
+    static record InnerRecord1(){}
+    // violation below, 'Implied modifier 'static' should be explicit'
+    record InnerRecord2(){}
+  }
+}
+</code></pre></div>
       </subsection>
 
       <subsection name="Example of Usage" id="ClassMemberImpliedModifier_Example_of_Usage">

--- a/src/site/xdoc/checks/modifier/classmemberimpliedmodifier.xml.template
+++ b/src/site/xdoc/checks/modifier/classmemberimpliedmodifier.xml.template
@@ -48,6 +48,59 @@
                  value="resources/com/puppycrawl/tools/checkstyle/checks/modifier/classmemberimpliedmodifier/Example1.java"/>
           <param name="type" value="code"/>
         </macro>
+        <hr class="example-separator"/>
+        <p id="Example2-config">
+          To configure the check to not require explicit <code>static</code> on nested enums:
+        </p>
+        <macro name="example">
+          <param name="path"
+                 value="resources/com/puppycrawl/tools/checkstyle/checks/modifier/classmemberimpliedmodifier/Example2.java"/>
+          <param name="type" value="config"/>
+        </macro>
+        <p id="Example2-code">
+          Code:
+        </p>
+        <macro name="example">
+          <param name="path"
+                 value="resources/com/puppycrawl/tools/checkstyle/checks/modifier/classmemberimpliedmodifier/Example2.java"/>
+          <param name="type" value="code"/>
+        </macro>
+
+        <hr class="example-separator"/>
+        <p id="Example3-config">
+          To configure the check to not require explicit <code>static</code> on nested interfaces:
+        </p>
+        <macro name="example">
+          <param name="path"
+                 value="resources/com/puppycrawl/tools/checkstyle/checks/modifier/classmemberimpliedmodifier/Example3.java"/>
+          <param name="type" value="config"/>
+        </macro>
+        <p id="Example3-code">
+          Code:
+        </p>
+        <macro name="example">
+          <param name="path"
+                 value="resources/com/puppycrawl/tools/checkstyle/checks/modifier/classmemberimpliedmodifier/Example3.java"/>
+          <param name="type" value="code"/>
+        </macro>
+
+        <hr class="example-separator"/>
+        <p id="Example4-config">
+          To configure the check to not require explicit <code>static</code> on nested records:
+        </p>
+        <macro name="example">
+          <param name="path"
+                 value="resources/com/puppycrawl/tools/checkstyle/checks/modifier/classmemberimpliedmodifier/Example4.java"/>
+          <param name="type" value="config"/>
+        </macro>
+        <p id="Example4-code">
+          Code:
+        </p>
+        <macro name="example">
+          <param name="path"
+                 value="resources/com/puppycrawl/tools/checkstyle/checks/modifier/classmemberimpliedmodifier/Example4.java"/>
+          <param name="type" value="code"/>
+        </macro>
       </subsection>
 
       <subsection name="Example of Usage" id="ClassMemberImpliedModifier_Example_of_Usage">

--- a/src/test/java/com/puppycrawl/tools/checkstyle/internal/XdocsExampleFileTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/internal/XdocsExampleFileTest.java
@@ -65,11 +65,6 @@ public class XdocsExampleFileTest {
                     "throwsIndent",
                     "arrayInitIndent",
                     "braceAdjustment"
-            )),
-            Map.entry("ClassMemberImpliedModifierCheck", Set.of(
-                    "violateImpliedStaticOnNestedEnum",
-                    "violateImpliedStaticOnNestedRecord",
-                    "violateImpliedStaticOnNestedInterface"
             ))
     );
 

--- a/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/checks/modifier/ClassMemberImpliedModifierCheckExamplesTest.java
+++ b/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/checks/modifier/ClassMemberImpliedModifierCheckExamplesTest.java
@@ -43,4 +43,43 @@ public class ClassMemberImpliedModifierCheckExamplesTest extends AbstractExample
         verifyWithInlineConfigParser(
                 getPath("Example1.java"), expected);
     }
+
+    @Test
+    public void testExample2() throws Exception {
+        final String[] expected = {
+            "17:3: " + getCheckMessage(MSG_KEY, "static"),
+            "24:3: " + getCheckMessage(MSG_KEY, "static"),
+            "30:3: " + getCheckMessage(MSG_KEY, "static"),
+            "35:5: " + getCheckMessage(MSG_KEY, "static"),
+        };
+
+        verifyWithInlineConfigParser(
+                getPath("Example2.java"), expected);
+    }
+
+    @Test
+    public void testExample3() throws Exception {
+        final String[] expected = {
+            "17:3: " + getCheckMessage(MSG_KEY, "static"),
+            "24:3: " + getCheckMessage(MSG_KEY, "static"),
+            "30:3: " + getCheckMessage(MSG_KEY, "static"),
+            "35:5: " + getCheckMessage(MSG_KEY, "static"),
+        };
+
+        verifyWithInlineConfigParser(
+                getPath("Example3.java"), expected);
+    }
+
+    @Test
+    public void testExample4() throws Exception {
+        final String[] expected = {
+            "17:3: " + getCheckMessage(MSG_KEY, "static"),
+            "24:3: " + getCheckMessage(MSG_KEY, "static"),
+            "30:3: " + getCheckMessage(MSG_KEY, "static"),
+            "35:5: " + getCheckMessage(MSG_KEY, "static"),
+        };
+
+        verifyWithInlineConfigParser(
+                getPath("Example4.java"), expected);
+    }
 }

--- a/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/modifier/classmemberimpliedmodifier/Example2.java
+++ b/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/modifier/classmemberimpliedmodifier/Example2.java
@@ -1,0 +1,38 @@
+/*xml
+<module name="Checker">
+  <module name="TreeWalker">
+    <module name="ClassMemberImpliedModifier" />
+      <property name="violateImpliedStaticOnNestedEnum" value="false"/>
+  </module>
+</module>
+*/
+// Java17
+package com.puppycrawl.tools.checkstyle.checks.modifier.classmemberimpliedmodifier;
+
+// xdoc section -- start
+public final class Example2 {
+  static interface Address1 {
+  }
+
+  interface Address2 {  // violation, 'Implied modifier 'static' should be explicit'
+  }
+
+  static enum Age1 {
+    CHILD, ADULT
+  }
+
+  enum Age2 {  // violation, 'Implied modifier 'static' should be explicit'
+    CHILD, ADULT
+  }
+
+  public static record GoodRecord() {}
+  // violation below, 'Implied modifier 'static' should be explicit'
+  public record BadRecord() {}
+
+  public static record OuterRecord() {
+    static record InnerRecord1(){}
+    // violation below, 'Implied modifier 'static' should be explicit'
+    record InnerRecord2(){}
+  }
+}
+// xdoc section -- end

--- a/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/modifier/classmemberimpliedmodifier/Example3.java
+++ b/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/modifier/classmemberimpliedmodifier/Example3.java
@@ -1,0 +1,38 @@
+/*xml
+<module name="Checker">
+  <module name="TreeWalker">
+    <module name="ClassMemberImpliedModifier" />
+      <property name="violateImpliedStaticOnNestedInterface" value="false"/>
+  </module>
+</module>
+*/
+// Java17
+package com.puppycrawl.tools.checkstyle.checks.modifier.classmemberimpliedmodifier;
+
+// xdoc section -- start
+public final class Example3 {
+  static interface Address1 {
+  }
+
+  interface Address2 {  // violation, 'Implied modifier 'static' should be explicit'
+  }
+
+  static enum Age1 {
+    CHILD, ADULT
+  }
+
+  enum Age2 {  // violation, 'Implied modifier 'static' should be explicit'
+    CHILD, ADULT
+  }
+
+  public static record GoodRecord() {}
+  // violation below, 'Implied modifier 'static' should be explicit'
+  public record BadRecord() {}
+
+  public static record OuterRecord() {
+    static record InnerRecord1(){}
+    // violation below, 'Implied modifier 'static' should be explicit'
+    record InnerRecord2(){}
+  }
+}
+// xdoc section -- end

--- a/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/modifier/classmemberimpliedmodifier/Example4.java
+++ b/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/modifier/classmemberimpliedmodifier/Example4.java
@@ -1,0 +1,38 @@
+/*xml
+<module name="Checker">
+  <module name="TreeWalker">
+    <module name="ClassMemberImpliedModifier" />
+      <property name="violateImpliedStaticOnNestedRecord" value="false"/>
+  </module>
+</module>
+*/
+// Java17
+package com.puppycrawl.tools.checkstyle.checks.modifier.classmemberimpliedmodifier;
+
+// xdoc section -- start
+public final class Example4 {
+  static interface Address1 {
+  }
+
+  interface Address2 {  // violation, 'Implied modifier 'static' should be explicit'
+  }
+
+  static enum Age1 {
+    CHILD, ADULT
+  }
+
+  enum Age2 {  // violation, 'Implied modifier 'static' should be explicit'
+    CHILD, ADULT
+  }
+
+  public static record GoodRecord() {}
+  // violation below, 'Implied modifier 'static' should be explicit'
+  public record BadRecord() {}
+
+  public static record OuterRecord() {
+    static record InnerRecord1(){}
+    // violation below, 'Implied modifier 'static' should be explicit'
+    record InnerRecord2(){}
+  }
+}
+// xdoc section -- end


### PR DESCRIPTION
#17449 

Added missing XDoc examples for ClassMemberImpliedModifierCheck

Example2: violateImpliedStaticOnNestedEnum
Example3: violateImpliedStaticOnNestedInterface
Example4: violateImpliedStaticOnNestedRecord

Updated the XDoc template file to include references to these examples.
Added ClassMemberImpliedModifierCheckTest to verify the examples.