### PR TITLE
Issue #19394: Increase MaxRAMPercentage to 90 for no-error-pmd job

### DIFF
--- a/.ci/validation.sh
+++ b/.ci/validation.sh
@@ -238,7 +238,7 @@ EOF
   ;;
 
 no-error-pmd)
-  export MAVEN_OPTS="-XX:MaxRAMPercentage=75"
+  export MAVEN_OPTS="-XX:MaxRAMPercentage=90"
   CS_POM_VERSION="$(getCheckstylePomVersion)"
   echo "CS_version: ${CS_POM_VERSION}"
   ./mvnw -e --no-transfer-progress clean install -Pno-validations


### PR DESCRIPTION
Resolves #19394

Changed `-XX:MaxRAMPercentage=75` to `-XX:MaxRAMPercentage=90` in `.ci/validation.sh` for the `no-error-pmd` job to address OOM failures on CircleCI `medium+` resource class