### PR TITLE
Issue #13518: fix duplicate maven-source-plugin execution

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -856,8 +856,13 @@
             <execution>
               <id>attach-sources</id>
               <goals>
-                <goal>test-jar</goal>
-                <goal>jar</goal>
+                <goal>jar-no-fork</goal>
+              </goals>
+            </execution>
+            <execution>
+              <id>attach-test-sources</id>
+              <goals>
+                <goal>test-jar-no-fork</goal>
               </goals>
             </execution>
           </executions>


### PR DESCRIPTION
fixes #13518 

https://maven.apache.org/plugins/maven-source-plugin/jar-no-fork-mojo.html

>Description:
This goal bundles all the sources into a jar archive. This goal functions the same as the jar goal but does not fork the build and is suitable for attaching to the build lifecycle.

split the single execution into two separate executions with  id ->
`attach-sources` running `jar-no-fork` for main sources
`attach-test-sources` running `test-jar-no-fork` for test sources

Using `jar-no-fork` and `test-jar-no-fork`  avoids re-forking the
lifecycle, which was contributing to the duplicate execution problem