### PR TITLE
Issue #19064: Add third test to XpathRegressionIllegalTypeTest

### DIFF
--- a/config/checkstyle-non-main-files-suppressions.xml
+++ b/config/checkstyle-non-main-files-suppressions.xml
@@ -420,7 +420,6 @@
   <suppress id="numberOfTestCasesInXpath" files="[\\/]src[\\/]it[\\/]java[\\/]org[\\/]checkstyle[\\/]suppressionxpathfilter[\\/]coding[\\/]XpathRegressionDeclarationOrderTest.java" />
   <suppress id="numberOfTestCasesInXpath" files="[\\/]src[\\/]it[\\/]java[\\/]org[\\/]checkstyle[\\/]suppressionxpathfilter[\\/]coding[\\/]XpathRegressionFallThroughTest.java" />
   <suppress id="numberOfTestCasesInXpath" files="[\\/]src[\\/]it[\\/]java[\\/]org[\\/]checkstyle[\\/]suppressionxpathfilter[\\/]coding[\\/]XpathRegressionHiddenFieldTest.java" />
-  <suppress id="numberOfTestCasesInXpath" files="[\\/]src[\\/]it[\\/]java[\\/]org[\\/]checkstyle[\\/]suppressionxpathfilter[\\/]coding[\\/]XpathRegressionIllegalTypeTest.java" />
   <suppress id="numberOfTestCasesInXpath" files="[\\/]src[\\/]it[\\/]java[\\/]org[\\/]checkstyle[\\/]suppressionxpathfilter[\\/]coding[\\/]XpathRegressionInnerAssignmentTest.java" />
   <suppress id="numberOfTestCasesInXpath" files="[\\/]src[\\/]it[\\/]java[\\/]org[\\/]checkstyle[\\/]suppressionxpathfilter[\\/]coding[\\/]XpathRegressionMissingNullCaseInSwitchTest.java" />
   <suppress id="numberOfTestCasesInXpath" files="[\\/]src[\\/]it[\\/]java[\\/]org[\\/]checkstyle[\\/]suppressionxpathfilter[\\/]coding[\\/]XpathRegressionMissingSwitchDefaultTest.java" />

--- a/src/it/java/org/checkstyle/suppressionxpathfilter/coding/XpathRegressionIllegalTypeTest.java
+++ b/src/it/java/org/checkstyle/suppressionxpathfilter/coding/XpathRegressionIllegalTypeTest.java
@@ -88,4 +88,30 @@ public class XpathRegressionIllegalTypeTest extends AbstractXpathTestSupport {
         runVerifications(moduleConfig, fileToProcess, expectedViolation,
                          expectedXpathQueries);
     }
+
+    @Test
+    public void testInnerClass() throws Exception {
+        final File fileToProcess =
+            new File(getPath("InputXpathIllegalTypeInnerClass.java"));
+        final DefaultConfiguration moduleConfig =
+            createModuleConfig(IllegalTypeCheck.class);
+
+        moduleConfig.addProperty("tokens", "METHOD_DEF");
+
+        final String[] expectedViolation = {
+            "5:27: " + getCheckMessage(IllegalTypeCheck.class,
+                                      IllegalTypeCheck.MSG_KEY, "java.util.HashMap"),
+        };
+        final List<String> expectedXpathQueries = Collections.singletonList(
+            "/COMPILATION_UNIT"
+                + "/CLASS_DEF[./IDENT[@text='InputXpathIllegalTypeInnerClass']]"
+                + "/OBJBLOCK/CLASS_DEF[./IDENT[@text='Inner']]"
+                + "/OBJBLOCK/METHOD_DEF[./IDENT[@text='typeParam']]/TYPE_PARAMETERS/TYPE_PARAMETER"
+                + "[./IDENT[@text='T']]/TYPE_UPPER_BOUNDS/DOT"
+                + "[./IDENT[@text='HashMap']]/DOT/IDENT[@text='java']"
+        );
+
+        runVerifications(moduleConfig, fileToProcess, expectedViolation,
+                         expectedXpathQueries);
+    }
 }

--- a/src/it/resources/org/checkstyle/suppressionxpathfilter/coding/illegaltype/InputXpathIllegalTypeInnerClass.java
+++ b/src/it/resources/org/checkstyle/suppressionxpathfilter/coding/illegaltype/InputXpathIllegalTypeInnerClass.java
@@ -1,0 +1,7 @@
+package org.checkstyle.suppressionxpathfilter.coding.illegaltype;
+
+public class InputXpathIllegalTypeInnerClass {
+    class Inner {
+        public <T extends java.util.HashMap> void typeParam(T t) {} // warn
+    }
+}


### PR DESCRIPTION
Issue: #19064

Add third test to XpathRegressionIllegalTypeTest to meet the requirement of 3 distinct test methods with different XPath structures.

Changes:
- Added new test method `testInnerClass()` with inner class structure
- Created new input file `InputXpathIllegalTypeInnerClass.java`
- Removed suppression for this file from `checkstyle-non-main-files-suppressions.xml`

The three tests now cover different AST structures:
1. Type parameter bound with HashSet (existing)
2. Type parameter bound with custom illegal class Boolean (existing)
3. Inner class with HashMap type parameter (new)

All tests pass with `mvn clean verify`.