### PR TITLE
Issue #19064: Add 3rd test XpathRegressionClassMemberImpliedModifierTest

### DIFF
--- a/config/checkstyle-non-main-files-suppressions.xml
+++ b/config/checkstyle-non-main-files-suppressions.xml
@@ -437,7 +437,6 @@
   <suppress id="numberOfTestCasesInXpath" files="[\\/]src[\\/]it[\\/]java[\\/]org[\\/]checkstyle[\\/]suppressionxpathfilter[\\/]javadoc[\\/]XpathRegressionJavadocVariableTest.java" />
   <suppress id="numberOfTestCasesInXpath" files="[\\/]src[\\/]it[\\/]java[\\/]org[\\/]checkstyle[\\/]suppressionxpathfilter[\\/]metrics[\\/]XpathRegressionCyclomaticComplexityTest.java" />
   <suppress id="numberOfTestCasesInXpath" files="[\\/]src[\\/]it[\\/]java[\\/]org[\\/]checkstyle[\\/]suppressionxpathfilter[\\/]metrics[\\/]XpathRegressionNPathComplexityTest.java" />
-  <suppress id="numberOfTestCasesInXpath" files="[\\/]src[\\/]it[\\/]java[\\/]org[\\/]checkstyle[\\/]suppressionxpathfilter[\\/]modifier[\\/]XpathRegressionClassMemberImpliedModifierTest.java" />
   <suppress id="numberOfTestCasesInXpath" files="[\\/]src[\\/]it[\\/]java[\\/]org[\\/]checkstyle[\\/]suppressionxpathfilter[\\/]naming[\\/]XpathRegressionIllegalIdentifierNameTest.java" />
   <suppress id="numberOfTestCasesInXpath" files="[\\/]src[\\/]it[\\/]java[\\/]org[\\/]checkstyle[\\/]suppressionxpathfilter[\\/]naming[\\/]XpathRegressionMemberNameTest.java" />
   <suppress id="numberOfTestCasesInXpath" files="[\\/]src[\\/]it[\\/]java[\\/]org[\\/]checkstyle[\\/]suppressionxpathfilter[\\/]naming[\\/]XpathRegressionRecordComponentNameTest.java" />

--- a/src/it/java/org/checkstyle/suppressionxpathfilter/modifier/XpathRegressionClassMemberImpliedModifierTest.java
+++ b/src/it/java/org/checkstyle/suppressionxpathfilter/modifier/XpathRegressionClassMemberImpliedModifierTest.java
@@ -100,4 +100,34 @@ public class XpathRegressionClassMemberImpliedModifierTest extends AbstractXpath
         runVerifications(moduleConfig, fileToProcess, expectedViolation,
                 expectedXpathQueries);
     }
+
+    @Test
+    public void testRecord() throws Exception {
+        final File fileToProcess =
+                new File(getPath("InputXpathClassMemberImpliedModifierRecord.java"));
+
+        final DefaultConfiguration moduleConfig =
+                createModuleConfig(ClassMemberImpliedModifierCheck.class);
+
+        final String[] expectedViolation = {
+            "4:5: " + getCheckMessage(ClassMemberImpliedModifierCheck.class,
+                ClassMemberImpliedModifierCheck.MSG_KEY, "static"),
+        };
+
+        final List<String> expectedXpathQueries = Arrays.asList(
+            "/COMPILATION_UNIT/CLASS_DEF"
+                    + "[./IDENT[@text='InputXpathClassMemberImpliedModifierRecord']]"
+                    + "/OBJBLOCK/RECORD_DEF[./IDENT[@text='Point']]",
+            "/COMPILATION_UNIT/CLASS_DEF"
+                    + "[./IDENT[@text='InputXpathClassMemberImpliedModifierRecord']]"
+                    + "/OBJBLOCK/RECORD_DEF[./IDENT[@text='Point']]/MODIFIERS",
+            "/COMPILATION_UNIT/CLASS_DEF"
+                    + "[./IDENT[@text='InputXpathClassMemberImpliedModifierRecord']]"
+                    + "/OBJBLOCK/RECORD_DEF[./IDENT[@text='Point']]/MODIFIERS"
+                    + "/LITERAL_PUBLIC"
+        );
+
+        runVerifications(moduleConfig, fileToProcess, expectedViolation,
+                expectedXpathQueries);
+    }
 }

--- a/src/it/resources/org/checkstyle/suppressionxpathfilter/modifier/classmemberimpliedmodifier/InputXpathClassMemberImpliedModifierRecord.java
+++ b/src/it/resources/org/checkstyle/suppressionxpathfilter/modifier/classmemberimpliedmodifier/InputXpathClassMemberImpliedModifierRecord.java
@@ -1,0 +1,6 @@
+package org.checkstyle.suppressionxpathfilter.modifier.classmemberimpliedmodifier;
+
+public class InputXpathClassMemberImpliedModifierRecord {
+    public record Point(int x, int y) { // warn
+    }
+}


### PR DESCRIPTION
Add 3rd test method `testRecord()` for `XpathRegressionClassMemberImpliedModifierTest`.

The new test uses a nested `public record` inside a class, which triggers the
`ClassMemberImpliedModifier` check for the missing explicit `static` modifier
(records in a class are implicitly static).

- Existing tests: `testInterface` (INTERFACE_DEF), `testEnum` (ENUM_DEF)
- New test: `testRecord` (RECORD_DEF)

Closes part of #19064