### PR TITLE
Issue #19436: Increase memory for no-error-pmd job to prevent OOM

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,6 @@
 version: 2.1
 
 jobs:
-
   validate-with-maven-script:
     description: Runs a maven script using the job name as the argument.
     parameters: &script_parameters
@@ -124,7 +123,7 @@ workflows:
       - validate-with-maven-script:
           name: no-error-pmd
           image-name: *cs_img
-          resource_class: medium+
+          resource_class: large
           command: ./.ci/validation.sh no-error-pmd
       - validate-with-maven-script:
           name: no-exception-struts


### PR DESCRIPTION
issue #19436

**Problem**
The `no-error-pmd` job consistently fails with "Killed" due to memory exhaustion (OOM killer) examples : #19439 #19434  . This job builds the PMD project, which has 44 modules and a large codebase (~550MB download).

**Root Cause**
The job currently uses `resource_class: medium+` (~6GB RAM). With `-XX:MaxRAMPercentage=90`, it gets ~5.4GB, which is insufficient for compiling PMD's Java module.

**Solution**
Increase the resource class to `large` (~8GB RAM), providing ~7.2GB for the build.

**Changes**
- `.circleci/config.yml`: Change `resource_class` for `no-error-pmd` from `medium+` to `large`

**Testing**
- This change gives the job ~2GB more memory, which should prevent OOM during PMD compilation.
- Other memory-intensive jobs may need similar updates in future PRs.