### PR TITLE
Issue #16246: Fix false positive indentation violations in nested method calls

### DIFF
--- a/config/checker-framework-suppressions/checker-nullness-optional-interning-suppressions.xml
+++ b/config/checker-framework-suppressions/checker-nullness-optional-interning-suppressions.xml
@@ -5667,11 +5667,44 @@
   <checkerFrameworkError unstable="false">
     <fileName>src/main/java/com/puppycrawl/tools/checkstyle/checks/indentation/MethodCallHandler.java</fileName>
     <specifier>argument</specifier>
-    <message>incompatible argument for parameter tree of AbstractExpressionHandler.checkExpressionSubtree.</message>
-    <lineContent>getMainAst().findFirstToken(TokenTypes.ELIST),</lineContent>
+    <message>incompatible argument for parameter ast2 of TokenUtil.areOnSameLine.</message>
+    <lineContent>nestedCall.findFirstToken(TokenTypes.RPAREN))) {</lineContent>
     <details>
       found   : @Initialized @Nullable DetailAST
       required: @Initialized @NonNull DetailAST
+    </details>
+  </checkerFrameworkError>
+
+  <checkerFrameworkError unstable="false">
+    <fileName>src/main/java/com/puppycrawl/tools/checkstyle/checks/indentation/MethodCallHandler.java</fileName>
+    <specifier>argument</specifier>
+    <message>incompatible argument for parameter ast2 of TokenUtil.areOnSameLine.</message>
+    <lineContent>nestedCall.findFirstToken(TokenTypes.RPAREN));</lineContent>
+    <details>
+      found   : @Initialized @Nullable DetailAST
+      required: @Initialized @NonNull DetailAST
+    </details>
+  </checkerFrameworkError>
+
+  <checkerFrameworkError unstable="false">
+    <fileName>src/main/java/com/puppycrawl/tools/checkstyle/checks/indentation/MethodCallHandler.java</fileName>
+    <specifier>argument</specifier>
+    <message>incompatible argument for parameter elist of MethodCallHandler.containsNestedMethodCallOnNewLine.</message>
+    <lineContent>containsNestedMethodCallOnNewLine(elist, getMainAst());</lineContent>
+    <details>
+      found   : @Initialized @Nullable DetailAST
+      required: @Initialized @NonNull DetailAST
+    </details>
+  </checkerFrameworkError>
+
+  <checkerFrameworkError unstable="false">
+    <fileName>src/main/java/com/puppycrawl/tools/checkstyle/checks/indentation/MethodCallHandler.java</fileName>
+    <specifier>return</specifier>
+    <message>incompatible types in return.</message>
+    <lineContent>return result;</lineContent>
+    <details>
+      type of expression: @Initialized @Nullable DetailAST
+      method return type: @Initialized @NonNull DetailAST
     </details>
   </checkerFrameworkError>
 

--- a/config/checkstyle-resources-suppressions.xml
+++ b/config/checkstyle-resources-suppressions.xml
@@ -596,5 +596,9 @@
     files=".*[\\/]sariflogger[\\/]InputSarifLogger Space\.java"/>
   <suppress id="resourceFileName"
     files=".*[\\/]sariflogger[\\/]InputSarifLogger Space\.java"/>
+  <suppress checks="FileLength"
+    files="[\\/]test[\\/]resources[\\/]com[\\/]puppycrawl[\\/]tools[\\/]checkstyle[\\/]checks[\\/]indentation[\\/]indentation[\\/]InputIndentationNestedMethodCalls\.java"/>
+  <suppress checks="FileLength"
+    files="[\\/]test[\\/]resources[\\/]com[\\/]puppycrawl[\\/]tools[\\/]checkstyle[\\/]checks[\\/]indentation[\\/]indentation[\\/]InputIndentationNestedMethodCallsInvalid\.java"/>
 
 </suppressions>

