### PR TITLE
Issue #19064: Add third test to XpathRegressionLambdaParameterNameTest

### DIFF
--- a/config/checkstyle-non-main-files-suppressions.xml
+++ b/config/checkstyle-non-main-files-suppressions.xml
@@ -448,7 +448,6 @@
   <suppress id="numberOfTestCasesInXpath" files="[\\/]src[\\/]it[\\/]java[\\/]org[\\/]checkstyle[\\/]suppressionxpathfilter[\\/]metrics[\\/]XpathRegressionNPathComplexityTest.java" />
   <suppress id="numberOfTestCasesInXpath" files="[\\/]src[\\/]it[\\/]java[\\/]org[\\/]checkstyle[\\/]suppressionxpathfilter[\\/]modifier[\\/]XpathRegressionClassMemberImpliedModifierTest.java" />
   <suppress id="numberOfTestCasesInXpath" files="[\\/]src[\\/]it[\\/]java[\\/]org[\\/]checkstyle[\\/]suppressionxpathfilter[\\/]naming[\\/]XpathRegressionIllegalIdentifierNameTest.java" />
-  <suppress id="numberOfTestCasesInXpath" files="[\\/]src[\\/]it[\\/]java[\\/]org[\\/]checkstyle[\\/]suppressionxpathfilter[\\/]naming[\\/]XpathRegressionLambdaParameterNameTest.java" />
   <suppress id="numberOfTestCasesInXpath" files="[\\/]src[\\/]it[\\/]java[\\/]org[\\/]checkstyle[\\/]suppressionxpathfilter[\\/]naming[\\/]XpathRegressionMemberNameTest.java" />
   <suppress id="numberOfTestCasesInXpath" files="[\\/]src[\\/]it[\\/]java[\\/]org[\\/]checkstyle[\\/]suppressionxpathfilter[\\/]naming[\\/]XpathRegressionRecordComponentNameTest.java" />
   <suppress id="numberOfTestCasesInXpath" files="[\\/]src[\\/]it[\\/]java[\\/]org[\\/]checkstyle[\\/]suppressionxpathfilter[\\/]naming[\\/]XpathRegressionRecordTypeParameterNameTest.java" />

--- a/src/it/java/org/checkstyle/suppressionxpathfilter/naming/XpathRegressionLambdaParameterNameTest.java
+++ b/src/it/java/org/checkstyle/suppressionxpathfilter/naming/XpathRegressionLambdaParameterNameTest.java
@@ -120,4 +120,29 @@ public class XpathRegressionLambdaParameterNameTest extends AbstractXpathTestSup
         runVerifications(moduleConfig, fileToProcess, expectedViolation,
                 expectedXpathQueries);
     }
+
+    @Test
+    public void testField() throws Exception {
+        final File fileToProcess =
+                new File(getPath("InputXpathLambdaParameterNameField.java"));
+
+        final DefaultConfiguration moduleConfig =
+                createModuleConfig(LambdaParameterNameCheck.class);
+        final String defaultPattern = "^([a-z][a-zA-Z0-9]*|_)$";
+
+        final String[] expectedViolation = {
+            "6:40: " + getCheckMessage(LambdaParameterNameCheck.class,
+                    AbstractNameCheck.MSG_INVALID_PATTERN, "S", defaultPattern),
+        };
+
+        final List<String> expectedXpathQueries = Collections.singletonList(
+               "/COMPILATION_UNIT/CLASS_DEF"
+                       + "[./IDENT[@text='InputXpathLambdaParameterNameField']]"
+                       + "/OBJBLOCK/VARIABLE_DEF[./IDENT[@text='trimmer']]"
+                       + "/ASSIGN/LAMBDA/IDENT[@text='S']"
+        );
+
+        runVerifications(moduleConfig, fileToProcess, expectedViolation,
+                expectedXpathQueries);
+    }
 }

--- a/src/it/resources/org/checkstyle/suppressionxpathfilter/naming/lambdaparametername/InputXpathLambdaParameterNameField.java
+++ b/src/it/resources/org/checkstyle/suppressionxpathfilter/naming/lambdaparametername/InputXpathLambdaParameterNameField.java
@@ -1,0 +1,7 @@
+package org.checkstyle.suppressionxpathfilter.naming.lambdaparametername;
+
+import java.util.function.Function;
+
+public class InputXpathLambdaParameterNameField {
+    Function<String, String> trimmer = S -> S.trim(); // warn
+}


### PR DESCRIPTION
Issue: #19064

Add third test `testField`  to `XpathRegressionLambdaParameterNameTest`. The new test uses a field-level lambda with an uppercase parameter name `S`, producing a different `XPath` structure compared to the existing tests which use method-local variable lambdas