### PR TITLE
Issue #15456: Replace shorthand violation comments in InputParameterNameOverrideAnnotationOne

### DIFF
--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/naming/parametername/InputParameterNameOverrideAnnotationOne.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/naming/parametername/InputParameterNameOverrideAnnotationOne.java
@@ -12,29 +12,31 @@ package com.puppycrawl.tools.checkstyle.checks.naming.parametername;
 public class InputParameterNameOverrideAnnotationOne {
 
     @Override
-    public boolean equals(Object o) { // violation
+    public boolean equals(Object o) { // violation 'Name 'o' must match pattern'
         return super.equals(o);
     }
 
     @SuppressWarnings("")
-    public void foo(Object object) { // violation
+    public void foo(Object object) { // violation 'Name 'object' must match pattern'
 
     }
 
-    public void foo2(Integer data) {} // violation
+    public void foo2(Integer data) {} // violation 'Name 'data' must match pattern'
 
     void foo3() {} // No NPE here!
 
-    void foo4(int abc, int bd) {} // 2 violations
-
-    int foo5(int abc) {return 1;} // violation
+    void foo4(int abc, int bd) {} // violation 'Name 'abc' must match pattern'
+    // violation above 'Name 'bd' must match pattern'
+    int foo5(int abc) {return 1;} // violation 'Name 'abc' must match pattern'
 
     private int field;
     private java.util.Set<String> packageNames;
 
     InputParameterNameOverrideAnnotationOne() {} // No NPE here!
-    // 2 violations below
-    InputParameterNameOverrideAnnotationOne(int fie, java.util.Set<String> pkgNames) {}
 
+    InputParameterNameOverrideAnnotationOne(int fie, java.util.Set<String> pkgNames) {}
+    // 2 violations above:
+    //  'Name 'fie' must match pattern'
+    //  'Name 'pkgNames' must match pattern'
 
 }


### PR DESCRIPTION
Fixes part of #15456

I updated violation comments in `InputParameterNameOverrideAnnotationOne.java` to use explicit messages instead of shorthand comments.

Replaced shorthand comments like:
- `// violation`
- `// 2 violations`
- `// 2 violations below`

with explicit messages in the existing BDD format.

This makes the expected violations clearer and keeps the test input consistent with the format already used in other checks.

Only the relevant lines in this file were changed.