### PR TITLE
Issue #11629: RightCurly: Google style config does not detect misplac…

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/blocks/RightCurlyCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/blocks/RightCurlyCheck.java
@@ -239,10 +239,41 @@ public class RightCurlyCheck extends AbstractCheck {
     private static boolean isAloneOnLine(Details details, String targetSrcLine) {
         final DetailAST rcurly = details.rcurly();
         final DetailAST nextToken = details.nextToken();
-        return (nextToken == null || !TokenUtil.areOnSameLine(rcurly, nextToken)
+
+        // Ignore trailing semicolon after class/enum/annotation/interface definitions
+        final boolean nextTokenOnSameLine = nextToken != null
+                && TokenUtil.areOnSameLine(rcurly, nextToken)
+                && !isTrailingSemicolonAfterDefinition(rcurly, nextToken);
+
+        return (!nextTokenOnSameLine
             || skipDoubleBraceInstInit(details))
             && CommonUtil.hasWhitespaceBefore(details.rcurly().getColumnNo(),
                targetSrcLine);
+    }
+
+    /**
+     * Checks whether the right curly is followed by a semicolon that belongs to a
+     * class, enum, annotation, interface, or record definition.
+     *
+     * @param rcurly the right curly token to check
+     * @param nextToken the token following the right curly
+     * @return true if the right curly is followed by a semicolon that belongs to a
+     *     class, enum, annotation, interface, or record definition
+     */
+    private static boolean isTrailingSemicolonAfterDefinition(DetailAST rcurly,
+                                                              DetailAST nextToken) {
+        boolean isTrailingSemicolonAfterDefinition = false;
+        if (nextToken.getType() == TokenTypes.SEMI) {
+            final DetailAST parent = rcurly.getParent();
+            final DetailAST grandParent = parent.getParent();
+            isTrailingSemicolonAfterDefinition = TokenUtil.isOfType(grandParent.getType(),
+                    TokenTypes.CLASS_DEF,
+                    TokenTypes.ENUM_DEF,
+                    TokenTypes.ANNOTATION_DEF,
+                    TokenTypes.INTERFACE_DEF,
+                    TokenTypes.RECORD_DEF);
+        }
+        return isTrailingSemicolonAfterDefinition;
     }
 
     /**

--- a/src/main/resources/google_checks.xml
+++ b/src/main/resources/google_checks.xml
@@ -145,7 +145,16 @@
       <property name="id" value="RightCurlyAlone"/>
       <property name="query" value="//RCURLY[parent::SLIST[count(./*)=1
                                and not(parent::LITERAL_CATCH)]
-                               or (preceding-sibling::*[last()][self::LCURLY]
+                               or parent::OBJBLOCK[
+                               count(*[not(self::LCURLY or self::RCURLY or self::SEMI
+                               or self::SINGLE_LINE_COMMENT
+                               or self::BLOCK_COMMENT_BEGIN)])=0
+                               and not(*[self::SINGLE_LINE_COMMENT
+                               or self::BLOCK_COMMENT_BEGIN][following-sibling::RCURLY])]
+                               or (parent::OBJBLOCK and preceding-sibling::*[1]
+                               [self::ENUM_CONSTANT_DEF or self::METHOD_DEF
+                               or self::CTOR_DEF or self::COMPACT_CTOR_DEF])
+                               or (preceding-sibling::*[last()][self::LCURLY] and parent::SLIST
                                and not(parent::SLIST/parent::LITERAL_CATCH))
                                or (parent::SLIST/parent::LITERAL_CATCH
                                and parent::SLIST/parent::LITERAL_CATCH/following-sibling::*)]"/>

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/blocks/RightCurlyCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/blocks/RightCurlyCheckTest.java
@@ -70,7 +70,6 @@ public class RightCurlyCheckTest extends AbstractModuleTestSupport {
             "29:17: " + getCheckMessage(MSG_KEY_LINE_SAME, "}", 17),
             "41:13: " + getCheckMessage(MSG_KEY_LINE_SAME, "}", 13),
             "45:13: " + getCheckMessage(MSG_KEY_LINE_SAME, "}", 13),
-            "87:5: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}", 5),
             "94:27: " + getCheckMessage(MSG_KEY_LINE_BREAK_BEFORE, "}", 27),
             "189:9: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}", 9),
             "190:41: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}", 41),
@@ -114,7 +113,6 @@ public class RightCurlyCheckTest extends AbstractModuleTestSupport {
     @Test
     public void testNewLine() throws Exception {
         final String[] expected = {
-            "86:5: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}", 5),
             "111:5: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}", 5),
             "111:6: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}", 6),
             "122:5: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}", 5),
@@ -138,7 +136,6 @@ public class RightCurlyCheckTest extends AbstractModuleTestSupport {
     @Test
     public void testShouldStartLine2() throws Exception {
         final String[] expected = {
-            "86:5: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}", 5),
             "111:5: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}", 5),
             "111:6: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}", 6),
             "122:5: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}", 5),
@@ -243,7 +240,6 @@ public class RightCurlyCheckTest extends AbstractModuleTestSupport {
             "231:31: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}", 31),
             "234:5: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}", 5),
             "236:29: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}", 29),
-            "239:5: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}", 5),
             "242:30: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}", 30),
             "245:9: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}", 9),
             "248:39: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}", 39),
@@ -251,8 +247,6 @@ public class RightCurlyCheckTest extends AbstractModuleTestSupport {
             "253:24: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}", 24),
             "263:29: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}", 29),
             "265:40: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}", 40),
-            "269:5: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}", 5),
-            "272:5: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}", 5),
             "274:61: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}", 61),
         };
         verifyWithInlineConfigParser(
@@ -482,18 +476,11 @@ public class RightCurlyCheckTest extends AbstractModuleTestSupport {
     public void testBlocksEndingWithSemiOptionSame() throws Exception {
         final String[] expected = {
             "16:5: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}", 5),
-            "21:5: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}", 5),
             "27:9: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}", 9),
             "35:29: " + getCheckMessage(MSG_KEY_LINE_BREAK_BEFORE, "}", 29),
-            "41:5: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}", 5),
-            "44:5: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}", 5),
             "51:20: " + getCheckMessage(MSG_KEY_LINE_BREAK_BEFORE, "}", 20),
-            "57:5: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}", 5),
-            "60:5: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}", 5),
             "65:30: " + getCheckMessage(MSG_KEY_LINE_BREAK_BEFORE, "}", 30),
-            "74:9: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}", 9),
             "74:11: " + getCheckMessage(MSG_KEY_LINE_BREAK_BEFORE, "}", 11),
-            "78:5: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}", 5),
         };
         verifyWithInlineConfigParser(
                 getPath("InputRightCurlyTestOptSameBlocksWithSemi.java"), expected);
@@ -505,23 +492,16 @@ public class RightCurlyCheckTest extends AbstractModuleTestSupport {
             "13:31: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}", 31),
             "16:5: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}", 5),
             "18:29: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}", 29),
-            "21:5: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}", 5),
             "24:30: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}", 30),
             "27:9: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}", 9),
             "35:29: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}", 29),
             "37:40: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}", 40),
-            "41:5: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}", 5),
-            "44:5: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}", 5),
             "46:61: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}", 61),
             "48:19: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}", 19),
             "51:20: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}", 20),
             "53:34: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}", 34),
-            "57:5: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}", 5),
-            "60:5: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}", 5),
             "65:30: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}", 30),
-            "71:9: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}", 9),
             "71:11: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}", 11),
-            "75:5: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}", 5),
         };
         verifyWithInlineConfigParser(
                 getPath("InputRightCurlyTestOptAloneBlocksWithSemi.java"), expected);
@@ -531,18 +511,11 @@ public class RightCurlyCheckTest extends AbstractModuleTestSupport {
     public void testBlocksEndingWithSemiOptionAloneOrSingleLine() throws Exception {
         final String[] expected = {
             "16:5: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}", 5),
-            "21:5: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}", 5),
             "27:9: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}", 9),
             "35:29: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}", 29),
-            "41:5: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}", 5),
-            "44:5: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}", 5),
             "51:20: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}", 20),
-            "57:5: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}", 5),
-            "60:5: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}", 5),
             "65:30: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}", 30),
-            "74:9: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}", 9),
             "74:11: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}", 11),
-            "78:5: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}", 5),
         };
         verifyWithInlineConfigParser(
                 getPath("InputRightCurlyTestOptAloneOrSingleLineBlocksWithSemi.java"), expected);
@@ -990,5 +963,14 @@ public class RightCurlyCheckTest extends AbstractModuleTestSupport {
         };
         final String fileName = "InputRightCurlySwitchWhen.java";
         verifyWithInlineConfigParser(getNonCompilablePath(fileName), expected);
+    }
+
+    @Test
+    public void testAnnotationAndEnum() throws Exception {
+        final String[] expected = {
+            "18:33: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}", 33),
+            "28:25: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}", 25),
+        };
+        verifyWithInlineConfigParser(getPath("InputRightCurlyAnnotationAndEnum.java"), expected);
     }
 }

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/blocks/rightcurly/InputRightCurlyAnnotationAndEnum.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/blocks/rightcurly/InputRightCurlyAnnotationAndEnum.java
@@ -1,0 +1,33 @@
+/*
+RightCurly
+option = ALONE_OR_SINGLELINE
+tokens = CLASS_DEF, METHOD_DEF, LITERAL_IF, LITERAL_ELSE, LITERAL_DO, LITERAL_WHILE, \
+         LITERAL_FOR, STATIC_INIT, INSTANCE_INIT, ANNOTATION_DEF, ENUM_DEF, INTERFACE_DEF
+
+
+*/
+
+package com.puppycrawl.tools.checkstyle.checks.blocks.rightcurly;
+
+public class InputRightCurlyAnnotationAndEnum {
+      public @interface TestAnnotation {}
+
+      public @interface TestAnnotation1 { String someValue(); }
+
+      public @interface TestAnnotation2 {
+            String someValue(); }  // violation ''}' at column 33 should be alone on a line'
+
+      public @interface TestAnnotation3 {
+            String someValue();
+      }
+
+      public @interface TestAnnotation4 { String someValue();
+      }
+
+      enum TestEnum2 {
+            SOME_VALUE; } // violation ''}' at column 25 should be alone on a line'
+
+      public @interface LimitedPrivate {
+          String[] value();
+      };
+}

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/blocks/rightcurly/InputRightCurlyLeftTestNewLine.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/blocks/rightcurly/InputRightCurlyLeftTestNewLine.java
@@ -83,7 +83,7 @@ class InputRightCurlyLeftTestNewLine
     {
         HELLO,
         GOODBYE
-    }; // violation ''}' at column 5 should be alone on a line'
+    };
 
     void method2()
     {

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/blocks/rightcurly/InputRightCurlyLeftTestSame.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/blocks/rightcurly/InputRightCurlyLeftTestSame.java
@@ -84,7 +84,7 @@ class InputRightCurlyLeftTestSame
     {
         HELLO,
         GOODBYE
-    }; // violation ''}' at column 5 should be alone on a line'
+    };
 
     void method2()
     {

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/blocks/rightcurly/InputRightCurlyLeftTestShouldStartLine2.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/blocks/rightcurly/InputRightCurlyLeftTestShouldStartLine2.java
@@ -83,7 +83,7 @@ class InputRightCurlyLeftTestShouldStartLine2
     {
         HELLO,
         GOODBYE
-    }; // violation ''}' at column 5 should be alone on a line'
+    };
 
     void method2()
     {

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/blocks/rightcurly/InputRightCurlyTestOptAloneBlocksWithSemi.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/blocks/rightcurly/InputRightCurlyTestOptAloneBlocksWithSemi.java
@@ -18,7 +18,7 @@ public class InputRightCurlyTestOptAloneBlocksWithSemi {
     public class TestClass {}; // violation ''}' at column 29 should be alone on a line'
 
     public class TestClass1 {
-    }; // violation ''}' at column 5 should be alone on a line'
+    };
 
     public class TestClass2 {
         public TestClass2() {}; // violation ''}' at column 30 should be alone on a line'
@@ -38,10 +38,10 @@ public class InputRightCurlyTestOptAloneBlocksWithSemi {
 
     public @interface TestAnnotation7 {
         String someValue();
-    }; // violation ''}' at column 5 should be alone on a line'
+    };
 
     public @interface TestAnnotation8 { String someValue();
-    }; // violation ''}' at column 5 should be alone on a line'
+    };
     // violation below ''}' at column 61 should be alone on a line'
     public @interface TestAnnotation9 { String someValue(); };
 
@@ -54,10 +54,10 @@ public class InputRightCurlyTestOptAloneBlocksWithSemi {
 
     enum TestEnum3{
         SOME_VALUE;
-    }; // violation ''}' at column 5 should be alone on a line'
+    };
 
     enum TestEnum4{ SOME_VALUE;
-    }; // violation ''}' at column 5 should be alone on a line'
+    };
 
     interface Interface1
     {
@@ -68,9 +68,9 @@ public class InputRightCurlyTestOptAloneBlocksWithSemi {
         void display();
         interface Interface4 {
             void myMethod();
-        };}; // 2 violations
+        };}; // violation ''}' at column 11 should be alone on a line'
 
     interface InterfaceEndingWithSemiColon2 {
         public void fooEmpty();
-    }; // violation ''}' at column 5 should be alone on a line'
+    };
 }

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/blocks/rightcurly/InputRightCurlyTestOptAloneOrSingleLineBlocksWithSemi.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/blocks/rightcurly/InputRightCurlyTestOptAloneOrSingleLineBlocksWithSemi.java
@@ -18,7 +18,7 @@ public class InputRightCurlyTestOptAloneOrSingleLineBlocksWithSemi {
     public class TestClass {};
 
     public class TestClass1 {
-    }; // violation ''}' at column 5 should be alone on a line'
+    };
 
     public class TestClass2 {
         public TestClass2() {};
@@ -38,10 +38,10 @@ public class InputRightCurlyTestOptAloneOrSingleLineBlocksWithSemi {
 
     public @interface TestAnnotation7 {
         String someValue();
-    }; // violation ''}' at column 5 should be alone on a line'
+    };
 
     public @interface TestAnnotation8 { String someValue();
-    }; // violation ''}' at column 5 should be alone on a line'
+    };
 
     public @interface TestAnnotation9 { String someValue(); };
 
