### PR TITLE
Issue #19064: Add 3rd test to XpathRegressionAvoidNoArgumentSuperConstructorCallTest

### DIFF
--- a/config/checkstyle-non-main-files-suppressions.xml
+++ b/config/checkstyle-non-main-files-suppressions.xml
@@ -414,7 +414,6 @@
 
   <suppress id="numberOfTestCasesInXpath" files="[\\/]src[\\/]it[\\/]java[\\/]org[\\/]checkstyle[\\/]suppressionxpathfilter[\\/]XpathRegressionOuterTypeFilenameTest.java" />
   <suppress id="numberOfTestCasesInXpath" files="[\\/]src[\\/]it[\\/]java[\\/]org[\\/]checkstyle[\\/]suppressionxpathfilter[\\/]XpathRegressionTodoCommentTest.java" />
-  <suppress id="numberOfTestCasesInXpath" files="[\\/]src[\\/]it[\\/]java[\\/]org[\\/]checkstyle[\\/]suppressionxpathfilter[\\/]coding[\\/]XpathRegressionAvoidNoArgumentSuperConstructorCallTest.java" />
   <suppress id="numberOfTestCasesInXpath" files="[\\/]src[\\/]it[\\/]java[\\/]org[\\/]checkstyle[\\/]suppressionxpathfilter[\\/]coding[\\/]XpathRegressionDefaultComesLastTest.java" />
   <suppress id="numberOfTestCasesInXpath" files="[\\/]src[\\/]it[\\/]java[\\/]org[\\/]checkstyle[\\/]suppressionxpathfilter[\\/]coding[\\/]XpathRegressionDeclarationOrderTest.java" />
   <suppress id="numberOfTestCasesInXpath" files="[\\/]src[\\/]it[\\/]java[\\/]org[\\/]checkstyle[\\/]suppressionxpathfilter[\\/]coding[\\/]XpathRegressionHiddenFieldTest.java" />

--- a/src/it/java/org/checkstyle/suppressionxpathfilter/coding/XpathRegressionAvoidNoArgumentSuperConstructorCallTest.java
+++ b/src/it/java/org/checkstyle/suppressionxpathfilter/coding/XpathRegressionAvoidNoArgumentSuperConstructorCallTest.java
@@ -94,4 +94,28 @@ public class XpathRegressionAvoidNoArgumentSuperConstructorCallTest
 
         runVerifications(moduleConfig, fileToProcess, expectedViolation, expectedXpathQueries);
     }
+
+    @Test
+    public void testStaticInnerClass() throws Exception {
+        final File fileToProcess = new File(getPath(
+            "InputXpathAvoidNoArgumentSuperConstructorCallStaticInner.java"));
+
+        final DefaultConfiguration moduleConfig =
+                createModuleConfig(CLASS);
+
+        final String[] expectedViolation = {
+            "6:13: " + getCheckMessage(CLASS,
+                AvoidNoArgumentSuperConstructorCallCheck.MSG_CTOR),
+        };
+
+        final List<String> expectedXpathQueries = Collections.singletonList(
+            "/COMPILATION_UNIT/CLASS_DEF[./IDENT[@text="
+                + "'InputXpathAvoidNoArgumentSuperConstructorCallStaticInner']]"
+                + "/OBJBLOCK/CLASS_DEF[./IDENT[@text='Nested']]"
+                + "/OBJBLOCK/CTOR_DEF[./IDENT[@text='Nested']]"
+                + "/SLIST/SUPER_CTOR_CALL"
+        );
+
+        runVerifications(moduleConfig, fileToProcess, expectedViolation, expectedXpathQueries);
+    }
 }

--- a/src/it/resources/org/checkstyle/suppressionxpathfilter/coding/avoidnoargumentsuperconstructorcall/InputXpathAvoidNoArgumentSuperConstructorCallStaticInner.java
+++ b/src/it/resources/org/checkstyle/suppressionxpathfilter/coding/avoidnoargumentsuperconstructorcall/InputXpathAvoidNoArgumentSuperConstructorCallStaticInner.java
@@ -1,0 +1,9 @@
+package org.checkstyle.suppressionxpathfilter.coding.avoidnoargumentsuperconstructorcall;
+
+public class InputXpathAvoidNoArgumentSuperConstructorCallStaticInner {
+    static class Nested {
+        Nested() {
+            super(); // warn
+        }
+    }
+}


### PR DESCRIPTION
Issue #19064: Add 3rd test to XpathRegressionAvoidNoArgumentSuperConstructorCallTest

Added a third test method `testStaticInnerClass()` that places the violation
in a static nested class, generating XPath through
`OBJBLOCK/CLASS_DEF/OBJBLOCK/CTOR_DEF` — different from the existing tests
which use a top-level class constructor (test 1) and a local class inside
a method (test 2).