### PR TITLE
Issue #9149: fix testNoStackoverflowError to use verifyWithLimitedResources and add deep tree test for DescendantIterator

### DIFF
--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/coding/MatchXpathCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/coding/MatchXpathCheckTest.java
@@ -50,9 +50,9 @@ public class MatchXpathCheckTest
     @Test
     public void testNoStackoverflowError()
             throws Exception {
-        final String[] expected = CommonUtil.EMPTY_STRING_ARRAY;
-        verifyWithInlineConfigParser(
-                getPath("InputMatchXpathNoStackoverflowError.java"), expected);
+        verifyWithLimitedResources(
+                getPath("InputMatchXpathNoStackoverflowError.java"),
+                CommonUtil.EMPTY_STRING_ARRAY);
     }
 
     @Test

--- a/src/test/java/com/puppycrawl/tools/checkstyle/xpath/iterators/DescendantIteratorTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/xpath/iterators/DescendantIteratorTest.java
@@ -24,6 +24,9 @@ import static com.puppycrawl.tools.checkstyle.internal.utils.XpathIteratorUtil.f
 
 import org.junit.jupiter.api.Test;
 
+import com.puppycrawl.tools.checkstyle.DetailAstImpl;
+import com.puppycrawl.tools.checkstyle.api.TokenTypes;
+import com.puppycrawl.tools.checkstyle.xpath.RootNode;
 import net.sf.saxon.om.NodeInfo;
 
 public class DescendantIteratorTest {
@@ -102,6 +105,35 @@ public class DescendantIteratorTest {
             assertWithMessage("Node should be null")
                     .that(iterator.next())
                     .isNull();
+        }
+    }
+
+    @Test
+    public void testNoStackOverflowOnDeepTree() {
+        final int depth = 10_000;
+        final DetailAstImpl root = new DetailAstImpl();
+        root.setType(TokenTypes.EXPR);
+        root.setLineNo(1);
+        root.setColumnNo(0);
+        DetailAstImpl current = root;
+        for (int index = 1; index < depth; index++) {
+            final DetailAstImpl child = new DetailAstImpl();
+            child.setType(TokenTypes.EXPR);
+            child.setLineNo(index + 1);
+            child.setColumnNo(0);
+            current.addChild(child);
+            current = child;
+        }
+        final RootNode rootNode = new RootNode(root);
+        try (DescendantIterator iterator = new DescendantIterator(
+                rootNode, DescendantIterator.StartWith.CHILDREN)) {
+            int count = 0;
+            while (iterator.next() != null) {
+                count++;
+            }
+            assertWithMessage("Expected %s descendants", depth)
+                    .that(count)
+                    .isEqualTo(depth);
         }
     }
 }


### PR DESCRIPTION
fixes #9149

main issue for #9149 was already solved in #9267. but, two problems were left-
1. `MatchXpathCheckTest#testNoStackoverflowError` was using 
   `verifyWithInlineConfigParser`  instead of 
   `verifyWithLimitedResources`, so couldn't catch regressions on 
   constrained/32-bit environments. 
2. `DescendantIteratorTest` had no test verifying `DescendantIterator` handles nested asts without stack-overflow. 