### PR TITLE
Issue #19064: Add 3rd test to XpathRegressionUnnecessarySemicolonInEnumerationTest

### DIFF
--- a/config/checkstyle-non-main-files-suppressions.xml
+++ b/config/checkstyle-non-main-files-suppressions.xml
@@ -427,7 +427,6 @@
   <suppress id="numberOfTestCasesInXpath" files="[\\/]src[\\/]it[\\/]java[\\/]org[\\/]checkstyle[\\/]suppressionxpathfilter[\\/]coding[\\/]XpathRegressionPackageDeclarationTest.java" />
   <suppress id="numberOfTestCasesInXpath" files="[\\/]src[\\/]it[\\/]java[\\/]org[\\/]checkstyle[\\/]suppressionxpathfilter[\\/]coding[\\/]XpathRegressionSimplifyBooleanReturnTest.java" />
   <suppress id="numberOfTestCasesInXpath" files="[\\/]src[\\/]it[\\/]java[\\/]org[\\/]checkstyle[\\/]suppressionxpathfilter[\\/]coding[\\/]XpathRegressionUnnecessarySemicolonAfterTypeMemberDeclarationTest.java" />
-  <suppress id="numberOfTestCasesInXpath" files="[\\/]src[\\/]it[\\/]java[\\/]org[\\/]checkstyle[\\/]suppressionxpathfilter[\\/]coding[\\/]XpathRegressionUnnecessarySemicolonInEnumerationTest.java" />
   <suppress id="numberOfTestCasesInXpath" files="[\\/]src[\\/]it[\\/]java[\\/]org[\\/]checkstyle[\\/]suppressionxpathfilter[\\/]coding[\\/]XpathRegressionUnusedCatchParameterShouldBeUnnamedTest.java" />
   <suppress id="numberOfTestCasesInXpath" files="[\\/]src[\\/]it[\\/]java[\\/]org[\\/]checkstyle[\\/]suppressionxpathfilter[\\/]coding[\\/]XpathRegressionVariableDeclarationUsageDistanceTest.java" />
   <suppress id="numberOfTestCasesInXpath" files="[\\/]src[\\/]it[\\/]java[\\/]org[\\/]checkstyle[\\/]suppressionxpathfilter[\\/]coding[\\/]XpathRegressionWhenShouldBeUsedTest.java" />

--- a/src/it/java/org/checkstyle/suppressionxpathfilter/coding/XpathRegressionUnnecessarySemicolonInEnumerationTest.java
+++ b/src/it/java/org/checkstyle/suppressionxpathfilter/coding/XpathRegressionUnnecessarySemicolonInEnumerationTest.java
@@ -87,4 +87,27 @@ public class XpathRegressionUnnecessarySemicolonInEnumerationTest
 
         runVerifications(moduleConfig, fileToProcess, expectedViolation, expectedXpathQueries);
     }
+
+    @Test
+    public void testInnerEnum() throws Exception {
+        final File fileToProcess = new File(getPath(
+            "InputXpathUnnecessarySemicolonInEnumerationInnerEnum.java"));
+
+        final DefaultConfiguration moduleConfig =
+                createModuleConfig(UnnecessarySemicolonInEnumerationCheck.class);
+
+        final String[] expectedViolation = {
+            "6:17: " + getCheckMessage(UnnecessarySemicolonInEnumerationCheck.class,
+                UnnecessarySemicolonInEnumerationCheck.MSG_SEMI),
+        };
+
+        final List<String> expectedXpathQueries = Collections.singletonList(
+            "/COMPILATION_UNIT/CLASS_DEF[./IDENT[@text="
+                + "'InputXpathUnnecessarySemicolonInEnumerationInnerEnum']]"
+                + "/OBJBLOCK/ENUM_DEF[./IDENT[@text='Status']]"
+                + "/OBJBLOCK/SEMI"
+        );
+
+        runVerifications(moduleConfig, fileToProcess, expectedViolation, expectedXpathQueries);
+    }
 }

--- a/src/it/resources/org/checkstyle/suppressionxpathfilter/coding/unnecessarysemicoloninenumeration/InputXpathUnnecessarySemicolonInEnumerationInnerEnum.java
+++ b/src/it/resources/org/checkstyle/suppressionxpathfilter/coding/unnecessarysemicoloninenumeration/InputXpathUnnecessarySemicolonInEnumerationInnerEnum.java
@@ -1,0 +1,8 @@
+package org.checkstyle.suppressionxpathfilter.coding.unnecessarysemicoloninenumeration;
+
+public class InputXpathUnnecessarySemicolonInEnumerationInnerEnum {
+    enum Status {
+        ACTIVE,
+        INACTIVE; // warn
+    }
+}


### PR DESCRIPTION
Contributes to #19064

Added testInnerEnum() as the 3rd test method to XpathRegressionUnnecessarySemicolonInEnumerationTest. The new test uses an inner enum (Status) declared inside a class, differentiating from the existing tests which use top-level enum definitions.

Changes:
Added input fie InputXpathUnnecessarySemicolonInEnumerationInnerEnum.java
Added testInnerEnum() to XpathRegressionUnnecessarySemicolonInEnumerationTest
Removed suppression for XpathRegressionUnnecessarySemicolonInEnumerationTest from checkstyle-non-main-files-suppressions.xml