### PR TITLE
Issue #15456: Define violation message for ParameterNumberCheck

### DIFF
--- a/src/test/java/com/puppycrawl/tools/checkstyle/bdd/InlineConfigParser.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/bdd/InlineConfigParser.java
@@ -275,7 +275,6 @@ public final class InlineConfigParser {
             "com.puppycrawl.tools.checkstyle.checks.sizes.AnonInnerLengthCheck",
             "com.puppycrawl.tools.checkstyle.checks.sizes.ExecutableStatementCountCheck",
             "com.puppycrawl.tools.checkstyle.checks.sizes.OuterTypeNumberCheck",
-            "com.puppycrawl.tools.checkstyle.checks.sizes.ParameterNumberCheck",
             "com.puppycrawl.tools.checkstyle.checks.sizes.RecordComponentNumberCheck",
             "com.puppycrawl.tools.checkstyle.checks.TodoCommentCheck",
             "com.puppycrawl.tools.checkstyle.checks.TrailingCommentCheck",

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/sizes/ParameterNumberCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/sizes/ParameterNumberCheckTest.java
@@ -109,7 +109,7 @@ public class ParameterNumberCheckTest
     public void shouldLogActualParameterNumber()
             throws Exception {
         final String[] expected = {
-            "199:10: 7,9",
+            "198:10: " + getCheckMessage(MSG_KEY, 7, 9),
         };
         verifyWithInlineConfigParser(
                 getPath("InputParameterNumberSimple4.java"), expected);

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/sizes/parameternumber/InputParameterNumber.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/sizes/parameternumber/InputParameterNumber.java
@@ -11,13 +11,13 @@ package com.puppycrawl.tools.checkstyle.checks.sizes.parameternumber;
 
 class InputParameterNumberCheckBase
 {
-    // method with many parameters
-    void myMethod(int a, int b, int c, int d, int e, int f, int g, int h) { // violation
+    // violation below, 'More than 7 parameters (found 8).'
+    void myMethod(int a, int b, int c, int d, int e, int f, int g, int h) {
 
     }
 
-    // method with many parameters
-    void myMethod2(int a, int b, int c, int d, int e, int f, int g, int h) { // violation
+    // violation below, 'More than 7 parameters (found 8).'
+    void myMethod2(int a, int b, int c, int d, int e, int f, int g, int h) {
 
     }
 }

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/sizes/parameternumber/InputParameterNumber2.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/sizes/parameternumber/InputParameterNumber2.java
@@ -11,13 +11,13 @@ package com.puppycrawl.tools.checkstyle.checks.sizes.parameternumber;
 
 class InputParameterNumberCheckBase2
 {
-    // method with many parameters
-    void myMethod(int a, int b, int c, int d, int e, int f, int g, int h) { // violation
+    // violation below, 'More than 7 parameters (found 8).'
+    void myMethod(int a, int b, int c, int d, int e, int f, int g, int h) {
 
     }
 
-    // method with many parameters
-    void myMethod2(int a, int b, int c, int d, int e, int f, int g, int h) { // violation
+    // violation below, 'More than 7 parameters (found 8).'
+    void myMethod2(int a, int b, int c, int d, int e, int f, int g, int h) {
 
     }
 }
@@ -25,12 +25,12 @@ class InputParameterNumberCheckBase2
 public class InputParameterNumber2 extends InputParameterNumberCheckBase
 {
     @Override
-    void myMethod(int a, int b, int c, int d, int e, int f, int g, int h) { // violation
+    void myMethod(int a, int b, int c, int d, int e, int f, int g, int h) {
 
-    }
+    } // violation 2 lines above 'More than 7 parameters (found 8).'
 
     @java.lang.Override
-    void myMethod2(int a, int b, int c, int d, int e, int f, int g, int h) { // violation
+    void myMethod2(int a, int b, int c, int d, int e, int f, int g, int h) {
 
-    }
+    } // violation 2 lines above 'More than 7 parameters (found 8).'
 }

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/sizes/parameternumber/InputParameterNumberSimple2.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/sizes/parameternumber/InputParameterNumberSimple2.java
@@ -72,8 +72,8 @@ final class InputParameterNumberSimple2
      * @param badFormat3 bad format
      * @throws java.lang.Exception abc
      **/
-    int test1(int badFormat1,int badFormat2, // violation
-              final int badFormat3)
+    int test1(int badFormat1,int badFormat2,
+              final int badFormat3) // violation above, 'More than 2 parameters (found 3).'
         throws java.lang.Exception
     {
         return 0;
@@ -195,10 +195,10 @@ final class InputParameterNumberSimple2
     /**
      * @see to lazy to document all args. Testing excessive # args
      **/
-    void toManyArgs(int aArg1, int aArg2, int aArg3, int aArg4, int aArg5, // violation
+    void toManyArgs(int aArg1, int aArg2, int aArg3, int aArg4, int aArg5,
                     int aArg6, int aArg7, int aArg8, int aArg9)
     {
-    }
+    } // violation 3 lines above 'More than 2 parameters (found 9).'
 }
 
 /** Test class for variable naming in for each clause. */

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/sizes/parameternumber/InputParameterNumberSimple4.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/sizes/parameternumber/InputParameterNumberSimple4.java
@@ -3,7 +3,6 @@ ParameterNumber
 max = (default)7
 ignoreOverriddenMethods = (default)false
 tokens = (default)METHOD_DEF, CTOR_DEF
-message.maxParam = {0},{1}
 
 
 */
@@ -196,10 +195,10 @@ final class InputParameterNumberSimple4
     /**
      * @see to lazy to document all args. Testing excessive # args
      **/
-    void toManyArgs(int aArg1, int aArg2, int aArg3, int aArg4, int aArg5, // violation
+    void toManyArgs(int aArg1, int aArg2, int aArg3, int aArg4, int aArg5,
                     int aArg6, int aArg7, int aArg8, int aArg9)
     {
-    }
+    } // violation 3 lines above 'More than 7 parameters (found 9).'
 }
 
 /** Test class for variable naming in for each clause. */

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/sizes/parameternumber/InputParameterNumberSimpleThree.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/sizes/parameternumber/InputParameterNumberSimpleThree.java
@@ -44,10 +44,10 @@ final class InputParameterNumberSimpleThree
     /**
      * @see to lazy to document all args. Testing excessive # args
      **/
-    void toManyArgs(int aArg1, int aArg2, int aArg3, int aArg4, int aArg5, // violation
+    void toManyArgs(int aArg1, int aArg2, int aArg3, int aArg4, int aArg5,
                     int aArg6, int aArg7, int aArg8, int aArg9)
     {
-    }
+    } // violation 3 lines above 'More than 7 parameters (found 9).'
 }
 
 /** Test class for variable naming in for each clause. */


### PR DESCRIPTION
Issue : #15456
Define violation message for `ParameterNumberCheck`
Remove `ParameterNumberCheck` from `InlineConfigParser` Suppresion list of violation message.