### PR TITLE
Issue #18673: Document excluded OpenRewrite recipes (TypecastParenPad, ExplicitInitialization, OperatorWrap)

### DIFF
--- a/config/rewrite.yml
+++ b/config/rewrite.yml
@@ -68,7 +68,16 @@ recipeList:
         - org.openrewrite.java.format.MethodParamPad
         - org.openrewrite.java.format.NoWhitespaceAfter
         - org.openrewrite.java.format.NoWhitespaceBefore
+        # Kept excluded: OpenRewrite's TypecastParenPad always removes spaces around
+        # typecast parentheses, while Checkstyle's TypecastParenPadCheck allows
+        # configuration via the `option` property (`space` or `nospace`).
         - org.openrewrite.staticanalysis.TypecastParenPad
+        # Kept excluded: OpenRewrite's ExplicitInitialization automatically removes
+        # explicit initializations to default values (null, 0, false), while
+        # Checkstyle's ExplicitInitializationCheck only reports violations,
+        # allowing developers to decide whether to keep them for clarity.
+        # Checkstyle also provides the `onlyObjectReferences` option to limit
+        # checks to object references only.
         - org.openrewrite.staticanalysis.ExplicitInitialization
         # Kept excluded: OpenRewrite's FallThrough always adds break statements,
         # ignoring Checkstyle's FallThroughCheck which allows configurable relief
@@ -81,6 +90,10 @@ recipeList:
         # statements and empty loop bodies via `allowSingleLineStatement` and
         # `allowEmptyLoopBody` options.
         - org.openrewrite.staticanalysis.NeedBraces
+        # Kept excluded: OpenRewrite's OperatorWrap forces operators to the end of
+        # the line with no configuration, while Checkstyle's OperatorWrapCheck
+        # allows projects to choose between `nl` (new line) and `eol` (end of line)
+        # via the `option` property, and can limit checks to specific tokens.
         - org.openrewrite.staticanalysis.OperatorWrap
         - org.openrewrite.staticanalysis.ReplaceThreadRunWithThreadStart
         - org.openrewrite.staticanalysis.ChainStringBuilderAppendCalls


### PR DESCRIPTION
Issue: #18952

related :#18673

Document the reasons for keeping three OpenRewrite recipes excluded in the CodeCleanup composite recipe.

---

## Recipes Documented

---

### 1. `org.openrewrite.staticanalysis.TypecastParenPad` : https://docs.openrewrite.org/recipes/staticanalysis/typecastparenpad

**What OpenRewrite does:**

```java
// Before
int i = ( int ) 0L;
int j = (int) 0L;
int k = ( int)0L;
int l = (int )0L;

// After
int i = (int) 0L;
int j = (int) 0L;
int k = (int) 0L;
int l = (int) 0L;
```

OpenRewrite always removes spaces around typecast parentheses, enforcing a single style with no configuration options.

**What Checkstyle does:**

Checkstyle's `TypecastParenPadCheck` is fully configurable:

```xml
<module name="TypecastParenPad">
    <!-- Require spaces: ( int ) -->
    <property name="option" value="space"/>
    <!-- OR -->
    <!-- Forbid spaces: (int) -->
    <property name="option" value="nospace"/>
</module>
```

**Why keep excluded:**

| Aspect        | OpenRewrite      | Checkstyle                  |
|---------------|------------------|-----------------------------|
| Spacing style | Fixed (no space) | Configurable (space/nospace)|

**Example conflict:**

```java
// Some projects prefer spaces for readability
int i = ( int ) 0L;

// Others prefer compact style
int i = (int) 0L;
```

OpenRewrite would force the compact style, overwriting projects that prefer spaces.

---

### 2. `org.openrewrite.staticanalysis.ExplicitInitialization` : https://docs.openrewrite.org/recipes/staticanalysis/explicitinitialization

**What OpenRewrite does:**

```java
// Before
class Example {
    private int count = 0;
    private boolean enabled = false;
    private String name = null;
    private Object obj = null;
}

// After
class Example {
    private int count;
    private boolean enabled;
    private String name;
    private Object obj;
}
```

OpenRewrite automatically removes explicit initializations to default values (0, false, null), with no configuration options.

**What Checkstyle does:**

Checkstyle's `ExplicitInitializationCheck` reports violations but does not modify code:

```xml
<module name="ExplicitInitialization">
    <!-- Only check object references (null), ignore primitives -->
    <property name="onlyObjectReferences" value="true"/>
</module>
```

**Why keep excluded:**

| Aspect        | OpenRewrite            | Checkstyle                                 |
|---------------|------------------------|--------------------------------------------|
| Action        | Removes code automatically | Reports only (no code change)             |
| Configuration | None                   | Configurable (`onlyObjectReferences`)      |

**Example conflict:**

```java
// Some teams prefer explicit initialization for clarity
private String name = null;  // Makes intent clear

// Others prefer relying on defaults
private String name;  // Relies on Java's default initialization
```

OpenRewrite would remove the explicit initialization, overriding teams that prefer explicit style.

---

### 3. `org.openrewrite.staticanalysis.OperatorWrap` : https://docs.openrewrite.org/recipes/staticanalysis/operatorwrap

**What OpenRewrite does:**

```java
// Before
String result = "Hello" +
    " World" + "!";

// After
String result = "Hello"
    + " World" + "!";
```

OpenRewrite forces operators to the beginning of the next line (NL style) with no configuration options.

**What Checkstyle does:**

Checkstyle's `OperatorWrapCheck` is fully configurable:

```xml
<module name="OperatorWrap">
    <!-- Operator at beginning of next line -->
    <property name="option" value="nl"/>
    <!-- OR -->
    <!-- Operator at end of current line -->
    <property name="option" value="eol"/>
    <!-- Limit to specific operators -->
    <property name="tokens" value="PLUS, MINUS, STAR, DIV, MOD, ASSIGN"/>
</module>
```

**Why keep excluded:**

| Aspect         | OpenRewrite    | Checkstyle                          |
|----------------|----------------|-------------------------------------|
| Wrap style     | Fixed (NL)     | Configurable (nl/eol)               |
| Tokens         | All tokens     | Configurable (`tokens`)             |

**Example conflict:**

```java
// Google Java Style (operator at beginning of line)
String result = "Hello"
    + " World";

// Sun/Oracle style (operator at end of line)
String result = "Hello" +
    " World";
```

OpenRewrite would force the Google style, overwriting projects that prefer Sun/Oracle style.

---

## Changes Made

- Added detailed comments for three recipes in config/rewrite.yml