### PR TITLE
Issue #19176: migrate design/modifier/naming/annotation/indentation t…

### DIFF
--- a/config/suppressions.xml
+++ b/config/suppressions.xml
@@ -176,6 +176,6 @@
   <!-- Remove suppression once all violations are fixed, tracked in #19176 -->
   <suppress checks="MatchXpath"
             id="MatchXpathForbidTryCatchFail"
-            files=".*[\\/]src[\\/]test[\\/]java[\\/]com[\\/]puppycrawl[\\/]tools[\\/]checkstyle[\\/](?!utils|xpath|checks[\\/]coding).*"/>
+            files=".*[\\/]src[\\/]test[\\/]java[\\/]com[\\/]puppycrawl[\\/]tools[\\/]checkstyle[\\/](?!utils|xpath|checks[\\/]coding|checks[\\/]design|checks[\\/]modifier|checks[\\/]naming|checks[\\/]annotation|checks[\\/]indentation).*"/>
 
 </suppressions>

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/annotation/AnnotationUseStyleCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/annotation/AnnotationUseStyleCheckTest.java
@@ -31,6 +31,7 @@ import org.junit.jupiter.api.Test;
 import com.puppycrawl.tools.checkstyle.AbstractModuleTestSupport;
 import com.puppycrawl.tools.checkstyle.DefaultConfiguration;
 import com.puppycrawl.tools.checkstyle.api.TokenTypes;
+import com.puppycrawl.tools.checkstyle.internal.utils.TestUtil;
 import com.puppycrawl.tools.checkstyle.utils.CommonUtil;
 import de.thetaphi.forbiddenapis.SuppressForbidden;
 
@@ -327,17 +328,18 @@ public class AnnotationUseStyleCheckTest extends AbstractModuleTestSupport {
     @Test
     public void testGetOption() {
         final AnnotationUseStyleCheck check = new AnnotationUseStyleCheck();
-        try {
-            check.setElementStyle("SHOULD_PRODUCE_ERROR");
-            assertWithMessage("ConversionException is expected").fail();
-        }
-        catch (IllegalArgumentException exc) {
-            final String messageStart = "unable to parse";
+        final IllegalArgumentException exc =
+            TestUtil.getExpectedThrowable(
+                IllegalArgumentException.class, () -> {
+                    check.setElementStyle(
+                        "SHOULD_PRODUCE_ERROR");
+                });
+        final String messageStart = "unable to parse";
 
-            assertWithMessage("Invalid exception message, should start with: " + messageStart)
-                    .that(exc.getMessage())
-                    .startsWith(messageStart);
-        }
+        assertWithMessage("Invalid exception message, "
+                + "should start with: " + messageStart)
+                .that(exc.getMessage())
+                .startsWith(messageStart);
     }
 
     @Test

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/design/FinalClassCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/design/FinalClassCheckTest.java
@@ -129,15 +129,14 @@ public class FinalClassCheckTest
         final DetailAstImpl badAst = new DetailAstImpl();
         final int unsupportedTokenByCheck = TokenTypes.COMPILATION_UNIT;
         badAst.setType(unsupportedTokenByCheck);
-        try {
-            finalClassCheck.visitToken(badAst);
-            assertWithMessage("IllegalStateException is expected").fail();
-        }
-        catch (IllegalStateException exc) {
-            assertWithMessage("Invalid exception message")
-                .that(exc.getMessage())
-                .isEqualTo(badAst.toString());
-        }
+        final IllegalStateException exc =
+            TestUtil.getExpectedThrowable(
+                IllegalStateException.class, () -> {
+                    finalClassCheck.visitToken(badAst);
+                });
+        assertWithMessage("Invalid exception message")
+            .that(exc.getMessage())
+            .isEqualTo(badAst.toString());
     }
 
     @Test

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/design/MutableExceptionCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/design/MutableExceptionCheckTest.java
@@ -34,6 +34,7 @@ import com.puppycrawl.tools.checkstyle.AbstractModuleTestSupport;
 import com.puppycrawl.tools.checkstyle.DefaultConfiguration;
 import com.puppycrawl.tools.checkstyle.DetailAstImpl;
 import com.puppycrawl.tools.checkstyle.api.TokenTypes;
