### PR TITLE
Issue #19064: Add third test to XpathRegressionNestedTryDepthTest

### DIFF
--- a/config/checkstyle-non-main-files-suppressions.xml
+++ b/config/checkstyle-non-main-files-suppressions.xml
@@ -427,7 +427,7 @@
   <suppress id="numberOfTestCasesInXpath" files="[\\/]src[\\/]it[\\/]java[\\/]org[\\/]checkstyle[\\/]suppressionxpathfilter[\\/]coding[\\/]XpathRegressionMultipleVariableDeclarationsTest.java" />
   <suppress id="numberOfTestCasesInXpath" files="[\\/]src[\\/]it[\\/]java[\\/]org[\\/]checkstyle[\\/]suppressionxpathfilter[\\/]coding[\\/]XpathRegressionNestedForDepthTest.java" />
   <suppress id="numberOfTestCasesInXpath" files="[\\/]src[\\/]it[\\/]java[\\/]org[\\/]checkstyle[\\/]suppressionxpathfilter[\\/]coding[\\/]XpathRegressionNestedIfDepthTest.java" />
-  <suppress id="numberOfTestCasesInXpath" files="[\\/]src[\\/]it[\\/]java[\\/]org[\\/]checkstyle[\\/]suppressionxpathfilter[\\/]coding[\\/]XpathRegressionNestedTryDepthTest.java" />
+
   <suppress id="numberOfTestCasesInXpath" files="[\\/]src[\\/]it[\\/]java[\\/]org[\\/]checkstyle[\\/]suppressionxpathfilter[\\/]coding[\\/]XpathRegressionNoEnumTrailingCommaTest.java" />
   <suppress id="numberOfTestCasesInXpath" files="[\\/]src[\\/]it[\\/]java[\\/]org[\\/]checkstyle[\\/]suppressionxpathfilter[\\/]coding[\\/]XpathRegressionOneStatementPerLineTest.java" />
   <suppress id="numberOfTestCasesInXpath" files="[\\/]src[\\/]it[\\/]java[\\/]org[\\/]checkstyle[\\/]suppressionxpathfilter[\\/]coding[\\/]XpathRegressionOverloadMethodsDeclarationOrderTest.java" />

--- a/src/it/java/org/checkstyle/suppressionxpathfilter/coding/XpathRegressionNestedTryDepthTest.java
+++ b/src/it/java/org/checkstyle/suppressionxpathfilter/coding/XpathRegressionNestedTryDepthTest.java
@@ -95,4 +95,30 @@ public class XpathRegressionNestedTryDepthTest extends AbstractXpathTestSupport 
         runVerifications(moduleConfig, fileToProcess, expectedViolation,
             expectedXpathQueries);
     }
+
+    @Test
+    public void testInnerClass() throws Exception {
+        final File fileToProcess =
+                new File(getPath("InputXpathNestedTryDepthInnerClass.java"));
+
+        final DefaultConfiguration moduleConfig =
+                createModuleConfig(NestedTryDepthCheck.class);
+
+        final String[] expectedViolation = {
+            "8:21: " + getCheckMessage(NestedTryDepthCheck.class,
+                NestedTryDepthCheck.MSG_KEY, 2, 1),
+        };
+
+        final List<String> expectedXpathQueries = Collections.singletonList(
+            "/COMPILATION_UNIT/CLASS_DEF"
+                + "[./IDENT[@text='InputXpathNestedTryDepthInnerClass']]"
+                + "/OBJBLOCK/CLASS_DEF[./IDENT[@text='Inner']]"
+                + "/OBJBLOCK/METHOD_DEF[./IDENT[@text='test']]"
+                + "/SLIST/LITERAL_TRY/SLIST"
+                + "/LITERAL_TRY/SLIST/LITERAL_TRY"
+        );
+
+        runVerifications(moduleConfig, fileToProcess, expectedViolation,
+                expectedXpathQueries);
+    }
 }

--- a/src/it/resources/org/checkstyle/suppressionxpathfilter/coding/nestedtrydepth/InputXpathNestedTryDepthInnerClass.java
+++ b/src/it/resources/org/checkstyle/suppressionxpathfilter/coding/nestedtrydepth/InputXpathNestedTryDepthInnerClass.java
@@ -1,0 +1,15 @@
+package org.checkstyle.suppressionxpathfilter.coding.nestedtrydepth;
+
+public class InputXpathNestedTryDepthInnerClass {
+    class Inner {
+        public void test() {
+            try {
+                try {
+                    try { // warn
+
+                    } catch (Exception e) {}
+                } catch (Exception e) {}
+            } catch (Exception e) {}
+        }
+    }
+}


### PR DESCRIPTION
Issue: #19064

Adds a third test method `testInnerClass()` to `XpathRegressionNestedTryDepthTest` with a violation inside an inner class, producing a distinct XPath structure:

```
/COMPILATION_UNIT/CLASS_DEF[...]/OBJBLOCK/CLASS_DEF[...]/OBJBLOCK/METHOD_DEF[...]/SLIST/LITERAL_TRY/SLIST/LITERAL_TRY/SLIST/LITERAL_TRY
```

This differs from the existing two tests which target violations directly inside `METHOD_DEF` without the nested `CLASS_DEF` node.

Removes the corresponding suppression entry from `checkstyle-non-main-files-suppressions.xml`.