### PR TITLE
Issue #19064: Add 3rd test for XpathRegressionNPathComplexityTest

### DIFF
--- a/config/checkstyle-non-main-files-suppressions.xml
+++ b/config/checkstyle-non-main-files-suppressions.xml
@@ -426,7 +426,6 @@
   <suppress id="numberOfTestCasesInXpath" files="[\\/]src[\\/]it[\\/]java[\\/]org[\\/]checkstyle[\\/]suppressionxpathfilter[\\/]design[\\/]XpathRegressionSealedShouldHavePermitsListTest.java" />
   <suppress id="numberOfTestCasesInXpath" files="[\\/]src[\\/]it[\\/]java[\\/]org[\\/]checkstyle[\\/]suppressionxpathfilter[\\/]imports[\\/]XpathRegressionIllegalImportTest.java" />
   <suppress id="numberOfTestCasesInXpath" files="[\\/]src[\\/]it[\\/]java[\\/]org[\\/]checkstyle[\\/]suppressionxpathfilter[\\/]metrics[\\/]XpathRegressionCyclomaticComplexityTest.java" />
-  <suppress id="numberOfTestCasesInXpath" files="[\\/]src[\\/]it[\\/]java[\\/]org[\\/]checkstyle[\\/]suppressionxpathfilter[\\/]metrics[\\/]XpathRegressionNPathComplexityTest.java" />
   <suppress id="numberOfTestCasesInXpath" files="[\\/]src[\\/]it[\\/]java[\\/]org[\\/]checkstyle[\\/]suppressionxpathfilter[\\/]modifier[\\/]XpathRegressionClassMemberImpliedModifierTest.java" />
   <suppress id="numberOfTestCasesInXpath" files="[\\/]src[\\/]it[\\/]java[\\/]org[\\/]checkstyle[\\/]suppressionxpathfilter[\\/]naming[\\/]XpathRegressionMemberNameTest.java" />
   <suppress id="numberOfTestCasesInXpath" files="[\\/]src[\\/]it[\\/]java[\\/]org[\\/]checkstyle[\\/]suppressionxpathfilter[\\/]sizes[\\/]XpathRegressionAnonInnerLengthTest.java" />

--- a/src/it/java/org/checkstyle/suppressionxpathfilter/metrics/XpathRegressionNPathComplexityTest.java
+++ b/src/it/java/org/checkstyle/suppressionxpathfilter/metrics/XpathRegressionNPathComplexityTest.java
@@ -98,4 +98,36 @@ public class XpathRegressionNPathComplexityTest extends AbstractXpathTestSupport
         runVerifications(moduleConfig, fileToProcess, expectedViolation,
                 expectedXpathQueries);
     }
+
+    @Test
+    public void testConstructor() throws Exception {
+        final File fileToProcess =
+                new File(getPath("InputXpathNPathComplexityConstructor.java"));
+
+        final DefaultConfiguration moduleConfig =
+                createModuleConfig(NPathComplexityCheck.class);
+        moduleConfig.addProperty("max", "0");
+
+        final String[] expectedViolation = {
+            "4:5: " + getCheckMessage(NPathComplexityCheck.class,
+                NPathComplexityCheck.MSG_KEY, 2, 0),
+        };
+
+        final List<String> expectedXpathQueries = Arrays.asList(
+            "/COMPILATION_UNIT/CLASS_DEF"
+                + "[./IDENT[@text='InputXpathNPathComplexityConstructor']]/OBJBLOCK"
+                + "/CTOR_DEF[./IDENT[@text='InputXpathNPathComplexityConstructor']]",
+            "/COMPILATION_UNIT/CLASS_DEF"
+                + "[./IDENT[@text='InputXpathNPathComplexityConstructor']]/OBJBLOCK"
+                + "/CTOR_DEF[./IDENT[@text='InputXpathNPathComplexityConstructor']]"
+                + "/MODIFIERS",
+            "/COMPILATION_UNIT/CLASS_DEF"
+                + "[./IDENT[@text='InputXpathNPathComplexityConstructor']]/OBJBLOCK"
+                + "/CTOR_DEF[./IDENT[@text='InputXpathNPathComplexityConstructor']]"
+                + "/MODIFIERS/LITERAL_PUBLIC"
+        );
+
+        runVerifications(moduleConfig, fileToProcess, expectedViolation,
+                expectedXpathQueries);
+    }
 }

--- a/src/it/resources/org/checkstyle/suppressionxpathfilter/metrics/npathcomplexity/InputXpathNPathComplexityConstructor.java
+++ b/src/it/resources/org/checkstyle/suppressionxpathfilter/metrics/npathcomplexity/InputXpathNPathComplexityConstructor.java
@@ -1,0 +1,11 @@
+package org.checkstyle.suppressionxpathfilter.metrics.npathcomplexity;
+
+public class InputXpathNPathComplexityConstructor {
+    public InputXpathNPathComplexityConstructor() { //warn
+        if (true) {
+            return;
+        } else {
+            return;
+        }
+    }
+}


### PR DESCRIPTION
Issue #19064: Add 3rd test for XpathRegressionNPathComplexityTest

Add testConstructor() method that tests NPath complexity in a constructor
with an if-else block. The existing tests cover a method (testMethod) and
a static initializer block (testStaticBlock). The new test uses a
different AST path through CTOR_DEF