### PR TITLE
Issue #16807: Update default properties in JavadocTypeCheck input files

### DIFF
--- a/src/test/java/com/puppycrawl/tools/checkstyle/bdd/InlineConfigParser.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/bdd/InlineConfigParser.java
@@ -303,7 +303,6 @@ public final class InlineConfigParser {
             "com.puppycrawl.tools.checkstyle.checks.imports.ImportOrderCheck",
             "com.puppycrawl.tools.checkstyle.checks.javadoc.JavadocContentLocationCheck",
             "com.puppycrawl.tools.checkstyle.checks.javadoc.JavadocParagraphCheck",
-            "com.puppycrawl.tools.checkstyle.checks.javadoc.JavadocTypeCheck",
             "com.puppycrawl.tools.checkstyle.checks.javadoc.JavadocVariableCheck",
             "com.puppycrawl.tools.checkstyle.checks.javadoc.MissingJavadocPackageCheck",
             "com.puppycrawl.tools.checkstyle.checks.javadoc.MissingJavadocTypeCheck",

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocTypeCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocTypeCheckTest.java
@@ -372,9 +372,9 @@ public class JavadocTypeCheckTest extends AbstractModuleTestSupport {
     @Test
     public void testJavadocTypeParamDescriptionWithAngularTags() throws Exception {
         final String[] expected = {
-            "44:4: " + getCheckMessage(MSG_UNUSED_TAG, "@param", "<P>"),
-            "46:1: " + getCheckMessage(MSG_MISSING_TAG, "@param <U>"),
-            "50:4: " + getCheckMessage(MSG_UNUSED_TAG, "@param", "region"),
+            "49:4: " + getCheckMessage(MSG_UNUSED_TAG, "@param", "<P>"),
+            "51:1: " + getCheckMessage(MSG_MISSING_TAG, "@param <U>"),
+            "55:4: " + getCheckMessage(MSG_UNUSED_TAG, "@param", "region"),
         };
 
         verifyWithInlineConfigParser(
@@ -384,12 +384,12 @@ public class JavadocTypeCheckTest extends AbstractModuleTestSupport {
     @Test
     public void testJavadocTypeRecordParamDescriptionWithAngularTags() throws Exception {
         final String[] expected = {
-            "51:4: " + getCheckMessage(MSG_UNUSED_TAG, "@param", "<P>"),
-            "53:1: " + getCheckMessage(MSG_MISSING_TAG, "@param <U>"),
-            "57:4: " + getCheckMessage(MSG_UNUSED_TAG, "@param", "region"),
-            "60:1: " + getCheckMessage(MSG_MISSING_TAG, "@param a"),
-            "73:4: " + getCheckMessage(MSG_UNUSED_TAG, "@param", "e"),
-            "76:1: " + getCheckMessage(MSG_MISSING_TAG, "@param c"),
+            "56:4: " + getCheckMessage(MSG_UNUSED_TAG, "@param", "<P>"),
+            "58:1: " + getCheckMessage(MSG_MISSING_TAG, "@param <U>"),
+            "62:4: " + getCheckMessage(MSG_UNUSED_TAG, "@param", "region"),
+            "65:1: " + getCheckMessage(MSG_MISSING_TAG, "@param a"),
+            "78:4: " + getCheckMessage(MSG_UNUSED_TAG, "@param", "e"),
+            "81:1: " + getCheckMessage(MSG_MISSING_TAG, "@param c"),
         };
 
         verifyWithInlineConfigParser(
@@ -449,7 +449,7 @@ public class JavadocTypeCheckTest extends AbstractModuleTestSupport {
     @Test
     public void testAuthorFormat2() throws Exception {
         final String[] expected = {
-            "15:1: " + getCheckMessage(MSG_MISSING_TAG, "@author"),
+            "20:1: " + getCheckMessage(MSG_MISSING_TAG, "@author"),
         };
         verifyWithInlineConfigParser(
                 getPath("InputJavadocType2.java"), expected);
@@ -474,8 +474,8 @@ public class JavadocTypeCheckTest extends AbstractModuleTestSupport {
     @Test
     public void testJavadocTypeAboveComments() throws Exception {
         final String[] expected = {
-            "15:1: " + getCheckMessage(MSG_MISSING_TAG, "@author"),
-            "41:15: " + getCheckMessage(MSG_MISSING_TAG, "@author"),
+            "20:1: " + getCheckMessage(MSG_MISSING_TAG, "@author"),
+            "46:15: " + getCheckMessage(MSG_MISSING_TAG, "@author"),
         };
         verifyWithInlineConfigParser(
                 getPath("InputJavadocTypeAboveComments.java"), expected);

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadoctype/InputJavadocType2.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadoctype/InputJavadocType2.java
@@ -1,7 +1,12 @@
 /*
 JavadocType
+scope = (default)private
 excludeScope = public
 authorFormat = \S
+allowMissingParamTags = (default)false
+allowUnknownTags = (default)false
+allowedAnnotations = (default)Generated
+tokens = (default)INTERFACE_DEF, CLASS_DEF, ENUM_DEF, ANNOTATION_DEF, RECORD_DEF
 
 
 */

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadoctype/InputJavadocType4.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadoctype/InputJavadocType4.java
@@ -1,6 +1,11 @@
 /*
 JavadocType
+scope = (default)private
 authorFormat = \S
+allowMissingParamTags = (default)false
+allowUnknownTags = (default)false
+allowedAnnotations = (default)Generated
+tokens = (default)INTERFACE_DEF, CLASS_DEF, ENUM_DEF, ANNOTATION_DEF, RECORD_DEF
 
 
 */

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadoctype/InputJavadocTypeAboveComments.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadoctype/InputJavadocTypeAboveComments.java
@@ -1,6 +1,11 @@
 /*
 JavadocType
+scope = (default)private
 authorFormat = Mohamed Mahfouz
+allowMissingParamTags = (default)false
+allowUnknownTags = (default)false
+allowedAnnotations = (default)Generated
+tokens = (default)INTERFACE_DEF, CLASS_DEF, ENUM_DEF, ANNOTATION_DEF, RECORD_DEF
 
 
 */

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadoctype/InputJavadocTypeParamDescriptionWithAngularTags.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadoctype/InputJavadocTypeParamDescriptionWithAngularTags.java
@@ -1,5 +1,10 @@
 /*
 JavadocType
+scope = (default)private
+allowMissingParamTags = (default)false
+allowUnknownTags = (default)false
+allowedAnnotations = (default)Generated
+tokens = (default)INTERFACE_DEF, CLASS_DEF, ENUM_DEF, ANNOTATION_DEF, RECORD_DEF
 
 
 */

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadoctype/InputJavadocTypeRecordParamDescriptionWithAngularTags.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadoctype/InputJavadocTypeRecordParamDescriptionWithAngularTags.java
@@ -1,5 +1,10 @@
 /*
 JavadocType
+scope = (default)private
+allowMissingParamTags = (default)false
+allowUnknownTags = (default)false
+allowedAnnotations = (default)Generated
+tokens = (default)INTERFACE_DEF, CLASS_DEF, ENUM_DEF, ANNOTATION_DEF, RECORD_DEF
 
 
 */


### PR DESCRIPTION
Related: #16807 

Added missing default properties (allowMissingParamTags, allowUnknownTags,
allowedAnnotations, scope, tokens) to 5 input test files for
JavadocTypeCheck and updated corresponding violation line numbers in
JavadocTypeCheckTest. Removed JavadocTypeCheck from SUPPRESSED_MODULES
in InlineConfigParser.