### PR TITLE
supplemental: fix PreferJavadocInlineTags violations in codebase

### DIFF
--- a/config/suppressions.xml
+++ b/config/suppressions.xml
@@ -194,4 +194,7 @@
             id="MatchXpathForbidTryCatchFail"
             files=".*[\\/]src[\\/]test[\\/]java[\\/]com[\\/]puppycrawl[\\/]tools[\\/]checkstyle[\\/](?!utils|xpath|checks[\\/]coding|checks[\\/]design|checks[\\/]modifier|checks[\\/]naming|checks[\\/]annotation|checks[\\/]indentation|checks[\\/]metrics|checks[\\/]whitespace|checks[\\/]javadoc|checks[\\/]NewlineAtEndOfFileCheckTest|checks[\\/]SuppressWarningsHolderTest|checks[\\/]UncommentedMainCheckTest|CheckerTest|ConfigurationLoaderTest|DetailNodeTreeStringPrinterTest|JavadocPropertiesGeneratorTest|MainTest|PackageNamesLoaderTest|SarifLoggerTest|SuppressionsStringPrinterTest|ThreadModeSettingsTest|TreeWalkerTest).*"/>
 
+  <!-- JavadocStyle incorrectly parses HTML tags inside {@literal}, {@code} blocks as real HTML,
+          until #19145 -->
+  <suppress checks="JavadocStyle" files="JavadocParagraphCheck\.java"/>
 </suppressions>

