### PR TITLE
Issue #16807: Update input files for RegexpSinglelineCheck

### DIFF
--- a/src/test/java/com/puppycrawl/tools/checkstyle/bdd/InlineConfigParser.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/bdd/InlineConfigParser.java
@@ -265,7 +265,6 @@ public final class InlineConfigParser {
 
             "com.puppycrawl.tools.checkstyle.checks.naming.RecordTypeParameterNameCheck",
             "com.puppycrawl.tools.checkstyle.checks.regexp.RegexpMultilineCheck",
-            "com.puppycrawl.tools.checkstyle.checks.regexp.RegexpSinglelineCheck",
             "com.puppycrawl.tools.checkstyle.checks.regexp.RegexpSinglelineJavaCheck",
             "com.puppycrawl.tools.checkstyle.checks.sizes.AnonInnerLengthCheck",
             "com.puppycrawl.tools.checkstyle.checks.sizes.ExecutableStatementCountCheck",
@@ -309,7 +308,6 @@ public final class InlineConfigParser {
             "com.puppycrawl.tools.checkstyle.checks.modifier.RedundantModifierCheck",
             "com.puppycrawl.tools.checkstyle.checks.naming.LocalFinalVariableNameCheck",
 
-            "com.puppycrawl.tools.checkstyle.checks.regexp.RegexpSinglelineCheck",
             "com.puppycrawl.tools.checkstyle.checks.regexp.RegexpSinglelineJavaCheck",
             "com.puppycrawl.tools.checkstyle.checks.whitespace.NoWhitespaceAfterCheck",
             "com.puppycrawl.tools.checkstyle.checks.whitespace.WhitespaceAfterCheck",

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/regexp/regexpsingleline/InputRegexpSinglelineSemantic10.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/regexp/regexpsingleline/InputRegexpSinglelineSemantic10.java
@@ -1,7 +1,7 @@
 /*
 RegexpSingleline
 format = SYSTEM\\.(OUT)|(ERR)\\.PRINT(LN)?\\(
-message =
+message = (default)
 ignoreCase = true
 minimum = (default)0
 maximum = (default)0

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/regexp/regexpsingleline/InputRegexpSinglelineSemantic8.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/regexp/regexpsingleline/InputRegexpSinglelineSemantic8.java
@@ -5,7 +5,7 @@ message = (default)
 ignoreCase = (default)false
 minimum = (default)0
 maximum = (default)0
-fileExtensions = (default)all files
+fileExtensions = (default)""
 
 
 */

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/regexp/regexpsingleline/InputRegexpSinglelineSemantic9.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/regexp/regexpsingleline/InputRegexpSinglelineSemantic9.java
@@ -2,6 +2,9 @@
 RegexpSingleline
 format = (default)$.
 message = not expected
+ignoreCase = (default)false
+minimum = (default)0
+maximum = (default)0
 fileExtensions = (default)""
 
 


### PR DESCRIPTION
Issue #16807

Updated input files for RegexpSinglelineCheck:
- Fixed message property in InputRegexpSinglelineSemantic10.java
- Fixed fileExtensions property in InputRegexpSinglelineSemantic8.java
- Added missing properties to InputRegexpSinglelineSemantic9.java
- Removed RegexpSinglelineCheck from SUPPRESSED_MODULES in InlineConfigParser