### PR TITLE
Issue #18435: Fixed AST consistency in Example1 for IndentationCheck

### DIFF
--- a/src/test/java/com/puppycrawl/tools/checkstyle/internal/XdocsExampleFileTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/internal/XdocsExampleFileTest.java
@@ -58,14 +58,7 @@ public class XdocsExampleFileTest {
     // This list is temporarily suppressed.
     // Until: https://github.com/checkstyle/checkstyle/issues/17449
     private static final Map<String, Set<String>> SUPPRESSED_PROPERTIES_BY_CHECK = Map.ofEntries(
-            Map.entry("SuppressWarningsHolder", Set.of("aliasList")),
-            Map.entry("IndentationCheck", Set.of(
-                    "basicOffset",
-                    "lineWrappingIndentation",
-                    "throwsIndent",
-                    "arrayInitIndent",
-                    "braceAdjustment"
-            ))
+            Map.entry("SuppressWarningsHolder", Set.of("aliasList"))
     );
 
     @Test

--- a/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/indentation/indentation/Example1.java
+++ b/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/indentation/indentation/Example1.java
@@ -1,7 +1,13 @@
 /*xml
 <module name="Checker">
   <module name="TreeWalker">
-    <module name="Indentation"/>
+    <module name="Indentation">
+      <property name="basicOffset" value="4"/>
+      <property name="braceAdjustment" value="0"/>
+      <property name="lineWrappingIndentation" value="4"/>
+      <property name="throwsIndent" value="4"/>
+      <property name="arrayInitIndent" value="4"/>
+    </module>
   </module>
 </module>
 */
@@ -12,9 +18,9 @@ package com.puppycrawl.tools.checkstyle.checks.indentation.indentation;
 class Example1 {
     String field = "example";                  // basicOffset
     int[] values = {                           // basicOffset
-        10,
-        20,
-        30
+            10,
+            20,
+            30
     };
 
     void processValues() throws Exception {
@@ -24,23 +30,23 @@ class Example1 {
     void handleValue(String aFooString,
                      int aFooInt) {             // indent:8 ; expected: > 4;
 
-        boolean cond1,cond2,cond3,cond4,cond5,cond6;
-        cond1=cond2=cond3=cond4=cond5=cond6=false;
+        boolean cond1,cond2,cond3,cond4,cond5;
+        cond1=cond2=cond3=cond4=cond5=false;
 
         if (cond1
-            || cond2) {
+                || cond2) {
             field = field.toUpperCase()
-                .concat(" TASK");
+                    .concat(" TASK");
         }
 
         if ((cond1 && cond2)
                 || (cond3 && cond4)          // ok, lineWrappingIndentation
-                || !(cond5 && cond6)) {      // ok, lineWrappingIndentation
+                || !cond5) {      // ok, lineWrappingIndentation
             field.toUpperCase()
-                 .concat(" TASK")             // ok, lineWrappingIndentation
-                 .chars().forEach(c -> {      // ok, lineWrappingIndentation
-                     System.out.println((char) c);
-                 });
+                    .concat(" TASK")             // ok, lineWrappingIndentation
+                    .chars().forEach(c -> {      // ok, lineWrappingIndentation
+                        System.out.println((char) c);
+                    });
         }
     }
 
@@ -52,4 +58,3 @@ class Example1 {
     }
 }
 // xdoc section -- end
-


### PR DESCRIPTION
Issue [Fix xdocs Examples AST Consistency Test (Reduce suppressions list) #18435](https://github.com/checkstyle/checkstyle/issues/18435)

Fixed AST consistency in Example1 for IndentationCheck

Added missing tags for IndentationCheck properties:

- basicOffset
- lineWrappingIndentation
- throwsIndent
- arrayInitIndent
- braceAdjustment

Cleaned up the suppression list by removing the map entry of IndentationCheck from SUPPRESSED_PROPERTIES_BY_CHECK in XdocsExampleFileTest.