### PR TITLE
Issue #19064: Add third test to XpathRegressionUnnecessarySemicolonInTryWithResourcesTest

### DIFF
--- a/config/checkstyle-non-main-files-suppressions.xml
+++ b/config/checkstyle-non-main-files-suppressions.xml
@@ -432,7 +432,6 @@
   <suppress id="numberOfTestCasesInXpath" files="[\\/]src[\\/]it[\\/]java[\\/]org[\\/]checkstyle[\\/]suppressionxpathfilter[\\/]coding[\\/]XpathRegressionSimplifyBooleanReturnTest.java" />
   <suppress id="numberOfTestCasesInXpath" files="[\\/]src[\\/]it[\\/]java[\\/]org[\\/]checkstyle[\\/]suppressionxpathfilter[\\/]coding[\\/]XpathRegressionUnnecessarySemicolonAfterTypeMemberDeclarationTest.java" />
   <suppress id="numberOfTestCasesInXpath" files="[\\/]src[\\/]it[\\/]java[\\/]org[\\/]checkstyle[\\/]suppressionxpathfilter[\\/]coding[\\/]XpathRegressionUnnecessarySemicolonInEnumerationTest.java" />
-  <suppress id="numberOfTestCasesInXpath" files="[\\/]src[\\/]it[\\/]java[\\/]org[\\/]checkstyle[\\/]suppressionxpathfilter[\\/]coding[\\/]XpathRegressionUnnecessarySemicolonInTryWithResourcesTest.java" />
   <suppress id="numberOfTestCasesInXpath" files="[\\/]src[\\/]it[\\/]java[\\/]org[\\/]checkstyle[\\/]suppressionxpathfilter[\\/]coding[\\/]XpathRegressionUnusedCatchParameterShouldBeUnnamedTest.java" />
   <suppress id="numberOfTestCasesInXpath" files="[\\/]src[\\/]it[\\/]java[\\/]org[\\/]checkstyle[\\/]suppressionxpathfilter[\\/]coding[\\/]XpathRegressionUnusedLambdaParameterShouldBeUnnamedTest.java" />
   <suppress id="numberOfTestCasesInXpath" files="[\\/]src[\\/]it[\\/]java[\\/]org[\\/]checkstyle[\\/]suppressionxpathfilter[\\/]coding[\\/]XpathRegressionVariableDeclarationUsageDistanceTest.java" />

--- a/src/it/java/org/checkstyle/suppressionxpathfilter/coding/XpathRegressionUnnecessarySemicolonInTryWithResourcesTest.java
+++ b/src/it/java/org/checkstyle/suppressionxpathfilter/coding/XpathRegressionUnnecessarySemicolonInTryWithResourcesTest.java
@@ -88,4 +88,27 @@ public class XpathRegressionUnnecessarySemicolonInTryWithResourcesTest
         );
         runVerifications(moduleConfig, fileToProcess, expectedViolation, expectedXpathQueries);
     }
+
+    @Test
+    public void testInnerClass() throws Exception {
+        final File fileToProcess = new File(getPath(
+            "InputXpathUnnecessarySemicolonInTryWithResourcesInnerClass.java"
+        ));
+
+        final DefaultConfiguration moduleConfig =
+            createModuleConfig(UnnecessarySemicolonInTryWithResourcesCheck.class);
+        final String[] expectedViolation = {
+            "9:50: " + getCheckMessage(UnnecessarySemicolonInTryWithResourcesCheck.class,
+                UnnecessarySemicolonInTryWithResourcesCheck.MSG_SEMI),
+        };
+
+        final List<String> expectedXpathQueries = Collections.singletonList(
+            "/COMPILATION_UNIT/CLASS_DEF[./IDENT[@text="
+                + "'InputXpathUnnecessarySemicolonInTryWithResourcesInnerClass']]"
+                + "/OBJBLOCK/CLASS_DEF[./IDENT[@text='Inner']]"
+                + "/OBJBLOCK/METHOD_DEF[./IDENT[@text='test']]"
+                + "/SLIST/LITERAL_TRY/RESOURCE_SPECIFICATION/SEMI"
+        );
+        runVerifications(moduleConfig, fileToProcess, expectedViolation, expectedXpathQueries);
+    }
 }

--- a/src/it/resources/org/checkstyle/suppressionxpathfilter/coding/unnecessarysemicolonintrywithresources/InputXpathUnnecessarySemicolonInTryWithResourcesInnerClass.java
+++ b/src/it/resources/org/checkstyle/suppressionxpathfilter/coding/unnecessarysemicolonintrywithresources/InputXpathUnnecessarySemicolonInTryWithResourcesInnerClass.java
@@ -1,0 +1,12 @@
+package org.checkstyle.suppressionxpathfilter.coding.unnecessarysemicolonintrywithresources;
+
+import java.io.PipedReader;
+import java.io.Reader;
+
+public class InputXpathUnnecessarySemicolonInTryWithResourcesInnerClass {
+    class Inner {
+        void test() throws Exception {
+            try(Reader reader = new PipedReader();){} // warn
+        }
+    }
+}


### PR DESCRIPTION
Issue: #19064

Add third test to XpathRegressionUnnecessarySemicolonInTryWithResourcesTest to meet the requirement of 3 distinct test methods with different XPath structures.

Changes:
- Added new test method `testInnerClass()` with inner class structure
- Created new input file `InputXpathUnnecessarySemicolonInTryWithResourcesInnerClass.java`
- Removed suppression for this file from `checkstyle-non-main-files-suppressions.xml`

The three tests now cover different AST structures:
1. Default try-with-resources with semicolon (existing)
2. No brace after semicolon configuration (existing)
3. Try-with-resources inside inner class (new)

All tests pass with `mvn clean verify`.