### PR TITLE
Issue #16807: remove LineLengthCheck from SUPPRESSED_MODULES

### DIFF
--- a/src/test/java/com/puppycrawl/tools/checkstyle/bdd/InlineConfigParser.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/bdd/InlineConfigParser.java
@@ -332,7 +332,6 @@ public final class InlineConfigParser {
             "com.puppycrawl.tools.checkstyle.checks.regexp.RegexpCheck",
             "com.puppycrawl.tools.checkstyle.checks.regexp.RegexpSinglelineCheck",
             "com.puppycrawl.tools.checkstyle.checks.regexp.RegexpSinglelineJavaCheck",
-            "com.puppycrawl.tools.checkstyle.checks.sizes.LineLengthCheck",
             "com.puppycrawl.tools.checkstyle.checks.sizes.ParameterNumberCheck",
             "com.puppycrawl.tools.checkstyle.checks.whitespace.NoWhitespaceAfterCheck",
             "com.puppycrawl.tools.checkstyle.checks.whitespace.ParenPadCheck",

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/SuppressWarningsHolderTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/SuppressWarningsHolderTest.java
@@ -539,11 +539,11 @@ public class SuppressWarningsHolderTest extends AbstractModuleTestSupport {
     @Test
     public void testAliasList5() throws Exception {
         final String[] expected = {
-            "18: " + getCheckMessage(LineLengthCheck.class, MSG_KEY, 80, 83),
-            "28: " + getCheckMessage(LineLengthCheck.class, MSG_KEY, 75, 96),
-            "28: " + getCheckMessage(LineLengthCheck.class, MSG_KEY, 80, 96),
-            "58: " + getCheckMessage(LineLengthCheck.class, MSG_KEY, 75, 76),
-            "65: " + getCheckMessage(LineLengthCheck.class, MSG_KEY, 75, 87),
+            "23: " + getCheckMessage(LineLengthCheck.class, MSG_KEY, 80, 83),
+            "33: " + getCheckMessage(LineLengthCheck.class, MSG_KEY, 75, 96),
+            "33: " + getCheckMessage(LineLengthCheck.class, MSG_KEY, 80, 96),
+            "63: " + getCheckMessage(LineLengthCheck.class, MSG_KEY, 75, 76),
+            "70: " + getCheckMessage(LineLengthCheck.class, MSG_KEY, 75, 87),
         };
 
         verifyWithInlineConfigParser(

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/sizes/LineLengthCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/sizes/LineLengthCheckTest.java
@@ -150,7 +150,7 @@ public class LineLengthCheckTest extends AbstractModuleTestSupport {
     @Test
     public void testUnmappableCharacters() throws Exception {
         final String[] expected = {
-            "4: " + getCheckMessage(MSG_KEY, 75, 288),
+            "11: " + getCheckMessage(MSG_KEY, 75, 288),
         };
 
         final DefaultConfiguration checkConfig = createModuleConfig(LineLengthCheck.class);

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/sizes/linelength/InputLineLengthIgnoringImportStatements.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/sizes/linelength/InputLineLengthIgnoringImportStatements.java
@@ -1,9 +1,9 @@
 /*
 LineLength
-fileExtensions = (default)
+fileExtensions = (default)null
 ignorePattern = ^import.*
 max = 75
-
+tabWidth = (default)0
 
 */
 // Java17

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/sizes/linelength/InputLineLengthIgnoringPackageStatements.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/sizes/linelength/InputLineLengthIgnoringPackageStatements.java
@@ -1,9 +1,9 @@
 /*
 LineLength
-fileExtensions = (default)
+fileExtensions = (default)null
 ignorePattern = ^package.*
 max = 75
-
+tabWidth = (default)0
 
 */
 // Java17

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/sizes/linelength/InputLineLengthLongImportStatements.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/sizes/linelength/InputLineLengthLongImportStatements.java
@@ -1,6 +1,6 @@
 /*
 LineLength
-fileExtensions = (default)
+fileExtensions = (default)null
 ignorePattern = (default)^(package|import) .*
 max = (default)80
 

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/sizes/linelength/InputLineLengthLongLink.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/sizes/linelength/InputLineLengthLongLink.java
@@ -1,9 +1,9 @@
 /*
 LineLength
-fileExtensions = (default)""
+fileExtensions = (default)null
 ignorePattern = ^ *\\* *([^ ]+|\\{@code .*|<a href="[^"]+">)$
 max = (default)80
-
+tabWidth = (default)0
 
 */
 

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/sizes/linelength/InputLineLengthSimple1One.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/sizes/linelength/InputLineLengthSimple1One.java
@@ -1,10 +1,10 @@
 /*
 LineLength
-fileExtensions = (default)""
+fileExtensions = (default)null
 ignorePattern = ^.*is OK.*regexp.*$
 max = (default)80
 message.maxLineLen = {0},{1}
-
+tabWidth = (default)0
 
 */
 

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/sizes/linelength/InputLineLengthSimple1Three.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/sizes/linelength/InputLineLengthSimple1Three.java
@@ -1,10 +1,10 @@
 /*
 LineLength
-fileExtensions = (default)""
+fileExtensions = (default)null
 ignorePattern = ^.*is OK.*regexp.*$
 max = (default)80
 message.maxLineLen = {0},{1}
-
+tabWidth = (default)0
 
 */
 

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/sizes/linelength/InputLineLengthSimple1Two.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/sizes/linelength/InputLineLengthSimple1Two.java
@@ -1,10 +1,10 @@
 /*
 LineLength
-fileExtensions = (default)""
+fileExtensions = (default)null
 ignorePattern = ^.*is OK.*regexp.*$
 max = (default)80
 message.maxLineLen = {0},{1}
-
+tabWidth = (default)0
 
 */
 

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/sizes/linelength/InputLineLengthSimpleOne.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/sizes/linelength/InputLineLengthSimpleOne.java
@@ -1,9 +1,9 @@
 /*
 LineLength
-fileExtensions = (default)""
+fileExtensions = (default)null
 ignorePattern = ^.*is OK.*regexp.*$
 max = (default)80
-
+tabWidth = (default)0
 
 */
 

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/sizes/linelength/InputLineLengthSimpleThree.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/sizes/linelength/InputLineLengthSimpleThree.java
@@ -1,9 +1,9 @@
 /*
 LineLength
-fileExtensions = (default)""
+fileExtensions = (default)null
 ignorePattern = ^.*is OK.*regexp.*$
 max = (default)80
-
+tabWidth = (default)0
 
 */
 

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/sizes/linelength/InputLineLengthSimpleTwo.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/sizes/linelength/InputLineLengthSimpleTwo.java
@@ -1,9 +1,9 @@
 /*
 LineLength
-fileExtensions = (default)""
+fileExtensions = (default)null
 ignorePattern = ^.*is OK.*regexp.*$
 max = (default)80
-
+tabWidth = (default)0
 
 */
 

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/sizes/linelength/InputLineLengthUnicodeChars.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/sizes/linelength/InputLineLengthUnicodeChars.java
@@ -1,9 +1,9 @@
 /*
 LineLength
-fileExtensions = (default)""
+fileExtensions = (default)null
 ignorePattern = (default)^(package|import) .*
 max = 100
-
+tabWidth = (default)0
 
 */
 

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/sizes/linelength/InputLineLengthUnmappableCharacters.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/sizes/linelength/InputLineLengthUnmappableCharacters.java
@@ -1,3 +1,10 @@
+/*
+LineLength
+max = 75
+ignorePattern = (default)^(package|import) .*
+tabWidth = (default)0
+fileExtensions = (default)null
+*/
 package com.puppycrawl.tools.checkstyle.checks.sizes.linelength;
 
 public class InputLineLengthUnmappableCharacters {

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/suppresswarningsholder/InputSuppressWarningsHolderAlias6.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/suppresswarningsholder/InputSuppressWarningsHolderAlias6.java
@@ -6,10 +6,15 @@ com.puppycrawl.tools.checkstyle.filters.SuppressWarningsFilter
 
 com.puppycrawl.tools.checkstyle.checks.sizes.LineLengthCheck
 ignorePattern = ^ *\\* *[^ ]+$
+max = (default)80
+tabWidth = (default)0
+fileExtensions = (default)null
 
 com.puppycrawl.tools.checkstyle.checks.sizes.LineLengthCheck
 max = 75
-
+ignorePattern = (default)^(package|import) .*
+tabWidth = (default)0
+fileExtensions = (default)null
 
 */
 


### PR DESCRIPTION
Hi @romani,

This is my first PR for a "good second issue": Issue #16807.

### Summary

This PR updates LineLengthCheck input files to explicitly mention all default properties, as requested in #16807.

---

**Changes:**

- Removed `com.puppycrawl.tools.checkstyle.checks.sizes.LineLengthCheck` from SUPPRESSED_MODULES in `InlineConfigParser.java`
- Added annotation blocks to all LineLengthCheck input files, including:
    - `max = (default)80` (or custom value)
    - `ignorePattern = (default)^(package|import) .*` (or custom pattern)
    - `tabWidth = (default)0`
    - `fileExtensions = (default)null`
- Updated line numbers in `LineLengthCheckTest.java` and `SuppressWarningsHolderTest.java` to account for added lines.
- Fixed LineLength configurations in `InputSuppressWarningsHolderAlias6.java` to include all properties.

---

**Testing:**

- All 5815 tests pass locally (`mvn clean verify`)
- i get some JaCoCo coverage warnings for some GUI classes (see attached screenshot).
<img width="1612" height="284" alt="20260314_01h07m05s_grim" src="https://github.com/user-attachments/assets/71c128d7-bb60-43fd-97eb-5c1577545f15" />

---

**General Question (GSOC related):**

I understand that for GSOC acceptance, it's good to work through `good first issue` → `good second issue` → etc.  
Can I still submit PRs for `good first issues` after finishing a `second issue`?  
I see many files that can be improved, and sometimes my ADHD drives me to tackle easy fixes!  
For instance, I have PR #19190 open, not reviewed yet.

Thank you for your guidance!