### PR TITLE
Issue #14716: fix false positives  when class declaration is wrapped after public and before static 

### DIFF
--- a/config/checker-framework-suppressions/checker-nullness-optional-interning-suppressions.xml
+++ b/config/checker-framework-suppressions/checker-nullness-optional-interning-suppressions.xml
@@ -4699,13 +4699,6 @@
 
   <checkerFrameworkError unstable="false">
     <fileName>src/main/java/com/puppycrawl/tools/checkstyle/checks/indentation/AbstractExpressionHandler.java</fileName>
-    <specifier>dereference.of.nullable</specifier>
-    <message>dereference of possibly-null reference modifiers</message>
-    <lineContent>for (DetailAST modifier = modifiers.getFirstChild();</lineContent>
-  </checkerFrameworkError>
-
-  <checkerFrameworkError unstable="false">
-    <fileName>src/main/java/com/puppycrawl/tools/checkstyle/checks/indentation/AbstractExpressionHandler.java</fileName>
     <specifier>initialization.fields.uninitialized</specifier>
     <message>the constructor does not initialize fields: indent</message>
     <lineContent>protected AbstractExpressionHandler(IndentationCheck indentCheck, String typeName,</lineContent>
@@ -4889,6 +4882,20 @@
     <specifier>dereference.of.nullable</specifier>
     <message>dereference of possibly-null reference ident</message>
     <lineContent>if (ident.getLineNo() == getMainAst().getLineNo()) {</lineContent>
+  </checkerFrameworkError>
+
+  <checkerFrameworkError unstable="false">
+    <fileName>src/main/java/com/puppycrawl/tools/checkstyle/checks/indentation/ClassDefHandler.java</fileName>
+    <specifier>dereference.of.nullable</specifier>
+    <message>dereference of possibly-null reference modifiers</message>
+    <lineContent>final DetailAST firstModifier = modifiers.getFirstChild();</lineContent>
+  </checkerFrameworkError>
+
+  <checkerFrameworkError unstable="false">
+    <fileName>src/main/java/com/puppycrawl/tools/checkstyle/checks/indentation/ClassDefHandler.java</fileName>
+    <specifier>dereference.of.nullable</specifier>
+    <message>dereference of possibly-null reference modifiers</message>
+    <lineContent>for (DetailAST modifier = modifiers.getFirstChild();</lineContent>
   </checkerFrameworkError>
 
   <checkerFrameworkError unstable="false">

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/indentation/AbstractExpressionHandler.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/indentation/AbstractExpressionHandler.java
@@ -529,23 +529,6 @@ public abstract class AbstractExpressionHandler {
     }
 
     /**
-     * Check the indentation level of modifiers.
-     */
-    protected void checkModifiers() {
-        final DetailAST modifiers =
-            mainAst.findFirstToken(TokenTypes.MODIFIERS);
-        for (DetailAST modifier = modifiers.getFirstChild();
-             modifier != null;
-             modifier = modifier.getNextSibling()) {
-            if (isOnStartOfLine(modifier)
-                && !getIndent().isAcceptable(expandedTabsColumnNo(modifier))) {
-                logError(modifier, "modifier",
-                    expandedTabsColumnNo(modifier));
-            }
-        }
-    }
-
-    /**
      * Accessor for the IndentCheck attribute.
      *
      * @return the IndentCheck attribute

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/indentation/ClassDefHandler.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/indentation/ClassDefHandler.java
@@ -28,6 +28,9 @@ import com.puppycrawl.tools.checkstyle.api.TokenTypes;
  */
 public class ClassDefHandler extends BlockParentHandler {
 
+    /** Token for modifier. */
+    private static final String MODIFIER = "modifier";
+
     /**
      * Construct an instance of this handler with the given indentation check,
      * abstract syntax tree, and parent handler.
@@ -107,6 +110,112 @@ public class ClassDefHandler extends BlockParentHandler {
             TokenTypes.LITERAL_THROW,
             TokenTypes.LITERAL_CONTINUE,
         };
+    }
+
+    /**
+     * Checks modifiers for class/annotation definitions.
+     */
+    private void checkModifiers() {
+        if (getMainAst().getType() == TokenTypes.ANNOTATION_DEF) {
+            checkAnnotationDefModifiers();
+        }
+        else {
+            checkClassDefModifiers();
+        }
+    }
+
+    /**
+     * Checks modifiers for annotation definitions, skipping modifiers that are
+     * not at the start of the line.
+     */
+    private void checkAnnotationDefModifiers() {
+        final DetailAST modifiers = getMainAst().findFirstToken(TokenTypes.MODIFIERS);
+        for (DetailAST modifier = modifiers.getFirstChild();
+             modifier != null;
+             modifier = modifier.getNextSibling()) {
+            if (isOnStartOfLine(modifier)
+                    && !getIndent().isAcceptable(expandedTabsColumnNo(modifier))) {
+                logError(modifier, MODIFIER, expandedTabsColumnNo(modifier));
+            }
+        }
+    }
+
+    /**
+     * Checks modifiers for class definitions, skipping wrapped modifiers
+     * that appear on lines after the first modifier line.
+     * Annotations that wrap before the class keyword are skipped only when
+     * they are correctly indented, since a correctly indented annotation
+     * before a wrongly indented class keyword is not itself a violation.
+     */
+    private void checkClassDefModifiers() {
+        final DetailAST modifiers = getMainAst().findFirstToken(TokenTypes.MODIFIERS);
+        final DetailAST firstModifier = modifiers.getFirstChild();
+        final DetailAST firstNonAnnotationMod = getFirstNonAnnotationModifier(firstModifier);
+        final int firstModifierLine = firstModifier.getLineNo();
+        final int firstNonAnnotationLine = firstNonAnnotationMod.getLineNo();
+
+        checkLineModifiers(firstModifier, firstModifierLine);
+
+        if (firstModifierLine != firstNonAnnotationLine) {
+            checkNonFirstLineModifiers(firstNonAnnotationMod);
+        }
+    }
+
+    /**
+     * Checks modifiers on the first modifier line.
+     *
+     * @param firstModifier the first modifier
+     * @param firstModifierLine line number of the first modifier
+     */
+    private void checkLineModifiers(DetailAST firstModifier,
+            int firstModifierLine) {
+        for (DetailAST modifier = firstModifier;
+             modifier != null
+                     && modifier.getLineNo() == firstModifierLine;
+             modifier = modifier.getNextSibling()) {
+            if (isOnStartOfLine(modifier)
+                    && !getIndent().isAcceptable(expandedTabsColumnNo(modifier))) {
+                logError(modifier, MODIFIER, expandedTabsColumnNo(modifier));
+            }
+        }
+    }
+
+    /**
+     * Checks modifiers on the line of the first non-annotation modifier,
+     * skipping correctly-indented annotations to avoid false positives
+     * when annotations wrap before the class keyword.
+     *
+     * @param firstNonAnnotationMod the first non-annotation modifier
+     */
+    private void checkNonFirstLineModifiers(DetailAST firstNonAnnotationMod) {
+        for (DetailAST modifier = firstNonAnnotationMod;
+             modifier != null;
+             modifier = modifier.getNextSibling()) {
+            if (isOnStartOfLine(modifier)
+                    && !getIndent().isAcceptable(
+                            expandedTabsColumnNo(modifier))) {
+                logError(modifier, MODIFIER, expandedTabsColumnNo(modifier));
+            }
+        }
+    }
+
+    /**
+     * Finds the first non-annotation modifier node.
+     *
+     * @param firstModifier the first modifier in the modifiers list
+     * @return the first non-annotation modifier node
+     */
+    private static DetailAST getFirstNonAnnotationModifier(DetailAST firstModifier) {
+        DetailAST result = firstModifier;
+        for (DetailAST modifier = firstModifier;
+             modifier != null;
+             modifier = modifier.getNextSibling()) {
+            if (modifier.getType() != TokenTypes.ANNOTATION) {
+                result = modifier;
+                break;
+            }
+        }
+        return result;
     }
 
     /**

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/indentation/MemberDefHandler.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/indentation/MemberDefHandler.java
@@ -82,8 +82,10 @@ public class MemberDefHandler extends AbstractExpressionHandler {
         return getIndent();
     }
 
-    @Override
-    protected void checkModifiers() {
+    /**
+     * Checks modifiers for member definitions.
+     */
+    private void checkModifiers() {
         final DetailAST modifier = getMainAst().findFirstToken(TokenTypes.MODIFIERS);
         if (isOnStartOfLine(modifier)
             && !getIndent().isAcceptable(expandedTabsColumnNo(modifier))) {

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/indentation/MethodDefHandler.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/indentation/MethodDefHandler.java
@@ -47,8 +47,10 @@ public class MethodDefHandler extends BlockParentHandler {
         return null;
     }
 
-    @Override
-    protected void checkModifiers() {
+    /**
+     * Checks modifiers for method definitions.
+     */
+    private void checkModifiers() {
         final DetailAST modifier = getMainAst().findFirstToken(TokenTypes.MODIFIERS);
         if (isOnStartOfLine(modifier)
             && !getIndent().isAcceptable(expandedTabsColumnNo(modifier))) {

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/indentation/IndentationCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/indentation/IndentationCheckTest.java
@@ -4318,6 +4318,89 @@ public class IndentationCheckTest extends AbstractModuleTestSupport {
     }
 
     @Test
+    public void testClassDefWrappedModifiers() throws Exception {
+        final DefaultConfiguration checkConfig = createModuleConfig(IndentationCheck.class);
+        checkConfig.addProperty("basicOffset", "2");
+        checkConfig.addProperty("braceAdjustment", "2");
+        checkConfig.addProperty("caseIndent", "2");
+        checkConfig.addProperty("lineWrappingIndentation", "4");
+        checkConfig.addProperty("throwsIndent", "4");
+        checkConfig.addProperty("forceStrictCondition", "false");
+        checkConfig.addProperty("tabWidth", "4");
+        checkConfig.addProperty("arrayInitIndent", "2");
+        final String fileName =
+                getPath("InputIndentationClassDefWrappedModifiers.java");
+        final String[] expected = {
+            "25:3: " + getCheckMessage(MSG_ERROR, "class", 2, 6),
+            "27:3: " + getCheckMessage(MSG_ERROR, "static", 2, 6),
+            "31:3: " + getCheckMessage(MSG_ERROR, "static", 2, 6),
+            "40:3: " + getCheckMessage(MSG_ERROR, "strictfp", 2, 6),
+            "44:3: " + getCheckMessage(MSG_ERROR, "@", 2, 6),
+            "50:3: " + getCheckMessage(MSG_ERROR, "static", 2, 6),
+            "51:3: " + getCheckMessage(MSG_ERROR, "strictfp", 2, 6),
+            "84:2: " + getCheckMessage(MSG_ERROR, "class def modifier", 1, 2),
+        };
+        verifyWarns(checkConfig, fileName, expected);
+    }
+
+    @Test
+    public void testAnnotationBeforeClass() throws Exception {
+        final DefaultConfiguration checkConfig = createModuleConfig(IndentationCheck.class);
+        checkConfig.addProperty("basicOffset", "2");
+        checkConfig.addProperty("braceAdjustment", "2");
+        checkConfig.addProperty("caseIndent", "2");
+        checkConfig.addProperty("lineWrappingIndentation", "4");
+        checkConfig.addProperty("throwsIndent", "4");
+        checkConfig.addProperty("forceStrictCondition", "false");
+        checkConfig.addProperty("tabWidth", "4");
+        checkConfig.addProperty("arrayInitIndent", "2");
+        final String fileName = getPath("InputIndentationAnnotationBeforeClass.java");
+        final String[] expected = {
+            "41:2: " + getCheckMessage(MSG_ERROR, "class def modifier", 1, 2),
+            "46:2: " + getCheckMessage(MSG_ERROR, "class def modifier", 1, 2),
+            "47:2: " + getCheckMessage(MSG_ERROR, "class def modifier", 1, 2),
+            "48:5: " + getCheckMessage(MSG_ERROR, "class def modifier", 4, 2),
+            "49:5: " + getCheckMessage(MSG_ERROR, "class def modifier", 4, 2),
+        };
+        verify(checkConfig, fileName, expected);
+    }
+
+    @Test
+    public void testAnnotationBeforeClassOpenJdkCase() throws Exception {
+        final DefaultConfiguration checkConfig = createModuleConfig(IndentationCheck.class);
+        checkConfig.addProperty("basicOffset", "4");
+        checkConfig.addProperty("braceAdjustment", "0");
+        checkConfig.addProperty("caseIndent", "4");
+        checkConfig.addProperty("lineWrappingIndentation", "4");
+        checkConfig.addProperty("throwsIndent", "4");
+        checkConfig.addProperty("forceStrictCondition", "false");
+        checkConfig.addProperty("tabWidth", "4");
+        checkConfig.addProperty("arrayInitIndent", "2");
+        final String fileName = getPath("InputIndentationAnnotBeforeClassOpenJdkCase.java");
+        final String[] expected = {
+            "12:4: " + getCheckMessage(MSG_ERROR, "class def modifier", 3, 4),
+            "13:4: " + getCheckMessage(MSG_ERROR, "class def modifier", 3, 4),
+            "15:9: " + getCheckMessage(MSG_ERROR, "class def modifier", 8, 4),
+            "16:9: " + getCheckMessage(MSG_ERROR, "class def modifier", 8, 4),
+            "18:3: " + getCheckMessage(MSG_ERROR, "class def modifier", 2, 4),
+            "19:3: " + getCheckMessage(MSG_ERROR, "class def modifier", 2, 4),
+            "21:7: " + getCheckMessage(MSG_ERROR, "class def modifier", 6, 4),
+            "22:7: " + getCheckMessage(MSG_ERROR, "class def modifier", 6, 4),
+            "24:4: " + getCheckMessage(MSG_ERROR, "class def modifier", 3, 4),
+            "26:4: " + getCheckMessage(MSG_ERROR, "class def modifier", 3, 4),
+            "28:7: " + getCheckMessage(MSG_ERROR, "class def modifier", 6, 4),
+            "30:7: " + getCheckMessage(MSG_ERROR, "class def modifier", 6, 4),
+            "32:3: " + getCheckMessage(MSG_ERROR, "class def modifier", 2, 4),
+            "33:3: " + getCheckMessage(MSG_ERROR, "class def modifier", 2, 4),
+            "35:4: " + getCheckMessage(MSG_ERROR, "enum def modifier", 3, 4),
+            "36:4: " + getCheckMessage(MSG_ERROR, "enum def modifier", 3, 4),
+            "38:4: " + getCheckMessage(MSG_ERROR, "interface def modifier", 3, 4),
+            "39:4: " + getCheckMessage(MSG_ERROR, "interface def modifier", 3, 4),
+        };
+        verify(checkConfig, fileName, expected);
+    }
+
+    @Test
     public void testTryResourcesLparenViolation() throws Exception {
         final DefaultConfiguration checkConfig = createModuleConfig(IndentationCheck.class);
         checkConfig.addProperty("basicOffset", "4");

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/indentation/indentation/InputIndentationAnnotBeforeClassOpenJdkCase.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/indentation/indentation/InputIndentationAnnotBeforeClassOpenJdkCase.java
@@ -1,0 +1,40 @@
+/* Config:                                                                 //indent:0 exp:0
+ * basicOffset = 4                                                         //indent:1 exp:1
+ * braceAdjustment = 0                                                     //indent:1 exp:1
+ * caseIndent = 4                                                          //indent:1 exp:1
+ * lineWrappingIndentation = 4                                             //indent:1 exp:1
+ * throwsIndent = 4                                                        //indent:1 exp:1
+ * tabWidth = 4                                                            //indent:1 exp:1
+ */                                                                        //indent:1 exp:1
+package com.puppycrawl.tools.checkstyle.checks.indentation.indentation;    //indent:0 exp:0
+
+public class InputIndentationAnnotBeforeClassOpenJdkCase {                 //indent:0 exp:0
+   @SuppressWarnings("deprecation")                                        //indent:3 exp:4 warn
+   private static final class TlsMasterSecretKey {}                        //indent:3 exp:4 warn
+
+        @SuppressWarnings("serial")                                        //indent:8 exp:4 warn
+        private static final class ResizeIcon {}                           //indent:8 exp:4 warn
+
+  @Deprecated                                                              //indent:2 exp:4 warn
+  public static class WrongIndentSingle {}                                 //indent:2 exp:4 warn
+
+      @Deprecated                                                          //indent:6 exp:4 warn
+      public static class WrongIndentOver {}                               //indent:6 exp:4 warn
+
+   @SuppressWarnings("foo")                                                //indent:3 exp:4 warn
+   @Deprecated                                                             //indent:3 exp:4
+   private static class TwoAnnotationsWrong {}                             //indent:3 exp:4 warn
+
+      @Deprecated                                                          //indent:6 exp:4 warn
+      @SuppressWarnings("x")                                               //indent:6 exp:4
+      public final class TwoAnnotationsOver {}                             //indent:6 exp:4 warn
+
+  @Deprecated                                                              //indent:2 exp:4 warn
+  protected static class WrongProtected {}                                 //indent:2 exp:4 warn
+
+   @SuppressWarnings("unchecked")                                          //indent:3 exp:4 warn
+   public enum WrongEnum {}                                                //indent:3 exp:4 warn
+
+   @SuppressWarnings("unchecked")                                          //indent:3 exp:4 warn
+   public interface WrongInterface {}                                      //indent:3 exp:4 warn
+}                                                                          //indent:0 exp:0

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/indentation/indentation/InputIndentationAnnotationBeforeClass.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/indentation/indentation/InputIndentationAnnotationBeforeClass.java
@@ -1,0 +1,50 @@
+/* Config:                                                                 //indent:0 exp:0
+ * basicOffset = 2                                                         //indent:1 exp:1
+ * braceAdjustment = 2                                                     //indent:1 exp:1
+ * caseIndent = 2                                                          //indent:1 exp:1
+ * lineWrappingIndentation = 4                                             //indent:1 exp:1
+ * throwsIndent = 4                                                        //indent:1 exp:1
+ * tabWidth = 4                                                            //indent:1 exp:1
+ * arrayInitIndent = 2                                                     //indent:1 exp:1
+ */                                                                        //indent:1 exp:1
+package com.puppycrawl.tools.checkstyle.checks.indentation.indentation;    //indent:0 exp:0
+
+@Deprecated                                                                //indent:0 exp:0
+public class InputIndentationAnnotationBeforeClass {                       //indent:0 exp:0
+  @SuppressWarnings("try")                                                 //indent:2 exp:2
+  public static class TestBatchSource implements Runnable {                //indent:2 exp:2
+    @Override                                                              //indent:4 exp:4
+    public void run() { }                                                  //indent:4 exp:4
+    @SuppressWarnings("unused")                                            //indent:4 exp:4
+    public static int count;                                               //indent:4 exp:4
+  }                                                                        //indent:2 exp:2
+  @SuppressWarnings("try")                                                 //indent:2 exp:2
+  public static class TestBatchSourceFail extends TestBatchSource {        //indent:2 exp:2
+  }                                                                        //indent:2 exp:2
+  @Deprecated                                                              //indent:2 exp:2
+  public class InnerConfig {                                               //indent:2 exp:2
+    @Deprecated                                                            //indent:4 exp:4
+    protected static class ReportingAdminOnlyConfiguration {               //indent:4 exp:4
+      @Deprecated                                                          //indent:6 exp:6
+      public Object stubResource() {                                       //indent:6 exp:6
+        return new Object();                                               //indent:8 exp:8
+      }                                                                    //indent:6 exp:6
+    }                                                                      //indent:4 exp:4
+  }                                                                        //indent:2 exp:2
+  @Deprecated                                                              //indent:2 exp:2
+  protected static class ReportingAdminOnlyConfig {                        //indent:2 exp:2
+    @Deprecated                                                            //indent:4 exp:4
+    public Object stubResource() {                                         //indent:4 exp:4
+      return new Object();                                                 //indent:6 exp:6
+    }                                                                      //indent:4 exp:4
+  }                                                                        //indent:2 exp:2
+ @Deprecated                                                               //indent:1 exp:2 warn
+  public static class AnnotationWrappedWrongIndent {                       //indent:2 exp:2
+  }                                                                        //indent:2 exp:2
+  @SuppressWarnings("deprecation")                                         //indent:2 exp:2
+  private static final class TlsMasterSecretKey {}                         //indent:2 exp:2
+ @SuppressWarnings("bar")                                                  //indent:1 exp:2 warn
+ private static final class SameWrongCol {}                                //indent:1 exp:2 warn
+    @SuppressWarnings("deprecation")                                       //indent:4 exp:2 warn
+    private static final class TlsMasterSecretKey2 {}                      //indent:4 exp:2 warn
+}                                                                          //indent:0 exp:0

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/indentation/indentation/InputIndentationClassDefWrappedModifiers.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/indentation/indentation/InputIndentationClassDefWrappedModifiers.java
@@ -1,0 +1,111 @@
+/* Config:                                                                 //indent:0 exp:0
+ * basicOffset = 2                                                         //indent:1 exp:1
+ * braceAdjustment = 2                                                     //indent:1 exp:1
+ * caseIndent = 2                                                          //indent:1 exp:1
+ * tabWidth = 4                                                            //indent:1 exp:1
+ * throwsIndent = 4                                                        //indent:1 exp:1
+ * arrayInitIndent = 2                                                     //indent:1 exp:1
+ * lineWrappingIndentation = 4                                             //indent:1 exp:1
+ */                                                                        //indent:1 exp:1
+package com.puppycrawl.tools.checkstyle.checks.indentation.indentation;    //indent:0 exp:0
+
+import java.lang.annotation.Target;                                        //indent:0 exp:0
+import java.lang.annotation.Retention;                                     //indent:0 exp:0
+import java.lang.annotation.RetentionPolicy;                               //indent:0 exp:0
+import java.lang.annotation.ElementType;                                   //indent:0 exp:0
+
+@interface AlphaChars {}                                                   //indent:0 exp:0
+@interface NumericChars {}                                                 //indent:0 exp:0
+@interface Chars {                                                         //indent:0 exp:0
+  char[] value();                                                          //indent:2 exp:2
+}                                                                          //indent:0 exp:0
+public class InputIndentationClassDefWrappedModifiers {                    //indent:0 exp:0
+  public class ValidClass {}                                               //indent:2 exp:2
+  public                                                                   //indent:2 exp:2
+  class WrappedClass {}                                                    //indent:2 exp:6 warn
+  public                                                                   //indent:2 exp:2
+  static class WrappedStatic {}                                            //indent:2 exp:6 warn
+  public                                                                   //indent:2 exp:2
+      static class CorrectlyWrappedStatic {}                               //indent:6 exp:6
+  public                                                                   //indent:2 exp:2
+  static                                                                   //indent:2 exp:6 warn
+      final class WrappedStaticFinal {}                                    //indent:6 exp:6
+  public                                                                   //indent:2 exp:2
+      static                                                               //indent:6 exp:6
+      final class CorrectlyWrappedStaticFinal {}                           //indent:6 exp:6
+  public @interface InlineAnnotation {}                                    //indent:2 exp:2
+  public                                                                   //indent:2 exp:2
+      strictfp class WrappedStrictfp {}                                    //indent:6 exp:6
+  public                                                                   //indent:2 exp:2
+  strictfp class CorrectlyWrappedStrictfp {}                               //indent:2 exp:6 warn
+  public                                                                   //indent:2 exp:2
+      @AlphaChars class WrappedAnnotation {}                               //indent:6 exp:6
+  public                                                                   //indent:2 exp:2
+  @AlphaChars class CorrectlyWrappedAnnotation {}                          //indent:2 exp:6 warn
+  public                                                                   //indent:2 exp:2
+      strictfp                                                             //indent:6 exp:6
+      @AlphaChars                                                          //indent:6 exp:6
+      static class WrappedMultiple {}                                      //indent:6 exp:6
+  public                                                                   //indent:2 exp:2
+  static                                                                   //indent:2 exp:6 warn
+  strictfp class C5{}                                                      //indent:2 exp:6 warn
+  public static                                                            //indent:2 exp:2
+      class WrapAfterStatic {};                                            //indent:6 exp:6
+  public static                                                            //indent:2 exp:2
+      final class WrapAfterStaticAndBeforeFinal {};                        //indent:6 exp:6
+  public                                                                   //indent:2 exp:2
+      static                                                               //indent:6 exp:6
+          final                                                            //indent:10 exp:10
+              class WrapBeforeStaticAndAfterFinal {};                      //indent:14 exp:14
+  public                                                                   //indent:2 exp:2
+      static                                                               //indent:6 exp:6
+          final class WrapBeforeStaticAndBeforeFinal {};                   //indent:10 exp:10
+  public @X class NoWrapWithAnnotation {};                                 //indent:2 exp:2
+  public @X @Y @Z class NoWrapWithManyAnnotations {};                      //indent:2 exp:2
+  public                                                                   //indent:2 exp:2
+      @X @Y @Z class ManyAnnotationsWrapped {};                            //indent:6 exp:6
+  public @X                                                                //indent:2 exp:2
+      @Y @Z class OneWrapWithManyAnnotations {};                           //indent:6 exp:6
+  public @X                                                                //indent:2 exp:2
+      @Y                                                                   //indent:6 exp:6
+        @Z class ManyAnnotationsWithManyWraps {};                          //indent:8 exp:8
+  public static @X @Y final class NoWrap2 {};                              //indent:2 exp:2
+  public static                                                            //indent:2 exp:2
+      @X @Y final class  WrapBetweenStaticAndAnnotation {};                //indent:6 exp:6
+  public static @X @Y                                                      //indent:2 exp:2
+      final class WrapBetweenAnnotationAndFinal {};                        //indent:6 exp:6
+  public static @X                                                         //indent:2 exp:2
+      @Y final                                                             //indent:6 exp:6
+          class ManyWrap2 {};                                              //indent:10 exp:10
+  public                                                                   //indent:2 exp:2
+      static @X @Y                                                         //indent:6 exp:6
+        final class ManyWraps3 {};                                         //indent:8 exp:8
+  @SuppressWarnings("deprecation")                                         //indent:2 exp:2
+ private static final class TlsMasterSecretKey {}                          //indent:1 exp:2 warn
+  @SuppressWarnings("foo")                                                 //indent:2 exp:2
+  protected static class AnnotationBeforeProtected {}                      //indent:2 exp:2
+  @Deprecated                                                              //indent:2 exp:2
+  @SuppressWarnings(                                                       //indent:2 exp:2
+      "deprecation")                                                       //indent:6 exp:6
+  @X                                                                       //indent:2 exp:2
+  class WrappedAnnotationBeforeClass {}                                    //indent:2 exp:2
+  @Deprecated                                                              //indent:2 exp:2
+  @SuppressWarnings("deprecation")                                         //indent:2 exp:2
+  static class TwoAnnotationsBeforeStaticClass {}                          //indent:2 exp:2
+  @SuppressWarnings({                                                      //indent:2 exp:2
+      "deprecation",                                                       //indent:6 exp:6
+      "unchecked",                                                         //indent:6 exp:6
+      "rawtypes",                                                          //indent:6 exp:6
+      "serial"                                                             //indent:6 exp:6
+  })                                                                       //indent:2 exp:2
+  class WrappedSuppressWarnings {}                                         //indent:2 exp:2
+}                                                                          //indent:0 exp:0
+  @interface X {};                                                         //indent:2 exp:2
+  @interface Y {};                                                         //indent:2 exp:2
+  @interface Z {};                                                         //indent:2 exp:2
+class StandardAuthorizerPropertyTest {                                     //indent:0 exp:0
+  @Target(ElementType.ANNOTATION_TYPE)                                     //indent:2 exp:2
+  @Retention(RetentionPolicy.RUNTIME)                                      //indent:2 exp:2
+  @AlphaChars @NumericChars @Chars({ '_', '-', '.' })                      //indent:2 exp:2
+  public @interface ValidTopicChars {}                                     //indent:2 exp:2
+}                                                                          //indent:0 exp:0


### PR DESCRIPTION
closes #14716

i was searching through the issue tracker for indentation PRs to help me understand it better to solve another PR that is not finished yet , and i found this #14149 abondoned one because it require #14716 to be solved first .

ClassDefHandler.checkModifiers() was checking all modifiers regardless of line number, causing false positives when modifiers are wrapped to a new line after `public` for example.

Fix:
- Removed the empty checkModifiers() method from AbstractExpressionHandler
- Added checkModifiers() method to ClassDefHandler that only checks modifiers on the same line as the first modifier
- Wrapped modifiers are already handled correctly by LineWrappingHandler

Why this approach:
- Treats ALL modifiers equally based on line position (not token type as this was the main reason of abondonning the previous PR)
- No hardcoded list of specific tokens

i tested all inputs as said in comment https://github.com/checkstyle/checkstyle/issues/14716#issuecomment-2041474406 , none of them produce a violation now

Build succes with `mvn clean verify` 