### PR TITLE
Issue #16807: mention defaults in RegexpSinglelineJavaCheck input files

### DIFF
--- a/src/test/java/com/puppycrawl/tools/checkstyle/bdd/InlineConfigParser.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/bdd/InlineConfigParser.java
@@ -305,7 +305,6 @@ public final class InlineConfigParser {
             "com.puppycrawl.tools.checkstyle.checks.javadoc.MissingJavadocTypeCheck",
             "com.puppycrawl.tools.checkstyle.checks.modifier.RedundantModifierCheck",
 
-            "com.puppycrawl.tools.checkstyle.checks.regexp.RegexpSinglelineJavaCheck",
             "com.puppycrawl.tools.checkstyle.checks.whitespace.WhitespaceAfterCheck",
             "com.puppycrawl.tools.checkstyle.checks.SuppressWarningsHolder",
             "com.puppycrawl.tools.checkstyle.filters.SuppressWithPlainTextCommentFilter",

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/regexp/regexpsinglelinejava/InputRegexpSinglelineJavaSemantic8.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/regexp/regexpsinglelinejava/InputRegexpSinglelineJavaSemantic8.java
@@ -2,6 +2,10 @@
 RegexpSinglelineJava
 format = (default)$.
 message = not expected
+ignoreCase = (default)false
+minimum = (default)0
+maximum = (default)0
+ignoreComments = (default)false
 
 
 */


### PR DESCRIPTION
: #16807

Added missing default property documentation in `InputRegexpSinglelineJavaSemantic8.java` and removed `RegexpSinglelineJavaCheck` from `SUPPRESSED_MODULES` in `InlineConfigParser.java`.