### PR TITLE
Issue #19064: Add third test to XpathRegressionHiddenFieldTest

### DIFF
--- a/config/checkstyle-non-main-files-suppressions.xml
+++ b/config/checkstyle-non-main-files-suppressions.xml
@@ -416,7 +416,6 @@
   <suppress id="numberOfTestCasesInXpath" files="[\\/]src[\\/]it[\\/]java[\\/]org[\\/]checkstyle[\\/]suppressionxpathfilter[\\/]XpathRegressionTodoCommentTest.java" />
   <suppress id="numberOfTestCasesInXpath" files="[\\/]src[\\/]it[\\/]java[\\/]org[\\/]checkstyle[\\/]suppressionxpathfilter[\\/]coding[\\/]XpathRegressionDefaultComesLastTest.java" />
   <suppress id="numberOfTestCasesInXpath" files="[\\/]src[\\/]it[\\/]java[\\/]org[\\/]checkstyle[\\/]suppressionxpathfilter[\\/]coding[\\/]XpathRegressionDeclarationOrderTest.java" />
-  <suppress id="numberOfTestCasesInXpath" files="[\\/]src[\\/]it[\\/]java[\\/]org[\\/]checkstyle[\\/]suppressionxpathfilter[\\/]coding[\\/]XpathRegressionHiddenFieldTest.java" />
   <suppress id="numberOfTestCasesInXpath" files="[\\/]src[\\/]it[\\/]java[\\/]org[\\/]checkstyle[\\/]suppressionxpathfilter[\\/]coding[\\/]XpathRegressionMissingSwitchDefaultTest.java" />
   <suppress id="numberOfTestCasesInXpath" files="[\\/]src[\\/]it[\\/]java[\\/]org[\\/]checkstyle[\\/]suppressionxpathfilter[\\/]coding[\\/]XpathRegressionNestedIfDepthTest.java" />
 

--- a/src/it/java/org/checkstyle/suppressionxpathfilter/coding/XpathRegressionHiddenFieldTest.java
+++ b/src/it/java/org/checkstyle/suppressionxpathfilter/coding/XpathRegressionHiddenFieldTest.java
@@ -90,4 +90,28 @@ public class XpathRegressionHiddenFieldTest extends AbstractXpathTestSupport {
         runVerifications(moduleConfig, fileToProcess, expectedViolation,
                 expectedXpathQueries);
     }
+
+    @Test
+    public void testLocalVariable() throws Exception {
+        final File fileToProcess =
+                new File(getPath("InputXpathHiddenFieldLocalVariable.java"));
+
+        final DefaultConfiguration moduleConfig =
+                createModuleConfig(HiddenFieldCheck.class);
+
+        final String[] expectedViolation = {
+            "7:13: " + getCheckMessage(HiddenFieldCheck.class,
+                HiddenFieldCheck.MSG_KEY, "count"),
+        };
+
+        final List<String> expectedXpathQueries = Collections.singletonList(
+            "/COMPILATION_UNIT/CLASS_DEF"
+                + "[./IDENT[@text='InputXpathHiddenFieldLocalVariable']]/OBJBLOCK"
+                + "/METHOD_DEF[./IDENT[@text='process']]/SLIST"
+                + "/VARIABLE_DEF/IDENT[@text='count']"
+        );
+
+        runVerifications(moduleConfig, fileToProcess, expectedViolation,
+                expectedXpathQueries);
+    }
 }

--- a/src/it/resources/org/checkstyle/suppressionxpathfilter/coding/hiddenfield/InputXpathHiddenFieldLocalVariable.java
+++ b/src/it/resources/org/checkstyle/suppressionxpathfilter/coding/hiddenfield/InputXpathHiddenFieldLocalVariable.java
@@ -1,0 +1,9 @@
+package org.checkstyle.suppressionxpathfilter.coding.hiddenfield;
+
+public class InputXpathHiddenFieldLocalVariable {
+    int count = 10;
+
+    void process() {
+        int count = 20; // warn
+    }
+}


### PR DESCRIPTION
Issue: #19064

Add the third test (`testLocalVariable`) to
`XpathRegressionHiddenFieldTest`.

The new test uses a local variable hiding a field, producing an XPath
through `VARIABLE_DEF` — different from the existing tests which use
`PARAMETER_DEF` (method param) and `LAMBDA/PARAMETERS/PARAMETER_DEF`
(lambda param).