### PR TITLE
Issue #19064: Add third test to XpathRegressionCyclomaticComplexityTest

### DIFF
--- a/config/checkstyle-non-main-files-suppressions.xml
+++ b/config/checkstyle-non-main-files-suppressions.xml
@@ -435,7 +435,6 @@
   <suppress id="numberOfTestCasesInXpath" files="[\\/]src[\\/]it[\\/]java[\\/]org[\\/]checkstyle[\\/]suppressionxpathfilter[\\/]imports[\\/]XpathRegressionIllegalImportTest.java" />
   <suppress id="numberOfTestCasesInXpath" files="[\\/]src[\\/]it[\\/]java[\\/]org[\\/]checkstyle[\\/]suppressionxpathfilter[\\/]javadoc[\\/]XpathRegressionJavadocContentLocationTest.java" />
   <suppress id="numberOfTestCasesInXpath" files="[\\/]src[\\/]it[\\/]java[\\/]org[\\/]checkstyle[\\/]suppressionxpathfilter[\\/]javadoc[\\/]XpathRegressionJavadocVariableTest.java" />
-  <suppress id="numberOfTestCasesInXpath" files="[\\/]src[\\/]it[\\/]java[\\/]org[\\/]checkstyle[\\/]suppressionxpathfilter[\\/]metrics[\\/]XpathRegressionCyclomaticComplexityTest.java" />
   <suppress id="numberOfTestCasesInXpath" files="[\\/]src[\\/]it[\\/]java[\\/]org[\\/]checkstyle[\\/]suppressionxpathfilter[\\/]metrics[\\/]XpathRegressionNPathComplexityTest.java" />
   <suppress id="numberOfTestCasesInXpath" files="[\\/]src[\\/]it[\\/]java[\\/]org[\\/]checkstyle[\\/]suppressionxpathfilter[\\/]modifier[\\/]XpathRegressionClassMemberImpliedModifierTest.java" />
   <suppress id="numberOfTestCasesInXpath" files="[\\/]src[\\/]it[\\/]java[\\/]org[\\/]checkstyle[\\/]suppressionxpathfilter[\\/]naming[\\/]XpathRegressionIllegalIdentifierNameTest.java" />

--- a/src/it/java/org/checkstyle/suppressionxpathfilter/metrics/XpathRegressionCyclomaticComplexityTest.java
+++ b/src/it/java/org/checkstyle/suppressionxpathfilter/metrics/XpathRegressionCyclomaticComplexityTest.java
@@ -103,4 +103,38 @@ public class XpathRegressionCyclomaticComplexityTest extends AbstractXpathTestSu
         runVerifications(moduleConfig, fileToProcess, expectedViolation,
                 expectedXpathQueries);
     }
+
+    @Test
+    public void testInnerClassLoops() throws Exception {
+        final File fileToProcess =
+                new File(getPath("InputXpathCyclomaticComplexityInnerClassLoops.java"));
+
+        final DefaultConfiguration moduleConfig =
+                createModuleConfig(CyclomaticComplexityCheck.class);
+        moduleConfig.addProperty("max", "0");
+
+        final String[] expectedViolation = {
+            "5:9: " + getCheckMessage(CyclomaticComplexityCheck.class,
+                    CyclomaticComplexityCheck.MSG_KEY, 3, 0),
+        };
+
+        final List<String> expectedXpathQueries = Arrays.asList(
+            "/COMPILATION_UNIT/CLASS_DEF"
+                + "[./IDENT[@text='InputXpathCyclomaticComplexityInnerClassLoops']]"
+                + "/OBJBLOCK/CLASS_DEF[./IDENT[@text='Inner']]"
+                + "/OBJBLOCK/METHOD_DEF[./IDENT[@text='loops']]",
+            "/COMPILATION_UNIT/CLASS_DEF"
+                + "[./IDENT[@text='InputXpathCyclomaticComplexityInnerClassLoops']]"
+                + "/OBJBLOCK/CLASS_DEF[./IDENT[@text='Inner']]"
+                + "/OBJBLOCK/METHOD_DEF[./IDENT[@text='loops']]/MODIFIERS",
+            "/COMPILATION_UNIT/CLASS_DEF"
+                + "[./IDENT[@text='InputXpathCyclomaticComplexityInnerClassLoops']]"
+                + "/OBJBLOCK/CLASS_DEF[./IDENT[@text='Inner']]"
+                + "/OBJBLOCK/METHOD_DEF[./IDENT[@text='loops']]/MODIFIERS/LITERAL_PUBLIC"
+        );
+
+        runVerifications(moduleConfig, fileToProcess, expectedViolation,
+                expectedXpathQueries);
+    }
+
 }

--- a/src/it/resources/org/checkstyle/suppressionxpathfilter/metrics/cyclomaticcomplexity/InputXpathCyclomaticComplexityInnerClassLoops.java
+++ b/src/it/resources/org/checkstyle/suppressionxpathfilter/metrics/cyclomaticcomplexity/InputXpathCyclomaticComplexityInnerClassLoops.java
@@ -1,0 +1,13 @@
+package org.checkstyle.suppressionxpathfilter.metrics.cyclomaticcomplexity;
+
+public class InputXpathCyclomaticComplexityInnerClassLoops {
+    class Inner {
+        public void loops(int n) { //warn
+            for (int i = 0; i < n; i++) {
+                if (i % 2 == 0) {
+                    // do something
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
Issue: #19064

Add third test to XpathRegressionCyclomaticComplexityTest to meet the requirement of 3 distinct test methods with different XPath structures.

Changes:
- Added new test method `testInnerClassLoops()` with inner class and loop structures
- Created new input file `InputXpathCyclomaticComplexityInnerClassLoops.java`
- Removed suppression for this file from `checkstyle-non-main-files-suppressions.xml`

The three tests now cover different AST structures:
1. Method with conditionals (existing)
2. Method with switch block (existing)
3. Inner class method with loops (new)

All tests pass with `mvn clean verify`.