### PR TITLE
Issue #16807: Update input files for ImportControlCheck

### DIFF
--- a/src/test/java/com/puppycrawl/tools/checkstyle/bdd/InlineConfigParser.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/bdd/InlineConfigParser.java
@@ -302,7 +302,6 @@ public final class InlineConfigParser {
             "com.puppycrawl.tools.checkstyle.checks.coding.RequireThisCheck",
             "com.puppycrawl.tools.checkstyle.checks.coding.UnusedLocalVariableCheck",
             "com.puppycrawl.tools.checkstyle.checks.imports.CustomImportOrderCheck",
-            "com.puppycrawl.tools.checkstyle.checks.imports.ImportControlCheck",
             "com.puppycrawl.tools.checkstyle.checks.imports.ImportOrderCheck",
             "com.puppycrawl.tools.checkstyle.checks.javadoc.JavadocContentLocationCheck",
             "com.puppycrawl.tools.checkstyle.checks.javadoc.JavadocParagraphCheck",

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/imports/importcontrol/InputImportControlTestRegexpInFile2.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/imports/importcontrol/InputImportControlTestRegexpInFile2.java
@@ -1,6 +1,8 @@
 /*
 ImportControl
 file = (file)(resource)InputImportControlTestRegexpInFile2.xml
+path = (default).*
+
 
 */
 


### PR DESCRIPTION
Fixes part of #16807

Updated input files for `ImportControlCheck` to mention all default properties
and use the `(default)` tag, then removed the module from `SUPPRESSED_MODULES`.

**Changes:**

- `InputImportControlTestRegexpInFile2.java`: Added missing default property
  `path = (default).*`
- `InlineConfigParser.java`: Removed `ImportControlCheck` from `SUPPRESSED_MODULES`

The only property with a default value (from XML metadata) is:
- `path` (default: `.*`)