### PR TITLE
Issue #16807: update input files for MissingJavadocPackageCheck to sp…

### DIFF
--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/missingjavadocpackage/nojavadoc/annotation/blockcomment/package-info.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/missingjavadocpackage/nojavadoc/annotation/blockcomment/package-info.java
@@ -9,8 +9,7 @@ MissingJavadocPackage
  */
 
 @Nullable
-// violation below, 'Missing javadoc for package-info.java file.'
-package com.puppycrawl.tools.checkstyle.checks
+package com.puppycrawl.tools.checkstyle.checks // violation 'Missing javadoc for package-info.java file.'
         .javadoc.missingjavadocpackage.nojavadoc.annotation.blockcomment;
 
 import javax.annotation.Nullable;

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/missingjavadocpackage/nojavadoc/annotation/package-info.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/missingjavadocpackage/nojavadoc/annotation/package-info.java
@@ -5,6 +5,5 @@ MissingJavadocPackage
 */
 
 @Deprecated
-// violation below, 'Missing javadoc for package-info.java file.'
-package com.puppycrawl.tools.checkstyle.checks
+package com.puppycrawl.tools.checkstyle.checks // violation 'Missing javadoc for package-info.java file.'
         .javadoc.missingjavadocpackage.nojavadoc.annotation;

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/missingjavadocpackage/nojavadoc/blank/package-info.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/missingjavadocpackage/nojavadoc/blank/package-info.java
@@ -5,6 +5,5 @@ MissingJavadocPackage
 */
 
 
-// violation below, 'Missing javadoc for package-info.java file.'
-package com.puppycrawl.tools.checkstyle.checks
+package com.puppycrawl.tools.checkstyle.checks // violation 'Missing javadoc for package-info.java file.'
         .javadoc.missingjavadocpackage.nojavadoc.blank;

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/missingjavadocpackage/nojavadoc/blockcomment/package-info.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/missingjavadocpackage/nojavadoc/blockcomment/package-info.java
@@ -7,5 +7,5 @@ MissingJavadocPackage
 /*
  * block comment
  */
-package com.puppycrawl.tools.checkstyle // violation, 'Missing javadoc for package-info.java file.'
+package com.puppycrawl.tools.checkstyle // violation 'Missing javadoc for package-info.java file.'
         .checks.javadoc.missingjavadocpackage.nojavadoc.blockcomment;

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/missingjavadocpackage/nojavadoc/detached/package-info.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/missingjavadocpackage/nojavadoc/detached/package-info.java
@@ -8,5 +8,5 @@ MissingJavadocPackage
  * Dangling javadoc
  */
 /* comment */
-package com.puppycrawl.tools.checkstyle // violation, 'Missing javadoc for package-info.java file.'
+package com.puppycrawl.tools.checkstyle // violation 'Missing javadoc for package-info.java file.'
         .checks.javadoc.missingjavadocpackage.nojavadoc.detached;

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/missingjavadocpackage/nojavadoc/package-info.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/missingjavadocpackage/nojavadoc/package-info.java
@@ -4,6 +4,5 @@ MissingJavadocPackage
 
 */
 
-// violation below, 'Missing javadoc for package-info.java file.'
-package com.puppycrawl.tools.checkstyle.checks.javadoc
+package com.puppycrawl.tools.checkstyle.checks.javadoc // violation 'Missing javadoc for package-info.java file.'
         .missingjavadocpackage.nojavadoc;

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/missingjavadocpackage/nojavadoc/single/package-info.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/missingjavadocpackage/nojavadoc/single/package-info.java
@@ -5,6 +5,5 @@ MissingJavadocPackage
 */
 
 //* not javadoc
-// violation below, 'Missing javadoc for package-info.java file.'
-package com.puppycrawl.tools.checkstyle.checks
+package com.puppycrawl.tools.checkstyle.checks // violation 'Missing javadoc for package-info.java file.'
         .javadoc.missingjavadocpackage.nojavadoc.single;

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/missingjavadocpackage/nojavadoc/singleline/package-info.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/missingjavadocpackage/nojavadoc/singleline/package-info.java
@@ -5,6 +5,5 @@ MissingJavadocPackage
 */
 
 /**/
-// violation below, 'Missing javadoc for package-info.java file.'
-package com.puppycrawl.tools.checkstyle.checks
+package com.puppycrawl.tools.checkstyle.checks // violation 'Missing javadoc for package-info.java file.'
         .javadoc.missingjavadocpackage.nojavadoc.singleline;


### PR DESCRIPTION
Issue: #16807

Updated input files for `MissingJavadocPackageCheck` to specify violation 
messages and removed it from `SUPPRESSED_CHECKS` in `InlineConfigParser`.