### PR TITLE
Issue #19064: Add 3rd test to XpathRegressionAnonInnerLengthTest

### DIFF
--- a/config/checkstyle-non-main-files-suppressions.xml
+++ b/config/checkstyle-non-main-files-suppressions.xml
@@ -442,7 +442,6 @@
   <suppress id="numberOfTestCasesInXpath" files="[\\/]src[\\/]it[\\/]java[\\/]org[\\/]checkstyle[\\/]suppressionxpathfilter[\\/]naming[\\/]XpathRegressionMemberNameTest.java" />
   <suppress id="numberOfTestCasesInXpath" files="[\\/]src[\\/]it[\\/]java[\\/]org[\\/]checkstyle[\\/]suppressionxpathfilter[\\/]naming[\\/]XpathRegressionRecordComponentNameTest.java" />
   <suppress id="numberOfTestCasesInXpath" files="[\\/]src[\\/]it[\\/]java[\\/]org[\\/]checkstyle[\\/]suppressionxpathfilter[\\/]naming[\\/]XpathRegressionRecordTypeParameterNameTest.java" />
-  <suppress id="numberOfTestCasesInXpath" files="[\\/]src[\\/]it[\\/]java[\\/]org[\\/]checkstyle[\\/]suppressionxpathfilter[\\/]sizes[\\/]XpathRegressionAnonInnerLengthTest.java" />
   <suppress id="numberOfTestCasesInXpath" files="[\\/]src[\\/]it[\\/]java[\\/]org[\\/]checkstyle[\\/]suppressionxpathfilter[\\/]sizes[\\/]XpathRegressionLambdaBodyLengthTest.java" />
   <suppress id="numberOfTestCasesInXpath" files="[\\/]src[\\/]it[\\/]java[\\/]org[\\/]checkstyle[\\/]suppressionxpathfilter[\\/]sizes[\\/]XpathRegressionOuterTypeNumberTest.java" />
   <suppress id="numberOfTestCasesInXpath" files="[\\/]src[\\/]it[\\/]java[\\/]org[\\/]checkstyle[\\/]suppressionxpathfilter[\\/]sizes[\\/]XpathRegressionRecordComponentNumberTest.java" />

--- a/src/it/java/org/checkstyle/suppressionxpathfilter/sizes/XpathRegressionAnonInnerLengthTest.java
+++ b/src/it/java/org/checkstyle/suppressionxpathfilter/sizes/XpathRegressionAnonInnerLengthTest.java
@@ -103,4 +103,34 @@ public class XpathRegressionAnonInnerLengthTest extends AbstractXpathTestSupport
         runVerifications(moduleConfig, fileToProcess, expectedViolation,
                 expectedXpathQueries);
     }
+
+    @Test
+    public void testField() throws Exception {
+        final int maxLen = 5;
+        final File fileToProcess =
+                new File(getPath("InputXpathAnonInnerLengthField.java"));
+
+        final DefaultConfiguration moduleConfig =
+                createModuleConfig(AnonInnerLengthCheck.class);
+        moduleConfig.addProperty("max", String.valueOf(maxLen));
+
+        final String[] expectedViolation = {
+            "4:25: " + getCheckMessage(AnonInnerLengthCheck.class,
+                    AnonInnerLengthCheck.MSG_KEY, 9, maxLen),
+        };
+
+        final List<String> expectedXpathQueries = Arrays.asList(
+                "/COMPILATION_UNIT/CLASS_DEF"
+                        + "[./IDENT[@text='InputXpathAnonInnerLengthField']]"
+                        + "/OBJBLOCK/VARIABLE_DEF[./IDENT[@text='runnable']]"
+                        + "/ASSIGN/EXPR",
+                "/COMPILATION_UNIT/CLASS_DEF"
+                        + "[./IDENT[@text='InputXpathAnonInnerLengthField']]"
+                        + "/OBJBLOCK/VARIABLE_DEF[./IDENT[@text='runnable']]"
+                        + "/ASSIGN/EXPR/LITERAL_NEW[./IDENT[@text='Runnable']]"
+        );
+
+        runVerifications(moduleConfig, fileToProcess, expectedViolation,
+                expectedXpathQueries);
+    }
 }

--- a/src/it/resources/org/checkstyle/suppressionxpathfilter/sizes/anoninnerlength/InputXpathAnonInnerLengthField.java
+++ b/src/it/resources/org/checkstyle/suppressionxpathfilter/sizes/anoninnerlength/InputXpathAnonInnerLengthField.java
@@ -1,0 +1,13 @@
+package org.checkstyle.suppressionxpathfilter.sizes.anoninnerlength;
+
+public class InputXpathAnonInnerLengthField {
+    Runnable runnable = new Runnable() { // warn
+        @Override
+        public void run() {
+            int x = 0;
+            x++;
+            x++;
+            x++;
+        }
+    };
+}


### PR DESCRIPTION
Issue #19064: Add 3rd test to XpathRegressionAnonInnerLengthTest

Added a third test method `testField()` that places the anonymous inner class 
in a field initializer context, generating XPath through `OBJBLOCK/VARIABLE_DEF/ASSIGN/EXPR`  different from the existing tests which use `METHOD_DEF/SLIST/VARIABLE_DEF`.