+import com.puppycrawl.tools.checkstyle.internal.utils.TestUtil;
 import com.puppycrawl.tools.checkstyle.utils.CommonUtil;
 
 public class MutableExceptionCheckTest extends AbstractModuleTestSupport {
@@ -130,17 +131,15 @@ public class MutableExceptionCheckTest extends AbstractModuleTestSupport {
         final MutableExceptionCheck obj = new MutableExceptionCheck();
         final DetailAstImpl ast = new DetailAstImpl();
         ast.initialize(new CommonToken(TokenTypes.INTERFACE_DEF, "interface"));
-        try {
-            obj.visitToken(ast);
-            assertWithMessage("IllegalStateException is expected")
-                    .fail();
-        }
-        catch (IllegalStateException exc) {
-            // exception is expected
-            assertWithMessage("Invalid exception message")
-                    .that(exc.getMessage())
-                    .isEqualTo("interface[0x-1]");
-        }
+        final IllegalStateException exc =
+            TestUtil.getExpectedThrowable(
+                IllegalStateException.class, () -> {
+                    obj.visitToken(ast);
+                });
+        // exception is expected
+        assertWithMessage("Invalid exception message")
+                .that(exc.getMessage())
+                .isEqualTo("interface[0x-1]");
     }
 
 }

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/design/ThrowsCountCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/design/ThrowsCountCheckTest.java
@@ -28,6 +28,7 @@ import org.junit.jupiter.api.Test;
 import com.puppycrawl.tools.checkstyle.AbstractModuleTestSupport;
 import com.puppycrawl.tools.checkstyle.DetailAstImpl;
 import com.puppycrawl.tools.checkstyle.api.TokenTypes;
+import com.puppycrawl.tools.checkstyle.internal.utils.TestUtil;
 
 public class ThrowsCountCheckTest extends AbstractModuleTestSupport {
 
@@ -84,15 +85,14 @@ public class ThrowsCountCheckTest extends AbstractModuleTestSupport {
         final ThrowsCountCheck obj = new ThrowsCountCheck();
         final DetailAstImpl ast = new DetailAstImpl();
         ast.initialize(new CommonToken(TokenTypes.CLASS_DEF, "class"));
-        try {
-            obj.visitToken(ast);
-            assertWithMessage("IllegalStateException is expected").fail();
-        }
-        catch (IllegalStateException exc) {
-            assertWithMessage("Invalid exception message")
-                .that(exc.getMessage())
-                .isEqualTo(ast.toString());
-        }
+        final IllegalStateException exc =
+            TestUtil.getExpectedThrowable(
+                IllegalStateException.class, () -> {
+                    obj.visitToken(ast);
+                });
+        assertWithMessage("Invalid exception message")
+            .that(exc.getMessage())
+            .isEqualTo(ast.toString());
     }
 
     @Test

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/design/VisibilityModifierCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/design/VisibilityModifierCheckTest.java
@@ -368,15 +368,14 @@ public class VisibilityModifierCheckTest
         final VisibilityModifierCheck obj = new VisibilityModifierCheck();
         final DetailAstImpl ast = new DetailAstImpl();
         ast.initialize(new CommonToken(TokenTypes.CLASS_DEF, "class"));
-        try {
-            obj.visitToken(ast);
-            assertWithMessage("exception expected").fail();
-        }
-        catch (IllegalArgumentException exc) {
-            assertWithMessage("Invalid exception message")
-                .that(exc.getMessage())
-                .isEqualTo("Unexpected token type: class");
-        }
+        final IllegalArgumentException exc =
+            TestUtil.getExpectedThrowable(
+                IllegalArgumentException.class, () -> {
+                    obj.visitToken(ast);
+                });
+        assertWithMessage("Invalid exception message")
+            .that(exc.getMessage())
+            .isEqualTo("Unexpected token type: class");
     }
 
     @Test

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/indentation/CommentsIndentationCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/indentation/CommentsIndentationCheckTest.java
@@ -28,6 +28,7 @@ import org.junit.jupiter.api.Test;
 import com.puppycrawl.tools.checkstyle.AbstractModuleTestSupport;
 import com.puppycrawl.tools.checkstyle.DetailAstImpl;
 import com.puppycrawl.tools.checkstyle.api.TokenTypes;
