### PR TITLE
Issue #19064: Add third test to XpathRegressionOneStatementPerLineTest

### DIFF
--- a/config/checkstyle-non-main-files-suppressions.xml
+++ b/config/checkstyle-non-main-files-suppressions.xml
@@ -422,7 +422,6 @@
   <suppress id="numberOfTestCasesInXpath" files="[\\/]src[\\/]it[\\/]java[\\/]org[\\/]checkstyle[\\/]suppressionxpathfilter[\\/]coding[\\/]XpathRegressionMissingNullCaseInSwitchTest.java" />
   <suppress id="numberOfTestCasesInXpath" files="[\\/]src[\\/]it[\\/]java[\\/]org[\\/]checkstyle[\\/]suppressionxpathfilter[\\/]coding[\\/]XpathRegressionNestedForDepthTest.java" />
 
-  <suppress id="numberOfTestCasesInXpath" files="[\\/]src[\\/]it[\\/]java[\\/]org[\\/]checkstyle[\\/]suppressionxpathfilter[\\/]coding[\\/]XpathRegressionOneStatementPerLineTest.java" />
   <suppress id="numberOfTestCasesInXpath" files="[\\/]src[\\/]it[\\/]java[\\/]org[\\/]checkstyle[\\/]suppressionxpathfilter[\\/]coding[\\/]XpathRegressionOverloadMethodsDeclarationOrderTest.java" />
   <suppress id="numberOfTestCasesInXpath" files="[\\/]src[\\/]it[\\/]java[\\/]org[\\/]checkstyle[\\/]suppressionxpathfilter[\\/]coding[\\/]XpathRegressionPackageDeclarationTest.java" />
   <suppress id="numberOfTestCasesInXpath" files="[\\/]src[\\/]it[\\/]java[\\/]org[\\/]checkstyle[\\/]suppressionxpathfilter[\\/]coding[\\/]XpathRegressionSimplifyBooleanReturnTest.java" />

--- a/src/it/java/org/checkstyle/suppressionxpathfilter/coding/XpathRegressionOneStatementPerLineTest.java
+++ b/src/it/java/org/checkstyle/suppressionxpathfilter/coding/XpathRegressionOneStatementPerLineTest.java
@@ -88,4 +88,27 @@ public class XpathRegressionOneStatementPerLineTest extends AbstractXpathTestSup
         runVerifications(moduleConfig, fileToProcess, expectedViolation,
                 expectedXpathQueries);
     }
+
+    @Test
+    public void testMethodBody() throws Exception {
+        final File fileToProcess =
+                new File(getPath("InputXpathOneStatementPerLineMethodBody.java"));
+
+        final DefaultConfiguration moduleConfig =
+                createModuleConfig(OneStatementPerLineCheck.class);
+
+        final String[] expectedViolation = {
+            "5:29: " + getCheckMessage(OneStatementPerLineCheck.class,
+                OneStatementPerLineCheck.MSG_KEY),
+        };
+
+        final List<String> expectedXpathQueries = Collections.singletonList(
+            "/COMPILATION_UNIT/CLASS_DEF"
+                + "[./IDENT[@text='InputXpathOneStatementPerLineMethodBody']]"
+                + "/OBJBLOCK/METHOD_DEF[./IDENT[@text='test']]/SLIST/SEMI[2]"
+        );
+
+        runVerifications(moduleConfig, fileToProcess, expectedViolation,
+                expectedXpathQueries);
+    }
 }

--- a/src/it/resources/org/checkstyle/suppressionxpathfilter/coding/onestatementperline/InputXpathOneStatementPerLineMethodBody.java
+++ b/src/it/resources/org/checkstyle/suppressionxpathfilter/coding/onestatementperline/InputXpathOneStatementPerLineMethodBody.java
@@ -1,0 +1,7 @@
+package org.checkstyle.suppressionxpathfilter.coding.onestatementperline;
+
+public class InputXpathOneStatementPerLineMethodBody {
+    void test() {
+        int a = 1; int b = 2; // warn
+    }
+}


### PR DESCRIPTION
Issue: #19064

Add third test `testMethodBody` to `XpathRegressionOneStatementPerLineTest`. The new test uses two statements on one line inside a method body, producing an XPath through `METHOD_DEF/SLIST/SEMI` different from the existing tests which use class field declarations `OBJBLOCK/VARIABLE_DEF/SEMI` and for loop bodies.