### PR TITLE
Issue #18673: Document excluded OpenRewrite formatting recipes (MethodParamPad, NoWhitespaceAfter, NoWhitespaceBefore)

### DIFF
--- a/config/rewrite.yml
+++ b/config/rewrite.yml
@@ -81,6 +81,12 @@ recipeList:
         # Both forms are functionally identical in for loops, and some style
         # guides prefer pre-increment.
         - org.openrewrite.staticanalysis.ForLoopControlVariablePostfixOperators
+        # conflicts with MethodParamPadCheck in checkstyle_checks.xml
+        - org.openrewrite.java.format.MethodParamPad
+        # conflicts with NoWhitespaceAfterCheck in checkstyle_checks.xml
+        - org.openrewrite.java.format.NoWhitespaceAfter
+        # conflicts with NoWhitespaceBeforeCheck in checkstyle_checks.xml
+        - org.openrewrite.java.format.NoWhitespaceBefore
         - org.openrewrite.staticanalysis.TypecastParenPad
         - org.openrewrite.staticanalysis.ExplicitInitialization
         # Kept excluded: OpenRewrite's FallThrough always adds break statements,


### PR DESCRIPTION
Issue : #18952
Issue: #18673

Document the reasons for keeping three OpenRewrite formatting recipes excluded in the CodeCleanup composite recipe.

---

## Recipes Documented

---

### 1. `org.openrewrite.java.format.MethodParamPad` : https://docs.openrewrite.org/recipes/java/format/methodparampad

**What OpenRewrite does:**

```java
// Before
public void method (int param) { }
someMethodInvocation (x);
new Example ();

// After
public void method(int param) { }
someMethodInvocation(x);
new Example();
```
OpenRewrite always removes the space between the method name and the left parenthesis, enforcing a single style with no configuration.

**What Checkstyle does:**

Checkstyle's `MethodParamPadCheck` is fully configurable:

```xml
<module name="MethodParamPad">
    <!-- Choose spacing style -->
    <property name="option" value="space"/>      <!-- Require space before ( -->
    <!-- OR -->
    <property name="option" value="nospace"/>    <!-- Forbid space before ( -->
    <property name="allowLineBreaks" value="true"/>
    <property name="tokens" value="METHOD_DEF, CTOR_DEF, METHOD_CALL"/>
</module>
```

**Why keep excluded:**

| Aspect           | OpenRewrite           | Checkstyle                                  |
|------------------|----------------------|---------------------------------------------|
| Spacing style    | Fixed (no space)     | Configurable (space/nospace)                |
| Line breaks      | Forbidden            | Configurable (`allowLineBreaks`)            |
| Token selection  | All tokens           | Configurable (`tokens`)                     |

**Example conflict:**

```java
// Google Java Style (no space)
public void method(int param) { }

// Some projects prefer space
public void method (int param) { }
```
OpenRewrite would force the first style, overwriting projects that prefer the second.

---

### 2. `org.openrewrite.java.format.NoWhitespaceAfter` : https://docs.openrewrite.org/recipes/java/format/nowhitespaceafter

**What OpenRewrite does:**

```java
// Before
int [] arr;
Integer. parseInt(s);
a = ~ a;
method (args);

// After
int[] arr;
Integer.parseInt(s);
a = ~a;
method(args);
```
OpenRewrite removes whitespace after certain tokens, always enforcing "no whitespace after" for all tokens.

**What Checkstyle does:**

Checkstyle's `NoWhitespaceAfterCheck` is configurable:

```xml
<module name="NoWhitespaceAfter">
    <property name="allowLineBreaks" value="true"/>
    <property name="tokens" value="ARRAY_INIT, DOT, UNARY_MINUS, UNARY_PLUS, BNOT, LNOT"/>
</module>
```

**Why keep excluded:**

| Aspect         | OpenRewrite          | Checkstyle                       |
|----------------|---------------------|----------------------------------|
| Token selection| Fixed (all tokens)  | Configurable (`tokens`)          |
| Line breaks    | Not configurable    | Configurable (`allowLineBreaks`) |

**Example conflict:**

```java
// Some projects prefer a space after unary operator
int a = ~ b;

// Others prefer no space
int a = ~b;
```
OpenRewrite would always force no space, overwriting the first style.

---

### 3. `org.openrewrite.java.format.NoWhitespaceBefore` : https://docs.openrewrite.org/recipes/java/format/nowhitespacebefore

**What OpenRewrite does:**

```java
// Before
for (int i = 0 ; i < 10 ; i++) { }
method (args);
new Test() .m = 2;
int [] arr;

// After
for (int i = 0; i < 10; i++) { }
method(args);
new Test().m = 2;
int[] arr;
```
OpenRewrite removes whitespace before certain tokens, always enforcing "no whitespace before" for all tokens.

**What Checkstyle does:**

Checkstyle's `NoWhitespaceBeforeCheck` is configurable:

```xml
<module name="NoWhitespaceBefore">
    <property name="allowLineBreaks" value="true"/>
    <property name="tokens" value="COMMA, SEMI, POST_INC, POST_DEC, DOT, ELLIPSIS"/>
</module>
```

**Why keep excluded:**

| Aspect         | OpenRewrite          | Checkstyle                       |
|----------------|---------------------|----------------------------------|
| Token selection| Fixed (all tokens)  | Configurable (`tokens`)          |
| Line breaks    | Not configurable    | Configurable (`allowLineBreaks`) |

**Example conflict:**

```java
// Some projects prefer space before semicolon
for (int i = 0 ; i < 10 ; i++) { }

// Others prefer no space
for (int i = 0; i < 10; i++) { }
```
OpenRewrite would always force no space, overwriting the first style.

----

## Changes Made

- Added detailed comments for three formatting recipes in config/rewrite.yml
- Included examples showing OpenRewrite vs Checkstyle behavior
- Referenced Checkstyle's configuration options to demonstrate flexibility