### PR TITLE
Issue #19436: Update no-exception-struts job memory to use MaxRAMPercentage=90

### DIFF
--- a/.ci/validation.sh
+++ b/.ci/validation.sh
@@ -1032,6 +1032,7 @@ no-error-trino)
   ;;
 
 no-exception-struts)
+  export MAVEN_OPTS="-XX:MaxRAMPercentage=90"
   CS_POM_VERSION="$(getCheckstylePomVersion)"
   BRANCH=$(git rev-parse --abbrev-ref HEAD)
   echo CS_version: "${CS_POM_VERSION}"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -129,6 +129,7 @@ workflows:
       - validate-with-maven-script:
           name: no-exception-struts
           image-name: *cs_img
+          resource_class: medium+
           command: ./.ci/validation.sh no-exception-struts
       - validate-with-maven-script:
           name: no-exception-checkstyle-sevntu


### PR DESCRIPTION
fixes Issue #19436

`no-exception-struts` was the only `no-exception` job missing both a memory setting and a `resource_class` overide, causing it to run on docker `medium` 4 GB with no jvm memory cap, oom at 78% ram