### PR TITLE
Issue #15456: Define violation messages for MissingJavadocPackage

### DIFF
--- a/src/test/java/com/puppycrawl/tools/checkstyle/bdd/InlineConfigParser.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/bdd/InlineConfigParser.java
@@ -250,7 +250,6 @@ public final class InlineConfigParser {
                     + ".JavadocTagContinuationIndentationCheck",
             "com.puppycrawl.tools.checkstyle.checks.javadoc.JavadocVariableCheck",
             "com.puppycrawl.tools.checkstyle.checks.javadoc.MissingJavadocMethodCheck",
-            "com.puppycrawl.tools.checkstyle.checks.javadoc.MissingJavadocPackageCheck",
             "com.puppycrawl.tools.checkstyle.checks.javadoc.MissingJavadocTypeCheck",
             "com.puppycrawl.tools.checkstyle.checks.javadoc"
                     + ".RequireEmptyLineBeforeBlockTagGroupCheck",

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/javadoc/MissingJavadocPackageCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/javadoc/MissingJavadocPackageCheckTest.java
@@ -62,7 +62,7 @@ public class MissingJavadocPackageCheckTest extends AbstractModuleTestSupport {
     @Test
     public void testPackageJavadocMissing() throws Exception {
         final String[] expected = {
-            "7:1: " + getCheckMessage(MSG_PKG_JAVADOC_MISSING),
+            "8:1: " + getCheckMessage(MSG_PKG_JAVADOC_MISSING),
         };
         verifyWithInlineConfigParser(getPath("nojavadoc/package-info.java"), expected);
     }
@@ -79,7 +79,7 @@ public class MissingJavadocPackageCheckTest extends AbstractModuleTestSupport {
     @Test
     public void testSinglelineCommentInsteadOfJavadoc() throws Exception {
         final String[] expected = {
-            "8:1: " + getCheckMessage(MSG_PKG_JAVADOC_MISSING),
+            "9:1: " + getCheckMessage(MSG_PKG_JAVADOC_MISSING),
         };
         verifyWithInlineConfigParser(
                 getPath("nojavadoc/singleline/package-info.java"), expected);
@@ -88,7 +88,7 @@ public class MissingJavadocPackageCheckTest extends AbstractModuleTestSupport {
     @Test
     public void testSinglelineCommentInsteadOfJavadoc2() throws Exception {
         final String[] expected = {
-            "8:1: " + getCheckMessage(MSG_PKG_JAVADOC_MISSING),
+            "9:1: " + getCheckMessage(MSG_PKG_JAVADOC_MISSING),
         };
         verifyWithInlineConfigParser(
                 getPath("nojavadoc/single/package-info.java"), expected);
@@ -97,7 +97,7 @@ public class MissingJavadocPackageCheckTest extends AbstractModuleTestSupport {
     @Test
     public void testPackageJavadocMissingWithAnnotation() throws Exception {
         final String[] expected = {
-            "8:1: " + getCheckMessage(MSG_PKG_JAVADOC_MISSING),
+            "9:1: " + getCheckMessage(MSG_PKG_JAVADOC_MISSING),
         };
         verifyWithInlineConfigParser(
                 getPath("nojavadoc/annotation/package-info.java"), expected);
@@ -106,7 +106,7 @@ public class MissingJavadocPackageCheckTest extends AbstractModuleTestSupport {
     @Test
     public void testPackageJavadocMissingWithAnnotationAndBlockComment() throws Exception {
         final String[] expected = {
-            "12:1: " + getCheckMessage(MSG_PKG_JAVADOC_MISSING),
+            "13:1: " + getCheckMessage(MSG_PKG_JAVADOC_MISSING),
         };
         verifyWithInlineConfigParser(
                 getPath("nojavadoc/annotation/blockcomment/package-info.java"), expected);
@@ -130,7 +130,7 @@ public class MissingJavadocPackageCheckTest extends AbstractModuleTestSupport {
     @Test
     public void testPackageJavadocMissingWithBlankLines() throws Exception {
         final String[] expected = {
-            "8:1: " + getCheckMessage(MSG_PKG_JAVADOC_MISSING),
+            "9:1: " + getCheckMessage(MSG_PKG_JAVADOC_MISSING),
         };
         verifyWithInlineConfigParser(
                 getPath("nojavadoc/blank/package-info.java"), expected);

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/missingjavadocpackage/nojavadoc/annotation/blockcomment/package-info.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/missingjavadocpackage/nojavadoc/annotation/blockcomment/package-info.java
@@ -9,7 +9,8 @@ MissingJavadocPackage
  */
 
 @Nullable
-package com.puppycrawl.tools.checkstyle.checks // violation
+// violation below, 'Missing javadoc for package-info.java file.'
+package com.puppycrawl.tools.checkstyle.checks
         .javadoc.missingjavadocpackage.nojavadoc.annotation.blockcomment;
 
 import javax.annotation.Nullable;

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/missingjavadocpackage/nojavadoc/annotation/package-info.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/missingjavadocpackage/nojavadoc/annotation/package-info.java
@@ -5,5 +5,6 @@ MissingJavadocPackage
 */
 
 @Deprecated
-package com.puppycrawl.tools.checkstyle.checks // violation
+// violation below, 'Missing javadoc for package-info.java file.'
+package com.puppycrawl.tools.checkstyle.checks
         .javadoc.missingjavadocpackage.nojavadoc.annotation;

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/missingjavadocpackage/nojavadoc/blank/package-info.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/missingjavadocpackage/nojavadoc/blank/package-info.java
@@ -5,5 +5,6 @@ MissingJavadocPackage
 */
 
 
-package com.puppycrawl.tools.checkstyle.checks // violation
+// violation below, 'Missing javadoc for package-info.java file.'
+package com.puppycrawl.tools.checkstyle.checks
         .javadoc.missingjavadocpackage.nojavadoc.blank;

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/missingjavadocpackage/nojavadoc/blockcomment/package-info.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/missingjavadocpackage/nojavadoc/blockcomment/package-info.java
@@ -7,5 +7,5 @@ MissingJavadocPackage
 /*
  * block comment
  */
-package com.puppycrawl.tools.checkstyle // violation
+package com.puppycrawl.tools.checkstyle // violation, 'Missing javadoc for package-info.java file.'
         .checks.javadoc.missingjavadocpackage.nojavadoc.blockcomment;

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/missingjavadocpackage/nojavadoc/detached/package-info.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/missingjavadocpackage/nojavadoc/detached/package-info.java
@@ -8,5 +8,5 @@ MissingJavadocPackage
  * Dangling javadoc
  */
 /* comment */
-package com.puppycrawl.tools.checkstyle // violation
+package com.puppycrawl.tools.checkstyle // violation, 'Missing javadoc for package-info.java file.'
         .checks.javadoc.missingjavadocpackage.nojavadoc.detached;

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/missingjavadocpackage/nojavadoc/package-info.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/missingjavadocpackage/nojavadoc/package-info.java
@@ -4,5 +4,6 @@ MissingJavadocPackage
 
 */
 
-package com.puppycrawl.tools.checkstyle.checks.javadoc // violation
+// violation below, 'Missing javadoc for package-info.java file.'
+package com.puppycrawl.tools.checkstyle.checks.javadoc
         .missingjavadocpackage.nojavadoc;

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/missingjavadocpackage/nojavadoc/single/package-info.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/missingjavadocpackage/nojavadoc/single/package-info.java
@@ -5,5 +5,6 @@ MissingJavadocPackage
 */
 
 //* not javadoc
-package com.puppycrawl.tools.checkstyle.checks // violation
+// violation below, 'Missing javadoc for package-info.java file.'
+package com.puppycrawl.tools.checkstyle.checks
         .javadoc.missingjavadocpackage.nojavadoc.single;

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/missingjavadocpackage/nojavadoc/singleline/package-info.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/missingjavadocpackage/nojavadoc/singleline/package-info.java
@@ -5,5 +5,6 @@ MissingJavadocPackage
 */
 
 /**/
-package com.puppycrawl.tools.checkstyle.checks // violation
+// violation below, 'Missing javadoc for package-info.java file.'
+package com.puppycrawl.tools.checkstyle.checks
         .javadoc.missingjavadocpackage.nojavadoc.singleline;


### PR DESCRIPTION
Issue #15456: Define violation messages for MissingJavadocPackage

Replaced bare `// violation` comments with specific violation messages
in all 8 test input `package-info.java` files under `nojavadoc/`.

- Message key: `package.javadoc.missing`
- Message: `Missing javadoc for package-info.java file.`

Updated expected line numbers in `MissingJavadocPackageCheckTest.java`
to account for the added `// violation below` lines. Removed `MissingJavadocPackageCheck` from `SUPPRESSED_CHECKS` in
`InlineConfigParser.java`.