### PR TITLE
Issue #9956: fix error swallowing in case version evaluation failed

### DIFF
--- a/.ci/bump-version.sh
+++ b/.ci/bump-version.sh
@@ -17,7 +17,8 @@ if ! [[ "$NEW_VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
   exit 1;
 fi
 
-CURRENT_VERSION=$(getCheckstylePomVersionWithoutSnapshot)
+CURRENT_VERSION=$(getCheckstylePomVersionWithoutSnapshot) \
+  || { echo "Failed to get Checkstyle POM version."; exit 1; }
 echo CURRENT_VERSION="$CURRENT_VERSION"
 
 if [ "$NEW_VERSION" == "$CURRENT_VERSION" ]; then

--- a/.ci/no-exception-test.sh
+++ b/.ci/no-exception-test.sh
@@ -6,7 +6,8 @@ source ./.ci/util.sh
 case $1 in
 
 guava-with-google-checks)
-  CS_POM_VERSION="$(getCheckstylePomVersion)"
+  CS_POM_VERSION="$(getCheckstylePomVersion)" \
+    || { echo "Failed to get Checkstyle POM version."; exit 1; }
   BRANCH=$(git rev-parse --abbrev-ref HEAD)
   echo CS_version: "$CS_POM_VERSION"
   checkout_from https://github.com/checkstyle/contribution
@@ -28,7 +29,8 @@ guava-with-google-checks)
   ;;
 
 guava-with-sun-checks)
-  CS_POM_VERSION="$(getCheckstylePomVersion)"
+  CS_POM_VERSION="$(getCheckstylePomVersion)" \
+    || { echo "Failed to get Checkstyle POM version."; exit 1; }
   BRANCH=$(git rev-parse --abbrev-ref HEAD)
   echo CS_version: "$CS_POM_VERSION"
   checkout_from https://github.com/checkstyle/contribution
@@ -138,7 +140,8 @@ openjdk25-with-checks-nonjavadoc-error)
   ;;
 
 no-exception-lucene-and-others-javadoc)
-  CS_POM_VERSION="$(getCheckstylePomVersion)"
+  CS_POM_VERSION="$(getCheckstylePomVersion)" \
+    || { echo "Failed to get Checkstyle POM version."; exit 1; }
   BRANCH=$(git rev-parse --abbrev-ref HEAD)
   echo 'CS_POM_VERSION='"${CS_POM_VERSION}"
   checkout_from https://github.com/checkstyle/contribution
@@ -160,7 +163,8 @@ no-exception-lucene-and-others-javadoc)
   ;;
 
 no-exception-cassandra-storm-tapestry-javadoc)
-  CS_POM_VERSION="$(getCheckstylePomVersion)"
+  CS_POM_VERSION="$(getCheckstylePomVersion)" \
+    || { echo "Failed to get Checkstyle POM version."; exit 1; }
   echo 'CS_POM_VERSION='"${CS_POM_VERSION}"
   BRANCH=$(git rev-parse --abbrev-ref HEAD)
   checkout_from https://github.com/checkstyle/contribution
@@ -181,7 +185,8 @@ no-exception-cassandra-storm-tapestry-javadoc)
   ;;
 
 no-exception-hadoop-apache-groovy-scouter-javadoc)
-  CS_POM_VERSION="$(getCheckstylePomVersion)"
+  CS_POM_VERSION="$(getCheckstylePomVersion)" \
+    || { echo "Failed to get Checkstyle POM version."; exit 1; }
   echo 'CS_POM_VERSION='"${CS_POM_VERSION}"
   BRANCH=$(git rev-parse --abbrev-ref HEAD)
   checkout_from https://github.com/checkstyle/contribution
@@ -203,7 +208,8 @@ no-exception-hadoop-apache-groovy-scouter-javadoc)
   ;;
 
 no-exception-only-javadoc)
-  CS_POM_VERSION="$(getCheckstylePomVersion)"
+  CS_POM_VERSION="$(getCheckstylePomVersion)" \
+    || { echo "Failed to get Checkstyle POM version."; exit 1; }
   echo 'CS_POM_VERSION='"${CS_POM_VERSION}"
   BRANCH=$(git rev-parse --abbrev-ref HEAD)
   checkout_from https://github.com/checkstyle/contribution
