### PR TITLE
Issue #16807: Update default properties in ClassFanOutComplexityCheck

### DIFF
--- a/src/test/java/com/puppycrawl/tools/checkstyle/bdd/InlineConfigParser.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/bdd/InlineConfigParser.java
@@ -312,7 +312,6 @@ public final class InlineConfigParser {
             "com.puppycrawl.tools.checkstyle.checks.javadoc.MissingJavadocPackageCheck",
             "com.puppycrawl.tools.checkstyle.checks.javadoc.MissingJavadocTypeCheck",
             "com.puppycrawl.tools.checkstyle.checks.javadoc.SummaryJavadocCheck",
-            "com.puppycrawl.tools.checkstyle.checks.metrics.ClassFanOutComplexityCheck",
             "com.puppycrawl.tools.checkstyle.checks.modifier.RedundantModifierCheck",
             "com.puppycrawl.tools.checkstyle.checks.naming.AbbreviationAsWordInNameCheck",
             "com.puppycrawl.tools.checkstyle.checks.naming.LocalFinalVariableNameCheck",

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/metrics/ClassFanOutComplexityCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/metrics/ClassFanOutComplexityCheckTest.java
@@ -389,7 +389,7 @@ public class ClassFanOutComplexityCheckTest extends AbstractModuleTestSupport {
     @Test
     public void testLambdaNew() throws Exception {
         final String[] expected = {
-            "28:1: " + getCheckMessage(MSG_KEY, 2, 0),
+            "29:1: " + getCheckMessage(MSG_KEY, 2, 0),
         };
         verifyWithInlineConfigParser(
                 getPath("InputClassFanOutComplexityLambdaNew.java"), expected);

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/metrics/classfanoutcomplexity/InputClassFanOutComplexityLambdaNew.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/metrics/classfanoutcomplexity/InputClassFanOutComplexityLambdaNew.java
@@ -12,6 +12,7 @@ excludedClasses = (default)ArrayIndexOutOfBoundsException, ArrayList, Boolean, B
                   StringBuffer, StringBuilder, SuppressWarnings, Throwable, TreeMap, TreeSet, \
                   UnsupportedOperationException, Void, boolean, byte, char, double, float, \
                   int, long, short, var, void
+excludeClassesRegexps = (default)^$
 excludedPackages = (default)
 
 


### PR DESCRIPTION
Issue: #16807

Added missing default property to ClassFanOutComplexityCheck input file
and removed ClassFanOutComplexityCheck from SUPPRESSED_MODULES.

Changes:
- InputClassFanOutComplexityLambdaNew.java: Added missing
  `excludeClassesRegexps = (default)^$`
- ClassFanOutComplexityCheckTest.java: Updated expected violation
  line number (28 → 29) due to added property line
- InlineConfigParser.java: Removed ClassFanOutComplexityCheck
  from SUPPRESSED_MODULES