### PR TITLE
Issue #19064: Add third test to XpathRegressionNoEnumTrailingCommaTest

### DIFF
--- a/config/checkstyle-non-main-files-suppressions.xml
+++ b/config/checkstyle-non-main-files-suppressions.xml
@@ -427,7 +427,6 @@
   <suppress id="numberOfTestCasesInXpath" files="[\\/]src[\\/]it[\\/]java[\\/]org[\\/]checkstyle[\\/]suppressionxpathfilter[\\/]coding[\\/]XpathRegressionNestedForDepthTest.java" />
   <suppress id="numberOfTestCasesInXpath" files="[\\/]src[\\/]it[\\/]java[\\/]org[\\/]checkstyle[\\/]suppressionxpathfilter[\\/]coding[\\/]XpathRegressionNestedIfDepthTest.java" />
 
-  <suppress id="numberOfTestCasesInXpath" files="[\\/]src[\\/]it[\\/]java[\\/]org[\\/]checkstyle[\\/]suppressionxpathfilter[\\/]coding[\\/]XpathRegressionNoEnumTrailingCommaTest.java" />
   <suppress id="numberOfTestCasesInXpath" files="[\\/]src[\\/]it[\\/]java[\\/]org[\\/]checkstyle[\\/]suppressionxpathfilter[\\/]coding[\\/]XpathRegressionOneStatementPerLineTest.java" />
   <suppress id="numberOfTestCasesInXpath" files="[\\/]src[\\/]it[\\/]java[\\/]org[\\/]checkstyle[\\/]suppressionxpathfilter[\\/]coding[\\/]XpathRegressionOverloadMethodsDeclarationOrderTest.java" />
   <suppress id="numberOfTestCasesInXpath" files="[\\/]src[\\/]it[\\/]java[\\/]org[\\/]checkstyle[\\/]suppressionxpathfilter[\\/]coding[\\/]XpathRegressionPackageDeclarationTest.java" />

--- a/src/it/java/org/checkstyle/suppressionxpathfilter/coding/XpathRegressionNoEnumTrailingCommaTest.java
+++ b/src/it/java/org/checkstyle/suppressionxpathfilter/coding/XpathRegressionNoEnumTrailingCommaTest.java
@@ -86,4 +86,27 @@ public class XpathRegressionNoEnumTrailingCommaTest extends AbstractXpathTestSup
 
         runVerifications(moduleConfig, fileToProcess, expectedViolation, expectedXpathQueries);
     }
+
+    @Test
+    public void testInnerClass() throws Exception {
+        final File fileToProcess = new File(getPath(
+                "InputXpathNoEnumTrailingCommaInnerClass.java"));
+
+        final DefaultConfiguration moduleConfig =
+                createModuleConfig(NoEnumTrailingCommaCheck.class);
+
+        final String[] expectedViolation = {
+            "7:16: " + getCheckMessage(NoEnumTrailingCommaCheck.class,
+                    NoEnumTrailingCommaCheck.MSG_KEY),
+        };
+
+        final List<String> expectedXpathQueries = Collections.singletonList(
+            "/COMPILATION_UNIT/CLASS_DEF"
+                    + "[./IDENT[@text='InputXpathNoEnumTrailingCommaInnerClass']]"
+                    + "/OBJBLOCK/CLASS_DEF[./IDENT[@text='Inner']]/OBJBLOCK/ENUM_DEF"
+                    + "[./IDENT[@text='Foo']]/OBJBLOCK/COMMA[2]"
+        );
+
+        runVerifications(moduleConfig, fileToProcess, expectedViolation, expectedXpathQueries);
+    }
 }

--- a/src/it/resources/org/checkstyle/suppressionxpathfilter/coding/noenumtrailingcomma/InputXpathNoEnumTrailingCommaInnerClass.java
+++ b/src/it/resources/org/checkstyle/suppressionxpathfilter/coding/noenumtrailingcomma/InputXpathNoEnumTrailingCommaInnerClass.java
@@ -1,0 +1,10 @@
+package org.checkstyle.suppressionxpathfilter.coding.noenumtrailingcomma;
+
+public class InputXpathNoEnumTrailingCommaInnerClass {
+    class Inner {
+        enum Foo {
+            ONE,
+            TWO, //warn
+        }
+    }
+}


### PR DESCRIPTION
Issue: #19064

Add third test to XpathRegressionNoEnumTrailingCommaTest to meet the requirement of 3 distinct test methods with different XPath structures.

Changes:
- Added new test method `testInnerClass()` with inner class structure
- Created new input file `InputXpathNoEnumTrailingCommaInnerClass.java`
- Removed suppression for this file from `checkstyle-non-main-files-suppressions.xml`

The three tests now cover different AST structures:
1. Basic enum with trailing comma (existing)
2. Another enum variation (existing)
3. Enum inside inner class (new)

All tests pass with `mvn clean verify`.