### PR TITLE
Issue #16361: Add explanatory comment for testReadResourceWithInvalid…

### DIFF
--- a/src/test/java/com/puppycrawl/tools/checkstyle/SarifLoggerTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/SarifLoggerTest.java
@@ -412,6 +412,13 @@ public class SarifLoggerTest extends AbstractModuleTestSupport {
                 getPath(inputFile), getPath(expectedReportFile), logger, outStream);
     }
 
+    /**
+     * SarifLogger.readResource(String) is a static utility method that loads
+     * classpath resources directly. Passing an invalid name triggers an IOException
+     * that is not reachable through the normal Checker.process(...) and
+     * Checker.fireErrors(...) execution flow, so this test must call the method
+     * directly rather than using verifyWithInlineConfigParserAndLogger.
+     */
     @Test
     public void testReadResourceWithInvalidName() {
         final IOException exception =


### PR DESCRIPTION
Issue #16361

`testReadResourceWithInvalidName` tests a static utility method `SarifLogger.readResource(String)`
that is not reachable through the normal `Checker.process(...)` and `Checker.fireErrors(...)`
execution flow, so conversion to `verifyWithInlineConfigParserAndLogger` is not possible.

Added explanatory comment to document why.