### PR TITLE
Issue #16807: Update input files for LocalVariableNameCheck

### DIFF
--- a/src/test/java/com/puppycrawl/tools/checkstyle/bdd/InlineConfigParser.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/bdd/InlineConfigParser.java
@@ -264,7 +264,6 @@ public final class InlineConfigParser {
             "com.puppycrawl.tools.checkstyle.checks.modifier.InterfaceMemberImpliedModifierCheck",
             "com.puppycrawl.tools.checkstyle.checks.modifier.RedundantModifierCheck",
             "com.puppycrawl.tools.checkstyle.checks.naming.AbbreviationAsWordInNameCheck",
-
             "com.puppycrawl.tools.checkstyle.checks.naming.IllegalIdentifierNameCheck",
             "com.puppycrawl.tools.checkstyle.checks.naming.LocalVariableNameCheck",
             "com.puppycrawl.tools.checkstyle.checks.naming.ParameterNameCheck",

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/naming/LocalVariableNameCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/naming/LocalVariableNameCheckTest.java
@@ -105,9 +105,9 @@ public class LocalVariableNameCheckTest
         final String pattern = "^([a-z][a-zA-Z0-9]*|_)$";
 
         final String[] expected = {
-            "16:13: " + getCheckMessage(MSG_INVALID_PATTERN, "__", pattern),
-            "17:13: " + getCheckMessage(MSG_INVALID_PATTERN, "_result", pattern),
-            "33:22: " + getCheckMessage(MSG_INVALID_PATTERN, "__", pattern),
+            "19:13: " + getCheckMessage(MSG_INVALID_PATTERN, "__", pattern),
+            "20:13: " + getCheckMessage(MSG_INVALID_PATTERN, "_result", pattern),
+            "36:22: " + getCheckMessage(MSG_INVALID_PATTERN, "__", pattern),
         };
         verifyWithInlineConfigParser(
                 getPath("InputLocalVariableNameUnnamedVariables.java"), expected);

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/naming/localvariablename/InputLocalVariableName1two.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/naming/localvariablename/InputLocalVariableName1two.java
@@ -1,4 +1,5 @@
 /*
+LocalVariableName
 format = (default)^([a-z][a-zA-Z0-9]*|_)$
 allowOneCharVarInForLoop = (default)false
 

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/naming/localvariablename/InputLocalVariableNameInnerClass.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/naming/localvariablename/InputLocalVariableNameInnerClass.java
@@ -1,6 +1,7 @@
 /*
 LocalVariableName
 format = (default)^([a-z][a-zA-Z0-9]*|_)$
+allowOneCharVarInForLoop = (default)false
 
 
 */


### PR DESCRIPTION
Updated input files for LocalVariableNameCheck to specify violation messages,
Removed it from SUPPRESSED_CHECKS in InlineConfigParser,
Fixed variable naming to comply with Java 21.