### PR TITLE
Issue #15456: Define violation messages for NoLineWrapCheck

### DIFF
--- a/src/test/java/com/puppycrawl/tools/checkstyle/bdd/InlineConfigParser.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/bdd/InlineConfigParser.java
@@ -271,7 +271,6 @@ public final class InlineConfigParser {
             "com.puppycrawl.tools.checkstyle.checks.sizes.RecordComponentNumberCheck",
             "com.puppycrawl.tools.checkstyle.checks.TodoCommentCheck",
             "com.puppycrawl.tools.checkstyle.checks.TrailingCommentCheck",
-            "com.puppycrawl.tools.checkstyle.checks.whitespace.NoLineWrapCheck",
             "com.puppycrawl.tools.checkstyle.checks.whitespace."
                     + "NoWhitespaceBeforeCaseDefaultColonCheck",
             "com.puppycrawl.tools.checkstyle.checks.whitespace.NoWhitespaceBeforeCheck",

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/whitespace/NoLineWrapCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/whitespace/NoLineWrapCheckTest.java
@@ -76,10 +76,10 @@ public class NoLineWrapCheckTest
             "28:9: " + getCheckMessage(MSG_KEY, "CTOR_DEF"),
             "34:5: " + getCheckMessage(MSG_KEY, "RECORD_DEF"),
             "36:9: " + getCheckMessage(MSG_KEY, "COMPACT_CTOR_DEF"),
-            "40:5: " + getCheckMessage(MSG_KEY, "RECORD_DEF"),
-            "42:9: " + getCheckMessage(MSG_KEY, "COMPACT_CTOR_DEF"),
-            "47:9: " + getCheckMessage(MSG_KEY, "RECORD_DEF"),
-            "49:13: " + getCheckMessage(MSG_KEY, "COMPACT_CTOR_DEF"),
+            "41:5: " + getCheckMessage(MSG_KEY, "RECORD_DEF"),
+            "43:9: " + getCheckMessage(MSG_KEY, "COMPACT_CTOR_DEF"),
+            "48:9: " + getCheckMessage(MSG_KEY, "RECORD_DEF"),
+            "50:13: " + getCheckMessage(MSG_KEY, "COMPACT_CTOR_DEF"),
         };
         verifyWithInlineConfigParser(
                 getPath("InputNoLineWrapRecordsAndCompactCtors.java"),

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/whitespace/nolinewrap/InputNoLineWrapBad.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/whitespace/nolinewrap/InputNoLineWrapBad.java
@@ -5,16 +5,16 @@ tokens = (default)PACKAGE_DEF, IMPORT, STATIC_IMPORT
 
 */
 
-package com.puppycrawl.tools. // violation
+package com.puppycrawl.tools. // violation 'package statement should not be line-wrapped.'
     checkstyle.checks.whitespace.nolinewrap;
 
 import java.util.Calendar;
 
-import javax.accessibility. // violation
+import javax.accessibility. // violation 'import statement should not be line-wrapped.'
     AccessibleAttributeSequence;
 import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
 
-import static java.math. // violation
+import static java.math. // violation 'import statement should not be line-wrapped.'
 		BigInteger.ZERO;
 
 public class

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/whitespace/nolinewrap/InputNoLineWrapBad2.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/whitespace/nolinewrap/InputNoLineWrapBad2.java
@@ -10,24 +10,24 @@ package com.puppycrawl.tools.
 
 import java.util.Calendar;
 
-import javax.accessibility. // violation
+import javax.accessibility. // violation 'import statement should not be line-wrapped.'
     AccessibleAttributeSequence;
 import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
 
-import static java.math. // violation
+import static java.math. // violation 'import statement should not be line-wrapped.'
 		BigInteger.ZERO;
 
-public class // violation
+public class // violation 'CLASS_DEF statement should not be line-wrapped.'
     InputNoLineWrapBad2 {
 
-	public void // violation
+	public void // violation 'METHOD_DEF statement should not be line-wrapped.'
 	    fooMethod() {
 		final int
 		    foo = 0;
 	}
 }
 
-enum // violation
+enum // violation 'ENUM_DEF statement should not be line-wrapped.'
     FooFoo2 {
 }
 

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/whitespace/nolinewrap/InputNoLineWrapRecordsAndCompactCtors.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/whitespace/nolinewrap/InputNoLineWrapRecordsAndCompactCtors.java
@@ -10,13 +10,13 @@ package com.puppycrawl.tools.checkstyle.checks.whitespace.nolinewrap;
 
 public class InputNoLineWrapRecordsAndCompactCtors {
     class Bar {
-        public // violation
+        public // violation 'CTOR_DEF statement should not be line-wrapped.'
         Bar() {
         }
         public void fun() {
         }
     }
-    record // violation
+    record // violation 'RECORD_DEF statement should not be line-wrapped.'
     MyRecord1() {
         public MyRecord1() {
         }
@@ -25,28 +25,30 @@ public class InputNoLineWrapRecordsAndCompactCtors {
         }
     }
     record MyRecord2() {
-        public // violation
+        public // violation 'CTOR_DEF statement should not be line-wrapped.'
         MyRecord2() {
         }
         public void fun() {
         }
     }
-    record MyRecord3(String str, int // violation
+    record MyRecord3(String str, int // violation 'RECORD_DEF statement should not be line-wrapped.'
                      x) {
-        public // violation
+        public // violation 'COMPACT_CTOR_DEF statement should not be line-wrapped.'
         MyRecord3{}
     }
 
-    record MyRecord4(String str, int x, // violation
+    // violation below 'RECORD_DEF statement should not be line-wrapped.'
+    record MyRecord4(String str, int x,
                      int y) {
-        public // violation
+        public // violation 'COMPACT_CTOR_DEF statement should not be line-wrapped.'
         MyRecord4{}
     }
 
     Record recordMethod (int x) {
-        record MyMethodRecord(int // violation
+        record MyMethodRecord(int // violation 'RECORD_DEF statement should not be line-wrapped.'
                                       x) {
-            public MyMethodRecord // violation
+            public MyMethodRecord
+            // violation above 'COMPACT_CTOR_DEF statement should not be line-wrapped.'
             {}
         }
 


### PR DESCRIPTION
Issue  #15456 

Violation messages are added to all `// violation` comments in NoLineWrapCheck input files, and the check is removed from `SUPPRESSED_CHECKS` in `InlineConfigParser.java`.
