### PR TITLE
Issue #11163: Enforce file size for MultipleStringLiterals input files

### DIFF
--- a/config/checkstyle-resources-suppressions.xml
+++ b/config/checkstyle-resources-suppressions.xml
@@ -591,8 +591,6 @@
   <suppress checks="FileLength"
     files="[\\/]test[\\/]resources[\\/]com[\\/]puppycrawl[\\/]tools[\\/]checkstyle[\\/]main[\\/]InputMainComplexityOverflow\.java"/>
   <suppress checks="FileLength"
-    files="[\\/]test[\\/]resources[\\/]com[\\/]puppycrawl[\\/]tools[\\/]checkstyle[\\/]checks[\\/]coding[\\/]multiplestringliterals[\\/]InputMultipleStringLiteralsTextBlocks\.java"/>
-  <suppress checks="FileLength"
     files="[\\/]test[\\/]resources-noncompilable[\\/]com[\\/]puppycrawl[\\/]tools[\\/]checkstyle[\\/]checks[\\/]blocks[\\/]needbraces[\\/]InputNeedBracesTestSwitchExpression\.java"/>
   <suppress checks="FileLength"
     files="[\\/]test[\\/]resources[\\/]com[\\/]puppycrawl[\\/]tools[\\/]checkstyle[\\/]checks[\\/]metrics[\\/]cyclomaticcomplexity[\\/]InputCyclomaticComplexityRecords\.java"/>

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/coding/MultipleStringLiteralsCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/coding/MultipleStringLiteralsCheckTest.java
@@ -152,8 +152,7 @@ public class MultipleStringLiteralsCheckTest extends AbstractModuleTestSupport {
     }
 
     @Test
-    public void testMultipleStringLiteralsTextBlocks() throws Exception {
-
+    public void testMultipleStringLiteralsTextBlocks1() throws Exception {
         final String[] expected = {
             "14:22: " + getCheckMessage(MSG_KEY, "\"string\"", 3),
             "19:25: " + getCheckMessage(MSG_KEY, "\"other string\"", 2),
@@ -168,16 +167,23 @@ public class MultipleStringLiteralsCheckTest extends AbstractModuleTestSupport {
                 + "\\r \\r\\n \\\\r\\\\n \\\\''\\n\\\\11 \\\\57 \\n\\\\n\\n\\\\\\n\\n \\\\ \"\"a "
                 + "\"a\\n\\\\' \\\\\\' \\'\\n\"", 2),
             "65:20: " + getCheckMessage(MSG_KEY, "\"foo\"", 4),
-            "73:19: " + getCheckMessage(MSG_KEY, "\"another test\"", 2),
-            "77:20: " + getCheckMessage(MSG_KEY, "\"\"", 6),
-            "88:23: " + getCheckMessage(MSG_KEY, "\"        .\\n         .\\n.\\n\"", 2),
-            "104:24: " + getCheckMessage(MSG_KEY, "\"             foo\\n\\n\\n "
-                + "       bar\"", 2),
-            };
-
+        };
         verifyWithInlineConfigParser(
-                getPath("InputMultipleStringLiteralsTextBlocks.java"),
+                getPath("InputMultipleStringLiteralsTextBlocks1.java"),
             expected);
     }
 
+    @Test
+    public void testMultipleStringLiteralsTextBlocks2() throws Exception {
+        final String[] expected = {
+            "14:19: " + getCheckMessage(MSG_KEY, "\"another test\"", 2),
+            "18:20: " + getCheckMessage(MSG_KEY, "\"\"", 6),
+            "29:23: " + getCheckMessage(MSG_KEY, "\"        .\\n         .\\n.\\n\"", 2),
+            "45:24: " + getCheckMessage(MSG_KEY, "\"             foo\\n\\n\\n "
+                + "       bar\"", 2),
+        };
+        verifyWithInlineConfigParser(
+                getPath("InputMultipleStringLiteralsTextBlocks2.java"),
+            expected);
+    }
 }

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/multiplestringliterals/InputMultipleStringLiteralsTextBlocks1.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/multiplestringliterals/InputMultipleStringLiteralsTextBlocks1.java
@@ -10,7 +10,7 @@ ignoreOccurrenceContext = (default)ANNOTATION
 // Java17
 package com.puppycrawl.tools.checkstyle.checks.coding.multiplestringliterals;
 
