### PR TITLE
Issue #16807: Update default properties in DesignForExtensionCheck input files

### DIFF
--- a/src/test/java/com/puppycrawl/tools/checkstyle/bdd/InlineConfigParser.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/bdd/InlineConfigParser.java
@@ -324,7 +324,6 @@ public final class InlineConfigParser {
             "com.puppycrawl.tools.checkstyle.checks.regexp.RegexpCheck",
             "com.puppycrawl.tools.checkstyle.checks.regexp.RegexpSinglelineCheck",
             "com.puppycrawl.tools.checkstyle.checks.regexp.RegexpSinglelineJavaCheck",
-            "com.puppycrawl.tools.checkstyle.checks.sizes.ParameterNumberCheck",
             "com.puppycrawl.tools.checkstyle.checks.whitespace.NoWhitespaceAfterCheck",
             "com.puppycrawl.tools.checkstyle.checks.whitespace.ParenPadCheck",
             "com.puppycrawl.tools.checkstyle.checks.whitespace.WhitespaceAfterCheck",

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/sizes/ParameterNumberCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/sizes/ParameterNumberCheckTest.java
@@ -80,7 +80,7 @@ public class ParameterNumberCheckTest
     public void testDefaultThree()
             throws Exception {
         final String[] expected = {
-            "47:10: " + getCheckMessage(MSG_KEY, 7, 9),
+            "48:10: " + getCheckMessage(MSG_KEY, 7, 9),
         };
         verifyWithInlineConfigParser(
                 getPath("InputParameterNumberSimpleThree.java"), expected);
@@ -90,8 +90,8 @@ public class ParameterNumberCheckTest
     public void testNum()
             throws Exception {
         final String[] expected = {
-            "75:9: " + getCheckMessage(MSG_KEY, 2, 3),
-            "198:10: " + getCheckMessage(MSG_KEY, 2, 9),
+            "76:9: " + getCheckMessage(MSG_KEY, 2, 3),
+            "199:10: " + getCheckMessage(MSG_KEY, 2, 9),
         };
         verifyWithInlineConfigParser(
                 getPath("InputParameterNumberSimple2.java"), expected);
@@ -109,7 +109,7 @@ public class ParameterNumberCheckTest
     public void shouldLogActualParameterNumber()
             throws Exception {
         final String[] expected = {
-            "199:10: 7,9",
+            "200:10: 7,9",
         };
         verifyWithInlineConfigParser(
                 getPath("InputParameterNumberSimple4.java"), expected);
@@ -119,8 +119,8 @@ public class ParameterNumberCheckTest
     public void testIgnoreOverriddenMethods()
             throws Exception {
         final String[] expected = {
-            "15:10: " + getCheckMessage(MSG_KEY, 7, 8),
-            "20:10: " + getCheckMessage(MSG_KEY, 7, 8),
+            "16:10: " + getCheckMessage(MSG_KEY, 7, 8),
+            "21:10: " + getCheckMessage(MSG_KEY, 7, 8),
         };
         verifyWithInlineConfigParser(
                 getPath("InputParameterNumber.java"), expected);
@@ -130,10 +130,10 @@ public class ParameterNumberCheckTest
     public void testIgnoreOverriddenMethodsFalse()
             throws Exception {
         final String[] expected = {
-            "15:10: " + getCheckMessage(MSG_KEY, 7, 8),
-            "20:10: " + getCheckMessage(MSG_KEY, 7, 8),
-            "28:10: " + getCheckMessage(MSG_KEY, 7, 8),
-            "33:10: " + getCheckMessage(MSG_KEY, 7, 8),
+            "16:10: " + getCheckMessage(MSG_KEY, 7, 8),
+            "21:10: " + getCheckMessage(MSG_KEY, 7, 8),
+            "29:10: " + getCheckMessage(MSG_KEY, 7, 8),
+            "34:10: " + getCheckMessage(MSG_KEY, 7, 8),
         };
         verifyWithInlineConfigParser(
                 getPath("InputParameterNumber2.java"), expected);
@@ -142,15 +142,15 @@ public class ParameterNumberCheckTest
     @Test
     public void testIgnoreAnnotatedBy() throws Exception {
         final String[] expected = {
-            "23:10: " + getCheckMessage(MSG_KEY, 2, 3),
-            "30:10: " + getCheckMessage(MSG_KEY, 2, 4),
-            "35:14: " + getCheckMessage(MSG_KEY, 2, 3),
-            "43:9: " + getCheckMessage(MSG_KEY, 2, 4),
-            "58:30: " + getCheckMessage(MSG_KEY, 2, 3),
-            "62:29: " + getCheckMessage(MSG_KEY, 2, 3),
-            "77:34: " + getCheckMessage(MSG_KEY, 2, 4),
-            "97:10: " + getCheckMessage(MSG_KEY, 2, 3),
-            "106:14: " + getCheckMessage(MSG_KEY, 2, 3),
+            "26:10: " + getCheckMessage(MSG_KEY, 2, 3),
+            "33:10: " + getCheckMessage(MSG_KEY, 2, 4),
+            "38:14: " + getCheckMessage(MSG_KEY, 2, 3),
+            "46:9: " + getCheckMessage(MSG_KEY, 2, 4),
+            "61:30: " + getCheckMessage(MSG_KEY, 2, 3),
+            "65:29: " + getCheckMessage(MSG_KEY, 2, 3),
+            "80:34: " + getCheckMessage(MSG_KEY, 2, 4),
+            "100:10: " + getCheckMessage(MSG_KEY, 2, 3),
+            "109:14: " + getCheckMessage(MSG_KEY, 2, 3),
         };
         verifyWithInlineConfigParser(
                 getPath("InputParameterNumberIgnoreAnnotatedBy.java"), expected);
@@ -159,12 +159,12 @@ public class ParameterNumberCheckTest
     @Test
     public void testIgnoreAnnotatedByFullyQualifiedClassName() throws Exception {
         final String[] expected = {
-            "15:10: " + getCheckMessage(MSG_KEY, 2, 3),
-            "17:10: " + getCheckMessage(MSG_KEY, 2, 3),
-            "23:10: " + getCheckMessage(MSG_KEY, 2, 3),
-            "27:10: " + getCheckMessage(MSG_KEY, 2, 3),
-            "41:14: " + getCheckMessage(MSG_KEY, 2, 3),
-            "45:14: " + getCheckMessage(MSG_KEY, 2, 3),
+            "18:10: " + getCheckMessage(MSG_KEY, 2, 3),
+            "20:10: " + getCheckMessage(MSG_KEY, 2, 3),
+            "26:10: " + getCheckMessage(MSG_KEY, 2, 3),
+            "30:10: " + getCheckMessage(MSG_KEY, 2, 3),
+            "44:14: " + getCheckMessage(MSG_KEY, 2, 3),
+            "48:14: " + getCheckMessage(MSG_KEY, 2, 3),
         };
         verifyWithInlineConfigParser(
                 getPath("InputParameterNumberIgnoreAnnotatedByFullyQualifiedClassName.java"),

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/sizes/parameternumber/InputParameterNumber.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/sizes/parameternumber/InputParameterNumber.java
@@ -1,6 +1,7 @@
 /*
 ParameterNumber
 max = (default)7
+ignoreAnnotatedBy = (default)
 ignoreOverriddenMethods = true
 tokens = (default)METHOD_DEF, CTOR_DEF
 

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/sizes/parameternumber/InputParameterNumber2.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/sizes/parameternumber/InputParameterNumber2.java
@@ -1,6 +1,7 @@
 /*
 ParameterNumber
 max = (default)7
+ignoreAnnotatedBy = (default)
 ignoreOverriddenMethods = (default)false
 tokens = (default)METHOD_DEF, CTOR_DEF
 

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/sizes/parameternumber/InputParameterNumberIgnoreAnnotatedBy.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/sizes/parameternumber/InputParameterNumberIgnoreAnnotatedBy.java
@@ -2,6 +2,9 @@
 ParameterNumber
 max = 2
 ignoreAnnotatedBy = MyAnno, Session
+ignoreOverriddenMethods = (default)false
+tokens = (default)METHOD_DEF, CTOR_DEF
+
 
 */
 

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/sizes/parameternumber/InputParameterNumberIgnoreAnnotatedByFullyQualifiedClassName.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/sizes/parameternumber/InputParameterNumberIgnoreAnnotatedByFullyQualifiedClassName.java
@@ -2,6 +2,9 @@
 ParameterNumber
 max = 2
 ignoreAnnotatedBy = java.lang.Deprecated, InnerClass.InnerAnno, Session
+ignoreOverriddenMethods = (default)false
+tokens = (default)METHOD_DEF, CTOR_DEF
+
 
 */
 

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/sizes/parameternumber/InputParameterNumberSimple2.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/sizes/parameternumber/InputParameterNumberSimple2.java
@@ -1,6 +1,7 @@
 /*
 ParameterNumber
 max = 2
+ignoreAnnotatedBy = (default)
 ignoreOverriddenMethods = (default)false
 tokens = (default)METHOD_DEF, CTOR_DEF
 

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/sizes/parameternumber/InputParameterNumberSimple3.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/sizes/parameternumber/InputParameterNumberSimple3.java
@@ -1,6 +1,7 @@
 /*
 ParameterNumber
 max = 9
+ignoreAnnotatedBy = (default)
 ignoreOverriddenMethods = (default)false
 tokens = (default)METHOD_DEF, CTOR_DEF
 

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/sizes/parameternumber/InputParameterNumberSimple4.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/sizes/parameternumber/InputParameterNumberSimple4.java
@@ -1,6 +1,7 @@
 /*
 ParameterNumber
 max = (default)7
+ignoreAnnotatedBy = (default)
 ignoreOverriddenMethods = (default)false
 tokens = (default)METHOD_DEF, CTOR_DEF
 message.maxParam = {0},{1}

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/sizes/parameternumber/InputParameterNumberSimpleOne.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/sizes/parameternumber/InputParameterNumberSimpleOne.java
@@ -1,6 +1,7 @@
 /*
 ParameterNumber
 max = (default)7
+ignoreAnnotatedBy = (default)
 ignoreOverriddenMethods = (default)false
 tokens = (default)METHOD_DEF, CTOR_DEF
 

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/sizes/parameternumber/InputParameterNumberSimpleThree.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/sizes/parameternumber/InputParameterNumberSimpleThree.java
@@ -1,6 +1,7 @@
 /*
 ParameterNumber
 max = (default)7
+ignoreAnnotatedBy = (default)
 ignoreOverriddenMethods = (default)false
 tokens = (default)METHOD_DEF, CTOR_DEF
 

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/sizes/parameternumber/InputParameterNumberSimpleTwo.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/sizes/parameternumber/InputParameterNumberSimpleTwo.java
@@ -1,6 +1,7 @@
 /*
 ParameterNumber
 max = (default)7
+ignoreAnnotatedBy = (default)
 ignoreOverriddenMethods = (default)false
 tokens = (default)METHOD_DEF, CTOR_DEF
 


### PR DESCRIPTION
Issue #16807

Updated input files for DesignForExtensionCheck to mention all default properties with the `(default)` tag as required.