### PR TITLE
Issue #15456: Replace shorthand violation comments in InputParameterNameWhitespaceInAccessModifierProperty

### DIFF
--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/naming/parametername/InputParameterNameWhitespaceInAccessModifierProperty.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/naming/parametername/InputParameterNameWhitespaceInAccessModifierProperty.java
@@ -11,11 +11,11 @@ package com.puppycrawl.tools.checkstyle.checks.naming.parametername;
 
 public class InputParameterNameWhitespaceInAccessModifierProperty {
 
-    public InputParameterNameWhitespaceInAccessModifierProperty(int parameter1) {} // violation
-
+    public InputParameterNameWhitespaceInAccessModifierProperty(int parameter1) {}
+    // violation above, 'Name 'parameter1' must match pattern'
     public void v1(int h) {
         new Object () {
-            public void i(int parameter2) {} // violation
+            public void i(int parameter2) {} // violation 'Name 'parameter2' must match pattern'
         };
     }
 


### PR DESCRIPTION
Fixes part of #15456

I updated violation comments in `InputParameterNameWhitespaceInAccessModifierProperty.java` to use explicit messages instead of shorthand comments.

Replaced shorthand comments like:
- `// violation`

with explicit messages in the existing BDD format:
- `// violation above, ''parameter'' must match pattern ''...''`

This makes the expected violations clearer and keeps the test input consistent with the format already used in other checks.

Only the relevant lines in this file were changed.