### PR TITLE
Issue #15456: Define violation messages for ClassDataAbstractionCouplingCheck

### DIFF
--- a/src/test/java/com/puppycrawl/tools/checkstyle/bdd/InlineConfigParser.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/bdd/InlineConfigParser.java
@@ -255,7 +255,6 @@ public final class InlineConfigParser {
                     + ".RequireEmptyLineBeforeBlockTagGroupCheck",
             "com.puppycrawl.tools.checkstyle.checks.javadoc.SingleLineJavadocCheck",
             "com.puppycrawl.tools.checkstyle.checks.metrics.BooleanExpressionComplexityCheck",
-            "com.puppycrawl.tools.checkstyle.checks.metrics.ClassDataAbstractionCouplingCheck",
             "com.puppycrawl.tools.checkstyle.checks.metrics.ClassFanOutComplexityCheck",
             "com.puppycrawl.tools.checkstyle.checks.metrics.NPathComplexityCheck",
             "com.puppycrawl.tools.checkstyle.checks.modifier.ClassMemberImpliedModifierCheck",

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/metrics/ClassDataAbstractionCouplingCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/metrics/ClassDataAbstractionCouplingCheckTest.java
@@ -61,9 +61,9 @@ public class ClassDataAbstractionCouplingCheckTest extends AbstractModuleTestSup
     public void test() throws Exception {
 
         final String[] expected = {
-            "16:1: " + getCheckMessage(MSG_KEY, 4, 0, "[AnotherInnerClass, HashMap, HashSet, int]"),
-            "17:5: " + getCheckMessage(MSG_KEY, 1, 0, "[ArrayList]"),
-            "37:1: " + getCheckMessage(MSG_KEY, 2, 0, "[HashMap, HashSet]"),
+            "17:1: " + getCheckMessage(MSG_KEY, 4, 0, "[AnotherInnerClass, HashMap, HashSet, int]"),
+            "19:5: " + getCheckMessage(MSG_KEY, 1, 0, "[ArrayList]"),
+            "39:1: " + getCheckMessage(MSG_KEY, 2, 0, "[HashMap, HashSet]"),
         };
 
         verifyWithInlineConfigParser(
@@ -73,9 +73,9 @@ public class ClassDataAbstractionCouplingCheckTest extends AbstractModuleTestSup
     @Test
     public void testExcludedPackageDirectPackages() throws Exception {
         final String[] expected = {
-            "28:1: " + getCheckMessage(MSG_KEY, 1, 0, "[StrTokenizer]"),
-            "32:5: " + getCheckMessage(MSG_KEY, 1, 0, "[BasicThreadFactory.Builder]"),
-            "38:1: " + getCheckMessage(MSG_KEY, 1, 0, "[BasicThreadFactory.Builder]"),
+            "29:1: " + getCheckMessage(MSG_KEY, 1, 0, "[StrTokenizer]"),
+            "33:5: " + getCheckMessage(MSG_KEY, 1, 0, "[BasicThreadFactory.Builder]"),
+            "40:1: " + getCheckMessage(MSG_KEY, 1, 0, "[BasicThreadFactory.Builder]"),
         };
 
         verifyWithInlineConfigParser(
@@ -86,9 +86,9 @@ public class ClassDataAbstractionCouplingCheckTest extends AbstractModuleTestSup
     @Test
     public void testExcludedPackageCommonPackages() throws Exception {
         final String[] expected = {
-            "28:1: " + getCheckMessage(MSG_KEY, 2, 0, "[ImmutablePair, StrTokenizer]"),
-            "32:5: " + getCheckMessage(MSG_KEY, 2, 0, "[BasicThreadFactory.Builder, MutablePair]"),
-            "38:1: " + getCheckMessage(MSG_KEY, 1, 0, "[BasicThreadFactory.Builder]"),
+            "29:1: " + getCheckMessage(MSG_KEY, 2, 0, "[ImmutablePair, StrTokenizer]"),
+            "33:5: " + getCheckMessage(MSG_KEY, 2, 0, "[BasicThreadFactory.Builder, MutablePair]"),
+            "40:1: " + getCheckMessage(MSG_KEY, 1, 0, "[BasicThreadFactory.Builder]"),
         };
 
         verifyWithInlineConfigParser(
@@ -122,9 +122,9 @@ public class ClassDataAbstractionCouplingCheckTest extends AbstractModuleTestSup
     @Test
     public void testExcludedPackageCommonPackagesAllIgnored() throws Exception {
         final String[] expected = {
-            "28:1: " + getCheckMessage(MSG_KEY, 1, 0, "[StrTokenizer]"),
-            "32:5: " + getCheckMessage(MSG_KEY, 1, 0, "[BasicThreadFactory.Builder]"),
-            "38:1: " + getCheckMessage(MSG_KEY, 1, 0, "[BasicThreadFactory.Builder]"),
+            "29:1: " + getCheckMessage(MSG_KEY, 1, 0, "[StrTokenizer]"),
+            "33:5: " + getCheckMessage(MSG_KEY, 1, 0, "[BasicThreadFactory.Builder]"),
+            "40:1: " + getCheckMessage(MSG_KEY, 1, 0, "[BasicThreadFactory.Builder]"),
         };
 
         verifyWithInlineConfigParser(
@@ -157,8 +157,8 @@ public class ClassDataAbstractionCouplingCheckTest extends AbstractModuleTestSup
     public void testRegularExpression() throws Exception {
 
         final String[] expected = {
-            "22:1: " + getCheckMessage(MSG_KEY, 2, 0, "[AnotherInnerClass, int]"),
-            "23:5: " + getCheckMessage(MSG_KEY, 1, 0, "[ArrayList]"),
+            "23:1: " + getCheckMessage(MSG_KEY, 2, 0, "[AnotherInnerClass, int]"),
+            "25:5: " + getCheckMessage(MSG_KEY, 1, 0, "[ArrayList]"),
         };
 
         verifyWithInlineConfigParser(
@@ -169,9 +169,9 @@ public class ClassDataAbstractionCouplingCheckTest extends AbstractModuleTestSup
     public void testEmptyRegularExpression() throws Exception {
 
         final String[] expected = {
-            "22:1: " + getCheckMessage(MSG_KEY, 4, 0, "[AnotherInnerClass, HashMap, HashSet, int]"),
-            "23:5: " + getCheckMessage(MSG_KEY, 1, 0, "[ArrayList]"),
-            "43:1: " + getCheckMessage(MSG_KEY, 2, 0, "[HashMap, HashSet]"),
+            "23:1: " + getCheckMessage(MSG_KEY, 4, 0, "[AnotherInnerClass, HashMap, HashSet, int]"),
+            "25:5: " + getCheckMessage(MSG_KEY, 1, 0, "[ArrayList]"),
+            "45:1: " + getCheckMessage(MSG_KEY, 2, 0, "[HashMap, HashSet]"),
         };
 
         verifyWithInlineConfigParser(
@@ -183,11 +183,11 @@ public class ClassDataAbstractionCouplingCheckTest extends AbstractModuleTestSup
 
         final int maxAbstraction = 1;
         final String[] expected = {
-            "31:1: " + getCheckMessage(MSG_KEY, 2, maxAbstraction, "[Date, Time]"),
-            "36:1: " + getCheckMessage(MSG_KEY, 2, maxAbstraction, "[Date, Time]"),
-            "46:1: " + getCheckMessage(MSG_KEY, 2, maxAbstraction, "[Date, Time]"),
-            "55:1: " + getCheckMessage(MSG_KEY, 2, maxAbstraction, "[Date, Time]"),
-            "67:5: " + getCheckMessage(MSG_KEY, 3, maxAbstraction, "[Date, Place, Time]"),
+            "32:1: " + getCheckMessage(MSG_KEY, 2, maxAbstraction, "[Date, Time]"),
+            "38:1: " + getCheckMessage(MSG_KEY, 2, maxAbstraction, "[Date, Time]"),
+            "49:1: " + getCheckMessage(MSG_KEY, 2, maxAbstraction, "[Date, Time]"),
+            "58:1: " + getCheckMessage(MSG_KEY, 2, maxAbstraction, "[Date, Time]"),
+            "71:5: " + getCheckMessage(MSG_KEY, 3, maxAbstraction, "[Date, Place, Time]"),
         };
 
         verifyWithInlineConfigParser(
@@ -199,7 +199,7 @@ public class ClassDataAbstractionCouplingCheckTest extends AbstractModuleTestSup
     public void testNew() throws Exception {
 
         final String[] expected = {
-            "19:1: " + getCheckMessage(MSG_KEY, 2, 0, "[File, Random]"),
+            "20:1: " + getCheckMessage(MSG_KEY, 2, 0, "[File, Random]"),
         };
         verifyWithInlineConfigParser(
                 getPath("InputClassDataAbstractionCoupling5.java"), expected);

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/metrics/classdataabstractioncoupling/InputClassDataAbstractionCoupling.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/metrics/classdataabstractioncoupling/InputClassDataAbstractionCoupling.java
@@ -13,8 +13,10 @@ package com.puppycrawl.tools.checkstyle.checks.metrics.classdataabstractioncoupl
 import javax.naming.NamingException;
 import java.util.*;
 
-public class InputClassDataAbstractionCoupling { // violation
-    private class InnerClass { // violation
+// violation below, 'Class Data Abstraction Coupling is 4 (max allowed is 0)'
+public class InputClassDataAbstractionCoupling {
+    // violation below, 'Class Data Abstraction Coupling is 1 (max allowed is 0)'
+    private class InnerClass {
         public List _list = new ArrayList();
     }
 
@@ -34,7 +36,7 @@ public class InputClassDataAbstractionCoupling { // violation
 
 }
 
-enum InnerEnum { // violation
+enum InnerEnum { // violation, 'Class Data Abstraction Coupling is 2 (max allowed is 0)'
     VALUE1;
 
     private InnerEnum()

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/metrics/classdataabstractioncoupling/InputClassDataAbstractionCoupling3.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/metrics/classdataabstractioncoupling/InputClassDataAbstractionCoupling3.java
@@ -19,8 +19,10 @@ import java.util.Set;
 
 import javax.naming.NamingException;
 
-public class InputClassDataAbstractionCoupling3 { // violation
-    private class InnerClass { // violation
+// violation below, 'Class Data Abstraction Coupling is 2 (max allowed is 0)'
+public class InputClassDataAbstractionCoupling3 {
+    // violation below, 'Class Data Abstraction Coupling is 1 (max allowed is 0)'
+    private class InnerClass {
         public List _list = new ArrayList();
     }
 

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/metrics/classdataabstractioncoupling/InputClassDataAbstractionCoupling4.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/metrics/classdataabstractioncoupling/InputClassDataAbstractionCoupling4.java
@@ -19,8 +19,10 @@ import java.util.Set;
 
 import javax.naming.NamingException;
 
-public class InputClassDataAbstractionCoupling4 { // violation
-    private class InnerClass { // violation
+// violation below, 'Class Data Abstraction Coupling is 4 (max allowed is 0)'
+public class InputClassDataAbstractionCoupling4 {
+    // violation below, 'Class Data Abstraction Coupling is 1 (max allowed is 0)'
+    private class InnerClass {
         public List _list = new ArrayList();
     }
 
@@ -40,7 +42,7 @@ public class InputClassDataAbstractionCoupling4 { // violation
 
 }
 
-enum InnerEnum4 { // violation
+enum InnerEnum4 { // violation, 'Class Data Abstraction Coupling is 2 (max allowed is 0)'
     VALUE1;
 
     private InnerEnum4()

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/metrics/classdataabstractioncoupling/InputClassDataAbstractionCoupling5.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/metrics/classdataabstractioncoupling/InputClassDataAbstractionCoupling5.java
@@ -16,7 +16,8 @@ import java.util.List;
 import java.util.Random;
 import java.util.stream.Collectors;
 
-public class InputClassDataAbstractionCoupling5 {  // violation, 'Coupling is 2'
+// violation below, 'Class Data Abstraction Coupling is 2 (max allowed is 0)'
+public class InputClassDataAbstractionCoupling5 {
     public void method(String... filenames) {
         Random random = new Random();
         final List<File> files = Arrays.stream(filenames)

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/metrics/classdataabstractioncoupling/InputClassDataAbstractionCouplingExcludedPackagesAllIgnored.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/metrics/classdataabstractioncoupling/InputClassDataAbstractionCouplingExcludedPackagesAllIgnored.java
@@ -26,16 +26,18 @@ import org.apache.commons.lang3.text.StrTokenizer;
 import org.apache.commons.lang3.concurrent.BasicThreadFactory;
 import org.apache.commons.lang3.tuple.MutablePair;
 
-public class InputClassDataAbstractionCouplingExcludedPackagesAllIgnored { // violation
+// violation below, 'Class Data Abstraction Coupling is 1 (max allowed is 0)'
+public class InputClassDataAbstractionCouplingExcludedPackagesAllIgnored {
     public ImmutablePair<String, Integer> aa = new ImmutablePair<>("test", 1);
     public StrTokenizer ab = new StrTokenizer();
 
-    class Inner { // violation
+    class Inner { // violation, 'Class Data Abstraction Coupling is 1 (max allowed is 0)'
         public MutablePair<String, String> b = new MutablePair<>("key", "value");
         public BasicThreadFactory c = new BasicThreadFactory.Builder().build();
     }
 }
 
-class InputClassDataAbstractionCouplingExcludedPackagesAllIgnoredHidden { // violation
+// violation below, 'Class Data Abstraction Coupling is 1 (max allowed is 0)'
+class InputClassDataAbstractionCouplingExcludedPackagesAllIgnoredHidden {
     public BasicThreadFactory c = new BasicThreadFactory.Builder().build();
 }

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/metrics/classdataabstractioncoupling/InputClassDataAbstractionCouplingExcludedPackagesCommonPackage.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/metrics/classdataabstractioncoupling/InputClassDataAbstractionCouplingExcludedPackagesCommonPackage.java
@@ -25,17 +25,19 @@ import org.apache.commons.lang3.tuple.MutablePair;
 import org.apache.commons.lang3.text.StrTokenizer;
 import org.apache.commons.lang3.concurrent.BasicThreadFactory;
 
-public class InputClassDataAbstractionCouplingExcludedPackagesCommonPackage { // violation
+// violation below, 'Class Data Abstraction Coupling is 2 (max allowed is 0)'
+public class InputClassDataAbstractionCouplingExcludedPackagesCommonPackage {
     public ImmutablePair<String, Integer> aa = new ImmutablePair<>("test", 1);
     public StrTokenizer ab = new StrTokenizer();
 
-    class Inner { // violation
+    class Inner { // violation, 'Class Data Abstraction Coupling is 2 (max allowed is 0)'
         public MutablePair<String, String> b = new MutablePair<>("key", "value");
         public BasicThreadFactory c = new BasicThreadFactory.Builder().build();
     }
 }
 
-class InputClassDataAbstractionCouplingExcludedPackagesCommonPackageHidden { // violation
+// violation below, 'Class Data Abstraction Coupling is 1 (max allowed is 0)'
+class InputClassDataAbstractionCouplingExcludedPackagesCommonPackageHidden {
     public BasicThreadFactory c = new BasicThreadFactory.Builder().build();
 }
 

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/metrics/classdataabstractioncoupling/InputClassDataAbstractionCouplingExcludedPackagesDirectPackages.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/metrics/classdataabstractioncoupling/InputClassDataAbstractionCouplingExcludedPackagesDirectPackages.java
@@ -25,17 +25,19 @@ import org.apache.commons.lang3.text.StrTokenizer;
 import org.apache.commons.lang3.concurrent.BasicThreadFactory;
 import org.apache.commons.lang3.tuple.MutablePair;
 
-public class InputClassDataAbstractionCouplingExcludedPackagesDirectPackages { // violation
+// violation below, 'Class Data Abstraction Coupling is 1 (max allowed is 0)'
+public class InputClassDataAbstractionCouplingExcludedPackagesDirectPackages {
     public ImmutablePair<String, Integer> aa = new ImmutablePair<>("test", 1);
     public StrTokenizer ab = new StrTokenizer();
 
-    class Inner { // violation
+    class Inner { // violation, 'Class Data Abstraction Coupling is 1 (max allowed is 0)'
         public MutablePair<String, String> b = new MutablePair<>("key", "value");
         public BasicThreadFactory c = new BasicThreadFactory.Builder().build();
     }
 }
 
-class InputClassDataAbstractionCouplingExcludedPackagesDirectPackagesHidden { // violation
+// violation below, 'Class Data Abstraction Coupling is 1 (max allowed is 0)'
+class InputClassDataAbstractionCouplingExcludedPackagesDirectPackagesHidden {
     public BasicThreadFactory c = new BasicThreadFactory.Builder().build();
 }
 

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/metrics/classdataabstractioncoupling/InputClassDataAbstractionCouplingRecords.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/metrics/classdataabstractioncoupling/InputClassDataAbstractionCouplingRecords.java
@@ -28,12 +28,14 @@ import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
 
-class InputClassDataAbstractionCouplingRecords { // violation
+// violation below, 'Class Data Abstraction Coupling is 2 (max allowed is 1)'
+class InputClassDataAbstractionCouplingRecords {
     Date date = new Date(); // Counted, 1
     Time time = new Time(2, 2, 2);
 }
 
-record MyRecord1(boolean a, boolean b) { // violation
+// violation below, 'Class Data Abstraction Coupling is 2 (max allowed is 1)'
+record MyRecord1(boolean a, boolean b) {
 
     private boolean myBool() {
         Date date = new Date(); // Counted, 1
@@ -43,7 +45,8 @@ record MyRecord1(boolean a, boolean b) { // violation
 
 }
 
-record MyRecord2(String myString, boolean a, boolean b) { // violation
+// violation below, 'Class Data Abstraction Coupling is 2 (max allowed is 1)'
+record MyRecord2(String myString, boolean a, boolean b) {
 
     // in compact ctor
     public MyRecord2 {
@@ -52,7 +55,7 @@ record MyRecord2(String myString, boolean a, boolean b) { // violation
     }
 }
 
-record MyRecord3(int x) { // violation
+record MyRecord3(int x) { // violation, 'Class Data Abstraction Coupling is 2 (max allowed is 1)'
 
     // in ctor
     MyRecord3() {
@@ -64,7 +67,8 @@ record MyRecord3(int x) { // violation
 }
 
 record MyRecord4(int y) {
-    private record MyRecord5(int z) { // violation
+    // violation below, 'Class Data Abstraction Coupling is 3 (max allowed is 1)'
+    private record MyRecord5(int z) {
         static Set<Integer> set = new HashSet<>(); // HashSet ignored
         static Map<String, Integer> map = new HashMap<>(); // HashMap ignored
         static Date date = new Date(); // Counted, 1


### PR DESCRIPTION
Issue #15456: Define violation messages for ClassDataAbstractionCouplingCheck

Define violation messages for `ClassDataAbstractionCouplingCheck`.

Added specific violation messages to all 24 violations across 9 input test files. Used `// violation below, '...'` where the line would exceed 100 characters, and inline `// violation, '...'` where it fits. 
Updated expected line numbers in ClassDataAbstractionCouplingCheckTest.java accordingly.