### PR TITLE
Issue #18435: Fixed AST consistency in Example1 for IndentationCheck

### DIFF
--- a/src/site/xdoc/checks/misc/indentation.xml
+++ b/src/site/xdoc/checks/misc/indentation.xml
@@ -121,7 +121,13 @@ if ((condition1 &amp;&amp; condition2)
         <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
 &lt;module name="Checker"&gt;
   &lt;module name="TreeWalker"&gt;
-    &lt;module name="Indentation"/&gt;
+    &lt;module name="Indentation"&gt;
+      &lt;property name="basicOffset" value="4"/&gt;
+      &lt;property name="braceAdjustment" value="0"/&gt;
+      &lt;property name="lineWrappingIndentation" value="4"/&gt;
+      &lt;property name="throwsIndent" value="4"/&gt;
+      &lt;property name="arrayInitIndent" value="4"/&gt;
+    &lt;/module&gt;
   &lt;/module&gt;
 &lt;/module&gt;
 </code></pre></div>

--- a/src/test/java/com/puppycrawl/tools/checkstyle/internal/XdocsExampleFileTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/internal/XdocsExampleFileTest.java
@@ -58,14 +58,7 @@ public class XdocsExampleFileTest {
     // This list is temporarily suppressed.
     // Until: https://github.com/checkstyle/checkstyle/issues/17449
     private static final Map<String, Set<String>> SUPPRESSED_PROPERTIES_BY_CHECK = Map.ofEntries(
-            Map.entry("SuppressWarningsHolder", Set.of("aliasList")),
-            Map.entry("IndentationCheck", Set.of(
-                    "basicOffset",
-                    "lineWrappingIndentation",
-                    "throwsIndent",
-                    "arrayInitIndent",
-                    "braceAdjustment"
-            ))
+            Map.entry("SuppressWarningsHolder", Set.of("aliasList"))
     );
 
     @Test

--- a/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/indentation/indentation/Example1.java
+++ b/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/indentation/indentation/Example1.java
@@ -1,7 +1,13 @@
 /*xml
 <module name="Checker">
   <module name="TreeWalker">
-    <module name="Indentation"/>
+    <module name="Indentation">
+      <property name="basicOffset" value="4"/>
+      <property name="braceAdjustment" value="0"/>
+      <property name="lineWrappingIndentation" value="4"/>
+      <property name="throwsIndent" value="4"/>
+      <property name="arrayInitIndent" value="4"/>
+    </module>
   </module>
 </module>
 */
@@ -23,7 +29,6 @@ class Example1 {
 
     void handleValue(String aFooString,
                      int aFooInt) {             // indent:8 ; expected: > 4;
-
         boolean cond1,cond2,cond3,cond4,cond5,cond6;
         cond1=cond2=cond3=cond4=cond5=cond6=false;
 
@@ -52,4 +57,3 @@ class Example1 {
     }
 }
 // xdoc section -- end
-


### PR DESCRIPTION
Issue [Fix xdocs Examples AST Consistency Test (Reduce suppressions list) #18435](https://github.com/checkstyle/checkstyle/issues/18435)

Fixed AST consistency in Example1 for IndentationCheck

Added missing tags for IndentationCheck properties:

- basicOffset
- lineWrappingIndentation
- throwsIndent
- arrayInitIndent
- braceAdjustment