@@ -54,10 +54,10 @@ public class InputRightCurlyTestOptAloneOrSingleLineBlocksWithSemi {
 
     enum TestEnum3{
         SOME_VALUE;
-    }; // violation ''}' at column 5 should be alone on a line'
+    };
 
     enum TestEnum4{ SOME_VALUE;
-    }; // violation ''}' at column 5 should be alone on a line'
+    };
 
     interface Interface1
     {
@@ -71,9 +71,9 @@ public class InputRightCurlyTestOptAloneOrSingleLineBlocksWithSemi {
         void display();
         interface Interface4 {
             void myMethod();
-        };}; // 2 violations
+        };}; // violation ''}' at column 11 should be alone on a line'
 
     interface InterfaceEndingWithSemiColon2 {
         public void fooEmpty();
-    }; // violation ''}' at column 5 should be alone on a line'
+    };
 }

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/blocks/rightcurly/InputRightCurlyTestOptSameBlocksWithSemi.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/blocks/rightcurly/InputRightCurlyTestOptSameBlocksWithSemi.java
@@ -18,7 +18,7 @@ public class InputRightCurlyTestOptSameBlocksWithSemi {
     public class TestClass {};
 
     public class TestClass1 {
-    }; // violation ''}' at column 5 should be alone on a line'
+    };
 
     public class TestClass2 {
         public TestClass2() {};
@@ -38,10 +38,10 @@ public class InputRightCurlyTestOptSameBlocksWithSemi {
 
     public @interface TestAnnotation7 {
         String someValue();
-    }; // violation ''}' at column 5 should be alone on a line'
+    };
 
     public @interface TestAnnotation8 { String someValue();
-    }; // violation ''}' at column 5 should be alone on a line'
+    };
 
     public @interface TestAnnotation9 { String someValue(); };
 
