### PR TITLE
Issue #19149: MissingJavadocTypeCheck Check to use AST

### DIFF
--- a/config/checkstyle-resources-suppressions.xml
+++ b/config/checkstyle-resources-suppressions.xml
@@ -505,6 +505,10 @@
   <suppress checks="FileLength"
     files="[\\/]test[\\/]resources-noncompilable[\\/]com[\\/]puppycrawl[\\/]tools[\\/]checkstyle[\\/]grammar[\\/]java14[\\/]InputJava14SwitchExpression\.java"/>
   <suppress checks="FileLength"
+    files="[\\/]test[\\/]resources[\\/]com[\\/]puppycrawl[\\/]tools[\\/]checkstyle[\\/]filters[\\/]suppresswarningsfilter[\\/]InputSuppressWarningsFilter\.java"/>
+  <suppress checks="FileLength"
+    files="[\\/]test[\\/]resources[\\/]com[\\/]puppycrawl[\\/]tools[\\/]checkstyle[\\/]filters[\\/]suppresswarningsfilter[\\/]InputSuppressWarningsFilterWithoutFilter\.java"/>
+  <suppress checks="FileLength"
     files="[\\/]test[\\/]resources-noncompilable[\\/]com[\\/]puppycrawl[\\/]tools[\\/]checkstyle[\\/]grammar[\\/]java14[\\/]InputJava14InstanceofWithPatternMatching\.java"/>
   <suppress checks="FileLength"
     files="[\\/]test[\\/]resources[\\/]com[\\/]puppycrawl[\\/]tools[\\/]checkstyle[\\/]grammar[\\/]java14[\\/]InputJava14Records\.java"/>

--- a/config/suppressions.xml
+++ b/config/suppressions.xml
@@ -139,8 +139,6 @@
   <suppress id="noUsageOfGetFileContentsMethod" files="JavadocVariableCheck.java"/>
   <!-- until #19148 -->
   <suppress id="noUsageOfGetFileContentsMethod" files="MissingJavadocMethodCheck.java"/>
-  <!-- until #19149 -->
-  <suppress id="noUsageOfGetFileContentsMethod" files="MissingJavadocTypeCheck.java"/>
   <!-- permanent suppression to allow regexp on content of the line -->
   <suppress id="noUsageOfGetFileContentsMethod" files="RegexpCheck.java"/>
   <suppress id="noUsageOfGetFileContentsMethod" files="RegexpSinglelineJavaCheck.java"/>

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/MissingJavadocTypeCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/MissingJavadocTypeCheck.java
@@ -19,17 +19,18 @@
 
 package com.puppycrawl.tools.checkstyle.checks.javadoc;
 
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Set;
 
-import com.puppycrawl.tools.checkstyle.StatelessCheck;
-import com.puppycrawl.tools.checkstyle.api.AbstractCheck;
+import com.puppycrawl.tools.checkstyle.FileStatefulCheck;
 import com.puppycrawl.tools.checkstyle.api.DetailAST;
-import com.puppycrawl.tools.checkstyle.api.FileContents;
+import com.puppycrawl.tools.checkstyle.api.DetailNode;
 import com.puppycrawl.tools.checkstyle.api.Scope;
-import com.puppycrawl.tools.checkstyle.api.TextBlock;
 import com.puppycrawl.tools.checkstyle.api.TokenTypes;
 import com.puppycrawl.tools.checkstyle.utils.AnnotationUtil;
 import com.puppycrawl.tools.checkstyle.utils.CommonUtil;
+import com.puppycrawl.tools.checkstyle.utils.JavadocUtil;
 import com.puppycrawl.tools.checkstyle.utils.ScopeUtil;
 
 /**
@@ -42,8 +43,8 @@ import com.puppycrawl.tools.checkstyle.utils.ScopeUtil;
  *
  * @since 8.20
  */
