### PR TITLE
Issue #19064: Add third test to XpathRegressionAvoidStarImportTest

### DIFF
--- a/config/checkstyle-non-main-files-suppressions.xml
+++ b/config/checkstyle-non-main-files-suppressions.xml
@@ -439,7 +439,6 @@
   <suppress id="numberOfTestCasesInXpath" files="[\\/]src[\\/]it[\\/]java[\\/]org[\\/]checkstyle[\\/]suppressionxpathfilter[\\/]design[\\/]XpathRegressionHideUtilityClassConstructorTest.java" />
   <suppress id="numberOfTestCasesInXpath" files="[\\/]src[\\/]it[\\/]java[\\/]org[\\/]checkstyle[\\/]suppressionxpathfilter[\\/]design[\\/]XpathRegressionInterfaceIsTypeTest.java" />
   <suppress id="numberOfTestCasesInXpath" files="[\\/]src[\\/]it[\\/]java[\\/]org[\\/]checkstyle[\\/]suppressionxpathfilter[\\/]design[\\/]XpathRegressionSealedShouldHavePermitsListTest.java" />
-  <suppress id="numberOfTestCasesInXpath" files="[\\/]src[\\/]it[\\/]java[\\/]org[\\/]checkstyle[\\/]suppressionxpathfilter[\\/]imports[\\/]XpathRegressionAvoidStarImportTest.java" />
   <suppress id="numberOfTestCasesInXpath" files="[\\/]src[\\/]it[\\/]java[\\/]org[\\/]checkstyle[\\/]suppressionxpathfilter[\\/]imports[\\/]XpathRegressionAvoidStaticImportTest.java" />
   <suppress id="numberOfTestCasesInXpath" files="[\\/]src[\\/]it[\\/]java[\\/]org[\\/]checkstyle[\\/]suppressionxpathfilter[\\/]imports[\\/]XpathRegressionIllegalImportTest.java" />
   <suppress id="numberOfTestCasesInXpath" files="[\\/]src[\\/]it[\\/]java[\\/]org[\\/]checkstyle[\\/]suppressionxpathfilter[\\/]javadoc[\\/]XpathRegressionJavadocContentLocationTest.java" />

--- a/src/it/java/org/checkstyle/suppressionxpathfilter/imports/XpathRegressionAvoidStarImportTest.java
+++ b/src/it/java/org/checkstyle/suppressionxpathfilter/imports/XpathRegressionAvoidStarImportTest.java
@@ -85,4 +85,24 @@ public class XpathRegressionAvoidStarImportTest
         runVerifications(moduleConfig, fileToProcess, expectedViolation, expectedXpathQueries);
     }
 
+    @Test
+    public void testThree() throws Exception {
+        final File fileToProcess = new File(getNonCompilablePath(
+            "InputXpathAvoidStarImportThree.java"));
+
+        final DefaultConfiguration moduleConfig =
+                createModuleConfig(CLASS);
+
+        final String[] expectedViolation = {
+            "3:12: " + getCheckMessage(CLASS,
+                AvoidStarImportCheck.MSG_KEY, "java.*"),
+        };
+
+        final List<String> expectedXpathQueries = Collections.singletonList(
+                "/COMPILATION_UNIT/IMPORT/DOT[./IDENT[@text='java']]"
+        );
+
+        runVerifications(moduleConfig, fileToProcess, expectedViolation, expectedXpathQueries);
+    }
+
 }

--- a/src/it/resources-noncompilable/org/checkstyle/suppressionxpathfilter/imports/avoidstarimport/InputXpathAvoidStarImportThree.java
+++ b/src/it/resources-noncompilable/org/checkstyle/suppressionxpathfilter/imports/avoidstarimport/InputXpathAvoidStarImportThree.java
@@ -1,0 +1,6 @@
+package org.checkstyle.suppressionxpathfilter.imports.avoidstarimport;
+
+import java.*; // warn
+
+public class InputXpathAvoidStarImportThree {
+}


### PR DESCRIPTION
Issue: #19064

Added a third test case to XpathRegressionAvoidStarImportTest to meet the minimum requirement of 3 test methods.
The new test uses `import java.*;` which produces a different XPath structure (`/COMPILATION_UNIT/IMPORT/DOT[./IDENT[@text='java']]`) compared to the existing two tests:
- testOne: static star import (`STATIC_IMPORT/DOT`)
- testTwo: deeper package star import (`IMPORT/DOT`)
Also removed the corresponding suppression entry from `checkstyle-non-main-files-suppressions.xml`.