@@ -54,10 +54,10 @@ public class InputRightCurlyTestOptSameBlocksWithSemi {
 
     enum TestEnum3{
         SOME_VALUE;
-    }; // violation ''}' at column 5 should be alone on a line'
+    };
 
     enum TestEnum4{ SOME_VALUE;
-    }; // violation ''}' at column 5 should be alone on a line'
+    };
 
     interface Interface1
     {
@@ -71,9 +71,9 @@ public class InputRightCurlyTestOptSameBlocksWithSemi {
         void display();
         interface Interface4 {
             void myMethod();
-        };}; // 2 violations
+        };}; // violation ''}' at column 11 should have line break before'
 
     interface InterfaceEndingWithSemiColon2 {
         public void fooEmpty();
-    }; // violation ''}' at column 5 should be alone on a line'
+    };
 }

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/blocks/rightcurly/InputRightCurlyTestWithAnnotations.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/blocks/rightcurly/InputRightCurlyTestWithAnnotations.java
@@ -236,7 +236,7 @@ class InputRightCurlyTestWithAnnotations
     public class TestClass {}; // violation ''}' at column 29 should be alone on a line'
 
     public class TestClass1 {
-    }; // violation ''}' at column 5 should be alone on a line'
+    };
 
     public class TestClass2 {
         public TestClass2() {}; // violation ''}' at column 30 should be alone on a line'
@@ -266,10 +266,10 @@ class InputRightCurlyTestWithAnnotations
 
     public @interface TestAnnotation7 {
         String someValue();
-    }; // violation ''}' at column 5 should be alone on a line'
+    };
 
     public @interface TestAnnotation8 { String someValue();
-    }; // violation ''}' at column 5 should be alone on a line'
+    };
 
     public @interface TestAnnotation9 { String someValue(); };
     // violation above ''}' at column 61 should be alone on a line'


### PR DESCRIPTION
Issue #11629: RightCurly: Google style config does not detect misplaced '}' for annotation declaration and enum

he previous suppression condition or (preceding-sibling::*[last()][self::LCURLY] ...) was too broad.
In some AST shapes, LCURLY and RCURLY can appear next to each other even when the block is not truly empty

so i replaced it with stricter OBJBLOCK aware matching

Diff Regression config: https://gist.githubusercontent.com/Youssefalaa7/884844b7ce14839564d555c5b726f170/raw/01f0401aa24bb25a79ecb8f0f0148097c1f6b945/google_checks_base.xml

Diff Regression patch config: https://gist.githubusercontent.com/Youssefalaa7/9828bb52ad7e104cb21ed108e4e5590f/raw/1608c0290026bf21bbe0b896667b8e35b5d8abef/patch_config.xml