### PR TITLE
Issue #19064: Added third test in XpathRegressionOuterTypeNumberTest

### DIFF
--- a/config/checkstyle-non-main-files-suppressions.xml
+++ b/config/checkstyle-non-main-files-suppressions.xml
@@ -428,6 +428,5 @@
   <suppress id="numberOfTestCasesInXpath" files="[\\/]src[\\/]it[\\/]java[\\/]org[\\/]checkstyle[\\/]suppressionxpathfilter[\\/]modifier[\\/]XpathRegressionClassMemberImpliedModifierTest.java" />
   <suppress id="numberOfTestCasesInXpath" files="[\\/]src[\\/]it[\\/]java[\\/]org[\\/]checkstyle[\\/]suppressionxpathfilter[\\/]naming[\\/]XpathRegressionMemberNameTest.java" />
   <suppress id="numberOfTestCasesInXpath" files="[\\/]src[\\/]it[\\/]java[\\/]org[\\/]checkstyle[\\/]suppressionxpathfilter[\\/]sizes[\\/]XpathRegressionAnonInnerLengthTest.java" />
-  <suppress id="numberOfTestCasesInXpath" files="[\\/]src[\\/]it[\\/]java[\\/]org[\\/]checkstyle[\\/]suppressionxpathfilter[\\/]sizes[\\/]XpathRegressionOuterTypeNumberTest.java" />
   <suppress id="numberOfTestCasesInXpath" files="[\\/]src[\\/]it[\\/]java[\\/]org[\\/]checkstyle[\\/]suppressionxpathfilter[\\/]whitespace[\\/]XpathRegressionEmptyForInitializerPadTest.java" />
 </suppressions>

--- a/src/it/java/org/checkstyle/suppressionxpathfilter/sizes/XpathRegressionOuterTypeNumberTest.java
+++ b/src/it/java/org/checkstyle/suppressionxpathfilter/sizes/XpathRegressionOuterTypeNumberTest.java
@@ -85,4 +85,26 @@ public class XpathRegressionOuterTypeNumberTest extends AbstractXpathTestSupport
         runVerifications(moduleConfig, fileToProcess, expectedViolation,
                 expectedXpathQueries);
     }
+
+    @Test
+    public void testThree() throws Exception {
+        final File fileToProcess =
+                new File(getPath("InputXpathOuterTypeNumberThree.java"));
+
+        final DefaultConfiguration moduleConfig =
+                createModuleConfig(OuterTypeNumberCheck.class);
+        moduleConfig.addProperty("max", "2");
+
+        final String[] expectedViolation = {
+            "1:1: " + getCheckMessage(OuterTypeNumberCheck.class,
+                    OuterTypeNumberCheck.MSG_KEY, 3, 2),
+        };
+
+        final List<String> expectedXpathQueries = Arrays.asList(
+                "/COMPILATION_UNIT", "/COMPILATION_UNIT/PACKAGE_DEF"
+        );
+
+        runVerifications(moduleConfig, fileToProcess, expectedViolation,
+                expectedXpathQueries);
+    }
 }

--- a/src/it/resources/org/checkstyle/suppressionxpathfilter/sizes/outertypenumber/InputXpathOuterTypeNumberThree.java
+++ b/src/it/resources/org/checkstyle/suppressionxpathfilter/sizes/outertypenumber/InputXpathOuterTypeNumberThree.java
@@ -1,0 +1,13 @@
+package org.checkstyle.suppressionxpathfilter.sizes.outertypenumber; //warn
+
+public class InputXpathOuterTypeNumberThree {
+    void method() {}
+}
+
+enum Direction {
+    NORTH, SOUTH, EAST, WEST;
+}
+
+interface SecondInterface {
+    int VALUE = 2;
+}


### PR DESCRIPTION
Issue #19064:
Added third test in `XpathRegressionOuterTypeNumberTest.java` 
The input file contains enum, interface  along with an empty method.