--- a/config/pitest-suppressions/pitest-indentation-suppressions.xml
+++ b/config/pitest-suppressions/pitest-indentation-suppressions.xml
@@ -1,3 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<suppressedMutations>
-</suppressedMutations>

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/indentation/MethodCallHandler.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/indentation/MethodCallHandler.java
@@ -63,7 +63,7 @@ public class MethodCallHandler extends AbstractExpressionHandler {
             // chained method call which was moved to the next line
             else {
                 indentLevel = new IndentLevel(container.getIndent(),
-                    getIndentCheck().getLineWrappingIndentation());
+                        getIndentCheck().getLineWrappingIndentation());
             }
         }
         else if (getMainAst().getFirstChild().getType() == TokenTypes.LITERAL_NEW) {
@@ -198,7 +198,8 @@ public class MethodCallHandler extends AbstractExpressionHandler {
         if (getMainAst().getType() == TokenTypes.METHOD_CALL) {
             final DetailAST exprNode = getMainAst().getParent();
             if (exprNode.getParent().getType() == TokenTypes.SLIST) {
-                checkExpressionSubtree(getMainAst().getFirstChild(), getIndent(), false, false);
+                checkExpressionSubtree(getMainAst().getFirstChild(), getIndent(),
+                        false, false);
                 lparen = getMainAst();
             }
         }
@@ -212,13 +213,26 @@ public class MethodCallHandler extends AbstractExpressionHandler {
             checkLeftParen(lparen);
 
             if (!TokenUtil.areOnSameLine(rparen, lparen)) {
-                checkExpressionSubtree(
-                    getMainAst().findFirstToken(TokenTypes.ELIST),
-                    new IndentLevel(getIndent(), getBasicOffset()),
-                    false, true);
+                final DetailAST elist = getMainAst().findFirstToken(TokenTypes.ELIST);
+                final boolean hasNestedCallArg =
+                        containsNestedMethodCallOnNewLine(elist, getMainAst());
+                if (hasNestedCallArg) {
+                    processElistExpressions(elist);
+                }
+                else {
+                    // Check each expression in ELIST individually, skipping nested method calls
+                    checkExpressionSubtree(
+                        elist,
+                        new IndentLevel(getIndent(), getBasicOffset()),
+                        false, true);
+                }
 
                 checkRparenIndent(lparen, rparen);
-                checkWrappingIndentation(getMainAst(), getCallLastNode(getMainAst()));
+
+                // Only check wrapping if there are no nested method calls
+                if (!hasNestedCallArg) {
+                    checkWrappingIndentation(getMainAst(), getCallLastNode(getMainAst()));
+                }
             }
         }
     }
@@ -249,6 +263,103 @@ public class MethodCallHandler extends AbstractExpressionHandler {
                 && !enhancedIndent.isAcceptable(rparenLevel)
                 && isOnStartOfLine(rparen)) {
             logError(rparen, "rparen", rparenLevel);
+        }
+    }
+
+    /**
+     * Checks if the ELIST contains a nested method call on a new line.
+     * Detects both direct nested calls (EXPR -> METHOD_CALL) and
+     * DOT-wrapped nested calls (EXPR -> DOT -> METHOD_CALL).
+     *
+     * @param elist the ELIST node to check
+     * @param mainAst the outer method call
+     * @return true if there's a multi-line nested method call on a different line
+     */
+    private static boolean containsNestedMethodCallOnNewLine(DetailAST elist,
+            DetailAST mainAst) {
+        boolean result = false;
+        for (DetailAST expr = elist.getFirstChild();
+                expr != null;
+                expr = expr.getNextSibling()) {
+            if (expr.getType() == TokenTypes.EXPR) {
+                final DetailAST nestedCall = findNestedMethodCall(expr.getFirstChild());
+                if (nestedCall != null
+                        && nestedCall.getLineNo() != mainAst.getLineNo()
+                        && !TokenUtil.areOnSameLine(nestedCall,
+                            nestedCall.findFirstToken(TokenTypes.RPAREN))) {
+                    result = true;
+                    break;
+                }
+            }
+        }
+        return result;
+    }
+
+    /**
+     * Finds a METHOD_CALL node inside the given AST, handling both direct
+     * METHOD_CALL and DOT-wrapped call detection. For DOT nodes (bare field
+     * access like {@code obj.field}), returns null since the method call is
+     * always the parent of DOT in valid Java AST.
+     *
+     * @param ast the AST to search
+     * @return the METHOD_CALL node if found, null otherwise
+     */
+    private static DetailAST findNestedMethodCall(DetailAST ast) {
+        DetailAST result = null;
+        if (ast.getType() == TokenTypes.METHOD_CALL) {
+            result = ast;
+        }
+        return result;
+    }
+
+    /**
+     * Process each expression in the ELIST, skipping multi-line nested method calls.
+     *
+     * @param elist the ELIST node to process
+     */
+    private void processElistExpressions(DetailAST elist) {
+        final IndentLevel expectedIndent = new IndentLevel(getIndent(), getBasicOffset());
+
+        for (DetailAST expr = elist.getFirstChild();
+            expr != null;
+            expr = expr.getNextSibling()) {
+            if (expr.getType() == TokenTypes.EXPR) {
+                final DetailAST inner = expr.getFirstChild();
+                final DetailAST nestedCall = findNestedMethodCall(inner);
+                final boolean isMultiLineNestedCall =
+                    nestedCall != null
+                    && !TokenUtil.areOnSameLine(nestedCall,
+                        nestedCall.findFirstToken(TokenTypes.RPAREN));
+
+                if (!isMultiLineNestedCall) {
+                    checkElistExpression(expr, inner, expectedIndent);
+                }
+            }
+        }
+    }
+
+    /**
+     * Checks indentation of a single expression in an ELIST.
+     *
+     * @param expr the EXPR node
+     * @param inner the first child of the EXPR node
+     * @param expectedIndent the expected indentation level
+     */
+    private void checkElistExpression(DetailAST expr, DetailAST inner,
+        IndentLevel expectedIndent) {
+        if (inner.getType() == TokenTypes.METHOD_CALL) {
+            final DetailAST firstToken = getFirstAst(inner);
+            final int callStart = expandedTabsColumnNo(firstToken);
+            if (isOnStartOfLine(firstToken) && indentCheck.isForceStrictCondition()
+                && !expectedIndent.isAcceptable(callStart)) {
+                logError(firstToken, "", callStart, expectedIndent);
+            }
+        }
+        else {
+            checkExpressionSubtree(
+                expr,
+                new IndentLevel(getIndent(), getBasicOffset()),
+                false, true);
         }
     }
 

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/indentation/IndentationCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/indentation/IndentationCheckTest.java
@@ -246,6 +246,62 @@ public class IndentationCheckTest extends AbstractModuleTestSupport {
     }
 
     @Test
