### PR TITLE
Issue #19176: migrate javadoc tests to getExpectedThrowable

### DIFF
--- a/config/suppressions.xml
+++ b/config/suppressions.xml
@@ -176,6 +176,6 @@
   <!-- Remove suppression once all violations are fixed, tracked in #19176 -->
   <suppress checks="MatchXpath"
             id="MatchXpathForbidTryCatchFail"
-            files=".*[\\/]src[\\/]test[\\/]java[\\/]com[\\/]puppycrawl[\\/]tools[\\/]checkstyle[\\/](?!utils|xpath|checks[\\/]coding|checks[\\/]design|checks[\\/]modifier|checks[\\/]naming|checks[\\/]annotation|checks[\\/]indentation|checks[\\/]metrics|checks[\\/]whitespace).*"/>
+            files=".*[\\/]src[\\/]test[\\/]java[\\/]com[\\/]puppycrawl[\\/]tools[\\/]checkstyle[\\/](?!utils|xpath|checks[\\/]coding|checks[\\/]design|checks[\\/]modifier|checks[\\/]naming|checks[\\/]annotation|checks[\\/]indentation|checks[\\/]metrics|checks[\\/]whitespace|checks[\\/]javadoc).*"/>
 
 </suppressions>

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/javadoc/AbstractJavadocCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/javadoc/AbstractJavadocCheckTest.java
@@ -41,6 +41,7 @@ import com.puppycrawl.tools.checkstyle.AbstractModuleTestSupport;
 import com.puppycrawl.tools.checkstyle.DefaultConfiguration;
 import com.puppycrawl.tools.checkstyle.api.DetailNode;
 import com.puppycrawl.tools.checkstyle.api.JavadocCommentsTokenTypes;
+import com.puppycrawl.tools.checkstyle.internal.utils.TestUtil;
 import com.puppycrawl.tools.checkstyle.utils.CommonUtil;
 import com.puppycrawl.tools.checkstyle.utils.JavadocUtil;
 
