### PR TITLE
Issue #16807: Update input files for RegexpCheck

### DIFF
--- a/src/test/java/com/puppycrawl/tools/checkstyle/bdd/InlineConfigParser.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/bdd/InlineConfigParser.java
@@ -318,7 +318,6 @@ public final class InlineConfigParser {
             "com.puppycrawl.tools.checkstyle.checks.naming.AbbreviationAsWordInNameCheck",
             "com.puppycrawl.tools.checkstyle.checks.naming.LocalFinalVariableNameCheck",
 
-            "com.puppycrawl.tools.checkstyle.checks.regexp.RegexpCheck",
             "com.puppycrawl.tools.checkstyle.checks.regexp.RegexpSinglelineCheck",
             "com.puppycrawl.tools.checkstyle.checks.regexp.RegexpSinglelineJavaCheck",
             "com.puppycrawl.tools.checkstyle.checks.whitespace.NoWhitespaceAfterCheck",

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/regexp/RegexpCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/regexp/RegexpCheckTest.java
@@ -93,8 +93,8 @@ public class RegexpCheckTest extends AbstractModuleTestSupport {
     @Test
     public void testRequiredNoDuplicatesFail() throws Exception {
         final String[] expected = {
-            "27: " + getCheckMessage(MSG_DUPLICATE_REGEXP, "Boolean x = new Boolean"),
             "32: " + getCheckMessage(MSG_DUPLICATE_REGEXP, "Boolean x = new Boolean"),
+            "37: " + getCheckMessage(MSG_DUPLICATE_REGEXP, "Boolean x = new Boolean"),
         };
         verifyWithInlineConfigParser(
                 getPath("InputRegexpSemantic5.java"), expected);
@@ -294,10 +294,10 @@ public class RegexpCheckTest extends AbstractModuleTestSupport {
         final String file1 = getPath("InputRegexpCheckB2.java");
         final String file2 = getPath("InputRegexpCheckB1.java");
         final List<String> expectedFromFile1 = List.of(
-            "12: " + getCheckMessage(MSG_ILLEGAL_REGEXP, "^import")
+            "15: " + getCheckMessage(MSG_ILLEGAL_REGEXP, "^import")
         );
         final List<String> expectedFromFile2 = List.of(
-            "12: " + getCheckMessage(MSG_ILLEGAL_REGEXP, "^import")
+            "15: " + getCheckMessage(MSG_ILLEGAL_REGEXP, "^import")
         );
         verifyWithInlineConfigParser(file1, file2, expectedFromFile1, expectedFromFile2);
     }

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/regexp/regexp/InputRegexpCheckB1.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/regexp/regexp/InputRegexpCheckB1.java
@@ -4,12 +4,16 @@ format = ^import
 errorLimit = 2
 duplicateLimit = 1
 illegalPattern = true
+ignoreComments = (default)false
+message = (default)null
+
 
 */
 
 package com.puppycrawl.tools.checkstyle.checks.regexp.regexp;
 
-import java.awt.*; // violation 'Line matches the illegal pattern '\^import''
+import java.awt.*;
+// violation above 'Line matches the illegal pattern '\^import''
 
 public class InputRegexpCheckB1 {
 }

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/regexp/regexp/InputRegexpCheckB2.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/regexp/regexp/InputRegexpCheckB2.java
@@ -4,6 +4,9 @@ format = ^import
 errorLimit = 2
 duplicateLimit = 1
 illegalPattern = true
+ignoreComments = (default)false
+message = (default)null
+
 
 */
 

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/regexp/regexp/InputRegexpCheckB3.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/regexp/regexp/InputRegexpCheckB3.java
@@ -3,13 +3,16 @@ Regexp
 format = .*
 errorLimit = 30
 duplicateLimit = 33
-illegalPattern = false
+illegalPattern = (default)false
+message = (default)null
+ignoreComments = (default)false
+
 
 */
 
 package com.puppycrawl.tools.checkstyle.checks.regexp.regexp;
 
-
 public class InputRegexpCheckB3 {
+
 }
 

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/regexp/regexp/InputRegexpCheckB4.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/regexp/regexp/InputRegexpCheckB4.java
@@ -3,7 +3,10 @@ Regexp
 format = .*
 errorLimit = 30
 duplicateLimit = 33
-illegalPattern = false
+illegalPattern = (default)false
+message = (default)null
+ignoreComments = (default)false
+
 
 */
 

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/regexp/regexp/InputRegexpCheckDefault.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/regexp/regexp/InputRegexpCheckDefault.java
@@ -1,6 +1,7 @@
 /*
 Regexp
 duplicateLimit = (default)0
+message = (default)null
 errorLimit = (default)100
 format = (default)^$
 ignoreComments = (default)false

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/regexp/regexp/InputRegexpCheckEmptyLine2.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/regexp/regexp/InputRegexpCheckEmptyLine2.java
@@ -2,6 +2,10 @@
 Regexp
 format =
 ignoreComments = true
+duplicateLimit = (default)0
+message = (default)null
+errorLimit = (default)100
+illegalPattern = (default)false
 
 
 */

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/regexp/regexp/InputRegexpSemantic5.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/regexp/regexp/InputRegexpSemantic5.java
@@ -3,7 +3,7 @@ Regexp
 format = Boolean x = new Boolean
 message = (default)null
 illegalPattern = (default)false
-duplicateLimit = 0
+duplicateLimit = 1
 errorLimit = (default)100
 ignoreComments = (default)false
 
@@ -22,6 +22,11 @@ import java.io.File;
  **/
 class InputRegexpSemantic5
 {
+    /* Boolean instantiation */
+    {
+        Boolean x = new Boolean(true);
+    }
+
     /* Boolean instantiation in a static initializer */
     static {
         Boolean x = new Boolean(true); // violation 'Found duplicate pattern'

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/regexp/regexp/InputRegexpStartingWithEmptyLine.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/regexp/regexp/InputRegexpStartingWithEmptyLine.java
@@ -5,6 +5,7 @@ errorLimit = (default)100
 format = (default)^$
 ignoreComments = (default)false
 illegalPattern = (default)false
+message = (default)null
 
 
 */


### PR DESCRIPTION
Closes Issue #16807
- Updated input files for RegexpCheck to specify violation messages
- Removed RegexpCheck from SUPPRESSED_MODULES in InlineConfigParser
- Added "default" tag for default properties
- Fixed buggy test case in InputRegexpSematic5 
