### PR TITLE
Issue #16807: Update default properties in ImportOrderCheck input files

### DIFF
--- a/src/test/java/com/puppycrawl/tools/checkstyle/api/FullIdentTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/api/FullIdentTest.java
@@ -249,7 +249,7 @@ public class FullIdentTest extends AbstractModuleTestSupport {
     @Test
     public void testCreateFullIdentBelow2() throws Exception {
         final String[] expected = {
-            "9:1: " + getCheckMessage(ImportOrderCheck.class,
+            "19:1: " + getCheckMessage(ImportOrderCheck.class,
                     MSG_ORDERING_LEX,
                     "java.util.HashMap",
                     "java.util.LinkedList"),

--- a/src/test/java/com/puppycrawl/tools/checkstyle/bdd/InlineConfigParser.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/bdd/InlineConfigParser.java
@@ -300,7 +300,6 @@ public final class InlineConfigParser {
             "com.puppycrawl.tools.checkstyle.checks.coding.RequireThisCheck",
             "com.puppycrawl.tools.checkstyle.checks.coding.UnusedLocalVariableCheck",
             "com.puppycrawl.tools.checkstyle.checks.imports.CustomImportOrderCheck",
-            "com.puppycrawl.tools.checkstyle.checks.imports.ImportOrderCheck",
             "com.puppycrawl.tools.checkstyle.checks.javadoc.JavadocContentLocationCheck",
             "com.puppycrawl.tools.checkstyle.checks.javadoc.JavadocParagraphCheck",
             "com.puppycrawl.tools.checkstyle.checks.javadoc.JavadocVariableCheck",

--- a/src/test/resources-noncompilable/com/puppycrawl/tools/checkstyle/checks/imports/importorder/InputImportOrder6.java
+++ b/src/test/resources-noncompilable/com/puppycrawl/tools/checkstyle/checks/imports/importorder/InputImportOrder6.java
@@ -9,6 +9,7 @@ caseSensitive = (default)true
 staticGroups = (default)
 sortStaticImportsAlphabetically = (default)false
 useContainerOrderingForStatic = (default)false
+tokens = (default)STATIC_IMPORT
 
 
 */

--- a/src/test/resources-noncompilable/com/puppycrawl/tools/checkstyle/checks/imports/importorder/InputImportOrderStaticGroupsTopSeparated.java
+++ b/src/test/resources-noncompilable/com/puppycrawl/tools/checkstyle/checks/imports/importorder/InputImportOrderStaticGroupsTopSeparated.java
@@ -2,7 +2,7 @@
 ImportOrder
 option = top
 groups = android, androidx, java
-ordered = true
+ordered = (default)true
 separated = (default)false
 separatedStaticGroups = true
 caseSensitive = (default)true

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/api/fullident/InputFullIdent.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/api/fullident/InputFullIdent.java
@@ -1,5 +1,15 @@
 /*
 com.puppycrawl.tools.checkstyle.checks.imports.ImportOrderCheck
+option = (default)under
+groups = (default)
+ordered = (default)true
+separated = (default)false
+separatedStaticGroups = (default)false
+caseSensitive = (default)true
+staticGroups = (default)
+sortStaticImportsAlphabetically = (default)false
+useContainerOrderingForStatic = (default)false
+tokens = (default)STATIC_IMPORT
 
 
 */

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/imports/importorder/InputImportOrder_HonorsTokensProperty.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/imports/importorder/InputImportOrder_HonorsTokensProperty.java
@@ -9,7 +9,7 @@ caseSensitive = (default)true
 staticGroups = (default)
 sortStaticImportsAlphabetically = (default)false
 useContainerOrderingForStatic = (default)false
-
+tokens = (default)STATIC_IMPORT
 
 
 */


### PR DESCRIPTION
Issue #16807

Updated default properties in ImportOrderCheck input files:
- `InputImportOrder_HonorsTokensProperty.java`
- `InputImportOrder6.java`
- `InputImportOrderStaticGroupsTopSeparated.java`
- Removed `ImportOrderCheck` from `SUPPRESSED_MODULES` in `InlineConfigParser.java`