### PR TITLE
Issue #15456: Update HideUtilityClassConstructorCheck to use explicit violation messages

### DIFF
--- a/src/test/java/com/puppycrawl/tools/checkstyle/bdd/InlineConfigParser.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/bdd/InlineConfigParser.java
@@ -238,7 +238,7 @@ public final class InlineConfigParser {
     private static final Set<String> SUPPRESSED_CHECKS = Set.of(
             "com.puppycrawl.tools.checkstyle.checks.coding.MultipleStringLiteralsCheck",
             "com.puppycrawl.tools.checkstyle.checks.design.DesignForExtensionCheck",
-            "com.puppycrawl.tools.checkstyle.checks.design.HideUtilityClassConstructorCheck",
+
             "com.puppycrawl.tools.checkstyle.checks.design.InnerTypeLastCheck",
             "com.puppycrawl.tools.checkstyle.checks.design.OneTopLevelClassCheck",
             "com.puppycrawl.tools.checkstyle.checks.javadoc."

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/design/hideutilityclassconstructor/InputHideUtilityClassConstructorInnerStaticClasses.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/design/hideutilityclassconstructor/InputHideUtilityClassConstructorInnerStaticClasses.java
@@ -6,7 +6,8 @@ ignoreAnnotatedBy = (default)
 
 package com.puppycrawl.tools.checkstyle.checks.design.hideutilityclassconstructor;
 
-public class InputHideUtilityClassConstructorInnerStaticClasses { // violation
+public class // violation, should not have a public or default constructor
+    InputHideUtilityClassConstructorInnerStaticClasses {
     private static int value = 0;
     public static void foo (int val) { value = val;}
 

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/design/hideutilityclassconstructor/InputHideUtilityClassConstructorPublic.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/design/hideutilityclassconstructor/InputHideUtilityClassConstructorPublic.java
@@ -6,7 +6,8 @@ ignoreAnnotatedBy = (default)
 
 package com.puppycrawl.tools.checkstyle.checks.design.hideutilityclassconstructor;
 
-public class InputHideUtilityClassConstructorPublic { // violation
+public class // violation, should not have a public or default constructor
+    InputHideUtilityClassConstructorPublic {
     public InputHideUtilityClassConstructorPublic() {}
 
     private static int value = 0;


### PR DESCRIPTION
Issue #15456: Update HideUtilityClassConstructorCheck to use explicit violation messages

- Replaced remaining shorthand violation comments with explicit messages
- Updated input files accordingly
- Removed HideUtilityClassConstructorCheck from SUPPRESSED_CHECKS

Local verification:
- Focused tests pass (HideUtilityClassConstructorCheckTest)
- Full verify is blocked locally due to JaCoCo/exec-maven-plugin issue:
  org.jacoco.agent.rt.internal_29a6edd.Offline

This change is limited to the affected input files and InlineConfigParser