### PR TITLE
Add missing default properties to NoWhitespaceBefore examples

### DIFF
--- a/src/site/xdoc/checks/whitespace/nowhitespacebefore.xml
+++ b/src/site/xdoc/checks/whitespace/nowhitespacebefore.xml
@@ -90,7 +90,13 @@
         <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
 &lt;module name="Checker"&gt;
   &lt;module name="TreeWalker"&gt;
-    &lt;module name="NoWhitespaceBefore"/&gt;
+    &lt;module name="NoWhitespaceBefore"&gt;
+      &lt;property name="allowLineBreaks"
+                value="(default) false"/&gt;
+      &lt;property name="tokens"
+                value="(default) COMMA, SEMI, POST_INC,
+                       POST_DEC, ELLIPSIS, LABELED_STAT"/&gt;
+    &lt;/module&gt;
   &lt;/module&gt;
 &lt;/module&gt;
 </code></pre></div>
@@ -129,7 +135,11 @@ class Example1 {
 &lt;module name="Checker"&gt;
   &lt;module name="TreeWalker"&gt;
     &lt;module name="NoWhitespaceBefore"&gt;
-      &lt;property name="allowLineBreaks" value="true"/&gt;
+      &lt;property name="allowLineBreaks"
+                value="true"/&gt;
+      &lt;property name="tokens"
+                value="(default) COMMA, SEMI, POST_INC,
+                       POST_DEC, ELLIPSIS, LABELED_STAT"/&gt;
     &lt;/module&gt;
   &lt;/module&gt;
 &lt;/module&gt;
@@ -158,7 +168,10 @@ class Example2 {
 &lt;module name="Checker"&gt;
   &lt;module name="TreeWalker"&gt;
     &lt;module name="NoWhitespaceBefore"&gt;
-      &lt;property name="tokens" value="METHOD_REF, DOT"/&gt;
+      &lt;property name="tokens"
+                value="METHOD_REF, DOT"/&gt;
+      &lt;property name="allowLineBreaks"
+                value="(default) false"/&gt;
     &lt;/module&gt;
   &lt;/module&gt;
 &lt;/module&gt;
@@ -183,8 +196,10 @@ class Example3 {
 &lt;module name="Checker"&gt;
   &lt;module name="TreeWalker"&gt;
     &lt;module name="NoWhitespaceBefore"&gt;
-      &lt;property name="tokens" value="METHOD_REF, DOT"/&gt;
-      &lt;property name="allowLineBreaks" value="true"/&gt;
+      &lt;property name="tokens"
+                value="METHOD_REF, DOT"/&gt;
+      &lt;property name="allowLineBreaks"
+                value="true"/&gt;
     &lt;/module&gt;
   &lt;/module&gt;
 &lt;/module&gt;

--- a/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/whitespace/nowhitespacebefore/Example1.java
+++ b/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/whitespace/nowhitespacebefore/Example1.java
@@ -1,12 +1,16 @@
 /*xml
 <module name="Checker">
   <module name="TreeWalker">
-    <module name="NoWhitespaceBefore"/>
+    <module name="NoWhitespaceBefore">
+      <property name="allowLineBreaks"
+                value="(default) false"/>
+      <property name="tokens"
+                value="(default) COMMA, SEMI, POST_INC,
+                       POST_DEC, ELLIPSIS, LABELED_STAT"/>
     </module>
   </module>
 </module>
 */
-
 package com.puppycrawl.tools.checkstyle.checks.whitespace.nowhitespacebefore;
 
 import com.google.common.collect.Lists;

--- a/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/whitespace/nowhitespacebefore/Example2.java
+++ b/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/whitespace/nowhitespacebefore/Example2.java
@@ -2,12 +2,15 @@
 <module name="Checker">
   <module name="TreeWalker">
     <module name="NoWhitespaceBefore">
-      <property name="allowLineBreaks" value="true"/>
+      <property name="allowLineBreaks"
+                value="true"/>
+      <property name="tokens"
+                value="(default) COMMA, SEMI, POST_INC,
+                       POST_DEC, ELLIPSIS, LABELED_STAT"/>
     </module>
   </module>
 </module>
 */
-
 package com.puppycrawl.tools.checkstyle.checks.whitespace.nowhitespacebefore;
 
 import com.google.common.collect.Lists;

--- a/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/whitespace/nowhitespacebefore/Example3.java
+++ b/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/whitespace/nowhitespacebefore/Example3.java
@@ -2,12 +2,14 @@
 <module name="Checker">
   <module name="TreeWalker">
     <module name="NoWhitespaceBefore">
-      <property name="tokens" value="METHOD_REF, DOT"/>
+      <property name="tokens"
+                value="METHOD_REF, DOT"/>
+      <property name="allowLineBreaks"
+                value="(default) false"/>
     </module>
   </module>
 </module>
 */
-
 package com.puppycrawl.tools.checkstyle.checks.whitespace.nowhitespacebefore;
 
 import com.google.common.collect.Lists;

--- a/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/whitespace/nowhitespacebefore/Example4.java
+++ b/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/whitespace/nowhitespacebefore/Example4.java
@@ -2,13 +2,14 @@
 <module name="Checker">
   <module name="TreeWalker">
     <module name="NoWhitespaceBefore">
-      <property name="tokens" value="METHOD_REF, DOT"/>
-      <property name="allowLineBreaks" value="true"/>
+      <property name="tokens"
+                value="METHOD_REF, DOT"/>
+      <property name="allowLineBreaks"
+                value="true"/>
     </module>
   </module>
 </module>
 */
-
 package com.puppycrawl.tools.checkstyle.checks.whitespace.nowhitespacebefore;
 
 import com.google.common.collect.Lists;


### PR DESCRIPTION
Added default properties to NOWhiteSpaceBefore xdoc examples. 