### PR TITLE
Issue #15080: Explained JavaNCSS counting

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/metrics/JavaNCSSCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/metrics/JavaNCSSCheck.java
@@ -57,6 +57,69 @@ import com.puppycrawl.tools.checkstyle.api.TokenTypes;
  * and/or functionalities which should be decomposed into smaller units.
  * </p>
  *
+ * <p>
+ * Here is a breakdown of what exactly is counted and not counted:
+ * </p>
+ * <div class="wrapper">
+ * <table>
+ * <caption>JavaNCSS metrics</caption>
+ * <thead><tr><th>Structure</th><th>NCSS Count</th><th>Notes</th></tr></thead>
+ * <tbody>
+ * <tr><td>Package declaration</td><td>1</td>
+ * <td>Counted at the terminating semicolon.</td></tr>
+ * <tr><td>Import declaration</td><td>1</td>
+ * <td>Each single, static, or wildcard import counts as 1.</td></tr>
+ * <tr><td>Class, Interface, Annotation ({@code @interface})</td><td>1</td>
+ * <td>Counted at the opening curly brace of the body.</td></tr>
+ * <tr><td>Method, Constructor</td><td>1</td>
+ * <td>Counted at the declaration.</td></tr>
+ * <tr><td>Static initializer, Instance initializer</td><td>1</td>
+ * <td>Both {@code static {}} and bare {@code {}} initializer blocks count as 1.</td></tr>
+ * <tr><td>Annotation type member</td><td>1</td>
+ * <td>Each method-like member declaration inside {@code @interface} counts as 1.
+ * A standalone {@code ;} inside {@code @interface} also counts as 1.</td></tr>
+ * <tr><td>Variable declaration</td><td>1</td>
+ * <td>1 per statement regardless of how many variables are declared on that line.
+ * {@code int x, y;} counts as 1.</td></tr>
+ * <tr><td>{@code if}</td><td>1</td>
+ * <td>The {@code if} keyword counts as 1.</td></tr>
+ * <tr><td>{@code else}, {@code else if}</td><td>1</td>
+ * <td>The {@code else} keyword counts as 1, separate from the {@code if} count.</td></tr>
+ * <tr><td>{@code while}, {@code do}, {@code for}</td><td>1</td>
+ * <td>The keyword header counts as 1.</td></tr>
+ * <tr><td>{@code switch}</td><td>1</td>
+ * <td>The {@code switch} keyword counts as 1.</td></tr>
+ * <tr><td>{@code case}, {@code default}</td><td>1</td>
+ * <td>Every case and default label adds 1.</td></tr>
+ * <tr><td>{@code try}</td><td>0</td>
+ * <td>The {@code try} keyword itself does not count.</td></tr>
+ * <tr><td>{@code catch}</td><td>1</td>
+ * <td>Each catch block counts as 1.</td></tr>
+ * <tr><td>{@code finally}</td><td>1</td>
+ * <td>The finally block counts as 1.</td></tr>
+ * <tr><td>{@code synchronized}</td><td>1</td>
+ * <td>The synchronized statement counts as 1.</td></tr>
+ * <tr><td>{@code return}, {@code break}, {@code continue}, {@code throw}</td><td>1</td>
+ * <td>Each counts as 1.</td></tr>
+ * <tr><td>{@code assert}</td><td>1</td>
+ * <td>Each assert statement counts as 1, with or without a message expression.</td></tr>
+ * <tr><td>Labeled statement</td><td>1</td>
+ * <td>{@code label: statement} counts as 1.</td></tr>
+ * <tr><td>Explicit constructor invocation</td><td>1</td>
+ * <td>{@code this()} or {@code super()} calls inside a constructor body
+ * each count as 1.</td></tr>
+ * <tr><td>Expression statements (assignments, method calls)</td><td>1</td>
+ * <td>Statement-level expressions terminated by {@code ;} count as 1.
+ * A method call inside a {@code return} does not add an extra count.</td></tr>
+ * <tr><td>Empty blocks {}</td><td>0</td>
+ * <td>Empty curly braces do not increase the count.</td></tr>
+ * <tr><td>Empty statements ;</td><td>0</td>
+ * <td>Standalone semicolons outside of {@code @interface} do not increase
+ * the count.</td></tr>
+ * </tbody>
+ * </table>
+ * </div>
+ *
  * @since 3.5
  */
 // -@cs[AbbreviationAsWordInName] We can not change it as,