-@StatelessCheck
-public class MissingJavadocTypeCheck extends AbstractCheck {
+@FileStatefulCheck
+public final class MissingJavadocTypeCheck extends AbstractJavadocCheck {
 
     /**
      * A key is pointing to the warning message text in "messages.properties"
@@ -51,8 +52,15 @@ public class MissingJavadocTypeCheck extends AbstractCheck {
      */
     public static final String MSG_JAVADOC_MISSING = "javadoc.missing";
 
+    /**
+     * Stores all Javadoc comment nodes collected during the tree traversal.
+     * Used to match a Javadoc comment to a type declaration.
+     */
+    private final List<DetailAST> javadocComments = new ArrayList<>();
+
     /** Specify the visibility scope where Javadoc comments are checked. */
     private Scope scope = Scope.PUBLIC;
+
     /** Specify the visibility scope where Javadoc comments are not checked. */
     private Scope excludeScope;
 
@@ -96,6 +104,50 @@ public class MissingJavadocTypeCheck extends AbstractCheck {
     }
 
     @Override
+    public int[] getDefaultJavadocTokens() {
+        return CommonUtil.EMPTY_INT_ARRAY;
+    }
+
+    @Override
+    public void visitJavadocToken(DetailNode node) {
+        // no-op
+    }
+
+    @Override
+    public void beginTree(DetailAST node) {
+        javadocComments.clear();
+        collectCommentNodes(node);
+    }
+
+    /**
+     * Collects all Javadoc comment nodes in the AST tree and stores them
+     * in {@code javadocComments}. These comments are later used to determine
+     * whether a type declaration has an associated Javadoc comment.
+     *
+     * @param ast the root AST node from which comment nodes are collected
+     */
+    private void collectCommentNodes(DetailAST ast) {
+        DetailAST current = ast;
+        while (current != null) {
+            if (current.getType() == TokenTypes.BLOCK_COMMENT_BEGIN
+                    && JavadocUtil.isJavadocComment(current)) {
+                javadocComments.add(current);
+            }
+            if (current.getFirstChild() != null) {
+                current = current.getFirstChild();
+            }
+            else {
+                DetailAST parent = current;
+                while (parent != null && current.getNextSibling() == null) {
+                    current = parent;
+                    parent = parent.getParent();
+                }
+                current = current.getNextSibling();
+            }
+        }
+    }
+
+    @Override
     public int[] getDefaultTokens() {
         return getAcceptableTokens();
     }
@@ -116,18 +168,73 @@ public class MissingJavadocTypeCheck extends AbstractCheck {
         return CommonUtil.EMPTY_INT_ARRAY;
     }
 
-    // suppress deprecation until https://github.com/checkstyle/checkstyle/issues/19149
     @Override
-    @SuppressWarnings("deprecation")
     public void visitToken(DetailAST ast) {
-        if (shouldCheck(ast)) {
-            final FileContents contents = getFileContents();
-            final int lineNo = ast.getLineNo();
-            final TextBlock textBlock = contents.getJavadocBefore(lineNo);
-            if (textBlock == null) {
-                log(ast, MSG_JAVADOC_MISSING);
+        if (shouldCheck(ast) && !hasJavadoc(ast)) {
+            log(ast, MSG_JAVADOC_MISSING);
+        }
+    }
+
+    /**
+     * Determines whether the specified type AST node has a valid Javadoc
+     * comment immediately preceding it, with no intervening executable code.
+     *
+     * @param ast the AST node representing the type definition
+     * @return {@code true} if a valid Javadoc comment exists before the type;
+     *         {@code false} otherwise
+     */
+    private boolean hasJavadoc(DetailAST ast) {
+        DetailAST best = null;
+
+        for (DetailAST comment : javadocComments) {
+            final int endLine = comment.getLineNo();
+            if (endLine <= ast.getLineNo()) {
+                best = comment;
             }
         }
+        return best != null && noInterveningCode(best, ast);
+    }
+
+    /**
+     * Checks whether there is any executable code between the Javadoc comment
+     * and the type declaration by walking AST siblings between them.
+     *
+     * @param javadoc the AST node representing the Javadoc comment
+     * @param type    the AST node representing the type declaration
+     * @return {@code true} if no executable code exists between them;
+     *         {@code false} otherwise
+     */
+    private static boolean noInterveningCode(DetailAST javadoc, DetailAST type) {
+        DetailAST detailAST = javadoc;
+        final int typeStartLine = type.getLineNo();
+        boolean hasOnlyJavadoc = true;
+        while (detailAST != null) {
+            final int siblingLine = detailAST.getLineNo();
+
+            if (siblingLine < typeStartLine) {
+                final int tokenType = detailAST.getType();
+                if (!isAllowedBetweenJavadocAndType(tokenType)) {
+                    hasOnlyJavadoc = false;
+                    break;
+                }
+            }
+            detailAST = detailAST.getNextSibling();
+        }
+        return hasOnlyJavadoc;
+    }
+
+    /**
+     * Returns whether the given token type is permitted to appear between
+     * a Javadoc comment and a type declaration.
+     *
+     * @param tokenType the token type to check
+     * @return {@code true} if the token is allowed between Javadoc and a type;
+     *         {@code false} otherwise
+     */
+    private static boolean isAllowedBetweenJavadocAndType(int tokenType) {
+        return tokenType == TokenTypes.BLOCK_COMMENT_BEGIN
+                || tokenType == TokenTypes.SINGLE_LINE_COMMENT;
+
     }
 
     /**
@@ -145,5 +252,4 @@ public class MissingJavadocTypeCheck extends AbstractCheck {
             })
             .orElse(Boolean.FALSE);
     }
-
 }

--- a/src/main/resources/com/puppycrawl/tools/checkstyle/meta/checks/javadoc/MissingJavadocTypeCheck.xml
+++ b/src/main/resources/com/puppycrawl/tools/checkstyle/meta/checks/javadoc/MissingJavadocTypeCheck.xml
@@ -32,9 +32,19 @@
                       validation-type="tokenSet">
                <description>tokens to check</description>
             </property>
+            <property default-value="false"
+                      name="violateExecutionOnNonTightHtml"
+                      type="boolean">
+               <description>Control when to print violations if the Javadoc being examined by this check
+ violates the tight html rules defined at
+ &lt;a href="https://checkstyle.org/writingjavadocchecks.html#Tight-HTML_rules"&gt;
+     Tight-HTML Rules&lt;/a&gt;.</description>
+            </property>
          </properties>
          <message-keys>
             <message-key key="javadoc.missing"/>
+            <message-key key="javadoc.parse.rule.error"/>
+            <message-key key="javadoc.unclosedHtml"/>
          </message-keys>
       </check>
    </module>

--- a/src/site/xdoc/checks/javadoc/missingjavadoctype.xml
+++ b/src/site/xdoc/checks/javadoc/missingjavadoctype.xml
@@ -49,6 +49,14 @@
               <td>8.20</td>
             </tr>
             <tr>
+              <td><a id="violateExecutionOnNonTightHtml"/><a href="#violateExecutionOnNonTightHtml">violateExecutionOnNonTightHtml</a></td>
+              <td>Control when to print violations if the Javadoc being examined by this check violates the tight html rules defined at <a href="../../writingjavadocchecks.html#Tight-HTML_rules">
+     Tight-HTML Rules</a>.</td>
+              <td><a href="../../property_types.html#boolean">boolean</a></td>
+              <td><code>false</code></td>
+              <td>8.20</td>
+            </tr>
+            <tr>
               <td><a id="tokens"/><a href="#tokens">tokens</a></td>
               <td>tokens to check</td>
               <td>subset of tokens
@@ -235,6 +243,16 @@ class Example5 {
           <li>
             <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources%2Fcom%2Fpuppycrawl%2Ftools%2Fcheckstyle%2Fchecks%2Fjavadoc+path%3A**%2Fmessages*.properties+repo%3Acheckstyle%2Fcheckstyle+%22javadoc.missing%22">
               javadoc.missing
+            </a>
+          </li>
+          <li>
+            <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources%2Fcom%2Fpuppycrawl%2Ftools%2Fcheckstyle%2Fchecks%2Fjavadoc+path%3A**%2Fmessages*.properties+repo%3Acheckstyle%2Fcheckstyle+%22javadoc.parse.rule.error%22">
+              javadoc.parse.rule.error
+            </a>
+          </li>
+          <li>
+            <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources%2Fcom%2Fpuppycrawl%2Ftools%2Fcheckstyle%2Fchecks%2Fjavadoc+path%3A**%2Fmessages*.properties+repo%3Acheckstyle%2Fcheckstyle+%22javadoc.unclosedHtml%22">
+              javadoc.unclosedHtml
             </a>
           </li>
         </ul>

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/javadoc/MissingJavadocTypeCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/javadoc/MissingJavadocTypeCheckTest.java
@@ -22,10 +22,14 @@ package com.puppycrawl.tools.checkstyle.checks.javadoc;
 import static com.google.common.truth.Truth.assertWithMessage;
 import static com.puppycrawl.tools.checkstyle.checks.javadoc.MissingJavadocTypeCheck.MSG_JAVADOC_MISSING;
 
+import java.util.ArrayList;
+import java.util.List;
+
 import org.junit.jupiter.api.Test;
 
 import com.puppycrawl.tools.checkstyle.AbstractModuleTestSupport;
 import com.puppycrawl.tools.checkstyle.api.TokenTypes;
+import com.puppycrawl.tools.checkstyle.internal.utils.TestUtil;
 import com.puppycrawl.tools.checkstyle.utils.CommonUtil;
 
 public class MissingJavadocTypeCheckTest extends AbstractModuleTestSupport {
@@ -38,6 +42,7 @@ public class MissingJavadocTypeCheckTest extends AbstractModuleTestSupport {
     @Test
     public void testGetRequiredTokens() {
         final MissingJavadocTypeCheck missingJavadocTypeCheck = new MissingJavadocTypeCheck();
+        missingJavadocTypeCheck.visitJavadocToken(null);
         assertWithMessage(
                 "MissingJavadocTypeCheck#getRequiredTokens should return empty array by default")
                         .that(missingJavadocTypeCheck.getRequiredTokens())
@@ -65,9 +70,9 @@ public class MissingJavadocTypeCheckTest extends AbstractModuleTestSupport {
     @Test
     public void testTagsOne() throws Exception {
         final String[] expected = {
-            "14:1: " + getCheckMessage(MSG_JAVADOC_MISSING),
-            "44:1: " + getCheckMessage(MSG_JAVADOC_MISSING),
-            "69:1: " + getCheckMessage(MSG_JAVADOC_MISSING),
+            "15:1: " + getCheckMessage(MSG_JAVADOC_MISSING),
+            "45:1: " + getCheckMessage(MSG_JAVADOC_MISSING),
+            "70:1: " + getCheckMessage(MSG_JAVADOC_MISSING),
         };
         verifyWithInlineConfigParser(
                 getPath("InputMissingJavadocTypeTagsOne.java"), expected);
@@ -76,7 +81,7 @@ public class MissingJavadocTypeCheckTest extends AbstractModuleTestSupport {
     @Test
     public void testTagsTwo() throws Exception {
         final String[] expected = {
-            "20:1: " + getCheckMessage(MSG_JAVADOC_MISSING),
+            "21:1: " + getCheckMessage(MSG_JAVADOC_MISSING),
         };
         verifyWithInlineConfigParser(
                 getPath("InputMissingJavadocTypeTagsTwo.java"), expected);
@@ -85,7 +90,7 @@ public class MissingJavadocTypeCheckTest extends AbstractModuleTestSupport {
     @Test
     public void testTagsThree() throws Exception {
         final String[] expected = {
-            "20:1: " + getCheckMessage(MSG_JAVADOC_MISSING),
+            "21:1: " + getCheckMessage(MSG_JAVADOC_MISSING),
         };
         verifyWithInlineConfigParser(
                 getPath("InputMissingJavadocTypeTagsThree.java"), expected);
@@ -94,7 +99,7 @@ public class MissingJavadocTypeCheckTest extends AbstractModuleTestSupport {
     @Test
     public void testTagsFour() throws Exception {
         final String[] expected = {
-            "20:1: " + getCheckMessage(MSG_JAVADOC_MISSING),
+            "21:1: " + getCheckMessage(MSG_JAVADOC_MISSING),
         };
         verifyWithInlineConfigParser(
                 getPath("InputMissingJavadocTypeTagsFour.java"), expected);
@@ -103,9 +108,9 @@ public class MissingJavadocTypeCheckTest extends AbstractModuleTestSupport {
     @Test
     public void testInner() throws Exception {
         final String[] expected = {
-            "19:5: " + getCheckMessage(MSG_JAVADOC_MISSING),
-            "26:5: " + getCheckMessage(MSG_JAVADOC_MISSING),
-            "32:9: " + getCheckMessage(MSG_JAVADOC_MISSING),
+            "20:5: " + getCheckMessage(MSG_JAVADOC_MISSING),
+            "27:5: " + getCheckMessage(MSG_JAVADOC_MISSING),
+            "33:9: " + getCheckMessage(MSG_JAVADOC_MISSING),
         };
         verifyWithInlineConfigParser(
                 getPath("InputMissingJavadocTypeInner.java"), expected);
@@ -114,10 +119,10 @@ public class MissingJavadocTypeCheckTest extends AbstractModuleTestSupport {
     @Test
     public void testMissingJavadocTypePublicOnly1One() throws Exception {
         final String[] expected = {
-            "13:1: " + getCheckMessage(MSG_JAVADOC_MISSING),
-            "15:5: " + getCheckMessage(MSG_JAVADOC_MISSING),
-            "20:9: " + getCheckMessage(MSG_JAVADOC_MISSING),
-            "40:5: " + getCheckMessage(MSG_JAVADOC_MISSING),
+            "14:1: " + getCheckMessage(MSG_JAVADOC_MISSING),
+            "16:5: " + getCheckMessage(MSG_JAVADOC_MISSING),
+            "21:9: " + getCheckMessage(MSG_JAVADOC_MISSING),
+            "41:5: " + getCheckMessage(MSG_JAVADOC_MISSING),
         };
         verifyWithInlineConfigParser(
                 getPath("InputMissingJavadocTypePublicOnly1One.java"), expected);
@@ -126,7 +131,7 @@ public class MissingJavadocTypeCheckTest extends AbstractModuleTestSupport {
     @Test
     public void testMissingJavadocTypePublicOnly1Two() throws Exception {
         final String[] expected = {
-            "13:1: " + getCheckMessage(MSG_JAVADOC_MISSING),
+            "14:1: " + getCheckMessage(MSG_JAVADOC_MISSING),
         };
         verifyWithInlineConfigParser(
                 getPath("InputMissingJavadocTypePublicOnly1Two.java"), expected);
@@ -135,7 +140,7 @@ public class MissingJavadocTypeCheckTest extends AbstractModuleTestSupport {
     @Test
     public void testMissingJavadocTypePublicOnly2One() throws Exception {
         final String[] expected = {
-            "13:1: " + getCheckMessage(MSG_JAVADOC_MISSING),
+            "14:1: " + getCheckMessage(MSG_JAVADOC_MISSING),
         };
         verifyWithInlineConfigParser(
                 getPath("InputMissingJavadocTypePublicOnly2One.java"), expected);
@@ -144,7 +149,7 @@ public class MissingJavadocTypeCheckTest extends AbstractModuleTestSupport {
     @Test
     public void testMissingJavadocTypePublicOnly2Two() throws Exception {
         final String[] expected = {
-            "13:1: " + getCheckMessage(MSG_JAVADOC_MISSING),
+            "14:1: " + getCheckMessage(MSG_JAVADOC_MISSING),
         };
         verifyWithInlineConfigParser(
                 getPath("InputMissingJavadocTypePublicOnly2Two.java"), expected);
@@ -153,8 +158,8 @@ public class MissingJavadocTypeCheckTest extends AbstractModuleTestSupport {
     @Test
     public void testPublic() throws Exception {
         final String[] expected = {
-            "13:1: " + getCheckMessage(MSG_JAVADOC_MISSING),
-            "44:5: " + getCheckMessage(MSG_JAVADOC_MISSING),
+            "14:1: " + getCheckMessage(MSG_JAVADOC_MISSING),
+            "45:5: " + getCheckMessage(MSG_JAVADOC_MISSING),
         };
         verifyWithInlineConfigParser(
                 getPath("InputMissingJavadocTypeScopeInnerInterfaces1.java"),
@@ -164,10 +169,10 @@ public class MissingJavadocTypeCheckTest extends AbstractModuleTestSupport {
     @Test
     public void testProtest() throws Exception {
         final String[] expected = {
-            "13:1: " + getCheckMessage(MSG_JAVADOC_MISSING),
-            "35:5: " + getCheckMessage(MSG_JAVADOC_MISSING),
-            "44:5: " + getCheckMessage(MSG_JAVADOC_MISSING),
-            "71:5: " + getCheckMessage(MSG_JAVADOC_MISSING),
+            "14:1: " + getCheckMessage(MSG_JAVADOC_MISSING),
+            "36:5: " + getCheckMessage(MSG_JAVADOC_MISSING),
+            "45:5: " + getCheckMessage(MSG_JAVADOC_MISSING),
+            "72:5: " + getCheckMessage(MSG_JAVADOC_MISSING),
         };
         verifyWithInlineConfigParser(
                 getPath("InputMissingJavadocTypeScopeInnerInterfaces2.java"),
@@ -177,9 +182,9 @@ public class MissingJavadocTypeCheckTest extends AbstractModuleTestSupport {
     @Test
     public void testPkg() throws Exception {
         final String[] expected = {
-            "22:5: " + getCheckMessage(MSG_JAVADOC_MISSING),
-            "24:9: " + getCheckMessage(MSG_JAVADOC_MISSING),
-            "26:13: " + getCheckMessage(MSG_JAVADOC_MISSING),
+            "23:5: " + getCheckMessage(MSG_JAVADOC_MISSING),
+            "25:9: " + getCheckMessage(MSG_JAVADOC_MISSING),
+            "27:13: " + getCheckMessage(MSG_JAVADOC_MISSING),
         };
         verifyWithInlineConfigParser(
                 getPath("InputMissingJavadocTypeScopeInnerClasses1.java"), expected);
@@ -188,7 +193,7 @@ public class MissingJavadocTypeCheckTest extends AbstractModuleTestSupport {
     @Test
     public void testEclipse() throws Exception {
         final String[] expected = {
-            "22:5: " + getCheckMessage(MSG_JAVADOC_MISSING),
+            "23:5: " + getCheckMessage(MSG_JAVADOC_MISSING),
         };
         verifyWithInlineConfigParser(
                 getPath("InputMissingJavadocTypeScopeInnerClasses2.java"), expected);
@@ -197,10 +202,10 @@ public class MissingJavadocTypeCheckTest extends AbstractModuleTestSupport {
     @Test
     public void testScopesOne() throws Exception {
         final String[] expected = {
-            "13:1: " + getCheckMessage(MSG_JAVADOC_MISSING),
-            "25:5: " + getCheckMessage(MSG_JAVADOC_MISSING),
-            "37:5: " + getCheckMessage(MSG_JAVADOC_MISSING),
-            "49:5: " + getCheckMessage(MSG_JAVADOC_MISSING),
+            "14:1: " + getCheckMessage(MSG_JAVADOC_MISSING),
+            "26:5: " + getCheckMessage(MSG_JAVADOC_MISSING),
+            "38:5: " + getCheckMessage(MSG_JAVADOC_MISSING),
+            "50:5: " + getCheckMessage(MSG_JAVADOC_MISSING),
         };
         verifyWithInlineConfigParser(
                 getPath("InputMissingJavadocTypeNoJavadoc1One.java"),
@@ -210,13 +215,13 @@ public class MissingJavadocTypeCheckTest extends AbstractModuleTestSupport {
     @Test
     public void testScopesTwo() throws Exception {
         final String[] expected = {
-            "13:1: " + getCheckMessage(MSG_JAVADOC_MISSING),
-            "15:1: " + getCheckMessage(MSG_JAVADOC_MISSING),
-            "26:5: " + getCheckMessage(MSG_JAVADOC_MISSING),
-            "38:5: " + getCheckMessage(MSG_JAVADOC_MISSING),
-            "50:5: " + getCheckMessage(MSG_JAVADOC_MISSING),
-            "62:5: " + getCheckMessage(MSG_JAVADOC_MISSING),
-            "74:5: " + getCheckMessage(MSG_JAVADOC_MISSING),
+            "14:1: " + getCheckMessage(MSG_JAVADOC_MISSING),
+            "16:1: " + getCheckMessage(MSG_JAVADOC_MISSING),
+            "27:5: " + getCheckMessage(MSG_JAVADOC_MISSING),
+            "39:5: " + getCheckMessage(MSG_JAVADOC_MISSING),
+            "51:5: " + getCheckMessage(MSG_JAVADOC_MISSING),
+            "63:5: " + getCheckMessage(MSG_JAVADOC_MISSING),
+            "75:5: " + getCheckMessage(MSG_JAVADOC_MISSING),
         };
         verifyWithInlineConfigParser(
                 getPath("InputMissingJavadocTypeNoJavadoc1Two.java"),
@@ -226,7 +231,7 @@ public class MissingJavadocTypeCheckTest extends AbstractModuleTestSupport {
     @Test
     public void testLimitViolationsBySpecifyingTokens() throws Exception {
         final String[] expected = {
-            "15:5: " + getCheckMessage(MSG_JAVADOC_MISSING),
+            "16:5: " + getCheckMessage(MSG_JAVADOC_MISSING),
         };
         verifyWithInlineConfigParser(
                 getPath("InputMissingJavadocTypeNoJavadocOnInterface.java"),
@@ -236,8 +241,8 @@ public class MissingJavadocTypeCheckTest extends AbstractModuleTestSupport {
     @Test
     public void testMissingJavadocTypeNoJavadoc2One() throws Exception {
         final String[] expected = {
-            "13:1: " + getCheckMessage(MSG_JAVADOC_MISSING),
-            "25:5: " + getCheckMessage(MSG_JAVADOC_MISSING),
+            "14:1: " + getCheckMessage(MSG_JAVADOC_MISSING),
+            "26:5: " + getCheckMessage(MSG_JAVADOC_MISSING),
         };
         verifyWithInlineConfigParser(
                 getPath("InputMissingJavadocTypeNoJavadoc2One.java"),
@@ -247,7 +252,7 @@ public class MissingJavadocTypeCheckTest extends AbstractModuleTestSupport {
     @Test
     public void testMissingJavadocTypeNoJavadoc2Two() throws Exception {
         final String[] expected = {
-            "13:1: " + getCheckMessage(MSG_JAVADOC_MISSING),
+            "14:1: " + getCheckMessage(MSG_JAVADOC_MISSING),
         };
         verifyWithInlineConfigParser(
                 getPath("InputMissingJavadocTypeNoJavadoc2Two.java"),
@@ -257,8 +262,8 @@ public class MissingJavadocTypeCheckTest extends AbstractModuleTestSupport {
     @Test
     public void testMissingJavadocTypeNoJavadoc3One() throws Exception {
         final String[] expected = {
-            "37:5: " + getCheckMessage(MSG_JAVADOC_MISSING),
-            "49:5: " + getCheckMessage(MSG_JAVADOC_MISSING),
+            "38:5: " + getCheckMessage(MSG_JAVADOC_MISSING),
+            "50:5: " + getCheckMessage(MSG_JAVADOC_MISSING),
         };
         verifyWithInlineConfigParser(
                 getPath("InputMissingJavadocTypeNoJavadoc3One.java"),
@@ -268,12 +273,12 @@ public class MissingJavadocTypeCheckTest extends AbstractModuleTestSupport {
     @Test
     public void testMissingJavadocTypeNoJavadoc3Two() throws Exception {
         final String[] expected = {
-            "15:1: " + getCheckMessage(MSG_JAVADOC_MISSING),
-            "26:5: " + getCheckMessage(MSG_JAVADOC_MISSING),
-            "38:5: " + getCheckMessage(MSG_JAVADOC_MISSING),
-            "50:5: " + getCheckMessage(MSG_JAVADOC_MISSING),
-            "62:5: " + getCheckMessage(MSG_JAVADOC_MISSING),
-            "74:5: " + getCheckMessage(MSG_JAVADOC_MISSING),
+            "16:1: " + getCheckMessage(MSG_JAVADOC_MISSING),
+            "27:5: " + getCheckMessage(MSG_JAVADOC_MISSING),
+            "39:5: " + getCheckMessage(MSG_JAVADOC_MISSING),
+            "51:5: " + getCheckMessage(MSG_JAVADOC_MISSING),
+            "63:5: " + getCheckMessage(MSG_JAVADOC_MISSING),
+            "75:5: " + getCheckMessage(MSG_JAVADOC_MISSING),
         };
         verifyWithInlineConfigParser(
                 getPath("InputMissingJavadocTypeNoJavadoc3Two.java"),
@@ -292,9 +297,9 @@ public class MissingJavadocTypeCheckTest extends AbstractModuleTestSupport {
     public void testSkipAnnotationsDefault() throws Exception {
 
         final String[] expected = {
-            "13:1: " + getCheckMessage(MSG_JAVADOC_MISSING),
-            "17:1: " + getCheckMessage(MSG_JAVADOC_MISSING),
-            "21:1: " + getCheckMessage(MSG_JAVADOC_MISSING),
+            "14:1: " + getCheckMessage(MSG_JAVADOC_MISSING),
+            "18:1: " + getCheckMessage(MSG_JAVADOC_MISSING),
+            "22:1: " + getCheckMessage(MSG_JAVADOC_MISSING),
         };
         verifyWithInlineConfigParser(
                 getPath("InputMissingJavadocTypeSkipAnnotations1.java"),
@@ -304,9 +309,9 @@ public class MissingJavadocTypeCheckTest extends AbstractModuleTestSupport {
     @Test
     public void testSkipAnnotationsWithFullyQualifiedName() throws Exception {
         final String[] expected = {
-            "13:1: " + getCheckMessage(MSG_JAVADOC_MISSING),
-            "17:1: " + getCheckMessage(MSG_JAVADOC_MISSING),
-            "21:1: " + getCheckMessage(MSG_JAVADOC_MISSING),
+            "14:1: " + getCheckMessage(MSG_JAVADOC_MISSING),
+            "18:1: " + getCheckMessage(MSG_JAVADOC_MISSING),
+            "22:1: " + getCheckMessage(MSG_JAVADOC_MISSING),
         };
         verifyWithInlineConfigParser(
                 getPath("InputMissingJavadocTypeSkipAnnotations2.java"),
@@ -326,9 +331,9 @@ public class MissingJavadocTypeCheckTest extends AbstractModuleTestSupport {
     public void testSkipAnnotationsNotAllowed() throws Exception {
 
         final String[] expected = {
-            "13:1: " + getCheckMessage(MSG_JAVADOC_MISSING),
-            "17:1: " + getCheckMessage(MSG_JAVADOC_MISSING),
-            "21:1: " + getCheckMessage(MSG_JAVADOC_MISSING),
+            "14:1: " + getCheckMessage(MSG_JAVADOC_MISSING),
+            "18:1: " + getCheckMessage(MSG_JAVADOC_MISSING),
+            "22:1: " + getCheckMessage(MSG_JAVADOC_MISSING),
         };
         verifyWithInlineConfigParser(
                 getPath("InputMissingJavadocTypeSkipAnnotations4.java"),
@@ -339,13 +344,13 @@ public class MissingJavadocTypeCheckTest extends AbstractModuleTestSupport {
     public void testMissingJavadocTypeCheckRecords() throws Exception {
 
         final String[] expected = {
-            "14:1: " + getCheckMessage(MSG_JAVADOC_MISSING),
-            "15:5: " + getCheckMessage(MSG_JAVADOC_MISSING),
-            "19:5: " + getCheckMessage(MSG_JAVADOC_MISSING),
-            "23:5: " + getCheckMessage(MSG_JAVADOC_MISSING),
-            "31:9: " + getCheckMessage(MSG_JAVADOC_MISSING),
-            "32:13: " + getCheckMessage(MSG_JAVADOC_MISSING),
-            "41:1: " + getCheckMessage(MSG_JAVADOC_MISSING),
+            "15:1: " + getCheckMessage(MSG_JAVADOC_MISSING),
+            "16:5: " + getCheckMessage(MSG_JAVADOC_MISSING),
+            "20:5: " + getCheckMessage(MSG_JAVADOC_MISSING),
+            "24:5: " + getCheckMessage(MSG_JAVADOC_MISSING),
+            "32:9: " + getCheckMessage(MSG_JAVADOC_MISSING),
+            "33:13: " + getCheckMessage(MSG_JAVADOC_MISSING),
+            "42:1: " + getCheckMessage(MSG_JAVADOC_MISSING),
         };
         verifyWithInlineConfigParser(
                 getPath("InputMissingJavadocTypeRecords.java"),
@@ -356,9 +361,9 @@ public class MissingJavadocTypeCheckTest extends AbstractModuleTestSupport {
     public void testInterfaceMemberScopeIsPublic() throws Exception {
 
         final String[] expected = {
-            "13:1: " + getCheckMessage(MSG_JAVADOC_MISSING),
-            "15:5: " + getCheckMessage(MSG_JAVADOC_MISSING),
-            "19:5: " + getCheckMessage(MSG_JAVADOC_MISSING),
+            "14:1: " + getCheckMessage(MSG_JAVADOC_MISSING),
+            "16:5: " + getCheckMessage(MSG_JAVADOC_MISSING),
+            "20:5: " + getCheckMessage(MSG_JAVADOC_MISSING),
         };
         verifyWithInlineConfigParser(
                 getPath("InputMissingJavadocTypeInterfaceMemberScopeIsPublic.java"),
@@ -368,9 +373,9 @@ public class MissingJavadocTypeCheckTest extends AbstractModuleTestSupport {
     @Test
     public void testQualifiedAnnotation1() throws Exception {
         final String[] expected = {
-            "16:5: " + getCheckMessage(MSG_JAVADOC_MISSING),
-            "20:5: " + getCheckMessage(MSG_JAVADOC_MISSING),
-            "23:5: " + getCheckMessage(MSG_JAVADOC_MISSING),
+            "17:5: " + getCheckMessage(MSG_JAVADOC_MISSING),
+            "21:5: " + getCheckMessage(MSG_JAVADOC_MISSING),
+            "24:5: " + getCheckMessage(MSG_JAVADOC_MISSING),
         };
         verifyWithInlineConfigParser(
             getPath("InputMissingJavadocTypeQualifiedAnnotation1.java"), expected);
@@ -379,8 +384,8 @@ public class MissingJavadocTypeCheckTest extends AbstractModuleTestSupport {
     @Test
     public void testQualifiedAnnotation2() throws Exception {
         final String[] expected = {
-            "20:5: " + getCheckMessage(MSG_JAVADOC_MISSING),
-            "23:5: " + getCheckMessage(MSG_JAVADOC_MISSING),
+            "21:5: " + getCheckMessage(MSG_JAVADOC_MISSING),
+            "24:5: " + getCheckMessage(MSG_JAVADOC_MISSING),
         };
         verifyWithInlineConfigParser(
             getPath("InputMissingJavadocTypeQualifiedAnnotation2.java"), expected);
@@ -389,8 +394,8 @@ public class MissingJavadocTypeCheckTest extends AbstractModuleTestSupport {
     @Test
     public void testQualifiedAnnotation3() throws Exception {
         final String[] expected = {
-            "16:5: " + getCheckMessage(MSG_JAVADOC_MISSING),
-            "22:5: " + getCheckMessage(MSG_JAVADOC_MISSING),
+            "17:5: " + getCheckMessage(MSG_JAVADOC_MISSING),
+            "23:5: " + getCheckMessage(MSG_JAVADOC_MISSING),
         };
         verifyWithInlineConfigParser(
             getPath("InputMissingJavadocTypeQualifiedAnnotation3.java"), expected);
@@ -399,8 +404,8 @@ public class MissingJavadocTypeCheckTest extends AbstractModuleTestSupport {
     @Test
     public void testQualifiedAnnotation4() throws Exception {
         final String[] expected = {
-            "17:5: " + getCheckMessage(MSG_JAVADOC_MISSING),
-            "21:5: " + getCheckMessage(MSG_JAVADOC_MISSING),
+            "18:5: " + getCheckMessage(MSG_JAVADOC_MISSING),
+            "22:5: " + getCheckMessage(MSG_JAVADOC_MISSING),
         };
         verifyWithInlineConfigParser(
             getPath("InputMissingJavadocTypeQualifiedAnnotation4.java"), expected);
@@ -416,8 +421,8 @@ public class MissingJavadocTypeCheckTest extends AbstractModuleTestSupport {
     @Test
     public void testMultipleQualifiedAnnotation() throws Exception {
         final String[] expected = {
-            "29:5: " + getCheckMessage(MSG_JAVADOC_MISSING),
-            "38:5: " + getCheckMessage(MSG_JAVADOC_MISSING),
+            "30:5: " + getCheckMessage(MSG_JAVADOC_MISSING),
+            "39:5: " + getCheckMessage(MSG_JAVADOC_MISSING),
         };
         verifyWithInlineConfigParser(
             getPath("InputMissingJavadocTypeMultipleQualifiedAnnotation.java"), expected);
@@ -426,10 +431,10 @@ public class MissingJavadocTypeCheckTest extends AbstractModuleTestSupport {
     @Test
     public void testQualifiedAnnotationWithParameters() throws Exception {
         final String[] expected = {
-            "33:5: " + getCheckMessage(MSG_JAVADOC_MISSING),
-            "37:5: " + getCheckMessage(MSG_JAVADOC_MISSING),
-            "42:5: " + getCheckMessage(MSG_JAVADOC_MISSING),
-            "50:5: " + getCheckMessage(MSG_JAVADOC_MISSING),
+            "34:5: " + getCheckMessage(MSG_JAVADOC_MISSING),
+            "38:5: " + getCheckMessage(MSG_JAVADOC_MISSING),
+            "43:5: " + getCheckMessage(MSG_JAVADOC_MISSING),
+            "51:5: " + getCheckMessage(MSG_JAVADOC_MISSING),
         };
         verifyWithInlineConfigParser(
             getPath("InputMissingJavadocTypeQualifiedAnnotationWithParameters.java"),
@@ -439,12 +444,50 @@ public class MissingJavadocTypeCheckTest extends AbstractModuleTestSupport {
     @Test
     public void testMissingJavadocTypeAboveComments() throws Exception {
         final String[] expected = {
-            "13:1: " + getCheckMessage(MSG_JAVADOC_MISSING),
-            "27:5: " + getCheckMessage(MSG_JAVADOC_MISSING),
+            "14:1: " + getCheckMessage(MSG_JAVADOC_MISSING),
+            "28:5: " + getCheckMessage(MSG_JAVADOC_MISSING),
         };
         verifyWithInlineConfigParser(
             getPath("InputMissingJavadocTypeAboveComments.java"),
             expected);
+    }
+
+    @Test
+    public void testNonJavadocBlockCommentDoesNotSatisfyJavadoc() throws Exception {
+        final String[] expected = {
+            "13:1: " + getCheckMessage(MSG_JAVADOC_MISSING),
+            "15:5: " + getCheckMessage(MSG_JAVADOC_MISSING),
+            "21:5: " + getCheckMessage(MSG_JAVADOC_MISSING),
+            "25:5: " + getCheckMessage(MSG_JAVADOC_MISSING),
+        };
+        verifyWithInlineConfigParser(
+                getPath("InputMissingJavadocTypeNonJavadocOnly.java"),
+                expected);
+    }
+
+    @Test
+    public void testMissingJavadocTypeEnum() throws Exception {
+        final String[] expected = {
+            "36:6: " + getCheckMessage(MSG_JAVADOC_MISSING),
+            "49:5: " + getCheckMessage(MSG_JAVADOC_MISSING),
+        };
+        verifyWithInlineConfigParser(
+            getPath("InputMissingJavadocTypeEnum.java"),
+            expected);
+    }
+
+    @Test
+    public void testClearJavadocComments() {
+        final MissingJavadocTypeCheck check = new MissingJavadocTypeCheck();
+        final List<Object> mockList = new ArrayList<>();
+        mockList.add(new Object());
+        TestUtil.setInternalState(check, "javadocComments", mockList);
+        check.beginTree(null);
+        final List<?> javadocComments =
+                (List<?>) TestUtil.getInternalState(check, "javadocComments", List.class);
+        assertWithMessage("javadocComments state is not cleared on beginTree")
+                .that(javadocComments)
+                .isEmpty();
     }
 
 }

--- a/src/test/java/com/puppycrawl/tools/checkstyle/filters/SuppressWarningsFilterTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/filters/SuppressWarningsFilterTest.java
@@ -36,45 +36,45 @@ public class SuppressWarningsFilterTest
     extends AbstractModuleTestSupport {
 
     private static final String[] ALL_MESSAGES = {
-        "49:5: " + getCheckMessage(MissingJavadocTypeCheck.class, MSG_JAVADOC_MISSING),
         "50:5: " + getCheckMessage(MissingJavadocTypeCheck.class, MSG_JAVADOC_MISSING),
-        "52:5: " + getCheckMessage(MissingJavadocTypeCheck.class, MSG_JAVADOC_MISSING),
-        "55:37: "
+        "51:5: " + getCheckMessage(MissingJavadocTypeCheck.class, MSG_JAVADOC_MISSING),
+        "53:5: " + getCheckMessage(MissingJavadocTypeCheck.class, MSG_JAVADOC_MISSING),
+        "56:37: "
             + getCheckMessage(AbstractNameCheck.class,
                 MSG_INVALID_PATTERN, "I", "^[a-z][a-zA-Z0-9]*$"),
-        "57:17: "
-            + getCheckMessage(AbstractNameCheck.class,
-                MSG_INVALID_PATTERN, "J", "^[a-z][a-zA-Z0-9]*$"),
         "58:17: "
             + getCheckMessage(AbstractNameCheck.class,
+                MSG_INVALID_PATTERN, "J", "^[a-z][a-zA-Z0-9]*$"),
+        "59:17: "
+            + getCheckMessage(AbstractNameCheck.class,
                 MSG_INVALID_PATTERN, "K", "^[a-z][a-zA-Z0-9]*$"),
-        "62:17: "
+        "63:17: "
             + getCheckMessage(AbstractNameCheck.class,
                 MSG_INVALID_PATTERN, "L", "^[a-z][a-zA-Z0-9]*$"),
-        "62:32: "
+        "63:32: "
             + getCheckMessage(AbstractNameCheck.class,
                 MSG_INVALID_PATTERN, "X", "^[a-z][a-zA-Z0-9]*$"),
-        "67:30: "
-            + getCheckMessage(AbstractNameCheck.class,
-                MSG_INVALID_PATTERN, "m", "^[A-Z][A-Z0-9]*(_[A-Z0-9]+)*$"),
         "68:30: "
             + getCheckMessage(AbstractNameCheck.class,
+                MSG_INVALID_PATTERN, "m", "^[A-Z][A-Z0-9]*(_[A-Z0-9]+)*$"),
+        "69:30: "
+            + getCheckMessage(AbstractNameCheck.class,
                 MSG_INVALID_PATTERN, "n", "^[A-Z][A-Z0-9]*(_[A-Z0-9]+)*$"),
-        "73:10: "
+        "74:10: "
             + getCheckMessage(ParameterNumberCheck.class, ParameterNumberCheck.MSG_KEY, 7, 8),
-        "77:9: "
+        "78:9: "
             + getCheckMessage(IllegalCatchCheck.class, IllegalCatchCheck.MSG_KEY, "Exception"),
-        "86:9: "
+        "87:9: "
             + getCheckMessage(IllegalCatchCheck.class, IllegalCatchCheck.MSG_KEY, "Exception"),
-        "91:5: " + getCheckMessage(MissingJavadocTypeCheck.class, MSG_JAVADOC_MISSING),
-        "100:5: " + getCheckMessage(UncommentedMainCheck.class, UncommentedMainCheck.MSG_KEY),
-        "103:5: " + getCheckMessage(MissingJavadocTypeCheck.class, MSG_JAVADOC_MISSING),
-        "104:9: " + getCheckMessage(UncommentedMainCheck.class, UncommentedMainCheck.MSG_KEY),
-        "108:5: " + getCheckMessage(MissingJavadocTypeCheck.class, MSG_JAVADOC_MISSING),
-        "109:9: " + getCheckMessage(UncommentedMainCheck.class, UncommentedMainCheck.MSG_KEY),
-        "113:5: " + getCheckMessage(MissingJavadocTypeCheck.class, MSG_JAVADOC_MISSING),
-        "114:9: " + getCheckMessage(UncommentedMainCheck.class, UncommentedMainCheck.MSG_KEY),
-        "118:5: " + getCheckMessage(MissingJavadocTypeCheck.class, MSG_JAVADOC_MISSING),
+        "92:5: " + getCheckMessage(MissingJavadocTypeCheck.class, MSG_JAVADOC_MISSING),
+        "101:5: " + getCheckMessage(UncommentedMainCheck.class, UncommentedMainCheck.MSG_KEY),
+        "104:5: " + getCheckMessage(MissingJavadocTypeCheck.class, MSG_JAVADOC_MISSING),
+        "105:9: " + getCheckMessage(UncommentedMainCheck.class, UncommentedMainCheck.MSG_KEY),
+        "109:5: " + getCheckMessage(MissingJavadocTypeCheck.class, MSG_JAVADOC_MISSING),
+        "110:9: " + getCheckMessage(UncommentedMainCheck.class, UncommentedMainCheck.MSG_KEY),
+        "114:5: " + getCheckMessage(MissingJavadocTypeCheck.class, MSG_JAVADOC_MISSING),
+        "115:9: " + getCheckMessage(UncommentedMainCheck.class, UncommentedMainCheck.MSG_KEY),
+        "119:5: " + getCheckMessage(MissingJavadocTypeCheck.class, MSG_JAVADOC_MISSING),
     };
 
     @Override
@@ -92,23 +92,23 @@ public class SuppressWarningsFilterTest
     @Test
     public void testDefault() throws Exception {
         final String[] suppressed = {
-            "57:17: "
+            "58:17: "
                 + getCheckMessage(AbstractNameCheck.class,
                     MSG_INVALID_PATTERN, "J", "^[a-z][a-zA-Z0-9]*$"),
-            "62:17: "
+            "63:17: "
                 + getCheckMessage(AbstractNameCheck.class,
                     MSG_INVALID_PATTERN, "L", "^[a-z][a-zA-Z0-9]*$"),
-            "67:30: "
+            "68:30: "
                 + getCheckMessage(AbstractNameCheck.class,
                     MSG_INVALID_PATTERN, "m", "^[A-Z][A-Z0-9]*(_[A-Z0-9]+)*$"),
-            "73:10: "
+            "74:10: "
                 + getCheckMessage(ParameterNumberCheck.class, ParameterNumberCheck.MSG_KEY, 7, 8),
-            "86:9: "
+            "87:9: "
                 + getCheckMessage(IllegalCatchCheck.class, IllegalCatchCheck.MSG_KEY, "Exception"),
-            "100:5: " + getCheckMessage(UncommentedMainCheck.class, UncommentedMainCheck.MSG_KEY),
-            "104:9: " + getCheckMessage(UncommentedMainCheck.class, UncommentedMainCheck.MSG_KEY),
-            "109:9: " + getCheckMessage(UncommentedMainCheck.class, UncommentedMainCheck.MSG_KEY),
-            "114:9: " + getCheckMessage(UncommentedMainCheck.class, UncommentedMainCheck.MSG_KEY),
+            "101:5: " + getCheckMessage(UncommentedMainCheck.class, UncommentedMainCheck.MSG_KEY),
+            "105:9: " + getCheckMessage(UncommentedMainCheck.class, UncommentedMainCheck.MSG_KEY),
+            "110:9: " + getCheckMessage(UncommentedMainCheck.class, UncommentedMainCheck.MSG_KEY),
+            "115:9: " + getCheckMessage(UncommentedMainCheck.class, UncommentedMainCheck.MSG_KEY),
         };
         verifySuppressedWithParser(getPath("InputSuppressWarningsFilter.java"), suppressed);
     }
@@ -116,18 +116,18 @@ public class SuppressWarningsFilterTest
     @Test
     public void testSuppressById() throws Exception {
         final String[] suppressedViolationMessages = {
-            "50:17: "
+            "51:17: "
                 + getCheckMessage(AbstractNameCheck.class,
                     MSG_INVALID_PATTERN, "A1", "^[a-z][a-zA-Z0-9]*$"),
-            "52:5: "
+            "53:5: "
                 + getCheckMessage(UncommentedMainCheck.class, UncommentedMainCheck.MSG_KEY),
         };
         final String[] expectedViolationMessages = {
-            "47:1: " + getCheckMessage(MissingJavadocTypeCheck.class, MSG_JAVADOC_MISSING),
-            "50:17: "
+            "48:1: " + getCheckMessage(MissingJavadocTypeCheck.class, MSG_JAVADOC_MISSING),
+            "51:17: "
                 + getCheckMessage(AbstractNameCheck.class,
                     MSG_INVALID_PATTERN, "A1", "^[a-z][a-zA-Z0-9]*$"),
-            "52:5: "
+            "53:5: "
                 + getCheckMessage(UncommentedMainCheck.class, UncommentedMainCheck.MSG_KEY),
         };
 

--- a/src/test/java/com/puppycrawl/tools/checkstyle/filters/SuppressionXpathSingleFilterTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/filters/SuppressionXpathSingleFilterTest.java
@@ -55,11 +55,11 @@ public class SuppressionXpathSingleFilterTest
     @Test
     public void testMatching() throws Exception {
         final String[] expected = {
-            "19:1: " + getCheckMessage(MissingJavadocTypeCheck.class, MSG_JAVADOC_MISSING),
+            "20:1: " + getCheckMessage(MissingJavadocTypeCheck.class, MSG_JAVADOC_MISSING),
         };
 
         final String[] suppressed = {
-            "19:1: " + getCheckMessage(MissingJavadocTypeCheck.class, MSG_JAVADOC_MISSING),
+            "20:1: " + getCheckMessage(MissingJavadocTypeCheck.class, MSG_JAVADOC_MISSING),
         };
 
         verifyFilterWithInlineConfigParser(
@@ -70,7 +70,7 @@ public class SuppressionXpathSingleFilterTest
     @Test
     public void testNonMatchingTokenType() throws Exception {
         final String[] expected = {
-            "19:1: " + getCheckMessage(MissingJavadocTypeCheck.class, MSG_JAVADOC_MISSING),
+            "20:1: " + getCheckMessage(MissingJavadocTypeCheck.class, MSG_JAVADOC_MISSING),
         };
 
         final String[] suppressed = CommonUtil.EMPTY_STRING_ARRAY;
@@ -83,12 +83,12 @@ public class SuppressionXpathSingleFilterTest
     @Test
     public void testNonMatchingLineNumber() throws Exception {
         final String[] expected = {
-            "18:1: " + getCheckMessage(MissingJavadocTypeCheck.class, MSG_JAVADOC_MISSING),
-            "21:1: " + getCheckMessage(MissingJavadocTypeCheck.class, MSG_JAVADOC_MISSING),
+            "19:1: " + getCheckMessage(MissingJavadocTypeCheck.class, MSG_JAVADOC_MISSING),
+            "22:1: " + getCheckMessage(MissingJavadocTypeCheck.class, MSG_JAVADOC_MISSING),
         };
 
         final String[] suppressed = {
-            "21:1: " + getCheckMessage(MissingJavadocTypeCheck.class, MSG_JAVADOC_MISSING),
+            "22:1: " + getCheckMessage(MissingJavadocTypeCheck.class, MSG_JAVADOC_MISSING),
         };
 
         verifyFilterWithInlineConfigParser(
@@ -144,11 +144,11 @@ public class SuppressionXpathSingleFilterTest
     @Test
     public void testNoQuery() throws Exception {
         final String[] expected = {
-            "18:1: " + getCheckMessage(MissingJavadocTypeCheck.class, MSG_JAVADOC_MISSING),
+            "19:1: " + getCheckMessage(MissingJavadocTypeCheck.class, MSG_JAVADOC_MISSING),
         };
 
         final String[] suppressed = {
-            "18:1: " + getCheckMessage(MissingJavadocTypeCheck.class, MSG_JAVADOC_MISSING),
+            "19:1: " + getCheckMessage(MissingJavadocTypeCheck.class, MSG_JAVADOC_MISSING),
         };
 
         verifyFilterWithInlineConfigParser(
@@ -159,7 +159,7 @@ public class SuppressionXpathSingleFilterTest
     @Test
     public void testNullFileName() throws Exception {
         final String[] expected = {
-            "18:1: " + getCheckMessage(MissingJavadocTypeCheck.class, MSG_JAVADOC_MISSING),
+            "19:1: " + getCheckMessage(MissingJavadocTypeCheck.class, MSG_JAVADOC_MISSING),
         };
 
         final String[] suppressed = CommonUtil.EMPTY_STRING_ARRAY;
@@ -172,7 +172,7 @@ public class SuppressionXpathSingleFilterTest
     @Test
     public void testNonMatchingFileRegexp() throws Exception {
         final String[] expected = {
-            "18:1: " + getCheckMessage(MissingJavadocTypeCheck.class, MSG_JAVADOC_MISSING),
+            "19:1: " + getCheckMessage(MissingJavadocTypeCheck.class, MSG_JAVADOC_MISSING),
         };
 
         final String[] suppressed = CommonUtil.EMPTY_STRING_ARRAY;
@@ -221,7 +221,7 @@ public class SuppressionXpathSingleFilterTest
     @Test
     public void testNonMatchingModuleId() throws Exception {
         final String[] expected = {
-            "20:1: " + getCheckMessage(MissingJavadocTypeCheck.class, MSG_JAVADOC_MISSING),
+            "21:1: " + getCheckMessage(MissingJavadocTypeCheck.class, MSG_JAVADOC_MISSING),
         };
 
         final String[] suppressed = CommonUtil.EMPTY_STRING_ARRAY;
@@ -234,11 +234,11 @@ public class SuppressionXpathSingleFilterTest
     @Test
     public void testMatchingModuleId() throws Exception {
         final String[] expected = {
-            "20:1: " + getCheckMessage(MissingJavadocTypeCheck.class, MSG_JAVADOC_MISSING),
+            "21:1: " + getCheckMessage(MissingJavadocTypeCheck.class, MSG_JAVADOC_MISSING),
         };
 
         final String[] suppressed = {
-            "20:1: " + getCheckMessage(MissingJavadocTypeCheck.class, MSG_JAVADOC_MISSING),
+            "21:1: " + getCheckMessage(MissingJavadocTypeCheck.class, MSG_JAVADOC_MISSING),
         };
 
         verifyFilterWithInlineConfigParser(
@@ -249,7 +249,7 @@ public class SuppressionXpathSingleFilterTest
     @Test
     public void testNonMatchingChecks() throws Exception {
         final String[] expected = {
-            "19:1: " + getCheckMessage(MissingJavadocTypeCheck.class, MSG_JAVADOC_MISSING),
+            "20:1: " + getCheckMessage(MissingJavadocTypeCheck.class, MSG_JAVADOC_MISSING),
         };
 
         final String[] suppressed = CommonUtil.EMPTY_STRING_ARRAY;
@@ -262,7 +262,7 @@ public class SuppressionXpathSingleFilterTest
     @Test
     public void testNonMatchingFileNameModuleIdAndCheck() throws Exception {
         final String[] expected = {
-            "20:1: " + getCheckMessage(MissingJavadocTypeCheck.class, MSG_JAVADOC_MISSING),
+            "21:1: " + getCheckMessage(MissingJavadocTypeCheck.class, MSG_JAVADOC_MISSING),
         };
         final String[] suppressed = CommonUtil.EMPTY_STRING_ARRAY;
 
@@ -274,7 +274,7 @@ public class SuppressionXpathSingleFilterTest
     @Test
     public void testNullModuleIdAndNonMatchingChecks() throws Exception {
         final String[] expected = {
-            "20:1: " + getCheckMessage(MissingJavadocTypeCheck.class, MSG_JAVADOC_MISSING),
+            "21:1: " + getCheckMessage(MissingJavadocTypeCheck.class, MSG_JAVADOC_MISSING),
         };
         final String[] suppressed = CommonUtil.EMPTY_STRING_ARRAY;
 
@@ -286,14 +286,14 @@ public class SuppressionXpathSingleFilterTest
     @Test
     public void testDecideByMessage() throws Exception {
         final String[] expected = {
-            "28:1: " + getCheckMessage(MissingJavadocTypeCheck.class, MSG_JAVADOC_MISSING),
-            "31:21: " + getCheckMessage(MagicNumberCheck.class, MSG_KEY, "3.14"),
-            "32:16: " + getCheckMessage(MagicNumberCheck.class, MSG_KEY, "123"),
-            "36:28: " + getCheckMessage(MagicNumberCheck.class, MSG_KEY, "123"),
+            "29:1: " + getCheckMessage(MissingJavadocTypeCheck.class, MSG_JAVADOC_MISSING),
+            "32:21: " + getCheckMessage(MagicNumberCheck.class, MSG_KEY, "3.14"),
+            "33:16: " + getCheckMessage(MagicNumberCheck.class, MSG_KEY, "123"),
+            "37:28: " + getCheckMessage(MagicNumberCheck.class, MSG_KEY, "123"),
         };
 
         final String[] suppressed = {
-            "28:1: " + getCheckMessage(MissingJavadocTypeCheck.class, MSG_JAVADOC_MISSING),
+            "29:1: " + getCheckMessage(MissingJavadocTypeCheck.class, MSG_JAVADOC_MISSING),
         };
 
         verifyFilterWithInlineConfigParser(
@@ -329,7 +329,7 @@ public class SuppressionXpathSingleFilterTest
     @Test
     public void testAllNullConfiguration() throws Exception {
         final String[] expected = {
-            "18:1: " + getCheckMessage(MissingJavadocTypeCheck.class, MSG_JAVADOC_MISSING),
+            "19:1: " + getCheckMessage(MissingJavadocTypeCheck.class, MSG_JAVADOC_MISSING),
         };
 
         final String[] suppressed = CommonUtil.EMPTY_STRING_ARRAY;
@@ -342,11 +342,11 @@ public class SuppressionXpathSingleFilterTest
     @Test
     public void testDecideByIdAndExpression() throws Exception {
         final String[] expected = {
-            "20:1: " + getCheckMessage(MissingJavadocTypeCheck.class, MSG_JAVADOC_MISSING),
+            "21:1: " + getCheckMessage(MissingJavadocTypeCheck.class, MSG_JAVADOC_MISSING),
         };
 
         final String[] suppressed = {
-            "20:1: " + getCheckMessage(MissingJavadocTypeCheck.class, MSG_JAVADOC_MISSING),
+            "21:1: " + getCheckMessage(MissingJavadocTypeCheck.class, MSG_JAVADOC_MISSING),
         };
 
         verifyFilterWithInlineConfigParser(
@@ -357,11 +357,11 @@ public class SuppressionXpathSingleFilterTest
     @Test
     public void testDefaultFileProperty() throws Exception {
         final String[] expected = {
-            "20:1: " + getCheckMessage(MissingJavadocTypeCheck.class, MSG_JAVADOC_MISSING),
+            "21:1: " + getCheckMessage(MissingJavadocTypeCheck.class, MSG_JAVADOC_MISSING),
         };
 
         final String[] suppressed = {
-            "20:1: " + getCheckMessage(MissingJavadocTypeCheck.class, MSG_JAVADOC_MISSING),
+            "21:1: " + getCheckMessage(MissingJavadocTypeCheck.class, MSG_JAVADOC_MISSING),
         };
 
         verifyFilterWithInlineConfigParser(
@@ -372,11 +372,11 @@ public class SuppressionXpathSingleFilterTest
     @Test
     public void testDecideByCheck() throws Exception {
         final String[] expected = {
-            "18:1: " + getCheckMessage(MissingJavadocTypeCheck.class, MSG_JAVADOC_MISSING),
+            "19:1: " + getCheckMessage(MissingJavadocTypeCheck.class, MSG_JAVADOC_MISSING),
         };
 
         final String[] suppressed = {
-            "18:1: " + getCheckMessage(MissingJavadocTypeCheck.class, MSG_JAVADOC_MISSING),
+            "19:1: " + getCheckMessage(MissingJavadocTypeCheck.class, MSG_JAVADOC_MISSING),
         };
 
         verifyFilterWithInlineConfigParser(
@@ -387,11 +387,11 @@ public class SuppressionXpathSingleFilterTest
     @Test
     public void testDecideById() throws Exception {
         final String[] expected = {
-            "19:1: " + getCheckMessage(MissingJavadocTypeCheck.class, MSG_JAVADOC_MISSING),
+            "20:1: " + getCheckMessage(MissingJavadocTypeCheck.class, MSG_JAVADOC_MISSING),
         };
 
         final String[] suppressed = {
-            "19:1: " + getCheckMessage(MissingJavadocTypeCheck.class, MSG_JAVADOC_MISSING),
+            "20:1: " + getCheckMessage(MissingJavadocTypeCheck.class, MSG_JAVADOC_MISSING),
         };
 
         verifyFilterWithInlineConfigParser(
@@ -402,7 +402,7 @@ public class SuppressionXpathSingleFilterTest
     @Test
     public void testNonMatchingCheckRegexp() throws Exception {
         final String[] expected = {
-            "19:1: " + getCheckMessage(MissingJavadocTypeCheck.class, MSG_JAVADOC_MISSING),
+            "20:1: " + getCheckMessage(MissingJavadocTypeCheck.class, MSG_JAVADOC_MISSING),
         };
 
         final String[] suppressed = CommonUtil.EMPTY_STRING_ARRAY;

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/missingjavadoctype/InputMissingJavadocTypeAboveComments.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/missingjavadoctype/InputMissingJavadocTypeAboveComments.java
@@ -3,6 +3,7 @@ MissingJavadocType
 excludeScope = (default)null
 scope = (default)public
 skipAnnotations = (default)Generated
+violateExecutionOnNonTightHtml = (default)false
 tokens = (default)INTERFACE_DEF, CLASS_DEF, ENUM_DEF, ANNOTATION_DEF, RECORD_DEF
 
 
@@ -25,4 +26,34 @@ public class InputMissingJavadocTypeAboveComments { // violation, 'Missing a Jav
     public class Myclass { } /* My class */
 
     public class Myclass2 { } // violation, 'Missing a Javadoc comment.'
+
+    /**
+     *
+     */
+
+    // singline comment missing javadoc
+    public class InputMissingJavadocTypeAboveComments3 { }
+
+
+    /**
+     *
+     */
+
+    /* singline comment missing javadoc */
+    public class InputMissingJavadocTypeAboveComments4 { }
+
+    /**
+     *
+     */ public class Myclass3 { }
+
+  /**javadoc*/ public class Myclass5 { }
+
+  /** Test class for variable naming in for each clause.
+   *
+   */
+  /*
+     Input class for JavadocType
+  */
+  public class InputJavadocTypeAboveComments { }
+
 }

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/missingjavadoctype/InputMissingJavadocTypeEnum.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/missingjavadoctype/InputMissingJavadocTypeEnum.java
@@ -1,0 +1,54 @@
+/*
+MissingJavadocType
+excludeScope = (default)null
+scope = PRIVATE
+skipAnnotations = (default)Generated
+violateExecutionOnNonTightHtml = (default)false
+tokens = (default)INTERFACE_DEF, CLASS_DEF, ENUM_DEF, ANNOTATION_DEF, RECORD_DEF
+
+
+*/
+
+package com.puppycrawl.tools.checkstyle.checks.javadoc.missingjavadoctype;
+
+/**
+ * Tests Enum with private
+ **/
+public class InputMissingJavadocTypeEnum {
+
+    /**
+     * A specification for which index to return.
+     *
+     */ enum Test {
+      /**
+       *
+       */
+      Test{
+            @Override
+            <T> void method(
+                    T value) { }
+        };
+
+        abstract <T> void method(
+                T value);
+    }
+
+     enum Test2 { // violation 'Missing a Javadoc comment.'
+        TEST_2 {
+            @Override
+            <T> void method(
+                    T value) { }
+        };
+
+        abstract <T> void method(
+                T value);
+    }
+
+    ; /** @deprecated */ ;
+
+    static class A { // violation 'Missing a Javadoc comment.'
+
+    }
+
+}
+

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/missingjavadoctype/InputMissingJavadocTypeInner.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/missingjavadoctype/InputMissingJavadocTypeInner.java
@@ -3,6 +3,7 @@ MissingJavadocType
 excludeScope = (default)null
 scope = PRIVATE
 skipAnnotations = (default)Generated
+violateExecutionOnNonTightHtml = (default)false
 tokens = (default)INTERFACE_DEF, CLASS_DEF, ENUM_DEF, ANNOTATION_DEF, RECORD_DEF
 
 

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/missingjavadoctype/InputMissingJavadocTypeInterfaceMemberScopeIsPublic.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/missingjavadoctype/InputMissingJavadocTypeInterfaceMemberScopeIsPublic.java
@@ -3,6 +3,7 @@ MissingJavadocType
 excludeScope = (default)null
 scope = (default)public
 skipAnnotations = (default)Generated
+violateExecutionOnNonTightHtml = (default)false
 tokens = (default)INTERFACE_DEF, CLASS_DEF, ENUM_DEF, ANNOTATION_DEF, RECORD_DEF
 
 

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/missingjavadoctype/InputMissingJavadocTypeMultipleQualifiedAnnotation.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/missingjavadoctype/InputMissingJavadocTypeMultipleQualifiedAnnotation.java
@@ -3,6 +3,7 @@ MissingJavadocType
 excludeScope = (default)null
 scope = (default)public
 skipAnnotations = Ann1, AnnClass.Ann3
+violateExecutionOnNonTightHtml = (default)false
 tokens = INTERFACE_DEF
 
 

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/missingjavadoctype/InputMissingJavadocTypeNoJavadoc1One.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/missingjavadoctype/InputMissingJavadocTypeNoJavadoc1One.java
@@ -3,6 +3,7 @@ MissingJavadocType
 excludeScope = (default)null
 scope = PRIVATE
 skipAnnotations = (default)Generated
+violateExecutionOnNonTightHtml = (default)false
 tokens = (default)INTERFACE_DEF, CLASS_DEF, ENUM_DEF, ANNOTATION_DEF, RECORD_DEF
 
 

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/missingjavadoctype/InputMissingJavadocTypeNoJavadoc1Two.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/missingjavadoctype/InputMissingJavadocTypeNoJavadoc1Two.java
@@ -3,6 +3,7 @@ MissingJavadocType
 excludeScope = (default)null
 scope = PRIVATE
 skipAnnotations = (default)Generated
+violateExecutionOnNonTightHtml = (default)false
 tokens = (default)INTERFACE_DEF, CLASS_DEF, ENUM_DEF, ANNOTATION_DEF, RECORD_DEF
 
 

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/missingjavadoctype/InputMissingJavadocTypeNoJavadoc2One.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/missingjavadoctype/InputMissingJavadocTypeNoJavadoc2One.java
@@ -3,6 +3,7 @@ MissingJavadocType
 excludeScope = (default)null
 scope = protected
 skipAnnotations = (default)Generated
+violateExecutionOnNonTightHtml = (default)false
 tokens = (default)INTERFACE_DEF, CLASS_DEF, ENUM_DEF, ANNOTATION_DEF, RECORD_DEF
 
 

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/missingjavadoctype/InputMissingJavadocTypeNoJavadoc2Two.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/missingjavadoctype/InputMissingJavadocTypeNoJavadoc2Two.java
@@ -3,6 +3,7 @@ MissingJavadocType
 excludeScope = (default)null
 scope = protected
 skipAnnotations = (default)Generated
+violateExecutionOnNonTightHtml = (default)false
 tokens = (default)INTERFACE_DEF, CLASS_DEF, ENUM_DEF, ANNOTATION_DEF, RECORD_DEF
 
 

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/missingjavadoctype/InputMissingJavadocTypeNoJavadoc3One.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/missingjavadoctype/InputMissingJavadocTypeNoJavadoc3One.java
@@ -3,6 +3,7 @@ MissingJavadocType
 excludeScope = protected
 scope = private
 skipAnnotations = (default)Generated
+violateExecutionOnNonTightHtml = (default)false
 tokens = (default)INTERFACE_DEF, CLASS_DEF, ENUM_DEF, ANNOTATION_DEF, RECORD_DEF
 
 

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/missingjavadoctype/InputMissingJavadocTypeNoJavadoc3Two.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/missingjavadoctype/InputMissingJavadocTypeNoJavadoc3Two.java
@@ -3,6 +3,7 @@ MissingJavadocType
 excludeScope = protected
 scope = private
 skipAnnotations = (default)Generated
+violateExecutionOnNonTightHtml = (default)false
 tokens = (default)INTERFACE_DEF, CLASS_DEF, ENUM_DEF, ANNOTATION_DEF, RECORD_DEF
 
 

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/missingjavadoctype/InputMissingJavadocTypeNoJavadocOnInterface.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/missingjavadoctype/InputMissingJavadocTypeNoJavadocOnInterface.java
@@ -3,6 +3,7 @@ MissingJavadocType
 excludeScope = (default)null
 scope = PRIVATE
 skipAnnotations = (default)Generated
+violateExecutionOnNonTightHtml = (default)false
 tokens = INTERFACE_DEF
 
 

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/missingjavadoctype/InputMissingJavadocTypeNonJavadocOnly.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/missingjavadoctype/InputMissingJavadocTypeNonJavadocOnly.java
@@ -1,0 +1,28 @@
+/*
+MissingJavadocType
+scope = (default)public
+excludeScope = (default)null
+skipAnnotations = (default)Generated
+violateExecutionOnNonTightHtml = (default)false
+tokens = (default)INTERFACE_DEF, CLASS_DEF, ENUM_DEF, ANNOTATION_DEF, RECORD_DEF
+
+
+*/
+package com.puppycrawl.tools.checkstyle.checks.javadoc.missingjavadoctype;
+
+public class InputMissingJavadocTypeNonJavadocOnly { // violation, 'Missing a Javadoc comment.'
+    /* This is NOT a Javadoc comment */
+    public class InnerClass { // violation, 'Missing a Javadoc comment.'
+    }
+
+    /*
+     This is NOT a Javadoc comment
+    */
+    public class InnerClass2 { // violation, 'Missing a Javadoc comment.'
+    }
+
+    // This is NOT a Javadoc comment
+    public class InnerClass3 { // violation, 'Missing a Javadoc comment.'
+    }
+
+}

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/missingjavadoctype/InputMissingJavadocTypePublicOnly1One.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/missingjavadoctype/InputMissingJavadocTypePublicOnly1One.java
@@ -3,6 +3,7 @@ MissingJavadocType
 excludeScope = (default)null
 scope = PRIVATE
 skipAnnotations = (default)Generated
+violateExecutionOnNonTightHtml = (default)false
 tokens = (default)INTERFACE_DEF, CLASS_DEF, ENUM_DEF, ANNOTATION_DEF, RECORD_DEF
 
 

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/missingjavadoctype/InputMissingJavadocTypePublicOnly1Two.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/missingjavadoctype/InputMissingJavadocTypePublicOnly1Two.java
@@ -3,6 +3,7 @@ MissingJavadocType
 excludeScope = (default)null
 scope = PRIVATE
 skipAnnotations = (default)Generated
+violateExecutionOnNonTightHtml = (default)false
 tokens = (default)INTERFACE_DEF, CLASS_DEF, ENUM_DEF, ANNOTATION_DEF, RECORD_DEF
 
 

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/missingjavadoctype/InputMissingJavadocTypePublicOnly2One.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/missingjavadoctype/InputMissingJavadocTypePublicOnly2One.java
@@ -3,6 +3,7 @@ MissingJavadocType
 excludeScope = (default)null
 scope = protected
 skipAnnotations = (default)Generated
+violateExecutionOnNonTightHtml = (default)false
 tokens = (default)INTERFACE_DEF, CLASS_DEF, ENUM_DEF, ANNOTATION_DEF, RECORD_DEF
 
 

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/missingjavadoctype/InputMissingJavadocTypePublicOnly2Two.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/missingjavadoctype/InputMissingJavadocTypePublicOnly2Two.java
@@ -3,6 +3,7 @@ MissingJavadocType
 excludeScope = (default)null
 scope = protected
 skipAnnotations = (default)Generated
+violateExecutionOnNonTightHtml = (default)false
 tokens = (default)INTERFACE_DEF, CLASS_DEF, ENUM_DEF, ANNOTATION_DEF, RECORD_DEF
 
 

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/missingjavadoctype/InputMissingJavadocTypeQualifiedAnnotation1.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/missingjavadoctype/InputMissingJavadocTypeQualifiedAnnotation1.java
@@ -3,6 +3,7 @@ MissingJavadocType
 excludeScope = (default)null
 scope = (default)public
 skipAnnotations = (default)Generated
+violateExecutionOnNonTightHtml = (default)false
 tokens = INTERFACE_DEF
 
 

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/missingjavadoctype/InputMissingJavadocTypeQualifiedAnnotation2.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/missingjavadoctype/InputMissingJavadocTypeQualifiedAnnotation2.java
@@ -3,6 +3,7 @@ MissingJavadocType
 excludeScope = (default)null
 scope = (default)public
 skipAnnotations = SomeAnnotation
+violateExecutionOnNonTightHtml = (default)false
 tokens = INTERFACE_DEF
 
 

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/missingjavadoctype/InputMissingJavadocTypeQualifiedAnnotation3.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/missingjavadoctype/InputMissingJavadocTypeQualifiedAnnotation3.java
@@ -3,6 +3,7 @@ MissingJavadocType
 excludeScope = (default)null
 scope = (default)public
 skipAnnotations = InputMissingJavadocTypeQualifiedAnnotation3.SomeAnnotation
+violateExecutionOnNonTightHtml = (default)false
 tokens = INTERFACE_DEF
 
 

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/missingjavadoctype/InputMissingJavadocTypeQualifiedAnnotation4.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/missingjavadoctype/InputMissingJavadocTypeQualifiedAnnotation4.java
@@ -4,6 +4,7 @@ excludeScope = (default)null
 scope = (default)public
 skipAnnotations = com.puppycrawl.tools.checkstyle.checks.javadoc.missingjavadoctype.\
     InputMissingJavadocTypeQualifiedAnnotation4.SomeAnnotation
+violateExecutionOnNonTightHtml = (default)false
 tokens = INTERFACE_DEF
 
 

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/missingjavadoctype/InputMissingJavadocTypeQualifiedAnnotation5.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/missingjavadoctype/InputMissingJavadocTypeQualifiedAnnotation5.java
@@ -5,6 +5,7 @@ scope = (default)public
 skipAnnotations = SomeAnnotation, InputMissingJavadocTypeQualifiedAnnotation5.SomeAnnotation, \
     com.puppycrawl.tools.checkstyle.checks.javadoc.missingjavadoctype.\
     InputMissingJavadocTypeQualifiedAnnotation5.SomeAnnotation
+violateExecutionOnNonTightHtml = (default)false
 tokens = INTERFACE_DEF
 
 

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/missingjavadoctype/InputMissingJavadocTypeQualifiedAnnotationWithParameters.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/missingjavadoctype/InputMissingJavadocTypeQualifiedAnnotationWithParameters.java
@@ -3,6 +3,7 @@ MissingJavadocType
 excludeScope = (default)null
 scope = (default)public
 skipAnnotations = SomeAnnotation
+violateExecutionOnNonTightHtml = (default)false
 tokens = INTERFACE_DEF
 
 

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/missingjavadoctype/InputMissingJavadocTypeRecords.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/missingjavadoctype/InputMissingJavadocTypeRecords.java
@@ -3,6 +3,7 @@ MissingJavadocType
 excludeScope = (default)null
 scope = PRIVATE
 skipAnnotations = NonNull1
+violateExecutionOnNonTightHtml = (default)false
 tokens = (default)INTERFACE_DEF, CLASS_DEF, ENUM_DEF, ANNOTATION_DEF, RECORD_DEF
 
 

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/missingjavadoctype/InputMissingJavadocTypeScopeInnerClasses1.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/missingjavadoctype/InputMissingJavadocTypeScopeInnerClasses1.java
@@ -3,6 +3,7 @@ MissingJavadocType
 excludeScope = (default)null
 scope = package
 skipAnnotations = (default)Generated
+violateExecutionOnNonTightHtml = (default)false
 tokens = (default)INTERFACE_DEF, CLASS_DEF, ENUM_DEF, ANNOTATION_DEF, RECORD_DEF
 
 

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/missingjavadoctype/InputMissingJavadocTypeScopeInnerClasses2.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/missingjavadoctype/InputMissingJavadocTypeScopeInnerClasses2.java
@@ -3,6 +3,7 @@ MissingJavadocType
 excludeScope = (default)null
 scope = (default)public
 skipAnnotations = (default)Generated
+violateExecutionOnNonTightHtml = (default)false
 tokens = (default)INTERFACE_DEF, CLASS_DEF, ENUM_DEF, ANNOTATION_DEF, RECORD_DEF
 
 

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/missingjavadoctype/InputMissingJavadocTypeScopeInnerInterfaces1.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/missingjavadoctype/InputMissingJavadocTypeScopeInnerInterfaces1.java
@@ -3,6 +3,7 @@ MissingJavadocType
 excludeScope = (default)null
 scope = (default)public
 skipAnnotations = (default)Generated
+violateExecutionOnNonTightHtml = (default)false
 tokens = (default)INTERFACE_DEF, CLASS_DEF, ENUM_DEF, ANNOTATION_DEF, RECORD_DEF
 
 

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/missingjavadoctype/InputMissingJavadocTypeScopeInnerInterfaces2.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/missingjavadoctype/InputMissingJavadocTypeScopeInnerInterfaces2.java
@@ -3,6 +3,7 @@ MissingJavadocType
 excludeScope = (default)null
 scope = protected
 skipAnnotations = (default)Generated
+violateExecutionOnNonTightHtml = (default)false
 tokens = (default)INTERFACE_DEF, CLASS_DEF, ENUM_DEF, ANNOTATION_DEF, RECORD_DEF
 
 

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/missingjavadoctype/InputMissingJavadocTypeSkipAnnotations1.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/missingjavadoctype/InputMissingJavadocTypeSkipAnnotations1.java
@@ -3,6 +3,7 @@ MissingJavadocType
 excludeScope = (default)null
 scope = PRIVATE
 skipAnnotations = (default)Generated
+violateExecutionOnNonTightHtml = (default)false
 tokens = (default)INTERFACE_DEF, CLASS_DEF, ENUM_DEF, ANNOTATION_DEF, RECORD_DEF
 
 

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/missingjavadoctype/InputMissingJavadocTypeSkipAnnotations2.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/missingjavadoctype/InputMissingJavadocTypeSkipAnnotations2.java
@@ -3,6 +3,7 @@ MissingJavadocType
 excludeScope = (default)null
 scope = PRIVATE
 skipAnnotations = com.puppycrawl.tools.checkstyle.checks.javadoc.javadoctype.ThisIsOk2
+violateExecutionOnNonTightHtml = (default)false
 tokens = (default)INTERFACE_DEF, CLASS_DEF, ENUM_DEF, ANNOTATION_DEF, RECORD_DEF
 
 

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/missingjavadoctype/InputMissingJavadocTypeSkipAnnotations3.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/missingjavadoctype/InputMissingJavadocTypeSkipAnnotations3.java
@@ -3,6 +3,7 @@ MissingJavadocType
 excludeScope = (default)null
 scope = (default)public
 skipAnnotations = Generated3, ThisIsOk3
+violateExecutionOnNonTightHtml = (default)false
 tokens = (default)INTERFACE_DEF, CLASS_DEF, ENUM_DEF, ANNOTATION_DEF, RECORD_DEF
 
 

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/missingjavadoctype/InputMissingJavadocTypeSkipAnnotations4.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/missingjavadoctype/InputMissingJavadocTypeSkipAnnotations4.java
@@ -3,6 +3,7 @@ MissingJavadocType
 excludeScope = (default)null
 scope = PRIVATE
 skipAnnotations = Override
+violateExecutionOnNonTightHtml = (default)false
 tokens = (default)INTERFACE_DEF, CLASS_DEF, ENUM_DEF, ANNOTATION_DEF, RECORD_DEF
 
 

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/missingjavadoctype/InputMissingJavadocTypeTagsFour.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/missingjavadoctype/InputMissingJavadocTypeTagsFour.java
@@ -3,6 +3,7 @@ MissingJavadocType
 excludeScope = (default)null
 scope = PRIVATE
 skipAnnotations = (default)Generated
+violateExecutionOnNonTightHtml = (default)false
 tokens = (default)INTERFACE_DEF, CLASS_DEF, ENUM_DEF, ANNOTATION_DEF, RECORD_DEF
 
 

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/missingjavadoctype/InputMissingJavadocTypeTagsOne.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/missingjavadoctype/InputMissingJavadocTypeTagsOne.java
@@ -3,6 +3,7 @@ MissingJavadocType
 excludeScope = (default)null
 scope = PRIVATE
 skipAnnotations = (default)Generated
+violateExecutionOnNonTightHtml = (default)false
 tokens = (default)INTERFACE_DEF, CLASS_DEF, ENUM_DEF, ANNOTATION_DEF, RECORD_DEF
 
 

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/missingjavadoctype/InputMissingJavadocTypeTagsThree.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/missingjavadoctype/InputMissingJavadocTypeTagsThree.java
@@ -3,6 +3,7 @@ MissingJavadocType
 excludeScope = (default)null
 scope = PRIVATE
 skipAnnotations = (default)Generated
+violateExecutionOnNonTightHtml = (default)false
 tokens = (default)INTERFACE_DEF, CLASS_DEF, ENUM_DEF, ANNOTATION_DEF, RECORD_DEF
 
 

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/missingjavadoctype/InputMissingJavadocTypeTagsTwo.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/missingjavadoctype/InputMissingJavadocTypeTagsTwo.java
@@ -3,6 +3,7 @@ MissingJavadocType
 excludeScope = (default)null
 scope = PRIVATE
 skipAnnotations = (default)Generated
+violateExecutionOnNonTightHtml = (default)false
 tokens = (default)INTERFACE_DEF, CLASS_DEF, ENUM_DEF, ANNOTATION_DEF, RECORD_DEF
 
 

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/missingjavadoctype/InputMissingJavadocTypeUnusedParamInJavadocForClass.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/missingjavadoctype/InputMissingJavadocTypeUnusedParamInJavadocForClass.java
@@ -3,6 +3,7 @@ MissingJavadocType
 excludeScope = (default)null
 scope = (default)public
 skipAnnotations = (default)Generated
+violateExecutionOnNonTightHtml = (default)false
 tokens = (default)INTERFACE_DEF, CLASS_DEF, ENUM_DEF, ANNOTATION_DEF, RECORD_DEF
 
 

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionxpathsinglefilter/InputSuppressionXpathSingleFilterAllNullConfiguration.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionxpathsinglefilter/InputSuppressionXpathSingleFilterAllNullConfiguration.java
@@ -10,6 +10,7 @@ com.puppycrawl.tools.checkstyle.checks.javadoc.MissingJavadocTypeCheck
 scope = (default)public
 excludeScope = (default)(null)
 skipAnnotations = (default)Generated
+violateExecutionOnNonTightHtml = (default)false
 tokens = CLASS_DEF
 
 */

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionxpathsinglefilter/InputSuppressionXpathSingleFilterDecideByCheck.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionxpathsinglefilter/InputSuppressionXpathSingleFilterDecideByCheck.java
@@ -10,6 +10,7 @@ com.puppycrawl.tools.checkstyle.checks.javadoc.MissingJavadocTypeCheck
 scope = (default)public
 excludeScope = (default)(null)
 skipAnnotations = (default)Generated
+violateExecutionOnNonTightHtml = (default)false
 tokens = CLASS_DEF
 
 */

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionxpathsinglefilter/InputSuppressionXpathSingleFilterDecideById.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionxpathsinglefilter/InputSuppressionXpathSingleFilterDecideById.java
@@ -11,6 +11,7 @@ id = 007
 scope = (default)public
 excludeScope = (default)(null)
 skipAnnotations = (default)Generated
+violateExecutionOnNonTightHtml = (default)false
 tokens = CLASS_DEF
 
 */

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionxpathsinglefilter/InputSuppressionXpathSingleFilterDecideByIdAndExpression.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionxpathsinglefilter/InputSuppressionXpathSingleFilterDecideByIdAndExpression.java
@@ -12,6 +12,7 @@ id = 007
 scope = (default)public
 excludeScope = (default)(null)
 skipAnnotations = (default)Generated
+violateExecutionOnNonTightHtml = (default)false
 tokens = CLASS_DEF
 
 */

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionxpathsinglefilter/InputSuppressionXpathSingleFilterDecideByMessage.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionxpathsinglefilter/InputSuppressionXpathSingleFilterDecideByMessage.java
@@ -10,6 +10,7 @@ com.puppycrawl.tools.checkstyle.checks.javadoc.MissingJavadocTypeCheck
 scope = (default)public
 excludeScope = (default)(null)
 skipAnnotations = (default)Generated
+violateExecutionOnNonTightHtml = (default)false
 tokens = CLASS_DEF
 
 com.puppycrawl.tools.checkstyle.checks.coding.MagicNumberCheck

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionxpathsinglefilter/InputSuppressionXpathSingleFilterDefaultFileProperty.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionxpathsinglefilter/InputSuppressionXpathSingleFilterDefaultFileProperty.java
@@ -12,6 +12,7 @@ id = 007
 scope = (default)public
 excludeScope = (default)(null)
 skipAnnotations = (default)Generated
+violateExecutionOnNonTightHtml = (default)false
 tokens = CLASS_DEF
 
 */

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionxpathsinglefilter/InputSuppressionXpathSingleFilterMatchingModuleId.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionxpathsinglefilter/InputSuppressionXpathSingleFilterMatchingModuleId.java
@@ -12,6 +12,7 @@ id = 007
 scope = (default)public
 excludeScope = (default)(null)
 skipAnnotations = (default)Generated
+violateExecutionOnNonTightHtml = (default)false
 tokens = CLASS_DEF
 
 */

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionxpathsinglefilter/InputSuppressionXpathSingleFilterMatchingTokenType.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionxpathsinglefilter/InputSuppressionXpathSingleFilterMatchingTokenType.java
@@ -11,6 +11,7 @@ com.puppycrawl.tools.checkstyle.checks.javadoc.MissingJavadocTypeCheck
 scope = (default)public
 excludeScope = (default)(null)
 skipAnnotations = (default)Generated
+violateExecutionOnNonTightHtml = (default)false
 tokens = CLASS_DEF
 
 */

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionxpathsinglefilter/InputSuppressionXpathSingleFilterNoQuery.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionxpathsinglefilter/InputSuppressionXpathSingleFilterNoQuery.java
@@ -10,6 +10,7 @@ com.puppycrawl.tools.checkstyle.checks.javadoc.MissingJavadocTypeCheck
 scope = (default)public
 excludeScope = (default)(null)
 skipAnnotations = (default)Generated
+violateExecutionOnNonTightHtml = (default)false
 tokens = CLASS_DEF
 
 */

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionxpathsinglefilter/InputSuppressionXpathSingleFilterNonMatchingCheck.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionxpathsinglefilter/InputSuppressionXpathSingleFilterNonMatchingCheck.java
@@ -11,6 +11,7 @@ com.puppycrawl.tools.checkstyle.checks.javadoc.MissingJavadocTypeCheck
 scope = (default)public
 excludeScope = (default)(null)
 skipAnnotations = (default)Generated
+violateExecutionOnNonTightHtml = (default)false
 tokens = CLASS_DEF
 
 */

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionxpathsinglefilter/InputSuppressionXpathSingleFilterNonMatchingCheckRegexp.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionxpathsinglefilter/InputSuppressionXpathSingleFilterNonMatchingCheckRegexp.java
@@ -11,6 +11,7 @@ com.puppycrawl.tools.checkstyle.checks.javadoc.MissingJavadocTypeCheck
 scope = (default)public
 excludeScope = (default)(null)
 skipAnnotations = (default)Generated
+violateExecutionOnNonTightHtml = (default)false
 tokens = CLASS_DEF
 
 */

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionxpathsinglefilter/InputSuppressionXpathSingleFilterNonMatchingFileNameModuleIdAndCheck.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionxpathsinglefilter/InputSuppressionXpathSingleFilterNonMatchingFileNameModuleIdAndCheck.java
@@ -12,6 +12,7 @@ id = 007
 scope = (default)public
 excludeScope = (default)(null)
 skipAnnotations = (default)Generated
+violateExecutionOnNonTightHtml = (default)false
 tokens = CLASS_DEF
 
 */

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionxpathsinglefilter/InputSuppressionXpathSingleFilterNonMatchingFileRegexp.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionxpathsinglefilter/InputSuppressionXpathSingleFilterNonMatchingFileRegexp.java
@@ -10,6 +10,7 @@ com.puppycrawl.tools.checkstyle.checks.javadoc.MissingJavadocTypeCheck
 scope = (default)public
 excludeScope = (default)(null)
 skipAnnotations = (default)Generated
+violateExecutionOnNonTightHtml = (default)false
 tokens = CLASS_DEF
 
 */

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionxpathsinglefilter/InputSuppressionXpathSingleFilterNonMatchingLineNumber.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionxpathsinglefilter/InputSuppressionXpathSingleFilterNonMatchingLineNumber.java
@@ -10,6 +10,7 @@ com.puppycrawl.tools.checkstyle.checks.javadoc.MissingJavadocTypeCheck
 scope = package
 excludeScope = (default)(null)
 skipAnnotations = (default)Generated
+violateExecutionOnNonTightHtml = (default)false
 tokens = CLASS_DEF
 
 */

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionxpathsinglefilter/InputSuppressionXpathSingleFilterNonMatchingModuleId.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionxpathsinglefilter/InputSuppressionXpathSingleFilterNonMatchingModuleId.java
@@ -12,6 +12,7 @@ id = 007
 scope = (default)public
 excludeScope = (default)(null)
 skipAnnotations = (default)Generated
+violateExecutionOnNonTightHtml = (default)false
 tokens = CLASS_DEF
 
 */

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionxpathsinglefilter/InputSuppressionXpathSingleFilterNonMatchingTokenType.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionxpathsinglefilter/InputSuppressionXpathSingleFilterNonMatchingTokenType.java
@@ -11,6 +11,7 @@ com.puppycrawl.tools.checkstyle.checks.javadoc.MissingJavadocTypeCheck
 scope = (default)public
 excludeScope = (default)(null)
 skipAnnotations = (default)Generated
+violateExecutionOnNonTightHtml = (default)false
 tokens = CLASS_DEF, INTERFACE_DEF
 
 */

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionxpathsinglefilter/InputSuppressionXpathSingleFilterNullFileName.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionxpathsinglefilter/InputSuppressionXpathSingleFilterNullFileName.java
@@ -10,6 +10,7 @@ com.puppycrawl.tools.checkstyle.checks.javadoc.MissingJavadocTypeCheck
 scope = (default)public
 excludeScope = (default)(null)
 skipAnnotations = (default)Generated
+violateExecutionOnNonTightHtml = (default)false
 tokens = CLASS_DEF
 
 */

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionxpathsinglefilter/InputSuppressionXpathSingleFilterNullModuleIdAndNonMatchingCheck.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionxpathsinglefilter/InputSuppressionXpathSingleFilterNullModuleIdAndNonMatchingCheck.java
@@ -12,6 +12,7 @@ id = 007
 scope = (default)public
 excludeScope = (default)(null)
 skipAnnotations = (default)Generated
+violateExecutionOnNonTightHtml = (default)false
 tokens = CLASS_DEF
 
 */

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionxpathsinglefilter/InputSuppressionXpathSingleFilterNullViolation.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionxpathsinglefilter/InputSuppressionXpathSingleFilterNullViolation.java
@@ -10,6 +10,7 @@ com.puppycrawl.tools.checkstyle.checks.javadoc.MissingJavadocTypeCheck
 scope = (default)public
 excludeScope = (default)(null)
 skipAnnotations = (default)Generated
+violateExecutionOnNonTightHtml = (default)false
 tokens = CLASS_DEF
 
 */

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppresswarningsfilter/InputSuppressWarningsFilter.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppresswarningsfilter/InputSuppressWarningsFilter.java
@@ -38,6 +38,7 @@ com.puppycrawl.tools.checkstyle.checks.javadoc.MissingJavadocTypeCheck
 scope = PRIVATE
 excludeScope = (default)null
 skipAnnotations = (default)Generated
+violateExecutionOnNonTightHtml = (default)false
 tokens = (default)INTERFACE_DEF, CLASS_DEF, ENUM_DEF, ANNOTATION_DEF, RECORD_DEF
 
 */

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppresswarningsfilter/InputSuppressWarningsFilterById.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppresswarningsfilter/InputSuppressWarningsFilterById.java
@@ -38,6 +38,7 @@ com.puppycrawl.tools.checkstyle.checks.javadoc.MissingJavadocTypeCheck
 scope = PRIVATE
 excludeScope = (default)null
 skipAnnotations = (default)Generated
+violateExecutionOnNonTightHtml = (default)false
 tokens = (default)INTERFACE_DEF, CLASS_DEF, ENUM_DEF, ANNOTATION_DEF, RECORD_DEF
 
 */

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppresswarningsfilter/InputSuppressWarningsFilterWithoutFilter.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppresswarningsfilter/InputSuppressWarningsFilterWithoutFilter.java
@@ -33,6 +33,7 @@ com.puppycrawl.tools.checkstyle.checks.javadoc.MissingJavadocTypeCheck
 scope = PRIVATE
 excludeScope = (default)null
 skipAnnotations = (default)Generated
+violateExecutionOnNonTightHtml = (default)false
 tokens = (default)INTERFACE_DEF, CLASS_DEF, ENUM_DEF, ANNOTATION_DEF, RECORD_DEF
 
 */


### PR DESCRIPTION
Issue :#19149
Updated the `MissingJavadocTypeCheck` to use AST.
Extend `AbstractJavadocCheck`.
Remove the Supression from `supression.xml`.
Now MissingJavadocTypeCheck use AST.