### PR TITLE
Issue #19064: Add third test to XpathRegressionOverloadMethodsDeclara…

### DIFF
--- a/config/checkstyle-non-main-files-suppressions.xml
+++ b/config/checkstyle-non-main-files-suppressions.xml
@@ -421,8 +421,6 @@
   <suppress id="numberOfTestCasesInXpath" files="[\\/]src[\\/]it[\\/]java[\\/]org[\\/]checkstyle[\\/]suppressionxpathfilter[\\/]coding[\\/]XpathRegressionMissingNullCaseInSwitchTest.java" />
   <suppress id="numberOfTestCasesInXpath" files="[\\/]src[\\/]it[\\/]java[\\/]org[\\/]checkstyle[\\/]suppressionxpathfilter[\\/]coding[\\/]XpathRegressionMissingSwitchDefaultTest.java" />
   <suppress id="numberOfTestCasesInXpath" files="[\\/]src[\\/]it[\\/]java[\\/]org[\\/]checkstyle[\\/]suppressionxpathfilter[\\/]coding[\\/]XpathRegressionNestedIfDepthTest.java" />
-
-  <suppress id="numberOfTestCasesInXpath" files="[\\/]src[\\/]it[\\/]java[\\/]org[\\/]checkstyle[\\/]suppressionxpathfilter[\\/]coding[\\/]XpathRegressionOverloadMethodsDeclarationOrderTest.java" />
   <suppress id="numberOfTestCasesInXpath" files="[\\/]src[\\/]it[\\/]java[\\/]org[\\/]checkstyle[\\/]suppressionxpathfilter[\\/]coding[\\/]XpathRegressionPackageDeclarationTest.java" />
   <suppress id="numberOfTestCasesInXpath" files="[\\/]src[\\/]it[\\/]java[\\/]org[\\/]checkstyle[\\/]suppressionxpathfilter[\\/]coding[\\/]XpathRegressionUnnecessarySemicolonAfterTypeMemberDeclarationTest.java" />
   <suppress id="numberOfTestCasesInXpath" files="[\\/]src[\\/]it[\\/]java[\\/]org[\\/]checkstyle[\\/]suppressionxpathfilter[\\/]coding[\\/]XpathRegressionUnusedCatchParameterShouldBeUnnamedTest.java" />

--- a/src/it/java/org/checkstyle/suppressionxpathfilter/coding/XpathRegressionOverloadMethodsDeclarationOrderTest.java
+++ b/src/it/java/org/checkstyle/suppressionxpathfilter/coding/XpathRegressionOverloadMethodsDeclarationOrderTest.java
@@ -106,4 +106,32 @@ public class XpathRegressionOverloadMethodsDeclarationOrderTest extends Abstract
         runVerifications(moduleConfig, fileToProcess, expectedViolation, expectedXpathQueries);
     }
 
+    @Test
+    public void testEnum() throws Exception {
+        final File fileToProcess = new File(
+                getPath("InputXpathOverloadMethodsDeclarationOrderEnum.java"));
+
+        final DefaultConfiguration moduleConfig = createModuleConfig(CLAZZ);
+
+        final String[] expectedViolation = {
+            "15:5: " + getCheckMessage(CLAZZ,
+                        OverloadMethodsDeclarationOrderCheck.MSG_KEY, "7"),
+        };
+
+        final List<String> expectedXpathQueries = Arrays.asList(
+                "/COMPILATION_UNIT/ENUM_DEF[./IDENT"
+                        + "[@text='InputXpathOverloadMethodsDeclarationOrderEnum']]"
+                        + "/OBJBLOCK/METHOD_DEF[./IDENT[@text='overloadMethod']]",
+                "/COMPILATION_UNIT/ENUM_DEF[./IDENT"
+                        + "[@text='InputXpathOverloadMethodsDeclarationOrderEnum']]"
+                        + "/OBJBLOCK/METHOD_DEF[./IDENT[@text='overloadMethod']]/MODIFIERS",
+                "/COMPILATION_UNIT/ENUM_DEF[./IDENT"
+                        + "[@text='InputXpathOverloadMethodsDeclarationOrderEnum']]"
+                        + "/OBJBLOCK/METHOD_DEF[./IDENT[@text='overloadMethod']]"
+                        + "/MODIFIERS/LITERAL_PUBLIC"
+        );
+
+        runVerifications(moduleConfig, fileToProcess, expectedViolation, expectedXpathQueries);
+    }
+
 }

--- a/src/it/resources/org/checkstyle/suppressionxpathfilter/coding/overloadmethodsdeclarationorder/InputXpathOverloadMethodsDeclarationOrderEnum.java
+++ b/src/it/resources/org/checkstyle/suppressionxpathfilter/coding/overloadmethodsdeclarationorder/InputXpathOverloadMethodsDeclarationOrderEnum.java
@@ -1,0 +1,18 @@
+package org.checkstyle.suppressionxpathfilter.coding.overloadmethodsdeclarationorder;
+
+public enum InputXpathOverloadMethodsDeclarationOrderEnum {
+
+    VALUE;
+
+    public void overloadMethod(String s) {
+        //do stuff
+    }
+
+    public void separatorMethod() {
+        //do stuff
+    }
+
+    public void overloadMethod(String s, Boolean b, int i) { // warn
+        //do stuff
+    }
+}


### PR DESCRIPTION
Issue: #19064

Add third test (`testEnum`) to `XpathRegressionOverloadMethodsDeclarationOrderTest`.

The new test uses overloaded methods in an enum, producing an XPath through `ENUM_DEF/OBJBLOCK/METHOD_DEF` — different from the existing tests which use `CLASS_DEF/OBJBLOCK/METHOD_DEF` (top-level class) and `CLASS_DEF/OBJBLOCK/CLASS_DEF/OBJBLOCK/METHOD_DEF` (inner class).