### PR TITLE
Issue #19064: Add third test to XpathRegressionSingleSpaceSeparatorTest

### DIFF
--- a/config/checkstyle-non-main-files-suppressions.xml
+++ b/config/checkstyle-non-main-files-suppressions.xml
@@ -468,5 +468,4 @@
   <suppress id="numberOfTestCasesInXpath" files="[\\/]src[\\/]it[\\/]java[\\/]org[\\/]checkstyle[\\/]suppressionxpathfilter[\\/]whitespace[\\/]XpathRegressionEmptyForInitializerPadTest.java" />
   <suppress id="numberOfTestCasesInXpath" files="[\\/]src[\\/]it[\\/]java[\\/]org[\\/]checkstyle[\\/]suppressionxpathfilter[\\/]whitespace[\\/]XpathRegressionEmptyForIteratorPadTest.java" />
   <suppress id="numberOfTestCasesInXpath" files="[\\/]src[\\/]it[\\/]java[\\/]org[\\/]checkstyle[\\/]suppressionxpathfilter[\\/]whitespace[\\/]XpathRegressionOperatorWrapTest.java" />
-  <suppress id="numberOfTestCasesInXpath" files="[\\/]src[\\/]it[\\/]java[\\/]org[\\/]checkstyle[\\/]suppressionxpathfilter[\\/]whitespace[\\/]XpathRegressionSingleSpaceSeparatorTest.java" />
 </suppressions>

--- a/src/it/java/org/checkstyle/suppressionxpathfilter/whitespace/XpathRegressionSingleSpaceSeparatorTest.java
+++ b/src/it/java/org/checkstyle/suppressionxpathfilter/whitespace/XpathRegressionSingleSpaceSeparatorTest.java
@@ -91,4 +91,27 @@ public class XpathRegressionSingleSpaceSeparatorTest extends AbstractXpathTestSu
         runVerifications(moduleConfig, fileToProcess, expectedViolation,
                 expectedXpathQueries);
     }
+
+    @Test
+    public void testInnerClassViolation() throws Exception {
+        final File fileToProcess =
+                new File(getPath("InputXpathSingleSpaceSeparatorInnerClass.java"));
+
+        final DefaultConfiguration moduleConfig =
+                createModuleConfig(SingleSpaceSeparatorCheck.class);
+
+        final String[] expectedViolation = {
+            "5:15: " + getCheckMessage(SingleSpaceSeparatorCheck.class,
+                SingleSpaceSeparatorCheck.MSG_KEY),
+        };
+
+        final List<String> expectedXpathQueries = Collections.singletonList(
+            "/COMPILATION_UNIT/CLASS_DEF[./IDENT[@text='InputXpathSingleSpaceSeparatorInnerClass']]"
+                + "/OBJBLOCK/CLASS_DEF[./IDENT[@text='Inner']]/OBJBLOCK/VARIABLE_DEF"
+                + "/IDENT[@text='bad']"
+        );
+
+        runVerifications(moduleConfig, fileToProcess, expectedViolation,
+                expectedXpathQueries);
+    }
 }

--- a/src/it/resources/org/checkstyle/suppressionxpathfilter/whitespace/singlespaceseparator/InputXpathSingleSpaceSeparatorInnerClass.java
+++ b/src/it/resources/org/checkstyle/suppressionxpathfilter/whitespace/singlespaceseparator/InputXpathSingleSpaceSeparatorInnerClass.java
@@ -1,0 +1,7 @@
+package org.checkstyle.suppressionxpathfilter.whitespace.singlespaceseparator;
+
+public class InputXpathSingleSpaceSeparatorInnerClass {
+    class Inner {
+        long  bad;//warn
+    }
+}


### PR DESCRIPTION
Issue: #19064

Add third test to XpathRegressionSingleSpaceSeparatorTest to meet the requirement of 3 distinct test methods with different XPath structures.

Changes:
- Added new test method `testInnerClassViolation()` with inner class structure
- Created new input file `InputXpathSingleSpaceSeparatorInnerClass.java`
- Removed suppression for this file from `checkstyle-non-main-files-suppressions.xml`

The three tests now cover different AST structures:
1. Basic variable declaration (existing)
2. Comment validation (existing)
3. Inner class variable declaration (new)

All tests pass with `mvn clean verify`.