### PR TITLE
Issue #19064: Add 3rd test for XpathRegressionIllegalImportTest

### DIFF
--- a/config/checkstyle-non-main-files-suppressions.xml
+++ b/config/checkstyle-non-main-files-suppressions.xml
@@ -423,7 +423,6 @@
   <suppress id="numberOfTestCasesInXpath" files="[\\/]src[\\/]it[\\/]java[\\/]org[\\/]checkstyle[\\/]suppressionxpathfilter[\\/]coding[\\/]XpathRegressionUnnecessarySemicolonAfterTypeMemberDeclarationTest.java" />
   <suppress id="numberOfTestCasesInXpath" files="[\\/]src[\\/]it[\\/]java[\\/]org[\\/]checkstyle[\\/]suppressionxpathfilter[\\/]coding[\\/]XpathRegressionUnusedCatchParameterShouldBeUnnamedTest.java" />
   <suppress id="numberOfTestCasesInXpath" files="[\\/]src[\\/]it[\\/]java[\\/]org[\\/]checkstyle[\\/]suppressionxpathfilter[\\/]coding[\\/]XpathRegressionVariableDeclarationUsageDistanceTest.java" />
-  <suppress id="numberOfTestCasesInXpath" files="[\\/]src[\\/]it[\\/]java[\\/]org[\\/]checkstyle[\\/]suppressionxpathfilter[\\/]imports[\\/]XpathRegressionIllegalImportTest.java" />
   <suppress id="numberOfTestCasesInXpath" files="[\\/]src[\\/]it[\\/]java[\\/]org[\\/]checkstyle[\\/]suppressionxpathfilter[\\/]metrics[\\/]XpathRegressionCyclomaticComplexityTest.java" />
   <suppress id="numberOfTestCasesInXpath" files="[\\/]src[\\/]it[\\/]java[\\/]org[\\/]checkstyle[\\/]suppressionxpathfilter[\\/]modifier[\\/]XpathRegressionClassMemberImpliedModifierTest.java" />
   <suppress id="numberOfTestCasesInXpath" files="[\\/]src[\\/]it[\\/]java[\\/]org[\\/]checkstyle[\\/]suppressionxpathfilter[\\/]naming[\\/]XpathRegressionMemberNameTest.java" />

--- a/src/it/java/org/checkstyle/suppressionxpathfilter/imports/XpathRegressionIllegalImportTest.java
+++ b/src/it/java/org/checkstyle/suppressionxpathfilter/imports/XpathRegressionIllegalImportTest.java
@@ -83,4 +83,23 @@ public class XpathRegressionIllegalImportTest extends AbstractXpathTestSupport {
         runVerifications(moduleConfig, fileToProcess, expectedViolation,
                 expectedXpathQueries);
     }
+
+    @Test
+    public void testClass() throws Exception {
+        final File fileToProcess =
+                new File(getPath("InputXpathIllegalImportClass.java"));
+        final DefaultConfiguration moduleConfig =
+                createModuleConfig(IllegalImportCheck.class);
+        moduleConfig.addProperty("illegalClasses", "java.util.List");
+        final String[] expectedViolation = {
+            "4:1: " + getCheckMessage(IllegalImportCheck.class,
+                        IllegalImportCheck.MSG_KEY, "java.util.List"),
+        };
+        final List<String> expectedXpathQueries = Collections.singletonList(
+            "/COMPILATION_UNIT/IMPORT[./DOT/IDENT[@text='List']]"
+        );
+
+        runVerifications(moduleConfig, fileToProcess, expectedViolation,
+                expectedXpathQueries);
+    }
 }

--- a/src/it/resources/org/checkstyle/suppressionxpathfilter/imports/illegalimport/InputXpathIllegalImportClass.java
+++ b/src/it/resources/org/checkstyle/suppressionxpathfilter/imports/illegalimport/InputXpathIllegalImportClass.java
@@ -1,0 +1,7 @@
+package org.checkstyle.suppressionxpathfilter.imports.illegalimport;
+
+import java.io.File;
+import java.util.List; // warn
+
+public class InputXpathIllegalImportClass {
+}


### PR DESCRIPTION
Add 3rd test method `testClass()` for `XpathRegressionIllegalImportTest`.

The new test uses `illegalClasses` property (instead of `illegalPkgs`) with a preceding
non-violating import, producing an XPath with a predicate:
- Existing tests: `testDefault`  `testStatic`
- New test: `testClass` 

Closes part of #19064