-public class InputMultipleStringLiteralsTextBlocks {
+public class InputMultipleStringLiteralsTextBlocks1 {
     String string1 = "string"; // occurance #1 // violation
     String string2a = "string"; // violation #1
     String string2b = """
@@ -68,54 +68,4 @@ public class InputMultipleStringLiteralsTextBlocks {
             foo"""; // violation #2
     String str2b = """
             foo"""; // violation #3
-
-
-    String str3 = "another test"; // occurrence #1 // violation
-    String str4 = """
-            another test"""; // violation #1
-
-    String str5a = ""; // occurrence #1 // violation
-    String str5b = """
-            """; // violation #1
-    String str6 = """
-                        """; // violation #2
-    String str7 = """
-"""; // violation #3
-
-    String str8 = """
-                             """; // violation #4
-     // violation below
-    String str8b = """
-        .
-         .
-.
-        """;
-
-    String str8c = """
-        .
-         .
-.
-        """;
-
-    String str9a = """
-            test    """; // trailing whitespace removed per javac result
-    String str9b = "test    "; // trailing whitespace not removed, strings are not equal!
-     // violation below
-    String str10a = """
-             foo
-
-
-        bar""";
-    String str10b = """
-             foo
-
-
-        bar""";
-    String emptyWithLotsOfLines = """
-
-
-
-
-""";
-
 }

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/multiplestringliterals/InputMultipleStringLiteralsTextBlocks2.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/multiplestringliterals/InputMultipleStringLiteralsTextBlocks2.java
@@ -1,0 +1,61 @@
+/*
+MultipleStringLiterals
+allowedDuplicates = (default)1
+ignoreStringsRegexp = (null)
+ignoreOccurrenceContext = (default)ANNOTATION
+
+
+*/
+
+// Java17
+package com.puppycrawl.tools.checkstyle.checks.coding.multiplestringliterals;
+
+public class InputMultipleStringLiteralsTextBlocks2 {
+    String str3 = "another test"; // occurrence #1 // violation
+    String str4 = """
+            another test"""; // violation #1
+
+    String str5a = ""; // occurrence #1 // violation
+    String str5b = """
+            """; // violation #1
+    String str6 = """
+                        """; // violation #2
+    String str7 = """
+"""; // violation #3
+
+    String str8 = """
+                             """; // violation #4
+     // violation below
+    String str8b = """
+        .
+         .
+.
+        """;
+
+    String str8c = """
+        .
+         .
+.
+        """;
+
+    String str9a = """
+            test    """; // trailing whitespace removed per javac result
+    String str9b = "test    "; // trailing whitespace not removed, strings are not equal!
+     // violation below
+    String str10a = """
+             foo
+
+
+        bar""";
+    String str10b = """
+             foo
+
+
+        bar""";
+    String emptyWithLotsOfLines = """
+
+
+
+
+""";
+}


### PR DESCRIPTION
issue  #11163

Split InputMultipleStringLiteralsTextBlocks.java into two files under 120-line limit:

- InputMultipleStringLiteralsTextBlocks1.java (first half: "string", "other string", escape strings, "foo" sections)
- InputMultipleStringLiteralsTextBlocks2.java (second half: "another test", empty strings, remaining text blocks)

Updated MultipleStringLiteralsCheckTest.java with two test methods for each new file.
Removed suppression from checkstyle-resources-suppressions.xml.
build succes with `mvn clean verify`