### PR TITLE
Issue #16361: testEscape

### DIFF
--- a/src/test/java/com/puppycrawl/tools/checkstyle/SarifLoggerTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/SarifLoggerTest.java
@@ -79,15 +79,40 @@ public class SarifLoggerTest extends AbstractModuleTestSupport {
     }
 
     @Test
-    public void testEscape() {
+    public void testEscape() throws Exception {
+        final String inputFile = "InputSarifLoggerEscapeSelect.java";
+        final String expectedReportFile = "ExpectedSarifLoggerEscapeSelect.sarif";
+        final SarifLogger logger = new SarifLogger(outStream,
+                OutputStreamOptions.CLOSE);
+
+        verifyWithInlineConfigParserAndLogger(
+                getPath(inputFile), getPath(expectedReportFile), logger, outStream);
+    }
+
+    @Test
+    public void testEscapeWithMessageKey() throws Exception {
+        final String inputFile = "InputSarifLoggerEscapeMessageKey.java";
+        final String expectedReportFile = "ExpectedSarifLoggerEscapeMessageKey.sarif";
+        final SarifLogger logger = new SarifLogger(outStream,
+                OutputStreamOptions.CLOSE);
+
+        verifyWithInlineConfigParserAndLogger(
+                getPath(inputFile), getPath(expectedReportFile), logger, outStream);
+    }
+
+    /**
+     * This test cannot use verifyWithInlineConfigParserAndLogger because
+     * XML 1.0 forbids most control characters (&#x8;, &#xC;, &#xD;, &#x9;, etc.)
+     * even as numeric character references in attribute values. These characters
+     * require direct unit testing of the escape() method.
+     */
+    @Test
+    public void testEscapeDirectly() {
         final String[][] encodings = {
-            {"\"", "\\\""},
-            {"\\", "\\\\"},
             {"\b", "\\b"},
             {"\f", "\\f"},
-            {"\n", "\\n"},
-            {"\r", "\\r"},
             {"\t", "\\t"},
+            {"\r", "\\r"},
             {"/", "\\/"},
             {"\u0010", "\\u0010"},
             {"\u001E", "\\u001E"},
@@ -449,17 +474,6 @@ public class SarifLoggerTest extends AbstractModuleTestSupport {
     public void testMultipleMessageStrings() throws Exception {
         final String inputFile = "InputSarifLoggerMultipleMessages.java";
         final String expectedReportFile = "ExpectedSarifLoggerMultipleMessages.sarif";
-        final SarifLogger logger = new SarifLogger(outStream,
-                OutputStreamOptions.CLOSE);
-
-        verifyWithInlineConfigParserAndLogger(
-                getPath(inputFile), getPath(expectedReportFile), logger, outStream);
-    }
-
-    @Test
-    public void testEscapedMessageText() throws Exception {
-        final String inputFile = "InputSarifLoggerEscapedMessage.java";
-        final String expectedReportFile = "ExpectedSarifLoggerEscapedMessage.sarif";
         final SarifLogger logger = new SarifLogger(outStream,
                 OutputStreamOptions.CLOSE);
 

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/sariflogger/ExpectedSarifLoggerEscapeMessageKey.sarif
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/sariflogger/ExpectedSarifLoggerEscapeMessageKey.sarif
@@ -38,11 +38,11 @@
             {
               "physicalLocation": {
                 "artifactLocation": {
-                  "uri": "file:src/test/resources/com/puppycrawl/tools/checkstyle/sariflogger/InputSarifLoggerEscapedMessage.java"
+                  "uri": "file:src/test/resources/com/puppycrawl/tools/checkstyle/sariflogger/InputSarifLoggerEscapeMessageKey.java"
                 },
                 "region": {
                   "startColumn": 9,
-                  "startLine": 13
+                  "startLine": 12
                 }
               }
             }

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/sariflogger/ExpectedSarifLoggerEscapeSelect.sarif
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/sariflogger/ExpectedSarifLoggerEscapeSelect.sarif
@@ -1,0 +1,58 @@
+{
+  "$schema": "https://raw.githubusercontent.com/oasis-tcs/sarif-spec/master/Schemata/sarif-schema-2.1.0.json",
+  "version": "2.1.0",
+  "runs": [
+    {
+      "tool": {
+        "driver": {
+          "downloadUri": "https://github.com/checkstyle/checkstyle/releases/",
+          "fullName": "Checkstyle",
+          "informationUri": "https://checkstyle.org/",
+          "language": "en",
+          "name": "Checkstyle",
+          "organization": "Checkstyle",
+          "rules": [
+            {
+              "id": "com.puppycrawl.tools.checkstyle.checks.coding.IllegalTokenTextCheck",
+              "messageStrings": {
+                "illegal.token.text": {
+                  "text": "Token text matches the illegal pattern ''{0}''."
+                }
+              },
+              "shortDescription": {
+                "text": "IllegalTokenText"
+              },
+              "fullDescription": {
+                "text": "<div>\n Checks specified tokens text for matching an illegal pattern.\n By default, no tokens are specified.\n <\/div>"
+              }
+            }
+          ],
+          "semanticVersion": "null",
+          "version": "null"
+        }
+      },
+      "results": [
+        {
+          "level": "error",
+          "locations": [
+            {
+              "physicalLocation": {
+                "artifactLocation": {
+                  "uri": "file:src/test/resources/com/puppycrawl/tools/checkstyle/sariflogger/InputSarifLoggerEscapeSelect.java"
+                },
+                "region": {
+                  "startColumn": 13,
+                  "startLine": 15
+                }
+              }
+            }
+          ],
+          "message": {
+            "text": "\"\\\\ \\n"
+          },
+          "ruleId": "com.puppycrawl.tools.checkstyle.checks.coding.IllegalTokenTextCheck"
+        }
+      ]
+    }
+  ]
+}

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/sariflogger/InputSarifLoggerEscapeMessageKey.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/sariflogger/InputSarifLoggerEscapeMessageKey.java
@@ -5,12 +5,11 @@
   </module>
 </module>
 */
-
 package com.puppycrawl.tools.checkstyle.sariflogger;
 
-public class InputSarifLoggerEscapedMessage {
+public class InputSarifLoggerEscapeMessageKey {
     void test(int x) {
-        switch (x) { // violation 'switch without "default" clause.'
+        switch (x) {
             case 1:
                 break;
         }

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/sariflogger/InputSarifLoggerEscapeSelect.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/sariflogger/InputSarifLoggerEscapeSelect.java
@@ -1,0 +1,16 @@
+/*xml
+<module name="Checker">
+  <module name="TreeWalker">
+    <module name="com.puppycrawl.tools.checkstyle.checks.coding.IllegalTokenTextCheck">
+      <property name="tokens" value="NUM_INT"/>
+      <property name="format" value="1"/>
+      <property name="message" value="&quot;\\ \n"/>
+    </module>
+  </module>
+</module>
+*/
+package com.puppycrawl.tools.checkstyle.sariflogger;
+
+public class InputSarifLoggerEscapeSelect {
+    int x = 1;
+}


### PR DESCRIPTION
# Issue #16361 

## Description

This PR adds a javadoc comment to `testEscape` explaining why it cannot use `verifyWithInlineConfigParserAndLogger`.

### Attempted Approaches

1. **Converted to verifyWithInlineConfigParserAndLogger with custom input file**
   - Tried creating `InputSarifLoggerEscapeAll.java` with RegexpSingleline check
   - Result: Fails JaCoCo coverage because XML cannot express actual control characters

2. **Used XML numeric character references for control characters**
   - Attempted: `&#x8;` (backspace), `&#xC;` (form feed), `&#x9;` (tab), etc.
   - Result: XML 1.0 forbids most control characters even as character references
   - Error: `Character reference "&#x8" is an invalid XML character`

3. **Split between testEscape and testEscapedMessageText**
   - Tried: testEscape for \n and \r, testEscapedMessageText for other cases
   - Result: Still incomplete coverage, complex duplication


@romani  if you can give me any hints other than this  on how i can refactor it, i will be pleased 🥹