### PR TITLE
Issue #3885: Handle simple infinite loops in FallThroughCheck

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/FallThroughCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/FallThroughCheck.java
@@ -28,6 +28,7 @@ import com.puppycrawl.tools.checkstyle.api.AbstractCheck;
 import com.puppycrawl.tools.checkstyle.api.DetailAST;
 import com.puppycrawl.tools.checkstyle.api.TokenTypes;
 import com.puppycrawl.tools.checkstyle.utils.CheckUtil;
+import com.puppycrawl.tools.checkstyle.utils.TokenUtil;
 
 /**
  * <div>
@@ -50,6 +51,12 @@ import com.puppycrawl.tools.checkstyle.utils.CheckUtil;
  *
  * <p>
  * Note: The check assumes that there is no unreachable code in the {@code case}.
+ * </p>
+ *
+ * <p>
+ * Note: The check handles {@code while (true)}, {@code do-while (true)},
+ * and {@code for (;;)} as infinite loops. It will not examine variables or
+ * complex expressions to determine if a loop is infinite.
  * </p>
  *
  * @since 3.4
@@ -127,12 +134,13 @@ public class FallThroughCheck extends AbstractCheck {
         if (!isLastGroup || checkLastCaseGroup) {
             final DetailAST slist = ast.findFirstToken(TokenTypes.SLIST);
 
-            if (slist != null && !CheckUtil.isTerminated(slist) && !hasFallThroughComment(ast)) {
+            if (slist != null && !CheckUtil.isTerminated(slist) && !hasFallThroughComment(ast)
+                    && !isTerminatedByInfiniteLoop(slist)) {
                 if (isLastGroup) {
                     log(ast, MSG_FALL_THROUGH_LAST);
                 }
                 else {
-                    log(nextGroup, MSG_FALL_THROUGH);
+                    log(ast, MSG_FALL_THROUGH);
                 }
             }
         }
@@ -197,4 +205,142 @@ public class FallThroughCheck extends AbstractCheck {
         return result;
     }
 
+    /**
+     * Checks if a statement list is terminated by an infinite loop.
+     *
+     * @param ast the AST node.
+     * @return true if the last statement is an infinite loop.
+     */
+    private static boolean isTerminatedByInfiniteLoop(DetailAST ast) {
+        if (ast == null) {
+            return false;
+        }
+
+        DetailAST lastStatement = ast.getLastChild();
+
+        while (lastStatement != null
+                && (lastStatement.getType() == TokenTypes.RCURLY
+                || lastStatement.getType() == TokenTypes.LCURLY
+                || lastStatement.getType() == TokenTypes.SEMI
+                || TokenUtil.isCommentType(lastStatement.getType()))) {
+
+            lastStatement = lastStatement.getPreviousSibling();
+        }
+
+        if (lastStatement == null) {
+            return false;
+        }
+
+        if (lastStatement.getType() == TokenTypes.SLIST) {
+            return isTerminatedByInfiniteLoop(lastStatement);
+        }
+
+        return isInfiniteLoop(lastStatement);
+    }
+
+    /**
+     * Checks if a given AST node represents an infinite loop.
+     *
+     * @param ast the AST node to check.
+     * @return true if it is an infinite loop (e.g., while(true), for(;;), do-while(true)).
+     */
+    private static boolean isInfiniteLoop(DetailAST ast) {
+        final int type = ast.getType();
+        boolean result = false;
+
+        if (type == TokenTypes.LITERAL_WHILE || type == TokenTypes.LITERAL_DO) {
+            final DetailAST expr = ast.findFirstToken(TokenTypes.EXPR);
+            result = isTrueExpression(expr) && !hasUnlabeledBreak(getLoopBody(ast));
+        }
+        else if (type == TokenTypes.LITERAL_FOR) {
+            final DetailAST forEach = ast.findFirstToken(TokenTypes.FOR_EACH_CLAUSE);
+            if (forEach == null) {
+                final DetailAST condition = ast.findFirstToken(TokenTypes.FOR_CONDITION);
+                // A for-loop condition is empty if it is null, has no children, 
+                // or has an empty EXPR child (for(;;))
+                final boolean isConditionEmpty = condition == null 
+                        || condition.getChildCount() == 0
+                        || (condition.getChildCount() == 1 
+                            && condition.getFirstChild().getChildCount() == 0);
+                
+                result = isConditionEmpty && !hasUnlabeledBreak(ast.getLastChild());
+            }
+        }
+        return result;
+    }
+
+    /**
+     * Finds the body of a loop.
+     *
+     * @param loop the loop node.
+     * @return the body node.
+     */
+    private static DetailAST getLoopBody(DetailAST loop) {
+        final DetailAST body;
+        if (loop.getType() == TokenTypes.LITERAL_DO) {
+            body = loop.getFirstChild();
+        }
+        else {
+            body = loop.getLastChild();
+        }
+        return body;
+    }
+
+    /**
+     * Checks if an EXPR AST node evaluates to a literal 'true'.
+     *
+     * @param expr the EXPR AST node.
+     * @return true if it contains a LITERAL_TRUE.
+     */
+    private static boolean isTrueExpression(DetailAST expr) {
+        if (expr == null) {
+            return false;
+        }
+        DetailAST child = expr.getFirstChild();
+        while (child != null) {
+            if (child.getType() == TokenTypes.LITERAL_TRUE) {
+                return true;
+            }
+            child = child.getNextSibling();
+        }
+        return false;
+    }
+
+    /**
+     * Checks if an AST node is a loop or switch.
+     *
+     * @param type the token type.
+     * @return true if it is a loop or switch.
+     */
+    private static boolean isLoopOrSwitch(int type) {
+        return type == TokenTypes.LITERAL_FOR
+                || type == TokenTypes.LITERAL_WHILE
+                || type == TokenTypes.LITERAL_DO
+                || type == TokenTypes.LITERAL_SWITCH;
+    }
+
+    /**
+     * Checks if an AST node or its children contain an unlabeled break.
+     *
+     * @param ast the AST node to check.
+     * @return true if an unlabeled break is found.
+     */
+    private static boolean hasUnlabeledBreak(DetailAST ast) {
+        boolean result = false;
+        if (ast != null) {
+            final int type = ast.getType();
+            if (type == TokenTypes.LITERAL_BREAK
+                    && ast.findFirstToken(TokenTypes.IDENT) == null) {
+                result = true;
+            }
+            else if (!isLoopOrSwitch(type)) {
+                DetailAST child = ast.getFirstChild();
+                while (child != null && !result) {
+                    result = hasUnlabeledBreak(child);
+                    child = child.getNextSibling();
+                }
+            }
+        }
+        return result;
+    }
 }

