### PR TITLE
Issue #16807: mention all default properties for WhitespaceAfterCheck

### DIFF
--- a/src/test/java/com/puppycrawl/tools/checkstyle/TreeWalkerTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/TreeWalkerTest.java
@@ -503,8 +503,8 @@ public class TreeWalkerTest extends AbstractModuleTestSupport {
     public void testMultiCheckOrder() throws Exception {
 
         final String[] expected = {
-            "28:9: " + getCheckMessage(WhitespaceAfterCheck.class, "ws.notFollowed", "if"),
-            "28:9: " + getCheckMessage(WhitespaceAroundCheck.class, "ws.notFollowed", "if"),
+            "29:9: " + getCheckMessage(WhitespaceAfterCheck.class, "ws.notFollowed", "if"),
+            "29:9: " + getCheckMessage(WhitespaceAroundCheck.class, "ws.notFollowed", "if"),
         };
 
         verifyWithInlineConfigParserTwice(

--- a/src/test/java/com/puppycrawl/tools/checkstyle/bdd/InlineConfigParser.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/bdd/InlineConfigParser.java
@@ -300,8 +300,6 @@ public final class InlineConfigParser {
             "com.puppycrawl.tools.checkstyle.checks.javadoc.JavadocParagraphCheck",
             "com.puppycrawl.tools.checkstyle.checks.javadoc.JavadocVariableCheck",
             "com.puppycrawl.tools.checkstyle.checks.javadoc.MissingJavadocTypeCheck",
-
-            "com.puppycrawl.tools.checkstyle.checks.whitespace.WhitespaceAfterCheck",
             "com.puppycrawl.tools.checkstyle.checks.SuppressWarningsHolder",
             "com.puppycrawl.tools.checkstyle.filters.SuppressionCommentFilter",
             "com.puppycrawl.tools.checkstyle.filters.SuppressionXpathFilter",

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/whitespace/whitespaceafter/InputWhitespaceAfterAround.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/whitespace/whitespaceafter/InputWhitespaceAfterAround.java
@@ -1,11 +1,11 @@
 /*
 WhitespaceAfter
 tokens = (default)COMMA, SEMI, TYPECAST, LITERAL_IF, LITERAL_ELSE, LITERAL_WHILE, \
-         LITERAL_DO, LITERAL_FOR, DO_WHILE
-
+         LITERAL_DO, LITERAL_FOR, LITERAL_FINALLY, LITERAL_RETURN, LITERAL_YIELD, \
+         LITERAL_CATCH, DO_WHILE, ELLIPSIS, LITERAL_SWITCH, LITERAL_SYNCHRONIZED, \
+         LITERAL_TRY, LITERAL_CASE, LAMBDA, LITERAL_WHEN
 
 */
-
 package com.puppycrawl.tools.checkstyle.checks.whitespace.whitespaceafter;
 
 @SuppressWarnings({"this", "that"})

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/whitespace/whitespaceafter/InputWhitespaceAfterCountUnicodeCorrectly.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/whitespace/whitespaceafter/InputWhitespaceAfterCountUnicodeCorrectly.java
@@ -1,11 +1,11 @@
 /*
 WhitespaceAfter
 tokens = (default)COMMA, SEMI, TYPECAST, LITERAL_IF, LITERAL_ELSE, LITERAL_WHILE, \
-         LITERAL_DO, LITERAL_FOR, DO_WHILE
-
+         LITERAL_DO, LITERAL_FOR, LITERAL_FINALLY, LITERAL_RETURN, LITERAL_YIELD, \
+         LITERAL_CATCH, DO_WHILE, ELLIPSIS, LITERAL_SWITCH, LITERAL_SYNCHRONIZED, \
+         LITERAL_TRY, LITERAL_CASE, LAMBDA, LITERAL_WHEN
 
 */
-
 package com.puppycrawl.tools.checkstyle.checks.whitespace.whitespaceafter;
 
 public class InputWhitespaceAfterCountUnicodeCorrectly {

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/whitespace/whitespaceafter/InputWhitespaceAfterDefaultConfig.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/whitespace/whitespaceafter/InputWhitespaceAfterDefaultConfig.java
@@ -1,11 +1,11 @@
 /*
 WhitespaceAfter
 tokens = (default)COMMA, SEMI, TYPECAST, LITERAL_IF, LITERAL_ELSE, LITERAL_WHILE, \
-         LITERAL_DO, LITERAL_FOR, DO_WHILE
-
+         LITERAL_DO, LITERAL_FOR, LITERAL_FINALLY, LITERAL_RETURN, LITERAL_YIELD, \
+         LITERAL_CATCH, DO_WHILE, ELLIPSIS, LITERAL_SWITCH, LITERAL_SYNCHRONIZED, \
+         LITERAL_TRY, LITERAL_CASE, LAMBDA, LITERAL_WHEN
 
 */
-
 package com.puppycrawl.tools.checkstyle.checks.whitespace.whitespaceafter;
 import java.io.*;
 /**

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/whitespace/whitespaceafter/InputWhitespaceAfterFor.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/whitespace/whitespaceafter/InputWhitespaceAfterFor.java
@@ -1,11 +1,11 @@
 /*
 WhitespaceAfter
 tokens = (default)COMMA, SEMI, TYPECAST, LITERAL_IF, LITERAL_ELSE, LITERAL_WHILE, \
-         LITERAL_DO, LITERAL_FOR, DO_WHILE
-
+         LITERAL_DO, LITERAL_FOR, LITERAL_FINALLY, LITERAL_RETURN, LITERAL_YIELD, \
+         LITERAL_CATCH, DO_WHILE, ELLIPSIS, LITERAL_SWITCH, LITERAL_SYNCHRONIZED, \
+         LITERAL_TRY, LITERAL_CASE, LAMBDA, LITERAL_WHEN
 
 */
-
 package com.puppycrawl.tools.checkstyle.checks.whitespace.whitespaceafter;
 
 class InputWhitespaceAfterFor

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/whitespace/whitespaceafter/InputWhitespaceAfterGenerics.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/whitespace/whitespaceafter/InputWhitespaceAfterGenerics.java
@@ -1,11 +1,11 @@
 /*
 WhitespaceAfter
 tokens = (default)COMMA, SEMI, TYPECAST, LITERAL_IF, LITERAL_ELSE, LITERAL_WHILE, \
-         LITERAL_DO, LITERAL_FOR, DO_WHILE
-
+         LITERAL_DO, LITERAL_FOR, LITERAL_FINALLY, LITERAL_RETURN, LITERAL_YIELD, \
+         LITERAL_CATCH, DO_WHILE, ELLIPSIS, LITERAL_SWITCH, LITERAL_SYNCHRONIZED, \
+         LITERAL_TRY, LITERAL_CASE, LAMBDA, LITERAL_WHEN
 
 */
-
 package com.puppycrawl.tools.checkstyle.checks.whitespace.whitespaceafter;
 
 import java.util.Collection;

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/whitespace/whitespaceafter/InputWhitespaceAfterWithEmoji.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/whitespace/whitespaceafter/InputWhitespaceAfterWithEmoji.java
@@ -1,11 +1,11 @@
 /*
 WhitespaceAfter
 tokens = (default)COMMA, SEMI, TYPECAST, LITERAL_IF, LITERAL_ELSE, LITERAL_WHILE, \
-         LITERAL_DO, LITERAL_FOR, DO_WHILE
-
+         LITERAL_DO, LITERAL_FOR, LITERAL_FINALLY, LITERAL_RETURN, LITERAL_YIELD, \
+         LITERAL_CATCH, DO_WHILE, ELLIPSIS, LITERAL_SWITCH, LITERAL_SYNCHRONIZED, \
+         LITERAL_TRY, LITERAL_CASE, LAMBDA, LITERAL_WHEN
 
 */
-
 package com.puppycrawl.tools.checkstyle.checks.whitespace.whitespaceafter;
 
 class InputWhitespaceAfterWithEmoji {

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/treewalker/InputTreeWalkerMultiCheckOrder.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/treewalker/InputTreeWalkerMultiCheckOrder.java
@@ -16,16 +16,17 @@ tokens = (default)ASSIGN, BAND, BAND_ASSIGN, BOR, BOR_ASSIGN, BSR, BSR_ASSIGN, B
          NOT_EQUAL, PLUS, PLUS_ASSIGN, QUESTION, RCURLY, SL, SLIST, SL_ASSIGN, SR, \
          SR_ASSIGN, STAR, STAR_ASSIGN, LITERAL_ASSERT, TYPE_EXTENSION_AND, LITERAL_WHEN
 
-
 com.puppycrawl.tools.checkstyle.checks.whitespace.WhitespaceAfterCheck
+tokens = (default)COMMA, SEMI, TYPECAST, LITERAL_IF, LITERAL_ELSE, LITERAL_WHILE, \
+         LITERAL_DO, LITERAL_FOR, LITERAL_FINALLY, LITERAL_RETURN, LITERAL_YIELD, \
+         LITERAL_CATCH, DO_WHILE, ELLIPSIS, LITERAL_SWITCH, LITERAL_SYNCHRONIZED, \
+         LITERAL_TRY, LITERAL_CASE, LAMBDA, LITERAL_WHEN
 
 */
 package com.puppycrawl.tools.checkstyle.treewalker;
-
 public class InputTreeWalkerMultiCheckOrder {
     public void method() {
-        boolean test = true;
-        if(test) {  // 2 violations
+        if(true) {  // 2 violations
 
         }
     }


### PR DESCRIPTION
Follow up of #16807

Updated all Input files for WhitespaceAfterCheck to mention all default properties with (default) tag.
Removed WhitespaceAfterCheck from SUPPRESSED_MODULES in InlineConfigParser.java.