### PR TITLE
Issue #19064: Add 3rd test to XpathRegressionUnusedCatchParameterShouldBeUnnamedTest

### DIFF
--- a/config/checkstyle-non-main-files-suppressions.xml
+++ b/config/checkstyle-non-main-files-suppressions.xml
@@ -421,7 +421,6 @@
 
   <suppress id="numberOfTestCasesInXpath" files="[\\/]src[\\/]it[\\/]java[\\/]org[\\/]checkstyle[\\/]suppressionxpathfilter[\\/]coding[\\/]XpathRegressionOverloadMethodsDeclarationOrderTest.java" />
   <suppress id="numberOfTestCasesInXpath" files="[\\/]src[\\/]it[\\/]java[\\/]org[\\/]checkstyle[\\/]suppressionxpathfilter[\\/]coding[\\/]XpathRegressionUnnecessarySemicolonAfterTypeMemberDeclarationTest.java" />
-  <suppress id="numberOfTestCasesInXpath" files="[\\/]src[\\/]it[\\/]java[\\/]org[\\/]checkstyle[\\/]suppressionxpathfilter[\\/]coding[\\/]XpathRegressionUnusedCatchParameterShouldBeUnnamedTest.java" />
   <suppress id="numberOfTestCasesInXpath" files="[\\/]src[\\/]it[\\/]java[\\/]org[\\/]checkstyle[\\/]suppressionxpathfilter[\\/]metrics[\\/]XpathRegressionCyclomaticComplexityTest.java" />
   <suppress id="numberOfTestCasesInXpath" files="[\\/]src[\\/]it[\\/]java[\\/]org[\\/]checkstyle[\\/]suppressionxpathfilter[\\/]modifier[\\/]XpathRegressionClassMemberImpliedModifierTest.java" />
   <suppress id="numberOfTestCasesInXpath" files="[\\/]src[\\/]it[\\/]java[\\/]org[\\/]checkstyle[\\/]suppressionxpathfilter[\\/]naming[\\/]XpathRegressionMemberNameTest.java" />

--- a/src/it/java/org/checkstyle/suppressionxpathfilter/coding/XpathRegressionUnusedCatchParameterShouldBeUnnamedTest.java
+++ b/src/it/java/org/checkstyle/suppressionxpathfilter/coding/XpathRegressionUnusedCatchParameterShouldBeUnnamedTest.java
@@ -125,4 +125,48 @@ public class XpathRegressionUnusedCatchParameterShouldBeUnnamedTest
         runVerifications(moduleConfig, fileToProcess, expectedViolation,
                 expectedXpathQueries);
     }
+
+    @Test
+    public void testConstructor() throws Exception {
+        final File fileToProcess =
+                new File(getPath(
+                        "InputXpathUnusedCatchParameterShouldBeUnnamedConstructor.java"));
+
+        final DefaultConfiguration moduleConfig =
+                createModuleConfig(UnusedCatchParameterShouldBeUnnamedCheck.class);
+
+        final String[] expectedViolation = {
+            "10:16: " + getCheckMessage(UnusedCatchParameterShouldBeUnnamedCheck.class,
+                    UnusedCatchParameterShouldBeUnnamedCheck.MSG_UNUSED_CATCH_PARAMETER,
+                    "e"),
+        };
+
+        final List<String> expectedXpathQueries = Arrays.asList(
+                "/COMPILATION_UNIT/CLASS_DEF[./IDENT[@text='InputXpath"
+                        + "UnusedCatchParameterShouldBeUnnamedConstructor']]"
+                        + "/OBJBLOCK/CTOR_DEF[./IDENT[@text='InputXpath"
+                        + "UnusedCatchParameterShouldBeUnnamedConstructor']]/SLIST"
+                        + "/LITERAL_TRY/LITERAL_CATCH/PARAMETER_DEF[./IDENT[@text='e']]",
+                "/COMPILATION_UNIT/CLASS_DEF[./IDENT[@text='InputXpath"
+                        + "UnusedCatchParameterShouldBeUnnamedConstructor']]"
+                        + "/OBJBLOCK/CTOR_DEF[./IDENT[@text='InputXpath"
+                        + "UnusedCatchParameterShouldBeUnnamedConstructor']]/SLIST"
+                        + "/LITERAL_TRY/LITERAL_CATCH/PARAMETER_DEF[./IDENT[@text='e']]/MODIFIERS",
+                "/COMPILATION_UNIT/CLASS_DEF[./IDENT[@text='InputXpath"
+                        + "UnusedCatchParameterShouldBeUnnamedConstructor']]"
+                        + "/OBJBLOCK/CTOR_DEF[./IDENT[@text='InputXpath"
+                        + "UnusedCatchParameterShouldBeUnnamedConstructor']]/SLIST"
+                        + "/LITERAL_TRY/LITERAL_CATCH/PARAMETER_DEF[./IDENT[@text='e']]"
+                        + "/TYPE[./IDENT[@text='Exception']]",
+                "/COMPILATION_UNIT/CLASS_DEF[./IDENT[@text='InputXpath"
+                        + "UnusedCatchParameterShouldBeUnnamedConstructor']]"
+                        + "/OBJBLOCK/CTOR_DEF[./IDENT[@text='InputXpath"
+                        + "UnusedCatchParameterShouldBeUnnamedConstructor']]/SLIST"
+                        + "/LITERAL_TRY/LITERAL_CATCH/PARAMETER_DEF[./IDENT[@text='e']]"
+                        + "/TYPE/IDENT[@text='Exception']"
+        );
+
+        runVerifications(moduleConfig, fileToProcess, expectedViolation,
+                expectedXpathQueries);
+    }
 }

--- a/src/it/resources/org/checkstyle/suppressionxpathfilter/coding/unusedcatchparametershouldbeunnamed/InputXpathUnusedCatchParameterShouldBeUnnamedConstructor.java
+++ b/src/it/resources/org/checkstyle/suppressionxpathfilter/coding/unusedcatchparametershouldbeunnamed/InputXpathUnusedCatchParameterShouldBeUnnamedConstructor.java
@@ -1,0 +1,14 @@
+// Java21
+package org.checkstyle.suppressionxpathfilter.coding.unusedcatchparametershouldbeunnamed;
+
+public class InputXpathUnusedCatchParameterShouldBeUnnamedConstructor {
+
+    InputXpathUnusedCatchParameterShouldBeUnnamedConstructor() {
+        try {
+            int x = 1 / 0;
+        }
+        catch (Exception e) {  // warn
+            System.out.println("infinity");
+        }
+    }
+}


### PR DESCRIPTION
Contributes to #19064

Added `testConstructor()` as the 3rd test method to `XpathRegressionUnusedCatchParameterShouldBeUnnamedTest`. The new test uses an unused catch parameter inside a constructor, differentiating from the existing tests which use catch parameters inside methods (`testSimple` in a method, `testNested` with nested try-catch in a method).

**updates:**
- Added input file `InputXpathUnusedCatchParameterShouldBeUnnamedConstructor`
- Added `testConstructor()` to `XpathRegressionUnusedCatchParameterShouldBeUnnamedTest`
- Removed suppression for `XpathRegressionUnusedCatchParameterShouldBeUnnamedTest` from `checkstyle-non-main-files-suppressions.xml`