--- a/src/main/resources/com/puppycrawl/tools/checkstyle/meta/checks/coding/FallThroughCheck.xml
+++ b/src/main/resources/com/puppycrawl/tools/checkstyle/meta/checks/coding/FallThroughCheck.xml
@@ -24,6 +24,12 @@
 
  &lt;p&gt;
  Note: The check assumes that there is no unreachable code in the &lt;code&gt;case&lt;/code&gt;.
+ &lt;/p&gt;
+
+ &lt;p&gt;
+ Note: The check handles &lt;code&gt;while (true)&lt;/code&gt;, &lt;code&gt;do-while (true)&lt;/code&gt;,
+ and &lt;code&gt;for (;;)&lt;/code&gt; as infinite loops. It will not examine variables or
+ complex expressions to determine if a loop is infinite.
  &lt;/p&gt;</description>
          <properties>
             <property default-value="false" name="checkLastCaseGroup" type="boolean">

--- a/src/site/xdoc/checks/coding/fallthrough.xml
+++ b/src/site/xdoc/checks/coding/fallthrough.xml
@@ -30,6 +30,12 @@
         <p>
           Note: The check assumes that there is no unreachable code in the <code>case</code>.
         </p>
+
+        <p>
+          Note: The check handles <code>while (true)</code>, <code>do-while (true)</code>,
+          and <code>for (;;)</code> as infinite loops. It will not examine variables or
+          complex expressions to determine if a loop is infinite.
+        </p>
       </subsection>
 
       <subsection name="Properties" id="FallThrough_Properties">

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/coding/FallThroughCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/coding/FallThroughCheckTest.java
@@ -448,4 +448,27 @@ public class FallThroughCheckTest extends AbstractModuleTestSupport {
                 getPath("InputFallThroughWithPatternMatchingCheckLastCase.java"),
                 expected);
     }
