### PR TITLE
Issue #19064: Add third test to XpathRegressionHideUtilityClassConstructorTest

### DIFF
--- a/config/checkstyle-non-main-files-suppressions.xml
+++ b/config/checkstyle-non-main-files-suppressions.xml
@@ -424,7 +424,6 @@
   <suppress id="numberOfTestCasesInXpath" files="[\\/]src[\\/]it[\\/]java[\\/]org[\\/]checkstyle[\\/]suppressionxpathfilter[\\/]coding[\\/]XpathRegressionUnnecessarySemicolonAfterTypeMemberDeclarationTest.java" />
   <suppress id="numberOfTestCasesInXpath" files="[\\/]src[\\/]it[\\/]java[\\/]org[\\/]checkstyle[\\/]suppressionxpathfilter[\\/]coding[\\/]XpathRegressionUnusedCatchParameterShouldBeUnnamedTest.java" />
   <suppress id="numberOfTestCasesInXpath" files="[\\/]src[\\/]it[\\/]java[\\/]org[\\/]checkstyle[\\/]suppressionxpathfilter[\\/]coding[\\/]XpathRegressionVariableDeclarationUsageDistanceTest.java" />
-  <suppress id="numberOfTestCasesInXpath" files="[\\/]src[\\/]it[\\/]java[\\/]org[\\/]checkstyle[\\/]suppressionxpathfilter[\\/]design[\\/]XpathRegressionHideUtilityClassConstructorTest.java" />
   <suppress id="numberOfTestCasesInXpath" files="[\\/]src[\\/]it[\\/]java[\\/]org[\\/]checkstyle[\\/]suppressionxpathfilter[\\/]design[\\/]XpathRegressionSealedShouldHavePermitsListTest.java" />
   <suppress id="numberOfTestCasesInXpath" files="[\\/]src[\\/]it[\\/]java[\\/]org[\\/]checkstyle[\\/]suppressionxpathfilter[\\/]imports[\\/]XpathRegressionIllegalImportTest.java" />
   <suppress id="numberOfTestCasesInXpath" files="[\\/]src[\\/]it[\\/]java[\\/]org[\\/]checkstyle[\\/]suppressionxpathfilter[\\/]javadoc[\\/]XpathRegressionJavadocVariableTest.java" />

--- a/src/it/java/org/checkstyle/suppressionxpathfilter/design/XpathRegressionHideUtilityClassConstructorTest.java
+++ b/src/it/java/org/checkstyle/suppressionxpathfilter/design/XpathRegressionHideUtilityClassConstructorTest.java
@@ -88,4 +88,26 @@ public class XpathRegressionHideUtilityClassConstructorTest extends AbstractXpat
         runVerifications(moduleConfig, fileToProcess, expectedViolation,
                 expectedXpathQueries);
     }
+
+    @Test
+    public void testFinalClass() throws Exception {
+        final File fileToProcess =
+                new File(getPath("InputXpathHideUtilityClassConstructorFinal.java"));
+        final DefaultConfiguration moduleConfig =
+                createModuleConfig(HideUtilityClassConstructorCheck.class);
+        final String[] expectedViolation = {
+            "3:1: " + getCheckMessage(HideUtilityClassConstructorCheck.class, MSG_KEY),
+        };
+        final List<String> expectedXpathQueries = Arrays.asList(
+            "/COMPILATION_UNIT/CLASS_DEF[./IDENT[@text='"
+                    + "InputXpathHideUtilityClassConstructorFinal']]",
+            "/COMPILATION_UNIT/CLASS_DEF[./IDENT[@text='"
+                    + "InputXpathHideUtilityClassConstructorFinal']]/MODIFIERS",
+            "/COMPILATION_UNIT/CLASS_DEF[./IDENT[@text='"
+                    + "InputXpathHideUtilityClassConstructorFinal']]/MODIFIERS/FINAL"
+        );
+
+        runVerifications(moduleConfig, fileToProcess, expectedViolation,
+                expectedXpathQueries);
+    }
 }

--- a/src/it/resources/org/checkstyle/suppressionxpathfilter/design/hideutilityclassconstructor/InputXpathHideUtilityClassConstructorFinal.java
+++ b/src/it/resources/org/checkstyle/suppressionxpathfilter/design/hideutilityclassconstructor/InputXpathHideUtilityClassConstructorFinal.java
@@ -1,0 +1,9 @@
+package org.checkstyle.suppressionxpathfilter.design.hideutilityclassconstructor;
+
+final class InputXpathHideUtilityClassConstructorFinal { // warn
+    private static int value = 0;
+
+    public static void foo(int val) {
+        value = val;
+    }
+}


### PR DESCRIPTION
### Description

Added a third test case to `XpathRegressionHideUtilityClassConstructorTest` to provide an additional distinct XPath structure and enable removal of suppression for this test.

### Changes

* Added new input file:

  * `InputXpathHideUtilityClassConstructorFinal.java`
* Added new test method `testFinalClass`
* Removed suppression entry from `checkstyle-non-main-files-suppressions.xml`

### Technical Details

Initially attempted to introduce a nested class to generate a different XPath structure, but discovered that `HideUtilityClassConstructorCheck` skips static classes:

```java
if (isAbstract(ast) || isStatic(ast)) {
    return;
}
```

This resulted in no violations (`Audit done.`), making the test ineffective.

To resolve this, used a **package-private final class**, which:

* Still triggers the check
* Produces a different AST modifier structure
* Results in a distinct XPath ending in `FINAL` instead of `LITERAL_PUBLIC`

### Result

* Generates a valid third XPath structure
* Removes need for suppression
* Keeps test suite consistent with Issue #19064 goals
