### PR TITLE
Issue #15456: Replace shorthand violation comments in InputParameterNameAccessModifier

### DIFF
--- a/src/site/xdoc/checks/naming/parametername.xml
+++ b/src/site/xdoc/checks/naming/parametername.xml
@@ -78,7 +78,7 @@
         <div class="wrapper"><pre class="prettyprint"><code class="language-java">
 class Example1 {
   void method1(int v1) {}
-  void method2(int V2) {} // violation
+  void method2(int V2) {} // violation 'Name 'V2' must match pattern'
 }
 </code></pre></div><hr class="example-separator"/>
         <p id="Example2-config">
@@ -99,7 +99,7 @@ class Example1 {
 class Example2 {
   void method1(int v1) {}
   void method2(int v_2) {}
-  void method3(int V3) {} // violation
+  void method3(int V3) {} // violation 'Name 'V3' must match pattern'
 }
 </code></pre></div><hr class="example-separator"/>
 
@@ -120,7 +120,7 @@ class Example2 {
         <div class="wrapper"><pre class="prettyprint"><code class="language-java">
 class Example3 {
   void method1(int v1) {}
-  void method2(int V2) {} // violation
+  void method2(int V2) {} // violation 'Name 'V2' must match pattern'
   @Override
   public boolean equals(Object V3) {
     return true;
@@ -144,8 +144,8 @@ class Example3 {
         <div class="wrapper"><pre class="prettyprint"><code class="language-java">
 class Example4 {
   void method1(int v1) {}
-  void method2(int v_2) {} // violation
-  void method3(int V3) {} // violation
+  void method2(int v_2) {} // violation 'Name 'v_2' must match pattern'
+  void method3(int V3) {} // violation 'Name 'V3' must match pattern'
 }
 </code></pre></div><hr class="example-separator"/>
         <p id="Example5-config">

--- a/src/test/java/com/puppycrawl/tools/checkstyle/TreeWalkerTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/TreeWalkerTest.java
@@ -533,9 +533,9 @@ public class TreeWalkerTest extends AbstractModuleTestSupport {
     public void testMultiCheckOfSameTypeNoIdResultsInOrderingByHash() throws Exception {
 
         final String[] expected = {
-            "15:28: " + getCheckMessage(ParameterNameCheck.class,
+            "17:28: " + getCheckMessage(ParameterNameCheck.class,
                     "name.invalidPattern", "V2", "^[a-z]([a-z0-9][a-zA-Z0-9]*)?$"),
-            "17:25: " + getCheckMessage(ParameterNameCheck.class,
+            "19:25: " + getCheckMessage(ParameterNameCheck.class,
                     "name.invalidPattern", "b", "^[a-z][a-z0-9][a-zA-Z0-9]*$"),
         };
 

--- a/src/test/java/com/puppycrawl/tools/checkstyle/bdd/InlineConfigParser.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/bdd/InlineConfigParser.java
@@ -266,7 +266,7 @@ public final class InlineConfigParser {
             "com.puppycrawl.tools.checkstyle.checks.naming.AbbreviationAsWordInNameCheck",
 
             "com.puppycrawl.tools.checkstyle.checks.naming.IllegalIdentifierNameCheck",
-            "com.puppycrawl.tools.checkstyle.checks.naming.ParameterNameCheck",
+
             "com.puppycrawl.tools.checkstyle.checks.naming.RecordComponentNameCheck",
             "com.puppycrawl.tools.checkstyle.checks.naming.RecordTypeParameterNameCheck",
             "com.puppycrawl.tools.checkstyle.checks.regexp.RegexpMultilineCheck",
@@ -320,7 +320,7 @@ public final class InlineConfigParser {
             "com.puppycrawl.tools.checkstyle.checks.modifier.RedundantModifierCheck",
             "com.puppycrawl.tools.checkstyle.checks.naming.AbbreviationAsWordInNameCheck",
             "com.puppycrawl.tools.checkstyle.checks.naming.LocalFinalVariableNameCheck",
-            "com.puppycrawl.tools.checkstyle.checks.naming.ParameterNameCheck",
+
             "com.puppycrawl.tools.checkstyle.checks.regexp.RegexpCheck",
             "com.puppycrawl.tools.checkstyle.checks.regexp.RegexpSinglelineCheck",
             "com.puppycrawl.tools.checkstyle.checks.regexp.RegexpSinglelineJavaCheck",

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/naming/ParameterNameCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/naming/ParameterNameCheckTest.java
@@ -199,12 +199,12 @@ public class ParameterNameCheckTest
         final String pattern = "^h$";
 
         final String[] expected = {
-            "14:49: " + getCheckMessage(MSG_INVALID_PATTERN, "constructorParam", pattern),
-            "18:31: " + getCheckMessage(MSG_INVALID_PATTERN, "inner", pattern),
-            "28:24: " + getCheckMessage(MSG_INVALID_PATTERN, "publicParam", pattern),
-            "39:21: " + getCheckMessage(MSG_INVALID_PATTERN, "interfaceParam", pattern),
-            "53:24: " + getCheckMessage(MSG_INVALID_PATTERN, "packageParam", pattern),
-            "69:21: " + getCheckMessage(MSG_INVALID_PATTERN, "paramName", pattern),
+            "15:49: " + getCheckMessage(MSG_INVALID_PATTERN, "constructorParam", pattern),
+            "19:31: " + getCheckMessage(MSG_INVALID_PATTERN, "inner", pattern),
+            "30:24: " + getCheckMessage(MSG_INVALID_PATTERN, "publicParam", pattern),
+            "42:21: " + getCheckMessage(MSG_INVALID_PATTERN, "interfaceParam", pattern),
+            "57:24: " + getCheckMessage(MSG_INVALID_PATTERN, "packageParam", pattern),
+            "74:21: " + getCheckMessage(MSG_INVALID_PATTERN, "paramName", pattern),
             };
         verifyWithInlineConfigParser(
                 getPath("InputParameterNameAccessModifier.java"), expected);

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/naming/parametername/InputParameterNameAccessModifier.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/naming/parametername/InputParameterNameAccessModifier.java
@@ -11,11 +11,12 @@ package com.puppycrawl.tools.checkstyle.checks.naming.parametername;
 
 public class InputParameterNameAccessModifier {
 
-    public InputParameterNameAccessModifier(int constructorParam) {} // violation
+    // violation below 'Name 'constructorParam' must match pattern'
+    public InputParameterNameAccessModifier(int constructorParam) {}
 
     public void v1(int h) {
         new Object () {
-            public void i(int inner) {} // violation
+            public void i(int inner) {} // violation 'Name 'inner' must match pattern'
         };
     }
 
@@ -25,7 +26,8 @@ public class InputParameterNameAccessModifier {
 
     private void v3(int h) {}
 
-    public void i1(int publicParam) {} // violation
+    // violation below 'Name 'publicParam' must match pattern'
+    public void i1(int publicParam) {}
 
     protected void i4(int pubprot) {}
 
@@ -36,7 +38,8 @@ public class InputParameterNameAccessModifier {
     public interface InterfaceScope {
         void v1(int h);
 
-        void i1(int interfaceParam); // violation
+        // violation below 'Name 'interfaceParam' must match pattern'
+        void i1(int interfaceParam);
     }
 }
 
@@ -50,7 +53,8 @@ class PrivateScope {
 
     private void v3(int h) {}
 
-    public void i1(int packageParam) {} // violation
+    // violation below 'Name 'packageParam' must match pattern'
+    public void i1(int packageParam) {}
 
     protected void i4(int packprot) {}
 
@@ -66,7 +70,8 @@ class PrivateScope {
     interface InterfaceScope {
         void v1(int h);
 
-        void i1(int paramName); // violation
+        // violation below 'Name 'paramName' must match pattern'
+        void i1(int paramName);
     }
 
     interface FuncIfc {

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/naming/parametername/InputParameterNameForEach.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/naming/parametername/InputParameterNameForEach.java
@@ -1,6 +1,6 @@
 /*
 ParameterName
-format = ^[a-z][a-zA-Z0-9]*$
+format = (default)^[a-z][a-zA-Z0-9]*$
 ignoreOverridden = (default)false
 accessModifiers = (default)public, protected, package, private
 

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/treewalker/InputTreeWalkerMultiCheckOrder2.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/treewalker/InputTreeWalkerMultiCheckOrder2.java
@@ -1,10 +1,12 @@
 /*
 com.puppycrawl.tools.checkstyle.checks.naming.ParameterNameCheck
 format = ^[a-z]([a-z0-9][a-zA-Z0-9]*)?$
+ignoreOverridden = (default)false
 accessModifiers =  protected, package, private
 
 com.puppycrawl.tools.checkstyle.checks.naming.ParameterNameCheck
 format = ^[a-z][a-z0-9][a-zA-Z0-9]*$
+ignoreOverridden = (default)false
 accessModifiers = public
 
 */

--- a/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/naming/parametername/Example1.java
+++ b/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/naming/parametername/Example1.java
@@ -11,6 +11,6 @@ package com.puppycrawl.tools.checkstyle.checks.naming.parametername;
 // xdoc section -- start
 class Example1 {
   void method1(int v1) {}
-  void method2(int V2) {} // violation
+  void method2(int V2) {} // violation 'Name 'V2' must match pattern'
 }
 // xdoc section -- end

--- a/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/naming/parametername/Example2.java
+++ b/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/naming/parametername/Example2.java
@@ -14,6 +14,6 @@ package com.puppycrawl.tools.checkstyle.checks.naming.parametername;
 class Example2 {
   void method1(int v1) {}
   void method2(int v_2) {}
-  void method3(int V3) {} // violation
+  void method3(int V3) {} // violation 'Name 'V3' must match pattern'
 }
 // xdoc section -- end

--- a/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/naming/parametername/Example3.java
+++ b/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/naming/parametername/Example3.java
@@ -13,7 +13,7 @@ package com.puppycrawl.tools.checkstyle.checks.naming.parametername;
 // xdoc section -- start
 class Example3 {
   void method1(int v1) {}
-  void method2(int V2) {} // violation
+  void method2(int V2) {} // violation 'Name 'V2' must match pattern'
   @Override
   public boolean equals(Object V3) {
     return true;

--- a/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/naming/parametername/Example4.java
+++ b/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/naming/parametername/Example4.java
@@ -13,7 +13,7 @@ package com.puppycrawl.tools.checkstyle.checks.naming.parametername;
 // xdoc section -- start
 class Example4 {
   void method1(int v1) {}
-  void method2(int v_2) {} // violation
-  void method3(int V3) {} // violation
+  void method2(int v_2) {} // violation 'Name 'v_2' must match pattern'
+  void method3(int V3) {} // violation 'Name 'V3' must match pattern'
 }
 // xdoc section -- end


### PR DESCRIPTION
Issue #15456

This PR completes the remaining `ParameterNameCheck` updates needed for inline config parsing.

Details:
- replaced remaining shorthand violation comments in `InputParameterNameAccessModifier.java`
- updated expected line numbers in `ParameterNameCheckTest`
- updated `ParameterNameCheck` xdoc examples to use explicit violation messages
- removed `ParameterNameCheck` from `SUPPRESSED_CHECKS` in `InlineConfigParser`

Verification:
- ./mvnw -Dtest=ParameterNameCheckTest,ParameterNameCheckExamplesTest test
- ./mvnw clean verify