### PR TITLE
Issue #19064: Add 3rd test to XpathRegressionVariableDeclarationUsaeDistance

### DIFF
--- a/config/checkstyle-non-main-files-suppressions.xml
+++ b/config/checkstyle-non-main-files-suppressions.xml
@@ -422,7 +422,6 @@
   <suppress id="numberOfTestCasesInXpath" files="[\\/]src[\\/]it[\\/]java[\\/]org[\\/]checkstyle[\\/]suppressionxpathfilter[\\/]coding[\\/]XpathRegressionOverloadMethodsDeclarationOrderTest.java" />
   <suppress id="numberOfTestCasesInXpath" files="[\\/]src[\\/]it[\\/]java[\\/]org[\\/]checkstyle[\\/]suppressionxpathfilter[\\/]coding[\\/]XpathRegressionUnnecessarySemicolonAfterTypeMemberDeclarationTest.java" />
   <suppress id="numberOfTestCasesInXpath" files="[\\/]src[\\/]it[\\/]java[\\/]org[\\/]checkstyle[\\/]suppressionxpathfilter[\\/]coding[\\/]XpathRegressionUnusedCatchParameterShouldBeUnnamedTest.java" />
-  <suppress id="numberOfTestCasesInXpath" files="[\\/]src[\\/]it[\\/]java[\\/]org[\\/]checkstyle[\\/]suppressionxpathfilter[\\/]coding[\\/]XpathRegressionVariableDeclarationUsageDistanceTest.java" />
   <suppress id="numberOfTestCasesInXpath" files="[\\/]src[\\/]it[\\/]java[\\/]org[\\/]checkstyle[\\/]suppressionxpathfilter[\\/]metrics[\\/]XpathRegressionCyclomaticComplexityTest.java" />
   <suppress id="numberOfTestCasesInXpath" files="[\\/]src[\\/]it[\\/]java[\\/]org[\\/]checkstyle[\\/]suppressionxpathfilter[\\/]modifier[\\/]XpathRegressionClassMemberImpliedModifierTest.java" />
   <suppress id="numberOfTestCasesInXpath" files="[\\/]src[\\/]it[\\/]java[\\/]org[\\/]checkstyle[\\/]suppressionxpathfilter[\\/]naming[\\/]XpathRegressionMemberNameTest.java" />

--- a/src/it/java/org/checkstyle/suppressionxpathfilter/coding/XpathRegressionVariableDeclarationUsageDistanceTest.java
+++ b/src/it/java/org/checkstyle/suppressionxpathfilter/coding/XpathRegressionVariableDeclarationUsageDistanceTest.java
@@ -123,4 +123,48 @@ public class XpathRegressionVariableDeclarationUsageDistanceTest extends Abstrac
                 expectedXpathQueries);
     }
 
+    @Test
+    public void testConstructor() throws Exception {
+        final File fileToProcess = new File(getPath(
+                "InputXpathVariableDeclarationUsageDistanceConstructor.java"));
+
+        final DefaultConfiguration moduleConfig =
+                createModuleConfig(VariableDeclarationUsageDistanceCheck.class);
+        moduleConfig.addProperty("allowedDistance", "1");
+        moduleConfig.addProperty("ignoreVariablePattern", "");
+        moduleConfig.addProperty("validateBetweenScopes", "true");
+        moduleConfig.addProperty("ignoreFinal", "false");
+
+        final String[] expectedViolation = {
+            "7:9: " + getCheckMessage(VariableDeclarationUsageDistanceCheck.class,
+                    VariableDeclarationUsageDistanceCheck.MSG_KEY, "temp", 2, 1),
+        };
+
+        final List<String> expectedXpathQueries = Arrays.asList(
+                "/COMPILATION_UNIT/CLASS_DEF[./IDENT[@text="
+                        + "'InputXpathVariableDeclarationUsageDistanceConstructor']]"
+                        + "/OBJBLOCK/CTOR_DEF[./IDENT[@text="
+                        + "'InputXpathVariableDeclarationUsageDistanceConstructor']]"
+                        + "/SLIST/VARIABLE_DEF[./IDENT[@text='temp']]",
+                "/COMPILATION_UNIT/CLASS_DEF[./IDENT[@text="
+                        + "'InputXpathVariableDeclarationUsageDistanceConstructor']]"
+                        + "/OBJBLOCK/CTOR_DEF[./IDENT[@text="
+                        + "'InputXpathVariableDeclarationUsageDistanceConstructor']]"
+                        + "/SLIST/VARIABLE_DEF[./IDENT[@text='temp']]/MODIFIERS",
+                "/COMPILATION_UNIT/CLASS_DEF[./IDENT[@text="
+                        + "'InputXpathVariableDeclarationUsageDistanceConstructor']]"
+                        + "/OBJBLOCK/CTOR_DEF[./IDENT[@text="
+                        + "'InputXpathVariableDeclarationUsageDistanceConstructor']]"
+                        + "/SLIST/VARIABLE_DEF[./IDENT[@text='temp']]/TYPE",
+                "/COMPILATION_UNIT/CLASS_DEF[./IDENT[@text="
+                        + "'InputXpathVariableDeclarationUsageDistanceConstructor']]"
+                        + "/OBJBLOCK/CTOR_DEF[./IDENT[@text="
+                        + "'InputXpathVariableDeclarationUsageDistanceConstructor']]"
+                        + "/SLIST/VARIABLE_DEF[./IDENT[@text='temp']]/TYPE/LITERAL_INT"
+        );
+
+        runVerifications(moduleConfig, fileToProcess, expectedViolation,
+                expectedXpathQueries);
+    }
+
 }

--- a/src/it/resources/org/checkstyle/suppressionxpathfilter/coding/variabledeclarationusagedistance/InputXpathVariableDeclarationUsageDistanceConstructor.java
+++ b/src/it/resources/org/checkstyle/suppressionxpathfilter/coding/variabledeclarationusagedistance/InputXpathVariableDeclarationUsageDistanceConstructor.java
@@ -1,0 +1,11 @@
+package org.checkstyle.suppressionxpathfilter.coding.variabledeclarationusagedistance;
+
+public class InputXpathVariableDeclarationUsageDistanceConstructor {
+    private int field;
+
+    InputXpathVariableDeclarationUsageDistanceConstructor(int val) {
+        int temp = -1; // warn
+        this.field = val;
+        temp = val;
+    }
+}


### PR DESCRIPTION
Contributes to #19064

Added `testConstructor()` as the 3rd test method to `XpathRegressionVariableDeclarationUsageDistanceTest`. The new test uses a variable declaration usage distance violation inside a constructor, differentiating from the existing tests which both use violations inside methods (`testOne` and `testTwo` use `METHOD_DEF`). The new test goes through `CTOR_DEF`.

**Changes:**
- Added input file `InputXpathVariableDeclarationUsageDistanceConstructor`
- Added `testConstructor()` to `XpathRegressionVariableDeclarationUsageDistanceTest`
- Removed suppression for `XpathRegressionVariableDeclarationUsageDistanceTest` from `checkstyle-non-main-files-suppressions.xml`