### PR TITLE
Issue #18673: Document 3 excluded OpenRewrite recipes in CodeCleanup

### DIFF
--- a/config/rewrite.yml
+++ b/config/rewrite.yml
@@ -59,6 +59,9 @@ recipeList:
       exclude:
         # all suppressions until https://github.com/checkstyle/checkstyle/issues/18952
         - org.openrewrite.staticanalysis.DefaultComesLast
+        # Kept excluded: OpenRewrite's EmptyBlock removes blocks entirely,
+        # which conflicts with Checkstyle's EmptyBlockCheck that requires
+        # blocks to have statements or text. Automatic deletion is too aggressive.
         - org.openrewrite.staticanalysis.EmptyBlock
         - org.openrewrite.staticanalysis.FinalizePrivateFields
         - org.openrewrite.staticanalysis.ForLoopControlVariablePostfixOperators
@@ -67,8 +70,16 @@ recipeList:
         - org.openrewrite.java.format.NoWhitespaceBefore
         - org.openrewrite.staticanalysis.TypecastParenPad
         - org.openrewrite.staticanalysis.ExplicitInitialization
+        # Kept excluded: OpenRewrite's FallThrough always adds break statements,
+        # ignoring Checkstyle's FallThroughCheck which allows configurable relief
+        # comments via `reliefPattern` and can optionally skip checking the last
+        # case group with `checkLastCaseGroup`
         - org.openrewrite.staticanalysis.FallThrough
         - org.openrewrite.staticanalysis.HideUtilityClassConstructor
+        # Kept excluded: OpenRewrite's NeedBraces always adds braces, overriding
+        # Checkstyle's NeedBracesCheck which allows configuration for single-line
+        # statements and empty loop bodies via `allowSingleLineStatement` and
+        # `allowEmptyLoopBody` options.
         - org.openrewrite.staticanalysis.NeedBraces
         - org.openrewrite.staticanalysis.OperatorWrap
         - org.openrewrite.staticanalysis.ReplaceThreadRunWithThreadStart


### PR DESCRIPTION
Issue: #18952

Document the reasons for keeping certain OpenRewrite recipes excluded in the CodeCleanup composite recipe.


@romani  If you like this approach (documenting each excluded recipe with clear reasons), I can continue with the remaining excluded recipes in separate PRs. This keeps each PR focused and easy to review. Let me know if you'd prefer me to batch multiple recipes together instead.
---

## Recipes Documented

---

### 1. `org.openrewrite.staticanalysis.EmptyBlock` https://docs.openrewrite.org/recipes/staticanalysis/emptyblock

**What OpenRewrite does:**

```java
// Before
switch(i) { }

// After
// (empty block is completely removed)
```

OpenRewrite removes empty blocks entirely from the code—it does not check for comments or intentional design.

**Checkstyle's equivalent: `EmptyBlockCheck`**

Checkstyle gives configurable validation for empty blocks:

```xml
<module name="EmptyBlock">
    <!-- Two policy options: -->
    <property name="option" value="statement"/>  <!-- Requires at least one statement -->
    <!-- OR -->
    <property name="option" value="text"/>       <!-- Allows comments in empty blocks -->
</module>
```

**Behavioral example:**

```java
// With option="text", this is OK:
try {
    // TODO: handle exception later
} catch (Exception e) {
    // Expected - contains comment, so check passes
}
// OpenRewrite would delete this entire try-catch block!
```

**Why keep excluded:**
- Removes code that Checkstyle explicitly allows (e.g., blocks with comments)
- May delete intentionally empty blocks
- Too aggressive for automated fix
- Ignores Checkstyle's `option` property

---

### 2. `org.openrewrite.staticanalysis.NeedBraces` https://docs.openrewrite.org/recipes/staticanalysis/needbraces

**What OpenRewrite does:**

```java
// Before
if (x > 0) return true;
for (int i = 0; i < 10; i++) count++;
while (condition) doSomething();

// After
if (x > 0) {
    return true;
}
for (int i = 0; i < 10; i++) {
    count++;
}
while (condition) {
    doSomething();
}
```

Forces braces onto single-line statements, with no configuration.

**Checkstyle's equivalent: `NeedBracesCheck`**

Checkstyle allows multiple configuration options:

```xml
<module name="NeedBraces">
    <property name="allowSingleLineStatement" value="true"/>
    <property name="allowEmptyLoopBody" value="true"/>
    <property name="tokens" value="LITERAL_IF, LITERAL_ELSE"/>
</module>
```

**Behavioral example:**

```java
// When allowSingleLineStatement="true", this is OK:
if (x > 0) return true;

// When allowEmptyLoopBody="true", this is OK:
for (int i = 0; i < 10; i++);
// OpenRewrite would force braces in both cases
```

**Why keep excluded:**
- Would force braces even when projects configure single-line statements
- Removes flexibility Checkstyle provides for style preferences
- Ignores project-specific configuration
- Adds unnecessary braces

---

### 3. `org.openrewrite.staticanalysis.FallThrough` : https://docs.openrewrite.org/recipes/staticanalysis/fallthrough

**What OpenRewrite does:**

```java
// Before
switch (i) {
case 0:
    i++;
case 1:
    i++;
}

// After
switch (i) {
case 0:
    i++;
    break;
case 1:
    i++;
}
```

Always adds break statements to prevent fall-through, with no configuration.

**Checkstyle's equivalent: `FallThroughCheck`**

Checkstyle intentionally allows fall-through with relief comments:

```xml
<module name="FallThrough">
    <property name="reliefPattern" value="falls?[ -]?thr(u|ough)"/>
    <property name="checkLastCaseGroup" value="false"/>
</module>
```

**Behavioral example:**

```java
switch (i) {
case 0:
    i++;
    // fall through  // ← Relief comment prevents violation
case 1:
    i++;
    break;
case 2:
    i++;
    // Intentionally no break
    // falls through    // ← Another relief comment
default:
    i++;
}
```

**Why keep excluded:**
- Would remove intentionally designed fall-through behavior
- Ignores relief comments and Checkstyle’s configurability
- Adds unnecessary breaks
- Doesn’t respect project conventions

---