### PR TITLE
Issue #18435: Fixed AST consistency in Example1 for IndentationCheck

### DIFF
--- a/src/site/xdoc/checks/misc/indentation.xml
+++ b/src/site/xdoc/checks/misc/indentation.xml
@@ -121,7 +121,13 @@ if ((condition1 &amp;&amp; condition2)
         <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
 &lt;module name="Checker"&gt;
   &lt;module name="TreeWalker"&gt;
-    &lt;module name="Indentation"/&gt;
+    &lt;module name="Indentation"&gt;
+      &lt;property name="basicOffset" value="4"/&gt;
+      &lt;property name="braceAdjustment" value="0"/&gt;
+      &lt;property name="lineWrappingIndentation" value="4"/&gt;
+      &lt;property name="throwsIndent" value="4"/&gt;
+      &lt;property name="arrayInitIndent" value="4"/&gt;
+    &lt;/module&gt;
   &lt;/module&gt;
 &lt;/module&gt;
 </code></pre></div>
@@ -340,6 +346,69 @@ class Example4 {
             case "COMPLETED": handleValue("Completed Case", 456);       // caseIndent
         }
     }
+}
+</code></pre></div><hr class="example-separator"/>
+        <p id="Example5-config">
+          To configure the Check with various different indentation settings:
+        </p>
+        <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
+&lt;module name="Checker"&gt;
+  &lt;module name="TreeWalker"&gt;
+    &lt;module name="Indentation"&gt;
+      &lt;property name="basicOffset" value="8"/&gt;
+      &lt;property name="braceAdjustment" value="0"/&gt;
+      &lt;property name="lineWrappingIndentation" value="8"/&gt;
+      &lt;property name="throwsIndent" value="8"/&gt;
+      &lt;property name="arrayInitIndent" value="8"/&gt;
+    &lt;/module&gt;
+  &lt;/module&gt;
+&lt;/module&gt;
+</code></pre></div>
+        <p id="Example5-code">
+          Example of code demonstrating configured indentation settings:
+        </p>
+        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+class Example5 {
+        String field = "example";                  // basicOffset
+        int[] values = {                           // basicOffset
+                10,
+                20,
+                30
+        };
+
+        void processValues() throws Exception {
+                handleValue("Test String", 42);          // basicOffset
+        }
+
+        void handleValue(String aFooString,
+                         int aFooInt) {             // indent:8 ; expected: &gt; 8;
+
+                boolean cond1,cond2,cond3,cond4,cond5,cond6;
+                cond1=cond2=cond3=cond4=cond5=cond6=false;
+
+                if (cond1
+                        || cond2) {
+                        field = field.toUpperCase()
+                                .concat(" TASK");
+                }
+
+                if ((cond1 &amp;&amp; cond2)
+                        || (cond3 &amp;&amp; cond4)          // ok, lineWrappingIndentation
+                        || !(cond5 &amp;&amp; cond6)) {      // ok, lineWrappingIndentation
+                        field.toUpperCase()
+                                .concat(" TASK")             // ok, lineWrappingIndentation
+                                .chars().forEach(c -&gt; {      // ok, lineWrappingIndentation
+                                        System.out.println((char) c);
+                                });
+                }
+        }
+
+        void demonstrateSwitch() throws Exception {
+                switch (field) {
+                    case "EXAMPLE": processValues();                        // caseIndent
+                    case "COMPLETED": handleValue("Completed Case", 456);   // caseIndent
+                }
+        }
 }
 </code></pre></div>
       </subsection>

--- a/src/site/xdoc/checks/misc/indentation.xml.template
+++ b/src/site/xdoc/checks/misc/indentation.xml.template
@@ -88,6 +88,22 @@
           <param name="path"
                  value="resources/com/puppycrawl/tools/checkstyle/checks/indentation/indentation/Example4.java"/>
           <param name="type" value="code"/>
+        </macro><hr class="example-separator"/>
+        <p id="Example5-config">
+          To configure the Check with various different indentation settings:
+        </p>
+        <macro name="example">
+          <param name="path"
+                 value="resources/com/puppycrawl/tools/checkstyle/checks/indentation/indentation/Example5.java"/>
+          <param name="type" value="config"/>
+        </macro>
+        <p id="Example5-code">
+          Example of code demonstrating configured indentation settings:
+        </p>
+        <macro name="example">
+          <param name="path"
+                 value="resources/com/puppycrawl/tools/checkstyle/checks/indentation/indentation/Example5.java"/>
+          <param name="type" value="code"/>
         </macro>
       </subsection>
 

