### PR TITLE
config: suppress OWASP XXE linkcheck 403 false positive

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -2451,6 +2451,10 @@
             <excludedLink>https://www.manning.com/books/java-development-with-ant</excludedLink>
             <!-- permanent 403, but it works fine out of plugin execution -->
             <excludedLink>https://opencollective.com/*</excludedLink>
+            <!-- 403 forbidden for linkcheck, works in the browser -->
+            <excludedLink>
+              https://owasp.org/www-community/vulnerabilities/XML_External_Entity_(XXE)_Processing
+            </excludedLink>
             <!-- 405 Not Allowed, link present in generated website only -->
             <excludedLink>https://oss.sonatype.org/service/local/staging/deploy/maven2/</excludedLink>
             <!-- site works fine in browser but for plugin always return 500  -->


### PR DESCRIPTION
## Summary

Exclude OWASP XXE documentation URL from linkcheck.


https://github.com/checkstyle/checkstyle/actions/runs/23413374784/job/68104421389


```

------------ grep of linkcheck.html--BEGIN
Checking internal (checkstyle website) and external links.
--- .ci-temp/linkcheck-suppressions-sorted.txt	2026-03-22 21:56:53.685589412 +0000
+++ .ci-temp/linkcheck-errors-sorted.txt	2026-03-22 21:56:53.682589432 +0000
@@ -1,3 +1,4 @@
+<a class="externalLink" href="https://owasp.org/www-community/vulnerabilities/XML_External_Entity_(XXE)_Processing">https://owasp.org/www-community/vulnerabilities/XML_External_Entity_(XXE)_Processing</a>: 403 Forbidden
 <a 
```

## Details

The URL works in a browser, but `maven-linkcheck-plugin` reports
`403 Forbidden` in CI, which makes the linkcheck job fail.

## Testing

Not run.
