### PR TITLE
Issue #16807: Update default properties in WhitespaceAroundCheck inpu…

### DIFF
--- a/src/test/java/com/puppycrawl/tools/checkstyle/TreeWalkerTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/TreeWalkerTest.java
@@ -503,8 +503,8 @@ public class TreeWalkerTest extends AbstractModuleTestSupport {
     public void testMultiCheckOrder() throws Exception {
 
         final String[] expected = {
-            "13:9: " + getCheckMessage(WhitespaceAfterCheck.class, "ws.notFollowed", "if"),
-            "13:9: " + getCheckMessage(WhitespaceAroundCheck.class, "ws.notFollowed", "if"),
+            "28:9: " + getCheckMessage(WhitespaceAfterCheck.class, "ws.notFollowed", "if"),
+            "28:9: " + getCheckMessage(WhitespaceAroundCheck.class, "ws.notFollowed", "if"),
         };
 
         verifyWithInlineConfigParserTwice(

--- a/src/test/java/com/puppycrawl/tools/checkstyle/bdd/InlineConfigParser.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/bdd/InlineConfigParser.java
@@ -313,7 +313,6 @@ public final class InlineConfigParser {
             "com.puppycrawl.tools.checkstyle.checks.regexp.RegexpSinglelineJavaCheck",
             "com.puppycrawl.tools.checkstyle.checks.whitespace.NoWhitespaceAfterCheck",
             "com.puppycrawl.tools.checkstyle.checks.whitespace.WhitespaceAfterCheck",
-            "com.puppycrawl.tools.checkstyle.checks.whitespace.WhitespaceAroundCheck",
             "com.puppycrawl.tools.checkstyle.checks.SuppressWarningsHolder",
             "com.puppycrawl.tools.checkstyle.filters.SuppressWithPlainTextCommentFilter",
             "com.puppycrawl.tools.checkstyle.filters.SuppressionCommentFilter",

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/whitespace/WhitespaceAroundCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/whitespace/WhitespaceAroundCheckTest.java
@@ -50,46 +50,46 @@ public class WhitespaceAroundCheckTest
     public void testKeywordsAndOperators()
             throws Exception {
         final String[] expected = {
-            "32:22: " + getCheckMessage(MSG_WS_NOT_PRECEDED, "="),
-            "32:22: " + getCheckMessage(MSG_WS_NOT_FOLLOWED, "="),
-            "34:23: " + getCheckMessage(MSG_WS_NOT_FOLLOWED, "="),
-            "42:14: " + getCheckMessage(MSG_WS_NOT_PRECEDED, "="),
-            "43:10: " + getCheckMessage(MSG_WS_NOT_PRECEDED, "="),
-            "43:10: " + getCheckMessage(MSG_WS_NOT_FOLLOWED, "="),
-            "44:10: " + getCheckMessage(MSG_WS_NOT_PRECEDED, "+="),
-            "44:10: " + getCheckMessage(MSG_WS_NOT_FOLLOWED, "+="),
-            "45:11: " + getCheckMessage(MSG_WS_NOT_FOLLOWED, "-="),
-            "53:9: " + getCheckMessage(MSG_WS_NOT_FOLLOWED, "synchronized"),
-            "55:9: " + getCheckMessage(MSG_WS_NOT_FOLLOWED, "try"),
-            "55:12: " + getCheckMessage(MSG_WS_NOT_PRECEDED, "{"),
-            "57:9: " + getCheckMessage(MSG_WS_NOT_FOLLOWED, "catch"),
-            "57:34: " + getCheckMessage(MSG_WS_NOT_PRECEDED, "{"),
-            "74:9: " + getCheckMessage(MSG_WS_NOT_FOLLOWED, "if"),
-            "92:13: " + getCheckMessage(MSG_WS_NOT_FOLLOWED, "return"),
-            "113:29: " + getCheckMessage(MSG_WS_NOT_PRECEDED, "?"),
-            "113:29: " + getCheckMessage(MSG_WS_NOT_FOLLOWED, "?"),
-            "113:34: " + getCheckMessage(MSG_WS_NOT_PRECEDED, ":"),
-            "113:34: " + getCheckMessage(MSG_WS_NOT_FOLLOWED, ":"),
-            "114:15: " + getCheckMessage(MSG_WS_NOT_PRECEDED, "=="),
-            "114:15: " + getCheckMessage(MSG_WS_NOT_FOLLOWED, "=="),
-            "120:19: " + getCheckMessage(MSG_WS_NOT_FOLLOWED, "*"),
-            "120:21: " + getCheckMessage(MSG_WS_NOT_PRECEDED, "*"),
-            "135:18: " + getCheckMessage(MSG_WS_NOT_PRECEDED, "%"),
-            "136:19: " + getCheckMessage(MSG_WS_NOT_FOLLOWED, "%"),
-            "137:18: " + getCheckMessage(MSG_WS_NOT_PRECEDED, "%"),
-            "137:18: " + getCheckMessage(MSG_WS_NOT_FOLLOWED, "%"),
-            "139:18: " + getCheckMessage(MSG_WS_NOT_PRECEDED, "/"),
-            "140:19: " + getCheckMessage(MSG_WS_NOT_FOLLOWED, "/"),
-            "141:18: " + getCheckMessage(MSG_WS_NOT_PRECEDED, "/"),
-            "141:18: " + getCheckMessage(MSG_WS_NOT_FOLLOWED, "/"),
-            "167:9: " + getCheckMessage(MSG_WS_NOT_FOLLOWED, "assert"),
-            "170:20: " + getCheckMessage(MSG_WS_NOT_PRECEDED, ":"),
-            "170:20: " + getCheckMessage(MSG_WS_NOT_FOLLOWED, ":"),
-            "276:13: " + getCheckMessage(MSG_WS_NOT_FOLLOWED, "}"),
-            "305:24: " + getCheckMessage(MSG_WS_NOT_FOLLOWED, "+"),
-            "305:24: " + getCheckMessage(MSG_WS_NOT_PRECEDED, "+"),
-            "305:28: " + getCheckMessage(MSG_WS_NOT_FOLLOWED, "+"),
-            "305:28: " + getCheckMessage(MSG_WS_NOT_PRECEDED, "+"),
+            "33:22: " + getCheckMessage(MSG_WS_NOT_PRECEDED, "="),
+            "33:22: " + getCheckMessage(MSG_WS_NOT_FOLLOWED, "="),
+            "35:23: " + getCheckMessage(MSG_WS_NOT_FOLLOWED, "="),
+            "43:14: " + getCheckMessage(MSG_WS_NOT_PRECEDED, "="),
+            "44:10: " + getCheckMessage(MSG_WS_NOT_PRECEDED, "="),
+            "44:10: " + getCheckMessage(MSG_WS_NOT_FOLLOWED, "="),
+            "45:10: " + getCheckMessage(MSG_WS_NOT_PRECEDED, "+="),
+            "45:10: " + getCheckMessage(MSG_WS_NOT_FOLLOWED, "+="),
+            "46:11: " + getCheckMessage(MSG_WS_NOT_FOLLOWED, "-="),
+            "54:9: " + getCheckMessage(MSG_WS_NOT_FOLLOWED, "synchronized"),
+            "56:9: " + getCheckMessage(MSG_WS_NOT_FOLLOWED, "try"),
+            "56:12: " + getCheckMessage(MSG_WS_NOT_PRECEDED, "{"),
+            "58:9: " + getCheckMessage(MSG_WS_NOT_FOLLOWED, "catch"),
+            "58:34: " + getCheckMessage(MSG_WS_NOT_PRECEDED, "{"),
+            "75:9: " + getCheckMessage(MSG_WS_NOT_FOLLOWED, "if"),
+            "93:13: " + getCheckMessage(MSG_WS_NOT_FOLLOWED, "return"),
+            "114:29: " + getCheckMessage(MSG_WS_NOT_PRECEDED, "?"),
+            "114:29: " + getCheckMessage(MSG_WS_NOT_FOLLOWED, "?"),
+            "114:34: " + getCheckMessage(MSG_WS_NOT_PRECEDED, ":"),
+            "114:34: " + getCheckMessage(MSG_WS_NOT_FOLLOWED, ":"),
+            "115:15: " + getCheckMessage(MSG_WS_NOT_PRECEDED, "=="),
+            "115:15: " + getCheckMessage(MSG_WS_NOT_FOLLOWED, "=="),
+            "121:19: " + getCheckMessage(MSG_WS_NOT_FOLLOWED, "*"),
+            "121:21: " + getCheckMessage(MSG_WS_NOT_PRECEDED, "*"),
+            "136:18: " + getCheckMessage(MSG_WS_NOT_PRECEDED, "%"),
+            "137:19: " + getCheckMessage(MSG_WS_NOT_FOLLOWED, "%"),
+            "138:18: " + getCheckMessage(MSG_WS_NOT_PRECEDED, "%"),
+            "138:18: " + getCheckMessage(MSG_WS_NOT_FOLLOWED, "%"),
+            "140:18: " + getCheckMessage(MSG_WS_NOT_PRECEDED, "/"),
+            "141:19: " + getCheckMessage(MSG_WS_NOT_FOLLOWED, "/"),
+            "142:18: " + getCheckMessage(MSG_WS_NOT_PRECEDED, "/"),
+            "142:18: " + getCheckMessage(MSG_WS_NOT_FOLLOWED, "/"),
+            "168:9: " + getCheckMessage(MSG_WS_NOT_FOLLOWED, "assert"),
+            "171:20: " + getCheckMessage(MSG_WS_NOT_PRECEDED, ":"),
+            "171:20: " + getCheckMessage(MSG_WS_NOT_FOLLOWED, ":"),
+            "277:13: " + getCheckMessage(MSG_WS_NOT_FOLLOWED, "}"),
+            "306:24: " + getCheckMessage(MSG_WS_NOT_FOLLOWED, "+"),
+            "306:24: " + getCheckMessage(MSG_WS_NOT_PRECEDED, "+"),
+            "306:28: " + getCheckMessage(MSG_WS_NOT_FOLLOWED, "+"),
+            "306:28: " + getCheckMessage(MSG_WS_NOT_PRECEDED, "+"),
         };
         verifyWithInlineConfigParser(
                 getPath("InputWhitespaceAroundKeywordsAndOperators.java"), expected);
@@ -107,12 +107,12 @@ public class WhitespaceAroundCheckTest
     public void testSimpleInputPart2()
             throws Exception {
         final String[] expected = {
-            "105:26: " + getCheckMessage(MSG_WS_NOT_FOLLOWED, "="),
-            "106:22: " + getCheckMessage(MSG_WS_NOT_FOLLOWED, "="),
+            "106:26: " + getCheckMessage(MSG_WS_NOT_FOLLOWED, "="),
             "107:22: " + getCheckMessage(MSG_WS_NOT_FOLLOWED, "="),
-            "108:18: " + getCheckMessage(MSG_WS_NOT_FOLLOWED, "="),
+            "108:22: " + getCheckMessage(MSG_WS_NOT_FOLLOWED, "="),
             "109:18: " + getCheckMessage(MSG_WS_NOT_FOLLOWED, "="),
-            "110:22: " + getCheckMessage(MSG_WS_NOT_FOLLOWED, "="),
+            "110:18: " + getCheckMessage(MSG_WS_NOT_FOLLOWED, "="),
+            "111:22: " + getCheckMessage(MSG_WS_NOT_FOLLOWED, "="),
         };
         verifyWithInlineConfigParser(
                 getPath("InputWhitespaceAroundSimplePart2.java"), expected);
@@ -130,7 +130,7 @@ public class WhitespaceAroundCheckTest
     public void testStartOfTheLine()
             throws Exception {
         final String[] expected = {
-            "25:2: " + getCheckMessage(MSG_WS_NOT_PRECEDED, "{"),
+            "26:2: " + getCheckMessage(MSG_WS_NOT_PRECEDED, "{"),
         };
         verifyWithInlineConfigParser(
                 getPath("InputWhitespaceAroundStartOfTheLine.java"), expected);
@@ -140,8 +140,8 @@ public class WhitespaceAroundCheckTest
     public void testBracesPart1()
             throws Exception {
         final String[] expected = {
-            "53:9: " + getCheckMessage(MSG_WS_NOT_FOLLOWED, "while"),
-            "70:9: " + getCheckMessage(MSG_WS_NOT_FOLLOWED, "for"),
+            "54:9: " + getCheckMessage(MSG_WS_NOT_FOLLOWED, "while"),
+            "71:9: " + getCheckMessage(MSG_WS_NOT_FOLLOWED, "for"),
         };
         verifyWithInlineConfigParser(
                 getPath("InputWhitespaceAroundBracesPart1.java"), expected);
@@ -151,14 +151,14 @@ public class WhitespaceAroundCheckTest
     public void testBracesPart2()
             throws Exception {
         final String[] expected = {
-            "36:47: " + getCheckMessage(MSG_WS_NOT_FOLLOWED, "{"),
-            "36:48: " + getCheckMessage(MSG_WS_NOT_PRECEDED, "}"),
-            "39:39: " + getCheckMessage(MSG_WS_NOT_FOLLOWED, "{"),
-            "39:40: " + getCheckMessage(MSG_WS_NOT_PRECEDED, "}"),
-            "43:9: " + getCheckMessage(MSG_WS_NOT_FOLLOWED, "if"),
-            "43:17: " + getCheckMessage(MSG_WS_NOT_FOLLOWED, "{"),
-            "43:17: " + getCheckMessage(MSG_WS_NOT_PRECEDED, "{"),
-            "43:18: " + getCheckMessage(MSG_WS_NOT_PRECEDED, "}"),
+            "37:47: " + getCheckMessage(MSG_WS_NOT_FOLLOWED, "{"),
+            "37:48: " + getCheckMessage(MSG_WS_NOT_PRECEDED, "}"),
+            "40:39: " + getCheckMessage(MSG_WS_NOT_FOLLOWED, "{"),
+            "40:40: " + getCheckMessage(MSG_WS_NOT_PRECEDED, "}"),
+            "44:9: " + getCheckMessage(MSG_WS_NOT_FOLLOWED, "if"),
+            "44:17: " + getCheckMessage(MSG_WS_NOT_FOLLOWED, "{"),
+            "44:17: " + getCheckMessage(MSG_WS_NOT_PRECEDED, "{"),
+            "44:18: " + getCheckMessage(MSG_WS_NOT_PRECEDED, "}"),
         };
         verifyWithInlineConfigParser(
                 getPath("InputWhitespaceAroundBracesPart2.java"), expected);
@@ -168,8 +168,8 @@ public class WhitespaceAroundCheckTest
     public void testBracesInMethodsAndConstructorsPart1()
             throws Exception {
         final String[] expected = {
-            "53:9: " + getCheckMessage(MSG_WS_NOT_FOLLOWED, "while"),
-            "70:9: " + getCheckMessage(MSG_WS_NOT_FOLLOWED, "for"),
+            "54:9: " + getCheckMessage(MSG_WS_NOT_FOLLOWED, "while"),
+            "71:9: " + getCheckMessage(MSG_WS_NOT_FOLLOWED, "for"),
         };
         verifyWithInlineConfigParser(
                 getPath("InputWhitespaceAroundBraces2Part1.java"), expected);
@@ -179,10 +179,10 @@ public class WhitespaceAroundCheckTest
     public void testBracesInMethodsAndConstructorsPart2()
             throws Exception {
         final String[] expected = {
-            "86:9: " + getCheckMessage(MSG_WS_NOT_FOLLOWED, "if"),
-            "86:17: " + getCheckMessage(MSG_WS_NOT_FOLLOWED, "{"),
-            "86:17: " + getCheckMessage(MSG_WS_NOT_PRECEDED, "{"),
-            "86:18: " + getCheckMessage(MSG_WS_NOT_PRECEDED, "}"),
+            "87:9: " + getCheckMessage(MSG_WS_NOT_FOLLOWED, "if"),
+            "87:17: " + getCheckMessage(MSG_WS_NOT_FOLLOWED, "{"),
+            "87:17: " + getCheckMessage(MSG_WS_NOT_PRECEDED, "{"),
+            "87:18: " + getCheckMessage(MSG_WS_NOT_PRECEDED, "}"),
         };
         verifyWithInlineConfigParser(
                 getPath("InputWhitespaceAroundBraces2Part2.java"), expected);
@@ -192,14 +192,14 @@ public class WhitespaceAroundCheckTest
     public void testArrayInitialization()
             throws Exception {
         final String[] expected = {
-            "21:39: " + getCheckMessage(MSG_WS_NOT_PRECEDED, "{"),
-            "25:37: " + getCheckMessage(MSG_WS_NOT_PRECEDED, "{"),
-            "28:30: " + getCheckMessage(MSG_WS_NOT_PRECEDED, "{"),
-            "36:42: " + getCheckMessage(MSG_WS_NOT_PRECEDED, "{"),
-            "36:59: " + getCheckMessage(MSG_WS_NOT_PRECEDED, "{"),
-            "38:40: " + getCheckMessage(MSG_WS_NOT_PRECEDED, "{"),
-            "38:41: " + getCheckMessage(MSG_WS_NOT_PRECEDED, "{"),
-            "43:20: " + getCheckMessage(MSG_WS_NOT_PRECEDED, "{"),
+            "22:39: " + getCheckMessage(MSG_WS_NOT_PRECEDED, "{"),
+            "26:37: " + getCheckMessage(MSG_WS_NOT_PRECEDED, "{"),
+            "29:30: " + getCheckMessage(MSG_WS_NOT_PRECEDED, "{"),
+            "37:42: " + getCheckMessage(MSG_WS_NOT_PRECEDED, "{"),
+            "37:59: " + getCheckMessage(MSG_WS_NOT_PRECEDED, "{"),
+            "39:40: " + getCheckMessage(MSG_WS_NOT_PRECEDED, "{"),
+            "39:41: " + getCheckMessage(MSG_WS_NOT_PRECEDED, "{"),
+            "44:20: " + getCheckMessage(MSG_WS_NOT_PRECEDED, "{"),
         };
         verifyWithInlineConfigParser(
                 getPath("InputWhitespaceAroundArrayInitialization.java"), expected);
@@ -209,8 +209,8 @@ public class WhitespaceAroundCheckTest
     public void testGenericsTokensAreFlagged()
             throws Exception {
         final String[] expected = {
-            "27:16: " + getCheckMessage(MSG_WS_NOT_PRECEDED, "&"),
-            "27:16: " + getCheckMessage(MSG_WS_NOT_FOLLOWED, "&"),
+            "28:16: " + getCheckMessage(MSG_WS_NOT_PRECEDED, "&"),
+            "28:16: " + getCheckMessage(MSG_WS_NOT_FOLLOWED, "&"),
         };
         verifyWithInlineConfigParser(
                 getPath("InputWhitespaceAroundGenerics.java"), expected);
@@ -227,12 +227,12 @@ public class WhitespaceAroundCheckTest
     @Test
     public void testAllowDoubleBraceInitialization() throws Exception {
         final String[] expected = {
-            "31:33: " + getCheckMessage(MSG_WS_NOT_PRECEDED, "}"),
-            "32:27: " + getCheckMessage(MSG_WS_NOT_FOLLOWED, "{"),
-            "34:27: " + getCheckMessage(MSG_WS_NOT_FOLLOWED, "{"),
-            "34:88: " + getCheckMessage(MSG_WS_NOT_PRECEDED, "}"),
-            "37:9: " + getCheckMessage(MSG_WS_NOT_FOLLOWED, "}"),
-            "37:24: " + getCheckMessage(MSG_WS_NOT_PRECEDED, "}"),
+            "32:33: " + getCheckMessage(MSG_WS_NOT_PRECEDED, "}"),
+            "33:27: " + getCheckMessage(MSG_WS_NOT_FOLLOWED, "{"),
+            "35:27: " + getCheckMessage(MSG_WS_NOT_FOLLOWED, "{"),
+            "35:88: " + getCheckMessage(MSG_WS_NOT_PRECEDED, "}"),
+            "38:9: " + getCheckMessage(MSG_WS_NOT_FOLLOWED, "}"),
+            "38:24: " + getCheckMessage(MSG_WS_NOT_PRECEDED, "}"),
         };
         verifyWithInlineConfigParser(
                 getPath("InputWhitespaceAroundDoubleBraceInitialization.java"),
@@ -242,7 +242,7 @@ public class WhitespaceAroundCheckTest
     @Test
     public void testIgnoreEnhancedForColon() throws Exception {
         final String[] expected = {
-            "39:20: " + getCheckMessage(MSG_WS_NOT_PRECEDED, ":"),
+            "40:20: " + getCheckMessage(MSG_WS_NOT_PRECEDED, ":"),
         };
         verifyWithInlineConfigParser(
                 getPath("InputWhitespaceAround2.java"),
@@ -252,12 +252,12 @@ public class WhitespaceAroundCheckTest
     @Test
     public void testEmptyTypes() throws Exception {
         final String[] expected = {
-            "45:94: " + getCheckMessage(MSG_WS_NOT_FOLLOWED, "{"),
-            "45:95: " + getCheckMessage(MSG_WS_NOT_PRECEDED, "}"),
-            "46:32: " + getCheckMessage(MSG_WS_NOT_FOLLOWED, "{"),
-            "46:33: " + getCheckMessage(MSG_WS_NOT_PRECEDED, "}"),
-            "47:20: " + getCheckMessage(MSG_WS_NOT_FOLLOWED, "{"),
-            "47:21: " + getCheckMessage(MSG_WS_NOT_PRECEDED, "}"),
+            "46:94: " + getCheckMessage(MSG_WS_NOT_FOLLOWED, "{"),
+            "46:95: " + getCheckMessage(MSG_WS_NOT_PRECEDED, "}"),
+            "47:32: " + getCheckMessage(MSG_WS_NOT_FOLLOWED, "{"),
+            "47:33: " + getCheckMessage(MSG_WS_NOT_PRECEDED, "}"),
+            "48:20: " + getCheckMessage(MSG_WS_NOT_FOLLOWED, "{"),
+            "48:21: " + getCheckMessage(MSG_WS_NOT_PRECEDED, "}"),
         };
         verifyWithInlineConfigParser(
                 getPath("InputWhitespaceAroundEmptyTypesAndCycles.java"),
@@ -267,16 +267,16 @@ public class WhitespaceAroundCheckTest
     @Test
     public void testEmptyLoops() throws Exception {
         final String[] expected = {
-            "56:65: " + getCheckMessage(MSG_WS_NOT_FOLLOWED, "{"),
-            "56:66: " + getCheckMessage(MSG_WS_NOT_PRECEDED, "}"),
-            "58:17: " + getCheckMessage(MSG_WS_NOT_FOLLOWED, "{"),
-            "58:18: " + getCheckMessage(MSG_WS_NOT_PRECEDED, "}"),
-            "60:20: " + getCheckMessage(MSG_WS_NOT_FOLLOWED, "{"),
-            "60:21: " + getCheckMessage(MSG_WS_NOT_PRECEDED, "}"),
-            "66:35: " + getCheckMessage(MSG_WS_NOT_FOLLOWED, "{"),
-            "66:36: " + getCheckMessage(MSG_WS_NOT_PRECEDED, "}"),
-            "76:18: " + getCheckMessage(MSG_WS_NOT_FOLLOWED, "{"),
-            "76:19: " + getCheckMessage(MSG_WS_NOT_PRECEDED, "}"),
+            "57:65: " + getCheckMessage(MSG_WS_NOT_FOLLOWED, "{"),
+            "57:66: " + getCheckMessage(MSG_WS_NOT_PRECEDED, "}"),
+            "59:17: " + getCheckMessage(MSG_WS_NOT_FOLLOWED, "{"),
+            "59:18: " + getCheckMessage(MSG_WS_NOT_PRECEDED, "}"),
+            "61:20: " + getCheckMessage(MSG_WS_NOT_FOLLOWED, "{"),
+            "61:21: " + getCheckMessage(MSG_WS_NOT_PRECEDED, "}"),
+            "67:35: " + getCheckMessage(MSG_WS_NOT_FOLLOWED, "{"),
+            "67:36: " + getCheckMessage(MSG_WS_NOT_PRECEDED, "}"),
+            "77:18: " + getCheckMessage(MSG_WS_NOT_FOLLOWED, "{"),
+            "77:19: " + getCheckMessage(MSG_WS_NOT_PRECEDED, "}"),
         };
         verifyWithInlineConfigParser(
                 getPath("InputWhitespaceAroundEmptyTypesAndCycles2.java"),
@@ -286,7 +286,7 @@ public class WhitespaceAroundCheckTest
     @Test
     public void testSwitchWhitespaceAround() throws Exception {
         final String[] expected = {
-            "26:9: " + getCheckMessage(MSG_WS_NOT_FOLLOWED, "switch"),
+            "27:9: " + getCheckMessage(MSG_WS_NOT_FOLLOWED, "switch"),
         };
         verifyWithInlineConfigParser(
                 getPath("InputWhitespaceAroundSwitch.java"), expected);
@@ -302,7 +302,7 @@ public class WhitespaceAroundCheckTest
     @Test
     public void testDoWhileWhitespaceAround() throws Exception {
         final String[] expected = {
-            "29:11: " + getCheckMessage(MSG_WS_NOT_FOLLOWED, "while"),
+            "30:11: " + getCheckMessage(MSG_WS_NOT_FOLLOWED, "while"),
         };
         verifyWithInlineConfigParser(
                 getPath("InputWhitespaceAroundDoWhile.java"), expected);
@@ -386,21 +386,21 @@ public class WhitespaceAroundCheckTest
     @Test
     public void testAllowEmptyTypesIsSetToFalseAndNonEmptyClasses() throws Exception {
         final String[] expected = {
-            "31:20: " + getCheckMessage(MSG_WS_NOT_PRECEDED, "{"),
-            "35:32: " + getCheckMessage(MSG_WS_NOT_PRECEDED, "{"),
-            "39:18: " + getCheckMessage(MSG_WS_NOT_PRECEDED, "{"),
-            "41:24: " + getCheckMessage(MSG_WS_NOT_PRECEDED, "{"),
-            "41:24: " + getCheckMessage(MSG_WS_NOT_FOLLOWED, "{"),
-            "41:31: " + getCheckMessage(MSG_WS_NOT_PRECEDED, "}"),
-            "43:30: " + getCheckMessage(MSG_WS_NOT_FOLLOWED, "}"),
-            "45:17: " + getCheckMessage(MSG_WS_NOT_FOLLOWED, "{"),
-            "45:18: " + getCheckMessage(MSG_WS_NOT_PRECEDED, "}"),
-            "47:68: " + getCheckMessage(MSG_WS_NOT_FOLLOWED, "{"),
-            "47:69: " + getCheckMessage(MSG_WS_NOT_PRECEDED, "}"),
-            "49:19: " + getCheckMessage(MSG_WS_NOT_PRECEDED, "{"),
-            "52:12: " + getCheckMessage(MSG_WS_NOT_FOLLOWED, "{"),
-            "52:13: " + getCheckMessage(MSG_WS_NOT_PRECEDED, "}"),
-            "56:34: " + getCheckMessage(MSG_WS_NOT_PRECEDED, "{"),
+            "32:20: " + getCheckMessage(MSG_WS_NOT_PRECEDED, "{"),
+            "36:32: " + getCheckMessage(MSG_WS_NOT_PRECEDED, "{"),
+            "40:18: " + getCheckMessage(MSG_WS_NOT_PRECEDED, "{"),
+            "42:24: " + getCheckMessage(MSG_WS_NOT_PRECEDED, "{"),
+            "42:24: " + getCheckMessage(MSG_WS_NOT_FOLLOWED, "{"),
+            "42:31: " + getCheckMessage(MSG_WS_NOT_PRECEDED, "}"),
+            "44:30: " + getCheckMessage(MSG_WS_NOT_FOLLOWED, "}"),
+            "46:17: " + getCheckMessage(MSG_WS_NOT_FOLLOWED, "{"),
+            "46:18: " + getCheckMessage(MSG_WS_NOT_PRECEDED, "}"),
+            "48:68: " + getCheckMessage(MSG_WS_NOT_FOLLOWED, "{"),
+            "48:69: " + getCheckMessage(MSG_WS_NOT_PRECEDED, "}"),
+            "50:19: " + getCheckMessage(MSG_WS_NOT_PRECEDED, "{"),
+            "53:12: " + getCheckMessage(MSG_WS_NOT_FOLLOWED, "{"),
+            "53:13: " + getCheckMessage(MSG_WS_NOT_PRECEDED, "}"),
+            "57:34: " + getCheckMessage(MSG_WS_NOT_PRECEDED, "{"),
         };
         verifyWithInlineConfigParser(
                 getPath("InputWhitespaceAroundAllowEmptyTypesAndNonEmptyClasses.java"),
@@ -410,17 +410,17 @@ public class WhitespaceAroundCheckTest
     @Test
     public void testAllowEmptyTypesIsSetToTrueAndNonEmptyClasses() throws Exception {
         final String[] expected = {
-            "30:20: " + getCheckMessage(MSG_WS_NOT_PRECEDED, "{"),
-            "34:32: " + getCheckMessage(MSG_WS_NOT_PRECEDED, "{"),
-            "38:18: " + getCheckMessage(MSG_WS_NOT_PRECEDED, "{"),
-            "40:24: " + getCheckMessage(MSG_WS_NOT_PRECEDED, "{"),
-            "40:24: " + getCheckMessage(MSG_WS_NOT_FOLLOWED, "{"),
-            "40:31: " + getCheckMessage(MSG_WS_NOT_PRECEDED, "}"),
-            "42:30: " + getCheckMessage(MSG_WS_NOT_FOLLOWED, "}"),
-            "48:23: " + getCheckMessage(MSG_WS_NOT_PRECEDED, "{"),
-            "51:12: " + getCheckMessage(MSG_WS_NOT_FOLLOWED, "{"),
-            "51:13: " + getCheckMessage(MSG_WS_NOT_PRECEDED, "}"),
-            "55:35: " + getCheckMessage(MSG_WS_NOT_PRECEDED, "{"),
+            "31:20: " + getCheckMessage(MSG_WS_NOT_PRECEDED, "{"),
+            "35:32: " + getCheckMessage(MSG_WS_NOT_PRECEDED, "{"),
+            "39:18: " + getCheckMessage(MSG_WS_NOT_PRECEDED, "{"),
+            "41:24: " + getCheckMessage(MSG_WS_NOT_PRECEDED, "{"),
+            "41:24: " + getCheckMessage(MSG_WS_NOT_FOLLOWED, "{"),
+            "41:31: " + getCheckMessage(MSG_WS_NOT_PRECEDED, "}"),
+            "43:30: " + getCheckMessage(MSG_WS_NOT_FOLLOWED, "}"),
+            "49:23: " + getCheckMessage(MSG_WS_NOT_PRECEDED, "{"),
+            "52:12: " + getCheckMessage(MSG_WS_NOT_FOLLOWED, "{"),
+            "52:13: " + getCheckMessage(MSG_WS_NOT_PRECEDED, "}"),
+            "56:35: " + getCheckMessage(MSG_WS_NOT_PRECEDED, "{"),
         };
         verifyWithInlineConfigParser(
                 getPath("InputWhitespaceAroundAllowEmptyTypesAndNonEmptyClasses2.java"),
@@ -430,12 +430,12 @@ public class WhitespaceAroundCheckTest
     @Test
     public void testNotAllowEmptyLambdaExpressionsByDefault() throws Exception {
         final String[] expected = {
-            "27:27: " + getCheckMessage(MSG_WS_NOT_FOLLOWED, "{"),
-            "27:28: " + getCheckMessage(MSG_WS_NOT_PRECEDED, "}"),
-            "32:28: " + getCheckMessage(MSG_WS_NOT_FOLLOWED, "{"),
-            "32:30: " + getCheckMessage(MSG_WS_NOT_PRECEDED, "}"),
+            "28:27: " + getCheckMessage(MSG_WS_NOT_FOLLOWED, "{"),
+            "28:28: " + getCheckMessage(MSG_WS_NOT_PRECEDED, "}"),
             "33:28: " + getCheckMessage(MSG_WS_NOT_FOLLOWED, "{"),
-            "33:42: " + getCheckMessage(MSG_WS_NOT_PRECEDED, "}"),
+            "33:30: " + getCheckMessage(MSG_WS_NOT_PRECEDED, "}"),
+            "34:28: " + getCheckMessage(MSG_WS_NOT_FOLLOWED, "{"),
+            "34:42: " + getCheckMessage(MSG_WS_NOT_PRECEDED, "}"),
         };
         verifyWithInlineConfigParser(
                 getPath("InputWhitespaceAroundAllowEmptyLambdaExpressions.java"),
@@ -445,10 +445,10 @@ public class WhitespaceAroundCheckTest
     @Test
     public void testAllowEmptyLambdaExpressionsWithAllowEmptyLambdaParameter() throws Exception {
         final String[] expected = {
-            "32:28: " + getCheckMessage(MSG_WS_NOT_FOLLOWED, "{"),
-            "32:30: " + getCheckMessage(MSG_WS_NOT_PRECEDED, "}"),
             "33:28: " + getCheckMessage(MSG_WS_NOT_FOLLOWED, "{"),
-            "33:42: " + getCheckMessage(MSG_WS_NOT_PRECEDED, "}"),
+            "33:30: " + getCheckMessage(MSG_WS_NOT_PRECEDED, "}"),
+            "34:28: " + getCheckMessage(MSG_WS_NOT_FOLLOWED, "{"),
+            "34:42: " + getCheckMessage(MSG_WS_NOT_PRECEDED, "}"),
         };
         verifyWithInlineConfigParser(
                 getPath("InputWhitespaceAroundAllowEmptyLambdaExpressions2.java"),
@@ -458,8 +458,8 @@ public class WhitespaceAroundCheckTest
     @Test
     public void testWhitespaceAroundLambda() throws Exception {
         final String[] expected = {
-            "28:48: " + getCheckMessage(MSG_WS_NOT_PRECEDED, "->"),
-            "28:48: " + getCheckMessage(MSG_WS_NOT_FOLLOWED, "->"),
+            "29:48: " + getCheckMessage(MSG_WS_NOT_PRECEDED, "->"),
+            "29:48: " + getCheckMessage(MSG_WS_NOT_FOLLOWED, "->"),
         };
         verifyWithInlineConfigParser(
                 getPath("InputWhitespaceAroundLambda.java"), expected);
@@ -476,14 +476,14 @@ public class WhitespaceAroundCheckTest
     @Test
     public void testWhitespaceAroundVarargs() throws Exception {
         final String[] expected = {
-            "19:29: " + getCheckMessage(MSG_WS_NOT_PRECEDED, "..."),
-            "20:37: " + getCheckMessage(MSG_WS_NOT_FOLLOWED, "..."),
-            "21:36: " + getCheckMessage(MSG_WS_NOT_PRECEDED, "..."),
-            "21:36: " + getCheckMessage(MSG_WS_NOT_FOLLOWED, "..."),
-            "23:28: " + getCheckMessage(MSG_WS_NOT_PRECEDED, "..."),
-            "23:28: " + getCheckMessage(MSG_WS_NOT_FOLLOWED, "..."),
-            "24:39: " + getCheckMessage(MSG_WS_NOT_PRECEDED, "..."),
-            "24:39: " + getCheckMessage(MSG_WS_NOT_FOLLOWED, "..."),
+            "20:29: " + getCheckMessage(MSG_WS_NOT_PRECEDED, "..."),
+            "21:37: " + getCheckMessage(MSG_WS_NOT_FOLLOWED, "..."),
+            "22:36: " + getCheckMessage(MSG_WS_NOT_PRECEDED, "..."),
+            "22:36: " + getCheckMessage(MSG_WS_NOT_FOLLOWED, "..."),
+            "24:28: " + getCheckMessage(MSG_WS_NOT_PRECEDED, "..."),
+            "24:28: " + getCheckMessage(MSG_WS_NOT_FOLLOWED, "..."),
+            "25:39: " + getCheckMessage(MSG_WS_NOT_PRECEDED, "..."),
+            "25:39: " + getCheckMessage(MSG_WS_NOT_FOLLOWED, "..."),
         };
         verifyWithInlineConfigParser(
                 getPath("InputWhitespaceAroundVarargs.java"), expected);
@@ -493,27 +493,27 @@ public class WhitespaceAroundCheckTest
     public void testWhitespaceAroundRecords()
             throws Exception {
         final String[] expected = {
-            "26:23: " + getCheckMessage(MSG_WS_NOT_FOLLOWED, "{"),
-            "26:24: " + getCheckMessage(MSG_WS_NOT_PRECEDED, "}"),
-            "34:23: " + getCheckMessage(MSG_WS_NOT_FOLLOWED, "{"),
-            "34:24: " + getCheckMessage(MSG_WS_NOT_PRECEDED, "}"),
+            "27:23: " + getCheckMessage(MSG_WS_NOT_FOLLOWED, "{"),
+            "27:24: " + getCheckMessage(MSG_WS_NOT_PRECEDED, "}"),
             "35:23: " + getCheckMessage(MSG_WS_NOT_FOLLOWED, "{"),
             "35:24: " + getCheckMessage(MSG_WS_NOT_PRECEDED, "}"),
-            "36:28: " + getCheckMessage(MSG_WS_NOT_FOLLOWED, "{"),
-            "36:29: " + getCheckMessage(MSG_WS_NOT_PRECEDED, "}"),
-            "41:23: " + getCheckMessage(MSG_WS_NOT_PRECEDED, "{"),
-            "43:18: " + getCheckMessage(MSG_WS_NOT_PRECEDED, "="),
-            "44:14: " + getCheckMessage(MSG_WS_NOT_FOLLOWED, "="),
-            "44:14: " + getCheckMessage(MSG_WS_NOT_PRECEDED, "="),
-            "53:18: " + getCheckMessage(MSG_WS_NOT_PRECEDED, "="),
-            "54:14: " + getCheckMessage(MSG_WS_NOT_FOLLOWED, "="),
-            "54:14: " + getCheckMessage(MSG_WS_NOT_PRECEDED, "="),
-            "62:18: " + getCheckMessage(MSG_WS_NOT_PRECEDED, "="),
-            "63:14: " + getCheckMessage(MSG_WS_NOT_FOLLOWED, "="),
-            "63:14: " + getCheckMessage(MSG_WS_NOT_PRECEDED, "="),
-            "70:21: " + getCheckMessage(MSG_WS_NOT_PRECEDED, "="),
-            "74:28: " + getCheckMessage(MSG_WS_NOT_FOLLOWED, "{"),
-            "74:29: " + getCheckMessage(MSG_WS_NOT_PRECEDED, "}"),
+            "36:23: " + getCheckMessage(MSG_WS_NOT_FOLLOWED, "{"),
+            "36:24: " + getCheckMessage(MSG_WS_NOT_PRECEDED, "}"),
+            "37:28: " + getCheckMessage(MSG_WS_NOT_FOLLOWED, "{"),
+            "37:29: " + getCheckMessage(MSG_WS_NOT_PRECEDED, "}"),
+            "42:23: " + getCheckMessage(MSG_WS_NOT_PRECEDED, "{"),
+            "44:18: " + getCheckMessage(MSG_WS_NOT_PRECEDED, "="),
+            "45:14: " + getCheckMessage(MSG_WS_NOT_FOLLOWED, "="),
+            "45:14: " + getCheckMessage(MSG_WS_NOT_PRECEDED, "="),
+            "54:18: " + getCheckMessage(MSG_WS_NOT_PRECEDED, "="),
+            "55:14: " + getCheckMessage(MSG_WS_NOT_FOLLOWED, "="),
+            "55:14: " + getCheckMessage(MSG_WS_NOT_PRECEDED, "="),
+            "63:18: " + getCheckMessage(MSG_WS_NOT_PRECEDED, "="),
+            "64:14: " + getCheckMessage(MSG_WS_NOT_FOLLOWED, "="),
+            "64:14: " + getCheckMessage(MSG_WS_NOT_PRECEDED, "="),
+            "71:21: " + getCheckMessage(MSG_WS_NOT_PRECEDED, "="),
+            "75:28: " + getCheckMessage(MSG_WS_NOT_FOLLOWED, "{"),
+            "75:29: " + getCheckMessage(MSG_WS_NOT_PRECEDED, "}"),
         };
         verifyWithInlineConfigParser(
                 getPath("InputWhitespaceAroundRecords.java"), expected);
@@ -523,27 +523,27 @@ public class WhitespaceAroundCheckTest
     public void testWhitespaceAroundAllowEmptyCompactCtors()
             throws Exception {
         final String[] expected = {
-            "26:23: " + getCheckMessage(MSG_WS_NOT_FOLLOWED, "{"),
-            "26:24: " + getCheckMessage(MSG_WS_NOT_PRECEDED, "}"),
-            "34:23: " + getCheckMessage(MSG_WS_NOT_FOLLOWED, "{"),
-            "34:24: " + getCheckMessage(MSG_WS_NOT_PRECEDED, "}"),
+            "27:23: " + getCheckMessage(MSG_WS_NOT_FOLLOWED, "{"),
+            "27:24: " + getCheckMessage(MSG_WS_NOT_PRECEDED, "}"),
             "35:23: " + getCheckMessage(MSG_WS_NOT_FOLLOWED, "{"),
             "35:24: " + getCheckMessage(MSG_WS_NOT_PRECEDED, "}"),
-            "36:28: " + getCheckMessage(MSG_WS_NOT_FOLLOWED, "{"),
-            "36:29: " + getCheckMessage(MSG_WS_NOT_PRECEDED, "}"),
-            "41:23: " + getCheckMessage(MSG_WS_NOT_PRECEDED, "{"),
-            "43:18: " + getCheckMessage(MSG_WS_NOT_PRECEDED, "="),
-            "44:14: " + getCheckMessage(MSG_WS_NOT_FOLLOWED, "="),
-            "44:14: " + getCheckMessage(MSG_WS_NOT_PRECEDED, "="),
-            "53:18: " + getCheckMessage(MSG_WS_NOT_PRECEDED, "="),
-            "54:14: " + getCheckMessage(MSG_WS_NOT_FOLLOWED, "="),
-            "54:14: " + getCheckMessage(MSG_WS_NOT_PRECEDED, "="),
-            "67:21: " + getCheckMessage(MSG_WS_NOT_PRECEDED, "="),
-            "80:18: " + getCheckMessage(MSG_WS_NOT_PRECEDED, "{"),
-            "84:18: " + getCheckMessage(MSG_WS_NOT_PRECEDED, "{"),
-            "84:18: " + getCheckMessage(MSG_WS_NOT_FOLLOWED, "{"),
-            "84:40: " + getCheckMessage(MSG_WS_NOT_PRECEDED, "}"),
-            "89:23: " + getCheckMessage(MSG_WS_NOT_PRECEDED, "{"),
+            "36:23: " + getCheckMessage(MSG_WS_NOT_FOLLOWED, "{"),
+            "36:24: " + getCheckMessage(MSG_WS_NOT_PRECEDED, "}"),
+            "37:28: " + getCheckMessage(MSG_WS_NOT_FOLLOWED, "{"),
+            "37:29: " + getCheckMessage(MSG_WS_NOT_PRECEDED, "}"),
+            "42:23: " + getCheckMessage(MSG_WS_NOT_PRECEDED, "{"),
+            "44:18: " + getCheckMessage(MSG_WS_NOT_PRECEDED, "="),
+            "45:14: " + getCheckMessage(MSG_WS_NOT_FOLLOWED, "="),
+            "45:14: " + getCheckMessage(MSG_WS_NOT_PRECEDED, "="),
+            "54:18: " + getCheckMessage(MSG_WS_NOT_PRECEDED, "="),
+            "55:14: " + getCheckMessage(MSG_WS_NOT_FOLLOWED, "="),
+            "55:14: " + getCheckMessage(MSG_WS_NOT_PRECEDED, "="),
+            "68:21: " + getCheckMessage(MSG_WS_NOT_PRECEDED, "="),
+            "81:18: " + getCheckMessage(MSG_WS_NOT_PRECEDED, "{"),
+            "85:18: " + getCheckMessage(MSG_WS_NOT_PRECEDED, "{"),
+            "85:18: " + getCheckMessage(MSG_WS_NOT_FOLLOWED, "{"),
+            "85:40: " + getCheckMessage(MSG_WS_NOT_PRECEDED, "}"),
+            "90:23: " + getCheckMessage(MSG_WS_NOT_PRECEDED, "{"),
         };
         verifyWithInlineConfigParser(
                 getPath("InputWhitespaceAroundAllowEmptyCompactCtors.java"),
@@ -562,15 +562,15 @@ public class WhitespaceAroundCheckTest
     @Test
     public void testWhitespaceAroundAllTokens() throws Exception {
         final String[] expected = {
-            "27:29: " + getCheckMessage(MSG_WS_NOT_FOLLOWED, "<"),
-            "27:29: " + getCheckMessage(MSG_WS_NOT_PRECEDED, "<"),
-            "27:35: " + getCheckMessage(MSG_WS_NOT_FOLLOWED, "<"),
-            "27:35: " + getCheckMessage(MSG_WS_NOT_PRECEDED, "<"),
-            "27:36: " + getCheckMessage(MSG_WS_NOT_FOLLOWED, "?"),
-            "27:36: " + getCheckMessage(MSG_WS_NOT_PRECEDED, "?"),
-            "27:37: " + getCheckMessage(MSG_WS_NOT_FOLLOWED, ">"),
-            "27:37: " + getCheckMessage(MSG_WS_NOT_PRECEDED, ">"),
-            "27:38: " + getCheckMessage(MSG_WS_NOT_PRECEDED, ">"),
+            "28:29: " + getCheckMessage(MSG_WS_NOT_FOLLOWED, "<"),
+            "28:29: " + getCheckMessage(MSG_WS_NOT_PRECEDED, "<"),
+            "28:35: " + getCheckMessage(MSG_WS_NOT_FOLLOWED, "<"),
+            "28:35: " + getCheckMessage(MSG_WS_NOT_PRECEDED, "<"),
+            "28:36: " + getCheckMessage(MSG_WS_NOT_FOLLOWED, "?"),
+            "28:36: " + getCheckMessage(MSG_WS_NOT_PRECEDED, "?"),
+            "28:37: " + getCheckMessage(MSG_WS_NOT_FOLLOWED, ">"),
+            "28:37: " + getCheckMessage(MSG_WS_NOT_PRECEDED, ">"),
+            "28:38: " + getCheckMessage(MSG_WS_NOT_PRECEDED, ">"),
         };
         verifyWithInlineConfigParser(
                 getPath("InputWhitespaceAroundAllTokens.java"), expected);
@@ -579,22 +579,22 @@ public class WhitespaceAroundCheckTest
     @Test
     public void testWhitespaceAroundAfterEmoji() throws Exception {
         final String[] expected = {
-            "25:22: " + getCheckMessage(MSG_WS_NOT_PRECEDED, "+"),
-            "26:23: " + getCheckMessage(MSG_WS_NOT_FOLLOWED, "+"),
-            "27:22: " + getCheckMessage(MSG_WS_NOT_FOLLOWED, "+"),
-            "27:22: " + getCheckMessage(MSG_WS_NOT_PRECEDED, "+"),
-            "29:19: " + getCheckMessage(MSG_WS_NOT_FOLLOWED, "+"),
-            "29:19: " + getCheckMessage(MSG_WS_NOT_PRECEDED, "+"),
-            "29:23: " + getCheckMessage(MSG_WS_NOT_FOLLOWED, "+"),
-            "29:23: " + getCheckMessage(MSG_WS_NOT_PRECEDED, "+"),
-            "29:28: " + getCheckMessage(MSG_WS_NOT_FOLLOWED, "+"),
-            "29:28: " + getCheckMessage(MSG_WS_NOT_PRECEDED, "+"),
-            "29:32: " + getCheckMessage(MSG_WS_NOT_FOLLOWED, "+"),
-            "29:32: " + getCheckMessage(MSG_WS_NOT_PRECEDED, "+"),
-            "29:36: " + getCheckMessage(MSG_WS_NOT_FOLLOWED, "+"),
-            "29:36: " + getCheckMessage(MSG_WS_NOT_PRECEDED, "+"),
-            "29:40: " + getCheckMessage(MSG_WS_NOT_FOLLOWED, "+"),
-            "29:40: " + getCheckMessage(MSG_WS_NOT_PRECEDED, "+"),
+            "26:22: " + getCheckMessage(MSG_WS_NOT_PRECEDED, "+"),
+            "27:23: " + getCheckMessage(MSG_WS_NOT_FOLLOWED, "+"),
+            "28:22: " + getCheckMessage(MSG_WS_NOT_FOLLOWED, "+"),
+            "28:22: " + getCheckMessage(MSG_WS_NOT_PRECEDED, "+"),
+            "30:19: " + getCheckMessage(MSG_WS_NOT_FOLLOWED, "+"),
+            "30:19: " + getCheckMessage(MSG_WS_NOT_PRECEDED, "+"),
+            "30:23: " + getCheckMessage(MSG_WS_NOT_FOLLOWED, "+"),
+            "30:23: " + getCheckMessage(MSG_WS_NOT_PRECEDED, "+"),
+            "30:28: " + getCheckMessage(MSG_WS_NOT_FOLLOWED, "+"),
+            "30:28: " + getCheckMessage(MSG_WS_NOT_PRECEDED, "+"),
+            "30:32: " + getCheckMessage(MSG_WS_NOT_FOLLOWED, "+"),
+            "30:32: " + getCheckMessage(MSG_WS_NOT_PRECEDED, "+"),
+            "30:36: " + getCheckMessage(MSG_WS_NOT_FOLLOWED, "+"),
+            "30:36: " + getCheckMessage(MSG_WS_NOT_PRECEDED, "+"),
+            "30:40: " + getCheckMessage(MSG_WS_NOT_FOLLOWED, "+"),
+            "30:40: " + getCheckMessage(MSG_WS_NOT_PRECEDED, "+"),
         };
         verifyWithInlineConfigParser(
                 getPath("InputWhitespaceAroundAfterEmoji.java"), expected);
@@ -603,16 +603,16 @@ public class WhitespaceAroundCheckTest
     @Test
     public void testLiteralWhen() throws Exception {
         final String[] expected = {
-            "21:28: " + getCheckMessage(MSG_WS_NOT_FOLLOWED, "when"),
-            "23:27: " + getCheckMessage(MSG_WS_NOT_FOLLOWED, "when"),
-            "25:39: " + getCheckMessage(MSG_WS_NOT_FOLLOWED, "when"),
-            "30:38: " + getCheckMessage(MSG_WS_NOT_FOLLOWED, "when"),
-            "30:38: " + getCheckMessage(MSG_WS_NOT_PRECEDED, "when"),
-            "34:38: " + getCheckMessage(MSG_WS_NOT_FOLLOWED, "when"),
-            "34:38: " + getCheckMessage(MSG_WS_NOT_PRECEDED, "when"),
-            "53:27: " + getCheckMessage(MSG_WS_NOT_FOLLOWED, "when"),
-            "64:21: " + getCheckMessage(MSG_WS_NOT_FOLLOWED, "when"),
-            "67:38: " + getCheckMessage(MSG_WS_NOT_PRECEDED, "when"),
+            "22:28: " + getCheckMessage(MSG_WS_NOT_FOLLOWED, "when"),
+            "24:27: " + getCheckMessage(MSG_WS_NOT_FOLLOWED, "when"),
+            "26:39: " + getCheckMessage(MSG_WS_NOT_FOLLOWED, "when"),
+            "31:38: " + getCheckMessage(MSG_WS_NOT_FOLLOWED, "when"),
+            "31:38: " + getCheckMessage(MSG_WS_NOT_PRECEDED, "when"),
+            "35:38: " + getCheckMessage(MSG_WS_NOT_FOLLOWED, "when"),
+            "35:38: " + getCheckMessage(MSG_WS_NOT_PRECEDED, "when"),
+            "54:27: " + getCheckMessage(MSG_WS_NOT_FOLLOWED, "when"),
+            "65:21: " + getCheckMessage(MSG_WS_NOT_FOLLOWED, "when"),
+            "68:38: " + getCheckMessage(MSG_WS_NOT_PRECEDED, "when"),
         };
         verifyWithInlineConfigParser(
             getPath("InputWhitespaceAroundLiteralWhen.java"),
@@ -622,15 +622,15 @@ public class WhitespaceAroundCheckTest
     @Test
     public void testWhitespaceAroundAfterPermitsList() throws Exception {
         final String[] expected = {
-            "25:53: " + getCheckMessage(MSG_WS_NOT_FOLLOWED, "{"),
-            "25:53: " + getCheckMessage(MSG_WS_NOT_PRECEDED, "{"),
-            "25:54: " + getCheckMessage(MSG_WS_NOT_PRECEDED, "}"),
-            "26:40: " + getCheckMessage(MSG_WS_NOT_FOLLOWED, "{"),
-            "26:40: " + getCheckMessage(MSG_WS_NOT_PRECEDED, "{"),
-            "26:41: " + getCheckMessage(MSG_WS_NOT_PRECEDED, "}"),
-            "27:48: " + getCheckMessage(MSG_WS_NOT_FOLLOWED, "{"),
-            "27:48: " + getCheckMessage(MSG_WS_NOT_PRECEDED, "{"),
-            "27:49: " + getCheckMessage(MSG_WS_NOT_PRECEDED, "}"),
+            "26:53: " + getCheckMessage(MSG_WS_NOT_FOLLOWED, "{"),
+            "26:53: " + getCheckMessage(MSG_WS_NOT_PRECEDED, "{"),
+            "26:54: " + getCheckMessage(MSG_WS_NOT_PRECEDED, "}"),
+            "27:40: " + getCheckMessage(MSG_WS_NOT_FOLLOWED, "{"),
+            "27:40: " + getCheckMessage(MSG_WS_NOT_PRECEDED, "{"),
+            "27:41: " + getCheckMessage(MSG_WS_NOT_PRECEDED, "}"),
+            "28:48: " + getCheckMessage(MSG_WS_NOT_FOLLOWED, "{"),
+            "28:48: " + getCheckMessage(MSG_WS_NOT_PRECEDED, "{"),
+            "28:49: " + getCheckMessage(MSG_WS_NOT_PRECEDED, "}"),
         };
         verifyWithInlineConfigParser(
                 getPath("InputWhitespaceAroundAfterPermitsList.java"), expected);

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/whitespace/whitespacearound/InputWhitespaceAround1.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/whitespace/whitespacearound/InputWhitespaceAround1.java
@@ -6,6 +6,7 @@ allowEmptyTypes = (default)false
 allowEmptyLoops = (default)false
 allowEmptyLambdas = (default)false
 allowEmptyCatches = (default)false
+allowEmptySwitchBlockStatements = (default)false
 ignoreEnhancedForColon = (default)true
 tokens = (default)ASSIGN, BAND, BAND_ASSIGN, BOR, BOR_ASSIGN, BSR, BSR_ASSIGN, BXOR, \
          BXOR_ASSIGN, COLON, DIV, DIV_ASSIGN, DO_WHILE, EQUAL, GE, GT, LAMBDA, LAND, \

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/whitespace/whitespacearound/InputWhitespaceAround2.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/whitespace/whitespacearound/InputWhitespaceAround2.java
@@ -6,6 +6,7 @@ allowEmptyTypes = (default)false
 allowEmptyLoops = (default)false
 allowEmptyLambdas = (default)false
 allowEmptyCatches = (default)false
+allowEmptySwitchBlockStatements = (default)false
 ignoreEnhancedForColon = false
 tokens = (default)ASSIGN, BAND, BAND_ASSIGN, BOR, BOR_ASSIGN, BSR, BSR_ASSIGN, BXOR, \
          BXOR_ASSIGN, COLON, DIV, DIV_ASSIGN, DO_WHILE, EQUAL, GE, GT, LAMBDA, LAND, \

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/whitespace/whitespacearound/InputWhitespaceAround3.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/whitespace/whitespacearound/InputWhitespaceAround3.java
@@ -6,6 +6,7 @@ allowEmptyTypes = (default)false
 allowEmptyLoops = (default)false
 allowEmptyLambdas = (default)false
 allowEmptyCatches = (default)false
+allowEmptySwitchBlockStatements = (default)false
 ignoreEnhancedForColon = (default)true
 tokens = (default)ASSIGN, BAND, BAND_ASSIGN, BOR, BOR_ASSIGN, BSR, BSR_ASSIGN, BXOR, \
          BXOR_ASSIGN, COLON, DIV, DIV_ASSIGN, DO_WHILE, EQUAL, GE, GT, LAMBDA, LAND, \

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/whitespace/whitespacearound/InputWhitespaceAroundAfterEmoji.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/whitespace/whitespacearound/InputWhitespaceAroundAfterEmoji.java
@@ -6,6 +6,7 @@ allowEmptyTypes = true
 allowEmptyLoops = (default)false
 allowEmptyLambdas = (default)false
 allowEmptyCatches = true
+allowEmptySwitchBlockStatements = (default)false
 ignoreEnhancedForColon = (default)true
 tokens = ASSIGN, ARRAY_INIT, BAND, BAND_ASSIGN, BOR, BOR_ASSIGN, BSR, BSR_ASSIGN, BXOR, \
          BXOR_ASSIGN, COLON, DIV, DIV_ASSIGN, DO_WHILE, EQUAL, GE, GT, LAMBDA, LAND, LCURLY, \

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/whitespace/whitespacearound/InputWhitespaceAroundAfterPermitsList.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/whitespace/whitespacearound/InputWhitespaceAroundAfterPermitsList.java
@@ -6,6 +6,7 @@ allowEmptyTypes = (default)false
 allowEmptyLoops = (default)false
 allowEmptyLambdas = (default)false
 allowEmptyCatches = (default)false
+allowEmptySwitchBlockStatements = (default)false
 ignoreEnhancedForColon = (default)true
 tokens = (default)ASSIGN, BAND, BAND_ASSIGN, BOR, BOR_ASSIGN, BSR, BSR_ASSIGN, BXOR, \
          BXOR_ASSIGN, COLON, DIV, DIV_ASSIGN, DO_WHILE, EQUAL, GE, GT, LAMBDA, LAND, \

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/whitespace/whitespacearound/InputWhitespaceAroundAllTokens.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/whitespace/whitespacearound/InputWhitespaceAroundAllTokens.java
@@ -6,6 +6,7 @@ allowEmptyTypes = true
 allowEmptyLoops = (default)false
 allowEmptyLambdas = (default)false
 allowEmptyCatches = true
+allowEmptySwitchBlockStatements = (default)false
 ignoreEnhancedForColon = (default)true
 tokens = ASSIGN, ARRAY_INIT, BAND, BAND_ASSIGN, BOR, BOR_ASSIGN, BSR, BSR_ASSIGN, BXOR, \
          BXOR_ASSIGN, COLON, DIV, DIV_ASSIGN, DO_WHILE, EQUAL, GE, GT, LAMBDA, LAND, LCURLY, \

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/whitespace/whitespacearound/InputWhitespaceAroundAllowEmptyCompactCtors.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/whitespace/whitespacearound/InputWhitespaceAroundAllowEmptyCompactCtors.java
@@ -6,6 +6,7 @@ allowEmptyTypes = (default)false
 allowEmptyLoops = (default)false
 allowEmptyLambdas = (default)false
 allowEmptyCatches = (default)false
+allowEmptySwitchBlockStatements = (default)false
 ignoreEnhancedForColon = (default)true
 tokens = (default)ASSIGN, BAND, BAND_ASSIGN, BOR, BOR_ASSIGN, BSR, BSR_ASSIGN, BXOR, \
          BXOR_ASSIGN, COLON, DIV, DIV_ASSIGN, DO_WHILE, EQUAL, GE, GT, LAMBDA, LAND, \

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/whitespace/whitespacearound/InputWhitespaceAroundAllowEmptyLambdaExpressions.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/whitespace/whitespacearound/InputWhitespaceAroundAllowEmptyLambdaExpressions.java
@@ -6,6 +6,7 @@ allowEmptyTypes = (default)false
 allowEmptyLoops = (default)false
 allowEmptyLambdas = (default)false
 allowEmptyCatches = (default)false
+allowEmptySwitchBlockStatements = (default)false
 ignoreEnhancedForColon = (default)true
 tokens = (default)ASSIGN, BAND, BAND_ASSIGN, BOR, BOR_ASSIGN, BSR, BSR_ASSIGN, BXOR, \
          BXOR_ASSIGN, COLON, DIV, DIV_ASSIGN, DO_WHILE, EQUAL, GE, GT, LAMBDA, LAND, \

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/whitespace/whitespacearound/InputWhitespaceAroundAllowEmptyLambdaExpressions2.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/whitespace/whitespacearound/InputWhitespaceAroundAllowEmptyLambdaExpressions2.java
@@ -6,6 +6,7 @@ allowEmptyTypes = (default)false
 allowEmptyLoops = (default)false
 allowEmptyLambdas = true
 allowEmptyCatches = (default)false
+allowEmptySwitchBlockStatements = (default)false
 ignoreEnhancedForColon = (default)true
 tokens = (default)ASSIGN, BAND, BAND_ASSIGN, BOR, BOR_ASSIGN, BSR, BSR_ASSIGN, BXOR, \
          BXOR_ASSIGN, COLON, DIV, DIV_ASSIGN, DO_WHILE, EQUAL, GE, GT, LAMBDA, LAND, \

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/whitespace/whitespacearound/InputWhitespaceAroundAllowEmptyTypesAndNonEmptyClasses.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/whitespace/whitespacearound/InputWhitespaceAroundAllowEmptyTypesAndNonEmptyClasses.java
@@ -6,6 +6,7 @@ allowEmptyTypes = (default)false
 allowEmptyLoops = (default)false
 allowEmptyLambdas = (default)false
 allowEmptyCatches = (default)false
+allowEmptySwitchBlockStatements = (default)false
 ignoreEnhancedForColon = (default)true
 tokens = (default)ASSIGN, BAND, BAND_ASSIGN, BOR, BOR_ASSIGN, BSR, BSR_ASSIGN, BXOR, \
          BXOR_ASSIGN, COLON, DIV, DIV_ASSIGN, DO_WHILE, EQUAL, GE, GT, LAMBDA, LAND, \

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/whitespace/whitespacearound/InputWhitespaceAroundAllowEmptyTypesAndNonEmptyClasses2.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/whitespace/whitespacearound/InputWhitespaceAroundAllowEmptyTypesAndNonEmptyClasses2.java
@@ -6,6 +6,7 @@ allowEmptyTypes = true
 allowEmptyLoops = (default)false
 allowEmptyLambdas = (default)false
 allowEmptyCatches = (default)false
+allowEmptySwitchBlockStatements = (default)false
 ignoreEnhancedForColon = (default)true
 tokens = (default)ASSIGN, BAND, BAND_ASSIGN, BOR, BOR_ASSIGN, BSR, BSR_ASSIGN, BXOR, \
          BXOR_ASSIGN, COLON, DIV, DIV_ASSIGN, DO_WHILE, EQUAL, GE, GT, LAMBDA, LAND, \

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/whitespace/whitespacearound/InputWhitespaceAroundArrayInitialization.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/whitespace/whitespacearound/InputWhitespaceAroundArrayInitialization.java
@@ -6,6 +6,7 @@ allowEmptyTypes = (default)false
 allowEmptyLoops = (default)false
 allowEmptyLambdas = (default)false
 allowEmptyCatches = (default)false
+allowEmptySwitchBlockStatements = (default)false
 ignoreEnhancedForColon = (default)true
 tokens = ARRAY_INIT
 

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/whitespace/whitespacearound/InputWhitespaceAroundBraces2Part1.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/whitespace/whitespacearound/InputWhitespaceAroundBraces2Part1.java
@@ -6,6 +6,7 @@ allowEmptyTypes = (default)false
 allowEmptyLoops = (default)false
 allowEmptyLambdas = (default)false
 allowEmptyCatches = (default)false
+allowEmptySwitchBlockStatements = (default)false
 ignoreEnhancedForColon = (default)true
 tokens = (default)ASSIGN, BAND, BAND_ASSIGN, BOR, BOR_ASSIGN, BSR, BSR_ASSIGN, BXOR, \
          BXOR_ASSIGN, COLON, DIV, DIV_ASSIGN, DO_WHILE, EQUAL, GE, GT, LAMBDA, LAND, \

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/whitespace/whitespacearound/InputWhitespaceAroundBraces2Part2.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/whitespace/whitespacearound/InputWhitespaceAroundBraces2Part2.java
@@ -6,6 +6,7 @@ allowEmptyTypes = (default)false
 allowEmptyLoops = (default)false
 allowEmptyLambdas = (default)false
 allowEmptyCatches = (default)false
+allowEmptySwitchBlockStatements = (default)false
 ignoreEnhancedForColon = (default)true
 tokens = (default)ASSIGN, BAND, BAND_ASSIGN, BOR, BOR_ASSIGN, BSR, BSR_ASSIGN, BXOR, \
          BXOR_ASSIGN, COLON, DIV, DIV_ASSIGN, DO_WHILE, EQUAL, GE, GT, LAMBDA, LAND, \

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/whitespace/whitespacearound/InputWhitespaceAroundBracesPart1.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/whitespace/whitespacearound/InputWhitespaceAroundBracesPart1.java
@@ -6,6 +6,7 @@ allowEmptyTypes = (default)false
 allowEmptyLoops = (default)false
 allowEmptyLambdas = (default)false
 allowEmptyCatches = (default)false
+allowEmptySwitchBlockStatements = (default)false
 ignoreEnhancedForColon = (default)true
 tokens = (default)ASSIGN, BAND, BAND_ASSIGN, BOR, BOR_ASSIGN, BSR, BSR_ASSIGN, BXOR, \
          BXOR_ASSIGN, COLON, DIV, DIV_ASSIGN, DO_WHILE, EQUAL, GE, GT, LAMBDA, LAND, \

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/whitespace/whitespacearound/InputWhitespaceAroundBracesPart2.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/whitespace/whitespacearound/InputWhitespaceAroundBracesPart2.java
@@ -6,6 +6,7 @@ allowEmptyTypes = (default)false
 allowEmptyLoops = (default)false
 allowEmptyLambdas = (default)false
 allowEmptyCatches = (default)false
+allowEmptySwitchBlockStatements = (default)false
 ignoreEnhancedForColon = (default)true
 tokens = (default)ASSIGN, BAND, BAND_ASSIGN, BOR, BOR_ASSIGN, BSR, BSR_ASSIGN, BXOR, \
          BXOR_ASSIGN, COLON, DIV, DIV_ASSIGN, DO_WHILE, EQUAL, GE, GT, LAMBDA, LAND, \

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/whitespace/whitespacearound/InputWhitespaceAroundCatch.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/whitespace/whitespacearound/InputWhitespaceAroundCatch.java
@@ -6,6 +6,7 @@ allowEmptyTypes = (default)false
 allowEmptyLoops = (default)false
 allowEmptyLambdas = (default)false
 allowEmptyCatches = true
+allowEmptySwitchBlockStatements = (default)false
 ignoreEnhancedForColon = (default)true
 tokens = (default)ASSIGN, BAND, BAND_ASSIGN, BOR, BOR_ASSIGN, BSR, BSR_ASSIGN, BXOR, \
          BXOR_ASSIGN, COLON, DIV, DIV_ASSIGN, DO_WHILE, EQUAL, GE, GT, LAMBDA, LAND, \

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/whitespace/whitespacearound/InputWhitespaceAroundDoWhile.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/whitespace/whitespacearound/InputWhitespaceAroundDoWhile.java
@@ -6,6 +6,7 @@ allowEmptyTypes = (default)false
 allowEmptyLoops = (default)false
 allowEmptyLambdas = (default)false
 allowEmptyCatches = (default)false
+allowEmptySwitchBlockStatements = (default)false
 ignoreEnhancedForColon = (default)true
 tokens = (default)ASSIGN, BAND, BAND_ASSIGN, BOR, BOR_ASSIGN, BSR, BSR_ASSIGN, BXOR, \
          BXOR_ASSIGN, COLON, DIV, DIV_ASSIGN, DO_WHILE, EQUAL, GE, GT, LAMBDA, LAND, \

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/whitespace/whitespacearound/InputWhitespaceAroundDoubleBraceInitialization.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/whitespace/whitespacearound/InputWhitespaceAroundDoubleBraceInitialization.java
@@ -6,6 +6,7 @@ allowEmptyTypes = (default)false
 allowEmptyLoops = (default)false
 allowEmptyLambdas = (default)false
 allowEmptyCatches = (default)false
+allowEmptySwitchBlockStatements = (default)false
 ignoreEnhancedForColon = (default)true
 tokens = (default)ASSIGN, BAND, BAND_ASSIGN, BOR, BOR_ASSIGN, BSR, BSR_ASSIGN, BXOR, \
          BXOR_ASSIGN, COLON, DIV, DIV_ASSIGN, DO_WHILE, EQUAL, GE, GT, LAMBDA, LAND, \

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/whitespace/whitespacearound/InputWhitespaceAroundEmptyTypesAndCycles.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/whitespace/whitespacearound/InputWhitespaceAroundEmptyTypesAndCycles.java
@@ -6,6 +6,7 @@ allowEmptyTypes = true
 allowEmptyLoops = (default)false
 allowEmptyLambdas = (default)false
 allowEmptyCatches = (default)false
+allowEmptySwitchBlockStatements = (default)false
 ignoreEnhancedForColon = (default)true
 tokens = (default)ASSIGN, BAND, BAND_ASSIGN, BOR, BOR_ASSIGN, BSR, BSR_ASSIGN, BXOR, \
          BXOR_ASSIGN, COLON, DIV, DIV_ASSIGN, DO_WHILE, EQUAL, GE, GT, LAMBDA, LAND, \

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/whitespace/whitespacearound/InputWhitespaceAroundEmptyTypesAndCycles2.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/whitespace/whitespacearound/InputWhitespaceAroundEmptyTypesAndCycles2.java
@@ -6,6 +6,7 @@ allowEmptyTypes = (default)false
 allowEmptyLoops = true
 allowEmptyLambdas = (default)false
 allowEmptyCatches = (default)false
+allowEmptySwitchBlockStatements = (default)false
 ignoreEnhancedForColon = (default)true
 tokens = (default)ASSIGN, BAND, BAND_ASSIGN, BOR, BOR_ASSIGN, BSR, BSR_ASSIGN, BXOR, \
          BXOR_ASSIGN, COLON, DIV, DIV_ASSIGN, DO_WHILE, EQUAL, GE, GT, LAMBDA, LAND, \

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/whitespace/whitespacearound/InputWhitespaceAroundGenerics.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/whitespace/whitespacearound/InputWhitespaceAroundGenerics.java
@@ -6,6 +6,7 @@ allowEmptyTypes = (default)false
 allowEmptyLoops = (default)false
 allowEmptyLambdas = (default)false
 allowEmptyCatches = (default)false
+allowEmptySwitchBlockStatements = (default)false
 ignoreEnhancedForColon = (default)true
 tokens = (default)ASSIGN, BAND, BAND_ASSIGN, BOR, BOR_ASSIGN, BSR, BSR_ASSIGN, BXOR, \
          BXOR_ASSIGN, COLON, DIV, DIV_ASSIGN, DO_WHILE, EQUAL, GE, GT, LAMBDA, LAND, \

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/whitespace/whitespacearound/InputWhitespaceAroundKeywordsAndOperators.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/whitespace/whitespacearound/InputWhitespaceAroundKeywordsAndOperators.java
@@ -6,6 +6,7 @@ allowEmptyTypes = (default)false
 allowEmptyLoops = (default)false
 allowEmptyLambdas = (default)false
 allowEmptyCatches = (default)false
+allowEmptySwitchBlockStatements = (default)false
 ignoreEnhancedForColon = (default)true
 tokens = (default)ASSIGN, BAND, BAND_ASSIGN, BOR, BOR_ASSIGN, BSR, BSR_ASSIGN, BXOR, \
          BXOR_ASSIGN, COLON, DIV, DIV_ASSIGN, DO_WHILE, EQUAL, GE, GT, LAMBDA, LAND, \

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/whitespace/whitespacearound/InputWhitespaceAroundLambda.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/whitespace/whitespacearound/InputWhitespaceAroundLambda.java
@@ -6,6 +6,7 @@ allowEmptyTypes = (default)false
 allowEmptyLoops = (default)false
 allowEmptyLambdas = (default)false
 allowEmptyCatches = (default)false
+allowEmptySwitchBlockStatements = (default)false
 ignoreEnhancedForColon = (default)true
 tokens = (default)ASSIGN, BAND, BAND_ASSIGN, BOR, BOR_ASSIGN, BSR, BSR_ASSIGN, BXOR, \
          BXOR_ASSIGN, COLON, DIV, DIV_ASSIGN, DO_WHILE, EQUAL, GE, GT, LAMBDA, LAND, \

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/whitespace/whitespacearound/InputWhitespaceAroundLiteralWhen.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/whitespace/whitespacearound/InputWhitespaceAroundLiteralWhen.java
@@ -6,6 +6,7 @@ allowEmptyTypes = (default)false
 allowEmptyLoops = (default)false
 allowEmptyLambdas = (default)false
 allowEmptyCatches = (default)false
+allowEmptySwitchBlockStatements = (default)false
 ignoreEnhancedForColon = (default)true
 tokens = LITERAL_WHEN
 

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/whitespace/whitespacearound/InputWhitespaceAroundRecords.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/whitespace/whitespacearound/InputWhitespaceAroundRecords.java
@@ -6,6 +6,7 @@ allowEmptyTypes = (default)false
 allowEmptyLoops = (default)false
 allowEmptyLambdas = (default)false
 allowEmptyCatches = (default)false
+allowEmptySwitchBlockStatements = (default)false
 ignoreEnhancedForColon = (default)true
 tokens = (default)ASSIGN, BAND, BAND_ASSIGN, BOR, BOR_ASSIGN, BSR, BSR_ASSIGN, BXOR, \
          BXOR_ASSIGN, COLON, DIV, DIV_ASSIGN, DO_WHILE, EQUAL, GE, GT, LAMBDA, LAND, \

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/whitespace/whitespacearound/InputWhitespaceAroundRecordsAllowEmptyTypes.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/whitespace/whitespacearound/InputWhitespaceAroundRecordsAllowEmptyTypes.java
@@ -6,6 +6,7 @@ allowEmptyTypes = true
 allowEmptyLoops = (default)false
 allowEmptyLambdas = (default)false
 allowEmptyCatches = (default)false
+allowEmptySwitchBlockStatements = (default)false
 ignoreEnhancedForColon = (default)true
 tokens = (default)ASSIGN, BAND, BAND_ASSIGN, BOR, BOR_ASSIGN, BSR, BSR_ASSIGN, BXOR, \
          BXOR_ASSIGN, COLON, DIV, DIV_ASSIGN, DO_WHILE, EQUAL, GE, GT, LAMBDA, LAND, \

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/whitespace/whitespacearound/InputWhitespaceAroundSimplePart1.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/whitespace/whitespacearound/InputWhitespaceAroundSimplePart1.java
@@ -6,6 +6,7 @@ allowEmptyTypes = (default)false
 allowEmptyLoops = (default)false
 allowEmptyLambdas = (default)false
 allowEmptyCatches = (default)false
+allowEmptySwitchBlockStatements = (default)false
 ignoreEnhancedForColon = (default)true
 tokens = (default)ASSIGN, BAND, BAND_ASSIGN, BOR, BOR_ASSIGN, BSR, BSR_ASSIGN, BXOR, \
          BXOR_ASSIGN, COLON, DIV, DIV_ASSIGN, DO_WHILE, EQUAL, GE, GT, LAMBDA, LAND, \

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/whitespace/whitespacearound/InputWhitespaceAroundSimplePart2.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/whitespace/whitespacearound/InputWhitespaceAroundSimplePart2.java
@@ -6,6 +6,7 @@ allowEmptyTypes = (default)false
 allowEmptyLoops = (default)false
 allowEmptyLambdas = (default)false
 allowEmptyCatches = (default)false
+allowEmptySwitchBlockStatements = (default)false
 ignoreEnhancedForColon = (default)true
 tokens = (default)ASSIGN, BAND, BAND_ASSIGN, BOR, BOR_ASSIGN, BSR, BSR_ASSIGN, BXOR, \
          BXOR_ASSIGN, COLON, DIV, DIV_ASSIGN, DO_WHILE, EQUAL, GE, GT, LAMBDA, LAND, \

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/whitespace/whitespacearound/InputWhitespaceAroundSimplePart3.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/whitespace/whitespacearound/InputWhitespaceAroundSimplePart3.java
@@ -6,6 +6,7 @@ allowEmptyTypes = (default)false
 allowEmptyLoops = (default)false
 allowEmptyLambdas = (default)false
 allowEmptyCatches = (default)false
+allowEmptySwitchBlockStatements = (default)false
 ignoreEnhancedForColon = (default)true
 tokens = (default)ASSIGN, BAND, BAND_ASSIGN, BOR, BOR_ASSIGN, BSR, BSR_ASSIGN, BXOR, \
          BXOR_ASSIGN, COLON, DIV, DIV_ASSIGN, DO_WHILE, EQUAL, GE, GT, LAMBDA, LAND, \

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/whitespace/whitespacearound/InputWhitespaceAroundStartOfTheLine.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/whitespace/whitespacearound/InputWhitespaceAroundStartOfTheLine.java
@@ -6,6 +6,7 @@ allowEmptyTypes = (default)false
 allowEmptyLoops = (default)false
 allowEmptyLambdas = (default)false
 allowEmptyCatches = (default)false
+allowEmptySwitchBlockStatements = (default)false
 ignoreEnhancedForColon = (default)true
 tokens = (default)ASSIGN, BAND, BAND_ASSIGN, BOR, BOR_ASSIGN, BSR, BSR_ASSIGN, BXOR, \
          BXOR_ASSIGN, COLON, DIV, DIV_ASSIGN, DO_WHILE, EQUAL, GE, GT, LAMBDA, LAND, \

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/whitespace/whitespacearound/InputWhitespaceAroundSwitch.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/whitespace/whitespacearound/InputWhitespaceAroundSwitch.java
@@ -6,6 +6,7 @@ allowEmptyTypes = (default)false
 allowEmptyLoops = (default)false
 allowEmptyLambdas = (default)false
 allowEmptyCatches = (default)false
+allowEmptySwitchBlockStatements = (default)false
 ignoreEnhancedForColon = (default)true
 tokens = (default)ASSIGN, BAND, BAND_ASSIGN, BOR, BOR_ASSIGN, BSR, BSR_ASSIGN, BXOR, \
          BXOR_ASSIGN, COLON, DIV, DIV_ASSIGN, DO_WHILE, EQUAL, GE, GT, LAMBDA, LAND, \

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/whitespace/whitespacearound/InputWhitespaceAroundSwitchExpressions.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/whitespace/whitespacearound/InputWhitespaceAroundSwitchExpressions.java
@@ -6,6 +6,7 @@ allowEmptyTypes = (default)false
 allowEmptyLoops = (default)false
 allowEmptyLambdas = (default)false
 allowEmptyCatches = (default)false
+allowEmptySwitchBlockStatements = (default)false
 ignoreEnhancedForColon = (default)true
 tokens = (default)ASSIGN, BAND, BAND_ASSIGN, BOR, BOR_ASSIGN, BSR, BSR_ASSIGN, BXOR, \
          BXOR_ASSIGN, COLON, DIV, DIV_ASSIGN, DO_WHILE, EQUAL, GE, GT, LAMBDA, LAND, \

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/whitespace/whitespacearound/InputWhitespaceAroundUnnamedPattern.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/whitespace/whitespacearound/InputWhitespaceAroundUnnamedPattern.java
@@ -6,6 +6,7 @@ allowEmptyTypes = (default)false
 allowEmptyLoops = (default)false
 allowEmptyLambdas = (default)false
 allowEmptyCatches = (default)false
+allowEmptySwitchBlockStatements = (default)false
 ignoreEnhancedForColon = (default)true
 tokens = (default)ASSIGN, BAND, BAND_ASSIGN, BOR, BOR_ASSIGN, BSR, BSR_ASSIGN, BXOR, \
          BXOR_ASSIGN, COLON, DIV, DIV_ASSIGN, DO_WHILE, EQUAL, GE, GT, LAMBDA, LAND, \

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/whitespace/whitespacearound/InputWhitespaceAroundVarargs.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/whitespace/whitespacearound/InputWhitespaceAroundVarargs.java
@@ -6,6 +6,7 @@ allowEmptyTypes = (default)false
 allowEmptyLoops = (default)false
 allowEmptyLambdas = (default)false
 allowEmptyCatches = (default)false
+allowEmptySwitchBlockStatements = (default)false
 ignoreEnhancedForColon = (default)true
 tokens = ELLIPSIS
 

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/treewalker/InputTreeWalkerMultiCheckOrder.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/treewalker/InputTreeWalkerMultiCheckOrder.java
@@ -1,5 +1,20 @@
 /*
 com.puppycrawl.tools.checkstyle.checks.whitespace.WhitespaceAroundCheck
+allowEmptyConstructors = (default)false
+allowEmptyMethods = (default)false
+allowEmptyTypes = (default)false
+allowEmptyLoops = (default)false
+allowEmptyLambdas = (default)false
+allowEmptyCatches = (default)false
+allowEmptySwitchBlockStatements = (default)false
+ignoreEnhancedForColon = (default)true
+tokens = (default)ASSIGN, BAND, BAND_ASSIGN, BOR, BOR_ASSIGN, BSR, BSR_ASSIGN, BXOR, \
+         BXOR_ASSIGN, COLON, DIV, DIV_ASSIGN, DO_WHILE, EQUAL, GE, GT, LAMBDA, LAND, \
+         LCURLY, LE, LITERAL_CATCH, LITERAL_DO, LITERAL_ELSE, LITERAL_FINALLY, \
+         LITERAL_FOR, LITERAL_IF, LITERAL_RETURN, LITERAL_SWITCH, LITERAL_SYNCHRONIZED, \
+         LITERAL_TRY, LITERAL_WHILE, LOR, LT, MINUS, MINUS_ASSIGN, MOD, MOD_ASSIGN, \
+         NOT_EQUAL, PLUS, PLUS_ASSIGN, QUESTION, RCURLY, SL, SLIST, SL_ASSIGN, SR, \
+         SR_ASSIGN, STAR, STAR_ASSIGN, LITERAL_ASSERT, TYPE_EXTENSION_AND, LITERAL_WHEN
 
 
 com.puppycrawl.tools.checkstyle.checks.whitespace.WhitespaceAfterCheck


### PR DESCRIPTION
Relates: #16807 

Added missing `allowEmptySwitchBlockStatements = (default)false` property
to 35 input test files for WhitespaceAroundCheck and updated corresponding
violation line numbers in WhitespaceAroundCheckTest. Removed
WhitespaceAroundCheck from SUPPRESSED_MODULES in InlineConfigParser.