### PR TITLE
Issue #15456: Define violation messages for RecordComponentName

### DIFF
--- a/src/test/java/com/puppycrawl/tools/checkstyle/bdd/InlineConfigParser.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/bdd/InlineConfigParser.java
@@ -267,7 +267,6 @@ public final class InlineConfigParser {
 
             "com.puppycrawl.tools.checkstyle.checks.naming.IllegalIdentifierNameCheck",
 
-            "com.puppycrawl.tools.checkstyle.checks.naming.RecordComponentNameCheck",
             "com.puppycrawl.tools.checkstyle.checks.naming.RecordTypeParameterNameCheck",
             "com.puppycrawl.tools.checkstyle.checks.regexp.RegexpMultilineCheck",
             "com.puppycrawl.tools.checkstyle.checks.regexp.RegexpSinglelineCheck",

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/naming/recordcomponentname/InputRecordComponentNameDefault.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/naming/recordcomponentname/InputRecordComponentNameDefault.java
@@ -16,10 +16,10 @@ import org.w3c.dom.Node;
 public record InputRecordComponentNameDefault(int x, String str, Double myValue1, int i1) {
 }
 
-record DefaultFirstRecord(String value_123, // violation
-    String... Values) { // violation
+record DefaultFirstRecord(String value_123, // violation, 'Name 'value_123' must match pattern'
+    String... Values) { // violation, 'Name 'Values' must match pattern'
 }
 
-record DefaultSecondRecord(String _value123, // violation
-    int $age) { // violation
+record DefaultSecondRecord(String _value123, // violation, 'Name '_value123' must match pattern'
+    int $age) { // violation, 'Name '\$age' must match pattern'
 }

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/naming/recordcomponentname/InputRecordComponentNameLowercase.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/naming/recordcomponentname/InputRecordComponentNameLowercase.java
@@ -16,10 +16,10 @@ import org.w3c.dom.Node;
 public record InputRecordComponentNameLowercase(Integer x, String str, Double val123) {
 }
 
-record LowercaseFirstRecord(String value_123, // violation
-    String... Values) { // violation
+record LowercaseFirstRecord(String value_123, // violation, 'Name 'value_123' must match pattern'
+    String... Values) { // violation, 'Name 'Values' must match pattern'
 }
 
-record LowercaseSecondRecord(String V, // violation
-    int $age) { // violation
+record LowercaseSecondRecord(String V, // violation, 'Name 'V' must match pattern'
+    int $age) { // violation, 'Name '\$age' must match pattern'
 }


### PR DESCRIPTION
Issue #15456: Define violation messages for RecordComponentName

Replaced bare `// violation` comments with specific violation messages
in both test input files for RecordComponentName check.

- Message key: `name.invalidPattern`
- Message: `Name '{name}' must match pattern '{pattern}'.`

Following the convention used by other naming checks (e.g.,
CatchParameterName, LocalFinalVariableName), the violation message
is truncated at `must match pattern` to avoid regex special
characters (`^`, `$`, `[`, `]`, `*`) in the pattern from breaking
the InlineConfigParser's regex matching.

The `$` in `$age` is escaped as `\$age` in the violation comment
to prevent regex interpretation.

Removed `RecordComponentNameCheck` from `SUPPRESSED_CHECKS` in
`InlineConfigParser.java`.