### PR TITLE
Issue #16603: Add missing blue-tick explanation guidance in Google st…

### DIFF
--- a/src/site/xdoc/google_style.xml
+++ b/src/site/xdoc/google_style.xml
@@ -53,6 +53,21 @@
           <br />
         </p>
       </subsection>
+            <subsection name="Blue-tick explanation details" id="Google_Blue_tick_details">
+        <p>
+          Blue-tick checks indicate partial coverage of a Google Style rule.
+          For each blue-tick row, we should provide a short explanation that describes:
+        </p>
+        <ul>
+          <li>what part of the rule is currently covered,</li>
+          <li>what part is still missing, and</li>
+          <li>a link to the blocking issue (if available).</li>
+        </ul>
+        <p>
+          This additional explanation improves contributor onboarding and helps
+          readers understand why a rule is not fully green yet.
+        </p>
+      </subsection>
       <subsection name="Coverage table" id="Google_Coverage_table">
         <p>
           <b>ATTENTION:</b>


### PR DESCRIPTION
Issue: #16603

### Summary
Added a dedicated “Blue-tick explanation details” subsection to
`src/site/xdoc/google_style.xml`  to clarify what partial coverage means and
what explanation each blue-tick row should include.

### Testing
./mvnw -q -DskipTests verify