### PR TITLE
Issue #11527: Extend TokenUtil.isOfType with overloaded methods to improve performance

### DIFF
--- a/config/jsoref-spellchecker/whitelist.words
+++ b/config/jsoref-spellchecker/whitelist.words
@@ -866,6 +866,7 @@ multiplevariabledeclarations
 Multiset
 multithreading
 mutableexception
+mutationtest
 MVC
 mvn
 mvnrepository

--- a/config/pitest-suppressions/pitest-utils-suppressions.xml
+++ b/config/pitest-suppressions/pitest-utils-suppressions.xml
@@ -1,3 +1,20 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <suppressedMutations>
+  <mutation unstable="false">
+    <sourceFile>TokenUtil.java</sourceFile>
+    <mutatedClass>com.puppycrawl.tools.checkstyle.utils.TokenUtil</mutatedClass>
+    <mutatedMethod>isOfType</mutatedMethod>
+    <mutator>org.pitest.mutationtest.engine.gregor.mutators.RemoveConditionalMutator_EQUAL_IF</mutator>
+    <description>removed conditional - replaced equality check with true</description>
+    <lineContent>return ast != null &amp;&amp; isOfType(ast.getType(), types);</lineContent>
+  </mutation>
+
+  <mutation unstable="false">
+    <sourceFile>TokenUtil.java</sourceFile>
+    <mutatedClass>com.puppycrawl.tools.checkstyle.utils.TokenUtil</mutatedClass>
+    <mutatedMethod>isOfType</mutatedMethod>
+    <mutator>org.pitest.mutationtest.engine.gregor.mutators.RemoveConditionalMutator_EQUAL_IF</mutator>
+    <description>removed conditional - replaced equality check with true</description>
+    <lineContent>return type == first || type == second || type == third || type == fourth;</lineContent>
+  </mutation>
 </suppressedMutations>

