### PR TITLE
Issue #19064: Add third test to XpathRegressionUnnecessarySemicolonAfterTypeMemberDeclarationTest

### DIFF
--- a/config/checkstyle-non-main-files-suppressions.xml
+++ b/config/checkstyle-non-main-files-suppressions.xml
@@ -424,7 +424,6 @@
 
   <suppress id="numberOfTestCasesInXpath" files="[\\/]src[\\/]it[\\/]java[\\/]org[\\/]checkstyle[\\/]suppressionxpathfilter[\\/]coding[\\/]XpathRegressionOverloadMethodsDeclarationOrderTest.java" />
   <suppress id="numberOfTestCasesInXpath" files="[\\/]src[\\/]it[\\/]java[\\/]org[\\/]checkstyle[\\/]suppressionxpathfilter[\\/]coding[\\/]XpathRegressionPackageDeclarationTest.java" />
-  <suppress id="numberOfTestCasesInXpath" files="[\\/]src[\\/]it[\\/]java[\\/]org[\\/]checkstyle[\\/]suppressionxpathfilter[\\/]coding[\\/]XpathRegressionUnnecessarySemicolonAfterTypeMemberDeclarationTest.java" />
   <suppress id="numberOfTestCasesInXpath" files="[\\/]src[\\/]it[\\/]java[\\/]org[\\/]checkstyle[\\/]suppressionxpathfilter[\\/]coding[\\/]XpathRegressionUnusedCatchParameterShouldBeUnnamedTest.java" />
   <suppress id="numberOfTestCasesInXpath" files="[\\/]src[\\/]it[\\/]java[\\/]org[\\/]checkstyle[\\/]suppressionxpathfilter[\\/]coding[\\/]XpathRegressionVariableDeclarationUsageDistanceTest.java" />
   <suppress id="numberOfTestCasesInXpath" files="[\\/]src[\\/]it[\\/]java[\\/]org[\\/]checkstyle[\\/]suppressionxpathfilter[\\/]coding[\\/]XpathRegressionWhenShouldBeUsedTest.java" />

--- a/src/it/java/org/checkstyle/suppressionxpathfilter/coding/XpathRegressionUnnecessarySemicolonAfterTypeMemberDeclarationTest.java
+++ b/src/it/java/org/checkstyle/suppressionxpathfilter/coding/XpathRegressionUnnecessarySemicolonAfterTypeMemberDeclarationTest.java
@@ -88,4 +88,24 @@ public class XpathRegressionUnnecessarySemicolonAfterTypeMemberDeclarationTest
 
         runVerifications(moduleConfig, fileToProcess, expectedViolation, expectedXpathQueries);
     }
+
+    @Test
+    public void testEnum() throws Exception {
+        final File fileToProcess = new File(getPath(
+            "InputXpathUnnecessarySemicolonAfterTypeMemberDeclarationEnum.java"));
+        final DefaultConfiguration moduleConfig = createModuleConfig(CLASS);
+        final String[] expectedViolation = {
+            "5:21: " + getCheckMessage(CLASS,
+                UnnecessarySemicolonAfterTypeMemberDeclarationCheck.MSG_SEMI),
+        };
+
+        final List<String> expectedXpathQueries = Collections.singletonList(
+            "/COMPILATION_UNIT/ENUM_DEF[./IDENT"
+                + "[@text="
+                + "'InputXpathUnnecessarySemicolonAfterTypeMemberDeclarationEnum']]"
+                + "/OBJBLOCK/SEMI[2]"
+        );
+
+        runVerifications(moduleConfig, fileToProcess, expectedViolation, expectedXpathQueries);
+    }
 }

--- a/src/it/resources/org/checkstyle/suppressionxpathfilter/coding/unnecessarysemicolonaftertypememberdeclaration/InputXpathUnnecessarySemicolonAfterTypeMemberDeclarationEnum.java
+++ b/src/it/resources/org/checkstyle/suppressionxpathfilter/coding/unnecessarysemicolonaftertypememberdeclaration/InputXpathUnnecessarySemicolonAfterTypeMemberDeclarationEnum.java
@@ -1,0 +1,6 @@
+package org.checkstyle.suppressionxpathfilter.coding.unnecessarysemicolonaftertypememberdeclaration;
+
+public enum InputXpathUnnecessarySemicolonAfterTypeMemberDeclarationEnum {
+    VALUE;
+    void method() {}; // warn
+}


### PR DESCRIPTION
Issue: #19064

Add third test (`testEnum`) to `XpathRegressionUnnecessarySemicolonAfterTypeMemberDeclarationTest`.The new test uses an unnecessary semicolon after a method in an enum, producing an XPath through `ENUM_DEF/OBJBLOCK/SEMI[2]` — different from the existing tests which use `CLASS_DEF/OBJBLOCK/SEMI` (top-level class).