### PR TITLE
Issue #19176: migrate checks tests to getExpectedThrowable

### DIFF
--- a/config/suppressions.xml
+++ b/config/suppressions.xml
@@ -188,6 +188,6 @@
   <!-- Remove suppression once all violations are fixed, tracked in #19176 -->
   <suppress checks="MatchXpath"
             id="MatchXpathForbidTryCatchFail"
-            files=".*[\\/]src[\\/]test[\\/]java[\\/]com[\\/]puppycrawl[\\/]tools[\\/]checkstyle[\\/](?!utils|xpath|checks[\\/]coding|checks[\\/]design|checks[\\/]modifier|checks[\\/]naming|checks[\\/]annotation|checks[\\/]indentation|checks[\\/]metrics|checks[\\/]whitespace|checks[\\/]javadoc).*"/>
+            files=".*[\\/]src[\\/]test[\\/]java[\\/]com[\\/]puppycrawl[\\/]tools[\\/]checkstyle[\\/](?!utils|xpath|checks[\\/]coding|checks[\\/]design|checks[\\/]modifier|checks[\\/]naming|checks[\\/]annotation|checks[\\/]indentation|checks[\\/]metrics|checks[\\/]whitespace|checks[\\/]javadoc|checks[\\/]NewlineAtEndOfFileCheckTest|checks[\\/]SuppressWarningsHolderTest|checks[\\/]UncommentedMainCheckTest).*"/>
 
 </suppressions>

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/NewlineAtEndOfFileCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/NewlineAtEndOfFileCheckTest.java
@@ -23,6 +23,7 @@ import static com.google.common.truth.Truth.assertWithMessage;
 import static com.puppycrawl.tools.checkstyle.checks.NewlineAtEndOfFileCheck.MSG_KEY_NO_NEWLINE_EOF;
 import static com.puppycrawl.tools.checkstyle.checks.NewlineAtEndOfFileCheck.MSG_KEY_UNABLE_OPEN;
 import static com.puppycrawl.tools.checkstyle.checks.NewlineAtEndOfFileCheck.MSG_KEY_WRONG_ENDING;
+import static com.puppycrawl.tools.checkstyle.internal.utils.TestUtil.getExpectedThrowable;
 
 import java.io.File;
 import java.io.FileNotFoundException;
@@ -120,22 +121,18 @@ public class NewlineAtEndOfFileCheckTest
     }
 
     @Test
