### PR TITLE
Issue #15456: Define violation messages for CyclomaticComplexity

### DIFF
--- a/src/test/java/com/puppycrawl/tools/checkstyle/bdd/InlineConfigParser.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/bdd/InlineConfigParser.java
@@ -258,7 +258,6 @@ public final class InlineConfigParser {
             "com.puppycrawl.tools.checkstyle.checks.metrics.BooleanExpressionComplexityCheck",
             "com.puppycrawl.tools.checkstyle.checks.metrics.ClassDataAbstractionCouplingCheck",
             "com.puppycrawl.tools.checkstyle.checks.metrics.ClassFanOutComplexityCheck",
-            "com.puppycrawl.tools.checkstyle.checks.metrics.CyclomaticComplexityCheck",
             "com.puppycrawl.tools.checkstyle.checks.metrics.NPathComplexityCheck",
             "com.puppycrawl.tools.checkstyle.checks.modifier.ClassMemberImpliedModifierCheck",
             "com.puppycrawl.tools.checkstyle.checks.modifier.InterfaceMemberImpliedModifierCheck",

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/metrics/CyclomaticComplexityCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/metrics/CyclomaticComplexityCheckTest.java
@@ -76,11 +76,11 @@ public class CyclomaticComplexityCheckTest
             "32:5: " + getCheckMessage(MSG_KEY, 6, 0),
             "45:5: " + getCheckMessage(MSG_KEY, 3, 0),
             "55:5: " + getCheckMessage(MSG_KEY, 5, 0),
-            "73:5: " + getCheckMessage(MSG_KEY, 3, 0),
-            "86:5: " + getCheckMessage(MSG_KEY, 3, 0),
-            "98:5: " + getCheckMessage(MSG_KEY, 3, 0),
-            "110:5: " + getCheckMessage(MSG_KEY, 1, 0),
-            "114:13: " + getCheckMessage(MSG_KEY, 2, 0),
+            "74:5: " + getCheckMessage(MSG_KEY, 3, 0),
+            "87:5: " + getCheckMessage(MSG_KEY, 3, 0),
+            "99:5: " + getCheckMessage(MSG_KEY, 3, 0),
+            "112:5: " + getCheckMessage(MSG_KEY, 1, 0),
+            "116:13: " + getCheckMessage(MSG_KEY, 2, 0),
         };
 
         verifyWithInlineConfigParser(
@@ -93,11 +93,11 @@ public class CyclomaticComplexityCheckTest
         final int max = 0;
 
         final String[] expected = {
-            "17:9: " + getCheckMessage(MSG_KEY, 11, max),
-            "48:9: " + getCheckMessage(MSG_KEY, 11, max),
-            "83:5: " + getCheckMessage(MSG_KEY, 11, max),
-            "115:5: " + getCheckMessage(MSG_KEY, 11, max),
-            "148:5: " + getCheckMessage(MSG_KEY, 11, max),
+            "18:9: " + getCheckMessage(MSG_KEY, 11, max),
+            "49:9: " + getCheckMessage(MSG_KEY, 11, max),
+            "84:5: " + getCheckMessage(MSG_KEY, 11, max),
+            "116:5: " + getCheckMessage(MSG_KEY, 11, max),
+            "149:5: " + getCheckMessage(MSG_KEY, 11, max),
         };
 
         verifyWithInlineConfigParser(

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/metrics/cyclomaticcomplexity/InputCyclomaticComplexity.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/metrics/cyclomaticcomplexity/InputCyclomaticComplexity.java
@@ -12,12 +12,12 @@ package com.puppycrawl.tools.checkstyle.checks.metrics.cyclomaticcomplexity;
 
 public class InputCyclomaticComplexity {
     // NP = 2
-    public void foo() { // violation
+    public void foo() { // violation, 'Cyclomatic Complexity is 2 (max allowed is 0).'
         //NP(while-statement) = (while-range=1) + (expr=0) + 1 = 2
         while (true) {
             Runnable runnable = new Runnable() {
                // NP = 2
-                public void run() { // violation
+                public void run() { // violation, 'Cyclomatic Complexity is 2 (max allowed is 0).'
                     // NP(while-statement) = (while-range=1) + (expr=0) + 1 = 2
                     while (true) {
                     }
@@ -29,7 +29,7 @@ public class InputCyclomaticComplexity {
     }
 
     // NP = 10
-    public void bar() { // violation
+    public void bar() { // violation, 'Cyclomatic Complexity is 6 (max allowed is 0).'
         // NP = (if-range=3*3) + (expr=0) + 1 = 10
         if (System.currentTimeMillis() == 0) {
             //NP = (if-range=1) + 1 + (expr=1) = 3
@@ -42,7 +42,7 @@ public class InputCyclomaticComplexity {
     }
 
     // NP = 3
-    public void simpleElseIf() { // violation
+    public void simpleElseIf() { // violation, 'Cyclomatic Complexity is 3 (max allowed is 0).'
         // NP = (if-range=1) + (else-range=2) + 0 = 3
         if (System.currentTimeMillis() == 0) {
         // NP(else-range) = (if-range=1) + (else-range=1) + (expr=0) = 2
@@ -52,7 +52,7 @@ public class InputCyclomaticComplexity {
     }
 
     // NP = 7
-    public void stupidElseIf() { // violation
+    public void stupidElseIf() { // violation, 'Cyclomatic Complexity is 5 (max allowed is 0).'
         // NP = (if-range=1) + (else-range=3*2) + (expr=0) = 7
         if (System.currentTimeMillis() == 0) {
         } else {
@@ -70,7 +70,8 @@ public class InputCyclomaticComplexity {
     }
 
     // NP = 3
-    public InputCyclomaticComplexity() // violation
+    // violation below, 'Cyclomatic Complexity is 3 (max allowed is 0).'
+    public InputCyclomaticComplexity()
     {
         int i = 1;
         // NP = (if-range=1) + (else-range=2) + 0 = 3
@@ -83,7 +84,7 @@ public class InputCyclomaticComplexity {
 
     // STATIC_INIT
     // NP = 3
-    static { // violation
+    static { // violation, 'Cyclomatic Complexity is 3 (max allowed is 0).'
         int i = 1;
         // NP = (if-range=1) + (else-range=2) + 0 = 3
         if (System.currentTimeMillis() == 0) {
@@ -95,7 +96,7 @@ public class InputCyclomaticComplexity {
 
     // INSTANCE_INIT
     // NP = 3
-    { // violation
+    { // violation, 'Cyclomatic Complexity is 3 (max allowed is 0).'
         int i = 1;
         // NP = (if-range=1) + (else-range=2) + 0 = 3
         if (System.currentTimeMillis() == 0) {
@@ -107,11 +108,12 @@ public class InputCyclomaticComplexity {
 
     /** Inner */
     // NP = 0
-    public InputCyclomaticComplexity(int aParam) // violation
+    // violation below, 'Cyclomatic Complexity is 1 (max allowed is 0).'
+    public InputCyclomaticComplexity(int aParam)
     {
         Runnable runnable = new Runnable() {
             // NP = 2
-            public void run() { // violation
+            public void run() { // violation, 'Cyclomatic Complexity is 2 (max allowed is 0).'
                 // NP(while-statement) = (while-range=1) + (expr=0) + 1 = 2
                 while (true) {
                 }

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/metrics/cyclomaticcomplexity/InputCyclomaticComplexityRecords.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/metrics/cyclomaticcomplexity/InputCyclomaticComplexityRecords.java
@@ -14,7 +14,8 @@ package com.puppycrawl.tools.checkstyle.checks.metrics.cyclomaticcomplexity;
 public class InputCyclomaticComplexityRecords {
 
     public record MyRecord1(String str, Record record) {
-        public MyRecord1 (String str) { // violation
+        // violation below, 'Cyclomatic Complexity is 11 (max allowed is 0).'
+        public MyRecord1 (String str) {
             this("my record", new MyRecord3(true, false));
             int a = 1;
             int b = 1;
@@ -45,7 +46,7 @@ public class InputCyclomaticComplexityRecords {
             d = a < 0 ? -1 : 1; // 11, ternary operator
         }
 
-        public void foo() { // violation
+        public void foo() { // violation, 'Cyclomatic Complexity is 11 (max allowed is 0).'
             int a = 1;
             int b = 1;
             int c = 1;
@@ -80,7 +81,7 @@ public class InputCyclomaticComplexityRecords {
 
 
 record MyRecord2(boolean t, boolean f) {
-    public MyRecord2 { // violation
+    public MyRecord2 { // violation, 'Cyclomatic Complexity is 11 (max allowed is 0).'
         int a = 1;
         int b = 1;
         int c = 1;
@@ -112,7 +113,7 @@ record MyRecord2(boolean t, boolean f) {
 }
 
 record MyRecord3(boolean a, boolean b) {
-    MyRecord3(String str) { // violation
+    MyRecord3(String str) { // violation, 'Cyclomatic Complexity is 11 (max allowed is 0).'
         this(true, true);
         int a = 1;
         int b = 1;
@@ -145,7 +146,7 @@ record MyRecord3(boolean a, boolean b) {
 }
 
 record MyRecord4(boolean a, boolean b) {
-    public Record foo() { // violation
+    public Record foo() { // violation, 'Cyclomatic Complexity is 11 (max allowed is 0).'
         int a = 1;
         int b = 1;
         int c = 1;

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/metrics/cyclomaticcomplexity/InputCyclomaticComplexitySwitchBlocks.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/metrics/cyclomaticcomplexity/InputCyclomaticComplexitySwitchBlocks.java
@@ -11,7 +11,7 @@ tokens = (default)LITERAL_WHILE, LITERAL_DO, LITERAL_FOR, LITERAL_IF, LITERAL_SW
 package com.puppycrawl.tools.checkstyle.checks.metrics.cyclomaticcomplexity;
 
 public class InputCyclomaticComplexitySwitchBlocks {
-    public void foo2() { // violation
+    public void foo2() { // violation, 'Cyclomatic Complexity is 2 (max allowed is 0).'
         String programmingLanguage = "Java";
         switch (programmingLanguage) {
             case "Java":

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/metrics/cyclomaticcomplexity/InputCyclomaticComplexitySwitchBlocks2.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/metrics/cyclomaticcomplexity/InputCyclomaticComplexitySwitchBlocks2.java
@@ -11,7 +11,7 @@ tokens = (default)LITERAL_WHILE, LITERAL_DO, LITERAL_FOR, LITERAL_IF, LITERAL_SW
 package com.puppycrawl.tools.checkstyle.checks.metrics.cyclomaticcomplexity;
 
 public class InputCyclomaticComplexitySwitchBlocks2 {
-    public void foo2() { // violation
+    public void foo2() { // violation, 'Cyclomatic Complexity is 5 (max allowed is 0).'
         String programmingLanguage = "Java";
         switch (programmingLanguage) {
             case "Java":

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/metrics/cyclomaticcomplexity/InputCyclomaticComplexitySwitchBlocks5.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/metrics/cyclomaticcomplexity/InputCyclomaticComplexitySwitchBlocks5.java
@@ -11,7 +11,7 @@ tokens = (default)LITERAL_WHILE, LITERAL_DO, LITERAL_FOR, LITERAL_IF, LITERAL_SW
 package com.puppycrawl.tools.checkstyle.checks.metrics.cyclomaticcomplexity;
 
 public class InputCyclomaticComplexitySwitchBlocks5 {
-    public void foo2() { // violation 'Cyclomatic Complexity is 12 (max allowed is 10)'
+    public void foo2() { // violation, 'Cyclomatic Complexity is 12 (max allowed is 10).'
         String programmingLanguage = "Java";
         switch (programmingLanguage) {
             case "Java":

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/metrics/cyclomaticcomplexity/InputCyclomaticComplexitySwitchBlocks6.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/metrics/cyclomaticcomplexity/InputCyclomaticComplexitySwitchBlocks6.java
@@ -13,7 +13,7 @@ package com.puppycrawl.tools.checkstyle.checks.metrics.cyclomaticcomplexity;
 
 public class InputCyclomaticComplexitySwitchBlocks6 {
 
-    // violation below, 'Cyclomatic Complexity is 2 (max allowed is 0)'
+    // violation below, 'Cyclomatic Complexity is 2 (max allowed is 0).'
     void test1(Object obj1, Object obj2) { // 1, method declaration
         switch (obj1) { // 2, switch
             case Integer i1 when obj2 instanceof Integer i2 -> System.out.println("1");
@@ -22,7 +22,7 @@ public class InputCyclomaticComplexitySwitchBlocks6 {
         }
     }
 
-    // violation below, 'Cyclomatic Complexity is 2 (max allowed is 0)'
+    // violation below, 'Cyclomatic Complexity is 2 (max allowed is 0).'
     void test2(Object obj1, Object obj2) { // 1, method declaration
         switch (obj1) { // 2, switch
             case Integer i1 -> {
@@ -37,7 +37,7 @@ public class InputCyclomaticComplexitySwitchBlocks6 {
         }
     }
 
-    // violation below, 'Cyclomatic Complexity is 2 (max allowed is 0)'
+    // violation below, 'Cyclomatic Complexity is 2 (max allowed is 0).'
     void test3(Object obj1, Object obj2, Object obj3) {
         int j1 = 0, k1 = 0, l1 = 0, m1 = 0; // Initialized variables
 

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/metrics/cyclomaticcomplexity/InputCyclomaticComplexityWhenExpression.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/metrics/cyclomaticcomplexity/InputCyclomaticComplexityWhenExpression.java
@@ -12,13 +12,13 @@ package com.puppycrawl.tools.checkstyle.checks.metrics.cyclomaticcomplexity;
 
 public class InputCyclomaticComplexityWhenExpression {
 
-   // violation below, 'Cyclomatic Complexity is 5 (max allowed is 0)'
+   // violation below, 'Cyclomatic Complexity is 5 (max allowed is 0).'
    void testIf(Object o) {   // 1, function declaration
       if (o instanceof Integer i && i == 9) {}  // 2, if - 3, &&
       else if (o instanceof String s && s.length() == 9) {} // 4, if - 5, &&
    }
 
-   // violation below, 'Cyclomatic Complexity is 5 (max allowed is 0)'
+   // violation below, 'Cyclomatic Complexity is 5 (max allowed is 0).'
    void testSwitch(Object o) {   // 1, function declaration
       switch (o) {
          case Integer i when i == 9 -> {} // 2, case - 3, when
@@ -27,7 +27,7 @@ public class InputCyclomaticComplexityWhenExpression {
       }
    }
 
-   // violation below, 'Cyclomatic Complexity is 7 (max allowed is 0)'
+   // violation below, 'Cyclomatic Complexity is 7 (max allowed is 0).'
    void testSwitch2(Object o) {  // 1, function declaration
      switch (o) {
          case Integer i -> {}  // 2, case

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/metrics/cyclomaticcomplexity/InputCyclomaticComplexityWhenSwitchAsSinglePoint.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/metrics/cyclomaticcomplexity/InputCyclomaticComplexityWhenSwitchAsSinglePoint.java
@@ -12,13 +12,13 @@ package com.puppycrawl.tools.checkstyle.checks.metrics.cyclomaticcomplexity;
 
 public class InputCyclomaticComplexityWhenSwitchAsSinglePoint {
 
-    // violation below, 'Cyclomatic Complexity is 5 (max allowed is 0)'
+    // violation below, 'Cyclomatic Complexity is 5 (max allowed is 0).'
     void testIf(Object o) {   // 1, function declaration
         if (o instanceof Integer i && i == 9) {}  // 2, if - 3, &&
         else if (o instanceof String s && s.length() == 9) {} // 4, if - 5, &&
     }
 
-    // violation below, 'Cyclomatic Complexity is 2 (max allowed is 0)'
+    // violation below, 'Cyclomatic Complexity is 2 (max allowed is 0).'
     void testSwitch(Object o) {   // 1, function declaration
         switch (o) {  // 2, switch
             case Integer i when i == 9 -> {}
@@ -27,7 +27,7 @@ public class InputCyclomaticComplexityWhenSwitchAsSinglePoint {
         }
     }
 
-    // violation below, 'Cyclomatic Complexity is 2 (max allowed is 0)'
+    // violation below, 'Cyclomatic Complexity is 2 (max allowed is 0).'
     void testSwitch2(Object o) {  // 1, function declaration
         switch (o) {    // 2 switch
             case Integer i -> {}
@@ -37,7 +37,7 @@ public class InputCyclomaticComplexityWhenSwitchAsSinglePoint {
         }
     }
 
-    // violation below, 'Cyclomatic Complexity is 2 (max allowed is 0)'
+    // violation below, 'Cyclomatic Complexity is 2 (max allowed is 0).'
     void testSwitch3(Object o) {  // 1, function declaration
         switch (o) {    // 2 switch
             case Integer i -> {}


### PR DESCRIPTION
Contribution to #15456

Define violation messages for all violations in CyclomaticComplexity check input files.

Changes:
- Updated 8 input files to specify violation messages in `// violation` comments
- Updated `CyclomaticComplexityCheckTest.java` line numbers to match shifted lines
- Removed `CyclomaticComplexityCheck` from `SUPPRESSED_CHECKS` in `InlineConfigParser.java`