### PR TITLE
Issue #16807: Update FinalParameters examples to reflect default properties

### DIFF
--- a/src/site/xdoc/checks/misc/finalparameters.xml
+++ b/src/site/xdoc/checks/misc/finalparameters.xml
@@ -85,7 +85,11 @@
         <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
 &lt;module name="Checker"&gt;
   &lt;module name="TreeWalker"&gt;
-    &lt;module name="FinalParameters"/&gt;
+    &lt;module name="FinalParameters"&gt;
+      &lt;property name="ignorePrimitiveTypes" value="false"/&gt;
+      &lt;property name="ignoreUnnamedParameters" value="true"/&gt;
+      &lt;property name="tokens" value="METHOD_DEF, CTOR_DEF"/&gt;
+    &lt;/module&gt;
   &lt;/module&gt;
 &lt;/module&gt;
 </code></pre></div>
@@ -96,7 +100,7 @@
 public class Example1 {
   public Example1() { }
   public Example1(final int m) { }
-  public Example1(final int m, int n) { } // violation, 'n should be final'
+  public Example1(final int m, int n) { } // violation, 'n should be final:'
   public void methodOne(final int x) { }
   public void methodTwo(int x) { } // violation, 'x should be final'
   public static void main(String[] args) { } // violation, 'args should be final'
@@ -110,6 +114,8 @@ public class Example1 {
 &lt;module name="Checker"&gt;
   &lt;module name="TreeWalker"&gt;
     &lt;module name="FinalParameters"&gt;
+      &lt;property name="ignorePrimitiveTypes" value="false"/&gt;
+      &lt;property name="ignoreUnnamedParameters" value="true"/&gt;
       &lt;property name="tokens" value="CTOR_DEF"/&gt;
     &lt;/module&gt;
   &lt;/module&gt;
@@ -138,6 +144,8 @@ public class Example2 {
   &lt;module name="TreeWalker"&gt;
     &lt;module name="FinalParameters"&gt;
       &lt;property name="ignorePrimitiveTypes" value="true"/&gt;
+      &lt;property name="ignoreUnnamedParameters" value="true"/&gt;
+      &lt;property name="tokens" value="METHOD_DEF, CTOR_DEF"/&gt;
     &lt;/module&gt;
   &lt;/module&gt;
 &lt;/module&gt;
@@ -163,8 +171,9 @@ public class Example3 {
 &lt;module name="Checker"&gt;
   &lt;module name="TreeWalker"&gt;
     &lt;module name="FinalParameters"&gt;
-      &lt;property name="tokens" value="FOR_EACH_CLAUSE, LITERAL_CATCH"/&gt;
+      &lt;property name="ignorePrimitiveTypes" value="false"/&gt;
       &lt;property name="ignoreUnnamedParameters" value="true"/&gt;
+      &lt;property name="tokens" value="FOR_EACH_CLAUSE, LITERAL_CATCH"/&gt;
     &lt;/module&gt;
   &lt;/module&gt;
 &lt;/module&gt;

--- a/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/finalparameters/Example1.java
+++ b/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/finalparameters/Example1.java
@@ -1,7 +1,11 @@
 /*xml
 <module name="Checker">
   <module name="TreeWalker">
-    <module name="FinalParameters"/>
+    <module name="FinalParameters">
+      <property name="ignorePrimitiveTypes" value="false"/>
+      <property name="ignoreUnnamedParameters" value="true"/>
+      <property name="tokens" value="METHOD_DEF, CTOR_DEF"/>
+    </module>
   </module>
 </module>
 */
@@ -11,7 +15,7 @@ package com.puppycrawl.tools.checkstyle.checks.finalparameters;
 public class Example1 {
   public Example1() { }
   public Example1(final int m) { }
-  public Example1(final int m, int n) { } // violation, 'n should be final'
+  public Example1(final int m, int n) { } // violation, 'n should be final:'
   public void methodOne(final int x) { }
   public void methodTwo(int x) { } // violation, 'x should be final'
   public static void main(String[] args) { } // violation, 'args should be final'

--- a/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/finalparameters/Example2.java
+++ b/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/finalparameters/Example2.java
@@ -2,6 +2,8 @@
 <module name="Checker">
   <module name="TreeWalker">
     <module name="FinalParameters">
+      <property name="ignorePrimitiveTypes" value="false"/>
+      <property name="ignoreUnnamedParameters" value="true"/>
       <property name="tokens" value="CTOR_DEF"/>
     </module>
   </module>

--- a/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/finalparameters/Example3.java
+++ b/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/finalparameters/Example3.java
@@ -3,6 +3,8 @@
   <module name="TreeWalker">
     <module name="FinalParameters">
       <property name="ignorePrimitiveTypes" value="true"/>
+      <property name="ignoreUnnamedParameters" value="true"/>
+      <property name="tokens" value="METHOD_DEF, CTOR_DEF"/>
     </module>
   </module>
 </module>

--- a/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/finalparameters/Example4.java
+++ b/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/finalparameters/Example4.java
@@ -2,8 +2,9 @@
 <module name="Checker">
   <module name="TreeWalker">
     <module name="FinalParameters">
-      <property name="tokens" value="FOR_EACH_CLAUSE, LITERAL_CATCH"/>
+      <property name="ignorePrimitiveTypes" value="false"/>
       <property name="ignoreUnnamedParameters" value="true"/>
+      <property name="tokens" value="FOR_EACH_CLAUSE, LITERAL_CATCH"/>
     </module>
   </module>
 </module>


### PR DESCRIPTION
Issue #16807

Description:
Updated FinalParameters xdoc examples to reflect the updated default property values.

Changes made:
- Added ignorePrimitiveTypes property to examples
- Added ignoreUnnamedParameters property
- Updated tokens configuration
- Updated violation examples accordingly
                             (or) 
Changes:
- Updated Example1–Example4 configurations
- Added explicit properties matching defaults
- Adjusted violation messages


Build:
mvn clean verify completed successfully.