### PR TITLE
Issue #19064: Add third test to XpathRegressionRecordTypeParameterNameTest

### DIFF
--- a/config/checkstyle-non-main-files-suppressions.xml
+++ b/config/checkstyle-non-main-files-suppressions.xml
@@ -431,7 +431,6 @@
   <suppress id="numberOfTestCasesInXpath" files="[\\/]src[\\/]it[\\/]java[\\/]org[\\/]checkstyle[\\/]suppressionxpathfilter[\\/]metrics[\\/]XpathRegressionNPathComplexityTest.java" />
   <suppress id="numberOfTestCasesInXpath" files="[\\/]src[\\/]it[\\/]java[\\/]org[\\/]checkstyle[\\/]suppressionxpathfilter[\\/]modifier[\\/]XpathRegressionClassMemberImpliedModifierTest.java" />
   <suppress id="numberOfTestCasesInXpath" files="[\\/]src[\\/]it[\\/]java[\\/]org[\\/]checkstyle[\\/]suppressionxpathfilter[\\/]naming[\\/]XpathRegressionMemberNameTest.java" />
-  <suppress id="numberOfTestCasesInXpath" files="[\\/]src[\\/]it[\\/]java[\\/]org[\\/]checkstyle[\\/]suppressionxpathfilter[\\/]naming[\\/]XpathRegressionRecordTypeParameterNameTest.java" />
   <suppress id="numberOfTestCasesInXpath" files="[\\/]src[\\/]it[\\/]java[\\/]org[\\/]checkstyle[\\/]suppressionxpathfilter[\\/]sizes[\\/]XpathRegressionAnonInnerLengthTest.java" />
   <suppress id="numberOfTestCasesInXpath" files="[\\/]src[\\/]it[\\/]java[\\/]org[\\/]checkstyle[\\/]suppressionxpathfilter[\\/]sizes[\\/]XpathRegressionOuterTypeNumberTest.java" />
   <suppress id="numberOfTestCasesInXpath" files="[\\/]src[\\/]it[\\/]java[\\/]org[\\/]checkstyle[\\/]suppressionxpathfilter[\\/]whitespace[\\/]XpathRegressionEmptyForInitializerPadTest.java" />

--- a/src/it/java/org/checkstyle/suppressionxpathfilter/naming/XpathRegressionRecordTypeParameterNameTest.java
+++ b/src/it/java/org/checkstyle/suppressionxpathfilter/naming/XpathRegressionRecordTypeParameterNameTest.java
@@ -99,4 +99,36 @@ public class XpathRegressionRecordTypeParameterNameTest extends AbstractXpathTes
         runVerifications(moduleConfig, fileToProcess, expectedViolation,
                 expectedXpathQueries);
     }
+
+    @Test
+    public void testNested() throws Exception {
+        final File fileToProcess = new File(getPath(
+                "InputXpathRecordTypeParameterNameNested.java"));
+
+        final DefaultConfiguration moduleConfig =
+                createModuleConfig(RecordTypeParameterNameCheck.class);
+
+        final String pattern = "^[A-Z]$";
+
+        final String[] expectedViolation = {
+            "6:25: " + getCheckMessage(RecordTypeParameterNameCheck.class,
+                    AbstractNameCheck.MSG_INVALID_PATTERN, "abc", pattern),
+        };
+
+        final List<String> expectedXpathQueries = Arrays.asList(
+            "/COMPILATION_UNIT/CLASS_DEF[./IDENT"
+                + "[@text='InputXpathRecordTypeParameterNameNested']]"
+                + "/OBJBLOCK/CLASS_DEF[./IDENT[@text='Inner']]"
+                + "/OBJBLOCK/RECORD_DEF[./IDENT[@text='MyRecord']]"
+                + "/TYPE_PARAMETERS/TYPE_PARAMETER[./IDENT[@text='abc']]",
+            "/COMPILATION_UNIT/CLASS_DEF[./IDENT"
+                + "[@text='InputXpathRecordTypeParameterNameNested']]"
+                + "/OBJBLOCK/CLASS_DEF[./IDENT[@text='Inner']]"
+                + "/OBJBLOCK/RECORD_DEF[./IDENT[@text='MyRecord']]"
+                + "/TYPE_PARAMETERS/TYPE_PARAMETER/IDENT[@text='abc']"
+        );
+
+        runVerifications(moduleConfig, fileToProcess, expectedViolation,
+                expectedXpathQueries);
+    }
 }

--- a/src/it/resources/org/checkstyle/suppressionxpathfilter/naming/recordtypeparametername/InputXpathRecordTypeParameterNameNested.java
+++ b/src/it/resources/org/checkstyle/suppressionxpathfilter/naming/recordtypeparametername/InputXpathRecordTypeParameterNameNested.java
@@ -1,0 +1,8 @@
+// Java17
+package org.checkstyle.suppressionxpathfilter.naming.recordtypeparametername;
+
+public class InputXpathRecordTypeParameterNameNested {
+    class Inner {
+        record MyRecord<abc>(Integer x, String str) { } // warn
+    }
+}


### PR DESCRIPTION
Issue: #19064

Add third test to XpathRegressionRecordTypeParameterNameTest to meet the requirement of 
3 distinct test methods with different XPath structures.

Changes:
- Added new test method `testNested()` with nested record inside inner class
- Created new input file `InputXpathRecordTypeParameterNameNested.java`
- Removed suppression for this file from `checkstyle-non-main-files-suppressions.xml`

The three tests now cover different AST structures:
1. Record type parameter with bounds (existing)
2. Simple record type parameter (existing)
3. Nested record with type parameter inside inner class (new)

All tests pass with `mvn clean verify`.