### PR TITLE
Issue #19064: Add 3rd test for XpathRegressionSealedShouldHavePermitsListTest

### DIFF
--- a/config/checkstyle-non-main-files-suppressions.xml
+++ b/config/checkstyle-non-main-files-suppressions.xml
@@ -423,7 +423,6 @@
   <suppress id="numberOfTestCasesInXpath" files="[\\/]src[\\/]it[\\/]java[\\/]org[\\/]checkstyle[\\/]suppressionxpathfilter[\\/]coding[\\/]XpathRegressionUnnecessarySemicolonAfterTypeMemberDeclarationTest.java" />
   <suppress id="numberOfTestCasesInXpath" files="[\\/]src[\\/]it[\\/]java[\\/]org[\\/]checkstyle[\\/]suppressionxpathfilter[\\/]coding[\\/]XpathRegressionUnusedCatchParameterShouldBeUnnamedTest.java" />
   <suppress id="numberOfTestCasesInXpath" files="[\\/]src[\\/]it[\\/]java[\\/]org[\\/]checkstyle[\\/]suppressionxpathfilter[\\/]coding[\\/]XpathRegressionVariableDeclarationUsageDistanceTest.java" />
-  <suppress id="numberOfTestCasesInXpath" files="[\\/]src[\\/]it[\\/]java[\\/]org[\\/]checkstyle[\\/]suppressionxpathfilter[\\/]design[\\/]XpathRegressionSealedShouldHavePermitsListTest.java" />
   <suppress id="numberOfTestCasesInXpath" files="[\\/]src[\\/]it[\\/]java[\\/]org[\\/]checkstyle[\\/]suppressionxpathfilter[\\/]imports[\\/]XpathRegressionIllegalImportTest.java" />
   <suppress id="numberOfTestCasesInXpath" files="[\\/]src[\\/]it[\\/]java[\\/]org[\\/]checkstyle[\\/]suppressionxpathfilter[\\/]metrics[\\/]XpathRegressionCyclomaticComplexityTest.java" />
   <suppress id="numberOfTestCasesInXpath" files="[\\/]src[\\/]it[\\/]java[\\/]org[\\/]checkstyle[\\/]suppressionxpathfilter[\\/]metrics[\\/]XpathRegressionNPathComplexityTest.java" />

--- a/src/it/java/org/checkstyle/suppressionxpathfilter/design/XpathRegressionSealedShouldHavePermitsListTest.java
+++ b/src/it/java/org/checkstyle/suppressionxpathfilter/design/XpathRegressionSealedShouldHavePermitsListTest.java
@@ -99,4 +99,33 @@ public class XpathRegressionSealedShouldHavePermitsListTest extends AbstractXpat
         runVerifications(moduleConfig, fileToProcess, expectedViolation,
                 expectedXpathQueries);
     }
+
+    @Test
+    public void testInterface() throws Exception {
+        final File fileToProcess =
+                new File(getPath(
+                        "InputXpathSealedShouldHavePermitsListInterface.java"));
+
+        final DefaultConfiguration moduleConfig =
+                createModuleConfig(SealedShouldHavePermitsListCheck.class);
+
+        final String[] expectedViolation = {
+            "4:1: " + getCheckMessage(SealedShouldHavePermitsListCheck.class,
+                SealedShouldHavePermitsListCheck.MSG_KEY),
+        };
+
+        final List<String> expectedXpathQueries = Arrays.asList(
+                "/COMPILATION_UNIT/INTERFACE_DEF[./IDENT"
+                + "[@text='InputXpathSealedShouldHavePermitsListInterface']]",
+                "/COMPILATION_UNIT/INTERFACE_DEF[./IDENT"
+                + "[@text='InputXpathSealedShouldHavePermitsListInterface']]"
+                        + "/MODIFIERS",
+                "/COMPILATION_UNIT/INTERFACE_DEF[./IDENT"
+                + "[@text='InputXpathSealedShouldHavePermitsListInterface']]"
+                        + "/MODIFIERS/LITERAL_PUBLIC"
+        );
+
+        runVerifications(moduleConfig, fileToProcess, expectedViolation,
+                expectedXpathQueries);
+    }
 }

--- a/src/it/resources/org/checkstyle/suppressionxpathfilter/design/sealedshouldhavepermitslist/InputXpathSealedShouldHavePermitsListInterface.java
+++ b/src/it/resources/org/checkstyle/suppressionxpathfilter/design/sealedshouldhavepermitslist/InputXpathSealedShouldHavePermitsListInterface.java
@@ -1,0 +1,7 @@
+// Java17
+package org.checkstyle.suppressionxpathfilter.design.sealedshouldhavepermitslist;
+
+public sealed interface InputXpathSealedShouldHavePermitsListInterface { // warn
+    final class A implements InputXpathSealedShouldHavePermitsListInterface {}
+    final class B implements InputXpathSealedShouldHavePermitsListInterface {}
+}


### PR DESCRIPTION
Issue #19064: Add 3rd test for XpathRegressionSealedShouldHavePermitsListTest

Add testInterface() method that tests a sealed interface without a permits
clause. The existing tests cover a sealed inner class (testInner) and a
sealed top-level class (testTopLevel). The new test uses a different AST
path through INTERFACE_DEF.