### PR TITLE
Issue #19064: Add 3rd test for XpathRegressionJavadocContentLocationTest

### DIFF
--- a/config/checkstyle-non-main-files-suppressions.xml
+++ b/config/checkstyle-non-main-files-suppressions.xml
@@ -433,7 +433,6 @@
   <suppress id="numberOfTestCasesInXpath" files="[\\/]src[\\/]it[\\/]java[\\/]org[\\/]checkstyle[\\/]suppressionxpathfilter[\\/]design[\\/]XpathRegressionSealedShouldHavePermitsListTest.java" />
   <suppress id="numberOfTestCasesInXpath" files="[\\/]src[\\/]it[\\/]java[\\/]org[\\/]checkstyle[\\/]suppressionxpathfilter[\\/]imports[\\/]XpathRegressionAvoidStaticImportTest.java" />
   <suppress id="numberOfTestCasesInXpath" files="[\\/]src[\\/]it[\\/]java[\\/]org[\\/]checkstyle[\\/]suppressionxpathfilter[\\/]imports[\\/]XpathRegressionIllegalImportTest.java" />
-  <suppress id="numberOfTestCasesInXpath" files="[\\/]src[\\/]it[\\/]java[\\/]org[\\/]checkstyle[\\/]suppressionxpathfilter[\\/]javadoc[\\/]XpathRegressionJavadocContentLocationTest.java" />
   <suppress id="numberOfTestCasesInXpath" files="[\\/]src[\\/]it[\\/]java[\\/]org[\\/]checkstyle[\\/]suppressionxpathfilter[\\/]javadoc[\\/]XpathRegressionJavadocVariableTest.java" />
   <suppress id="numberOfTestCasesInXpath" files="[\\/]src[\\/]it[\\/]java[\\/]org[\\/]checkstyle[\\/]suppressionxpathfilter[\\/]metrics[\\/]XpathRegressionCyclomaticComplexityTest.java" />
   <suppress id="numberOfTestCasesInXpath" files="[\\/]src[\\/]it[\\/]java[\\/]org[\\/]checkstyle[\\/]suppressionxpathfilter[\\/]metrics[\\/]XpathRegressionNPathComplexityTest.java" />

--- a/src/it/java/org/checkstyle/suppressionxpathfilter/javadoc/XpathRegressionJavadocContentLocationTest.java
+++ b/src/it/java/org/checkstyle/suppressionxpathfilter/javadoc/XpathRegressionJavadocContentLocationTest.java
@@ -93,4 +93,29 @@ public class XpathRegressionJavadocContentLocationTest extends AbstractXpathTest
                 expectedXpathQueries);
     }
 
+    @Test
+    public void testField() throws Exception {
+        final File fileToProcess =
+                new File(getPath("InputXpathJavadocContentLocationField.java"));
+
+        final DefaultConfiguration moduleConfig =
+                createModuleConfig(JavadocContentLocationCheck.class);
+
+        final String[] expectedViolation = {
+            "5:5: " + getCheckMessage(JavadocContentLocationCheck.class,
+                    JavadocContentLocationCheck.MSG_JAVADOC_CONTENT_SECOND_LINE),
+        };
+
+        final List<String> expectedXpathQueries = Collections.singletonList(
+            "/COMPILATION_UNIT/CLASS_DEF[./IDENT["
+                + "@text='InputXpathJavadocContentLocationField']]"
+                + "/OBJBLOCK/VARIABLE_DEF[./IDENT[@text='field']]/TYPE"
+                + "/BLOCK_COMMENT_BEGIN[./COMMENT_CONTENT[@text='* Text."
+                + " // warn\\n     ']]"
+        );
+
+        runVerifications(moduleConfig, fileToProcess, expectedViolation,
+                expectedXpathQueries);
+    }
+
 }

--- a/src/it/resources/org/checkstyle/suppressionxpathfilter/javadoc/javadoccontentlocation/InputXpathJavadocContentLocationField.java
+++ b/src/it/resources/org/checkstyle/suppressionxpathfilter/javadoc/javadoccontentlocation/InputXpathJavadocContentLocationField.java
@@ -1,0 +1,8 @@
+package org.checkstyle.suppressionxpathfilter.javadoc.javadoccontentlocation;
+
+public class InputXpathJavadocContentLocationField {
+
+    /** Text. // warn
+     */
+    int field;
+}


### PR DESCRIPTION
Add 3rd test method `testField()` for `XpathRegressionJavadocContentLocationTest`.
The new test places the javadoc on a field inside a class, producing an XPath through
`CLASS_DEF/OBJBLOCK/VARIABLE_DEF/TYPE/BLOCK_COMMENT_BEGIN` instead of
`INTERFACE_DEF/OBJBLOCK/METOD_DEF/TYPE/BLOCK_COMMENT_BEGIN`.
- Existing tests: `testOne`, `testTwo`
- New test: `testField` 
Closes part of #19064