### PR TITLE
Issue #19064: Add 3rd test for XpathRegressionEmptyForInitializerPadTest

### DIFF
--- a/config/checkstyle-non-main-files-suppressions.xml
+++ b/config/checkstyle-non-main-files-suppressions.xml
@@ -446,5 +446,4 @@
   <suppress id="numberOfTestCasesInXpath" files="[\\/]src[\\/]it[\\/]java[\\/]org[\\/]checkstyle[\\/]suppressionxpathfilter[\\/]sizes[\\/]XpathRegressionLambdaBodyLengthTest.java" />
   <suppress id="numberOfTestCasesInXpath" files="[\\/]src[\\/]it[\\/]java[\\/]org[\\/]checkstyle[\\/]suppressionxpathfilter[\\/]sizes[\\/]XpathRegressionOuterTypeNumberTest.java" />
   <suppress id="numberOfTestCasesInXpath" files="[\\/]src[\\/]it[\\/]java[\\/]org[\\/]checkstyle[\\/]suppressionxpathfilter[\\/]sizes[\\/]XpathRegressionRecordComponentNumberTest.java" />
-  <suppress id="numberOfTestCasesInXpath" files="[\\/]src[\\/]it[\\/]java[\\/]org[\\/]checkstyle[\\/]suppressionxpathfilter[\\/]whitespace[\\/]XpathRegressionEmptyForInitializerPadTest.java" />
 </suppressions>

--- a/src/it/java/org/checkstyle/suppressionxpathfilter/whitespace/XpathRegressionEmptyForInitializerPadTest.java
+++ b/src/it/java/org/checkstyle/suppressionxpathfilter/whitespace/XpathRegressionEmptyForInitializerPadTest.java
@@ -97,4 +97,30 @@ public class XpathRegressionEmptyForInitializerPadTest extends AbstractXpathTest
                 expectedXpathQueries);
     }
 
+    @Test
+    public void testPrecededStaticInit() throws Exception {
+        final File fileToProcess = new File(
+                getPath("InputXpathEmptyForInitializerPadPrecededStaticInit.java"));
+
+        final DefaultConfiguration moduleConfig =
+                createModuleConfig(EmptyForInitializerPadCheck.class);
+
+        final String[] expectedViolation = {
+            "6:15: " + getCheckMessage(EmptyForInitializerPadCheck.class,
+                    EmptyForInitializerPadCheck.MSG_PRECEDED, ";"),
+        };
+
+        final List<String> expectedXpathQueries = Arrays.asList(
+            "/COMPILATION_UNIT/CLASS_DEF[./IDENT["
+                    + "@text='InputXpathEmptyForInitializerPadPrecededStaticInit']]"
+                    + "/OBJBLOCK/STATIC_INIT/SLIST/LITERAL_FOR/FOR_INIT",
+            "/COMPILATION_UNIT/CLASS_DEF[./IDENT["
+                    + "@text='InputXpathEmptyForInitializerPadPrecededStaticInit']]"
+                    + "/OBJBLOCK/STATIC_INIT/SLIST/LITERAL_FOR/SEMI[1]"
+        );
+
+        runVerifications(moduleConfig, fileToProcess, expectedViolation,
+                expectedXpathQueries);
+    }
+
 }

--- a/src/it/resources/org/checkstyle/suppressionxpathfilter/whitespace/emptyforinitializerpad/InputXpathEmptyForInitializerPadPrecededStaticInit.java
+++ b/src/it/resources/org/checkstyle/suppressionxpathfilter/whitespace/emptyforinitializerpad/InputXpathEmptyForInitializerPadPrecededStaticInit.java
@@ -1,0 +1,9 @@
+package org.checkstyle.suppressionxpathfilter.whitespace.emptyforinitializerpad;
+
+public class InputXpathEmptyForInitializerPadPrecededStaticInit {
+    static int i;
+    static {
+        for ( ; i < 1; i++) { // warn
+        }
+    }
+}


### PR DESCRIPTION
Add 3rd test method `testPrecededStaticInit()` for `XpathRegressionEmptyForInitializerPadTest`.

The new test places the `for` loop with empty initializer inside a static initializer block,
producing an XPath through `STATIC_INIT/SLIST/LITERAL_FOR` instead of `METHOD_DEF/SLIST/LITERAL_FOR`.

- Existing tests: `testPreceded` (METHOD_DEF, default option), `testNotPreceded` (METHOD_DEF, SPACE option)  
- New test: `testPrecededStaticInit` (STATIC_INIT, default option)

Closes part of #19064