### PR TITLE
Issue #19064: Add third test to XpathRegressionInnerAssignmentTest

### DIFF
--- a/config/checkstyle-non-main-files-suppressions.xml
+++ b/config/checkstyle-non-main-files-suppressions.xml
@@ -418,7 +418,6 @@
   <suppress id="numberOfTestCasesInXpath" files="[\\/]src[\\/]it[\\/]java[\\/]org[\\/]checkstyle[\\/]suppressionxpathfilter[\\/]coding[\\/]XpathRegressionDefaultComesLastTest.java" />
   <suppress id="numberOfTestCasesInXpath" files="[\\/]src[\\/]it[\\/]java[\\/]org[\\/]checkstyle[\\/]suppressionxpathfilter[\\/]coding[\\/]XpathRegressionDeclarationOrderTest.java" />
   <suppress id="numberOfTestCasesInXpath" files="[\\/]src[\\/]it[\\/]java[\\/]org[\\/]checkstyle[\\/]suppressionxpathfilter[\\/]coding[\\/]XpathRegressionHiddenFieldTest.java" />
-  <suppress id="numberOfTestCasesInXpath" files="[\\/]src[\\/]it[\\/]java[\\/]org[\\/]checkstyle[\\/]suppressionxpathfilter[\\/]coding[\\/]XpathRegressionInnerAssignmentTest.java" />
   <suppress id="numberOfTestCasesInXpath" files="[\\/]src[\\/]it[\\/]java[\\/]org[\\/]checkstyle[\\/]suppressionxpathfilter[\\/]coding[\\/]XpathRegressionMissingNullCaseInSwitchTest.java" />
   <suppress id="numberOfTestCasesInXpath" files="[\\/]src[\\/]it[\\/]java[\\/]org[\\/]checkstyle[\\/]suppressionxpathfilter[\\/]coding[\\/]XpathRegressionMissingSwitchDefaultTest.java" />
   <suppress id="numberOfTestCasesInXpath" files="[\\/]src[\\/]it[\\/]java[\\/]org[\\/]checkstyle[\\/]suppressionxpathfilter[\\/]coding[\\/]XpathRegressionNestedForDepthTest.java" />

--- a/src/it/java/org/checkstyle/suppressionxpathfilter/coding/XpathRegressionInnerAssignmentTest.java
+++ b/src/it/java/org/checkstyle/suppressionxpathfilter/coding/XpathRegressionInnerAssignmentTest.java
@@ -90,4 +90,37 @@ public class XpathRegressionInnerAssignmentTest extends AbstractXpathTestSupport
 
         runVerifications(moduleConfig, fileToProcess, expectedViolation, expectedXpathQueries);
     }
+
+    @Test
+    public void testMethodCall() throws Exception {
+        final File fileToProcess = new
+                File(getPath("InputXpathInnerAssignmentMethodCall.java"));
+
+        final DefaultConfiguration moduleConfig = createModuleConfig(InnerAssignmentCheck.class);
+
+        final String[] expectedViolation = {
+            "6:46: " + getCheckMessage(InnerAssignmentCheck.class, InnerAssignmentCheck.MSG_KEY),
+        };
+
+        final List<String> expectedXpathQueries = Arrays.asList(
+                "/COMPILATION_UNIT"
+                + "/CLASS_DEF[./IDENT[@text='InputXpathInnerAssignmentMethodCall']]"
+                + "/OBJBLOCK/METHOD_DEF[./IDENT[@text='testMethod']]"
+                + "/SLIST/VARIABLE_DEF[./IDENT[@text='result']]"
+                + "/ASSIGN/EXPR/METHOD_CALL/ELIST",
+                "/COMPILATION_UNIT"
+                + "/CLASS_DEF[./IDENT[@text='InputXpathInnerAssignmentMethodCall']]"
+                + "/OBJBLOCK/METHOD_DEF[./IDENT[@text='testMethod']]"
+                + "/SLIST/VARIABLE_DEF[./IDENT[@text='result']]"
+                + "/ASSIGN/EXPR/METHOD_CALL/ELIST/EXPR",
+                "/COMPILATION_UNIT"
+                + "/CLASS_DEF[./IDENT[@text='InputXpathInnerAssignmentMethodCall']]"
+                + "/OBJBLOCK/METHOD_DEF[./IDENT[@text='testMethod']]"
+                + "/SLIST/VARIABLE_DEF[./IDENT[@text='result']]"
+                + "/ASSIGN/EXPR/METHOD_CALL/ELIST"
+                + "/EXPR/ASSIGN[./IDENT[@text='value']]"
+        );
+
+        runVerifications(moduleConfig, fileToProcess, expectedViolation, expectedXpathQueries);
+    }
 }

--- a/src/it/resources/org/checkstyle/suppressionxpathfilter/coding/innerassignment/InputXpathInnerAssignmentMethodCall.java
+++ b/src/it/resources/org/checkstyle/suppressionxpathfilter/coding/innerassignment/InputXpathInnerAssignmentMethodCall.java
@@ -1,0 +1,8 @@
+package org.checkstyle.suppressionxpathfilter.coding.innerassignment;
+
+public class InputXpathInnerAssignmentMethodCall {
+    public void testMethod() {
+        int value;
+        String result = String.valueOf(value = 42); // warn
+    }
+}


### PR DESCRIPTION
Issue: #19064

Add the third test (`testMethodCall`) to
`XpathRegressionInnerAssignmentTest`.

The new test uses an inner assignment inside a method call argument
String.valueOf(value = 42), producing an XPath through
`METHOD_CALL/ELIST/EXPR/ASSIGN` — different from the existing tests
which use chained assignment (`EXPR/ASSIGN/ASSIGN`) and array
initializer assignment (`ARRAY_INIT/EXPR/ASSIGN`).