### PR TITLE
Issue #19064: Add third test to XpathRegressionNestedForDepthTest

### DIFF
--- a/config/checkstyle-non-main-files-suppressions.xml
+++ b/config/checkstyle-non-main-files-suppressions.xml
@@ -420,7 +420,7 @@
   <suppress id="numberOfTestCasesInXpath" files="[\\/]src[\\/]it[\\/]java[\\/]org[\\/]checkstyle[\\/]suppressionxpathfilter[\\/]coding[\\/]XpathRegressionHiddenFieldTest.java" />
   <suppress id="numberOfTestCasesInXpath" files="[\\/]src[\\/]it[\\/]java[\\/]org[\\/]checkstyle[\\/]suppressionxpathfilter[\\/]coding[\\/]XpathRegressionInnerAssignmentTest.java" />
   <suppress id="numberOfTestCasesInXpath" files="[\\/]src[\\/]it[\\/]java[\\/]org[\\/]checkstyle[\\/]suppressionxpathfilter[\\/]coding[\\/]XpathRegressionMissingNullCaseInSwitchTest.java" />
-  <suppress id="numberOfTestCasesInXpath" files="[\\/]src[\\/]it[\\/]java[\\/]org[\\/]checkstyle[\\/]suppressionxpathfilter[\\/]coding[\\/]XpathRegressionNestedForDepthTest.java" />
+  <suppress id="numberOfTestCasesInXpath" files="[\\/]src[\\/]it[\\/]java[\\/]org[\\/]checkstyle[\\/]suppressionxpathfilter[\\/]coding[\\/]XpathRegressionNestedIfDepthTest.java" />
 
   <suppress id="numberOfTestCasesInXpath" files="[\\/]src[\\/]it[\\/]java[\\/]org[\\/]checkstyle[\\/]suppressionxpathfilter[\\/]coding[\\/]XpathRegressionOneStatementPerLineTest.java" />
   <suppress id="numberOfTestCasesInXpath" files="[\\/]src[\\/]it[\\/]java[\\/]org[\\/]checkstyle[\\/]suppressionxpathfilter[\\/]coding[\\/]XpathRegressionOverloadMethodsDeclarationOrderTest.java" />

--- a/src/it/java/org/checkstyle/suppressionxpathfilter/coding/XpathRegressionNestedForDepthTest.java
+++ b/src/it/java/org/checkstyle/suppressionxpathfilter/coding/XpathRegressionNestedForDepthTest.java
@@ -94,4 +94,29 @@ public class XpathRegressionNestedForDepthTest extends AbstractXpathTestSupport 
         runVerifications(moduleConfig, fileToProcess, expectedViolation,
                 expectedXpathQueries);
     }
+
+    @Test
+    public void testConstructor() throws Exception {
+        final File fileToProcess =
+                new File(getPath("InputXpathNestedForDepthConstructor.java"));
+
+        final DefaultConfiguration moduleConfig =
+                createModuleConfig(NestedForDepthCheck.class);
+
+        final String[] expectedViolation = {
+            "7:17: " + getCheckMessage(NestedForDepthCheck.class,
+                NestedForDepthCheck.MSG_KEY, 2, 1),
+        };
+
+        final List<String> expectedXpathQueries = Collections.singletonList(
+            "/COMPILATION_UNIT/CLASS_DEF"
+                + "[./IDENT[@text='InputXpathNestedForDepthConstructor']]"
+                + "/OBJBLOCK/CTOR_DEF[./IDENT"
+                + "[@text='InputXpathNestedForDepthConstructor']]"
+                + "/SLIST/LITERAL_FOR/SLIST/LITERAL_FOR/SLIST/LITERAL_FOR"
+        );
+
+        runVerifications(moduleConfig, fileToProcess, expectedViolation,
+                expectedXpathQueries);
+    }
 }

--- a/src/it/resources/org/checkstyle/suppressionxpathfilter/coding/nestedfordepth/InputXpathNestedForDepthConstructor.java
+++ b/src/it/resources/org/checkstyle/suppressionxpathfilter/coding/nestedfordepth/InputXpathNestedForDepthConstructor.java
@@ -1,0 +1,12 @@
+package org.checkstyle.suppressionxpathfilter.coding.nestedfordepth;
+
+public class InputXpathNestedForDepthConstructor {
+    InputXpathNestedForDepthConstructor() {
+        for (int i = 0; i < 10; i++) {
+            for (int j = 0; j < 10; j++) {
+                for (int k = 0; k < 10; k++) { // warn
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
resolved Issue: #19064

Add third test `testConstructor` to `XpathRegressionNestedForDepthTest`. The new test uses nested for loops inside a constructor, producing an XPath through `CTOR_DEF` instead of `METHOD_DEF` used by the existing two tests.