### PR TITLE
Issue #16807: fix PatternVariableName xdoc examples and tests

### DIFF
--- a/src/site/xdoc/checks/naming/patternvariablename.xml
+++ b/src/site/xdoc/checks/naming/patternvariablename.xml
@@ -51,9 +51,11 @@
         <div class="wrapper"><pre class="prettyprint"><code class="language-java">
 class Example1 {
   void foo(Object o1){
-    if (o1 instanceof String STRING) {} // violation
+    if (o1 instanceof String STRING) {}
+    // violation above, 'Name 'STRING' must match pattern*.'
     if (o1 instanceof Integer num) {}
-    if (o1 instanceof Integer num_1) {} // violation
+    if (o1 instanceof Integer num_1) {}
+    // violation above, 'Name 'num_1' must match pattern*.'
     if (o1 instanceof Integer n) {}
   }
 }
@@ -66,7 +68,7 @@ class Example1 {
 &lt;module name="Checker"&gt;
   &lt;module name="TreeWalker"&gt;
     &lt;module name="PatternVariableName"&gt;
-        &lt;property name="format" value="^[a-z](_?[a-zA-Z0-9]+)*$"/&gt;
+      &lt;property name="format" value="^[a-z](_?[a-zA-Z0-9]+)*$"/&gt;
     &lt;/module&gt;
   &lt;/module&gt;
 &lt;/module&gt;
@@ -75,7 +77,8 @@ class Example1 {
         <div class="wrapper"><pre class="prettyprint"><code class="language-java">
 class Example2 {
   void foo(Object o1){
-    if (o1 instanceof String STRING) {} // violation
+    if (o1 instanceof String STRING) {}
+    // violation above, 'Name 'STRING' must match pattern*.'
     if (o1 instanceof Integer num) {}
     if (o1 instanceof Integer num_1) {}
     if (o1 instanceof Integer n) {}
@@ -90,7 +93,7 @@ class Example2 {
 &lt;module name="Checker"&gt;
   &lt;module name="TreeWalker"&gt;
     &lt;module name="PatternVariableName"&gt;
-        &lt;property name="format" value="^[a-z][_a-zA-Z0-9]{2,}$"/&gt;
+      &lt;property name="format" value="^[a-z][_a-zA-Z0-9]{2,}$"/&gt;
     &lt;/module&gt;
   &lt;/module&gt;
 &lt;/module&gt;
@@ -99,10 +102,12 @@ class Example2 {
         <div class="wrapper"><pre class="prettyprint"><code class="language-java">
 class Example3 {
   void foo(Object o1){
-    if (o1 instanceof String STRING) {} // violation
+    if (o1 instanceof String STRING) {}
+    // violation above, 'Name 'STRING' must match pattern*.'
     if (o1 instanceof Integer num) {}
     if (o1 instanceof Integer num_1) {}
-    if (o1 instanceof Integer n) {} // violation
+    if (o1 instanceof Integer n) {}
+    // violation above, 'Name 'n' must match pattern*.'
   }
 }
 </code></pre></div><hr class="example-separator"/>

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/naming/PatternVariableNameCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/naming/PatternVariableNameCheckTest.java
@@ -55,11 +55,11 @@ public class PatternVariableNameCheckTest
             "28:34: " + getCheckMessage(MSG_INVALID_PATTERN, "Count", pattern),
             "43:36: " + getCheckMessage(MSG_INVALID_PATTERN, "S", pattern),
             "44:42: " + getCheckMessage(MSG_INVALID_PATTERN, "STRING", pattern),
-            "47:34: " + getCheckMessage(MSG_INVALID_PATTERN, "STRING", pattern),
-            "48:43: " + getCheckMessage(MSG_INVALID_PATTERN, "STRING", pattern),
-            "60:37: " + getCheckMessage(MSG_INVALID_PATTERN, "INTEGER", pattern),
-            "66:43: " + getCheckMessage(MSG_INVALID_PATTERN, "Thing1", pattern),
-            "70:41: " + getCheckMessage(MSG_INVALID_PATTERN, "Thing2", pattern),
+            "48:34: " + getCheckMessage(MSG_INVALID_PATTERN, "STRING", pattern),
+            "49:43: " + getCheckMessage(MSG_INVALID_PATTERN, "STRING", pattern),
+            "62:37: " + getCheckMessage(MSG_INVALID_PATTERN, "INTEGER", pattern),
+            "68:43: " + getCheckMessage(MSG_INVALID_PATTERN, "Thing1", pattern),
+            "72:41: " + getCheckMessage(MSG_INVALID_PATTERN, "Thing2", pattern),
         };
         verifyWithInlineConfigParser(
                 getPath(
@@ -78,23 +78,22 @@ public class PatternVariableNameCheckTest
             "28:34: " + getCheckMessage(MSG_INVALID_PATTERN, "Count", pattern),
             "43:36: " + getCheckMessage(MSG_INVALID_PATTERN, "S", pattern),
             "44:42: " + getCheckMessage(MSG_INVALID_PATTERN, "STRING", pattern),
-            "46:34: " + getCheckMessage(MSG_INVALID_PATTERN, "STRING", pattern),
-            "47:43: " + getCheckMessage(MSG_INVALID_PATTERN, "STRING", pattern),
-            "49:57: " + getCheckMessage(MSG_INVALID_PATTERN, "s", pattern),
-            "56:48: " + getCheckMessage(MSG_INVALID_PATTERN, "a", pattern),
-            "57:39: " + getCheckMessage(MSG_INVALID_PATTERN, "x", pattern),
-            "58:43: " + getCheckMessage(MSG_INVALID_PATTERN, "y", pattern),
-            "60:37: " + getCheckMessage(MSG_INVALID_PATTERN, "INTEGER", pattern),
-            "65:43: " + getCheckMessage(MSG_INVALID_PATTERN, "Thing1", pattern),
-            "69:41: " + getCheckMessage(MSG_INVALID_PATTERN, "Thing2", pattern),
-            "74:38: " + getCheckMessage(MSG_INVALID_PATTERN, "j", pattern),
-            "75:36: " + getCheckMessage(MSG_INVALID_PATTERN, "j", pattern),
-            "76:37: " + getCheckMessage(MSG_INVALID_PATTERN, "j", pattern),
-            "83:41: " + getCheckMessage(MSG_INVALID_PATTERN, "s", pattern),
+            "47:34: " + getCheckMessage(MSG_INVALID_PATTERN, "STRING", pattern),
+            "48:43: " + getCheckMessage(MSG_INVALID_PATTERN, "STRING", pattern),
+            "51:57: " + getCheckMessage(MSG_INVALID_PATTERN, "s", pattern),
+            "59:48: " + getCheckMessage(MSG_INVALID_PATTERN, "a", pattern),
+            "60:39: " + getCheckMessage(MSG_INVALID_PATTERN, "x", pattern),
+            "61:43: " + getCheckMessage(MSG_INVALID_PATTERN, "y", pattern),
+            "63:37: " + getCheckMessage(MSG_INVALID_PATTERN, "INTEGER", pattern),
+            "68:43: " + getCheckMessage(MSG_INVALID_PATTERN, "Thing1", pattern),
+            "72:41: " + getCheckMessage(MSG_INVALID_PATTERN, "Thing2", pattern),
+            "77:36: " + getCheckMessage(MSG_INVALID_PATTERN, "j", pattern),
+            "78:34: " + getCheckMessage(MSG_INVALID_PATTERN, "j", pattern),
+            "79:37: " + getCheckMessage(MSG_INVALID_PATTERN, "j", pattern),
+            "86:41: " + getCheckMessage(MSG_INVALID_PATTERN, "s", pattern),
         };
-
         verifyWithInlineConfigParser(
-                 getPath(
+                getPath(
                         "InputPatternVariableNameEnhancedInstanceofNoSingleChar.java"),
                 expected);
     }

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/naming/patternvariablename/InputPatternVariableNameEnhancedInstanceofNoSingleChar.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/naming/patternvariablename/InputPatternVariableNameEnhancedInstanceofNoSingleChar.java
@@ -15,17 +15,17 @@ public class InputPatternVariableNameEnhancedInstanceofNoSingleChar {
     private Object obj;
 
     static boolean doStuff(Object obj) {
-        return obj instanceof Integer OTHER && OTHER > 0; // violation
-    }
+        return obj instanceof Integer OTHER && OTHER > 0;
+    } // violation above, 'Name 'OTHER' must match pattern*.'
 
     static {
         Object o = "";
-        if (o instanceof String s) { // violation
+        if (o instanceof String s) { // violation, 'Name 's' must match pattern*.'
             System.out.println(s.toLowerCase(Locale.forLanguageTag(s)));
             boolean stringCheck = "test".equals(s);
         }
 
-        if (o instanceof Integer Count) { // violation
+        if (o instanceof Integer Count) { // violation, 'Name 'Count' must match pattern*.'
             int value = Count.byteValue();
             if (Count.equals(value)) {
                 value = 25;
@@ -40,46 +40,49 @@ public class InputPatternVariableNameEnhancedInstanceofNoSingleChar {
     public void t(Object o1, Object o2) {
         Object b;
         Object c;
-        if (!(o1 instanceof String S) // violation
-                && (o2 instanceof String STRING)) { // violation
+        if (!(o1 instanceof String S) // violation, 'Name 'S' must match pattern*.'
+                && (o2 instanceof String STRING)) {
+            // violation above, 'Name 'STRING' must match pattern*.'
         }
-        if (o1 instanceof String STRING // violation
-                || !(o2 instanceof String STRING)) { // violation
+        if (o1 instanceof String STRING // violation, 'Name 'STRING' must match pattern*.'
+                || !(o2 instanceof String STRING)) {
+            // violation above, 'Name 'STRING' must match pattern*.'
         }
-        b = ((VoidPredicate) () -> o1 instanceof String s).get(); // violation
+        b = ((VoidPredicate) () -> o1 instanceof String s).get();
+        // violation above, 'Name 's' must match pattern*.'
 
         List<Integer> arrayList = new ArrayList<Integer>();
         if (arrayList instanceof ArrayList<Integer> ai) {
             System.out.println("Blah");
         }
 
-        boolean result = (o1 instanceof String a) ? // violation
-                (o1 instanceof String x) // violation
-                : (!(o1 instanceof String y)); // violation
+        boolean result = (o1 instanceof String a) ? // violation, 'Name 'a' must match pattern*.'
+                (o1 instanceof String x) // violation, 'Name 'x' must match pattern*.'
+                : (!(o1 instanceof String y)); // violation, 'Name 'y' must match pattern*.'
 
-        if (!(o1 instanceof Integer INTEGER) ? false : INTEGER > 0) { // violation
-            System.out.println("done");
+        if (!(o1 instanceof Integer INTEGER) ? false : INTEGER > 0) {
+            System.out.println("done"); // violation above, 'Name 'INTEGER' must match pattern*.'
         }
 
         {
-            while (!(o1 instanceof String Thing1)) { // violation
-                L3:
+            while (!(o1 instanceof String Thing1)) {
+                L3: // violation above, 'Name 'Thing1' must match pattern*.'
                 break L3;
             }
-            while (o1 instanceof String Thing2) { // violation
+            while (o1 instanceof String Thing2) { // violation, 'Name 'Thing2' must match pattern*.'
                 Thing2.length();
             }
         }
 
-        int x = o1 instanceof String j ? j.length() : 2; // violation
-        x = !(o1 instanceof String j) ? 2 : j.length(); // violation
-        for (; o1 instanceof String j; j.length()) { // violation
+        int x=o1 instanceof String j?j.length():2;//violation,'Name 'j' must match pattern*.'
+        x=!(o1 instanceof String j)?2:j.length();//violation,'Name 'j' must match pattern*.'
+        for (; o1 instanceof String j; j.length()) { // violation, 'Name 'j' must match pattern*.'
             System.out.println(j);
         }
 
         do {
             L4:
             break L4;
-        } while (!(o1 instanceof String s)); // violation
+        } while (!(o1 instanceof String s)); // violation, 'Name 's' must match pattern*.'
     }
 }

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/naming/patternvariablename/InputPatternVariableNameEnhancedInstanceofTestDefault.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/naming/patternvariablename/InputPatternVariableNameEnhancedInstanceofTestDefault.java
@@ -15,8 +15,8 @@ public class InputPatternVariableNameEnhancedInstanceofTestDefault {
     private Object obj;
 
     static boolean doStuff(Object obj) {
-        return obj instanceof Integer OTHER && OTHER > 0; // violation
-    }
+        return obj instanceof Integer OTHER && OTHER > 0;
+    } // violation above, 'Name 'OTHER' must match pattern*.'
 
     static {
         Object o = "";
@@ -25,7 +25,7 @@ public class InputPatternVariableNameEnhancedInstanceofTestDefault {
             boolean stringCheck = "test".equals(s);
         }
 
-        if (o instanceof Integer Count) { // violation
+        if (o instanceof Integer Count) { // violation, 'Name 'Count' must match pattern*.'
             int value = Count.byteValue();
             if (Count.equals(value)) {
                 value = 25;
@@ -40,12 +40,14 @@ public class InputPatternVariableNameEnhancedInstanceofTestDefault {
     public void t(Object o1, Object o2) {
         Object b;
         Object c;
-        if (!(o1 instanceof String S) // violation
-                && (o2 instanceof String STRING)) { // violation
+        if (!(o1 instanceof String S) // violation, 'Name 'S' must match pattern*.'
+                && (o2 instanceof String STRING)) {
+            // violation above, 'Name 'STRING' must match pattern*.'
         }
 
-        if (o1 instanceof String STRING // violation
-                || !(o2 instanceof String STRING)) { // violation
+        if (o1 instanceof String STRING // violation, 'Name 'STRING' must match pattern*.'
+                || !(o2 instanceof String STRING)) {
+            // violation above, 'Name 'STRING' must match pattern*.'
         }
         b = ((VoidPredicate) () -> o1 instanceof String s).get();
 
@@ -57,17 +59,17 @@ public class InputPatternVariableNameEnhancedInstanceofTestDefault {
         boolean result = (o1 instanceof String a) ?
                 (o1 instanceof String x) : (!(o1 instanceof String y));
 
-        if (!(o1 instanceof Integer INTEGER) ? // violation
+        if (!(o1 instanceof Integer INTEGER) ? // violation, 'Name 'INTEGER' must match pattern*.'
                 false : INTEGER > 0) {
             System.out.println("done");
         }
 
         {
-            while (!(o1 instanceof String Thing1)) { // violation
-                L3:
+            while (!(o1 instanceof String Thing1)) {
+                L3: // violation above, 'Name 'Thing1' must match pattern*.'
                 break L3;
             }
-            while (o1 instanceof String Thing2) { // violation
+            while (o1 instanceof String Thing2) { // violation, 'Name 'Thing2' must match pattern*.'
                 Thing2.length();
             }
         }

--- a/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/checks/naming/PatternVariableNameCheckExamplesTest.java
+++ b/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/checks/naming/PatternVariableNameCheckExamplesTest.java
@@ -38,7 +38,7 @@ public class PatternVariableNameCheckExamplesTest extends AbstractExamplesModule
 
         final String[] expected = {
             "15:30: " + getCheckMessage(MSG_INVALID_PATTERN, "STRING", pattern),
-            "17:31: " + getCheckMessage(MSG_INVALID_PATTERN, "num_1", pattern),
+            "18:31: " + getCheckMessage(MSG_INVALID_PATTERN, "num_1", pattern),
         };
 
         verifyWithInlineConfigParser(getPath("Example1.java"), expected);
@@ -63,7 +63,7 @@ public class PatternVariableNameCheckExamplesTest extends AbstractExamplesModule
 
         final String[] expected = {
             "17:30: " + getCheckMessage(MSG_INVALID_PATTERN, "STRING", pattern),
-            "20:31: " + getCheckMessage(MSG_INVALID_PATTERN, "n", pattern),
+            "21:31: " + getCheckMessage(MSG_INVALID_PATTERN, "n", pattern),
         };
 
         verifyWithInlineConfigParser(getPath("Example3.java"), expected);
@@ -80,3 +80,4 @@ public class PatternVariableNameCheckExamplesTest extends AbstractExamplesModule
         verifyWithInlineConfigParser(getPath("Example4.java"), expected);
     }
 }
+

--- a/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/naming/patternvariablename/Example1.java
+++ b/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/naming/patternvariablename/Example1.java
@@ -12,9 +12,11 @@ package com.puppycrawl.tools.checkstyle.checks.naming.patternvariablename;
 // xdoc section -- start
 class Example1 {
   void foo(Object o1){
-    if (o1 instanceof String STRING) {} // violation
+    if (o1 instanceof String STRING) {}
+    // violation above, 'Name 'STRING' must match pattern*.'
     if (o1 instanceof Integer num) {}
-    if (o1 instanceof Integer num_1) {} // violation
+    if (o1 instanceof Integer num_1) {}
+    // violation above, 'Name 'num_1' must match pattern*.'
     if (o1 instanceof Integer n) {}
   }
 }

--- a/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/naming/patternvariablename/Example2.java
+++ b/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/naming/patternvariablename/Example2.java
@@ -2,7 +2,7 @@
 <module name="Checker">
   <module name="TreeWalker">
     <module name="PatternVariableName">
-        <property name="format" value="^[a-z](_?[a-zA-Z0-9]+)*$"/>
+      <property name="format" value="^[a-z](_?[a-zA-Z0-9]+)*$"/>
     </module>
   </module>
 </module>
@@ -14,7 +14,8 @@ package com.puppycrawl.tools.checkstyle.checks.naming.patternvariablename;
 // xdoc section -- start
 class Example2 {
   void foo(Object o1){
-    if (o1 instanceof String STRING) {} // violation
+    if (o1 instanceof String STRING) {}
+    // violation above, 'Name 'STRING' must match pattern*.'
     if (o1 instanceof Integer num) {}
     if (o1 instanceof Integer num_1) {}
     if (o1 instanceof Integer n) {}

--- a/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/naming/patternvariablename/Example3.java
+++ b/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/naming/patternvariablename/Example3.java
@@ -2,7 +2,7 @@
 <module name="Checker">
   <module name="TreeWalker">
     <module name="PatternVariableName">
-        <property name="format" value="^[a-z][_a-zA-Z0-9]{2,}$"/>
+      <property name="format" value="^[a-z][_a-zA-Z0-9]{2,}$"/>
     </module>
   </module>
 </module>
@@ -14,10 +14,12 @@ package com.puppycrawl.tools.checkstyle.checks.naming.patternvariablename;
 // xdoc section -- start
 class Example3 {
   void foo(Object o1){
-    if (o1 instanceof String STRING) {} // violation
+    if (o1 instanceof String STRING) {}
+    // violation above, 'Name 'STRING' must match pattern*.'
     if (o1 instanceof Integer num) {}
     if (o1 instanceof Integer num_1) {}
-    if (o1 instanceof Integer n) {} // violation
+    if (o1 instanceof Integer n) {}
+    // violation above, 'Name 'n' must match pattern*.'
   }
 }
 // xdoc section -- end


### PR DESCRIPTION
Issue #16807

Summary:
- updated PatternVariableName test inputs and expected violation positions
- updated PatternVariableName xdoc examples
- updated example tests to match the xdoc examples
- aligned violation comments with inline config parser expectations

Verification:
- ./mvnw -Dtest=PatternVariableNameCheckTest,PatternVariableNameCheckExamplesTest test
- ./mvnw clean verify