### PR TITLE
Issue 19176 root internal checks migration

### DIFF
--- a/config/suppressions.xml
+++ b/config/suppressions.xml
@@ -192,6 +192,6 @@
   <!-- Remove suppression once all violations are fixed, tracked in #19176 -->
   <suppress checks="MatchXpath"
             id="MatchXpathForbidTryCatchFail"
-            files=".*[\\/]src[\\/]test[\\/]java[\\/]com[\\/]puppycrawl[\\/]tools[\\/]checkstyle[\\/](?!utils|xpath|checks[\\/]coding|checks[\\/]design|checks[\\/]modifier|checks[\\/]naming|checks[\\/]annotation|checks[\\/]indentation|checks[\\/]metrics|checks[\\/]whitespace|checks[\\/]javadoc|checks[\\/]NewlineAtEndOfFileCheckTest|checks[\\/]SuppressWarningsHolderTest|checks[\\/]UncommentedMainCheckTest).*"/>
+            files=".*[\\/]src[\\/]test[\\/]java[\\/]com[\\/]puppycrawl[\\/]tools[\\/]checkstyle[\\/](?!utils|xpath|checks[\\/]coding|checks[\\/]design|checks[\\/]modifier|checks[\\/]naming|checks[\\/]annotation|checks[\\/]indentation|checks[\\/]metrics|checks[\\/]whitespace|checks[\\/]javadoc|checks[\\/]NewlineAtEndOfFileCheckTest|checks[\\/]SuppressWarningsHolderTest|checks[\\/]UncommentedMainCheckTest|CheckerTest|ConfigurationLoaderTest|DetailNodeTreeStringPrinterTest|JavadocPropertiesGeneratorTest|MainTest|PackageNamesLoaderTest|SarifLoggerTest|SuppressionsStringPrinterTest|ThreadModeSettingsTest|TreeWalkerTest).*"/>
 
 </suppressions>

--- a/src/test/java/com/puppycrawl/tools/checkstyle/DetailNodeTreeStringPrinterTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/DetailNodeTreeStringPrinterTest.java
@@ -21,6 +21,7 @@ package com.puppycrawl.tools.checkstyle;
 
 import static com.google.common.truth.Truth.assertWithMessage;
 import static com.puppycrawl.tools.checkstyle.JavadocDetailNodeParser.MSG_JAVADOC_PARSE_RULE_ERROR;
+import static com.puppycrawl.tools.checkstyle.internal.utils.TestUtil.getExpectedThrowable;
 import static com.puppycrawl.tools.checkstyle.internal.utils.TestUtil.isUtilsClassHasPrivateConstructor;
 
 import java.io.File;
@@ -79,37 +80,33 @@ public class DetailNodeTreeStringPrinterTest extends AbstractTreeTestSupport {
     public void testNoViableAltException() throws Exception {
         final File file = new File(
                 getPath("InputDetailNodeTreeStringPrinterNoViableAltException.javadoc"));
-        try {
-            DetailNodeTreeStringPrinter.printFileAst(file);
-            assertWithMessage("Exception is expected").fail();
-        }
-        catch (IllegalArgumentException exc) {
-            final String expected = TestUtil.invokeStaticMethod(DetailNodeTreeStringPrinter.class,
-                    "getParseErrorMessage", String.class,
-                    new ParseErrorMessage(0, MSG_JAVADOC_PARSE_RULE_ERROR,
-                            8, "no viable alternative at input 'see <'", "SEE_TAG"));
-            assertWithMessage("Generated and expected parse error messages don't match")
-                .that(exc.getMessage())
-                .isEqualTo(expected);
-        }
+        final IllegalArgumentException exc =
+                getExpectedThrowable(IllegalArgumentException.class, () -> {
+                    DetailNodeTreeStringPrinter.printFileAst(file);
+                }, "Exception is expected");
+        final String expected = TestUtil.invokeStaticMethod(DetailNodeTreeStringPrinter.class,
+                "getParseErrorMessage", String.class,
+                new ParseErrorMessage(0, MSG_JAVADOC_PARSE_RULE_ERROR,
+                        8, "no viable alternative at input 'see <'", "SEE_TAG"));
+        assertWithMessage("Generated and expected parse error messages don't match")
+            .that(exc.getMessage())
+            .isEqualTo(expected);
     }
 
     @Test
     public void testHtmlTagCloseBeforeTagOpen() throws Exception {
         final File file = new File(
                 getPath("InputDetailNodeTreeStringPrinterHtmlTagCloseBeforeTagOpen.javadoc"));
-        try {
-            DetailNodeTreeStringPrinter.printFileAst(file);
-            assertWithMessage("Exception is expected").fail();
-        }
-        catch (IllegalArgumentException exc) {
-            final String expected = TestUtil.invokeStaticMethod(DetailNodeTreeStringPrinter.class,
-                    "getParseErrorMessage", String.class,
-                    new ParseErrorMessage(0, MSG_JAVADOC_PARSE_RULE_ERROR,
-                            3, "no viable alternative at input '</'", "HTML_ELEMENT"));
-            assertWithMessage("Generated and expected parse error messages don't match")
-                .that(exc.getMessage())
-                .isEqualTo(expected);
-        }
+        final IllegalArgumentException exc =
+                getExpectedThrowable(IllegalArgumentException.class, () -> {
+                    DetailNodeTreeStringPrinter.printFileAst(file);
+                }, "Exception is expected");
+        final String expected = TestUtil.invokeStaticMethod(DetailNodeTreeStringPrinter.class,
+                "getParseErrorMessage", String.class,
+                new ParseErrorMessage(0, MSG_JAVADOC_PARSE_RULE_ERROR,
+                        3, "no viable alternative at input '</'", "HTML_ELEMENT"));
+        assertWithMessage("Generated and expected parse error messages don't match")
+            .that(exc.getMessage())
+            .isEqualTo(expected);
     }
 }

