### PR TITLE
Issue #19064: Add third test to XpathRegressionSimplifyBooleanReturnTest

### DIFF
--- a/config/checkstyle-non-main-files-suppressions.xml
+++ b/config/checkstyle-non-main-files-suppressions.xml
@@ -427,7 +427,6 @@
   <suppress id="numberOfTestCasesInXpath" files="[\\/]src[\\/]it[\\/]java[\\/]org[\\/]checkstyle[\\/]suppressionxpathfilter[\\/]coding[\\/]XpathRegressionOneStatementPerLineTest.java" />
   <suppress id="numberOfTestCasesInXpath" files="[\\/]src[\\/]it[\\/]java[\\/]org[\\/]checkstyle[\\/]suppressionxpathfilter[\\/]coding[\\/]XpathRegressionOverloadMethodsDeclarationOrderTest.java" />
   <suppress id="numberOfTestCasesInXpath" files="[\\/]src[\\/]it[\\/]java[\\/]org[\\/]checkstyle[\\/]suppressionxpathfilter[\\/]coding[\\/]XpathRegressionPackageDeclarationTest.java" />
-  <suppress id="numberOfTestCasesInXpath" files="[\\/]src[\\/]it[\\/]java[\\/]org[\\/]checkstyle[\\/]suppressionxpathfilter[\\/]coding[\\/]XpathRegressionSimplifyBooleanReturnTest.java" />
   <suppress id="numberOfTestCasesInXpath" files="[\\/]src[\\/]it[\\/]java[\\/]org[\\/]checkstyle[\\/]suppressionxpathfilter[\\/]coding[\\/]XpathRegressionUnnecessarySemicolonAfterTypeMemberDeclarationTest.java" />
   <suppress id="numberOfTestCasesInXpath" files="[\\/]src[\\/]it[\\/]java[\\/]org[\\/]checkstyle[\\/]suppressionxpathfilter[\\/]coding[\\/]XpathRegressionUnnecessarySemicolonInEnumerationTest.java" />
   <suppress id="numberOfTestCasesInXpath" files="[\\/]src[\\/]it[\\/]java[\\/]org[\\/]checkstyle[\\/]suppressionxpathfilter[\\/]coding[\\/]XpathRegressionUnnecessarySemicolonInTryWithResourcesTest.java" />

--- a/src/it/java/org/checkstyle/suppressionxpathfilter/coding/XpathRegressionSimplifyBooleanReturnTest.java
+++ b/src/it/java/org/checkstyle/suppressionxpathfilter/coding/XpathRegressionSimplifyBooleanReturnTest.java
@@ -91,4 +91,29 @@ public class XpathRegressionSimplifyBooleanReturnTest extends AbstractXpathTestS
         runVerifications(moduleConfig, fileToProcess, expectedViolation,
             expectedXpathQueries);
     }
+
+    @Test
+    public void testAnonymousInnerClass() throws Exception {
+        final File fileToProcess = new File(
+            getPath(
+                "InputXpathSimplifyBooleanReturnAnonymousInnerClass.java"
+            ));
+
+        final DefaultConfiguration moduleConfig = createModuleConfig(CLASS);
+
+        final String[] expectedViolation = {
+            "12:17: " + getCheckMessage(CLASS, MSG_KEY),
+        };
+
+        final List<String> expectedXpathQueries = Collections.singletonList(
+            "/COMPILATION_UNIT/CLASS_DEF[./IDENT[@text="
+                + "'InputXpathSimplifyBooleanReturnAnonymousInnerClass']]"
+                + "/OBJBLOCK/METHOD_DEF[./IDENT[@text='getChecker']]"
+                + "/SLIST/LITERAL_RETURN/EXPR/LITERAL_NEW[./IDENT[@text='Checker']]"
+                + "/OBJBLOCK/METHOD_DEF[./IDENT[@text='check']]/SLIST/LITERAL_IF"
+        );
+
+        runVerifications(moduleConfig, fileToProcess, expectedViolation,
+            expectedXpathQueries);
+    }
 }

--- a/src/it/resources/org/checkstyle/suppressionxpathfilter/coding/simplifybooleanreturn/InputXpathSimplifyBooleanReturnAnonymousInnerClass.java
+++ b/src/it/resources/org/checkstyle/suppressionxpathfilter/coding/simplifybooleanreturn/InputXpathSimplifyBooleanReturnAnonymousInnerClass.java
@@ -1,0 +1,21 @@
+package org.checkstyle.suppressionxpathfilter.coding.simplifybooleanreturn;
+
+public class InputXpathSimplifyBooleanReturnAnonymousInnerClass {
+    interface Checker {
+        boolean check(int value);
+    }
+
+    public Checker getChecker() {
+        return new Checker() {
+            @Override
+            public boolean check(int value) {
+                if (value > 0) { // warn
+                    return true;
+                }
+                else {
+                    return false;
+                }
+            }
+        };
+    }
+}


### PR DESCRIPTION
Issue: #19064

Add the third test (`testAnonymousInnerClass`) to
`XpathRegressionSimplifyBooleanReturnTest`.

The new test uses `LITERAL_IF` inside an anonymous inner class,
producing a different XPath structure from the existing two tests.