### PR TITLE
Issue #11163: Enforce file size for OverloadMethodsDeclarationOrder input files

### DIFF
--- a/config/checkstyle-resources-suppressions.xml
+++ b/config/checkstyle-resources-suppressions.xml
@@ -417,8 +417,6 @@
   <suppress checks="FileLength"
     files="[\\/]test[\\/]resources[\\/]com[\\/]puppycrawl[\\/]tools[\\/]checkstyle[\\/]checks[\\/]coding[\\/]nofinalizer[\\/]InputNoFinalizerFallThrough\.java"/>
   <suppress checks="FileLength"
-    files="[\\/]test[\\/]resources[\\/]com[\\/]puppycrawl[\\/]tools[\\/]checkstyle[\\/]checks[\\/]coding[\\/]overloadmethodsdeclarationorder[\\/]InputOverloadMethodsDeclarationOrder\.java"/>
-  <suppress checks="FileLength"
     files="[\\/]test[\\/]resources[\\/]com[\\/]puppycrawl[\\/]tools[\\/]checkstyle[\\/]checks[\\/]coding[\\/]fallthrough[\\/]InputFallThrough\.java"/>
   <suppress checks="FileLength"
     files="[\\/]test[\\/]resources[\\/]com[\\/]puppycrawl[\\/]tools[\\/]checkstyle[\\/]checks[\\/]coding[\\/]fallthrough[\\/]InputFallThrough3\.java"/>

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/coding/OverloadMethodsDeclarationOrderCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/coding/OverloadMethodsDeclarationOrderCheckTest.java
@@ -36,20 +36,27 @@ public class OverloadMethodsDeclarationOrderCheckTest
     }
 
     @Test
-    public void testDefault() throws Exception {
-
+    public void testDefaultPart1() throws Exception {
         final String[] expected = {
             "33:5: " + getCheckMessage(MSG_KEY, 21),
             "62:9: " + getCheckMessage(MSG_KEY, 50),
             "67:9: " + getCheckMessage(MSG_KEY, 62),
             "87:5: " + getCheckMessage(MSG_KEY, 83),
-            "132:5: " + getCheckMessage(MSG_KEY, 120),
-            "144:5: " + getCheckMessage(MSG_KEY, 137),
-            "156:9: " + getCheckMessage(MSG_KEY, 149),
-            "159:5: " + getCheckMessage(MSG_KEY, 144),
         };
         verifyWithInlineConfigParser(
-                getPath("InputOverloadMethodsDeclarationOrder.java"), expected);
+            getPath("InputOverloadMethodsDeclarationOrder1.java"), expected);
+    }
+
+    @Test
+    public void testDefaultPart2() throws Exception {
+        final String[] expected = {
+            "53:9: " + getCheckMessage(MSG_KEY, 41),
+            "65:9: " + getCheckMessage(MSG_KEY, 58),
+            "77:13: " + getCheckMessage(MSG_KEY, 70),
+            "80:9: " + getCheckMessage(MSG_KEY, 65),
+        };
+        verifyWithInlineConfigParser(
+            getPath("InputOverloadMethodsDeclarationOrder2.java"), expected);
     }
 
     @Test

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/overloadmethodsdeclarationorder/InputOverloadMethodsDeclarationOrder1.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/overloadmethodsdeclarationorder/InputOverloadMethodsDeclarationOrder1.java
@@ -6,7 +6,7 @@ OverloadMethodsDeclarationOrder
 
 package com.puppycrawl.tools.checkstyle.checks.coding.overloadmethodsdeclarationorder;
 
