### PR TITLE
Issue #16963: fix Uncaught TypeError in resetStyling

### DIFF
--- a/src/site/resources/js/checkstyle.js
+++ b/src/site/resources/js/checkstyle.js
@@ -168,11 +168,27 @@ function setCollapsableMenuButton() {
 }
 
 function resetStyling() {
-    document.querySelector("#leftColumn").removeAttribute("style");
-    document.querySelector("body").removeAttribute("style");
-    document.querySelector("#bodyColumn").style.removeProperty("position");
-    document.querySelector("#hamburger").remove();
-    document.querySelector(".xright").lastChild.remove();
+    const leftColumn = document.querySelector("#leftColumn");
+    const body = document.querySelector("body");
+    const bodyColumn = document.querySelector("#bodyColumn");
+    const hamburger = document.querySelector("#hamburger");
+    const xright = document.querySelector(".xright");
+
+    if (leftColumn) {
+        leftColumn.removeAttribute("style");
+    }
+    if (body) {
+        body.removeAttribute("style");
+    }
+    if (bodyColumn) {
+        bodyColumn.style.removeProperty("position");
+    }
+    if (hamburger) {
+        hamburger.remove();
+    }
+    if (xright && xright.lastChild) {
+        xright.lastChild.remove();
+    }
 }
 
 window.addEventListener("load", function () {

--- a/src/test/java/com/puppycrawl/tools/checkstyle/internal/XdocsPagesTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/internal/XdocsPagesTest.java
@@ -2466,6 +2466,30 @@ public class XdocsPagesTest {
     }
 
     @Test
+    public void testResetStylingHasNullChecks() throws Exception {
+        final String checkstyleJsContent = Files.readString(CHECKSTYLE_JS_PATH);
+        final String[] requiredNullChecks = {
+            "const leftColumn = document.querySelector(\"#leftColumn\")",
+            "const body = document.querySelector(\"body\")",
+            "const bodyColumn = document.querySelector(\"#bodyColumn\")",
+            "const hamburger = document.querySelector(\"#hamburger\")",
+            "const xright = document.querySelector(\".xright\")",
+            "if (leftColumn)",
+            "if (body)",
+            "if (bodyColumn)",
+            "if (hamburger)",
+            "if (xright && xright.lastChild)",
+        };
+        for (String nullCheck : requiredNullChecks) {
+            assertWithMessage(
+                    "resetStyling() in %s is missing null check: '%s'",
+                    CHECKSTYLE_JS_PATH, nullCheck)
+                .that(checkstyleJsContent)
+                .contains(nullCheck);
+        }
+    }
+
+    @Test
     public void testAllXdocsModulesTemplatesHaveSinceMacroAtTheBeginning() throws Exception {
         for (Path path : XdocUtil.getXdocsTemplatesFilePaths()) {
             final String fileName = path.getFileName().toString();


### PR DESCRIPTION
Fixes #16963

## Problem
`resetStyling()` function in `src/site/resources/js/checkstyle.js` 
was directly chaining method calls on all 5 `document.querySelector()` 
calls without any null checks.

When any of these elements are missing from the DOM (e.g., when user 
opens DevTools twice quickly, or navigates between pages), 
`document.querySelector()` returns `null`, causing:

Uncaught TypeError: Cannot read properties of null (reading 'lastChild')
    at resetStyling (checkstyle.js:135:38)
    at setBodyColumnMargin (checkstyle.js:78:9)

This affected almost all left-side navigation links across the website,
not just cmdline.html.

## Root Cause
All 5 elements were accessed without null guards:
- `#leftColumn`
- `body`
- `#bodyColumn`
- `#hamburger`
- `.xright`

Any of these can be `null` depending on the page state or 
timing of DOM availability.

## Fix
Refactored `resetStyling()` to:
1. Store each `document.querySelector()` result in a `const` variable
2. Wrap each DOM operation in a null check before executing

## Testing
- Added `testResetStylingHasNullChecks()` in `XdocsPagesTest.java`
- Test reads `checkstyle.js` and verifies all null guards exist
- Verified fix locally by generating site with `mvn site -DskipTests`
- Confirmed original bug reproducible on official website
- Confirmed no TypeError in local build after fix