### PR TITLE
Issue 16214 Add Autocomplete search bar in documentation to direct navigate to all sections(POC)

### DIFF
--- a/config/jsoref-spellchecker/whitelist.words
+++ b/config/jsoref-spellchecker/whitelist.words
@@ -147,6 +147,7 @@ casegroup
 catchparametername
 cba
 cbeaff
+ccc
 CComments
 cdata
 cde
@@ -344,6 +345,7 @@ Edad
 ededed
 edef
 edu
+eee
 Eghj
 Ei
 ej
@@ -416,6 +418,7 @@ FFFA
 FFFB
 FFFD
 ffff
+ffffff
 FFFFL
 Fgoogle
 Fheader
@@ -739,6 +742,7 @@ kazgroup
 kbd
 kclee
 KDoc
+keydown
 keyframes
 keyname
 keyscan
@@ -1073,6 +1077,7 @@ pmdruleset
 PModel
 png
 Pno
+poc
 poetix
 Pointcut
 POJO
@@ -1276,6 +1281,7 @@ STT
 Studman
 Styleable
 styleguide
+stylesheet
 subdir
 subelements
 subext
@@ -1357,6 +1363,7 @@ tokentype
 tolist
 Toolbar
 toolongpackagetotestcoveragegooglesjavastylerule
+topbar
 TOSTRING
 Touchscreen
 tpc

--- a/src/site/resources/css/search-box-poc.css
+++ b/src/site/resources/css/search-box-poc.css
@@ -1,0 +1,58 @@
+#doc-search-topbar {
+    width: 100%;
+    display: flex;
+    justify-content: center;
+    margin: 20px 0;
+}
+
+#doc-search-input {
+    width: 700px;
+    max-width: 90%;
+    height: 46px;
+    padding: 0 16px;
+    font-size: 18px;
+    border: 1px solid #444;
+    border-radius: 24px;
+    box-sizing: border-box;
+    outline: none;
+    background-color: #ffffff;
+    color: #111;
+}
+
+#doc-search-input::placeholder {
+    color: #aaa;
+}
+
+#doc-search-results {
+    width: 700px;
+    max-width: 90%;
+    margin: 8px auto 0;
+    background: #fff;
+    border: 1px solid #ccc;
+    border-radius: 12px;
+    padding: 0;
+    list-style: none;
+    box-sizing: border-box;
+    overflow: hidden;
+}
+
+.doc-search-result-item {
+    padding: 10px 14px;
+    border-bottom: 1px solid #eee;
+    cursor: pointer;
+    font-size: 15px;
+    color: #222;
+    background: #fff;
+}
+
+.doc-search-result-item:last-child {
+    border-bottom: none;
+}
+
+.doc-search-result-item:hover {
+    background: #f5f5f5;
+}
+
+.doc-search-hidden {
+    display: none;
+}

--- a/src/site/resources/js/search-box-poc.js
+++ b/src/site/resources/js/search-box-poc.js
@@ -1,0 +1,107 @@
+document.addEventListener("DOMContentLoaded", function () {
+    var topBar = document.createElement("div");
+    topBar.id = "doc-search-topbar";
+
+    var input = document.createElement("input");
+    input.type = "text";
+    input.id = "doc-search-input";
+    input.placeholder = "Search documentation...";
+    input.setAttribute("autocomplete", "off");
+
+    var results = document.createElement("ul");
+    results.id = "doc-search-results";
+    results.className = "doc-search-hidden";
+
+    topBar.appendChild(input);
+    topBar.appendChild(results);
+
+    document.body.insertBefore(topBar, document.body.firstChild);
+
+    var allLinks = Array.from
+    (document.querySelectorAll(".nav-list a, .well.sidebar-nav a, .accordion a"));
+
+    var searchableItems = allLinks
+        .map(function (link) {
+            return {
+                title: link.textContent.trim(),
+                href: link.href
+            };
+        })
+        .filter(function (item) {
+            return item.title.length > 0;
+        });
+
+    function normalize(text) {
+        return text.toLowerCase().trim();
+    }
+
+    function getMatches(query) {
+        var normalizedQuery = normalize(query);
+
+        var startsWithMatches = searchableItems.filter(function (item) {
+            return normalize(item.title).startsWith(normalizedQuery);
+        });
+
+        var containsMatches = searchableItems.filter(function (item) {
+            var title = normalize(item.title);
+            return !title.startsWith(normalizedQuery) && title.includes(normalizedQuery);
+        });
+
+        return startsWithMatches.concat(containsMatches).slice(0, 8);
+    }
+
+    function renderResults(matches, query) {
+        results.innerHTML = "";
+
+        if (query.length < 1) {
+            results.classList.add("doc-search-hidden");
+            return;
+        }
+
+        if (matches.length === 0) {
+            var noResult = document.createElement("li");
+            noResult.className = "doc-search-result-item";
+            noResult.textContent = 'No suggestions found';
+            results.appendChild(noResult);
+            results.classList.remove("doc-search-hidden");
+            return;
+        }
+
+        matches.forEach(function (item) {
+            var li = document.createElement("li");
+            li.className = "doc-search-result-item";
+            li.textContent = item.title;
+
+            li.addEventListener("click", function () {
+                window.location.href = item.href;
+            });
+
+            results.appendChild(li);
+        });
+
+        results.classList.remove("doc-search-hidden");
+    }
+
+    input.addEventListener("input", function () {
+        var query = input.value;
+        var matches = getMatches(query);
+        renderResults(matches, query);
+    });
+
+    input.addEventListener("keydown", function (event) {
+        if (event.key === "Enter") {
+            var query = input.value;
+            var matches = getMatches(query);
+
+            if (matches.length > 0) {
+                window.location.href = matches[0].href;
+            }
+        }
+    });
+
+    document.addEventListener("click", function (event) {
+        if (!topBar.contains(event.target)) {
+            results.classList.add("doc-search-hidden");
+        }
+    });
+});

--- a/src/site/site.xml
+++ b/src/site/site.xml
@@ -57,6 +57,8 @@
                 src="$relativePath/js/google-analytics.js" defer async></script>
         <script type="text/javascript"
                 src="$relativePath/js/copy-clipboard.js" defer async></script>
+        <script type="text/javascript" src="$relativePath/js/search-box-poc.js" defer></script>
+        <link rel="stylesheet" href="$relativePath/css/search-box-poc.css" />
         <link rel="icon" href="$relativePath/images/favicon.png" type="image/x-icon" />
         <link rel="shortcut icon" href="$relativePath/images/favicon.ico" type="image/ico" />
       ]]>


### PR DESCRIPTION
#19507 

# What was Problem
Currently Checkstyle documentation navigation entirely relies on sidebar browsing which becomes inefficient for larger documentation, user scroll manually to see sections page which seems not good.

---

# Solution(POC)
This pr introduces Autoamatic search bar that allow users quickly locate documentation sections.
It supports-->
1. Real-time suggestion
2. Partial matching
3. Direct navigation to matched sections
<img width="1900" height="987" alt="image" src="https://github.com/user-attachments/assets/00e4d569-5c75-4653-a7ad-230535d7b87b" />

---

# Technical Approach
1. I use existing side bar navigation `site.xml`
2. I created one Javascript file and one css file(no backend)
3.  dynamic DOM rendering for suggestions

---

# Future scope in Summer
1. indexing full documentation content
2. User can search command, properties, examples and many more
3. Highlighting matched results

Note--> This pr is proof of concept that search bar can be added and direct navigation to sections is possible.