### PR TITLE
Issue #16807: mention defaults in NoWhitespaceAfterCheck input files

### DIFF
--- a/src/test/java/com/puppycrawl/tools/checkstyle/bdd/InlineConfigParser.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/bdd/InlineConfigParser.java
@@ -307,7 +307,6 @@ public final class InlineConfigParser {
             "com.puppycrawl.tools.checkstyle.checks.naming.LocalFinalVariableNameCheck",
 
             "com.puppycrawl.tools.checkstyle.checks.regexp.RegexpSinglelineJavaCheck",
-            "com.puppycrawl.tools.checkstyle.checks.whitespace.NoWhitespaceAfterCheck",
             "com.puppycrawl.tools.checkstyle.checks.whitespace.WhitespaceAfterCheck",
             "com.puppycrawl.tools.checkstyle.checks.SuppressWarningsHolder",
             "com.puppycrawl.tools.checkstyle.filters.SuppressWithPlainTextCommentFilter",

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/whitespace/nowhitespaceafter/InputNoWhitespaceAfterUnnamedPattern.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/whitespace/nowhitespaceafter/InputNoWhitespaceAfterUnnamedPattern.java
@@ -1,5 +1,8 @@
 /*
 NoWhitespaceAfter
+allowLineBreaks = (default)true
+tokens = (default)ARRAY_INIT, AT, INC, DEC, UNARY_MINUS, UNARY_PLUS, BNOT, LNOT, \
+         DOT, ARRAY_DECLARATOR, INDEX_OP
 
 
 */


### PR DESCRIPTION
 #16807 (partial)

Added missing default property documentation in `InputNoWhitespaceAfterUnnamedPattern.java` and removed `NoWhitespaceAfterCheck` from `SUPPRESSED_MODULES` in `InlineConfigParser.java`.