### PR TITLE
Issue #16807: Remove JavadocVariableCheck from SUPPRESSED_MODULES

### DIFF
--- a/src/test/java/com/puppycrawl/tools/checkstyle/bdd/InlineConfigParser.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/bdd/InlineConfigParser.java
@@ -297,7 +297,6 @@ public final class InlineConfigParser {
             "com.puppycrawl.tools.checkstyle.checks.coding.UnusedLocalVariableCheck",
             "com.puppycrawl.tools.checkstyle.checks.javadoc.JavadocContentLocationCheck",
             "com.puppycrawl.tools.checkstyle.checks.javadoc.JavadocParagraphCheck",
-            "com.puppycrawl.tools.checkstyle.checks.javadoc.JavadocVariableCheck",
             "com.puppycrawl.tools.checkstyle.checks.javadoc.MissingJavadocTypeCheck",
             "com.puppycrawl.tools.checkstyle.checks.SuppressWarningsHolder",
             "com.puppycrawl.tools.checkstyle.filters.SuppressionCommentFilter",

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocVariableCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocVariableCheckTest.java
@@ -409,10 +409,10 @@ public class JavadocVariableCheckTest
     @Test
     public void testMethodInnerClass() throws Exception {
         final String[] expected = {
-            "9:5: " + getCheckMessage(MSG_JAVADOC_MISSING),
-            "10:5: " + getCheckMessage(MSG_JAVADOC_MISSING),
-            "11:5: " + getCheckMessage(MSG_JAVADOC_MISSING),
             "12:5: " + getCheckMessage(MSG_JAVADOC_MISSING),
+            "13:5: " + getCheckMessage(MSG_JAVADOC_MISSING),
+            "14:5: " + getCheckMessage(MSG_JAVADOC_MISSING),
+            "15:5: " + getCheckMessage(MSG_JAVADOC_MISSING),
         };
         verifyWithInlineConfigParser(
             getPath("InputJavadocVariableMethodInnerClass.java"),
@@ -422,7 +422,7 @@ public class JavadocVariableCheckTest
     @Test
     public void testJavadocVariableAboveComment() throws Exception {
         final String[] expected = {
-            "23:5: " + getCheckMessage(MSG_JAVADOC_MISSING),
+            "26:5: " + getCheckMessage(MSG_JAVADOC_MISSING),
         };
         verifyWithInlineConfigParser(
             getPath("InputJavadocVariableAboveComment.java"),

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadocvariable/InputJavadocVariableAboveComment.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadocvariable/InputJavadocVariableAboveComment.java
@@ -1,5 +1,8 @@
 /*
 JavadocVariable
+accessModifiers = (default)public,protected,package,private
+ignoreNamePattern = (default)null
+tokens = (default)ENUM_CONSTANT_DEF
 
 */
 

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadocvariable/InputJavadocVariableMethodInnerClass.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadocvariable/InputJavadocVariableMethodInnerClass.java
@@ -1,5 +1,8 @@
 /*
 JavadocVariable
+accessModifiers = (default)public,protected,package,private
+ignoreNamePattern = (default)null
+tokens = (default)ENUM_CONSTANT_DEF
 
 */
 


### PR DESCRIPTION
Issue: #16807

Remove `JavadocVariableCheck` from `SUPPRESSED_MODULES` and add missing `accessModifiers` and `tokens` properties with `(default)` tag to 2 input files where they were not explicitly specified. Update hardcoded violation line numbers in `JavadocVariableCheckTest.java` to account for the added header lines.