### PR TITLE
Issue #16807: Update default properties in AbbreviationAsWordInNameCheck

### DIFF
--- a/src/test/java/com/puppycrawl/tools/checkstyle/bdd/InlineConfigParser.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/bdd/InlineConfigParser.java
@@ -314,7 +314,6 @@ public final class InlineConfigParser {
             "com.puppycrawl.tools.checkstyle.checks.javadoc.SummaryJavadocCheck",
             "com.puppycrawl.tools.checkstyle.checks.metrics.ClassFanOutComplexityCheck",
             "com.puppycrawl.tools.checkstyle.checks.modifier.RedundantModifierCheck",
-            "com.puppycrawl.tools.checkstyle.checks.naming.AbbreviationAsWordInNameCheck",
             "com.puppycrawl.tools.checkstyle.checks.naming.LocalFinalVariableNameCheck",
 
             "com.puppycrawl.tools.checkstyle.checks.regexp.RegexpSinglelineCheck",

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/naming/AbbreviationAsWordInNameCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/naming/AbbreviationAsWordInNameCheckTest.java
@@ -533,15 +533,15 @@ public class AbbreviationAsWordInNameCheckTest extends AbstractModuleTestSupport
     @Test
     public void testInputAbbreviationAsWordInNameTypeSnakeStyle() throws Exception {
         final String[] expected = {
-            "13:20: " + getWarningMessage("FLAG_IS_FIRST_RUN", 4),
-            "16:17: " + getWarningMessage("HYBRID_LOCK_PATH", 4),
-            "21:17: " + getWarningMessage("__DEMOS__TESTS_VAR", 4),
-            "28:16: " + getWarningMessage("TESTING_FAM_23456", 4),
-            "33:16: " + getWarningMessage("TESTING_23456_FAM", 4),
-            "38:16: " + getWarningMessage("_234VIOLATION", 4),
-            "41:16: " + getWarningMessage("VIOLATION23456", 4),
-            "72:21: " + getWarningMessage("getIsFIRST_Run", 4),
-            "77:21: " + getWarningMessage("getBoolean_VALUES", 4),
+            "21:20: " + getWarningMessage("FLAG_IS_FIRST_RUN", 4),
+            "24:17: " + getWarningMessage("HYBRID_LOCK_PATH", 4),
+            "29:17: " + getWarningMessage("__DEMOS__TESTS_VAR", 4),
+            "36:16: " + getWarningMessage("TESTING_FAM_23456", 4),
+            "41:16: " + getWarningMessage("TESTING_23456_FAM", 4),
+            "46:16: " + getWarningMessage("_234VIOLATION", 4),
+            "49:16: " + getWarningMessage("VIOLATION23456", 4),
+            "80:21: " + getWarningMessage("getIsFIRST_Run", 4),
+            "85:21: " + getWarningMessage("getBoolean_VALUES", 4),
         };
 
         verifyWithInlineConfigParser(
@@ -551,7 +551,7 @@ public class AbbreviationAsWordInNameCheckTest extends AbstractModuleTestSupport
     @Test
     public void testAnnotation() throws Exception {
         final String[] expected = {
-            "16:12: " + getWarningMessage("readMETHOD", 4),
+            "25:12: " + getWarningMessage("readMETHOD", 4),
         };
 
         verifyWithInlineConfigParser(

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/naming/abbreviationaswordinname/InputAbbreviationAsWordInNameAnnotation.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/naming/abbreviationaswordinname/InputAbbreviationAsWordInNameAnnotation.java
@@ -1,5 +1,14 @@
 /*
 AbbreviationAsWordInName
+allowedAbbreviationLength = (default)3
+allowedAbbreviations = (default)
+ignoreFinal = (default)true
+ignoreStatic = (default)true
+ignoreStaticFinal = (default)true
+ignoreOverriddenMethods = (default)true
+tokens = (default)CLASS_DEF, INTERFACE_DEF, ENUM_DEF, ANNOTATION_DEF, ANNOTATION_FIELD_DEF, \
+         PARAMETER_DEF, VARIABLE_DEF, METHOD_DEF, PATTERN_VARIABLE_DEF, RECORD_DEF, \
+         RECORD_COMPONENT_DEF
 
 
 */

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/naming/abbreviationaswordinname/InputAbbreviationAsWordInNameTypeSnakeStyle.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/naming/abbreviationaswordinname/InputAbbreviationAsWordInNameTypeSnakeStyle.java
@@ -1,6 +1,14 @@
 /*
 AbbreviationAsWordInName
+allowedAbbreviationLength = (default)3
 allowedAbbreviations = ORDER, OBSERVATION, UNDERSCORE, TEST
+ignoreFinal = (default)true
+ignoreStatic = (default)true
+ignoreStaticFinal = (default)true
+ignoreOverriddenMethods = (default)true
+tokens = (default)CLASS_DEF, INTERFACE_DEF, ENUM_DEF, ANNOTATION_DEF, ANNOTATION_FIELD_DEF, \
+         PARAMETER_DEF, VARIABLE_DEF, METHOD_DEF, PATTERN_VARIABLE_DEF, RECORD_DEF, \
+         RECORD_COMPONENT_DEF
 
 
 */


### PR DESCRIPTION
Issue #16807: Update default properties in AbbreviationAsWordInNameCheck input files

Added missing default properties to input files for AbbreviationAsWordInNameCheck and removed the module from SUPPRESSED_MODULES in InlineConfigParser.java