--- a/src/main/resources/com/puppycrawl/tools/checkstyle/meta/checks/metrics/JavaNCSSCheck.xml
+++ b/src/main/resources/com/puppycrawl/tools/checkstyle/meta/checks/metrics/JavaNCSSCheck.xml
@@ -31,7 +31,70 @@
  Rationale: Too large methods and classes are hard to read and costly to maintain.
  A large NCSS number often means that a method or class has too many responsibilities
  and/or functionalities which should be decomposed into smaller units.
- &lt;/p&gt;</description>
+ &lt;/p&gt;
+
+ &lt;p&gt;
+ Here is a breakdown of what exactly is counted and not counted:
+ &lt;/p&gt;
+ &lt;div class="wrapper"&gt;
+ &lt;table&gt;
+ &lt;caption&gt;JavaNCSS metrics&lt;/caption&gt;
+ &lt;thead&gt;&lt;tr&gt;&lt;th&gt;Structure&lt;/th&gt;&lt;th&gt;NCSS Count&lt;/th&gt;&lt;th&gt;Notes&lt;/th&gt;&lt;/tr&gt;&lt;/thead&gt;
+ &lt;tbody&gt;
+ &lt;tr&gt;&lt;td&gt;Package declaration&lt;/td&gt;&lt;td&gt;1&lt;/td&gt;
+ &lt;td&gt;Counted at the terminating semicolon.&lt;/td&gt;&lt;/tr&gt;
+ &lt;tr&gt;&lt;td&gt;Import declaration&lt;/td&gt;&lt;td&gt;1&lt;/td&gt;
+ &lt;td&gt;Each single, static, or wildcard import counts as 1.&lt;/td&gt;&lt;/tr&gt;
+ &lt;tr&gt;&lt;td&gt;Class, Interface, Annotation (&lt;code&gt;@interface&lt;/code&gt;)&lt;/td&gt;&lt;td&gt;1&lt;/td&gt;
+ &lt;td&gt;Counted at the opening curly brace of the body.&lt;/td&gt;&lt;/tr&gt;
+ &lt;tr&gt;&lt;td&gt;Method, Constructor&lt;/td&gt;&lt;td&gt;1&lt;/td&gt;
+ &lt;td&gt;Counted at the declaration.&lt;/td&gt;&lt;/tr&gt;
+ &lt;tr&gt;&lt;td&gt;Static initializer, Instance initializer&lt;/td&gt;&lt;td&gt;1&lt;/td&gt;
+ &lt;td&gt;Both &lt;code&gt;static {}&lt;/code&gt; and bare &lt;code&gt;{}&lt;/code&gt; initializer blocks count as 1.&lt;/td&gt;&lt;/tr&gt;
+ &lt;tr&gt;&lt;td&gt;Annotation type member&lt;/td&gt;&lt;td&gt;1&lt;/td&gt;
+ &lt;td&gt;Each method-like member declaration inside &lt;code&gt;@interface&lt;/code&gt; counts as 1.
+ A standalone &lt;code&gt;;&lt;/code&gt; inside &lt;code&gt;@interface&lt;/code&gt; also counts as 1.&lt;/td&gt;&lt;/tr&gt;
+ &lt;tr&gt;&lt;td&gt;Variable declaration&lt;/td&gt;&lt;td&gt;1&lt;/td&gt;
+ &lt;td&gt;1 per statement regardless of how many variables are declared on that line.
+ &lt;code&gt;int x, y;&lt;/code&gt; counts as 1.&lt;/td&gt;&lt;/tr&gt;
+ &lt;tr&gt;&lt;td&gt;&lt;code&gt;if&lt;/code&gt;&lt;/td&gt;&lt;td&gt;1&lt;/td&gt;
+ &lt;td&gt;The &lt;code&gt;if&lt;/code&gt; keyword counts as 1.&lt;/td&gt;&lt;/tr&gt;
+ &lt;tr&gt;&lt;td&gt;&lt;code&gt;else&lt;/code&gt;, &lt;code&gt;else if&lt;/code&gt;&lt;/td&gt;&lt;td&gt;1&lt;/td&gt;
+ &lt;td&gt;The &lt;code&gt;else&lt;/code&gt; keyword counts as 1, separate from the &lt;code&gt;if&lt;/code&gt; count.&lt;/td&gt;&lt;/tr&gt;
+ &lt;tr&gt;&lt;td&gt;&lt;code&gt;while&lt;/code&gt;, &lt;code&gt;do&lt;/code&gt;, &lt;code&gt;for&lt;/code&gt;&lt;/td&gt;&lt;td&gt;1&lt;/td&gt;
+ &lt;td&gt;The keyword header counts as 1.&lt;/td&gt;&lt;/tr&gt;
+ &lt;tr&gt;&lt;td&gt;&lt;code&gt;switch&lt;/code&gt;&lt;/td&gt;&lt;td&gt;1&lt;/td&gt;
+ &lt;td&gt;The &lt;code&gt;switch&lt;/code&gt; keyword counts as 1.&lt;/td&gt;&lt;/tr&gt;
+ &lt;tr&gt;&lt;td&gt;&lt;code&gt;case&lt;/code&gt;, &lt;code&gt;default&lt;/code&gt;&lt;/td&gt;&lt;td&gt;1&lt;/td&gt;
+ &lt;td&gt;Every case and default label adds 1.&lt;/td&gt;&lt;/tr&gt;
+ &lt;tr&gt;&lt;td&gt;&lt;code&gt;try&lt;/code&gt;&lt;/td&gt;&lt;td&gt;0&lt;/td&gt;
+ &lt;td&gt;The &lt;code&gt;try&lt;/code&gt; keyword itself does not count.&lt;/td&gt;&lt;/tr&gt;
+ &lt;tr&gt;&lt;td&gt;&lt;code&gt;catch&lt;/code&gt;&lt;/td&gt;&lt;td&gt;1&lt;/td&gt;
+ &lt;td&gt;Each catch block counts as 1.&lt;/td&gt;&lt;/tr&gt;
+ &lt;tr&gt;&lt;td&gt;&lt;code&gt;finally&lt;/code&gt;&lt;/td&gt;&lt;td&gt;1&lt;/td&gt;
+ &lt;td&gt;The finally block counts as 1.&lt;/td&gt;&lt;/tr&gt;
+ &lt;tr&gt;&lt;td&gt;&lt;code&gt;synchronized&lt;/code&gt;&lt;/td&gt;&lt;td&gt;1&lt;/td&gt;
+ &lt;td&gt;The synchronized statement counts as 1.&lt;/td&gt;&lt;/tr&gt;
+ &lt;tr&gt;&lt;td&gt;&lt;code&gt;return&lt;/code&gt;, &lt;code&gt;break&lt;/code&gt;, &lt;code&gt;continue&lt;/code&gt;, &lt;code&gt;throw&lt;/code&gt;&lt;/td&gt;&lt;td&gt;1&lt;/td&gt;
+ &lt;td&gt;Each counts as 1.&lt;/td&gt;&lt;/tr&gt;
+ &lt;tr&gt;&lt;td&gt;&lt;code&gt;assert&lt;/code&gt;&lt;/td&gt;&lt;td&gt;1&lt;/td&gt;
+ &lt;td&gt;Each assert statement counts as 1, with or without a message expression.&lt;/td&gt;&lt;/tr&gt;
+ &lt;tr&gt;&lt;td&gt;Labeled statement&lt;/td&gt;&lt;td&gt;1&lt;/td&gt;
+ &lt;td&gt;&lt;code&gt;label: statement&lt;/code&gt; counts as 1.&lt;/td&gt;&lt;/tr&gt;
+ &lt;tr&gt;&lt;td&gt;Explicit constructor invocation&lt;/td&gt;&lt;td&gt;1&lt;/td&gt;
+ &lt;td&gt;&lt;code&gt;this()&lt;/code&gt; or &lt;code&gt;super()&lt;/code&gt; calls inside a constructor body
+ each count as 1.&lt;/td&gt;&lt;/tr&gt;
+ &lt;tr&gt;&lt;td&gt;Expression statements (assignments, method calls)&lt;/td&gt;&lt;td&gt;1&lt;/td&gt;
+ &lt;td&gt;Statement-level expressions terminated by &lt;code&gt;;&lt;/code&gt; count as 1.
+ A method call inside a &lt;code&gt;return&lt;/code&gt; does not add an extra count.&lt;/td&gt;&lt;/tr&gt;
+ &lt;tr&gt;&lt;td&gt;Empty blocks {}&lt;/td&gt;&lt;td&gt;0&lt;/td&gt;
+ &lt;td&gt;Empty curly braces do not increase the count.&lt;/td&gt;&lt;/tr&gt;
+ &lt;tr&gt;&lt;td&gt;Empty statements ;&lt;/td&gt;&lt;td&gt;0&lt;/td&gt;
+ &lt;td&gt;Standalone semicolons outside of &lt;code&gt;@interface&lt;/code&gt; do not increase
+ the count.&lt;/td&gt;&lt;/tr&gt;
+ &lt;/tbody&gt;
+ &lt;/table&gt;
+ &lt;/div&gt;</description>
          <properties>
             <property default-value="1500" name="classMaximum" type="int">
                <description>Specify the maximum allowed number of non commenting lines in a class.</description>

