### PR TITLE
Issue #19064: Add third test to XpathRegressionMissingNullCaseInSwitchTest

### DIFF
--- a/config/checkstyle-non-main-files-suppressions.xml
+++ b/config/checkstyle-non-main-files-suppressions.xml
@@ -418,7 +418,6 @@
   <suppress id="numberOfTestCasesInXpath" files="[\\/]src[\\/]it[\\/]java[\\/]org[\\/]checkstyle[\\/]suppressionxpathfilter[\\/]coding[\\/]XpathRegressionDefaultComesLastTest.java" />
   <suppress id="numberOfTestCasesInXpath" files="[\\/]src[\\/]it[\\/]java[\\/]org[\\/]checkstyle[\\/]suppressionxpathfilter[\\/]coding[\\/]XpathRegressionDeclarationOrderTest.java" />
   <suppress id="numberOfTestCasesInXpath" files="[\\/]src[\\/]it[\\/]java[\\/]org[\\/]checkstyle[\\/]suppressionxpathfilter[\\/]coding[\\/]XpathRegressionHiddenFieldTest.java" />
-  <suppress id="numberOfTestCasesInXpath" files="[\\/]src[\\/]it[\\/]java[\\/]org[\\/]checkstyle[\\/]suppressionxpathfilter[\\/]coding[\\/]XpathRegressionMissingNullCaseInSwitchTest.java" />
   <suppress id="numberOfTestCasesInXpath" files="[\\/]src[\\/]it[\\/]java[\\/]org[\\/]checkstyle[\\/]suppressionxpathfilter[\\/]coding[\\/]XpathRegressionMissingSwitchDefaultTest.java" />
   <suppress id="numberOfTestCasesInXpath" files="[\\/]src[\\/]it[\\/]java[\\/]org[\\/]checkstyle[\\/]suppressionxpathfilter[\\/]coding[\\/]XpathRegressionNestedIfDepthTest.java" />
 

--- a/src/it/java/org/checkstyle/suppressionxpathfilter/coding/XpathRegressionMissingNullCaseInSwitchTest.java
+++ b/src/it/java/org/checkstyle/suppressionxpathfilter/coding/XpathRegressionMissingNullCaseInSwitchTest.java
@@ -91,4 +91,25 @@ public class XpathRegressionMissingNullCaseInSwitchTest
         );
         runVerifications(moduleConfig, fileToProcess, expectedViolation, expectedXpathQueries);
     }
+
+    @Test
+    public void testStaticBlock() throws Exception {
+        final File fileToProcess =
+            new File(getPath("InputXpathMissingNullCaseInSwitchStaticBlock.java"));
+
+        final DefaultConfiguration moduleConfig =
+                createModuleConfig(MissingNullCaseInSwitchCheck.class);
+        final String[] expectedViolation = {
+            "7:9: " + getCheckMessage(MissingNullCaseInSwitchCheck.class,
+                    MissingNullCaseInSwitchCheck.MSG_KEY),
+        };
+
+        final List<String> expectedXpathQueries = Collections.singletonList(
+            "/COMPILATION_UNIT/CLASS_DEF"
+                + "[./IDENT[@text='InputXpathMissingNullCaseInSwitchStaticBlock']]"
+                + "/OBJBLOCK/STATIC_INIT/SLIST/LITERAL_SWITCH"
+        );
+
+        runVerifications(moduleConfig, fileToProcess, expectedViolation, expectedXpathQueries);
+    }
 }

--- a/src/it/resources/org/checkstyle/suppressionxpathfilter/coding/missingnullcaseinswitch/InputXpathMissingNullCaseInSwitchStaticBlock.java
+++ b/src/it/resources/org/checkstyle/suppressionxpathfilter/coding/missingnullcaseinswitch/InputXpathMissingNullCaseInSwitchStaticBlock.java
@@ -1,0 +1,15 @@
+// non-compiled with javac: Compilable with Java22
+package org.checkstyle.suppressionxpathfilter.coding.missingnullcaseinswitch;
+
+public class InputXpathMissingNullCaseInSwitchStaticBlock {
+    static {
+        Object obj = null;
+        switch (obj) { // warn
+            case Rectangle(ColoredPoint _, ColoredPoint _) -> {}
+            case ColoredPoint(int _, int _, String _) -> {}
+            default -> {}
+        }
+    }
+    record ColoredPoint(int p, int x, String c) { }
+    record Rectangle(ColoredPoint upperLeft, ColoredPoint lowerRight) { }
+}


### PR DESCRIPTION
Issue: #19064

Add third test to XpathRegressionMissingNullCaseInSwitchTest to meet the requirement of 3 distinct test methods with different XPath structures.

Changes:
- Added new test method `testStaticBlock()` with static block structure
- Created new input file `InputXpathMissingNullCaseInSwitchStaticBlock.java`
- Removed suppression for this file from `checkstyle-non-main-files-suppressions.xml`

The three tests now cover different AST structures:
1. Simple switch without null case (existing)
2. Nested switch expression (existing)
3. Switch inside static block (new)

All tests pass with `mvn clean verify`.