### PR TITLE
Issue #19064: Add third test to XpathRegressionNestedIfDepthTest

### DIFF
--- a/config/checkstyle-non-main-files-suppressions.xml
+++ b/config/checkstyle-non-main-files-suppressions.xml
@@ -422,7 +422,6 @@
   <suppress id="numberOfTestCasesInXpath" files="[\\/]src[\\/]it[\\/]java[\\/]org[\\/]checkstyle[\\/]suppressionxpathfilter[\\/]coding[\\/]XpathRegressionMissingNullCaseInSwitchTest.java" />
   <suppress id="numberOfTestCasesInXpath" files="[\\/]src[\\/]it[\\/]java[\\/]org[\\/]checkstyle[\\/]suppressionxpathfilter[\\/]coding[\\/]XpathRegressionMissingSwitchDefaultTest.java" />
   <suppress id="numberOfTestCasesInXpath" files="[\\/]src[\\/]it[\\/]java[\\/]org[\\/]checkstyle[\\/]suppressionxpathfilter[\\/]coding[\\/]XpathRegressionNestedForDepthTest.java" />
-  <suppress id="numberOfTestCasesInXpath" files="[\\/]src[\\/]it[\\/]java[\\/]org[\\/]checkstyle[\\/]suppressionxpathfilter[\\/]coding[\\/]XpathRegressionNestedIfDepthTest.java" />
 
   <suppress id="numberOfTestCasesInXpath" files="[\\/]src[\\/]it[\\/]java[\\/]org[\\/]checkstyle[\\/]suppressionxpathfilter[\\/]coding[\\/]XpathRegressionOneStatementPerLineTest.java" />
   <suppress id="numberOfTestCasesInXpath" files="[\\/]src[\\/]it[\\/]java[\\/]org[\\/]checkstyle[\\/]suppressionxpathfilter[\\/]coding[\\/]XpathRegressionOverloadMethodsDeclarationOrderTest.java" />

--- a/src/it/java/org/checkstyle/suppressionxpathfilter/coding/XpathRegressionNestedIfDepthTest.java
+++ b/src/it/java/org/checkstyle/suppressionxpathfilter/coding/XpathRegressionNestedIfDepthTest.java
@@ -95,4 +95,28 @@ public class XpathRegressionNestedIfDepthTest extends AbstractXpathTestSupport {
         runVerifications(moduleConfig, fileToProcess, expectedViolation,
             expectedXpathQueries);
     }
+
+    @Test
+    public void testStaticBlock() throws Exception {
+        final File fileToProcess =
+                new File(getPath("InputXpathNestedIfDepthStaticBlock.java"));
+
+        final DefaultConfiguration moduleConfig =
+            createModuleConfig(NestedIfDepthCheck.class);
+
+        final String[] expectedViolation = {
+            "10:17: " + getCheckMessage(NestedIfDepthCheck.class,
+                NestedIfDepthCheck.MSG_KEY, 2, 1),
+        };
+
+        final List<String> expectedXpathQueries = Collections.singletonList(
+            "/COMPILATION_UNIT/CLASS_DEF"
+                + "[./IDENT[@text='InputXpathNestedIfDepthStaticBlock']]/OBJBLOCK"
+                + "/STATIC_INIT/SLIST/LITERAL_IF"
+                + "/SLIST/LITERAL_IF/SLIST/LITERAL_IF"
+        );
+
+        runVerifications(moduleConfig, fileToProcess, expectedViolation,
+            expectedXpathQueries);
+    }
 }

--- a/src/it/resources/org/checkstyle/suppressionxpathfilter/coding/nestedifdepth/InputXpathNestedIfDepthStaticBlock.java
+++ b/src/it/resources/org/checkstyle/suppressionxpathfilter/coding/nestedifdepth/InputXpathNestedIfDepthStaticBlock.java
@@ -1,0 +1,15 @@
+package org.checkstyle.suppressionxpathfilter.coding.nestedifdepth;
+
+public class InputXpathNestedIfDepthStaticBlock {
+    static {
+        int a = 1;
+        int b = 2;
+        int c = 3;
+        if (a > b) {
+            if (c > b) {
+                if (c > a) { //warn
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
Issue: #19064

Add third test to XpathRegressionNestedIfDepthTest to meet the requirement of 3 distinct test methods with different XPath structures.

Changes:
- Added new test method `testStaticBlock()` with static initializer structure
- Created new input file `InputXpathNestedIfDepthStaticBlock.java`
- Removed suppression for this file from `checkstyle-non-main-files-suppressions.xml`

The three tests now cover different AST structures:
1. Basic nested if statements exceeding default max (existing)
2. Nested if statements exceeding custom max value (existing)
3. Nested if statements inside a static block (new)

All tests pass with `mvn clean verify`.