### PR TITLE
Issue #18435: Fix XdocsExamplesAstConsistencyTest(InterfaceTypeParame…

### DIFF
--- a/src/site/xdoc/checks/naming/interfacetypeparametername.xml
+++ b/src/site/xdoc/checks/naming/interfacetypeparametername.xml
@@ -51,6 +51,7 @@
 class Example1 {
   interface FirstInterface&lt;T&gt; {}
   interface SecondInterface&lt;t&gt; {} // violation 'Name 't' must match pattern'
+  interface ThirdInterface&lt;type&gt; {} // violation 'Name 'type' must match pattern'
 }
 </code></pre></div><hr class="example-separator"/>
         <p id="Example2-config">

--- a/src/test/java/com/puppycrawl/tools/checkstyle/internal/XdocsExamplesAstConsistencyTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/internal/XdocsExamplesAstConsistencyTest.java
@@ -188,7 +188,6 @@ public class XdocsExamplesAstConsistencyTest {
             "checks/naming/abbreviationaswordinname/Example5",
             "checks/naming/abbreviationaswordinname/Example6",
             "checks/naming/abbreviationaswordinname/Example7",
-            "checks/naming/interfacetypeparametername/Example2",
             "checks/naming/lambdaparametername/Example2",
             "checks/naming/localfinalvariablename/Example3",
             "checks/naming/localvariablename/Example3",

--- a/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/checks/naming/InterfaceTypeParameterNameCheckExamplesTest.java
+++ b/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/checks/naming/InterfaceTypeParameterNameCheckExamplesTest.java
@@ -36,6 +36,7 @@ public class InterfaceTypeParameterNameCheckExamplesTest extends AbstractExample
 
         final String[] expected = {
             "14:29: " + getCheckMessage(MSG_INVALID_PATTERN, "t", "^[A-Z]$"),
+            "15:28: " + getCheckMessage(MSG_INVALID_PATTERN, "type", "^[A-Z]$"),
         };
 
         verifyWithInlineConfigParser(getPath("Example1.java"), expected);

--- a/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/naming/interfacetypeparametername/Example1.java
+++ b/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/naming/interfacetypeparametername/Example1.java
@@ -12,5 +12,6 @@ package com.puppycrawl.tools.checkstyle.checks.naming.interfacetypeparametername
 class Example1 {
   interface FirstInterface<T> {}
   interface SecondInterface<t> {} // violation 'Name 't' must match pattern'
+  interface ThirdInterface<type> {} // violation 'Name 'type' must match pattern'
 }
 // xdoc section -- end


### PR DESCRIPTION
Issue: #18435

Remove `InterfaceTypeParameterName` of `Example 1` from `XdocsExamplesAstConsistencyTest Suppression List`.
Diff link of Example 1 vs Example 2 : https://www.diffchecker.com/KjREqMY0/
<img width="951" height="808" alt="Screenshot 2026-03-20 104150" src="https://github.com/user-attachments/assets/68611875-313f-4dfd-9946-fb4042021e26" />
 
