### PR TITLE
Issue #19411: Improve throwsIndent example in IndentationCheck

### DIFF
--- a/src/site/xdoc/checks/misc/indentation.xml
+++ b/src/site/xdoc/checks/misc/indentation.xml
@@ -341,6 +341,70 @@ class Example4 {
         }
     }
 }
+</code></pre></div><hr class="example-separator"/>
+        <p id="Example7-config">
+          To configure the check with custom throwsIndent (8 spaces instead of default 4):
+        </p>
+        <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
+&lt;module name="Checker"&gt;
+  &lt;module name="TreeWalker"&gt;
+    &lt;module name="Indentation"&gt;
+      &lt;property name="throwsIndent" value="8"/&gt;
+    &lt;/module&gt;
+  &lt;/module&gt;
+&lt;/module&gt;
+</code></pre></div>
+        <p id="Example7-code">
+          Example of code with throwsIndent set to 8.
+          Method 'processValues' has throws on a new line with only 4-space indent,
+          which violates the configured 8-space throwsIndent.
+          Method 'demonstrateSwitch' has throws on a new line with correct 8-space indent:
+        </p>
+        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+class Example7 {
+    String field = "example";                  // basicOffset
+    int[] values = {                           // basicOffset
+        10,
+        20,
+        30
+    };
+
+    void processValues()
+        throws Exception { // violation, ''throws' has incorrect indentation'
+        handleValue("Test String", 42);          // basicOffset
+    }
+
+    void handleValue(String aFooString,
+                     int aFooInt) {             // indent:8 ; expected: &gt; 4;
+
+        boolean cond1,cond2,cond3,cond4,cond5,cond6;
+        cond1=cond2=cond3=cond4=cond5=cond6=false;
+
+        if (cond1
+            || cond2) {
+            field = field.toUpperCase()
+                .concat(" TASK");
+        }
+
+        if ((cond1 &amp;&amp; cond2)
+                || (cond3 &amp;&amp; cond4)          // ok, lineWrappingIndentation
+                || !(cond5 &amp;&amp; cond6)) {      // ok, lineWrappingIndentation
+            field.toUpperCase()
+                 .concat(" TASK")             // ok, lineWrappingIndentation
+                 .chars().forEach(c -&gt; {      // ok, lineWrappingIndentation
+                     System.out.println((char) c);
+                 });
+        }
+    }
+
+    void demonstrateSwitch()
+            throws Exception {               // ok, throwsIndent is 8
+        switch (field) {
+            case "EXAMPLE": processValues();                        // caseIndent
+            case "COMPLETED": handleValue("Completed Case", 456);   // caseIndent
+        }
+    }
+}
 </code></pre></div>
       </subsection>
 

--- a/src/site/xdoc/checks/misc/indentation.xml.template
+++ b/src/site/xdoc/checks/misc/indentation.xml.template
@@ -88,6 +88,25 @@
           <param name="path"
                  value="resources/com/puppycrawl/tools/checkstyle/checks/indentation/indentation/Example4.java"/>
           <param name="type" value="code"/>
+        </macro><hr class="example-separator"/>
+        <p id="Example7-config">
+          To configure the check with custom throwsIndent (8 spaces instead of default 4):
+        </p>
+        <macro name="example">
+          <param name="path"
+                 value="resources/com/puppycrawl/tools/checkstyle/checks/indentation/indentation/Example7.java"/>
+          <param name="type" value="config"/>
+        </macro>
+        <p id="Example7-code">
+          Example of code with throwsIndent set to 8.
+          Method 'processValues' has throws on a new line with only 4-space indent,
+          which violates the configured 8-space throwsIndent.
+          Method 'demonstrateSwitch' has throws on a new line with correct 8-space indent:
+        </p>
+        <macro name="example">
+          <param name="path"
+                 value="resources/com/puppycrawl/tools/checkstyle/checks/indentation/indentation/Example7.java"/>
+          <param name="type" value="code"/>
         </macro>
       </subsection>
 

--- a/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/checks/indentation/IndentationCheckExamplesTest.java
+++ b/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/checks/indentation/IndentationCheckExamplesTest.java
@@ -76,7 +76,9 @@ public class IndentationCheckExamplesTest extends AbstractExamplesModuleTestSupp
 
     @Test
     public void testExample7() throws Exception {
-        final String[] expected = {};
+        final String[] expected = {
+            "23:9: " + getCheckMessage(MSG_ERROR, "throws", 8, 12),
+        };
         verifyWithInlineConfigParser(getPath("Example7.java"), expected);
     }
 

--- a/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/indentation/indentation/Example7.java
+++ b/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/indentation/indentation/Example7.java
@@ -20,7 +20,7 @@ class Example7 {
     };
 
     void processValues()
-            throws Exception {                 // ok, throwsIndent
+        throws Exception { // violation, ''throws' has incorrect indentation'
         handleValue("Test String", 42);          // basicOffset
     }
 
@@ -48,7 +48,7 @@ class Example7 {
     }
 
     void demonstrateSwitch()
-            throws Exception {               // ok, throwsIndent
+            throws Exception {               // ok, throwsIndent is 8
         switch (field) {
             case "EXAMPLE": processValues();                        // caseIndent
             case "COMPLETED": handleValue("Completed Case", 456);   // caseIndent


### PR DESCRIPTION
 #19411

Improved Example7 to clearly demonstrate how the `throwsIndent` property affects validation.

Changes:
- Modified `processValues()` to have throws on a new line with only 4-space indent 
- `demonstrateSwitch()` retains correct 8-space throws indent (ok) for contrast
- Added Example7 config and code sections to `indentation.xml` xdocs
- Updated `IndentationCheckExamplesTest` to expect the new violation