### PR TITLE
Issue #16807: Remove SuppressWithPlainTextCommentFilter from SUPPRESS…

### DIFF
--- a/src/test/java/com/puppycrawl/tools/checkstyle/bdd/InlineConfigParser.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/bdd/InlineConfigParser.java
@@ -307,7 +307,6 @@ public final class InlineConfigParser {
 
             "com.puppycrawl.tools.checkstyle.checks.whitespace.WhitespaceAfterCheck",
             "com.puppycrawl.tools.checkstyle.checks.SuppressWarningsHolder",
-            "com.puppycrawl.tools.checkstyle.filters.SuppressWithPlainTextCommentFilter",
             "com.puppycrawl.tools.checkstyle.filters.SuppressionCommentFilter",
             "com.puppycrawl.tools.checkstyle.filters.SuppressionXpathFilter",
             "com.puppycrawl.tools.checkstyle.filters.SuppressionXpathSingleFilter"

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppresswithplaintextcommentfilter/InputSuppressWithPlainTextCommentFilterCustomMessageFormat.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppresswithplaintextcommentfilter/InputSuppressWithPlainTextCommentFilterCustomMessageFormat.java
@@ -1,7 +1,7 @@
 /*
 SuppressWithPlainTextCommentFilter
-offCommentFormat = // CHECKSTYLE:OFF
-onCommentFormat = // CHECKSTYLE:ON
+offCommentFormat = (default)// CHECKSTYLE:OFF
+onCommentFormat = (default)// CHECKSTYLE:ON
 checkFormat = (default).*
 messageFormat = .*tab.*
 idFormat = (default)(null)


### PR DESCRIPTION
Issue: #16807

Remove `SuppressWithPlainTextCommentFilter` from `SUPPRESSED_MODULES` and add missing `(default)` tag to `offCommentFormat` and `onCommentFormat` properties in 1 input file where the values match the defaults.