### PR TITLE
Issue #16807: mention defaults in CustomImportOrderCheck input files

### DIFF
--- a/src/test/java/com/puppycrawl/tools/checkstyle/bdd/InlineConfigParser.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/bdd/InlineConfigParser.java
@@ -297,7 +297,6 @@ public final class InlineConfigParser {
             "com.puppycrawl.tools.checkstyle.checks.coding.MatchXpathCheck",
             "com.puppycrawl.tools.checkstyle.checks.coding.RequireThisCheck",
             "com.puppycrawl.tools.checkstyle.checks.coding.UnusedLocalVariableCheck",
-            "com.puppycrawl.tools.checkstyle.checks.imports.CustomImportOrderCheck",
             "com.puppycrawl.tools.checkstyle.checks.javadoc.JavadocContentLocationCheck",
             "com.puppycrawl.tools.checkstyle.checks.javadoc.JavadocParagraphCheck",
             "com.puppycrawl.tools.checkstyle.checks.javadoc.JavadocVariableCheck",

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/imports/customimportorder/InputCustomImportOrderEmptyRule.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/imports/customimportorder/InputCustomImportOrderEmptyRule.java
@@ -1,6 +1,6 @@
 /*
 CustomImportOrder
-customImportOrderRules =
+customImportOrderRules = (default)
 standardPackageRegExp = (default)^(java|javax)\\.
 thirdPartyPackageRegExp = (default).*
 specialImportsRegExp = (default)^$

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/imports/customimportorder/InputCustomImportOrderListRulesWhitespace.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/imports/customimportorder/InputCustomImportOrderListRulesWhitespace.java
@@ -1,6 +1,6 @@
 /*
 CustomImportOrder
-customImportOrderRules =
+customImportOrderRules = (default)
 standardPackageRegExp = (default)^(java|javax)\\.
 thirdPartyPackageRegExp = com.|org.
 specialImportsRegExp = (default)^$


### PR DESCRIPTION
Issue: #16807

Remove `CustomImportOrderCheck` from `SUPPRESSED_MODULES` and add missing `(default)` tag to `customImportOrderRules` property in 2 input files where the empty value matches the default.