+
+    @Test
+    public void testInfiniteLoop() throws Exception {
+        final String[] expected = {
+            "22:13: " + getCheckMessage(MSG_FALL_THROUGH),
+            "24:13: " + getCheckMessage(MSG_FALL_THROUGH),
+            "26:13: " + getCheckMessage(MSG_FALL_THROUGH),
+            "28:13: " + getCheckMessage(MSG_FALL_THROUGH),
+            "35:13: " + getCheckMessage(MSG_FALL_THROUGH),
+            "43:13: " + getCheckMessage(MSG_FALL_THROUGH),
+            "46:13: " + getCheckMessage(MSG_FALL_THROUGH),
+            "48:13: " + getCheckMessage(MSG_FALL_THROUGH),
+            "50:13: " + getCheckMessage(MSG_FALL_THROUGH),
+            "63:13: " + getCheckMessage(MSG_FALL_THROUGH),
+            "69:13: " + getCheckMessage(MSG_FALL_THROUGH),
+            "71:13: " + getCheckMessage(MSG_FALL_THROUGH),
+        };
+
+        verifyWithInlineConfigParser(
+            getPath("InputFallThroughInfiniteLoop.java"),
+            expected
+        );
+    }
 }

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/fallthrough/InputFallThroughInfiniteLoop.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/fallthrough/InputFallThroughInfiniteLoop.java
@@ -1,0 +1,87 @@
+/*
+FallThrough
+checkLastCaseGroup = (default)false
+reliefPattern = (default)falls?[ -]?thr(u|ough)
+*/
+package com.puppycrawl.tools.checkstyle.checks.coding.fallthrough;
+
+public class InputFallThroughInfiniteLoop {
+    void test(int i) {
+        boolean cond = true;
+        switch (i) {
+            case 1:
+                while (true) {}
+            case 2:
+                for (;;) {}
+            case 3:
+                do {} while (true);
+            case 4:
+                while (cond) {}
+            case 5: // violation 'Fall\ through from previous branch of the switch statement.'
+                for (int j = 0; j < 10; j++) {}
+            case 6: // violation 'Fall\ through from previous branch of the switch statement.'
+                do {} while (cond);
+            case 7: // violation 'Fall\ through from previous branch of the switch statement.'
+                while (cond) {}
+            case 8: // violation 'Fall\ through from previous branch of the switch statement.'
+                {
+                    int a = 1;
+                    while (true) {}
+                }
+            case 9:
+                for (int k : new int[]{1}) {}
+            case 10: // violation 'Fall\ through from previous branch of the switch statement.'
+                while (true) {}
+                // single line comment
+            case 11:
+                while (true) {}
+                // single line comment
+            case 12:
+                int z = 0;
+            case 13: // violation 'Fall\ through from previous branch of the switch statement.'
+                int b = 2;
+                { }
+            case 14: // violation 'Fall\ through from previous branch of the switch statement.'
+                while (true) { break; }
+            case 15: // violation 'Fall\ through from previous branch of the switch statement.'
+                while (true) break;
+            case 16: // violation 'Fall\ through from previous branch of the switch statement.'
+                while (true) {}
+            case 17:
+                while (true) { for (;;) { break; } }
+            case 18:
+                while (true) { while (true) { break; } }
+            case 19:
+                while (true) { do { break; } while (true); }
+            case 20:
+                while (true) { switch (0) { case 0: break; } }
+            case 21:
+                while (true) { { break; } }
+            case 22: // violation 'Fall\ through from previous branch of the switch statement.'
+                while (true) { int y = 0; }
+            case 23:
+                while (true) { if (cond) {} }
+            case 24:
+                while (true) { if (cond) { break; } }
+            case 25: // violation 'Fall\ through from previous branch of the switch statement.'
+                int c = 3;
+            // additional coverage cases for infinite loop detection
+            case 26:
+                while (true) {
+                    if (cond) {
+                        break;
+                    }
+                }
+            case 27:
+                while (true) {
+                    while (true) {}
+                }
+            case 28:
+                while (true) {
+                    continue;
+                }
+            default: // violation 'Fall\ through from previous branch of the switch statement.'
+                break;
+        }
+    }
+}


### PR DESCRIPTION
fixes #3885

this pr resolves Issue #3885 by updating `FallThroughCheck` to see simple infinite loops `, `do-while (true)`, and `for (;;)`) as valid terminations for a `switch` case branch. before, these loops would trigger a false positive fall through violation.