### PR TITLE
Issue #19064: Add third test to XpathRegressionUnusedLambdaParameterShouldBeUnnamedTest

### DIFF
--- a/config/checkstyle-non-main-files-suppressions.xml
+++ b/config/checkstyle-non-main-files-suppressions.xml
@@ -432,7 +432,6 @@
   <suppress id="numberOfTestCasesInXpath" files="[\\/]src[\\/]it[\\/]java[\\/]org[\\/]checkstyle[\\/]suppressionxpathfilter[\\/]coding[\\/]XpathRegressionUnnecessarySemicolonInEnumerationTest.java" />
   <suppress id="numberOfTestCasesInXpath" files="[\\/]src[\\/]it[\\/]java[\\/]org[\\/]checkstyle[\\/]suppressionxpathfilter[\\/]coding[\\/]XpathRegressionUnnecessarySemicolonInTryWithResourcesTest.java" />
   <suppress id="numberOfTestCasesInXpath" files="[\\/]src[\\/]it[\\/]java[\\/]org[\\/]checkstyle[\\/]suppressionxpathfilter[\\/]coding[\\/]XpathRegressionUnusedCatchParameterShouldBeUnnamedTest.java" />
-  <suppress id="numberOfTestCasesInXpath" files="[\\/]src[\\/]it[\\/]java[\\/]org[\\/]checkstyle[\\/]suppressionxpathfilter[\\/]coding[\\/]XpathRegressionUnusedLambdaParameterShouldBeUnnamedTest.java" />
   <suppress id="numberOfTestCasesInXpath" files="[\\/]src[\\/]it[\\/]java[\\/]org[\\/]checkstyle[\\/]suppressionxpathfilter[\\/]coding[\\/]XpathRegressionVariableDeclarationUsageDistanceTest.java" />
   <suppress id="numberOfTestCasesInXpath" files="[\\/]src[\\/]it[\\/]java[\\/]org[\\/]checkstyle[\\/]suppressionxpathfilter[\\/]coding[\\/]XpathRegressionWhenShouldBeUsedTest.java" />
   <suppress id="numberOfTestCasesInXpath" files="[\\/]src[\\/]it[\\/]java[\\/]org[\\/]checkstyle[\\/]suppressionxpathfilter[\\/]design[\\/]XpathRegressionDesignForExtensionTest.java" />

--- a/src/it/java/org/checkstyle/suppressionxpathfilter/coding/XpathRegressionUnusedLambdaParameterShouldBeUnnamedTest.java
+++ b/src/it/java/org/checkstyle/suppressionxpathfilter/coding/XpathRegressionUnusedLambdaParameterShouldBeUnnamedTest.java
@@ -134,4 +134,46 @@ public class XpathRegressionUnusedLambdaParameterShouldBeUnnamedTest
         runVerifications(moduleConfig, fileToProcess, expectedViolation,
                 expectedXpathQueries);
     }
+
+    @Test
+    public void testStaticBlock() throws Exception {
+        final File fileToProcess =
+                new File(getPath(
+                        "InputXpathUnusedLambdaParameterShouldBeUnnamedStaticBlock.java"));
+
+        final DefaultConfiguration moduleConfig =
+                createModuleConfig(UnusedLambdaParameterShouldBeUnnamedCheck.class);
+
+        final String[] expectedViolation = {
+            "8:41: " + getCheckMessage(UnusedLambdaParameterShouldBeUnnamedCheck.class,
+                    UnusedLambdaParameterShouldBeUnnamedCheck.MSG_UNUSED_LAMBDA_PARAMETER,
+                    "x"),
+        };
+
+        final List<String> expectedXpathQueries = Arrays.asList(
+            "/COMPILATION_UNIT/CLASS_DEF["
+                + "./IDENT[@text='InputXpathUnusedLambdaParameterShouldBeUnnamedStaticBlock']]"
+                + "/OBJBLOCK/STATIC_INIT/SLIST/VARIABLE_DEF[./IDENT[@text='f']]"
+                + "/ASSIGN/LAMBDA/PARAMETERS",
+            "/COMPILATION_UNIT/CLASS_DEF["
+                + "./IDENT[@text='InputXpathUnusedLambdaParameterShouldBeUnnamedStaticBlock']]"
+                + "/OBJBLOCK/STATIC_INIT/SLIST/VARIABLE_DEF[./IDENT[@text='f']]"
+                + "/ASSIGN/LAMBDA/PARAMETERS/PARAMETER_DEF[./IDENT[@text='x']]",
+            "/COMPILATION_UNIT/CLASS_DEF["
+                + "./IDENT[@text='InputXpathUnusedLambdaParameterShouldBeUnnamedStaticBlock']]"
+                + "/OBJBLOCK/STATIC_INIT/SLIST/VARIABLE_DEF[./IDENT[@text='f']]"
+                + "/ASSIGN/LAMBDA/PARAMETERS/PARAMETER_DEF[./IDENT[@text='x']]/MODIFIERS",
+            "/COMPILATION_UNIT/CLASS_DEF["
+                + "./IDENT[@text='InputXpathUnusedLambdaParameterShouldBeUnnamedStaticBlock']]"
+                + "/OBJBLOCK/STATIC_INIT/SLIST/VARIABLE_DEF[./IDENT[@text='f']]"
+                + "/ASSIGN/LAMBDA/PARAMETERS/PARAMETER_DEF[./IDENT[@text='x']]/TYPE",
+            "/COMPILATION_UNIT/CLASS_DEF["
+                + "./IDENT[@text='InputXpathUnusedLambdaParameterShouldBeUnnamedStaticBlock']]"
+                + "/OBJBLOCK/STATIC_INIT/SLIST/VARIABLE_DEF[./IDENT[@text='f']]"
+                + "/ASSIGN/LAMBDA/PARAMETERS/PARAMETER_DEF/IDENT[@text='x']"
+        );
+
+        runVerifications(moduleConfig, fileToProcess, expectedViolation,
+                expectedXpathQueries);
+    }
 }

--- a/src/it/resources/org/checkstyle/suppressionxpathfilter/coding/unusedlambdaparametershouldbeunnamed/InputXpathUnusedLambdaParameterShouldBeUnnamedStaticBlock.java
+++ b/src/it/resources/org/checkstyle/suppressionxpathfilter/coding/unusedlambdaparametershouldbeunnamed/InputXpathUnusedLambdaParameterShouldBeUnnamedStaticBlock.java
@@ -1,0 +1,10 @@
+// Java21
+package org.checkstyle.suppressionxpathfilter.coding.unusedlambdaparametershouldbeunnamed;
+
+import java.util.function.Function;
+
+public class InputXpathUnusedLambdaParameterShouldBeUnnamedStaticBlock {
+    static {
+        Function<Integer, Integer> f = (x) -> 1; // warn
+    }
+}


### PR DESCRIPTION
Issue: #19064

Add third test to XpathRegressionUnusedLambdaParameterShouldBeUnnamedTest to meet the requirement of 3 distinct test methods with different XPath structures.

Changes:
- Added new test method `testStaticBlock()` with static initializer structure
- Created new input file `InputXpathUnusedLambdaParameterShouldBeUnnamedStaticBlock.java`
- Removed suppression for this file from `checkstyle-non-main-files-suppressions.xml`

The three tests now cover different AST structures:
1. Simple lambda with unused parameter (existing)
2. Nested lambda with unused parameter (existing)
3. Lambda inside static block (new)

All tests pass with `mvn clean verify`.