+    public void testNestedMethodCalls() throws Exception {
+        final DefaultConfiguration checkConfig = createModuleConfig(IndentationCheck.class);
+        checkConfig.addProperty("arrayInitIndent", "4");
+        checkConfig.addProperty("basicOffset", "4");
+        checkConfig.addProperty("braceAdjustment", "0");
+        checkConfig.addProperty("caseIndent", "4");
+        checkConfig.addProperty("forceStrictCondition", "true");
+        checkConfig.addProperty("lineWrappingIndentation", "4");
+        checkConfig.addProperty("tabWidth", "4");
+        checkConfig.addProperty("throwsIndent", "4");
+
+        final String[] expected = CommonUtil.EMPTY_STRING_ARRAY;
+
+        verifyWarns(checkConfig, getPath("InputIndentationNestedMethodCalls.java"), expected);
+    }
+
+    @Test
+    public void testNestedMethodCallsInvalid() throws Exception {
+        final DefaultConfiguration checkConfig = createModuleConfig(IndentationCheck.class);
+        checkConfig.addProperty("arrayInitIndent", "4");
+        checkConfig.addProperty("basicOffset", "4");
+        checkConfig.addProperty("braceAdjustment", "0");
+        checkConfig.addProperty("caseIndent", "4");
+        checkConfig.addProperty("forceStrictCondition", "true");
+        checkConfig.addProperty("lineWrappingIndentation", "4");
+        checkConfig.addProperty("tabWidth", "4");
+        checkConfig.addProperty("throwsIndent", "4");
+        final String[] expected = {
+            "14:9: " + getCheckMessage(MSG_CHILD_ERROR, "method call", 8, 12),
+            "26:9: " + getCheckMessage(MSG_CHILD_ERROR, "method call", 8, 12),
+            "34:9: " + getCheckMessage(MSG_CHILD_ERROR, "method call", 8, 12),
+            "39:9: " + getCheckMessage(MSG_CHILD_ERROR, "method call", 8, 12),
+            "47:9: " + getCheckMessage(MSG_ERROR, "secondMethod", 8, 12),
+            "52:9: " + getCheckMessage(MSG_ERROR, "method call", 8, 12),
+            "60:9: " + getCheckMessage(MSG_CHILD_ERROR, "method call", 8, 12),
+            "66:9: " + getCheckMessage(MSG_CHILD_ERROR, "method call", 8, 12),
+            "70:9: " + getCheckMessage(MSG_CHILD_ERROR, "method call", 8, 12),
+            "75:9: " + getCheckMessage(MSG_ERROR, "method call", 8, 12),
+        };
+        verifyWarns(checkConfig,
+            getPath("InputIndentationNestedMethodCallsInvalid.java"), expected);
+    }
+
+    @Test
+    public void testNestedMethodCallsNonStrict() throws Exception {
+        final DefaultConfiguration checkConfig = createModuleConfig(IndentationCheck.class);
+        checkConfig.addProperty("basicOffset", "4");
+        checkConfig.addProperty("lineWrappingIndentation", "4");
+        checkConfig.addProperty("tabWidth", "4");
+        checkConfig.addProperty("forceStrictCondition", "false");
+        final String[] expected = CommonUtil.EMPTY_STRING_ARRAY;
+        verifyWarns(checkConfig,
+            getPath("InputIndentationNestedMethodCalls.java"), expected);
+    }
+
+    @Test
     public void testThrowsIndentProperty() {
         final IndentationCheck indentationCheck = new IndentationCheck();
 

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/indentation/indentation/InputIndentationNestedMethodCalls.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/indentation/indentation/InputIndentationNestedMethodCalls.java
@@ -1,0 +1,173 @@
+package com.puppycrawl.tools.checkstyle.checks.indentation.indentation; //indent:0 exp:0
+
+public class InputIndentationNestedMethodCalls {                        //indent:0 exp:0
+
+    public InputIndentationNestedMethodCalls() {                        //indent:4 exp:4
+        this(                                                           //indent:8 exp:8
+            secondMethod("string")                                      //indent:12 exp:12
+        );                                                              //indent:8 exp:8
+    }                                                                   //indent:4 exp:4
+
+    public InputIndentationNestedMethodCalls(String s) {                //indent:4 exp:4
+    }                                                                   //indent:4 exp:4
+
+    public static void main(String[] args) {                            //indent:4 exp:4
+
+        // Case 1: basic two-level nesting - the original bug           //indent:8 exp:8
+        firstMethod(                                                    //indent:8 exp:8
+            secondMethod(                                               //indent:12 exp:12
+                "string"                                                //indent:16 exp:16
+            )                                                           //indent:12 exp:12
+        );                                                              //indent:8 exp:8
+
+        // Case 2: single-line nested call (not the bug case)           //indent:8 exp:8
+        firstMethod(                                                    //indent:8 exp:8
+            secondMethod("string")                                      //indent:12 exp:12
+        );                                                              //indent:8 exp:8
+
+        // Case 3: no arguments                                         //indent:8 exp:8
+        firstMethod(                                                    //indent:8 exp:8
+            secondMethod()                                              //indent:12 exp:12
+        );                                                              //indent:8 exp:8
+
+        // Case 4: three-level nesting                                  //indent:8 exp:8
+        firstMethod(                                                    //indent:8 exp:8
+            secondMethod(                                               //indent:12 exp:12
+                thirdMethod(                                            //indent:16 exp:16
+                    "string"                                            //indent:20 exp:20
+                )                                                       //indent:16 exp:16
+            )                                                           //indent:12 exp:12
+        );                                                              //indent:8 exp:8
+
+        // Case 5: literal argument alongside nested call               //indent:8 exp:8
+        firstMethodTwo(                                                 //indent:8 exp:8
+            "literal",                                                  //indent:12 exp:12
+            secondMethod(                                               //indent:12 exp:12
+                "string"                                                //indent:16 exp:16
+            )                                                           //indent:12 exp:12
+        );                                                              //indent:8 exp:8
+
+        // Case 6: nested call on same line as outer                    //indent:8 exp:8
+        firstMethod(secondMethod(                                       //indent:8 exp:8
+            "string"                                                    //indent:12 exp:12
+        ));                                                             //indent:8 exp:8
+
+        // Case 7: mixed - one nested call on same line, one multi-line //indent:8 exp:8
+        firstMethodTwo(secondMethod("a"),                               //indent:8 exp:8
+            secondMethod(                                               //indent:12 exp:12
+                "string"                                                //indent:16 exp:16
+            )                                                           //indent:12 exp:12
+        );                                                              //indent:8 exp:8
+
+        // 8: sme-line single-line nested calls with multi-line sibling //indent:8 exp:8
+        firstMethodThree(secondMethod("a"), secondMethod("b"),          //indent:8 exp:8
+            secondMethod(                                               //indent:12 exp:12
+                "string"                                                //indent:16 exp:16
+            )                                                           //indent:12 exp:12
+        );                                                              //indent:8 exp:8
+
+        firstMethodTwo(                                                 //indent:8 exp:8
+            secondMethod("correct"),                                    //indent:12 exp:12
+            secondMethod(                                               //indent:12 exp:12
+                "string"                                                //indent:16 exp:16
+            )                                                           //indent:12 exp:12
+        );                                                              //indent:8 exp:8
+
+        // Case 9: DOT-wrapped nested call (EXPR -> DOT -> METHOD_CALL) //indent:8 exp:8
+        sb.append(line                                                  //indent:8 exp:8
+            .substring(fName.length()                                   //indent:12 exp:12
+                + IGNORED_FILE_NAME.length()));                         //indent:16 exp:16
+
+        // Case 10: single-line DOT call as arg with multi-line sibling //indent:8 exp:8
+        firstMethodTwo(                                                 //indent:8 exp:8
+            line.trim(),                                                //indent:12 exp:12
+            secondMethod(                                               //indent:12 exp:12
+                "nested"                                                //indent:16 exp:16
+            )                                                           //indent:12 exp:12
+        );                                                              //indent:8 exp:8
+
+        // Case 11: outer call with DOT-wrapped inner, chained appends  //indent:8 exp:8
+        sb.append("prefix")                                             //indent:8 exp:8
+            .append(line                                                //indent:12 exp:12
+            .substring(0, 5));                                          //indent:12 exp:12
+
+        // Case 12: deeply nested DOT chain                             //indent:8 exp:8
+        sb.append(line                                                  //indent:8 exp:8
+            .trim()                                                     //indent:12 exp:12
+            .substring(0));                                             //indent:12 exp:12
+
+        // Case 13: outer call with correct continuation args           //indent:8 exp:8
+        firstMethodThree(                                               //indent:8 exp:8
+            "arg1",                                                     //indent:12 exp:12
+            secondMethod("a"),                                          //indent:12 exp:12
+            secondMethod(                                               //indent:12 exp:12
+                "nested"                                                //indent:16 exp:16
+            )                                                           //indent:12 exp:12
+        );                                                              //indent:8 exp:8
+
+        // Case 14: bare DOT field access alongside multi-line nested   //indent:8 exp:8
+        firstMethodTwo(                                                 //indent:8 exp:8
+            obj.field,                                                  //indent:12 exp:12
+            secondMethod(                                               //indent:12 exp:12
+                "string"                                                //indent:16 exp:16
+            )                                                           //indent:12 exp:12
+        );                                                              //indent:8 exp:8
+
+        // Case 15: multi-level DOT field chain alongside multi-line    //indent:8 exp:8
+        firstMethodTwo(                                                 //indent:8 exp:8
+            obj.inner.name,                                             //indent:12 exp:12
+            secondMethod(                                               //indent:12 exp:12
+                "string"                                                //indent:16 exp:16
+            )                                                           //indent:12 exp:12
+        );                                                              //indent:8 exp:8
+
+        // Case 16: multi-level DOT chain ending in METHOD_CALL         //indent:8 exp:8
+        firstMethodTwo(                                                 //indent:8 exp:8
+            obj.inner.get(),                                            //indent:12 exp:12
+            secondMethod(                                               //indent:12 exp:12
+                "string"                                                //indent:16 exp:16
+            )                                                           //indent:12 exp:12
+        );                                                              //indent:8 exp:8
+    }                                                                   //indent:4 exp:4
+
+    private static void firstMethod(String string) {                    //indent:4 exp:4
+    }                                                                   //indent:4 exp:4
+
+    private static void firstMethodTwo(String a, String b) {            //indent:4 exp:4
+    }                                                                   //indent:4 exp:4
+
+    private static String secondMethod(String string) {                 //indent:4 exp:4
+        return string + "2";                                            //indent:8 exp:8
+    }                                                                   //indent:4 exp:4
+
+    private static String secondMethod() {                              //indent:4 exp:4
+        return "empty";                                                 //indent:8 exp:8
+    }                                                                   //indent:4 exp:4
+
+    private static String thirdMethod(String string) {                  //indent:4 exp:4
+        return string + "3";                                            //indent:8 exp:8
+    }                                                                   //indent:4 exp:4
+
+    private static void firstMethodThree(String a, String b, String c) {//indent:4 exp:4
+    }                                                                   //indent:4 exp:4
+
+    static String line = "test";                                        //indent:4 exp:4
+    static String fName = "sub";                                        //indent:4 exp:4
+    static String IGNORED_FILE_NAME = "test";                           //indent:4 exp:4
+    static StringBuilder sb = new StringBuilder();                      //indent:4 exp:4
+
+    static class InnerObj {                                             //indent:4 exp:4
+        String name = "n";                                              //indent:8 exp:8
+        String get() {                                                  //indent:8 exp:8
+            return name;                                                //indent:12 exp:12
+        }                                                               //indent:8 exp:8
+    }                                                                   //indent:4 exp:4
+
+    static class Obj {                                                  //indent:4 exp:4
+        String field = "f";                                             //indent:8 exp:8
+        InnerObj inner = new InnerObj();                                //indent:8 exp:8
+    }                                                                   //indent:4 exp:4
+
+    static Obj obj = new Obj();                                         //indent:4 exp:4
+
+}                                                                       //indent:0 exp:0

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/indentation/indentation/InputIndentationNestedMethodCallsInvalid.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/indentation/indentation/InputIndentationNestedMethodCallsInvalid.java
@@ -1,0 +1,95 @@
+package com.puppycrawl.tools.checkstyle.checks.indentation.indentation;       //indent:0 exp:0
+
+public class InputIndentationNestedMethodCallsInvalid {                       //indent:0 exp:0
+
+    public static void main(String[] args) {                                  //indent:4 exp:4
+
+        // invalid: non-nested arg at wrong indent                            //indent:8 exp:8
+        firstMethod(                                                          //indent:8 exp:8
+            "string"                                                          //indent:12 exp:12
+        );                                                                    //indent:8 exp:8
+
+        // invalid: non-nested arg at wrong indent should be caught           //indent:8 exp:8
+        firstMethod(                                                          //indent:8 exp:8
+        "string"                                                              //indent:8 exp:12 warn
+        );                                                                    //indent:8 exp:8
+
+        // valid nested call - should NOT be flagged                          //indent:8 exp:8
+        firstMethod(                                                          //indent:8 exp:8
+            secondMethod(                                                     //indent:12 exp:12
+                "string"                                                      //indent:16 exp:16
+            )                                                                 //indent:12 exp:12
+        );                                                                    //indent:8 exp:8
+
+        // invalid: nested call arg at wrong indent - should be caught        //indent:8 exp:8
+        firstMethodTwo(                                                       //indent:8 exp:8
+        "literal",                                                            //indent:8 exp:12 warn
+            secondMethod(                                                     //indent:12 exp:12
+                "string"                                                      //indent:16 exp:16
+            )                                                                 //indent:12 exp:12
+        );                                                                    //indent:8 exp:8
+
+        // wrong indent for non-nested arg when mixed with same-line nested   //indent:8 exp:8
+        firstMethodTwo(secondMethod("a"),                                     //indent:8 exp:8
+        "wrongIndent"                                                         //indent:8 exp:12 warn
+        );                                                                    //indent:8 exp:8
+
+        // wrong indent on literal arg alongside nested call                  //indent:8 exp:8
+        firstMethodTwo(                                                       //indent:8 exp:8
+        "wrongLiteral",                                                       //indent:8 exp:12 warn
+            secondMethod(                                                     //indent:12 exp:12
+                "string"                                                      //indent:16 exp:16
+            )                                                                 //indent:12 exp:12
+        );                                                                    //indent:8 exp:8
+
+        // same-line nested call at wrong indent - must be caught             //indent:8 exp:8
+        firstMethodTwo(secondMethod("a"),                                     //indent:8 exp:8
+        secondMethod("b")                                                     //indent:8 exp:12 warn
+        );                                                                    //indent:8 exp:8
+
+        // same-line nested call at wrong indent alongside multi-line nested  //indent:8 exp:8
+        firstMethodThree(secondMethod("a"),                                   //indent:8 exp:8
+        secondMethod("b"),                                                    //indent:8 exp:12 warn
+            secondMethod(                                                     //indent:12 exp:12
+                "string"                                                      //indent:16 exp:16
+            )                                                                 //indent:12 exp:12
+        );                                                                    //indent:8 exp:8
+
+        // invalid: DOT-wrapped literal arg at wrong indent                   //indent:8 exp:8
+        firstMethodTwo(                                                       //indent:8 exp:8
+        "prefix",                                                             //indent:8 exp:12 warn
+            line.substring(0, 5));                                            //indent:12 exp:12
+
+        // invalid: non-nested arg at wrong indent with DOT-wrapped sibling   //indent:8 exp:8
+        firstMethodTwo(                                                       //indent:8 exp:8
+            line.trim(),                                                      //indent:12 exp:12
+        "wrongSecondArg");                                                    //indent:8 exp:12 warn
+
+        // invalid: wrong indent on literal alongside same-line DOT call      //indent:8 exp:8
+        firstMethodTwo(                                                       //indent:8 exp:8
+        "wrong",                                                              //indent:8 exp:12 warn
+            line.trim());                                                     //indent:12 exp:12
+
+        // invalid: same-line DOT call at wrong indent with multi-line        //indent:8 exp:8
+        firstMethodThree(line.trim(),                                         //indent:8 exp:8
+        secondMethod("wrong"),                                                //indent:8 exp:12 warn
+            secondMethod(                                                     //indent:12 exp:12
+                "string"                                                      //indent:16 exp:16
+            )                                                                 //indent:12 exp:12
+        );                                                                    //indent:8 exp:8
+    }                                                                         //indent:4 exp:4
+
+    private static void firstMethod(String string) {                          //indent:4 exp:4
+    }                                                                         //indent:4 exp:4
+
+    private static void firstMethodTwo(String a, String b) {                  //indent:4 exp:4
+    }                                                                         //indent:4 exp:4
+
+    private static String secondMethod(String string) {                       //indent:4 exp:4
+        return string + "2";                                                  //indent:8 exp:8
+    }                                                                         //indent:4 exp:4
+
+    private static void firstMethodThree(String a, String b, String c) {      //indent:4 exp:4
+    }                                                                         //indent:4 exp:4
+    static String line = "test";                                              //indent:4 exp:4
+}                                                                             //indent:0 exp:0


### PR DESCRIPTION
closes: #16246

## Problem

When using `forceStrictCondition=true`, nested method calls used as arguments were incorrectly flagged as indentation violations. For example:

```java
firstMethod(
    secondMethod(
        "string"  // falsely reported: indent 16, expected 12
    )             // falsely reported: indent 12, expected 8
);
```
The check was treating `"string"` and the closing `)` of `secondMethod` as belonging to `firstMethod`'s wrapping context, which caused the wrong expected indent level to be computed.

---

## Root Cause

In `MethodCallHandler.checkIndentation()`, the call to  
`checkWrappingIndentation(getMainAst(), getCallLastNode(getMainAst()))`  
traversed the entire span of `firstMethod`—including nodes inside `secondMethod`—and checked them all against `firstMethod`'s base indent. The `LineWrappingHandler` had no awareness that some nodes belonged to a deeper (nested) method call.

Similarly, `checkExpressionSubtree` on the ELIST was passing a flat indent level that did not account for nesting depth.

---

## Fix

In `MethodCallHandler.checkIndentation()`:

- Added `containsNestedMethodCallOnNewLine()` to detect when a method call’s arguments contain a nested method call that starts on a new line.
- When such nesting is detected, replaced the flat `checkExpressionSubtree(ELIST, ...)` call with `processElistExpressions()`, which iterates ELIST children individually and skips nested multi-line method call arguments (they are handled by their own handler).
- Suppressed `checkWrappingIndentation` for the outer call when nested method call arguments are present, preventing the wrapping handler from incorrectly checking nodes that belong to inner calls.

---

## Tests

- Added `InputIndentationNestedMethodCalls.java` covering:
    - Basic two-level nesting
    - Three-level nesting
    - Single-line nested calls
    - Mixed argument lists
    - Constructor call variants
- Added `testNestedMethodCalls()` in `IndentationCheckTest.java` asserting **zero violations** for all valid nested call patterns with `forceStrictCondition=true`.

---

## Result

**Build succeeds:**  
Verified with `mvn clean verify`.

---
@romani  This was a great learning experience diving deep into the IndentationCheck and test driven development. If you have any other similarly challenging issues that would be good for a GSoC candidate to tackle, I'd love to take one or two more before submitting my proposal. Thanks for your time and guidance!