--- a/src/site/xdoc/checks/metrics/javancss.xml
+++ b/src/site/xdoc/checks/metrics/javancss.xml
@@ -37,6 +37,69 @@
           A large NCSS number often means that a method or class has too many responsibilities
           and/or functionalities which should be decomposed into smaller units.
         </p>
+
+        <p>
+          Here is a breakdown of what exactly is counted and not counted:
+        </p>
+        <div class="wrapper">
+        <table>
+        <caption>JavaNCSS metrics</caption>
+        <thead><tr><th>Structure</th><th>NCSS Count</th><th>Notes</th></tr></thead>
+        <tbody>
+        <tr><td>Package declaration</td><td>1</td>
+        <td>Counted at the terminating semicolon.</td></tr>
+        <tr><td>Import declaration</td><td>1</td>
+        <td>Each single, static, or wildcard import counts as 1.</td></tr>
+        <tr><td>Class, Interface, Annotation (<code>@interface</code>)</td><td>1</td>
+        <td>Counted at the opening curly brace of the body.</td></tr>
+        <tr><td>Method, Constructor</td><td>1</td>
+        <td>Counted at the declaration.</td></tr>
+        <tr><td>Static initializer, Instance initializer</td><td>1</td>
+        <td>Both <code>static {}</code> and bare <code>{}</code> initializer blocks count as 1.</td></tr>
+        <tr><td>Annotation type member</td><td>1</td>
+        <td>Each method-like member declaration inside <code>@interface</code> counts as 1.
+          A standalone <code>;</code> inside <code>@interface</code> also counts as 1.</td></tr>
+        <tr><td>Variable declaration</td><td>1</td>
+        <td>1 per statement regardless of how many variables are declared on that line.
+          <code>int x, y;</code> counts as 1.</td></tr>
+        <tr><td><code>if</code></td><td>1</td>
+        <td>The <code>if</code> keyword counts as 1.</td></tr>
+        <tr><td><code>else</code>, <code>else if</code></td><td>1</td>
+        <td>The <code>else</code> keyword counts as 1, separate from the <code>if</code> count.</td></tr>
+        <tr><td><code>while</code>, <code>do</code>, <code>for</code></td><td>1</td>
+        <td>The keyword header counts as 1.</td></tr>
+        <tr><td><code>switch</code></td><td>1</td>
+        <td>The <code>switch</code> keyword counts as 1.</td></tr>
+        <tr><td><code>case</code>, <code>default</code></td><td>1</td>
+        <td>Every case and default label adds 1.</td></tr>
+        <tr><td><code>try</code></td><td>0</td>
+        <td>The <code>try</code> keyword itself does not count.</td></tr>
+        <tr><td><code>catch</code></td><td>1</td>
+        <td>Each catch block counts as 1.</td></tr>
+        <tr><td><code>finally</code></td><td>1</td>
+        <td>The finally block counts as 1.</td></tr>
+        <tr><td><code>synchronized</code></td><td>1</td>
+        <td>The synchronized statement counts as 1.</td></tr>
+        <tr><td><code>return</code>, <code>break</code>, <code>continue</code>, <code>throw</code></td><td>1</td>
+        <td>Each counts as 1.</td></tr>
+        <tr><td><code>assert</code></td><td>1</td>
+        <td>Each assert statement counts as 1, with or without a message expression.</td></tr>
+        <tr><td>Labeled statement</td><td>1</td>
+        <td><code>label: statement</code> counts as 1.</td></tr>
+        <tr><td>Explicit constructor invocation</td><td>1</td>
+        <td><code>this()</code> or <code>super()</code> calls inside a constructor body
+          each count as 1.</td></tr>
+        <tr><td>Expression statements (assignments, method calls)</td><td>1</td>
+        <td>Statement-level expressions terminated by <code>;</code> count as 1.
+          A method call inside a <code>return</code> does not add an extra count.</td></tr>
+        <tr><td>Empty blocks {}</td><td>0</td>
+        <td>Empty curly braces do not increase the count.</td></tr>
+        <tr><td>Empty statements ;</td><td>0</td>
+        <td>Standalone semicolons outside of <code>@interface</code> do not increase
+          the count.</td></tr>
+        </tbody>
+        </table>
+        </div>
       </subsection>
 
       <subsection name="Properties" id="JavaNCSS_Properties">


