### PR TITLE
Issue #16807: remove PatternVariableNameCheck from SUPPRESSED_CHECKS

### DIFF
--- a/src/test/java/com/puppycrawl/tools/checkstyle/bdd/InlineConfigParser.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/bdd/InlineConfigParser.java
@@ -268,7 +268,6 @@ public final class InlineConfigParser {
             "com.puppycrawl.tools.checkstyle.checks.naming.IllegalIdentifierNameCheck",
             "com.puppycrawl.tools.checkstyle.checks.naming.LocalVariableNameCheck",
             "com.puppycrawl.tools.checkstyle.checks.naming.ParameterNameCheck",
-            "com.puppycrawl.tools.checkstyle.checks.naming.PatternVariableNameCheck",
             "com.puppycrawl.tools.checkstyle.checks.naming.RecordComponentNameCheck",
             "com.puppycrawl.tools.checkstyle.checks.naming.RecordTypeParameterNameCheck",
             "com.puppycrawl.tools.checkstyle.checks.regexp.RegexpMultilineCheck",


### PR DESCRIPTION
Issue #16807

This follow-up PR removes `PatternVariableNameCheck` from `SUPPRESSED_CHECKS` in `InlineConfigParser`.

This addresses the review feedback on the previous PR, where this removal was missed.

Verification:
- `git diff --check`
- `./mvnw -Dtest=PatternVariableNameCheckTest,PatternVariableNameCheckExamplesTest test`
- `./mvnw clean verify`

Thanks for pointing this out.