### PR TITLE
Issue #16807: Update input files for RegexpSinglelineCheck

### DIFF
--- a/src/test/java/com/puppycrawl/tools/checkstyle/bdd/InlineConfigParser.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/bdd/InlineConfigParser.java
@@ -309,7 +309,6 @@ public final class InlineConfigParser {
             "com.puppycrawl.tools.checkstyle.checks.modifier.RedundantModifierCheck",
             "com.puppycrawl.tools.checkstyle.checks.naming.LocalFinalVariableNameCheck",
 
-            "com.puppycrawl.tools.checkstyle.checks.regexp.RegexpSinglelineCheck",
             "com.puppycrawl.tools.checkstyle.checks.regexp.RegexpSinglelineJavaCheck",
             "com.puppycrawl.tools.checkstyle.checks.whitespace.NoWhitespaceAfterCheck",
             "com.puppycrawl.tools.checkstyle.checks.whitespace.WhitespaceAfterCheck",

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/regexp/regexpsingleline/InputRegexpSinglelineSemantic8.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/regexp/regexpsingleline/InputRegexpSinglelineSemantic8.java
@@ -5,7 +5,7 @@ message = (default)
 ignoreCase = (default)false
 minimum = (default)0
 maximum = (default)0
-fileExtensions = (default)all files
+fileExtensions = (default)""
 
 
 */

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/regexp/regexpsingleline/InputRegexpSinglelineSemantic9.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/regexp/regexpsingleline/InputRegexpSinglelineSemantic9.java
@@ -2,6 +2,9 @@
 RegexpSingleline
 format = (default)$.
 message = not expected
+ignoreCase = (default)false
+minimum = (default)0
+maximum = (default)0
 fileExtensions = (default)""
 
 

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppresswithnearbytextfilter/InputSuppressWithNearbyTextFilterCheckPattern.bash.txt
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppresswithnearbytextfilter/InputSuppressWithNearbyTextFilterCheckPattern.bash.txt
@@ -17,7 +17,7 @@ message = (default)(null)
 ignoreCase = (default)false
 minimum = (default)0
 maximum = (default)0
-
+fileExtensions = (default)""
 
 
 */

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppresswithnearbytextfilter/InputSuppressWithNearbyTextFilterIdPattern.html.txt
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppresswithnearbytextfilter/InputSuppressWithNearbyTextFilterIdPattern.html.txt
@@ -18,7 +18,7 @@ message = (default)(null)
 ignoreCase = (default)false
 minimum = (default)0
 maximum = (default)0
-
+fileExtensions = (default)""
 
 
 */

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppresswithnearbytextfilter/InputSuppressWithNearbyTextFilterLineRangeNegative2.txt
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppresswithnearbytextfilter/InputSuppressWithNearbyTextFilterLineRangeNegative2.txt
@@ -17,7 +17,7 @@ message = (default)(null)
 ignoreCase = (default)false
 minimum = (default)0
 maximum = (default)0
-
+fileExtensions = (default)""
 
 
 */

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppresswithnearbytextfilter/InputSuppressWithNearbyTextFilterLineRangePositive3.sql.txt
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppresswithnearbytextfilter/InputSuppressWithNearbyTextFilterLineRangePositive3.sql.txt
@@ -17,7 +17,7 @@ message = (default)(null)
 ignoreCase = (default)false
 minimum = (default)0
 maximum = (default)0
-
+fileExtensions = (default)""
 
 
 */

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppresswithnearbytextfilter/InputSuppressWithNearbyTextFilterMessagePattern.xml.txt
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppresswithnearbytextfilter/InputSuppressWithNearbyTextFilterMessagePattern.xml.txt
@@ -17,7 +17,7 @@ message = (default)(null)
 ignoreCase = (default)false
 minimum = (default)0
 maximum = (default)0
-
+fileExtensions = (default)""
 
 
 */

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppresswithnearbytextfilter/InputSuppressWithNearbyTextFilterNearbyTextPattern.css.txt
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppresswithnearbytextfilter/InputSuppressWithNearbyTextFilterNearbyTextPattern.css.txt
@@ -17,7 +17,7 @@ message = (default)(null)
 ignoreCase = (default)false
 minimum = (default)0
 maximum = (default)0
-
+fileExtensions = (default)""
 
 
 */


### PR DESCRIPTION
Fixes part of #16807

Updated input files for `RegexpSinglelineCheck` to mention all default properties
and use the `default` tag, then removed the module from `SUPPRESSED_MODULES`.

**Changes:**

- `InputRegexpSinglelineSemantic8.java`: Fixed incorrect default value
  `fileExtensions = (default)all files` → `fileExtensions = (default)""`
- `InputRegexpSinglelineSemantic9.java`: Added missing default properties:
  `ignoreCase = (default)false`, `minimum = (default)0`, `maximum = (default)0`
- `InlineConfigParser.java`: Removed `RegexpSinglelineCheck` from `SUPPRESSED_MODULES`

Files 1-7 and 10 already had all required default properties correctly specified.

The 5 validated properties (from XML metadata) are:
- `fileExtensions` (default: `""`)
- `format` (default: `$.`)
- `ignoreCase` (default: `false`)
- `maximum` (default: `0`)
- `minimum` (default: `0`)

Note: `message` has no `default-value` in the metadata, so it is not subject to validation.