### PR TITLE
Issue #19064: Add 3rd test to XpathRegressionDesignForExtensionTest

### DIFF
--- a/config/checkstyle-non-main-files-suppressions.xml
+++ b/config/checkstyle-non-main-files-suppressions.xml
@@ -431,7 +431,6 @@
   <suppress id="numberOfTestCasesInXpath" files="[\\/]src[\\/]it[\\/]java[\\/]org[\\/]checkstyle[\\/]suppressionxpathfilter[\\/]coding[\\/]XpathRegressionUnusedCatchParameterShouldBeUnnamedTest.java" />
   <suppress id="numberOfTestCasesInXpath" files="[\\/]src[\\/]it[\\/]java[\\/]org[\\/]checkstyle[\\/]suppressionxpathfilter[\\/]coding[\\/]XpathRegressionVariableDeclarationUsageDistanceTest.java" />
   <suppress id="numberOfTestCasesInXpath" files="[\\/]src[\\/]it[\\/]java[\\/]org[\\/]checkstyle[\\/]suppressionxpathfilter[\\/]coding[\\/]XpathRegressionWhenShouldBeUsedTest.java" />
-  <suppress id="numberOfTestCasesInXpath" files="[\\/]src[\\/]it[\\/]java[\\/]org[\\/]checkstyle[\\/]suppressionxpathfilter[\\/]design[\\/]XpathRegressionDesignForExtensionTest.java" />
   <suppress id="numberOfTestCasesInXpath" files="[\\/]src[\\/]it[\\/]java[\\/]org[\\/]checkstyle[\\/]suppressionxpathfilter[\\/]design[\\/]XpathRegressionHideUtilityClassConstructorTest.java" />
   <suppress id="numberOfTestCasesInXpath" files="[\\/]src[\\/]it[\\/]java[\\/]org[\\/]checkstyle[\\/]suppressionxpathfilter[\\/]design[\\/]XpathRegressionInterfaceIsTypeTest.java" />
   <suppress id="numberOfTestCasesInXpath" files="[\\/]src[\\/]it[\\/]java[\\/]org[\\/]checkstyle[\\/]suppressionxpathfilter[\\/]design[\\/]XpathRegressionSealedShouldHavePermitsListTest.java" />

--- a/src/it/java/org/checkstyle/suppressionxpathfilter/design/XpathRegressionDesignForExtensionTest.java
+++ b/src/it/java/org/checkstyle/suppressionxpathfilter/design/XpathRegressionDesignForExtensionTest.java
@@ -109,4 +109,35 @@ public class XpathRegressionDesignForExtensionTest extends AbstractXpathTestSupp
         runVerifications(moduleConfig, fileToProcess, expected, expectedXpathQueries);
 
     }
+
+    @Test
+    public void testProtected() throws Exception {
+        final File fileToProcess =
+                new File(getPath("InputXpathDesignForExtensionProtected.java"));
+
+        final DefaultConfiguration moduleConfig =
+                createModuleConfig(DesignForExtensionCheck.class);
+        moduleConfig.addProperty("ignoredAnnotations", "Override");
+
+        final String[] expected = {
+            "7:5: " + getCheckMessage(DesignForExtensionCheck.class,
+                    DesignForExtensionCheck.MSG_KEY,
+                    "InputXpathDesignForExtensionProtected",
+                    "getValue"),
+        };
+
+        final List<String> expectedXpathQueries = Arrays.asList(
+            "/COMPILATION_UNIT/CLASS_DEF[./IDENT"
+               + "[@text='InputXpathDesignForExtensionProtected']]/OBJBLOCK"
+               + "/METHOD_DEF[./IDENT[@text='getValue']]",
+            "/COMPILATION_UNIT/CLASS_DEF[./IDENT"
+               + "[@text='InputXpathDesignForExtensionProtected']]/OBJBLOCK"
+               + "/METHOD_DEF[./IDENT[@text='getValue']]/MODIFIERS",
+            "/COMPILATION_UNIT/CLASS_DEF[./IDENT"
+               + "[@text='InputXpathDesignForExtensionProtected']]/OBJBLOCK"
+               + "/METHOD_DEF[./IDENT[@text='getValue']]/MODIFIERS/LITERAL_PROTECTED"
+        );
+
+        runVerifications(moduleConfig, fileToProcess, expected, expectedXpathQueries);
+    }
 }

--- a/src/it/resources/org/checkstyle/suppressionxpathfilter/design/designforextension/InputXpathDesignForExtensionProtected.java
+++ b/src/it/resources/org/checkstyle/suppressionxpathfilter/design/designforextension/InputXpathDesignForExtensionProtected.java
@@ -1,0 +1,15 @@
+package org.checkstyle.suppressionxpathfilter.design.designforextension;
+
+public class InputXpathDesignForExtensionProtected
+        extends ParentClass
+        implements ExampleInterface {
+
+    protected int getValue() {  // warn
+        return 1;
+    }
+
+    @Override
+    public void someMethod() {
+        return;
+    }
+}


### PR DESCRIPTION
Contributes to #19064

Added `testProtected()` as the 3rd test method to `XpathRegressionDesignForExtensionTest`. The new test uses a `protected` method that is not designed for safe extension, differentiating from the existing tests which both use `public` methods (`LITERAL_PUBLIC`). The new test's XPath ends with `LITERAL_PROTECTED`.