### PR TITLE
Issue #19064: Add third test to XpathRegressionAvoidStaticImportTest

### DIFF
--- a/config/checkstyle-non-main-files-suppressions.xml
+++ b/config/checkstyle-non-main-files-suppressions.xml
@@ -431,7 +431,6 @@
   <suppress id="numberOfTestCasesInXpath" files="[\\/]src[\\/]it[\\/]java[\\/]org[\\/]checkstyle[\\/]suppressionxpathfilter[\\/]design[\\/]XpathRegressionHideUtilityClassConstructorTest.java" />
   <suppress id="numberOfTestCasesInXpath" files="[\\/]src[\\/]it[\\/]java[\\/]org[\\/]checkstyle[\\/]suppressionxpathfilter[\\/]design[\\/]XpathRegressionInterfaceIsTypeTest.java" />
   <suppress id="numberOfTestCasesInXpath" files="[\\/]src[\\/]it[\\/]java[\\/]org[\\/]checkstyle[\\/]suppressionxpathfilter[\\/]design[\\/]XpathRegressionSealedShouldHavePermitsListTest.java" />
-  <suppress id="numberOfTestCasesInXpath" files="[\\/]src[\\/]it[\\/]java[\\/]org[\\/]checkstyle[\\/]suppressionxpathfilter[\\/]imports[\\/]XpathRegressionAvoidStaticImportTest.java" />
   <suppress id="numberOfTestCasesInXpath" files="[\\/]src[\\/]it[\\/]java[\\/]org[\\/]checkstyle[\\/]suppressionxpathfilter[\\/]imports[\\/]XpathRegressionIllegalImportTest.java" />
   <suppress id="numberOfTestCasesInXpath" files="[\\/]src[\\/]it[\\/]java[\\/]org[\\/]checkstyle[\\/]suppressionxpathfilter[\\/]javadoc[\\/]XpathRegressionJavadocContentLocationTest.java" />
   <suppress id="numberOfTestCasesInXpath" files="[\\/]src[\\/]it[\\/]java[\\/]org[\\/]checkstyle[\\/]suppressionxpathfilter[\\/]javadoc[\\/]XpathRegressionJavadocVariableTest.java" />

--- a/src/it/java/org/checkstyle/suppressionxpathfilter/imports/XpathRegressionAvoidStaticImportTest.java
+++ b/src/it/java/org/checkstyle/suppressionxpathfilter/imports/XpathRegressionAvoidStaticImportTest.java
@@ -85,4 +85,24 @@ public class XpathRegressionAvoidStaticImportTest
         runVerifications(moduleConfig, fileToProcess, expectedViolation, expectedXpathQueries);
     }
 
+    @Test
+    public void testThree() throws Exception {
+        final File fileToProcess = new File(getPath(
+            "InputXpathAvoidStaticImportThree.java"));
+
+        final DefaultConfiguration moduleConfig =
+                createModuleConfig(CLASS);
+
+        final String[] expectedViolation = {
+            "3:29: " + getCheckMessage(CLASS,
+                AvoidStaticImportCheck.MSG_KEY, "java.lang.Math.abs"),
+        };
+
+        final List<String> expectedXpathQueries = Collections.singletonList(
+                "/COMPILATION_UNIT/STATIC_IMPORT/DOT[./IDENT[@text='abs']]"
+        );
+
+        runVerifications(moduleConfig, fileToProcess, expectedViolation, expectedXpathQueries);
+    }
+
 }

--- a/src/it/resources/org/checkstyle/suppressionxpathfilter/imports/avoidstaticimport/InputXpathAvoidStaticImportThree.java
+++ b/src/it/resources/org/checkstyle/suppressionxpathfilter/imports/avoidstaticimport/InputXpathAvoidStaticImportThree.java
@@ -1,0 +1,6 @@
+package org.checkstyle.suppressionxpathfilter.imports.avoidstaticimport;
+
+import static java.lang.Math.abs; // warn
+
+public class InputXpathAvoidStaticImportThree {
+}


### PR DESCRIPTION
Issue: #19064

Added a third test case to XpathRegressionAvoidStaticImportTest to meet the minimum requirement of 3 test methods.

The new test uses `import static java.lang.Math.abs;` which produces the XPath `/COMPILATION_UNIT/STATIC_IMPORT/DOT[./IDENT[@text='abs']]`.

Also removed the corresponding suppression entry from `checkstyle-non-main-files-suppressions.xml`.