### PR DESCRIPTION
Issue #15080

## Summary
This PR updates the `JavaNCSS` check documentation by verifying all 36
counting instances in the JavaNCSS specification (`Java1.1.jj`) against
both the reference tool (JavaNCSS 34.55) and Checkstyle's implementation.

# Verification Method
Each structure was verified by:
1. Reading the counting logic in `Java1.1.jj` from the
   [nokia/javancss](https://github.com/nokia/javancss/blob/90aca669d2dce3937f4f981dece4a77c4453c91c/src/main/javacc/Java1.1.jj)
   repository
2. Running the test file against JavaNCSS 34.55 reference tool
3. Running the same test file against Checkstyle's JavaNCSS check

### Bug 1: Enum body not counted
Checkstyle does not count the enum declaration as an NCSS statement,
but JavaNCSS 34.55 does.
```java
public class Outer {
    enum Color { RED }  // JavaNCSS=2, Checkstyle=1
}
```
### Bug 2: `assert` statement not counted
Checkstyle does not count `assert` statements, but JavaNCSS 34.55 does.
Both forms are affected .
```java
public class Test {
    public void foo(int x) {
        assert x > 0;                       // not counted by Checkstyle
        assert x > 0 : "must be positive";  // not counted by Checkstyle
        // JavaNCSS=4, Checkstyle=2
    }
}
```

### Bug 3: `@interface` body and members not counted
Checkstyle counts an `@interface` declaration as 1 (same as a class),
but JavaNCSS 34.55 also counts each member declaration inside it.
```java
public @interface MyAnnotation {
    String value();        // not counted by Checkstyle
    int count() default 0; // not counted by Checkstyle
    // JavaNCSS=3, Checkstyle=1
}
```

### Bug 4: Standalone `;` inside `@interface` not counted
JavaNCSS 34.55 counts a standalone semicolon inside an `@interface` body,
but Checkstyle does not count it at all.
```java
public @interface MyAnnotation {
    ;  // JavaNCSS=2, Checkstyle=0
}
```