### PR TITLE
Issue #19064: Add 3rd test for XpathRegressionInterfaceIsTypeTest

### DIFF
--- a/config/checkstyle-non-main-files-suppressions.xml
+++ b/config/checkstyle-non-main-files-suppressions.xml
@@ -429,7 +429,6 @@
   <suppress id="numberOfTestCasesInXpath" files="[\\/]src[\\/]it[\\/]java[\\/]org[\\/]checkstyle[\\/]suppressionxpathfilter[\\/]coding[\\/]XpathRegressionVariableDeclarationUsageDistanceTest.java" />
   <suppress id="numberOfTestCasesInXpath" files="[\\/]src[\\/]it[\\/]java[\\/]org[\\/]checkstyle[\\/]suppressionxpathfilter[\\/]coding[\\/]XpathRegressionWhenShouldBeUsedTest.java" />
   <suppress id="numberOfTestCasesInXpath" files="[\\/]src[\\/]it[\\/]java[\\/]org[\\/]checkstyle[\\/]suppressionxpathfilter[\\/]design[\\/]XpathRegressionHideUtilityClassConstructorTest.java" />
-  <suppress id="numberOfTestCasesInXpath" files="[\\/]src[\\/]it[\\/]java[\\/]org[\\/]checkstyle[\\/]suppressionxpathfilter[\\/]design[\\/]XpathRegressionInterfaceIsTypeTest.java" />
   <suppress id="numberOfTestCasesInXpath" files="[\\/]src[\\/]it[\\/]java[\\/]org[\\/]checkstyle[\\/]suppressionxpathfilter[\\/]design[\\/]XpathRegressionSealedShouldHavePermitsListTest.java" />
   <suppress id="numberOfTestCasesInXpath" files="[\\/]src[\\/]it[\\/]java[\\/]org[\\/]checkstyle[\\/]suppressionxpathfilter[\\/]imports[\\/]XpathRegressionAvoidStaticImportTest.java" />
   <suppress id="numberOfTestCasesInXpath" files="[\\/]src[\\/]it[\\/]java[\\/]org[\\/]checkstyle[\\/]suppressionxpathfilter[\\/]imports[\\/]XpathRegressionIllegalImportTest.java" />

--- a/src/it/java/org/checkstyle/suppressionxpathfilter/design/XpathRegressionInterfaceIsTypeTest.java
+++ b/src/it/java/org/checkstyle/suppressionxpathfilter/design/XpathRegressionInterfaceIsTypeTest.java
@@ -98,4 +98,34 @@ public class XpathRegressionInterfaceIsTypeTest extends AbstractXpathTestSupport
         runVerifications(moduleConfig, fileToProcess, expectedViolation,
                 expectedXpathQueries);
     }
+
+    @Test
+    public void testNested() throws Exception {
+        final File fileToProcess = new File(getPath(
+                "InputXpathInterfaceIsTypeNested.java"));
+
+        final DefaultConfiguration moduleConfig =
+                createModuleConfig(InterfaceIsTypeCheck.class);
+
+        final String[] expectedViolation = {
+            "4:5: " + getCheckMessage(InterfaceIsTypeCheck.class,
+                    InterfaceIsTypeCheck.MSG_KEY),
+        };
+
+        final List<String> expectedXpathQueries = Arrays.asList(
+                "/COMPILATION_UNIT/CLASS_DEF[./IDENT["
+                    + "@text='InputXpathInterfaceIsTypeNested']]"
+                    + "/OBJBLOCK/INTERFACE_DEF[./IDENT[@text='Foo']]",
+                "/COMPILATION_UNIT/CLASS_DEF[./IDENT["
+                    + "@text='InputXpathInterfaceIsTypeNested']]"
+                    + "/OBJBLOCK/INTERFACE_DEF[./IDENT[@text='Foo']]/MODIFIERS",
+                "/COMPILATION_UNIT/CLASS_DEF[./IDENT["
+                    + "@text='InputXpathInterfaceIsTypeNested']]"
+                    + "/OBJBLOCK/INTERFACE_DEF[./IDENT[@text='Foo']]"
+                    + "/MODIFIERS/LITERAL_PUBLIC"
+        );
+
+        runVerifications(moduleConfig, fileToProcess, expectedViolation,
+                expectedXpathQueries);
+    }
 }

--- a/src/it/resources/org/checkstyle/suppressionxpathfilter/design/interfaceistype/InputXpathInterfaceIsTypeNested.java
+++ b/src/it/resources/org/checkstyle/suppressionxpathfilter/design/interfaceistype/InputXpathInterfaceIsTypeNested.java
@@ -1,0 +1,7 @@
+package org.checkstyle.suppressionxpathfilter.design.interfaceistype;
+
+public class InputXpathInterfaceIsTypeNested {
+    public interface Foo { // warn
+        int VALUE = 1;
+    }
+}


### PR DESCRIPTION
Add 3rd test method `testNested()` for `XpathRegressionInterfaceIsTypeTest`.

The new test uses a nested interface inside a class, producing an XPath through
`CLASS_DEF/OBJBLOCK/INTERFACE_DEF` instead of the top-level `INTERFACE_DEF`.
- Existing tests: `testAllowMarker` (top-level INTERFACE_DEF), `testAllowMarkerFalse` (top-level INTERFACE_DEF)
- New test: `testNested` (nested INTERFACE_DEF inside CLASS_DEF)
Closes part of #19064