### PR TITLE
Issue #19064: Add third test to XpathRegressionOperatorWrapTest

### DIFF
--- a/config/checkstyle-non-main-files-suppressions.xml
+++ b/config/checkstyle-non-main-files-suppressions.xml
@@ -464,5 +464,4 @@
   <suppress id="numberOfTestCasesInXpath" files="[\\/]src[\\/]it[\\/]java[\\/]org[\\/]checkstyle[\\/]suppressionxpathfilter[\\/]sizes[\\/]XpathRegressionRecordComponentNumberTest.java" />
   <suppress id="numberOfTestCasesInXpath" files="[\\/]src[\\/]it[\\/]java[\\/]org[\\/]checkstyle[\\/]suppressionxpathfilter[\\/]whitespace[\\/]XpathRegressionEmptyForInitializerPadTest.java" />
   <suppress id="numberOfTestCasesInXpath" files="[\\/]src[\\/]it[\\/]java[\\/]org[\\/]checkstyle[\\/]suppressionxpathfilter[\\/]whitespace[\\/]XpathRegressionEmptyForIteratorPadTest.java" />
-  <suppress id="numberOfTestCasesInXpath" files="[\\/]src[\\/]it[\\/]java[\\/]org[\\/]checkstyle[\\/]suppressionxpathfilter[\\/]whitespace[\\/]XpathRegressionOperatorWrapTest.java" />
 </suppressions>

--- a/src/it/java/org/checkstyle/suppressionxpathfilter/whitespace/XpathRegressionOperatorWrapTest.java
+++ b/src/it/java/org/checkstyle/suppressionxpathfilter/whitespace/XpathRegressionOperatorWrapTest.java
@@ -95,4 +95,37 @@ public class XpathRegressionOperatorWrapTest extends AbstractXpathTestSupport {
         runVerifications(moduleConfig, fileToProcess, expectedViolation,
                 expectedXpathQueries);
     }
+
+    @Test
+    public void testOperatorWrapInnerClass() throws Exception {
+        final File fileToProcess =
+                new File(getPath("InputXpathOperatorWrapInnerClass.java"));
+
+        final DefaultConfiguration moduleConfig =
+                createModuleConfig(OperatorWrapCheck.class);
+
+        final String[] expectedViolation = {
+            "7:23: " + getCheckMessage(OperatorWrapCheck.class,
+                        OperatorWrapCheck.MSG_LINE_NEW, "+"),
+        };
+
+        final List<String> expectedXpathQueries = List.of(
+             "/COMPILATION_UNIT"
+                + "/CLASS_DEF[./IDENT[@text='InputXpathOperatorWrapInnerClass']]"
+                + "/OBJBLOCK/CLASS_DEF[./IDENT[@text='Inner']]"
+                + "/OBJBLOCK/METHOD_DEF[./IDENT[@text='compute']]"
+                + "/SLIST/VARIABLE_DEF[./IDENT[@text='y']]"
+                + "/ASSIGN/EXPR",
+             "/COMPILATION_UNIT"
+                + "/CLASS_DEF[./IDENT[@text='InputXpathOperatorWrapInnerClass']]"
+                + "/OBJBLOCK/CLASS_DEF[./IDENT[@text='Inner']]"
+                + "/OBJBLOCK/METHOD_DEF[./IDENT[@text='compute']]"
+                + "/SLIST/VARIABLE_DEF[./IDENT[@text='y']]"
+                + "/ASSIGN/EXPR/PLUS[./NUM_INT[@text='5']]"
+        );
+
+        runVerifications(moduleConfig, fileToProcess, expectedViolation,
+                expectedXpathQueries);
+    }
+
 }

--- a/src/it/resources/org/checkstyle/suppressionxpathfilter/whitespace/operatorwrap/InputXpathOperatorWrapInnerClass.java
+++ b/src/it/resources/org/checkstyle/suppressionxpathfilter/whitespace/operatorwrap/InputXpathOperatorWrapInnerClass.java
@@ -1,0 +1,11 @@
+package org.checkstyle.suppressionxpathfilter.whitespace.operatorwrap;
+
+public class InputXpathOperatorWrapInnerClass {
+
+    class Inner {
+        void compute() {
+            int y = 5 + // warn
+                7;
+        }
+    }
+}


### PR DESCRIPTION
Issue: #19064

Add third test to XpathRegressionOperatorWrapTest to meet the requirement of 3 distinct test methods with different XPath structures.

Changes:
- Added new test method `testOperatorWrapInnerClass()` with inner class structure
- Created new input file `InputXpathOperatorWrapInnerClass.java`
- Removed suppression for this file from `checkstyle-non-main-files-suppressions.xml`

The three tests now cover different AST structures:
1. Operator on new line (existing)
2. Operator on previous line (existing)
3. Inner class with operator on new line (new)

All tests pass with `mvn clean verify`.