### PR TITLE
Issue #4997: Column number in DetailAST should start with 1

### DIFF
--- a/config/checker-framework-suppressions/checker-nullness-optional-interning-suppressions.xml
+++ b/config/checker-framework-suppressions/checker-nullness-optional-interning-suppressions.xml
@@ -5635,7 +5635,7 @@
     <fileName>src/main/java/com/puppycrawl/tools/checkstyle/checks/indentation/MethodCallHandler.java</fileName>
     <specifier>argument</specifier>
     <message>incompatible argument for parameter ast of AbstractExpressionHandler.getLineStart.</message>
-    <lineContent>if (getLineStart(rparen) == rparen.getColumnNo()) {</lineContent>
+    <lineContent>if (getLineStart(rparen) == rparen.getColumnNo() - 1) {</lineContent>
     <details>
       found   : @Initialized @Nullable DetailAST
       required: @Initialized @NonNull DetailAST
@@ -7128,7 +7128,7 @@
     <fileName>src/main/java/com/puppycrawl/tools/checkstyle/checks/whitespace/NoWhitespaceAfterCheck.java</fileName>
     <specifier>dereference.of.nullable</specifier>
     <message>dereference of possibly-null reference endOfParams</message>
-    <lineContent>after = endOfParams.getColumnNo() + 1;</lineContent>
+    <lineContent>after = endOfParams.getColumnNo();</lineContent>
   </checkerFrameworkError>
 
   <checkerFrameworkError unstable="false">

--- a/config/jsoref-spellchecker/whitelist.words
+++ b/config/jsoref-spellchecker/whitelist.words
@@ -866,6 +866,7 @@ multiplevariabledeclarations
 Multiset
 multithreading
 mutableexception
+mutationtest
 MVC
 mvn
 mvnrepository

--- a/config/pitest-suppressions/pitest-filters-suppressions.xml
+++ b/config/pitest-suppressions/pitest-filters-suppressions.xml
@@ -1,3 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <suppressedMutations>
+  <mutation unstable="false">
+    <sourceFile>XpathFilterElement.java</sourceFile>
+    <mutatedClass>com.puppycrawl.tools.checkstyle.filters.XpathFilterElement</mutatedClass>
+    <mutatedMethod>isXpathQueryMatching</mutatedMethod>
+    <mutator>org.pitest.mutationtest.engine.gregor.mutators.RemoveConditionalMutator_EQUAL_IF</mutator>
+    <description>removed conditional - replaced equality check with true</description>
+    <lineContent>isMatching = abstractNode.getTokenType() == event.getTokenType()</lineContent>
+  </mutation>
 </suppressedMutations>

--- a/src/main/java/com/puppycrawl/tools/checkstyle/AstTreeStringPrinter.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/AstTreeStringPrinter.java
@@ -185,7 +185,7 @@ public final class AstTreeStringPrinter {
     private static String getNodeInfo(DetailAST node) {
         return TokenUtil.getTokenName(node.getType())
                 + " -> " + escapeAllControlChars(node.getText())
-                + " [" + node.getLineNo() + ':' + (node.getColumnNo() + 1) + ']';
+                + " [" + node.getLineNo() + ':' + node.getColumnNo() + ']';
     }
 
     /**

--- a/src/main/java/com/puppycrawl/tools/checkstyle/DetailAstImpl.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/DetailAstImpl.java
@@ -106,7 +106,7 @@ public final class DetailAstImpl implements DetailAST {
         text = token.getText();
         type = token.getType();
         lineNo = token.getLine();
-        columnNo = token.getCharPositionInLine();
+        columnNo = token.getCharPositionInLine() + 1;
     }
 
     /**

--- a/src/main/java/com/puppycrawl/tools/checkstyle/JavaParser.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/JavaParser.java
@@ -68,6 +68,9 @@ public final class JavaParser {
 
     }
 
+    /** Text for single-line comments. */
+    private static final String SINGLE_LINE_COMMENT_TEXT = "//";
+
     /** Stop instances being created. **/
     private JavaParser() {
     }
@@ -224,16 +227,17 @@ public final class JavaParser {
     private static DetailAST createSlCommentNode(Token token) {
         final DetailAstImpl slComment = new DetailAstImpl();
         slComment.setType(TokenTypes.SINGLE_LINE_COMMENT);
-        slComment.setText("//");
+        slComment.setText(SINGLE_LINE_COMMENT_TEXT);
 
-        slComment.setColumnNo(token.getCharPositionInLine());
+        slComment.setColumnNo(token.getCharPositionInLine() + 1);
         slComment.setLineNo(token.getLine());
 
         final DetailAstImpl slCommentContent = new DetailAstImpl();
         slCommentContent.setType(TokenTypes.COMMENT_CONTENT);
 
         // plus length of '//'
-        slCommentContent.setColumnNo(token.getCharPositionInLine() + 2);
+        slCommentContent.setColumnNo(token.getCharPositionInLine()
+                + SINGLE_LINE_COMMENT_TEXT.length() + 1);
         slCommentContent.setLineNo(token.getLine());
         slCommentContent.setText(token.getText());
 

--- a/src/main/java/com/puppycrawl/tools/checkstyle/JavadocDetailNodeParser.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/JavadocDetailNodeParser.java
@@ -116,7 +116,7 @@ public class JavadocDetailNodeParser {
 
         try {
             final JavadocCommentsParser.JavadocContext javadoc = parser.javadoc();
-            final int javadocColumnNumber = javadocCommentAst.getColumnNo()
+            final int javadocColumnNumber = javadocCommentAst.getColumnNo() - 1
                             + JAVADOC_START.length();
 
             final JavadocCommentsAstVisitor visitor = new JavadocCommentsAstVisitor(

--- a/src/main/java/com/puppycrawl/tools/checkstyle/api/AbstractCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/api/AbstractCheck.java
@@ -273,7 +273,7 @@ public abstract class AbstractCheck extends AbstractViolationReporter {
         // is increased by one.
 
         final int col = 1 + CommonUtil.lengthExpandedTabs(
-                getLines()[ast.getLineNo() - 1], ast.getColumnNo(), tabWidth);
+                getLines()[ast.getLineNo() - 1], ast.getColumnNo() - 1, tabWidth);
         context.get().violations.add(
                 new Violation(
                         ast.getLineNo(),

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/SuppressWarningsHolder.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/SuppressWarningsHolder.java
@@ -300,7 +300,7 @@ public class SuppressWarningsHolder
     private static void addSuppressions(List<String> values, DetailAST targetAST) {
         // get text range of target
         final int firstLine = targetAST.getLineNo();
-        final int firstColumn = targetAST.getColumnNo();
+        final int firstColumn = targetAST.getColumnNo() - 1;
         final DetailAST nextAST = targetAST.getNextSibling();
         final int lastLine;
         final int lastColumn;
@@ -310,7 +310,7 @@ public class SuppressWarningsHolder
         }
         else {
             lastLine = nextAST.getLineNo();
-            lastColumn = nextAST.getColumnNo();
+            lastColumn = nextAST.getColumnNo() - 1;
         }
 
         final List<Entry> entries = ENTRIES.get();

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/TrailingCommentCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/TrailingCommentCheck.java
@@ -175,7 +175,7 @@ public class TrailingCommentCheck extends AbstractCheck {
         final int lineNo = ast.getLineNo();
         final String comment = ast.getFirstChild().getText();
         final int[] lineBeforeCodePoints =
-                Arrays.copyOfRange(getLineCodePoints(lineNo - 1), 0, ast.getColumnNo());
+                Arrays.copyOfRange(getLineCodePoints(lineNo - 1), 0, ast.getColumnNo() - 1);
         final String lineBefore = new String(lineBeforeCodePoints, 0, lineBeforeCodePoints.length);
 
         if (!format.matcher(lineBefore).find() && !isLegalCommentContent(comment)) {
@@ -195,16 +195,16 @@ public class TrailingCommentCheck extends AbstractCheck {
         final String comment = firstChild.getText();
         int[] lineCodePoints = getLineCodePoints(lineNo - 1);
 
-        if (lineCodePoints.length > lastChild.getColumnNo() + 1) {
+        if (lineCodePoints.length > lastChild.getColumnNo()) {
             lineCodePoints = Arrays.copyOfRange(lineCodePoints,
-                    lastChild.getColumnNo() + 2, lineCodePoints.length);
+                    lastChild.getColumnNo() + 1, lineCodePoints.length);
         }
 
         String line = new String(lineCodePoints, 0, lineCodePoints.length);
         line = FORMAT_LINE.matcher(line).replaceAll("");
 
         final int[] lineBeforeCodePoints =
-                Arrays.copyOfRange(getLineCodePoints(lineNo - 1), 0, ast.getColumnNo());
+                Arrays.copyOfRange(getLineCodePoints(lineNo - 1), 0, ast.getColumnNo() - 1);
         final String lineBefore = new String(lineBeforeCodePoints, 0, lineBeforeCodePoints.length);
         final boolean isCommentAtEndOfLine = ast.getLineNo() != lastChild.getLineNo()
                 || CommonUtil.isBlank(line);

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/annotation/AnnotationLocationCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/annotation/AnnotationLocationCheck.java
@@ -227,7 +227,8 @@ public class AnnotationLocationCheck extends AbstractCheck {
             }
             else if (annotation.getColumnNo() != correctIndentation && !hasNodeBefore(annotation)) {
                 log(annotation, MSG_KEY_ANNOTATION_LOCATION,
-                    getAnnotationName(annotation), annotation.getColumnNo(), correctIndentation);
+                    getAnnotationName(annotation), annotation.getColumnNo() - 1,
+                    correctIndentation - 1);
             }
             annotation = annotation.getNextSibling();
         }

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/blocks/EmptyBlockCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/blocks/EmptyBlockCheck.java
@@ -171,7 +171,7 @@ public class EmptyBlockCheck
         if (slistLineNo == rcurlyLineNo) {
             // Handle braces on the same line
             final int[] txt = Arrays.copyOfRange(getLineCodePoints(slistLineNo - 1),
-                    slistColNo + 1, rcurlyColNo);
+                    slistColNo, rcurlyColNo - 1);
 
             if (!CodePointUtil.isBlank(txt)) {
                 returnValue = true;
@@ -180,9 +180,9 @@ public class EmptyBlockCheck
         else {
             final int[] codePointsFirstLine = getLineCodePoints(slistLineNo - 1);
             final int[] firstLine = Arrays.copyOfRange(codePointsFirstLine,
-                    slistColNo + 1, codePointsFirstLine.length);
+                    slistColNo, codePointsFirstLine.length);
             final int[] codePointsLastLine = getLineCodePoints(rcurlyLineNo - 1);
-            final int[] lastLine = Arrays.copyOfRange(codePointsLastLine, 0, rcurlyColNo);
+            final int[] lastLine = Arrays.copyOfRange(codePointsLastLine, 0, rcurlyColNo - 1);
             // check if all lines are also only whitespace
             returnValue = !(CodePointUtil.isBlank(firstLine) && CodePointUtil.isBlank(lastLine))
                     || !checkIsAllLinesAreWhitespace(slistLineNo, rcurlyLineNo);

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/blocks/LeftCurlyCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/blocks/LeftCurlyCheck.java
@@ -278,11 +278,11 @@ public class LeftCurlyCheck
         final String braceLine = getLine(brace.getLineNo() - 1);
 
         // Check for being told to ignore, or have '{}' which is a special case
-        if (braceLine.length() <= brace.getColumnNo() + 1
-                || braceLine.charAt(brace.getColumnNo() + 1) != '}') {
+        if (braceLine.length() <= brace.getColumnNo()
+                || braceLine.charAt(brace.getColumnNo()) != '}') {
             if (option == LeftCurlyOption.NL) {
-                if (!CommonUtil.hasWhitespaceBefore(brace.getColumnNo(), braceLine)) {
-                    log(brace, MSG_KEY_LINE_NEW, OPEN_CURLY_BRACE, brace.getColumnNo() + 1);
+                if (!CommonUtil.hasWhitespaceBefore(brace.getColumnNo() - 1, braceLine)) {
+                    log(brace, MSG_KEY_LINE_NEW, OPEN_CURLY_BRACE, brace.getColumnNo());
                 }
             }
             else if (option == LeftCurlyOption.EOL) {
@@ -301,11 +301,11 @@ public class LeftCurlyCheck
      * @param braceLine line content
      */
     private void validateEol(DetailAST brace, String braceLine) {
-        if (CommonUtil.hasWhitespaceBefore(brace.getColumnNo(), braceLine)) {
-            log(brace, MSG_KEY_LINE_PREVIOUS, OPEN_CURLY_BRACE, brace.getColumnNo() + 1);
+        if (CommonUtil.hasWhitespaceBefore(brace.getColumnNo() - 1, braceLine)) {
+            log(brace, MSG_KEY_LINE_PREVIOUS, OPEN_CURLY_BRACE, brace.getColumnNo());
         }
         if (!hasLineBreakAfter(brace)) {
-            log(brace, MSG_KEY_LINE_BREAK_AFTER, OPEN_CURLY_BRACE, brace.getColumnNo() + 1);
+            log(brace, MSG_KEY_LINE_BREAK_AFTER, OPEN_CURLY_BRACE, brace.getColumnNo());
         }
     }
 
@@ -319,15 +319,15 @@ public class LeftCurlyCheck
     private void validateNewLinePosition(DetailAST brace, DetailAST startToken, String braceLine) {
         // not on the same line
         if (startToken.getLineNo() + 1 == brace.getLineNo()) {
-            if (CommonUtil.hasWhitespaceBefore(brace.getColumnNo(), braceLine)) {
-                log(brace, MSG_KEY_LINE_PREVIOUS, OPEN_CURLY_BRACE, brace.getColumnNo() + 1);
+            if (CommonUtil.hasWhitespaceBefore(brace.getColumnNo() - 1, braceLine)) {
+                log(brace, MSG_KEY_LINE_PREVIOUS, OPEN_CURLY_BRACE, brace.getColumnNo());
             }
             else {
-                log(brace, MSG_KEY_LINE_NEW, OPEN_CURLY_BRACE, brace.getColumnNo() + 1);
+                log(brace, MSG_KEY_LINE_NEW, OPEN_CURLY_BRACE, brace.getColumnNo());
             }
         }
-        else if (!CommonUtil.hasWhitespaceBefore(brace.getColumnNo(), braceLine)) {
-            log(brace, MSG_KEY_LINE_NEW, OPEN_CURLY_BRACE, brace.getColumnNo() + 1);
+        else if (!CommonUtil.hasWhitespaceBefore(brace.getColumnNo() - 1, braceLine)) {
+            log(brace, MSG_KEY_LINE_NEW, OPEN_CURLY_BRACE, brace.getColumnNo());
         }
     }
 

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/blocks/RightCurlyCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/blocks/RightCurlyCheck.java
@@ -132,7 +132,7 @@ public class RightCurlyCheck extends AbstractCheck {
         if (rcurly != null) {
             final String violation = validate(details);
             if (!violation.isEmpty()) {
-                log(rcurly, violation, "}", rcurly.getColumnNo() + 1);
+                log(rcurly, violation, "}", rcurly.getColumnNo());
             }
         }
     }
@@ -241,7 +241,7 @@ public class RightCurlyCheck extends AbstractCheck {
         final DetailAST nextToken = details.nextToken();
         return (nextToken == null || !TokenUtil.areOnSameLine(rcurly, nextToken)
             || skipDoubleBraceInstInit(details))
-            && CommonUtil.hasWhitespaceBefore(details.rcurly().getColumnNo(),
+            && CommonUtil.hasWhitespaceBefore(details.rcurly().getColumnNo() - 1,
                targetSrcLine);
     }
 

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/indentation/AbstractExpressionHandler.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/indentation/AbstractExpressionHandler.java
@@ -486,7 +486,7 @@ public abstract class AbstractExpressionHandler {
         final String line =
             indentCheck.getLine(ast.getLineNo() - 1);
 
-        return CommonUtil.lengthExpandedTabs(line, ast.getColumnNo(),
+        return CommonUtil.lengthExpandedTabs(line, ast.getColumnNo() - 1,
             indentCheck.getIndentationTabWidth());
     }
 

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/indentation/CommentsIndentationCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/indentation/CommentsIndentationCheck.java
@@ -127,7 +127,7 @@ public class CommentsIndentationCheck extends AbstractCheck {
             else if (nextStmt != null && !areSameLevelIndented(comment, nextStmt, nextStmt)
                     && !areInSameMethodCallWithSameIndent(comment)) {
                 log(comment, getMessageKey(comment), nextStmt.getLineNo(),
-                    comment.getColumnNo(), nextStmt.getColumnNo());
+                    comment.getColumnNo() - 1, nextStmt.getColumnNo() - 1);
             }
         }
     }
@@ -486,7 +486,7 @@ public class CommentsIndentationCheck extends AbstractCheck {
                     || prevStmt.getType() == TokenTypes.LITERAL_DEFAULT) {
                 if (comment.getColumnNo() < nextStmt.getColumnNo()) {
                     log(comment, getMessageKey(comment), nextStmt.getLineNo(),
-                        comment.getColumnNo(), nextStmt.getColumnNo());
+                        comment.getColumnNo() - 1, nextStmt.getColumnNo() - 1);
                 }
             }
             else if (isCommentForMultiblock(nextStmt)) {
@@ -497,7 +497,7 @@ public class CommentsIndentationCheck extends AbstractCheck {
             else if (!areSameLevelIndented(comment, prevStmt, prevStmt)) {
                 final int prevStmtLineNo = prevStmt.getLineNo();
                 log(comment, getMessageKey(comment), prevStmtLineNo,
-                        comment.getColumnNo(), getLineStart(prevStmtLineNo));
+                        comment.getColumnNo() - 1, getLineStart(prevStmtLineNo));
             }
         }
     }
@@ -542,7 +542,7 @@ public class CommentsIndentationCheck extends AbstractCheck {
     private void handleCommentInEmptyCodeBlock(DetailAST comment, DetailAST nextStmt) {
         if (comment.getColumnNo() < nextStmt.getColumnNo()) {
             log(comment, getMessageKey(comment), nextStmt.getLineNo(),
-                comment.getColumnNo(), nextStmt.getColumnNo());
+                comment.getColumnNo() - 1, nextStmt.getColumnNo() - 1);
         }
     }
 
@@ -741,7 +741,7 @@ public class CommentsIndentationCheck extends AbstractCheck {
         final String multilineNoTemplate = "%d, %d";
         log(comment, getMessageKey(comment),
             String.format(Locale.getDefault(), multilineNoTemplate, prevStmt.getLineNo(),
-                nextStmt.getLineNo()), comment.getColumnNo(),
+                nextStmt.getLineNo()), comment.getColumnNo() - 1,
             String.format(Locale.getDefault(), multilineNoTemplate,
                     getLineStart(prevStmt.getLineNo()), getLineStart(nextStmt.getLineNo())));
     }
@@ -857,8 +857,8 @@ public class CommentsIndentationCheck extends AbstractCheck {
      */
     private boolean areSameLevelIndented(DetailAST comment, DetailAST prevStmt,
                                                 DetailAST nextStmt) {
-        return comment.getColumnNo() == getLineStart(nextStmt.getLineNo())
-            || comment.getColumnNo() == getLineStart(prevStmt.getLineNo());
+        return comment.getColumnNo() - 1 == getLineStart(nextStmt.getLineNo())
+            || comment.getColumnNo() - 1 == getLineStart(prevStmt.getLineNo());
     }
 
     /**
@@ -908,7 +908,7 @@ public class CommentsIndentationCheck extends AbstractCheck {
     private boolean isTrailingSingleLineComment(DetailAST singleLineComment) {
         final String targetSourceLine = getLine(singleLineComment.getLineNo() - 1);
         final int commentColumnNo = singleLineComment.getColumnNo();
-        return !CommonUtil.hasWhitespaceBefore(commentColumnNo, targetSourceLine);
+        return !CommonUtil.hasWhitespaceBefore(commentColumnNo - 1, targetSourceLine);
     }
 
     /**
@@ -928,7 +928,7 @@ public class CommentsIndentationCheck extends AbstractCheck {
         final String commentLine = getLine(blockComment.getLineNo() - 1);
         final int commentColumnNo = blockComment.getColumnNo();
         final DetailAST nextSibling = blockComment.getNextSibling();
-        return !CommonUtil.hasWhitespaceBefore(commentColumnNo, commentLine)
+        return !CommonUtil.hasWhitespaceBefore(commentColumnNo - 1, commentLine)
             || nextSibling != null && TokenUtil.areOnSameLine(nextSibling, blockComment);
     }
 

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/indentation/DetailAstSet.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/indentation/DetailAstSet.java
@@ -135,7 +135,7 @@ public class DetailAstSet {
         final String line =
             indentCheck.getLine(ast.getLineNo() - 1);
 
-        return CommonUtil.lengthExpandedTabs(line, ast.getColumnNo(),
+        return CommonUtil.lengthExpandedTabs(line, ast.getColumnNo() - 1,
             indentCheck.getIndentationTabWidth());
     }
 

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/indentation/LineWrappingHandler.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/indentation/LineWrappingHandler.java
@@ -403,7 +403,7 @@ public class LineWrappingHandler {
         final String line =
             indentCheck.getLine(ast.getLineNo() - 1);
 
-        return CommonUtil.lengthExpandedTabs(line, ast.getColumnNo(),
+        return CommonUtil.lengthExpandedTabs(line, ast.getColumnNo() - 1,
             indentCheck.getIndentationTabWidth());
     }
 

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/indentation/MethodCallHandler.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/indentation/MethodCallHandler.java
@@ -182,7 +182,7 @@ public class MethodCallHandler extends AbstractExpressionHandler {
 
         // If the right parenthesis is at the start of a line;
         // include line wrapping in suggested indent level.
-        if (getLineStart(rparen) == rparen.getColumnNo()) {
+        if (getLineStart(rparen) == rparen.getColumnNo() - 1) {
             suggestedLevel = IndentLevel.addAcceptable(suggestedLevel, new IndentLevel(
                     getParent().getSuggestedChildIndent(this),
                     getIndentCheck().getLineWrappingIndentation()

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/indentation/NewHandler.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/indentation/NewHandler.java
@@ -121,7 +121,7 @@ public class NewHandler extends AbstractExpressionHandler {
         IndentLevel result;
         // if our expression isn't first on the line, just use the start
         // of the line
-        if (getLineStart(mainAst) == mainAst.getColumnNo()) {
+        if (getLineStart(mainAst) == mainAst.getColumnNo() - 1) {
             result = super.getIndentImpl();
 
             final boolean isLineWrappedNew = TokenUtil.isOfType(mainAst.getParent().getParent(),

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/whitespace/AbstractParenPadCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/whitespace/AbstractParenPadCheck.java
@@ -87,7 +87,7 @@ public abstract class AbstractParenPadCheck
      */
     protected void processLeft(DetailAST ast) {
         final int[] line = getLineCodePoints(ast.getLineNo() - 1);
-        final int after = ast.getColumnNo() + 1;
+        final int after = ast.getColumnNo();
 
         if (after < line.length) {
             final boolean hasWhitespaceAfter =
@@ -108,7 +108,7 @@ public abstract class AbstractParenPadCheck
      * @param ast the token representing a right parentheses
      */
     protected void processRight(DetailAST ast) {
-        final int before = ast.getColumnNo() - 1;
+        final int before = ast.getColumnNo() - 2;
         if (before >= 0) {
             final int[] line = getLineCodePoints(ast.getLineNo() - 1);
             final boolean hasPrecedingWhitespace =

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/whitespace/EmptyForInitializerPadCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/whitespace/EmptyForInitializerPadCheck.java
@@ -94,9 +94,9 @@ public class EmptyForInitializerPadCheck
         if (!ast.hasChildren()) {
             final int lineIdx = ast.getLineNo() - 1;
             final int[] line = getLineCodePoints(lineIdx);
-            final int before = ast.getColumnNo() - 1;
+            final int before = ast.getColumnNo() - 2;
             // don't check if semi at beginning of line
-            if (ast.getColumnNo() > 0 && !CodePointUtil.hasWhitespaceBefore(before, line)) {
+            if (ast.getColumnNo() > 1 && !CodePointUtil.hasWhitespaceBefore(before, line)) {
                 if (option == PadOption.NOSPACE
                     && CommonUtil.isCodePointWhitespace(line, before)) {
                     log(ast, MSG_PRECEDED, SEMICOLON);

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/whitespace/EmptyForIteratorPadCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/whitespace/EmptyForIteratorPadCheck.java
@@ -95,7 +95,7 @@ public class EmptyForIteratorPadCheck
             // empty for iterator. test pad after semi.
             final DetailAST semi = ast.getPreviousSibling();
             final int[] line = getLineCodePoints(semi.getLineNo() - 1);
-            final int after = semi.getColumnNo() + 1;
+            final int after = semi.getColumnNo();
             // don't check if at end of line
             if (after < line.length) {
                 if (option == PadOption.NOSPACE

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/whitespace/GenericWhitespaceCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/whitespace/GenericWhitespaceCheck.java
@@ -143,8 +143,8 @@ public class GenericWhitespaceCheck extends AbstractCheck {
      */
     private void processEnd(DetailAST ast) {
         final int[] line = getLineCodePoints(ast.getLineNo() - 1);
-        final int before = ast.getColumnNo() - 1;
-        final int after = ast.getColumnNo() + 1;
+        final int before = ast.getColumnNo() - 2;
+        final int after = ast.getColumnNo();
 
         if (before >= 0 && CommonUtil.isCodePointWhitespace(line, before)
                 && !containsWhitespaceBefore(before, line)) {
@@ -298,8 +298,8 @@ public class GenericWhitespaceCheck extends AbstractCheck {
      */
     private void processStart(DetailAST ast) {
         final int[] line = getLineCodePoints(ast.getLineNo() - 1);
-        final int before = ast.getColumnNo() - 1;
-        final int after = ast.getColumnNo() + 1;
+        final int before = ast.getColumnNo() - 2;
+        final int after = ast.getColumnNo();
 
         // Checks if generic needs to be preceded by a whitespace or not.
         // Handles 3 cases as in:

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/whitespace/MethodParamPadCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/whitespace/MethodParamPadCheck.java
@@ -112,13 +112,13 @@ public class MethodParamPadCheck
 
         if (parenAST != null) {
             final int[] line = getLineCodePoints(parenAST.getLineNo() - 1);
-            if (CodePointUtil.hasWhitespaceBefore(parenAST.getColumnNo(), line)) {
+            if (CodePointUtil.hasWhitespaceBefore(parenAST.getColumnNo() - 1, line)) {
                 if (!allowLineBreaks) {
                     log(parenAST, MSG_LINE_PREVIOUS, parenAST.getText());
                 }
             }
             else {
-                final int before = parenAST.getColumnNo() - 1;
+                final int before = parenAST.getColumnNo() - 2;
                 if (option == PadOption.NOSPACE
                     && CommonUtil.isCodePointWhitespace(line, before)) {
                     log(parenAST, MSG_WS_PRECEDED, parenAST.getText());

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/whitespace/NoWhitespaceAfterCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/whitespace/NoWhitespaceAfterCheck.java
@@ -191,10 +191,10 @@ public class NoWhitespaceAfterCheck extends AbstractCheck {
                 && ast.getNextSibling().getType() == TokenTypes.LPAREN) {
             final DetailAST methodDef = ast.getParent();
             final DetailAST endOfParams = methodDef.findFirstToken(TokenTypes.RPAREN);
-            after = endOfParams.getColumnNo() + 1;
+            after = endOfParams.getColumnNo();
         }
         else {
-            after = ast.getColumnNo() + ast.getText().length();
+            after = ast.getColumnNo() - 1 + ast.getText().length();
         }
         return after;
     }

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/whitespace/NoWhitespaceBeforeCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/whitespace/NoWhitespaceBeforeCheck.java
@@ -87,7 +87,7 @@ public class NoWhitespaceBeforeCheck
     @Override
     public void visitToken(DetailAST ast) {
         final int[] line = getLineCodePoints(ast.getLineNo() - 1);
-        final int columnNoBeforeToken = ast.getColumnNo() - 1;
+        final int columnNoBeforeToken = ast.getColumnNo() - 2;
         final boolean isFirstToken = columnNoBeforeToken == -1;
 
         if ((isFirstToken || CommonUtil.isCodePointWhitespace(line, columnNoBeforeToken))

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/whitespace/SeparatorWrapCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/whitespace/SeparatorWrapCheck.java
@@ -98,7 +98,7 @@ public class SeparatorWrapCheck
     @Override
     public void visitToken(DetailAST ast) {
         final String text = ast.getText();
-        final int colNo = ast.getColumnNo();
+        final int colNo = ast.getColumnNo() - 1;
         final int lineNo = ast.getLineNo();
         final int[] currentLine = getLineCodePoints(lineNo - 1);
         final boolean isLineEmptyAfterToken = CodePointUtil.isBlank(

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/whitespace/SingleSpaceSeparatorCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/whitespace/SingleSpaceSeparatorCheck.java
@@ -117,7 +117,7 @@ public class SingleSpaceSeparatorCheck extends AbstractCheck {
         DetailAST currentNode = node;
 
         do {
-            final int columnNo = currentNode.getColumnNo() - 1;
+            final int columnNo = currentNode.getColumnNo() - 2;
 
             // in such expression: "j  =123", placed at the start of the string index of the second
             // space character will be: 2 = 0(j) + 1(whitespace) + 1(whitespace). It is a minimal

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/whitespace/WhitespaceAfterCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/whitespace/WhitespaceAfterCheck.java
@@ -150,7 +150,7 @@ public class WhitespaceAfterCheck
      */
     private static boolean isFollowedByWhitespace(DetailAST targetAST, int... line) {
         final int after =
-            targetAST.getColumnNo() + targetAST.getText().length();
+            targetAST.getColumnNo() - 1 + targetAST.getText().length();
         boolean followedByWhitespace = true;
 
         if (after < line.length) {

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/whitespace/WhitespaceAroundCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/whitespace/WhitespaceAroundCheck.java
@@ -333,8 +333,8 @@ public class WhitespaceAroundCheck extends AbstractCheck {
         final int currentType = ast.getType();
         if (!isNotRelevantSituation(ast, currentType)) {
             final int[] line = getLineCodePoints(ast.getLineNo() - 1);
-            final int before = ast.getColumnNo() - 1;
-            final int after = ast.getColumnNo() + ast.getText().length();
+            final int before = ast.getColumnNo() - 2;
+            final int after = ast.getColumnNo() - 1 + ast.getText().length();
 
             if (before >= 0 && shouldCheckSeparationFromPreviousToken(ast)
                         && !CommonUtil.isCodePointWhitespace(line, before)) {

--- a/src/main/java/com/puppycrawl/tools/checkstyle/gui/CodeSelectorPresentation.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/gui/CodeSelectorPresentation.java
@@ -103,7 +103,7 @@ public class CodeSelectorPresentation {
      * @param ast DetailAST node for which selection finds
      */
     private void findSelectionPositions(DetailAST ast) {
-        selectionStart = lines2position.get(ast.getLineNo()) + ast.getColumnNo();
+        selectionStart = lines2position.get(ast.getLineNo()) + ast.getColumnNo() - 1;
 
         if (ast.hasChildren() || !TokenUtil.getTokenName(ast.getType()).equals(ast.getText())) {
             selectionEnd = findLastPosition(ast);
@@ -137,7 +137,7 @@ public class CodeSelectorPresentation {
             lastPosition = findLastPosition(astNode.getLastChild());
         }
         else {
-            lastPosition = lines2position.get(astNode.getLineNo()) + astNode.getColumnNo()
+            lastPosition = lines2position.get(astNode.getLineNo()) + astNode.getColumnNo() - 1
                     + astNode.getText().length();
         }
         return lastPosition;

--- a/src/main/java/com/puppycrawl/tools/checkstyle/utils/ParserUtil.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/utils/ParserUtil.java
@@ -55,7 +55,7 @@ public final class ParserUtil {
         blockCommentBegin.setType(TokenTypes.BLOCK_COMMENT_BEGIN);
         blockCommentBegin.setText(BLOCK_MULTIPLE_COMMENT_BEGIN);
         blockCommentBegin.setLineNo(0);
-        blockCommentBegin.setColumnNo(-JAVADOC_START.length());
+        blockCommentBegin.setColumnNo(-JAVADOC_START.length() + 1);
 
         final DetailAstImpl commentContent = new DetailAstImpl();
         commentContent.setType(TokenTypes.COMMENT_CONTENT);
@@ -88,14 +88,15 @@ public final class ParserUtil {
         final int tokenLine = token.getLine();
         final String tokenText = token.getText();
 
-        blockComment.setColumnNo(tokenCharPositionInLine);
+        blockComment.setColumnNo(tokenCharPositionInLine + 1);
         blockComment.setLineNo(tokenLine);
 
         final DetailAstImpl blockCommentContent = new DetailAstImpl();
         blockCommentContent.setType(TokenTypes.COMMENT_CONTENT);
 
         // Add length of '/*'
-        blockCommentContent.setColumnNo(tokenCharPositionInLine + 2);
+        blockCommentContent.setColumnNo(tokenCharPositionInLine
+                + BLOCK_MULTIPLE_COMMENT_BEGIN.length() + 1);
         blockCommentContent.setLineNo(tokenLine);
         blockCommentContent.setText(tokenText);
 
@@ -105,7 +106,7 @@ public final class ParserUtil {
         final Map.Entry<Integer, Integer> linesColumns = countLinesColumns(
                 tokenText, tokenLine, tokenCharPositionInLine + 1);
         blockCommentClose.setLineNo(linesColumns.getKey());
-        blockCommentClose.setColumnNo(linesColumns.getValue());
+        blockCommentClose.setColumnNo(linesColumns.getValue() + 1);
 
         blockComment.addChild(blockCommentContent);
         blockComment.addChild(blockCommentClose);

--- a/src/main/java/com/puppycrawl/tools/checkstyle/xpath/XpathQueryGenerator.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/xpath/XpathQueryGenerator.java
@@ -320,7 +320,7 @@ public class XpathQueryGenerator {
      */
     private int expandedTabColumn(DetailAST ast) {
         return 1 + CommonUtil.lengthExpandedTabs(fileText.get(lineNumber - 1),
-                ast.getColumnNo(), tabWidth);
+                ast.getColumnNo() - 1, tabWidth);
     }
 
     /**

--- a/src/test/java/com/puppycrawl/tools/checkstyle/DetailAstImplTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/DetailAstImplTest.java
@@ -123,7 +123,7 @@ public class DetailAstImplTest extends AbstractModuleTestSupport {
             .isEqualTo(2);
         assertWithMessage("Invalid column number")
             .that(ast.getColumnNo())
-            .isEqualTo(3);
+            .isEqualTo(4);
     }
 
     @Test

--- a/src/test/java/com/puppycrawl/tools/checkstyle/JavaParserTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/JavaParserTest.java
@@ -77,7 +77,7 @@ public class JavaParserTest extends AbstractModuleTestSupport {
             .isEqualTo(3);
         assertWithMessage("Unexpected column number")
             .that(comment.getColumnNo())
-            .isEqualTo(0);
+            .isEqualTo(1);
         assertWithMessage("Unexpected comment content")
             .that(comment.getText())
             .isEqualTo("/*");
@@ -90,13 +90,13 @@ public class JavaParserTest extends AbstractModuleTestSupport {
             .isEqualTo(3);
         assertWithMessage("Unexpected column number")
             .that(commentContent.getColumnNo())
-            .isEqualTo(2);
+            .isEqualTo(3);
         assertWithMessage("Unexpected line number")
             .that(commentEnd.getLineNo())
             .isEqualTo(9);
         assertWithMessage("Unexpected column number")
             .that(commentEnd.getColumnNo())
-            .isEqualTo(1);
+            .isEqualTo(2);
     }
 
     @Test
@@ -118,7 +118,7 @@ public class JavaParserTest extends AbstractModuleTestSupport {
             .isEqualTo(13);
         assertWithMessage("Unexpected column number")
             .that(comment.getColumnNo())
-            .isEqualTo(0);
+            .isEqualTo(1);
         assertWithMessage("Unexpected comment content")
             .that(comment.getText())
             .isEqualTo("//");
@@ -133,7 +133,7 @@ public class JavaParserTest extends AbstractModuleTestSupport {
             .isEqualTo(13);
         assertWithMessage("Unexpected column number")
             .that(commentContent.getColumnNo())
-            .isEqualTo(2);
+            .isEqualTo(3);
         assertWithMessage("Unexpected comment content")
                 .that(commentContent.getText())
                 .startsWith(" inline comment");
@@ -158,7 +158,7 @@ public class JavaParserTest extends AbstractModuleTestSupport {
             .isEqualTo(1);
         assertWithMessage("Unexpected column number")
             .that(comment.getColumnNo())
-            .isEqualTo(4);
+            .isEqualTo(5);
         assertWithMessage("Unexpected comment content")
             .that(comment.getText())
             .isEqualTo("//");
@@ -173,7 +173,7 @@ public class JavaParserTest extends AbstractModuleTestSupport {
             .isEqualTo(1);
         assertWithMessage("Unexpected column number")
             .that(commentContent.getColumnNo())
-            .isEqualTo(6);
+            .isEqualTo(7);
         assertWithMessage("Unexpected comment content")
                 .that(commentContent.getText())
                 .startsWith(" indented comment");
@@ -224,10 +224,10 @@ public class JavaParserTest extends AbstractModuleTestSupport {
 
         assertWithMessage("Invalid line comments")
             .that(counter.lineComments)
-            .isEqualTo(Arrays.asList("1,4", "6,4", "9,0"));
+            .isEqualTo(Arrays.asList("1,5", "6,5", "9,1"));
         assertWithMessage("Invalid block comments")
             .that(counter.blockComments)
-            .isEqualTo(Arrays.asList("5,4", "8,0"));
+            .isEqualTo(Arrays.asList("5,5", "8,1"));
     }
 
     @Test
@@ -252,7 +252,7 @@ public class JavaParserTest extends AbstractModuleTestSupport {
             .isEqualTo(5);
         assertWithMessage("Unexpected column number")
             .that(content.getColumnNo())
-            .isEqualTo(32);
+            .isEqualTo(33);
         assertWithMessage("Unexpected text block content")
             .that(content.getText())
             .isEqualTo(expectedContents);

--- a/src/test/java/com/puppycrawl/tools/checkstyle/api/AbstractCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/api/AbstractCheckTest.java
@@ -383,7 +383,7 @@ public class AbstractCheckTest extends AbstractModuleTestSupport {
                 .isEqualTo(1);
         assertWithMessage("expected column")
                 .that(firstViolation.getColumnNo())
-                .isEqualTo(5);
+                .isEqualTo(4);
         assertWithMessage("expected severity level")
                 .that(firstViolation.getSeverityLevel())
                 .isEqualTo(SeverityLevel.ERROR);

--- a/src/test/java/com/puppycrawl/tools/checkstyle/api/FullIdentTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/api/FullIdentTest.java
@@ -92,7 +92,7 @@ public class FullIdentTest extends AbstractModuleTestSupport {
         final FullIdent ident = FullIdent.createFullIdent(packageName);
         assertWithMessage("Invalid full indent")
                 .that(ident.getDetailAst().toString())
-                .isEqualTo("com[1x8]");
+                .isEqualTo("com[1x9]");
     }
 
     @Test
@@ -126,7 +126,7 @@ public class FullIdentTest extends AbstractModuleTestSupport {
         final FullIdent ident = FullIdent.createFullIdent(arrayDeclarator);
         assertWithMessage("Invalid full indent")
                 .that(ident.toString())
-                .isEqualTo("int[][][5x12]");
+                .isEqualTo("int[][][5x13]");
     }
 
     @Test
@@ -153,7 +153,7 @@ public class FullIdentTest extends AbstractModuleTestSupport {
         final FullIdent ident = FullIdent.createFullIdent(parameter);
         assertWithMessage("Invalid full indent")
                 .that(ident.toString())
-                .isEqualTo("char[][7x29]");
+                .isEqualTo("char[][7x30]");
     }
 
     @Test
@@ -177,7 +177,7 @@ public class FullIdentTest extends AbstractModuleTestSupport {
         final FullIdent ident = FullIdent.createFullIdent(literalInt);
         assertWithMessage("Invalid full indent")
                 .that(ident.toString())
-                .isEqualTo("int[4x32]");
+                .isEqualTo("int[4x33]");
     }
 
     private static FullIdent prepareFullIdentWithCoordinates(int columnNo, int lineNo) {

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/design/MutableExceptionCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/design/MutableExceptionCheckTest.java
@@ -139,7 +139,7 @@ public class MutableExceptionCheckTest extends AbstractModuleTestSupport {
         // exception is expected
         assertWithMessage("Invalid exception message")
                 .that(exc.getMessage())
-                .isEqualTo("interface[0x-1]");
+                .isEqualTo("interface[0x0]");
     }
 
 }

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/metrics/BooleanExpressionComplexityCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/metrics/BooleanExpressionComplexityCheckTest.java
@@ -82,7 +82,7 @@ public class BooleanExpressionComplexityCheckTest extends AbstractModuleTestSupp
                         () -> booleanExpressionComplexityCheckObj.visitToken(ast));
         assertWithMessage("Invalid exception message")
             .that(exc.getMessage())
-            .isEqualTo("Unknown type: interface[0x-1]");
+            .isEqualTo("Unknown type: interface[0x0]");
     }
 
     @Test

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/metrics/ClassDataAbstractionCouplingCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/metrics/ClassDataAbstractionCouplingCheckTest.java
@@ -150,7 +150,7 @@ public class ClassDataAbstractionCouplingCheckTest extends AbstractModuleTestSup
                         () -> classDataAbstractionCouplingCheckObj.visitToken(ast));
         assertWithMessage("Invalid exception message")
             .that(exc.getMessage())
-            .isEqualTo("Unknown type: ctor[0x-1]");
+            .isEqualTo("Unknown type: ctor[0x0]");
     }
 
     @Test

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/sizes/ExecutableStatementCountCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/sizes/ExecutableStatementCountCheckTest.java
@@ -138,7 +138,7 @@ public class ExecutableStatementCountCheckTest
                         () -> checkObj.visitToken(ast));
         assertWithMessage("Invalid exception message")
             .that(visit.getMessage())
-            .isEqualTo("ENUM[0x-1]");
+            .isEqualTo("ENUM[0x0]");
     }
 
     @Test
@@ -153,7 +153,7 @@ public class ExecutableStatementCountCheckTest
                         () -> checkObj.leaveToken(ast));
         assertWithMessage("Invalid exception message")
             .that(leave.getMessage())
-            .isEqualTo("ENUM[0x-1]");
+            .isEqualTo("ENUM[0x0]");
     }
 
     @Test

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/whitespace/GenericWhitespaceCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/whitespace/GenericWhitespaceCheckTest.java
@@ -326,7 +326,7 @@ public class GenericWhitespaceCheckTest
             });
         assertWithMessage("Invalid exception message")
             .that(exc.getMessage())
-            .isEqualTo("Unknown type interface[0x-1]");
+            .isEqualTo("Unknown type interface[0x0]");
     }
 
     @Test

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/whitespace/MethodParamPadCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/whitespace/MethodParamPadCheckTest.java
@@ -256,4 +256,5 @@ public class MethodParamPadCheckTest
         verifyWithInlineConfigParser(
                 getPath("InputMethodParamPadCheckRecordPattern2.java"), expected);
     }
+
 }

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/whitespace/NoWhitespaceAfterCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/whitespace/NoWhitespaceAfterCheckTest.java
@@ -238,7 +238,7 @@ public class NoWhitespaceAfterCheckTest
             });
         assertWithMessage("Invalid exception message")
             .that(exc.getMessage())
-            .isEqualTo("unexpected ast syntax import[0x-1]");
+            .isEqualTo("unexpected ast syntax import[0x0]");
     }
 
     @Test

--- a/src/test/java/com/puppycrawl/tools/checkstyle/filters/XpathFilterElementTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/filters/XpathFilterElementTest.java
@@ -64,7 +64,7 @@ public class XpathFilterElementTest extends AbstractModuleTestSupport {
         final String xpath = "//CLASS_DEF[./IDENT[@text='InputXpathFilterElementSuppressByXpath']]";
         final XpathFilterElement filter = new XpathFilterElement(
                 "InputXpathFilterElementSuppressByXpath", "Test", null, null, xpath);
-        final TreeWalkerAuditEvent ev = getEvent(3, 0,
+        final TreeWalkerAuditEvent ev = getEvent(3, 1,
                 TokenTypes.CLASS_DEF);
         assertWithMessage("Event should be rejected")
                 .that(filter.accept(ev))
@@ -114,11 +114,11 @@ public class XpathFilterElementTest extends AbstractModuleTestSupport {
                 + "| //VARIABLE_DEF[./IDENT[@text='someVariable'] and ../../IDENT[@text='sum']]";
         final XpathFilterElement filter = new XpathFilterElement(
                 "InputXpathFilterElementSuppressByXpath", "Test", null, null, xpath);
-        final TreeWalkerAuditEvent eventOne = getEvent(5, 8,
+        final TreeWalkerAuditEvent eventOne = getEvent(5, 9,
                 TokenTypes.VARIABLE_DEF);
         final TreeWalkerAuditEvent eventTwo = getEvent(10, 4,
                 TokenTypes.VARIABLE_DEF);
-        final TreeWalkerAuditEvent eventThree = getEvent(15, 8,
+        final TreeWalkerAuditEvent eventThree = getEvent(15, 9,
                 TokenTypes.VARIABLE_DEF);
         assertWithMessage("Event should be rejected")
                 .that(filter.accept(eventOne))
@@ -187,7 +187,7 @@ public class XpathFilterElementTest extends AbstractModuleTestSupport {
     public void testNonMatchingFileRegexp() throws Exception {
         final XpathFilterElement filter =
                 new XpathFilterElement("NonMatchingRegexp", "Test", null, null, null);
-        final TreeWalkerAuditEvent ev = getEvent(3, 0,
+        final TreeWalkerAuditEvent ev = getEvent(3, 1,
                 TokenTypes.CLASS_DEF);
         assertWithMessage("Event should be accepted")
                 .that(filter.accept(ev))
@@ -199,7 +199,7 @@ public class XpathFilterElementTest extends AbstractModuleTestSupport {
         final Pattern pattern = Pattern.compile("NonMatchingRegexp");
         final XpathFilterElement filter =
                 new XpathFilterElement(pattern, null, null, null, null);
-        final TreeWalkerAuditEvent ev = getEvent(3, 0,
+        final TreeWalkerAuditEvent ev = getEvent(3, 1,
                 TokenTypes.CLASS_DEF);
         assertWithMessage("Event should be accepted")
                 .that(filter.accept(ev))
@@ -211,7 +211,7 @@ public class XpathFilterElementTest extends AbstractModuleTestSupport {
         final Pattern pattern = Pattern.compile("NonMatchingRegexp");
         final XpathFilterElement filter =
                 new XpathFilterElement(null, pattern, null, null, null);
-        final TreeWalkerAuditEvent ev = getEvent(3, 0,
+        final TreeWalkerAuditEvent ev = getEvent(3, 1,
                 TokenTypes.CLASS_DEF);
         assertWithMessage("Event should be accepted")
                 .that(filter.accept(ev))
@@ -234,7 +234,7 @@ public class XpathFilterElementTest extends AbstractModuleTestSupport {
         final XpathFilterElement filter = new XpathFilterElement(
                 "InputXpathFilterElementSuppressByXpath", "Test", null, "id19", null);
         final Violation message =
-                new Violation(3, 0, TokenTypes.CLASS_DEF, "", "", null, null, "id20",
+                new Violation(3, 1, TokenTypes.CLASS_DEF, "", "", null, null, "id20",
                         getClass(), null);
         final TreeWalkerAuditEvent ev = new TreeWalkerAuditEvent(fileContents, file.getName(),
                 message, JavaParser.parseFile(file, JavaParser.Options.WITHOUT_COMMENTS));
@@ -249,7 +249,7 @@ public class XpathFilterElementTest extends AbstractModuleTestSupport {
         final XpathFilterElement filter = new XpathFilterElement(
                 "InputXpathFilterElementSuppressByXpath", "Test", null, "id19", xpath);
         final Violation message =
-                new Violation(3, 0, TokenTypes.CLASS_DEF, "", "", null, null, "id19",
+                new Violation(3, 1, TokenTypes.CLASS_DEF, "", "", null, null, "id19",
                         getClass(), null);
         final TreeWalkerAuditEvent ev = new TreeWalkerAuditEvent(fileContents, file.getName(),
                 message, JavaParser.parseFile(file, JavaParser.Options.WITHOUT_COMMENTS));
@@ -264,7 +264,7 @@ public class XpathFilterElementTest extends AbstractModuleTestSupport {
         final XpathFilterElement filter = new XpathFilterElement(
                 "InputXpathFilterElementSuppressByXpath", "NonMatchingRegexp", null, "id19", xpath);
         final Violation message =
-                new Violation(3, 0, TokenTypes.CLASS_DEF, "", "", null, null, "id19",
+                new Violation(3, 1, TokenTypes.CLASS_DEF, "", "", null, null, "id19",
                         getClass(), null);
         final TreeWalkerAuditEvent ev = new TreeWalkerAuditEvent(fileContents, file.getName(),
                 message, JavaParser.parseFile(file, JavaParser.Options.WITHOUT_COMMENTS));
@@ -278,7 +278,7 @@ public class XpathFilterElementTest extends AbstractModuleTestSupport {
         final String xpath = "NON_MATCHING_QUERY";
         final XpathFilterElement filter = new XpathFilterElement(
                 "InputXpathFilterElementSuppressByXpath", null, null, null, xpath);
-        final TreeWalkerAuditEvent ev = getEvent(3, 0,
+        final TreeWalkerAuditEvent ev = getEvent(3, 1,
                 TokenTypes.CLASS_DEF);
         assertWithMessage("Event should be accepted")
                 .that(filter.accept(ev))
@@ -290,7 +290,7 @@ public class XpathFilterElementTest extends AbstractModuleTestSupport {
         final String xpath = "NON_MATCHING_QUERY";
         final XpathFilterElement filter = new XpathFilterElement(
                 "InputXpathFilterElementSuppressByXpath", "NonMatchingRegexp", null, null, xpath);
-        final TreeWalkerAuditEvent ev = getEvent(3, 0,
+        final TreeWalkerAuditEvent ev = getEvent(3, 1,
                 TokenTypes.CLASS_DEF);
         assertWithMessage("Event should be accepted")
                 .that(filter.accept(ev))
@@ -319,7 +319,7 @@ public class XpathFilterElementTest extends AbstractModuleTestSupport {
         final XpathFilterElement filter = new XpathFilterElement(
                 "InputXpathFilterElementSuppressByXpath", "Test", null, null, xpath);
         final Violation message =
-                new Violation(3, 0, TokenTypes.CLASS_DEF, "", "", null, null, "id19",
+                new Violation(3, 1, TokenTypes.CLASS_DEF, "", "", null, null, "id19",
                         getClass(), null);
         final TreeWalkerAuditEvent ev = new TreeWalkerAuditEvent(fileContents,
                 file.getName(), message, null);

--- a/src/test/java/com/puppycrawl/tools/checkstyle/gui/ParseTreeTableModelTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/gui/ParseTreeTableModelTest.java
@@ -263,7 +263,7 @@ public class ParseTreeTableModelTest extends AbstractPathTestSupport {
             .isEqualTo(6);
         assertWithMessage("Class name should start from column 6")
             .that(column)
-            .isEqualTo(6);
+            .isEqualTo(7);
         assertWithMessage("Wrong class name")
             .that(text)
             .isEqualTo("InputParseTreeTablePresentation");

--- a/src/test/java/com/puppycrawl/tools/checkstyle/gui/ParseTreeTablePresentationTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/gui/ParseTreeTablePresentationTest.java
@@ -286,7 +286,7 @@ public class ParseTreeTablePresentationTest extends AbstractPathTestSupport {
             .isEqualTo(6);
         assertWithMessage("Class name should start from column 6")
             .that(column)
-            .isEqualTo(6);
+            .isEqualTo(7);
         assertWithMessage("Wrong class name")
             .that(text)
             .isEqualTo("InputParseTreeTablePresentation");

--- a/src/test/java/com/puppycrawl/tools/checkstyle/gui/TreeTableTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/gui/TreeTableTest.java
@@ -234,7 +234,7 @@ public class TreeTableTest extends AbstractGuiTestSupport {
         mainFrame.openFile(new File(getPath("InputTreeTableXpathAreaPanel.java")));
 
         assertWithMessage("Value at Column (0, 3) expected to equal 0")
-                .that(treeTable.getValueAt(0, 3).equals(0))
+                .that(treeTable.getValueAt(0, 3).equals(1))
                 .isEqualTo(true);
 
         assertWithMessage("getColumn class expected to return string class")

--- a/src/test/java/com/puppycrawl/tools/checkstyle/xpath/RootNodeTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/xpath/RootNodeTest.java
@@ -107,13 +107,12 @@ public class RootNodeTest extends AbstractPathTestSupport {
     public void testGetColumnNumber() {
         assertWithMessage("Invalid column number")
             .that(rootNode.getColumnNumber())
-            .isEqualTo(0);
+            .isEqualTo(1);
     }
 
     /*
      * This test exists to cover pitest mutation.
-     * It is impossible to create RootNode that does not have column as 0.
-     * Test exists until https://github.com/checkstyle/checkstyle/issues/4997
+     * It is impossible to create RootNode that does not have column as 1.
      */
     @Test
     public void testNonRealGetColumnNumber() {

--- a/src/test/java/com/puppycrawl/tools/checkstyle/xpath/XpathMapperTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/xpath/XpathMapperTest.java
@@ -328,7 +328,7 @@ public class XpathMapperTest extends AbstractModuleTestSupport {
                 .isEqualTo(3);
         assertWithMessage("Invalid column number")
                 .that(classDefNode.getColumnNumber())
-                .isEqualTo(0);
+                .isEqualTo(1);
         final DetailAST[] actual = convertToArray(nodes);
         final DetailAST expectedClassDefNode = getSiblingByType(rootNode.getUnderlyingNode(),
                 TokenTypes.COMPILATION_UNIT)


### PR DESCRIPTION
fixes #4997
column numbers in `DetailAST` previously started at 0 , with a workaround in `AbstractCheck.log()` that added 
+1 before reporting violations, this was inconsistent with most modern ides/editor display col no. (1-based).