### PR TITLE
Add arrayInitIndent example for IndentationCheck

### DIFF
--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/indentation/indentation/Example_ArrayInitIndent.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/indentation/indentation/Example_ArrayInitIndent.java
@@ -1,0 +1,51 @@
+package com.puppycrawl.tools.checkstyle.checks.indentation.indentation;            //indent:0 exp:0
+
+/**                                                                                //indent:0 exp:0
+ * This test-input is intended to be checked using following configuration:        //indent:1 exp:1
+ *                                                                                 //indent:1 exp:1
+ * arrayInitIndent = 4                                                             //indent:1 exp:1
+ * basicOffset = 4                                                                 //indent:1 exp:1
+ * braceAdjustment = 0                                                             //indent:1 exp:1
+ * caseIndent = 4                                                                  //indent:1 exp:1
+ * forceStrictCondition = false                                                    //indent:1 exp:1
+ * lineWrappingIndentation = 4                                                     //indent:1 exp:1
+ * tabWidth = 4                                                                    //indent:1 exp:1
+ * throwsIndent = 4                                                                //indent:1 exp:1
+ *                                                                                 //indent:1 exp:1
+ */                                                                                //indent:1 exp:1
+public class Example_ArrayInitIndent {                                             //indent:0 exp:0
+
+    // Example 1: Default arrayInitIndent (4) - correct                            //indent:4 exp:4
+    int[] defaultArr = {                                                           //indent:4 exp:4
+        1,                                                                         //indent:8 exp:8
+        2,                                                                         //indent:8 exp:8
+        3                                                                          //indent:8 exp:8
+    };                                                                             //indent:4 exp:4
+
+    // Example 2: Incorrect indentation - only 2 spaces instead of 4               //indent:4 exp:4
+    int[] wrongArr =                                                               //below indent:4 exp:4
+    {
+      1,                                                                           //indent:6 exp:8 warn
+      2                                                                            //indent:6 exp:8 warn
+    };                                                                             //indent:4 exp:4
+
+    // Example 3: Multi-dimensional array - correct                                //indent:4 exp:4
+    int[][] matrix = {                                                             //indent:4 exp:4
+        {                                                                          //indent:8 exp:8
+            1,                                                                     //indent:12 exp:12
+            2                                                                      //indent:12 exp:12
+        },                                                                         //indent:8 exp:8
+        {                                                                          //indent:8 exp:8
+            3,                                                                     //indent:12 exp:12
+            4                                                                      //indent:12 exp:12
+        }                                                                          //indent:8 exp:8
+    };                                                                             //indent:4 exp:4
+
+    void method() {                                                                //indent:4 exp:4
+        int[] localArr = {                                                         //indent:8 exp:8
+            10,                                                                    //indent:12 exp:12
+            20,                                                                    //indent:12 exp:12
+            30                                                                     //indent:12 exp:12
+        };                                                                         //indent:8 exp:8
+    }                                                                              //indent:4 exp:4
+}                                                                                  //indent:0 exp:0

--- a/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/indentation/indentation/Example_ArrayInitIndent.java
+++ b/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/indentation/indentation/Example_ArrayInitIndent.java
@@ -1,0 +1,46 @@
+/*xml
+<module name="Checker">
+  <module name="TreeWalker">
+    <module name="Indentation">
+      <property name="arrayInitIndent" value="4"/>
+    </module>
+  </module>
+</module>
+*/
+
+package com.puppycrawl.tools.checkstyle.checks.indentation.indentation;
+
+// xdoc section -- start
+public class Example_ArrayInitIndent {
+
+    // Example 1: Default arrayInitIndent (4) - correct
+    int[] defaultArr = {
+        1,
+        2,
+        3
+    };
+
+    // Example 2: Custom arrayInitIndent (e.g., 8)
+    // If arrayInitIndent is set to 8, this would be correct:
+    /*
+    int[] customArr = {
+            10,
+            20
+    };
+    */
+
+    // Example 3: Incorrect indentation - only 2 spaces instead of 4
+    int[] wrongArr = {
+      1, // violation, 'array initialization' child has incorrect indentation level 6, expected level should be 8
+      2
+    };
+
+    void method() {
+        int[] localArr = {
+            10,
+            20,
+            30
+        };
+    }
+}
+// xdoc section -- end


### PR DESCRIPTION
- Add dedicated example demonstrating arrayInitIndent property behavior
- Include default, custom, and incorrect indentation cases

This PR focuses only on example changes as suggested in the issue discussion.
Javadoc and tests will be submitted in a follow-up PR.

Fixes #19411