-    public void testSetLineSeparatorFailure()
-            throws Exception {
+    public void testSetLineSeparatorFailure() {
         final DefaultConfiguration checkConfig =
             createModuleConfig(NewlineAtEndOfFileCheck.class);
         checkConfig.addProperty("lineSeparator", "ct");
-        try {
-            createChecker(checkConfig);
-            assertWithMessage("exception expected").fail();
-        }
-        catch (CheckstyleException exc) {
-            assertWithMessage("Error message is unexpected")
-                    .that(exc.getMessage())
-                    .isEqualTo("cannot initialize module com.puppycrawl.tools.checkstyle."
-                            + "checks.NewlineAtEndOfFileCheck - "
-                            + "Cannot set property 'lineSeparator' to 'ct'");
-        }
+        final CheckstyleException exc = getExpectedThrowable(
+                CheckstyleException.class,
+                () -> createChecker(checkConfig));
+        assertWithMessage("Error message is unexpected")
+                .that(exc.getMessage())
+                .isEqualTo("cannot initialize module com.puppycrawl.tools.checkstyle."
+                        + "checks.NewlineAtEndOfFileCheck - "
+                        + "Cannot set property 'lineSeparator' to 'ct'");
     }
 
     @Test
@@ -196,11 +193,12 @@ public class NewlineAtEndOfFileCheckTest
     public void testWrongSeparatorLength() throws Exception {
         try (RandomAccessFile file =
                      new ReadZeroRandomAccessFile(getPath("InputNewlineAtEndOfFileLf.java"), "r")) {
-            TestUtil.invokeVoidMethod(new NewlineAtEndOfFileCheck(), "endsWithNewline", file,
-                LineSeparatorOption.LF);
-            assertWithMessage("ReflectiveOperationException is expected").fail();
-        }
-        catch (ReflectiveOperationException exc) {
+            final ReflectiveOperationException exc = getExpectedThrowable(
+                ReflectiveOperationException.class,
+                () -> {
+                    TestUtil.invokeVoidMethod(new NewlineAtEndOfFileCheck(),
+                            "endsWithNewline", file, LineSeparatorOption.LF);
+                });
             assertWithMessage("Error message is unexpected")
                 .that(exc)
                     .hasCauseThat()

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/SuppressWarningsHolderTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/SuppressWarningsHolderTest.java
@@ -22,6 +22,7 @@ package com.puppycrawl.tools.checkstyle.checks;
 import static com.google.common.truth.Truth.assertWithMessage;
 import static com.puppycrawl.tools.checkstyle.checks.coding.UnusedLocalVariableCheck.MSG_UNUSED_LOCAL_VARIABLE;
 import static com.puppycrawl.tools.checkstyle.checks.sizes.LineLengthCheck.MSG_KEY;
+import static com.puppycrawl.tools.checkstyle.internal.utils.TestUtil.getExpectedThrowable;
 
 import java.io.File;
 import java.util.List;
@@ -146,15 +147,12 @@ public class SuppressWarningsHolderTest extends AbstractModuleTestSupport {
     public void testSetAliasListWrong() {
         final SuppressWarningsHolder holder = new SuppressWarningsHolder();
 
-        try {
-            holder.setAliasList("=SomeAlias");
-            assertWithMessage("Exception expected").fail();
-        }
-        catch (IllegalArgumentException exc) {
-            assertWithMessage("Error message is unexpected")
-                .that(exc.getMessage())
-                .isEqualTo("'=' expected in alias list item: =SomeAlias");
-        }
+        final IllegalArgumentException exc = getExpectedThrowable(
+                IllegalArgumentException.class,
+                () -> holder.setAliasList("=SomeAlias"));
+        assertWithMessage("Error message is unexpected")
+            .that(exc.getMessage())
+            .isEqualTo("'=' expected in alias list item: =SomeAlias");
     }
 
     @Test
@@ -297,21 +295,18 @@ public class SuppressWarningsHolderTest extends AbstractModuleTestSupport {
         parent.addChild(lparen);
         parent.addChild(methodDef);
 
-        try {
-            TestUtil.invokeVoidMethod(holder, "getAllAnnotationValues", parent);
-            assertWithMessage("Exception expected").fail();
-        }
-        catch (ReflectiveOperationException exc) {
-            assertWithMessage("Error type is unexpected")
-                    .that(exc)
-                    .hasCauseThat()
-                    .isInstanceOf(IllegalArgumentException.class);
-            assertWithMessage("Error message is unexpected")
-                .that(exc)
+        final ReflectiveOperationException exc1 = getExpectedThrowable(
+                ReflectiveOperationException.class,
+                () -> TestUtil.invokeVoidMethod(holder, "getAllAnnotationValues", parent));
+        assertWithMessage("Error type is unexpected")
+                .that(exc1)
                 .hasCauseThat()
-                .hasMessageThat()
-                .isEqualTo("Unexpected AST: Method Def[0x0]");
-        }
+                .isInstanceOf(IllegalArgumentException.class);
+        assertWithMessage("Error message is unexpected")
+            .that(exc1)
+            .hasCauseThat()
+            .hasMessageThat()
+            .isEqualTo("Unexpected AST: Method Def[0x0]");
     }
 
     @Test
@@ -324,22 +319,19 @@ public class SuppressWarningsHolderTest extends AbstractModuleTestSupport {
         methodDef.setLineNo(0);
         methodDef.setColumnNo(0);
 
-        try {
-            TestUtil.invokeVoidMethod(holder, "getAnnotationValues", methodDef);
-            assertWithMessage("Exception expected").fail();
-        }
-        catch (ReflectiveOperationException exc) {
-            assertWithMessage("Error type is unexpected")
-                    .that(exc)
-                    .hasCauseThat()
-                    .isInstanceOf(IllegalArgumentException.class);
-            assertWithMessage("Error message is unexpected")
-                .that(exc)
+        final ReflectiveOperationException exc2 = getExpectedThrowable(
+                ReflectiveOperationException.class,
+                () -> TestUtil.invokeVoidMethod(holder, "getAnnotationValues", methodDef));
+        assertWithMessage("Error type is unexpected")
+                .that(exc2)
                 .hasCauseThat()
-                .hasMessageThat()
-                .isEqualTo("Expression or annotation array initializer AST expected: "
-                        + "Method Def[0x0]");
-        }
+                .isInstanceOf(IllegalArgumentException.class);
+        assertWithMessage("Error message is unexpected")
+            .that(exc2)
+            .hasCauseThat()
+            .hasMessageThat()
+            .isEqualTo("Expression or annotation array initializer AST expected: "
+                    + "Method Def[0x0]");
     }
 
     @Test
@@ -357,21 +349,18 @@ public class SuppressWarningsHolderTest extends AbstractModuleTestSupport {
         parent.setLineNo(0);
         parent.setColumnNo(0);
 
-        try {
-            TestUtil.invokeVoidMethod(holder, "getAnnotationTarget", methodDef);
-            assertWithMessage("Exception expected").fail();
-        }
-        catch (ReflectiveOperationException exc) {
-            assertWithMessage("Error type is unexpected")
-                    .that(exc)
-                    .hasCauseThat()
-                    .isInstanceOf(IllegalArgumentException.class);
-            assertWithMessage("Error message is unexpected")
-                .that(exc)
+        final ReflectiveOperationException exc3 = getExpectedThrowable(
+                ReflectiveOperationException.class,
+                () -> TestUtil.invokeVoidMethod(holder, "getAnnotationTarget", methodDef));
+        assertWithMessage("Error type is unexpected")
+                .that(exc3)
                 .hasCauseThat()
-                .hasMessageThat()
-                .isEqualTo("Unexpected container AST: Parent ast[0x0]");
-        }
+                .isInstanceOf(IllegalArgumentException.class);
+        assertWithMessage("Error message is unexpected")
+            .that(exc3)
+            .hasCauseThat()
+            .hasMessageThat()
+            .isEqualTo("Unexpected container AST: Parent ast[0x0]");
     }
 
     @Test
@@ -380,15 +369,12 @@ public class SuppressWarningsHolderTest extends AbstractModuleTestSupport {
         final DetailAstImpl methodDef = new DetailAstImpl();
         methodDef.setType(TokenTypes.METHOD_DEF);
 
-        try {
-            holder.visitToken(methodDef);
-            assertWithMessage("Exception expected").fail();
-        }
-        catch (IllegalArgumentException exc) {
-            assertWithMessage("Error message is unexpected")
-                .that(exc.getMessage())
-                .isEqualTo("Identifier AST expected, but get null.");
-        }
+        final IllegalArgumentException exc4 = getExpectedThrowable(
+                IllegalArgumentException.class,
+                () -> holder.visitToken(methodDef));
+        assertWithMessage("Error message is unexpected")
+            .that(exc4.getMessage())
+            .isEqualTo("Identifier AST expected, but get null.");
     }
 
     @Test

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/UncommentedMainCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/UncommentedMainCheckTest.java
@@ -21,6 +21,7 @@ package com.puppycrawl.tools.checkstyle.checks;
 
 import static com.google.common.truth.Truth.assertWithMessage;
 import static com.puppycrawl.tools.checkstyle.checks.UncommentedMainCheck.MSG_KEY;
+import static com.puppycrawl.tools.checkstyle.internal.utils.TestUtil.getExpectedThrowable;
 
 import java.io.File;
 import java.util.List;
@@ -120,15 +121,12 @@ public class UncommentedMainCheckTest
         final UncommentedMainCheck check = new UncommentedMainCheck();
         final DetailAstImpl ast = new DetailAstImpl();
         ast.initialize(new CommonToken(TokenTypes.CTOR_DEF, "ctor"));
-        try {
-            check.visitToken(ast);
-            assertWithMessage("IllegalStateException is expected").fail();
-        }
-        catch (IllegalStateException exc) {
-            assertWithMessage("Error message is unexpected")
-                .that(exc.getMessage())
-                .isEqualTo(ast.toString());
-        }
+        final IllegalStateException exc = getExpectedThrowable(
+                IllegalStateException.class,
+                () -> check.visitToken(ast));
+        assertWithMessage("Error message is unexpected")
+            .that(exc.getMessage())
+            .isEqualTo(ast.toString());
     }
 
     @Test


### PR DESCRIPTION
Issue: #19176

Migrated 3 root-level test files in the `checks` package from
`assertWithMessage(...).fail()` to `getExpectedThrowable`.

Files changed:
- `UncommentedMainCheckTest.java` (1 occurrence)
- `SuppressWarningsHolderTest.java` (5 occurrences)
- `NewlineAtEndOfFileCheckTest.java` (2 occurrences)

Updated `config/suppressions.xml` to remove these files from the
`MatchXpathForbidTryCatchFail` suppression scope.