+import com.puppycrawl.tools.checkstyle.internal.utils.TestUtil;
 import com.puppycrawl.tools.checkstyle.utils.CommonUtil;
 
 public class CommentsIndentationCheckTest extends AbstractModuleTestSupport {
@@ -279,16 +280,14 @@ public class CommentsIndentationCheckTest extends AbstractModuleTestSupport {
         final DetailAstImpl methodDef = new DetailAstImpl();
         methodDef.setType(TokenTypes.METHOD_DEF);
         methodDef.setText("methodStub");
-        try {
-            check.visitToken(methodDef);
-            assertWithMessage("IllegalArgumentException should have been thrown!").fail();
-        }
-        catch (IllegalArgumentException exc) {
-            final String msg = exc.getMessage();
-            assertWithMessage("Invalid exception message")
-                .that(msg)
-                .isEqualTo("Unexpected token type: methodStub");
-        }
+        final IllegalArgumentException exc =
+            TestUtil.getExpectedThrowable(
+                IllegalArgumentException.class, () -> {
+                    check.visitToken(methodDef);
+                });
+        assertWithMessage("Invalid exception message")
+            .that(exc.getMessage())
+            .isEqualTo("Unexpected token type: methodStub");
     }
 
     @Test

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/modifier/ClassMemberImpliedModifierCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/modifier/ClassMemberImpliedModifierCheckTest.java
@@ -27,6 +27,7 @@ import org.junit.jupiter.api.Test;
 import com.puppycrawl.tools.checkstyle.AbstractModuleTestSupport;
 import com.puppycrawl.tools.checkstyle.DetailAstImpl;
 import com.puppycrawl.tools.checkstyle.api.TokenTypes;
+import com.puppycrawl.tools.checkstyle.internal.utils.TestUtil;
 import com.puppycrawl.tools.checkstyle.utils.CommonUtil;
 
 public class ClassMemberImpliedModifierCheckTest
@@ -155,15 +156,14 @@ public class ClassMemberImpliedModifierCheckTest
         interfaceAst.addChild(objBlock);
         final ClassMemberImpliedModifierCheck check =
             new ClassMemberImpliedModifierCheck();
-        try {
-            check.visitToken(init);
-            assertWithMessage("IllegalStateException is expected").fail();
-        }
-        catch (IllegalStateException exc) {
-            assertWithMessage("Error message is unexpected")
-                .that(exc.getMessage())
-                .isEqualTo(init.toString());
-        }
+        final IllegalStateException exc =
+            TestUtil.getExpectedThrowable(
+                IllegalStateException.class, () -> {
+                    check.visitToken(init);
+                });
+        assertWithMessage("Error message is unexpected")
+            .that(exc.getMessage())
+            .isEqualTo(init.toString());
     }
 
 }

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/modifier/InterfaceMemberImpliedModifierCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/modifier/InterfaceMemberImpliedModifierCheckTest.java
@@ -27,6 +27,7 @@ import org.junit.jupiter.api.Test;
 import com.puppycrawl.tools.checkstyle.AbstractModuleTestSupport;
 import com.puppycrawl.tools.checkstyle.DetailAstImpl;
 import com.puppycrawl.tools.checkstyle.api.TokenTypes;