-class InputOverloadMethodsDeclarationOrder
+class InputOverloadMethodsDeclarationOrder1
 {
     public void overloadMethod(int i)
     {
@@ -35,7 +35,7 @@ class InputOverloadMethodsDeclarationOrder
         //some foo code
     }
 
-    InputOverloadMethodsDeclarationOrder anonymous = new InputOverloadMethodsDeclarationOrder()
+    InputOverloadMethodsDeclarationOrder1 anonymous = new InputOverloadMethodsDeclarationOrder1()
     {
         public void overloadMethod(int i)
         {
@@ -77,7 +77,7 @@ class InputOverloadMethodsDeclarationOrder
     };
 }
 
-interface Fooable
+interface Fooable1
 {
     public abstract void foo(int i);
     public abstract void foo(String s);
@@ -85,94 +85,4 @@ interface Fooable
 
     // violation below 'All overloaded methods should be placed next to each other.'
     public abstract void foo(String s, Boolean b, int i);
-}
-
-enum FooType {
-    Strategy(""),
-    Shooter(""),
-    RPG("");
-
-    private String description;
-
-    private FooType(String description) {
-        this.description = description;
-    }
-
-    public String getDescription() {
-        return description;
-    }
-
-    public void setDescription(String description) {
-        this.description = description;
-    }
-
-    public void overloadMethod(int i)
-    {
-        //some foo code
-    }
-
-    public void overloadMethod(String s)
-    {
-        //some foo code
-    }
-
-    // comments between overloaded methods are allowed.
-    public void overloadMethod(boolean b)
-    {
-        //some foo code
-    }
-
-    public void fooMethod()
-    {
-
-    }
-
-    // violation : because overloads never split
-    // violation below 'All overloaded methods should be placed next to each other.'
-    public void overloadMethod(String s, Boolean b, int i)
-    {
-        //some foo code
-    }
-
-    void test() {}
-
-    String str;
-
-    private interface Testing {}
-
-    // violation below 'All overloaded methods should be placed next to each other.'
-    void test(int x) {}
-
-    private class Inner {
-        void test() {}
-
-        void test(String str) {}
-
-        void test2() {}
-
-        String str;
-
-        // violation below 'All overloaded methods should be placed next to each other.'
-        void test(int x) {}
-    }
-    // violation below 'All overloaded methods should be placed next to each other.'
-    void test(double d) {}
-}
-
-enum Foo2 {
-    VALUE {
-        public void value() {
-            value("");
-        }
-
-        public void middle() {
-        }
-
-        public void value(String s) {
-        }
-    };
-}
-
-@interface ClassPreamble {
-    String author();
 }

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/overloadmethodsdeclarationorder/InputOverloadMethodsDeclarationOrder2.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/overloadmethodsdeclarationorder/InputOverloadMethodsDeclarationOrder2.java
@@ -1,0 +1,101 @@
+/*
+OverloadMethodsDeclarationOrder
+
+
+*/
+
+package com.puppycrawl.tools.checkstyle.checks.coding.overloadmethodsdeclarationorder;
+
+class InputOverloadMethodsDeclarationOrder2 {
+
+    enum FooType2 {
+        Strategy(""),
+        Shooter(""),
+        RPG("");
+
+        private String description;
+
+        private FooType2(String description) {
+            this.description = description;
+        }
+
+        public String getDescription() {
+            return description;
+        }
+
+        public void setDescription(String description) {
+            this.description = description;
+        }
+
+        public void overloadMethod(int i)
+        {
+            //some foo code
+        }
+
+        public void overloadMethod(String s)
+        {
+            //some foo code
+        }
+
+        // comments between overloaded methods are allowed.
+        public void overloadMethod(boolean b)
+        {
+            //some foo code
+        }
+
+        public void fooMethod()
+        {
+
+        }
+
+        // violation : because overloads never split
+        // violation below 'All overloaded methods should be placed next to each other.'
+        public void overloadMethod(String s, Boolean b, int i)
+        {
+            //some foo code
+        }
+
+        void test() {}
+
+        String str;
+
+        private interface Testing {}
+
+        // violation below 'All overloaded methods should be placed next to each other.'
+        void test(int x) {}
+
+        private class Inner {
+            void test() {}
+
+            void test(String str) {}
+
+            void test2() {}
+
+            String str;
+
+            // violation below 'All overloaded methods should be placed next to each other.'
+            void test(int x) {}
+        }
+        // violation below 'All overloaded methods should be placed next to each other.'
+        void test(double d) {}
+    }
+
+    enum Foo3 {
+        VALUE {
+            public void value() {
+                value("");
+            }
+
+            public void middle() {
+            }
+
+            public void value(String s) {
+            }
+        };
+    }
+
+    @interface ClassPreamble {
+        String author();
+    }
+
+}


### PR DESCRIPTION
issue #11163

Split InputOverloadMethodsDeclarationOrder.java (178 lines) into two focused files:

- InputOverloadMethodsDeclarationOrder1.java (class + anonymous class + interface)
- InputOverloadMethodsDeclarationOrder2.java (enums + annotation)

Both files are under the 120-line limit.

Updated OverloadMethodsDeclarationOrderCheckTest.java to use both new input files with corrected line numbers.