@@ -329,20 +330,19 @@ public class AbstractJavadocCheckTest extends AbstractModuleTestSupport {
     @Test
     public void testAcceptableTokensFail() throws Exception {
         final String path = getPath("InputAbstractJavadocTokensFail.java");
-        try {
-            final String[] expected = CommonUtil.EMPTY_STRING_ARRAY;
-            verifyWithInlineConfigParser(path, expected);
-            assertWithMessage("CheckstyleException is expected").fail();
-        }
-        catch (IllegalStateException exc) {
-            final String expected = "Javadoc Token "
-                    + "\"RETURN_BLOCK_TAG\" was not found in "
-                    + "Acceptable javadoc tokens list in check "
-                    + TokenIsNotInAcceptablesCheck.class.getName();
-            assertWithMessage("Invalid exception, should start with: %s", expected)
-                    .that(exc.getMessage())
-                    .startsWith(expected);
-        }
+        final String[] expectedArr = CommonUtil.EMPTY_STRING_ARRAY;
+        final IllegalStateException exc =
+                TestUtil.getExpectedThrowable(
+                    IllegalStateException.class, () -> {
+                        verifyWithInlineConfigParser(path, expectedArr);
+                    });
+        final String expected = "Javadoc Token "
+                + "\"RETURN_BLOCK_TAG\" was not found in "
+                + "Acceptable javadoc tokens list in check "
+                + TokenIsNotInAcceptablesCheck.class.getName();
+        assertWithMessage("Invalid exception, should start with: %s", expected)
+                .that(exc.getMessage())
+                .startsWith(expected);
     }
 
     @Test
@@ -352,25 +352,24 @@ public class AbstractJavadocCheckTest extends AbstractModuleTestSupport {
     }
 
     @Test
-    public void testRequiredTokenIsNotInDefaultTokens() throws Exception {
+    public void testRequiredTokenIsNotInDefaultTokens() {
         final DefaultConfiguration checkConfig =
             createModuleConfig(RequiredTokenIsNotInDefaultsJavadocCheck.class);
         final String uniqueFileName = "empty_" + UUID.randomUUID() + ".java";
         final File pathToEmptyFile = new File(temporaryFolder, uniqueFileName);
 
-        try {
-            execute(checkConfig, pathToEmptyFile.toString());
-            assertWithMessage("CheckstyleException is expected").fail();
-        }
-        catch (IllegalStateException exc) {
-            final String expected = "Javadoc Token \""
-                    + JavadocCommentsTokenTypes.RETURN_BLOCK_TAG + "\" from required"
-                    + " javadoc tokens was not found in default javadoc tokens list in check "
-                    + RequiredTokenIsNotInDefaultsJavadocCheck.class.getName();
-            assertWithMessage("Invalid exception, should start with: %s", expected)
-                    .that(exc.getMessage())
-                    .startsWith(expected);
-        }
+        final IllegalStateException exc =
+                TestUtil.getExpectedThrowable(
+                    IllegalStateException.class, () -> {
+                        execute(checkConfig, pathToEmptyFile.toString());
+                    });
+        final String expected = "Javadoc Token \""
+                + JavadocCommentsTokenTypes.RETURN_BLOCK_TAG + "\" from required"
+                + " javadoc tokens was not found in default javadoc tokens list in check "
+                + RequiredTokenIsNotInDefaultsJavadocCheck.class.getName();
+        assertWithMessage("Invalid exception, should start with: %s", expected)
+                .that(exc.getMessage())
+                .startsWith(expected);
     }
 
     @Test

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocPackageCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocPackageCheckTest.java
@@ -31,6 +31,7 @@ import org.junit.jupiter.api.Test;
 import com.puppycrawl.tools.checkstyle.AbstractModuleTestSupport;
 import com.puppycrawl.tools.checkstyle.api.CheckstyleException;
 import com.puppycrawl.tools.checkstyle.api.FileText;
+import com.puppycrawl.tools.checkstyle.internal.utils.TestUtil;
 import com.puppycrawl.tools.checkstyle.utils.CommonUtil;
 
 public class JavadocPackageCheckTest
@@ -118,15 +119,17 @@ public class JavadocPackageCheckTest
         final FileText mockFileText = new FileText(fileWithInvalidPath, Collections.emptyList());
         final String expectedExceptionMessage =
                 "Exception while getting canonical path to file " + fileWithInvalidPath.getPath();
-        try {
-            check.processFiltered(fileWithInvalidPath, mockFileText);
-            assertWithMessage("CheckstyleException expected to be thrown").fail();
-        }
-        catch (CheckstyleException exc) {
-            assertWithMessage("Invalid exception message. Expected: %s", expectedExceptionMessage)
-                .that(exc.getMessage())
-                .isEqualTo(expectedExceptionMessage);
-        }
+        final CheckstyleException exc =
+                TestUtil.getExpectedThrowable(
+                    CheckstyleException.class, () -> {
+                        check.processFiltered(
+                            fileWithInvalidPath, mockFileText);
+                    });
+        assertWithMessage(
+                "Invalid exception message. Expected: %s",
+                expectedExceptionMessage)
+            .that(exc.getMessage())
+            .isEqualTo(expectedExceptionMessage);
     }
 
     @Test

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocTagInfoTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocTagInfoTest.java
@@ -447,45 +447,41 @@ public class JavadocTagInfoTest {
             .that(JavadocTagInfo.VERSION.toString())
             .isEqualTo("text [@version] name [version] type [BLOCK]");
 
-        try {
-            JavadocTagInfo.fromName(null);
-            assertWithMessage("IllegalArgumentException is expected").fail();
-        }
-        catch (IllegalArgumentException exc) {
-            assertWithMessage("Invalid exception message")
-                .that(exc.getMessage())
-                .isEqualTo("the name is null");
-        }
+        final IllegalArgumentException excNull =
+                TestUtil.getExpectedThrowable(
+                    IllegalArgumentException.class, () -> {
+                        JavadocTagInfo.fromName(null);
+                    });
+        assertWithMessage("Invalid exception message")
+            .that(excNull.getMessage())
+            .isEqualTo("the name is null");
 
-        try {
-            JavadocTagInfo.fromName("myname");
-            assertWithMessage("IllegalArgumentException is expected").fail();
-        }
-        catch (IllegalArgumentException exc) {
-            assertWithMessage("Invalid exception message")
-                .that(exc.getMessage())
-                .isEqualTo("the name [myname] is not a valid Javadoc tag name");
-        }
+        final IllegalArgumentException excName =
+                TestUtil.getExpectedThrowable(
+                    IllegalArgumentException.class, () -> {
+                        JavadocTagInfo.fromName("myname");
+                    });
+        assertWithMessage("Invalid exception message")
+            .that(excName.getMessage())
+            .isEqualTo("the name [myname] is not a valid Javadoc tag name");
 
-        try {
-            JavadocTagInfo.fromText(null);
-            assertWithMessage("IllegalArgumentException is expected").fail();
-        }
-        catch (IllegalArgumentException exc) {
-            assertWithMessage("Invalid exception message")
-                .that(exc.getMessage())
-                .isEqualTo("the text is null");
-        }
+        final IllegalArgumentException excTextNull =
+                TestUtil.getExpectedThrowable(
+                    IllegalArgumentException.class, () -> {
+                        JavadocTagInfo.fromText(null);
+                    });
+        assertWithMessage("Invalid exception message")
+            .that(excTextNull.getMessage())
+            .isEqualTo("the text is null");
 
-        try {
-            JavadocTagInfo.fromText("myname");
-            assertWithMessage("IllegalArgumentException is expected").fail();
-        }
-        catch (IllegalArgumentException exc) {
-            assertWithMessage("Invalid exception message")
-                .that(exc.getMessage())
-                .isEqualTo("the text [myname] is not a valid Javadoc tag text");
-        }
+        final IllegalArgumentException excText =
+                TestUtil.getExpectedThrowable(
+                    IllegalArgumentException.class, () -> {
+                        JavadocTagInfo.fromText("myname");
+                    });
+        assertWithMessage("Invalid exception message")
+            .that(excText.getMessage())
+            .isEqualTo("the text [myname] is not a valid Javadoc tag text");
 
         assertWithMessage("Invalid fromText result")
             .that(JavadocTagInfo.fromText("@version"))

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/javadoc/utils/InlineTagUtilTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/javadoc/utils/InlineTagUtilTest.java
@@ -105,28 +105,26 @@ public class InlineTagUtilTest {
 
     @Test
     public void testBadInputExtractInlineTagsLineFeed() {
-        try {
-            InlineTagUtil.extractInlineTags("abc\ndef");
-            assertWithMessage("IllegalArgumentException expected").fail();
-        }
-        catch (IllegalArgumentException exc) {
-            assertWithMessage("Unexpected error message")
-                    .that(exc.getMessage())
-                    .contains("newline");
-        }
+        final IllegalArgumentException exc =
+                TestUtil.getExpectedThrowable(
+                    IllegalArgumentException.class, () -> {
+                        InlineTagUtil.extractInlineTags("abc\ndef");
+                    });
+        assertWithMessage("Unexpected error message")
+                .that(exc.getMessage())
+                .contains("newline");
     }
 
     @Test
     public void testBadInputExtractInlineTagsCarriageReturn() {
-        try {
-            InlineTagUtil.extractInlineTags("abc\rdef");
-            assertWithMessage("IllegalArgumentException expected").fail();
-        }
-        catch (IllegalArgumentException exc) {
-            assertWithMessage("Invalid error message")
-                    .that(exc.getMessage())
-                    .contains("newline");
-        }
+        final IllegalArgumentException exc =
+                TestUtil.getExpectedThrowable(
+                    IllegalArgumentException.class, () -> {
+                        InlineTagUtil.extractInlineTags("abc\rdef");
+                    });
+        assertWithMessage("Invalid error message")
+                .that(exc.getMessage())
+                .contains("newline");
     }
 
     private static void assertTag(TagInfo tag, String name, String value, int line, int col) {


### PR DESCRIPTION
Issue #19176: migrate javadoc tests to getExpectedThrowable

Migrated 4 test files in the checks/javadoc package from the old
assertWithMessage(...).fail() try-catch pattern to the new
getExpectedThrowable utility method.

Files migrated:
- JavadocTagInfoTest.java (4 try-catch blocks)
- AbstractJavadocCheckTest.java (2 try-catch blocks)
- InlineTagUtilTest.java (2 try-catch blocks)
- JavadocPackageCheckTest.java (1 try-catch block)

Also updated config/suppressions.xml to add checks[\\/]javadoc to the
MatchXpathForbidTryCatchFail exclusion regex.