+import com.puppycrawl.tools.checkstyle.internal.utils.TestUtil;
 import com.puppycrawl.tools.checkstyle.utils.CommonUtil;
 
 public class InterfaceMemberImpliedModifierCheckTest
@@ -374,15 +375,14 @@ public class InterfaceMemberImpliedModifierCheckTest
         interfaceAst.addChild(objBlock);
         final InterfaceMemberImpliedModifierCheck check =
             new InterfaceMemberImpliedModifierCheck();
-        try {
-            check.visitToken(init);
-            assertWithMessage("IllegalStateException is expected").fail();
-        }
-        catch (IllegalStateException exc) {
-            assertWithMessage("Error message is unexpected")
-                .that(exc.getMessage())
-                .isEqualTo(init.toString());
-        }
+        final IllegalStateException exc =
+            TestUtil.getExpectedThrowable(
+                IllegalStateException.class, () -> {
+                    check.visitToken(init);
+                });
+        assertWithMessage("Error message is unexpected")
+            .that(exc.getMessage())
+            .isEqualTo(init.toString());
     }
 
     @Test

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/naming/ConstantNameCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/naming/ConstantNameCheckTest.java
@@ -28,6 +28,7 @@ import com.puppycrawl.tools.checkstyle.AbstractModuleTestSupport;
 import com.puppycrawl.tools.checkstyle.DefaultConfiguration;
 import com.puppycrawl.tools.checkstyle.api.CheckstyleException;
 import com.puppycrawl.tools.checkstyle.api.TokenTypes;
+import com.puppycrawl.tools.checkstyle.internal.utils.TestUtil;
 import com.puppycrawl.tools.checkstyle.utils.CommonUtil;
 
 public class ConstantNameCheckTest
@@ -48,22 +49,22 @@ public class ConstantNameCheckTest
     }
 
     @Test
-    public void testIllegalRegexp()
-            throws Exception {
+    public void testIllegalRegexp() {
         final DefaultConfiguration checkConfig =
             createModuleConfig(ConstantNameCheck.class);
         checkConfig.addProperty("format", "\\");
-        try {
-            createChecker(checkConfig);
-            assertWithMessage("CheckstyleException is expected").fail();
-        }
-        catch (CheckstyleException exc) {
-            assertWithMessage("Invalid exception message")
-                .that(exc.getMessage())
-                .isEqualTo("cannot initialize module com.puppycrawl.tools.checkstyle.TreeWalker - "
-                    + "cannot initialize module com.puppycrawl.tools.checkstyle.checks."
-                    + "naming.ConstantNameCheck");
-        }
+        final CheckstyleException exc =
+            TestUtil.getExpectedThrowable(
+                CheckstyleException.class, () -> {
+                    createChecker(checkConfig);
+                });
+        assertWithMessage("Invalid exception message")
+            .that(exc.getMessage())
+            .isEqualTo("cannot initialize module "
+                + "com.puppycrawl.tools.checkstyle.TreeWalker - "
+                + "cannot initialize module "
+                + "com.puppycrawl.tools.checkstyle.checks."
+                + "naming.ConstantNameCheck");
     }
 
     @Test


### PR DESCRIPTION
Issue: #19176

Migrated 9 test files in `checks/design`, `checks/modifier`, `checks/naming`,
`checks/annotation`, and `checks/indentation` packages from the old
`assertWithMessage(...).fail()` try-catch pattern to `getExpectedThrowable()`.

Files changed:
- FinalClassCheckTest.java 
- ThrowsCountCheckTest.java 
- VisibilityModifierCheckTest.java 
- MutableExceptionCheckTest.java 
- ClassMemberImpliedModifierCheckTest.java 
- InterfaceMemberImpliedModifierCheckTest.java 
- ConstantNameCheckTest.java 
- AnnotationUseStyleCheckTest.java 
- CommentsIndentationCheckTest.java
- config/suppressions.xml (updated negative lookahead)