### PR TITLE
Issue #19064: Add 3rd test to XpathRegressionHideUtilityClassConstructorTest

### DIFF
--- a/config/checkstyle-non-main-files-suppressions.xml
+++ b/config/checkstyle-non-main-files-suppressions.xml
@@ -424,7 +424,6 @@
   <suppress id="numberOfTestCasesInXpath" files="[\\/]src[\\/]it[\\/]java[\\/]org[\\/]checkstyle[\\/]suppressionxpathfilter[\\/]coding[\\/]XpathRegressionUnnecessarySemicolonAfterTypeMemberDeclarationTest.java" />
   <suppress id="numberOfTestCasesInXpath" files="[\\/]src[\\/]it[\\/]java[\\/]org[\\/]checkstyle[\\/]suppressionxpathfilter[\\/]coding[\\/]XpathRegressionUnusedCatchParameterShouldBeUnnamedTest.java" />
   <suppress id="numberOfTestCasesInXpath" files="[\\/]src[\\/]it[\\/]java[\\/]org[\\/]checkstyle[\\/]suppressionxpathfilter[\\/]coding[\\/]XpathRegressionVariableDeclarationUsageDistanceTest.java" />
-  <suppress id="numberOfTestCasesInXpath" files="[\\/]src[\\/]it[\\/]java[\\/]org[\\/]checkstyle[\\/]suppressionxpathfilter[\\/]design[\\/]XpathRegressionHideUtilityClassConstructorTest.java" />
   <suppress id="numberOfTestCasesInXpath" files="[\\/]src[\\/]it[\\/]java[\\/]org[\\/]checkstyle[\\/]suppressionxpathfilter[\\/]design[\\/]XpathRegressionSealedShouldHavePermitsListTest.java" />
   <suppress id="numberOfTestCasesInXpath" files="[\\/]src[\\/]it[\\/]java[\\/]org[\\/]checkstyle[\\/]suppressionxpathfilter[\\/]imports[\\/]XpathRegressionIllegalImportTest.java" />
   <suppress id="numberOfTestCasesInXpath" files="[\\/]src[\\/]it[\\/]java[\\/]org[\\/]checkstyle[\\/]suppressionxpathfilter[\\/]javadoc[\\/]XpathRegressionJavadocVariableTest.java" />

--- a/src/it/java/org/checkstyle/suppressionxpathfilter/design/XpathRegressionHideUtilityClassConstructorTest.java
+++ b/src/it/java/org/checkstyle/suppressionxpathfilter/design/XpathRegressionHideUtilityClassConstructorTest.java
@@ -23,6 +23,7 @@ import static com.puppycrawl.tools.checkstyle.checks.design.HideUtilityClassCons
 
 import java.io.File;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 
 import org.checkstyle.suppressionxpathfilter.AbstractXpathTestSupport;
@@ -83,6 +84,28 @@ public class XpathRegressionHideUtilityClassConstructorTest extends AbstractXpat
                     + "InputXpathHideUtilityClassConstructorPublic']]/MODIFIERS",
             "/COMPILATION_UNIT/CLASS_DEF[./IDENT[@text='"
                     + "InputXpathHideUtilityClassConstructorPublic']]/MODIFIERS/LITERAL_PUBLIC"
+        );
+
+        runVerifications(moduleConfig, fileToProcess, expectedViolation,
+                expectedXpathQueries);
+    }
+
+    @Test
+    public void testPackagePrivate() throws Exception {
+        final File fileToProcess =
+                new File(getPath("InputXpathHideUtilityClassConstructorPackagePrivate.java"));
+        final DefaultConfiguration moduleConfig =
+                createModuleConfig(HideUtilityClassConstructorCheck.class);
+        final String[] expectedViolation = {
+            "3:1: " + getCheckMessage(HideUtilityClassConstructorCheck.class, MSG_KEY),
+        };
+        final List<String> expectedXpathQueries = Arrays.asList(
+            "/COMPILATION_UNIT/CLASS_DEF[./IDENT[@text='"
+                    + "InputXpathHideUtilityClassConstructorPackagePrivate']]",
+            "/COMPILATION_UNIT/CLASS_DEF[./IDENT[@text='"
+                    + "InputXpathHideUtilityClassConstructorPackagePrivate']]/MODIFIERS",
+            "/COMPILATION_UNIT/CLASS_DEF[./IDENT[@text='"
+                    + "InputXpathHideUtilityClassConstructorPackagePrivate']]/LITERAL_CLASS"
         );
 
         runVerifications(moduleConfig, fileToProcess, expectedViolation,

--- a/src/it/resources/org/checkstyle/suppressionxpathfilter/design/hideutilityclassconstructor/InputXpathHideUtilityClassConstructorPackagePrivate.java
+++ b/src/it/resources/org/checkstyle/suppressionxpathfilter/design/hideutilityclassconstructor/InputXpathHideUtilityClassConstructorPackagePrivate.java
@@ -1,0 +1,6 @@
+package org.checkstyle.suppressionxpathfilter.design.hideutilityclassconstructor;
+
+class InputXpathHideUtilityClassConstructorPackagePrivate { // warn
+    public static void doSomething() {
+    }
+}


### PR DESCRIPTION
Contributes to #19064

Added `testPackagePrivate()` as the 3rd test method to `XpathRegressionHideUtilityClassConstructorTest`. The new test uses a package-private (no access modifier) utility class, differentiating from the existing tests which both use `public` classes. The new test's XPath includes `MODIFIERS` (empty) and `LITERAL_CLASS` instead of `MODIFIERS/LITERAL_PUBLIC`.