### PR TITLE
Issue #19064: Add third test to XpathRegressionUnnecessarySemicolonAfterOuterTypeDeclarationTest

### DIFF
--- a/config/checkstyle-non-main-files-suppressions.xml
+++ b/config/checkstyle-non-main-files-suppressions.xml
@@ -432,7 +432,6 @@
   <suppress id="numberOfTestCasesInXpath" files="[\\/]src[\\/]it[\\/]java[\\/]org[\\/]checkstyle[\\/]suppressionxpathfilter[\\/]coding[\\/]XpathRegressionOverloadMethodsDeclarationOrderTest.java" />
   <suppress id="numberOfTestCasesInXpath" files="[\\/]src[\\/]it[\\/]java[\\/]org[\\/]checkstyle[\\/]suppressionxpathfilter[\\/]coding[\\/]XpathRegressionPackageDeclarationTest.java" />
   <suppress id="numberOfTestCasesInXpath" files="[\\/]src[\\/]it[\\/]java[\\/]org[\\/]checkstyle[\\/]suppressionxpathfilter[\\/]coding[\\/]XpathRegressionSimplifyBooleanReturnTest.java" />
-  <suppress id="numberOfTestCasesInXpath" files="[\\/]src[\\/]it[\\/]java[\\/]org[\\/]checkstyle[\\/]suppressionxpathfilter[\\/]coding[\\/]XpathRegressionUnnecessarySemicolonAfterOuterTypeDeclarationTest.java" />
   <suppress id="numberOfTestCasesInXpath" files="[\\/]src[\\/]it[\\/]java[\\/]org[\\/]checkstyle[\\/]suppressionxpathfilter[\\/]coding[\\/]XpathRegressionUnnecessarySemicolonAfterTypeMemberDeclarationTest.java" />
   <suppress id="numberOfTestCasesInXpath" files="[\\/]src[\\/]it[\\/]java[\\/]org[\\/]checkstyle[\\/]suppressionxpathfilter[\\/]coding[\\/]XpathRegressionUnnecessarySemicolonInEnumerationTest.java" />
   <suppress id="numberOfTestCasesInXpath" files="[\\/]src[\\/]it[\\/]java[\\/]org[\\/]checkstyle[\\/]suppressionxpathfilter[\\/]coding[\\/]XpathRegressionUnnecessarySemicolonInTryWithResourcesTest.java" />

--- a/src/it/java/org/checkstyle/suppressionxpathfilter/coding/XpathRegressionUnnecessarySemicolonAfterOuterTypeDeclarationTest.java
+++ b/src/it/java/org/checkstyle/suppressionxpathfilter/coding/XpathRegressionUnnecessarySemicolonAfterOuterTypeDeclarationTest.java
@@ -78,4 +78,21 @@ public class XpathRegressionUnnecessarySemicolonAfterOuterTypeDeclarationTest
 
         runVerifications(moduleConfig, fileToProcess, expectedViolation, expectedXpathQueries);
     }
+
+    @Test
+    public void testAnnotationType() throws Exception {
+        final File fileToProcess = new File(getPath(
+            "InputXpathUnnecessarySemicolonAfterOuterTypeDeclarationAnnotation"
+                    + ".java"));
+        final DefaultConfiguration moduleConfig = createModuleConfig(CLASS);
+        final String[] expectedViolation = {
+            "5:2: " + getCheckMessage(CLASS,
+                UnnecessarySemicolonAfterOuterTypeDeclarationCheck.MSG_SEMI),
+        };
+
+        final List<String> expectedXpathQueries =
+                Collections.singletonList("/COMPILATION_UNIT/SEMI");
+
+        runVerifications(moduleConfig, fileToProcess, expectedViolation, expectedXpathQueries);
+    }
 }

--- a/src/it/resources/org/checkstyle/suppressionxpathfilter/coding/unnecessarysemicolonafteroutertypedeclaration/InputXpathUnnecessarySemicolonAfterOuterTypeDeclarationAnnotation.java
+++ b/src/it/resources/org/checkstyle/suppressionxpathfilter/coding/unnecessarysemicolonafteroutertypedeclaration/InputXpathUnnecessarySemicolonAfterOuterTypeDeclarationAnnotation.java
@@ -1,0 +1,5 @@
+package org.checkstyle.suppressionxpathfilter.coding.unnecessarysemicolonafteroutertypedeclaration;
+
+@interface InputXpathUnnecessarySemicolonAfterOuterTypeDeclarationAnnotation {
+
+}; //warn


### PR DESCRIPTION
Issue: #19064

Add third test to XpathRegressionUnnecessarySemicolonAfterOuterTypeDeclarationTest to meet the requirement of 3 distinct test methods with different XPath structures.

Changes:
- Added new test method `testAnnotationType()` with top-level annotation structure
- Created new input file `InputXpathUnnecessarySemicolonAfterOuterTypeDeclarationAnnotation.java`
- Removed suppression for this file from `checkstyle-non-main-files-suppressions.xml`

The three tests now cover different AST structures:
1. Simple top-level class with semicolon (existing)
2. Top-level interface with multiple inner types (existing)
3. Top-level annotation with semicolon (new)

All tests pass with `mvn clean verify`.