### PR TITLE
Issue #17449: Add example for arrayInitIndent

### DIFF
--- a/src/site/xdoc/checks/misc/indentation.xml
+++ b/src/site/xdoc/checks/misc/indentation.xml
@@ -341,6 +341,65 @@ class Example4 {
         }
     }
 }
+</code></pre></div><hr class="example-separator"/>
+        <p id="Example5-config">
+          To configure the Check with arrayInitIndent:.
+        </p>
+        <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
+&lt;module name="Checker"&gt;
+  &lt;module name="TreeWalker"&gt;
+    &lt;module name="Indentation"&gt;
+      &lt;property name="arrayInitIndent" value="2"/&gt;
+    &lt;/module&gt;
+  &lt;/module&gt;
+&lt;/module&gt;
+</code></pre></div>
+        <p id="Example5-code">
+           Example of compliant code with arrayInitIndent
+        </p>
+        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+class Example5 {
+    String field = "example";                  // basicOffset
+    int[] values = {                           // basicOffset
+        10,
+        20,
+        30
+    };
+
+    void processValues() throws Exception {
+        handleValue("Test String", 42);          // basicOffset
+    }
+
+    void handleValue(String aFooString,
+                     int aFooInt) {             // indent:8 ; expected: &gt; 4;
+
+        boolean cond1,cond2,cond3,cond4,cond5,cond6;
+        cond1=cond2=cond3=cond4=cond5=cond6=false;
+
+        if (cond1
+                || cond2) {
+            field = field.toUpperCase()
+                    .concat(" TASK");
+        }
+
+        if ((cond1 &amp;&amp; cond2)
+                || (cond3 &amp;&amp; cond4)          // ok, lineWrappingIndentation
+                || !(cond5 &amp;&amp; cond6)) {      // ok, lineWrappingIndentation
+            field.toUpperCase()
+                    .concat(" TASK")             // ok, lineWrappingIndentation
+                    .chars().forEach(c -&gt; {      // ok, lineWrappingIndentation
+                        System.out.println((char) c);
+                    });
+        }
+    }
+
+    void demonstrateSwitch() throws Exception {
+        switch (field) {
+            case "EXAMPLE": processValues();                        // caseIndent
+            case "COMPLETED": handleValue("Completed Case", 456);   // caseIndent
+        }
+    }
+}
 </code></pre></div>
       </subsection>
 

--- a/src/site/xdoc/checks/misc/indentation.xml.template
+++ b/src/site/xdoc/checks/misc/indentation.xml.template
@@ -88,6 +88,22 @@
           <param name="path"
                  value="resources/com/puppycrawl/tools/checkstyle/checks/indentation/indentation/Example4.java"/>
           <param name="type" value="code"/>
+        </macro><hr class="example-separator"/>
+        <p id="Example5-config">
+          To configure the Check with arrayInitIndent:.
+        </p>
+        <macro name="example">
+          <param name="path"
+                     value="resources/com/puppycrawl/tools/checkstyle/checks/indentation/indentation/Example5.java"/>
+          <param name="type" value="config"/>
+        </macro>
+        <p id="Example5-code">
+           Example of compliant code with arrayInitIndent
+        </p>
+        <macro name="example">
+          <param name="path"
+                 value="resources/com/puppycrawl/tools/checkstyle/checks/indentation/indentation/Example5.java"/>
+          <param name="type" value="code"/>
         </macro>
       </subsection>
 

--- a/src/test/java/com/puppycrawl/tools/checkstyle/internal/XdocsExampleFileTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/internal/XdocsExampleFileTest.java
@@ -63,7 +63,6 @@ public class XdocsExampleFileTest {
                     "basicOffset",
                     "lineWrappingIndentation",
                     "throwsIndent",
-                    "arrayInitIndent",
                     "braceAdjustment"
             ))
     );

--- a/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/checks/indentation/IndentationCheckExamplesTest.java
+++ b/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/checks/indentation/IndentationCheckExamplesTest.java
@@ -61,4 +61,10 @@ public class IndentationCheckExamplesTest extends AbstractExamplesModuleTestSupp
         final String[] expected = {};
         verifyWithInlineConfigParser(getPath("Example4.java"), expected);
     }
+
+    @Test
+    public void testExample5() throws Exception {
+        final String[] expected = {};
+        verifyWithInlineConfigParser(getPath("Example5.java"), expected);
+    }
 }

--- a/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/indentation/indentation/Example5.java
+++ b/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/indentation/indentation/Example5.java
@@ -1,0 +1,57 @@
+/*xml
+<module name="Checker">
+  <module name="TreeWalker">
+    <module name="Indentation">
+      <property name="arrayInitIndent" value="2"/>
+    </module>
+  </module>
+</module>
+*/
+
+package com.puppycrawl.tools.checkstyle.checks.indentation.indentation;
+
+// xdoc section -- start
+class Example5 {
+    String field = "example";                  // basicOffset
+    int[] values = {                           // basicOffset
+        10,
+        20,
+        30
+    };
+
+    void processValues() throws Exception {
+        handleValue("Test String", 42);          // basicOffset
+    }
+
+    void handleValue(String aFooString,
+                     int aFooInt) {             // indent:8 ; expected: > 4;
+
+        boolean cond1,cond2,cond3,cond4,cond5,cond6;
+        cond1=cond2=cond3=cond4=cond5=cond6=false;
+
+        if (cond1
+                || cond2) {
+            field = field.toUpperCase()
+                    .concat(" TASK");
+        }
+
+        if ((cond1 && cond2)
+                || (cond3 && cond4)          // ok, lineWrappingIndentation
+                || !(cond5 && cond6)) {      // ok, lineWrappingIndentation
+            field.toUpperCase()
+                    .concat(" TASK")             // ok, lineWrappingIndentation
+                    .chars().forEach(c -> {      // ok, lineWrappingIndentation
+                        System.out.println((char) c);
+                    });
+        }
+    }
+
+    void demonstrateSwitch() throws Exception {
+        switch (field) {
+            case "EXAMPLE": processValues();                        // caseIndent
+            case "COMPLETED": handleValue("Completed Case", 456);   // caseIndent
+        }
+    }
+}
+// xdoc section -- end
+


### PR DESCRIPTION
#17449 

Added missing XDoc examples for IndentationCheck

Example5: arrayInitIndent
Updated the XDoc template file to include references to arrayInitIndent propoerty
Added IndentationCheckExamplesTest to verify the  araryInitIndent example.