--- a/src/test/java/com/puppycrawl/tools/checkstyle/MainTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/MainTest.java
@@ -21,6 +21,7 @@ package com.puppycrawl.tools.checkstyle;
 
 import static com.google.common.truth.Truth.assertWithMessage;
 import static com.puppycrawl.tools.checkstyle.AbstractPathTestSupport.addEndOfLine;
+import static com.puppycrawl.tools.checkstyle.internal.utils.TestUtil.getExpectedThrowable;
 import static com.puppycrawl.tools.checkstyle.internal.utils.TestUtil.isUtilsClassHasPrivateConstructor;
 import static org.junit.jupiter.api.Assumptions.assumeTrue;
 import static org.mockito.Mockito.mock;
@@ -813,38 +814,36 @@ public class MainTest {
     @Test
     public void testLoadPropertiesIoException() throws Exception {
         final Class<?> cliOptionsClass = Class.forName(Main.class.getName());
-        try {
-            TestUtil.invokeVoidStaticMethod(cliOptionsClass,
-                    "loadProperties", new File("."));
-            assertWithMessage("Exception was expected").fail();
-        }
-        catch (ReflectiveOperationException exc) {
-            assertWithMessage("Invalid error cause")
-                    .that(exc)
-                    .hasCauseThat()
-                    .isInstanceOf(CheckstyleException.class);
-            // We do separate validation for message as in Windows
-            // disk drive letter appear in message,
-            // so we skip that drive letter for compatibility issues
-            final Violation loadPropertiesMessage = new Violation(1,
-                    Definitions.CHECKSTYLE_BUNDLE, Main.LOAD_PROPERTIES_EXCEPTION,
-                    new String[] {""}, null, getClass(), null);
-            final String causeMessage = exc.getCause().getLocalizedMessage();
-            final String violation = loadPropertiesMessage.getViolation();
-            final boolean samePrefix = causeMessage.substring(0, causeMessage.indexOf(' '))
-                    .equals(violation
-                            .substring(0, violation.indexOf(' ')));
-            final boolean sameSuffix =
-                    causeMessage.substring(causeMessage.lastIndexOf(' '))
-                    .equals(violation
-                            .substring(violation.lastIndexOf(' ')));
-            assertWithMessage("Invalid violation")
-                    .that(samePrefix || sameSuffix)
-                    .isTrue();
-            assertWithMessage("Invalid violation")
-                    .that(causeMessage)
-                    .contains(".'");
-        }
+        final ReflectiveOperationException exc =
+                getExpectedThrowable(ReflectiveOperationException.class, () -> {
+                    TestUtil.invokeVoidStaticMethod(cliOptionsClass,
+                            "loadProperties", new File("."));
+                }, "Exception was expected");
+        assertWithMessage("Invalid error cause")
+                .that(exc)
+                .hasCauseThat()
+                .isInstanceOf(CheckstyleException.class);
+        // We do separate validation for message as in Windows
+        // disk drive letter appear in message,
+        // so we skip that drive letter for compatibility issues
+        final Violation loadPropertiesMessage = new Violation(1,
+                Definitions.CHECKSTYLE_BUNDLE, Main.LOAD_PROPERTIES_EXCEPTION,
+                new String[] {""}, null, getClass(), null);
+        final String causeMessage = exc.getCause().getLocalizedMessage();
+        final String violation = loadPropertiesMessage.getViolation();
+        final boolean samePrefix = causeMessage.substring(0, causeMessage.indexOf(' '))
+                .equals(violation
+                        .substring(0, violation.indexOf(' ')));
+        final boolean sameSuffix =
+                causeMessage.substring(causeMessage.lastIndexOf(' '))
+                .equals(violation
+                        .substring(violation.lastIndexOf(' ')));
+        assertWithMessage("Invalid violation")
+                .that(samePrefix || sameSuffix)
+                .isTrue();
+        assertWithMessage("Invalid violation")
+                .that(causeMessage)
+                .contains(".'");
     }
 
     @Test
@@ -2057,7 +2056,8 @@ public class MainTest {
      * @noinspectionreason ResultOfMethodCallIgnored - Setup for mockito to only
      *                     mock getRuntime to avoid VM termination.
      */
-    private static void assertMainReturnCode(int expectedExitCode, String... arguments) {
+    private static void assertMainReturnCode(int expectedExitCode,
+            String... arguments) {
         final Runtime mock = mock();
         try (MockedStatic<Runtime> runtime = mockStatic(Runtime.class)) {
             runtime.when(Runtime::getRuntime)
@@ -2065,7 +2065,7 @@ public class MainTest {
             Main.main(arguments);
         }
         catch (IOException exception) {
-            assertWithMessage("Unexpected exception: %s", exception).fail();
+            throw new IllegalStateException("Unexpected IOException", exception);
         }
         verify(mock).exit(expectedExitCode);
     }

--- a/src/test/java/com/puppycrawl/tools/checkstyle/PackageNamesLoaderTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/PackageNamesLoaderTest.java
@@ -163,16 +163,14 @@ public class PackageNamesLoaderTest extends AbstractPathTestSupport {
         final Enumeration<URL> enumeration = Collections.enumeration(Collections.singleton(
                 new File(getPath("InputPackageNamesLoaderNotXml.java")).toURI().toURL()));
 
-        try {
-            PackageNamesLoader.getPackageNames(new TestUrlsClassLoader(enumeration));
-            assertWithMessage("CheckstyleException is expected").fail();
-        }
-        catch (CheckstyleException exc) {
-            assertWithMessage("Invalid exception cause class")
-                    .that(exc)
-                    .hasCauseThat()
-                    .isInstanceOf(SAXException.class);
-        }
+        final CheckstyleException exc =
+                getExpectedThrowable(CheckstyleException.class, () -> {
+                    PackageNamesLoader.getPackageNames(new TestUrlsClassLoader(enumeration));
+                }, "CheckstyleException is expected");
+        assertWithMessage("Invalid exception cause class")
+                .that(exc)
+                .hasCauseThat()
+                .isInstanceOf(SAXException.class);
     }
 
     @Test
@@ -188,40 +186,36 @@ public class PackageNamesLoaderTest extends AbstractPathTestSupport {
 
         final Enumeration<URL> enumeration = Collections.enumeration(Collections.singleton(url));
 
-        try {
-            PackageNamesLoader.getPackageNames(new TestUrlsClassLoader(enumeration));
-            assertWithMessage("CheckstyleException is expected").fail();
-        }
-        catch (CheckstyleException exc) {
-            assertWithMessage("Invalid exception cause class")
-                    .that(exc)
-                    .hasCauseThat()
-                    .isInstanceOf(IOException.class);
-            assertWithMessage("Invalid exception message")
-                    .that(exc)
-                    .hasMessageThat()
-                    .isNotEqualTo("unable to get package file resources");
-            assertWithMessage("Exception message must contain URL")
-                    .that(exc.getMessage())
-                    .contains(url.toString());
-        }
+        final CheckstyleException exc =
+                getExpectedThrowable(CheckstyleException.class, () -> {
+                    PackageNamesLoader.getPackageNames(new TestUrlsClassLoader(enumeration));
+                }, "CheckstyleException is expected");
+        assertWithMessage("Invalid exception cause class")
+                .that(exc)
+                .hasCauseThat()
+                .isInstanceOf(IOException.class);
+        assertWithMessage("Invalid exception message")
+                .that(exc)
+                .hasMessageThat()
+                .isNotEqualTo("unable to get package file resources");
+        assertWithMessage("Exception message must contain URL")
+                .that(exc.getMessage())
+                .contains(url.toString());
     }
 
     @Test
     public void testPackagesWithIoExceptionGetResources() {
-        try {
-            PackageNamesLoader.getPackageNames(new TestIoExceptionClassLoader());
-            assertWithMessage("CheckstyleException is expected").fail();
-        }
-        catch (CheckstyleException exc) {
-            assertWithMessage("Invalid exception cause class")
-                    .that(exc)
-                    .hasCauseThat()
-                    .isInstanceOf(IOException.class);
-            assertWithMessage("Invalid exception message")
-                .that(exc.getMessage())
-                .isEqualTo("unable to get package file resources");
-        }
+        final CheckstyleException exc =
+                getExpectedThrowable(CheckstyleException.class, () -> {
+                    PackageNamesLoader.getPackageNames(new TestIoExceptionClassLoader());
+                }, "CheckstyleException is expected");
+        assertWithMessage("Invalid exception cause class")
+                .that(exc)
+                .hasCauseThat()
+                .isInstanceOf(IOException.class);
+        assertWithMessage("Invalid exception message")
+            .that(exc.getMessage())
+            .isEqualTo("unable to get package file resources");
     }
 
     @Test

--- a/src/test/java/com/puppycrawl/tools/checkstyle/PropertyCacheFileTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/PropertyCacheFileTest.java
@@ -73,25 +73,23 @@ public class PropertyCacheFileTest extends AbstractPathTestSupport {
 
     @Test
     public void testCtor() {
-        try {
-            final Object test = new PropertyCacheFile(null, "");
-            assertWithMessage("exception expected but got %s", test).fail();
-        }
-        catch (IllegalArgumentException exc) {
-            assertWithMessage("Invalid exception message")
-                .that(exc.getMessage())
-                .isEqualTo("config can not be null");
-        }
+        final IllegalArgumentException exc =
+                getExpectedThrowable(IllegalArgumentException.class, () -> {
+                    final Object test = new PropertyCacheFile(null, "");
+                    assertWithMessage("exception expected but got %s", test).fail();
+                });
+        assertWithMessage("Invalid exception message")
+            .that(exc.getMessage())
+            .isEqualTo("config can not be null");
         final Configuration config = new DefaultConfiguration("myName");
-        try {
-            final Object test = new PropertyCacheFile(config, null);
-            assertWithMessage("exception expected but got %s", test).fail();
-        }
-        catch (IllegalArgumentException exc) {
-            assertWithMessage("Invalid exception message")
-                .that(exc.getMessage())
-                .isEqualTo("fileName can not be null");
-        }
+        final IllegalArgumentException exc2 =
+                getExpectedThrowable(IllegalArgumentException.class, () -> {
+                    final Object test = new PropertyCacheFile(config, null);
+                    assertWithMessage("exception expected but got %s", test).fail();
+                });
+        assertWithMessage("Invalid exception message")
+            .that(exc2.getMessage())
+            .isEqualTo("fileName can not be null");
     }
 
     @Test

--- a/src/test/java/com/puppycrawl/tools/checkstyle/SarifLoggerTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/SarifLoggerTest.java
@@ -20,6 +20,7 @@
 package com.puppycrawl.tools.checkstyle;
 
 import static com.google.common.truth.Truth.assertWithMessage;
+import static com.puppycrawl.tools.checkstyle.internal.utils.TestUtil.getExpectedThrowable;
 
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
@@ -324,19 +325,19 @@ public class SarifLoggerTest extends AbstractModuleTestSupport {
 
     @Test
     public void testNullOutputStreamOptions() {
-        try {
-            final SarifLogger logger = new SarifLogger(outStream, (OutputStreamOptions) null);
-            // assert required to calm down eclipse's 'The allocated object is never used' violation
-            assertWithMessage("Null instance")
-                .that(logger)
-                .isNotNull();
-            assertWithMessage("Exception was expected").fail();
-        }
-        catch (IllegalArgumentException | IOException exception) {
-            assertWithMessage("Invalid error message")
-                .that(exception.getMessage())
-                .isEqualTo("Parameter outputStreamOptions can not be null");
-        }
+        final IllegalArgumentException exception =
+                getExpectedThrowable(IllegalArgumentException.class, () -> {
+                    final SarifLogger logger =
+                            new SarifLogger(outStream, (OutputStreamOptions) null);
+                    // assert required to calm down eclipse's
+                    // 'The allocated object is never used' violation
+                    assertWithMessage("Null instance")
+                        .that(logger)
+                        .isNotNull();
+                }, "Exception was expected");
+        assertWithMessage("Invalid error message")
+            .that(exception.getMessage())
+            .isEqualTo("Parameter outputStreamOptions can not be null");
     }
 
     @Test
@@ -386,15 +387,13 @@ public class SarifLoggerTest extends AbstractModuleTestSupport {
 
     @Test
     public void testReadResourceWithInvalidName() {
-        try {
-            SarifLogger.readResource("random");
-            assertWithMessage("Exception expected").fail();
-        }
-        catch (IOException exception) {
-            assertWithMessage("Exception message must match")
-                .that(exception.getMessage())
-                .isEqualTo("Cannot find the resource random");
-        }
+        final IOException exception =
+                getExpectedThrowable(IOException.class, () -> {
+                    SarifLogger.readResource("random");
+                }, "Exception expected");
+        assertWithMessage("Exception message must match")
+            .that(exception.getMessage())
+            .isEqualTo("Cannot find the resource random");
     }
 
     @Test

--- a/src/test/java/com/puppycrawl/tools/checkstyle/SuppressionsStringPrinterTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/SuppressionsStringPrinterTest.java
@@ -20,6 +20,7 @@
 package com.puppycrawl.tools.checkstyle;
 
 import static com.google.common.truth.Truth.assertWithMessage;
+import static com.puppycrawl.tools.checkstyle.internal.utils.TestUtil.getExpectedThrowable;
 import static com.puppycrawl.tools.checkstyle.internal.utils.TestUtil.isUtilsClassHasPrivateConstructor;
 
 import java.io.File;
@@ -104,16 +105,14 @@ public class SuppressionsStringPrinterTest extends AbstractTreeTestSupport {
         final File input = new File(getPath("InputSuppressionsStringPrinter.java"));
         final String invalidLineAndColumnNumber = "abc-432";
         final int tabWidth = 2;
-        try {
-            SuppressionsStringPrinter.printSuppressions(input,
-                    invalidLineAndColumnNumber, tabWidth);
-            assertWithMessage("exception expected").fail();
-        }
-        catch (IllegalStateException exc) {
-            assertWithMessage("Invalid exception message")
-                .that(exc.getMessage())
-                .isEqualTo("abc-432 does not match valid format 'line:column'.");
-        }
+        final IllegalStateException exc =
+                getExpectedThrowable(IllegalStateException.class, () -> {
+                    SuppressionsStringPrinter.printSuppressions(input,
+                            invalidLineAndColumnNumber, tabWidth);
+                }, "exception expected");
+        assertWithMessage("Invalid exception message")
+            .that(exc.getMessage())
+            .isEqualTo("abc-432 does not match valid format 'line:column'.");
     }
 
     @Test
@@ -121,20 +120,18 @@ public class SuppressionsStringPrinterTest extends AbstractTreeTestSupport {
         final File input = new File(getNonCompilablePath("InputSuppressionsStringPrinter.java"));
         final String lineAndColumnNumber = "2:3";
         final int tabWidth = 2;
-        try {
-            SuppressionsStringPrinter.printSuppressions(input,
-                    lineAndColumnNumber, tabWidth);
-            assertWithMessage("exception expected").fail();
-        }
-        catch (CheckstyleException exc) {
-            assertWithMessage("Invalid class")
-                .that(exc.getCause())
-                .isInstanceOf(IllegalStateException.class);
-            assertWithMessage("Invalid exception message")
-                .that(exc.getCause().toString())
-                .isEqualTo(IllegalStateException.class.getName()
-                            + ": 2:0: no viable alternative at input 'classD'");
-        }
+        final CheckstyleException exc =
+                getExpectedThrowable(CheckstyleException.class, () -> {
+                    SuppressionsStringPrinter.printSuppressions(input,
+                            lineAndColumnNumber, tabWidth);
+                }, "exception expected");
+        assertWithMessage("Invalid class")
+            .that(exc.getCause())
+            .isInstanceOf(IllegalStateException.class);
+        assertWithMessage("Invalid exception message")
+            .that(exc.getCause().toString())
+            .isEqualTo(IllegalStateException.class.getName()
+                        + ": 2:0: no viable alternative at input 'classD'");
     }
 
 }

--- a/src/test/java/com/puppycrawl/tools/checkstyle/ThreadModeSettingsTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/ThreadModeSettingsTest.java
@@ -20,6 +20,7 @@
 package com.puppycrawl.tools.checkstyle;
 
 import static com.google.common.truth.Truth.assertWithMessage;
+import static com.puppycrawl.tools.checkstyle.internal.utils.TestUtil.getExpectedThrowable;
 
 import java.util.Set;
 
@@ -44,15 +45,13 @@ public class ThreadModeSettingsTest {
     public void testResolveCheckerInMultiThreadMode() {
         final ThreadModeSettings configuration = new ThreadModeSettings(2, 2);
 
-        try {
-            configuration.resolveName(ThreadModeSettings.CHECKER_MODULE_NAME);
-            assertWithMessage("An exception is expected").fail();
-        }
-        catch (IllegalArgumentException exc) {
-            assertWithMessage("Invalid exception message")
-                    .that(exc.getMessage())
-                    .isEqualTo("Multi thread mode for Checker module is not implemented");
-        }
+        final IllegalArgumentException exc =
+                getExpectedThrowable(IllegalArgumentException.class, () -> {
+                    configuration.resolveName(ThreadModeSettings.CHECKER_MODULE_NAME);
+                }, "An exception is expected");
+        assertWithMessage("Invalid exception message")
+                .that(exc.getMessage())
+                .isEqualTo("Multi thread mode for Checker module is not implemented");
     }
 
     @Test
@@ -69,15 +68,13 @@ public class ThreadModeSettingsTest {
     public void testResolveTreeWalker() {
         final ThreadModeSettings configuration = new ThreadModeSettings(2, 2);
 
-        try {
-            configuration.resolveName(ThreadModeSettings.TREE_WALKER_MODULE_NAME);
-            assertWithMessage("Exception is expected").fail();
-        }
-        catch (IllegalArgumentException exc) {
-            assertWithMessage("Invalid exception message")
-                    .that(exc.getMessage())
-                    .isEqualTo("Multi thread mode for TreeWalker module is not implemented");
-        }
+        final IllegalArgumentException exc =
+                getExpectedThrowable(IllegalArgumentException.class, () -> {
+                    configuration.resolveName(ThreadModeSettings.TREE_WALKER_MODULE_NAME);
+                }, "Exception is expected");
+        assertWithMessage("Invalid exception message")
+                .that(exc.getMessage())
+                .isEqualTo("Multi thread mode for TreeWalker module is not implemented");
     }
 
     @Test


### PR DESCRIPTION
Resolves part of #19176

Migrated assertWithMessage(...).fail()  try-catch pattern to getExpectedThrowable() utility.

Files migrated in this PR:

CheckerTest
ConfigurationLoaderTest
PackageObjectFactoryTest
TreeWalkerTest
JavadocPropertiesGeneratorTest
SuppressWarningsHolderTest
PackageNamesLoaderTest
DetailNodeTreeStringPrinterTest
PropertyCacheFileTest
SarifLoggerTest
SuppressionsStringPrinterTest
ThreadModeSettingsTest
NewlineAtEndOfFileCheckTest
MainTest
SuppressWithNearbyCommentFilterTest
SuppressWithNearbyTextFilterTest
SuppressWithPlainTextCommentFilterTest
SuppressionCommentFilterTest
SuppressionFilterTest
SuppressionXpathFilterTest
SuppressionXpathSingleFilterTest
SuppressionsLoaderTest
XpathFilterElementTest
Updated suppressions.xmltadd checks/newlineatendoflile to the MatchXpathForbidTryCatchFail exclusion list.