--- a/src/main/java/com/puppycrawl/tools/checkstyle/utils/TokenUtil.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/utils/TokenUtil.java
@@ -343,6 +343,114 @@ public final class TokenUtil {
     }
 
     /**
+     * Determines if the token type belongs to the given type.
+     *
+     * @param type the Token Type to check
+     * @param first the acceptable type
+     *
+     * @return true if type matches the given type.
+     */
+    public static boolean isOfType(int type, int first) {
+        return type == first;
+    }
+
+    /**
+     * Determines if the token type belongs to the given types.
+     *
+     * @param type the Token Type to check
+     * @param first the first acceptable type
+     * @param second the second acceptable type
+     *
+     * @return true if type matches one of the given types.
+     */
+    public static boolean isOfType(int type, int first, int second) {
+        return type == first || type == second;
+    }
+
+    /**
+     * Determines if the token type belongs to the given types.
+     *
+     * @param type the Token Type to check
+     * @param first the first acceptable type
+     * @param second the second acceptable type
+     * @param third the third acceptable type
+     *
+     * @return true if type matches one of the given types.
+     */
+    public static boolean isOfType(int type, int first, int second, int third) {
+        return type == first || type == second || type == third;
+    }
+
+    /**
+     * Determines if the token type belongs to the given types.
+     *
+     * @param type the Token Type to check
+     * @param first the first acceptable type
+     * @param second the second acceptable type
+     * @param third the third acceptable type
+     * @param fourth the fourth acceptable type
+     *
+     * @return true if type matches one of the given types.
+     */
+    public static boolean isOfType(int type, int first, int second, int third, int fourth) {
+        return type == first || type == second || type == third || type == fourth;
+    }
+
+    /**
+     * Determines if the AST belongs to the given type.
+     *
+     * @param ast the AST node to check
+     * @param first the acceptable type
+     *
+     * @return true if type matches the given type.
+     */
+    public static boolean isOfType(DetailAST ast, int first) {
+        return ast != null && isOfType(ast.getType(), first);
+    }
+
+    /**
+     * Determines if the AST belongs to the given types.
+     *
+     * @param ast the AST node to check
+     * @param first the first acceptable type
+     * @param second the second acceptable type
+     *
+     * @return true if type matches one of the given types.
+     */
+    public static boolean isOfType(DetailAST ast, int first, int second) {
+        return ast != null && isOfType(ast.getType(), first, second);
+    }
+
+    /**
+     * Determines if the AST belongs to the given types.
+     *
+     * @param ast the AST node to check
+     * @param first the first acceptable type
+     * @param second the second acceptable type
+     * @param third the third acceptable type
+     *
+     * @return true if type matches one of the given types.
+     */
+    public static boolean isOfType(DetailAST ast, int first, int second, int third) {
+        return ast != null && isOfType(ast.getType(), first, second, third);
+    }
+
+    /**
+     * Determines if the AST belongs to the given types.
+     *
+     * @param ast the AST node to check
+     * @param first the first acceptable type
+     * @param second the second acceptable type
+     * @param third the third acceptable type
+     * @param fourth the fourth acceptable type
+     *
+     * @return true if type matches one of the given types.
+     */
+    public static boolean isOfType(DetailAST ast, int first, int second, int third, int fourth) {
+        return ast != null && isOfType(ast.getType(), first, second, third, fourth);
+    }
+
+    /**
      * Determines if given AST is a root node, i.e. if the type
      * of the token we are checking is {@code COMPILATION_UNIT}.
      *

--- a/src/test/java/com/puppycrawl/tools/checkstyle/utils/TokenUtilTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/utils/TokenUtilTest.java
@@ -378,6 +378,100 @@ public class TokenUtilTest {
     }
 
     @Test
+    public void testIsOfTypeOverloadsTrue() {
+        final int type = TokenTypes.LITERAL_CATCH;
+        final DetailAstImpl ast = new DetailAstImpl();
+        ast.setType(type);
+
+        assertWithMessage("1-arg int overload")
+                .that(TokenUtil.isOfType(type, TokenTypes.LITERAL_CATCH))
+                .isTrue();
+        assertWithMessage("2-arg int overload")
+                .that(TokenUtil.isOfType(type, TokenTypes.LITERAL_FOR, TokenTypes.LITERAL_CATCH))
+                .isTrue();
+        assertWithMessage("3-arg int overload")
+                .that(TokenUtil.isOfType(type, TokenTypes.LITERAL_FOR,
+                        TokenTypes.LITERAL_IF, TokenTypes.LITERAL_CATCH))
+                .isTrue();
+        assertWithMessage("4-arg int overload")
+                .that(TokenUtil.isOfType(type, TokenTypes.LITERAL_FOR,
+                        TokenTypes.LITERAL_IF, TokenTypes.LITERAL_ELSE, TokenTypes.LITERAL_CATCH))
+                .isTrue();
+
+        assertWithMessage("1-arg ast overload")
+                .that(TokenUtil.isOfType(ast, TokenTypes.LITERAL_CATCH))
+                .isTrue();
+        assertWithMessage("2-arg ast overload")
+                .that(TokenUtil.isOfType(ast, TokenTypes.LITERAL_FOR, TokenTypes.LITERAL_CATCH))
+                .isTrue();
+        assertWithMessage("3-arg ast overload")
+                .that(TokenUtil.isOfType(ast, TokenTypes.LITERAL_FOR,
+                        TokenTypes.LITERAL_IF, TokenTypes.LITERAL_CATCH))
+                .isTrue();
+        assertWithMessage("4-arg ast overload")
+                .that(TokenUtil.isOfType(ast, TokenTypes.LITERAL_FOR,
+                        TokenTypes.LITERAL_IF, TokenTypes.LITERAL_ELSE, TokenTypes.LITERAL_CATCH))
+                .isTrue();
+    }
+
+    @Test
+    public void testIsOfTypeOverloadsFalse() {
+        final int type = TokenTypes.LITERAL_CATCH;
+        final DetailAstImpl ast = new DetailAstImpl();
+        ast.setType(type);
+
+        assertWithMessage("1-arg int overload")
+                .that(TokenUtil.isOfType(type, TokenTypes.LITERAL_FOR))
+                .isFalse();
+        assertWithMessage("2-arg int overload")
+                .that(TokenUtil.isOfType(type, TokenTypes.LITERAL_FOR, TokenTypes.LITERAL_IF))
+                .isFalse();
+        assertWithMessage("3-arg int overload")
+                .that(TokenUtil.isOfType(type, TokenTypes.LITERAL_FOR,
+                        TokenTypes.LITERAL_IF, TokenTypes.LITERAL_ELSE))
+                .isFalse();
+        assertWithMessage("4-arg int overload")
+                .that(TokenUtil.isOfType(type, TokenTypes.LITERAL_FOR, TokenTypes.LITERAL_IF,
+                        TokenTypes.LITERAL_ELSE, TokenTypes.LITERAL_SWITCH))
+                .isFalse();
+
+        assertWithMessage("1-arg ast overload")
+                .that(TokenUtil.isOfType(ast, TokenTypes.LITERAL_FOR))
+                .isFalse();
+        assertWithMessage("2-arg ast overload")
+                .that(TokenUtil.isOfType(ast, TokenTypes.LITERAL_FOR, TokenTypes.LITERAL_IF))
+                .isFalse();
+        assertWithMessage("3-arg ast overload")
+                .that(TokenUtil.isOfType(ast, TokenTypes.LITERAL_FOR,
+                        TokenTypes.LITERAL_IF, TokenTypes.LITERAL_ELSE))
+                .isFalse();
+        assertWithMessage("4-arg ast overload")
+                .that(TokenUtil.isOfType(ast, TokenTypes.LITERAL_FOR, TokenTypes.LITERAL_IF,
+                        TokenTypes.LITERAL_ELSE, TokenTypes.LITERAL_SWITCH))
+                .isFalse();
+    }
+
+    @Test
+    public void testIsOfTypeOverloadsNullAstFalse() {
+        final DetailAstImpl nullAst = null;
+
+        assertWithMessage("1-arg null ast overload")
+                .that(TokenUtil.isOfType(nullAst, TokenTypes.LITERAL_CATCH))
+                .isFalse();
+        assertWithMessage("2-arg null ast overload")
+                .that(TokenUtil.isOfType(nullAst, TokenTypes.LITERAL_FOR, TokenTypes.LITERAL_CATCH))
+                .isFalse();
+        assertWithMessage("3-arg null ast overload")
+                .that(TokenUtil.isOfType(nullAst, TokenTypes.LITERAL_FOR,
+                        TokenTypes.LITERAL_IF, TokenTypes.LITERAL_CATCH))
+                .isFalse();
+        assertWithMessage("4-arg null ast overload")
+                .that(TokenUtil.isOfType(nullAst, TokenTypes.LITERAL_FOR, TokenTypes.LITERAL_IF,
+                        TokenTypes.LITERAL_ELSE, TokenTypes.LITERAL_CATCH))
+                .isFalse();
+    }
+
+    @Test
     public void testIsBooleanLiteralType() {
         assertWithMessage("Result is not expected")
                 .that(TokenUtil.isBooleanLiteralType(TokenTypes.LITERAL_TRUE))


### PR DESCRIPTION
Fixes #11527 

added overloaded methods to `TokenUtil.isOfType` to avoid varargs array allocation when checking against fixed no. of token types (1 - 4)