### PR TITLE
Issue #16360: Add comments to 3 methods in XMLLoggerTest.java

### DIFF
--- a/src/test/java/com/puppycrawl/tools/checkstyle/XMLLoggerTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/XMLLoggerTest.java
@@ -274,6 +274,14 @@ public class XMLLoggerTest extends AbstractXmlTestSupport {
             .isEqualTo(1);
     }
 
+    /**
+     * Cannot use verifyWithInlineConfigParserAndXmlLogger, because
+     * this test requires an Exception is logged. This cannot be
+     * done right now as the method uses Checker, which only calls
+     * the addError() method. Would be possible if Checker or the
+     * verifyWithInlineConfigParserAndXmlLogger method are modified
+     * to handle addException() calls.
+     */
     @Test
     public void testAddExceptionAfterFileStarted()
             throws Exception {
@@ -297,6 +305,14 @@ public class XMLLoggerTest extends AbstractXmlTestSupport {
             .isEqualTo(1);
     }
 
+    /**
+     * Cannot use verifyWithInlineConfigParserAndXmlLogger, because
+     * this test requires an Exception is logged. This cannot be
+     * done right now as the method uses Checker, which only calls
+     * the addError() method. Would be possible if Checker or the
+     * verifyWithInlineConfigParserAndXmlLogger method are modified
+     * to handle addException() calls.
+     */
     @Test
     public void testAddExceptionBeforeFileFinished()
             throws Exception {
@@ -316,6 +332,14 @@ public class XMLLoggerTest extends AbstractXmlTestSupport {
             .isEqualTo(1);
     }
 
+    /**
+     * Cannot use verifyWithInlineConfigParserAndXmlLogger, because
+     * this test requires an Exception is logged. This cannot be
+     * done right now as the method uses Checker, which only calls
+     * the addError() method. Would be possible if Checker or the
+     * verifyWithInlineConfigParserAndXmlLogger method are modified
+     * to handle addException() calls.
+     */
     @Test
     public void testAddExceptionBetweenFileStartedAndFinished()
             throws Exception {


### PR DESCRIPTION
#16360

Added comments that explain why `verifyWithInlineConfigParserAndXmlLogger()` cannot be applied in methods `testAddExceptionAfterFileStarted()`, `testAddExceptionBeforeFileFinished()`, and `testAddExceptionBetweenFileStartedAndFinished()` in `XMLLogTest.java` right now. This can be achieved by including additional functionalities in `Checker.java` or the `verifyWithInlineConfigParserAndXmlLogger()` method that allow `addException()` to be called.