### PR TITLE
Issue #16807: Update default properties in JavadocStyleCheck input files

### DIFF
--- a/src/test/java/com/puppycrawl/tools/checkstyle/bdd/InlineConfigParser.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/bdd/InlineConfigParser.java
@@ -306,7 +306,6 @@ public final class InlineConfigParser {
             "com.puppycrawl.tools.checkstyle.checks.imports.ImportOrderCheck",
             "com.puppycrawl.tools.checkstyle.checks.javadoc.JavadocContentLocationCheck",
             "com.puppycrawl.tools.checkstyle.checks.javadoc.JavadocParagraphCheck",
-            "com.puppycrawl.tools.checkstyle.checks.javadoc.JavadocStyleCheck",
             "com.puppycrawl.tools.checkstyle.checks.javadoc.JavadocTypeCheck",
             "com.puppycrawl.tools.checkstyle.checks.javadoc.JavadocVariableCheck",
             "com.puppycrawl.tools.checkstyle.checks.javadoc.MissingJavadocPackageCheck",

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocStyleCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocStyleCheckTest.java
@@ -768,8 +768,8 @@ public class JavadocStyleCheckTest
     @Test
     public void testJavadocTag() throws Exception {
         final String[] expected = {
-            "11: " + getCheckMessage(MSG_NO_PERIOD),
-            "15: " + getCheckMessage(MSG_NO_PERIOD),
+            "19: " + getCheckMessage(MSG_NO_PERIOD),
+            "23: " + getCheckMessage(MSG_NO_PERIOD),
         };
 
         verifyWithInlineConfigParser(
@@ -780,8 +780,8 @@ public class JavadocStyleCheckTest
     @Test
     public void testJavadocTag2() throws Exception {
         final String[] expected = {
-            "16: " + getCheckMessage(MSG_NO_PERIOD),
-            "18:16: " + getCheckMessage(MSG_UNCLOSED_HTML,
+            "24: " + getCheckMessage(MSG_NO_PERIOD),
+            "26:16: " + getCheckMessage(MSG_UNCLOSED_HTML,
                     "<AREA ALT=\"alt\" Coordination=\"100,0,200,50\" HREF=\"/href/\"> <"),
         };
 
@@ -793,7 +793,7 @@ public class JavadocStyleCheckTest
     @Test
     public void testJavadocTag3() throws Exception {
         final String[] expected = {
-            "21:4: " + getCheckMessage(MSG_EXTRA_HTML, "</body>"),
+            "29:4: " + getCheckMessage(MSG_EXTRA_HTML, "</body>"),
         };
 
         verifyWithInlineConfigParser(
@@ -804,7 +804,7 @@ public class JavadocStyleCheckTest
     @Test
     public void testJavadocStyleCheck3() throws Exception {
         final String[] expected = {
-            "11: " + getCheckMessage(MSG_NO_PERIOD),
+            "19: " + getCheckMessage(MSG_NO_PERIOD),
         };
 
         verifyWithInlineConfigParser(
@@ -815,7 +815,7 @@ public class JavadocStyleCheckTest
     @Test
     public void testJavadocStyleCheck4() throws Exception {
         final String[] expected = {
-            "12: " + getCheckMessage(MSG_NO_PERIOD),
+            "19: " + getCheckMessage(MSG_NO_PERIOD),
         };
 
         verifyWithInlineConfigParser(
@@ -826,8 +826,8 @@ public class JavadocStyleCheckTest
     @Test
     public void testJavadocStyleAboveComments() throws Exception {
         final String[] expected = {
-            "13: " + getCheckMessage(MSG_NO_PERIOD),
             "20: " + getCheckMessage(MSG_NO_PERIOD),
+            "27: " + getCheckMessage(MSG_NO_PERIOD),
         };
 
         verifyWithInlineConfigParser(

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadocstyle/InputJavadocStyleAboveComments.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadocstyle/InputJavadocStyleAboveComments.java
@@ -1,6 +1,13 @@
 /*
 JavadocStyle
+scope = (default)private
+checkFirstSentence = (default)true
+checkHtml = (default)true
+checkEmptyJavadoc = (default)false
 endOfSentenceFormat = (default)([.?!][ \t\n\r\f<])|([.?!]$)
+tokens = (default)ANNOTATION_DEF, ANNOTATION_FIELD_DEF, CLASS_DEF, CTOR_DEF, \
+         ENUM_CONSTANT_DEF, ENUM_DEF, INTERFACE_DEF, METHOD_DEF, PACKAGE_DEF, \
+         VARIABLE_DEF, RECORD_DEF, COMPACT_CTOR_DEF
 
 
 */

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadocstyle/InputJavadocStyleCheck1.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadocstyle/InputJavadocStyleCheck1.java
@@ -1,5 +1,13 @@
 /*
 JavadocStyle
+scope = (default)private
+checkFirstSentence = (default)true
+checkHtml = (default)true
+checkEmptyJavadoc = (default)false
+endOfSentenceFormat = (default)([.?!][ \t\n\r\f<])|([.?!]$)
+tokens = (default)ANNOTATION_DEF, ANNOTATION_FIELD_DEF, CLASS_DEF, CTOR_DEF, \
+         ENUM_CONSTANT_DEF, ENUM_DEF, INTERFACE_DEF, METHOD_DEF, PACKAGE_DEF, \
+         VARIABLE_DEF, RECORD_DEF, COMPACT_CTOR_DEF
 
 
 */

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadocstyle/InputJavadocStyleCheck2.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadocstyle/InputJavadocStyleCheck2.java
@@ -1,5 +1,13 @@
 /*
 JavadocStyle
+scope = (default)private
+checkFirstSentence = (default)true
+checkHtml = (default)true
+checkEmptyJavadoc = (default)false
+endOfSentenceFormat = (default)([.?!][ \t\n\r\f<])|([.?!]$)
+tokens = (default)ANNOTATION_DEF, ANNOTATION_FIELD_DEF, CLASS_DEF, CTOR_DEF, \
+         ENUM_CONSTANT_DEF, ENUM_DEF, INTERFACE_DEF, METHOD_DEF, PACKAGE_DEF, \
+         VARIABLE_DEF, RECORD_DEF, COMPACT_CTOR_DEF
 
 
 */

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadocstyle/InputJavadocStyleCheck3.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadocstyle/InputJavadocStyleCheck3.java
@@ -1,5 +1,13 @@
 /*
 JavadocStyle
+scope = (default)private
+checkFirstSentence = (default)true
+checkHtml = (default)true
+checkEmptyJavadoc = (default)false
+endOfSentenceFormat = (default)([.?!][ \t\n\r\f<])|([.?!]$)
+tokens = (default)ANNOTATION_DEF, ANNOTATION_FIELD_DEF, CLASS_DEF, CTOR_DEF, \
+         ENUM_CONSTANT_DEF, ENUM_DEF, INTERFACE_DEF, METHOD_DEF, PACKAGE_DEF, \
+         VARIABLE_DEF, RECORD_DEF, COMPACT_CTOR_DEF
 
 
 */

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadocstyle/InputJavadocStyleCheck5.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadocstyle/InputJavadocStyleCheck5.java
@@ -1,6 +1,13 @@
 /*
 JavadocStyle
+scope = (default)private
+checkFirstSentence = (default)true
+checkHtml = (default)true
+checkEmptyJavadoc = (default)false
 endOfSentenceFormat = \n
+tokens = (default)ANNOTATION_DEF, ANNOTATION_FIELD_DEF, CLASS_DEF, CTOR_DEF, \
+         ENUM_CONSTANT_DEF, ENUM_DEF, INTERFACE_DEF, METHOD_DEF, PACKAGE_DEF, \
+         VARIABLE_DEF, RECORD_DEF, COMPACT_CTOR_DEF
 
 
 */

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadocstyle/InputJavadocStyleCheckOptionLowercaseProperty.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadocstyle/InputJavadocStyleCheckOptionLowercaseProperty.java
@@ -3,6 +3,7 @@ JavadocStyle
 scope = (default)private
 excludeScope = (default)null
 checkFirstSentence = false
+endOfSentenceFormat = (default)([.?!][ \t\n\r\f<])|([.?!]$)
 checkEmptyJavadoc = (default)false
 checkHtml = (default)true
 tokens = (default)ANNOTATION_DEF, ANNOTATION_FIELD_DEF, CLASS_DEF, CTOR_DEF, \

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadocstyle/InputJavadocStyleDefault4.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadocstyle/InputJavadocStyleDefault4.java
@@ -1,5 +1,13 @@
 /*
 JavadocStyle
+scope = (default)private
+checkFirstSentence = (default)true
+checkHtml = (default)true
+checkEmptyJavadoc = (default)false
+endOfSentenceFormat = (default)([.?!][ \t\n\r\f<])|([.?!]$)
+tokens = (default)ANNOTATION_DEF, ANNOTATION_FIELD_DEF, CLASS_DEF, CTOR_DEF, \
+         ENUM_CONSTANT_DEF, ENUM_DEF, INTERFACE_DEF, METHOD_DEF, PACKAGE_DEF, \
+         VARIABLE_DEF, RECORD_DEF, COMPACT_CTOR_DEF
 
 
 */


### PR DESCRIPTION
Issue #16807: Update default properties in JavadocStyleCheck input files

Added missing default properties to input files for JavadocStyleCheck and removed the module from SUPPRESSED_MODULES in InlineConfigParser.java.

Changes:
- InputJavadocStyleDefault4.java: Added all 6 missing default properties (scope, checkFirstSentence, checkHtml, checkEmptyJavadoc, endOfSentenceFormat, tokens)
- InputJavadocStyleCheck1.java: Added all 6 missing default properties
- InputJavadocStyleCheck2.java: Added all 6 missing default properties
- InputJavadocStyleCheck3.java: Added all 6 missing default properties
- InputJavadocStyleCheck5.java: Added 5 missing default properties (scope, checkFirstSentence, checkHtml, checkEmptyJavadoc, tokens)
- InputJavadocStyleAboveComments.java: Added 5 missing default properties (scope, checkFirstSentence, checkHtml, checkEmptyJavadoc, tokens)
- InputJavadocStyleCheckOptionLowercaseProperty.java: Added 1 missing default property (endOfSentenceFormat)
- JavadocStyleCheckTest.java: Updated violation line numbers for 6 test methods
- InlineConfigParser.java: Removed JavadocStyleCheck from SUPPRESSED_MODULES