--- a/src/main/java/com/puppycrawl/tools/checkstyle/JavaAstVisitor.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/JavaAstVisitor.java
@@ -2084,7 +2084,7 @@ public final class JavaAstVisitor extends JavaLanguageParserBaseVisitor<DetailAs
 
     /**
      * Create a DetailAstImpl from a given token and token type. This method
-     * should be used for imaginary nodes only, i.e. 'OBJBLOCK -&gt; OBJBLOCK',
+     * should be used for imaginary nodes only, i.e. {@literal 'OBJBLOCK -> OBJBLOCK'},
      * where the text on the RHS matches the text on the LHS.
      *
      * @param tokenType the token type of this DetailAstImpl
@@ -2099,7 +2099,7 @@ public final class JavaAstVisitor extends JavaLanguageParserBaseVisitor<DetailAs
 
     /**
      * Create a DetailAstImpl from a given token and token type. This method
-     * should be used for literal nodes only, i.e. 'PACKAGE_DEF -&gt; package'.
+     * should be used for literal nodes only, i.e. {@literal 'PACKAGE_DEF -> package'}.
      *
      * @param tokenType the token type of this DetailAstImpl
      * @param startToken the first token that appears in this DetailAstImpl.

--- a/src/main/java/com/puppycrawl/tools/checkstyle/JavadocCommentsAstVisitor.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/JavadocCommentsAstVisitor.java
@@ -685,8 +685,8 @@ public class JavadocCommentsAstVisitor extends JavadocCommentsParserBaseVisitor<
     }
 
     /**
-     * Create a JavadocNodeImpl from a given token and token type. This method
-     * should be used for imaginary nodes only, i.e. 'JAVADOC_INLINE_TAG -&gt; JAVADOC_INLINE_TAG',
+     * Create a JavadocNodeImpl from a given token and token type. This method should be used for
+     * imaginary nodes only, i.e. {@literal 'JAVADOC_INLINE_TAG -> JAVADOC_INLINE_TAG'},
      * where the text on the RHS matches the text on the LHS.
      *
      * @param tokenType the token type of this JavadocNodeImpl

--- a/src/main/java/com/puppycrawl/tools/checkstyle/XMLLogger.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/XMLLogger.java
@@ -257,7 +257,7 @@ public final class XMLLogger
     }
 
     /**
-     * Escape &lt;, &gt; &amp; &#39; and &quot; as their entities.
+     * Escape {@literal <}, {@literal >} &amp; &#39; and &quot; as their entities.
      *
      * @param value the value to escape.
      * @return the escaped value if necessary.

--- a/src/main/java/com/puppycrawl/tools/checkstyle/api/TokenTypes.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/api/TokenTypes.java
@@ -1866,7 +1866,7 @@ public final class TokenTypes {
      **/
     public static final int IDENT = JavaLanguageLexer.IDENT;
     /**
-     * The <code>&#46;</code> (dot) operator.
+     * The {@code .} (dot) operator.
      *
      * <p>For example:</p>
      * <pre>
@@ -1884,9 +1884,6 @@ public final class TokenTypes {
      * </pre>
      *
      * @see FullIdent
-     * @noinspection HtmlTagCanBeJavadocTag
-     * @noinspectionreason HtmlTagCanBeJavadocTag - encoded symbols were not decoded
-     *      when replaced with Javadoc tag
      **/
     public static final int DOT = JavaLanguageLexer.DOT;
     /**
@@ -3680,7 +3677,7 @@ public final class TokenTypes {
      **/
     public static final int BOR_ASSIGN = JavaLanguageLexer.BOR_ASSIGN;
     /**
-     * The <code>&#63;</code> (conditional) operator.  Technically,
+     * The {@code ?} (conditional) operator.  Technically,
      * the colon is also part of this operator, but it appears as a
      * separate token.
      *
@@ -3715,9 +3712,6 @@ public final class TokenTypes {
      *     Language Specification, &sect;15.25</a>
      * @see #EXPR
      * @see #COLON
-     * @noinspection HtmlTagCanBeJavadocTag
-     * @noinspectionreason HtmlTagCanBeJavadocTag - encoded symbols were not decoded
-     *      when replaced with Javadoc tag
      **/
     public static final int QUESTION = JavaLanguageLexer.QUESTION;
     /**
@@ -3838,7 +3832,7 @@ public final class TokenTypes {
      **/
     public static final int BAND = JavaLanguageLexer.BAND;
     /**
-     * The <code>&#33;=</code> (not equal) operator.
+     * The {@code !=} (not equal) operator.
      *
      * <p>For example:</p>
      * <pre>
@@ -3855,9 +3849,6 @@ public final class TokenTypes {
      * </pre>
      *
      * @see #EXPR
-     * @noinspection HtmlTagCanBeJavadocTag
-     * @noinspectionreason HtmlTagCanBeJavadocTag - encoded symbols were not decoded
-     *      when replaced with Javadoc tag
      **/
     public static final int NOT_EQUAL = JavaLanguageLexer.NOT_EQUAL;
     /**
@@ -4272,7 +4263,7 @@ public final class TokenTypes {
      **/
     public static final int BNOT = JavaLanguageLexer.BNOT;
     /**
-     * The <code>&#33;</code> (logical complement) operator.
+     * The {@code !} (logical complement) operator.
      *
      * <p>For example:</p>
      * <pre>
@@ -4293,9 +4284,6 @@ public final class TokenTypes {
      *     href="https://docs.oracle.com/javase/specs/jls/se8/html/jls-15.html#jls-15.15.6">Java
      *     Language Specification, &sect;15.15.6</a>
      * @see #EXPR
-     * @noinspection HtmlTagCanBeJavadocTag
-     * @noinspectionreason HtmlTagCanBeJavadocTag - encoded symbols were not decoded
-     *      when replaced with Javadoc tag
      **/
     public static final int LNOT = JavaLanguageLexer.LNOT;
     /**

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/StringLiteralEqualityCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/StringLiteralEqualityCheck.java
@@ -26,9 +26,9 @@ import com.puppycrawl.tools.checkstyle.api.TokenTypes;
 
 /**
  * <div>
- * Checks that string literals are not used with <code>==</code> or <code>&#33;=</code>.
- * Since <code>==</code> will compare the object references, not the actual value of the strings,
- * <code>String.equals()</code> should be used.
+ * Checks that string literals are not used with {@code ==} or {@code !=}.
+ * Since {@code ==} will compare the object references, not the actual value of the strings,
+ * {@code String.equals()} should be used.
  * More information can be found
  * <a href="https://stackoverflow.com/questions/513832/how-do-i-compare-strings-in-java/">
  * in this article</a>.
@@ -49,9 +49,6 @@ import com.puppycrawl.tools.checkstyle.api.TokenTypes;
  * </code></pre></div>
  *
  * @since 3.2
- * @noinspection HtmlTagCanBeJavadocTag
- * @noinspectionreason HtmlTagCanBeJavadocTag - encoded symbols were not decoded
- *      when replaced with Javadoc tag
  */
 @StatelessCheck
 public class StringLiteralEqualityCheck extends AbstractCheck {

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/HtmlTag.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/HtmlTag.java
@@ -94,7 +94,7 @@ public class HtmlTag {
     }
 
     /**
-     * Indicates if this tag is incomplete (has no close &gt;).
+     * Indicates if this tag is incomplete (has no close {@literal >}).
      *
      * @return {@code true} if the tag is incomplete.
      */

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocParagraphCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocParagraphCheck.java
@@ -39,16 +39,17 @@ import com.puppycrawl.tools.checkstyle.utils.JavadocUtil;
  * </p>
  * <ul>
  * <li>There is one blank line between each of two paragraphs.</li>
- * <li>Each paragraph but the first has &lt;p&gt; immediately
+ * <li>Each paragraph but the first has {@literal <p>} immediately
  * before the first word, with no space after.</li>
  * <li>The outer most paragraph tags should not precede
  * <a href="https://www.w3schools.com/html/html_blocks.asp">HTML block-tag</a>.
  * Nested paragraph tags are allowed to do that. This check only supports following block-tags:
- * &lt;address&gt;,&lt;blockquote&gt;
- * ,&lt;div&gt;,&lt;dl&gt;
- * ,&lt;h1&gt;,&lt;h2&gt;,&lt;h3&gt;,&lt;h4&gt;,&lt;h5&gt;,&lt;h6&gt;,&lt;hr&gt;
- * ,&lt;ol&gt;,&lt;p&gt;,&lt;pre&gt;
- * ,&lt;table&gt;,&lt;ul&gt;.
+ * {@literal <address>},{@literal <blockquote>}
+ * ,{@literal <div>},{@literal <dl>}
+ * ,{@literal <h1>},{@literal <h2>},{@literal <h3>},{@literal <h4>},{@literal <h5>},
+ * {@literal <h6>},{@literal <hr>}
+ * ,{@literal <ol>},{@literal <p>},{@literal <pre>}
+ * ,{@literal <table>},{@literal <ul>}.
  * </li>
  * </ul>
  *
@@ -109,12 +110,12 @@ public class JavadocParagraphCheck extends AbstractJavadocCheck {
                    "ol", PARAGRAPH_TAG, "pre", "table", "ul");
 
     /**
-     * Control whether the &lt;p&gt; tag should be placed immediately before the first word.
+     * Control whether the {@literal <p>} tag should be placed immediately before the first word.
      */
     private boolean allowNewlineParagraph = true;
 
     /**
-     * Setter to control whether the &lt;p&gt; tag should be placed
+     * Setter to control whether the {@literal <p>} tag should be placed
      * immediately before the first word.
      *
      * @param value value to set.

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/metrics/AbstractClassCouplingCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/metrics/AbstractClassCouplingCheck.java
@@ -90,7 +90,7 @@ public abstract class AbstractClassCouplingCheck extends AbstractCheck {
     /** Specify user-configured regular expressions to ignore classes. */
     private final List<Pattern> excludeClassesRegexps = new ArrayList<>();
 
-    /** A map of (imported class name -&gt; class name with package) pairs. */
+    /** A map of {@literal (imported class name -> class name with package)} pairs. */
     private final Map<String, String> importedClassPackages = new HashMap<>();
 
     /** Stack of class contexts. */

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/whitespace/GenericWhitespaceCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/whitespace/GenericWhitespaceCheck.java
@@ -31,7 +31,7 @@ import com.puppycrawl.tools.checkstyle.utils.CommonUtil;
 /**
  * <div>
  * Checks that the whitespace around the Generic tokens (angle brackets)
- * "&lt;" and "&gt;" are correct to the <i>typical</i> convention.
+ * "{@literal <}" and "{@literal >}" are correct to the <i>typical</i> convention.
  * The convention is not configurable.
  * </div>
  *
@@ -41,7 +41,7 @@ import com.puppycrawl.tools.checkstyle.utils.CommonUtil;
  * </p>
  *
  * <p>
- * Left angle bracket ("&lt;"):
+ * Left angle bracket ("{@literal <}"):
  * </p>
  * <ul>
  * <li> should be preceded with whitespace only
@@ -53,7 +53,7 @@ import com.puppycrawl.tools.checkstyle.utils.CommonUtil;
  * </ul>
  *
  * <p>
- * Right angle bracket ("&gt;"):
+ * Right angle bracket ("{@literal >}"):
  * </p>
  * <ul>
  * <li> should not be preceded with whitespace in all cases.</li>
@@ -281,11 +281,11 @@ public class GenericWhitespaceCheck extends AbstractCheck {
     }
 
     /**
-     * Checks if current generic end ('&gt;') is located after
+     * Checks if current generic end ('{@literal >}') is located after
      * {@link TokenTypes#METHOD_REF method reference operator}.
      *
      * @param genericEnd {@link TokenTypes#GENERIC_END}
-     * @return true if '&gt;' follows after method reference.
+     * @return true if '{@literal >}' follows after method reference.
      */
     private static boolean isAfterMethodReference(DetailAST genericEnd) {
         return genericEnd.getParent().getParent().getType() == TokenTypes.METHOD_REF;

--- a/src/main/java/com/puppycrawl/tools/checkstyle/filters/SuppressionsLoader.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/filters/SuppressionsLoader.java
@@ -165,7 +165,7 @@ public final class SuppressionsLoader
     /**
      * Returns the suppress element, initialized from given attributes.
      *
-     * @param attributes the attributes of xml-tag "&lt;suppress&gt;&lt;/suppress&gt;",
+     * @param attributes the attributes of xml-tag {@literal "<suppress></suppress>"},
      *                   specified inside suppression file.
      * @return the suppress element
      * @throws SAXException if an error occurs.
@@ -196,7 +196,7 @@ public final class SuppressionsLoader
     /**
      * Returns the xpath filter, initialized from given attributes.
      *
-     * @param attributes the attributes of xml-tag "&lt;suppress-xpath&gt;&lt;/suppress-xpath&gt;",
+     * @param attributes the attributes of xml-tag {@literal "<suppress-xpath></suppress-xpath>"},
      *                   specified inside suppression file.
      * @return the xpath filter
      * @throws SAXException if an error occurs.

--- a/src/main/java/com/puppycrawl/tools/checkstyle/xpath/XpathQueryGenerator.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/xpath/XpathQueryGenerator.java
@@ -337,7 +337,7 @@ public class XpathQueryGenerator {
     }
 
     /**
-     * Escape &lt;, &gt;, &amp;, &#39; and &quot; as their entities.
+     * Escape {@literal <}, {@literal >}, &amp;, &#39; and &quot; as their entities.
      * Custom method for Xpath generation to maintain compatibility
      * with Saxon and encoding outside Ascii range characters.
      *

--- a/src/main/resources/com/puppycrawl/tools/checkstyle/meta/checks/coding/StringLiteralEqualityCheck.xml
+++ b/src/main/resources/com/puppycrawl/tools/checkstyle/meta/checks/coding/StringLiteralEqualityCheck.xml
@@ -5,7 +5,7 @@
              name="StringLiteralEquality"
              parent="com.puppycrawl.tools.checkstyle.TreeWalker">
          <description>&lt;div&gt;
- Checks that string literals are not used with &lt;code&gt;==&lt;/code&gt; or &lt;code&gt;&amp;#33;=&lt;/code&gt;.
+ Checks that string literals are not used with &lt;code&gt;==&lt;/code&gt; or &lt;code&gt;!=&lt;/code&gt;.
  Since &lt;code&gt;==&lt;/code&gt; will compare the object references, not the actual value of the strings,
  &lt;code&gt;String.equals()&lt;/code&gt; should be used.
  More information can be found

--- a/src/main/resources/com/puppycrawl/tools/checkstyle/meta/checks/javadoc/JavadocParagraphCheck.xml
+++ b/src/main/resources/com/puppycrawl/tools/checkstyle/meta/checks/javadoc/JavadocParagraphCheck.xml
@@ -20,7 +20,8 @@
  Nested paragraph tags are allowed to do that. This check only supports following block-tags:
  &amp;lt;address&amp;gt;,&amp;lt;blockquote&amp;gt;
  ,&amp;lt;div&amp;gt;,&amp;lt;dl&amp;gt;
- ,&amp;lt;h1&amp;gt;,&amp;lt;h2&amp;gt;,&amp;lt;h3&amp;gt;,&amp;lt;h4&amp;gt;,&amp;lt;h5&amp;gt;,&amp;lt;h6&amp;gt;,&amp;lt;hr&amp;gt;
+ ,&amp;lt;h1&amp;gt;,&amp;lt;h2&amp;gt;,&amp;lt;h3&amp;gt;,&amp;lt;h4&amp;gt;,&amp;lt;h5&amp;gt;,
+ &amp;lt;h6&amp;gt;,&amp;lt;hr&amp;gt;
  ,&amp;lt;ol&amp;gt;,&amp;lt;p&amp;gt;,&amp;lt;pre&amp;gt;
  ,&amp;lt;table&amp;gt;,&amp;lt;ul&amp;gt;.
  &lt;/li&gt;

--- a/src/site/xdoc/checks.xml
+++ b/src/site/xdoc/checks.xml
@@ -1800,7 +1800,7 @@
               </a>
             </td>
             <td>
-              Checks that string literals are not used with <code>==</code> or <code>&#33;=</code>.
+              Checks that string literals are not used with <code>==</code> or <code>!=</code>.
             </td>
           </tr>
           <tr>

--- a/src/site/xdoc/checks/coding/index.xml
+++ b/src/site/xdoc/checks/coding/index.xml
@@ -504,7 +504,7 @@
               </a>
             </td>
             <td>
-              Checks that string literals are not used with <code>==</code> or <code>&#33;=</code>.
+              Checks that string literals are not used with <code>==</code> or <code>!=</code>.
             </td>
           </tr>
           <tr>

--- a/src/site/xdoc/checks/coding/stringliteralequality.xml
+++ b/src/site/xdoc/checks/coding/stringliteralequality.xml
@@ -10,7 +10,7 @@
       <p>Since Checkstyle 3.2</p>
       <subsection name="Description" id="StringLiteralEquality_Description">
         <div>
-          Checks that string literals are not used with <code>==</code> or <code>&#33;=</code>.
+          Checks that string literals are not used with <code>==</code> or <code>!=</code>.
           Since <code>==</code> will compare the object references, not the actual value of the strings,
           <code>String.equals()</code> should be used.
           More information can be found

--- a/src/site/xdoc/checks/javadoc/javadocparagraph.xml
+++ b/src/site/xdoc/checks/javadoc/javadocparagraph.xml
@@ -25,7 +25,8 @@
           Nested paragraph tags are allowed to do that. This check only supports following block-tags:
           &lt;address&gt;,&lt;blockquote&gt;
           ,&lt;div&gt;,&lt;dl&gt;
-          ,&lt;h1&gt;,&lt;h2&gt;,&lt;h3&gt;,&lt;h4&gt;,&lt;h5&gt;,&lt;h6&gt;,&lt;hr&gt;
+          ,&lt;h1&gt;,&lt;h2&gt;,&lt;h3&gt;,&lt;h4&gt;,&lt;h5&gt;,
+          &lt;h6&gt;,&lt;hr&gt;
           ,&lt;ol&gt;,&lt;p&gt;,&lt;pre&gt;
           ,&lt;table&gt;,&lt;ul&gt;.
         </li>

--- a/src/test/java/com/puppycrawl/tools/checkstyle/internal/XdocsCategoryIndexTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/internal/XdocsCategoryIndexTest.java
@@ -148,13 +148,13 @@ public class XdocsCategoryIndexTest extends AbstractModuleTestSupport {
 
     /**
      * Extracts the main section name from a check's XDoc file.
-     * This is typically the value of the 'name' attribute of the first &lt;section&gt; tag.
+     * This is typically the value of the 'name' attribute of the first {@literal <section>} tag.
      *
      * @param checkXdocFile Path to the check's XDoc file.
      * @return The main section name.
      * @throws ParserConfigurationException if a DocumentBuilder cannot be created.
      * @throws IOException if an I/O error occurs reading the file.
-     * @throws AssertionError if no &lt;section name=...&gt; is found.
+     * @throws AssertionError if no {@literal <section name=...>} is found.
      */
     private static String getMainSectionName(Path checkXdocFile)
             throws ParserConfigurationException, IOException {
@@ -177,8 +177,8 @@ public class XdocsCategoryIndexTest extends AbstractModuleTestSupport {
 
     /**
      * Extracts the description of a check from its XDoc file.
-     * It looks for a &lt;subsection name="Description"&gt; and then tries to find the content
-     * within a &lt;div&gt; or &lt;p&gt; tag.
+     * It looks for a {@literal <subsection name="Description">} and then tries to find the content
+     * within a {@literal <div>} or {@literal <p>} tag.
      * If not found, it aggregates direct text nodes of the subsection.
      * As a last resort, it uses the full text content of the subsection.
      *
@@ -302,11 +302,11 @@ public class XdocsCategoryIndexTest extends AbstractModuleTestSupport {
      * It iterates through all tables and their rows to find check names, hrefs, and descriptions.
      *
      * @param categoryIndexFile Path to the category's index.xml file.
-     * @return A map with check names (from &lt;a&gt; tag text) as keys
+     * @return A map with check names (from {@literal <a>} tag text) as keys
      *         and {@link CheckIndexInfo} objects as values.
      * @throws ParserConfigurationException if a DocumentBuilder cannot be created.
      * @throws IOException if an I/O error occurs reading the file.
-     * @throws AssertionError if no &lt;table&gt; is found in the index file.
+     * @throws AssertionError if no {@literal <table>} is found in the index file.
      */
     private static Map<String, CheckIndexInfo> parseCategoryIndex(Path categoryIndexFile)
             throws ParserConfigurationException, IOException {
@@ -331,10 +331,10 @@ public class XdocsCategoryIndexTest extends AbstractModuleTestSupport {
     }
 
     /**
-     * Processes a single &lt;table&gt; element from a category index file.
+     * Processes a single {@literal <table>} element from a category index file.
      * Iterates over its rows, skipping a potential header row, and processes data rows.
      *
-     * @param tableElement The &lt;table&gt; DOM element.
+     * @param tableElement The {@literal <table>} DOM element.
      * @param indexedChecks The map to populate with check information.
      */
     private static void processTableElement(Element tableElement,
@@ -354,9 +354,10 @@ public class XdocsCategoryIndexTest extends AbstractModuleTestSupport {
     }
 
     /**
-     * Checks if a given table row element is a header row (i.e., contains &lt;th&gt; elements).
+     * Checks if a given table row element is a header row
+     * (i.e., contains {@literal <th>} elements).
      *
-     * @param rowElement The &lt;tr&gt; DOM element.
+     * @param rowElement The {@literal <tr>} DOM element.
      * @return True if it's a header row, false otherwise.
      */
     private static boolean isHeaderRow(Element rowElement) {
@@ -364,10 +365,10 @@ public class XdocsCategoryIndexTest extends AbstractModuleTestSupport {
     }
 
     /**
-     * Processes a data row (&lt;tr&gt; with &lt;td&gt; children) from a category index table.
-     * Extracts the check name, href, and description.
+     * Processes a data row ({@literal <tr>} with {@literal <td>} children) from a
+     * category index table. Extracts the check name, href, and description.
      *
-     * @param rowElement The &lt;tr&gt; DOM element representing a data row.
+     * @param rowElement The {@literal <tr>} DOM element representing a data row.
      * @param indexedChecks The map to populate with check information.
      */
     private static void processDataRow(Element rowElement,


### PR DESCRIPTION
https://github.com/checkstyle/checkstyle/issues/18570
Replace `&lt;/&gt;` with {@literal} and `<code>` with `{@code}` in Javadoc.