--- a/src/test/java/com/puppycrawl/tools/checkstyle/internal/XdocsExampleFileTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/internal/XdocsExampleFileTest.java
@@ -58,14 +58,7 @@ public class XdocsExampleFileTest {
     // This list is temporarily suppressed.
     // Until: https://github.com/checkstyle/checkstyle/issues/17449
     private static final Map<String, Set<String>> SUPPRESSED_PROPERTIES_BY_CHECK = Map.ofEntries(
-            Map.entry("SuppressWarningsHolder", Set.of("aliasList")),
-            Map.entry("IndentationCheck", Set.of(
-                    "basicOffset",
-                    "lineWrappingIndentation",
-                    "throwsIndent",
-                    "arrayInitIndent",
-                    "braceAdjustment"
-            ))
+            Map.entry("SuppressWarningsHolder", Set.of("aliasList"))
     );
 
     @Test

--- a/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/checks/indentation/IndentationCheckExamplesTest.java
+++ b/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/checks/indentation/IndentationCheckExamplesTest.java
@@ -61,4 +61,10 @@ public class IndentationCheckExamplesTest extends AbstractExamplesModuleTestSupp
         final String[] expected = {};
         verifyWithInlineConfigParser(getPath("Example4.java"), expected);
     }
+
+    @Test
+    public void testExample5() throws Exception {
+        final String[] expected = {};
+        verifyWithInlineConfigParser(getPath("Example5.java"), expected);
+    }
 }

--- a/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/indentation/indentation/Example1.java
+++ b/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/indentation/indentation/Example1.java
@@ -1,7 +1,13 @@
 /*xml
 <module name="Checker">
   <module name="TreeWalker">
-    <module name="Indentation"/>
+    <module name="Indentation">
+      <property name="basicOffset" value="4"/>
+      <property name="braceAdjustment" value="0"/>
+      <property name="lineWrappingIndentation" value="4"/>
+      <property name="throwsIndent" value="4"/>
+      <property name="arrayInitIndent" value="4"/>
+    </module>
   </module>
 </module>
 */
@@ -52,4 +58,3 @@ class Example1 {
     }
 }
 // xdoc section -- end
-

--- a/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/indentation/indentation/Example5.java
+++ b/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/indentation/indentation/Example5.java
@@ -1,0 +1,60 @@
+/*xml
+<module name="Checker">
+  <module name="TreeWalker">
+    <module name="Indentation">
+      <property name="basicOffset" value="8"/>
+      <property name="braceAdjustment" value="0"/>
+      <property name="lineWrappingIndentation" value="8"/>
+      <property name="throwsIndent" value="8"/>
+      <property name="arrayInitIndent" value="8"/>
+    </module>
+  </module>
+</module>
+*/
+
+package com.puppycrawl.tools.checkstyle.checks.indentation.indentation;
+
+// xdoc section -- start
+class Example5 {
+        String field = "example";                  // basicOffset
+        int[] values = {                           // basicOffset
+                10,
+                20,
+                30
+        };
+
+        void processValues() throws Exception {
+                handleValue("Test String", 42);          // basicOffset
+        }
+
+        void handleValue(String aFooString,
+                         int aFooInt) {             // indent:8 ; expected: > 8;
+
+                boolean cond1,cond2,cond3,cond4,cond5,cond6;
+                cond1=cond2=cond3=cond4=cond5=cond6=false;
+
+                if (cond1
+                        || cond2) {
+                        field = field.toUpperCase()
+                                .concat(" TASK");
+                }
+
+                if ((cond1 && cond2)
+                        || (cond3 && cond4)          // ok, lineWrappingIndentation
+                        || !(cond5 && cond6)) {      // ok, lineWrappingIndentation
+                        field.toUpperCase()
+                                .concat(" TASK")             // ok, lineWrappingIndentation
+                                .chars().forEach(c -> {      // ok, lineWrappingIndentation
+                                        System.out.println((char) c);
+                                });
+                }
+        }
+
+        void demonstrateSwitch() throws Exception {
+                switch (field) {
+                    case "EXAMPLE": processValues();                        // caseIndent
+                    case "COMPLETED": handleValue("Completed Case", 456);   // caseIndent
+                }
+        }
+}
+// xdoc section -- end


### PR DESCRIPTION
Issue [Fix xdocs Examples AST Consistency Test (Reduce suppressions list) #18435](https://github.com/checkstyle/checkstyle/issues/18435)

Fixed AST consistency in Example1 for IndentationCheck

Added missing tags for IndentationCheck properties:

- basicOffset
- lineWrappingIndentation
- throwsIndent
- arrayInitIndent
- braceAdjustment

Cleaned up the suppression list by removing the map entry of IndentationCheck from SUPPRESSED_PROPERTIES_BY_CHECK in XdocsExampleFileTest.