@@ -224,7 +230,8 @@ no-exception-only-javadoc)
   ;;
 
 no-exception-samples-ant)
-  CS_POM_VERSION="$(getCheckstylePomVersion)"
+  CS_POM_VERSION="$(getCheckstylePomVersion)" \
+    || { echo "Failed to get Checkstyle POM version."; exit 1; }
   echo 'CS_POM_VERSION='"${CS_POM_VERSION}"
   ./mvnw -e --no-transfer-progress -B install -Pno-validations
   checkout_from https://github.com/sevntu-checkstyle/checkstyle-samples
@@ -241,7 +248,8 @@ no-exception-samples-ant)
   ;;
 
 no-exception-samples-gradle)
-  CS_POM_VERSION="$(getCheckstylePomVersion)"
+  CS_POM_VERSION="$(getCheckstylePomVersion)" \
+    || { echo "Failed to get Checkstyle POM version."; exit 1; }
   echo 'CS_POM_VERSION='"${CS_POM_VERSION}"
   ./mvnw -e --no-transfer-progress -B install -Pno-validations
   checkout_from https://github.com/sevntu-checkstyle/checkstyle-samples
@@ -259,7 +267,8 @@ no-exception-samples-gradle)
   ;;
 
 no-exception-samples-maven)
-  CS_POM_VERSION="$(getCheckstylePomVersion)"
+  CS_POM_VERSION="$(getCheckstylePomVersion)" \
+    || { echo "Failed to get Checkstyle POM version."; exit 1; }
   echo 'CS_POM_VERSION='"${CS_POM_VERSION}"
   ./mvnw -e --no-transfer-progress -B install -Pno-validations
 

--- a/.ci/release-close-create-milestone.sh
+++ b/.ci/release-close-create-milestone.sh
@@ -19,7 +19,8 @@ curl --fail-with-body -i -H "Authorization: token $GITHUB_TOKEN" \
 
 echo "Creation of new milestone ..."
 
-CURRENT_VERSION=$(getCheckstylePomVersionWithoutSnapshot)
+CURRENT_VERSION=$(getCheckstylePomVersionWithoutSnapshot) \
+  || { echo "Failed to get Checkstyle POM version."; exit 1; }
 echo CURRENT_VERSION="$CURRENT_VERSION"
 
 LAST_SUNDAY_DAY=$(cal -d "$(date -d "next month" +"%Y-%m")" \

--- a/.ci/release-maven-prepare.sh
+++ b/.ci/release-maven-prepare.sh
@@ -13,7 +13,8 @@ fi
 TARGET_VERSION=$1
 echo TARGET_VERSION="$TARGET_VERSION"
 
-CURRENT_VERSION=$(getCheckstylePomVersionWithoutSnapshot)
+CURRENT_VERSION=$(getCheckstylePomVersionWithoutSnapshot) \
+  || { echo "Failed to get Checkstyle POM version."; exit 1; }
 echo CURRENT_VERSION="$CURRENT_VERSION"
 
 if [ "$TARGET_VERSION" != "$CURRENT_VERSION" ]; then

--- a/.ci/release-update-xdoc-with-releasenotes.sh
+++ b/.ci/release-update-xdoc-with-releasenotes.sh
@@ -13,7 +13,8 @@ fi
 TARGET_VERSION=$1
 echo TARGET_VERSION="$TARGET_VERSION"
 
-CURRENT_VERSION=$(getCheckstylePomVersionWithoutSnapshot)
+CURRENT_VERSION=$(getCheckstylePomVersionWithoutSnapshot) \
+  || { echo "Failed to get Checkstyle POM version."; exit 1; }
 echo CURRENT_VERSION="$CURRENT_VERSION"
 
 if [ "$TARGET_VERSION" != "$CURRENT_VERSION" ]; then


### PR DESCRIPTION
fixes Issue #9956

Added explicit || { echo "Failed to get Checkstyle POM version."; exit 1; } guard after all 9 occurrences of getCheckstylePomVersion assignment in `.ci/no-exception-test.sh` so script exits immediately with a clear error message if version evaluation fails.