### PR TITLE
Issue #10969: Fix false positives for pattern variables in RequireThisCheck

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/RequireThisCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/RequireThisCheck.java
@@ -27,6 +27,7 @@ import java.util.HashSet;
 import java.util.Map;
 import java.util.Queue;
 import java.util.Set;
+import java.util.TreeSet;
 
 import javax.annotation.Nullable;
 
@@ -100,7 +101,9 @@ public class RequireThisCheck extends AbstractCheck {
         TokenTypes.TYPE_ARGUMENT,
         TokenTypes.RECORD_DEF,
         TokenTypes.RECORD_COMPONENT_DEF,
-        TokenTypes.RESOURCE
+        TokenTypes.RECORD_PATTERN_DEF,
+        TokenTypes.RESOURCE,
+        TokenTypes.PATTERN_VARIABLE_DEF
     );
     /** Set of all assign tokens. */
     private static final BitSet ASSIGN_TOKENS = TokenUtil.asBitSet(
@@ -384,8 +387,10 @@ public class RequireThisCheck extends AbstractCheck {
         if (!importOrPackage
                 && !typeName
                 && !DECLARATION_TOKENS.get(parentType)
-                && !isLambdaParameter(ast)) {
-            final AbstractFrame fieldFrame = findClassFrame(ast, LookMode.NO_LOOK_FOR_METHOD);
+                && !isLambdaParameter(ast)
+                && !isPatternVariableInScope(ast)) {
+            final AbstractFrame fieldFrame =
+                    findClassFrame(ast, LookMode.NO_LOOK_FOR_METHOD);
 
             if (fieldFrame != null && ((ClassFrame) fieldFrame).hasInstanceMember(ast)) {
                 frame = getClassFrameWhereViolationIsFound(ast);
@@ -1142,6 +1147,237 @@ public class RequireThisCheck extends AbstractCheck {
      */
     private static boolean isAstSimilar(DetailAST left, DetailAST right) {
         return left.getType() == right.getType() && left.getText().equals(right.getText());
+    }
+
+    /**
+     * Checks whether the given identifier is a pattern variable that is in scope
+     * at its current location.
+     *
+     * @param ident identifier token to check
+     * @return {@code true} if the identifier is a pattern variable in scope;
+     *         {@code false} otherwise
+     */
+    private static boolean isPatternVariableInScope(DetailAST ident) {
+        final Set<String> patternVariablesInScope = new HashSet<>();
+        DetailAST child = ident;
+
+        for (DetailAST parent = ident; parent != null;
+                parent = parent.getParent()) {
+            if (parent.getType() == TokenTypes.LAND
+                    && parent.getLastChild().equals(child)) {
+                patternVariablesInScope.addAll(
+                        getPatternVariablesIntroducedWhenTrue(parent.getFirstChild()));
+            }
+            else if (parent.getType() == TokenTypes.LOR
+                    && parent.getLastChild().equals(child)) {
+                patternVariablesInScope.addAll(
+                        getPatternVariablesIntroducedWhenFalse(parent.getFirstChild()));
+            }
+            else if (parent.getType() == TokenTypes.LITERAL_IF) {
+                final DetailAST condition = parent.findFirstToken(TokenTypes.EXPR);
+                final DetailAST thenStatement =
+                        parent.findFirstToken(TokenTypes.RPAREN).getNextSibling();
+                final DetailAST elseLiteral = parent.findFirstToken(TokenTypes.LITERAL_ELSE);
+
+                if (thenStatement.equals(child)) {
+                    patternVariablesInScope.addAll(
+                            getPatternVariablesInTrueBranch(condition));
+                }
+                else if (elseLiteral != null && elseLiteral.equals(child)) {
+                    patternVariablesInScope.addAll(
+                            getPatternVariablesInFalseBranch(condition));
+                }
+            }
+            child = parent;
+        }
+
+        return patternVariablesInScope.contains(ident.getText());
+    }
+
+    /**
+     * Gets the set of pattern variables that are guaranteed to be in scope when
+     * the given expression evaluates to {@code true}.
+     *
+     * @param ast expression AST node
+     * @return pattern variable names that are in scope in the true branch
+     */
+    private static Set<String> getPatternVariablesInTrueBranch(DetailAST ast) {
+        final Set<String> result = new HashSet<>();
+        final DetailAST expression = skipParentheses(ast);
+
+        switch (expression.getType()) {
+            case TokenTypes.EXPR ->
+                result.addAll(getPatternVariablesInTrueBranch(expression.getFirstChild()));
+            case TokenTypes.LNOT ->
+                result.addAll(getPatternVariablesInFalseBranch(expression.getFirstChild()));
+            case TokenTypes.LAND -> {
+                result.addAll(getPatternVariablesInTrueBranch(expression.getFirstChild()));
+                result.addAll(getPatternVariablesInTrueBranch(expression.getLastChild()));
+            }
+            case TokenTypes.LOR -> {
+                final Set<String> left =
+                        getPatternVariablesInTrueBranch(expression.getFirstChild());
+                final Set<String> right =
+                        getPatternVariablesInTrueBranch(expression.getLastChild());
+
+                left.retainAll(right);
+                result.addAll(left);
+            }
+            case TokenTypes.LITERAL_INSTANCEOF ->
+                result.addAll(getPatternVariablesDeclaredBy(expression));
+            default -> {
+                // no-op
+            }
+        }
+
+        return result;
+    }
+
+    /**
+     * Gets the set of pattern variables that are guaranteed to be in scope when
+     * the given expression evaluates to {@code false}.
+     *
+     * @param ast expression AST node
+     * @return pattern variable names that are in scope in the false branch
+     */
+    private static Set<String> getPatternVariablesInFalseBranch(DetailAST ast) {
+        final Set<String> result = new HashSet<>();
+        final DetailAST expression = skipParentheses(ast);
+
+        switch (expression.getType()) {
+            case TokenTypes.EXPR ->
+                result.addAll(getPatternVariablesInFalseBranch(expression.getFirstChild()));
+            case TokenTypes.LNOT ->
+                result.addAll(getPatternVariablesInTrueBranch(expression.getFirstChild()));
+            case TokenTypes.LAND -> {
+                final Set<String> left =
+                        getPatternVariablesInFalseBranch(expression.getFirstChild());
+                final Set<String> right =
+                        getPatternVariablesInFalseBranch(expression.getLastChild());
+
+                left.retainAll(right);
+                result.addAll(left);
+            }
+            case TokenTypes.LOR -> {
+                result.addAll(getPatternVariablesInFalseBranch(expression.getFirstChild()));
+                result.addAll(getPatternVariablesInFalseBranch(expression.getLastChild()));
+            }
+            default -> {
+                // no-op
+            }
+        }
+
+        return result;
+    }
+
+    /**
+     * Skips parenthesis tokens surrounding an expression.
+     *
+     * @param ast first token of an expression
+     * @return expression token inside the parentheses
+     */
+    private static DetailAST skipParentheses(DetailAST ast) {
+        DetailAST result = ast;
+
+        while (result.getType() == TokenTypes.LPAREN
+                || result.getType() == TokenTypes.RPAREN) {
+            if (result.getType() == TokenTypes.LPAREN) {
+                result = result.getNextSibling();
+            }
+            else {
+                result = result.getPreviousSibling();
+            }
+        }
+
+        return result;
+    }
+
+    /**
+     * Gets pattern variables introduced by the given expression when that
+     * expression evaluates to {@code true}.
+     *
+     * @param ast expression AST node
+     * @return pattern variable names introduced when the expression is true
+     */
+    private static Set<String> getPatternVariablesIntroducedWhenTrue(DetailAST ast) {
+        final Set<String> result = new HashSet<>();
+        final DetailAST expression = skipParentheses(ast);
+
+        switch (expression.getType()) {
+            case TokenTypes.LNOT ->
+                result.addAll(getPatternVariablesIntroducedWhenFalse(
+                        expression.getFirstChild()));
+            case TokenTypes.LAND -> {
+                result.addAll(getPatternVariablesIntroducedWhenTrue(
+                        expression.getFirstChild()));
+                result.addAll(getPatternVariablesIntroducedWhenTrue(
+                        expression.getLastChild()));
+            }
+            case TokenTypes.LITERAL_INSTANCEOF ->
+                result.addAll(getPatternVariablesDeclaredBy(expression));
+            default -> {
+                // no-op
+            }
+        }
+
+        return result;
+    }
+
+    /**
+     * Gets pattern variables introduced by the given expression when that
+     * expression evaluates to {@code false}.
+     *
+     * @param ast expression AST node
+     * @return pattern variable names introduced when the expression is false
+     */
+    private static Set<String> getPatternVariablesIntroducedWhenFalse(DetailAST ast) {
+        final Set<String> result = new HashSet<>();
+        final DetailAST expression = skipParentheses(ast);
+
+        switch (expression.getType()) {
+            case TokenTypes.LNOT ->
+                result.addAll(getPatternVariablesIntroducedWhenTrue(
+                        expression.getFirstChild()));
+            case TokenTypes.LOR -> {
+                result.addAll(getPatternVariablesIntroducedWhenFalse(
+                        expression.getFirstChild()));
+                result.addAll(getPatternVariablesIntroducedWhenFalse(
+                        expression.getLastChild()));
+            }
+            default -> {
+                // no-op
+            }
+        }
+
+        return result;
+    }
+
+    /**
+     * Gets pattern variables declared by an instanceof pattern.
+     *
+     * @param ast instanceof token
+     * @return declared pattern variable names
+     */
+    private static Set<String> getPatternVariablesDeclaredBy(DetailAST ast) {
+        final Set<String> result = new TreeSet<>();
+        final Set<DetailAST> patternVariables =
+                getAllTokensOfType(ast, TokenTypes.PATTERN_VARIABLE_DEF);
+        final Set<DetailAST> recordPatterns =
+                getAllTokensOfType(ast, TokenTypes.RECORD_PATTERN_DEF);
+
+        for (DetailAST patternVariable : patternVariables) {
+            final DetailAST ident = patternVariable.findFirstToken(TokenTypes.IDENT);
+            result.add(ident.getText());
+        }
+
+        for (DetailAST recordPattern : recordPatterns) {
+            final DetailAST bindingVariable = recordPattern.findFirstToken(TokenTypes.IDENT);
+            if (bindingVariable != null) {
+                result.add(bindingVariable.getText());
+            }
+        }
+
+        return result;
     }
 
     /** An AbstractFrame type. */

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/coding/RequireThisCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/coding/RequireThisCheckTest.java
@@ -721,4 +721,60 @@ public class RequireThisCheckTest extends AbstractModuleTestSupport {
                 getPath("InputRequireThisAnnotationOverlappingTrue.java"), expected);
     }
 
+    /**
+     * Verifies that pattern variables in scope are not treated as instance fields,
+     * while actual instance field references are still reported.
+     *
+     * @throws Exception when code tested throws exception
+     */
+    @Test
+    public void testPatternVariables() throws Exception {
+        final String[] expected = {
+            "25:13: " + getCheckMessage(MSG_VARIABLE, "p", ""),
+            "29:13: " + getCheckMessage(MSG_VARIABLE, "s", ""),
+            "30:13: " + getCheckMessage(MSG_VARIABLE, "n", ""),
+            "42:45: " + getCheckMessage(MSG_VARIABLE, "p", ""),
+            "43:13: " + getCheckMessage(MSG_VARIABLE, "p", ""),
+            "51:34: " + getCheckMessage(MSG_VARIABLE, "p", ""),
+            "52:13: " + getCheckMessage(MSG_VARIABLE, "p", ""),
+            "75:14: " + getCheckMessage(MSG_VARIABLE, "p", ""),
+            "80:14: " + getCheckMessage(MSG_VARIABLE, "s", ""),
+            "102:23: " + getCheckMessage(MSG_VARIABLE, "p", ""),
+            "106:24: " + getCheckMessage(MSG_VARIABLE, "s", ""),
+            "112:13: " + getCheckMessage(MSG_VARIABLE, "p", ""),
+        };
+
+        verifyWithInlineConfigParser(
+                getPath("InputRequireThisPatternVariables.java"),
+                expected);
+    }
+
+    @Test
+    public void testPatternVariablesRecordPattern() throws Exception {
+        final String[] expected = {
+            "21:13: " + getCheckMessage(MSG_VARIABLE, "s", ""),
+            "22:13: " + getCheckMessage(MSG_VARIABLE, "x", ""),
+            "23:13: " + getCheckMessage(MSG_VARIABLE, "z", ""),
+        };
+
+        verifyWithInlineConfigParser(
+                getPath("InputRequireThisPatternVariablesRecordPattern.java"),
+                expected);
+    }
+
+    @Test
+    public void testPatternVariablesRecordPatternBinding() throws Exception {
+        final String[] expected = {
+            "27:13: " + getCheckMessage(MSG_VARIABLE, "component", ""),
+            "28:13: " + getCheckMessage(MSG_VARIABLE, "binding", ""),
+            "42:32: " + getCheckMessage(MSG_VARIABLE, "binding", ""),
+            "53:32: " + getCheckMessage(MSG_VARIABLE, "binding", ""),
+        };
+
+        verifyWithInlineConfigParser(
+                getNonCompilablePath(
+                        "InputRequireThisPatternVariablesRecordPatternBinding.java"),
+                expected);
+    }
+
 }

--- a/src/test/resources-noncompilable/com/puppycrawl/tools/checkstyle/checks/coding/requirethis/InputRequireThisPatternVariablesRecordPatternBinding.java
+++ b/src/test/resources-noncompilable/com/puppycrawl/tools/checkstyle/checks/coding/requirethis/InputRequireThisPatternVariablesRecordPatternBinding.java
@@ -1,0 +1,56 @@
+/*
+RequireThis
+checkFields = (default)true
+checkMethods = (default)true
+validateOnlyOverlapping = false
+
+
+*/
+
+// non-compiled with javac: Compilable with Java19
+// Named record patterns were removed in Java 20, see https://openjdk.org/jeps/432.
+package com.puppycrawl.tools.checkstyle.checks.coding.requirethis;
+
+public class InputRequireThisPatternVariablesRecordPatternBinding {
+    private String component;
+    private String binding;
+
+    record R(String component) { }
+    record Empty() { }
+
+    public void test(Object value) {
+        if (value instanceof R(String component) binding) {
+            System.out.println(component);
+            System.out.println(binding);
+        }
+        else {
+            component = "field"; // violation '.*variable 'component'.*'
+            binding = "field"; // violation '.*variable 'binding'.*'
+        }
+    }
+
+    public void testEmptyRecordPattern(Object value) {
+        if (value instanceof Empty() component) {
+            System.out.println(component);
+        }
+    }
+
+    public void testTrueBranchIntersection(Object first, Object second, Object third) {
+        if ((first instanceof String component && second instanceof String binding)
+                || third instanceof String component) {
+            System.out.println(component);
+            System.out.println(binding); // violation '.*variable 'binding'.*'
+        }
+    }
+
+    public void testFalseBranchIntersection(Object first, Object second, Object third) {
+        if ((!(first instanceof String component) || !(second instanceof String binding))
+                && !(third instanceof String component)) {
+            System.out.println();
+        }
+        else {
+            System.out.println(component);
+            System.out.println(binding); // violation '.*variable 'binding'.*'
+        }
+    }
+}

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/requirethis/InputRequireThisPatternVariables.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/requirethis/InputRequireThisPatternVariables.java
@@ -1,0 +1,120 @@
+/*
+RequireThis
+checkFields = (default)true
+checkMethods = (default)true
+validateOnlyOverlapping = false
+
+
+*/
+
+package com.puppycrawl.tools.checkstyle.checks.coding.requirethis;
+
+public class InputRequireThisPatternVariables {
+    String p;
+    String s;
+    String n;
+
+    public void run(String... arguments) {
+        this.p = null;
+        this.s = null;
+        this.n = null;
+
+        Object o = 45;
+        if (!(o instanceof String p && p.equals("sd"))
+            || !p.equals("wq")) {
+            p = "a"; // violation 'Reference to instance variable 'p' needs "this."\.'
+        }
+        else if (!(o instanceof Integer s && o instanceof String n)) {
+            p = "b";
+            s = "b"; // violation 'Reference to instance variable 's' needs "this."\.'
+            n = "b"; // violation 'Reference to instance variable 'n' needs "this."\.'
+        }
+        else {
+            p = "c";
+            s = 41;
+            n = "c";
+        }
+
+        System.out.println(this.p + ":" + this.s + ":" + this.n);
+    }
+
+    public void testLogicalAnd(Object value) {
+        if (!(value instanceof String p) && p.isEmpty()) { // violation '.*variable 'p'.*'
+            p = "field"; // violation 'Reference to instance variable 'p' needs "this."\.'
+        }
+        if (value instanceof String p && !p.isEmpty() && p.length() > 1) {
+            System.out.println(p);
+        }
+    }
+
+    public void testLogicalOr(boolean first, boolean second) {
+        if (!first || !second || p.isEmpty()) { // violation '.*variable 'p'.*'
+            p = "field"; // violation 'Reference to instance variable 'p' needs "this."\.'
+        }
+    }
+
+    public void testNestedLogicalAnd(Object first, Object second) {
+        if (first instanceof String p
+                && second instanceof String s
+                && !p.isEmpty()
+                && !s.isEmpty()) {
+            System.out.println(p + s);
+        }
+    }
+
+    public void testNestedLogicalOr(Object first, Object second) {
+        if (!(first instanceof String p)
+                || !(second instanceof String s)
+                || p.isEmpty()
+                || s.isEmpty()) {
+            System.out.println();
+        }
+    }
+
+    public void testScopeBeforePattern(Object value) {
+        if ((p.isEmpty() && value instanceof String p) // violation '.*variable 'p'.*'
+                && p.length() > 1) {
+            System.out.println(p);
+        }
+
+        if ((s.isEmpty() || !(value instanceof String s)) // violation '.*variable 's'.*'
+                || s.isEmpty()) {
+            System.out.println();
+        }
+    }
+
+    public void testDoubleNegation(Object value) {
+        if (!!(value instanceof String p) && !p.isEmpty()) {
+            System.out.println(p);
+        }
+    }
+
+    public void testFalseBranchLogicalOr(Object first, Object second) {
+        if (!(first instanceof String p) || !(second instanceof String s)) {
+            System.out.println();
+        }
+        else {
+            System.out.println(p + s);
+        }
+    }
+
+    public void testNestedLastOperands(Object first, Object second) {
+        if (true && !(p.isEmpty() || !(first instanceof String p)) // violation
+                && (second instanceof String s)) {
+            System.out.println(p + s);
+        }
+        if (false || !(s.isEmpty() && second instanceof String s)) { // violation
+            System.out.println();
+        }
+    }
+
+    public void testFieldBeforePatternWithElse(Object value) {
+        if (p.isEmpty() // violation '.*variable 'p'.*'
+                || !(value instanceof String p)) {
+            System.out.println();
+        }
+        else {
+            System.out.println(p);
+        }
+    }
+}

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/requirethis/InputRequireThisPatternVariablesRecordPattern.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/requirethis/InputRequireThisPatternVariablesRecordPattern.java
@@ -1,0 +1,31 @@
+/*
+RequireThis
+checkFields = (default)true
+checkMethods = (default)true
+validateOnlyOverlapping = false
+
+
+*/
+
+package com.puppycrawl.tools.checkstyle.checks.coding.requirethis;
+
+public class InputRequireThisPatternVariablesRecordPattern {
+    private String s;
+    private int x;
+    private int z;
+
+    record R(String s, int x, int z) { }
+
+    public void test(Object obj) {
+        if (!(obj instanceof R(String s, int x, int z))) {
+            s = "a"; // violation 'Reference to instance variable 's' needs "this."\.'
+            x = 1; // violation 'Reference to instance variable 'x' needs "this."\.'
+            z = 2; // violation 'Reference to instance variable 'z' needs "this."\.'
+        }
+        else {
+            s = "b";
+            x = 3;
+            z = 4;
+        }
+    }
+}


### PR DESCRIPTION
Issue: #10969

Cause:
RequireThisCheck could still treat references to pattern variables as
instance field accesses in boolean expressions and if/else branches,
which caused false positives for missing `this.`

Fix:
Update RequireThisCheck to respect pattern variable scope when resolving
unqualified references, so pattern variables are not reported as
instance members

Tests:
Added regression tests for the reported case