### PR TITLE
Issue #19064: Add third test to XpathRegressionRecordComponentNameTest

### DIFF
--- a/config/checkstyle-non-main-files-suppressions.xml
+++ b/config/checkstyle-non-main-files-suppressions.xml
@@ -440,7 +440,6 @@
   <suppress id="numberOfTestCasesInXpath" files="[\\/]src[\\/]it[\\/]java[\\/]org[\\/]checkstyle[\\/]suppressionxpathfilter[\\/]modifier[\\/]XpathRegressionClassMemberImpliedModifierTest.java" />
   <suppress id="numberOfTestCasesInXpath" files="[\\/]src[\\/]it[\\/]java[\\/]org[\\/]checkstyle[\\/]suppressionxpathfilter[\\/]naming[\\/]XpathRegressionIllegalIdentifierNameTest.java" />
   <suppress id="numberOfTestCasesInXpath" files="[\\/]src[\\/]it[\\/]java[\\/]org[\\/]checkstyle[\\/]suppressionxpathfilter[\\/]naming[\\/]XpathRegressionMemberNameTest.java" />
-  <suppress id="numberOfTestCasesInXpath" files="[\\/]src[\\/]it[\\/]java[\\/]org[\\/]checkstyle[\\/]suppressionxpathfilter[\\/]naming[\\/]XpathRegressionRecordComponentNameTest.java" />
   <suppress id="numberOfTestCasesInXpath" files="[\\/]src[\\/]it[\\/]java[\\/]org[\\/]checkstyle[\\/]suppressionxpathfilter[\\/]naming[\\/]XpathRegressionRecordTypeParameterNameTest.java" />
   <suppress id="numberOfTestCasesInXpath" files="[\\/]src[\\/]it[\\/]java[\\/]org[\\/]checkstyle[\\/]suppressionxpathfilter[\\/]sizes[\\/]XpathRegressionAnonInnerLengthTest.java" />
   <suppress id="numberOfTestCasesInXpath" files="[\\/]src[\\/]it[\\/]java[\\/]org[\\/]checkstyle[\\/]suppressionxpathfilter[\\/]sizes[\\/]XpathRegressionLambdaBodyLengthTest.java" />

--- a/src/it/java/org/checkstyle/suppressionxpathfilter/naming/XpathRegressionRecordComponentNameTest.java
+++ b/src/it/java/org/checkstyle/suppressionxpathfilter/naming/XpathRegressionRecordComponentNameTest.java
@@ -92,4 +92,30 @@ public class XpathRegressionRecordComponentNameTest extends AbstractXpathTestSup
         runVerifications(moduleConfig, fileToProcess, expectedViolation,
                 expectedXpathQueries);
     }
+
+    @Test
+    public void testNested() throws Exception {
+        final File fileToProcess = new File(getPath(
+                "InputXpathRecordComponentNameNested.java"));
+
+        final DefaultConfiguration moduleConfig =
+                createModuleConfig(RecordComponentNameCheck.class);
+
+        final String[] expectedViolation = {
+            "8:36: " + getCheckMessage(RecordComponentNameCheck.class,
+                AbstractNameCheck.MSG_INVALID_PATTERN,
+                    "_value", "^[a-z][a-zA-Z0-9]*$"),
+        };
+
+        final List<String> expectedXpathQueries = Collections.singletonList(
+            "/COMPILATION_UNIT/CLASS_DEF"
+                + "[./IDENT[@text='InputXpathRecordComponentNameNested']]"
+                + "/OBJBLOCK/CLASS_DEF[./IDENT[@text='Inner']]/OBJBLOCK"
+                + "/RECORD_DEF[./IDENT[@text='MyRecord']]"
+                + "/RECORD_COMPONENTS/RECORD_COMPONENT_DEF/IDENT[@text='_value']"
+        );
+
+        runVerifications(moduleConfig, fileToProcess, expectedViolation,
+                expectedXpathQueries);
+    }
 }

--- a/src/it/resources/org/checkstyle/suppressionxpathfilter/naming/recordcomponentname/InputXpathRecordComponentNameNested.java
+++ b/src/it/resources/org/checkstyle/suppressionxpathfilter/naming/recordcomponentname/InputXpathRecordComponentNameNested.java
@@ -1,0 +1,10 @@
+// Java17
+package org.checkstyle.suppressionxpathfilter.naming.recordcomponentname;
+
+/* Config: default
+ */
+public class InputXpathRecordComponentNameNested {
+    class Inner {
+        public record MyRecord(int _value) { } // warn
+    }
+}


### PR DESCRIPTION
Issue: #19064

Add third test to XpathRegressionRecordComponentNameTest to meet the requirement of 3 distinct test methods with different XPath structures.

Changes:
- Added new test method `testNested()` with nested class structure
- Created new input file `InputXpathRecordComponentNameNested.java`
- Removed suppression for this file from `checkstyle-non-main-files-suppressions.xml`

The three tests now cover different AST structures:
1. Top-level record with default pattern violation (existing)
2. Record inside class with custom pattern violation (existing)
3. Record inside nested inner class (new)

All tests pass with `mvn clean verify`.