### PR TITLE
Issue #17878: Detect trailing whitespace in Google Style

### DIFF
--- a/config/checkstyle-resources-suppressions.xml
+++ b/config/checkstyle-resources-suppressions.xml
@@ -114,6 +114,8 @@
 
   <!-- intentional problem for testing -->
   <suppress id="noTrailingWhitespace"
+    files="rule462horizontalwhitespace[\\/]InputWhitespaceTrailingWhitespace\.java"/>
+  <suppress id="noTrailingWhitespace"
     files="/InputJavadocContentLocationTrailingSpace\.java"/>
   <suppress id="noTrailingWhitespace"
     files="/InputJavadocParagraphCorrect\.java"/>

--- a/config/google-java-format/excluded/compilable-input-paths.txt
+++ b/config/google-java-format/excluded/compilable-input-paths.txt
@@ -52,6 +52,7 @@ src/it/resources/com/google/checkstyle/test/chapter4formatting/rule462horizontal
 src/it/resources/com/google/checkstyle/test/chapter4formatting/rule462horizontalwhitespace/InputWhitespaceAroundArrow.java
 src/it/resources/com/google/checkstyle/test/chapter4formatting/rule462horizontalwhitespace/InputGenericWhitespace.java
 src/it/resources/com/google/checkstyle/test/chapter4formatting/rule462horizontalwhitespace/InputWhitespaceAfterDoubleSlashes.java
+src/it/resources/com/google/checkstyle/test/chapter4formatting/rule462horizontalwhitespace/InputWhitespaceTrailingWhitespace.java
 src/it/resources/com/google/checkstyle/test/chapter4formatting/rule462horizontalwhitespace/InputWhitespaceBeforeLeftCurlyOfEmptyBlock.java
 src/it/resources/com/google/checkstyle/test/chapter4formatting/rule462horizontalwhitespace/InputNoWhitespaceBeforeEllipsis.java
 src/it/resources/com/google/checkstyle/test/chapter4formatting/rule462horizontalwhitespace/InputWhitespaceInsideArrayInitializer.java

--- a/src/it/java/com/google/checkstyle/test/chapter4formatting/rule462horizontalwhitespace/HorizontalWhitespaceTest.java
+++ b/src/it/java/com/google/checkstyle/test/chapter4formatting/rule462horizontalwhitespace/HorizontalWhitespaceTest.java
@@ -211,6 +211,16 @@ public class HorizontalWhitespaceTest extends AbstractGoogleModuleTestSupport {
     }
 
     @Test
+    public void testWhitespaceTrailingWhitespace() throws Exception {
+        verifyWithWholeConfig(getPath("InputWhitespaceTrailingWhitespace.java"));
+    }
+
+    @Test
+    public void testWhitespaceTrailingWhitespaceFormatted() throws Exception {
+        verifyWithWholeConfig(getPath("InputFormattedWhitespaceTrailingWhitespace.java"));
+    }
+
+    @Test
     public void testWhitespaceBeforeLeftCurlyOfEmptyBlocks() throws Exception {
         verifyWithWholeConfig(getPath("InputWhitespaceBeforeLeftCurlyOfEmptyBlock.java"));
     }

--- a/src/it/resources/com/google/checkstyle/test/chapter4formatting/rule462horizontalwhitespace/InputFormattedWhitespaceTrailingWhitespace.java
+++ b/src/it/resources/com/google/checkstyle/test/chapter4formatting/rule462horizontalwhitespace/InputFormattedWhitespaceTrailingWhitespace.java
@@ -1,0 +1,9 @@
+package com.google.checkstyle.test.chapter4formatting.rule462horizontalwhitespace;
+
+final class InputFormattedWhitespaceTrailingWhitespace {
+
+  /** Some javadoc. */
+  int test() {
+    return 0;
+  }
+}

--- a/src/it/resources/com/google/checkstyle/test/chapter4formatting/rule462horizontalwhitespace/InputWhitespaceTrailingWhitespace.java
+++ b/src/it/resources/com/google/checkstyle/test/chapter4formatting/rule462horizontalwhitespace/InputWhitespaceTrailingWhitespace.java
@@ -1,0 +1,13 @@
+package com.google.checkstyle.test.chapter4formatting.rule462horizontalwhitespace;
+
+final class InputWhitespaceTrailingWhitespace {
+
+  // violation 2 lines below 'Trailing whitespace is not allowed'
+  /**
+   * Some javadoc.  
+   */
+  int test() {
+    // violation below 'Trailing whitespace is not allowed'
+    return 0;  
+  }
+}

