### PR TITLE
Issue #17449: remove outdated comment in XdocsExampleFileTest

### DIFF
--- a/src/test/java/com/puppycrawl/tools/checkstyle/XMLLoggerTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/XMLLoggerTest.java
@@ -274,6 +274,14 @@ public class XMLLoggerTest extends AbstractXmlTestSupport {
             .isEqualTo(1);
     }
 
+    /**
+     * Cannot use verifyWithInlineConfigParserAndXmlLogger, because
+     * this test requires an Exception is logged. This cannot be
+     * done right now as the method uses Checker, which only calls
+     * the addError() method. Would be possible if Checker or the
+     * verifyWithInlineConfigParserAndXmlLogger method are modified
+     * to handle addException() calls.
+     */
     @Test
     public void testAddExceptionAfterFileStarted()
             throws Exception {
@@ -297,6 +305,14 @@ public class XMLLoggerTest extends AbstractXmlTestSupport {
             .isEqualTo(1);
     }
 
+    /**
+     * Cannot use verifyWithInlineConfigParserAndXmlLogger, because
+     * this test requires an Exception is logged. This cannot be
+     * done right now as the method uses Checker, which only calls
+     * the addError() method. Would be possible if Checker or the
+     * verifyWithInlineConfigParserAndXmlLogger method are modified
+     * to handle addException() calls.
+     */
     @Test
     public void testAddExceptionBeforeFileFinished()
             throws Exception {
@@ -316,6 +332,14 @@ public class XMLLoggerTest extends AbstractXmlTestSupport {
             .isEqualTo(1);
     }
 
+    /**
+     * Cannot use verifyWithInlineConfigParserAndXmlLogger, because
+     * this test requires an Exception is logged. This cannot be
+     * done right now as the method uses Checker, which only calls
+     * the addError() method. Would be possible if Checker or the
+     * verifyWithInlineConfigParserAndXmlLogger method are modified
+     * to handle addException() calls.
+     */
     @Test
     public void testAddExceptionBetweenFileStartedAndFinished()
             throws Exception {

--- a/src/test/java/com/puppycrawl/tools/checkstyle/internal/XdocsExampleFileTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/internal/XdocsExampleFileTest.java
@@ -55,7 +55,6 @@ public class XdocsExampleFileTest {
         "violateExecutionOnNonTightHtml"
     );
 
-    // This list is temporarily suppressed.
     // Until: https://github.com/checkstyle/checkstyle/issues/17449
     private static final Map<String, Set<String>> SUPPRESSED_PROPERTIES_BY_CHECK = Map.ofEntries(
             Map.entry("SuppressWarningsHolder", Set.of("aliasList")),


### PR DESCRIPTION
Issue #17449  : remove outdated comment in XdocsExampleFileTest

This PR removes an outdated comment in XdocsExampleFileTest.java.
The suppression related to issue #17449 is no longer present, so only the old comment remained.
