### PR TITLE
Issue #19064: Add third test to XpathRegressionMultipleVariableDeclarationsTest

### DIFF
--- a/config/checkstyle-non-main-files-suppressions.xml
+++ b/config/checkstyle-non-main-files-suppressions.xml
@@ -424,7 +424,6 @@
   <suppress id="numberOfTestCasesInXpath" files="[\\/]src[\\/]it[\\/]java[\\/]org[\\/]checkstyle[\\/]suppressionxpathfilter[\\/]coding[\\/]XpathRegressionInnerAssignmentTest.java" />
   <suppress id="numberOfTestCasesInXpath" files="[\\/]src[\\/]it[\\/]java[\\/]org[\\/]checkstyle[\\/]suppressionxpathfilter[\\/]coding[\\/]XpathRegressionMissingNullCaseInSwitchTest.java" />
   <suppress id="numberOfTestCasesInXpath" files="[\\/]src[\\/]it[\\/]java[\\/]org[\\/]checkstyle[\\/]suppressionxpathfilter[\\/]coding[\\/]XpathRegressionMissingSwitchDefaultTest.java" />
-  <suppress id="numberOfTestCasesInXpath" files="[\\/]src[\\/]it[\\/]java[\\/]org[\\/]checkstyle[\\/]suppressionxpathfilter[\\/]coding[\\/]XpathRegressionMultipleVariableDeclarationsTest.java" />
   <suppress id="numberOfTestCasesInXpath" files="[\\/]src[\\/]it[\\/]java[\\/]org[\\/]checkstyle[\\/]suppressionxpathfilter[\\/]coding[\\/]XpathRegressionNestedForDepthTest.java" />
   <suppress id="numberOfTestCasesInXpath" files="[\\/]src[\\/]it[\\/]java[\\/]org[\\/]checkstyle[\\/]suppressionxpathfilter[\\/]coding[\\/]XpathRegressionNestedIfDepthTest.java" />
 

--- a/src/it/java/org/checkstyle/suppressionxpathfilter/coding/XpathRegressionMultipleVariableDeclarationsTest.java
+++ b/src/it/java/org/checkstyle/suppressionxpathfilter/coding/XpathRegressionMultipleVariableDeclarationsTest.java
@@ -118,4 +118,56 @@ public class XpathRegressionMultipleVariableDeclarationsTest extends AbstractXpa
         runVerifications(moduleConfig, fileToProcess, expectedViolation,
                 expectedXpathQueries);
     }
+
+    @Test
+    public void testMultipleVariableDeclarationsInMethod() throws Exception {
+        final File fileToProcess = new File(
+                getPath("InputXpathMultipleVariableDeclarationsInMethod.java"));
+
+        final DefaultConfiguration moduleConfig =
+                createModuleConfig(MultipleVariableDeclarationsCheck.class);
+
+        final String[] expectedViolation = {
+            "5:9: " + getCheckMessage(MultipleVariableDeclarationsCheck.class,
+                MultipleVariableDeclarationsCheck.MSG_MULTIPLE_COMMA),
+        };
+
+        final List<String> expectedXpathQueries = Arrays.asList(
+            "/COMPILATION_UNIT"
+                + "/CLASS_DEF[./IDENT[@text='InputXpathMultipleVariableDeclarationsInMethod']]"
+                + "/OBJBLOCK/METHOD_DEF[./IDENT[@text='foo']]"
+                + "/SLIST/VARIABLE_DEF[./IDENT[@text='a']]",
+            "/COMPILATION_UNIT"
+                + "/CLASS_DEF[./IDENT[@text='InputXpathMultipleVariableDeclarationsInMethod']]"
+                + "/OBJBLOCK/METHOD_DEF[./IDENT[@text='foo']]"
+                + "/SLIST/VARIABLE_DEF[./IDENT[@text='a']]/MODIFIERS",
+            "/COMPILATION_UNIT"
+                + "/CLASS_DEF[./IDENT[@text='InputXpathMultipleVariableDeclarationsInMethod']]"
+                + "/OBJBLOCK/METHOD_DEF[./IDENT[@text='foo']]"
+                + "/SLIST/VARIABLE_DEF[./IDENT[@text='a']]/TYPE",
+            "/COMPILATION_UNIT"
+                + "/CLASS_DEF[./IDENT[@text='InputXpathMultipleVariableDeclarationsInMethod']]"
+                + "/OBJBLOCK/METHOD_DEF[./IDENT[@text='foo']]"
+                + "/SLIST/VARIABLE_DEF[./IDENT[@text='a']]/TYPE/LITERAL_INT",
+            "/COMPILATION_UNIT"
+                + "/CLASS_DEF[./IDENT[@text='InputXpathMultipleVariableDeclarationsInMethod']]"
+                + "/OBJBLOCK/METHOD_DEF[./IDENT[@text='foo']]"
+                + "/SLIST/VARIABLE_DEF[./IDENT[@text='b']]",
+            "/COMPILATION_UNIT"
+                + "/CLASS_DEF[./IDENT[@text='InputXpathMultipleVariableDeclarationsInMethod']]"
+                + "/OBJBLOCK/METHOD_DEF[./IDENT[@text='foo']]"
+                + "/SLIST/VARIABLE_DEF[./IDENT[@text='b']]/MODIFIERS",
+            "/COMPILATION_UNIT"
+                + "/CLASS_DEF[./IDENT[@text='InputXpathMultipleVariableDeclarationsInMethod']]"
+                + "/OBJBLOCK/METHOD_DEF[./IDENT[@text='foo']]"
+                + "/SLIST/VARIABLE_DEF[./IDENT[@text='b']]/TYPE",
+            "/COMPILATION_UNIT"
+                + "/CLASS_DEF[./IDENT[@text='InputXpathMultipleVariableDeclarationsInMethod']]"
+                + "/OBJBLOCK/METHOD_DEF[./IDENT[@text='foo']]"
+                + "/SLIST/VARIABLE_DEF[./IDENT[@text='b']]/TYPE/LITERAL_INT"
+        );
+
+        runVerifications(moduleConfig, fileToProcess, expectedViolation,
+                expectedXpathQueries);
+    }
 }

--- a/src/it/resources/org/checkstyle/suppressionxpathfilter/coding/multiplevariabledeclarations/InputXpathMultipleVariableDeclarationsInMethod.java
+++ b/src/it/resources/org/checkstyle/suppressionxpathfilter/coding/multiplevariabledeclarations/InputXpathMultipleVariableDeclarationsInMethod.java
@@ -1,0 +1,7 @@
+package org.checkstyle.suppressionxpathfilter.coding.multiplevariabledeclarations;
+
+public class InputXpathMultipleVariableDeclarationsInMethod {
+    void foo() {
+        int a, b; //warn
+    }
+}


### PR DESCRIPTION
Issue: #19064

Add third test to XpathRegressionMultipleVariableDeclarationsTest to meet the requirement of 3 distinct test methods with different XPath structures.

Changes:
- Added new test method `testMultipleVariableDeclarationsInMethod()` with declarations inside a method body
- Created new input file `InputXpathMultipleVariableDeclarationsInMethod.java`
- Removed suppression for this file from `checkstyle-non-main-files-suppressions.xml`

The three tests now cover different AST structures:
1. Comma-separated variable declarations (existing)
2. Semicolon-separated variable declarations (existing)
3. Variable declarations inside a method body (new)

All tests pass with `mvn clean verify`.