### PR TITLE
Issue #16807: mention defaults in RequireThisCheck input files

### DIFF
--- a/src/test/java/com/puppycrawl/tools/checkstyle/bdd/InlineConfigParser.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/bdd/InlineConfigParser.java
@@ -295,7 +295,6 @@ public final class InlineConfigParser {
     private static final Set<String> SUPPRESSED_MODULES = Set.of(
             "com.puppycrawl.tools.checkstyle.checks.coding.IllegalTypeCheck",
             "com.puppycrawl.tools.checkstyle.checks.coding.MatchXpathCheck",
-            "com.puppycrawl.tools.checkstyle.checks.coding.RequireThisCheck",
             "com.puppycrawl.tools.checkstyle.checks.coding.UnusedLocalVariableCheck",
             "com.puppycrawl.tools.checkstyle.checks.imports.CustomImportOrderCheck",
             "com.puppycrawl.tools.checkstyle.checks.javadoc.JavadocContentLocationCheck",

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/requirethis/InputRequireThisRecordsWithCheckFields.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/requirethis/InputRequireThisRecordsWithCheckFields.java
@@ -1,6 +1,6 @@
 /*
 RequireThis
-checkFields = true
+checkFields = (default)true
 checkMethods = (default)true
 validateOnlyOverlapping = (default)true
 

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/requirethis/InputRequireThisRecordsWithCheckFieldsOverlap.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/requirethis/InputRequireThisRecordsWithCheckFieldsOverlap.java
@@ -1,6 +1,6 @@
 /*
 RequireThis
-checkFields = true
+checkFields = (default)true
 checkMethods = (default)true
 validateOnlyOverlapping = false
 


### PR DESCRIPTION
Issue: #16807

Remove `RequireThisCheck` from `SUPPRESSED_MODULES` and add missing `(default)` tag to `checkFields` property in 2 input files where the value matches the default.