### PR TITLE
Issue #19064: Add 3rd test to XpathRegressionWhenShouldBeUsedTest

### DIFF
--- a/config/checkstyle-non-main-files-suppressions.xml
+++ b/config/checkstyle-non-main-files-suppressions.xml
@@ -427,7 +427,6 @@
   <suppress id="numberOfTestCasesInXpath" files="[\\/]src[\\/]it[\\/]java[\\/]org[\\/]checkstyle[\\/]suppressionxpathfilter[\\/]coding[\\/]XpathRegressionUnnecessarySemicolonAfterTypeMemberDeclarationTest.java" />
   <suppress id="numberOfTestCasesInXpath" files="[\\/]src[\\/]it[\\/]java[\\/]org[\\/]checkstyle[\\/]suppressionxpathfilter[\\/]coding[\\/]XpathRegressionUnusedCatchParameterShouldBeUnnamedTest.java" />
   <suppress id="numberOfTestCasesInXpath" files="[\\/]src[\\/]it[\\/]java[\\/]org[\\/]checkstyle[\\/]suppressionxpathfilter[\\/]coding[\\/]XpathRegressionVariableDeclarationUsageDistanceTest.java" />
-  <suppress id="numberOfTestCasesInXpath" files="[\\/]src[\\/]it[\\/]java[\\/]org[\\/]checkstyle[\\/]suppressionxpathfilter[\\/]coding[\\/]XpathRegressionWhenShouldBeUsedTest.java" />
   <suppress id="numberOfTestCasesInXpath" files="[\\/]src[\\/]it[\\/]java[\\/]org[\\/]checkstyle[\\/]suppressionxpathfilter[\\/]design[\\/]XpathRegressionHideUtilityClassConstructorTest.java" />
   <suppress id="numberOfTestCasesInXpath" files="[\\/]src[\\/]it[\\/]java[\\/]org[\\/]checkstyle[\\/]suppressionxpathfilter[\\/]design[\\/]XpathRegressionInterfaceIsTypeTest.java" />
   <suppress id="numberOfTestCasesInXpath" files="[\\/]src[\\/]it[\\/]java[\\/]org[\\/]checkstyle[\\/]suppressionxpathfilter[\\/]design[\\/]XpathRegressionSealedShouldHavePermitsListTest.java" />

--- a/src/it/java/org/checkstyle/suppressionxpathfilter/coding/XpathRegressionWhenShouldBeUsedTest.java
+++ b/src/it/java/org/checkstyle/suppressionxpathfilter/coding/XpathRegressionWhenShouldBeUsedTest.java
@@ -94,4 +94,27 @@ public class XpathRegressionWhenShouldBeUsedTest
         );
         runVerifications(moduleConfig, fileToProcess, expectedViolation, expectedXpathQueries);
     }
+
+    @Test
+    public void testStaticInit() throws Exception {
+        final File fileToProcess =
+                new File(getPath(
+                        "InputXpathWhenShouldBeUsedStaticInit.java"));
+
+        final DefaultConfiguration moduleConfig =
+                createModuleConfig(WhenShouldBeUsedCheck.class);
+        final String[] expectedViolation = {
+            "8:13: " + getCheckMessage(WhenShouldBeUsedCheck.class,
+                    WhenShouldBeUsedCheck.MSG_KEY),
+        };
+
+        final List<String> expectedXpathQueries = Arrays.asList(
+                "/COMPILATION_UNIT/CLASS_DEF[./IDENT[@text='InputXpathWhenShouldBeUsedStaticInit']]"
+                + "/OBJBLOCK/STATIC_INIT/SLIST/LITERAL_SWITCH/SWITCH_RULE"
+                + "[./LITERAL_CASE/PATTERN_VARIABLE_DEF/IDENT[@text='i']]",
+                "/COMPILATION_UNIT/CLASS_DEF[./IDENT[@text='InputXpathWhenShouldBeUsedStaticInit']]"
+                + "/OBJBLOCK/STATIC_INIT/SLIST/LITERAL_SWITCH/SWITCH_RULE/LITERAL_CASE"
+        );
+        runVerifications(moduleConfig, fileToProcess, expectedViolation, expectedXpathQueries);
+    }
 }

--- a/src/it/resources/org/checkstyle/suppressionxpathfilter/coding/whenshouldbeused/InputXpathWhenShouldBeUsedStaticInit.java
+++ b/src/it/resources/org/checkstyle/suppressionxpathfilter/coding/whenshouldbeused/InputXpathWhenShouldBeUsedStaticInit.java
@@ -1,0 +1,16 @@
+// Java21
+package org.checkstyle.suppressionxpathfilter.coding.whenshouldbeused;
+
+public class InputXpathWhenShouldBeUsedStaticInit {
+    static Object obj = "test";
+    static {
+        switch (obj) {
+            case Integer i -> { // warn
+                if (i > 0) {
+                    System.out.println("positive");
+                }
+            }
+            default -> {}
+        }
+    }
+}


### PR DESCRIPTION
Contributes to #19064
Added `testStaticInit()` as the 3rd test method to `XpathRegressionWhenShouldBeUsedTest`. The new test uses a pattern variable in a switch statement inside a static initializer block, differentiating from the existing tests which use violations inside methods `testSimple` and `testNested` use `METHOD_DEF`. The new test goes through `STATIC_INIT`.