--- a/src/main/resources/google_checks.xml
+++ b/src/main/resources/google_checks.xml
@@ -52,6 +52,14 @@
     <property name="eachLine" value="true"/>
   </module>
 
+  <module name="RegexpSingleline">
+    <property name="id" value="noTrailingWhitespace"/>
+    <property name="format" value="\s+$"/>
+    <property name="minimum" value="0"/>
+    <property name="maximum" value="0"/>
+    <property name="message" value="Trailing whitespace is not allowed"/>
+  </module>
+
   <module name="LineLength">
     <property name="fileExtensions" value="java"/>
     <property name="max" value="100"/>

--- a/src/test/java/com/puppycrawl/tools/checkstyle/internal/XdocsPagesTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/internal/XdocsPagesTest.java
@@ -244,6 +244,11 @@ public class XdocsPagesTest {
     private static final Set<String> GOOGLE_MODULES = Collections.unmodifiableSet(
         CheckUtil.getConfigGoogleStyleModules());
 
+    // Requirement is not yet public.
+    private static final Set<String> IGNORED_GOOGLE_MODULES = Set.of(
+            "RegexpSingleline"
+    );
+
     private static final Set<String> OPENJDK_MODULES = Collections.unmodifiableSet(
         CheckUtil.getConfigOpenJdkStyleModules());
 
@@ -1847,7 +1852,9 @@ public class XdocsPagesTest {
                 .isTrue();
         assertWithMessage("%s section '%s' should have a google section since it is in it's config",
             fileName, sectionName)
-                .that(hasGoogle || !GOOGLE_MODULES.contains(sectionName))
+                .that(hasGoogle
+                    || !GOOGLE_MODULES.contains(sectionName)
+                    || IGNORED_GOOGLE_MODULES.contains(sectionName))
                 .isTrue();
         assertWithMessage("%s section '%s' should have a sun section since it is in it's config",
             fileName, sectionName)
@@ -1930,7 +1937,11 @@ public class XdocsPagesTest {
             final NodeList sources = getTagSourcesNode(path, "tr");
 
             final Set<String> styleChecks = switch (styleName) {
-                case "google" -> new HashSet<>(GOOGLE_MODULES);
+                case "google" -> {
+                    final Set<String> checks = new HashSet<>(GOOGLE_MODULES);
+                    checks.removeAll(IGNORED_GOOGLE_MODULES);
+                    yield checks;
+                }
                 case "sun" -> {
                     final Set<String> checks = new HashSet<>(SUN_MODULES);
                     checks.removeAll(IGNORED_SUN_MODULES);


### PR DESCRIPTION
Issue #17878

Adds a file-level `RegexpSingleline` module to `google_checks.xml` to detect
trailing whitespace on all lines.

The configuration uses the existing project convention:

```xml
<module name="RegexpSingleline">
  <property name="id" value="noTrailingWhitespace"/>
  <property name="format" value="\s+$"/>
  <property name="minimum" value="0"/>
  <property name="maximum" value="0"/>
  <property name="message" value="Trailing whitespace is not allowed"/>
</module>
```

Integration coverage is located under Google Style section 4.6.2, Horizontal
Whitespace.

The new nonformatted/formatted input pair is:

- `InputWhitespaceTrailingWhitespace.java`
- `InputFormattedWhitespaceTrailingWhitespace.java`

The nonformatted input verifies trailing whitespace in:

- a Javadoc content line;
- an ordinary Java code line.

The formatted sibling contains the same semantic code without trailing
whitespace.

The nonformatted input is excluded from automatic Google Java Format and has a
narrow resource-lint suppression for its two intentional trailing-space lines.

The public Google Style coverage table was not updated because this requirement
is not yet public.

Validation:

- `HorizontalWhitespaceTest`: 40 integration tests passed
- `XdocsPagesTest`: 19 tests passed
- resource validation passed
- full `./mvnw clean verify` passed
