### PR TITLE
Issue #19515: install xmlstarlet if not present in versions validation

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -100,6 +100,7 @@ strategy:
       image: 'ubuntu-24.04'
       cmd: "./.ci/validation.sh versions"
       onCronOnly: true
+      needXmlstarlet: true
 
     # lint for .md files, OSX is used because there is problem to install gem on linux
     'markdownlint':
@@ -123,7 +124,7 @@ variables:
 
 steps:
   - bash: |
-      apt-fast install -y xmlstarlet
+      sudo apt-get install -y xmlstarlet
     condition: |
         and(
              ne(variables['Agent.OS'], 'Darwin'),


### PR DESCRIPTION
fixes #19515
moved xmlstarlet installation to azure-pipelines.yml as a pre-step before job execution, since all tasks in validation.sh expect tools to be already installed.