### PR TITLE
Issue 13194

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -15,12 +15,10 @@ maintainers alike.**
 
 - [Code of Conduct](#code-of-conduct)
 - [Getting Started](#getting-started)
-- [Build](#build)
-- [Submitting Pull Requests](#submitting-pull-requests)
-- [Quality Matters](#quality-matters)
-- [Code Review](#code-review)
 - [Opening an Issue](#opening-an-issue)
 - [Reporting Security Issues](#reporting-security-issues)
+- [Submitting Pull Requests](#submitting-pull-requests)
+- [Code Review](#code-review)
 - [Google Summer of Code](#google-summer-of-code)
 - [Asking Questions](#asking-questions)
 - [Credits](#credits)
@@ -55,57 +53,8 @@ This project and everyone participating in it is governed by the
   If you see such comment created long time ago but issue is still open and no Pull created, please
   feel free to make a comment that you will try to do it.
 
-### Build
-
-The project follows a general maven layout and phases for its build.
-Generated jars will be in folder `target`.
-
-- Generate maven standard jar:
-
-```bash
-./mvnw clean install
-```
-
-- Generate maven standard jar and skip all validations/verifications:
-
-```bash
-./mvnw -P no-validations clean install
-```
-
-- Generate uber jar (checkstyle-all-X.XX.jar) to use our command line:
-
-```bash
-./mvnw -P assembly clean package
-```
-
 ## Submitting Pull Requests
 
-- The commit message must adhere to a certain format. It should be "Issue #Number:
-   Brief single-line message", where NUMBER is the issue number at GitHub
-   (see [an example](https://github.com/checkstyle/checkstyle/commit/9303fd9d971eb55cdfd62686ba2f5698edb2c83e)).
-    Small changes of configuration files, documentation fixes, etc.
-    can be contributed by starting the commit message with one of
-    "minor:", "config:", "infra:", "doc:", "dependency:" or "spelling:",
-    followed by a space and a brief single-line message.
-    "supplemental:" is used for PRs/commits that will support other,
-    more significant changes with format as
-    "supplemental: .... for Issue #XXXX" where "XXXX"
-    refers to the issue that requires this supplemental commit.
-    After submitting a Pull Request, it will be
-    automatically checked by our continuous integration (CI) systems,
-    including GitHub Workflows, CircleCI, and Azure Pipelines.
-    Therefore, please recheck after some minutes
-    that the CIs didn't find any issues with your changes.
-    If there are issues, please fix them by amending commit
-    (not by separate commit) and provide an
-    updated version of the same Pull Request.
-    At times we are busy with our day jobs. This means
-    that you might not always get an immediate answer.
-    You are not being ignored, and we value your work -
-    we might just be too busy to review your code,
-    especially if it is a bit complex.
-    If you don't get a response within two weeks,
-    feel free to send a reminder email about your tracker item.
 - **Read our pull request rules.** See [PR Rules](https://github.com/checkstyle/checkstyle/wiki/PR-rules).
 - **Comment on the issue.** When you decide which issue you would like to take up,
   please comment on the issue to let others know that you are working on it ("I am on it.").
@@ -114,58 +63,13 @@ Generated jars will be in folder `target`.
   activity, feel free to ask if the issue is still being worked on.
 - **Read the Github docs.** Visit GitHub's [Pull Request Guide](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests)
   for information on how to submit a pull request.
-- **Run maven build locally.** `mvn clean verify` should pass on your local before
-  submitting a pull request.
-- Please create a
-  [Pull Request](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/about-pull-requests)
-  for your contribution.
-  In the Pull Request description, add any
-  explanations of the implementation nuances.
-- ATTENTION:
-   Please verify that the Pull Request contains ONLY
-   your intended changes and is based on the
-   most recent HEAD of our master branch.
-   Please read the Pull Request template for more requirements.
 - **Follow the template.** Please follow the [CheckStyle Pull Request Template](https://github.com/checkstyle/checkstyle/blob/master/.github/PULL_REQUEST_TEMPLATE.md)
   that is provided in the pull request description when submitting a pull request.
+- **Run maven build locally.** `mvn clean verify` should pass on your local before
+  submitting a pull request.
 - **Keep the PR small.** If you are working on a large feature, consider breaking it up into
   smaller PRs that can be reviewed and merged independently. This makes it easier for
   reviewers to understand the changes and for maintainers to merge the PR.
-
-## Quality Matters
-
-We use a set of development tools to ensure that
-the quality of our code is kept at a high level.
-Like most projects today, we use JUnit to test our code.
-However, we do take this one step further and measure
-the coverage of our unit tests using [JaCoCo](https://www.eclemma.org/jacoco/).
-This means it is not sufficient to pass all tests,
-but the tests should ideally execute each line in the code,
-code coverage should be 100%.
-To generate the JaCoCo report, run the Maven command:
-
-```bash
-
-./mvnw clean test jacoco:restore-instrumented-classes jacoco:report@default-report .
-
-```
-
-Check the results of the report in
-target/site/jacoco/index.html in the project's root folder.
-Besides using unit testing, we obviously
-also use checkstyle to check its own code.
-The Maven command `./mvnw clean verify` must pass without any errors.
-
-If you add new end user features (Check, Filter, ....), remember
-to document them in JavaDoc of java classes and xdoc files
-that are used to generate that site.
-Please recheck the site and all bundles generated by `./mvnw clean site`
-
-We require regression testing for most functional changes,
-especially for check modules.
-See our
-[regression testing tool documentation](https://github.com/checkstyle/contribution/tree/master/checkstyle-tester#checkstyle-tester)
-for details.
 
 ## Code Review
 
@@ -207,13 +111,6 @@ Some points to consider when opening an issue:
   Provide as much information as you can, including steps to reproduce, stack traces, etc.
 - **Use [GitHub-flavored Markdown](https://help.github.com/en/github/writing-on-github/basic-writing-and-formatting-syntax).**
   Especially put code blocks and console outputs in backticks (```). This improves readability.
-- To report an issue please follow our practices page -
-  [How to report an bug and new module request?](https://checkstyle.sourceforge.io/report_issue.html)
-- As soon as one of admins of our project approved your idea you are good
-  to start implementation and you will be welcome with final code contribution.
-  Please do not expect that we will accept any code that you send to us.
-  Example of ideal [issue description](https://github.com/checkstyle/checkstyle/issues/258),
-  and how it is commented on fix [Pull Request](https://github.com/checkstyle/checkstyle/pull/601).
 
 ## Reporting Security Issues
 

--- a/config/jsoref-spellchecker/whitelist.words
+++ b/config/jsoref-spellchecker/whitelist.words
@@ -150,7 +150,6 @@ cbeaff
 CComments
 cdata
 cde
-cdfd
 Cdi
 Cfg
 Cfml
@@ -337,14 +336,11 @@ Duser
 dv
 Dversion
 Dxml
-eb
 EBFF
 EBNF
 ecj
-eclemma
 eclipsecommunityawards
 Edad
-edb
 ededed
 edef
 edu

--- a/src/site/xdoc/checks/annotation/annotationlocation.xml
+++ b/src/site/xdoc/checks/annotation/annotationlocation.xml
@@ -320,8 +320,12 @@ class Example4 {
         </p>
       </subsection>
 
-      <subsection name="Package" id="AnnotationLocation_Package">
-        <p> com.puppycrawl.tools.checkstyle.checks.annotation </p>
+      <subsection name="Fully Qualified Name" id="Fully_Qualified_Name">
+          <p> com.puppycrawl.tools.checkstyle.checks.annotation.AnnotationLocationCheck</p>
+          <p>
+            Use this fully qualified class name in configuration when an exact class reference is
+            required.
+          </p>
       </subsection>
 
       <subsection name="Parent Module" id="AnnotationLocation_Parent_Module">

--- a/src/site/xdoc/checks/annotation/annotationlocation.xml.template
+++ b/src/site/xdoc/checks/annotation/annotationlocation.xml.template
@@ -121,8 +121,12 @@
         </p>
       </subsection>
 
-      <subsection name="Package" id="AnnotationLocation_Package">
-        <p> com.puppycrawl.tools.checkstyle.checks.annotation </p>
+      <subsection name="Fully Qualified Name" id="Fully_Qualified_Name">
+          <p> com.puppycrawl.tools.checkstyle.checks.annotation.AnnotationLocationCheck</p>
+          <p>
+            Use this fully qualified class name in configuration when an exact class reference is
+            required.
+          </p>
       </subsection>
 
       <subsection name="Parent Module" id="AnnotationLocation_Parent_Module">

--- a/src/site/xdoc/checks/annotation/annotationonsameline.xml
+++ b/src/site/xdoc/checks/annotation/annotationonsameline.xml
@@ -204,8 +204,12 @@ class Example2 implements Foo {
         </p>
       </subsection>
 
-      <subsection name="Package" id="AnnotationOnSameLine_Package">
-        <p> com.puppycrawl.tools.checkstyle.checks.annotation </p>
+      <subsection name="Fully Qualified Name" id="Fully_Qualified_Name">
+        <p> com.puppycrawl.tools.checkstyle.checks.annotation.AnnotationOnSameLineCheck</p>
+        <p>
+          Use this fully qualified class name in configuration when an exact class reference is
+          required.
+        </p>
       </subsection>
 
       <subsection name="Parent Module" id="AnnotationOnSameLine_Parent_Module">

--- a/src/site/xdoc/checks/annotation/annotationonsameline.xml.template
+++ b/src/site/xdoc/checks/annotation/annotationonsameline.xml.template
@@ -80,8 +80,12 @@
         </p>
       </subsection>
 
-      <subsection name="Package" id="AnnotationOnSameLine_Package">
-        <p> com.puppycrawl.tools.checkstyle.checks.annotation </p>
+      <subsection name="Fully Qualified Name" id="Fully_Qualified_Name">
+        <p> com.puppycrawl.tools.checkstyle.checks.annotation.AnnotationOnSameLineCheck</p>
+        <p>
+          Use this fully qualified class name in configuration when an exact class reference is
+          required.
+        </p>
       </subsection>
 
       <subsection name="Parent Module" id="AnnotationOnSameLine_Parent_Module">

--- a/src/site/xdoc/checks/annotation/annotationusestyle.xml
+++ b/src/site/xdoc/checks/annotation/annotationusestyle.xml
@@ -304,8 +304,12 @@ class TestStyle4 {
         </p>
       </subsection>
 
-      <subsection name="Package" id="AnnotationUseStyle_Package">
-        <p> com.puppycrawl.tools.checkstyle.checks.annotation </p>
+      <subsection name="Fully Qualified Name" id="Fully_Qualified_Name">
+        <p> com.puppycrawl.tools.checkstyle.checks.annotation.AnnotationUseStyleCheck</p>
+        <p>
+            Use this fully qualified class name in configuration when an exact class reference is
+            required.
+        </p>
       </subsection>
 
       <subsection name="Parent Module" id="AnnotationUseStyle_Parent_Module">

--- a/src/site/xdoc/checks/annotation/annotationusestyle.xml.template
+++ b/src/site/xdoc/checks/annotation/annotationusestyle.xml.template
@@ -108,8 +108,12 @@
         </p>
       </subsection>
 
-      <subsection name="Package" id="AnnotationUseStyle_Package">
-        <p> com.puppycrawl.tools.checkstyle.checks.annotation </p>
+      <subsection name="Fully Qualified Name" id="Fully_Qualified_Name">
+        <p> com.puppycrawl.tools.checkstyle.checks.annotation.AnnotationUseStyleCheck</p>
+        <p>
+            Use this fully qualified class name in configuration when an exact class reference is
+            required.
+        </p>
       </subsection>
 
       <subsection name="Parent Module" id="AnnotationUseStyle_Parent_Module">

--- a/src/site/xdoc/checks/annotation/missingdeprecated.xml
+++ b/src/site/xdoc/checks/annotation/missingdeprecated.xml
@@ -186,8 +186,12 @@ class Example2 {
         </p>
       </subsection>
 
-      <subsection name="Package" id="MissingDeprecated_Package">
-        <p> com.puppycrawl.tools.checkstyle.checks.annotation </p>
+      <subsection name="Fully Qualified Name" id="Fully_Qualified_Name">
+        <p> com.puppycrawl.tools.checkstyle.checks.annotation.MissingDeprecatedCheck</p>
+        <p>
+          Use this fully qualified class name in configuration when an exact class reference is
+          required.
+        </p>
       </subsection>
 
       <subsection name="Parent Module" id="MissingDeprecated_Parent_Module">

--- a/src/site/xdoc/checks/annotation/missingdeprecated.xml.template
+++ b/src/site/xdoc/checks/annotation/missingdeprecated.xml.template
@@ -78,8 +78,12 @@
         </p>
       </subsection>
 
-      <subsection name="Package" id="MissingDeprecated_Package">
-        <p> com.puppycrawl.tools.checkstyle.checks.annotation </p>
+      <subsection name="Fully Qualified Name" id="Fully_Qualified_Name">
+        <p> com.puppycrawl.tools.checkstyle.checks.annotation.MissingDeprecatedCheck</p>
+        <p>
+          Use this fully qualified class name in configuration when an exact class reference is
+          required.
+        </p>
       </subsection>
 
       <subsection name="Parent Module" id="MissingDeprecated_Parent_Module">

--- a/src/site/xdoc/checks/annotation/missingoverride.xml
+++ b/src/site/xdoc/checks/annotation/missingoverride.xml
@@ -192,8 +192,12 @@ class E {
         </p>
       </subsection>
 
-      <subsection name="Package" id="MissingOverride_Package">
-        <p> com.puppycrawl.tools.checkstyle.checks.annotation </p>
+      <subsection name="Fully Qualified Name" id="Fully_Qualified_Name">
+        <p> com.puppycrawl.tools.checkstyle.checks.annotation.MissingOverrideCheck</p>
+        <p>
+            Use this fully qualified class name in configuration when an exact class reference is
+            required.
+        </p>
       </subsection>
 
       <subsection name="Parent Module" id="MissingOverride_Parent_Module">

--- a/src/site/xdoc/checks/annotation/missingoverride.xml.template
+++ b/src/site/xdoc/checks/annotation/missingoverride.xml.template
@@ -77,8 +77,12 @@
         </p>
       </subsection>
 
-      <subsection name="Package" id="MissingOverride_Package">
-        <p> com.puppycrawl.tools.checkstyle.checks.annotation </p>
+      <subsection name="Fully Qualified Name" id="Fully_Qualified_Name">
+        <p> com.puppycrawl.tools.checkstyle.checks.annotation.MissingOverrideCheck</p>
+        <p>
+            Use this fully qualified class name in configuration when an exact class reference is
+            required.
+        </p>
       </subsection>
 
       <subsection name="Parent Module" id="MissingOverride_Parent_Module">

--- a/src/site/xdoc/checks/annotation/missingoverrideonrecordaccessor.xml
+++ b/src/site/xdoc/checks/annotation/missingoverrideonrecordaccessor.xml
@@ -114,9 +114,13 @@ record Document(String title) implements Printable {
           see the documentation</a> to learn how to.
         </p>
       </subsection>
-      <subsection name="Package" id="MissingOverrideOnRecordAccessor_Package">
-        <p> com.puppycrawl.tools.checkstyle.checks.annotation </p>
-      </subsection>
+  <subsection name="Fully Qualified Name" id="Fully_Qualified_Name">
+    <p> com.puppycrawl.tools.checkstyle.checks.annotation.MissingOverrideOnRecordAccessorCheck</p>
+    <p>
+      Use this fully qualified class name in configuration when an exact class reference is
+      required.
+    </p>
+  </subsection>
       <subsection name="Parent Module" id="MissingOverrideOnRecordAccessor_Parent_Module">
         <p>
           <a href="../../config.html#TreeWalker">TreeWalker</a>

--- a/src/site/xdoc/checks/annotation/missingoverrideonrecordaccessor.xml.template
+++ b/src/site/xdoc/checks/annotation/missingoverrideonrecordaccessor.xml.template
@@ -68,9 +68,13 @@
           see the documentation</a> to learn how to.
         </p>
       </subsection>
-      <subsection name="Package" id="MissingOverrideOnRecordAccessor_Package">
-        <p> com.puppycrawl.tools.checkstyle.checks.annotation </p>
-      </subsection>
+  <subsection name="Fully Qualified Name" id="Fully_Qualified_Name">
+    <p> com.puppycrawl.tools.checkstyle.checks.annotation.MissingOverrideOnRecordAccessorCheck</p>
+    <p>
+      Use this fully qualified class name in configuration when an exact class reference is
+      required.
+    </p>
+  </subsection>
       <subsection name="Parent Module" id="MissingOverrideOnRecordAccessor_Parent_Module">
         <macro name="parent-module">
           <param name="moduleName" value="MissingOverrideOnRecordAccessor"/>

--- a/src/site/xdoc/checks/annotation/packageannotation.xml
+++ b/src/site/xdoc/checks/annotation/packageannotation.xml
@@ -85,8 +85,12 @@ package com.puppycrawl.tools.checkstyle.checks.annotation.packageannotation.exam
         </p>
       </subsection>
 
-      <subsection name="Package" id="PackageAnnotation_Package">
-        <p> com.puppycrawl.tools.checkstyle.checks.annotation </p>
+      <subsection name="Fully Qualified Name" id="Fully_Qualified_Name">
+        <p> com.puppycrawl.tools.checkstyle.checks.annotation.PackageAnnotationCheck</p>
+        <p>
+          Use this fully qualified class name in configuration when an exact class reference is
+          required.
+        </p>
       </subsection>
 
       <subsection name="Parent Module" id="PackageAnnotation_Parent_Module">

--- a/src/site/xdoc/checks/annotation/packageannotation.xml.template
+++ b/src/site/xdoc/checks/annotation/packageannotation.xml.template
@@ -66,8 +66,12 @@
         </p>
       </subsection>
 
-      <subsection name="Package" id="PackageAnnotation_Package">
-        <p> com.puppycrawl.tools.checkstyle.checks.annotation </p>
+      <subsection name="Fully Qualified Name" id="Fully_Qualified_Name">
+        <p> com.puppycrawl.tools.checkstyle.checks.annotation.PackageAnnotationCheck</p>
+        <p>
+          Use this fully qualified class name in configuration when an exact class reference is
+          required.
+        </p>
       </subsection>
 
       <subsection name="Parent Module" id="PackageAnnotation_Parent_Module">

--- a/src/site/xdoc/checks/annotation/suppresswarnings.xml
+++ b/src/site/xdoc/checks/annotation/suppresswarnings.xml
@@ -254,8 +254,12 @@ class Test2 {}
         </p>
       </subsection>
 
-      <subsection name="Package" id="SuppressWarnings_Package">
-        <p> com.puppycrawl.tools.checkstyle.checks.annotation </p>
+      <subsection name="Fully Qualified Name" id="Fully_Qualified_Name">
+        <p> com.puppycrawl.tools.checkstyle.checks.annotation.SuppressWarningsCheck</p>
+        <p>
+          Use this fully qualified class name in configuration when an exact class reference is
+            required.
+        </p>
       </subsection>
 
       <subsection name="Parent Module" id="SuppressWarnings_Parent_Module">

--- a/src/site/xdoc/checks/annotation/suppresswarnings.xml.template
+++ b/src/site/xdoc/checks/annotation/suppresswarnings.xml.template
@@ -79,8 +79,12 @@
         </p>
       </subsection>
 
-      <subsection name="Package" id="SuppressWarnings_Package">
-        <p> com.puppycrawl.tools.checkstyle.checks.annotation </p>
+      <subsection name="Fully Qualified Name" id="Fully_Qualified_Name">
+        <p> com.puppycrawl.tools.checkstyle.checks.annotation.SuppressWarningsCheck</p>
+        <p>
+          Use this fully qualified class name in configuration when an exact class reference is
+            required.
+        </p>
       </subsection>
 
       <subsection name="Parent Module" id="SuppressWarnings_Parent_Module">

--- a/src/site/xdoc/checks/annotation/suppresswarningsholder.xml
+++ b/src/site/xdoc/checks/annotation/suppresswarningsholder.xml
@@ -200,8 +200,12 @@ public class Example4 {
         </ul>
       </subsection>
 
-      <subsection name="Package" id="SuppressWarningsHolder_Package">
-        <p> com.puppycrawl.tools.checkstyle.checks </p>
+      <subsection name="Fully Qualified Name" id="Fully_Qualified_Name">
+        <p> com.puppycrawl.tools.checkstyle.checks.SuppressWarningsHolder</p>
+        <p>
+         Use this fully qualified class name in configuration when an exact class reference is
+         required.
+        </p>
       </subsection>
 
       <subsection name="Parent Module" id="SuppressWarningsHolder_Parent_Module">

--- a/src/site/xdoc/checks/annotation/suppresswarningsholder.xml.template
+++ b/src/site/xdoc/checks/annotation/suppresswarningsholder.xml.template
@@ -108,8 +108,12 @@
         </ul>
       </subsection>
 
-      <subsection name="Package" id="SuppressWarningsHolder_Package">
-        <p> com.puppycrawl.tools.checkstyle.checks </p>
+      <subsection name="Fully Qualified Name" id="Fully_Qualified_Name">
+        <p> com.puppycrawl.tools.checkstyle.checks.SuppressWarningsHolder</p>
+        <p>
+         Use this fully qualified class name in configuration when an exact class reference is
+         required.
+        </p>
       </subsection>
 
       <subsection name="Parent Module" id="SuppressWarningsHolder_Parent_Module">

--- a/src/site/xdoc/checks/blocks/avoidnestedblocks.xml
+++ b/src/site/xdoc/checks/blocks/avoidnestedblocks.xml
@@ -165,8 +165,12 @@ public class Example2 {
         </p>
       </subsection>
 
-      <subsection name="Package" id="AvoidNestedBlocks_Package">
-        <p> com.puppycrawl.tools.checkstyle.checks.blocks </p>
+      <subsection name="Fully Qualified Name" id="Fully_Qualified_Name">
+        <p> com.puppycrawl.tools.checkstyle.checks.blocks.AvoidNestedBlocksCheck</p>
+        <p>
+            Use this fully qualified class name in configuration when an exact class reference is
+            required.
+        </p>
       </subsection>
 
       <subsection name="Parent Module" id="AvoidNestedBlocks_Parent_Module">

--- a/src/site/xdoc/checks/blocks/avoidnestedblocks.xml.template
+++ b/src/site/xdoc/checks/blocks/avoidnestedblocks.xml.template
@@ -78,8 +78,12 @@
         </p>
       </subsection>
 
-      <subsection name="Package" id="AvoidNestedBlocks_Package">
-        <p> com.puppycrawl.tools.checkstyle.checks.blocks </p>
+      <subsection name="Fully Qualified Name" id="Fully_Qualified_Name">
+        <p> com.puppycrawl.tools.checkstyle.checks.blocks.AvoidNestedBlocksCheck</p>
+        <p>
+            Use this fully qualified class name in configuration when an exact class reference is
+            required.
+        </p>
       </subsection>
 
       <subsection name="Parent Module" id="AvoidNestedBlocks_Parent_Module">

--- a/src/site/xdoc/checks/blocks/emptyblock.xml
+++ b/src/site/xdoc/checks/blocks/emptyblock.xml
@@ -254,8 +254,12 @@ public class Example3 {
         </p>
       </subsection>
 
-      <subsection name="Package" id="EmptyBlock_Package">
-        <p> com.puppycrawl.tools.checkstyle.checks.blocks </p>
+      <subsection name="Fully Qualified Name" id="Fully_Qualified_Name">
+        <p> com.puppycrawl.tools.checkstyle.checks.blocks.EmptyBlockCheck</p>
+        <p>
+          Use this fully qualified class name in configuration when an exact class reference is
+          required.
+        </p>
       </subsection>
 
       <subsection name="Parent Module" id="EmptyBlock_Parent_Module">

--- a/src/site/xdoc/checks/blocks/emptyblock.xml.template
+++ b/src/site/xdoc/checks/blocks/emptyblock.xml.template
@@ -95,8 +95,12 @@
         </p>
       </subsection>
 
-      <subsection name="Package" id="EmptyBlock_Package">
-        <p> com.puppycrawl.tools.checkstyle.checks.blocks </p>
+      <subsection name="Fully Qualified Name" id="Fully_Qualified_Name">
+        <p> com.puppycrawl.tools.checkstyle.checks.blocks.EmptyBlockCheck</p>
+        <p>
+          Use this fully qualified class name in configuration when an exact class reference is
+          required.
+        </p>
       </subsection>
 
       <subsection name="Parent Module" id="EmptyBlock_Parent_Module">

--- a/src/site/xdoc/checks/blocks/emptycatchblock.xml
+++ b/src/site/xdoc/checks/blocks/emptycatchblock.xml
@@ -314,8 +314,12 @@ public class Example5 {
         </p>
       </subsection>
 
-      <subsection name="Package" id="EmptyCatchBlock_Package">
-        <p> com.puppycrawl.tools.checkstyle.checks.blocks </p>
+      <subsection name="Fully Qualified Name" id="Fully_Qualified_Name">
+        <p> com.puppycrawl.tools.checkstyle.checks.blocks.EmptyCatchBlockCheck</p>
+        <p>
+          Use this fully qualified class name in configuration when an exact class reference is
+          required.
+        </p>
       </subsection>
 
       <subsection name="Parent Module" id="EmptyCatchBlock_Parent_Module">

--- a/src/site/xdoc/checks/blocks/emptycatchblock.xml.template
+++ b/src/site/xdoc/checks/blocks/emptycatchblock.xml.template
@@ -136,8 +136,12 @@
         </p>
       </subsection>
 
-      <subsection name="Package" id="EmptyCatchBlock_Package">
-        <p> com.puppycrawl.tools.checkstyle.checks.blocks </p>
+      <subsection name="Fully Qualified Name" id="Fully_Qualified_Name">
+        <p> com.puppycrawl.tools.checkstyle.checks.blocks.EmptyCatchBlockCheck</p>
+        <p>
+          Use this fully qualified class name in configuration when an exact class reference is
+          required.
+        </p>
       </subsection>
 
       <subsection name="Parent Module" id="EmptyCatchBlock_Parent_Module">

--- a/src/site/xdoc/checks/blocks/leftcurly.xml
+++ b/src/site/xdoc/checks/blocks/leftcurly.xml
@@ -322,8 +322,12 @@ class Example4
         </p>
       </subsection>
 
-      <subsection name="Package" id="LeftCurly_Package">
-        <p> com.puppycrawl.tools.checkstyle.checks.blocks </p>
+      <subsection name="Fully Qualified Name" id="Fully_Qualified_Name">
+        <p> com.puppycrawl.tools.checkstyle.checks.blocks.LeftCurlyCheck</p>
+        <p>
+          Use this fully qualified class name in configuration when an exact class reference is
+          required.
+        </p>
       </subsection>
 
       <subsection name="Parent Module" id="LeftCurly_Parent_Module">

--- a/src/site/xdoc/checks/blocks/leftcurly.xml.template
+++ b/src/site/xdoc/checks/blocks/leftcurly.xml.template
@@ -107,8 +107,12 @@
         </p>
       </subsection>
 
-      <subsection name="Package" id="LeftCurly_Package">
-        <p> com.puppycrawl.tools.checkstyle.checks.blocks </p>
+      <subsection name="Fully Qualified Name" id="Fully_Qualified_Name">
+        <p> com.puppycrawl.tools.checkstyle.checks.blocks.LeftCurlyCheck</p>
+        <p>
+          Use this fully qualified class name in configuration when an exact class reference is
+          required.
+        </p>
       </subsection>
 
       <subsection name="Parent Module" id="LeftCurly_Parent_Module">

--- a/src/site/xdoc/checks/blocks/needbraces.xml
+++ b/src/site/xdoc/checks/blocks/needbraces.xml
@@ -425,8 +425,12 @@ class CustomCompletableFuture&lt;T&gt; {
         </p>
       </subsection>
 
-      <subsection name="Package" id="NeedBraces_Package">
-        <p> com.puppycrawl.tools.checkstyle.checks.blocks </p>
+      <subsection name="Fully Qualified Name" id="Fully_Qualified_Name">
+        <p> com.puppycrawl.tools.checkstyle.checks.blocks.NeedBracesCheck</p>
+        <p>
+          Use this fully qualified class name in configuration when an exact class reference is
+          required.
+        </p>
       </subsection>
 
       <subsection name="Parent Module" id="NeedBraces_Parent_Module">

--- a/src/site/xdoc/checks/blocks/needbraces.xml.template
+++ b/src/site/xdoc/checks/blocks/needbraces.xml.template
@@ -145,8 +145,12 @@
         </p>
       </subsection>
 
-      <subsection name="Package" id="NeedBraces_Package">
-        <p> com.puppycrawl.tools.checkstyle.checks.blocks </p>
+      <subsection name="Fully Qualified Name" id="Fully_Qualified_Name">
+        <p> com.puppycrawl.tools.checkstyle.checks.blocks.NeedBracesCheck</p>
+        <p>
+          Use this fully qualified class name in configuration when an exact class reference is
+          required.
+        </p>
       </subsection>
 
       <subsection name="Parent Module" id="NeedBraces_Parent_Module">

--- a/src/site/xdoc/checks/blocks/rightcurly.xml
+++ b/src/site/xdoc/checks/blocks/rightcurly.xml
@@ -439,8 +439,12 @@ public class Example5 {
         </p>
       </subsection>
 
-      <subsection name="Package" id="RightCurly_Package">
-        <p> com.puppycrawl.tools.checkstyle.checks.blocks </p>
+      <subsection name="Fully Qualified Name" id="Fully_Qualified_Name">
+        <p> com.puppycrawl.tools.checkstyle.checks.blocks.RightCurlyCheck</p>
+        <p>
+            Use this fully qualified class name in configuration when an exact class reference is
+            required.
+        </p>
       </subsection>
 
       <subsection name="Parent Module" id="RightCurly_Parent_Module">

--- a/src/site/xdoc/checks/blocks/rightcurly.xml.template
+++ b/src/site/xdoc/checks/blocks/rightcurly.xml.template
@@ -139,8 +139,12 @@
         </p>
       </subsection>
 
-      <subsection name="Package" id="RightCurly_Package">
-        <p> com.puppycrawl.tools.checkstyle.checks.blocks </p>
+      <subsection name="Fully Qualified Name" id="Fully_Qualified_Name">
+        <p> com.puppycrawl.tools.checkstyle.checks.blocks.RightCurlyCheck</p>
+        <p>
+            Use this fully qualified class name in configuration when an exact class reference is
+            required.
+        </p>
       </subsection>
 
       <subsection name="Parent Module" id="RightCurly_Parent_Module">

--- a/src/site/xdoc/checks/coding/arraytrailingcomma.xml
+++ b/src/site/xdoc/checks/coding/arraytrailingcomma.xml
@@ -221,9 +221,11 @@ public class Example2 {
         </p>
       </subsection>
 
-      <subsection name="Package" id="ArrayTrailingComma_Package">
+      <subsection name="Fully Qualified Name" id="Fully_Qualified_Name">
+        <p>com.puppycrawl.tools.checkstyle.checks.coding.ArrayTrailingCommaCheck</p>
         <p>
-          com.puppycrawl.tools.checkstyle.checks.coding
+          Use this fully qualified class name in configuration when an exact class reference is
+          required.
         </p>
       </subsection>
 

--- a/src/site/xdoc/checks/coding/arraytrailingcomma.xml.template
+++ b/src/site/xdoc/checks/coding/arraytrailingcomma.xml.template
@@ -78,9 +78,11 @@
         </p>
       </subsection>
 
-      <subsection name="Package" id="ArrayTrailingComma_Package">
+      <subsection name="Fully Qualified Name" id="Fully_Qualified_Name">
+        <p>com.puppycrawl.tools.checkstyle.checks.coding.ArrayTrailingCommaCheck</p>
         <p>
-          com.puppycrawl.tools.checkstyle.checks.coding
+          Use this fully qualified class name in configuration when an exact class reference is
+          required.
         </p>
       </subsection>
 

--- a/src/site/xdoc/checks/coding/avoiddoublebraceinitialization.xml
+++ b/src/site/xdoc/checks/coding/avoiddoublebraceinitialization.xml
@@ -96,9 +96,11 @@ class Example1 {
         </p>
       </subsection>
 
-      <subsection name="Package" id="AvoidDoubleBraceInitialization_Package">
+      <subsection name="Fully Qualified Name" id="Fully_Qualified_Name">
+        <p>com.puppycrawl.tools.checkstyle.checks.coding.AvoidDoubleBraceInitializationCheck</p>
         <p>
-          com.puppycrawl.tools.checkstyle.checks.coding
+            Use this fully qualified class name in configuration when an exact class reference is
+            required.
         </p>
       </subsection>
 

--- a/src/site/xdoc/checks/coding/avoiddoublebraceinitialization.xml.template
+++ b/src/site/xdoc/checks/coding/avoiddoublebraceinitialization.xml.template
@@ -57,9 +57,11 @@
         </p>
       </subsection>
 
-      <subsection name="Package" id="AvoidDoubleBraceInitialization_Package">
+      <subsection name="Fully Qualified Name" id="Fully_Qualified_Name">
+        <p>com.puppycrawl.tools.checkstyle.checks.coding.AvoidDoubleBraceInitializationCheck</p>
         <p>
-          com.puppycrawl.tools.checkstyle.checks.coding
+            Use this fully qualified class name in configuration when an exact class reference is
+            required.
         </p>
       </subsection>
 

--- a/src/site/xdoc/checks/coding/avoidinlineconditionals.xml
+++ b/src/site/xdoc/checks/coding/avoidinlineconditionals.xml
@@ -80,9 +80,11 @@ public class Example1 {
         </p>
       </subsection>
 
-      <subsection name="Package" id="AvoidInlineConditionals_Package">
+      <subsection name="Fully Qualified Name" id="Fully_Qualified_Name">
+        <p>com.puppycrawl.tools.checkstyle.checks.coding.AvoidInlineConditionalsCheck</p>
         <p>
-          com.puppycrawl.tools.checkstyle.checks.coding
+              Use this fully qualified class name in configuration when an exact class reference is
+              required.
         </p>
       </subsection>
 

--- a/src/site/xdoc/checks/coding/avoidinlineconditionals.xml.template
+++ b/src/site/xdoc/checks/coding/avoidinlineconditionals.xml.template
@@ -55,9 +55,11 @@
         </p>
       </subsection>
 
-      <subsection name="Package" id="AvoidInlineConditionals_Package">
+      <subsection name="Fully Qualified Name" id="Fully_Qualified_Name">
+        <p>com.puppycrawl.tools.checkstyle.checks.coding.AvoidInlineConditionalsCheck</p>
         <p>
-          com.puppycrawl.tools.checkstyle.checks.coding
+              Use this fully qualified class name in configuration when an exact class reference is
+              required.
         </p>
       </subsection>
 

--- a/src/site/xdoc/checks/coding/avoidnoargumentsuperconstructorcall.xml
+++ b/src/site/xdoc/checks/coding/avoidnoargumentsuperconstructorcall.xml
@@ -79,11 +79,13 @@ class Example1 extends SuperClass {
         </p>
       </subsection>
 
-      <subsection name="Package" id="AvoidNoArgumentSuperConstructorCall_Package">
-        <p>
-          com.puppycrawl.tools.checkstyle.checks.coding
-        </p>
-      </subsection>
+   <subsection name="Fully Qualified Name" id="Fully_Qualified_Name">
+     <p>com.puppycrawl.tools.checkstyle.checks.coding.AvoidNoArgumentSuperConstructorCallCheck</p>
+     <p>
+        Use this fully qualified class name in configuration when an exact class reference is
+        required.
+     </p>
+   </subsection>
 
       <subsection name="Parent Module" id="AvoidNoArgumentSuperConstructorCall_Parent_Module">
         <p>

--- a/src/site/xdoc/checks/coding/avoidnoargumentsuperconstructorcall.xml.template
+++ b/src/site/xdoc/checks/coding/avoidnoargumentsuperconstructorcall.xml.template
@@ -58,11 +58,13 @@
         </p>
       </subsection>
 
-      <subsection name="Package" id="AvoidNoArgumentSuperConstructorCall_Package">
-        <p>
-          com.puppycrawl.tools.checkstyle.checks.coding
-        </p>
-      </subsection>
+   <subsection name="Fully Qualified Name" id="Fully_Qualified_Name">
+     <p>com.puppycrawl.tools.checkstyle.checks.coding.AvoidNoArgumentSuperConstructorCallCheck</p>
+     <p>
+        Use this fully qualified class name in configuration when an exact class reference is
+        required.
+     </p>
+   </subsection>
 
       <subsection name="Parent Module" id="AvoidNoArgumentSuperConstructorCall_Parent_Module">
         <macro name="parent-module">

--- a/src/site/xdoc/checks/coding/constructorsdeclarationgrouping.xml
+++ b/src/site/xdoc/checks/coding/constructorsdeclarationgrouping.xml
@@ -131,9 +131,11 @@ public class Example2 {
         </p>
       </subsection>
 
-      <subsection name="Package" id="ConstructorsDeclarationGrouping_Package">
+      <subsection name="Fully Qualified Name" id="Fully_Qualified_Name">
+        <p>com.puppycrawl.tools.checkstyle.checks.coding.ConstructorsDeclarationGroupingCheck</p>
         <p>
-          com.puppycrawl.tools.checkstyle.checks.coding
+           Use this fully qualified class name in configuration when an exact class reference is
+           required.
         </p>
       </subsection>
 

--- a/src/site/xdoc/checks/coding/constructorsdeclarationgrouping.xml.template
+++ b/src/site/xdoc/checks/coding/constructorsdeclarationgrouping.xml.template
@@ -63,9 +63,11 @@
         </p>
       </subsection>
 
-      <subsection name="Package" id="ConstructorsDeclarationGrouping_Package">
+      <subsection name="Fully Qualified Name" id="Fully_Qualified_Name">
+        <p>com.puppycrawl.tools.checkstyle.checks.coding.ConstructorsDeclarationGroupingCheck</p>
         <p>
-          com.puppycrawl.tools.checkstyle.checks.coding
+           Use this fully qualified class name in configuration when an exact class reference is
+           required.
         </p>
       </subsection>
 

--- a/src/site/xdoc/checks/coding/covariantequals.xml
+++ b/src/site/xdoc/checks/coding/covariantequals.xml
@@ -140,9 +140,11 @@ public class Example2 {
         </p>
       </subsection>
 
-      <subsection name="Package" id="CovariantEquals_Package">
+      <subsection name="Fully Qualified Name" id="Fully_Qualified_Name">
+        <p>com.puppycrawl.tools.checkstyle.checks.coding.CovariantEqualsCheck</p>
         <p>
-          com.puppycrawl.tools.checkstyle.checks.coding
+           Use this fully qualified class name in configuration when an exact class reference is
+           required.
         </p>
       </subsection>
 

--- a/src/site/xdoc/checks/coding/covariantequals.xml.template
+++ b/src/site/xdoc/checks/coding/covariantequals.xml.template
@@ -66,9 +66,11 @@
         </p>
       </subsection>
 
-      <subsection name="Package" id="CovariantEquals_Package">
+      <subsection name="Fully Qualified Name" id="Fully_Qualified_Name">
+        <p>com.puppycrawl.tools.checkstyle.checks.coding.CovariantEqualsCheck</p>
         <p>
-          com.puppycrawl.tools.checkstyle.checks.coding
+           Use this fully qualified class name in configuration when an exact class reference is
+           required.
         </p>
       </subsection>
 

--- a/src/site/xdoc/checks/coding/declarationorder.xml
+++ b/src/site/xdoc/checks/coding/declarationorder.xml
@@ -230,9 +230,11 @@ public class Example3 {
         </p>
       </subsection>
 
-      <subsection name="Package" id="DeclarationOrder_Package">
+      <subsection name="Fully Qualified Name" id="Fully_Qualified_Name">
+        <p>com.puppycrawl.tools.checkstyle.checks.coding.DeclarationOrderCheck</p>
         <p>
-          com.puppycrawl.tools.checkstyle.checks.coding
+            Use this fully qualified class name in configuration when an exact class reference is
+            required.
         </p>
       </subsection>
 

--- a/src/site/xdoc/checks/coding/declarationorder.xml.template
+++ b/src/site/xdoc/checks/coding/declarationorder.xml.template
@@ -96,9 +96,11 @@
         </p>
       </subsection>
 
-      <subsection name="Package" id="DeclarationOrder_Package">
+      <subsection name="Fully Qualified Name" id="Fully_Qualified_Name">
+        <p>com.puppycrawl.tools.checkstyle.checks.coding.DeclarationOrderCheck</p>
         <p>
-          com.puppycrawl.tools.checkstyle.checks.coding
+            Use this fully qualified class name in configuration when an exact class reference is
+            required.
         </p>
       </subsection>
 

--- a/src/site/xdoc/checks/coding/defaultcomeslast.xml
+++ b/src/site/xdoc/checks/coding/defaultcomeslast.xml
@@ -190,9 +190,11 @@ public class Example2 {
         </p>
       </subsection>
 
-      <subsection name="Package" id="DefaultComesLast_Package">
+      <subsection name="Fully Qualified Name" id="Fully_Qualified_Name">
+        <p>com.puppycrawl.tools.checkstyle.checks.coding.DefaultComesLastCheck</p>
         <p>
-          com.puppycrawl.tools.checkstyle.checks.coding
+            Use this fully qualified class name in configuration when an exact class reference is
+            required.
         </p>
       </subsection>
 

--- a/src/site/xdoc/checks/coding/defaultcomeslast.xml.template
+++ b/src/site/xdoc/checks/coding/defaultcomeslast.xml.template
@@ -80,9 +80,11 @@
         </p>
       </subsection>
 
-      <subsection name="Package" id="DefaultComesLast_Package">
+      <subsection name="Fully Qualified Name" id="Fully_Qualified_Name">
+        <p>com.puppycrawl.tools.checkstyle.checks.coding.DefaultComesLastCheck</p>
         <p>
-          com.puppycrawl.tools.checkstyle.checks.coding
+            Use this fully qualified class name in configuration when an exact class reference is
+            required.
         </p>
       </subsection>
 

--- a/src/site/xdoc/checks/coding/emptystatement.xml
+++ b/src/site/xdoc/checks/coding/emptystatement.xml
@@ -72,9 +72,11 @@ public class Example1 {
         </p>
       </subsection>
 
-      <subsection name="Package" id="EmptyStatement_Package">
+      <subsection name="Fully Qualified Name" id="Fully_Qualified_Name">
+        <p>com.puppycrawl.tools.checkstyle.checks.coding.EmptyStatementCheck</p>
         <p>
-          com.puppycrawl.tools.checkstyle.checks.coding
+          Use this fully qualified class name in configuration when an exact class reference is
+          required.
         </p>
       </subsection>
 

--- a/src/site/xdoc/checks/coding/emptystatement.xml.template
+++ b/src/site/xdoc/checks/coding/emptystatement.xml.template
@@ -61,9 +61,11 @@
         </p>
       </subsection>
 
-      <subsection name="Package" id="EmptyStatement_Package">
+      <subsection name="Fully Qualified Name" id="Fully_Qualified_Name">
+        <p>com.puppycrawl.tools.checkstyle.checks.coding.EmptyStatementCheck</p>
         <p>
-          com.puppycrawl.tools.checkstyle.checks.coding
+          Use this fully qualified class name in configuration when an exact class reference is
+          required.
         </p>
       </subsection>
 

--- a/src/site/xdoc/checks/coding/equalsavoidnull.xml
+++ b/src/site/xdoc/checks/coding/equalsavoidnull.xml
@@ -134,9 +134,11 @@ public class Example2 {
         </p>
       </subsection>
 
-      <subsection name="Package" id="EqualsAvoidNull_Package">
+      <subsection name="Fully Qualified Name" id="Fully_Qualified_Name">
+        <p>com.puppycrawl.tools.checkstyle.checks.coding.EqualsAvoidNullCheck</p>
         <p>
-          com.puppycrawl.tools.checkstyle.checks.coding
+            Use this fully qualified class name in configuration when an exact class reference is
+            required.
         </p>
       </subsection>
 

--- a/src/site/xdoc/checks/coding/equalsavoidnull.xml.template
+++ b/src/site/xdoc/checks/coding/equalsavoidnull.xml.template
@@ -82,9 +82,11 @@
         </p>
       </subsection>
 
-      <subsection name="Package" id="EqualsAvoidNull_Package">
+      <subsection name="Fully Qualified Name" id="Fully_Qualified_Name">
+        <p>com.puppycrawl.tools.checkstyle.checks.coding.EqualsAvoidNullCheck</p>
         <p>
-          com.puppycrawl.tools.checkstyle.checks.coding
+            Use this fully qualified class name in configuration when an exact class reference is
+            required.
         </p>
       </subsection>
 

--- a/src/site/xdoc/checks/coding/equalshashcode.xml
+++ b/src/site/xdoc/checks/coding/equalshashcode.xml
@@ -116,9 +116,11 @@ class ExampleNoValidEquals {
         </p>
       </subsection>
 
-      <subsection name="Package" id="EqualsHashCode_Package">
+      <subsection name="Fully Qualified Name" id="Fully_Qualified_Name">
+        <p>com.puppycrawl.tools.checkstyle.checks.coding.EqualsHashCodeCheck</p>
         <p>
-          com.puppycrawl.tools.checkstyle.checks.coding
+            Use this fully qualified class name in configuration when an exact class reference is
+            required.
         </p>
       </subsection>
 

--- a/src/site/xdoc/checks/coding/equalshashcode.xml.template
+++ b/src/site/xdoc/checks/coding/equalshashcode.xml.template
@@ -59,9 +59,11 @@
         </p>
       </subsection>
 
-      <subsection name="Package" id="EqualsHashCode_Package">
+      <subsection name="Fully Qualified Name" id="Fully_Qualified_Name">
+        <p>com.puppycrawl.tools.checkstyle.checks.coding.EqualsHashCodeCheck</p>
         <p>
-          com.puppycrawl.tools.checkstyle.checks.coding
+            Use this fully qualified class name in configuration when an exact class reference is
+            required.
         </p>
       </subsection>
 

--- a/src/site/xdoc/checks/coding/explicitinitialization.xml
+++ b/src/site/xdoc/checks/coding/explicitinitialization.xml
@@ -146,9 +146,11 @@ public class Example2 {
         </p>
       </subsection>
 
-      <subsection name="Package" id="ExplicitInitialization_Package">
+      <subsection name="Fully Qualified Name" id="Fully_Qualified_Name">
+        <p>com.puppycrawl.tools.checkstyle.checks.coding.ExplicitInitializationCheck</p>
         <p>
-          com.puppycrawl.tools.checkstyle.checks.coding
+           Use this fully qualified class name in configuration when an exact class reference is
+           required.
         </p>
       </subsection>
 

--- a/src/site/xdoc/checks/coding/explicitinitialization.xml.template
+++ b/src/site/xdoc/checks/coding/explicitinitialization.xml.template
@@ -79,9 +79,11 @@
         </p>
       </subsection>
 
-      <subsection name="Package" id="ExplicitInitialization_Package">
+      <subsection name="Fully Qualified Name" id="Fully_Qualified_Name">
+        <p>com.puppycrawl.tools.checkstyle.checks.coding.ExplicitInitializationCheck</p>
         <p>
-          com.puppycrawl.tools.checkstyle.checks.coding
+           Use this fully qualified class name in configuration when an exact class reference is
+           required.
         </p>
       </subsection>
 

--- a/src/site/xdoc/checks/coding/fallthrough.xml
+++ b/src/site/xdoc/checks/coding/fallthrough.xml
@@ -232,9 +232,11 @@ class Example3 {
         </p>
       </subsection>
 
-      <subsection name="Package" id="FallThrough_Package">
+      <subsection name="Fully Qualified Name" id="Fully_Qualified_Name">
+        <p>com.puppycrawl.tools.checkstyle.checks.coding.FallThroughCheck</p>
         <p>
-          com.puppycrawl.tools.checkstyle.checks.coding
+            Use this fully qualified class name in configuration when an exact class reference is
+            required.
         </p>
       </subsection>
 

--- a/src/site/xdoc/checks/coding/fallthrough.xml.template
+++ b/src/site/xdoc/checks/coding/fallthrough.xml.template
@@ -104,9 +104,11 @@
         </p>
       </subsection>
 
-      <subsection name="Package" id="FallThrough_Package">
+      <subsection name="Fully Qualified Name" id="Fully_Qualified_Name">
+        <p>com.puppycrawl.tools.checkstyle.checks.coding.FallThroughCheck</p>
         <p>
-          com.puppycrawl.tools.checkstyle.checks.coding
+            Use this fully qualified class name in configuration when an exact class reference is
+            required.
         </p>
       </subsection>
 

--- a/src/site/xdoc/checks/coding/finallocalvariable.xml
+++ b/src/site/xdoc/checks/coding/finallocalvariable.xml
@@ -276,9 +276,11 @@ class Example5
         </p>
       </subsection>
 
-      <subsection name="Package" id="FinalLocalVariable_Package">
+      <subsection name="Fully Qualified Name" id="Fully_Qualified_Name">
+        <p>com.puppycrawl.tools.checkstyle.checks.coding.FinalLocalVariableCheck</p>
         <p>
-          com.puppycrawl.tools.checkstyle.checks.coding
+              Use this fully qualified class name in configuration when an exact class reference is
+              required.
         </p>
       </subsection>
 

--- a/src/site/xdoc/checks/coding/finallocalvariable.xml.template
+++ b/src/site/xdoc/checks/coding/finallocalvariable.xml.template
@@ -140,9 +140,11 @@
         </p>
       </subsection>
 
-      <subsection name="Package" id="FinalLocalVariable_Package">
+      <subsection name="Fully Qualified Name" id="Fully_Qualified_Name">
+        <p>com.puppycrawl.tools.checkstyle.checks.coding.FinalLocalVariableCheck</p>
         <p>
-          com.puppycrawl.tools.checkstyle.checks.coding
+              Use this fully qualified class name in configuration when an exact class reference is
+              required.
         </p>
       </subsection>
 

--- a/src/site/xdoc/checks/coding/hiddenfield.xml
+++ b/src/site/xdoc/checks/coding/hiddenfield.xml
@@ -422,9 +422,11 @@ class Example7 {
         </p>
       </subsection>
 
-      <subsection name="Package" id="HiddenField_Package">
+      <subsection name="Fully Qualified Name" id="Fully_Qualified_Name">
+        <p>com.puppycrawl.tools.checkstyle.checks.coding.HiddenFieldCheck</p>
         <p>
-          com.puppycrawl.tools.checkstyle.checks.coding
+            Use this fully qualified class name in configuration when an exact class reference is
+            required.
         </p>
       </subsection>
 

--- a/src/site/xdoc/checks/coding/hiddenfield.xml.template
+++ b/src/site/xdoc/checks/coding/hiddenfield.xml.template
@@ -163,9 +163,11 @@
         </p>
       </subsection>
 
-      <subsection name="Package" id="HiddenField_Package">
+      <subsection name="Fully Qualified Name" id="Fully_Qualified_Name">
+        <p>com.puppycrawl.tools.checkstyle.checks.coding.HiddenFieldCheck</p>
         <p>
-          com.puppycrawl.tools.checkstyle.checks.coding
+            Use this fully qualified class name in configuration when an exact class reference is
+            required.
         </p>
       </subsection>
 

--- a/src/site/xdoc/checks/coding/illegalcatch.xml
+++ b/src/site/xdoc/checks/coding/illegalcatch.xml
@@ -192,9 +192,11 @@ class Example2 {
         </p>
       </subsection>
 
-      <subsection name="Package" id="IllegalCatch_Package">
+      <subsection name="Fully Qualified Name" id="Fully_Qualified_Name">
+        <p>com.puppycrawl.tools.checkstyle.checks.coding.IllegalCatchCheck</p>
         <p>
-          com.puppycrawl.tools.checkstyle.checks.coding
+            Use this fully qualified class name in configuration when an exact class reference is
+            required.
         </p>
       </subsection>
 

--- a/src/site/xdoc/checks/coding/illegalcatch.xml.template
+++ b/src/site/xdoc/checks/coding/illegalcatch.xml.template
@@ -83,9 +83,11 @@
         </p>
       </subsection>
 
-      <subsection name="Package" id="IllegalCatch_Package">
+      <subsection name="Fully Qualified Name" id="Fully_Qualified_Name">
+        <p>com.puppycrawl.tools.checkstyle.checks.coding.IllegalCatchCheck</p>
         <p>
-          com.puppycrawl.tools.checkstyle.checks.coding
+            Use this fully qualified class name in configuration when an exact class reference is
+            required.
         </p>
       </subsection>
 

--- a/src/site/xdoc/checks/coding/illegalinstantiation.xml
+++ b/src/site/xdoc/checks/coding/illegalinstantiation.xml
@@ -197,9 +197,11 @@ class Example3 {
         </p>
       </subsection>
 
-      <subsection name="Package" id="IllegalInstantiation_Package">
+      <subsection name="Fully Qualified Name" id="Fully_Qualified_Name">
+        <p>com.puppycrawl.tools.checkstyle.checks.coding.IllegalInstantiationCheck</p>
         <p>
-          com.puppycrawl.tools.checkstyle.checks.coding
+            Use this fully qualified class name in configuration when an exact class reference is
+            required.
         </p>
       </subsection>
 

--- a/src/site/xdoc/checks/coding/illegalinstantiation.xml.template
+++ b/src/site/xdoc/checks/coding/illegalinstantiation.xml.template
@@ -104,9 +104,11 @@
         </p>
       </subsection>
 
-      <subsection name="Package" id="IllegalInstantiation_Package">
+      <subsection name="Fully Qualified Name" id="Fully_Qualified_Name">
+        <p>com.puppycrawl.tools.checkstyle.checks.coding.IllegalInstantiationCheck</p>
         <p>
-          com.puppycrawl.tools.checkstyle.checks.coding
+            Use this fully qualified class name in configuration when an exact class reference is
+            required.
         </p>
       </subsection>
 

--- a/src/site/xdoc/checks/coding/illegalsymbol.xml
+++ b/src/site/xdoc/checks/coding/illegalsymbol.xml
@@ -181,9 +181,11 @@ public class Example3 {
         </p>
       </subsection>
 
-      <subsection name="Package" id="IllegalSymbol_Package">
+      <subsection name="Fully Qualified Name" id="Fully_Qualified_Name">
+        <p>com.puppycrawl.tools.checkstyle.checks.coding.IllegalSymbolCheck</p>
         <p>
-          com.puppycrawl.tools.checkstyle.checks.coding
+          Use this fully qualified class name in configuration when an exact class reference is
+          required.
         </p>
       </subsection>
 

--- a/src/site/xdoc/checks/coding/illegalsymbol.xml.template
+++ b/src/site/xdoc/checks/coding/illegalsymbol.xml.template
@@ -98,9 +98,11 @@
         </p>
       </subsection>
 
-      <subsection name="Package" id="IllegalSymbol_Package">
+      <subsection name="Fully Qualified Name" id="Fully_Qualified_Name">
+        <p>com.puppycrawl.tools.checkstyle.checks.coding.IllegalSymbolCheck</p>
         <p>
-          com.puppycrawl.tools.checkstyle.checks.coding
+          Use this fully qualified class name in configuration when an exact class reference is
+          required.
         </p>
       </subsection>
 

--- a/src/site/xdoc/checks/coding/illegalthrows.xml
+++ b/src/site/xdoc/checks/coding/illegalthrows.xml
@@ -187,9 +187,11 @@ public class Example4 {
         </p>
       </subsection>
 
-      <subsection name="Package" id="IllegalThrows_Package">
+      <subsection name="Fully Qualified Name" id="Fully_Qualified_Name">
+        <p>com.puppycrawl.tools.checkstyle.checks.coding.IllegalThrowsCheck</p>
         <p>
-          com.puppycrawl.tools.checkstyle.checks.coding
+            Use this fully qualified class name in configuration when an exact class reference is
+            required.
         </p>
       </subsection>
 

--- a/src/site/xdoc/checks/coding/illegalthrows.xml.template
+++ b/src/site/xdoc/checks/coding/illegalthrows.xml.template
@@ -106,9 +106,11 @@
         </p>
       </subsection>
 
-      <subsection name="Package" id="IllegalThrows_Package">
+      <subsection name="Fully Qualified Name" id="Fully_Qualified_Name">
+        <p>com.puppycrawl.tools.checkstyle.checks.coding.IllegalThrowsCheck</p>
         <p>
-          com.puppycrawl.tools.checkstyle.checks.coding
+            Use this fully qualified class name in configuration when an exact class reference is
+            required.
         </p>
       </subsection>
 

--- a/src/site/xdoc/checks/coding/illegaltoken.xml
+++ b/src/site/xdoc/checks/coding/illegaltoken.xml
@@ -128,9 +128,11 @@ class Example2 {
         </p>
       </subsection>
 
-      <subsection name="Package" id="IllegalToken_Package">
+      <subsection name="Fully Qualified Name" id="Fully_Qualified_Name">
+        <p>com.puppycrawl.tools.checkstyle.checks.coding.IllegalTokenCheck</p>
         <p>
-          com.puppycrawl.tools.checkstyle.checks.coding
+            Use this fully qualified class name in configuration when an exact class reference is
+            required.
         </p>
       </subsection>
 

--- a/src/site/xdoc/checks/coding/illegaltoken.xml.template
+++ b/src/site/xdoc/checks/coding/illegaltoken.xml.template
@@ -78,9 +78,11 @@
         </p>
       </subsection>
 
-      <subsection name="Package" id="IllegalToken_Package">
+      <subsection name="Fully Qualified Name" id="Fully_Qualified_Name">
+        <p>com.puppycrawl.tools.checkstyle.checks.coding.IllegalTokenCheck</p>
         <p>
-          com.puppycrawl.tools.checkstyle.checks.coding
+            Use this fully qualified class name in configuration when an exact class reference is
+            required.
         </p>
       </subsection>
 

--- a/src/site/xdoc/checks/coding/illegaltokentext.xml
+++ b/src/site/xdoc/checks/coding/illegaltokentext.xml
@@ -234,9 +234,11 @@ public class Example5 {
         </p>
       </subsection>
 
-      <subsection name="Package" id="IllegalTokenText_Package">
+      <subsection name="Fully Qualified Name" id="Fully_Qualified_Name">
+        <p>com.puppycrawl.tools.checkstyle.checks.coding.IllegalTokenTextCheck</p>
         <p>
-          com.puppycrawl.tools.checkstyle.checks.coding
+            Use this fully qualified class name in configuration when an exact class reference is
+            required.
         </p>
       </subsection>
 

--- a/src/site/xdoc/checks/coding/illegaltokentext.xml.template
+++ b/src/site/xdoc/checks/coding/illegaltokentext.xml.template
@@ -129,9 +129,11 @@
         </p>
       </subsection>
 
-      <subsection name="Package" id="IllegalTokenText_Package">
+      <subsection name="Fully Qualified Name" id="Fully_Qualified_Name">
+        <p>com.puppycrawl.tools.checkstyle.checks.coding.IllegalTokenTextCheck</p>
         <p>
-          com.puppycrawl.tools.checkstyle.checks.coding
+            Use this fully qualified class name in configuration when an exact class reference is
+            required.
         </p>
       </subsection>
 

--- a/src/site/xdoc/checks/coding/illegaltype.xml
+++ b/src/site/xdoc/checks/coding/illegaltype.xml
@@ -950,9 +950,11 @@ public class Example9 extends TreeSet {
         </p>
       </subsection>
 
-      <subsection name="Package" id="IllegalType_Package">
+      <subsection name="Fully Qualified Name" id="Fully_Qualified_Name">
+        <p>com.puppycrawl.tools.checkstyle.checks.coding.IllegalTypeCheck</p>
         <p>
-          com.puppycrawl.tools.checkstyle.checks.coding
+            Use this fully qualified class name in configuration when an exact class reference is
+            required.
         </p>
       </subsection>
 

--- a/src/site/xdoc/checks/coding/illegaltype.xml.template
+++ b/src/site/xdoc/checks/coding/illegaltype.xml.template
@@ -185,9 +185,11 @@
         </p>
       </subsection>
 
-      <subsection name="Package" id="IllegalType_Package">
+      <subsection name="Fully Qualified Name" id="Fully_Qualified_Name">
+        <p>com.puppycrawl.tools.checkstyle.checks.coding.IllegalTypeCheck</p>
         <p>
-          com.puppycrawl.tools.checkstyle.checks.coding
+            Use this fully qualified class name in configuration when an exact class reference is
+            required.
         </p>
       </subsection>
 

--- a/src/site/xdoc/checks/coding/innerassignment.xml
+++ b/src/site/xdoc/checks/coding/innerassignment.xml
@@ -166,9 +166,11 @@ public class Example2 {
         </p>
       </subsection>
 
-      <subsection name="Package" id="InnerAssignment_Package">
+      <subsection name="Fully Qualified Name" id="Fully_Qualified_Name">
+        <p>com.puppycrawl.tools.checkstyle.checks.coding.InnerAssignmentCheck</p>
         <p>
-          com.puppycrawl.tools.checkstyle.checks.coding
+              Use this fully qualified class name in configuration when an exact class reference is
+              required.
         </p>
       </subsection>
 

--- a/src/site/xdoc/checks/coding/innerassignment.xml.template
+++ b/src/site/xdoc/checks/coding/innerassignment.xml.template
@@ -65,9 +65,11 @@
         </p>
       </subsection>
 
-      <subsection name="Package" id="InnerAssignment_Package">
+      <subsection name="Fully Qualified Name" id="Fully_Qualified_Name">
+        <p>com.puppycrawl.tools.checkstyle.checks.coding.InnerAssignmentCheck</p>
         <p>
-          com.puppycrawl.tools.checkstyle.checks.coding
+              Use this fully qualified class name in configuration when an exact class reference is
+              required.
         </p>
       </subsection>
 

--- a/src/site/xdoc/checks/coding/magicnumber.xml
+++ b/src/site/xdoc/checks/coding/magicnumber.xml
@@ -525,9 +525,11 @@ public class Example6 {
         </p>
       </subsection>
 
-      <subsection name="Package" id="MagicNumber_Package">
+      <subsection name="Fully Qualified Name" id="Fully_Qualified_Name">
+        <p>com.puppycrawl.tools.checkstyle.checks.coding.MagicNumberCheck</p>
         <p>
-          com.puppycrawl.tools.checkstyle.checks.coding
+            Use this fully qualified class name in configuration when an exact class reference is
+            required.
         </p>
       </subsection>
 

--- a/src/site/xdoc/checks/coding/magicnumber.xml.template
+++ b/src/site/xdoc/checks/coding/magicnumber.xml.template
@@ -148,9 +148,11 @@
         </p>
       </subsection>
 
-      <subsection name="Package" id="MagicNumber_Package">
+      <subsection name="Fully Qualified Name" id="Fully_Qualified_Name">
+        <p>com.puppycrawl.tools.checkstyle.checks.coding.MagicNumberCheck</p>
         <p>
-          com.puppycrawl.tools.checkstyle.checks.coding
+            Use this fully qualified class name in configuration when an exact class reference is
+            required.
         </p>
       </subsection>
 

--- a/src/site/xdoc/checks/coding/matchxpath.xml
+++ b/src/site/xdoc/checks/coding/matchxpath.xml
@@ -292,9 +292,11 @@ public class Example6 {
         </p>
       </subsection>
 
-      <subsection name="Package" id="MatchXpath_Package">
+      <subsection name="Fully Qualified Name" id="Fully_Qualified_Name">
+        <p>com.puppycrawl.tools.checkstyle.checks.coding.MatchXpathCheck</p>
         <p>
-          com.puppycrawl.tools.checkstyle.checks.coding
+              Use this fully qualified class name in configuration when an exact class reference is
+              required.
         </p>
       </subsection>
 

--- a/src/site/xdoc/checks/coding/matchxpath.xml.template
+++ b/src/site/xdoc/checks/coding/matchxpath.xml.template
@@ -187,9 +187,11 @@ CLASS_DEF -&gt; CLASS_DEF [1:0]
         </p>
       </subsection>
 
-      <subsection name="Package" id="MatchXpath_Package">
+      <subsection name="Fully Qualified Name" id="Fully_Qualified_Name">
+        <p>com.puppycrawl.tools.checkstyle.checks.coding.MatchXpathCheck</p>
         <p>
-          com.puppycrawl.tools.checkstyle.checks.coding
+              Use this fully qualified class name in configuration when an exact class reference is
+              required.
         </p>
       </subsection>
 

--- a/src/site/xdoc/checks/coding/missingctor.xml
+++ b/src/site/xdoc/checks/coding/missingctor.xml
@@ -73,9 +73,11 @@ abstract class AbstractExample {
         </p>
       </subsection>
 
-      <subsection name="Package" id="MissingCtor_Package">
+      <subsection name="Fully Qualified Name" id="Fully_Qualified_Name">
+        <p>com.puppycrawl.tools.checkstyle.checks.coding.MissingCtorCheck</p>
         <p>
-          com.puppycrawl.tools.checkstyle.checks.coding
+            Use this fully qualified class name in configuration when an exact class reference is
+            required.
         </p>
       </subsection>
 

--- a/src/site/xdoc/checks/coding/missingctor.xml.template
+++ b/src/site/xdoc/checks/coding/missingctor.xml.template
@@ -55,9 +55,11 @@
         </p>
       </subsection>
 
-      <subsection name="Package" id="MissingCtor_Package">
+      <subsection name="Fully Qualified Name" id="Fully_Qualified_Name">
+        <p>com.puppycrawl.tools.checkstyle.checks.coding.MissingCtorCheck</p>
         <p>
-          com.puppycrawl.tools.checkstyle.checks.coding
+            Use this fully qualified class name in configuration when an exact class reference is
+            required.
         </p>
       </subsection>
 

--- a/src/site/xdoc/checks/coding/missingnullcaseinswitch.xml
+++ b/src/site/xdoc/checks/coding/missingnullcaseinswitch.xml
@@ -131,9 +131,11 @@ public class Example1 {
         </p>
       </subsection>
 
-      <subsection name="Package" id="MissingNullCaseInSwitch_Package">
+      <subsection name="Fully Qualified Name" id="Fully_Qualified_Name">
+        <p>com.puppycrawl.tools.checkstyle.checks.coding.MissingNullCaseInSwitchCheck</p>
         <p>
-          com.puppycrawl.tools.checkstyle.checks.coding
+            Use this fully qualified class name in configuration when an exact class reference is
+            required.
         </p>
       </subsection>
 

--- a/src/site/xdoc/checks/coding/missingnullcaseinswitch.xml.template
+++ b/src/site/xdoc/checks/coding/missingnullcaseinswitch.xml.template
@@ -57,9 +57,11 @@
         </p>
       </subsection>
 
-      <subsection name="Package" id="MissingNullCaseInSwitch_Package">
+      <subsection name="Fully Qualified Name" id="Fully_Qualified_Name">
+        <p>com.puppycrawl.tools.checkstyle.checks.coding.MissingNullCaseInSwitchCheck</p>
         <p>
-          com.puppycrawl.tools.checkstyle.checks.coding
+            Use this fully qualified class name in configuration when an exact class reference is
+            required.
         </p>
       </subsection>
 

--- a/src/site/xdoc/checks/coding/missingswitchdefault.xml
+++ b/src/site/xdoc/checks/coding/missingswitchdefault.xml
@@ -202,10 +202,12 @@ public class Example3 {
         </p>
       </subsection>
 
-      <subsection name="Package" id="MissingSwitchDefault_Package">
-        <p>
-          com.puppycrawl.tools.checkstyle.checks.coding
-        </p>
+      <subsection name="Fully Qualified Name" id="Fully_Qualified_Name">
+         <p>com.puppycrawl.tools.checkstyle.checks.coding.MissingSwitchDefaultCheck</p>
+         <p>
+             Use this fully qualified class name in configuration when an exact class reference is
+             required.
+         </p>
       </subsection>
 
       <subsection name="Parent Module" id="MissingSwitchDefault_Parent_Module">

--- a/src/site/xdoc/checks/coding/missingswitchdefault.xml.template
+++ b/src/site/xdoc/checks/coding/missingswitchdefault.xml.template
@@ -81,10 +81,12 @@
         </p>
       </subsection>
 
-      <subsection name="Package" id="MissingSwitchDefault_Package">
-        <p>
-          com.puppycrawl.tools.checkstyle.checks.coding
-        </p>
+      <subsection name="Fully Qualified Name" id="Fully_Qualified_Name">
+         <p>com.puppycrawl.tools.checkstyle.checks.coding.MissingSwitchDefaultCheck</p>
+         <p>
+             Use this fully qualified class name in configuration when an exact class reference is
+             required.
+         </p>
       </subsection>
 
       <subsection name="Parent Module" id="MissingSwitchDefault_Parent_Module">

--- a/src/site/xdoc/checks/coding/modifiedcontrolvariable.xml
+++ b/src/site/xdoc/checks/coding/modifiedcontrolvariable.xml
@@ -156,9 +156,11 @@ class Example2 {
         </p>
       </subsection>
 
-      <subsection name="Package" id="ModifiedControlVariable_Package">
+      <subsection name="Fully Qualified Name" id="Fully_Qualified_Name">
+        <p>com.puppycrawl.tools.checkstyle.checks.coding.ModifiedControlVariableCheck</p>
         <p>
-          com.puppycrawl.tools.checkstyle.checks.coding
+              Use this fully qualified class name in configuration when an exact class reference is
+              required.
         </p>
       </subsection>
 

--- a/src/site/xdoc/checks/coding/modifiedcontrolvariable.xml.template
+++ b/src/site/xdoc/checks/coding/modifiedcontrolvariable.xml.template
@@ -89,9 +89,11 @@
         </p>
       </subsection>
 
-      <subsection name="Package" id="ModifiedControlVariable_Package">
+      <subsection name="Fully Qualified Name" id="Fully_Qualified_Name">
+        <p>com.puppycrawl.tools.checkstyle.checks.coding.ModifiedControlVariableCheck</p>
         <p>
-          com.puppycrawl.tools.checkstyle.checks.coding
+              Use this fully qualified class name in configuration when an exact class reference is
+              required.
         </p>
       </subsection>
 

--- a/src/site/xdoc/checks/coding/multiplestringliterals.xml
+++ b/src/site/xdoc/checks/coding/multiplestringliterals.xml
@@ -190,9 +190,11 @@ public class Example4 {
         </p>
       </subsection>
 
-      <subsection name="Package" id="MultipleStringLiterals_Package">
+      <subsection name="Fully Qualified Name" id="Fully_Qualified_Name">
+        <p>com.puppycrawl.tools.checkstyle.checks.coding.MultipleStringLiteralsCheck</p>
         <p>
-          com.puppycrawl.tools.checkstyle.checks.coding
+           Use this fully qualified class name in configuration when an exact class reference is
+           required.
         </p>
       </subsection>
 

--- a/src/site/xdoc/checks/coding/multiplestringliterals.xml.template
+++ b/src/site/xdoc/checks/coding/multiplestringliterals.xml.template
@@ -109,9 +109,11 @@
         </p>
       </subsection>
 
-      <subsection name="Package" id="MultipleStringLiterals_Package">
+      <subsection name="Fully Qualified Name" id="Fully_Qualified_Name">
+        <p>com.puppycrawl.tools.checkstyle.checks.coding.MultipleStringLiteralsCheck</p>
         <p>
-          com.puppycrawl.tools.checkstyle.checks.coding
+           Use this fully qualified class name in configuration when an exact class reference is
+           required.
         </p>
       </subsection>
 

--- a/src/site/xdoc/checks/coding/multiplevariabledeclarations.xml
+++ b/src/site/xdoc/checks/coding/multiplevariabledeclarations.xml
@@ -91,9 +91,11 @@ public class Example1 {
         </p>
       </subsection>
 
-      <subsection name="Package" id="MultipleVariableDeclarations_Package">
+      <subsection name="Fully Qualified Name" id="Fully_Qualified_Name">
+        <p>com.puppycrawl.tools.checkstyle.checks.coding.MultipleVariableDeclarationsCheck</p>
         <p>
-          com.puppycrawl.tools.checkstyle.checks.coding
+            Use this fully qualified class name in configuration when an exact class reference is
+            required.
         </p>
       </subsection>
 

--- a/src/site/xdoc/checks/coding/multiplevariabledeclarations.xml.template
+++ b/src/site/xdoc/checks/coding/multiplevariabledeclarations.xml.template
@@ -65,9 +65,11 @@
         </p>
       </subsection>
 
-      <subsection name="Package" id="MultipleVariableDeclarations_Package">
+      <subsection name="Fully Qualified Name" id="Fully_Qualified_Name">
+        <p>com.puppycrawl.tools.checkstyle.checks.coding.MultipleVariableDeclarationsCheck</p>
         <p>
-          com.puppycrawl.tools.checkstyle.checks.coding
+            Use this fully qualified class name in configuration when an exact class reference is
+            required.
         </p>
       </subsection>
 

--- a/src/site/xdoc/checks/coding/nestedfordepth.xml
+++ b/src/site/xdoc/checks/coding/nestedfordepth.xml
@@ -144,9 +144,11 @@ public class Example2 {
         </p>
       </subsection>
 
-      <subsection name="Package" id="NestedForDepth_Package">
+      <subsection name="Fully Qualified Name" id="Fully_Qualified_Name">
+        <p>com.puppycrawl.tools.checkstyle.checks.coding.NestedForDepthCheck</p>
         <p>
-          com.puppycrawl.tools.checkstyle.checks.coding
+            Use this fully qualified class name in configuration when an exact class reference is
+            required.
         </p>
       </subsection>
 

--- a/src/site/xdoc/checks/coding/nestedfordepth.xml.template
+++ b/src/site/xdoc/checks/coding/nestedfordepth.xml.template
@@ -78,9 +78,11 @@
         </p>
       </subsection>
 
-      <subsection name="Package" id="NestedForDepth_Package">
+      <subsection name="Fully Qualified Name" id="Fully_Qualified_Name">
+        <p>com.puppycrawl.tools.checkstyle.checks.coding.NestedForDepthCheck</p>
         <p>
-          com.puppycrawl.tools.checkstyle.checks.coding
+            Use this fully qualified class name in configuration when an exact class reference is
+            required.
         </p>
       </subsection>
 

--- a/src/site/xdoc/checks/coding/nestedifdepth.xml
+++ b/src/site/xdoc/checks/coding/nestedifdepth.xml
@@ -164,9 +164,11 @@ class Example2 {
         </p>
       </subsection>
 
-      <subsection name="Package" id="NestedIfDepth_Package">
+      <subsection name="Fully Qualified Name" id="Fully_Qualified_Name">
+        <p>com.puppycrawl.tools.checkstyle.checks.coding.NestedIfDepthCheck</p>
         <p>
-          com.puppycrawl.tools.checkstyle.checks.coding
+            Use this fully qualified class name in configuration when an exact class reference is
+            required.
         </p>
       </subsection>
 

--- a/src/site/xdoc/checks/coding/nestedifdepth.xml.template
+++ b/src/site/xdoc/checks/coding/nestedifdepth.xml.template
@@ -78,9 +78,11 @@
         </p>
       </subsection>
 
-      <subsection name="Package" id="NestedIfDepth_Package">
+      <subsection name="Fully Qualified Name" id="Fully_Qualified_Name">
+        <p>com.puppycrawl.tools.checkstyle.checks.coding.NestedIfDepthCheck</p>
         <p>
-          com.puppycrawl.tools.checkstyle.checks.coding
+            Use this fully qualified class name in configuration when an exact class reference is
+            required.
         </p>
       </subsection>
 

--- a/src/site/xdoc/checks/coding/nestedtrydepth.xml
+++ b/src/site/xdoc/checks/coding/nestedtrydepth.xml
@@ -146,9 +146,11 @@ public class Example2 {
         </p>
       </subsection>
 
-      <subsection name="Package" id="NestedTryDepth_Package">
+      <subsection name="Fully Qualified Name" id="Fully_Qualified_Name">
+        <p>com.puppycrawl.tools.checkstyle.checks.coding.NestedTryDepthCheck</p>
         <p>
-          com.puppycrawl.tools.checkstyle.checks.coding
+            Use this fully qualified class name in configuration when an exact class reference is
+            required.
         </p>
       </subsection>
 

--- a/src/site/xdoc/checks/coding/nestedtrydepth.xml.template
+++ b/src/site/xdoc/checks/coding/nestedtrydepth.xml.template
@@ -82,9 +82,11 @@
         </p>
       </subsection>
 
-      <subsection name="Package" id="NestedTryDepth_Package">
+      <subsection name="Fully Qualified Name" id="Fully_Qualified_Name">
+        <p>com.puppycrawl.tools.checkstyle.checks.coding.NestedTryDepthCheck</p>
         <p>
-          com.puppycrawl.tools.checkstyle.checks.coding
+            Use this fully qualified class name in configuration when an exact class reference is
+            required.
         </p>
       </subsection>
 

--- a/src/site/xdoc/checks/coding/noarraytrailingcomma.xml
+++ b/src/site/xdoc/checks/coding/noarraytrailingcomma.xml
@@ -88,9 +88,11 @@ class Example1 {
         </p>
       </subsection>
 
-      <subsection name="Package" id="NoArrayTrailingComma_Package">
+      <subsection name="Fully Qualified Name" id="Fully_Qualified_Name">
+        <p>com.puppycrawl.tools.checkstyle.checks.coding.NoArrayTrailingCommaCheck</p>
         <p>
-          com.puppycrawl.tools.checkstyle.checks.coding
+              Use this fully qualified class name in configuration when an exact class reference is
+              required.
         </p>
       </subsection>
 

--- a/src/site/xdoc/checks/coding/noarraytrailingcomma.xml.template
+++ b/src/site/xdoc/checks/coding/noarraytrailingcomma.xml.template
@@ -55,9 +55,11 @@
         </p>
       </subsection>
 
-      <subsection name="Package" id="NoArrayTrailingComma_Package">
+      <subsection name="Fully Qualified Name" id="Fully_Qualified_Name">
+        <p>com.puppycrawl.tools.checkstyle.checks.coding.NoArrayTrailingCommaCheck</p>
         <p>
-          com.puppycrawl.tools.checkstyle.checks.coding
+              Use this fully qualified class name in configuration when an exact class reference is
+              required.
         </p>
       </subsection>
 

--- a/src/site/xdoc/checks/coding/noclone.xml
+++ b/src/site/xdoc/checks/coding/noclone.xml
@@ -166,9 +166,11 @@ public class Example1 {
         </p>
       </subsection>
 
-      <subsection name="Package" id="NoClone_Package">
+      <subsection name="Fully Qualified Name" id="Fully_Qualified_Name">
+        <p>com.puppycrawl.tools.checkstyle.checks.coding.NoCloneCheck</p>
         <p>
-          com.puppycrawl.tools.checkstyle.checks.coding
+          Use this fully qualified class name in configuration when an exact class reference is
+          required.
         </p>
       </subsection>
 

--- a/src/site/xdoc/checks/coding/noclone.xml.template
+++ b/src/site/xdoc/checks/coding/noclone.xml.template
@@ -54,9 +54,11 @@
         </p>
       </subsection>
 
-      <subsection name="Package" id="NoClone_Package">
+      <subsection name="Fully Qualified Name" id="Fully_Qualified_Name">
+        <p>com.puppycrawl.tools.checkstyle.checks.coding.NoCloneCheck</p>
         <p>
-          com.puppycrawl.tools.checkstyle.checks.coding
+          Use this fully qualified class name in configuration when an exact class reference is
+          required.
         </p>
       </subsection>
 

--- a/src/site/xdoc/checks/coding/noenumtrailingcomma.xml
+++ b/src/site/xdoc/checks/coding/noenumtrailingcomma.xml
@@ -106,9 +106,11 @@ class Example1 {
         </p>
       </subsection>
 
-      <subsection name="Package" id="NoEnumTrailingComma_Package">
+      <subsection name="Fully Qualified Name" id="Fully_Qualified_Name">
+        <p>com.puppycrawl.tools.checkstyle.checks.coding.NoEnumTrailingCommaCheck</p>
         <p>
-          com.puppycrawl.tools.checkstyle.checks.coding
+            Use this fully qualified class name in configuration when an exact class reference is
+            required.
         </p>
       </subsection>
 

--- a/src/site/xdoc/checks/coding/noenumtrailingcomma.xml.template
+++ b/src/site/xdoc/checks/coding/noenumtrailingcomma.xml.template
@@ -57,9 +57,11 @@
         </p>
       </subsection>
 
-      <subsection name="Package" id="NoEnumTrailingComma_Package">
+      <subsection name="Fully Qualified Name" id="Fully_Qualified_Name">
+        <p>com.puppycrawl.tools.checkstyle.checks.coding.NoEnumTrailingCommaCheck</p>
         <p>
-          com.puppycrawl.tools.checkstyle.checks.coding
+            Use this fully qualified class name in configuration when an exact class reference is
+            required.
         </p>
       </subsection>
 

--- a/src/site/xdoc/checks/coding/nofinalizer.xml
+++ b/src/site/xdoc/checks/coding/nofinalizer.xml
@@ -83,9 +83,11 @@ public class Example1 {
         </p>
       </subsection>
 
-      <subsection name="Package" id="NoFinalizer_Package">
+      <subsection name="Fully Qualified Name" id="Fully_Qualified_Name">
+        <p>com.puppycrawl.tools.checkstyle.checks.coding.NoFinalizerCheck</p>
         <p>
-          com.puppycrawl.tools.checkstyle.checks.coding
+            Use this fully qualified class name in configuration when an exact class reference is
+            required.
         </p>
       </subsection>
 

--- a/src/site/xdoc/checks/coding/nofinalizer.xml.template
+++ b/src/site/xdoc/checks/coding/nofinalizer.xml.template
@@ -59,9 +59,11 @@
         </p>
       </subsection>
 
-      <subsection name="Package" id="NoFinalizer_Package">
+      <subsection name="Fully Qualified Name" id="Fully_Qualified_Name">
+        <p>com.puppycrawl.tools.checkstyle.checks.coding.NoFinalizerCheck</p>
         <p>
-          com.puppycrawl.tools.checkstyle.checks.coding
+            Use this fully qualified class name in configuration when an exact class reference is
+            required.
         </p>
       </subsection>
 

--- a/src/site/xdoc/checks/coding/onestatementperline.xml
+++ b/src/site/xdoc/checks/coding/onestatementperline.xml
@@ -202,9 +202,11 @@ public class Example2 {
         </p>
       </subsection>
 
-      <subsection name="Package" id="OneStatementPerLine_Package">
+      <subsection name="Fully Qualified Name" id="Fully_Qualified_Name">
+        <p>com.puppycrawl.tools.checkstyle.checks.coding.OneStatementPerLineCheck</p>
         <p>
-          com.puppycrawl.tools.checkstyle.checks.coding
+            Use this fully qualified class name in configuration when an exact class reference is
+            required.
         </p>
       </subsection>
 

--- a/src/site/xdoc/checks/coding/onestatementperline.xml.template
+++ b/src/site/xdoc/checks/coding/onestatementperline.xml.template
@@ -102,9 +102,11 @@
         </p>
       </subsection>
 
-      <subsection name="Package" id="OneStatementPerLine_Package">
+      <subsection name="Fully Qualified Name" id="Fully_Qualified_Name">
+        <p>com.puppycrawl.tools.checkstyle.checks.coding.OneStatementPerLineCheck</p>
         <p>
-          com.puppycrawl.tools.checkstyle.checks.coding
+            Use this fully qualified class name in configuration when an exact class reference is
+            required.
         </p>
       </subsection>
 

--- a/src/site/xdoc/checks/coding/overloadmethodsdeclarationorder.xml
+++ b/src/site/xdoc/checks/coding/overloadmethodsdeclarationorder.xml
@@ -72,9 +72,11 @@ class Example1 {
         </p>
       </subsection>
 
-      <subsection name="Package" id="OverloadMethodsDeclarationOrder_Package">
+      <subsection name="Fully Qualified Name" id="Fully_Qualified_Name">
+        <p>com.puppycrawl.tools.checkstyle.checks.coding.OverloadMethodsDeclarationOrderCheck</p>
         <p>
-          com.puppycrawl.tools.checkstyle.checks.coding
+            Use this fully qualified class name in configuration when an exact class reference is
+            required.
         </p>
       </subsection>
 

--- a/src/site/xdoc/checks/coding/overloadmethodsdeclarationorder.xml.template
+++ b/src/site/xdoc/checks/coding/overloadmethodsdeclarationorder.xml.template
@@ -57,9 +57,11 @@
         </p>
       </subsection>
 
-      <subsection name="Package" id="OverloadMethodsDeclarationOrder_Package">
+      <subsection name="Fully Qualified Name" id="Fully_Qualified_Name">
+        <p>com.puppycrawl.tools.checkstyle.checks.coding.OverloadMethodsDeclarationOrderCheck</p>
         <p>
-          com.puppycrawl.tools.checkstyle.checks.coding
+            Use this fully qualified class name in configuration when an exact class reference is
+            required.
         </p>
       </subsection>
 

--- a/src/site/xdoc/checks/coding/packagedeclaration.xml
+++ b/src/site/xdoc/checks/coding/packagedeclaration.xml
@@ -115,9 +115,11 @@ public class Example2{
         </p>
       </subsection>
 
-      <subsection name="Package" id="PackageDeclaration_Package">
+      <subsection name="Fully Qualified Name" id="Fully_Qualified_Name">
+        <p>com.puppycrawl.tools.checkstyle.checks.coding.PackageDeclarationCheck</p>
         <p>
-          com.puppycrawl.tools.checkstyle.checks.coding
+            Use this fully qualified class name in configuration when an exact class reference is
+            required.
         </p>
       </subsection>
 

--- a/src/site/xdoc/checks/coding/packagedeclaration.xml.template
+++ b/src/site/xdoc/checks/coding/packagedeclaration.xml.template
@@ -78,9 +78,11 @@
         </p>
       </subsection>
 
-      <subsection name="Package" id="PackageDeclaration_Package">
+      <subsection name="Fully Qualified Name" id="Fully_Qualified_Name">
+        <p>com.puppycrawl.tools.checkstyle.checks.coding.PackageDeclarationCheck</p>
         <p>
-          com.puppycrawl.tools.checkstyle.checks.coding
+            Use this fully qualified class name in configuration when an exact class reference is
+            required.
         </p>
       </subsection>
 

--- a/src/site/xdoc/checks/coding/parameterassignment.xml
+++ b/src/site/xdoc/checks/coding/parameterassignment.xml
@@ -95,9 +95,11 @@ class Example1 {
         </p>
       </subsection>
 
-      <subsection name="Package" id="ParameterAssignment_Package">
+      <subsection name="Fully Qualified Name" id="Fully_Qualified_Name">
+        <p>com.puppycrawl.tools.checkstyle.checks.coding.ParameterAssignmentCheck</p>
         <p>
-          com.puppycrawl.tools.checkstyle.checks.coding
+            Use this fully qualified class name in configuration when an exact class reference is
+            required.
         </p>
       </subsection>
 

--- a/src/site/xdoc/checks/coding/parameterassignment.xml.template
+++ b/src/site/xdoc/checks/coding/parameterassignment.xml.template
@@ -57,9 +57,11 @@
         </p>
       </subsection>
 
-      <subsection name="Package" id="ParameterAssignment_Package">
+      <subsection name="Fully Qualified Name" id="Fully_Qualified_Name">
+        <p>com.puppycrawl.tools.checkstyle.checks.coding.ParameterAssignmentCheck</p>
         <p>
-          com.puppycrawl.tools.checkstyle.checks.coding
+            Use this fully qualified class name in configuration when an exact class reference is
+            required.
         </p>
       </subsection>
 

--- a/src/site/xdoc/checks/coding/patternvariableassignment.xml
+++ b/src/site/xdoc/checks/coding/patternvariableassignment.xml
@@ -84,9 +84,11 @@ public class Example1 {
         </p>
       </subsection>
 
-      <subsection name="Package" id="PatternVariableAssignment_Package">
+      <subsection name="Fully Qualified Name" id="Fully_Qualified_Name">
+        <p>com.puppycrawl.tools.checkstyle.checks.coding.PatternVariableAssignmentCheck</p>
         <p>
-          com.puppycrawl.tools.checkstyle.checks.coding
+            Use this fully qualified class name in configuration when an exact class reference is
+            required.
         </p>
       </subsection>
 

--- a/src/site/xdoc/checks/coding/patternvariableassignment.xml.template
+++ b/src/site/xdoc/checks/coding/patternvariableassignment.xml.template
@@ -57,9 +57,11 @@
         </p>
       </subsection>
 
-      <subsection name="Package" id="PatternVariableAssignment_Package">
+      <subsection name="Fully Qualified Name" id="Fully_Qualified_Name">
+        <p>com.puppycrawl.tools.checkstyle.checks.coding.PatternVariableAssignmentCheck</p>
         <p>
-          com.puppycrawl.tools.checkstyle.checks.coding
+            Use this fully qualified class name in configuration when an exact class reference is
+            required.
         </p>
       </subsection>
 

--- a/src/site/xdoc/checks/coding/requirethis.xml
+++ b/src/site/xdoc/checks/coding/requirethis.xml
@@ -281,9 +281,11 @@ class Example6 {
         </p>
       </subsection>
 
-      <subsection name="Package" id="RequireThis_Package">
+      <subsection name="Fully Qualified Name" id="Fully_Qualified_Name">
+        <p>com.puppycrawl.tools.checkstyle.checks.coding.RequireThisCheck</p>
         <p>
-          com.puppycrawl.tools.checkstyle.checks.coding
+            Use this fully qualified class name in configuration when an exact class reference is
+            required.
         </p>
       </subsection>
 

--- a/src/site/xdoc/checks/coding/requirethis.xml.template
+++ b/src/site/xdoc/checks/coding/requirethis.xml.template
@@ -138,9 +138,11 @@
         </p>
       </subsection>
 
-      <subsection name="Package" id="RequireThis_Package">
+      <subsection name="Fully Qualified Name" id="Fully_Qualified_Name">
+        <p>com.puppycrawl.tools.checkstyle.checks.coding.RequireThisCheck</p>
         <p>
-          com.puppycrawl.tools.checkstyle.checks.coding
+            Use this fully qualified class name in configuration when an exact class reference is
+            required.
         </p>
       </subsection>
 

--- a/src/site/xdoc/checks/coding/returncount.xml
+++ b/src/site/xdoc/checks/coding/returncount.xml
@@ -368,9 +368,11 @@ public class Example5 {
         </p>
       </subsection>
 
-      <subsection name="Package" id="ReturnCount_Package">
+      <subsection name="Fully Qualified Name" id="Fully_Qualified_Name">
+        <p>com.puppycrawl.tools.checkstyle.checks.coding.ReturnCountCheck</p>
         <p>
-          com.puppycrawl.tools.checkstyle.checks.coding
+          Use this fully qualified class name in configuration when an exact class reference is
+          required.
         </p>
       </subsection>
 

--- a/src/site/xdoc/checks/coding/returncount.xml.template
+++ b/src/site/xdoc/checks/coding/returncount.xml.template
@@ -138,9 +138,11 @@
         </p>
       </subsection>
 
-      <subsection name="Package" id="ReturnCount_Package">
+      <subsection name="Fully Qualified Name" id="Fully_Qualified_Name">
+        <p>com.puppycrawl.tools.checkstyle.checks.coding.ReturnCountCheck</p>
         <p>
-          com.puppycrawl.tools.checkstyle.checks.coding
+          Use this fully qualified class name in configuration when an exact class reference is
+          required.
         </p>
       </subsection>
 

--- a/src/site/xdoc/checks/coding/simplifybooleanexpression.xml
+++ b/src/site/xdoc/checks/coding/simplifybooleanexpression.xml
@@ -85,9 +85,11 @@ class Example1 {
         </p>
       </subsection>
 
-      <subsection name="Package" id="SimplifyBooleanExpression_Package">
+      <subsection name="Fully Qualified Name" id="Fully_Qualified_Name">
+        <p>com.puppycrawl.tools.checkstyle.checks.coding.SimplifyBooleanExpressionCheck</p>
         <p>
-          com.puppycrawl.tools.checkstyle.checks.coding
+             Use this fully qualified class name in configuration when an exact class reference is
+             required.
         </p>
       </subsection>
 

--- a/src/site/xdoc/checks/coding/simplifybooleanexpression.xml.template
+++ b/src/site/xdoc/checks/coding/simplifybooleanexpression.xml.template
@@ -59,9 +59,11 @@
         </p>
       </subsection>
 
-      <subsection name="Package" id="SimplifyBooleanExpression_Package">
+      <subsection name="Fully Qualified Name" id="Fully_Qualified_Name">
+        <p>com.puppycrawl.tools.checkstyle.checks.coding.SimplifyBooleanExpressionCheck</p>
         <p>
-          com.puppycrawl.tools.checkstyle.checks.coding
+             Use this fully qualified class name in configuration when an exact class reference is
+             required.
         </p>
       </subsection>
 

--- a/src/site/xdoc/checks/coding/simplifybooleanreturn.xml
+++ b/src/site/xdoc/checks/coding/simplifybooleanreturn.xml
@@ -116,9 +116,11 @@ class Example1 {
         </p>
       </subsection>
 
-      <subsection name="Package" id="SimplifyBooleanReturn_Package">
+      <subsection name="Fully Qualified Name" id="Fully_Qualified_Name">
+        <p>com.puppycrawl.tools.checkstyle.checks.coding.SimplifyBooleanReturnCheck</p>
         <p>
-          com.puppycrawl.tools.checkstyle.checks.coding
+              Use this fully qualified class name in configuration when an exact class reference is
+              required.
         </p>
       </subsection>
 

--- a/src/site/xdoc/checks/coding/simplifybooleanreturn.xml.template
+++ b/src/site/xdoc/checks/coding/simplifybooleanreturn.xml.template
@@ -59,9 +59,11 @@
         </p>
       </subsection>
 
-      <subsection name="Package" id="SimplifyBooleanReturn_Package">
+      <subsection name="Fully Qualified Name" id="Fully_Qualified_Name">
+        <p>com.puppycrawl.tools.checkstyle.checks.coding.SimplifyBooleanReturnCheck</p>
         <p>
-          com.puppycrawl.tools.checkstyle.checks.coding
+              Use this fully qualified class name in configuration when an exact class reference is
+              required.
         </p>
       </subsection>
 

--- a/src/site/xdoc/checks/coding/stringliteralequality.xml
+++ b/src/site/xdoc/checks/coding/stringliteralequality.xml
@@ -93,9 +93,11 @@ class Example1 {
         </p>
       </subsection>
 
-      <subsection name="Package" id="StringLiteralEquality_Package">
+      <subsection name="Fully Qualified Name" id="Fully_Qualified_Name">
+        <p>com.puppycrawl.tools.checkstyle.checks.coding.StringLiteralEqualityCheck</p>
         <p>
-          com.puppycrawl.tools.checkstyle.checks.coding
+              Use this fully qualified class name in configuration when an exact class reference is
+              required.
         </p>
       </subsection>
 

--- a/src/site/xdoc/checks/coding/stringliteralequality.xml.template
+++ b/src/site/xdoc/checks/coding/stringliteralequality.xml.template
@@ -57,9 +57,11 @@
         </p>
       </subsection>
 
-      <subsection name="Package" id="StringLiteralEquality_Package">
+      <subsection name="Fully Qualified Name" id="Fully_Qualified_Name">
+        <p>com.puppycrawl.tools.checkstyle.checks.coding.StringLiteralEqualityCheck</p>
         <p>
-          com.puppycrawl.tools.checkstyle.checks.coding
+              Use this fully qualified class name in configuration when an exact class reference is
+              required.
         </p>
       </subsection>
 

--- a/src/site/xdoc/checks/coding/superclone.xml
+++ b/src/site/xdoc/checks/coding/superclone.xml
@@ -84,9 +84,11 @@ class SuperCloneC {
         </p>
       </subsection>
 
-      <subsection name="Package" id="SuperClone_Package">
+      <subsection name="Fully Qualified Name" id="Fully_Qualified_Name">
+        <p>com.puppycrawl.tools.checkstyle.checks.coding.SuperCloneCheck</p>
         <p>
-          com.puppycrawl.tools.checkstyle.checks.coding
+            Use this fully qualified class name in configuration when an exact class reference is
+            required.
         </p>
       </subsection>
 

--- a/src/site/xdoc/checks/coding/superclone.xml.template
+++ b/src/site/xdoc/checks/coding/superclone.xml.template
@@ -55,9 +55,11 @@
         </p>
       </subsection>
 
-      <subsection name="Package" id="SuperClone_Package">
+      <subsection name="Fully Qualified Name" id="Fully_Qualified_Name">
+        <p>com.puppycrawl.tools.checkstyle.checks.coding.SuperCloneCheck</p>
         <p>
-          com.puppycrawl.tools.checkstyle.checks.coding
+            Use this fully qualified class name in configuration when an exact class reference is
+            required.
         </p>
       </subsection>
 

--- a/src/site/xdoc/checks/coding/superfinalize.xml
+++ b/src/site/xdoc/checks/coding/superfinalize.xml
@@ -74,9 +74,11 @@ class InvalidExample {
         </p>
       </subsection>
 
-      <subsection name="Package" id="SuperFinalize_Package">
+      <subsection name="Fully Qualified Name" id="Fully_Qualified_Name">
+        <p>com.puppycrawl.tools.checkstyle.checks.coding.SuperFinalizeCheck</p>
         <p>
-          com.puppycrawl.tools.checkstyle.checks.coding
+            Use this fully qualified class name in configuration when an exact class reference is
+            required.
         </p>
       </subsection>
 

--- a/src/site/xdoc/checks/coding/superfinalize.xml.template
+++ b/src/site/xdoc/checks/coding/superfinalize.xml.template
@@ -56,9 +56,11 @@
         </p>
       </subsection>
 
-      <subsection name="Package" id="SuperFinalize_Package">
+      <subsection name="Fully Qualified Name" id="Fully_Qualified_Name">
+        <p>com.puppycrawl.tools.checkstyle.checks.coding.SuperFinalizeCheck</p>
         <p>
-          com.puppycrawl.tools.checkstyle.checks.coding
+            Use this fully qualified class name in configuration when an exact class reference is
+            required.
         </p>
       </subsection>
 

--- a/src/site/xdoc/checks/coding/textblockgooglestyleformatting.xml
+++ b/src/site/xdoc/checks/coding/textblockgooglestyleformatting.xml
@@ -250,9 +250,11 @@ public class Example4 {
         </p>
       </subsection>
 
-      <subsection name="Package" id="Package">
+      <subsection name="Fully Qualified Name" id="Fully_Qualified_Name">
+        <p>com.puppycrawl.tools.checkstyle.checks.coding.TextBlockGoogleStyleFormattingCheck</p>
         <p>
-          com.puppycrawl.tools.checkstyle.checks.coding
+              Use this fully qualified class name in configuration when an exact class reference is
+              required.
         </p>
       </subsection>
 

--- a/src/site/xdoc/checks/coding/textblockgooglestyleformatting.xml.template
+++ b/src/site/xdoc/checks/coding/textblockgooglestyleformatting.xml.template
@@ -78,9 +78,11 @@
         </p>
       </subsection>
 
-      <subsection name="Package" id="Package">
+      <subsection name="Fully Qualified Name" id="Fully_Qualified_Name">
+        <p>com.puppycrawl.tools.checkstyle.checks.coding.TextBlockGoogleStyleFormattingCheck</p>
         <p>
-          com.puppycrawl.tools.checkstyle.checks.coding
+              Use this fully qualified class name in configuration when an exact class reference is
+              required.
         </p>
       </subsection>
 

--- a/src/site/xdoc/checks/coding/unnecessarynullcheckwithinstanceof.xml
+++ b/src/site/xdoc/checks/coding/unnecessarynullcheckwithinstanceof.xml
@@ -105,9 +105,11 @@ public class Example1 {
         </p>
       </subsection>
 
-      <subsection name="Package" id="UnnecessaryNullCheckWithInstanceOf_Package">
+      <subsection name="Fully Qualified Name" id="Fully_Qualified_Name">
+        <p>com.puppycrawl.tools.checkstyle.checks.coding.UnnecessaryNullCheckWithInstanceOfCheck</p>
         <p>
-          com.puppycrawl.tools.checkstyle.checks.coding
+           Use this fully qualified class name in configuration when an exact class reference is
+           required.
         </p>
       </subsection>
 

--- a/src/site/xdoc/checks/coding/unnecessarynullcheckwithinstanceof.xml.template
+++ b/src/site/xdoc/checks/coding/unnecessarynullcheckwithinstanceof.xml.template
@@ -58,9 +58,11 @@
         </p>
       </subsection>
 
-      <subsection name="Package" id="UnnecessaryNullCheckWithInstanceOf_Package">
+      <subsection name="Fully Qualified Name" id="Fully_Qualified_Name">
+        <p>com.puppycrawl.tools.checkstyle.checks.coding.UnnecessaryNullCheckWithInstanceOfCheck</p>
         <p>
-          com.puppycrawl.tools.checkstyle.checks.coding
+           Use this fully qualified class name in configuration when an exact class reference is
+           required.
         </p>
       </subsection>
 

--- a/src/site/xdoc/checks/coding/unnecessaryparentheses.xml
+++ b/src/site/xdoc/checks/coding/unnecessaryparentheses.xml
@@ -463,9 +463,11 @@ class Example3 {
         </p>
       </subsection>
 
-      <subsection name="Package" id="UnnecessaryParentheses_Package">
+      <subsection name="Fully Qualified Name" id="Fully_Qualified_Name">
+        <p>com.puppycrawl.tools.checkstyle.checks.coding.UnnecessaryParenthesesCheck</p>
         <p>
-          com.puppycrawl.tools.checkstyle.checks.coding
+              Use this fully qualified class name in configuration when an exact class reference is
+              required.
         </p>
       </subsection>
 

--- a/src/site/xdoc/checks/coding/unnecessaryparentheses.xml.template
+++ b/src/site/xdoc/checks/coding/unnecessaryparentheses.xml.template
@@ -104,9 +104,11 @@
         </p>
       </subsection>
 
-      <subsection name="Package" id="UnnecessaryParentheses_Package">
+      <subsection name="Fully Qualified Name" id="Fully_Qualified_Name">
+        <p>com.puppycrawl.tools.checkstyle.checks.coding.UnnecessaryParenthesesCheck</p>
         <p>
-          com.puppycrawl.tools.checkstyle.checks.coding
+              Use this fully qualified class name in configuration when an exact class reference is
+              required.
         </p>
       </subsection>
 

--- a/src/site/xdoc/checks/coding/unnecessarysemicolonafteroutertypedeclaration.xml
+++ b/src/site/xdoc/checks/coding/unnecessarysemicolonafteroutertypedeclaration.xml
@@ -164,11 +164,14 @@ enum U {
         </p>
       </subsection>
 
-      <subsection name="Package" id="UnnecessarySemicolonAfterOuterTypeDeclaration_Package">
-        <p>
-          com.puppycrawl.tools.checkstyle.checks.coding
-        </p>
-      </subsection>
+<subsection name="Fully Qualified Name" id="Fully_Qualified_Name">
+  <p>com.puppycrawl.tools.checkstyle.checks.coding.
+  UnnecessarySemicolonAfterOuterTypeDeclarationCheck</p>
+  <p>
+    Use this fully qualified class name in configuration when an exact class reference is
+    required.
+  </p>
+</subsection>
 
       <subsection name="Parent Module"
             id="UnnecessarySemicolonAfterOuterTypeDeclaration_Parent_Module">

--- a/src/site/xdoc/checks/coding/unnecessarysemicolonafteroutertypedeclaration.xml.template
+++ b/src/site/xdoc/checks/coding/unnecessarysemicolonafteroutertypedeclaration.xml.template
@@ -90,11 +90,14 @@
         </p>
       </subsection>
 
-      <subsection name="Package" id="UnnecessarySemicolonAfterOuterTypeDeclaration_Package">
-        <p>
-          com.puppycrawl.tools.checkstyle.checks.coding
-        </p>
-      </subsection>
+<subsection name="Fully Qualified Name" id="Fully_Qualified_Name">
+  <p>com.puppycrawl.tools.checkstyle.checks.coding.
+  UnnecessarySemicolonAfterOuterTypeDeclarationCheck</p>
+  <p>
+    Use this fully qualified class name in configuration when an exact class reference is
+    required.
+  </p>
+</subsection>
 
       <subsection name="Parent Module"
             id="UnnecessarySemicolonAfterOuterTypeDeclaration_Parent_Module">

--- a/src/site/xdoc/checks/coding/unnecessarysemicolonaftertypememberdeclaration.xml
+++ b/src/site/xdoc/checks/coding/unnecessarysemicolonaftertypememberdeclaration.xml
@@ -164,11 +164,14 @@ class Example1 {
         </p>
       </subsection>
 
-      <subsection name="Package" id="UnnecessarySemicolonAfterTypeMemberDeclaration_Package">
-        <p>
-          com.puppycrawl.tools.checkstyle.checks.coding
-        </p>
-      </subsection>
+<subsection name="Fully Qualified Name" id="Fully_Qualified_Name">
+  <p>com.puppycrawl.tools.checkstyle.checks.coding.
+  UnnecessarySemicolonAfterTypeMemberDeclarationCheck</p>
+  <p>
+    Use this fully qualified class name in configuration when an exact class reference is
+    required.
+  </p>
+</subsection>
 
       <subsection name="Parent Module"
             id="UnnecessarySemicolonAfterTypeMemberDeclaration_Parent_Module">

--- a/src/site/xdoc/checks/coding/unnecessarysemicolonaftertypememberdeclaration.xml.template
+++ b/src/site/xdoc/checks/coding/unnecessarysemicolonaftertypememberdeclaration.xml.template
@@ -74,11 +74,14 @@
         </p>
       </subsection>
 
-      <subsection name="Package" id="UnnecessarySemicolonAfterTypeMemberDeclaration_Package">
-        <p>
-          com.puppycrawl.tools.checkstyle.checks.coding
-        </p>
-      </subsection>
+<subsection name="Fully Qualified Name" id="Fully_Qualified_Name">
+  <p>com.puppycrawl.tools.checkstyle.checks.coding.
+  UnnecessarySemicolonAfterTypeMemberDeclarationCheck</p>
+  <p>
+    Use this fully qualified class name in configuration when an exact class reference is
+    required.
+  </p>
+</subsection>
 
       <subsection name="Parent Module"
             id="UnnecessarySemicolonAfterTypeMemberDeclaration_Parent_Module">

--- a/src/site/xdoc/checks/coding/unnecessarysemicoloninenumeration.xml
+++ b/src/site/xdoc/checks/coding/unnecessarysemicoloninenumeration.xml
@@ -89,9 +89,11 @@ enum NoSemicolon {
         </p>
       </subsection>
 
-      <subsection name="Package" id="UnnecessarySemicolonInEnumeration_Package">
+      <subsection name="Fully Qualified Name" id="Fully_Qualified_Name">
+        <p>com.puppycrawl.tools.checkstyle.checks.coding.UnnecessarySemicolonInEnumerationCheck</p>
         <p>
-          com.puppycrawl.tools.checkstyle.checks.coding
+              Use this fully qualified class name in configuration when an exact class reference is
+              required.
         </p>
       </subsection>
 

--- a/src/site/xdoc/checks/coding/unnecessarysemicoloninenumeration.xml.template
+++ b/src/site/xdoc/checks/coding/unnecessarysemicoloninenumeration.xml.template
@@ -66,9 +66,11 @@
         </p>
       </subsection>
 
-      <subsection name="Package" id="UnnecessarySemicolonInEnumeration_Package">
+      <subsection name="Fully Qualified Name" id="Fully_Qualified_Name">
+        <p>com.puppycrawl.tools.checkstyle.checks.coding.UnnecessarySemicolonInEnumerationCheck</p>
         <p>
-          com.puppycrawl.tools.checkstyle.checks.coding
+              Use this fully qualified class name in configuration when an exact class reference is
+              required.
         </p>
       </subsection>
 

--- a/src/site/xdoc/checks/coding/unnecessarysemicolonintrywithresources.xml
+++ b/src/site/xdoc/checks/coding/unnecessarysemicolonintrywithresources.xml
@@ -119,11 +119,13 @@ class Example2 {
         </p>
       </subsection>
 
-      <subsection name="Package" id="UnnecessarySemicolonInTryWithResources_Package">
-        <p>
-          com.puppycrawl.tools.checkstyle.checks.coding
-        </p>
-      </subsection>
+  <subsection name="Fully Qualified Name" id="Fully_Qualified_Name">
+    <p>com.puppycrawl.tools.checkstyle.checks.coding.UnnecessarySemicolonInTryWithResourcesCheck</p>
+    <p>
+      Use this fully qualified class name in configuration when an exact class reference is
+      required.
+    </p>
+  </subsection>
 
       <subsection name="Parent Module" id="UnnecessarySemicolonInTryWithResources_Parent_Module">
         <p>

--- a/src/site/xdoc/checks/coding/unnecessarysemicolonintrywithresources.xml.template
+++ b/src/site/xdoc/checks/coding/unnecessarysemicolonintrywithresources.xml.template
@@ -85,11 +85,13 @@
         </p>
       </subsection>
 
-      <subsection name="Package" id="UnnecessarySemicolonInTryWithResources_Package">
-        <p>
-          com.puppycrawl.tools.checkstyle.checks.coding
-        </p>
-      </subsection>
+  <subsection name="Fully Qualified Name" id="Fully_Qualified_Name">
+    <p>com.puppycrawl.tools.checkstyle.checks.coding.UnnecessarySemicolonInTryWithResourcesCheck</p>
+    <p>
+      Use this fully qualified class name in configuration when an exact class reference is
+      required.
+    </p>
+  </subsection>
 
       <subsection name="Parent Module" id="UnnecessarySemicolonInTryWithResources_Parent_Module">
         <macro name="parent-module">

--- a/src/site/xdoc/checks/coding/unusedcatchparametershouldbeunnamed.xml
+++ b/src/site/xdoc/checks/coding/unusedcatchparametershouldbeunnamed.xml
@@ -107,11 +107,13 @@ public class Example1 {
         </p>
       </subsection>
 
-      <subsection name="Package" id="UnusedCatchParameterShouldBeUnnamed_Package">
-        <p>
-          com.puppycrawl.tools.checkstyle.checks.coding
-        </p>
-      </subsection>
+  <subsection name="Fully Qualified Name" id="Fully_Qualified_Name">
+    <p>com.puppycrawl.tools.checkstyle.checks.coding.UnusedCatchParameterShouldBeUnnamedCheck</p>
+    <p>
+        Use this fully qualified class name in configuration when an exact class reference is
+        required.
+    </p>
+  </subsection>
 
       <subsection name="Parent Module" id="UnusedCatchParameterShouldBeUnnamed_Parent_Module">
         <p>

--- a/src/site/xdoc/checks/coding/unusedcatchparametershouldbeunnamed.xml.template
+++ b/src/site/xdoc/checks/coding/unusedcatchparametershouldbeunnamed.xml.template
@@ -58,11 +58,13 @@
         </p>
       </subsection>
 
-      <subsection name="Package" id="UnusedCatchParameterShouldBeUnnamed_Package">
-        <p>
-          com.puppycrawl.tools.checkstyle.checks.coding
-        </p>
-      </subsection>
+  <subsection name="Fully Qualified Name" id="Fully_Qualified_Name">
+    <p>com.puppycrawl.tools.checkstyle.checks.coding.UnusedCatchParameterShouldBeUnnamedCheck</p>
+    <p>
+        Use this fully qualified class name in configuration when an exact class reference is
+        required.
+    </p>
+  </subsection>
 
       <subsection name="Parent Module" id="UnusedCatchParameterShouldBeUnnamed_Parent_Module">
         <macro name="parent-module">

--- a/src/site/xdoc/checks/coding/unusedlambdaparametershouldbeunnamed.xml
+++ b/src/site/xdoc/checks/coding/unusedlambdaparametershouldbeunnamed.xml
@@ -96,11 +96,13 @@ public class Example1 {
         </p>
       </subsection>
 
-      <subsection name="Package" id="UnusedLambdaParameterShouldBeUnnamed_Package">
-        <p>
-          com.puppycrawl.tools.checkstyle.checks.coding
-        </p>
-      </subsection>
+  <subsection name="Fully Qualified Name" id="Fully_Qualified_Name">
+    <p>com.puppycrawl.tools.checkstyle.checks.coding.UnusedLambdaParameterShouldBeUnnamedCheck</p>
+    <p>
+        Use this fully qualified class name in configuration when an exact class reference is
+        required.
+    </p>
+  </subsection>
 
       <subsection name="Parent Module" id="UnusedLambdaParameterShouldBeUnnamed_Parent_Module">
         <p>

--- a/src/site/xdoc/checks/coding/unusedlambdaparametershouldbeunnamed.xml.template
+++ b/src/site/xdoc/checks/coding/unusedlambdaparametershouldbeunnamed.xml.template
@@ -59,11 +59,13 @@
         </p>
       </subsection>
 
-      <subsection name="Package" id="UnusedLambdaParameterShouldBeUnnamed_Package">
-        <p>
-          com.puppycrawl.tools.checkstyle.checks.coding
-        </p>
-      </subsection>
+  <subsection name="Fully Qualified Name" id="Fully_Qualified_Name">
+    <p>com.puppycrawl.tools.checkstyle.checks.coding.UnusedLambdaParameterShouldBeUnnamedCheck</p>
+    <p>
+        Use this fully qualified class name in configuration when an exact class reference is
+        required.
+    </p>
+  </subsection>
 
       <subsection name="Parent Module" id="UnusedLambdaParameterShouldBeUnnamed_Parent_Module">
         <macro name="parent-module">

--- a/src/site/xdoc/checks/coding/unusedlocalvariable.xml
+++ b/src/site/xdoc/checks/coding/unusedlocalvariable.xml
@@ -200,9 +200,11 @@ public class Example2 {
         </p>
       </subsection>
 
-      <subsection name="Package" id="UnusedLocalVariable_Package">
+      <subsection name="Fully Qualified Name" id="Fully_Qualified_Name">
+        <p>com.puppycrawl.tools.checkstyle.checks.coding.UnusedLocalVariableCheck</p>
         <p>
-          com.puppycrawl.tools.checkstyle.checks.coding
+            Use this fully qualified class name in configuration when an exact class reference is
+            required.
         </p>
       </subsection>
 

--- a/src/site/xdoc/checks/coding/unusedlocalvariable.xml.template
+++ b/src/site/xdoc/checks/coding/unusedlocalvariable.xml.template
@@ -83,9 +83,11 @@
         </p>
       </subsection>
 
-      <subsection name="Package" id="UnusedLocalVariable_Package">
+      <subsection name="Fully Qualified Name" id="Fully_Qualified_Name">
+        <p>com.puppycrawl.tools.checkstyle.checks.coding.UnusedLocalVariableCheck</p>
         <p>
-          com.puppycrawl.tools.checkstyle.checks.coding
+            Use this fully qualified class name in configuration when an exact class reference is
+            required.
         </p>
       </subsection>
 

--- a/src/site/xdoc/checks/coding/useenhancedswitch.xml
+++ b/src/site/xdoc/checks/coding/useenhancedswitch.xml
@@ -131,9 +131,11 @@ public class Example2 {
         </p>
       </subsection>
 
-      <subsection name="Package" id="UseEnhancedSwitch_Package">
+      <subsection name="Fully Qualified Name" id="Fully_Qualified_Name">
+        <p>com.puppycrawl.tools.checkstyle.checks.coding.UseEnhancedSwitchCheck</p>
         <p>
-          com.puppycrawl.tools.checkstyle.checks.coding
+          Use this fully qualified class name in configuration when an exact class reference is
+          required.
         </p>
       </subsection>
 

--- a/src/site/xdoc/checks/coding/useenhancedswitch.xml.template
+++ b/src/site/xdoc/checks/coding/useenhancedswitch.xml.template
@@ -65,9 +65,11 @@
         </p>
       </subsection>
 
-      <subsection name="Package" id="UseEnhancedSwitch_Package">
+      <subsection name="Fully Qualified Name" id="Fully_Qualified_Name">
+        <p>com.puppycrawl.tools.checkstyle.checks.coding.UseEnhancedSwitchCheck</p>
         <p>
-          com.puppycrawl.tools.checkstyle.checks.coding
+          Use this fully qualified class name in configuration when an exact class reference is
+          required.
         </p>
       </subsection>
 

--- a/src/site/xdoc/checks/coding/variabledeclarationusagedistance.xml
+++ b/src/site/xdoc/checks/coding/variabledeclarationusagedistance.xml
@@ -352,9 +352,11 @@ public class Example6 {
         </p>
       </subsection>
 
-      <subsection name="Package" id="VariableDeclarationUsageDistance_Package">
+      <subsection name="Fully Qualified Name" id="Fully_Qualified_Name">
+        <p>com.puppycrawl.tools.checkstyle.checks.coding.VariableDeclarationUsageDistanceCheck</p>
         <p>
-          com.puppycrawl.tools.checkstyle.checks.coding
+            Use this fully qualified class name in configuration when an exact class reference is
+            required.
         </p>
       </subsection>
 

--- a/src/site/xdoc/checks/coding/variabledeclarationusagedistance.xml.template
+++ b/src/site/xdoc/checks/coding/variabledeclarationusagedistance.xml.template
@@ -156,9 +156,11 @@
         </p>
       </subsection>
 
-      <subsection name="Package" id="VariableDeclarationUsageDistance_Package">
+      <subsection name="Fully Qualified Name" id="Fully_Qualified_Name">
+        <p>com.puppycrawl.tools.checkstyle.checks.coding.VariableDeclarationUsageDistanceCheck</p>
         <p>
-          com.puppycrawl.tools.checkstyle.checks.coding
+            Use this fully qualified class name in configuration when an exact class reference is
+            required.
         </p>
       </subsection>
 

--- a/src/site/xdoc/checks/coding/whenshouldbeused.xml
+++ b/src/site/xdoc/checks/coding/whenshouldbeused.xml
@@ -109,9 +109,11 @@ public class Example1 {
         </p>
       </subsection>
 
-      <subsection name="Package" id="WhenShouldBeUsed_Package">
+      <subsection name="Fully Qualified Name" id="Fully_Qualified_Name">
+        <p>com.puppycrawl.tools.checkstyle.checks.coding.WhenShouldBeUsedCheck</p>
         <p>
-          com.puppycrawl.tools.checkstyle.checks.coding
+            Use this fully qualified class name in configuration when an exact class reference is
+            required.
         </p>
       </subsection>
 

--- a/src/site/xdoc/checks/coding/whenshouldbeused.xml.template
+++ b/src/site/xdoc/checks/coding/whenshouldbeused.xml.template
@@ -57,9 +57,11 @@
         </p>
       </subsection>
 
-      <subsection name="Package" id="WhenShouldBeUsed_Package">
+      <subsection name="Fully Qualified Name" id="Fully_Qualified_Name">
+        <p>com.puppycrawl.tools.checkstyle.checks.coding.WhenShouldBeUsedCheck</p>
         <p>
-          com.puppycrawl.tools.checkstyle.checks.coding
+            Use this fully qualified class name in configuration when an exact class reference is
+            required.
         </p>
       </subsection>
 

--- a/src/site/xdoc/checks/design/designforextension.xml
+++ b/src/site/xdoc/checks/design/designforextension.xml
@@ -397,9 +397,11 @@ public abstract class Example4 {
         </p>
       </subsection>
 
-      <subsection name="Package" id="DesignForExtension_Package">
+      <subsection name="Fully Qualified Name" id="Fully_Qualified_Name">
+        <p> com.puppycrawl.tools.checkstyle.checks.design.DesignForExtensionCheck</p>
         <p>
-          com.puppycrawl.tools.checkstyle.checks.design
+          Use this fully qualified class name in configuration when an exact class reference is
+          required.
         </p>
       </subsection>
 

--- a/src/site/xdoc/checks/design/designforextension.xml.template
+++ b/src/site/xdoc/checks/design/designforextension.xml.template
@@ -113,9 +113,11 @@
         </p>
       </subsection>
 
-      <subsection name="Package" id="DesignForExtension_Package">
+      <subsection name="Fully Qualified Name" id="Fully_Qualified_Name">
+        <p> com.puppycrawl.tools.checkstyle.checks.design.DesignForExtensionCheck</p>
         <p>
-          com.puppycrawl.tools.checkstyle.checks.design
+          Use this fully qualified class name in configuration when an exact class reference is
+          required.
         </p>
       </subsection>
 

--- a/src/site/xdoc/checks/design/finalclass.xml
+++ b/src/site/xdoc/checks/design/finalclass.xml
@@ -125,9 +125,11 @@ public class Example1 { // ok, since it has a public constructor
         </p>
       </subsection>
 
-      <subsection name="Package" id="FinalClass_Package">
+      <subsection name="Fully Qualified Name" id="Fully_Qualified_Name">
+        <p> com.puppycrawl.tools.checkstyle.checks.design.FinalClassCheck</p>
         <p>
-          com.puppycrawl.tools.checkstyle.checks.design
+            Use this fully qualified class name in configuration when an exact class reference is
+            required.
         </p>
       </subsection>
 

--- a/src/site/xdoc/checks/design/finalclass.xml.template
+++ b/src/site/xdoc/checks/design/finalclass.xml.template
@@ -59,9 +59,11 @@
         </p>
       </subsection>
 
-      <subsection name="Package" id="FinalClass_Package">
+      <subsection name="Fully Qualified Name" id="Fully_Qualified_Name">
+        <p> com.puppycrawl.tools.checkstyle.checks.design.FinalClassCheck</p>
         <p>
-          com.puppycrawl.tools.checkstyle.checks.design
+            Use this fully qualified class name in configuration when an exact class reference is
+            required.
         </p>
       </subsection>
 

--- a/src/site/xdoc/checks/design/hideutilityclassconstructor.xml
+++ b/src/site/xdoc/checks/design/hideutilityclassconstructor.xml
@@ -199,9 +199,11 @@ class Application2 {
         </p>
       </subsection>
 
-      <subsection name="Package" id="HideUtilityClassConstructor_Package">
+      <subsection name="Fully Qualified Name" id="Fully_Qualified_Name">
+        <p> com.puppycrawl.tools.checkstyle.checks.design.HideUtilityClassConstructorCheck</p>
         <p>
-          com.puppycrawl.tools.checkstyle.checks.design
+            Use this fully qualified class name in configuration when an exact class reference is
+            required.
         </p>
       </subsection>
 

--- a/src/site/xdoc/checks/design/hideutilityclassconstructor.xml.template
+++ b/src/site/xdoc/checks/design/hideutilityclassconstructor.xml.template
@@ -83,9 +83,11 @@
         </p>
       </subsection>
 
-      <subsection name="Package" id="HideUtilityClassConstructor_Package">
+      <subsection name="Fully Qualified Name" id="Fully_Qualified_Name">
+        <p> com.puppycrawl.tools.checkstyle.checks.design.HideUtilityClassConstructorCheck</p>
         <p>
-          com.puppycrawl.tools.checkstyle.checks.design
+            Use this fully qualified class name in configuration when an exact class reference is
+            required.
         </p>
       </subsection>
 

--- a/src/site/xdoc/checks/design/innertypelast.xml
+++ b/src/site/xdoc/checks/design/innertypelast.xml
@@ -73,9 +73,11 @@ class Example1 {
         </p>
       </subsection>
 
-      <subsection name="Package" id="InnerTypeLast_Package">
+      <subsection name="Fully Qualified Name" id="Fully_Qualified_Name">
+        <p> com.puppycrawl.tools.checkstyle.checks.design.InnerTypeLastCheck</p>
         <p>
-          com.puppycrawl.tools.checkstyle.checks.design
+            Use this fully qualified class name in configuration when an exact class reference is
+            required.
         </p>
       </subsection>
 

--- a/src/site/xdoc/checks/design/innertypelast.xml.template
+++ b/src/site/xdoc/checks/design/innertypelast.xml.template
@@ -55,9 +55,11 @@
         </p>
       </subsection>
 
-      <subsection name="Package" id="InnerTypeLast_Package">
+      <subsection name="Fully Qualified Name" id="Fully_Qualified_Name">
+        <p> com.puppycrawl.tools.checkstyle.checks.design.InnerTypeLastCheck</p>
         <p>
-          com.puppycrawl.tools.checkstyle.checks.design
+            Use this fully qualified class name in configuration when an exact class reference is
+            required.
         </p>
       </subsection>
 

--- a/src/site/xdoc/checks/design/interfaceistype.xml
+++ b/src/site/xdoc/checks/design/interfaceistype.xml
@@ -140,9 +140,11 @@ class Example2 {
         </p>
       </subsection>
 
-      <subsection name="Package" id="InterfaceIsType_Package">
+      <subsection name="Fully Qualified Name" id="Fully_Qualified_Name">
+        <p> com.puppycrawl.tools.checkstyle.checks.design.InterfaceIsTypeCheck</p>
         <p>
-          com.puppycrawl.tools.checkstyle.checks.design
+            Use this fully qualified class name in configuration when an exact class reference is
+            required.
         </p>
       </subsection>
 

--- a/src/site/xdoc/checks/design/interfaceistype.xml.template
+++ b/src/site/xdoc/checks/design/interfaceistype.xml.template
@@ -82,9 +82,11 @@
         </p>
       </subsection>
 
-      <subsection name="Package" id="InterfaceIsType_Package">
+      <subsection name="Fully Qualified Name" id="Fully_Qualified_Name">
+        <p> com.puppycrawl.tools.checkstyle.checks.design.InterfaceIsTypeCheck</p>
         <p>
-          com.puppycrawl.tools.checkstyle.checks.design
+            Use this fully qualified class name in configuration when an exact class reference is
+            required.
         </p>
       </subsection>
 

--- a/src/site/xdoc/checks/design/mutableexception.xml
+++ b/src/site/xdoc/checks/design/mutableexception.xml
@@ -231,9 +231,11 @@ class ThirdBadException extends java.lang.Exception {
         </p>
       </subsection>
 
-      <subsection name="Package" id="MutableException_Package">
+      <subsection name="Fully Qualified Name" id="Fully_Qualified_Name">
+        <p> com.puppycrawl.tools.checkstyle.checks.design.MutableExceptionCheck</p>
         <p>
-          com.puppycrawl.tools.checkstyle.checks.design
+            Use this fully qualified class name in configuration when an exact class reference is
+            required.
         </p>
       </subsection>
 

--- a/src/site/xdoc/checks/design/mutableexception.xml.template
+++ b/src/site/xdoc/checks/design/mutableexception.xml.template
@@ -94,9 +94,11 @@
         </p>
       </subsection>
 
-      <subsection name="Package" id="MutableException_Package">
+      <subsection name="Fully Qualified Name" id="Fully_Qualified_Name">
+        <p> com.puppycrawl.tools.checkstyle.checks.design.MutableExceptionCheck</p>
         <p>
-          com.puppycrawl.tools.checkstyle.checks.design
+            Use this fully qualified class name in configuration when an exact class reference is
+            required.
         </p>
       </subsection>
 

--- a/src/site/xdoc/checks/design/onetoplevelclass.xml
+++ b/src/site/xdoc/checks/design/onetoplevelclass.xml
@@ -96,9 +96,11 @@ public class Example3 { // ok, only one top-level class
         </p>
       </subsection>
 
-      <subsection name="Package" id="OneTopLevelClass_Package">
+      <subsection name="Fully Qualified Name" id="Fully_Qualified_Name">
+        <p> com.puppycrawl.tools.checkstyle.checks.design.OneTopLevelClassCheck</p>
         <p>
-          com.puppycrawl.tools.checkstyle.checks.design
+          Use this fully qualified class name in configuration when an exact class reference is
+          required.
         </p>
       </subsection>
 

--- a/src/site/xdoc/checks/design/onetoplevelclass.xml.template
+++ b/src/site/xdoc/checks/design/onetoplevelclass.xml.template
@@ -81,9 +81,11 @@
         </p>
       </subsection>
 
-      <subsection name="Package" id="OneTopLevelClass_Package">
+      <subsection name="Fully Qualified Name" id="Fully_Qualified_Name">
+        <p> com.puppycrawl.tools.checkstyle.checks.design.OneTopLevelClassCheck</p>
         <p>
-          com.puppycrawl.tools.checkstyle.checks.design
+          Use this fully qualified class name in configuration when an exact class reference is
+          required.
         </p>
       </subsection>
 

--- a/src/site/xdoc/checks/design/sealedshouldhavepermitslist.xml
+++ b/src/site/xdoc/checks/design/sealedshouldhavepermitslist.xml
@@ -89,9 +89,11 @@ class CorrectedExample1 {
         </p>
       </subsection>
 
-      <subsection name="Package" id="SealedShouldHavePermitsList_Package">
+      <subsection name="Fully Qualified Name" id="Fully_Qualified_Name">
+        <p> com.puppycrawl.tools.checkstyle.checks.design.SealedShouldHavePermitsListCheck</p>
         <p>
-          com.puppycrawl.tools.checkstyle.checks.design
+            Use this fully qualified class name in configuration when an exact class reference is
+            required.
         </p>
       </subsection>
 

--- a/src/site/xdoc/checks/design/sealedshouldhavepermitslist.xml.template
+++ b/src/site/xdoc/checks/design/sealedshouldhavepermitslist.xml.template
@@ -57,9 +57,11 @@
         </p>
       </subsection>
 
-      <subsection name="Package" id="SealedShouldHavePermitsList_Package">
+      <subsection name="Fully Qualified Name" id="Fully_Qualified_Name">
+        <p> com.puppycrawl.tools.checkstyle.checks.design.SealedShouldHavePermitsListCheck</p>
         <p>
-          com.puppycrawl.tools.checkstyle.checks.design
+            Use this fully qualified class name in configuration when an exact class reference is
+            required.
         </p>
       </subsection>
 

--- a/src/site/xdoc/checks/design/throwscount.xml
+++ b/src/site/xdoc/checks/design/throwscount.xml
@@ -219,9 +219,11 @@ public class Example3 {
         </p>
       </subsection>
 
-      <subsection name="Package" id="ThrowsCount_Package">
+      <subsection name="Fully Qualified Name" id="Fully_Qualified_Name">
+        <p> com.puppycrawl.tools.checkstyle.checks.design.ThrowsCountCheck</p>
         <p>
-          com.puppycrawl.tools.checkstyle.checks.design
+          Use this fully qualified class name in configuration when an exact class reference is
+          required.
         </p>
       </subsection>
 

--- a/src/site/xdoc/checks/design/throwscount.xml.template
+++ b/src/site/xdoc/checks/design/throwscount.xml.template
@@ -99,9 +99,11 @@
         </p>
       </subsection>
 
-      <subsection name="Package" id="ThrowsCount_Package">
+      <subsection name="Fully Qualified Name" id="Fully_Qualified_Name">
+        <p> com.puppycrawl.tools.checkstyle.checks.design.ThrowsCountCheck</p>
         <p>
-          com.puppycrawl.tools.checkstyle.checks.design
+          Use this fully qualified class name in configuration when an exact class reference is
+          required.
         </p>
       </subsection>
 

--- a/src/site/xdoc/checks/design/visibilitymodifier.xml
+++ b/src/site/xdoc/checks/design/visibilitymodifier.xml
@@ -789,9 +789,11 @@ class Example12 {
         </p>
       </subsection>
 
-      <subsection name="Package" id="VisibilityModifier_Package">
+      <subsection name="Fully Qualified Name" id="Fully_Qualified_Name">
+        <p> com.puppycrawl.tools.checkstyle.checks.design.VisibilityModifierCheck</p>
         <p>
-          com.puppycrawl.tools.checkstyle.checks.design
+            Use this fully qualified class name in configuration when an exact class reference is
+            required.
         </p>
       </subsection>
 

--- a/src/site/xdoc/checks/design/visibilitymodifier.xml.template
+++ b/src/site/xdoc/checks/design/visibilitymodifier.xml.template
@@ -246,9 +246,11 @@
         </p>
       </subsection>
 
-      <subsection name="Package" id="VisibilityModifier_Package">
+      <subsection name="Fully Qualified Name" id="Fully_Qualified_Name">
+        <p> com.puppycrawl.tools.checkstyle.checks.design.VisibilityModifierCheck</p>
         <p>
-          com.puppycrawl.tools.checkstyle.checks.design
+            Use this fully qualified class name in configuration when an exact class reference is
+            required.
         </p>
       </subsection>
 

--- a/src/site/xdoc/checks/header/header.xml
+++ b/src/site/xdoc/checks/header/header.xml
@@ -220,9 +220,13 @@ public class Example4 { }
         </p>
       </subsection>
 
-      <subsection name="Package" id="Header_Package">
-        <p> com.puppycrawl.tools.checkstyle.checks.header </p>
-      </subsection>
+       <subsection name="Fully Qualified Name" id="Fully_Qualified_Name">
+         <p> com.puppycrawl.tools.checkstyle.checks.header.HeaderCheck</p>
+         <p>
+              Use this fully qualified class name in configuration when an exact class reference is
+              required.
+         </p>
+       </subsection>
 
       <subsection name="Parent Module" id="Header_Parent_Module">
         <p>

--- a/src/site/xdoc/checks/header/header.xml.template
+++ b/src/site/xdoc/checks/header/header.xml.template
@@ -125,9 +125,13 @@
         </p>
       </subsection>
 
-      <subsection name="Package" id="Header_Package">
-        <p> com.puppycrawl.tools.checkstyle.checks.header </p>
-      </subsection>
+       <subsection name="Fully Qualified Name" id="Fully_Qualified_Name">
+         <p> com.puppycrawl.tools.checkstyle.checks.header.HeaderCheck</p>
+         <p>
+              Use this fully qualified class name in configuration when an exact class reference is
+              required.
+         </p>
+       </subsection>
 
       <subsection name="Parent Module" id="Header_Parent_Module">
         <macro name="parent-module">

--- a/src/site/xdoc/checks/header/multifileregexpheader.xml
+++ b/src/site/xdoc/checks/header/multifileregexpheader.xml
@@ -202,9 +202,11 @@ public class Example4 { }
         </p>
       </subsection>
 
-      <subsection name="Package" id="MultiFileRegexpHeader_Package">
+      <subsection name="Fully Qualified Name" id="Fully_Qualified_Name">
+        <p> com.puppycrawl.tools.checkstyle.checks.header.MultiFileRegexpHeaderCheck</p>
         <p>
-          com.puppycrawl.tools.checkstyle.checks.header
+          Use this fully qualified class name in configuration when an exact class reference is
+          required.
         </p>
       </subsection>
 

--- a/src/site/xdoc/checks/header/multifileregexpheader.xml.template
+++ b/src/site/xdoc/checks/header/multifileregexpheader.xml.template
@@ -143,9 +143,11 @@
         </p>
       </subsection>
 
-      <subsection name="Package" id="MultiFileRegexpHeader_Package">
+      <subsection name="Fully Qualified Name" id="Fully_Qualified_Name">
+        <p> com.puppycrawl.tools.checkstyle.checks.header.MultiFileRegexpHeaderCheck</p>
         <p>
-          com.puppycrawl.tools.checkstyle.checks.header
+          Use this fully qualified class name in configuration when an exact class reference is
+          required.
         </p>
       </subsection>
 

--- a/src/site/xdoc/checks/header/regexpheader.xml
+++ b/src/site/xdoc/checks/header/regexpheader.xml
@@ -220,9 +220,11 @@ public class Example4 { }
         </p>
       </subsection>
 
-      <subsection name="Package" id="RegexpHeader_Package">
+      <subsection name="Fully Qualified Name" id="Fully_Qualified_Name">
+        <p> com.puppycrawl.tools.checkstyle.checks.header.RegexpHeaderCheck</p>
         <p>
-          com.puppycrawl.tools.checkstyle.checks.header
+          Use this fully qualified class name in configuration when an exact class reference is
+          required.
         </p>
       </subsection>
 

--- a/src/site/xdoc/checks/header/regexpheader.xml.template
+++ b/src/site/xdoc/checks/header/regexpheader.xml.template
@@ -130,9 +130,11 @@
         </p>
       </subsection>
 
-      <subsection name="Package" id="RegexpHeader_Package">
+      <subsection name="Fully Qualified Name" id="Fully_Qualified_Name">
+        <p> com.puppycrawl.tools.checkstyle.checks.header.RegexpHeaderCheck</p>
         <p>
-          com.puppycrawl.tools.checkstyle.checks.header
+          Use this fully qualified class name in configuration when an exact class reference is
+          required.
         </p>
       </subsection>
 

--- a/src/site/xdoc/checks/imports/avoidstarimport.xml
+++ b/src/site/xdoc/checks/imports/avoidstarimport.xml
@@ -235,8 +235,12 @@ import java.net.*;
           to learn how to.
         </p>
       </subsection>
-      <subsection name="Package" id="AvoidStarImport_Package">
-        <p> com.puppycrawl.tools.checkstyle.checks.imports </p>
+      <subsection name="Fully Qualified Name" id="Fully_Qualified_Name">
+        <p> com.puppycrawl.tools.checkstyle.checks.imports.AvoidStarImportCheck</p>
+        <p>
+              Use this fully qualified class name in configuration when an exact class reference is
+              required.
+        </p>
       </subsection>
 
       <subsection name="Parent Module" id="AvoidStarImport_Parent_Module">

--- a/src/site/xdoc/checks/imports/avoidstarimport.xml.template
+++ b/src/site/xdoc/checks/imports/avoidstarimport.xml.template
@@ -166,8 +166,12 @@
           to learn how to.
         </p>
       </subsection>
-      <subsection name="Package" id="AvoidStarImport_Package">
-        <p> com.puppycrawl.tools.checkstyle.checks.imports </p>
+      <subsection name="Fully Qualified Name" id="Fully_Qualified_Name">
+        <p> com.puppycrawl.tools.checkstyle.checks.imports.AvoidStarImportCheck</p>
+        <p>
+              Use this fully qualified class name in configuration when an exact class reference is
+              required.
+        </p>
       </subsection>
 
       <subsection name="Parent Module" id="AvoidStarImport_Parent_Module">

--- a/src/site/xdoc/checks/imports/avoidstaticimport.xml
+++ b/src/site/xdoc/checks/imports/avoidstaticimport.xml
@@ -124,8 +124,12 @@ import java.util.*;
         </p>
       </subsection>
 
-      <subsection name="Package" id="AvoidStaticImport_Package">
-        <p> com.puppycrawl.tools.checkstyle.checks.imports </p>
+      <subsection name="Fully Qualified Name" id="Fully_Qualified_Name">
+        <p> com.puppycrawl.tools.checkstyle.checks.imports.AvoidStaticImportCheck</p>
+        <p>
+          Use this fully qualified class name in configuration when an exact class reference is
+          required.
+        </p>
       </subsection>
 
       <subsection name="Parent Module" id="AvoidStaticImport_Parent_Module">

--- a/src/site/xdoc/checks/imports/avoidstaticimport.xml.template
+++ b/src/site/xdoc/checks/imports/avoidstaticimport.xml.template
@@ -90,8 +90,12 @@
         </p>
       </subsection>
 
-      <subsection name="Package" id="AvoidStaticImport_Package">
-        <p> com.puppycrawl.tools.checkstyle.checks.imports </p>
+      <subsection name="Fully Qualified Name" id="Fully_Qualified_Name">
+        <p> com.puppycrawl.tools.checkstyle.checks.imports.AvoidStaticImportCheck</p>
+        <p>
+          Use this fully qualified class name in configuration when an exact class reference is
+          required.
+        </p>
       </subsection>
 
       <subsection name="Parent Module" id="AvoidStaticImport_Parent_Module">

--- a/src/site/xdoc/checks/imports/customimportorder.xml
+++ b/src/site/xdoc/checks/imports/customimportorder.xml
@@ -723,9 +723,11 @@ import java.lang.String;
         </p>
       </subsection>
 
-      <subsection name="Package" id="CustomImportOrder_Package">
+      <subsection name="Fully Qualified Name" id="Fully_Qualified_Name">
+        <p> com.puppycrawl.tools.checkstyle.checks.imports.CustomImportOrderCheck</p>
         <p>
-          com.puppycrawl.tools.checkstyle.checks.imports
+          Use this fully qualified class name in configuration when an exact class reference is
+          required.
         </p>
       </subsection>
 

--- a/src/site/xdoc/checks/imports/customimportorder.xml.template
+++ b/src/site/xdoc/checks/imports/customimportorder.xml.template
@@ -345,9 +345,11 @@
         </p>
       </subsection>
 
-      <subsection name="Package" id="CustomImportOrder_Package">
+      <subsection name="Fully Qualified Name" id="Fully_Qualified_Name">
+        <p> com.puppycrawl.tools.checkstyle.checks.imports.CustomImportOrderCheck</p>
         <p>
-          com.puppycrawl.tools.checkstyle.checks.imports
+          Use this fully qualified class name in configuration when an exact class reference is
+          required.
         </p>
       </subsection>
 

--- a/src/site/xdoc/checks/imports/illegalimport.xml
+++ b/src/site/xdoc/checks/imports/illegalimport.xml
@@ -291,9 +291,11 @@ public class Example6 {}
         </p>
       </subsection>
 
-      <subsection name="Package" id="IllegalImport_Package">
+      <subsection name="Fully Qualified Name" id="Fully_Qualified_Name">
+        <p> com.puppycrawl.tools.checkstyle.checks.imports.IllegalImportCheck</p>
         <p>
-          com.puppycrawl.tools.checkstyle.checks.imports
+          Use this fully qualified class name in configuration when an exact class reference is
+          required.
         </p>
       </subsection>
 

--- a/src/site/xdoc/checks/imports/illegalimport.xml.template
+++ b/src/site/xdoc/checks/imports/illegalimport.xml.template
@@ -190,9 +190,11 @@
         </p>
       </subsection>
 
-      <subsection name="Package" id="IllegalImport_Package">
+      <subsection name="Fully Qualified Name" id="Fully_Qualified_Name">
+        <p> com.puppycrawl.tools.checkstyle.checks.imports.IllegalImportCheck</p>
         <p>
-          com.puppycrawl.tools.checkstyle.checks.imports
+          Use this fully qualified class name in configuration when an exact class reference is
+          required.
         </p>
       </subsection>
 

--- a/src/site/xdoc/checks/imports/importcontrol.xml
+++ b/src/site/xdoc/checks/imports/importcontrol.xml
@@ -907,9 +907,11 @@ public class Example14 {}
         </p>
       </subsection>
 
-      <subsection name="Package" id="ImportControl_Package">
+      <subsection name="Fully Qualified Name" id="Fully_Qualified_Name">
+        <p> com.puppycrawl.tools.checkstyle.checks.imports.ImportControlCheck</p>
         <p>
-          com.puppycrawl.tools.checkstyle.checks.imports
+          Use this fully qualified class name in configuration when an exact class reference is
+          required.
         </p>
       </subsection>
 

--- a/src/site/xdoc/checks/imports/importcontrol.xml.template
+++ b/src/site/xdoc/checks/imports/importcontrol.xml.template
@@ -549,9 +549,11 @@
         </p>
       </subsection>
 
-      <subsection name="Package" id="ImportControl_Package">
+      <subsection name="Fully Qualified Name" id="Fully_Qualified_Name">
+        <p> com.puppycrawl.tools.checkstyle.checks.imports.ImportControlCheck</p>
         <p>
-          com.puppycrawl.tools.checkstyle.checks.imports
+          Use this fully qualified class name in configuration when an exact class reference is
+          required.
         </p>
       </subsection>
 

--- a/src/site/xdoc/checks/imports/importorder.xml
+++ b/src/site/xdoc/checks/imports/importorder.xml
@@ -591,9 +591,11 @@ import static org.apache.commons.lang3.StringUtils.isEmpty;
         </p>
       </subsection>
 
-      <subsection name="Package" id="ImportOrder_Package">
+      <subsection name="Fully Qualified Name" id="Fully_Qualified_Name">
+        <p> com.puppycrawl.tools.checkstyle.checks.imports.ImportOrderCheck</p>
         <p>
-          com.puppycrawl.tools.checkstyle.checks.imports
+          Use this fully qualified class name in configuration when an exact class reference is
+          required.
         </p>
       </subsection>
 

--- a/src/site/xdoc/checks/imports/importorder.xml.template
+++ b/src/site/xdoc/checks/imports/importorder.xml.template
@@ -352,9 +352,11 @@ import static java.lang.Character.UnicodeBlock.BASIC_LATIN => java.lang.Characte
         </p>
       </subsection>
 
-      <subsection name="Package" id="ImportOrder_Package">
+      <subsection name="Fully Qualified Name" id="Fully_Qualified_Name">
+        <p> com.puppycrawl.tools.checkstyle.checks.imports.ImportOrderCheck</p>
         <p>
-          com.puppycrawl.tools.checkstyle.checks.imports
+          Use this fully qualified class name in configuration when an exact class reference is
+          required.
         </p>
       </subsection>
 

--- a/src/site/xdoc/checks/imports/redundantimport.xml
+++ b/src/site/xdoc/checks/imports/redundantimport.xml
@@ -100,9 +100,11 @@ public class Example2{ }
         </p>
       </subsection>
 
-      <subsection name="Package" id="RedundantImport_Package">
+      <subsection name="Fully Qualified Name" id="Fully_Qualified_Name">
+        <p> com.puppycrawl.tools.checkstyle.checks.imports.RedundantImportCheck</p>
         <p>
-          com.puppycrawl.tools.checkstyle.checks.imports
+          Use this fully qualified class name in configuration when an exact class reference is
+          required.
         </p>
       </subsection>
 

--- a/src/site/xdoc/checks/imports/redundantimport.xml.template
+++ b/src/site/xdoc/checks/imports/redundantimport.xml.template
@@ -70,9 +70,11 @@
         </p>
       </subsection>
 
-      <subsection name="Package" id="RedundantImport_Package">
+      <subsection name="Fully Qualified Name" id="Fully_Qualified_Name">
+        <p> com.puppycrawl.tools.checkstyle.checks.imports.RedundantImportCheck</p>
         <p>
-          com.puppycrawl.tools.checkstyle.checks.imports
+          Use this fully qualified class name in configuration when an exact class reference is
+          required.
         </p>
       </subsection>
 

--- a/src/site/xdoc/checks/imports/unusedimports.xml
+++ b/src/site/xdoc/checks/imports/unusedimports.xml
@@ -213,9 +213,11 @@ class Example2{
         </p>
       </subsection>
 
-      <subsection name="Package" id="UnusedImports_Package">
+      <subsection name="Fully Qualified Name" id="Fully_Qualified_Name">
+        <p> com.puppycrawl.tools.checkstyle.checks.imports.UnusedImportsCheck</p>
         <p>
-          com.puppycrawl.tools.checkstyle.checks.imports
+            Use this fully qualified class name in configuration when an exact class reference is
+            required.
         </p>
       </subsection>
 

--- a/src/site/xdoc/checks/imports/unusedimports.xml.template
+++ b/src/site/xdoc/checks/imports/unusedimports.xml.template
@@ -82,9 +82,11 @@
         </p>
       </subsection>
 
-      <subsection name="Package" id="UnusedImports_Package">
+      <subsection name="Fully Qualified Name" id="Fully_Qualified_Name">
+        <p> com.puppycrawl.tools.checkstyle.checks.imports.UnusedImportsCheck</p>
         <p>
-          com.puppycrawl.tools.checkstyle.checks.imports
+            Use this fully qualified class name in configuration when an exact class reference is
+            required.
         </p>
       </subsection>
 

--- a/src/site/xdoc/checks/javadoc/atclauseorder.xml
+++ b/src/site/xdoc/checks/javadoc/atclauseorder.xml
@@ -287,9 +287,11 @@ enum Test3 {}
         </p>
       </subsection>
 
-      <subsection name="Package" id="AtclauseOrder_Package">
+      <subsection name="Fully Qualified Name" id="Fully_Qualified_Name">
+        <p>com.puppycrawl.tools.checkstyle.checks.javadoc.AtclauseOrderCheck</p>
         <p>
-          com.puppycrawl.tools.checkstyle.checks.javadoc
+            Use this fully qualified class name in configuration when an exact class reference is
+            required.
         </p>
       </subsection>
 

--- a/src/site/xdoc/checks/javadoc/atclauseorder.xml.template
+++ b/src/site/xdoc/checks/javadoc/atclauseorder.xml.template
@@ -102,9 +102,11 @@
         </p>
       </subsection>
 
-      <subsection name="Package" id="AtclauseOrder_Package">
+      <subsection name="Fully Qualified Name" id="Fully_Qualified_Name">
+        <p>com.puppycrawl.tools.checkstyle.checks.javadoc.AtclauseOrderCheck</p>
         <p>
-          com.puppycrawl.tools.checkstyle.checks.javadoc
+            Use this fully qualified class name in configuration when an exact class reference is
+            required.
         </p>
       </subsection>
 

--- a/src/site/xdoc/checks/javadoc/invalidjavadocposition.xml
+++ b/src/site/xdoc/checks/javadoc/invalidjavadocposition.xml
@@ -80,9 +80,11 @@ public class Example1 {
         </p>
       </subsection>
 
-      <subsection name="Package" id="InvalidJavadocPosition_Package">
+      <subsection name="Fully Qualified Name" id="Fully_Qualified_Name">
+        <p>com.puppycrawl.tools.checkstyle.checks.javadoc.InvalidJavadocPositionCheck</p>
         <p>
-          com.puppycrawl.tools.checkstyle.checks.javadoc
+              Use this fully qualified class name in configuration when an exact class reference is
+              required.
         </p>
       </subsection>
 

--- a/src/site/xdoc/checks/javadoc/invalidjavadocposition.xml.template
+++ b/src/site/xdoc/checks/javadoc/invalidjavadocposition.xml.template
@@ -66,9 +66,11 @@
         </p>
       </subsection>
 
-      <subsection name="Package" id="InvalidJavadocPosition_Package">
+      <subsection name="Fully Qualified Name" id="Fully_Qualified_Name">
+        <p>com.puppycrawl.tools.checkstyle.checks.javadoc.InvalidJavadocPositionCheck</p>
         <p>
-          com.puppycrawl.tools.checkstyle.checks.javadoc
+              Use this fully qualified class name in configuration when an exact class reference is
+              required.
         </p>
       </subsection>
 

--- a/src/site/xdoc/checks/javadoc/javadocblocktaglocation.xml
+++ b/src/site/xdoc/checks/javadoc/javadocblocktaglocation.xml
@@ -156,9 +156,11 @@
         </p>
       </subsection>
 
-      <subsection name="Package" id="JavadocBlockTagLocation_Package">
+      <subsection name="Fully Qualified Name" id="Fully_Qualified_Name">
+        <p>com.puppycrawl.tools.checkstyle.checks.javadoc.JavadocBlockTagLocationCheck</p>
         <p>
-          com.puppycrawl.tools.checkstyle.checks.javadoc
+              Use this fully qualified class name in configuration when an exact class reference is
+              required.
         </p>
       </subsection>
 

--- a/src/site/xdoc/checks/javadoc/javadocblocktaglocation.xml.template
+++ b/src/site/xdoc/checks/javadoc/javadocblocktaglocation.xml.template
@@ -87,9 +87,11 @@
         </p>
       </subsection>
 
-      <subsection name="Package" id="JavadocBlockTagLocation_Package">
+      <subsection name="Fully Qualified Name" id="Fully_Qualified_Name">
+        <p>com.puppycrawl.tools.checkstyle.checks.javadoc.JavadocBlockTagLocationCheck</p>
         <p>
-          com.puppycrawl.tools.checkstyle.checks.javadoc
+              Use this fully qualified class name in configuration when an exact class reference is
+              required.
         </p>
       </subsection>
 

--- a/src/site/xdoc/checks/javadoc/javadoccontentlocation.xml
+++ b/src/site/xdoc/checks/javadoc/javadoccontentlocation.xml
@@ -200,9 +200,11 @@ class Example2 {
         </p>
       </subsection>
 
-      <subsection name="Package" id="JavadocContentLocation_Package">
+      <subsection name="Fully Qualified Name" id="Fully_Qualified_Name">
+        <p>com.puppycrawl.tools.checkstyle.checks.javadoc.JavadocContentLocationCheck</p>
         <p>
-          com.puppycrawl.tools.checkstyle.checks.javadoc
+              Use this fully qualified class name in configuration when an exact class reference is
+              required.
         </p>
       </subsection>
 

--- a/src/site/xdoc/checks/javadoc/javadoccontentlocation.xml.template
+++ b/src/site/xdoc/checks/javadoc/javadoccontentlocation.xml.template
@@ -95,9 +95,11 @@
         </p>
       </subsection>
 
-      <subsection name="Package" id="JavadocContentLocation_Package">
+      <subsection name="Fully Qualified Name" id="Fully_Qualified_Name">
+        <p>com.puppycrawl.tools.checkstyle.checks.javadoc.JavadocContentLocationCheck</p>
         <p>
-          com.puppycrawl.tools.checkstyle.checks.javadoc
+              Use this fully qualified class name in configuration when an exact class reference is
+              required.
         </p>
       </subsection>
 

--- a/src/site/xdoc/checks/javadoc/javadocleadingasteriskalign.xml
+++ b/src/site/xdoc/checks/javadoc/javadocleadingasteriskalign.xml
@@ -234,9 +234,11 @@ public class Example3 {
         </p>
       </subsection>
 
-      <subsection name="Package" id="JavadocLeadingAsteriskAlign_Package">
+      <subsection name="Fully Qualified Name" id="Fully_Qualified_Name">
+        <p>com.puppycrawl.tools.checkstyle.checks.javadoc.JavadocLeadingAsteriskAlignCheck</p>
         <p>
-          com.puppycrawl.tools.checkstyle.checks.javadoc
+              Use this fully qualified class name in configuration when an exact class reference is
+              required.
         </p>
       </subsection>
 

--- a/src/site/xdoc/checks/javadoc/javadocleadingasteriskalign.xml.template
+++ b/src/site/xdoc/checks/javadoc/javadocleadingasteriskalign.xml.template
@@ -95,9 +95,11 @@
         </p>
       </subsection>
 
-      <subsection name="Package" id="JavadocLeadingAsteriskAlign_Package">
+      <subsection name="Fully Qualified Name" id="Fully_Qualified_Name">
+        <p>com.puppycrawl.tools.checkstyle.checks.javadoc.JavadocLeadingAsteriskAlignCheck</p>
         <p>
-          com.puppycrawl.tools.checkstyle.checks.javadoc
+              Use this fully qualified class name in configuration when an exact class reference is
+              required.
         </p>
       </subsection>
 

--- a/src/site/xdoc/checks/javadoc/javadocmethod.xml
+++ b/src/site/xdoc/checks/javadoc/javadocmethod.xml
@@ -574,9 +574,11 @@ public class Example8 {
         </p>
       </subsection>
 
-      <subsection name="Package" id="JavadocMethod_Package">
+      <subsection name="Fully Qualified Name" id="Fully_Qualified_Name">
+        <p>com.puppycrawl.tools.checkstyle.checks.javadoc.JavadocMethodCheck</p>
         <p>
-          com.puppycrawl.tools.checkstyle.checks.javadoc
+              Use this fully qualified class name in configuration when an exact class reference is
+              required.
         </p>
       </subsection>
 

--- a/src/site/xdoc/checks/javadoc/javadocmethod.xml.template
+++ b/src/site/xdoc/checks/javadoc/javadocmethod.xml.template
@@ -174,9 +174,11 @@
         </p>
       </subsection>
 
-      <subsection name="Package" id="JavadocMethod_Package">
+      <subsection name="Fully Qualified Name" id="Fully_Qualified_Name">
+        <p>com.puppycrawl.tools.checkstyle.checks.javadoc.JavadocMethodCheck</p>
         <p>
-          com.puppycrawl.tools.checkstyle.checks.javadoc
+              Use this fully qualified class name in configuration when an exact class reference is
+              required.
         </p>
       </subsection>
 

--- a/src/site/xdoc/checks/javadoc/javadocmissingleadingasterisk.xml
+++ b/src/site/xdoc/checks/javadoc/javadocmissingleadingasterisk.xml
@@ -135,9 +135,11 @@ class Example1 {}
         </p>
       </subsection>
 
-      <subsection name="Package" id="JavadocMissingLeadingAsterisk_Package">
+      <subsection name="Fully Qualified Name" id="Fully_Qualified_Name">
+        <p>com.puppycrawl.tools.checkstyle.checks.javadoc.JavadocMissingLeadingAsteriskCheck</p>
         <p>
-          com.puppycrawl.tools.checkstyle.checks.javadoc
+              Use this fully qualified class name in configuration when an exact class reference is
+              required.
         </p>
       </subsection>
 

--- a/src/site/xdoc/checks/javadoc/javadocmissingleadingasterisk.xml.template
+++ b/src/site/xdoc/checks/javadoc/javadocmissingleadingasterisk.xml.template
@@ -68,9 +68,11 @@
         </p>
       </subsection>
 
-      <subsection name="Package" id="JavadocMissingLeadingAsterisk_Package">
+      <subsection name="Fully Qualified Name" id="Fully_Qualified_Name">
+        <p>com.puppycrawl.tools.checkstyle.checks.javadoc.JavadocMissingLeadingAsteriskCheck</p>
         <p>
-          com.puppycrawl.tools.checkstyle.checks.javadoc
+              Use this fully qualified class name in configuration when an exact class reference is
+              required.
         </p>
       </subsection>
 

--- a/src/site/xdoc/checks/javadoc/javadocmissingwhitespaceafterasterisk.xml
+++ b/src/site/xdoc/checks/javadoc/javadocmissingwhitespaceafterasterisk.xml
@@ -112,11 +112,13 @@ class Example1 {
         </p>
       </subsection>
 
-      <subsection name="Package" id="JavadocMissingWhitespaceAfterAsterisk_Package">
-        <p>
-          com.puppycrawl.tools.checkstyle.checks.javadoc
-        </p>
-      </subsection>
+  <subsection name="Fully Qualified Name" id="Fully_Qualified_Name">
+    <p>com.puppycrawl.tools.checkstyle.checks.javadoc.JavadocMissingWhitespaceAfterAsteriskCheck</p>
+    <p>
+      Use this fully qualified class name in configuration when an exact class reference is
+      required.
+    </p>
+  </subsection>
 
       <subsection name="Parent Module" id="JavadocMissingWhitespaceAfterAsterisk_Parent_Module">
         <p>

--- a/src/site/xdoc/checks/javadoc/javadocmissingwhitespaceafterasterisk.xml.template
+++ b/src/site/xdoc/checks/javadoc/javadocmissingwhitespaceafterasterisk.xml.template
@@ -68,11 +68,13 @@
         </p>
       </subsection>
 
-      <subsection name="Package" id="JavadocMissingWhitespaceAfterAsterisk_Package">
-        <p>
-          com.puppycrawl.tools.checkstyle.checks.javadoc
-        </p>
-      </subsection>
+  <subsection name="Fully Qualified Name" id="Fully_Qualified_Name">
+    <p>com.puppycrawl.tools.checkstyle.checks.javadoc.JavadocMissingWhitespaceAfterAsteriskCheck</p>
+    <p>
+      Use this fully qualified class name in configuration when an exact class reference is
+      required.
+    </p>
+  </subsection>
 
       <subsection name="Parent Module" id="JavadocMissingWhitespaceAfterAsterisk_Parent_Module">
         <macro name="parent-module">

--- a/src/site/xdoc/checks/javadoc/javadocpackage.xml
+++ b/src/site/xdoc/checks/javadoc/javadocpackage.xml
@@ -158,9 +158,11 @@ public class Example3 { }
         </p>
       </subsection>
 
-      <subsection name="Package" id="JavadocPackage_Package">
+      <subsection name="Fully Qualified Name" id="Fully_Qualified_Name">
+        <p>com.puppycrawl.tools.checkstyle.checks.javadoc.JavadocPackageCheck</p>
         <p>
-          com.puppycrawl.tools.checkstyle.checks.javadoc
+              Use this fully qualified class name in configuration when an exact class reference is
+              required.
         </p>
       </subsection>
 

--- a/src/site/xdoc/checks/javadoc/javadocpackage.xml.template
+++ b/src/site/xdoc/checks/javadoc/javadocpackage.xml.template
@@ -124,9 +124,11 @@
         </p>
       </subsection>
 
-      <subsection name="Package" id="JavadocPackage_Package">
+      <subsection name="Fully Qualified Name" id="Fully_Qualified_Name">
+        <p>com.puppycrawl.tools.checkstyle.checks.javadoc.JavadocPackageCheck</p>
         <p>
-          com.puppycrawl.tools.checkstyle.checks.javadoc
+              Use this fully qualified class name in configuration when an exact class reference is
+              required.
         </p>
       </subsection>
 

--- a/src/site/xdoc/checks/javadoc/javadocparagraph.xml
+++ b/src/site/xdoc/checks/javadoc/javadocparagraph.xml
@@ -274,9 +274,11 @@ public class Example2 {
         </p>
       </subsection>
 
-      <subsection name="Package" id="JavadocParagraph_Package">
+      <subsection name="Fully Qualified Name" id="Fully_Qualified_Name">
+        <p>com.puppycrawl.tools.checkstyle.checks.javadoc.JavadocParagraphCheck</p>
         <p>
-          com.puppycrawl.tools.checkstyle.checks.javadoc
+              Use this fully qualified class name in configuration when an exact class reference is
+              required.
         </p>
       </subsection>
 

--- a/src/site/xdoc/checks/javadoc/javadocparagraph.xml.template
+++ b/src/site/xdoc/checks/javadoc/javadocparagraph.xml.template
@@ -86,9 +86,11 @@
         </p>
       </subsection>
 
-      <subsection name="Package" id="JavadocParagraph_Package">
+      <subsection name="Fully Qualified Name" id="Fully_Qualified_Name">
+        <p>com.puppycrawl.tools.checkstyle.checks.javadoc.JavadocParagraphCheck</p>
         <p>
-          com.puppycrawl.tools.checkstyle.checks.javadoc
+              Use this fully qualified class name in configuration when an exact class reference is
+              required.
         </p>
       </subsection>
 

--- a/src/site/xdoc/checks/javadoc/javadocstyle.xml
+++ b/src/site/xdoc/checks/javadoc/javadocstyle.xml
@@ -736,9 +736,11 @@ public class Example8 {
         </p>
       </subsection>
 
-      <subsection name="Package" id="JavadocStyle_Package">
+      <subsection name="Fully Qualified Name" id="Fully_Qualified_Name">
+        <p>com.puppycrawl.tools.checkstyle.checks.javadoc.JavadocStyleCheck</p>
         <p>
-          com.puppycrawl.tools.checkstyle.checks.javadoc
+              Use this fully qualified class name in configuration when an exact class reference is
+              required.
         </p>
       </subsection>
 

--- a/src/site/xdoc/checks/javadoc/javadocstyle.xml.template
+++ b/src/site/xdoc/checks/javadoc/javadocstyle.xml.template
@@ -177,9 +177,11 @@
         </p>
       </subsection>
 
-      <subsection name="Package" id="JavadocStyle_Package">
+      <subsection name="Fully Qualified Name" id="Fully_Qualified_Name">
+        <p>com.puppycrawl.tools.checkstyle.checks.javadoc.JavadocStyleCheck</p>
         <p>
-          com.puppycrawl.tools.checkstyle.checks.javadoc
+              Use this fully qualified class name in configuration when an exact class reference is
+              required.
         </p>
       </subsection>
 

--- a/src/site/xdoc/checks/javadoc/javadoctagcontinuationindentation.xml
+++ b/src/site/xdoc/checks/javadoc/javadoctagcontinuationindentation.xml
@@ -285,9 +285,11 @@ class Example3 {
         </p>
       </subsection>
 
-      <subsection name="Package" id="JavadocTagContinuationIndentation_Package">
+      <subsection name="Fully Qualified Name" id="Fully_Qualified_Name">
+        <p>com.puppycrawl.tools.checkstyle.checks.javadoc.JavadocTagContinuationIndentationCheck</p>
         <p>
-          com.puppycrawl.tools.checkstyle.checks.javadoc
+          Use this fully qualified class name in configuration when an exact class reference is
+          required.
         </p>
       </subsection>
 

--- a/src/site/xdoc/checks/javadoc/javadoctagcontinuationindentation.xml.template
+++ b/src/site/xdoc/checks/javadoc/javadoctagcontinuationindentation.xml.template
@@ -110,9 +110,11 @@
         </p>
       </subsection>
 
-      <subsection name="Package" id="JavadocTagContinuationIndentation_Package">
+      <subsection name="Fully Qualified Name" id="Fully_Qualified_Name">
+        <p>com.puppycrawl.tools.checkstyle.checks.javadoc.JavadocTagContinuationIndentationCheck</p>
         <p>
-          com.puppycrawl.tools.checkstyle.checks.javadoc
+          Use this fully qualified class name in configuration when an exact class reference is
+          required.
         </p>
       </subsection>
 

--- a/src/site/xdoc/checks/javadoc/javadoctype.xml
+++ b/src/site/xdoc/checks/javadoc/javadoctype.xml
@@ -573,9 +573,11 @@ public class Example8 {
         </p>
       </subsection>
 
-      <subsection name="Package" id="JavadocType_Package">
+      <subsection name="Fully Qualified Name" id="Fully_Qualified_Name">
+        <p>com.puppycrawl.tools.checkstyle.checks.javadoc.JavadocTypeCheck</p>
         <p>
-          com.puppycrawl.tools.checkstyle.checks.javadoc
+          Use this fully qualified class name in configuration when an exact class reference is
+          required.
         </p>
       </subsection>
 

--- a/src/site/xdoc/checks/javadoc/javadoctype.xml.template
+++ b/src/site/xdoc/checks/javadoc/javadoctype.xml.template
@@ -169,9 +169,11 @@
         </p>
       </subsection>
 
-      <subsection name="Package" id="JavadocType_Package">
+      <subsection name="Fully Qualified Name" id="Fully_Qualified_Name">
+        <p>com.puppycrawl.tools.checkstyle.checks.javadoc.JavadocTypeCheck</p>
         <p>
-          com.puppycrawl.tools.checkstyle.checks.javadoc
+          Use this fully qualified class name in configuration when an exact class reference is
+          required.
         </p>
       </subsection>
 

--- a/src/site/xdoc/checks/javadoc/javadocvariable.xml
+++ b/src/site/xdoc/checks/javadoc/javadocvariable.xml
@@ -285,9 +285,11 @@ public class Example5 {
         </p>
       </subsection>
 
-      <subsection name="Package" id="JavadocVariable_Package">
+      <subsection name="Fully Qualified Name" id="Fully_Qualified_Name">
+        <p>com.puppycrawl.tools.checkstyle.checks.javadoc.JavadocVariableCheck</p>
         <p>
-          com.puppycrawl.tools.checkstyle.checks.javadoc
+            Use this fully qualified class name in configuration when an exact class reference is
+            required.
         </p>
       </subsection>
 

--- a/src/site/xdoc/checks/javadoc/javadocvariable.xml.template
+++ b/src/site/xdoc/checks/javadoc/javadocvariable.xml.template
@@ -139,9 +139,11 @@
         </p>
       </subsection>
 
-      <subsection name="Package" id="JavadocVariable_Package">
+      <subsection name="Fully Qualified Name" id="Fully_Qualified_Name">
+        <p>com.puppycrawl.tools.checkstyle.checks.javadoc.JavadocVariableCheck</p>
         <p>
-          com.puppycrawl.tools.checkstyle.checks.javadoc
+            Use this fully qualified class name in configuration when an exact class reference is
+            required.
         </p>
       </subsection>
 

--- a/src/site/xdoc/checks/javadoc/missingjavadocmethod.xml
+++ b/src/site/xdoc/checks/javadoc/missingjavadocmethod.xml
@@ -433,9 +433,11 @@ public class Example7 {
         </p>
       </subsection>
 
-      <subsection name="Package" id="MissingJavadocMethod_Package">
+      <subsection name="Fully Qualified Name" id="Fully_Qualified_Name">
+        <p>com.puppycrawl.tools.checkstyle.checks.javadoc.MissingJavadocMethodCheck</p>
         <p>
-          com.puppycrawl.tools.checkstyle.checks.javadoc
+              Use this fully qualified class name in configuration when an exact class reference is
+              required.
         </p>
       </subsection>
 

--- a/src/site/xdoc/checks/javadoc/missingjavadocmethod.xml.template
+++ b/src/site/xdoc/checks/javadoc/missingjavadocmethod.xml.template
@@ -161,9 +161,11 @@
         </p>
       </subsection>
 
-      <subsection name="Package" id="MissingJavadocMethod_Package">
+      <subsection name="Fully Qualified Name" id="Fully_Qualified_Name">
+        <p>com.puppycrawl.tools.checkstyle.checks.javadoc.MissingJavadocMethodCheck</p>
         <p>
-          com.puppycrawl.tools.checkstyle.checks.javadoc
+              Use this fully qualified class name in configuration when an exact class reference is
+              required.
         </p>
       </subsection>
 

--- a/src/site/xdoc/checks/javadoc/missingjavadocpackage.xml
+++ b/src/site/xdoc/checks/javadoc/missingjavadocpackage.xml
@@ -79,9 +79,11 @@ package com.puppycrawl.tools.checkstyle.checks.javadoc.missingjavadocpackage.noj
         </p>
       </subsection>
 
-      <subsection name="Package" id="MissingJavadocPackage_Package">
+      <subsection name="Fully Qualified Name" id="Fully_Qualified_Name">
+        <p>com.puppycrawl.tools.checkstyle.checks.javadoc.MissingJavadocPackageCheck</p>
         <p>
-          com.puppycrawl.tools.checkstyle.checks.javadoc
+              Use this fully qualified class name in configuration when an exact class reference is
+              required.
         </p>
       </subsection>
 

--- a/src/site/xdoc/checks/javadoc/missingjavadocpackage.xml.template
+++ b/src/site/xdoc/checks/javadoc/missingjavadocpackage.xml.template
@@ -61,9 +61,11 @@
         </p>
       </subsection>
 
-      <subsection name="Package" id="MissingJavadocPackage_Package">
+      <subsection name="Fully Qualified Name" id="Fully_Qualified_Name">
+        <p>com.puppycrawl.tools.checkstyle.checks.javadoc.MissingJavadocPackageCheck</p>
         <p>
-          com.puppycrawl.tools.checkstyle.checks.javadoc
+              Use this fully qualified class name in configuration when an exact class reference is
+              required.
         </p>
       </subsection>
 

--- a/src/site/xdoc/checks/javadoc/missingjavadoctype.xml
+++ b/src/site/xdoc/checks/javadoc/missingjavadoctype.xml
@@ -245,9 +245,11 @@ class Example5 {
         </p>
       </subsection>
 
-      <subsection name="Package" id="MissingJavadocType_Package">
+      <subsection name="Fully Qualified Name" id="Fully_Qualified_Name">
+        <p>com.puppycrawl.tools.checkstyle.checks.javadoc.MissingJavadocTypeCheck</p>
         <p>
-          com.puppycrawl.tools.checkstyle.checks.javadoc
+            Use this fully qualified class name in configuration when an exact class reference is
+            required.
         </p>
       </subsection>
 

--- a/src/site/xdoc/checks/javadoc/missingjavadoctype.xml.template
+++ b/src/site/xdoc/checks/javadoc/missingjavadoctype.xml.template
@@ -131,9 +131,11 @@
         </p>
       </subsection>
 
-      <subsection name="Package" id="MissingJavadocType_Package">
+      <subsection name="Fully Qualified Name" id="Fully_Qualified_Name">
+        <p>com.puppycrawl.tools.checkstyle.checks.javadoc.MissingJavadocTypeCheck</p>
         <p>
-          com.puppycrawl.tools.checkstyle.checks.javadoc
+            Use this fully qualified class name in configuration when an exact class reference is
+            required.
         </p>
       </subsection>
 

--- a/src/site/xdoc/checks/javadoc/nonemptyatclausedescription.xml
+++ b/src/site/xdoc/checks/javadoc/nonemptyatclausedescription.xml
@@ -178,9 +178,11 @@ class Example2 {
         </p>
       </subsection>
 
-      <subsection name="Package" id="NonEmptyAtclauseDescription_Package">
+      <subsection name="Fully Qualified Name" id="Fully_Qualified_Name">
+        <p>com.puppycrawl.tools.checkstyle.checks.javadoc.NonEmptyAtclauseDescriptionCheck</p>
         <p>
-          com.puppycrawl.tools.checkstyle.checks.javadoc
+              Use this fully qualified class name in configuration when an exact class reference is
+              required.
         </p>
       </subsection>
 

--- a/src/site/xdoc/checks/javadoc/nonemptyatclausedescription.xml.template
+++ b/src/site/xdoc/checks/javadoc/nonemptyatclausedescription.xml.template
@@ -88,9 +88,11 @@
         </p>
       </subsection>
 
-      <subsection name="Package" id="NonEmptyAtclauseDescription_Package">
+      <subsection name="Fully Qualified Name" id="Fully_Qualified_Name">
+        <p>com.puppycrawl.tools.checkstyle.checks.javadoc.NonEmptyAtclauseDescriptionCheck</p>
         <p>
-          com.puppycrawl.tools.checkstyle.checks.javadoc
+              Use this fully qualified class name in configuration when an exact class reference is
+              required.
         </p>
       </subsection>
 

--- a/src/site/xdoc/checks/javadoc/requireemptylinebeforeblocktaggroup.xml
+++ b/src/site/xdoc/checks/javadoc/requireemptylinebeforeblocktaggroup.xml
@@ -111,11 +111,13 @@ class Example1 {
         </p>
       </subsection>
 
-      <subsection name="Package" id="RequireEmptyLineBeforeBlockTagGroup_Package">
-        <p>
-          com.puppycrawl.tools.checkstyle.checks.javadoc
-        </p>
-      </subsection>
+  <subsection name="Fully Qualified Name" id="Fully_Qualified_Name">
+    <p>com.puppycrawl.tools.checkstyle.checks.javadoc.RequireEmptyLineBeforeBlockTagGroupCheck</p>
+    <p>
+       Use this fully qualified class name in configuration when an exact class reference is
+       required.
+    </p>
+  </subsection>
 
       <subsection name="Parent Module" id="RequireEmptyLineBeforeBlockTagGroup_Parent_Module">
         <p>

--- a/src/site/xdoc/checks/javadoc/requireemptylinebeforeblocktaggroup.xml.template
+++ b/src/site/xdoc/checks/javadoc/requireemptylinebeforeblocktaggroup.xml.template
@@ -72,11 +72,13 @@
         </p>
       </subsection>
 
-      <subsection name="Package" id="RequireEmptyLineBeforeBlockTagGroup_Package">
-        <p>
-          com.puppycrawl.tools.checkstyle.checks.javadoc
-        </p>
-      </subsection>
+  <subsection name="Fully Qualified Name" id="Fully_Qualified_Name">
+    <p>com.puppycrawl.tools.checkstyle.checks.javadoc.RequireEmptyLineBeforeBlockTagGroupCheck</p>
+    <p>
+       Use this fully qualified class name in configuration when an exact class reference is
+       required.
+    </p>
+  </subsection>
 
       <subsection name="Parent Module" id="RequireEmptyLineBeforeBlockTagGroup_Parent_Module">
         <macro name="parent-module">

--- a/src/site/xdoc/checks/javadoc/singlelinejavadoc.xml
+++ b/src/site/xdoc/checks/javadoc/singlelinejavadoc.xml
@@ -288,9 +288,11 @@ public class Example4 {
         </p>
       </subsection>
 
-      <subsection name="Package" id="SingleLineJavadoc_Package">
+      <subsection name="Fully Qualified Name" id="Fully_Qualified_Name">
+        <p>com.puppycrawl.tools.checkstyle.checks.javadoc.SingleLineJavadocCheck</p>
         <p>
-          com.puppycrawl.tools.checkstyle.checks.javadoc
+            Use this fully qualified class name in configuration when an exact class reference is
+            required.
         </p>
       </subsection>
 

--- a/src/site/xdoc/checks/javadoc/singlelinejavadoc.xml.template
+++ b/src/site/xdoc/checks/javadoc/singlelinejavadoc.xml.template
@@ -118,9 +118,11 @@
         </p>
       </subsection>
 
-      <subsection name="Package" id="SingleLineJavadoc_Package">
+      <subsection name="Fully Qualified Name" id="Fully_Qualified_Name">
+        <p>com.puppycrawl.tools.checkstyle.checks.javadoc.SingleLineJavadocCheck</p>
         <p>
-          com.puppycrawl.tools.checkstyle.checks.javadoc
+            Use this fully qualified class name in configuration when an exact class reference is
+            required.
         </p>
       </subsection>
 

--- a/src/site/xdoc/checks/javadoc/summaryjavadoc.xml
+++ b/src/site/xdoc/checks/javadoc/summaryjavadoc.xml
@@ -301,9 +301,11 @@ class Example3 {
         </p>
       </subsection>
 
-      <subsection name="Package" id="SummaryJavadoc_Package">
+      <subsection name="Fully Qualified Name" id="Fully_Qualified_Name">
+        <p>com.puppycrawl.tools.checkstyle.checks.javadoc.SummaryJavadocCheck</p>
         <p>
-          com.puppycrawl.tools.checkstyle.checks.javadoc
+              Use this fully qualified class name in configuration when an exact class reference is
+              required.
         </p>
       </subsection>
 

--- a/src/site/xdoc/checks/javadoc/summaryjavadoc.xml.template
+++ b/src/site/xdoc/checks/javadoc/summaryjavadoc.xml.template
@@ -98,9 +98,11 @@
         </p>
       </subsection>
 
-      <subsection name="Package" id="SummaryJavadoc_Package">
+      <subsection name="Fully Qualified Name" id="Fully_Qualified_Name">
+        <p>com.puppycrawl.tools.checkstyle.checks.javadoc.SummaryJavadocCheck</p>
         <p>
-          com.puppycrawl.tools.checkstyle.checks.javadoc
+              Use this fully qualified class name in configuration when an exact class reference is
+              required.
         </p>
       </subsection>
 

--- a/src/site/xdoc/checks/javadoc/writetag.xml
+++ b/src/site/xdoc/checks/javadoc/writetag.xml
@@ -311,9 +311,11 @@ public class Example5 {
         </p>
       </subsection>
 
-      <subsection name="Package" id="WriteTag_Package">
+      <subsection name="Fully Qualified Name" id="Fully_Qualified_Name">
+        <p>com.puppycrawl.tools.checkstyle.checks.javadoc.WriteTagCheck</p>
         <p>
-          com.puppycrawl.tools.checkstyle.checks.javadoc
+          Use this fully qualified class name in configuration when an exact class reference is
+          required.
         </p>
       </subsection>
 

--- a/src/site/xdoc/checks/javadoc/writetag.xml.template
+++ b/src/site/xdoc/checks/javadoc/writetag.xml.template
@@ -135,9 +135,11 @@
         </p>
       </subsection>
 
-      <subsection name="Package" id="WriteTag_Package">
+      <subsection name="Fully Qualified Name" id="Fully_Qualified_Name">
+        <p>com.puppycrawl.tools.checkstyle.checks.javadoc.WriteTagCheck</p>
         <p>
-          com.puppycrawl.tools.checkstyle.checks.javadoc
+          Use this fully qualified class name in configuration when an exact class reference is
+          required.
         </p>
       </subsection>
 

--- a/src/site/xdoc/checks/metrics/booleanexpressioncomplexity.xml
+++ b/src/site/xdoc/checks/metrics/booleanexpressioncomplexity.xml
@@ -209,9 +209,11 @@ public class Example3
         </p>
       </subsection>
 
-      <subsection name="Package" id="BooleanExpressionComplexity_Package">
+      <subsection name="Fully Qualified Name" id="Fully_Qualified_Name">
+        <p> com.puppycrawl.tools.checkstyle.checks.metrics.BooleanExpressionComplexityCheck</p>
         <p>
-          com.puppycrawl.tools.checkstyle.checks.metrics
+            Use this fully qualified class name in configuration when an exact class reference is
+            required.
         </p>
       </subsection>
 

--- a/src/site/xdoc/checks/metrics/booleanexpressioncomplexity.xml.template
+++ b/src/site/xdoc/checks/metrics/booleanexpressioncomplexity.xml.template
@@ -94,9 +94,11 @@
         </p>
       </subsection>
 
-      <subsection name="Package" id="BooleanExpressionComplexity_Package">
+      <subsection name="Fully Qualified Name" id="Fully_Qualified_Name">
+        <p> com.puppycrawl.tools.checkstyle.checks.metrics.BooleanExpressionComplexityCheck</p>
         <p>
-          com.puppycrawl.tools.checkstyle.checks.metrics
+            Use this fully qualified class name in configuration when an exact class reference is
+            required.
         </p>
       </subsection>
 

--- a/src/site/xdoc/checks/metrics/classdataabstractioncoupling.xml
+++ b/src/site/xdoc/checks/metrics/classdataabstractioncoupling.xml
@@ -506,9 +506,11 @@ class Example11 {
         </p>
       </subsection>
 
-      <subsection name="Package" id="ClassDataAbstractionCoupling_Package">
+      <subsection name="Fully Qualified Name" id="Fully_Qualified_Name">
+        <p> com.puppycrawl.tools.checkstyle.checks.metrics.ClassDataAbstractionCouplingCheck</p>
         <p>
-          com.puppycrawl.tools.checkstyle.checks.metrics
+            Use this fully qualified class name in configuration when an exact class reference is
+            required.
         </p>
       </subsection>
 

--- a/src/site/xdoc/checks/metrics/classdataabstractioncoupling.xml.template
+++ b/src/site/xdoc/checks/metrics/classdataabstractioncoupling.xml.template
@@ -255,9 +255,11 @@
         </p>
       </subsection>
 
-      <subsection name="Package" id="ClassDataAbstractionCoupling_Package">
+      <subsection name="Fully Qualified Name" id="Fully_Qualified_Name">
+        <p> com.puppycrawl.tools.checkstyle.checks.metrics.ClassDataAbstractionCouplingCheck</p>
         <p>
-          com.puppycrawl.tools.checkstyle.checks.metrics
+            Use this fully qualified class name in configuration when an exact class reference is
+            required.
         </p>
       </subsection>
 

--- a/src/site/xdoc/checks/metrics/classfanoutcomplexity.xml
+++ b/src/site/xdoc/checks/metrics/classfanoutcomplexity.xml
@@ -353,9 +353,11 @@ class Time6 {}
         </p>
       </subsection>
 
-      <subsection name="Package" id="ClassFanOutComplexity_Package">
+      <subsection name="Fully Qualified Name" id="Fully_Qualified_Name">
+        <p> com.puppycrawl.tools.checkstyle.checks.metrics.ClassFanOutComplexityCheck</p>
         <p>
-          com.puppycrawl.tools.checkstyle.checks.metrics
+          Use this fully qualified class name in configuration when an exact class reference is
+          required.
         </p>
       </subsection>
 

--- a/src/site/xdoc/checks/metrics/classfanoutcomplexity.xml.template
+++ b/src/site/xdoc/checks/metrics/classfanoutcomplexity.xml.template
@@ -201,9 +201,11 @@
         </p>
       </subsection>
 
-      <subsection name="Package" id="ClassFanOutComplexity_Package">
+      <subsection name="Fully Qualified Name" id="Fully_Qualified_Name">
+        <p> com.puppycrawl.tools.checkstyle.checks.metrics.ClassFanOutComplexityCheck</p>
         <p>
-          com.puppycrawl.tools.checkstyle.checks.metrics
+          Use this fully qualified class name in configuration when an exact class reference is
+          required.
         </p>
       </subsection>
 

--- a/src/site/xdoc/checks/metrics/cyclomaticcomplexity.xml
+++ b/src/site/xdoc/checks/metrics/cyclomaticcomplexity.xml
@@ -381,9 +381,11 @@ class Example3 {
         </p>
       </subsection>
 
-      <subsection name="Package" id="CyclomaticComplexity_Package">
+      <subsection name="Fully Qualified Name" id="Fully_Qualified_Name">
+        <p> com.puppycrawl.tools.checkstyle.checks.metrics.CyclomaticComplexityCheck</p>
         <p>
-          com.puppycrawl.tools.checkstyle.checks.metrics
+            Use this fully qualified class name in configuration when an exact class reference is
+            required.
         </p>
       </subsection>
 

--- a/src/site/xdoc/checks/metrics/cyclomaticcomplexity.xml.template
+++ b/src/site/xdoc/checks/metrics/cyclomaticcomplexity.xml.template
@@ -98,9 +98,11 @@
         </p>
       </subsection>
 
-      <subsection name="Package" id="CyclomaticComplexity_Package">
+      <subsection name="Fully Qualified Name" id="Fully_Qualified_Name">
+        <p> com.puppycrawl.tools.checkstyle.checks.metrics.CyclomaticComplexityCheck</p>
         <p>
-          com.puppycrawl.tools.checkstyle.checks.metrics
+            Use this fully qualified class name in configuration when an exact class reference is
+            required.
         </p>
       </subsection>
 

--- a/src/site/xdoc/checks/metrics/javancss.xml
+++ b/src/site/xdoc/checks/metrics/javancss.xml
@@ -357,9 +357,11 @@ public class Example5 {
         </p>
       </subsection>
 
-      <subsection name="Package" id="JavaNCSS_Package">
+      <subsection name="Fully Qualified Name" id="Fully_Qualified_Name">
+        <p> com.puppycrawl.tools.checkstyle.checks.metrics.JavaNCSSCheck</p>
         <p>
-          com.puppycrawl.tools.checkstyle.checks.metrics
+            Use this fully qualified class name in configuration when an exact class reference is
+            required.
         </p>
       </subsection>
 

--- a/src/site/xdoc/checks/metrics/javancss.xml.template
+++ b/src/site/xdoc/checks/metrics/javancss.xml.template
@@ -124,9 +124,11 @@
         </p>
       </subsection>
 
-      <subsection name="Package" id="JavaNCSS_Package">
+      <subsection name="Fully Qualified Name" id="Fully_Qualified_Name">
+        <p> com.puppycrawl.tools.checkstyle.checks.metrics.JavaNCSSCheck</p>
         <p>
-          com.puppycrawl.tools.checkstyle.checks.metrics
+            Use this fully qualified class name in configuration when an exact class reference is
+            required.
         </p>
       </subsection>
 

--- a/src/site/xdoc/checks/metrics/npathcomplexity.xml
+++ b/src/site/xdoc/checks/metrics/npathcomplexity.xml
@@ -254,9 +254,11 @@ public abstract class Example2 {
         </p>
       </subsection>
 
-      <subsection name="Package" id="NPathComplexity_Package">
+      <subsection name="Fully Qualified Name" id="Fully_Qualified_Name">
+        <p> com.puppycrawl.tools.checkstyle.checks.metrics.NPathComplexityCheck</p>
         <p>
-          com.puppycrawl.tools.checkstyle.checks.metrics
+            Use this fully qualified class name in configuration when an exact class reference is
+            required.
         </p>
       </subsection>
 

--- a/src/site/xdoc/checks/metrics/npathcomplexity.xml.template
+++ b/src/site/xdoc/checks/metrics/npathcomplexity.xml.template
@@ -82,9 +82,11 @@
         </p>
       </subsection>
 
-      <subsection name="Package" id="NPathComplexity_Package">
+      <subsection name="Fully Qualified Name" id="Fully_Qualified_Name">
+        <p> com.puppycrawl.tools.checkstyle.checks.metrics.NPathComplexityCheck</p>
         <p>
-          com.puppycrawl.tools.checkstyle.checks.metrics
+            Use this fully qualified class name in configuration when an exact class reference is
+            required.
         </p>
       </subsection>
 

--- a/src/site/xdoc/checks/misc/arraytypestyle.xml
+++ b/src/site/xdoc/checks/misc/arraytypestyle.xml
@@ -138,9 +138,11 @@ public class Example2 {
         </p>
       </subsection>
 
-      <subsection name="Package" id="ArrayTypeStyle_Package">
+      <subsection name="Fully Qualified Name" id="Fully_Qualified_Name">
+        <p> com.puppycrawl.tools.checkstyle.checks.ArrayTypeStyleCheck</p>
         <p>
-          com.puppycrawl.tools.checkstyle.checks
+          Use this fully qualified class name in configuration when an exact class reference is
+          required.
         </p>
       </subsection>
 

--- a/src/site/xdoc/checks/misc/arraytypestyle.xml.template
+++ b/src/site/xdoc/checks/misc/arraytypestyle.xml.template
@@ -90,9 +90,11 @@
         </p>
       </subsection>
 
-      <subsection name="Package" id="ArrayTypeStyle_Package">
+      <subsection name="Fully Qualified Name" id="Fully_Qualified_Name">
+        <p> com.puppycrawl.tools.checkstyle.checks.ArrayTypeStyleCheck</p>
         <p>
-          com.puppycrawl.tools.checkstyle.checks
+          Use this fully qualified class name in configuration when an exact class reference is
+          required.
         </p>
       </subsection>
 

--- a/src/site/xdoc/checks/misc/avoidescapedunicodecharacters.xml
+++ b/src/site/xdoc/checks/misc/avoidescapedunicodecharacters.xml
@@ -263,9 +263,11 @@ public class Example5 {
         </p>
       </subsection>
 
-      <subsection name="Package" id="AvoidEscapedUnicodeCharacters_Package">
+      <subsection name="Fully Qualified Name" id="Fully_Qualified_Name">
+        <p> com.puppycrawl.tools.checkstyle.checks.AvoidEscapedUnicodeCharactersCheck</p>
         <p>
-          com.puppycrawl.tools.checkstyle.checks
+            Use this fully qualified class name in configuration when an exact class reference is
+            required.
         </p>
       </subsection>
 

--- a/src/site/xdoc/checks/misc/avoidescapedunicodecharacters.xml.template
+++ b/src/site/xdoc/checks/misc/avoidescapedunicodecharacters.xml.template
@@ -134,9 +134,11 @@
         </p>
       </subsection>
 
-      <subsection name="Package" id="AvoidEscapedUnicodeCharacters_Package">
+      <subsection name="Fully Qualified Name" id="Fully_Qualified_Name">
+        <p> com.puppycrawl.tools.checkstyle.checks.AvoidEscapedUnicodeCharactersCheck</p>
         <p>
-          com.puppycrawl.tools.checkstyle.checks
+            Use this fully qualified class name in configuration when an exact class reference is
+            required.
         </p>
       </subsection>
 

--- a/src/site/xdoc/checks/misc/commentsindentation.xml
+++ b/src/site/xdoc/checks/misc/commentsindentation.xml
@@ -306,9 +306,11 @@ public class Example8 {
         </p>
       </subsection>
 
-      <subsection name="Package" id="CommentsIndentation_Package">
+      <subsection name="Fully Qualified Name" id="Fully_Qualified_Name">
+        <p>com.puppycrawl.tools.checkstyle.checks.indentation.CommentsIndentationCheck</p>
         <p>
-          com.puppycrawl.tools.checkstyle.checks.indentation
+          Use this fully qualified class name in configuration when an exact class reference is
+          required.
         </p>
       </subsection>
 

--- a/src/site/xdoc/checks/misc/commentsindentation.xml.template
+++ b/src/site/xdoc/checks/misc/commentsindentation.xml.template
@@ -146,9 +146,11 @@
         </p>
       </subsection>
 
-      <subsection name="Package" id="CommentsIndentation_Package">
+      <subsection name="Fully Qualified Name" id="Fully_Qualified_Name">
+        <p>com.puppycrawl.tools.checkstyle.checks.indentation.CommentsIndentationCheck</p>
         <p>
-          com.puppycrawl.tools.checkstyle.checks.indentation
+          Use this fully qualified class name in configuration when an exact class reference is
+          required.
         </p>
       </subsection>
 

--- a/src/site/xdoc/checks/misc/descendanttoken.xml
+++ b/src/site/xdoc/checks/misc/descendanttoken.xml
@@ -994,9 +994,11 @@ class Example17 {
         </p>
       </subsection>
 
-      <subsection name="Package" id="DescendantToken_Package">
+      <subsection name="Fully Qualified Name" id="Fully_Qualified_Name">
+        <p>com.puppycrawl.tools.checkstyle.checks.DescendantTokenCheck</p>
         <p>
-          com.puppycrawl.tools.checkstyle.checks
+            Use this fully qualified class name in configuration when an exact class reference is
+            required.
         </p>
       </subsection>
 

--- a/src/site/xdoc/checks/misc/descendanttoken.xml.template
+++ b/src/site/xdoc/checks/misc/descendanttoken.xml.template
@@ -354,9 +354,11 @@
         </p>
       </subsection>
 
-      <subsection name="Package" id="DescendantToken_Package">
+      <subsection name="Fully Qualified Name" id="Fully_Qualified_Name">
+        <p>com.puppycrawl.tools.checkstyle.checks.DescendantTokenCheck</p>
         <p>
-          com.puppycrawl.tools.checkstyle.checks
+            Use this fully qualified class name in configuration when an exact class reference is
+            required.
         </p>
       </subsection>
 

--- a/src/site/xdoc/checks/misc/finalparameters.xml
+++ b/src/site/xdoc/checks/misc/finalparameters.xml
@@ -242,9 +242,11 @@ public class Example4 {
         </p>
       </subsection>
 
-      <subsection name="Package" id="FinalParameters_Package">
+      <subsection name="Fully Qualified Name" id="Fully_Qualified_Name">
+        <p>com.puppycrawl.tools.checkstyle.checks.FinalParametersCheck</p>
         <p>
-          com.puppycrawl.tools.checkstyle.checks
+              Use this fully qualified class name in configuration when an exact class reference is
+              required.
         </p>
       </subsection>
 

--- a/src/site/xdoc/checks/misc/finalparameters.xml.template
+++ b/src/site/xdoc/checks/misc/finalparameters.xml.template
@@ -123,9 +123,11 @@
         </p>
       </subsection>
 
-      <subsection name="Package" id="FinalParameters_Package">
+      <subsection name="Fully Qualified Name" id="Fully_Qualified_Name">
+        <p>com.puppycrawl.tools.checkstyle.checks.FinalParametersCheck</p>
         <p>
-          com.puppycrawl.tools.checkstyle.checks
+              Use this fully qualified class name in configuration when an exact class reference is
+              required.
         </p>
       </subsection>
 

--- a/src/site/xdoc/checks/misc/hexliteralcase.xml
+++ b/src/site/xdoc/checks/misc/hexliteralcase.xml
@@ -99,8 +99,12 @@ class Example1 {
         </p>
       </subsection>
 
-      <subsection name="Package" id="HexLiteralCase_Package">
-        <p> com.puppycrawl.tools.checkstyle.checks </p>
+      <subsection name="Fully Qualified Name" id="Fully_Qualified_Name">
+        <p>com.puppycrawl.tools.checkstyle.checks.HexLiteralCaseCheck</p>
+        <p>
+            Use this fully qualified class name in configuration when an exact class reference is
+            required.
+        </p>
       </subsection>
 
       <subsection name="Parent Module" id="HexLiteralCase_Parent_Module">

--- a/src/site/xdoc/checks/misc/hexliteralcase.xml.template
+++ b/src/site/xdoc/checks/misc/hexliteralcase.xml.template
@@ -55,8 +55,12 @@
         </p>
       </subsection>
 
-      <subsection name="Package" id="HexLiteralCase_Package">
-        <p> com.puppycrawl.tools.checkstyle.checks </p>
+      <subsection name="Fully Qualified Name" id="Fully_Qualified_Name">
+        <p>com.puppycrawl.tools.checkstyle.checks.HexLiteralCaseCheck</p>
+        <p>
+            Use this fully qualified class name in configuration when an exact class reference is
+            required.
+        </p>
       </subsection>
 
       <subsection name="Parent Module" id="HexLiteralCase_Parent_Module">

--- a/src/site/xdoc/checks/misc/indentation.xml
+++ b/src/site/xdoc/checks/misc/indentation.xml
@@ -387,9 +387,11 @@ class Example4 {
         </p>
       </subsection>
 
-      <subsection name="Package" id="Indentation_Package">
+      <subsection name="Fully Qualified Name" id="Fully_Qualified_Name">
+        <p>com.puppycrawl.tools.checkstyle.checks.indentation.IndentationCheck</p>
         <p>
-          com.puppycrawl.tools.checkstyle.checks.indentation
+              Use this fully qualified class name in configuration when an exact class reference is
+              required.
         </p>
       </subsection>
 

--- a/src/site/xdoc/checks/misc/indentation.xml.template
+++ b/src/site/xdoc/checks/misc/indentation.xml.template
@@ -115,9 +115,11 @@
         </p>
       </subsection>
 
-      <subsection name="Package" id="Indentation_Package">
+      <subsection name="Fully Qualified Name" id="Fully_Qualified_Name">
+        <p>com.puppycrawl.tools.checkstyle.checks.indentation.IndentationCheck</p>
         <p>
-          com.puppycrawl.tools.checkstyle.checks.indentation
+              Use this fully qualified class name in configuration when an exact class reference is
+              required.
         </p>
       </subsection>
 

--- a/src/site/xdoc/checks/misc/lineending.xml
+++ b/src/site/xdoc/checks/misc/lineending.xml
@@ -141,9 +141,11 @@ public class Example3 {  // ␊ // violation 'Expected line ending for file is C
         </p>
       </subsection>
 
-      <subsection name="Package" id="LineEnding_Package">
+      <subsection name="Fully Qualified Name" id="Fully_Qualified_Name">
+        <p>com.puppycrawl.tools.checkstyle.checks.LineEndingCheck</p>
         <p>
-          com.puppycrawl.tools.checkstyle.checks
+            Use this fully qualified class name in configuration when an exact class reference is
+            required.
         </p>
       </subsection>
 

--- a/src/site/xdoc/checks/misc/lineending.xml.template
+++ b/src/site/xdoc/checks/misc/lineending.xml.template
@@ -101,9 +101,11 @@
         </p>
       </subsection>
 
-      <subsection name="Package" id="LineEnding_Package">
+      <subsection name="Fully Qualified Name" id="Fully_Qualified_Name">
+        <p>com.puppycrawl.tools.checkstyle.checks.LineEndingCheck</p>
         <p>
-          com.puppycrawl.tools.checkstyle.checks
+            Use this fully qualified class name in configuration when an exact class reference is
+            required.
         </p>
       </subsection>
 

--- a/src/site/xdoc/checks/misc/newlineatendoffile.xml
+++ b/src/site/xdoc/checks/misc/newlineatendoffile.xml
@@ -203,9 +203,11 @@ Sample txt file. // ok, this file is not specified in the config.
         </p>
       </subsection>
 
-      <subsection name="Package" id="NewlineAtEndOfFile_Package">
+      <subsection name="Fully Qualified Name" id="Fully_Qualified_Name">
+        <p>com.puppycrawl.tools.checkstyle.checks.NewlineAtEndOfFileCheck</p>
         <p>
-          com.puppycrawl.tools.checkstyle.checks
+              Use this fully qualified class name in configuration when an exact class reference is
+              required.
         </p>
       </subsection>
 

--- a/src/site/xdoc/checks/misc/newlineatendoffile.xml.template
+++ b/src/site/xdoc/checks/misc/newlineatendoffile.xml.template
@@ -126,9 +126,11 @@
         </p>
       </subsection>
 
-      <subsection name="Package" id="NewlineAtEndOfFile_Package">
+      <subsection name="Fully Qualified Name" id="Fully_Qualified_Name">
+        <p>com.puppycrawl.tools.checkstyle.checks.NewlineAtEndOfFileCheck</p>
         <p>
-          com.puppycrawl.tools.checkstyle.checks
+              Use this fully qualified class name in configuration when an exact class reference is
+              required.
         </p>
       </subsection>
 

--- a/src/site/xdoc/checks/misc/nocodeinfile.xml
+++ b/src/site/xdoc/checks/misc/nocodeinfile.xml
@@ -82,9 +82,11 @@
         </p>
       </subsection>
 
-      <subsection name="Package" id="NoCodeInFile_Package">
+      <subsection name="Fully Qualified Name" id="Fully_Qualified_Name">
+        <p>com.puppycrawl.tools.checkstyle.checks.NoCodeInFileCheck</p>
         <p>
-          com.puppycrawl.tools.checkstyle.checks
+              Use this fully qualified class name in configuration when an exact class reference is
+              required.
         </p>
       </subsection>
 

--- a/src/site/xdoc/checks/misc/nocodeinfile.xml.template
+++ b/src/site/xdoc/checks/misc/nocodeinfile.xml.template
@@ -62,9 +62,11 @@
         </p>
       </subsection>
 
-      <subsection name="Package" id="NoCodeInFile_Package">
+      <subsection name="Fully Qualified Name" id="Fully_Qualified_Name">
+        <p>com.puppycrawl.tools.checkstyle.checks.NoCodeInFileCheck</p>
         <p>
-          com.puppycrawl.tools.checkstyle.checks
+              Use this fully qualified class name in configuration when an exact class reference is
+              required.
         </p>
       </subsection>
 

--- a/src/site/xdoc/checks/misc/numericalprefixesinfixessuffixescharactercase.xml
+++ b/src/site/xdoc/checks/misc/numericalprefixesinfixessuffixescharactercase.xml
@@ -110,9 +110,13 @@ public class Example1 {
         </p>
       </subsection>
 
-      <subsection name="Package" id="NumericalPrefixesInfixesSuffixesCharacterCase_Package">
-        <p> com.puppycrawl.tools.checkstyle.checks </p>
-      </subsection>
+  <subsection name="Fully Qualified Name" id="Fully_Qualified_Name">
+    <p>com.puppycrawl.tools.checkstyle.checks.NumericalPrefixesInfixesSuffixesCharacterCaseCheck</p>
+    <p>
+      Use this fully qualified class name in configuration when an exact class reference is
+      required.
+    </p>
+  </subsection>
 
       <subsection name="Parent Module"
         id="NumericalPrefixesInfixesSuffixesCharacterCase_Parent_Module">

--- a/src/site/xdoc/checks/misc/numericalprefixesinfixessuffixescharactercase.xml.template
+++ b/src/site/xdoc/checks/misc/numericalprefixesinfixessuffixescharactercase.xml.template
@@ -57,9 +57,13 @@
         </p>
       </subsection>
 
-      <subsection name="Package" id="NumericalPrefixesInfixesSuffixesCharacterCase_Package">
-        <p> com.puppycrawl.tools.checkstyle.checks </p>
-      </subsection>
+  <subsection name="Fully Qualified Name" id="Fully_Qualified_Name">
+    <p>com.puppycrawl.tools.checkstyle.checks.NumericalPrefixesInfixesSuffixesCharacterCaseCheck</p>
+    <p>
+      Use this fully qualified class name in configuration when an exact class reference is
+      required.
+    </p>
+  </subsection>
 
       <subsection name="Parent Module"
         id="NumericalPrefixesInfixesSuffixesCharacterCase_Parent_Module">

--- a/src/site/xdoc/checks/misc/orderedproperties.xml
+++ b/src/site/xdoc/checks/misc/orderedproperties.xml
@@ -121,9 +121,11 @@ key.png=value
         </p>
       </subsection>
 
-      <subsection name="Package" id="OrderedProperties_Package">
+      <subsection name="Fully Qualified Name" id="Fully_Qualified_Name">
+        <p>com.puppycrawl.tools.checkstyle.checks.OrderedPropertiesCheck</p>
         <p>
-          com.puppycrawl.tools.checkstyle.checks
+          Use this fully qualified class name in configuration when an exact class reference is
+          required.
         </p>
       </subsection>
 

--- a/src/site/xdoc/checks/misc/orderedproperties.xml.template
+++ b/src/site/xdoc/checks/misc/orderedproperties.xml.template
@@ -82,9 +82,11 @@
         </p>
       </subsection>
 
-      <subsection name="Package" id="OrderedProperties_Package">
+      <subsection name="Fully Qualified Name" id="Fully_Qualified_Name">
+        <p>com.puppycrawl.tools.checkstyle.checks.OrderedPropertiesCheck</p>
         <p>
-          com.puppycrawl.tools.checkstyle.checks
+          Use this fully qualified class name in configuration when an exact class reference is
+          required.
         </p>
       </subsection>
 

--- a/src/site/xdoc/checks/misc/outertypefilename.xml
+++ b/src/site/xdoc/checks/misc/outertypefilename.xml
@@ -90,9 +90,11 @@ class Example5ButNotSameName {}
         </p>
       </subsection>
 
-      <subsection name="Package" id="OuterTypeFilename_Package">
+      <subsection name="Fully Qualified Name" id="Fully_Qualified_Name">
+        <p>com.puppycrawl.tools.checkstyle.checks.OuterTypeFilenameCheck</p>
         <p>
-          com.puppycrawl.tools.checkstyle.checks
+              Use this fully qualified class name in configuration when an exact class reference is
+              required.
         </p>
       </subsection>
 

--- a/src/site/xdoc/checks/misc/outertypefilename.xml.template
+++ b/src/site/xdoc/checks/misc/outertypefilename.xml.template
@@ -93,9 +93,11 @@
         </p>
       </subsection>
 
-      <subsection name="Package" id="OuterTypeFilename_Package">
+      <subsection name="Fully Qualified Name" id="Fully_Qualified_Name">
+        <p>com.puppycrawl.tools.checkstyle.checks.OuterTypeFilenameCheck</p>
         <p>
-          com.puppycrawl.tools.checkstyle.checks
+              Use this fully qualified class name in configuration when an exact class reference is
+              required.
         </p>
       </subsection>
 

--- a/src/site/xdoc/checks/misc/todocomment.xml
+++ b/src/site/xdoc/checks/misc/todocomment.xml
@@ -133,9 +133,11 @@ public class Example2 {
         </p>
       </subsection>
 
-      <subsection name="Package" id="TodoComment_Package">
+      <subsection name="Fully Qualified Name" id="Fully_Qualified_Name">
+        <p>com.puppycrawl.tools.checkstyle.checks.TodoCommentCheck</p>
         <p>
-          com.puppycrawl.tools.checkstyle.checks
+            Use this fully qualified class name in configuration when an exact class reference is
+            required.
         </p>
       </subsection>
 

--- a/src/site/xdoc/checks/misc/todocomment.xml.template
+++ b/src/site/xdoc/checks/misc/todocomment.xml.template
@@ -98,9 +98,11 @@
         </p>
       </subsection>
 
-      <subsection name="Package" id="TodoComment_Package">
+      <subsection name="Fully Qualified Name" id="Fully_Qualified_Name">
+        <p>com.puppycrawl.tools.checkstyle.checks.TodoCommentCheck</p>
         <p>
-          com.puppycrawl.tools.checkstyle.checks
+            Use this fully qualified class name in configuration when an exact class reference is
+            required.
         </p>
       </subsection>
 

--- a/src/site/xdoc/checks/misc/trailingcomment.xml
+++ b/src/site/xdoc/checks/misc/trailingcomment.xml
@@ -307,9 +307,11 @@ public class Example6 {
         </p>
       </subsection>
 
-      <subsection name="Package" id="TrailingComment_Package">
+      <subsection name="Fully Qualified Name" id="Fully_Qualified_Name">
+        <p>com.puppycrawl.tools.checkstyle.checks.TrailingCommentCheck</p>
         <p>
-          com.puppycrawl.tools.checkstyle.checks
+              Use this fully qualified class name in configuration when an exact class reference is
+              required.
         </p>
       </subsection>
 

--- a/src/site/xdoc/checks/misc/trailingcomment.xml.template
+++ b/src/site/xdoc/checks/misc/trailingcomment.xml.template
@@ -161,9 +161,11 @@
         </p>
       </subsection>
 
-      <subsection name="Package" id="TrailingComment_Package">
+      <subsection name="Fully Qualified Name" id="Fully_Qualified_Name">
+        <p>com.puppycrawl.tools.checkstyle.checks.TrailingCommentCheck</p>
         <p>
-          com.puppycrawl.tools.checkstyle.checks
+              Use this fully qualified class name in configuration when an exact class reference is
+              required.
         </p>
       </subsection>
 

--- a/src/site/xdoc/checks/misc/translation.xml
+++ b/src/site/xdoc/checks/misc/translation.xml
@@ -230,9 +230,11 @@ messages_home.translations // violation,
         </p>
       </subsection>
 
-      <subsection name="Package" id="Translation_Package">
+      <subsection name="Fully Qualified Name" id="Fully_Qualified_Name">
+        <p>com.puppycrawl.tools.checkstyle.checks.TranslationCheck</p>
         <p>
-          com.puppycrawl.tools.checkstyle.checks
+              Use this fully qualified class name in configuration when an exact class reference is
+              required.
         </p>
       </subsection>
 

--- a/src/site/xdoc/checks/misc/translation.xml.template
+++ b/src/site/xdoc/checks/misc/translation.xml.template
@@ -168,9 +168,11 @@ messages_home.translations
         </p>
       </subsection>
 
-      <subsection name="Package" id="Translation_Package">
+      <subsection name="Fully Qualified Name" id="Fully_Qualified_Name">
+        <p>com.puppycrawl.tools.checkstyle.checks.TranslationCheck</p>
         <p>
-          com.puppycrawl.tools.checkstyle.checks
+              Use this fully qualified class name in configuration when an exact class reference is
+              required.
         </p>
       </subsection>
 

--- a/src/site/xdoc/checks/misc/uncommentedmain.xml
+++ b/src/site/xdoc/checks/misc/uncommentedmain.xml
@@ -149,9 +149,11 @@ record MyRecord2() {
         </p>
       </subsection>
 
-      <subsection name="Package" id="UncommentedMain_Package">
+      <subsection name="Fully Qualified Name" id="Fully_Qualified_Name">
+        <p>com.puppycrawl.tools.checkstyle.checks.UncommentedMainCheck</p>
         <p>
-          com.puppycrawl.tools.checkstyle.checks
+            Use this fully qualified class name in configuration when an exact class reference is
+            required.
         </p>
       </subsection>
 

--- a/src/site/xdoc/checks/misc/uncommentedmain.xml.template
+++ b/src/site/xdoc/checks/misc/uncommentedmain.xml.template
@@ -79,9 +79,11 @@
         </p>
       </subsection>
 
-      <subsection name="Package" id="UncommentedMain_Package">
+      <subsection name="Fully Qualified Name" id="Fully_Qualified_Name">
+        <p>com.puppycrawl.tools.checkstyle.checks.UncommentedMainCheck</p>
         <p>
-          com.puppycrawl.tools.checkstyle.checks
+            Use this fully qualified class name in configuration when an exact class reference is
+            required.
         </p>
       </subsection>
 

--- a/src/site/xdoc/checks/misc/uniqueproperties.xml
+++ b/src/site/xdoc/checks/misc/uniqueproperties.xml
@@ -119,9 +119,11 @@ key.one=54
         </p>
       </subsection>
 
-      <subsection name="Package" id="UniqueProperties_Package">
+      <subsection name="Fully Qualified Name" id="Fully_Qualified_Name">
+        <p>com.puppycrawl.tools.checkstyle.checks.UniquePropertiesCheck</p>
         <p>
-          com.puppycrawl.tools.checkstyle.checks
+          Use this fully qualified class name in configuration when an exact class reference is
+          required.
         </p>
       </subsection>
 

--- a/src/site/xdoc/checks/misc/uniqueproperties.xml.template
+++ b/src/site/xdoc/checks/misc/uniqueproperties.xml.template
@@ -91,9 +91,11 @@
         </p>
       </subsection>
 
-      <subsection name="Package" id="UniqueProperties_Package">
+      <subsection name="Fully Qualified Name" id="Fully_Qualified_Name">
+        <p>com.puppycrawl.tools.checkstyle.checks.UniquePropertiesCheck</p>
         <p>
-          com.puppycrawl.tools.checkstyle.checks
+          Use this fully qualified class name in configuration when an exact class reference is
+          required.
         </p>
       </subsection>
 

--- a/src/site/xdoc/checks/misc/upperell.xml
+++ b/src/site/xdoc/checks/misc/upperell.xml
@@ -75,9 +75,11 @@ class Example1 {
         </p>
       </subsection>
 
-      <subsection name="Package" id="UpperEll_Package">
+      <subsection name="Fully Qualified Name" id="Fully_Qualified_Name">
+        <p>com.puppycrawl.tools.checkstyle.checks.UpperEllCheck</p>
         <p>
-          com.puppycrawl.tools.checkstyle.checks
+          Use this fully qualified class name in configuration when an exact class reference is
+          required.
         </p>
       </subsection>
 

--- a/src/site/xdoc/checks/misc/upperell.xml.template
+++ b/src/site/xdoc/checks/misc/upperell.xml.template
@@ -63,9 +63,11 @@
         </p>
       </subsection>
 
-      <subsection name="Package" id="UpperEll_Package">
+      <subsection name="Fully Qualified Name" id="Fully_Qualified_Name">
+        <p>com.puppycrawl.tools.checkstyle.checks.UpperEllCheck</p>
         <p>
-          com.puppycrawl.tools.checkstyle.checks
+          Use this fully qualified class name in configuration when an exact class reference is
+          required.
         </p>
       </subsection>
 

--- a/src/site/xdoc/checks/modifier/classmemberimpliedmodifier.xml
+++ b/src/site/xdoc/checks/modifier/classmemberimpliedmodifier.xml
@@ -276,8 +276,12 @@ public final class Example4 {
         </p>
       </subsection>
 
-      <subsection name="Package" id="ClassMemberImpliedModifier_Package">
-        <p> com.puppycrawl.tools.checkstyle.checks.modifier </p>
+      <subsection name="Fully Qualified Name" id="Fully_Qualified_Name">
+        <p> com.puppycrawl.tools.checkstyle.checks.modifier.ClassMemberImpliedModifierCheck</p>
+        <p>
+            Use this fully qualified class name in configuration when an exact class reference is
+            required.
+        </p>
       </subsection>
 
       <subsection name="Parent Module" id="ClassMemberImpliedModifier_Parent_Module">

--- a/src/site/xdoc/checks/modifier/classmemberimpliedmodifier.xml.template
+++ b/src/site/xdoc/checks/modifier/classmemberimpliedmodifier.xml.template
@@ -123,8 +123,12 @@
         </p>
       </subsection>
 
-      <subsection name="Package" id="ClassMemberImpliedModifier_Package">
-        <p> com.puppycrawl.tools.checkstyle.checks.modifier </p>
+      <subsection name="Fully Qualified Name" id="Fully_Qualified_Name">
+        <p> com.puppycrawl.tools.checkstyle.checks.modifier.ClassMemberImpliedModifierCheck</p>
+        <p>
+            Use this fully qualified class name in configuration when an exact class reference is
+            required.
+        </p>
       </subsection>
 
       <subsection name="Parent Module" id="ClassMemberImpliedModifier_Parent_Module">

--- a/src/site/xdoc/checks/modifier/interfacememberimpliedmodifier.xml
+++ b/src/site/xdoc/checks/modifier/interfacememberimpliedmodifier.xml
@@ -352,8 +352,12 @@ public interface Example4 {
         </p>
       </subsection>
 
-      <subsection name="Package" id="InterfaceMemberImpliedModifier_Package">
-        <p> com.puppycrawl.tools.checkstyle.checks.modifier </p>
+      <subsection name="Fully Qualified Name" id="Fully_Qualified_Name">
+        <p> com.puppycrawl.tools.checkstyle.checks.modifier.InterfaceMemberImpliedModifierCheck</p>
+        <p>
+          Use this fully qualified class name in configuration when an exact class reference is
+          required.
+        </p>
       </subsection>
 
       <subsection name="Parent Module" id="InterfaceMemberImpliedModifier_Parent_Module">

--- a/src/site/xdoc/checks/modifier/interfacememberimpliedmodifier.xml.template
+++ b/src/site/xdoc/checks/modifier/interfacememberimpliedmodifier.xml.template
@@ -130,8 +130,12 @@
         </p>
       </subsection>
 
-      <subsection name="Package" id="InterfaceMemberImpliedModifier_Package">
-        <p> com.puppycrawl.tools.checkstyle.checks.modifier </p>
+      <subsection name="Fully Qualified Name" id="Fully_Qualified_Name">
+        <p> com.puppycrawl.tools.checkstyle.checks.modifier.InterfaceMemberImpliedModifierCheck</p>
+        <p>
+          Use this fully qualified class name in configuration when an exact class reference is
+          required.
+        </p>
       </subsection>
 
       <subsection name="Parent Module" id="InterfaceMemberImpliedModifier_Parent_Module">

--- a/src/site/xdoc/checks/modifier/modifierorder.xml
+++ b/src/site/xdoc/checks/modifier/modifierorder.xml
@@ -111,8 +111,12 @@ public class Example1 {
         </p>
       </subsection>
 
-      <subsection name="Package" id="ModifierOrder_Package">
-        <p> com.puppycrawl.tools.checkstyle.checks.modifier </p>
+      <subsection name="Fully Qualified Name" id="Fully_Qualified_Name">
+        <p> com.puppycrawl.tools.checkstyle.checks.modifier.ModifierOrderCheck</p>
+        <p>
+            Use this fully qualified class name in configuration when an exact class reference is
+            required.
+        </p>
       </subsection>
 
       <subsection name="Parent Module" id="ModifierOrder_Parent_Module">

--- a/src/site/xdoc/checks/modifier/modifierorder.xml.template
+++ b/src/site/xdoc/checks/modifier/modifierorder.xml.template
@@ -61,8 +61,12 @@
         </p>
       </subsection>
 
-      <subsection name="Package" id="ModifierOrder_Package">
-        <p> com.puppycrawl.tools.checkstyle.checks.modifier </p>
+      <subsection name="Fully Qualified Name" id="Fully_Qualified_Name">
+        <p> com.puppycrawl.tools.checkstyle.checks.modifier.ModifierOrderCheck</p>
+        <p>
+            Use this fully qualified class name in configuration when an exact class reference is
+            required.
+        </p>
       </subsection>
 
       <subsection name="Parent Module" id="ModifierOrder_Parent_Module">

--- a/src/site/xdoc/checks/modifier/redundantmodifier.xml
+++ b/src/site/xdoc/checks/modifier/redundantmodifier.xml
@@ -392,8 +392,12 @@ public class Example3 {
         </p>
       </subsection>
 
-      <subsection name="Package" id="RedundantModifier_Package">
-        <p> com.puppycrawl.tools.checkstyle.checks.modifier </p>
+      <subsection name="Fully Qualified Name" id="Fully_Qualified_Name">
+        <p> com.puppycrawl.tools.checkstyle.checks.modifier.RedundantModifierCheck</p>
+        <p>
+          Use this fully qualified class name in configuration when an exact class reference is
+          required.
+        </p>
       </subsection>
 
       <subsection name="Parent Module" id="RedundantModifier_Parent_Module">

--- a/src/site/xdoc/checks/modifier/redundantmodifier.xml.template
+++ b/src/site/xdoc/checks/modifier/redundantmodifier.xml.template
@@ -101,8 +101,12 @@
         </p>
       </subsection>
 
-      <subsection name="Package" id="RedundantModifier_Package">
-        <p> com.puppycrawl.tools.checkstyle.checks.modifier </p>
+      <subsection name="Fully Qualified Name" id="Fully_Qualified_Name">
+        <p> com.puppycrawl.tools.checkstyle.checks.modifier.RedundantModifierCheck</p>
+        <p>
+          Use this fully qualified class name in configuration when an exact class reference is
+          required.
+        </p>
       </subsection>
 
       <subsection name="Parent Module" id="RedundantModifier_Parent_Module">

--- a/src/site/xdoc/checks/naming/abbreviationaswordinname.xml
+++ b/src/site/xdoc/checks/naming/abbreviationaswordinname.xml
@@ -398,8 +398,12 @@ class Example7 {
         </p>
       </subsection>
 
-      <subsection name="Package" id="AbbreviationAsWordInName_Package">
-        <p> com.puppycrawl.tools.checkstyle.checks.naming </p>
+      <subsection name="Fully Qualified Name" id="Fully_Qualified_Name">
+        <p> com.puppycrawl.tools.checkstyle.checks.naming.AbbreviationAsWordInNameCheck</p>
+        <p>
+          Use this fully qualified class name in configuration when an exact class reference is
+          required.
+        </p>
       </subsection>
 
       <subsection name="Parent Module" id="AbbreviationAsWordInName_Parent_Module">

--- a/src/site/xdoc/checks/naming/abbreviationaswordinname.xml.template
+++ b/src/site/xdoc/checks/naming/abbreviationaswordinname.xml.template
@@ -166,8 +166,12 @@
         </p>
       </subsection>
 
-      <subsection name="Package" id="AbbreviationAsWordInName_Package">
-        <p> com.puppycrawl.tools.checkstyle.checks.naming </p>
+      <subsection name="Fully Qualified Name" id="Fully_Qualified_Name">
+        <p> com.puppycrawl.tools.checkstyle.checks.naming.AbbreviationAsWordInNameCheck</p>
+        <p>
+          Use this fully qualified class name in configuration when an exact class reference is
+          required.
+        </p>
       </subsection>
 
       <subsection name="Parent Module" id="AbbreviationAsWordInName_Parent_Module">

--- a/src/site/xdoc/checks/naming/abstractclassname.xml
+++ b/src/site/xdoc/checks/naming/abstractclassname.xml
@@ -184,8 +184,12 @@ class Example4 {
         </p>
       </subsection>
 
-      <subsection name="Package" id="AbstractClassName_Package">
-        <p> com.puppycrawl.tools.checkstyle.checks.naming </p>
+      <subsection name="Fully Qualified Name" id="Fully_Qualified_Name">
+        <p> com.puppycrawl.tools.checkstyle.checks.naming.AbstractClassNameCheck</p>
+        <p>
+            Use this fully qualified class name in configuration when an exact class reference is
+            required.
+        </p>
       </subsection>
 
       <subsection name="Parent Module" id="AbstractClassName_Parent_Module">

--- a/src/site/xdoc/checks/naming/abstractclassname.xml.template
+++ b/src/site/xdoc/checks/naming/abstractclassname.xml.template
@@ -109,8 +109,12 @@
         </p>
       </subsection>
 
-      <subsection name="Package" id="AbstractClassName_Package">
-        <p> com.puppycrawl.tools.checkstyle.checks.naming </p>
+      <subsection name="Fully Qualified Name" id="Fully_Qualified_Name">
+        <p> com.puppycrawl.tools.checkstyle.checks.naming.AbstractClassNameCheck</p>
+        <p>
+            Use this fully qualified class name in configuration when an exact class reference is
+            required.
+        </p>
       </subsection>
 
       <subsection name="Parent Module" id="AbstractClassName_Parent_Module">

--- a/src/site/xdoc/checks/naming/catchparametername.xml
+++ b/src/site/xdoc/checks/naming/catchparametername.xml
@@ -154,8 +154,12 @@ public class Example2 {
         </p>
       </subsection>
 
-      <subsection name="Package" id="CatchParameterName_Package">
-        <p>com.puppycrawl.tools.checkstyle.checks.naming</p>
+      <subsection name="Fully Qualified Name" id="Fully_Qualified_Name">
+        <p> com.puppycrawl.tools.checkstyle.checks.naming.CatchParameterNameCheck</p>
+        <p>
+            Use this fully qualified class name in configuration when an exact class reference is
+            required.
+        </p>
       </subsection>
 
       <subsection name="Parent Module" id="CatchParameterName_Parent_Module">

--- a/src/site/xdoc/checks/naming/catchparametername.xml.template
+++ b/src/site/xdoc/checks/naming/catchparametername.xml.template
@@ -87,8 +87,12 @@
         </p>
       </subsection>
 
-      <subsection name="Package" id="CatchParameterName_Package">
-        <p>com.puppycrawl.tools.checkstyle.checks.naming</p>
+      <subsection name="Fully Qualified Name" id="Fully_Qualified_Name">
+        <p> com.puppycrawl.tools.checkstyle.checks.naming.CatchParameterNameCheck</p>
+        <p>
+            Use this fully qualified class name in configuration when an exact class reference is
+            required.
+        </p>
       </subsection>
 
       <subsection name="Parent Module" id="CatchParameterName_Parent_Module">

--- a/src/site/xdoc/checks/naming/classtypeparametername.xml
+++ b/src/site/xdoc/checks/naming/classtypeparametername.xml
@@ -131,8 +131,12 @@ class Example3 {
         </p>
       </subsection>
 
-      <subsection name="Package" id="ClassTypeParameterName_Package">
-        <p> com.puppycrawl.tools.checkstyle.checks.naming </p>
+      <subsection name="Fully Qualified Name" id="Fully_Qualified_Name">
+        <p> com.puppycrawl.tools.checkstyle.checks.naming.ClassTypeParameterNameCheck</p>
+        <p>
+            Use this fully qualified class name in configuration when an exact class reference is
+            required.
+        </p>
       </subsection>
 
       <subsection name="Parent Module" id="ClassTypeParameterName_Parent_Module">

--- a/src/site/xdoc/checks/naming/classtypeparametername.xml.template
+++ b/src/site/xdoc/checks/naming/classtypeparametername.xml.template
@@ -97,8 +97,12 @@
         </p>
       </subsection>
 
-      <subsection name="Package" id="ClassTypeParameterName_Package">
-        <p> com.puppycrawl.tools.checkstyle.checks.naming </p>
+      <subsection name="Fully Qualified Name" id="Fully_Qualified_Name">
+        <p> com.puppycrawl.tools.checkstyle.checks.naming.ClassTypeParameterNameCheck</p>
+        <p>
+            Use this fully qualified class name in configuration when an exact class reference is
+            required.
+        </p>
       </subsection>
 
       <subsection name="Parent Module" id="ClassTypeParameterName_Parent_Module">

--- a/src/site/xdoc/checks/naming/constantname.xml
+++ b/src/site/xdoc/checks/naming/constantname.xml
@@ -233,8 +233,12 @@ class Example5 {
         </p>
       </subsection>
 
-      <subsection name="Package" id="ConstantName_Package">
-        <p> com.puppycrawl.tools.checkstyle.checks.naming </p>
+      <subsection name="Fully Qualified Name" id="Fully_Qualified_Name">
+        <p> com.puppycrawl.tools.checkstyle.checks.naming.ConstantNameCheck</p>
+        <p>
+            Use this fully qualified class name in configuration when an exact class reference is
+            required.
+        </p>
       </subsection>
 
       <subsection name="Parent Module" id="ConstantName_Parent_Module">

--- a/src/site/xdoc/checks/naming/constantname.xml.template
+++ b/src/site/xdoc/checks/naming/constantname.xml.template
@@ -129,8 +129,12 @@
         </p>
       </subsection>
 
-      <subsection name="Package" id="ConstantName_Package">
-        <p> com.puppycrawl.tools.checkstyle.checks.naming </p>
+      <subsection name="Fully Qualified Name" id="Fully_Qualified_Name">
+        <p> com.puppycrawl.tools.checkstyle.checks.naming.ConstantNameCheck</p>
+        <p>
+            Use this fully qualified class name in configuration when an exact class reference is
+            required.
+        </p>
       </subsection>
 
       <subsection name="Parent Module" id="ConstantName_Parent_Module">

--- a/src/site/xdoc/checks/naming/googlenonconstantfieldname.xml
+++ b/src/site/xdoc/checks/naming/googlenonconstantfieldname.xml
@@ -122,8 +122,12 @@ class Example1 {
         </p>
       </subsection>
 
-      <subsection name="Package" id="GoogleNonConstantFieldName_Package">
-        <p> com.puppycrawl.tools.checkstyle.checks.naming </p>
+      <subsection name="Fully Qualified Name" id="Fully_Qualified_Name">
+        <p> com.puppycrawl.tools.checkstyle.checks.naming.GoogleNonConstantFieldNameCheck</p>
+        <p>
+            Use this fully qualified class name in configuration when an exact class reference is
+            required.
+        </p>
       </subsection>
 
       <subsection name="Parent Module" id="GoogleNonConstantFieldName_Parent_Module">

--- a/src/site/xdoc/checks/naming/googlenonconstantfieldname.xml.template
+++ b/src/site/xdoc/checks/naming/googlenonconstantfieldname.xml.template
@@ -59,8 +59,12 @@
         </p>
       </subsection>
 
-      <subsection name="Package" id="GoogleNonConstantFieldName_Package">
-        <p> com.puppycrawl.tools.checkstyle.checks.naming </p>
+      <subsection name="Fully Qualified Name" id="Fully_Qualified_Name">
+        <p> com.puppycrawl.tools.checkstyle.checks.naming.GoogleNonConstantFieldNameCheck</p>
+        <p>
+            Use this fully qualified class name in configuration when an exact class reference is
+            required.
+        </p>
       </subsection>
 
       <subsection name="Parent Module" id="GoogleNonConstantFieldName_Parent_Module">

--- a/src/site/xdoc/checks/naming/illegalidentifiername.xml
+++ b/src/site/xdoc/checks/naming/illegalidentifiername.xml
@@ -212,8 +212,12 @@ public class Example2 {
         </p>
       </subsection>
 
-      <subsection name="Package" id="IllegalIdentifierName_Package">
-        <p>com.puppycrawl.tools.checkstyle.checks.naming</p>
+      <subsection name="Fully Qualified Name" id="Fully_Qualified_Name">
+        <p> com.puppycrawl.tools.checkstyle.checks.naming.IllegalIdentifierNameCheck</p>
+        <p>
+          Use this fully qualified class name in configuration when an exact class reference is
+          required.
+        </p>
       </subsection>
 
       <subsection name="Parent Module" id="IllegalIdentifierName_Parent_Module">

--- a/src/site/xdoc/checks/naming/illegalidentifiername.xml.template
+++ b/src/site/xdoc/checks/naming/illegalidentifiername.xml.template
@@ -83,8 +83,12 @@
         </p>
       </subsection>
 
-      <subsection name="Package" id="IllegalIdentifierName_Package">
-        <p>com.puppycrawl.tools.checkstyle.checks.naming</p>
+      <subsection name="Fully Qualified Name" id="Fully_Qualified_Name">
+        <p> com.puppycrawl.tools.checkstyle.checks.naming.IllegalIdentifierNameCheck</p>
+        <p>
+          Use this fully qualified class name in configuration when an exact class reference is
+          required.
+        </p>
       </subsection>
 
       <subsection name="Parent Module" id="IllegalIdentifierName_Parent_Module">

--- a/src/site/xdoc/checks/naming/interfacetypeparametername.xml
+++ b/src/site/xdoc/checks/naming/interfacetypeparametername.xml
@@ -105,8 +105,12 @@ class Example2 {
         </p>
       </subsection>
 
-      <subsection name="Package" id="InterfaceTypeParameterName_Package">
-        <p> com.puppycrawl.tools.checkstyle.checks.naming </p>
+      <subsection name="Fully Qualified Name" id="Fully_Qualified_Name">
+        <p> com.puppycrawl.tools.checkstyle.checks.naming.InterfaceTypeParameterNameCheck</p>
+        <p>
+            Use this fully qualified class name in configuration when an exact class reference is
+            required.
+        </p>
       </subsection>
 
       <subsection name="Parent Module" id="InterfaceTypeParameterName_Parent_Module">

--- a/src/site/xdoc/checks/naming/interfacetypeparametername.xml.template
+++ b/src/site/xdoc/checks/naming/interfacetypeparametername.xml.template
@@ -83,8 +83,12 @@
         </p>
       </subsection>
 
-      <subsection name="Package" id="InterfaceTypeParameterName_Package">
-        <p> com.puppycrawl.tools.checkstyle.checks.naming </p>
+      <subsection name="Fully Qualified Name" id="Fully_Qualified_Name">
+        <p> com.puppycrawl.tools.checkstyle.checks.naming.InterfaceTypeParameterNameCheck</p>
+        <p>
+            Use this fully qualified class name in configuration when an exact class reference is
+            required.
+        </p>
       </subsection>
 
       <subsection name="Parent Module" id="InterfaceTypeParameterName_Parent_Module">

--- a/src/site/xdoc/checks/naming/lambdaparametername.xml
+++ b/src/site/xdoc/checks/naming/lambdaparametername.xml
@@ -112,8 +112,12 @@ class Example2 {
         </p>
       </subsection>
 
-      <subsection name="Package" id="LambdaParameterName_Package">
-        <p> com.puppycrawl.tools.checkstyle.checks.naming </p>
+      <subsection name="Fully Qualified Name" id="Fully_Qualified_Name">
+        <p> com.puppycrawl.tools.checkstyle.checks.naming.LambdaParameterNameCheck</p>
+        <p>
+            Use this fully qualified class name in configuration when an exact class reference is
+            required.
+        </p>
       </subsection>
 
       <subsection name="Parent Module" id="LambdaParameterName_Parent_Module">

--- a/src/site/xdoc/checks/naming/lambdaparametername.xml.template
+++ b/src/site/xdoc/checks/naming/lambdaparametername.xml.template
@@ -83,8 +83,12 @@
         </p>
       </subsection>
 
-      <subsection name="Package" id="LambdaParameterName_Package">
-        <p> com.puppycrawl.tools.checkstyle.checks.naming </p>
+      <subsection name="Fully Qualified Name" id="Fully_Qualified_Name">
+        <p> com.puppycrawl.tools.checkstyle.checks.naming.LambdaParameterNameCheck</p>
+        <p>
+            Use this fully qualified class name in configuration when an exact class reference is
+            required.
+        </p>
       </subsection>
 
       <subsection name="Parent Module" id="LambdaParameterName_Parent_Module">

--- a/src/site/xdoc/checks/naming/localfinalvariablename.xml
+++ b/src/site/xdoc/checks/naming/localfinalvariablename.xml
@@ -181,8 +181,12 @@ class Example3 {
         </p>
       </subsection>
 
-      <subsection name="Package" id="LocalFinalVariableName_Package">
-        <p> com.puppycrawl.tools.checkstyle.checks.naming </p>
+      <subsection name="Fully Qualified Name" id="Fully_Qualified_Name">
+        <p> com.puppycrawl.tools.checkstyle.checks.naming.LocalFinalVariableNameCheck</p>
+        <p>
+            Use this fully qualified class name in configuration when an exact class reference is
+            required.
+        </p>
       </subsection>
 
       <subsection name="Parent Module" id="LocalFinalVariableName_Parent_Module">

--- a/src/site/xdoc/checks/naming/localfinalvariablename.xml.template
+++ b/src/site/xdoc/checks/naming/localfinalvariablename.xml.template
@@ -98,8 +98,12 @@
         </p>
       </subsection>
 
-      <subsection name="Package" id="LocalFinalVariableName_Package">
-        <p> com.puppycrawl.tools.checkstyle.checks.naming </p>
+      <subsection name="Fully Qualified Name" id="Fully_Qualified_Name">
+        <p> com.puppycrawl.tools.checkstyle.checks.naming.LocalFinalVariableNameCheck</p>
+        <p>
+            Use this fully qualified class name in configuration when an exact class reference is
+            required.
+        </p>
       </subsection>
 
       <subsection name="Parent Module" id="LocalFinalVariableName_Parent_Module">

--- a/src/site/xdoc/checks/naming/localvariablename.xml
+++ b/src/site/xdoc/checks/naming/localvariablename.xml
@@ -211,8 +211,12 @@ class Example5 {
         </p>
       </subsection>
 
-      <subsection name="Package" id="LocalVariableName_Package">
-        <p> com.puppycrawl.tools.checkstyle.checks.naming </p>
+      <subsection name="Fully Qualified Name" id="Fully_Qualified_Name">
+        <p> com.puppycrawl.tools.checkstyle.checks.naming.LocalVariableNameCheck</p>
+        <p>
+          Use this fully qualified class name in configuration when an exact class reference is
+          required.
+        </p>
       </subsection>
 
       <subsection name="Parent Module" id="LocalVariableName_Parent_Module">

--- a/src/site/xdoc/checks/naming/localvariablename.xml.template
+++ b/src/site/xdoc/checks/naming/localvariablename.xml.template
@@ -128,8 +128,12 @@
         </p>
       </subsection>
 
-      <subsection name="Package" id="LocalVariableName_Package">
-        <p> com.puppycrawl.tools.checkstyle.checks.naming </p>
+      <subsection name="Fully Qualified Name" id="Fully_Qualified_Name">
+        <p> com.puppycrawl.tools.checkstyle.checks.naming.LocalVariableNameCheck</p>
+        <p>
+          Use this fully qualified class name in configuration when an exact class reference is
+          required.
+        </p>
       </subsection>
 
       <subsection name="Parent Module" id="LocalVariableName_Parent_Module">

--- a/src/site/xdoc/checks/naming/membername.xml
+++ b/src/site/xdoc/checks/naming/membername.xml
@@ -179,8 +179,12 @@ class Example3 {
         </p>
       </subsection>
 
-      <subsection name="Package" id="MemberName_Package">
-        <p> com.puppycrawl.tools.checkstyle.checks.naming </p>
+      <subsection name="Fully Qualified Name" id="Fully_Qualified_Name">
+        <p> com.puppycrawl.tools.checkstyle.checks.naming.MemberNameCheck</p>
+        <p>
+          Use this fully qualified class name in configuration when an exact class reference is
+          required.
+        </p>
       </subsection>
 
       <subsection name="Parent Module" id="MemberName_Parent_Module">

--- a/src/site/xdoc/checks/naming/membername.xml.template
+++ b/src/site/xdoc/checks/naming/membername.xml.template
@@ -101,8 +101,12 @@
         </p>
       </subsection>
 
-      <subsection name="Package" id="MemberName_Package">
-        <p> com.puppycrawl.tools.checkstyle.checks.naming </p>
+      <subsection name="Fully Qualified Name" id="Fully_Qualified_Name">
+        <p> com.puppycrawl.tools.checkstyle.checks.naming.MemberNameCheck</p>
+        <p>
+          Use this fully qualified class name in configuration when an exact class reference is
+          required.
+        </p>
       </subsection>
 
       <subsection name="Parent Module" id="MemberName_Parent_Module">

--- a/src/site/xdoc/checks/naming/methodname.xml
+++ b/src/site/xdoc/checks/naming/methodname.xml
@@ -275,8 +275,12 @@ class Example7 {
         </p>
       </subsection>
 
-      <subsection name="Package" id="MethodName_Package">
-        <p> com.puppycrawl.tools.checkstyle.checks.naming </p>
+      <subsection name="Fully Qualified Name" id="Fully_Qualified_Name">
+        <p> com.puppycrawl.tools.checkstyle.checks.naming.MethodNameCheck</p>
+        <p>
+          Use this fully qualified class name in configuration when an exact class reference is
+          required.
+        </p>
       </subsection>
 
       <subsection name="Parent Module" id="MethodName_Parent_Module">

--- a/src/site/xdoc/checks/naming/methodname.xml.template
+++ b/src/site/xdoc/checks/naming/methodname.xml.template
@@ -160,8 +160,12 @@
         </p>
       </subsection>
 
-      <subsection name="Package" id="MethodName_Package">
-        <p> com.puppycrawl.tools.checkstyle.checks.naming </p>
+      <subsection name="Fully Qualified Name" id="Fully_Qualified_Name">
+        <p> com.puppycrawl.tools.checkstyle.checks.naming.MethodNameCheck</p>
+        <p>
+          Use this fully qualified class name in configuration when an exact class reference is
+          required.
+        </p>
       </subsection>
 
       <subsection name="Parent Module" id="MethodName_Parent_Module">

--- a/src/site/xdoc/checks/naming/methodtypeparametername.xml
+++ b/src/site/xdoc/checks/naming/methodtypeparametername.xml
@@ -106,8 +106,12 @@ class Example2 {
         </p>
       </subsection>
 
-      <subsection name="Package" id="MethodTypeParameterName_Package">
-        <p> com.puppycrawl.tools.checkstyle.checks.naming </p>
+      <subsection name="Fully Qualified Name" id="Fully_Qualified_Name">
+        <p> com.puppycrawl.tools.checkstyle.checks.naming.MethodTypeParameterNameCheck</p>
+        <p>
+            Use this fully qualified class name in configuration when an exact class reference is
+            required.
+        </p>
       </subsection>
 
       <subsection name="Parent Module" id="MethodTypeParameterName_Parent_Module">

--- a/src/site/xdoc/checks/naming/methodtypeparametername.xml.template
+++ b/src/site/xdoc/checks/naming/methodtypeparametername.xml.template
@@ -82,8 +82,12 @@
         </p>
       </subsection>
 
-      <subsection name="Package" id="MethodTypeParameterName_Package">
-        <p> com.puppycrawl.tools.checkstyle.checks.naming </p>
+      <subsection name="Fully Qualified Name" id="Fully_Qualified_Name">
+        <p> com.puppycrawl.tools.checkstyle.checks.naming.MethodTypeParameterNameCheck</p>
+        <p>
+            Use this fully qualified class name in configuration when an exact class reference is
+            required.
+        </p>
       </subsection>
 
       <subsection name="Parent Module" id="MethodTypeParameterName_Parent_Module">

--- a/src/site/xdoc/checks/naming/packagename.xml
+++ b/src/site/xdoc/checks/naming/packagename.xml
@@ -119,8 +119,12 @@ public class Example2 {
         </p>
       </subsection>
 
-      <subsection name="Package" id="PackageName_Package">
-        <p> com.puppycrawl.tools.checkstyle.checks.naming </p>
+      <subsection name="Fully Qualified Name" id="Fully_Qualified_Name">
+        <p> com.puppycrawl.tools.checkstyle.checks.naming.PackageNameCheck</p>
+        <p>
+          Use this fully qualified class name in configuration when an exact class reference is
+          required.
+        </p>
       </subsection>
 
       <subsection name="Parent Module" id="PackageName_Parent_Module">

--- a/src/site/xdoc/checks/naming/packagename.xml.template
+++ b/src/site/xdoc/checks/naming/packagename.xml.template
@@ -87,8 +87,12 @@
         </p>
       </subsection>
 
-      <subsection name="Package" id="PackageName_Package">
-        <p> com.puppycrawl.tools.checkstyle.checks.naming </p>
+      <subsection name="Fully Qualified Name" id="Fully_Qualified_Name">
+        <p> com.puppycrawl.tools.checkstyle.checks.naming.PackageNameCheck</p>
+        <p>
+          Use this fully qualified class name in configuration when an exact class reference is
+          required.
+        </p>
       </subsection>
 
       <subsection name="Parent Module" id="PackageName_Parent_Module">

--- a/src/site/xdoc/checks/naming/parametername.xml
+++ b/src/site/xdoc/checks/naming/parametername.xml
@@ -214,8 +214,12 @@ class Example5 {
         </p>
       </subsection>
 
-      <subsection name="Package" id="ParameterName_Package">
-        <p> com.puppycrawl.tools.checkstyle.checks.naming </p>
+      <subsection name="Fully Qualified Name" id="Fully_Qualified_Name">
+        <p> com.puppycrawl.tools.checkstyle.checks.naming.ParameterNameCheck</p>
+        <p>
+          Use this fully qualified class name in configuration when an exact class reference is
+          required.
+        </p>
       </subsection>
 
       <subsection name="Parent Module" id="ParameterName_Parent_Module">

--- a/src/site/xdoc/checks/naming/parametername.xml.template
+++ b/src/site/xdoc/checks/naming/parametername.xml.template
@@ -134,8 +134,12 @@
         </p>
       </subsection>
 
-      <subsection name="Package" id="ParameterName_Package">
-        <p> com.puppycrawl.tools.checkstyle.checks.naming </p>
+      <subsection name="Fully Qualified Name" id="Fully_Qualified_Name">
+        <p> com.puppycrawl.tools.checkstyle.checks.naming.ParameterNameCheck</p>
+        <p>
+          Use this fully qualified class name in configuration when an exact class reference is
+          required.
+        </p>
       </subsection>
 
       <subsection name="Parent Module" id="ParameterName_Parent_Module">

--- a/src/site/xdoc/checks/naming/patternvariablename.xml
+++ b/src/site/xdoc/checks/naming/patternvariablename.xml
@@ -185,8 +185,12 @@ class Example4 {
         </p>
       </subsection>
 
-      <subsection name="Package" id="PatternVariableName_Package">
-        <p> com.puppycrawl.tools.checkstyle.checks.naming </p>
+      <subsection name="Fully Qualified Name" id="Fully_Qualified_Name">
+        <p> com.puppycrawl.tools.checkstyle.checks.naming.PatternVariableNameCheck</p>
+        <p>
+              Use this fully qualified class name in configuration when an exact class reference is
+              required.
+        </p>
       </subsection>
 
       <subsection name="Parent Module" id="PatternVariableName_Parent_Module">

--- a/src/site/xdoc/checks/naming/patternvariablename.xml.template
+++ b/src/site/xdoc/checks/naming/patternvariablename.xml.template
@@ -116,8 +116,12 @@
         </p>
       </subsection>
 
-      <subsection name="Package" id="PatternVariableName_Package">
-        <p> com.puppycrawl.tools.checkstyle.checks.naming </p>
+      <subsection name="Fully Qualified Name" id="Fully_Qualified_Name">
+        <p> com.puppycrawl.tools.checkstyle.checks.naming.PatternVariableNameCheck</p>
+        <p>
+              Use this fully qualified class name in configuration when an exact class reference is
+              required.
+        </p>
       </subsection>
 
       <subsection name="Parent Module" id="PatternVariableName_Parent_Module">

--- a/src/site/xdoc/checks/naming/recordcomponentname.xml
+++ b/src/site/xdoc/checks/naming/recordcomponentname.xml
@@ -111,8 +111,12 @@ class Example2 {
         </p>
       </subsection>
 
-      <subsection name="Package" id="RecordComponentName_Package">
-        <p>com.puppycrawl.tools.checkstyle.checks.naming</p>
+      <subsection name="Fully Qualified Name" id="Fully_Qualified_Name">
+        <p> com.puppycrawl.tools.checkstyle.checks.naming.RecordComponentNameCheck</p>
+        <p>
+            Use this fully qualified class name in configuration when an exact class reference is
+            required.
+        </p>
       </subsection>
 
       <subsection name="Parent Module" id="RecordComponentName_Parent_Module">

--- a/src/site/xdoc/checks/naming/recordcomponentname.xml.template
+++ b/src/site/xdoc/checks/naming/recordcomponentname.xml.template
@@ -85,8 +85,12 @@
         </p>
       </subsection>
 
-      <subsection name="Package" id="RecordComponentName_Package">
-        <p>com.puppycrawl.tools.checkstyle.checks.naming</p>
+      <subsection name="Fully Qualified Name" id="Fully_Qualified_Name">
+        <p> com.puppycrawl.tools.checkstyle.checks.naming.RecordComponentNameCheck</p>
+        <p>
+            Use this fully qualified class name in configuration when an exact class reference is
+            required.
+        </p>
       </subsection>
 
       <subsection name="Parent Module" id="RecordComponentName_Parent_Module">

--- a/src/site/xdoc/checks/naming/recordtypeparametername.xml
+++ b/src/site/xdoc/checks/naming/recordtypeparametername.xml
@@ -111,8 +111,12 @@ class Example2 {
         </p>
       </subsection>
 
-      <subsection name="Package" id="RecordTypeParameterName_Package">
-        <p>com.puppycrawl.tools.checkstyle.checks.naming</p>
+      <subsection name="Fully Qualified Name" id="Fully_Qualified_Name">
+        <p> com.puppycrawl.tools.checkstyle.checks.naming.RecordTypeParameterNameCheck</p>
+        <p>
+          Use this fully qualified class name in configuration when an exact class reference is
+          required.
+        </p>
       </subsection>
 
       <subsection name="Parent Module" id="RecordTypeParameterName_Parent_Module">

--- a/src/site/xdoc/checks/naming/recordtypeparametername.xml.template
+++ b/src/site/xdoc/checks/naming/recordtypeparametername.xml.template
@@ -85,8 +85,12 @@
         </p>
       </subsection>
 
-      <subsection name="Package" id="RecordTypeParameterName_Package">
-        <p>com.puppycrawl.tools.checkstyle.checks.naming</p>
+      <subsection name="Fully Qualified Name" id="Fully_Qualified_Name">
+        <p> com.puppycrawl.tools.checkstyle.checks.naming.RecordTypeParameterNameCheck</p>
+        <p>
+          Use this fully qualified class name in configuration when an exact class reference is
+          required.
+        </p>
       </subsection>
 
       <subsection name="Parent Module" id="RecordTypeParameterName_Parent_Module">

--- a/src/site/xdoc/checks/naming/staticvariablename.xml
+++ b/src/site/xdoc/checks/naming/staticvariablename.xml
@@ -175,8 +175,12 @@ class Example3 {
         </p>
       </subsection>
 
-      <subsection name="Package" id="StaticVariableName_Package">
-        <p> com.puppycrawl.tools.checkstyle.checks.naming </p>
+      <subsection name="Fully Qualified Name" id="Fully_Qualified_Name">
+        <p> com.puppycrawl.tools.checkstyle.checks.naming.StaticVariableNameCheck</p>
+        <p>
+            Use this fully qualified class name in configuration when an exact class reference is
+            required.
+        </p>
       </subsection>
 
       <subsection name="Parent Module" id="StaticVariableName_Parent_Module">

--- a/src/site/xdoc/checks/naming/staticvariablename.xml.template
+++ b/src/site/xdoc/checks/naming/staticvariablename.xml.template
@@ -98,8 +98,12 @@
         </p>
       </subsection>
 
-      <subsection name="Package" id="StaticVariableName_Package">
-        <p> com.puppycrawl.tools.checkstyle.checks.naming </p>
+      <subsection name="Fully Qualified Name" id="Fully_Qualified_Name">
+        <p> com.puppycrawl.tools.checkstyle.checks.naming.StaticVariableNameCheck</p>
+        <p>
+            Use this fully qualified class name in configuration when an exact class reference is
+            required.
+        </p>
       </subsection>
 
       <subsection name="Parent Module" id="StaticVariableName_Parent_Module">

--- a/src/site/xdoc/checks/naming/typename.xml
+++ b/src/site/xdoc/checks/naming/typename.xml
@@ -223,8 +223,12 @@ class Example4 {
         </p>
       </subsection>
 
-      <subsection name="Package" id="TypeName_Package">
-        <p> com.puppycrawl.tools.checkstyle.checks.naming </p>
+      <subsection name="Fully Qualified Name" id="Fully_Qualified_Name">
+        <p> com.puppycrawl.tools.checkstyle.checks.naming.TypeNameCheck</p>
+        <p>
+            Use this fully qualified class name in configuration when an exact class reference is
+            required.
+        </p>
       </subsection>
 
       <subsection name="Parent Module" id="TypeName_Parent_Module">

--- a/src/site/xdoc/checks/naming/typename.xml.template
+++ b/src/site/xdoc/checks/naming/typename.xml.template
@@ -121,8 +121,12 @@
         </p>
       </subsection>
 
-      <subsection name="Package" id="TypeName_Package">
-        <p> com.puppycrawl.tools.checkstyle.checks.naming </p>
+      <subsection name="Fully Qualified Name" id="Fully_Qualified_Name">
+        <p> com.puppycrawl.tools.checkstyle.checks.naming.TypeNameCheck</p>
+        <p>
+            Use this fully qualified class name in configuration when an exact class reference is
+            required.
+        </p>
       </subsection>
 
       <subsection name="Parent Module" id="TypeName_Parent_Module">

--- a/src/site/xdoc/checks/regexp/regexp.xml
+++ b/src/site/xdoc/checks/regexp/regexp.xml
@@ -423,9 +423,11 @@ public class Example11 {}
         </p>
       </subsection>
 
-      <subsection name="Package" id="Regexp_Package">
+      <subsection name="Fully Qualified Name" id="Fully_Qualified_Name">
+        <p> com.puppycrawl.tools.checkstyle.checks.regexp.RegexpCheck</p>
         <p>
-          com.puppycrawl.tools.checkstyle.checks.regexp
+            Use this fully qualified class name in configuration when an exact class reference is
+            required.
         </p>
       </subsection>
 

--- a/src/site/xdoc/checks/regexp/regexp.xml.template
+++ b/src/site/xdoc/checks/regexp/regexp.xml.template
@@ -209,9 +209,11 @@
         </p>
       </subsection>
 
-      <subsection name="Package" id="Regexp_Package">
+      <subsection name="Fully Qualified Name" id="Fully_Qualified_Name">
+        <p> com.puppycrawl.tools.checkstyle.checks.regexp.RegexpCheck</p>
         <p>
-          com.puppycrawl.tools.checkstyle.checks.regexp
+            Use this fully qualified class name in configuration when an exact class reference is
+            required.
         </p>
       </subsection>
 

--- a/src/site/xdoc/checks/regexp/regexpmultiline.xml
+++ b/src/site/xdoc/checks/regexp/regexpmultiline.xml
@@ -396,9 +396,11 @@ class Example5 {
         </p>
       </subsection>
 
-      <subsection name="Package" id="RegexpMultiline_Package">
+      <subsection name="Fully Qualified Name" id="Fully_Qualified_Name">
+        <p> com.puppycrawl.tools.checkstyle.checks.regexp.RegexpMultilineCheck</p>
         <p>
-          com.puppycrawl.tools.checkstyle.checks.regexp
+            Use this fully qualified class name in configuration when an exact class reference is
+            required.
         </p>
       </subsection>
 

--- a/src/site/xdoc/checks/regexp/regexpmultiline.xml.template
+++ b/src/site/xdoc/checks/regexp/regexpmultiline.xml.template
@@ -160,9 +160,11 @@
         </p>
       </subsection>
 
-      <subsection name="Package" id="RegexpMultiline_Package">
+      <subsection name="Fully Qualified Name" id="Fully_Qualified_Name">
+        <p> com.puppycrawl.tools.checkstyle.checks.regexp.RegexpMultilineCheck</p>
         <p>
-          com.puppycrawl.tools.checkstyle.checks.regexp
+            Use this fully qualified class name in configuration when an exact class reference is
+            required.
         </p>
       </subsection>
 

--- a/src/site/xdoc/checks/regexp/regexponfilename.xml
+++ b/src/site/xdoc/checks/regexp/regexponfilename.xml
@@ -235,11 +235,13 @@
         </p>
       </subsection>
 
-      <subsection name="Package" id="RegexpOnFilename_Package">
-        <p>
-          com.puppycrawl.tools.checkstyle.checks.regexp
-        </p>
-      </subsection>
+        <subsection name="Fully Qualified Name" id="Fully_Qualified_Name">
+          <p> com.puppycrawl.tools.checkstyle.checks.regexp.RegexpOnFilenameCheck</p>
+          <p>
+              Use this fully qualified class name in configuration when an exact class reference is
+              required.
+          </p>
+        </subsection>
 
       <subsection name="Parent Module" id="RegexpOnFilename_Parent_Module">
         <p>

--- a/src/site/xdoc/checks/regexp/regexponfilename.xml.template
+++ b/src/site/xdoc/checks/regexp/regexponfilename.xml.template
@@ -122,11 +122,13 @@
         </p>
       </subsection>
 
-      <subsection name="Package" id="RegexpOnFilename_Package">
-        <p>
-          com.puppycrawl.tools.checkstyle.checks.regexp
-        </p>
-      </subsection>
+        <subsection name="Fully Qualified Name" id="Fully_Qualified_Name">
+          <p> com.puppycrawl.tools.checkstyle.checks.regexp.RegexpOnFilenameCheck</p>
+          <p>
+              Use this fully qualified class name in configuration when an exact class reference is
+              required.
+          </p>
+        </subsection>
 
       <subsection name="Parent Module" id="RegexpOnFilename_Parent_Module">
         <macro name="parent-module">

--- a/src/site/xdoc/checks/regexp/regexpsingleline.xml
+++ b/src/site/xdoc/checks/regexp/regexpsingleline.xml
@@ -247,11 +247,13 @@ CREATE DATABASE MyDB;
         </p>
       </subsection>
 
-      <subsection name="Package" id="RegexpSingleline_Package">
-        <p>
-          com.puppycrawl.tools.checkstyle.checks.regexp
-        </p>
-      </subsection>
+      <subsection name="Fully Qualified Name" id="Fully_Qualified_Name">
+         <p> com.puppycrawl.tools.checkstyle.checks.regexp.RegexpSinglelineCheck</p>
+         <p>
+          Use this fully qualified class name in configuration when an exact class reference is
+          required.
+          </p>
+       </subsection>
 
       <subsection name="Parent Module" id="RegexpSingleline_Parent_Module">
         <p>

--- a/src/site/xdoc/checks/regexp/regexpsingleline.xml.template
+++ b/src/site/xdoc/checks/regexp/regexpsingleline.xml.template
@@ -139,11 +139,13 @@
         </p>
       </subsection>
 
-      <subsection name="Package" id="RegexpSingleline_Package">
-        <p>
-          com.puppycrawl.tools.checkstyle.checks.regexp
-        </p>
-      </subsection>
+      <subsection name="Fully Qualified Name" id="Fully_Qualified_Name">
+         <p> com.puppycrawl.tools.checkstyle.checks.regexp.RegexpSinglelineCheck</p>
+         <p>
+          Use this fully qualified class name in configuration when an exact class reference is
+          required.
+          </p>
+       </subsection>
 
       <subsection name="Parent Module" id="RegexpSingleline_Parent_Module">
         <macro name="parent-module">

--- a/src/site/xdoc/checks/regexp/regexpsinglelinejava.xml
+++ b/src/site/xdoc/checks/regexp/regexpsinglelinejava.xml
@@ -450,11 +450,13 @@ class Example7 {
         </p>
       </subsection>
 
-      <subsection name="Package" id="RegexpSinglelineJava_Package">
-        <p>
-          com.puppycrawl.tools.checkstyle.checks.regexp
-        </p>
-      </subsection>
+  <subsection name="Fully Qualified Name" id="Fully_Qualified_Name">
+      <p> com.puppycrawl.tools.checkstyle.checks.regexp.RegexpSinglelineJavaCheck</p>
+      <p>
+        Use this fully qualified class name in configuration when an exact class reference is
+        required.
+      </p>
+  </subsection>
 
       <subsection name="Parent Module" id="RegexpSinglelineJava_Parent_Module">
         <p>

--- a/src/site/xdoc/checks/regexp/regexpsinglelinejava.xml.template
+++ b/src/site/xdoc/checks/regexp/regexpsinglelinejava.xml.template
@@ -162,11 +162,13 @@
         </p>
       </subsection>
 
-      <subsection name="Package" id="RegexpSinglelineJava_Package">
-        <p>
-          com.puppycrawl.tools.checkstyle.checks.regexp
-        </p>
-      </subsection>
+  <subsection name="Fully Qualified Name" id="Fully_Qualified_Name">
+      <p> com.puppycrawl.tools.checkstyle.checks.regexp.RegexpSinglelineJavaCheck</p>
+      <p>
+        Use this fully qualified class name in configuration when an exact class reference is
+        required.
+      </p>
+  </subsection>
 
       <subsection name="Parent Module" id="RegexpSinglelineJava_Parent_Module">
         <macro name="parent-module">

--- a/src/site/xdoc/checks/sizes/anoninnerlength.xml
+++ b/src/site/xdoc/checks/sizes/anoninnerlength.xml
@@ -142,9 +142,11 @@ class Example2 {
         </p>
       </subsection>
 
-      <subsection name="Package" id="AnonInnerLength_Package">
+      <subsection name="Fully Qualified Name" id="Fully_Qualified_Name">
+        <p> com.puppycrawl.tools.checkstyle.checks.sizes.AnonInnerLengthCheck</p>
         <p>
-          com.puppycrawl.tools.checkstyle.checks.sizes
+            Use this fully qualified class name in configuration when an exact class reference is
+            required.
         </p>
       </subsection>
 

--- a/src/site/xdoc/checks/sizes/anoninnerlength.xml.template
+++ b/src/site/xdoc/checks/sizes/anoninnerlength.xml.template
@@ -78,9 +78,11 @@
         </p>
       </subsection>
 
-      <subsection name="Package" id="AnonInnerLength_Package">
+      <subsection name="Fully Qualified Name" id="Fully_Qualified_Name">
+        <p> com.puppycrawl.tools.checkstyle.checks.sizes.AnonInnerLengthCheck</p>
         <p>
-          com.puppycrawl.tools.checkstyle.checks.sizes
+            Use this fully qualified class name in configuration when an exact class reference is
+            required.
         </p>
       </subsection>
 

--- a/src/site/xdoc/checks/sizes/executablestatementcount.xml
+++ b/src/site/xdoc/checks/sizes/executablestatementcount.xml
@@ -183,9 +183,11 @@ class Example3 {
         </p>
       </subsection>
 
-      <subsection name="Package" id="ExecutableStatementCount_Package">
+      <subsection name="Fully Qualified Name" id="Fully_Qualified_Name">
+        <p> com.puppycrawl.tools.checkstyle.checks.sizes.ExecutableStatementCountCheck</p>
         <p>
-          com.puppycrawl.tools.checkstyle.checks.sizes
+          Use this fully qualified class name in configuration when an exact class reference is
+          required.
         </p>
       </subsection>
 

--- a/src/site/xdoc/checks/sizes/executablestatementcount.xml.template
+++ b/src/site/xdoc/checks/sizes/executablestatementcount.xml.template
@@ -94,9 +94,11 @@
         </p>
       </subsection>
 
-      <subsection name="Package" id="ExecutableStatementCount_Package">
+      <subsection name="Fully Qualified Name" id="Fully_Qualified_Name">
+        <p> com.puppycrawl.tools.checkstyle.checks.sizes.ExecutableStatementCountCheck</p>
         <p>
-          com.puppycrawl.tools.checkstyle.checks.sizes
+          Use this fully qualified class name in configuration when an exact class reference is
+          required.
         </p>
       </subsection>
 

--- a/src/site/xdoc/checks/sizes/filelength.xml
+++ b/src/site/xdoc/checks/sizes/filelength.xml
@@ -135,9 +135,11 @@ public class Example3 {
         </p>
       </subsection>
 
-      <subsection name="Package" id="FileLength_Package">
+      <subsection name="Fully Qualified Name" id="Fully_Qualified_Name">
+        <p> com.puppycrawl.tools.checkstyle.checks.sizes.FileLengthCheck</p>
         <p>
-          com.puppycrawl.tools.checkstyle.checks.sizes
+            Use this fully qualified class name in configuration when an exact class reference is
+            required.
         </p>
       </subsection>
 

--- a/src/site/xdoc/checks/sizes/filelength.xml.template
+++ b/src/site/xdoc/checks/sizes/filelength.xml.template
@@ -96,9 +96,11 @@
         </p>
       </subsection>
 
-      <subsection name="Package" id="FileLength_Package">
+      <subsection name="Fully Qualified Name" id="Fully_Qualified_Name">
+        <p> com.puppycrawl.tools.checkstyle.checks.sizes.FileLengthCheck</p>
         <p>
-          com.puppycrawl.tools.checkstyle.checks.sizes
+            Use this fully qualified class name in configuration when an exact class reference is
+            required.
         </p>
       </subsection>
 

--- a/src/site/xdoc/checks/sizes/lambdabodylength.xml
+++ b/src/site/xdoc/checks/sizes/lambdabodylength.xml
@@ -160,9 +160,11 @@ class Example2 {
         </p>
       </subsection>
 
-      <subsection name="Package" id="LambdaBodyLength_Package">
+      <subsection name="Fully Qualified Name" id="Fully_Qualified_Name">
+        <p> com.puppycrawl.tools.checkstyle.checks.sizes.LambdaBodyLengthCheck</p>
         <p>
-          com.puppycrawl.tools.checkstyle.checks.sizes
+              Use this fully qualified class name in configuration when an exact class reference is
+              required.
         </p>
       </subsection>
 

--- a/src/site/xdoc/checks/sizes/lambdabodylength.xml.template
+++ b/src/site/xdoc/checks/sizes/lambdabodylength.xml.template
@@ -82,9 +82,11 @@
         </p>
       </subsection>
 
-      <subsection name="Package" id="LambdaBodyLength_Package">
+      <subsection name="Fully Qualified Name" id="Fully_Qualified_Name">
+        <p> com.puppycrawl.tools.checkstyle.checks.sizes.LambdaBodyLengthCheck</p>
         <p>
-          com.puppycrawl.tools.checkstyle.checks.sizes
+              Use this fully qualified class name in configuration when an exact class reference is
+              required.
         </p>
       </subsection>
 

--- a/src/site/xdoc/checks/sizes/linelength.xml
+++ b/src/site/xdoc/checks/sizes/linelength.xml
@@ -319,9 +319,11 @@ public class Example6 {
         </p>
       </subsection>
 
-      <subsection name="Package" id="LineLength_Package">
+      <subsection name="Fully Qualified Name" id="Fully_Qualified_Name">
+        <p> com.puppycrawl.tools.checkstyle.checks.sizes.LineLengthCheck</p>
         <p>
-          com.puppycrawl.tools.checkstyle.checks.sizes
+          Use this fully qualified class name in configuration when an exact class reference is
+          required.
         </p>
       </subsection>
 

--- a/src/site/xdoc/checks/sizes/linelength.xml.template
+++ b/src/site/xdoc/checks/sizes/linelength.xml.template
@@ -168,9 +168,11 @@
         </p>
       </subsection>
 
-      <subsection name="Package" id="LineLength_Package">
+      <subsection name="Fully Qualified Name" id="Fully_Qualified_Name">
+        <p> com.puppycrawl.tools.checkstyle.checks.sizes.LineLengthCheck</p>
         <p>
-          com.puppycrawl.tools.checkstyle.checks.sizes
+          Use this fully qualified class name in configuration when an exact class reference is
+          required.
         </p>
       </subsection>
 

--- a/src/site/xdoc/checks/sizes/methodcount.xml
+++ b/src/site/xdoc/checks/sizes/methodcount.xml
@@ -394,9 +394,11 @@ class Example6 { // no violations: there are no protected methods in this class
         </p>
       </subsection>
 
-      <subsection name="Package" id="MethodCount_Package">
+      <subsection name="Fully Qualified Name" id="Fully_Qualified_Name">
+        <p> com.puppycrawl.tools.checkstyle.checks.sizes.MethodCountCheck</p>
         <p>
-          com.puppycrawl.tools.checkstyle.checks.sizes
+            Use this fully qualified class name in configuration when an exact class reference is
+            required.
         </p>
       </subsection>
 

--- a/src/site/xdoc/checks/sizes/methodcount.xml.template
+++ b/src/site/xdoc/checks/sizes/methodcount.xml.template
@@ -135,9 +135,11 @@
         </p>
       </subsection>
 
-      <subsection name="Package" id="MethodCount_Package">
+      <subsection name="Fully Qualified Name" id="Fully_Qualified_Name">
+        <p> com.puppycrawl.tools.checkstyle.checks.sizes.MethodCountCheck</p>
         <p>
-          com.puppycrawl.tools.checkstyle.checks.sizes
+            Use this fully qualified class name in configuration when an exact class reference is
+            required.
         </p>
       </subsection>
 

--- a/src/site/xdoc/checks/sizes/methodlength.xml
+++ b/src/site/xdoc/checks/sizes/methodlength.xml
@@ -284,9 +284,11 @@ public class Example3 {
         </p>
       </subsection>
 
-      <subsection name="Package" id="MethodLength_Package">
+      <subsection name="Fully Qualified Name" id="Fully_Qualified_Name">
+        <p> com.puppycrawl.tools.checkstyle.checks.sizes.MethodLengthCheck</p>
         <p>
-          com.puppycrawl.tools.checkstyle.checks.sizes
+          Use this fully qualified class name in configuration when an exact class reference is
+          required.
         </p>
       </subsection>
 

--- a/src/site/xdoc/checks/sizes/methodlength.xml.template
+++ b/src/site/xdoc/checks/sizes/methodlength.xml.template
@@ -99,9 +99,11 @@
         </p>
       </subsection>
 
-      <subsection name="Package" id="MethodLength_Package">
+      <subsection name="Fully Qualified Name" id="Fully_Qualified_Name">
+        <p> com.puppycrawl.tools.checkstyle.checks.sizes.MethodLengthCheck</p>
         <p>
-          com.puppycrawl.tools.checkstyle.checks.sizes
+          Use this fully qualified class name in configuration when an exact class reference is
+          required.
         </p>
       </subsection>
 

--- a/src/site/xdoc/checks/sizes/outertypenumber.xml
+++ b/src/site/xdoc/checks/sizes/outertypenumber.xml
@@ -116,9 +116,11 @@ enum outer1 {
         </p>
       </subsection>
 
-      <subsection name="Package" id="OuterTypeNumber_Package">
+      <subsection name="Fully Qualified Name" id="Fully_Qualified_Name">
+        <p> com.puppycrawl.tools.checkstyle.checks.sizes.OuterTypeNumberCheck</p>
         <p>
-          com.puppycrawl.tools.checkstyle.checks.sizes
+          Use this fully qualified class name in configuration when an exact class reference is
+          required.
         </p>
       </subsection>
 

--- a/src/site/xdoc/checks/sizes/outertypenumber.xml.template
+++ b/src/site/xdoc/checks/sizes/outertypenumber.xml.template
@@ -80,9 +80,11 @@
         </p>
       </subsection>
 
-      <subsection name="Package" id="OuterTypeNumber_Package">
+      <subsection name="Fully Qualified Name" id="Fully_Qualified_Name">
+        <p> com.puppycrawl.tools.checkstyle.checks.sizes.OuterTypeNumberCheck</p>
         <p>
-          com.puppycrawl.tools.checkstyle.checks.sizes
+          Use this fully qualified class name in configuration when an exact class reference is
+          required.
         </p>
       </subsection>
 

--- a/src/site/xdoc/checks/sizes/parameternumber.xml
+++ b/src/site/xdoc/checks/sizes/parameternumber.xml
@@ -269,9 +269,11 @@ class ExternalService4 {
         </p>
       </subsection>
 
-      <subsection name="Package" id="ParameterNumber_Package">
+      <subsection name="Fully Qualified Name" id="Fully_Qualified_Name">
+        <p> com.puppycrawl.tools.checkstyle.checks.sizes.ParameterNumberCheck</p>
         <p>
-          com.puppycrawl.tools.checkstyle.checks.sizes
+          Use this fully qualified class name in configuration when an exact class reference is
+          required.
         </p>
       </subsection>
 

--- a/src/site/xdoc/checks/sizes/parameternumber.xml.template
+++ b/src/site/xdoc/checks/sizes/parameternumber.xml.template
@@ -121,9 +121,11 @@
         </p>
       </subsection>
 
-      <subsection name="Package" id="ParameterNumber_Package">
+      <subsection name="Fully Qualified Name" id="Fully_Qualified_Name">
+        <p> com.puppycrawl.tools.checkstyle.checks.sizes.ParameterNumberCheck</p>
         <p>
-          com.puppycrawl.tools.checkstyle.checks.sizes
+          Use this fully qualified class name in configuration when an exact class reference is
+          required.
         </p>
       </subsection>
 

--- a/src/site/xdoc/checks/sizes/recordcomponentnumber.xml
+++ b/src/site/xdoc/checks/sizes/recordcomponentnumber.xml
@@ -163,9 +163,11 @@ class Example3 {
         </p>
       </subsection>
 
-      <subsection name="Package" id="RecordComponentNumber_Package">
+      <subsection name="Fully Qualified Name" id="Fully_Qualified_Name">
+        <p> com.puppycrawl.tools.checkstyle.checks.sizes.RecordComponentNumberCheck</p>
         <p>
-          com.puppycrawl.tools.checkstyle.checks.sizes
+          Use this fully qualified class name in configuration when an exact class reference is
+          required.
         </p>
       </subsection>
 

--- a/src/site/xdoc/checks/sizes/recordcomponentnumber.xml.template
+++ b/src/site/xdoc/checks/sizes/recordcomponentnumber.xml.template
@@ -100,9 +100,11 @@
         </p>
       </subsection>
 
-      <subsection name="Package" id="RecordComponentNumber_Package">
+      <subsection name="Fully Qualified Name" id="Fully_Qualified_Name">
+        <p> com.puppycrawl.tools.checkstyle.checks.sizes.RecordComponentNumberCheck</p>
         <p>
-          com.puppycrawl.tools.checkstyle.checks.sizes
+          Use this fully qualified class name in configuration when an exact class reference is
+          required.
         </p>
       </subsection>
 

--- a/src/site/xdoc/checks/whitespace/emptyforinitializerpad.xml
+++ b/src/site/xdoc/checks/whitespace/emptyforinitializerpad.xml
@@ -129,9 +129,11 @@ class Example2 {
         </p>
       </subsection>
 
-      <subsection name="Package" id="EmptyForInitializerPad_Package">
+      <subsection name="Fully Qualified Name" id="Fully_Qualified_Name">
+        <p> com.puppycrawl.tools.checkstyle.checks.whitespace.EmptyForInitializerPadCheck</p>
         <p>
-          com.puppycrawl.tools.checkstyle.checks.whitespace
+            Use this fully qualified class name in configuration when an exact class reference is
+            required.
         </p>
       </subsection>
 

--- a/src/site/xdoc/checks/whitespace/emptyforinitializerpad.xml.template
+++ b/src/site/xdoc/checks/whitespace/emptyforinitializerpad.xml.template
@@ -84,9 +84,11 @@
         </p>
       </subsection>
 
-      <subsection name="Package" id="EmptyForInitializerPad_Package">
+      <subsection name="Fully Qualified Name" id="Fully_Qualified_Name">
+        <p> com.puppycrawl.tools.checkstyle.checks.whitespace.EmptyForInitializerPadCheck</p>
         <p>
-          com.puppycrawl.tools.checkstyle.checks.whitespace
+            Use this fully qualified class name in configuration when an exact class reference is
+            required.
         </p>
       </subsection>
 

--- a/src/site/xdoc/checks/whitespace/emptyforiteratorpad.xml
+++ b/src/site/xdoc/checks/whitespace/emptyforiteratorpad.xml
@@ -135,9 +135,11 @@ class Example2 {
         </p>
       </subsection>
 
-      <subsection name="Package" id="EmptyForIteratorPad_Package">
+      <subsection name="Fully Qualified Name" id="Fully_Qualified_Name">
+        <p> com.puppycrawl.tools.checkstyle.checks.whitespace.EmptyForIteratorPadCheck</p>
         <p>
-          com.puppycrawl.tools.checkstyle.checks.whitespace
+          Use this fully qualified class name in configuration when an exact class reference is
+          required.
         </p>
       </subsection>
 

--- a/src/site/xdoc/checks/whitespace/emptyforiteratorpad.xml.template
+++ b/src/site/xdoc/checks/whitespace/emptyforiteratorpad.xml.template
@@ -87,9 +87,11 @@
         </p>
       </subsection>
 
-      <subsection name="Package" id="EmptyForIteratorPad_Package">
+      <subsection name="Fully Qualified Name" id="Fully_Qualified_Name">
+        <p> com.puppycrawl.tools.checkstyle.checks.whitespace.EmptyForIteratorPadCheck</p>
         <p>
-          com.puppycrawl.tools.checkstyle.checks.whitespace
+          Use this fully qualified class name in configuration when an exact class reference is
+          required.
         </p>
       </subsection>
 

--- a/src/site/xdoc/checks/whitespace/emptylineseparator.xml
+++ b/src/site/xdoc/checks/whitespace/emptylineseparator.xml
@@ -546,10 +546,12 @@ package com.puppycrawl.tools.checkstyle.checks.whitespace.emptylineseparator.pac
         </p>
       </subsection>
 
-      <subsection name="Package" id="EmptyLineSeparator_Package">
-        <p>
-          com.puppycrawl.tools.checkstyle.checks.whitespace
-        </p>
+      <subsection name="Fully Qualified Name" id="Fully_Qualified_Name">
+          <p> com.puppycrawl.tools.checkstyle.checks.whitespace.EmptyLineSeparatorCheck</p>
+          <p>
+            Use this fully qualified class name in configuration when an exact class reference is
+            required.
+          </p>
       </subsection>
 
       <subsection name="Parent Module" id="EmptyLineSeparator_Parent_Module">

--- a/src/site/xdoc/checks/whitespace/emptylineseparator.xml.template
+++ b/src/site/xdoc/checks/whitespace/emptylineseparator.xml.template
@@ -232,10 +232,12 @@
         </p>
       </subsection>
 
-      <subsection name="Package" id="EmptyLineSeparator_Package">
-        <p>
-          com.puppycrawl.tools.checkstyle.checks.whitespace
-        </p>
+      <subsection name="Fully Qualified Name" id="Fully_Qualified_Name">
+          <p> com.puppycrawl.tools.checkstyle.checks.whitespace.EmptyLineSeparatorCheck</p>
+          <p>
+            Use this fully qualified class name in configuration when an exact class reference is
+            required.
+          </p>
       </subsection>
 
       <subsection name="Parent Module" id="EmptyLineSeparator_Parent_Module">

--- a/src/site/xdoc/checks/whitespace/filetabcharacter.xml
+++ b/src/site/xdoc/checks/whitespace/filetabcharacter.xml
@@ -177,9 +177,11 @@ class Example3 {
         </p>
       </subsection>
 
-      <subsection name="Package" id="FileTabCharacter_Package">
+      <subsection name="Fully Qualified Name" id="Fully_Qualified_Name">
+        <p> com.puppycrawl.tools.checkstyle.checks.whitespace.FileTabCharacterCheck</p>
         <p>
-          com.puppycrawl.tools.checkstyle.checks.whitespace
+            Use this fully qualified class name in configuration when an exact class reference is
+            required.
         </p>
       </subsection>
 

--- a/src/site/xdoc/checks/whitespace/filetabcharacter.xml.template
+++ b/src/site/xdoc/checks/whitespace/filetabcharacter.xml.template
@@ -117,9 +117,11 @@
         </p>
       </subsection>
 
-      <subsection name="Package" id="FileTabCharacter_Package">
+      <subsection name="Fully Qualified Name" id="Fully_Qualified_Name">
+        <p> com.puppycrawl.tools.checkstyle.checks.whitespace.FileTabCharacterCheck</p>
         <p>
-          com.puppycrawl.tools.checkstyle.checks.whitespace
+            Use this fully qualified class name in configuration when an exact class reference is
+            required.
         </p>
       </subsection>
 

--- a/src/site/xdoc/checks/whitespace/genericwhitespace.xml
+++ b/src/site/xdoc/checks/whitespace/genericwhitespace.xml
@@ -128,9 +128,11 @@ class Example2 {
         </p>
       </subsection>
 
-      <subsection name="Package" id="GenericWhitespace_Package">
+      <subsection name="Fully Qualified Name" id="Fully_Qualified_Name">
+        <p> com.puppycrawl.tools.checkstyle.checks.whitespace.GenericWhitespaceCheck</p>
         <p>
-          com.puppycrawl.tools.checkstyle.checks.whitespace
+            Use this fully qualified class name in configuration when an exact class reference is
+            required.
         </p>
       </subsection>
 

--- a/src/site/xdoc/checks/whitespace/genericwhitespace.xml.template
+++ b/src/site/xdoc/checks/whitespace/genericwhitespace.xml.template
@@ -73,9 +73,11 @@
         </p>
       </subsection>
 
-      <subsection name="Package" id="GenericWhitespace_Package">
+      <subsection name="Fully Qualified Name" id="Fully_Qualified_Name">
+        <p> com.puppycrawl.tools.checkstyle.checks.whitespace.GenericWhitespaceCheck</p>
         <p>
-          com.puppycrawl.tools.checkstyle.checks.whitespace
+            Use this fully qualified class name in configuration when an exact class reference is
+            required.
         </p>
       </subsection>
 

--- a/src/site/xdoc/checks/whitespace/methodparampad.xml
+++ b/src/site/xdoc/checks/whitespace/methodparampad.xml
@@ -203,9 +203,11 @@ class Example2 {
         </p>
       </subsection>
 
-      <subsection name="Package" id="MethodParamPad_Package">
+      <subsection name="Fully Qualified Name" id="Fully_Qualified_Name">
+        <p> com.puppycrawl.tools.checkstyle.checks.whitespace.MethodParamPadCheck</p>
         <p>
-          com.puppycrawl.tools.checkstyle.checks.whitespace
+          Use this fully qualified class name in configuration when an exact class reference is
+          required.
         </p>
       </subsection>
 

--- a/src/site/xdoc/checks/whitespace/methodparampad.xml.template
+++ b/src/site/xdoc/checks/whitespace/methodparampad.xml.template
@@ -89,9 +89,11 @@
         </p>
       </subsection>
 
-      <subsection name="Package" id="MethodParamPad_Package">
+      <subsection name="Fully Qualified Name" id="Fully_Qualified_Name">
+        <p> com.puppycrawl.tools.checkstyle.checks.whitespace.MethodParamPadCheck</p>
         <p>
-          com.puppycrawl.tools.checkstyle.checks.whitespace
+          Use this fully qualified class name in configuration when an exact class reference is
+          required.
         </p>
       </subsection>
 

--- a/src/site/xdoc/checks/whitespace/nolinewrap.xml
+++ b/src/site/xdoc/checks/whitespace/nolinewrap.xml
@@ -212,9 +212,11 @@ class // violation 'should not be line-wrapped'
         </p>
       </subsection>
 
-      <subsection name="Package" id="NoLineWrap_Package">
+      <subsection name="Fully Qualified Name" id="Fully_Qualified_Name">
+        <p> com.puppycrawl.tools.checkstyle.checks.whitespace.NoLineWrapCheck</p>
         <p>
-          com.puppycrawl.tools.checkstyle.checks.whitespace
+          Use this fully qualified class name in configuration when an exact class reference is
+          required.
         </p>
       </subsection>
 

--- a/src/site/xdoc/checks/whitespace/nolinewrap.xml.template
+++ b/src/site/xdoc/checks/whitespace/nolinewrap.xml.template
@@ -119,9 +119,11 @@
         </p>
       </subsection>
 
-      <subsection name="Package" id="NoLineWrap_Package">
+      <subsection name="Fully Qualified Name" id="Fully_Qualified_Name">
+        <p> com.puppycrawl.tools.checkstyle.checks.whitespace.NoLineWrapCheck</p>
         <p>
-          com.puppycrawl.tools.checkstyle.checks.whitespace
+          Use this fully qualified class name in configuration when an exact class reference is
+          required.
         </p>
       </subsection>
 

--- a/src/site/xdoc/checks/whitespace/nowhitespaceafter.xml
+++ b/src/site/xdoc/checks/whitespace/nowhitespaceafter.xml
@@ -232,9 +232,11 @@ class Example2 {
         </p>
       </subsection>
 
-      <subsection name="Package" id="NoWhitespaceAfter_Package">
+      <subsection name="Fully Qualified Name" id="Fully_Qualified_Name">
+        <p> com.puppycrawl.tools.checkstyle.checks.whitespace.NoWhitespaceAfterCheck</p>
         <p>
-          com.puppycrawl.tools.checkstyle.checks.whitespace
+          Use this fully qualified class name in configuration when an exact class reference is
+          required.
         </p>
       </subsection>
 

--- a/src/site/xdoc/checks/whitespace/nowhitespaceafter.xml.template
+++ b/src/site/xdoc/checks/whitespace/nowhitespaceafter.xml.template
@@ -82,9 +82,11 @@
         </p>
       </subsection>
 
-      <subsection name="Package" id="NoWhitespaceAfter_Package">
+      <subsection name="Fully Qualified Name" id="Fully_Qualified_Name">
+        <p> com.puppycrawl.tools.checkstyle.checks.whitespace.NoWhitespaceAfterCheck</p>
         <p>
-          com.puppycrawl.tools.checkstyle.checks.whitespace
+          Use this fully qualified class name in configuration when an exact class reference is
+          required.
         </p>
       </subsection>
 

--- a/src/site/xdoc/checks/whitespace/nowhitespacebefore.xml
+++ b/src/site/xdoc/checks/whitespace/nowhitespacebefore.xml
@@ -237,9 +237,11 @@ class Example4 {
         </p>
       </subsection>
 
-      <subsection name="Package" id="NoWhitespaceBefore_Package">
+      <subsection name="Fully Qualified Name" id="Fully_Qualified_Name">
+        <p> com.puppycrawl.tools.checkstyle.checks.whitespace.NoWhitespaceBeforeCheck</p>
         <p>
-          com.puppycrawl.tools.checkstyle.checks.whitespace
+          Use this fully qualified class name in configuration when an exact class reference is
+          required.
         </p>
       </subsection>
 

--- a/src/site/xdoc/checks/whitespace/nowhitespacebefore.xml.template
+++ b/src/site/xdoc/checks/whitespace/nowhitespacebefore.xml.template
@@ -114,9 +114,11 @@
         </p>
       </subsection>
 
-      <subsection name="Package" id="NoWhitespaceBefore_Package">
+      <subsection name="Fully Qualified Name" id="Fully_Qualified_Name">
+        <p> com.puppycrawl.tools.checkstyle.checks.whitespace.NoWhitespaceBeforeCheck</p>
         <p>
-          com.puppycrawl.tools.checkstyle.checks.whitespace
+          Use this fully qualified class name in configuration when an exact class reference is
+          required.
         </p>
       </subsection>
 

--- a/src/site/xdoc/checks/whitespace/nowhitespacebeforecasedefaultcolon.xml
+++ b/src/site/xdoc/checks/whitespace/nowhitespacebeforecasedefaultcolon.xml
@@ -89,11 +89,13 @@ class Example1 {
         </p>
       </subsection>
 
-      <subsection name="Package" id="NoWhitespaceBeforeCaseDefaultColon_Package">
-        <p>
-          com.puppycrawl.tools.checkstyle.checks.whitespace
-        </p>
-      </subsection>
+<subsection name="Fully Qualified Name" id="Fully_Qualified_Name">
+  <p> com.puppycrawl.tools.checkstyle.checks.whitespace.NoWhitespaceBeforeCaseDefaultColonCheck</p>
+  <p>
+    Use this fully qualified class name in configuration when an exact class reference is
+    required.
+  </p>
+</subsection>
 
       <subsection name="Parent Module" id="NoWhitespaceBeforeCaseDefaultColon_Parent_Module">
         <p>

--- a/src/site/xdoc/checks/whitespace/nowhitespacebeforecasedefaultcolon.xml.template
+++ b/src/site/xdoc/checks/whitespace/nowhitespacebeforecasedefaultcolon.xml.template
@@ -60,11 +60,13 @@
         </p>
       </subsection>
 
-      <subsection name="Package" id="NoWhitespaceBeforeCaseDefaultColon_Package">
-        <p>
-          com.puppycrawl.tools.checkstyle.checks.whitespace
-        </p>
-      </subsection>
+<subsection name="Fully Qualified Name" id="Fully_Qualified_Name">
+  <p> com.puppycrawl.tools.checkstyle.checks.whitespace.NoWhitespaceBeforeCaseDefaultColonCheck</p>
+  <p>
+    Use this fully qualified class name in configuration when an exact class reference is
+    required.
+  </p>
+</subsection>
 
       <subsection name="Parent Module" id="NoWhitespaceBeforeCaseDefaultColon_Parent_Module">
         <macro name="parent-module">

--- a/src/site/xdoc/checks/whitespace/operatorwrap.xml
+++ b/src/site/xdoc/checks/whitespace/operatorwrap.xml
@@ -297,9 +297,11 @@ class Example2 {
         </p>
       </subsection>
 
-      <subsection name="Package" id="OperatorWrap_Package">
+      <subsection name="Fully Qualified Name" id="Fully_Qualified_Name">
+        <p> com.puppycrawl.tools.checkstyle.checks.whitespace.OperatorWrapCheck</p>
         <p>
-          com.puppycrawl.tools.checkstyle.checks.whitespace
+          Use this fully qualified class name in configuration when an exact class reference is
+          required.
         </p>
       </subsection>
 

--- a/src/site/xdoc/checks/whitespace/operatorwrap.xml.template
+++ b/src/site/xdoc/checks/whitespace/operatorwrap.xml.template
@@ -90,9 +90,11 @@
         </p>
       </subsection>
 
-      <subsection name="Package" id="OperatorWrap_Package">
+      <subsection name="Fully Qualified Name" id="Fully_Qualified_Name">
+        <p> com.puppycrawl.tools.checkstyle.checks.whitespace.OperatorWrapCheck</p>
         <p>
-          com.puppycrawl.tools.checkstyle.checks.whitespace
+          Use this fully qualified class name in configuration when an exact class reference is
+          required.
         </p>
       </subsection>
 

--- a/src/site/xdoc/checks/whitespace/parenpad.xml
+++ b/src/site/xdoc/checks/whitespace/parenpad.xml
@@ -298,9 +298,11 @@ try (Closeable resource = acquire(); ) // no check before right parenthesis
         </p>
       </subsection>
 
-      <subsection name="Package" id="ParenPad_Package">
+      <subsection name="Fully Qualified Name" id="Fully_Qualified_Name">
+        <p> com.puppycrawl.tools.checkstyle.checks.whitespace.ParenPadCheck</p>
         <p>
-          com.puppycrawl.tools.checkstyle.checks.whitespace
+          Use this fully qualified class name in configuration when an exact class reference is
+          required.
         </p>
       </subsection>
 

--- a/src/site/xdoc/checks/whitespace/parenpad.xml.template
+++ b/src/site/xdoc/checks/whitespace/parenpad.xml.template
@@ -100,9 +100,11 @@ try (Closeable resource = acquire(); ) // no check before right parenthesis
         </p>
       </subsection>
 
-      <subsection name="Package" id="ParenPad_Package">
+      <subsection name="Fully Qualified Name" id="Fully_Qualified_Name">
+        <p> com.puppycrawl.tools.checkstyle.checks.whitespace.ParenPadCheck</p>
         <p>
-          com.puppycrawl.tools.checkstyle.checks.whitespace
+          Use this fully qualified class name in configuration when an exact class reference is
+          required.
         </p>
       </subsection>
 

--- a/src/site/xdoc/checks/whitespace/separatorwrap.xml
+++ b/src/site/xdoc/checks/whitespace/separatorwrap.xml
@@ -205,9 +205,11 @@ class Example3 {
         </p>
       </subsection>
 
-      <subsection name="Package" id="SeparatorWrap_Package">
+      <subsection name="Fully Qualified Name" id="Fully_Qualified_Name">
+        <p> com.puppycrawl.tools.checkstyle.checks.whitespace.SeparatorWrapCheck</p>
         <p>
-          com.puppycrawl.tools.checkstyle.checks.whitespace
+          Use this fully qualified class name in configuration when an exact class reference is
+          required.
         </p>
       </subsection>
 

--- a/src/site/xdoc/checks/whitespace/separatorwrap.xml.template
+++ b/src/site/xdoc/checks/whitespace/separatorwrap.xml.template
@@ -104,9 +104,11 @@
         </p>
       </subsection>
 
-      <subsection name="Package" id="SeparatorWrap_Package">
+      <subsection name="Fully Qualified Name" id="Fully_Qualified_Name">
+        <p> com.puppycrawl.tools.checkstyle.checks.whitespace.SeparatorWrapCheck</p>
         <p>
-          com.puppycrawl.tools.checkstyle.checks.whitespace
+          Use this fully qualified class name in configuration when an exact class reference is
+          required.
         </p>
       </subsection>
 

--- a/src/site/xdoc/checks/whitespace/singlespaceseparator.xml
+++ b/src/site/xdoc/checks/whitespace/singlespaceseparator.xml
@@ -146,9 +146,11 @@ class Example2 {
         </p>
       </subsection>
 
-      <subsection name="Package" id="SingleSpaceSeparator_Package">
+      <subsection name="Fully Qualified Name" id="Fully_Qualified_Name">
+        <p> com.puppycrawl.tools.checkstyle.checks.whitespace.SingleSpaceSeparatorCheck</p>
         <p>
-          com.puppycrawl.tools.checkstyle.checks.whitespace
+          Use this fully qualified class name in configuration when an exact class reference is
+          required.
         </p>
       </subsection>
 

--- a/src/site/xdoc/checks/whitespace/singlespaceseparator.xml.template
+++ b/src/site/xdoc/checks/whitespace/singlespaceseparator.xml.template
@@ -80,9 +80,11 @@
         </p>
       </subsection>
 
-      <subsection name="Package" id="SingleSpaceSeparator_Package">
+      <subsection name="Fully Qualified Name" id="Fully_Qualified_Name">
+        <p> com.puppycrawl.tools.checkstyle.checks.whitespace.SingleSpaceSeparatorCheck</p>
         <p>
-          com.puppycrawl.tools.checkstyle.checks.whitespace
+          Use this fully qualified class name in configuration when an exact class reference is
+          required.
         </p>
       </subsection>
 

--- a/src/site/xdoc/checks/whitespace/typecastparenpad.xml
+++ b/src/site/xdoc/checks/whitespace/typecastparenpad.xml
@@ -142,9 +142,11 @@ class Example2 {
         </p>
       </subsection>
 
-      <subsection name="Package" id="TypecastParenPad_Package">
+      <subsection name="Fully Qualified Name" id="Fully_Qualified_Name">
+        <p> com.puppycrawl.tools.checkstyle.checks.whitespace.TypecastParenPadCheck</p>
         <p>
-          com.puppycrawl.tools.checkstyle.checks.whitespace
+          Use this fully qualified class name in configuration when an exact class reference is
+          required.
         </p>
       </subsection>
 

--- a/src/site/xdoc/checks/whitespace/typecastparenpad.xml.template
+++ b/src/site/xdoc/checks/whitespace/typecastparenpad.xml.template
@@ -87,9 +87,11 @@
         </p>
       </subsection>
 
-      <subsection name="Package" id="TypecastParenPad_Package">
+      <subsection name="Fully Qualified Name" id="Fully_Qualified_Name">
+        <p> com.puppycrawl.tools.checkstyle.checks.whitespace.TypecastParenPadCheck</p>
         <p>
-          com.puppycrawl.tools.checkstyle.checks.whitespace
+          Use this fully qualified class name in configuration when an exact class reference is
+          required.
         </p>
       </subsection>
 

--- a/src/site/xdoc/checks/whitespace/whitespaceafter.xml
+++ b/src/site/xdoc/checks/whitespace/whitespaceafter.xml
@@ -256,9 +256,11 @@ class Example2 {
         </p>
       </subsection>
 
-      <subsection name="Package" id="WhitespaceAfter_Package">
+      <subsection name="Fully Qualified Name" id="Fully_Qualified_Name">
+        <p> com.puppycrawl.tools.checkstyle.checks.whitespace.WhitespaceAfterCheck</p>
         <p>
-          com.puppycrawl.tools.checkstyle.checks.whitespace
+          Use this fully qualified class name in configuration when an exact class reference is
+          required.
         </p>
       </subsection>
 

--- a/src/site/xdoc/checks/whitespace/whitespaceafter.xml.template
+++ b/src/site/xdoc/checks/whitespace/whitespaceafter.xml.template
@@ -88,9 +88,11 @@
         </p>
       </subsection>
 
-      <subsection name="Package" id="WhitespaceAfter_Package">
+      <subsection name="Fully Qualified Name" id="Fully_Qualified_Name">
+        <p> com.puppycrawl.tools.checkstyle.checks.whitespace.WhitespaceAfterCheck</p>
         <p>
-          com.puppycrawl.tools.checkstyle.checks.whitespace
+          Use this fully qualified class name in configuration when an exact class reference is
+          required.
         </p>
       </subsection>
 

--- a/src/site/xdoc/checks/whitespace/whitespacearound.xml
+++ b/src/site/xdoc/checks/whitespace/whitespacearound.xml
@@ -697,9 +697,11 @@ class Example11 {
         </p>
       </subsection>
 
-      <subsection name="Package" id="WhitespaceAround_Package">
+      <subsection name="Fully Qualified Name" id="Fully_Qualified_Name">
+        <p> com.puppycrawl.tools.checkstyle.checks.whitespace.WhitespaceAroundCheck</p>
         <p>
-          com.puppycrawl.tools.checkstyle.checks.whitespace
+          Use this fully qualified class name in configuration when an exact class reference is
+          required.
         </p>
       </subsection>
 

--- a/src/site/xdoc/checks/whitespace/whitespacearound.xml.template
+++ b/src/site/xdoc/checks/whitespace/whitespacearound.xml.template
@@ -219,9 +219,11 @@
         </p>
       </subsection>
 
-      <subsection name="Package" id="WhitespaceAround_Package">
+      <subsection name="Fully Qualified Name" id="Fully_Qualified_Name">
+        <p> com.puppycrawl.tools.checkstyle.checks.whitespace.WhitespaceAroundCheck</p>
         <p>
-          com.puppycrawl.tools.checkstyle.checks.whitespace
+          Use this fully qualified class name in configuration when an exact class reference is
+          required.
         </p>
       </subsection>
 

--- a/src/site/xdoc/config.xml
+++ b/src/site/xdoc/config.xml
@@ -508,8 +508,8 @@
         </ul>
       </subsection>
 
-      <subsection name="Package" id="Checker_Package">
-        <p> com.puppycrawl.tools.checkstyle </p>
+      <subsection name="Fully Qualified Name" id="Checker_Fully_Qualified_Name">
+        <p> com.puppycrawl.tools.checkstyle.Checker </p>
       </subsection>
     </section>
 
@@ -676,8 +676,8 @@
         </ul>
       </subsection>
 
-      <subsection name="Package" id="TreeWalker_Package">
-        <p> com.puppycrawl.tools.checkstyle </p>
+      <subsection name="Fully Qualified Name" id="TreeWalker_Fully_Qualified_Name">
+        <p> com.puppycrawl.tools.checkstyle.TreeWalker </p>
       </subsection>
 
       <subsection name="Parent Module" id="TreeWalker_Parent_Module">

--- a/src/site/xdoc/filefilters/beforeexecutionexclusionfilefilter.xml
+++ b/src/site/xdoc/filefilters/beforeexecutionexclusionfilefilter.xml
@@ -196,8 +196,13 @@
           </li>
         </ul>
       </subsection>
-      <subsection name="Package" id="BeforeExecutionExclusionFileFilter_Package">
-        <p> com.puppycrawl.tools.checkstyle.filefilters </p>
+
+      <subsection name="Fully Qualified Name" id="Fully_Qualified_Name">
+        <p> com.puppycrawl.tools.checkstyle.filefilters.BeforeExecutionExclusionFileFilter </p>
+        <p>
+            This is the fully qualified class name of the module.
+            Use this name in configuration when an exact class reference is required.
+        </p>
       </subsection>
 
       <subsection name="Parent Module" id="BeforeExecutionExclusionFileFilter_Parent_Module">

--- a/src/site/xdoc/filefilters/beforeexecutionexclusionfilefilter.xml.template
+++ b/src/site/xdoc/filefilters/beforeexecutionexclusionfilefilter.xml.template
@@ -107,8 +107,13 @@
           </li>
         </ul>
       </subsection>
-      <subsection name="Package" id="BeforeExecutionExclusionFileFilter_Package">
-        <p> com.puppycrawl.tools.checkstyle.filefilters </p>
+
+      <subsection name="Fully Qualified Name" id="Fully_Qualified_Name">
+        <p> com.puppycrawl.tools.checkstyle.filefilters.BeforeExecutionExclusionFileFilter </p>
+        <p>
+            This is the fully qualified class name of the module.
+            Use this name in configuration when an exact class reference is required.
+        </p>
       </subsection>
 
       <subsection name="Parent Module" id="BeforeExecutionExclusionFileFilter_Parent_Module">

--- a/src/site/xdoc/filters/severitymatchfilter.xml
+++ b/src/site/xdoc/filters/severitymatchfilter.xml
@@ -86,8 +86,12 @@ public class Example1 {
           </li>
         </ul>
       </subsection>
-      <subsection name="Package" id="SeverityMatchFilter_Package">
-        <p> com.puppycrawl.tools.checkstyle.filters </p>
+      <subsection name="Fully Qualified Name" id="Fully_Qualified_Name">
+        <p> com.puppycrawl.tools.checkstyle.filters.SeverityMatchFilter </p>
+        <p>
+            This is the fully qualified class name of the module.
+            Use this name in configuration when an exact class reference is required.
+        </p>
       </subsection>
 
       <subsection name="Parent Module" id="SeverityMatchFilter_Parent_Module">

--- a/src/site/xdoc/filters/severitymatchfilter.xml.template
+++ b/src/site/xdoc/filters/severitymatchfilter.xml.template
@@ -59,8 +59,12 @@
           </li>
         </ul>
       </subsection>
-      <subsection name="Package" id="SeverityMatchFilter_Package">
-        <p> com.puppycrawl.tools.checkstyle.filters </p>
+      <subsection name="Fully Qualified Name" id="Fully_Qualified_Name">
+        <p> com.puppycrawl.tools.checkstyle.filters.SeverityMatchFilter </p>
+        <p>
+            This is the fully qualified class name of the module.
+            Use this name in configuration when an exact class reference is required.
+        </p>
       </subsection>
 
       <subsection name="Parent Module" id="SeverityMatchFilter_Parent_Module">

--- a/src/site/xdoc/filters/suppressioncommentfilter.xml
+++ b/src/site/xdoc/filters/suppressioncommentfilter.xml
@@ -550,8 +550,12 @@ class Example8
           </li>
         </ul>
       </subsection>
-      <subsection name="Package" id="SuppressionCommentFilter_Package">
-        <p> com.puppycrawl.tools.checkstyle.filters </p>
+      <subsection name="Fully Qualified Name" id="Fully_Qualified_Name">
+        <p> com.puppycrawl.tools.checkstyle.filters.SuppressionCommentFilter </p>
+        <p>
+            This is the fully qualified class name of the module.
+            Use this name in configuration when an exact class reference is required.
+        </p>
       </subsection>
 
       <subsection name="Parent Module" id="SuppressionCommentFilter_Parent_Module">

--- a/src/site/xdoc/filters/suppressioncommentfilter.xml.template
+++ b/src/site/xdoc/filters/suppressioncommentfilter.xml.template
@@ -175,8 +175,12 @@
           </li>
         </ul>
       </subsection>
-      <subsection name="Package" id="SuppressionCommentFilter_Package">
-        <p> com.puppycrawl.tools.checkstyle.filters </p>
+      <subsection name="Fully Qualified Name" id="Fully_Qualified_Name">
+        <p> com.puppycrawl.tools.checkstyle.filters.SuppressionCommentFilter </p>
+        <p>
+            This is the fully qualified class name of the module.
+            Use this name in configuration when an exact class reference is required.
+        </p>
       </subsection>
 
       <subsection name="Parent Module" id="SuppressionCommentFilter_Parent_Module">

--- a/src/site/xdoc/filters/suppressionfilter.xml
+++ b/src/site/xdoc/filters/suppressionfilter.xml
@@ -401,8 +401,12 @@ files=&quot;com[\\/]mycompany[\\/]app[\\/].*IT.java&quot;/&gt;
           </li>
         </ul>
       </subsection>
-      <subsection name="Package" id="SuppressionFilter_Package">
-        <p> com.puppycrawl.tools.checkstyle.filters </p>
+      <subsection name="Fully Qualified Name" id="Fully_Qualified_Name">
+        <p> com.puppycrawl.tools.checkstyle.filters.SuppressionFilter </p>
+        <p>
+              This is the fully qualified class name of the module.
+              Use this name in configuration when an exact class reference is required.
+        </p>
       </subsection>
 
       <subsection name="Parent Module" id="SuppressionFilter_Parent_Module">

--- a/src/site/xdoc/filters/suppressionfilter.xml.template
+++ b/src/site/xdoc/filters/suppressionfilter.xml.template
@@ -201,8 +201,12 @@ files="com[\\/]mycompany[\\/]app[\\/].*IT.java"/&gt;
           </li>
         </ul>
       </subsection>
-      <subsection name="Package" id="SuppressionFilter_Package">
-        <p> com.puppycrawl.tools.checkstyle.filters </p>
+      <subsection name="Fully Qualified Name" id="Fully_Qualified_Name">
+        <p> com.puppycrawl.tools.checkstyle.filters.SuppressionFilter </p>
+        <p>
+              This is the fully qualified class name of the module.
+              Use this name in configuration when an exact class reference is required.
+        </p>
       </subsection>
 
       <subsection name="Parent Module" id="SuppressionFilter_Parent_Module">

--- a/src/site/xdoc/filters/suppressionsinglefilter.xml
+++ b/src/site/xdoc/filters/suppressionsinglefilter.xml
@@ -223,8 +223,12 @@ public class Example4 {
           </li>
         </ul>
       </subsection>
-      <subsection name="Package" id="SuppressionSingleFilter_Package">
-        <p> com.puppycrawl.tools.checkstyle.filters </p>
+      <subsection name="Fully Qualified Name" id="Fully_Qualified_Name">
+        <p> com.puppycrawl.tools.checkstyle.filters.SuppressionSingleFilter</p>
+        <p>
+            This is the fully qualified class name of the module.
+            Use this name in configuration when an exact class reference is required.
+        </p>
       </subsection>
       <subsection name="Parent Module" id="SuppressionSingleFilter_Parent_Module">
         <p>

--- a/src/site/xdoc/filters/suppressionsinglefilter.xml.template
+++ b/src/site/xdoc/filters/suppressionsinglefilter.xml.template
@@ -107,8 +107,12 @@
           </li>
         </ul>
       </subsection>
-      <subsection name="Package" id="SuppressionSingleFilter_Package">
-        <p> com.puppycrawl.tools.checkstyle.filters </p>
+      <subsection name="Fully Qualified Name" id="Fully_Qualified_Name">
+        <p> com.puppycrawl.tools.checkstyle.filters.SuppressionSingleFilter</p>
+        <p>
+            This is the fully qualified class name of the module.
+            Use this name in configuration when an exact class reference is required.
+        </p>
       </subsection>
       <subsection name="Parent Module" id="SuppressionSingleFilter_Parent_Module">
         <macro name="parent-module">

--- a/src/site/xdoc/filters/suppressionxpathfilter.xml
+++ b/src/site/xdoc/filters/suppressionxpathfilter.xml
@@ -1017,8 +1017,12 @@ public class Example14 {
           </li>
         </ul>
       </subsection>
-      <subsection name="Package" id="SuppressionXpathFilter_Package">
-        <p> com.puppycrawl.tools.checkstyle.filters </p>
+      <subsection name="Fully Qualified Name" id="Fully_Qualified_Name">
+        <p> com.puppycrawl.tools.checkstyle.filters.SuppressionXpathFilter</p>
+        <p>
+            This is the fully qualified class name of the module.
+            Use this name in configuration when an exact class reference is required.
+        </p>
       </subsection>
 
       <subsection name="Parent Module" id="SuppressionXpathFilter_Parent_Module">

--- a/src/site/xdoc/filters/suppressionxpathfilter.xml.template
+++ b/src/site/xdoc/filters/suppressionxpathfilter.xml.template
@@ -569,8 +569,12 @@ CLASS_DEF -&gt; CLASS_DEF [1:0]
           </li>
         </ul>
       </subsection>
-      <subsection name="Package" id="SuppressionXpathFilter_Package">
-        <p> com.puppycrawl.tools.checkstyle.filters </p>
+      <subsection name="Fully Qualified Name" id="Fully_Qualified_Name">
+        <p> com.puppycrawl.tools.checkstyle.filters.SuppressionXpathFilter</p>
+        <p>
+            This is the fully qualified class name of the module.
+            Use this name in configuration when an exact class reference is required.
+        </p>
       </subsection>
 
       <subsection name="Parent Module" id="SuppressionXpathFilter_Parent_Module">

--- a/src/site/xdoc/filters/suppressionxpathsinglefilter.xml
+++ b/src/site/xdoc/filters/suppressionxpathsinglefilter.xml
@@ -504,8 +504,12 @@ public class Example13 {
           </li>
         </ul>
       </subsection>
-      <subsection name="Package" id="SuppressionXpathSingleFilter_Package">
-        <p> com.puppycrawl.tools.checkstyle.filters </p>
+      <subsection name="Fully Qualified Name" id="Fully_Qualified_Name">
+        <p> com.puppycrawl.tools.checkstyle.filters.SuppressionXpathSingleFilter</p>
+        <p>
+              This is the fully qualified class name of the module.
+              Use this name in configuration when an exact class reference is required.
+        </p>
       </subsection>
       <subsection name="Parent Module" id="SuppressionXpathSingleFilter_Parent_Module">
         <p>

--- a/src/site/xdoc/filters/suppressionxpathsinglefilter.xml.template
+++ b/src/site/xdoc/filters/suppressionxpathsinglefilter.xml.template
@@ -267,8 +267,12 @@
           </li>
         </ul>
       </subsection>
-      <subsection name="Package" id="SuppressionXpathSingleFilter_Package">
-        <p> com.puppycrawl.tools.checkstyle.filters </p>
+      <subsection name="Fully Qualified Name" id="Fully_Qualified_Name">
+        <p> com.puppycrawl.tools.checkstyle.filters.SuppressionXpathSingleFilter</p>
+        <p>
+              This is the fully qualified class name of the module.
+              Use this name in configuration when an exact class reference is required.
+        </p>
       </subsection>
       <subsection name="Parent Module" id="SuppressionXpathSingleFilter_Parent_Module">
         <macro name="parent-module">

--- a/src/site/xdoc/filters/suppresswarningsfilter.xml
+++ b/src/site/xdoc/filters/suppresswarningsfilter.xml
@@ -114,8 +114,12 @@ public class Example2 {
           </li>
         </ul>
       </subsection>
-      <subsection name="Package" id="SuppressWarningsFilter_Package">
-        <p> com.puppycrawl.tools.checkstyle.filters </p>
+      <subsection name="Fully Qualified Name" id="Fully_Qualified_Name">
+        <p> com.puppycrawl.tools.checkstyle.filters.SuppressWarningsFilter</p>
+        <p>
+            This is the fully qualified class name of the module.
+            Use this name in configuration when an exact class reference is required.
+        </p>
       </subsection>
 
       <subsection name="Parent Module" id="SuppressWarningsFilter_Parent_Module">

--- a/src/site/xdoc/filters/suppresswarningsfilter.xml.template
+++ b/src/site/xdoc/filters/suppresswarningsfilter.xml.template
@@ -68,8 +68,12 @@
           </li>
         </ul>
       </subsection>
-      <subsection name="Package" id="SuppressWarningsFilter_Package">
-        <p> com.puppycrawl.tools.checkstyle.filters </p>
+      <subsection name="Fully Qualified Name" id="Fully_Qualified_Name">
+        <p> com.puppycrawl.tools.checkstyle.filters.SuppressWarningsFilter</p>
+        <p>
+            This is the fully qualified class name of the module.
+            Use this name in configuration when an exact class reference is required.
+        </p>
       </subsection>
 
       <subsection name="Parent Module" id="SuppressWarningsFilter_Parent_Module">

--- a/src/site/xdoc/filters/suppresswithnearbycommentfilter.xml
+++ b/src/site/xdoc/filters/suppresswithnearbycommentfilter.xml
@@ -348,8 +348,12 @@ public class Example8 { // filtered violation 'Class Data Abstraction Coupling i
           </li>
         </ul>
       </subsection>
-      <subsection name="Package" id="SuppressWithNearbyCommentFilter_Package">
-        <p> com.puppycrawl.tools.checkstyle.filters </p>
+      <subsection name="Fully Qualified Name" id="Fully_Qualified_Name">
+        <p> com.puppycrawl.tools.checkstyle.filters.SuppressWithNearbyCommentFilter</p>
+        <p>
+            This is the fully qualified class name of the module.
+            Use this name in configuration when an exact class reference is required.
+        </p>
       </subsection>
 
       <subsection name="Parent Module" id="SuppressWithNearbyCommentFilter_Parent_Module">

--- a/src/site/xdoc/filters/suppresswithnearbycommentfilter.xml.template
+++ b/src/site/xdoc/filters/suppresswithnearbycommentfilter.xml.template
@@ -177,8 +177,12 @@
           </li>
         </ul>
       </subsection>
-      <subsection name="Package" id="SuppressWithNearbyCommentFilter_Package">
-        <p> com.puppycrawl.tools.checkstyle.filters </p>
+      <subsection name="Fully Qualified Name" id="Fully_Qualified_Name">
+        <p> com.puppycrawl.tools.checkstyle.filters.SuppressWithNearbyCommentFilter</p>
+        <p>
+            This is the fully qualified class name of the module.
+            Use this name in configuration when an exact class reference is required.
+        </p>
       </subsection>
 
       <subsection name="Parent Module" id="SuppressWithNearbyCommentFilter_Parent_Module">

--- a/src/site/xdoc/filters/suppresswithnearbytextfilter.xml
+++ b/src/site/xdoc/filters/suppresswithnearbytextfilter.xml
@@ -313,8 +313,12 @@ public class Example9 {
           </li>
         </ul>
       </subsection>
-      <subsection name="Package" id="SuppressWithNearbyTextFilter_Package">
-        <p> com.puppycrawl.tools.checkstyle.filters </p>
+      <subsection name="Fully Qualified Name" id="Fully_Qualified_Name">
+        <p> com.puppycrawl.tools.checkstyle.filters.SuppressWithNearbyTextFilter</p>
+        <p>
+              This is the fully qualified class name of the module.
+              Use this name in configuration when an exact class reference is required.
+        </p>
       </subsection>
 
       <subsection name="Parent Module" id="SuppressWithNearbyTextFilter_Parent_Module">

--- a/src/site/xdoc/filters/suppresswithnearbytextfilter.xml.template
+++ b/src/site/xdoc/filters/suppresswithnearbytextfilter.xml.template
@@ -196,8 +196,12 @@
           </li>
         </ul>
       </subsection>
-      <subsection name="Package" id="SuppressWithNearbyTextFilter_Package">
-        <p> com.puppycrawl.tools.checkstyle.filters </p>
+      <subsection name="Fully Qualified Name" id="Fully_Qualified_Name">
+        <p> com.puppycrawl.tools.checkstyle.filters.SuppressWithNearbyTextFilter</p>
+        <p>
+              This is the fully qualified class name of the module.
+              Use this name in configuration when an exact class reference is required.
+        </p>
       </subsection>
 
       <subsection name="Parent Module" id="SuppressWithNearbyTextFilter_Parent_Module">

--- a/src/site/xdoc/filters/suppresswithplaintextcommentfilter.xml
+++ b/src/site/xdoc/filters/suppresswithplaintextcommentfilter.xml
@@ -483,8 +483,12 @@ public class Example9 {
           </li>
         </ul>
       </subsection>
-      <subsection name="Package" id="SuppressWithPlainTextCommentFilter_Package">
-        <p> com.puppycrawl.tools.checkstyle.filters </p>
+      <subsection name="Fully Qualified Name" id="Fully_Qualified_Name">
+        <p> com.puppycrawl.tools.checkstyle.filters.SuppressWithPlainTextCommentFilter</p>
+        <p>
+            This is the fully qualified class name of the module.
+            Use this name in configuration when an exact class reference is required.
+        </p>
       </subsection>
 
       <subsection name="Parent Module" id="SuppressWithPlainTextCommentFilter_Parent_Module">

--- a/src/site/xdoc/filters/suppresswithplaintextcommentfilter.xml.template
+++ b/src/site/xdoc/filters/suppresswithplaintextcommentfilter.xml.template
@@ -215,8 +215,12 @@
           </li>
         </ul>
       </subsection>
-      <subsection name="Package" id="SuppressWithPlainTextCommentFilter_Package">
-        <p> com.puppycrawl.tools.checkstyle.filters </p>
+      <subsection name="Fully Qualified Name" id="Fully_Qualified_Name">
+        <p> com.puppycrawl.tools.checkstyle.filters.SuppressWithPlainTextCommentFilter</p>
+        <p>
+            This is the fully qualified class name of the module.
+            Use this name in configuration when an exact class reference is required.
+        </p>
       </subsection>
 
       <subsection name="Parent Module" id="SuppressWithPlainTextCommentFilter_Parent_Module">

--- a/src/test/java/com/puppycrawl/tools/checkstyle/internal/XdocsPagesTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/internal/XdocsPagesTest.java
@@ -934,7 +934,8 @@ public class XdocsPagesTest {
                 case 1 -> validatePropertySection(fileName, sectionName, subSection, instance);
                 case 3 -> validateUsageExample(fileName, sectionName, subSection);
                 case 4 -> validateViolationSection(fileName, sectionName, subSection, instance);
-                case 5 -> validatePackageSection(fileName, sectionName, subSection, instance);
+                case 5 -> validateFullyQualifiedNameSection(
+                        fileName, sectionName, subSection, instance);
                 case 6 -> validateParentSection(fileName, sectionName, subSection);
                 default -> {
                     // no code by design
@@ -974,7 +975,7 @@ public class XdocsPagesTest {
             case 2 -> "Examples";
             case 3 -> "Example of Usage";
             case 4 -> "Violation Messages";
-            case 5 -> "Package";
+            case 5 -> "Fully Qualified Name";
             case 6 -> "Parent Module";
             default -> null;
         };
@@ -1841,11 +1842,15 @@ public class XdocsPagesTest {
                 .isTrue();
     }
 
-    private static void validatePackageSection(String fileName, String sectionName,
-            Node subSection, Object instance) {
-        assertWithMessage("%s section '%s' should have matching package", fileName, sectionName)
-            .that(subSection.getTextContent().trim())
-            .isEqualTo(instance.getClass().getPackage().getName());
+    private static void validateFullyQualifiedNameSection(String fileName, String sectionName,
+                                                          Node subSection, Object instance) {
+        final String fullyQualifiedName = subSection.getTextContent()
+                .replaceAll("\\s+", "");
+
+        assertWithMessage("%s section '%s' should have matching fully qualified name",
+                fileName, sectionName)
+                .that(fullyQualifiedName)
+                .contains(instance.getClass().getName());
     }
 
     private static void validateParentSection(String fileName, String sectionName,


### PR DESCRIPTION
#13194 

# What was problem

`Rethink purpose of package section in Check module documentation`  so, as per discussion I keep each check package section into their documentation page and modified each and every check whole package section into fully qualified name.

---

# Outcome
<img width="1410" height="554" alt="image" src="https://github.com/user-attachments/assets/4b2b47e2-7399-4308-a041-ea830345918c" />

I changed file `XdocExamplePageTest.java` , `src/site/Xdocs/checks/...` , `src/site/Xdocs/filefilters...` , `src/site/Xdocs/filters...`.