### PR TITLE
Issue #19064: Remove stale suppression for XpathRegressionDeclarationOrderTest

### DIFF
--- a/config/checkstyle-non-main-files-suppressions.xml
+++ b/config/checkstyle-non-main-files-suppressions.xml
@@ -410,4 +410,5 @@
   <suppress id="violationMessagesModuleMacroMustExist"
             files="src[\\/]site[\\/]xdoc[\\/]checks[\\/][a-z]+\.xml"/>
 
+
 </suppressions>


### PR DESCRIPTION
Contributes to #19064

Remove stale numberOfTestCasesInXpath suppression for XpathRegressionDeclarationOrderTest — the test file already has 3 @Test methods.