### PR TITLE
Issue #19064: Add third test to XpathRegressionMissingSwitchDefaultTest

### DIFF
--- a/config/checkstyle-non-main-files-suppressions.xml
+++ b/config/checkstyle-non-main-files-suppressions.xml
@@ -422,7 +422,6 @@
   <suppress id="numberOfTestCasesInXpath" files="[\\/]src[\\/]it[\\/]java[\\/]org[\\/]checkstyle[\\/]suppressionxpathfilter[\\/]coding[\\/]XpathRegressionHiddenFieldTest.java" />
   <suppress id="numberOfTestCasesInXpath" files="[\\/]src[\\/]it[\\/]java[\\/]org[\\/]checkstyle[\\/]suppressionxpathfilter[\\/]coding[\\/]XpathRegressionInnerAssignmentTest.java" />
   <suppress id="numberOfTestCasesInXpath" files="[\\/]src[\\/]it[\\/]java[\\/]org[\\/]checkstyle[\\/]suppressionxpathfilter[\\/]coding[\\/]XpathRegressionMissingNullCaseInSwitchTest.java" />
-  <suppress id="numberOfTestCasesInXpath" files="[\\/]src[\\/]it[\\/]java[\\/]org[\\/]checkstyle[\\/]suppressionxpathfilter[\\/]coding[\\/]XpathRegressionMissingSwitchDefaultTest.java" />
   <suppress id="numberOfTestCasesInXpath" files="[\\/]src[\\/]it[\\/]java[\\/]org[\\/]checkstyle[\\/]suppressionxpathfilter[\\/]coding[\\/]XpathRegressionNestedForDepthTest.java" />
   <suppress id="numberOfTestCasesInXpath" files="[\\/]src[\\/]it[\\/]java[\\/]org[\\/]checkstyle[\\/]suppressionxpathfilter[\\/]coding[\\/]XpathRegressionNestedIfDepthTest.java" />
 

--- a/src/it/java/org/checkstyle/suppressionxpathfilter/coding/XpathRegressionMissingSwitchDefaultTest.java
+++ b/src/it/java/org/checkstyle/suppressionxpathfilter/coding/XpathRegressionMissingSwitchDefaultTest.java
@@ -89,4 +89,24 @@ public class XpathRegressionMissingSwitchDefaultTest extends AbstractXpathTestSu
 
         runVerifications(moduleConfig, fileToProcess, expectedViolation, expectedXpathQueries);
     }
+
+    @Test
+    public void testStaticBlock() throws Exception {
+        final File fileToProcess =
+                new File(getPath("InputXpathMissingSwitchDefaultStaticBlock.java"));
+
+        final DefaultConfiguration moduleConfig = createModuleConfig(CLAZZ);
+
+        final String[] expectedViolation = {
+            "6:9: " + getCheckMessage(CLAZZ, MissingSwitchDefaultCheck.MSG_KEY),
+        };
+
+        final List<String> expectedXpathQueries = Collections.singletonList(
+            "/COMPILATION_UNIT/CLASS_DEF"
+                    + "[./IDENT[@text='InputXpathMissingSwitchDefaultStaticBlock']]"
+                    + "/OBJBLOCK/STATIC_INIT/SLIST/LITERAL_SWITCH"
+        );
+
+        runVerifications(moduleConfig, fileToProcess, expectedViolation, expectedXpathQueries);
+    }
 }

--- a/src/it/resources/org/checkstyle/suppressionxpathfilter/coding/missingswitchdefault/InputXpathMissingSwitchDefaultStaticBlock.java
+++ b/src/it/resources/org/checkstyle/suppressionxpathfilter/coding/missingswitchdefault/InputXpathMissingSwitchDefaultStaticBlock.java
@@ -1,0 +1,13 @@
+package org.checkstyle.suppressionxpathfilter.coding.missingswitchdefault;
+
+public class InputXpathMissingSwitchDefaultStaticBlock {
+    static {
+        int key = 2;
+        switch (key) { // warn
+            case 1:
+                break;
+            case 2:
+                break;
+        }
+    }
+}


### PR DESCRIPTION
Issue: #19064

Add third test to XpathRegressionMissingSwitchDefaultTest to meet the requirement of 3 distinct test methods with different XPath structures.

Changes:
- Added new test method `testStaticBlock()` with static initializer structure
- Created new input file `InputXpathMissingSwitchDefaultStaticBlock.java`
- Removed suppression for this file from `checkstyle-non-main-files-suppressions.xml`

The three tests now cover different AST structures:
1. Simple switch without default (existing)
2. Nested switch without default (existing)
3. Switch inside static block (new)

All tests pass with `mvn clean verify`.