### PR TITLE
Issue #15456: Define violation messages for JavadocTagContinuationIndentation

### DIFF
--- a/src/site/xdoc/checks/javadoc/javadoctagcontinuationindentation.xml
+++ b/src/site/xdoc/checks/javadoc/javadoctagcontinuationindentation.xml
@@ -101,10 +101,10 @@ class Example1 {
    * Writes the object using a
    * &lt;a href="{@docRoot}/serialized-form.html#java.time.Ser"&gt;dedicated form&lt;/a&gt;.
    * @serialData
-   * &lt;code&gt; // violation
-   * out.writeByte(1); // violation
-   * out.writeInt(nanos); // violation
-   * &lt;/code&gt; // violation
+   * &lt;code&gt; // violation 'expected level should be 4'
+   * out.writeByte(1); // violation 'expected level should be 4'
+   * out.writeInt(nanos); // violation 'expected level should be 4'
+   * &lt;/code&gt; // violation 'expected level should be 4'
    */
   public void testMethodCode(String input) {}
 
@@ -164,10 +164,10 @@ class Example2 {
    * Writes the object using a
    * &lt;a href="{@docRoot}/serialized-form.html#java.time.Ser"&gt;dedicated form&lt;/a&gt;.
    * @serialData
-   * &lt;code&gt; // violation
-   * out.writeByte(1); // violation
-   * out.writeInt(nanos); // violation
-   * &lt;/code&gt; // violation
+   * &lt;code&gt; // violation 'expected level should be 2'
+   * out.writeByte(1); // violation 'expected level should be 2'
+   * out.writeInt(nanos); // violation 'expected level should be 2'
+   * &lt;/code&gt; // violation 'expected level should be 2'
    */
   public void testMethodCode(String input) {}
 
@@ -228,10 +228,10 @@ class Example3 {
    * Writes the object using a
    * &lt;a href="{@docRoot}/serialized-form.html#java.time.Ser"&gt;dedicated form&lt;/a&gt;.
    * @serialData
-   * &lt;code&gt; // violation
-   * out.writeByte(1); // violation
-   * out.writeInt(nanos); // violation
-   * &lt;/code&gt; // violation
+   * &lt;code&gt; // violation 'expected level should be 4'
+   * out.writeByte(1); // violation 'expected level should be 4'
+   * out.writeInt(nanos); // violation 'expected level should be 4'
+   * &lt;/code&gt; // violation 'expected level should be 4'
    */
   public void testMethodCode(String input) {}
 

--- a/src/test/java/com/puppycrawl/tools/checkstyle/bdd/InlineConfigParser.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/bdd/InlineConfigParser.java
@@ -246,8 +246,6 @@ public final class InlineConfigParser {
             "com.puppycrawl.tools.checkstyle.checks.javadoc.AtclauseOrderCheck",
             "com.puppycrawl.tools.checkstyle.checks.javadoc.InvalidJavadocPositionCheck",
             "com.puppycrawl.tools.checkstyle.checks.javadoc.JavadocBlockTagLocationCheck",
-            "com.puppycrawl.tools.checkstyle.checks.javadoc"
-                    + ".JavadocTagContinuationIndentationCheck",
             "com.puppycrawl.tools.checkstyle.checks.javadoc.MissingJavadocMethodCheck",
             "com.puppycrawl.tools.checkstyle.checks.javadoc.MissingJavadocTypeCheck",
             "com.puppycrawl.tools.checkstyle.checks.javadoc"

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocTagContinuationIndentationCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocTagContinuationIndentationCheckTest.java
@@ -114,9 +114,6 @@ public class JavadocTagContinuationIndentationCheckTest
             "62: " + getCheckMessage(MSG_KEY, 4),
             "74: " + getCheckMessage(MSG_KEY, 4),
             "75: " + getCheckMessage(MSG_KEY, 4),
-            "86: " + getCheckMessage(MSG_KEY, 4),
-            "87: " + getCheckMessage(MSG_KEY, 4),
-            "88: " + getCheckMessage(MSG_KEY, 4),
             "89: " + getCheckMessage(MSG_KEY, 4),
             "90: " + getCheckMessage(MSG_KEY, 4),
             "91: " + getCheckMessage(MSG_KEY, 4),
@@ -128,8 +125,11 @@ public class JavadocTagContinuationIndentationCheckTest
             "97: " + getCheckMessage(MSG_KEY, 4),
             "98: " + getCheckMessage(MSG_KEY, 4),
             "99: " + getCheckMessage(MSG_KEY, 4),
-            "104: " + getCheckMessage(MSG_KEY, 4),
-            "105: " + getCheckMessage(MSG_KEY, 4),
+            "100: " + getCheckMessage(MSG_KEY, 4),
+            "101: " + getCheckMessage(MSG_KEY, 4),
+            "102: " + getCheckMessage(MSG_KEY, 4),
+            "107: " + getCheckMessage(MSG_KEY, 4),
+            "108: " + getCheckMessage(MSG_KEY, 4),
         };
         verifyWithInlineConfigParser(
                 getPath("InputJavadocTagContinuationIndentationBlockTag.java"),
@@ -197,21 +197,29 @@ public class JavadocTagContinuationIndentationCheckTest
             "33: " + getCheckMessage(MSG_KEY, 4),
             "34: " + getCheckMessage(MSG_KEY, 4),
             "35: " + getCheckMessage(MSG_KEY, 4),
-            "70: " + getCheckMessage(MSG_KEY, 4),
-            "78: " + getCheckMessage(MSG_KEY, 4),
-            "79: " + getCheckMessage(MSG_KEY, 4),
-            "80: " + getCheckMessage(MSG_KEY, 4),
-            "81: " + getCheckMessage(MSG_KEY, 4),
-            "82: " + getCheckMessage(MSG_KEY, 4),
-            "83: " + getCheckMessage(MSG_KEY, 4),
-            "84: " + getCheckMessage(MSG_KEY, 4),
-            "85: " + getCheckMessage(MSG_KEY, 4),
-            "90: " + getCheckMessage(MSG_KEY, 4),
-            "91: " + getCheckMessage(MSG_KEY, 4),
-            "92: " + getCheckMessage(MSG_KEY, 4),
         };
         verifyWithInlineConfigParser(
             getPath("InputJavadocTagContinuationIndentationPreTag2.java"), expected);
+    }
+
+    @Test
+    public void testJavadocTagContinuationIndentationCheckPreTag2Two() throws Exception {
+        final String[] expected = {
+            "23: " + getCheckMessage(MSG_KEY, 4),
+            "31: " + getCheckMessage(MSG_KEY, 4),
+            "32: " + getCheckMessage(MSG_KEY, 4),
+            "33: " + getCheckMessage(MSG_KEY, 4),
+            "34: " + getCheckMessage(MSG_KEY, 4),
+            "35: " + getCheckMessage(MSG_KEY, 4),
+            "36: " + getCheckMessage(MSG_KEY, 4),
+            "37: " + getCheckMessage(MSG_KEY, 4),
+            "38: " + getCheckMessage(MSG_KEY, 4),
+            "43: " + getCheckMessage(MSG_KEY, 4),
+            "44: " + getCheckMessage(MSG_KEY, 4),
+            "45: " + getCheckMessage(MSG_KEY, 4),
+        };
+        verifyWithInlineConfigParser(
+            getPath("InputJavadocTagContinuationIndentationPreTag2Two.java"), expected);
     }
 
     @Test

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadoctagcontinuationindentation/InputJavadocTagContinuationIndentation.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadoctagcontinuationindentation/InputJavadocTagContinuationIndentation.java
@@ -52,7 +52,7 @@ class InputJavadocTagContinuationIndentation implements Serializable
      * @return Some text.
      * @serialData Some javadoc.
      * @see Some text.
-     *    Some javadoc. // violation
+     *    Some javadoc. // violation, 'Line continuation .* expected level should be 4'
      * @throws Exception Some text.
      */
     String method(String aString) throws Exception
@@ -114,10 +114,10 @@ class InputJavadocTagContinuationIndentation implements Serializable
      * Some text.
      * @param aString Some text.
      * @return Some text.
-     *    Some javadoc. // violation
+     *    Some javadoc. // violation, 'Line continuation .* expected level should be 4'
      * @serialData Some javadoc.
      * @param aInt Some text.
-     *    Some javadoc. // violation
+     *    Some javadoc. // violation, 'Line continuation .* expected level should be 4'
      * @throws Exception Some text.
      * @param aBoolean Some text.
      * @see Some text.
@@ -208,10 +208,10 @@ class InputJavadocTagContinuationIndentation implements Serializable
          * @param aString Some text.
          * @return Some text.
          * @param aInt Some text.
-         *    Some javadoc. // violation
+         *    Some javadoc. // violation, 'Line continuation .* expected level should be 4'
          * @throws Exception Some text.
          * @param aBoolean Some text.
-         *    Some javadoc. // violation
+         *    Some javadoc. // violation, 'Line continuation .* expected level should be 4'
          * @see Some text.
          */
         String method6(String aString, int aInt, boolean aBoolean) throws Exception
@@ -226,9 +226,9 @@ class InputJavadocTagContinuationIndentation implements Serializable
          * Some text.
          * @throws Exception Some text.
          * @param aString Some text.
-         *   Some javadoc. // violation
+         *   Some javadoc. // violation, 'Line continuation .* expected level should be 4'
          * @serialData Some javadoc.
-         *    Some javadoc. // violation
+         *    Some javadoc. // violation, 'Line continuation .* expected level should be 4'
          * @see Some text.
          * @return Some text.
          */
@@ -290,12 +290,12 @@ class InputJavadocTagContinuationIndentation implements Serializable
          * Some text.
          *       Some javadoc.
          * @param aString Some text.
-         *    Some javadoc. // violation
+         *    Some javadoc. // violation, 'Line continuation .* expected level should be 4'
          * @return Some text.
          * @param aInt Some text.
-         *    Some javadoc. // violation
+         *    Some javadoc. // violation, 'Line continuation .* expected level should be 4'
          * @throws Exception Some text.
-         *    Some javadoc. // violation
+         *    Some javadoc. // violation, 'Line continuation .* expected level should be 4'
          * @param aBoolean Some text.
          * @see Some text.
          */
@@ -315,7 +315,7 @@ class InputJavadocTagContinuationIndentation implements Serializable
  *     Some javadoc.
  *     Some javadoc.
  * @see Some javadoc.
- *    Some javadoc. // violation
+ *    Some javadoc. // violation, 'Line continuation .* expected level should be 4'
  * @author max
  */
 enum Foo1 {}
@@ -327,9 +327,9 @@ enum Foo1 {}
  * @since Some javadoc.
  *     Some javadoc.
  * @serialData Some javadoc.
- *   Line below is empty on purpose. // violation
- * @see Some Text.
- * L. // violation
+ *   Line below is empty on purpose.
+ * @see Some Text. // violation above 'Line continuation .* expected level should be 4'
+ * L. // violation, 'Line continuation .* expected level should be 4'
  *
  * @author max
  * @customTag {@link com.puppycrawl.tools.checkstyle.AllChecksPresentOnAvailableChecksPageTest
@@ -347,7 +347,7 @@ class ShortNextLine {
      * Test.
      *
      * @return Test
-     * tt <code>null</code>. // violation
+     * tt <code>null</code>. // violation, 'Line continuation .* expected level should be 4'
      */
     public void example() {
     }

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadoctagcontinuationindentation/InputJavadocTagContinuationIndentationBlockTag.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadoctagcontinuationindentation/InputJavadocTagContinuationIndentationBlockTag.java
@@ -18,7 +18,7 @@ public class InputJavadocTagContinuationIndentationBlockTag {
      * type. Returns 0 for types other than float, double, int, and long.
      * @param text the string to be parsed.
      * @param type the token type of the text. Should be a constant of
-     * {@link TokenTypes}. // violation
+     * {@link TokenTypes}. // violation, 'Line continuation .* expected level should be 4'
      * @return the double value represented by the string argument.
      */
     public static double parseDouble(String text, int type) {
@@ -29,8 +29,8 @@ public class InputJavadocTagContinuationIndentationBlockTag {
      * Javadoc.
      *
      * @param x this line is normal
-     * {@code this} line is wrongly indented // violation
-     */
+     * {@code this} line is wrongly indented
+     */ // violation above 'Line continuation .* expected level should be 4'
     public void newlineThenBlockTag(int x) {
         // do stuff
     }
@@ -39,8 +39,8 @@ public class InputJavadocTagContinuationIndentationBlockTag {
      * Not enough indentation.
      *
      * @param x this line is normal
-     *   {@code this} line is wrongly indented // violation
-     */
+     *   {@code this} line is wrongly indented
+     */ // violation above 'Line continuation .* expected level should be 4'
     public void partialIndent(int x) {
         // do stuff
     }
@@ -59,8 +59,8 @@ public class InputJavadocTagContinuationIndentationBlockTag {
      * Javadoc.
      *
      * @param args
-     * {@code this} line is not correctly indented // violation
-     *     {@code this}
+     * {@code this} line is not correctly indented
+     *     {@code this} // violation above 'Line continuation .* expected level should be 4'
      * <pre>pre tags are skipped</pre>
      */
     public void multipleLines1(String args) {
@@ -71,40 +71,43 @@ public class InputJavadocTagContinuationIndentationBlockTag {
      * Javadoc.
      *
      * @return false always
-     * {@code this} line is not correctly indented // violation
-     * {@code this} line is not correctly indented // violation
+     * {@code this} line is not correctly indented
+     * {@code this} line is not correctly indented
      * <pre>pre tags are skipped</pre>
      */
     public boolean isMultipleLines2() {
         return false;
     }
+    // violation 7 lines above 'Line continuation .* expected level should be 4'
+    // violation 7 lines above 'Line continuation .* expected level should be 4'
+    // violation 6 lines below 'Line continuation .* expected level should be 4'
 
     /**
      * Javadoc from regression test case (apache-ant).
-     *
+     * // violation 3 lines below 'Line continuation .* expected level should be 4'
      * @param c the command line which will be configured
-     * if the commandline is initially null, the function is a noop // violation
-     * otherwise the function append to the commandline arguments concerning // violation
-     * <ul> // violation
-     * <li> // violation
-     * cvs package // violation
-     * </li> // violation
-     * <li> // violation
-     * compression // violation
-     * </li> // violation
-     * <li> // violation
-     * quiet or reallyquiet // violation
-     * </li> // violation
-     * <li>cvsroot</li> // violation
-     * <li>noexec</li> // violation
+     * if the commandline is initially null, the function is a noop
+     * otherwise the function append to the commandline arguments concerning
+     * <ul> // violation, 'Line continuation .* expected level should be 4'
+     * <li> // violation, 'Line continuation .* expected level should be 4'
+     * cvs package // violation, 'Line continuation .* expected level should be 4'
+     * </li> // violation, 'Line continuation .* expected level should be 4'
+     * <li> // violation, 'Line continuation .* expected level should be 4'
+     * compression // violation, 'Line continuation .* expected level should be 4'
+     * </li> // violation, 'Line continuation .* expected level should be 4'
+     * <li> // violation, 'Line continuation .* expected level should be 4'
+     * quiet or reallyquiet // violation, 'Line continuation .* expected level should be 4'
+     * </li> // violation, 'Line continuation .* expected level should be 4'
+     * <li>cvsroot</li> // violation, 'Line continuation .* expected level should be 4'
+     * <li>noexec</li> // violation, 'Line continuation .* expected level should be 4'
      *     <li>
      *     another item
      *     </li>
      *     <li> yet another item </li>
-     * </ul> // violation
-     * some text <i>word</i> more text. // violation
+     * </ul> // violation, 'Line continuation .* expected level should be 4'
+     * some text <i>word</i> more text.
      *     some text <i>word</i> more text.
-     */
+     */ // violation 2 lines above 'Line continuation .* expected level should be 4'
     public String regressionNestedHtml(CharSequence c) {
         return "";
     }

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadoctagcontinuationindentation/InputJavadocTagContinuationIndentationDescription.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadoctagcontinuationindentation/InputJavadocTagContinuationIndentationDescription.java
@@ -13,9 +13,9 @@ public class InputJavadocTagContinuationIndentationDescription {
      * General Description here.
      *
      * @param s
-     * Description 1. // violation
-     * Description 2. // violation
-     * Description 3. // violation
+     * Description 1. // violation, 'Line continuation .* expected level should be 4'
+     * Description 2. // violation, 'Line continuation .* expected level should be 4'
+     * Description 3. // violation, 'Line continuation .* expected level should be 4'
      *                         Description 4 with extra indentation.
      *
      *
@@ -43,12 +43,12 @@ public class InputJavadocTagContinuationIndentationDescription {
     public void testWithMissingAsterisk(int x) {}
 
     /**
-     * @param s
-     *Description with missing space. // violation
-     * @param s2
-     *****Description with multiple asterisk and missing space // violation
-     ***** Description with multiple asterisk and missing space // violation
-     */
+     * @param s // violation below 'Line continuation .* expected level should be 4'
+     *Description with missing space.
+     * @param s2 // violation below 'Line continuation .* expected level should be 4'
+     *****Description with multiple asterisk and missing space
+     ***** Description with multiple asterisk and missing space
+     */ // violation above 'Line continuation .* expected level should be 4'
     public void testOtherCases(String s, String s2) {}
     
     /**
@@ -71,6 +71,6 @@ public class InputJavadocTagContinuationIndentationDescription {
      *  >SAX.</a>     
      */
     public void test() { }
-    // violation 4 lines above
-    // violation 4 lines above
+    // violation 4 lines above 'Line continuation .* expected level should be 4'
+    // violation 4 lines above 'Line continuation .* expected level should be 4'
 }

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadoctagcontinuationindentation/InputJavadocTagContinuationIndentationOffset3.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadoctagcontinuationindentation/InputJavadocTagContinuationIndentationOffset3.java
@@ -12,7 +12,7 @@ package com.puppycrawl.tools.checkstyle.checks.javadoc.javadoctagcontinuationind
  * Some javadoc.
  *
  * @since Some javadoc.
- *   Some javadoc. // violation
+ *   Some javadoc. // violation, 'Line continuation .* expected level should be 3'
  * @version 1.0
  * @deprecated Some javadoc.
  *    Some javadoc.
@@ -24,7 +24,7 @@ class InputJavadocTagContinuationIndentationOffset3 {
         /**
      * The client's first name.
      * @serial Some javadoc.
-        *   Some javadoc. // violation
+        *   Some javadoc. // violation, 'Line continuation .* expected level should be 3'
      */
     private String fFirstName;
 

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadoctagcontinuationindentation/InputJavadocTagContinuationIndentationPreTag.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadoctagcontinuationindentation/InputJavadocTagContinuationIndentationPreTag.java
@@ -96,10 +96,10 @@ public class InputJavadocTagContinuationIndentationPreTag {
     /**
      * Writes the object using a
      * <a href="{@docRoot}/serialized-form.html#ja">deserialized form</a>.
-     * @serialData
-     * Refer to the serialized form of // violation
-     * <a href="{@docRoot}/serialized-formRules">ZoneRules.writeReplace</a> // violation
-     * for the encoding of epoch seconds and offsets. // violation
+     * @serialData // violation below 'Line continuation .* expected level should be 4'
+     * Refer to the serialized form of
+     * <a href="{@docRoot}/serialized-formRules">ZoneRules.writeReplace</a>
+     * for the encoding of epoch seconds and offsets.
      * <pre style="font-size:1.0em">{@code
      *
      *   out.writeByte(2);                // identifies a ZoneOffsetTransition
@@ -112,4 +112,6 @@ public class InputJavadocTagContinuationIndentationPreTag {
     private Object writeReplace() {
         return new Object();
     }
+    // violation 14 lines above 'Line continuation .* expected level should be 4'
+    // violation 14 lines above 'Line continuation .* expected level should be 4'
 }

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadoctagcontinuationindentation/InputJavadocTagContinuationIndentationPreTag2.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadoctagcontinuationindentation/InputJavadocTagContinuationIndentationPreTag2.java
@@ -29,15 +29,19 @@ public class InputJavadocTagContinuationIndentationPreTag2 {
       * <pre>
       *          <em> {@code <field> [N] IMPLICIT <type>}</em>
       * </pre>
-      * For example, <em>FooLength [1] IMPLICIT INTEGER</em>, with value=4; // violation
-      * would be encoded as "81 01 04"  whereas in explicit // violation
-      * tagging it would be encoded as "A1 03 02 01 04". // violation
-      * explicit tagging the form is always constructed. // violation
+      * For example, <em>FooLength [1] IMPLICIT INTEGER</em>, with value=4;
+      * would be encoded as "81 01 04"  whereas in explicit
+      * tagging it would be encoded as "A1 03 02 01 04".
+      * explicit tagging the form is always constructed.
       * @param value original value being implicitly tagged
       */
      public Object writeImplicit(byte tag, Object value) {
          return new Object();
      }
+     // violation 9 lines above 'Line continuation .* expected level should be 4'
+     // violation 9 lines above 'Line continuation .* expected level should be 4'
+     // violation 9 lines above 'Line continuation .* expected level should be 4'
+     // violation 9 lines above 'Line continuation .* expected level should be 4'
 
      /**
       * Writes the object using a
@@ -53,47 +57,6 @@ public class InputJavadocTagContinuationIndentationPreTag2 {
       */
      @Serial
      private Object writeReplace() {
-         return new Object();
-     }
-
-     /**
-      * Queries this date-time.
-      * <p>
-      * This queries this date-time using the specified query strategy object.
-      * <p>
-      * Queries are a key tool for extracting information from date-times.
-      * <p>
-      * The most common query implementations are method references, such as
-      * Additional implementations are provided as static methods on {@link TemporalQuery}.
-      *
-      * @implSpec
-      * The default implementation must behave equivalent to this code: // violation
-      * <pre>
-      *  if (query == TemporalQueries.zoneId() ||
-      *        query == TemporalQueries.chronology() || query == TemporalQueries.precision()) {
-      *    return null;
-      *  }
-      *  return query.queryFrom(this);
-      * </pre>
-      * Future versions are permitted to add further queries to the if statement. // violation
-      * <p> // violation
-      * All classes implementing this interface and overriding this method must call // violation
-      * {@code TemporalAccessor.super.query(query)}. JDK classes may avoid calling // violation
-      * non-JDK classes may this optimization and must call {@code super}. // violation
-      * <p> // violation
-      * If the implementation for one of the queries listed in the // violation
-      * if statement of the default implementation, then it must do so. // violation
-      * <pre>
-      *    return MINUTES;
-      *  return TemporalAccessor.super.query(query);
-      * </pre>
-      * <p> // violation
-      * Implementations must ensure that no observable state is altered when this // violation
-      * read-only method is invoked. // violation
-      *
-      * @param query  the query to invoke, not null
-      */
-     Object query(Object query) {
          return new Object();
      }
 

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadoctagcontinuationindentation/InputJavadocTagContinuationIndentationPreTag2Two.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadoctagcontinuationindentation/InputJavadocTagContinuationIndentationPreTag2Two.java
@@ -1,0 +1,64 @@
+/*
+JavadocTagContinuationIndentation
+violateExecutionOnNonTightHtml = (default)false
+offset = (default)4
+
+*/
+
+package com.puppycrawl.tools.checkstyle.checks.javadoc.javadoctagcontinuationindentation;
+
+class InputJavadocTagContinuationIndentationPreTag2Two {
+
+     /**
+      * Queries this date-time.
+      * <p>
+      * This queries this date-time using the specified query strategy object.
+      * <p>
+      * Queries are a key tool for extracting information from date-times.
+      * <p>
+      * The most common query implementations are method references, such as
+      * Additional implementations are provided as static methods on {@link TemporalQuery}.
+      *
+      * @implSpec
+      * The default implementation must behave equivalent to this code:
+      * <pre>
+      *  if (query == TemporalQueries.zoneId() ||
+      *        query == TemporalQueries.chronology() || query == TemporalQueries.precision()) {
+      *    return null;
+      *  }
+      *  return query.queryFrom(this);
+      * </pre>
+      * Future versions are permitted to add further queries to the if statement.
+      * <p>
+      * All classes implementing this interface and overriding this method must call
+      * {@code TemporalAccessor.super.query(query)}. JDK classes may avoid calling
+      * non-JDK classes may this optimization and must call {@code super}.
+      * <p>
+      * If the implementation for one of the queries listed in the
+      * if statement of the default implementation, then it must do so.
+      * <pre>
+      *    return MINUTES;
+      *  return TemporalAccessor.super.query(query);
+      * </pre>
+      * <p>
+      * Implementations must ensure that no observable state is altered when this
+      * read-only method is invoked.
+      *
+      * @param query  the query to invoke, not null
+      */
+     Object query(Object query) {
+         return new Object();
+     }
+     // violation 29 lines above 'Line continuation .* expected level should be 4'
+     // violation 22 lines above 'Line continuation .* expected level should be 4'
+     // violation 22 lines above 'Line continuation .* expected level should be 4'
+     // violation 22 lines above 'Line continuation .* expected level should be 4'
+     // violation 22 lines above 'Line continuation .* expected level should be 4'
+     // violation 22 lines above 'Line continuation .* expected level should be 4'
+     // violation 22 lines above 'Line continuation .* expected level should be 4'
+     // violation 22 lines above 'Line continuation .* expected level should be 4'
+     // violation 22 lines above 'Line continuation .* expected level should be 4'
+     // violation 18 lines above 'Line continuation .* expected level should be 4'
+     // violation 18 lines above 'Line continuation .* expected level should be 4'
+     // violation 18 lines above 'Line continuation .* expected level should be 4'
+}

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadoctagcontinuationindentation/InputJavadocTagContinuationIndentationPreTag3.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadoctagcontinuationindentation/InputJavadocTagContinuationIndentationPreTag3.java
@@ -31,13 +31,17 @@ public class InputJavadocTagContinuationIndentationPreTag3 {
     /**
      * @return sub role of this role, which match `item`.
      *
-     * <code> // violation
-     * CtMethod method = ... // violation
-     * CtRole role = CtRole.TYPE_MEMBER.getMatchingSubRoleFor(method); // violation
-     * </code> // violation
+     * <code>
+     * CtMethod method = ...
+     * CtRole role = CtRole.TYPE_MEMBER.getMatchingSubRoleFor(method);
+     * </code>
      */
     @Internal
     public Object testMethod2() {
         return new Object();
     }
+    // violation 9 lines above 'Line continuation .* expected level should be 4'
+    // violation 9 lines above 'Line continuation .* expected level should be 4'
+    // violation 9 lines above 'Line continuation .* expected level should be 4'
+    // violation 9 lines above 'Line continuation .* expected level should be 4'
 }

--- a/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadoctagcontinuationindentation/Example1.java
+++ b/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadoctagcontinuationindentation/Example1.java
@@ -39,10 +39,10 @@ class Example1 {
    * Writes the object using a
    * <a href="{@docRoot}/serialized-form.html#java.time.Ser">dedicated form</a>.
    * @serialData
-   * <code> // violation
-   * out.writeByte(1); // violation
-   * out.writeInt(nanos); // violation
-   * </code> // violation
+   * <code> // violation 'expected level should be 4'
+   * out.writeByte(1); // violation 'expected level should be 4'
+   * out.writeInt(nanos); // violation 'expected level should be 4'
+   * </code> // violation 'expected level should be 4'
    */
   public void testMethodCode(String input) {}
 

--- a/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadoctagcontinuationindentation/Example2.java
+++ b/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadoctagcontinuationindentation/Example2.java
@@ -41,10 +41,10 @@ class Example2 {
    * Writes the object using a
    * <a href="{@docRoot}/serialized-form.html#java.time.Ser">dedicated form</a>.
    * @serialData
-   * <code> // violation
-   * out.writeByte(1); // violation
-   * out.writeInt(nanos); // violation
-   * </code> // violation
+   * <code> // violation 'expected level should be 2'
+   * out.writeByte(1); // violation 'expected level should be 2'
+   * out.writeInt(nanos); // violation 'expected level should be 2'
+   * </code> // violation 'expected level should be 2'
    */
   public void testMethodCode(String input) {}
 

--- a/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadoctagcontinuationindentation/Example3.java
+++ b/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadoctagcontinuationindentation/Example3.java
@@ -42,10 +42,10 @@ class Example3 {
    * Writes the object using a
    * <a href="{@docRoot}/serialized-form.html#java.time.Ser">dedicated form</a>.
    * @serialData
-   * <code> // violation
-   * out.writeByte(1); // violation
-   * out.writeInt(nanos); // violation
-   * </code> // violation
+   * <code> // violation 'expected level should be 4'
+   * out.writeByte(1); // violation 'expected level should be 4'
+   * out.writeInt(nanos); // violation 'expected level should be 4'
+   * </code> // violation 'expected level should be 4'
    */
   public void testMethodCode(String input) {}
 


### PR DESCRIPTION
Resolves part of #15456

Added specific violation messages to all `// violation` comments in JavadocTagContinuationIndentation input test files, replacing bare `// violation` markers with messages matching the pattern `'Line continuation .* expected level should be 4'`.

Changes:

- Updated 9 input test files to include violation messages:
  - InputJavadocTagContinuationIndentation.java 
  - InputJavadocTagContinuationIndentationBlockTag.java 
  - InputJavadocTagContinuationIndentationDescription.java
  - InputJavadocTagContinuationIndentationOffset3.java 
  - InputJavadocTagContinuationIndentationPreTag.java 
  - `InputJavadocTagContinuationIndentationPreTag2.java` 
  - InputJavadocTagContinuationIndentationPreTag3.java 
- Split `InputJavadocTagContinuationIndentationPreTag2.java` into two files to stay within the 120-line file size limit:
  - Created InputJavadocTagContinuationIndentationPreTag2Two.java
- Added `testJavadocTagContinuationIndentationCheckPreTag2Two` test method in JavadocTagContinuationIndentationCheckTest.java
- Removed `JavadocTagContinuationIndentationCheck` from `SUPPRESSED_CHECKS` in `InlineConfigParser.java`