### PR TITLE
Issue #19411: Improve IndentationCheck examples

### DIFF
--- a/src/site/xdoc/checks/misc/indentation.xml
+++ b/src/site/xdoc/checks/misc/indentation.xml
@@ -229,8 +229,8 @@ class Example2 {
 
     void demonstrateSwitch() throws Exception {
         switch (field) {
-        case "EXAMPLE": processValues();                            // caseIndent
-        case "COMPLETED": handleValue("Completed Case", 456);       // caseIndent
+        case "EXAMPLE": processValues();                            // caseIndent=0
+        case "COMPLETED": handleValue("Completed Case", 456);       // caseIndent=0
         }
     }
 }
@@ -265,7 +265,7 @@ class Example3 {
     }
 
     void handleValue(String aFooString,
-                     int aFooInt) {      // violation, "incorrect indentation"
+                     int aFooInt) {      // violation, forceStrictCondition=true
 
         boolean cond1,cond2,cond3,cond4,cond5,cond6;
         cond1=cond2=cond3=cond4=cond5=cond6=false;
@@ -277,11 +277,11 @@ class Example3 {
         }
 
         if ((cond1 &amp;&amp; cond2)
-                || (cond3 &amp;&amp; cond4)        // violation, "incorrect indentation"
-                || !(cond5 &amp;&amp; cond6)) {    // violation, "incorrect indentation"
+                || (cond3 &amp;&amp; cond4)        // violation, forceStrictCondition=true
+                || !(cond5 &amp;&amp; cond6)) {    // violation, forceStrictCondition=true
             field.toUpperCase()
-                 .concat(" TASK")           // violation, "incorrect indentation"
-                 .chars().forEach(c -&gt; {    // violation, "incorrect indentation"
+                 .concat(" TASK")           // violation, forceStrictCondition=true
+                 .chars().forEach(c -&gt; {    // violation, forceStrictCondition=true
                      System.out.println((char) c);
                  });
         }

--- a/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/indentation/indentation/Example2.java
+++ b/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/indentation/indentation/Example2.java
@@ -48,12 +48,9 @@ class Example2 {
 
     void demonstrateSwitch() throws Exception {
         switch (field) {
-        case "EXAMPLE": processValues();                            // caseIndent
-        case "COMPLETED": handleValue("Completed Case", 456);       // caseIndent
+        case "EXAMPLE": processValues();                            // caseIndent=0
+        case "COMPLETED": handleValue("Completed Case", 456);       // caseIndent=0
         }
     }
 }
 // xdoc section -- end
-
-
-

--- a/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/indentation/indentation/Example3.java
+++ b/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/indentation/indentation/Example3.java
@@ -24,7 +24,7 @@ class Example3 {
     }
 
     void handleValue(String aFooString,
-                     int aFooInt) {      // violation, "incorrect indentation"
+                     int aFooInt) {      // violation, forceStrictCondition=true
 
         boolean cond1,cond2,cond3,cond4,cond5,cond6;
         cond1=cond2=cond3=cond4=cond5=cond6=false;
@@ -36,11 +36,11 @@ class Example3 {
         }
 
         if ((cond1 && cond2)
-                || (cond3 && cond4)        // violation, "incorrect indentation"
-                || !(cond5 && cond6)) {    // violation, "incorrect indentation"
+                || (cond3 && cond4)        // violation, forceStrictCondition=true
+                || !(cond5 && cond6)) {    // violation, forceStrictCondition=true
             field.toUpperCase()
-                 .concat(" TASK")           // violation, "incorrect indentation"
-                 .chars().forEach(c -> {    // violation, "incorrect indentation"
+                 .concat(" TASK")           // violation, forceStrictCondition=true
+                 .chars().forEach(c -> {    // violation, forceStrictCondition=true
                      System.out.println((char) c);
                  });
         }
@@ -53,6 +53,4 @@ class Example3 {
         }
     }
 }
-
-
 // xdoc section -- end


### PR DESCRIPTION
Fixes #19411 improved IndentationCheck examples.

Changes:
- refined Example2 for clearer caseIndent behavior
- refined Example3 while preserving AST consistency and expected violations

Validation:
- ./mvnw -Dtest=IndentationCheckExamplesTest -Djacoco.skip=true test
- ./mvnw -Dtest=XdocsExamplesAstConsistencyTest -Djacoco.skip=true test
- ./mvnw clean verify -Djacoco.skip=true